### PR TITLE
[Fix] 床置きアイテム自動破壊時にメッセージウインドウが遅れる #92

### DIFF
--- a/src/core/window-redrawer.c
+++ b/src/core/window-redrawer.c
@@ -258,7 +258,7 @@ void window_stuff(player_type *player_ptr)
 
     if (window_flags & (PW_MONSTER_LIST)) {
         player_ptr->window_flags &= ~(PW_MONSTER_LIST);
-        fix_monster_list(player_ptr, FALSE);
+        fix_monster_list(player_ptr);
     }
 
     if (window_flags & (PW_MESSAGE)) {

--- a/src/io/input-key-requester.c
+++ b/src/io/input-key-requester.c
@@ -3,6 +3,8 @@
 #include "cmd-io/macro-util.h"
 #include "core/asking-player.h" // todo 相互依存している、後で何とかする.
 #include "core/player-processor.h"
+#include "core/stuff-handler.h"
+#include "core/window-redrawer.h"
 #include "game-option/game-play-options.h"
 #include "game-option/input-options.h"
 #include "game-option/map-screen-options.h"
@@ -212,7 +214,9 @@ void request_command(player_type *player_ptr, int shopping)
         if (macro_running() && !fresh_after) {
             stop_term_fresh();
         } else {
-            fix_monster_list(player_ptr, TRUE);
+            start_term_fresh();
+            player_ptr->window_flags |= PW_MONSTER_LIST;
+            handle_stuff(player_ptr);
         }
 
         if (command_new) {

--- a/src/window/display-sub-windows.c
+++ b/src/window/display-sub-windows.c
@@ -175,7 +175,7 @@ void print_monster_list(floor_type *floor_ptr, TERM_LEN x, TERM_LEN y, TERM_LEN 
  * @param player_ptr プレーヤーへの参照ポインタ
  * @return なし
  */
-void fix_monster_list(player_type *player_ptr, bool force_term_fresh)
+void fix_monster_list(player_type *player_ptr)
 {
     for (int j = 0; j < 8; j++) {
         term_type *old = Term;
@@ -183,10 +183,9 @@ void fix_monster_list(player_type *player_ptr, bool force_term_fresh)
             continue;
         if (!(window_flag[j] & PW_MONSTER_LIST))
             continue;
-        if (angband_term[j]->never_fresh && !force_term_fresh)
+        if (angband_term[j]->never_fresh)
             continue;
 
-        angband_term[j]->never_fresh = FALSE;
         term_activate(angband_term[j]);
         int w, h;
         term_get_size(&w, &h);

--- a/src/window/display-sub-windows.h
+++ b/src/window/display-sub-windows.h
@@ -5,7 +5,7 @@
 
 void fix_inventory(player_type *player_ptr, tval_type item_tester_tval);
 void print_monster_list(floor_type *floor_ptr, TERM_LEN x, TERM_LEN y, TERM_LEN max_lines);
-void fix_monster_list(player_type *player_ptr, bool force_term_fresh);
+void fix_monster_list(player_type *player_ptr);
 void fix_equip(player_type *player_ptr, tval_type item_tester_tval);
 void fix_player(player_type *player_ptr);
 void fix_message(void);


### PR DESCRIPTION
マクロ動作完了後、キー入力前のタイミングで必要項目を再描画するようにしました。
全サブウィンドウに対してこの処理を実行するので、視界内のモンスター表示のみを強制描写していた処理が不要になりました。
fix_monster_list()の引数を減らし、never_freshフラグを操作して描写処理を行います。