### PR TITLE
[fix] #65 未初期化の変数を参照している

### DIFF
--- a/src/floor/floor-object.c
+++ b/src/floor/floor-object.c
@@ -620,6 +620,10 @@ void floor_item_describe(player_type *owner_ptr, INVENTORY_IDX item)
 object_type *choose_object(player_type *owner_ptr, OBJECT_IDX *idx, concptr q, concptr s, BIT_FLAGS option, tval_type tval)
 {
     OBJECT_IDX item;
+
+    if (idx)
+        *idx = INVEN_NONE;
+
     if (!get_item(owner_ptr, &item, q, s, option, tval))
         return NULL;
 

--- a/src/inventory/inventory-slot-types.h
+++ b/src/inventory/inventory-slot-types.h
@@ -16,5 +16,6 @@ typedef enum inventory_slot_type {
     INVEN_FEET = 35, /*!< アイテムスロット…脚部 */
     INVEN_AMMO = 23, /*!< used for get_random_ego()  */
     INVEN_TOTAL = 36, /*!< Total number of inventory_list slots (hard-coded). */
+    INVEN_NONE = 1000, /*!< アイテムスロット非選択状態 */
     INVEN_FORCE = 1111, /*!< inventory_list slot for selecting force (hard-coded). */
 } inventory_slot_type;


### PR DESCRIPTION
魔法書のを選択する時にchoose_objectがNULLを返した場合、
item == INVEN_FORCEなら練気術が選択されたとするアドホックな
実装がなされているが、選択をキャンセルした場合もNULLが
返され、その場合itemは更新されていないので未初期化の変数itemが
たまたまINVEN_FORCEっだった場合にdo_cmd_mind()が呼ばれてしまう。

そもそもinventory_slot_typeにスロット非選択状態の値があるべきなので、
INVEN_NONEを新設して-1を割り当てる。
(enumに-1を割り当てるのはC言語の仕様としてvalid)
choose_object()の最初で、第2引数に参照渡しされた変数をINVEN_NONEで
初期化するようにする。