### PR TITLE
[Fix] キャラクタメイク時の経験値修正に職業の修正が入っていない #554

### DIFF
--- a/src/birth/birth-stat.cpp
+++ b/src/birth/birth-stat.cpp
@@ -86,18 +86,29 @@ void get_stats(player_type* creature_ptr)
 }
 
 /*!
+ * @brief 経験値修正の合計値を計算
+ * @return なし
+ */
+u16b get_expfact(player_type *creature_ptr)
+{
+    u16b expfact = rp_ptr->r_exp;
+
+    if (creature_ptr->prace != RACE_ANDROID)
+        expfact += cp_ptr->c_exp;
+    if (((creature_ptr->pclass == CLASS_MONK) || (creature_ptr->pclass == CLASS_FORCETRAINER) || (creature_ptr->pclass == CLASS_NINJA))
+        && ((creature_ptr->prace == RACE_KLACKON) || (creature_ptr->prace == RACE_SPRITE)))
+        expfact -= 15;
+
+    return expfact;
+}
+
+/*!
  * @brief その他「オートローラ中は算出の対象にしない」副次ステータスを処理する / Roll for some info that the auto-roller ignores
  * @return なし
  */
 void get_extra(player_type* creature_ptr, bool roll_hitdie)
 {
-    if (creature_ptr->prace == RACE_ANDROID)
-        creature_ptr->expfact = rp_ptr->r_exp;
-    else
-        creature_ptr->expfact = rp_ptr->r_exp + cp_ptr->c_exp;
-
-    if (((creature_ptr->pclass == CLASS_MONK) || (creature_ptr->pclass == CLASS_FORCETRAINER) || (creature_ptr->pclass == CLASS_NINJA)) && ((creature_ptr->prace == RACE_KLACKON) || (creature_ptr->prace == RACE_SPRITE)))
-        creature_ptr->expfact -= 15;
+    creature_ptr->expfact = get_expfact(creature_ptr);
 
     /* Reset record of race/realm changes */
     creature_ptr->start_race = creature_ptr->prace;

--- a/src/birth/birth-stat.h
+++ b/src/birth/birth-stat.h
@@ -4,6 +4,7 @@
 
 int adjust_stat(int value, int amount);
 void get_stats(player_type* creature_ptr);
-void get_extra(player_type* creature_ptr, bool roll_hitdie);
+u16b get_expfact(player_type *creature_ptr);
+void get_extra(player_type *creature_ptr, bool roll_hitdie);
 
 void get_max_stats(player_type* creature_ptr);

--- a/src/birth/birth-wizard.cpp
+++ b/src/birth/birth-wizard.cpp
@@ -267,6 +267,7 @@ static bool let_player_build_character(player_type *creature_ptr)
 
 static void display_initial_options(player_type *creature_ptr)
 {
+    u16b expfact = get_expfact(creature_ptr) - 100;
     s16b adj[A_MAX];
     for (int i = 0; i < A_MAX; i++) {
         adj[i] = rp_ptr->r_adj[i] + cp_ptr->c_adj[i] + ap_ptr->a_adj[i];
@@ -276,7 +277,7 @@ static void display_initial_options(player_type *creature_ptr)
     put_str("                                   ", 3, 40);
     put_str(_("修正の合計値", "Your total modification"), 3, 40);
     put_str(_("腕力 知能 賢さ 器用 耐久 魅力 経験 ", "Str  Int  Wis  Dex  Con  Chr   EXP "), 4, 40);
-    sprintf(buf, "%+3d  %+3d  %+3d  %+3d  %+3d  %+3d %+4d%% ", adj[0], adj[1], adj[2], adj[3], adj[4], adj[5], cp_ptr->c_exp);
+    sprintf(buf, "%+3d  %+3d  %+3d  %+3d  %+3d  %+3d %+4d%% ", adj[0], adj[1], adj[2], adj[3], adj[4], adj[5], expfact);
     c_put_str(TERM_L_BLUE, buf, 5, 40);
 
     put_str("HD ", 6, 40);


### PR DESCRIPTION
アンドロイド、妖精、クラッコン考慮済み。