### PR TITLE
画面再描写関連の整理

### DIFF
--- a/src/action/activation-execution.c
+++ b/src/action/activation-execution.c
@@ -231,7 +231,7 @@ void exe_activate(player_type *user_ptr, INVENTORY_IDX item)
     sound(SOUND_ZAP);
     if (activation_index(user_ptr, ae_ptr->o_ptr)) {
         (void)activate_artifact(user_ptr, ae_ptr->o_ptr);
-        user_ptr->window |= PW_INVEN | PW_EQUIP;
+        user_ptr->window_flags |= PW_INVEN | PW_EQUIP;
         return;
     }
 

--- a/src/artifact/random-art-generator.c
+++ b/src/artifact/random-art-generator.c
@@ -380,7 +380,7 @@ static void generate_unnatural_random_artifact(player_type *player_ptr, object_t
     msg_format_wizard(player_ptr, CHEAT_OBJECT,
         _("パワー %d で 価値%ld のランダムアーティファクト生成 バイアスは「%s」", "Random artifact generated - Power:%d Value:%d Bias:%s."), max_powers,
         total_flags, artifact_bias_name[o_ptr->artifact_bias]);
-    player_ptr->window |= PW_INVEN | PW_EQUIP;
+    player_ptr->window_flags |= PW_INVEN | PW_EQUIP;
 }
 
 /*!

--- a/src/autopick/autopick-util.c
+++ b/src/autopick/autopick-util.c
@@ -77,7 +77,7 @@ void auto_inscribe_item(player_type *player_ptr, object_type *o_ptr, int idx)
 	if (!o_ptr->inscription)
 		o_ptr->inscription = quark_add(autopick_list[idx].insc);
 
-	player_ptr->window |= (PW_EQUIP | PW_INVEN);
+	player_ptr->window_flags |= (PW_EQUIP | PW_INVEN);
 	player_ptr->update |= (PU_BONUS);
 }
 

--- a/src/blue-magic/learnt-power-getter.c
+++ b/src/blue-magic/learnt-power-getter.c
@@ -427,7 +427,7 @@ bool get_learned_power(player_type *caster_ptr, SPELL_IDX *sn)
     if (lm_ptr->redraw)
         screen_load();
 
-    caster_ptr->window |= PW_SPELL;
+    caster_ptr->window_flags |= PW_SPELL;
     handle_stuff(caster_ptr);
 
     if (!lm_ptr->flag)

--- a/src/cmd-action/cmd-hissatsu.c
+++ b/src/cmd-action/cmd-hissatsu.c
@@ -284,7 +284,7 @@ static int get_hissatsu_power(player_type *creature_ptr, SPELL_IDX *sn)
     if (redraw)
         screen_load();
 
-    creature_ptr->window |= (PW_SPELL);
+    creature_ptr->window_flags |= (PW_SPELL);
     handle_stuff(creature_ptr);
 
     /* Abort if needed */
@@ -355,7 +355,7 @@ void do_cmd_hissatsu(player_type *creature_ptr)
     if (creature_ptr->csp < 0)
         creature_ptr->csp = 0;
     creature_ptr->redraw |= (PR_MANA);
-    creature_ptr->window |= (PW_PLAYER | PW_SPELL);
+    creature_ptr->window_flags |= (PW_PLAYER | PW_SPELL);
 }
 
 /*!

--- a/src/cmd-action/cmd-mane.c
+++ b/src/cmd-action/cmd-mane.c
@@ -269,7 +269,7 @@ static int get_mane_power(player_type *caster_ptr, int *sn, bool baigaesi)
     if (redraw)
         screen_load();
 
-    caster_ptr->window |= (PW_SPELL);
+    caster_ptr->window_flags |= (PW_SPELL);
     handle_stuff(caster_ptr);
 
     /* Abort if needed */
@@ -1135,8 +1135,8 @@ bool do_cmd_mane(player_type *creature_ptr, bool baigaesi)
     take_turn(creature_ptr, 100);
 
     creature_ptr->redraw |= (PR_IMITATION);
-    creature_ptr->window |= (PW_PLAYER);
-    creature_ptr->window |= (PW_SPELL);
+    creature_ptr->window_flags |= (PW_PLAYER);
+    creature_ptr->window_flags |= (PW_SPELL);
 
     return TRUE;
 }

--- a/src/cmd-action/cmd-mind.c
+++ b/src/cmd-action/cmd-mind.c
@@ -380,8 +380,8 @@ void do_cmd_mind(player_type *caster_ptr)
     mind_turn_passing(caster_ptr, cm_ptr);
     process_hard_concentration(caster_ptr, cm_ptr);
     caster_ptr->redraw |= PR_MANA;
-    caster_ptr->window |= PW_PLAYER;
-    caster_ptr->window |= PW_SPELL;
+    caster_ptr->window_flags |= PW_PLAYER;
+    caster_ptr->window_flags |= PW_SPELL;
 }
 
 static mind_kind_type decide_use_mind_browse(player_type *caster_ptr)

--- a/src/cmd-action/cmd-move.c
+++ b/src/cmd-action/cmd-move.c
@@ -17,6 +17,7 @@
 #include "game-option/input-options.h"
 #include "game-option/play-record-options.h"
 #include "game-option/special-options.h"
+#include "game-option/map-screen-options.h"
 #include "grid/grid.h"
 #include "info-reader/fixed-map-parser.h"
 #include "io/input-key-requester.h"
@@ -425,6 +426,6 @@ void do_cmd_rest(player_type *creature_ptr)
     update_creature(creature_ptr);
     creature_ptr->redraw |= (PR_STATE);
     update_output(creature_ptr);
-    if (need_term_fresh(creature_ptr))
+    if (fresh_after)
         term_fresh();
 }

--- a/src/cmd-action/cmd-pet.c
+++ b/src/cmd-action/cmd-pet.c
@@ -12,6 +12,7 @@
 #include "game-option/input-options.h"
 #include "game-option/play-record-options.h"
 #include "game-option/text-display-options.h"
+#include "game-option/map-screen-options.h"
 #include "grid/feature.h"
 #include "grid/grid.h"
 #include "inventory/inventory-slot-types.h"
@@ -170,7 +171,7 @@ void do_cmd_pet_dismiss(player_type *creature_ptr)
 
     Term->scr->cu = cu;
     Term->scr->cv = cv;
-    if (need_term_fresh(creature_ptr))
+    if (fresh_after)
         term_fresh();
 
     C_KILL(who, current_world_ptr->max_m_idx, MONSTER_IDX);

--- a/src/cmd-action/cmd-pet.c
+++ b/src/cmd-action/cmd-pet.c
@@ -162,7 +162,7 @@ void do_cmd_pet_dismiss(player_type *creature_ptr)
             /* HACK : Add the line to message buffer */
             msg_format(_("%s を放した。", "Dismissed %s."), friend_name);
             creature_ptr->update |= (PU_BONUS);
-            creature_ptr->window |= (PW_MESSAGE);
+            creature_ptr->window_flags |= (PW_MESSAGE);
 
             delete_monster_idx(creature_ptr, pet_ctr);
             Dismissed++;

--- a/src/cmd-action/cmd-racial.c
+++ b/src/cmd-action/cmd-racial.c
@@ -309,5 +309,5 @@ void do_cmd_racial_power(player_type *creature_ptr)
         return;
 
     creature_ptr->redraw |= PR_HP | PR_MANA;
-    creature_ptr->window |= PW_PLAYER | PW_SPELL;
+    creature_ptr->window_flags |= PW_PLAYER | PW_SPELL;
 }

--- a/src/cmd-action/cmd-spell.c
+++ b/src/cmd-action/cmd-spell.c
@@ -330,7 +330,7 @@ static int get_spell(player_type *caster_ptr, SPELL_IDX *sn, concptr prompt, OBJ
     flag = FALSE;
     redraw = FALSE;
 
-    caster_ptr->window |= (PW_SPELL);
+    caster_ptr->window_flags |= (PW_SPELL);
     handle_stuff(caster_ptr);
 
     /* Build a prompt (accept all spells) */
@@ -483,7 +483,7 @@ static int get_spell(player_type *caster_ptr, SPELL_IDX *sn, concptr prompt, OBJ
     if (redraw)
         screen_load();
 
-    caster_ptr->window |= (PW_SPELL);
+    caster_ptr->window_flags |= (PW_SPELL);
     handle_stuff(caster_ptr);
 
     /* Abort if needed */
@@ -927,7 +927,7 @@ void do_cmd_study(player_type *caster_ptr)
     update_creature(caster_ptr);
 
     /* Redraw object recall */
-    caster_ptr->window |= (PW_OBJECT);
+    caster_ptr->window_flags |= (PW_OBJECT);
 }
 
 /*!
@@ -1173,7 +1173,7 @@ void do_cmd_cast(player_type *caster_ptr)
             }
 
             gain_exp(caster_ptr, e * s_ptr->slevel);
-            caster_ptr->window |= (PW_OBJECT);
+            caster_ptr->window_flags |= (PW_OBJECT);
 
             switch (realm) {
             case REALM_LIFE:
@@ -1343,6 +1343,6 @@ void do_cmd_cast(player_type *caster_ptr)
         }
     }
 
-    caster_ptr->window |= (PW_PLAYER);
-    caster_ptr->window |= (PW_SPELL);
+    caster_ptr->window_flags |= (PW_PLAYER);
+    caster_ptr->window_flags |= (PW_SPELL);
 }

--- a/src/cmd-building/cmd-building.c
+++ b/src/cmd-building/cmd-building.c
@@ -413,5 +413,5 @@ void do_cmd_building(player_type *player_ptr)
 
 	player_ptr->update |= (PU_VIEW | PU_MONSTERS | PU_BONUS | PU_LITE | PU_MON_LITE);
 	player_ptr->redraw |= (PR_BASIC | PR_EXTRA | PR_EQUIPPY | PR_MAP);
-	player_ptr->window |= (PW_OVERHEAD | PW_DUNGEON);
+	player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
 }

--- a/src/cmd-building/cmd-store.c
+++ b/src/cmd-building/cmd-store.c
@@ -197,5 +197,5 @@ void do_cmd_store(player_type *player_ptr)
     player_ptr->update |= PU_MONSTERS;
     player_ptr->redraw |= PR_BASIC | PR_EXTRA | PR_EQUIPPY;
     player_ptr->redraw |= PR_MAP;
-    player_ptr->window |= PW_OVERHEAD | PW_DUNGEON;
+    player_ptr->window_flags |= PW_OVERHEAD | PW_DUNGEON;
 }

--- a/src/cmd-io/cmd-floor.c
+++ b/src/cmd-io/cmd-floor.c
@@ -38,7 +38,7 @@ void do_cmd_target(player_type *creature_ptr)
  */
 void do_cmd_look(player_type *creature_ptr)
 {
-    creature_ptr->window |= PW_MONSTER_LIST;
+    creature_ptr->window_flags |= PW_MONSTER_LIST;
     handle_stuff(creature_ptr);
     if (target_set(creature_ptr, TARGET_LOOK))
         msg_print(_("ターゲット決定。", "Target Selected."));
@@ -92,6 +92,6 @@ void do_cmd_locate(player_type *creature_ptr)
     verify_panel(creature_ptr);
     creature_ptr->update |= PU_MONSTERS;
     creature_ptr->redraw |= PR_MAP;
-    creature_ptr->window |= PW_OVERHEAD | PW_DUNGEON;
+    creature_ptr->window_flags |= PW_OVERHEAD | PW_DUNGEON;
     handle_stuff(creature_ptr);
 }

--- a/src/cmd-io/cmd-gameoption.c
+++ b/src/cmd-io/cmd-gameoption.c
@@ -511,7 +511,7 @@ void do_cmd_options(player_type *player_ptr)
         case 'W':
         case 'w': {
             do_cmd_options_win(player_ptr);
-            player_ptr->window |= (PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER | PW_MESSAGE | PW_OVERHEAD | PW_MONSTER | PW_OBJECT | PW_SNAPSHOT | PW_DUNGEON
+            player_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER | PW_MESSAGE | PW_OVERHEAD | PW_MONSTER | PW_OBJECT | PW_SNAPSHOT | PW_DUNGEON
                 | PW_MONSTER_LIST);
             break;
         }

--- a/src/cmd-item/cmd-destroy.c
+++ b/src/cmd-item/cmd-destroy.c
@@ -60,7 +60,7 @@ static bool check_destory_item(player_type *creature_ptr, destroy_type *destroy_
     sprintf(destroy_ptr->out_val, _("本当に%sを壊しますか? [y/n/Auto]", "Really destroy %s? [y/n/Auto]"), destroy_ptr->o_name);
     msg_print(NULL);
     message_add(destroy_ptr->out_val);
-    creature_ptr->window |= PW_MESSAGE;
+    creature_ptr->window_flags |= PW_MESSAGE;
     handle_stuff(creature_ptr);
     while (TRUE) {
         prt(destroy_ptr->out_val, 0, 0);

--- a/src/cmd-item/cmd-eat.c
+++ b/src/cmd-item/cmd-eat.c
@@ -301,7 +301,7 @@ void exe_eat_food(player_type *creature_ptr, INVENTORY_IDX item)
         gain_exp(creature_ptr, (lev + (creature_ptr->lev >> 1)) / creature_ptr->lev);
     }
 
-    creature_ptr->window |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
+    creature_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
 
     /* Food can feed the player */
     if (is_specific_player_race(creature_ptr, RACE_VAMPIRE) || (creature_ptr->mimic_form == MIMIC_VAMPIRE)) {
@@ -328,7 +328,7 @@ void exe_eat_food(player_type *creature_ptr, INVENTORY_IDX item)
             msg_format(_("この%sにはもう魔力が残っていない。", "The %s has no charges left."), staff);
             o_ptr->ident |= (IDENT_EMPTY);
             creature_ptr->update |= inventory_flags;
-            creature_ptr->window |= (PW_INVEN);
+            creature_ptr->window_flags |= (PW_INVEN);
 
             return;
         }
@@ -370,7 +370,7 @@ void exe_eat_food(player_type *creature_ptr, INVENTORY_IDX item)
             floor_item_charges(creature_ptr->current_floor_ptr, 0 - item);
         }
 
-        creature_ptr->window |= (PW_INVEN | PW_EQUIP);
+        creature_ptr->window_flags |= (PW_INVEN | PW_EQUIP);
         creature_ptr->update |= inventory_flags;
 
         /* Don't eat a staff/wand itself */

--- a/src/cmd-item/cmd-equipment.c
+++ b/src/cmd-item/cmd-equipment.c
@@ -286,7 +286,7 @@ void do_cmd_wield(player_type *creature_ptr)
 
     creature_ptr->update |= PU_BONUS | PU_TORCH | PU_MANA;
     creature_ptr->redraw |= PR_EQUIPPY;
-    creature_ptr->window |= PW_INVEN | PW_EQUIP | PW_PLAYER;
+    creature_ptr->window_flags |= PW_INVEN | PW_EQUIP | PW_PLAYER;
     calc_android_exp(creature_ptr);
 }
 
