### PR TITLE
[fix] 探索モード中に探索コマンドを実行するとその場に留まるより損をする #680

### DIFF
--- a/src/cmd-action/cmd-others.cpp
+++ b/src/cmd-action/cmd-others.cpp
@@ -50,6 +50,9 @@ void do_cmd_search(player_type *creature_ptr)
 
     take_turn(creature_ptr, 100);
     search(creature_ptr);
+
+    if (creature_ptr->action == ACTION_SEARCH)
+        search(creature_ptr);
 }
 
 static bool exe_alter(player_type *creature_ptr)


### PR DESCRIPTION
探索コマンドにおいても、探索モードでは追加の探索処理を実行する。