### PR TITLE
Feature/fix monster attack evasion

### DIFF
--- a/src/floor/floor-object.c
+++ b/src/floor/floor-object.c
@@ -620,6 +620,10 @@ void floor_item_describe(player_type *owner_ptr, INVENTORY_IDX item)
 object_type *choose_object(player_type *owner_ptr, OBJECT_IDX *idx, concptr q, concptr s, BIT_FLAGS option, tval_type tval)
 {
     OBJECT_IDX item;
+
+    if (idx)
+        *idx = INVEN_NONE;
+
     if (!get_item(owner_ptr, &item, q, s, option, tval))
         return NULL;
 

--- a/src/inventory/inventory-slot-types.h
+++ b/src/inventory/inventory-slot-types.h
@@ -16,5 +16,6 @@ typedef enum inventory_slot_type {
     INVEN_FEET = 35, /*!< アイテムスロット…脚部 */
     INVEN_AMMO = 23, /*!< used for get_random_ego()  */
     INVEN_TOTAL = 36, /*!< Total number of inventory_list slots (hard-coded). */
+    INVEN_NONE = 1000, /*!< アイテムスロット非選択状態 */
     INVEN_FORCE = 1111, /*!< inventory_list slot for selecting force (hard-coded). */
 } inventory_slot_type;

--- a/src/melee/melee-util.h
+++ b/src/melee/melee-util.h
@@ -31,7 +31,6 @@ typedef struct mam_type {
     DEPTH rlev;
     bool blinked;
     bool do_silly_attack;
-    ARMOUR_CLASS ap_cnt;
     HIT_POINT power;
     bool obvious;
     int d_dice;

--- a/src/melee/monster-attack-monster.c
+++ b/src/melee/monster-attack-monster.c
@@ -266,11 +266,11 @@ static void explode_monster_by_melee(player_type *subject_ptr, mam_type *mam_ptr
 void repeat_melee(player_type *subject_ptr, mam_type *mam_ptr)
 {
     monster_race *r_ptr = &r_info[mam_ptr->m_ptr->r_idx];
-    for (mam_ptr->ap_cnt = 0; mam_ptr->ap_cnt < MAX_NUM_BLOWS; mam_ptr->ap_cnt++) {
-        mam_ptr->effect = r_ptr->blow[mam_ptr->ap_cnt].effect;
-        mam_ptr->method = r_ptr->blow[mam_ptr->ap_cnt].method;
-        mam_ptr->d_dice = r_ptr->blow[mam_ptr->ap_cnt].d_dice;
-        mam_ptr->d_side = r_ptr->blow[mam_ptr->ap_cnt].d_side;
+    for (int ap_cnt = 0; ap_cnt < MAX_NUM_BLOWS; ap_cnt++) {
+        mam_ptr->effect = r_ptr->blow[ap_cnt].effect;
+        mam_ptr->method = r_ptr->blow[ap_cnt].method;
+        mam_ptr->d_dice = r_ptr->blow[ap_cnt].d_dice;
+        mam_ptr->d_side = r_ptr->blow[ap_cnt].d_side;
 
         if (!monster_is_valid(mam_ptr->m_ptr) || (mam_ptr->t_ptr->fx != mam_ptr->x_saver) || (mam_ptr->t_ptr->fy != mam_ptr->y_saver) || !mam_ptr->method)
             break;
@@ -283,11 +283,11 @@ void repeat_melee(player_type *subject_ptr, mam_type *mam_ptr)
         if (!is_original_ap_and_seen(subject_ptr, mam_ptr->m_ptr) || mam_ptr->do_silly_attack)
             continue;
 
-        if (!mam_ptr->obvious && !mam_ptr->damage && (r_ptr->r_blows[mam_ptr->ap_cnt] <= 10))
+        if (!mam_ptr->obvious && !mam_ptr->damage && (r_ptr->r_blows[ap_cnt] <= 10))
             continue;
 
-        if (r_ptr->r_blows[mam_ptr->ap_cnt] < MAX_UCHAR)
-            r_ptr->r_blows[mam_ptr->ap_cnt]++;
+        if (r_ptr->r_blows[ap_cnt] < MAX_UCHAR)
+            r_ptr->r_blows[ap_cnt]++;
     }
 }
 

--- a/src/melee/monster-attack-monster.c
+++ b/src/melee/monster-attack-monster.c
@@ -35,9 +35,6 @@
 #include "system/floor-type-definition.h"
 #include "view/display-messages.h"
 
-/* todo モンスター共通なので、monster-attack-player.cでも使うはず */
-const int MAX_BLOW = 4;
-
 static void heal_monster_by_melee(player_type *subject_ptr, mam_type *mam_ptr)
 {
     if (!monster_living(mam_ptr->m_idx) || (mam_ptr->damage <= 2))
@@ -269,7 +266,7 @@ static void explode_monster_by_melee(player_type *subject_ptr, mam_type *mam_ptr
 void repeat_melee(player_type *subject_ptr, mam_type *mam_ptr)
 {
     monster_race *r_ptr = &r_info[mam_ptr->m_ptr->r_idx];
-    for (mam_ptr->ap_cnt = 0; mam_ptr->ap_cnt < MAX_BLOW; mam_ptr->ap_cnt++) {
+    for (mam_ptr->ap_cnt = 0; mam_ptr->ap_cnt < MAX_NUM_BLOWS; mam_ptr->ap_cnt++) {
         mam_ptr->effect = r_ptr->blow[mam_ptr->ap_cnt].effect;
         mam_ptr->method = r_ptr->blow[mam_ptr->ap_cnt].method;
         mam_ptr->d_dice = r_ptr->blow[mam_ptr->ap_cnt].d_dice;

--- a/src/monster-attack/monster-attack-player.c
+++ b/src/monster-attack/monster-attack-player.c
@@ -373,7 +373,7 @@ static void increase_blow_type_seen(player_type *target_ptr, monap_type *monap_p
 static bool process_monster_blows(player_type *target_ptr, monap_type *monap_ptr)
 {
     monster_race *r_ptr = &r_info[monap_ptr->m_ptr->r_idx];
-    for (monap_ptr->ap_cnt = 0; monap_ptr->ap_cnt < 4; monap_ptr->ap_cnt++) {
+    for (monap_ptr->ap_cnt = 0; monap_ptr->ap_cnt < MAX_NUM_BLOWS; monap_ptr->ap_cnt++) {
         monap_ptr->obvious = FALSE;
         HIT_POINT power = 0;
         monap_ptr->damage = 0;

--- a/src/monster-attack/monster-attack-player.c
+++ b/src/monster-attack/monster-attack-player.c
@@ -273,7 +273,8 @@ static void describe_attack_evasion(player_type *target_ptr, monap_type *monap_p
 
 static void gain_armor_exp(player_type *target_ptr, monap_type *monap_ptr)
 {
-    if (!object_is_armour(target_ptr, &target_ptr->inventory_list[INVEN_MAIN_HAND]) && !object_is_armour(target_ptr, &target_ptr->inventory_list[INVEN_SUB_HAND]))
+    if (!object_is_armour(target_ptr, &target_ptr->inventory_list[INVEN_MAIN_HAND])
+        && !object_is_armour(target_ptr, &target_ptr->inventory_list[INVEN_SUB_HAND]))
         return;
 
     int cur = target_ptr->skill_exp[GINOU_SHIELD];
@@ -390,20 +391,16 @@ static bool process_monster_blows(player_type *target_ptr, monap_type *monap_ptr
 
         power = mbe_info[monap_ptr->effect].power;
         monap_ptr->ac = target_ptr->ac + target_ptr->to_a;
-        if ((monap_ptr->effect == RBE_NONE)
-            || check_hit_from_monster_to_player(target_ptr, power, monap_ptr->rlev, monster_stunned_remaining(monap_ptr->m_ptr))) {
-            if (!process_monster_attack_hit(target_ptr, monap_ptr))
-                continue;
-            else
-                process_monster_attack_evasion(target_ptr, monap_ptr);
+        if (!check_hit_from_monster_to_player(target_ptr, power, monap_ptr->rlev, monster_stunned_remaining(monap_ptr->m_ptr)) ||
+            !process_monster_attack_hit(target_ptr, monap_ptr)) {
+            process_monster_attack_evasion(target_ptr, monap_ptr);
+            continue;
         }
 
         increase_blow_type_seen(target_ptr, monap_ptr);
         check_fall_off_horse(target_ptr, monap_ptr);
-        if (target_ptr->special_defense & NINJA_KAWARIMI) {
-            if (kawarimi(target_ptr, FALSE))
-                return TRUE;
-        }
+        if (((target_ptr->special_defense & NINJA_KAWARIMI) != 0) && kawarimi(target_ptr, FALSE))
+            return TRUE;
     }
 
     return FALSE;

--- a/src/monster-attack/monster-attack-player.c
+++ b/src/monster-attack/monster-attack-player.c
@@ -73,7 +73,7 @@ static bool check_no_blow(player_type *target_ptr, monap_type *monap_ptr)
  * @param monap_ptr モンスターからプレーヤーへの直接攻撃構造体への参照ポインタ
  * @return 攻撃続行ならばTRUE、打ち切りになったらFALSE
  */
-static bool check_monster_attack_terminated(player_type *target_ptr, monap_type *monap_ptr)
+static bool check_monster_continuous_attack(player_type *target_ptr, monap_type *monap_ptr)
 {
     if (!monster_is_valid(monap_ptr->m_ptr))
         return FALSE;
@@ -383,7 +383,7 @@ static bool process_monster_blows(player_type *target_ptr, monap_type *monap_ptr
         monap_ptr->d_dice = r_ptr->blow[monap_ptr->ap_cnt].d_dice;
         monap_ptr->d_side = r_ptr->blow[monap_ptr->ap_cnt].d_side;
 
-        if (!check_monster_attack_terminated(target_ptr, monap_ptr))
+        if (!check_monster_continuous_attack(target_ptr, monap_ptr))
             break;
 
         if (monap_ptr->method == RBM_SHOOT)

--- a/src/monster-attack/monster-attack-player.c
+++ b/src/monster-attack/monster-attack-player.c
@@ -357,31 +357,38 @@ static void process_monster_attack_evasion(player_type *target_ptr, monap_type *
     }
 }
 
-static void increase_blow_type_seen(player_type *target_ptr, monap_type *monap_ptr)
+/*!
+ * @brief モンスターの打撃情報を蓄積させる
+ * @param target_ptr プレーヤーへの参照ポインタ
+ * @param monap_ptr モンスターからプレーヤーへの直接攻撃構造体への参照ポインタ
+ * @param ap_cnt モンスターの打撃 N回目
+ * @return なし
+ */
+static void increase_blow_type_seen(player_type *target_ptr, monap_type *monap_ptr, const int ap_cnt)
 {
     if (!is_original_ap_and_seen(target_ptr, monap_ptr->m_ptr) || monap_ptr->do_silly_attack)
         return;
 
     monster_race *r_ptr = &r_info[monap_ptr->m_ptr->r_idx];
-    if (!monap_ptr->obvious && (monap_ptr->damage == 0) && (r_ptr->r_blows[monap_ptr->ap_cnt] <= 10))
+    if (!monap_ptr->obvious && (monap_ptr->damage == 0) && (r_ptr->r_blows[ap_cnt] <= 10))
         return;
 
-    if (r_ptr->r_blows[monap_ptr->ap_cnt] < MAX_UCHAR)
-        r_ptr->r_blows[monap_ptr->ap_cnt]++;
+    if (r_ptr->r_blows[ap_cnt] < MAX_UCHAR)
+        r_ptr->r_blows[ap_cnt]++;
 }
 
 static bool process_monster_blows(player_type *target_ptr, monap_type *monap_ptr)
 {
     monster_race *r_ptr = &r_info[monap_ptr->m_ptr->r_idx];
-    for (monap_ptr->ap_cnt = 0; monap_ptr->ap_cnt < MAX_NUM_BLOWS; monap_ptr->ap_cnt++) {
+    for (int ap_cnt = 0; ap_cnt < MAX_NUM_BLOWS; ap_cnt++) {
         monap_ptr->obvious = FALSE;
         HIT_POINT power = 0;
         monap_ptr->damage = 0;
         monap_ptr->act = NULL;
-        monap_ptr->effect = r_ptr->blow[monap_ptr->ap_cnt].effect;
-        monap_ptr->method = r_ptr->blow[monap_ptr->ap_cnt].method;
-        monap_ptr->d_dice = r_ptr->blow[monap_ptr->ap_cnt].d_dice;
-        monap_ptr->d_side = r_ptr->blow[monap_ptr->ap_cnt].d_side;
+        monap_ptr->effect = r_ptr->blow[ap_cnt].effect;
+        monap_ptr->method = r_ptr->blow[ap_cnt].method;
+        monap_ptr->d_dice = r_ptr->blow[ap_cnt].d_dice;
+        monap_ptr->d_side = r_ptr->blow[ap_cnt].d_side;
 
         if (!check_monster_continuous_attack(target_ptr, monap_ptr))
             break;
@@ -397,7 +404,7 @@ static bool process_monster_blows(player_type *target_ptr, monap_type *monap_ptr
             continue;
         }
 
-        increase_blow_type_seen(target_ptr, monap_ptr);
+        increase_blow_type_seen(target_ptr, monap_ptr, ap_cnt);
         check_fall_off_horse(target_ptr, monap_ptr);
         if (((target_ptr->special_defense & NINJA_KAWARIMI) != 0) && kawarimi(target_ptr, FALSE))
             return TRUE;

--- a/src/monster-attack/monster-attack-util.h
+++ b/src/monster-attack/monster-attack-util.h
@@ -34,7 +34,6 @@ typedef struct monap_type {
     ARMOUR_CLASS ac;
     bool alive;
     bool fear;
-    int ap_cnt;
 } monap_type;
 
 monap_type *initialize_monap_type(player_type *target_ptr, monap_type *monap_ptr, MONSTER_IDX m_idx);

--- a/src/mspell/mspell-checker.c
+++ b/src/mspell/mspell-checker.c
@@ -299,24 +299,19 @@ void breath(
  */
 bool spell_is_inate(SPELL_IDX spell)
 {
-    if (spell < 32 * 4) /* Set RF4 */
+    if (32 * 3 <= spell && spell < 32 * 4) /* Set RF4 */
     {
-        if ((1L << (spell - 32 * 3)) & RF4_NOMAGIC_MASK)
-            return TRUE;
+        return ((1UL << (spell - 32 * 3)) & RF4_NOMAGIC_MASK) != 0;
+    }
+    if (32 * 4 <= spell && spell < 32 * 5) /* Set RF5 */
+    {
+        return ((1UL << (spell - 32 * 4)) & RF5_NOMAGIC_MASK) != 0;
+    }
+    if (32 * 5 <= spell && spell < 32 * 6) /* Set RF6 */
+    {
+        return ((1UL << (spell - 32 * 5)) & RF6_NOMAGIC_MASK) != 0;
     }
 
-    if (spell < 32 * 5) /* Set RF5 */
-    {
-        if ((1L << (spell - 32 * 4)) & RF5_NOMAGIC_MASK)
-            return TRUE;
-    }
-
-    if (spell < 32 * 6) /* Set RF6 */
-    {
-        if ((1L << (spell - 32 * 5)) & RF6_NOMAGIC_MASK)
-            return TRUE;
-    }
-
-    /* This spell is not "inate" */
+    // 無効なモンスタースペルIDが渡されたら FALSE を返す。
     return FALSE;
 }

--- a/src/system/monster-race-definition.h
+++ b/src/system/monster-race-definition.h
@@ -4,6 +4,9 @@
 #include "monster-attack/monster-attack-types.h"
 #include "system/angband.h"
 
+#define MAX_NUM_BLOWS                                                                                                                                          \
+    4 /*!< モンスターが1ターンに攻撃する最大回数 (射撃を含む) / The maximum number of times a monster can attack in a turn (including SHOOT) */
+
 /*
  * Monster blow structure
  *
@@ -66,7 +69,7 @@ typedef struct monster_race {
     BIT_FLAGS a_ability_flags2; /* Activate Ability Flags 6 (special spells) */
     BIT_FLAGS a_ability_flags3; /* Activate Ability Flags 7 (implementing) */
     BIT_FLAGS a_ability_flags4; /* Activate Ability Flags 8 (implementing) */
-    monster_blow blow[4]; /* Up to four blows per round */
+    monster_blow blow[MAX_NUM_BLOWS]; /* Up to four blows per round */
     MONRACE_IDX reinforce_id[6];
     DICE_NUMBER reinforce_dd[6];
     DICE_SID reinforce_ds[6];


### PR DESCRIPTION
taotao氏とは別方向で、モンスターの攻撃が当たった場合/当たらなかった場合の各種処理を修正しました
また、#63 も併せて修正しています
ご確認下さい

(なお、関数名と関数内の処理が一致していることを前提としています)
(割と前にフィーリングで分割していた頃の名残も多々あるので怪しい処理があるかもしれません。一応簡易的にチェック済)