@@ -319,7 +319,7 @@ void do_cmd_takeoff(player_type *creature_ptr)
             o_ptr->curse_flags = 0L;
             o_ptr->feeling = FEEL_NONE;
             creature_ptr->update |= PU_BONUS;
-            creature_ptr->window |= PW_EQUIP;
+            creature_ptr->window_flags |= PW_EQUIP;
             msg_print(_("呪いを打ち破った。", "You break the curse."));
         } else {
             msg_print(_("装備を外せなかった。", "You couldn't remove the equipment."));

--- a/src/cmd-item/cmd-item.c
+++ b/src/cmd-item/cmd-item.c
@@ -186,7 +186,7 @@ void do_cmd_uninscribe(player_type *creature_ptr)
     msg_print(_("銘を消した。", "Inscription removed."));
     o_ptr->inscription = 0;
     creature_ptr->update |= (PU_COMBINE);
-    creature_ptr->window |= (PW_INVEN | PW_EQUIP);
+    creature_ptr->window_flags |= (PW_INVEN | PW_EQUIP);
     creature_ptr->update |= (PU_BONUS);
 }
 
@@ -217,7 +217,7 @@ void do_cmd_inscribe(player_type *creature_ptr)
     if (get_string(_("銘: ", "Inscription: "), out_val, 80)) {
         o_ptr->inscription = quark_add(out_val);
         creature_ptr->update |= (PU_COMBINE);
-        creature_ptr->window |= (PW_INVEN | PW_EQUIP);
+        creature_ptr->window_flags |= (PW_INVEN | PW_EQUIP);
         creature_ptr->update |= (PU_BONUS);
     }
 }

--- a/src/cmd-item/cmd-smith.c
+++ b/src/cmd-item/cmd-smith.c
@@ -449,7 +449,7 @@ static void drain_essence(player_type *creature_ptr)
     /* Apply autodestroy/inscription to the drained item */
     autopick_alter_item(creature_ptr, item, TRUE);
     creature_ptr->update |= (PU_COMBINE | PU_REORDER);
-    creature_ptr->window |= (PW_INVEN);
+    creature_ptr->window_flags |= (PW_INVEN);
 }
 
 /*!
@@ -983,7 +983,7 @@ static void add_essence(player_type *creature_ptr, ESSENCE_IDX mode)
     take_turn(creature_ptr, 100);
     _(msg_format("%sに%sの能力を付加しました。", o_name, es_ptr->add_name), msg_format("You have added ability of %s to %s.", es_ptr->add_name, o_name));
     creature_ptr->update |= (PU_COMBINE | PU_REORDER);
-    creature_ptr->window |= (PW_INVEN);
+    creature_ptr->window_flags |= (PW_INVEN);
 }
 
 /*!
@@ -1028,7 +1028,7 @@ static void erase_essence(player_type *creature_ptr)
         o_ptr->pval = 0;
     msg_print(_("エッセンスを取り去った。", "You removed all essence you have added."));
     creature_ptr->update |= (PU_COMBINE | PU_REORDER);
-    creature_ptr->window |= (PW_INVEN);
+    creature_ptr->window_flags |= (PW_INVEN);
 }
 
 /*!

--- a/src/cmd-item/cmd-throw.c
+++ b/src/cmd-item/cmd-throw.c
@@ -479,7 +479,7 @@ static void process_boomerang_back(player_type *creature_ptr, it_type *it_ptr)
         object_copy(it_ptr->o_ptr, it_ptr->q_ptr);
         creature_ptr->equip_cnt++;
         creature_ptr->update |= PU_BONUS | PU_TORCH | PU_MANA;
-        creature_ptr->window |= PW_EQUIP;
+        creature_ptr->window_flags |= PW_EQUIP;
         it_ptr->do_drop = FALSE;
         return;
     }

--- a/src/cmd-item/cmd-usestaff.c
+++ b/src/cmd-item/cmd-usestaff.c
@@ -354,7 +354,7 @@ void exe_use_staff(player_type *creature_ptr, INVENTORY_IDX item)
         msg_print(_("この杖にはもう魔力が残っていない。", "The staff has no charges left."));
         o_ptr->ident |= (IDENT_EMPTY);
         creature_ptr->update |= (PU_COMBINE | PU_REORDER);
-        creature_ptr->window |= (PW_INVEN);
+        creature_ptr->window_flags |= (PW_INVEN);
 
         return;
     }
@@ -386,7 +386,7 @@ void exe_use_staff(player_type *creature_ptr, INVENTORY_IDX item)
         gain_exp(creature_ptr, (lev + (creature_ptr->lev >> 1)) / creature_ptr->lev);
     }
 
-    creature_ptr->window |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
+    creature_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
     creature_ptr->update |= inventory_flags;
 
     /* Hack -- some uses are "free" */

--- a/src/cmd-item/cmd-zaprod.c
+++ b/src/cmd-item/cmd-zaprod.c
@@ -400,7 +400,7 @@ void exe_zap_rod(player_type *creature_ptr, INVENTORY_IDX item)
         gain_exp(creature_ptr, (lev + (creature_ptr->lev >> 1)) / creature_ptr->lev);
     }
 
-    creature_ptr->window |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
+    creature_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
 }
 
 /*!

--- a/src/cmd-item/cmd-zapwand.c
+++ b/src/cmd-item/cmd-zapwand.c
@@ -395,7 +395,7 @@ void exe_aim_wand(player_type *creature_ptr, INVENTORY_IDX item)
         msg_print(_("この魔法棒にはもう魔力が残っていない。", "The wand has no charges left."));
         o_ptr->ident |= (IDENT_EMPTY);
         creature_ptr->update |= (PU_COMBINE | PU_REORDER);
-        creature_ptr->window |= (PW_INVEN);
+        creature_ptr->window_flags |= (PW_INVEN);
 
         return;
     }
@@ -427,7 +427,7 @@ void exe_aim_wand(player_type *creature_ptr, INVENTORY_IDX item)
         gain_exp(creature_ptr, (lev + (creature_ptr->lev >> 1)) / creature_ptr->lev);
     }
 
-    creature_ptr->window |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
+    creature_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
     creature_ptr->update |= inventory_flags;
 
     /* Use a single charge */

--- a/src/cmd-visual/cmd-draw.c
+++ b/src/cmd-visual/cmd-draw.c
@@ -48,8 +48,8 @@ void do_cmd_redraw(player_type *creature_ptr)
 
 	creature_ptr->redraw |= (PR_WIPE | PR_BASIC | PR_EXTRA | PR_MAP | PR_EQUIPPY);
 
-	creature_ptr->window |= (PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER);
-	creature_ptr->window |= (PW_MESSAGE | PW_OVERHEAD | PW_DUNGEON | PW_MONSTER | PW_OBJECT);
+	creature_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER);
+	creature_ptr->window_flags |= (PW_MESSAGE | PW_OVERHEAD | PW_DUNGEON | PW_MONSTER | PW_OBJECT);
 
 	update_playtime();
 	handle_stuff(creature_ptr);

--- a/src/core/asking-player.c
+++ b/src/core/asking-player.c
@@ -238,7 +238,7 @@ bool get_check_strict(player_type *player_ptr, concptr prompt, BIT_FLAGS mode)
 {
     char buf[80];
     if (auto_more) {
-        player_ptr->window |= PW_MESSAGE;
+        player_ptr->window_flags |= PW_MESSAGE;
         handle_stuff(player_ptr);
         num_more = 0;
     }
@@ -261,7 +261,7 @@ bool get_check_strict(player_type *player_ptr, concptr prompt, BIT_FLAGS mode)
     prt(buf, 0, 0);
     if (!(mode & CHECK_NO_HISTORY) && player_ptr->playing) {
         message_add(buf);
-        player_ptr->window |= (PW_MESSAGE);
+        player_ptr->window_flags |= (PW_MESSAGE);
         handle_stuff(player_ptr);
     }
 

--- a/src/core/game-play.c
+++ b/src/core/game-play.c
@@ -293,7 +293,7 @@ static void generate_world(player_type *player_ptr, bool new_game)
 static void init_io(player_type *player_ptr)
 {
     term_xtra(TERM_XTRA_REACT, 0);
-    player_ptr->window |= PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER | PW_MESSAGE | PW_OVERHEAD | PW_DUNGEON | PW_MONSTER | PW_OBJECT;
+    player_ptr->window_flags |= PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER | PW_MESSAGE | PW_OVERHEAD | PW_DUNGEON | PW_MONSTER | PW_OBJECT;
     handle_stuff(player_ptr);
     if (arg_force_original)
         rogue_like_commands = FALSE;

--- a/src/core/hp-mp-processor.c
+++ b/src/core/hp-mp-processor.c
@@ -437,7 +437,7 @@ bool hp_player(player_type *creature_ptr, int num)
         }
 
         creature_ptr->redraw |= (PR_HP);
-        creature_ptr->window |= (PW_PLAYER);
+        creature_ptr->window_flags |= (PW_PLAYER);
         if (num < 5) {
             msg_print(_("少し気分が良くなった。", "You feel a little better."));
         } else if (num < 15) {

--- a/src/core/hp-mp-regenerator.c
+++ b/src/core/hp-mp-regenerator.c
@@ -46,7 +46,7 @@ void regenhp(player_type *creature_ptr, int percent)
 
     if (old_chp != creature_ptr->chp) {
         creature_ptr->redraw |= (PR_HP);
-        creature_ptr->window |= (PW_PLAYER);
+        creature_ptr->window_flags |= (PW_PLAYER);
         wild_regen = 20;
     }
 }
@@ -103,8 +103,8 @@ void regenmana(player_type *creature_ptr, MANA_POINT upkeep_factor, MANA_POINT r
 
     if (old_csp != creature_ptr->csp) {
         creature_ptr->redraw |= (PR_MANA);
-        creature_ptr->window |= (PW_PLAYER);
-        creature_ptr->window |= (PW_SPELL);
+        creature_ptr->window_flags |= (PW_PLAYER);
+        creature_ptr->window_flags |= (PW_SPELL);
         wild_regen = 20;
     }
 }
@@ -229,8 +229,8 @@ void regenerate_captured_monsters(player_type *creature_ptr)
 
     if (heal) {
         creature_ptr->update |= (PU_COMBINE);
-        creature_ptr->window |= (PW_INVEN);
-        creature_ptr->window |= (PW_EQUIP);
+        creature_ptr->window_flags |= (PW_INVEN);
+        creature_ptr->window_flags |= (PW_EQUIP);
         wild_regen = 20;
     }
 }

--- a/src/core/object-compressor.c
+++ b/src/core/object-compressor.c
@@ -77,7 +77,7 @@ void compact_objects(player_type *player_ptr, int size)
     if (size) {
         msg_print(_("アイテム情報を圧縮しています...", "Compacting objects..."));
         player_ptr->redraw |= PR_MAP;
-        player_ptr->window |= PW_OVERHEAD | PW_DUNGEON;
+        player_ptr->window_flags |= PW_OVERHEAD | PW_DUNGEON;
     }
 
     floor_type *floor_ptr = player_ptr->current_floor_ptr;

--- a/src/core/output-updater.c
+++ b/src/core/output-updater.c
@@ -11,6 +11,6 @@ void update_output(player_type* player_ptr)
 {
     if (player_ptr->redraw)
         redraw_stuff(player_ptr);
-    if (player_ptr->window)
+    if (player_ptr->window_flags)
         window_stuff(player_ptr);
 }

--- a/src/core/player-processor.c
+++ b/src/core/player-processor.c
@@ -44,6 +44,7 @@
 #include "system/floor-type-definition.h"
 #include "term/screen-processor.h"
 #include "view/display-messages.h"
+#include "window/display-sub-windows.h"
 #include "world/world-turn-processor.h"
 
 bool load = TRUE;
@@ -125,8 +126,13 @@ void process_player(player_type *creature_ptr)
 
     if (creature_ptr->energy_need > 0)
         return;
