### PR TITLE
[Fix] *.rawの更新がされず齟齬が生じる可能性がある / TRGフラグのクラス化で番号の付け違い

### DIFF
--- a/src/info-reader/general-parser.cpp
+++ b/src/info-reader/general-parser.cpp
@@ -52,8 +52,8 @@ errr init_info_txt(FILE *fp, char *buf, angband_header *head, parse_info_txt_fun
         if (buf[0] != 'N' && buf[0] != 'D') {
             int i;
             for (i = 0; buf[i]; i++) {
-                head->v_extra += (byte)buf[i];
-                head->v_extra ^= (1U << (i % 8));
+                head->checksum += (byte)buf[i];
+                head->checksum ^= (1U << (i % 8));
             }
         }
 

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -548,8 +548,8 @@ static void dump_aux_home_museum(player_type *creature_ptr, FILE *fff)
  */
 static concptr get_check_sum(void)
 {
-    return format("%02x%02x%02x%02x%02x%02x%02x%02x%02x", f_head.v_extra, k_head.v_extra, a_head.v_extra, e_head.v_extra, r_head.v_extra, d_head.v_extra,
-        m_head.v_extra, s_head.v_extra, v_head.v_extra);
+    return format("%02x%02x%02x%02x%02x%02x%02x%02x%02x", f_head.checksum, k_head.checksum, a_head.checksum, e_head.checksum, r_head.checksum, d_head.checksum,
+        m_head.checksum, s_head.checksum, v_head.checksum);
 }
 
 /*!

--- a/src/main/angband-headers.h
+++ b/src/main/angband-headers.h
@@ -9,28 +9,31 @@ typedef struct angband_header angband_header;
 typedef errr (*parse_info_txt_func)(char *buf, angband_header *head);
 
 struct angband_header {
-    byte v_major; /* Version -- major */
-    byte v_minor; /* Version -- minor */
-    byte v_patch; /* Version -- patch */
-    byte checksum; /* Version -- extra */
+    byte v_major; //!< Major version
+    byte v_minor; //!< Minor version
+    byte v_patch; //!< Patch version
+    byte checksum; //!< Checksum of "info" records
 
-    u16b info_num; /* Number of "info" records */
-    int info_len; /* Size of each "info" record */
-    u16b head_size; /* Size of the "header" in bytes */
+    u16b info_num; //!< このinfoのデータ数
+    int info_len; //!< このinfoの総サイズ
+    u16b head_size; //!< このinfoのヘッダサイズ
 
-    STR_OFFSET info_size; /* Size of the "info" array in bytes */
-    STR_OFFSET name_size; /* Size of the "name" array in bytes */
-    STR_OFFSET text_size; /* Size of the "text" array in bytes */
-    STR_OFFSET tag_size; /* Size of the "tag" array in bytes */
+    STR_OFFSET info_size; //!< info配列サイズ
+    STR_OFFSET name_size; //!< 名前文字列群サイズ(総文字長)
+    STR_OFFSET text_size; //!< フレーバー文字列群サイズ(総文字長)
+    STR_OFFSET tag_size; //!< タグ文字列群サイズ(総文字長)
 
-    void *info_ptr;
-    char *name_ptr;
-    char *text_ptr;
-    char *tag_ptr;
+    void *info_ptr; //!< info配列へのポインタ
+    char *name_ptr; //!< 名前文字列群へのポインタ
+    char *text_ptr; //!< フレーバー文字列群へのポインタ
+    char *tag_ptr; //!< タグ文字列群へのポインタ
 
-    parse_info_txt_func parse_info_txt;
+    parse_info_txt_func parse_info_txt; //!< Pointer to parser callback function
 
-    void (*retouch)(angband_header *head);
+    void (*retouch)(angband_header *head); //!< 設定再読み込み用？
+
+    byte v_extra; ///< Extra version for Alpha, Beta
+    byte v_savefile; ///< Savefile version
 };
 
 extern angband_header f_head;

