### PR TITLE
[add] 自動更新スポイラーdeploy用Workflowにautoconf-archive追加

### DIFF
--- a/.github/workflows/publish-spoiler-page.yml
+++ b/.github/workflows/publish-spoiler-page.yml
@@ -17,6 +17,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install \
+            autoconf-archive \
             nkf \
 
       - name: Generate configure


### PR DESCRIPTION
51c0357 で行ったC++17標準のコンパイラ対応チェックマクロが
含まれるautoconf-archiveパッケージの追加を自動更新スポイラー
deploy用Workflowではやっていなかったためバイナリのビルドに
失敗していた。
自動更新スポイラーdeploy用Workflowにもautoconf-archiveを
追加する。