### PR TITLE
[fix]  毎ターンエルドリッチホラーの影響を受ける #666

### DIFF
--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -449,7 +449,8 @@ static void update_invisible_monster(player_type *subject_ptr, um_type *um_ptr, 
             r_ptr->r_sights++;
     }
 
-    if (r_info[um_ptr->m_ptr->ap_r_idx].flags2 & RF2_ELDRITCH_HORROR)
+    if (current_world_ptr->is_loading_now && current_world_ptr->character_dungeon && !subject_ptr->phase_out
+        && r_info[um_ptr->m_ptr->ap_r_idx].flags2 & RF2_ELDRITCH_HORROR)
         um_ptr->m_ptr->mflag.set(MFLAG::SANITY_BLAST);
 
     if (disturb_near


### PR DESCRIPTION
PR #621 でis_loading_now等のグローバル変数によってエルドリッチホラーの
効果を無効にする処理を考慮していなかっため、実際の効果を発生させるタイミングが
変わった事により、セーブ時にエルドリッチホラーの判定が行われてしまう。
これによりデバッグセーブ実装直後と同様の問題が発生している。

is_loading_nowという安易なグローバルスイッチの存在が一番のエルドリッチホラー
というオチである。