### PR TITLE
[feature] セーブファイルの仕様バージョンを本体のバージョンと分離する #470

### DIFF
--- a/src/load/dummy-loader.cpp
+++ b/src/load/dummy-loader.cpp
@@ -70,9 +70,6 @@ void rd_ghost(void)
 
 void rd_dummy3(void)
 {
-    u32b tmp32u;
-    rd_u32b(&tmp32u);
-
     u16b tmp16u;
     rd_u16b(&tmp16u);
 

--- a/src/load/floor-loader.cpp
+++ b/src/load/floor-loader.cpp
@@ -247,6 +247,7 @@ static bool load_floor_aux(player_type *player_ptr, saved_floor_type *sf_ptr)
     current_world_ptr->h_ver_patch = H_VER_PATCH;
     current_world_ptr->h_ver_minor = H_VER_MINOR;
     current_world_ptr->h_ver_major = H_VER_MAJOR;
+    loading_savefile_version = SAVEFILE_VERSION;
 
     u32b tmp32u;
     rd_u32b(&tmp32u);
@@ -302,6 +303,7 @@ bool load_floor(player_type *player_ptr, saved_floor_type *sf_ptr, BIT_FLAGS mod
     byte old_h_ver_minor = 0;
     byte old_h_ver_patch = 0;
     byte old_h_ver_extra = 0;
+    u32b old_loading_savefile_version = 0;
     if (mode & SLF_SECOND) {
         old_fff = loading_savefile;
         old_xor_byte = load_xor_byte;
@@ -311,6 +313,7 @@ bool load_floor(player_type *player_ptr, saved_floor_type *sf_ptr, BIT_FLAGS mod
         old_h_ver_minor = current_world_ptr->h_ver_minor;
         old_h_ver_patch = current_world_ptr->h_ver_patch;
         old_h_ver_extra = current_world_ptr->h_ver_extra;
+        old_loading_savefile_version = loading_savefile_version;
     }
 
     char floor_savefile[sizeof(savefile) + 32];
@@ -346,6 +349,7 @@ bool load_floor(player_type *player_ptr, saved_floor_type *sf_ptr, BIT_FLAGS mod
         current_world_ptr->h_ver_minor = old_h_ver_minor;
         current_world_ptr->h_ver_patch = old_h_ver_patch;
         current_world_ptr->h_ver_extra = old_h_ver_extra;
+        loading_savefile_version = old_loading_savefile_version;
     }
 
     byte old_kanji_code = kanji_code;

--- a/src/load/info-loader.cpp
+++ b/src/load/info-loader.cpp
@@ -20,14 +20,16 @@ void rd_version_info(void)
     rd_byte(&current_world_ptr->h_ver_minor);
     rd_byte(&current_world_ptr->h_ver_major);
 
-    load_note(format(_("バージョン %d.%d.%d.%d のセーブ・ファイルをロード中...", "Loading a %d.%d.%d.%d savefile..."),
-        (current_world_ptr->h_ver_major > 9) ? current_world_ptr->h_ver_major - 10 : current_world_ptr->h_ver_major, current_world_ptr->h_ver_minor,
-        current_world_ptr->h_ver_patch, current_world_ptr->h_ver_extra));
-
     rd_u32b(&current_world_ptr->sf_system);
     rd_u32b(&current_world_ptr->sf_when);
     rd_u16b(&current_world_ptr->sf_lives);
     rd_u16b(&current_world_ptr->sf_saves);
+
+    rd_u32b(&loading_savefile_version);
+
+    load_note(format(_("バージョン %d.%d.%d.%d のセーブデータ(SAVE%lu形式)をロード中...", "Loading a Verison %d.%d.%d.%d savefile (SAVE%lu format)..."),
+        (current_world_ptr->h_ver_major > 9) ? current_world_ptr->h_ver_major - 10 : current_world_ptr->h_ver_major, current_world_ptr->h_ver_minor,
+        current_world_ptr->h_ver_patch, current_world_ptr->h_ver_extra, loading_savefile_version));
 }
 
 /*!

--- a/src/load/load-util.cpp
+++ b/src/load/load-util.cpp
@@ -5,6 +5,7 @@
 #endif
 
 FILE *loading_savefile;
+u32b loading_savefile_version;
 byte load_xor_byte; // Old "encryption" byte.
 u32b v_check = 0L; // Simple "checksum" on the actual values.
 u32b x_check = 0L; // Simple "checksum" on the encoded bytes.
@@ -156,4 +157,16 @@ void strip_bytes(int n)
     byte tmp8u;
     while (n--)
         rd_byte(&tmp8u);
+}
+
+/**
+ * @brief ロード中のセーブファイルのバージョンが引数で指定したバージョンと比較して古いかどうか調べる
+ *
+ * @param version 比較するセーブファイルのバージョン
+ * @return bool ロード中のセーブファイルのバージョンが version より古いなら true
+ *              version と等しいかより新しいなら false
+ */
+bool loading_savefile_version_is_older_than(u32b version)
+{
+    return loading_savefile_version < version;
 }

--- a/src/load/load-util.h
+++ b/src/load/load-util.h
@@ -3,6 +3,7 @@
 #include "system/angband.h"
 
 extern FILE *loading_savefile;
+extern u32b loading_savefile_version;
 extern byte load_xor_byte;
 extern u32b v_check;
 extern u32b x_check;
@@ -17,3 +18,4 @@ void rd_u32b(u32b *ip);
 void rd_s32b(s32b *ip);
 void rd_string(char *str, int max);
 void strip_bytes(int n);
+bool loading_savefile_version_is_older_than(u32b version);

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -162,7 +162,6 @@ static errr verify_encoded_checksum()
 static errr exe_reading_savefile(player_type *creature_ptr)
 {
     rd_version_info();
-    rd_u32b(&loading_savefile_version);
     rd_dummy3();
     rd_system_info();
     rd_unique_info();

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -162,6 +162,7 @@ static errr verify_encoded_checksum()
 static errr exe_reading_savefile(player_type *creature_ptr)
 {
     rd_version_info();
+    rd_u32b(&loading_savefile_version);
     rd_dummy3();
     rd_system_info();
     rd_unique_info();

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -76,7 +76,7 @@ static bool wr_savefile_new(player_type *player_ptr, save_type type)
     wr_u16b(current_world_ptr->sf_lives);
     wr_u16b(current_world_ptr->sf_saves);
 
-    wr_u32b(0L);
+    wr_u32b(SAVEFILE_VERSION);
     wr_u16b(0);
     wr_byte(0);
 

--- a/src/spell/spells-util.h
+++ b/src/spell/spells-util.h
@@ -7,7 +7,7 @@
 
 enum spell_type { SPELL_NAME = 0, SPELL_DESC = 1, SPELL_INFO = 2, SPELL_CAST = 3, SPELL_FAIL = 4, SPELL_STOP = 5, SPELL_CONT = 6 };
 
-enum spell_operation : uint16_t {
+enum spell_operation {
     SPOP_NONE = 0x0000U,
     SPOP_DISPLAY_MES = 0x0001U, // !< スペル処理オプション … メッセージを表示する
     SPOP_NO_UPDATE = 0x0002U, // !< スペル処理オプション … ステータス更新を解決後行う

--- a/src/system/angband-version.h
+++ b/src/system/angband-version.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "system/h-type.h"
+
 #define VERSION_NAME "Hengband" /*!< バリアント名称 / Name of the version/variant */
 
 /*!
@@ -48,5 +50,8 @@
 #define H_VER_MINOR FAKE_VER_MINOR /*!< セーブファイル上のバージョン定義(マイナー番号) */
 #define H_VER_PATCH FAKE_VER_PATCH /*!< セーブファイル上のバージョン定義(パッチ番号) */
 #define H_VER_EXTRA FAKE_VER_EXTRA /*!< セーブファイル上のバージョン定義(エクストラ番号) */
+
+/** セーブファイルのバージョン */
+constexpr u32b SAVEFILE_VERSION = 1;
 
 void put_version(char *buf);


### PR DESCRIPTION
セーブファイルのバージョンを本体のバージョンと分離する。
今後はセーブファイルの仕様を更新する時は、
SAVEFILE_VERSIONをインクリメントし、
loading_savefile_version_older_than関数を使用して
通常の読み込み処理と古いセーブファイルの読み込み処理の
分岐を行う。

この仕様で、flag_group導入によるセーブファイルの仕様変更に対応出来ていることを手元で確認しています。
マージされたら、flag_groupのPRもこの方式のものに切り替えます。