### PR TITLE
[Feature] 帰還できるダンジョンがないのに帰還してしまう #284

### DIFF
--- a/src/cmd-action/cmd-move.c
+++ b/src/cmd-action/cmd-move.c
@@ -92,8 +92,10 @@ void do_cmd_go_up(player_type *creature_ptr)
             quest[creature_ptr->current_floor_ptr->inside_quest].status = QUEST_STATUS_TAKEN;
         }
 
-        if (!creature_ptr->current_floor_ptr->inside_quest)
+        if (!creature_ptr->current_floor_ptr->inside_quest) {
             creature_ptr->current_floor_ptr->dun_level = 0;
+            creature_ptr->word_recall = 0;
+        }
 
         creature_ptr->leaving = TRUE;
         creature_ptr->oldpx = 0;
@@ -143,8 +145,10 @@ void do_cmd_go_up(player_type *creature_ptr)
 
     if (is_echizen(creature_ptr))
         msg_print(_("なんだこの階段は！", "What's this STAIRWAY!"));
-    else if (up_num == creature_ptr->current_floor_ptr->dun_level)
+    else if (up_num == creature_ptr->current_floor_ptr->dun_level) {
         msg_print(_("地上に戻った。", "You go back to the surface."));
+        creature_ptr->word_recall = 0;
+    }
     else
         msg_print(_("階段を上って新たなる迷宮へと足を踏み入れた。", "You enter a maze of up staircases."));
 
@@ -199,8 +203,10 @@ void do_cmd_go_down(player_type *creature_ptr)
             quest[creature_ptr->current_floor_ptr->inside_quest].status = QUEST_STATUS_TAKEN;
         }
 
-        if (!creature_ptr->current_floor_ptr->inside_quest)
+        if (!creature_ptr->current_floor_ptr->inside_quest) {
             creature_ptr->current_floor_ptr->dun_level = 0;
+            creature_ptr->word_recall = 0;
+        }
 
         creature_ptr->leaving = TRUE;
         creature_ptr->oldpx = 0;

--- a/src/floor/floor-leaver.c
+++ b/src/floor/floor-leaver.c
@@ -329,6 +329,7 @@ static void exit_to_wilderness(player_type *creature_ptr)
     }
 
     creature_ptr->recall_dungeon = creature_ptr->dungeon_idx;
+    creature_ptr->word_recall = 0;
     creature_ptr->dungeon_idx = 0;
     creature_ptr->change_floor_mode &= ~CFM_SAVE_FLOORS; // TODO
 }

--- a/src/player/player-move.c
+++ b/src/player/player-move.c
@@ -224,6 +224,8 @@ bool move_player_effect(player_type *creature_ptr, POSITION ny, POSITION nx, BIT
         leave_quest_check(creature_ptr);
         floor_ptr->inside_quest = g_ptr->special;
         floor_ptr->dun_level = 0;
+        if (!floor_ptr->inside_quest)
+            creature_ptr->word_recall = 0;
         creature_ptr->oldpx = 0;
         creature_ptr->oldpy = 0;
         creature_ptr->leaving = TRUE;


### PR DESCRIPTION
地上に戻って帰還するときにキャンセルするのではなく、ダンジョンやクエストから地上に戻ったときに帰還をキャンセルするようにした。

[Feature] Cancel recall when exit from dungeons or quests.
