### PR TITLE
[Feature] fresh_afterコマンドの分割

### DIFF
--- a/src/cmd-action/cmd-move.c
+++ b/src/cmd-action/cmd-move.c
@@ -426,6 +426,5 @@ void do_cmd_rest(player_type *creature_ptr)
     update_creature(creature_ptr);
     creature_ptr->redraw |= (PR_STATE);
     update_output(creature_ptr);
-    if (fresh_after)
-        term_fresh();
+    term_fresh();
 }

--- a/src/cmd-action/cmd-pet.c
+++ b/src/cmd-action/cmd-pet.c
@@ -171,8 +171,7 @@ void do_cmd_pet_dismiss(player_type *creature_ptr)
 
     Term->scr->cu = cu;
     Term->scr->cv = cv;
-    if (fresh_after)
-        term_fresh();
+    term_fresh();
 
     C_KILL(who, current_world_ptr->max_m_idx, MONSTER_IDX);
 

--- a/src/core/player-processor.c
+++ b/src/core/player-processor.c
@@ -251,7 +251,7 @@ void process_player(player_type *creature_ptr)
         handle_stuff(creature_ptr);
         move_cursor_relative(creature_ptr->y, creature_ptr->x);
         if (fresh_before)
-            term_fresh();
+            term_fresh_force();
 
         pack_overflow(creature_ptr);
         if (!command_new)

--- a/src/core/player-processor.c
+++ b/src/core/player-processor.c
@@ -130,7 +130,7 @@ void process_player(player_type *creature_ptr)
         print_time(creature_ptr);
     }
 
-    if (!fresh_after && (continuous_action_running(creature_ptr) || !command_rep)) {
+    if (fresh_once && (continuous_action_running(creature_ptr) || !command_rep)) {
         stop_term_fresh();
     }
 

--- a/src/dungeon/dungeon-processor.c
+++ b/src/dungeon/dungeon-processor.c
@@ -102,8 +102,7 @@ void process_dungeon(player_type *player_ptr, bool load_game)
     player_ptr->update |= (PU_BONUS | PU_HP | PU_MANA | PU_SPELLS);
     player_ptr->update |= (PU_COMBINE | PU_REORDER);
     handle_stuff(player_ptr);
-    if (fresh_after)
-        term_fresh();
+    term_fresh();
 
     if (quest_num
         && (is_fixed_quest_idx(quest_num) && !((quest_num == QUEST_OBERON) || (quest_num == QUEST_SERPENT) || !(quest[quest_num].flags & QUEST_FLAG_PRESET))))

--- a/src/dungeon/dungeon-processor.c
+++ b/src/dungeon/dungeon-processor.c
@@ -170,7 +170,7 @@ void process_dungeon(player_type *player_ptr, bool load_game)
 
         move_cursor_relative(player_ptr->y, player_ptr->x);
         if (fresh_after)
-            term_fresh();
+            term_fresh_force();
 
         if (!player_ptr->playing || player_ptr->is_dead)
             break;
@@ -180,7 +180,7 @@ void process_dungeon(player_type *player_ptr, bool load_game)
 
         move_cursor_relative(player_ptr->y, player_ptr->x);
         if (fresh_after)
-            term_fresh();
+            term_fresh_force();
 
         if (!player_ptr->playing || player_ptr->is_dead)
             break;
@@ -190,7 +190,7 @@ void process_dungeon(player_type *player_ptr, bool load_game)
 
         move_cursor_relative(player_ptr->y, player_ptr->x);
         if (fresh_after) {
-            term_fresh();
+            term_fresh_force();
         }
 
         if (!player_ptr->playing || player_ptr->is_dead)

--- a/src/effect/effect-processor.c
+++ b/src/effect/effect-processor.c
@@ -8,8 +8,8 @@
 #include "effect/spells-effect-util.h"
 #include "floor/cave.h"
 #include "floor/line-of-sight.h"
-#include "game-option/special-options.h"
 #include "game-option/map-screen-options.h"
+#include "game-option/special-options.h"
 #include "grid/feature-flag-types.h"
 #include "io/cursor.h"
 #include "io/screen-util.h"
@@ -543,8 +543,7 @@ bool project(player_type *caster_ptr, const MONSTER_IDX who, POSITION rad, POSIT
             }
 
             move_cursor_relative(by, bx);
-            if (fresh_after)
-                term_fresh();
+            term_fresh();
         }
     }
 

