### PR TITLE
[Feature] 店舗商品入れ替え処理の向上

### DIFF
--- a/src/io/store-key-processor.cpp
+++ b/src/io/store-key-processor.cpp
@@ -85,18 +85,14 @@ void store_process_command(player_type *client_ptr)
             msg_print(_("これで全部です。", "Entire inventory is shown."));
         } else {
             store_top += store_bottom;
+
             /*
              * 隠しオプション(powerup_home)がセットされていないときは
              * 我が家では 2 ページまでしか表示しない
              */
-            if ((cur_store_num == STORE_HOME) && (powerup_home == FALSE) && (st_ptr->stock_num >= STORE_INVEN_MAX)) {
-                if (store_top >= (STORE_INVEN_MAX - 1)) {
-                    store_top = 0;
-                }
-            } else {
-                if (store_top >= st_ptr->stock_num)
-                    store_top = 0;
-            }
+            auto inven_max = store_get_stock_max(STORE_HOME, powerup_home);
+            if (store_top >= st_ptr->stock_num || store_top >= inven_max)
+                store_top = 0;
 
             display_store_inventory(client_ptr);
         }

--- a/src/market/building-initializer.cpp
+++ b/src/market/building-initializer.cpp
@@ -40,10 +40,7 @@ errr init_towns(void)
             if ((j == STORE_BLACK) || (j == STORE_HOME) || (j == STORE_MUSEUM))
                 continue;
 
-            store_ptr->regular_num = 0;
-            store_ptr->regular_size = STORE_INVEN_MAX;
-            C_MAKE(store_ptr->regular, store_ptr->regular_size + 1, KIND_OBJECT_IDX);
-            for (int k = 0; k < store_ptr->regular_size; k++) {
+            for (int k = 0; k < STORE_INVEN_MAX; k++) {
                 int tv = store_regular_table[j][k].tval;
                 int sv = store_regular_table[j][k].sval;
                 if (tv == 0)
@@ -54,13 +51,10 @@ errr init_towns(void)
                 if (k_idx == 0)
                     continue;
 
-                store_ptr->regular[store_ptr->regular_num++] = k_idx;
+                store_ptr->regular.push_back(k_idx);
             }
 
-            store_ptr->table_num = 0;
-            store_ptr->table_size = STORE_CHOICES;
-            C_MAKE(store_ptr->table, store_ptr->table_size + 1, KIND_OBJECT_IDX);
-            for (int k = 0; k < store_ptr->table_size; k++) {
+            for (int k = 0; k < STORE_CHOICES; k++) {
                 int tv = store_table[j][k].tval;
                 int sv = store_table[j][k].sval;
                 if (tv == 0)
@@ -71,7 +65,7 @@ errr init_towns(void)
                 if (k_idx == 0)
                     continue;
 
-                store_ptr->table[store_ptr->table_num++] = k_idx;
+                store_ptr->table.push_back(k_idx);
             }
         }
     }

--- a/src/market/building-initializer.cpp
+++ b/src/market/building-initializer.cpp
@@ -28,13 +28,7 @@ errr init_towns(void)
              * 我が家が 20 ページまで使える隠し機能のための準備。
              * オプションが有効でもそうでなくても一応スペースを作っておく。
              */
-            if (j == STORE_HOME) {
-                store_ptr->stock_size = STORE_INVEN_MAX * 10;
-            } else if (j == STORE_MUSEUM) {
-                store_ptr->stock_size = STORE_INVEN_MAX * 50;
-            } else {
-                store_ptr->stock_size = STORE_INVEN_MAX;
-            }
+            store_ptr->stock_size = store_get_stock_max(static_cast<STORE_TYPE_IDX>(j));
 
             C_MAKE(store_ptr->stock, store_ptr->stock_size, object_type);
             if ((j == STORE_BLACK) || (j == STORE_HOME) || (j == STORE_MUSEUM))

--- a/src/store/store-util.cpp
+++ b/src/store/store-util.cpp
@@ -93,6 +93,7 @@ void store_delete(void)
     store_item_optimize(what);
 }
 
