### PR TITLE
[Fix] アイテム選択時にクラッシュ #117

### DIFF
--- a/src/inventory/floor-item-getter.c
+++ b/src/inventory/floor-item-getter.c
@@ -77,9 +77,6 @@ static bool check_floor_item_tag_aux(player_type *owner_ptr, fis_type *fis_ptr, 
  */
 static bool get_floor_item_tag_inventory(player_type *owner_ptr, fis_type *fis_ptr, char *prev_tag)
 {
-    if ((*prev_tag == '\0') || !command_cmd)
-        return FALSE;
-
     bool flag = FALSE;
     item_use_flag use_flag = (*fis_ptr->cp >= INVEN_MAIN_HAND) ? USE_EQUIP : USE_INVEN;
 
@@ -91,7 +88,7 @@ static bool get_floor_item_tag_inventory(player_type *owner_ptr, fis_type *fis_p
     else
         flag |= !fis_ptr->equip;
 
-    if (!flag) {
+    if (flag) {
         *prev_tag = '\0';
         return FALSE;
     }
@@ -116,8 +113,8 @@ static bool check_floor_item_tag_inventory(player_type *owner_ptr, fis_type *fis
         && (!fis_ptr->equip || (*fis_ptr->cp < INVEN_MAIN_HAND) || (*fis_ptr->cp >= INVEN_TOTAL)))
         return FALSE;
 
-    if (get_floor_item_tag_inventory(owner_ptr, fis_ptr, prev_tag))
-        return TRUE;
+    if ((*prev_tag != '\0') && command_cmd)
+        return get_floor_item_tag_inventory(owner_ptr, fis_ptr, prev_tag);
 
     if (get_item_okay(owner_ptr, *fis_ptr->cp, fis_ptr->tval)) {
         fis_ptr->tval = 0;


### PR DESCRIPTION
コマンド繰り返しでタグ付アイテムを使用する行動を繰り返すとき、個数が0になっても該当アイテムを選択し続けていた。
check_floor_item_tag_inventory()の処理がv2.2.1と異なっていたため、従来の挙動通りになるように再度実装した。
具体的には、コマンド繰り返しでタグ付アイテムの取得に失敗したときに以降の処理を打ち切ってFALSEを返すように変更した。