### PR TITLE
[Fix] ビットテスト用の左シフトの左辺を全て符号なしにする

### DIFF
--- a/src/autopick/autopick-entry.c
+++ b/src/autopick/autopick-entry.c
@@ -268,7 +268,7 @@ bool autopick_new_entry(autopick_type *entry, concptr str, bool allow_default)
             ADD_FLG_NOUN(FLG_ITEMS);
     } else {
         if (prev_flg != -1) {
-            entry->flag[prev_flg / 32] &= ~(1L << (prev_flg % 32));
+            entry->flag[prev_flg / 32] &= ~(1UL << (prev_flg % 32));
             ptr = prev_ptr;
         }
     }

--- a/src/autopick/autopick-key-flag-process.h
+++ b/src/autopick/autopick-key-flag-process.h
@@ -12,7 +12,7 @@
 #endif
 #define ADD_KEY2(KEY) strcat(ptr, KEY)
 
-#define ADD_FLG(FLG) (entry->flag[FLG / 32] |= (1L << (FLG % 32)))
-#define REM_FLG(FLG) (entry->flag[FLG / 32] &= ~(1L << (FLG % 32)))
+#define ADD_FLG(FLG) (entry->flag[FLG / 32] |= (1UL << (FLG % 32)))
+#define REM_FLG(FLG) (entry->flag[FLG / 32] &= ~(1UL << (FLG % 32)))
 #define ADD_FLG_NOUN(FLG) (ADD_FLG(FLG), prev_flg = FLG)
-#define IS_FLG(FLG) (entry->flag[FLG / 32] & (1L << (FLG % 32)))
+#define IS_FLG(FLG) (entry->flag[FLG / 32] & (1UL << (FLG % 32)))

--- a/src/birth/birth-select-class.c
+++ b/src/birth/birth-select-class.c
@@ -21,7 +21,7 @@ static void enumerate_class_list(char *sym)
             sym[n] = ('A' + n - 26);
 
         char buf[80];
-        if (!(rp_ptr->choice & (1L << n)))
+        if (!(rp_ptr->choice & (1UL << n)))
             sprintf(buf, "%c%c(%s)", sym[n], p2, str);
         else
             sprintf(buf, "%c%c%s", sym[n], p2, str);
@@ -45,7 +45,7 @@ static void display_class_stat(int cs, int *os, char *cur, char *sym)
         cp_ptr = &class_info[cs];
         mp_ptr = &m_info[cs];
         concptr str = cp_ptr->title;
-        if (!(rp_ptr->choice & (1L << cs)))
+        if (!(rp_ptr->choice & (1UL << cs)))
             sprintf(cur, "%c%c(%s)", sym[cs], p2, str);
         else
             sprintf(cur, "%c%c%s", sym[cs], p2, str);

--- a/src/birth/birth-select-realm.c
+++ b/src/birth/birth-select-realm.c
@@ -124,7 +124,7 @@ static void impose_first_realm(player_type *creature_ptr, s32b choices)
 static void analyze_realms(player_type *creature_ptr, s32b choices, birth_realm_type *birth_realm_ptr)
 {
     for (int i = 0; i < 32; i++) {
-        if ((choices & (1L << i)) == 0)
+        if ((choices & (1UL << i)) == 0)
             continue;
 
         if (creature_ptr->realm1 == i + 1) {

--- a/src/blue-magic/learnt-power-getter.c
+++ b/src/blue-magic/learnt-power-getter.c
@@ -172,15 +172,15 @@ static bool sweep_learnt_spells(player_type *caster_ptr, learnt_magic_type *lm_p
 {
     set_rf_masks(&lm_ptr->f4, &lm_ptr->f5, &lm_ptr->f6, lm_ptr->mode);
     for (lm_ptr->blue_magic_num = 0, lm_ptr->count = 0; lm_ptr->blue_magic_num < 32; lm_ptr->blue_magic_num++)
-        if ((0x00000001 << lm_ptr->blue_magic_num) & lm_ptr->f4)
+        if ((0x00000001U << lm_ptr->blue_magic_num) & lm_ptr->f4)
             lm_ptr->blue_magics[lm_ptr->count++] = lm_ptr->blue_magic_num;
 
     for (; lm_ptr->blue_magic_num < 64; lm_ptr->blue_magic_num++)
-        if ((0x00000001 << (lm_ptr->blue_magic_num - 32)) & lm_ptr->f5)
+        if ((0x00000001U << (lm_ptr->blue_magic_num - 32)) & lm_ptr->f5)
             lm_ptr->blue_magics[lm_ptr->count++] = lm_ptr->blue_magic_num;
 
     for (; lm_ptr->blue_magic_num < 96; lm_ptr->blue_magic_num++)
-        if ((0x00000001 << (lm_ptr->blue_magic_num - 64)) & lm_ptr->f6)
+        if ((0x00000001U << (lm_ptr->blue_magic_num - 64)) & lm_ptr->f6)
             lm_ptr->blue_magics[lm_ptr->count++] = lm_ptr->blue_magic_num;
 
     for (lm_ptr->blue_magic_num = 0; lm_ptr->blue_magic_num < lm_ptr->count; lm_ptr->blue_magic_num++) {

--- a/src/cmd-action/cmd-hissatsu.c
+++ b/src/cmd-action/cmd-hissatsu.c
@@ -125,7 +125,7 @@ static int get_hissatsu_power(player_type *creature_ptr, SPELL_IDX *sn)
                     menu_line += 31;
                     if (menu_line > 32)
                         menu_line -= 32;
-                } while (!(creature_ptr->spell_learned1 & (1L << (menu_line - 1))));
+                } while (!(creature_ptr->spell_learned1 & (1UL << (menu_line - 1))));
                 break;
             }
 
@@ -136,7 +136,7 @@ static int get_hissatsu_power(player_type *creature_ptr, SPELL_IDX *sn)
                     menu_line++;
                     if (menu_line > 32)
                         menu_line -= 32;
-                } while (!(creature_ptr->spell_learned1 & (1L << (menu_line - 1))));
+                } while (!(creature_ptr->spell_learned1 & (1UL << (menu_line - 1))));
                 break;
             }
 
@@ -154,7 +154,7 @@ static int get_hissatsu_power(player_type *creature_ptr, SPELL_IDX *sn)
                     reverse = TRUE;
                 } else
                     menu_line += 16;
