### PR TITLE
[Feature/Fix] 地獄、時間、水属性の追加実装と不具合の修正 #473 #474 #476

### DIFF
--- a/src/flavor/flag-inscriptions-table.cpp
+++ b/src/flavor/flag-inscriptions-table.cpp
@@ -15,116 +15,150 @@ const concptr game_inscriptions[MAX_GAME_INSCRIPTIONS] = {
     _("特別製", "special"), /* FEEL_SPECIAL */
 };
 
+// clang-format off
 #ifdef JP
 /*! オブジェクトの特性表示記号テーブルの定義(pval要素) */
-flag_insc_table flag_insc_plus[MAX_INSCRIPTIONS_PLUS]
-    = { { "攻", "At", TR_BLOWS, -1 }, { "速", "Sp", TR_SPEED, -1 }, { "腕", "St", TR_STR, -1 }, { "知", "In", TR_INT, -1 },
-    { "賢", "Wi", TR_WIS, -1 }, { "器", "Dx", TR_DEX, -1 }, { "耐", "Cn", TR_CON, -1 }, { "魅", "Ch", TR_CHR, -1 }, { "道", "Md", TR_MAGIC_MASTERY, -1 },
-    { "隠", "Sl", TR_STEALTH, -1 }, { "探", "Sr", TR_SEARCH, -1 }, { "赤", "If", TR_INFRA, -1 }, { "掘", "Dg", TR_TUNNEL, -1 }, { NULL, NULL, 0, -1 } };
+std::vector<flag_insc_table> flag_insc_plus = {
+    { "攻", "At", TR_BLOWS, -1 }, { "速", "Sp", TR_SPEED, -1 },
+    { "腕", "St", TR_STR, -1 }, { "知", "In", TR_INT, -1 }, { "賢", "Wi", TR_WIS, -1 },
+    { "器", "Dx", TR_DEX, -1 }, { "耐", "Cn", TR_CON, -1 }, { "魅", "Ch", TR_CHR, -1 }, { "道", "Md", TR_MAGIC_MASTERY, -1 },
+    { "隠", "Sl", TR_STEALTH, -1 }, { "探", "Sr", TR_SEARCH, -1 }, { "赤", "If", TR_INFRA, -1 }, { "掘", "Dg", TR_TUNNEL, -1 },
+};
 
 /*! オブジェクトの特性表示記号テーブルの定義(免疫) */
-flag_insc_table flag_insc_immune[MAX_INSCRIPTIONS_IMMUNE]
-    = { { "酸", "Ac", TR_IM_ACID, -1 }, { "電", "El", TR_IM_ELEC, -1 }, { "火", "Fi", TR_IM_FIRE, -1 }, { "冷", "Co", TR_IM_COLD, -1 }, { NULL, NULL, 0, -1 } };
+std::vector<flag_insc_table> flag_insc_immune = {
+    { "酸", "Ac", TR_IM_ACID, -1 }, { "電", "El", TR_IM_ELEC, -1 }, { "火", "Fi", TR_IM_FIRE, -1 }, { "冷", "Co", TR_IM_COLD, -1 },
+};
 
 /*! オブジェクトの特性表示記号テーブルの定義(耐性) */
-flag_insc_table flag_insc_resistance[MAX_INSCRIPTIONS_RESISTANCE] = { { "酸", "Ac", TR_RES_ACID, TR_IM_ACID }, { "電", "El", TR_RES_ELEC, TR_IM_ELEC },
-    { "火", "Fi", TR_RES_FIRE, TR_IM_FIRE }, { "冷", "Co", TR_RES_COLD, TR_IM_COLD }, { "毒", "Po", TR_RES_POIS, -1 }, { "閃", "Li", TR_RES_LITE, -1 },
-    { "暗", "Dk", TR_RES_DARK, -1 }, { "破", "Sh", TR_RES_SHARDS, -1 }, { "盲", "Bl", TR_RES_BLIND, -1 }, { "乱", "Cf", TR_RES_CONF, -1 },
-    { "轟", "So", TR_RES_SOUND, -1 }, { "獄", "Nt", TR_RES_NETHER, -1 }, { "因", "Nx", TR_RES_NEXUS, -1 }, { "沌", "Ca", TR_RES_CHAOS, -1 },
-    { "劣", "Di", TR_RES_DISEN, -1 }, { "恐", "Fe", TR_RES_FEAR, -1 }, { NULL, NULL, 0, -1 } };
+std::vector<flag_insc_table> flag_insc_resistance = {
+    { "酸", "Ac", TR_RES_ACID, TR_IM_ACID }, { "電", "El", TR_RES_ELEC, TR_IM_ELEC }, { "火", "Fi", TR_RES_FIRE, TR_IM_FIRE }, { "冷", "Co", TR_RES_COLD, TR_IM_COLD },
+    { "毒", "Po", TR_RES_POIS, -1 }, { "閃", "Li", TR_RES_LITE, -1 }, { "暗", "Dk", TR_RES_DARK, -1 }, { "破", "Sh", TR_RES_SHARDS, -1 },
+    { "盲", "Bl", TR_RES_BLIND, -1 }, { "乱", "Cf", TR_RES_CONF, -1 }, { "轟", "So", TR_RES_SOUND, -1 }, { "獄", "Nt", TR_RES_NETHER, -1 },
+    { "因", "Nx", TR_RES_NEXUS, -1 }, { "沌", "Ca", TR_RES_CHAOS, -1 }, { "劣", "Di", TR_RES_DISEN, -1 }, { "恐", "Fe", TR_RES_FEAR, -1 },
+};
 
 /*! オブジェクトの特性表示記号テーブルの定義(その他特性) */
