### PR TITLE
[Fix] 自己分析メッセージ中のコスト表示不一致 #388

### DIFF
--- a/src/player-info/class-ability-info.c
+++ b/src/player-info/class-ability-info.c
@@ -9,7 +9,7 @@ void set_class_ability_info(player_type *creature_ptr, self_info_type *self_ptr)
     case CLASS_WARRIOR:
         if (creature_ptr->lev > 39)
             self_ptr->info[self_ptr->line++]
-                = _("あなたはランダムな方向に対して数回攻撃することができる。(75 MP)", "You can attack some random directions simultaneously (cost 75).");
+                = _("あなたはランダムな方向に対して数回攻撃することができる。(75 HP)", "You can attack some random directions simultaneously (cost 75).");
 
         break;
     case CLASS_HIGH_MAGE:
@@ -62,8 +62,8 @@ void set_class_ability_info(player_type *creature_ptr, self_info_type *self_ptr)
         break;
     case CLASS_WARRIOR_MAGE:
         if (creature_ptr->lev > 24) {
-            self_ptr->info[self_ptr->line++] = _("あなたはＨＰをＭＰに変換することができる。(0 MP)", "You can convert HP to SP (cost 0).");
-            self_ptr->info[self_ptr->line++] = _("あなたはＭＰをＨＰに変換することができる。(0 MP)", "You can convert SP to HP (cost 0).");
+            self_ptr->info[self_ptr->line++] = _("あなたはＨＰをＭＰに変換することができる。(消費なし)", "You can convert HP to SP (cost 0).");
+            self_ptr->info[self_ptr->line++] = _("あなたはＭＰをＨＰに変換することができる。(消費なし)", "You can convert SP to HP (cost 0).");
         }
 
         break;
@@ -76,21 +76,23 @@ void set_class_ability_info(player_type *creature_ptr, self_info_type *self_ptr)
         break;
     case CLASS_MONK:
         if (creature_ptr->lev > 24)
-            self_ptr->info[self_ptr->line++] = _("あなたは構えることができる。(0 MP)", "You can assume a special stance (cost 0).");
+            self_ptr->info[self_ptr->line++] = _("あなたは構えることができる。(消費なし)", "You can assume a special stance (cost 0).");
 
         if (creature_ptr->lev > 29)
-            self_ptr->info[self_ptr->line++] = _("あなたは通常の2倍の攻撃を行うことができる。(30 MP)", "You can perform two attacks at the same time (cost 30).");
+            self_ptr->info[self_ptr->line++]
+                = _("あなたは通常の2倍の攻撃を行うことができる。(30 MP)", "You can perform two attacks at the same time (cost 30).");
 
         break;
     case CLASS_MINDCRAFTER:
     case CLASS_FORCETRAINER:
         if (creature_ptr->lev > 14)
             self_ptr->info[self_ptr->line++]
-                = _("あなたは精神を集中してＭＰを回復させることができる。(0 MP)", "You can concentrate to regenerate your mana (cost 0).");
+                = _("あなたは精神を集中してＭＰを回復させることができる。(消費なし)", "You can concentrate to regenerate your mana (cost 0).");
 
         break;
     case CLASS_TOURIST:
-        self_ptr->info[self_ptr->line++] = _("あなたは写真を撮影することができる。(0 MP)", "You can take a photograph (cost 0).");
+        self_ptr->info[self_ptr->line++] = _("あなたは写真を撮影することができる。(消費なし)", "You can take a photograph (cost 0).");
+
         if (creature_ptr->lev > 24)
             self_ptr->info[self_ptr->line++] = _("あなたはアイテムを完全に鑑定することができる。(20 MP)", "You can *identify* items (cost 20).");
 
@@ -103,14 +105,21 @@ void set_class_ability_info(player_type *creature_ptr, self_info_type *self_ptr)
         break;
     case CLASS_BEASTMASTER:
         self_ptr->info[self_ptr->line++]
-            = _("あなたは1体の生命のあるモンスターを支配することができる。(レベル/4 MP)", "You can dominate a monster (cost level/4).");
+            = _("あなたは1体の生命のあるモンスターを支配することができる。((レベル+3)/4 MP)", "You can dominate a monster (cost (level+3)/4).");
+
         if (creature_ptr->lev > 29)
             self_ptr->info[self_ptr->line++] = _("あなたは視界内の生命のあるモンスターを支配することができる。((レベル+20)/2 MP)",
                 "You can dominate living monsters in sight (cost (level+20)/2).");
 
         break;
     case CLASS_MAGIC_EATER:
-        self_ptr->info[self_ptr->line++] = _("あなたは杖/魔法棒/ロッドの魔力を自分のものにすることができる。", "You can absorb a staff, wand or rod itself.");
+        self_ptr->info[self_ptr->line++]
+            = _("あなたは杖/魔法棒/ロッドの魔力を自分のものにすることができる。(消費なし)", "You can absorb a staff, wand or rod itself (cost 0).");
+
+        if (creature_ptr->lev > 9)
+            self_ptr->info[self_ptr->line++] = _("あなたは杖/魔法棒/ロッドの魔力を強力に発動することができる。(10+(レベル-10)/2 HP)",
+                "You can powerfully activate a staff, wand or rod (cost 10+(level-10)/2).");
+
         break;
     case CLASS_RED_MAGE:
         if (creature_ptr->lev > 47)
@@ -118,32 +127,41 @@ void set_class_ability_info(player_type *creature_ptr, self_info_type *self_ptr)
 
         break;
     case CLASS_SAMURAI:
-        self_ptr->info[self_ptr->line++] = _("あなたは精神を集中して気合いを溜めることができる。", "You can concentrate to regenerate your mana.");
+        self_ptr->info[self_ptr->line++]
+            = _("あなたは精神を集中して気合いを溜めることができる。(消費なし)", "You can concentrate to regenerate your mana (cost 0).");
+
         if (creature_ptr->lev > 24)
-            self_ptr->info[self_ptr->line++] = _("あなたは特殊な型で構えることができる。", "You can assume a special stance.");
+            self_ptr->info[self_ptr->line++] = _("あなたは特殊な型で構えることができる。(消費なし)", "You can assume a special stance (cost 0).");
 
         break;
     case CLASS_BLUE_MAGE:
-        self_ptr->info[self_ptr->line++] = _("あなたは相手に使われた魔法を学ぶことができる。", "You can study spells which your enemy casts on you.");
+        self_ptr->info[self_ptr->line++]
+            = _("あなたは相手に使われた魔法を学ぶことができる。(消費なし)", "You can study spells which your enemy casts on you (cost 0).");
         break;
     case CLASS_CAVALRY:
         if (creature_ptr->lev > 9)
-            self_ptr->info[self_ptr->line++]
-                = _("あなたはモンスターに乗って無理矢理ペットにすることができる。", "You can ride on a hostile monster to forcibly turn it into a pet.");
+            self_ptr->info[self_ptr->line++] = _("あなたはモンスターに乗って無理矢理ペットにすることができる。(消費なし)",
+                "You can ride on a hostile monster to forcibly turn it into a pet  (cost 0).");
 
         break;
     case CLASS_BERSERKER:
         if (creature_ptr->lev > 9)
-            self_ptr->info[self_ptr->line++] = _("あなたは街とダンジョンの間を行き来することができる。", "You can travel between town and the depths.");
+            self_ptr->info[self_ptr->line++]
+                = _("あなたは街とダンジョンの間を行き来することができる。(10 HP)", "You can travel between town and the depths (cost 10).");
+
+        break;
+    case CLASS_SMITH:
+        if (creature_ptr->lev > 4)
+            self_ptr->info[self_ptr->line++] = _("あなたは武器や防具を鑑定することができる。(15 HP)", "You can identify weapons or armours (cost 15).");
 
         break;
     case CLASS_MIRROR_MASTER:
         self_ptr->info[self_ptr->line++] = _("あなたは鏡を作り出すことができる。(2 MP)", "You can create a Mirror (cost 2).");
-        self_ptr->info[self_ptr->line++] = _("あなたは鏡を割ることができる。(0 MP)", "You can break distant Mirrors (cost 0).");
+        self_ptr->info[self_ptr->line++] = _("あなたは鏡を割ることができる。(消費なし)", "You can break distant Mirrors (cost 0).");
         break;
     case CLASS_NINJA:
         if (creature_ptr->lev > 19)
-            self_ptr->info[self_ptr->line++] = _("あなたは素早く移動することができる。", "You can walk extremely fast.");
+            self_ptr->info[self_ptr->line++] = _("あなたは素早く移動することができる。(消費なし)", "You can walk extremely fast (cost 0).");
 
         break;
     }


### PR DESCRIPTION
魔獣使いの生物支配の真の消費MPが(level+3)/4であることを確認し、自己分析で表示されるメッセージを修正した。
加えて他の職業能力のメッセージも確認と修正を行なった。
・消費なしの表記がブレていた。(消費なし)で統一。
・MPのないクラスの表記を(X HP)で統一。
・魔道具術師の強力発動の説明を追加。
・鍛冶師の目利きの説明を追加。