### PR TITLE
[fix] C_WIPEで先頭の要素しかクリアされていない

### DIFF
--- a/src/term/z-virt.h
+++ b/src/term/z-virt.h
@@ -13,6 +13,7 @@
 
 #include "system/h-basic.h"
 
+#include <algorithm>
 #include <type_traits>
 
 /*
@@ -59,10 +60,7 @@ inline T *wipe_impl(T *p)
 template <typename T, std::enable_if_t<!std::is_trivial_v<T>, std::nullptr_t> = nullptr>
 inline T *c_wipe_impl(T *p, size_t n)
 {
-    T obj{};
-    for (size_t i = 0; i < n; i++) {
-        *p = obj;
-    }
+    std::fill_n(p, n, T{});
     return p;
 }
 template <typename T, std::enable_if_t<!std::is_trivial_v<T>, std::nullptr_t> = nullptr>


### PR DESCRIPTION
ポインタを進め忘れているというしょうもないやらかしにより
先頭の要素だけを何度もクリアしており、残りの要素が
クリアされていない。
やはり自前でループを実装するのは悪。プリコンパイルヘッダの
導入によりコンパイル時間が伸びる懸念はなくなったので、
std::fill_nを使用するようにする。

hotfix出したばかりで申し訳ないが、敵がアイテムを拾うとほぼ確実にフリーズするのでhotfix案件かと思います。