### PR TITLE
[fix] キャラクタ作成時のメモリリークの可能性

### DIFF
--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -50,7 +50,7 @@ void player_wipe_without_name(player_type *creature_ptr)
         string_free(creature_ptr->last_message);
 
     if (creature_ptr->inventory_list != NULL)
-        C_WIPE(creature_ptr->inventory_list, INVEN_TOTAL, object_type);
+        C_KILL(creature_ptr->inventory_list, INVEN_TOTAL, object_type);
 
     (void)WIPE(creature_ptr, player_type);
 
@@ -218,7 +218,7 @@ void init_dungeon_quests(player_type *creature_ptr)
  * @param creature_ptr プレーヤーへの参照ポインタ
  * @return なし
  * @details アンデッド系種族は開始時刻を夜からにする / Undead start just sunset
- * @details        
+ * @details
  */
 void init_turn(player_type *creature_ptr)
 {

--- a/src/load/inventory-loader.cpp
+++ b/src/load/inventory-loader.cpp
@@ -25,7 +25,7 @@ static errr rd_inventory(player_type *player_ptr)
     player_ptr->equip_cnt = 0;
 
     if (player_ptr->inventory_list != NULL)
-        C_WIPE(player_ptr->inventory_list, INVEN_TOTAL, object_type);
+        C_KILL(player_ptr->inventory_list, INVEN_TOTAL, object_type);
     C_MAKE(player_ptr->inventory_list, INVEN_TOTAL, object_type);
 
     int slot = 0;


### PR DESCRIPTION
キャラクタの作成を途中でやりなおした時、
C_KILLを呼ぶべき箇所で誤ってC_WIPEを呼んでおり、直後に
C_MAKEでポインタを上書きしているため以前に確保した
領域が解放されておらずメモリリークが発生している。
正しくC_KILLを呼ぶようにする。

軽微なのでPRのみ。
ちなみにキャラクタ作成時に最初からを繰り返すことで無限にメモリリークを発生させることができます。
