### PR TITLE
[Fix] モンスターの思い出の経験値表示でクラッシュ (英語版) 

### DIFF
--- a/src/term/z-form.c
+++ b/src/term/z-form.c
@@ -14,7 +14,6 @@
 #include "term/z-util.h"
 #include "term/z-virt.h"
 
-
 /*
  * Here is some information about the routines in this file.
  *
@@ -144,10 +143,6 @@
  * character capitilized, if reasonable.
  */
 
-
-
-
-
 /*
  * The "type" of the "user defined print routine" pointer
  */
@@ -158,19 +153,20 @@ typedef uint (*vstrnfmt_aux_func)(char *buf, uint max, concptr fmt, vptr arg);
  */
 static uint vstrnfmt_aux_dflt(char *buf, uint max, concptr fmt, vptr arg)
 {
-	uint len;
-	char tmp[32];
+    uint len;
+    char tmp[32];
 
-	/* XXX XXX */
-	fmt = fmt ? fmt : 0;
+    /* XXX XXX */
+    fmt = fmt ? fmt : 0;
 
-	/* Pointer display */
-	sprintf(tmp, "<<%p>>", arg);
-	len = strlen(tmp);
-	if (len >= max) len = max - 1;
-	tmp[len] = '\0';
-	strcpy(buf, tmp);
-	return (len);
+    /* Pointer display */
+    sprintf(tmp, "<<%p>>", arg);
+    len = strlen(tmp);
+    if (len >= max)
+        len = max - 1;
+    tmp[len] = '\0';
+    strcpy(buf, tmp);
+    return (len);
 }
 
 /*
@@ -178,8 +174,6 @@ static uint vstrnfmt_aux_dflt(char *buf, uint max, concptr fmt, vptr arg)
  * dynamically by sending the proper "%r" sequence to "vstrnfmt()"
  */
 static vstrnfmt_aux_func vstrnfmt_aux = vstrnfmt_aux_dflt;
