### PR TITLE
[MISC] Hengband.vcxproj.filtersのコンフリクト対策

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.vcxproj.filters merge=union


### PR DESCRIPTION
.gitattributesに.vcxproj.filtersファイルのマージ設定を追加した。
ソースコードファイル追加を含む場合に.vcxproj.filtersファイルのコンフリクトが発生しやすい。
このファイルの特性上、コンフリクト時にunion merge driverの指定で適切にマージが行われる。