### PR TITLE
[Refactor] メンバ関数の命名規則の統一

### DIFF
--- a/src/player-status/player-basic-statistics.cpp
+++ b/src/player-status/player-basic-statistics.cpp
@@ -19,16 +19,16 @@
  * @details
  * * 各要素によるステータス修正値の合計
  */
-s16b PlayerBasicStatistics::ModificationValue() 
+s16b PlayerBasicStatistics::modification_value() 
 {
-    return PlayerStatusBase::getValue();
+    return PlayerStatusBase::get_value();
 }
 
 /*!
  * @brief 基礎ステータスの実値
  * @return status_typeに対応するステータスの実値を返す
  */
-s16b PlayerBasicStatistics::getValue()
+s16b PlayerBasicStatistics::get_value()
 {
     this->set_locals();
     return this->owner_ptr->stat_index[(int)this->status_type];
@@ -83,7 +83,7 @@ s16b PlayerBasicStatistics::personality_value()
  * @details
  * * owner_ptrのステータスを更新する
  */
-void PlayerBasicStatistics::updateValue()
+void PlayerBasicStatistics::update_value()
 {
     this->set_locals();
     this->update_top_status();

--- a/src/player-status/player-basic-statistics.h
+++ b/src/player-status/player-basic-statistics.h
@@ -6,9 +6,9 @@ public:
     using PlayerStatusBase::PlayerStatusBase;
     PlayerBasicStatistics() = delete;
 
-    void updateValue();
-    s16b ModificationValue();
-    s16b getValue() override;
+    void update_value();
+    s16b modification_value();
+    s16b get_value() override;
 
 protected:
     base_status_type status_type;

--- a/src/player-status/player-charisma.cpp
+++ b/src/player-status/player-charisma.cpp
@@ -84,9 +84,9 @@ s16b PlayerCharisma::set_exception_value(s16b value)
     return result;
 }
 
-BIT_FLAGS PlayerCharisma::getAllFlags()
+BIT_FLAGS PlayerCharisma::get_all_flags()
 {
-    BIT_FLAGS flags = PlayerStatusBase::getAllFlags();
+    BIT_FLAGS flags = PlayerStatusBase::get_all_flags();
 
     if (any_bits(this->owner_ptr->muta3, MUT3_ILL_NORM)) {
         set_bits(flags, FLAG_CAUSE_MUTATION);
@@ -95,9 +95,9 @@ BIT_FLAGS PlayerCharisma::getAllFlags()
     return flags;
 }
 
-BIT_FLAGS PlayerCharisma::getBadFlags()
+BIT_FLAGS PlayerCharisma::get_bad_flags()
 {
-    BIT_FLAGS flags = PlayerStatusBase::getBadFlags();
+    BIT_FLAGS flags = PlayerStatusBase::get_bad_flags();
 
     if (any_bits(this->owner_ptr->muta3, MUT3_ILL_NORM)) {
         set_bits(flags, FLAG_CAUSE_MUTATION);

--- a/src/player-status/player-charisma.h
+++ b/src/player-status/player-charisma.h
@@ -6,8 +6,8 @@ public:
     using PlayerBasicStatistics::PlayerBasicStatistics;
     PlayerCharisma() = delete;
 
-    BIT_FLAGS getAllFlags() override;
-    BIT_FLAGS getBadFlags() override;
+    BIT_FLAGS get_all_flags() override;
+    BIT_FLAGS get_bad_flags() override;
 
 protected:
     void set_locals() override;

--- a/src/player-status/player-status-base.cpp
+++ b/src/player-status/player-status-base.cpp
@@ -23,7 +23,7 @@ PlayerStatusBase::PlayerStatusBase(player_type *owner_ptr)
  * * 派生クラスからset_locals()をコールして初期値、上限、下限をセット。
  * * 各要素毎に計算した値を初期値に単純に加算し、上限と下限で丸める。
  */
-s16b PlayerStatusBase::getValue()
+s16b PlayerStatusBase::get_value()
 {
     this->set_locals(); /* 計算前に値のセット。派生クラスの値がセットされる。*/
     s16b pow = this->default_value;
@@ -55,7 +55,7 @@ s16b PlayerStatusBase::getValue()
  * @brief 修正値が0でないところにビットを立てて返す。
  * @return 判定結果のBIT_FLAGS
  */
-BIT_FLAGS PlayerStatusBase::getAllFlags()
+BIT_FLAGS PlayerStatusBase::get_all_flags()
 {
     this->set_locals(); /* 計算前に値のセット。派生クラスの値がセットされる。*/
     BIT_FLAGS result = equipments_flags(this->tr_flag);
@@ -94,7 +94,7 @@ BIT_FLAGS PlayerStatusBase::getAllFlags()
  * @brief 修正値が1以上のところにビットを立てて返す。
  * @return 判定結果のBIT_FLAGS
  */
-BIT_FLAGS PlayerStatusBase::getGoodFlags()
+BIT_FLAGS PlayerStatusBase::get_good_flags()
 {
     this->set_locals(); /* 計算前に値のセット。派生クラスの値がセットされる。*/
     BIT_FLAGS result = equipments_flags(this->tr_flag);
@@ -133,7 +133,7 @@ BIT_FLAGS PlayerStatusBase::getGoodFlags()
  * @brief 修正値が-1以下のところにビットを立てて返す。
  * @return 判定結果のBIT_FLAGS
  */
-BIT_FLAGS PlayerStatusBase::getBadFlags()
+BIT_FLAGS PlayerStatusBase::get_bad_flags()
 {
     this->set_locals(); /* 計算前に値のセット。派生クラスの値がセットされる。*/
     BIT_FLAGS result = equipments_bad_flags(this->tr_bad_flag);

--- a/src/player-status/player-status-base.h
+++ b/src/player-status/player-status-base.h
@@ -7,10 +7,10 @@ public:
     PlayerStatusBase(player_type *owner_ptr);
     PlayerStatusBase() = delete;
     virtual ~PlayerStatusBase() = default;
-    virtual s16b getValue();
-    virtual BIT_FLAGS getAllFlags();
-    virtual BIT_FLAGS getGoodFlags();
-    virtual BIT_FLAGS getBadFlags();
+    virtual s16b get_value();
+    virtual BIT_FLAGS get_all_flags();
+    virtual BIT_FLAGS get_good_flags();
+    virtual BIT_FLAGS get_bad_flags();
 
 protected:
     s16b default_value;

--- a/src/player-status/player-stealth.cpp
+++ b/src/player-status/player-stealth.cpp
@@ -144,9 +144,9 @@ s16b PlayerStealth::set_exception_value(s16b value)
  * @details
  * * TR_STELATHがマイナスの要素に加え、種族影フェアリーかつ反感のとき種族にマイナスフラグを与える
  */
-BIT_FLAGS PlayerStealth::getBadFlags()
+BIT_FLAGS PlayerStealth::get_bad_flags()
 {
-    BIT_FLAGS result = PlayerStatusBase::getBadFlags();
+    BIT_FLAGS result = PlayerStatusBase::get_bad_flags();
 
     if (this->is_aggravated_s_fairy())
         set_bits(result, FLAG_CAUSE_RACE);

--- a/src/player-status/player-stealth.h
+++ b/src/player-status/player-stealth.h
@@ -6,7 +6,7 @@ public:
     using PlayerStatusBase::PlayerStatusBase;
     PlayerStealth() = delete;
 
-    BIT_FLAGS getBadFlags() override;
+    BIT_FLAGS get_bad_flags() override;
 
 protected:
     void set_locals() override;

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -149,23 +149,23 @@ BIT_FLAGS get_player_flags(player_type *creature_ptr, tr_type tr_flag)
 {
     switch (tr_flag) {
     case TR_STR:
-        return PlayerStrength(creature_ptr).getAllFlags();
+        return PlayerStrength(creature_ptr).get_all_flags();
     case TR_INT:
-        return PlayerIntelligence(creature_ptr).getAllFlags();
+        return PlayerIntelligence(creature_ptr).get_all_flags();
     case TR_WIS:
-        return PlayerWisdom(creature_ptr).getAllFlags();
+        return PlayerWisdom(creature_ptr).get_all_flags();
     case TR_DEX:
-        return PlayerDextarity(creature_ptr).getAllFlags();
+        return PlayerDextarity(creature_ptr).get_all_flags();
     case TR_CON:
-        return PlayerConstitution(creature_ptr).getAllFlags();
+        return PlayerConstitution(creature_ptr).get_all_flags();
     case TR_CHR:
-        return PlayerCharisma(creature_ptr).getAllFlags();
+        return PlayerCharisma(creature_ptr).get_all_flags();
     case TR_MAGIC_MASTERY:
         return has_magic_mastery(creature_ptr);
     case TR_FORCE_WEAPON:
         return check_equipment_flags(creature_ptr, tr_flag);
     case TR_STEALTH:
-        return PlayerStealth(creature_ptr).getAllFlags();
+        return PlayerStealth(creature_ptr).get_all_flags();
     case TR_SEARCH:
         return 0;
     case TR_INFRA:
@@ -173,7 +173,7 @@ BIT_FLAGS get_player_flags(player_type *creature_ptr, tr_type tr_flag)
     case TR_TUNNEL:
         return 0;
     case TR_SPEED:
-        return PlayerSpeed(creature_ptr).getAllFlags();
+        return PlayerSpeed(creature_ptr).get_all_flags();
     case TR_BLOWS:
         return 0;
     case TR_CHAOTIC:

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -385,19 +385,19 @@ static void update_bonuses(player_type *creature_ptr)
         }
     }
 
-    creature_ptr->stat_add[A_STR] = PlayerStrength(creature_ptr).ModificationValue();
-    creature_ptr->stat_add[A_INT] = PlayerIntelligence(creature_ptr).ModificationValue();
-    creature_ptr->stat_add[A_WIS] = PlayerWisdom(creature_ptr).ModificationValue();
-    creature_ptr->stat_add[A_DEX] = PlayerDextarity(creature_ptr).ModificationValue();
-    creature_ptr->stat_add[A_CON] = PlayerConstitution(creature_ptr).ModificationValue();
-    creature_ptr->stat_add[A_CHR] = PlayerCharisma(creature_ptr).ModificationValue();
+    creature_ptr->stat_add[A_STR] = PlayerStrength(creature_ptr).modification_value();
+    creature_ptr->stat_add[A_INT] = PlayerIntelligence(creature_ptr).modification_value();
+    creature_ptr->stat_add[A_WIS] = PlayerWisdom(creature_ptr).modification_value();
+    creature_ptr->stat_add[A_DEX] = PlayerDextarity(creature_ptr).modification_value();
+    creature_ptr->stat_add[A_CON] = PlayerConstitution(creature_ptr).modification_value();
+    creature_ptr->stat_add[A_CHR] = PlayerCharisma(creature_ptr).modification_value();
 
-    PlayerStrength(creature_ptr).updateValue();
-    PlayerIntelligence(creature_ptr).updateValue();
-    PlayerWisdom(creature_ptr).updateValue();
-    PlayerDextarity(creature_ptr).updateValue();
-    PlayerConstitution(creature_ptr).updateValue();
-    PlayerCharisma(creature_ptr).updateValue();
+    PlayerStrength(creature_ptr).update_value();
+    PlayerIntelligence(creature_ptr).update_value();
+    PlayerWisdom(creature_ptr).update_value();
+    PlayerDextarity(creature_ptr).update_value();
+    PlayerConstitution(creature_ptr).update_value();
+    PlayerCharisma(creature_ptr).update_value();
 
     o_ptr = &creature_ptr->inventory_list[INVEN_BOW];
     if (o_ptr->k_idx) {
@@ -416,9 +416,9 @@ static void update_bonuses(player_type *creature_ptr)
         creature_ptr->to_ds[i] = calc_to_weapon_dice_side(creature_ptr, INVEN_MAIN_HAND + i);
     }
 
-    creature_ptr->pspeed = PlayerSpeed(creature_ptr).getValue();
+    creature_ptr->pspeed = PlayerSpeed(creature_ptr).get_value();
     creature_ptr->see_infra = calc_intra_vision(creature_ptr);
-    creature_ptr->skill_stl = PlayerStealth(creature_ptr).getValue();
+    creature_ptr->skill_stl = PlayerStealth(creature_ptr).get_value();
     creature_ptr->skill_dis = calc_disarming(creature_ptr);
     creature_ptr->skill_dev = calc_device_ability(creature_ptr);
     creature_ptr->skill_sav = calc_saving_throw(creature_ptr);


### PR DESCRIPTION
クラスのメンバ関数をlower_snakeで統一する。
player-status/以下のlowerCamelを使用していたメンバ関数の名称を変更した。