### PR TITLE
[Fix] 装備してない欄の(なし)の表記が(なし) {未判明}などになる #695

### DIFF
--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -22,10 +22,12 @@
 /*!
  * @brief ベースアイテム構造体の鑑定済みフラグをリセットする。
  * @return なし
+ * @details
+ * 不具合対策で0からリセットする(セーブは0から)
  */
 static void k_info_reset(void)
 {
-    for (int i = 1; i < max_k_idx; i++) {
+    for (int i = 0; i < max_k_idx; i++) {
         object_kind *k_ptr = &k_info[i];
         k_ptr->tried = FALSE;
         k_ptr->aware = FALSE;

--- a/src/flavor/flavor-describer.cpp
+++ b/src/flavor/flavor-describer.cpp
@@ -499,7 +499,7 @@ void describe_flavor(player_type *player_ptr, char *buf, object_type *o_ptr, BIT
     flavor_type tmp_flavor;
     flavor_type *flavor_ptr = initialize_flavor_type(&tmp_flavor, buf, o_ptr, mode);
     describe_named_item(player_ptr, flavor_ptr);
-    if (flavor_ptr->mode & OD_NAME_ONLY) {
+    if (flavor_ptr->mode & OD_NAME_ONLY || o_ptr->k_idx == 0) {
         angband_strcpy(flavor_ptr->buf, flavor_ptr->tmp_val, MAX_NLEN);
         return;
     }


### PR DESCRIPTION
何かの要因でk_info[0]の情報が更新された場合にエンバグで不要な情報を表示してしまう((なし)以外は不要)
基本的にエンバグ対策。