### PR TITLE
[Fix] mbe_info の配列外参照を修正

### DIFF
--- a/src/info-reader/race-info-tokens-table.c
+++ b/src/info-reader/race-info-tokens-table.c
@@ -1,10 +1,12 @@
 ﻿#include "info-reader/race-info-tokens-table.h"
+#include "monster-attack/monster-attack-effect.h"
+#include "monster-attack/monster-attack-types.h"
 
 /*!
   * モンスターの打撃手段トークンの定義 /
   * Monster Blow Methods
   */
-concptr r_info_blow_method[NUM_R_BLOW_METHOD] = {
+concptr r_info_blow_method[NB_RBM_TYPE + 1] = {
 	"",
 	"HIT",
 	"TOUCH",
@@ -38,7 +40,7 @@ concptr r_info_blow_method[NUM_R_BLOW_METHOD] = {
  * モンスターの打撃属性トークンの定義 /
  * Monster Blow Effects
  */
-concptr r_info_blow_effect[NUM_R_BLOW_EFFECT] = {
+concptr r_info_blow_effect[NB_RBE_TYPE + 1] = {
 	"",
 	"HURT",
 	"POISON",

--- a/src/info-reader/race-info-tokens-table.h
+++ b/src/info-reader/race-info-tokens-table.h
@@ -1,9 +1,9 @@
 ﻿#pragma once
 
+#include "monster-attack/monster-attack-effect.h"
+#include "monster-attack/monster-attack-types.h"
 #include "system/angband.h"
 
-#define NUM_R_BLOW_METHOD 27
-#define NUM_R_BLOW_EFFECT 38
 #define NUM_R_FLAGS_1 32
 #define NUM_R_FLAGS_2 32
 #define NUM_R_FLAGS_3 32
@@ -15,8 +15,8 @@
 #define NUM_R_FLAGS_9 33
 #define NUM_R_FLAGS_R 32
 
-extern concptr r_info_blow_method[NUM_R_BLOW_METHOD];
-extern concptr r_info_blow_effect[NUM_R_BLOW_EFFECT];
+extern concptr r_info_blow_method[NB_RBM_TYPE + 1];
+extern concptr r_info_blow_effect[NB_RBE_TYPE + 1];
 extern concptr r_info_flags1[NUM_R_FLAGS_1];
 extern concptr r_info_flags2[NUM_R_FLAGS_2];
 extern concptr r_info_flags3[NUM_R_FLAGS_3];

--- a/src/monster-attack/monster-attack-effect.h
+++ b/src/monster-attack/monster-attack-effect.h
@@ -2,6 +2,9 @@
 
 /*!
  * @note モンスターの攻撃効果 / New monster blow effects
+ *
+ * "Race Blow Effect" の略。
+ * 実装の都合上、0 から始まる連番でなければならない。
  */
 typedef enum rbe_type {
     RBE_NONE = 0,
@@ -41,4 +44,6 @@ typedef enum rbe_type {
     RBE_INERTIA = 34, /*!< モンスターの攻撃効果: 減速させる*/
     RBE_STUN = 35, /*!< モンスターの攻撃効果: 朦朧とさせる*/
     RBE_FLAVOR = 36, /*!< モンスターの攻撃効果: フレーバー(メッセージ表示のみ) */
+
+    NB_RBE_TYPE, /*!< enum バリアント数 */
 } rbe_type;

--- a/src/monster-attack/monster-attack-types.c
+++ b/src/monster-attack/monster-attack-types.c
@@ -177,4 +177,16 @@ const mbe_info_type mbe_info[NB_RBE_TYPE] = {
         60,
         GF_MISSILE,
     }, /* SUPERHURT */
+    {
+        5,
+        GF_MISSILE,
+    }, /* INERTIA */
+    {
+        5,
+        GF_MISSILE,
+    }, /* STUN */
+    {
+        0,
+        GF_NONE,
+    }, /* FLAVOR */
 };

--- a/src/monster-attack/monster-attack-types.c
+++ b/src/monster-attack/monster-attack-types.c
@@ -1,11 +1,12 @@
 ﻿#include "monster-attack/monster-attack-types.h"
+#include "monster-attack/monster-attack-effect.h"
 #include "spell/spell-types.h"
 
 /*!
  * @brief モンスターの打撃効力テーブル /
  * The table of monsters' blow effects
  */
-const mbe_info_type mbe_info[MAX_MBE] = {
+const mbe_info_type mbe_info[NB_RBE_TYPE] = {
     {
         0,
         0,

--- a/src/monster-attack/monster-attack-types.h
+++ b/src/monster-attack/monster-attack-types.h
@@ -1,10 +1,14 @@
 ﻿#pragma once
 
+#include "monster-attack/monster-attack-effect.h"
 #include "system/angband.h"
 
 /*!
  * @note モンスターの打撃方法 / New monster blow methods
  * 打撃の種別に応じて傷と朦朧が発生するかがコメントの通りに決まる
+ *
+ * "Race Blow Method" の略。
+ * 実装の都合上、0 から始まる連番でなければならない。
  */
 typedef enum rbm_type {
     RBM_NONE = 0,
@@ -33,13 +37,13 @@ typedef enum rbm_type {
     RBM_MOAN = 23, /*!< モンスターの攻撃種別:うめく */
     RBM_SHOW = 24, /*!< モンスターの攻撃種別:歌う */
     RBM_SHOOT = 25, /*!< モンスターの攻撃種別:射撃(非打撃) */
-} rbm_type;
 
-#define MAX_MBE 34
+    NB_RBM_TYPE, /*!< enum バリアント数 */
+} rbm_type;
 
 typedef struct mbe_info_type {
     int power; /* The attack "power" */
     int explode_type; /* Explosion effect */
 } mbe_info_type;
 
-extern const mbe_info_type mbe_info[MAX_MBE];
+extern const mbe_info_type mbe_info[NB_RBE_TYPE];


### PR DESCRIPTION
Fixes #105.

mbe_info の配列サイズが足りておらず、INERTIA(減速), STUN(朦朧), FLAVOR(フレーバー) に対応する要素がなかったため、これらの効果の打撃を受けると配列外参照が発生していた。
mbe_info の配列サイズを拡張し、上記3効果に対応する要素を追加した。これで配列外参照が起こらなくなっているはず。

要素の内容:

* FLAVOR はただのフレーバーなので (0, GF_NONE) を設定した。
* INERTIA, STUN は、他のデバフ系効果の power が 0~10 程度なのでとりあえず power=5 とした。また、この効果で爆発するモンスターはいないので、とりあえず explode_type は GF_MISSILE とした。

配列サイズ変更忘れの再発を防ぐため、rbm_type, rbe_type にバリアント数を示すバリアント(接頭辞 `NB_`) を追加し、これを配列サイズ計算に用いることとした。これで少なくとも配列外参照はなくなるが、配列内容の変更忘れまでは防げない。今後の課題。