### PR TITLE
[Refactor] ビットテスト/ビット操作マクロの再整理案 #283

### DIFF
--- a/src/combat/shoot.c
+++ b/src/combat/shoot.c
@@ -90,146 +90,146 @@ static MULTIPLY calc_shot_damage_with_slay(player_type *sniper_ptr, object_type 
     case TV_SHOT:
     case TV_ARROW:
     case TV_BOLT: {
-        if ((has_flag(flags, TR_SLAY_ANIMAL)) && (test_bit(race_ptr->flags3, RF3_ANIMAL))) {
+        if ((has_flag(flags, TR_SLAY_ANIMAL)) && any_bits(race_ptr->flags3, RF3_ANIMAL)) {
             if (is_original_ap_and_seen(sniper_ptr, monster_ptr)) {
-                set_bit(race_ptr->r_flags3, RF3_ANIMAL);
+                set_bits(race_ptr->r_flags3, RF3_ANIMAL);
             }
             if (mult < 17)
                 mult = 17;
         }
 
-        if ((has_flag(flags, TR_KILL_ANIMAL)) && (test_bit(race_ptr->flags3, RF3_ANIMAL))) {
+        if ((has_flag(flags, TR_KILL_ANIMAL)) && any_bits(race_ptr->flags3, RF3_ANIMAL)) {
             if (is_original_ap_and_seen(sniper_ptr, monster_ptr)) {
-                set_bit(race_ptr->r_flags3, RF3_ANIMAL);
+                set_bits(race_ptr->r_flags3, RF3_ANIMAL);
             }
             if (mult < 27)
                 mult = 27;
         }
 
-        if ((has_flag(flags, TR_SLAY_EVIL)) && (test_bit(race_ptr->flags3, RF3_EVIL))) {
+        if ((has_flag(flags, TR_SLAY_EVIL)) && any_bits(race_ptr->flags3, RF3_EVIL)) {
             if (is_original_ap_and_seen(sniper_ptr, monster_ptr)) {
-                set_bit(race_ptr->r_flags3, RF3_EVIL);
+                set_bits(race_ptr->r_flags3, RF3_EVIL);
             }
             if (mult < 15)
                 mult = 15;
         }
 
-        if ((has_flag(flags, TR_KILL_EVIL)) && (test_bit(race_ptr->flags3, RF3_EVIL))) {
+        if ((has_flag(flags, TR_KILL_EVIL)) && any_bits(race_ptr->flags3, RF3_EVIL)) {
             if (is_original_ap_and_seen(sniper_ptr, monster_ptr)) {
-                set_bit(race_ptr->r_flags3, RF3_EVIL);
+                set_bits(race_ptr->r_flags3, RF3_EVIL);
             }
             if (mult < 25)
                 mult = 25;
         }
 
-        if ((has_flag(flags, TR_SLAY_HUMAN)) && (test_bit(race_ptr->flags2, RF2_HUMAN))) {
+        if ((has_flag(flags, TR_SLAY_HUMAN)) && any_bits(race_ptr->flags2, RF2_HUMAN)) {
             if (is_original_ap_and_seen(sniper_ptr, monster_ptr)) {
-                set_bit(race_ptr->r_flags2, RF2_HUMAN);
+                set_bits(race_ptr->r_flags2, RF2_HUMAN);
             }
             if (mult < 17)
                 mult = 17;
         }
 
-        if ((has_flag(flags, TR_KILL_HUMAN)) && (test_bit(race_ptr->flags2, RF2_HUMAN))) {
+        if ((has_flag(flags, TR_KILL_HUMAN)) && any_bits(race_ptr->flags2, RF2_HUMAN)) {
             if (is_original_ap_and_seen(sniper_ptr, monster_ptr)) {
-                set_bit(race_ptr->r_flags2, RF2_HUMAN);
+                set_bits(race_ptr->r_flags2, RF2_HUMAN);
             }
             if (mult < 27)
                 mult = 27;
         }
 
-        if ((has_flag(flags, TR_SLAY_UNDEAD)) && (test_bit(race_ptr->flags3, RF3_UNDEAD))) {
+        if ((has_flag(flags, TR_SLAY_UNDEAD)) && any_bits(race_ptr->flags3, RF3_UNDEAD)) {
             if (is_original_ap_and_seen(sniper_ptr, monster_ptr)) {
-                set_bit(race_ptr->r_flags3, RF3_UNDEAD);
+                set_bits(race_ptr->r_flags3, RF3_UNDEAD);
             }
             if (mult < 20)
                 mult = 20;
         }
 
-        if ((has_flag(flags, TR_KILL_UNDEAD)) && (test_bit(race_ptr->flags3, RF3_UNDEAD))) {
+        if ((has_flag(flags, TR_KILL_UNDEAD)) && any_bits(race_ptr->flags3, RF3_UNDEAD)) {
             if (is_original_ap_and_seen(sniper_ptr, monster_ptr)) {
-                set_bit(race_ptr->r_flags3, RF3_UNDEAD);
+                set_bits(race_ptr->r_flags3, RF3_UNDEAD);
             }
             if (mult < 30)
                 mult = 30;
         }
 
-        if ((has_flag(flags, TR_SLAY_DEMON)) && (test_bit(race_ptr->flags3, RF3_DEMON))) {
+        if ((has_flag(flags, TR_SLAY_DEMON)) && any_bits(race_ptr->flags3, RF3_DEMON)) {
             if (is_original_ap_and_seen(sniper_ptr, monster_ptr)) {
-                set_bit(race_ptr->r_flags3, RF3_DEMON);
+                set_bits(race_ptr->r_flags3, RF3_DEMON);
             }
             if (mult < 20)
                 mult = 20;
         }
 
-        if ((has_flag(flags, TR_KILL_DEMON)) && (test_bit(race_ptr->flags3, RF3_DEMON))) {
+        if ((has_flag(flags, TR_KILL_DEMON)) && any_bits(race_ptr->flags3, RF3_DEMON)) {
             if (is_original_ap_and_seen(sniper_ptr, monster_ptr)) {
-                set_bit(race_ptr->r_flags3, RF3_DEMON);
+                set_bits(race_ptr->r_flags3, RF3_DEMON);
             }
             if (mult < 30)
                 mult = 30;
         }
 
-        if ((has_flag(flags, TR_SLAY_ORC)) && (test_bit(race_ptr->flags3, RF3_ORC))) {
+        if ((has_flag(flags, TR_SLAY_ORC)) && any_bits(race_ptr->flags3, RF3_ORC)) {
             if (is_original_ap_and_seen(sniper_ptr, monster_ptr)) {
-                set_bit(race_ptr->r_flags3, RF3_ORC);
+                set_bits(race_ptr->r_flags3, RF3_ORC);
             }
             if (mult < 20)
                 mult = 20;
         }
 
-        if ((has_flag(flags, TR_KILL_ORC)) && (test_bit(race_ptr->flags3, RF3_ORC))) {
+        if ((has_flag(flags, TR_KILL_ORC)) && any_bits(race_ptr->flags3, RF3_ORC)) {
             if (is_original_ap_and_seen(sniper_ptr, monster_ptr)) {
-                set_bit(race_ptr->r_flags3, RF3_ORC);
+                set_bits(race_ptr->r_flags3, RF3_ORC);
             }
             if (mult < 30)
                 mult = 30;
         }
 
-        if ((has_flag(flags, TR_SLAY_TROLL)) && (test_bit(race_ptr->flags3, RF3_TROLL))) {
+        if ((has_flag(flags, TR_SLAY_TROLL)) && any_bits(race_ptr->flags3, RF3_TROLL)) {
             if (is_original_ap_and_seen(sniper_ptr, monster_ptr)) {
-                set_bit(race_ptr->r_flags3, RF3_TROLL);
+                set_bits(race_ptr->r_flags3, RF3_TROLL);
             }
 
             if (mult < 20)
                 mult = 20;
         }
 
-        if ((has_flag(flags, TR_KILL_TROLL)) && (test_bit(race_ptr->flags3, RF3_TROLL))) {
+        if ((has_flag(flags, TR_KILL_TROLL)) && any_bits(race_ptr->flags3, RF3_TROLL)) {
             if (is_original_ap_and_seen(sniper_ptr, monster_ptr)) {
-                set_bit(race_ptr->r_flags3, RF3_TROLL);
+                set_bits(race_ptr->r_flags3, RF3_TROLL);
             }
             if (mult < 30)
                 mult = 30;
         }
 
-        if ((has_flag(flags, TR_SLAY_GIANT)) && (test_bit(race_ptr->flags3, RF3_GIANT))) {
+        if ((has_flag(flags, TR_SLAY_GIANT)) && any_bits(race_ptr->flags3, RF3_GIANT)) {
             if (is_original_ap_and_seen(sniper_ptr, monster_ptr)) {
-                set_bit(race_ptr->r_flags3, RF3_GIANT);
+                set_bits(race_ptr->r_flags3, RF3_GIANT);
             }
             if (mult < 20)
                 mult = 20;
         }
 
-        if ((has_flag(flags, TR_KILL_GIANT)) && (test_bit(race_ptr->flags3, RF3_GIANT))) {
+        if ((has_flag(flags, TR_KILL_GIANT)) && any_bits(race_ptr->flags3, RF3_GIANT)) {
             if (is_original_ap_and_seen(sniper_ptr, monster_ptr)) {
-                set_bit(race_ptr->r_flags3, RF3_GIANT);
+                set_bits(race_ptr->r_flags3, RF3_GIANT);
             }
             if (mult < 30)
                 mult = 30;
         }
 
-        if ((has_flag(flags, TR_SLAY_DRAGON)) && (test_bit(race_ptr->flags3, RF3_DRAGON))) {
+        if ((has_flag(flags, TR_SLAY_DRAGON)) && any_bits(race_ptr->flags3, RF3_DRAGON)) {
             if (is_original_ap_and_seen(sniper_ptr, monster_ptr)) {
-                set_bit(race_ptr->r_flags3, RF3_DRAGON);
+                set_bits(race_ptr->r_flags3, RF3_DRAGON);
             }
             if (mult < 20)
                 mult = 20;
         }
 
-        if ((has_flag(flags, TR_KILL_DRAGON)) && (test_bit(race_ptr->flags3, RF3_DRAGON))) {
+        if ((has_flag(flags, TR_KILL_DRAGON)) && any_bits(race_ptr->flags3, RF3_DRAGON)) {
             if (is_original_ap_and_seen(sniper_ptr, monster_ptr)) {
-                set_bit(race_ptr->r_flags3, RF3_DRAGON);
+                set_bits(race_ptr->r_flags3, RF3_DRAGON);
             }
             if (mult < 30)
                 mult = 30;
@@ -239,9 +239,9 @@ static MULTIPLY calc_shot_damage_with_slay(player_type *sniper_ptr, object_type 
 
         if (has_flag(flags, TR_BRAND_ACID)) {
             /* Notice immunity */
-            if (test_bit(race_ptr->flagsr, RFR_EFF_IM_ACID_MASK)) {
+            if (any_bits(race_ptr->flagsr, RFR_EFF_IM_ACID_MASK)) {
                 if (is_original_ap_and_seen(sniper_ptr, monster_ptr)) {
-                    set_bit(race_ptr->r_flagsr, (race_ptr->flagsr & RFR_EFF_IM_ACID_MASK));
+                    set_bits(race_ptr->r_flagsr, (race_ptr->flagsr & RFR_EFF_IM_ACID_MASK));
                 }
             } else {
                 if (mult < 17)
@@ -251,9 +251,9 @@ static MULTIPLY calc_shot_damage_with_slay(player_type *sniper_ptr, object_type 
 
         if (has_flag(flags, TR_BRAND_ELEC)) {
             /* Notice immunity */
-            if (test_bit(race_ptr->flagsr, RFR_EFF_IM_ELEC_MASK)) {
+            if (any_bits(race_ptr->flagsr, RFR_EFF_IM_ELEC_MASK)) {
                 if (is_original_ap_and_seen(sniper_ptr, monster_ptr)) {
-                    set_bit(race_ptr->r_flagsr, (race_ptr->flagsr & RFR_EFF_IM_ELEC_MASK));
+                    set_bits(race_ptr->r_flagsr, (race_ptr->flagsr & RFR_EFF_IM_ELEC_MASK));
                 }
             } else {
                 if (mult < 17)
@@ -263,18 +263,18 @@ static MULTIPLY calc_shot_damage_with_slay(player_type *sniper_ptr, object_type 
 
         if (has_flag(flags, TR_BRAND_FIRE)) {
             /* Notice immunity */
-            if (test_bit(race_ptr->flagsr, RFR_EFF_IM_FIRE_MASK)) {
+            if (any_bits(race_ptr->flagsr, RFR_EFF_IM_FIRE_MASK)) {
                 if (is_original_ap_and_seen(sniper_ptr, monster_ptr)) {
-                    set_bit(race_ptr->r_flagsr, (race_ptr->flagsr & RFR_EFF_IM_FIRE_MASK));
+                    set_bits(race_ptr->r_flagsr, (race_ptr->flagsr & RFR_EFF_IM_FIRE_MASK));
                 }
             }
             /* Otherwise, take the damage */
             else {
-                if (test_bit(race_ptr->flags3, RF3_HURT_FIRE)) {
+                if (any_bits(race_ptr->flags3, RF3_HURT_FIRE)) {
                     if (mult < 25)
                         mult = 25;
                     if (is_original_ap_and_seen(sniper_ptr, monster_ptr)) {
-                        set_bit(race_ptr->r_flags3, RF3_HURT_FIRE);
+                        set_bits(race_ptr->r_flags3, RF3_HURT_FIRE);
                     }
                 } else if (mult < 17)
                     mult = 17;
@@ -283,18 +283,18 @@ static MULTIPLY calc_shot_damage_with_slay(player_type *sniper_ptr, object_type 
 
         if (has_flag(flags, TR_BRAND_COLD)) {
             /* Notice immunity */
-            if (test_bit(race_ptr->flagsr, RFR_EFF_IM_COLD_MASK)) {
+            if (any_bits(race_ptr->flagsr, RFR_EFF_IM_COLD_MASK)) {
                 if (is_original_ap_and_seen(sniper_ptr, monster_ptr)) {
-                    set_bit(race_ptr->r_flagsr, (race_ptr->flagsr & RFR_EFF_IM_COLD_MASK));
+                    set_bits(race_ptr->r_flagsr, (race_ptr->flagsr & RFR_EFF_IM_COLD_MASK));
                 }
             }
             /* Otherwise, take the damage */
             else {
-                if (test_bit(race_ptr->flags3, RF3_HURT_COLD)) {
+                if (any_bits(race_ptr->flags3, RF3_HURT_COLD)) {
                     if (mult < 25)
                         mult = 25;
                     if (is_original_ap_and_seen(sniper_ptr, monster_ptr)) {
-                        set_bit(race_ptr->r_flags3, RF3_HURT_COLD);
+                        set_bits(race_ptr->r_flags3, RF3_HURT_COLD);
                     }
                 } else if (mult < 17)
                     mult = 17;
@@ -303,9 +303,9 @@ static MULTIPLY calc_shot_damage_with_slay(player_type *sniper_ptr, object_type 
 
         if (has_flag(flags, TR_BRAND_POIS)) {
             /* Notice immunity */
-            if (test_bit(race_ptr->flagsr, RFR_EFF_IM_POIS_MASK)) {
+            if (any_bits(race_ptr->flagsr, RFR_EFF_IM_POIS_MASK)) {
                 if (is_original_ap_and_seen(sniper_ptr, monster_ptr)) {
-                    set_bit(race_ptr->r_flagsr, race_ptr->flagsr & RFR_EFF_IM_POIS_MASK);
+                    set_bits(race_ptr->r_flagsr, race_ptr->flagsr & RFR_EFF_IM_POIS_MASK);
                 }
             }
             /* Otherwise, take the damage */
@@ -317,7 +317,7 @@ static MULTIPLY calc_shot_damage_with_slay(player_type *sniper_ptr, object_type 
 
         if ((has_flag(flags, TR_FORCE_WEAPON)) && (sniper_ptr->csp > (sniper_ptr->msp / 30))) {
             sniper_ptr->csp -= (1 + (sniper_ptr->msp / 30));
-            set_bit(sniper_ptr->redraw, PR_MANA);
+            set_bits(sniper_ptr->redraw, PR_MANA);
             mult = mult * 5 / 2;
         }
         break;
@@ -519,11 +519,11 @@ void exe_fire(player_type *shooter_ptr, INVENTORY_IDX item, object_type *j_ptr, 
                 g_ptr = &shooter_ptr->current_floor_ptr->grid_array[ny][nx];
 
                 if (cave_has_flag_grid(g_ptr, FF_HURT_ROCK) && !g_ptr->m_idx) {
-                    if (test_bit(g_ptr->info, (CAVE_MARK)))
+                    if (any_bits(g_ptr->info, (CAVE_MARK)))
                         msg_print(_("岩が砕け散った。", "Wall rocks were shattered."));
                     /* Forget the wall */
-                    reset_bit(g_ptr->info, (CAVE_MARK));
-                    set_bit(shooter_ptr->update, PU_VIEW | PU_LITE | PU_FLOW | PU_MON_LITE);
+                    reset_bits(g_ptr->info, (CAVE_MARK));
+                    set_bits(shooter_ptr->update, PU_VIEW | PU_LITE | PU_FLOW | PU_MON_LITE);
 
                     /* Destroy the wall */
                     cave_alter_feat(shooter_ptr, ny, nx, FF_HURT_ROCK);
@@ -542,7 +542,7 @@ void exe_fire(player_type *shooter_ptr, INVENTORY_IDX item, object_type *j_ptr, 
 
             /* Sniper */
             if (snipe_type == SP_LITE) {
-                set_bit(shooter_ptr->current_floor_ptr->grid_array[ny][nx].info, CAVE_GLOW);
+                set_bits(shooter_ptr->current_floor_ptr->grid_array[ny][nx].info, CAVE_GLOW);
                 note_spot(shooter_ptr, ny, nx);
                 lite_spot(shooter_ptr, ny, nx);
             }
@@ -578,7 +578,7 @@ void exe_fire(player_type *shooter_ptr, INVENTORY_IDX item, object_type *j_ptr, 
 
             /* Sniper */
             if (snipe_type == SP_EVILNESS) {
-                reset_bit(shooter_ptr->current_floor_ptr->grid_array[ny][nx].info, (CAVE_GLOW | CAVE_MARK));
+                reset_bits(shooter_ptr->current_floor_ptr->grid_array[ny][nx].info, (CAVE_GLOW | CAVE_MARK));
                 note_spot(shooter_ptr, ny, nx);
                 lite_spot(shooter_ptr, ny, nx);
             }
@@ -604,9 +604,9 @@ void exe_fire(player_type *shooter_ptr, INVENTORY_IDX item, object_type *j_ptr, 
                 hit_body = TRUE;
 
                 if (monster_csleep_remaining(m_ptr)) {
-                    if (!test_bit(r_ptr->flags3, RF3_EVIL) || one_in_(5))
+                    if (none_bits(r_ptr->flags3, RF3_EVIL) || one_in_(5))
                         chg_virtue(shooter_ptr, V_COMPASSION, -1);
-                    if (!test_bit(r_ptr->flags3, RF3_EVIL) || one_in_(5))
+                    if (none_bits(r_ptr->flags3, RF3_EVIL) || one_in_(5))
                         chg_virtue(shooter_ptr, V_HONOUR, -1);
                 }
 
@@ -623,7 +623,7 @@ void exe_fire(player_type *shooter_ptr, INVENTORY_IDX item, object_type *j_ptr, 
                         else if (shooter_ptr->lev > 34)
                             amount = 2;
                         shooter_ptr->weapon_exp[0][j_ptr->sval] += amount;
-                        set_bit(shooter_ptr->update, PU_BONUS);
+                        set_bits(shooter_ptr->update, PU_BONUS);
                     }
                 }
 
@@ -633,7 +633,7 @@ void exe_fire(player_type *shooter_ptr, INVENTORY_IDX item, object_type *j_ptr, 
                             < r_info[shooter_ptr->current_floor_ptr->m_list[shooter_ptr->riding].r_idx].level)
                         && one_in_(2)) {
                         shooter_ptr->skill_exp[GINOU_RIDING] += 1;
-                        set_bit(shooter_ptr->update, PU_BONUS);
+                        set_bits(shooter_ptr->update, PU_BONUS);
                     }
                 }
 
@@ -669,8 +669,8 @@ void exe_fire(player_type *shooter_ptr, INVENTORY_IDX item, object_type *j_ptr, 
                     }
 
                     if (snipe_type == SP_NEEDLE) {
-                        if ((randint1(randint1(r_ptr->level / (3 + shooter_ptr->concent)) + (8 - shooter_ptr->concent)) == 1) && !(test_bit(r_ptr->flags1, RF1_UNIQUE))
-                            && !(test_bit(r_ptr->flags7, RF7_UNIQUE2))) {
+                        if ((randint1(randint1(r_ptr->level / (3 + shooter_ptr->concent)) + (8 - shooter_ptr->concent)) == 1)
+                            && none_bits(r_ptr->flags1, RF1_UNIQUE) && none_bits(r_ptr->flags7, RF7_UNIQUE2)) {
                             GAME_TEXT m_name[MAX_NLEN];
 
                             /* Get "the monster" or "it" */
@@ -707,7 +707,7 @@ void exe_fire(player_type *shooter_ptr, INVENTORY_IDX item, object_type *j_ptr, 
 
                     /* Sniper */
                     if (snipe_type == SP_HOLYNESS) {
-                        set_bit(shooter_ptr->current_floor_ptr->grid_array[ny][nx].info, CAVE_GLOW);
+                        set_bits(shooter_ptr->current_floor_ptr->grid_array[ny][nx].info, CAVE_GLOW);
                         note_spot(shooter_ptr, ny, nx);
                         lite_spot(shooter_ptr, ny, nx);
                     }
@@ -828,7 +828,7 @@ void exe_fire(player_type *shooter_ptr, INVENTORY_IDX item, object_type *j_ptr, 
             object_copy(o_ptr, q_ptr);
 
             /* Forget mark */
-            reset_bit(o_ptr->marked, OM_TOUCHED);
+            reset_bits(o_ptr->marked, OM_TOUCHED);
 
             /* Forget location */
             o_ptr->iy = o_ptr->ix = 0;

--- a/src/knowledge/knowledge-monsters.c
+++ b/src/knowledge/knowledge-monsters.c
@@ -65,10 +65,10 @@ static IDX collect_monsters(player_type *creature_ptr, IDX grp_cur, IDX mon_idx[
             continue;
 
         if (grp_unique) {
-            if (!test_bit(r_ptr->flags1, RF1_UNIQUE))
+            if (none_bits(r_ptr->flags1, RF1_UNIQUE))
                 continue;
         } else if (grp_riding) {
-            if (!test_bit(r_ptr->flags7, RF7_RIDING))
+            if (none_bits(r_ptr->flags7, RF7_RIDING))
                 continue;
         } else if (grp_wanted) {
             bool wanted = FALSE;
@@ -83,7 +83,7 @@ static IDX collect_monsters(player_type *creature_ptr, IDX grp_cur, IDX mon_idx[
             if (!wanted)
                 continue;
         } else if (grp_amberite) {
-            if (!test_bit(r_ptr->flags3, RF3_AMBERITE))
+            if (none_bits(r_ptr->flags3, RF3_AMBERITE))
                 continue;
         } else {
             if (!angband_strchr(group_char, r_ptr->d_char))
@@ -162,7 +162,7 @@ void do_cmd_knowledge_kill_count(player_type *creature_ptr)
     for (int kk = 1; kk < max_r_idx; kk++) {
         monster_race *r_ptr = &r_info[kk];
 
-        if (test_bit(r_ptr->flags1, RF1_UNIQUE)) {
+        if (any_bits(r_ptr->flags1, RF1_UNIQUE)) {
             bool dead = (r_ptr->max_num == 0);
 
             if (dead) {
@@ -198,7 +198,7 @@ void do_cmd_knowledge_kill_count(player_type *creature_ptr)
     ang_sort(creature_ptr, who, &why, n, ang_sort_comp_hook, ang_sort_swap_hook);
     for (int k = 0; k < n; k++) {
         monster_race *r_ptr = &r_info[who[k]];
-        if (test_bit(r_ptr->flags1, RF1_UNIQUE)) {
+        if (any_bits(r_ptr->flags1, RF1_UNIQUE)) {
             bool dead = (r_ptr->max_num == 0);
             if (dead) {
                 fprintf(fff, "     %s\n", (r_name + r_ptr->name));
@@ -266,7 +266,7 @@ static void display_monster_list(int col, int row, int per_page, s16b mon_idx[],
         term_erase(69, row + i, 255);
         term_queue_bigchar(use_bigtile ? 69 : 70, row + i, r_ptr->x_attr, r_ptr->x_char, 0, 0);
         if (!visual_only) {
-            if (!test_bit(r_ptr->flags1, RF1_UNIQUE))
+            if (none_bits(r_ptr->flags1, RF1_UNIQUE))
                 put_str(format("%5d", r_ptr->r_pkills), row + i, 73);
             else
                 c_put_str((r_ptr->max_num == 0 ? TERM_L_DARK : TERM_WHITE), (r_ptr->max_num == 0 ? _("死亡", " dead") : _("生存", "alive")), row + i, 74);

--- a/src/monster-floor/monster-death-util.c
+++ b/src/monster-floor/monster-death-util.c
@@ -42,9 +42,9 @@ monster_death_type *initialize_monster_death_type(player_type *player_ptr, monst
     md_ptr->m_idx = m_idx;
     md_ptr->m_ptr = &floor_ptr->m_list[m_idx];
     md_ptr->r_ptr = &r_info[md_ptr->m_ptr->r_idx];
-    md_ptr->do_gold = (!test_bit(md_ptr->r_ptr->flags1, RF1_ONLY_ITEM) && !test_bit(md_ptr->r_ptr->flags1, (RF1_DROP_GOOD | RF1_DROP_GREAT)));
-    md_ptr->do_item = (!test_bit(md_ptr->r_ptr->flags1, RF1_ONLY_GOLD) || test_bit(md_ptr->r_ptr->flags1, (RF1_DROP_GOOD | RF1_DROP_GREAT)));
-    md_ptr->cloned = test_bit(md_ptr->m_ptr->smart, SM_CLONED) ? TRUE : FALSE;
+    md_ptr->do_gold = (none_bits(md_ptr->r_ptr->flags1, (RF1_ONLY_ITEM | RF1_DROP_GOOD | RF1_DROP_GREAT)));
+    md_ptr->do_item = (none_bits(md_ptr->r_ptr->flags1, RF1_ONLY_GOLD) || any_bits(md_ptr->r_ptr->flags1, (RF1_DROP_GOOD | RF1_DROP_GREAT)));
+    md_ptr->cloned = any_bits(md_ptr->m_ptr->smart, SM_CLONED) ? TRUE : FALSE;
     md_ptr->force_coin = get_coin_type(md_ptr->m_ptr->r_idx);
     md_ptr->drop_chosen_item = drop_item && !md_ptr->cloned && !floor_ptr->inside_arena && !player_ptr->phase_out && !is_pet(md_ptr->m_ptr);
     return md_ptr;

--- a/src/monster-race/monster-race-hook.c
+++ b/src/monster-race/monster-race-hook.c
@@ -97,16 +97,16 @@ bool mon_hook_quest(player_type *player_ptr, MONRACE_IDX r_idx)
     (void)player_ptr;
 
     monster_race *r_ptr = &r_info[r_idx];
-    if (test_bit(r_ptr->flags8, RF8_WILD_ONLY))
+    if (any_bits(r_ptr->flags8, RF8_WILD_ONLY))
         return FALSE;
 
-    if (test_bit(r_ptr->flags7, RF7_AQUATIC))
+    if (any_bits(r_ptr->flags7, RF7_AQUATIC))
         return FALSE;
 
-    if (test_bit(r_ptr->flags2, RF2_MULTIPLY))
+    if (any_bits(r_ptr->flags2, RF2_MULTIPLY))
         return FALSE;
 
-    if (test_bit(r_ptr->flags7, RF7_FRIENDLY))
+    if (any_bits(r_ptr->flags7, RF7_FRIENDLY))
         return FALSE;
 
     return TRUE;
@@ -133,13 +133,13 @@ bool mon_hook_dungeon(player_type *player_ptr, MONRACE_IDX r_idx)
     monster_race *r_ptr = &r_info[r_idx];
     dungeon_type *d_ptr = &d_info[player_ptr->dungeon_idx];
 
-    if (test_bit(r_ptr->flags8, RF8_WILD_ONLY))
-        return (test_bit(d_ptr->mflags8, RF8_WILD_MOUNTAIN) && test_bit(r_ptr->flags8, RF8_WILD_MOUNTAIN));
+    if (any_bits(r_ptr->flags8, RF8_WILD_ONLY))
+        return (any_bits(d_ptr->mflags8, RF8_WILD_MOUNTAIN) && any_bits(r_ptr->flags8, RF8_WILD_MOUNTAIN));
 
-    bool land = !test_bit(r_ptr->flags7, RF7_AQUATIC);
-    return !test_bit(d_ptr->mflags8, RF8_WILD_MOUNTAIN | RF8_WILD_VOLCANO)
-        || (test_bit(d_ptr->mflags8, RF8_WILD_MOUNTAIN) && (land || test_bit(r_ptr->flags8, RF8_WILD_MOUNTAIN)))
-        || (test_bit(d_ptr->mflags8, RF8_WILD_VOLCANO) && (land || test_bit(r_ptr->flags8, RF8_WILD_VOLCANO)));
+    bool land = none_bits(r_ptr->flags7, RF7_AQUATIC);
+    return none_bits(d_ptr->mflags8, RF8_WILD_MOUNTAIN | RF8_WILD_VOLCANO)
+        || (any_bits(d_ptr->mflags8, RF8_WILD_MOUNTAIN) && (land || any_bits(r_ptr->flags8, RF8_WILD_MOUNTAIN)))
+        || (any_bits(d_ptr->mflags8, RF8_WILD_VOLCANO) && (land || any_bits(r_ptr->flags8, RF8_WILD_VOLCANO)));
 }
 
 /*!
@@ -153,7 +153,7 @@ bool mon_hook_ocean(player_type *player_ptr, MONRACE_IDX r_idx)
     (void)player_ptr;
 
     monster_race *r_ptr = &r_info[r_idx];
-    return test_bit(r_ptr->flags8, RF8_WILD_OCEAN);
+    return any_bits(r_ptr->flags8, RF8_WILD_OCEAN);
 }
 
 /*!
@@ -167,7 +167,7 @@ bool mon_hook_shore(player_type *player_ptr, MONRACE_IDX r_idx)
     (void)player_ptr;
 
     monster_race *r_ptr = &r_info[r_idx];
-    return test_bit(r_ptr->flags8, RF8_WILD_SHORE);
+    return any_bits(r_ptr->flags8, RF8_WILD_SHORE);
 }
 
 /*!
@@ -181,7 +181,7 @@ bool mon_hook_waste(player_type *player_ptr, MONRACE_IDX r_idx)
     (void)player_ptr;
 
     monster_race *r_ptr = &r_info[r_idx];
-    return test_bit(r_ptr->flags8, (RF8_WILD_WASTE | RF8_WILD_ALL));
+    return any_bits(r_ptr->flags8, (RF8_WILD_WASTE | RF8_WILD_ALL));
 }
 
 /*!
@@ -195,7 +195,7 @@ bool mon_hook_town(player_type *player_ptr, MONRACE_IDX r_idx)
     (void)player_ptr;
 
     monster_race *r_ptr = &r_info[r_idx];
-    return test_bit(r_ptr->flags8, (RF8_WILD_TOWN | RF8_WILD_ALL));
+    return any_bits(r_ptr->flags8, (RF8_WILD_TOWN | RF8_WILD_ALL));
 }
 
 /*!
@@ -209,7 +209,7 @@ bool mon_hook_wood(player_type *player_ptr, MONRACE_IDX r_idx)
     (void)player_ptr;
 
     monster_race *r_ptr = &r_info[r_idx];
-    return test_bit(r_ptr->flags8, (RF8_WILD_WOOD | RF8_WILD_ALL));
+    return any_bits(r_ptr->flags8, (RF8_WILD_WOOD | RF8_WILD_ALL));
 }
 
 /*!
@@ -223,7 +223,7 @@ bool mon_hook_volcano(player_type *player_ptr, MONRACE_IDX r_idx)
     (void)player_ptr;
 
     monster_race *r_ptr = &r_info[r_idx];
-    return test_bit(r_ptr->flags8, RF8_WILD_VOLCANO);
+    return any_bits(r_ptr->flags8, RF8_WILD_VOLCANO);
 }
 
 /*!
@@ -237,7 +237,7 @@ bool mon_hook_mountain(player_type *player_ptr, MONRACE_IDX r_idx)
     (void)player_ptr;
 
     monster_race *r_ptr = &r_info[r_idx];
-    return test_bit(r_ptr->flags8, RF8_WILD_MOUNTAIN);
+    return any_bits(r_ptr->flags8, RF8_WILD_MOUNTAIN);
 }
 
 /*!
@@ -251,7 +251,7 @@ bool mon_hook_grass(player_type *player_ptr, MONRACE_IDX r_idx)
     (void)player_ptr;
 
     monster_race *r_ptr = &r_info[r_idx];
-    return test_bit(r_ptr->flags8, (RF8_WILD_GRASS | RF8_WILD_ALL));
+    return any_bits(r_ptr->flags8, (RF8_WILD_GRASS | RF8_WILD_ALL));
 }
 
 /*!
@@ -265,7 +265,7 @@ bool mon_hook_deep_water(player_type *player_ptr, MONRACE_IDX r_idx)
     if (!mon_hook_dungeon(player_ptr, r_idx))
         return FALSE;
 
-    return test_bit(r_ptr->flags7, RF7_AQUATIC);
+    return any_bits(r_ptr->flags7, RF7_AQUATIC);
 }
 
 /*!
@@ -279,7 +279,7 @@ bool mon_hook_shallow_water(player_type *player_ptr, MONRACE_IDX r_idx)
     if (!mon_hook_dungeon(player_ptr, r_idx))
         return FALSE;
 
-    return !test_bit(r_ptr->flags2, RF2_AURA_FIRE);
+    return none_bits(r_ptr->flags2, RF2_AURA_FIRE);
 }
 
 /*!
@@ -293,7 +293,7 @@ bool mon_hook_lava(player_type *player_ptr, MONRACE_IDX r_idx)
     if (!mon_hook_dungeon(player_ptr, r_idx))
         return FALSE;
 
-    return (test_bit(r_ptr->flagsr, RFR_EFF_IM_FIRE_MASK) || test_bit(r_ptr->flags7, RF7_CAN_FLY)) && !test_bit(r_ptr->flags3, RF3_AURA_COLD);
+    return (any_bits(r_ptr->flagsr, RFR_EFF_IM_FIRE_MASK) || any_bits(r_ptr->flags7, RF7_CAN_FLY)) && none_bits(r_ptr->flags3, RF3_AURA_COLD);
 }
 
 /*!
@@ -307,7 +307,7 @@ bool mon_hook_floor(player_type *player_ptr, MONRACE_IDX r_idx)
     (void)player_ptr;
 
     monster_race *r_ptr = &r_info[r_idx];
-    if (!test_bit(r_ptr->flags7, RF7_AQUATIC) || test_bit(r_ptr->flags7, RF7_CAN_FLY))
+    if (none_bits(r_ptr->flags7, RF7_AQUATIC) || any_bits(r_ptr->flags7, RF7_CAN_FLY))
         return TRUE;
     else
         return FALSE;
@@ -325,13 +325,13 @@ bool vault_aux_lite(player_type *player_ptr, MONRACE_IDX r_idx)
     if (!vault_monster_okay(player_ptr, r_idx))
         return FALSE;
 
-    if (!test_bit(r_ptr->flags4, RF4_BR_LITE) && !test_bit(r_ptr->a_ability_flags1, RF5_BA_LITE))
+    if (none_bits(r_ptr->flags4, RF4_BR_LITE) && none_bits(r_ptr->a_ability_flags1, RF5_BA_LITE))
         return FALSE;
 
-    if (test_bit(r_ptr->flags2, (RF2_PASS_WALL | RF2_KILL_WALL)))
+    if (any_bits(r_ptr->flags2, (RF2_PASS_WALL | RF2_KILL_WALL)))
         return FALSE;
 
-    if (test_bit(r_ptr->flags4, RF4_BR_DISI))
+    if (any_bits(r_ptr->flags4, RF4_BR_DISI))
         return FALSE;
 
     return TRUE;
@@ -346,7 +346,7 @@ bool vault_aux_shards(player_type *player_ptr, MONRACE_IDX r_idx)
     if (!vault_monster_okay(player_ptr, r_idx))
         return FALSE;
 
-    if (!test_bit(r_ptr->flags4, RF4_BR_SHAR))
+    if (none_bits(r_ptr->flags4, RF4_BR_SHAR))
         return FALSE;
 
     return TRUE;
@@ -378,10 +378,10 @@ bool vault_aux_jelly(player_type *player_ptr, MONRACE_IDX r_idx)
     if (!vault_monster_okay(player_ptr, r_idx))
         return FALSE;
 
-    if (test_bit(r_ptr->flags2, RF2_KILL_BODY) && !test_bit(r_ptr->flags1, RF1_NEVER_BLOW))
+    if (any_bits(r_ptr->flags2, RF2_KILL_BODY) && none_bits(r_ptr->flags1, RF1_NEVER_BLOW))
         return FALSE;
 
-    if (test_bit(r_ptr->flags3, RF3_EVIL))
+    if (any_bits(r_ptr->flags3, RF3_EVIL))
         return FALSE;
 
     if (!angband_strchr("ijm,", r_ptr->d_char))
@@ -402,7 +402,7 @@ bool vault_aux_animal(player_type *player_ptr, MONRACE_IDX r_idx)
     if (!vault_monster_okay(player_ptr, r_idx))
         return FALSE;
 
-    if (!test_bit(r_ptr->flags3, RF3_ANIMAL))
+    if (none_bits(r_ptr->flags3, RF3_ANIMAL))
         return FALSE;
 
     return TRUE;
@@ -420,7 +420,7 @@ bool vault_aux_undead(player_type *player_ptr, MONRACE_IDX r_idx)
     if (!vault_monster_okay(player_ptr, r_idx))
         return FALSE;
 
-    if (!test_bit(r_ptr->flags3, RF3_UNDEAD))
+    if (none_bits(r_ptr->flags3, RF3_UNDEAD))
         return FALSE;
 
     return TRUE;
@@ -441,7 +441,7 @@ bool vault_aux_chapel_g(player_type *player_ptr, MONRACE_IDX r_idx)
     if (!vault_monster_okay(player_ptr, r_idx))
         return FALSE;
 
-    if (test_bit(r_ptr->flags3, RF3_EVIL))
+    if (any_bits(r_ptr->flags3, RF3_EVIL))
         return FALSE;
 
     if ((r_idx == MON_A_GOLD) || (r_idx == MON_A_SILVER))
@@ -519,10 +519,10 @@ bool vault_aux_symbol_e(player_type *player_ptr, MONRACE_IDX r_idx)
     if (!vault_monster_okay(player_ptr, r_idx))
         return FALSE;
 
-    if (test_bit(r_ptr->flags2, RF2_KILL_BODY) && !test_bit(r_ptr->flags1, RF1_NEVER_BLOW))
+    if (any_bits(r_ptr->flags2, RF2_KILL_BODY) && none_bits(r_ptr->flags1, RF1_NEVER_BLOW))
         return FALSE;
 
-    if (test_bit(r_ptr->flags3, RF3_GOOD))
+    if (any_bits(r_ptr->flags3, RF3_GOOD))
         return FALSE;
 
     if (r_ptr->d_char != vault_aux_char)
@@ -543,10 +543,10 @@ bool vault_aux_symbol_g(player_type *player_ptr, MONRACE_IDX r_idx)
     if (!vault_monster_okay(player_ptr, r_idx))
         return FALSE;
 
-    if (test_bit(r_ptr->flags2, RF2_KILL_BODY) && !test_bit(r_ptr->flags1, RF1_NEVER_BLOW))
+    if (any_bits(r_ptr->flags2, RF2_KILL_BODY) && none_bits(r_ptr->flags1, RF1_NEVER_BLOW))
         return FALSE;
 
-    if (test_bit(r_ptr->flags3, RF3_EVIL))
+    if (any_bits(r_ptr->flags3, RF3_EVIL))
         return FALSE;
 
     if (r_ptr->d_char != vault_aux_char)
@@ -567,10 +567,10 @@ bool vault_aux_orc(player_type *player_ptr, MONRACE_IDX r_idx)
     if (!vault_monster_okay(player_ptr, r_idx))
         return FALSE;
 
-    if (!test_bit(r_ptr->flags3, RF3_ORC))
+    if (none_bits(r_ptr->flags3, RF3_ORC))
         return FALSE;
 
-    if (test_bit(r_ptr->flags3, RF3_UNDEAD))
+    if (any_bits(r_ptr->flags3, RF3_UNDEAD))
         return FALSE;
 
     return TRUE;
@@ -588,10 +588,10 @@ bool vault_aux_troll(player_type *player_ptr, MONRACE_IDX r_idx)
     if (!vault_monster_okay(player_ptr, r_idx))
         return FALSE;
 
-    if (!test_bit(r_ptr->flags3, RF3_TROLL))
+    if (none_bits(r_ptr->flags3, RF3_TROLL))
         return FALSE;
 
-    if (test_bit(r_ptr->flags3, RF3_UNDEAD))
+    if (any_bits(r_ptr->flags3, RF3_UNDEAD))
         return FALSE;
 
     return TRUE;
@@ -609,13 +609,13 @@ bool vault_aux_giant(player_type *player_ptr, MONRACE_IDX r_idx)
     if (!vault_monster_okay(player_ptr, r_idx))
         return FALSE;
 
-    if (!test_bit(r_ptr->flags3, RF3_GIANT))
+    if (none_bits(r_ptr->flags3, RF3_GIANT))
         return FALSE;
 
-    if (test_bit(r_ptr->flags3, RF3_GOOD))
+    if (any_bits(r_ptr->flags3, RF3_GOOD))
         return FALSE;
 
-    if (test_bit(r_ptr->flags3, RF3_UNDEAD))
+    if (any_bits(r_ptr->flags3, RF3_UNDEAD))
         return FALSE;
 
     return TRUE;
@@ -633,13 +633,13 @@ bool vault_aux_dragon(player_type *player_ptr, MONRACE_IDX r_idx)
     if (!vault_monster_okay(player_ptr, r_idx))
         return FALSE;
 
-    if (!test_bit(r_ptr->flags3, RF3_DRAGON))
+    if (none_bits(r_ptr->flags3, RF3_DRAGON))
         return FALSE;
 
-    if (!test_bit(r_ptr->flags4, vault_aux_dragon_mask4))
+    if (none_bits(r_ptr->flags4, vault_aux_dragon_mask4))
         return FALSE;
 
-    if (test_bit(r_ptr->flags3, RF3_UNDEAD))
+    if (any_bits(r_ptr->flags3, RF3_UNDEAD))
         return FALSE;
 
     return TRUE;
@@ -657,10 +657,10 @@ bool vault_aux_demon(player_type *player_ptr, MONRACE_IDX r_idx)
     if (!vault_monster_okay(player_ptr, r_idx))
         return FALSE;
 
-    if (test_bit(r_ptr->flags2, RF2_KILL_BODY) && !test_bit(r_ptr->flags1, RF1_NEVER_BLOW))
+    if (any_bits(r_ptr->flags2, RF2_KILL_BODY) && none_bits(r_ptr->flags1, RF1_NEVER_BLOW))
         return FALSE;
 
-    if (!test_bit(r_ptr->flags3, RF3_DEMON))
+    if (none_bits(r_ptr->flags3, RF3_DEMON))
         return FALSE;
 
     return TRUE;
@@ -731,7 +731,7 @@ bool vault_aux_dark_elf(player_type *player_ptr, MONRACE_IDX r_idx)
 bool monster_living(MONRACE_IDX r_idx)
 {
     monster_race *r_ptr = &r_info[r_idx];
-    return !test_bit(r_ptr->flags3, (RF3_DEMON | RF3_UNDEAD | RF3_NONLIVING));
+    return none_bits(r_ptr->flags3, (RF3_DEMON | RF3_UNDEAD | RF3_NONLIVING));
 }
 
 /*!
@@ -769,7 +769,7 @@ bool monster_hook_human(player_type *player_ptr, MONRACE_IDX r_idx)
     (void)player_ptr;
 
     monster_race *r_ptr = &r_info[r_idx];
-    if (test_bit(r_ptr->flags1, RF1_UNIQUE))
+    if (any_bits(r_ptr->flags1, RF1_UNIQUE))
         return FALSE;
 
     if (angband_strchr("pht", r_ptr->d_char))
@@ -786,7 +786,7 @@ bool monster_hook_human(player_type *player_ptr, MONRACE_IDX r_idx)
 bool get_nightmare(player_type *player_ptr, MONRACE_IDX r_idx)
 {
     monster_race *r_ptr = &r_info[r_idx];
-    if (!test_bit(r_ptr->flags2, RF2_ELDRITCH_HORROR))
+    if (none_bits(r_ptr->flags2, RF2_ELDRITCH_HORROR))
         return FALSE;
 
     if (r_ptr->level <= player_ptr->lev)
@@ -806,7 +806,7 @@ bool monster_is_fishing_target(player_type *player_ptr, MONRACE_IDX r_idx)
     (void)player_ptr;
 
     monster_race *r_ptr = &r_info[r_idx];
-    if (test_bit(r_ptr->flags7, RF7_AQUATIC) && !test_bit(r_ptr->flags1, RF1_UNIQUE) && angband_strchr("Jjlw", r_ptr->d_char))
+    if (any_bits(r_ptr->flags7, RF7_AQUATIC) && none_bits(r_ptr->flags1, RF1_UNIQUE) && angband_strchr("Jjlw", r_ptr->d_char))
         return TRUE;
     else
         return FALSE;
@@ -826,11 +826,11 @@ bool monster_can_entry_arena(player_type *player_ptr, MONRACE_IDX r_idx)
 
     HIT_POINT dam = 0;
     monster_race *r_ptr = &r_info[r_idx];
-    bool unselectable = test_bit(r_ptr->flags1, RF1_NEVER_MOVE);
-    unselectable |= test_bit(r_ptr->flags2, RF2_MULTIPLY);
-    unselectable |= test_bit(r_ptr->flags2, RF2_QUANTUM) && !test_bit(r_ptr->flags1, RF1_UNIQUE);
-    unselectable |= test_bit(r_ptr->flags7, RF7_AQUATIC);
-    unselectable |= test_bit(r_ptr->flags7, RF7_CHAMELEON);
+    bool unselectable = any_bits(r_ptr->flags1, RF1_NEVER_MOVE);
+    unselectable |= any_bits(r_ptr->flags2, RF2_MULTIPLY);
+    unselectable |= any_bits(r_ptr->flags2, RF2_QUANTUM) && none_bits(r_ptr->flags1, RF1_UNIQUE);
+    unselectable |= any_bits(r_ptr->flags7, RF7_AQUATIC);
+    unselectable |= any_bits(r_ptr->flags7, RF7_CHAMELEON);
     if (unselectable)
         return FALSE;
 
@@ -842,9 +842,9 @@ bool monster_can_entry_arena(player_type *player_ptr, MONRACE_IDX r_idx)
             dam += r_ptr->blow[i].d_dice;
     }
 
-    if (!dam && !test_bit(r_ptr->flags4, (RF4_BOLT_MASK | RF4_BEAM_MASK | RF4_BALL_MASK | RF4_BREATH_MASK))
-        && !test_bit(r_ptr->a_ability_flags1, (RF5_BOLT_MASK | RF5_BEAM_MASK | RF5_BALL_MASK | RF5_BREATH_MASK))
-        && !test_bit(r_ptr->a_ability_flags2, (RF6_BOLT_MASK | RF6_BEAM_MASK | RF6_BALL_MASK | RF6_BREATH_MASK)))
+    if (!dam && none_bits(r_ptr->flags4, (RF4_BOLT_MASK | RF4_BEAM_MASK | RF4_BALL_MASK | RF4_BREATH_MASK))
+        && none_bits(r_ptr->a_ability_flags1, (RF5_BOLT_MASK | RF5_BEAM_MASK | RF5_BALL_MASK | RF5_BREATH_MASK))
+        && none_bits(r_ptr->a_ability_flags2, (RF6_BOLT_MASK | RF6_BEAM_MASK | RF6_BALL_MASK | RF6_BREATH_MASK)))
         return FALSE;
 
     return TRUE;
@@ -861,22 +861,22 @@ bool item_monster_okay(player_type *player_ptr, MONRACE_IDX r_idx)
     (void)player_ptr;
 
     monster_race *r_ptr = &r_info[r_idx];
-    if (test_bit(r_ptr->flags1, RF1_UNIQUE))
+    if (any_bits(r_ptr->flags1, RF1_UNIQUE))
         return FALSE;
 
-    if (test_bit(r_ptr->flags7, RF7_KAGE))
+    if (any_bits(r_ptr->flags7, RF7_KAGE))
         return FALSE;
 
-    if (test_bit(r_ptr->flagsr, RFR_RES_ALL))
+    if (any_bits(r_ptr->flagsr, RFR_RES_ALL))
         return FALSE;
 
-    if (test_bit(r_ptr->flags7, RF7_NAZGUL))
+    if (any_bits(r_ptr->flags7, RF7_NAZGUL))
         return FALSE;
 
-    if (test_bit(r_ptr->flags1, RF1_FORCE_DEPTH))
+    if (any_bits(r_ptr->flags1, RF1_FORCE_DEPTH))
         return FALSE;
 
-    if (test_bit(r_ptr->flags7, RF7_UNIQUE2))
+    if (any_bits(r_ptr->flags7, RF7_UNIQUE2))
         return FALSE;
 
     return TRUE;
@@ -893,6 +893,6 @@ bool item_monster_okay(player_type *player_ptr, MONRACE_IDX r_idx)
  */
 bool vault_monster_okay(player_type *player_ptr, MONRACE_IDX r_idx)
 {
-    return (mon_hook_dungeon(player_ptr, r_idx) && !test_bit(r_info[r_idx].flags1, RF1_UNIQUE) && !test_bit(r_info[r_idx].flags7, RF7_UNIQUE2)
-        && !test_bit(r_info[r_idx].flagsr, RFR_RES_ALL) && !test_bit(r_info[r_idx].flags7, RF7_AQUATIC));
+    return (mon_hook_dungeon(player_ptr, r_idx) && none_bits(r_info[r_idx].flags1, RF1_UNIQUE) && none_bits(r_info[r_idx].flags7, RF7_UNIQUE2)
+        && none_bits(r_info[r_idx].flagsr, RFR_RES_ALL) && none_bits(r_info[r_idx].flags7, RF7_AQUATIC));
 }

--- a/src/mspell/element-resistance-checker.c
+++ b/src/mspell/element-resistance-checker.c
@@ -11,215 +11,215 @@
 void add_cheat_remove_flags_element(player_type *target_ptr, msr_type *msr_ptr)
 {
     if (has_resist_acid(target_ptr))
-        set_bit(msr_ptr->smart, SM_RES_ACID);
+        set_bits(msr_ptr->smart, SM_RES_ACID);
 
     if (is_oppose_acid(target_ptr))
-        set_bit(msr_ptr->smart, SM_OPP_ACID);
+        set_bits(msr_ptr->smart, SM_OPP_ACID);
 
     if (has_immune_acid(target_ptr))
-        set_bit(msr_ptr->smart, SM_IMM_ACID);
+        set_bits(msr_ptr->smart, SM_IMM_ACID);
 
     if (has_resist_elec(target_ptr))
-        set_bit(msr_ptr->smart, SM_RES_ELEC);
+        set_bits(msr_ptr->smart, SM_RES_ELEC);
 
     if (is_oppose_elec(target_ptr))
-        set_bit(msr_ptr->smart, SM_OPP_ELEC);
+        set_bits(msr_ptr->smart, SM_OPP_ELEC);
 
     if (has_immune_elec(target_ptr))
-        set_bit(msr_ptr->smart, SM_IMM_ELEC);
+        set_bits(msr_ptr->smart, SM_IMM_ELEC);
 
     if (has_resist_fire(target_ptr))
-        set_bit(msr_ptr->smart, SM_RES_FIRE);
+        set_bits(msr_ptr->smart, SM_RES_FIRE);
 
     if (is_oppose_fire(target_ptr))
-        set_bit(msr_ptr->smart, SM_OPP_FIRE);
+        set_bits(msr_ptr->smart, SM_OPP_FIRE);
 
     if (has_immune_fire(target_ptr))
-        set_bit(msr_ptr->smart, SM_IMM_FIRE);
+        set_bits(msr_ptr->smart, SM_IMM_FIRE);
 
     if (has_resist_cold(target_ptr))
-        set_bit(msr_ptr->smart, SM_RES_COLD);
+        set_bits(msr_ptr->smart, SM_RES_COLD);
 
     if (is_oppose_cold(target_ptr))
-        set_bit(msr_ptr->smart, SM_OPP_COLD);
+        set_bits(msr_ptr->smart, SM_OPP_COLD);
 
     if (has_immune_cold(target_ptr))
-        set_bit(msr_ptr->smart, SM_IMM_COLD);
+        set_bits(msr_ptr->smart, SM_IMM_COLD);
 
     if (has_resist_pois(target_ptr))
-        set_bit(msr_ptr->smart, SM_RES_POIS);
+        set_bits(msr_ptr->smart, SM_RES_POIS);
 
     if (is_oppose_pois(target_ptr))
-        set_bit(msr_ptr->smart, SM_OPP_POIS);
+        set_bits(msr_ptr->smart, SM_OPP_POIS);
 }
 
 static void check_acid_resistance(msr_type *msr_ptr)
 {
-    if (test_bit(msr_ptr->smart, SM_IMM_ACID)) {
-        reset_bit(msr_ptr->f4, RF4_BR_ACID);
-        reset_bit(msr_ptr->f5, RF5_BA_ACID);
-        reset_bit(msr_ptr->f5, RF5_BO_ACID);
+    if (any_bits(msr_ptr->smart, SM_IMM_ACID)) {
+        reset_bits(msr_ptr->f4, RF4_BR_ACID);
+        reset_bits(msr_ptr->f5, RF5_BA_ACID);
+        reset_bits(msr_ptr->f5, RF5_BO_ACID);
         return;
     }
 
-    if (test_bit(msr_ptr->smart, SM_OPP_ACID) && test_bit(msr_ptr->smart, SM_RES_ACID)) {
+    if (all_bits(msr_ptr->smart, (SM_OPP_ACID | SM_RES_ACID))) {
         if (int_outof(msr_ptr->r_ptr, 80))
-            reset_bit(msr_ptr->f4, RF4_BR_ACID);
+            reset_bits(msr_ptr->f4, RF4_BR_ACID);
 
         if (int_outof(msr_ptr->r_ptr, 80))
-            reset_bit(msr_ptr->f5, RF5_BA_ACID);
+            reset_bits(msr_ptr->f5, RF5_BA_ACID);
 
         if (int_outof(msr_ptr->r_ptr, 80))
-            reset_bit(msr_ptr->f5, RF5_BO_ACID);
+            reset_bits(msr_ptr->f5, RF5_BO_ACID);
 
         return;
     }
 
-    if (test_bit(msr_ptr->smart, (SM_OPP_ACID | SM_RES_ACID))) {
+    if (any_bits(msr_ptr->smart, (SM_OPP_ACID | SM_RES_ACID))) {
         if (int_outof(msr_ptr->r_ptr, 30))
-            reset_bit(msr_ptr->f4, RF4_BR_ACID);
+            reset_bits(msr_ptr->f4, RF4_BR_ACID);
 
         if (int_outof(msr_ptr->r_ptr, 30))
-            reset_bit(msr_ptr->f5, RF5_BA_ACID);
+            reset_bits(msr_ptr->f5, RF5_BA_ACID);
 
         if (int_outof(msr_ptr->r_ptr, 30))
-            reset_bit(msr_ptr->f5, RF5_BO_ACID);
+            reset_bits(msr_ptr->f5, RF5_BO_ACID);
     }
 }
 
 static void check_elec_resistance(msr_type *msr_ptr)
 {
-    if (test_bit(msr_ptr->smart, SM_IMM_ELEC)) {
-        reset_bit(msr_ptr->f4, RF4_BR_ELEC);
-        reset_bit(msr_ptr->f5, RF5_BA_ELEC);
-        reset_bit(msr_ptr->f5, RF5_BO_ELEC);
+    if (any_bits(msr_ptr->smart, SM_IMM_ELEC)) {
+        reset_bits(msr_ptr->f4, RF4_BR_ELEC);
+        reset_bits(msr_ptr->f5, RF5_BA_ELEC);
+        reset_bits(msr_ptr->f5, RF5_BO_ELEC);
         return;
     }
 
-    if (test_bit(msr_ptr->smart, SM_OPP_ELEC) && test_bit(msr_ptr->smart, SM_RES_ELEC)) {
+    if (all_bits(msr_ptr->smart, (SM_OPP_ELEC | SM_RES_ELEC))) {
         if (int_outof(msr_ptr->r_ptr, 80))
-            reset_bit(msr_ptr->f4, RF4_BR_ELEC);
+            reset_bits(msr_ptr->f4, RF4_BR_ELEC);
 
         if (int_outof(msr_ptr->r_ptr, 80))
-            reset_bit(msr_ptr->f5, RF5_BA_ELEC);
+            reset_bits(msr_ptr->f5, RF5_BA_ELEC);
 
         if (int_outof(msr_ptr->r_ptr, 80))
-            reset_bit(msr_ptr->f5, RF5_BO_ELEC);
+            reset_bits(msr_ptr->f5, RF5_BO_ELEC);
 
         return;
     }
 
-    if (test_bit(msr_ptr->smart, (SM_OPP_ELEC | SM_RES_ELEC))) {
+    if (any_bits(msr_ptr->smart, (SM_OPP_ELEC | SM_RES_ELEC))) {
         if (int_outof(msr_ptr->r_ptr, 30))
-            reset_bit(msr_ptr->f4, RF4_BR_ELEC);
+            reset_bits(msr_ptr->f4, RF4_BR_ELEC);
 
         if (int_outof(msr_ptr->r_ptr, 30))
-            reset_bit(msr_ptr->f5, RF5_BA_ELEC);
+            reset_bits(msr_ptr->f5, RF5_BA_ELEC);
 
         if (int_outof(msr_ptr->r_ptr, 30))
-            reset_bit(msr_ptr->f5, RF5_BO_ELEC);
+            reset_bits(msr_ptr->f5, RF5_BO_ELEC);
     }
 }
 
 static void check_fire_resistance(msr_type *msr_ptr)
 {
-    if (test_bit(msr_ptr->smart, SM_IMM_FIRE)) {
-        reset_bit(msr_ptr->f4, RF4_BR_FIRE);
-        reset_bit(msr_ptr->f5, RF5_BA_FIRE);
-        reset_bit(msr_ptr->f5, RF5_BO_FIRE);
+    if (any_bits(msr_ptr->smart, SM_IMM_FIRE)) {
+        reset_bits(msr_ptr->f4, RF4_BR_FIRE);
+        reset_bits(msr_ptr->f5, RF5_BA_FIRE);
+        reset_bits(msr_ptr->f5, RF5_BO_FIRE);
         return;
     }
 
-    if (test_bit(msr_ptr->smart, SM_OPP_FIRE) && test_bit(msr_ptr->smart, SM_RES_FIRE)) {
+    if (all_bits(msr_ptr->smart, (SM_OPP_FIRE | SM_RES_FIRE))) {
         if (int_outof(msr_ptr->r_ptr, 80))
-            reset_bit(msr_ptr->f4, RF4_BR_FIRE);
+            reset_bits(msr_ptr->f4, RF4_BR_FIRE);
 
         if (int_outof(msr_ptr->r_ptr, 80))
-            reset_bit(msr_ptr->f5, RF5_BA_FIRE);
+            reset_bits(msr_ptr->f5, RF5_BA_FIRE);
 
         if (int_outof(msr_ptr->r_ptr, 80))
-            reset_bit(msr_ptr->f5, RF5_BO_FIRE);
+            reset_bits(msr_ptr->f5, RF5_BO_FIRE);
 
         return;
     }
 
-    if (test_bit(msr_ptr->smart, (SM_OPP_FIRE | SM_RES_FIRE))) {
+    if (any_bits(msr_ptr->smart, (SM_OPP_FIRE | SM_RES_FIRE))) {
         if (int_outof(msr_ptr->r_ptr, 30))
-            reset_bit(msr_ptr->f4, RF4_BR_FIRE);
+            reset_bits(msr_ptr->f4, RF4_BR_FIRE);
 
         if (int_outof(msr_ptr->r_ptr, 30))
-            reset_bit(msr_ptr->f5, RF5_BA_FIRE);
+            reset_bits(msr_ptr->f5, RF5_BA_FIRE);
 
         if (int_outof(msr_ptr->r_ptr, 30))
-            reset_bit(msr_ptr->f5, RF5_BO_FIRE);
+            reset_bits(msr_ptr->f5, RF5_BO_FIRE);
     }
 }
 
 static void check_cold_resistance(msr_type *msr_ptr)
 {
-    if (test_bit(msr_ptr->smart, SM_IMM_COLD)) {
-        reset_bit(msr_ptr->f4, RF4_BR_COLD);
-        reset_bit(msr_ptr->f5, RF5_BA_COLD);
-        reset_bit(msr_ptr->f5, RF5_BO_COLD);
-        reset_bit(msr_ptr->f5, RF5_BO_ICEE);
+    if (any_bits(msr_ptr->smart, SM_IMM_COLD)) {
+        reset_bits(msr_ptr->f4, RF4_BR_COLD);
+        reset_bits(msr_ptr->f5, RF5_BA_COLD);
+        reset_bits(msr_ptr->f5, RF5_BO_COLD);
+        reset_bits(msr_ptr->f5, RF5_BO_ICEE);
         return;
     }
 
-    if (test_bit(msr_ptr->smart, SM_OPP_COLD) && test_bit(msr_ptr->smart, SM_RES_COLD)) {
+    if (all_bits(msr_ptr->smart, (SM_OPP_COLD | SM_RES_COLD))) {
         if (int_outof(msr_ptr->r_ptr, 80))
-            reset_bit(msr_ptr->f4, RF4_BR_COLD);
+            reset_bits(msr_ptr->f4, RF4_BR_COLD);
 
         if (int_outof(msr_ptr->r_ptr, 80))
-            reset_bit(msr_ptr->f5, RF5_BA_COLD);
+            reset_bits(msr_ptr->f5, RF5_BA_COLD);
 
         if (int_outof(msr_ptr->r_ptr, 80))
-            reset_bit(msr_ptr->f5, RF5_BO_COLD);
+            reset_bits(msr_ptr->f5, RF5_BO_COLD);
 
         if (int_outof(msr_ptr->r_ptr, 80))
-            reset_bit(msr_ptr->f5, RF5_BO_ICEE);
+            reset_bits(msr_ptr->f5, RF5_BO_ICEE);
 
         return;
     }
 
-    if (test_bit(msr_ptr->smart, (SM_OPP_COLD | SM_RES_COLD))) {
+    if (any_bits(msr_ptr->smart, (SM_OPP_COLD | SM_RES_COLD))) {
         if (int_outof(msr_ptr->r_ptr, 30))
-            reset_bit(msr_ptr->f4, RF4_BR_COLD);
+            reset_bits(msr_ptr->f4, RF4_BR_COLD);
 
         if (int_outof(msr_ptr->r_ptr, 30))
-            reset_bit(msr_ptr->f5, RF5_BA_COLD);
+            reset_bits(msr_ptr->f5, RF5_BA_COLD);
 
         if (int_outof(msr_ptr->r_ptr, 30))
-            reset_bit(msr_ptr->f5, RF5_BO_COLD);
+            reset_bits(msr_ptr->f5, RF5_BO_COLD);
 
         if (int_outof(msr_ptr->r_ptr, 20))
-            reset_bit(msr_ptr->f5, RF5_BO_ICEE);
+            reset_bits(msr_ptr->f5, RF5_BO_ICEE);
     }
 }
 
 static void check_pois_resistance(msr_type *msr_ptr)
 {
-    if (test_bit(msr_ptr->smart, SM_OPP_POIS) && test_bit(msr_ptr->smart, SM_RES_POIS)) {
+    if (all_bits(msr_ptr->smart, (SM_OPP_POIS | SM_RES_POIS))) {
         if (int_outof(msr_ptr->r_ptr, 80))
-            reset_bit(msr_ptr->f4, RF4_BR_POIS);
+            reset_bits(msr_ptr->f4, RF4_BR_POIS);
 
         if (int_outof(msr_ptr->r_ptr, 80))
-            reset_bit(msr_ptr->f5, RF5_BA_POIS);
+            reset_bits(msr_ptr->f5, RF5_BA_POIS);
 
         if (int_outof(msr_ptr->r_ptr, 60))
-            reset_bit(msr_ptr->f4, RF4_BA_NUKE);
+            reset_bits(msr_ptr->f4, RF4_BA_NUKE);
 
         if (int_outof(msr_ptr->r_ptr, 60))
-            reset_bit(msr_ptr->f4, RF4_BR_NUKE);
+            reset_bits(msr_ptr->f4, RF4_BR_NUKE);
 
         return;
     }
 
-    if (test_bit(msr_ptr->smart, (SM_OPP_POIS | SM_RES_POIS))) {
+    if (any_bits(msr_ptr->smart, (SM_OPP_POIS | SM_RES_POIS))) {
         if (int_outof(msr_ptr->r_ptr, 30))
-            reset_bit(msr_ptr->f4, RF4_BR_POIS);
+            reset_bits(msr_ptr->f4, RF4_BR_POIS);
 
         if (int_outof(msr_ptr->r_ptr, 30))
-            reset_bit(msr_ptr->f5, RF5_BA_POIS);
+            reset_bits(msr_ptr->f5, RF5_BA_POIS);
     }
 }
 

--- a/src/mspell/high-resistance-checker.c
+++ b/src/mspell/high-resistance-checker.c
@@ -11,167 +11,167 @@
 void add_cheat_remove_flags_others(player_type *target_ptr, msr_type *msr_ptr)
 {
     if (has_resist_neth(target_ptr))
-        set_bit(msr_ptr->smart, SM_RES_NETH);
+        set_bits(msr_ptr->smart, SM_RES_NETH);
 
     if (has_resist_lite(target_ptr))
-        set_bit(msr_ptr->smart, SM_RES_LITE);
+        set_bits(msr_ptr->smart, SM_RES_LITE);
 
     if (has_resist_dark(target_ptr))
-        set_bit(msr_ptr->smart, SM_RES_DARK);
+        set_bits(msr_ptr->smart, SM_RES_DARK);
 
     if (has_resist_fear(target_ptr))
-        set_bit(msr_ptr->smart, SM_RES_FEAR);
+        set_bits(msr_ptr->smart, SM_RES_FEAR);
 
     if (has_resist_conf(target_ptr))
-        set_bit(msr_ptr->smart, SM_RES_CONF);
+        set_bits(msr_ptr->smart, SM_RES_CONF);
 
     if (has_resist_chaos(target_ptr))
-        set_bit(msr_ptr->smart, SM_RES_CHAOS);
+        set_bits(msr_ptr->smart, SM_RES_CHAOS);
 
     if (has_resist_disen(target_ptr))
-        set_bit(msr_ptr->smart, SM_RES_DISEN);
+        set_bits(msr_ptr->smart, SM_RES_DISEN);
 
     if (has_resist_blind(target_ptr))
-        set_bit(msr_ptr->smart, SM_RES_BLIND);
+        set_bits(msr_ptr->smart, SM_RES_BLIND);
 
     if (has_resist_nexus(target_ptr))
-        set_bit(msr_ptr->smart, SM_RES_NEXUS);
+        set_bits(msr_ptr->smart, SM_RES_NEXUS);
 
     if (has_resist_sound(target_ptr))
-        set_bit(msr_ptr->smart, SM_RES_SOUND);
+        set_bits(msr_ptr->smart, SM_RES_SOUND);
 
     if (has_resist_shard(target_ptr))
-        set_bit(msr_ptr->smart, SM_RES_SHARD);
+        set_bits(msr_ptr->smart, SM_RES_SHARD);
 
     if (has_reflect(target_ptr))
-        set_bit(msr_ptr->smart, SM_IMM_REFLECT);
+        set_bits(msr_ptr->smart, SM_IMM_REFLECT);
 
     if (target_ptr->free_act)
-        set_bit(msr_ptr->smart, SM_IMM_FREE);
+        set_bits(msr_ptr->smart, SM_IMM_FREE);
 
     if (!target_ptr->msp)
-        set_bit(msr_ptr->smart, SM_IMM_MANA);
+        set_bits(msr_ptr->smart, SM_IMM_MANA);
 }
 
 static void check_nether_resistance(player_type *target_ptr, msr_type *msr_ptr)
 {
-    if (!test_bit(msr_ptr->smart, SM_RES_NETH))
+    if (none_bits(msr_ptr->smart, SM_RES_NETH))
         return;
 
     if (is_specific_player_race(target_ptr, RACE_SPECTRE)) {
-        reset_bit(msr_ptr->f4, RF4_BR_NETH);
-        reset_bit(msr_ptr->f5, RF5_BA_NETH);
-        reset_bit(msr_ptr->f5, RF5_BO_NETH);
+        reset_bits(msr_ptr->f4, RF4_BR_NETH);
+        reset_bits(msr_ptr->f5, RF5_BA_NETH);
+        reset_bits(msr_ptr->f5, RF5_BO_NETH);
         return;
     }
 
     if (int_outof(msr_ptr->r_ptr, 20))
-        reset_bit(msr_ptr->f4, RF4_BR_NETH);
+        reset_bits(msr_ptr->f4, RF4_BR_NETH);
 
     if (int_outof(msr_ptr->r_ptr, 50))
-        reset_bit(msr_ptr->f5, RF5_BA_NETH);
+        reset_bits(msr_ptr->f5, RF5_BA_NETH);
 
     if (int_outof(msr_ptr->r_ptr, 50))
-        reset_bit(msr_ptr->f5, RF5_BO_NETH);
+        reset_bits(msr_ptr->f5, RF5_BO_NETH);
 }
 
 static void check_lite_resistance(msr_type *msr_ptr)
 {
-    if (!test_bit(msr_ptr->smart, SM_RES_LITE))
+    if (none_bits(msr_ptr->smart, SM_RES_LITE))
         return;
 
     if (int_outof(msr_ptr->r_ptr, 50))
-        reset_bit(msr_ptr->f4, RF4_BR_LITE);
+        reset_bits(msr_ptr->f4, RF4_BR_LITE);
 
     if (int_outof(msr_ptr->r_ptr, 50))
-        reset_bit(msr_ptr->f5, RF5_BA_LITE);
+        reset_bits(msr_ptr->f5, RF5_BA_LITE);
 }
 
 static void check_dark_resistance(player_type *target_ptr, msr_type *msr_ptr)
 {
-    if (!test_bit(msr_ptr->smart, SM_RES_DARK))
+    if (none_bits(msr_ptr->smart, SM_RES_DARK))
         return;
 
     if (is_specific_player_race(target_ptr, RACE_VAMPIRE)) {
-        reset_bit(msr_ptr->f4, RF4_BR_DARK);
-        reset_bit(msr_ptr->f5, RF5_BA_DARK);
+        reset_bits(msr_ptr->f4, RF4_BR_DARK);
+        reset_bits(msr_ptr->f5, RF5_BA_DARK);
         return;
     }
 
     if (int_outof(msr_ptr->r_ptr, 50))
-        reset_bit(msr_ptr->f4, RF4_BR_DARK);
+        reset_bits(msr_ptr->f4, RF4_BR_DARK);
 
     if (int_outof(msr_ptr->r_ptr, 50))
-        reset_bit(msr_ptr->f5, RF5_BA_DARK);
+        reset_bits(msr_ptr->f5, RF5_BA_DARK);
 }
 
 static void check_conf_resistance(msr_type *msr_ptr)
 {
-    if (!test_bit(msr_ptr->smart, SM_RES_CONF))
+    if (none_bits(msr_ptr->smart, SM_RES_CONF))
         return;
 
-    reset_bit(msr_ptr->f5, RF5_CONF);
+    reset_bits(msr_ptr->f5, RF5_CONF);
     if (int_outof(msr_ptr->r_ptr, 50))
-        reset_bit(msr_ptr->f4, RF4_BR_CONF);
+        reset_bits(msr_ptr->f4, RF4_BR_CONF);
 }
 
 static void check_chaos_resistance(msr_type *msr_ptr)
 {
-    if (!test_bit(msr_ptr->smart, SM_RES_CHAOS))
+    if (none_bits(msr_ptr->smart, SM_RES_CHAOS))
         return;
 
     if (int_outof(msr_ptr->r_ptr, 20))
-        reset_bit(msr_ptr->f4, RF4_BR_CHAO);
+        reset_bits(msr_ptr->f4, RF4_BR_CHAO);
 
     if (int_outof(msr_ptr->r_ptr, 50))
-        reset_bit(msr_ptr->f4, RF4_BA_CHAO);
+        reset_bits(msr_ptr->f4, RF4_BA_CHAO);
 }
 
 static void check_nexus_resistance(msr_type *msr_ptr)
 {
-    if (!test_bit(msr_ptr->smart, SM_RES_NEXUS))
+    if (none_bits(msr_ptr->smart, SM_RES_NEXUS))
         return;
 
     if (int_outof(msr_ptr->r_ptr, 50))
-        reset_bit(msr_ptr->f4, RF4_BR_NEXU);
+        reset_bits(msr_ptr->f4, RF4_BR_NEXU);
 
-    reset_bit(msr_ptr->f6, RF6_TELE_LEVEL);
+    reset_bits(msr_ptr->f6, RF6_TELE_LEVEL);
 }
 
 static void check_reflection(msr_type *msr_ptr)
 {
-    if (!test_bit(msr_ptr->smart, SM_IMM_REFLECT))
+    if (none_bits(msr_ptr->smart, SM_IMM_REFLECT))
         return;
 
     if (int_outof(msr_ptr->r_ptr, 150))
-        reset_bit(msr_ptr->f5, RF5_BO_COLD);
+        reset_bits(msr_ptr->f5, RF5_BO_COLD);
 
     if (int_outof(msr_ptr->r_ptr, 150))
-        reset_bit(msr_ptr->f5, RF5_BO_FIRE);
+        reset_bits(msr_ptr->f5, RF5_BO_FIRE);
 
     if (int_outof(msr_ptr->r_ptr, 150))
-        reset_bit(msr_ptr->f5, RF5_BO_ACID);
+        reset_bits(msr_ptr->f5, RF5_BO_ACID);
 
     if (int_outof(msr_ptr->r_ptr, 150))
-        reset_bit(msr_ptr->f5, RF5_BO_ELEC);
+        reset_bits(msr_ptr->f5, RF5_BO_ELEC);
 
     if (int_outof(msr_ptr->r_ptr, 150))
-        reset_bit(msr_ptr->f5, RF5_BO_NETH);
+        reset_bits(msr_ptr->f5, RF5_BO_NETH);
 
     if (int_outof(msr_ptr->r_ptr, 150))
-        reset_bit(msr_ptr->f5, RF5_BO_WATE);
+        reset_bits(msr_ptr->f5, RF5_BO_WATE);
 
     if (int_outof(msr_ptr->r_ptr, 150))
-        reset_bit(msr_ptr->f5, RF5_BO_MANA);
+        reset_bits(msr_ptr->f5, RF5_BO_MANA);
 
     if (int_outof(msr_ptr->r_ptr, 150))
-        reset_bit(msr_ptr->f5, RF5_BO_PLAS);
+        reset_bits(msr_ptr->f5, RF5_BO_PLAS);
 
     if (int_outof(msr_ptr->r_ptr, 150))
-        reset_bit(msr_ptr->f5, RF5_BO_ICEE);
+        reset_bits(msr_ptr->f5, RF5_BO_ICEE);
 
     if (int_outof(msr_ptr->r_ptr, 150))
-        reset_bit(msr_ptr->f5, RF5_MISSILE);
+        reset_bits(msr_ptr->f5, RF5_MISSILE);
 }
 
 void check_high_resistances(player_type *target_ptr, msr_type *msr_ptr)
@@ -179,30 +179,30 @@ void check_high_resistances(player_type *target_ptr, msr_type *msr_ptr)
     check_nether_resistance(target_ptr, msr_ptr);
     check_lite_resistance(msr_ptr);
     check_dark_resistance(target_ptr, msr_ptr);
-    if (test_bit(msr_ptr->smart, SM_RES_FEAR))
-        reset_bit(msr_ptr->f5, RF5_SCARE);
+    if (any_bits(msr_ptr->smart, SM_RES_FEAR))
+        reset_bits(msr_ptr->f5, RF5_SCARE);
 
     check_conf_resistance(msr_ptr);
     check_chaos_resistance(msr_ptr);
-    if (test_bit(msr_ptr->smart, SM_RES_DISEN) && int_outof(msr_ptr->r_ptr, 40))
-        reset_bit(msr_ptr->f4, RF4_BR_DISE);
+    if (any_bits(msr_ptr->smart, SM_RES_DISEN) && int_outof(msr_ptr->r_ptr, 40))
+        reset_bits(msr_ptr->f4, RF4_BR_DISE);
 
-    if (test_bit(msr_ptr->smart, SM_RES_BLIND))
-        reset_bit(msr_ptr->f5, RF5_BLIND);
+    if (any_bits(msr_ptr->smart, SM_RES_BLIND))
+        reset_bits(msr_ptr->f5, RF5_BLIND);
 
     check_nexus_resistance(msr_ptr);
-    if (test_bit(msr_ptr->smart, SM_RES_SOUND) && int_outof(msr_ptr->r_ptr, 50))
-        reset_bit(msr_ptr->f4, RF4_BR_SOUN);
+    if (any_bits(msr_ptr->smart, SM_RES_SOUND) && int_outof(msr_ptr->r_ptr, 50))
+        reset_bits(msr_ptr->f4, RF4_BR_SOUN);
 
-    if (test_bit(msr_ptr->smart, SM_RES_SHARD) && int_outof(msr_ptr->r_ptr, 40))
-        reset_bit(msr_ptr->f4, RF4_BR_SHAR);
+    if (any_bits(msr_ptr->smart, SM_RES_SHARD) && int_outof(msr_ptr->r_ptr, 40))
+        reset_bits(msr_ptr->f4, RF4_BR_SHAR);
 
     check_reflection(msr_ptr);
-    if (test_bit(msr_ptr->smart, SM_IMM_FREE)) {
-        reset_bit(msr_ptr->f5, RF5_HOLD);
-        reset_bit(msr_ptr->f5, RF5_SLOW);
+    if (any_bits(msr_ptr->smart, SM_IMM_FREE)) {
+        reset_bits(msr_ptr->f5, RF5_HOLD);
+        reset_bits(msr_ptr->f5, RF5_SLOW);
     }
 
-    if (test_bit(msr_ptr->smart, SM_IMM_MANA))
-        reset_bit(msr_ptr->f5, RF5_DRAIN_MANA);
+    if (any_bits(msr_ptr->smart, SM_IMM_MANA))
+        reset_bits(msr_ptr->f5, RF5_DRAIN_MANA);
 }

--- a/src/player-attack/player-attack.c
+++ b/src/player-attack/player-attack.c
@@ -235,7 +235,7 @@ static void process_weapon_attack(player_type *attacker_ptr, player_attack_type 
     calc_surprise_attack_damage(attacker_ptr, pa_ptr);
 
     BIT_FLAGS attack_hand = 0x01U << ((pa_ptr->hand == 0) ? FLAG_CAUSE_INVEN_MAIN_HAND : FLAG_CAUSE_INVEN_SUB_HAND);
-    if ((test_bit(attacker_ptr->impact, attack_hand) && ((pa_ptr->attack_damage > 50) || one_in_(7))) || (pa_ptr->chaos_effect == CE_QUAKE)
+    if ((any_bits(attacker_ptr->impact, attack_hand) && ((pa_ptr->attack_damage > 50) || one_in_(7))) || (pa_ptr->chaos_effect == CE_QUAKE)
         || (pa_ptr->mode == HISSATSU_QUAKE))
         *do_quake = TRUE;
 

--- a/src/player/permanent-resistances.c
+++ b/src/player/permanent-resistances.c
@@ -573,7 +573,7 @@ void riding_flags(player_type *creature_ptr, BIT_FLAGS *flags, BIT_FLAGS *negati
     if (!creature_ptr->riding)
         return;
 
-    if (test_bit(has_levitation(creature_ptr), 0x01U << FLAG_CAUSE_RIDING)) {
+    if (any_bits(has_levitation(creature_ptr), 0x01U << FLAG_CAUSE_RIDING)) {
         add_flag(flags, TR_LEVITATION);
     } else {
         add_flag(negative_flags, TR_LEVITATION);

--- a/src/player/player-status.c
+++ b/src/player/player-status.c
@@ -252,17 +252,17 @@ static void delayed_visual_update(player_type *player_ptr)
         POSITION x = floor_ptr->redraw_x[i];
         grid_type *g_ptr;
         g_ptr = &floor_ptr->grid_array[y][x];
-        if (!test_bit(g_ptr->info, CAVE_REDRAW))
+        if (none_bits(g_ptr->info, CAVE_REDRAW))
             continue;
 
-        if (test_bit(g_ptr->info, CAVE_NOTE))
+        if (any_bits(g_ptr->info, CAVE_NOTE))
             note_spot(player_ptr, y, x);
 
         lite_spot(player_ptr, y, x);
         if (g_ptr->m_idx)
             update_monster(player_ptr, g_ptr->m_idx, FALSE);
 
-        reset_bit(g_ptr->info, (CAVE_NOTE | CAVE_REDRAW));
+        reset_bits(g_ptr->info, (CAVE_NOTE | CAVE_REDRAW));
     }
 
     floor_ptr->redraw_n = 0;
@@ -387,8 +387,8 @@ static void update_bonuses(player_type *creature_ptr)
 
     creature_ptr->lite = has_lite(creature_ptr);
 
-    if (test_bit(creature_ptr->special_defense, KAMAE_MASK)) {
-        if (!test_bit(empty_hands_status, EMPTY_HAND_MAIN)) {
+    if (any_bits(creature_ptr->special_defense, KAMAE_MASK)) {
+        if (none_bits(empty_hands_status, EMPTY_HAND_MAIN)) {
             set_action(creature_ptr, ACTION_NONE);
         }
     }
@@ -459,27 +459,27 @@ static void update_bonuses(player_type *creature_ptr)
     }
 
     if (creature_ptr->telepathy != old_telepathy) {
-        set_bit(creature_ptr->update, PU_MONSTERS);
+        set_bits(creature_ptr->update, PU_MONSTERS);
     }
 
     if ((creature_ptr->esp_animal != old_esp_animal) || (creature_ptr->esp_undead != old_esp_undead) || (creature_ptr->esp_demon != old_esp_demon)
         || (creature_ptr->esp_orc != old_esp_orc) || (creature_ptr->esp_troll != old_esp_troll) || (creature_ptr->esp_giant != old_esp_giant)
         || (creature_ptr->esp_dragon != old_esp_dragon) || (creature_ptr->esp_human != old_esp_human) || (creature_ptr->esp_evil != old_esp_evil)
         || (creature_ptr->esp_good != old_esp_good) || (creature_ptr->esp_nonliving != old_esp_nonliving) || (creature_ptr->esp_unique != old_esp_unique)) {
-        set_bit(creature_ptr->update, PU_MONSTERS);
+        set_bits(creature_ptr->update, PU_MONSTERS);
     }
 
     if (creature_ptr->see_inv != old_see_inv) {
-        set_bit(creature_ptr->update, PU_MONSTERS);
+        set_bits(creature_ptr->update, PU_MONSTERS);
     }
 
     if (creature_ptr->pspeed != old_speed) {
-        set_bit(creature_ptr->redraw, PR_SPEED);
+        set_bits(creature_ptr->redraw, PR_SPEED);
     }
 
     if ((creature_ptr->dis_ac != old_dis_ac) || (creature_ptr->dis_to_a != old_dis_to_a)) {
-        set_bit(creature_ptr->redraw, PR_ARMOR);
-        set_bit(creature_ptr->window_flags, PW_PLAYER);
+        set_bits(creature_ptr->redraw, PR_ARMOR);
+        set_bits(creature_ptr->window_flags, PW_PLAYER);
     }
 
     if (current_world_ptr->character_xtra)
@@ -504,9 +504,9 @@ static void update_alignment(player_type *creature_ptr)
         if (!is_pet(m_ptr))
             continue;
 
-        if (test_bit(r_ptr->flags3, RF3_GOOD))
+        if (any_bits(r_ptr->flags3, RF3_GOOD))
             creature_ptr->align += r_ptr->level;
-        if (test_bit(r_ptr->flags3, RF3_EVIL))
+        if (any_bits(r_ptr->flags3, RF3_EVIL))
             creature_ptr->align -= r_ptr->level;
     }
 
@@ -688,7 +688,7 @@ static void update_num_of_spells(player_type *creature_ptr)
 
     int num_boukyaku = 0;
     for (int j = 0; j < 64; j++) {
-        if ((j < 32) ? test_bit(creature_ptr->spell_forgotten1, (1UL << j)) : test_bit(creature_ptr->spell_forgotten2, (1UL << (j - 32)))) {
+        if ((j < 32) ? any_bits(creature_ptr->spell_forgotten1, (1UL << j)) : any_bits(creature_ptr->spell_forgotten2, (1UL << (j - 32)))) {
             num_boukyaku++;
         }
     }
@@ -716,24 +716,24 @@ static void update_num_of_spells(player_type *creature_ptr)
         if (s_ptr->slevel <= creature_ptr->lev)
             continue;
 
-        bool is_spell_learned = (j < 32) ? test_bit(creature_ptr->spell_learned1, (1UL << j)) : test_bit(creature_ptr->spell_learned2, (1UL << (j - 32)));
+        bool is_spell_learned = (j < 32) ? any_bits(creature_ptr->spell_learned1, (1UL << j)) : any_bits(creature_ptr->spell_learned2, (1UL << (j - 32)));
         if (!is_spell_learned)
             continue;
 
         REALM_IDX which;
         if (j < 32) {
-            set_bit(creature_ptr->spell_forgotten1, (1UL << j));
+            set_bits(creature_ptr->spell_forgotten1, (1UL << j));
             which = creature_ptr->realm1;
         } else {
-            set_bit(creature_ptr->spell_forgotten2, (1UL << (j - 32)));
+            set_bits(creature_ptr->spell_forgotten2, (1UL << (j - 32)));
             which = creature_ptr->realm2;
         }
 
         if (j < 32) {
-            reset_bit(creature_ptr->spell_learned1, (1UL << j));
+            reset_bits(creature_ptr->spell_learned1, (1UL << j));
             which = creature_ptr->realm1;
         } else {
-            reset_bit(creature_ptr->spell_learned2, (1UL << (j - 32)));
+            reset_bits(creature_ptr->spell_learned2, (1UL << (j - 32)));
             which = creature_ptr->realm2;
         }
 
@@ -756,24 +756,24 @@ static void update_num_of_spells(player_type *creature_ptr)
         if (j >= 99)
             continue;
 
-        bool is_spell_learned = (j < 32) ? test_bit(creature_ptr->spell_learned1, (1UL << j)) : test_bit(creature_ptr->spell_learned2, (1UL << (j - 32)));
+        bool is_spell_learned = (j < 32) ? any_bits(creature_ptr->spell_learned1, (1UL << j)) : any_bits(creature_ptr->spell_learned2, (1UL << (j - 32)));
         if (!is_spell_learned)
             continue;
 
         REALM_IDX which;
         if (j < 32) {
-            set_bit(creature_ptr->spell_forgotten1, (1UL << j));
+            set_bits(creature_ptr->spell_forgotten1, (1UL << j));
             which = creature_ptr->realm1;
         } else {
-            set_bit(creature_ptr->spell_forgotten2, (1UL << (j - 32)));
+            set_bits(creature_ptr->spell_forgotten2, (1UL << (j - 32)));
             which = creature_ptr->realm2;
         }
 
         if (j < 32) {
-            reset_bit(creature_ptr->spell_learned1, (1UL << j));
+            reset_bits(creature_ptr->spell_learned1, (1UL << j));
             which = creature_ptr->realm1;
         } else {
-            reset_bit(creature_ptr->spell_learned2, (1UL << (j - 32)));
+            reset_bits(creature_ptr->spell_learned2, (1UL << (j - 32)));
             which = creature_ptr->realm2;
         }
 
@@ -809,24 +809,24 @@ static void update_num_of_spells(player_type *creature_ptr)
         if (s_ptr->slevel > creature_ptr->lev)
             continue;
 
-        bool is_spell_learned = (j < 32) ? test_bit(creature_ptr->spell_forgotten1, (1UL << j)) : test_bit(creature_ptr->spell_forgotten2, (1UL << (j - 32)));
+        bool is_spell_learned = (j < 32) ? any_bits(creature_ptr->spell_forgotten1, (1UL << j)) : any_bits(creature_ptr->spell_forgotten2, (1UL << (j - 32)));
         if (!is_spell_learned)
             continue;
 
         REALM_IDX which;
         if (j < 32) {
-            reset_bit(creature_ptr->spell_forgotten1, (1UL << j));
+            reset_bits(creature_ptr->spell_forgotten1, (1UL << j));
             which = creature_ptr->realm1;
         } else {
-            reset_bit(creature_ptr->spell_forgotten2, (1UL << (j - 32)));
+            reset_bits(creature_ptr->spell_forgotten2, (1UL << (j - 32)));
             which = creature_ptr->realm2;
         }
 
         if (j < 32) {
-            set_bit(creature_ptr->spell_learned1, (1UL << j));
+            set_bits(creature_ptr->spell_learned1, (1UL << j));
             which = creature_ptr->realm1;
         } else {
-            set_bit(creature_ptr->spell_learned2, (1UL << (j - 32)));
+            set_bits(creature_ptr->spell_learned2, (1UL << (j - 32)));
             which = creature_ptr->realm2;
         }
 
@@ -850,7 +850,7 @@ static void update_num_of_spells(player_type *creature_ptr)
             if (s_ptr->slevel > creature_ptr->lev)
                 continue;
 
-            if (test_bit(creature_ptr->spell_learned1, (1UL << j))) {
+            if (any_bits(creature_ptr->spell_learned1, (1UL << j))) {
                 continue;
             }
 
@@ -883,8 +883,8 @@ static void update_num_of_spells(player_type *creature_ptr)
     }
 
     creature_ptr->old_spells = creature_ptr->new_spells;
-    set_bit(creature_ptr->redraw, PR_STUDY);
-    set_bit(creature_ptr->window_flags, PW_OBJECT);
+    set_bits(creature_ptr->redraw, PR_STUDY);
+    set_bits(creature_ptr->window_flags, PW_OBJECT);
 }
 
 /*!
@@ -906,7 +906,7 @@ static void update_max_mana(player_type *creature_ptr)
     } else {
         if (mp_ptr->spell_first > creature_ptr->lev) {
             creature_ptr->msp = 0;
-            set_bit(creature_ptr->redraw, PR_MANA);
+            set_bits(creature_ptr->redraw, PR_MANA);
             return;
         }
 
@@ -932,7 +932,7 @@ static void update_max_mana(player_type *creature_ptr)
             msp += msp * (25 + creature_ptr->lev) / 100;
     }
 
-    if (test_bit(mp_ptr->spell_xtra, MAGIC_GLOVE_REDUCE_MANA)) {
+    if (any_bits(mp_ptr->spell_xtra, MAGIC_GLOVE_REDUCE_MANA)) {
         BIT_FLAGS flgs[TR_FLAG_SIZE];
         creature_ptr->cumber_glove = FALSE;
         object_type *o_ptr;
@@ -1075,8 +1075,8 @@ static void update_max_mana(player_type *creature_ptr)
         }
 #endif
         creature_ptr->msp = msp;
-        set_bit(creature_ptr->redraw, PR_MANA);
-        set_bit(creature_ptr->window_flags, (PW_PLAYER | PW_SPELL));
+        set_bits(creature_ptr->redraw, PR_MANA);
+        set_bits(creature_ptr->window_flags, (PW_PLAYER | PW_SPELL));
     }
 
     if (current_world_ptr->character_xtra)
@@ -1187,7 +1187,7 @@ static ACTION_SKILL_POWER calc_intra_vision(player_type *creature_ptr)
 
     pow = tmp_rp_ptr->infra;
 
-    if (test_bit(creature_ptr->muta3, MUT3_INFRAVIS)) {
+    if (any_bits(creature_ptr->muta3, MUT3_INFRAVIS)) {
         pow += 3;
     }
 
@@ -1254,10 +1254,10 @@ static ACTION_SKILL_POWER calc_stealth(player_type *creature_ptr)
             pow += o_ptr->pval;
     }
 
-    if (test_bit(creature_ptr->muta3, MUT3_XTRA_NOIS)) {
+    if (any_bits(creature_ptr->muta3, MUT3_XTRA_NOIS)) {
         pow -= 3;
     }
-    if (test_bit(creature_ptr->muta3, MUT3_MOTION)) {
+    if (any_bits(creature_ptr->muta3, MUT3_MOTION)) {
         pow += 1;
     }
     if (creature_ptr->realm1 == REALM_HEX) {
@@ -1396,7 +1396,7 @@ static ACTION_SKILL_POWER calc_saving_throw(player_type *creature_ptr)
     pow = tmp_rp_ptr->r_sav + c_ptr->c_sav + a_ptr->a_sav;
     pow += ((cp_ptr->x_sav * creature_ptr->lev / 10) + (ap_ptr->a_sav * creature_ptr->lev / 50));
 
-    if (test_bit(creature_ptr->muta3, MUT3_MAGIC_RES))
+    if (any_bits(creature_ptr->muta3, MUT3_MAGIC_RES))
         pow += (15 + (creature_ptr->lev / 5));
 
     pow += adj_wis_sav[creature_ptr->stat_ind[A_WIS]];
@@ -1456,7 +1456,7 @@ static ACTION_SKILL_POWER calc_search(player_type *creature_ptr)
             pow += (o_ptr->pval * 5);
     }
 
-    if (test_bit(creature_ptr->muta3, MUT3_XTRA_EYES)) {
+    if (any_bits(creature_ptr->muta3, MUT3_XTRA_EYES)) {
         pow += 15;
     }
 
@@ -1508,7 +1508,7 @@ static ACTION_SKILL_POWER calc_search_freq(player_type *creature_ptr)
         pow -= 15;
     }
 
-    if (test_bit(creature_ptr->muta3, MUT3_XTRA_EYES)) {
+    if (any_bits(creature_ptr->muta3, MUT3_XTRA_EYES)) {
         pow += 15;
     }
 
@@ -1656,7 +1656,7 @@ static ACTION_SKILL_POWER calc_skill_dig(player_type *creature_ptr)
 static bool is_martial_arts_mode(player_type *creature_ptr)
 {
     return ((creature_ptr->pclass == CLASS_MONK) || (creature_ptr->pclass == CLASS_FORCETRAINER) || (creature_ptr->pclass == CLASS_BERSERKER))
-        && (test_bit(empty_hands(creature_ptr, TRUE), EMPTY_HAND_MAIN)) && !can_attack_with_sub_hand(creature_ptr);
+        && (any_bits(empty_hands(creature_ptr, TRUE), EMPTY_HAND_MAIN)) && !can_attack_with_sub_hand(creature_ptr);
 }
 
 static bool is_heavy_wield(player_type *creature_ptr, int i)
@@ -1721,7 +1721,7 @@ static s16b calc_num_blow(player_type *creature_ptr, int i)
             else if ((creature_ptr->pclass == CLASS_ROGUE) && (o_ptr->weight < 50) && (creature_ptr->stat_ind[A_DEX] >= 30))
                 num_blow++;
 
-            if (test_bit(creature_ptr->special_defense, KATA_FUUJIN))
+            if (any_bits(creature_ptr->special_defense, KATA_FUUJIN))
                 num_blow -= 1;
 
             if ((o_ptr->tval == TV_SWORD) && (o_ptr->sval == SV_POISON_NEEDLE))
@@ -1768,13 +1768,13 @@ static s16b calc_num_blow(player_type *creature_ptr, int i)
         if (heavy_armor(creature_ptr) && (creature_ptr->pclass != CLASS_BERSERKER))
             num_blow /= 2;
 
-        if (test_bit(creature_ptr->special_defense, KAMAE_GENBU)) {
+        if (any_bits(creature_ptr->special_defense, KAMAE_GENBU)) {
             num_blow -= 2;
             if ((creature_ptr->pclass == CLASS_MONK) && (creature_ptr->lev > 42))
                 num_blow--;
             if (num_blow < 0)
                 num_blow = 0;
-        } else if (test_bit(creature_ptr->special_defense, KAMAE_SUZAKU)) {
+        } else if (any_bits(creature_ptr->special_defense, KAMAE_SUZAKU)) {
             num_blow /= 2;
         }
 
@@ -1849,22 +1849,22 @@ static s16b calc_strength_addition(player_type *creature_ptr)
         }
     }
 
-    if (test_bit(creature_ptr->special_defense, KATA_KOUKIJIN)) {
+    if (any_bits(creature_ptr->special_defense, KATA_KOUKIJIN)) {
         pow += 5;
     }
 
-    if (test_bit(creature_ptr->special_defense, KAMAE_BYAKKO)) {
+    if (any_bits(creature_ptr->special_defense, KAMAE_BYAKKO)) {
         pow += 2;
-    } else if (test_bit(creature_ptr->special_defense, KAMAE_SUZAKU)) {
+    } else if (any_bits(creature_ptr->special_defense, KAMAE_SUZAKU)) {
         pow -= 2;
     }
 
     if (creature_ptr->muta3) {
-        if (test_bit(creature_ptr->muta3, MUT3_HYPER_STR)) {
+        if (any_bits(creature_ptr->muta3, MUT3_HYPER_STR)) {
             pow += 4;
         }
 
-        if (test_bit(creature_ptr->muta3, MUT3_PUNY)) {
+        if (any_bits(creature_ptr->muta3, MUT3_PUNY)) {
             pow -= 4;
         }
     }
@@ -1914,22 +1914,22 @@ s16b calc_intelligence_addition(player_type *creature_ptr)
         }
     }
 
-    if (test_bit(creature_ptr->special_defense, KATA_KOUKIJIN)) {
+    if (any_bits(creature_ptr->special_defense, KATA_KOUKIJIN)) {
         pow += 5;
     }
 
-    if (test_bit(creature_ptr->special_defense, KAMAE_GENBU)) {
+    if (any_bits(creature_ptr->special_defense, KAMAE_GENBU)) {
         pow -= 1;
-    } else if (test_bit(creature_ptr->special_defense, KAMAE_SUZAKU)) {
+    } else if (any_bits(creature_ptr->special_defense, KAMAE_SUZAKU)) {
         pow += 1;
     }
 
     if (creature_ptr->muta3) {
-        if (test_bit(creature_ptr->muta3, MUT3_HYPER_INT)) {
+        if (any_bits(creature_ptr->muta3, MUT3_HYPER_INT)) {
             pow += 4;
         }
 
-        if (test_bit(creature_ptr->muta3, MUT3_MORONIC)) {
+        if (any_bits(creature_ptr->muta3, MUT3_MORONIC)) {
             pow -= 4;
         }
     }
@@ -1976,22 +1976,22 @@ static s16b calc_wisdom_addition(player_type *creature_ptr)
         }
     }
 
-    if (test_bit(creature_ptr->special_defense, KATA_KOUKIJIN)) {
+    if (any_bits(creature_ptr->special_defense, KATA_KOUKIJIN)) {
         pow += 5;
     }
 
-    if (test_bit(creature_ptr->special_defense, KAMAE_GENBU)) {
+    if (any_bits(creature_ptr->special_defense, KAMAE_GENBU)) {
         pow -= 1;
-    } else if (test_bit(creature_ptr->special_defense, KAMAE_SUZAKU)) {
+    } else if (any_bits(creature_ptr->special_defense, KAMAE_SUZAKU)) {
         pow += 1;
     }
 
     if (creature_ptr->muta3) {
-        if (test_bit(creature_ptr->muta3, MUT3_HYPER_INT)) {
+        if (any_bits(creature_ptr->muta3, MUT3_HYPER_INT)) {
             pow += 4;
         }
 
-        if (test_bit(creature_ptr->muta3, MUT3_MORONIC)) {
+        if (any_bits(creature_ptr->muta3, MUT3_MORONIC)) {
             pow -= 4;
         }
     }
@@ -2055,27 +2055,27 @@ static s16b calc_dexterity_addition(player_type *creature_ptr)
         }
     }
 
-    if (test_bit(creature_ptr->special_defense, KATA_KOUKIJIN)) {
+    if (any_bits(creature_ptr->special_defense, KATA_KOUKIJIN)) {
         pow += 5;
     }
 
-    if (test_bit(creature_ptr->special_defense, KAMAE_BYAKKO)) {
+    if (any_bits(creature_ptr->special_defense, KAMAE_BYAKKO)) {
         pow += 2;
-    } else if (test_bit(creature_ptr->special_defense, KAMAE_GENBU)) {
+    } else if (any_bits(creature_ptr->special_defense, KAMAE_GENBU)) {
         pow -= 2;
-    } else if (test_bit(creature_ptr->special_defense, KAMAE_SUZAKU)) {
+    } else if (any_bits(creature_ptr->special_defense, KAMAE_SUZAKU)) {
         pow += 2;
     }
 
-    if (test_bit(creature_ptr->muta3, MUT3_IRON_SKIN)) {
+    if (any_bits(creature_ptr->muta3, MUT3_IRON_SKIN)) {
         pow -= 1;
     }
 
-    if (test_bit(creature_ptr->muta3, MUT3_LIMBER)) {
+    if (any_bits(creature_ptr->muta3, MUT3_LIMBER)) {
         pow += 3;
     }
 
-    if (test_bit(creature_ptr->muta3, MUT3_ARTHRITIS)) {
+    if (any_bits(creature_ptr->muta3, MUT3_ARTHRITIS)) {
         pow -= 3;
     }
 
@@ -2139,32 +2139,32 @@ static s16b calc_constitution_addition(player_type *creature_ptr)
         }
     }
 
-    if (test_bit(creature_ptr->special_defense, KATA_KOUKIJIN)) {
+    if (any_bits(creature_ptr->special_defense, KATA_KOUKIJIN)) {
         pow += 5;
     }
 
-    if (test_bit(creature_ptr->special_defense, KAMAE_BYAKKO)) {
+    if (any_bits(creature_ptr->special_defense, KAMAE_BYAKKO)) {
         pow -= 3;
-    } else if (test_bit(creature_ptr->special_defense, KAMAE_GENBU)) {
+    } else if (any_bits(creature_ptr->special_defense, KAMAE_GENBU)) {
         pow += 3;
-    } else if (test_bit(creature_ptr->special_defense, KAMAE_SUZAKU)) {
+    } else if (any_bits(creature_ptr->special_defense, KAMAE_SUZAKU)) {
         pow -= 2;
     }
 
     if (creature_ptr->muta3) {
-        if (test_bit(creature_ptr->muta3, MUT3_RESILIENT)) {
+        if (any_bits(creature_ptr->muta3, MUT3_RESILIENT)) {
             pow += 4;
         }
 
-        if (test_bit(creature_ptr->muta3, MUT3_ALBINO)) {
+        if (any_bits(creature_ptr->muta3, MUT3_ALBINO)) {
             pow -= 4;
         }
 
-        if (test_bit(creature_ptr->muta3, MUT3_XTRA_FAT)) {
+        if (any_bits(creature_ptr->muta3, MUT3_XTRA_FAT)) {
             pow += 2;
         }
 
-        if (test_bit(creature_ptr->muta3, MUT3_FLESH_ROT)) {
+        if (any_bits(creature_ptr->muta3, MUT3_FLESH_ROT)) {
             pow -= 2;
         }
     }
@@ -2215,27 +2215,27 @@ static s16b calc_charisma_addition(player_type *creature_ptr)
             pow += o_ptr->pval;
     }
 
-    if (test_bit(creature_ptr->special_defense, KATA_KOUKIJIN)) {
+    if (any_bits(creature_ptr->special_defense, KATA_KOUKIJIN)) {
         pow += 5;
     }
 
     if (creature_ptr->muta3) {
-        if (test_bit(creature_ptr->muta3, MUT3_FLESH_ROT)) {
+        if (any_bits(creature_ptr->muta3, MUT3_FLESH_ROT)) {
             pow -= 1;
         }
-        if (test_bit(creature_ptr->muta3, MUT3_SILLY_VOI)) {
+        if (any_bits(creature_ptr->muta3, MUT3_SILLY_VOI)) {
             pow -= 4;
         }
-        if (test_bit(creature_ptr->muta3, MUT3_BLANK_FAC)) {
+        if (any_bits(creature_ptr->muta3, MUT3_BLANK_FAC)) {
             pow -= 1;
         }
-        if (test_bit(creature_ptr->muta3, MUT3_WART_SKIN)) {
+        if (any_bits(creature_ptr->muta3, MUT3_WART_SKIN)) {
             pow -= 2;
         }
-        if (test_bit(creature_ptr->muta3, MUT3_SCALES)) {
+        if (any_bits(creature_ptr->muta3, MUT3_SCALES)) {
             pow -= 1;
         }
-        if (test_bit(creature_ptr->muta3, MUT3_ILL_NORM)) {
+        if (any_bits(creature_ptr->muta3, MUT3_ILL_NORM)) {
             pow = 0;
         }
     }
@@ -2274,8 +2274,8 @@ static s16b calc_to_magic_chance(player_type *creature_ptr)
         if (!o_ptr->k_idx)
             continue;
         object_flags(creature_ptr, o_ptr, flgs);
-        if (test_bit(o_ptr->curse_flags, TRC_LOW_MAGIC)) {
-            if (test_bit(o_ptr->curse_flags, TRC_HEAVY_CURSE)) {
+        if (any_bits(o_ptr->curse_flags, TRC_LOW_MAGIC)) {
+            if (any_bits(o_ptr->curse_flags, TRC_HEAVY_CURSE)) {
                 chance += 10;
             } else {
                 chance += 3;
@@ -2343,8 +2343,8 @@ static ARMOUR_CLASS calc_to_ac(player_type *creature_ptr, bool is_real_value)
         if (is_real_value || object_is_known(o_ptr))
             ac += o_ptr->to_a;
 
-        if (test_bit(o_ptr->curse_flags, TRC_LOW_AC)) {
-            if (test_bit(o_ptr->curse_flags, TRC_HEAVY_CURSE)) {
+        if (any_bits(o_ptr->curse_flags, TRC_LOW_AC)) {
+            if (any_bits(o_ptr->curse_flags, TRC_HEAVY_CURSE)) {
                 if (is_real_value || object_is_fully_known(o_ptr))
                     ac -= 30;
             } else {
@@ -2376,15 +2376,15 @@ static ARMOUR_CLASS calc_to_ac(player_type *creature_ptr, bool is_real_value)
         ac += 5;
     }
 
-    if (test_bit(creature_ptr->muta3, MUT3_WART_SKIN)) {
+    if (any_bits(creature_ptr->muta3, MUT3_WART_SKIN)) {
         ac += 5;
     }
 
-    if (test_bit(creature_ptr->muta3, MUT3_SCALES)) {
+    if (any_bits(creature_ptr->muta3, MUT3_SCALES)) {
         ac += 10;
     }
 
-    if (test_bit(creature_ptr->muta3, MUT3_IRON_SKIN)) {
+    if (any_bits(creature_ptr->muta3, MUT3_IRON_SKIN)) {
         ac += 25;
     }
 
@@ -2422,26 +2422,26 @@ static ARMOUR_CLASS calc_to_ac(player_type *creature_ptr, bool is_real_value)
                 continue;
             if (!object_is_cursed(o_ptr))
                 continue;
-            if (test_bit(o_ptr->curse_flags, TRC_CURSED))
+            if (any_bits(o_ptr->curse_flags, TRC_CURSED))
                 ac += 5;
-            if (test_bit(o_ptr->curse_flags, TRC_HEAVY_CURSE))
+            if (any_bits(o_ptr->curse_flags, TRC_HEAVY_CURSE))
                 ac += 7;
-            if (test_bit(o_ptr->curse_flags, TRC_PERMA_CURSE))
+            if (any_bits(o_ptr->curse_flags, TRC_PERMA_CURSE))
                 ac += 13;
         }
     }
 
-    if (test_bit(creature_ptr->special_defense, KAMAE_GENBU)) {
+    if (any_bits(creature_ptr->special_defense, KAMAE_GENBU)) {
         ac += (creature_ptr->lev * creature_ptr->lev) / 50;
-    } else if (test_bit(creature_ptr->special_defense, KAMAE_BYAKKO)) {
+    } else if (any_bits(creature_ptr->special_defense, KAMAE_BYAKKO)) {
         ac -= 40;
-    } else if (test_bit(creature_ptr->special_defense, KAMAE_SEIRYU)) {
+    } else if (any_bits(creature_ptr->special_defense, KAMAE_SEIRYU)) {
         ac -= 50;
-    } else if (test_bit(creature_ptr->special_defense, KATA_KOUKIJIN)) {
+    } else if (any_bits(creature_ptr->special_defense, KATA_KOUKIJIN)) {
         ac -= 50;
     }
 
-    if (creature_ptr->ult_res || (test_bit(creature_ptr->special_defense, KATA_MUSOU))) {
+    if (creature_ptr->ult_res || (any_bits(creature_ptr->special_defense, KATA_MUSOU))) {
         ac += 100;
     } else if (creature_ptr->tsubureru || creature_ptr->shield || creature_ptr->magicdef) {
         ac += 50;
@@ -2587,19 +2587,19 @@ static s16b calc_speed(player_type *creature_ptr)
         if (creature_ptr->food >= PY_FOOD_MAX)
             pow -= 10;
 
-        if (test_bit(creature_ptr->special_defense, KAMAE_SUZAKU))
+        if (any_bits(creature_ptr->special_defense, KAMAE_SUZAKU))
             pow += 10;
 
         if (creature_ptr->muta3) {
-            if (test_bit(creature_ptr->muta3, MUT3_XTRA_FAT)) {
+            if (any_bits(creature_ptr->muta3, MUT3_XTRA_FAT)) {
                 pow -= 2;
             }
 
-            if (test_bit(creature_ptr->muta3, MUT3_XTRA_LEGS)) {
+            if (any_bits(creature_ptr->muta3, MUT3_XTRA_LEGS)) {
                 pow += 3;
             }
 
-            if (test_bit(creature_ptr->muta3, MUT3_SHORT_LEG)) {
+            if (any_bits(creature_ptr->muta3, MUT3_SHORT_LEG)) {
                 pow -= 3;
             }
         }
@@ -2733,29 +2733,29 @@ static void update_ind_status(player_type *creature_ptr, int status)
 
     creature_ptr->stat_ind[status] = (s16b)ind;
     if (status == A_CON) {
-        set_bit(creature_ptr->update, PU_HP);
+        set_bits(creature_ptr->update, PU_HP);
     } else if (status == A_INT) {
         if (mp_ptr->spell_stat == A_INT) {
-            set_bit(creature_ptr->update, (PU_MANA | PU_SPELLS));
+            set_bits(creature_ptr->update, (PU_MANA | PU_SPELLS));
         }
     } else if (status == A_WIS) {
         if (mp_ptr->spell_stat == A_WIS) {
-            set_bit(creature_ptr->update, (PU_MANA | PU_SPELLS));
+            set_bits(creature_ptr->update, (PU_MANA | PU_SPELLS));
         }
     } else if (status == A_CHR) {
         if (mp_ptr->spell_stat == A_CHR) {
-            set_bit(creature_ptr->update, (PU_MANA | PU_SPELLS));
+            set_bits(creature_ptr->update, (PU_MANA | PU_SPELLS));
         }
     }
 
-    set_bit(creature_ptr->window_flags, PW_PLAYER);
+    set_bits(creature_ptr->window_flags, PW_PLAYER);
 }
 
 static void update_use_status(player_type *creature_ptr, int status)
 {
     int use = modify_stat_value(creature_ptr->stat_cur[status], creature_ptr->stat_add[status]);
 
-    if ((status == A_CHR) && (test_bit(creature_ptr->muta3, MUT3_ILL_NORM))) {
+    if ((status == A_CHR) && (any_bits(creature_ptr->muta3, MUT3_ILL_NORM))) {
         /* 10 to 18/90 charisma, guaranteed, based on level */
         if (use < 8 + 2 * creature_ptr->lev) {
             use = 8 + 2 * creature_ptr->lev;
@@ -2764,8 +2764,8 @@ static void update_use_status(player_type *creature_ptr, int status)
 
     if (creature_ptr->stat_use[status] != use) {
         creature_ptr->stat_use[status] = (s16b)use;
-        set_bit(creature_ptr->redraw, PR_STATS);
-        set_bit(creature_ptr->window_flags, PW_PLAYER);
+        set_bits(creature_ptr->redraw, PR_STATS);
+        set_bits(creature_ptr->window_flags, PW_PLAYER);
     }
 }
 
@@ -2775,8 +2775,8 @@ static void update_top_status(player_type *creature_ptr, int status)
 
     if (creature_ptr->stat_top[status] != top) {
         creature_ptr->stat_top[status] = (s16b)top;
-        set_bit(creature_ptr->redraw, PR_STATS);
-        set_bit(creature_ptr->window_flags, PW_PLAYER);
+        set_bits(creature_ptr->redraw, PR_STATS);
+        set_bits(creature_ptr->window_flags, PW_PLAYER);
     }
 }
 
@@ -2788,7 +2788,7 @@ static bool is_riding_two_hands(player_type *creature_ptr)
 
     if (has_two_handed_weapons(creature_ptr) || (empty_hands(creature_ptr, FALSE) == EMPTY_HAND_NONE))
         return TRUE;
-    else if (test_bit(creature_ptr->pet_extra_flags, PF_TWO_HANDS)) {
+    else if (any_bits(creature_ptr->pet_extra_flags, PF_TWO_HANDS)) {
         switch (creature_ptr->pclass) {
         case CLASS_MONK:
         case CLASS_FORCETRAINER:
@@ -2964,13 +2964,13 @@ static s16b calc_to_damage(player_type *creature_ptr, INVENTORY_IDX slot, bool i
 
     if ((creature_ptr->realm1 == REALM_HEX) && object_is_cursed(o_ptr)) {
         if (hex_spelling(creature_ptr, HEX_RUNESWORD)) {
-            if (test_bit(o_ptr->curse_flags, (TRC_CURSED))) {
+            if (any_bits(o_ptr->curse_flags, (TRC_CURSED))) {
                 damage += 5;
             }
-            if (test_bit(o_ptr->curse_flags, (TRC_HEAVY_CURSE))) {
+            if (any_bits(o_ptr->curse_flags, (TRC_HEAVY_CURSE))) {
                 damage += 7;
             }
-            if (test_bit(o_ptr->curse_flags, (TRC_PERMA_CURSE))) {
+            if (any_bits(o_ptr->curse_flags, (TRC_PERMA_CURSE))) {
                 damage += 13;
             }
         }
@@ -3050,7 +3050,7 @@ static s16b calc_to_damage(player_type *creature_ptr, INVENTORY_IDX slot, bool i
     }
 
     // 朱雀の構えをとっているとき、格闘ダメージに -(レベル)/6 の修正を得る。
-    if (test_bit(creature_ptr->special_defense, KAMAE_SUZAKU)) {
+    if (any_bits(creature_ptr->special_defense, KAMAE_SUZAKU)) {
         if (is_martial_arts_mode(creature_ptr) && calc_hand == PLAYER_HAND_MAIN) {
             damage -= (creature_ptr->lev / 6);
         }
@@ -3138,8 +3138,8 @@ static s16b calc_to_hit(player_type *creature_ptr, INVENTORY_IDX slot, bool is_r
         }
 
         /* Low melee penalty */
-        if ((object_is_fully_known(o_ptr) || is_real_value) && test_bit(o_ptr->curse_flags, TRC_LOW_MELEE)) {
-            if (test_bit(o_ptr->curse_flags, TRC_HEAVY_CURSE)) {
+        if ((object_is_fully_known(o_ptr) || is_real_value) && any_bits(o_ptr->curse_flags, TRC_LOW_MELEE)) {
+            if (any_bits(o_ptr->curse_flags, TRC_HEAVY_CURSE)) {
                 hit -= 15;
             } else {
                 hit -= 5;
@@ -3189,16 +3189,16 @@ static s16b calc_to_hit(player_type *creature_ptr, INVENTORY_IDX slot, bool is_r
 
         /* Hex realm bonuses */
         if ((creature_ptr->realm1 == REALM_HEX) && object_is_cursed(o_ptr)) {
-            if (test_bit(o_ptr->curse_flags, (TRC_CURSED))) {
+            if (any_bits(o_ptr->curse_flags, (TRC_CURSED))) {
                 hit += 5;
             }
-            if (test_bit(o_ptr->curse_flags, (TRC_HEAVY_CURSE))) {
+            if (any_bits(o_ptr->curse_flags, (TRC_HEAVY_CURSE))) {
                 hit += 7;
             }
-            if (test_bit(o_ptr->curse_flags, (TRC_PERMA_CURSE))) {
+            if (any_bits(o_ptr->curse_flags, (TRC_PERMA_CURSE))) {
                 hit += 13;
             }
-            if (test_bit(o_ptr->curse_flags, (TRC_TY_CURSE))) {
+            if (any_bits(o_ptr->curse_flags, (TRC_TY_CURSE))) {
                 hit += 5;
             }
         }
@@ -3278,7 +3278,7 @@ static s16b calc_to_hit(player_type *creature_ptr, INVENTORY_IDX slot, bool is_r
     hit -= calc_double_weapon_penalty(creature_ptr, slot);
 
     // 朱雀の構えをとっているとき、格闘命中に -(レベル)/3 の修正を得る。
-    if (test_bit(creature_ptr->special_defense, KAMAE_SUZAKU)) {
+    if (any_bits(creature_ptr->special_defense, KAMAE_SUZAKU)) {
         if (is_martial_arts_mode(creature_ptr) && calc_hand == PLAYER_HAND_MAIN) {
             hit -= (creature_ptr->lev / 3);
         }
@@ -3301,8 +3301,8 @@ static s16b calc_to_hit_bow(player_type *creature_ptr, bool is_real_value)
         if (o_ptr->k_idx) {
             object_flags(creature_ptr, o_ptr, flgs);
 
-            if (test_bit(o_ptr->curse_flags, TRC_LOW_MELEE)) {
-                if (test_bit(o_ptr->curse_flags, TRC_HEAVY_CURSE)) {
+            if (any_bits(o_ptr->curse_flags, TRC_LOW_MELEE)) {
+                if (any_bits(o_ptr->curse_flags, TRC_HEAVY_CURSE)) {
                     pow -= 15;
                 } else {
                     pow -= 5;
@@ -3506,11 +3506,11 @@ BIT_FLAGS16 empty_hands(player_type *creature_ptr, bool riding_control)
     if (!creature_ptr->inventory_list[INVEN_SUB_HAND].k_idx)
         status |= EMPTY_HAND_SUB;
 
-    if (riding_control && (status != EMPTY_HAND_NONE) && creature_ptr->riding && !test_bit(creature_ptr->pet_extra_flags, PF_TWO_HANDS)) {
-        if (test_bit(status, EMPTY_HAND_SUB))
-            reset_bit(status, EMPTY_HAND_SUB);
-        else if (test_bit(status, EMPTY_HAND_MAIN))
-            reset_bit(status, EMPTY_HAND_MAIN);
+    if (riding_control && (status != EMPTY_HAND_NONE) && creature_ptr->riding && none_bits(creature_ptr->pet_extra_flags, PF_TWO_HANDS)) {
+        if (any_bits(status, EMPTY_HAND_SUB))
+            reset_bits(status, EMPTY_HAND_SUB);
+        else if (any_bits(status, EMPTY_HAND_MAIN))
+            reset_bits(status, EMPTY_HAND_MAIN);
     }
 
     return status;
@@ -3550,44 +3550,44 @@ void update_creature(player_type *creature_ptr)
         return;
 
     floor_type *floor_ptr = creature_ptr->current_floor_ptr;
-    if (test_bit(creature_ptr->update, (PU_AUTODESTROY))) {
-        reset_bit(creature_ptr->update, PU_AUTODESTROY);
+    if (any_bits(creature_ptr->update, (PU_AUTODESTROY))) {
+        reset_bits(creature_ptr->update, PU_AUTODESTROY);
         autopick_delayed_alter(creature_ptr);
     }
 
-    if (test_bit(creature_ptr->update, (PU_COMBINE))) {
-        reset_bit(creature_ptr->update, PU_COMBINE);
+    if (any_bits(creature_ptr->update, (PU_COMBINE))) {
+        reset_bits(creature_ptr->update, PU_COMBINE);
         combine_pack(creature_ptr);
     }
 
-    if (test_bit(creature_ptr->update, (PU_REORDER))) {
-        reset_bit(creature_ptr->update, PU_REORDER);
+    if (any_bits(creature_ptr->update, (PU_REORDER))) {
+        reset_bits(creature_ptr->update, PU_REORDER);
         reorder_pack(creature_ptr);
     }
 
-    if (test_bit(creature_ptr->update, (PU_BONUS))) {
-        reset_bit(creature_ptr->update, PU_BONUS);
+    if (any_bits(creature_ptr->update, (PU_BONUS))) {
+        reset_bits(creature_ptr->update, PU_BONUS);
         update_alignment(creature_ptr);
         update_bonuses(creature_ptr);
     }
 
-    if (test_bit(creature_ptr->update, (PU_TORCH))) {
-        reset_bit(creature_ptr->update, PU_TORCH);
+    if (any_bits(creature_ptr->update, (PU_TORCH))) {
+        reset_bits(creature_ptr->update, PU_TORCH);
         update_lite_radius(creature_ptr);
     }
 
-    if (test_bit(creature_ptr->update, (PU_HP))) {
-        reset_bit(creature_ptr->update, PU_HP);
+    if (any_bits(creature_ptr->update, (PU_HP))) {
+        reset_bits(creature_ptr->update, PU_HP);
         update_max_hitpoints(creature_ptr);
     }
 
-    if (test_bit(creature_ptr->update, (PU_MANA))) {
-        reset_bit(creature_ptr->update, PU_MANA);
+    if (any_bits(creature_ptr->update, (PU_MANA))) {
+        reset_bits(creature_ptr->update, PU_MANA);
         update_max_mana(creature_ptr);
     }
 
-    if (test_bit(creature_ptr->update, (PU_SPELLS))) {
-        reset_bit(creature_ptr->update, PU_SPELLS);
+    if (any_bits(creature_ptr->update, (PU_SPELLS))) {
+        reset_bits(creature_ptr->update, PU_SPELLS);
         update_num_of_spells(creature_ptr);
     }
 
@@ -3595,49 +3595,49 @@ void update_creature(player_type *creature_ptr)
         return;
     if (current_world_ptr->character_icky)
         return;
-    if (test_bit(creature_ptr->update, (PU_UN_LITE))) {
-        reset_bit(creature_ptr->update, PU_UN_LITE);
+    if (any_bits(creature_ptr->update, (PU_UN_LITE))) {
+        reset_bits(creature_ptr->update, PU_UN_LITE);
         forget_lite(floor_ptr);
     }
 
-    if (test_bit(creature_ptr->update, (PU_UN_VIEW))) {
-        reset_bit(creature_ptr->update, PU_UN_VIEW);
+    if (any_bits(creature_ptr->update, (PU_UN_VIEW))) {
+        reset_bits(creature_ptr->update, PU_UN_VIEW);
         forget_view(floor_ptr);
     }
 
-    if (test_bit(creature_ptr->update, (PU_VIEW))) {
-        reset_bit(creature_ptr->update, PU_VIEW);
+    if (any_bits(creature_ptr->update, (PU_VIEW))) {
+        reset_bits(creature_ptr->update, PU_VIEW);
         update_view(creature_ptr);
     }
 
-    if (test_bit(creature_ptr->update, (PU_LITE))) {
-        reset_bit(creature_ptr->update, PU_LITE);
+    if (any_bits(creature_ptr->update, (PU_LITE))) {
+        reset_bits(creature_ptr->update, PU_LITE);
         update_lite(creature_ptr);
     }
 
-    if (test_bit(creature_ptr->update, (PU_FLOW))) {
-        reset_bit(creature_ptr->update, PU_FLOW);
+    if (any_bits(creature_ptr->update, (PU_FLOW))) {
+        reset_bits(creature_ptr->update, PU_FLOW);
         update_flow(creature_ptr);
     }
 
-    if (test_bit(creature_ptr->update, (PU_DISTANCE))) {
-        reset_bit(creature_ptr->update, PU_DISTANCE);
+    if (any_bits(creature_ptr->update, (PU_DISTANCE))) {
+        reset_bits(creature_ptr->update, PU_DISTANCE);
 
         update_monsters(creature_ptr, TRUE);
     }
 
-    if (test_bit(creature_ptr->update, (PU_MON_LITE))) {
-        reset_bit(creature_ptr->update, PU_MON_LITE);
+    if (any_bits(creature_ptr->update, (PU_MON_LITE))) {
+        reset_bits(creature_ptr->update, PU_MON_LITE);
         update_mon_lite(creature_ptr);
     }
 
-    if (test_bit(creature_ptr->update, (PU_DELAY_VIS))) {
-        reset_bit(creature_ptr->update, PU_DELAY_VIS);
+    if (any_bits(creature_ptr->update, (PU_DELAY_VIS))) {
+        reset_bits(creature_ptr->update, PU_DELAY_VIS);
         delayed_visual_update(creature_ptr);
     }
 
-    if (test_bit(creature_ptr->update, (PU_MONSTERS))) {
-        reset_bit(creature_ptr->update, PU_MONSTERS);
+    if (any_bits(creature_ptr->update, (PU_MONSTERS))) {
+        reset_bits(creature_ptr->update, PU_MONSTERS);
         update_monsters(creature_ptr, FALSE);
     }
 }
@@ -3658,7 +3658,7 @@ bool player_has_no_spellbooks(player_type *creature_ptr)
     floor_type *floor_ptr = creature_ptr->current_floor_ptr;
     for (int i = floor_ptr->grid_array[creature_ptr->y][creature_ptr->x].o_idx; i; i = o_ptr->next_o_idx) {
         o_ptr = &floor_ptr->o_list[i];
-        if (o_ptr->k_idx && test_bit(o_ptr->marked, OM_FOUND) && check_book_realm(creature_ptr, o_ptr->tval, o_ptr->sval))
+        if (o_ptr->k_idx && any_bits(o_ptr->marked, OM_FOUND) && check_book_realm(creature_ptr, o_ptr->tval, o_ptr->sval))
             return FALSE;
     }
 
@@ -3742,16 +3742,16 @@ void check_experience(player_type *creature_ptr)
     if (creature_ptr->max_exp > creature_ptr->max_max_exp)
         creature_ptr->max_max_exp = creature_ptr->max_exp;
 
-    set_bit(creature_ptr->redraw, PR_EXP);
+    set_bits(creature_ptr->redraw, PR_EXP);
     handle_stuff(creature_ptr);
 
     bool android = (creature_ptr->prace == RACE_ANDROID ? TRUE : FALSE);
     PLAYER_LEVEL old_lev = creature_ptr->lev;
     while ((creature_ptr->lev > 1) && (creature_ptr->exp < ((android ? player_exp_a : player_exp)[creature_ptr->lev - 2] * creature_ptr->expfact / 100L))) {
         creature_ptr->lev--;
-        set_bit(creature_ptr->update, PU_BONUS | PU_HP | PU_MANA | PU_SPELLS);
-        set_bit(creature_ptr->redraw, PR_LEV | PR_TITLE);
-        set_bit(creature_ptr->window_flags, PW_PLAYER);
+        set_bits(creature_ptr->update, PU_BONUS | PU_HP | PU_MANA | PU_SPELLS);
+        set_bits(creature_ptr->redraw, PR_LEV | PR_TITLE);
+        set_bits(creature_ptr->window_flags, PW_PLAYER);
         handle_stuff(creature_ptr);
     }
 
@@ -3764,7 +3764,7 @@ void check_experience(player_type *creature_ptr)
         if (creature_ptr->lev > creature_ptr->max_plv) {
             creature_ptr->max_plv = creature_ptr->lev;
 
-            if ((creature_ptr->pclass == CLASS_CHAOS_WARRIOR) || test_bit(creature_ptr->muta2, MUT2_CHAOS_GIFT)) {
+            if ((creature_ptr->pclass == CLASS_CHAOS_WARRIOR) || any_bits(creature_ptr->muta2, MUT2_CHAOS_GIFT)) {
                 level_reward = TRUE;
             }
             if (creature_ptr->prace == RACE_BEASTMAN) {
@@ -3778,9 +3778,9 @@ void check_experience(player_type *creature_ptr)
 
         sound(SOUND_LEVEL);
         msg_format(_("レベル %d にようこそ。", "Welcome to level %d."), creature_ptr->lev);
-        set_bit(creature_ptr->update, (PU_BONUS | PU_HP | PU_MANA | PU_SPELLS));
-        set_bit(creature_ptr->redraw, (PR_LEV | PR_TITLE | PR_EXP));
-        set_bit(creature_ptr->window_flags, (PW_PLAYER | PW_SPELL | PW_INVEN));
+        set_bits(creature_ptr->update, (PU_BONUS | PU_HP | PU_MANA | PU_SPELLS));
+        set_bits(creature_ptr->redraw, (PR_LEV | PR_TITLE | PR_EXP));
+        set_bits(creature_ptr->window_flags, (PW_PLAYER | PW_SPELL | PW_INVEN));
         creature_ptr->level_up_message = TRUE;
         handle_stuff(creature_ptr);
 
@@ -3841,9 +3841,9 @@ void check_experience(player_type *creature_ptr)
             level_reward = FALSE;
         }
 
-        set_bit(creature_ptr->update, PU_BONUS | PU_HP | PU_MANA | PU_SPELLS);
-        set_bit(creature_ptr->redraw, (PR_LEV | PR_TITLE));
-        set_bit(creature_ptr->window_flags, (PW_PLAYER | PW_SPELL));
+        set_bits(creature_ptr->update, PU_BONUS | PU_HP | PU_MANA | PU_SPELLS);
+        set_bits(creature_ptr->redraw, (PR_LEV | PR_TITLE));
+        set_bits(creature_ptr->window_flags, (PW_PLAYER | PW_SPELL));
         handle_stuff(creature_ptr);
     }
 
@@ -4009,7 +4009,7 @@ bool is_time_limit_esp(player_type *creature_ptr)
 
 bool is_time_limit_stealth(player_type *creature_ptr) { return creature_ptr->tim_stealth || music_singing(creature_ptr, MUSIC_STEALTH); }
 
-bool can_two_hands_wielding(player_type *creature_ptr) { return !creature_ptr->riding || test_bit(creature_ptr->pet_extra_flags, PF_TWO_HANDS); }
+bool can_two_hands_wielding(player_type *creature_ptr) { return !creature_ptr->riding || any_bits(creature_ptr->pet_extra_flags, PF_TWO_HANDS); }
 
 /*!
  * @brief 歌の停止を処理する / Stop singing if the player is a Bard
@@ -4040,8 +4040,8 @@ void stop_singing(player_type *creature_ptr)
 
     SINGING_SONG_EFFECT(creature_ptr) = MUSIC_NONE;
     SINGING_SONG_ID(creature_ptr) = 0;
-    set_bit(creature_ptr->update, PU_BONUS);
-    set_bit(creature_ptr->redraw, PR_STATUS);
+    set_bits(creature_ptr->update, PU_BONUS);
+    set_bits(creature_ptr->redraw, PR_STATUS);
 }
 
 /*!
@@ -4080,11 +4080,11 @@ PERCENTAGE calculate_upkeep(player_type *creature_ptr)
 
         if (is_pet(m_ptr)) {
             total_friends++;
-            if (test_bit(r_ptr->flags1, RF1_UNIQUE)) {
+            if (any_bits(r_ptr->flags1, RF1_UNIQUE)) {
                 if (creature_ptr->pclass == CLASS_CAVALRY) {
                     if (creature_ptr->riding == m_idx)
                         total_friend_levels += (r_ptr->level + 5) * 2;
-                    else if (!has_a_unique && test_bit(r_info[m_ptr->r_idx].flags7, RF7_RIDING))
+                    else if (!has_a_unique && any_bits(r_info[m_ptr->r_idx].flags7, RF7_RIDING))
                         total_friend_levels += (r_ptr->level + 5) * 7 / 2;
                     else
                         total_friend_levels += (r_ptr->level + 5) * 10;

--- a/src/player/temporary-resistances.c
+++ b/src/player/temporary-resistances.c
@@ -25,9 +25,9 @@
 void tim_player_flags(player_type *creature_ptr, BIT_FLAGS *flags)
 {
     BIT_FLAGS tmp_effect_flag = (0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT);
-    set_bit(tmp_effect_flag, (0x01U << FLAG_CAUSE_BATTLE_FORM));
+    set_bits(tmp_effect_flag, (0x01U << FLAG_CAUSE_BATTLE_FORM));
     BIT_FLAGS race_class_flag = (0x01U << FLAG_CAUSE_CLASS);
-    set_bit(race_class_flag, (0x01U << FLAG_CAUSE_RACE));
+    set_bits(race_class_flag, (0x01U << FLAG_CAUSE_RACE));
 
     for (int i = 0; i < TR_FLAG_SIZE; i++)
         flags[i] = 0L;
@@ -46,90 +46,90 @@ void tim_player_flags(player_type *creature_ptr, BIT_FLAGS *flags)
     if (creature_ptr->special_attack & ATTACK_POIS)
         add_flag(flags, TR_BRAND_POIS);
 
-    if (is_oppose_acid(creature_ptr) && !test_bit(has_immune_acid(creature_ptr), (race_class_flag | tmp_effect_flag)))
+    if (is_oppose_acid(creature_ptr) && none_bits(has_immune_acid(creature_ptr), (race_class_flag | tmp_effect_flag)))
         add_flag(flags, TR_RES_ACID);
-    if (is_oppose_elec(creature_ptr) && !test_bit(has_immune_elec(creature_ptr), (race_class_flag | tmp_effect_flag)))
+    if (is_oppose_elec(creature_ptr) && none_bits(has_immune_elec(creature_ptr), (race_class_flag | tmp_effect_flag)))
         add_flag(flags, TR_RES_ELEC);
-    if (is_oppose_fire(creature_ptr) && !test_bit(has_immune_fire(creature_ptr), (race_class_flag | tmp_effect_flag)))
+    if (is_oppose_fire(creature_ptr) && none_bits(has_immune_fire(creature_ptr), (race_class_flag | tmp_effect_flag)))
         add_flag(flags, TR_RES_FIRE);
-    if (is_oppose_cold(creature_ptr) && !test_bit(has_immune_cold(creature_ptr), (race_class_flag | tmp_effect_flag)))
+    if (is_oppose_cold(creature_ptr) && none_bits(has_immune_cold(creature_ptr), (race_class_flag | tmp_effect_flag)))
         add_flag(flags, TR_RES_COLD);
     if (is_oppose_pois(creature_ptr))
         add_flag(flags, TR_RES_POIS);
 
-    if (test_bit(has_immune_acid(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_immune_acid(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_IM_ACID);
-    if (test_bit(has_immune_elec(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_immune_elec(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_IM_ELEC);
-    if (test_bit(has_immune_fire(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_immune_fire(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_IM_FIRE);
-    if (test_bit(has_immune_cold(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_immune_cold(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_IM_COLD);
     
-    if (test_bit(has_resist_lite(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_resist_lite(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_RES_LITE);
-    if (test_bit(has_resist_dark(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_resist_dark(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_RES_DARK);
-    if (test_bit(has_resist_blind(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_resist_blind(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_RES_BLIND);
-    if (test_bit(has_resist_conf(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_resist_conf(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_RES_CONF);
-    if (test_bit(has_resist_sound(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_resist_sound(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_RES_SOUND);
-    if (test_bit(has_resist_shard(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_resist_shard(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_RES_SHARDS);
-    if (test_bit(has_resist_neth(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_resist_neth(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_RES_NETHER);
-    if (test_bit(has_resist_nexus(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_resist_nexus(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_RES_NEXUS);
-    if (test_bit(has_resist_chaos(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_resist_chaos(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_RES_CHAOS);
-    if (test_bit(has_resist_disen(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_resist_disen(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_RES_DISEN);
 
-    if (test_bit(has_resist_fear(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_resist_fear(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_RES_FEAR);
-    if (test_bit(has_reflect(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_reflect(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_REFLECT);
-    if (test_bit(has_sh_fire(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_sh_fire(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_SH_FIRE);
-    if (test_bit(has_sh_cold(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_sh_cold(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_SH_COLD);
-    if (test_bit(has_sh_elec(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_sh_elec(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_SH_ELEC);
 
-    if (test_bit(has_free_act(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_free_act(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_FREE_ACT);
-    if (test_bit(has_see_inv(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_see_inv(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_SEE_INVIS);
-    if (test_bit(has_hold_exp(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_hold_exp(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_HOLD_EXP);
     
-    if (test_bit(has_slow_digest(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_slow_digest(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_SLOW_DIGEST);
-    if (test_bit(has_regenerate(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_regenerate(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_REGEN);
-    if (test_bit(has_levitation(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_levitation(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_LEVITATION);
-    if (test_bit(has_lite(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_lite(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_LITE_1);
 
-    if (test_bit(has_esp_telepathy(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_esp_telepathy(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_TELEPATHY);
     
-    if (test_bit(has_sustain_str(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_sustain_str(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_SUST_STR);
-    if (test_bit(has_sustain_int(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_sustain_int(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_SUST_INT);
-    if (test_bit(has_sustain_wis(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_sustain_wis(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_SUST_WIS);
-    if (test_bit(has_sustain_dex(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_sustain_dex(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_SUST_DEX);
-    if (test_bit(has_sustain_con(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_sustain_con(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_SUST_CON);
-    if (test_bit(has_sustain_chr(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_sustain_chr(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_SUST_CHR);
 
-    if (test_bit(has_infra_vision(creature_ptr), tmp_effect_flag))
+    if (any_bits(has_infra_vision(creature_ptr), tmp_effect_flag))
         add_flag(flags, TR_INFRA);
 }

--- a/src/util/bit-flags-calculator.h
+++ b/src/util/bit-flags-calculator.h
@@ -1,8 +1,10 @@
 ﻿#pragma once
 
-#define reset_bit(FLAG, INDEX) ((FLAG) &= ~(INDEX))
-#define set_bit(FLAG, INDEX) ((FLAG) |= (INDEX))
-#define test_bit(FLAG, INDEX) (((FLAG) & (INDEX)) != 0)
+#define reset_bits(FLAG, INDEX) ((FLAG) &= ~(INDEX))
+#define set_bits(FLAG, INDEX) ((FLAG) |= (INDEX))
+#define any_bits(FLAG, INDEX) (((FLAG) & (INDEX)) != 0)
+#define all_bits(FLAG, INDEX) (((FLAG) & (INDEX)) == (INDEX))
+#define none_bits(FLAG, INDEX) (((FLAG) & (INDEX)) == 0)
 #define has_flag(ARRAY, INDEX) !!((ARRAY)[(INDEX) / 32] & (1UL << ((INDEX) % 32)))
 #define add_flag(ARRAY, INDEX) ((ARRAY)[(INDEX) / 32] |= (1UL << ((INDEX) % 32)))
 #define remove_flag(ARRAY, INDEX) ((ARRAY)[(INDEX) / 32] &= ~(1UL << ((INDEX) % 32)))

--- a/src/wizard/monster-info-spoiler.c
+++ b/src/wizard/monster-info-spoiler.c
@@ -110,7 +110,7 @@ spoiler_output_status spoil_mon_desc(concptr fname, bool show_all, race_flags8 R
     for (int i = 0; i < n; i++) {
         monster_race *r_ptr = &r_info[who[i]];
         concptr name = (r_name + r_ptr->name);
-        if (!show_all && !test_bit(r_ptr->flags8, RF8_flags))
+        if (!show_all && none_bits(r_ptr->flags8, RF8_flags))
             continue;
 
         if (r_ptr->flags7 & RF7_KAGE)


### PR DESCRIPTION
複数形への修正 set_bit -> set_bits, reest_bit -> reset_bits
ビットテストマクロの細分化
test_bit -> any_bits (第二引数で指定したいずれかのビットがON)
all_bits (第二引数で指定した全てのビットがON)
none_bits (第二引数で指定した全てのビットがOFF)
以上の導入と、以前に使用していたマクロの置換を行った。