### PR TITLE
[Feature] 足元/床上のアイテム一覧ウィンドウフラグ (from 東方勝手版)

### DIFF
--- a/src/artifact/random-art-generator.cpp
+++ b/src/artifact/random-art-generator.cpp
@@ -380,7 +380,7 @@ static void generate_unnatural_random_artifact(player_type *player_ptr, object_t
     msg_format_wizard(player_ptr, CHEAT_OBJECT,
         _("パワー %d で 価値%ld のランダムアーティファクト生成 バイアスは「%s」", "Random artifact generated - Power:%d Value:%d Bias:%s."), max_powers,
         total_flags, artifact_bias_name[o_ptr->artifact_bias]);
-    player_ptr->window_flags |= PW_INVEN | PW_EQUIP;
+    set_bits(player_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_FLOOR_ITEM_LIST);
 }
 
 /*!

--- a/src/autopick/autopick.cpp
+++ b/src/autopick/autopick.cpp
@@ -28,6 +28,7 @@
 #include "system/floor-type-definition.h"
 #include "term/screen-processor.h"
 #include "view/display-messages.h"
+#include "window/display-sub-windows.h"
 
 /*
  *  Auto-destroy marked item
@@ -73,6 +74,9 @@ void autopick_delayed_alter(player_type *owner_ptr)
         autopick_delayed_alter_aux(owner_ptr, -item);
         item = next;
     }
+
+    // PW_FLOOR_ITEM_LISTは遅れるので即時更新
+    fix_floor_item_list(owner_ptr, owner_ptr->y, owner_ptr->x);
 }
 
 /*

--- a/src/birth/inventory-initializer.cpp
+++ b/src/birth/inventory-initializer.cpp
@@ -59,7 +59,7 @@ void wield_all(player_type *creature_ptr)
             inven_item_increase(creature_ptr, item, -1);
             inven_item_optimize(creature_ptr, item);
         } else {
-            floor_item_increase(creature_ptr->current_floor_ptr, 0 - item, -1);
+            floor_item_increase(creature_ptr, 0 - item, -1);
             floor_item_optimize(creature_ptr, 0 - item);
         }
 

--- a/src/cmd-io/cmd-floor.cpp
+++ b/src/cmd-io/cmd-floor.cpp
@@ -12,6 +12,7 @@
 #include "target/target-checker.h"
 #include "target/target-setter.h"
 #include "target/target-types.h"
+#include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "window/main-window-util.h"
 
@@ -38,7 +39,7 @@ void do_cmd_target(player_type *creature_ptr)
  */
 void do_cmd_look(player_type *creature_ptr)
 {
-    creature_ptr->window_flags |= PW_MONSTER_LIST;
+    set_bits(creature_ptr->window_flags, PW_MONSTER_LIST | PW_FLOOR_ITEM_LIST);
     handle_stuff(creature_ptr);
     if (target_set(creature_ptr, TARGET_LOOK))
         msg_print(_("ターゲット決定。", "Target Selected."));

--- a/src/cmd-io/cmd-gameoption.cpp
+++ b/src/cmd-io/cmd-gameoption.cpp
@@ -511,8 +511,7 @@ void do_cmd_options(player_type *player_ptr)
         case 'W':
         case 'w': {
             do_cmd_options_win(player_ptr);
-            player_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER | PW_MESSAGE | PW_OVERHEAD | PW_MONSTER | PW_OBJECT | PW_SNAPSHOT | PW_DUNGEON
-                | PW_MONSTER_LIST);
+            player_ptr->window_flags = PW_ALL;
             break;
         }
         case 'P':

--- a/src/cmd-item/cmd-equipment.cpp
+++ b/src/cmd-item/cmd-equipment.cpp
@@ -231,7 +231,7 @@ void do_cmd_wield(player_type *creature_ptr)
         inven_item_increase(creature_ptr, item, -1);
         inven_item_optimize(creature_ptr, item);
     } else {
-        floor_item_increase(creature_ptr->current_floor_ptr, 0 - item, -1);
+        floor_item_increase(creature_ptr, 0 - item, -1);
         floor_item_optimize(creature_ptr, 0 - item);
     }
 

--- a/src/cmd-item/cmd-item.cpp
+++ b/src/cmd-item/cmd-item.cpp
@@ -56,6 +56,7 @@
 #include "realm/realm-types.h"
 #include "status/action-setter.h"
 #include "term/screen-processor.h"
+#include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
 #include "util/quarks.h"
 #include "view/display-inventory.h"
