### PR TITLE
[Refactor] ZAngbandバージョンの廃止

### DIFF
--- a/src/load/angband-version-comparer.cpp
+++ b/src/load/angband-version-comparer.cpp
@@ -36,27 +36,29 @@ bool h_older_than(byte major, byte minor, byte patch, byte extra)
 }
 
 /*!
- * @brief Zangbandのバージョン比較処理 / The above function, adapted for Zangband
- * @param x メジャーバージョン値
- * @param y マイナーバージョン値
- * @param z パッチバージョン値
+ * @brief [互換性用/新規仕様禁止]変愚蛮怒のバージョン比較処理 / The above function, adapted for Hengband
+ * @param major メジャーバージョン値
+ * @param minor マイナーバージョン値
+ * @param patch パッチバージョン値
  * @return 現在のバージョンより値が古いならtrue
+ * @detail
+ * 旧バージョン比較の互換性のためにのみ保持。
  */
-bool z_older_than(byte x, byte y, byte z)
+bool h_older_than(byte major, byte minor, byte patch)
 {
-    if (current_world_ptr->z_major < x)
+    if (current_world_ptr->h_ver_major < major)
         return TRUE;
-    if (current_world_ptr->z_major > x)
+    if (current_world_ptr->h_ver_major > major)
         return FALSE;
 
-    if (current_world_ptr->z_minor < y)
+    if (current_world_ptr->h_ver_minor < minor)
         return TRUE;
-    if (current_world_ptr->z_minor > y)
+    if (current_world_ptr->h_ver_minor > minor)
         return FALSE;
 
-    if (current_world_ptr->z_patch < z)
+    if (current_world_ptr->h_ver_patch < patch)
         return TRUE;
-    if (current_world_ptr->z_patch > z)
+    if (current_world_ptr->h_ver_patch > patch)
         return FALSE;
 
     return FALSE;

--- a/src/load/angband-version-comparer.h
+++ b/src/load/angband-version-comparer.h
@@ -3,4 +3,4 @@
 #include "system/angband.h"
 
 bool h_older_than(byte major, byte minor, byte patch, byte extra);
-bool z_older_than(byte x, byte y, byte z);
+bool h_older_than(byte major, byte minor, byte patch);

--- a/src/load/birth-loader.cpp
+++ b/src/load/birth-loader.cpp
@@ -10,7 +10,7 @@
  */
 void load_quick_start(void)
 {
-    if (z_older_than(11, 0, 13)) {
+    if (h_older_than(1, 0, 13)) {
         previous_char.quick_ok = FALSE;
         return;
     }

--- a/src/load/extra-loader.cpp
+++ b/src/load/extra-loader.cpp
@@ -19,7 +19,7 @@
  */
 void rd_extra(player_type *creature_ptr)
 {
-    if (z_older_than(10, 0, 7))
+    if (h_older_than(0, 0, 7))
         creature_ptr->riding = 0;
     else
         rd_s16b(&creature_ptr->riding);
@@ -30,12 +30,12 @@ void rd_extra(player_type *creature_ptr)
         rd_s16b(&creature_ptr->floor_id);
 
     rd_dummy_monsters(creature_ptr);
-    if (z_older_than(10, 1, 2))
+    if (h_older_than(0, 1, 2))
         current_world_ptr->play_time = 0;
     else
         rd_u32b(&current_world_ptr->play_time);
 
     rd_visited_towns(creature_ptr);
-    if (!z_older_than(11, 0, 5))
+    if (!h_older_than(1, 0, 5))
         rd_u32b(&creature_ptr->count);
 }

--- a/src/load/info-loader.cpp
+++ b/src/load/info-loader.cpp
@@ -4,12 +4,22 @@
 #include "load/load-util.h"
 #include "load/option-loader.h"
 #include "system/angband.h"
+#include "system/angband-version.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 
+/*!
+ * @brief セーブファイルからバージョン情報及びセーブ情報を取得する
+ * @details
+ * バージョン0.x.x時代のバージョン情報である場合、サポート対象外
+ * (FAKE_VERもH_VERも10台の数字のはず)
+ */
 void rd_version_info(void)
 {
-    strip_bytes(4);
+    byte fake_major;
+    rd_byte(&fake_major);
+
+    strip_bytes(3);
     load_xor_byte = current_world_ptr->sf_extra;
     v_check = 0L;
     x_check = 0L;
@@ -27,9 +37,13 @@ void rd_version_info(void)
 
     rd_u32b(&loading_savefile_version);
 
-    load_note(format(_("バージョン %d.%d.%d.%d のセーブデータ(SAVE%lu形式)をロード中...", "Loading a Verison %d.%d.%d.%d savefile (SAVE%lu format)..."),
-        (current_world_ptr->h_ver_major > 9) ? current_world_ptr->h_ver_major - 10 : current_world_ptr->h_ver_major, current_world_ptr->h_ver_minor,
-        current_world_ptr->h_ver_patch, current_world_ptr->h_ver_extra, loading_savefile_version));
+    /* h_ver_majorがfake_ver_majorと同じだったころへの対策 */
+    if (fake_major - current_world_ptr->h_ver_major < FAKE_VER_PLUS)
+        current_world_ptr->h_ver_major -= FAKE_VER_PLUS;
+
+    load_note(format(_("バージョン %d.%d.%d のセーブデータ(SAVE%lu形式)をロード中...", "Loading a Verison %d.%d.%d savefile (SAVE%lu format)..."),
+        current_world_ptr->h_ver_major, current_world_ptr->h_ver_minor, current_world_ptr->h_ver_patch,
+        loading_savefile_version));
 }
 
 /*!

--- a/src/load/load-v1-5-0.cpp
+++ b/src/load/load-v1-5-0.cpp
@@ -72,7 +72,7 @@ void rd_item_old(player_type *player_ptr, object_type *o_ptr)
     rd_byte(&tmp8u);
     o_ptr->sval = tmp8u;
 
-    if (z_older_than(10, 4, 4)) {
+    if (h_older_than(0, 4, 4)) {
         if (o_ptr->tval == 100)
             o_ptr->tval = TV_GOLD;
         if (o_ptr->tval == 98)
@@ -124,7 +124,7 @@ void rd_item_old(player_type *player_ptr, object_type *o_ptr)
             add_flag(o_ptr->art_flags, TR_TELEPATHY);
     }
 
-    if (z_older_than(11, 0, 11)) {
+    if (h_older_than(1, 0, 11)) {
         o_ptr->curse_flags = 0L;
         if (o_ptr->ident & 0x40) {
             o_ptr->curse_flags |= TRC_CURSED;
@@ -156,7 +156,7 @@ void rd_item_old(player_type *player_ptr, object_type *o_ptr)
     rd_byte(&tmp8u);
     o_ptr->xtra2 = tmp8u;
 
-    if (z_older_than(11, 0, 10)) {
+    if (h_older_than(1, 0, 10)) {
         if (o_ptr->xtra1 == EGO_XTRA_SUSTAIN) {
             switch (o_ptr->xtra2 % 6) {
             case 0:
@@ -248,7 +248,7 @@ void rd_item_old(player_type *player_ptr, object_type *o_ptr)
         o_ptr->xtra1 = 0;
     }
 
-    if (z_older_than(10, 2, 3)) {
+    if (h_older_than(0, 2, 3)) {
         o_ptr->xtra3 = 0;
         o_ptr->xtra4 = 0;
         o_ptr->xtra5 = 0;
@@ -277,7 +277,7 @@ void rd_item_old(player_type *player_ptr, object_type *o_ptr)
         rd_s16b(&o_ptr->xtra5);
     }
 
-    if (z_older_than(11, 0, 5)
+    if (h_older_than(1, 0, 5)
         && (((o_ptr->tval == TV_LITE) && ((o_ptr->sval == SV_LITE_TORCH) || (o_ptr->sval == SV_LITE_LANTERN))) || (o_ptr->tval == TV_FLASK))) {
         o_ptr->xtra4 = o_ptr->pval;
         o_ptr->pval = 0;
@@ -305,10 +305,10 @@ void rd_item_old(player_type *player_ptr, object_type *o_ptr)
     if ((o_ptr->k_idx >= 445) && (o_ptr->k_idx <= 479))
         return;
 
-    if (z_older_than(10, 4, 10) && (o_ptr->name2 == EGO_YOIYAMI))
+    if (h_older_than(0, 4, 10) && (o_ptr->name2 == EGO_YOIYAMI))
         o_ptr->k_idx = lookup_kind(TV_SOFT_ARMOR, SV_YOIYAMI_ROBE);
 
-    if (z_older_than(10, 4, 9)) {
+    if (h_older_than(0, 4, 9)) {
         if (has_flag(o_ptr->art_flags, TR_MAGIC_MASTERY)) {
             remove_flag(o_ptr->art_flags, TR_MAGIC_MASTERY);
             add_flag(o_ptr->art_flags, TR_DEC_MANA);
@@ -340,12 +340,12 @@ void rd_monster_old(player_type *player_ptr, monster_type *m_ptr)
 {
     rd_s16b(&m_ptr->r_idx);
 
-    if (z_older_than(11, 0, 12))
+    if (h_older_than(1, 0, 12))
         m_ptr->ap_r_idx = m_ptr->r_idx;
     else
         rd_s16b(&m_ptr->ap_r_idx);
 
-    if (z_older_than(11, 0, 14)) {
+    if (h_older_than(1, 0, 14)) {
         monster_race *r_ptr = &r_info[m_ptr->r_idx];
 
         m_ptr->sub_align = SUB_ALIGN_NEUTRAL;
@@ -369,7 +369,7 @@ void rd_monster_old(player_type *player_ptr, monster_type *m_ptr)
     rd_s16b(&tmp16s);
     m_ptr->maxhp = tmp16s;
 
-    if (z_older_than(11, 0, 5)) {
+    if (h_older_than(1, 0, 5)) {
         m_ptr->max_maxhp = m_ptr->maxhp;
     } else {
         rd_s16b(&tmp16s);
@@ -385,16 +385,16 @@ void rd_monster_old(player_type *player_ptr, monster_type *m_ptr)
     rd_byte(&tmp8u);
     m_ptr->mspeed = tmp8u;
 
-    if (z_older_than(10, 4, 2)) {
+    if (h_older_than(0, 4, 2)) {
         rd_byte(&tmp8u);
         m_ptr->energy_need = (s16b)tmp8u;
     } else
         rd_s16b(&m_ptr->energy_need);
 
-    if (z_older_than(11, 0, 13))
+    if (h_older_than(1, 0, 13))
         m_ptr->energy_need = 100 - m_ptr->energy_need;
 
-    if (z_older_than(10, 0, 7)) {
+    if (h_older_than(0, 0, 7)) {
         m_ptr->mtimed[MTIMED_FAST] = 0;
         m_ptr->mtimed[MTIMED_SLOW] = 0;
     } else {
@@ -411,9 +411,9 @@ void rd_monster_old(player_type *player_ptr, monster_type *m_ptr)
     rd_byte(&tmp8u);
     m_ptr->mtimed[MTIMED_MONFEAR] = (s16b)tmp8u;
 
-    if (z_older_than(10, 0, 10)) {
+    if (h_older_than(0, 0, 10)) {
         reset_target(m_ptr);
-    } else if (z_older_than(10, 0, 11)) {
+    } else if (h_older_than(0, 0, 11)) {
         rd_s16b(&tmp16s);
         reset_target(m_ptr);
     } else {
@@ -446,14 +446,14 @@ void rd_monster_old(player_type *player_ptr, monster_type *m_ptr)
     }
 
     u32b tmp32u;
-    if (z_older_than(10, 4, 5)) {
+    if (h_older_than(0, 4, 5)) {
         m_ptr->exp = 0;
     } else {
         rd_u32b(&tmp32u);
         m_ptr->exp = tmp32u;
     }
 
-    if (z_older_than(10, 2, 2)) {
+    if (h_older_than(0, 2, 2)) {
         if (m_ptr->r_idx < 0) {
             m_ptr->r_idx = (0 - m_ptr->r_idx);
             m_ptr->mflag2.set(MFLAG2::KAGE);
@@ -468,12 +468,12 @@ void rd_monster_old(player_type *player_ptr, monster_type *m_ptr)
         }
     }
 
-    if (z_older_than(11, 0, 12)) {
+    if (h_older_than(1, 0, 12)) {
         if (m_ptr->mflag2.has(MFLAG2::KAGE))
             m_ptr->ap_r_idx = MON_KAGE;
     }
 
-    if (z_older_than(10, 1, 3)) {
+    if (h_older_than(0, 1, 3)) {
         m_ptr->nickname = 0;
     } else {
         char buf[128];
@@ -555,7 +555,7 @@ errr rd_dungeon_old(player_type *player_ptr)
     rd_s16b(&tmp16s);
     floor_type *floor_ptr = player_ptr->current_floor_ptr;
     floor_ptr->dun_level = (DEPTH)tmp16s;
-    if (z_older_than(10, 3, 8))
+    if (h_older_than(0, 3, 8))
         player_ptr->dungeon_idx = DUNGEON_ANGBAND;
     else {
         byte tmp8u;
@@ -573,7 +573,7 @@ errr rd_dungeon_old(player_type *player_ptr)
     player_ptr->y = (POSITION)tmp16s;
     rd_s16b(&tmp16s);
     player_ptr->x = (POSITION)tmp16s;
-    if (z_older_than(10, 3, 13) && !floor_ptr->dun_level && !floor_ptr->inside_arena) {
+    if (h_older_than(0, 3, 13) && !floor_ptr->dun_level && !floor_ptr->inside_arena) {
         player_ptr->y = 33;
         player_ptr->x = 131;
     }
@@ -591,7 +591,7 @@ errr rd_dungeon_old(player_type *player_ptr)
         u16b info;
         byte count;
         rd_byte(&count);
-        if (z_older_than(10, 3, 6)) {
+        if (h_older_than(0, 3, 6)) {
             byte tmp8u;
             rd_byte(&tmp8u);
             info = (u16b)tmp8u;
@@ -662,7 +662,7 @@ errr rd_dungeon_old(player_type *player_ptr)
         }
     }
 
-    if (z_older_than(11, 0, 99)) {
+    if (h_older_than(1, 0, 99)) {
         for (int y = 0; y < ymax; y++) {
             for (int x = 0; x < xmax; x++) {
                 floor_ptr->grid_array[y][x].info &= ~(CAVE_MASK);
@@ -792,7 +792,7 @@ errr rd_dungeon_old(player_type *player_ptr)
         real_r_ptr(m_ptr)->cur_num++;
     }
 
-    if (z_older_than(10, 3, 13) && !floor_ptr->dun_level && !floor_ptr->inside_arena)
+    if (h_older_than(0, 3, 13) && !floor_ptr->dun_level && !floor_ptr->inside_arena)
         current_world_ptr->character_dungeon = FALSE;
     else
         current_world_ptr->character_dungeon = TRUE;

--- a/src/load/load-v1-5-0.cpp
+++ b/src/load/load-v1-5-0.cpp
@@ -426,26 +426,21 @@ void rd_monster_old(player_type *player_ptr, monster_type *m_ptr)
     rd_byte(&tmp8u);
     m_ptr->mtimed[MTIMED_INVULNER] = (s16b)tmp8u;
 
-    if (!(current_world_ptr->z_major == 2 && current_world_ptr->z_minor == 0 && current_world_ptr->z_patch == 6)) {
-        u32b tmp32u;
-        rd_u32b(&tmp32u);
-        std::bitset<32> rd_bits(tmp32u);
-        for (size_t i = 0; i < std::min(m_ptr->smart.size(), rd_bits.size()); i++) {
-            auto f = static_cast<SM>(i);
-            m_ptr->smart[f] = rd_bits[i];
-        }
-
-        // 3.0.0Alpha10以前のSM_CLONED(ビット位置22)、SM_PET(23)、SM_FRIEDLY(28)をMFLAG2に移行する
-        // ビット位置の定義はなくなるので、ビット位置の値をハードコードする。
-        m_ptr->mflag2[MFLAG2::CLONED] = rd_bits[22];
-        m_ptr->mflag2[MFLAG2::PET] = rd_bits[23];
-        m_ptr->mflag2[MFLAG2::FRIENDLY] = rd_bits[28];
-        m_ptr->smart.reset(static_cast<SM>(22)).reset(static_cast<SM>(23)).reset(static_cast<SM>(28));
-    } else {
-        m_ptr->smart.clear();
+    u32b tmp32u;
+    rd_u32b(&tmp32u);
+    std::bitset<32> rd_bits(tmp32u);
+    for (size_t i = 0; i < std::min(m_ptr->smart.size(), rd_bits.size()); i++) {
+        auto f = static_cast<SM>(i);
+        m_ptr->smart[f] = rd_bits[i];
     }
 
-    u32b tmp32u;
+    // 3.0.0Alpha10以前のSM_CLONED(ビット位置22)、SM_PET(23)、SM_FRIEDLY(28)をMFLAG2に移行する
+    // ビット位置の定義はなくなるので、ビット位置の値をハードコードする。
+    m_ptr->mflag2[MFLAG2::CLONED] = rd_bits[22];
+    m_ptr->mflag2[MFLAG2::PET] = rd_bits[23];
+    m_ptr->mflag2[MFLAG2::FRIENDLY] = rd_bits[28];
+    m_ptr->smart.reset(static_cast<SM>(22)).reset(static_cast<SM>(23)).reset(static_cast<SM>(28));
+
     if (h_older_than(0, 4, 5)) {
         m_ptr->exp = 0;
     } else {

--- a/src/load/load-zangband.cpp
+++ b/src/load/load-zangband.cpp
@@ -239,22 +239,22 @@ void set_zangband_quest(player_type *creature_ptr, quest_type *const q_ptr, int 
 
 void set_zangband_class(player_type *creature_ptr)
 {
-    if (z_older_than(10, 2, 2) && (creature_ptr->pclass == CLASS_BEASTMASTER) && !creature_ptr->is_dead) {
+    if (h_older_than(0, 2, 2) && (creature_ptr->pclass == CLASS_BEASTMASTER) && !creature_ptr->is_dead) {
         creature_ptr->hitdie = rp_ptr->r_mhp + cp_ptr->c_mhp + ap_ptr->a_mhp;
         roll_hitdice(creature_ptr, SPOP_NONE);
     }
 
-    if (z_older_than(10, 3, 2) && (creature_ptr->pclass == CLASS_ARCHER) && !creature_ptr->is_dead) {
+    if (h_older_than(0, 3, 2) && (creature_ptr->pclass == CLASS_ARCHER) && !creature_ptr->is_dead) {
         creature_ptr->hitdie = rp_ptr->r_mhp + cp_ptr->c_mhp + ap_ptr->a_mhp;
         roll_hitdice(creature_ptr, SPOP_NONE);
     }
 
-    if (z_older_than(10, 2, 6) && (creature_ptr->pclass == CLASS_SORCERER) && !creature_ptr->is_dead) {
+    if (h_older_than(0, 2, 6) && (creature_ptr->pclass == CLASS_SORCERER) && !creature_ptr->is_dead) {
         creature_ptr->hitdie = rp_ptr->r_mhp / 2 + cp_ptr->c_mhp + ap_ptr->a_mhp;
         roll_hitdice(creature_ptr, SPOP_NONE);
     }
 
-    if (z_older_than(10, 4, 7) && (creature_ptr->pclass == CLASS_BLUE_MAGE) && !creature_ptr->is_dead) {
+    if (h_older_than(0, 4, 7) && (creature_ptr->pclass == CLASS_BLUE_MAGE) && !creature_ptr->is_dead) {
         creature_ptr->hitdie = rp_ptr->r_mhp + cp_ptr->c_mhp + ap_ptr->a_mhp;
         roll_hitdice(creature_ptr, SPOP_NONE);
     }
@@ -280,7 +280,7 @@ void set_zangband_pet(player_type *creature_ptr)
     if (tmp8u)
         creature_ptr->pet_extra_flags |= PF_PICKUP_ITEMS;
 
-    if (z_older_than(10, 0, 4))
+    if (h_older_than(0, 0, 4))
         creature_ptr->pet_extra_flags |= PF_TELEPORT;
     else {
         rd_byte(&tmp8u);
@@ -288,7 +288,7 @@ void set_zangband_pet(player_type *creature_ptr)
             creature_ptr->pet_extra_flags |= PF_TELEPORT;
     }
 
-    if (z_older_than(10, 0, 7))
+    if (h_older_than(0, 0, 7))
         creature_ptr->pet_extra_flags |= PF_ATTACK_SPELL;
     else {
         rd_byte(&tmp8u);
@@ -296,7 +296,7 @@ void set_zangband_pet(player_type *creature_ptr)
             creature_ptr->pet_extra_flags |= PF_ATTACK_SPELL;
     }
 
-    if (z_older_than(10, 0, 8))
+    if (h_older_than(0, 0, 8))
         creature_ptr->pet_extra_flags |= PF_SUMMON_SPELL;
     else {
         rd_byte(&tmp8u);
@@ -304,7 +304,7 @@ void set_zangband_pet(player_type *creature_ptr)
             creature_ptr->pet_extra_flags |= PF_SUMMON_SPELL;
     }
 
-    if (z_older_than(10, 0, 8))
+    if (h_older_than(0, 0, 8))
         return;
 
     rd_byte(&tmp8u);

--- a/src/load/load-zangband.cpp
+++ b/src/load/load-zangband.cpp
@@ -119,37 +119,6 @@ void set_zangband_bounty_uniques(player_type *creature_ptr)
     }
 }
 
-/*!
- * @brief ZAngband v2.0.6に存在しない時限効果を0で初期化する / Old savefiles do not have the following fields...
- * @param creature_ptr プレーヤーへの参照ポインタ
- * @return なし
- * @details 厳密にv2.0.6しか見ていないため、ZAngband v2.0.5 以前のセーブデータは非対応
- */
-void set_zangband_timed_effects(player_type *creature_ptr)
-{
-    creature_ptr->tim_esp = 0;
-    creature_ptr->wraith_form = 0;
-    creature_ptr->resist_magic = 0;
-    creature_ptr->tim_regen = 0;
-    creature_ptr->tim_pass_wall = 0;
-    creature_ptr->tim_stealth = 0;
-    creature_ptr->tim_levitation = 0;
-    creature_ptr->tim_sh_touki = 0;
-    creature_ptr->lightspeed = 0;
-    creature_ptr->tsubureru = 0;
-    creature_ptr->tim_res_nether = 0;
-    creature_ptr->tim_res_time = 0;
-    creature_ptr->mimic_form = 0;
-    creature_ptr->tim_mimic = 0;
-    creature_ptr->tim_sh_fire = 0;
-    creature_ptr->tim_reflect = 0;
-    creature_ptr->multishadow = 0;
-    creature_ptr->dustrobe = 0;
-    creature_ptr->chaos_patron = ((creature_ptr->age + creature_ptr->sc) % MAX_PATRON);
-    creature_ptr->muta.clear();
-    get_virtues(creature_ptr);
-}
-
 void set_zangband_mimic(player_type *creature_ptr)
 {
     creature_ptr->tim_res_time = 0;

--- a/src/load/load-zangband.h
+++ b/src/load/load-zangband.h
@@ -9,7 +9,6 @@ void set_zangband_skill(player_type *creature_ptr);
 void set_zangband_spells(player_type *creature_ptr);
 void set_zangband_race(player_type *creature_ptr);
 void set_zangband_bounty_uniques(player_type *creature_ptr);
-void set_zangband_timed_effects(player_type *creature_ptr);
 void set_zangband_mimic(player_type *creature_ptr);
 void set_zangband_holy_aura(player_type *creature_ptr);
 void set_zangband_reflection(player_type *creature_ptr);

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -51,7 +51,7 @@
  */
 static errr load_town_quest(player_type *creature_ptr)
 {
-    if (z_older_than(12, 1, 3))
+    if (h_older_than(2, 1, 3))
         return 0;
 
     errr load_town_result = load_town();
@@ -120,12 +120,12 @@ static void load_spells(player_type *creature_ptr)
     rd_u32b(&creature_ptr->spell_forgotten1);
     rd_u32b(&creature_ptr->spell_forgotten2);
 
-    if (z_older_than(10, 0, 5))
+    if (h_older_than(0, 0, 5))
         set_zangband_learnt_spells(creature_ptr);
     else
         rd_s16b(&creature_ptr->learned_spells);
 
-    if (z_older_than(10, 0, 6))
+    if (h_older_than(0, 0, 6))
         creature_ptr->add_spells = 0;
     else
         rd_s16b(&creature_ptr->add_spells);
@@ -210,12 +210,12 @@ static errr exe_reading_savefile(player_type *creature_ptr)
         return load_store_result;
 
     rd_s16b(&creature_ptr->pet_follow_distance);
-    if (z_older_than(10, 4, 10))
+    if (h_older_than(0, 4, 10))
         set_zangband_pet(creature_ptr);
     else
         rd_s16b(&creature_ptr->pet_extra_flags);
 
-    if (!z_older_than(11, 0, 9)) {
+    if (!h_older_than(1, 0, 9)) {
         char *buf;
         C_MAKE(buf, SCREEN_BUF_MAX_SIZE, char);
         rd_string(buf, SCREEN_BUF_MAX_SIZE);

--- a/src/load/option-loader.cpp
+++ b/src/load/option-loader.cpp
@@ -84,7 +84,7 @@ void rd_options(void)
         }
     }
 
-    if (z_older_than(10, 4, 5))
+    if (h_older_than(0, 4, 5))
         load_zangband_options();
 
     extract_option_vars();

--- a/src/load/player-attack-loader.cpp
+++ b/src/load/player-attack-loader.cpp
@@ -7,7 +7,7 @@
 
 void rd_special_attack(player_type *creature_ptr)
 {
-    if (z_older_than(10, 0, 9)) {
+    if (h_older_than(0, 0, 9)) {
         set_zangband_special_attack(creature_ptr);
         return;
     }
@@ -29,7 +29,7 @@ void rd_special_action(player_type *creature_ptr)
 
 void rd_special_defense(player_type *creature_ptr)
 {
-    if (z_older_than(10, 0, 12)) {
+    if (h_older_than(0, 0, 12)) {
         set_zangband_special_defense(creature_ptr);
         return;
     }
@@ -44,6 +44,6 @@ void rd_action(player_type *creature_ptr)
     rd_byte(&tmp8u);
     rd_byte(&tmp8u);
     creature_ptr->action = (ACTION_IDX)tmp8u;
-    if (!z_older_than(10, 4, 3))
+    if (!h_older_than(0, 4, 3))
         set_zangband_action(creature_ptr);
 }

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -425,15 +425,9 @@ static void set_virtues(player_type *creature_ptr)
  * @brief 各種時限効果を読み込む
  * @param creature_ptr プレーヤーへの参照ポインタ
  * @return なし
- * @details ZAngbandとの互換性を保つ都合上、突然変異と徳の処理も追加している
  */
 static void rd_timed_effects(player_type *creature_ptr)
 {
-    if ((current_world_ptr->z_major == 2) && (current_world_ptr->z_minor == 0) && (current_world_ptr->z_patch == 6)) {
-        set_zangband_timed_effects(creature_ptr);
-        return;
-    }
-
     set_timed_effects(creature_ptr);
     rd_s16b(&creature_ptr->chaos_patron);
     set_mutations(creature_ptr);

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -50,7 +50,7 @@ void rd_base_info(player_type *creature_ptr)
     creature_ptr->realm2 = (REALM_IDX)tmp8u;
 
     rd_byte(&tmp8u);
-    if (z_older_than(10, 4, 4))
+    if (h_older_than(0, 4, 4))
         set_zangband_realm(creature_ptr);
 
     rd_byte(&tmp8u);
@@ -80,11 +80,11 @@ void rd_experience(player_type *creature_ptr)
     for (int i = 0; i < 64; i++)
         rd_s16b(&creature_ptr->spell_exp[i]);
 
-    if ((creature_ptr->pclass == CLASS_SORCERER) && z_older_than(10, 4, 2))
+    if ((creature_ptr->pclass == CLASS_SORCERER) && h_older_than(0, 4, 2))
         for (int i = 0; i < 64; i++)
             creature_ptr->spell_exp[i] = SPELL_EXP_MASTER;
 
-    const int max_weapon_exp_size = z_older_than(10, 3, 6) ? 60 : 64;
+    const int max_weapon_exp_size = h_older_than(0, 3, 6) ? 60 : 64;
     for (int i = 0; i < 5; i++)
         for (int j = 0; j < max_weapon_exp_size; j++)
             rd_s16b(&creature_ptr->weapon_exp[i][j]);
@@ -107,10 +107,10 @@ static void set_spells(player_type *creature_ptr)
 
 void rd_skills(player_type *creature_ptr)
 {
-    if (z_older_than(10, 4, 1))
+    if (h_older_than(0, 4, 1))
         set_zangband_skill(creature_ptr);
 
-    if (z_older_than(10, 3, 14))
+    if (h_older_than(0, 3, 14))
         set_zangband_spells(creature_ptr);
     else
         set_spells(creature_ptr);
@@ -134,7 +134,7 @@ static void set_race(player_type *creature_ptr)
 
 void rd_race(player_type *creature_ptr)
 {
-    if (z_older_than(11, 0, 7)) {
+    if (h_older_than(1, 0, 7)) {
         set_zangband_race(creature_ptr);
         return;
     }
@@ -144,7 +144,7 @@ void rd_race(player_type *creature_ptr)
 
 void rd_bounty_uniques(player_type *creature_ptr)
 {
-    if (z_older_than(10, 0, 3)) {
+    if (h_older_than(0, 0, 3)) {
         set_zangband_bounty_uniques(creature_ptr);
         return;
     }
@@ -172,7 +172,7 @@ static void rd_base_status(player_type *creature_ptr)
 
 static void set_imitation(player_type *creature_ptr)
 {
-    if (z_older_than(10, 0, 1)) {
+    if (h_older_than(0, 0, 1)) {
         for (int i = 0; i < MAX_MANE; i++) {
             creature_ptr->mane_spell[i] = -1;
             creature_ptr->mane_dam[i] = 0;
@@ -182,7 +182,7 @@ static void set_imitation(player_type *creature_ptr)
         return;
     }
 
-    if (z_older_than(10, 2, 3)) {
+    if (h_older_than(0, 2, 3)) {
         s16b tmp16s;
         const int OLD_MAX_MANE = 22;
         for (int i = 0; i < OLD_MAX_MANE; i++) {
@@ -217,7 +217,7 @@ static void rd_phase_out(player_type *creature_ptr)
     rd_s16b(&tmp16s);
     creature_ptr->current_floor_ptr->inside_arena = (bool)tmp16s;
     rd_s16b(&creature_ptr->current_floor_ptr->inside_quest);
-    if (z_older_than(10, 3, 5))
+    if (h_older_than(0, 3, 5))
         creature_ptr->phase_out = FALSE;
     else {
         rd_s16b(&tmp16s);
@@ -227,7 +227,7 @@ static void rd_phase_out(player_type *creature_ptr)
 
 static void rd_arena(player_type *creature_ptr)
 {
-    if (z_older_than(10, 0, 3))
+    if (h_older_than(0, 0, 3))
         update_gambling_monsters(creature_ptr);
     else
         set_gambling_monsters();
@@ -248,7 +248,7 @@ static void rd_arena(player_type *creature_ptr)
     creature_ptr->oldpx = (POSITION)tmp16s;
     rd_s16b(&tmp16s);
     creature_ptr->oldpy = (POSITION)tmp16s;
-    if (z_older_than(10, 3, 13) && !is_in_dungeon(creature_ptr) && !creature_ptr->current_floor_ptr->inside_arena) {
+    if (h_older_than(0, 3, 13) && !is_in_dungeon(creature_ptr) && !creature_ptr->current_floor_ptr->inside_arena) {
         creature_ptr->oldpy = 33;
         creature_ptr->oldpx = 131;
     }
@@ -306,7 +306,7 @@ static void rd_bad_status(player_type *creature_ptr)
 static void rd_energy(player_type *creature_ptr)
 {
     rd_s16b(&creature_ptr->energy_need);
-    if (z_older_than(11, 0, 13))
+    if (h_older_than(1, 0, 13))
         creature_ptr->energy_need = 100 - creature_ptr->energy_need;
 
     if (h_older_than(2, 1, 2, 0))
@@ -332,7 +332,7 @@ static void rd_status(player_type *creature_ptr)
     rd_s16b(&creature_ptr->image);
     rd_s16b(&creature_ptr->protevil);
     rd_s16b(&creature_ptr->invuln);
-    if (z_older_than(10, 0, 0))
+    if (h_older_than(0, 0, 0))
         creature_ptr->ult_res = 0;
     else
         rd_s16b(&creature_ptr->ult_res);
@@ -340,7 +340,7 @@ static void rd_status(player_type *creature_ptr)
 
 static void rd_tsuyoshi(player_type *creature_ptr)
 {
-    if (z_older_than(10, 0, 2))
+    if (h_older_than(0, 0, 2))
         creature_ptr->tsuyoshi = 0;
     else
         rd_s16b(&creature_ptr->tsuyoshi);
@@ -358,13 +358,13 @@ static void set_timed_effects(player_type *creature_ptr)
     rd_s16b(&creature_ptr->tim_sh_touki);
     rd_s16b(&creature_ptr->lightspeed);
     rd_s16b(&creature_ptr->tsubureru);
-    if (z_older_than(10, 4, 7))
+    if (h_older_than(0, 4, 7))
         creature_ptr->magicdef = 0;
     else
         rd_s16b(&creature_ptr->magicdef);
 
     rd_s16b(&creature_ptr->tim_res_nether);
-    if (z_older_than(10, 4, 11))
+    if (h_older_than(0, 4, 11))
         set_zangband_mimic(creature_ptr);
     else {
         rd_s16b(&creature_ptr->tim_res_time);
@@ -376,14 +376,14 @@ static void set_timed_effects(player_type *creature_ptr)
         rd_s16b(&creature_ptr->tim_sh_fire);
     }
 
-    if (z_older_than(11, 0, 99))
+    if (h_older_than(1, 0, 99))
         set_zangband_holy_aura(creature_ptr);
     else {
         rd_s16b(&creature_ptr->tim_sh_holy);
         rd_s16b(&creature_ptr->tim_eyeeye);
     }
 
-    if (z_older_than(11, 0, 3))
+    if (h_older_than(1, 0, 3))
         set_zangband_reflection(creature_ptr);
     else {
         rd_s16b(&creature_ptr->tim_reflect);

--- a/src/load/quest-loader.cpp
+++ b/src/load/quest-loader.cpp
@@ -46,7 +46,7 @@ errr load_town(void)
 errr load_quest_info(u16b *max_quests_load, byte *max_rquests_load)
 {
     rd_u16b(max_quests_load);
-    if (z_older_than(11, 0, 7))
+    if (h_older_than(1, 0, 7))
         *max_rquests_load = 10;
     else
         rd_byte(max_rquests_load);
@@ -75,7 +75,7 @@ static void load_quest_completion(quest_type *q_ptr)
     rd_s16b(&tmp16s);
     q_ptr->level = tmp16s;
 
-    if (z_older_than(11, 0, 6))
+    if (h_older_than(1, 0, 6))
         q_ptr->complev = 0;
     else {
         byte tmp8u;
@@ -121,13 +121,13 @@ void analyze_quests(player_type *creature_ptr, const u16b max_quests_load, const
         quest_type *const q_ptr = &quest[i];
         load_quest_completion(q_ptr);
         bool is_quest_running = (q_ptr->status == QUEST_STATUS_TAKEN);
-        is_quest_running |= (!z_older_than(10, 3, 14) && (q_ptr->status == QUEST_STATUS_COMPLETED));
-        is_quest_running |= (!z_older_than(11, 0, 7) && (i >= MIN_RANDOM_QUEST) && (i <= (MIN_RANDOM_QUEST + max_rquests_load)));
+        is_quest_running |= (!h_older_than(0, 3, 14) && (q_ptr->status == QUEST_STATUS_COMPLETED));
+        is_quest_running |= (!h_older_than(1, 0, 7) && (i >= MIN_RANDOM_QUEST) && (i <= (MIN_RANDOM_QUEST + max_rquests_load)));
         if (!is_quest_running)
             continue;
 
         load_quest_details(creature_ptr, q_ptr, i);
-        if (z_older_than(10, 3, 11))
+        if (h_older_than(0, 3, 11))
             set_zangband_quest(creature_ptr, q_ptr, i, old_inside_quest);
         else {
             byte tmp8u;

--- a/src/load/store-loader.cpp
+++ b/src/load/store-loader.cpp
@@ -66,7 +66,7 @@ static errr rd_store(player_type *player_ptr, int town_number, int store_number)
 {
     store_type *store_ptr;
     bool sort = FALSE;
-    if (z_older_than(10, 3, 3) && (store_number == STORE_HOME)) {
+    if (h_older_than(0, 3, 3) && (store_number == STORE_HOME)) {
         store_ptr = &town_info[1].store[store_number];
         if (store_ptr->stock_num)
             sort = TRUE;
@@ -80,7 +80,7 @@ static errr rd_store(player_type *player_ptr, int town_number, int store_number)
     rd_s32b(&store_ptr->store_open);
     rd_s16b(&store_ptr->insult_cur);
     rd_byte(&own);
-    if (z_older_than(11, 0, 4)) {
+    if (h_older_than(1, 0, 4)) {
         rd_byte(&tmp8u);
         num = tmp8u;
     } else {

--- a/src/load/world-loader.cpp
+++ b/src/load/world-loader.cpp
@@ -25,7 +25,7 @@ static void rd_hengband_dungeons(void)
 
 void rd_dungeons(player_type *creature_ptr)
 {
-    if (z_older_than(10, 3, 8))
+    if (h_older_than(0, 3, 8))
         rd_zangband_dungeon();
     else
         rd_hengband_dungeons();
@@ -42,7 +42,7 @@ void rd_dungeons(player_type *creature_ptr)
 void rd_alter_reality(player_type *creature_ptr)
 {
     s16b tmp16s;
-    if (z_older_than(10, 3, 8))
+    if (h_older_than(0, 3, 8))
         creature_ptr->recall_dungeon = DUNGEON_ANGBAND;
     else {
         rd_s16b(&tmp16s);
@@ -60,7 +60,7 @@ void set_gambling_monsters(void)
     const int max_gambling_monsters = 4;
     for (int i = 0; i < max_gambling_monsters; i++) {
         rd_s16b(&battle_mon[i]);
-        if (z_older_than(10, 3, 4))
+        if (h_older_than(0, 3, 4))
             set_zangband_gambling_monsters(i);
         else
             rd_u32b(&mon_odds[i]);
@@ -103,20 +103,20 @@ static void rd_world_info(player_type *creature_ptr)
         rd_s32b(&creature_ptr->feeling_turn);
 
     rd_s32b(&current_world_ptr->game_turn);
-    if (z_older_than(10, 3, 12))
+    if (h_older_than(0, 3, 12))
         current_world_ptr->dungeon_turn = current_world_ptr->game_turn;
     else
         rd_s32b(&current_world_ptr->dungeon_turn);
 
-    if (z_older_than(11, 0, 13))
+    if (h_older_than(1, 0, 13))
         set_zangband_game_turns(creature_ptr);
 
-    if (z_older_than(10, 3, 13))
+    if (h_older_than(0, 3, 13))
         current_world_ptr->arena_start_turn = current_world_ptr->game_turn;
     else
         rd_s32b(&current_world_ptr->arena_start_turn);
 
-    if (z_older_than(10, 0, 3))
+    if (h_older_than(0, 0, 3))
         determine_daily_bounty(creature_ptr, TRUE);
     else {
         rd_s16b(&current_world_ptr->today_mon);
@@ -126,12 +126,12 @@ static void rd_world_info(player_type *creature_ptr)
 
 void rd_visited_towns(player_type *creature_ptr)
 {
-    if (z_older_than(10, 3, 9)) {
+    if (h_older_than(0, 3, 9)) {
         creature_ptr->visit = 1L;
         return;
     }
 
-    if (z_older_than(10, 3, 10)) {
+    if (h_older_than(0, 3, 10)) {
         set_zangband_visited_towns(creature_ptr);
         return;
     }
@@ -162,17 +162,17 @@ void load_wilderness_info(player_type *creature_ptr)
 {
     rd_s32b(&creature_ptr->wilderness_x);
     rd_s32b(&creature_ptr->wilderness_y);
-    if (z_older_than(10, 3, 13)) {
+    if (h_older_than(0, 3, 13)) {
         creature_ptr->wilderness_x = 5;
         creature_ptr->wilderness_y = 48;
     }
 
-    if (z_older_than(10, 3, 7))
+    if (h_older_than(0, 3, 7))
         creature_ptr->wild_mode = FALSE;
     else
         rd_byte((byte *)&creature_ptr->wild_mode);
 
-    if (z_older_than(10, 3, 7))
+    if (h_older_than(0, 3, 7))
         creature_ptr->ambush_flag = FALSE;
     else
         rd_byte((byte *)&creature_ptr->ambush_flag);

--- a/src/system/angband-version.h
+++ b/src/system/angband-version.h
@@ -5,26 +5,29 @@
 #define VERSION_NAME "Hengband" /*!< バリアント名称 / Name of the version/variant */
 
 /*!
- * @brief ゲームのバージョン番号定義 / "Program Version Number" of the game
+ * @brief セーブファイル上のバージョン定義(メジャー番号) / "Savefile Version Number" for Hengband 1.1.1 and later
  * @details
- * 本FAKE_VERSIONそのものは未使用である。Zangと整合性を合わせるための疑似的処理のためFAKE_VER_MAJORは実値-10が該当のバージョン番号となる。
+ * 当面FAKE_VER_*を参照しておく。
  * <pre>
- * FAKE_VER_MAJOR=1,2 were reserved for ZAngband version 1.x.x/2.x.x .
  * Program Version of Hengband version is
- *   "(FAKE_VER_MAJOR-10).(FAKE_VER_MINOR).(FAKE_VER_PATCH)".
+ *   "(H_VER_MAJOR).(H_VER_MINOR).(H_VER_PATCH).(H_VER_EXTRA)".
+ * Upper compatibility is always guaranteed when it is more than 1.0.0 .
  * </pre>
  */
-#define FAKE_VERSION 0
-
-#define FAKE_VER_MAJOR 13 /*!< ゲームのバージョン番号定義(メジャー番号 + 10) */
-#define FAKE_VER_MINOR 0 /*!< ゲームのバージョン番号定義(マイナー番号) */
-#define FAKE_VER_PATCH 0 /*!< ゲームのバージョン番号定義(パッチ番号) */
-#define FAKE_VER_EXTRA 13 /*!< ゲームのバージョン番号定義(エクストラ番号) */
+#define H_VER_MAJOR  3 //!< ゲームのバージョン定義(メジャー番号)
+#define H_VER_MINOR  0 //!< ゲームのバージョン定義(マイナー番号)
+#define H_VER_PATCH  0 //!< ゲームのバージョン定義(パッチ番号)
+#define H_VER_EXTRA 13 //!< ゲームのバージョン定義(エクストラ番号)
 
 /*!
- * @brief バージョンが開発版が安定版かを返す
+ * @brief セーブファイルのバージョン(3.0.0から導入)
  */
-#define IS_STABLE_VERSION (FAKE_VER_MINOR % 2 == 0 && FAKE_VER_EXTRA == 0)
+constexpr u32b SAVEFILE_VERSION = 2;
+
+/*!
+ * @brief バージョンが開発版が安定版かを返す(廃止予定)
+ */
+#define IS_STABLE_VERSION (H_VER_MINOR % 2 == 0 && H_VER_EXTRA == 0)
 
 /*!
  * @brief 状態がアルファ版かどうかを返す
@@ -33,25 +36,17 @@
 #define IS_ALPHA_VERSION 1
 
 /*!
- * @brief セーブファイル上のバージョン定義(メジャー番号) / "Savefile Version Number" for Hengband 1.1.1 and later
+ * @brief ゲームのバージョン番号定義 / "Program Version Number" of the game
  * @details
- * 当面FAKE_VER_*を参照しておく。
+ * 本FAKE_VERSIONそのものは未使用である。Zangと整合性を合わせるための疑似的処理のためFAKE_VER_MAJORは実値-10が該当のバージョン番号となる。
  * <pre>
- * First three digits may be same as the Program Version.  But not
- * always same.  It means that newer version may preserves lower
- * compatibility with the older version.
- * For example, newer Hengband 1.4.4 creates savefiles marked with
- * Savefile Version 1.4.0.0 .  It means that Hengband 1.4.0 can load a
- * savefile of Hengband 1.4.4 (lower compatibility!).
- * Upper compatibility is always guaranteed.
+ * FAKE_VER_MAJOR=1,2 were reserved for ZAngband version 1.x.x/2.x.x .
  * </pre>
  */
-#define H_VER_MAJOR (FAKE_VER_MAJOR - 10) /*!< セーブファイル上のバージョン定義(メジャー番号) */
-#define H_VER_MINOR FAKE_VER_MINOR /*!< セーブファイル上のバージョン定義(マイナー番号) */
-#define H_VER_PATCH FAKE_VER_PATCH /*!< セーブファイル上のバージョン定義(パッチ番号) */
-#define H_VER_EXTRA FAKE_VER_EXTRA /*!< セーブファイル上のバージョン定義(エクストラ番号) */
-
-/** セーブファイルのバージョン */
-constexpr u32b SAVEFILE_VERSION = 2;
+#define FAKE_VER_PLUS 10 //!< 偽バージョン番号としていくつ足すか
+#define FAKE_VER_MAJOR (H_VER_MAJOR + FAKE_VER_PLUS) //!< 偽バージョン番号定義(メジャー番号) */
+#define FAKE_VER_MINOR H_VER_MINOR //!< 偽バージョン番号定義(マイナー番号) */
+#define FAKE_VER_PATCH H_VER_PATCH //!< 偽バージョン番号定義(パッチ番号) */
+#define FAKE_VER_EXTRA H_VER_EXTRA //!< 偽バージョン番号定義(エクストラ番号) */
 
 void put_version(char *buf);

--- a/src/world/world.h
+++ b/src/world/world.h
@@ -4,7 +4,10 @@
 
 #define MAX_BOUNTY 20
 
-typedef struct world_type {
+/*!
+ * @brief 世界情報構造体
+ */
+struct world_type {
 
     POSITION max_wild_x; /*!< Maximum size of the wilderness */
     POSITION max_wild_y; /*!< Maximum size of the wilderness */
@@ -29,27 +32,17 @@ typedef struct world_type {
 
     bool is_loading_now; /*!< ロード処理中フラグ...ロード直後にcalc_bonus()時の徳変化、及びsanity_blast()による異常を抑止する */
 
-    /*
-     * Savefile version
-     */
-    byte h_ver_major; /* Savefile version for Hengband 1.1.1 and later */
-    byte h_ver_minor;
-    byte h_ver_patch;
-    byte h_ver_extra;
+    byte h_ver_major; //!< 変愚蛮怒バージョン(メジャー番号) / Hengband version (major ver.)
+    byte h_ver_minor; //!< 変愚蛮怒バージョン(マイナー番号) / Hengband version (minor ver.)
+    byte h_ver_patch; //!< 変愚蛮怒バージョン(パッチ番号) / Hengband version (patch ver.)
+    byte h_ver_extra; //!< 変愚蛮怒バージョン(エクストラ番号) / Hengband version (extra ver.)
 
-    byte sf_extra; /* Savefile's encoding key */
+    byte sf_extra; //!< セーブファイルエンコードキー(XOR)
 
-    byte z_major; /* Savefile version for Hengband */
-    byte z_minor;
-    byte z_patch;
-
-    /*
-     * Savefile information
-     */
-    u32b sf_system; /* Operating system info */
-    u32b sf_when; /* Time when savefile created */
-    u16b sf_lives; /* Number of past "lives" with this file */
-    u16b sf_saves; /* Number of "saves" during this life */
+    u32b sf_system; //!< OS情報 / OS information
+    u32b sf_when; //!< 作成日時 / Created Date
+    u16b sf_lives; //!< このセーブファイルで何人プレイしたか / Number of past "lives" with this file
+    u16b sf_saves; //!< 現在のプレイで何回セーブしたか / Number of "saves" during this life
 
     bool character_generated; /* The character exists */
     bool character_dungeon; /* The character has a dungeon */
@@ -68,7 +61,7 @@ typedef struct world_type {
 
     DUNGEON_IDX max_d_idx;
 
-} world_type;
+};
 
 extern world_type *current_world_ptr;
 


### PR DESCRIPTION
セーブファイルの読み込みやworld_typeからZAngbandバージョンを廃止。
これに伴って、ZAngbandバージョン2.0.6でセーブされていたかなり初期の変愚蛮怒のセーブデータの互換性はなくなる。
ZAngband2.0.6以前のセーブデータについては、おそらくすでに互換性の保証はなかったと思われる。
セーブファイルや*.rawファイルの冒頭に保存される偽バージョンは残る。