### PR TITLE
Add English translations in src/object-use/quaff-execution.c

### DIFF
--- a/src/object-use/quaff-execution.c
+++ b/src/object-use/quaff-execution.c
@@ -151,7 +151,7 @@ void exe_quaff_potion(player_type *creature_ptr, INVENTORY_IDX item)
             break;
 
         case SV_POTION_APPLE_JUICE:
-            msg_print(_("甘くてサッパリとしていて、とてもおいしい。", ""));
+            msg_print(_("甘くてサッパリとしていて、とてもおいしい。", "It's sweet, refreshing and very tasty."));
             msg_print(_("のどの渇きが少しおさまった。", "You feel less thirsty."));
             ident = TRUE;
             break;

--- a/src/object-use/quaff-execution.c
+++ b/src/object-use/quaff-execution.c
@@ -145,7 +145,7 @@ void exe_quaff_potion(player_type *creature_ptr, INVENTORY_IDX item)
         switch (q_ptr->sval) {
             /* 飲みごたえをオリジナルより細かく表現 */
         case SV_POTION_WATER:
-            msg_print(_("口の中がさっぱりした。", ""));
+            msg_print(_("口の中がさっぱりした。", "That was refreshing."));
             msg_print(_("のどの渇きが少しおさまった。", "You feel less thirsty."));
             ident = TRUE;
             break;

--- a/src/object-use/quaff-execution.c
+++ b/src/object-use/quaff-execution.c
@@ -157,7 +157,7 @@ void exe_quaff_potion(player_type *creature_ptr, INVENTORY_IDX item)
             break;
 
         case SV_POTION_SLIME_MOLD:
-            msg_print(_("なんとも不気味な味だ。", ""));
+            msg_print(_("なんとも不気味な味だ。", "That was strange."));
             msg_print(_("のどの渇きが少しおさまった。", "You feel less thirsty."));
             ident = TRUE;
             break;


### PR DESCRIPTION
These are initial attempts at the three messages (one for SV_POTION_WATER, SV_POTION_APPLE_JUICE, and SV_POTION_SLIME_MOLD) that are currently empty in English.

Attempts to resolve #5 .