### PR TITLE
[Refactor] Point構造体の定義を一箇所にまとめる

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -1234,6 +1234,7 @@
     <ClInclude Include="..\..\src\util\buffer-shaper.h" />
     <ClInclude Include="..\..\src\util\flag-group.h" />
     <ClInclude Include="..\..\src\util\int-char-converter.h" />
+    <ClInclude Include="..\..\src\util\point-2d.h" />
     <ClInclude Include="..\..\src\util\quarks.h" />
     <ClInclude Include="..\..\src\lore\combat-types-setter.h" />
     <ClInclude Include="..\..\src\lore\magic-types-setter.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -4854,6 +4854,9 @@
     <ClInclude Include="..\..\src\main-win\main-win-cfg-reader.h">
       <Filter>main-win</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\util\point-2d.h">
+      <Filter>util</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\src\wall.bmp" />

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -860,6 +860,7 @@ hengband_SOURCES = \
 	util/flag-group.h \
 	util/int-char-converter.h \
 	util/object-sort.cpp util/object-sort.h \
+	util/point-2d.h \
 	util/probability-table.h \
 	util/quarks.cpp util/quarks.h \
 	util/sort.cpp util/sort.h \

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -34,11 +34,11 @@
 #include "io/screen-util.h"
 #include "monster-floor/monster-remover.h"
 #include "monster-race/monster-race.h"
+#include "monster-race/race-flags2.h"
+#include "monster-race/race-flags7.h"
 #include "monster/monster-info.h"
 #include "monster/monster-status.h"
 #include "monster/monster-update.h"
-#include "monster-race/race-flags2.h"
-#include "monster-race/race-flags7.h"
 #include "object/item-tester-hooker.h"
 #include "object/object-mark-types.h"
 #include "player/player-class.h"
@@ -49,6 +49,7 @@
 #include "system/floor-type-definition.h"
 #include "term/term-color-types.h"
 #include "util/bit-flags-calculator.h"
+#include "util/point-2d.h"
 #include "view/display-map.h"
 #include "view/display-messages.h"
 #include "window/main-window-util.h"
