### PR TITLE
アーティファクト装備の能力等を調整 (α9)

### DIFF
--- a/lib/edit/a_info.txt
+++ b/lib/edit/a_info.txt
@@ -1304,28 +1304,30 @@ D:アンバーの艦隊を指揮するケインのダガーだ。
 #J0# ???
 N:66:『ナルサンク』
 E:'Narthanc'
-I:23:4:0
+I:23:4:1
 W:4:10:12:12000
-P:0:1d4:4:6:0
+P:0:2d4:4:6:0
+F:STR | HIDE_TYPE
 F:BRAND_FIRE | RES_FIRE | ACTIVATE | SHOW_MODS | LITE | THROW | XTRA_H_RES
-U:BO_FIRE_1
+U:FIRE_BALL_AND_RESITANCE
 D:$A fiery dagger finely balanced for deadly throws.
 D:「焔の牙」を意味する名を持つこの燃え盛る短剣は、
-D:その刃から焔の矢を迸らせる力をもつ。
+D:その刃から焔の球を迸らせる力をもつ。
 
 # The Dagger 'Nimthanc'
 
 #J0# ???
 N:67:『ニムサンク』
 E:'Nimthanc'
-I:23:4:0
+I:23:4:1
 W:3:10:12:11000
-P:0:1d4:4:6:0
+P:0:2d4:4:6:0
+F:DEX | HIDE_TYPE
 F:BRAND_COLD | RES_COLD | ACTIVATE | SHOW_MODS | THROW | XTRA_H_RES
-U:BO_COLD_1
+U:COLD_BALL_AND_RESITANCE
 D:$A frosty dagger finely balanced for deadly throws.
 D:「白き牙」を意味する名を持つこの短剣は必殺の冷気をもって
-D:敵を凍てつかせ、刃からは氷の矢を迸らせる力をもつ。
+D:敵を凍てつかせ、刃からは氷の球を迸らせる力をもつ。
 
 
 # The Dagger 'Dethanc'
@@ -1333,14 +1335,15 @@ D:敵を凍てつかせ、刃からは氷の矢を迸らせる力をもつ。
 #J0# ???
 N:68:『デサンク』
 E:'Dethanc'
-I:23:4:0
+I:23:4:1
 W:5:10:12:13000
-P:0:1d4:4:6:0
+P:0:2d4:4:6:0
+F:CON | HIDE_TYPE
 F:BRAND_ELEC | RES_ELEC | ACTIVATE | SHOW_MODS | THROW | XTRA_H_RES
-U:BO_ELEC_1
+U:ACID_BALL_AND_RESISTANCE
 D:$A dagger covered in sparks and finely balanced for deadly throws.
 D:「黒の牙」を意味する名を持つ、この短剣は雷光に覆われ、
-D:その刃から雷の矢を迸らせる力をもつ。
+D:その刃から雷の球を迸らせる力をもつ。
 
 # The Dagger of Rilia
 
@@ -1351,7 +1354,7 @@ I:23:4:0
 W:5:40:12:35000
 P:0:2d4:4:3:0
 F:SLAY_ORC | RES_POIS | RES_DISEN | ACTIVATE | SHOW_MODS | BRAND_POIS | THROW
-U:BA_POIS_1
+U:POIS_BALL_AND_RESITANCE
 D:$A large stiletto dagger that glistens with odorless poison, to which the 
 D:$wearer seems oddly immune.
 D:シンダール語で「地獄の輝き」を意味する名を持つ
@@ -1436,11 +1439,11 @@ D:（ロジャー・ゼラズニイ、アンバー１０「混沌の王子」）
 N:73:『グラムドリング』
 E:'Glamdring'
 I:23:16:1
-W:20:20:150:40000
+W:20:12:150:40000
 P:0:2d5:10:15:0
-F:SEARCH |
-F:SLAY_EVIL | BRAND_FIRE | KILL_ORC | RES_FIRE | RES_LITE | LITE |
-F:SLOW_DIGEST | SHOW_MODS | RIDING | XTRA_RES_OR_POWER |
+F:INT | WIS | SEARCH | MAGIC_MASTERY | HIDE_TYPE
+F:SLAY_EVIL | BRAND_FIRE | KILL_ORC | RES_FIRE | RES_LITE | LITE
+F:SLOW_DIGEST | SHOW_MODS | RIDING | XTRA_RES_OR_POWER
 F:ESP_ORC | ESP_TROLL | ESP_GIANT
 D:$This fiery, shining blade earned its sobriquet "Foe-Hammer" from dying orcs 
 D:$who dared to come near hidden Gondolin.
