### PR TITLE
[clang compatibility] include <vector> in main/scene-table.h

### DIFF
--- a/src/main/scene-table.h
+++ b/src/main/scene-table.h
@@ -3,6 +3,7 @@
 #include "system/angband.h"
 
 #include <iterator>
+#include <vector>
 
 struct scene_type;
 // シチュエーション判定関数。valueに設定した場合trueを返す。


### PR DESCRIPTION
With clang 12 on macOS and no use of precompiled headers, there were compilation errors with the current version of main/scene-table.h:  implicitly defined template for vector in the declaration of  get_scene_table_iterator().  Including vector got rid of the errors.