### PR TITLE
[Refactor] flag_cause列挙子の修正 #287

### DIFF
--- a/src/player-attack/player-attack.c
+++ b/src/player-attack/player-attack.c
@@ -234,7 +234,7 @@ static void process_weapon_attack(player_type *attacker_ptr, player_attack_type 
     pa_ptr->attack_damage = calc_attack_damage_with_slay(attacker_ptr, o_ptr, pa_ptr->attack_damage, pa_ptr->m_ptr, pa_ptr->mode, FALSE);
     calc_surprise_attack_damage(attacker_ptr, pa_ptr);
 
-    BIT_FLAGS attack_hand = 0x01U << ((pa_ptr->hand == 0) ? FLAG_CAUSE_INVEN_MAIN_HAND : FLAG_CAUSE_INVEN_SUB_HAND);
+    BIT_FLAGS attack_hand = (pa_ptr->hand == 0) ? FLAG_CAUSE_INVEN_MAIN_HAND : FLAG_CAUSE_INVEN_SUB_HAND;
     if ((any_bits(attacker_ptr->impact, attack_hand) && ((pa_ptr->attack_damage > 50) || one_in_(7))) || (pa_ptr->chaos_effect == CE_QUAKE)
         || (pa_ptr->mode == HISSATSU_QUAKE))
         *do_quake = TRUE;

--- a/src/player/permanent-resistances.c
+++ b/src/player/permanent-resistances.c
@@ -573,7 +573,7 @@ void riding_flags(player_type *creature_ptr, BIT_FLAGS *flags, BIT_FLAGS *negati
     if (!creature_ptr->riding)
         return;
 
-    if (any_bits(has_levitation(creature_ptr), 0x01U << FLAG_CAUSE_RIDING)) {
+    if (any_bits(has_levitation(creature_ptr), FLAG_CAUSE_RIDING)) {
         add_flag(flags, TR_LEVITATION);
     } else {
         add_flag(negative_flags, TR_LEVITATION);

--- a/src/player/player-status-flags.c
+++ b/src/player/player-status-flags.c
@@ -553,9 +553,13 @@ BIT_FLAGS has_esp_telepathy(player_type *creature_ptr)
 {
     BIT_FLAGS result = 0L;
 
-    if (is_time_limit_esp(creature_ptr) || creature_ptr->ult_res || (creature_ptr->special_defense & KATA_MUSOU)) {
+    if (is_time_limit_esp(creature_ptr) || creature_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
+    if (creature_ptr->special_defense & KATA_MUSOU) {
+        result |= FLAG_CAUSE_BATTLE_FORM;
+    }
+
 
     if (creature_ptr->muta3 & MUT3_ESP) {
         result |= FLAG_CAUSE_MUTATION;
@@ -1107,7 +1111,7 @@ BIT_FLAGS has_regenerate(player_type *creature_ptr)
         result |= FLAG_CAUSE_MUTATION;
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_MUTATION;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (hex_spelling(creature_ptr, HEX_DEMON_AURA) || creature_ptr->ult_res || creature_ptr->tim_regen) {

--- a/src/player/player-status-flags.c
+++ b/src/player/player-status-flags.c
@@ -439,13 +439,13 @@ BIT_FLAGS has_infra_vision(player_type *creature_ptr)
         tmp_rp_ptr = &race_info[creature_ptr->prace];
 
     if (tmp_rp_ptr->infra > 0)
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
 
     if (creature_ptr->muta3 & MUT3_INFRAVIS)
-        result |= 0x01U << FLAG_CAUSE_MUTATION;
+        result |= FLAG_CAUSE_MUTATION;
 
     if (creature_ptr->tim_infra)
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
 
     result |= check_equipment_flags(creature_ptr, TR_INFRA);
     return result;
@@ -461,7 +461,7 @@ BIT_FLAGS has_esp_evil(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
     if (creature_ptr->realm1 == REALM_HEX) {
         if (hex_spelling(creature_ptr, HEX_DETECT_EVIL))
-            result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+            result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
     result |= check_equipment_flags(creature_ptr, TR_ESP_EVIL);
     return result;
@@ -554,24 +554,24 @@ BIT_FLAGS has_esp_telepathy(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (is_time_limit_esp(creature_ptr) || creature_ptr->ult_res || (creature_ptr->special_defense & KATA_MUSOU)) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (creature_ptr->muta3 & MUT3_ESP) {
-        result |= 0x01U << FLAG_CAUSE_MUTATION;
+        result |= FLAG_CAUSE_MUTATION;
     }
 
     if (is_specific_player_race(creature_ptr, RACE_MIND_FLAYER) && creature_ptr->lev > 29)
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
 
     if (is_specific_player_race(creature_ptr, RACE_SPECTRE) && creature_ptr->lev > 34)
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
 
     if (creature_ptr->pclass == CLASS_MINDCRAFTER && creature_ptr->lev > 39)
-        result |= 0x01U << FLAG_CAUSE_CLASS;
+        result |= FLAG_CAUSE_CLASS;
 
     if (creature_ptr->mimic_form == MIMIC_DEMON_LORD) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_TELEPATHY);
@@ -645,24 +645,24 @@ BIT_FLAGS has_reflect(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->pclass == CLASS_BERSERKER && creature_ptr->lev > 39)
-        result |= 0x01U << FLAG_CAUSE_CLASS;
+        result |= FLAG_CAUSE_CLASS;
 
     if (creature_ptr->pclass == CLASS_MIRROR_MASTER && creature_ptr->lev > 39)
-        result |= 0x01U << FLAG_CAUSE_CLASS;
+        result |= FLAG_CAUSE_CLASS;
 
     if (creature_ptr->special_defense & KAMAE_GENBU || creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res || creature_ptr->wraith_form || creature_ptr->magicdef || creature_ptr->tim_reflect) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_REFLECT);
     return result;
 }
 
-BIT_FLAGS has_see_nocto(player_type *creature_ptr) { return creature_ptr->pclass == CLASS_NINJA ? (0x01U << FLAG_CAUSE_CLASS) : 0L; }
+BIT_FLAGS has_see_nocto(player_type *creature_ptr) { return creature_ptr->pclass == CLASS_NINJA ? FLAG_CAUSE_CLASS : 0L; }
 
 BIT_FLAGS has_warning(player_type *creature_ptr)
 {
@@ -694,19 +694,19 @@ BIT_FLAGS has_sh_fire(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->muta3 & MUT3_FIRE_BODY) {
-        result |= 0x01U << FLAG_CAUSE_MUTATION;
+        result |= FLAG_CAUSE_MUTATION;
     }
 
     if (creature_ptr->mimic_form == MIMIC_DEMON_LORD) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KAMAE_SEIRYU || creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (hex_spelling(creature_ptr, HEX_DEMON_AURA) || creature_ptr->ult_res || creature_ptr->tim_sh_fire) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_SH_FIRE);
@@ -718,14 +718,14 @@ BIT_FLAGS has_sh_elec(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->muta3 & MUT3_ELEC_TOUC)
-        result |= 0x01U << FLAG_CAUSE_MUTATION;
+        result |= FLAG_CAUSE_MUTATION;
 
     if (hex_spelling(creature_ptr, HEX_SHOCK_CLOAK) || creature_ptr->ult_res) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (creature_ptr->special_defense & KAMAE_SEIRYU || (creature_ptr->special_defense & KATA_MUSOU)) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_SH_ELEC);
@@ -737,11 +737,11 @@ BIT_FLAGS has_sh_cold(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->special_defense & KAMAE_SEIRYU || creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res || hex_spelling(creature_ptr, HEX_ICE_ARMOR)) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_SH_COLD);
@@ -757,31 +757,31 @@ BIT_FLAGS has_hold_exp(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->pseikaku == PERSONALITY_MUNCHKIN) {
-        result |= 0x01U << FLAG_CAUSE_PERSONALITY;
+        result |= FLAG_CAUSE_PERSONALITY;
     }
 
     if (creature_ptr->mimic_form == MIMIC_DEMON || creature_ptr->mimic_form == MIMIC_DEMON_LORD || creature_ptr->mimic_form == MIMIC_VAMPIRE) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (is_specific_player_race(creature_ptr, RACE_HOBBIT) || is_specific_player_race(creature_ptr, RACE_SKELETON)
         || is_specific_player_race(creature_ptr, RACE_ZOMBIE) || is_specific_player_race(creature_ptr, RACE_VAMPIRE)
         || is_specific_player_race(creature_ptr, RACE_SPECTRE) || is_specific_player_race(creature_ptr, RACE_BALROG)
         || is_specific_player_race(creature_ptr, RACE_ANDROID)) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (is_specific_player_race(creature_ptr, RACE_GOLEM)) {
         if (creature_ptr->lev > 34)
-            result |= 0x01U << FLAG_CAUSE_RACE;
+            result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_HOLD_EXP);
@@ -793,28 +793,28 @@ BIT_FLAGS has_see_inv(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->pclass == CLASS_NINJA && creature_ptr->lev > 29)
-        result |= 0x01U << FLAG_CAUSE_CLASS;
+        result |= FLAG_CAUSE_CLASS;
 
     if (creature_ptr->mimic_form == MIMIC_DEMON || creature_ptr->mimic_form == MIMIC_DEMON_LORD || creature_ptr->mimic_form == MIMIC_VAMPIRE) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     } else if (is_specific_player_race(creature_ptr, RACE_HIGH_ELF) || is_specific_player_race(creature_ptr, RACE_GOLEM)
         || is_specific_player_race(creature_ptr, RACE_SKELETON) || is_specific_player_race(creature_ptr, RACE_ZOMBIE)
         || is_specific_player_race(creature_ptr, RACE_SPECTRE) || is_specific_player_race(creature_ptr, RACE_ARCHON)) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     } else if (is_specific_player_race(creature_ptr, RACE_DARK_ELF) && creature_ptr->lev > 19) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     } else if (is_specific_player_race(creature_ptr, RACE_MIND_FLAYER) && creature_ptr->lev > 14) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     } else if ((is_specific_player_race(creature_ptr, RACE_IMP) || is_specific_player_race(creature_ptr, RACE_BALROG)) && creature_ptr->lev > 9) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res || creature_ptr->tim_invis) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_SEE_INVIS);
@@ -828,37 +828,37 @@ BIT_FLAGS has_free_act(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->muta3 & MUT3_MOTION)
-        result |= 0x01U << FLAG_CAUSE_MUTATION;
+        result |= FLAG_CAUSE_MUTATION;
 
     if (is_specific_player_race(creature_ptr, RACE_GNOME) || is_specific_player_race(creature_ptr, RACE_GOLEM)
         || is_specific_player_race(creature_ptr, RACE_SPECTRE) || is_specific_player_race(creature_ptr, RACE_ANDROID)) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->pclass == CLASS_NINJA && !heavy_armor(creature_ptr)
         && (!creature_ptr->inventory_list[INVEN_MAIN_HAND].k_idx || can_attack_with_main_hand(creature_ptr))
         && (!creature_ptr->inventory_list[INVEN_SUB_HAND].k_idx || can_attack_with_sub_hand(creature_ptr))) {
         if (creature_ptr->lev > 24)
-            result |= 0x01U << FLAG_CAUSE_CLASS;
+            result |= FLAG_CAUSE_CLASS;
     }
 
     if (creature_ptr->pclass == CLASS_MONK || creature_ptr->pclass == CLASS_FORCETRAINER) {
         if (!(heavy_armor(creature_ptr))) {
             if (creature_ptr->lev > 24)
-                result |= 0x01U << FLAG_CAUSE_CLASS;
+                result |= FLAG_CAUSE_CLASS;
         }
     }
 
     if (creature_ptr->pclass == CLASS_BERSERKER) {
-        result |= 0x01U << FLAG_CAUSE_CLASS;
+        result |= FLAG_CAUSE_CLASS;
     }
 
     if (creature_ptr->ult_res || creature_ptr->magicdef) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_FREE_ACT);
