### PR TITLE
[Linux/Unix] add the libcurl archive libraries for Windows to the result of "make dist"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,3 +31,8 @@ EXTRA_DIST = \
 	$(visual_studio_files)
 
 SUBDIRS = src lib
+
+# Handle some paths in Hengband/Hengband that have spaces in them and would
+# be mishandled by make/automake.
+dist-hook:
+	(cd $(srcdir)/Hengband/Hengband/curl && tar -cf - "x86 Debug" "x86 Release" ) | (cd $(distdir)/Hengband/Hengband/curl && tar -xf -)


### PR DESCRIPTION
Do that with a dist-hook rule rather then explicitly adding them to EXTRA_DIST to simplify handling the spaces in "x86 Debug" and "x86 Release".