### PR TITLE
[Fix] 打撃回避判定のバグ修正

### DIFF
--- a/src/monster-attack/monster-attack-player.c
+++ b/src/monster-attack/monster-attack-player.c
@@ -392,10 +392,9 @@ static bool process_monster_blows(player_type *target_ptr, monap_type *monap_ptr
         monap_ptr->ac = target_ptr->ac + target_ptr->to_a;
         if ((monap_ptr->effect == RBE_NONE)
             || check_hit_from_monster_to_player(target_ptr, power, monap_ptr->rlev, monster_stunned_remaining(monap_ptr->m_ptr))) {
-            if (!process_monster_attack_hit(target_ptr, monap_ptr))
-                continue;
-            else
-                process_monster_attack_evasion(target_ptr, monap_ptr);
+            (void)process_monster_attack_hit(target_ptr, monap_ptr);
+        } else {
+            process_monster_attack_evasion(target_ptr, monap_ptr);
         }
 
         increase_blow_type_seen(target_ptr, monap_ptr);

--- a/src/monster-attack/monster-attack-player.c
+++ b/src/monster-attack/monster-attack-player.c
@@ -395,19 +395,25 @@ static bool process_monster_blows(player_type *target_ptr, monap_type *monap_ptr
         if (monap_ptr->method == RBM_SHOOT)
             continue;
 
+        // 命中判定の成否によらず思い出処理は行う。
+        // ご都合主義的な仕様ではある(魔力吸収など、食らってみるまでわからないはずのものもあるので)。
+        increase_blow_type_seen(target_ptr, monap_ptr);
+
+        // 命中判定。
         power = mbe_info[monap_ptr->effect].power;
         monap_ptr->ac = target_ptr->ac + target_ptr->to_a;
         if (check_hit_from_monster_to_player(target_ptr, power, monap_ptr->rlev, monster_stunned_remaining(monap_ptr->m_ptr))) {
+            // 命中した。
+            // 命中時の処理、落馬処理、変わり身のテレポート処理を行う。
             (void)process_monster_attack_hit(target_ptr, monap_ptr);
+            check_fall_off_horse(target_ptr, monap_ptr);
+            if (target_ptr->special_defense & NINJA_KAWARIMI) {
+                if (kawarimi(target_ptr, FALSE))
+                    return TRUE;
+            }
         } else {
+            // 命中しなかった。回避時の処理を行う。
             process_monster_attack_evasion(target_ptr, monap_ptr);
-        }
-
-        increase_blow_type_seen(target_ptr, monap_ptr);
-        check_fall_off_horse(target_ptr, monap_ptr);
-        if (target_ptr->special_defense & NINJA_KAWARIMI) {
-            if (kawarimi(target_ptr, FALSE))
-                return TRUE;
         }
     }
 

--- a/src/monster-attack/monster-attack-player.c
+++ b/src/monster-attack/monster-attack-player.c
@@ -356,12 +356,19 @@ static void process_monster_attack_evasion(player_type *target_ptr, monap_type *
     }
 }
 
