### PR TITLE
[Implement] アプリを切り替えてもサブウィンドウが消えないオプションが欲しい #14

### DIFF
--- a/src/game-option/game-play-options.c
+++ b/src/game-option/game-play-options.c
@@ -7,6 +7,7 @@ bool small_levels; /* Allow unusually small dungeon levels */
 bool always_small_levels; /* Always create unusually small dungeon levels */
 bool empty_levels; /* Allow empty 'on_defeat_arena_monster' levels */
 bool bound_walls_perm; /* Boundary walls become 'permanent wall' */
+bool keep_subwindows; /* Show sub-windows even when Hengband is not in focus */
 bool last_words; /* Leave last words when your character dies */
 bool auto_dump; /* Dump a character record automatically */
 bool auto_debug_save; /* Dump a debug savedata every key input */

--- a/src/game-option/game-play-options.h
+++ b/src/game-option/game-play-options.h
@@ -9,6 +9,7 @@ extern bool small_levels; /* Allow unusually small dungeon levels */
 extern bool always_small_levels; /* Always create unusually small dungeon levels */
 extern bool empty_levels; /* Allow empty 'on_defeat_arena_monster' levels */
 extern bool bound_walls_perm; /* Boundary walls become 'permanent wall' */
+extern bool keep_subwindows; /* Show sub-windows even when Hengband is not in focus */
 extern bool last_words; /* Leave last words when your character dies */
 extern bool auto_dump; /* Dump a character record automatically */
 extern bool auto_debug_save; /* Dump a debug savedata every key input */

--- a/src/game-option/option-types-table.c
+++ b/src/game-option/option-types-table.c
@@ -148,6 +148,8 @@ const option_type option_info[MAX_OPTION_INFO] = {
 
     { &bound_walls_perm, FALSE, OPT_PAGE_GAMEPLAY, 2, 1, "bound_walls_perm", _("ダンジョンの外壁を永久岩にする", "Boundary walls become 'permanent wall'") },
 
+    { &keep_subwindows, TRUE, OPT_PAGE_GAMEPLAY, 4, 8, "keep_subwindows", _("フォーカスが外れてもサブウィンドウを表示する", "Show sub-windows even when Hengband is not in focus") },
+
     { &last_words, TRUE, OPT_PAGE_GAMEPLAY, 0, 28, "last_words", _("キャラクターが死んだ時遺言をのこす", "Leave last words when your character dies") },
 
     { &auto_dump, FALSE, OPT_PAGE_GAMEPLAY, 4, 5, "auto_dump", _("自動的にキャラクターの記録をファイルに書き出す", "Dump a character record automatically") },

--- a/src/game-option/option-types-table.h
+++ b/src/game-option/option-types-table.h
@@ -22,7 +22,7 @@ typedef struct option_type {
     concptr o_desc;
 } option_type;
 
-#define MAX_OPTION_INFO 123
+#define MAX_OPTION_INFO 124
 #define MAX_CHEAT_OPTIONS 10
 #define MAX_AUTOSAVE_INFO 2
 

--- a/src/main-win.c
+++ b/src/main-win.c
@@ -101,6 +101,7 @@
 #include "dungeon/quest.h"
 #include "floor/floor-base-definitions.h"
 #include "floor/floor-events.h"
+#include "game-option/game-play-options.h"
 #include "game-option/runtime-arguments.h"
 #include "game-option/special-options.h"
 #include "io/files-util.h"
@@ -131,11 +132,11 @@
 #include "world/world.h"
 
 #ifdef WINDOWS
-#include "direct.h"
 #include "dungeon/dungeon.h"
-#include "locale.h"
 #include "save/save.h"
-#include "windows.h"
+#include <direct.h>
+#include <locale.h>
+#include <windows.h>
 
 /*
  * Available graphic modes
@@ -3161,6 +3162,15 @@ LRESULT PASCAL AngbandWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam
                     ShowWindow(data[i].w, SW_SHOW);
                 } else {
                     ShowWindow(data[i].w, SW_HIDE);
+                }
+            }
+        }
+    }
+    case WM_ENABLE: {
+        if (wParam == FALSE && keep_subwindows) {
+            for (int i = 0; i < MAX_TERM_DATA; i++) {
+                if (data[i].visible) {
+                    ShowWindow(data[i].w, SW_SHOW);
                 }
             }
         }


### PR DESCRIPTION
オプションkeep_subwindowsを新設する。
このオプションが有効なとき、Hengbandがフォーカスを失うときにサブウィンドウを表示する。