@@ -804,16 +805,6 @@ static POSITION flow_y = 0;
  */
 void update_flow(player_type *subject_ptr)
 {
-    struct Point {
-        int y;
-        int x;
-        Point(const int y, const int x)
-            : y(y)
-            , x(x)
-        {
-        }
-    };
-
     POSITION x, y;
     DIRECTION d;
     floor_type *f_ptr = subject_ptr->current_floor_ptr;
@@ -839,7 +830,7 @@ void update_flow(player_type *subject_ptr)
 
     for (int i = 0; i < FLOW_MAX; i++) {
         // 幅優先探索用のキュー。
-        std::queue<Point> que;
+        std::queue<Pos2D> que;
         que.emplace(subject_ptr->y, subject_ptr->x);
 
         /* Now process the queue */

--- a/src/monster-floor/monster-lite.cpp
+++ b/src/monster-floor/monster-lite.cpp
@@ -14,18 +14,9 @@
 #include "player/special-defense-types.h"
 #include "system/floor-type-definition.h"
 #include "system/monster-type-definition.h"
+#include "util/point-2d.h"
 #include "view/display-messages.h"
 #include "world/world.h"
-
-struct Point {
-    int y;
-    int x;
-    Point(const int y, const int x)
-        : y(y)
-        , x(x)
-    {
-    }
-};
 
 /*!
  * @brief モンスターによる光量状態更新 / Add a square to the changes array
@@ -35,7 +26,7 @@ struct Point {
  * @param x X座標
  */
 static void update_monster_lite(
-    player_type *const subject_ptr, std::vector<Point> &points, const POSITION y, const POSITION x, const monster_lite_type *const ml_ptr)
+    player_type *const subject_ptr, std::vector<Pos2D> &points, const POSITION y, const POSITION x, const monster_lite_type *const ml_ptr)
 {
     grid_type *g_ptr;
     int dpf, d;
@@ -87,7 +78,7 @@ static void update_monster_lite(
  * Add a square to the changes array
  */
 static void update_monster_dark(
-    player_type *const subject_ptr, std::vector<Point> &points, const POSITION y, const POSITION x, const monster_lite_type *const ml_ptr)
+    player_type *const subject_ptr, std::vector<Pos2D> &points, const POSITION y, const POSITION x, const monster_lite_type *const ml_ptr)
 {
     grid_type *g_ptr;
     int midpoint, dpf, d;
@@ -139,9 +130,9 @@ static void update_monster_dark(
 void update_mon_lite(player_type *subject_ptr)
 {
     // 座標たちを記録する配列。
-    std::vector<Point> points;
+    std::vector<Pos2D> points;
 
-    void (*add_mon_lite)(player_type *, std::vector<Point> &, const POSITION, const POSITION, const monster_lite_type *);
+    void (*add_mon_lite)(player_type *, std::vector<Pos2D> &, const POSITION, const POSITION, const monster_lite_type *);
     int dis_lim = ((d_info[subject_ptr->dungeon_idx].flags1 & DF1_DARKNESS) && !subject_ptr->see_nocto) ? (MAX_SIGHT / 2 + 1) : (MAX_SIGHT + 3);
     floor_type *floor_ptr = subject_ptr->current_floor_ptr;
     for (int i = 0; i < floor_ptr->mon_lite_n; i++) {

--- a/src/player/player-view.cpp
+++ b/src/player/player-view.cpp
@@ -7,6 +7,7 @@
 #include "grid/grid.h"
 #include "player/player-view.h"
 #include "system/floor-type-definition.h"
+#include "util/point-2d.h"
 
 /*
  * Helper function for "update_view()" below
@@ -96,18 +97,8 @@ static bool update_view_aux(player_type *subject_ptr, POSITION y, POSITION x, PO
  */
 void update_view(player_type *subject_ptr)
 {
-    struct Point {
-        int y;
-        int x;
-        Point(const int y, const int x)
-            : y(y)
-            , x(x)
-        {
-        }
-    };
-
     // 前回プレイヤーから見えていた座標たちを格納する配列。
-    std::vector<Point> points;
+    std::vector<Pos2D> points;
 
     int n, m, d, k, z;
     POSITION y, x;

--- a/src/room/cave-filler.cpp
+++ b/src/room/cave-filler.cpp
@@ -14,6 +14,7 @@
 #include "room/cave-filler.h"
 #include "room/lake-types.h"
 #include "system/floor-type-definition.h"
+#include "util/point-2d.h"
 
 typedef struct fill_data_type {
     POSITION xmin;
@@ -227,20 +228,10 @@ static bool hack_isnt_wall(player_type *player_ptr, POSITION y, POSITION x, int 
  */
 static void cave_fill(player_type *player_ptr, const POSITION y, const POSITION x)
 {
-    struct Point {
-        int y;
-        int x;
-        Point(const int y, const int x)
-            : y(y)
-            , x(x)
-        {
-        }
-    };
-
     floor_type *floor_ptr = player_ptr->current_floor_ptr;
 
     // 幅優先探索用のキュー。
-    std::queue<Point> que;
+    std::queue<Pos2D> que;
     que.emplace(y, x);
 
     while (!que.empty()) {

--- a/src/specific-object/torch.cpp
+++ b/src/specific-object/torch.cpp
@@ -14,6 +14,7 @@
 #include "sv-definition/sv-lite-types.h"
 #include "system/floor-type-definition.h"
 #include "util/bit-flags-calculator.h"
+#include "util/point-2d.h"
 
 /*!
  * @brief 投擲時たいまつに投げやすい/焼棄/アンデッドスレイの特別効果を返す。
@@ -166,18 +167,8 @@ void update_lite_radius(player_type *creature_ptr)
  */
 void update_lite(player_type *subject_ptr)
 {
-    struct Point {
-        int y;
-        int x;
-        Point(const int y, const int x)
-            : y(y)
-            , x(x)
-        {
-        }
-    };
-
     // 前回照らされていた座標たちを格納する配列。
-    std::vector<Point> points;
+    std::vector<Pos2D> points;
 
     POSITION p = subject_ptr->cur_lite;
     floor_type *const floor_ptr = subject_ptr->current_floor_ptr;

--- a/src/spell-kind/spells-lite.cpp
+++ b/src/spell-kind/spells-lite.cpp
@@ -22,18 +22,9 @@
 #include "system/floor-type-definition.h"
 #include "target/projection-path-calculator.h"
 #include "util/bit-flags-calculator.h"
+#include "util/point-2d.h"
 #include "view/display-messages.h"
 #include "world/world.h"
-
-struct Point {
-    int y;
-    int x;
-    Point(const int y, const int x)
-        : y(y)
-        , x(x)
-    {
-    }
-};
 
 using PassBoldFunc = bool (*)(floor_type *, POSITION, POSITION);
 
@@ -55,7 +46,7 @@ using PassBoldFunc = bool (*)(floor_type *, POSITION, POSITION);
  * </pre>
  * @todo この辺、xとyが引数になっているが、caster_ptr->xとcaster_ptr->yで全て置き換えが効くはず……
  */
-static void cave_temp_room_lite(player_type *caster_ptr, const std::vector<Point> &points)
+static void cave_temp_room_lite(player_type *caster_ptr, const std::vector<Pos2D> &points)
 {
     for (const auto &point : points) {
         const POSITION y = point.y;
@@ -104,7 +95,7 @@ static void cave_temp_room_lite(player_type *caster_ptr, const std::vector<Point
  * </pre>
  * @todo この辺、xとyが引数になっているが、caster_ptr->xとcaster_ptr->yで全て置き換えが効くはず……
  */
-static void cave_temp_room_unlite(player_type *caster_ptr, const std::vector<Point> &points)
+static void cave_temp_room_unlite(player_type *caster_ptr, const std::vector<Pos2D> &points)
 {
     for (const auto &point : points) {
         const POSITION y = point.y;
@@ -213,7 +204,7 @@ static int next_to_walls_adj(floor_type *floor_ptr, const POSITION cy, const POS
  * @param pass_bold 地形条件を返す関数ポインタ
  */
 static void cave_temp_room_aux(
-    player_type *caster_ptr, std::vector<Point> &points, const POSITION y, const POSITION x, const bool only_room, const PassBoldFunc pass_bold)
+    player_type *caster_ptr, std::vector<Pos2D> &points, const POSITION y, const POSITION x, const bool only_room, const PassBoldFunc pass_bold)
 {
     floor_type *floor_ptr = caster_ptr->current_floor_ptr;
     grid_type *g_ptr = &floor_ptr->grid_array[y][x];
@@ -256,7 +247,7 @@ static void cave_temp_room_aux(
  * @param y 指定Y座標
  * @param x 指定X座標
  */
-static void cave_temp_lite_room_aux(player_type *caster_ptr, std::vector<Point> &points, const POSITION y, const POSITION x)
+static void cave_temp_lite_room_aux(player_type *caster_ptr, std::vector<Pos2D> &points, const POSITION y, const POSITION x)
 {
     cave_temp_room_aux(caster_ptr, points, y, x, FALSE, cave_los_bold);
 }
@@ -276,7 +267,7 @@ static bool cave_pass_dark_bold(floor_type *floor_ptr, POSITION y, POSITION x) {
  * @param y 指定Y座標
  * @param x 指定X座標
  */
-static void cave_temp_unlite_room_aux(player_type *caster_ptr, std::vector<Point> &points, const POSITION y, const POSITION x)
+static void cave_temp_unlite_room_aux(player_type *caster_ptr, std::vector<Pos2D> &points, const POSITION y, const POSITION x)
 {
     cave_temp_room_aux(caster_ptr, points, y, x, TRUE, cave_pass_dark_bold);
 }
@@ -292,7 +283,7 @@ static void cave_temp_unlite_room_aux(player_type *caster_ptr, std::vector<Point
 void lite_room(player_type *caster_ptr, const POSITION y1, const POSITION x1)
 {
     // 明るくするマスを記録する配列。
-    std::vector<Point> points;
+    std::vector<Pos2D> points;
 
     floor_type *floor_ptr = caster_ptr->current_floor_ptr;
 
@@ -337,7 +328,7 @@ void lite_room(player_type *caster_ptr, const POSITION y1, const POSITION x1)
 void unlite_room(player_type *caster_ptr, const POSITION y1, const POSITION x1)
 {
     // 暗くするマスを記録する配列。
-    std::vector<Point> points;
+    std::vector<Pos2D> points;
 
     floor_type *floor_ptr = caster_ptr->current_floor_ptr;
 

--- a/src/util/point-2d.h
+++ b/src/util/point-2d.h
@@ -1,0 +1,20 @@
+﻿#pragma once
+
+#include "system/h-type.h"
+
+/**
+ * @brief 2次元平面上の座標を表す構造体
+ */
+template <typename T>
+struct Point2D {
+    T y{};
+    T x{};
+    constexpr Point2D(T y, T x)
+        : y(y)
+        , x(x)
+    {
+    }
+};
+
+//! ゲームの平面マップ上の座標位置を表す構造体
+using Pos2D = Point2D<POSITION>;


### PR DESCRIPTION
2次元平面の座標を扱うPoint構造体が複数箇所で定義されている。
DRYの原則に反しているし、今後別の処理で使うことが考えられる
ので、point-2d.h ヘッダに定義をまとめる。