### PR TITLE
[Fix] MCIコマンド処理修正

### DIFF
--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -2571,7 +2571,7 @@ LRESULT PASCAL AngbandWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam
         break;
     }
     case WM_CREATE: {
-        mop.dwCallback = (DWORD)hWnd;
+        setup_mci(hWnd);
         return 0;
     }
     case WM_GETMINMAXINFO: {
@@ -2602,10 +2602,7 @@ LRESULT PASCAL AngbandWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam
         return 0;
     }
     case MM_MCINOTIFY: {
-        if (wParam == MCI_NOTIFY_SUCCESSFUL) {
-            mciSendCommand(mop.wDeviceID, MCI_SEEK, MCI_SEEK_TO_START, 0);
-            mciSendCommand(mop.wDeviceID, MCI_PLAY, MCI_NOTIFY, (DWORD)&mop);
-        }
+        main_win_music::on_mci_notify(wParam, lParam);
 
         return 0;
     }

--- a/src/main-win/main-win-mci.cpp
+++ b/src/main-win/main-win-mci.cpp
@@ -5,5 +5,14 @@
 
 #include "main-win/main-win-mci.h"
 
-MCI_OPEN_PARMS mop;
+MCI_OPEN_PARMS mci_open_parms;
+MCI_PLAY_PARMS mci_play_parms;
 char mci_device_type[MCI_DEVICE_TYPE_MAX_LENGTH];
+
+/*!
+ * @brief MCI用設定の初期化
+ * @param hWnd MCIコマンドのコールバックウインドウ
+ */
+void setup_mci(HWND hWnd) {
+    mci_play_parms.dwCallback = (DWORD)hWnd;
+}

--- a/src/main-win/main-win-mci.cpp
+++ b/src/main-win/main-win-mci.cpp
@@ -14,5 +14,6 @@ char mci_device_type[MCI_DEVICE_TYPE_MAX_LENGTH];
  * @param hWnd MCIコマンドのコールバックウインドウ
  */
 void setup_mci(HWND hWnd) {
+    mci_open_parms.dwCallback = (DWORD)hWnd;
     mci_play_parms.dwCallback = (DWORD)hWnd;
 }

--- a/src/main-win/main-win-mci.h
+++ b/src/main-win/main-win-mci.h
@@ -4,6 +4,9 @@
 
 #include <mciapi.h>
 
-extern MCI_OPEN_PARMS mop;
+extern MCI_OPEN_PARMS mci_open_parms;
+extern MCI_PLAY_PARMS mci_play_parms;
 #define MCI_DEVICE_TYPE_MAX_LENGTH 256
 extern char mci_device_type[MCI_DEVICE_TYPE_MAX_LENGTH];
+
+void setup_mci(HWND hWnd);

--- a/src/main-win/main-win-music.cpp
+++ b/src/main-win/main-win-music.cpp
@@ -20,6 +20,7 @@ concptr quest_music_file[1000][SAMPLE_MUSIC_MAX];
 
 static int current_music_type = TERM_XTRA_MUSIC_MUTE;
 static int current_music_id = 0;
+// current filename being played 
 static char current_music_path[MAIN_WIN_MAX_PATH];
 
 /*
@@ -93,8 +94,8 @@ void load_music_prefs(DUNGEON_IDX max_d_idx, QUEST_IDX max_q_idx)
  */
 void stop_music(void)
 {
-    mciSendCommand(mop.wDeviceID, MCI_STOP, 0, 0);
-    mciSendCommand(mop.wDeviceID, MCI_CLOSE, 0, 0);
+    mciSendCommand(mci_open_parms.wDeviceID, MCI_STOP, 0, 0);
+    mciSendCommand(mci_open_parms.wDeviceID, MCI_CLOSE, 0, 0);
     current_music_type = TERM_XTRA_MUSIC_MUTE;
     current_music_id = 0;
     strcpy(current_music_path, "\0");
@@ -169,13 +170,25 @@ errr play_music(int type, int val)
     current_music_id = val;
     strcpy(current_music_path, buf);
 
-    mop.lpstrDeviceType = mci_device_type;
-    mop.lpstrElementName = buf;
-    mciSendCommand(mop.wDeviceID, MCI_STOP, 0, 0);
-    mciSendCommand(mop.wDeviceID, MCI_CLOSE, 0, 0);
-    mciSendCommand(mop.wDeviceID, MCI_OPEN, MCI_OPEN_TYPE | MCI_OPEN_ELEMENT, (DWORD)&mop);
-    mciSendCommand(mop.wDeviceID, MCI_SEEK, MCI_SEEK_TO_START, 0);
-    mciSendCommand(mop.wDeviceID, MCI_PLAY, MCI_NOTIFY, (DWORD)&mop);
+    mci_open_parms.lpstrDeviceType = mci_device_type;
+    mci_open_parms.lpstrElementName = buf;
+    mciSendCommand(mci_open_parms.wDeviceID, MCI_STOP, 0, 0);
+    mciSendCommand(mci_open_parms.wDeviceID, MCI_CLOSE, 0, 0);
+    mciSendCommand(mci_open_parms.wDeviceID, MCI_OPEN, MCI_OPEN_TYPE | MCI_OPEN_ELEMENT, (DWORD)&mci_open_parms);
+    mciSendCommand(mci_open_parms.wDeviceID, MCI_SEEK, MCI_SEEK_TO_START, 0);
+    mciSendCommand(mci_open_parms.wDeviceID, MCI_PLAY, MCI_NOTIFY, (DWORD)&mci_play_parms);
     return 0;
 }
