### PR TITLE
[feature] UNIX系環境用のスポイラーを出力するオプション

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -11,9 +11,9 @@
 #include "core/game-play.h"
 #include "core/scores.h"
 #include "game-option/runtime-arguments.h"
-#include "io/record-play-movie.h"
 #include "io/files-util.h"
 #include "io/inet.h"
+#include "io/record-play-movie.h"
 #include "io/signal-handlers.h"
 #include "io/uid-checker.h"
 #include "main/angband-initializer.h"
@@ -116,27 +116,29 @@ static void create_user_dir(void)
  */
 static void init_stuff(void)
 {
-	char libpath[1024], varpath[1024];
+    char libpath[1024], varpath[1024];
 
     concptr tail;
 
     /* Get the environment variable */
     tail = getenv("ANGBAND_PATH");
 
-	/* Use the angband_path, or a default */
-	strncpy(libpath, tail ? tail : DEFAULT_LIB_PATH, 511);
-	strncpy(varpath, tail ? tail : DEFAULT_VAR_PATH, 511);
+    /* Use the angband_path, or a default */
+    strncpy(libpath, tail ? tail : DEFAULT_LIB_PATH, 511);
+    strncpy(varpath, tail ? tail : DEFAULT_VAR_PATH, 511);
 
-	/* Make sure they're terminated */
-	libpath[511] = '\0';
-	varpath[511] = '\0';
+    /* Make sure they're terminated */
+    libpath[511] = '\0';
+    varpath[511] = '\0';
 
-	/* Hack -- Add a path separator (only if needed) */
-	if (!suffix(libpath, PATH_SEP)) strcat(libpath, PATH_SEP);
-	if (!suffix(varpath, PATH_SEP)) strcat(varpath, PATH_SEP);
+    /* Hack -- Add a path separator (only if needed) */
+    if (!suffix(libpath, PATH_SEP))
+        strcat(libpath, PATH_SEP);
+    if (!suffix(varpath, PATH_SEP))
+        strcat(varpath, PATH_SEP);
 
-	/* Initialize */
-	init_file_paths(libpath, varpath);
+    /* Initialize */
+    init_file_paths(libpath, varpath);
 }
 
 /*

--- a/src/main.c
+++ b/src/main.c
@@ -236,10 +236,10 @@ static void change_path(concptr info)
     }
 }
 
-static void display_usage(void)
+static void display_usage(const char* program)
 {
     /* Dump usage information */
-    puts("Usage: angband [options] [-- subopts]");
+    printf("Usage: %s [options] [-- subopts]\n", program);
     puts("  -n       Start a new character");
     puts("  -f       Request fiddle mode");
     puts("  -w       Request wizard mode");
@@ -384,7 +384,7 @@ int main(int argc, char *argv[])
     for (i = 1; args && (i < argc); i++) {
         /* Require proper options */
         if (argv[i][0] != '-') {
-            display_usage();
+            display_usage(argv[0]);
             continue;
         }
 
@@ -497,7 +497,7 @@ int main(int argc, char *argv[])
         if (!is_usage_needed)
             continue;
 
-        display_usage();
+        display_usage(argv[0]);
     }
 
     /* Hack -- Forget standard args */


### PR DESCRIPTION
Issues #28 に対応。
PR #152 で対応されたコマンドラインからのスポイラー出力機能を、Linux/UNIX環境でも --output-spoilers を与えることで実現する。
また、コマンドラインオプションのヘルプ出力時にプログラム名がangband固定になっているので、プログラム名が表示されるように変更する。