-
-
 
 /*
  * Basic "vararg" format function.
@@ -233,406 +227,380 @@ static vstrnfmt_aux_func vstrnfmt_aux = vstrnfmt_aux_dflt;
  */
 uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
 {
-	concptr s;
+    concptr s;
 
-	/* The argument is "long" */
-	bool do_long;
+    /* The argument is "long" */
+    bool do_long;
 
-	/* The argument needs "processing" */
-	bool do_xtra;
+    /* The argument needs "processing" */
+    bool do_xtra;
 
-	/* Bytes used in buffer */
-	uint n;
+    /* Bytes used in buffer */
+    uint n;
 
-	/* Bytes used in format sequence */
-	uint q;
+    /* Bytes used in format sequence */
+    uint q;
 
-	/* Format sequence */
-	char aux[128];
+    /* Format sequence */
+    char aux[128];
 
-	/* Resulting string */
-	char tmp[1024];
+    /* Resulting string */
+    char tmp[1024];
 
+    /* Mega-Hack -- treat "illegal" length as "infinite" */
+    if (!max)
+        max = 32767;
 
-	/* Mega-Hack -- treat "illegal" length as "infinite" */
-	if (!max) max = 32767;
+    /* Mega-Hack -- treat "no format" as "empty string" */
+    if (!fmt)
+        fmt = "";
 
-	/* Mega-Hack -- treat "no format" as "empty string" */
-	if (!fmt) fmt = "";
-
-
-	/* Begin the buffer */
-	n = 0;
-
-	/* Begin the format string */
-	s = fmt;
-
-	/* Scan the format string */
-	while (TRUE)
-	{
-		/* All done */
-		if (!*s) break;
-
-		/* Normal character */
-		if (*s != '%')
-		{
-			/* Check total length */
-			if (n == max-1) break;
-
-			/* Save the character */
-			buf[n++] = *s++;
-			continue;
-		}
-
-		/* Skip the "percent" */
-		s++;
-
-		/* Pre-process "%%" */
-		if (*s == '%')
-		{
-			/* Check total length */
-			if (n == max-1) break;
-
-			/* Save the percent */
-			buf[n++] = '%';
-
-			/* Skip the "%" */
-			s++;
-			continue;
-		}
-
-		/* Pre-process "%n" */
-		if (*s == 'n')
-		{
-			int *arg;
-
-			/* Access the next argument */
-			arg = va_arg(vp, int *);
-
-			/* Save the current length */
-			(*arg) = n;
-
-			/* Skip the "n" */
-			s++;
-			continue;
-		}
-
-		/* Hack -- Pre-process "%r" */
-		if (*s == 'r')
-		{
-			/* Extract the next argument, and save it (globally) */
-			vstrnfmt_aux = va_arg(vp, vstrnfmt_aux_func);
-
-			/* Skip the "r" */
-			s++;
-			continue;
-		}
-
-
-		/* Begin the "aux" string */
-		q = 0;
-
-		/* Save the "percent" */
-		aux[q++] = '%';
-
-		/* Assume no "long" argument */
-		do_long = FALSE;
-
-		/* Assume no "xtra" processing */
-		do_xtra = FALSE;
-
-		/* Build the "aux" string */
-		while (TRUE)
-		{
-			/* Error -- format sequence is not terminated */
-			if (!*s)
-			{
-				/* Terminate the buffer */
-				buf[0] = '\0';
-
-				/* Return "error" */
-				return 0;
-			}
-
-			/* Error -- format sequence may be too long */
-			if (q > 100)
-			{
-				/* Terminate the buffer */
-				buf[0] = '\0';
-
-				/* Return "error" */
-				return 0;
-			}
-
-			/* Handle "alphabetic" chars */
-			if (isalpha(*s))
-			{
-				/* Hack -- handle "long" request */
-				if (*s == 'l')
-				{
-					/* Save the character */
-					aux[q++] = *s++;
-
-					/* Note the "long" flag */
-					do_long = TRUE;
-				}
-
-				/* Mega-Hack -- handle "extra-long" request */
-				else if (*s == 'L')
-				{
-					/* Error -- illegal format char */
-					buf[0] = '\0';
-
-					/* Return "error" */
-					return 0;
-				}
-
-				/* Handle normal end of format sequence */
-				else
-				{
-					/* Save the character */
-					aux[q++] = *s++;
-
-					/* Stop processing the format sequence */
-					break;
-				}
-			}
-
-			/* Handle "non-alphabetic" chars */
-			else
-			{
-				/* Hack -- Handle 'star' (for "variable length" argument) */
-				if (*s == '*')
-				{
-					int arg;
-
-					/* Access the next argument */
-					arg = va_arg(vp, int);
-
-					/* Hack -- append the "length" */
-					sprintf(aux + q, "%d", arg);
-
-					/* Hack -- accept the "length" */
-					while (aux[q]) q++;
-
-					/* Skip the "*" */
-					s++;
-				}
-
-				/* Mega-Hack -- Handle 'caret' (for "uppercase" request) */
-				else if (*s == '^')
-				{
-					/* Note the "xtra" flag */
-					do_xtra = TRUE;
-
-					/* Skip the "^" */
-					s++;
-				}
-
-				/* Collect "normal" characters (digits, "-", "+", ".", etc) */
-				else
-				{
-					/* Save the character */
-					aux[q++] = *s++;
-				}
-			}
-		}
-
-
-		/* Terminate "aux" */
-		aux[q] = '\0';
-
-		/* Clear "tmp" */
-		tmp[0] = '\0';
-
-		/* Process the "format" char */
-		switch (aux[q-1])
-		{
-			/* Simple Character -- standard format */
-			case 'c':
-			{
-				int arg;
-
-				/* Access next argument */
-				arg = va_arg(vp, int);
-
-				/* Format the argument */
-				sprintf(tmp, "%c", arg);
-
-				break;
-			}
-
-			/* Signed Integers -- standard format */
-			case 'd': case 'i':
-			{
-				if (do_long)
-				{
-					long arg;
-
-					/* Access next argument */
-					arg = va_arg(vp, long);
-
-					/* Format the argument */
-					sprintf(tmp, aux, arg);
-				}
-				else
-				{
-					int arg;
-
-					/* Access next argument */
-					arg = va_arg(vp, int);
-
-					/* Format the argument */
-					sprintf(tmp, aux, arg);
-				}
-
-				break;
-			}
-
-			/* Unsigned Integers -- various formats */
-			case 'u': case 'o': case 'x': case 'X':
-			{
-				if (do_long)
-				{
-					unsigned long arg;
-
-					/* Access next argument */
-					arg = va_arg(vp, unsigned long);
-
-					sprintf(tmp, aux, arg);
-				}
-				else
-				{
-					unsigned int arg;
-
-					/* Access next argument */
-					arg = va_arg(vp, unsigned int);
-					sprintf(tmp, aux, arg);
-
-				}
-
-				break;
-			}
-
-			/* Floating Point -- various formats */
-			case 'f':
-			case 'e': case 'E':
-			case 'g': case 'G':
-			{
-				double arg;
-
-				/* Access next argument */
-				arg = va_arg(vp, double);
-
-				/* Format the argument */
-				sprintf(tmp, aux, arg);
-
-				break;
-			}
-
-			/* Pointer -- implementation varies */
-			case 'p':
-			{
-				vptr arg;
-
-				/* Access next argument */
-				arg = va_arg(vp, vptr);
-
-				/* Format the argument */
-				sprintf(tmp, aux, arg);
-
-				break;
-			}
-
-			/* String */
-			case 's':
-			{
-				concptr arg;
-				char arg2[1024];
-
-				/* Access next argument */
-				arg = va_arg(vp, concptr);
-
-				/* Hack -- convert NULL to EMPTY */
-				if (!arg) arg = "";
-
-				/* Prevent buffer overflows */
-				strncpy(arg2, arg, 1024);
-				arg2[1023] = '\0';
-
-				/* Format the argument */
-				sprintf(tmp, aux, arg);
-
-				break;
-			}
-
-			/* User defined data */
-			case 'V':
-			case 'v':
-			{
-				vptr arg;
-
-				/* Access next argument */
-				arg = va_arg(vp, vptr);
-
-				/* Format the "user data" */
-				sprintf(tmp, aux, arg);
-
-				break;
-			}
-
-
-			default:
-			{
-				/* Error -- illegal format char */
-				buf[0] = '\0';
-
-				/* Return "error" */
-				return 0;
-			}
-		}
-
+    /* Begin the buffer */
+    n = 0;
+
+    /* Begin the format string */
+    s = fmt;
+
+    /* Scan the format string */
+    while (TRUE) {
+        /* All done */
+        if (!*s)
+            break;
+
+        /* Normal character */
+        if (*s != '%') {
+            /* Check total length */
+            if (n == max - 1)
+                break;
+
+            /* Save the character */
+            buf[n++] = *s++;
+            continue;
+        }
+
+        /* Skip the "percent" */
+        s++;
+
+        /* Pre-process "%%" */
+        if (*s == '%') {
+            /* Check total length */
+            if (n == max - 1)
+                break;
+
+            /* Save the percent */
+            buf[n++] = '%';
+
+            /* Skip the "%" */
+            s++;
+            continue;
+        }
+
+        /* Pre-process "%n" */
+        if (*s == 'n') {
+            int *arg;
+
+            /* Access the next argument */
+            arg = va_arg(vp, int *);
+
+            /* Save the current length */
+            (*arg) = n;
+
+            /* Skip the "n" */
+            s++;
+            continue;
+        }
+
+        /* Hack -- Pre-process "%r" */
+        if (*s == 'r') {
+            /* Extract the next argument, and save it (globally) */
+            vstrnfmt_aux = va_arg(vp, vstrnfmt_aux_func);
+
+            /* Skip the "r" */
+            s++;
+            continue;
+        }
+
+        /* Begin the "aux" string */
+        q = 0;
+
+        /* Save the "percent" */
+        aux[q++] = '%';
+
+        /* Assume no "long" argument */
+        do_long = FALSE;
+
+        /* Assume no "xtra" processing */
+        do_xtra = FALSE;
+
+        /* Build the "aux" string */
+        while (TRUE) {
+            /* Error -- format sequence is not terminated */
+            if (!*s) {
+                /* Terminate the buffer */
+                buf[0] = '\0';
+
+                /* Return "error" */
+                return 0;
+            }
+
+            /* Error -- format sequence may be too long */
+            if (q > 100) {
+                /* Terminate the buffer */
+                buf[0] = '\0';
+
+                /* Return "error" */
+                return 0;
+            }
+
+            /* Handle "alphabetic" chars */
+            if (isalpha(*s)) {
+                /* Hack -- handle "long" request */
+                if (*s == 'l') {
+                    /* Save the character */
+                    aux[q++] = *s++;
+
+                    /* Note the "long" flag */
+                    do_long = TRUE;
+                }
+
+                /* Mega-Hack -- handle "extra-long" request */
+                else if (*s == 'L') {
+                    /* Error -- illegal format char */
+                    buf[0] = '\0';
+
+                    /* Return "error" */
+                    return 0;
+                }
+
+                /* Handle normal end of format sequence */
+                else {
+                    /* Save the character */
+                    aux[q++] = *s++;
+
+                    /* Stop processing the format sequence */
+                    break;
+                }
+            }
+
+            /* Handle "non-alphabetic" chars */
+            else {
+                /* Hack -- Handle 'star' (for "variable length" argument) */
+                if (*s == '*') {
+                    int arg;
+
+                    /* Access the next argument */
+                    arg = va_arg(vp, int);
+
+                    /* Hack -- append the "length" */
+                    sprintf(aux + q, "%d", arg);
+
+                    /* Hack -- accept the "length" */
+                    while (aux[q])
+                        q++;
+
+                    /* Skip the "*" */
+                    s++;
+                }
+
+                /* Mega-Hack -- Handle 'caret' (for "uppercase" request) */
+                else if (*s == '^') {
+                    /* Note the "xtra" flag */
+                    do_xtra = TRUE;
+
+                    /* Skip the "^" */
+                    s++;
+                }
+
+                /* Collect "normal" characters (digits, "-", "+", ".", etc) */
+                else {
+                    /* Save the character */
+                    aux[q++] = *s++;
+                }
+            }
+        }
+
+        /* Terminate "aux" */
+        aux[q] = '\0';
+
+        /* Clear "tmp" */
+        tmp[0] = '\0';
+
+        /* Process the "format" char */
+        switch (aux[q - 1]) {
+        /* Simple Character -- standard format */
+        case 'c': {
+            int arg;
+
+            /* Access next argument */
+            arg = va_arg(vp, int);
+
+            /* Format the argument */
+            sprintf(tmp, "%c", arg);
+
+            break;
+        }
+
+        /* Signed Integers -- standard format */
+        case 'd':
+        case 'i': {
+            if (do_long) {
+                long arg;
+
+                /* Access next argument */
+                arg = va_arg(vp, long);
+
+                /* Format the argument */
+                sprintf(tmp, aux, arg);
+            } else {
+                int arg;
+
+                /* Access next argument */
+                arg = va_arg(vp, int);
+
+                /* Format the argument */
+                sprintf(tmp, aux, arg);
+            }
+
+            break;
+        }
+
+        /* Unsigned Integers -- various formats */
+        case 'u':
+        case 'o':
+        case 'x':
+        case 'X': {
+            if (do_long) {
+                unsigned long arg;
+
+                /* Access next argument */
+                arg = va_arg(vp, unsigned long);
+
+                sprintf(tmp, aux, arg);
+            } else {
+                unsigned int arg;
+
+                /* Access next argument */
+                arg = va_arg(vp, unsigned int);
+                sprintf(tmp, aux, arg);
+            }
+
+            break;
+        }
+
+        /* Floating Point -- various formats */
+        case 'f':
+        case 'e':
+        case 'E':
+        case 'g':
+        case 'G': {
+            double arg;
+
+            /* Access next argument */
+            arg = va_arg(vp, double);
+
+            /* Format the argument */
+            sprintf(tmp, aux, arg);
+
+            break;
+        }
+
+        /* Pointer -- implementation varies */
+        case 'p': {
+            vptr arg;
+
+            /* Access next argument */
+            arg = va_arg(vp, vptr);
+
+            /* Format the argument */
+            sprintf(tmp, aux, arg);
+
+            break;
+        }
+
+        /* String */
+        case 's': {
+            concptr arg;
+            char arg2[1024];
+
+            /* Access next argument */
+            arg = va_arg(vp, concptr);
+
+            /* Hack -- convert NULL to EMPTY */
+            if (!arg)
+                arg = "";
+
+            /* Prevent buffer overflows */
+            strncpy(arg2, arg, 1024);
+            arg2[1023] = '\0';
+
+            /* Format the argument */
+            sprintf(tmp, aux, arg);
+
+            break;
+        }
+
+        /* User defined data */
+        case 'V':
+        case 'v': {
+            vptr arg;
+
+            /* Access next argument */
+            arg = va_arg(vp, vptr);
+
+            /* Format the "user data" */
+            sprintf(tmp, aux, arg);
+
+            break;
+        }
+
+        default: {
+            /* Error -- illegal format char */
+            buf[0] = '\0';
+
+            /* Return "error" */
+            return 0;
+        }
+        }
 
 #ifdef JP
-		for (q = 0; tmp[q]; q++) if (iskanji(tmp[q])) { do_xtra=FALSE;break;} 
+        for (q = 0; tmp[q]; q++)
+            if (iskanji(tmp[q])) {
+                do_xtra = FALSE;
+                break;
+            }
 #endif
-		/* Mega-Hack -- handle "capitilization" */
-		if (do_xtra)
-		{
-			/* Now append "tmp" to "buf" */
-			for (q = 0; tmp[q]; q++)
-			{
-				/* Notice first non-space */
-				if (!iswspace(tmp[q]))
-				{
-					/* Capitalize if possible */
-					if (islower(tmp[q]))
-						tmp[q] = (char)toupper(tmp[q]);
+        /* Mega-Hack -- handle "capitilization" */
+        if (do_xtra) {
+            /* Now append "tmp" to "buf" */
+            for (q = 0; tmp[q]; q++) {
+                /* Notice first non-space */
+                if (!iswspace(tmp[q])) {
+                    /* Capitalize if possible */
+                    if (islower(tmp[q]))
+                        tmp[q] = (char)toupper(tmp[q]);
 
-					break;
-				}
-			}
-		}
+                    break;
+                }
+            }
+        }
 
-		/* Now append "tmp" to "buf" */
-		for (q = 0; tmp[q]; q++)
-		{
-			/* Check total length */
-			if (n == max-1) break;
+        /* Now append "tmp" to "buf" */
+        for (q = 0; tmp[q]; q++) {
+            /* Check total length */
+            if (n == max - 1)
+                break;
 
-			/* Save the character */
-			buf[n++] = tmp[q];
-		}
-	}
+            /* Save the character */
+            buf[n++] = tmp[q];
+        }
+    }
 
+    /* Terminate buffer */
+    buf[n] = '\0';
 
-	/* Terminate buffer */
-	buf[n] = '\0';
-
-	/* Return length */
-	return (n);
+    /* Return length */
+    return (n);
 }
