### PR TITLE
[fix/refactor] clangのWarning対策

### DIFF
--- a/src/artifact/random-art-characteristics.cpp
+++ b/src/artifact/random-art-characteristics.cpp
@@ -87,8 +87,7 @@ void curse_artifact(player_type *player_ptr, object_type *o_ptr)
 static concptr get_random_art_filename(const bool armour, const int power)
 {
     concptr filename;
-    switch (armour) {
-    case 1:
+    if (armour) {
         switch (power) {
         case 0:
             filename = _("a_cursed_j.txt", "a_cursed.txt");
@@ -102,8 +101,7 @@ static concptr get_random_art_filename(const bool armour, const int power)
         default:
             filename = _("a_high_j.txt", "a_high.txt");
         }
-        break;
-    default:
+    } else {
         switch (power) {
         case 0:
             filename = _("w_cursed_j.txt", "w_cursed.txt");

--- a/src/maid-x11.cpp
+++ b/src/maid-x11.cpp
@@ -802,9 +802,9 @@ static XImage *ResizeImage(Display *dpy, XImage *Im,
 	Visual *visual = DefaultVisual(dpy, DefaultScreen(dpy));
 
 	int width1, height1, width2, height2;
-	int x1, x2, y1, y2, Tx, Ty;
-	int *px1, *px2, *dx1, *dx2;
-	int *py1, *py2, *dy1, *dy2;
+	volatile int x1, x2, y1, y2, Tx, Ty;
+	volatile int *px1, *px2, *dx1, *dx2;
+	volatile int *py1, *py2, *dy1, *dy2;
 
 	XImage *Tmp;
 

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -113,7 +113,7 @@ void display_rumor(player_type *player_ptr, bool ex)
         IDX t_idx;
         while (TRUE) {
             t_idx = rumor_num(zz[1], NO_TOWN);
-            if (town_info[t_idx].name)
+            if (town_info[t_idx].name[0] != '\0')
                 break;
         }
 

--- a/src/system/system-variables.cpp
+++ b/src/system/system-variables.cpp
@@ -10,6 +10,7 @@
   * todo どこからも呼ばれていない。main関数辺りに移設するか、そもそもコメントでいいと思われる
   * コピーライト情報 / Link a copyright message into the executable
   */
+/*
 const concptr copyright[5] =
 {
 	"Copyright (c) 1989 James E. Wilson, Robert A. Keoneke",
@@ -18,6 +19,7 @@ const concptr copyright[5] =
 	"and not for profit purposes provided that this copyright and statement",
 	"are included in all such copies."
 };
+*/
 
 concptr ANGBAND_SYS = "xxx";
 concptr ANGBAND_KEYBOARD = _("JAPAN", "0");


### PR DESCRIPTION
- rumor.cpp:
配列のアドレスのnullチェックをしていて常にtrueになる無意味な
判定になっている。空文字列かどうかのチェックにする。

- random-art-characteristics.cpp:
bool変数でswitchするという独創的な分岐をしている。
普通にif文にする。

- system-variables.cpp:
上のコメントにあるように、使用されていないコピーライト
文字列。コメントアウトしておく。

- random-art-characteristics.cpp:
x1,x2,y1,y2はポインタ経由で更新されている。
#pragma によりこのループでの警告を抑制する。