-    if (!command_rep)
+    if (!command_rep) {
         print_time(creature_ptr);
+    }
+
+    if (!fresh_after && (continuous_action_running(creature_ptr) || !command_rep)) {
+        stop_term_fresh();
+    }
 
     if (creature_ptr->resting < 0) {
         if (creature_ptr->resting == COMMAND_ARG_REST_FULL_HEALING) {

--- a/src/core/player-processor.c
+++ b/src/core/player-processor.c
@@ -242,7 +242,7 @@ void process_player(player_type *creature_ptr)
 
     /*** Handle actual user input ***/
     while (creature_ptr->energy_need <= 0) {
-        creature_ptr->window |= PW_PLAYER;
+        creature_ptr->window_flags |= PW_PLAYER;
         creature_ptr->sutemi = FALSE;
         creature_ptr->counter = FALSE;
         creature_ptr->now_damaged = FALSE;
@@ -289,7 +289,7 @@ void process_player(player_type *creature_ptr)
         } else {
             move_cursor_relative(creature_ptr->y, creature_ptr->x);
 
-            creature_ptr->window |= PW_MONSTER_LIST;
+            creature_ptr->window_flags |= PW_MONSTER_LIST;
             window_stuff(creature_ptr);
 
             can_save = TRUE;
@@ -377,7 +377,7 @@ void process_player(player_type *creature_ptr)
             if (creature_ptr->timewalk && (creature_ptr->energy_need > -1000)) {
                 creature_ptr->redraw |= (PR_MAP);
                 creature_ptr->update |= (PU_MONSTERS);
-                creature_ptr->window |= (PW_OVERHEAD | PW_DUNGEON);
+                creature_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
 
                 msg_print(_("「時は動きだす…」", "You feel time flowing around you once more."));
                 msg_print(NULL);

--- a/src/core/stuff-handler.c
+++ b/src/core/stuff-handler.c
@@ -14,7 +14,7 @@ void handle_stuff(player_type* player_ptr)
         update_creature(player_ptr);
     if (player_ptr->redraw)
         redraw_stuff(player_ptr);
-    if (player_ptr->window)
+    if (player_ptr->window_flags)
         window_stuff(player_ptr);
 }
 
@@ -24,7 +24,7 @@ void handle_stuff(player_type* player_ptr)
 void monster_race_track(player_type *player_ptr, MONRACE_IDX r_idx)
 {
     player_ptr->monster_race_idx = r_idx;
-    player_ptr->window |= (PW_MONSTER);
+    player_ptr->window_flags |= (PW_MONSTER);
 }
 
 /*
@@ -33,7 +33,7 @@ void monster_race_track(player_type *player_ptr, MONRACE_IDX r_idx)
 void object_kind_track(player_type *player_ptr, KIND_OBJECT_IDX k_idx)
 {
     player_ptr->object_kind_idx = k_idx;
-    player_ptr->window |= (PW_OBJECT);
+    player_ptr->window_flags |= (PW_OBJECT);
 }
 
 /*
@@ -54,7 +54,7 @@ void health_track(player_type *player_ptr, MONSTER_IDX m_idx)
 bool update_player(player_type *caster_ptr)
 {
     caster_ptr->update |= PU_COMBINE | PU_REORDER;
-    caster_ptr->window |= PW_INVEN;
+    caster_ptr->window_flags |= PW_INVEN;
     return TRUE;
 }
 
@@ -66,6 +66,6 @@ bool redraw_player(player_type *caster_ptr)
 
     caster_ptr->redraw |= PR_MANA;
     caster_ptr->update |= PU_COMBINE | PU_REORDER;
-    caster_ptr->window |= PW_INVEN;
+    caster_ptr->window_flags |= PW_INVEN;
     return TRUE;
 }

--- a/src/core/window-redrawer.c
+++ b/src/core/window-redrawer.c
@@ -231,62 +231,60 @@ void window_stuff(player_type *player_ptr)
     
     BIT_FLAGS mask = 0L;
     for (int j = 0; j < 8; j++) {
-        if (angband_term[j])
+        if (angband_term[j] && !angband_term[j]->never_fresh)
             mask |= window_flag[j];
     }
+    BIT_FLAGS window = player_ptr->window & mask;
 
-    player_ptr->window &= mask;
-
-    if (!player_ptr->window)
+    if (!window)
         return;
 
-    if (need_term_fresh(player_ptr) && player_ptr->window & (PW_INVEN)) {
+    if (window & (PW_INVEN)) {
         player_ptr->window &= ~(PW_INVEN);
         fix_inventory(player_ptr, 0); // TODO:2.2.2 まともなtval参照手段を確保
     }
 
-    if (need_term_fresh(player_ptr) && player_ptr->window & (PW_EQUIP)) {
+    if (window & (PW_EQUIP)) {
         player_ptr->window &= ~(PW_EQUIP);
         fix_equip(player_ptr, 0); // TODO:2.2.2 まともなtval参照手段を確保
     }
 
-    if (need_term_fresh(player_ptr) && player_ptr->window & (PW_SPELL)) {
+    if (window & (PW_SPELL)) {
         player_ptr->window &= ~(PW_SPELL);
         fix_spell(player_ptr);
     }
 
-    if (need_term_fresh(player_ptr) && player_ptr->window & (PW_PLAYER)) {
+    if (window & (PW_PLAYER)) {
         player_ptr->window &= ~(PW_PLAYER);
         fix_player(player_ptr);
     }
 
-    if (player_ptr->window & (PW_MONSTER_LIST)) {
-        if (need_term_fresh(player_ptr))
-            player_ptr->window &= ~(PW_MONSTER_LIST);
-        fix_monster_list(player_ptr); //need this side-effect for work targetting collect
+    if (window & (PW_MONSTER_LIST)) {
+        player_ptr->window &= ~(PW_MONSTER_LIST);
+        fix_monster_list(player_ptr, FALSE);
     }
 
-    if (need_term_fresh(player_ptr) && player_ptr->window & (PW_MESSAGE)) {
+    if (window & (PW_MESSAGE)) {
         player_ptr->window &= ~(PW_MESSAGE);
         fix_message();
     }
 
-    if (need_term_fresh(player_ptr) && player_ptr->window & (PW_OVERHEAD)) {
+    if (window & (PW_OVERHEAD)) {
         player_ptr->window &= ~(PW_OVERHEAD);
         fix_overhead(player_ptr);
     }
 
-    if (need_term_fresh(player_ptr) && player_ptr->window & (PW_DUNGEON)) {
+    if (window & (PW_DUNGEON)) {
         player_ptr->window &= ~(PW_DUNGEON);
         fix_dungeon(player_ptr);
     }
 
-    if (need_term_fresh(player_ptr) && player_ptr->window & (PW_MONSTER)) {
+    if (window & (PW_MONSTER)) {
         player_ptr->window &= ~(PW_MONSTER);
         fix_monster(player_ptr);
     }
 
-    if (need_term_fresh(player_ptr) && player_ptr->window & (PW_OBJECT)) {
+    if (window & (PW_OBJECT)) {
         player_ptr->window &= ~(PW_OBJECT);
         fix_object(player_ptr);
     }

--- a/src/core/window-redrawer.c
+++ b/src/core/window-redrawer.c
@@ -34,8 +34,8 @@ void redraw_window(void)
     if (!current_world_ptr->character_dungeon)
         return;
 
-    p_ptr->window |= (PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER);
-    p_ptr->window |= (PW_MESSAGE | PW_OVERHEAD | PW_DUNGEON | PW_MONSTER | PW_OBJECT);
+    p_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER);
+    p_ptr->window_flags |= (PW_MESSAGE | PW_OVERHEAD | PW_DUNGEON | PW_MONSTER | PW_OBJECT);
 
     handle_stuff(p_ptr);
     term_redraw();
@@ -226,7 +226,7 @@ void redraw_stuff(player_type *creature_ptr)
  */
 void window_stuff(player_type *player_ptr)
 {
-    if (!player_ptr->window)
+    if (!player_ptr->window_flags)
         return;
     
     BIT_FLAGS mask = 0L;
@@ -234,58 +234,55 @@ void window_stuff(player_type *player_ptr)
         if (angband_term[j] && !angband_term[j]->never_fresh)
             mask |= window_flag[j];
     }
-    BIT_FLAGS window = player_ptr->window & mask;
+    BIT_FLAGS window_flags = player_ptr->window_flags & mask;
 
-    if (!window)
-        return;
-
-    if (window & (PW_INVEN)) {
-        player_ptr->window &= ~(PW_INVEN);
+    if (window_flags & (PW_INVEN)) {
+        player_ptr->window_flags &= ~(PW_INVEN);
         fix_inventory(player_ptr, 0); // TODO:2.2.2 まともなtval参照手段を確保
     }
 
-    if (window & (PW_EQUIP)) {
-        player_ptr->window &= ~(PW_EQUIP);
+    if (window_flags & (PW_EQUIP)) {
+        player_ptr->window_flags &= ~(PW_EQUIP);
         fix_equip(player_ptr, 0); // TODO:2.2.2 まともなtval参照手段を確保
     }
 
-    if (window & (PW_SPELL)) {
-        player_ptr->window &= ~(PW_SPELL);
+    if (window_flags & (PW_SPELL)) {
+        player_ptr->window_flags &= ~(PW_SPELL);
         fix_spell(player_ptr);
     }
 
-    if (window & (PW_PLAYER)) {
-        player_ptr->window &= ~(PW_PLAYER);
+    if (window_flags & (PW_PLAYER)) {
+        player_ptr->window_flags &= ~(PW_PLAYER);
         fix_player(player_ptr);
     }
 
-    if (window & (PW_MONSTER_LIST)) {
-        player_ptr->window &= ~(PW_MONSTER_LIST);
+    if (window_flags & (PW_MONSTER_LIST)) {
+        player_ptr->window_flags &= ~(PW_MONSTER_LIST);
         fix_monster_list(player_ptr, FALSE);
     }
 
-    if (window & (PW_MESSAGE)) {
-        player_ptr->window &= ~(PW_MESSAGE);
+    if (window_flags & (PW_MESSAGE)) {
+        player_ptr->window_flags &= ~(PW_MESSAGE);
         fix_message();
     }
 
-    if (window & (PW_OVERHEAD)) {
-        player_ptr->window &= ~(PW_OVERHEAD);
+    if (window_flags & (PW_OVERHEAD)) {
+        player_ptr->window_flags &= ~(PW_OVERHEAD);
         fix_overhead(player_ptr);
     }
 
-    if (window & (PW_DUNGEON)) {
-        player_ptr->window &= ~(PW_DUNGEON);
+    if (window_flags & (PW_DUNGEON)) {
+        player_ptr->window_flags &= ~(PW_DUNGEON);
         fix_dungeon(player_ptr);
     }
 
-    if (window & (PW_MONSTER)) {
-        player_ptr->window &= ~(PW_MONSTER);
+    if (window_flags & (PW_MONSTER)) {
+        player_ptr->window_flags &= ~(PW_MONSTER);
         fix_monster(player_ptr);
     }
 
-    if (window & (PW_OBJECT)) {
-        player_ptr->window &= ~(PW_OBJECT);
+    if (window_flags & (PW_OBJECT)) {
+        player_ptr->window_flags &= ~(PW_OBJECT);
         fix_object(player_ptr);
     }
 }

--- a/src/dungeon/dungeon-processor.c
+++ b/src/dungeon/dungeon-processor.c
@@ -93,7 +93,7 @@ void process_dungeon(player_type *player_ptr, bool load_game)
     msg_erase();
 
     current_world_ptr->character_xtra = TRUE;
-    player_ptr->window |= (PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER | PW_MONSTER | PW_OVERHEAD | PW_DUNGEON);
+    player_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER | PW_MONSTER | PW_OVERHEAD | PW_DUNGEON);
     player_ptr->redraw |= (PR_WIPE | PR_BASIC | PR_EXTRA | PR_EQUIPPY | PR_MAP);
     player_ptr->update |= (PU_BONUS | PU_HP | PU_MANA | PU_SPELLS | PU_VIEW | PU_LITE | PU_MON_LITE | PU_TORCH | PU_MONSTERS | PU_DISTANCE | PU_FLOW);
     handle_stuff(player_ptr);

--- a/src/dungeon/dungeon-processor.c
+++ b/src/dungeon/dungeon-processor.c
@@ -102,7 +102,7 @@ void process_dungeon(player_type *player_ptr, bool load_game)
     player_ptr->update |= (PU_BONUS | PU_HP | PU_MANA | PU_SPELLS);
     player_ptr->update |= (PU_COMBINE | PU_REORDER);
     handle_stuff(player_ptr);
-    if (need_term_fresh(player_ptr))
+    if (fresh_after)
         term_fresh();
 
     if (quest_num

--- a/src/effect/effect-monster-psi.c
+++ b/src/effect/effect-monster-psi.c
@@ -197,7 +197,7 @@ static void effect_monster_psi_drain_resist(player_type *caster_ptr, effect_mons
 	if (caster_ptr->csp < 0) caster_ptr->csp = 0;
 
 	caster_ptr->redraw |= PR_MANA;
-	caster_ptr->window |= (PW_SPELL);
+	caster_ptr->window_flags |= (PW_SPELL);
 	take_hit(caster_ptr, DAMAGE_ATTACK, em_ptr->dam, em_ptr->killer, -1);
 	em_ptr->dam = 0;
 }
@@ -214,7 +214,7 @@ static void effect_monster_psi_drain_change_power(player_type *caster_ptr, effec
 	b = MIN(caster_ptr->msp, caster_ptr->csp + b);
 	caster_ptr->csp = b;
 	caster_ptr->redraw |= PR_MANA;
-	caster_ptr->window |= (PW_SPELL);
+	caster_ptr->window_flags |= (PW_SPELL);
 }
 
 

--- a/src/effect/effect-monster.c
+++ b/src/effect/effect-monster.c
@@ -593,7 +593,7 @@ bool affect_monster(
 
     lite_spot(caster_ptr, em_ptr->y, em_ptr->x);
     if ((caster_ptr->monster_race_idx == em_ptr->m_ptr->r_idx) && (em_ptr->seen || !em_ptr->m_ptr->r_idx))
-        caster_ptr->window |= (PW_MONSTER);
+        caster_ptr->window_flags |= (PW_MONSTER);
 
     postprocess_spell(caster_ptr, em_ptr);
     return em_ptr->obvious;

--- a/src/effect/effect-player-resist-hurt.c
+++ b/src/effect/effect-player-resist-hurt.c
@@ -367,7 +367,7 @@ void effect_player_lite(player_type *target_ptr, effect_player_type *ep_ptr)
 
     target_ptr->redraw |= (PR_MAP | PR_STATUS);
     target_ptr->update |= (PU_MONSTERS);
-    target_ptr->window |= (PW_OVERHEAD | PW_DUNGEON);
+    target_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
 }
 
 void effect_player_dark(player_type *target_ptr, effect_player_type *ep_ptr)

--- a/src/effect/effect-player-spirit.c
+++ b/src/effect/effect-player-spirit.c
@@ -38,7 +38,7 @@ void effect_player_drain_mana(player_type *target_ptr, effect_player_type *ep_pt
 
     learn_spell(target_ptr, ep_ptr->monspell);
     target_ptr->redraw |= (PR_MANA);
-    target_ptr->window |= (PW_PLAYER | PW_SPELL);
+    target_ptr->window_flags |= (PW_PLAYER | PW_SPELL);
 
     if ((ep_ptr->who <= 0) || (ep_ptr->m_ptr->hp >= ep_ptr->m_ptr->maxhp)) {
         ep_ptr->dam = 0;

--- a/src/effect/effect-processor.c
+++ b/src/effect/effect-processor.c
@@ -9,6 +9,7 @@
 #include "floor/cave.h"
 #include "floor/line-of-sight.h"
 #include "game-option/special-options.h"
+#include "game-option/map-screen-options.h"
 #include "grid/feature-flag-types.h"
 #include "io/cursor.h"
 #include "io/screen-util.h"
@@ -542,7 +543,7 @@ bool project(player_type *caster_ptr, const MONSTER_IDX who, POSITION rad, POSIT
             }
 
             move_cursor_relative(by, bx);
-            if (need_term_fresh(caster_ptr))
+            if (fresh_after)
                 term_fresh();
         }
     }

--- a/src/floor/floor-events.c
+++ b/src/floor/floor-events.c
@@ -58,7 +58,7 @@ void day_break(player_type *subject_ptr)
 
     subject_ptr->update |= PU_MONSTERS | PU_MON_LITE;
     subject_ptr->redraw |= PR_MAP;
-    subject_ptr->window |= PW_OVERHEAD | PW_DUNGEON;
+    subject_ptr->window_flags |= PW_OVERHEAD | PW_DUNGEON;
     if (((subject_ptr->special_defense & NINJA_S_STEALTH) != 0) && ((floor_ptr->grid_array[subject_ptr->y][subject_ptr->x].info & CAVE_GLOW) != 0))
         set_superstealth(subject_ptr, FALSE);
 }
@@ -88,7 +88,7 @@ void night_falls(player_type *subject_ptr)
 
     subject_ptr->update |= PU_MONSTERS | PU_MON_LITE;
     subject_ptr->redraw |= PR_MAP;
-    subject_ptr->window |= PW_OVERHEAD | PW_DUNGEON;
+    subject_ptr->window_flags |= PW_OVERHEAD | PW_DUNGEON;
 
     if (((subject_ptr->special_defense & NINJA_S_STEALTH) != 0) && ((floor_ptr->grid_array[subject_ptr->y][subject_ptr->x].info & CAVE_GLOW) != 0))
         set_superstealth(subject_ptr, FALSE);

--- a/src/grid/grid.c
+++ b/src/grid/grid.c
@@ -569,7 +569,7 @@ void lite_spot(player_type *player_ptr, POSITION y, POSITION x)
         term_queue_bigchar(panel_col_of(x), y - panel_row_prt, a, c, ta, tc);
 
         /* Update sub-windows */
-        player_ptr->window |= (PW_OVERHEAD | PW_DUNGEON);
+        player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
     }
 }
 

--- a/src/inventory/floor-item-getter.c
+++ b/src/inventory/floor-item-getter.c
@@ -306,7 +306,7 @@ bool get_item_floor(player_type *owner_ptr, COMMAND_CODE *cp, concptr pmt, concp
             fis_ptr->toggle = !fis_ptr->toggle;
         }
 
-        owner_ptr->window |= (PW_INVEN | PW_EQUIP);
+        owner_ptr->window_flags |= (PW_INVEN | PW_EQUIP);
         handle_stuff(owner_ptr);
         COMMAND_CODE get_item_label = 0;
         if (command_wrk == USE_INVEN) {
@@ -842,7 +842,7 @@ bool get_item_floor(player_type *owner_ptr, COMMAND_CODE *cp, concptr pmt, concp
     if (fis_ptr->toggle)
         toggle_inventory_equipment(owner_ptr);
 
-    owner_ptr->window |= (PW_INVEN | PW_EQUIP);
+    owner_ptr->window_flags |= (PW_INVEN | PW_EQUIP);
     handle_stuff(owner_ptr);
     prt("", 0, 0);
     if (fis_ptr->oops && str)

--- a/src/inventory/inventory-object.c
+++ b/src/inventory/inventory-object.c
@@ -55,7 +55,7 @@ void inven_item_increase(player_type *owner_ptr, INVENTORY_IDX item, ITEM_NUMBER
     owner_ptr->update |= (PU_BONUS);
     owner_ptr->update |= (PU_MANA);
     owner_ptr->update |= (PU_COMBINE);
-    owner_ptr->window |= (PW_INVEN | PW_EQUIP);
+    owner_ptr->window_flags |= (PW_INVEN | PW_EQUIP);
 
     if (o_ptr->number || !owner_ptr->ele_attack)
         return;
@@ -89,8 +89,8 @@ void inven_item_optimize(player_type *owner_ptr, INVENTORY_IDX item)
         owner_ptr->update |= PU_TORCH;
         owner_ptr->update |= PU_MANA;
 
-        owner_ptr->window |= PW_EQUIP;
-        owner_ptr->window |= PW_SPELL;
+        owner_ptr->window_flags |= PW_EQUIP;
+        owner_ptr->window_flags |= PW_SPELL;
         return;
     }
 
@@ -101,8 +101,8 @@ void inven_item_optimize(player_type *owner_ptr, INVENTORY_IDX item)
     }
 
     object_wipe(&owner_ptr->inventory_list[i]);
-    owner_ptr->window |= PW_INVEN;
-    owner_ptr->window |= PW_SPELL;
+    owner_ptr->window_flags |= PW_INVEN;
+    owner_ptr->window_flags |= PW_SPELL;
 }
 
 /*!
@@ -206,7 +206,7 @@ void combine_pack(player_type *owner_ptr)
                     }
                 }
 
-                owner_ptr->window |= (PW_INVEN);
+                owner_ptr->window_flags |= (PW_INVEN);
                 combined = TRUE;
                 break;
             }
@@ -259,7 +259,7 @@ void reorder_pack(player_type *owner_ptr)
         }
 
         object_copy(&owner_ptr->inventory_list[j], q_ptr);
-        owner_ptr->window |= (PW_INVEN);
+        owner_ptr->window_flags |= (PW_INVEN);
     }
 
     if (flag)
@@ -302,7 +302,7 @@ s16b store_item_to_inventory(player_type *owner_ptr, object_type *o_ptr)
             object_absorb(j_ptr, o_ptr);
 
             owner_ptr->update |= (PU_BONUS);
-            owner_ptr->window |= (PW_INVEN);
+            owner_ptr->window_flags |= (PW_INVEN);
             return (j);
         }
     }
@@ -341,7 +341,7 @@ s16b store_item_to_inventory(player_type *owner_ptr, object_type *o_ptr)
 
     owner_ptr->inven_cnt++;
     owner_ptr->update |= (PU_BONUS | PU_COMBINE | PU_REORDER);
-    owner_ptr->window |= (PW_INVEN);
+    owner_ptr->window_flags |= (PW_INVEN);
 
     return i;
 }

--- a/src/inventory/item-getter.c
+++ b/src/inventory/item-getter.c
@@ -295,7 +295,7 @@ bool get_item(player_type *owner_ptr, OBJECT_IDX *cp, concptr pmt, concptr str, 
             item_selection_ptr->toggle = !item_selection_ptr->toggle;
         }
 
-        owner_ptr->window |= (PW_INVEN | PW_EQUIP);
+        owner_ptr->window_flags |= (PW_INVEN | PW_EQUIP);
         handle_stuff(owner_ptr);
 
         if (!command_wrk) {
@@ -608,7 +608,7 @@ bool get_item(player_type *owner_ptr, OBJECT_IDX *cp, concptr pmt, concptr str, 
     if (item_selection_ptr->toggle)
         toggle_inventory_equipment(owner_ptr);
 
-    owner_ptr->window |= (PW_INVEN | PW_EQUIP);
+    owner_ptr->window_flags |= (PW_INVEN | PW_EQUIP);
     handle_stuff(owner_ptr);
     prt("", 0, 0);
     if (item_selection_ptr->oops && str)

--- a/src/inventory/player-inventory.c
+++ b/src/inventory/player-inventory.c
@@ -97,7 +97,7 @@ void py_pickup_floor(player_type *owner_ptr, bool pickup)
             msg_format(_(" $%ld の価値がある%sを見つけた。", "You have found %ld gold pieces worth of %s."), (long)o_ptr->pval, o_name);
             owner_ptr->au += o_ptr->pval;
             owner_ptr->redraw |= (PR_GOLD);
-            owner_ptr->window |= (PW_PLAYER);
+            owner_ptr->window_flags |= (PW_PLAYER);
             delete_object_idx(owner_ptr, this_o_idx);
             continue;
         } else if (o_ptr->marked & OM_NOMSG) {
@@ -241,7 +241,7 @@ void carry(player_type *creature_ptr, bool pickup)
     verify_panel(creature_ptr);
     creature_ptr->update |= PU_MONSTERS;
     creature_ptr->redraw |= PR_MAP;
-    creature_ptr->window |= PW_OVERHEAD;
+    creature_ptr->window_flags |= PW_OVERHEAD;
     handle_stuff(creature_ptr);
     grid_type *g_ptr = &creature_ptr->current_floor_ptr->grid_array[creature_ptr->y][creature_ptr->x];
     autopick_pickup_items(creature_ptr, g_ptr);
@@ -265,7 +265,7 @@ void carry(player_type *creature_ptr, bool pickup)
             sound(SOUND_SELL);
             creature_ptr->au += value;
             creature_ptr->redraw |= (PR_GOLD);
-            creature_ptr->window |= (PW_PLAYER);
+            creature_ptr->window_flags |= (PW_PLAYER);
             continue;
         }
 

--- a/src/inventory/recharge-processor.c
+++ b/src/inventory/recharge-processor.c
@@ -70,7 +70,7 @@ void recharge_magic_items(player_type *creature_ptr)
     }
 
     if (changed) {
-        creature_ptr->window |= (PW_EQUIP);
+        creature_ptr->window_flags |= (PW_EQUIP);
         wild_regen = 20;
     }
 
@@ -104,7 +104,7 @@ void recharge_magic_items(player_type *creature_ptr)
     }
 
     if (changed) {
-        creature_ptr->window |= (PW_INVEN);
+        creature_ptr->window_flags |= (PW_INVEN);
         wild_regen = 20;
     }
 

--- a/src/io/input-key-acceptor.c
+++ b/src/io/input-key-acceptor.c
@@ -1,7 +1,8 @@
 ﻿#include "io/input-key-acceptor.h"
 #include "cmd-io/macro-util.h"
-#include "game-option/map-screen-options.h"
+#include "core/window-redrawer.h"
 #include "game-option/input-options.h"
+#include "game-option/map-screen-options.h"
 #include "io/signal-handlers.h"
 #include "term/gameterm.h"
 #include "util/string-processor.h"
@@ -201,6 +202,7 @@ char inkey(void)
         }
 
         if (!done && (0 != term_inkey(&kk, FALSE, FALSE))) {
+            start_term_fresh();
             term_activate(old);
             term_fresh();
             term_activate(angband_term[0]);
@@ -394,4 +396,20 @@ int inkey_special(bool numpad_cursor)
 
     inkey_macro_trigger_string[0] = '\0';
     return (int)((unsigned char)key);
+}
+
+void stop_term_fresh(void)
+{
+    for (int j = 0; j < 8; j++) {
+        if (angband_term[j])
+            angband_term[j]->never_fresh = TRUE;
+    }
+}
+
+void start_term_fresh(void)
+{
+    for (int j = 0; j < 8; j++) {
+        if (angband_term[j])
+            angband_term[j]->never_fresh = FALSE;
+    }
 }

--- a/src/io/input-key-acceptor.h
+++ b/src/io/input-key-acceptor.h
@@ -29,3 +29,5 @@ extern concptr inkey_next;
 
 char inkey(void);
 int inkey_special(bool numpad_cursor);
+void start_term_fresh(void);
+void stop_term_fresh(void);

--- a/src/io/input-key-requester.c
+++ b/src/io/input-key-requester.c
@@ -2,8 +2,10 @@
 #include "cmd-io/cmd-menu-content-table.h"
 #include "cmd-io/macro-util.h"
 #include "core/asking-player.h" // todo 相互依存している、後で何とかする.
+#include "core/player-processor.h"
 #include "game-option/game-play-options.h"
 #include "game-option/input-options.h"
+#include "game-option/map-screen-options.h"
 #include "inventory/inventory-slot-types.h"
 #include "io/cursor.h"
 #include "io/input-key-acceptor.h"
@@ -16,6 +18,7 @@
 #include "util/quarks.h"
 #include "util/string-processor.h"
 #include "view/display-messages.h"
+#include "window/display-sub-windows.h"
 #include "window/main-window-util.h"
 #include "world/world.h"
 
@@ -206,6 +209,11 @@ void request_command(player_type *player_ptr, int shopping)
         if (!macro_running() && !command_new && auto_debug_save) {
             save_player(player_ptr, SAVE_TYPE_DEBUG);
         }
+        if (macro_running() && !fresh_after) {
+            stop_term_fresh();
+        } else {
+            fix_monster_list(player_ptr, TRUE);
+        }
 
         if (command_new) {
             msg_erase();
@@ -215,9 +223,7 @@ void request_command(player_type *player_ptr, int shopping)
             msg_flag = FALSE;
             num_more = 0;
             inkey_flag = TRUE;
-            if (need_term_fresh(player_ptr)) {
-                term_fresh();
-            }
+            term_fresh();
             cmd = inkey();
             if (!shopping && command_menu && ((cmd == '\r') || (cmd == '\n') || (cmd == 'x') || (cmd == 'X')) && !keymap_act[mode][(byte)(cmd)])
                 cmd = inkey_from_menu(player_ptr);

--- a/src/lore/lore-store.c
+++ b/src/lore/lore-store.c
@@ -86,7 +86,7 @@ int lore_do_probe(player_type *player_ptr, MONRACE_IDX r_idx)
     r_ptr->r_xtra1 |= MR1_EVOLUTION;
 
     if (player_ptr->monster_race_idx == r_idx) {
-        player_ptr->window |= (PW_MONSTER);
+        player_ptr->window_flags |= (PW_MONSTER);
     }
 
     return n;
@@ -118,5 +118,5 @@ void lore_treasure(player_type *player_ptr, MONSTER_IDX m_idx, ITEM_NUMBER num_i
     if (r_ptr->flags1 & (RF1_DROP_GREAT))
         r_ptr->r_flags1 |= (RF1_DROP_GREAT);
     if (player_ptr->monster_race_idx == m_ptr->r_idx)
-        player_ptr->window |= (PW_MONSTER);
+        player_ptr->window_flags |= (PW_MONSTER);
 }

--- a/src/main-win.c
+++ b/src/main-win.c
@@ -3222,7 +3222,7 @@ LRESULT PASCAL AngbandListProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPara
             term_resize(td->cols, td->rows);
             term_activate(old_term);
             InvalidateRect(td->w, NULL, TRUE);
-            p_ptr->window = 0xFFFFFFFF;
+            p_ptr->window_flags = 0xFFFFFFFF;
             handle_stuff(p_ptr);
         }
 

--- a/src/market/arena.c
+++ b/src/market/arena.c
@@ -131,7 +131,7 @@ static void see_arena_poster(player_type *player_ptr)
     msg_format(_("%s に挑戦するものはいないか？", "Do I hear any challenges against: %s"), name);
 
     player_ptr->monster_race_idx = arena_info[player_ptr->arena_number].r_idx;
-    player_ptr->window |= (PW_MONSTER);
+    player_ptr->window_flags |= (PW_MONSTER);
     handle_stuff(player_ptr);
 }
 

--- a/src/market/building-recharger.c
+++ b/src/market/building-recharger.c
@@ -158,7 +158,7 @@ void building_recharge(player_type *player_ptr)
     msg_format("%^s %s recharged for %d gold.", tmp_str, ((o_ptr->number > 1) ? "were" : "was"), price);
 #endif
     player_ptr->update |= (PU_COMBINE | PU_REORDER);
-    player_ptr->window |= (PW_INVEN);
+    player_ptr->window_flags |= (PW_INVEN);
     player_ptr->au -= price;
 }
 
@@ -268,6 +268,6 @@ void building_recharge_all(player_type *player_ptr)
     msg_format(_("＄%d で再充填しました。", "You pay %d gold."), total_cost);
     msg_print(NULL);
     player_ptr->update |= (PU_COMBINE | PU_REORDER);
-    player_ptr->window |= (PW_INVEN);
+    player_ptr->window_flags |= (PW_INVEN);
     player_ptr->au -= total_cost;
 }

--- a/src/mind/mind-blue-mage.c
+++ b/src/mind/mind-blue-mage.c
@@ -110,6 +110,6 @@ bool do_cmd_cast_learned(player_type *caster_ptr)
 
     take_turn(caster_ptr, 100);
     caster_ptr->redraw |= PR_MANA;
-    caster_ptr->window |= PW_PLAYER | PW_SPELL;
+    caster_ptr->window_flags |= PW_PLAYER | PW_SPELL;
     return TRUE;
 }

--- a/src/mind/mind-mindcrafter.c
+++ b/src/mind/mind-mindcrafter.c
@@ -84,7 +84,7 @@ bool psychometry(player_type *caster_ptr)
     o_ptr->marked |= OM_TOUCHED;
 
     caster_ptr->update |= (PU_COMBINE | PU_REORDER);
-    caster_ptr->window |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
+    caster_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
 
     bool okay = FALSE;
     switch (o_ptr->tval) {

--- a/src/mind/mind-mirror-master.c
+++ b/src/mind/mind-mirror-master.c
@@ -12,6 +12,7 @@
 #include "effect/spells-effect-util.h"
 #include "floor/cave.h"
 #include "game-option/disturbance-options.h"
+#include "game-option/map-screen-options.h"
 #include "game-option/special-options.h"
 #include "grid/feature.h"
 #include "io/cursor.h"
@@ -168,7 +169,7 @@ bool binding_field(player_type *caster_ptr, HIT_POINT dam)
                         u16b p = bolt_pict(y, x, y, x, GF_MANA);
                         print_rel(caster_ptr, PICT_C(p), PICT_A(p), y, x);
                         move_cursor_relative(y, x);
-                        if (need_term_fresh(caster_ptr)) {
+                        if (fresh_after) {
                             term_fresh();
                             term_xtra(TERM_XTRA_DELAY, msec);
                         }

--- a/src/mind/mind-power-getter.c
+++ b/src/mind/mind-power-getter.c
@@ -281,7 +281,7 @@ bool get_mind_power(player_type *caster_ptr, SPELL_IDX *sn, bool only_browse)
     if (redraw && !only_browse)
         screen_load();
 
-    caster_ptr->window |= PW_SPELL;
+    caster_ptr->window_flags |= PW_SPELL;
     handle_stuff(caster_ptr);
     if (!flag)
         return FALSE;

--- a/src/mind/mind-priest.c
+++ b/src/mind/mind-priest.c
@@ -62,7 +62,7 @@ bool bless_weapon(player_type *caster_ptr)
         o_ptr->ident |= IDENT_SENSE;
         o_ptr->feeling = FEEL_NONE;
         caster_ptr->update |= PU_BONUS;
-        caster_ptr->window |= PW_EQUIP;
+        caster_ptr->window_flags |= PW_EQUIP;
     }
 
     /*
@@ -133,7 +133,7 @@ bool bless_weapon(player_type *caster_ptr)
     }
 
     caster_ptr->update |= PU_BONUS;
-    caster_ptr->window |= PW_EQUIP | PW_PLAYER;
+    caster_ptr->window_flags |= PW_EQUIP | PW_PLAYER;
     calc_android_exp(caster_ptr);
     return TRUE;
 }

--- a/src/mind/mind-sniper.c
+++ b/src/mind/mind-sniper.c
@@ -384,7 +384,7 @@ static int get_snipe_power(player_type *sniper_ptr, COMMAND_CODE *sn, bool only_
 	}
 	if (redraw && !only_browse) screen_load();
 
-	sniper_ptr->window |= (PW_SPELL);
+	sniper_ptr->window_flags |= (PW_SPELL);
 	handle_stuff(sniper_ptr);
 
 	/* Abort if needed */
@@ -568,8 +568,8 @@ void do_cmd_snipe(player_type *sniper_ptr)
 
 	if (!cast) return;
 	sniper_ptr->redraw |= (PR_HP | PR_MANA);
-	sniper_ptr->window |= (PW_PLAYER);
-	sniper_ptr->window |= (PW_SPELL);
+	sniper_ptr->window_flags |= (PW_PLAYER);
+	sniper_ptr->window_flags |= (PW_SPELL);
 }
 
 /*!

--- a/src/monster-attack/monster-eating.c
+++ b/src/monster-attack/monster-eating.c
@@ -62,7 +62,7 @@ void process_eat_gold(player_type *target_ptr, monap_type *monap_ptr)
     }
 
     target_ptr->redraw |= (PR_GOLD);
-    target_ptr->window |= (PW_PLAYER);
+    target_ptr->window_flags |= (PW_PLAYER);
     monap_ptr->blinked = TRUE;
 }
 
@@ -190,7 +190,7 @@ void process_eat_lite(player_type *target_ptr, monap_type *monap_ptr)
         monap_ptr->obvious = TRUE;
     }
 
-    target_ptr->window |= (PW_EQUIP);
+    target_ptr->window_flags |= (PW_EQUIP);
 }
 
 /*!
@@ -233,7 +233,7 @@ bool process_un_power(player_type *target_ptr, monap_type *monap_ptr)
 
     monap_ptr->o_ptr->pval = !is_magic_mastery || (monap_ptr->o_ptr->pval == 1) ? 0 : monap_ptr->o_ptr->pval - drain;
     target_ptr->update |= PU_COMBINE | PU_REORDER;
-    target_ptr->window |= PW_INVEN;
+    target_ptr->window_flags |= PW_INVEN;
     return TRUE;
 }
 

--- a/src/monster-floor/monster-move.c
+++ b/src/monster-floor/monster-move.c
@@ -185,7 +185,7 @@ static bool process_door(player_type *target_ptr, turn_flags *turn_flags_ptr, mo
         cave_alter_feat(target_ptr, ny, nx, FF_BASH);
         if (!monster_is_valid(m_ptr)) {
             target_ptr->update |= (PU_FLOW);
-            target_ptr->window |= (PW_OVERHEAD | PW_DUNGEON);
+            target_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
             if (is_original_ap_and_seen(target_ptr, m_ptr))
                 r_ptr->r_flags2 |= (RF2_BASH_DOOR);
 
@@ -308,7 +308,7 @@ static bool process_post_dig_wall(player_type *target_ptr, turn_flags *turn_flag
 
     if (!monster_is_valid(m_ptr)) {
         target_ptr->update |= (PU_FLOW);
-        target_ptr->window |= (PW_OVERHEAD | PW_DUNGEON);
+        target_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
         if (is_original_ap_and_seen(target_ptr, m_ptr))
             r_ptr->r_flags2 |= (RF2_KILL_WALL);
 

--- a/src/monster/monster-status-setter.c
+++ b/src/monster/monster-status-setter.c
@@ -390,7 +390,7 @@ bool set_monster_timewalk(player_type *target_ptr, int num, MONSTER_IDX who, boo
 
     target_ptr->redraw |= PR_MAP;
     target_ptr->update |= PU_MONSTERS;
-    target_ptr->window |= PW_OVERHEAD | PW_DUNGEON;
+    target_ptr->window_flags |= PW_OVERHEAD | PW_DUNGEON;
     current_world_ptr->timewalk_m_idx = 0;
     if (vs_player || (player_has_los_bold(target_ptr, m_ptr->fy, m_ptr->fx) && projectable(target_ptr, target_ptr->y, target_ptr->x, m_ptr->fy, m_ptr->fx))) {
         msg_print(_("「時は動きだす…」", "You feel time flowing around you once more."));

--- a/src/monster/monster-update.c
+++ b/src/monster/monster-update.c
@@ -93,7 +93,7 @@ void update_player_type(player_type *target_ptr, turn_flags *turn_flags_ptr, mon
 {
     if (turn_flags_ptr->do_view) {
         target_ptr->update |= PU_FLOW;
-        target_ptr->window |= PW_OVERHEAD | PW_DUNGEON;
+        target_ptr->window_flags |= PW_OVERHEAD | PW_DUNGEON;
     }
 
     if (turn_flags_ptr->do_move
@@ -155,7 +155,7 @@ void update_player_window(player_type *target_ptr, old_race_flags *old_race_flag
         || (old_race_flags_ptr->old_r_flagsr != r_ptr->r_flagsr) || (old_race_flags_ptr->old_r_blows0 != r_ptr->r_blows[0])
         || (old_race_flags_ptr->old_r_blows1 != r_ptr->r_blows[1]) || (old_race_flags_ptr->old_r_blows2 != r_ptr->r_blows[2])
         || (old_race_flags_ptr->old_r_blows3 != r_ptr->r_blows[3]) || (old_race_flags_ptr->old_r_cast_spell != r_ptr->r_cast_spell)) {
-        target_ptr->window |= PW_MONSTER;
+        target_ptr->window_flags |= PW_MONSTER;
     }
 }
 

--- a/src/mspell/mspell-dispel.c
+++ b/src/mspell/mspell-dispel.c
@@ -93,7 +93,7 @@ static void dispel_player(player_type *creature_ptr)
         creature_ptr->action = ACTION_NONE;
         creature_ptr->update |= (PU_BONUS | PU_HP | PU_MONSTERS);
         creature_ptr->redraw |= (PR_MAP | PR_STATUS | PR_STATE);
-        creature_ptr->window |= (PW_OVERHEAD | PW_DUNGEON);
+        creature_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
         creature_ptr->energy_need += ENERGY_NEED();
     }
 }

--- a/src/object-hook/hook-expendable.c
+++ b/src/object-hook/hook-expendable.c
@@ -126,7 +126,7 @@ bool can_player_destroy_object(player_type *player_ptr, object_type *o_ptr)
         o_ptr->feeling = feel;
         o_ptr->ident |= IDENT_SENSE;
         player_ptr->update |= (PU_COMBINE);
-        player_ptr->window |= (PW_INVEN | PW_EQUIP);
+        player_ptr->window_flags |= (PW_INVEN | PW_EQUIP);
         return FALSE;
     }
 

--- a/src/object-use/quaff-execution.c
+++ b/src/object-use/quaff-execution.c
@@ -576,7 +576,7 @@ void exe_quaff_potion(player_type *creature_ptr, INVENTORY_IDX item)
         gain_exp(creature_ptr, (lev + (creature_ptr->lev >> 1)) / creature_ptr->lev);
     }
 
-    creature_ptr->window |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
+    creature_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
 
     /* Potions can feed the player */
     switch (creature_ptr->mimic_form) {

--- a/src/object-use/read-execution.c
+++ b/src/object-use/read-execution.c
@@ -510,7 +510,7 @@ void exe_read(player_type *creature_ptr, INVENTORY_IDX item, bool known)
         gain_exp(creature_ptr, (lev + (creature_ptr->lev >> 1)) / creature_ptr->lev);
     }
 
-    creature_ptr->window |= PW_INVEN | PW_EQUIP | PW_PLAYER;
+    creature_ptr->window_flags |= PW_INVEN | PW_EQUIP | PW_PLAYER;
     creature_ptr->update |= inventory_flags;
     if (!used_up)
         return;

--- a/src/object/lite-processor.c
+++ b/src/object/lite-processor.c
@@ -42,7 +42,7 @@ void reduce_lite_life(player_type* creature_ptr)
 void notice_lite_change(player_type* creature_ptr, object_type* o_ptr)
 {
     if ((o_ptr->xtra4 < 100) || (!(o_ptr->xtra4 % 100))) {
-        creature_ptr->window |= (PW_EQUIP);
+        creature_ptr->window_flags |= (PW_EQUIP);
     }
 
     if (creature_ptr->blind) {

--- a/src/perception/simple-perception.c
+++ b/src/perception/simple-perception.c
@@ -110,7 +110,7 @@ static void sense_inventory_aux(player_type *creature_ptr, INVENTORY_IDX slot, b
 
     autopick_alter_item(creature_ptr, slot, destroy_feeling);
     creature_ptr->update |= (PU_COMBINE | PU_REORDER);
-    creature_ptr->window |= (PW_INVEN | PW_EQUIP);
+    creature_ptr->window_flags |= (PW_INVEN | PW_EQUIP);
 }
 
 /*!

--- a/src/pet/pet-fall-off.c
+++ b/src/pet/pet-fall-off.c
@@ -158,7 +158,7 @@ bool process_fall_off_horse(player_type *creature_ptr, HIT_POINT dam, bool force
     creature_ptr->update |= (PU_BONUS | PU_VIEW | PU_LITE | PU_FLOW | PU_MON_LITE | PU_MONSTERS);
     handle_stuff(creature_ptr);
 
-    creature_ptr->window |= (PW_OVERHEAD | PW_DUNGEON);
+    creature_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
     creature_ptr->redraw |= (PR_EXTRA);
 
     /* Update health track of mount */

--- a/src/player/player-damage.c
+++ b/src/player/player-damage.c
@@ -119,7 +119,7 @@ static bool acid_minus_ac(player_type *creature_ptr)
     msg_format(_("%sが酸で腐食した！", "Your %s is corroded!"), o_name);
     o_ptr->to_a--;
     creature_ptr->update |= PU_BONUS;
-    creature_ptr->window |= PW_EQUIP | PW_PLAYER;
+    creature_ptr->window_flags |= PW_EQUIP | PW_PLAYER;
     calc_android_exp(creature_ptr);
     return TRUE;
 }
@@ -342,7 +342,7 @@ int take_hit(player_type *creature_ptr, int damage_type, HIT_POINT damage, concp
     }
 
     creature_ptr->redraw |= PR_HP;
-    creature_ptr->window |= PW_PLAYER;
+    creature_ptr->window_flags |= PW_PLAYER;
 
     if (damage_type != DAMAGE_GENO && creature_ptr->chp == 0) {
         chg_virtue(creature_ptr, V_SACRIFICE, 1);

--- a/src/player/player-move.c
+++ b/src/player/player-move.c
@@ -157,7 +157,7 @@ bool move_player_effect(player_type *creature_ptr, POSITION ny, POSITION nx, BIT
         }
 
         creature_ptr->update |= PU_VIEW | PU_LITE | PU_FLOW | PU_MON_LITE | PU_DISTANCE;
-        creature_ptr->window |= PW_OVERHEAD | PW_DUNGEON;
+        creature_ptr->window_flags |= PW_OVERHEAD | PW_DUNGEON;
         if ((!creature_ptr->blind && !no_lite(creature_ptr)) || !is_trap(creature_ptr, g_ptr->feat))
             g_ptr->info &= ~(CAVE_UNSAFE);
 

--- a/src/player/player-status.c
+++ b/src/player/player-status.c
@@ -451,7 +451,7 @@ void calc_bonuses(player_type *creature_ptr)
     creature_ptr->dis_to_a = calc_to_ac(creature_ptr, FALSE);
 
     if (old_mighty_throw != creature_ptr->mighty_throw) {
-        creature_ptr->window |= PW_INVEN;
+        creature_ptr->window_flags |= PW_INVEN;
     }
 
     if (creature_ptr->telepathy != old_telepathy) {
@@ -475,7 +475,7 @@ void calc_bonuses(player_type *creature_ptr)
 
     if ((creature_ptr->dis_ac != old_dis_ac) || (creature_ptr->dis_to_a != old_dis_to_a)) {
         creature_ptr->redraw |= (PR_ARMOR);
-        creature_ptr->window |= (PW_PLAYER);
+        creature_ptr->window_flags |= (PW_PLAYER);
     }
 
     if (current_world_ptr->character_xtra)
@@ -632,7 +632,7 @@ static void calc_hitpoints(player_type *creature_ptr)
     creature_ptr->mhp = mhp;
 
     creature_ptr->redraw |= PR_HP;
-    creature_ptr->window |= PW_PLAYER;
+    creature_ptr->window_flags |= PW_PLAYER;
 }
 
 /*!
@@ -880,7 +880,7 @@ static void calc_spells(player_type *creature_ptr)
 
     creature_ptr->old_spells = creature_ptr->new_spells;
     creature_ptr->redraw |= PR_STUDY;
-    creature_ptr->window |= PW_OBJECT;
+    creature_ptr->window_flags |= PW_OBJECT;
 }
 
 /*!
@@ -1072,7 +1072,7 @@ static void calc_mana(player_type *creature_ptr)
 #endif
         creature_ptr->msp = msp;
         creature_ptr->redraw |= (PR_MANA);
-        creature_ptr->window |= (PW_PLAYER | PW_SPELL);
+        creature_ptr->window_flags |= (PW_PLAYER | PW_SPELL);
     }
 
     if (current_world_ptr->character_xtra)
@@ -2729,7 +2729,7 @@ static void calc_ind_status(player_type *creature_ptr, int status)
         }
     }
 
-    creature_ptr->window |= (PW_PLAYER);
+    creature_ptr->window_flags |= (PW_PLAYER);
 }
 
 static void calc_use_status(player_type *creature_ptr, int status)
@@ -2746,7 +2746,7 @@ static void calc_use_status(player_type *creature_ptr, int status)
     if (creature_ptr->stat_use[status] != use) {
         creature_ptr->stat_use[status] = (s16b)use;
         creature_ptr->redraw |= (PR_STATS);
-        creature_ptr->window |= (PW_PLAYER);
+        creature_ptr->window_flags |= (PW_PLAYER);
     }
 }
 
@@ -2757,7 +2757,7 @@ static void calc_top_status(player_type *creature_ptr, int status)
     if (creature_ptr->stat_top[status] != top) {
         creature_ptr->stat_top[status] = (s16b)top;
         creature_ptr->redraw |= (PR_STATS);
-        creature_ptr->window |= (PW_PLAYER);
+        creature_ptr->window_flags |= (PW_PLAYER);
     }
 }
 
@@ -3726,7 +3726,7 @@ void check_experience(player_type *creature_ptr)
         creature_ptr->lev--;
         creature_ptr->update |= (PU_BONUS | PU_HP | PU_MANA | PU_SPELLS);
         creature_ptr->redraw |= (PR_LEV | PR_TITLE);
-        creature_ptr->window |= (PW_PLAYER);
+        creature_ptr->window_flags |= (PW_PLAYER);
         handle_stuff(creature_ptr);
     }
 
@@ -3755,7 +3755,7 @@ void check_experience(player_type *creature_ptr)
         msg_format(_("レベル %d にようこそ。", "Welcome to level %d."), creature_ptr->lev);
         creature_ptr->update |= (PU_BONUS | PU_HP | PU_MANA | PU_SPELLS);
         creature_ptr->redraw |= (PR_LEV | PR_TITLE | PR_EXP);
-        creature_ptr->window |= (PW_PLAYER | PW_SPELL | PW_INVEN);
+        creature_ptr->window_flags |= (PW_PLAYER | PW_SPELL | PW_INVEN);
         creature_ptr->level_up_message = TRUE;
         handle_stuff(creature_ptr);
 
@@ -3818,7 +3818,7 @@ void check_experience(player_type *creature_ptr)
 
         creature_ptr->update |= (PU_BONUS | PU_HP | PU_MANA | PU_SPELLS);
         creature_ptr->redraw |= (PR_LEV | PR_TITLE);
-        creature_ptr->window |= (PW_PLAYER | PW_SPELL);
+        creature_ptr->window_flags |= (PW_PLAYER | PW_SPELL);
         handle_stuff(creature_ptr);
     }
 

--- a/src/player/player-status.h
+++ b/src/player/player-status.h
@@ -346,7 +346,7 @@ typedef struct player_type {
 
     BIT_FLAGS update; /* Pending Updates */
     BIT_FLAGS redraw; /* Normal Redraws */
-    BIT_FLAGS window; /* Window Redraws */
+    BIT_FLAGS window_flags; /* Window Redraws */
     s16b stat_use[A_MAX]; /* Current modified stats */
     s16b stat_top[A_MAX]; /* Maximal modified stats */
 

--- a/src/realm/realm-song.c
+++ b/src/realm/realm-song.c
@@ -976,7 +976,7 @@ concptr do_music_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             caster_ptr->redraw |= (PR_MAP);
             caster_ptr->update |= (PU_MONSTERS);
-            caster_ptr->window |= (PW_OVERHEAD | PW_DUNGEON);
+            caster_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
 
             start_singing(caster_ptr, spell, MUSIC_INVULN);
         }
@@ -987,7 +987,7 @@ concptr do_music_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
                 caster_ptr->redraw |= (PR_MAP);
                 caster_ptr->update |= (PU_MONSTERS);
-                caster_ptr->window |= (PW_OVERHEAD | PW_DUNGEON);
+                caster_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
             }
         }
 

--- a/src/spell-kind/earthquake.c
+++ b/src/spell-kind/earthquake.c
@@ -339,7 +339,7 @@ bool earthquake(player_type *caster_ptr, POSITION cy, POSITION cx, POSITION r, M
 
     caster_ptr->update |= (PU_UN_VIEW | PU_UN_LITE | PU_VIEW | PU_LITE | PU_FLOW | PU_MON_LITE | PU_MONSTERS);
     caster_ptr->redraw |= (PR_HEALTH | PR_UHEALTH | PR_MAP);
-    caster_ptr->window |= (PW_OVERHEAD | PW_DUNGEON);
+    caster_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
     if (caster_ptr->special_defense & NINJA_S_STEALTH) {
         if (floor_ptr->grid_array[caster_ptr->y][caster_ptr->x].info & CAVE_GLOW)
             set_superstealth(caster_ptr, FALSE);

--- a/src/spell-kind/spells-curse-removal.c
+++ b/src/spell-kind/spells-curse-removal.c
@@ -37,7 +37,7 @@ static int exe_curse_removal(player_type *creature_ptr, int all)
         o_ptr->feeling = FEEL_NONE;
 
         creature_ptr->update |= (PU_BONUS);
-        creature_ptr->window |= (PW_EQUIP);
+        creature_ptr->window_flags |= (PW_EQUIP);
         cnt++;
     }
 

--- a/src/spell-kind/spells-detection.c
+++ b/src/spell-kind/spells-detection.c
@@ -365,7 +365,7 @@ bool detect_monsters_invis(player_type *caster_ptr, POSITION range)
 
         if (r_ptr->flags2 & RF2_INVISIBLE) {
             if (caster_ptr->monster_race_idx == m_ptr->r_idx) {
-                caster_ptr->window |= (PW_MONSTER);
+                caster_ptr->window_flags |= (PW_MONSTER);
             }
 
             repair_monsters = TRUE;
@@ -412,7 +412,7 @@ bool detect_monsters_evil(player_type *caster_ptr, POSITION range)
             if (is_original_ap(m_ptr)) {
                 r_ptr->r_flags3 |= (RF3_EVIL);
                 if (caster_ptr->monster_race_idx == m_ptr->r_idx) {
-                    caster_ptr->window |= (PW_MONSTER);
+                    caster_ptr->window_flags |= (PW_MONSTER);
                 }
             }
 
@@ -454,7 +454,7 @@ bool detect_monsters_nonliving(player_type *caster_ptr, POSITION range)
 
         if (!monster_living(m_ptr->r_idx)) {
             if (caster_ptr->monster_race_idx == m_ptr->r_idx) {
-                caster_ptr->window |= (PW_MONSTER);
+                caster_ptr->window_flags |= (PW_MONSTER);
             }
 
             repair_monsters = TRUE;
@@ -497,7 +497,7 @@ bool detect_monsters_mind(player_type *caster_ptr, POSITION range)
 
         if (!(r_ptr->flags2 & RF2_EMPTY_MIND)) {
             if (caster_ptr->monster_race_idx == m_ptr->r_idx) {
-                caster_ptr->window |= (PW_MONSTER);
+                caster_ptr->window_flags |= (PW_MONSTER);
             }
 
             repair_monsters = TRUE;
@@ -541,7 +541,7 @@ bool detect_monsters_string(player_type *caster_ptr, POSITION range, concptr Mat
 
         if (angband_strchr(Match, r_ptr->d_char)) {
             if (caster_ptr->monster_race_idx == m_ptr->r_idx) {
-                caster_ptr->window |= (PW_MONSTER);
+                caster_ptr->window_flags |= (PW_MONSTER);
             }
 
             repair_monsters = TRUE;
@@ -589,7 +589,7 @@ bool detect_monsters_xxx(player_type *caster_ptr, POSITION range, u32b match_fla
             if (is_original_ap(m_ptr)) {
                 r_ptr->r_flags3 |= (match_flag);
                 if (caster_ptr->monster_race_idx == m_ptr->r_idx) {
-                    caster_ptr->window |= (PW_MONSTER);
+                    caster_ptr->window_flags |= (PW_MONSTER);
                 }
             }
 

--- a/src/spell-kind/spells-equipment.c
+++ b/src/spell-kind/spells-equipment.c
@@ -111,7 +111,7 @@ bool apply_disenchant(player_type *target_ptr, BIT_FLAGS mode)
     chg_virtue(target_ptr, V_HARMONY, 1);
     chg_virtue(target_ptr, V_ENCHANT, -2);
     target_ptr->update |= (PU_BONUS);
-    target_ptr->window |= (PW_EQUIP | PW_PLAYER);
+    target_ptr->window_flags |= (PW_EQUIP | PW_PLAYER);
 
     calc_android_exp(target_ptr);
     return TRUE;

--- a/src/spell-kind/spells-floor.c
+++ b/src/spell-kind/spells-floor.c
@@ -120,7 +120,7 @@ void wiz_lite(player_type *caster_ptr, bool ninja)
 
     caster_ptr->update |= (PU_MONSTERS);
     caster_ptr->redraw |= (PR_MAP);
-    caster_ptr->window |= (PW_OVERHEAD | PW_DUNGEON);
+    caster_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
 
     if (caster_ptr->special_defense & NINJA_S_STEALTH) {
         if (caster_ptr->current_floor_ptr->grid_array[caster_ptr->y][caster_ptr->x].info & CAVE_GLOW)
@@ -176,7 +176,7 @@ void wiz_dark(player_type *caster_ptr)
     caster_ptr->update |= (PU_VIEW | PU_LITE | PU_MON_LITE);
     caster_ptr->update |= (PU_MONSTERS);
     caster_ptr->redraw |= (PR_MAP);
-    caster_ptr->window |= (PW_OVERHEAD | PW_DUNGEON);
+    caster_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
 }
 
 /*
@@ -232,7 +232,7 @@ void map_area(player_type *caster_ptr, POSITION range)
     }
 
     caster_ptr->redraw |= (PR_MAP);
-    caster_ptr->window |= (PW_OVERHEAD | PW_DUNGEON);
+    caster_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
 }
 
 /*!
@@ -465,7 +465,7 @@ bool destroy_area(player_type *caster_ptr, POSITION y1, POSITION x1, POSITION r,
     /* Mega-Hack -- Forget the view and lite */
     caster_ptr->update |= (PU_UN_VIEW | PU_UN_LITE | PU_VIEW | PU_LITE | PU_FLOW | PU_MON_LITE | PU_MONSTERS);
     caster_ptr->redraw |= (PR_MAP);
-    caster_ptr->window |= (PW_OVERHEAD | PW_DUNGEON);
+    caster_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
 
     if (caster_ptr->special_defense & NINJA_S_STEALTH) {
         if (floor_ptr->grid_array[caster_ptr->y][caster_ptr->x].info & CAVE_GLOW)

--- a/src/spell-kind/spells-genocide.c
+++ b/src/spell-kind/spells-genocide.c
@@ -99,7 +99,7 @@ bool genocide_aux(player_type *caster_ptr, MONSTER_IDX m_idx, int power, bool pl
 
     move_cursor_relative(caster_ptr->y, caster_ptr->x);
     caster_ptr->redraw |= (PR_HP);
-    caster_ptr->window |= (PW_PLAYER);
+    caster_ptr->window_flags |= (PW_PLAYER);
     handle_stuff(caster_ptr);
     if (fresh_after)
         term_fresh();

--- a/src/spell-kind/spells-genocide.c
+++ b/src/spell-kind/spells-genocide.c
@@ -4,6 +4,7 @@
 #include "core/stuff-handler.h"
 #include "core/window-redrawer.h"
 #include "dungeon/quest.h"
+#include "game-option/map-screen-options.h"
 #include "game-option/play-record-options.h"
 #include "game-option/special-options.h"
 #include "grid/grid.h"
@@ -100,7 +101,7 @@ bool genocide_aux(player_type *caster_ptr, MONSTER_IDX m_idx, int power, bool pl
     caster_ptr->redraw |= (PR_HP);
     caster_ptr->window |= (PW_PLAYER);
     handle_stuff(caster_ptr);
-    if (need_term_fresh(caster_ptr))
+    if (fresh_after)
         term_fresh();
 
     int msec = delay_factor * delay_factor * delay_factor;

--- a/src/spell-kind/spells-perception.c
+++ b/src/spell-kind/spells-perception.c
@@ -72,7 +72,7 @@ bool identify_item(player_type *owner_ptr, object_type *o_ptr)
     o_ptr->marked |= OM_TOUCHED;
 
     owner_ptr->update |= (PU_BONUS | PU_COMBINE | PU_REORDER);
-    owner_ptr->window |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
+    owner_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
 
     strcpy(record_o_name, o_name);
     record_turn = current_world_ptr->game_turn;

--- a/src/spell-kind/spells-sight.c
+++ b/src/spell-kind/spells-sight.c
@@ -6,6 +6,7 @@
 #include "effect/effect-processor.h"
 #include "floor/cave.h"
 #include "game-option/birth-options.h"
+#include "game-option/map-screen-options.h"
 #include "grid/grid.h"
 #include "io/cursor.h"
 #include "io/input-key-acceptor.h"
@@ -396,7 +397,7 @@ bool probing(player_type *caster_ptr)
 
     Term->scr->cu = cu;
     Term->scr->cv = cv;
-    if (need_term_fresh(caster_ptr))
+    if (fresh_after)
         term_fresh();
 
     if (probe) {

--- a/src/spell-kind/spells-sight.c
+++ b/src/spell-kind/spells-sight.c
@@ -376,7 +376,7 @@ bool probing(player_type *caster_ptr)
         prt(buf, 0, 0);
 
         message_add(buf);
-        caster_ptr->window |= (PW_MESSAGE);
+        caster_ptr->window_flags |= (PW_MESSAGE);
         handle_stuff(caster_ptr);
         move_cursor_relative(m_ptr->fy, m_ptr->fx);
         inkey();

--- a/src/spell-realm/spells-chaos.c
+++ b/src/spell-realm/spells-chaos.c
@@ -176,7 +176,7 @@ bool vanish_dungeon(player_type *caster_ptr)
 
     caster_ptr->update |= (PU_UN_VIEW | PU_UN_LITE | PU_VIEW | PU_LITE | PU_FLOW | PU_MON_LITE | PU_MONSTERS);
     caster_ptr->redraw |= (PR_MAP);
-    caster_ptr->window |= (PW_OVERHEAD | PW_DUNGEON);
+    caster_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
     return TRUE;
 }
 

--- a/src/spell-realm/spells-hex.c
+++ b/src/spell-realm/spells-hex.c
@@ -179,7 +179,7 @@ void check_hex(player_type *caster_ptr)
             caster_ptr->update |= (PU_BONUS | PU_HP);
             caster_ptr->redraw |= (PR_MAP | PR_STATUS | PR_STATE);
             caster_ptr->update |= (PU_MONSTERS);
-            caster_ptr->window |= (PW_OVERHEAD | PW_DUNGEON);
+            caster_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
         }
     }
 

--- a/src/spell-realm/spells-song.c
+++ b/src/spell-realm/spells-song.c
@@ -52,7 +52,7 @@ void check_music(player_type *caster_ptr)
             caster_ptr->action = ACTION_SING;
             caster_ptr->update |= (PU_BONUS | PU_HP | PU_MONSTERS);
             caster_ptr->redraw |= (PR_MAP | PR_STATUS | PR_STATE);
-            caster_ptr->window |= (PW_OVERHEAD | PW_DUNGEON);
+            caster_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
         }
     }
 

--- a/src/spell-realm/spells-sorcery.c
+++ b/src/spell-realm/spells-sorcery.c
@@ -78,7 +78,7 @@ bool alchemy(player_type *caster_ptr)
 
     caster_ptr->au += price;
     caster_ptr->redraw |= PR_GOLD;
-    caster_ptr->window |= PW_PLAYER;
+    caster_ptr->window_flags |= PW_PLAYER;
     vary_item(caster_ptr, item, -amt);
     return TRUE;
 }

--- a/src/spell/spells-object.c
+++ b/src/spell/spells-object.c
@@ -260,7 +260,7 @@ bool curse_armor(player_type *owner_ptr)
     /* Break it */
     o_ptr->ident |= (IDENT_BROKEN);
     owner_ptr->update |= (PU_BONUS | PU_MANA);
-    owner_ptr->window |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
+    owner_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
     return TRUE;
 }
 
@@ -315,7 +315,7 @@ bool curse_weapon_object(player_type *owner_ptr, bool force, object_type *o_ptr)
     /* Break it */
     o_ptr->ident |= (IDENT_BROKEN);
     owner_ptr->update |= (PU_BONUS | PU_MANA);
-    owner_ptr->window |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
+    owner_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
     return TRUE;
 }
 
@@ -530,7 +530,7 @@ bool enchant(player_type *caster_ptr, object_type *o_ptr, int n, int eflag)
     if (!res)
         return FALSE;
     caster_ptr->update |= (PU_BONUS | PU_COMBINE | PU_REORDER);
-    caster_ptr->window |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
+    caster_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
 
     calc_android_exp(caster_ptr);
 

--- a/src/spell/spells-status.c
+++ b/src/spell/spells-status.c
@@ -199,7 +199,7 @@ bool time_walk(player_type *creature_ptr)
     creature_ptr->energy_need -= 1000 + (100 + creature_ptr->csp - 50) * TURNS_PER_TICK / 10;
     creature_ptr->redraw |= (PR_MAP);
     creature_ptr->update |= (PU_MONSTERS);
-    creature_ptr->window |= (PW_OVERHEAD | PW_DUNGEON);
+    creature_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
     handle_stuff(creature_ptr);
     return TRUE;
 }
@@ -240,7 +240,7 @@ void roll_hitdice(player_type *creature_ptr, spell_operation options)
     /* Update and redraw hitpoints */
     creature_ptr->update |= (PU_HP);
     creature_ptr->redraw |= (PR_HP);
-    creature_ptr->window |= (PW_PLAYER);
+    creature_ptr->window_flags |= (PW_PLAYER);
 
     if (!(options & SPOP_NO_UPDATE))
         handle_stuff(creature_ptr);
@@ -397,7 +397,7 @@ bool restore_mana(player_type *creature_ptr, bool magic_eater)
         }
 
         msg_print(_("頭がハッキリとした。", "You feel your head clear."));
-        creature_ptr->window |= (PW_PLAYER);
+        creature_ptr->window_flags |= (PW_PLAYER);
         return TRUE;
     }
 
@@ -408,8 +408,8 @@ bool restore_mana(player_type *creature_ptr, bool magic_eater)
     creature_ptr->csp_frac = 0;
     msg_print(_("頭がハッキリとした。", "You feel your head clear."));
     creature_ptr->redraw |= (PR_MANA);
-    creature_ptr->window |= (PW_PLAYER);
-    creature_ptr->window |= (PW_SPELL);
+    creature_ptr->window_flags |= (PW_PLAYER);
+    creature_ptr->window_flags |= (PW_SPELL);
     return TRUE;
 }
 

--- a/src/status/bad-status-setter.c
+++ b/src/status/bad-status-setter.c
@@ -68,7 +68,7 @@ bool set_blind(player_type *creature_ptr, TIME_EFFECT v)
 
     creature_ptr->update |= (PU_UN_VIEW | PU_UN_LITE | PU_VIEW | PU_LITE | PU_MONSTERS | PU_MON_LITE);
     creature_ptr->redraw |= (PR_MAP);
-    creature_ptr->window |= (PW_OVERHEAD | PW_DUNGEON);
+    creature_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
     handle_stuff(creature_ptr);
     return TRUE;
 }
@@ -321,7 +321,7 @@ bool set_image(player_type *creature_ptr, TIME_EFFECT v)
 
     creature_ptr->redraw |= (PR_MAP | PR_HEALTH | PR_UHEALTH);
     creature_ptr->update |= (PU_MONSTERS);
-    creature_ptr->window |= (PW_OVERHEAD | PW_DUNGEON);
+    creature_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
     handle_stuff(creature_ptr);
     return TRUE;
 }

--- a/src/status/base-status.c
+++ b/src/status/base-status.c
@@ -278,7 +278,7 @@ bool lose_all_info(player_type *creature_ptr)
 
     creature_ptr->update |= (PU_BONUS);
     creature_ptr->update |= (PU_COMBINE | PU_REORDER);
-    creature_ptr->window |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
+    creature_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
     wiz_dark(creature_ptr);
     return TRUE;
 }

--- a/src/status/body-improvement.c
+++ b/src/status/body-improvement.c
@@ -82,7 +82,7 @@ bool set_invuln(player_type *creature_ptr, TIME_EFFECT v, bool do_dec)
             creature_ptr->redraw |= (PR_MAP);
             creature_ptr->update |= (PU_MONSTERS);
 
-            creature_ptr->window |= (PW_OVERHEAD | PW_DUNGEON);
+            creature_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
         }
     } else {
         if (creature_ptr->invuln && !music_singing(creature_ptr, MUSIC_INVULN)) {
@@ -92,7 +92,7 @@ bool set_invuln(player_type *creature_ptr, TIME_EFFECT v, bool do_dec)
             creature_ptr->redraw |= (PR_MAP);
             creature_ptr->update |= (PU_MONSTERS);
 
-            creature_ptr->window |= (PW_OVERHEAD | PW_DUNGEON);
+            creature_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
 
             creature_ptr->energy_need += ENERGY_NEED();
         }

--- a/src/status/buff-setter.c
+++ b/src/status/buff-setter.c
@@ -435,7 +435,7 @@ bool set_wraith_form(player_type *creature_ptr, TIME_EFFECT v, bool do_dec)
             creature_ptr->redraw |= (PR_MAP);
             creature_ptr->update |= (PU_MONSTERS);
 
-            creature_ptr->window |= (PW_OVERHEAD | PW_DUNGEON);
+            creature_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
         }
     } else {
         if (creature_ptr->wraith_form) {
@@ -445,7 +445,7 @@ bool set_wraith_form(player_type *creature_ptr, TIME_EFFECT v, bool do_dec)
             creature_ptr->redraw |= (PR_MAP);
             creature_ptr->update |= (PU_MONSTERS);
 
-            creature_ptr->window |= (PW_OVERHEAD | PW_DUNGEON);
+            creature_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
         }
     }
 

