### PR TITLE
[Refactor] main-win系処理のVS警告への対処

### DIFF
--- a/src/main-win/main-win-bg.cpp
+++ b/src/main-win/main-win-bg.cpp
@@ -8,7 +8,10 @@
 #include "system/h-define.h"
 #include "term/z-form.h"
 
+#pragma warning(push)
+#pragma warning(disable : 4458)
 #include <gdiplus.h>
+#pragma warning(pop)
 
 static HBITMAP hBG = NULL;
 char bg_bitmap_file[MAIN_WIN_MAX_PATH] = ""; //!< 現在の背景ビットマップファイル名。

--- a/src/main-win/main-win-music.cpp
+++ b/src/main-win/main-win-music.cpp
@@ -183,6 +183,8 @@ errr play_music(int type, int val)
  * Notify event
  */
 void on_mci_notify(WPARAM wFlags, LONG lDevID) {
+    UNREFERENCED_PARAMETER(lDevID);
+
     if (wFlags == MCI_NOTIFY_SUCCESSFUL) {
         // (repeat) play a music
         mciSendCommand(mci_open_parms.wDeviceID, MCI_SEEK, MCI_SEEK_TO_START | MCI_WAIT, 0);


### PR DESCRIPTION
GDI+のヘッダーから出る警告はpragma warningで抑制する。