+
 /*!
  * @brief 店舗の品揃え変化のためにアイテムを追加する /
  * Creates a random item and gives it to a store

--- a/src/store/store-util.cpp
+++ b/src/store/store-util.cpp
@@ -32,9 +32,8 @@ store_type *st_ptr = NULL;
  * Increase, by a given amount, the number of a certain item
  * in a certain store.	This can result in zero items.
  * </pre>
- * @todo numは本来ITEM_NUMBER型にしたい。
  */
-void store_item_increase(INVENTORY_IDX item, int num)
+void store_item_increase(INVENTORY_IDX item, ITEM_NUMBER num)
 {
     object_type *o_ptr;
     o_ptr = &st_ptr->stock[item];
@@ -45,7 +44,7 @@ void store_item_increase(INVENTORY_IDX item, int num)
         cnt = 0;
 
     num = cnt - o_ptr->number;
-    o_ptr->number += (ITEM_NUMBER)num;
+    o_ptr->number += num;
 }
 
 /*!
@@ -127,7 +126,7 @@ void store_create(
             k_idx = fix_k_idx;
             level = rand_range(1, STORE_OBJ_LEVEL);
         } else {
-            k_idx = st_ptr->table[randint0(st_ptr->table_num)];
+            k_idx = st_ptr->table[randint0(st_ptr->table.size())];
             level = rand_range(1, STORE_OBJ_LEVEL);
         }
 

--- a/src/store/store-util.h
+++ b/src/store/store-util.h
@@ -1,40 +1,44 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include <vector>
 
-#define STORE_OBJ_LEVEL 5 /* Magic Level for normal stores */
+#define STORE_OBJ_LEVEL 5 //!< 通常店舗の階層レベル / Magic Level for normal stores
 
-#define STORE_GENERAL   0 /*!< 店舗の種類: 雑貨屋 */
-#define STORE_ARMOURY   1 /*!< 店舗の種類: 防具屋 */
-#define STORE_WEAPON    2 /*!< 店舗の種類: 武器屋 */
-#define STORE_TEMPLE    3 /*!< 店舗の種類: 寺院 */
-#define STORE_ALCHEMIST 4 /*!< 店舗の種類: 錬金術の店 */
-#define STORE_MAGIC     5 /*!< 店舗の種類: 魔道具屋 */
-#define STORE_BLACK     6 /*!< 店舗の種類: ブラック・マーケット */
-#define STORE_HOME      7 /*!< 店舗の種類: 我が家 */
-#define STORE_BOOK      8 /*!< 店舗の種類: 書店 */
-#define STORE_MUSEUM    9 /*!< 店舗の種類: 博物館 */
+enum STORE_TYPE_IDX {
+    STORE_GENERAL   = 0, //!< 店舗の種類: 雑貨屋
+    STORE_ARMOURY   = 1, //!< 店舗の種類: 防具屋
+    STORE_WEAPON    = 2, //!< 店舗の種類: 武器屋
+    STORE_TEMPLE    = 3, //!< 店舗の種類: 寺院
+    STORE_ALCHEMIST = 4, //!< 店舗の種類: 錬金術の店
+    STORE_MAGIC     = 5, //!< 店舗の種類: 魔道具屋
+    STORE_BLACK     = 6, //!< 店舗の種類: ブラック・マーケット
+    STORE_HOME      = 7, //!< 店舗の種類: 我が家
+    STORE_BOOK      = 8, //!< 店舗の種類: 書店
+    STORE_MUSEUM    = 9, //!< 店舗の種類: 博物館
+    STORE_MAX       = 10
+};
 
