### PR TITLE
[Feature] Spoiler File出力関数のplayer_type依存解消

### DIFF
--- a/src/autopick/autopick-matcher.c
+++ b/src/autopick/autopick-matcher.c
@@ -11,20 +11,21 @@
 #include "inventory/inventory-slot-types.h"
 #include "monster-race/monster-race.h"
 #include "monster-race/race-flags1.h"
-#include "perception/object-perception.h"
 #include "object-enchant/item-feeling.h"
+#include "object-enchant/special-object-flags.h"
 #include "object-hook/hook-armor.h"
 #include "object-hook/hook-bow.h"
 #include "object-hook/hook-checker.h"
 #include "object-hook/hook-enchant.h"
 #include "object-hook/hook-quest.h"
 #include "object-hook/hook-weapon.h"
+#include "object/object-info.h"
 #include "object/object-kind.h"
 #include "object/object-stack.h"
 #include "object/object-value.h"
-#include "object/object-info.h"
-#include "object-enchant/special-object-flags.h"
+#include "perception/object-perception.h"
 #include "player/player-realm.h"
+#include "system/floor-type-definition.h"
 #include "util/string-processor.h"
 
 /*
@@ -33,343 +34,264 @@
  */
 bool is_autopick_match(player_type *player_ptr, object_type *o_ptr, autopick_type *entry, concptr o_name)
 {
-	concptr ptr = entry->name;
-	if (IS_FLG(FLG_UNAWARE) && object_is_aware(o_ptr))
-		return FALSE;
+    concptr ptr = entry->name;
+    if (IS_FLG(FLG_UNAWARE) && object_is_aware(o_ptr))
+        return FALSE;
 
-	if (IS_FLG(FLG_UNIDENTIFIED)
-		&& (object_is_known(o_ptr) || (o_ptr->ident & IDENT_SENSE)))
-		return FALSE;
+    if (IS_FLG(FLG_UNIDENTIFIED) && (object_is_known(o_ptr) || (o_ptr->ident & IDENT_SENSE)))
+        return FALSE;
 
-	if (IS_FLG(FLG_IDENTIFIED) && !object_is_known(o_ptr))
-		return FALSE;
+    if (IS_FLG(FLG_IDENTIFIED) && !object_is_known(o_ptr))
+        return FALSE;
 
-	if (IS_FLG(FLG_STAR_IDENTIFIED) &&
-		(!object_is_known(o_ptr) || !object_is_fully_known(o_ptr)))
-		return FALSE;
+    if (IS_FLG(FLG_STAR_IDENTIFIED) && (!object_is_known(o_ptr) || !object_is_fully_known(o_ptr)))
+        return FALSE;
 
-	if (IS_FLG(FLG_BOOSTED))
-	{
-		object_kind *k_ptr = &k_info[o_ptr->k_idx];
-		if (!object_is_melee_weapon(o_ptr))
-			return FALSE;
+    if (IS_FLG(FLG_BOOSTED)) {
+        object_kind *k_ptr = &k_info[o_ptr->k_idx];
+        if (!object_is_melee_weapon(o_ptr))
+            return FALSE;
 
-		if ((o_ptr->dd == k_ptr->dd) && (o_ptr->ds == k_ptr->ds))
-			return FALSE;
+        if ((o_ptr->dd == k_ptr->dd) && (o_ptr->ds == k_ptr->ds))
+            return FALSE;
 
-		if (!object_is_known(o_ptr) && object_is_quest_target(player_ptr, o_ptr))
-		{
-			return FALSE;
-		}
-	}
+        if (!object_is_known(o_ptr) && object_is_quest_target(player_ptr->current_floor_ptr->inside_quest, o_ptr)) {
+            return FALSE;
+        }
+    }
 
-	if (IS_FLG(FLG_MORE_DICE))
-	{
-		if (o_ptr->dd * o_ptr->ds < entry->dice)
-			return FALSE;
-	}
+    if (IS_FLG(FLG_MORE_DICE)) {
+        if (o_ptr->dd * o_ptr->ds < entry->dice)
+            return FALSE;
+    }
 
-	if (IS_FLG(FLG_MORE_BONUS))
-	{
-		if (!object_is_known(o_ptr)) return FALSE;
+    if (IS_FLG(FLG_MORE_BONUS)) {
+        if (!object_is_known(o_ptr))
+            return FALSE;
 
-		if (o_ptr->pval)
-		{
-			if (o_ptr->pval < entry->bonus) return FALSE;
-		}
-		else
-		{
-			if (o_ptr->to_h < entry->bonus &&
-				o_ptr->to_d < entry->bonus &&
-				o_ptr->to_a < entry->bonus &&
-				o_ptr->pval < entry->bonus)
-				return FALSE;
-		}
-	}
+        if (o_ptr->pval) {
+            if (o_ptr->pval < entry->bonus)
+                return FALSE;
+        } else {
+            if (o_ptr->to_h < entry->bonus && o_ptr->to_d < entry->bonus && o_ptr->to_a < entry->bonus && o_ptr->pval < entry->bonus)
+                return FALSE;
+        }
+    }
 
-	if (IS_FLG(FLG_WORTHLESS) && object_value(player_ptr, o_ptr) > 0)
-		return FALSE;
+    if (IS_FLG(FLG_WORTHLESS) && object_value(player_ptr, o_ptr) > 0)
+        return FALSE;
 
-	if (IS_FLG(FLG_ARTIFACT))
-	{
-		if (!object_is_known(o_ptr) || !object_is_artifact(o_ptr))
-			return FALSE;
-	}
+    if (IS_FLG(FLG_ARTIFACT)) {
+        if (!object_is_known(o_ptr) || !object_is_artifact(o_ptr))
+            return FALSE;
+    }
 
-	if (IS_FLG(FLG_EGO))
-	{
-		if (!object_is_ego(o_ptr)) return FALSE;
-		if (!object_is_known(o_ptr) &&
-			!((o_ptr->ident & IDENT_SENSE) && o_ptr->feeling == FEEL_EXCELLENT))
-			return FALSE;
-	}
+    if (IS_FLG(FLG_EGO)) {
+        if (!object_is_ego(o_ptr))
+            return FALSE;
+        if (!object_is_known(o_ptr) && !((o_ptr->ident & IDENT_SENSE) && o_ptr->feeling == FEEL_EXCELLENT))
+            return FALSE;
+    }
 
-	if (IS_FLG(FLG_GOOD))
-	{
-		if (!object_is_equipment(o_ptr)) return FALSE;
-		if (object_is_known(o_ptr))
-		{
-			if (!object_is_nameless(player_ptr, o_ptr))
-				return FALSE;
+    if (IS_FLG(FLG_GOOD)) {
+        if (!object_is_equipment(o_ptr))
+            return FALSE;
+        if (object_is_known(o_ptr)) {
+            if (!object_is_nameless(player_ptr, o_ptr))
+                return FALSE;
 
-			if (o_ptr->to_a <= 0 && (o_ptr->to_h + o_ptr->to_d) <= 0)
-				return FALSE;
-		}
-		else if (o_ptr->ident & IDENT_SENSE)
-		{
-			switch (o_ptr->feeling)
-			{
-			case FEEL_GOOD:
-				break;
+            if (o_ptr->to_a <= 0 && (o_ptr->to_h + o_ptr->to_d) <= 0)
+                return FALSE;
+        } else if (o_ptr->ident & IDENT_SENSE) {
+            switch (o_ptr->feeling) {
+            case FEEL_GOOD:
+                break;
 
-			default:
-				return FALSE;
-			}
-		}
-		else
-		{
-			return FALSE;
-		}
-	}
+            default:
+                return FALSE;
+            }
+        } else {
+            return FALSE;
+        }
+    }
 
-	if (IS_FLG(FLG_NAMELESS))
-	{
-		if (!object_is_equipment(o_ptr)) return FALSE;
-		if (object_is_known(o_ptr))
-		{
-			if (!object_is_nameless(player_ptr, o_ptr))
-				return FALSE;
-		}
-		else if (o_ptr->ident & IDENT_SENSE)
-		{
-			switch (o_ptr->feeling)
-			{
-			case FEEL_AVERAGE:
-			case FEEL_GOOD:
-			case FEEL_BROKEN:
-			case FEEL_CURSED:
-				break;
+    if (IS_FLG(FLG_NAMELESS)) {
+        if (!object_is_equipment(o_ptr))
+            return FALSE;
+        if (object_is_known(o_ptr)) {
+            if (!object_is_nameless(player_ptr, o_ptr))
+                return FALSE;
+        } else if (o_ptr->ident & IDENT_SENSE) {
+            switch (o_ptr->feeling) {
+            case FEEL_AVERAGE:
+            case FEEL_GOOD:
+            case FEEL_BROKEN:
+            case FEEL_CURSED:
+                break;
 
-			default:
-				return FALSE;
-			}
-		}
-		else
-		{
-			return FALSE;
-		}
-	}
+            default:
+                return FALSE;
+            }
+        } else {
+            return FALSE;
+        }
+    }
 
-	if (IS_FLG(FLG_AVERAGE))
-	{
-		if (!object_is_equipment(o_ptr)) return FALSE;
-		if (object_is_known(o_ptr))
-		{
-			if (!object_is_nameless(player_ptr, o_ptr))
-				return FALSE;
+    if (IS_FLG(FLG_AVERAGE)) {
+        if (!object_is_equipment(o_ptr))
+            return FALSE;
+        if (object_is_known(o_ptr)) {
+            if (!object_is_nameless(player_ptr, o_ptr))
+                return FALSE;
 
-			if (object_is_cursed(o_ptr) || object_is_broken(o_ptr))
-				return FALSE;
+            if (object_is_cursed(o_ptr) || object_is_broken(o_ptr))
+                return FALSE;
 
-			if (o_ptr->to_a > 0 || (o_ptr->to_h + o_ptr->to_d) > 0)
-				return FALSE;
-		}
-		else if (o_ptr->ident & IDENT_SENSE)
-		{
-			switch (o_ptr->feeling)
-			{
-			case FEEL_AVERAGE:
-				break;
+            if (o_ptr->to_a > 0 || (o_ptr->to_h + o_ptr->to_d) > 0)
+                return FALSE;
+        } else if (o_ptr->ident & IDENT_SENSE) {
+            switch (o_ptr->feeling) {
+            case FEEL_AVERAGE:
+                break;
 
-			default:
-				return FALSE;
-			}
-		}
-		else
-		{
-			return FALSE;
-		}
-	}
+            default:
+                return FALSE;
+            }
+        } else {
+            return FALSE;
+        }
+    }
 
-	if (IS_FLG(FLG_RARE) && !object_is_rare(o_ptr))
-		return FALSE;
+    if (IS_FLG(FLG_RARE) && !object_is_rare(o_ptr))
+        return FALSE;
 
-	if (IS_FLG(FLG_COMMON) && object_is_rare(o_ptr))
-		return FALSE;
+    if (IS_FLG(FLG_COMMON) && object_is_rare(o_ptr))
+        return FALSE;
 
-	if (IS_FLG(FLG_WANTED) && !object_is_bounty(player_ptr, o_ptr))
-		return FALSE;
+    if (IS_FLG(FLG_WANTED) && !object_is_bounty(player_ptr, o_ptr))
+        return FALSE;
 
-	if (IS_FLG(FLG_UNIQUE) &&
-		((o_ptr->tval != TV_CORPSE && o_ptr->tval != TV_STATUE) ||
-			!(r_info[o_ptr->pval].flags1 & RF1_UNIQUE)))
-		return FALSE;
+    if (IS_FLG(FLG_UNIQUE) && ((o_ptr->tval != TV_CORPSE && o_ptr->tval != TV_STATUE) || !(r_info[o_ptr->pval].flags1 & RF1_UNIQUE)))
+        return FALSE;
 
-	if (IS_FLG(FLG_HUMAN) &&
-		(o_ptr->tval != TV_CORPSE ||
-			!angband_strchr("pht", r_info[o_ptr->pval].d_char)))
-		return FALSE;
+    if (IS_FLG(FLG_HUMAN) && (o_ptr->tval != TV_CORPSE || !angband_strchr("pht", r_info[o_ptr->pval].d_char)))
+        return FALSE;
 
-	if (IS_FLG(FLG_UNREADABLE) &&
-		(o_ptr->tval < TV_LIFE_BOOK ||
-			check_book_realm(player_ptr, o_ptr->tval, o_ptr->sval)))
-		return FALSE;
+    if (IS_FLG(FLG_UNREADABLE) && (o_ptr->tval < TV_LIFE_BOOK || check_book_realm(player_ptr, o_ptr->tval, o_ptr->sval)))
+        return FALSE;
 
-	if (IS_FLG(FLG_REALM1) && (get_realm1_book(player_ptr) != o_ptr->tval ||
-			player_ptr->pclass == CLASS_SORCERER ||
-			player_ptr->pclass == CLASS_RED_MAGE))
-		return FALSE;
+    if (IS_FLG(FLG_REALM1) && (get_realm1_book(player_ptr) != o_ptr->tval || player_ptr->pclass == CLASS_SORCERER || player_ptr->pclass == CLASS_RED_MAGE))
+        return FALSE;
 
-	if (IS_FLG(FLG_REALM2) && (get_realm2_book(player_ptr) != o_ptr->tval ||
-			player_ptr->pclass == CLASS_SORCERER ||
-			player_ptr->pclass == CLASS_RED_MAGE))
-		return FALSE;
+    if (IS_FLG(FLG_REALM2) && (get_realm2_book(player_ptr) != o_ptr->tval || player_ptr->pclass == CLASS_SORCERER || player_ptr->pclass == CLASS_RED_MAGE))
+        return FALSE;
 
-	if (IS_FLG(FLG_FIRST) &&
-		(o_ptr->tval < TV_LIFE_BOOK || 0 != o_ptr->sval))
-		return FALSE;
+    if (IS_FLG(FLG_FIRST) && (o_ptr->tval < TV_LIFE_BOOK || 0 != o_ptr->sval))
+        return FALSE;
 
-	if (IS_FLG(FLG_SECOND) &&
-		(o_ptr->tval < TV_LIFE_BOOK || 1 != o_ptr->sval))
-		return FALSE;
+    if (IS_FLG(FLG_SECOND) && (o_ptr->tval < TV_LIFE_BOOK || 1 != o_ptr->sval))
+        return FALSE;
 
-	if (IS_FLG(FLG_THIRD) &&
-		(o_ptr->tval < TV_LIFE_BOOK || 2 != o_ptr->sval))
-		return FALSE;
+    if (IS_FLG(FLG_THIRD) && (o_ptr->tval < TV_LIFE_BOOK || 2 != o_ptr->sval))
+        return FALSE;
 
-	if (IS_FLG(FLG_FOURTH) &&
-		(o_ptr->tval < TV_LIFE_BOOK || 3 != o_ptr->sval))
-		return FALSE;
+    if (IS_FLG(FLG_FOURTH) && (o_ptr->tval < TV_LIFE_BOOK || 3 != o_ptr->sval))
+        return FALSE;
 
-	if (IS_FLG(FLG_WEAPONS))
-	{
-		if (!object_is_weapon(player_ptr, o_ptr))
-			return FALSE;
-	}
-	else if (IS_FLG(FLG_FAVORITE_WEAPONS))
-	{
-		if (!object_is_favorite(player_ptr, o_ptr))
-			return FALSE;
-	}
-	else if (IS_FLG(FLG_ARMORS))
-	{
-		if (!object_is_armour(player_ptr, o_ptr))
-			return FALSE;
-	}
-	else if (IS_FLG(FLG_MISSILES))
-	{
-		if (!object_is_ammo(o_ptr)) return FALSE;
-	}
-	else if (IS_FLG(FLG_DEVICES))
-	{
-		switch (o_ptr->tval)
-		{
-		case TV_SCROLL: case TV_STAFF: case TV_WAND: case TV_ROD:
-			break;
-		default: return FALSE;
-		}
-	}
-	else if (IS_FLG(FLG_LIGHTS))
-	{
-		if (!(o_ptr->tval == TV_LITE))
-			return FALSE;
-	}
-	else if (IS_FLG(FLG_JUNKS))
-	{
-		switch (o_ptr->tval)
-		{
-		case TV_SKELETON: case TV_BOTTLE:
-		case TV_JUNK: case TV_STATUE:
-			break;
-		default: return FALSE;
-		}
-	}
-	else if (IS_FLG(FLG_CORPSES))
-	{
-		if (o_ptr->tval != TV_CORPSE && o_ptr->tval != TV_SKELETON)
-			return FALSE;
-	}
-	else if (IS_FLG(FLG_SPELLBOOKS))
-	{
-		if (!(o_ptr->tval >= TV_LIFE_BOOK))
-			return FALSE;
-	}
-	else if (IS_FLG(FLG_HAFTED))
-	{
-		if (!(o_ptr->tval == TV_HAFTED))
-			return FALSE;
-	}
-	else if (IS_FLG(FLG_SHIELDS))
-	{
-		if (!(o_ptr->tval == TV_SHIELD))
-			return FALSE;
-	}
-	else if (IS_FLG(FLG_BOWS))
-	{
-		if (!(o_ptr->tval == TV_BOW))
-			return FALSE;
-	}
-	else if (IS_FLG(FLG_RINGS))
-	{
-		if (!(o_ptr->tval == TV_RING))
-			return FALSE;
-	}
-	else if (IS_FLG(FLG_AMULETS))
-	{
-		if (!(o_ptr->tval == TV_AMULET))
-			return FALSE;
-	}
-	else if (IS_FLG(FLG_SUITS))
-	{
-		if (!(o_ptr->tval == TV_DRAG_ARMOR ||
-			o_ptr->tval == TV_HARD_ARMOR ||
-			o_ptr->tval == TV_SOFT_ARMOR))
-			return FALSE;
-	}
-	else if (IS_FLG(FLG_CLOAKS))
-	{
-		if (!(o_ptr->tval == TV_CLOAK))
-			return FALSE;
-	}
-	else if (IS_FLG(FLG_HELMS))
-	{
-		if (!(o_ptr->tval == TV_CROWN || o_ptr->tval == TV_HELM))
-			return FALSE;
-	}
-	else if (IS_FLG(FLG_GLOVES))
-	{
-		if (!(o_ptr->tval == TV_GLOVES))
-			return FALSE;
-	}
-	else if (IS_FLG(FLG_BOOTS))
-	{
-		if (!(o_ptr->tval == TV_BOOTS))
-			return FALSE;
-	}
+    if (IS_FLG(FLG_WEAPONS)) {
+        if (!object_is_weapon(player_ptr, o_ptr))
+            return FALSE;
+    } else if (IS_FLG(FLG_FAVORITE_WEAPONS)) {
+        if (!object_is_favorite(player_ptr, o_ptr))
+            return FALSE;
+    } else if (IS_FLG(FLG_ARMORS)) {
+        if (!object_is_armour(player_ptr, o_ptr))
+            return FALSE;
+    } else if (IS_FLG(FLG_MISSILES)) {
+        if (!object_is_ammo(o_ptr))
+            return FALSE;
+    } else if (IS_FLG(FLG_DEVICES)) {
+        switch (o_ptr->tval) {
+        case TV_SCROLL:
+        case TV_STAFF:
+        case TV_WAND:
+        case TV_ROD:
+            break;
+        default:
+            return FALSE;
+        }
+    } else if (IS_FLG(FLG_LIGHTS)) {
+        if (!(o_ptr->tval == TV_LITE))
+            return FALSE;
+    } else if (IS_FLG(FLG_JUNKS)) {
+        switch (o_ptr->tval) {
+        case TV_SKELETON:
+        case TV_BOTTLE:
+        case TV_JUNK:
+        case TV_STATUE:
+            break;
+        default:
+            return FALSE;
+        }
+    } else if (IS_FLG(FLG_CORPSES)) {
+        if (o_ptr->tval != TV_CORPSE && o_ptr->tval != TV_SKELETON)
+            return FALSE;
+    } else if (IS_FLG(FLG_SPELLBOOKS)) {
+        if (!(o_ptr->tval >= TV_LIFE_BOOK))
+            return FALSE;
+    } else if (IS_FLG(FLG_HAFTED)) {
+        if (!(o_ptr->tval == TV_HAFTED))
+            return FALSE;
+    } else if (IS_FLG(FLG_SHIELDS)) {
+        if (!(o_ptr->tval == TV_SHIELD))
+            return FALSE;
+    } else if (IS_FLG(FLG_BOWS)) {
+        if (!(o_ptr->tval == TV_BOW))
+            return FALSE;
+    } else if (IS_FLG(FLG_RINGS)) {
+        if (!(o_ptr->tval == TV_RING))
+            return FALSE;
+    } else if (IS_FLG(FLG_AMULETS)) {
+        if (!(o_ptr->tval == TV_AMULET))
+            return FALSE;
+    } else if (IS_FLG(FLG_SUITS)) {
+        if (!(o_ptr->tval == TV_DRAG_ARMOR || o_ptr->tval == TV_HARD_ARMOR || o_ptr->tval == TV_SOFT_ARMOR))
+            return FALSE;
+    } else if (IS_FLG(FLG_CLOAKS)) {
+        if (!(o_ptr->tval == TV_CLOAK))
+            return FALSE;
+    } else if (IS_FLG(FLG_HELMS)) {
+        if (!(o_ptr->tval == TV_CROWN || o_ptr->tval == TV_HELM))
+            return FALSE;
+    } else if (IS_FLG(FLG_GLOVES)) {
+        if (!(o_ptr->tval == TV_GLOVES))
+            return FALSE;
+    } else if (IS_FLG(FLG_BOOTS)) {
+        if (!(o_ptr->tval == TV_BOOTS))
+            return FALSE;
+    }
 
-	if (*ptr == '^')
-	{
-		ptr++;
-		if (strncmp(o_name, ptr, strlen(ptr))) return FALSE;
-	}
-	else
-	{
-		if (!angband_strstr(o_name, ptr)) return FALSE;
-	}
+    if (*ptr == '^') {
+        ptr++;
+        if (strncmp(o_name, ptr, strlen(ptr)))
+            return FALSE;
+    } else {
+        if (!angband_strstr(o_name, ptr))
+            return FALSE;
+    }
 
-	if (!IS_FLG(FLG_COLLECTING)) return TRUE;
+    if (!IS_FLG(FLG_COLLECTING))
+        return TRUE;
 
-	for (int j = 0; j < INVEN_PACK; j++)
-	{
-		/*
-		 * 'Collecting' means the item must be absorbed
-		 * into an inventory slot.
-		 * But an item can not be absorbed into itself!
-		 */
-		if ((&player_ptr->inventory_list[j] != o_ptr) &&
-			object_similar(&player_ptr->inventory_list[j], o_ptr))
-			return TRUE;
-	}
+    for (int j = 0; j < INVEN_PACK; j++) {
+        /*
+         * 'Collecting' means the item must be absorbed
+         * into an inventory slot.
+         * But an item can not be absorbed into itself!
+         */
+        if ((&player_ptr->inventory_list[j] != o_ptr) && object_similar(&player_ptr->inventory_list[j], o_ptr))
+            return TRUE;
+    }
 
-	return FALSE;
+    return FALSE;
 }

