### PR TITLE
[Fix] 魔法の鎧使用時、実際には浮遊していない

### DIFF
--- a/src/player/player-status-flags.c
+++ b/src/player/player-status-flags.c
@@ -705,7 +705,7 @@ BIT_FLAGS has_levitation(player_type *creature_ptr)
         result = FLAG_CAUSE_BATTLE_FORM;
     }
 
-    if (creature_ptr->ult_res) {
+    if (creature_ptr->ult_res || creature_ptr->magicdef) {
         result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 


### PR DESCRIPTION
表示のみ浮遊になっているが、実際に浮遊を付与する処理が漏れていた。
該当箇所を修正。