### PR TITLE
[Refactor] calc_stealthの分解・整理し隠密修正の成分取得を可能とする

### DIFF
--- a/src/player/player-status-flags.c
+++ b/src/player/player-status-flags.c
@@ -163,7 +163,7 @@ BIT_FLAGS get_player_flags(player_type *creature_ptr, tr_type tr_flag)
     case TR_FORCE_WEAPON:
         return check_equipment_flags(creature_ptr, tr_flag);
     case TR_STEALTH:
-        return 0;
+        return player_flags_stealth(creature_ptr);
     case TR_SEARCH:
         return 0;
     case TR_INFRA:

--- a/src/player/player-status.h
+++ b/src/player/player-status.h
@@ -52,11 +52,7 @@ enum empty_hand_status {
 };
 
 /*!< Weapon hand status */
-typedef enum player_hand {
-    PLAYER_HAND_MAIN = 0x0000,
-    PLAYER_HAND_SUB = 0x0001,
-    PLAYER_HAND_OTHER = 0x0002
-} player_hand;
+typedef enum player_hand { PLAYER_HAND_MAIN = 0x0000, PLAYER_HAND_SUB = 0x0001, PLAYER_HAND_OTHER = 0x0002 } player_hand;
 
 /*
  * Player sex constants (hard-coded by save-files, arrays, etc)
@@ -482,6 +478,7 @@ extern WEIGHT calc_inventory_weight(player_type *creature_ptr);
 
 extern s16b calc_num_fire(player_type *creature_ptr, object_type *o_ptr);
 BIT_FLAGS player_flags_speed(player_type *creature_ptr);
+BIT_FLAGS player_flags_stealth(player_type *creature_ptr);
 static void update_bonuses(player_type *creature_ptr);
 extern WEIGHT calc_weight_limit(player_type *creature_ptr);
 extern bool has_melee_weapon(player_type *creature_ptr, int i);


### PR DESCRIPTION
プレイヤーの隠密計算をcalc_stealth()で一括で行っていたが、これを隠密修正の原因毎に分解する。
分解した処理を流用してplayer_flags_stealth()を作成し、隠密修正の原因をBIT_FLAGSで取得可能とする。
現時点では、Cの画面2に一時的隠密が反映されるようになった。呪術、狂戦士化、隠遁の歌が該当する。