### PR TITLE
[Feature] モンスターの思い出で打撃を手段や効果で色分けする

### DIFF
--- a/src/lore/combat-types-setter.c
+++ b/src/lore/combat-types-setter.c
@@ -1,41 +1,51 @@
 ﻿#include "lore/combat-types-setter.h"
 #include "monster-attack/monster-attack-effect.h"
 #include "monster-attack/monster-attack-types.h"
+#include "term/term-color-types.h"
 
 void set_monster_blow_method(lore_type *lore_ptr, int m)
 {
     rbm_type method = lore_ptr->r_ptr->blow[m].method;
     lore_ptr->p = NULL;
+    lore_ptr->pc = TERM_WHITE;
     switch (method) {
     case RBM_HIT:
         lore_ptr->p = _("殴る", "hit");
+        lore_ptr->pc = TERM_L_WHITE;
         break;
     case RBM_TOUCH:
         lore_ptr->p = _("触る", "touch");
         break;
     case RBM_PUNCH:
         lore_ptr->p = _("パンチする", "punch");
+        lore_ptr->pc = TERM_L_WHITE;
         break;
     case RBM_KICK:
         lore_ptr->p = _("蹴る", "kick");
+        lore_ptr->pc = TERM_L_WHITE;
         break;
     case RBM_CLAW:
         lore_ptr->p = _("ひっかく", "claw");
+        lore_ptr->pc = TERM_L_UMBER;
         break;
     case RBM_BITE:
         lore_ptr->p = _("噛む", "bite");
+        lore_ptr->pc = TERM_L_UMBER;
         break;
     case RBM_STING:
         lore_ptr->p = _("刺す", "sting");
         break;
     case RBM_SLASH:
         lore_ptr->p = _("斬る", "slash");
+        lore_ptr->pc = TERM_L_UMBER;
         break;
     case RBM_BUTT:
         lore_ptr->p = _("角で突く", "butt");
+        lore_ptr->pc = TERM_L_WHITE;
         break;
     case RBM_CRUSH:
         lore_ptr->p = _("体当たりする", "crush");
+        lore_ptr->pc = TERM_L_WHITE;
         break;
     case RBM_ENGULF:
         lore_ptr->p = _("飲み込む", "engulf");
@@ -48,35 +58,45 @@ void set_monster_blow_method(lore_type *lore_ptr, int m)
         break;
     case RBM_DROOL:
         lore_ptr->p = _("よだれをたらす", "drool on you");
+        lore_ptr->pc = TERM_SLATE;
         break;
     case RBM_SPIT:
         lore_ptr->p = _("つばを吐く", "spit");
+        lore_ptr->pc = TERM_SLATE;
         break;
     case RBM_EXPLODE:
         lore_ptr->p = _("爆発する", "explode");
+        lore_ptr->pc = TERM_L_BLUE;
         break;
     case RBM_GAZE:
         lore_ptr->p = _("にらむ", "gaze");
+        lore_ptr->pc = TERM_SLATE;
         break;
     case RBM_WAIL:
         lore_ptr->p = _("泣き叫ぶ", "wail");
+        lore_ptr->pc = TERM_SLATE;
         break;
     case RBM_SPORE:
         lore_ptr->p = _("胞子を飛ばす", "release spores");
+        lore_ptr->pc = TERM_SLATE;
         break;
     case RBM_XXX4:
         break;
     case RBM_BEG:
         lore_ptr->p = _("金をせがむ", "beg");
+        lore_ptr->pc = TERM_SLATE;
         break;
     case RBM_INSULT:
         lore_ptr->p = _("侮辱する", "insult");
+        lore_ptr->pc = TERM_SLATE;
         break;
     case RBM_MOAN:
         lore_ptr->p = _("うめく", "moan");
+        lore_ptr->pc = TERM_SLATE;
         break;
     case RBM_SHOW:
         lore_ptr->p = _("歌う", "sing");
+        lore_ptr->pc = TERM_SLATE;
         break;
     }
 }