--- a/src/target/grid-selector.c
+++ b/src/target/grid-selector.c
@@ -131,7 +131,7 @@ bool tgt_pt(player_type *creature_ptr, POSITION *x_ptr, POSITION *y_ptr)
                 verify_panel(creature_ptr);
                 creature_ptr->update |= PU_MONSTERS;
                 creature_ptr->redraw |= PR_MAP;
-                creature_ptr->window |= PW_OVERHEAD;
+                creature_ptr->window_flags |= PW_OVERHEAD;
                 handle_stuff(creature_ptr);
             } else {
                 y = tmp_pos.y[n];
@@ -191,7 +191,7 @@ bool tgt_pt(player_type *creature_ptr, POSITION *x_ptr, POSITION *y_ptr)
     verify_panel(creature_ptr);
     creature_ptr->update |= PU_MONSTERS;
     creature_ptr->redraw |= PR_MAP;
-    creature_ptr->window |= PW_OVERHEAD;
+    creature_ptr->window_flags |= PW_OVERHEAD;
     handle_stuff(creature_ptr);
     *x_ptr = x;
     *y_ptr = y;

--- a/src/target/target-checker.c
+++ b/src/target/target-checker.c
@@ -109,7 +109,7 @@ void verify_panel(player_type *creature_ptr)
     panel_bounds_center();
     creature_ptr->update |= PU_MONSTERS;
     creature_ptr->redraw |= PR_MAP;
-    creature_ptr->window |= PW_OVERHEAD | PW_DUNGEON;
+    creature_ptr->window_flags |= PW_OVERHEAD | PW_DUNGEON;
 }
 
 /*

--- a/src/target/target-setter.c
+++ b/src/target/target-setter.c
@@ -479,3 +479,11 @@ bool target_set(player_type *creature_ptr, target_type mode)
     handle_stuff(creature_ptr);
     return target_who != 0;
 }
+
+void target_clear(player_type *creature_ptr) {
+    ts_type tmp_ts;
+    ts_type *ts_ptr = initialize_target_set_type(creature_ptr, &tmp_ts, TARGET_LOOK);
+    ts_ptr->done = TRUE;
+    tmp_pos.n = 0;
+    verify_panel(creature_ptr);
+}

--- a/src/target/target-setter.c
+++ b/src/target/target-setter.c
@@ -202,7 +202,7 @@ static void switch_target_input(player_type *creature_ptr, ts_type *ts_ptr)
         verify_panel(creature_ptr);
         creature_ptr->update |= PU_MONSTERS;
         creature_ptr->redraw |= PR_MAP;
-        creature_ptr->window |= PW_OVERHEAD;
+        creature_ptr->window_flags |= PW_OVERHEAD;
         handle_stuff(creature_ptr);
         target_set_prepare(creature_ptr, ts_ptr->mode);
         ts_ptr->y = creature_ptr->y;
@@ -266,7 +266,7 @@ static void sweep_targets(player_type *creature_ptr, ts_type *ts_ptr)
         panel_bounds_center();
         creature_ptr->update |= PU_MONSTERS;
         creature_ptr->redraw |= PR_MAP;
-        creature_ptr->window |= PW_OVERHEAD;
+        creature_ptr->window_flags |= PW_OVERHEAD;
         handle_stuff(creature_ptr);
         target_set_prepare(creature_ptr, ts_ptr->mode);
         ts_ptr->flag = FALSE;
@@ -352,7 +352,7 @@ static void switch_next_grid_command(player_type *creature_ptr, ts_type *ts_ptr)
         verify_panel(creature_ptr);
         creature_ptr->update |= PU_MONSTERS;
         creature_ptr->redraw |= PR_MAP;
-        creature_ptr->window |= PW_OVERHEAD;
+        creature_ptr->window_flags |= PW_OVERHEAD;
         handle_stuff(creature_ptr);
         target_set_prepare(creature_ptr, ts_ptr->mode);
         ts_ptr->y = creature_ptr->y;
@@ -475,7 +475,7 @@ bool target_set(player_type *creature_ptr, target_type mode)
     verify_panel(creature_ptr);
     creature_ptr->update |= (PU_MONSTERS);
     creature_ptr->redraw |= (PR_MAP);
-    creature_ptr->window |= (PW_OVERHEAD);
+    creature_ptr->window_flags |= (PW_OVERHEAD);
     handle_stuff(creature_ptr);
     return target_who != 0;
 }

--- a/src/target/target-setter.h
+++ b/src/target/target-setter.h
@@ -4,3 +4,4 @@
 
 typedef enum target_type target_type;
 bool target_set(player_type *creature_ptr, target_type mode);
+void target_clear(player_type *creature_ptr);

--- a/src/term/z-term.c
+++ b/src/term/z-term.c
@@ -8,7 +8,6 @@
  */
 
 #include "term/z-term.h"
