### PR TITLE
[Refactor] tim_player_flagsから二重実装になっている判定を排除

### DIFF
--- a/src/player/player-status-flags.c
+++ b/src/player/player-status-flags.c
@@ -129,13 +129,13 @@ BIT_FLAGS has_infra_vision(player_type *creature_ptr)
         tmp_rp_ptr = &race_info[creature_ptr->prace];
 
     if (tmp_rp_ptr->infra > 0)
-        result |= FLAG_CAUSE_RACE;
+        result |= 0x01U << FLAG_CAUSE_RACE;
 
     if (creature_ptr->muta3 & MUT3_INFRAVIS)
-        result |= FLAG_CAUSE_MUTATION;
+        result |= 0x01U << FLAG_CAUSE_MUTATION;
 
     if (creature_ptr->tim_infra)
-        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
 
     result |= check_equipment_flags(creature_ptr, TR_INFRA);
     return result;

--- a/src/player/temporary-resistances.c
+++ b/src/player/temporary-resistances.c
@@ -3,6 +3,7 @@
 #include "player/attack-defense-types.h"
 #include "player/player-race-types.h"
 #include "player/player-race.h"
+#include "player/player-status-flags.h"
 #include "player/special-defense-types.h"
 #include "realm/realm-hex-numbers.h"
 #include "realm/realm-song-numbers.h"