-typedef struct object_type object_type;
-typedef struct store_type {
-	byte type;				  /* Store type */
-	byte owner;				  /* Owner index */
-	byte extra;				  /* Unused for now */
-	s16b insult_cur;		  /* Insult counter */
-	s16b good_buy;			  /* Number of "good" buys */
-	s16b bad_buy;			  /* Number of "bad" buys */
-	s32b store_open;		  /* Closed until this turn */
-	s32b last_visit;		  /* Last visited on this turn */
-    s16b regular_num;         /* Table -- Number of entries */
-    s16b regular_size;        /* Table -- Total Size of Array */
-    KIND_OBJECT_IDX *regular; /* Table -- Legal regular item kinds */
-    s16b table_num;           /* Table -- Number of entries */
-	s16b table_size;		  /* Table -- Total Size of Array */
-    KIND_OBJECT_IDX *table;   /* Table -- Legal item kinds */
-	s16b stock_num;			  /* Stock -- Number of entries */
-	s16b stock_size;		  /* Stock -- Total Size of Array */
-	object_type *stock;		  /* Stock -- Actual stock items */
-} store_type;
+using store_k_idx = std::vector<KIND_OBJECT_IDX>;
+
+/*!
+ * @brief 店舗の情報構造体
+ */
+struct store_type {
+    byte type{};           //!< Store type
+    byte owner{};          //!< Owner index
+    byte extra{};          //!< Unused for now
+    s16b insult_cur{};     //!< Insult counter
+    s16b good_buy{};       //!< Number of "good" buys
+    s16b bad_buy{};        //!< Number of "bad" buys
+    s32b store_open{};     //!< Closed until this turn
+    s32b last_visit{};     //!< Last visited on this turn
+    store_k_idx regular{}; //!< Table -- Legal regular item kinds
+    store_k_idx table{};   //!< Table -- Legal item kinds
+    s16b stock_num{};      //!< Stock -- Number of entries
+    s16b stock_size{};     //!< Stock -- Total Size of Array
+    object_type *stock{};  //!< Stock -- Actual stock items
+};
 
 extern int cur_store_num;
 extern store_type *st_ptr;
@@ -44,7 +48,7 @@ typedef bool (*store_will_buy_pf)(player_type *, object_type *);
 typedef void (*mass_produce_pf)(player_type *, object_type *);
 void store_delete(void);
 void store_create(player_type *player_ptr, KIND_OBJECT_IDX k_idx, black_market_crap_pf black_market_crap, store_will_buy_pf store_will_buy, mass_produce_pf mass_produce);