-
 
 /*
  * Do a vstrnfmt (see above) into a (growable) static buffer.
@@ -640,64 +608,61 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
  */
 char *vformat(concptr fmt, va_list vp)
 {
-	static char *format_buf = NULL;
-	static huge format_len = 0;
+    static char *format_buf = NULL;
+    static huge format_len = 0;
 
-	/* Initial allocation */
-	if (!format_buf)
-	{
-		format_len = 1024;
-		C_MAKE(format_buf, format_len, char);
-	}
+    /* Initial allocation */
+    if (!format_buf) {
+        format_len = 1024;
+        C_MAKE(format_buf, format_len, char);
+    }
 
-	/* Null format yields last result */
-	if (!fmt) return (format_buf);
+    /* Null format yields last result */
+    if (!fmt)
+        return (format_buf);
 
-	/* Keep going until successful */
-	while (TRUE)
-	{
-		uint len;
+    /* Keep going until successful */
+    while (TRUE) {
+        uint len;
 
-		/* Build the string */
-		len = vstrnfmt(format_buf, format_len, fmt, vp);
+        /* Build the string */
+        len = vstrnfmt(format_buf, format_len, fmt, vp);
 
-		/* Success */
-		if (len < format_len-1) break;
+        /* Success */
+        if (len < format_len - 1)
+            break;
 
-		/* Grow the buffer */
-		C_KILL(format_buf, format_len, char);
-		format_len = format_len * 2;
-		C_MAKE(format_buf, format_len, char);
-	}
+        /* Grow the buffer */
+        C_KILL(format_buf, format_len, char);
+        format_len = format_len * 2;
+        C_MAKE(format_buf, format_len, char);
+    }
 
-	/* Return the new buffer */
-	return (format_buf);
+    /* Return the new buffer */
+    return (format_buf);
 }