@@ -1456,11 +1459,12 @@ D:発見され、それ以降ガンダルフの物となる。
 N:74:『ノートゥング』
 E:'Nothung'
 I:23:16:4
-W:20:90:150:95000
+W:20:12:150:95000
 P:0:2d5:12:16:0
-F:SEARCH | BRAND_ELEC | SLAY_ORC | KILL_DRAGON | RES_FEAR |
-F:RES_ELEC | LITE | RES_FIRE | RES_POIS |
-F:SLOW_DIGEST | SHOW_MODS | RIDING
+F:STR | SEARCH | HIDE_TYPE
+F:BRAND_ELEC | SLAY_ORC | KILL_DRAGON | RES_FEAR
+F:RES_ELEC | LITE | RES_FIRE | RES_POIS
+F:SLOW_DIGEST | SHOW_MODS | RIDING | ESP_DRAGON
 D:$The sword of Sigurd which is also called Balmung or Gram.
 D:$ With it, Sigurd cut the anvil at Mime's forge in half and slew Fafner,
 D:$ the dragon.
@@ -1503,10 +1507,11 @@ D:龍ファフナーを屠ったのだった。
 N:75:『オルクリスト』
 E:'Orcrist'
 I:23:16:3
-W:20:20:150:40000
+W:20:12:150:40000
 P:0:2d5:10:15:0
-F:STEALTH | SLAY_EVIL | BRAND_COLD | KILL_ORC | RES_COLD | LITE |
-F:SLOW_DIGEST | SHOW_MODS | RIDING | XTRA_RES_OR_POWER |
+F:DEX | STEALTH | SEARCH | INFRA | LITE
+F:SLAY_EVIL | BRAND_COLD | SLAY_TROLL | SLAY_GIANT | KILL_ORC | RES_COLD
+F:SLOW_DIGEST | SHOW_MODS | RIDING | XTRA_RES_OR_POWER
 F:ESP_ORC | ESP_TROLL | ESP_GIANT
 D:$This coldly gleaming blade is called simply "Biter", by orcs who came to 
 D:$know its power all too well.
@@ -1719,9 +1724,10 @@ D:血に飢えた叫びが聞こえるだろう。
 N:86:『フォラスギル』
 E:'Forasgil'
 I:23:7:0
-W:15:8:40:15000
-P:0:1d6:12:19:0
+W:10:8:40:15000
+P:0:2d6:12:19:0
 F:SLAY_ANIMAL | BRAND_COLD | RES_COLD | RES_LITE | LITE | SHOW_MODS
+F:XTRA_H_RES
 D:$A slender, tapered blade whose wielder strikes icy blows with deadly 
 D:$accuracy.
 D:細身で先が細い剣であり、使用者は恐るべき正確さで凍てつく攻撃を繰り出す。
@@ -1733,10 +1739,10 @@ D:細身で先が細い剣であり、使用者は恐るべき正確さで凍て
 N:87:『カレス・アスドリアグ』
 E:'Careth Asdriag'
 I:23:11:1
-W:15:8:50:25000
+W:10:8:50:25000
 P:0:1d7:6:8:0
-F:BLOWS | SLAY_DRAGON | SLAY_ANIMAL | SLAY_TROLL | SLAY_GIANT | SLAY_HUMAN |
-F:SLAY_ORC | SHOW_MODS | RIDING
+F:BLOWS | KILL_DRAGON | KILL_ANIMAL | KILL_TROLL | KILL_GIANT | KILL_HUMAN |
+F:KILL_ORC | SHOW_MODS | RIDING
 D:$An heirloom of the Lords of Rhun far to the east, and a name of 
 D:$dismay to creatures natural and unnatural.
 D:遥か東の国リュンの豪胆な王の一族に伝わる家宝で、
@@ -1880,11 +1886,11 @@ D:この死の用心棒を振り降ろす時、内に宿る禍々しい破壊の
 N:95:『オソンディア』
 E:'Osondir'
 I:22:15:3
