### PR TITLE
[Feature] Windowsの高DPI環境での表示改善

### DIFF
--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -3573,6 +3573,21 @@ static spoiler_output_status create_debug_spoiler(LPSTR cmd_line)
     return output_all_spoilers();
 }
 
+typedef BOOL(_stdcall *SetProcessDpiAwarenessContextFunc)(DPI_AWARENESS_CONTEXT);
+/*!
+ * @brief 高DPI設定。Windows10に高DPIスケール設定をまかせる。Windows 10バージョン1809以降のみ有効。
+ */
+void setup_dpi_Awareness()
+{
+    SetDllDirectory("");
+    HMODULE hm = LoadLibrary("User32.dll");
+    SetProcessDpiAwarenessContextFunc func = (SetProcessDpiAwarenessContextFunc)GetProcAddress(hm, "SetProcessDpiAwarenessContext");
+    if (func)
+        (*func)(DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED);
+    if (hm)
+        FreeLibrary(hm);
+}
+
 /*!
  * todo よく見るとhMutexはちゃんと使われていない……？
  * @brief (Windows固有)変愚蛮怒が起動済かどうかのチェック
@@ -3597,6 +3612,7 @@ int PASCAL WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPSTR lpCmdLine, int nC
     HDC hdc;
     MSG msg;
 
+    setup_dpi_Awareness();
     setlocale(LC_ALL, "ja_JP");
     (void)nCmdShow;
     hInstance = hInst;


### PR DESCRIPTION
高DPI環境での若干ぼやけた表示、メニュー部分やダイアログは特に、をきれいに表示したい。
Windows10（バージョン1809以降）の高DPIスケール設定を適用するときれいな表示になります。

効果としては、Hengband.exeのプロパティを開き互換性タブにある「高DPI設定の変更」で「システム（拡張）」を設定した場合と同等の効果があります。（プロパティで上書きしている場合は、上書き設定が適用される。）
挙動としてはOSにDPIスケーリングをおまかせで、高DPI非対応のこれまでと同じです。表示内容がきれいになるだけ。

Windows10（バージョン1809）より前でも動作するようにしています。非対応の場合は何も設定されません。