### PR TITLE
[Feature] 知識情報配列のロードの改修

### DIFF
--- a/src/load/item-loader.cpp
+++ b/src/load/item-loader.cpp
@@ -272,18 +272,24 @@ void rd_item(player_type *player_ptr, object_type *o_ptr)
     }
 }
 
+/*!
+ * @brief アイテムオブジェクトの鑑定情報をロードする
+ * @return 成功なら0
+ */
 errr load_item(void)
 {
-    u16b tmp16u;
-    rd_u16b(&tmp16u);
-    if (tmp16u > max_k_idx) {
-        load_note(format(_("アイテムの種類が多すぎる(%u)！", "Too many (%u) object kinds!"), tmp16u));
-        return 22;
-    }
+    u16b loading_max_k_idx;
+    rd_u16b(&loading_max_k_idx);
 
+    object_kind *k_ptr;
+    object_kind dummy;
     byte tmp8u;
-    for (int i = 0; i < tmp16u; i++) {
-        object_kind *k_ptr = &k_info[i];
+    for (int i = 0; i < loading_max_k_idx; i++) {
+        if (i < max_k_idx)
+            k_ptr = &k_info[i];
+        else
+            k_ptr = &dummy;
+
         rd_byte(&tmp8u);
         k_ptr->aware = (tmp8u & 0x01) ? TRUE : FALSE;
         k_ptr->tried = (tmp8u & 0x02) ? TRUE : FALSE;
@@ -295,18 +301,24 @@ errr load_item(void)
     return 0;
 }
 
+/*!
+ * @brief 固定アーティファクトの出現情報をロードする
+ * @return 成功なら0
+ */
 errr load_artifact(void)
 {
-    u16b tmp16u;
-    rd_u16b(&tmp16u);
-    if (tmp16u > max_a_idx) {
-        load_note(format(_("伝説のアイテムが多すぎる(%u)！", "Too many (%u) artifacts!"), tmp16u));
-        return 24;
-    }
+    u16b loading_max_a_idx;
+    rd_u16b(&loading_max_a_idx);
 
+    artifact_type *a_ptr;
+    artifact_type dummy;
     byte tmp8u;
-    for (int i = 0; i < tmp16u; i++) {
-        artifact_type *a_ptr = &a_info[i];
+    for (int i = 0; i < loading_max_a_idx; i++) {
+        if (i < max_a_idx)
+            a_ptr = &a_info[i];
+        else
+            a_ptr = &dummy;
+
         rd_byte(&tmp8u);
         a_ptr->cur_num = tmp8u;
         if (h_older_than(1, 5, 0, 0)) {

--- a/src/load/lore-loader.cpp
+++ b/src/load/lore-loader.cpp
@@ -7,13 +7,12 @@
 
 /*!
  * @brief モンスターの思い出を読み込む / Read the monster lore
- * @param r_idx 読み込み先モンスターID
+ * @param r_ptr 読み込み先モンスター種族情報へのポインタ
+ * @param r_idx 読み込み先モンスターID(種族特定用)
  * @return なし
  */
-void rd_lore(MONRACE_IDX r_idx)
+void rd_lore(monster_race *r_ptr, MONRACE_IDX r_idx)
 {
-    monster_race *r_ptr = &r_info[r_idx];
-
     s16b tmp16s;
     rd_s16b(&tmp16s);
     r_ptr->r_sights = (MONSTER_NUMBER)tmp16s;
@@ -81,15 +80,19 @@ void rd_lore(MONRACE_IDX r_idx)
 
 errr load_lore(void)
 {
-    u16b tmp16u;
-    rd_u16b(&tmp16u);
-    if (tmp16u > max_r_idx) {
-        load_note(format(_("モンスターの種族が多すぎる(%u)！", "Too many (%u) monster races!"), tmp16u));
-        return 21;
-    }
+    u16b loading_max_r_idx;
+    rd_u16b(&loading_max_r_idx);
 
-    for (int i = 0; i < tmp16u; i++)
-        rd_lore((MONRACE_IDX)i);
+    monster_race *r_ptr;
+    monster_race dummy;
+    for (int i = 0; i < loading_max_r_idx; i++) {
+        if (i < max_r_idx)
+            r_ptr = &r_info[i];
+        else
+            r_ptr = &dummy;
+
+        rd_lore(r_ptr, (MONRACE_IDX)i);
+    }
 
     if (arg_fiddle)
         load_note(_("モンスターの思い出をロードしました", "Loaded Monster Memory"));


### PR DESCRIPTION
追加モンスター種族やアイテムがある状況でセーブして、ないバージョン
のブランチ等に移動したとき、配列が多すぎてロードできないのを改善。