### PR TITLE
[Linux/Unix] add configure option to disable use of precompiled headers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -64,6 +64,10 @@ AC_ARG_ENABLE(worldscore,
 [  --disable-worldscore    disable worldscore support], worldscore=no, AC_DEFINE(WORLD_SCORE, 1, [Allow the game to send scores to the score server]))
 AC_ARG_ENABLE(chuukei,
 [  --enable-chuukei        enable internet chuukei support], AC_DEFINE(CHUUKEI, 1, [Chuukei mode]))
+AC_ARG_ENABLE([pch],
+[  --disable-pch           disable use of precompiled headers],
+enable_pch=no, enable_pch=yes)
+AM_CONDITIONAL([PCH], [test x$enable_pch = xyes])
 
 dnl Checks for libraries.
 dnl Replace `main' with a function in -lncurses:

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -938,19 +938,24 @@ EXTRA_DIST = \
 	gcc-wrap
 
 DEFAULT_INCLUDES = -I$(srcdir) -I$(top_builddir)/src
-CPPFLAGS += $(XFT_CFLAGS) $(libcurl_CFLAGS) -include stdafx.h
+CPPFLAGS += $(XFT_CFLAGS) $(libcurl_CFLAGS)
+if PCH
+CPPFLAGS += -include stdafx.h
+endif
 LIBS += $(XFT_LIBS) $(libcurl_LIBS)
 COMPILE = $(srcdir)/gcc-wrap $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) \
 	$(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
 CXXCOMPILE = $(srcdir)/gcc-wrap $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) \
 	$(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CXXFLAGS)
 
+if PCH
 stdafx.h.gch: stdafx.h stdafx.cpp Makefile
 	$(CXX) -x c++-header $(CXXFLAGS) $(srcdir)/stdafx.cpp -o $@
 	rm -f stdafx.h.gch.sum
 	md5sum $@ > stdafx.h.gch.sum
 
 $(hengband_SOURCES:.cpp=.$(OBJEXT)): stdafx.h.gch
+endif
 
 install-exec-hook:
 if SET_GID


### PR DESCRIPTION
The option is --disable-pch .  The use cases would be:

- compiling on some platform (not certain if there are any) that does not use gcc/clang's syntax for precompiled headers or does not support precompiled headers at all
- testing that the software builds when not using precompiled headers
- universal builds on macOS (i.e. x86_64 and ARM) using multiple -arch flags since clang doesn't support precompiled headers when multiple -arch flags are present

I don't know if those are sufficient to justify the extra code in configure.ac and src/Makefile.am.