@@ -185,9 +186,9 @@ void do_cmd_uninscribe(player_type *creature_ptr)
 
     msg_print(_("銘を消した。", "Inscription removed."));
     o_ptr->inscription = 0;
-    creature_ptr->update |= (PU_COMBINE);
-    creature_ptr->window_flags |= (PW_INVEN | PW_EQUIP);
-    creature_ptr->update |= (PU_BONUS);
+    set_bits(creature_ptr->update, PU_COMBINE);
+    set_bits(creature_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_FLOOR_ITEM_LIST);
+    set_bits(creature_ptr->update, PU_BONUS);
 }
 
 /*!
@@ -216,9 +217,9 @@ void do_cmd_inscribe(player_type *creature_ptr)
 
     if (get_string(_("銘: ", "Inscription: "), out_val, 80)) {
         o_ptr->inscription = quark_add(out_val);
-        creature_ptr->update |= (PU_COMBINE);
-        creature_ptr->window_flags |= (PW_INVEN | PW_EQUIP);
-        creature_ptr->update |= (PU_BONUS);
+        set_bits(creature_ptr->update, PU_COMBINE);
+        set_bits(creature_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_FLOOR_ITEM_LIST);
+        set_bits(creature_ptr->update, PU_BONUS);
     }
 }
 

--- a/src/cmd-item/cmd-throw.cpp
+++ b/src/cmd-item/cmd-throw.cpp
@@ -182,7 +182,7 @@ static void reflect_inventory_by_throw(player_type *creature_ptr, it_type *it_pt
         it_ptr->return_when_thrown = TRUE;
 
     if (it_ptr->item < 0) {
-        floor_item_increase(creature_ptr->current_floor_ptr, 0 - it_ptr->item, -1);
+        floor_item_increase(creature_ptr, 0 - it_ptr->item, -1);
         floor_item_optimize(creature_ptr, 0 - it_ptr->item);
         return;
     }

--- a/src/cmd-item/cmd-usestaff.cpp
+++ b/src/cmd-item/cmd-usestaff.cpp
@@ -46,6 +46,7 @@
 #include "status/shape-changer.h"
 #include "sv-definition/sv-staff-types.h"
 #include "system/floor-type-definition.h"
+#include "util/bit-flags-calculator.h"
 #include "term/screen-processor.h"
 #include "view/display-messages.h"
 #include "view/object-describer.h"
@@ -375,7 +376,7 @@ void exe_use_staff(player_type *creature_ptr, INVENTORY_IDX item)
      * is deducted from the staff.
      */
     BIT_FLAGS inventory_flags = (PU_COMBINE | PU_REORDER | (creature_ptr->update & PU_AUTODESTROY));
-    creature_ptr->update &= ~(PU_COMBINE | PU_REORDER | PU_AUTODESTROY);
+    reset_bits(creature_ptr->update, PU_COMBINE | PU_REORDER | PU_AUTODESTROY);
 
     /* Tried the item */
     object_tried(o_ptr);
@@ -386,8 +387,8 @@ void exe_use_staff(player_type *creature_ptr, INVENTORY_IDX item)
         gain_exp(creature_ptr, (lev + (creature_ptr->lev >> 1)) / creature_ptr->lev);
     }
 
-    creature_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
-    creature_ptr->update |= inventory_flags;
+    set_bits(creature_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_PLAYER | PW_FLOOR_ITEM_LIST);
+    set_bits(creature_ptr->update, inventory_flags);
 
     /* Hack -- some uses are "free" */
     if (!use_charge)

--- a/src/cmd-item/cmd-zaprod.cpp
+++ b/src/cmd-item/cmd-zaprod.cpp
@@ -38,6 +38,7 @@
 #include "sv-definition/sv-rod-types.h"
 #include "target/target-getter.h"
 #include "term/screen-processor.h"
+#include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 
 /*!
@@ -400,7 +401,7 @@ void exe_zap_rod(player_type *creature_ptr, INVENTORY_IDX item)
         gain_exp(creature_ptr, (lev + (creature_ptr->lev >> 1)) / creature_ptr->lev);
     }
 
-    creature_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
+    set_bits(creature_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_PLAYER | PW_FLOOR_ITEM_LIST);
 }
 
 /*!

--- a/src/cmd-item/cmd-zapwand.cpp
+++ b/src/cmd-item/cmd-zapwand.cpp
@@ -32,6 +32,7 @@
 #include "sv-definition/sv-wand-types.h"
 #include "target/target-getter.h"
 #include "term/screen-processor.h"
+#include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "view/object-describer.h"
 
@@ -410,7 +411,7 @@ void exe_aim_wand(player_type *creature_ptr, INVENTORY_IDX item)
      * is deducted from the wand.
      */
     BIT_FLAGS inventory_flags = (PU_COMBINE | PU_REORDER | (creature_ptr->update & PU_AUTODESTROY));