@@ -870,19 +870,19 @@ BIT_FLAGS has_sustain_str(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->pclass == CLASS_BERSERKER) {
-        result |= 0x01U << FLAG_CAUSE_CLASS;
+        result |= FLAG_CAUSE_CLASS;
     }
     if (is_specific_player_race(creature_ptr, RACE_HALF_TROLL) || is_specific_player_race(creature_ptr, RACE_HALF_OGRE)
         || is_specific_player_race(creature_ptr, RACE_HALF_GIANT)) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_SUST_STR);
@@ -894,15 +894,15 @@ BIT_FLAGS has_sustain_int(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (is_specific_player_race(creature_ptr, RACE_MIND_FLAYER)) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_SUST_INT);
@@ -914,18 +914,18 @@ BIT_FLAGS has_sustain_wis(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->pclass == CLASS_MINDCRAFTER && creature_ptr->lev > 19)
-        result |= 0x01U << FLAG_CAUSE_CLASS;
+        result |= FLAG_CAUSE_CLASS;
 
     if (!creature_ptr->mimic_form && (creature_ptr->prace == RACE_MIND_FLAYER)) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_SUST_WIS);
@@ -936,18 +936,18 @@ BIT_FLAGS has_sustain_dex(player_type *creature_ptr)
 {
     BIT_FLAGS result = 0L;
     if (creature_ptr->pclass == CLASS_BERSERKER) {
-        result |= 0x01U << FLAG_CAUSE_CLASS;
+        result |= FLAG_CAUSE_CLASS;
     }
 
     if (creature_ptr->pclass == CLASS_NINJA && creature_ptr->lev > 24)
-        result |= 0x01U << FLAG_CAUSE_CLASS;
+        result |= FLAG_CAUSE_CLASS;
 
     if (creature_ptr->ult_res) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_SUST_DEX);
