### PR TITLE
[Feature] mon-info.txtの出力情報を現在のプレイヤー情報に依存させない

### DIFF
--- a/src/view/display-lore.c
+++ b/src/view/display-lore.c
@@ -120,10 +120,14 @@ void display_roff(player_type *player_ptr)
  * @param roff_func 出力処理を行う関数ポインタ
  * @return なし
  */
-void output_monster_spoiler(player_type *player_ptr, MONRACE_IDX r_idx, void (*roff_func)(TERM_COLOR attr, concptr str))
+void output_monster_spoiler(MONRACE_IDX r_idx, void (*roff_func)(TERM_COLOR attr, concptr str))
 {
     hook_c_roff = roff_func;
-    process_monster_lore(player_ptr, r_idx, MONSTER_LORE_DEBUG);
+    player_type dummy;
+
+    dummy.lev = 1;
+    dummy.max_plv = 1;
+    process_monster_lore(&dummy, r_idx, MONSTER_LORE_DEBUG);
 }
 
 static bool display_kill_unique(lore_type *lore_ptr)

--- a/src/view/display-lore.h
+++ b/src/view/display-lore.h
@@ -6,7 +6,7 @@
 void roff_top(MONRACE_IDX r_idx);
 void screen_roff(player_type *player_ptr, MONRACE_IDX r_idx, monster_lore_mode mode);
 void display_roff(player_type *player_ptr);
-void output_monster_spoiler(player_type *player_ptr, MONRACE_IDX r_idx, void (*roff_func)(TERM_COLOR attr, concptr str));
+void output_monster_spoiler(MONRACE_IDX r_idx, void (*roff_func)(TERM_COLOR attr, concptr str));
 void display_kill_numbers(lore_type *lore_ptr);
 bool display_where_to_appear(lore_type *lore_ptr);
 void display_random_move(lore_type *lore_ptr);

--- a/src/wizard/monster-info-spoiler.c
+++ b/src/wizard/monster-info-spoiler.c
@@ -237,7 +237,7 @@ void spoil_mon_info(player_type *player_ptr, concptr fname)
         spoil_out(buf);
         sprintf(buf, "Exp:%ld\n", (long)(r_ptr->mexp));
         spoil_out(buf);
-        output_monster_spoiler(player_ptr, who[i], roff_func);
+        output_monster_spoiler(who[i], roff_func);
         spoil_out(NULL);
     }
 


### PR DESCRIPTION
デバッグ情報の出力が現在のキャラクターの状態に依存していて不安定であった。
将来的にコマンドラインからコールすることも考慮し、依存関係を排除する。