### PR TITLE
[Refactor] PlayerStatusBase、PlayerSpeedクラスの導入

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -387,6 +387,8 @@
     <ClCompile Include="..\..\src\player-info\resistance-info.cpp" />
     <ClCompile Include="..\..\src\player-info\self-info-util.cpp" />
     <ClCompile Include="..\..\src\player-info\weapon-effect-info.cpp" />
+    <ClCompile Include="..\..\src\player-status\player-speed.cpp" />
+    <ClCompile Include="..\..\src\player-status\player-status-base.cpp" />
     <ClCompile Include="..\..\src\player\player-status-resist.cpp" />
     <ClCompile Include="..\..\src\room\vault-builder.cpp" />
     <ClCompile Include="..\..\src\specific-object\blade-turner.cpp" />
@@ -1040,6 +1042,8 @@
     <ClInclude Include="..\..\src\player-info\resistance-info.h" />
     <ClInclude Include="..\..\src\player-info\self-info-util.h" />
     <ClInclude Include="..\..\src\player-info\weapon-effect-info.h" />
+    <ClInclude Include="..\..\src\player-status\player-speed.h" />
+    <ClInclude Include="..\..\src\player-status\player-status-base.h" />
     <ClInclude Include="..\..\src\player\player-status-resist.h" />
     <ClInclude Include="..\..\src\room\vault-builder.h" />
     <ClInclude Include="..\..\src\specific-object\blade-turner.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2198,6 +2198,12 @@
     <ClCompile Include="..\..\src\wizard\wizard-player-modifier.cpp">
       <Filter>wizard</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\player-status\player-speed.cpp">
+      <Filter>player-status</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\player-status\player-status-base.cpp">
+      <Filter>player-status</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -4729,6 +4735,12 @@
     <ClInclude Include="..\..\src\wizard\wizard-player-modifier.h">
       <Filter>wizard</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\player-status\player-speed.h">
