### PR TITLE
[Feature] モンスター遭遇時にBGMを再生する

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -360,6 +360,8 @@
     <ClCompile Include="..\..\src\main\info-initializer.cpp" />
     <ClCompile Include="..\..\src\main\init-error-messages-table.cpp" />
     <ClCompile Include="..\..\src\main-win\main-win-bg.cpp" />
+    <ClCompile Include="..\..\src\main\scene-table-floor.cpp" />
+    <ClCompile Include="..\..\src\main\scene-table-monster.cpp" />
     <ClCompile Include="..\..\src\main\scene-table.cpp" />
     <ClCompile Include="..\..\src\market\building-initializer.cpp" />
     <ClCompile Include="..\..\src\melee\melee-spell-flags-checker.cpp" />
@@ -1039,6 +1041,8 @@
     <ClInclude Include="..\..\src\main\init-error-messages-table.h" />
     <ClInclude Include="..\..\src\main-win\main-win-bg.h" />
     <ClInclude Include="..\..\src\main-win\main-win-windows.h" />
+    <ClInclude Include="..\..\src\main\scene-table-floor.h" />
+    <ClInclude Include="..\..\src\main\scene-table-monster.h" />
     <ClInclude Include="..\..\src\main\scene-table.h" />
     <ClInclude Include="..\..\src\market\building-initializer.h" />
     <ClInclude Include="..\..\src\melee\melee-spell-flags-checker.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2253,6 +2253,12 @@
     <ClCompile Include="..\..\src\store\store-key-processor.cpp">
       <Filter>store</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\main\scene-table-floor.cpp">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\scene-table-monster.cpp">
+      <Filter>main</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -4832,6 +4838,12 @@
     </ClInclude>
     <ClInclude Include="..\..\src\main-win\main-win-menuitem.h">
       <Filter>main-win</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\scene-table-floor.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\scene-table-monster.h">
+      <Filter>main</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\monster-race\race-ability-flags.h">
       <Filter>monster-race</Filter>

--- a/lib/xtra/music/music.cfg
+++ b/lib/xtra/music/music.cfg
@@ -32,6 +32,10 @@ type = MPEGVideo
 # quest_clear       クエストをクリアした時からフロアを移る時まで 
 # final_quest_clear 最終クエスト（＊勝利＊条件）をクリアした時からフロアを移る時まで
 # ambush    襲撃を受けてフロアを移る時まで
+# unique    ユニークモンスターに遭遇時
+# shadower  あやしい影に遭遇時
+# unk_monster 未知のモンスターに遭遇時
+# hl_monster レベルの高いモンスターに遭遇時
 [Basic]
 gameover = 
 exit = 
@@ -53,6 +57,10 @@ battle =
 quest_clear = 
 final_quest_clear = 
 ambush = 
+unique = 
+shadower = 
+unk_monster = 
+hl_monster = 
 
 # [Town]項目
 # 町の個別BGMを指定します
@@ -78,3 +86,12 @@ ambush =
 [Quest]
 # 001は盗賊の隠れ家です
 # quest001 = quest.mp3
+
+# [Monster]項目
+# モンスターの個別BGMを指定します
+# 以下の区間にmonster[モンスターID] = [ファイル名]の形で設定して下さい
+# IDは0001と四桁で指定して下さい。
+# 特に設定されていない場合、[Basic]の設定に従います
+[Monster]
+# 0001は汚いイタズラ小僧です
+# monster0001 = monster.mp3

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -377,6 +377,8 @@ hengband_SOURCES = \
 	main/init-error-messages-table.cpp main/init-error-messages-table.h \
 	main/music-definitions-table.cpp main/music-definitions-table.h \
 	main/scene-table.cpp main/scene-table.h \
+	main/scene-table-floor.cpp main/scene-table-floor.h \
+	main/scene-table-monster.cpp main/scene-table-monster.h \
 	main/sound-definitions-table.cpp main/sound-definitions-table.h \
 	main/sound-of-music.cpp main/sound-of-music.h \
 	main/x11-gamma-builder.cpp main/x11-gamma-builder.h \

--- a/src/core/window-redrawer.cpp
+++ b/src/core/window-redrawer.cpp
@@ -256,10 +256,9 @@ void window_stuff(player_type *player_ptr)
         fix_player(player_ptr);
     }
 
