### PR TITLE
[feature] 各種構造体のPOD型としての扱いをやめる #564

### DIFF
--- a/src/autopick/autopick-util.cpp
+++ b/src/autopick/autopick-util.cpp
@@ -46,7 +46,7 @@ void free_text_lines(concptr *lines_list)
 	}
 
 	/* free list of pointers */
-	C_FREE((vptr)lines_list, MAX_LINES, concptr);
+	C_FREE(lines_list, MAX_LINES, concptr);
 }
 
 

--- a/src/main/game-data-initializer.cpp
+++ b/src/main/game-data-initializer.cpp
@@ -103,10 +103,10 @@ errr init_other(player_type *player_ptr)
 errr init_object_alloc(void)
 {
     s16b aux[MAX_DEPTH];
-    (void)C_WIPE(&aux, MAX_DEPTH, s16b);
+    (void)C_WIPE(aux, MAX_DEPTH, s16b);
 
     s16b num[MAX_DEPTH];
-    (void)C_WIPE(&num, MAX_DEPTH, s16b);
+    (void)C_WIPE(num, MAX_DEPTH, s16b);
 
     if (alloc_kind_table)
         C_KILL(alloc_kind_table, alloc_kind_size, alloc_entry);

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -236,7 +236,8 @@ static errr init_info(player_type *player_ptr, concptr filename, angband_header 
         (void)fd_close(fd);
     }
 
-    C_KILL(head->info_ptr, head->info_size, char);
+    C_FREE(static_cast<char *>(head->info_ptr), head->info_size, char);
+    head->info_ptr = nullptr;
     if (name)
         C_KILL(head->name_ptr, FAKE_NAME_SIZE, char);
 

--- a/src/term/z-virt.h
+++ b/src/term/z-virt.h
@@ -41,101 +41,67 @@
  * in particular, that it returns its first argument.
  */
 
-
-
 /**** Available macros ****/
 
-
 /* Size of 'N' things of type 'T' */
-#define C_SIZE(N,T) \
-	((huge)((N)*(sizeof(T))))
+#define C_SIZE(N, T) ((huge)((N) * (sizeof(T))))
 
 /* Size of one thing of type 'T' */
-#define SIZE(T) \
-	((huge)(sizeof(T)))
-
+#define SIZE(T) ((huge)(sizeof(T)))
 
 /* Compare two arrays of type T[N], at locations P1 and P2 */
-#define C_DIFF(P1,P2,N,T) \
-	(memcmp((char*)(P1),(char*)(P2),C_SIZE(N,T)))
+#define C_DIFF(P1, P2, N, T) (memcmp((char *)(P1), (char *)(P2), C_SIZE(N, T)))
 
 /* Compare two things of type T, at locations P1 and P2 */
-#define DIFF(P1,P2,T) \
-	(memcmp((char*)(P1),(char*)(P2),SIZE(T)))
-
+#define DIFF(P1, P2, T) (memcmp((char *)(P1), (char *)(P2), SIZE(T)))
 
 /* Set every byte in an array of type T[N], at location P, to V, and return P */
-#define C_BSET(P,V,N,T) \
-	(T*)(memset((char*)(P),(V),C_SIZE(N,T)))
+#define C_BSET(P, V, N, T) (T *)(memset((char *)(P), (V), C_SIZE(N, T)))
 
 /* Set every byte in a thing of type T, at location P, to V, and return P */
-#define BSET(P,V,T) \
-	(T*)(memset((char*)(P),(V),SIZE(T)))
-
+#define BSET(P, V, T) (T *)(memset((char *)(P), (V), SIZE(T)))
 
 /* Wipe an array of type T[N], at location P, and return P */
-#define C_WIPE(P,N,T) \
-	(T*)(memset((char*)(P),0,C_SIZE(N,T)))
+#define C_WIPE(P, N, T) (T *)(memset((char *)(P), 0, C_SIZE(N, T)))
 
 /* Wipe a thing of type T, at location P, and return P */
-#define WIPE(P,T) \
-	(T*)(memset((char*)(P),0,SIZE(T)))
-
+#define WIPE(P, T) (T *)(memset((char *)(P), 0, SIZE(T)))
 
 /* Load an array of type T[N], at location P1, from another, at location P2 */
-#define C_COPY(P1,P2,N,T) \
-	(T*)(memcpy((char*)(P1),(char*)(P2),C_SIZE(N,T)))
+#define C_COPY(P1, P2, N, T) (T *)(memcpy((char *)(P1), (char *)(P2), C_SIZE(N, T)))
 
 /* Load a thing of type T, at location P1, from another, at location P2 */
-#define COPY(P1,P2,T) \
-	(T*)(memcpy((char*)(P1),(char*)(P2),SIZE(T)))
-
+#define COPY(P1, P2, T) (T *)(memcpy((char *)(P1), (char *)(P2), SIZE(T)))
 
 /* Free an array of N things of type T at P, return NULL */
-#define C_FREE(P,N,T) \
-	(T*)(rnfree(P,C_SIZE(N,T)))
+#define C_FREE(P, N, T) (T *)(rnfree(P, C_SIZE(N, T)))
 
 /* Free one thing of type T at P, return NULL */
-#define FREE(P,T) \
-	(T*)(rnfree(P,SIZE(T)))
-
+#define FREE(P, T) (T *)(rnfree(P, SIZE(T)))
 
 /* Allocate, and return, an array of type T[N] */
-#define C_RNEW(N,T) \
-	((T*)(ralloc(C_SIZE(N,T))))
+#define C_RNEW(N, T) ((T *)(ralloc(C_SIZE(N, T))))
 
 /* Allocate, and return, a thing of type T */
-#define RNEW(T) \
-	((T*)(ralloc(SIZE(T))))
-
+#define RNEW(T) ((T *)(ralloc(SIZE(T))))
 
 /* Allocate, wipe, and return an array of type T[N] */
-#define C_ZNEW(N,T) \
-	((T*)(C_WIPE(C_RNEW(N,T),N,T)))
+#define C_ZNEW(N, T) ((T *)(C_WIPE(C_RNEW(N, T), N, T)))
 
 /* Allocate, wipe, and return a thing of type T */
-#define ZNEW(T) \
-	((T*)(WIPE(RNEW(T),T)))
-
+#define ZNEW(T) ((T *)(WIPE(RNEW(T), T)))
 
 /* Allocate a wiped array of type T[N], assign to pointer P */
-#define C_MAKE(P,N,T) \
-	((P)=C_ZNEW(N,T))
+#define C_MAKE(P, N, T) ((P) = C_ZNEW(N, T))
 
 /* Allocate a wiped thing of type T, assign to pointer P */
-#define MAKE(P,T) \
-	((P)=ZNEW(T))
-
+#define MAKE(P, T) ((P) = ZNEW(T))
 
 /* Free an array of type T[N], at location P, and set P to NULL */
-#define C_KILL(P,N,T) \
-	((P)=C_FREE(P,N,T))
+#define C_KILL(P, N, T) ((P) = C_FREE(P, N, T))
 
 /* Free a thing of type T, at location P, and set P to NULL */
-#define KILL(P,T) \
-	((P)=FREE(P,T))
-
-
+#define KILL(P, T) ((P) = FREE(P, T))
 
 /**** Available variables ****/
 
@@ -147,7 +113,6 @@ extern vptr (*rpanic_aux)(huge);
 
 /* Replacement hook for "ralloc()" */
 extern vptr (*ralloc_aux)(huge);
-
 
 /**** Available functions ****/
 
@@ -166,10 +131,4 @@ extern concptr string_make(concptr str);
 /* Free a string allocated with "string_make()" */
 extern errr string_free(concptr str);
 
-
-
-
 #endif
-
-
-


### PR DESCRIPTION
コード修正量が少なくて済むよう、z-virt.h で定義されているメモリ操作系マクロで呼ばれる最終的な実装を修正する。
修正方法は #564 に従う。
但し、全ての構造体の定義で初期値を与えるようにするのは手間がかかるので、SFINAEによりトリビアルコピーが可能かどうかで分岐し、トリビアルコピーが可能であればmemsetでのゼロクリアやmemcpyでのコピーを行う。
したがって、std::vectorやstd::string等、トリビアルコピーが不可能なクラスオブジェクトを持たせない構造体は初期値を与える必要はなく現状のままの定義で使用できる。

とりあえず現時点では既存の構造体の定義はいじっていないので、malloc/freeがnew/deleteになる以外に動作が変わる所はないはず。