### PR TITLE
3.0.0.0: minor English edits for src/spell

### DIFF
--- a/src/spell/spells-status.c
+++ b/src/spell/spells-status.c
@@ -254,7 +254,7 @@ void roll_hitdice(player_type *creature_ptr, spell_operation options)
         return;
     }
 
-    msg_print(_("体力ランクが変わった。", "Life rate is changed."));
+    msg_print(_("体力ランクが変わった。", "Life rate has changed."));
     creature_ptr->knowledge &= ~(KNOW_HPRATE);
 }
 

--- a/src/spell/spells-status.c
+++ b/src/spell/spells-status.c
@@ -440,7 +440,7 @@ bool fishing(player_type *creature_ptr)
     POSITION x = creature_ptr->x + ddx[dir];
     creature_ptr->fishing_dir = dir;
     if (!cave_has_flag_bold(creature_ptr->current_floor_ptr, y, x, FF_WATER)) {
-        msg_print(_("そこは水辺ではない。", "There is no fishing place."));
+        msg_print(_("そこは水辺ではない。", "You can't fish here."));
         return FALSE;
     }
 

--- a/src/spell/spells-summon.c
+++ b/src/spell/spells-summon.c
@@ -152,9 +152,9 @@ bool cast_summon_hound(player_type *creature_ptr, int power)
 	if (summon_specific(creature_ptr, (pet ? -1 : 0), creature_ptr->y, creature_ptr->x, power, SUMMON_HOUND, mode))
 	{
 		if (pet)
-			msg_print(_("ハウンドがあなたの下僕として出現した。", "A group of hounds appear as your servant."));
+			msg_print(_("ハウンドがあなたの下僕として出現した。", "A group of hounds appear as your servants."));
 		else
-			msg_print(_("ハウンドはあなたに牙を向けている！", "A group of hounds appear as your enemy!"));
+			msg_print(_("ハウンドはあなたに牙を向けている！", "A group of hounds appear as your enemies!"));
 	}
 
 	return TRUE;
@@ -190,9 +190,9 @@ bool cast_summon_octopus(player_type *creature_ptr)
 	if (summon_named_creature(creature_ptr, 0, creature_ptr->y, creature_ptr->x, MON_JIZOTAKO, mode))
 	{
 		if (pet)
-			msg_print(_("蛸があなたの下僕として出現した。", "A group of octopuses appear as your servant."));
+			msg_print(_("蛸があなたの下僕として出現した。", "A group of octopuses appear as your servants."));
 		else
-			msg_print(_("蛸はあなたを睨んでいる！", "A group of octopuses appear as your enemy!"));
+			msg_print(_("蛸はあなたを睨んでいる！", "A group of octopuses appear as your enemies!"));
 	}
 
 	return TRUE;


### PR DESCRIPTION
- Use past tense rather than present for message after changing the life rating.
- Reword message about attempt to fish without any water nearby.
- For summoning messages that use "A group of x appear" use "servants" or "enemies" to match the use of the plural verb with "group".