-
-
 
 /*
  * Do a vstrnfmt (see above) into a buffer of a given size.
  */
 uint strnfmt(char *buf, uint max, concptr fmt, ...)
 {
-	uint len;
+    uint len;
 
-	va_list vp;
+    va_list vp;
 
-	/* Begin the Varargs Stuff */
-	va_start(vp, fmt);
+    /* Begin the Varargs Stuff */
+    va_start(vp, fmt);
 
-	/* Do a virtual fprintf to stderr */
-	len = vstrnfmt(buf, max, fmt, vp);
+    /* Do a virtual fprintf to stderr */
+    len = vstrnfmt(buf, max, fmt, vp);
 
-	/* End the Varargs Stuff */
-	va_end(vp);
+    /* End the Varargs Stuff */
+    va_end(vp);
 
-	/* Return the number of bytes written */
-	return (len);
+    /* Return the number of bytes written */
+    return (len);
 }
-
 
 /*
  * Do a vstrnfmt (see above) into a buffer of unknown size.
@@ -705,25 +670,22 @@ uint strnfmt(char *buf, uint max, concptr fmt, ...)
  */
 uint strfmt(char *buf, concptr fmt, ...)
 {
-	uint len;
+    uint len;
 
-	va_list vp;
+    va_list vp;
 
-	/* Begin the Varargs Stuff */
-	va_start(vp, fmt);
+    /* Begin the Varargs Stuff */
+    va_start(vp, fmt);
 
-	/* Build the string, assume 32K buffer */
-	len = vstrnfmt(buf, 32767, fmt, vp);
+    /* Build the string, assume 32K buffer */
+    len = vstrnfmt(buf, 32767, fmt, vp);
 
-	/* End the Varargs Stuff */
-	va_end(vp);
+    /* End the Varargs Stuff */
+    va_end(vp);
 
-	/* Return the number of bytes written */
-	return (len);
+    /* Return the number of bytes written */
+    return (len);
 }
