### PR TITLE
[refactor] UTF-8 ↔ EUC-JPの変換処理を共通化

### DIFF
--- a/src/locale/japanese.c
+++ b/src/locale/japanese.c
@@ -13,51 +13,30 @@
 
 typedef struct convert_key convert_key;
 
-struct convert_key
-{
-	concptr key1;
-	concptr key2;
+struct convert_key {
+    concptr key1;
+    concptr key2;
 };
 
-static const convert_key s2j_table[] = {
-	{"mb","nb"}, {"mp","np"}, {"mv","nv"}, {"mm","nm"},
-	{"x","ks"},
-	/* sindar:シンダール  parantir:パランティア  feanor:フェアノール */
-	{"ar$","a-ru$"}, {"ir$","ia$"}, {"or$","o-ru$"},
-	{"ra","ラ"}, {"ri","リ"}, {"ru","ル"}, {"re","レ"}, {"ro","ロ"},
-	{"ir","ia"}, {"ur","ua"}, {"er","ea"}, {"ar","aル"},
-	{"sha","シャ"}, {"shi","シ"}, {"shu","シュ"}, {"she","シェ"}, {"sho","ショ"},
-	{"tha","サ"}, {"thi","シ"}, {"thu","ス"}, {"the","セ"}, {"tho","ソ"},
-	{"cha","ハ"}, {"chi","ヒ"}, {"chu","フ"}, {"che","ヘ"}, {"cho","ホ"},
-	{"dha","ザ"}, {"dhi","ジ"}, {"dhu","ズ"}, {"dhe","ゼ"}, {"dho","ゾ"},
-	{"ba","バ"}, {"bi","ビ"}, {"bu","ブ"}, {"be","ベ"}, {"bo","ボ"},
-	{"ca","カ"}, {"ci","キ"}, {"cu","ク"}, {"ce","ケ"}, {"co","コ"},
-	{"da","ダ"}, {"di","ディ"}, {"du","ドゥ"}, {"de","デ"}, {"do","ド"},
-	{"fa","ファ"}, {"fi","フィ"}, {"fu","フ"}, {"fe","フェ"}, {"fo","フォ"},
-	{"ga","ガ"}, {"gi","ギ"}, {"gu","グ"}, {"ge","ゲ"}, {"go","ゴ"},
-	{"ha","ハ"}, {"hi","ヒ"}, {"hu","フ"}, {"he","ヘ"}, {"ho","ホ"},
-	{"ja","ジャ"}, {"ji","ジ"}, {"ju","ジュ"}, {"je","ジェ"}, {"jo","ジョ"},
-	{"ka","カ"}, {"ki","キ"}, {"ku","ク"}, {"ke","ケ"}, {"ko","コ"},
-	{"la","ラ"}, {"li","リ"}, {"lu","ル"}, {"le","レ"}, {"lo","ロ"},
-	{"ma","マ"}, {"mi","ミ"}, {"mu","ム"}, {"me","メ"}, {"mo","モ"},
-	{"na","ナ"}, {"ni","ニ"}, {"nu","ヌ"}, {"ne","ネ"}, {"no","ノ"},
-	{"pa","パ"}, {"pi","ピ"}, {"pu","プ"}, {"pe","ペ"}, {"po","ポ"},
-	{"qu","ク"},
-	{"sa","サ"}, {"si","シ"}, {"su","ス"}, {"se","セ"}, {"so","ソ"},
-	{"ta","タ"}, {"ti","ティ"}, {"tu","トゥ"}, {"te","テ"}, {"to","ト"},
-	{"va","ヴァ"}, {"vi","ヴィ"}, {"vu","ヴ"}, {"ve","ヴェ"}, {"vo","ヴォ"},
-	{"wa","ワ"}, {"wi","ウィ"}, {"wu","ウ"}, {"we","ウェ"}, {"wo","ウォ"},
-	{"ya","ヤ"}, {"yu","ユ"}, {"yo","ヨ"},
-	{"za","ザ"}, {"zi","ジ"}, {"zu","ズ"}, {"ze","ゼ"}, {"zo","ゾ"},
-	{"dh","ズ"}, {"ch","フ"}, {"th","ス"},
-	{"b","ブ"}, {"c","ク"}, {"d","ド"}, {"f","フ"}, {"g","グ"},
-	{"h","フ"}, {"j","ジュ"}, {"k","ク"}, {"l","ル"}, {"m","ム"},
-	{"n","ン"}, {"p","プ"}, {"q","ク"}, {"r","ル"}, {"s","ス"},
-	{"t","ト"}, {"v","ヴ"}, {"w","ウ"}, {"y","イ"},
-	{"a","ア"}, {"i","イ"}, {"u","ウ"}, {"e","エ"}, {"o","オ"},
-	{"-","ー"},
-	{NULL,NULL}
-};
+static const convert_key s2j_table[] = { { "mb", "nb" }, { "mp", "np" }, { "mv", "nv" }, { "mm", "nm" }, { "x", "ks" },
+    /* sindar:シンダール  parantir:パランティア  feanor:フェアノール */
+    { "ar$", "a-ru$" }, { "ir$", "ia$" }, { "or$", "o-ru$" }, { "ra", "ラ" }, { "ri", "リ" }, { "ru", "ル" }, { "re", "レ" }, { "ro", "ロ" }, { "ir", "ia" },
+    { "ur", "ua" }, { "er", "ea" }, { "ar", "aル" }, { "sha", "シャ" }, { "shi", "シ" }, { "shu", "シュ" }, { "she", "シェ" }, { "sho", "ショ" },
+    { "tha", "サ" }, { "thi", "シ" }, { "thu", "ス" }, { "the", "セ" }, { "tho", "ソ" }, { "cha", "ハ" }, { "chi", "ヒ" }, { "chu", "フ" }, { "che", "ヘ" },
+    { "cho", "ホ" }, { "dha", "ザ" }, { "dhi", "ジ" }, { "dhu", "ズ" }, { "dhe", "ゼ" }, { "dho", "ゾ" }, { "ba", "バ" }, { "bi", "ビ" }, { "bu", "ブ" },
+    { "be", "ベ" }, { "bo", "ボ" }, { "ca", "カ" }, { "ci", "キ" }, { "cu", "ク" }, { "ce", "ケ" }, { "co", "コ" }, { "da", "ダ" }, { "di", "ディ" },
+    { "du", "ドゥ" }, { "de", "デ" }, { "do", "ド" }, { "fa", "ファ" }, { "fi", "フィ" }, { "fu", "フ" }, { "fe", "フェ" }, { "fo", "フォ" }, { "ga", "ガ" },
+    { "gi", "ギ" }, { "gu", "グ" }, { "ge", "ゲ" }, { "go", "ゴ" }, { "ha", "ハ" }, { "hi", "ヒ" }, { "hu", "フ" }, { "he", "ヘ" }, { "ho", "ホ" },
+    { "ja", "ジャ" }, { "ji", "ジ" }, { "ju", "ジュ" }, { "je", "ジェ" }, { "jo", "ジョ" }, { "ka", "カ" }, { "ki", "キ" }, { "ku", "ク" }, { "ke", "ケ" },
+    { "ko", "コ" }, { "la", "ラ" }, { "li", "リ" }, { "lu", "ル" }, { "le", "レ" }, { "lo", "ロ" }, { "ma", "マ" }, { "mi", "ミ" }, { "mu", "ム" },
+    { "me", "メ" }, { "mo", "モ" }, { "na", "ナ" }, { "ni", "ニ" }, { "nu", "ヌ" }, { "ne", "ネ" }, { "no", "ノ" }, { "pa", "パ" }, { "pi", "ピ" },
+    { "pu", "プ" }, { "pe", "ペ" }, { "po", "ポ" }, { "qu", "ク" }, { "sa", "サ" }, { "si", "シ" }, { "su", "ス" }, { "se", "セ" }, { "so", "ソ" },
+    { "ta", "タ" }, { "ti", "ティ" }, { "tu", "トゥ" }, { "te", "テ" }, { "to", "ト" }, { "va", "ヴァ" }, { "vi", "ヴィ" }, { "vu", "ヴ" }, { "ve", "ヴェ" },
+    { "vo", "ヴォ" }, { "wa", "ワ" }, { "wi", "ウィ" }, { "wu", "ウ" }, { "we", "ウェ" }, { "wo", "ウォ" }, { "ya", "ヤ" }, { "yu", "ユ" }, { "yo", "ヨ" },
+    { "za", "ザ" }, { "zi", "ジ" }, { "zu", "ズ" }, { "ze", "ゼ" }, { "zo", "ゾ" }, { "dh", "ズ" }, { "ch", "フ" }, { "th", "ス" }, { "b", "ブ" },
+    { "c", "ク" }, { "d", "ド" }, { "f", "フ" }, { "g", "グ" }, { "h", "フ" }, { "j", "ジュ" }, { "k", "ク" }, { "l", "ル" }, { "m", "ム" }, { "n", "ン" },
+    { "p", "プ" }, { "q", "ク" }, { "r", "ル" }, { "s", "ス" }, { "t", "ト" }, { "v", "ヴ" }, { "w", "ウ" }, { "y", "イ" }, { "a", "ア" }, { "i", "イ" },
+    { "u", "ウ" }, { "e", "エ" }, { "o", "オ" }, { "-", "ー" }, { NULL, NULL } };
 
 /*!
  * @brief シンダリンを日本語の読みに変換する
@@ -68,92 +47,87 @@ static const convert_key s2j_table[] = {
  */
 void sindarin_to_kana(char *kana, concptr sindarin)
 {
-	char buf[256];
-	int idx;
+    char buf[256];
+    int idx;
 
-	sprintf(kana, "%s$", sindarin);
-	for (idx = 0; kana[idx]; idx++)
-		if (isupper(kana[idx])) kana[idx] = (char)tolower(kana[idx]);
+    sprintf(kana, "%s$", sindarin);
+    for (idx = 0; kana[idx]; idx++)
+        if (isupper(kana[idx]))
+            kana[idx] = (char)tolower(kana[idx]);
 
-	for (idx = 0; s2j_table[idx].key1 != NULL; idx++)
-	{
-		concptr pat1 = s2j_table[idx].key1;
-		concptr pat2 = s2j_table[idx].key2;
-		int len = strlen(pat1);
-		char *src = kana;
-		char *dest = buf;
+    for (idx = 0; s2j_table[idx].key1 != NULL; idx++) {
+        concptr pat1 = s2j_table[idx].key1;
+        concptr pat2 = s2j_table[idx].key2;
+        int len = strlen(pat1);
+        char *src = kana;
+        char *dest = buf;
 
-		while (*src)
-		{
-			if (strncmp(src, pat1, len) == 0)
-			{
-				strcpy(dest, pat2);
-				src += len;
-				dest += strlen(pat2);
-			}
-			else
-			{
-				if (iskanji(*src))
-				{
-					*dest = *src;
-					src++;
-					dest++;
-				}
-				*dest = *src;
-				src++;
-				dest++;
-			}
-		}
+        while (*src) {
+            if (strncmp(src, pat1, len) == 0) {
+                strcpy(dest, pat2);
+                src += len;
+                dest += strlen(pat2);
+            } else {
+                if (iskanji(*src)) {
+                    *dest = *src;
+                    src++;
+                    dest++;
+                }
+                *dest = *src;
+                src++;
+                dest++;
+            }
+        }
 
-		*dest = 0;
-		strcpy(kana, buf);
-	}
+        *dest = 0;
+        strcpy(kana, buf);
+    }
 
-	idx = 0;
+    idx = 0;
 
-	while (kana[idx] != '$') idx++;
+    while (kana[idx] != '$')
+        idx++;
 
-	kana[idx] = '\0';
+    kana[idx] = '\0';
 }
-
 
 /*! 日本語動詞活用 (打つ＞打って,打ち etc)
  * JVERB_AND: 殴る,蹴る > 殴り,蹴る
  * JVERB_TO:  殴る,蹴る > 殴って蹴る
  * JVERB_OR:  殴る,蹴る > 殴ったり蹴ったり */
 static const struct jverb_table_t {
-	const char* from;
-	const char* to[3];
+    const char *from;
+    const char *to[3];
 } jverb_table[] = {
-	{ "する", {"し", "して", "した"}},
-	{ "いる", {"いて", "いて", "いた"}},
+    { "する", { "し", "して", "した" } },
+    { "いる", { "いて", "いて", "いた" } },
 
-	{ "える", {"え", "えて", "えた"}},
-	{ "ける", {"け", "けて", "けた"}},
-	{ "げる", {"げ", "えて", "げた"}},
-	{ "せる", {"せ", "せて", "せた"}},
-	{ "ぜる", {"ぜ", "ぜて", "ぜた"}},
-	{ "てる", {"て", "てって", "てった"}},
-	{ "でる", {"で", "でて", "でた"}},
-	{ "ねる", {"ね", "ねて", "ねた"}},
-	{ "へる", {"へ", "へて", "へた"}},
-	{ "べる", {"べ", "べて", "べた"}},
-	{ "める", {"め", "めて", "めた"}},
-	{ "れる", {"れ", "れて", "れた"}},
+    { "える", { "え", "えて", "えた" } },
+    { "ける", { "け", "けて", "けた" } },
+    { "げる", { "げ", "えて", "げた" } },
+    { "せる", { "せ", "せて", "せた" } },
+    { "ぜる", { "ぜ", "ぜて", "ぜた" } },
+    { "てる", { "て", "てって", "てった" } },
+    { "でる", { "で", "でて", "でた" } },
+    { "ねる", { "ね", "ねて", "ねた" } },
+    { "へる", { "へ", "へて", "へた" } },
+    { "べる", { "べ", "べて", "べた" } },
+    { "める", { "め", "めて", "めた" } },
+    { "れる", { "れ", "れて", "れた" } },
 
-	{ "う", {"い", "って", "った"}},
-	{ "く", {"き", "いて", "いた"}},
-	{ "ぐ", {"ぎ", "いで", "いだ"}},
-	{ "す", {"し", "して", "した"}},
-	{ "ず", {"じ", "じて", "じた"}},
-	{ "つ", {"ち", "って", "った"}},
-	{ "づ", {"ぢ", "って", "った"}},
-	{ "ぬ", {"に", "ねて", "ねた"}},
-	{ "ふ", {"ひ", "へて", "へた"}},
-	{ "ぶ", {"び", "んで", "んだ"}},
-	{ "む", {"み", "んで", "んだ"}},
-	{ "る", {"り", "って", "った"}},
-	{ NULL, {"そして", "ことにより", "ことや"}},
+    { "う", { "い", "って", "った" } },
+    { "く", { "き", "いて", "いた" } },
+    { "ぐ", { "ぎ", "いで", "いだ" } },
+    { "す", { "し", "して", "した" } },
+    { "ず", { "じ", "じて", "じた" } },
+    { "つ", { "ち", "って", "った" } },
+    { "づ", { "ぢ", "って", "った" } },
+    { "ぬ", { "に", "ねて", "ねた" } },
+    { "ふ", { "ひ", "へて", "へた" } },
+    { "ぶ", { "び", "んで", "んだ" } },
+    { "む", { "み", "んで", "んだ" } },
+    { "る", { "り", "って", "った" } },
+    { NULL, { "そして", "ことにより", "ことや" } },
 };
 
 /*!
@@ -166,21 +140,21 @@ static const struct jverb_table_t {
  */
 void jverb(concptr in, char *out, int flag)
 {
-	const struct jverb_table_t * p;
-	int in_len = strlen(in);
+    const struct jverb_table_t *p;
+    int in_len = strlen(in);
 
-	strcpy(out, in);
+    strcpy(out, in);
 
-	for (p = jverb_table; p->from; p++) {
-		int from_len = strlen(p->from);
-		if (strncmp(&in[in_len-from_len], p->from, from_len) == 0) {
-			strcpy(&out[in_len - from_len], p->to[flag - 1]);
-			break;
-		}
-	}
+    for (p = jverb_table; p->from; p++) {
+        int from_len = strlen(p->from);
+        if (strncmp(&in[in_len - from_len], p->from, from_len) == 0) {
+            strcpy(&out[in_len - from_len], p->to[flag - 1]);
+            break;
+        }
+    }
 
-	if (p->from == NULL)
-		strcpy(&out[in_len], p->to[flag - 1]);
+    if (p->from == NULL)
+        strcpy(&out[in_len], p->to[flag - 1]);
 }
 
 /*!
@@ -191,43 +165,36 @@ void jverb(concptr in, char *out, int flag)
  */
 void sjis2euc(char *str)
 {
-	int i;
-	unsigned char c1, c2;
-	unsigned char *tmp;
+    int i;
+    unsigned char c1, c2;
+    unsigned char *tmp;
 
-	int len = strlen(str);
+    int len = strlen(str);
 
-	C_MAKE(tmp, len+1, byte);
+    C_MAKE(tmp, len + 1, byte);
 
-	for (i = 0; i < len; i++)
-	{
-		c1 = str[i];
-		if (c1 & 0x80)
-		{
-			i++;
-			c2 = str[i];
-			if (c2 >= 0x9f)
-			{
-				c1 = c1 * 2 - (c1 >= 0xe0 ? 0xe0 : 0x60);
-				c2 += 2;
-			}
-			else
-			{
-				c1 = c1 * 2 - (c1 >= 0xe0 ? 0xe1 : 0x61);
-				c2 += 0x60 + (c2 < 0x7f);
-			}
-			tmp[i - 1] = c1;
-			tmp[i] = c2;
-		}
-		else
-			tmp[i] = c1;
-	}
-	tmp[len] = 0;
-	strcpy(str, (char *)tmp);
+    for (i = 0; i < len; i++) {
+        c1 = str[i];
+        if (c1 & 0x80) {
+            i++;
+            c2 = str[i];
+            if (c2 >= 0x9f) {
+                c1 = c1 * 2 - (c1 >= 0xe0 ? 0xe0 : 0x60);
+                c2 += 2;
+            } else {
+                c1 = c1 * 2 - (c1 >= 0xe0 ? 0xe1 : 0x61);
+                c2 += 0x60 + (c2 < 0x7f);
+            }
+            tmp[i - 1] = c1;
+            tmp[i] = c2;
+        } else
+            tmp[i] = c1;
+    }
+    tmp[len] = 0;
+    strcpy(str, (char *)tmp);
 
-	C_KILL(tmp, len+1, byte);
-}  
-
+    C_KILL(tmp, len + 1, byte);
+}
 
 /*!
  * @brief 文字コードをEUCからSJISに変換する / Convert EUC string to SJIS string
@@ -237,49 +204,42 @@ void sjis2euc(char *str)
  */
 void euc2sjis(char *str)
 {
-	int i;
-	unsigned char c1, c2;
-	unsigned char *tmp;
-	
-	int len = strlen(str);
+    int i;
+    unsigned char c1, c2;
+    unsigned char *tmp;
 
-	C_MAKE(tmp, len+1, byte);
+    int len = strlen(str);
 
-	for (i = 0; i < len; i++)
-	{
-		c1 = str[i];
-		if (c1 & 0x80)
-		{
-			i++;
-			c2 = str[i];
-			if (c1 % 2)
-			{
-				c1 = (c1 >> 1) + (c1 < 0xdf ? 0x31 : 0x71);
-				c2 -= 0x60 + (c2 < 0xe0);
-			}
-			else
-			{
-				c1 = (c1 >> 1) + (c1 < 0xdf ? 0x30 : 0x70);
-				c2 -= 2;
-			}
+    C_MAKE(tmp, len + 1, byte);
 
-			tmp[i - 1] = c1;
-			tmp[i] = c2;
-		}
-		else
-			tmp[i] = c1;
-	}
-	tmp[len] = 0;
-	strcpy(str, (char *)tmp);
+    for (i = 0; i < len; i++) {
+        c1 = str[i];
+        if (c1 & 0x80) {
+            i++;
+            c2 = str[i];
+            if (c1 % 2) {
+                c1 = (c1 >> 1) + (c1 < 0xdf ? 0x31 : 0x71);
+                c2 -= 0x60 + (c2 < 0xe0);
+            } else {
+                c1 = (c1 >> 1) + (c1 < 0xdf ? 0x30 : 0x70);
+                c2 -= 2;
+            }
 
-	C_KILL(tmp, len+1, byte);
-}  
+            tmp[i - 1] = c1;
+            tmp[i] = c2;
+        } else
+            tmp[i] = c1;
+    }
+    tmp[len] = 0;
+    strcpy(str, (char *)tmp);
 
