### PR TITLE
[update] #1 ビルドテストを並列実行する

### DIFF
--- a/.github/workflows/buildtest-on-linux.yml
+++ b/.github/workflows/buildtest-on-linux.yml
@@ -31,7 +31,7 @@ jobs:
         run: ./configure
 
       - name: Build Japanese version
-        run: make
+        run: make -j$(nproc)
 
       - name: Clean source tree
         run: make clean
@@ -40,4 +40,4 @@ jobs:
         run: ./configure --disable-japanese
 
       - name: Build English version
-        run: make
+        run: make -j$(nproc)


### PR DESCRIPTION
GitHubホストランナーはマルチコアCPUなので、ビルドテストを
並列ビルドに対応させる。
nprocコマンドでCPUスレッド数が取得できるので、makeコマンドの
-jオプションにnprocコマンドの結果を与えるようにする。