-flag_insc_table flag_insc_misc[MAX_INSCRIPTIONS_MISC] = { { "易", "Es", TR_EASY_SPELL, -1 }, { "減", "Dm", TR_DEC_MANA, -1 }, { "投", "Th", TR_THROW, -1 },
-    { "反", "Rf", TR_REFLECT, -1 }, { "麻", "Fa", TR_FREE_ACT, -1 }, { "視", "Si", TR_SEE_INVIS, -1 }, { "経", "Hl", TR_HOLD_EXP, -1 },
-    { "遅", "Sd", TR_SLOW_DIGEST, -1 }, { "活", "Rg", TR_REGEN, -1 }, { "浮", "Lv", TR_LEVITATION, -1 }, { "明", "Lu", TR_LITE_1, -1 },
-    { "明", "Lu", TR_LITE_2, -1 }, { "明", "Lu", TR_LITE_3, -1 }, { "闇", "Dl", TR_LITE_M1, -1 }, { "闇", "Dl", TR_LITE_M2, -1 },
-    { "闇", "Dl", TR_LITE_M3, -1 }, { "警", "Wr", TR_WARNING, -1 }, { "倍", "Xm", TR_XTRA_MIGHT, -1 }, { "射", "Xs", TR_XTRA_SHOTS, -1 },
-    { "瞬", "Te", TR_TELEPORT, -1 }, { "怒", "Ag", TR_AGGRAVATE, -1 }, { "祝", "Bs", TR_BLESSED, -1 }, { "忌", "Ty", TR_TY_CURSE, -1 },
-    { "呪", "C-", TR_ADD_L_CURSE, -1 }, { "詛", "C+", TR_ADD_H_CURSE, -1 }, { NULL, NULL, 0, -1 } };
+std::vector<flag_insc_table> flag_insc_misc = {
+    { "易", "Es", TR_EASY_SPELL, -1 }, { "減", "Dm", TR_DEC_MANA, -1 },
+    { "投", "Th", TR_THROW, -1 }, { "反", "Rf", TR_REFLECT, -1 }, { "麻", "Fa", TR_FREE_ACT, -1 }, { "視", "Si", TR_SEE_INVIS, -1 },
+    { "経", "Hl", TR_HOLD_EXP, -1 }, { "遅", "Sd", TR_SLOW_DIGEST, -1 }, { "活", "Rg", TR_REGEN, -1 }, { "浮", "Lv", TR_LEVITATION, -1 },
+    { "明", "Lu", TR_LITE_1, -1 }, { "明", "Lu", TR_LITE_2, -1 }, { "明", "Lu", TR_LITE_3, -1 }, { "闇", "Dl", TR_LITE_M1, -1 },
+    { "闇", "Dl", TR_LITE_M2, -1 }, { "闇", "Dl", TR_LITE_M3, -1 }, { "警", "Wr", TR_WARNING, -1 }, { "倍", "Xm", TR_XTRA_MIGHT, -1 },
+    { "射", "Xs", TR_XTRA_SHOTS, -1 }, { "瞬", "Te", TR_TELEPORT, -1 }, { "怒", "Ag", TR_AGGRAVATE, -1 }, { "祝", "Bs", TR_BLESSED, -1 },
+    { "忌", "Ty", TR_TY_CURSE, -1 }, { "呪", "C-", TR_ADD_L_CURSE, -1 }, { "詛", "C+", TR_ADD_H_CURSE, -1 },
+};
 
 /*! オブジェクトの特性表示記号テーブルの定義(オーラ) */
-flag_insc_table flag_insc_aura[MAX_INSCRIPTIONS_AURA] = { { "炎", "F", TR_SH_FIRE, -1 }, { "電", "E", TR_SH_ELEC, -1 }, { "冷", "C", TR_SH_COLD, -1 },
-    { "魔", "M", TR_NO_MAGIC, -1 }, { "瞬", "T", TR_NO_TELE, -1 }, { NULL, NULL, 0, -1 } };
+std::vector<flag_insc_table> flag_insc_aura = {
+    { "炎", "F", TR_SH_FIRE, -1 }, { "電", "E", TR_SH_ELEC, -1 }, { "冷", "C", TR_SH_COLD, -1 },
+    { "魔", "M", TR_NO_MAGIC, -1 }, { "瞬", "T", TR_NO_TELE, -1 },
+};
 
 /*! オブジェクトの特性表示記号テーブルの定義(属性スレイ) */
-flag_insc_table flag_insc_brand[MAX_INSCRIPTIONS_BRAND] = { { "酸", "A", TR_BRAND_ACID, -1 }, { "電", "E", TR_BRAND_ELEC, -1 },
-    { "焼", "F", TR_BRAND_FIRE, -1 },
-    { "凍", "Co", TR_BRAND_COLD, -1 }, { "毒", "P", TR_BRAND_POIS, -1 }, { "沌", "Ca", TR_CHAOTIC, -1 }, { "吸", "V", TR_VAMPIRIC, -1 },
-    { "震", "Q", TR_IMPACT, -1 }, { "切", "S", TR_VORPAL, -1 }, { "理", "M", TR_FORCE_WEAPON, -1 }, { NULL, NULL, 0, -1 } };
+std::vector<flag_insc_table> flag_insc_brand = {
+    { "酸", "A", TR_BRAND_ACID, -1 }, { "電", "E", TR_BRAND_ELEC, -1 }, { "焼", "F", TR_BRAND_FIRE, -1 }, { "凍", "Co", TR_BRAND_COLD, -1 },
+    { "毒", "P", TR_BRAND_POIS, -1 }, { "沌", "Ca", TR_CHAOTIC, -1 },
+    { "吸", "V", TR_VAMPIRIC, -1 }, { "震", "Q", TR_IMPACT, -1 }, { "切", "S", TR_VORPAL, -1 }, { "理", "M", TR_FORCE_WEAPON, -1 }
+};
 
 /*! オブジェクトの特性表示記号テーブルの定義(種族スレイ) */
