### PR TITLE
[Implement] Windows環境で--output-spoilersオプションの実装

### DIFF
--- a/src/wizard/wizard-spoiler.c
+++ b/src/wizard/wizard-spoiler.c
@@ -217,3 +217,34 @@ void exe_output_spoilers(void)
         msg_erase();
     }
 }
+
+/*!
+ * @brief 全スポイラー出力を行うコマンドのメインルーチン /
+ * Create Spoiler files -BEN-
+ * @return 成功時SPOILER_OUTPUT_SUCCESS / 失敗時エラー状態
+ */
+spoiler_output_status output_all_spoilers(void)
+{
+    spoiler_output_status status;
+    status = spoil_obj_desc("obj-desc.txt");
+    if (status != SPOILER_OUTPUT_SUCCESS)
+        return status;
+
+    status = spoil_fixed_artifact("artifact.txt");
+    if (status != SPOILER_OUTPUT_SUCCESS)
+        return status;
+
+    status = spoil_mon_desc("mon-desc.txt");
+    if (status != SPOILER_OUTPUT_SUCCESS)
+        return status;
+
+    status = spoil_mon_info("mon-info.txt");
+    if (status != SPOILER_OUTPUT_SUCCESS)
+        return status;
+
+    status = spoil_mon_evol("mon-evol.txt");
+    if (status != SPOILER_OUTPUT_SUCCESS)
+        return status;
+
+    return SPOILER_OUTPUT_SUCCESS;
+}

--- a/src/wizard/wizard-spoiler.h
+++ b/src/wizard/wizard-spoiler.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include "wizard/spoiler-util.h"
 
 void exe_output_spoilers(void);
+spoiler_output_status output_all_spoilers(void);


### PR DESCRIPTION
全スポイラーを出力するoutput_all_spoilers()を実装した。
コマンドラインオプションが--output-spoilersのとき、これをコールしてアプリケーションを終了する。