### PR TITLE
[English] make two minor changes to messages

### DIFF
--- a/src/cmd-io/cmd-lore.cpp
+++ b/src/cmd-io/cmd-lore.cpp
@@ -79,7 +79,7 @@ void do_cmd_query_symbol(player_type *creature_ptr)
             temp[0] = 0;
             return;
         }
-        sprintf(buf, _("名前:%sにマッチ", "Monsters with a name \"%s\""), temp);
+        sprintf(buf, _("名前:%sにマッチ", "Monsters' names with \"%s\""), temp);
     } else if (ident_info[i]) {
         sprintf(buf, "%c - %s.", sym, ident_info[i] + 2);
     } else {

--- a/src/object-activation/activation-switcher.cpp
+++ b/src/object-activation/activation-switcher.cpp
@@ -221,7 +221,7 @@ bool switch_activation(player_type *user_ptr, object_type **o_ptr_ptr, const act
         true_healing(user_ptr, 0);
         return TRUE;
     case ACT_CURE_MANA_FULL:
-        msg_format(_("%sが青白く光った．．．", "The %s glows pale..."), name);
+        msg_format(_("%sが青白く光った．．．", "The %s glows palely..."), name);
         restore_mana(user_ptr, TRUE);
         return TRUE;
     case ACT_ESP:


### PR DESCRIPTION
- In src/cmd-io/cmd-lore.cpp, change header label for the monster list selected by matching a substring so it is the same as what's used in src/market/building-monster.cpp.
- In src/object-activation/activation-switcher.c, change an adjective to an adverb for the ACT_CURE_MANA_FULL message.  The Japanese activation message uses the same message as the mana ball activation, but the English messages differ (mana ball uses "becomes pale"; this one is "glows palely").