### PR TITLE
[Refactor] .cfgファイル読み込み処理のリファクタリング #635

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -349,6 +349,7 @@
     <ClCompile Include="..\..\src\io\store-key-processor.cpp" />
     <ClCompile Include="..\..\src\load\info-loader.cpp" />
     <ClCompile Include="..\..\src\locale\utf-8.cpp" />
+    <ClCompile Include="..\..\src\main-win\main-win-cfg-reader.cpp" />
     <ClCompile Include="..\..\src\main-win\main-win-file-utils.cpp" />
     <ClCompile Include="..\..\src\main-win\main-win-mci.cpp" />
     <ClCompile Include="..\..\src\main-win\main-win-music.cpp" />
@@ -1023,6 +1024,7 @@
     <ClInclude Include="..\..\src\load\info-loader.h" />
     <ClInclude Include="..\..\src\locale\language-switcher.h" />
     <ClInclude Include="..\..\src\locale\utf-8.h" />
+    <ClInclude Include="..\..\src\main-win\main-win-cfg-reader.h" />
     <ClInclude Include="..\..\src\main-win\main-win-file-utils.h" />
     <ClInclude Include="..\..\src\main-win\main-win-mci.h" />
     <ClInclude Include="..\..\src\main-win\main-win-mmsystem.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2250,6 +2250,9 @@
     <ClCompile Include="..\..\src\main\scene-table.cpp">
       <Filter>main</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\main-win\main-win-cfg-reader.cpp">
+      <Filter>main-win</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -4847,6 +4850,9 @@
     <ClInclude Include="..\..\src\stdafx.h" />
     <ClInclude Include="..\..\src\main\scene-table.h">
       <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main-win\main-win-cfg-reader.h">
+      <Filter>main-win</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/lib/xtra/sound/sound.cfg
+++ b/lib/xtra/sound/sound.cfg
@@ -11,12 +11,6 @@
 # Look at the definition of "angband_sound_name" in variable.c for a complete list of
 # all the available event names.
 
-# [Device]項目
-# MCIデバイスを設定します。通常wav/mp3ならばMPEGVideoです。
-# 動作保証は出来ませんが、PC毎に予め用意したデバイスでの再生も可能です
-[Device]
-type = MPEGVideo
-
 [Sound]
 player_combat_start = sword-drawn1-r.wav
 hit = sword-slash3-r.wav

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -923,6 +923,7 @@ hengband_SOURCES = \
 EXTRA_hengband_SOURCES = \
 	angband.ico angband.rc ang_eng.rc ang_jp.rc maid-x11.cpp main-win.cpp \
 	main-win/main-win-bg.cpp main-win/main-win-bg.h \
+	main-win/main-win-cfg-reader.cpp main-win/main-win-cfg-reader.h \
 	main-win/main-win-define.h \
 	main-win/main-win-file-utils.cpp main-win/main-win-file-utils.h \
 	main-win/main-win-mci.cpp main-win/main-win-mci.h \

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -102,7 +102,6 @@
 #include "core/special-internal-keys.h"
 #include "core/stuff-handler.h"
 #include "core/visuals-reseter.h"
-#include "dungeon/quest.h"
 #include "floor/floor-base-definitions.h"
 #include "floor/floor-events.h"
 #include "game-option/runtime-arguments.h"
@@ -951,7 +950,7 @@ static void init_music(void)
     static bool can_use_music = FALSE;
 
     if (!can_use_music) {
-        main_win_music::load_music_prefs(current_world_ptr->max_d_idx, max_q_idx);
+        main_win_music::load_music_prefs();
         can_use_music = TRUE;
     }
 }

