### PR TITLE
[refactor] repair_monstersフラグの削除

### DIFF
--- a/src/dungeon/dungeon-processor.c
+++ b/src/dungeon/dungeon-processor.c
@@ -69,7 +69,6 @@ void process_dungeon(player_type *player_ptr, bool load_game)
     player_ptr->riding_t_m_idx = 0;
     player_ptr->ambush_flag = FALSE;
     health_track(player_ptr, 0);
-    repair_monsters = TRUE;
 
     disturb(player_ptr, TRUE, TRUE);
     int quest_num = quest_num = quest_number(player_ptr, floor_ptr->dun_level);

--- a/src/floor/floor-changer.c
+++ b/src/floor/floor-changer.c
@@ -110,7 +110,6 @@ static void set_pet_params(player_type *master_ptr, monster_race **r_ptr, const 
     m_ptr->target_y = 0;
     if (((*r_ptr)->flags1 & RF1_PREVENT_SUDDEN_MAGIC) && !ironman_nightmare) {
         m_ptr->mflag |= MFLAG_PREVENT_MAGIC;
-        repair_monsters = TRUE;
     }
 }
 

--- a/src/floor/floor-save-util.c
+++ b/src/floor/floor-save-util.c
@@ -6,7 +6,6 @@
  */
 u32b saved_floor_file_sign;
 saved_floor_type saved_floors[MAX_SAVED_FLOORS];
-bool repair_monsters;
 FLOOR_IDX max_floor_id; /*!< Number of floor_id used from birth */
 FLOOR_IDX new_floor_id; /*!<次のフロアのID / floor_id of the destination */
 u32b latest_visit_mark; /*!<フロアを渡った回数？(確認中) / Max number of visit_mark */

--- a/src/floor/floor-save-util.h
+++ b/src/floor/floor-save-util.h
@@ -18,7 +18,6 @@ typedef struct saved_floor_type {
 
 extern u32b saved_floor_file_sign;
 extern saved_floor_type saved_floors[MAX_SAVED_FLOORS];
-extern bool repair_monsters;
 extern FLOOR_IDX max_floor_id;
 
 extern FLOOR_IDX new_floor_id;

--- a/src/monster-floor/one-monster-placer.c
+++ b/src/monster-floor/one-monster-placer.c
@@ -359,7 +359,6 @@ bool place_monster_one(player_type *player_ptr, MONSTER_IDX who, POSITION y, POS
 
     if ((r_ptr->flags1 & RF1_PREVENT_SUDDEN_MAGIC) && !ironman_nightmare) {
         m_ptr->mflag |= (MFLAG_PREVENT_MAGIC);
-        repair_monsters = TRUE;
     }
 
     if (g_ptr->m_idx < hack_m_idx) {

--- a/src/spell-kind/spells-detection.c
+++ b/src/spell-kind/spells-detection.c
@@ -322,7 +322,6 @@ bool detect_monsters_normal(player_type *caster_ptr, POSITION range)
             continue;
 
         if (!(r_ptr->flags2 & RF2_INVISIBLE) || caster_ptr->see_inv) {
-            repair_monsters = TRUE;
             m_ptr->mflag2 |= (MFLAG2_MARK | MFLAG2_SHOW);
             update_monster(caster_ptr, i, FALSE);
             flag = TRUE;
@@ -368,7 +367,6 @@ bool detect_monsters_invis(player_type *caster_ptr, POSITION range)
                 caster_ptr->window_flags |= (PW_MONSTER);
             }
 
-            repair_monsters = TRUE;
             m_ptr->mflag2 |= (MFLAG2_MARK | MFLAG2_SHOW);
             update_monster(caster_ptr, i, FALSE);
             flag = TRUE;
@@ -416,7 +414,6 @@ bool detect_monsters_evil(player_type *caster_ptr, POSITION range)
                 }
             }
 
-            repair_monsters = TRUE;
             m_ptr->mflag2 |= (MFLAG2_MARK | MFLAG2_SHOW);
             update_monster(caster_ptr, i, FALSE);
             flag = TRUE;
@@ -457,7 +454,6 @@ bool detect_monsters_nonliving(player_type *caster_ptr, POSITION range)
                 caster_ptr->window_flags |= (PW_MONSTER);
             }
 
-            repair_monsters = TRUE;
             m_ptr->mflag2 |= (MFLAG2_MARK | MFLAG2_SHOW);
             update_monster(caster_ptr, i, FALSE);
             flag = TRUE;
@@ -500,7 +496,6 @@ bool detect_monsters_mind(player_type *caster_ptr, POSITION range)
                 caster_ptr->window_flags |= (PW_MONSTER);
             }
 
-            repair_monsters = TRUE;
             m_ptr->mflag2 |= (MFLAG2_MARK | MFLAG2_SHOW);
             update_monster(caster_ptr, i, FALSE);
             flag = TRUE;
@@ -544,7 +539,6 @@ bool detect_monsters_string(player_type *caster_ptr, POSITION range, concptr Mat
                 caster_ptr->window_flags |= (PW_MONSTER);
             }
 
-            repair_monsters = TRUE;
             m_ptr->mflag2 |= (MFLAG2_MARK | MFLAG2_SHOW);
             update_monster(caster_ptr, i, FALSE);
             flag = TRUE;
@@ -593,7 +587,6 @@ bool detect_monsters_xxx(player_type *caster_ptr, POSITION range, u32b match_fla
                 }
             }
 
-            repair_monsters = TRUE;
             m_ptr->mflag2 |= (MFLAG2_MARK | MFLAG2_SHOW);
             update_monster(caster_ptr, i, FALSE);
             flag = TRUE;


### PR DESCRIPTION
プレイヤーの行動処理中に一時的にモンスターにフラグを
設定しておき、プレイヤーの行動後にまとめてモンスターの
処理を行う時に、この処理が必要かどうかを設定する
repair_monstersというグローバル変数のフラグがある。
しかし、このフラグが設定されていない場合に軽減できる
処理は雀の涙程度のものでしかなく、しかも今後同様の
モンスターをフラグを立てておくような処理を追加する
たびに、そのすべての場所でrepair_monstersをTRUEに
設定する必要がある。
はっきり言ってコストにリターンが見合っていないので
repair_monstersを削除する。