### PR TITLE
[fix] モンスター一覧を表示すると画面がちらつく#96

### DIFF
--- a/src/window/display-sub-windows.c
+++ b/src/window/display-sub-windows.c
@@ -79,6 +79,7 @@ static void print_monster_line(TERM_LEN x, TERM_LEN y, monster_type *m_ptr, int 
     MONRACE_IDX r_idx = m_ptr->ap_r_idx;
     monster_race *r_ptr = &r_info[r_idx];
 
+    term_erase(0, y, 255);
     term_gotoxy(x, y);
     if (!r_ptr)
         return;
@@ -158,11 +159,14 @@ void print_monster_list(floor_type *floor_ptr, TERM_LEN x, TERM_LEN y, TERM_LEN 
     }
 
     if (line - y - 1 == max_lines && i != tmp_pos.n) {
+        term_erase(0, line, 255);
         term_gotoxy(x, line);
         term_addstr(-1, TERM_WHITE, "-- and more --");
     } else {
         if (last_mons)
             print_monster_line(x, line++, last_mons, n_same);
+        for (; line < max_lines; line++)
+            term_erase(0, line, 255);
     }
 }
 
@@ -186,7 +190,6 @@ void fix_monster_list(player_type *player_ptr, bool force_term_fresh)
         term_activate(angband_term[j]);
         int w, h;
         term_get_size(&w, &h);
-        term_clear();
         target_set_prepare(player_ptr, TARGET_LOOK);
         print_monster_list(player_ptr->current_floor_ptr, 0, 0, h);
         target_clear(player_ptr);


### PR DESCRIPTION
Linux/UNIX環境のGCU版で、サブウィンドウに視界内のモンスター
一覧を表示していると、毎ターン画面がちらつく。
原因は、視界内のモンスター一覧で最初に画面を全消去するため
term_clear()を呼んでいる事にある。
GCU版では、term_clearにより画面の全消去が入ると、端末全体の
再描画が行われるようになっているので、モンスター一覧のみで
なく画面全体の再描画が行われてしまう。

対応策として、term_clear()による全消去は行わずモンスター一覧を
表示する時に1行ずつterm_eraseで消去してから書くようにする。
これはサブウィンドウの持ち物一覧表示などでも使用している
方法で、先に全消去するよりもパフォーマンスもいいのではないかと
推察する。