### PR TITLE
[Fix] savefile_baseが更新されず、一時ファイルとplayrecord.txtのファイル名がおかしい #738

### DIFF
--- a/src/birth/quick-start.cpp
+++ b/src/birth/quick-start.cpp
@@ -62,7 +62,7 @@ bool ask_quick_start(player_type *creature_ptr)
     update_creature(creature_ptr);
     creature_ptr->chp = creature_ptr->mhp;
     creature_ptr->csp = creature_ptr->msp;
-    process_player_name(creature_ptr, FALSE);
+    process_player_name(creature_ptr);
     return TRUE;
 }
 /*!

--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -96,7 +96,7 @@ void do_cmd_player_status(player_type *creature_ptr)
 		if (c == 'c')
 		{
 			get_name(creature_ptr);
-			process_player_name(creature_ptr, FALSE);
+			process_player_name(creature_ptr);
 		}
 		else if (c == 'f')
 		{

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -150,7 +150,7 @@ static void init_random_seed(player_type *player_ptr, bool new_game)
         init_saved_floors(player_ptr, TRUE);
 
     if (!new_game)
-        process_player_name(player_ptr, FALSE);
+        process_player_name(player_ptr);
 
     if (init_random_seed)
         Rand_state_init();

--- a/src/player/process-name.h
+++ b/src/player/process-name.h
@@ -1,6 +1,6 @@
-#pragma once
+﻿#pragma once
 
 #include "system/angband.h"
 
-void process_player_name(player_type *creature_ptr, bool sf);
+void process_player_name(player_type *creature_ptr, bool is_new_savefile = false);
 void get_name(player_type *creature_ptr);


### PR DESCRIPTION
#676のエンバグ

リファクタリング込み。
いつの間にか消えていたSAVEFILE_MUTABLEのマクロ変数を削除してkeep_savefileオプションで一本化。
判定のロジック等がわかりにくかったので書き直し。

セーブファイル名及びsavefile_baseは完全新規スタート時またはkeep_savefileオフでスタートした場合に変更される。