### PR TITLE
[Feature] 勝手版のウィンドウフラグ「足元のアイテム一覧」の輸入

### DIFF
--- a/src/autopick/autopick.c
+++ b/src/autopick/autopick.c
@@ -28,6 +28,7 @@
 #include "system/floor-type-definition.h"
 #include "term/screen-processor.h"
 #include "view/display-messages.h"
+#include "window/display-sub-windows.h"
 
 /*
  *  Auto-destroy marked item
@@ -73,6 +74,8 @@ void autopick_delayed_alter(player_type *owner_ptr)
         autopick_delayed_alter_aux(owner_ptr, -item);
         item = next;
     }
+
+    fix_floor_item_list(owner_ptr, owner_ptr->y, owner_ptr->x);
 }
 
 /*

--- a/src/birth/inventory-initializer.c
+++ b/src/birth/inventory-initializer.c
@@ -59,7 +59,7 @@ void wield_all(player_type *creature_ptr)
             inven_item_increase(creature_ptr, item, -1);
             inven_item_optimize(creature_ptr, item);
         } else {
-            floor_item_increase(creature_ptr->current_floor_ptr, 0 - item, -1);
+            floor_item_increase(creature_ptr, 0 - item, -1);
             floor_item_optimize(creature_ptr, 0 - item);
         }
 

--- a/src/cmd-io/cmd-floor.c
+++ b/src/cmd-io/cmd-floor.c
@@ -38,7 +38,7 @@ void do_cmd_target(player_type *creature_ptr)
  */
 void do_cmd_look(player_type *creature_ptr)
 {
-    creature_ptr->window_flags |= PW_MONSTER_LIST;
+    creature_ptr->window_flags |= (PW_MONSTER_LIST | PW_FLOOR_ITEM_LIST);
     handle_stuff(creature_ptr);
     if (target_set(creature_ptr, TARGET_LOOK))
         msg_print(_("ターゲット決定。", "Target Selected."));

--- a/src/cmd-io/cmd-gameoption.c
+++ b/src/cmd-io/cmd-gameoption.c
@@ -511,8 +511,7 @@ void do_cmd_options(player_type *player_ptr)
         case 'W':
         case 'w': {
             do_cmd_options_win(player_ptr);
-            player_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER | PW_MESSAGE | PW_OVERHEAD | PW_MONSTER | PW_OBJECT | PW_SNAPSHOT | PW_DUNGEON
-                | PW_MONSTER_LIST);
+            player_ptr->window_flags = PW_ALL;
             break;
         }
         case 'P':

--- a/src/cmd-item/cmd-equipment.c
+++ b/src/cmd-item/cmd-equipment.c
@@ -231,7 +231,7 @@ void do_cmd_wield(player_type *creature_ptr)
         inven_item_increase(creature_ptr, item, -1);
         inven_item_optimize(creature_ptr, item);
     } else {
-        floor_item_increase(creature_ptr->current_floor_ptr, 0 - item, -1);
+        floor_item_increase(creature_ptr, 0 - item, -1);
         floor_item_optimize(creature_ptr, 0 - item);
     }
 

