### PR TITLE
Feature/implement skip more

### DIFF
--- a/src/game-option/input-options.c
+++ b/src/game-option/input-options.c
@@ -5,6 +5,7 @@ bool always_pickup; /* Pick things up by default */
 bool carry_query_flag; /* Prompt before picking things up */
 bool quick_messages; /* Activate quick messages */
 bool auto_more; /* Automatically clear '-more-' prompts */
+bool skip_more; /* Automatically skip '-more-' prompts every time */
 bool command_menu; /* Enable command selection menu */
 bool other_query_flag; /* Prompt for floor item selection */
 bool use_old_target; /* Use old target by default */

--- a/src/game-option/input-options.h
+++ b/src/game-option/input-options.h
@@ -7,6 +7,7 @@ extern bool always_pickup; /* Pick things up by default */
 extern bool carry_query_flag; /* Prompt before picking things up */
 extern bool quick_messages; /* Activate quick messages */
 extern bool auto_more; /* Automatically clear '-more-' prompts */
+extern bool skip_more; /* Automatically skip '-more-' prompts every time */
 extern bool command_menu; /* Enable command selection menu */
 extern bool other_query_flag; /* Prompt for floor item selection */
 extern bool use_old_target; /* Use old target by default */

--- a/src/game-option/option-types-table.c
+++ b/src/game-option/option-types-table.c
@@ -28,6 +28,8 @@ const option_type option_info[MAX_OPTION_INFO] = {
 
     { &auto_more, FALSE, OPT_PAGE_INPUT, 2, 6, "auto_more", _("キー待ちしないで連続でメッセージを表示する", "Automatically clear '-more-' prompts") },
 
+    { &skip_more, FALSE, OPT_PAGE_INPUT, 2, 18, "skip_more", _("キー待ちしないで全てのメッセージを読み飛ばす", "Automatically skip all messages.") },
+
     { &command_menu, TRUE, OPT_PAGE_INPUT, 2, 7, "command_menu", _("メニューによりコマンド選択を有効にする", "Enable command selection menu") },
 
     { &other_query_flag, FALSE, OPT_PAGE_INPUT, 0, 2, "other_query_flag", _("床上のアイテムを使用するときに確認する", "Prompt for floor item selection") },

--- a/src/game-option/option-types-table.h
+++ b/src/game-option/option-types-table.h
@@ -22,7 +22,7 @@ typedef struct option_type {
     concptr o_desc;
 } option_type;
 
-#define MAX_OPTION_INFO 121
+#define MAX_OPTION_INFO 122
 #define MAX_CHEAT_OPTIONS 10
 #define MAX_AUTOSAVE_INFO 2
 

--- a/src/view/display-messages.c
+++ b/src/view/display-messages.c
@@ -282,6 +282,9 @@ static void msg_flush(player_type *player_ptr, int x)
     if (auto_more && !player_ptr->now_damaged)
         show_more = is_msg_window_flowed();
 
+    if (skip_more)
+        show_more = FALSE;
+
     player_ptr->now_damaged = FALSE;
     if (!player_ptr->playing || show_more) {
         term_putstr(x, 0, -1, a, _("-続く-", "-more-"));


### PR DESCRIPTION
キー待ちしないで全メッセージを流すオプションの作成 #7

現在のauto_moreオプションは被弾したら一次停止し、メッセージサブウィンドウが溢れたら一次停止する仕様となっている。
完全ノンストップで全メッセージを流すオプションを実装したい。