### PR TITLE
[fix] X11版でXFTを有効にすると、フォントのサイズによって描画が崩れる #178

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -321,6 +321,7 @@
     <ClCompile Include="..\..\src\io\input-key-requester.c" />
     <ClCompile Include="..\..\src\io\store-key-processor.c" />
     <ClCompile Include="..\..\src\load\info-loader.c" />
+    <ClCompile Include="..\..\src\locale\utf-8.c" />
     <ClCompile Include="..\..\src\main\angband-headers.c" />
     <ClCompile Include="..\..\src\main\game-data-initializer.c" />
     <ClCompile Include="..\..\src\main\info-initializer.c" />
@@ -970,6 +971,7 @@
     <ClInclude Include="..\..\src\io\store-key-processor.h" />
     <ClInclude Include="..\..\src\load\info-loader.h" />
     <ClInclude Include="..\..\src\locale\language-switcher.h" />
+    <ClInclude Include="..\..\src\locale\utf-8.h" />
     <ClInclude Include="..\..\src\main\angband-headers.h" />
     <ClInclude Include="..\..\src\main\game-data-initializer.h" />
     <ClInclude Include="..\..\src\main\info-initializer.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2189,6 +2189,9 @@
     <ClCompile Include="..\..\src\system\angband-version.c">
       <Filter>system</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\locale\utf-8.c">
+      <Filter>locale</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -4710,6 +4713,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\artifact\random-art-effects.h">
       <Filter>artifact</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\locale\utf-8.h">
+      <Filter>locale</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -361,6 +361,7 @@ hengband_SOURCES = \
 	\
 	locale/english.c locale/english.h \
 	locale/japanese.c locale/japanese.h \
+	locale/utf-8.c locale/utf-8.h \
 	locale/language-switcher.h \
 	\
 	lore/combat-types-setter.c lore/combat-types-setter.h \

--- a/src/locale/japanese.c
+++ b/src/locale/japanese.c
@@ -5,6 +5,7 @@
  */
 
 #include "locale/japanese.h"
+#include "locale/utf-8.h"
 #include "util/string-processor.h"
 #include "view/display-messages.h"
 
@@ -396,31 +397,6 @@ static bool is_ascii_str(concptr str)
 		int ch = *str;
 		if (!(0x00 < ch && ch <= 0x7f))
 			return FALSE;
-	}
-	return TRUE;
-}
-
-/*!
- * @brief 文字列の文字コードがUTF-8かどうかを判定する
- * @param str 判定する文字列へのポインタ
- * @return 文字列の文字コードがUTF-8ならTRUE、そうでなければFALSE
- */
-static bool is_utf8_str(concptr str)
-{
-	const unsigned char* p;
-	for (p = (const unsigned char*)str; *p; p++) {
-		int subseq_num = 0;
-		if (0x00 < *p && *p <= 0x7f) continue;
-		
-		if ((*p & 0xe0) == 0xc0) subseq_num = 1;
-		if ((*p & 0xf0) == 0xe0) subseq_num = 2;
-		if ((*p & 0xf8) == 0xf0) subseq_num = 3;
-
-		if (subseq_num == 0) return FALSE;
-		while (subseq_num--) {
-			p++;
-			if (!*p || (*p & 0xc0) != 0x80) return FALSE;
-		}
 	}
 	return TRUE;
 }