--- a/src/cmd-item/cmd-throw.c
+++ b/src/cmd-item/cmd-throw.c
@@ -182,7 +182,7 @@ static void reflect_inventory_by_throw(player_type *creature_ptr, it_type *it_pt
         it_ptr->return_when_thrown = TRUE;
 
     if (it_ptr->item < 0) {
-        floor_item_increase(creature_ptr->current_floor_ptr, 0 - it_ptr->item, -1);
+        floor_item_increase(creature_ptr, 0 - it_ptr->item, -1);
         floor_item_optimize(creature_ptr, 0 - it_ptr->item);
         return;
     }

--- a/src/core/game-play.c
+++ b/src/core/game-play.c
@@ -293,7 +293,7 @@ static void generate_world(player_type *player_ptr, bool new_game)
 static void init_io(player_type *player_ptr)
 {
     term_xtra(TERM_XTRA_REACT, 0);
-    player_ptr->window_flags |= PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER | PW_MESSAGE | PW_OVERHEAD | PW_DUNGEON | PW_MONSTER | PW_OBJECT;
+    player_ptr->window_flags = PW_ALL;
     handle_stuff(player_ptr);
     if (arg_force_original)
         rogue_like_commands = FALSE;

--- a/src/core/window-redrawer.c
+++ b/src/core/window-redrawer.c
@@ -284,4 +284,9 @@ void window_stuff(player_type *player_ptr)
         player_ptr->window_flags &= ~(PW_OBJECT);
         fix_object(player_ptr);
     }
+
+    if (window_flags & (PW_FLOOR_ITEM_LIST)) {
+        player_ptr->window_flags &= ~(PW_FLOOR_ITEM_LIST);
+        fix_floor_item_list(player_ptr, player_ptr->y, player_ptr->x);
+    }
 }

--- a/src/core/window-redrawer.h
+++ b/src/core/window-redrawer.h
@@ -2,21 +2,23 @@
 
 #include "system/angband.h"
 
+// clang-format off
 typedef enum window_redraw_type {
-    PW_INVEN = 0x00000001L, /*!<サブウィンドウ描画フラグ: 所持品-装備品 / Display inven/equip */
-    PW_EQUIP = 0x00000002L, /*!<サブウィンドウ描画フラグ: 装備品-所持品 / Display equip/inven */
-    PW_SPELL = 0x00000004L, /*!<サブウィンドウ描画フラグ: 魔法一覧 / Display spell list */
-    PW_PLAYER = 0x00000008L, /*!<サブウィンドウ描画フラグ: プレイヤーのステータス / Display character */
+    PW_INVEN        = 0x00000001L, /*!<サブウィンドウ描画フラグ: 所持品-装備品 / Display inven/equip */
+    PW_EQUIP        = 0x00000002L, /*!<サブウィンドウ描画フラグ: 装備品-所持品 / Display equip/inven */
+    PW_SPELL        = 0x00000004L, /*!<サブウィンドウ描画フラグ: 魔法一覧 / Display spell list */
+    PW_PLAYER       = 0x00000008L, /*!<サブウィンドウ描画フラグ: プレイヤーのステータス / Display character */
     PW_MONSTER_LIST = 0x00000010L, /*!<サブウィンドウ描画フラグ: 視界内モンスターの一覧 / Display monster list */
-    PW_MESSAGE = 0x00000040L, /*!<サブウィンドウ描画フラグ: メッセージログ / Display messages */
-    PW_OVERHEAD = 0x00000080L, /*!<サブウィンドウ描画フラグ: 周辺の光景 / Display overhead view */
-    PW_MONSTER = 0x00000100L, /*!<サブウィンドウ描画フラグ: モンスターの思い出 / Display monster recall */
-    PW_OBJECT = 0x00000200L, /*!<サブウィンドウ描画フラグ: アイテムの知識 / Display object recall */
-    PW_DUNGEON = 0x00000400L, /*!<サブウィンドウ描画フラグ: ダンジョンの地形 / Display dungeon view */
-    PW_SNAPSHOT = 0x00000800L, /*!<サブウィンドウ描画フラグ: 記念写真 / Display snap-shot */
+    PW_MESSAGE      = 0x00000040L, /*!<サブウィンドウ描画フラグ: メッセージログ / Display messages */
+    PW_OVERHEAD     = 0x00000080L, /*!<サブウィンドウ描画フラグ: 周辺の光景 / Display overhead view */
+    PW_MONSTER      = 0x00000100L, /*!<サブウィンドウ描画フラグ: モンスターの思い出 / Display monster recall */
+    PW_OBJECT       = 0x00000200L, /*!<サブウィンドウ描画フラグ: アイテムの知識 / Display object recall */
+    PW_DUNGEON      = 0x00000400L, /*!<サブウィンドウ描画フラグ: ダンジョンの地形 / Display dungeon view */
+    PW_SNAPSHOT     = 0x00000800L, /*!<サブウィンドウ描画フラグ: 記念写真 / Display snap-shot */
 
     PW_ALL = (PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER | PW_MONSTER_LIST | PW_MESSAGE | PW_OVERHEAD | PW_MONSTER | PW_OBJECT | PW_DUNGEON | PW_SNAPSHOT),
 } window_redraw_type;