@@ -23,33 +24,16 @@
  */
 void tim_player_flags(player_type *creature_ptr, BIT_FLAGS *flags)
 {
+    BIT_FLAGS tmp_effect_flag = (0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT);
+    set_bit(tmp_effect_flag, (0x01U << FLAG_CAUSE_BATTLE_FORM));
+    BIT_FLAGS race_class_flag = (0x01U << FLAG_CAUSE_CLASS);
+    set_bit(race_class_flag, (0x01U << FLAG_CAUSE_RACE));
+
     for (int i = 0; i < TR_FLAG_SIZE; i++)
         flags[i] = 0L;
 
-    if (is_hero(creature_ptr) || is_shero(creature_ptr))
-        add_flag(flags, TR_RES_FEAR);
-    if (creature_ptr->tim_infra)
-        add_flag(flags, TR_INFRA);
-    if (creature_ptr->tim_invis)
-        add_flag(flags, TR_SEE_INVIS);
-    if (creature_ptr->tim_regen)
-        add_flag(flags, TR_REGEN);
-    if (is_time_limit_esp(creature_ptr))
-        add_flag(flags, TR_TELEPATHY);
     if (is_fast(creature_ptr) || creature_ptr->slow)
         add_flag(flags, TR_SPEED);
-
-    if (is_oppose_acid(creature_ptr) && !(creature_ptr->special_defense & DEFENSE_ACID)
-        && !(is_specific_player_race(creature_ptr, RACE_YEEK) && (creature_ptr->lev > 19)))
-        add_flag(flags, TR_RES_ACID);
-    if (is_oppose_elec(creature_ptr) && !(creature_ptr->special_defense & DEFENSE_ELEC))
-        add_flag(flags, TR_RES_ELEC);
-    if (is_oppose_fire(creature_ptr) && !(creature_ptr->special_defense & DEFENSE_FIRE))
-        add_flag(flags, TR_RES_FIRE);
-    if (is_oppose_cold(creature_ptr) && !(creature_ptr->special_defense & DEFENSE_COLD))
-        add_flag(flags, TR_RES_COLD);
-    if (is_oppose_pois(creature_ptr))
-        add_flag(flags, TR_RES_POIS);
 
     if (creature_ptr->special_attack & ATTACK_ACID)
         add_flag(flags, TR_BRAND_ACID);
@@ -61,75 +45,91 @@ void tim_player_flags(player_type *creature_ptr, BIT_FLAGS *flags)
         add_flag(flags, TR_BRAND_COLD);
     if (creature_ptr->special_attack & ATTACK_POIS)
         add_flag(flags, TR_BRAND_POIS);
-    if (creature_ptr->special_defense & DEFENSE_ACID)
+
+    if (is_oppose_acid(creature_ptr) && !test_bit(has_immune_acid(creature_ptr), (race_class_flag | tmp_effect_flag)))
+        add_flag(flags, TR_RES_ACID);
+    if (is_oppose_elec(creature_ptr) && !test_bit(has_immune_elec(creature_ptr), (race_class_flag | tmp_effect_flag)))
+        add_flag(flags, TR_RES_ELEC);
+    if (is_oppose_fire(creature_ptr) && !test_bit(has_immune_fire(creature_ptr), (race_class_flag | tmp_effect_flag)))
+        add_flag(flags, TR_RES_FIRE);
+    if (is_oppose_cold(creature_ptr) && !test_bit(has_immune_cold(creature_ptr), (race_class_flag | tmp_effect_flag)))
+        add_flag(flags, TR_RES_COLD);
+    if (is_oppose_pois(creature_ptr))
+        add_flag(flags, TR_RES_POIS);
+
+    if (test_bit(has_immune_acid(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_IM_ACID);
-    if (creature_ptr->special_defense & DEFENSE_ELEC)
+    if (test_bit(has_immune_elec(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_IM_ELEC);
-    if (creature_ptr->special_defense & DEFENSE_FIRE)
+    if (test_bit(has_immune_fire(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_IM_FIRE);
-    if (creature_ptr->special_defense & DEFENSE_COLD)
+    if (test_bit(has_immune_cold(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_IM_COLD);
-    if (creature_ptr->wraith_form)
-        add_flag(flags, TR_REFLECT);
-    if (creature_ptr->tim_reflect)
-        add_flag(flags, TR_REFLECT);
-
-    if (creature_ptr->magicdef) {
-        add_flag(flags, TR_RES_BLIND);
-        add_flag(flags, TR_RES_CONF);
-        add_flag(flags, TR_REFLECT);
-        add_flag(flags, TR_FREE_ACT);
-        add_flag(flags, TR_LEVITATION);
-    }
-
-    if (creature_ptr->tim_res_nether)
-        add_flag(flags, TR_RES_NETHER);
-
-    if (creature_ptr->tim_sh_fire)
-        add_flag(flags, TR_SH_FIRE);
-
-    if (creature_ptr->ult_res) {
-        add_flag(flags, TR_RES_FEAR);
+    
+    if (test_bit(has_resist_lite(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_RES_LITE);
+    if (test_bit(has_resist_dark(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_RES_DARK);
+    if (test_bit(has_resist_blind(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_RES_BLIND);
+    if (test_bit(has_resist_conf(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_RES_CONF);
+    if (test_bit(has_resist_sound(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_RES_SOUND);
+    if (test_bit(has_resist_shard(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_RES_SHARDS);
+    if (test_bit(has_resist_neth(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_RES_NETHER);
+    if (test_bit(has_resist_nexus(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_RES_NEXUS);
+    if (test_bit(has_resist_chaos(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_RES_CHAOS);
+    if (test_bit(has_resist_disen(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_RES_DISEN);
+
+    if (test_bit(has_resist_fear(creature_ptr), tmp_effect_flag))
+        add_flag(flags, TR_RES_FEAR);
+    if (test_bit(has_reflect(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_REFLECT);
-        add_flag(flags, TR_HOLD_EXP);
+    if (test_bit(has_sh_fire(creature_ptr), tmp_effect_flag))
+        add_flag(flags, TR_SH_FIRE);
+    if (test_bit(has_sh_cold(creature_ptr), tmp_effect_flag))
+        add_flag(flags, TR_SH_COLD);
+    if (test_bit(has_sh_elec(creature_ptr), tmp_effect_flag))
+        add_flag(flags, TR_SH_ELEC);
+
+    if (test_bit(has_free_act(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_FREE_ACT);
-        add_flag(flags, TR_SH_FIRE);
-        add_flag(flags, TR_SH_ELEC);
-        add_flag(flags, TR_SH_COLD);
-        add_flag(flags, TR_LEVITATION);
-        add_flag(flags, TR_LITE_1);
+    if (test_bit(has_see_inv(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_SEE_INVIS);
-        add_flag(flags, TR_TELEPATHY);
+    if (test_bit(has_hold_exp(creature_ptr), tmp_effect_flag))
+        add_flag(flags, TR_HOLD_EXP);
+    
+    if (test_bit(has_slow_digest(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_SLOW_DIGEST);
+    if (test_bit(has_regenerate(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_REGEN);
+    if (test_bit(has_levitation(creature_ptr), tmp_effect_flag))
+        add_flag(flags, TR_LEVITATION);
+    if (test_bit(has_lite(creature_ptr), tmp_effect_flag))
+        add_flag(flags, TR_LITE_1);
+
+    if (test_bit(has_esp_telepathy(creature_ptr), tmp_effect_flag))
+        add_flag(flags, TR_TELEPATHY);
+    
+    if (test_bit(has_sustain_str(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_SUST_STR);
+    if (test_bit(has_sustain_int(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_SUST_INT);
+    if (test_bit(has_sustain_wis(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_SUST_WIS);
+    if (test_bit(has_sustain_dex(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_SUST_DEX);
+    if (test_bit(has_sustain_con(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_SUST_CON);
+    if (test_bit(has_sustain_chr(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_SUST_CHR);
-    }
 
-    if (creature_ptr->realm1 != REALM_HEX)
-        return;
-
-    if (hex_spelling(creature_ptr, HEX_DEMON_AURA)) {
-        add_flag(flags, TR_SH_FIRE);
-        add_flag(flags, TR_REGEN);
-    }
-
-    if (hex_spelling(creature_ptr, HEX_ICE_ARMOR))
-        add_flag(flags, TR_SH_COLD);
-    if (hex_spelling(creature_ptr, HEX_SHOCK_CLOAK))
-        add_flag(flags, TR_SH_ELEC);
+    if (test_bit(has_infra_vision(creature_ptr), tmp_effect_flag))
+        add_flag(flags, TR_INFRA);
 }


### PR DESCRIPTION
表示用のテンポラリフラグ取得関数に、外部実装されているものを可能な限り使用するよう変更した。
二重に実装されている部分を排除する目的。
ついでに発見した、一時的赤外線視力のフラグが適切に反映されていないバグを修正。