### PR TITLE
[feature] 敵を一撃で倒すデバッグコマンド #234

### DIFF
--- a/src/wizard/cmd-wizard.c
+++ b/src/wizard/cmd-wizard.c
@@ -276,6 +276,9 @@ void do_cmd_debug(player_type *creature_ptr)
 
         player_outfit(creature_ptr);
         break;
+    case 'y':
+        wiz_kill_enemy(creature_ptr);
+        break;
     case 'z':
         wiz_zap_surrounding_monsters(creature_ptr);
         break;

--- a/src/wizard/wizard-spells.c
+++ b/src/wizard/wizard-spells.c
@@ -15,13 +15,16 @@
 #include "monster-floor/monster-summon.h"
 #include "monster-floor/place-monster-types.h"
 #include "mutation/mutation-processor.h"
+#include "spell-kind/spells-launcher.h"
 #include "spell-kind/spells-teleport.h"
 #include "spell-realm/spells-chaos.h"
+#include "spell/spell-types.h"
 #include "spell/spells-status.h"
 #include "spell/summon-types.h"
 #include "system/floor-type-definition.h"
-#include "target/target-checker.h"
 #include "target/grid-selector.h"
+#include "target/target-checker.h"
+#include "target/target-getter.h"
 #include "view/display-messages.h"
 
 debug_spell_command debug_spell_commands_list[SPELL_MAX] = {
@@ -179,4 +182,19 @@ void wiz_summon_specific_enemy(player_type *summoner_ptr, MONRACE_IDX r_idx)
 void wiz_summon_pet(player_type *summoner_ptr, MONRACE_IDX r_idx)
 {
     (void)summon_named_creature(summoner_ptr, 0, summoner_ptr->y, summoner_ptr->x, r_idx, PM_ALLOW_SLEEP | PM_ALLOW_GROUP | PM_FORCE_PET);
+}
+
+/*!
+ * @brief ターゲットを指定してダメージ100万・半径0の弱魔力のボールを放つ
+ * @return なし
+ * @details
+ */
+void wiz_kill_enemy(player_type *caster_ptr)
+{
+    DIRECTION dir;
+
+    if (!get_aim_dir(caster_ptr, &dir))
+        return;
+
+    fire_ball(caster_ptr, GF_MISSILE, dir, 1000000, 0);
 }

--- a/src/wizard/wizard-spells.h
+++ b/src/wizard/wizard-spells.h
@@ -35,3 +35,4 @@ void wiz_learn_blue_magic_all(player_type *caster_ptr);
 void wiz_summon_random_enemy(player_type *caster_ptr, int num);
 void wiz_summon_specific_enemy(player_type *summoner_ptr, MONRACE_IDX r_idx);
 void wiz_summon_pet(player_type *summoner_ptr, MONRACE_IDX r_idx);
+void wiz_kill_enemy(player_type *caster_ptr);


### PR DESCRIPTION
Implement #234.

敵を倒した時の挙動が確認しやすくなるように、敵を一撃で
倒すデバッグコマンドを追加する。
発動は ^A y で、目当ての敵を倒す以外の作用が起きない
ように、GF_MISSILE属性でダメージ100万・半径0の
ボールを放つ。