### PR TITLE
[Fix] X11 ドライバで視界内モンスターリストウィンドウがリサイズ時に再描画されていなかった

### DIFF
--- a/src/core/window-redrawer.c
+++ b/src/core/window-redrawer.c
@@ -34,9 +34,7 @@ void redraw_window(void)
     if (!current_world_ptr->character_dungeon)
         return;
 
-    p_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER);
-    p_ptr->window_flags |= (PW_MESSAGE | PW_OVERHEAD | PW_DUNGEON | PW_MONSTER | PW_OBJECT);
-    p_ptr->window_flags |= PW_MONSTER_LIST;
+    p_ptr->window_flags = PW_ALL;
 
     handle_stuff(p_ptr);
     term_redraw();

--- a/src/core/window-redrawer.c
+++ b/src/core/window-redrawer.c
@@ -228,7 +228,7 @@ void window_stuff(player_type *player_ptr)
 {
     if (!player_ptr->window_flags)
         return;
-    
+
     BIT_FLAGS mask = 0L;
     for (int j = 0; j < 8; j++) {
         if (angband_term[j] && !angband_term[j]->never_fresh)

--- a/src/core/window-redrawer.c
+++ b/src/core/window-redrawer.c
@@ -36,6 +36,7 @@ void redraw_window(void)
 
     p_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER);
     p_ptr->window_flags |= (PW_MESSAGE | PW_OVERHEAD | PW_DUNGEON | PW_MONSTER | PW_OBJECT);
+    p_ptr->window_flags |= PW_MONSTER_LIST;
 
     handle_stuff(p_ptr);
     term_redraw();

--- a/src/core/window-redrawer.h
+++ b/src/core/window-redrawer.h
@@ -14,6 +14,8 @@ typedef enum window_redraw_type {
     PW_OBJECT = 0x00000200L, /*!<サブウィンドウ描画フラグ: アイテムの知識 / Display object recall */
     PW_DUNGEON = 0x00000400L, /*!<サブウィンドウ描画フラグ: ダンジョンの地形 / Display dungeon view */
     PW_SNAPSHOT = 0x00000800L, /*!<サブウィンドウ描画フラグ: 記念写真 / Display snap-shot */
+
+    PW_ALL = (PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER | PW_MONSTER_LIST | PW_MESSAGE | PW_OVERHEAD | PW_MONSTER | PW_OBJECT | PW_DUNGEON | PW_SNAPSHOT),
 } window_redraw_type;
 
 void redraw_window(void);


### PR DESCRIPTION
例えばサイズを1行まで縮めてから再度拡大すると2行目以降が表示されなくなっていた。

`redraw_window()` で `window_flags` に `PW_MONSTER_LIST` を含めていなかったのが原因なので、そこを修正。
個別のウィンドウフラグの OR をとる方式だと今後ウィンドウフラグを新設したときまた漏れが生じうるので、全ウィンドウフラグの論理和 `PW_ALL` を新設した。

なお、Windows ドライバだと従来のコードでもリサイズ時に再描画が行われていた模様。`term_redraw()` 呼び出しがあるため?