### PR TITLE
[fix] sanity_blast時にモンスターの表示位置がずれる #330

### DIFF
--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -35,6 +35,7 @@
 #include "monster/monster-util.h"
 #include "mutation/mutation-investor-remover.h"
 #include "player/attack-defense-types.h"
+#include "player/eldritch-horror.h"
 #include "player/player-skill.h"
 #include "player/special-defense-types.h"
 #include "spell-kind/spells-random.h"
@@ -327,6 +328,11 @@ void process_player(player_type *creature_ptr)
                 // 出現して即魔法を使わないようにするフラグを落とす処理
                 if (m_ptr->mflag.has(MFLAG::PREVENT_MAGIC)) {
                     m_ptr->mflag.reset(MFLAG::PREVENT_MAGIC);
+                }
+
+                if (m_ptr->mflag.has(MFLAG::SANITY_BLAST)) {
+                    m_ptr->mflag.reset(MFLAG::SANITY_BLAST);
+                    sanity_blast(creature_ptr, m_ptr, FALSE);
                 }
 
                 // 感知中のモンスターのフラグを落とす処理

--- a/src/monster/monster-flag-types.h
+++ b/src/monster/monster-flag-types.h
@@ -7,6 +7,7 @@ enum class MFLAG {
     ETF = 3, /* Monster is entering the field. */
     BORN = 4, /* Monster is still being born */
     PREVENT_MAGIC = 5, /* Monster is still being no-magic */
+    SANITY_BLAST = 6, /* Monster gives sanity blast effects to player */
     MAX,
 };
 

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -26,7 +26,6 @@
 #include "monster/monster-info.h"
 #include "monster/monster-status.h"
 #include "monster/smart-learn-types.h"
-#include "player/eldritch-horror.h"
 #include "player/player-move.h"
 #include "player/player-status-flags.h"
 #include "player/special-defense-types.h"
@@ -451,7 +450,7 @@ static void update_invisible_monster(player_type *subject_ptr, um_type *um_ptr, 
     }
 
     if (r_info[um_ptr->m_ptr->ap_r_idx].flags2 & RF2_ELDRITCH_HORROR)
-        sanity_blast(subject_ptr, um_ptr->m_ptr, FALSE);
+        um_ptr->m_ptr->mflag.set(MFLAG::SANITY_BLAST);
 
     if (disturb_near
         && (projectable(subject_ptr, um_ptr->m_ptr->fy, um_ptr->m_ptr->fx, subject_ptr->y, subject_ptr->x)


### PR DESCRIPTION
プレイヤーの移動処理が完了する前にsanity_blastの処理が行われ、
地形の表示が移動前の状態なのでモンスターの位置だけずれて
しまうのが原因。
MFLAGにSANITY_BLASTを新設し、プレイヤーの移動処理中には
フラグを立てるだけにしておき、移動完了後にsanity_blastの
処理を行うようにする。