### PR TITLE
3.0.0.0: minor English edits for src/player-info

### DIFF
--- a/src/player-info/body-improvement-info.c
+++ b/src/player-info/body-improvement-info.c
@@ -98,10 +98,10 @@ void set_body_improvement_info_3(player_type *creature_ptr, self_info_type *self
         self_ptr->info[self_ptr->line++] = _("あなたは少ない消費魔力で魔法を唱えることができる。", "You can cast spells with fewer mana points.");
 
     if (creature_ptr->easy_spell)
-        self_ptr->info[self_ptr->line++] = _("あなたは低い失敗率で魔法を唱えることができる。", "Fail rate of your magic is decreased.");
+        self_ptr->info[self_ptr->line++] = _("あなたは低い失敗率で魔法を唱えることができる。", "Your magic fails less often.");
 
     if (creature_ptr->heavy_spell)
-        self_ptr->info[self_ptr->line++] = _("あなたは高い失敗率で魔法を唱えなければいけない。", "Fail rate of your magic is increased.");
+        self_ptr->info[self_ptr->line++] = _("あなたは高い失敗率で魔法を唱えなければいけない。", "Your magic fails more often.");
 
     if (creature_ptr->mighty_throw)
         self_ptr->info[self_ptr->line++] = _("あなたは強く物を投げる。", "You can throw objects powerfully.");

--- a/src/player-info/class-ability-info.c
+++ b/src/player-info/class-ability-info.c
@@ -106,7 +106,7 @@ void set_class_ability_info(player_type *creature_ptr, self_info_type *self_ptr)
             = _("あなたは1体の生命のあるモンスターを支配することができる。(レベル/4 MP)", "You can dominate a monster (cost level/4).");
         if (creature_ptr->lev > 29)
             self_ptr->info[self_ptr->line++] = _("あなたは視界内の生命のあるモンスターを支配することができる。((レベル+20)/2 MP)",
-                "You can dominate living monsters in sight (cost (level+20)/4).");
+                "You can dominate living monsters in sight (cost (level+20)/2).");
 
         break;
     case CLASS_MAGIC_EATER:

--- a/src/player-info/weapon-effect-info.c
+++ b/src/player-info/weapon-effect-info.c
@@ -98,7 +98,7 @@ void set_weapon_effect_info(player_type *creature_ptr, self_info_type *self_ptr)
     set_brand_attack_info(self_ptr);
     set_slay_info(self_ptr);
     if (has_flag(self_ptr->flags, TR_FORCE_WEAPON))
-        self_ptr->info[self_ptr->line++] = _("あなたの武器はMPを使って攻撃する。", "Your weapon causes greate damages using your MP.");
+        self_ptr->info[self_ptr->line++] = _("あなたの武器はMPを使って攻撃する。", "Your weapon causes great damage using your MP.");
 
     if (has_flag(self_ptr->flags, TR_THROW))
         self_ptr->info[self_ptr->line++] = _("あなたの武器は投げやすい。", "Your weapon can be thrown well.");


### PR DESCRIPTION
- Match quoted cost for beastmaster's dominate living things ability to that in the Japanese description and the implementation in racial/class-racial-switcher.c.
- For clearer English, replace "greate damages" with "great damage".
- Use terser, and perhaps more idiomatic, descriptions for the easy_spell and heavy_spell effects.