### PR TITLE
[feature] モンスター一覧表示用のターゲット準備処理 #159

### DIFF
--- a/src/target/grid-selector.c
+++ b/src/target/grid-selector.c
@@ -69,7 +69,7 @@ static void tgt_pt_prepare(player_type *creature_ptr)
         }
     }
 
-    ang_sort(creature_ptr, tmp_pos.x, tmp_pos.y, tmp_pos.n, ang_sort_comp_distance, ang_sort_swap_distance);
+    ang_sort(creature_ptr, tmp_pos.x, tmp_pos.y, tmp_pos.n, ang_sort_comp_distance, ang_sort_swap_position);
 }
 
 /*

--- a/src/target/target-preparation.c
+++ b/src/target/target-preparation.c
@@ -134,9 +134,9 @@ void target_set_prepare(player_type *creature_ptr, BIT_FLAGS mode)
     }
 
     if (mode & (TARGET_KILL)) {
-        ang_sort(creature_ptr, tmp_pos.x, tmp_pos.y, tmp_pos.n, ang_sort_comp_distance, ang_sort_swap_distance);
+        ang_sort(creature_ptr, tmp_pos.x, tmp_pos.y, tmp_pos.n, ang_sort_comp_distance, ang_sort_swap_position);
     } else {
-        ang_sort(creature_ptr, tmp_pos.x, tmp_pos.y, tmp_pos.n, ang_sort_comp_importance, ang_sort_swap_distance);
+        ang_sort(creature_ptr, tmp_pos.x, tmp_pos.y, tmp_pos.n, ang_sort_comp_importance, ang_sort_swap_position);
     }
 
     if (creature_ptr->riding == 0 || !target_pet || (tmp_pos.n <= 1) || !(mode & (TARGET_KILL)))
@@ -168,5 +168,5 @@ void target_sensing_monsters_prepare(player_type *creature_ptr)
         tmp_pos.n++;
     }
 
-    ang_sort(creature_ptr, tmp_pos.x, tmp_pos.y, tmp_pos.n, ang_sort_comp_importance, ang_sort_swap_distance);
+    ang_sort(creature_ptr, tmp_pos.x, tmp_pos.y, tmp_pos.n, ang_sort_comp_importance, ang_sort_swap_position);
 }

--- a/src/target/target-preparation.c
+++ b/src/target/target-preparation.c
@@ -150,9 +150,9 @@ void target_set_prepare(player_type *creature_ptr, BIT_FLAGS mode)
     tmp_pos.x[1] = tmp;
 }
 
-void target_sensing_monsters_prepare(player_type *creature_ptr)
+void target_sensing_monsters_prepare(player_type *creature_ptr, pos_list* plist)
 {
-    tmp_pos.n = 0;
+    plist->n = 0;
 
     // 幻覚時は正常に感知できない
     if (creature_ptr->image)
@@ -163,10 +163,10 @@ void target_sensing_monsters_prepare(player_type *creature_ptr)
         if (!monster_is_valid(m_ptr) || !m_ptr->ml || is_pet(m_ptr))
             continue;
 
-        tmp_pos.x[tmp_pos.n] = m_ptr->fx;
-        tmp_pos.y[tmp_pos.n] = m_ptr->fy;
-        tmp_pos.n++;
+        plist->x[plist->n] = m_ptr->fx;
+        plist->y[plist->n] = m_ptr->fy;
+        plist->n++;
     }
 
-    ang_sort(creature_ptr, tmp_pos.x, tmp_pos.y, tmp_pos.n, ang_sort_comp_importance, ang_sort_swap_position);
+    ang_sort(creature_ptr, plist->x, plist->y, plist->n, ang_sort_comp_importance, ang_sort_swap_position);
 }

--- a/src/target/target-preparation.c
+++ b/src/target/target-preparation.c
@@ -149,3 +149,24 @@ void target_set_prepare(player_type *creature_ptr, BIT_FLAGS mode)
     tmp_pos.x[0] = tmp_pos.x[1];
     tmp_pos.x[1] = tmp;
 }
+
+void target_sensing_monsters_prepare(player_type *creature_ptr)
+{
+    tmp_pos.n = 0;
+
+    // 幻覚時は正常に感知できない
+    if (creature_ptr->image)
+        return;
+
+    for (int i = 1; i < creature_ptr->current_floor_ptr->m_max; i++) {
+        monster_type *m_ptr = &creature_ptr->current_floor_ptr->m_list[i];
+        if (!monster_is_valid(m_ptr) || !m_ptr->ml || is_pet(m_ptr))
+            continue;
+
+        tmp_pos.x[tmp_pos.n] = m_ptr->fx;
+        tmp_pos.y[tmp_pos.n] = m_ptr->fy;
+        tmp_pos.n++;
+    }
+
+    ang_sort(creature_ptr, tmp_pos.x, tmp_pos.y, tmp_pos.n, ang_sort_comp_importance, ang_sort_swap_distance);
+}

--- a/src/target/target-preparation.h
+++ b/src/target/target-preparation.h
@@ -2,6 +2,8 @@
 
 #include "system/angband.h"
 
+typedef struct pos_list pos_list;
+
 bool target_able(player_type *creature_ptr, MONSTER_IDX m_idx);
 void target_set_prepare(player_type *creature_ptr, BIT_FLAGS mode);
-void target_sensing_monsters_prepare(player_type *creature_ptr);
+void target_sensing_monsters_prepare(player_type *creature_ptr, pos_list *plist);

--- a/src/target/target-preparation.h
+++ b/src/target/target-preparation.h
@@ -4,3 +4,4 @@
 
 bool target_able(player_type *creature_ptr, MONSTER_IDX m_idx);
 void target_set_prepare(player_type *creature_ptr, BIT_FLAGS mode);
+void target_sensing_monsters_prepare(player_type *creature_ptr);

--- a/src/target/target-setter.c
+++ b/src/target/target-setter.c
@@ -479,10 +479,3 @@ bool target_set(player_type *creature_ptr, target_type mode)
     handle_stuff(creature_ptr);
     return target_who != 0;
 }
-
-void target_clear(player_type *creature_ptr) {
-    ts_type tmp_ts;
-    ts_type *ts_ptr = initialize_target_set_type(creature_ptr, &tmp_ts, TARGET_LOOK);
-    ts_ptr->done = TRUE;
-    tmp_pos.n = 0;
-}

--- a/src/target/target-setter.h
+++ b/src/target/target-setter.h
@@ -4,4 +4,3 @@
 
 typedef enum target_type target_type;
 bool target_set(player_type *creature_ptr, target_type mode);
-void target_clear(player_type *creature_ptr);

--- a/src/util/sort.c
+++ b/src/util/sort.c
@@ -203,7 +203,7 @@ bool ang_sort_comp_importance(player_type *player_ptr, vptr u, vptr v, int a, in
  * We use "u" and "v" to point to arrays of "x" and "y" positions,
  * and sort the arrays by distance to the player.
  */