+    C_KILL(tmp, len + 1, byte);
+}
 
 /*!
  * @brief strを環境に合った文字コードに変換し、変換前の文字コードを返す。strの長さに制限はない。
  * @param str 変換する文字列のポインタ
- * @return 
+ * @return
  * 0: Unknown<br>
  * 1: ASCII (Never known to be ASCII in this function.)<br>
  * 2: EUC<br>
@@ -287,84 +247,73 @@ void euc2sjis(char *str)
  */
 byte codeconv(char *str)
 {
-	byte code = 0;
-	int i;
+    byte code = 0;
+    int i;
 
-	for (i = 0; str[i]; i++)
-	{
-		unsigned char c1;
-		unsigned char c2;
+    for (i = 0; str[i]; i++) {
+        unsigned char c1;
+        unsigned char c2;
 
-		/* First byte */
-		c1 = str[i];
+        /* First byte */
+        c1 = str[i];
 
-		/* ASCII? */
-		if (!(c1 & 0x80)) continue;
+        /* ASCII? */
+        if (!(c1 & 0x80))
+            continue;
 
-		/* Second byte */
-		i++;
-		c2 = str[i];
+        /* Second byte */
+        i++;
+        c2 = str[i];
 
-		if (((0xa1 <= c1 && c1 <= 0xdf) || (0xfd <= c1 && c1 <= 0xfe)) &&
-		    (0xa1 <= c2 && c2 <= 0xfe))
-		{
-			/* Only EUC is allowed */
-			if (!code)
-			{
-				/* EUC */
-				code = 2;
-			}
+        if (((0xa1 <= c1 && c1 <= 0xdf) || (0xfd <= c1 && c1 <= 0xfe)) && (0xa1 <= c2 && c2 <= 0xfe)) {
+            /* Only EUC is allowed */
+            if (!code) {
+                /* EUC */
+                code = 2;
+            }
 
-			/* Broken string? */
-			else if (code != 2)
-			{
-				/* No conversion */
-				return 0;
-			}
-		}
+            /* Broken string? */
+            else if (code != 2) {
+                /* No conversion */
+                return 0;
+            }
+        }
 
-		else if (((0x81 <= c1 && c1 <= 0x9f) &&
-			  ((0x40 <= c2 && c2 <= 0x7e) || (0x80 <= c2 && c2 <= 0xfc))) ||
-			 ((0xe0 <= c1 && c1 <= 0xfc) &&
-			  (0x40 <= c2 && c2 <= 0x7e)))
-		{
-			/* Only SJIS is allowed */
-			if (!code)
-			{
-				/* SJIS */
-				code = 3;
-			}
+        else if (((0x81 <= c1 && c1 <= 0x9f) && ((0x40 <= c2 && c2 <= 0x7e) || (0x80 <= c2 && c2 <= 0xfc)))
+            || ((0xe0 <= c1 && c1 <= 0xfc) && (0x40 <= c2 && c2 <= 0x7e))) {
+            /* Only SJIS is allowed */
+            if (!code) {
+                /* SJIS */
+                code = 3;
+            }
 
-			/* Broken string? */
-			else if (code != 3)
-			{
-				/* No conversion */
-				return 0;
-			}
-		}
-	}
+            /* Broken string? */
+            else if (code != 3) {
+                /* No conversion */
+                return 0;
+            }
+        }
+    }
 
-
-	switch (code)
-	{
+    switch (code) {
 #ifdef EUC
-	case 3:
-		/* SJIS -> EUC */
-		sjis2euc(str);
-		break;
+    case 3:
+        /* SJIS -> EUC */
+        sjis2euc(str);
+        break;
 #endif
 
 #ifdef SJIS
-	case 2:
-		/* EUC -> SJIS */
-		euc2sjis(str);
+    case 2:
+        /* EUC -> SJIS */
+        euc2sjis(str);
 
-		break;
+        break;
 #endif
-	}
+    }
 
-	/* Return kanji code */
-	return code;
+    /* Return kanji code */
+    return code;
 }
 
 /*!
@@ -375,15 +324,16 @@ byte codeconv(char *str)
  */
 bool iskanji2(concptr s, int x)
 {
-	int i;
+    int i;
 
-	for (i = 0; i < x; i++)
-	{
-		if (iskanji(s[i])) i++;
-	}
-	if ((x == i) && iskanji(s[x])) return TRUE;
+    for (i = 0; i < x; i++) {
+        if (iskanji(s[i]))
+            i++;
+    }
+    if ((x == i) && iskanji(s[x]))
+        return TRUE;
 
-	return FALSE;
+    return FALSE;
 }
 
 /*!
@@ -393,23 +343,23 @@ bool iskanji2(concptr s, int x)
  */
 static bool is_ascii_str(concptr str)
 {
-	for (;*str; str++) {
-		int ch = *str;
-		if (!(0x00 < ch && ch <= 0x7f))
-			return FALSE;
-	}
-	return TRUE;
+    for (; *str; str++) {
+        int ch = *str;
+        if (!(0x00 < ch && ch <= 0x7f))
+            return FALSE;
+    }
+    return TRUE;
 }
 
 #if defined(EUC)
 #include <iconv.h>
 
 static const struct ms_to_jis_unicode_conv_t {
-	char from[3];
-	char to[3];
+    char from[3];
+    char to[3];
 } ms_to_jis_unicode_conv[] = {
-	{{0xef, 0xbd, 0x9e}, {0xe3, 0x80, 0x9c}}, /* FULLWIDTH TILDE -> WAVE DASH */
-	{{0xef, 0xbc, 0x8d}, {0xe2, 0x88, 0x92}}, /* FULLWIDTH HYPHEN-MINUS -> MINUS SIGN */
+    { { 0xef, 0xbd, 0x9e }, { 0xe3, 0x80, 0x9c } }, /* FULLWIDTH TILDE -> WAVE DASH */
+    { { 0xef, 0xbc, 0x8d }, { 0xe2, 0x88, 0x92 } }, /* FULLWIDTH HYPHEN-MINUS -> MINUS SIGN */
 };
 
 /*!
@@ -417,28 +367,31 @@ static const struct ms_to_jis_unicode_conv_t {
  * @param str 変換する文字列のポインタ
  * @return なし
  */
