### PR TITLE
[fix] テレポートレベル巻物で下の階へ移動してから階段を登ると巻物を読んだ場所に出ることがある #192

### DIFF
--- a/src/floor/floor-leaver.c
+++ b/src/floor/floor-leaver.c
@@ -409,13 +409,10 @@ void leave_floor(player_type *creature_ptr)
         set_superstealth(creature_ptr, FALSE);
 
     new_floor_id = 0;
-    FLOOR_IDX tmp_floor_idx = 0;
-    if (!creature_ptr->floor_id && (creature_ptr->change_floor_mode & CFM_SAVE_FLOORS) && !(creature_ptr->change_floor_mode & CFM_NO_RETURN))
-        tmp_floor_idx = get_new_floor_id(creature_ptr);
 
     preserve_info(creature_ptr);
     saved_floor_type *sf_ptr = get_sf_ptr(creature_ptr->floor_id);
-    if ((creature_ptr->change_floor_mode & CFM_RAND_CONNECT) && tmp_floor_idx)
+    if (creature_ptr->change_floor_mode & CFM_RAND_CONNECT)
         locate_connected_stairs(creature_ptr, creature_ptr->current_floor_ptr, sf_ptr, creature_ptr->change_floor_mode);
 
     exe_leave_floor(creature_ptr, sf_ptr);


### PR DESCRIPTION
レベルテレポートで移動した時に移動元フロアの階段から適当なものを
選んで移動先のフロアにつなげる処理が呼ばれていないため、移動元
フロアの最後に居た位置に戻ってしまうのが原因。
そもそも上述の処理が呼ばれていない原因となっている、フロアIDを
新規に取得する処理が不要だと思われる（後に再度取得されている）
ので、その部分の処理を削除して階段をつなげる処理が必ず
行われるようにする。