### PR TITLE
[Fix] セーブファイルを指定して起動した時にpath指定がおかしくて起動しない #101

### DIFF
--- a/src/main-win.c
+++ b/src/main-win.c
@@ -2275,7 +2275,7 @@ static void check_for_save_file(player_type *player_ptr, LPSTR cmd_line)
     if (!*s)
         return;
 
-    strcat(savefile, s);
+    strcpy(savefile, s);
     validate_file(savefile);
     game_in_progress = TRUE;
     play_game(player_ptr, FALSE, FALSE);


### PR DESCRIPTION
コマンドライン等からセーブファイルを起動するときcheck_for_save_file()にて引数を判断している。
ここでグローバル変数savefileが空であることを前提にしてstrcatしていたためパスを正常に指定できなくなっていた。
コマンドライン等からの起動であるとき、INIファイルを無視して指定セーブを開く挙動が正しい。
よってsavefileを上書きするstrcpyを使用するよう変更した。