+// clang-format on
 
 void redraw_window(void);
 void window_stuff(player_type *player_ptr);

--- a/src/core/window-redrawer.h
+++ b/src/core/window-redrawer.h
@@ -4,17 +4,17 @@
 
 // clang-format off
 typedef enum window_redraw_type {
-    PW_INVEN        = 0x00000001L, /*!<サブウィンドウ描画フラグ: 所持品-装備品 / Display inven/equip */
-    PW_EQUIP        = 0x00000002L, /*!<サブウィンドウ描画フラグ: 装備品-所持品 / Display equip/inven */
-    PW_SPELL        = 0x00000004L, /*!<サブウィンドウ描画フラグ: 魔法一覧 / Display spell list */
-    PW_PLAYER       = 0x00000008L, /*!<サブウィンドウ描画フラグ: プレイヤーのステータス / Display character */
-    PW_MONSTER_LIST = 0x00000010L, /*!<サブウィンドウ描画フラグ: 視界内モンスターの一覧 / Display monster list */
-    PW_MESSAGE      = 0x00000040L, /*!<サブウィンドウ描画フラグ: メッセージログ / Display messages */
-    PW_OVERHEAD     = 0x00000080L, /*!<サブウィンドウ描画フラグ: 周辺の光景 / Display overhead view */
-    PW_MONSTER      = 0x00000100L, /*!<サブウィンドウ描画フラグ: モンスターの思い出 / Display monster recall */
-    PW_OBJECT       = 0x00000200L, /*!<サブウィンドウ描画フラグ: アイテムの知識 / Display object recall */
-    PW_DUNGEON      = 0x00000400L, /*!<サブウィンドウ描画フラグ: ダンジョンの地形 / Display dungeon view */
-    PW_SNAPSHOT     = 0x00000800L, /*!<サブウィンドウ描画フラグ: 記念写真 / Display snap-shot */
+    PW_INVEN        = 1U <<  0, /*!<サブウィンドウ描画フラグ: 所持品-装備品 / Display inven/equip */
+    PW_EQUIP        = 1U <<  1, /*!<サブウィンドウ描画フラグ: 装備品-所持品 / Display equip/inven */
+    PW_SPELL        = 1U <<  2, /*!<サブウィンドウ描画フラグ: 魔法一覧 / Display spell list */
+    PW_PLAYER       = 1U <<  3, /*!<サブウィンドウ描画フラグ: プレイヤーのステータス / Display character */
+    PW_MONSTER_LIST = 1U <<  4, /*!<サブウィンドウ描画フラグ: 視界内モンスターの一覧 / Display monster list */
+    PW_MESSAGE      = 1U <<  6, /*!<サブウィンドウ描画フラグ: メッセージログ / Display messages */
+    PW_OVERHEAD     = 1U <<  7, /*!<サブウィンドウ描画フラグ: 周辺の光景 / Display overhead view */
+    PW_MONSTER      = 1U <<  8, /*!<サブウィンドウ描画フラグ: モンスターの思い出 / Display monster recall */
+    PW_OBJECT       = 1U <<  9, /*!<サブウィンドウ描画フラグ: アイテムの知識 / Display object recall */
+    PW_DUNGEON      = 1U << 10, /*!<サブウィンドウ描画フラグ: ダンジョンの地形 / Display dungeon view */
+    PW_SNAPSHOT     = 1U << 11, /*!<サブウィンドウ描画フラグ: 記念写真 / Display snap-shot */
 
     PW_ALL = (PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER | PW_MONSTER_LIST | PW_MESSAGE | PW_OVERHEAD | PW_MONSTER | PW_OBJECT | PW_DUNGEON | PW_SNAPSHOT),
 } window_redraw_type;