--- a/src/main-win/main-win-cfg-reader.cpp
+++ b/src/main-win/main-win-cfg-reader.cpp
@@ -1,0 +1,123 @@
+﻿/*!
+ * @file main-win-cfg-reader.cpp
+ * @brief Windows版固有実装(.cfgファイル処理)
+ */
+
+#include "main-win/main-win-cfg-reader.h"
+#include "main-win/main-win-define.h"
+#include "main-win/main-win-file-utils.h"
+#include "main-win/main-win-tokenizer.h"
+#include "main-win/main-win-windows.h"
+#include "term/z-term.h"
+#include "util/angband-files.h"
+
+#include "main/sound-definitions-table.h"
+
+// 1つの項目に設定可能な最大ファイル数
+#define SAMPLE_MAX 16
+
+/*!
+ * @brief マップのキーを生成する
+ * @details
+ * typeを上位16ビット, valを下位16ビットに設定した値をマップのキーとする。
+ * @param type the "actions" value of "term_xtra()". see:z-term.h TERM_XTRA_xxxxx
+ * @param val the 2nd parameter of "term_xtra()"
+ * @return 生成したキーを返す
+ */
+static cfg_key make_cfg_key(int type, int val)
+{
+    return ((type << 16) | (val & 0xffff));
+}
+
+/*!
+ * @brief マップのキーに対応する値を取得する
+ * @param key1_type the "actions" value of "term_xtra()". see:z-term.h TERM_XTRA_xxxxx
+ * @param key2_val the 2nd parameter of "term_xtra()"
+ * @return キーに対応する値を返す。登録されていない場合はNULLを返す。
+ */
+static cfg_values *get_map_value(cfg_map *map, int key1_type, int key2_val)
+{
+    cfg_values *value = NULL;
+    auto ite = map->find(make_cfg_key(key1_type, key2_val));
+    if (ite != map->end()) {
+        value = ite->second;
+    }
+    return value;
+}
+
+/*!
+ * @brief 登録されている中からランダムに選択する
+ * @param type the "actions" value of "term_xtra()". see:z-term.h TERM_XTRA_xxxxx
+ * @param val the 2nd parameter of "term_xtra()"
+ * @return キーに対応する値、複数のファイル名の中からからランダムに返す。登録されていない場合はNULLを返す。
+ */
+concptr CfgData::get_rand(int key1_type, int key2_val)
+{
+    cfg_values *filenames = get_map_value(this->map, key1_type, key2_val);
+    if (!filenames) {
+        return NULL;
+    }
+
+    return filenames->at(Rand_external(filenames->size()));
+}
+
+void CfgData::insert(int key1_type, int key2_val, cfg_values *value)
+{
+    this->map->insert(std::make_pair(make_cfg_key(key1_type, key2_val), value));
+}
+
+/*!
+ * @param dir .cfgファイルのディレクトリ
+ * @param files .cfgファイル名。複数指定可能で、最初に見つかったファイルから読み取る。
+ */
+CfgReader::CfgReader(concptr dir, std::initializer_list<concptr> files)
+{
+    this->dir = dir;
+    this->cfg_path = find_any_file(dir, files);
+}
+
+/*!
+ * @brief データの読み込みを行う。
+ * @param sections 読み取るデータの指定
+ * @return 読み込んだデータを登録したCfgDataを返す。
+ */
+CfgData *CfgReader::read_sections(std::initializer_list<cfg_section> sections)
+{
+    CfgData *result = new CfgData();
+
+    if (!check_file(this->cfg_path.c_str())) {
+        return result;
+    }
+
+    char key_buf[80];
+    char buf[MAIN_WIN_MAX_PATH];
+    char path[MAIN_WIN_MAX_PATH];
+    char *tokens[SAMPLE_MAX];
+
+    for (auto &section : sections) {
+    
+        int index = 0;
+        concptr read_key;
+        while ((read_key = section.key_at(index, key_buf)) != NULL) {
+            GetPrivateProfileString(section.section_name, read_key, "", buf, MAIN_WIN_MAX_PATH, this->cfg_path.c_str());
+            if (*buf != '\0') {
+                cfg_values *filenames = new cfg_values();
+                const int num = tokenize_whitespace(buf, SAMPLE_MAX, tokens);
+                for (int j = 0; j < num; j++) {
+                    path_build(path, MAIN_WIN_MAX_PATH, dir, tokens[j]);
+                    if (check_file(path))
+                        filenames->push_back(string_make(tokens[j]));
+                }
+                if (filenames->empty()) {
+                    delete filenames;
+                } else {
+                    result->insert(section.action_type, index, filenames);
+                }
+            }
+
+            index++;
+        }
+    }
+
+    return result;
+}

