### PR TITLE
[Fix] ワーグクエストの報酬が報酬時と成功後次クエスト移行時の2回報酬を落としていた

### DIFF
--- a/lib/edit/t0000001.txt
+++ b/lib/edit/t0000001.txt
@@ -136,7 +136,6 @@ F:!:FLOOR:3:0:75
 # Continue with quest 18
 ?:[EQU $QUEST14 4]
 F:b:BUILDING_1:3:0:0:0:0:NONE:18
-F:!:FLOOR:3:0:75
 
 # Continue with quest 18
 ?:[EQU $QUEST14 6]


### PR DESCRIPTION
#641のエンバグ