### PR TITLE
[fix] obj-desc.txtの出力がおかしい #657

### DIFF
--- a/src/wizard/items-spoiler.cpp
+++ b/src/wizard/items-spoiler.cpp
@@ -104,8 +104,8 @@ spoiler_output_status spoil_obj_desc(concptr fname)
     fprintf(spoiler_file, "%-37s%8s%7s%5s %40s%9s\n", "-------------------------------------", "------", "---", "---", "----------------", "----");
     int n = 0;
     int group_start = 0;
+    OBJECT_IDX who[200];
     for (int i = 0; TRUE; i++) {
-        OBJECT_IDX who[200];
         if (group_item[i].name) {
             if (n) {
                 for (int s = 0; s < n - 1; s++) {


### PR DESCRIPTION
アイテムのidを格納する配列whoのスコープが狭すぎるため、
最適化が有効だとwhoの内容が不定となるのが原因。
whoをループの外に移動することで解決する。