-    creature_ptr->update &= ~(PU_COMBINE | PU_REORDER | PU_AUTODESTROY);
+    reset_bits(creature_ptr->update, PU_COMBINE | PU_REORDER | PU_AUTODESTROY);
 
     if (!(object_is_aware(o_ptr))) {
         chg_virtue(creature_ptr, V_PATIENCE, -1);
@@ -427,8 +428,8 @@ void exe_aim_wand(player_type *creature_ptr, INVENTORY_IDX item)
         gain_exp(creature_ptr, (lev + (creature_ptr->lev >> 1)) / creature_ptr->lev);
     }
 
-    creature_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
-    creature_ptr->update |= inventory_flags;
+    set_bits(creature_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_PLAYER | PW_FLOOR_ITEM_LIST);
+    set_bits(creature_ptr->update, inventory_flags);
 
     /* Use a single charge */
     o_ptr->pval--;

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -300,7 +300,7 @@ static void generate_world(player_type *player_ptr, bool new_game)
 static void init_io(player_type *player_ptr)
 {
     term_xtra(TERM_XTRA_REACT, 0);
-    player_ptr->window_flags |= PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER | PW_MESSAGE | PW_OVERHEAD | PW_DUNGEON | PW_MONSTER | PW_OBJECT;
+    player_ptr->window_flags = PW_ALL;
     handle_stuff(player_ptr);
     if (arg_force_original)
         rogue_like_commands = FALSE;

--- a/src/core/window-redrawer.cpp
+++ b/src/core/window-redrawer.cpp
@@ -12,6 +12,7 @@
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "view/display-player.h"
 #include "window/display-sub-window-spells.h"
@@ -283,5 +284,11 @@ void window_stuff(player_type *player_ptr)
     if (window_flags & (PW_OBJECT)) {
         player_ptr->window_flags &= ~(PW_OBJECT);
         fix_object(player_ptr);
+    }
+
+    if (any_bits(window_flags, PW_FLOOR_ITEM_LIST)) {
+        reset_bits(player_ptr->window_flags, PW_FLOOR_ITEM_LIST);
+        // ウィンドウサイズ変更に対応できず。カーソル位置を取る必要がある。
+        fix_floor_item_list(player_ptr, player_ptr->y, player_ptr->x);
     }
 }