-static void ms_to_jis_unicode(char* str)
+static void ms_to_jis_unicode(char *str)
 {
-	unsigned char* p;
-	for (p = (unsigned char*)str; *p; p++) {
-		int subseq_num = 0;
-		if (0x00 < *p && *p <= 0x7f) continue;
+    unsigned char *p;
+    for (p = (unsigned char *)str; *p; p++) {
+        int subseq_num = 0;
+        if (0x00 < *p && *p <= 0x7f)
+            continue;
 
-		if ((*p & 0xe0) == 0xc0) subseq_num = 1;
-		if ((*p & 0xf0) == 0xe0) {
-			size_t i;
-			for (i = 0; i < sizeof(ms_to_jis_unicode_conv) / sizeof(ms_to_jis_unicode_conv[0]); ++ i) {
-				const struct ms_to_jis_unicode_conv_t *c = &ms_to_jis_unicode_conv[i];
-				if (memcmp(p, c->from, 3) == 0) {
-					memcpy(p, c->to, 3);
-				}
-			}
-			subseq_num = 2;
+        if ((*p & 0xe0) == 0xc0)
+            subseq_num = 1;
+        if ((*p & 0xf0) == 0xe0) {
+            size_t i;
+            for (i = 0; i < sizeof(ms_to_jis_unicode_conv) / sizeof(ms_to_jis_unicode_conv[0]); ++i) {
+                const struct ms_to_jis_unicode_conv_t *c = &ms_to_jis_unicode_conv[i];
+                if (memcmp(p, c->from, 3) == 0) {
+                    memcpy(p, c->to, 3);
                 }
-		if ((*p & 0xf8) == 0xf0) subseq_num = 3;
+            }
+            subseq_num = 2;
+        }
+        if ((*p & 0xf8) == 0xf0)
+            subseq_num = 3;
 
-		p += subseq_num;
-	}
+        p += subseq_num;
+    }
 }
 
 #elif defined(SJIS) && defined(WINDOWS)
@@ -451,41 +404,41 @@ static void ms_to_jis_unicode(char* str)
  * @param sys_str_buflen 変換したシステムの文字コードの文字列を格納するバッファの長さ
  * @return 変換に成功した場合TRUE、失敗した場合FALSEを返す
  */
-static bool utf8_to_sys(char* utf8_str, char* sys_str_buffer, size_t sys_str_buflen)
+static bool utf8_to_sys(char *utf8_str, char *sys_str_buffer, size_t sys_str_buflen)
 {
 #if defined(EUC)
 
-	iconv_t cd = iconv_open("EUC-JP", "UTF-8");
-	size_t utf8_len = strlen(utf8_str) + 1; /* include termination character */
-	char *from = utf8_str;
-	int ret;
+    iconv_t cd = iconv_open("EUC-JP", "UTF-8");
+    size_t utf8_len = strlen(utf8_str) + 1; /* include termination character */
+    char *from = utf8_str;
+    int ret;
 
-	ms_to_jis_unicode(utf8_str);
-	ret = iconv(cd, &from, &utf8_len, &sys_str_buffer, &sys_str_buflen);
-	iconv_close(cd);
-	return (ret >= 0);
+    ms_to_jis_unicode(utf8_str);
+    ret = iconv(cd, &from, &utf8_len, &sys_str_buffer, &sys_str_buflen);
+    iconv_close(cd);
+    return (ret >= 0);
 
 #elif defined(SJIS) && defined(WINDOWS)
 
-	LPWSTR utf16buf;
-	int input_len = strlen(utf8_str) + 1; /* include termination character */
+    LPWSTR utf16buf;
+    int input_len = strlen(utf8_str) + 1; /* include termination character */
 
-	C_MAKE(utf16buf, input_len, WCHAR);
+    C_MAKE(utf16buf, input_len, WCHAR);
 
-	/* UTF-8 -> UTF-16 */
-	if (MultiByteToWideChar( CP_UTF8, 0, utf8_str, input_len, utf16buf, input_len) == 0) {
-		C_KILL(utf16buf, input_len, WCHAR);
-		return FALSE;
-	}
+    /* UTF-8 -> UTF-16 */
+    if (MultiByteToWideChar(CP_UTF8, 0, utf8_str, input_len, utf16buf, input_len) == 0) {
+        C_KILL(utf16buf, input_len, WCHAR);
+        return FALSE;
+    }
 
-	/* UTF-8 -> SJIS(CP932) */
-	if (WideCharToMultiByte( CP_ACP, 0, utf16buf, -1, sys_str_buffer, sys_str_buflen, NULL, NULL ) == 0) {
-		C_KILL(utf16buf, input_len, WCHAR);
-		return FALSE;
-	}
+    /* UTF-8 -> SJIS(CP932) */
+    if (WideCharToMultiByte(CP_ACP, 0, utf16buf, -1, sys_str_buffer, sys_str_buflen, NULL, NULL) == 0) {
+        C_KILL(utf16buf, input_len, WCHAR);
+        return FALSE;
+    }
 
-	C_KILL(utf16buf, input_len, WCHAR);
-	return TRUE;
+    C_KILL(utf16buf, input_len, WCHAR);
+    return TRUE;
 
 #endif
 }
@@ -498,20 +451,21 @@ static bool utf8_to_sys(char* utf8_str, char* sys_str_buffer, size_t sys_str_buf
  * @param buflen バッファの長さ。
  * @return なし
  */
-void guess_convert_to_system_encoding(char* strbuf, int buflen)
+void guess_convert_to_system_encoding(char *strbuf, int buflen)
 {
-	if (is_ascii_str(strbuf)) return;
+    if (is_ascii_str(strbuf))
+        return;
 
-	if (is_utf8_str(strbuf)) {
-		char* work;
-		C_MAKE(work, buflen, char);
-		angband_strcpy(work, strbuf, buflen);
-		if (!utf8_to_sys(work, strbuf, buflen)) {
-			msg_print("警告:文字コードの変換に失敗しました");
-			msg_print(NULL);
-		}
-		C_KILL(work, buflen, char);
-	}
+    if (is_utf8_str(strbuf)) {
+        char *work;
+        C_MAKE(work, buflen, char);
+        angband_strcpy(work, strbuf, buflen);
+        if (!utf8_to_sys(work, strbuf, buflen)) {
+            msg_print("警告:文字コードの変換に失敗しました");
+            msg_print(NULL);
+        }
+        C_KILL(work, buflen, char);
+    }
 }
 
 #endif /* JP */

--- a/src/locale/japanese.h
+++ b/src/locale/japanese.h
@@ -14,4 +14,10 @@ void euc2sjis(char *str);
 byte codeconv(char *str);
 bool iskanji2(concptr s, int x);
 void guess_convert_to_system_encoding(char* strbuf, int buflen);
+
+#ifdef EUC
+int utf8_to_euc(char *utf8_str, size_t utf8_str_len, char *euc_buf, size_t euc_buf_len);
+int euc_to_utf8(const char *euc_str, size_t euc_str_len, char *utf8_buf, size_t utf8_buf_len);
+#endif
+
 #endif

--- a/src/main-gcu.c
+++ b/src/main-gcu.c
@@ -30,7 +30,8 @@
  * Date: 1 Apr 99 05:40:14 GMT
  * Organization: University of Missouri - Rolla
  * Lines: 199
- * Path: xs4all!xs4all!newsfeed.wirehub.nl!news-peer.gip.net!news.gsl.net!gip.net!news.he.net!mercury.cts.com!alpha.sky.net!news.missouri.edu!news.cc.umr.edu!not-for-mail
+ * Path:
+ * xs4all!xs4all!newsfeed.wirehub.nl!news-peer.gip.net!news.gsl.net!gip.net!news.he.net!mercury.cts.com!alpha.sky.net!news.missouri.edu!news.cc.umr.edu!not-for-mail
  * Xref: xs4all rec.games.roguelike.angband:86332
  *
  * Greg Wooledge <wooledge@kellnet.com> wrote:
@@ -156,13 +157,13 @@
  * XXX XXX XXX Consider the use of "savetty()" and "resetty()".
  */
 
-#include "system/angband.h"
 #include "game-option/runtime-arguments.h"
 #include "game-option/special-options.h"
 #include "io/exit-panic.h"
 #include "io/files-util.h"
 #include "main/sound-definitions-table.h"
 #include "main/sound-of-music.h"
+#include "system/angband.h"
 #include "term/gameterm.h"
 #include "term/term-color-types.h"
 #include "util/angband-files.h"
@@ -183,11 +184,10 @@
 
 typedef struct term_data term_data;
 
-struct term_data
-{
-   term_type t;
+struct term_data {
+    term_type t;
 
-   WINDOW *win;
+    WINDOW *win;
 };
 
 #define MAX_TERM_DATA 4
@@ -203,15 +203,15 @@ static iconv_t iconv_to_gui;
  * If the user defines two of these, we will probably crash.
  */
 #if !defined(USE_TCHARS)
-# if defined(_POSIX_VERSION)
-#  define USE_TPOSIX
-# else
-#  if defined(linux)
-#   define USE_TERMIO
-#  else
-#   define USE_TCHARS
-#  endif
-# endif
+#if defined(_POSIX_VERSION)
+#define USE_TPOSIX
+#else
+#if defined(linux)
+#define USE_TERMIO
+#else
+#define USE_TCHARS
+#endif
+#endif
 #endif
 
 /*
@@ -223,27 +223,27 @@ static iconv_t iconv_to_gui;
  * POSIX stuff
  */
 #ifdef USE_TPOSIX
-# include <sys/ioctl.h>
-# include <termios.h>
+#include <sys/ioctl.h>
+#include <termios.h>
 #endif
 
 /*
  * One version needs this file
  */
 #ifdef USE_TERMIO
-# include <sys/ioctl.h>
-# include <termio.h>
+#include <sys/ioctl.h>
+#include <termio.h>
 #endif
 
 /*
  * The other needs this file
  */
 #ifdef USE_TCHARS
-# include <sys/ioctl.h>
-# include <sys/resource.h>
-# include <sys/param.h>
-# include <sys/file.h>
-# include <sys/types.h>
+#include <sys/file.h>
+#include <sys/ioctl.h>
+#include <sys/param.h>
+#include <sys/resource.h>
+#include <sys/types.h>
 #endif
 
 #include <locale.h>
@@ -254,7 +254,7 @@ static iconv_t iconv_to_gui;
  * They should both work due to the "(i != 1)" test below.
  */
 #ifndef O_NDELAY
-# define O_NDELAY O_NONBLOCK
+#define O_NDELAY O_NONBLOCK
 #endif
 
 /*
@@ -289,30 +289,30 @@ static concptr sound_file[SOUND_MAX];
 
 #ifdef USE_TPOSIX
 
-static struct termios  norm_termios;
+static struct termios norm_termios;
 
-static struct termios  game_termios;
+static struct termios game_termios;
 
 #endif
 
 #ifdef USE_TERMIO
 
-static struct termio  norm_termio;
+static struct termio norm_termio;
 
-static struct termio  game_termio;
+static struct termio game_termio;
 
 #endif
 
 #ifdef USE_TCHARS
 static struct ltchars norm_speciax_chars;
-static struct sgttyb  norm_ttyb;
-static struct tchars  norm_tchars;
-static int            norm_locax_chars;
+static struct sgttyb norm_ttyb;
+static struct tchars norm_tchars;
+static int norm_locax_chars;
 
 static struct ltchars game_speciax_chars;
-static struct sgttyb  game_ttyb;
-static struct tchars  game_tchars;
-static int            game_locax_chars;
+static struct sgttyb game_ttyb;
+static struct tchars game_tchars;
+static int game_locax_chars;
 #endif
 
 /*
@@ -326,7 +326,7 @@ static int active = 0;
  * machines, "A_BRIGHT" produces ugly "inverse" video.
  */
 #ifndef A_BRIGHT
-# define A_BRIGHT A_BOLD
+#define A_BRIGHT A_BOLD
 #endif
 
 /*
@@ -351,24 +351,23 @@ static int colortable[16];
 static void keymap_norm(void)
 {
 #ifdef USE_TPOSIX
-   /* restore the saved values of the special chars */
-   (void)tcsetattr(0, TCSAFLUSH, &norm_termios);
+    /* restore the saved values of the special chars */
+    (void)tcsetattr(0, TCSAFLUSH, &norm_termios);
 #endif
 
 #ifdef USE_TERMIO
-   /* restore the saved values of the special chars */
-   (void)ioctl(0, TCSETA, (char *)&norm_termio);
+    /* restore the saved values of the special chars */
+    (void)ioctl(0, TCSETA, (char *)&norm_termio);
 #endif
 
 #ifdef USE_TCHARS
-   /* restore the saved values of the special chars */
-   (void)ioctl(0, TIOCSLTC, (char *)&norm_speciax_chars);
-   (void)ioctl(0, TIOCSETP, (char *)&norm_ttyb);
-   (void)ioctl(0, TIOCSETC, (char *)&norm_tchars);
-   (void)ioctl(0, TIOCLSET, (char *)&norm_locax_chars);
+    /* restore the saved values of the special chars */
+    (void)ioctl(0, TIOCSLTC, (char *)&norm_speciax_chars);
+    (void)ioctl(0, TIOCSETP, (char *)&norm_ttyb);
+    (void)ioctl(0, TIOCSETC, (char *)&norm_tchars);
+    (void)ioctl(0, TIOCLSET, (char *)&norm_locax_chars);
 #endif
 }
-
 
 /*
  * Place the "keymap" into the "game" state
@@ -376,24 +375,23 @@ static void keymap_norm(void)
 static void keymap_game(void)
 {
 #ifdef USE_TPOSIX
-   /* restore the saved values of the special chars */
-   (void)tcsetattr(0, TCSAFLUSH, &game_termios);
+    /* restore the saved values of the special chars */
+    (void)tcsetattr(0, TCSAFLUSH, &game_termios);
 #endif
 
 #ifdef USE_TERMIO
-   /* restore the saved values of the special chars */
-   (void)ioctl(0, TCSETA, (char *)&game_termio);
+    /* restore the saved values of the special chars */
+    (void)ioctl(0, TCSETA, (char *)&game_termio);
 #endif
 
 #ifdef USE_TCHARS
-   /* restore the saved values of the special chars */
-   (void)ioctl(0, TIOCSLTC, (char *)&game_speciax_chars);
-   (void)ioctl(0, TIOCSETP, (char *)&game_ttyb);
-   (void)ioctl(0, TIOCSETC, (char *)&game_tchars);
-   (void)ioctl(0, TIOCLSET, (char *)&game_locax_chars);
+    /* restore the saved values of the special chars */
+    (void)ioctl(0, TIOCSLTC, (char *)&game_speciax_chars);
+    (void)ioctl(0, TIOCSETP, (char *)&game_ttyb);
+    (void)ioctl(0, TIOCSETC, (char *)&game_tchars);
+    (void)ioctl(0, TIOCLSET, (char *)&game_locax_chars);
 #endif
 }
-
 
 /*
  * Save the normal keymap
@@ -401,24 +399,23 @@ static void keymap_game(void)
 static void keymap_norm_prepare(void)
 {
 #ifdef USE_TPOSIX
-   /* Get the normal keymap */
-   tcgetattr(0, &norm_termios);
+    /* Get the normal keymap */
+    tcgetattr(0, &norm_termios);
 #endif
 
 #ifdef USE_TERMIO
-   /* Get the normal keymap */
-   (void)ioctl(0, TCGETA, (char *)&norm_termio);
+    /* Get the normal keymap */
+    (void)ioctl(0, TCGETA, (char *)&norm_termio);
 #endif
 
 #ifdef USE_TCHARS
-   /* Get the normal keymap */
-   (void)ioctl(0, TIOCGETP, (char *)&norm_ttyb);
-   (void)ioctl(0, TIOCGLTC, (char *)&norm_speciax_chars);
-   (void)ioctl(0, TIOCGETC, (char *)&norm_tchars);
-   (void)ioctl(0, TIOCLGET, (char *)&norm_locax_chars);
+    /* Get the normal keymap */
+    (void)ioctl(0, TIOCGETP, (char *)&norm_ttyb);
+    (void)ioctl(0, TIOCGLTC, (char *)&norm_speciax_chars);
+    (void)ioctl(0, TIOCGETC, (char *)&norm_tchars);
+    (void)ioctl(0, TIOCLGET, (char *)&norm_locax_chars);
 #endif
 }
