### PR TITLE
[Fix] ブロンズ・クロスを発動で脱ぐと裸にtimeoutが設定される #547

### DIFF
--- a/src/action/activation-execution.cpp
+++ b/src/action/activation-execution.cpp
@@ -139,7 +139,7 @@ static bool activate_artifact(player_type *user_ptr, object_type *o_ptr)
         return FALSE;
     }
 
-    if (!switch_activation(user_ptr, o_ptr, act_ptr, name))
+    if (!switch_activation(user_ptr, &o_ptr, act_ptr, name))
         return FALSE;
 
     if (act_ptr->timeout.constant >= 0) {

--- a/src/object-activation/activation-switcher.cpp
+++ b/src/object-activation/activation-switcher.cpp
@@ -38,8 +38,10 @@
 #include "system/floor-type-definition.h"
 #include "view/display-messages.h"
 
-bool switch_activation(player_type *user_ptr, object_type *o_ptr, const activation_type *const act_ptr, concptr name)
+bool switch_activation(player_type *user_ptr, object_type **o_ptr_ptr, const activation_type *const act_ptr, concptr name)
 {
+    object_type *o_ptr = (*o_ptr_ptr);
+
     switch (act_ptr->index) {
     case ACT_SUNLIGHT:
         return activate_sunlight(user_ptr);
@@ -338,7 +340,7 @@ bool switch_activation(player_type *user_ptr, object_type *o_ptr, const activati
     case ACT_ULTIMATE_RESIST:
         return activate_ultimate_resistance(user_ptr);
     case ACT_CAST_OFF:
-        (void)cosmic_cast_off(user_ptr, o_ptr);
+        (void)cosmic_cast_off(user_ptr, o_ptr_ptr);
         return TRUE;
     case ACT_FALLING_STAR:
         return activate_toragoroshi(user_ptr);

--- a/src/object-activation/activation-switcher.h
+++ b/src/object-activation/activation-switcher.h
@@ -3,4 +3,4 @@
 #include "system/angband.h"
 
 typedef struct activation_type activation_type;
-bool switch_activation(player_type *user_ptr, object_type *o_ptr, const activation_type *const act_ptr, concptr name);
+bool switch_activation(player_type *user_ptr, object_type **o_ptr_ptr, const activation_type *const act_ptr, concptr name);

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -457,27 +457,38 @@ bool fishing(player_type *creature_ptr)
     return TRUE;
 }
 
-bool cosmic_cast_off(player_type *creature_ptr, object_type *o_ptr)
+/*!
+ * @brief 装備を脱ぎ捨てて小宇宙を燃やす
+ * @param creature_ptr プレイヤー情報への参照ポインタ
+ * @param o_ptr_ptr 脱ぐ装備品への参照ポインタのポインタ
+ * @return 脱いだらTRUE、脱がなかったらFALSE
+ * @detail
+ * 脱いで落とした装備にtimeoutを設定するために装備品のアドレスを返す。
+ */
+bool cosmic_cast_off(player_type *creature_ptr, object_type **o_ptr_ptr)
 {
+    object_type *o_ptr = (*o_ptr_ptr);
+
     /* Cast off activated item */
-    INVENTORY_IDX inv;
-    for (inv = INVEN_MAIN_HAND; inv <= INVEN_FEET; inv++) {
-        if (o_ptr == &creature_ptr->inventory_list[inv])
+    INVENTORY_IDX slot;
+    for (slot = INVEN_MAIN_HAND; slot <= INVEN_FEET; slot++) {
+        if (o_ptr == &creature_ptr->inventory_list[slot])
             break;
     }
 
-    if (inv > INVEN_FEET)
+    if (slot > INVEN_FEET)
         return FALSE;
 
     object_type forge;
     object_copy(&forge, o_ptr);
-    inven_item_increase(creature_ptr, inv, (0 - o_ptr->number));
-    inven_item_optimize(creature_ptr, inv);
-    OBJECT_IDX o_idx = drop_near(creature_ptr, &forge, 0, creature_ptr->y, creature_ptr->x);
-    o_ptr = &creature_ptr->current_floor_ptr->o_list[o_idx];
+    inven_item_increase(creature_ptr, slot, (0 - o_ptr->number));
+    inven_item_optimize(creature_ptr, slot);
+
+    OBJECT_IDX old_o_idx = drop_near(creature_ptr, &forge, 0, creature_ptr->y, creature_ptr->x);
+    *o_ptr_ptr = &creature_ptr->current_floor_ptr->o_list[old_o_idx];
 
     GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(creature_ptr, o_name, o_ptr, OD_NAME_ONLY);
+    describe_flavor(creature_ptr, o_name, &forge, OD_NAME_ONLY);
     msg_format(_("%sを脱ぎ捨てた。", "You cast off %s."), o_name);
 
     /* Get effects */

--- a/src/spell/spells-status.h
+++ b/src/spell/spells-status.h
@@ -28,6 +28,6 @@ bool restore_mana(player_type *creature_ptr, bool magic_eater);
 bool restore_all_status(player_type *creature_ptr);
 
 bool fishing(player_type *creature_ptr);
-bool cosmic_cast_off(player_type *creature_ptr, object_type *o_ptr);
+bool cosmic_cast_off(player_type *creature_ptr, object_type **o_ptr_ptr);
 void apply_nexus(monster_type *m_ptr, player_type *target_ptr);
 void status_shuffle(player_type *creature_ptr);


### PR DESCRIPTION
落とした方の元装備品へのアドレスをポインタを通じて返す。
裸にtimeout設定しなくなり、装備欄の(なし)も同時に解決。