### PR TITLE
[feature] 確率テーブルクラス

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -858,6 +858,7 @@ hengband_SOURCES = \
 	util/flag-group.h \
 	util/int-char-converter.h \
 	util/object-sort.cpp util/object-sort.h \
+	util/probability-table.h \
 	util/quarks.cpp util/quarks.h \
 	util/sort.cpp util/sort.h \
 	util/string-processor.cpp util/string-processor.h \

--- a/src/main/game-data-initializer.cpp
+++ b/src/main/game-data-initializer.cpp
@@ -147,7 +147,6 @@ errr init_object_alloc(void)
             table[z].level = (DEPTH)x;
             table[z].prob1 = (PROB)p;
             table[z].prob2 = (PROB)p;
-            table[z].prob3 = (PROB)p;
             aux[x]++;
         }
     }
@@ -184,7 +183,6 @@ errr init_alloc(void)
         alloc_race_table[i].level = (DEPTH)x;
         alloc_race_table[i].prob1 = (PROB)p;
         alloc_race_table[i].prob2 = (PROB)p;
-        alloc_race_table[i].prob3 = (PROB)p;
     }
 
     C_KILL(elements, max_r_idx, tag_type);

--- a/src/room/room-generator.cpp
+++ b/src/room/room-generator.cpp
@@ -16,6 +16,7 @@
 #include "room/rooms-vault.h"
 #include "system/dungeon-data-definition.h"
 #include "system/floor-type-definition.h"