-
-
-
 
 /*
  * Do a vstrnfmt() into (see above) into a (growable) static buffer.
@@ -733,90 +695,81 @@ uint strfmt(char *buf, concptr fmt, ...)
  */
 char *format(concptr fmt, ...)
 {
-	char *res;
-	va_list vp;
+    char *res;
+    va_list vp;
 
-	/* Begin the Varargs Stuff */
-	va_start(vp, fmt);
+    /* Begin the Varargs Stuff */
+    va_start(vp, fmt);
 
-	/* Format the args */
-	res = vformat(fmt, vp);
+    /* Format the args */
+    res = vformat(fmt, vp);
 
-	/* End the Varargs Stuff */
-	va_end(vp);
+    /* End the Varargs Stuff */
+    va_end(vp);
 
-	/* Return the result */
-	return (res);
+    /* Return the result */
+    return (res);
 }
-
-
-
 
 /*
  * Vararg interface to plog()
  */
 void plog_fmt(concptr fmt, ...)
 {
-	char *res;
-	va_list vp;
+    char *res;
+    va_list vp;
 
-	/* Begin the Varargs Stuff */
-	va_start(vp, fmt);
+    /* Begin the Varargs Stuff */
+    va_start(vp, fmt);
 
-	/* Format the args */
-	res = vformat(fmt, vp);
+    /* Format the args */
+    res = vformat(fmt, vp);
 
-	/* End the Varargs Stuff */
-	va_end(vp);
+    /* End the Varargs Stuff */
+    va_end(vp);
 
-	/* Call plog */
-	plog(res);
+    /* Call plog */
+    plog(res);
 }