+      <Filter>player-status</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-status\player-status-base.h">
+      <Filter>player-status</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\src\wall.bmp" />
@@ -4929,6 +4941,9 @@
     </Filter>
     <Filter Include="player-info">
       <UniqueIdentifier>{9b6116c6-24e1-4d33-b3b5-3591f58fb9e1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="player-status">
+      <UniqueIdentifier>{d6c9dc68-d79b-4509-bf9c-34ff9620bbf4}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -634,6 +634,11 @@ hengband_SOURCES = \
 	player-attack/blood-sucking-processor.cpp player-attack/blood-sucking-processor.h \
 	player-attack/player-attack.cpp player-attack/player-attack.h \
 	\
+	player-status/player-status-base.h \
+	player-status/player-speed.h \
+	player-status/player-status-base.cpp \
+	player-status/player-speed.cpp \
+	\
 	player-info/avatar.h player-info/avatar.cpp \
 	player-info/base-status-info.cpp player-info/base-status-info.h \
 	player-info/base-status-types.h \

--- a/src/player-status/player-speed.cpp
+++ b/src/player-status/player-speed.cpp
@@ -1,0 +1,383 @@
+﻿#include "player-status/player-speed.h"
+#include "artifact/fixed-art-types.h"
+#include "grid/feature-flag-types.h"
+#include "grid/feature.h"
+#include "grid/grid.h"
+#include "inventory/inventory-slot-types.h"
+#include "monster-race/monster-race.h"
+#include "monster/monster-status.h"
+#include "mutation/mutation-flag-types.h"
+#include "object-enchant/tr-types.h"
+#include "object/object-flags.h"
+#include "player/attack-defense-types.h"
+#include "player/player-race.h"
+#include "player/player-skill.h"
+#include "player/player-status-flags.h"
+#include "player/player-status.h"
+#include "player/special-defense-types.h"
+#include "realm/realm-hex-numbers.h"
+#include "realm/realm-types.h"
+#include "spell-realm/spells-hex.h"
+#include "system/floor-type-definition.h"
+#include "util/bit-flags-calculator.h"
+
+/*
+ * @brief 速度 - 初期値、下限、上限
+ * @details
+ * * 初期値110 - 加速+0に相当
+ * * 上限209 - 加速+99相当
+ * * 下限11 - 加速-99相当
+ */
+void PlayerSpeed::set_locals()
+{
+    this->default_value = 110;
+    this->min_value = 11;
+    this->max_value = 209;
+    this->tr_flag = TR_SPEED;
+    this->tr_bad_flag = TR_SPEED;
+}
+
+/*
+ * @brief 速度計算 - 種族
+ * @return 速度値の増減分
+ * @details
+ * ** クラッコンと妖精に加算(+レベル/10)
+ * ** 悪魔変化/吸血鬼変化で加算(+3)
+ * ** 魔王変化で加算(+5)
+ * ** マーフォークがFF_WATER地形にいれば加算(+2+レベル/10)
+ * ** そうでなく浮遊を持っていないなら減算(-2)
+ */
+s16b PlayerSpeed::race_value()
+{
+    s16b result = 0;
+
+    if (is_specific_player_race(this->owner_ptr, RACE_KLACKON) || is_specific_player_race(this->owner_ptr, RACE_SPRITE))
+        result += (this->owner_ptr->lev) / 10;
+
+    if (is_specific_player_race(this->owner_ptr, RACE_MERFOLK)) {
+        floor_type *floor_ptr = this->owner_ptr->current_floor_ptr;
+        feature_type *f_ptr = &f_info[floor_ptr->grid_array[this->owner_ptr->y][this->owner_ptr->x].feat];
+        if (has_flag(f_ptr->flags, FF_WATER)) {
+            result += (2 + this->owner_ptr->lev / 10);
+        } else if (!this->owner_ptr->levitation) {
+            result -= 2;
+        }
+    }
+
+    if (this->owner_ptr->mimic_form) {
+        switch (this->owner_ptr->mimic_form) {
+        case MIMIC_DEMON:
+            result += 3;
+            break;
+        case MIMIC_DEMON_LORD:
+            result += 5;
+            break;
+        case MIMIC_VAMPIRE:
+            result += 3;
+            break;
+        }
+    }
+    return result;
+}
+
+/*
+ * @brief 速度計算 - 職業
+ * @return 速度値の増減分
+ * @details
+ * ** 忍者の装備が重ければ減算(-レベル/10)
+ * ** 忍者の装備が適正ならば加算(+3)さらにクラッコン、妖精、いかさま以外なら加算(+レベル/10)
+ * ** 錬気術師で装備が重くなくクラッコン、妖精、いかさま以外なら加算(+レベル/10)
+ * ** 狂戦士なら加算(+3),レベル20/30/40/50ごとに+1
+ */
+s16b PlayerSpeed::class_value()
+{
+    SPEED result = 0;
+
+    if (this->owner_ptr->pclass == CLASS_NINJA) {
+        if (heavy_armor(this->owner_ptr)) {
+            result -= (this->owner_ptr->lev) / 10;
+        } else if ((!this->owner_ptr->inventory_list[INVEN_MAIN_HAND].k_idx || can_attack_with_main_hand(this->owner_ptr))
+            && (!this->owner_ptr->inventory_list[INVEN_SUB_HAND].k_idx || can_attack_with_sub_hand(this->owner_ptr))) {
+            result += 3;
+            if (!(is_specific_player_race(this->owner_ptr, RACE_KLACKON) || is_specific_player_race(this->owner_ptr, RACE_SPRITE)
+                    || (this->owner_ptr->pseikaku == PERSONALITY_MUNCHKIN)))
+                result += (this->owner_ptr->lev) / 10;
+        }
+    }
+
+    if ((this->owner_ptr->pclass == CLASS_MONK || this->owner_ptr->pclass == CLASS_FORCETRAINER) && !(heavy_armor(this->owner_ptr))) {
+        if (!(is_specific_player_race(this->owner_ptr, RACE_KLACKON) || is_specific_player_race(this->owner_ptr, RACE_SPRITE)
+                || (this->owner_ptr->pseikaku == PERSONALITY_MUNCHKIN)))
+            result += (this->owner_ptr->lev) / 10;
+    }
+
+    if (this->owner_ptr->pclass == CLASS_BERSERKER) {
+        result += 2;
+        if (this->owner_ptr->lev > 29)
+            result++;
+        if (this->owner_ptr->lev > 39)
+            result++;
+        if (this->owner_ptr->lev > 44)
+            result++;
+        if (this->owner_ptr->lev > 49)
+            result++;
+    }
+    return result;
+}
+
+/*
+ * @brief 速度計算 - 性格
+ * @return 速度値の増減分
+ * @details
+ * ** いかさまでクラッコン/妖精以外なら加算(+5+レベル/10)
+ */
+s16b PlayerSpeed::personality_value()
+{
+    s16b result = 0;
+    if (this->owner_ptr->pseikaku == PERSONALITY_MUNCHKIN && this->owner_ptr->prace != RACE_KLACKON && this->owner_ptr->prace != RACE_SPRITE) {
+        result += (this->owner_ptr->lev) / 10 + 5;
+    }
+    return result;
+}
+
+/*
+ * @brief 速度計算 - 装備品特殊セット
+ * @return 速度値の増減分
+ * @details
+ * ** 棘セット装備中ならば加算(+7)
+ * ** アイシングデス-トゥインクル装備中ならば加算(+7)
+ */
+s16b PlayerSpeed::special_weapon_set_value()
+{
+    s16b result = 0;
+    if (has_melee_weapon(this->owner_ptr, INVEN_MAIN_HAND) && has_melee_weapon(this->owner_ptr, INVEN_SUB_HAND)) {
+        if ((this->owner_ptr->inventory_list[INVEN_MAIN_HAND].name1 == ART_QUICKTHORN)
+            && (this->owner_ptr->inventory_list[INVEN_SUB_HAND].name1 == ART_TINYTHORN)) {
+            result += 7;
+        }
+
+        if ((this->owner_ptr->inventory_list[INVEN_MAIN_HAND].name1 == ART_ICINGDEATH)
+            && (this->owner_ptr->inventory_list[INVEN_SUB_HAND].name1 == ART_TWINKLE)) {
+            result += 5;
+        }
+    }
+    return result;
+}
+
+/*
+ * @brief 速度計算 - 装備品
+ * @return 速度値の増減分
+ * @details
+ * ** 装備品にTR_SPEEDがあれば加算(+pval+1
+ * ** セットで加速増減があるものを計算
+ */
+s16b PlayerSpeed::equipments_value()
+{
+    s16b result = PlayerStatusBase::equipments_value();
+    result += this->special_weapon_set_value();
+
+    return result;
+}
+
+/*
+ * @brief 速度計算 - 一時的効果
+ * @return 速度値の増減分
+ * @details
+ * ** 加速状態中なら加算(+10)
+ * ** 減速状態中なら減算(-10)
+ * ** 呪術「衝撃のクローク」で加算(+3)
+ * ** 食い過ぎなら減算(-10)
+ * ** 光速移動中は+999(最終的に+99になる)
+ */
+s16b PlayerSpeed::time_effect_value()
+{
+    s16b result = 0;
+
+    if (is_fast(this->owner_ptr)) {
+        result += 10;
+    }
+
+    if (this->owner_ptr->slow) {
+        result -= 10;
+    }
+
+    if (this->owner_ptr->realm1 == REALM_HEX) {
+        if (hex_spelling(this->owner_ptr, HEX_SHOCK_CLOAK)) {
+            result += 3;
+        }
+    }
+
+    if (this->owner_ptr->food >= PY_FOOD_MAX)
+        result -= 10;
+
+    /* Temporary lightspeed forces to be maximum speed */
+    if (this->owner_ptr->lightspeed)
+        result += 999;
+
+    return result;
+}
+
+/*
+ * @brief 速度計算 - 型
+ * @return 速度値の増減分
+ * @details
+ * ** 朱雀の構えなら加算(+10)
+ */
+s16b PlayerSpeed::battleform_value()
+{
+    s16b result = 0;
+    if (any_bits(this->owner_ptr->special_defense, KAMAE_SUZAKU))
+        result += 10;
+    return result;
+}
+
+/*
+ * @brief 速度計算 - 変異
+ * @return 速度値の増減分
+ * @details
+ * ** 変異MUT3_XTRA_FATなら減算(-2)
+ * ** 変異MUT3_XTRA_LEGなら加算(+3)
+ * ** 変異MUT3_SHORT_LEGなら減算(-3)
+ */
+s16b PlayerSpeed::mutation_value()
+{
+    SPEED result = 0;
+    if (this->owner_ptr->muta3) {
+        if (any_bits(this->owner_ptr->muta3, MUT3_XTRA_FAT)) {
+            result -= 2;
+        }
+
+        if (any_bits(this->owner_ptr->muta3, MUT3_XTRA_LEGS)) {
+            result += 3;
+        }
+
+        if (any_bits(this->owner_ptr->muta3, MUT3_SHORT_LEG)) {
+            result -= 3;
+        }
+    }
+    return result;
+}
+
+/*
+ * @brief 速度計算 - 乗馬
+ * @return 速度値の増減分
+ * @details
+ * * 騎乗中ならばモンスターの加速に準拠、ただし騎乗技能値とモンスターレベルによるキャップ処理あり
+ */
+s16b PlayerSpeed::riding_value()
+{
+    monster_type *riding_m_ptr = &(this->owner_ptr)->current_floor_ptr->m_list[this->owner_ptr->riding];
+    SPEED speed = riding_m_ptr->mspeed;
+    SPEED result = 0;
+
+    if (!this->owner_ptr->riding) {
+        return 0;
+    }
+
+    if (riding_m_ptr->mspeed > 110) {
+        result = (s16b)((speed - 110) * (this->owner_ptr->skill_exp[GINOU_RIDING] * 3 + this->owner_ptr->lev * 160L - 10000L) / (22000L));
+        if (result < 0)
+            result = 0;
+    } else {
+        result = speed - 110;
+    }
+
+    result += (this->owner_ptr->skill_exp[GINOU_RIDING] + this->owner_ptr->lev * 160L) / 3200;
+
+    if (monster_fast_remaining(riding_m_ptr))
+        result += 10;
+    if (monster_slow_remaining(riding_m_ptr))
+        result -= 10;
+
+    return result;
+}
+
+/*
+ * @brief 速度計算 - 重量
+ * @return 速度値の増減分
+ * @details
+ * * 所持品の重量による減速処理。乗馬時は別計算。
+ */
+s16b PlayerSpeed::inventory_weight_value()
+{
+    SPEED result = 0;
+
+    int weight = calc_inventory_weight(this->owner_ptr);
+    int count;
+
+    if (this->owner_ptr->riding) {
+        monster_type *riding_m_ptr = &(this->owner_ptr)->current_floor_ptr->m_list[this->owner_ptr->riding];
+        monster_race *riding_r_ptr = &r_info[riding_m_ptr->r_idx];
+        count = 1500 + riding_r_ptr->level * 25;
+
+        if (this->owner_ptr->skill_exp[GINOU_RIDING] < RIDING_EXP_SKILLED) {
+            weight += (this->owner_ptr->wt * 3 * (RIDING_EXP_SKILLED - this->owner_ptr->skill_exp[GINOU_RIDING])) / RIDING_EXP_SKILLED;
+        }
+
+        if (weight > count) {
+            result -= ((weight - count) / (count / 5));
+        }
+    } else {
+        count = (int)calc_weight_limit(this->owner_ptr);
+        if (weight > count) {
+            result -= ((weight - count) / (count / 5));
+        }
+    }
+    return result;
+}
+
+/*
+ * @brief 速度計算 - ACTION
+ * @return 速度値の増減分
+ * @details
+ * * 探索中なら減算(-10)
+ */
+s16b PlayerSpeed::action_value()
+{
+    SPEED result = 0;
+    if (this->owner_ptr->action == ACTION_SEARCH)
+        result -= 10;
+    return result;
+}
+
+/*
+ * @brief 速度フラグ - 装備
+ * @return 加速修正が0でない装備に対応したBIT_FLAG
+ * @details
+ * * セット二刀流は両手のフラグをONにする
+ */
+BIT_FLAGS PlayerSpeed::equipments_flags()
+{
+    BIT_FLAGS result = PlayerStatusBase::equipments_flags();
+
+    if (this->special_weapon_set_value() != 0)
+        set_bits(result, FLAG_CAUSE_INVEN_MAIN_HAND | FLAG_CAUSE_INVEN_SUB_HAND);
+
+    return result;
+}
+
+/*
+ * @brief 速度計算 - 合計値
+ * @return 計算済の速度値 11 - 209
+ * @details
+ * * 非乗馬時 - 乗馬以外の全要素の単純加算
+ * * 乗馬時 - 乗馬の速度と重量減衰のみを計算
+ */
+s16b PlayerSpeed::getValue()
+{
+    s16b pow = PlayerStatusBase::getValue();
+
+    if (this->owner_ptr->riding) {
+        pow = this->default_value;
+        pow += this->riding_value();
+        pow += this->inventory_weight_value();
+
+        if ((pow > this->max_value)) {
+            pow = this->max_value;
+        }
+
+        if (pow < this->min_value)
+            pow = this->min_value;
+    }
+    return pow;
+}

--- a/src/player-status/player-speed.h
+++ b/src/player-status/player-speed.h
@@ -1,0 +1,25 @@
+﻿#pragma once
+#include "player-status/player-status-base.h"
+
+class PlayerSpeed : public PlayerStatusBase {
+public:
+    PlayerSpeed(player_type *owner_ptr)
+        : PlayerStatusBase(owner_ptr){};
+
+    s16b getValue() override;
+
+protected:
+    void set_locals() override;
+    s16b race_value() override;
+    s16b class_value() override;
+    s16b personality_value() override;
+    s16b equipments_value() override;
+    s16b time_effect_value() override;
+    s16b battleform_value() override;
+    s16b mutation_value() override;
+    s16b riding_value() override;
+    s16b inventory_weight_value() override;
+    s16b action_value() override;
+    BIT_FLAGS equipments_flags() override;
+    s16b special_weapon_set_value();
+};

--- a/src/player-status/player-status-base.cpp
+++ b/src/player-status/player-status-base.cpp
@@ -1,0 +1,203 @@
+﻿#include "player-status/player-status-base.h"
+#include "inventory/inventory-slot-types.h"
+#include "object/object-flags.h"
+#include "player/player-status.h"
+#include "system/object-type-definition.h"
+#include "util/bit-flags-calculator.h"
+
+/*!
+ * @brief プレイヤーの各ステータス計算用のクラス
+ * @param owner_ptr プレイヤーの参照ポインタ
+ * @details
+ * * コンストラクタでowner_ptrをセット。メンバ変数を0クリア。
+ */
+PlayerStatusBase::PlayerStatusBase(player_type *owner_ptr)
+{
+    this->owner_ptr = owner_ptr;
+    this->set_locals(); /* 初期化。基底クラスの0クリアが呼ばれる。*/
+}
+
+/*!
+ * @brief 該当する値を計算して取得する。
+ * @details
+ * * 派生クラスからset_locals()をコールして初期値、上限、下限をセット。
+ * * 各要素毎に計算した値を初期値に単純に加算し、上限と下限で丸める。
+ */
+s16b PlayerStatusBase::getValue()
+{
+    this->set_locals(); /* 計算前に値のセット。派生クラスの値がセットされる。*/
+    s16b pow = this->default_value;
+
+    pow += this->action_value();
+    pow += this->battleform_value();
+    pow += this->class_value();
+    pow += this->equipments_value();
+    pow += this->inventory_weight_value();
+    pow += this->mutation_value();
+    pow += this->personality_value();
+    pow += this->race_value();
+    pow += this->riding_value();
+    pow += this->time_effect_value();
+
+    if ((pow > this->max_value)) {
+        pow = this->max_value;
+    }
+
+    if (pow < this->min_value)
+        pow = this->min_value;
+
+    return pow;
+}
+
+/*!
+ * @brief 修正値が0でないところにビットを立てて返す。
+ * @return 判定結果のBIT_FLAGS
+ */
+BIT_FLAGS PlayerStatusBase::getFlags()
+{
+    BIT_FLAGS result = equipments_flags();
+
+    if (this->class_value() != 0)
+        set_bits(result, FLAG_CAUSE_CLASS);
+
+    if (this->race_value() != 0)
+        set_bits(result, FLAG_CAUSE_RACE);
+
+    if (this->battleform_value() != 0)
+        set_bits(result, FLAG_CAUSE_BATTLE_FORM);
+
+    if (this->mutation_value() != 0)
+        set_bits(result, FLAG_CAUSE_MUTATION);
+
+    if (this->time_effect_value() != 0)
+        set_bits(result, FLAG_CAUSE_MAGIC_TIME_EFFECT);
+
+    if (this->personality_value() != 0)
+        set_bits(result, FLAG_CAUSE_PERSONALITY);
+
+    if (this->riding_value() != 0)
+        set_bits(result, FLAG_CAUSE_RIDING);
+
+    if (this->inventory_weight_value() != 0)
+        set_bits(result, FLAG_CAUSE_INVEN_PACK);
+
+    if (this->action_value() != 0)
+        set_bits(result, FLAG_CAUSE_ACTION);
+
+    return result;
+}
+
+/*!
+ * @brief 修正値が0以下のところにビットを立てて返す。
+ * @return 判定結果のBIT_FLAGS
+ */
+BIT_FLAGS PlayerStatusBase::getBadFlags()
+{
+    BIT_FLAGS result = equipments_bad_flags();
+
+    if (this->class_value() < 0)
+        set_bits(result, FLAG_CAUSE_CLASS);
+
+    if (this->race_value() < 0)
+        set_bits(result, FLAG_CAUSE_RACE);
+
+    if (this->battleform_value() < 0)
+        set_bits(result, FLAG_CAUSE_BATTLE_FORM);
+
+    if (this->mutation_value() < 0)
+        set_bits(result, FLAG_CAUSE_MUTATION);
+
+    if (this->time_effect_value() < 0)
+        set_bits(result, FLAG_CAUSE_MAGIC_TIME_EFFECT);
+
+    if (this->personality_value() < 0)
+        set_bits(result, FLAG_CAUSE_PERSONALITY);
+
+    if (this->riding_value() < 0)
+        set_bits(result, FLAG_CAUSE_RIDING);
+
+    if (this->inventory_weight_value() < 0)
+        set_bits(result, FLAG_CAUSE_INVEN_PACK);
+
+    if (this->action_value() < 0)
+        set_bits(result, FLAG_CAUSE_ACTION);
+
+    return result;
+}
+
+void PlayerStatusBase::set_locals()
+{
+    this->default_value = 0;
+    this->min_value = 0;
+    this->max_value = 0;
+    this->tr_flag = TR_FLAG_MAX;
+    this->tr_bad_flag = TR_FLAG_MAX;
+}
+
+BIT_FLAGS PlayerStatusBase::equipments_flags()
+{
+    this->set_locals(); /* 計算前に値のセット。派生クラスの値がセットされる。*/
+    object_type *o_ptr;
+    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    BIT_FLAGS result = 0L;
+    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+        o_ptr = &owner_ptr->inventory_list[i];
+        if (!o_ptr->k_idx)
+            continue;
+
+        object_flags(owner_ptr, o_ptr, flgs);
+
+        if (has_flag(flgs, tr_flag))
+            set_bits(result, convert_inventory_slot_type_to_flag_cause(static_cast<inventory_slot_type>(i)));
+    }
+    return result;
+}
+
+BIT_FLAGS PlayerStatusBase::equipments_bad_flags()
+{
+    this->set_locals(); /* 計算前に値のセット。派生クラスの値がセットされる。*/
+    object_type *o_ptr;
+    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    BIT_FLAGS result = 0L;
+    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+        o_ptr = &owner_ptr->inventory_list[i];
+        if (!o_ptr->k_idx)
+            continue;
+
+        object_flags(owner_ptr, o_ptr, flgs);
+
+        if (has_flag(flgs, tr_bad_flag)) {
+            if (o_ptr->pval < 0) {
+                set_bits(result, convert_inventory_slot_type_to_flag_cause(static_cast<inventory_slot_type>(i)));
+            }
+        }
+    }
+    return result;
+}
+
+s16b PlayerStatusBase::equipments_value()
+{
+    this->set_locals(); /* 計算前に値のセット。派生クラスの値がセットされる。*/
+    s16b result = 0;
+    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+        object_type *o_ptr = &owner_ptr->inventory_list[i];
+        BIT_FLAGS flgs[TR_FLAG_SIZE];
+        object_flags(owner_ptr, o_ptr, flgs);
+
+        if (!o_ptr->k_idx)
+            continue;
+        if (has_flag(flgs, tr_flag))
+            result += o_ptr->pval;
+    }
+    return result;
+}
+
+s16b PlayerStatusBase::race_value() { return 0; }
+s16b PlayerStatusBase::class_value() { return 0; }
+s16b PlayerStatusBase::personality_value() { return 0; }
+s16b PlayerStatusBase::time_effect_value() { return 0; }
+s16b PlayerStatusBase::battleform_value() { return 0; }
+s16b PlayerStatusBase::mutation_value() { return 0; }
+s16b PlayerStatusBase::riding_value() { return 0; }
+s16b PlayerStatusBase::inventory_weight_value() { return 0; }
+s16b PlayerStatusBase::action_value() { return 0; }