+
+/*
+ * Notify event
+ */
+void on_mci_notify(WPARAM wFlags, LONG lDevID) {
+    if (wFlags == MCI_NOTIFY_SUCCESSFUL) {
+        // repeat play a music
+        mciSendCommand(mci_open_parms.wDeviceID, MCI_SEEK, MCI_SEEK_TO_START, 0);
+        mciSendCommand(mci_open_parms.wDeviceID, MCI_PLAY, MCI_NOTIFY, (DWORD)&mci_play_parms);
+    }
+}
+
 }

--- a/src/main-win/main-win-music.cpp
+++ b/src/main-win/main-win-music.cpp
@@ -94,8 +94,8 @@ void load_music_prefs(DUNGEON_IDX max_d_idx, QUEST_IDX max_q_idx)
  */
 void stop_music(void)
 {
-    mciSendCommand(mci_open_parms.wDeviceID, MCI_STOP, 0, 0);
-    mciSendCommand(mci_open_parms.wDeviceID, MCI_CLOSE, 0, 0);
+    mciSendCommand(mci_open_parms.wDeviceID, MCI_STOP, MCI_WAIT, 0);
+    mciSendCommand(mci_open_parms.wDeviceID, MCI_CLOSE, MCI_WAIT, 0);
     current_music_type = TERM_XTRA_MUSIC_MUTE;
     current_music_id = 0;
     strcpy(current_music_path, "\0");
@@ -172,11 +172,10 @@ errr play_music(int type, int val)
 
     mci_open_parms.lpstrDeviceType = mci_device_type;
     mci_open_parms.lpstrElementName = buf;
-    mciSendCommand(mci_open_parms.wDeviceID, MCI_STOP, 0, 0);
-    mciSendCommand(mci_open_parms.wDeviceID, MCI_CLOSE, 0, 0);
-    mciSendCommand(mci_open_parms.wDeviceID, MCI_OPEN, MCI_OPEN_TYPE | MCI_OPEN_ELEMENT, (DWORD)&mci_open_parms);
-    mciSendCommand(mci_open_parms.wDeviceID, MCI_SEEK, MCI_SEEK_TO_START, 0);
-    mciSendCommand(mci_open_parms.wDeviceID, MCI_PLAY, MCI_NOTIFY, (DWORD)&mci_play_parms);
+    mciSendCommand(mci_open_parms.wDeviceID, MCI_STOP, MCI_WAIT, 0);
+    mciSendCommand(mci_open_parms.wDeviceID, MCI_CLOSE, MCI_WAIT, 0);
+    mciSendCommand(mci_open_parms.wDeviceID, MCI_OPEN, MCI_OPEN_TYPE | MCI_OPEN_ELEMENT | MCI_NOTIFY, (DWORD)&mci_open_parms);
+    // Start MCI_PLAY in the notification event after MCI_OPEN is completed
     return 0;
 }
 
@@ -185,8 +184,8 @@ errr play_music(int type, int val)
  */
 void on_mci_notify(WPARAM wFlags, LONG lDevID) {
     if (wFlags == MCI_NOTIFY_SUCCESSFUL) {
-        // repeat play a music
-        mciSendCommand(mci_open_parms.wDeviceID, MCI_SEEK, MCI_SEEK_TO_START, 0);
+        // (repeat) play a music
+        mciSendCommand(mci_open_parms.wDeviceID, MCI_SEEK, MCI_SEEK_TO_START | MCI_WAIT, 0);
         mciSendCommand(mci_open_parms.wDeviceID, MCI_PLAY, MCI_NOTIFY, (DWORD)&mci_play_parms);
     }
 }

--- a/src/main-win/main-win-music.h
+++ b/src/main-win/main-win-music.h
@@ -4,6 +4,8 @@
 
 #include "main/music-definitions-table.h"
 
+#include <windows.h>
+
 #define SAMPLE_MUSIC_MAX 16
 extern concptr music_file[MUSIC_BASIC_MAX][SAMPLE_MUSIC_MAX];
 // TODO マジックナンバー除去
@@ -16,4 +18,5 @@ namespace main_win_music {
 void load_music_prefs(DUNGEON_IDX max_d_idx, QUEST_IDX max_q_idx);
 void stop_music(void);
 errr play_music(int type, int val);
+void on_mci_notify(WPARAM wFlags, LONG lDevID);
 }


### PR DESCRIPTION
MCI_OPENとMCI_PLAYでは渡す構造体が異なるため、適切なものを渡すように修正した。
また、main-win.cppに残っていたBGM（MCI）の処理をmain-win-mci.cpp、main-win-music.cppへ移した。