### PR TITLE
[Compatibility for without precompiled headers] include <array> in option-types-table.h

### DIFF
--- a/src/game-option/option-types-table.h
+++ b/src/game-option/option-types-table.h
@@ -2,6 +2,8 @@
 
 #include "system/angband.h"
 
+#include <array>
+
 /*
  * Available "options"
  *	- Address of actual option variable (or NULL)


### PR DESCRIPTION
Avoids compilation errors when using clang 12 on macOS and the precompiled headers via stdafx.h are not used.