-#include "core/player-processor.h"
 #include "game-option/map-screen-options.h"
 #include "game-option/runtime-arguments.h"
 #include "game-option/special-options.h"
@@ -1029,8 +1028,6 @@ bool macro_running(void)
     return diff < -1 || 1 < diff;
 }
 
-bool need_term_fresh(player_type *player_ptr) { return (!macro_running() && !continuous_action_running(player_ptr)) || fresh_after; }
-
 /*
  * @brief Actually perform all requested changes to the window
  */
@@ -1049,6 +1046,9 @@ errr term_fresh(void)
     if (!old || !scr)
         return 1;
 
+    if (Term->never_fresh)
+        return 1;
+    
     /* Do nothing unless "mapped" */
     if (!Term->mapped_flag)
         return 1;

--- a/src/term/z-term.h
+++ b/src/term/z-term.h
@@ -57,6 +57,7 @@ typedef struct term_type {
     bool unused_flag; //!< Flag "unused_flag" Reserved for future use
     bool never_bored; //!< Flag "never_bored" Never call the "TERM_XTRA_BORED" action
     bool never_frosh; //!< Flag "never_frosh" Never call the "TERM_XTRA_FROSH" action
+    bool never_fresh; //!< Flag "never_fresh" Never redraw the Term
 
     byte attr_blank; //!< Value "attr_blank" Use this "attr" value for "blank" grids
     char char_blank; //!< Value "char_blank" Use this "char" value for "blank" grids
@@ -95,8 +96,6 @@ typedef struct term_type {
     errr (*pict_hook)(TERM_LEN x, TERM_LEN y, int n, const TERM_COLOR *ap, concptr cp, const TERM_COLOR *tap,
         concptr tcp); //!< タイル描画実装部 / Hook for drawing a sequence of special attr / char pairs
 } term_type;
-
-typedef struct player_type player_type;
 
 /**** Available Constants ****/
 
@@ -145,10 +144,7 @@ errr term_xtra(int n, int v);
 
 void term_queue_char(TERM_LEN x, TERM_LEN y, TERM_COLOR a, char c, TERM_COLOR ta, char tc);
 void term_queue_bigchar(TERM_LEN x, TERM_LEN y, TERM_COLOR a, char c, TERM_COLOR ta, char tc);
-
 void term_queue_line(TERM_LEN x, TERM_LEN y, int n, TERM_COLOR *a, char *c, TERM_COLOR *ta, char *tc);
-
-bool need_term_fresh(player_type *player_ptr);
 bool macro_running(void);
 
 errr term_fresh(void);

--- a/src/view/display-messages.c
+++ b/src/view/display-messages.c
@@ -420,7 +420,7 @@ void msg_print(concptr msg)
     }
 
     term_putstr(p, 0, n, TERM_WHITE, t);