--- a/src/player-status/player-status-base.h
+++ b/src/player-status/player-status-base.h
@@ -1,0 +1,33 @@
+﻿#pragma once
+#include "system/angband.h"
+#include "player/player-status-flags.h"
+
+class PlayerStatusBase {
+public:
+    PlayerStatusBase(player_type *owner_ptr);
+    PlayerStatusBase() = delete;
+    virtual ~PlayerStatusBase() = default;
+    virtual s16b getValue();
+    virtual BIT_FLAGS getFlags();
+    virtual BIT_FLAGS getBadFlags();
+protected:
+    s16b default_value;
+    s16b min_value;
+    s16b max_value;
+    player_type *owner_ptr;
+    tr_type tr_flag;
+    tr_type tr_bad_flag;
+    virtual void set_locals();
+    virtual s16b race_value();
+    virtual s16b class_value();
+    virtual s16b personality_value();
+    virtual s16b equipments_value();
+    virtual s16b time_effect_value();
+    virtual s16b battleform_value();
+    virtual s16b mutation_value();
+    virtual s16b riding_value();
+    virtual s16b inventory_weight_value();
+    virtual s16b action_value();
+    virtual BIT_FLAGS equipments_flags();
+    virtual BIT_FLAGS equipments_bad_flags();
+};

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -12,6 +12,7 @@
 #include "object-hook/hook-checker.h"
 #include "object-hook/hook-weapon.h"
 #include "object/object-flags.h"
