### PR TITLE
[Refacotr] resistance-checkerのBIT_FLAGS演算をマクロで置換

### DIFF
--- a/src/mspell/element-resistance-checker.c
+++ b/src/mspell/element-resistance-checker.c
@@ -4,221 +4,222 @@
 #include "monster-race/race-flags4.h"
 #include "monster/smart-learn-types.h"
 #include "mspell/smart-mspell-util.h"
-#include "status/element-resistance.h"
 #include "player/player-status-flags.h"
+#include "status/element-resistance.h"
+#include "util/bit-flags-calculator.h"
 
 void add_cheat_remove_flags_element(player_type *target_ptr, msr_type *msr_ptr)
 {
     if (has_resist_acid(target_ptr))
-        msr_ptr->smart |= SM_RES_ACID;
+        set_bit(msr_ptr->smart, SM_RES_ACID);
 
     if (is_oppose_acid(target_ptr))
-        msr_ptr->smart |= SM_OPP_ACID;
+        set_bit(msr_ptr->smart, SM_OPP_ACID);
 
     if (has_immune_acid(target_ptr))
-        msr_ptr->smart |= SM_IMM_ACID;
+        set_bit(msr_ptr->smart, SM_IMM_ACID);
 
     if (has_resist_elec(target_ptr))
-        msr_ptr->smart |= SM_RES_ELEC;
+        set_bit(msr_ptr->smart, SM_RES_ELEC);
 
     if (is_oppose_elec(target_ptr))
-        msr_ptr->smart |= SM_OPP_ELEC;
+        set_bit(msr_ptr->smart, SM_OPP_ELEC);
 
     if (has_immune_elec(target_ptr))
-        msr_ptr->smart |= SM_IMM_ELEC;
+        set_bit(msr_ptr->smart, SM_IMM_ELEC);
 
     if (has_resist_fire(target_ptr))
-        msr_ptr->smart |= SM_RES_FIRE;
+        set_bit(msr_ptr->smart, SM_RES_FIRE);
 
     if (is_oppose_fire(target_ptr))
-        msr_ptr->smart |= SM_OPP_FIRE;
+        set_bit(msr_ptr->smart, SM_OPP_FIRE);
 
     if (has_immune_fire(target_ptr))
-        msr_ptr->smart |= SM_IMM_FIRE;
+        set_bit(msr_ptr->smart, SM_IMM_FIRE);
 
     if (has_resist_cold(target_ptr))
-        msr_ptr->smart |= SM_RES_COLD;
+        set_bit(msr_ptr->smart, SM_RES_COLD);
 
     if (is_oppose_cold(target_ptr))
-        msr_ptr->smart |= SM_OPP_COLD;
+        set_bit(msr_ptr->smart, SM_OPP_COLD);
 
     if (has_immune_cold(target_ptr))
-        msr_ptr->smart |= SM_IMM_COLD;
+        set_bit(msr_ptr->smart, SM_IMM_COLD);
 
     if (has_resist_pois(target_ptr))
-        msr_ptr->smart |= SM_RES_POIS;
+        set_bit(msr_ptr->smart, SM_RES_POIS);
 
     if (is_oppose_pois(target_ptr))
-        msr_ptr->smart |= SM_OPP_POIS;
+        set_bit(msr_ptr->smart, SM_OPP_POIS);
 }
 
 static void check_acid_resistance(msr_type *msr_ptr)
 {
-    if (msr_ptr->smart & SM_IMM_ACID) {
-        msr_ptr->f4 &= ~(RF4_BR_ACID);
-        msr_ptr->f5 &= ~(RF5_BA_ACID);
-        msr_ptr->f5 &= ~(RF5_BO_ACID);
+    if (test_bit(msr_ptr->smart, SM_IMM_ACID)) {
+        reset_bit(msr_ptr->f4, RF4_BR_ACID);
+        reset_bit(msr_ptr->f5, RF5_BA_ACID);
+        reset_bit(msr_ptr->f5, RF5_BO_ACID);
         return;
     }
 
-    if ((msr_ptr->smart & SM_OPP_ACID) && (msr_ptr->smart & SM_RES_ACID)) {
+    if (test_bit(msr_ptr->smart, SM_OPP_ACID) && test_bit(msr_ptr->smart, SM_RES_ACID)) {
         if (int_outof(msr_ptr->r_ptr, 80))
-            msr_ptr->f4 &= ~(RF4_BR_ACID);
+            reset_bit(msr_ptr->f4, RF4_BR_ACID);
 
         if (int_outof(msr_ptr->r_ptr, 80))
-            msr_ptr->f5 &= ~(RF5_BA_ACID);
+            reset_bit(msr_ptr->f5, RF5_BA_ACID);
 
         if (int_outof(msr_ptr->r_ptr, 80))
-            msr_ptr->f5 &= ~(RF5_BO_ACID);
+            reset_bit(msr_ptr->f5, RF5_BO_ACID);
 
         return;
     }
 
-    if ((msr_ptr->smart & SM_OPP_ACID) || (msr_ptr->smart & SM_RES_ACID)) {
+    if (test_bit(msr_ptr->smart, (SM_OPP_ACID | SM_RES_ACID))) {
         if (int_outof(msr_ptr->r_ptr, 30))
-            msr_ptr->f4 &= ~(RF4_BR_ACID);
+            reset_bit(msr_ptr->f4, RF4_BR_ACID);
 
         if (int_outof(msr_ptr->r_ptr, 30))
-            msr_ptr->f5 &= ~(RF5_BA_ACID);
+            reset_bit(msr_ptr->f5, RF5_BA_ACID);
 
         if (int_outof(msr_ptr->r_ptr, 30))
-            msr_ptr->f5 &= ~(RF5_BO_ACID);
+            reset_bit(msr_ptr->f5, RF5_BO_ACID);
     }
 }
 
 static void check_elec_resistance(msr_type *msr_ptr)
 {
-    if (msr_ptr->smart & SM_IMM_ELEC) {
-        msr_ptr->f4 &= ~(RF4_BR_ELEC);
-        msr_ptr->f5 &= ~(RF5_BA_ELEC);
-        msr_ptr->f5 &= ~(RF5_BO_ELEC);
+    if (test_bit(msr_ptr->smart, SM_IMM_ELEC)) {
+        reset_bit(msr_ptr->f4, RF4_BR_ELEC);
+        reset_bit(msr_ptr->f5, RF5_BA_ELEC);
+        reset_bit(msr_ptr->f5, RF5_BO_ELEC);
         return;
     }
 
-    if ((msr_ptr->smart & SM_OPP_ELEC) && (msr_ptr->smart & SM_RES_ELEC)) {
+    if (test_bit(msr_ptr->smart, SM_OPP_ELEC) && test_bit(msr_ptr->smart, SM_RES_ELEC)) {
         if (int_outof(msr_ptr->r_ptr, 80))
-            msr_ptr->f4 &= ~(RF4_BR_ELEC);
+            reset_bit(msr_ptr->f4, RF4_BR_ELEC);
 
         if (int_outof(msr_ptr->r_ptr, 80))
-            msr_ptr->f5 &= ~(RF5_BA_ELEC);
+            reset_bit(msr_ptr->f5, RF5_BA_ELEC);
 
         if (int_outof(msr_ptr->r_ptr, 80))
-            msr_ptr->f5 &= ~(RF5_BO_ELEC);
+            reset_bit(msr_ptr->f5, RF5_BO_ELEC);
 
         return;
     }
 
-    if ((msr_ptr->smart & SM_OPP_ELEC) || (msr_ptr->smart & SM_RES_ELEC)) {
+    if (test_bit(msr_ptr->smart, (SM_OPP_ELEC | SM_RES_ELEC))) {
         if (int_outof(msr_ptr->r_ptr, 30))
-            msr_ptr->f4 &= ~(RF4_BR_ELEC);
+            reset_bit(msr_ptr->f4, RF4_BR_ELEC);
 
         if (int_outof(msr_ptr->r_ptr, 30))
-            msr_ptr->f5 &= ~(RF5_BA_ELEC);
+            reset_bit(msr_ptr->f5, RF5_BA_ELEC);
 
         if (int_outof(msr_ptr->r_ptr, 30))
-            msr_ptr->f5 &= ~(RF5_BO_ELEC);
+            reset_bit(msr_ptr->f5, RF5_BO_ELEC);
     }
 }
 
 static void check_fire_resistance(msr_type *msr_ptr)
 {
-    if (msr_ptr->smart & SM_IMM_FIRE) {
-        msr_ptr->f4 &= ~(RF4_BR_FIRE);
-        msr_ptr->f5 &= ~(RF5_BA_FIRE);
-        msr_ptr->f5 &= ~(RF5_BO_FIRE);
+    if (test_bit(msr_ptr->smart, SM_IMM_FIRE)) {
+        reset_bit(msr_ptr->f4, RF4_BR_FIRE);
+        reset_bit(msr_ptr->f5, RF5_BA_FIRE);
+        reset_bit(msr_ptr->f5, RF5_BO_FIRE);
         return;
     }
 
-    if ((msr_ptr->smart & SM_OPP_FIRE) && (msr_ptr->smart & SM_RES_FIRE)) {
+    if (test_bit(msr_ptr->smart, SM_OPP_FIRE) && test_bit(msr_ptr->smart, SM_RES_FIRE)) {
         if (int_outof(msr_ptr->r_ptr, 80))
-            msr_ptr->f4 &= ~(RF4_BR_FIRE);
+            reset_bit(msr_ptr->f4, RF4_BR_FIRE);
 
         if (int_outof(msr_ptr->r_ptr, 80))
-            msr_ptr->f5 &= ~(RF5_BA_FIRE);
+            reset_bit(msr_ptr->f5, RF5_BA_FIRE);
 
         if (int_outof(msr_ptr->r_ptr, 80))
-            msr_ptr->f5 &= ~(RF5_BO_FIRE);
+            reset_bit(msr_ptr->f5, RF5_BO_FIRE);
 
         return;
     }
 
-    if ((msr_ptr->smart & SM_OPP_FIRE) || (msr_ptr->smart & SM_RES_FIRE)) {
+    if (test_bit(msr_ptr->smart, (SM_OPP_FIRE | SM_RES_FIRE))) {
         if (int_outof(msr_ptr->r_ptr, 30))
-            msr_ptr->f4 &= ~(RF4_BR_FIRE);
+            reset_bit(msr_ptr->f4, RF4_BR_FIRE);
 
         if (int_outof(msr_ptr->r_ptr, 30))
-            msr_ptr->f5 &= ~(RF5_BA_FIRE);
+            reset_bit(msr_ptr->f5, RF5_BA_FIRE);
 
         if (int_outof(msr_ptr->r_ptr, 30))
-            msr_ptr->f5 &= ~(RF5_BO_FIRE);
+            reset_bit(msr_ptr->f5, RF5_BO_FIRE);
     }
 }
 
 static void check_cold_resistance(msr_type *msr_ptr)
 {
-    if (msr_ptr->smart & (SM_IMM_COLD)) {
-        msr_ptr->f4 &= ~(RF4_BR_COLD);
-        msr_ptr->f5 &= ~(RF5_BA_COLD);
-        msr_ptr->f5 &= ~(RF5_BO_COLD);
-        msr_ptr->f5 &= ~(RF5_BO_ICEE);
+    if (test_bit(msr_ptr->smart, SM_IMM_COLD)) {
+        reset_bit(msr_ptr->f4, RF4_BR_COLD);
+        reset_bit(msr_ptr->f5, RF5_BA_COLD);
+        reset_bit(msr_ptr->f5, RF5_BO_COLD);
+        reset_bit(msr_ptr->f5, RF5_BO_ICEE);
         return;
     }
 
-    if ((msr_ptr->smart & SM_OPP_COLD) && (msr_ptr->smart & SM_RES_COLD)) {
+    if (test_bit(msr_ptr->smart, SM_OPP_COLD) && test_bit(msr_ptr->smart, SM_RES_COLD)) {
         if (int_outof(msr_ptr->r_ptr, 80))
-            msr_ptr->f4 &= ~(RF4_BR_COLD);
+            reset_bit(msr_ptr->f4, RF4_BR_COLD);
 
         if (int_outof(msr_ptr->r_ptr, 80))
-            msr_ptr->f5 &= ~(RF5_BA_COLD);
+            reset_bit(msr_ptr->f5, RF5_BA_COLD);
 
         if (int_outof(msr_ptr->r_ptr, 80))
-            msr_ptr->f5 &= ~(RF5_BO_COLD);
+            reset_bit(msr_ptr->f5, RF5_BO_COLD);
 
         if (int_outof(msr_ptr->r_ptr, 80))
-            msr_ptr->f5 &= ~(RF5_BO_ICEE);
+            reset_bit(msr_ptr->f5, RF5_BO_ICEE);
 
         return;
     }
 
-    if ((msr_ptr->smart & SM_OPP_COLD) || (msr_ptr->smart & SM_RES_COLD)) {
+    if (test_bit(msr_ptr->smart, (SM_OPP_COLD | SM_RES_COLD))) {
         if (int_outof(msr_ptr->r_ptr, 30))
-            msr_ptr->f4 &= ~(RF4_BR_COLD);
+            reset_bit(msr_ptr->f4, RF4_BR_COLD);
 
         if (int_outof(msr_ptr->r_ptr, 30))
-            msr_ptr->f5 &= ~(RF5_BA_COLD);
+            reset_bit(msr_ptr->f5, RF5_BA_COLD);
 
         if (int_outof(msr_ptr->r_ptr, 30))
-            msr_ptr->f5 &= ~(RF5_BO_COLD);
+            reset_bit(msr_ptr->f5, RF5_BO_COLD);
 
         if (int_outof(msr_ptr->r_ptr, 20))
-            msr_ptr->f5 &= ~(RF5_BO_ICEE);
+            reset_bit(msr_ptr->f5, RF5_BO_ICEE);
     }
 }
 
 static void check_pois_resistance(msr_type *msr_ptr)
 {
-    if ((msr_ptr->smart & SM_OPP_POIS) && (msr_ptr->smart & SM_RES_POIS)) {
+    if (test_bit(msr_ptr->smart, SM_OPP_POIS) && test_bit(msr_ptr->smart, SM_RES_POIS)) {
         if (int_outof(msr_ptr->r_ptr, 80))
-            msr_ptr->f4 &= ~(RF4_BR_POIS);
+            reset_bit(msr_ptr->f4, RF4_BR_POIS);
 
         if (int_outof(msr_ptr->r_ptr, 80))
-            msr_ptr->f5 &= ~(RF5_BA_POIS);
+            reset_bit(msr_ptr->f5, RF5_BA_POIS);
 
         if (int_outof(msr_ptr->r_ptr, 60))
-            msr_ptr->f4 &= ~(RF4_BA_NUKE);
+            reset_bit(msr_ptr->f4, RF4_BA_NUKE);
 
         if (int_outof(msr_ptr->r_ptr, 60))
-            msr_ptr->f4 &= ~(RF4_BR_NUKE);
+            reset_bit(msr_ptr->f4, RF4_BR_NUKE);
 
         return;
     }
 
-    if ((msr_ptr->smart & SM_OPP_POIS) || (msr_ptr->smart & SM_RES_POIS)) {
+    if (test_bit(msr_ptr->smart, (SM_OPP_POIS | SM_RES_POIS))) {
         if (int_outof(msr_ptr->r_ptr, 30))
-            msr_ptr->f4 &= ~(RF4_BR_POIS);
+            reset_bit(msr_ptr->f4, RF4_BR_POIS);
 
         if (int_outof(msr_ptr->r_ptr, 30))
-            msr_ptr->f5 &= ~(RF5_BA_POIS);
+            reset_bit(msr_ptr->f5, RF5_BA_POIS);
     }
 }
 

--- a/src/mspell/high-resistance-checker.c
+++ b/src/mspell/high-resistance-checker.c
@@ -6,171 +6,172 @@
 #include "mspell/smart-mspell-util.h"
 #include "player/player-race.h"
 #include "player/player-status-flags.h"
+#include "util/bit-flags-calculator.h"
 
 void add_cheat_remove_flags_others(player_type *target_ptr, msr_type *msr_ptr)
 {
     if (has_resist_neth(target_ptr))
-        msr_ptr->smart |= SM_RES_NETH;
+        set_bit(msr_ptr->smart, SM_RES_NETH);
 
     if (has_resist_lite(target_ptr))
-        msr_ptr->smart |= SM_RES_LITE;
+        set_bit(msr_ptr->smart, SM_RES_LITE);
 
     if (has_resist_dark(target_ptr))
-        msr_ptr->smart |= SM_RES_DARK;
+        set_bit(msr_ptr->smart, SM_RES_DARK);
 
     if (has_resist_fear(target_ptr))
-        msr_ptr->smart |= SM_RES_FEAR;
+        set_bit(msr_ptr->smart, SM_RES_FEAR);
 
     if (has_resist_conf(target_ptr))
-        msr_ptr->smart |= SM_RES_CONF;
+        set_bit(msr_ptr->smart, SM_RES_CONF);
 
     if (has_resist_chaos(target_ptr))
-        msr_ptr->smart |= SM_RES_CHAOS;
+        set_bit(msr_ptr->smart, SM_RES_CHAOS);
 
     if (has_resist_disen(target_ptr))
-        msr_ptr->smart |= SM_RES_DISEN;
+        set_bit(msr_ptr->smart, SM_RES_DISEN);
 
     if (has_resist_blind(target_ptr))
-        msr_ptr->smart |= SM_RES_BLIND;
+        set_bit(msr_ptr->smart, SM_RES_BLIND);
 
     if (has_resist_nexus(target_ptr))
-        msr_ptr->smart |= SM_RES_NEXUS;
+        set_bit(msr_ptr->smart, SM_RES_NEXUS);
 
     if (has_resist_sound(target_ptr))
-        msr_ptr->smart |= SM_RES_SOUND;
+        set_bit(msr_ptr->smart, SM_RES_SOUND);
 
     if (has_resist_shard(target_ptr))
-        msr_ptr->smart |= SM_RES_SHARD;
+        set_bit(msr_ptr->smart, SM_RES_SHARD);
 
     if (has_reflect(target_ptr))
-        msr_ptr->smart |= SM_IMM_REFLECT;
+        set_bit(msr_ptr->smart, SM_IMM_REFLECT);
 
     if (target_ptr->free_act)
-        msr_ptr->smart |= SM_IMM_FREE;
+        set_bit(msr_ptr->smart, SM_IMM_FREE);
 
     if (!target_ptr->msp)
-        msr_ptr->smart |= SM_IMM_MANA;
+        set_bit(msr_ptr->smart, SM_IMM_MANA);
 }
 
 static void check_nether_resistance(player_type *target_ptr, msr_type *msr_ptr)
 {
-    if ((msr_ptr->smart & SM_RES_NETH) == 0)
+    if (!test_bit(msr_ptr->smart, SM_RES_NETH))
         return;
 
     if (is_specific_player_race(target_ptr, RACE_SPECTRE)) {
-        msr_ptr->f4 &= ~(RF4_BR_NETH);
-        msr_ptr->f5 &= ~(RF5_BA_NETH);
-        msr_ptr->f5 &= ~(RF5_BO_NETH);
+        reset_bit(msr_ptr->f4, RF4_BR_NETH);
+        reset_bit(msr_ptr->f5, RF5_BA_NETH);
+        reset_bit(msr_ptr->f5, RF5_BO_NETH);
         return;
     }
 
     if (int_outof(msr_ptr->r_ptr, 20))
-        msr_ptr->f4 &= ~(RF4_BR_NETH);
+        reset_bit(msr_ptr->f4, RF4_BR_NETH);
 
     if (int_outof(msr_ptr->r_ptr, 50))
-        msr_ptr->f5 &= ~(RF5_BA_NETH);
+        reset_bit(msr_ptr->f5, RF5_BA_NETH);
 
     if (int_outof(msr_ptr->r_ptr, 50))
-        msr_ptr->f5 &= ~(RF5_BO_NETH);
+        reset_bit(msr_ptr->f5, RF5_BO_NETH);
 }
 
 static void check_lite_resistance(msr_type *msr_ptr)
 {
-    if ((msr_ptr->smart & SM_RES_LITE) == 0)
+    if (!test_bit(msr_ptr->smart, SM_RES_LITE))
         return;
 
     if (int_outof(msr_ptr->r_ptr, 50))
-        msr_ptr->f4 &= ~(RF4_BR_LITE);
+        reset_bit(msr_ptr->f4, RF4_BR_LITE);
 
     if (int_outof(msr_ptr->r_ptr, 50))
-        msr_ptr->f5 &= ~(RF5_BA_LITE);
+        reset_bit(msr_ptr->f5, RF5_BA_LITE);
 }
 
 static void check_dark_resistance(player_type *target_ptr, msr_type *msr_ptr)
 {
-    if ((msr_ptr->smart & SM_RES_DARK) == 0)
+    if (!test_bit(msr_ptr->smart, SM_RES_DARK))
         return;
 
     if (is_specific_player_race(target_ptr, RACE_VAMPIRE)) {
-        msr_ptr->f4 &= ~(RF4_BR_DARK);
-        msr_ptr->f5 &= ~(RF5_BA_DARK);
+        reset_bit(msr_ptr->f4, RF4_BR_DARK);
+        reset_bit(msr_ptr->f5, RF5_BA_DARK);
         return;
     }
 
     if (int_outof(msr_ptr->r_ptr, 50))
-        msr_ptr->f4 &= ~(RF4_BR_DARK);
+        reset_bit(msr_ptr->f4, RF4_BR_DARK);
 
     if (int_outof(msr_ptr->r_ptr, 50))
-        msr_ptr->f5 &= ~(RF5_BA_DARK);
+        reset_bit(msr_ptr->f5, RF5_BA_DARK);
 }
 
 static void check_conf_resistance(msr_type *msr_ptr)
 {
-    if ((msr_ptr->smart & SM_RES_CONF) == 0)
+    if (!test_bit(msr_ptr->smart, SM_RES_CONF))
         return;
 
-    msr_ptr->f5 &= ~(RF5_CONF);
+    reset_bit(msr_ptr->f5, RF5_CONF);
     if (int_outof(msr_ptr->r_ptr, 50))
-        msr_ptr->f4 &= ~(RF4_BR_CONF);
+        reset_bit(msr_ptr->f4, RF4_BR_CONF);
 }
 
 static void check_chaos_resistance(msr_type *msr_ptr)
 {
-    if ((msr_ptr->smart & SM_RES_CHAOS) == 0)
+    if (!test_bit(msr_ptr->smart, SM_RES_CHAOS))
         return;
 
     if (int_outof(msr_ptr->r_ptr, 20))
-        msr_ptr->f4 &= ~(RF4_BR_CHAO);
+        reset_bit(msr_ptr->f4, RF4_BR_CHAO);
 
     if (int_outof(msr_ptr->r_ptr, 50))
-        msr_ptr->f4 &= ~(RF4_BA_CHAO);
+        reset_bit(msr_ptr->f4, RF4_BA_CHAO);
 }
 
 static void check_nexus_resistance(msr_type *msr_ptr)
 {
-    if ((msr_ptr->smart & SM_RES_NEXUS) == 0)
+    if (!test_bit(msr_ptr->smart, SM_RES_NEXUS))
         return;
 
     if (int_outof(msr_ptr->r_ptr, 50))
-        msr_ptr->f4 &= ~(RF4_BR_NEXU);
+        reset_bit(msr_ptr->f4, RF4_BR_NEXU);
 
-    msr_ptr->f6 &= ~(RF6_TELE_LEVEL);
+    reset_bit(msr_ptr->f6, RF6_TELE_LEVEL);
 }
 
 static void check_reflection(msr_type *msr_ptr)
 {
-    if ((msr_ptr->smart & SM_IMM_REFLECT) == 0)
+    if (!test_bit(msr_ptr->smart, SM_IMM_REFLECT))
         return;
 
     if (int_outof(msr_ptr->r_ptr, 150))
-        msr_ptr->f5 &= ~(RF5_BO_COLD);
+        reset_bit(msr_ptr->f5, RF5_BO_COLD);
 
     if (int_outof(msr_ptr->r_ptr, 150))
-        msr_ptr->f5 &= ~(RF5_BO_FIRE);
+        reset_bit(msr_ptr->f5, RF5_BO_FIRE);
 
     if (int_outof(msr_ptr->r_ptr, 150))
-        msr_ptr->f5 &= ~(RF5_BO_ACID);
+        reset_bit(msr_ptr->f5, RF5_BO_ACID);
 
     if (int_outof(msr_ptr->r_ptr, 150))
-        msr_ptr->f5 &= ~(RF5_BO_ELEC);
+        reset_bit(msr_ptr->f5, RF5_BO_ELEC);
 
     if (int_outof(msr_ptr->r_ptr, 150))
-        msr_ptr->f5 &= ~(RF5_BO_NETH);
+        reset_bit(msr_ptr->f5, RF5_BO_NETH);
 
     if (int_outof(msr_ptr->r_ptr, 150))
-        msr_ptr->f5 &= ~(RF5_BO_WATE);
+        reset_bit(msr_ptr->f5, RF5_BO_WATE);
 
     if (int_outof(msr_ptr->r_ptr, 150))
-        msr_ptr->f5 &= ~(RF5_BO_MANA);
+        reset_bit(msr_ptr->f5, RF5_BO_MANA);
 
     if (int_outof(msr_ptr->r_ptr, 150))
-        msr_ptr->f5 &= ~(RF5_BO_PLAS);
+        reset_bit(msr_ptr->f5, RF5_BO_PLAS);
 
     if (int_outof(msr_ptr->r_ptr, 150))
-        msr_ptr->f5 &= ~(RF5_BO_ICEE);
+        reset_bit(msr_ptr->f5, RF5_BO_ICEE);
 
     if (int_outof(msr_ptr->r_ptr, 150))
-        msr_ptr->f5 &= ~(RF5_MISSILE);
+        reset_bit(msr_ptr->f5, RF5_MISSILE);
 }
 
 void check_high_resistances(player_type *target_ptr, msr_type *msr_ptr)
@@ -178,30 +179,30 @@ void check_high_resistances(player_type *target_ptr, msr_type *msr_ptr)
     check_nether_resistance(target_ptr, msr_ptr);
     check_lite_resistance(msr_ptr);
     check_dark_resistance(target_ptr, msr_ptr);
-    if (msr_ptr->smart & SM_RES_FEAR)
-        msr_ptr->f5 &= ~(RF5_SCARE);
+    if (test_bit(msr_ptr->smart, SM_RES_FEAR))
+        reset_bit(msr_ptr->f5, RF5_SCARE);
 
     check_conf_resistance(msr_ptr);
     check_chaos_resistance(msr_ptr);
-    if (((msr_ptr->smart & SM_RES_DISEN) != 0) && int_outof(msr_ptr->r_ptr, 40))
-        msr_ptr->f4 &= ~(RF4_BR_DISE);
+    if (test_bit(msr_ptr->smart, SM_RES_DISEN) && int_outof(msr_ptr->r_ptr, 40))
+        reset_bit(msr_ptr->f4, RF4_BR_DISE);
 
-    if (msr_ptr->smart & SM_RES_BLIND)
-        msr_ptr->f5 &= ~(RF5_BLIND);
+    if (test_bit(msr_ptr->smart, SM_RES_BLIND))
+        reset_bit(msr_ptr->f5, RF5_BLIND);
 
     check_nexus_resistance(msr_ptr);
-    if (((msr_ptr->smart & SM_RES_SOUND) != 0) && int_outof(msr_ptr->r_ptr, 50))
-        msr_ptr->f4 &= ~(RF4_BR_SOUN);
+    if (test_bit(msr_ptr->smart, SM_RES_SOUND) && int_outof(msr_ptr->r_ptr, 50))
+        reset_bit(msr_ptr->f4, RF4_BR_SOUN);
 
-    if (((msr_ptr->smart & SM_RES_SHARD) != 0) && int_outof(msr_ptr->r_ptr, 40))
-        msr_ptr->f4 &= ~(RF4_BR_SHAR);
+    if (test_bit(msr_ptr->smart, SM_RES_SHARD) && int_outof(msr_ptr->r_ptr, 40))
+        reset_bit(msr_ptr->f4, RF4_BR_SHAR);
 
     check_reflection(msr_ptr);
-    if (msr_ptr->smart & SM_IMM_FREE) {
-        msr_ptr->f5 &= ~(RF5_HOLD);
-        msr_ptr->f5 &= ~(RF5_SLOW);
+    if (test_bit(msr_ptr->smart, SM_IMM_FREE)) {
+        reset_bit(msr_ptr->f5, RF5_HOLD);
+        reset_bit(msr_ptr->f5, RF5_SLOW);
     }
 
-    if (msr_ptr->smart & SM_IMM_MANA)
-        msr_ptr->f5 &= ~(RF5_DRAIN_MANA);
+    if (test_bit(msr_ptr->smart, SM_IMM_MANA))
+        reset_bit(msr_ptr->f5, RF5_DRAIN_MANA);
 }


### PR DESCRIPTION
可読性向上のため、BIT_FLAGS演算をマクロで置換する。
動作は変更しない。