### PR TITLE
[Fix] X11 ドライバで valgrind 警告が出なくなるようにした

### DIFF
--- a/src/maid-x11.c
+++ b/src/maid-x11.c
@@ -115,6 +115,7 @@ static unsigned long create_pixel(Display *dpy, byte red, byte green, byte blue)
 	xcol.red = xcolour.red;
 	xcol.green = xcolour.green;
 	xcol.blue = xcolour.blue;
+	xcol.alpha = 0xFFFF;
 	if (!XftColorAllocValue(dpy, DefaultVisual(dpy, 0), cmap, &xcol, &color))
 	{
 		quit_fmt("Couldn't allocate bitmap color '#%02x%02x%02x'\n",

--- a/src/main-x11.c
+++ b/src/main-x11.c
@@ -911,7 +911,7 @@ static errr Infofnt_text_std(int x, int y, concptr str, int len)
 		char *kanji = malloc(outlen);
 		char *sp; char *kp = kanji;
 		char sbuf[1024];
-		angband_strcpy(sbuf, str, sizeof(sbuf));
+		memcpy(sbuf, str, (size_t)len);
 		sp = sbuf;
 		iconv(cd, &sp, &inlen, &kp, &outlen);
 		iconv_close(cd);


### PR DESCRIPTION
Fixes #73.

バッファサイズが不十分な場合の例外などまだ課題はありますが、とりあえず元のコードと機能的に同等のまま valgrind 警告が出なくなるようにしました。
