### PR TITLE
[feature] ゲーム画面無しでゲームデータ初期化を行うスイッチ

### DIFF
--- a/src/main-win.c
+++ b/src/main-win.c
@@ -3611,7 +3611,7 @@ int PASCAL WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPSTR lpCmdLine, int nC
 
     signals_init();
     term_activate(term_screen);
-    init_angband(p_ptr, process_autopick_file_command);
+    init_angband(p_ptr, process_autopick_file_command, FALSE);
     initialized = TRUE;
     check_for_save_file(p_ptr, lpCmdLine);
     prt(_("[ファイル] メニューの [新規] または [開く] を選択してください。", "[Choose 'New' or 'Open' from the 'File' menu]"), 23, _(8, 17));

--- a/src/main.c
+++ b/src/main.c
@@ -532,7 +532,7 @@ int main(int argc, char *argv[])
     signals_init();
 
     /* Initialize */
-    init_angband(p_ptr, process_autopick_file_command);
+    init_angband(p_ptr, process_autopick_file_command, FALSE);
 
     /* Wait for response */
     pause_line(23);

--- a/src/main/angband-initializer.h
+++ b/src/main/angband-initializer.h
@@ -15,7 +15,7 @@
 #include "system/angband.h"
 
 typedef void (*process_autopick_file_command_pf)(char *);
-void init_angband(player_type *player_ptr, process_autopick_file_command_pf process_autopick_file_command);
+void init_angband(player_type *player_ptr, process_autopick_file_command_pf process_autopick_file_command, bool no_term);
 void init_file_paths(char *path, char *varpath);
 
 #endif /* INCLUDED_INIT_H */


### PR DESCRIPTION
現在のゲームデータ初期化関数init_angband()は、ゲーム画面がすでに
存在する事を前提としている。
スポイラーを出力するにはゲームデータの初期化を行う必要があるので、
コマンドラインからスポイラーを出力して終了する機能を実装するにあたり、
ゲーム画面が必須となるのは具合が悪い。
init_angbandの第3引数(仮引数名no_term)にTRUEを渡すことでゲーム画面無しでも
ゲームデータの初期化を行えるようにする。