-    p_ptr->window |= (PW_MESSAGE);
+    p_ptr->window_flags |= (PW_MESSAGE);
     update_output(p_ptr);
 
     msg_flag = TRUE;

--- a/src/window/display-sub-window-spells.c
+++ b/src/window/display-sub-window-spells.c
@@ -185,7 +185,7 @@ void fix_spell(player_type *player_ptr)
         term_activate(angband_term[j]);
         display_spell_list(player_ptr);
         term_fresh();
-        player_ptr->window &= ~(PW_SPELL);
+        player_ptr->window_flags &= ~(PW_SPELL);
         term_activate(old);
     }
 }

--- a/src/window/display-sub-window-spells.c
+++ b/src/window/display-sub-window-spells.c
@@ -184,10 +184,8 @@ void fix_spell(player_type *player_ptr)
 
         term_activate(angband_term[j]);
         display_spell_list(player_ptr);
-        if (need_term_fresh(player_ptr)) {
-            term_fresh();
-            player_ptr->window &= ~(PW_SPELL);
-        }
+        term_fresh();
+        player_ptr->window &= ~(PW_SPELL);
         term_activate(old);
     }
 }

--- a/src/window/display-sub-windows.c
+++ b/src/window/display-sub-windows.c
@@ -21,6 +21,7 @@
 #include "system/floor-type-definition.h"
 #include "system/monster-type-definition.h"
 #include "target/target-preparation.h"
