### PR TITLE
[Fix] セクシースペルマスターの初期武器

### DIFF
--- a/src/birth/inventory-initializer.c
+++ b/src/birth/inventory-initializer.c
@@ -233,9 +233,11 @@ void player_outfit(player_type *creature_ptr)
         add_outfit(creature_ptr, q_ptr);
     }
 
-    if (creature_ptr->pseikaku == PERSONALITY_SEXY) {
-        player_init[creature_ptr->pclass][2][0] = TV_HAFTED;
-        player_init[creature_ptr->pclass][2][1] = SV_WHIP;
+    if (creature_ptr->pclass != CLASS_SORCERER) {
+        if (creature_ptr->pseikaku == PERSONALITY_SEXY) {
+            player_init[creature_ptr->pclass][2][0] = TV_HAFTED;
+            player_init[creature_ptr->pclass][2][1] = SV_WHIP;
+        }
     }
 
     for (int i = 0; i < 3; i++) {

--- a/src/core/game-play.c
+++ b/src/core/game-play.c
@@ -270,8 +270,11 @@ static void generate_world(player_type *player_ptr, bool new_game)
     floor_type *floor_ptr = player_ptr->current_floor_ptr;
     panel_row_min = floor_ptr->height;
     panel_col_min = floor_ptr->width;
-    if (player_ptr->pseikaku == PERSONALITY_SEXY)
-        s_info[player_ptr->pclass].w_max[TV_HAFTED - TV_WEAPON_BEGIN][SV_WHIP] = WEAPON_EXP_MASTER;
+
+    if (player_ptr->pclass != CLASS_SORCERER) {
+        if (player_ptr->pseikaku == PERSONALITY_SEXY)
+            s_info[player_ptr->pclass].w_max[TV_HAFTED - TV_WEAPON_BEGIN][SV_WHIP] = WEAPON_EXP_MASTER;
+    }
 
     set_floor_and_wall(player_ptr->dungeon_idx);
     flavor_init();


### PR DESCRIPTION
魔術師の杖に加えてムチも配備されていたためおかしくなっていた。
スペマスの場合はムチの配備と熟練度はなし。