### PR TITLE
[Feature] 願いコマンドをwizardモード用に実装

### DIFF
--- a/src/util/string-processor.cpp
+++ b/src/util/string-processor.cpp
@@ -474,3 +474,66 @@ char *angband_strchr(concptr ptr, char ch)
 
     return NULL;
 }
+
+/*!
+ * @brief 左側の空白を除去
+ * @param p char型のポインタ
+ * @return 除去後のポインタ
+ */
+char *ltrim(char *p)
+{
+    while (p[0] == ' ')
+        p++;
+    return p;
+}
+
+/*!
+ * @brief 右側の空白を除去
+ * @param p char型のポインタ
+ * @return 除去後のポインタ
+ */
+char *rtrim(char *p)
+{
+    int i = strlen(p) - 1;
+    while (p[i] == ' ')
+        p[i--] = '\0';
+    return p;
+}
+
+/*!
+ * @brief 文字列の後方から一致するかどうか比較する
+ * @param s1 比較元文字列ポインタ
+ * @param s2 比較先文字列ポインタ
+ * @param len 比較する長さ
+ * @return 等しい場合は0、p1が大きい場合は-1、p2が大きい場合は1
+ * @detail
+ * strncmpの後方から比較する版
+ */
+int strrncmp(const char *s1, const char *s2, int len)
+{
+    int i;
+    int l1 = strlen(s1);
+    int l2 = strlen(s2);
+
+    for (i = 1; i <= len; i++) {
+        int p1 = l1 - i;
+        int p2 = l2 - i;
+
+        if (l1 != l2) {
+            if (p1 < 0)
+                return (-1);
+            if (p2 < 0)
+                return (1);
+        } else {
+            if (p1 < 0)
+                return (0);
+        }
+
+        if (s1[p1] < s2[p2])
+            return (-1);
+        if (s1[p1] > s2[p2])
+            return (-1);
+    }
+
+    return (0);
+}

--- a/src/util/string-processor.h
+++ b/src/util/string-processor.h
@@ -23,3 +23,6 @@ size_t angband_strcpy(char *buf, concptr src, size_t bufsize);
 size_t angband_strcat(char *buf, concptr src, size_t bufsize);
 char *angband_strstr(concptr haystack, concptr needle);
 char *angband_strchr(concptr ptr, char ch);
+char *ltrim(char *p);
+char *rtrim(char *p);
+int strrncmp(const char *s1, const char *s2, int len);

--- a/src/wizard/cmd-wizard.cpp
+++ b/src/wizard/cmd-wizard.cpp
@@ -73,6 +73,7 @@ std::vector<std::vector<std::string>> debug_menu_table = {
     { "u", _("啓蒙(忍者以外)", "Wiz-lite all floor except Ninja") },
     { "v", _("特別品獲得ドロップ", "Drop special object") },
     { "w", _("啓蒙(忍者配慮)", "Wiz-lite all floor") },
+    { "W", _("願い", "Wishing") },
     { "x", _("経験値を得る(指定可)", "Get experience") },
     { "X", _("所持品を初期状態に戻す", "Return inventory to initial") },
     { "z", _("近隣のモンスター消去", "Terminate near monsters") },
@@ -235,6 +236,9 @@ bool exe_cmd_debug(player_type *creature_ptr, char cmd)
         break;
     case 'w':
         wiz_lite(creature_ptr, (bool)(creature_ptr->pclass == CLASS_NINJA));
+        break;
+    case 'W':
+        do_cmd_wishing(creature_ptr, -1, TRUE, TRUE, TRUE);
         break;
     case 'x':
         gain_exp(creature_ptr, command_arg ? command_arg : (creature_ptr->exp + 1));

--- a/src/wizard/wizard-item-modifier.h
+++ b/src/wizard/wizard-item-modifier.h
@@ -2,4 +2,7 @@
 
 #include "system/angband.h"
 
+enum class WishResult { FAIL = -1, NOTHING = 0, NORMAL = 1, EGO = 2, ARTIFACT = 3, MAX };
+
 void wiz_modify_item(player_type *creature_ptr);
+WishResult do_cmd_wishing(player_type *caster_ptr, int prob, bool art_ok, bool ego_ok, bool confirm);


### PR DESCRIPTION
Issueなし。
★のIDを探すのが大変なことがあるので、文字列で願えるコマンドを追加。
マッチする例:
・リンギル
・★リンギル
・『リンギル』
・ロング・ソード『リンギル』
・ガラドリエル
・ガラドリエルの
・ガラドリエルの玻璃瓶
・玻璃瓶 (ベースがINSTA_ART)