### PR TITLE
[Add] 不滅チートオプション実装．　/ Implement cheat_immortal.

### DIFF
--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -125,6 +125,7 @@ void player_wipe_without_name(player_type *creature_ptr)
     cheat_save = FALSE;
     cheat_diary_output = FALSE;
     cheat_turn = FALSE;
+    cheat_immortal = FALSE;
 
     current_world_ptr->total_winner = FALSE;
     creature_ptr->timewalk = FALSE;

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -425,7 +425,7 @@ void play_game(player_type *player_ptr, bool new_game, bool browsing_movie)
         player_outfit(player_ptr);
 
     init_io(player_ptr);
-    if (player_ptr->chp < 0)
+    if (player_ptr->chp < 0 && !cheat_immortal)
         player_ptr->is_dead = TRUE;
 
     if (player_ptr->prace == RACE_ANDROID)

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -13,6 +13,7 @@
 #include "floor/wild.h"
 #include "game-option/disturbance-options.h"
 #include "game-option/map-screen-options.h"
+#include "game-option/cheat-options.h"
 #include "grid/grid.h"
 #include "inventory/pack-overflow.h"
 #include "io/cursor.h"
@@ -264,7 +265,7 @@ void process_player(player_type *creature_ptr)
             move_cursor_relative(creature_ptr->y, creature_ptr->x);
             command_cmd = SPECIAL_KEY_BUILDING;
             process_command(creature_ptr);
