### PR TITLE
[Fix] ロード時に latest_visit_mark を復元

### DIFF
--- a/src/load/dungeon-loader.c
+++ b/src/load/dungeon-loader.c
@@ -84,6 +84,14 @@ static errr rd_dungeon(player_type *player_ptr)
             if (!load_floor(player_ptr, get_sf_ptr(player_ptr->floor_id), SLF_SECOND))
                 err = 183;
         }
+
+        // latest_visit_mark の復元。
+        // 全ての保存フロアについての visit_mark の最大値 + 1 とする。
+        for (int i = 0; i < num; ++i) {
+            const u32b next_visit_mark = saved_floors[i].visit_mark + 1;
+            if (next_visit_mark > latest_visit_mark)
+                latest_visit_mark = next_visit_mark;
+        }
     }
 
     switch (err) {


### PR DESCRIPTION
Fixes #239.

起動時の `latest_visit_mark` の値が 1 固定だったため、セーブ/ロードを挟むと保存フロアがいっぱいになったときの削除順がおかしくなっていた。

ロード時に全ての保存済みフロアについての `visit_mark` の最大値 + 1 を `latest_visit_mark` の値とすることで解決。