-
 
 /*
  * Save the keymaps (normal and game)
@@ -426,233 +423,228 @@ static void keymap_norm_prepare(void)
 static void keymap_game_prepare(void)
 {
 #ifdef USE_TPOSIX
-   /* Acquire the current mapping */
-   tcgetattr(0, &game_termios);
+    /* Acquire the current mapping */
+    tcgetattr(0, &game_termios);
 
-   /* Force "Ctrl-C" to interupt */
-   game_termios.c_cc[VINTR] = (char)3;
+    /* Force "Ctrl-C" to interupt */
+    game_termios.c_cc[VINTR] = (char)3;
 
-   /* Force "Ctrl-Z" to suspend */
-   game_termios.c_cc[VSUSP] = (char)26;
+    /* Force "Ctrl-Z" to suspend */
+    game_termios.c_cc[VSUSP] = (char)26;
 
-   /* Hack -- Leave "VSTART/VSTOP" alone */
+    /* Hack -- Leave "VSTART/VSTOP" alone */
 
-   /* Disable the standard control characters */
-   game_termios.c_cc[VQUIT] = (char)-1;
-   game_termios.c_cc[VERASE] = (char)-1;
-   game_termios.c_cc[VKILL] = (char)-1;
-   game_termios.c_cc[VEOF] = (char)-1;
-   game_termios.c_cc[VEOL] = (char)-1;
+    /* Disable the standard control characters */
+    game_termios.c_cc[VQUIT] = (char)-1;
+    game_termios.c_cc[VERASE] = (char)-1;
+    game_termios.c_cc[VKILL] = (char)-1;
+    game_termios.c_cc[VEOF] = (char)-1;
+    game_termios.c_cc[VEOL] = (char)-1;
 
-   /* Normally, block until a character is read */
-   game_termios.c_cc[VMIN] = 1;
-   game_termios.c_cc[VTIME] = 0;
+    /* Normally, block until a character is read */
+    game_termios.c_cc[VMIN] = 1;
+    game_termios.c_cc[VTIME] = 0;
 #endif
 
 #ifdef USE_TERMIO
-   /* Acquire the current mapping */
-   (void)ioctl(0, TCGETA, (char *)&game_termio);
+    /* Acquire the current mapping */
+    (void)ioctl(0, TCGETA, (char *)&game_termio);
 
-   /* Force "Ctrl-C" to interupt */
-   game_termio.c_cc[VINTR] = (char)3;
+    /* Force "Ctrl-C" to interupt */
+    game_termio.c_cc[VINTR] = (char)3;
 
-   /* Force "Ctrl-Z" to suspend */
-   game_termio.c_cc[VSUSP] = (char)26;
+    /* Force "Ctrl-Z" to suspend */
+    game_termio.c_cc[VSUSP] = (char)26;
 
