### PR TITLE
[Feature] キャラ作成画面に追加の能力値表示 #436

### DIFF
--- a/src/birth/birth-select-class.cpp
+++ b/src/birth/birth-select-class.cpp
@@ -41,6 +41,7 @@ static void display_class_stat(int cs, int *os, char *cur, char *sym)
         sprintf(cur, "%c%c%s", '*', p2, _("ランダム", "Random"));
         put_str("                                   ", 4, 40);
         put_str("                                   ", 5, 40);
+        put_str("                                   ", 6, 40);
     } else {
         cp_ptr = &class_info[cs];
         mp_ptr = &m_info[cs];
@@ -57,6 +58,17 @@ static void display_class_stat(int cs, int *os, char *cur, char *sym)
         sprintf(buf, "%+3d  %+3d  %+3d  %+3d  %+3d  %+3d %+4d%% ", cp_ptr->c_adj[0], cp_ptr->c_adj[1], cp_ptr->c_adj[2], cp_ptr->c_adj[3], cp_ptr->c_adj[4],
             cp_ptr->c_adj[5], cp_ptr->c_exp);
         c_put_str(TERM_L_BLUE, buf, 5, 40);
+
+        put_str("HD", 6, 40);
+        sprintf(buf, "%+3d", cp_ptr->c_mhp);
+        c_put_str(TERM_L_BLUE, buf, 6, 42);
+
+        put_str(_("隠密", "Stealth"), 6, 47);
+        if (cs == CLASS_BERSERKER)
+            strcpy(buf, " xx");
+        else
+            sprintf(buf, " %+2d", cp_ptr->c_stl);
+        c_put_str(TERM_L_BLUE, buf, 6, _(51, 54));
     }
 
     c_put_str(TERM_YELLOW, cur, 13 + (cs / 4), 2 + 19 * (cs % 4));
@@ -154,6 +166,7 @@ bool get_player_class(player_type *creature_ptr)
         _("注意：《職業》によってキャラクターの先天的な能力やボーナスが変化します。", "Note: Your 'class' determines various intrinsic abilities and bonuses."),
         23, 5);
     put_str(_("()で囲まれた選択肢はこの種族には似合わない職業です。", "Any entries in parentheses should only be used by advanced players."), 11, 5);
+    put_str("                                   ", 6, 40);
 
     char sym[MAX_CLASS];
     enumerate_class_list(sym);

--- a/src/birth/birth-select-personality.cpp
+++ b/src/birth/birth-select-personality.cpp
@@ -39,6 +39,7 @@ static void display_personality_stat(int cs, int *os, concptr *str, char *cur, c
         sprintf(cur, "%c%c%s", '*', p2, _("ランダム", "Random"));
         put_str("                                   ", 4, 40);
         put_str("                                   ", 5, 40);
+        put_str("                                   ", 6, 40);
     } else {
         ap_ptr = &personality_info[cs];
         *str = ap_ptr->title;
@@ -49,6 +50,14 @@ static void display_personality_stat(int cs, int *os, concptr *str, char *cur, c
         sprintf(buf, "%+3d  %+3d  %+3d  %+3d  %+3d  %+3d       ", ap_ptr->a_adj[0], ap_ptr->a_adj[1], ap_ptr->a_adj[2], ap_ptr->a_adj[3], ap_ptr->a_adj[4],
             ap_ptr->a_adj[5]);
         c_put_str(TERM_L_BLUE, buf, 5, 40);
+
+        put_str("HD", 6, 40);
+        sprintf(buf, "%+3d", ap_ptr->a_mhp);
+        c_put_str(TERM_L_BLUE, buf, 6, 42);
+
+        put_str(_("隠密", "Stealth"), 6, 47);
+        sprintf(buf, "%+3d", ap_ptr->a_stl);
+        c_put_str(TERM_L_BLUE, buf, 6, _(51, 54));
     }
 
     c_put_str(TERM_YELLOW, cur, 12 + (cs / 4), 2 + 18 * (cs % 4));
@@ -180,6 +189,8 @@ bool get_player_personality(player_type *creature_ptr)
     clear_from(10);
     put_str(_("注意：《性格》によってキャラクターの能力やボーナスが変化します。", "Note: Your personality determines various intrinsic abilities and bonuses."),
         23, 5);
+    put_str("                                   ", 6, 40);
+
     concptr str;
     char sym[MAX_PERSONALITIES];
     enumerate_personality_list(creature_ptr, &str, sym);

--- a/src/birth/birth-select-race.cpp
+++ b/src/birth/birth-select-race.cpp
@@ -37,6 +37,7 @@ static void display_race_stat(int cs, int *os, char *cur, char *sym)
         sprintf(cur, "%c%c%s", '*', p2, _("ランダム", "Random"));
         put_str("                                   ", 4, 40);
         put_str("                                   ", 5, 40);
+        put_str("                                   ", 6, 40);
     } else {
         rp_ptr = &race_info[cs];
         concptr str = rp_ptr->title;
@@ -48,6 +49,18 @@ static void display_race_stat(int cs, int *os, char *cur, char *sym)
         sprintf(buf, "%+3d  %+3d  %+3d  %+3d  %+3d  %+3d %+4d%% ", rp_ptr->r_adj[0], rp_ptr->r_adj[1], rp_ptr->r_adj[2], rp_ptr->r_adj[3], rp_ptr->r_adj[4],
             rp_ptr->r_adj[5], (rp_ptr->r_exp - 100));
         c_put_str(TERM_L_BLUE, buf, 5, 40);
+
+        put_str("HD ", 6, 40);
+        sprintf(buf, "%2d", rp_ptr->r_mhp);
+        c_put_str(TERM_L_BLUE, buf, 6, 43);
+
+        put_str(_("隠密","Stealth"), 6, 47);
+        sprintf(buf, "%+2d", rp_ptr->r_stl);
+        c_put_str(TERM_L_BLUE, buf, 6, _(52, 55));
+
+        put_str(_("赤外線視力", "Infra"), 6, _(56, 59));
+        sprintf(buf, _("%2dft", "%2dft"), 10 * rp_ptr->infra);
+        c_put_str(TERM_L_BLUE, buf, 6, _(67, 65));
     }
 
     c_put_str(TERM_YELLOW, cur, 12 + (cs / 5), 1 + 16 * (cs % 5));

