### PR TITLE
3.0.0.0: minor English edits for src/status

### DIFF
--- a/src/status/bad-status-setter.c
+++ b/src/status/bad-status-setter.c
@@ -562,7 +562,7 @@ bool set_cut(player_type *creature_ptr, TIME_EFFECT v)
         }
     } else if (new_aux < old_aux) {
         if (new_aux == 0) {
-            msg_format(_("やっと%s。", "You are no longer bleeding."), creature_ptr->prace == RACE_ANDROID ? "怪我が直った" : "出血が止まった");
+            msg_format(_("やっと%s。", "You are no longer %s."), creature_ptr->prace == RACE_ANDROID ? _("怪我が直った", "leaking fluid") : _("出血が止まった", "bleeding"));
             if (disturb_state)
                 disturb(creature_ptr, FALSE, FALSE);
         }

--- a/src/status/bad-status-setter.c
+++ b/src/status/bad-status-setter.c
@@ -37,7 +37,7 @@ bool set_blind(player_type *creature_ptr, TIME_EFFECT v)
     if (v) {
         if (!creature_ptr->blind) {
             if (creature_ptr->prace == RACE_ANDROID) {
-                msg_print(_("センサーをやられた！", "You are blind!"));
+                msg_print(_("センサーをやられた！", "The sensor broke!"));
             } else {
                 msg_print(_("目が見えなくなってしまった！", "You are blind!"));
             }
@@ -50,7 +50,7 @@ bool set_blind(player_type *creature_ptr, TIME_EFFECT v)
     else {
         if (creature_ptr->blind) {
             if (creature_ptr->prace == RACE_ANDROID) {
-                msg_print(_("センサーが復旧した。", "You can see again."));
+                msg_print(_("センサーが復旧した。", "The sensor has been restored."));
             } else {
                 msg_print(_("やっと目が見えるようになった。", "You can see again."));
             }

--- a/src/status/body-improvement.c
+++ b/src/status/body-improvement.c
@@ -136,7 +136,7 @@ bool set_tim_regen(player_type *creature_ptr, TIME_EFFECT v, bool do_dec)
         }
     } else {
         if (creature_ptr->tim_regen) {
-            msg_print(_("素早く回復する感じがなくなった。", "You feel yourself regenerating slowly."));
+            msg_print(_("素早く回復する感じがなくなった。", "You feel you are no longer regenerating quickly."));
             notice = TRUE;
         }
     }

--- a/src/status/shape-changer.c
+++ b/src/status/shape-changer.c
@@ -55,7 +55,7 @@ void change_race(player_type *creature_ptr, player_race_type new_race, concptr e
 #ifdef JP
     msg_format("あなたは%s%sに変化した！", effect_msg, title);
 #else
-    msg_format("You turn into %s %s%s!", (!effect_msg[0] && is_a_vowel(title[0]) ? "an" : "a"), effect_msg, title);
+    msg_format("You turn into %s %s%s!", (is_a_vowel((effect_msg[0]) ? effect_msg[0] : title[0]) ? "an" : "a"), effect_msg, title);
 #endif
 
     chg_virtue(creature_ptr, V_CHANCE, 2);

--- a/src/status/temporary-resistance.c
+++ b/src/status/temporary-resistance.c
@@ -100,14 +100,14 @@ bool set_tim_res_nether(player_type *creature_ptr, TIME_EFFECT v, bool do_dec)
             if (creature_ptr->tim_res_nether > v)
                 return FALSE;
         } else if (!creature_ptr->tim_res_nether) {
-            msg_print(_("地獄の力に対して耐性がついた気がする！", "You feel nether resistant!"));
+            msg_print(_("地獄の力に対して耐性がついた気がする！", "You feel nether-resistant!"));
             notice = TRUE;
         }
     }
 
     else {
         if (creature_ptr->tim_res_nether) {
-            msg_print(_("地獄の力に対する耐性が薄れた気がする。", "You feel less nether resistant"));
+            msg_print(_("地獄の力に対する耐性が薄れた気がする。", "You feel less nether-resistant"));
             notice = TRUE;
         }
     }
@@ -137,12 +137,12 @@ bool set_tim_res_time(player_type *creature_ptr, TIME_EFFECT v, bool do_dec)
             if (creature_ptr->tim_res_time > v)
                 return FALSE;
         } else if (!creature_ptr->tim_res_time) {
-            msg_print(_("時間逆転の力に対して耐性がついた気がする！", "You feel time resistant!"));
+            msg_print(_("時間逆転の力に対して耐性がついた気がする！", "You feel time-resistant!"));
             notice = TRUE;
         }
     } else {
         if (creature_ptr->tim_res_time) {
-            msg_print(_("時間逆転の力に対する耐性が薄れた気がする。", "You feel less time resistant"));
+            msg_print(_("時間逆転の力に対する耐性が薄れた気がする。", "You feel less time-resistant"));
             notice = TRUE;
         }
     }


### PR DESCRIPTION
- For flavor, change the messages about blinding for androids to be closer to what Google Translate gives for the Japanese messages.  Similarly, use a specialized message for androids when there's no longer any cuts.
- Reword message about fast regeneration lapsing - want to avoid implying that there's three states (fast, normal, and slow) rather than two (fast and normal).
- Modify test for "a" or "an" in race change message to allow case where effect_msg begins with a vowel.  Should have no effect with current code:  all callers to change_race() use either empty strings or strings beginning with consonants for effect_msg.
- Replace "x resistant" with "x-resistant" to indicate the noun and adjective are combined to form and adjective.  Could use "resistant to x" instead, but that's longer.