+#include "target/target-setter.h"
 #include "target/target-types.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
@@ -188,6 +189,7 @@ void fix_monster_list(player_type *player_ptr, bool force_term_fresh)
         term_clear();
         target_set_prepare(player_ptr, TARGET_LOOK);
         print_monster_list(player_ptr->current_floor_ptr, 0, 0, h);
+        target_clear(player_ptr);
         term_fresh();
         term_activate(old);
     }

--- a/src/window/display-sub-windows.c
+++ b/src/window/display-sub-windows.c
@@ -170,7 +170,7 @@ void print_monster_list(floor_type *floor_ptr, TERM_LEN x, TERM_LEN y, TERM_LEN 
  * @param player_ptr プレーヤーへの参照ポインタ
  * @return なし
  */
-void fix_monster_list(player_type *player_ptr)
+void fix_monster_list(player_type *player_ptr, bool force_term_fresh)
 {
     for (int j = 0; j < 8; j++) {
         term_type *old = Term;
@@ -178,15 +178,17 @@ void fix_monster_list(player_type *player_ptr)
             continue;
         if (!(window_flag[j] & PW_MONSTER_LIST))
             continue;
+        if (angband_term[j]->never_fresh && !force_term_fresh)
+            continue;
 
+        angband_term[j]->never_fresh = FALSE;
         term_activate(angband_term[j]);
         int w, h;
         term_get_size(&w, &h);
         term_clear();
         target_set_prepare(player_ptr, TARGET_LOOK);
         print_monster_list(player_ptr->current_floor_ptr, 0, 0, h);
-        if (need_term_fresh(player_ptr))
-            term_fresh();
+        term_fresh();
         term_activate(old);
     }
 }

--- a/src/window/display-sub-windows.c
+++ b/src/window/display-sub-windows.c
@@ -481,14 +481,14 @@ void toggle_inventory_equipment(player_type *owner_ptr)
         if (window_flag[j] & (PW_INVEN)) {
             window_flag[j] &= ~(PW_INVEN);
             window_flag[j] |= (PW_EQUIP);
-            owner_ptr->window |= (PW_EQUIP);
+            owner_ptr->window_flags |= (PW_EQUIP);
             continue;
         }
 
         if (window_flag[j] & PW_EQUIP) {
             window_flag[j] &= ~(PW_EQUIP);
             window_flag[j] |= PW_INVEN;
-            owner_ptr->window |= PW_INVEN;
+            owner_ptr->window_flags |= PW_INVEN;
         }
     }
 }

