### PR TITLE
[Fix] モンスターの経験値表示に不具合 #155

### DIFF
--- a/src/view/display-lore.c
+++ b/src/view/display-lore.c
@@ -371,14 +371,17 @@ void display_monster_exp(player_type *player_ptr, lore_type *lore_ptr)
 #ifdef JP
     hooked_roff("を倒すことは");
 #endif
-    long exp_integer = (long)lore_ptr->r_ptr->mexp * lore_ptr->r_ptr->level / (player_ptr->max_plv + 2) * 3 / 2;
-    long exp_decimal
-        = ((((long)lore_ptr->r_ptr->mexp * lore_ptr->r_ptr->level % (player_ptr->max_plv + 2) * 3 / 2) * (long)1000 / (player_ptr->max_plv + 2) + 5) / 10);
+
+    int64_t base_exp = lore_ptr->r_ptr->mexp * lore_ptr->r_ptr->level * 3 / 2;
+    int64_t player_factor = player_ptr->max_plv + 2;
+    
+    int64_t exp_integer = base_exp / player_factor;
+    int64_t exp_decimal = ((base_exp % player_factor * 1000 / player_factor) + 5) / 10;
 
 #ifdef JP
-    hooked_roff(format(" %d レベルのキャラクタにとって 約%ld.%02ld ポイントの経験となる。", player_ptr->lev, (long)exp_integer, (long)exp_decimal));
+    hooked_roff(format(" %d レベルのキャラクタにとって 約%ld.%02ld ポイントの経験となる。", player_ptr->lev, exp_integer, exp_decimal));
 #else
-    hooked_roff(format(" is worth about %ld.%02ld point%s", (long)exp_integer, (long)exp_decimal, ((exp_integer == 1) && (exp_decimal == 0)) ? "" : "s"));
+    hooked_roff(format(" is worth about %ld.%02ld point%s", exp_integer, exp_decimal, ((exp_integer == 1) && (exp_decimal == 0)) ? "" : "s"));
 
     char *ordinal;
     ordinal = "th";


### PR DESCRIPTION
display_monster_exp()内で経験値の小数点以下を表示する計算部に誤りがあり、表記が正しくなかった。
経験値補正項の*3/2を余りの計算後にかけていたが、経験値量を*3/2してから余りを取るのが正しい。