--- a/src/flavor/flavor-describer.c
+++ b/src/flavor/flavor-describer.c
@@ -28,6 +28,7 @@
 #include "player/player-status-table.h"
 #include "specific-object/bow.h"
 #include "sv-definition/sv-lite-types.h"
+#include "system/floor-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "util/string-processor.h"
 #include "window/display-sub-window-items.h"
@@ -113,7 +114,7 @@ static void decide_tval_show(player_type *player_ptr, flavor_type *flavor_ptr)
 
 static void describe_digging(player_type *player_ptr, flavor_type *flavor_ptr)
 {
-    if (object_is_quest_target(player_ptr, flavor_ptr->o_ptr) && !flavor_ptr->known)
+    if (!flavor_ptr->known && object_is_quest_target(player_ptr->current_floor_ptr->inside_quest, flavor_ptr->o_ptr))
         return;
 
     flavor_ptr->t = object_desc_chr(flavor_ptr->t, ' ');
@@ -135,9 +136,12 @@ static void describe_bow(player_type *player_ptr, flavor_type *flavor_ptr)
     flavor_ptr->t = object_desc_chr(flavor_ptr->t, 'x');
     flavor_ptr->t = object_desc_num(flavor_ptr->t, flavor_ptr->power);
     flavor_ptr->t = object_desc_chr(flavor_ptr->t, flavor_ptr->p2);
-    flavor_ptr->fire_rate = calc_num_fire(player_ptr, flavor_ptr->o_ptr);
-    if ((flavor_ptr->fire_rate == 0) || (flavor_ptr->power <= 0) || !flavor_ptr->known)
-        return;
+
+    if (!(flavor_ptr->mode & OD_DEBUG)) {
+        flavor_ptr->fire_rate = calc_num_fire(player_ptr, flavor_ptr->o_ptr);
+        if ((flavor_ptr->fire_rate == 0) || (flavor_ptr->power <= 0) || !flavor_ptr->known)
+            return;
+    }
 
     flavor_ptr->fire_rate = bow_energy(flavor_ptr->o_ptr->sval) / flavor_ptr->fire_rate;
     flavor_ptr->t = object_desc_chr(flavor_ptr->t, ' ');
@@ -489,12 +493,14 @@ void describe_flavor(player_type *player_ptr, char *buf, object_type *o_ptr, BIT
     decide_tval_show(player_ptr, flavor_ptr);
     describe_tval(player_ptr, flavor_ptr);
     describe_named_item_tval(flavor_ptr);
-    flavor_ptr->bow_ptr = &player_ptr->inventory_list[INVEN_BOW];
-    if ((flavor_ptr->bow_ptr->k_idx != 0) && (flavor_ptr->o_ptr->tval == bow_tval_ammo(flavor_ptr->bow_ptr)))
-        describe_bow_power(player_ptr, flavor_ptr);
-    else if ((player_ptr->pclass == CLASS_NINJA) && (flavor_ptr->o_ptr->tval == TV_SPIKE))
-        describe_spike_power(player_ptr, flavor_ptr);
-
+    if (!(mode & OD_DEBUG)) {
+        flavor_ptr->bow_ptr = &player_ptr->inventory_list[INVEN_BOW];
+        if ((flavor_ptr->bow_ptr->k_idx != 0) && (flavor_ptr->o_ptr->tval == bow_tval_ammo(flavor_ptr->bow_ptr)))
+            describe_bow_power(player_ptr, flavor_ptr);
+        else if ((player_ptr->pclass == CLASS_NINJA) && (flavor_ptr->o_ptr->tval == TV_SPIKE))
+            describe_spike_power(player_ptr, flavor_ptr);
+    }
+    
     describe_ac(flavor_ptr);
     if (flavor_ptr->mode & OD_NAME_AND_ENCHANT) {
         angband_strcpy(flavor_ptr->buf, flavor_ptr->tmp_val, MAX_NLEN);

--- a/src/flavor/object-flavor-types.h
+++ b/src/flavor/object-flavor-types.h
@@ -1,12 +1,13 @@
 ﻿#pragma once
 
 typedef enum object_description_type {
-	OD_NAME_ONLY = 0x00000001, /* Omit values, pval, inscription */
-	OD_NAME_AND_ENCHANT = 0x00000002, /* Omit pval, inscription */
-	OD_OMIT_INSCRIPTION = 0x00000004, /* Omit inscription */
-	OD_OMIT_PREFIX = 0x00000008, /* Omit numeric prefix */
-	OD_NO_PLURAL = 0x00000010, /* Don't use plural */
-	OD_STORE = 0x00000020, /* Assume to be aware and known */
-	OD_NO_FLAVOR = 0x00000040, /* Allow to hidden flavor */
-	OD_FORCE_FLAVOR = 0x00000080, /* Get un-shuffled flavor name */
+    OD_NAME_ONLY = 0x00000001, /* Omit values, pval, inscription */
+    OD_NAME_AND_ENCHANT = 0x00000002, /* Omit pval, inscription */
+    OD_OMIT_INSCRIPTION = 0x00000004, /* Omit inscription */
+    OD_OMIT_PREFIX = 0x00000008, /* Omit numeric prefix */
+    OD_NO_PLURAL = 0x00000010, /* Don't use plural */
+    OD_STORE = 0x00000020, /* Assume to be aware and known */
+    OD_NO_FLAVOR = 0x00000040, /* Allow to hidden flavor */
+    OD_FORCE_FLAVOR = 0x00000080, /* Get un-shuffled flavor name */
+    OD_DEBUG = 0x10000000, /* Print for DEBUG */
 } object_description_type;

--- a/src/main-win.c
+++ b/src/main-win.c
@@ -126,6 +126,7 @@
 #include "util/string-processor.h"
 #include "view/display-map.h"
 #include "view/display-messages.h"
+#include "wizard/wizard-spoiler.h"
 #include "world/world.h"
 
 #ifdef WINDOWS

--- a/src/object-hook/hook-quest.c
+++ b/src/object-hook/hook-quest.c
@@ -45,12 +45,12 @@ bool object_is_bounty(player_type *player_ptr, object_type *o_ptr)
  * @param o_ptr 特性短縮表記を得たいオブジェクト構造体の参照ポインタ
  * @return 現在クエスト達成目的のアイテムならばTRUEを返す。
  */
-bool object_is_quest_target(player_type *player_ptr, object_type *o_ptr)
+bool object_is_quest_target(QUEST_IDX quest_idx, object_type *o_ptr)
 {
-    if (player_ptr->current_floor_ptr->inside_quest == 0)
+    if (quest_idx == 0)
         return FALSE;
 
-    ARTIFACT_IDX a_idx = quest[player_ptr->current_floor_ptr->inside_quest].k_idx;
+    ARTIFACT_IDX a_idx = quest[quest_idx].k_idx;
     if (a_idx == 0)
         return FALSE;
 

--- a/src/object-hook/hook-quest.h
+++ b/src/object-hook/hook-quest.h
@@ -3,4 +3,4 @@
 #include "system/angband.h"
 
 bool object_is_bounty(player_type *player_ptr, object_type *o_ptr);
-bool object_is_quest_target(player_type *player_ptr, object_type *o_ptr);
+bool object_is_quest_target(QUEST_IDX quest_idx, object_type *o_ptr);

--- a/src/wizard/artifact-analyzer.c
+++ b/src/wizard/artifact-analyzer.c
@@ -49,7 +49,7 @@ static concptr *spoiler_flag_aux(const BIT_FLAGS art_flags[TR_FLAG_SIZE], const 
  */
 static void analyze_general(player_type *player_ptr, object_type *o_ptr, char *desc_ptr)
 {
-    describe_flavor(player_ptr, desc_ptr, o_ptr, OD_NAME_AND_ENCHANT | OD_STORE);
+    describe_flavor(player_ptr, desc_ptr, o_ptr, OD_NAME_AND_ENCHANT | OD_STORE | OD_DEBUG);
 }
 
 /*!

--- a/src/wizard/cmd-wizard.c
+++ b/src/wizard/cmd-wizard.c
@@ -289,7 +289,7 @@ void do_cmd_debug(player_type *creature_ptr)
         wiz_debug_spell(creature_ptr);
         break;
     case '"':
-        exe_output_spoilers(creature_ptr);
+        exe_output_spoilers();
         break;
     case '?':
         do_cmd_help(creature_ptr);

--- a/src/wizard/fixed-artifacts-spoiler.c
+++ b/src/wizard/fixed-artifacts-spoiler.c
@@ -146,8 +146,9 @@ static void spoiler_print_art(obj_desc_list *art_ptr)
  * @param fname 生成ファイル名
  * @return なし
  */
-void spoil_fixed_artifact(player_type *player_ptr, concptr fname)
+void spoil_fixed_artifact(concptr fname)
 {
+    player_type dummy;
     object_type forge;
     object_type *q_ptr;
     obj_desc_list artifact;
@@ -174,10 +175,10 @@ void spoil_fixed_artifact(player_type *player_ptr, concptr fname)
 
             q_ptr = &forge;
             object_wipe(q_ptr);
-            if (!make_fake_artifact(player_ptr, q_ptr, j))
+            if (!make_fake_artifact(&dummy, q_ptr, j))
                 continue;
 
-            object_analyze(player_ptr, q_ptr, &artifact);
+            object_analyze(&dummy, q_ptr, &artifact);
             spoiler_print_art(&artifact);
         }
     }

--- a/src/wizard/fixed-artifacts-spoiler.h
+++ b/src/wizard/fixed-artifacts-spoiler.h
@@ -3,4 +3,4 @@
 #include "system/angband.h"
 
 void spoiler_outlist(concptr header, concptr *list, char separator);
-void spoil_fixed_artifact(player_type *player_ptr, concptr fname);
+void spoil_fixed_artifact(concptr fname);

--- a/src/wizard/items-spoiler.c
+++ b/src/wizard/items-spoiler.c
@@ -89,8 +89,9 @@ static void kind_info(player_type *player_ptr, char *buf, char *dam, char *wgt, 
  * @param fname ファイル名
  * @return なし
  */
-void spoil_obj_desc(player_type *player_ptr, concptr fname)
+void spoil_obj_desc(concptr fname)
 {
+    player_type dummy;
     char buf[1024];
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, fname);
     spoiler_file = angband_fopen(buf, "w");
@@ -121,8 +122,8 @@ void spoil_obj_desc(player_type *player_ptr, concptr fname)
                         PRICE t1;
                         PRICE t2;
 
-                        kind_info(player_ptr, NULL, NULL, NULL, NULL, &e1, &t1, who[i1]);
-                        kind_info(player_ptr, NULL, NULL, NULL, NULL, &e2, &t2, who[i2]);
+                        kind_info(&dummy, NULL, NULL, NULL, NULL, &e1, &t1, who[i1]);
+                        kind_info(&dummy, NULL, NULL, NULL, NULL, &e2, &t2, who[i2]);
 
                         if ((t1 > t2) || ((t1 == t2) && (e1 > e2))) {
                             u16b tmp = who[i1];
@@ -139,7 +140,7 @@ void spoil_obj_desc(player_type *player_ptr, concptr fname)
                     char wgt[80];
                     char chance[80];
                     char dam[80];
-                    kind_info(player_ptr, buf, dam, wgt, chance, &e, &v, who[s]);
+                    kind_info(&dummy, buf, dam, wgt, chance, &e, &v, who[s]);
                     fprintf(spoiler_file, "  %-35s%8s%7s%5d %-40s%9ld\n", buf, dam, wgt, (int)e, chance, (long)(v));
                 }
 

--- a/src/wizard/items-spoiler.h
+++ b/src/wizard/items-spoiler.h
@@ -2,4 +2,4 @@
 
 #include "system/angband.h"
 
-void spoil_obj_desc(player_type *player_ptr, concptr fname);
+void spoil_obj_desc(concptr fname);

--- a/src/wizard/monster-info-spoiler.c
+++ b/src/wizard/monster-info-spoiler.c
@@ -72,8 +72,9 @@ static concptr attr_to_text(monster_race *r_ptr)
  * @param fname 生成ファイル名
  * @return なし
  */
-void spoil_mon_desc(player_type *player_ptr, concptr fname)
+void spoil_mon_desc(concptr fname)
 {
+    player_type dummy;
     u16b why = 2;
     MONRACE_IDX *who;
     char buf[1024];
@@ -111,7 +112,7 @@ void spoil_mon_desc(player_type *player_ptr, concptr fname)
             who[n++] = (s16b)i;
     }
 
-    ang_sort(player_ptr, who, &why, n, ang_sort_comp_hook, ang_sort_swap_hook);
+    ang_sort(&dummy, who, &why, n, ang_sort_comp_hook, ang_sort_swap_hook);
     for (int i = 0; i < n; i++) {
         monster_race *r_ptr = &r_info[who[i]];
         concptr name = (r_name + r_ptr->name);
@@ -169,8 +170,9 @@ static void roff_func(TERM_COLOR attr, concptr str)
  * @param fname ファイル名
  * @return なし
  */
-void spoil_mon_info(player_type *player_ptr, concptr fname)
+void spoil_mon_info(concptr fname)
 {
+    player_type dummy;
     char buf[1024];
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, fname);
     spoiler_file = angband_fopen(buf, "w");
@@ -195,7 +197,7 @@ void spoil_mon_info(player_type *player_ptr, concptr fname)
     }
 
     u16b why = 2;
-    ang_sort(player_ptr, who, &why, n, ang_sort_comp_hook, ang_sort_swap_hook);
+    ang_sort(&dummy, who, &why, n, ang_sort_comp_hook, ang_sort_swap_hook);
     for (int i = 0; i < n; i++) {
         monster_race *r_ptr = &r_info[who[i]];
         BIT_FLAGS flags1 = r_ptr->flags1;

--- a/src/wizard/monster-info-spoiler.h
+++ b/src/wizard/monster-info-spoiler.h
@@ -2,5 +2,5 @@
 
 #include "system/angband.h"
 
-void spoil_mon_desc(player_type *player_ptr, concptr fname);
-void spoil_mon_info(player_type *player_ptr, concptr fname);
+void spoil_mon_desc(concptr fname);
+void spoil_mon_info(concptr fname);

--- a/src/wizard/wizard-spoiler.c
+++ b/src/wizard/wizard-spoiler.c
@@ -79,10 +79,11 @@ static bool is_partial_tree(int *tree, int *partial_tree)
  * @param fname 出力ファイル名
  * @return なし
  */
-static void spoil_mon_evol(player_type *player_ptr, concptr fname)
+static void spoil_mon_evol(concptr fname)
 {
     char buf[1024];
     monster_race *r_ptr;
+    player_type dummy;
     int **evol_tree, i, j, n, r_idx;
     int *evol_tree_zero; /* For C_KILL() */
     path_build(buf, sizeof buf, ANGBAND_DIR_USER, fname);
@@ -135,7 +136,7 @@ static void spoil_mon_evol(player_type *player_ptr, concptr fname)
         }
     }
 
-    ang_sort(player_ptr, evol_tree, NULL, max_r_idx, ang_sort_comp_evol_tree, ang_sort_swap_evol_tree);
+    ang_sort(&dummy, evol_tree, NULL, max_r_idx, ang_sort_comp_evol_tree, ang_sort_swap_evol_tree);
     for (i = 0; i < max_r_idx; i++) {
         r_idx = evol_tree[i][0];
         if (!r_idx)
@@ -168,7 +169,7 @@ static void spoil_mon_evol(player_type *player_ptr, concptr fname)
  * Create Spoiler files -BEN-
  * @return なし
  */
-void exe_output_spoilers(player_type *player_ptr)
+void exe_output_spoilers(void)
 {
     screen_save();
     while (TRUE) {
@@ -185,19 +186,19 @@ void exe_output_spoilers(player_type *player_ptr)
             screen_load();
             return;
         case '1':
-            spoil_obj_desc(player_ptr, "obj-desc.txt");
+            spoil_obj_desc("obj-desc.txt");
             break;
         case '2':
-            spoil_fixed_artifact(player_ptr, "artifact.txt");
+            spoil_fixed_artifact("artifact.txt");
             break;
         case '3':
-            spoil_mon_desc(player_ptr, "mon-desc.txt");
+            spoil_mon_desc("mon-desc.txt");
             break;
         case '4':
-            spoil_mon_info(player_ptr, "mon-info.txt");
+            spoil_mon_info("mon-info.txt");
             break;
         case '5':
-            spoil_mon_evol(player_ptr, "mon-evol.txt");
+            spoil_mon_evol("mon-evol.txt");
             break;
         default:
             bell();

--- a/src/wizard/wizard-spoiler.h
+++ b/src/wizard/wizard-spoiler.h
@@ -2,4 +2,4 @@
 
 #include "system/angband.h"
 
-void exe_output_spoilers(player_type* player_ptr);
+void exe_output_spoilers(void);


### PR DESCRIPTION
exe_output_spoilers()で呼び出されるspoiler file生成関数が現在のplayerの状態に依存している。
この依存関係を解消し、playerの状態に寄らずspoiler fileの出力を一定にした。
必要な部分にdummyのplayer構造体を与える処理、デバッグ出力に不要な処理の排除を行った。