--- a/src/birth/birth-select-realm.cpp
+++ b/src/birth/birth-select-realm.cpp
@@ -309,6 +309,7 @@ bool get_player_realms(player_type *creature_ptr)
     put_str("                                   ", 3, 40);
     put_str("                                   ", 4, 40);
     put_str("                                   ", 5, 40);
+    put_str("                                   ", 6, 40);
 
     /* Select the first realm */
     creature_ptr->realm1 = REALM_NONE;

--- a/src/birth/birth-wizard.cpp
+++ b/src/birth/birth-wizard.cpp
@@ -267,10 +267,34 @@ static bool let_player_build_character(player_type *creature_ptr)
 
 static void display_initial_options(player_type *creature_ptr)
 {
-    clear_from(10);
+    s16b adj[A_MAX];
+    for (int i = 0; i < A_MAX; i++) {
+        adj[i] = rp_ptr->r_adj[i] + cp_ptr->c_adj[i] + ap_ptr->a_adj[i];
+    }
+
+    char buf[80];
     put_str("                                   ", 3, 40);
-    put_str("                                   ", 4, 40);
-    put_str("                                   ", 5, 40);
+    put_str(_("修正の合計値", "Your total modification"), 3, 40);
+    put_str(_("腕力 知能 賢さ 器用 耐久 魅力 経験 ", "Str  Int  Wis  Dex  Con  Chr   EXP "), 4, 40);
+    sprintf(buf, "%+3d  %+3d  %+3d  %+3d  %+3d  %+3d %+4d%% ", adj[0], adj[1], adj[2], adj[3], adj[4], adj[5], cp_ptr->c_exp);
+    c_put_str(TERM_L_BLUE, buf, 5, 40);
+
+    put_str("HD ", 6, 40);
+    sprintf(buf, "%2d", rp_ptr->r_mhp + cp_ptr->c_mhp + ap_ptr->a_mhp);
+    c_put_str(TERM_L_BLUE, buf, 6, 43);
+
+    put_str(_("隠密", "Stealth"), 6, 47);
+    if (creature_ptr->pclass == CLASS_BERSERKER)
+        strcpy(buf, "xx");
+    else
+        sprintf(buf, "%+2d", rp_ptr->r_stl + cp_ptr->c_stl + ap_ptr->a_stl);
+    c_put_str(TERM_L_BLUE, buf, 6, _(52, 55));
+
+    put_str(_("赤外線視力", "Infra"), 6, _(56, 59));
+    sprintf(buf, _("%2dft", "%2dft"), 10 * rp_ptr->infra);
+    c_put_str(TERM_L_BLUE, buf, 6, _(67, 65));
+
+    clear_from(10);
     screen_save();
     do_cmd_options_aux(creature_ptr, OPT_PAGE_BIRTH, _("初期オプション((*)はスコアに影響)", "Birth Options ((*)) affect score"));
     screen_load();


### PR DESCRIPTION
種族、職業、性格を選択時にHD、隠密、赤外線視力も表示する。
オートローラー画面ではそれらの合計値を表示する。