### PR TITLE
[fix] 構造体のゼロクリアの条件

### DIFF
--- a/src/term/z-virt.h
+++ b/src/term/z-virt.h
@@ -47,20 +47,20 @@
 // データクリアマクロ WIPE/C_WIPE の実装
 //
 
-// トリビアルコピーが可能な型は memset でゼロクリアする
-template <typename T, std::enable_if_t<std::is_trivially_copyable_v<T>, std::nullptr_t> = nullptr>
+// トリビアル型は memset でゼロクリアする
+template <typename T, std::enable_if_t<std::is_trivial_v<T>, std::nullptr_t> = nullptr>
 inline T *c_wipe_impl(T *p, size_t n)
 {
     return static_cast<T *>(memset(p, 0, sizeof(T) * n));
 }
-template <typename T, std::enable_if_t<std::is_trivially_copyable_v<T>, std::nullptr_t> = nullptr>
+template <typename T, std::enable_if_t<std::is_trivial_v<T>, std::nullptr_t> = nullptr>
 inline T *wipe_impl(T *p)
 {
     return static_cast<T *>(memset(p, 0, sizeof(T)));
 }
 
-// トリビアルコピーが不可能な型はデフォルトコンストラクタで生成したオブジェクトをコピーする
-template <typename T, std::enable_if_t<!std::is_trivially_copyable_v<T>, std::nullptr_t> = nullptr>
+// 非トリビアル型はデフォルトコンストラクタで生成したオブジェクトをコピーする
+template <typename T, std::enable_if_t<!std::is_trivial_v<T>, std::nullptr_t> = nullptr>
 inline T *c_wipe_impl(T *p, size_t n)
 {
     T obj{};
@@ -69,7 +69,7 @@ inline T *c_wipe_impl(T *p, size_t n)
     }
     return p;
 }
-template <typename T, std::enable_if_t<!std::is_trivially_copyable_v<T>, std::nullptr_t> = nullptr>
+template <typename T, std::enable_if_t<!std::is_trivial_v<T>, std::nullptr_t> = nullptr>
 inline T *wipe_impl(T *p)
 {
     *p = T{};


### PR DESCRIPTION
std::is_trivial_v が false かつ std::is_trivially_copyable_v
が true の型に memset してゼロクリアしようとするとgccが
警告を発するので、memsetでのクリアを行うのは std::is_trivial_v
が true の型に条件を狭める。

## 経緯

POD型の扱いを改めたうえで、いざFlagGroupを入れようとすると、gccが以下の警告を出した。

>./term/z-virt.h:59:35: error: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct player_type’; use assignment or value-initialization instead [-Werror=class-memaccess]
>   59 |     return static_cast<T *>(memset(p, 0, sizeof(T)));
>      |                             ~~~~~~^~~~~~~~~~~~~~~~~

FlagGroupクラスはtrivially_copyableな型である条件を満たしているので、それを導入したplayer_typeクラスもtrivially_copyableだが、memsetによるゼロクリアが警告となる。
trivially_copyable な型であればmemsetによるゼロクリア可能と認識していたが、 trivial型でないとmemsetによるゼロクリアは無理なのかもしれない。（少なくともGCCに警告を出される。）
memcpyに関しては trivially_copyable であれば警告は出ないようなので、実際に trivial型でないとまずいのかもしれない。
いずれにしても警告に対処するために、ゼロクリアできる条件を狭めて構造体がトリビアル型である時( std::is_trivial_v が true)のみにする。