--- a/src/core/window-redrawer.h
+++ b/src/core/window-redrawer.h
@@ -4,19 +4,20 @@
 
 // clang-format off
 typedef enum window_redraw_type {
-    PW_INVEN        = 1U <<  0, /*!<サブウィンドウ描画フラグ: 所持品-装備品 / Display inven/equip */
-    PW_EQUIP        = 1U <<  1, /*!<サブウィンドウ描画フラグ: 装備品-所持品 / Display equip/inven */
-    PW_SPELL        = 1U <<  2, /*!<サブウィンドウ描画フラグ: 魔法一覧 / Display spell list */
-    PW_PLAYER       = 1U <<  3, /*!<サブウィンドウ描画フラグ: プレイヤーのステータス / Display character */
-    PW_MONSTER_LIST = 1U <<  4, /*!<サブウィンドウ描画フラグ: 視界内モンスターの一覧 / Display monster list */
-    PW_MESSAGE      = 1U <<  6, /*!<サブウィンドウ描画フラグ: メッセージログ / Display messages */
-    PW_OVERHEAD     = 1U <<  7, /*!<サブウィンドウ描画フラグ: 周辺の光景 / Display overhead view */
-    PW_MONSTER      = 1U <<  8, /*!<サブウィンドウ描画フラグ: モンスターの思い出 / Display monster recall */
-    PW_OBJECT       = 1U <<  9, /*!<サブウィンドウ描画フラグ: アイテムの知識 / Display object recall */
-    PW_DUNGEON      = 1U << 10, /*!<サブウィンドウ描画フラグ: ダンジョンの地形 / Display dungeon view */
-    PW_SNAPSHOT     = 1U << 11, /*!<サブウィンドウ描画フラグ: 記念写真 / Display snap-shot */
+    PW_INVEN           = 1U <<  0, /*!<サブウィンドウ描画フラグ: 所持品-装備品 / Display inven/equip */
+    PW_EQUIP           = 1U <<  1, /*!<サブウィンドウ描画フラグ: 装備品-所持品 / Display equip/inven */
+    PW_SPELL           = 1U <<  2, /*!<サブウィンドウ描画フラグ: 魔法一覧 / Display spell list */
+    PW_PLAYER          = 1U <<  3, /*!<サブウィンドウ描画フラグ: プレイヤーのステータス / Display character */
+    PW_MONSTER_LIST    = 1U <<  4, /*!<サブウィンドウ描画フラグ: 視界内モンスターの一覧 / Display monster list */
+    PW_MESSAGE         = 1U <<  6, /*!<サブウィンドウ描画フラグ: メッセージログ / Display messages */
+    PW_OVERHEAD        = 1U <<  7, /*!<サブウィンドウ描画フラグ: 周辺の光景 / Display overhead view */
+    PW_MONSTER         = 1U <<  8, /*!<サブウィンドウ描画フラグ: モンスターの思い出 / Display monster recall */
+    PW_OBJECT          = 1U <<  9, /*!<サブウィンドウ描画フラグ: アイテムの知識 / Display object recall */
+    PW_DUNGEON         = 1U << 10, /*!<サブウィンドウ描画フラグ: ダンジョンの地形 / Display dungeon view */
+    PW_SNAPSHOT        = 1U << 11, /*!<サブウィンドウ描画フラグ: 記念写真 / Display snap-shot */
+    PW_FLOOR_ITEM_LIST = 1U << 12, /*!<サブウィンドウ描画フラグ: 足元のアイテム一覧 / Display items at feet */
 
-    PW_ALL = (PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER | PW_MONSTER_LIST | PW_MESSAGE | PW_OVERHEAD | PW_MONSTER | PW_OBJECT | PW_DUNGEON | PW_SNAPSHOT),
+    PW_ALL = (PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER | PW_MONSTER_LIST | PW_MESSAGE | PW_OVERHEAD | PW_MONSTER | PW_OBJECT | PW_DUNGEON | PW_SNAPSHOT | PW_FLOOR_ITEM_LIST),
 } window_redraw_type;
 // clang-format on
 

