### PR TITLE
English autopick adjustments for "junks" to "junk" change

### DIFF
--- a/lib/help/editor.txt
+++ b/lib/help/editor.txt
@@ -186,14 +186,14 @@ Keywords:
   missiles          : Arrows, bolts, and shots match.
   magical devices   : Wands, staffs, rods and scrolls match.
   lights            : Light sources match.
-  junks             : Junk items like Shard of Pottery or etc. match.
+  junk              : Junk items like Shard of Pottery or etc. match.
   corpses or skeletons : Corpses or skeletons of monsters match.
   spellbooks        : All books match.
   favorite weapons  : Weapons suitable for your class (for Priest, Monk,
                       BeastMaster, ForceTrainer, Cavalry, and Ninja)
 
   You may also use keywords which match specified kinds of equipment:
-  weapons, armors, missiles, magical devices, lights, junks, spellbooks, 
+  weapons, armors, missiles, magical devices, lights, junk, spellbooks,
   hafted weapons, shields, bows, rings, amulets, suits, cloaks, helms, 
   gloves, boots.
 
@@ -270,7 +270,7 @@ Special Notes:
    [wanted] [unique monster's] [human] [unreadable] 
    [first realm's] [second realm's] [first] [second] [third] [fourth] 
    [items | weapons | favorite weapons | armors | missiles |
-    magical devices | lights | junks | corpses or skeletons | spellbooks |
+    magical devices | lights | junk | corpses or skeletons | spellbooks |
     hafted weapons | shields | bows | rings | amulets | suits | cloaks |
     helms | gloves | boots] :]
   [[^]part-of-item-name] [#auto-inscription-string]

--- a/lib/pref/pickpref.prf
+++ b/lib/pref/pickpref.prf
@@ -57,8 +57,8 @@ scroll of genocide
 
 ?:[EQU $CLASS Archer]
 # Archers pick up all bones to create arrows from it.
-junks:^broken skull
-junks:^broken bone
+junk:^broken skull
+junk:^broken bone
 corpses or skeletons:skeleton
 
 ?:[EQU $CLASS Magic-Eater]


### PR DESCRIPTION
Make the existing lib/pref/autopick.prf and lib/help/editor.prf consistent with this commit, https://github.com/hengband/hengband/commit/7def7b1376f35c5fa2ccaf393aa72681ef6679ef#diff-927c5529b966f004336ea19da011b8949442e4753146eab1f314ea1b537e533e  , that changed "junks" to "junk" for the autopick key in the source code.

That earlier commit does break backwards compatibility for old autopick preference files that reference the "junks" key.  If that backwards compatibility is desired, then that commit should be reverted back and this pull request should be closed as not being relevant.