### PR TITLE
[feature] モンスター一覧表示用のターゲット準備処理 #159

### DIFF
--- a/src/target/grid-selector.c
+++ b/src/target/grid-selector.c
@@ -69,7 +69,7 @@ static void tgt_pt_prepare(player_type *creature_ptr)
         }
     }
 
-    ang_sort(creature_ptr, tmp_pos.x, tmp_pos.y, tmp_pos.n, ang_sort_comp_distance, ang_sort_swap_distance);
+    ang_sort(creature_ptr, tmp_pos.x, tmp_pos.y, tmp_pos.n, ang_sort_comp_distance, ang_sort_swap_position);
 }
 
 /*

--- a/src/target/target-preparation.c
+++ b/src/target/target-preparation.c
@@ -134,9 +134,9 @@ void target_set_prepare(player_type *creature_ptr, BIT_FLAGS mode)
     }
 
     if (mode & (TARGET_KILL)) {
-        ang_sort(creature_ptr, tmp_pos.x, tmp_pos.y, tmp_pos.n, ang_sort_comp_distance, ang_sort_swap_distance);
+        ang_sort(creature_ptr, tmp_pos.x, tmp_pos.y, tmp_pos.n, ang_sort_comp_distance, ang_sort_swap_position);
     } else {
-        ang_sort(creature_ptr, tmp_pos.x, tmp_pos.y, tmp_pos.n, ang_sort_comp_importance, ang_sort_swap_distance);
+        ang_sort(creature_ptr, tmp_pos.x, tmp_pos.y, tmp_pos.n, ang_sort_comp_importance, ang_sort_swap_position);
     }
 
     if (creature_ptr->riding == 0 || !target_pet || (tmp_pos.n <= 1) || !(mode & (TARGET_KILL)))
@@ -168,5 +168,5 @@ void target_sensing_monsters_prepare(player_type *creature_ptr)
         tmp_pos.n++;
     }
 
-    ang_sort(creature_ptr, tmp_pos.x, tmp_pos.y, tmp_pos.n, ang_sort_comp_importance, ang_sort_swap_distance);
+    ang_sort(creature_ptr, tmp_pos.x, tmp_pos.y, tmp_pos.n, ang_sort_comp_importance, ang_sort_swap_position);
 }

--- a/src/target/target-preparation.c
+++ b/src/target/target-preparation.c
@@ -149,3 +149,24 @@ void target_set_prepare(player_type *creature_ptr, BIT_FLAGS mode)
     tmp_pos.x[0] = tmp_pos.x[1];
     tmp_pos.x[1] = tmp;
 }
+
+void target_sensing_monsters_prepare(player_type *creature_ptr)
+{
+    tmp_pos.n = 0;
+
+    // 幻覚時は正常に感知できない
+    if (creature_ptr->image)
+        return;
+
+    for (int i = 1; i < creature_ptr->current_floor_ptr->m_max; i++) {
+        monster_type *m_ptr = &creature_ptr->current_floor_ptr->m_list[i];
+        if (!monster_is_valid(m_ptr) || !m_ptr->ml || is_pet(m_ptr))
+            continue;
+
+        tmp_pos.x[tmp_pos.n] = m_ptr->fx;
+        tmp_pos.y[tmp_pos.n] = m_ptr->fy;
+        tmp_pos.n++;
+    }
+
+    ang_sort(creature_ptr, tmp_pos.x, tmp_pos.y, tmp_pos.n, ang_sort_comp_importance, ang_sort_swap_distance);
+}

--- a/src/target/target-preparation.h
+++ b/src/target/target-preparation.h
@@ -4,3 +4,4 @@
 
 bool target_able(player_type *creature_ptr, MONSTER_IDX m_idx);
 void target_set_prepare(player_type *creature_ptr, BIT_FLAGS mode);
+void target_sensing_monsters_prepare(player_type *creature_ptr);

--- a/src/util/sort.c
+++ b/src/util/sort.c
@@ -203,7 +203,7 @@ bool ang_sort_comp_importance(player_type *player_ptr, vptr u, vptr v, int a, in
  * We use "u" and "v" to point to arrays of "x" and "y" positions,
  * and sort the arrays by distance to the player.
  */
-void ang_sort_swap_distance(player_type *player_ptr, vptr u, vptr v, int a, int b)
+void ang_sort_swap_position(player_type *player_ptr, vptr u, vptr v, int a, int b)
 {
     /* Unused */
     (void)player_ptr;

--- a/src/util/sort.h
+++ b/src/util/sort.h
@@ -7,7 +7,7 @@ void ang_sort(player_type *player_ptr, vptr u, vptr v, int n, bool (*ang_sort_co
 
 bool ang_sort_comp_distance(player_type *player_ptr, vptr u, vptr v, int a, int b);
 bool ang_sort_comp_importance(player_type *player_ptr, vptr u, vptr v, int a, int b);
-void ang_sort_swap_distance(player_type *player_ptr, vptr u, vptr v, int a, int b);
+void ang_sort_swap_position(player_type *player_ptr, vptr u, vptr v, int a, int b);
 
 bool ang_sort_art_comp(player_type *player_ptr, vptr u, vptr v, int a, int b);
 void ang_sort_art_swap(player_type *player_ptr, vptr u, vptr v, int a, int b);

--- a/src/window/display-sub-windows.c
+++ b/src/window/display-sub-windows.c
@@ -189,7 +189,7 @@ void fix_monster_list(player_type *player_ptr)
         term_activate(angband_term[j]);
         int w, h;
         term_get_size(&w, &h);
-        target_set_prepare(player_ptr, TARGET_LOOK);
+        target_sensing_monsters_prepare(player_ptr);
         print_monster_list(player_ptr->current_floor_ptr, 0, 0, h);
         target_clear(player_ptr);
         term_fresh();


### PR DESCRIPTION
サブウィンドウへのモンスター一覧表示にlookの処理を使い回すと副作用が発生するため、専用の処理を作成してそれを使うようにしました。
既存のモンスター一覧表示の仕様は、「画面内に表示されているモンスターの一覧」ですが、これは完全にlookによるターゲッティングの都合（画面外がターゲットされないようにするため）にすぎないと思われるので、新しい処理ではとりあえず感知しているすべてのモンスターの一覧にしました。
したがって、啓蒙などでフロア全体のモンスターが見えているときは、フロア全体のモンスターから一覧が表示されます。この辺の仕様には議論の余地があるかもしれません。