--- a/src/main-win/main-win-cfg-reader.h
+++ b/src/main-win/main-win-cfg-reader.h
@@ -1,0 +1,66 @@
+﻿#pragma once
+
+#include "system/h-type.h"
+
+#include <cstddef>
+#include <vector>
+#include <map>
+#include <initializer_list>
+
+typedef uint cfg_key;
+using cfg_values = std::vector<concptr>;
+using cfg_map = std::unordered_map<cfg_key, cfg_values *>;
+using key_name_func = concptr (*)(int, char *);
+
+/*!
+ * @brief .cfgファイルの読み取り対象とCfgData格納先のキー指定
+ * @details
+ * "term_xtra()"の第1引数(action-type)、第2引数(action-val)をデータの格納キーとする。
+ * action-typeはaction_typeメンバで指定する。
+ * key_name_funcにより、action-valと.cfg内の読取対象キーの対応を取る。
+ * key_name_funcの引数にaction-valが渡され、対応する読取対象キーを返す。
+ * key_name_func引数のaction-valは0から1,2,3...と順に呼ばれ、key_name_funcがNULLを返すまで続ける。
+ */
+struct cfg_section {
+
+    //! The name of the section in cfg file
+    concptr section_name;
+    //! the "actions" value of "term_xtra()". see:z-term.h TERM_XTRA_xxxxx
+    int action_type;
+    /*!
+     * Returns a reference to the name of the key at a specified action-val* in the section.
+     * *action-val : the 2nd parameter of "term_xtra()"
+     */
+    key_name_func key_at;
+};
+
+class CfgData {
+public:
+    CfgData()
+    {
+        map = new cfg_map();
+    }
+    virtual ~CfgData()
+    {
+        delete map;
+    }
+    concptr get_rand(int key1_type, int key2_val);
+    void insert(int key1_type, int key2_val, cfg_values *value);
+
+protected:
+    cfg_map *map;
+};
+
+class CfgReader {
+public:
+    CfgReader(concptr dir, std::initializer_list<concptr> files);
+    CfgData *read_sections(std::initializer_list<cfg_section> sections);
+    concptr get_cfg_path()
+    {
+        return cfg_path.c_str();
+    }
+
+protected:
+    concptr dir;
+    std::string cfg_path;
+};

--- a/src/main-win/main-win-file-utils.cpp
+++ b/src/main-win/main-win-file-utils.cpp
@@ -6,6 +6,7 @@
 #include "main-win/main-win-file-utils.h"
 #include "main-win/main-win-define.h"
 #include "main-win/main-win-windows.h"
+#include "util/angband-files.h"
 
 /*
  * Check for existance of a file
@@ -41,4 +42,24 @@ bool check_dir(concptr s)
         return FALSE;
 
     return TRUE;
+}
+
+/*!
+ * @brief 候補リストを順に確認し、存在するファイルのパスを返す。
+ * @param dir ディレクトリ
+ * @param files ファイル名のリスト
+ * @return ファイルのパスを返す。候補リストのファイルすべて存在しない場合は空文字列を返す。
+ */
+std::string find_any_file(concptr dir, std::initializer_list<concptr> files)
+{
+    char path[MAIN_WIN_MAX_PATH];
+
+    for (concptr filename : files) {
+        path_build(path, MAIN_WIN_MAX_PATH, dir, filename);
+        if (check_file(path)) {
+            return std::string(path);
+        }
+    }
+
+    return std::string();
 }

--- a/src/main-win/main-win-file-utils.h
+++ b/src/main-win/main-win-file-utils.h
@@ -2,5 +2,9 @@
 
 #include "system/h-type.h"
 
