### PR TITLE
[Fix] 変わり身失敗時のメッセージをわかりやすくした

### DIFF
--- a/src/mind/mind-ninja.c
+++ b/src/mind/mind-ninja.c
@@ -68,7 +68,7 @@ bool kawarimi(player_type *caster_ptr, bool success)
         return FALSE;
 
     if (!success && one_in_(3)) {
-        msg_print(_("失敗！逃げられなかった。", "Failed! You couldn't run away."));
+        msg_print(_("変わり身失敗！逃げられなかった。", "Kawarimi failed! You couldn't run away."));
         caster_ptr->special_defense &= ~(NINJA_KAWARIMI);
         caster_ptr->redraw |= (PR_STATUS);
         return FALSE;
@@ -88,7 +88,7 @@ bool kawarimi(player_type *caster_ptr, bool success)
     if (success)
         msg_print(_("攻撃を受ける前に素早く身をひるがえした。", "You have turned around just before the attack hit you."));
     else
-        msg_print(_("失敗！攻撃を受けてしまった。", "Failed! You are hit by the attack."));
+        msg_print(_("変わり身失敗！攻撃を受けてしまった。", "Kawarimi failed! You are hit by the attack."));
 
     caster_ptr->special_defense &= ~(NINJA_KAWARIMI);
     caster_ptr->redraw |= (PR_STATUS);


### PR DESCRIPTION
変わり身の攻撃回避部分が失敗したときテレポートを試みるが、このときのメッセージが

* 成功時「失敗！攻撃を受けてしまった。」
* 失敗時「失敗！逃げられなかった。」

となっており、慣れていないと何が失敗したのかわかりにくい。
そこで、「変わり身失敗！〜」というメッセージに変更する。