### PR TITLE
Update top-level Makefile.am for the renaming of readme.txt

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,9 +12,9 @@ EXTRA_DIST = \
 	autopick.txt \
 	autopick_eng.txt \
 	bootstrap \
-	readme.txt \
+	readme.md \
 	readme_angband \
-	readme_eng.txt \
+	readme-eng.md \
 	hengband.spec \
 	$(visual_studio_files)
 


### PR DESCRIPTION
That will let "make dist" or "make distcheck" work correctly on Unix or Macintosh.