### PR TITLE
[Fix] キー定義のないマクロ定義を読み込んで誤爆登録する #418

### DIFF
--- a/src/cmd-io/macro-util.cpp
+++ b/src/cmd-io/macro-util.cpp
@@ -122,6 +122,8 @@ errr macro_add(concptr pat, concptr act)
 {
     if (!pat || !act)
         return -1;
+    if (strlen(pat) == 0 || strlen(act) == 0)
+        return -1;
 
     int n = macro_find_exact(pat);
     if (n >= 0) {

--- a/src/io/interpret-pref-file.cpp
+++ b/src/io/interpret-pref-file.cpp
@@ -226,8 +226,7 @@ static errr interpret_p_token(char *buf)
 {
 	char tmp[1024];
 	text_to_ascii(tmp, buf + 2);
-	macro_add(tmp, macro__buf);
-	return 0;
+	return macro_add(tmp, macro__buf);
 }
 
 


### PR DESCRIPTION
無限実行されたりなどおかしくなっていた。