### PR TITLE
[fix] pkg-config のチェックを追加 #12

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,7 @@ AC_SUBST(DEFAULT_VAR_PATH)
 
 dnl Checks for programs.
 AC_PROG_CC
+PKG_PROG_PKG_CONFIG
 
 AC_ARG_ENABLE(japanese,
 [  --disable-japanese      build english version], use_japanese=no, [AC_DEFINE(JP, 1, [Enable Japanese]) AC_DEFINE(EUC, 1, [Use Extended Unix Code])])


### PR DESCRIPTION
./configureに --enable-xft と --disable-worldscore の両方の
スイッチを渡すと、XFTの検出ができずエラーとなる。
現象から判断するに、先にlibcurlの検出をしていると
XFTの検出もできる模様。
他のソフトウェアのconfigure.acの例を見て、
PKG_PROG_PKG_CONFIG (pkg-configの検出)を追加すると
--enable-xft と --disable-worldscore の両方を渡しても
正常に検出できるようになった。
正直 configure.ac は複雑すぎてわからないところだらけで
PKG_PROG_PKG_CONFIG の追加でOKになった理由も
よくわからないが、どのみち pkg-config の検出は
あったほうが良いと思われるので追加して修正とする。