-    if (window_flags & (PW_MONSTER_LIST)) {
-        player_ptr->window_flags &= ~(PW_MONSTER_LIST);
-        fix_monster_list(player_ptr);
-    }
+    // Always call without PW_MONSTER_LIST flag
+    player_ptr->window_flags &= ~(PW_MONSTER_LIST);
+    fix_monster_list(player_ptr);
 
     if (window_flags & (PW_MESSAGE)) {
         player_ptr->window_flags &= ~(PW_MESSAGE);

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -1151,14 +1151,14 @@ static errr term_xtra_win_music(int n, int v)
 /*
  * Hack -- play a music matches a situation
  */
-static errr term_xtra_win_scene()
+static errr term_xtra_win_scene(int v)
 {
     // TODO 場面に合った壁紙変更対応
     if (!use_music) {
         return 1;
     }
 
-    return main_win_music::play_music_scene();
+    return main_win_music::play_music_scene(v);
 }
 
 /*
@@ -1183,14 +1183,15 @@ static errr term_xtra_win(int n, int v)
     case TERM_XTRA_MUSIC_BASIC:
     case TERM_XTRA_MUSIC_DUNGEON:
     case TERM_XTRA_MUSIC_QUEST:
-    case TERM_XTRA_MUSIC_TOWN: {
+    case TERM_XTRA_MUSIC_TOWN:
+    case TERM_XTRA_MUSIC_MONSTER: {
         return term_xtra_win_music(n, v);
     }
     case TERM_XTRA_MUSIC_MUTE: {
         return main_win_music::stop_music();
     }
     case TERM_XTRA_SCENE: {
-        return term_xtra_win_scene();
+        return term_xtra_win_scene(v);
     }
     case TERM_XTRA_SOUND: {
         return (term_xtra_win_sound(v));

--- a/src/main-win/main-win-cfg-reader.cpp
+++ b/src/main-win/main-win-cfg-reader.cpp
@@ -61,6 +61,12 @@ concptr CfgData::get_rand(int key1_type, int key2_val)
     return filenames->at(Rand_external(filenames->size()));
 }
 
+bool CfgData::has_key(int key1_type, int key2_val)
+{
+    auto ite = map->find(make_cfg_key(key1_type, key2_val));
+    return (ite != map->end());
+}
+
 void CfgData::insert(int key1_type, int key2_val, cfg_values *value)
 {
     this->map->insert(std::make_pair(make_cfg_key(key1_type, key2_val), value));
@@ -96,6 +102,7 @@ CfgData *CfgReader::read_sections(std::initializer_list<cfg_section> sections)
 
     for (auto &section : sections) {
     
+        bool has_data = false;
         int index = 0;
         concptr read_key;
         while ((read_key = section.key_at(index, key_buf)) != NULL) {
@@ -112,10 +119,15 @@ CfgData *CfgReader::read_sections(std::initializer_list<cfg_section> sections)
                     delete filenames;
                 } else {
                     result->insert(section.action_type, index, filenames);
+                    has_data = true;
                 }
             }
 
             index++;
+        }
+
+        if (section.has_data) {
+            *(section.has_data) = has_data;
         }
     }
 

--- a/src/main-win/main-win-cfg-reader.h
+++ b/src/main-win/main-win-cfg-reader.h
@@ -32,6 +32,8 @@ struct cfg_section {
      * *action-val : the 2nd parameter of "term_xtra()"
      */
     key_name_func key_at;
+    //! 1つでもデータを読み込めた場合にtrueを設定する。（NULLの場合を除く）
+    bool *has_data = NULL;
 };
 
 class CfgData {
@@ -45,6 +47,7 @@ public:
         delete map;
     }
     concptr get_rand(int key1_type, int key2_val);
+    bool has_key(int key1_type, int key2_val);
     void insert(int key1_type, int key2_val, cfg_values *value);
 
 protected:

--- a/src/main-win/main-win-music.cpp
+++ b/src/main-win/main-win-music.cpp
@@ -12,6 +12,8 @@
 #include "main-win/main-win-mmsystem.h"
 #include "main-win/main-win-tokenizer.h"
 #include "main/scene-table.h"
+#include "main/sound-of-music.h"
+#include "monster-race/monster-race.h"
 #include "term/z-term.h"
 #include "util/angband-files.h"
 #include "world/world.h"
@@ -109,6 +111,26 @@ static concptr town_key_at(int index, char *buf)
     return buf;
 }
 
+static inline MONRACE_IDX get_monster_count()
+{
+    return max_r_idx;
+}
+
+/*!
+ * @brief action-valに対応する[Monster]セクションのキー名を取得する
+ * @param index "term_xtra()"の第2引数action-valに対応する値
+ * @param buf バッファ
+ * @return 対応するキー名を返す
+ */
+static concptr monster_key_at(int index, char *buf)
+{
+    if (index >= get_monster_count())
+        return NULL;
+
+    sprintf(buf, "monster%04d", index);
+    return buf;
+}
+
 /*!
  * @brief BGMの設定を読み込む。
  * @details
@@ -126,9 +148,20 @@ void load_music_prefs()
         { "Basic", TERM_XTRA_MUSIC_BASIC, basic_key_at },
         { "Dungeon", TERM_XTRA_MUSIC_DUNGEON, dungeon_key_at },
         { "Quest", TERM_XTRA_MUSIC_QUEST, quest_key_at },
-        { "Town", TERM_XTRA_MUSIC_TOWN, town_key_at }
+        { "Town", TERM_XTRA_MUSIC_TOWN, town_key_at },
+        { "Monster", TERM_XTRA_MUSIC_MONSTER, monster_key_at, &has_monster_music }
         });
     // clang-format on
+
+    if (!has_monster_music) {
+        int type = TERM_XTRA_MUSIC_BASIC;
+        for (int val = MUSIC_BASIC_UNIQUE; val <= MUSIC_BASIC_HIGHER_LEVEL_MONSTER; val++) {
+            if (music_cfg_data->has_key(type, val)) {
+                has_monster_music = true;
+                break;
+            }
+        }
+    }
 }
 
 /*
@@ -182,13 +215,15 @@ errr play_music(int type, int val)
 /*
  * Play a music matches a situation
  */