--- a/src/core/window-redrawer.h
+++ b/src/core/window-redrawer.h
@@ -7,19 +7,20 @@
  * @brief サブウィンドウ描画フラグ
  */
 enum window_redraw_type {
-    PW_INVEN        = 1U <<  0, /*!<サブウィンドウ描画フラグ: 所持品-装備品 / Display inven/equip */
-    PW_EQUIP        = 1U <<  1, /*!<サブウィンドウ描画フラグ: 装備品-所持品 / Display equip/inven */
-    PW_SPELL        = 1U <<  2, /*!<サブウィンドウ描画フラグ: 魔法一覧 / Display spell list */
-    PW_PLAYER       = 1U <<  3, /*!<サブウィンドウ描画フラグ: プレイヤーのステータス / Display character */
-    PW_MONSTER_LIST = 1U <<  4, /*!<サブウィンドウ描画フラグ: 視界内モンスターの一覧 / Display monster list */
-    PW_MESSAGE      = 1U <<  6, /*!<サブウィンドウ描画フラグ: メッセージログ / Display messages */
-    PW_OVERHEAD     = 1U <<  7, /*!<サブウィンドウ描画フラグ: 周辺の光景 / Display overhead view */
-    PW_MONSTER      = 1U <<  8, /*!<サブウィンドウ描画フラグ: モンスターの思い出 / Display monster recall */
-    PW_OBJECT       = 1U <<  9, /*!<サブウィンドウ描画フラグ: アイテムの知識 / Display object recall */
-    PW_DUNGEON      = 1U << 10, /*!<サブウィンドウ描画フラグ: ダンジョンの地形 / Display dungeon view */
-    PW_SNAPSHOT     = 1U << 11, /*!<サブウィンドウ描画フラグ: 記念写真 / Display snap-shot */
+    PW_INVEN           = 1U <<  0, /*!<サブウィンドウ描画フラグ: 所持品-装備品 / Display inven/equip */
+    PW_EQUIP           = 1U <<  1, /*!<サブウィンドウ描画フラグ: 装備品-所持品 / Display equip/inven */
+    PW_SPELL           = 1U <<  2, /*!<サブウィンドウ描画フラグ: 魔法一覧 / Display spell list */
+    PW_PLAYER          = 1U <<  3, /*!<サブウィンドウ描画フラグ: プレイヤーのステータス / Display character */
+    PW_MONSTER_LIST    = 1U <<  4, /*!<サブウィンドウ描画フラグ: 視界内モンスターの一覧 / Display monster list */
+    PW_MESSAGE         = 1U <<  6, /*!<サブウィンドウ描画フラグ: メッセージログ / Display messages */
+    PW_OVERHEAD        = 1U <<  7, /*!<サブウィンドウ描画フラグ: 周辺の光景 / Display overhead view */
+    PW_MONSTER         = 1U <<  8, /*!<サブウィンドウ描画フラグ: モンスターの思い出 / Display monster recall */
+    PW_OBJECT          = 1U <<  9, /*!<サブウィンドウ描画フラグ: アイテムの知識 / Display object recall */
+    PW_DUNGEON         = 1U << 10, /*!<サブウィンドウ描画フラグ: ダンジョンの地形 / Display dungeon view */
+    PW_SNAPSHOT        = 1U << 11, /*!<サブウィンドウ描画フラグ: 記念写真 / Display snap-shot */
+    PW_FLOOR_ITEM_LIST = 1U << 12, /*!<サブウィンドウ描画フラグ: 床上のアイテム一覧 / Display items at feet */
 
-    PW_ALL = (PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER | PW_MONSTER_LIST | PW_MESSAGE | PW_OVERHEAD | PW_MONSTER | PW_OBJECT | PW_DUNGEON | PW_SNAPSHOT),
+    PW_ALL = (PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER | PW_MONSTER_LIST | PW_MESSAGE | PW_OVERHEAD | PW_MONSTER | PW_OBJECT | PW_DUNGEON | PW_SNAPSHOT | PW_FLOOR_ITEM_LIST),
 };
 
 // clang-format on

--- a/src/core/window-redrawer.h
+++ b/src/core/window-redrawer.h
@@ -2,22 +2,27 @@
 
 #include "system/angband.h"
 
+// clang-format off
+/*!
+ * @brief サブウィンドウ描画フラグ
+ */
 enum window_redraw_type {
-    PW_INVEN = 0x00000001L, /*!<サブウィンドウ描画フラグ: 所持品-装備品 / Display inven/equip */
-    PW_EQUIP = 0x00000002L, /*!<サブウィンドウ描画フラグ: 装備品-所持品 / Display equip/inven */
-    PW_SPELL = 0x00000004L, /*!<サブウィンドウ描画フラグ: 魔法一覧 / Display spell list */
-    PW_PLAYER = 0x00000008L, /*!<サブウィンドウ描画フラグ: プレイヤーのステータス / Display character */
-    PW_MONSTER_LIST = 0x00000010L, /*!<サブウィンドウ描画フラグ: 視界内モンスターの一覧 / Display monster list */
-    PW_MESSAGE = 0x00000040L, /*!<サブウィンドウ描画フラグ: メッセージログ / Display messages */
-    PW_OVERHEAD = 0x00000080L, /*!<サブウィンドウ描画フラグ: 周辺の光景 / Display overhead view */
-    PW_MONSTER = 0x00000100L, /*!<サブウィンドウ描画フラグ: モンスターの思い出 / Display monster recall */
-    PW_OBJECT = 0x00000200L, /*!<サブウィンドウ描画フラグ: アイテムの知識 / Display object recall */
-    PW_DUNGEON = 0x00000400L, /*!<サブウィンドウ描画フラグ: ダンジョンの地形 / Display dungeon view */
-    PW_SNAPSHOT = 0x00000800L, /*!<サブウィンドウ描画フラグ: 記念写真 / Display snap-shot */
+    PW_INVEN        = 1U <<  0, /*!<サブウィンドウ描画フラグ: 所持品-装備品 / Display inven/equip */
+    PW_EQUIP        = 1U <<  1, /*!<サブウィンドウ描画フラグ: 装備品-所持品 / Display equip/inven */
+    PW_SPELL        = 1U <<  2, /*!<サブウィンドウ描画フラグ: 魔法一覧 / Display spell list */
+    PW_PLAYER       = 1U <<  3, /*!<サブウィンドウ描画フラグ: プレイヤーのステータス / Display character */
+    PW_MONSTER_LIST = 1U <<  4, /*!<サブウィンドウ描画フラグ: 視界内モンスターの一覧 / Display monster list */
+    PW_MESSAGE      = 1U <<  6, /*!<サブウィンドウ描画フラグ: メッセージログ / Display messages */
+    PW_OVERHEAD     = 1U <<  7, /*!<サブウィンドウ描画フラグ: 周辺の光景 / Display overhead view */
+    PW_MONSTER      = 1U <<  8, /*!<サブウィンドウ描画フラグ: モンスターの思い出 / Display monster recall */
+    PW_OBJECT       = 1U <<  9, /*!<サブウィンドウ描画フラグ: アイテムの知識 / Display object recall */
+    PW_DUNGEON      = 1U << 10, /*!<サブウィンドウ描画フラグ: ダンジョンの地形 / Display dungeon view */
+    PW_SNAPSHOT     = 1U << 11, /*!<サブウィンドウ描画フラグ: 記念写真 / Display snap-shot */
 
     PW_ALL = (PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER | PW_MONSTER_LIST | PW_MESSAGE | PW_OVERHEAD | PW_MONSTER | PW_OBJECT | PW_DUNGEON | PW_SNAPSHOT),
 };
 
