### PR TITLE
店舗の常時陳列商品を設定

### DIFF
--- a/src/cmd-building/cmd-store.c
+++ b/src/cmd-building/cmd-store.c
@@ -90,8 +90,7 @@ void do_cmd_store(player_type *player_ptr)
     if (maintain_num > 10)
         maintain_num = 10;
     if (maintain_num) {
-        for (int i = 0; i < maintain_num; i++)
-            store_maintenance(player_ptr, player_ptr->town_num, which);
+        store_maintenance(player_ptr, player_ptr->town_num, which, maintain_num);
 
         town_info[player_ptr->town_num].store[which].last_visit = current_world_ptr->game_turn;
     }

--- a/src/market/articles-on-sale.c
+++ b/src/market/articles-on-sale.c
@@ -1,5 +1,4 @@
 ﻿#include "market/articles-on-sale.h"
-#include "object/tval-types.h"
 #include "sv-definition/sv-amulet-types.h"
 #include "sv-definition/sv-armor-types.h"
 #include "sv-definition/sv-bow-types.h"
@@ -11,14 +10,110 @@
 #include "sv-definition/sv-protector-types.h"
 #include "sv-definition/sv-scroll-types.h"
 #include "sv-definition/sv-ring-types.h"
+#include "sv-definition/sv-rod-types.h"
 #include "sv-definition/sv-staff-types.h"
 #include "sv-definition/sv-wand-types.h"
 #include "sv-definition/sv-weapon-types.h"
 
 /*!
- * 店舗で販売するオブジェクトを定義する / Hack -- Objects sold in the stores -- by tval/sval pair.
+ * @brief 店舗で常時販売するオブジェクトを定義する 
+ * @detail
+ * 上から優先して配置する。
+ * 重複して同じ商品を設定した場合、数量が増える。
+ * 17エントリーまで設定可能。(最後は TV_NONE で止める)
+ * 種類が多すぎる場合、店舗を埋めつくすので注意。
  */