--- a/src/floor/floor-object.h
+++ b/src/floor/floor-object.h
@@ -6,7 +6,7 @@
 bool make_object(player_type *owner_ptr, object_type *j_ptr, BIT_FLAGS mode);
 bool make_gold(player_type *player_ptr, object_type *j_ptr);
 void delete_all_items_from_floor(player_type *owner_ptr, POSITION y, POSITION x);
-void floor_item_increase(floor_type *floor_ptr, INVENTORY_IDX item, ITEM_NUMBER num);
+void floor_item_increase(player_type *owner_ptr, INVENTORY_IDX item, ITEM_NUMBER num);
 void floor_item_optimize(player_type *owner_ptr, INVENTORY_IDX item);
 void delete_object_idx(player_type *owner_ptr, OBJECT_IDX o_idx);
 void excise_object_idx(floor_type *floor_ptr, OBJECT_IDX o_idx);

--- a/src/inventory/inventory-object.c
+++ b/src/inventory/inventory-object.c
@@ -24,8 +24,7 @@ void vary_item(player_type *owner_ptr, INVENTORY_IDX item, ITEM_NUMBER num)
         return;
     }
 
-    floor_type *floor_ptr = owner_ptr->current_floor_ptr;
-    floor_item_increase(floor_ptr, 0 - item, num);
+    floor_item_increase(owner_ptr, 0 - item, num);
     floor_item_describe(owner_ptr, 0 - item);
     floor_item_optimize(owner_ptr, 0 - item);
 }