+// clang-format on
 void redraw_window(void);
 void window_stuff(player_type *player_ptr);
 void redraw_stuff(player_type *creature_ptr);

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -196,13 +196,15 @@ void delete_all_items_from_floor(player_type *player_ptr, POSITION y, POSITION x
 /*!
  * @brief 床上のアイテムの数を増やす /
  * Increase the "number" of an item on the floor
- * @param floo_ptr 現在フロアへの参照ポインタ
+ * @param owner_ptr プレイヤーへの参照ポインタ
  * @param item 増やしたいアイテムの所持スロット
  * @param num 増やしたいアイテムの数
  * @return なし
  */
-void floor_item_increase(floor_type *floor_ptr, INVENTORY_IDX item, ITEM_NUMBER num)
+void floor_item_increase(player_type *owner_ptr, INVENTORY_IDX item, ITEM_NUMBER num)
 {
+    const floor_type *floor_ptr = owner_ptr->current_floor_ptr;
+
     object_type *o_ptr = &floor_ptr->o_list[item];
     num += o_ptr->number;
     if (num > 255)

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -7,6 +7,7 @@
 
 #include "floor/floor-object.h"
 #include "artifact/fixed-art-generator.h"
+#include "core/window-redrawer.h"
 #include "flavor/flavor-describer.h"
 #include "flavor/object-flavor-types.h"
 #include "floor/cave.h"
@@ -214,6 +215,8 @@ void floor_item_increase(player_type *owner_ptr, INVENTORY_IDX item, ITEM_NUMBER
 
     num -= o_ptr->number;
     o_ptr->number += num;
+
+    set_bits(owner_ptr->window_flags, PW_FLOOR_ITEM_LIST);
 }
 
 /*!
@@ -232,6 +235,8 @@ void floor_item_optimize(player_type *owner_ptr, INVENTORY_IDX item)
         return;
 
     delete_object_idx(owner_ptr, item);
+
+    set_bits(owner_ptr->window_flags, PW_FLOOR_ITEM_LIST);
 }
 
 /*!
@@ -555,6 +560,9 @@ OBJECT_IDX drop_near(player_type *owner_ptr, object_type *j_ptr, PERCENTAGE chan
     note_spot(owner_ptr, by, bx);
     lite_spot(owner_ptr, by, bx);
     sound(SOUND_DROP);
+
+    if (player_bold(owner_ptr, by, bx))
+        set_bits(owner_ptr->window_flags, PW_FLOOR_ITEM_LIST);
 
     if (chance && player_bold(owner_ptr, by, bx)) {
         msg_print(_("何かが足下に転がってきた。", "You feel something roll beneath your feet."));

--- a/src/floor/floor-object.h
+++ b/src/floor/floor-object.h
@@ -6,7 +6,7 @@
 bool make_object(player_type *owner_ptr, object_type *j_ptr, BIT_FLAGS mode);
 bool make_gold(player_type *player_ptr, object_type *j_ptr);
 void delete_all_items_from_floor(player_type *owner_ptr, POSITION y, POSITION x);
-void floor_item_increase(floor_type *floor_ptr, INVENTORY_IDX item, ITEM_NUMBER num);
+void floor_item_increase(player_type *owner_ptr, INVENTORY_IDX item, ITEM_NUMBER num);
 void floor_item_optimize(player_type *owner_ptr, INVENTORY_IDX item);
 void delete_object_idx(player_type *owner_ptr, OBJECT_IDX o_idx);
 void excise_object_idx(floor_type *floor_ptr, OBJECT_IDX o_idx);

--- a/src/inventory/inventory-object.cpp
+++ b/src/inventory/inventory-object.cpp
@@ -24,8 +24,7 @@ void vary_item(player_type *owner_ptr, INVENTORY_IDX item, ITEM_NUMBER num)
         return;
     }
 
-    floor_type *floor_ptr = owner_ptr->current_floor_ptr;
-    floor_item_increase(floor_ptr, 0 - item, num);
+    floor_item_increase(owner_ptr, 0 - item, num);
     floor_item_describe(owner_ptr, 0 - item);
     floor_item_optimize(owner_ptr, 0 - item);
 }

--- a/src/mind/mind-mindcrafter.cpp
+++ b/src/mind/mind-mindcrafter.cpp
@@ -34,6 +34,7 @@
 #include "status/sight-setter.h"
 #include "system/object-type-definition.h"
 #include "target/target-getter.h"
+#include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 
 /*!
@@ -79,12 +80,12 @@ bool psychometry(player_type *caster_ptr)
     msg_format("You feel that the %s %s %s...", o_name, ((o_ptr->number == 1) ? "is" : "are"), game_inscriptions[feel]);
 #endif
 
-    o_ptr->ident |= (IDENT_SENSE);
+    set_bits(o_ptr->ident, IDENT_SENSE);
     o_ptr->feeling = feel;
-    o_ptr->marked |= OM_TOUCHED;
+    set_bits(o_ptr->marked, OM_TOUCHED);
 
-    caster_ptr->update |= (PU_COMBINE | PU_REORDER);
-    caster_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
+    set_bits(caster_ptr->update, PU_COMBINE | PU_REORDER);
+    set_bits(caster_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_PLAYER | PW_FLOOR_ITEM_LIST);
 
     bool okay = FALSE;
     switch (o_ptr->tval) {

--- a/src/mind/mind-priest.cpp
+++ b/src/mind/mind-priest.cpp
@@ -59,10 +59,10 @@ bool bless_weapon(player_type *caster_ptr)
         msg_format("A malignant aura leaves %s %s.", ((item >= 0) ? "your" : "the"), o_name);
 #endif
         o_ptr->curse_flags = 0L;
-        o_ptr->ident |= IDENT_SENSE;
-        o_ptr->feeling = FEEL_NONE;
-        caster_ptr->update |= PU_BONUS;
-        caster_ptr->window_flags |= PW_EQUIP;
+        set_bits(o_ptr->ident, IDENT_SENSE);
+        set_bits(o_ptr->feeling, FEEL_NONE);
+        set_bits(caster_ptr->update, PU_BONUS);
+        set_bits(caster_ptr->window_flags, PW_EQUIP | PW_FLOOR_ITEM_LIST);
     }
 
     /*
@@ -132,8 +132,8 @@ bool bless_weapon(player_type *caster_ptr)
         }
     }
 
-    caster_ptr->update |= PU_BONUS;
-    caster_ptr->window_flags |= PW_EQUIP | PW_PLAYER;
+    set_bits(caster_ptr->update, PU_BONUS);
+    set_bits(caster_ptr->window_flags, PW_EQUIP | PW_PLAYER | PW_FLOOR_ITEM_LIST);
     calc_android_exp(caster_ptr);
     return TRUE;
 }

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -205,6 +205,12 @@ bool move_player_effect(player_type *creature_ptr, POSITION ny, POSITION nx, BIT
     if (!(mpe_mode & MPE_DONT_PICKUP))
         carry(creature_ptr, (mpe_mode & MPE_DO_PICKUP) ? TRUE : FALSE);
 
+    if (!creature_ptr->running) {
+        // 自動拾い/自動破壊により床上のアイテムリストが変化した可能性があるので表示を更新
+        set_bits(creature_ptr->window_flags, PW_FLOOR_ITEM_LIST);
+        window_stuff(creature_ptr);
+    }
+
     if (has_flag(f_ptr->flags, FF_STORE)) {
         disturb(creature_ptr, FALSE, TRUE);
         free_turn(creature_ptr);

--- a/src/spell-kind/spells-enchant.cpp
+++ b/src/spell-kind/spells-enchant.cpp
@@ -76,7 +76,7 @@ bool artifact_scroll(player_type *caster_ptr)
             if (item >= 0) {
                 inven_item_increase(caster_ptr, item, 1 - (o_ptr->number));
             } else {
-                floor_item_increase(caster_ptr->current_floor_ptr, 0 - item, 1 - (o_ptr->number));
+                floor_item_increase(caster_ptr, 0 - item, 1 - (o_ptr->number));
             }
         }
 

--- a/src/spell-kind/spells-perception.cpp
+++ b/src/spell-kind/spells-perception.cpp
@@ -24,6 +24,7 @@
 #include "perception/object-perception.h"
 #include "player-info/avatar.h"
 #include "system/object-type-definition.h"
+#include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 
@@ -59,7 +60,7 @@ bool identify_item(player_type *owner_ptr, object_type *o_ptr)
     describe_flavor(owner_ptr, o_name, o_ptr, 0);
 
     bool old_known = FALSE;
-    if (o_ptr->ident & IDENT_KNOWN)
+    if (any_bits(o_ptr->ident, IDENT_KNOWN))
         old_known = TRUE;
 
     if (!object_is_fully_known(o_ptr)) {
@@ -69,10 +70,10 @@ bool identify_item(player_type *owner_ptr, object_type *o_ptr)
 
     object_aware(owner_ptr, o_ptr);
     object_known(o_ptr);
-    o_ptr->marked |= OM_TOUCHED;
+    set_bits(o_ptr->marked, OM_TOUCHED);
 
-    owner_ptr->update |= (PU_BONUS | PU_COMBINE | PU_REORDER);
-    owner_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
+    set_bits(owner_ptr->update, PU_BONUS | PU_COMBINE | PU_REORDER);
+    set_bits(owner_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_PLAYER | PW_FLOOR_ITEM_LIST);
 
     strcpy(record_o_name, o_name);
     record_turn = current_world_ptr->game_turn;

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -45,6 +45,7 @@
 #include "system/artifact-type-definition.h"
 #include "system/floor-type-definition.h"
 #include "term/screen-processor.h"
+#include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 
 typedef struct {
@@ -529,8 +530,8 @@ bool enchant(player_type *caster_ptr, object_type *o_ptr, int n, int eflag)
     /* Failure */
     if (!res)
         return FALSE;
-    caster_ptr->update |= (PU_BONUS | PU_COMBINE | PU_REORDER);
-    caster_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
+    set_bits(caster_ptr->update, PU_BONUS | PU_COMBINE | PU_REORDER);
+    set_bits(caster_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_PLAYER | PW_FLOOR_ITEM_LIST);
 
     calc_android_exp(caster_ptr);
 

--- a/src/status/base-status.cpp
+++ b/src/status/base-status.cpp
@@ -11,6 +11,7 @@
 #include "player-info/avatar.h"
 #include "spell-kind/spells-floor.h"
 #include "system/object-type-definition.h"
+#include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 
 /* Array of stat "descriptions" */
@@ -276,9 +277,8 @@ bool lose_all_info(player_type *creature_ptr)
         o_ptr->ident &= ~(IDENT_SENSE);
     }
 
-    creature_ptr->update |= (PU_BONUS);
-    creature_ptr->update |= (PU_COMBINE | PU_REORDER);
-    creature_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
+    set_bits(creature_ptr->update, PU_BONUS | PU_COMBINE | PU_REORDER);
+    set_bits(creature_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_PLAYER | PW_FLOOR_ITEM_LIST);
     wiz_dark(creature_ptr);
     return TRUE;
 }