+/*!
+ * @brief モンスターの打撃に関する知識を増やすことを試みる
+ */
 static void increase_blow_type_seen(player_type *target_ptr, monap_type *monap_ptr)
 {
+    // どの敵が何をしてきたか正しく認識できていなければならない。
     if (!is_original_ap_and_seen(target_ptr, monap_ptr->m_ptr) || monap_ptr->do_silly_attack)
         return;
 
     monster_race *r_ptr = &r_info[monap_ptr->m_ptr->r_idx];
+
+    // 非自明な類の打撃については、そのダメージが 0 ならば基本的に知識が増えない。
+    // ただし、既に一定以上の知識があれば常に知識が増える(何をされたのか察知できる)。
     if (!monap_ptr->obvious && (monap_ptr->damage == 0) && (r_ptr->r_blows[monap_ptr->ap_cnt] <= 10))
         return;
 
@@ -369,9 +376,14 @@ static void increase_blow_type_seen(player_type *target_ptr, monap_type *monap_p
         r_ptr->r_blows[monap_ptr->ap_cnt]++;
 }
 
+/*!
+ * @brief モンスターからプレイヤーへの打撃処理本体
+ * @return 打撃に反応してプレイヤーがその場から離脱したかどうか
+ */
 static bool process_monster_blows(player_type *target_ptr, monap_type *monap_ptr)
 {
     monster_race *r_ptr = &r_info[monap_ptr->m_ptr->r_idx];
+
     for (monap_ptr->ap_cnt = 0; monap_ptr->ap_cnt < 4; monap_ptr->ap_cnt++) {
         monap_ptr->obvious = FALSE;
         HIT_POINT power = 0;
@@ -395,28 +407,28 @@ static bool process_monster_blows(player_type *target_ptr, monap_type *monap_ptr
         if (monap_ptr->method == RBM_SHOOT)
             continue;
 
-        // 命中判定の成否によらず思い出処理は行う。
-        // ご都合主義的な仕様ではある(魔力吸収など、食らってみるまでわからないはずのものもあるので)。
-        increase_blow_type_seen(target_ptr, monap_ptr);
-
         // 命中判定。
         power = mbe_info[monap_ptr->effect].power;
         monap_ptr->ac = target_ptr->ac + target_ptr->to_a;
         if (check_hit_from_monster_to_player(target_ptr, power, monap_ptr->rlev, monster_stunned_remaining(monap_ptr->m_ptr))) {
             // 命中した。
-            // 命中時の処理、落馬処理、変わり身のテレポート処理を行う。
+            // 命中時の処理、思い出処理、落馬処理、変わり身のテレポート処理を行う。
             (void)process_monster_attack_hit(target_ptr, monap_ptr);
+            increase_blow_type_seen(target_ptr, monap_ptr);
             check_fall_off_horse(target_ptr, monap_ptr);
             if (target_ptr->special_defense & NINJA_KAWARIMI) {
+                // 変わり身のテレポートが成功したら攻撃を打ち切り、プレイヤーが離脱した旨を返す。
                 if (kawarimi(target_ptr, FALSE))
                     return TRUE;
             }
         } else {
-            // 命中しなかった。回避時の処理を行う。
+            // 命中しなかった。回避時の処理、思い出処理を行う。
             process_monster_attack_evasion(target_ptr, monap_ptr);
+            increase_blow_type_seen(target_ptr, monap_ptr);
         }
     }
 
+    // 通常はプレイヤーはその場にとどまる。
     return FALSE;
 }
 

--- a/src/monster-attack/monster-attack-player.c
+++ b/src/monster-attack/monster-attack-player.c
@@ -411,10 +411,16 @@ static bool process_monster_blows(player_type *target_ptr, monap_type *monap_ptr
         power = mbe_info[monap_ptr->effect].power;
         monap_ptr->ac = target_ptr->ac + target_ptr->to_a;
         if (check_hit_from_monster_to_player(target_ptr, power, monap_ptr->rlev, monster_stunned_remaining(monap_ptr->m_ptr))) {
-            // 命中した。
-            // 命中時の処理、思い出処理、落馬処理、変わり身のテレポート処理を行う。
-            (void)process_monster_attack_hit(target_ptr, monap_ptr);
+            // 命中した。命中処理と思い出処理を行う。
+            // 打撃そのものは対邪悪結界で撃退した可能性がある。
+            const bool protect = !process_monster_attack_hit(target_ptr, monap_ptr);
             increase_blow_type_seen(target_ptr, monap_ptr);
+
+            // 撃退成功時はそのまま次の打撃へ移行。
+            if (protect)
+                continue;
+
+            // 撃退失敗時は落馬処理、変わり身のテレポート処理を行う。
             check_fall_off_horse(target_ptr, monap_ptr);
             if (target_ptr->special_defense & NINJA_KAWARIMI) {
                 // 変わり身のテレポートが成功したら攻撃を打ち切り、プレイヤーが離脱した旨を返す。

--- a/src/monster-attack/monster-attack-player.c
+++ b/src/monster-attack/monster-attack-player.c
@@ -385,13 +385,19 @@ static bool process_monster_blows(player_type *target_ptr, monap_type *monap_ptr
         if (!check_monster_attack_terminated(target_ptr, monap_ptr))
             break;
 
+        // effect が RBE_NONE (無効値)になることはあり得ないはずだが、万一そう
+        // なっていたら単に攻撃を打ち切る。
+        if (monap_ptr->effect == RBE_NONE) {
+            plog("unexpected: monap_ptr->effect == RBE_NONE");
+            break;
+        }
+
         if (monap_ptr->method == RBM_SHOOT)
             continue;
 
         power = mbe_info[monap_ptr->effect].power;
         monap_ptr->ac = target_ptr->ac + target_ptr->to_a;
-        if ((monap_ptr->effect == RBE_NONE)
-            || check_hit_from_monster_to_player(target_ptr, power, monap_ptr->rlev, monster_stunned_remaining(monap_ptr->m_ptr))) {
+        if (check_hit_from_monster_to_player(target_ptr, power, monap_ptr->rlev, monster_stunned_remaining(monap_ptr->m_ptr))) {
             (void)process_monster_attack_hit(target_ptr, monap_ptr);
         } else {
             process_monster_attack_evasion(target_ptr, monap_ptr);


### PR DESCRIPTION
Fixes #21.

`check_hit_from_monster_to_player()` が偽を返したときに回避時の処理を行うべきだが、そうなっていなかった。
本修正により、打撃をかわしたときに盾技能が成長するようになる。以前は打撃を食らったときに盾技能が成長していた。