### PR TITLE
[Refactor] calc_speed()関数を分解・整理し速度増減の由来を取得可能とする

### DIFF
--- a/src/player/player-status-flags.c
+++ b/src/player/player-status-flags.c
@@ -33,7 +33,6 @@
 #include "util/quarks.h"
 #include "util/string-processor.h"
 
-static BIT_FLAGS check_equipment_flags(player_type *creature_ptr, tr_type tr_flag);
 
 static BIT_FLAGS convert_inventory_slot_type_to_flag_cause(inventory_slot_type inventory_slot)
 {
@@ -71,7 +70,7 @@ static BIT_FLAGS convert_inventory_slot_type_to_flag_cause(inventory_slot_type i
 /*!
  * @brief 装備による所定の特性フラグを得ているかを一括して取得する関数。
  */
-static BIT_FLAGS check_equipment_flags(player_type *creature_ptr, tr_type tr_flag)
+BIT_FLAGS check_equipment_flags(player_type *creature_ptr, tr_type tr_flag)
 {
     object_type *o_ptr;
     BIT_FLAGS flgs[TR_FLAG_SIZE];
@@ -172,7 +171,7 @@ BIT_FLAGS get_player_flags(player_type *creature_ptr, tr_type tr_flag)
     case TR_TUNNEL:
         return 0;
     case TR_SPEED:
-        return 0;
+        return player_flags_speed(creature_ptr);
     case TR_BLOWS:
         return 0;
     case TR_CHAOTIC:

--- a/src/player/player-status-flags.h
+++ b/src/player/player-status-flags.h
@@ -21,7 +21,9 @@ enum flag_cause {
     FLAG_CAUSE_MUTATION = 0x01U << 16, /*!< 変異による効果 */
     FLAG_CAUSE_BATTLE_FORM = 0x01U << 17, /*!< 構えによる効果 */
     FLAG_CAUSE_RIDING = 0x01U << 18, /*!< 乗馬による効果 */
-    FLAG_CAUSE_MAX = 0x01U << 19
+    FLAG_CAUSE_INVEN_PACK = 0x01U << 19, /*!< その他インベントリによる効果 重量超過等 */
+    FLAG_CAUSE_ACTION = 0x01U << 20, /*!< ACTIONによる効果 探索モード等 */
+    FLAG_CAUSE_MAX = 0x01U << 21
 };
 
 typedef enum melee_type {
@@ -41,6 +43,7 @@ enum aggravate_state {
     AGGRAVATE_NORMAL = 0x00000002L,
 };
 
+BIT_FLAGS check_equipment_flags(player_type *creature_ptr, tr_type tr_flag);
 BIT_FLAGS get_player_flags(player_type *creature_ptr, tr_type tr_flag);
 bool has_pass_wall(player_type *creature_ptr);
 bool has_kill_wall(player_type *creature_ptr);

--- a/src/player/player-status.c
+++ b/src/player/player-status.c
@@ -1661,7 +1661,7 @@ static bool is_martial_arts_mode(player_type *creature_ptr)
 
 static bool is_heavy_wield(player_type *creature_ptr, int i)
 {
-    const object_type* o_ptr = &creature_ptr->inventory_list[INVEN_MAIN_HAND + i];
+    const object_type *o_ptr = &creature_ptr->inventory_list[INVEN_MAIN_HAND + i];
 
     return has_melee_weapon(creature_ptr, INVEN_MAIN_HAND + i) && (calc_weapon_weight_limit(creature_ptr) < o_ptr->weight / 10);
 }
@@ -2371,8 +2371,7 @@ static ARMOUR_CLASS calc_to_ac(player_type *creature_ptr, bool is_real_value)
         ac += 10;
     }
 
-    if ((creature_ptr->inventory_list[INVEN_MAIN_HAND].name1 == ART_ICINGDEATH)
-        && (creature_ptr->inventory_list[INVEN_SUB_HAND].name1 == ART_TWINKLE)) {
+    if ((creature_ptr->inventory_list[INVEN_MAIN_HAND].name1 == ART_ICINGDEATH) && (creature_ptr->inventory_list[INVEN_SUB_HAND].name1 == ART_TWINKLE)) {
         ac += 5;
     }
 
@@ -2466,201 +2465,388 @@ static ARMOUR_CLASS calc_to_ac(player_type *creature_ptr, bool is_real_value)
 }
 
 /*!
- * @brief 速度計算
+ * @brief 速度計算 - 種族
  * @param creature_ptr 計算するクリーチャーの参照ポインタ
- * @return 速度値
+ * @return 速度値の増減分
  * @details
- * * 基礎値110(+-0に対応)
- * * 騎乗していない場合以下の処理
  * ** クラッコンと妖精に加算(+レベル/10)
  * ** 悪魔変化/吸血鬼変化で加算(+3)
  * ** 魔王変化で加算(+5)
+ * ** マーフォークがFF_WATER地形にいれば加算(+2+レベル/10)
+ * ** そうでなく浮遊を持っていないなら減算(-2)
+ */
+static SPEED calc_player_speed_by_race(player_type *creature_ptr)
+{
+    SPEED result = 0;
+
+    if (is_specific_player_race(creature_ptr, RACE_KLACKON) || is_specific_player_race(creature_ptr, RACE_SPRITE))
+        result += (creature_ptr->lev) / 10;
+
+    if (is_specific_player_race(creature_ptr, RACE_MERFOLK)) {
+        floor_type *floor_ptr = creature_ptr->current_floor_ptr;
+        feature_type *f_ptr = &f_info[floor_ptr->grid_array[creature_ptr->y][creature_ptr->x].feat];
+        if (has_flag(f_ptr->flags, FF_WATER)) {
+            result += (2 + creature_ptr->lev / 10);
+        } else if (!creature_ptr->levitation) {
+            result -= 2;
+        }
+    }
+
+    if (creature_ptr->mimic_form) {
+        switch (creature_ptr->mimic_form) {
+        case MIMIC_DEMON:
+            result += 3;
+            break;
+        case MIMIC_DEMON_LORD:
+            result += 5;
+            break;
+        case MIMIC_VAMPIRE:
+            result += 3;
+            break;
+        }
+    }
+    return result;
+}
+
+static SPEED calc_speed_by_secial_weapon_set(player_type *creature_ptr) 
+{
+    SPEED result = 0;
+    if (has_melee_weapon(creature_ptr, INVEN_MAIN_HAND) && has_melee_weapon(creature_ptr, INVEN_SUB_HAND)) {
+        if ((creature_ptr->inventory_list[INVEN_MAIN_HAND].name1 == ART_QUICKTHORN) && (creature_ptr->inventory_list[INVEN_SUB_HAND].name1 == ART_TINYTHORN)) {
+            result += 7;
+        }
+
+        if ((creature_ptr->inventory_list[INVEN_MAIN_HAND].name1 == ART_ICINGDEATH) && (creature_ptr->inventory_list[INVEN_SUB_HAND].name1 == ART_TWINKLE)) {
+            result += 5;
+        }
+    }
+    return result;
+}
+
+
+/*!
+ * @brief 速度計算 - ACTION
+ * @param creature_ptr 計算するクリーチャーの参照ポインタ
+ * @return 速度値の増減分
+ * @details
  * ** 装備品にTR_SPEEDがあれば加算(+pval+1
+ * ** 棘セット装備中ならば加算(+7)
+ * ** アイシングデス-トゥインクル装備中ならば加算(+7)
+ */
+static SPEED calc_player_speed_by_equipment(player_type *creature_ptr)
+{
+    SPEED result = 0;
+    for (inventory_slot_type i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+        object_type *o_ptr = &creature_ptr->inventory_list[i];
+        BIT_FLAGS flgs[TR_FLAG_SIZE];
+        object_flags(creature_ptr, o_ptr, flgs);
+
+        if (!o_ptr->k_idx)
+            continue;
+        if (has_flag(flgs, TR_SPEED))
+            result += o_ptr->pval;
+    }
+    result += calc_speed_by_secial_weapon_set(creature_ptr);
+
+    return result;
+}
+
+/*!
+ * @brief 速度計算 - ACTION
+ * @param creature_ptr 計算するクリーチャーの参照ポインタ
+ * @return 速度値の増減分
+ * @details
  * ** 忍者の装備が重ければ減算(-レベル/10)
  * ** 忍者の装備が適正ならば加算(+3)さらにクラッコン、妖精、いかさま以外なら加算(+レベル/10)
  * ** 錬気術師で装備が重くなくクラッコン、妖精、いかさま以外なら加算(+レベル/10)
  * ** 狂戦士なら加算(+3),レベル20/30/40/50ごとに+1
- * ** いかさまでクラッコン/妖精以外なら加算(+5+レベル/10)
- * ** 加速状態中なら加算(+10)
- * ** 原則状態中なら減算(-10)
- * ** 呪術「衝撃のクローク」で加算(+3)
- * ** 食い過ぎなら減算(-10)
+ */
+static SPEED calc_player_speed_by_class(player_type *creature_ptr)
+{
+    SPEED result = 0;
+
+    if (creature_ptr->pclass == CLASS_NINJA) {
+        if (heavy_armor(creature_ptr)) {
+            result -= (creature_ptr->lev) / 10;
+        } else if ((!creature_ptr->inventory_list[INVEN_MAIN_HAND].k_idx || can_attack_with_main_hand(creature_ptr))
+            && (!creature_ptr->inventory_list[INVEN_SUB_HAND].k_idx || can_attack_with_sub_hand(creature_ptr))) {
+            result += 3;
+            if (!(is_specific_player_race(creature_ptr, RACE_KLACKON) || is_specific_player_race(creature_ptr, RACE_SPRITE)
+                    || (creature_ptr->pseikaku == PERSONALITY_MUNCHKIN)))
+                result += (creature_ptr->lev) / 10;
+        }
+    }
+
+    if ((creature_ptr->pclass == CLASS_MONK || creature_ptr->pclass == CLASS_FORCETRAINER) && !(heavy_armor(creature_ptr))) {
+        if (!(is_specific_player_race(creature_ptr, RACE_KLACKON) || is_specific_player_race(creature_ptr, RACE_SPRITE)
+                || (creature_ptr->pseikaku == PERSONALITY_MUNCHKIN)))
+            result += (creature_ptr->lev) / 10;
+    }
+
+    if (creature_ptr->pclass == CLASS_BERSERKER) {
+        result += 2;
+        if (creature_ptr->lev > 29)
+            result++;
+        if (creature_ptr->lev > 39)
+            result++;
+        if (creature_ptr->lev > 44)
+            result++;
+        if (creature_ptr->lev > 49)
+            result++;
+    }
+    return result;
+}
+
+/*!
+ * @brief 速度計算 - 型
+ * @param creature_ptr 計算するクリーチャーの参照ポインタ
+ * @return 速度値の増減分
+ * @details
+ * * 基礎値110(+-0に対応)
  * ** 朱雀の構えなら加算(+10)
+ */
+static SPEED calc_player_speed_by_battleform(player_type *creature_ptr)
+{
+    SPEED result = 0;
+    if (any_bits(creature_ptr->special_defense, KAMAE_SUZAKU))
+        result += 10;
+    return result;
+}
+
+/*!
+ * @brief 速度計算 - 変異
+ * @param creature_ptr 計算するクリーチャーの参照ポインタ
+ * @return 速度値の増減分
+ * @details
+ * * 基礎値110(+-0に対応)
  * ** 変異MUT3_XTRA_FATなら減算(-2)
  * ** 変異MUT3_XTRA_LEGなら加算(+3)
  * ** 変異MUT3_SHORT_LEGなら減算(-3)
- * ** マーフォークがFF_WATER地形にいれば加算(+2+レベル/10)
- * ** そうでなく浮遊を持っていないなら減算(-2)
- * ** 棘セット装備中ならば加算(+7)
- * * 騎乗中ならばモンスターの加速に準拠、ただし騎乗技能値とモンスターレベルによるキャップ処理あり
- * * 探索中なら減算(-10)
- * * 光速移動中かこの時点で+99を超えていたら+99にキャップ
- * * -99未満なら-99にキャップ
  */
-static s16b calc_speed(player_type *creature_ptr)
+static SPEED calc_player_speed_by_mutation(player_type *creature_ptr)
 {
-    floor_type *floor_ptr = creature_ptr->current_floor_ptr;
-    feature_type *f_ptr = &f_info[floor_ptr->grid_array[creature_ptr->y][creature_ptr->x].feat];
-
-    s16b pow = 110;
-
-    int j = calc_inventory_weight(creature_ptr);
-    int count;
-
-    if (!creature_ptr->riding) {
-        if (is_specific_player_race(creature_ptr, RACE_KLACKON) || is_specific_player_race(creature_ptr, RACE_SPRITE))
-            pow += (creature_ptr->lev) / 10;
-
-        if (creature_ptr->mimic_form) {
-            switch (creature_ptr->mimic_form) {
-            case MIMIC_DEMON:
-                pow += 3;
-                break;
-            case MIMIC_DEMON_LORD:
-                pow += 5;
-                break;
-            case MIMIC_VAMPIRE:
-                pow += 3;
-                break;
-            }
+    SPEED result = 0;
+    if (creature_ptr->muta3) {
+        if (any_bits(creature_ptr->muta3, MUT3_XTRA_FAT)) {
+            result -= 2;
         }
 
-        for (inventory_slot_type i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-            object_type *o_ptr = &creature_ptr->inventory_list[i];
-            BIT_FLAGS flgs[TR_FLAG_SIZE];
-            object_flags(creature_ptr, o_ptr, flgs);
-
-            if (!o_ptr->k_idx)
-                continue;
-            if (has_flag(flgs, TR_SPEED))
-                pow += o_ptr->pval;
+        if (any_bits(creature_ptr->muta3, MUT3_XTRA_LEGS)) {
+            result += 3;
         }
 
-        if (creature_ptr->pclass == CLASS_NINJA) {
-            if (heavy_armor(creature_ptr)) {
-                pow -= (creature_ptr->lev) / 10;
-            } else if ((!creature_ptr->inventory_list[INVEN_MAIN_HAND].k_idx || can_attack_with_main_hand(creature_ptr))
-                && (!creature_ptr->inventory_list[INVEN_SUB_HAND].k_idx || can_attack_with_sub_hand(creature_ptr))) {
-                pow += 3;
-                if (!(is_specific_player_race(creature_ptr, RACE_KLACKON) || is_specific_player_race(creature_ptr, RACE_SPRITE)
-                        || (creature_ptr->pseikaku == PERSONALITY_MUNCHKIN)))
-                    pow += (creature_ptr->lev) / 10;
-            }
+        if (any_bits(creature_ptr->muta3, MUT3_SHORT_LEG)) {
+            result -= 3;
         }
+    }
+    return result;
+}
 
-        if ((creature_ptr->pclass == CLASS_MONK || creature_ptr->pclass == CLASS_FORCETRAINER) && !(heavy_armor(creature_ptr))) {
-            if (!(is_specific_player_race(creature_ptr, RACE_KLACKON) || is_specific_player_race(creature_ptr, RACE_SPRITE)
-                    || (creature_ptr->pseikaku == PERSONALITY_MUNCHKIN)))
-                pow += (creature_ptr->lev) / 10;
-        }
+/*!
+ * @brief 速度計算 - 一時的効果
+ * @param creature_ptr 計算するクリーチャーの参照ポインタ
+ * @return 速度値の増減分
+ * @details
+ * ** 加速状態中なら加算(+10)
+ * ** 減速状態中なら減算(-10)
+ * ** 呪術「衝撃のクローク」で加算(+3)
+ * ** 食い過ぎなら減算(-10)
+ * ** 光速移動中は+999(最終的に+99になる)
+ */
+static SPEED calc_player_speed_by_time_effect(player_type *creature_ptr)
+{
+    SPEED result = 0;
 
-        if (creature_ptr->pclass == CLASS_BERSERKER) {
-            pow += 2;
-            if (creature_ptr->lev > 29)
-                pow++;
-            if (creature_ptr->lev > 39)
-                pow++;
-            if (creature_ptr->lev > 44)
-                pow++;
-            if (creature_ptr->lev > 49)
-                pow++;
-        }
-
-        if (creature_ptr->pseikaku == PERSONALITY_MUNCHKIN && creature_ptr->prace != RACE_KLACKON && creature_ptr->prace != RACE_SPRITE) {
-            pow += (creature_ptr->lev) / 10 + 5;
-        }
-
-        if (is_fast(creature_ptr)) {
-            pow += 10;
-        }
-
-        if (creature_ptr->slow) {
-            pow -= 10;
-        }
-
-        if (creature_ptr->realm1 == REALM_HEX) {
-            if (hex_spelling(creature_ptr, HEX_SHOCK_CLOAK)) {
-                pow += 3;
-            }
-        }
-
-        if (creature_ptr->food >= PY_FOOD_MAX)
-            pow -= 10;
-
-        if (any_bits(creature_ptr->special_defense, KAMAE_SUZAKU))
-            pow += 10;
-
-        if (creature_ptr->muta3) {
-            if (any_bits(creature_ptr->muta3, MUT3_XTRA_FAT)) {
-                pow -= 2;
-            }
-
-            if (any_bits(creature_ptr->muta3, MUT3_XTRA_LEGS)) {
-                pow += 3;
-            }
-
-            if (any_bits(creature_ptr->muta3, MUT3_SHORT_LEG)) {
-                pow -= 3;
-            }
-        }
-
-        if (creature_ptr->prace == RACE_MERFOLK) {
-            if (has_flag(f_ptr->flags, FF_WATER)) {
-                pow += (2 + creature_ptr->lev / 10);
-            } else if (!creature_ptr->levitation) {
-                pow -= 2;
-            }
-        }
-
-        if (has_melee_weapon(creature_ptr, INVEN_MAIN_HAND) && has_melee_weapon(creature_ptr, INVEN_SUB_HAND)) {
-            if ((creature_ptr->inventory_list[INVEN_MAIN_HAND].name1 == ART_QUICKTHORN)
-                && (creature_ptr->inventory_list[INVEN_SUB_HAND].name1 == ART_TINYTHORN)) {
-                pow += 7;
-            }
-
-            if ((creature_ptr->inventory_list[INVEN_MAIN_HAND].name1 == ART_ICINGDEATH)
-                && (creature_ptr->inventory_list[INVEN_SUB_HAND].name1 == ART_TWINKLE)) {
-                pow += 5;
-            }
-        }
-
-        count = (int)calc_weight_limit(creature_ptr);
-        if (j > count)
-            pow -= ((j - count) / (count / 5));
-    } else {
-        monster_type *riding_m_ptr = &creature_ptr->current_floor_ptr->m_list[creature_ptr->riding];
-        monster_race *riding_r_ptr = &r_info[riding_m_ptr->r_idx];
-        SPEED speed = riding_m_ptr->mspeed;
-
-        if (riding_m_ptr->mspeed > 110) {
-            pow = 110 + (s16b)((speed - 110) * (creature_ptr->skill_exp[GINOU_RIDING] * 3 + creature_ptr->lev * 160L - 10000L) / (22000L));
-            if (pow < 110)
-                pow = 110;
-        } else {
-            pow = speed;
-        }
-
-        pow += (creature_ptr->skill_exp[GINOU_RIDING] + creature_ptr->lev * 160L) / 3200;
-
-        if (monster_fast_remaining(riding_m_ptr))
-            pow += 10;
-        if (monster_slow_remaining(riding_m_ptr))
-            pow -= 10;
-
-        if (creature_ptr->skill_exp[GINOU_RIDING] < RIDING_EXP_SKILLED)
-            j += (creature_ptr->wt * 3 * (RIDING_EXP_SKILLED - creature_ptr->skill_exp[GINOU_RIDING])) / RIDING_EXP_SKILLED;
-
-        count = 1500 + riding_r_ptr->level * 25;
-        if (j > count)
-            pow -= ((j - count) / (count / 5));
+    if (is_fast(creature_ptr)) {
+        result += 10;
     }
 
+    if (creature_ptr->slow) {
+        result -= 10;
+    }
+
+    if (creature_ptr->realm1 == REALM_HEX) {
+        if (hex_spelling(creature_ptr, HEX_SHOCK_CLOAK)) {
+            result += 3;
+        }
+    }
+
+    if (creature_ptr->food >= PY_FOOD_MAX)
+        result -= 10;
+
+    /* Temporary lightspeed forces to be maximum speed */
+    if (creature_ptr->lightspeed)
+        result += 999;
+
+    return result;
+}
+
+/*!
+ * @brief 速度計算 - 性格
+ * @param creature_ptr 計算するクリーチャーの参照ポインタ
+ * @return 速度値の増減分
+ * @details
+ * ** いかさまでクラッコン/妖精以外なら加算(+5+レベル/10)
+ */
+static SPEED calc_player_speed_by_personality(player_type *creature_ptr)
+{
+    SPEED result = 0;
+    if (creature_ptr->pseikaku == PERSONALITY_MUNCHKIN && creature_ptr->prace != RACE_KLACKON && creature_ptr->prace != RACE_SPRITE) {
+        result += (creature_ptr->lev) / 10 + 5;
+    }
+    return result;
+}
+
+/*!
+ * @brief 速度計算 - 重量
+ * @param creature_ptr 計算するクリーチャーの参照ポインタ
+ * @return 速度値の増減分
+ * @details
+ * * 所持品の重量による減速処理。乗馬時は別計算。
+ */
+static SPEED calc_player_speed_by_inventory_weight(player_type *creature_ptr)
+{
+    SPEED result = 0;
+
+    int weight = calc_inventory_weight(creature_ptr);
+    int count;
+
+    if (creature_ptr->riding) {
+        monster_type *riding_m_ptr = &creature_ptr->current_floor_ptr->m_list[creature_ptr->riding];
+        monster_race *riding_r_ptr = &r_info[riding_m_ptr->r_idx];
+        count = 1500 + riding_r_ptr->level * 25;
+
+        if (creature_ptr->skill_exp[GINOU_RIDING] < RIDING_EXP_SKILLED) {
+            weight += (creature_ptr->wt * 3 * (RIDING_EXP_SKILLED - creature_ptr->skill_exp[GINOU_RIDING])) / RIDING_EXP_SKILLED;
+        }
+
+        if (weight > count) {
+            result -= ((weight - count) / (count / 5));
+        }
+    } else {
+        count = (int)calc_weight_limit(creature_ptr);
+        if (weight > count) {
+            result -= ((weight - count) / (count / 5));
+        }
+    }
+
+    return result;
+}
+
+/*!
+ * @brief 速度計算 - 乗馬
+ * @param creature_ptr 計算するクリーチャーの参照ポインタ
+ * @return 速度値の増減分
+ * @details
+ * * 騎乗中ならばモンスターの加速に準拠、ただし騎乗技能値とモンスターレベルによるキャップ処理あり
+ */
+static SPEED calc_player_speed_by_riding(player_type *creature_ptr)
+{
+    monster_type *riding_m_ptr = &creature_ptr->current_floor_ptr->m_list[creature_ptr->riding];
+    SPEED speed = riding_m_ptr->mspeed;
+    SPEED result = 0;
+
+    if (creature_ptr->riding) {
+        return 0;
+    }
+
+    if (riding_m_ptr->mspeed > 110) {
+        result = (s16b)((speed - 110) * (creature_ptr->skill_exp[GINOU_RIDING] * 3 + creature_ptr->lev * 160L - 10000L) / (22000L));
+        if (result < 0)
+            result = 0;
+    } else {
+        result = speed - 110;
+    }
+
+    result += (creature_ptr->skill_exp[GINOU_RIDING] + creature_ptr->lev * 160L) / 3200;
+
+    if (monster_fast_remaining(riding_m_ptr))
+        result += 10;
+    if (monster_slow_remaining(riding_m_ptr))
+        result -= 10;
+
+    return result;
+}
+
+/*!
+ * @brief 速度計算 - ACTION
+ * @param creature_ptr 計算するクリーチャーの参照ポインタ
+ * @return 速度値の増減分
+ * @details
+ * * 探索中なら減算(-10)
+ */
+static SPEED calc_player_speed_by_action(player_type *creature_ptr)
+{
+    SPEED result = 0;
     if (creature_ptr->action == ACTION_SEARCH)
-        pow -= 10;
+        result -= 10;
+    return result;
+}
+
+BIT_FLAGS player_flags_speed(player_type *creature_ptr)
+{
+    BIT_FLAGS result = check_equipment_flags(creature_ptr, TR_SPEED);
+
+    if (calc_speed_by_secial_weapon_set(creature_ptr) != 0)
+        set_bits(result, FLAG_CAUSE_INVEN_MAIN_HAND | FLAG_CAUSE_INVEN_SUB_HAND);
+
+    if (calc_player_speed_by_class(creature_ptr) != 0)
+        set_bits(result, FLAG_CAUSE_CLASS);
+
+    if (calc_player_speed_by_race(creature_ptr) != 0)
+        set_bits(result, FLAG_CAUSE_RACE);
+
+    if (calc_player_speed_by_battleform(creature_ptr) != 0)
+        set_bits(result, FLAG_CAUSE_BATTLE_FORM);
+
+    if (calc_player_speed_by_mutation(creature_ptr) != 0)
+        set_bits(result, FLAG_CAUSE_MUTATION);
+
+    if (calc_player_speed_by_time_effect(creature_ptr) != 0)
+        set_bits(result, FLAG_CAUSE_MAGIC_TIME_EFFECT);
+
+    if (calc_player_speed_by_personality(creature_ptr) != 0)
+        set_bits(result, FLAG_CAUSE_PERSONALITY);
+
+    if (calc_player_speed_by_riding(creature_ptr) != 0)
+        set_bits(result, FLAG_CAUSE_RIDING);
+
+    if (calc_player_speed_by_inventory_weight(creature_ptr) != 0)
+        set_bits(result, FLAG_CAUSE_INVEN_PACK);
+
+    if (calc_player_speed_by_action(creature_ptr) != 0)
+        set_bits(result, FLAG_CAUSE_ACTION);
+
+    return result;
+}
+
+/*!
+ * @brief 速度計算
+ * @param creature_ptr 計算するクリーチャーの参照ポインタ
+ * @return 速度値
+ * @details 上限99、下限-99
+ */
+static SPEED calc_speed(player_type *creature_ptr)
+{
+    SPEED pow = 110;
+
+    if (creature_ptr->riding) {
+        pow += calc_player_speed_by_riding(creature_ptr);
+        pow += calc_player_speed_by_inventory_weight(creature_ptr);
+    } else {
+        pow += calc_player_speed_by_race(creature_ptr);
+        pow += calc_player_speed_by_equipment(creature_ptr);
+        pow += calc_player_speed_by_class(creature_ptr);
+        pow += calc_player_speed_by_personality(creature_ptr);
+        pow += calc_player_speed_by_time_effect(creature_ptr);
+        pow += calc_player_speed_by_battleform(creature_ptr);
+        pow += calc_player_speed_by_mutation(creature_ptr);
+        pow += calc_player_speed_by_inventory_weight(creature_ptr);
+    }
+    pow += calc_player_speed_by_action(creature_ptr);
 
     /* Maximum speed is (+99). (internally it's 110 + 99) */
-    /* Temporary lightspeed forces to be maximum speed */
-    if ((creature_ptr->lightspeed && !creature_ptr->riding) || (pow > 209)) {
+    if ((pow > 209)) {
         pow = 209;
     }
 
@@ -2689,10 +2875,9 @@ s16b calc_double_weapon_penalty(player_type *creature_ptr, INVENTORY_IDX slot)
     int penalty = 0;
     if (has_melee_weapon(creature_ptr, INVEN_MAIN_HAND) && has_melee_weapon(creature_ptr, INVEN_SUB_HAND)) {
         penalty = ((100 - creature_ptr->skill_exp[GINOU_NITOURYU] / 160) - (130 - creature_ptr->inventory_list[slot].weight) / 8);
-        if (((creature_ptr->inventory_list[INVEN_MAIN_HAND].name1 == ART_QUICKTHORN)
-            && (creature_ptr->inventory_list[INVEN_SUB_HAND].name1 == ART_TINYTHORN))
+        if (((creature_ptr->inventory_list[INVEN_MAIN_HAND].name1 == ART_QUICKTHORN) && (creature_ptr->inventory_list[INVEN_SUB_HAND].name1 == ART_TINYTHORN))
             || ((creature_ptr->inventory_list[INVEN_MAIN_HAND].name1 == ART_ICINGDEATH)
-            && (creature_ptr->inventory_list[INVEN_SUB_HAND].name1 == ART_TWINKLE))) {
+                && (creature_ptr->inventory_list[INVEN_SUB_HAND].name1 == ART_TWINKLE))) {
             penalty = penalty / 2 - 5;
         }
         if (creature_ptr->easy_2weapon) {

--- a/src/player/player-status.h
+++ b/src/player/player-status.h
@@ -481,7 +481,8 @@ extern int calc_weapon_weight_limit(player_type *creature_ptr);
 extern WEIGHT calc_inventory_weight(player_type *creature_ptr);
 
 extern s16b calc_num_fire(player_type *creature_ptr, object_type *o_ptr);
-extern void calc_bonuses(player_type *creature_ptr);
+BIT_FLAGS player_flags_speed(player_type *creature_ptr);
+static void update_bonuses(player_type *creature_ptr);
 extern WEIGHT calc_weight_limit(player_type *creature_ptr);
 extern bool has_melee_weapon(player_type *creature_ptr, int i);
 

--- a/src/player/temporary-resistances.c
+++ b/src/player/temporary-resistances.c
@@ -31,9 +31,6 @@ void tim_player_flags(player_type *creature_ptr, BIT_FLAGS *flags)
     for (int i = 0; i < TR_FLAG_SIZE; i++)
         flags[i] = 0L;
 
-    if (is_fast(creature_ptr) || creature_ptr->slow)
-        add_flag(flags, TR_SPEED);
-
     if (is_oppose_acid(creature_ptr) && none_bits(has_immune_acid(creature_ptr), (race_class_flag | tmp_effect_flag)))
         add_flag(flags, TR_RES_ACID);
     if (is_oppose_elec(creature_ptr) && none_bits(has_immune_elec(creature_ptr), (race_class_flag | tmp_effect_flag)))


### PR DESCRIPTION
    プレイヤーの速度計算をcalc_speed()関数が一括で行なっていたが、これを速度変化の原因毎に分解して処理する。
    (ついでにマーフォークが一時的種族変化時に加減速計算を適用したままであった部分を修正)
    分解した処理を流用してplayer_flags_speed()を作成し、速度変化の原因をBIT_FLAGで取得可能とする。
    これを流用してtim_player_flags()から加速/減速状態の例外処理を除外する。
    (ついでに光速移動時の一時フラグがCの画面に表示されていなかったバグを改善する)
