### PR TITLE
3.0.0.0: minor English edits for src/pet

### DIFF
--- a/src/pet/pet-fall-off.c
+++ b/src/pet/pet-fall-off.c
@@ -167,7 +167,7 @@ bool process_fall_off_horse(player_type *creature_ptr, HIT_POINT dam, bool force
     bool fall_dam = FALSE;
     if (creature_ptr->levitation && !force) {
         monster_desc(creature_ptr, m_name, m_ptr, 0);
-        msg_format(_("%sから落ちたが、空中でうまく体勢を立て直して着地した。", "You are thrown from %s, but make a good landing."), m_name);
+        msg_format(_("%sから落ちたが、空中でうまく体勢を立て直して着地した。", "You are thrown from %s but make a good landing."), m_name);
     } else {
         take_hit(creature_ptr, DAMAGE_NOESCAPE, r_ptr->level + 3, _("落馬", "Falling from riding"), -1);
         fall_dam = TRUE;

--- a/src/pet/pet-fall-off.c
+++ b/src/pet/pet-fall-off.c
@@ -137,8 +137,8 @@ bool process_fall_off_horse(player_type *creature_ptr, HIT_POINT dam, bool force
 
         if (!sn) {
             monster_desc(creature_ptr, m_name, m_ptr, 0);
-            msg_format(_("%sから振り落とされそうになって、壁にぶつかった。", "You have nearly fallen from %s, but bumped into wall."), m_name);
-            take_hit(creature_ptr, DAMAGE_NOESCAPE, r_ptr->level + 3, _("壁への衝突", "bumping into wall"), -1);
+            msg_format(_("%sから振り落とされそうになって、壁にぶつかった。", "You have nearly fallen from %s but bumped into a wall."), m_name);
+            take_hit(creature_ptr, DAMAGE_NOESCAPE, r_ptr->level + 3, _("壁への衝突", "bumping into a wall"), -1);
             return FALSE;
         }
 


### PR DESCRIPTION
- Drop two commas that aren't separating independent clauses.
- Add some indefinite articles to be more idiomatic