### PR TITLE
[Fix] カメレオン洞に通常モンスターが生成されるのを修正

### DIFF
--- a/src/market/bounty.c
+++ b/src/market/bounty.c
@@ -281,7 +281,7 @@ void determine_daily_bounty(player_type *player_ptr, bool conv_old)
         max_dl = MAX(max_dlv[DUNGEON_ANGBAND], 3);
     }
 
-    get_mon_num_prep(player_ptr, NULL, NULL);
+    get_mon_num_prep_bounty(player_ptr);
 
     while (TRUE) {
         today_mon = get_mon_num(player_ptr, MIN(max_dl / 2, 40), max_dl, GMN_ARENA);
@@ -313,7 +313,8 @@ void determine_daily_bounty(player_type *player_ptr, bool conv_old)
  */
 void determine_bounty_uniques(player_type *player_ptr)
 {
-    get_mon_num_prep(player_ptr, NULL, NULL);
+    get_mon_num_prep_bounty(player_ptr);
+
     for (int i = 0; i < MAX_BOUNTY; i++) {
         while (TRUE) {
             current_world_ptr->bounty_r_idx[i] = get_mon_num(player_ptr, 0, MAX_DEPTH - 1, GMN_ARENA);

--- a/src/monster/monster-list.c
+++ b/src/monster/monster-list.c
@@ -83,7 +83,7 @@ MONRACE_IDX get_mon_num(player_type *player_ptr, DEPTH min_level, DEPTH max_leve
 {
     int i, j, p;
     int r_idx;
-    long value, total;
+    long value, total_prob3;
     int mon_num = 0;
     monster_race *r_ptr;
     alloc_entry *table = alloc_race_table;
@@ -130,7 +130,7 @@ MONRACE_IDX get_mon_num(player_type *player_ptr, DEPTH min_level, DEPTH max_leve
         }
     }
 
-    total = 0L;
+    total_prob3 = 0L;
 
     /* Process probabilities */
     for (i = 0; i < alloc_race_size; i++) {
@@ -158,19 +158,22 @@ MONRACE_IDX get_mon_num(player_type *player_ptr, DEPTH min_level, DEPTH max_leve
             }
         }
 
-        mon_num++;
         table[i].prob3 = table[i].prob2;
-        total += table[i].prob3;
+
+        if (table[i].prob3 > 0) {
+            mon_num++;
+            total_prob3 += table[i].prob3;
+        }
     }
 
     if (cheat_hear) {
-        msg_format(_("モンスター第3次候補数:%d(%d-%dF)%d ", "monster third selection:%d(%d-%dF)%d "), mon_num, min_level, max_level, total);
+        msg_format(_("モンスター第3次候補数:%d(%d-%dF)%d ", "monster third selection:%d(%d-%dF)%d "), mon_num, min_level, max_level, total_prob3);
     }
 
-    if (total <= 0)
+    if (total_prob3 <= 0)
         return 0;
 
-    value = randint0(total);
+    value = randint0(total_prob3);
     int found_count = 0;
     for (i = 0; i < alloc_race_size; i++) {
         if (value < table[i].prob3)
@@ -184,7 +187,7 @@ MONRACE_IDX get_mon_num(player_type *player_ptr, DEPTH min_level, DEPTH max_leve
     /* Try for a "harder" monster once (50%) or twice (10%) */
     if (p < 60) {
         j = found_count;
-        value = randint0(total);
+        value = randint0(total_prob3);
         for (found_count = 0; found_count < alloc_race_size; found_count++) {
             if (value < table[found_count].prob3)
                 break;
@@ -199,7 +202,7 @@ MONRACE_IDX get_mon_num(player_type *player_ptr, DEPTH min_level, DEPTH max_leve
     /* Try for a "harder" monster twice (10%) */
     if (p < 10) {
         j = found_count;
-        value = randint0(total);
+        value = randint0(total_prob3);
         for (found_count = 0; found_count < alloc_race_size; found_count++) {
             if (value < table[found_count].prob3)
                 break;

--- a/src/monster/monster-util.h
+++ b/src/monster/monster-util.h
@@ -12,4 +12,5 @@ extern summon_type summon_specific_type;
 
 monsterrace_hook_type get_monster_hook(player_type *player_ptr);
 monsterrace_hook_type get_monster_hook2(player_type *player_ptr, POSITION y, POSITION x);
-errr get_mon_num_prep(player_type *player_ptr, monsterrace_hook_type monster_hook, monsterrace_hook_type monster_hook2);
+errr get_mon_num_prep(player_type *player_ptr, monsterrace_hook_type hook1, monsterrace_hook_type hook2);
+errr get_mon_num_prep_bounty(player_type *player_ptr);


### PR DESCRIPTION
#20 の修正です。賞金首選定用に `get_mon_num_prep_bounty()` を設けて対応しました。

モンスター生成時のデバッグ用統計情報ですが、従来のコードでは重みが 0 のものもカ
ウントされていたため、動作確認時にカメレオン1種のみになっているかどうかわかりま
せんでした。そこで、重みが正のもののみカウントするように変更しました。
もし仕様的にまずい点があればご指摘ください。

今のところ本修正によって賞金首選定が失敗することはないと予想しますが、本来
`get_mon_num()` は生成失敗がありうるという仕様なので、bounty.c 側でも一定回数以
上失敗したら何か適当なモンスターを採用する、などの措置をとる方が安全かもしれま
せん。
