### PR TITLE
[refactor] 正式なbool型の導入

### DIFF
--- a/src/cmd-building/cmd-building.c
+++ b/src/cmd-building/cmd-building.c
@@ -358,7 +358,7 @@ void do_cmd_building(player_type *player_ptr)
 
 	forget_lite(player_ptr->current_floor_ptr);
 	forget_view(player_ptr->current_floor_ptr);
-	current_world_ptr->character_icky++;
+	current_world_ptr->character_icky = TRUE;
 
 	command_arg = 0;
 	command_rep = 0;
@@ -408,7 +408,7 @@ void do_cmd_building(player_type *player_ptr)
 
 	if (reinit_wilderness) player_ptr->leaving = TRUE;
 
-	current_world_ptr->character_icky--;
+	current_world_ptr->character_icky = FALSE;
 	term_clear();
 
 	player_ptr->update |= (PU_VIEW | PU_MONSTERS | PU_BONUS | PU_LITE | PU_MON_LITE);

--- a/src/main-gcu.c
+++ b/src/main-gcu.c
@@ -173,7 +173,9 @@
 /*
  * Hack -- play games with "bool"
  */
+#if __STDC_VERSION__ < 199901L
 #undef bool
+#endif
 
 /*
  * Include the proper "header" file

--- a/src/mspell/mspell-attack-util.h
+++ b/src/mspell/mspell-attack-util.h
@@ -24,7 +24,7 @@ typedef struct msa_type {
     POSITION y;
     POSITION x_br_lite;
     POSITION y_br_lite;
-    bool do_spell;
+    mspell_lite_type do_spell;
     bool in_no_magic_dungeon;
     bool success;
     byte mspells[96];

--- a/src/system/h-type.h
+++ b/src/system/h-type.h
@@ -63,7 +63,11 @@ typedef int errr;
 /* A signed byte of memory */
 /* typedef signed char syte; */
 typedef unsigned char byte; /*!< byte型をunsighned charとして定義 / Note that unsigned values can cause math problems / An unsigned byte of memory */
+#if __STDC_VERSION__ >= 199901L
+#include <stdbool.h>
+#else
 typedef char bool; /*!< bool型をcharとして定義 / Note that a bool is smaller than a full "int" / Simple True/False type */
+#endif
 typedef unsigned int uint; /* uint型をintとして定義 /  An unsigned, "standard" integer (often pre-defined) */
 
 /* The largest possible unsigned integer */

--- a/src/term/screen-processor.c
+++ b/src/term/screen-processor.c
@@ -34,7 +34,7 @@ void screen_save()
     if (screen_depth++ == 0)
         term_save();
 
-    current_world_ptr->character_icky++;
+    current_world_ptr->character_icky = TRUE;
 }
 
 /*
@@ -48,7 +48,7 @@ void screen_load()
     if (--screen_depth == 0)
         term_load();
 
-    current_world_ptr->character_icky--;
+    current_world_ptr->character_icky = FALSE;
 }
 
 /*

--- a/src/term/z-term.c
+++ b/src/term/z-term.c
@@ -1067,7 +1067,8 @@ errr term_fresh(void)
         term_xtra(TERM_XTRA_CLEAR, 0);
 
         /* clear all "cursor" data */
-        old->cv = old->cu = old->cx = old->cy = 0;
+        old->cv = old->cu = FALSE;
+        old->cx = old->cy = 0;
 
         /* Wipe each row */
         for (TERM_LEN y = 0; y < h; y++) {


### PR DESCRIPTION
すでにC99準拠の書き方が使われている(コードブロックの途中で
変数宣言を行う、for文の中で変数宣言を行う等)ので、
typedef char bool ではなく、C99準拠で正式に採用された bool 型を
定義する <stdbool.h> を導入する。
すでにC99準拠以上でなくてはコンパイルが通らなくなっている
はずだが、一応 `__STDC_VERSION__` をチェックしてC99以上の時のみ
インクルードする。
また、正式な bool 型を導入した事で bool 型をインクリメント/
デクリメントしているコードやbool型でswitchしているコード、
bool型に0を連続で代入しているコードが見つかったので、
合わせて修正する。