@@ -958,19 +958,19 @@ BIT_FLAGS has_sustain_con(player_type *creature_ptr)
 {
     BIT_FLAGS result = 0L;
     if (creature_ptr->pclass == CLASS_BERSERKER) {
-        result |= 0x01U << FLAG_CAUSE_CLASS;
+        result |= FLAG_CAUSE_CLASS;
     }
 
     if (!creature_ptr->mimic_form && (creature_ptr->prace == RACE_AMBERITE || creature_ptr->prace == RACE_DUNADAN)) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_SUST_CON);
@@ -982,11 +982,11 @@ BIT_FLAGS has_sustain_chr(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->ult_res) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_SUST_CHR);
@@ -998,29 +998,29 @@ BIT_FLAGS has_levitation(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->muta3 & MUT3_WINGS) {
-        result |= 0x01U << FLAG_CAUSE_MUTATION;
+        result |= FLAG_CAUSE_MUTATION;
     }
 
     if (creature_ptr->mimic_form == MIMIC_DEMON_LORD) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (is_specific_player_race(creature_ptr, RACE_DRACONIAN) || is_specific_player_race(creature_ptr, RACE_SPECTRE)
         || is_specific_player_race(creature_ptr, RACE_SPRITE) || is_specific_player_race(creature_ptr, RACE_ARCHON)
         || is_specific_player_race(creature_ptr, RACE_S_FAIRY)) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KAMAE_SEIRYU || creature_ptr->special_defense & KAMAE_SUZAKU || (creature_ptr->special_defense & KATA_MUSOU)) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res || creature_ptr->magicdef) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (creature_ptr->tim_levitation) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_LEVITATION);