--- a/src/main/angband-headers.h
+++ b/src/main/angband-headers.h
@@ -12,7 +12,7 @@ struct angband_header {
     byte v_major; /* Version -- major */
     byte v_minor; /* Version -- minor */
     byte v_patch; /* Version -- patch */
-    byte v_extra; /* Version -- extra */
+    byte checksum; /* Version -- extra */
 
     u16b info_num; /* Number of "info" records */
     int info_len; /* Size of each "info" record */

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -105,7 +105,7 @@ static void init_header(angband_header *head, IDX num, int len)
     head->v_major = FAKE_VER_MAJOR;
     head->v_minor = FAKE_VER_MINOR;
     head->v_patch = FAKE_VER_PATCH;
-    head->v_extra = 0;
+    head->checksum = 0;
 
     head->info_num = (IDX)num;
     head->info_len = len;

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -50,11 +50,12 @@ errr init_misc(player_type *player_ptr) { return parse_fixed_map(player_ptr, "mi
 static errr init_info_raw(int fd, angband_header *head)
 {
     angband_header test;
-    if (fd_read(fd, (char *)(&test), sizeof(angband_header)) || (test.v_major != head->v_major) || (test.v_minor != head->v_minor)
-        || (test.v_patch != head->v_patch) || (test.info_num != head->info_num) || (test.info_len != head->info_len) || (test.head_size != head->head_size)
-        || (test.info_size != head->info_size)) {
+    if (fd_read(fd, (char *)(&test), sizeof(angband_header))
+        || (test.v_major != head->v_major) || (test.v_minor != head->v_minor) || (test.v_patch != head->v_patch)
+        || (test.v_extra != head->v_extra) || (test.v_savefile != head->v_savefile)
+        || (test.head_size != head->head_size) || (test.info_size != head->info_size)
+        || (test.info_num != head->info_num) || (test.info_len != head->info_len))
         return -1;
-    }
 
     *head = test;
     C_MAKE(head->info_ptr, head->info_size, char);
@@ -112,6 +113,9 @@ static void init_header(angband_header *head, IDX num, int len)
 
     head->head_size = sizeof(angband_header);
     head->info_size = head->info_num * head->info_len;
+
+    head->v_extra = FAKE_VER_EXTRA;
+    head->v_savefile = SAVEFILE_VERSION;
 }
 
 /*!

--- a/src/object-enchant/trg-types.h
+++ b/src/object-enchant/trg-types.h
@@ -2,24 +2,24 @@
 
 // clang-format off
 enum class TRG {
-	INSTA_ART         =  1, /* Item must be an artifact */
-    QUESTITEM         =  2, /* quest level item -KMW- */
-    XTRA_POWER        =  3, /* Extra power */
-    ONE_SUSTAIN       =  4, /* One sustain */
-    XTRA_RES_OR_POWER =  5, /* Extra resistance or power */
-    XTRA_H_RES        =  6, /* Extra high resistance */
-    XTRA_E_RES        =  7, /* Extra element resistance */
-    XTRA_L_RES        =  8, /* Extra lordly resistance */
-    XTRA_D_RES        =  9, /* Extra dragon resistance */
-    XTRA_RES          = 10, /* Extra resistance */
-    CURSED            = 11, /* Item is Cursed */
-    HEAVY_CURSE       = 12, /* Item is Heavily Cursed */
-    PERMA_CURSE       = 13, /* Item is Perma Cursed */
-    RANDOM_CURSE0     = 14, /* Item is Random Cursed */
-    RANDOM_CURSE1     = 15, /* Item is Random Cursed */
-    RANDOM_CURSE2     = 16, /* Item is Random Cursed */
-    XTRA_DICE         = 17, /* Extra dice */
-    POWERFUL          = 18, /* Item has good value even if Cursed */
+	INSTA_ART         =  0, /* Item must be an artifact */
+    QUESTITEM         =  1, /* quest level item -KMW- */
+    XTRA_POWER        =  2, /* Extra power */
+    ONE_SUSTAIN       =  3, /* One sustain */
+    XTRA_RES_OR_POWER =  4, /* Extra resistance or power */
+    XTRA_H_RES        =  5, /* Extra high resistance */
+    XTRA_E_RES        =  6, /* Extra element resistance */
+    XTRA_L_RES        =  7, /* Extra lordly resistance */
+    XTRA_D_RES        =  8, /* Extra dragon resistance */
+    XTRA_RES          =  9, /* Extra resistance */
+    CURSED            = 10, /* Item is Cursed */
+    HEAVY_CURSE       = 11, /* Item is Heavily Cursed */
+    PERMA_CURSE       = 12, /* Item is Perma Cursed */
+    RANDOM_CURSE0     = 13, /* Item is Random Cursed */
+    RANDOM_CURSE1     = 14, /* Item is Random Cursed */
+    RANDOM_CURSE2     = 15, /* Item is Random Cursed */
+    XTRA_DICE         = 16, /* Extra dice */
+    POWERFUL          = 17, /* Item has good value even if Cursed */
     MAX,
 };
 // clang-format on


### PR DESCRIPTION
アイテムのTRGフラグの付け間違い(1多かった)があったが、環境によって*.rawファイルが更新されず、番号が1ずれたフラグとして認識される不具合を修正。
#527 apply_magicの無限ループに影響。