-flag_insc_table flag_insc_kill[MAX_INSCRIPTIONS_KILL] = { { "邪", "*", TR_KILL_EVIL, -1 }, { "人", "p", TR_KILL_HUMAN, -1 }, { "龍", "D", TR_KILL_DRAGON, -1 },
-    { "オ", "o", TR_KILL_ORC, -1 }, { "ト", "T", TR_KILL_TROLL, -1 }, { "巨", "P", TR_KILL_GIANT, -1 }, { "デ", "U", TR_KILL_DEMON, -1 },
-    { "死", "L", TR_KILL_UNDEAD, -1 }, { "動", "Z", TR_KILL_ANIMAL, -1 }, { NULL, NULL, 0, -1 } };
+std::vector<flag_insc_table> flag_insc_kill = {
+    { "邪", "*", TR_KILL_EVIL, -1 }, { "人", "p", TR_KILL_HUMAN, -1 }, { "龍", "D", TR_KILL_DRAGON, -1 }, { "オ", "o", TR_KILL_ORC, -1 },
+    { "ト", "T", TR_KILL_TROLL, -1 }, { "巨", "P", TR_KILL_GIANT, -1 }, { "デ", "U", TR_KILL_DEMON, -1 }, { "死", "L", TR_KILL_UNDEAD, -1 },
+    { "動", "Z", TR_KILL_ANIMAL, -1 },
+};
 
 /*! オブジェクトの特性表示記号テーブルの定義(種族*スレイ*) */
-flag_insc_table flag_insc_slay[MAX_INSCRIPTIONS_SLAY] = { { "邪", "*", TR_SLAY_EVIL, TR_KILL_EVIL }, { "人", "p", TR_SLAY_HUMAN, TR_KILL_HUMAN },
-    { "竜", "D", TR_SLAY_DRAGON, TR_KILL_DRAGON }, { "オ", "o", TR_SLAY_ORC, TR_KILL_ORC }, { "ト", "T", TR_SLAY_TROLL, TR_KILL_TROLL },
-    { "巨", "P", TR_SLAY_GIANT, TR_KILL_GIANT }, { "デ", "U", TR_SLAY_DEMON, TR_KILL_DEMON }, { "死", "L", TR_SLAY_UNDEAD, TR_KILL_UNDEAD },
-    { "動", "Z", TR_SLAY_ANIMAL, TR_KILL_ANIMAL }, { NULL, NULL, 0, -1 } };
+std::vector<flag_insc_table> flag_insc_slay = {
+    { "邪", "*", TR_SLAY_EVIL, TR_KILL_EVIL }, { "人", "p", TR_SLAY_HUMAN, TR_KILL_HUMAN }, { "竜", "D", TR_SLAY_DRAGON, TR_KILL_DRAGON },
+    { "オ", "o", TR_SLAY_ORC, TR_KILL_ORC }, { "ト", "T", TR_SLAY_TROLL, TR_KILL_TROLL }, { "巨", "P", TR_SLAY_GIANT, TR_KILL_GIANT },
+    { "デ", "U", TR_SLAY_DEMON, TR_KILL_DEMON }, { "死", "L", TR_SLAY_UNDEAD, TR_KILL_UNDEAD }, { "動", "Z", TR_SLAY_ANIMAL, TR_KILL_ANIMAL },
+};
 
 /*! オブジェクトの特性表示記号テーブルの定義(ESP1) */
-flag_insc_table flag_insc_esp1[MAX_INSCRIPTIONS_ESP_1] = { { "感", "Tele", TR_TELEPATHY, -1 }, { "邪", "Evil", TR_ESP_EVIL, -1 },
-    { "善", "Good", TR_ESP_GOOD, -1 },
-    { "無", "Nolv", TR_ESP_NONLIVING, -1 }, { "個", "Uniq", TR_ESP_UNIQUE, -1 }, { NULL, NULL, 0, -1 } };
+std::vector<flag_insc_table> flag_insc_esp1 = {
+    { "感", "Tele", TR_TELEPATHY, -1 }, { "邪", "Evil", TR_ESP_EVIL, -1 }, { "善", "Good", TR_ESP_GOOD, -1 },
+    { "無", "Nolv", TR_ESP_NONLIVING, -1 }, { "個", "Uniq", TR_ESP_UNIQUE, -1 },
+};
 
 /*! オブジェクトの特性表示記号テーブルの定義(ESP2) */
-flag_insc_table flag_insc_esp2[MAX_INSCRIPTIONS_ESP_2] = { { "人", "p", TR_ESP_HUMAN, -1 }, { "竜", "D", TR_ESP_DRAGON, -1 }, { "オ", "o", TR_ESP_ORC, -1 },
-    { "ト", "T", TR_ESP_TROLL, -1 }, { "巨", "P", TR_ESP_GIANT, -1 }, { "デ", "U", TR_ESP_DEMON, -1 }, { "死", "L", TR_ESP_UNDEAD, -1 },
-    { "動", "Z", TR_ESP_ANIMAL, -1 }, { NULL, NULL, 0, -1 } };
+std::vector<flag_insc_table> flag_insc_esp2 = {
+    { "人", "p", TR_ESP_HUMAN, -1 }, { "竜", "D", TR_ESP_DRAGON, -1 }, { "オ", "o", TR_ESP_ORC, -1 }, { "ト", "T", TR_ESP_TROLL, -1 },
+    { "巨", "P", TR_ESP_GIANT, -1 }, { "デ", "U", TR_ESP_DEMON, -1 }, { "死", "L", TR_ESP_UNDEAD, -1 }, { "動", "Z", TR_ESP_ANIMAL, -1 },
+};
 
 /*! オブジェクトの特性表示記号テーブルの定義(能力維持) */
-flag_insc_table flag_insc_sust[MAX_INSCRIPTIONS_SUSTAINER] = { { "腕", "St", TR_SUST_STR, -1 }, { "知", "In", TR_SUST_INT, -1 },
-    { "賢", "Wi", TR_SUST_WIS, -1 },
-    { "器", "Dx", TR_SUST_DEX, -1 }, { "耐", "Cn", TR_SUST_CON, -1 }, { "魅", "Ch", TR_SUST_CHR, -1 }, { NULL, NULL, 0, -1 } };
+std::vector<flag_insc_table> flag_insc_sust = {
+    { "腕", "St", TR_SUST_STR, -1 }, { "知", "In", TR_SUST_INT, -1 }, { "賢", "Wi", TR_SUST_WIS, -1 },
+    { "器", "Dx", TR_SUST_DEX, -1 }, { "耐", "Cn", TR_SUST_CON, -1 }, { "魅", "Ch", TR_SUST_CHR, -1 },
+};
 
 #else
