### PR TITLE
[Fix] 隠密計算に職業の基礎値が足されていない #515

### DIFF
--- a/src/player-status/player-stealth.cpp
+++ b/src/player-status/player-stealth.cpp
@@ -47,7 +47,7 @@ s16b PlayerStealth::personality_value()
  * @details
  * * 職業による加算
  */
-s16b PlayerStealth::base_class_value()
+s16b PlayerStealth::class_base_value()
 {
     const player_class *c_ptr = &class_info[this->owner_ptr->pclass];
     return c_ptr->c_stl + (c_ptr->x_stl * this->owner_ptr->lev / 10);

--- a/src/player-status/player-stealth.h
+++ b/src/player-status/player-stealth.h
@@ -12,7 +12,7 @@ protected:
     void set_locals() override;
     s16b race_value() override;
     s16b class_value() override;
-    s16b base_class_value();
+    s16b class_base_value() override;
     s16b personality_value() override;
     s16b time_effect_value() override;
     s16b mutation_value() override;


### PR DESCRIPTION
派生クラスでclass_base_value()の名前を間違っていたので正しくoverrideされず、
職業の基礎値が計算から漏れていた。名称を修正して期待される挙動に戻す。