-   /* Disable the standard control characters */
-   game_termio.c_cc[VQUIT] = (char)-1;
-   game_termio.c_cc[VERASE] = (char)-1;
-   game_termio.c_cc[VKILL] = (char)-1;
-   game_termio.c_cc[VEOF] = (char)-1;
-   game_termio.c_cc[VEOL] = (char)-1;
+    /* Disable the standard control characters */
+    game_termio.c_cc[VQUIT] = (char)-1;
+    game_termio.c_cc[VERASE] = (char)-1;
+    game_termio.c_cc[VKILL] = (char)-1;
+    game_termio.c_cc[VEOF] = (char)-1;
+    game_termio.c_cc[VEOL] = (char)-1;
 
-   /* Normally, block until a character is read */
-   game_termio.c_cc[VMIN] = 1;
-   game_termio.c_cc[VTIME] = 0;
+    /* Normally, block until a character is read */
+    game_termio.c_cc[VMIN] = 1;
+    game_termio.c_cc[VTIME] = 0;
 #endif
 
 #ifdef USE_TCHARS
-   /* Get the default game characters */
-   (void)ioctl(0, TIOCGETP, (char *)&game_ttyb);
-   (void)ioctl(0, TIOCGLTC, (char *)&game_speciax_chars);
-   (void)ioctl(0, TIOCGETC, (char *)&game_tchars);
-   (void)ioctl(0, TIOCLGET, (char *)&game_locax_chars);
+    /* Get the default game characters */
+    (void)ioctl(0, TIOCGETP, (char *)&game_ttyb);
+    (void)ioctl(0, TIOCGLTC, (char *)&game_speciax_chars);
+    (void)ioctl(0, TIOCGETC, (char *)&game_tchars);
+    (void)ioctl(0, TIOCLGET, (char *)&game_locax_chars);
 
-   /* Force suspend (^Z) */
-   game_speciax_chars.t_suspc = (char)26;
+    /* Force suspend (^Z) */
+    game_speciax_chars.t_suspc = (char)26;
 
-   /* Cancel some things */
-   game_speciax_chars.t_dsuspc = (char)-1;
-   game_speciax_chars.t_rprntc = (char)-1;
-   game_speciax_chars.t_flushc = (char)-1;
-   game_speciax_chars.t_werasc = (char)-1;
-   game_speciax_chars.t_lnextc = (char)-1;
+    /* Cancel some things */
+    game_speciax_chars.t_dsuspc = (char)-1;
+    game_speciax_chars.t_rprntc = (char)-1;
+    game_speciax_chars.t_flushc = (char)-1;
+    game_speciax_chars.t_werasc = (char)-1;
+    game_speciax_chars.t_lnextc = (char)-1;
 
-   /* Force interupt (^C) */
-   game_tchars.t_intrc = (char)3;
+    /* Force interupt (^C) */
+    game_tchars.t_intrc = (char)3;
 
-   /* Force start/stop (^Q, ^S) */
-   game_tchars.t_startc = (char)17;
-   game_tchars.t_stopc = (char)19;
+    /* Force start/stop (^Q, ^S) */
+    game_tchars.t_startc = (char)17;
+    game_tchars.t_stopc = (char)19;
 
-   /* Cancel some things */
-   game_tchars.t_quitc = (char)-1;
-   game_tchars.t_eofc = (char)-1;
-   game_tchars.t_brkc = (char)-1;
+    /* Cancel some things */
+    game_tchars.t_quitc = (char)-1;
+    game_tchars.t_eofc = (char)-1;
+    game_tchars.t_brkc = (char)-1;
 #endif
 }
-
-
 
 /*
  * Suspend/Resume
  */
 static errr Term_xtra_gcu_alive(int v)
 {
-   if (!v)
-   {
-      /* Go to normal keymap mode */
-      keymap_norm();
+    if (!v) {
+        /* Go to normal keymap mode */
+        keymap_norm();
 
-      /* Restore modes */
-      nocbreak();
-      echo();
-      nl();
+        /* Restore modes */
+        nocbreak();
+        echo();
+        nl();
 
-      /* Hack -- make sure the cursor is visible */
-      term_xtra(TERM_XTRA_SHAPE, 1);
+        /* Hack -- make sure the cursor is visible */
+        term_xtra(TERM_XTRA_SHAPE, 1);
 
-      /* Flush the curses buffer */
-      (void)refresh();
+        /* Flush the curses buffer */
+        (void)refresh();
 
-      /* this moves curses to bottom right corner */
-      mvcur(getcury(curscr), getcurx(curscr), LINES - 1, 0);
+        /* this moves curses to bottom right corner */
+        mvcur(getcury(curscr), getcurx(curscr), LINES - 1, 0);
 
-      /* Exit curses */
-      endwin();
+        /* Exit curses */
+        endwin();
 
-      /* Flush the output */
-      (void)fflush(stdout);
-   }
-   else
-   {
-      /* Restore the settings */
-      cbreak();
-      noecho();
-      nonl();
+        /* Flush the output */
+        (void)fflush(stdout);
+    } else {
+        /* Restore the settings */
+        cbreak();
+        noecho();
+        nonl();
 
-      /* Go to angband keymap mode */
-      keymap_game();
-   }
+        /* Go to angband keymap mode */
+        keymap_game();
+    }
 
-   return (0);
+    return (0);
 }
-
 
 /*
  * Check for existance of a file
  */
 static bool check_file(concptr s)
 {
-   FILE *fff;
-   fff = fopen(s, "r");
-   if (!fff) return (FALSE);
+    FILE *fff;
+    fff = fopen(s, "r");
+    if (!fff)
+        return (FALSE);
 
-   fclose(fff);
-   return (TRUE);
+    fclose(fff);
+    return (TRUE);
 }
-
 
 /*
  * Initialize sound
  */
 static bool init_sound(void)
 {
-   /* Initialize once */
-	if (can_use_sound) return can_use_sound;
+    /* Initialize once */
+    if (can_use_sound)
+        return can_use_sound;
 
-	int i;
-	char wav[128];
-	char buf[1024];
+    int i;
+    char wav[128];
+    char buf[1024];
 
-	/* Prepare the sounds */
-	for (i = 1; i < SOUND_MAX; i++)
-	{
-		/* Extract name of sound file */
-		sprintf(wav, "%s.wav", angband_sound_name[i]);
+    /* Prepare the sounds */
+    for (i = 1; i < SOUND_MAX; i++) {
+        /* Extract name of sound file */
+        sprintf(wav, "%s.wav", angband_sound_name[i]);
 
-		/* Access the sound */
-		path_build(buf, sizeof(buf), ANGBAND_DIR_XTRA_SOUND, wav);
+        /* Access the sound */
+        path_build(buf, sizeof(buf), ANGBAND_DIR_XTRA_SOUND, wav);
 
-		/* Save the sound filename, if it exists */
-		if (check_file(buf)) sound_file[i] = string_make(buf);
-	}
+        /* Save the sound filename, if it exists */
+        if (check_file(buf))
+            sound_file[i] = string_make(buf);
+    }
 
-	/* Sound available */
-	can_use_sound = TRUE;
-	return (can_use_sound);
+    /* Sound available */
+    can_use_sound = TRUE;
+    return (can_use_sound);
 }
-
 
 /*
  * Init the "curses" system
  */
 static void Term_init_gcu(term_type *t)
 {
-   term_data *td = (term_data *)(t->data);
+    term_data *td = (term_data *)(t->data);
 
-   /* Count init's, handle first */
-   if (active++ != 0) return;
+    /* Count init's, handle first */
+    if (active++ != 0)
+        return;
 
-   /* Erase the screen */
-   (void)wclear(td->win);
+    /* Erase the screen */
+    (void)wclear(td->win);
 
-   /* Reset the cursor */
-   (void)wmove(td->win, 0, 0);
+    /* Reset the cursor */
+    (void)wmove(td->win, 0, 0);
 
-   /* Flush changes */
-   (void)wrefresh(td->win);
+    /* Flush changes */
+    (void)wrefresh(td->win);
 
-   /* Game keymap */
-   keymap_game();
+    /* Game keymap */
+    keymap_game();
 }
-
 
 /*
  * Nuke the "curses" system
  */
 static void Term_nuke_gcu(term_type *t)
 {
-   term_data *td = (term_data *)(t->data);
+    term_data *td = (term_data *)(t->data);
 
-   /* Delete this window */
-   delwin(td->win);
+    /* Delete this window */
+    delwin(td->win);
 
-   /* Count nuke's, handle last */
-   if (--active != 0) return;
+    /* Count nuke's, handle last */
+    if (--active != 0)
+        return;
 
-   /* Hack -- make sure the cursor is visible */
-   term_xtra(TERM_XTRA_SHAPE, 1);
+    /* Hack -- make sure the cursor is visible */
+    term_xtra(TERM_XTRA_SHAPE, 1);
 
 #ifdef A_COLOR
-  /* Reset colors to defaults */
-  start_color();
+    /* Reset colors to defaults */
+    start_color();
 #endif
 
-   /* This moves curses to bottom right corner */
-   mvcur(getcury(curscr), getcurx(curscr), LINES - 1, 0);
+    /* This moves curses to bottom right corner */
+    mvcur(getcury(curscr), getcurx(curscr), LINES - 1, 0);
 
-   /* Flush the curses buffer */
-   (void)refresh();
+    /* Flush the curses buffer */
+    (void)refresh();
 
-   /* Exit curses */
-   endwin();
+    /* Exit curses */
+    endwin();
 
-   /* Flush the output */
-   (void)fflush(stdout);
+    /* Flush the output */
+    (void)fflush(stdout);
 
-   /* Normal keymap */
-   keymap_norm();
+    /* Normal keymap */
+    keymap_norm();
 }
 
 /*
@@ -660,22 +652,25 @@ static void Term_nuke_gcu(term_type *t)
  */
 static void convert_to_sys(char *buf)
 {
-   size_t inlen = strlen(buf);
-   size_t outlen = inlen;
-   char tmp[outlen + 1];
+    size_t inlen = strlen(buf);
+    size_t outlen = inlen;
+    char tmp[outlen + 1];
 
-   char *inbuf = buf;
-   char *outbuf = tmp;
-   size_t res;
-   res = iconv(iconv_to_sys, 0, 0, 0, 0);
-   if(res == (size_t)-1) return;
-   res = iconv(iconv_to_sys, &inbuf, &inlen, &outbuf, &outlen);
-   if(res == (size_t)-1) return;
-   res = iconv(iconv_to_sys, 0, 0, &outbuf, &outlen);
-   if(res == (size_t)-1) return;
+    char *inbuf = buf;
+    char *outbuf = tmp;
+    size_t res;
+    res = iconv(iconv_to_sys, 0, 0, 0, 0);
+    if (res == (size_t)-1)
+        return;
+    res = iconv(iconv_to_sys, &inbuf, &inlen, &outbuf, &outlen);
+    if (res == (size_t)-1)
+        return;
+    res = iconv(iconv_to_sys, 0, 0, &outbuf, &outlen);
+    if (res == (size_t)-1)
+        return;
 
-   outbuf[0] = '\0';
-   strcpy(buf, tmp);
+    outbuf[0] = '\0';
+    strcpy(buf, tmp);
 }
 
 /*
@@ -683,9 +678,9 @@ static void convert_to_sys(char *buf)
  */
 static void term_string_push(char *buf)
 {
-   int i, l = strlen(buf);
-   for (i = l; i >= 0; i--)
-      term_key_push(buf[i]);
+    int i, l = strlen(buf);
+    for (i = l; i >= 0; i--)
+        term_key_push(buf[i]);
 }
 
 #ifdef USE_GETCH
