### PR TITLE
[fix] アリーナで友好的な敵が出現 #202

### DIFF
--- a/src/monster-floor/one-monster-placer.c
+++ b/src/monster-floor/one-monster-placer.c
@@ -316,7 +316,7 @@ bool place_monster_one(player_type *player_ptr, MONSTER_IDX who, POSITION y, POS
     if (mode & PM_FORCE_PET) {
         set_pet(player_ptr, m_ptr);
     } else if ((r_ptr->flags7 & RF7_FRIENDLY) || (mode & PM_FORCE_FRIENDLY) || is_friendly_idx(player_ptr, who)) {
-        if (!monster_has_hostile_align(player_ptr, NULL, 0, -1, r_ptr))
+        if (!monster_has_hostile_align(player_ptr, NULL, 0, -1, r_ptr) && !player_ptr->current_floor_ptr->inside_arena)
             set_friendly(m_ptr);
     }
 


### PR DESCRIPTION
FRIENDLYフラグ持ちのエルフ・ロードがアリーナでも
友好的な状態で出現する。
アリーナで友好的というのはやはりおかしい気が
するのでアリーナではFRIENDLYフラグ持ちでも
友好的な状態で生成しないようにする。