-flag_insc_table flag_insc_plus[MAX_INSCRIPTIONS_PLUS] = { { "At", TR_BLOWS, -1 }, { "Sp", TR_SPEED, -1 }, { "St", TR_STR, -1 }, { "In", TR_INT, -1 },
-    { "Wi", TR_WIS, -1 },
-    { "Dx", TR_DEX, -1 }, { "Cn", TR_CON, -1 }, { "Ch", TR_CHR, -1 }, { "Md", TR_MAGIC_MASTERY, -1 }, { "Sl", TR_STEALTH, -1 }, { "Sr", TR_SEARCH, -1 },
-    { "If", TR_INFRA, -1 }, { "Dg", TR_TUNNEL, -1 }, { NULL, 0, -1 } };
+std::vector<flag_insc_table> flag_insc_plus ={
+    { "At", TR_BLOWS, -1 }, { "Sp", TR_SPEED, -1 },
+    { "St", TR_STR, -1 }, { "In", TR_INT, -1 }, { "Wi", TR_WIS, -1 },
+    { "Dx", TR_DEX, -1 }, { "Cn", TR_CON, -1 }, { "Ch", TR_CHR, -1 }, { "Md", TR_MAGIC_MASTERY, -1 },
+    { "Sl", TR_STEALTH, -1 }, { "Sr", TR_SEARCH, -1 }, { "If", TR_INFRA, -1 }, { "Dg", TR_TUNNEL, -1 },
+};
 
-flag_insc_table flag_insc_immune[MAX_INSCRIPTIONS_IMMUNE]
-    = { { "Ac", TR_IM_ACID, -1 }, { "El", TR_IM_ELEC, -1 }, { "Fi", TR_IM_FIRE, -1 }, { "Co", TR_IM_COLD, -1 }, { NULL, 0, -1 } };
+std::vector<flag_insc_table> flag_insc_immune = {
+    { "Ac", TR_IM_ACID, -1 }, { "El", TR_IM_ELEC, -1 }, { "Fi", TR_IM_FIRE, -1 }, { "Co", TR_IM_COLD, -1 },
+};
 
-flag_insc_table flag_insc_resistance[MAX_INSCRIPTIONS_RESISTANCE] = { { "Ac", TR_RES_ACID, TR_IM_ACID }, { "El", TR_RES_ELEC, TR_IM_ELEC },
-    { "Fi", TR_RES_FIRE, TR_IM_FIRE },
-    { "Co", TR_RES_COLD, TR_IM_COLD }, { "Po", TR_RES_POIS, -1 }, { "Li", TR_RES_LITE, -1 }, { "Dk", TR_RES_DARK, -1 }, { "Sh", TR_RES_SHARDS, -1 },
-    { "Bl", TR_RES_BLIND, -1 }, { "Cf", TR_RES_CONF, -1 }, { "So", TR_RES_SOUND, -1 }, { "Nt", TR_RES_NETHER, -1 }, { "Nx", TR_RES_NEXUS, -1 },
-    { "Ca", TR_RES_CHAOS, -1 }, { "Di", TR_RES_DISEN, -1 }, { "Fe", TR_RES_FEAR, -1 }, { NULL, 0, -1 } };
+std::vector<flag_insc_table> flag_insc_resistance = {
+    { "Ac", TR_RES_ACID, TR_IM_ACID }, { "El", TR_RES_ELEC, TR_IM_ELEC }, { "Fi", TR_RES_FIRE, TR_IM_FIRE }, { "Co", TR_RES_COLD, TR_IM_COLD },
+    { "Po", TR_RES_POIS, -1 }, { "Li", TR_RES_LITE, -1 }, { "Dk", TR_RES_DARK, -1 }, { "Sh", TR_RES_SHARDS, -1 },
+     { "Bl", TR_RES_BLIND, -1 }, { "Cf", TR_RES_CONF, -1 }, { "So", TR_RES_SOUND, -1 }, { "Nt", TR_RES_NETHER, -1 },
+    { "Nx", TR_RES_NEXUS, -1 }, { "Ca", TR_RES_CHAOS, -1 }, { "Di", TR_RES_DISEN, -1 }, { "Fe", TR_RES_FEAR, -1 },
+};
 
-flag_insc_table flag_insc_misc[MAX_INSCRIPTIONS_MISC] = { { "Es", TR_EASY_SPELL, -1 }, { "Dm", TR_DEC_MANA, -1 }, { "Th", TR_THROW, -1 },
-    { "Rf", TR_REFLECT, -1 },
-    { "Fa", TR_FREE_ACT, -1 }, { "Si", TR_SEE_INVIS, -1 }, { "Hl", TR_HOLD_EXP, -1 }, { "Sd", TR_SLOW_DIGEST, -1 }, { "Rg", TR_REGEN, -1 },
-    { "Lv", TR_LEVITATION, -1 }, { "Lu", TR_LITE_1, -1 }, { "Lu", TR_LITE_2, -1 }, { "Lu", TR_LITE_3, -1 }, { "Dl", TR_LITE_M1, -1 }, { "Dl", TR_LITE_M2, -1 },
-    { "Dl", TR_LITE_M3, -1 }, { "Wr", TR_WARNING, -1 }, { "Xm", TR_XTRA_MIGHT, -1 }, { "Xs", TR_XTRA_SHOTS, -1 }, { "Te", TR_TELEPORT, -1 },
-    { "Ag", TR_AGGRAVATE, -1 }, { "Bs", TR_BLESSED, -1 }, { "Ty", TR_TY_CURSE, -1 }, { "C-", TR_ADD_L_CURSE, -1 }, { "C+", TR_ADD_H_CURSE, -1 },
-    { NULL, 0, -1 } };
+std::vector<flag_insc_table> flag_insc_misc = {
+    { "Es", TR_EASY_SPELL, -1 }, { "Dm", TR_DEC_MANA, -1 },
+    { "Th", TR_THROW, -1 }, { "Rf", TR_REFLECT, -1 }, { "Fa", TR_FREE_ACT, -1 }, { "Si", TR_SEE_INVIS, -1 },
+    { "Hl", TR_HOLD_EXP, -1 }, { "Sd", TR_SLOW_DIGEST, -1 }, { "Rg", TR_REGEN, -1 }, { "Lv", TR_LEVITATION, -1 },
+    { "Lu", TR_LITE_1, -1 }, { "Lu", TR_LITE_2, -1 }, { "Lu", TR_LITE_3, -1 }, { "Dl", TR_LITE_M1, -1 },
+    { "Dl", TR_LITE_M2, -1 }, { "Dl", TR_LITE_M3, -1 }, { "Wr", TR_WARNING, -1 }, { "Xm", TR_XTRA_MIGHT, -1 },
+    { "Xs", TR_XTRA_SHOTS, -1 }, { "Te", TR_TELEPORT, -1 }, { "Ag", TR_AGGRAVATE, -1 }, { "Bs", TR_BLESSED, -1 },
+    { "Ty", TR_TY_CURSE, -1 }, { "C-", TR_ADD_L_CURSE, -1 }, { "C+", TR_ADD_H_CURSE, -1 },
+};
 
