### PR TITLE
3.0.0.0: minor English edits for src/view

### DIFF
--- a/src/view/display-self-info.c
+++ b/src/view/display-self-info.c
@@ -78,7 +78,7 @@ void display_mimic_race_ability(player_type *creature_ptr, self_info_type *self_
     switch (creature_ptr->mimic_form) {
     case MIMIC_DEMON:
     case MIMIC_DEMON_LORD:
-        sprintf(self_ptr->plev_buf, _("あなたは %d ダメージの地獄か火炎のブレスを吐くことができる。(%d MP)", "You can nether breathe, dam. %d (cost %d)."),
+        sprintf(self_ptr->plev_buf, _("あなたは %d ダメージの地獄か火炎のブレスを吐くことができる。(%d MP)", "You can breathe nether, dam. %d (cost %d)."),
             3 * creature_ptr->lev, 10 + creature_ptr->lev / 3);
 
         self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;

--- a/src/view/display-util.c
+++ b/src/view/display-util.c
@@ -59,7 +59,7 @@ static struct
 };
 #else
 = {
-	{ 1, 10, 25, "Bare hand"},
+	{ 1, 10, 25, "Barehanded"},
 	{ 1, 10, 25, "Two hands"},
 	{ 1, 10, 25, "Right hand"},
 	{ 1, 10, 25, "Left hand"},


### PR DESCRIPTION
- For self information about the demon forms, put "nether" after "breathe" to be more idiomatic and match other messages about breath weapons.
- Replace "Bare hand" with "Barehanded" as character sheet label for fighting without weapons.