### PR TITLE
[Feature] 通常エゴと呪いエゴの選出ルーチンを変更

### DIFF
--- a/src/object-enchant/apply-magic-armor.cpp
+++ b/src/object-enchant/apply-magic-armor.cpp
@@ -112,46 +112,59 @@ void apply_magic_armor(player_type *owner_ptr, object_type *o_ptr, DEPTH level, 
                 o_ptr->weight = (2 * k_info[o_ptr->k_idx].weight / 3);
                 o_ptr->ac = k_info[o_ptr->k_idx].ac + 5;
                 break;
-
-            case EGO_A_DEMON:
-                if (one_in_(3))
-                    o_ptr->curse_flags |= (TRC_HEAVY_CURSE);
-                one_in_(3) ? add_flag(o_ptr->art_flags, TR_DRAIN_EXP)
-                           : one_in_(2) ? add_flag(o_ptr->art_flags, TR_DRAIN_HP) : add_flag(o_ptr->art_flags, TR_DRAIN_MANA);
-
-                if (one_in_(3))
-                    add_flag(o_ptr->art_flags, TR_AGGRAVATE);
-                if (one_in_(3))
-                    add_flag(o_ptr->art_flags, TR_ADD_L_CURSE);
-                if (one_in_(5))
-                    add_flag(o_ptr->art_flags, TR_ADD_H_CURSE);
-                if (one_in_(5))
-                    add_flag(o_ptr->art_flags, TR_DRAIN_HP);
-                if (one_in_(5))
-                    add_flag(o_ptr->art_flags, TR_DRAIN_MANA);
-                if (one_in_(5))
-                    add_flag(o_ptr->art_flags, TR_DRAIN_EXP);
-                if (one_in_(5))
-                    add_flag(o_ptr->art_flags, TR_TY_CURSE);
-                if (one_in_(5))
-                    add_flag(o_ptr->art_flags, TR_CALL_DEMON);
-                break;
-            case EGO_A_MORGUL:
-                if (one_in_(3))
-                    o_ptr->curse_flags |= (TRC_HEAVY_CURSE);
-                if (one_in_(9))
-                    add_flag(o_ptr->art_flags, TR_TY_CURSE);
-                if (one_in_(4))
-                    add_flag(o_ptr->art_flags, TR_ADD_H_CURSE);
-                if (one_in_(6))
-                    add_flag(o_ptr->art_flags, TR_AGGRAVATE);
-                if (one_in_(9))
-                    add_flag(o_ptr->art_flags, TR_NO_MAGIC);
-                if (one_in_(9))
-                    add_flag(o_ptr->art_flags, TR_NO_TELE);
-                break;
             default:
                 break;
+            }
+        } else if (power < -1) {
+            while (TRUE) {
+                bool okay_flag = TRUE;
+                o_ptr->name2 = get_random_ego(INVEN_BODY, FALSE);
+
+                switch (o_ptr->name2) {
+                case EGO_A_DEMON:
+                    if (one_in_(3))
+                        o_ptr->curse_flags |= (TRC_HEAVY_CURSE);
+                    one_in_(3) ? add_flag(o_ptr->art_flags, TR_DRAIN_EXP)
+                               : one_in_(2) ? add_flag(o_ptr->art_flags, TR_DRAIN_HP) : add_flag(o_ptr->art_flags, TR_DRAIN_MANA);
+
+                    if (one_in_(3))
+                        add_flag(o_ptr->art_flags, TR_AGGRAVATE);
+                    if (one_in_(3))
+                        add_flag(o_ptr->art_flags, TR_ADD_L_CURSE);
+                    if (one_in_(5))
+                        add_flag(o_ptr->art_flags, TR_ADD_H_CURSE);
+                    if (one_in_(5))
+                        add_flag(o_ptr->art_flags, TR_DRAIN_HP);
+                    if (one_in_(5))
+                        add_flag(o_ptr->art_flags, TR_DRAIN_MANA);
+                    if (one_in_(5))
+                        add_flag(o_ptr->art_flags, TR_DRAIN_EXP);
+                    if (one_in_(5))
+                        add_flag(o_ptr->art_flags, TR_TY_CURSE);
+                    if (one_in_(5))
+                        add_flag(o_ptr->art_flags, TR_CALL_DEMON);
+                    break;
+                case EGO_A_MORGUL:
+                    if (one_in_(3))
+                        o_ptr->curse_flags |= (TRC_HEAVY_CURSE);
+                    if (one_in_(9))
+                        add_flag(o_ptr->art_flags, TR_TY_CURSE);
+                    if (one_in_(4))
+                        add_flag(o_ptr->art_flags, TR_ADD_H_CURSE);
+                    if (one_in_(6))
+                        add_flag(o_ptr->art_flags, TR_AGGRAVATE);
+                    if (one_in_(9))
+                        add_flag(o_ptr->art_flags, TR_NO_MAGIC);
+                    if (one_in_(9))
+                        add_flag(o_ptr->art_flags, TR_NO_TELE);
+                    break;
+                default:
+                    okay_flag = false;
+                    break;
+                }
+
+                if (okay_flag)
+                    break;
             }
         }
 