+#include <initializer_list>
+#include <string>
+
 bool check_file(concptr s);
 bool check_dir(concptr s);
+std::string find_any_file(concptr dir, std::initializer_list<concptr> files);

--- a/src/main-win/main-win-music.h
+++ b/src/main-win/main-win-music.h
@@ -1,21 +1,17 @@
 ﻿#pragma once
 
+#include "main-win/main-win-cfg-reader.h"
 #include "system/h-type.h"
 
 #include "main/music-definitions-table.h"
 
 #include <windows.h>
 
-#define SAMPLE_MUSIC_MAX 16
-extern concptr music_file[MUSIC_BASIC_MAX][SAMPLE_MUSIC_MAX];
-// TODO マジックナンバー除去
-extern concptr dungeon_music_file[1000][SAMPLE_MUSIC_MAX];
-extern concptr town_music_file[1000][SAMPLE_MUSIC_MAX];
-extern concptr quest_music_file[1000][SAMPLE_MUSIC_MAX];
 extern concptr ANGBAND_DIR_XTRA_MUSIC;
+extern CfgData *music_cfg_data;
 
 namespace main_win_music {
-void load_music_prefs(DUNGEON_IDX max_d_idx, QUEST_IDX max_q_idx);
+void load_music_prefs();
 errr stop_music(void);
 errr play_music(int type, int val);
 errr play_music_scene();

--- a/src/main-win/main-win-sound.h
+++ b/src/main-win/main-win-sound.h
@@ -1,12 +1,10 @@
 ﻿#pragma once
 
+#include "main-win/main-win-cfg-reader.h"
 #include "system/h-type.h"
 
-#include "main/sound-definitions-table.h"
-
-#define SAMPLE_SOUND_MAX 16
-extern concptr sound_file[SOUND_MAX][SAMPLE_SOUND_MAX];
 extern concptr ANGBAND_DIR_XTRA_SOUND;
+extern CfgData *sound_cfg_data;
 
 void load_sound_prefs(void);
 errr play_sound(int val);

--- a/src/main/scene-table.cpp
+++ b/src/main/scene-table.cpp
@@ -178,7 +178,7 @@ void refresh_scene_table(player_type *player_ptr)
     }
 }
 
-std::vector<scene_type>::iterator get_scene_table_iterator()
+scene_iterator get_scene_table_iterator()
 {
     return playfallback.begin();
 }

--- a/src/main/scene-table.h
+++ b/src/main/scene-table.h
@@ -7,25 +7,26 @@
 
 struct scene_type;
 // シチュエーション判定関数。valueに設定した場合trueを返す。
-typedef bool (*SCENE_DEF_FUNC)(player_type *player_ptr, scene_type *value);
+using scene_def_func = bool (*)(player_type *player_ptr, scene_type *value);
 
 struct scene_type {
-    int type; //!< シチュエーションカテゴリ
-    int val; //!< シチュエーション項目
+    int type = 0; //!< シチュエーションカテゴリ
+    int val = 0; //!< シチュエーション項目
 
     bool update(player_type *player_ptr, scene_type *value)
     {
         return scene_def(player_ptr, value);
     }
 
-    scene_type(SCENE_DEF_FUNC f)
+    scene_type(scene_def_func f)
         : scene_def(f)
     {
     }
 
 private:
-    SCENE_DEF_FUNC scene_def; //!< シチュエーション判定関数
+    scene_def_func scene_def; //!< シチュエーション判定関数
 };
 
 void refresh_scene_table(player_type *player_ptr);
-std::vector<scene_type>::iterator get_scene_table_iterator();
+using scene_iterator = std::vector<scene_type>::const_iterator;
+scene_iterator get_scene_table_iterator();


### PR DESCRIPTION
.cfgの読み取りクラスCfgReaderを作成し、処理を置き換えた。
データ構造を配列からmapに変更し、再生時の対象ファイル取得を簡略化した。

sound.cfgの[Device]項目は、効果音再生には不要なこととBGMの同設定項目と競合するため削除した。