### PR TITLE
[Fix] #247のサブウィンドウ関連オプションをウィンドウズのメニュー処理に移行

### DIFF
--- a/src/angband.rc
+++ b/src/angband.rc
@@ -52,6 +52,8 @@ ANGBAND MENU
 			MENUITEM "サブウィンドウ 7", 227
 		}
 
+		MENUITEM "常にサブウィンドウを表示(&K)", 280
+
 		MENUITEM SEPARATOR
 
 		/*  POPUP "Bizarre Display"

--- a/src/game-option/game-play-options.c
+++ b/src/game-option/game-play-options.c
@@ -7,7 +7,6 @@ bool small_levels; /* Allow unusually small dungeon levels */
 bool always_small_levels; /* Always create unusually small dungeon levels */
 bool empty_levels; /* Allow empty 'on_defeat_arena_monster' levels */
 bool bound_walls_perm; /* Boundary walls become 'permanent wall' */
-bool keep_subwindows; /* Show sub-windows even when Hengband is not in focus */
 bool last_words; /* Leave last words when your character dies */
 bool auto_dump; /* Dump a character record automatically */
 bool auto_debug_save; /* Dump a debug savedata every key input */

--- a/src/game-option/game-play-options.h
+++ b/src/game-option/game-play-options.h
@@ -9,7 +9,6 @@ extern bool small_levels; /* Allow unusually small dungeon levels */
 extern bool always_small_levels; /* Always create unusually small dungeon levels */
 extern bool empty_levels; /* Allow empty 'on_defeat_arena_monster' levels */
 extern bool bound_walls_perm; /* Boundary walls become 'permanent wall' */
-extern bool keep_subwindows; /* Show sub-windows even when Hengband is not in focus */
 extern bool last_words; /* Leave last words when your character dies */
 extern bool auto_dump; /* Dump a character record automatically */
 extern bool auto_debug_save; /* Dump a debug savedata every key input */

--- a/src/game-option/option-types-table.c
+++ b/src/game-option/option-types-table.c
@@ -148,8 +148,6 @@ const option_type option_info[MAX_OPTION_INFO] = {
 
     { &bound_walls_perm, FALSE, OPT_PAGE_GAMEPLAY, 2, 1, "bound_walls_perm", _("ダンジョンの外壁を永久岩にする", "Boundary walls become 'permanent wall'") },
 
-    { &keep_subwindows, TRUE, OPT_PAGE_GAMEPLAY, 4, 8, "keep_subwindows", _("フォーカスが外れてもサブウィンドウを表示する", "Show sub-windows even when Hengband is not in focus") },
-
     { &last_words, TRUE, OPT_PAGE_GAMEPLAY, 0, 28, "last_words", _("キャラクターが死んだ時遺言をのこす", "Leave last words when your character dies") },
 
     { &auto_dump, FALSE, OPT_PAGE_GAMEPLAY, 4, 5, "auto_dump", _("自動的にキャラクターの記録をファイルに書き出す", "Dump a character record automatically") },

--- a/src/game-option/option-types-table.h
+++ b/src/game-option/option-types-table.h
@@ -22,7 +22,7 @@ typedef struct option_type {
     concptr o_desc;
 } option_type;
 
-#define MAX_OPTION_INFO 124
+#define MAX_OPTION_INFO 123
 #define MAX_CHEAT_OPTIONS 10
 #define MAX_AUTOSAVE_INFO 2
 

--- a/src/main-win.c
+++ b/src/main-win.c
@@ -228,6 +228,8 @@
 #define IDM_WINDOW_D_HGT_6 276
 #define IDM_WINDOW_D_HGT_7 277
 
+#define IDM_WINDOW_KEEP_SUBWINDOWS 280
+
 #define IDM_OPTIONS_NO_GRAPHICS 400
 #define IDM_OPTIONS_OLD_GRAPHICS 401
 #define IDM_OPTIONS_NEW_GRAPHICS 402
@@ -447,6 +449,11 @@ static DIBINIT infMask;
  * Flag set once "sound" has been initialized
  */
 static bool can_use_sound = FALSE;
+
+/*
+ * Show sub-windows even when Hengband is not in focus 
+ */
+static bool keep_subwindows = TRUE;
 
 #define SAMPLE_SOUND_MAX 16
 /*
@@ -834,6 +841,9 @@ static void save_prefs(void)
         WritePrivateProfileString("Angband", "SaveFile", savefile, ini_file);
     }
 
+    strcpy(buf, keep_subwindows ? "1" : "0");
+    WritePrivateProfileString("Angband", "KeepSubwindows", buf, ini_file);
+
     for (int i = 0; i < MAX_TERM_DATA; ++i) {
         save_prefs_aux(i);
     }
@@ -919,6 +929,7 @@ static void load_prefs(void)
         strncpy(savefile, tmp, strlen(tmp));
     }
 
+    keep_subwindows = (GetPrivateProfileInt("Angband", "KeepSubwindows", 0, ini_file) != 0);
     for (int i = 0; i < MAX_TERM_DATA; ++i) {
         load_prefs_aux(i);
     }
@@ -2250,6 +2261,8 @@ static void setup_menus(void)
             EnableMenuItem(hm, IDM_WINDOW_D_HGT_0 + i, MF_BYCOMMAND | MF_ENABLED);
         }
     }
+    EnableMenuItem(hm, IDM_WINDOW_KEEP_SUBWINDOWS, MF_BYCOMMAND | MF_ENABLED);
+    CheckMenuItem(hm, IDM_WINDOW_KEEP_SUBWINDOWS, (keep_subwindows ? MF_CHECKED : MF_UNCHECKED));
 
     EnableMenuItem(hm, IDM_OPTIONS_NO_GRAPHICS, MF_BYCOMMAND | MF_DISABLED | MF_GRAYED);
     EnableMenuItem(hm, IDM_OPTIONS_OLD_GRAPHICS, MF_BYCOMMAND | MF_DISABLED | MF_GRAYED);
@@ -2588,6 +2601,10 @@ static void process_menus(player_type *player_ptr, WORD wCmd)
         td->tile_hgt -= 1;
         term_getsize(td);
         term_window_resize(td);
+        break;
+    }
+    case IDM_WINDOW_KEEP_SUBWINDOWS: {
+        keep_subwindows = !keep_subwindows;
         break;
     }
     case IDM_OPTIONS_NO_GRAPHICS: {


### PR DESCRIPTION
keep_subwindowsの所作はwindowsのみに影響があるので、ゲームメニューオプションにあるべきではなかった。
オプションからは削除し、メニュー処理として改めて実装する。
ウィンドウズ固有の処理なので、保存領域としてはHengband.INIを使用する。