--- a/src/locale/utf-8.c
+++ b/src/locale/utf-8.c
@@ -1,0 +1,69 @@
+﻿#include "locale/utf-8.h"
+
+/*!
+ * @brief 文字列の最初の文字のUTF-8エンコーディングにおけるバイト長を返す
+ *
+ * UTF-8エンコーディングの文字列が渡されるのを想定し、
+ * その文字列の最初の文字のバイト長を返す。
+ * UTF-8エンコーディングとして適合しなければ0を返す。
+ * また文字列終端文字('\\0')の場合も0を返す。
+ *
+ * @note UTF-8エンコーディングの厳密なバリデーションにはなっていない。
+ *       2バイト目以降は0x80-0xBF固定ではなく、バイト長・何バイト目かなど
+ *       によって若干変化するが、ここでは簡便のため0x80-0xBFの範囲のみ
+ *       チェックする
+ *
+ * @param str 判定する文字列へのポインタ
+ *
+ * @return 最初の文字のバイト長を返す。
+ *         終端文字もしくはUTF-8エンコーディングに適合しない場合は0を返す。
+ */
+int utf8_next_char_byte_length(concptr str)
+{
+    const unsigned char *p = (const unsigned char *)str;
+    int length = 0;
+
+    // バイト長の判定
+    if (0x00 < *p && *p <= 0x7f) {
+        length = 1;
+    } else if ((*p & 0xe0) == 0xc0) {
+        length = 2;
+    } else if ((*p & 0xf0) == 0xe0) {
+        length = 3;
+    } else if ((*p & 0xf8) == 0xf0) {
+        length = 4;
+    } else {
+        return 0;
+    }
+
+    // trailing bytesが0x80-0xBFである事のチェック
+    while ((++p) < (const unsigned char *)str + length) {
+        if ((*p & 0xc0) != 0x80) {
+            return 0;
+        }
+    }
+
+    return length;
+}
+
+/*!
+ * @brief 文字列がUTF-8の文字列として適合かどうかを判定する
+ *
+ * @param str 判定する文字列へのポインタ
+ *
+ * @return 文字列がUTF-8として適合ならTRUE、そうでなければFALSE
+ */
+bool is_utf8_str(concptr str)
+{
+    while (*str) {
+        const int byte_length = utf8_next_char_byte_length(str);
+
+        if (byte_length == 0) {
+            return FALSE;
+        }
+
+        str += byte_length;
+    }
+
+    return TRUE;
+}

--- a/src/locale/utf-8.h
+++ b/src/locale/utf-8.h
@@ -1,0 +1,6 @@
+﻿#pragma once
+
+#include "system/angband.h"
+
+int utf8_next_char_byte_length(concptr s);
+bool is_utf8_str(concptr str);

--- a/src/main-x11.c
+++ b/src/main-x11.c
@@ -797,7 +797,7 @@ static errr Infofnt_prepare(XFontSet info)
 
 #ifdef USE_XFT
 	ifnt->asc = info->ascent;
-	ifnt->hgt = info->ascent + info->descent;
+	ifnt->hgt = info->height;
 	const char *text = "A";
 	XGlyphInfo extent;
 	XftTextExtentsUtf8(Metadpy->dpy, info, (FcChar8*)text, strlen(text), &extent);

--- a/src/main-x11.c
+++ b/src/main-x11.c
@@ -97,6 +97,7 @@
 #include "game-option/runtime-arguments.h"
 #include "game-option/special-options.h"
 #include "io/files-util.h"
+#include "locale/utf-8.h"
 #include "main/sound-definitions-table.h"
 #include "main/sound-of-music.h"
 #include "main/x11-type-string.h"
@@ -882,6 +883,24 @@ static void Infofnt_init_data(concptr name)
 	Infofnt->nuke = 1;
 }
 
+#ifdef USE_XFT
+static void Infofnt_text_std_xft_draw_str(int x, int y, concptr str, concptr str_end)
+{
+    int offset = 0;
+    while (str < str_end) {
+        const int byte_len = utf8_next_char_byte_length(str);
+
+        if (byte_len == 0 || str + byte_len > str_end) {
+            return;
+        }
+
+        XftDrawStringUtf8(Infowin->draw, &Infoclr->fg, Infofnt->info, x + Infofnt->wid * offset, y, (const FcChar8 *)str, byte_len);
+        offset += (byte_len > 1 ? 2 : 1);
+        str += byte_len;
+    }
+}
+#endif
+
 /*
  * Standard Text
  */
@@ -926,8 +945,7 @@ static errr Infofnt_text_std(int x, int y, concptr str, int len)
 		r.height = Infofnt->hgt;
 		XftDrawSetClipRectangles(draw, x, y-Infofnt->asc, &r, 1);
 		XftDrawRect(draw, &Infoclr->bg, x, y-Infofnt->asc, Infofnt->wid*len, Infofnt->hgt);
-		XftDrawStringUtf8(draw, &Infoclr->fg, Infofnt->info, x, y,
-			 (FcChar8*)kanji, kp - kanji);
+                Infofnt_text_std_xft_draw_str(x, y, kanji, kp);
 		XftDrawSetClip(draw, 0);
 #else
 		XmbDrawImageString(Metadpy->dpy, Infowin->win, Infofnt->info,


### PR DESCRIPTION
#178 の対策として、1文字ずつ座標を計算して描画する処理を実装してみました。
今の所体感できるような描画パフォーマンスの低下はなさそうに思います。

X11版という事で @taotao54321 氏にはレビューしていただきたいのでレビューアに割り当てました。