### PR TITLE
Cosmetic: avoid clang's warnings about ((x == y)) versus ((x = y))

### DIFF
--- a/src/player/player-status.c
+++ b/src/player/player-status.c
@@ -2987,14 +2987,14 @@ static s16b calc_to_damage(player_type *creature_ptr, INVENTORY_IDX slot, bool i
             break;
 
         case MELEE_TYPE_WEAPON_DOUBLE:
-            if ((calc_hand == PLAYER_HAND_MAIN)) {
+            if (calc_hand == PLAYER_HAND_MAIN) {
                 if (i == INVEN_MAIN_RING) {
                     damage += (s16b)bonus_to_d;
                 } else if (i != INVEN_SUB_RING) {
                     damage += (bonus_to_d > 0) ? (bonus_to_d + 1) / 2 : bonus_to_d;
                 }
             }
-            if ((calc_hand == PLAYER_HAND_SUB)) {
+            if (calc_hand == PLAYER_HAND_SUB) {
                 if (i == INVEN_SUB_RING) {
                     damage += (s16b)bonus_to_d;
                 } else if (i != INVEN_MAIN_RING) {
@@ -3220,14 +3220,14 @@ static s16b calc_to_hit(player_type *creature_ptr, INVENTORY_IDX slot, bool is_r
             break;
 
         case MELEE_TYPE_WEAPON_DOUBLE:
-            if ((calc_hand == PLAYER_HAND_MAIN)) {
+            if (calc_hand == PLAYER_HAND_MAIN) {
                 if (i == INVEN_MAIN_RING) {
                     hit += (s16b)bonus_to_h;
                 } else if (i != INVEN_SUB_RING) {
                     hit += (bonus_to_h > 0) ? (bonus_to_h + 1) / 2 : bonus_to_h;
                 }
             }
-            if ((calc_hand == PLAYER_HAND_SUB)) {
+            if (calc_hand == PLAYER_HAND_SUB) {
                 if (i == INVEN_SUB_RING) {
                     hit += (s16b)bonus_to_h;
                 } else if (i != INVEN_MAIN_RING) {


### PR DESCRIPTION
clang (at least in version 12) will issue a warning by default for whether a construct like "if ((x == y)) ..." was intended to be "if ((x = y)) ...".  This pull request removes some extra parentheses in src/player/player-status.c to avoid that warning since, in all the affected cases, the intent is to test "if (x == y)".