### PR TITLE
Feature/fix priest realm

### DIFF
--- a/src/birth/birth-select-realm.c
+++ b/src/birth/birth-select-realm.c
@@ -106,7 +106,7 @@ static birth_realm_type *initialize_birth_realm_type(birth_realm_type *birth_rea
     return birth_realm_ptr;
 }
 
-static void impose_first_realm(player_type *creature_ptr, s32b choices)
+static void impose_first_realm(player_type *creature_ptr, s32b *choices)
 {
     if (creature_ptr->realm2 == REALM_SELECT_CANCEL)
         return;
@@ -115,9 +115,9 @@ static void impose_first_realm(player_type *creature_ptr, s32b choices)
         return;
 
     if (is_good_realm(creature_ptr->realm1)) {
-        choices &= ~(CH_DEATH | CH_DAEMON);
+        *choices &= ~(CH_DEATH | CH_DAEMON);
     } else {
-        choices &= ~(CH_LIFE | CH_CRUSADE);
+        *choices &= ~(CH_LIFE | CH_CRUSADE);
     }
 }
 
@@ -258,7 +258,7 @@ static byte select_realm(player_type *creature_ptr, s32b choices, int *count)
     if ((*count) < 2)
         return auto_select;
 
-    impose_first_realm(creature_ptr, choices);
+    impose_first_realm(creature_ptr, &choices);
     put_str(_("注意：魔法の領域の選択によりあなたが習得する呪文のタイプが決まります。", "Note: The realm of magic will determine which spells you can learn."),
         23, 5);
 

--- a/src/birth/birth-select-realm.c
+++ b/src/birth/birth-select-realm.c
@@ -23,7 +23,7 @@ typedef struct birth_realm_type {
     int os;
 } birth_realm_type;
 
-static byte count_realm_selection(const s32b choices, int *count)
+static byte count_realm_selection(const u32b choices, int *count)
 {
     byte auto_select = REALM_NONE;
     if (choices & CH_LIFE) {
@@ -106,7 +106,7 @@ static birth_realm_type *initialize_birth_realm_type(birth_realm_type *birth_rea
     return birth_realm_ptr;
 }
 
-static void impose_first_realm(const player_type *creature_ptr, s32b *choices)
+static void impose_first_realm(const player_type *creature_ptr, u32b *choices)
 {
     if (creature_ptr->realm2 == REALM_SELECT_CANCEL)
         return;
@@ -121,7 +121,7 @@ static void impose_first_realm(const player_type *creature_ptr, s32b *choices)
     }
 }
 
-static void analyze_realms(const player_type *creature_ptr, const s32b choices, birth_realm_type *birth_realm_ptr)
+static void analyze_realms(const player_type *creature_ptr, const u32b choices, birth_realm_type *birth_realm_ptr)
 {
     for (int i = 0; i < 32; i++) {
         if ((choices & (1UL << i)) == 0)
@@ -251,7 +251,7 @@ static bool get_a_realm(player_type *creature_ptr, birth_realm_type *birth_realm
  * @return 選択した魔法領域のID
  * @details 領域数が0 (戦士等)or 1 (観光客等)なら自動での値を返す
  */
-static byte select_realm(player_type *creature_ptr, s32b choices, int *count)
+static byte select_realm(player_type *creature_ptr, u32b choices, int *count)
 {
     byte auto_select = count_realm_selection(choices, count);
     clear_from(10);

--- a/src/birth/birth-select-realm.c
+++ b/src/birth/birth-select-realm.c
@@ -23,7 +23,7 @@ typedef struct birth_realm_type {
     int os;
 } birth_realm_type;
 
-static byte count_realm_selection(s32b choices, int *count)
+static byte count_realm_selection(const s32b choices, int *count)
 {
     byte auto_select = REALM_NONE;
     if (choices & CH_LIFE) {
@@ -106,7 +106,7 @@ static birth_realm_type *initialize_birth_realm_type(birth_realm_type *birth_rea
     return birth_realm_ptr;
 }
 
-static void impose_first_realm(player_type *creature_ptr, s32b *choices)
+static void impose_first_realm(const player_type *creature_ptr, s32b *choices)
 {
     if (creature_ptr->realm2 == REALM_SELECT_CANCEL)
         return;
@@ -121,7 +121,7 @@ static void impose_first_realm(player_type *creature_ptr, s32b *choices)
     }
 }
 
-static void analyze_realms(player_type *creature_ptr, s32b choices, birth_realm_type *birth_realm_ptr)
+static void analyze_realms(const player_type *creature_ptr, const s32b choices, birth_realm_type *birth_realm_ptr)
 {
     for (int i = 0; i < 32; i++) {
         if ((choices & (1UL << i)) == 0)

--- a/src/player/player-realm.c
+++ b/src/player/player-realm.c
@@ -4,7 +4,7 @@
 /*!
  * 職業毎に選択可能な第一領域魔法テーブル
  */
-const s32b realm_choices1[MAX_CLASS] = {
+const u32b realm_choices1[MAX_CLASS] = {
     (CH_NONE), /* Warrior */
     (CH_LIFE | CH_SORCERY | CH_NATURE | CH_CHAOS | CH_DEATH | CH_TRUMP | CH_ARCANE | CH_ENCHANT | CH_DAEMON | CH_CRUSADE), /* Mage */
     (CH_LIFE | CH_DEATH | CH_DAEMON | CH_CRUSADE), /* Priest */
@@ -38,7 +38,7 @@ const s32b realm_choices1[MAX_CLASS] = {
 /*!
  * 職業毎に選択可能な第二領域魔法テーブル
  */
-const s32b realm_choices2[MAX_CLASS] = {
+const u32b realm_choices2[MAX_CLASS] = {
     (CH_NONE), /* Warrior */
     (CH_LIFE | CH_SORCERY | CH_NATURE | CH_CHAOS | CH_DEATH | CH_TRUMP | CH_ARCANE | CH_ENCHANT | CH_DAEMON | CH_CRUSADE), /* Mage */
     (CH_LIFE | CH_SORCERY | CH_NATURE | CH_CHAOS | CH_DEATH | CH_TRUMP | CH_ARCANE | CH_ENCHANT | CH_DAEMON | CH_CRUSADE), /* Priest */

--- a/src/player/player-realm.h
+++ b/src/player/player-realm.h
@@ -21,8 +21,8 @@ typedef enum choosable_realm {
     CH_HEX = 0x20000,
 } choosable_realm;
 
-extern const s32b realm_choices1[];
-extern const s32b realm_choices2[];
+extern const u32b realm_choices1[];
+extern const u32b realm_choices2[];
 
 /* Magic-books for the realms */
 REALM_IDX get_realm1_book(player_type *player_ptr);


### PR DESCRIPTION
Fixes #173.

原因はポインタの付け忘れでした
他、小さいですがconst修飾子を付けておきました
第2領域の選択はプリーストだけ専用処理されていますが、設計変更については保留しています