--- a/src/target/target-setter.cpp
+++ b/src/target/target-setter.cpp
@@ -19,7 +19,9 @@
 #include "target/target-preparation.h"
 #include "target/target-types.h"
 #include "term/screen-processor.h"
+#include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
+#include "window/display-sub-windows.h"
 #include "window/main-window-util.h"
 
 // Target Setter.
@@ -302,6 +304,8 @@ static bool set_target_grid(player_type *creature_ptr, ts_type *ts_ptr)
         return FALSE;
 
     describe_projectablity(creature_ptr, ts_ptr);
+    fix_floor_item_list(creature_ptr, ts_ptr->y, ts_ptr->x);
+
     while (TRUE) {
         ts_ptr->query = examine_grid(creature_ptr, ts_ptr->y, ts_ptr->x, ts_ptr->mode, ts_ptr->info);
         if (ts_ptr->query)
@@ -446,6 +450,7 @@ static void sweep_target_grids(player_type *creature_ptr, ts_type *ts_ptr)
         ts_ptr->g_ptr = &creature_ptr->current_floor_ptr->grid_array[ts_ptr->y][ts_ptr->x];
         strcpy(ts_ptr->info, _("q止 t決 p自 m近 +次 -前", "q,t,p,m,+,-,<dir>"));
         describe_grid_wizard(creature_ptr, ts_ptr);
+        fix_floor_item_list(creature_ptr, ts_ptr->y, ts_ptr->x);
 
         /* Describe and Prompt (enable "TARGET_LOOK") */
         while ((ts_ptr->query = examine_grid(creature_ptr, ts_ptr->y, ts_ptr->x, static_cast<target_type>(ts_ptr->mode | TARGET_LOOK), ts_ptr->info)) == 0)
@@ -473,9 +478,9 @@ bool target_set(player_type *creature_ptr, target_type mode)
     tmp_pos.n = 0;
     prt("", 0, 0);
     verify_panel(creature_ptr);
-    creature_ptr->update |= (PU_MONSTERS);
-    creature_ptr->redraw |= (PR_MAP);
-    creature_ptr->window_flags |= (PW_OVERHEAD);
+    set_bits(creature_ptr->update, PU_MONSTERS);
+    set_bits(creature_ptr->redraw, PR_MAP);
+    set_bits(creature_ptr->window_flags, PW_OVERHEAD | PW_FLOOR_ITEM_LIST);
     handle_stuff(creature_ptr);
     return target_who != 0;
 }