-W:20:8:190:22000
-P:0:3d5:6:9:0
-F:CHR | HIDE_TYPE |
-F:BRAND_FIRE | SLAY_UNDEAD | SLAY_GIANT | RES_FIRE | RES_SOUND |
-F:LEVITATION | SEE_INVIS | SHOW_MODS | LITE
+W:12:8:190:22000
+P:0:4d5:6:9:0
+F:STR | CHR | HIDE_TYPE
+F:BRAND_FIRE | SLAY_UNDEAD | KILL_GIANT | RES_FIRE | RES_SOUND
+F:LEVITATION | SEE_INVIS | SHOW_MODS | LITE_3 | XTRA_H_RES
 D:$Lordly and tall did Osondir stand against the wrath of giants, and 
 D:$clear-eyed in barrows fell, wielding a halberd glowing ruby red.
 D:巨人の怒りに立ち向かうようにオソンディアは堂々として高く、
@@ -1897,11 +1903,12 @@ D:構えるハルベルトはルビー色に輝き、塚山の中でも視力を
 N:96:『ティル=イ=アルク』
 E:'Til-i-arc'
 I:22:8:2
-W:20:15:160:32000
-P:0:2d5:10:12:10
-F:INT | HIDE_TYPE |
-F:BRAND_COLD | BRAND_FIRE | SLAY_DEMON | SLAY_TROLL | SLAY_GIANT |
-F:RES_FIRE | RES_COLD | SUST_INT | SLOW_DIGEST | SHOW_MODS | LITE
+W:12:8:160:32000
+P:0:3d5:10:12:10
+F:STR | INT | CON | HIDE_TYPE
+F:SUST_STR | SUST_INT | SUST_CON
+F:BRAND_COLD | BRAND_FIRE | SLAY_DEMON | SLAY_TROLL | SLAY_GIANT
+F:RES_FIRE | RES_COLD | REGEN | SLOW_DIGEST | SHOW_MODS | LITE_2
 D:$Within this long thrusting spear, the spirits of frost giants and fire
 D:$ demons war forever, trapped by magely spells.
 D:この両手持ちの長槍の中には
@@ -1914,7 +1921,7 @@ D:封印されていて永遠に争っている。
 N:97:『グングニル』
 E:'Runespear'
 I:22:7:4
-W:15:50:100:180000
+W:15:30:100:180000
 P:0:3d9:15:25:5
 F:INT | WIS | HIDE_TYPE | BRAND_FIRE | BRAND_ELEC |
 F:SLAY_TROLL | SLAY_ORC | SLAY_GIANT |
@@ -1938,12 +1945,13 @@ D:ルーン文字が刻まれている。（北欧神話）
 N:98:『ロンギヌス』
 E:of Destiny
 I:22:7:4
-W:15:40:100:80000
+W:15:25:100:80000
 P:0:2d9:15:15:0
-F:INT | WIS | INFRA | HIDE_TYPE | SEARCH | BRAND_FIRE |
-F:SLAY_GIANT | SLAY_EVIL | SLAY_DEMON | SLAY_UNDEAD | SLAY_DRAGON |
-F:RES_FIRE | RES_LITE | HOLD_EXP | RES_FEAR | LEVITATION |
-F:LITE | SEE_INVIS | ACTIVATE | BLESSED | SHOW_MODS | RIDING
+F:INT | WIS | INFRA | HIDE_TYPE | SEARCH | BRAND_FIRE
+F:SLAY_GIANT | SLAY_EVIL | SLAY_DEMON | SLAY_UNDEAD | SLAY_DRAGON
+F:RES_FIRE | RES_LITE | HOLD_EXP | RES_FEAR | LEVITATION
+F:LITE_3 | SEE_INVIS | ACTIVATE | BLESSED | SHOW_MODS | RIDING
+F:EASY_SPELL
 U:STONE_MUD
 D:$It is said that the person wielding this spear which is known as
 D:$ the Holy Lance can rule all over the world.
@@ -2053,11 +2061,12 @@ D:様々な攻撃への防御を与えてくれるだろう。
 N:104:『ロサラング』
 E:'Lotharang'
 I:22:22:1
-W:30:15:170:21000
-P:0:2d8:4:3:0
-F:STR | DEX | HIDE_TYPE |
-F:SLAY_TROLL | SLAY_ORC | ACTIVATE | SHOW_MODS
-U:CURE_MW
+W:15:8:170:21000
+P:0:3d8:4:3:0
+F:STR | DEX | TUNNEL | HIDE_TYPE
+F:SLAY_ANIMAL | KILL_TROLL | KILL_ORC
+F:RES_FEAR | FREE_ACT | ACTIVATE | SHOW_MODS
+U:HERO
 D:$A superbly crafted double-bladed axe that slays the creatures of earth and 
 D:$allows rapid recovery from their blows.
 D:アルノールの野伏の頭領ケルサインが使っていた、
