### PR TITLE
[Fix] 剣術家の「斬魔剣弐の太刀」の判定ミス #456

### DIFF
--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -127,7 +127,7 @@ static void hissatsu_serpent_tongue(player_type *attacker_ptr, samurai_slaying_t
  */
 static void hissatsu_zanma_ken(samurai_slaying_type *samurai_slaying_ptr)
 {
-    if (samurai_slaying_ptr->mode == HISSATSU_ZANMA)
+    if (samurai_slaying_ptr->mode != HISSATSU_ZANMA)
         return;
 
     if (!monster_living(samurai_slaying_ptr->m_ptr->r_idx) && (samurai_slaying_ptr->r_ptr->flags3 & RF3_EVIL)) {


### PR DESCRIPTION
「斬魔剣弐の太刀」の使用時にはスレイ効果がなく、
逆に不使用時の攻撃に「斬魔剣弐の太刀」分のスレイ効果が付いている。
該当部の判定を修正。