### PR TITLE
[fix] 思い出の改行位置がおかしい #17

### DIFF
--- a/src/term/screen-processor.c
+++ b/src/term/screen-processor.c
@@ -136,25 +136,28 @@ void c_roff(TERM_COLOR a, concptr str)
 #endif
         {
             int i, n = 0;
+            const int end_col = x - 1;
 
             TERM_COLOR av[256];
             char cv[256];
-            if (x < w)
+            if (x < w) {
 #ifdef JP
-            {
                 /* 現在が半角文字の場合 */
                 if (!k_flag)
 #endif
                 {
-                    for (i = w - 2; i >= 0; i--) {
+                    for (i = 0; i <= end_col; i++) {
                         term_what(i, y, &av[i], &cv[i]);
-                        if (cv[i] == ' ')
-                            break;
 
-                        n = i;
+                        if (cv[i] == ' ') {
+                            n = i + 1;
+                        }
 #ifdef JP
-                        if (cv[i] == '(')
-                            break;
+                        if (iskanji(cv[i])) {
+                            n = i + 2;
+                            i++;
+                            term_what(i, y, &av[i], &cv[i]);
+                        }
 #endif
                     }
                 }
@@ -163,15 +166,13 @@ void c_roff(TERM_COLOR a, concptr str)
                     /* 現在が全角文字のとき */
                     /* 文頭が「。」「、」等になるときは、その１つ前の語で改行 */
                     if (strncmp(s, "。", 2) == 0 || strncmp(s, "、", 2) == 0) {
-                        term_what(x, y, &av[x], &cv[x]);
                         term_what(x - 1, y, &av[x - 1], &cv[x - 1]);
                         term_what(x - 2, y, &av[x - 2], &cv[x - 2]);
                         n = x - 2;
-                        cv[x] = '\0';
                     }
                 }
-            }
 #endif
+            }
             if (n == 0)
                 n = w;
 
@@ -182,7 +183,7 @@ void c_roff(TERM_COLOR a, concptr str)
                 break;
 
             term_erase(x, y, 255);
-            for (i = n; i < w - 1; i++) {
+            for (i = n; i <= end_col; i++) {
 #ifdef JP
                 if (cv[i] == '\0')
                     break;


### PR DESCRIPTION
思い出を描画中にASCII文字で端末の右端に到達した場合、
区切りの良い場所から次の行へ移動させるために
遡って半角スペースを探しているが、直前が日本語の
全角文字だった場合にスペースがみつかるまで
大幅に遡ってしまい、改行位置がおかしくなる。
遡った時に半角スペースに加え、全角文字である場合も
探すのを終了するべきだが、全角文字の2バイト目のコードが
SHIFT-JISの場合ASCIIとコードが被っており後ろからの
検索では全角文字の2バイト目の正確な判定ができないので、
行の先頭からASCIIと全角文字を読み分けながら次の行へ
移す位置を探すように修正する。