### PR TITLE
[Fix] fresh_onceオプション使用時、マクロ使用直後にサブウィンドウが更新されない

### DIFF
--- a/src/io/input-key-acceptor.cpp
+++ b/src/io/input-key-acceptor.cpp
@@ -413,3 +413,27 @@ void start_term_fresh(void)
             angband_term[j]->never_fresh = FALSE;
     }
 }
+
+/*!
+ * @brief マクロ実行中かの判定関数
+ * @return 実行中であればtrue
+ */
+bool macro_running(void)
+{
+    /* マクロ展開中のみ詳細に判定する */
+    if (parse_macro) {
+        int diff = angband_term[0]->key_head - angband_term[0]->key_tail;
+
+        /* 最終入力を展開した直後はdiff==1となる */
+        if (diff != 1)
+            return true;
+
+        /* 最終入力の処理中はまだtrueを返す */
+        if (inkey_next && *inkey_next && !inkey_xtra)
+            return true;
+
+        return false;
+    }
+
+    return false;
+}

--- a/src/io/input-key-acceptor.h
+++ b/src/io/input-key-acceptor.h
@@ -31,3 +31,4 @@ char inkey(void);
 int inkey_special(bool numpad_cursor);
 void start_term_fresh(void);
 void stop_term_fresh(void);
+bool macro_running(void);

--- a/src/term/z-term.cpp
+++ b/src/term/z-term.cpp
@@ -1021,12 +1021,6 @@ static void term_fresh_row_text(TERM_LEN y, TERM_LEN x1, TERM_LEN x2)
     }
 }
 
-bool macro_running(void)
-{
-    int diff = angband_term[0]->key_head - angband_term[0]->key_tail;
-    return diff != 0;
-}
-
 /*
  * @brief Actually perform all requested changes to the window
  */

--- a/src/term/z-term.h
+++ b/src/term/z-term.h
@@ -145,7 +145,6 @@ errr term_xtra(int n, int v);
 void term_queue_char(TERM_LEN x, TERM_LEN y, TERM_COLOR a, char c, TERM_COLOR ta, char tc);
 void term_queue_bigchar(TERM_LEN x, TERM_LEN y, TERM_COLOR a, char c, TERM_COLOR ta, char tc);
 void term_queue_line(TERM_LEN x, TERM_LEN y, int n, TERM_COLOR *a, char *c, TERM_COLOR *ta, char *tc);
-bool macro_running(void);
 
 errr term_fresh(void);
 errr term_fresh_force(void);


### PR DESCRIPTION
macro_running()の判定に一部漏れがあった。
判定関数をinput-key-acceptor.cppに移して修正した。