--- a/src/term/gameterm.cpp
+++ b/src/term/gameterm.cpp
@@ -123,7 +123,7 @@ const concptr window_flag_desc[32] =
 	_("アイテムの詳細", "Display object recall"),
 	_("自分の周囲を表示", "Display dungeon view"),
 	_("記念撮影", "Display snap-shot"),
-	NULL,
+	_("足元/床上のアイテム一覧", "Display items on floor"),
 	NULL,
 	NULL,
 	NULL,

--- a/src/window/display-sub-windows.h
+++ b/src/window/display-sub-windows.h
@@ -15,4 +15,5 @@ void fix_overhead(player_type *player_ptr);
 void fix_dungeon(player_type *player_ptr);
 void fix_monster(player_type *player_ptr);
 void fix_object(player_type *player_ptr);
+void fix_floor_item_list(player_type *player_ptr, const int y, const int x);
 void toggle_inventory_equipment(player_type *owner_ptr);

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -22,6 +22,7 @@
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 #include "view/display-messages.h"
+#include "util/bit-flags-calculator.h"
 
 #define K_MAX_DEPTH 110 /*!< アイテムの階層毎生成率を表示する最大階 */
 
@@ -348,9 +349,8 @@ static void wiz_reroll_item(player_type *owner_ptr, object_type *o_ptr)
         return;
 
     object_copy(o_ptr, q_ptr);
