### PR TITLE
[fix] ペットが召喚したペットが消えない #302

### DIFF
--- a/src/monster-floor/monster-remover.c
+++ b/src/monster-floor/monster-remover.c
@@ -74,6 +74,15 @@ void delete_monster_idx(player_type *player_ptr, MONSTER_IDX i)
         delete_object_idx(player_ptr, this_o_idx);
     }
 
+    // 召喚元のモンスターが消滅した時は、召喚されたモンスターのparent_m_idxが
+    // 召喚されたモンスター自身のm_idxを指すようにする
+    for (MONSTER_IDX child_m_idx = 1; child_m_idx < floor_ptr->m_max; child_m_idx++) {
+        monster_type *child_m_ptr = &floor_ptr->m_list[child_m_idx];
+        if (child_m_ptr->r_idx && child_m_ptr->parent_m_idx == i) {
+            child_m_ptr->parent_m_idx = child_m_idx;
+        }
+    }
+
     (void)WIPE(m_ptr, monster_type);
     floor_ptr->m_cnt--;
     lite_spot(player_ptr, y, x);

--- a/src/monster/monster-processor.c
+++ b/src/monster/monster-processor.c
@@ -53,9 +53,9 @@
 #include "object-enchant/trc-types.h"
 #include "pet/pet-fall-off.h"
 #include "player-info/avatar.h"
+#include "player/player-move.h"
 #include "player/player-skill.h"
 #include "player/player-status-flags.h"
-#include "player/player-move.h"
 #include "player/special-defense-types.h"
 #include "spell-realm/spells-hex.h"
 #include "spell/summon-types.h"
@@ -242,7 +242,12 @@ void decide_drop_from_monster(player_type *target_ptr, MONSTER_IDX m_idx, bool i
 bool vanish_summoned_children(player_type *target_ptr, MONSTER_IDX m_idx, bool see_m)
 {
     monster_type *m_ptr = &target_ptr->current_floor_ptr->m_list[m_idx];
-    if ((m_ptr->parent_m_idx == 0) || (target_ptr->current_floor_ptr->m_list[m_ptr->parent_m_idx].r_idx > 0))
+
+    if (m_ptr->parent_m_idx == 0)
+        return FALSE;
+
+    // parent_m_idxが自分自身を指している場合は召喚主は消滅している
+    if (m_ptr->parent_m_idx != m_idx && (target_ptr->current_floor_ptr->m_list[m_ptr->parent_m_idx].r_idx > 0))
         return FALSE;
 
     if (see_m) {


### PR DESCRIPTION
詳細な原因は下記を参照:
https://github.com/hengband/hengband/issues/302#issuecomment-786108417

対応策として、召喚元の親モンスターが消滅した場合は、召喚された
子モンスターのparent_m_idxを自分自身のm_idxを指すようにし、
召喚された子モンスターを消す処理でparent_m_idxが自分自身の
m_idxを指している場合も消すようにする。