+#include "util/probability-table.h"
 #include "wizard/wizard-messages.h"
 
 /*!
@@ -146,24 +147,18 @@ bool generate_rooms(player_type *player_ptr, dun_data_type *dd_ptr)
     if (!(d_info[floor_ptr->dungeon_idx].flags1 & DF1_ARCADE))
         prob_list[ROOM_T_ARCADE] = 0;
 
-    int total_prob = 0;
+    ProbabilityTable<int> prob_table;
     for (int i = 0; i < ROOM_T_MAX; i++) {
         room_num[i] = 0;
-        total_prob += prob_list[i];
+        prob_table.entry_item(i, prob_list[i]);
     }
 
     for (int i = dun_rooms; i > 0; i--) {
         int room_type;
-        int rand = randint0(total_prob);
-        for (room_type = 0; room_type < ROOM_T_MAX; room_type++) {
-            if (rand < prob_list[room_type])
-                break;
-            else
-                rand -= prob_list[room_type];
-        }
-
-        if (room_type >= ROOM_T_MAX)
+        if (prob_table.empty())
             room_type = ROOM_T_NORMAL;
+        else
+            room_type = prob_table.pick_one_at_random();
 
         room_num[room_type]++;
         switch (room_type) {

--- a/src/system/alloc-entry-definition.h
+++ b/src/system/alloc-entry-definition.h
@@ -1,5 +1,5 @@
 ﻿/*
- * @brief 
+ * @brief
  * @author
  * Copyright (c) 1997 Ben Harrison, James E. Wilson, Robert A. Koeneke
  * 2002/01/12 mogami
@@ -17,7 +17,6 @@
  *
  * Pass 1 is determined from allocation information
  * Pass 2 is determined from allocation restriction
- * Pass 3 is determined from allocation calculation
  */
 typedef struct alloc_entry {
     KIND_OBJECT_IDX index; /* The actual index */
@@ -25,7 +24,6 @@ typedef struct alloc_entry {
     DEPTH level; /* Base dungeon level */
     PROB prob1; /* Probability, pass 1 */
     PROB prob2; /* Probability, pass 2 */
-    PROB prob3; /* Probability, pass 3 */
 
     u16b total; /* Unused for now */
 } alloc_entry;

--- a/src/util/probability-table.h
+++ b/src/util/probability-table.h
@@ -1,0 +1,142 @@
+﻿#pragma once
+
+#include "term/z-rand.h"
+
+#include <algorithm>
+#include <exception>
+#include <stdexcept>
+#include <tuple>
+#include <vector>
+
+/**
+ * @brief 確率テーブルクラス
+ *
+ * 確率テーブルを作成し、確率に従った抽選を行うクラス
+ *
+ * @tparam IdType 確率テーブルに登録するIDの型
+ */
+template <typename IdType>
+class ProbabilityTable {
+public:
+    /**
+     * @brief コンストラクタ
+     *
+     * 空の確率テーブルを生成する
+     */
+    ProbabilityTable() = default;
+
+    /**
+     * @brief 確率テーブルを空にする
+     */
+    void clear()
+    {
+        return item_list_.clear();
+    }
+
+    /**
+     * @brief 確率テーブルに項目を登録する
+     *
+     * 確率テーブルに項目のIDと選択確率のセットを登録する。
+     * 追加した項目が選択される確率は、
+     * 追加した項目の確率(引数prob) / すべての項目のprobの合計
+     * となる。
+     * probが0もしくは負数の場合はなにも登録しない。
+     *
+     * @param id 項目のID
+     * @param prob 項目の選択確率
+     */
+    void entry_item(IdType id, int prob)
+    {
+        if (prob > 0) {
+            // 二分探索を行うため、probは累積値を格納する
+            auto cumulative_prob = item_list_.empty() ? 0 : std::get<1>(item_list_.back());
+            item_list_.emplace_back(id, cumulative_prob + prob);
+        }
+    }
+
+    /**
+     * @brief 現在の確率テーブルのすべての項目の選択確率の合計を取得する
+     *
+     * 確率テーブルに登録されているすべての項目の確率(登録時の引数prob)の合計を取得する。
+     *
+     * @return int 現在の確率テーブルのすべての項目の選択確率の合計
+     */
+    int total_prob() const
+    {
+        if (item_list_.empty())
+            return 0;
+
+        return std::get<1>(item_list_.back());
+    }
+
+    /**
+     * @brief 確率テーブルに登録されている項目の数を取得する
+     *
+     * 確率テーブルに登録されている項目の数を取得する。
+     * 登録されている項目のIDに被りがある場合は別の項目として加算した数となる。
+     *
+     * @return size_t 確率テーブルに登録されている項目の数
+     */
+    size_t item_count() const
+    {
+        return item_list_.size();
+    }
+
+    /**
+     * @brief 確率テーブルの項目が空かどうかを調べる
+     *
+     * @return bool 確率テーブルに項目が一つも登録されておらず空であれば true
+     *              項目が一つ以上登録されており空でなければ false
+     */
+    bool empty() const
+    {
+        return item_list_.empty();
+    }
+
+    /**
+     * @brief 確率テーブルから項目をランダムに1つ選択する
+     *
+     * 確率テーブルに登録されているすべての項目から、確率に従って項目を1つ選択する
+     * それぞれの項目が選択される確率は、確率設定probに対して
+     * 該当項目のprob / すべての項目のprobの合計
+     * となる。
+     * 抽選は独立試行で行われ、選択された項目がテーブルから取り除かれる事はない。
+     * 確率テーブルになにも登録されていない場合、std::runtime_error例外を送出する。
+     *
+     * @return int 選択された項目のID
+     */
+    IdType pick_one_at_random() const
+    {
+        if (empty()) {
+            throw std::runtime_error("There is no entry in the probability table.");
+        }
+
+        // probの合計の範囲からランダムでkeyを取得し、二分探索で選択する項目を決定する
+        const int key = randint0(total_prob());
+        auto it = std::partition_point(item_list_.begin(), item_list_.end(), [key](const auto &i) { return std::get<1>(i) <= key; });
+
+        return std::get<0>(*it);
+    }
+
+    /**
+     * @brief 確率テーブルから複数回抽選する
+     *
+     * 確率テーブルから引数 n で指定した回数抽選し、抽選の結果選択された項目のIDを
+     * 出力イテレータに n 個書き込む。
+     * 抽選は独立試行で行われ、選択された項目がテーブルから取り除かれる事はない。
+     *
+     * @tparam OutputIter 出力イテレータの型
+     * @param first 結果を書き込む出力イテレータ
+     * @param table 抽選を行う確率テーブル
+     * @param n 抽選を行う回数
+     */
+    template <typename OutputIter>
+    static void lottery(OutputIter first, const ProbabilityTable &table, size_t n)
+    {
+        std::generate_n(first, n, [&table] { return table.pick_one_at_random(); });
+    }
+
+private:
+    /** 項目のIDと確率のセットを格納する配列 */
+    std::vector<std::tuple<IdType, int>> item_list_;
+};


### PR DESCRIPTION
モンスター/アイテム/ダンジョンの部屋の生成などで、
選択確率に重み付けされた複数の候補のリストを生成して
その中から抽選するという同じような処理があるので
処理を共通化した確率テーブルクラスを導入する。
既存の処理は選択時の探索が線形探索なので計算量が
O(N)だが、確率テーブルクラスでは二分探索をするので
O(log N)ですむ。
但し現状は毎回候補のテーブルを生成しており、
そちらがO(N)なので高速化の効果はほぼ無い。