### PR TITLE
[fix] FlagGroupの定数定義をクラス定義の冒頭に移動する

### DIFF
--- a/src/util/flag-group.h
+++ b/src/util/flag-group.h
@@ -12,6 +12,10 @@
  */
 template <typename FlagType>
 class FlagGroup {
+private:
+    /** フラグ集合のフラグ数 */
+    static constexpr auto FLAG_TYPE_MAX = static_cast<size_t>(FlagType::MAX);
+
 public:
     /**
      * @brief フラグ集合に含まれるフラグの種類数を返す
@@ -419,7 +423,7 @@ public:
      *              見つからなかった場合 false
      */
     template <typename Map>
-    static bool grab_one_flag(FlagGroup<FlagType>& fg, const Map &dict, std::string_view what)
+    static bool grab_one_flag(FlagGroup<FlagType> &fg, const Map &dict, std::string_view what)
     {
         auto it = dict.find(what);
         if (it == dict.end())
@@ -476,9 +480,6 @@ public:
     }
 
 private:
-    /** フラグ集合のフラグ数 */
-    static constexpr auto FLAG_TYPE_MAX = static_cast<size_t>(FlagType::MAX);
-
     /** フラグ集合を保持するstd::bitsetのインスタンス */
     std::bitset<FLAG_TYPE_MAX> bs_;
 };


### PR DESCRIPTION
Mac App版のビルドでコンパイラにclangを使用すると
FLAG_TYPE_MAXの定義が見つからずエラーになる。
clangではスコープの決定がMSVC/gccより厳密なのかも
しれない。
回避策としてFLAG_TYPE_MAXの定義をFlagGroupクラスの
定義冒頭に移動する。