### PR TITLE
[documentation] align the contents of dungeon.txt with jdungeon.txt

### DIFF
--- a/lib/help/dungeon.hlp
+++ b/lib/help/dungeon.hlp
@@ -8,8 +8,9 @@ Please choose one of the following online help files:
     (d) Objects in the Dungeon                (dungeon.txt#Objects)
     (e) Mining                                (dungeon.txt#Mining)
     (f) Staircases, Doors, Passages & Rooms   (dungeon.txt#StairsDoorsEtc)
-    (g) Level Feelings                        (dungeon.txt#Feelings)
-    (h) Random Quests                         (dungeon.txt#RandomQuests)
+    (g) Dangerous Terrain                     (dungeon.txt#DangerousTerrain)
+    (h) Level Feelings                        (dungeon.txt#Feelings)
+    (i) Random Quests                         (dungeon.txt#RandomQuests)
 
     (?) Help System Commands                  (helpinfo.txt)
 
@@ -20,5 +21,6 @@ Please choose one of the following online help files:
 ***** [d] dungeon.txt#Objects
 ***** [e] dungeon.txt#Mining
 ***** [f] dungeon.txt#StairsDoorsEtc
-***** [g] dungeon.txt#Feelings
-***** [h] dungeon.txt#RandomQuests
+***** [g] dungeon.txt#DangerousTerrain
+***** [h] dungeon.txt#Feelings
+***** [i] dungeon.txt#RandomQuests

--- a/lib/help/dungeon.txt
+++ b/lib/help/dungeon.txt
@@ -5,15 +5,15 @@ Although Hengband contains an extensive town level featuring multiple
 towns and a large wilderness area, the bulk of your adventuring will
 take place in the dungeon. Symbols appearing on your screen will
 represent the dungeon's walls, floor, objects, features, and creatures
-lurking about. In order to direct your character through his adventure,
-you will enter single character commands (see command.txt [b]).
+lurking about. In order to direct your character, you will enter single
+character commands (see command.txt [b]).
 
 
 ***** <MapSymbols>
 === Symbols On Your Map ===
 
-Symbols on your map can be broken down into three categories: Features
-of the dungeon such as walls, floor, doors, and traps; Objects which
+Symbols on your map can be broken down into three categories: features
+of the dungeon such as walls, floor, doors, and traps; objects which
 can be picked up such as treasure, weapons, magical devices, etc; and
 creatures which may or may not move about the dungeon, but are mostly
 harmful to your character's well being.
@@ -32,42 +32,46 @@ to something you are more comfortable with.
  
 --- Features that do not block line of sight ---
  
-  [[[[w|.|   Floor                       [[[[v|*|   A Mirror                     
-  [[[[w|.|   A trap (hidden)             [[[[y|;|   A rune of protection         
-  [[[[w|^|   A trap (known)              [[[[R|;|   A explosive rune             
-  [[[[u|.|   Dirt                        [[[[B|*|   Section of the Pattern  
-  [[[[g|.|   Patch of grass              [[[[b|*|   Section of the Pattern  
-  [[[[G|:|   Flower                      [[[[U|1|   General Store             
-  [[[[g|:|   Brake                       [[[[s|2|   Armoury                     
-  [[[[B|.|   Swamp                       [[[[w|3|   Weaponsmith's Shop
-  [[[[B|~|   Shallow Water               [[[[g|4|   Temple                     
-  [[[[b|~|   Deep Water                  [[[[b|5|   Alchemy Shop             
-  [[[[U|~|   Shallow Lava                [[[[r|6|   Magic Shop                     
-  [[[[r|~|   Deep Lava                   [[[[D|7|   Black Market             
-  [[[[D|#|   Dark pit                    [[[[y|8|   Home                     
-  [[[[U|'|   An open door                [[[[o|9|   Bookstore                     
-  [[[[u|'|   A broken door               [[[[v|0|   Museum                     
-  [[[[w|<|   A staircase up              [[[[B|+|   Other building             
-  [[[[w|>|   A staircase down            [[[[v|+|   Other building          
-  [[[[U|<|   A shaft up                       
-  [[[[U|>|   A shaft down                   
-  [[[[v|>|   An entrance to dungeon
-  [[[[y|>|   quest entrance
+  [[[[w|.|   Floor                       [[[[r|'|   Open curtain
+  [[[[w|.|   A trap (hidden)             [[[[w|<|   A staircase up
+  [[[[w|^|   A trap (known)              [[[[w|>|   A staircase down
+  [[[[u|.|   Dirt                        [[[[U|<|   A shaft up
+  [[[[g|.|   Patch of grass              [[[[U|>|   A shaft down
+  [[[[G|:|   Flower                      [[[[v|>|   Dungeon entrance
+  [[[[g|:|   Brake                       [[[[y|>|   Quest entrance
+  [[[[B|.|   Swamp                       [[[[v|*|   Mirror
+  [[[[B|~|   Shallow water               [[[[y|;|   A rune of protection
+  [[[[b|~|   Deep water                  [[[[R|;|   An explosive rune
+  [[[[o|~|   Shallow lava                [[[[B|*|   Section of the Pattern
+  [[[[r|~|   Deep lava                   [[[[b|*|   Section of the Pattern
+  [[[[B|^|   Cold zone                   [[[[U|1|   General Store
+  [[[[b|^|   Heavy cold zone             [[[[s|2|   Armoury
+  [[[[o|^|   Electrical zone             [[[[w|3|   Weaponsmith's Shop
+  [[[[y|^|   Heavy electrical zone       [[[[g|4|   Temple
+  [[[[U|~|   Shallow acid puddle         [[[[b|5|   Alchemy Shop
+  [[[[u|~|   Deep acid puddle            [[[[r|6|   Magic Shop
+  [[[[G|~|   Shallow poisonous puddle    [[[[D|7|   Black Market
+  [[[[g|~|   Deep poisonous puddle       [[[[y|8|   Home
+  [[[[D|#|   Dark pit                    [[[[o|9|   Bookstore
+  [[[[U|'|   An open door                [[[[v|0|   Museum
+  [[[[u|'|   A broken door               [[[[B|+|   Other building
+  [[[[w|+|   Closed glass door           [[[[v|+|   Other building
+  [[[[w|#|   Glass wall
 
 --- Features that block line of sight ---
 
-  [[[[w|#|   A granite wall              [[[[G|#|   A Tree          
-  [[[[s|%|   A magma vein                [[[[o|^|   Mountain chain  
-  [[[[w|%|   A quartz vein               [[[[U|+|   A door          
-  [[[[w|#|   A secret door               [[[[w|:|   A pile of rubble
-  [[[[o|*|   Treasure in wall
+  [[[[w|#|   A granite wall              [[[[G|#|   A tree
+  [[[[s|%|   A magma vein                [[[[o|^|   Mountain chain
+  [[[[w|%|   A quartz vein               [[[[U|+|   A door
+  [[[[w|#|   A secret door               [[[[R|'|   Curtain
+  [[[[o|*|   Treasure in wall            [[[[w|:|   A pile of rubble
 
 
 ***** <WithinDungeon>
 === Within The Dungeon ===
 
 Once your character is adequately supplied with food, light, armor, and
-weapons, he is ready to enter the dungeon. Move on top of the '>'
+weapons, he or she is ready to enter the dungeon. Move on top of the '>'
 symbol and use the "Down" command (">").
 
 Your character will enter a maze of interconnecting staircases and
@@ -86,14 +90,14 @@ In the dungeon, there are many things to find, but your character must
 survive many horrible and challenging encounters to find the treasure
 lying about and take it safely back to the town to sell.
 
-There are two sources for light once inside the dungeon. Permanent
-light which has been magically placed within rooms, and a light source
-carried by the player. If neither is present, the character will be
-unable to see. This will affect searching, picking locks, disarming
-traps, reading scrolls, casting spells, browsing books, etc. So be very
-careful not to run out of light!
+There are two sources for light once inside the dungeon. One is permanent
+light which has been magically placed within rooms. The other is light
+sources carried by the player or monsters. If neither is present, the
+character will be unable to see. This will affect searching, picking
+locks, disarming traps, reading scrolls, casting spells, browsing books
+and more. So be very careful not to run out of light!
 
-A character must wield a torch or lamp in order to supply his own
+A character must wield a torch or lamp in order to supply his or her own
 light. A torch or lamp burns fuel as it is used, and once it is out of
 fuel, it stops supplying light. You will be warned as the light
 approaches this point. You may use the "Fuel" command ("F") to refuel
@@ -117,20 +121,18 @@ One item in particular will be discussed here. The scroll of "Word of
 Recall" can be found within the dungeon, or bought at the temple in
 town. It acts in two manners, depending upon your current location.
 If read within the dungeon, it will teleport you back to town. If read
-in town, it will teleport you back down to the deepest level of the
-dungeon which your character has previously been on. This makes the
-scroll very useful for getting back to the deeper levels of Hengband.
-Once the scroll has been read it takes a while for the spell to act, so
-don't expect it to save you in a crisis. Reading a second scroll before
-the first has had a chance to take effect will cancel both scrolls.
+in town, it will teleport you back down to the deepest level (usually)
+of the dungeon which your character has previously been on. This makes
+the scroll very useful for getting back to the deeper levels of Hengband.
+The return floor is usually the deepest floor you've been to, but you
+can change the return floor by going back to a shallower floor and
+reading a scroll of "Word of Recall".
 
-Since an accidental dive to a new depth (via a trapdoor, for example),
-may result in the Word of Recall dungeon depth being 'broken', so to
-speak (meaning that the next Word of Recall in town will take you back
-deeper than you would like to), there is a new feature in Hengband
-which allows you to read a scroll of Word of Recall on a different
-level and 'reset' the recall depth to that level (instead of the
-deepest level).
+A scroll of "Word of Recall" will take some time to take effect after
+your character reads it, so don't expect to use it as an instant escape
+from a crisis. If your character reads another such scroll before the
+first has taken effect, the second cancels the first and your character
+will not be teleported.
 
 A more complete description of Hengband objects is found elsewhere in
 the documentation (see object.txt [c]).
@@ -155,18 +157,17 @@ pick or shovel and begin digging out a section. When that section is
 removed, he can locate another section of the vein and begin the
 process again. Since granite rock is much harder to dig through, it is
 much faster to follow the vein exactly and dig around the granite.
-There is an option for highlighting magma and quartz. At a certain
-point, it becomes more cumbersome to dig out treasure than to simply
-kill monsters and discover items in the dungeon to sell. However, early
-on mineral veins can be a wonderful source of easy treasure.
+At a certain point, it becomes more cumbersome to dig out treasure than
+to simply kill monsters and discover items in the dungeon to sell. Early
+on, however, mineral veins can be a wonderful source of easy treasure.
 
 If the character has a scroll, staff, or spell of treasure location, he
-can immediately locate all strikes of treasure within a vein shown on
-the screen. This makes mining much easier and more profitable.
+or she can immediately locate all strikes of treasure within the veins
+shown on the screen. This makes mining much easier and more profitable.
 
 Note that a character with high strength and/or a heavy weapon does not
 need a shovel/pick to dig, but even the strongest character will
-benefit from a pick if trying to dig through a granite wall.
+benefit from a pick or shovel if trying to dig through a granite wall.
 
 It is sometimes possible to get a character trapped within the dungeon
 by using various magical spells and items. So it can be a good idea to
@@ -188,6 +189,9 @@ dungeon. The symbols for the up and down staircases are the same as the
 commands to use them. A "<" represents an up staircase and a ">"
 represents a down staircase. You must move your character over the
 staircase before you can use it.
+
+In Hengband, stairs will go up or down one level.  Shafts will go up
+or down two levels at a time.
 
 Each level has at least one up staircase and at least two down
 staircases. There are no exceptions to this rule. You may have trouble
@@ -212,6 +216,52 @@ Doors can be broken down by bashing them. Once a door is bashed open,
 it is forever useless and cannot be closed.
 
 
+***** <DangerousTerrain>
+=== Dangerous Terrain ===
+
+While all of the dungeon can be dangerous, there is some terrain that
+will harm an adventurer just by standing upon it. While an adventurer
+may have a source of resistance or immunity to limit or entirely avoid
+that damage, another way to deal with that terrain is to magically
+levitate over it.
+
+Shallow or deep water is more common and is usually safe to enter, but
+entering deep water while carrying too much can lead the character to
+flounder, losing hit points until the character either leaves the deep
+water or dies from drowning.
+
+Shallow or deep lava flows often appear deep in the dungeon and can
+be found in some mountainous parts of the wilderness. Even a brief
+foray into a lava flow can be deadly for an ill-prepared adventurer.
+Moreover, deep lava flows can cause drowning if the character is
+carrying too much. The harmful effects from lava can be relieved or
+avoided by wearing a source of fire resistance, fire immunity or
+levitation.
+
+Cold or extremely ("heavy") cold zones are rarely seen in the dungeon,
+but they'll cause damage by freezing to any adventurer who enters or
+remains upon them. The damage can be alleviated by wearing a source
+of cold resistance or levitation.
+
+Electrical or high voltage ("heavy") electrical zones are also rarely
+seen, but they'll cause electrical damage to characters who enter or
+remain upon them.  The damage can be alleviated by wearing a source
+of electrical resistance or levitation.
+
+Shallow or deep acid puddles often appear deep in the dungeon.
+Entering or remaining in them will cause acid damage.  In deep puddles,
+a character can drown if carrying too much.  Wearing a source of
+acid resistance, acid immunity, or levitation can alleviate the
+harmful effects of the puddles.
+
+Shallow or deep poisonous puddles often appear deep in the dungeon.
+Entering or remaining in them will cause immediate poison damage as
+well as lingering poison damage even after leaving the puddle.  In
+addition, a character carrying too much can drown in a deep puddle.
+Wearing a source of poison resistance or levitation can alleviate
+the harmful effects of the puddles.
+
+
 ***** <Feelings>
 === Level Feelings ===
 
@@ -225,9 +275,10 @@ The actual 'feeling' prompt is generated based on a number of factors.
 Things which increase the feeling level include the presence of vaults
 and certain other special rooms, out of depth objects and monsters and
 objects of a certain quality (for example, ego items, artifacts and
-other objects that are considered 'great' (see objects.txt)). A feeling
-is only indicative of the level at the time you entered it and has no
-impact on subsequent monsters generated or items dropped.
+other objects that are considered 'great' (see objects.txt)). The
+feeling may change, with more perceptive adventurers picking up the
+change earlier. Defeating powerful monsters of picking up powerful
+items can calm the feeling for a level.
 
 In Hengband, the nastier the feeling prompt, the better the level. From
 worst to best, the prompts are as follows:
@@ -283,13 +334,12 @@ During character generation, you will be asked to input the number of
 random quests you wish to participate in. You may choose any number
 from 0 to 10. Random quests are always of the type 'Kill an out-of
 depth unique monster'. There is a limit to the number of levels a
-random quest monster may be out-of-depth but these quests can still be
-very dangerous.
+random quest monster may be out-of-depth, but these quests can still
+be very dangerous.
 
 Random quests appear on level 6, 12, 24, 38, 44, 50, 56, 62, 76 and
 88.  On entering a random quest level you will be told what the quest
-monster is (for example, 'Beware, this level is protected by The
-Borshin.').
+monster is (for example, 'Beware, this level is protected by Gachapin').
 
 On random quest levels, no down staircases are generated until the
 last monster is killed which means that you cannot continue further
@@ -308,6 +358,7 @@ Original   : (??)
 Updated    : (??)
 Updated    : Zangband DevTeam
 Updated    : Hengband 1.0.11
+Updated    : Hengband 3.0.0Alpha15, English translation backwardsEric
 
 ***** Begin Hyperlinks
 ***** [b] command.txt


### PR DESCRIPTION
That most notably affects the lists of feature symbols and the description of dangerous terrain. Make some minor changes to punctuation, to avoid assuming a male character, and to avoid an incomplete sentence.