### PR TITLE
3.0.0.0: minor English edits for src/spell-realm

### DIFF
--- a/src/spell-realm/spells-arcane.c
+++ b/src/spell-realm/spells-arcane.c
@@ -29,10 +29,10 @@ void phlogiston(player_type *caster_ptr)
     }
 
     o_ptr->xtra4 += (XTRA16)(max_flog / 2);
-    msg_print(_("照明用アイテムに燃素を補充した。", "You add phlogiston to your light item."));
+    msg_print(_("照明用アイテムに燃素を補充した。", "You add phlogiston to your light."));
     if (o_ptr->xtra4 >= max_flog) {
         o_ptr->xtra4 = (XTRA16)max_flog;
-        msg_print(_("照明用アイテムは満タンになった。", "Your light item is full."));
+        msg_print(_("照明用アイテムは満タンになった。", "Your light is full."));
     }
 
     caster_ptr->update |= PU_TORCH;

--- a/src/spell-realm/spells-craft.c
+++ b/src/spell-realm/spells-craft.c
@@ -131,7 +131,7 @@ bool set_ele_immune(player_type *creature_ptr, u32b immune_type, TIME_EFFECT v)
     if ((v) && (immune_type)) {
         creature_ptr->special_defense |= (immune_type);
         creature_ptr->ele_immune = v;
-        msg_format(_("%sの攻撃を受けつけなくなった！", "For a while, You are immune to %s"),
+        msg_format(_("%sの攻撃を受けつけなくなった！", "For a while, you are immune to %s"),
             ((immune_type == DEFENSE_ACID)
                     ? _("酸", "acid!")
                     : ((immune_type == DEFENSE_ELEC)
@@ -140,7 +140,7 @@ bool set_ele_immune(player_type *creature_ptr, u32b immune_type, TIME_EFFECT v)
                                     ? _("火炎", "fire!")
                                     : ((immune_type == DEFENSE_COLD)
                                             ? _("冷気", "cold!")
-                                            : ((immune_type == DEFENSE_POIS) ? _("毒", "poison!") : _("(なし)", "do nothing special.")))))));
+                                            : ((immune_type == DEFENSE_POIS) ? _("毒", "poison!") : _("(なし)", "nothing special.")))))));
     }
 
     if (disturb_state)

--- a/src/spell-realm/spells-craft.c
+++ b/src/spell-realm/spells-craft.c
@@ -261,8 +261,8 @@ bool choose_ele_immune(player_type *creature_ptr, TIME_EFFECT immune_turn)
  */
 bool pulish_shield(player_type *caster_ptr)
 {
-    concptr q = _("どの盾を磨きますか？", "Pulish which weapon? ");
-    concptr s = _("磨く盾がありません。", "You have weapon to pulish.");
+    concptr q = _("どの盾を磨きますか？", "Polish which shield? ");
+    concptr s = _("磨く盾がありません。", "You have no shield to polish.");
 
     OBJECT_IDX item;
     object_type *o_ptr = choose_object(caster_ptr, &item, q, s, USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT, TV_SHIELD);

--- a/src/spell-realm/spells-crusade.c
+++ b/src/spell-realm/spells-crusade.c
@@ -167,7 +167,7 @@ bool set_tim_eyeeye(player_type *creature_ptr, TIME_EFFECT v, bool do_dec)
         }
     } else {
         if (creature_ptr->tim_eyeeye) {
-            msg_print(_("懲罰を執行することができなくなった。", "You no longer feel like a keeper."));
+            msg_print(_("懲罰を執行することができなくなった。", "You lost your aura of retribution."));
             notice = TRUE;
         }
     }

--- a/src/spell-realm/spells-hex.c
+++ b/src/spell-realm/spells-hex.c
@@ -59,7 +59,7 @@ bool stop_hex_spell(player_type *caster_ptr)
     int sp[MAX_KEEP];
 
     if (!hex_spelling_any(caster_ptr)) {
-        msg_print(_("呪文を詠唱していません。", "You are casting no spell."));
+        msg_print(_("呪文を詠唱していません。", "You are not casting a spell."));
         return FALSE;
     }
 

--- a/src/spell-realm/spells-song.c
+++ b/src/spell-realm/spells-song.c
@@ -48,7 +48,7 @@ void check_music(player_type *caster_ptr)
         if (INTERUPTING_SONG_EFFECT(caster_ptr)) {
             SINGING_SONG_EFFECT(caster_ptr) = INTERUPTING_SONG_EFFECT(caster_ptr);
             INTERUPTING_SONG_EFFECT(caster_ptr) = MUSIC_NONE;
-            msg_print(_("歌を再開した。", "You restart singing."));
+            msg_print(_("歌を再開した。", "You resume singing."));
             caster_ptr->action = ACTION_SING;
             caster_ptr->update |= (PU_BONUS | PU_HP | PU_MONSTERS);
             caster_ptr->redraw |= (PR_MAP | PR_STATUS | PR_STATE);

--- a/src/spell-realm/spells-trump.c
+++ b/src/spell-realm/spells-trump.c
@@ -194,7 +194,7 @@ void cast_shuffle(player_type *caster_ptr)
     }
 
     if (die < 111) {
-        msg_print(_("《審判》だ。", "It's the Judgement."));
+        msg_print(_("《審判》だ。", "It's Judgement."));
         roll_hitdice(caster_ptr, 0L);
         lose_all_mutations(caster_ptr);
         return;


### PR DESCRIPTION
- Change "light item" to "light" in message about the arcane spell to refuel a torch or lantern.
- Remove extraneous "do" and capitalization in the message for the onset of immunity from a craft spell.
- Fix English messages to select an item with the polish shield spell.
- Reword English message for the lapse of "An Eye for An Eye".
- Move negative from object to verb in the message about no hex spell to stop.
- Use "resume" rather than "restart" for the message about singing again.
- Drop "the" from "Judgement" when referring to the Tarot card.