### PR TITLE
[update] 大きなサイズのマップもスコアサーバへ送信できるようにしたい #43

### DIFF
--- a/src/load/load.c
+++ b/src/load/load.c
@@ -216,10 +216,12 @@ static errr exe_reading_savefile(player_type *creature_ptr)
         rd_s16b(&creature_ptr->pet_extra_flags);
 
     if (!z_older_than(11, 0, 9)) {
-        char buf[SCREEN_BUF_MAX_SIZE];
-        rd_string(buf, sizeof(buf));
+        char *buf;
+        C_MAKE(buf, SCREEN_BUF_MAX_SIZE, char);
+        rd_string(buf, SCREEN_BUF_MAX_SIZE);
         if (buf[0])
             screen_dump = string_make(buf);
+        C_KILL(buf, SCREEN_BUF_MAX_SIZE, char);
     }
 
     errr restore_dungeon_result = restore_dungeon(creature_ptr);

--- a/src/system/system-variables.h
+++ b/src/system/system-variables.h
@@ -3,7 +3,7 @@
 #include "system/angband.h"
 
 #define MAX_NAZGUL_NUM 5
-#define SCREEN_BUF_MAX_SIZE (4 * 65536) /*!< Max size of screen dump buffer */
+#define SCREEN_BUF_MAX_SIZE (1024 * 1024) /*!< Max size of screen dump buffer */
 
 typedef enum init_flags_type {
 	INIT_NAME_ONLY = 0x01,


### PR DESCRIPTION
生成されるスクリーンダンプのサイズ制限を、256KiB→1MiBに拡張する。
また、セーブファイルからスクリーンダンプをロードする時に
スタック領域に1MiBのバッファを積むことはできないので、
ヒープ領域にバッファを用意する。