@@ -2107,7 +2116,7 @@ W:20:8:130:50000
 P:0:2d6:13:19:0
 F:CON | HIDE_TYPE |
 F:SLAY_EVIL | SLAY_TROLL | SLAY_GIANT | SLAY_ORC |
-F:SEE_INVIS | SHOW_MODS
+F:SEE_INVIS | FREE_ACT | LITE | SHOW_MODS
 D:$A royal heirloom of the southern coast, strong in combat against evil 
 D:$creatures of the earth.
 D:ドワーフの言葉で「鏡の斧」を意味するこの斧は、
@@ -2146,7 +2155,7 @@ D:冥界の者共の軍勢を刺し貫いたオスセの霊力を宿している
 N:108:水の王ウルモの
 E:of Ulmo
 I:22:5:4
-W:30:90:70:120000
+W:30:35:70:120000
 P:0:4d8:15:19:0
 F:DEX | HIDE_TYPE | XTRA_POWER |
 F:SLAY_DRAGON | SLAY_ANIMAL | FREE_ACT | HOLD_EXP | IM_ACID |
@@ -2169,9 +2178,9 @@ E:'Avavir'
 I:22:17:3
 W:40:8:250:18000
 P:0:5d3:8:8:10
-F:DEX | CHR | HIDE_TYPE |
-F:BRAND_COLD | BRAND_FIRE | FREE_ACT | RES_FIRE | RES_COLD |
-F:RES_LITE | LITE | SEE_INVIS | ACTIVATE | SHOW_MODS
+F:DEX | CHR | HIDE_TYPE | SHOW_MODS
+F:BRAND_COLD | BRAND_FIRE | BRAND_ELEC | RES_FIRE | RES_COLD | RES_ELEC
+F:RES_LITE | FREE_ACT | LITE | SEE_INVIS | ACTIVATE | XTRA_H_RES
 U:RECALL
 D:$With elemental powers whose struggles turn this weapon red and purest 
 D:$white, this shining reaper bears within it a power of going forth and 
@@ -2187,7 +2196,7 @@ D:行き来する能力を持っている。
 N:110:『暁の剣』
 E:of the Dawn
 I:23:17:3
-W:40:120:130:250000
+W:40:40:130:250000
 P:0:3d5:20:20:0
 F:ACTIVATE | LITE | BRAND_FIRE | FREE_ACT | RES_FIRE | INFRA | RIDING |
 F:SLAY_EVIL | SLAY_DRAGON | SLAY_UNDEAD | SLAY_DEMON | VORPAL |
@@ -2227,12 +2236,12 @@ D:手中に収める。
 
 N:112:『トティラ』
 E:'Totila'
-I:21:13:2
+I:21:13:1
 W:20:8:150:55000
 P:0:3d6:6:8:0
-F:STEALTH |
-F:SLAY_EVIL | BRAND_FIRE | RES_FIRE | RES_CONF | ACTIVATE |
-F:SHOW_MODS | LITE | RIDING
+F:BLOWS | STEALTH | TUNNEL | HIDE_TYPE
+F:SLAY_EVIL | BRAND_FIRE | RES_FIRE | RES_CONF | ACTIVATE
+F:SHOW_MODS | LITE_2 | RIDING
 U:CONFUSE
 D:$A flail whose head befuddles those who stare as you whirl it around, and 
 D:$becomes a fiery comet as you bring it down. 
@@ -2246,11 +2255,12 @@ D:振り降ろせば炎の流星となって敵を打つ。
 N:113:『稲妻の拳』
 E:'Thunderfist'
 I:21:18:4
-W:45:38:300:160000
+W:45:20:300:160000
 P:0:3d6:5:18:0
-F:STR | HIDE_TYPE |
-F:SLAY_ANIMAL | BRAND_FIRE | BRAND_ELEC | SLAY_TROLL | SLAY_ORC |
-F:RES_ELEC | RES_FIRE | RES_DARK | SHOW_MODS | LITE
+F:STR | HIDE_TYPE
+F:SLAY_ANIMAL | BRAND_FIRE | BRAND_ELEC | SLAY_TROLL | SLAY_ORC
+F:RES_ELEC | RES_FIRE | RES_DARK | SHOW_MODS | LITE | ACTIVATE
+U:BA_ELEC_2
 D:$The long-lost weapon of Kzurin, Dwarven champion of ancient Belegost, 
 D:$with runes of strength in its handle, and flames and sparks that roar and 
 D:$crackle around its massive head.
