### PR TITLE
[Fix] fresh_onceオプションをセーブできない

### DIFF
--- a/src/game-option/option-types-table.c
+++ b/src/game-option/option-types-table.c
@@ -85,7 +85,7 @@ const option_type option_info[MAX_OPTION_INFO] = {
 
     { &fresh_after, FALSE, OPT_PAGE_MAPSCREEN, 1, 24, "fresh_after", _("コマンド後に画面を常に再描画し続ける", "Flush output after monster's move") },
 
-    { &fresh_once, FALSE, OPT_PAGE_MAPSCREEN, 1, 32, "fresh_once", _("キー入力毎に一度だけ画面を再描画する", "Flush output once per key input") },
+    { &fresh_once, FALSE, OPT_PAGE_MAPSCREEN, 1, 10, "fresh_once", _("キー入力毎に一度だけ画面を再描画する", "Flush output once per key input") },
 
     { &fresh_message, FALSE, OPT_PAGE_MAPSCREEN, 1, 25, "fresh_message", _("メッセージの後に画面を再描画する", "Flush output after every message") },
 


### PR DESCRIPTION
option_typeのo_bitを保存している領域の都合上、o_bitは0～31しか記録できないようである。
そのため、fresh_onceをTRUEでセーブしても次回起動時デフォルトのFALSEになっていた。
今回は空き番号を使用して回避する。