### PR TITLE
[fix] character_icky の型変更による不具合

### DIFF
--- a/src/cmd-building/cmd-building.c
+++ b/src/cmd-building/cmd-building.c
@@ -358,7 +358,7 @@ void do_cmd_building(player_type *player_ptr)
 
 	forget_lite(player_ptr->current_floor_ptr);
 	forget_view(player_ptr->current_floor_ptr);
-	current_world_ptr->character_icky = TRUE;
+	current_world_ptr->character_icky_depth++;
 
 	command_arg = 0;
 	command_rep = 0;
@@ -408,7 +408,7 @@ void do_cmd_building(player_type *player_ptr)
 
 	if (reinit_wilderness) player_ptr->leaving = TRUE;
 
-	current_world_ptr->character_icky = FALSE;
+	current_world_ptr->character_icky_depth--;
 	term_clear();
 
 	player_ptr->update |= (PU_VIEW | PU_MONSTERS | PU_BONUS | PU_LITE | PU_MON_LITE);

--- a/src/cmd-building/cmd-store.c
+++ b/src/cmd-building/cmd-store.c
@@ -98,7 +98,7 @@ void do_cmd_store(player_type *player_ptr)
 
     forget_lite(player_ptr->current_floor_ptr);
     forget_view(player_ptr->current_floor_ptr);
-    current_world_ptr->character_icky = TRUE;
+    current_world_ptr->character_icky_depth = 1;
     command_arg = 0;
     command_rep = 0;
     command_new = 0;
@@ -146,7 +146,7 @@ void do_cmd_store(player_type *player_ptr)
         store_process_command(player_ptr);
 
         bool need_redraw_store_inv = (player_ptr->update & PU_BONUS) ? TRUE : FALSE;
-        current_world_ptr->character_icky = TRUE;
+        current_world_ptr->character_icky_depth = 1;
         handle_stuff(player_ptr);
         if (player_ptr->inventory_list[INVEN_PACK].k_idx) {
             INVENTORY_IDX item = INVEN_PACK;
@@ -194,7 +194,7 @@ void do_cmd_store(player_type *player_ptr)
 
     select_floor_music(player_ptr);
     take_turn(player_ptr, 100);
-    current_world_ptr->character_icky = FALSE;
+    current_world_ptr->character_icky_depth = 0;
     command_new = 0;
     command_see = FALSE;
     get_com_no_macros = FALSE;

--- a/src/core/game-closer.c
+++ b/src/core/game-closer.c
@@ -79,7 +79,7 @@ void close_game(player_type *player_ptr)
     flush();
     signals_ignore_tstp();
 
-    current_world_ptr->character_icky = TRUE;
+    current_world_ptr->character_icky_depth = 1;
     char buf[1024];
     path_build(buf, sizeof(buf), ANGBAND_DIR_APEX, "scores.raw");
     safe_setuid_grab(player_ptr);

--- a/src/core/game-play.c
+++ b/src/core/game-play.c
@@ -92,7 +92,7 @@
 static void restore_windows(player_type *player_ptr)
 {
     player_ptr->hack_mutation = FALSE;
-    current_world_ptr->character_icky = TRUE;
+    current_world_ptr->character_icky_depth = 1;
     term_activate(angband_term[0]);
     angband_term[0]->resize_hook = resize_map;
     for (MONSTER_IDX i = 1; i < 8; i++)
@@ -116,7 +116,7 @@ static void send_waiting_record(player_type *player_ptr)
     player_ptr->is_dead = TRUE;
     current_world_ptr->start_time = (u32b)time(NULL);
     signals_ignore_tstp();
-    current_world_ptr->character_icky = TRUE;
+    current_world_ptr->character_icky_depth = 1;
     path_build(buf, sizeof(buf), ANGBAND_DIR_APEX, "scores.raw");
     highscore_fd = fd_open(buf, O_RDWR);
 
@@ -281,7 +281,7 @@ static void generate_world(player_type *player_ptr, bool new_game)
     generate_wilderness(player_ptr);
     change_floor_if_error(player_ptr);
     current_world_ptr->character_generated = TRUE;
-    current_world_ptr->character_icky = FALSE;
+    current_world_ptr->character_icky_depth = 0;
     if (!new_game)
         return;
 

--- a/src/core/window-redrawer.c
+++ b/src/core/window-redrawer.c
@@ -69,7 +69,7 @@ void redraw_stuff(player_type *creature_ptr)
     if (!current_world_ptr->character_generated)
         return;
 
-    if (current_world_ptr->character_icky)
+    if (current_world_ptr->character_icky_depth > 0)
         return;
 
     if (creature_ptr->redraw & (PR_WIPE)) {

--- a/src/io/input-key-acceptor.c
+++ b/src/io/input-key-acceptor.c
@@ -190,7 +190,7 @@ char inkey(void)
     (void)term_get_cursor(&v);
 
     /* Show the cursor if waiting, except sometimes in "command" mode */
-    if (!inkey_scan && (!inkey_flag || hilite_player || current_world_ptr->character_icky)) {
+    if (!inkey_scan && (!inkey_flag || hilite_player || current_world_ptr->character_icky_depth > 0)) {
         (void)term_set_cursor(1);
     }
 

--- a/src/player/player-status.c
+++ b/src/player/player-status.c
@@ -3593,7 +3593,7 @@ void update_creature(player_type *creature_ptr)
 
     if (!current_world_ptr->character_generated)
         return;
-    if (current_world_ptr->character_icky)
+    if (current_world_ptr->character_icky_depth > 0)
         return;
     if (any_bits(creature_ptr->update, (PU_UN_LITE))) {
         reset_bits(creature_ptr->update, PU_UN_LITE);

--- a/src/term/screen-processor.c
+++ b/src/term/screen-processor.c
@@ -34,7 +34,7 @@ void screen_save()
     if (screen_depth++ == 0)
         term_save();
 
-    current_world_ptr->character_icky = TRUE;
+    current_world_ptr->character_icky_depth++;
 }
 
 /*
@@ -48,7 +48,7 @@ void screen_load()
     if (--screen_depth == 0)
         term_load();
 
-    current_world_ptr->character_icky = FALSE;
+    current_world_ptr->character_icky_depth--;
 }
 
 /*

--- a/src/world/world.h
+++ b/src/world/world.h
@@ -55,7 +55,7 @@ typedef struct world_type {
 	bool character_loaded;		/* The character was loaded from a savefile */
 	bool character_saved;		/* The character was just saved to a savefile */
 
-	bool character_icky;		/* The game is in an icky full screen mode */
+	byte character_icky_depth;	/* The game is in an icky full screen mode */
 	bool character_xtra;		/* The game is in an icky startup mode */
 
 	bool creating_savefile;		/* New savefile is currently created */


### PR DESCRIPTION
真のbool型導入により、character_ickyがTRUEかFALSEの値のみしか
取らなくなったが、実際は整数型として使用されていたため、
描画周りに不具合が発生するようになった。
character_ikcyを元と同様のbyte型に定義しなおし、変数名を
実情に合わせてcharacter_icky_depthに変更する。