### PR TITLE
セーブ直後にキャラクターが移動できない #231

### DIFF
--- a/src/io/input-key-requester.c
+++ b/src/io/input-key-requester.c
@@ -208,7 +208,7 @@ void request_command(player_type *player_ptr, int shopping)
     use_menu = FALSE;
 
     while (TRUE) {
-        if (!macro_running() && !command_new && auto_debug_save) {
+        if (!macro_running() && !command_new && auto_debug_save && (!inkey_next || *inkey_next == '\0')) {
             save_player(player_ptr, SAVE_TYPE_DEBUG);
         }
         if (macro_running() && fresh_once) {


### PR DESCRIPTION
マクロじゃないコマンドが実行されるときに、inkey()のキューの如何に関係なくsave_player()関数でデバグセーブをしていて、その後キューを消されていたので、想定外にinkey()によるキー待ち状態になっていた。
なので、キューの末尾じゃないコマンドを解釈するときは自動セーブしないようにした。