+#include "player-status/player-speed.h"
 #include "player/attack-defense-types.h"
 #include "player/mimic-info-table.h"
 #include "player/player-class.h"
@@ -33,8 +34,7 @@
 #include "util/quarks.h"
 #include "util/string-processor.h"
 
-
-static BIT_FLAGS convert_inventory_slot_type_to_flag_cause(inventory_slot_type inventory_slot)
+BIT_FLAGS convert_inventory_slot_type_to_flag_cause(inventory_slot_type inventory_slot)
 {
     switch (inventory_slot) {
     case INVEN_MAIN_HAND:
@@ -171,7 +171,7 @@ BIT_FLAGS get_player_flags(player_type *creature_ptr, tr_type tr_flag)
     case TR_TUNNEL:
         return 0;
     case TR_SPEED:
-        return player_flags_speed(creature_ptr);
+        return PlayerSpeed(creature_ptr).getFlags();
     case TR_BLOWS:
         return 0;
     case TR_CHAOTIC:

--- a/src/player/player-status-flags.h
+++ b/src/player/player-status-flags.h
@@ -1,5 +1,7 @@
-﻿#include "player/player-status.h"
+﻿#pragma once
+#include "inventory/inventory-slot-types.h"
 #include "object-enchant/tr-types.h"
+#include "player/player-status.h"
 
 enum flag_cause : uint32_t {
     FLAG_CAUSE_NONE = 0x0U,
@@ -44,6 +46,7 @@ enum aggravate_state {
     AGGRAVATE_NORMAL = 0x00000002L,
 };
 
+BIT_FLAGS convert_inventory_slot_type_to_flag_cause(inventory_slot_type inventory_slot);
 BIT_FLAGS check_equipment_flags(player_type *creature_ptr, tr_type tr_flag);
 BIT_FLAGS get_player_flags(player_type *creature_ptr, tr_type tr_flag);
 bool has_pass_wall(player_type *creature_ptr);

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -59,6 +59,8 @@
 #include "perception/object-perception.h"
 #include "pet/pet-util.h"
 #include "player-info/avatar.h"
+#include "player-status/player-speed.h"
+#include "player-status/player-status-base.h"
 #include "player/attack-defense-types.h"
 #include "player/digestion-processor.h"
 #include "player/mimic-info-table.h"
@@ -123,7 +125,6 @@ static s16b calc_charisma_addition(player_type *creature_ptr);
 static s16b calc_to_magic_chance(player_type *creature_ptr);
 static ARMOUR_CLASS calc_base_ac(player_type *creature_ptr);
 static ARMOUR_CLASS calc_to_ac(player_type *creature_ptr, bool is_real_value);
-static s16b calc_speed(player_type *creature_ptr);
 static s16b calc_double_weapon_penalty(player_type *creature_ptr, INVENTORY_IDX slot);
 static void update_use_status(player_type *creature_ptr, int status);
 static void update_top_status(player_type *creature_ptr, int status);
@@ -423,7 +424,7 @@ static void update_bonuses(player_type *creature_ptr)
         creature_ptr->to_ds[i] = calc_to_weapon_dice_side(creature_ptr, INVEN_MAIN_HAND + i);
     }
 
-    creature_ptr->pspeed = calc_speed(creature_ptr);
+    creature_ptr->pspeed = PlayerSpeed(creature_ptr).getValue();
     creature_ptr->see_infra = calc_intra_vision(creature_ptr);
     creature_ptr->skill_stl = calc_stealth(creature_ptr);
     creature_ptr->skill_dis = calc_disarming(creature_ptr);
@@ -1209,7 +1210,6 @@ static ACTION_SKILL_POWER calc_intra_vision(player_type *creature_ptr)
     return pow;
 }
 
-
 /*!
  * @brief 隠密能力計算 - 種族
  * @param creature_ptr 計算するクリーチャーの参照ポインタ
@@ -1217,7 +1217,7 @@ static ACTION_SKILL_POWER calc_intra_vision(player_type *creature_ptr)
  * @details
  * * 種族による加算
  */
-static ACTION_SKILL_POWER calc_player_stealth_by_race(player_type *creature_ptr) 
+static ACTION_SKILL_POWER calc_player_stealth_by_race(player_type *creature_ptr)
 {
     const player_race *tmp_rp_ptr;
 
@@ -1228,7 +1228,6 @@ static ACTION_SKILL_POWER calc_player_stealth_by_race(player_type *creature_ptr)
 
     return tmp_rp_ptr->r_stl;
 }
-
 
 /*!
  * @brief 隠密能力計算 - 性格
@@ -1257,7 +1256,6 @@ static ACTION_SKILL_POWER calc_player_base_stealth_by_class(player_type *creatur
     return c_ptr->c_stl + (c_ptr->x_stl * creature_ptr->lev / 10);
 }
 
-
 /*!
  * @brief 隠密能力計算 - 職業(追加分)
  * @param creature_ptr 計算するクリーチャーの参照ポインタ
@@ -1269,7 +1267,7 @@ static ACTION_SKILL_POWER calc_player_base_stealth_by_class(player_type *creatur
 static ACTION_SKILL_POWER calc_player_additional_stealth_by_class(player_type *creature_ptr)
 {
     ACTION_SKILL_POWER result = 0;
-    
+
     if (creature_ptr->pclass == CLASS_NINJA) {
         if (heavy_armor(creature_ptr)) {
             result -= (creature_ptr->lev) / 10;
@@ -1282,7 +1280,6 @@ static ACTION_SKILL_POWER calc_player_additional_stealth_by_class(player_type *c
     return result;
 }
 
-
 /*!
  * @brief 隠密能力計算 - 装備
  * @param creature_ptr 計算するクリーチャーの参照ポインタ
@@ -1292,7 +1289,6 @@ static ACTION_SKILL_POWER calc_player_additional_stealth_by_class(player_type *c
  */
 static ACTION_SKILL_POWER calc_player_stealth_by_equipment(player_type *creature_ptr)
 {
-
     ACTION_SKILL_POWER result = 0;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         object_type *o_ptr;
@@ -1306,7 +1302,6 @@ static ACTION_SKILL_POWER calc_player_stealth_by_equipment(player_type *creature
     }
     return result;
 }
-
 
 /*!
  * @brief 隠密能力計算 - 変異
@@ -1368,14 +1363,13 @@ static ACTION_SKILL_POWER calc_player_stealth_by_s_faiery(player_type *creature_
     return pow;
 }
 
-
 BIT_FLAGS player_flags_stealth(player_type *creature_ptr)
 {
     BIT_FLAGS result = check_equipment_flags(creature_ptr, TR_STEALTH);
 
     if (calc_player_additional_stealth_by_class(creature_ptr) != 0)
         set_bits(result, FLAG_CAUSE_CLASS);
-    
+
     if (calc_player_stealth_by_mutation(creature_ptr) != 0)
         set_bits(result, FLAG_CAUSE_MUTATION);
 
@@ -1406,7 +1400,7 @@ static ACTION_SKILL_POWER calc_stealth(player_type *creature_ptr)
     pow += calc_player_stealth_by_equipment(creature_ptr);
     pow += calc_player_stealth_by_mutation(creature_ptr);
     pow += calc_player_stealth_by_time_effect(creature_ptr);
-    pow = calc_player_stealth_by_s_faiery(creature_ptr, pow); /* Set New Value */
+    pow = calc_player_stealth_by_s_faiery(creature_ptr, pow); /* Set New getValue */
 
     if (pow > 30)
         pow = 30;
@@ -2588,399 +2582,6 @@ static ARMOUR_CLASS calc_to_ac(player_type *creature_ptr, bool is_real_value)
     }
 
     return ac;
