### PR TITLE
[Fix] 視界内のモンスター表示中、center_playerの描写がおかしくなる #66

### DIFF
--- a/src/target/target-setter.c
+++ b/src/target/target-setter.c
@@ -485,5 +485,4 @@ void target_clear(player_type *creature_ptr) {
     ts_type *ts_ptr = initialize_target_set_type(creature_ptr, &tmp_ts, TARGET_LOOK);
     ts_ptr->done = TRUE;
     tmp_pos.n = 0;
-    verify_panel(creature_ptr);
 }


### PR DESCRIPTION
#38で実装したtarget_clear()内のverify_panel()が不要だった。
fix_monster_list()内で座標更新処理が行なわれていたため、描写が二重になっていた。
該当の処理を省くことで処理を正常化する。