### PR TITLE
[Feature] Debugセーブのメッセージログを40行に制限

### DIFF
--- a/src/save/save.c
+++ b/src/save/save.c
@@ -94,7 +94,7 @@ static bool wr_savefile_new(player_type *player_ptr, save_type type)
     wr_randomizer();
     wr_options(type);
     u32b tmp32u = message_num();
-    if (compress_savefile && (tmp32u > 40))
+    if ((compress_savefile || (type == SAVE_TYPE_DEBUG)) && (tmp32u > 40))
         tmp32u = 40;
 
     wr_u32b(tmp32u);


### PR DESCRIPTION
Debugセーブのパフォーマンスを改善するため、セーブファイルの容量の大半を占めるメッセージログをcompress_savefile使用時と同じ40行に制限した。
この変更によりsave/log内に自動生成されるセーブファイルには40行を越えるメッセージは保存されなくなる。
通常セーブに関する挙動は変更しない。