### PR TITLE
[Fix] drawing sniper rushing arrow's moving points #251

### DIFF
--- a/src/combat/shoot.c
+++ b/src/combat/shoot.c
@@ -777,7 +777,7 @@ void exe_fire(player_type *shooter_ptr, INVENTORY_IDX item, object_type *j_ptr, 
                                 m_ptr->fx = nx;
                                 m_ptr->fy = ny;
 
-                                update_monster(shooter_ptr, c_mon_ptr->m_idx, TRUE);
+                                update_monster(shooter_ptr, m_idx, TRUE);
 
                                 if (msec > 0) {
                                     lite_spot(shooter_ptr, ny, nx);


### PR DESCRIPTION
Fix drawing oddly moving points of monster which is rushed by rushing arrow with many @s because update_monster() reference wrong monster's index.