-flag_insc_table flag_insc_aura[MAX_INSCRIPTIONS_AURA]
-    = { { "F", TR_SH_FIRE, -1 }, { "E", TR_SH_ELEC, -1 }, { "C", TR_SH_COLD, -1 }, { "M", TR_NO_MAGIC, -1 }, { "T", TR_NO_TELE, -1 }, { NULL, 0, -1 } };
+std::vector<flag_insc_table> flag_insc_aura = {
+    { "F", TR_SH_FIRE, -1 }, { "E", TR_SH_ELEC, -1 }, { "C", TR_SH_COLD, -1 },
+    { "M", TR_NO_MAGIC, -1 }, { "T", TR_NO_TELE, -1 },
+};
 
-flag_insc_table flag_insc_brand[MAX_INSCRIPTIONS_BRAND]
-    = { { "A", TR_BRAND_ACID, -1 }, { "E", TR_BRAND_ELEC, -1 }, { "F", TR_BRAND_FIRE, -1 }, { "Co", TR_BRAND_COLD, -1 }, { "P", TR_BRAND_POIS, -1 },
-          { "Ca", TR_CHAOTIC, -1 }, { "V", TR_VAMPIRIC, -1 }, { "Q", TR_IMPACT, -1 }, { "S", TR_VORPAL, -1 }, { "M", TR_FORCE_WEAPON, -1 }, { NULL, 0, -1 } };
+std::vector<flag_insc_table> flag_insc_brand = {
+    { "A", TR_BRAND_ACID, -1 }, { "E", TR_BRAND_ELEC, -1 }, { "F", TR_BRAND_FIRE, -1 }, { "Co", TR_BRAND_COLD, -1 },
+    { "P", TR_BRAND_POIS, -1 }, { "Ca", TR_CHAOTIC, -1 },
+    { "V", TR_VAMPIRIC, -1 }, { "Q", TR_IMPACT, -1 }, { "S", TR_VORPAL, -1 }, { "M", TR_FORCE_WEAPON, -1 },
+};
 
-flag_insc_table flag_insc_kill[MAX_INSCRIPTIONS_KILL]
-    = { { "*", TR_KILL_EVIL, -1 }, { "p", TR_KILL_HUMAN, -1 }, { "D", TR_KILL_DRAGON, -1 }, { "o", TR_KILL_ORC, -1 }, { "T", TR_KILL_TROLL, -1 },
-          { "P", TR_KILL_GIANT, -1 }, { "U", TR_KILL_DEMON, -1 }, { "L", TR_KILL_UNDEAD, -1 }, { "Z", TR_KILL_ANIMAL, -1 }, { NULL, 0, -1 } };
+std::vector<flag_insc_table> flag_insc_kill = {
+    { "*", TR_KILL_EVIL, -1 }, { "p", TR_KILL_HUMAN, -1 }, { "D", TR_KILL_DRAGON, -1 }, { "o", TR_KILL_ORC, -1 },
+    { "T", TR_KILL_TROLL, -1 }, { "P", TR_KILL_GIANT, -1 }, { "U", TR_KILL_DEMON, -1 }, { "L", TR_KILL_UNDEAD, -1 },
+    { "Z", TR_KILL_ANIMAL, -1 },
+};
 
-flag_insc_table flag_insc_slay[MAX_INSCRIPTIONS_SLAY] = { { "*", TR_SLAY_EVIL, TR_KILL_EVIL }, { "p", TR_SLAY_HUMAN, TR_KILL_HUMAN },
-    { "D", TR_SLAY_DRAGON, TR_KILL_DRAGON },
-    { "o", TR_SLAY_ORC, TR_KILL_ORC }, { "T", TR_SLAY_TROLL, TR_KILL_TROLL }, { "P", TR_SLAY_GIANT, TR_KILL_GIANT }, { "U", TR_SLAY_DEMON, TR_KILL_DEMON },
-    { "L", TR_SLAY_UNDEAD, TR_KILL_UNDEAD }, { "Z", TR_SLAY_ANIMAL, TR_KILL_ANIMAL }, { NULL, 0, -1 } };
+std::vector<flag_insc_table> flag_insc_slay = {
+    { "*", TR_SLAY_EVIL, TR_KILL_EVIL }, { "p", TR_SLAY_HUMAN, TR_KILL_HUMAN }, { "D", TR_SLAY_DRAGON, TR_KILL_DRAGON }, { "o", TR_SLAY_ORC, TR_KILL_ORC },
+    { "T", TR_SLAY_TROLL, TR_KILL_TROLL }, { "P", TR_SLAY_GIANT, TR_KILL_GIANT }, { "U", TR_SLAY_DEMON, TR_KILL_DEMON }, { "L", TR_SLAY_UNDEAD, TR_KILL_UNDEAD },
+    { "Z", TR_SLAY_ANIMAL, TR_KILL_ANIMAL },
+};
 
