### PR TITLE
[Fix] 店や家でアイテム選択後に視界範囲再計算表示が行われる

### DIFF
--- a/src/cmd-building/cmd-store.c
+++ b/src/cmd-building/cmd-store.c
@@ -148,6 +148,7 @@ void do_cmd_store(player_type *player_ptr)
         bool need_redraw_store_inv = (player_ptr->update & PU_BONUS) ? TRUE : FALSE;
         current_world_ptr->character_icky = TRUE;
         handle_stuff(player_ptr);
+        player_ptr->redraw = 0L;
         if (player_ptr->inventory_list[INVEN_PACK].k_idx) {
             INVENTORY_IDX item = INVEN_PACK;
             object_type *o_ptr = &player_ptr->inventory_list[item];

--- a/src/inventory/floor-item-getter.c
+++ b/src/inventory/floor-item-getter.c
@@ -306,7 +306,7 @@ bool get_item_floor(player_type *owner_ptr, COMMAND_CODE *cp, concptr pmt, concp
         }
 
         owner_ptr->window_flags |= (PW_INVEN | PW_EQUIP);
-        handle_stuff(owner_ptr);
+        window_stuff(owner_ptr);
         COMMAND_CODE get_item_label = 0;
         if (command_wrk == USE_INVEN) {
             fis_ptr->n1 = I2A(fis_ptr->i1);
@@ -843,7 +843,7 @@ bool get_item_floor(player_type *owner_ptr, COMMAND_CODE *cp, concptr pmt, concp
         toggle_inventory_equipment(owner_ptr);
 
     owner_ptr->window_flags |= (PW_INVEN | PW_EQUIP);
-    handle_stuff(owner_ptr);
+    window_stuff(owner_ptr);
     prt("", 0, 0);
     if (fis_ptr->oops && str)
         msg_print(str);

--- a/src/inventory/item-getter.c
+++ b/src/inventory/item-getter.c
@@ -296,7 +296,7 @@ bool get_item(player_type *owner_ptr, OBJECT_IDX *cp, concptr pmt, concptr str, 
         }
 
         owner_ptr->window_flags |= (PW_INVEN | PW_EQUIP);
-        handle_stuff(owner_ptr);
+        window_stuff(owner_ptr);
 
         if (!command_wrk) {
             if (command_see)
@@ -609,7 +609,7 @@ bool get_item(player_type *owner_ptr, OBJECT_IDX *cp, concptr pmt, concptr str, 
         toggle_inventory_equipment(owner_ptr);
 
     owner_ptr->window_flags |= (PW_INVEN | PW_EQUIP);
-    handle_stuff(owner_ptr);
+    window_stuff(owner_ptr);
     prt("", 0, 0);
     if (item_selection_ptr->oops && str)
         msg_print(str);

--- a/src/store/sell-order.c
+++ b/src/store/sell-order.c
@@ -3,6 +3,7 @@
 #include "autopick/autopick.h"
 #include "core/asking-player.h"
 #include "core/stuff-handler.h"
+#include "core/window-redrawer.h"
 #include "flavor/flavor-describer.h"
 #include "flavor/object-flavor-types.h"
 #include "floor/floor-object.h"
@@ -297,7 +298,7 @@ void store_sell(player_type *owner_ptr)
                 autopick_alter_item(owner_ptr, item, FALSE);
 
             inven_item_optimize(owner_ptr, item);
-            handle_stuff(owner_ptr);
+            window_stuff(owner_ptr);
             int item_pos = store_carry(owner_ptr, q_ptr);
             if (item_pos >= 0) {
                 store_top = (item_pos / store_bottom) * store_bottom;
@@ -324,7 +325,7 @@ void store_sell(player_type *owner_ptr)
         choice = 0;
 
         vary_item(owner_ptr, item, -amt);
-        handle_stuff(owner_ptr);
+        window_stuff(owner_ptr);
 
         int item_pos = home_carry(owner_ptr, q_ptr);
         if (item_pos >= 0) {
@@ -336,7 +337,7 @@ void store_sell(player_type *owner_ptr)
         msg_format(_("%sを置いた。(%c)", "You drop %s (%c)."), o_name, index_to_label(item));
         choice = 0;
         vary_item(owner_ptr, item, -amt);
-        handle_stuff(owner_ptr);
+        window_stuff(owner_ptr);
         int item_pos = home_carry(owner_ptr, q_ptr);
         if (item_pos >= 0) {
             store_top = (item_pos / store_bottom) * store_bottom;


### PR DESCRIPTION
他施設でも同様な現象が発生していた。
get_item()内でhandle_stuff()していたためなので、必要分のwindow_stuff()を利用してインベントリ表示の更新を行う。

https://github.com/hengband/hengband/pull/307 によって、current_world_ptr->character_ickyの値がTRUE以上に増えないことによるエンバグの可能性がありますので、この修正を採用するかはレビュアーの方で判断してください。