-
-
 
 /*
  * Vararg interface to quit()
  */
 void quit_fmt(concptr fmt, ...)
 {
-	char *res;
-	va_list vp;
+    char *res;
+    va_list vp;
 
-	/* Begin the Varargs Stuff */
-	va_start(vp, fmt);
+    /* Begin the Varargs Stuff */
+    va_start(vp, fmt);
 
-	/* Format */
-	res = vformat(fmt, vp);
+    /* Format */
+    res = vformat(fmt, vp);
 
-	/* End the Varargs Stuff */
-	va_end(vp);
+    /* End the Varargs Stuff */
+    va_end(vp);
 
-	/* Call quit() */
-	quit(res);
+    /* Call quit() */
+    quit(res);
 }
-
-
 
 /*
  * Vararg interface to core()
  */
 void core_fmt(concptr fmt, ...)
 {
-	char *res;
-	va_list vp;
+    char *res;
+    va_list vp;
 
-	/* Begin the Varargs Stuff */
-	va_start(vp, fmt);
+    /* Begin the Varargs Stuff */
+    va_start(vp, fmt);
 
-	/* If requested, Do a virtual fprintf to stderr */
-	res = vformat(fmt, vp);
+    /* If requested, Do a virtual fprintf to stderr */
+    res = vformat(fmt, vp);
 
-	/* End the Varargs Stuff */
-	va_end(vp);
+    /* End the Varargs Stuff */
+    va_end(vp);
 
-	/* Call core() */
-	core(res);
+    /* Call core() */
+    core(res);
 }