-void ang_sort_swap_distance(player_type *player_ptr, vptr u, vptr v, int a, int b)
+void ang_sort_swap_position(player_type *player_ptr, vptr u, vptr v, int a, int b)
 {
     /* Unused */
     (void)player_ptr;

--- a/src/util/sort.h
+++ b/src/util/sort.h
@@ -7,7 +7,7 @@ void ang_sort(player_type *player_ptr, vptr u, vptr v, int n, bool (*ang_sort_co
 
 bool ang_sort_comp_distance(player_type *player_ptr, vptr u, vptr v, int a, int b);
 bool ang_sort_comp_importance(player_type *player_ptr, vptr u, vptr v, int a, int b);
-void ang_sort_swap_distance(player_type *player_ptr, vptr u, vptr v, int a, int b);
+void ang_sort_swap_position(player_type *player_ptr, vptr u, vptr v, int a, int b);
 
 bool ang_sort_art_comp(player_type *player_ptr, vptr u, vptr v, int a, int b);
 void ang_sort_art_swap(player_type *player_ptr, vptr u, vptr v, int a, int b);

--- a/src/window/display-sub-windows.c
+++ b/src/window/display-sub-windows.c
@@ -189,9 +189,8 @@ void fix_monster_list(player_type *player_ptr)
         term_activate(angband_term[j]);
         int w, h;
         term_get_size(&w, &h);
-        target_set_prepare(player_ptr, TARGET_LOOK);
+        target_sensing_monsters_prepare(player_ptr);
         print_monster_list(player_ptr->current_floor_ptr, 0, 0, h);
-        target_clear(player_ptr);
         term_fresh();
         term_activate(old);
     }

--- a/src/window/display-sub-windows.c
+++ b/src/window/display-sub-windows.c
@@ -119,15 +119,15 @@ static void print_monster_line(TERM_LEN x, TERM_LEN y, monster_type *m_ptr, int 
  * @param y 表示行
  * @param max_lines 最大何行描画するか
  */
-void print_monster_list(floor_type *floor_ptr, TERM_LEN x, TERM_LEN y, TERM_LEN max_lines)
+void print_monster_list(floor_type *floor_ptr, pos_list *plist, TERM_LEN x, TERM_LEN y, TERM_LEN max_lines)
 {
     TERM_LEN line = y;
     monster_type *last_mons = NULL;
     monster_type *m_ptr = NULL;
     int n_same = 0;
     int i;
-    for (i = 0; i < tmp_pos.n; i++) {
-        grid_type *g_ptr = &floor_ptr->grid_array[tmp_pos.y[i]][tmp_pos.x[i]];
+    for (i = 0; i < plist->n; i++) {
+        grid_type *g_ptr = &floor_ptr->grid_array[plist->y[i]][plist->x[i]];
         if (!g_ptr->m_idx || !floor_ptr->m_list[g_ptr->m_idx].ml)
             continue;
         m_ptr = &floor_ptr->m_list[g_ptr->m_idx];
@@ -158,7 +158,7 @@ void print_monster_list(floor_type *floor_ptr, TERM_LEN x, TERM_LEN y, TERM_LEN 
             break;
     }
 
-    if (line - y - 1 == max_lines && i != tmp_pos.n) {
+    if (line - y - 1 == max_lines && i != plist->n) {
         term_erase(0, line, 255);
         term_gotoxy(x, line);
         term_addstr(-1, TERM_WHITE, "-- and more --");
@@ -177,6 +177,10 @@ void print_monster_list(floor_type *floor_ptr, TERM_LEN x, TERM_LEN y, TERM_LEN 
  */
 void fix_monster_list(player_type *player_ptr)
 {
+    // 副作用を起こさないようにfix_monster_list専用のpos_listを用意する。
+    // サイズが大きいためスタック領域に入れるには懸念があるのでstatic変数とする。
+    static pos_list plist;
+
     for (int j = 0; j < 8; j++) {
         term_type *old = Term;
         if (!angband_term[j])
@@ -189,8 +193,8 @@ void fix_monster_list(player_type *player_ptr)
         term_activate(angband_term[j]);
         int w, h;
         term_get_size(&w, &h);
-        target_sensing_monsters_prepare(player_ptr);
-        print_monster_list(player_ptr->current_floor_ptr, 0, 0, h);
+        target_sensing_monsters_prepare(player_ptr, &plist);
+        print_monster_list(player_ptr->current_floor_ptr, &plist, 0, 0, h);
         term_fresh();
         term_activate(old);
     }

--- a/src/window/display-sub-windows.h
+++ b/src/window/display-sub-windows.h
@@ -3,8 +3,10 @@
 #include "system/angband.h"
 #include "object/tval-types.h"
 
+typedef struct pos_list pos_list;
+
 void fix_inventory(player_type *player_ptr, tval_type item_tester_tval);
-void print_monster_list(floor_type *floor_ptr, TERM_LEN x, TERM_LEN y, TERM_LEN max_lines);
+void print_monster_list(floor_type *floor_ptr, pos_list *plist, TERM_LEN x, TERM_LEN y, TERM_LEN max_lines);
 void fix_monster_list(player_type *player_ptr);
 void fix_equip(player_type *player_ptr, tval_type item_tester_tval);
 void fix_player(player_type *player_ptr);


### PR DESCRIPTION
※ ブランチ名が間違っていたのでRenameしたら勝手にPRがCloseされたので上げ直し。どうやらブランチ名変更に追従はしてくれないらしい。

サブウィンドウへのモンスター一覧表示にlookの処理を使い回すと副作用が発生するため、専用の処理を作成してそれを使うようにしました。
既存のモンスター一覧表示の仕様は、「画面内に表示されているモンスターの一覧」ですが、これは完全にlookによるターゲッティングの都合（画面外がターゲットされないようにするため）にすぎないと思われるので、新しい処理ではとりあえず感知しているすべてのモンスターの一覧にしました。
したがって、啓蒙などでフロア全体のモンスターが見えているときは、フロア全体のモンスターから一覧が表示されます。この辺の仕様には議論の余地があるかもしれません。