@@ -695,66 +690,69 @@ static void term_string_push(char *buf)
  */
 static errr Term_xtra_gcu_event(int v)
 {
-   int i, k;
+    int i, k;
 
-   /* Wait */
-   if (v)
-   {
-      char buf[256];
-      char *bp = buf;
+    /* Wait */
+    if (v) {
+        char buf[256];
+        char *bp = buf;
 
-      /* Paranoia -- Wait for it */
-      nodelay(stdscr, FALSE);
+        /* Paranoia -- Wait for it */
+        nodelay(stdscr, FALSE);
 
-      /* Get a keypress */
-      i = getch();
+        /* Get a keypress */
+        i = getch();
 
-      /* Broken input is special */
-      if (i == ERR) exit_game_panic(p_ptr);
-      if (i == EOF) exit_game_panic(p_ptr);
+        /* Broken input is special */
+        if (i == ERR)
+            exit_game_panic(p_ptr);
+        if (i == EOF)
+            exit_game_panic(p_ptr);
 
-      *bp++ = (char)i;
+        *bp++ = (char)i;
 
-      /* Do not wait for it */
-      nodelay(stdscr, TRUE);
+        /* Do not wait for it */
+        nodelay(stdscr, TRUE);
 
-      while((i = getch()) != EOF)
-      {
-         if (i == ERR) exit_game_panic(p_ptr);
-         *bp++ = (char)i;
-         if (bp == &buf[255]) break;
-      }
+        while ((i = getch()) != EOF) {
+            if (i == ERR)
+                exit_game_panic(p_ptr);
+            *bp++ = (char)i;
+            if (bp == &buf[255])
+                break;
+        }
 
-      /* Wait for it next time */
-      nodelay(stdscr, FALSE);
+        /* Wait for it next time */
+        nodelay(stdscr, FALSE);
 
-      *bp = '\0';
-      convert_to_sys(buf);
-      term_string_push(buf);
-   }
+        *bp = '\0';
+        convert_to_sys(buf);
+        term_string_push(buf);
+    }
 
-   /* Do not wait */
-   else
-   {
-      /* Do not wait for it */
-      nodelay(stdscr, TRUE);
+    /* Do not wait */
+    else {
+        /* Do not wait for it */
+        nodelay(stdscr, TRUE);
 
-      /* Check for keypresses */
-      i = getch();
+        /* Check for keypresses */
+        i = getch();
 
-      /* Wait for it next time */
-      nodelay(stdscr, FALSE);
+        /* Wait for it next time */
+        nodelay(stdscr, FALSE);
 
-      /* None ready */
-      if (i == ERR) return (1);
-      if (i == EOF) return (1);
+        /* None ready */
+        if (i == ERR)
+            return (1);
+        if (i == EOF)
+            return (1);
 
-      /* Enqueue the keypress */
-      term_key_push(i);
-   }
+        /* Enqueue the keypress */
+        term_key_push(i);
+    }
 
-   /* Success */
-   return (0);
+    /* Success */
+    return (0);
 }
 
 #else /* USE_GETCH */
@@ -764,99 +762,103 @@ static errr Term_xtra_gcu_event(int v)
  */
 static errr Term_xtra_gcu_event(int v)
 {
-   int i, k;
+    int i, k;
 
-   char buf[256];
+    char buf[256];
 
-   /* Wait */
-   if (v)
-   {
-      char *bp = buf;
+    /* Wait */
+    if (v) {
+        char *bp = buf;
 
-      /* Wait for one byte */
-      i = read(0, bp++, 1);
+        /* Wait for one byte */
+        i = read(0, bp++, 1);
 
-      /* Hack -- Handle bizarre "errors" */
-      if ((i <= 0) && (errno != EINTR)) exit_game_panic(p_ptr);
+        /* Hack -- Handle bizarre "errors" */
+        if ((i <= 0) && (errno != EINTR))
+            exit_game_panic(p_ptr);
 
-      /* Get the current flags for stdin */
-      k = fcntl(0, F_GETFL, 0);
+        /* Get the current flags for stdin */
+        k = fcntl(0, F_GETFL, 0);
 
-      /* Oops */
-      if (k < 0) return (1);
+        /* Oops */
+        if (k < 0)
+            return (1);
 
-      /* Tell stdin not to block */
-      if (fcntl(0, F_SETFL, k | O_NDELAY) >= 0)
-      {
-         if ((i = read(0, bp, 254)) > 0)
-         {
-            bp += i;
-         }
+        /* Tell stdin not to block */
+        if (fcntl(0, F_SETFL, k | O_NDELAY) >= 0) {
+            if ((i = read(0, bp, 254)) > 0) {
+                bp += i;
+            }
 
-         /* Replace the flags for stdin */
-         if (fcntl(0, F_SETFL, k)) return (1);
-      }
+            /* Replace the flags for stdin */
+            if (fcntl(0, F_SETFL, k))
+                return (1);
+        }
 
-      bp[0] = '\0';
-      convert_to_sys(buf);
-      term_string_push(buf);
-   }
+        bp[0] = '\0';
+        convert_to_sys(buf);
+        term_string_push(buf);
+    }
 
-   /* Do not wait */
-   else
-   {
-      /* Get the current flags for stdin */
-      k = fcntl(0, F_GETFL, 0);
+    /* Do not wait */
+    else {
+        /* Get the current flags for stdin */
+        k = fcntl(0, F_GETFL, 0);
 
-      /* Oops */
-      if (k < 0) return (1);
+        /* Oops */
+        if (k < 0)
+            return (1);
 
-      /* Tell stdin not to block */
-      if (fcntl(0, F_SETFL, k | O_NDELAY) < 0) return (1);
+        /* Tell stdin not to block */
+        if (fcntl(0, F_SETFL, k | O_NDELAY) < 0)
+            return (1);
 
-      /* Read one byte, if possible */
-      i = read(0, buf, 1);
+        /* Read one byte, if possible */
+        i = read(0, buf, 1);
 
-      /* Replace the flags for stdin */
-      if (fcntl(0, F_SETFL, k)) return (1);
+        /* Replace the flags for stdin */
+        if (fcntl(0, F_SETFL, k))
+            return (1);
 
-      /* Ignore "invalid" keys */
-      if ((i != 1) || (!buf[0])) return (1);
+        /* Ignore "invalid" keys */
+        if ((i != 1) || (!buf[0]))
+            return (1);
 
-      /* Enqueue the keypress */
-      term_key_push(buf[0]);
-   }
+        /* Enqueue the keypress */
+        term_key_push(buf[0]);
+    }
 
-   /* Success */
-   return (0);
+    /* Success */
+    return (0);
 }
 
-#endif   /* USE_GETCH */
+#endif /* USE_GETCH */
 
 /*
  * Hack -- make a sound
  */
 static errr Term_xtra_gcu_sound(int v)
 {
-   char buf[1024];
+    char buf[1024];
 
-   /* Sound disabled */
-   if (!use_sound) return (1);
+    /* Sound disabled */
+    if (!use_sound)
+        return (1);
 
-   /* Illegal sound */
-   if ((v < 0) || (v >= SOUND_MAX)) return (1);
+    /* Illegal sound */
+    if ((v < 0) || (v >= SOUND_MAX))
+        return (1);
 
-   /* Unknown sound */
-   if (!sound_file[v]) return (1);
+    /* Unknown sound */
+    if (!sound_file[v])
+        return (1);
 
-   sprintf(buf,"./gcusound.sh %s\n", sound_file[v]);
-   
-   return (system(buf) < 0);
+    sprintf(buf, "./gcusound.sh %s\n", sound_file[v]);
 
-   return (0);
+    return (system(buf) < 0);
 
+    return (0);
 }
-
 
 /*
  * React to changes
@@ -866,110 +868,103 @@ static errr Term_xtra_gcu_react(void)
 
 #ifdef A_COLOR
 
-	int i;
+    int i;
 
-	/* Cannot handle color redefinition */
-	if (!can_fix_color) return (0);
+    /* Cannot handle color redefinition */
+    if (!can_fix_color)
+        return (0);
 
-	/* Set the colors */
-	for (i = 0; i < 16; i++)
-	{
-		/* Set one color (note scaling) */
-		init_color(i, angband_color_table[i][1] * 1000 / 255,
-			      angband_color_table[i][2] * 1000 / 255,
-			      angband_color_table[i][3] * 1000 / 255);
-	}
+    /* Set the colors */
+    for (i = 0; i < 16; i++) {
+        /* Set one color (note scaling) */
+        init_color(i, angband_color_table[i][1] * 1000 / 255, angband_color_table[i][2] * 1000 / 255, angband_color_table[i][3] * 1000 / 255);
+    }
 
 #endif
 
-	/* Success */
-	return (0);
+    /* Success */
+    return (0);
 }
-
 
 /*
  * Handle a "special request"
  */
 static errr Term_xtra_gcu(int n, int v)
 {
-   term_data *td = (term_data *)(Term->data);
+    term_data *td = (term_data *)(Term->data);
 
-   /* Analyze the request */
-   switch (n)
-   {
-      /* Clear screen */
-      case TERM_XTRA_CLEAR:
-      touchwin(td->win);
-      (void)wclear(td->win);
-      return (0);
+    /* Analyze the request */
+    switch (n) {
+    /* Clear screen */
+    case TERM_XTRA_CLEAR:
+        touchwin(td->win);
+        (void)wclear(td->win);
+        return (0);
 
-      /* Make a noise */
-      case TERM_XTRA_NOISE:
-      return write(1, "\007", 1) != 1;
+    /* Make a noise */
+    case TERM_XTRA_NOISE:
+        return write(1, "\007", 1) != 1;
 
-      /* Make a special sound */
-      case TERM_XTRA_SOUND:
-	 return (Term_xtra_gcu_sound(v));
+    /* Make a special sound */
+    case TERM_XTRA_SOUND:
+        return (Term_xtra_gcu_sound(v));
 
-      /* Flush the Curses buffer */
-      case TERM_XTRA_FRESH:
-      (void)wrefresh(td->win);
-      return (0);
+    /* Flush the Curses buffer */
+    case TERM_XTRA_FRESH:
+        (void)wrefresh(td->win);
+        return (0);
 
 #ifdef USE_CURS_SET
 
-      /* Change the cursor visibility */
-      case TERM_XTRA_SHAPE:
-      curs_set(v);
-      return (0);
+    /* Change the cursor visibility */
+    case TERM_XTRA_SHAPE:
+        curs_set(v);
+        return (0);
 
 #endif
 
-      /* Suspend/Resume curses */
-      case TERM_XTRA_ALIVE:
-      return (Term_xtra_gcu_alive(v));
+    /* Suspend/Resume curses */
+    case TERM_XTRA_ALIVE:
+        return (Term_xtra_gcu_alive(v));
 
-      /* Process events */
-      case TERM_XTRA_EVENT:
-      return (Term_xtra_gcu_event(v));
+    /* Process events */
+    case TERM_XTRA_EVENT:
+        return (Term_xtra_gcu_event(v));
 
-      /* Flush events */
-      case TERM_XTRA_FLUSH:
-      while (!Term_xtra_gcu_event(FALSE));
-      return (0);
+    /* Flush events */
+    case TERM_XTRA_FLUSH:
+        while (!Term_xtra_gcu_event(FALSE))
+            ;
+        return (0);
 
-      /* Delay */
-      case TERM_XTRA_DELAY:
-      usleep(1000 * v);
-      return (0);
+    /* Delay */
+    case TERM_XTRA_DELAY:
+        usleep(1000 * v);
+        return (0);
 
-      /* React to events */
-      case TERM_XTRA_REACT:
-      Term_xtra_gcu_react();
-      return (0);
+    /* React to events */
+    case TERM_XTRA_REACT:
+        Term_xtra_gcu_react();
+        return (0);
+    }
 
-   }
-
-
-   /* Unknown */
-   return (1);
+    /* Unknown */
+    return (1);
 }
