### PR TITLE
3.0.0.0: minor English edits for src/realm

### DIFF
--- a/src/realm/realm-arcane.c
+++ b/src/realm/realm-arcane.c
@@ -498,7 +498,7 @@ concptr do_arcane_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
         {
             if (cast) {
                 if (!summon_specific(caster_ptr, -1, caster_ptr->y, caster_ptr->x, plev, SUMMON_ELEMENTAL, (PM_ALLOW_GROUP | PM_FORCE_PET))) {
-                    msg_print(_("エレメンタルは現れなかった。", "No Elementals arrive."));
+                    msg_print(_("エレメンタルは現れなかった。", "No elementals arrive."));
                 }
             }
         }

--- a/src/realm/realm-arcane.c
+++ b/src/realm/realm-arcane.c
@@ -279,7 +279,7 @@ concptr do_arcane_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
         if (name)
             return _("解毒", "Cure Poison");
         if (desc)
-            return _("毒を体内から完全に取り除く。", "Cures poison status.");
+            return _("毒を体内から完全に取り除く。", "Cures yourself of any poisons.");
 
         {
             if (cast) {

--- a/src/realm/realm-chaos.c
+++ b/src/realm/realm-chaos.c
@@ -68,7 +68,7 @@ concptr do_chaos_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
         if (name)
             return _("トラップ/ドア破壊", "Trap / Door Destruction");
         if (desc)
-            return _("隣接する罠と扉を破壊する。", "Destroys all traps in adjacent squares.");
+            return _("隣接する罠と扉を破壊する。", "Destroys all doors and traps in adjacent squares.");
 
         {
             POSITION rad = 1;

--- a/src/realm/realm-craft.c
+++ b/src/realm/realm-craft.c
@@ -464,7 +464,7 @@ concptr do_craft_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
         if (name)
             return _("装備無力化", "Remove Enchantment");
         if (desc)
-            return _("武器・防具にかけられたあらゆる魔力を完全に解除する。", "Removes all magics completely from any weapon or armor.");
+            return _("武器・防具にかけられたあらゆる魔力を完全に解除する。", "Completely removes all magics from any weapon or armor.");
 
         {
             if (cast) {

--- a/src/realm/realm-craft.c
+++ b/src/realm/realm-craft.c
@@ -435,7 +435,7 @@ concptr do_craft_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
                 if (summon_specific(caster_ptr, -1, caster_ptr->y, caster_ptr->x, plev, SUMMON_GOLEM, PM_FORCE_PET)) {
                     msg_print(_("ゴーレムを作った。", "You make a golem."));
                 } else {
-                    msg_print(_("うまくゴーレムを作れなかった。", "No Golems arrive."));
+                    msg_print(_("うまくゴーレムを作れなかった。", "You couldn't make a golem."));
                 }
             }
         }

--- a/src/realm/realm-craft.c
+++ b/src/realm/realm-craft.c
@@ -478,7 +478,7 @@ concptr do_craft_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
         if (name)
             return _("呪い粉砕", "Remove All Curse");
         if (desc)
-            return _("アイテムにかかった強力な呪いを解除する。", "Removes normal and heavy curse from equipped items.");
+            return _("アイテムにかかった強力な呪いを解除する。", "Removes normal and heavy curses from equipped items.");
 
         {
             if (cast)

--- a/src/realm/realm-crusade.c
+++ b/src/realm/realm-crusade.c
@@ -508,7 +508,7 @@ concptr do_crusade_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
         if (name)
             return _("呪い退散", "Dispel Curse");
         if (desc)
-            return _("アイテムにかかった強力な呪いを解除する。", "Removes normal and heavy curse from equipped items.");
+            return _("アイテムにかかった強力な呪いを解除する。", "Removes normal and heavy curses from equipped items.");
 
         {
             if (cast)

--- a/src/realm/realm-crusade.c
+++ b/src/realm/realm-crusade.c
@@ -371,7 +371,7 @@ concptr do_crusade_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
             return _("聖なるオーラ", "Holy Aura");
         if (desc)
             return _("一定時間、邪悪なモンスターを傷つける聖なるオーラを得る。",
-                "Gives aura of holy power that injures evil monsters which attacked you for a while.");
+                "Gives a temporary aura of holy power that injures evil monsters which attack you.");
 
         {
             int base = 20;

--- a/src/realm/realm-death.c
+++ b/src/realm/realm-death.c
@@ -389,7 +389,7 @@ concptr do_death_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
         if (name)
             return _("反魂の術", "Animate dead");
         if (desc)
-            return _("周囲の死体や骨を生き返す。", "Resurrects nearby corpse and skeletons. And makes these your pets.");
+            return _("周囲の死体や骨を生き返す。", "Resurrects nearby corpses and skeletons. And makes these your pets.");
 
         {
             if (cast) {

--- a/src/realm/realm-death.c
+++ b/src/realm/realm-death.c
@@ -237,7 +237,7 @@ concptr do_death_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
             return _("エントロピーの球", "Orb of Entropy");
         if (desc)
             return _(
-                "生命のある者のHPと最大HP双方にダメージを与える効果のある球を放つ。", "Fires a ball which damages to both HP and MaxHP of living monsters.");
+                "生命のある者のHPと最大HP双方にダメージを与える効果のある球を放つ。", "Fires a ball which reduces both HP and MaxHP of living monsters.");
 
         {
             DICE_NUMBER dice = 3;

--- a/src/realm/realm-demon.c
+++ b/src/realm/realm-demon.c
@@ -407,7 +407,7 @@ concptr do_daemon_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
     case 18:
         if (name)
-            return _("溶岩流", "The Flow of Lava");
+            return _("溶岩流", "Lava Flow");
         if (desc)
             return _("自分を中心とした炎の球を作り出し、床を溶岩に変える。", "Generates a ball of fire centered on you which transforms floors to magma.");
 

--- a/src/realm/realm-demon.c
+++ b/src/realm/realm-demon.c
@@ -489,7 +489,7 @@ concptr do_daemon_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
     case 22:
         if (name)
-            return _("サキュバスの接吻", "Kiss of Succubus");
+            return _("サキュバスの接吻", "Succubus's Kiss");
         if (desc)
             return _("因果混乱の球を放つ。", "Fires a ball of nexus.");
 

--- a/src/realm/realm-demon.c
+++ b/src/realm/realm-demon.c
@@ -468,7 +468,7 @@ concptr do_daemon_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
     case 21:
         if (name)
-            return _("地獄の波動", "Nather Wave");
+            return _("地獄の波動", "Nether Wave");
         if (desc)
             return _("視界内の全てのモンスターにダメージを与える。善良なモンスターに特に大きなダメージを与える。",
                 "Damages all monsters in sight. Hurts good monsters greatly.");

--- a/src/realm/realm-demon.c
+++ b/src/realm/realm-demon.c
@@ -171,7 +171,7 @@ concptr do_daemon_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
         if (name)
             return _("古代の死霊召喚", "Summon Manes");
         if (desc)
-            return _("古代の死霊を召喚する。", "Summons a manes.");
+            return _("古代の死霊を召喚する。", "Summons one or more Manes.");
 
         {
             if (cast) {

--- a/src/realm/realm-hex.c
+++ b/src/realm/realm-hex.c
@@ -484,7 +484,7 @@ concptr do_hex_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
         if (name)
             return _("防具呪縛", "Curse armor");
         if (desc)
-            return _("装備している防具に呪いをかける。", "Curse a piece of armour that you wielding.");
+            return _("装備している防具に呪いをかける。", "Curse a piece of armour that you are wielding.");
         if (cast) {
             OBJECT_IDX item;
             concptr q, s;

--- a/src/realm/realm-hex.c
+++ b/src/realm/realm-hex.c
@@ -622,7 +622,7 @@ concptr do_hex_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
         if (desc)
             return _("その階の増殖するモンスターの増殖を阻止する。", "Obstructs all multiplying by monsters on entire floor.");
         if (cast) {
-            msg_print(_("増殖を阻止する呪いをかけた。", "You feel anyone can not already multiply."));
+            msg_print(_("増殖を阻止する呪いをかけた。", "You feel anyone can not multiply."));
         }
         break;
 

--- a/src/realm/realm-hex.c
+++ b/src/realm/realm-hex.c
@@ -620,7 +620,7 @@ concptr do_hex_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
         if (name)
             return _("反増殖結界", "Anti multiply barrier");
         if (desc)
-            return _("その階の増殖するモンスターの増殖を阻止する。", "Obstructs all multiplying by monsters in entire floor.");
+            return _("その階の増殖するモンスターの増殖を阻止する。", "Obstructs all multiplying by monsters on entire floor.");
         if (cast) {
             msg_print(_("増殖を阻止する呪いをかけた。", "You feel anyone can not already multiply."));
         }

--- a/src/realm/realm-hissatsu.c
+++ b/src/realm/realm-hissatsu.c
@@ -882,7 +882,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
         if (name)
             return _("二重の剣撃", "Twin Slash");
         if (desc)
-            return _("1ターンで2度攻撃を行う。", "double attacks at a time.");
+            return _("1ターンで2度攻撃を行う。", "Attack twice in one turn.");
 
         if (cast) {
             POSITION x, y;

--- a/src/realm/realm-life.c
+++ b/src/realm/realm-life.c
@@ -301,7 +301,7 @@ concptr do_life_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
         if (name)
             return _("*解呪*", "Dispel Curse");
         if (desc)
-            return _("アイテムにかかった強力な呪いを解除する。", "Removes normal and heavy curse from equipped items.");
+            return _("アイテムにかかった強力な呪いを解除する。", "Removes normal and heavy curses from equipped items.");
         {
             if (cast)
                 (void)remove_all_curse(caster_ptr);

--- a/src/realm/realm-song.c
+++ b/src/realm/realm-song.c
@@ -495,7 +495,7 @@ concptr do_music_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
         if (name)
             return _("フィリエルの歌", "Firiel's Song");
         if (desc)
-            return _("周囲の死体や骨を生き返す。", "Resurrects nearby corpse and skeletons. And makes them your pets.");
+            return _("周囲の死体や骨を生き返す。", "Resurrects nearby corpses and skeletons. And makes them your pets.");
 
         {
             /* Stop singing before start another */

--- a/src/realm/realm-song.c
+++ b/src/realm/realm-song.c
@@ -916,7 +916,7 @@ concptr do_music_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
     case 29:
         if (name)
-            return _("再生の歌", "Goddess' rebirth");
+            return _("再生の歌", "Goddess's rebirth");
         if (desc)
             return _("すべてのステータスと経験値を回復する。", "Restores all stats and experience.");
 

--- a/src/realm/realm-song.c
+++ b/src/realm/realm-song.c
@@ -549,7 +549,7 @@ concptr do_music_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
             stop_singing(caster_ptr);
 
         if (cast) {
-            msg_print(_("粉砕するメロディを奏で始めた．．．", "You weave a violent pattern of sounds to break wall."));
+            msg_print(_("粉砕するメロディを奏で始めた．．．", "You weave a violent pattern of sounds to break walls."));
             start_singing(caster_ptr, spell, MUSIC_WALL);
         }
 

--- a/src/realm/realm-song.c
+++ b/src/realm/realm-song.c
@@ -616,7 +616,7 @@ concptr do_music_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
             stop_singing(caster_ptr);
 
         if (cast) {
-            msg_print(_("軽快な歌を口ずさみ始めた．．．", "You start singing joyful pop song..."));
+            msg_print(_("軽快な歌を口ずさみ始めた．．．", "You start singing a joyful pop song..."));
             start_singing(caster_ptr, spell, MUSIC_SPEED);
         }
 

--- a/src/realm/realm-trump.c
+++ b/src/realm/realm-trump.c
@@ -214,7 +214,7 @@ concptr do_trump_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
         if (name)
             return _("カミカゼのカード", "Trump Kamikaze");
         if (desc)
-            return _("複数の爆発するモンスターを召喚する。", "Summons monsters which explode by itself.");
+            return _("複数の爆発するモンスターを召喚する。", "Summons multiple exploding monsters.");
 
         {
             if (cast || fail) {


### PR DESCRIPTION
- Remove extraneous capitalization in failed elemental summoning message.
- For completeness, mention doors in the description of "Trap / Door Destruction".
- Make "Create Golem" failure message closer to the form of the success message rather than similar to the failure messages for typical summoning spells.
- To be more idiomatic, swap position of adverb in description of "Remove Enchantment".
- For clarity, reword description of "Holy Aura".
- Change "damages to" to "reduces" in the description of "Orb of Entropy".
- Mention that a group is possible in the description of "Summon Manes".
- Correct typo ("Nather" rather than "Nether").
- Use "Lava Flow" rather than "The Flow of Lave" for title of demon spell.
- Use "Succubus's Kiss" rather than "Kiss of Succubus" for title of demon spell.
- Insert missing "are" in description of "Curse Armor".
- To be more idiomatic, change "in" to "on" in description of "Anti multiply barrier".
- For clarity, drop "already" from onset message for "Anti multiply barrier".
- Reword description of "Twin Slash".
- Change the description of the arcane realm's "Cure Poison" to be the same as the life realm's "Cure Poison".
- Make "curse" plural in the descriptions for "Remove All Curse" and "Dispel Curse".
- Make "corpse" plural in the descriptions for "Animate Dead" and "Firiel's Song".
- Make "wall" plural in the onset message for "Sound of disintegration".
- To be more idiomatic, insert indefinite article in onset message for "Hobbit Melodies".
- Since goddess is singular, add "'s" when forming possessive.
- Reword description of "Trump Kamikaze".