### PR TITLE
[Fix] デバグ自動セーブの直後にいろんな情報を再計算/表示してしまう

### DIFF
--- a/src/save/save.c
+++ b/src/save/save.c
@@ -298,7 +298,7 @@ bool save_player(player_type *player_ptr, save_type type)
         result = TRUE;
     }
 
-    if (type != SAVE_TYPE_CLOSE_GAME) {
+    if (type == SAVE_TYPE_CONTINUE_GAME) {
         current_world_ptr->is_loading_now = FALSE;
         update_creature(player_ptr);
         mproc_init(player_ptr->current_floor_ptr);


### PR DESCRIPTION
本来後のタイミングで実行されるべきhandle_stuff()が実行されていたため、余計な再計算やデータの切り詰め、再表示がデバグ自動セーブ時に発生していたので、終了セーブ時と同様に実行しないようにした。

エルドリッチホラー時にモンスターの位置が1マスずれる問題(#330)の調査中に発見。