### PR TITLE
[feature] *_info の std::vector 化

### DIFF
--- a/src/dungeon/dungeon.cpp
+++ b/src/dungeon/dungeon.cpp
@@ -11,7 +11,7 @@
 /*
  * The dungeon arrays
  */
-dungeon_type *d_info;
+std::vector<dungeon_type> d_info;
 
 /*
  * Maximum number of dungeon in d_info.txt
@@ -99,4 +99,3 @@ DUNGEON_IDX choose_dungeon(concptr note, POSITION y, POSITION x)
 
 	return select_dungeon;
 }
-

--- a/src/dungeon/dungeon.h
+++ b/src/dungeon/dungeon.h
@@ -7,6 +7,7 @@
 #include "util/flag-group.h"
 
 #include <string>
+#include <vector>
 
 #define DUNGEON_FEAT_PROB_NUM 3
 
@@ -81,6 +82,6 @@ struct dungeon_type {
 };
 
 extern DEPTH *max_dlv;
-extern dungeon_type *d_info;
+extern std::vector<dungeon_type> d_info;
 
 extern DUNGEON_IDX choose_dungeon(concptr note, POSITION y, POSITION x);

--- a/src/grid/feature.cpp
+++ b/src/grid/feature.cpp
@@ -17,7 +17,7 @@
 /*** Terrain feature variables ***/
 
 /* The terrain feature arrays */
-feature_type *f_info;
+std::vector<feature_type> f_info;
 
 /* Nothing */
 FEAT_IDX feat_none;

--- a/src/grid/feature.h
+++ b/src/grid/feature.h
@@ -1,8 +1,11 @@
 ﻿#pragma once
 
-#include "grid/feature-flag-types.h"
 #include "system/angband.h"
+
+#include "grid/feature-flag-types.h"
+
 #include <string>
+#include <vector>
 
 /* Number of feats we change to (Excluding default). Used in f_info.txt. */
 #define MAX_FEAT_STATES	 8
@@ -54,7 +57,7 @@ typedef struct feature_type {
 } feature_type;
 
 extern FEAT_IDX max_f_idx;
-extern feature_type *f_info;
+extern std::vector<feature_type> f_info;
 
 /*** Terrain feature variables ***/
 extern FEAT_IDX feat_none;

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -66,7 +66,7 @@ static void init_header(angband_header *head, IDX num)
  * even if the string happens to be empty (everyone has a unique '\0').
  */
 template <typename InfoType>
