### PR TITLE
[Fix] 現在の知識コマンドの鑑定済みの装備の耐性のヘッダ #444

### DIFF
--- a/src/knowledge/knowledge-inventory.cpp
+++ b/src/knowledge/knowledge-inventory.cpp
@@ -24,8 +24,9 @@
 #include "util/angband-files.h"
 #include "util/bit-flags-calculator.h"
 
-static concptr inven_res_label = _("                               酸電火冷毒光闇破轟獄因沌劣 盲怖乱痺透命感消復浮",
-    "                               AcElFiCoPoLiDkShSoNtNxCaDi BlFeCfFaSeHlEpSdRgLv");
+static concptr inven_res_label = _(
+    "                               酸電火冷毒閃暗破轟獄因沌劣 盲恐乱麻視経感遅活浮",
+    "                               AcElFiCoPoLiDkShSoNtNxCaDi BlFeCfFaSiHlEpSdRgLv");
 
 #define IM_FLAG_STR _("＊", "* ")
 #define HAS_FLAG_STR _("＋", "+ ")


### PR DESCRIPTION
自動銘刻みの文字の方に合わせた。

自動銘刻み:「閃」「暗」「恐」「麻」「視」「経」「遅」「活」「Si」
知識コマンド:「光」「闇」「怖」「痺」「透」「命」「消」「復」「Se」