-
 
 /*
  * Actually MOVE the hardware cursor
  */
 static errr Term_curs_gcu(int x, int y)
 {
-   term_data *td = (term_data *)(Term->data);
+    term_data *td = (term_data *)(Term->data);
 
-   /* Literally move the cursor */
-   wmove(td->win, y, x);
+    /* Literally move the cursor */
+    wmove(td->win, y, x);
 
-   /* Success */
-   return (0);
+    /* Success */
+    return (0);
 }
-
 
 /*
  * Erase a grid of space
@@ -977,25 +972,24 @@ static errr Term_curs_gcu(int x, int y)
  */
 static errr Term_wipe_gcu(int x, int y, int n)
 {
-   term_data *td = (term_data *)(Term->data);
+    term_data *td = (term_data *)(Term->data);
 
-   /* Place cursor */
-   wmove(td->win, y, x);
+    /* Place cursor */
+    wmove(td->win, y, x);
 
-   /* Clear to end of line */
-   if (x + n >= 80)
-   {
-      wclrtoeol(td->win);
-   }
+    /* Clear to end of line */
+    if (x + n >= 80) {
+        wclrtoeol(td->win);
+    }
 
-   /* Clear some characters */
-   else
-   {
-      while (n-- > 0) waddch(td->win, ' ');
-   }
+    /* Clear some characters */
+    else {
+        while (n-- > 0)
+            waddch(td->win, ' ');
+    }
 
-   /* Success */
-   return (0);
+    /* Success */
+    return (0);
 }
 
 #ifdef USE_NCURSES_ACS
@@ -1009,23 +1003,22 @@ static errr Term_wipe_gcu(int x, int y, int n)
  */
 static void Term_acs_text_gcu(int x, int y, int n, byte a, concptr s)
 {
-   term_data *td = (term_data *)(Term->data);
-   int i;
+    term_data *td = (term_data *)(Term->data);
+    int i;
 
-   /* position the cursor */
-   wmove(td->win, y, x);
+    /* position the cursor */
+    wmove(td->win, y, x);
 
 #ifdef A_COLOR
-   /* Set the color */
-   wattrset(td->win, colortable[a & 0x0F]);
+    /* Set the color */
+    wattrset(td->win, colortable[a & 0x0F]);
 #endif
 
-   for (i=0; i < n; i++)
-   {
-      /* add acs_map of a */
-      waddch(td->win, acs_map[(int)s[i]]);
-   }
-   wattrset(td->win, WA_NORMAL);
+    for (i = 0; i < n; i++) {
+        /* add acs_map of a */
+        waddch(td->win, acs_map[(int)s[i]]);
+    }
+    wattrset(td->win, WA_NORMAL);
 }
 #endif
 
@@ -1034,118 +1027,117 @@ static void Term_acs_text_gcu(int x, int y, int n, byte a, concptr s)
  */
 static errr Term_text_gcu(int x, int y, int n, byte a, concptr s)
 {
-   term_data *td = (term_data *)(Term->data);
+    term_data *td = (term_data *)(Term->data);
 
-   char intext[n];
-   char text[80 * 3 + 1];
-   size_t inlen = n;
-   size_t outlen = sizeof(text);
-   char *inbuf = intext;
-   char *outbuf = text;
-   size_t res;
+    char intext[n];
+    char text[80 * 3 + 1];
+    size_t inlen = n;
+    size_t outlen = sizeof(text);
+    char *inbuf = intext;
+    char *outbuf = text;
+    size_t res;
 
 #ifdef USE_NCURSES_ACS
-   /* do we have colors + 16 ? */
-   /* then call special routine for drawing special characters */
-   if (a & 0x10)
-   {
-      Term_acs_text_gcu(x, y, n, a, s);
-      return(0);
-   }
+    /* do we have colors + 16 ? */
+    /* then call special routine for drawing special characters */
+    if (a & 0x10) {
+        Term_acs_text_gcu(x, y, n, a, s);
+        return (0);
+    }
 #endif
 
-   /* Copy to char array because of iconv's warning by const char pointer */
-   memcpy(intext, s, (size_t)n);
+    /* Copy to char array because of iconv's warning by const char pointer */
+    memcpy(intext, s, (size_t)n);
 
-   /* Obtain a copy of the text */
-   res = iconv(iconv_to_gui, 0, 0, 0, 0);
-   if(res == (size_t)-1) return (-1);
-   res = iconv(iconv_to_gui, &inbuf, &inlen, &outbuf, &outlen);
-   if(res == (size_t)-1) return (-1);
-   res = iconv(iconv_to_gui, 0, 0, &outbuf, &outlen);
-   if(res == (size_t)-1) return (-1);
+    /* Obtain a copy of the text */
+    res = iconv(iconv_to_gui, 0, 0, 0, 0);
+    if (res == (size_t)-1)
+        return (-1);
+    res = iconv(iconv_to_gui, &inbuf, &inlen, &outbuf, &outlen);
+    if (res == (size_t)-1)
+        return (-1);
+    res = iconv(iconv_to_gui, 0, 0, &outbuf, &outlen);
+    if (res == (size_t)-1)
+        return (-1);
 
-   if(outlen == 0) return (-1);
-   *outbuf = '\0';
+    if (outlen == 0)
+        return (-1);
+    *outbuf = '\0';
 
-   /* Move the cursor and dump the string */
-   wmove(td->win, y, x);
+    /* Move the cursor and dump the string */
+    wmove(td->win, y, x);
 
 #ifdef A_COLOR
-   /* Set the color */
-   if (can_use_color) wattrset(td->win, colortable[a & 0x0F]);
+    /* Set the color */
+    if (can_use_color)
+        wattrset(td->win, colortable[a & 0x0F]);
 #endif
 
-   /* Add the text */
-   waddstr(td->win, text);
+    /* Add the text */
+    waddstr(td->win, text);
 
-   /* Success */
-   return (0);
+    /* Success */
+    return (0);
 }
-
-
 
 static errr term_data_init(term_data *td, int rows, int cols, int y, int x)
 {
-   term_type *t = &td->t;
+    term_type *t = &td->t;
 
-   /* Make sure the window has a positive size */
-   if (rows <= 0 || cols <= 0) return (0);
+    /* Make sure the window has a positive size */
+    if (rows <= 0 || cols <= 0)
+        return (0);
 
-   /* Create a window */
-   td->win = newwin(rows, cols, y, x);
+    /* Create a window */
+    td->win = newwin(rows, cols, y, x);
 
-   /* Make sure we succeed */
-   if (!td->win)
-   {
-      plog("Failed to setup curses window.");
-      return (-1);
-   }
+    /* Make sure we succeed */
+    if (!td->win) {
+        plog("Failed to setup curses window.");
+        return (-1);
+    }
 
-   /* Initialize the term */
-   term_init(t, cols, rows, 256);
+    /* Initialize the term */
+    term_init(t, cols, rows, 256);
 
-   /* Avoid the bottom right corner */
-   t->icky_corner = TRUE;
+    /* Avoid the bottom right corner */
+    t->icky_corner = TRUE;
 
-   /* Erase with "white space" */
-   t->attr_blank = TERM_WHITE;
-   t->char_blank = ' ';
+    /* Erase with "white space" */
+    t->attr_blank = TERM_WHITE;
+    t->char_blank = ' ';
 
-   /* Set some hooks */
-   t->init_hook = Term_init_gcu;
-   t->nuke_hook = Term_nuke_gcu;
+    /* Set some hooks */
+    t->init_hook = Term_init_gcu;
+    t->nuke_hook = Term_nuke_gcu;
 
-   /* Set some more hooks */
-   t->text_hook = Term_text_gcu;
-   t->wipe_hook = Term_wipe_gcu;
-   t->curs_hook = Term_curs_gcu;
-   t->xtra_hook = Term_xtra_gcu;
+    /* Set some more hooks */
+    t->text_hook = Term_text_gcu;
+    t->wipe_hook = Term_wipe_gcu;
+    t->curs_hook = Term_curs_gcu;
+    t->xtra_hook = Term_xtra_gcu;
 
-   /* Save the data */
-   t->data = td;
+    /* Save the data */
+    t->data = td;
 
-   /* Activate it */
-   term_activate(t);
+    /* Activate it */
+    term_activate(t);
 
-
-   /* Success */
-   return (0);
+    /* Success */
+    return (0);
 }
-
 
 static void hook_quit(concptr str)
 {
-	/* Unused */
-	(void)str;
+    /* Unused */
+    (void)str;
 
-   /* Exit curses */
-   endwin();
+    /* Exit curses */
+    endwin();
 
-   iconv_close(iconv_to_sys);
-   iconv_close(iconv_to_gui);
+    iconv_close(iconv_to_sys);
+    iconv_close(iconv_to_gui);
 }
