### PR TITLE
﻿[Add] .editorconfig を追加

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+﻿root = true
+
+[*]
+charset = utf-8-bom
+insert_final_newline = true


### PR DESCRIPTION
新規ファイルを追加する際、エンコーディングなどが統一されないミスが生じていたので、自動で統一されるよう .editorconfig を追加する。

設定は以下の通り:

* エンコーディング: UTF-8-BOM
* ファイル末尾の改行: あり