--- a/src/player/player-move.c
+++ b/src/player/player-move.c
@@ -205,6 +205,12 @@ bool move_player_effect(player_type *creature_ptr, POSITION ny, POSITION nx, BIT
     if (!(mpe_mode & MPE_DONT_PICKUP))
         carry(creature_ptr, (mpe_mode & MPE_DO_PICKUP) ? TRUE : FALSE);
 
+    // 自動拾い/自動破壊により足元のアイテムリストが変化した可能性があるので表示を更新。
+    if (!creature_ptr->running) {
+        creature_ptr->window_flags |= PW_FLOOR_ITEM_LIST;
+        window_stuff(creature_ptr);
+    }
+
     if (has_flag(f_ptr->flags, FF_STORE)) {
         disturb(creature_ptr, FALSE, TRUE);
         free_turn(creature_ptr);

--- a/src/spell-kind/spells-enchant.c
+++ b/src/spell-kind/spells-enchant.c
@@ -76,7 +76,7 @@ bool artifact_scroll(player_type *caster_ptr)
             if (item >= 0) {
                 inven_item_increase(caster_ptr, item, 1 - (o_ptr->number));
             } else {
-                floor_item_increase(caster_ptr->current_floor_ptr, 0 - item, 1 - (o_ptr->number));
+                floor_item_increase(caster_ptr, 0 - item, 1 - (o_ptr->number));
             }
         }
 

--- a/src/spell-kind/spells-perception.c
+++ b/src/spell-kind/spells-perception.c
@@ -25,6 +25,7 @@
 #include "player-info/avatar.h"
 #include "system/object-type-definition.h"
 #include "view/display-messages.h"
+#include "window/display-sub-windows.h"
 #include "world/world.h"
 
 /*!
@@ -133,6 +134,7 @@ bool ident_spell(player_type *caster_ptr, bool only_equip, tval_type item_tester
         msg_format(_("ザック中: %s(%c)。", "In your pack: %s (%c)."), o_name, index_to_label(item));
     } else {
         msg_format(_("床上: %s。", "On the ground: %s."), o_name);
+        fix_floor_item_list(caster_ptr, caster_ptr->y, caster_ptr->x);
     }
 
     autopick_alter_item(caster_ptr, item, (bool)(destroy_identify && !old_known));

--- a/src/target/target-setter.c
+++ b/src/target/target-setter.c
@@ -20,6 +20,7 @@
 #include "target/target-types.h"
 #include "term/screen-processor.h"
 #include "util/int-char-converter.h"
+#include "window/display-sub-windows.h"
 #include "window/main-window-util.h"
 
 // Target Setter.
@@ -302,6 +303,9 @@ static bool set_target_grid(player_type *creature_ptr, ts_type *ts_ptr)
         return FALSE;
 
     describe_projectablity(creature_ptr, ts_ptr);
+
+    fix_floor_item_list(creature_ptr, ts_ptr->y, ts_ptr->x);
+
     while (TRUE) {
         ts_ptr->query = examine_grid(creature_ptr, ts_ptr->y, ts_ptr->x, ts_ptr->mode, ts_ptr->info);
         if (ts_ptr->query)
@@ -443,6 +447,8 @@ static void sweep_target_grids(player_type *creature_ptr, ts_type *ts_ptr)
         if ((ts_ptr->mode & TARGET_LOOK) == 0)
             print_path(creature_ptr, ts_ptr->y, ts_ptr->x);
 
+        fix_floor_item_list(creature_ptr, ts_ptr->y, ts_ptr->x);
+
         ts_ptr->g_ptr = &creature_ptr->current_floor_ptr->grid_array[ts_ptr->y][ts_ptr->x];
         strcpy(ts_ptr->info, _("q止 t決 p自 m近 +次 -前", "q,t,p,m,+,-,<dir>"));
         describe_grid_wizard(creature_ptr, ts_ptr);
@@ -475,7 +481,7 @@ bool target_set(player_type *creature_ptr, target_type mode)
     verify_panel(creature_ptr);
     creature_ptr->update |= (PU_MONSTERS);
     creature_ptr->redraw |= (PR_MAP);
-    creature_ptr->window_flags |= (PW_OVERHEAD);
+    creature_ptr->window_flags |= (PW_OVERHEAD | PW_FLOOR_ITEM_LIST);
     handle_stuff(creature_ptr);
     return target_who != 0;
 }

--- a/src/term/gameterm.c
+++ b/src/term/gameterm.c
@@ -123,7 +123,7 @@ const concptr window_flag_desc[32] =
 	_("アイテムの詳細", "Display object recall"),
 	_("自分の周囲を表示", "Display dungeon view"),
 	_("記念撮影", "Display snap-shot"),
-	NULL,
+	_("足元のアイテム一覧", "Display items at feet"),
 	NULL,
 	NULL,
 	NULL,

--- a/src/window/display-sub-windows.h
+++ b/src/window/display-sub-windows.h
@@ -15,4 +15,5 @@ void fix_overhead(player_type *player_ptr);
 void fix_dungeon(player_type *player_ptr);
 void fix_monster(player_type *player_ptr);
 void fix_object(player_type *player_ptr);
+void fix_floor_item_list(player_type *player_ptr, int y, int x);
 void toggle_inventory_equipment(player_type *owner_ptr);


### PR DESCRIPTION
Fixes #127.

一応勝手版のコードに倣って実装してみたが、更新タイミングなど自信のない点もあるのでとりあえず draft とする。

普段は @ の足元が対象となる。look コマンドやターゲッティング動作中はカーソルのあるマスが対象。

BUG: ターゲッティング動作中にサブウィンドウのサイズを変更すると @ の足元表示に切り替わってしまう(勝手版でも同様)。これを修正するにはターゲッティング状況をグローバルに保持しておく必要があり、やや重い変更となるので、当面はそういう仕様ということにしても良いのではと思う。