-        } else if (creature_ptr->paralyzed || (creature_ptr->stun >= 100)) {
+        } else if ((creature_ptr->paralyzed || creature_ptr->stun >= 100) && !cheat_immortal) {
             take_turn(creature_ptr, 100);
         } else if (creature_ptr->action == ACTION_REST) {
             if (creature_ptr->resting > 0) {

--- a/src/dungeon/dungeon-processor.cpp
+++ b/src/dungeon/dungeon-processor.cpp
@@ -17,6 +17,7 @@
 #include "floor/floor-save.h"
 #include "game-option/map-screen-options.h"
 #include "game-option/play-record-options.h"
+#include "game-option/cheat-options.h"
 #include "io/cursor.h"
 #include "io/input-key-requester.h"
 #include "io/write-diary.h"

--- a/src/game-option/cheat-options.cpp
+++ b/src/game-option/cheat-options.cpp
@@ -10,3 +10,4 @@ bool cheat_save; /* Ask for saving death */
 bool cheat_diary_output; /* Detailed info to diary */
 bool cheat_turn; /* Peek turn */
 bool cheat_sight;
+bool cheat_immortal;

--- a/src/game-option/cheat-options.h
+++ b/src/game-option/cheat-options.h
@@ -12,3 +12,4 @@ extern bool cheat_save;
 extern bool cheat_diary_output;
 extern bool cheat_turn;
 extern bool cheat_sight;
+extern bool cheat_immortal;

--- a/src/game-option/option-types-table.cpp
+++ b/src/game-option/option-types-table.cpp
@@ -319,7 +319,11 @@ const option_type cheat_info[MAX_CHEAT_OPTIONS]
 
           { &cheat_turn, FALSE, 255, 0x81, 0x00, "cheat_turn", _("ゲームメッセージにターン表示を行う", "Put turn in game messages.") },
 
-          { &cheat_sight, FALSE, 255, 0x82, 0x00, "cheat_sight", _("「見る」コマンドを拡張する。", "Expand \"L\"ook command.") } };
+          { &cheat_sight, FALSE, 255, 0x82, 0x00, "cheat_sight", _("「見る」コマンドを拡張する。", "Expand \"L\"ook command.") },
+
+          { &cheat_immortal, FALSE, 255, 0x83, 0x00, "cheat_immortal", _("完全な不滅状態になる。", "Completely immortal.") } };
+
+
 
 /*!
  * 自動セーブオプションテーブル

--- a/src/game-option/option-types-table.h
+++ b/src/game-option/option-types-table.h
@@ -24,7 +24,7 @@ struct option_type {
 };
 
 #define MAX_OPTION_INFO 125
-#define MAX_CHEAT_OPTIONS 10
+#define MAX_CHEAT_OPTIONS 11
 #define MAX_AUTOSAVE_INFO 2
 
 extern const std::array<const option_type, MAX_OPTION_INFO> option_info;

--- a/src/io/signal-handlers.cpp
+++ b/src/io/signal-handlers.cpp
@@ -11,6 +11,7 @@
 #include "floor/floor-events.h"
 #include "io/write-diary.h"
 #include "monster-floor/monster-lite.h"
+#include "game-option/cheat-options.h"
 #include "save/save.h"
 #include "system/system-variables.h"
 #include "term/term-color-types.h"
@@ -78,7 +79,8 @@ static void handle_signal_simple(int sig)
         forget_view(p_ptr->current_floor_ptr);
         clear_mon_lite(p_ptr->current_floor_ptr);
         p_ptr->playing = FALSE;
-        p_ptr->is_dead = TRUE;
+        if (!cheat_immortal)
+            p_ptr->is_dead = TRUE;
         p_ptr->leaving = TRUE;
         close_game(p_ptr);
         quit(_("強制終了", "interrupt"));

--- a/src/load/option-loader.cpp
+++ b/src/load/option-loader.cpp
@@ -56,6 +56,7 @@ void rd_options(void)
     cheat_diary_output = (c & 0x8000) ? TRUE : FALSE;
     cheat_turn = (c & 0x0080) ? TRUE : FALSE;
     cheat_sight = (c & 0x0040) ? TRUE : FALSE;
+    cheat_immortal = (c & 0x0020) ? TRUE : FALSE;
 
     rd_byte((byte *)&autosave_l);
     rd_byte((byte *)&autosave_t);

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -327,6 +327,8 @@ int take_hit(player_type *creature_ptr, int damage_type, HIT_POINT damage, concp
     }
 
     creature_ptr->chp -= damage;
+    if (creature_ptr->chp < -9999)
+        creature_ptr->chp = -9999;
     if (damage_type == DAMAGE_GENO && creature_ptr->chp < 0) {
         damage += creature_ptr->chp;
         creature_ptr->chp = 0;
@@ -340,7 +342,7 @@ int take_hit(player_type *creature_ptr, int damage_type, HIT_POINT damage, concp
         chg_virtue(creature_ptr, V_CHANCE, 2);
     }
 
-    if (creature_ptr->chp < 0) {
+    if (creature_ptr->chp < 0 && !cheat_immortal) {
         bool android = (creature_ptr->prace == RACE_ANDROID ? TRUE : FALSE);
 
 #ifdef JP
@@ -353,7 +355,7 @@ int take_hit(player_type *creature_ptr, int damage_type, HIT_POINT damage, concp
         chg_virtue(creature_ptr, V_SACRIFICE, 10);
         handle_stuff(creature_ptr);
         creature_ptr->leaving = TRUE;
-        creature_ptr->is_dead = TRUE;
+        if(!cheat_immortal) creature_ptr->is_dead = TRUE;
         if (creature_ptr->current_floor_ptr->inside_arena) {
             concptr m_name = r_info[arena_info[creature_ptr->arena_number].r_idx].name.c_str();
             msg_format(_("あなたは%sの前に敗れ去った。", "You are beaten by %s."), m_name);

--- a/src/save/info-writer.cpp
+++ b/src/save/info-writer.cpp
@@ -90,6 +90,9 @@ void wr_options(save_type type)
     if (cheat_diary_output)
         c |= 0x8000;
 
+    if (cheat_immortal)
+        c |= 0x0020;
+
     if (type == SAVE_TYPE_DEBUG)
         c |= 0xFFFF;
 


### PR DESCRIPTION
実装してみました。実質死を欺くオプションの上位互換みたいになってしまった感はあるかもしれません。＠の生死や行動不能というかなり重大なところいじったことになるので何らかの手落ちがないかよろしくお願いします。