--- a/src/game-option/map-screen-options.c
+++ b/src/game-option/map-screen-options.c
@@ -12,6 +12,7 @@ bool view_unsafe_grids; /* Map marked by detect traps */
 bool view_reduce_view; /* Reduce view-radius in town */
 bool fresh_before; /* Flush output while in repeated command */
 bool fresh_after; /* Flush output after monster's move */
+bool fresh_once; /* Flush output only once per key input */
 bool fresh_message; /* Flush output after every message */
 bool hilite_player; /* Hilite the player with the cursor */
 bool display_path; /* Display actual path before shooting */

--- a/src/game-option/map-screen-options.h
+++ b/src/game-option/map-screen-options.h
@@ -14,6 +14,7 @@ extern bool view_unsafe_grids; /* Map marked by detect traps */
 extern bool view_reduce_view; /* Reduce view-radius in town */
 extern bool fresh_before; /* Flush output while continuous command */
 extern bool fresh_after; /* Flush output after monster's move */
+extern bool fresh_once; /* Flush output only once per key input */
 extern bool fresh_message; /* Flush output after every message */
 extern bool hilite_player; /* Hilite the player with the cursor */
 extern bool display_path; /* Display actual path before shooting */

--- a/src/game-option/option-types-table.c
+++ b/src/game-option/option-types-table.c
@@ -3,7 +3,6 @@
 #include "game-option/birth-options.h"
 #include "game-option/cheat-options.h"
 #include "game-option/disturbance-options.h"
-#include "game-option/disturbance-options.h"
 #include "game-option/game-play-options.h"
 #include "game-option/input-options.h"
 #include "game-option/map-screen-options.h"