-flag_insc_table flag_insc_esp1[MAX_INSCRIPTIONS_ESP_1] = { { "Tele", TR_TELEPATHY, -1 }, { "Evil", TR_ESP_EVIL, -1 }, { "Good", TR_ESP_GOOD, -1 },
-    { "Nolv", TR_ESP_NONLIVING, -1 }, { "Uniq", TR_ESP_UNIQUE, -1 }, { NULL, 0, -1 } };
+std::vector<flag_insc_table> flag_insc_esp1 = {
+    { "Tele", TR_TELEPATHY, -1 }, { "Evil", TR_ESP_EVIL, -1 }, { "Good", TR_ESP_GOOD, -1 }, { "Nolv", TR_ESP_NONLIVING, -1 },
+    { "Uniq", TR_ESP_UNIQUE, -1 },
+};
 
-flag_insc_table flag_insc_esp2[MAX_INSCRIPTIONS_ESP_2] = { { "p", TR_ESP_HUMAN, -1 }, { "D", TR_ESP_DRAGON, -1 }, { "o", TR_ESP_ORC, -1 },
-    { "T", TR_ESP_TROLL, -1 },
-    { "P", TR_ESP_GIANT, -1 }, { "U", TR_ESP_DEMON, -1 }, { "L", TR_ESP_UNDEAD, -1 }, { "Z", TR_ESP_ANIMAL, -1 }, { NULL, 0, -1 } };
+std::vector<flag_insc_table> flag_insc_esp2 = {
+    { "p", TR_ESP_HUMAN, -1 }, { "D", TR_ESP_DRAGON, -1 }, { "o", TR_ESP_ORC, -1 }, { "T", TR_ESP_TROLL, -1 },
+    { "P", TR_ESP_GIANT, -1 }, { "U", TR_ESP_DEMON, -1 }, { "L", TR_ESP_UNDEAD, -1 }, { "Z", TR_ESP_ANIMAL, -1 },
+};
 
-flag_insc_table flag_insc_sust[MAX_INSCRIPTIONS_SUSTAINER] = { { "St", TR_SUST_STR, -1 }, { "In", TR_SUST_INT, -1 }, { "Wi", TR_SUST_WIS, -1 },
-    { "Dx", TR_SUST_DEX, -1 },
-    { "Cn", TR_SUST_CON, -1 }, { "Ch", TR_SUST_CHR, -1 }, { NULL, 0, -1 } };
+std::vector<flag_insc_table> flag_insc_sust = {
+    { "St", TR_SUST_STR, -1 }, { "In", TR_SUST_INT, -1 }, { "Wi", TR_SUST_WIS, -1 },
+    { "Dx", TR_SUST_DEX, -1 }, { "Cn", TR_SUST_CON, -1 }, { "Ch", TR_SUST_CHR, -1 },
+};
 #endif
+// clang format on

