### PR TITLE
[Fix] モンスターの思い出の経験値表示でクラッシュ (英語版)

### DIFF
--- a/src/term/z-form.c
+++ b/src/term/z-form.c
@@ -70,11 +70,17 @@
  * Format("%ld", long int i)
  *   Append the long integer "i".
  *
+ * Format("%Ld", long long int i)
+ *   Append the long long integer "i".
+ *
  * Format("%d", int i)
  *   Append the integer "i".
  *
  * Format("%lu", unsigned long int i)
  *   Append the unsigned long integer "i".
+ *
+ * Format("%Lu", unsigned long long int i)
+ *   Append the unsigned long long integer "i".
  *
  * Format("%u", unsigned int i)
  *   Append the unsigned integer "i".
@@ -238,6 +244,9 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
 	/* The argument is "long" */
 	bool do_long;
 
+    /* The argument is "long long" */
+    bool do_long_long;
+
 	/* The argument needs "processing" */
 	bool do_xtra;
 
@@ -338,6 +347,9 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
 		/* Assume no "long" argument */
 		do_long = FALSE;
 
+        /* Assume no "long long" argument */
+        do_long_long = FALSE;
+
 		/* Assume no "xtra" processing */
 		do_xtra = FALSE;
 
@@ -380,12 +392,12 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
 				/* Mega-Hack -- handle "extra-long" request */
 				else if (*s == 'L')
 				{
-					/* Error -- illegal format char */
-					buf[0] = '\0';
+                    /* Save the character */
+                    aux[q++] = *s++;
 
-					/* Return "error" */
-					return 0;
-				}
+                    /* Note the "long long" flag */
+                    do_long_long = TRUE;
+                }
 
 				/* Handle normal end of format sequence */
 				else
@@ -475,6 +487,16 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
 					/* Format the argument */
 					sprintf(tmp, aux, arg);
 				}
+				else if (do_long_long)
+				{
+					long long arg;
+
+					/* Access next argument */
+					arg = va_arg(vp, long long);
+
+					/* Format the argument */
+					sprintf(tmp, "%lld", arg);
+				}
 				else
 				{
 					int arg;
@@ -500,6 +522,15 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
 					arg = va_arg(vp, unsigned long);
 
 					sprintf(tmp, aux, arg);
+				}
+				if (do_long_long)
+				{
+					unsigned long long arg;
+
+					/* Access next argument */
+					arg = va_arg(vp, unsigned long long);
+
+					sprintf(tmp, "%llu", arg);
 				}
 				else
 				{

--- a/src/view/display-lore.c
+++ b/src/view/display-lore.c
@@ -373,35 +373,45 @@ void display_monster_exp(player_type *player_ptr, lore_type *lore_ptr)
 #endif
 
     int64_t base_exp = lore_ptr->r_ptr->mexp * lore_ptr->r_ptr->level * 3 / 2;
-    int64_t player_factor = player_ptr->max_plv + 2;
+    int64_t player_factor = (int64_t)player_ptr->max_plv + 2;
     
     int64_t exp_integer = base_exp / player_factor;
     int64_t exp_decimal = ((base_exp % player_factor * 1000 / player_factor) + 5) / 10;
 
 #ifdef JP
-    hooked_roff(format(" %d レベルのキャラクタにとって 約%ld.%02ld ポイントの経験となる。", player_ptr->lev, exp_integer, exp_decimal));
+    hooked_roff(format(" %d レベルのキャラクタにとって 約%Ld.%02Ld ポイントの経験となる。", player_ptr->lev, exp_integer, exp_decimal));
 #else
-    hooked_roff(format(" is worth about %ld.%02ld point%s", exp_integer, exp_decimal, ((exp_integer == 1) && (exp_decimal == 0)) ? "" : "s"));
+    hooked_roff(format(" is worth about %Ld.%02Ld point%s", exp_integer, exp_decimal, ((exp_integer == 1) && (exp_decimal == 0)) ? "" : "s"));
 
-    char *ordinal;
-    ordinal = "th";
-    exp_integer = player_ptr->lev % 10;
-    if ((player_ptr->lev / 10) != 1) {
-        if (exp_integer == 1)
-            ordinal = "st";
-        else if (exp_integer == 2)
-            ordinal = "nd";
-        else if (exp_integer == 3)
-            ordinal = "rd";
+    concptr ordinal;
+    switch (player_ptr->lev % 10) {
+    case 1:
+        ordinal = "st";
+        break;
+    case 2:
+        ordinal = "nd";
+        break;
+    case 3:
+        ordinal = "rd";
+        break;
+    default:
+        ordinal = "th";
+        break;
     }
 
-    char *vowel;
-    vowel = "";
-    exp_integer = player_ptr->lev;
-    if ((exp_integer == 8) || (exp_integer == 11) || (exp_integer == 18))
+    concptr vowel;
+    switch (player_ptr->lev) {
+    case 8:
+    case 11:
+    case 18:
         vowel = "n";
+        break;
+    default:
+        vowel = "";
+        break;
+    }
 
-    hooked_roff(format(" for a%s %lu%s level character.  ", vowel, (long)exp_integer, ordinal));
+    hooked_roff(format(" for a%s %d%s level character.  ", vowel, player_ptr->lev, ordinal));
 #endif
 }
 


### PR DESCRIPTION
format()にint64_tの経験値を渡していたが、%ldが64bitに対応できていないようでクラッシュしていた。
とりあえず(int32_t)へのキャストで対応してみたが、format()文を2つに分けても動作はする。

```
    hooked_roff(format(" is worth about %ld", exp_integer));
    hooked_roff(format(".%02ld point%s", exp_decimal, ((exp_integer == 1) && (exp_decimal == 0)) ? "" : "s"));
```