### PR TITLE
[Refactor] モンスターの思い出表示のモードをenumに変更

### DIFF
--- a/src/cmd-io/cmd-lore.c
+++ b/src/cmd-io/cmd-lore.c
@@ -170,7 +170,7 @@ void do_cmd_query_symbol(player_type *creature_ptr)
         while (TRUE) {
             if (recall) {
                 screen_save();
-                screen_roff(creature_ptr, who[i], 0);
+                screen_roff(creature_ptr, who[i], MONSTER_LORE_NORMAL);
             }
 
             roff_top(r_idx);

--- a/src/knowledge/knowledge-monsters.c
+++ b/src/knowledge/knowledge-monsters.c
@@ -433,7 +433,7 @@ void do_cmd_knowledge_monsters(player_type *creature_ptr, bool *need_redraw, boo
         case 'R':
         case 'r': {
             if (!visual_list && !visual_only && (mon_idx[mon_cur] > 0)) {
-                screen_roff(creature_ptr, mon_idx[mon_cur], 0);
+                screen_roff(creature_ptr, mon_idx[mon_cur], MONSTER_LORE_NORMAL);
 
                 (void)inkey();
 

--- a/src/lore/lore-util.c
+++ b/src/lore/lore-util.c
@@ -12,14 +12,14 @@ concptr wd_his[3] = { _("それの", "its"), _("彼の", "his"), _("彼女の", 
  */
 hook_c_roff_pf hook_c_roff = c_roff;
 
-lore_type *initialize_lore_type(lore_type *lore_ptr, MONRACE_IDX r_idx, BIT_FLAGS mode)
+lore_type *initialize_lore_type(lore_type *lore_ptr, MONRACE_IDX r_idx, monster_lore_mode mode)
 {
 #ifdef JP
 #else
     lore_ptr->sin = FALSE;
 #endif
     lore_ptr->r_idx = r_idx;
-    lore_ptr->nightmare = ironman_nightmare && !(mode & 0x02);
+    lore_ptr->nightmare = ironman_nightmare && (mode != MONSTER_LORE_DEBUG);
     lore_ptr->r_ptr = &r_info[r_idx];
     lore_ptr->speed = lore_ptr->nightmare ? lore_ptr->r_ptr->speed + 5 : lore_ptr->r_ptr->speed;
     lore_ptr->drop_gold = lore_ptr->r_ptr->r_drop_gold;

--- a/src/lore/lore-util.h
+++ b/src/lore/lore-util.h
@@ -48,11 +48,17 @@ typedef struct lore_type {
     int count;
 } lore_type;
 
+typedef enum monster_lore_mode { 
+    MONSTER_LORE_NORMAL,
+    MONSTER_LORE_RESEARCH,
+    MONSTER_LORE_DEBUG
+} monster_lore_mode;
+
 typedef void (*hook_c_roff_pf)(TERM_COLOR attr, concptr str);
 extern hook_c_roff_pf hook_c_roff;
 
 extern concptr wd_he[3];
 extern concptr wd_his[3];
 
-lore_type *initialize_lore_type(lore_type *lore_ptr, MONRACE_IDX r_idx, BIT_FLAGS mode);
+lore_type *initialize_lore_type(lore_type *lore_ptr, MONRACE_IDX r_idx, monster_lore_mode mode);
 void hooked_roff(concptr str);

--- a/src/lore/monster-lore.c
+++ b/src/lore/monster-lore.c
@@ -118,7 +118,7 @@ static void set_race_flags(lore_type *lore_ptr)
  * left edge of the screen, on a cleared line, in which the recall is
  * to take place.  One extra blank line is left after the recall.
  */
-void process_monster_lore(player_type *player_ptr, MONRACE_IDX r_idx, BIT_FLAGS mode)
+void process_monster_lore(player_type *player_ptr, MONRACE_IDX r_idx, monster_lore_mode mode)
 {
     lore_type tmp_lore;
     lore_type *lore_ptr = initialize_lore_type(&tmp_lore, r_idx, mode);
@@ -127,7 +127,7 @@ void process_monster_lore(player_type *player_ptr, MONRACE_IDX r_idx, BIT_FLAGS 
             lore_ptr->reinforce = TRUE;
     }
 
-    if (cheat_know || (mode & 0x01))
+    if (cheat_know || (mode == MONSTER_LORE_RESEARCH) || (mode == MONSTER_LORE_DEBUG))
         lore_ptr->know_everything = TRUE;
 
     set_drop_flags(lore_ptr);

--- a/src/lore/monster-lore.h
+++ b/src/lore/monster-lore.h
@@ -1,5 +1,6 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include "lore/lore-util.h"
 
-void process_monster_lore(player_type *player_ptr, MONRACE_IDX r_idx, BIT_FLAGS mode);
+void process_monster_lore(player_type *player_ptr, MONRACE_IDX r_idx, monster_lore_mode mode);

--- a/src/market/building-monster.c
+++ b/src/market/building-monster.c
@@ -168,7 +168,7 @@ bool research_mon(player_type *player_ptr)
                 lore_do_probe(player_ptr, r_idx);
                 monster_race_track(player_ptr, r_idx);
                 handle_stuff(player_ptr);
-                screen_roff(player_ptr, r_idx, 0x01);
+                screen_roff(player_ptr, r_idx, MONSTER_LORE_RESEARCH);
                 notpicked = FALSE;
                 old_sym = sym;
                 old_i = i;

--- a/src/target/target-describer.c
+++ b/src/target/target-describer.c
@@ -174,7 +174,7 @@ static process_result describe_hallucinated_target(player_type *subject_ptr, eg_
 static bool describe_grid_lore(player_type *subject_ptr, eg_type *eg_ptr)
 {
     screen_save();
-    screen_roff(subject_ptr, eg_ptr->m_ptr->ap_r_idx, 0);
+    screen_roff(subject_ptr, eg_ptr->m_ptr->ap_r_idx, MONSTER_LORE_NORMAL);
     term_addstr(-1, TERM_WHITE, format(_("  [r思 %s%s]", "  [r,%s%s]"), eg_ptr->x_info, eg_ptr->info));
     eg_ptr->query = inkey();
     screen_load();

--- a/src/view/display-lore.c
+++ b/src/view/display-lore.c
@@ -84,7 +84,7 @@ void roff_top(MONRACE_IDX r_idx)
  * @param mode 表示オプション
  * @return なし
  */
-void screen_roff(player_type *player_ptr, MONRACE_IDX r_idx, BIT_FLAGS mode)
+void screen_roff(player_type *player_ptr, MONRACE_IDX r_idx, monster_lore_mode mode)
 {
     msg_erase();
     term_erase(0, 1, 255);
@@ -108,7 +108,7 @@ void display_roff(player_type *player_ptr)
     term_gotoxy(0, 1);
     hook_c_roff = c_roff;
     MONRACE_IDX r_idx = player_ptr->monster_race_idx;
-    process_monster_lore(player_ptr, r_idx, 0);
+    process_monster_lore(player_ptr, r_idx, MONSTER_LORE_NORMAL);
     roff_top(r_idx);
 }
 
@@ -123,7 +123,7 @@ void display_roff(player_type *player_ptr)
 void output_monster_spoiler(player_type *player_ptr, MONRACE_IDX r_idx, void (*roff_func)(TERM_COLOR attr, concptr str))
 {
     hook_c_roff = roff_func;
-    process_monster_lore(player_ptr, r_idx, 0x03);
+    process_monster_lore(player_ptr, r_idx, MONSTER_LORE_DEBUG);
 }
 
 static bool display_kill_unique(lore_type *lore_ptr)

--- a/src/view/display-lore.h
+++ b/src/view/display-lore.h
@@ -4,7 +4,7 @@
 #include "lore/lore-util.h"
 
 void roff_top(MONRACE_IDX r_idx);
-void screen_roff(player_type *player_ptr, MONRACE_IDX r_idx, BIT_FLAGS mode);
+void screen_roff(player_type *player_ptr, MONRACE_IDX r_idx, monster_lore_mode mode);
 void display_roff(player_type *player_ptr);
 void output_monster_spoiler(player_type *player_ptr, MONRACE_IDX r_idx, void (*roff_func)(TERM_COLOR attr, concptr str));
 void display_kill_numbers(lore_type *lore_ptr);


### PR DESCRIPTION
可読性が厳しかったため、enumにして条件を整理した。
通常用、調査時専用、デバッグ専用の3種類のモードがある。