### PR TITLE
Feature/remove gcc overflow warning

### DIFF
--- a/.github/workflows/buildtest-on-linux.yml
+++ b/.github/workflows/buildtest-on-linux.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build test on Ubuntu-20.04
     runs-on: ubuntu-20.04
     env:
-      CFLAGS: "-pipe -Werror -Wall -Wextra -Wno-format-overflow -Wno-switch -Wno-sign-compare -Wno-unused-parameter -Wno-unused-function"
+      CFLAGS: "-pipe -O3 -Werror -Wall -Wextra -Wno-switch -Wno-sign-compare -Wno-unused-parameter -Wno-unused-function"
     steps:
       - uses: actions/checkout@v2
 

--- a/src/autopick/autopick-entry.c
+++ b/src/autopick/autopick-entry.c
@@ -287,7 +287,7 @@ void autopick_entry_from_object(player_type *player_ptr, autopick_type *entry, o
 {
     /* Assume that object name is to be added */
     bool name = TRUE;
-    GAME_TEXT name_str[MAX_NLEN];
+    GAME_TEXT name_str[MAX_NLEN + 32];
     name_str[0] = '\0';
     entry->insc = string_make(quark_str(o_ptr->inscription));
     entry->action = DO_AUTOPICK | DO_DISPLAY;

--- a/src/birth/auto-roller.c
+++ b/src/birth/auto-roller.c
@@ -114,8 +114,8 @@ bool get_stat_limits(player_type *creature_ptr)
     put_str(_("確率: 非常に容易(1/10000以上)", "Prob: Quite Easy(>1/10000)"), 23, col_stat);
 
     int cval[6];
-    char buf[80];
-    char cur[80];
+    char buf[320];
+    char cur[160];
     char inp[80];
     for (int i = 0; i < A_MAX; i++) {
         cval[i] = 3;

--- a/src/cmd-action/cmd-mane.c
+++ b/src/cmd-action/cmd-mane.c
@@ -164,7 +164,7 @@ static int get_mane_power(player_type *caster_ptr, int *sn, bool baigaesi)
         if ((choice == ' ') || (choice == '*') || (choice == '?')) {
             /* Show the list */
             if (!redraw) {
-                char psi_desc[80];
+                char psi_desc[160];
                 redraw = TRUE;
                 screen_save();
 

--- a/src/cmd-io/cmd-dump.c
+++ b/src/cmd-io/cmd-dump.c
@@ -247,7 +247,7 @@ void do_cmd_time(player_type *creature_ptr)
     char desc[1024];
     strcpy(desc, _("変な時刻だ。", "It is a strange time."));
 
-    char day_buf[10];
+    char day_buf[20];
     if (day < MAX_DAYS)
         sprintf(day_buf, "%d", day);
     else

--- a/src/cmd-io/cmd-lore.c
+++ b/src/cmd-io/cmd-lore.c
@@ -38,7 +38,7 @@ void do_cmd_query_symbol(player_type *creature_ptr)
     int n;
     MONRACE_IDX r_idx;
     char sym, query;
-    char buf[128];
+    char buf[256];
 
     bool all = FALSE;
     bool uniq = FALSE;

--- a/src/cmd-item/cmd-smith.c
+++ b/src/cmd-item/cmd-smith.c
@@ -639,7 +639,7 @@ static void add_essence(player_type *creature_ptr, ESSENCE_IDX mode)
                 if (!redraw || use_menu) {
                     byte y, x = 10;
                     int ctr;
-                    char dummy[80], dummy2[80];
+                    char dummy[80], dummy2[160];
                     byte col;
 
                     strcpy(dummy, "");

--- a/src/core/show-file.c
+++ b/src/core/show-file.c
@@ -137,7 +137,7 @@ bool show_file(player_type *creature_ptr, bool show_version, concptr name, concp
     char shower_str[81];
     strcpy(shower_str, "");
 
-    char caption[128];
+    char caption[1024 + 256];
     strcpy(caption, "");
 
     char hook[68][32];
@@ -453,7 +453,7 @@ bool show_file(player_type *creature_ptr, bool show_version, concptr name, concp
         if (skey == '|') {
             FILE *ffp;
             char buff[1024];
-            char xtmp[82];
+            char xtmp[sizeof(caption) + 128];
 
             strcpy(xtmp, "");
 

--- a/src/floor/floor-save.c
+++ b/src/floor/floor-save.c
@@ -28,7 +28,7 @@ static void check_saved_tmp_files(const int fd, bool *force)
         (void)fd_close(fd);
         return;
     }
-    
+
     if (*force)
         return;
 
@@ -51,7 +51,7 @@ static void check_saved_tmp_files(const int fd, bool *force)
  */
 void init_saved_floors(player_type *creature_ptr, bool force)
 {
-    char floor_savefile[1024];
+    char floor_savefile[sizeof(savefile) + 32];
     int fd = -1;
     BIT_FLAGS mode = 0644;
     for (int i = 0; i < MAX_SAVED_FLOORS; i++) {
@@ -82,7 +82,7 @@ void init_saved_floors(player_type *creature_ptr, bool force)
  */
 void clear_saved_floor_files(player_type *creature_ptr)
 {
-    char floor_savefile[1024];
+    char floor_savefile[sizeof(savefile) + 32];
     for (int i = 0; i < MAX_SAVED_FLOORS; i++) {
         saved_floor_type *sf_ptr = &saved_floors[i];
         if ((sf_ptr->floor_id == 0) || (sf_ptr->floor_id == creature_ptr->floor_id))
@@ -122,7 +122,7 @@ saved_floor_type *get_sf_ptr(FLOOR_IDX floor_id)
  */
 void kill_saved_floor(player_type *creature_ptr, saved_floor_type *sf_ptr)
 {
-    char floor_savefile[1024];
+    char floor_savefile[sizeof(savefile) + 32];
     if (!sf_ptr || (sf_ptr->floor_id == 0))
         return;
 

--- a/src/info-reader/dungeon-reader.c
+++ b/src/info-reader/dungeon-reader.c
@@ -269,7 +269,7 @@ errr parse_d_info(char *buf, angband_header *head)
 
             if (!strncmp(s, "R_CHAR_", 7)) {
                 s += 7;
-                strncpy(d_ptr->r_char, s, sizeof(d_ptr->r_char));
+                angband_strcpy(d_ptr->r_char, s, sizeof(d_ptr->r_char));
                 s = t;
                 continue;
             }

--- a/src/inventory/floor-item-getter.c
+++ b/src/inventory/floor-item-getter.c
@@ -330,8 +330,9 @@ bool get_item_floor(player_type *owner_ptr, COMMAND_CODE *cp, concptr pmt, concp
         if (command_wrk == USE_INVEN) {
             sprintf(fis_ptr->out_val, _("持ち物:", "Inven:"));
             if (!use_menu) {
-                sprintf(fis_ptr->tmp_val, _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(fis_ptr->i1), index_to_label(fis_ptr->i2));
-                strcat(fis_ptr->out_val, fis_ptr->tmp_val);
+                char tmp_val[80];
+                sprintf(tmp_val, _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(fis_ptr->i1), index_to_label(fis_ptr->i2));
+                strcat(fis_ptr->out_val, tmp_val);
             }
 
             if (!command_see && !use_menu)
@@ -357,8 +358,9 @@ bool get_item_floor(player_type *owner_ptr, COMMAND_CODE *cp, concptr pmt, concp
         } else if (command_wrk == (USE_EQUIP)) {
             sprintf(fis_ptr->out_val, _("装備品:", "Equip:"));
             if (!use_menu) {
-                sprintf(fis_ptr->tmp_val, _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(fis_ptr->e1), index_to_label(fis_ptr->e2));
-                strcat(fis_ptr->out_val, fis_ptr->tmp_val);
+                char tmp_val[80];
+                sprintf(tmp_val, _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(fis_ptr->e1), index_to_label(fis_ptr->e2));
+                strcat(fis_ptr->out_val, tmp_val);
             }
 
             if (!command_see && !use_menu)
@@ -384,8 +386,9 @@ bool get_item_floor(player_type *owner_ptr, COMMAND_CODE *cp, concptr pmt, concp
         } else if (command_wrk == USE_FLOOR) {
             sprintf(fis_ptr->out_val, _("床上:", "Floor:"));
             if (!use_menu) {
-                sprintf(fis_ptr->tmp_val, _("%c-%c,'(',')',", " %c-%c,'(',')',"), fis_ptr->n1, fis_ptr->n2);
-                strcat(fis_ptr->out_val, fis_ptr->tmp_val);
+                char tmp_val[80];
+                sprintf(tmp_val, _("%c-%c,'(',')',", " %c-%c,'(',')',"), fis_ptr->n1, fis_ptr->n2);
+                strcat(fis_ptr->out_val, tmp_val);
             }
 
             if (!command_see && !use_menu)

--- a/src/inventory/item-getter.c
+++ b/src/inventory/item-getter.c
@@ -81,7 +81,7 @@ static bool check_item_tag_inventory(player_type *owner_ptr, item_selection_type
         return FALSE;
 
     if (*prev_tag && command_cmd) {
-        
+
         bool flag = FALSE;
         item_use_flag use_flag = (*item_selection_ptr->cp >= INVEN_MAIN_HAND) ? USE_EQUIP : USE_INVEN;
 
@@ -309,9 +309,10 @@ bool get_item(player_type *owner_ptr, OBJECT_IDX *cp, concptr pmt, concptr str, 
         if (!command_wrk) {
             sprintf(item_selection_ptr->out_val, _("持ち物:", "Inven:"));
             if ((item_selection_ptr->i1 <= item_selection_ptr->i2) && !use_menu) {
-                sprintf(item_selection_ptr->tmp_val, _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(item_selection_ptr->i1),
+                char tmp_val[80];
+                sprintf(tmp_val, _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(item_selection_ptr->i1),
                     index_to_label(item_selection_ptr->i2));
-                strcat(item_selection_ptr->out_val, item_selection_ptr->tmp_val);
+                strcat(item_selection_ptr->out_val, tmp_val);
             }
 
             if (!command_see && !use_menu)
@@ -322,9 +323,10 @@ bool get_item(player_type *owner_ptr, OBJECT_IDX *cp, concptr pmt, concptr str, 
         } else {
             sprintf(item_selection_ptr->out_val, _("装備品:", "Equip:"));
             if ((item_selection_ptr->e1 <= item_selection_ptr->e2) && !use_menu) {
-                sprintf(item_selection_ptr->tmp_val, _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(item_selection_ptr->e1),
+                char tmp_val[80];
+                sprintf(tmp_val, _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(item_selection_ptr->e1),
                     index_to_label(item_selection_ptr->e2));
-                strcat(item_selection_ptr->out_val, item_selection_ptr->tmp_val);
+                strcat(item_selection_ptr->out_val, tmp_val);
             }
 
             if (!command_see && !use_menu)

--- a/src/inventory/item-selection-util.h
+++ b/src/inventory/item-selection-util.h
@@ -27,7 +27,7 @@ typedef struct fis_type {
     bool allow_inven;
     bool allow_floor;
     bool toggle;
-    char tmp_val[160];
+    char tmp_val[320];
     char out_val[160];
     ITEM_NUMBER floor_num;
     OBJECT_IDX floor_list[23];
@@ -59,7 +59,7 @@ typedef struct item_selection_type {
     bool floor;
     bool allow_floor;
     bool toggle;
-    char tmp_val[160];
+    char tmp_val[320];
     char out_val[160];
     int menu_line;
     int max_inven;

--- a/src/io/files-util.c
+++ b/src/io/files-util.c
@@ -61,7 +61,7 @@ errr file_character(player_type *creature_ptr, concptr name, update_playtime_pf 
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, name);
     int fd = fd_open(buf, O_RDONLY);
     if (fd >= 0) {
-        char out_val[160];
+        char out_val[sizeof(buf) + 128];
         (void)fd_close(fd);
         (void)sprintf(out_val, _("現存するファイル %s に上書きしますか? ", "Replace existing file %s? "), buf);
         if (get_check_strict(creature_ptr, out_val, CHECK_NO_HISTORY))

--- a/src/io/record-play-movie.c
+++ b/src/io/record-play-movie.c
@@ -166,7 +166,7 @@ static bool string_is_repeat(char *str, int len)
 
 static errr send_text_to_chuukei_server(TERM_LEN x, TERM_LEN y, int len, TERM_COLOR col, concptr str)
 {
-    char buf[1024];
+    char buf[1024 + 32];
     char buf2[1024];
 
     strncpy(buf2, str, len);
@@ -292,7 +292,7 @@ void prepare_movie_hooks(player_type *player_ptr)
 
             /* Existing file */
             if (fd >= 0) {
-                char out_val[160];
+                char out_val[sizeof(buf) + 128];
                 (void)fd_close(fd);
 
                 /* Build query */
@@ -489,7 +489,7 @@ static bool flush_ringbuf_client(void)
 #endif
             update_term_size(x, y, len);
             (void)((*angband_term[0]->text_hook)(x, y, len, (byte)col, mesg));
-            strncpy(&Term->scr->c[y][x], mesg, len);
+            memcpy(&Term->scr->c[y][x], mesg, len);
             for (i = x; i < x + len; i++) {
                 Term->scr->a[y][i] = col;
             }
@@ -502,7 +502,7 @@ static bool flush_ringbuf_client(void)
             mesg[i] = '\0';
             update_term_size(x, y, len);
             (void)((*angband_term[0]->text_hook)(x, y, len, (byte)col, mesg));
-            strncpy(&Term->scr->c[y][x], mesg, len);
+            memcpy(&Term->scr->c[y][x], mesg, len);
             for (i = x; i < x + len; i++) {
                 Term->scr->a[y][i] = col;
             }
@@ -511,7 +511,7 @@ static bool flush_ringbuf_client(void)
         case 's': /* 一文字 */
             update_term_size(x, y, 1);
             (void)((*angband_term[0]->text_hook)(x, y, 1, (byte)col, mesg));
-            strncpy(&Term->scr->c[y][x], mesg, 1);
+            memcpy(&Term->scr->c[y][x], mesg, 1);
             Term->scr->a[y][x] = col;
             break;
 

--- a/src/knowledge/knowledge-quests.c
+++ b/src/knowledge/knowledge-quests.c
@@ -45,8 +45,8 @@ void do_cmd_checkquest(player_type *creature_ptr)
  */
 static void do_cmd_knowledge_quests_current(player_type *creature_ptr, FILE *fff)
 {
-    char tmp_str[120];
-    char rand_tmp_str[120] = "\0";
+    char tmp_str[1024];
+    char rand_tmp_str[512] = "\0";
     GAME_TEXT name[MAX_NLEN];
     monster_race *r_ptr;
     int rand_level = 100;
@@ -75,7 +75,7 @@ static void do_cmd_knowledge_quests_current(player_type *creature_ptr, FILE *fff
 
         total++;
         if (quest[i].type != QUEST_TYPE_RANDOM) {
-            char note[80] = "\0";
+            char note[512] = "\0";
 
             if (quest[i].status == QUEST_STATUS_TAKEN || quest[i].status == QUEST_STATUS_STAGE_COMPLETED) {
                 switch (quest[i].type) {

--- a/src/load/floor-loader.c
+++ b/src/load/floor-loader.c
@@ -313,7 +313,7 @@ bool load_floor(player_type *player_ptr, saved_floor_type *sf_ptr, BIT_FLAGS mod
         old_h_ver_extra = current_world_ptr->h_ver_extra;
     }
 
-    char floor_savefile[1024];
+    char floor_savefile[sizeof(savefile) + 32];
     sprintf(floor_savefile, "%s.F%02d", savefile, (int)sf_ptr->savefile_id);
 
     safe_setuid_grab(player_ptr);

--- a/src/lore/lore-calculator.c
+++ b/src/lore/lore-calculator.c
@@ -117,7 +117,7 @@ void set_damage(player_type *player_ptr, lore_type *lore_ptr, monster_spell_type
     int dice_side = monspell_race_damage(player_ptr, ms_type, r_idx, DICE_SIDE);
     int dice_mult = monspell_race_damage(player_ptr, ms_type, r_idx, DICE_MULT);
     int dice_div = monspell_race_damage(player_ptr, ms_type, r_idx, DICE_DIV);
-    char dmg_str[80], dice_str[80];
+    char dmg_str[80], dice_str[sizeof(dmg_str) + 10];
     char *tmp = lore_ptr->tmp_msg[lore_ptr->vn];
     dice_to_string(base_damage, dice_num, dice_side, dice_mult, dice_div, dmg_str);
     sprintf(dice_str, "(%s)", dmg_str);

--- a/src/main/angband-initializer.c
+++ b/src/main/angband-initializer.c
@@ -226,7 +226,7 @@ void init_angband(player_type *player_ptr, process_autopick_file_command_pf proc
     path_build(buf, sizeof(buf), ANGBAND_DIR_FILE, _("news_j.txt", "news.txt"));
     int fd = fd_open(buf, O_RDONLY);
     if (fd < 0) {
-        char why[1024];
+        char why[sizeof(buf) + 128];
         sprintf(why, _("'%s'ファイルにアクセスできません!", "Cannot access the '%s' file!"), buf);
         init_angband_aux(why);
     }
@@ -258,7 +258,7 @@ void init_angband(player_type *player_ptr, process_autopick_file_command_pf proc
         fd = fd_make(buf, file_permission);
         safe_setuid_drop();
         if (fd < 0) {
-            char why[1024];
+            char why[sizeof(buf) + 128];
             sprintf(why, _("'%s'ファイルを作成できません!", "Cannot create the '%s' file!"), buf);
             init_angband_aux(why);
         }

--- a/src/market/bounty.c
+++ b/src/market/bounty.c
@@ -49,7 +49,7 @@ bool exchange_cash(player_type *player_ptr)
     for (INVENTORY_IDX i = 0; i <= INVEN_SUB_HAND; i++) {
         o_ptr = &player_ptr->inventory_list[i];
         if ((o_ptr->tval == TV_CAPTURE) && (o_ptr->pval == MON_TSUCHINOKO)) {
-            char buf[MAX_NLEN + 20];
+            char buf[MAX_NLEN + 32];
             describe_flavor(player_ptr, o_name, o_ptr, 0);
             sprintf(buf, _("%s を換金しますか？", "Convert %s into money? "), o_name);
             if (get_check(buf)) {
@@ -66,7 +66,7 @@ bool exchange_cash(player_type *player_ptr)
     for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
         o_ptr = &player_ptr->inventory_list[i];
         if ((o_ptr->tval == TV_CORPSE) && (o_ptr->sval == SV_CORPSE) && (o_ptr->pval == MON_TSUCHINOKO)) {
-            char buf[MAX_NLEN + 20];
+            char buf[MAX_NLEN + 32];
             describe_flavor(player_ptr, o_name, o_ptr, 0);
             sprintf(buf, _("%s を換金しますか？", "Convert %s into money? "), o_name);
             if (get_check(buf)) {
@@ -83,7 +83,7 @@ bool exchange_cash(player_type *player_ptr)
     for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
         o_ptr = &player_ptr->inventory_list[i];
         if ((o_ptr->tval == TV_CORPSE) && (o_ptr->sval == SV_SKELETON) && (o_ptr->pval == MON_TSUCHINOKO)) {
-            char buf[MAX_NLEN + 20];
+            char buf[MAX_NLEN + 32];
             describe_flavor(player_ptr, o_name, o_ptr, 0);
             sprintf(buf, _("%s を換金しますか？", "Convert %s into money? "), o_name);
             if (get_check(buf)) {
@@ -100,7 +100,7 @@ bool exchange_cash(player_type *player_ptr)
     for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
         o_ptr = &player_ptr->inventory_list[i];
         if ((o_ptr->tval == TV_CORPSE) && (o_ptr->sval == SV_CORPSE) && (streq(r_name + r_info[o_ptr->pval].name, r_name + r_info[today_mon].name))) {
-            char buf[MAX_NLEN + 20];
+            char buf[MAX_NLEN + 32];
             describe_flavor(player_ptr, o_name, o_ptr, 0);
             sprintf(buf, _("%s を換金しますか？", "Convert %s into money? "), o_name);
             if (get_check(buf)) {
@@ -118,7 +118,7 @@ bool exchange_cash(player_type *player_ptr)
         o_ptr = &player_ptr->inventory_list[i];
 
         if ((o_ptr->tval == TV_CORPSE) && (o_ptr->sval == SV_SKELETON) && (streq(r_name + r_info[o_ptr->pval].name, r_name + r_info[today_mon].name))) {
-            char buf[MAX_NLEN + 20];
+            char buf[MAX_NLEN + 32];
             describe_flavor(player_ptr, o_name, o_ptr, 0);
             sprintf(buf, _("%s を換金しますか？", "Convert %s into money? "), o_name);
             if (get_check(buf)) {

--- a/src/market/building-monster.c
+++ b/src/market/building-monster.c
@@ -22,7 +22,7 @@
  */
 bool research_mon(player_type *player_ptr)
 {
-    char buf[128];
+    char buf[256];
     bool notpicked;
     bool recall = FALSE;
     u16b why = 0;

--- a/src/object/object-info.c
+++ b/src/object/object-info.c
@@ -65,8 +65,8 @@ static concptr item_activation_dragon_breath(player_type *owner_ptr, object_type
  */
 static concptr item_activation_aux(player_type *owner_ptr, object_type *o_ptr)
 {
-    static char activation_detail[256];
-    char timeout[32];
+    static char activation_detail[512];
+    char timeout[64];
     const activation_type *const act_ptr = find_activation_info(owner_ptr, o_ptr);
 
     if (!act_ptr)

--- a/src/save/floor-writer.c
+++ b/src/save/floor-writer.c
@@ -260,7 +260,7 @@ bool save_floor(player_type *player_ptr, saved_floor_type *sf_ptr, BIT_FLAGS mod
     u32b old_v_stamp = 0;
     u32b old_x_stamp = 0;
 
-    char floor_savefile[1024];
+    char floor_savefile[sizeof(savefile) + 32];
     if ((mode & SLF_SECOND) != 0) {
         old_fff = saving_savefile;
         old_xor_byte = save_xor_byte;

--- a/src/status/shape-changer.c
+++ b/src/status/shape-changer.c
@@ -105,6 +105,7 @@ void do_poly_self(player_type *creature_ptr)
 
     if ((power > randint0(20)) && one_in_(3) && (creature_ptr->prace != RACE_ANDROID)) {
         char effect_msg[80] = "";
+        char sex_msg[32] = "";
         player_race_type new_race;
 
         power -= 10;
@@ -113,11 +114,11 @@ void do_poly_self(player_type *creature_ptr)
             if (creature_ptr->psex == SEX_MALE) {
                 creature_ptr->psex = SEX_FEMALE;
                 sp_ptr = &sex_info[creature_ptr->psex];
-                sprintf(effect_msg, _("女性の", "female "));
+                sprintf(sex_msg, _("女性の", "female"));
             } else {
                 creature_ptr->psex = SEX_MALE;
                 sp_ptr = &sex_info[creature_ptr->psex];
-                sprintf(effect_msg, _("男性の", "male "));
+                sprintf(sex_msg, _("男性の", "male"));
             }
         }
 
@@ -134,10 +135,8 @@ void do_poly_self(player_type *creature_ptr)
 
             (void)dec_stat(creature_ptr, A_CHR, randint1(6), TRUE);
 
-            if (effect_msg[0]) {
-                char tmp_msg[10];
-                sprintf(tmp_msg, _("%s", "%s "), effect_msg);
-                sprintf(effect_msg, _("奇形の%s", "deformed %s "), tmp_msg);
+            if (sex_msg[0]) {
+                sprintf(effect_msg, _("奇形の%s", "deformed %s "), sex_msg);
             } else {
                 sprintf(effect_msg, _("奇形の", "deformed "));
             }

--- a/src/window/display-sub-window-spells.c
+++ b/src/window/display-sub-window-spells.c
@@ -51,7 +51,7 @@ static void display_spell_list(player_type *caster_ptr)
         PERCENTAGE chance = 0;
         mind_type spell;
         char comment[80];
-        char psi_desc[80];
+        char psi_desc[160];
         int use_mind;
         bool use_hp = FALSE;
 

--- a/src/wizard/fixed-artifacts-spoiler.c
+++ b/src/wizard/fixed-artifacts-spoiler.c
@@ -20,7 +20,7 @@
  */
 void spoiler_outlist(concptr header, concptr *list, char separator)
 {
-    char line[MAX_LINE_LEN + 1], buf[80];
+    char line[MAX_LINE_LEN + 20], buf[80];
     if (*list == NULL)
         return;
 
@@ -70,7 +70,7 @@ void spoiler_outlist(concptr header, concptr *list, char separator)
  */
 static void print_header(void)
 {
-    char buf[180];
+    char buf[360];
     char title[180];
     put_version(title);
     sprintf(buf, "Artifact Spoilers for Hengband Version %s", title);

--- a/src/wizard/wizard-messages.c
+++ b/src/wizard/wizard-messages.c
@@ -16,7 +16,7 @@ void msg_print_wizard(player_type *player_ptr, int cheat_type, concptr msg)
         return;
 
     concptr cheat_mes[] = { "ITEM", "MONS", "DUNG", "MISC" };
-    char buf[1024];
+    char buf[1024 + 32];
     sprintf(buf, "WIZ-%s:%s", cheat_mes[cheat_type], msg);
     msg_print(buf);
 


### PR DESCRIPTION
C++移行前に、いい加減 -Wno-format-overflow のスイッチは削除したいので、バッファ容量不足の可能性の警告に対処した。