-}
-
-/*!
- * @brief 速度計算 - 種族
- * @param creature_ptr 計算するクリーチャーの参照ポインタ
- * @return 速度値の増減分
- * @details
- * ** クラッコンと妖精に加算(+レベル/10)
- * ** 悪魔変化/吸血鬼変化で加算(+3)
- * ** 魔王変化で加算(+5)
- * ** マーフォークがFF_WATER地形にいれば加算(+2+レベル/10)
- * ** そうでなく浮遊を持っていないなら減算(-2)
- */
-static SPEED calc_player_speed_by_race(player_type *creature_ptr)
-{
-    SPEED result = 0;
-
-    if (is_specific_player_race(creature_ptr, RACE_KLACKON) || is_specific_player_race(creature_ptr, RACE_SPRITE))
-        result += (creature_ptr->lev) / 10;
-
-    if (is_specific_player_race(creature_ptr, RACE_MERFOLK)) {
-        floor_type *floor_ptr = creature_ptr->current_floor_ptr;
-        feature_type *f_ptr = &f_info[floor_ptr->grid_array[creature_ptr->y][creature_ptr->x].feat];
-        if (has_flag(f_ptr->flags, FF_WATER)) {
-            result += (2 + creature_ptr->lev / 10);
-        } else if (!creature_ptr->levitation) {
-            result -= 2;
-        }
-    }
-
-    if (creature_ptr->mimic_form) {
-        switch (creature_ptr->mimic_form) {
-        case MIMIC_DEMON:
-            result += 3;
-            break;
-        case MIMIC_DEMON_LORD:
-            result += 5;
-            break;
-        case MIMIC_VAMPIRE:
-            result += 3;
-            break;
-        }
-    }
-    return result;
-}
-
-static SPEED calc_speed_by_secial_weapon_set(player_type *creature_ptr) 
-{
-    SPEED result = 0;
-    if (has_melee_weapon(creature_ptr, INVEN_MAIN_HAND) && has_melee_weapon(creature_ptr, INVEN_SUB_HAND)) {
-        if ((creature_ptr->inventory_list[INVEN_MAIN_HAND].name1 == ART_QUICKTHORN) && (creature_ptr->inventory_list[INVEN_SUB_HAND].name1 == ART_TINYTHORN)) {
-            result += 7;
-        }
-
-        if ((creature_ptr->inventory_list[INVEN_MAIN_HAND].name1 == ART_ICINGDEATH) && (creature_ptr->inventory_list[INVEN_SUB_HAND].name1 == ART_TWINKLE)) {
-            result += 5;
-        }
-    }
-    return result;
-}
-
-
-/*!
- * @brief 速度計算 - ACTION
- * @param creature_ptr 計算するクリーチャーの参照ポインタ
- * @return 速度値の増減分
- * @details
- * ** 装備品にTR_SPEEDがあれば加算(+pval+1
- * ** 棘セット装備中ならば加算(+7)
- * ** アイシングデス-トゥインクル装備中ならば加算(+7)
- */
-static SPEED calc_player_speed_by_equipment(player_type *creature_ptr)
-{
-    SPEED result = 0;
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        object_type *o_ptr = &creature_ptr->inventory_list[i];
-        BIT_FLAGS flgs[TR_FLAG_SIZE];
-        object_flags(creature_ptr, o_ptr, flgs);
-
-        if (!o_ptr->k_idx)
-            continue;
-        if (has_flag(flgs, TR_SPEED))
-            result += o_ptr->pval;
-    }
-    result += calc_speed_by_secial_weapon_set(creature_ptr);
-
-    return result;
-}
-
-/*!
- * @brief 速度計算 - ACTION
- * @param creature_ptr 計算するクリーチャーの参照ポインタ
- * @return 速度値の増減分
- * @details
- * ** 忍者の装備が重ければ減算(-レベル/10)
- * ** 忍者の装備が適正ならば加算(+3)さらにクラッコン、妖精、いかさま以外なら加算(+レベル/10)
- * ** 錬気術師で装備が重くなくクラッコン、妖精、いかさま以外なら加算(+レベル/10)
- * ** 狂戦士なら加算(+3),レベル20/30/40/50ごとに+1
- */
-static SPEED calc_player_speed_by_class(player_type *creature_ptr)
-{
-    SPEED result = 0;
-
-    if (creature_ptr->pclass == CLASS_NINJA) {
-        if (heavy_armor(creature_ptr)) {
-            result -= (creature_ptr->lev) / 10;
-        } else if ((!creature_ptr->inventory_list[INVEN_MAIN_HAND].k_idx || can_attack_with_main_hand(creature_ptr))
-            && (!creature_ptr->inventory_list[INVEN_SUB_HAND].k_idx || can_attack_with_sub_hand(creature_ptr))) {
-            result += 3;
-            if (!(is_specific_player_race(creature_ptr, RACE_KLACKON) || is_specific_player_race(creature_ptr, RACE_SPRITE)
-                    || (creature_ptr->pseikaku == PERSONALITY_MUNCHKIN)))
-                result += (creature_ptr->lev) / 10;
-        }
-    }
-
-    if ((creature_ptr->pclass == CLASS_MONK || creature_ptr->pclass == CLASS_FORCETRAINER) && !(heavy_armor(creature_ptr))) {
-        if (!(is_specific_player_race(creature_ptr, RACE_KLACKON) || is_specific_player_race(creature_ptr, RACE_SPRITE)
-                || (creature_ptr->pseikaku == PERSONALITY_MUNCHKIN)))
-            result += (creature_ptr->lev) / 10;
-    }
-
-    if (creature_ptr->pclass == CLASS_BERSERKER) {
-        result += 2;
-        if (creature_ptr->lev > 29)
-            result++;
-        if (creature_ptr->lev > 39)
-            result++;
-        if (creature_ptr->lev > 44)
-            result++;
-        if (creature_ptr->lev > 49)
-            result++;
-    }
-    return result;
-}
-
-/*!
- * @brief 速度計算 - 型
- * @param creature_ptr 計算するクリーチャーの参照ポインタ
- * @return 速度値の増減分
- * @details
- * * 基礎値110(+-0に対応)
- * ** 朱雀の構えなら加算(+10)
- */
-static SPEED calc_player_speed_by_battleform(player_type *creature_ptr)
-{
-    SPEED result = 0;
-    if (any_bits(creature_ptr->special_defense, KAMAE_SUZAKU))
-        result += 10;
-    return result;
-}
-
-/*!
- * @brief 速度計算 - 変異
- * @param creature_ptr 計算するクリーチャーの参照ポインタ
- * @return 速度値の増減分
- * @details
- * * 基礎値110(+-0に対応)
- * ** 変異MUT3_XTRA_FATなら減算(-2)
- * ** 変異MUT3_XTRA_LEGなら加算(+3)
- * ** 変異MUT3_SHORT_LEGなら減算(-3)
- */
-static SPEED calc_player_speed_by_mutation(player_type *creature_ptr)
-{
-    SPEED result = 0;
-    if (creature_ptr->muta3) {
-        if (any_bits(creature_ptr->muta3, MUT3_XTRA_FAT)) {
-            result -= 2;
-        }
-
-        if (any_bits(creature_ptr->muta3, MUT3_XTRA_LEGS)) {
-            result += 3;
-        }
-
-        if (any_bits(creature_ptr->muta3, MUT3_SHORT_LEG)) {
-            result -= 3;
-        }
-    }
-    return result;
-}
-
-/*!
- * @brief 速度計算 - 一時的効果
- * @param creature_ptr 計算するクリーチャーの参照ポインタ
- * @return 速度値の増減分
- * @details
- * ** 加速状態中なら加算(+10)
- * ** 減速状態中なら減算(-10)
- * ** 呪術「衝撃のクローク」で加算(+3)
- * ** 食い過ぎなら減算(-10)
- * ** 光速移動中は+999(最終的に+99になる)
- */
-static SPEED calc_player_speed_by_time_effect(player_type *creature_ptr)
-{
-    SPEED result = 0;
-
-    if (is_fast(creature_ptr)) {
-        result += 10;
-    }
-
-    if (creature_ptr->slow) {
-        result -= 10;
-    }
-
-    if (creature_ptr->realm1 == REALM_HEX) {
-        if (hex_spelling(creature_ptr, HEX_SHOCK_CLOAK)) {
-            result += 3;
-        }
-    }
-
-    if (creature_ptr->food >= PY_FOOD_MAX)
-        result -= 10;
-
-    /* Temporary lightspeed forces to be maximum speed */
-    if (creature_ptr->lightspeed)
-        result += 999;
-
-    return result;
-}
-
-/*!
- * @brief 速度計算 - 性格
- * @param creature_ptr 計算するクリーチャーの参照ポインタ
- * @return 速度値の増減分
- * @details
- * ** いかさまでクラッコン/妖精以外なら加算(+5+レベル/10)
- */
-static SPEED calc_player_speed_by_personality(player_type *creature_ptr)
-{
-    SPEED result = 0;
-    if (creature_ptr->pseikaku == PERSONALITY_MUNCHKIN && creature_ptr->prace != RACE_KLACKON && creature_ptr->prace != RACE_SPRITE) {
-        result += (creature_ptr->lev) / 10 + 5;
-    }
-    return result;
-}
-
-/*!
- * @brief 速度計算 - 重量
- * @param creature_ptr 計算するクリーチャーの参照ポインタ
- * @return 速度値の増減分
- * @details
- * * 所持品の重量による減速処理。乗馬時は別計算。
- */
-static SPEED calc_player_speed_by_inventory_weight(player_type *creature_ptr)
-{
-    SPEED result = 0;
-
-    int weight = calc_inventory_weight(creature_ptr);
-    int count;
-
-    if (creature_ptr->riding) {
-        monster_type *riding_m_ptr = &creature_ptr->current_floor_ptr->m_list[creature_ptr->riding];
-        monster_race *riding_r_ptr = &r_info[riding_m_ptr->r_idx];
-        count = 1500 + riding_r_ptr->level * 25;
-
-        if (creature_ptr->skill_exp[GINOU_RIDING] < RIDING_EXP_SKILLED) {
-            weight += (creature_ptr->wt * 3 * (RIDING_EXP_SKILLED - creature_ptr->skill_exp[GINOU_RIDING])) / RIDING_EXP_SKILLED;
-        }
-
-        if (weight > count) {
-            result -= ((weight - count) / (count / 5));
-        }
-    } else {
-        count = (int)calc_weight_limit(creature_ptr);
-        if (weight > count) {
-            result -= ((weight - count) / (count / 5));
-        }
-    }
-
-    return result;
-}
-
-/*!
- * @brief 速度計算 - 乗馬
- * @param creature_ptr 計算するクリーチャーの参照ポインタ
- * @return 速度値の増減分
- * @details
- * * 騎乗中ならばモンスターの加速に準拠、ただし騎乗技能値とモンスターレベルによるキャップ処理あり
- */
-static SPEED calc_player_speed_by_riding(player_type *creature_ptr)
-{
-    monster_type *riding_m_ptr = &creature_ptr->current_floor_ptr->m_list[creature_ptr->riding];
-    SPEED speed = riding_m_ptr->mspeed;
-    SPEED result = 0;
-
-    if (creature_ptr->riding) {
-        return 0;
-    }
-
-    if (riding_m_ptr->mspeed > 110) {
-        result = (s16b)((speed - 110) * (creature_ptr->skill_exp[GINOU_RIDING] * 3 + creature_ptr->lev * 160L - 10000L) / (22000L));
-        if (result < 0)
-            result = 0;
-    } else {
-        result = speed - 110;
-    }
-
-    result += (creature_ptr->skill_exp[GINOU_RIDING] + creature_ptr->lev * 160L) / 3200;
-
-    if (monster_fast_remaining(riding_m_ptr))
-        result += 10;
-    if (monster_slow_remaining(riding_m_ptr))
-        result -= 10;
-
-    return result;
-}
-
-/*!
- * @brief 速度計算 - ACTION
- * @param creature_ptr 計算するクリーチャーの参照ポインタ
- * @return 速度値の増減分
- * @details
- * * 探索中なら減算(-10)
- */
-static SPEED calc_player_speed_by_action(player_type *creature_ptr)
-{
-    SPEED result = 0;
-    if (creature_ptr->action == ACTION_SEARCH)
-        result -= 10;
-    return result;
-}
-
-BIT_FLAGS player_flags_speed(player_type *creature_ptr)
-{
-    BIT_FLAGS result = check_equipment_flags(creature_ptr, TR_SPEED);
-
-    if (calc_speed_by_secial_weapon_set(creature_ptr) != 0)
-        set_bits(result, FLAG_CAUSE_INVEN_MAIN_HAND | FLAG_CAUSE_INVEN_SUB_HAND);
-
-    if (calc_player_speed_by_class(creature_ptr) != 0)
-        set_bits(result, FLAG_CAUSE_CLASS);
-
-    if (calc_player_speed_by_race(creature_ptr) != 0)
-        set_bits(result, FLAG_CAUSE_RACE);
-
-    if (calc_player_speed_by_battleform(creature_ptr) != 0)
-        set_bits(result, FLAG_CAUSE_BATTLE_FORM);
-
-    if (calc_player_speed_by_mutation(creature_ptr) != 0)
-        set_bits(result, FLAG_CAUSE_MUTATION);
-
-    if (calc_player_speed_by_time_effect(creature_ptr) != 0)
-        set_bits(result, FLAG_CAUSE_MAGIC_TIME_EFFECT);
-
-    if (calc_player_speed_by_personality(creature_ptr) != 0)
-        set_bits(result, FLAG_CAUSE_PERSONALITY);
-
-    if (calc_player_speed_by_riding(creature_ptr) != 0)
-        set_bits(result, FLAG_CAUSE_RIDING);
-
-    if (calc_player_speed_by_inventory_weight(creature_ptr) != 0)
-        set_bits(result, FLAG_CAUSE_INVEN_PACK);
-
-    if (calc_player_speed_by_action(creature_ptr) != 0)
-        set_bits(result, FLAG_CAUSE_ACTION);
-
-    return result;
-}
-
-/*!
- * @brief 速度計算
- * @param creature_ptr 計算するクリーチャーの参照ポインタ
- * @return 速度値
- * @details 上限99、下限-99
- */
-static SPEED calc_speed(player_type *creature_ptr)
-{
-    SPEED pow = 110;
-
-    if (creature_ptr->riding) {
-        pow += calc_player_speed_by_riding(creature_ptr);
-        pow += calc_player_speed_by_inventory_weight(creature_ptr);
-    } else {
-        pow += calc_player_speed_by_race(creature_ptr);
-        pow += calc_player_speed_by_equipment(creature_ptr);
-        pow += calc_player_speed_by_class(creature_ptr);
-        pow += calc_player_speed_by_personality(creature_ptr);
-        pow += calc_player_speed_by_time_effect(creature_ptr);
-        pow += calc_player_speed_by_battleform(creature_ptr);
-        pow += calc_player_speed_by_mutation(creature_ptr);
-        pow += calc_player_speed_by_inventory_weight(creature_ptr);
-    }
-    pow += calc_player_speed_by_action(creature_ptr);
-
-    /* Maximum speed is (+99). (internally it's 110 + 99) */
-    if ((pow > 209)) {
-        pow = 209;
-    }
-
-    /* Minimum speed is (-99). (internally it's 110 - 99) */
-    if (pow < 11)
-        pow = 11;
-
-    return pow;
 }
 
 /*!

--- a/src/player/player-status.h
+++ b/src/player/player-status.h
@@ -8,7 +8,6 @@
 #include "player/player-personalities-types.h"
 #include "player/player-race-types.h"
 #include "spell/spells-util.h"
-
 /*
  * Most of the "player" information goes here.
  *
@@ -481,7 +480,6 @@ extern int calc_weapon_weight_limit(player_type *creature_ptr);
 extern WEIGHT calc_inventory_weight(player_type *creature_ptr);
 
 extern s16b calc_num_fire(player_type *creature_ptr, object_type *o_ptr);
-BIT_FLAGS player_flags_speed(player_type *creature_ptr);
 BIT_FLAGS player_flags_stealth(player_type *creature_ptr);
 extern WEIGHT calc_weight_limit(player_type *creature_ptr);
 extern bool has_melee_weapon(player_type *creature_ptr, int i);


### PR DESCRIPTION
player_typeの各能力値は種族/職業/装備等の多様な要素により修正を受ける。
これらは現在のところ能力毎に混然と処理されていて、しかも実数値とdump用表記の二重実装となっている。
各数値の内部処理をなるべく統一し、画一的に出力するためPlayerStatusBaseクラスを導入する。
これを継承して各能力値の処理クラスを実装し、見通しを良くしたい。
とりあえずは基底クラスと速度計算クラスを導入する。