@@ -300,6 +313,9 @@ void apply_magic_armor(player_type *owner_ptr, object_type *o_ptr, DEPTH level, 
                 o_ptr->name2 = get_random_ego(INVEN_HEAD, FALSE);
 
                 switch (o_ptr->name2) {
+                case EGO_H_DEMON:
+                    ok_flag = false;
+                    break;
                 case EGO_ANCIENT_CURSE:
                     if (one_in_(3))
                         add_flag(o_ptr->art_flags, TR_NO_MAGIC);
@@ -361,6 +377,22 @@ void apply_magic_armor(player_type *owner_ptr, object_type *o_ptr, DEPTH level, 
                     if (one_in_(3))
                         add_flag(o_ptr->art_flags, TR_LITE_2);
                     break;
+                default:
+                    /* not existing helm (Magi, Might, etc...)*/
+                    ok_flag = FALSE;
+                }
+
+                if (ok_flag)
+                    break;
+            }
+
+            break;
+        } else if (power < -1) {
+            while (TRUE) {
+                bool ok_flag = TRUE;
+                o_ptr->name2 = get_random_ego(INVEN_HEAD, FALSE);
+
+                switch (o_ptr->name2) {
                 case EGO_H_DEMON:
                     if (one_in_(3))
                         o_ptr->curse_flags |= (TRC_HEAVY_CURSE);
@@ -384,23 +416,9 @@ void apply_magic_armor(player_type *owner_ptr, object_type *o_ptr, DEPTH level, 
                     if (one_in_(5))
                         add_flag(o_ptr->art_flags, TR_CALL_DEMON);
                     break;
-                default:
-                    /* not existing helm (Magi, Might, etc...)*/
-                    ok_flag = FALSE;
-                }
-                if (ok_flag)
-                    break;
-            }
-
-            break;
-        } else if (power < -1) {
-            while (TRUE) {
-                bool ok_flag = TRUE;
-                o_ptr->name2 = get_random_ego(INVEN_HEAD, FALSE);
-
-                switch (o_ptr->name2) {
                 case EGO_ANCIENT_CURSE:
                     ok_flag = FALSE;
+                    break;
                 }
 
                 if (ok_flag)

--- a/src/object-enchant/apply-magic-weapon.cpp
+++ b/src/object-enchant/apply-magic-weapon.cpp
@@ -165,22 +165,6 @@ void apply_magic_weapon(player_type *owner_ptr, object_type *o_ptr, DEPTH level,
                 if (one_in_(5))
                     add_flag(o_ptr->art_flags, TR_SLAY_HUMAN);
                 break;
-            case EGO_DEMON:
-
-                if (one_in_(3))
-                    o_ptr->curse_flags |= (TRC_HEAVY_CURSE);
-                one_in_(3) ? add_flag(o_ptr->art_flags, TR_DRAIN_EXP)
-                           : one_in_(2) ? add_flag(o_ptr->art_flags, TR_DRAIN_HP) : add_flag(o_ptr->art_flags, TR_DRAIN_MANA);
-
-                if (one_in_(3))
-                    add_flag(o_ptr->art_flags, TR_CHAOTIC);
-                if (one_in_(4))
-                    add_flag(o_ptr->art_flags, TR_BLOWS);
-                if (one_in_(5))
-                    add_flag(o_ptr->art_flags, TR_ADD_H_CURSE);
-                if (one_in_(5))
-                    add_flag(o_ptr->art_flags, TR_CALL_DEMON);
-                break;
             }
 
             if (!o_ptr->art_name) {
@@ -207,6 +191,22 @@ void apply_magic_weapon(player_type *owner_ptr, object_type *o_ptr, DEPTH level,
                         add_flag(o_ptr->art_flags, TR_TY_CURSE);
                     if (one_in_(3))
                         o_ptr->curse_flags |= (TRC_HEAVY_CURSE);
+                    break;
+                case EGO_DEMON:
+
+                    if (one_in_(3))
+                        o_ptr->curse_flags |= (TRC_HEAVY_CURSE);
+                    one_in_(3) ? add_flag(o_ptr->art_flags, TR_DRAIN_EXP)
+                               : one_in_(2) ? add_flag(o_ptr->art_flags, TR_DRAIN_HP) : add_flag(o_ptr->art_flags, TR_DRAIN_MANA);
+
+                    if (one_in_(3))
+                        add_flag(o_ptr->art_flags, TR_CHAOTIC);
+                    if (one_in_(4))
+                        add_flag(o_ptr->art_flags, TR_BLOWS);
+                    if (one_in_(5))
+                        add_flag(o_ptr->art_flags, TR_ADD_H_CURSE);
+                    if (one_in_(5))
+                        add_flag(o_ptr->art_flags, TR_CALL_DEMON);
                     break;
                 }
             }

--- a/src/object-enchant/apply-magic.cpp
+++ b/src/object-enchant/apply-magic.cpp
@@ -270,7 +270,9 @@ void apply_magic(player_type *owner_ptr, object_type *o_ptr, DEPTH lev, BIT_FLAG
         if (e_ptr->act_idx)
             o_ptr->xtra2 = (XTRA8)e_ptr->act_idx;
 
-        if ((object_is_cursed(o_ptr) || object_is_broken(o_ptr)) && e_ptr->gen_flags.has_not(TRG::POWERFUL)) {
+        bool is_powerful = e_ptr->gen_flags.has(TRG::POWERFUL);
+
+        if ((object_is_cursed(o_ptr) || object_is_broken(o_ptr)) && !is_powerful) {
             if (e_ptr->max_to_h)
                 o_ptr->to_h -= randint1(e_ptr->max_to_h);
             if (e_ptr->max_to_d)
@@ -280,6 +282,15 @@ void apply_magic(player_type *owner_ptr, object_type *o_ptr, DEPTH lev, BIT_FLAG
             if (e_ptr->max_pval)
                 o_ptr->pval -= randint1(e_ptr->max_pval);
         } else {
+            if (is_powerful) {
+                if (e_ptr->max_to_h > 0 && o_ptr->to_h < 0)
+                    o_ptr->to_h = 0 - o_ptr->to_h;
+                if (e_ptr->max_to_d > 0 && o_ptr->to_d < 0)
+                    o_ptr->to_d = 0 - o_ptr->to_d;
+                if (e_ptr->max_to_a > 0 && o_ptr->to_a < 0)
+                    o_ptr->to_a = 0 - o_ptr->to_a;
+            }
+
             o_ptr->to_h += (HIT_PROB)randint1_signed(e_ptr->max_to_h);
             o_ptr->to_d += randint1_signed(e_ptr->max_to_d);
             o_ptr->to_a += (ARMOUR_CLASS)randint1_signed(e_ptr->max_to_a);

--- a/src/object-enchant/object-ego.cpp
+++ b/src/object-enchant/object-ego.cpp
@@ -5,6 +5,9 @@
  * @details Ego-Item indexes (see "lib/edit/e_info.txt")
  */
 #include "object-enchant/object-ego.h"
+#include "object-enchant/trg-types.h"
+#include "util/bit-flags-calculator.h"
+#include <vector>
 
 /*
  * The ego-item arrays
@@ -18,37 +21,43 @@ char *e_text;
  */
 EGO_IDX max_e_idx;
 
+struct random_ego_weight
+{
+    EGO_IDX idx;
+    long weight;
+};
+
 /*!
  * @brief アイテムのエゴをレア度の重みに合わせてランダムに選択する
  * Choose random ego type
  * @param slot 取得したいエゴの装備部位
  * @param good TRUEならば通常のエゴ、FALSEならば呪いのエゴが選択対象となる。
- * @return 選択されたエゴ情報のID、万一選択できなかった場合はmax_e_idxが返る。
+ * @return 選択されたエゴ情報のID、万一選択できなかった場合は0が返る。
  */
 byte get_random_ego(byte slot, bool good)
 {
+    std::vector<random_ego_weight> list;
     long total = 0L;
-    for (int i = 1; i < max_e_idx; i++) {
-        ego_item_type *e_ptr;
-        e_ptr = &e_info[i];
-        if (e_ptr->slot == slot && ((good && e_ptr->rating) || (!good && !e_ptr->rating))) {
-            if (e_ptr->rarity)
-                total += (255 / e_ptr->rarity);
+    for (EGO_IDX i = 1; i < max_e_idx; i++) {
+        ego_item_type *e_ptr = &e_info[i];
+        if (e_ptr->slot != slot || e_ptr->rarity <= 0)
+            continue;
+
+        bool worthless = e_ptr->rating == 0 || e_ptr->gen_flags.has_any_of({ TRG::CURSED, TRG::HEAVY_CURSE, TRG::PERMA_CURSE });
+
+        if (good != worthless) {
+            random_ego_weight ew = { i, (255 / e_ptr->rarity) };
+            list.push_back(ew);
+            total += ew.weight;
         }
     }
 
     int value = randint1(total);
-    int j;
-    for (j = 1; j < max_e_idx; j++) {
-        ego_item_type *e_ptr;
-        e_ptr = &e_info[j];
-        if (e_ptr->slot == slot && ((good && e_ptr->rating) || (!good && !e_ptr->rating))) {
-            if (e_ptr->rarity)
-                value -= (255 / e_ptr->rarity);
-            if (value <= 0L)
-                break;
-        }
+    for (random_ego_weight &ew : list) {
+        value -= ew.weight;
+        if (value <= 0L)
+            return ew.idx;
     }
 
-    return (byte)j;
+    return (EGO_IDX)0;
 }


### PR DESCRIPTION
通常エゴには呪いが付加されるエゴを選出しない(悪魔など)
呪いエゴにはレーティングが0または呪いが付加されるエゴを選出(悪魔など)

#325のようなエゴに対応できるように前準備として。
また、高級品確定ドロップで呪いエゴが落ちるのは序盤厳しいという意見もあるので。