-byte store_table[MAX_STORES][STORE_CHOICES][2] =
+store_stock_item_type store_regular_table[MAX_STORES][STORE_MAX_KEEP] =
+{ 
+	{
+        /* General Store */
+        { TV_FOOD, SV_FOOD_RATION },
+        { TV_LITE, SV_LITE_TORCH },
+        { TV_LITE, SV_LITE_LANTERN },
+        { TV_FLASK, SV_FLASK_OIL },
+        { TV_POTION, SV_POTION_WATER },
+        { TV_SPIKE, 0 },
+        { TV_NONE, 0 },
+    },
+    {
+        /* Armoury */
+        { TV_NONE, 0 },
+    },
+    {
+        /* Weaponsmith */
+        { TV_HISSATSU_BOOK, 0 },
+        { TV_SHOT, SV_AMMO_NORMAL },
+        { TV_SHOT, SV_AMMO_NORMAL },
+        { TV_ARROW, SV_AMMO_NORMAL },
+        { TV_ARROW, SV_AMMO_NORMAL },
+        { TV_BOLT, SV_AMMO_NORMAL },
+        { TV_BOLT, SV_AMMO_NORMAL },
+        { TV_NONE, 0 },
+    },
+    {
+        /* Temple */
+        { TV_POTION, SV_POTION_CURE_CRITICAL },
+        { TV_POTION, SV_POTION_CURE_SERIOUS },
+        { TV_POTION, SV_POTION_HEROISM },
+        { TV_SCROLL, SV_SCROLL_WORD_OF_RECALL },
+        { TV_SCROLL, SV_SCROLL_REMOVE_CURSE },
+        { TV_LIFE_BOOK, 0 },
+        { TV_CRUSADE_BOOK, 0 },
+        { TV_NONE, 0 },
+    },
+    {
+        /* Alchemy shop */
+        { TV_SCROLL, SV_SCROLL_PHASE_DOOR },
+        { TV_SCROLL, SV_SCROLL_PHASE_DOOR },
+        { TV_SCROLL, SV_SCROLL_TELEPORT },
+        { TV_SCROLL, SV_SCROLL_TELEPORT },
+        { TV_SCROLL, SV_SCROLL_RECHARGING },
+        { TV_SCROLL, SV_SCROLL_IDENTIFY },
+        { TV_SCROLL, SV_SCROLL_DETECT_GOLD },
+        { TV_NONE, 0 },
+    },
+    {
+        /* Magic User */
+        { TV_STAFF, SV_STAFF_IDENTIFY },
+        { TV_STAFF, SV_STAFF_IDENTIFY },
+        { TV_STAFF, SV_STAFF_MAPPING },
+        { TV_ARCANE_BOOK, 0 },
+        { TV_SORCERY_BOOK, 0 },
+        { TV_NONE, 0 },
+    },
+    {
+        /* Blackmarket */
+        { TV_NONE, 0 },
+    },
+    {
+        /* Home */
+        { TV_NONE, 0 },
+    },
+    {
+        /* Bookstore */
+        { TV_SORCERY_BOOK, 0 },
+        { TV_NATURE_BOOK, 0 },
+        { TV_CHAOS_BOOK, 0 },
+        { TV_DEATH_BOOK, 0 },
+        { TV_TRUMP_BOOK, 0 },
+        { TV_ARCANE_BOOK, 0 },
+        { TV_CRAFT_BOOK, 0 },
+        { TV_DEMON_BOOK, 0 },
+        { TV_MUSIC_BOOK, 0 },
+        { TV_HEX_BOOK, 0 },
+        { TV_NONE, 0 },
+    },
+    {
+        /* Museum */
+        { TV_NONE, 0 },
+    },
+};
+
+/*!
+ * @brief 店舗でランダム販売するオブジェクトを定義する
+ * @detail tval/svalのペア
+ */
+store_stock_item_type store_table[MAX_STORES][STORE_CHOICES] =
 {
 	{
 		/* General Store */
@@ -27,60 +122,60 @@ byte store_table[MAX_STORES][STORE_CHOICES][2] =
 		{ TV_FOOD, SV_FOOD_RATION },
 		{ TV_FOOD, SV_FOOD_RATION },
 
-		{ TV_FOOD, SV_FOOD_RATION },
 		{ TV_FOOD, SV_FOOD_BISCUIT },
 		{ TV_FOOD, SV_FOOD_JERKY },
-		{ TV_FOOD, SV_FOOD_JERKY },
-
 		{ TV_FOOD, SV_FOOD_PINT_OF_WINE },
 		{ TV_FOOD, SV_FOOD_PINT_OF_ALE },
-		{ TV_LITE, SV_LITE_TORCH },
-		{ TV_LITE, SV_LITE_TORCH },
 
 		{ TV_LITE, SV_LITE_TORCH },
 		{ TV_LITE, SV_LITE_TORCH },
 		{ TV_LITE, SV_LITE_LANTERN },
 		{ TV_LITE, SV_LITE_LANTERN },
 
-		{ TV_FLASK, 0 },
-		{ TV_FLASK, 0 },
-		{ TV_FLASK, 0 },
-		{ TV_FLASK, 0 },
+		{ TV_POTION, SV_POTION_WATER },
+		{ TV_POTION, SV_POTION_WATER },
+		{ TV_FOOD, SV_FOOD_WAYBREAD },
+		{ TV_FOOD, SV_FOOD_WAYBREAD },
 
 		{ TV_FLASK, 0 },
 		{ TV_FLASK, 0 },
 		{ TV_SPIKE, 0 },
 		{ TV_SPIKE, 0 },
 
+		{ TV_SPIKE, 0 },
+		{ TV_SPIKE, 0 },
 		{ TV_SHOT, SV_AMMO_NORMAL },
+		{ TV_SHOT, SV_AMMO_NORMAL },
+
+		{ TV_ARROW, SV_AMMO_NORMAL },
 		{ TV_ARROW, SV_AMMO_NORMAL },
 		{ TV_BOLT, SV_AMMO_NORMAL },
-		{ TV_DIGGING, SV_SHOVEL },
+		{ TV_BOLT, SV_AMMO_NORMAL },
 
+		{ TV_DIGGING, SV_SHOVEL },
+		{ TV_DIGGING, SV_SHOVEL },
 		{ TV_DIGGING, SV_PICK },
 		{ TV_CLOAK, SV_CLOAK },
+
 		{ TV_CLOAK, SV_CLOAK },
 		{ TV_CLOAK, SV_FUR_CLOAK },
-
-		{ TV_FOOD, SV_FOOD_RATION },
-		{ TV_FOOD, SV_FOOD_RATION },
-		{ TV_FOOD, SV_FOOD_RATION },
-		{ TV_FOOD, SV_FOOD_RATION },
-
-		{ TV_POTION, SV_POTION_WATER },
-		{ TV_POTION, SV_POTION_WATER },
-		{ TV_LITE, SV_LITE_LANTERN },
-		{ TV_LITE, SV_LITE_LANTERN },
-
-		{ TV_FOOD, SV_FOOD_WAYBREAD },
-		{ TV_FOOD, SV_FOOD_WAYBREAD },
 		{ TV_CAPTURE, 0 },
-		{ TV_FIGURINE, 0 },
+		{ TV_CAPTURE, 0 },
 
-		{ TV_SHOT, SV_AMMO_NORMAL },
-		{ TV_ARROW, SV_AMMO_NORMAL },
-		{ TV_BOLT, SV_AMMO_NORMAL },
-		{ TV_DIGGING, SV_SHOVEL }
+		{ TV_FIGURINE, 0 },
+        { TV_WHISTLE, 1 },
+        { TV_ROD, SV_ROD_PESTICIDE },
+        { TV_STATUE, SV_ANY },
+
+		{ TV_NONE, 0 },
+        { TV_NONE, 0 },
+        { TV_NONE, 0 },
+        { TV_NONE, 0 },
+
+		{ TV_NONE, 0 },
+        { TV_NONE, 0 },
+        { TV_NONE, 0 },
+        { TV_NONE, 0 },
 	},
 
 	{
@@ -226,28 +321,33 @@ byte store_table[MAX_STORES][STORE_CHOICES][2] =
 		{ TV_SCROLL, SV_SCROLL_BLESSING },
 		{ TV_SCROLL, SV_SCROLL_HOLY_CHANT },
 
+		{ TV_SCROLL, SV_SCROLL_WORD_OF_RECALL },
+		{ TV_SCROLL, SV_SCROLL_WORD_OF_RECALL },
+		{ TV_SCROLL, SV_SCROLL_WORD_OF_RECALL },
+        { TV_POTION, SV_POTION_CURE_LIGHT },
+
 		{ TV_POTION, SV_POTION_HEROISM },
-		{ TV_SCROLL, SV_SCROLL_WORD_OF_RECALL },
-		{ TV_SCROLL, SV_SCROLL_WORD_OF_RECALL },
-		{ TV_SCROLL, SV_SCROLL_WORD_OF_RECALL },
-
-		{ TV_POTION, SV_POTION_CURE_LIGHT },
+		{ TV_POTION, SV_POTION_HEROISM },
 		{ TV_POTION, SV_POTION_CURE_SERIOUS },
 		{ TV_POTION, SV_POTION_CURE_SERIOUS },
-		{ TV_POTION, SV_POTION_CURE_CRITICAL },
 
 		{ TV_POTION, SV_POTION_CURE_CRITICAL },
+		{ TV_POTION, SV_POTION_CURE_CRITICAL },
+		{ TV_POTION, SV_POTION_CURE_CRITICAL },
+		{ TV_POTION, SV_POTION_CURE_CRITICAL },
+
+		{ TV_POTION, SV_POTION_RESTORE_EXP },
 		{ TV_POTION, SV_POTION_RESTORE_EXP },
 		{ TV_POTION, SV_POTION_RESTORE_EXP },
 		{ TV_POTION, SV_POTION_RESTORE_EXP },
 
 		{ TV_LIFE_BOOK, 0 },
-		{ TV_LIFE_BOOK, 0 },
+		{ TV_LIFE_BOOK, 1 },
 		{ TV_LIFE_BOOK, 1 },
 		{ TV_LIFE_BOOK, 1 },
 
 		{ TV_CRUSADE_BOOK, 0 },
-		{ TV_CRUSADE_BOOK, 0 },
+		{ TV_CRUSADE_BOOK, 1 },
 		{ TV_CRUSADE_BOOK, 1 },
 		{ TV_CRUSADE_BOOK, 1 },
 
@@ -256,21 +356,15 @@ byte store_table[MAX_STORES][STORE_CHOICES][2] =
 		{ TV_HAFTED, SV_BALL_AND_CHAIN },
 		{ TV_HAFTED, SV_WAR_HAMMER },
 
-		{ TV_SCROLL, SV_SCROLL_WORD_OF_RECALL },
-		{ TV_SCROLL, SV_SCROLL_WORD_OF_RECALL },
-		{ TV_SCROLL, SV_SCROLL_WORD_OF_RECALL },
-		{ TV_POTION, SV_POTION_CURE_CRITICAL },
-
-		{ TV_POTION, SV_POTION_CURE_CRITICAL },
-		{ TV_POTION, SV_POTION_RESTORE_EXP },
-
+		{ TV_POTION, SV_POTION_RESIST_HEAT },
+		{ TV_POTION, SV_POTION_RESIST_COLD },
 		{ TV_FIGURINE, 0 },
 		{ TV_STATUE, SV_ANY },
 
 		{ TV_SCROLL, SV_SCROLL_REMOVE_CURSE },
 		{ TV_SCROLL, SV_SCROLL_REMOVE_CURSE },
 		{ TV_SCROLL, SV_SCROLL_STAR_REMOVE_CURSE },
-		{ TV_SCROLL, SV_SCROLL_STAR_REMOVE_CURSE }
+		{ TV_SCROLL, SV_SCROLL_STAR_REMOVE_CURSE },
 	},
 
 	{

--- a/src/market/articles-on-sale.h
+++ b/src/market/articles-on-sale.h
@@ -1,8 +1,16 @@
 ﻿#pragma once
 
+#include "store/store.h"
 #include "store/store-owners.h"
+#include "object/tval-types.h"
 #include "system/angband.h"
 
 #define STORE_CHOICES   48 /* Number of items to choose stock from */
 
-extern byte store_table[MAX_STORES][STORE_CHOICES][2];
+typedef struct store_stock_item_type {
+    tval_type tval;
+    OBJECT_SUBTYPE_VALUE sval;
+} store_stock_item_type;
+
+extern store_stock_item_type store_regular_table[MAX_STORES][STORE_MAX_KEEP];
+extern store_stock_item_type store_table[MAX_STORES][STORE_CHOICES];

--- a/src/market/building-initializer.c
+++ b/src/market/building-initializer.c
@@ -2,6 +2,7 @@
 #include "floor/floor-town.h"
 #include "market/articles-on-sale.h"
 #include "object/object-kind.h"
+#include "object/object-kind-hook.h"
 #include "store/store-owners.h"
 #include "store/store-util.h"
 #include "store/store.h"
@@ -39,19 +40,35 @@ errr init_towns(void)
             if ((j == STORE_BLACK) || (j == STORE_HOME) || (j == STORE_MUSEUM))
                 continue;
 
-            store_ptr->table_size = STORE_CHOICES;
-            C_MAKE(store_ptr->table, store_ptr->table_size, s16b);
-            for (int k = 0; k < STORE_CHOICES; k++) {
-                KIND_OBJECT_IDX k_idx;
-                int tv = store_table[j][k][0];
-                int sv = store_table[j][k][1];
-                for (k_idx = 1; k_idx < max_k_idx; k_idx++) {
-                    object_kind *k_ptr = &k_info[k_idx];
-                    if ((k_ptr->tval == tv) && (k_ptr->sval == sv))
-                        break;
-                }
+            store_ptr->regular_num = 0;
+            store_ptr->regular_size = STORE_INVEN_MAX;
+            C_MAKE(store_ptr->regular, store_ptr->regular_size + 1, KIND_OBJECT_IDX);
+            for (int k = 0; k < store_ptr->regular_size; k++) {
+                int tv = store_regular_table[j][k].tval;
+                int sv = store_regular_table[j][k].sval;
+                if (tv == 0)
+                    break;
 
-                if (k_idx == max_k_idx)
+                KIND_OBJECT_IDX k_idx = lookup_kind(tv, sv);
+
+                if (k_idx == 0)
+                    continue;
+
+                store_ptr->regular[store_ptr->regular_num++] = k_idx;
+            }
+
+            store_ptr->table_num = 0;
+            store_ptr->table_size = STORE_CHOICES;
+            C_MAKE(store_ptr->table, store_ptr->table_size + 1, KIND_OBJECT_IDX);
+            for (int k = 0; k < store_ptr->table_size; k++) {
+                int tv = store_table[j][k].tval;
+                int sv = store_table[j][k].sval;
+                if (tv == 0)
+                    break;
+
+                KIND_OBJECT_IDX k_idx = lookup_kind(tv, sv);
+
+                if (k_idx == 0)
                     continue;
 
                 store_ptr->table[store_ptr->table_num++] = k_idx;

--- a/src/store/purchase-order.c
+++ b/src/store/purchase-order.c
@@ -292,8 +292,7 @@ static void switch_store_stock(player_type *player_ptr, const int i, const COMMA
 {
     if (st_ptr->stock_num == 0) {
         shuffle_store(player_ptr);
-        for (int j = 0; j < 10; j++)
-            store_maintenance(player_ptr, player_ptr->town_num, cur_store_num);
+        store_maintenance(player_ptr, player_ptr->town_num, cur_store_num, 10);
 
         store_top = 0;
         display_store_inventory(player_ptr);

--- a/src/store/service-checker.c
+++ b/src/store/service-checker.c
@@ -7,6 +7,7 @@
 #include "object/object-value.h"
 #include "store/store-util.h"
 #include "sv-definition/sv-potion-types.h"
+#include "sv-definition/sv-rod-types.h"
 #include "sv-definition/sv-scroll-types.h"
 #include "sv-definition/sv-weapon-types.h"
 #include "system/object-type-definition.h"
@@ -28,10 +29,10 @@ static bool is_blessed_item(player_type *player_ptr, object_type *o_ptr)
 static bool check_store_general(object_type *o_ptr)
 {
     switch (o_ptr->tval) {
+    case TV_ROD:
+        return (o_ptr->sval == SV_ROD_PESTICIDE);
     case TV_POTION:
-        if (o_ptr->sval != SV_POTION_WATER)
-            return FALSE;
-        /* Fall through */
+        return (o_ptr->sval == SV_POTION_WATER);
     case TV_WHISTLE:
     case TV_FOOD:
     case TV_LITE:

--- a/src/store/store-util.c
+++ b/src/store/store-util.c
@@ -109,28 +109,32 @@ void store_delete(void)
  * Should we check for "permission" to have the given item?
  * </pre>
  */
-void store_create(player_type *player_ptr, black_market_crap_pf black_market_crap, store_will_buy_pf store_will_buy, mass_produce_pf mass_produce)
+void store_create(
+    player_type *player_ptr, KIND_OBJECT_IDX fix_k_idx, black_market_crap_pf black_market_crap, store_will_buy_pf store_will_buy, mass_produce_pf mass_produce)
 {
     if (st_ptr->stock_num >= st_ptr->stock_size)
         return;
 
     for (int tries = 0; tries < 4; tries++) {
-        OBJECT_IDX i;
+        KIND_OBJECT_IDX k_idx;
         DEPTH level;
         if (cur_store_num == STORE_BLACK) {
             level = 25 + randint0(25);
-            i = get_obj_num(player_ptr, level, 0x00000000);
-            if (i == 0)
+            k_idx = get_obj_num(player_ptr, level, 0x00000000);
+            if (k_idx == 0)
                 continue;
+        } else if (fix_k_idx > 0) {
+            k_idx = fix_k_idx;
+            level = rand_range(1, STORE_OBJ_LEVEL);
         } else {
-            i = st_ptr->table[randint0(st_ptr->table_num)];
+            k_idx = st_ptr->table[randint0(st_ptr->table_num)];
             level = rand_range(1, STORE_OBJ_LEVEL);
         }
 
         object_type forge;
         object_type *q_ptr;
         q_ptr = &forge;
-        object_prep(player_ptr, q_ptr, i);
+        object_prep(player_ptr, q_ptr, k_idx);
         apply_magic(player_ptr, q_ptr, level, AM_NO_FIXED_ART);
         if (!(*store_will_buy)(player_ptr, q_ptr))
             continue;

--- a/src/store/store-util.h
+++ b/src/store/store-util.h
@@ -17,20 +17,23 @@
 
 typedef struct object_type object_type;
 typedef struct store_type {
-	byte type;				/* Store type */
-	byte owner;				/* Owner index */
-	byte extra;				/* Unused for now */
-	s16b insult_cur;		/* Insult counter */
-	s16b good_buy;			/* Number of "good" buys */
-	s16b bad_buy;			/* Number of "bad" buys */
-	s32b store_open;		/* Closed until this turn */
-	s32b last_visit;		/* Last visited on this turn */
-	s16b table_num;			/* Table -- Number of entries */
-	s16b table_size;		/* Table -- Total Size of Array */
-	s16b *table;			/* Table -- Legal item kinds */
-	s16b stock_num;			/* Stock -- Number of entries */
-	s16b stock_size;		/* Stock -- Total Size of Array */
-	object_type *stock;		/* Stock -- Actual stock items */
+	byte type;				  /* Store type */
+	byte owner;				  /* Owner index */
+	byte extra;				  /* Unused for now */
+	s16b insult_cur;		  /* Insult counter */
+	s16b good_buy;			  /* Number of "good" buys */
+	s16b bad_buy;			  /* Number of "bad" buys */
+	s32b store_open;		  /* Closed until this turn */
+	s32b last_visit;		  /* Last visited on this turn */
+    s16b regular_num;         /* Table -- Number of entries */
+    s16b regular_size;        /* Table -- Total Size of Array */
+    KIND_OBJECT_IDX *regular; /* Table -- Legal regular item kinds */
+    s16b table_num;           /* Table -- Number of entries */
+	s16b table_size;		  /* Table -- Total Size of Array */
+    KIND_OBJECT_IDX *table;   /* Table -- Legal item kinds */
+	s16b stock_num;			  /* Stock -- Number of entries */
+	s16b stock_size;		  /* Stock -- Total Size of Array */
+	object_type *stock;		  /* Stock -- Actual stock items */
 } store_type;
 
 extern int cur_store_num;
@@ -40,7 +43,7 @@ typedef bool (*black_market_crap_pf)(player_type *, object_type *);
 typedef bool (*store_will_buy_pf)(player_type *, object_type *);
 typedef void (*mass_produce_pf)(player_type *, object_type *);
 void store_delete(void);
-void store_create(player_type *player_ptr, black_market_crap_pf black_market_crap, store_will_buy_pf store_will_buy, mass_produce_pf mass_produce);
+void store_create(player_type *player_ptr, KIND_OBJECT_IDX k_idx, black_market_crap_pf black_market_crap, store_will_buy_pf store_will_buy, mass_produce_pf mass_produce);
 void store_item_increase(INVENTORY_IDX item, int num);
 void store_item_optimize(INVENTORY_IDX item);
 int store_carry(player_type *player_ptr, object_type *o_ptr);

--- a/src/store/store.h
+++ b/src/store/store.h
@@ -22,7 +22,7 @@ extern int cur_store_feat;
 extern bool allow_inc;
 
 void store_shuffle(player_type *player_ptr, int which);
-void store_maintenance(player_type *player_ptr, int town_num, int store_num);
+void store_maintenance(player_type *player_ptr, int town_num, int store_num, int chance);
 void store_init(int town_num, int store_num);
 void store_examine(player_type *player_ptr);
 int store_check_num(object_type *o_ptr);


### PR DESCRIPTION
[Feature] 店舗の常時陳列商品を設定 #419
store_stock_item_type型を定義して、store_regular_table配列とstore_table配列に利用する。
店舗陳列の更新ループをstore系の関数外で回して何度も商品整理していたので、store_maintenance()内で回す。
常時陳列商品のランダム出現率を調整して、別の商品を追加した。