### PR TITLE
[Linux/Unix] allow testing of distribution generation with "make distcheck"

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -925,7 +925,7 @@ EXTRA_hengband_SOURCES = \
 EXTRA_DIST = \
 	gcc-wrap
 
-DEFAULT_INCLUDES = -I$(srcdir)
+DEFAULT_INCLUDES = -I$(srcdir) -I$(top_builddir)/src
 CPPFLAGS += $(XFT_CFLAGS) $(libcurl_CFLAGS)
 LIBS += $(XFT_LIBS) $(libcurl_LIBS)
 COMPILE = $(srcdir)/gcc-wrap $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) \


### PR DESCRIPTION
Adjusts a recent change to DEFAULT_INCLUDES in src/Makefile.am so that "./configure --disable-japanese ; make DISTCHECK_CONFIGURE_FLAGS=--disable-japanese distcheck" does not immediately fail because autoconf.h is not found ("make distcheck" tests building in separate directory from the source files).