-void store_item_increase(INVENTORY_IDX item, int num);
+void store_item_increase(INVENTORY_IDX item, ITEM_NUMBER num);
 void store_item_optimize(INVENTORY_IDX item);
 int store_carry(player_type *player_ptr, object_type *o_ptr);
 bool store_object_similar(object_type *o_ptr, object_type *j_ptr);

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -325,7 +325,7 @@ void store_maintenance(player_type *player_ptr, int town_num, int store_num, int
     if (j >= st_ptr->stock_size)
         j = st_ptr->stock_size - 1;
 
-    for (int k = 0; k < st_ptr->regular_num; k++) {
+    for (size_t k = 0; k < st_ptr->regular.size(); k++) {
         store_create(player_ptr, st_ptr->regular[k], black_market_crap, store_will_buy, mass_produce);
         if (st_ptr->stock_num >= STORE_MAX_KEEP)
             break;

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -47,7 +47,24 @@ int cur_store_feat;
 /* Enable "increments" */
 bool allow_inc = FALSE;
 
-/*
+/*!
+ * @brief 店舗の最大スロット数を返す
+ * @param store_idx 店舗ID
+ * @return 店舗の最大スロット数
+ */
+s16b store_get_stock_max(STORE_TYPE_IDX store_idx, bool powerup)
+{
+    switch (store_idx) {
+    case STORE_HOME:
+        return powerup ? STORE_INVEN_MAX * 10 : STORE_INVEN_MAX;
+    case STORE_MUSEUM:
+        return STORE_INVEN_MAX * 50;
+    default:
+        return STORE_INVEN_MAX;
+    }
+}
+
+/*!
  * @brief アイテムが格納可能な数より多いかをチェックする
  * @param なし
  * @return 
@@ -295,24 +312,24 @@ void store_maintenance(player_type *player_ptr, int town_num, int store_num, int
     }
 
     INVENTORY_IDX j = st_ptr->stock_num;
-    int turn_over = 0;
-    for (int i = 0; i < chance; i++)
-        turn_over = MAX(turn_over, randint1(STORE_TURNOVER));
+    int remain = STORE_TURNOVER;
+    int turn_over = 1;
+    for (int i = 0; i < chance; i++) {
+        auto n = randint0(remain);
+        turn_over += n;
+        remain -= n;
+    }
 
     j = j - turn_over;
     if (j > STORE_MAX_KEEP)
         j = STORE_MAX_KEEP;
-
     if (j < STORE_MIN_KEEP)
         j = STORE_MIN_KEEP;
-
-    if (j < 0)
-        j = 0;
 
     while (st_ptr->stock_num > j)
         store_delete();
 
-    int diff = STORE_MAX_KEEP - st_ptr->stock_num;
+    auto diff = STORE_MAX_KEEP - st_ptr->stock_num;
     turn_over = 0;
     for (int i = 0; i < chance; i++)
         turn_over = MAX(turn_over, randint1(diff));

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -60,7 +60,7 @@ s16b store_get_stock_max(STORE_TYPE_IDX store_idx, bool powerup)
     case STORE_MUSEUM:
         return STORE_INVEN_MAX * 50;
     default:
-        return STORE_INVEN_MAX;
+        return STORE_INVEN_MAX * 3 / 2;
     }
 }
 
@@ -312,7 +312,7 @@ void store_maintenance(player_type *player_ptr, int town_num, int store_num, int
     }
 
     INVENTORY_IDX j = st_ptr->stock_num;
-    int remain = STORE_TURNOVER;
+    int remain = STORE_TURNOVER + MAX(0, j - STORE_MAX_KEEP);
     int turn_over = 1;
     for (int i = 0; i < chance; i++) {
         auto n = randint0(remain);
@@ -329,10 +329,13 @@ void store_maintenance(player_type *player_ptr, int town_num, int store_num, int
     while (st_ptr->stock_num > j)
         store_delete();
 
-    auto diff = STORE_MAX_KEEP - st_ptr->stock_num;
-    turn_over = 0;
-    for (int i = 0; i < chance; i++)
-        turn_over = MAX(turn_over, randint1(diff));
+    remain = STORE_MAX_KEEP - st_ptr->stock_num;
+    turn_over = 1;
+    for (int i = 0; i < chance; i++) {
+        auto n = randint0(remain);
+        turn_over += n;
+        remain -= n;
+    }
 
     j = st_ptr->stock_num + turn_over;
     if (j > STORE_MAX_KEEP)

--- a/src/store/store.h
+++ b/src/store/store.h
@@ -2,6 +2,7 @@
 
 #include "system/angband.h"
 #include "store/store-owners.h"
+#include "store/store-util.h"
 
  /* Store constants */
 #define STORE_INVEN_MAX 24              /* Max number of discrete objs in inven */
@@ -21,6 +22,7 @@ extern s16b inner_town_num;
 extern int cur_store_feat;
 extern bool allow_inc;
 
+s16b store_get_stock_max(STORE_TYPE_IDX store_idx, bool powerup = true);
 void store_shuffle(player_type *player_ptr, int which);
 void store_maintenance(player_type *player_ptr, int town_num, int store_num, int chance);
 void store_init(int town_num, int store_num);

--- a/src/store/store.h
+++ b/src/store/store.h
@@ -6,9 +6,9 @@
 
  /* Store constants */
 #define STORE_INVEN_MAX 24              /* Max number of discrete objs in inven */
-#define STORE_TURNOVER  9               /* Normal shop turnover, per day */
+#define STORE_TURNOVER  12              /* Normal shop turnover, per day */
 #define STORE_MIN_KEEP  6               /* Min slots to "always" keep full */
-#define STORE_MAX_KEEP  18              /* Max slots to "always" keep full */
+#define STORE_MAX_KEEP  21              /* Max slots to "always" keep full */
 #define STORE_SHUFFLE   21              /* 1/Chance (per day) of an owner changing */
 #define STORE_TICKS     1000            /* Number of ticks between turnovers */
 


### PR DESCRIPTION
**\*注意\* セーブデータバージョンは上がりませんが、店舗が24アイテムを超えて陳列しているセーブデータは過去のバージョンで読み込めない可能性があります**。

-----

店舗スロット最大数を関数で取得するように変更して、店舗の最大スロット数を3ページ(24*3)に増加して物を売るスペースを確保。
できるだけ多くの商品数が入れ替わるように処理を変えた。