### PR TITLE
[Refactor] get_player_flags()を整理

### DIFF
--- a/src/player/player-status-flags.c
+++ b/src/player/player-status-flags.c
@@ -12,6 +12,7 @@
 #include "object-hook/hook-checker.h"
 #include "object-hook/hook-weapon.h"
 #include "object/object-flags.h"
+#include "player/attack-defense-types.h"
 #include "player/mimic-info-table.h"
 #include "player/player-class.h"
 #include "player/player-race-types.h"
@@ -88,6 +89,56 @@ static BIT_FLAGS check_equipment_flags(player_type *creature_ptr, tr_type tr_fla
     return result;
 }
 
+BIT_FLAGS player_flags_brand_pois(player_type *creature_ptr)
+{
+    BIT_FLAGS result = check_equipment_flags(creature_ptr, TR_BRAND_POIS);
+
+    if (creature_ptr->special_attack & ATTACK_POIS)
+        set_bits(result, FLAG_CAUSE_MAGIC_TIME_EFFECT);
+
+    return result;
+}
+
+BIT_FLAGS player_flags_brand_acid(player_type *creature_ptr)
+{
+    BIT_FLAGS result = check_equipment_flags(creature_ptr, TR_BRAND_ACID);
+
+    if (creature_ptr->special_attack & ATTACK_ACID)
+        set_bits(result, FLAG_CAUSE_MAGIC_TIME_EFFECT);
+
+    return result;
+}
+
+BIT_FLAGS player_flags_brand_elec(player_type *creature_ptr)
+{
+    BIT_FLAGS result = check_equipment_flags(creature_ptr, TR_BRAND_ELEC);
+
+    if (creature_ptr->special_attack & ATTACK_ELEC)
+        set_bits(result, FLAG_CAUSE_MAGIC_TIME_EFFECT);
+
+    return result;
+}
+
+BIT_FLAGS player_flags_brand_fire(player_type *creature_ptr)
+{
+    BIT_FLAGS result = check_equipment_flags(creature_ptr, TR_BRAND_FIRE);
+
+    if (creature_ptr->special_attack & ATTACK_FIRE)
+        set_bits(result, FLAG_CAUSE_MAGIC_TIME_EFFECT);
+
+    return result;
+}
+
+BIT_FLAGS player_flags_brand_cold(player_type *creature_ptr)
+{
+    BIT_FLAGS result = check_equipment_flags(creature_ptr, TR_BRAND_COLD);
+
+    if (creature_ptr->special_attack & ATTACK_COLD)
+        set_bits(result, FLAG_CAUSE_MAGIC_TIME_EFFECT);
+
+    return result;
+}
+
 /*!
  * @brief プレイヤーの所持するフラグのうち、tr_flagに対応するものを返す
  * @param creature_ptr 判定対象のクリーチャー参照ポインタ
@@ -111,7 +162,7 @@ BIT_FLAGS get_player_flags(player_type *creature_ptr, tr_type tr_flag)
     case TR_MAGIC_MASTERY:
         return has_magic_mastery(creature_ptr);
     case TR_FORCE_WEAPON:
-        return 0;
+        return check_equipment_flags(creature_ptr, tr_flag);
     case TR_STEALTH:
         return 0;
     case TR_SEARCH:
@@ -125,41 +176,30 @@ BIT_FLAGS get_player_flags(player_type *creature_ptr, tr_type tr_flag)
     case TR_BLOWS:
         return 0;
     case TR_CHAOTIC:
-        return 0;
     case TR_VAMPIRIC:
-        return 0;
     case TR_SLAY_ANIMAL:
-        return 0;
     case TR_SLAY_EVIL:
-        return 0;
     case TR_SLAY_UNDEAD:
-        return 0;
     case TR_SLAY_DEMON:
-        return 0;
     case TR_SLAY_ORC:
-        return 0;
     case TR_SLAY_TROLL:
-        return 0;
     case TR_SLAY_GIANT:
-        return 0;
     case TR_SLAY_DRAGON:
-        return 0;
     case TR_KILL_DRAGON:
-        return 0;
     case TR_VORPAL:
-        return 0;
+        return check_equipment_flags(creature_ptr, tr_flag);
     case TR_IMPACT:
         return has_impact(creature_ptr);
     case TR_BRAND_POIS:
-        return 0;
+        return player_flags_brand_pois(creature_ptr);
     case TR_BRAND_ACID:
-        return 0;
+        return player_flags_brand_acid(creature_ptr);
     case TR_BRAND_ELEC:
-        return 0;
+        return player_flags_brand_elec(creature_ptr);
     case TR_BRAND_FIRE:
-        return 0;
+        return player_flags_brand_fire(creature_ptr);
     case TR_BRAND_COLD:
-        return 0;
+        return player_flags_brand_cold(creature_ptr);
 
     case TR_SUST_STR:
         return has_sustain_str(creature_ptr);
@@ -174,7 +214,7 @@ BIT_FLAGS get_player_flags(player_type *creature_ptr, tr_type tr_flag)
     case TR_SUST_CHR:
         return has_sustain_chr(creature_ptr);
     case TR_RIDING:
-        return 0;
+        return check_equipment_flags(creature_ptr, tr_flag);
     case TR_EASY_SPELL:
         return has_easy_spell(creature_ptr);
     case TR_IM_ACID:
@@ -186,7 +226,7 @@ BIT_FLAGS get_player_flags(player_type *creature_ptr, tr_type tr_flag)
     case TR_IM_COLD:
         return has_immune_cold(creature_ptr);
     case TR_THROW:
-        return 0;
+        return check_equipment_flags(creature_ptr, tr_flag);
     case TR_REFLECT:
         return has_reflect(creature_ptr);
     case TR_FREE_ACT:
@@ -231,7 +271,7 @@ BIT_FLAGS get_player_flags(player_type *creature_ptr, tr_type tr_flag)
     case TR_SH_ELEC:
         return has_sh_elec(creature_ptr);
     case TR_SLAY_HUMAN:
-        return 0;
+        return check_equipment_flags(creature_ptr, tr_flag);
     case TR_SH_COLD:
         return has_sh_cold(creature_ptr);
     case TR_NO_TELE:
@@ -241,13 +281,12 @@ BIT_FLAGS get_player_flags(player_type *creature_ptr, tr_type tr_flag)
     case TR_DEC_MANA:
         return has_dec_mana(creature_ptr);
     case TR_TY_CURSE:
-        return 0;
+        return check_equipment_flags(creature_ptr, tr_flag);
     case TR_WARNING:
         return has_warning(creature_ptr);
     case TR_HIDE_TYPE:
-        return 0;
     case TR_SHOW_MODS:
-        return 0;
+        return check_equipment_flags(creature_ptr, tr_flag);
     case TR_SLAY_GOOD:
         return 0;
     case TR_LEVITATION:
@@ -265,48 +304,30 @@ BIT_FLAGS get_player_flags(player_type *creature_ptr, tr_type tr_flag)
     case TR_XTRA_MIGHT:
         return has_xtra_might(creature_ptr);
     case TR_XTRA_SHOTS:
-        return 0;
     case TR_IGNORE_ACID:
-        return 0;
     case TR_IGNORE_ELEC:
-        return 0;
     case TR_IGNORE_FIRE:
-        return 0;
     case TR_IGNORE_COLD:
-        return 0;
     case TR_ACTIVATE:
-        return 0;
     case TR_DRAIN_EXP:
-        return 0;
     case TR_TELEPORT:
-        return 0;
+        return check_equipment_flags(creature_ptr, tr_flag);
     case TR_AGGRAVATE:
         return 0;
     case TR_BLESSED:
         return has_bless_blade(creature_ptr);
     case TR_ES_ATTACK:
-        return 0;
     case TR_ES_AC:
-        return 0;
     case TR_KILL_GOOD:
-        return 0;
-
     case TR_KILL_ANIMAL:
-        return 0;
     case TR_KILL_EVIL:
-        return 0;
     case TR_KILL_UNDEAD:
-        return 0;
     case TR_KILL_DEMON:
-        return 0;
     case TR_KILL_ORC:
-        return 0;
     case TR_KILL_TROLL:
-        return 0;
     case TR_KILL_GIANT:
-        return 0;
     case TR_KILL_HUMAN:
-        return 0;
+        return check_equipment_flags(creature_ptr, tr_flag);
     case TR_ESP_ANIMAL:
         return has_esp_animal(creature_ptr);
     case TR_ESP_UNDEAD:
@@ -332,50 +353,28 @@ BIT_FLAGS get_player_flags(player_type *creature_ptr, tr_type tr_flag)
     case TR_ESP_UNIQUE:
         return has_esp_unique(creature_ptr);
     case TR_FULL_NAME:
-        return 0;
     case TR_FIXED_FLAVOR:
-        return 0;
     case TR_ADD_L_CURSE:
-        return 0;
     case TR_ADD_H_CURSE:
-        return 0;
     case TR_DRAIN_HP:
-        return 0;
     case TR_DRAIN_MANA:
-        return 0;
     case TR_LITE_2:
-        return 0;
     case TR_LITE_3:
-        return 0;
     case TR_LITE_M1:
-        return 0;
     case TR_LITE_M2:
-        return 0;
     case TR_LITE_M3:
-        return 0;
     case TR_LITE_FUEL:
-        return 0;
-
     case TR_CALL_ANIMAL:
-        return 0;
     case TR_CALL_DEMON:
-        return 0;
     case TR_CALL_DRAGON:
-        return 0;
     case TR_CALL_UNDEAD:
-        return 0;
     case TR_COWARDICE:
-        return 0;
     case TR_LOW_MELEE:
-        return 0;
     case TR_LOW_AC:
-        return 0;
     case TR_LOW_MAGIC:
-        return 0;
     case TR_FAST_DIGEST:
-        return 0;
     case TR_SLOW_REGEN:
-        return 0;
+        return check_equipment_flags(creature_ptr, tr_flag);
     case TR_MIGHTY_THROW:
         return has_mighty_throw(creature_ptr);
     case TR_EASY2_WEAPON:
@@ -393,7 +392,7 @@ BIT_FLAGS get_player_flags(player_type *creature_ptr, tr_type tr_flag)
     case TR_INVULN_ARROW:
         return has_invuln_arrow(creature_ptr);
     case TR_DARK_SOURCE:
-        return 0;
+        return check_equipment_flags(creature_ptr, tr_flag);
     }
     return 0;
 }

--- a/src/player/temporary-resistances.c
+++ b/src/player/temporary-resistances.c
@@ -1,6 +1,5 @@
 ﻿#include "temporary-resistances.h"
 #include "object-enchant/tr-types.h"
-#include "player/attack-defense-types.h"
 #include "player/player-race-types.h"
 #include "player/player-race.h"
 #include "player/player-status-flags.h"
@@ -34,17 +33,6 @@ void tim_player_flags(player_type *creature_ptr, BIT_FLAGS *flags)
 
     if (is_fast(creature_ptr) || creature_ptr->slow)
         add_flag(flags, TR_SPEED);
-
-    if (creature_ptr->special_attack & ATTACK_ACID)
-        add_flag(flags, TR_BRAND_ACID);
-    if (creature_ptr->special_attack & ATTACK_ELEC)
-        add_flag(flags, TR_BRAND_ELEC);
-    if (creature_ptr->special_attack & ATTACK_FIRE)
-        add_flag(flags, TR_BRAND_FIRE);
-    if (creature_ptr->special_attack & ATTACK_COLD)
-        add_flag(flags, TR_BRAND_COLD);
-    if (creature_ptr->special_attack & ATTACK_POIS)
-        add_flag(flags, TR_BRAND_POIS);
 
     if (is_oppose_acid(creature_ptr) && none_bits(has_immune_acid(creature_ptr), (race_class_flag | tmp_effect_flag)))
         add_flag(flags, TR_RES_ACID);


### PR DESCRIPTION
get_player_flags()に装備由来でしかフラグが立たないものを実装した。
加えてplayer_flags_brand_*()を実装し、TR_BRAND_*に対応させた。
この修正を使用してtim_player_flags()からTR_BRAND_*例外処理を排除した。