@@ -85,6 +84,8 @@ const option_type option_info[MAX_OPTION_INFO] = {
     { &fresh_before, TRUE, OPT_PAGE_MAPSCREEN, 1, 23, "fresh_before", _("連続コマンド中に画面を再描画し続ける", "Flush output while in repeated command") },
 
     { &fresh_after, FALSE, OPT_PAGE_MAPSCREEN, 1, 24, "fresh_after", _("コマンド後に画面を常に再描画し続ける", "Flush output after monster's move") },
+
+    { &fresh_once, FALSE, OPT_PAGE_MAPSCREEN, 1, 32, "fresh_once", _("キー入力毎に一度だけ画面を再描画する", "Flush output once per key input") },
 
     { &fresh_message, FALSE, OPT_PAGE_MAPSCREEN, 1, 25, "fresh_message", _("メッセージの後に画面を再描画する", "Flush output after every message") },
 
@@ -295,25 +296,26 @@ const option_type option_info[MAX_OPTION_INFO] = {
 /*!
  * チートオプションの定義テーブル / Cheating options
  */
-const option_type cheat_info[MAX_CHEAT_OPTIONS] = { { &cheat_peek, FALSE, 255, 0x01, 0x00, "cheat_peek", _("アイテムの生成をのぞき見る", "Peek into object creation") },
+const option_type cheat_info[MAX_CHEAT_OPTIONS]
+    = { { &cheat_peek, FALSE, 255, 0x01, 0x00, "cheat_peek", _("アイテムの生成をのぞき見る", "Peek into object creation") },
 
-    { &cheat_hear, FALSE, 255, 0x02, 0x00, "cheat_hear", _("モンスターの生成をのぞき見る", "Peek into monster creation") },
+          { &cheat_hear, FALSE, 255, 0x02, 0x00, "cheat_hear", _("モンスターの生成をのぞき見る", "Peek into monster creation") },
 
-    { &cheat_room, FALSE, 255, 0x04, 0x00, "cheat_room", _("ダンジョンの生成をのぞき見る", "Peek into dungeon creation") },
+          { &cheat_room, FALSE, 255, 0x04, 0x00, "cheat_room", _("ダンジョンの生成をのぞき見る", "Peek into dungeon creation") },
 
-    { &cheat_xtra, FALSE, 255, 0x08, 0x00, "cheat_xtra", _("その他の事をのぞき見る", "Peek into something else") },
+          { &cheat_xtra, FALSE, 255, 0x08, 0x00, "cheat_xtra", _("その他の事をのぞき見る", "Peek into something else") },
 
-    { &cheat_know, FALSE, 255, 0x10, 0x00, "cheat_know", _("完全なモンスターの思い出を知る", "Know complete monster info") },
+          { &cheat_know, FALSE, 255, 0x10, 0x00, "cheat_know", _("完全なモンスターの思い出を知る", "Know complete monster info") },
 
-    { &cheat_live, FALSE, 255, 0x20, 0x00, "cheat_live", _("死を回避することを可能にする", "Allow player to avoid death") },
+          { &cheat_live, FALSE, 255, 0x20, 0x00, "cheat_live", _("死を回避することを可能にする", "Allow player to avoid death") },
 
-    { &cheat_save, FALSE, 255, 0x40, 0x00, "cheat_save", _("死んだ時セーブするか確認する", "Ask for saving death") },
+          { &cheat_save, FALSE, 255, 0x40, 0x00, "cheat_save", _("死んだ時セーブするか確認する", "Ask for saving death") },
 
-    { &cheat_diary_output, FALSE, 255, 0x80, 0x00, "cheat_diary_output", _("ウィザードログを日記に出力する", "Output wizard log to diary.") },
+          { &cheat_diary_output, FALSE, 255, 0x80, 0x00, "cheat_diary_output", _("ウィザードログを日記に出力する", "Output wizard log to diary.") },
 
-    { &cheat_turn, FALSE, 255, 0x81, 0x00, "cheat_turn", _("ゲームメッセージにターン表示を行う", "Put turn in game messages.") },
+          { &cheat_turn, FALSE, 255, 0x81, 0x00, "cheat_turn", _("ゲームメッセージにターン表示を行う", "Put turn in game messages.") },
 
-    { &cheat_sight, FALSE, 255, 0x82, 0x00, "cheat_sight", _("「見る」コマンドを拡張する。", "Expand \"L\"ook command.") } };
+          { &cheat_sight, FALSE, 255, 0x82, 0x00, "cheat_sight", _("「見る」コマンドを拡張する。", "Expand \"L\"ook command.") } };
 
 /*!
  * 自動セーブオプションテーブル

--- a/src/game-option/option-types-table.h
+++ b/src/game-option/option-types-table.h
@@ -22,7 +22,7 @@ typedef struct option_type {
     concptr o_desc;
 } option_type;
 
-#define MAX_OPTION_INFO 122
+#define MAX_OPTION_INFO 123
 #define MAX_CHEAT_OPTIONS 10
 #define MAX_AUTOSAVE_INFO 2
 

--- a/src/io/input-key-requester.c
+++ b/src/io/input-key-requester.c
@@ -211,7 +211,7 @@ void request_command(player_type *player_ptr, int shopping)
         if (!macro_running() && !command_new && auto_debug_save) {
             save_player(player_ptr, SAVE_TYPE_DEBUG);
         }
-        if (macro_running() && !fresh_after) {
+        if (macro_running() && fresh_once) {
             stop_term_fresh();
         } else {
             start_term_fresh();

--- a/src/mind/mind-mirror-master.c
+++ b/src/mind/mind-mirror-master.c
@@ -169,10 +169,8 @@ bool binding_field(player_type *caster_ptr, HIT_POINT dam)
                         u16b p = bolt_pict(y, x, y, x, GF_MANA);
                         print_rel(caster_ptr, PICT_C(p), PICT_A(p), y, x);
                         move_cursor_relative(y, x);
-                        if (fresh_after) {
-                            term_fresh();
-                            term_xtra(TERM_XTRA_DELAY, msec);
-                        }
+                        term_fresh();
+                        term_xtra(TERM_XTRA_DELAY, msec);
                     }
                 }
             }

--- a/src/spell-kind/spells-genocide.c
+++ b/src/spell-kind/spells-genocide.c
@@ -101,8 +101,7 @@ bool genocide_aux(player_type *caster_ptr, MONSTER_IDX m_idx, int power, bool pl
     caster_ptr->redraw |= (PR_HP);
     caster_ptr->window_flags |= (PW_PLAYER);
     handle_stuff(caster_ptr);
-    if (fresh_after)
-        term_fresh();
+    term_fresh();
 
     int msec = delay_factor * delay_factor * delay_factor;
     term_xtra(TERM_XTRA_DELAY, msec);

--- a/src/spell-kind/spells-sight.c
+++ b/src/spell-kind/spells-sight.c
@@ -397,8 +397,7 @@ bool probing(player_type *caster_ptr)
 
     Term->scr->cu = cu;
     Term->scr->cv = cv;
-    if (fresh_after)
-        term_fresh();
+    term_fresh();
 
     if (probe) {
         chg_virtue(caster_ptr, V_KNOWLEDGE, 1);

--- a/src/term/z-term.c
+++ b/src/term/z-term.c
@@ -11,7 +11,6 @@
 #include "game-option/map-screen-options.h"
 #include "game-option/runtime-arguments.h"
 #include "game-option/special-options.h"
-#include "io/input-key-requester.h"
 #include "term/gameterm.h"
 #include "term/term-color-types.h"
 #include "term/z-virt.h"
@@ -1272,6 +1271,19 @@ errr term_fresh(void)
     /* Actually flush the output */
     term_xtra(TERM_XTRA_FRESH, 0);
     return 0;
+}
+
+
+/*
+ * @brief never_freshの値を無視して強制的にterm_freshを行う。
+ */
+errr term_fresh_force(void)
+{
+    bool old = Term->never_fresh;
+    Term->never_fresh = FALSE;
+    errr err = term_fresh();
+    Term->never_fresh = old;
+    return err;
 }
 
 /*** Output routines ***/

--- a/src/term/z-term.c
+++ b/src/term/z-term.c
@@ -1025,7 +1025,7 @@ static void term_fresh_row_text(TERM_LEN y, TERM_LEN x1, TERM_LEN x2)
 bool macro_running(void)
 {
     int diff = angband_term[0]->key_head - angband_term[0]->key_tail;
-    return diff < -1 || 1 < diff;
+    return diff != 0;
 }
 
 /*

--- a/src/term/z-term.h
+++ b/src/term/z-term.h
@@ -148,6 +148,7 @@ void term_queue_line(TERM_LEN x, TERM_LEN y, int n, TERM_COLOR *a, char *c, TERM
 bool macro_running(void);
 
 errr term_fresh(void);
+errr term_fresh_force(void);
 errr term_set_cursor(int v);
 errr term_gotoxy(TERM_LEN x, TERM_LEN y);
 errr term_draw(TERM_LEN x, TERM_LEN y, TERM_COLOR a, char c);

--- a/src/view/display-messages.c
+++ b/src/view/display-messages.c
@@ -431,7 +431,7 @@ void msg_print(concptr msg)
 #endif
 
     if (fresh_message)
-        term_fresh();
+        term_fresh_force();
 }
 
 /*


### PR DESCRIPTION
描画過多を解消するためfresh_afterコマンドに手を入れていった結果、旧来のfresh_afterコマンドとはかなり挙動が異なるものに変化していた。
旧来のfresh_afterコマンドとの差分を分離し、新たにfresh_onceコマンドとして独立させる。
このコマンドがONのとき、一度のキー入力に対し描写を一度に制限する。