-
 
 /*
  * Prepare "curses" for use by the file "term.c"
@@ -1157,212 +1149,206 @@ static void hook_quit(concptr str)
  */
 errr init_gcu(int argc, char *argv[])
 {
-   int i;
+    int i;
 
-   int num_term = 4, next_win = 0;
-   char path[1024];
+    int num_term = 4, next_win = 0;
+    char path[1024];
 
-   /* Unused */
-   (void)argc;
-   (void)argv;
+    /* Unused */
+    (void)argc;
+    (void)argv;
 
+    setlocale(LC_ALL, "");
+    iconv_to_sys = iconv_open("EUC-JP", "");
+    if (iconv_to_sys == (iconv_t)-1)
+        return (-1);
+    iconv_to_gui = iconv_open("", "EUC-JP");
+    if (iconv_to_gui == (iconv_t)-1)
+        return (-1);
 
-   setlocale(LC_ALL, "");
-   iconv_to_sys = iconv_open("EUC-JP", "");
-   if(iconv_to_sys == (iconv_t)-1) return (-1);
-   iconv_to_gui = iconv_open("", "EUC-JP");
-   if(iconv_to_gui == (iconv_t)-1) return (-1);
+    /* Build the "sound" path */
+    path_build(path, sizeof(path), ANGBAND_DIR_XTRA, "sound");
 
-   /* Build the "sound" path */
-   path_build(path, sizeof(path), ANGBAND_DIR_XTRA, "sound");
+    /* Allocate the path */
+    ANGBAND_DIR_XTRA_SOUND = string_make(path);
 
-   /* Allocate the path */
-   ANGBAND_DIR_XTRA_SOUND = string_make(path);
+    /* Extract the normal keymap */
+    keymap_norm_prepare();
 
-   /* Extract the normal keymap */
-   keymap_norm_prepare();
+    /* Initialize for others systems */
+    if (initscr() == (WINDOW *)ERR)
+        return (-1);
 
-   /* Initialize for others systems */
-   if (initscr() == (WINDOW*)ERR) return (-1);
+    /* Activate hooks */
+    quit_aux = hook_quit;
+    core_aux = hook_quit;
 
-   /* Activate hooks */
-   quit_aux = hook_quit;
-   core_aux = hook_quit;
-
-   /* Hack -- Require large screen, or Quit with message */
-   i = ((LINES < 24) || (COLS < 80));
-   if (i) quit("Angband needs an 80x24 'curses' screen");
-
+    /* Hack -- Require large screen, or Quit with message */
+    i = ((LINES < 24) || (COLS < 80));
+    if (i)
+        quit("Angband needs an 80x24 'curses' screen");
 
 #ifdef A_COLOR
 
-   /*** Init the Color-pairs and set up a translation table ***/
+    /*** Init the Color-pairs and set up a translation table ***/
 
-   /* Do we have color, and enough color, available? */
-   can_use_color = ((start_color() != ERR) && has_colors() &&
-		    (COLORS >= 8) && (COLOR_PAIRS >= 8));
+    /* Do we have color, and enough color, available? */
+    can_use_color = ((start_color() != ERR) && has_colors() && (COLORS >= 8) && (COLOR_PAIRS >= 8));
 
 #ifdef REDEFINE_COLORS
-	/* Can we change colors? */
-	can_fix_color = (can_use_color && can_change_color() &&
-			 (COLORS >= 16) && (COLOR_PAIRS > 8));
+    /* Can we change colors? */
+    can_fix_color = (can_use_color && can_change_color() && (COLORS >= 16) && (COLOR_PAIRS > 8));
 #endif
 
-   /* Attempt to use customized colors */
-   if (can_fix_color)
-   {
-      /* Prepare the color pairs */
-	   for (i = 1; i <= 15; i++)
-	   {
-		   if (init_pair(i, i, 0) == ERR)
-		   {
-			   quit("Color pair init failed");
-		   }
+    /* Attempt to use customized colors */
+    if (can_fix_color) {
+        /* Prepare the color pairs */
+        for (i = 1; i <= 15; i++) {
+            if (init_pair(i, i, 0) == ERR) {
+                quit("Color pair init failed");
+            }
 
-		   colortable[i] = COLOR_PAIR(i);
-		   Term_xtra_gcu_react();
-	   }
-   }
-   /* Attempt to use colors */
-   else if (can_use_color)
-   {
-		/* Color-pair 0 is *always* WHITE on BLACK */
+            colortable[i] = COLOR_PAIR(i);
+            Term_xtra_gcu_react();
+        }
+    }
+    /* Attempt to use colors */
+    else if (can_use_color) {
+        /* Color-pair 0 is *always* WHITE on BLACK */
 
-		/* Prepare the color pairs */
-		init_pair(1, COLOR_RED,     COLOR_BLACK);
-		init_pair(2, COLOR_GREEN,   COLOR_BLACK);
-		init_pair(3, COLOR_YELLOW,  COLOR_BLACK);
-		init_pair(4, COLOR_BLUE,    COLOR_BLACK);
-		init_pair(5, COLOR_MAGENTA, COLOR_BLACK);
-		init_pair(6, COLOR_CYAN,    COLOR_BLACK);
-		init_pair(7, COLOR_BLACK,   COLOR_BLACK);
+        /* Prepare the color pairs */
+        init_pair(1, COLOR_RED, COLOR_BLACK);
+        init_pair(2, COLOR_GREEN, COLOR_BLACK);
+        init_pair(3, COLOR_YELLOW, COLOR_BLACK);
+        init_pair(4, COLOR_BLUE, COLOR_BLACK);
+        init_pair(5, COLOR_MAGENTA, COLOR_BLACK);
+        init_pair(6, COLOR_CYAN, COLOR_BLACK);
+        init_pair(7, COLOR_BLACK, COLOR_BLACK);
 
-		/* Prepare the "Angband Colors" -- Bright white is too bright */
-		/* Changed in Drangband. Cyan as grey sucks -- -TM- */
-		colortable[0] = (COLOR_PAIR(7) | A_NORMAL);	/* Black */
-		colortable[1] = (COLOR_PAIR(0) | A_BRIGHT);	/* White */
-		colortable[2] = (COLOR_PAIR(0) | A_NORMAL);	/* Grey XXX */
-		colortable[3] = (COLOR_PAIR(1) | A_BRIGHT);	/* Orange XXX */
-		colortable[4] = (COLOR_PAIR(1) | A_NORMAL);	/* Red */
-		colortable[5] = (COLOR_PAIR(2) | A_NORMAL);	/* Green */
-		colortable[6] = (COLOR_PAIR(4) | A_BRIGHT);	/* Blue */
-		colortable[7] = (COLOR_PAIR(3) | A_NORMAL);	/* Umber */
-		colortable[8] = (COLOR_PAIR(7) | A_BRIGHT);	/* Dark-grey XXX */
-		colortable[9] = (COLOR_PAIR(0) | A_NORMAL);	/* Light-grey XXX */
-		colortable[10] = (COLOR_PAIR(5) | A_BRIGHT);	/* Purple */
-		colortable[11] = (COLOR_PAIR(3) | A_BRIGHT);	/* Yellow */
-		colortable[12] = (COLOR_PAIR(5) | A_NORMAL);	/* Light Red XXX */
-		colortable[13] = (COLOR_PAIR(2) | A_BRIGHT);	/* Light Green */
-		colortable[14] = (COLOR_PAIR(6) | A_BRIGHT);	/* Light Blue */
-		colortable[15] = (COLOR_PAIR(3) | A_NORMAL);	/* Light Umber XXX */
-
-   }
+        /* Prepare the "Angband Colors" -- Bright white is too bright */
+        /* Changed in Drangband. Cyan as grey sucks -- -TM- */
+        colortable[0] = (COLOR_PAIR(7) | A_NORMAL); /* Black */
+        colortable[1] = (COLOR_PAIR(0) | A_BRIGHT); /* White */
+        colortable[2] = (COLOR_PAIR(0) | A_NORMAL); /* Grey XXX */
+        colortable[3] = (COLOR_PAIR(1) | A_BRIGHT); /* Orange XXX */
+        colortable[4] = (COLOR_PAIR(1) | A_NORMAL); /* Red */
+        colortable[5] = (COLOR_PAIR(2) | A_NORMAL); /* Green */
+        colortable[6] = (COLOR_PAIR(4) | A_BRIGHT); /* Blue */
+        colortable[7] = (COLOR_PAIR(3) | A_NORMAL); /* Umber */
+        colortable[8] = (COLOR_PAIR(7) | A_BRIGHT); /* Dark-grey XXX */
+        colortable[9] = (COLOR_PAIR(0) | A_NORMAL); /* Light-grey XXX */
+        colortable[10] = (COLOR_PAIR(5) | A_BRIGHT); /* Purple */
+        colortable[11] = (COLOR_PAIR(3) | A_BRIGHT); /* Yellow */
+        colortable[12] = (COLOR_PAIR(5) | A_NORMAL); /* Light Red XXX */
+        colortable[13] = (COLOR_PAIR(2) | A_BRIGHT); /* Light Green */
+        colortable[14] = (COLOR_PAIR(6) | A_BRIGHT); /* Light Blue */
+        colortable[15] = (COLOR_PAIR(3) | A_NORMAL); /* Light Umber XXX */
+    }
 
 #endif
 
-   /* Handle "arg_sound" */
-   if (use_sound != arg_sound)
-   {
-      /* Initialize (if needed) */
-      if (arg_sound && !init_sound())
-      {
-	 /* Warning */
-	 plog("Cannot initialize sound!");
+    /* Handle "arg_sound" */
+    if (use_sound != arg_sound) {
+        /* Initialize (if needed) */
+        if (arg_sound && !init_sound()) {
+            /* Warning */
+            plog("Cannot initialize sound!");
 
-	 /* Cannot enable */
-	 arg_sound = FALSE;
-      }
+            /* Cannot enable */
+            arg_sound = FALSE;
+        }
 
-      /* Change setting */
-      use_sound = arg_sound;
-   }
+        /* Change setting */
+        use_sound = arg_sound;
+    }
 
-   /* Try graphics */
-   if (arg_graphics)
-   {
-      /* if USE_NCURSES_ACS is defined, we can do something with graphics in curses! */
+    /* Try graphics */
+    if (arg_graphics) {
+        /* if USE_NCURSES_ACS is defined, we can do something with graphics in curses! */
 #ifdef USE_NCURSES_ACS
-      use_graphics = TRUE;
+        use_graphics = TRUE;
 #endif
-   }
+    }
 
-   /*** Low level preparation ***/
+    /*** Low level preparation ***/
 
 #ifdef USE_GETCH
 
-   /* Paranoia -- Assume no waiting */
-   nodelay(stdscr, FALSE);
+    /* Paranoia -- Assume no waiting */
+    nodelay(stdscr, FALSE);
 
 #endif
 
-   /* Prepare */
-   cbreak();
-   noecho();
-   nonl();
-   raw();
+    /* Prepare */
+    cbreak();
+    noecho();
+    nonl();
+    raw();
 
-   /* Extract the game keymap */
-   keymap_game_prepare();
+    /* Extract the game keymap */
+    keymap_game_prepare();
 
+    /*** Now prepare the term(s) ***/
+    for (i = 0; i < num_term; i++) {
+        int rows, cols;
+        int y, x;
 
-   /*** Now prepare the term(s) ***/
-   for (i = 0; i < num_term; i++)
-   {
-      int rows, cols;
-      int y, x;
+        switch (i) {
+        /* Upper left */
+        case 0:
+            rows = 24;
+            cols = 80;
+            y = x = 0;
+            break;
+        /* Lower left */
+        case 1:
+            rows = LINES - 25;
+            cols = 80;
+            y = 24;
+            x = 0;
+            break;
+        /* Upper right */
+        case 2:
+            rows = 24;
+            cols = COLS - 81;
+            y = 0;
+            x = 81;
+            break;
+        /* Lower right */
+        case 3:
+            rows = LINES - 25;
+            cols = COLS - 81;
+            y = 24;
+            x = 81;
+            break;
+        /* XXX */
+        default:
+            rows = cols = 0;
+            y = x = 0;
+            break;
+        }
 
-      switch (i)
-      {
-	 /* Upper left */
-	 case 0: rows = 24;
-	    cols = 80;
-	    y = x = 0;
-	    break;
-	 /* Lower left */
-	 case 1: rows = LINES - 25;
-	    cols = 80;
-	    y = 24;
-	    x = 0;
-	    break;
-	 /* Upper right */
-	 case 2: rows = 24;
-	    cols = COLS - 81;
-	    y = 0;
-	    x = 81;
-	    break;
-	 /* Lower right */
-	 case 3: rows = LINES - 25;
-	    cols = COLS - 81;
-	    y = 24;
-	    x = 81;
-	    break;
-	 /* XXX */
-	 default: rows = cols = 0;
-	     y = x = 0;
-	     break;
-      }
+        /* No non-windows */
+        if (rows <= 0 || cols <= 0)
+            continue;
 
-      /* No non-windows */
-      if (rows <= 0 || cols <= 0) continue;
+        /* Initialize */
+        term_data_init(&data[next_win], rows, cols, y, x);
 
-      /* Initialize */
-      term_data_init(&data[next_win], rows, cols, y, x);
+        /* Store */
+        angband_term[next_win] = Term;
 
-      /* Store */
-      angband_term[next_win] = Term;
+        next_win++;
+    }
 
-      next_win++;
-   }
+    /* Activate the "Angband" window screen */
+    term_activate(&data[0].t);
 
-   /* Activate the "Angband" window screen */
-   term_activate(&data[0].t);
+    /* Store */
+    term_screen = &data[0].t;
 
-   /* Store */
-   term_screen = &data[0].t;
-
-   /* Success */
-   return (0);
+    /* Success */
+    return (0);
 }
-
 
 #endif /* USE_GCU */


### PR DESCRIPTION
X11ドライバとGCUドライバでそれぞれ独自に行っている
UTF-8とEUC-JP間の変換処理をlocale/japanese.cにまとめ
共通化する。
Linux/UNIX(EUC-JP)環境では utf8_to_sys からも同じく
共通化した処理を使用する。