### PR TITLE
[feature] #1 Linuxでビルドテストを行うWorkflow

### DIFF
--- a/.github/workflows/buildtest-on-linux.yml
+++ b/.github/workflows/buildtest-on-linux.yml
@@ -1,0 +1,43 @@
+name: Build test on Linux
+
+on:
+  # プルリクエストがopen、synchronize、reopenされた時にトリガーする
+  pull_request:
+
+  # 手動トリガーを許可
+  workflow_dispatch:
+
+jobs:
+  build_test:
+    name: Build test on Ubuntu-20.04
+    runs-on: ubuntu-20.04
+    env:
+      CFLAGS: "-pipe -Werror -Wall -Wextra -Wno-format-overflow -Wno-switch -Wno-sign-compare -Wno-unused-parameter -Wno-unused-function"
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install required packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install \
+            libncursesw5-dev \
+            libcurl4-openssl-dev \
+            nkf \
+
+      - name: Generate configure
+        run: ./bootstrap
+
+      - name: Configuratoin for Japanese version
+        run: ./configure
+
+      - name: Build Japanese version
+        run: make
+
+      - name: Clean source tree
+        run: make clean
+
+      - name: Configure for English versoin
+        run: ./configure --disable-japanese
+
+      - name: Build English version
+        run: make


### PR DESCRIPTION
Linux(Ubuntu-20.04)でビルドが通ることを確認するWorkflowを作成した。
このWorkflowは日本語版/英語版ともにエラーなくビルドができる
状態であることを確認する。
GCCのオプションに "-Werror -Wall -Wextra" を与えて、
警告レベル最大で警告をエラーとして扱うようにする。
ただし、現状のコードを鑑みて以下の警告は抑制する。

 - format-overflow
sprintfはstrcatなどのバッファサイズを指定しない文字列操作関数が
大量に使用されており、警告をなくすにはすべてsnprintfなどに
修正する必要がある。

 - no-switch
アイテム等の種類によるスイッチでdefault句が無い箇所が多い。
enumのすべてが列挙されていない場合defaultが無いと警告が出る。
とりあえず抑制しておく。

 - no-sign-compare
符号ありと符号無しで比較している箇所が多すぎて修正が困難。

 - no-unused-parameter, no-unused-function
修正や日英切り替えにより出る事があるが、ソースが壊れるわけではないので
ひとまず許可する。