### PR TITLE
[Fix] 設定ファイルがBOM付で保存される #333

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,8 @@
 ﻿root = true
 
 [*]
-charset = utf-8-bom
 insert_final_newline = true
+charset = utf-8
+
+[*.{c,h}]
+charset = utf-8-bom


### PR DESCRIPTION
UTF-8 BOM付のファイルを読み込むと、先頭のBOMが処理できなくてエラーになります。
.cと.hだけBOM付で、他はなしにしました。