-
-

--- a/src/term/z-form.c
+++ b/src/term/z-form.c
@@ -69,11 +69,17 @@
  * Format("%ld", long int i)
  *   Append the long integer "i".
  *
+ * Format("%Ld", long long int i)
+ *   Append the long long integer "i".
+ *
  * Format("%d", int i)
  *   Append the integer "i".
  *
  * Format("%lu", unsigned long int i)
  *   Append the unsigned long integer "i".
+ *
+ * Format("%Lu", unsigned long long int i)
+ *   Append the unsigned long long integer "i".
  *
  * Format("%u", unsigned int i)
  *   Append the unsigned integer "i".
@@ -232,6 +238,9 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
     /* The argument is "long" */
     bool do_long;
 
+    /* The argument is "long long" */
+    bool do_long_long;
+
     /* The argument needs "processing" */
     bool do_xtra;
 
@@ -329,6 +338,9 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
         /* Assume no "long" argument */
         do_long = FALSE;
 
+        /* Assume no "long long" argument */
+        do_long_long = FALSE;
+
         /* Assume no "xtra" processing */
         do_xtra = FALSE;
 
@@ -365,11 +377,13 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
 
                 /* Mega-Hack -- handle "extra-long" request */
                 else if (*s == 'L') {
-                    /* Error -- illegal format char */
-                    buf[0] = '\0';
+                    /* Save the character */
+                    aux[q++] = 'l';
+                    aux[q++] = 'l';
+                    s++;
 
-                    /* Return "error" */
-                    return 0;
+                    /* Note the "long long" flag */
+                    do_long_long = TRUE;
                 }
 
                 /* Handle normal end of format sequence */
@@ -451,6 +465,14 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
 
                 /* Format the argument */
                 sprintf(tmp, aux, arg);