-errr play_music_scene()
+errr play_music_scene(int val)
 {
-    // テーブルの先頭から順に再生を試み、再生できたら抜ける
-    auto ite = get_scene_table_iterator();
+    // リストの先頭から順に再生を試み、再生できたら抜ける
+    auto list = get_scene_type_list(val);
     const errr err_sucsess = 0;
-    while (play_music(ite->type, ite->val) != err_sucsess) {
-        ++ite;
+    for (auto &item : list) {
+        if (play_music(item.type, item.val) == err_sucsess) {
+            break;
+        }
     }
 
     return 0;

--- a/src/main-win/main-win-music.h
+++ b/src/main-win/main-win-music.h
@@ -14,6 +14,6 @@ namespace main_win_music {
 void load_music_prefs();
 errr stop_music(void);
 errr play_music(int type, int val);
-errr play_music_scene();
+errr play_music_scene(int val);
 void on_mci_notify(WPARAM wFlags, LONG lDevID);
 }

--- a/src/main/music-definitions-table.cpp
+++ b/src/main/music-definitions-table.cpp
@@ -24,4 +24,8 @@ const concptr angband_music_basic_name[MUSIC_BASIC_MAX] =
 	"quest_clear",
 	"final_quest_clear",
 	"ambush",
+    "unique",
+    "shadower",
+    "unk_monster",
+    "hl_monster",
 };

--- a/src/main/music-definitions-table.h
+++ b/src/main/music-definitions-table.h
@@ -22,7 +22,11 @@ enum music_type {
     MUSIC_BASIC_QUEST_CLEAR = 18,
     MUSIC_BASIC_FINAL_QUEST_CLEAR = 19,
     MUSIC_BASIC_AMBUSH = 20,
-    MUSIC_BASIC_MAX = 21, /*!< BGM定義の最大数 */
+    MUSIC_BASIC_UNIQUE = 21,
+    MUSIC_BASIC_SHADOWER = 22,
+    MUSIC_BASIC_UNKNOWN_MONSTER = 23,
+    MUSIC_BASIC_HIGHER_LEVEL_MONSTER = 24,
+    MUSIC_BASIC_MAX = 25, /*!< BGM定義の最大数 */
 };
 
 extern const concptr angband_music_basic_name[MUSIC_BASIC_MAX];

--- a/src/main/scene-table-floor.cpp
+++ b/src/main/scene-table-floor.cpp
@@ -1,0 +1,195 @@
+﻿#include "main/scene-table-floor.h"
+#include "dungeon/quest.h"
+#include "main/music-definitions-table.h"
+#include "system/floor-type-definition.h"
+
+using scene_feel_func = bool (*)(player_type *player_ptr, scene_type *value);
+
+static bool scene_basic(player_type *player_ptr, scene_type *value)
+{
+    if (player_ptr->ambush_flag) {
+        value->type = TERM_XTRA_MUSIC_BASIC;
+        value->val = MUSIC_BASIC_AMBUSH;
+        return true;
+    }
+
+    if (player_ptr->wild_mode) {
+        value->type = TERM_XTRA_MUSIC_BASIC;
+        value->val = MUSIC_BASIC_WILD;
+        return true;
+    }
+
+    if (player_ptr->current_floor_ptr->inside_arena) {
+        value->type = TERM_XTRA_MUSIC_BASIC;
+        value->val = MUSIC_BASIC_ARENA;
+        return true;
+    }
+
+    if (player_ptr->phase_out) {
+        value->type = TERM_XTRA_MUSIC_BASIC;
+        value->val = MUSIC_BASIC_BATTLE;
+        return true;
+    }
+
+    return false;
+}
+
+static bool scene_quest(player_type *player_ptr, scene_type *value)
+{
+    const QUEST_IDX quest_id = quest_number(player_ptr, player_ptr->current_floor_ptr->dun_level);
+    const bool enable = (quest_id > 0);
+    if (enable) {
+        value->type = TERM_XTRA_MUSIC_QUEST;
+        value->val = quest_id;
+    }
+
+    return enable;
+}
+
+static bool scene_quest_basic(player_type *player_ptr, scene_type *value)
+{
+    const QUEST_IDX quest_id = quest_number(player_ptr, player_ptr->current_floor_ptr->dun_level);
+    const bool enable = (quest_id > 0);
+    if (enable) {
+        value->type = TERM_XTRA_MUSIC_BASIC;
+        value->val = MUSIC_BASIC_QUEST;
+    }
+
+    return enable;
+}
+
+static bool scene_town(player_type *player_ptr, scene_type *value)
+{
+    const bool enable = !is_in_dungeon(player_ptr) && (player_ptr->town_num > 0);
+    if (enable) {
+        value->type = TERM_XTRA_MUSIC_TOWN;
+        value->val = player_ptr->town_num;
+    }
+    return enable;
+}
+
+static bool scene_town_basic(player_type *player_ptr, scene_type *value)
+{
+    const bool enable = !is_in_dungeon(player_ptr) && (player_ptr->town_num > 0);
+    if (enable) {
+        value->type = TERM_XTRA_MUSIC_BASIC;
+        value->val = MUSIC_BASIC_TOWN;
+    }
+    return enable;
+}
+
+static bool scene_field(player_type *player_ptr, scene_type *value)
+{
+    const bool enable = !is_in_dungeon(player_ptr);
+    if (enable) {
+        value->type = TERM_XTRA_MUSIC_BASIC;
+
+        if (player_ptr->lev >= 45)
+            value->val = MUSIC_BASIC_FIELD3;
+        else if (player_ptr->lev >= 25)
+            value->val = MUSIC_BASIC_FIELD2;
+        else
+            value->val = MUSIC_BASIC_FIELD1;
+    }
+    return enable;
+}
+
+static bool scene_dungeon_feeling(player_type *player_ptr, scene_type *value)
+{
+    const bool enable = (player_ptr->feeling >= 2) && (player_ptr->feeling <= 5);
+    if (enable) {
+        value->type = TERM_XTRA_MUSIC_BASIC;
+
+        if (player_ptr->feeling == 2)
+            value->val = MUSIC_BASIC_DUN_FEEL2;
+        else
+            value->val = MUSIC_BASIC_DUN_FEEL1;
+    }
+    return enable;
+}
+
+static bool scene_dungeon(player_type *player_ptr, scene_type *value)
+{
+    const bool enable = (player_ptr->dungeon_idx > 0);
+    if (enable) {
+        value->type = TERM_XTRA_MUSIC_DUNGEON;
+        value->val = player_ptr->dungeon_idx;
+    }
+    return enable;
+}
+
+static bool scene_dungeon_basic(player_type *player_ptr, scene_type *value)
+{
+    const bool enable = is_in_dungeon(player_ptr);
+    if (enable) {
+        value->type = TERM_XTRA_MUSIC_BASIC;
+
+        const auto dun_level = player_ptr->current_floor_ptr->dun_level;
+        if (dun_level >= 80)
+            value->val = MUSIC_BASIC_DUN_HIGH;
+        else if (dun_level >= 40)
+            value->val = MUSIC_BASIC_DUN_MED;
+        else
+            value->val = MUSIC_BASIC_DUN_LOW;
+    }
+    return enable;
+}
+
+static bool scene_mute(player_type *player_ptr, scene_type *value)
+{
+    (void)player_ptr;
+    value->type = TERM_XTRA_MUSIC_MUTE;
+    value->val = 0;
+    return true;
+}
+
+/*! シチュエーション選択のフォールバック設定。
+ * 先頭から適用する（先にある方を優先する）。
+ */
+std::vector<scene_feel_func> scene_floor_def_list = {
+    // scene_basic : ambush, wild, arena, battleの判定
+    scene_basic,
+    // scene_quest : questの判定（クエストの個別BGMを指定）
+    scene_quest,
+    // scene_quest_basic : questの判定 (Basicのquest指定)
+    scene_quest_basic,
+    // scene_town : townの判定（町の個別BGMを指定）
+    scene_town,
+    // scene_town_basic : townの判定 (Basicのtown指定)
+    scene_town_basic,
+    // scene_field : field1/2/3の判定（プレイヤーレベル25未満、25以上45未満、45以上時の荒野）
+    scene_field,
+    // scene_dungeon_feeling : feed1/2の判定（ダンジョンの雰囲気が「悪い予感」～「とても危険」、「死の幻」）
+    scene_dungeon_feeling,
+    // scene_dungeon : dungeonの判定（ダンジョンの個別BGMを指定）
+    scene_dungeon,
+    // scene_dungeon_basic : dun_low/med/highの判定（ダンジョンレベルが40未満、40以上80未満、80以上）
+    scene_dungeon_basic,
+    // scene_mute : 最後にミュートを配置する
+    scene_mute
+};
+
+int get_scene_floor_count()
+{
+    return scene_floor_def_list.size();
+}
+
+/*!
+ * @brief 現在の条件でフロアのBGM選曲をリストに設定する。
+ * @details リストのfrom_indexの位置から、get_scene_floor_count()で得られる個数分設定する。
+ * @param player_ptr プレーヤーへの参照ポインタ
+ * @param list BGM選曲リスト
+ * @param from_index リストの更新開始位置
+ */
+void refresh_scene_floor(player_type *player_ptr, scene_type_list &list, int from_index)
+{
+    for (auto func : scene_floor_def_list) {
+        scene_type &item = list[from_index];
+        if (!func(player_ptr, &item)) {
+            // Note -- 特に定義を設けていないが、type = 0は無効な値とする。
+            item.type = 0;
+            item.val = 0;
+        }
+        ++from_index;
+    }
+}

--- a/src/main/scene-table-floor.h
+++ b/src/main/scene-table-floor.h
@@ -1,0 +1,7 @@
+﻿#pragma once
+
+#include "main/scene-table.h"
+#include "system/angband.h"
+
+int get_scene_floor_count();
+void refresh_scene_floor(player_type *player_ptr, scene_type_list &list, int start_index);

--- a/src/main/scene-table-monster.cpp
+++ b/src/main/scene-table-monster.cpp
@@ -1,0 +1,271 @@
+﻿#include "main/scene-table-monster.h"
+#include "dungeon/quest.h"
+#include "main/music-definitions-table.h"
+#include "monster-race/monster-race.h"
+#include "monster-race/race-flags1.h"
+#include "system/floor-type-definition.h"
+#include "util/bit-flags-calculator.h"
+#include "world/world.h"
+
+struct scene_monster_info {
+    MONSTER_IDX m_idx;
+    monster_race *ap_r_ptr;
+    GAME_TURN last_seen; //!< 最後に対象モンスター見たゲームターン
+    u32b mute_until; //!< この時間に到達するまでモンスターBGMは設定しない
+};
+
+scene_monster_info scene_target_monster;
+
+inline static bool has_shadower_flag(monster_type *m_ptr)
+{
+    return m_ptr->mflag2.has(MFLAG2::KAGE);
+}
+
+inline static bool is_unique(monster_race *ap_r_ptr)
+{
+    return any_bits(ap_r_ptr->flags1, RF1_UNIQUE);
+}
+
+inline static bool is_unknown_monster(monster_race *ap_r_ptr)
+{
+    return (ap_r_ptr->r_tkills == 0);
+}
+
+void clear_scene_target_monster()
+{
+    scene_target_monster.ap_r_ptr = NULL;
+}
+
+static GAME_TURN get_game_turn()
+{
+    GAME_TURN ret = current_world_ptr->game_turn;
+    if (ret == current_world_ptr->game_turn_limit) {
+        ret = 0;
+    }
+    return ret;
+}
+
+/*!
+ * @brief モンスターBGMの制限期間を設定する
+ * @details 指定の時間が経過するまでモンスターBGMの再生を制限する
+ * @param msec 制限する時間（秒）
+ */
+void set_temp_mute_scene_monster(int sec)
+{
+    scene_target_monster.mute_until = (u32b)time(NULL) + sec;
+}
+
+/*!
+ * @brief モンスターBGMの制限期間か判定する
+ * @details ダンジョンターン数がscene_target_monster.mute_untilの値になるまで制限期間。
+ * @return モンスターBGMの制限期間の場合trueを返す
+ */
+inline static bool can_mute_scene_monster()
+{
+    return (scene_target_monster.mute_until > time(NULL));
+}
+
+/*!
+ * @brief モンスターの優先判定
+ * @details ユニーク、あやしい影、未知のモンスター、レベルの高さ、モンスターIDで優先を付ける。
+ * @param player_ptr プレーヤーへの参照ポインタ
+ * @param m_idx1 モンスターA（新参）
+ * @param m_idx2 モンスターB（現対象）
+ * @retval true モンスターAが優先
+ * @retval false モンスターBが優先
+ */
+static bool is_high_rate(player_type *player_ptr, MONSTER_IDX m_idx1, MONSTER_IDX m_idx2)
+{
+    // FIXME 視界内モンスターリストの比較関数と同じ処理
+    auto floor_ptr = player_ptr->current_floor_ptr;
+    auto m_ptr1 = &floor_ptr->m_list[m_idx1];
+    auto m_ptr2 = &floor_ptr->m_list[m_idx2];
+    auto ap_r_ptr1 = &r_info[m_ptr1->ap_r_idx];
+    auto ap_r_ptr2 = &r_info[m_ptr2->ap_r_idx];
+
+    /* Unique monsters first */
+    if (any_bits(ap_r_ptr1->flags1, RF1_UNIQUE) != any_bits(ap_r_ptr2->flags1, RF1_UNIQUE))
+        return any_bits(ap_r_ptr1->flags1, RF1_UNIQUE);
+
+    /* Shadowers first (あやしい影) */
+    if (m_ptr1->mflag2.has(MFLAG2::KAGE) != m_ptr2->mflag2.has(MFLAG2::KAGE))
+        return m_ptr1->mflag2.has(MFLAG2::KAGE);
+
+    /* Unknown monsters first */
+    if ((ap_r_ptr1->r_tkills == 0) != (ap_r_ptr2->r_tkills == 0))
+        return (ap_r_ptr1->r_tkills == 0);
+
+    /* Higher level monsters first (if known) */
+    if (ap_r_ptr1->r_tkills && ap_r_ptr2->r_tkills && ap_r_ptr1->level != ap_r_ptr2->level)
+        return ap_r_ptr1->level > ap_r_ptr2->level;
+
+    /* Sort by index if all conditions are same */
+    return m_ptr1->ap_r_idx > m_ptr2->ap_r_idx;
+}
+
+/*!
+ * @brief BGM対象モンスター更新処理
+ * @details 現在の対象と対象候補が同一モンスターの場合、最後に見たゲームターン情報を更新する。
+ * 対象候補が現在の対象よりも上位であれば対象を入れ替える。
+ * ユニーク、あやしい影、未知のモンスター、レベルの高さ、モンスターIDで優先を付ける。
+ * @param player_ptr プレーヤーへの参照ポインタ
+ * @param m_idx BGM対象候補のモンスター
+ */
+static void update_target_monster(player_type *player_ptr, MONSTER_IDX m_idx)
+{
+    if (scene_target_monster.ap_r_ptr && (scene_target_monster.m_idx == m_idx)) {
+        // 同一モンスター。最後に見たゲームターンを更新。
+        scene_target_monster.last_seen = get_game_turn();
+    } else {
+        bool do_dwap = false;
+        if (!scene_target_monster.ap_r_ptr) {
+            // 空席
+            do_dwap = true;
+        } else if (is_high_rate(player_ptr, m_idx, scene_target_monster.m_idx)) {
+            // 入れ替え
+            do_dwap = true;
+        }
+
+        if (do_dwap) {
+            monster_type *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
+            monster_race *ap_r_ptr = &r_info[m_ptr->ap_r_idx];
+            scene_target_monster.m_idx = m_idx;
+            scene_target_monster.ap_r_ptr = ap_r_ptr;
+            scene_target_monster.last_seen = get_game_turn();
+        }
+    }
+}
+
+using scene_monster_func = bool (*)(player_type *player_ptr, scene_type *value);
+
+static bool scene_monster(player_type *player_ptr, scene_type *value)
+{
+    monster_type *m_ptr = &player_ptr->current_floor_ptr->m_list[scene_target_monster.m_idx];
+
+    if (has_shadower_flag(m_ptr)) {
+        value->type = TERM_XTRA_MUSIC_BASIC;
+        value->val = MUSIC_BASIC_SHADOWER;
+        return true;
+    } else {
+        value->type = TERM_XTRA_MUSIC_MONSTER;
+        value->val = m_ptr->ap_r_idx;
+        return true;
+    }
+}
+
+static bool scene_unique(player_type *player_ptr, scene_type *value)
+{
+    (void)player_ptr;
+
+    if (is_unique(scene_target_monster.ap_r_ptr)) {
+        value->type = TERM_XTRA_MUSIC_BASIC;
+        value->val = MUSIC_BASIC_UNIQUE;
+        return true;
+    }
+
+    return false;
+}
+
+static bool scene_unknown(player_type *player_ptr, scene_type *value)
+{
+    (void)player_ptr;
+    if (is_unknown_monster(scene_target_monster.ap_r_ptr)) {
+        value->type = TERM_XTRA_MUSIC_BASIC;
+        value->val = MUSIC_BASIC_UNKNOWN_MONSTER;
+        return true;
+    }
+
+    return false;
+}
+
+static bool scene_high_level(player_type *player_ptr, scene_type *value)
+{
+    if (!is_unknown_monster(scene_target_monster.ap_r_ptr) && (scene_target_monster.ap_r_ptr->level >= player_ptr->lev)) {
+        value->type = TERM_XTRA_MUSIC_BASIC;
+        value->val = MUSIC_BASIC_HIGHER_LEVEL_MONSTER;
+        return true;
+    }
+
+    return false;
+}
+
+/*! モンスターBGMのフォールバック設定。
+ * 先頭から適用する（先にある方を優先する）。
+ */
+std::vector<scene_monster_func> scene_monster_def_list = {
+    // scene_monster : あやしい影 or モンスターID
+    scene_monster,
+    // scene_unique : ユニークモンスター判定
+    scene_unique,
+    // scene_unkown : 未知のモンスター判定
+    scene_unknown,
+    // scene_high_level : 高レベルのモンスター判定
+    scene_high_level,
+};
+
+int get_scene_monster_count()
+{
+    return scene_monster_def_list.size();
+}
+
+/*!
+ * @brief 現在の条件でモンスターのBGM選曲をリストに設定する。
+ * @details リストのfrom_indexの位置から、get_scene_monster_count()で得られる個数分設定する。
+ * 視界内モンスターリスト先頭のモンスターを記憶し、以前のモンスターと比較してより上位のモンスターをBGM選曲の対象とする。
+ * 記憶したモンスターが視界内に存在しない場合、一定のゲームターン経過で忘れる。
+ * @param player_ptr プレーヤーへの参照ポインタ
+ * @param monster_list 視界内モンスターリスト
+ * @param list BGM選曲リスト
+ * @param from_index リストの更新開始位置
+ */
+void refresh_scene_monster(player_type *player_ptr, const std::vector<MONSTER_IDX> &monster_list, scene_type_list &list, int from_index)
+{
+    const bool mute = can_mute_scene_monster();
+
+    if (mute) {
+        // モンスターBGM制限中
+        clear_scene_target_monster();
+    } else {
+        if (scene_target_monster.ap_r_ptr) {
+            // BGM対象から外すチェック
+            if (get_game_turn() - scene_target_monster.last_seen >= 200) {
+                // 最後に見かけてから一定のゲームターンが経過した場合、BGM対象から外す
+                clear_scene_target_monster();
+            } else {
+                monster_type *m_ptr = &player_ptr->current_floor_ptr->m_list[scene_target_monster.m_idx];
+                monster_race *ap_r_ptr = &r_info[m_ptr->ap_r_idx];
+                if (ap_r_ptr != scene_target_monster.ap_r_ptr) {
+                    // 死亡、チェンジモンスター、etc.
+                    clear_scene_target_monster();
+                }
+            }
+        }
+
+        if (!monster_list.empty()) {
+            // 現在のBGM対象とモンスターリスト先頭を比較し、上位をBGM対象に設定する
+            update_target_monster(player_ptr, monster_list.front());
+        }
+    }
+
+    if (scene_target_monster.ap_r_ptr) {
+        // BGM対象の条件で選曲リストを設定する
+        for (auto func : scene_monster_def_list) {
+            scene_type &item = list[from_index];
+            if (!func(player_ptr, &item)) {
+                // Note -- 特に定義を設けていないが、type = 0は無効な値とする。
+                item.type = 0;
+                item.val = 0;
+            }
+            ++from_index;
+        }
+    } else {
+        // BGM対象なしの場合は0で埋める
+        const int count = get_scene_monster_count();
+        for (int i = 0; i < count; i++) {
+            scene_type &item = list[from_index + i];
+            // Note -- 特に定義を設けていないが、type = 0は無効な値とする。
+            item.type = 0;
+            item.val = 0;
+        }
+    }
+}

--- a/src/main/scene-table-monster.h
+++ b/src/main/scene-table-monster.h
@@ -1,0 +1,10 @@
+﻿#pragma once
+
+#include "main/scene-table.h"
+#include "system/angband.h"
+#include "system/monster-race-definition.h"
+
+void clear_scene_target_monster();
+void set_temp_mute_scene_monster(int sec);
+int get_scene_monster_count();
+void refresh_scene_monster(player_type *player_ptr, const std::vector<MONSTER_IDX> &monster_list, scene_type_list &list, int from_index);

--- a/src/main/scene-table.cpp
+++ b/src/main/scene-table.cpp
@@ -1,184 +1,84 @@
 ﻿#include "main/scene-table.h"
-#include "dungeon/quest.h"
-#include "main/music-definitions-table.h"
+#include "main/scene-table-floor.h"
+#include "main/scene-table-monster.h"
 #include "system/floor-type-definition.h"
+#include "term/z-term.h"
 
-static bool scene_basic(player_type *player_ptr, scene_type *value)
+int interrupt_scene_type;
+int interrupt_scene_val;
+
+scene_type_list scene_list;
+
+static void resize_scene_list()
 {
-    if (player_ptr->ambush_flag) {
-        value->type = TERM_XTRA_MUSIC_BASIC;
-        value->val = MUSIC_BASIC_AMBUSH;
-        return true;
-    }
-
-    if (player_ptr->wild_mode) {
-        value->type = TERM_XTRA_MUSIC_BASIC;
-        value->val = MUSIC_BASIC_WILD;
-        return true;
-    }
-
-    if (player_ptr->current_floor_ptr->inside_arena) {
-        value->type = TERM_XTRA_MUSIC_BASIC;
-        value->val = MUSIC_BASIC_ARENA;
-        return true;
-    }
-
-    if (player_ptr->phase_out) {
-        value->type = TERM_XTRA_MUSIC_BASIC;
-        value->val = MUSIC_BASIC_BATTLE;
-        return true;
-    }
-
-    return false;
+    const int monster_def_count = get_scene_monster_count();
+    const int interrupt_def_count = 1;
+    const int floor_def_count = get_scene_floor_count();
+    scene_list.resize(monster_def_count + interrupt_def_count + floor_def_count);
 }
 
-static bool scene_quest(player_type *player_ptr, scene_type *value)
-{
-    const QUEST_IDX quest_id = quest_number(player_ptr, player_ptr->current_floor_ptr->dun_level);
-    const bool enable = (quest_id > 0);
-    if (enable) {
-        value->type = TERM_XTRA_MUSIC_QUEST;
-        value->val = quest_id;
-    }
-
-    return enable;
-}
-
-static bool scene_quest_basic(player_type *player_ptr, scene_type *value)
-{
-    const QUEST_IDX quest_id = quest_number(player_ptr, player_ptr->current_floor_ptr->dun_level);
-    const bool enable = (quest_id > 0);
-    if (enable) {
-        value->type = TERM_XTRA_MUSIC_BASIC;
-        value->val = MUSIC_BASIC_QUEST;
-    }
-
-    return enable;
-}
-
-static bool scene_town(player_type *player_ptr, scene_type *value)
-{
-    const bool enable = !is_in_dungeon(player_ptr) && (player_ptr->town_num > 0);
-    if (enable) {
-        value->type = TERM_XTRA_MUSIC_TOWN;
-        value->val = player_ptr->town_num;
-    }
-    return enable;
-}
-
-static bool scene_town_basic(player_type *player_ptr, scene_type *value)
-{
-    const bool enable = !is_in_dungeon(player_ptr) && (player_ptr->town_num > 0);
-    if (enable) {
-        value->type = TERM_XTRA_MUSIC_BASIC;
-        value->val = MUSIC_BASIC_TOWN;
-    }
-    return enable;
-}
-
-static bool scene_field(player_type *player_ptr, scene_type *value)
-{
-    const bool enable = !is_in_dungeon(player_ptr);
-    if (enable) {
-        value->type = TERM_XTRA_MUSIC_BASIC;
-
-        if (player_ptr->lev >= 45)
-            value->val = MUSIC_BASIC_FIELD3;
-        else if (player_ptr->lev >= 25)
-            value->val = MUSIC_BASIC_FIELD2;
-        else
-            value->val = MUSIC_BASIC_FIELD1;
-    }
-    return enable;
-}
-
-static bool scene_dungeon_feeling(player_type *player_ptr, scene_type *value)
-{
-    const bool enable = (player_ptr->feeling >= 2) && (player_ptr->feeling <= 5);
-    if (enable) {
-        value->type = TERM_XTRA_MUSIC_BASIC;
-
-        if (player_ptr->feeling == 2)
-            value->val = MUSIC_BASIC_DUN_FEEL2;
-        else
-            value->val = MUSIC_BASIC_DUN_FEEL1;
-    }
-    return enable;
-}
-
-static bool scene_dungeon(player_type *player_ptr, scene_type *value)
-{
-    const bool enable = (player_ptr->dungeon_idx > 0);
-    if (enable) {
-        value->type = TERM_XTRA_MUSIC_DUNGEON;
-        value->val = player_ptr->dungeon_idx;
-    }
-    return enable;
-}
-
-static bool scene_dungeon_basic(player_type *player_ptr, scene_type *value)
-{
-    const bool enable = is_in_dungeon(player_ptr);
-    if (enable) {
-        value->type = TERM_XTRA_MUSIC_BASIC;
-
-        const auto dun_level = player_ptr->current_floor_ptr->dun_level;
-        if (dun_level >= 80)
-            value->val = MUSIC_BASIC_DUN_HIGH;
-        else if (dun_level >= 40)
-            value->val = MUSIC_BASIC_DUN_MED;
-        else
-            value->val = MUSIC_BASIC_DUN_LOW;
-    }
-    return enable;
-}
-
-static bool scene_mute(player_type *player_ptr, scene_type *value)
-{
-    (void)player_ptr;
-    value->type = TERM_XTRA_MUSIC_MUTE;
-    value->val = 0;
-    return true;
-}
-
-/*! シチュエーション選択のフォールバック設定。
- * 先頭から適用する（先にある方を優先する）。
+/*!
+ * @brief 選曲の割り込み通知
+ * @details 選曲テーブル外の曲（クエストクリア等）の再生を取得しておく。
+ * モンスターBGMを含む選曲テーブルを構築する場合に、
+ * 1.モンスターBGM
+ * 2.割り込みBGM
+ * 3.通常BGM
+ * の順に設定する。
+ * 街の施設等で、コマンド実行→視界内モンスターリスト更新(空のリスト:再生なし)→割り込みBGMに戻るようにする。
+ * @param type action-type
+ * @param val action-val
  */
-std::vector<scene_type> playfallback = {
-    // scene_basic : ambush, wild, arena, battleの判定
-    { scene_basic },
-    // scene_quest : questの判定（クエストの個別BGMを指定）
-    { scene_quest },
-    // scene_quest_basic : questの判定 (Basicのquest指定)
-    { scene_quest_basic },
-    // scene_town : townの判定（町の個別BGMを指定）
-    { scene_town },
-    // scene_town_basic : townの判定 (Basicのtown指定)
-    { scene_town_basic },
-    // scene_field : field1/2/3の判定（プレイヤーレベル25未満、25以上45未満、45以上時の荒野）
-    { scene_field },
-    // scene_dungeon_feeling : feed1/2の判定（ダンジョンの雰囲気が「悪い予感」～「とても危険」、「死の幻」）
-    { scene_dungeon_feeling },
-    // scene_dungeon : dungeonの判定（ダンジョンの個別BGMを指定）
-    { scene_dungeon },
-    // scene_dungeon_basic : dun_low/med/highの判定（ダンジョンレベルが40未満、40以上80未満、80以上）
-    { scene_dungeon_basic },
-    // scene_mute : 最後にミュートを配置する
-    { scene_mute }
-};
+void interrupt_scene(int type, int val) {
+    interrupt_scene_type = type;
+    interrupt_scene_val = val;
+}
 
+/*!
+ * @brief 現在のフロアに合ったBGM選曲
+ * @param player_ptr プレーヤーへの参照ポインタ
+ */
 void refresh_scene_table(player_type *player_ptr)
 {
-    for (auto &item : playfallback) {
-        if (!item.update(player_ptr, &item)) {
-            // Note -- 特に定義を設けていないが、type = 0は無効な値とする。
-            item.type = 0;
-            item.val = 0;
-        }
-    }
+    // forget BGM-target monster
+    clear_scene_target_monster();
+    // clear interrupt_scene
+    interrupt_scene(0, 0);
+    // モンスターBGMの再生を一時的に抑制する
+    set_temp_mute_scene_monster(2);
+
+    resize_scene_list();
+    refresh_scene_floor(player_ptr, scene_list, 0);
 }
 
-scene_iterator get_scene_table_iterator()
+/*!
+ * @brief 見かけたモンスターを含め、現在のフロアに合ったBGM選曲
+ * @param player_ptr プレーヤーへの参照ポインタ
+ * @param monster_list 視界内モンスターリスト
+ */
+void refresh_scene_table(player_type *player_ptr, const std::vector<MONSTER_IDX> &monster_list)
 {
-    return playfallback.begin();
+    resize_scene_list();
+    int index = 0;
+
+    refresh_scene_monster(player_ptr, monster_list, scene_list, index);
+    index += get_scene_monster_count();
+
+    // interrupt scene
+    scene_type &item = scene_list[index];
+    item.type = interrupt_scene_type;
+    item.val = interrupt_scene_val;
+    ++index;
+
+    refresh_scene_floor(player_ptr, scene_list, index);
+}
+
+/*!
+ * @brief BGM選曲リスト取得
+ * @param type 未使用
+ */
+scene_type_list &get_scene_type_list(int type)
+{
+    (void)type;
+    return scene_list;
 }

--- a/src/main/scene-table.h
+++ b/src/main/scene-table.h
@@ -1,32 +1,19 @@
 ﻿#pragma once
 
+#include "player/player-status.h"
 #include "system/angband.h"
+#include "system/monster-race-definition.h"
 
-#include <iterator>
 #include <vector>
-
-struct scene_type;
-// シチュエーション判定関数。valueに設定した場合trueを返す。
-using scene_def_func = bool (*)(player_type *player_ptr, scene_type *value);
 
 struct scene_type {
     int type = 0; //!< シチュエーションカテゴリ
     int val = 0; //!< シチュエーション項目
-
-    bool update(player_type *player_ptr, scene_type *value)
-    {
-        return scene_def(player_ptr, value);
-    }
-
-    scene_type(scene_def_func f)
-        : scene_def(f)
-    {
-    }
-
-private:
-    scene_def_func scene_def; //!< シチュエーション判定関数
 };
 
+using scene_type_list = std::vector<scene_type>;
+
+void interrupt_scene(int type, int val);
 void refresh_scene_table(player_type *player_ptr);
-using scene_iterator = std::vector<scene_type>::const_iterator;
-scene_iterator get_scene_table_iterator();
+void refresh_scene_table(player_type *player_ptr, const std::vector<MONSTER_IDX> &monster_list);
+scene_type_list &get_scene_type_list(int val);

--- a/src/main/sound-of-music.cpp
+++ b/src/main/sound-of-music.cpp
@@ -4,6 +4,9 @@
 #include "main/scene-table.h"
 #include "term/screen-processor.h"
 
+// モンスターBGMの設定有無。設定なし時に関連処理をスキップする。
+bool has_monster_music = false;
+
 /*
  * Flush the screen, make a noise
  */
@@ -36,6 +39,7 @@ errr play_music(int type, int val)
     if (!use_music)
         return 1;
 
+    interrupt_scene(type, val);
     return term_xtra(type, val);
 }
 