@@ -2265,11 +2275,11 @@ D:炎と火花が轟々と音を立て渦巻いている。
 N:114:『血流の刺』
 E:'Bloodspike'
 I:21:12:4
-W:20:30:150:50000
+W:20:15:150:50000
 P:0:2d6:8:22:0
-F:STR | HIDE_TYPE | SLAY_HUMAN |
-F:SLAY_ANIMAL | SLAY_TROLL | SLAY_ORC | RES_NEXUS | SEE_INVIS |
-F:SHOW_MODS
+F:STR | HIDE_TYPE | SLAY_HUMAN
+F:SLAY_ANIMAL | SLAY_TROLL | SLAY_ORC | RES_NEXUS | SEE_INVIS
+F:FREE_ACT | REGEN | SHOW_MODS
 D:$You feel strong and firm of foot as you whip the chain-suspended spiked orb 
 D:$around - and bathe it in the blood of your foes.
 D:鎖でつながれた刺付きの球を振り回す時強くしっかりとした足取りを感じ、
@@ -2281,10 +2291,11 @@ D:鉄球は敵の血に浸かる。
 #J0# 日本語化
 N:115:『焔の星』
 E:'Firestar'
-I:21:12:0
+I:21:12:2
 W:20:15:150:35000
-P:0:2d6:5:7:2
-F:BRAND_FIRE | RES_FIRE | ACTIVATE | SHOW_MODS | LITE
+P:0:3d6:5:7:2
+F:STR | HIDE_TYPE
+F:BRAND_FIRE | RES_FIRE | RES_FEAR | ACTIVATE | SHOW_MODS | LITE_3
 U:BA_FIRE_2
 D:$A famed battle-lord of old with a ruddy head, colored as embers are that
 D:$ can yet rise up in wrath.
@@ -2417,10 +2428,10 @@ N:122:『トゥアミル』
 E:'Turmil'
 I:22:12:4
 W:20:15:120:30000
-P:0:2d5:10:6:8
-F:WIS | INFRA | HIDE_TYPE | BLESSED |
-F:BRAND_COLD | SLAY_ORC | RES_COLD | RES_LITE | LITE | REGEN |
-F:ACTIVATE | SHOW_MODS | XTRA_H_RES
+P:0:2d5:10:16:8
+F:WIS | INFRA | HIDE_TYPE | BLESSED
+F:BRAND_COLD | SLAY_ORC | RES_COLD | RES_LITE | RES_DARK
+F:LITE | REGEN | EASY_SPELL | ACTIVATE | SHOW_MODS | XTRA_H_RES
 U:DRAIN_2
 D:$Wielded by the High Priest of Meneltarma, this great hammer gleams coldly
 D:$ as though moonlit, and it can strike as mighty a blow spiritually as
@@ -2958,7 +2969,7 @@ D:朱金に輝く刀身で魔性の心臓をつらぬき、その命を食べつ
 N:161:『蜻蛉切』
 E:'Tonbo giri'
 I:22:7:3
-W:35:70:350:250000
+W:35:50:350:250000
 P:0:4d9:6:23:10
 F:STR | DEX | HIDE_TYPE | SEARCH | FREE_ACT | SLAY_HUMAN |
 F:SLAY_TROLL | SLAY_GIANT | SLAY_ANIMAL | SLAY_ORC | RES_FIRE | RES_COLD |
@@ -2984,7 +2995,7 @@ D:必ずや、スーパーアクションを可能にするだろう。
 N:163:『ガエボルグ』
 E:'GaeBolg'
 I:22:2:4
-W:45:90:80:150000
+W:45:30:80:150000
 P:0:3d6:16:18:0
 F:STR | DEX | HIDE_TYPE | THROW |
 F:BRAND_ELEC | SLAY_EVIL | SLAY_GIANT |
@@ -3002,7 +3013,7 @@ D:逆に所有者の視力を守る。
 N:164:顕聖二郎真君の
 E:of Arryu-Chien-Kun
 I:22:5:2
