### PR TITLE
[clang compatibility] src/util/flag-group.h and FLAG_TYPE_MAX

### DIFF
--- a/src/util/flag-group.h
+++ b/src/util/flag-group.h
@@ -435,7 +435,7 @@ private:
      */
     class reference {
     public:
-        reference(std::bitset<FlagGroup::FLAG_TYPE_MAX> &flags, size_t pos)
+        reference(std::bitset<static_cast<size_t>(FlagType::MAX)> &flags, size_t pos)
             : bs_(flags)
             , pos_(pos)
         {
@@ -459,7 +459,7 @@ private:
         }
 
     private:
-        std::bitset<FlagGroup::FLAG_TYPE_MAX> &bs_;
+        std::bitset<static_cast<size_t>(FlagType::MAX)> &bs_;
         size_t pos_;
     };
 


### PR DESCRIPTION
I did not find a -std= option that would let clang 12 compile the code where FlagGroup::FLAG_TYPE_MAX is used a template argument for bitset.  This change substitutes the definition of FlagGroup::FLAG_TYPE_MAX in those instances.