### PR TITLE
[update] clang-formatの設定を更新

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,16 +11,16 @@ AlignTrailingComments: false
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: All
+AllowShortFunctionsOnASingleLine: Empty
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: false
+AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: true
 BinPackParameters: true
-BraceWrapping:   
+BraceWrapping:
   AfterClass:      false
   AfterControlStatement: false
   AfterEnum:       false
@@ -55,12 +55,12 @@ DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: false
-ForEachMacros:   
+ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
 IncludeBlocks:   Preserve
-IncludeCategories: 
+IncludeCategories:
   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
     Priority:        2
   - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
@@ -90,7 +90,7 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Right
-RawStringFormats: 
+RawStringFormats:
   - Delimiters:      [pb]
     Language:        TextProto
     BasedOnStyle:    google
@@ -112,4 +112,3 @@ Standard:        Cpp11
 TabWidth:        8
 UseTab:          Never
 ...
-


### PR DESCRIPTION
clang-formatが過剰に1行に整形してしまう場面があるので、
そうならないように以下の設定を変更する。

AllowShortFunctionsOnASingleLine: All → Empty
  空ブロックの時のみ1行にする。

AlwaysBreakTemplateDeclarations: false → Yes
  template 宣言は単独行のほうが見やすいのでそうする。