--- a/src/flavor/flag-inscriptions-table.cpp
+++ b/src/flavor/flag-inscriptions-table.cpp
@@ -35,7 +35,8 @@ std::vector<flag_insc_table> flag_insc_resistance = {
     { "酸", "Ac", TR_RES_ACID, TR_IM_ACID }, { "電", "El", TR_RES_ELEC, TR_IM_ELEC }, { "火", "Fi", TR_RES_FIRE, TR_IM_FIRE }, { "冷", "Co", TR_RES_COLD, TR_IM_COLD },
     { "毒", "Po", TR_RES_POIS, -1 }, { "閃", "Li", TR_RES_LITE, -1 }, { "暗", "Dk", TR_RES_DARK, -1 }, { "破", "Sh", TR_RES_SHARDS, -1 },
     { "盲", "Bl", TR_RES_BLIND, -1 }, { "乱", "Cf", TR_RES_CONF, -1 }, { "轟", "So", TR_RES_SOUND, -1 }, { "獄", "Nt", TR_RES_NETHER, -1 },
-    { "因", "Nx", TR_RES_NEXUS, -1 }, { "沌", "Ca", TR_RES_CHAOS, -1 }, { "劣", "Di", TR_RES_DISEN, -1 }, { "恐", "Fe", TR_RES_FEAR, -1 },
+    { "因", "Nx", TR_RES_NEXUS, -1 }, { "沌", "Ca", TR_RES_CHAOS, -1 }, { "劣", "Di", TR_RES_DISEN, -1 }, { "時", "Tm", TR_RES_TIME, -1 },
+    { "水", "Wt", TR_RES_WATER, -1 }, { "恐", "Fe", TR_RES_FEAR, -1 },
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(その他特性) */
@@ -110,7 +111,8 @@ std::vector<flag_insc_table> flag_insc_resistance = {
     { "Ac", TR_RES_ACID, TR_IM_ACID }, { "El", TR_RES_ELEC, TR_IM_ELEC }, { "Fi", TR_RES_FIRE, TR_IM_FIRE }, { "Co", TR_RES_COLD, TR_IM_COLD },
     { "Po", TR_RES_POIS, -1 }, { "Li", TR_RES_LITE, -1 }, { "Dk", TR_RES_DARK, -1 }, { "Sh", TR_RES_SHARDS, -1 },
      { "Bl", TR_RES_BLIND, -1 }, { "Cf", TR_RES_CONF, -1 }, { "So", TR_RES_SOUND, -1 }, { "Nt", TR_RES_NETHER, -1 },
-    { "Nx", TR_RES_NEXUS, -1 }, { "Ca", TR_RES_CHAOS, -1 }, { "Di", TR_RES_DISEN, -1 }, { "Fe", TR_RES_FEAR, -1 },
+    { "Nx", TR_RES_NEXUS, -1 }, { "Ca", TR_RES_CHAOS, -1 }, { "Di", TR_RES_DISEN, -1 }, { "Tm", TR_RES_TIME, -1 },
+    { "Wt", TR_RES_WATER, -1 }, { "Fe", TR_RES_FEAR, -1 },
 };
 
 std::vector<flag_insc_table> flag_insc_misc = {

--- a/src/flavor/flag-inscriptions-table.h
+++ b/src/flavor/flag-inscriptions-table.h
@@ -1,20 +1,9 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include <vector>
 
 #define MAX_GAME_INSCRIPTIONS 10
-
-#define MAX_INSCRIPTIONS_PLUS 14
-#define MAX_INSCRIPTIONS_IMMUNE 5
-#define MAX_INSCRIPTIONS_RESISTANCE 17
-#define MAX_INSCRIPTIONS_MISC 26
-#define MAX_INSCRIPTIONS_AURA 6
-#define MAX_INSCRIPTIONS_BRAND 11
-#define MAX_INSCRIPTIONS_KILL 10
-#define MAX_INSCRIPTIONS_SLAY 10
-#define MAX_INSCRIPTIONS_ESP_1 6
-#define MAX_INSCRIPTIONS_ESP_2 9
-#define MAX_INSCRIPTIONS_SUSTAINER 7
 
 /*! オブジェクトの特性表示記号テーブルの構造体 / Structs and tables for Auto Inscription for flags */
 typedef struct flag_insc_table {
@@ -28,14 +17,14 @@ typedef struct flag_insc_table {
 
 extern const concptr game_inscriptions[MAX_GAME_INSCRIPTIONS];
 
-extern flag_insc_table flag_insc_plus[MAX_INSCRIPTIONS_PLUS];
-extern flag_insc_table flag_insc_immune[MAX_INSCRIPTIONS_IMMUNE];
-extern flag_insc_table flag_insc_resistance[MAX_INSCRIPTIONS_RESISTANCE];
-extern flag_insc_table flag_insc_misc[MAX_INSCRIPTIONS_MISC];
-extern flag_insc_table flag_insc_aura[MAX_INSCRIPTIONS_AURA];
-extern flag_insc_table flag_insc_brand[MAX_INSCRIPTIONS_BRAND];
-extern flag_insc_table flag_insc_kill[MAX_INSCRIPTIONS_KILL];
-extern flag_insc_table flag_insc_slay[MAX_INSCRIPTIONS_SLAY];
-extern flag_insc_table flag_insc_esp1[MAX_INSCRIPTIONS_ESP_1];
-extern flag_insc_table flag_insc_esp2[MAX_INSCRIPTIONS_ESP_2];
-extern flag_insc_table flag_insc_sust[MAX_INSCRIPTIONS_SUSTAINER];
+extern std::vector<flag_insc_table>flag_insc_plus;
+extern std::vector<flag_insc_table>flag_insc_immune;
+extern std::vector<flag_insc_table>flag_insc_resistance;
+extern std::vector<flag_insc_table>flag_insc_misc;
+extern std::vector<flag_insc_table>flag_insc_aura;
+extern std::vector<flag_insc_table>flag_insc_brand;
+extern std::vector<flag_insc_table>flag_insc_kill;
+extern std::vector<flag_insc_table>flag_insc_slay;
+extern std::vector<flag_insc_table>flag_insc_esp1;
+extern std::vector<flag_insc_table>flag_insc_esp2;
+extern std::vector<flag_insc_table>flag_insc_sust;

--- a/src/flavor/flavor-util.cpp
+++ b/src/flavor/flavor-util.cpp
@@ -141,7 +141,7 @@ static void add_inscription(char **short_flavor, concptr str) { *short_flavor = 
 
 /*!
  * @brief get_inscriptionのサブセットとしてオブジェクトの特性フラグを返す / Helper function for get_inscription()
- * @param fi_ptr 参照する特性表示記号テーブル
+ * @param fi_vec 参照する特性表示記号テーブル
  * @param flgs 対応するオブジェクトのフラグ文字列
  * @param kanji TRUEならば漢字記述/FALSEならば英語記述
  * @param ptr フラグ群を保管する文字列参照ポインタ
@@ -151,19 +151,16 @@ static void add_inscription(char **short_flavor, concptr str) { *short_flavor = 
  * sprintf(t, "%+d", n), and return a pointer to the terminator.
  * Note that we always print a sign, either "+" or "-".
  */
-static char *inscribe_flags_aux(flag_insc_table *fi_ptr, BIT_FLAGS flgs[TR_FLAG_SIZE], bool kanji, char *ptr)
+static char *inscribe_flags_aux(std::vector<flag_insc_table>& fi_vec, BIT_FLAGS flgs[TR_FLAG_SIZE], bool kanji, char *ptr)
 {
 #ifdef JP
 #else
     (void)kanji;
 #endif
 
-    while (fi_ptr->english) {
-        if (has_flag(flgs, fi_ptr->flag) && (fi_ptr->except_flag == -1 || !has_flag(flgs, fi_ptr->except_flag)))
-            add_inscription(&ptr, _(kanji ? fi_ptr->japanese : fi_ptr->english, fi_ptr->english));
-
-        fi_ptr++;
-    }
+    for (flag_insc_table &fi : fi_vec)
+        if (has_flag(flgs, fi.flag) && (fi.except_flag == -1 || !has_flag(flgs, fi.except_flag)))
+            add_inscription(&ptr, _(kanji ? fi.japanese : fi.english, fi.english));
 
     return ptr;
 }
@@ -171,18 +168,15 @@ static char *inscribe_flags_aux(flag_insc_table *fi_ptr, BIT_FLAGS flgs[TR_FLAG_
 /*!
  * @brief オブジェクトの特性表示記号テーブル1つに従いオブジェクトの特性フラグ配列に1つでも該当の特性があるかを返す / Special variation of has_flag for
  * auto-inscription
- * @param fi_ptr 参照する特性表示記号テーブル
+ * @param fi_vec 参照する特性表示記号テーブル
  * @param flgs 対応するオブジェクトのフラグ文字列
  * @return 1つでも該当の特性があったらTRUEを返す。
  */
-static bool has_flag_of(flag_insc_table *fi_ptr, BIT_FLAGS flgs[TR_FLAG_SIZE])
+static bool has_flag_of(std::vector<flag_insc_table>& fi_vec, BIT_FLAGS flgs[TR_FLAG_SIZE])
 {
-    while (fi_ptr->english) {
-        if (has_flag(flgs, fi_ptr->flag) && (fi_ptr->except_flag == -1 || !has_flag(flgs, fi_ptr->except_flag)))
+    for (flag_insc_table &fi : fi_vec)
+        if (has_flag(flgs, fi.flag) && (fi.except_flag == -1 || !has_flag(flgs, fi.except_flag)))
             return TRUE;
-
-        fi_ptr++;
-    }
 
     return FALSE;
 }

--- a/src/object-enchant/object-boost.cpp
+++ b/src/object-enchant/object-boost.cpp
@@ -508,7 +508,7 @@ void one_activation(object_type *o_ptr)
  */
 void one_lordly_high_resistance(object_type *o_ptr)
 {
-    switch (randint0(10)) {
+    switch (randint0(12)) {
     case 0:
         add_flag(o_ptr->art_flags, TR_RES_LITE);
         break;
@@ -538,6 +538,12 @@ void one_lordly_high_resistance(object_type *o_ptr)
         break;
     case 9:
         add_flag(o_ptr->art_flags, TR_RES_FEAR);
+        break;
+    case 10:
+        add_flag(o_ptr->art_flags, TR_RES_TIME);
+        break;
+    case 11:
+        add_flag(o_ptr->art_flags, TR_RES_WATER);
         break;
     }
 }

--- a/src/object/object-value-calc.cpp
+++ b/src/object/object-value-calc.cpp
@@ -290,6 +290,14 @@ PRICE flag_cost(player_type *player_ptr, object_type *o_ptr, int plusses)
         tmp_cost += 2000;
         count += 2;
     }
+    if (has_flag(flgs, TR_RES_TIME)) {
+        tmp_cost += 2000;
+        count += 2;
+    }
+    if (has_flag(flgs, TR_RES_WATER)) {
+        tmp_cost += 2000;
+        count += 2;
+    }
     total += (tmp_cost * count);
 
     if (has_flag(flgs, TR_SH_FIRE))

--- a/src/perception/identification.cpp
+++ b/src/perception/identification.cpp
@@ -442,6 +442,14 @@ bool screen_object(player_type *player_ptr, object_type *o_ptr, BIT_FLAGS mode)
         info[i++] = _("それはカオスへの耐性を授ける。", "It provides resistance to chaos.");
     }
 
+    if (has_flag(flgs, TR_RES_TIME)) {
+        info[i++] = _("それは時間逆転への耐性を授ける。", "It provides resistance to time stream.");
+    }
+
+    if (has_flag(flgs, TR_RES_WATER)) {
+        info[i++] = _("それは水流への耐性を授ける。", "It provides resistance to water stream.");
+    }
+
     if (has_flag(flgs, TR_RES_DISEN)) {
         info[i++] = _("それは劣化への耐性を授ける。", "It provides resistance to disenchantment.");
     }

--- a/src/player/permanent-resistances.cpp
+++ b/src/player/permanent-resistances.cpp
@@ -412,6 +412,10 @@ static void add_race_flags(player_type *creature_ptr, BIT_FLAGS *flags)
         add_flag(flags, TR_HOLD_EXP);
         break;
     }
+    case RACE_MERFOLK: {
+        add_flag(flags, TR_RES_WATER);
+        break;
+    }
     default:
         break;
     }

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -265,6 +265,10 @@ BIT_FLAGS get_player_flags(player_type *creature_ptr, tr_type tr_flag)
         return has_resist_chaos(creature_ptr);
     case TR_RES_DISEN:
         return has_resist_disen(creature_ptr);
+    case TR_RES_TIME:
+        return has_resist_time(creature_ptr);
+    case TR_RES_WATER:
+        return has_resist_water(creature_ptr);
 
     case TR_SH_FIRE:
         return has_sh_fire(creature_ptr);
@@ -385,10 +389,6 @@ BIT_FLAGS get_player_flags(player_type *creature_ptr, tr_type tr_flag)
         return has_no_ac(creature_ptr);
     case TR_HEAVY_SPELL:
         return has_heavy_spell(creature_ptr);
-    case TR_RES_TIME:
-        return has_resist_time(creature_ptr);
-    case TR_RES_WATER:
-        return has_resist_water(creature_ptr);
     case TR_INVULN_ARROW:
         return has_invuln_arrow(creature_ptr);
     case TR_DARK_SOURCE:

--- a/src/player/player-status-resist.cpp
+++ b/src/player/player-status-resist.cpp
@@ -405,6 +405,22 @@ PERCENTAGE calc_time_damage_rate(player_type *creature_ptr, rate_calc_type_mode 
 }
 
 /*!
+ * @brief 水流攻撃に対するダメージ倍率計算
+ */
+PERCENTAGE calc_water_damage_rate(player_type *creature_ptr, rate_calc_type_mode mode)
+{
+    (void)mode; // unused
+    PERCENTAGE per = 100;
+
+    if (has_resist_water(creature_ptr)) {
+        per *= 400;
+        per /= randrate(4, 7, mode);
+    }
+
+    return per;
+}
+
+/*!
  * @brief 聖なる火炎攻撃に対するダメージ倍率計算
  */
 PERCENTAGE calc_holy_fire_damage_rate(player_type *creature_ptr, rate_calc_type_mode mode)

--- a/src/player/player-status-resist.h
+++ b/src/player/player-status-resist.h
@@ -27,6 +27,7 @@ PERCENTAGE calc_nether_damage_rate(player_type *creature_ptr, rate_calc_type_mod
 PERCENTAGE calc_disenchant_damage_rate(player_type *creature_ptr, rate_calc_type_mode mode);
 PERCENTAGE calc_nexus_damage_rate(player_type *creature_ptr, rate_calc_type_mode mode);
 PERCENTAGE calc_time_damage_rate(player_type *creature_ptr, rate_calc_type_mode mode);
+PERCENTAGE calc_water_damage_rate(player_type *creature_ptr, rate_calc_type_mode mode);
 PERCENTAGE calc_rocket_damage_rate(player_type *creature_ptr, rate_calc_type_mode mode);
 PERCENTAGE calc_deathray_damage_rate(player_type *creature_ptr, rate_calc_type_mode mode);
 PERCENTAGE calc_holy_fire_damage_rate(player_type *creature_ptr, rate_calc_type_mode mode);


### PR DESCRIPTION
リファクタリングも込み。

時間と水属性は、以下のものにはまだ未対応
・鍛冶師のエッセンス(耐性エッセンス付加画面の改修が必要)
・*鑑定*済みの装備の耐性一覧(画面レイアウトの改修が必要)
・'C'コマンドの耐性一覧(レイアウトの大幅改装が必要)