### PR TITLE
[Fix] 店や家でサブウィンドウのキャラ情報が更新されない #259

### DIFF
--- a/src/cmd-item/cmd-equipment.c
+++ b/src/cmd-item/cmd-equipment.c
@@ -284,10 +284,10 @@ void do_cmd_wield(player_type *creature_ptr)
     if ((o_ptr->name1 == ART_STONEMASK) && (creature_ptr->prace != RACE_VAMPIRE) && (creature_ptr->prace != RACE_ANDROID))
         change_race(creature_ptr, RACE_VAMPIRE, "");
 
+    calc_android_exp(creature_ptr);
     creature_ptr->update |= PU_BONUS | PU_TORCH | PU_MANA;
     creature_ptr->redraw |= PR_EQUIPPY;
     creature_ptr->window_flags |= PW_INVEN | PW_EQUIP | PW_PLAYER;
-    calc_android_exp(creature_ptr);
 }
 
 /*!
@@ -332,5 +332,7 @@ void do_cmd_takeoff(player_type *creature_ptr)
     (void)inven_takeoff(creature_ptr, item, 255);
     verify_equip_slot(creature_ptr, item);
     calc_android_exp(creature_ptr);
+    creature_ptr->update |= PU_BONUS | PU_TORCH | PU_MANA;
     creature_ptr->redraw |= PR_EQUIPPY;
+    creature_ptr->window_flags |= PW_INVEN | PW_EQUIP | PW_PLAYER;
 }

--- a/src/inventory/inventory-object.c
+++ b/src/inventory/inventory-object.c
@@ -302,7 +302,7 @@ s16b store_item_to_inventory(player_type *owner_ptr, object_type *o_ptr)
             object_absorb(j_ptr, o_ptr);
 
             owner_ptr->update |= (PU_BONUS);
-            owner_ptr->window_flags |= (PW_INVEN);
+            owner_ptr->window_flags |= (PW_INVEN | PW_PLAYER);
             return (j);
         }
     }
@@ -341,7 +341,7 @@ s16b store_item_to_inventory(player_type *owner_ptr, object_type *o_ptr)
 
     owner_ptr->inven_cnt++;
     owner_ptr->update |= (PU_BONUS | PU_COMBINE | PU_REORDER);
-    owner_ptr->window_flags |= (PW_INVEN);
+    owner_ptr->window_flags |= (PW_INVEN | PW_PLAYER);
 
     return i;
 }

--- a/src/store/purchase-order.c
+++ b/src/store/purchase-order.c
@@ -246,8 +246,8 @@ static bool process_purchase_result(player_type *player_ptr, object_type *o_ptr,
     *item_new = store_item_to_inventory(player_ptr, j_ptr);
     GAME_TEXT o_name[MAX_NLEN];
     describe_flavor(player_ptr, o_name, &player_ptr->inventory_list[*item_new], 0);
-    msg_format(_("%s(%c)を取った。", "You have %s (%c)."), o_name, index_to_label(*item_new));
     handle_stuff(player_ptr);
+    msg_format(_("%s(%c)を取った。", "You have %s (%c)."), o_name, index_to_label(*item_new));
     *i = st_ptr->stock_num;
     store_item_increase(item, -amt);
     store_item_optimize(item);
@@ -445,14 +445,15 @@ void store_purchase(player_type *player_ptr)
     j_ptr->feeling = FEEL_NONE;
     j_ptr->ident &= ~(IDENT_STORE);
     item_new = store_item_to_inventory(player_ptr, j_ptr);
+    handle_stuff(player_ptr);
 
     describe_flavor(player_ptr, o_name, &player_ptr->inventory_list[item_new], 0);
     msg_format(_("%s(%c)を手に入れた。", "You have %s (%c)."), o_name, index_to_label(item_new));
+
     autopick_alter_item(player_ptr, item_new, FALSE);
     if ((o_ptr->tval == TV_ROD) || (o_ptr->tval == TV_WAND))
         o_ptr->pval -= j_ptr->pval;
 
-    handle_stuff(player_ptr);
     i = st_ptr->stock_num;
     store_item_increase(item, -amt);
     store_item_optimize(item);

--- a/src/store/sell-order.c
+++ b/src/store/sell-order.c
@@ -2,7 +2,9 @@
 #include "action/weapon-shield.h"
 #include "autopick/autopick.h"
 #include "core/asking-player.h"
+#include "core/player-update-types.h"
 #include "core/stuff-handler.h"
+#include "core/window-redrawer.h"
 #include "flavor/flavor-describer.h"
 #include "flavor/object-flavor-types.h"
 #include "floor/floor-object.h"
@@ -37,6 +39,7 @@
 #include "view/display-messages.h"
 #include "view/display-store.h"
 #include "view/object-describer.h"
+#include "util/bit-flags-calculator.h"
 #include "world/world.h"
 
 /*!
@@ -297,7 +300,6 @@ void store_sell(player_type *owner_ptr)
                 autopick_alter_item(owner_ptr, item, FALSE);
 
             inven_item_optimize(owner_ptr, item);
-            handle_stuff(owner_ptr);
             int item_pos = store_carry(owner_ptr, q_ptr);
             if (item_pos >= 0) {
                 store_top = (item_pos / store_bottom) * store_bottom;
@@ -324,7 +326,6 @@ void store_sell(player_type *owner_ptr)
         choice = 0;
 
         vary_item(owner_ptr, item, -amt);
-        handle_stuff(owner_ptr);
 
         int item_pos = home_carry(owner_ptr, q_ptr);
         if (item_pos >= 0) {
@@ -336,13 +337,16 @@ void store_sell(player_type *owner_ptr)
         msg_format(_("%sを置いた。(%c)", "You drop %s (%c)."), o_name, index_to_label(item));
         choice = 0;
         vary_item(owner_ptr, item, -amt);
-        handle_stuff(owner_ptr);
         int item_pos = home_carry(owner_ptr, q_ptr);
         if (item_pos >= 0) {
             store_top = (item_pos / store_bottom) * store_bottom;
             display_store_inventory(owner_ptr);
         }
     }
+
+    set_bits(owner_ptr->update, PU_BONUS);
+    set_bits(owner_ptr->window_flags, PW_PLAYER);
+    handle_stuff(owner_ptr);
 
     if ((choice == 0) && (item >= INVEN_MAIN_HAND)) {
         calc_android_exp(owner_ptr);


### PR DESCRIPTION
インベントリアイテム増加時にキャラ情報の更新フラグを立てる。
購入時にmsg_formatが更新フラグを投げ捨てるのでその前にhundle_stuff()を配置。
売却時にmsg_formatが更新フラグを投げ捨てるので最後にフラグを立て直す。
装備を外すときに更新フラグを立てる。