### PR TITLE
[Refactor] scan_floor_items() のモードを表す定数を導入

### DIFF
--- a/src/floor/object-scanner.c
+++ b/src/floor/object-scanner.c
@@ -39,17 +39,17 @@ ITEM_NUMBER scan_floor_items(player_type *owner_ptr, OBJECT_IDX *items, POSITION
         object_type *o_ptr;
         o_ptr = &floor_ptr->o_list[this_o_idx];
         next_o_idx = o_ptr->next_o_idx;
-        if ((mode & 0x01) && !item_tester_okay(owner_ptr, o_ptr, item_tester_tval))
+        if ((mode & SCAN_FLOOR_ITEM_TESTER) && !item_tester_okay(owner_ptr, o_ptr, item_tester_tval))
             continue;
 
-        if ((mode & 0x02) && !(o_ptr->marked & OM_FOUND))
+        if ((mode & SCAN_FLOOR_ONLY_MARKED) && !(o_ptr->marked & OM_FOUND))
             continue;
 
         if (num < 23)
             items[num] = this_o_idx;
 
         num++;
-        if (mode & 0x04)
+        if (mode & SCAN_FLOOR_AT_MOST_ONE)
             break;
     }
 
@@ -110,7 +110,7 @@ COMMAND_CODE show_floor_items(player_type *owner_ptr, int target_item, POSITION 
     bool dont_need_to_show_weights = TRUE;
     term_get_size(&wid, &hgt);
     int len = MAX((*min_width), 20);
-    floor_num = scan_floor_items(owner_ptr, floor_list, y, x, 0x03, item_tester_tval);
+    floor_num = scan_floor_items(owner_ptr, floor_list, y, x, SCAN_FLOOR_ITEM_TESTER | SCAN_FLOOR_ONLY_MARKED, item_tester_tval);
     floor_type *floor_ptr = owner_ptr->current_floor_ptr;
     for (k = 0, i = 0; i < floor_num && i < 23; i++) {
         o_ptr = &floor_ptr->o_list[floor_list[i]];

--- a/src/floor/object-scanner.h
+++ b/src/floor/object-scanner.h
@@ -3,5 +3,14 @@
 #include "object/tval-types.h"
 #include "system/angband.h"
 
+/*!
+ * @brief scan_floor_items() の動作を指定するフラグたち。
+ */
+typedef enum scan_floor_mode {
+    SCAN_FLOOR_ITEM_TESTER = 1U << 0, /*!< item_tester_hook によるフィルタリングを適用する */
+    SCAN_FLOOR_ONLY_MARKED = 1U << 1, /*!< マークされたアイテムのみを対象とする */
+    SCAN_FLOOR_AT_MOST_ONE = 1U << 2, /*!< 高々1つのアイテムしか取得しない */
+} scan_floor_mode;
+
 ITEM_NUMBER scan_floor_items(player_type *owner_ptr, OBJECT_IDX *items, POSITION y, POSITION x, BIT_FLAGS mode, tval_type item_tester_tval);
 COMMAND_CODE show_floor_items(player_type *owner_ptr, int target_item, POSITION y, POSITION x, TERM_LEN *min_width, tval_type item_tester_tval);

--- a/src/inventory/floor-item-getter.c
+++ b/src/inventory/floor-item-getter.c
@@ -46,7 +46,8 @@ static bool check_floor_item_tag_aux(player_type *owner_ptr, fis_type *fis_ptr, 
         return FALSE;
 
     if (*prev_tag && command_cmd) {
-        fis_ptr->floor_num = scan_floor_items(owner_ptr, fis_ptr->floor_list, owner_ptr->y, owner_ptr->x, 0x03, fis_ptr->tval);
+        fis_ptr->floor_num
+            = scan_floor_items(owner_ptr, fis_ptr->floor_list, owner_ptr->y, owner_ptr->x, SCAN_FLOOR_ITEM_TESTER | SCAN_FLOOR_ONLY_MARKED, fis_ptr->tval);
         if (get_tag_floor(owner_ptr->current_floor_ptr, &fis_ptr->k, *prev_tag, fis_ptr->floor_list, fis_ptr->floor_num)) {
             *fis_ptr->cp = 0 - fis_ptr->floor_list[fis_ptr->k];
             fis_ptr->tval = 0;
@@ -246,7 +247,8 @@ bool get_item_floor(player_type *owner_ptr, COMMAND_CODE *cp, concptr pmt, concp
 
     fis_ptr->floor_num = 0;
     if (fis_ptr->floor)
-        fis_ptr->floor_num = scan_floor_items(owner_ptr, fis_ptr->floor_list, owner_ptr->y, owner_ptr->x, 0x03, fis_ptr->tval);
+        fis_ptr->floor_num
+            = scan_floor_items(owner_ptr, fis_ptr->floor_list, owner_ptr->y, owner_ptr->x, SCAN_FLOOR_ITEM_TESTER | SCAN_FLOOR_ONLY_MARKED, fis_ptr->tval);
 
     if ((mode & USE_INVEN) && (fis_ptr->i1 <= fis_ptr->i2))
         fis_ptr->allow_inven = TRUE;
@@ -624,7 +626,8 @@ bool get_item_floor(player_type *owner_ptr, COMMAND_CODE *cp, concptr pmt, concp
                 i = owner_ptr->current_floor_ptr->o_list[i].next_o_idx;
 
             owner_ptr->current_floor_ptr->o_list[i].next_o_idx = o_idx;
-            fis_ptr->floor_num = scan_floor_items(owner_ptr, fis_ptr->floor_list, owner_ptr->y, owner_ptr->x, 0x03, fis_ptr->tval);
+            fis_ptr->floor_num
+                = scan_floor_items(owner_ptr, fis_ptr->floor_list, owner_ptr->y, owner_ptr->x, SCAN_FLOOR_ITEM_TESTER | SCAN_FLOOR_ONLY_MARKED, fis_ptr->tval);
             if (command_see) {
                 screen_load();
                 screen_save();

--- a/src/inventory/player-inventory.c
+++ b/src/inventory/player-inventory.c
@@ -49,7 +49,7 @@ bool can_get_item(player_type *owner_ptr, tval_type tval)
             return TRUE;
 
     OBJECT_IDX floor_list[23];
-    ITEM_NUMBER floor_num = scan_floor_items(owner_ptr, floor_list, owner_ptr->y, owner_ptr->x, 0x03, tval);
+    ITEM_NUMBER floor_num = scan_floor_items(owner_ptr, floor_list, owner_ptr->y, owner_ptr->x, SCAN_FLOOR_ITEM_TESTER | SCAN_FLOOR_ONLY_MARKED, tval);
     return floor_num != 0;
 }
 

--- a/src/target/target-describer.c
+++ b/src/target/target-describer.c
@@ -129,7 +129,7 @@ static void describe_scan_result(player_type *subject_ptr, eg_type *eg_ptr)
     if (!easy_floor)
         return;
 
-    eg_ptr->floor_num = scan_floor_items(subject_ptr, eg_ptr->floor_list, eg_ptr->y, eg_ptr->x, 0x02, 0);
+    eg_ptr->floor_num = scan_floor_items(subject_ptr, eg_ptr->floor_list, eg_ptr->y, eg_ptr->x, SCAN_FLOOR_ONLY_MARKED, 0);
     if (eg_ptr->floor_num > 0)
         eg_ptr->x_info = _("x物 ", "x,");
 }
@@ -512,7 +512,7 @@ char examine_grid(player_type *subject_ptr, const POSITION y, const POSITION x, 
     case PROCESS_CONTINUE:
         break;
     }
-    
+
     s16b description_grid = describe_grid(subject_ptr, eg_ptr);
     if (within_char_util(description_grid))
         return (char)description_grid;


### PR DESCRIPTION
即値指定で呼び出されており、可読性に問題があったため。