### PR TITLE
English: falmer and chaurus descriptions

### DIFF
--- a/lib/edit/r_info.txt
+++ b/lib/edit/r_info.txt
@@ -24550,8 +24550,8 @@ B:STING:HURT:4d10
 B:CRUSH:HURT:4d10
 F:EVIL | ANIMAL | DROP_CORPSE | BASH_DOOR | DROP_90 | DROP_1D2 | FRIENDS
 F:IM_POIS | RES_DARK
-D:$It is Chaurus who has grown into a human-like body.
-D:$  It is often seen that they are kept in falmer.
+D:$It is a Chaurus that keeps it's two front legs off the ground, ready to
+D:$ use as weapons.  It is often seen near the falmer.
 D:人間並みの身体に成長したシャウラスだ。
 D:ファルメルに飼われている姿をよく見かける。
 

--- a/lib/edit/r_info.txt
+++ b/lib/edit/r_info.txt
@@ -24512,7 +24512,7 @@ B:BITE:HURT:1d13
 B:STING:HURT:1d13
 F:EVIL | ANIMAL | DROP_CORPSE | BASH_DOOR | DROP_60 | FRIENDS
 F:IM_POIS | RES_DARK
-D:$It is about the size of a human and is covered with crustaceans.
+D:$It is about the size of a human and is covered with a shell of chitin.
 D:それは人ほどの大きさを誇り、甲殻に覆われている。
 
 N:1234:シャウラス・リーパー
@@ -24524,8 +24524,8 @@ B:BITE:HURT:3d13
 B:STING:HURT:3d13
 F:EVIL | ANIMAL | DROP_CORPSE | BASH_DOOR | DROP_90 | FRIENDS
 F:IM_POIS | RES_DARK
-D:$It is large enough to easily exceed humans
-D:$ and is covered with an extremely hard crustacean.
+D:$It is much larger than a human
+D:$ and has an extremely hard shell made of chitin.
 D:それは人を軽く超えるほどの大きさを誇り、極めて硬い甲殻に覆われている。
 
 N:1235:シャウラス・ハンターの幼体

--- a/lib/edit/r_info.txt
+++ b/lib/edit/r_info.txt
@@ -24537,7 +24537,7 @@ B:BITE:HURT:4d11
 B:STING:HURT:4d11
 F:EVIL | ANIMAL | DROP_CORPSE | BASH_DOOR | DROP_1D2 | FRIENDS
 F:IM_POIS | RES_DARK
-D:$It still has a small body, but it can easily prey on adventurers.
+D:$It is not fully grown, but it can easily prey on adventurers.
 D:それはまだ小さい体躯をしているが、冒険者を容易に捕食できる。
 
 N:1236:シャウラス・ハンター

--- a/lib/edit/r_info.txt
+++ b/lib/edit/r_info.txt
@@ -24344,8 +24344,8 @@ W:8:2:0:32:0:0
 B:HIT:POISON:5d5
 F:EVIL | FRIENDS | DROP_CORPSE | DROP_SKELETON | DROP_90
 F:IM_POIS | RES_LITE | RES_DARK | BASH_DOOR
-D:$It is the fallen descendant of the snow elf.
-D:$  It is blind but good ears.
+D:$It is the fallen descendant of a snow elf.
+D:$  It is blind but has good ears.
 D:スノーエルフの堕落した末裔だ。目は見えないがとても耳が利く。
 
 N:1223:ファルメル・スクルカー

--- a/lib/edit/r_info.txt
+++ b/lib/edit/r_info.txt
@@ -24359,7 +24359,7 @@ F:EVIL | FRIENDS | DROP_CORPSE | DROP_SKELETON | DROP_90
 F:IM_POIS | RES_LITE | RES_DARK | BASH_DOOR
 S:1_IN_8 | SHOOT | BA_POIS
 D:$A falmer whose body is covered with a chaurus shell.
-D:$  It is blind and does not shrug in the light.
+D:$  It is blind and is not bothered by light.
 D:シャウラスの殻で身体を覆ったファルメルだ。
 D:目が見えないので光に身をすくめることもない。
 

--- a/lib/edit/r_info.txt
+++ b/lib/edit/r_info.txt
@@ -24420,7 +24420,7 @@ B:SLASH:POISON:17d11
 F:EVIL | DROP_CORPSE | DROP_SKELETON | BASH_DOOR | POWERFUL
 F:DROP_2D2 | DROP_3D2 | ONLY_ITEM | IM_POIS | RES_LITE | RES_DARK
 S:1_IN_6 | SHOOT | BA_ELEC | BA_POIS | BR_POIS | CONF | HOLD | BLIND
-D:$It is the strongest falmer among general soldiers.
+D:$It is the strongest of the falmers' general soldiers.
 D:一般兵士の中では最強のファルメルだ。
 
 N:1228:グレーター・ファルメル・スクルカー


### PR DESCRIPTION
These changes are to try to improve the English descriptions for the different forms of falmer and chaurus.  At least for my taste, the descriptions for the falmer shadowmaster, greater falmer skulker, greater falmer nightprowler, greater falmer shadowmaster, and greater falmer warmonger are still problematic, but I don't know what to recommend as changes since I don't know the source material.  The greater falmer nightprowler (just the first sentence is an issue; what is "finally dangerous" supposed to mean) and greater falmer shadowmaster (I'm not sure what the second sentence is about; it doesn't seem to match up with something in the creature flags) are likely the easiest to fix.