### PR TITLE
[refactor] VSが出力する警告に対処

### DIFF
--- a/src/load/load-v1-5-0.cpp
+++ b/src/load/load-v1-5-0.cpp
@@ -459,7 +459,6 @@ void rd_monster_old(player_type *player_ptr, monster_type *m_ptr)
             m_ptr->mflag2.set(MFLAG2::KAGE);
         }
     } else {
-        byte tmp8u;
         rd_byte(&tmp8u);
         constexpr auto base = static_cast<int>(MFLAG2::KAGE);
         std::bitset<7> rd_bits(tmp8u);

--- a/src/load/monster-loader.cpp
+++ b/src/load/monster-loader.cpp
@@ -144,7 +144,6 @@ void rd_monster(player_type *player_ptr, monster_type *m_ptr)
 
     if (flags & SAVE_MON_MFLAG2) {
         if (loading_savefile_version_is_older_than(2)) {
-            byte tmp8u;
             rd_byte(&tmp8u);
             constexpr auto base = static_cast<int>(MFLAG2::KAGE);
             std::bitset<7> rd_bits(tmp8u);

--- a/src/monster-race/race-flags4.h
+++ b/src/monster-race/race-flags4.h
@@ -1,7 +1,7 @@
 ﻿#pragma once
 
-enum race_flags4 {
-	RF4_SHRIEK = 0x00000001, /*!< モンスター能力: 叫ぶ / Shriek for help */
+enum race_flags4 : u32b {
+    RF4_SHRIEK = 0x00000001, /*!< モンスター能力: 叫ぶ / Shriek for help */
     RF4_XXX1 = 0x00000002, /*!< モンスター能力: 未使用 / XXX */
     RF4_DISPEL = 0x00000004, /*!< モンスター能力: 魔力消去 / Dispel magic */
     RF4_ROCKET = 0x00000008, /*!< モンスター能力: ロケット / TY: Rocket */

--- a/src/player-status/player-basic-statistics.cpp
+++ b/src/player-status/player-basic-statistics.cpp
@@ -132,7 +132,7 @@ s16b PlayerBasicStatistics::set_exception_use_status(s16b value)
 void PlayerBasicStatistics::update_use_status()
 {
     int status = (int)this->status_type;
-    int use = modify_stat_value(this->owner_ptr->stat_cur[status], this->owner_ptr->stat_add[status]);
+    s16b use = modify_stat_value(this->owner_ptr->stat_cur[status], this->owner_ptr->stat_add[status]);
 
     use = this->set_exception_use_status(use);
 

--- a/src/player/player-view.cpp
+++ b/src/player/player-view.cpp
@@ -348,13 +348,13 @@ void update_view(player_type *subject_ptr)
         cave_note_and_redraw_later(floor_ptr, g_ptr, y, x);
     }
 
-    for (const auto &[y, x] : points) {
-        g_ptr = &floor_ptr->grid_array[y][x];
+    for (const auto &[py, px] : points) {
+        g_ptr = &floor_ptr->grid_array[py][px];
         g_ptr->info &= ~(CAVE_TEMP);
         if (g_ptr->info & CAVE_VIEW)
             continue;
 
-        cave_redraw_later(floor_ptr, g_ptr, y, x);
+        cave_redraw_later(floor_ptr, g_ptr, py, px);
     }
 
     subject_ptr->update |= PU_DELAY_VIS;

--- a/src/target/target-preparation.cpp
+++ b/src/target/target-preparation.cpp
@@ -170,7 +170,7 @@ void target_sensing_monsters_prepare(player_type *creature_ptr, std::vector<MONS
     if (creature_ptr->image)
         return;
 
-    for (int i = 1; i < creature_ptr->current_floor_ptr->m_max; i++) {
+    for (MONSTER_IDX i = 1; i < creature_ptr->current_floor_ptr->m_max; i++) {
         monster_type *m_ptr = &creature_ptr->current_floor_ptr->m_list[i];
         if (!monster_is_valid(m_ptr) || !m_ptr->ml || is_pet(m_ptr))
             continue;


### PR DESCRIPTION
すべて変数名の隠蔽/変数の型の不一致によるもの。