+            } else if (do_long_long) {
+                long long arg;
+
+                /* Access next argument */
+                arg = va_arg(vp, long long);
+
+                /* Format the argument */
+                sprintf(tmp, aux, arg);
             } else {
                 int arg;
 
@@ -474,6 +496,13 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
 
                 /* Access next argument */
                 arg = va_arg(vp, unsigned long);
+
+                sprintf(tmp, aux, arg);
+            } else if (do_long_long) {
+                unsigned long long arg;
+
+                /* Access next argument */
+                arg = va_arg(vp, unsigned long long);
 
                 sprintf(tmp, aux, arg);
             } else {

--- a/src/view/display-lore.c
+++ b/src/view/display-lore.c
@@ -366,6 +366,11 @@ void display_monster_alignment(lore_type *lore_ptr)
         hook_c_roff(TERM_VIOLET, _("アンバーの王族の", " Amberite"));
 }
 
+/*!
+ * @brief モンスターの経験値の思い出を表示する
+ * @param player_ptr プレイヤーの情報へのポインター
+ * @param lore_ptr モンスターの思い出の情報へのポインター
+ */
 void display_monster_exp(player_type *player_ptr, lore_type *lore_ptr)
 {
 #ifdef JP
@@ -373,35 +378,45 @@ void display_monster_exp(player_type *player_ptr, lore_type *lore_ptr)
 #endif
 
     int64_t base_exp = lore_ptr->r_ptr->mexp * lore_ptr->r_ptr->level * 3 / 2;
-    int64_t player_factor = player_ptr->max_plv + 2;
-    
+    int64_t player_factor = (int64_t)player_ptr->max_plv + 2;
+
     int64_t exp_integer = base_exp / player_factor;
     int64_t exp_decimal = ((base_exp % player_factor * 1000 / player_factor) + 5) / 10;
 
 #ifdef JP
-    hooked_roff(format(" %d レベルのキャラクタにとって 約%ld.%02ld ポイントの経験となる。", player_ptr->lev, exp_integer, exp_decimal));
+    hooked_roff(format(" %d レベルのキャラクタにとって 約%Ld.%02Ld ポイントの経験となる。", player_ptr->lev, exp_integer, exp_decimal));
 #else
-    hooked_roff(format(" is worth about %ld.%02ld point%s", exp_integer, exp_decimal, ((exp_integer == 1) && (exp_decimal == 0)) ? "" : "s"));
+    hooked_roff(format(" is worth about %Ld.%02Ld point%s", exp_integer, exp_decimal, ((exp_integer == 1) && (exp_decimal == 0)) ? "" : "s"));
 
-    char *ordinal;
-    ordinal = "th";
-    exp_integer = player_ptr->lev % 10;
-    if ((player_ptr->lev / 10) != 1) {
-        if (exp_integer == 1)
-            ordinal = "st";
-        else if (exp_integer == 2)
-            ordinal = "nd";
-        else if (exp_integer == 3)
-            ordinal = "rd";
+    concptr ordinal;
+    switch (player_ptr->lev % 10) {
+    case 1:
+        ordinal = "st";
+        break;
+    case 2:
+        ordinal = "nd";
+        break;
+    case 3:
+        ordinal = "rd";
+        break;
+    default:
+        ordinal = "th";
+        break;
     }
 
-    char *vowel;
-    vowel = "";
-    exp_integer = player_ptr->lev;
-    if ((exp_integer == 8) || (exp_integer == 11) || (exp_integer == 18))
+    concptr vowel;
+    switch (player_ptr->lev) {
+    case 8:
+    case 11:
+    case 18:
         vowel = "n";
+        break;
+    default:
+        vowel = "";
+        break;
+    }
 
-    hooked_roff(format(" for a%s %lu%s level character.  ", vowel, (long)exp_integer, ordinal));
+    hooked_roff(format(" for a%s %d%s level character.  ", vowel, player_ptr->lev, ordinal));
 #endif
 }
 


### PR DESCRIPTION
英語版で経験値表示でクラッシュしていたのを修正。
・z-form.cの書式を整形
・shimiteiさんのformat()に関する64bit対応の修正を適用
・display_monster_exp()の表示等に関する修正