### PR TITLE
3.0.0.0: minor English edits for src/player

### DIFF
--- a/src/player/patron.c
+++ b/src/player/patron.c
@@ -210,7 +210,7 @@ void gain_level_reward(player_type *creature_ptr, int chosen_reward)
             msg_print(_("「汝は良く行いたり！続けよ！」", "'Well done, mortal! Lead on!'"));
 
             if (creature_ptr->prace == RACE_ANDROID) {
-                msg_print(_("しかし何も起こらなかった。", "But, nothing happen."));
+                msg_print(_("しかし何も起こらなかった。", "But, nothing happens."));
             } else if (creature_ptr->exp < PY_MAX_EXP) {
                 s32b ee = (creature_ptr->exp / 2) + 10;
                 if (ee > 100000L)
@@ -228,7 +228,7 @@ void gain_level_reward(player_type *creature_ptr, int chosen_reward)
             msg_print(_("「下僕よ、汝それに値せず。」", "'Thou didst not deserve that, slave.'"));
 
             if (creature_ptr->prace == RACE_ANDROID) {
-                msg_print(_("しかし何も起こらなかった。", "But, nothing happen."));
+                msg_print(_("しかし何も起こらなかった。", "But, nothing happens."));
             } else {
                 lose_exp(creature_ptr, creature_ptr->exp / 6);
                 reward = _("経験値を失った。", "losing experience");

--- a/src/player/player-class.c
+++ b/src/player/player-class.c
@@ -828,7 +828,7 @@ const concptr player_title[MAX_CLASS][PY_MAX_LEVEL / 5] =
 		"Warlock",
 		"Sorcerer",
 		"Ipsissimus",
-		"Archimage",
+		"Archmage",
 	},
 
 	/* Priest */
@@ -954,7 +954,7 @@ const concptr player_title[MAX_CLASS][PY_MAX_LEVEL / 5] =
 		"Warlock",
 		"Sorcerer",
 		"Ipsissimus",
-		"Archimage",
+		"Archmage",
 	},
 
 	/* Tourist */
@@ -1010,7 +1010,7 @@ const concptr player_title[MAX_CLASS][PY_MAX_LEVEL / 5] =
 		"Warlock",
 		"Sorcerer",
 		"Ipsissimus",
-		"Archimage",
+		"Archmage",
 	},
 
 	/* Archer */
@@ -1108,7 +1108,7 @@ const concptr player_title[MAX_CLASS][PY_MAX_LEVEL / 5] =
 		"Warlock",
 		"Sorcerer",
 		"Ipsissimus",
-		"Archimage",
+		"Archmage",
 	},
 
 	/* Warrior */

--- a/src/player/player-class.c
+++ b/src/player/player-class.c
@@ -1111,7 +1111,7 @@ const concptr player_title[MAX_CLASS][PY_MAX_LEVEL / 5] =
 		"Archmage",
 	},
 
-	/* Warrior */
+	/* Cavalry */
 	{
 		"Rookie",
 		"Soldier",

--- a/src/player/player-damage.c
+++ b/src/player/player-damage.c
@@ -445,7 +445,7 @@ int take_hit(player_type *creature_ptr, int damage_type, HIT_POINT damage, concp
                     while (!get_string(winning_seppuku ? "辞世の句: " : "断末魔の叫び: ", death_message, sizeof(death_message)))
                         ;
 #else
-                    while (!get_string("Last word: ", death_message, 1024))
+                    while (!get_string("Last words: ", death_message, 1024))
                         ;
 #endif
                 } while (winning_seppuku && !get_check_strict(creature_ptr, _("よろしいですか？", "Are you sure? "), CHECK_NO_HISTORY));

--- a/src/player/player-status.c
+++ b/src/player/player-status.c
@@ -2822,7 +2822,7 @@ void put_equipment_warning(player_type *creature_ptr)
             } else if (has_melee_weapon(creature_ptr, INVEN_MAIN_HAND + i)) {
                 msg_print(_("これなら装備していても辛くない。", "You have no trouble wielding your weapon."));
             } else if (creature_ptr->heavy_wield[1 - i]) {
-                msg_print(_("まだ武器が重い。", "You have still trouble wielding a heavy weapon."));
+                msg_print(_("まだ武器が重い。", "You still have trouble wielding a heavy weapon."));
             } else {
                 msg_print(_("重い武器を装備からはずして体が楽になった。", "You feel relieved to put down your heavy weapon."));
             }

--- a/src/player/process-death.c
+++ b/src/player/process-death.c
@@ -218,7 +218,7 @@ void print_tomb(player_type *dead_ptr)
     term_clear();
     char buf[1024];
     read_dead_file(buf, sizeof(buf));
-    concptr p = (current_world_ptr->total_winner || (dead_ptr->lev > PY_MAX_LEVEL)) ? _("偉大なる者", "Magnificant")
+    concptr p = (current_world_ptr->total_winner || (dead_ptr->lev > PY_MAX_LEVEL)) ? _("偉大なる者", "Magnificent")
                                                                                     : player_title[dead_ptr->pclass][(dead_ptr->lev - 1) / 5];
 
     center_string(buf, dead_ptr->name);


### PR DESCRIPTION
- Use "last words" rather than "last word" to be more idiomatic.
- Correct spelling mistake for "archmage".
- Correct comment introducing English titles for the cavalry class.
- Correct spelling mistake for "magnificent".
- Swap position of "still" so it doesn't split "have" from the main verb.
- Use "happens" with "nothing" for subject/verb agreement.