@@ -1028,7 +1028,7 @@ BIT_FLAGS has_levitation(player_type *creature_ptr)
     if (creature_ptr->riding) {
         monster_type *riding_m_ptr = &creature_ptr->current_floor_ptr->m_list[creature_ptr->riding];
         monster_race *riding_r_ptr = &r_info[riding_m_ptr->r_idx];
-        result = (riding_r_ptr->flags7 & RF7_CAN_FLY) ? (0x01U << FLAG_CAUSE_RIDING) : 0;
+        result = (riding_r_ptr->flags7 & RF7_CAN_FLY) ? FLAG_CAUSE_RIDING : 0;
     }
     return result;
 }
@@ -1051,12 +1051,12 @@ BIT_FLAGS has_slow_digest(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->pclass == CLASS_NINJA) {
-        result |= 0x01U << FLAG_CAUSE_CLASS;
+        result |= FLAG_CAUSE_CLASS;
     }
 
     if (creature_ptr->lev > 14 && !creature_ptr->mimic_form && creature_ptr->prace == RACE_HALF_TROLL) {
         if (creature_ptr->pclass == CLASS_WARRIOR || creature_ptr->pclass == CLASS_BERSERKER) {
-            result |= 0x01U << FLAG_CAUSE_CLASS;
+            result |= FLAG_CAUSE_CLASS;
             /* Let's not make Regeneration
              * a disadvantage for the poor warriors who can
              * never learn a spell that satisfies hunger (actually
@@ -1066,17 +1066,17 @@ BIT_FLAGS has_slow_digest(player_type *creature_ptr)
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (!creature_ptr->mimic_form
         && (creature_ptr->prace == RACE_GOLEM || creature_ptr->prace == RACE_ZOMBIE || creature_ptr->prace == RACE_SPECTRE
             || creature_ptr->prace == RACE_ANDROID)) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_SLOW_DIGEST);
@@ -1088,30 +1088,30 @@ BIT_FLAGS has_regenerate(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (is_specific_player_race(creature_ptr, RACE_HALF_TROLL) && creature_ptr->lev > 14) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (is_specific_player_race(creature_ptr, RACE_AMBERITE)) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->pclass == CLASS_WARRIOR && creature_ptr->lev > 44) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->pclass == CLASS_BERSERKER) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->muta3 & MUT3_REGEN)
-        result |= 0x01U << FLAG_CAUSE_MUTATION;
+        result |= FLAG_CAUSE_MUTATION;
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_MUTATION;
+        result |= FLAG_CAUSE_MUTATION;
     }
 
     if (hex_spelling(creature_ptr, HEX_DEMON_AURA) || creature_ptr->ult_res || creature_ptr->tim_regen) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_REGEN);
@@ -1226,19 +1226,19 @@ BIT_FLAGS has_resist_acid(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->mimic_form == MIMIC_DEMON_LORD) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     } else if (is_specific_player_race(creature_ptr, RACE_YEEK) || is_specific_player_race(creature_ptr, RACE_KLACKON)) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     } else if (is_specific_player_race(creature_ptr, RACE_DRACONIAN) && creature_ptr->lev > 14) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KAMAE_SEIRYU || creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= has_immune_acid(creature_ptr);
@@ -1251,11 +1251,11 @@ BIT_FLAGS has_vuln_acid(player_type *creature_ptr)
 {
     BIT_FLAGS result = 0L;
     if (creature_ptr->muta3 & MUT3_VULN_ELEM) {
-        result |= 0x01U << FLAG_CAUSE_MUTATION;
+        result |= FLAG_CAUSE_MUTATION;
     }
 
     if (creature_ptr->special_defense & KATA_KOUKIJIN) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
     return result;
 }
@@ -1265,17 +1265,17 @@ BIT_FLAGS has_resist_elec(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->mimic_form == MIMIC_DEMON_LORD) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     } else if (is_specific_player_race(creature_ptr, RACE_DRACONIAN) && creature_ptr->lev > 19) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KAMAE_SEIRYU || creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_ELEC);
@@ -1287,15 +1287,15 @@ BIT_FLAGS has_vuln_elec(player_type *creature_ptr)
 {
     BIT_FLAGS result = 0L;
     if (creature_ptr->muta3 & MUT3_VULN_ELEM) {
-        result |= 0x01U << FLAG_CAUSE_MUTATION;
+        result |= FLAG_CAUSE_MUTATION;
     }
 
     if (is_specific_player_race(creature_ptr, RACE_ANDROID)) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KATA_KOUKIJIN) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
     return result;
 }
@@ -1305,23 +1305,23 @@ BIT_FLAGS has_resist_fire(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->mimic_form == MIMIC_DEMON || creature_ptr->mimic_form == MIMIC_DEMON_LORD) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (is_specific_player_race(creature_ptr, RACE_DRACONIAN) && creature_ptr->lev > 4) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (!creature_ptr->mimic_form && (creature_ptr->prace == RACE_IMP || creature_ptr->prace == RACE_BALROG)) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KAMAE_SEIRYU || creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_FIRE);
@@ -1333,15 +1333,15 @@ BIT_FLAGS has_vuln_fire(player_type *creature_ptr)
 {
     BIT_FLAGS result = 0L;
     if (creature_ptr->muta3 & MUT3_VULN_ELEM) {
-        result |= 0x01U << FLAG_CAUSE_MUTATION;
+        result |= FLAG_CAUSE_MUTATION;
     }
 
     if (is_specific_player_race(creature_ptr, RACE_ENT)) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KATA_KOUKIJIN) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
     return result;
 }
@@ -1351,27 +1351,27 @@ BIT_FLAGS has_resist_cold(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->mimic_form == MIMIC_DEMON_LORD || creature_ptr->mimic_form == MIMIC_VAMPIRE) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (!creature_ptr->mimic_form && (creature_ptr->prace == RACE_ZOMBIE) && creature_ptr->lev > 4) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if ((is_specific_player_race(creature_ptr, RACE_DRACONIAN) || is_specific_player_race(creature_ptr, RACE_SKELETON)) && creature_ptr->lev > 9) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (!creature_ptr->mimic_form && (creature_ptr->prace == RACE_VAMPIRE || creature_ptr->prace == RACE_SPECTRE)) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KAMAE_SEIRYU || creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_COLD);
@@ -1383,11 +1383,11 @@ BIT_FLAGS has_vuln_cold(player_type *creature_ptr)
 {
     BIT_FLAGS result = 0L;
     if (creature_ptr->muta3 & MUT3_VULN_ELEM) {
-        result |= 0x01U << FLAG_CAUSE_MUTATION;
+        result |= FLAG_CAUSE_MUTATION;
     }
 
     if (creature_ptr->special_defense & KATA_KOUKIJIN) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
     return result;
 }
@@ -1397,28 +1397,28 @@ BIT_FLAGS has_resist_pois(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->pclass == CLASS_NINJA && creature_ptr->lev > 19)
-        result |= 0x01U << FLAG_CAUSE_CLASS;
+        result |= FLAG_CAUSE_CLASS;
 
     if (creature_ptr->mimic_form == MIMIC_VAMPIRE || creature_ptr->mimic_form == MIMIC_DEMON_LORD) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (is_specific_player_race(creature_ptr, RACE_DRACONIAN) && creature_ptr->lev > 34) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (!creature_ptr->mimic_form
         && (creature_ptr->prace == RACE_KOBOLD || creature_ptr->prace == RACE_GOLEM || creature_ptr->prace == RACE_SKELETON
             || creature_ptr->prace == RACE_VAMPIRE || creature_ptr->prace == RACE_SPECTRE || creature_ptr->prace == RACE_ANDROID)) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KAMAE_SEIRYU || creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_POIS);
@@ -1430,26 +1430,26 @@ BIT_FLAGS has_resist_conf(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->pclass == CLASS_MINDCRAFTER && creature_ptr->lev > 29)
-        result |= 0x01U << FLAG_CAUSE_CLASS;
+        result |= FLAG_CAUSE_CLASS;
 
     if (creature_ptr->pseikaku == PERSONALITY_CHARGEMAN || creature_ptr->pseikaku == PERSONALITY_MUNCHKIN) {
-        result |= 0x01U << FLAG_CAUSE_PERSONALITY;
+        result |= FLAG_CAUSE_PERSONALITY;
     }
 
     if (!creature_ptr->mimic_form && (creature_ptr->prace == RACE_KLACKON || creature_ptr->prace == RACE_BEASTMAN || creature_ptr->prace == RACE_KUTAR)) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->mimic_form == MIMIC_DEMON_LORD) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->ult_res || creature_ptr->magicdef) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_CONF);
@@ -1461,19 +1461,19 @@ BIT_FLAGS has_resist_sound(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->pclass == CLASS_BARD) {
-        result |= 0x01U << FLAG_CAUSE_CLASS;
+        result |= FLAG_CAUSE_CLASS;
     }
 
     if (!creature_ptr->mimic_form && (creature_ptr->prace == RACE_CYCLOPS || creature_ptr->prace == RACE_BEASTMAN)) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_SOUND);
@@ -1485,15 +1485,15 @@ BIT_FLAGS has_resist_lite(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (!creature_ptr->mimic_form && (creature_ptr->prace == RACE_ELF || creature_ptr->prace == RACE_HIGH_ELF || creature_ptr->prace == RACE_SPRITE)) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_LITE);
@@ -1505,11 +1505,11 @@ BIT_FLAGS has_vuln_lite(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
     if (is_specific_player_race(creature_ptr, RACE_S_FAIRY) || is_specific_player_race(creature_ptr, RACE_VAMPIRE)
         || (creature_ptr->mimic_form == MIMIC_VAMPIRE)) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->wraith_form) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     return result;
@@ -1520,21 +1520,21 @@ BIT_FLAGS has_resist_dark(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->mimic_form == MIMIC_VAMPIRE) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (!creature_ptr->mimic_form
         && (creature_ptr->prace == RACE_HALF_ORC || creature_ptr->prace == RACE_HALF_OGRE || creature_ptr->prace == RACE_NIBELUNG
             || creature_ptr->prace == RACE_DARK_ELF || creature_ptr->prace == RACE_VAMPIRE)) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_DARK);
@@ -1546,21 +1546,21 @@ BIT_FLAGS has_resist_chaos(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->pclass == CLASS_CHAOS_WARRIOR && creature_ptr->lev > 29)
-        result |= 0x01U << FLAG_CAUSE_CLASS;
+        result |= FLAG_CAUSE_CLASS;
 
     if (creature_ptr->mimic_form == MIMIC_DEMON || creature_ptr->mimic_form == MIMIC_DEMON_LORD) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (!creature_ptr->mimic_form && creature_ptr->prace == RACE_HALF_TITAN)
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_CHAOS);
@@ -1572,18 +1572,18 @@ BIT_FLAGS has_resist_disen(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->mimic_form == MIMIC_DEMON_LORD) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (!creature_ptr->mimic_form && creature_ptr->prace == RACE_NIBELUNG)
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_DISEN);
@@ -1595,14 +1595,14 @@ BIT_FLAGS has_resist_shard(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (!creature_ptr->mimic_form && (creature_ptr->prace == RACE_HALF_GIANT || creature_ptr->prace == RACE_SKELETON))
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_SHARDS);
@@ -1614,15 +1614,15 @@ BIT_FLAGS has_resist_nexus(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->mimic_form == MIMIC_DEMON_LORD) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_NEXUS);
@@ -1634,18 +1634,18 @@ BIT_FLAGS has_resist_blind(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->pseikaku == PERSONALITY_MUNCHKIN) {
-        result |= 0x01U << FLAG_CAUSE_PERSONALITY;
+        result |= FLAG_CAUSE_PERSONALITY;
     }
 
     if (!creature_ptr->mimic_form && creature_ptr->prace == RACE_DWARF)
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res || creature_ptr->magicdef) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_BLIND);
@@ -1657,20 +1657,20 @@ BIT_FLAGS has_resist_neth(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->mimic_form == MIMIC_DEMON_LORD || creature_ptr->mimic_form == MIMIC_DEMON || creature_ptr->mimic_form == MIMIC_VAMPIRE) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (!creature_ptr->mimic_form
         && (creature_ptr->prace == RACE_ZOMBIE || creature_ptr->prace == RACE_VAMPIRE || creature_ptr->prace == RACE_SPECTRE
             || creature_ptr->prace == RACE_BALROG))
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (creature_ptr->ult_res || creature_ptr->tim_res_nether) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_NETHER);
@@ -1682,7 +1682,7 @@ BIT_FLAGS has_resist_time(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->tim_res_time) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_TIME);
@@ -1694,7 +1694,7 @@ BIT_FLAGS has_resist_water(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (!creature_ptr->mimic_form && creature_ptr->prace == RACE_MERFOLK)
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
 
     result |= check_equipment_flags(creature_ptr, TR_RES_WATER);
     return result;
@@ -1705,41 +1705,41 @@ BIT_FLAGS has_resist_fear(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (creature_ptr->muta3 & MUT3_FEARLESS)
-        result |= 0x01U << FLAG_CAUSE_MUTATION;
+        result |= FLAG_CAUSE_MUTATION;
 
     switch (creature_ptr->pclass) {
     case CLASS_WARRIOR:
     case CLASS_SAMURAI:
         if (creature_ptr->lev > 29)
-            result |= 0x01U << FLAG_CAUSE_CLASS;
+            result |= FLAG_CAUSE_CLASS;
         break;
     case CLASS_PALADIN:
     case CLASS_CHAOS_WARRIOR:
         if (creature_ptr->lev > 39)
-            result |= 0x01U << FLAG_CAUSE_CLASS;
+            result |= FLAG_CAUSE_CLASS;
         break;
     case CLASS_MINDCRAFTER:
         if (creature_ptr->lev > 9)
-            result |= 0x01U << FLAG_CAUSE_CLASS;
+            result |= FLAG_CAUSE_CLASS;
         break;
     case CLASS_NINJA:
-        result |= 0x01U << FLAG_CAUSE_CLASS;
+        result |= FLAG_CAUSE_CLASS;
         break;
     }
 
     if (creature_ptr->mimic_form == MIMIC_DEMON_LORD) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (!creature_ptr->mimic_form && creature_ptr->prace == RACE_BARBARIAN)
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
 
     if ((creature_ptr->special_defense & KATA_MUSOU)) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (is_hero(creature_ptr) || is_shero(creature_ptr) || creature_ptr->ult_res) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_RES_FEAR);
@@ -1750,11 +1750,11 @@ BIT_FLAGS has_immune_acid(player_type *creature_ptr)
 {
     BIT_FLAGS result = 0L;
     if (!creature_ptr->mimic_form && creature_ptr->prace == RACE_YEEK && creature_ptr->lev > 19)
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
 
     if (creature_ptr->ele_immune) {
         if (creature_ptr->special_defense & DEFENSE_ACID)
-            result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+            result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_IM_ACID);
@@ -1767,7 +1767,7 @@ BIT_FLAGS has_immune_elec(player_type *creature_ptr)
 
     if (creature_ptr->ele_immune) {
         if (creature_ptr->special_defense & DEFENSE_ELEC)
-            result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+            result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_IM_ELEC);
@@ -1780,7 +1780,7 @@ BIT_FLAGS has_immune_fire(player_type *creature_ptr)
 
     if (creature_ptr->ele_immune) {
         if (creature_ptr->special_defense & DEFENSE_FIRE)
-            result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+            result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_IM_FIRE);
@@ -1793,7 +1793,7 @@ BIT_FLAGS has_immune_cold(player_type *creature_ptr)
 
     if (creature_ptr->ele_immune) {
         if (creature_ptr->special_defense & DEFENSE_COLD)
-            result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+            result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     result |= check_equipment_flags(creature_ptr, TR_IM_COLD);
@@ -1805,11 +1805,11 @@ BIT_FLAGS has_immune_dark(player_type *creature_ptr)
     BIT_FLAGS result = 0L;
 
     if (is_specific_player_race(creature_ptr, RACE_VAMPIRE) || (creature_ptr->mimic_form == MIMIC_VAMPIRE)) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (creature_ptr->wraith_form) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     return result;
@@ -1890,22 +1890,22 @@ BIT_FLAGS has_lite(player_type *creature_ptr)
         return 0L;
 
     if (creature_ptr->pseikaku == PERSONALITY_MUNCHKIN) {
-        result |= 0x01U << FLAG_CAUSE_PERSONALITY;
+        result |= FLAG_CAUSE_PERSONALITY;
     }
 
     if (creature_ptr->mimic_form == MIMIC_VAMPIRE) {
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
     }
 
     if (!creature_ptr->mimic_form && creature_ptr->prace == RACE_VAMPIRE)
-        result |= 0x01U << FLAG_CAUSE_RACE;
+        result |= FLAG_CAUSE_RACE;
 
     if (creature_ptr->ult_res) {
-        result |= 0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT;
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
     if (creature_ptr->special_defense & KATA_MUSOU) {
-        result |= 0x01U << FLAG_CAUSE_BATTLE_FORM;
+        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     result |= has_sh_fire(creature_ptr);

--- a/src/player/player-status-flags.h
+++ b/src/player/player-status-flags.h
@@ -2,26 +2,26 @@
 #include "object-enchant/tr-types.h"
 
 enum flag_cause {
-    FLAG_CAUSE_INVEN_MAIN_HAND = 0, /*!< アイテムスロット…利手 */
-    FLAG_CAUSE_INVEN_SUB_HAND = 1, /*!< アイテムスロット…逆手 */
-    FLAG_CAUSE_INVEN_BOW = 2, /*!< アイテムスロット…射撃 */
-    FLAG_CAUSE_INVEN_MAIN_RING = 3, /*!< アイテムスロット…利手指 */
-    FLAG_CAUSE_INVEN_SUB_RING = 4, /*!< アイテムスロット…逆手指 */
-    FLAG_CAUSE_INVEN_NECK = 5, /*!< アイテムスロット…首 */
-    FLAG_CAUSE_INVEN_LITE = 6, /*!< アイテムスロット…光源 */
-    FLAG_CAUSE_INVEN_BODY = 7, /*!< アイテムスロット…体 */
-    FLAG_CAUSE_INVEN_OUTER = 8, /*!< アイテムスロット…体の上 */
-    FLAG_CAUSE_INVEN_HEAD = 9, /*!< アイテムスロット…頭部 */
-    FLAG_CAUSE_INVEN_ARMS = 10, /*!< アイテムスロット…腕部 */
-    FLAG_CAUSE_INVEN_FEET = 11, /*!< アイテムスロット…脚部 */
-    FLAG_CAUSE_RACE = 12, /*!< 種族上の体得 */
-    FLAG_CAUSE_CLASS = 13, /*!< 職業上の体得 */
-    FLAG_CAUSE_PERSONALITY = 14, /*!< 性格上の体得 */
-    FLAG_CAUSE_MAGIC_TIME_EFFECT = 15, /*!< 魔法による時限効果 */
-    FLAG_CAUSE_MUTATION = 16, /*!< 変異による効果 */
-    FLAG_CAUSE_BATTLE_FORM = 17, /*!< 構えによる効果 */
-    FLAG_CAUSE_RIDING = 18, /*!< 乗馬による効果 */
-    FLAG_CAUSE_MAX = 19
+    FLAG_CAUSE_INVEN_MAIN_HAND = 0x01U << 0, /*!< アイテムスロット…利手 */
+    FLAG_CAUSE_INVEN_SUB_HAND = 0x01U << 1, /*!< アイテムスロット…逆手 */
+    FLAG_CAUSE_INVEN_BOW = 0x01U << 2, /*!< アイテムスロット…射撃 */
+    FLAG_CAUSE_INVEN_MAIN_RING = 0x01U << 3, /*!< アイテムスロット…利手指 */
+    FLAG_CAUSE_INVEN_SUB_RING = 0x01U << 4, /*!< アイテムスロット…逆手指 */
+    FLAG_CAUSE_INVEN_NECK = 0x01U << 5, /*!< アイテムスロット…首 */
+    FLAG_CAUSE_INVEN_LITE = 0x01U << 6, /*!< アイテムスロット…光源 */
+    FLAG_CAUSE_INVEN_BODY = 0x01U << 7, /*!< アイテムスロット…体 */
+    FLAG_CAUSE_INVEN_OUTER = 0x01U << 8, /*!< アイテムスロット…体の上 */
+    FLAG_CAUSE_INVEN_HEAD = 0x01U << 9, /*!< アイテムスロット…頭部 */
+    FLAG_CAUSE_INVEN_ARMS = 0x01U << 10, /*!< アイテムスロット…腕部 */
+    FLAG_CAUSE_INVEN_FEET = 0x01U << 11, /*!< アイテムスロット…脚部 */
+    FLAG_CAUSE_RACE = 0x01U << 12, /*!< 種族上の体得 */
+    FLAG_CAUSE_CLASS = 0x01U << 13, /*!< 職業上の体得 */
+    FLAG_CAUSE_PERSONALITY = 0x01U << 14, /*!< 性格上の体得 */
+    FLAG_CAUSE_MAGIC_TIME_EFFECT = 0x01U << 15, /*!< 魔法による時限効果 */
+    FLAG_CAUSE_MUTATION = 0x01U << 16, /*!< 変異による効果 */
+    FLAG_CAUSE_BATTLE_FORM = 0x01U << 17, /*!< 構えによる効果 */
+    FLAG_CAUSE_RIDING = 0x01U << 18, /*!< 乗馬による効果 */
+    FLAG_CAUSE_MAX = 0x01U << 19
 };
 
 typedef enum melee_type {

--- a/src/player/player-status-resist.c
+++ b/src/player/player-status-resist.c
@@ -69,9 +69,10 @@ PERCENTAGE calc_acid_damage_rate(player_type *creature_ptr)
     }
 
     BIT_FLAGS flgs = has_vuln_acid(creature_ptr);
-    for (int i = 0; i < FLAG_CAUSE_MAX; i++) {
-        if (flgs & (0x01U << i)) {
-            if (i == FLAG_CAUSE_MUTATION) {
+    
+    for (BIT_FLAGS check_flag = 0x01U; check_flag < FLAG_CAUSE_MAX; check_flag <<= 1) {
+        if (any_bits(flgs, check_flag)) {
+            if (check_flag == FLAG_CAUSE_MUTATION) {
                 per *= 2;
             } else {
                 per += per / 3;
@@ -99,9 +100,9 @@ PERCENTAGE calc_elec_damage_rate(player_type *creature_ptr)
     }
 
     BIT_FLAGS flgs = has_vuln_elec(creature_ptr);
-    for (int i = 0; i < FLAG_CAUSE_MAX; i++) {
-        if (flgs & (0x01U << i)) {
-            if (i == FLAG_CAUSE_MUTATION) {
+    for (BIT_FLAGS check_flag = 0x01U; check_flag < FLAG_CAUSE_MAX; check_flag <<= 1) {
+        if (any_bits(flgs, check_flag)) {
+            if (check_flag == FLAG_CAUSE_MUTATION) {
                 per *= 2;
             } else {
                 per += per / 3;
@@ -124,9 +125,9 @@ PERCENTAGE calc_fire_damage_rate(player_type *creature_ptr)
 {
     PERCENTAGE per = 100;
     BIT_FLAGS flgs = has_vuln_fire(creature_ptr);
-     for (int i = 0; i < FLAG_CAUSE_MAX; i++) {
-        if (flgs & (0x01U << i)) {
-            if (i == FLAG_CAUSE_MUTATION) {
+    for (BIT_FLAGS check_flag = 0x01U; check_flag < FLAG_CAUSE_MAX; check_flag <<= 1) {
+        if (any_bits(flgs, check_flag)) {
+            if (check_flag == FLAG_CAUSE_MUTATION) {
                 per *= 2;
             } else {
                 per += per / 3;
@@ -150,9 +151,9 @@ PERCENTAGE calc_cold_damage_rate(player_type *creature_ptr)
 {
     PERCENTAGE per = 100;
     BIT_FLAGS flgs = has_vuln_cold(creature_ptr);
-    for (int i = 0; i < FLAG_CAUSE_MAX; i++) {
-        if (flgs & (0x01U << i)) {
-            if (i == FLAG_CAUSE_MUTATION) {
+    for (BIT_FLAGS check_flag = 0x01U; check_flag < FLAG_CAUSE_MAX; check_flag <<= 1) {
+        if (any_bits(flgs, check_flag)) {
+            if (check_flag == FLAG_CAUSE_MUTATION) {
                 per *= 2;
             } else {
                 per += per / 3;

--- a/src/player/temporary-resistances.c
+++ b/src/player/temporary-resistances.c
@@ -24,10 +24,10 @@
  */
 void tim_player_flags(player_type *creature_ptr, BIT_FLAGS *flags)
 {
-    BIT_FLAGS tmp_effect_flag = (0x01U << FLAG_CAUSE_MAGIC_TIME_EFFECT);
-    set_bits(tmp_effect_flag, (0x01U << FLAG_CAUSE_BATTLE_FORM));
-    BIT_FLAGS race_class_flag = (0x01U << FLAG_CAUSE_CLASS);
-    set_bits(race_class_flag, (0x01U << FLAG_CAUSE_RACE));
+    BIT_FLAGS tmp_effect_flag = FLAG_CAUSE_MAGIC_TIME_EFFECT;
+    set_bits(tmp_effect_flag, FLAG_CAUSE_BATTLE_FORM);
+    BIT_FLAGS race_class_flag = FLAG_CAUSE_CLASS;
+    set_bits(race_class_flag, FLAG_CAUSE_RACE);
 
     for (int i = 0; i < TR_FLAG_SIZE; i++)
         flags[i] = 0L;


### PR DESCRIPTION
flag_cause列挙子はBIT_FLAGS演算で使用することを前提としていたが、各処理でBIT_FLAGSへの変換を要求していたので処理漏れが発生する原因となっていた。
あらかじめBIT_FLAGSとして定義しておくとこでこれを改善する。
合わせて、インクリメント処理をしていたplayer-status-resist.c内部の処理を修正する。