--- a/src/window/display-sub-windows.h
+++ b/src/window/display-sub-windows.h
@@ -5,7 +5,7 @@
 
 void fix_inventory(player_type *player_ptr, tval_type item_tester_tval);
 void print_monster_list(floor_type *floor_ptr, TERM_LEN x, TERM_LEN y, TERM_LEN max_lines);
-void fix_monster_list(player_type *player_ptr);
+void fix_monster_list(player_type *player_ptr, bool force_term_fresh);
 void fix_equip(player_type *player_ptr, tval_type item_tester_tval);
 void fix_player(player_type *player_ptr);
 void fix_message(void);

--- a/src/wizard/wizard-item-modifier.c
+++ b/src/wizard/wizard-item-modifier.c
@@ -226,8 +226,7 @@ static void wiz_statistics(player_type *caster_ptr, object_type *o_ptr)
                 }
 
                 prt(format(q, i, correct, matches, better, worse, other), 0, 0);
-                if (need_term_fresh(caster_ptr))
-                    term_fresh();
+                term_fresh();
             }
 
             object_type forge;

--- a/src/wizard/wizard-item-modifier.c
+++ b/src/wizard/wizard-item-modifier.c
@@ -350,7 +350,7 @@ static void wiz_reroll_item(player_type *owner_ptr, object_type *o_ptr)
     object_copy(o_ptr, q_ptr);
     owner_ptr->update |= PU_BONUS;
     owner_ptr->update |= PU_COMBINE | PU_REORDER;
-    owner_ptr->window |= PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER;
+    owner_ptr->window_flags |= PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER;
 }
 
 /*!
@@ -489,7 +489,7 @@ void wiz_modify_item(player_type *creature_ptr)
         object_copy(o_ptr, q_ptr);
         creature_ptr->update |= PU_BONUS;
         creature_ptr->update |= PU_COMBINE | PU_REORDER;
-        creature_ptr->window |= PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER;
+        creature_ptr->window_flags |= PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER;
     } else {
         msg_print("Changes ignored.");
     }

--- a/src/wizard/wizard-special-process.c
+++ b/src/wizard/wizard-special-process.c
@@ -460,7 +460,7 @@ void wiz_reset_class(player_type *creature_ptr)
         return;
 
     creature_ptr->pclass = (byte)tmp_int;
-    creature_ptr->window |= PW_PLAYER;
+    creature_ptr->window_flags |= PW_PLAYER;
     creature_ptr->update |= PU_BONUS | PU_HP | PU_MANA | PU_SPELLS;
     handle_stuff(creature_ptr);
 }


### PR DESCRIPTION
再描写を管理するフラグをtermに持たせて描写の過不足を解消した。
z-termにて再描写を判断していたneed_term_fresh()が不要になったため、player構造体とともに排除した。

関連して、fix_monster_list()のターゲッティングに関する副作用の原因が特定できたので排除した。