-    owner_ptr->update |= PU_BONUS;
-    owner_ptr->update |= PU_COMBINE | PU_REORDER;
-    owner_ptr->window_flags |= PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER;
+    set_bits(owner_ptr->update, PU_BONUS | PU_COMBINE | PU_REORDER);
+    set_bits(owner_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER | PW_FLOOR_ITEM_LIST);
 }
 
 /*!
@@ -487,9 +487,8 @@ void wiz_modify_item(player_type *creature_ptr)
         msg_print("Changes accepted.");
 
         object_copy(o_ptr, q_ptr);
-        creature_ptr->update |= PU_BONUS;
-        creature_ptr->update |= PU_COMBINE | PU_REORDER;
-        creature_ptr->window_flags |= PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER;
+        set_bits(creature_ptr->update, PU_BONUS | PU_COMBINE | PU_REORDER);
+        set_bits(creature_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER | PW_FLOOR_ITEM_LIST);
     } else {
         msg_print("Changes ignored.");
     }


### PR DESCRIPTION
#160のプルリクエストを最新のdevelopに合わせて再実装。

・普段は @ の足元が対象となる。look コマンドやターゲッティング動作中はカーソルのあるマスが対象。
・現在カーソルのある位置の座標とモンスター名/地名が表示される

[既知のバグ等]
・ターゲッティング動作中にサブウィンドウのサイズを変更すると @ の足元表示に切り替わってしまう
　→ターゲッティング状況をグローバルに保持しておく必要があり、やや重い変更となるので将来の対応に任せる
　　ターゲッティング中はメインウィンドウのリサイズも不具合があるので、合わせて変更？
・ダンジョン、クエスト及び一部街の建物の入り口の名称がメインウィンドウと異なる
　→本機能のために名称取得処理を実装または流用するのは、やや重い変更となるので将来の対応に任せる