### PR TITLE
[Fix] X11 ドライバで日本語入力時にゴミが入ることがあるのを修正

### DIFF
--- a/src/main-x11.c
+++ b/src/main-x11.c
@@ -1047,7 +1047,8 @@ static x11_selection_type s_ptr[1];
 static void convert_to_euc(char *buf)
 {
 	size_t inlen = strlen(buf);
-	size_t outlen = inlen + 1;
+	size_t outlen_orig = inlen + 1;
+	size_t outlen = outlen_orig;
 	char tmp[outlen];
 
 	iconv_t iconvd = iconv_open("EUC-JP", "UTF-8");
@@ -1056,10 +1057,9 @@ static void convert_to_euc(char *buf)
 	iconv(iconvd, &inbuf, &inlen, &outbuf, &outlen);
 	iconv_close(iconvd);
 
-	int i, l = strlen(tmp);
-	for (i = 0; i < l; i++)
-		buf[i] = tmp[i];
-	buf[l] = '\0';
+	size_t n = outlen_orig - outlen;
+	memcpy(buf, tmp, n);
+	buf[n] = '\0';
 }
 #endif
 


### PR DESCRIPTION
Fixes #77.

`iconv()` は引数として与えたバッファサイズを残りバッファサイズに書き換える。よって、両者の差分から出力サイズを計算できる。