@@ -85,111 +105,146 @@ void set_monster_blow_effect(lore_type *lore_ptr, int m)
 {
     rbe_type effect = lore_ptr->r_ptr->blow[m].effect;
     lore_ptr->q = NULL;
+    lore_ptr->qc = TERM_WHITE;
     switch (effect) {
     case RBE_SUPERHURT:
         lore_ptr->q = _("強力に攻撃する", "slaughter");
+        lore_ptr->qc = TERM_L_RED;
         break;
     case RBE_HURT:
         lore_ptr->q = _("攻撃する", "attack");
         break;
     case RBE_POISON:
         lore_ptr->q = _("毒をくらわす", "poison");
+        lore_ptr->qc = TERM_L_GREEN;
         break;
     case RBE_UN_BONUS:
         lore_ptr->q = _("劣化させる", "disenchant");
+        lore_ptr->qc = TERM_VIOLET;
         break;
     case RBE_UN_POWER:
         lore_ptr->q = _("充填魔力を吸収する", "drain charges");
+        lore_ptr->qc = TERM_SLATE;
         break;
     case RBE_EAT_GOLD:
         lore_ptr->q = _("金を盗む", "steal gold");
+        lore_ptr->qc = TERM_YELLOW;
         break;
     case RBE_EAT_ITEM:
         lore_ptr->q = _("アイテムを盗む", "steal items");
+        lore_ptr->qc = TERM_UMBER;
         break;
     case RBE_EAT_FOOD:
         lore_ptr->q = _("あなたの食料を食べる", "eat your food");
+        lore_ptr->qc = TERM_L_UMBER;
         break;
     case RBE_EAT_LITE:
         lore_ptr->q = _("明かりを吸収する", "absorb light");
+        lore_ptr->qc = TERM_YELLOW;
         break;
     case RBE_ACID:
         lore_ptr->q = _("酸を飛ばす", "shoot acid");
+        lore_ptr->qc = TERM_GREEN;
         break;
     case RBE_ELEC:
         lore_ptr->q = _("感電させる", "electrocute");
+        lore_ptr->qc = TERM_BLUE;
         break;
     case RBE_FIRE:
         lore_ptr->q = _("燃やす", "burn");
+        lore_ptr->qc = TERM_RED;
         break;
     case RBE_COLD:
         lore_ptr->q = _("凍らせる", "freeze");
+        lore_ptr->qc = TERM_L_WHITE;
         break;
     case RBE_BLIND:
         lore_ptr->q = _("盲目にする", "blind");
+        lore_ptr->qc = TERM_L_DARK;
         break;
     case RBE_CONFUSE:
         lore_ptr->q = _("混乱させる", "confuse");
+        lore_ptr->qc = TERM_L_UMBER;
         break;
     case RBE_TERRIFY:
         lore_ptr->q = _("恐怖させる", "terrify");
+        lore_ptr->qc = TERM_SLATE;
         break;
     case RBE_PARALYZE:
         lore_ptr->q = _("麻痺させる", "paralyze");
+        lore_ptr->qc = TERM_BLUE;
         break;
     case RBE_LOSE_STR:
         lore_ptr->q = _("腕力を減少させる", "reduce strength");
+        lore_ptr->qc = TERM_L_GREEN;
         break;
     case RBE_LOSE_INT:
         lore_ptr->q = _("知能を減少させる", "reduce intelligence");
+        lore_ptr->qc = TERM_L_GREEN;
         break;
     case RBE_LOSE_WIS:
         lore_ptr->q = _("賢さを減少させる", "reduce wisdom");
+        lore_ptr->qc = TERM_L_GREEN;
         break;
     case RBE_LOSE_DEX:
         lore_ptr->q = _("器用さを減少させる", "reduce dexterity");
+        lore_ptr->qc = TERM_L_GREEN;
         break;
     case RBE_LOSE_CON:
         lore_ptr->q = _("耐久力を減少させる", "reduce constitution");
+        lore_ptr->qc = TERM_L_GREEN;
         break;
     case RBE_LOSE_CHR:
         lore_ptr->q = _("魅力を減少させる", "reduce charisma");
+        lore_ptr->qc = TERM_L_GREEN;
         break;
     case RBE_LOSE_ALL:
         lore_ptr->q = _("全ステータスを減少させる", "reduce all stats");
+        lore_ptr->qc = TERM_L_GREEN;
         break;
     case RBE_SHATTER:
         lore_ptr->q = _("粉砕する", "shatter");
+        lore_ptr->qc = TERM_SLATE;
         break;
     case RBE_EXP_10:
         lore_ptr->q = _("経験値を減少(10d6+)させる", "lower experience (by 10d6+)");
+        lore_ptr->qc = TERM_L_BLUE;
         break;
     case RBE_EXP_20:
         lore_ptr->q = _("経験値を減少(20d6+)させる", "lower experience (by 20d6+)");
+        lore_ptr->qc = TERM_L_BLUE;
         break;
     case RBE_EXP_40:
         lore_ptr->q = _("経験値を減少(40d6+)させる", "lower experience (by 40d6+)");
+        lore_ptr->qc = TERM_L_BLUE;
         break;
     case RBE_EXP_80:
         lore_ptr->q = _("経験値を減少(80d6+)させる", "lower experience (by 80d6+)");
+        lore_ptr->qc = TERM_L_BLUE;
         break;
     case RBE_DISEASE:
         lore_ptr->q = _("病気にする", "disease");
+        lore_ptr->qc = TERM_L_GREEN;
         break;
     case RBE_TIME:
         lore_ptr->q = _("時間を逆戻りさせる", "time");
+        lore_ptr->qc = TERM_L_BLUE;
         break;
     case RBE_DR_LIFE:
         lore_ptr->q = _("生命力を吸収する", "drain life");
+        lore_ptr->qc = TERM_L_BLUE;
         break;
     case RBE_DR_MANA:
         lore_ptr->q = _("魔力を奪う", "drain mana force");
+        lore_ptr->qc = TERM_SLATE;
         break;
     case RBE_INERTIA:
         lore_ptr->q = _("減速させる", "slow");
+        lore_ptr->qc = TERM_UMBER;
         break;
     case RBE_STUN:
         lore_ptr->q = _("朦朧とさせる", "stun");
+        lore_ptr->qc = TERM_ORANGE;
         break;
     case RBE_FLAVOR:
         // フレーバー打撃には何の効果もないので付加説明もない。

--- a/src/lore/lore-util.h
+++ b/src/lore/lore-util.h
@@ -43,7 +43,9 @@ typedef struct lore_type {
     int drop_quantity;
     concptr drop_quality;
     concptr p;
+    byte pc;
     concptr q;
+    byte qc;
     rbm_type method;
     int count;
 } lore_type;

--- a/src/lore/monster-lore.c
+++ b/src/lore/monster-lore.c
@@ -209,6 +209,6 @@ void process_monster_lore(player_type *player_ptr, MONRACE_IDX r_idx, monster_lo
     display_monster_immunities(lore_ptr);
     display_monster_alert(lore_ptr);
     display_monster_drops(lore_ptr);
-    display_monster_attacks(lore_ptr);
+    display_monster_blows(lore_ptr);
     display_monster_guardian(lore_ptr);
 }

--- a/src/view/display-lore-attacks.c
+++ b/src/view/display-lore-attacks.c
@@ -3,6 +3,7 @@
 #include "lore/lore-calculator.h"
 #include "monster-attack/monster-attack-types.h"
 #include "monster-race/race-flags1.h"
+#include "term/term-color-types.h"
 #ifdef JP
 #include "locale/japanese.h"
 #endif
@@ -15,12 +16,14 @@ static void display_monster_blows_jp(lore_type *lore_ptr, int attack_numbers, in
     }
 
     if (d1 && d2 && (lore_ptr->know_everything || know_damage(lore_ptr->r_idx, m))) {
-        hooked_roff(format(" %dd%d ", d1, d2));
+        hook_c_roff(TERM_L_WHITE, format(" %dd%d ", d1, d2));
         hooked_roff("のダメージで");
     }
 
-    if (!lore_ptr->p)
+    if (!lore_ptr->p) {
         lore_ptr->p = "何か奇妙なことをする";
+        lore_ptr->pc = TERM_VIOLET;
+    }
 
     /* XXしてYYし/XXしてYYする/XXし/XXする */
     if (lore_ptr->q != NULL)
@@ -30,13 +33,15 @@ static void display_monster_blows_jp(lore_type *lore_ptr, int attack_numbers, in
     else
         strcpy(lore_ptr->jverb_buf, lore_ptr->p);
 
-    hooked_roff(lore_ptr->jverb_buf);
+    hook_c_roff(lore_ptr->pc, lore_ptr->jverb_buf);
+
     if (lore_ptr->q) {
         if (attack_numbers != lore_ptr->count - 1)
             jverb(lore_ptr->q, lore_ptr->jverb_buf, JVERB_AND);
         else
             strcpy(lore_ptr->jverb_buf, lore_ptr->q);
-        hooked_roff(lore_ptr->jverb_buf);
+
+        hook_c_roff(lore_ptr->qc, lore_ptr->jverb_buf);
     }
 
     if (attack_numbers != lore_ptr->count - 1)
@@ -54,16 +59,18 @@ static void display_monster_blows_en(lore_type *lore_ptr, int attack_numbers, in
         hooked_roff(", and ");
     }
 
-    if (lore_ptr->p == NULL)
+    if (lore_ptr->p == NULL) {
         lore_ptr->p = "do something weird";
+        lore_ptr->pc = TERM_VIOLET;
+    }
 
-    hooked_roff(lore_ptr->p);
+    hook_c_roff(lore_ptr->pc, lore_ptr->p);
     if (lore_ptr->q != NULL) {
         hooked_roff(" to ");
-        hooked_roff(lore_ptr->q);
+        hook_c_roff(lore_ptr->qc, lore_ptr->q);
         if (d1 && d2 && (lore_ptr->know_everything || know_damage(lore_ptr->r_idx, m))) {
             hooked_roff(" with damage");
-            hooked_roff(format(" %dd%d", d1, d2));
+            hook_c_roff(TERM_L_WHITE, format(" %dd%d", d1, d2));
         }
     }
 }

--- a/src/view/display-lore-attacks.c
+++ b/src/view/display-lore-attacks.c
@@ -9,7 +9,16 @@
 #endif
 
 #ifdef JP
-static void display_monster_blows_jp(lore_type *lore_ptr, int attack_numbers, int d1, int d2, int m)
+/*!
+ * @brief [日本語]モンスター打撃の1回分を出力する
+ * @param lore_ptr 思い出情報へのポインタ
+ * @param attack_numbers 打撃の最大回数
+ * @param d1 ダメージダイス数
+ * @param d2 ダメージダイス面
+ * @param m 打撃の何番目か
+ * @return なし
+ */
+static void display_monster_blow_jp(lore_type *lore_ptr, int attack_numbers, int d1, int d2, int m)
 {
     if (attack_numbers == 0) {
         hooked_roff(format("%^sは", wd_he[lore_ptr->msex]));
@@ -48,8 +57,16 @@ static void display_monster_blows_jp(lore_type *lore_ptr, int attack_numbers, in
         hooked_roff("、");
 }
 #else
-
-static void display_monster_blows_en(lore_type *lore_ptr, int attack_numbers, int d1, int d2, int m)
+/*!
+ * @brief [英語]モンスター打撃の1回分を出力する
+ * @param lore_ptr 思い出情報へのポインタ
+ * @param attack_numbers 打撃の最大回数
+ * @param d1 ダメージダイス数
+ * @param d2 ダメージダイス面
+ * @param m 打撃の何番目か
+ * @return なし
+ */
+static void display_monster_blow_en(lore_type *lore_ptr, int attack_numbers, int d1, int d2, int m)
 {
     if (attack_numbers == 0) {
         hooked_roff(format("%^s can ", wd_he[lore_ptr->msex]));
@@ -76,15 +93,27 @@ static void display_monster_blows_en(lore_type *lore_ptr, int attack_numbers, in
 }
 #endif
 
-void display_monster_blows(lore_type *lore_ptr, int m, int attack_numbers)
+/*!
+ * @brief モンスター打撃の1回分を出力する(日英切替への踏み台)
+ * @param lore_ptr 思い出情報へのポインタ
+ * @param m 打撃の何番目か
+ * @param attack_numbers 打撃の最大回数
+ * @return なし
+ */
+void display_monster_blow(lore_type *lore_ptr, int m, int attack_numbers)
 {
     int d1 = lore_ptr->r_ptr->blow[m].d_dice;
     int d2 = lore_ptr->r_ptr->blow[m].d_side;
-    void (*display_monster_blows_pf)(lore_type *, int, int, int, int) = _(display_monster_blows_jp, display_monster_blows_en);
+    void (*display_monster_blows_pf)(lore_type *, int, int, int, int) = _(display_monster_blow_jp, display_monster_blow_en);
     (*display_monster_blows_pf)(lore_ptr, attack_numbers, d1, d2, m);
 }
 
-void display_monster_attacks(lore_type *lore_ptr)
+/*!
+ * @brief モンスターの思い出に打撃に関する情報を出力する
+ * @param lore_ptr 思い出情報へのポインタ
+ * @return なし
+ */
+void display_monster_blows(lore_type *lore_ptr)
 {
     const int max_attack_numbers = 4;
     for (int m = 0; m < max_attack_numbers; m++) {
@@ -103,7 +132,7 @@ void display_monster_attacks(lore_type *lore_ptr)
 
         set_monster_blow_method(lore_ptr, m);
         set_monster_blow_effect(lore_ptr, m);
-        display_monster_blows(lore_ptr, m, attack_numbers);
+        display_monster_blow(lore_ptr, m, attack_numbers);
         attack_numbers++;
     }
 

--- a/src/view/display-lore-attacks.h
+++ b/src/view/display-lore-attacks.h
@@ -3,5 +3,4 @@
 #include "system/angband.h"
 #include "lore/lore-util.h"
 
-void display_monster_blows(lore_type *lore_ptr, int m, int attack_numbers);
-void display_monster_attacks(lore_type *lore_ptr);
+void display_monster_blows(lore_type *lore_ptr);


### PR DESCRIPTION
手段は、朦朧あり、切傷あり、接触なし、その他で色分け。
効果は、ブレス・呪文の色を参考に色分け。