-W:30:45:70:120000
+W:30:25:70:120000
 P:0:2d8:12:16:0
 F:WIS | DEX | HIDE_TYPE | 
 F:SLAY_DRAGON | SLAY_DEMON | SLAY_ANIMAL | FREE_ACT | HOLD_EXP |
@@ -3179,7 +3190,7 @@ D:（FINAL FANTASY V）
 N:178:怪力サムソンの
 E:of Samson
 I:21:1:3
-W:10:20:50:40000
+W:10:8:50:40000
 P:0:2d4:8:10:0
 F:STR | CON | RES_FEAR | SEE_INVIS | SLAY_EVIL | SLAY_UNDEAD
 D:$This is the donkey's jawbone that Samson used to defeat a Philistine Army.
@@ -3328,7 +3339,7 @@ D:(J.R.R.トールキン、瀬田貞二・田中明子訳 新版指輪物語)
 N:187:『アイグロス』
 E:'Aeglos'
 I:22:2:4
-W:15:45:80:140000
+W:15:30:80:140000
 P:0:3d6:15:25:10
 F:WIS | HIDE_TYPE | THROW | RIDING |
 F:BRAND_COLD | SLAY_TROLL | SLAY_ORC | FREE_ACT | RES_COLD | 
@@ -3498,7 +3509,7 @@ N:202:『天の沼矛』
 E:'Ama-no-NumaHoko'
 I:22:4:4
 W:50:40:240:150000
-P:0:2d8:16:20:0
+P:0:3d8:16:20:0
 F:WIS | CHR | SUST_WIS | SUST_CHR | HIDE_TYPE |
 F:SLAY_EVIL | SLAY_DEMON | SLAY_UNDEAD |
 F:RES_ACID | RES_COLD | RES_BLIND | RES_CHAOS |

--- a/lib/edit/a_info.txt
+++ b/lib/edit/a_info.txt
@@ -4212,15 +4212,17 @@ P:0:0d0:0:0:0
 F:DEX | CHR
 F:RES_FIRE | RES_SOUND | RES_NETHER | SHOW_MODS | INSTA_ART
 
+# 能力はD&Dベースで調整
 N:252:『サンブレード』
 E:'Sun Blade'
-I:23:25:3
-W:30:150:180:65000
-P:0:3d6:16:20:10
-F:INT | FORCE_WEAPON
-F:SHOW_MODS
-F:SLAY_EVIL | SLAY_UNDEAD
-F:FREE_ACT | LITE
+I:23:21:3
+W:40:150:80:80000
+P:0:5d4:16:16:0
+F:INT | WIS | INFRA | SEARCH | HIDE_TYPE | SHOW_MODS
+F:BRAND_FIRE | KILL_EVIL | KILL_UNDEAD
+F:RES_FIRE | RES_LITE | SH_FIRE
+F:SEE_INVIS | BLESSED | LITE_3 | ACTIVATE
+U:BLINDING_LIGHT
 D:$A shining sword that keeps waiting for a hero in the back of the Mirage Tower.
 D:$  The blade was held by many red robes and continued to slaughter the evil ones.
 D:$ (Square, "Final Fantasy", 1987)
@@ -4257,11 +4259,13 @@ D:太陽を追った巨人、夸父の杖だ。まだ生きているこの木の
 # Eat steel, hungry wolves!
 N:255:ドン・キホーテの
 E:of Don Quixote
-I:22:29:-3
-W:40:30:300:70000
-P:0:3d8:-12:12:0
-F:STR | CON | CHR | IM_ELEC | RES_DARK | RES_FEAR | RIDING
-F:FREE_ACT | SUST_STR | SUST_CON | SUST_CHR | SLAY_EVIL | KILL_GIANT
+I:22:29:-1
+W:40:30:300:76543
+P:0:3d8:-13:13:0
+F:INT | WIS | DEX | CHR | STEALTH | SEARCH | HIDE_TYPE
+F:IM_ELEC | RES_FEAR | ESP_GIANT | ESP_TROLL | RIDING
+F:SLAY_EVIL | KILL_GIANT | KILL_TROLL | ACTIVATE
+U:BERSERK
 D:$Don Quixote born in La Mancha is the brave knight
 D:$ trying to defeat the colossal giant "Windmill".
 D:$  The lance he carried has the courage to face any fear.


### PR DESCRIPTION
アーティファクト武器を調整。
古い城の報酬にする予定のドン・キホーテとサンブレードを含む。