-                while (!(creature_ptr->spell_learned1 & (1L << (menu_line - 1)))) {
+                while (!(creature_ptr->spell_learned1 & (1UL << (menu_line - 1)))) {
                     if (reverse) {
                         menu_line--;
                         if (menu_line < 2)
@@ -205,7 +205,7 @@ static int get_hissatsu_power(player_type *creature_ptr, SPELL_IDX *sn)
                     /* Access the spell */
                     if (spell.slevel > plev)
                         continue;
-                    if (!(creature_ptr->spell_learned1 & (1L << i)))
+                    if (!(creature_ptr->spell_learned1 & (1UL << i)))
                         continue;
                     if (use_menu) {
                         if (i == (menu_line - 1))
@@ -259,7 +259,7 @@ static int get_hissatsu_power(player_type *creature_ptr, SPELL_IDX *sn)
         }
 
         /* Totally Illegal */
-        if ((i < 0) || (i >= 32) || !(creature_ptr->spell_learned1 & (1 << sentaku[i]))) {
+        if ((i < 0) || (i >= 32) || !(creature_ptr->spell_learned1 & (1U << sentaku[i]))) {
             bell();
             continue;
         }
@@ -400,13 +400,13 @@ void do_cmd_gain_hissatsu(player_type *creature_ptr)
         return;
 
     for (i = o_ptr->sval * 8; i < o_ptr->sval * 8 + 8; i++) {
-        if (creature_ptr->spell_learned1 & (1L << i))
+        if (creature_ptr->spell_learned1 & (1UL << i))
             continue;
         if (technic_info[TECHNIC_HISSATSU][i].slevel > creature_ptr->lev)
             continue;
 
-        creature_ptr->spell_learned1 |= (1L << i);
-        creature_ptr->spell_worked1 |= (1L << i);
+        creature_ptr->spell_learned1 |= (1UL << i);
+        creature_ptr->spell_worked1 |= (1UL << i);
         msg_format(_("%sの技を覚えた。", "You have learned the special attack of %s."), exe_spell(creature_ptr, REALM_HISSATSU, i, SPELL_NAME));
         for (j = 0; j < 64; j++) {
             /* Stop at the first empty space */

--- a/src/cmd-action/cmd-spell.c
+++ b/src/cmd-action/cmd-spell.c
@@ -223,7 +223,7 @@ static bool spell_okay(player_type *caster_ptr, int spell, bool learned, bool st
         return FALSE;
 
     /* Spell is forgotten */
-    if ((use_realm == caster_ptr->realm2) ? (caster_ptr->spell_forgotten2 & (1L << spell)) : (caster_ptr->spell_forgotten1 & (1L << spell))) {
+    if ((use_realm == caster_ptr->realm2) ? (caster_ptr->spell_forgotten2 & (1UL << spell)) : (caster_ptr->spell_forgotten1 & (1UL << spell))) {
         /* Never okay */
         return FALSE;
     }
@@ -234,7 +234,7 @@ static bool spell_okay(player_type *caster_ptr, int spell, bool learned, bool st
         return TRUE;
 
     /* Spell is learned */
-    if ((use_realm == caster_ptr->realm2) ? (caster_ptr->spell_learned2 & (1L << spell)) : (caster_ptr->spell_learned1 & (1L << spell))) {
+    if ((use_realm == caster_ptr->realm2) ? (caster_ptr->spell_learned2 & (1UL << spell)) : (caster_ptr->spell_learned1 & (1UL << spell))) {
         /* Always true */
         return (!study_pray);
     }
@@ -294,7 +294,7 @@ static int get_spell(player_type *caster_ptr, SPELL_IDX *sn, concptr prompt, OBJ
     /* Extract spells */
     for (spell = 0; spell < 32; spell++) {
         /* Check for this spell */
-        if ((fake_spell_flags[sval] & (1L << spell))) {
+        if ((fake_spell_flags[sval] & (1UL << spell))) {
             /* Collect this spell */
             spells[num++] = spell;
         }
@@ -617,7 +617,7 @@ void do_cmd_browse(player_type *caster_ptr)
     /* Extract spells */
     for (spell = 0; spell < 32; spell++) {
         /* Check for this spell */
-        if ((fake_spell_flags[sval] & (1L << spell))) {
+        if ((fake_spell_flags[sval] & (1UL << spell))) {
             /* Collect this spell */
             spells[num++] = spell;
         }
@@ -693,7 +693,7 @@ static void change_realm2(player_type *caster_ptr, player_personality_type next_
 
     sprintf(tmp, _("魔法の領域を%sから%sに変更した。", "changed magic realm from %s to %s."), realm_names[caster_ptr->realm2], realm_names[next_realm]);
     exe_write_diary(caster_ptr, DIARY_DESCRIPTION, 0, tmp);
-    caster_ptr->old_realm |= 1 << (caster_ptr->realm2 - 1);
+    caster_ptr->old_realm |= 1U << (caster_ptr->realm2 - 1);
     caster_ptr->realm2 = next_realm;
 
     caster_ptr->update |= (PU_REORDER);
@@ -800,7 +800,7 @@ void do_cmd_study(player_type *caster_ptr)
         /* Extract spells */
         for (spell = 0; spell < 32; spell++) {
             /* Check spells in the book */
-            if ((fake_spell_flags[sval] & (1L << spell))) {
+            if ((fake_spell_flags[sval] & (1UL << spell))) {
                 /* Skip non "okay" prayers */
                 if (!spell_okay(caster_ptr, spell, FALSE, TRUE, (increment ? caster_ptr->realm2 : caster_ptr->realm1)))
                     continue;
@@ -831,15 +831,15 @@ void do_cmd_study(player_type *caster_ptr)
 
     /* Learn the spell */
     if (spell < 32) {
-        if (caster_ptr->spell_learned1 & (1L << spell))
+        if (caster_ptr->spell_learned1 & (1UL << spell))
             learned = TRUE;
         else
-            caster_ptr->spell_learned1 |= (1L << spell);
+            caster_ptr->spell_learned1 |= (1UL << spell);
     } else {
-        if (caster_ptr->spell_learned2 & (1L << (spell - 32)))
+        if (caster_ptr->spell_learned2 & (1UL << (spell - 32)))
             learned = TRUE;
         else
-            caster_ptr->spell_learned2 |= (1L << (spell - 32));
+            caster_ptr->spell_learned2 |= (1UL << (spell - 32));
     }
 
     if (learned) {
@@ -1161,15 +1161,15 @@ void do_cmd_cast(player_type *caster_ptr)
             chg_virtue(caster_ptr, V_CHANCE, 1);
 
         /* A spell was cast */
-        if (!(increment ? (caster_ptr->spell_worked2 & (1L << spell)) : (caster_ptr->spell_worked1 & (1L << spell))) && (caster_ptr->pclass != CLASS_SORCERER)
+        if (!(increment ? (caster_ptr->spell_worked2 & (1UL << spell)) : (caster_ptr->spell_worked1 & (1UL << spell))) && (caster_ptr->pclass != CLASS_SORCERER)
             && (caster_ptr->pclass != CLASS_RED_MAGE)) {
             int e = s_ptr->sexp;
 
             /* The spell worked */
             if (realm == caster_ptr->realm1) {
-                caster_ptr->spell_worked1 |= (1L << spell);
+                caster_ptr->spell_worked1 |= (1UL << spell);
             } else {
-                caster_ptr->spell_worked2 |= (1L << spell);
+                caster_ptr->spell_worked2 |= (1UL << spell);
             }
 
             gain_exp(caster_ptr, e * s_ptr->slevel);

--- a/src/cmd-io/cmd-gameoption.c
+++ b/src/cmd-io/cmd-gameoption.c
@@ -212,7 +212,7 @@ static void do_cmd_options_win(player_type *player_ptr)
                 if ((i == y) && (j == x))
                     a = TERM_L_BLUE;
 
-                if (window_flag[j] & (1L << i))
+                if (window_flag[j] & (1UL << i))
                     c = 'X';
 
                 term_putch(35 + j * 5, i + 5, a, c);
@@ -229,11 +229,11 @@ static void do_cmd_options_win(player_type *player_ptr)
         case 'T':
         case 't': {
             for (j = 0; j < 8; j++) {
-                window_flag[j] &= ~(1L << y);
+                window_flag[j] &= ~(1UL << y);
             }
 
             for (i = 0; i < 16; i++) {
-                window_flag[x] &= ~(1L << i);
+                window_flag[x] &= ~(1UL << i);
             }
         }
             /* Fall through */
@@ -242,12 +242,12 @@ static void do_cmd_options_win(player_type *player_ptr)
             if (x == 0)
                 break;
 
-            window_flag[x] |= (1L << y);
+            window_flag[x] |= (1UL << y);
             break;
         }
         case 'n':
         case 'N': {
-            window_flag[x] &= ~(1L << y);
+            window_flag[x] &= ~(1UL << y);
             break;
         }
         case '?': {
@@ -378,7 +378,7 @@ void extract_option_vars(void)
         int os = option_info[i].o_set;
         int ob = option_info[i].o_bit;
         if (option_info[i].o_var) {
-            if (option_flag[os] & (1L << ob)) {
+            if (option_flag[os] & (1UL << ob)) {
                 (*option_info[i].o_var) = TRUE;
             } else {
                 (*option_info[i].o_var) = FALSE;

--- a/src/floor/wild.c
+++ b/src/floor/wild.c
@@ -306,7 +306,7 @@ static void generate_area(player_type *player_ptr, POSITION y, POSITION x, bool 
 
         parse_fixed_map(player_ptr, "t_info.txt", 0, 0, MAX_HGT, MAX_WID);
         if (!corner && !border)
-            player_ptr->visit |= (1L << (player_ptr->town_num - 1));
+            player_ptr->visit |= (1UL << (player_ptr->town_num - 1));
     } else {
         int terrain = wilderness[y][x].terrain;
         u32b seed = wilderness[y][x].seed;

--- a/src/info-reader/general-parser.c
+++ b/src/info-reader/general-parser.c
@@ -53,7 +53,7 @@ errr init_info_txt(FILE *fp, char *buf, angband_header *head, parse_info_txt_fun
             int i;
             for (i = 0; buf[i]; i++) {
                 head->v_extra += (byte)buf[i];
-                head->v_extra ^= (1 << (i % 8));
+                head->v_extra ^= (1U << (i % 8));
             }
         }
 

--- a/src/info-reader/info-reader-util.c
+++ b/src/info-reader/info-reader-util.c
@@ -119,7 +119,7 @@ errr grab_one_flag(u32b *flags, concptr names[], concptr what)
 {
     for (int i = 0; i < 32; i++) {
         if (streq(what, names[i])) {
-            *flags |= (1L << i);
+            *flags |= (1UL << i);
             return 0;
         }
     }

--- a/src/io-dump/character-dump.c
+++ b/src/io-dump/character-dump.c
@@ -371,10 +371,10 @@ static void dump_aux_race_history(player_type *creature_ptr, FILE *fff)
         if (creature_ptr->start_race == i)
             continue;
         if (i < 32) {
-            if (!(creature_ptr->old_race1 & 1L << i))
+            if (!(creature_ptr->old_race1 & 1UL << i))
                 continue;
         } else {
-            if (!(creature_ptr->old_race2 & 1L << (i - 32)))
+            if (!(creature_ptr->old_race2 & 1UL << (i - 32)))
                 continue;
         }
 
@@ -397,7 +397,7 @@ static void dump_aux_realm_history(player_type *creature_ptr, FILE *fff)
 
     fputc('\n', fff);
     for (int i = 0; i < MAX_MAGIC; i++) {
-        if (!(creature_ptr->old_realm & 1L << i))
+        if (!(creature_ptr->old_realm & 1UL << i))
             continue;
         fprintf(fff, _("\n あなたはかつて%s魔法を使えた。", "\n You were able to use %s magic before."), realm_names[i + 1]);
     }

--- a/src/io-dump/special-class-dump.c
+++ b/src/io-dump/special-class-dump.c
@@ -172,17 +172,17 @@ static void dump_blue_mage(player_type *creature_ptr, FILE *fff)
 
         int num = 0;
         for (int i = 0; i < 32; i++) {
-            if ((0x00000001 << i) & learnt_magic.f4)
+            if ((0x00000001U << i) & learnt_magic.f4)
                 spellnum[num++] = i;
         }
 
         for (int i = 32; i < 64; i++) {
-            if ((0x00000001 << (i - 32)) & learnt_magic.f5)
+            if ((0x00000001U << (i - 32)) & learnt_magic.f5)
                 spellnum[num++] = i;
         }
 
         for (int i = 64; i < 96; i++) {
-            if ((0x00000001 << (i - 64)) & learnt_magic.f6)
+            if ((0x00000001U << (i - 64)) & learnt_magic.f6)
                 spellnum[num++] = i;
         }
 

--- a/src/io/interpret-pref-file.c
+++ b/src/io/interpret-pref-file.c
@@ -305,12 +305,12 @@ static errr interpret_xy_token(player_type *creature_ptr, char *buf)
 
 		if (buf[0] == 'X')
 		{
-			option_flag[os] &= ~(1L << ob);
+			option_flag[os] &= ~(1UL << ob);
 			(*option_info[i].o_var) = FALSE;
 			return 0;
 		}
 
-		option_flag[os] |= (1L << ob);
+		option_flag[os] |= (1UL << ob);
 		(*option_info[i].o_var) = TRUE;
 		return 0;
 	}

--- a/src/load/load-zangband.c
+++ b/src/load/load-zangband.c
@@ -23,50 +23,50 @@
 
 void load_zangband_options(void)
 {
-    if (option_flag[5] & (0x00000001 << 4))
-        option_flag[5] &= ~(0x00000001 << 4);
+    if (option_flag[5] & (0x00000001U << 4))
+        option_flag[5] &= ~(0x00000001U << 4);
     else
-        option_flag[5] |= (0x00000001 << 4);
+        option_flag[5] |= (0x00000001U << 4);
 
-    if (option_flag[2] & (0x00000001 << 5))
-        option_flag[2] &= ~(0x00000001 << 5);
+    if (option_flag[2] & (0x00000001U << 5))
+        option_flag[2] &= ~(0x00000001U << 5);
     else
-        option_flag[2] |= (0x00000001 << 5);
+        option_flag[2] |= (0x00000001U << 5);
 
-    if (option_flag[4] & (0x00000001 << 5))
-        option_flag[4] &= ~(0x00000001 << 5);
+    if (option_flag[4] & (0x00000001U << 5))
+        option_flag[4] &= ~(0x00000001U << 5);
     else
-        option_flag[4] |= (0x00000001 << 5);
+        option_flag[4] |= (0x00000001U << 5);
 
-    if (option_flag[5] & (0x00000001 << 0))
-        option_flag[5] &= ~(0x00000001 << 0);
+    if (option_flag[5] & (0x00000001U << 0))
+        option_flag[5] &= ~(0x00000001U << 0);
     else
-        option_flag[5] |= (0x00000001 << 0);
+        option_flag[5] |= (0x00000001U << 0);
 
-    if (option_flag[5] & (0x00000001 << 12))
-        option_flag[5] &= ~(0x00000001 << 12);
+    if (option_flag[5] & (0x00000001U << 12))
+        option_flag[5] &= ~(0x00000001U << 12);
     else
-        option_flag[5] |= (0x00000001 << 12);
+        option_flag[5] |= (0x00000001U << 12);
 
-    if (option_flag[1] & (0x00000001 << 0))
-        option_flag[1] &= ~(0x00000001 << 0);
+    if (option_flag[1] & (0x00000001U << 0))
+        option_flag[1] &= ~(0x00000001U << 0);
     else
-        option_flag[1] |= (0x00000001 << 0);
+        option_flag[1] |= (0x00000001U << 0);
 
-    if (option_flag[1] & (0x00000001 << 18))
-        option_flag[1] &= ~(0x00000001 << 18);
+    if (option_flag[1] & (0x00000001U << 18))
+        option_flag[1] &= ~(0x00000001U << 18);
     else
-        option_flag[1] |= (0x00000001 << 18);
+        option_flag[1] |= (0x00000001U << 18);
 
-    if (option_flag[1] & (0x00000001 << 19))
-        option_flag[1] &= ~(0x00000001 << 19);
+    if (option_flag[1] & (0x00000001U << 19))
+        option_flag[1] &= ~(0x00000001U << 19);
     else
-        option_flag[1] |= (0x00000001 << 19);
+        option_flag[1] |= (0x00000001U << 19);
 
-    if (option_flag[5] & (0x00000001 << 3))
-        option_flag[1] &= ~(0x00000001 << 3);
+    if (option_flag[5] & (0x00000001U << 3))
+        option_flag[1] &= ~(0x00000001U << 3);
     else
-        option_flag[5] |= (0x00000001 << 3);
+        option_flag[5] |= (0x00000001U << 3);
 }
 
 void set_zangband_realm(player_type* creature_ptr)
@@ -266,7 +266,7 @@ void set_zangband_learnt_spells(player_type *creature_ptr)
 {
     creature_ptr->learned_spells = 0;
     for (int i = 0; i < 64; i++)
-        if ((i < 32) ? (creature_ptr->spell_learned1 & (1L << i)) : (creature_ptr->spell_learned2 & (1L << (i - 32))))
+        if ((i < 32) ? (creature_ptr->spell_learned1 & (1UL << i)) : (creature_ptr->spell_learned2 & (1UL << (i - 32))))
             creature_ptr->learned_spells++;
 }
 

--- a/src/load/option-loader.c
+++ b/src/load/option-loader.c
@@ -71,15 +71,15 @@ void rd_options(void)
 
     for (int n = 0; n < 8; n++) {
         for (int i = 0; i < 32; i++) {
-            if (!(mask[n] & (1L << i)))
+            if (!(mask[n] & (1UL << i)))
                 continue;
-            if (!(option_mask[n] & (1L << i)))
+            if (!(option_mask[n] & (1UL << i)))
                 continue;
 
-            if (flag[n] & (1L << i)) {
-                option_flag[n] |= (1L << i);
+            if (flag[n] & (1UL << i)) {
+                option_flag[n] |= (1UL << i);
             } else {
-                option_flag[n] &= ~(1L << i);
+                option_flag[n] &= ~(1UL << i);
             }
         }
     }
@@ -96,15 +96,15 @@ void rd_options(void)
 
     for (int n = 0; n < 8; n++) {
         for (int i = 0; i < 32; i++) {
-            if (!(mask[n] & (1L << i)))
+            if (!(mask[n] & (1UL << i)))
                 continue;
-            if (!(window_mask[n] & (1L << i)))
+            if (!(window_mask[n] & (1UL << i)))
                 continue;
 
-            if (flag[n] & (1L << i)) {
-                window_flag[n] |= (1L << i);
+            if (flag[n] & (1UL << i)) {
+                window_flag[n] |= (1UL << i);
             } else {
-                window_flag[n] &= ~(1L << i);
+                window_flag[n] &= ~(1UL << i);
             }
         }
     }

--- a/src/lore/lore-store.c
+++ b/src/lore/lore-store.c
@@ -57,19 +57,19 @@ int lore_do_probe(player_type *player_ptr, MONRACE_IDX r_idx)
     r_ptr->r_cast_spell = MAX_UCHAR;
 
     for (int i = 0; i < 32; i++) {
-        if (!(r_ptr->r_flags1 & (1L << i)) && (r_ptr->flags1 & (1L << i)))
+        if (!(r_ptr->r_flags1 & (1UL << i)) && (r_ptr->flags1 & (1UL << i)))
             n++;
-        if (!(r_ptr->r_flags2 & (1L << i)) && (r_ptr->flags2 & (1L << i)))
+        if (!(r_ptr->r_flags2 & (1UL << i)) && (r_ptr->flags2 & (1UL << i)))
             n++;
-        if (!(r_ptr->r_flags3 & (1L << i)) && (r_ptr->flags3 & (1L << i)))
+        if (!(r_ptr->r_flags3 & (1UL << i)) && (r_ptr->flags3 & (1UL << i)))
             n++;
-        if (!(r_ptr->r_flags4 & (1L << i)) && (r_ptr->flags4 & (1L << i)))
+        if (!(r_ptr->r_flags4 & (1UL << i)) && (r_ptr->flags4 & (1UL << i)))
             n++;
-        if (!(r_ptr->r_flags5 & (1L << i)) && (r_ptr->a_ability_flags1 & (1L << i)))
+        if (!(r_ptr->r_flags5 & (1UL << i)) && (r_ptr->a_ability_flags1 & (1UL << i)))
             n++;
-        if (!(r_ptr->r_flags6 & (1L << i)) && (r_ptr->a_ability_flags2 & (1L << i)))
+        if (!(r_ptr->r_flags6 & (1UL << i)) && (r_ptr->a_ability_flags2 & (1UL << i)))
             n++;
-        if (!(r_ptr->r_flagsr & (1L << i)) && (r_ptr->flagsr & (1L << i)))
+        if (!(r_ptr->r_flagsr & (1UL << i)) && (r_ptr->flagsr & (1UL << i)))
             n++;
     }
 

--- a/src/main/game-data-initializer.c
+++ b/src/main/game-data-initializer.c
@@ -72,25 +72,25 @@ errr init_other(player_type *player_ptr)
         if (!option_info[i].o_var)
             continue;
 
-        option_mask[os] |= (1L << ob);
+        option_mask[os] |= (1UL << ob);
         if (option_info[i].o_norm)
-            option_flag[os] |= (1L << ob);
+            option_flag[os] |= (1UL << ob);
         else
-            option_flag[os] &= ~(1L << ob);
+            option_flag[os] &= ~(1UL << ob);
     }
 
     for (int n = 0; n < 8; n++)
         for (int i = 0; i < 32; i++)
             if (window_flag_desc[i])
-                window_mask[n] |= (1L << i);
+                window_mask[n] |= (1UL << i);
 
     /*
      *  Set the "default" window flags
      *  Window 1 : Display messages
      *  Window 2 : Display inven/equip
      */
-    window_flag[1] = 1L << A_MAX;
-    window_flag[2] = 1L << 0;
+    window_flag[1] = 1UL << A_MAX;
+    window_flag[2] = 1UL << 0;
     (void)format("%s (%s).", "Mr.Hoge", MAINTAINER);
     return 0;
 }

--- a/src/melee/melee-spell-flags-checker.c
+++ b/src/melee/melee-spell-flags-checker.c
@@ -326,15 +326,15 @@ static bool set_melee_spell_set(player_type *target_ptr, melee_spell_type *ms_pt
         return FALSE;
 
     for (int k = 0; k < 32; k++)
-        if (ms_ptr->f4 & (1L << k))
+        if (ms_ptr->f4 & (1UL << k))
             ms_ptr->spell[ms_ptr->num++] = k + RF4_SPELL_START;
 
     for (int k = 0; k < 32; k++)
-        if (ms_ptr->f5 & (1L << k))
+        if (ms_ptr->f5 & (1UL << k))
             ms_ptr->spell[ms_ptr->num++] = k + RF5_SPELL_START;
 
     for (int k = 0; k < 32; k++)
-        if (ms_ptr->f6 & (1L << k))
+        if (ms_ptr->f6 & (1UL << k))
             ms_ptr->spell[ms_ptr->num++] = k + RF6_SPELL_START;
 
     return (ms_ptr->num != 0) && target_ptr->playing && !target_ptr->is_dead && !target_ptr->leaving;

--- a/src/melee/melee-spell.c
+++ b/src/melee/melee-spell.c
@@ -79,7 +79,7 @@ static void process_rememberance(melee_spell_type *ms_ptr)
         return;
 
     if (ms_ptr->thrown_spell < RF4_SPELL_START + RF4_SPELL_SIZE) {
-        ms_ptr->r_ptr->r_flags4 |= (1L << (ms_ptr->thrown_spell - RF4_SPELL_START));
+        ms_ptr->r_ptr->r_flags4 |= (1UL << (ms_ptr->thrown_spell - RF4_SPELL_START));
         if (ms_ptr->r_ptr->r_cast_spell < MAX_UCHAR)
             ms_ptr->r_ptr->r_cast_spell++;
 
@@ -87,7 +87,7 @@ static void process_rememberance(melee_spell_type *ms_ptr)
     }
     
     if (ms_ptr->thrown_spell < RF5_SPELL_START + RF5_SPELL_SIZE) {
-        ms_ptr->r_ptr->r_flags5 |= (1L << (ms_ptr->thrown_spell - RF5_SPELL_START));
+        ms_ptr->r_ptr->r_flags5 |= (1UL << (ms_ptr->thrown_spell - RF5_SPELL_START));
         if (ms_ptr->r_ptr->r_cast_spell < MAX_UCHAR)
             ms_ptr->r_ptr->r_cast_spell++;
 
@@ -95,7 +95,7 @@ static void process_rememberance(melee_spell_type *ms_ptr)
     }
     
     if (ms_ptr->thrown_spell < RF6_SPELL_START + RF6_SPELL_SIZE) {
-        ms_ptr->r_ptr->r_flags6 |= (1L << (ms_ptr->thrown_spell - RF6_SPELL_START));
+        ms_ptr->r_ptr->r_flags6 |= (1UL << (ms_ptr->thrown_spell - RF6_SPELL_START));
         if (ms_ptr->r_ptr->r_cast_spell < MAX_UCHAR)
             ms_ptr->r_ptr->r_cast_spell++;
     }

--- a/src/monster/monster-status.c
+++ b/src/monster/monster-status.c
@@ -464,7 +464,7 @@ void process_monsters_mtimed(player_type *target_ptr, int mtimed_idx)
 
     /* Hack -- calculate the "player noise" */
     if (mtimed_idx == MTIMED_CSLEEP)
-        csleep_noise = (1L << (30 - target_ptr->skill_stl));
+        csleep_noise = (1U << (30 - target_ptr->skill_stl));
 
     /* Process the monsters (backwards) */
     for (int i = floor_ptr->mproc_max[mtimed_idx] - 1; i >= 0; i--) {

--- a/src/mspell/mspell-attack.c
+++ b/src/mspell/mspell-attack.c
@@ -123,15 +123,15 @@ static bool check_mspell_non_stupid(player_type *target_ptr, msa_type *msa_ptr)
 static void set_mspell_list(msa_type *msa_ptr)
 {
     for (int k = 0; k < 32; k++)
-        if (msa_ptr->f4 & (1L << k))
+        if (msa_ptr->f4 & (1UL << k))
             msa_ptr->mspells[msa_ptr->num++] = k + RF4_SPELL_START;
 
     for (int k = 0; k < 32; k++)
-        if (msa_ptr->f5 & (1L << k))
+        if (msa_ptr->f5 & (1UL << k))
             msa_ptr->mspells[msa_ptr->num++] = k + RF5_SPELL_START;
 
     for (int k = 0; k < 32; k++)
-        if (msa_ptr->f6 & (1L << k))
+        if (msa_ptr->f6 & (1UL << k))
             msa_ptr->mspells[msa_ptr->num++] = k + RF6_SPELL_START;
 }
 
@@ -293,7 +293,7 @@ static void remember_mspell(msa_type *msa_ptr)
         return;
 
     if (msa_ptr->thrown_spell < 32 * 4) {
-        msa_ptr->r_ptr->r_flags4 |= (1L << (msa_ptr->thrown_spell - 32 * 3));
+        msa_ptr->r_ptr->r_flags4 |= (1UL << (msa_ptr->thrown_spell - 32 * 3));
         if (msa_ptr->r_ptr->r_cast_spell < MAX_UCHAR)
             msa_ptr->r_ptr->r_cast_spell++;
 
@@ -301,7 +301,7 @@ static void remember_mspell(msa_type *msa_ptr)
     }
     
     if (msa_ptr->thrown_spell < 32 * 5) {
-        msa_ptr->r_ptr->r_flags5 |= (1L << (msa_ptr->thrown_spell - 32 * 4));
+        msa_ptr->r_ptr->r_flags5 |= (1UL << (msa_ptr->thrown_spell - 32 * 4));
         if (msa_ptr->r_ptr->r_cast_spell < MAX_UCHAR)
             msa_ptr->r_ptr->r_cast_spell++;
 
@@ -309,7 +309,7 @@ static void remember_mspell(msa_type *msa_ptr)
     }
     
     if (msa_ptr->thrown_spell < 32 * 6) {
-        msa_ptr->r_ptr->r_flags6 |= (1L << (msa_ptr->thrown_spell - 32 * 5));
+        msa_ptr->r_ptr->r_flags6 |= (1UL << (msa_ptr->thrown_spell - 32 * 5));
         if (msa_ptr->r_ptr->r_cast_spell < MAX_UCHAR)
             msa_ptr->r_ptr->r_cast_spell++;
     }

--- a/src/object-enchant/object-curse.c
+++ b/src/object-enchant/object-curse.c
@@ -29,7 +29,7 @@ BIT_FLAGS get_curse(player_type *owner_ptr, int power, object_type *o_ptr)
     BIT_FLAGS new_curse;
 
     while (TRUE) {
-        new_curse = (1 << (randint0(MAX_CURSE) + 4));
+        new_curse = (1U << (randint0(MAX_CURSE) + 4));
         if (power == 2) {
             if (!(new_curse & TRC_HEAVY_MASK))
                 continue;

--- a/src/object-hook/hook-magic.c
+++ b/src/object-hook/hook-magic.c
@@ -113,7 +113,7 @@ bool item_tester_learn_spell(player_type *player_ptr, object_type *o_ptr)
     else if (!is_magic(tval2realm(o_ptr->tval)))
         return FALSE;
 
-    return (get_realm1_book(player_ptr) == o_ptr->tval) || (get_realm2_book(player_ptr) == o_ptr->tval) || (choices & (0x0001 << (tval2realm(o_ptr->tval) - 1)));
+    return (get_realm1_book(player_ptr) == o_ptr->tval) || (get_realm2_book(player_ptr) == o_ptr->tval) || (choices & (0x0001U << (tval2realm(o_ptr->tval) - 1)));
 }
 
 /*!

--- a/src/player/player-status-flags.c
+++ b/src/player/player-status-flags.c
@@ -50,7 +50,7 @@ static BIT_FLAGS check_equipment_flags(player_type *creature_ptr, tr_type tr_fla
         object_flags(creature_ptr, o_ptr, flgs);
 
         if (has_flag(flgs, tr_flag))
-            result |= 0x01 << (i - INVEN_MAIN_HAND);
+            result |= 0x01U << (i - INVEN_MAIN_HAND);
     }
     return result;
 }
@@ -151,7 +151,7 @@ BIT_FLAGS has_esp_evil(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
     if (creature_ptr->realm1 == REALM_HEX) {
         if (hex_spelling(creature_ptr, HEX_DETECT_EVIL))
-            result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+            result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
     result |= check_equipment_flags(creature_ptr, TR_ESP_EVIL);
     return result;
@@ -244,24 +244,24 @@ BIT_FLAGS has_esp_telepathy(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (is_time_limit_esp(creature_ptr) || creature_ptr->ult_res || (creature_ptr->special_defense & KATA_MUSOU)) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (creature_ptr->muta3 & MUT3_ESP) {
-        result |= 0x01 << FLAG_CAUSE_MUTATION;
+        result |= 0x01U << FLAG_CAUSE_MUTATION;
     }
 
     if (is_specific_player_race(creature_ptr, RACE_MIND_FLAYER) && creature_ptr->lev > 29)
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
 
     if (is_specific_player_race(creature_ptr, RACE_SPECTRE) && creature_ptr->lev > 34)
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
 
     if (creature_ptr->pclass == CLASS_MINDCRAFTER && creature_ptr->lev > 39)
-        result |= 0x01 << FLAG_CAUSE_CLASS;
+        result |= 0x01U << FLAG_CAUSE_CLASS;
 
     if (creature_ptr->mimic_form == MIMIC_DEMON_LORD) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_TELEPATHY);
@@ -335,17 +335,17 @@ BIT_FLAGS has_reflect(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->pclass == CLASS_BERSERKER && creature_ptr->lev > 39)
-        result |= 0x01 << FLAG_CAUSE_CLASS;
+        result |= 0x01U << FLAG_CAUSE_CLASS;
 
     if (creature_ptr->pclass == CLASS_MIRROR_MASTER && creature_ptr->lev > 39)
-        result |= 0x01 << FLAG_CAUSE_CLASS;
+        result |= 0x01U << FLAG_CAUSE_CLASS;
 
     if (creature_ptr->special_defense & KAMAE_GENBU || creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res || creature_ptr->wraith_form || creature_ptr->magicdef || creature_ptr->tim_reflect) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_REFLECT);
@@ -369,7 +369,7 @@ BIT_FLAGS has_warning(player_type *creature_ptr)
 
         if (has_flag(flgs, TR_WARNING)) {
             if (!o_ptr->inscription || !(angband_strchr(quark_str(o_ptr->inscription), '$')))
-                result |= 0x01 << (i - INVEN_MAIN_HAND);
+                result |= 0x01U << (i - INVEN_MAIN_HAND);
         }
     }
     return result;
@@ -384,19 +384,19 @@ BIT_FLAGS has_sh_fire(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->muta3 & MUT3_FIRE_BODY) {
-        result |= 0x01 << FLAG_CAUSE_MUTATION;
+        result |= 0x01U << FLAG_CAUSE_MUTATION;
     }
 
     if (creature_ptr->mimic_form == MIMIC_DEMON_LORD) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KAMAE_SEIRYU || creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (hex_spelling(creature_ptr, HEX_DEMON_AURA) || creature_ptr->ult_res || creature_ptr->tim_sh_fire) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_SH_FIRE);
@@ -408,14 +408,14 @@ BIT_FLAGS has_sh_elec(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->muta3 & MUT3_ELEC_TOUC)
-        result |= 0x01 << FLAG_CAUSE_MUTATION;
+        result |= 0x01U << FLAG_CAUSE_MUTATION;
 
     if (hex_spelling(creature_ptr, HEX_SHOCK_CLOAK) || creature_ptr->ult_res) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (creature_ptr->special_defense & KAMAE_SEIRYU || (creature_ptr->special_defense & KATA_MUSOU)) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_SH_ELEC);
@@ -427,11 +427,11 @@ BIT_FLAGS has_sh_cold(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->special_defense & KAMAE_SEIRYU || creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res || hex_spelling(creature_ptr, HEX_ICE_ARMOR)) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_SH_COLD);
@@ -447,31 +447,31 @@ BIT_FLAGS has_hold_exp(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->pseikaku == PERSONALITY_MUNCHKIN) {
-        result |= 0x01 << FLAG_CAUSE_PERSONALITY;
+        result |= 0x01U << FLAG_CAUSE_PERSONALITY;
     }
 
     if (creature_ptr->mimic_form == MIMIC_DEMON || creature_ptr->mimic_form == MIMIC_DEMON_LORD || creature_ptr->mimic_form == MIMIC_VAMPIRE) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (is_specific_player_race(creature_ptr, RACE_HOBBIT) || is_specific_player_race(creature_ptr, RACE_SKELETON)
         || is_specific_player_race(creature_ptr, RACE_ZOMBIE) || is_specific_player_race(creature_ptr, RACE_VAMPIRE)
         || is_specific_player_race(creature_ptr, RACE_SPECTRE) || is_specific_player_race(creature_ptr, RACE_BALROG)
         || is_specific_player_race(creature_ptr, RACE_ANDROID)) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (is_specific_player_race(creature_ptr, RACE_GOLEM)) {
         if (creature_ptr->lev > 34)
-            result |= 0x01 << FLAG_CAUSE_RACE;
+            result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_HOLD_EXP);
@@ -483,28 +483,28 @@ BIT_FLAGS has_see_inv(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->pclass == CLASS_NINJA && creature_ptr->lev > 29)
-        result |= 0x01 << FLAG_CAUSE_CLASS;
+        result |= 0x01U << FLAG_CAUSE_CLASS;
 
     if (creature_ptr->mimic_form == MIMIC_DEMON || creature_ptr->mimic_form == MIMIC_DEMON_LORD || creature_ptr->mimic_form == MIMIC_VAMPIRE) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     } else if (is_specific_player_race(creature_ptr, RACE_HIGH_ELF) || is_specific_player_race(creature_ptr, RACE_GOLEM)
         || is_specific_player_race(creature_ptr, RACE_SKELETON) || is_specific_player_race(creature_ptr, RACE_ZOMBIE)
         || is_specific_player_race(creature_ptr, RACE_SPECTRE) || is_specific_player_race(creature_ptr, RACE_ARCHON)) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     } else if (is_specific_player_race(creature_ptr, RACE_DARK_ELF) && creature_ptr->lev > 19) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     } else if (is_specific_player_race(creature_ptr, RACE_MIND_FLAYER) && creature_ptr->lev > 14) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     } else if ((is_specific_player_race(creature_ptr, RACE_IMP) || is_specific_player_race(creature_ptr, RACE_BALROG)) && creature_ptr->lev > 9) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res || creature_ptr->tim_invis) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_SEE_INVIS);
@@ -518,37 +518,37 @@ BIT_FLAGS has_free_act(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->muta3 & MUT3_MOTION)
-        result |= 0x01 << FLAG_CAUSE_MUTATION;
+        result |= 0x01U << FLAG_CAUSE_MUTATION;
 
     if (is_specific_player_race(creature_ptr, RACE_GNOME) || is_specific_player_race(creature_ptr, RACE_GOLEM)
         || is_specific_player_race(creature_ptr, RACE_SPECTRE) || is_specific_player_race(creature_ptr, RACE_ANDROID)) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->pclass == CLASS_NINJA && !heavy_armor(creature_ptr)
         && (!creature_ptr->inventory_list[INVEN_MAIN_HAND].k_idx || can_attack_with_main_hand(creature_ptr))
         && (!creature_ptr->inventory_list[INVEN_SUB_HAND].k_idx || can_attack_with_sub_hand(creature_ptr))) {
         if (creature_ptr->lev > 24)
-            result |= 0x01 << FLAG_CAUSE_CLASS;
+            result |= 0x01U << FLAG_CAUSE_CLASS;
     }
 
     if (creature_ptr->pclass == CLASS_MONK || creature_ptr->pclass == CLASS_FORCETRAINER) {
         if (!(heavy_armor(creature_ptr))) {
             if (creature_ptr->lev > 24)
-                result |= 0x01 << FLAG_CAUSE_CLASS;
+                result |= 0x01U << FLAG_CAUSE_CLASS;
         }
     }
 
     if (creature_ptr->pclass == CLASS_BERSERKER) {
-        result |= 0x01 << FLAG_CAUSE_CLASS;
+        result |= 0x01U << FLAG_CAUSE_CLASS;
     }
 
     if (creature_ptr->ult_res || creature_ptr->magicdef) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_FREE_ACT);
@@ -560,19 +560,19 @@ BIT_FLAGS has_sustain_str(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->pclass == CLASS_BERSERKER) {
-        result |= 0x01 << FLAG_CAUSE_CLASS;
+        result |= 0x01U << FLAG_CAUSE_CLASS;
     }
     if (is_specific_player_race(creature_ptr, RACE_HALF_TROLL) || is_specific_player_race(creature_ptr, RACE_HALF_OGRE)
         || is_specific_player_race(creature_ptr, RACE_HALF_GIANT)) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_SUST_STR);
@@ -584,15 +584,15 @@ BIT_FLAGS has_sustain_int(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (is_specific_player_race(creature_ptr, RACE_MIND_FLAYER)) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_SUST_INT);
@@ -605,18 +605,18 @@ BIT_FLAGS has_sustain_wis(player_type *creature_ptr)
 
     result = FALSE;
     if (creature_ptr->pclass == CLASS_MINDCRAFTER && creature_ptr->lev > 19)
-        result |= 0x01 << FLAG_CAUSE_CLASS;
+        result |= 0x01U << FLAG_CAUSE_CLASS;
 
     if (!creature_ptr->mimic_form && (creature_ptr->prace == RACE_MIND_FLAYER)) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_SUST_WIS);
@@ -627,18 +627,18 @@ BIT_FLAGS has_sustain_dex(player_type *creature_ptr)
 {
     BIT_FLAGS result = 0L;
     if (creature_ptr->pclass == CLASS_BERSERKER) {
-        result |= 0x01 << FLAG_CAUSE_CLASS;
+        result |= 0x01U << FLAG_CAUSE_CLASS;
     }
 
     if (creature_ptr->pclass == CLASS_NINJA && creature_ptr->lev > 24)
-        result |= 0x01 << FLAG_CAUSE_CLASS;
+        result |= 0x01U << FLAG_CAUSE_CLASS;
 
     if (creature_ptr->ult_res) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_SUST_DEX);
@@ -649,19 +649,19 @@ BIT_FLAGS has_sustain_con(player_type *creature_ptr)
 {
     BIT_FLAGS result = 0L;
     if (creature_ptr->pclass == CLASS_BERSERKER) {
-        result |= 0x01 << FLAG_CAUSE_CLASS;
+        result |= 0x01U << FLAG_CAUSE_CLASS;
     }
 
     if (!creature_ptr->mimic_form && (creature_ptr->prace == RACE_AMBERITE || creature_ptr->prace == RACE_DUNADAN)) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_SUST_CON);
@@ -673,11 +673,11 @@ BIT_FLAGS has_sustain_chr(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->ult_res) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_SUST_CHR);
@@ -706,7 +706,7 @@ BIT_FLAGS has_levitation(player_type *creature_ptr)
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (creature_ptr->riding) {
@@ -716,7 +716,7 @@ BIT_FLAGS has_levitation(player_type *creature_ptr)
     }
 
     if (creature_ptr->tim_levitation) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_LEVITATION);
@@ -758,7 +758,7 @@ BIT_FLAGS has_slow_digest(player_type *creature_ptr)
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (!creature_ptr->mimic_form
@@ -776,30 +776,30 @@ BIT_FLAGS has_regenerate(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (is_specific_player_race(creature_ptr, RACE_HALF_TROLL) && creature_ptr->lev > 14) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (is_specific_player_race(creature_ptr, RACE_AMBERITE)) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->pclass == CLASS_WARRIOR && creature_ptr->lev > 44) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->pclass == CLASS_BERSERKER) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->muta3 & MUT3_REGEN)
-        result |= 0x01 << FLAG_CAUSE_MUTATION;
+        result |= 0x01U << FLAG_CAUSE_MUTATION;
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_MUTATION;
+        result |= 0x01U << FLAG_CAUSE_MUTATION;
     }
 
     if (hex_spelling(creature_ptr, HEX_DEMON_AURA) || creature_ptr->ult_res || creature_ptr->tim_regen) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_REGEN);
@@ -914,19 +914,19 @@ BIT_FLAGS has_resist_acid(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->mimic_form == MIMIC_DEMON_LORD) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     } else if (is_specific_player_race(creature_ptr, RACE_YEEK) || is_specific_player_race(creature_ptr, RACE_KLACKON)) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     } else if (is_specific_player_race(creature_ptr, RACE_DRACONIAN) && creature_ptr->lev > 14) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KAMAE_SEIRYU || creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= has_immune_acid(creature_ptr);
@@ -939,11 +939,11 @@ BIT_FLAGS has_vuln_acid(player_type *creature_ptr)
 {
     BIT_FLAGS result = 0L;
     if (creature_ptr->muta3 & MUT3_VULN_ELEM) {
-        result |= 0x01 << FLAG_CAUSE_MUTATION;
+        result |= 0x01U << FLAG_CAUSE_MUTATION;
     }
 
     if (creature_ptr->special_defense & KATA_KOUKIJIN) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
     return result;
 }
@@ -953,17 +953,17 @@ BIT_FLAGS has_resist_elec(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->mimic_form == MIMIC_DEMON_LORD) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     } else if (is_specific_player_race(creature_ptr, RACE_DRACONIAN) && creature_ptr->lev > 19) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KAMAE_SEIRYU || creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_ELEC);
@@ -975,15 +975,15 @@ BIT_FLAGS has_vuln_elec(player_type *creature_ptr)
 {
     BIT_FLAGS result = 0L;
     if (creature_ptr->muta3 & MUT3_VULN_ELEM) {
-        result |= 0x01 << FLAG_CAUSE_MUTATION;
+        result |= 0x01U << FLAG_CAUSE_MUTATION;
     }
 
     if (is_specific_player_race(creature_ptr, RACE_ANDROID)) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KATA_KOUKIJIN) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
     return result;
 }
@@ -993,23 +993,23 @@ BIT_FLAGS has_resist_fire(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->mimic_form == MIMIC_DEMON || creature_ptr->mimic_form == MIMIC_DEMON_LORD) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (is_specific_player_race(creature_ptr, RACE_DRACONIAN) && creature_ptr->lev > 4) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (!creature_ptr->mimic_form && (creature_ptr->prace == RACE_IMP || creature_ptr->prace == RACE_BALROG)) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KAMAE_SEIRYU || creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_FIRE);
@@ -1021,15 +1021,15 @@ BIT_FLAGS has_vuln_fire(player_type *creature_ptr)
 {
     BIT_FLAGS result = 0L;
     if (creature_ptr->muta3 & MUT3_VULN_ELEM) {
-        result |= 0x01 << FLAG_CAUSE_MUTATION;
+        result |= 0x01U << FLAG_CAUSE_MUTATION;
     }
 
     if (is_specific_player_race(creature_ptr, RACE_ENT)) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KATA_KOUKIJIN) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
     return result;
 }
@@ -1039,27 +1039,27 @@ BIT_FLAGS has_resist_cold(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->mimic_form == MIMIC_DEMON_LORD || creature_ptr->mimic_form == MIMIC_VAMPIRE) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (!creature_ptr->mimic_form && (creature_ptr->prace == RACE_ZOMBIE) && creature_ptr->lev > 4) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if ((is_specific_player_race(creature_ptr, RACE_DRACONIAN) || is_specific_player_race(creature_ptr, RACE_SKELETON)) && creature_ptr->lev > 9) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (!creature_ptr->mimic_form && (creature_ptr->prace == RACE_VAMPIRE || creature_ptr->prace == RACE_SPECTRE)) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KAMAE_SEIRYU || creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_COLD);
@@ -1071,11 +1071,11 @@ BIT_FLAGS has_vuln_cold(player_type *creature_ptr)
 {
     BIT_FLAGS result = 0L;
     if (creature_ptr->muta3 & MUT3_VULN_ELEM) {
-        result |= 0x01 << FLAG_CAUSE_MUTATION;
+        result |= 0x01U << FLAG_CAUSE_MUTATION;
     }
 
     if (creature_ptr->special_defense & KATA_KOUKIJIN) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
     return result;
 }
@@ -1085,28 +1085,28 @@ BIT_FLAGS has_resist_pois(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->pclass == CLASS_NINJA && creature_ptr->lev > 19)
-        result |= 0x01 << FLAG_CAUSE_CLASS;
+        result |= 0x01U << FLAG_CAUSE_CLASS;
 
     if (creature_ptr->mimic_form == MIMIC_VAMPIRE || creature_ptr->mimic_form == MIMIC_DEMON_LORD) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (is_specific_player_race(creature_ptr, RACE_DRACONIAN) && creature_ptr->lev > 34) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (!creature_ptr->mimic_form
         && (creature_ptr->prace == RACE_KOBOLD || creature_ptr->prace == RACE_GOLEM || creature_ptr->prace == RACE_SKELETON
             || creature_ptr->prace == RACE_VAMPIRE || creature_ptr->prace == RACE_SPECTRE || creature_ptr->prace == RACE_ANDROID)) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KAMAE_SEIRYU || creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_POIS);
@@ -1118,26 +1118,26 @@ BIT_FLAGS has_resist_conf(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->pclass == CLASS_MINDCRAFTER && creature_ptr->lev > 29)
-        result |= 0x01 << FLAG_CAUSE_CLASS;
+        result |= 0x01U << FLAG_CAUSE_CLASS;
 
     if (creature_ptr->pseikaku == PERSONALITY_CHARGEMAN || creature_ptr->pseikaku == PERSONALITY_MUNCHKIN) {
-        result |= 0x01 << FLAG_CAUSE_PERSONALITY;
+        result |= 0x01U << FLAG_CAUSE_PERSONALITY;
     }
 
     if (!creature_ptr->mimic_form && (creature_ptr->prace == RACE_KLACKON || creature_ptr->prace == RACE_BEASTMAN || creature_ptr->prace == RACE_KUTAR)) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->mimic_form == MIMIC_DEMON_LORD) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->ult_res || creature_ptr->magicdef) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_CONF);
@@ -1149,19 +1149,19 @@ BIT_FLAGS has_resist_sound(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->pclass == CLASS_BARD) {
-        result |= 0x01 << FLAG_CAUSE_CLASS;
+        result |= 0x01U << FLAG_CAUSE_CLASS;
     }
 
     if (!creature_ptr->mimic_form && (creature_ptr->prace == RACE_CYCLOPS || creature_ptr->prace == RACE_BEASTMAN)) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_SOUND);
@@ -1173,15 +1173,15 @@ BIT_FLAGS has_resist_lite(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (!creature_ptr->mimic_form && (creature_ptr->prace == RACE_ELF || creature_ptr->prace == RACE_HIGH_ELF || creature_ptr->prace == RACE_SPRITE)) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_LITE);
@@ -1193,11 +1193,11 @@ BIT_FLAGS has_vuln_lite(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
     if (is_specific_player_race(creature_ptr, RACE_S_FAIRY) || is_specific_player_race(creature_ptr, RACE_VAMPIRE)
         || (creature_ptr->mimic_form == MIMIC_VAMPIRE)) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->wraith_form) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     return result;
@@ -1208,21 +1208,21 @@ BIT_FLAGS has_resist_dark(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->mimic_form == MIMIC_VAMPIRE) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (!creature_ptr->mimic_form
         && (creature_ptr->prace == RACE_HALF_ORC || creature_ptr->prace == RACE_HALF_OGRE || creature_ptr->prace == RACE_NIBELUNG
             || creature_ptr->prace == RACE_DARK_ELF || creature_ptr->prace == RACE_VAMPIRE)) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_DARK);
@@ -1234,21 +1234,21 @@ BIT_FLAGS has_resist_chaos(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->pclass == CLASS_CHAOS_WARRIOR && creature_ptr->lev > 29)
-        result |= 0x01 << FLAG_CAUSE_CLASS;
+        result |= 0x01U << FLAG_CAUSE_CLASS;
 
     if (creature_ptr->mimic_form == MIMIC_DEMON || creature_ptr->mimic_form == MIMIC_DEMON_LORD) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (!creature_ptr->mimic_form && creature_ptr->prace == RACE_HALF_TITAN)
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_CHAOS);
@@ -1260,18 +1260,18 @@ BIT_FLAGS has_resist_disen(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->mimic_form == MIMIC_DEMON_LORD) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (!creature_ptr->mimic_form && creature_ptr->prace == RACE_NIBELUNG)
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_DISEN);
@@ -1283,14 +1283,14 @@ BIT_FLAGS has_resist_shard(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (!creature_ptr->mimic_form && (creature_ptr->prace == RACE_HALF_GIANT || creature_ptr->prace == RACE_SKELETON))
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_SHARDS);
@@ -1302,15 +1302,15 @@ BIT_FLAGS has_resist_nexus(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->mimic_form == MIMIC_DEMON_LORD) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_NEXUS);
@@ -1322,18 +1322,18 @@ BIT_FLAGS has_resist_blind(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->pseikaku == PERSONALITY_MUNCHKIN) {
-        result |= 0x01 << FLAG_CAUSE_PERSONALITY;
+        result |= 0x01U << FLAG_CAUSE_PERSONALITY;
     }
 
     if (!creature_ptr->mimic_form && creature_ptr->prace == RACE_DWARF)
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res || creature_ptr->magicdef) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_BLIND);
@@ -1345,20 +1345,20 @@ BIT_FLAGS has_resist_neth(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->mimic_form == MIMIC_DEMON_LORD || creature_ptr->mimic_form == MIMIC_DEMON || creature_ptr->mimic_form == MIMIC_VAMPIRE) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (!creature_ptr->mimic_form
         && (creature_ptr->prace == RACE_ZOMBIE || creature_ptr->prace == RACE_VAMPIRE || creature_ptr->prace == RACE_SPECTRE
             || creature_ptr->prace == RACE_BALROG))
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res || creature_ptr->tim_res_nether) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_NETHER);
@@ -1370,7 +1370,7 @@ BIT_FLAGS has_resist_time(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->tim_res_time) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_TIME);
@@ -1382,7 +1382,7 @@ BIT_FLAGS has_resist_water(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (!creature_ptr->mimic_form && creature_ptr->prace == RACE_MERFOLK)
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
 
     result |= check_equipment_flags(creature_ptr, TR_RES_WATER);
     return result;
@@ -1393,41 +1393,41 @@ BIT_FLAGS has_resist_fear(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->muta3 & MUT3_FEARLESS)
-        result |= 0x01 << FLAG_CAUSE_MUTATION;
+        result |= 0x01U << FLAG_CAUSE_MUTATION;
 
     switch (creature_ptr->pclass) {
     case CLASS_WARRIOR:
     case CLASS_SAMURAI:
         if (creature_ptr->lev > 29)
-            result |= 0x01 << FLAG_CAUSE_CLASS;
+            result |= 0x01U << FLAG_CAUSE_CLASS;
         break;
     case CLASS_PALADIN:
     case CLASS_CHAOS_WARRIOR:
         if (creature_ptr->lev > 39)
-            result |= 0x01 << FLAG_CAUSE_CLASS;
+            result |= 0x01U << FLAG_CAUSE_CLASS;
         break;
     case CLASS_MINDCRAFTER:
         if (creature_ptr->lev > 9)
-            result |= 0x01 << FLAG_CAUSE_CLASS;
+            result |= 0x01U << FLAG_CAUSE_CLASS;
         break;
     case CLASS_NINJA:
-        result |= 0x01 << FLAG_CAUSE_CLASS;
+        result |= 0x01U << FLAG_CAUSE_CLASS;
         break;
     }
 
     if (creature_ptr->mimic_form == MIMIC_DEMON_LORD) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (!creature_ptr->mimic_form && creature_ptr->prace == RACE_BARBARIAN)
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
 
     if ((creature_ptr->special_defense & KATA_MUSOU)) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (is_hero(creature_ptr) || is_shero(creature_ptr) || creature_ptr->ult_res) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_FEAR);
@@ -1438,11 +1438,11 @@ BIT_FLAGS has_immune_acid(player_type *creature_ptr)
 {
     BIT_FLAGS result = 0L;
     if (!creature_ptr->mimic_form && creature_ptr->prace == RACE_YEEK && creature_ptr->lev > 19)
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
 
     if (creature_ptr->ele_immune) {
         if (creature_ptr->special_defense & DEFENSE_ACID)
-            result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+            result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_IM_ACID);
@@ -1455,7 +1455,7 @@ BIT_FLAGS has_immune_elec(player_type *creature_ptr)
 
     if (creature_ptr->ele_immune) {
         if (creature_ptr->special_defense & DEFENSE_ELEC)
-            result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+            result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_IM_ELEC);
@@ -1468,7 +1468,7 @@ BIT_FLAGS has_immune_fire(player_type *creature_ptr)
 
     if (creature_ptr->ele_immune) {
         if (creature_ptr->special_defense & DEFENSE_FIRE)
-            result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+            result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_IM_FIRE);
@@ -1481,7 +1481,7 @@ BIT_FLAGS has_immune_cold(player_type *creature_ptr)
 
     if (creature_ptr->ele_immune) {
         if (creature_ptr->special_defense & DEFENSE_COLD)
-            result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+            result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_IM_COLD);
@@ -1493,11 +1493,11 @@ BIT_FLAGS has_immune_dark(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (is_specific_player_race(creature_ptr, RACE_VAMPIRE) || (creature_ptr->mimic_form == MIMIC_VAMPIRE)) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->wraith_form) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     return result;
@@ -1578,22 +1578,22 @@ BIT_FLAGS has_lite(player_type *creature_ptr)
         return 0L;
 
     if (creature_ptr->pseikaku == PERSONALITY_MUNCHKIN) {
-        result |= 0x01 << FLAG_CAUSE_PERSONALITY;
+        result |= 0x01U << FLAG_CAUSE_PERSONALITY;
     }
 
     if (creature_ptr->mimic_form == MIMIC_VAMPIRE) {
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
     }
 
     if (!creature_ptr->mimic_form && creature_ptr->prace == RACE_VAMPIRE)
-        result |= 0x01 << FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
 
     if (creature_ptr->ult_res) {
-        result |= 0x01 << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01 << FLAG_CAUSE_BATTLE_FORM;
+        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
     }
 
     result |= has_sh_fire(creature_ptr);

--- a/src/player/player-status-resist.c
+++ b/src/player/player-status-resist.c
@@ -70,7 +70,7 @@ PERCENTAGE calc_acid_damage_rate(player_type *creature_ptr)
 
     BIT_FLAGS flgs = has_vuln_acid(creature_ptr);
     for (int i = 0; i < FLAG_CAUSE_MAX; i++) {
-        if (flgs & (0x01 << i)) {
+        if (flgs & (0x01U << i)) {
             if (i == FLAG_CAUSE_MUTATION) {
                 per *= 2;
             } else {
@@ -100,7 +100,7 @@ PERCENTAGE calc_elec_damage_rate(player_type *creature_ptr)
 
     BIT_FLAGS flgs = has_vuln_elec(creature_ptr);
     for (int i = 0; i < FLAG_CAUSE_MAX; i++) {
-        if (flgs & (0x01 << i)) {
+        if (flgs & (0x01U << i)) {
             if (i == FLAG_CAUSE_MUTATION) {
                 per *= 2;
             } else {
@@ -125,7 +125,7 @@ PERCENTAGE calc_fire_damage_rate(player_type *creature_ptr)
     PERCENTAGE per = 100;
     BIT_FLAGS flgs = has_vuln_fire(creature_ptr);
      for (int i = 0; i < FLAG_CAUSE_MAX; i++) {
-        if (flgs & (0x01 << i)) {
+        if (flgs & (0x01U << i)) {
             if (i == FLAG_CAUSE_MUTATION) {
                 per *= 2;
             } else {
@@ -151,7 +151,7 @@ PERCENTAGE calc_cold_damage_rate(player_type *creature_ptr)
     PERCENTAGE per = 100;
     BIT_FLAGS flgs = has_vuln_cold(creature_ptr);
     for (int i = 0; i < FLAG_CAUSE_MAX; i++) {
-        if (flgs & (0x01 << i)) {
+        if (flgs & (0x01U << i)) {
             if (i == FLAG_CAUSE_MUTATION) {
                 per *= 2;
             } else {

--- a/src/player/player-status.c
+++ b/src/player/player-status.c
@@ -684,7 +684,7 @@ static void calc_spells(player_type *creature_ptr)
 
     int num_boukyaku = 0;
     for (int j = 0; j < 64; j++) {
-        if ((j < 32) ? (creature_ptr->spell_forgotten1 & (1L << j)) : (creature_ptr->spell_forgotten2 & (1L << (j - 32)))) {
+        if ((j < 32) ? (creature_ptr->spell_forgotten1 & (1UL << j)) : (creature_ptr->spell_forgotten2 & (1UL << (j - 32)))) {
             num_boukyaku++;
         }
     }
@@ -712,24 +712,24 @@ static void calc_spells(player_type *creature_ptr)
         if (s_ptr->slevel <= creature_ptr->lev)
             continue;
 
-        bool is_spell_learned = (j < 32) ? (creature_ptr->spell_learned1 & (1L << j)) : (creature_ptr->spell_learned2 & (1L << (j - 32)));
+        bool is_spell_learned = (j < 32) ? (creature_ptr->spell_learned1 & (1UL << j)) : (creature_ptr->spell_learned2 & (1UL << (j - 32)));
         if (!is_spell_learned)
             continue;
 
         REALM_IDX which;
         if (j < 32) {
-            creature_ptr->spell_forgotten1 |= (1L << j);
+            creature_ptr->spell_forgotten1 |= (1UL << j);
             which = creature_ptr->realm1;
         } else {
-            creature_ptr->spell_forgotten2 |= (1L << (j - 32));
+            creature_ptr->spell_forgotten2 |= (1UL << (j - 32));
             which = creature_ptr->realm2;
         }
 
         if (j < 32) {
-            creature_ptr->spell_learned1 &= ~(1L << j);
+            creature_ptr->spell_learned1 &= ~(1UL << j);
             which = creature_ptr->realm1;
         } else {
-            creature_ptr->spell_learned2 &= ~(1L << (j - 32));
+            creature_ptr->spell_learned2 &= ~(1UL << (j - 32));
             which = creature_ptr->realm2;
         }
 
@@ -752,24 +752,24 @@ static void calc_spells(player_type *creature_ptr)
         if (j >= 99)
             continue;
 
-        bool is_spell_learned = (j < 32) ? (creature_ptr->spell_learned1 & (1L << j)) : (creature_ptr->spell_learned2 & (1L << (j - 32)));
+        bool is_spell_learned = (j < 32) ? (creature_ptr->spell_learned1 & (1UL << j)) : (creature_ptr->spell_learned2 & (1UL << (j - 32)));
         if (!is_spell_learned)
             continue;
 
         REALM_IDX which;
         if (j < 32) {
-            creature_ptr->spell_forgotten1 |= (1L << j);
+            creature_ptr->spell_forgotten1 |= (1UL << j);
             which = creature_ptr->realm1;
         } else {
-            creature_ptr->spell_forgotten2 |= (1L << (j - 32));
+            creature_ptr->spell_forgotten2 |= (1UL << (j - 32));
             which = creature_ptr->realm2;
         }
 
         if (j < 32) {
-            creature_ptr->spell_learned1 &= ~(1L << j);
+            creature_ptr->spell_learned1 &= ~(1UL << j);
             which = creature_ptr->realm1;
         } else {
-            creature_ptr->spell_learned2 &= ~(1L << (j - 32));
+            creature_ptr->spell_learned2 &= ~(1UL << (j - 32));
             which = creature_ptr->realm2;
         }
 
@@ -805,24 +805,24 @@ static void calc_spells(player_type *creature_ptr)
         if (s_ptr->slevel > creature_ptr->lev)
             continue;
 
-        bool is_spell_learned = (j < 32) ? (creature_ptr->spell_forgotten1 & (1L << j)) : (creature_ptr->spell_forgotten2 & (1L << (j - 32)));
+        bool is_spell_learned = (j < 32) ? (creature_ptr->spell_forgotten1 & (1UL << j)) : (creature_ptr->spell_forgotten2 & (1UL << (j - 32)));
         if (!is_spell_learned)
             continue;
 
         REALM_IDX which;
         if (j < 32) {
-            creature_ptr->spell_forgotten1 &= ~(1L << j);
+            creature_ptr->spell_forgotten1 &= ~(1UL << j);
             which = creature_ptr->realm1;
         } else {
-            creature_ptr->spell_forgotten2 &= ~(1L << (j - 32));
+            creature_ptr->spell_forgotten2 &= ~(1UL << (j - 32));
             which = creature_ptr->realm2;
         }
 
         if (j < 32) {
-            creature_ptr->spell_learned1 |= (1L << j);
+            creature_ptr->spell_learned1 |= (1UL << j);
             which = creature_ptr->realm1;
         } else {
-            creature_ptr->spell_learned2 |= (1L << (j - 32));
+            creature_ptr->spell_learned2 |= (1UL << (j - 32));
             which = creature_ptr->realm2;
         }
 
@@ -846,7 +846,7 @@ static void calc_spells(player_type *creature_ptr)
             if (s_ptr->slevel > creature_ptr->lev)
                 continue;
 
-            if (creature_ptr->spell_learned1 & (1L << j)) {
+            if (creature_ptr->spell_learned1 & (1UL << j)) {
                 continue;
             }
 

--- a/src/realm/realm-hex.c
+++ b/src/realm/realm-hex.c
@@ -342,9 +342,9 @@ concptr do_hex_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
         if (desc)
             return _("呪文詠唱を中止することなく、薬の効果を得ることができる。", "Quaffs a potion without canceling spell casting.");
         if (cast) {
-            casting_hex_flags(caster_ptr) |= (1L << HEX_INHAIL);
+            casting_hex_flags(caster_ptr) |= (1UL << HEX_INHAIL);
             do_cmd_quaff_potion(caster_ptr);
-            casting_hex_flags(caster_ptr) &= ~(1L << HEX_INHAIL);
+            casting_hex_flags(caster_ptr) &= ~(1UL << HEX_INHAIL);
             add = FALSE;
         }
         break;
@@ -581,7 +581,7 @@ concptr do_hex_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
 
             if ((!o_ptr->k_idx) || (!object_is_cursed(o_ptr))) {
                 exe_spell(caster_ptr, REALM_HEX, spell, SPELL_STOP);
-                casting_hex_flags(caster_ptr) &= ~(1L << spell);
+                casting_hex_flags(caster_ptr) &= ~(1UL << spell);
                 casting_hex_num(caster_ptr)--;
                 if (!SINGING_SONG_ID(caster_ptr))
                     set_action(caster_ptr, ACTION_NONE);
@@ -668,7 +668,7 @@ concptr do_hex_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
 
             if (!flag) {
                 msg_format(_("%sの呪文の詠唱をやめた。", "Finish casting '%^s'."), exe_spell(caster_ptr, REALM_HEX, HEX_RESTORE, SPELL_NAME));
-                casting_hex_flags(caster_ptr) &= ~(1L << HEX_RESTORE);
+                casting_hex_flags(caster_ptr) &= ~(1UL << HEX_RESTORE);
                 if (cont)
                     casting_hex_num(caster_ptr)--;
                 if (casting_hex_num(caster_ptr))
@@ -873,7 +873,7 @@ concptr do_hex_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
     /* start casting */
     if ((cast) && (add)) {
         /* add spell */
-        casting_hex_flags(caster_ptr) |= 1L << (spell);
+        casting_hex_flags(caster_ptr) |= 1UL << (spell);
         casting_hex_num(caster_ptr)++;
 
         if (caster_ptr->action != ACTION_SPELL)

--- a/src/room/rooms-pit-nest.c
+++ b/src/room/rooms-pit-nest.c
@@ -44,7 +44,7 @@ static int pick_vault_type(floor_type *floor_ptr, vault_aux_type *l_ptr, BIT_FLA
         if (n_ptr->level > floor_ptr->dun_level)
             continue;
 
-        if (!(allow_flag_mask & (1L << count)))
+        if (!(allow_flag_mask & (1UL << count)))
             continue;
 
         total += n_ptr->chance * MAX_DEPTH / (MIN(floor_ptr->dun_level, MAX_DEPTH - 1) - n_ptr->level + 5);
@@ -58,7 +58,7 @@ static int pick_vault_type(floor_type *floor_ptr, vault_aux_type *l_ptr, BIT_FLA
         if (n_ptr->level > floor_ptr->dun_level)
             continue;
 
-        if (!(allow_flag_mask & (1L << count)))
+        if (!(allow_flag_mask & (1UL << count)))
             continue;
 
         total += n_ptr->chance * MAX_DEPTH / (MIN(floor_ptr->dun_level, MAX_DEPTH - 1) - n_ptr->level + 5);

--- a/src/save/info-writer.c
+++ b/src/save/info-writer.c
@@ -106,9 +106,9 @@ void wr_options(save_type type)
             continue;
 
         if (*option_info[i].o_var)
-            option_flag[os] |= (1L << ob);
+            option_flag[os] |= (1UL << ob);
         else
-            option_flag[os] &= ~(1L << ob);
+            option_flag[os] &= ~(1UL << ob);
     }
 
     for (int i = 0; i < 8; i++)

--- a/src/spell-kind/spells-world.c
+++ b/src/spell-kind/spells-world.c
@@ -264,7 +264,7 @@ bool tele_town(player_type *caster_ptr)
     for (i = 1; i < max_towns; i++) {
         char buf[80];
 
-        if ((i == NO_TOWN) || (i == SECRET_TOWN) || (i == caster_ptr->town_num) || !(caster_ptr->visit & (1L << (i - 1))))
+        if ((i == NO_TOWN) || (i == SECRET_TOWN) || (i == caster_ptr->town_num) || !(caster_ptr->visit & (1UL << (i - 1))))
             continue;
 
         sprintf(buf, "%c) %-20s", I2A(i - 1), town_info[i].name);
@@ -291,7 +291,7 @@ bool tele_town(player_type *caster_ptr)
         else if ((i < 'a') || (i > ('a' + max_towns - 2)))
             continue;
         else if (((i - 'a' + 1) == caster_ptr->town_num) || ((i - 'a' + 1) == NO_TOWN) || ((i - 'a' + 1) == SECRET_TOWN)
-            || !(caster_ptr->visit & (1L << (i - 'a'))))
+            || !(caster_ptr->visit & (1UL << (i - 'a'))))
             continue;
         break;
     }

--- a/src/spell-realm/spells-hex.c
+++ b/src/spell-realm/spells-hex.c
@@ -106,7 +106,7 @@ bool stop_hex_spell(player_type *caster_ptr)
         int n = sp[A2I(choice)];
 
         exe_spell(caster_ptr, REALM_HEX, n, SPELL_STOP);
-        casting_hex_flags(caster_ptr) &= ~(1L << n);
+        casting_hex_flags(caster_ptr) &= ~(1UL << n);
         casting_hex_num(caster_ptr)--;
     }
 
@@ -319,6 +319,6 @@ bool multiply_barrier(player_type *caster_ptr, MONSTER_IDX m_idx)
     return TRUE;
 }
 
-bool hex_spelling(player_type *caster_ptr, int hex) { return (caster_ptr->realm1 == REALM_HEX) && (caster_ptr->magic_num1[0] & (1L << (hex))); }
+bool hex_spelling(player_type *caster_ptr, int hex) { return (caster_ptr->realm1 == REALM_HEX) && (caster_ptr->magic_num1[0] & (1UL << (hex))); }
 
 bool hex_spelling_any(player_type *caster_ptr) { return (caster_ptr->realm1 == REALM_HEX) && (caster_ptr->magic_num1[0] != 0); }

--- a/src/spell/spell-info.c
+++ b/src/spell/spell-info.c
@@ -311,13 +311,13 @@ void print_spells(player_type *caster_ptr, SPELL_IDX target_spell, SPELL_IDX *sp
         } else if ((use_realm != caster_ptr->realm1) && (use_realm != caster_ptr->realm2)) {
             comment = _("未知", "unknown");
             line_attr = TERM_L_BLUE;
-        } else if ((use_realm == caster_ptr->realm1) ? ((caster_ptr->spell_forgotten1 & (1L << spell))) : ((caster_ptr->spell_forgotten2 & (1L << spell)))) {
+        } else if ((use_realm == caster_ptr->realm1) ? ((caster_ptr->spell_forgotten1 & (1UL << spell))) : ((caster_ptr->spell_forgotten2 & (1UL << spell)))) {
             comment = _("忘却", "forgotten");
             line_attr = TERM_YELLOW;
-        } else if (!((use_realm == caster_ptr->realm1) ? (caster_ptr->spell_learned1 & (1L << spell)) : (caster_ptr->spell_learned2 & (1L << spell)))) {
+        } else if (!((use_realm == caster_ptr->realm1) ? (caster_ptr->spell_learned1 & (1UL << spell)) : (caster_ptr->spell_learned2 & (1UL << spell)))) {
             comment = _("未知", "unknown");
             line_attr = TERM_L_BLUE;
-        } else if (!((use_realm == caster_ptr->realm1) ? (caster_ptr->spell_worked1 & (1L << spell)) : (caster_ptr->spell_worked2 & (1L << spell)))) {
+        } else if (!((use_realm == caster_ptr->realm1) ? (caster_ptr->spell_worked1 & (1UL << spell)) : (caster_ptr->spell_worked2 & (1UL << spell)))) {
             comment = _("未経験", "untried");
             line_attr = TERM_L_GREEN;
         }

--- a/src/status/shape-changer.c
+++ b/src/status/shape-changer.c
@@ -60,9 +60,9 @@ void change_race(player_type *creature_ptr, player_race_type new_race, concptr e
 
     chg_virtue(creature_ptr, V_CHANCE, 2);
     if (creature_ptr->prace < 32) {
-        creature_ptr->old_race1 |= 1L << creature_ptr->prace;
+        creature_ptr->old_race1 |= 1UL << creature_ptr->prace;
     } else {
-        creature_ptr->old_race2 |= 1L << (creature_ptr->prace - 32);
+        creature_ptr->old_race2 |= 1UL << (creature_ptr->prace - 32);
     }
 
     creature_ptr->prace = new_race;

--- a/src/store/rumor.c
+++ b/src/store/rumor.c
@@ -119,7 +119,7 @@ void display_rumor(player_type *player_ptr, bool ex)
 
         strcpy(fullname, town_info[t_idx].name);
 
-        s32b visit = (1L << (t_idx - 1));
+        s32b visit = (1UL << (t_idx - 1));
         if ((t_idx != SECRET_TOWN) && !(player_ptr->visit & visit)) {
             player_ptr->visit |= visit;
             rumor_eff_format = _("%sに行ったことがある気がする。", "You feel you have been to %s.");

--- a/src/term/z-util.c
+++ b/src/term/z-util.c
@@ -255,9 +255,9 @@ void s64b_div(s32b *A1, u32b *A2, s32b B1, u32b B2)
 		if (s64b_cmp(A1val, A2val, B1, B2) >= 0)
 		{
 			if (bit >= 32)
-				result1 |= (0x00000001L << (bit - 32));
+				result1 |= (0x00000001UL << (bit - 32));
 			else
-				result2 |= (0x00000001L << bit);
+				result2 |= (0x00000001UL << bit);
 
 			s64b_sub(&A1val, &A2val, B1, B2);
 		}

--- a/src/util/bit-flags-calculator.h
+++ b/src/util/bit-flags-calculator.h
@@ -1,7 +1,7 @@
 ﻿#pragma once
 
-#define has_flag(ARRAY, INDEX) !!((ARRAY)[(INDEX) / 32] & (1L << ((INDEX) % 32)))
-#define add_flag(ARRAY, INDEX) ((ARRAY)[(INDEX) / 32] |= (1L << ((INDEX) % 32)))
-#define remove_flag(ARRAY, INDEX) ((ARRAY)[(INDEX) / 32] &= ~(1L << ((INDEX) % 32)))
+#define has_flag(ARRAY, INDEX) !!((ARRAY)[(INDEX) / 32] & (1UL << ((INDEX) % 32)))
+#define add_flag(ARRAY, INDEX) ((ARRAY)[(INDEX) / 32] |= (1UL << ((INDEX) % 32)))
+#define remove_flag(ARRAY, INDEX) ((ARRAY)[(INDEX) / 32] &= ~(1UL << ((INDEX) % 32)))
 #define is_pval_flag(INDEX) ((TR_STR <= (INDEX) && (INDEX) <= TR_MAGIC_MASTERY) || (TR_STEALTH <= (INDEX) && (INDEX) <= TR_BLOWS))
 #define has_pval_flags(ARRAY) !!((ARRAY)[0] & (0x00003f7f))

--- a/src/view/object-describer.c
+++ b/src/view/object-describer.c
@@ -113,7 +113,7 @@ void display_koff(player_type *owner_ptr, KIND_OBJECT_IDX k_idx)
     SPELL_IDX spells[64];
 
     for (int spell = 0; spell < 32; spell++) {
-        if (fake_spell_flags[sval] & (1L << spell)) {
+        if (fake_spell_flags[sval] & (1UL << spell)) {
             spells[num++] = spell;
         }
     }

--- a/src/window/display-sub-window-spells.c
+++ b/src/window/display-sub-window-spells.c
@@ -149,11 +149,11 @@ static void display_spell_list(player_type *caster_ptr)
             if (s_ptr->slevel >= 99) {
                 strcpy(name, _("(判読不能)", "(illegible)"));
                 a = TERM_L_DARK;
-            } else if ((j < 1) ? ((caster_ptr->spell_forgotten1 & (1L << i))) : ((caster_ptr->spell_forgotten2 & (1L << (i % 32))))) {
+            } else if ((j < 1) ? ((caster_ptr->spell_forgotten1 & (1UL << i))) : ((caster_ptr->spell_forgotten2 & (1UL << (i % 32))))) {
                 a = TERM_ORANGE;
-            } else if (!((j < 1) ? (caster_ptr->spell_learned1 & (1L << i)) : (caster_ptr->spell_learned2 & (1L << (i % 32))))) {
+            } else if (!((j < 1) ? (caster_ptr->spell_learned1 & (1UL << i)) : (caster_ptr->spell_learned2 & (1UL << (i % 32))))) {
                 a = TERM_RED;
-            } else if (!((j < 1) ? (caster_ptr->spell_worked1 & (1L << i)) : (caster_ptr->spell_worked2 & (1L << (i % 32))))) {
+            } else if (!((j < 1) ? (caster_ptr->spell_worked1 & (1UL << i)) : (caster_ptr->spell_worked2 & (1UL << (i % 32))))) {
                 a = TERM_YELLOW;
             }
 

--- a/src/window/main-window-stat-poster.c
+++ b/src/window/main-window-stat-poster.c
@@ -20,14 +20,14 @@
  * @param FLG フラグ位置(ビット)
  * @return なし
  */
-#define ADD_BAR_FLAG(FLG) (bar_flags[FLG / 32] |= (1L << (FLG % 32)))
+#define ADD_BAR_FLAG(FLG) (bar_flags[FLG / 32] |= (1UL << (FLG % 32)))
 
 /*!
  * @brief 32ビット変数配列の指定位置のビットフラグが1かどうかを返す。
  * @param FLG フラグ位置(ビット)
  * @return 1ならば0以外を返す
  */
-#define IS_BAR_FLAG(FLG) (bar_flags[FLG / 32] & (1L << (FLG % 32)))
+#define IS_BAR_FLAG(FLG) (bar_flags[FLG / 32] & (1UL << (FLG % 32)))
 
 /*!
  * @brief プレイヤー能力値を描画する / Print character stat in given row, column

--- a/src/wizard/spoiler-table.h
+++ b/src/wizard/spoiler-table.h
@@ -26,7 +26,7 @@ typedef struct grouper {
  * Pair together a constant flag with a textual description.
  * Note that it sometimes more efficient to actually make an array
  * of textual names, where entry 'N' is assumed to be paired with
- * the flag whose value is "1L << N", but that requires hard-coding.
+ * the flag whose value is "1UL << N", but that requires hard-coding.
  */
 typedef struct flag_desc {
     const tr_type flag;

--- a/src/wizard/wizard-spells.c
+++ b/src/wizard/wizard-spells.c
@@ -126,17 +126,17 @@ void wiz_learn_blue_magic_all(player_type *caster_ptr)
 
         int i;
         for (i = 0; i < 32; i++) {
-            if ((0x00000001 << i) & f4)
+            if ((0x00000001U << i) & f4)
                 caster_ptr->magic_num2[i] = 1;
         }
 
         for (; i < 64; i++) {
-            if ((0x00000001 << (i - 32)) & f5)
+            if ((0x00000001U << (i - 32)) & f5)
                 caster_ptr->magic_num2[i] = 1;
         }
 
         for (; i < 96; i++) {
-            if ((0x00000001 << (i - 64)) & f6)
+            if ((0x00000001U << (i - 64)) & f6)
                 caster_ptr->magic_num2[i] = 1;
         }
     }


### PR DESCRIPTION
Fixes #106.

符号付きだとシフト量が 31 のとき符号付きオーバーフローが発生してしまい、
ubsan に怒られる。よって符号なしにする。

変更自体は単純だが、量が多くてチェックが大変なので優先度低めでも良いと思う。

本件がマージされるまでは、`-fno-sanitize=shift-base` を付けることで上記の問題を回避しつつ ubsan を利用できる。