-static errr init_info(concptr filename, angband_header& head, InfoType*& info, parse_info_txt_func parser, void(*retouch)(angband_header *head))
+static errr init_info(concptr filename, angband_header &head, std::vector<InfoType> &info, parse_info_txt_func parser, void (*retouch)(angband_header *head))
 {
     char buf[1024];
     path_build(buf, sizeof(buf), ANGBAND_DIR_EDIT, format("%s.txt", filename));
@@ -76,7 +76,7 @@ static errr init_info(concptr filename, angband_header& head, InfoType*& info, p
     if (!fp)
         quit(format(_("'%s.txt'ファイルをオープンできません。", "Cannot open '%s.txt' file."), filename));
 
-    C_MAKE(info, head.info_num, InfoType);
+    info = std::vector<InfoType>(head.info_num);
 
     errr err = init_info_txt(fp, buf, &head, parser);
     angband_fclose(fp);

--- a/src/monster-race/monster-race.cpp
+++ b/src/monster-race/monster-race.cpp
@@ -1,7 +1,7 @@
 ﻿#include "monster-race/monster-race.h"
 
 /* The monster race arrays */
-monster_race *r_info;
+std::vector<monster_race> r_info;
 
 /* Maximum number of monsters in r_info.txt */
 MONRACE_IDX max_r_idx;

--- a/src/monster-race/monster-race.h
+++ b/src/monster-race/monster-race.h
@@ -3,5 +3,7 @@
 #include "system/angband.h"
 #include "system/monster-race-definition.h"
 
-extern monster_race *r_info;
+#include <vector>
+
+extern std::vector<monster_race> r_info;
 extern MONRACE_IDX max_r_idx;

--- a/src/object-enchant/object-ego.cpp
+++ b/src/object-enchant/object-ego.cpp
@@ -13,7 +13,7 @@
 /*
  * The ego-item arrays
  */
-ego_item_type *e_info;
+std::vector<ego_item_type> e_info;
 
 /*
  * Maximum number of ego-items in e_info.txt

--- a/src/object-enchant/object-ego.h
+++ b/src/object-enchant/object-ego.h
@@ -1,10 +1,13 @@
 ﻿#pragma once
 
-#include "object-enchant/trg-types.h"
 #include "system/angband.h"
+
+#include "object-enchant/trg-types.h"
 #include "system/object-type-definition.h"
 #include "util/flag-group.h"
+
 #include <string>
+#include <vector>
 
 /* Body Armor */
 #define EGO_A_MORGUL            4
@@ -242,6 +245,6 @@ typedef struct ego_item_type {
 } ego_item_type;
 
 extern EGO_IDX max_e_idx;
-extern ego_item_type *e_info;
+extern std::vector<ego_item_type> e_info;
 
 byte get_random_ego(byte slot, bool good);

--- a/src/object/object-kind.cpp
+++ b/src/object/object-kind.cpp
@@ -12,7 +12,7 @@
 /*
  * The object kind arrays
  */
-object_kind *k_info;
+std::vector<object_kind> k_info;
 
 /*
  * Maximum number of items in k_info.txt

--- a/src/object/object-kind.h
+++ b/src/object/object-kind.h
@@ -1,10 +1,13 @@
 ﻿#pragma once
 
-#include "object-enchant/trg-types.h"
 #include "system/angband.h"
+
+#include "object-enchant/trg-types.h"
 #include "system/object-type-definition.h"
 #include "util/flag-group.h"
+
 #include <string>
+#include <vector>
 
 typedef struct object_kind {
     std::string name; /*!< ベースアイテム名参照のためのネームバッファオフセット値 / Name (offset) */
@@ -53,7 +56,7 @@ typedef struct object_kind {
     ACTIVATION_IDX act_idx{}; /*!< 発動能力のID /  Activative ability index */
 } object_kind;
 
-extern object_kind *k_info;
+extern std::vector<object_kind> k_info;
 extern KIND_OBJECT_IDX max_k_idx;
 
 SYMBOL_CODE object_char(object_type *o_ptr);

--- a/src/player/player-class.cpp
+++ b/src/player/player-class.cpp
@@ -14,8 +14,7 @@
  * The magic info
  */
 const player_magic *mp_ptr;
-player_magic *m_info;
-
+std::vector<player_magic> m_info;
 
 const player_class *cp_ptr;
 

--- a/src/player/player-class.h
+++ b/src/player/player-class.h
@@ -1,12 +1,15 @@
 ﻿#pragma once
 
 /* 人畜無害なenumヘッダを先に読み込む */
-#include "player/player-classes-types.h"
-#include "object/tval-types.h"
-#include "realm/realm-types.h"
 #include "system/angband.h"
+
+#include "object/tval-types.h"
+#include "player/player-classes-types.h"
+#include "realm/realm-types.h"
 #include "spell/technic-info-table.h"
+
 #include <string>
+#include <vector>
 
 /** m_info.txtでMPの無い職業に設定される */
 #define SPELL_FIRST_NO_SPELL 99
@@ -30,7 +33,7 @@ typedef struct player_magic {
     magic_type info[MAX_MAGIC][32]{}; /* The available spells */
 } player_magic;
 
-extern player_magic *m_info;
+extern std::vector<player_magic> m_info;
 extern const player_magic *mp_ptr;
 
 /*

--- a/src/player/player-skill.cpp
+++ b/src/player/player-skill.cpp
@@ -3,7 +3,7 @@
 /*
  * The skill table
  */
-skill_table *s_info;
+std::vector<skill_table> s_info;
 
 /*!
  * @brief 技能値到達表記テーブル

--- a/src/player/player-skill.h
+++ b/src/player/player-skill.h
@@ -2,6 +2,7 @@
 
 #include "system/angband.h"
 #include <string>
+#include <vector>
 
 #define GINOU_SUDE 0
 #define GINOU_NITOURYU 1
@@ -49,4 +50,4 @@ typedef struct skill_table {
     SUB_EXP s_max[10]{}; /* max skill */
 } skill_table;
 
-extern skill_table *s_info;
+extern std::vector<skill_table> s_info;

--- a/src/room/rooms-vault.cpp
+++ b/src/room/rooms-vault.cpp
@@ -35,7 +35,7 @@
 /*
  * The vault generation arrays
  */
-vault_type *v_info;
+std::vector<vault_type> v_info;
 
 /*
  * Maximum number of vaults in v_info.txt

--- a/src/room/rooms-vault.h
+++ b/src/room/rooms-vault.h
@@ -2,6 +2,7 @@
 
 #include "system/angband.h"
 #include <string>
+#include <vector>
 
 typedef struct vault_type {
     std::string name; /* Name (offset) */
@@ -13,7 +14,7 @@ typedef struct vault_type {
     POSITION wid{}; /* Vault width */
 } vault_type;
 
-extern vault_type *v_info;
+extern std::vector<vault_type> v_info;
 extern VAULT_IDX max_v_idx;
 
 typedef struct dun_data_type dun_data_type;

--- a/src/system/artifact-type-definition.cpp
+++ b/src/system/artifact-type-definition.cpp
@@ -3,7 +3,7 @@
 /*
  * The artifact arrays
  */
-artifact_type *a_info;
+std::vector<artifact_type> a_info;
 
 /*
  * Maximum number of artifacts in a_info.txt

--- a/src/system/artifact-type-definition.h
+++ b/src/system/artifact-type-definition.h
@@ -1,10 +1,13 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+
 #include "object-enchant/trg-types.h"
-#include "util/flag-group.h"
 #include "system/object-type-definition.h"
+#include "util/flag-group.h"
+
 #include <string>
+#include <vector>
 
 /*!
  * @struct artifact_type
@@ -38,5 +41,5 @@ typedef struct artifact_type {
 	byte act_idx{};		/*! 発動能力ID / Activative ability index */
 } artifact_type;
 
-extern artifact_type *a_info;
+extern std::vector<artifact_type> a_info;
 extern ARTIFACT_IDX max_a_idx;


### PR DESCRIPTION
new[] による配列領域の確保を std::vector に置き換える。
ひとまず置き換えのみで misc.txt によってサイズを指定する
仕様はそのまま継続。
misc.txt によるサイズ指定を無くすとしたら別途対応する。