@@ -50,5 +54,19 @@ void select_floor_music(player_type *player_ptr)
         return;
 
     refresh_scene_table(player_ptr);
-    play_music(TERM_XTRA_SCENE, 0);
+    term_xtra(TERM_XTRA_SCENE, 0);
+}
+
+/*!
+ * @brief モンスターBGM選曲
+ * @param player_ptr プレーヤーへの参照ポインタ
+ * @param monster_list モンスターリスト
+ */
+void select_monster_music(player_type *player_ptr, const std::vector<MONSTER_IDX> &monster_list)
+{
+    if (!use_music)
+        return;
+
+    refresh_scene_table(player_ptr, monster_list);
+    term_xtra(TERM_XTRA_SCENE, 0);
 }

--- a/src/main/sound-of-music.h
+++ b/src/main/sound-of-music.h
@@ -2,7 +2,12 @@
 
 #include "system/angband.h"
 
+#include <vector>
+
+extern bool has_monster_music;
+
 void bell(void);
 void sound(int num);
 errr play_music(int type, int num);
 void select_floor_music(player_type *player_ptr);
+void select_monster_music(player_type *player_ptr, const std::vector<MONSTER_IDX> &monster_list);

--- a/src/term/z-term.h
+++ b/src/term/z-term.h
@@ -129,12 +129,13 @@ typedef struct term_type {
 #define TERM_XTRA_ALIVE 11 /* Change the "hard" level (optional) */
 #define TERM_XTRA_LEVEL 12 /* Change the "soft" level (optional) */
 #define TERM_XTRA_DELAY 13 /* Delay some milliseconds (optional) */
-#define TERM_XTRA_MUSIC_BASIC 14 /* Play a music(basic)   (optional) */
+#define TERM_XTRA_MUSIC_BASIC 14 /* Play a music(basic) (optional) */
 #define TERM_XTRA_MUSIC_DUNGEON 15 /* Play a music(dungeon) (optional) */
-#define TERM_XTRA_MUSIC_QUEST 16 /* Play a music(quest)   (optional) */
-#define TERM_XTRA_MUSIC_TOWN 17 /* Play a music(floor)   (optional) */
-#define TERM_XTRA_MUSIC_MUTE 18
-#define TERM_XTRA_SCENE 19 /* React to scene changes (optional) */
+#define TERM_XTRA_MUSIC_QUEST 16 /* Play a music(quest) (optional) */
+#define TERM_XTRA_MUSIC_TOWN 17 /* Play a music(floor) (optional) */
+#define TERM_XTRA_MUSIC_MONSTER 18 /* Play a music(monster) (optional) */
+#define TERM_XTRA_MUSIC_MUTE 19
+#define TERM_XTRA_SCENE 20 /* React to scene changes (optional) */
 
 /**** Available Variables ****/
 extern term_type *Term;


### PR DESCRIPTION
視界内モンスター表示のリスト先頭モンスターのBGMを再生する。
視界内モンスターを表示しない設定であっても、モンスターBGMが設定されている場合は視界内モンスターリストを取得する。
以下の順にBGMの再生を試みる。条件にマッチしない場合は、通常のBGM再生を試みる。

- あやしい影 ([Basic] shadower)
- モンスターIDのBGM ([Monster] monsterXXXX)
- ユニーク ([Basic] unique)
- 未知のモンスター ([Basic] unk_monster)
- 既知の高レベルモンスター ([Basic] hl_monster)

より上位のモンスターを見かけた場合、そのモンスターをBGM対象に設定する。
対象のモンスターが視界から消えても、一定のターンが経過するまではBGM対象とする。


- [x] 視界内のモンスター表示OFFの場合もモンスターBGMを再生すること
モンスターBGM設定有無をチェックし、設定がある場合は視界内モンスターリストを取得し再生する。
サブウインドウで視界内モンスターリストを表示している場合はリストを再利用する。

- [x] モンスターBGMの条件にマッチしない場合、通常BGMへ切り替わること
1つの選曲テーブルにモンスターBGMと通常BGMの両方を載せることで、モンスターBGM条件にマッチしない場合には通常BGMに切り替える。

- [x] 視界内モンスターリストのみに頼ると、モンスターBGMが頻繁に切り替わってしまう
BGM対象モンスターを覚えておくことで対応する。
BGM対象モンスターと視界内モンスターから、最上位のモンスターを新しいBGM対象に設定する。

- [x] 通常BGMを優先するケース
雰囲気のBGMを認識できる程度には短時間でも再生したい。
通常BGMの選曲処理（select_floor_music）でBGM対象モンスターをリセットし、さらに数秒間通常BGMを優先して再生する。
新しいフロアに移動した時なども通常BGMが優先されるが、仕様ということで。

- [x] BGM対象を覚えることによる弊害対策
いつまでも見かけた上位のモンスターBGMが流れ続けるのは避けたい。
対象の死亡、チェンジモンスター等でモンスター情報を取得できなくなるため対象から外す。
対象モンスターが視界から消えて一定のターンが経過した場合に対象から外す。
