### PR TITLE
[Fix] 元素使い系統を第一領域と共有したことによる不具合

### DIFF
--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -393,7 +393,7 @@ void autopick_entry_from_object(player_type *player_ptr, autopick_type *entry, o
             name = FALSE;
     }
 
-    bool realm_except_class = player_ptr->pclass == CLASS_SORCERER || player_ptr->pclass == CLASS_RED_MAGE || player_ptr->pclass == CLASS_ELEMENTALIST;
+    bool realm_except_class = player_ptr->pclass == CLASS_SORCERER || player_ptr->pclass == CLASS_RED_MAGE;
 
     if (get_realm1_book(player_ptr) == o_ptr->tval && !realm_except_class) {
         ADD_FLG(FLG_REALM1);

--- a/src/autopick/autopick-matcher.cpp
+++ b/src/autopick/autopick-matcher.cpp
@@ -180,7 +180,7 @@ bool is_autopick_match(player_type *player_ptr, object_type *o_ptr, autopick_typ
     if (IS_FLG(FLG_UNREADABLE) && (o_ptr->tval < TV_LIFE_BOOK || check_book_realm(player_ptr, o_ptr->tval, o_ptr->sval)))
         return FALSE;
 
-    bool realm_except_class = player_ptr->pclass == CLASS_SORCERER || player_ptr->pclass == CLASS_RED_MAGE || player_ptr->pclass == CLASS_ELEMENTALIST;
+    bool realm_except_class = player_ptr->pclass == CLASS_SORCERER || player_ptr->pclass == CLASS_RED_MAGE;
 
     if (IS_FLG(FLG_REALM1) && (get_realm1_book(player_ptr) != o_ptr->tval || realm_except_class))
         return FALSE;

--- a/src/birth/birth-select-realm.cpp
+++ b/src/birth/birth-select-realm.cpp
@@ -314,38 +314,42 @@ bool get_player_realms(player_type *creature_ptr)
 
     /* Select the first realm */
     creature_ptr->realm1 = REALM_NONE;
-    creature_ptr->realm2 = REALM_SELECT_CANCEL;
+    creature_ptr->realm2 = REALM_NONE;
 
     if (creature_ptr->pclass == CLASS_ELEMENTALIST) {
-        creature_ptr->realm1 = select_element_realm(creature_ptr);
+        creature_ptr->element = select_element_realm(creature_ptr);
+        if (creature_ptr->element == REALM_SELECT_CANCEL)
+            return FALSE;
+
+        put_str(_("魔法        :", "Magic       :"), 6, 1);
+        c_put_str(TERM_L_BLUE, get_element_title(creature_ptr->element), 6, 15);
+        return TRUE;
+    }
+
+    while (TRUE) {
+        char temp[80 * 10];
+        int count = 0;
+        creature_ptr->realm1 = select_realm(creature_ptr, realm_choices1[creature_ptr->pclass], &count);
         if (creature_ptr->realm1 == REALM_SELECT_CANCEL)
             return FALSE;
-    }
-    else
-        while (TRUE) {
-            char temp[80 * 10];
-            int count = 0;
-            creature_ptr->realm1 = select_realm(creature_ptr, realm_choices1[creature_ptr->pclass], &count);
-            if (creature_ptr->realm1 == REALM_SELECT_CANCEL)
-                return FALSE;
-            if (!creature_ptr->realm1)
-                break;
+        if (!creature_ptr->realm1)
+            break;
 
-            cleanup_realm_selection_window();
-            shape_buffer(realm_explanations[technic2magic(creature_ptr->realm1) - 1], 74, temp, sizeof(temp));
-            concptr t = temp;
-            for (int i = 0; i < 10; i++) {
-                if (t[0] == 0)
-                    break;
-                else {
-                    prt(t, 12 + i, 3);
-                    t += strlen(t) + 1;
-                }
+        cleanup_realm_selection_window();
+        shape_buffer(realm_explanations[technic2magic(creature_ptr->realm1) - 1], 74, temp, sizeof(temp));
+        concptr t = temp;
+        for (int i = 0; i < 10; i++) {
+            if (t[0] == 0)
+                break;
+            else {
+                prt(t, 12 + i, 3);
+                t += strlen(t) + 1;
             }
-
-            if (check_realm_selection(creature_ptr, count))
-                break;
         }
+
+        if (check_realm_selection(creature_ptr, count))
+            break;
+    }
 
     /* Select the second realm */
     creature_ptr->realm2 = REALM_NONE;
@@ -354,10 +358,7 @@ bool get_player_realms(player_type *creature_ptr)
 
     /* Print the realm */
     put_str(_("魔法        :", "Magic       :"), 6, 1);
-    if (creature_ptr->pclass == CLASS_ELEMENTALIST)
-        c_put_str(TERM_L_BLUE, get_element_title(creature_ptr->realm1), 6, 15);
-    else
-        c_put_str(TERM_L_BLUE, realm_names[creature_ptr->realm1], 6, 15);
+    c_put_str(TERM_L_BLUE, realm_names[creature_ptr->realm1], 6, 15);
 
     /* Select the second realm */
     while (TRUE) {

--- a/src/birth/quick-start.cpp
+++ b/src/birth/quick-start.cpp
@@ -76,7 +76,12 @@ void save_prev_data(player_type *creature_ptr, birther *birther_ptr)
     birther_ptr->prace = creature_ptr->prace;
     birther_ptr->pclass = creature_ptr->pclass;
     birther_ptr->pseikaku = creature_ptr->pseikaku;
-    birther_ptr->realm1 = creature_ptr->realm1;
+
+    if (creature_ptr->pclass == CLASS_ELEMENTALIST)
+        birther_ptr->realm1 = creature_ptr->element;
+    else
+        birther_ptr->realm1 = creature_ptr->realm1;
+
     birther_ptr->realm2 = creature_ptr->realm2;
     birther_ptr->age = creature_ptr->age;
     birther_ptr->ht = creature_ptr->ht;
@@ -118,7 +123,12 @@ void load_prev_data(player_type *creature_ptr, bool swap)
     creature_ptr->prace = previous_char.prace;
     creature_ptr->pclass = previous_char.pclass;
     creature_ptr->pseikaku = previous_char.pseikaku;
-    creature_ptr->realm1 = previous_char.realm1;
+
+    if (creature_ptr->pclass == CLASS_ELEMENTALIST)
+        creature_ptr->element = previous_char.realm1;
+    else
+        creature_ptr->realm1 = previous_char.realm1;
+
     creature_ptr->realm2 = previous_char.realm2;
     creature_ptr->age = previous_char.age;
     creature_ptr->ht = previous_char.ht;

--- a/src/birth/quick-start.h
+++ b/src/birth/quick-start.h
@@ -5,33 +5,33 @@
 /*
  * A structure to hold "rolled" information
  */
-typedef struct birther {
-    SEX_IDX psex; /* Sex index */
-    player_race_type prace; /* Race index */
-    player_class_type pclass; /* Class index */
-    player_personality_type pseikaku; /* Seikaku index */
-    REALM_IDX realm1; /* First magic realm */
-    REALM_IDX realm2; /* Second magic realm */
+struct birther {
+    SEX_IDX psex{}; /* Sex index */
+    player_race_type prace{}; /* Race index */
+    player_class_type pclass{}; /* Class index */
+    player_personality_type pseikaku{}; /* Seikaku index */
+    REALM_IDX realm1{}; /* First magic realm */
+    REALM_IDX realm2{}; /* Second magic realm */
 
-    s16b age;
-    s16b ht;
-    s16b wt;
-    s16b sc;
+    s16b age{};
+    s16b ht{};
+    s16b wt{};
+    s16b sc{};
 
-    PRICE au; /*!< 初期の所持金 */
+    PRICE au{}; /*!< 初期の所持金 */
 
-    BASE_STATUS stat_max[6]; /* Current "maximal" stat values */
-    BASE_STATUS stat_max_max[6]; /* Maximal "maximal" stat values */
-    HIT_POINT player_hp[PY_MAX_LEVEL];
+    BASE_STATUS stat_max[6]{}; /* Current "maximal" stat values */
+    BASE_STATUS stat_max_max[6]{}; /* Maximal "maximal" stat values */
+    HIT_POINT player_hp[PY_MAX_LEVEL]{};
 
-    PATRON_IDX chaos_patron;
+    PATRON_IDX chaos_patron{};
 
-    s16b vir_types[8];
+    s16b vir_types[8]{};
 
-    char history[4][60];
+    char history[4][60]{};
 
-    bool quick_ok;
-} birther;
+    bool quick_ok{};
+};
 
 extern birther previous_char;
 

--- a/src/io/read-pref-file.cpp
+++ b/src/io/read-pref-file.cpp
@@ -285,7 +285,7 @@ void load_all_pref_files(player_type *player_ptr)
     process_pref_file(player_ptr, buf, process_autopick_file_command);
     sprintf(buf, "%s.prf", player_ptr->base_name);
     process_pref_file(player_ptr, buf, process_autopick_file_command);
-    if (player_ptr->realm1 != REALM_NONE && player_ptr->pclass != CLASS_ELEMENTALIST) {
+    if (player_ptr->realm1 != REALM_NONE) {
         sprintf(buf, "%s.prf", realm_names[player_ptr->realm1]);
         process_pref_file(player_ptr, buf, process_autopick_file_command);
     }

--- a/src/io/report.cpp
+++ b/src/io/report.cpp
@@ -418,7 +418,7 @@ errr report_score(player_type *creature_ptr, void (*update_playtime)(void), disp
 #endif
 
     if (creature_ptr->pclass == CLASS_ELEMENTALIST)
-        realm1_name = get_element_title(creature_ptr->realm1);
+        realm1_name = get_element_title(creature_ptr->element);
     else
         realm1_name = realm_names[creature_ptr->realm1];
 

--- a/src/knowledge/knowledge-experiences.cpp
+++ b/src/knowledge/knowledge-experiences.cpp
@@ -73,7 +73,7 @@ void do_cmd_knowledge_spell_exp(player_type *creature_ptr)
     if (!open_temporary_file(&fff, file_name))
         return;
 
-    if (creature_ptr->realm1 != REALM_NONE && creature_ptr->pclass != CLASS_ELEMENTALIST) {
+    if (creature_ptr->realm1 != REALM_NONE) {
         fprintf(fff, _("%sの魔法書\n", "%s Spellbook\n"), realm_names[creature_ptr->realm1]);
         for (SPELL_IDX i = 0; i < 32; i++) {
             const magic_type *s_ptr;

--- a/src/knowledge/knowledge-self.cpp
+++ b/src/knowledge/knowledge-self.cpp
@@ -90,7 +90,7 @@ static void dump_yourself(player_type *creature_ptr, FILE *fff)
     }
 
     fprintf(fff, "\n");
-    if (creature_ptr->realm1 && creature_ptr->pclass != CLASS_ELEMENTALIST) {
+    if (creature_ptr->realm1) {
         shape_buffer(realm_explanations[technic2magic(creature_ptr->realm1) - 1], 78, temp, sizeof(temp));
         fprintf(fff, _("魔法: %s\n", "Realm: %s\n"), realm_names[creature_ptr->realm1]);
 

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -17,6 +17,30 @@
 #include "system/floor-type-definition.h"
 #include "world/world.h"
 
+/*!
+ * @brief セーブデータから領域情報を読み込む / Read player realms
+ * @param creature_ptr プレーヤーへの参照ポインタ
+ * @return なし
+ */
+static void rd_realms(player_type *creature_ptr)
+{
+    byte tmp8u;
+
+    rd_byte(&tmp8u);
+    if (creature_ptr->pclass == CLASS_ELEMENTALIST)
+        creature_ptr->element = (REALM_IDX)tmp8u;
+    else
+        creature_ptr->realm1 = (REALM_IDX)tmp8u;
+
+    rd_byte(&tmp8u);
+    creature_ptr->realm2 = (REALM_IDX)tmp8u;
+}
+
+/*!
+ * @brief セーブデータからプレイヤー基本情報を読み込む / Read player's basic info
+ * @param creature_ptr プレーヤーへの参照ポインタ
+ * @return なし
+ */
 void rd_base_info(player_type *creature_ptr)
 {
     rd_string(creature_ptr->name, sizeof(creature_ptr->name));
@@ -44,11 +68,8 @@ void rd_base_info(player_type *creature_ptr)
     creature_ptr->pseikaku = (player_personality_type)tmp8u;
 
     rd_byte(&creature_ptr->psex);
-    rd_byte(&tmp8u);
-    creature_ptr->realm1 = (REALM_IDX)tmp8u;
 
-    rd_byte(&tmp8u);
-    creature_ptr->realm2 = (REALM_IDX)tmp8u;
+    rd_realms(creature_ptr);
 
     rd_byte(&tmp8u);
     if (h_older_than(0, 4, 4))

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -318,7 +318,7 @@ spells_type get_element_type(int realm_idx, int n)
  * @return 属性タイプ
  */
 static spells_type get_element_spells_type(player_type *caster_ptr, int n) {
-    auto realm = element_types.at(static_cast<ElementRealm>(caster_ptr->realm1));
+    auto realm = element_types.at(static_cast<ElementRealm>(caster_ptr->element));
     auto t = realm.type.at(n);
     if (realm.extra.find(t) != realm.extra.end()) {
         if (randint0(100) < caster_ptr->lev * 2)
@@ -357,7 +357,7 @@ concptr get_element_name(int realm_idx, int n)
  */
 static concptr get_element_tip(player_type *caster_ptr, int spell_idx)
 {
-    auto realm = static_cast<ElementRealm>(caster_ptr->realm1);
+    auto realm = static_cast<ElementRealm>(caster_ptr->element);
     auto spell = static_cast<ElementSpells>(spell_idx);
     auto elem = element_powers.at(spell).elem;
     return format(element_tips.at(spell).data(), element_types.at(realm).name[elem].data());
@@ -774,7 +774,7 @@ bool get_element_power(player_type *caster_ptr, SPELL_IDX *sn, bool only_browse)
                     } else
                         sprintf(desc, "  %c) ", I2A(i));
 
-                    concptr s = get_element_name(caster_ptr->realm1, elem);
+                    concptr s = get_element_name(caster_ptr->element, elem);
                     sprintf(name, spell.name, s);
                     strcat(desc,
                         format("%-30s%2d %4d %3d%%%s", name, spell.min_lev, mana_cost, chance, comment));
@@ -808,7 +808,7 @@ bool get_element_power(player_type *caster_ptr, SPELL_IDX *sn, bool only_browse)
             char tmp_val[160];
             elem = get_elemental_elem(caster_ptr, i);
             spell = get_elemental_info(caster_ptr, i);
-            (void)sprintf(name, spell.name, get_element_name(caster_ptr->realm1, elem));
+            (void)sprintf(name, spell.name, get_element_name(caster_ptr->element, elem));
             (void)strnfmt(tmp_val, 78, _("%sを使いますか？", "Use %s? "), name);
             if (!get_check(tmp_val))
                 continue;
@@ -873,7 +873,7 @@ static bool try_cast_element_spell(player_type *caster_ptr, SPELL_IDX spell_idx,
         msg_print(_("元素の力が制御できない氾流となって解放された！",
             "Elemental power unleashes its power in an uncontrollable storm!"));
         project(caster_ptr, PROJECT_WHO_UNCTRL_POWER, 2 + plev / 10, caster_ptr->y, caster_ptr->x, plev * 2,
-            get_element_types(caster_ptr->realm1)[0],
+            get_element_types(caster_ptr->element)[0],
             PROJECT_JUMP | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM, -1);
         caster_ptr->csp = MAX(0, caster_ptr->csp - caster_ptr->msp * 10 / (20 + randint1(10)));
 
@@ -1019,8 +1019,8 @@ bool is_elemental_genocide_effective(monster_race *r_ptr, spells_type type)
  */
 process_result effect_monster_elemental_genocide(player_type *caster_ptr, effect_monster_type *em_ptr)
 {
-    auto type = get_element_type(caster_ptr->realm1, 0);
-    auto name = get_element_name(caster_ptr->realm1, 0);
+    auto type = get_element_type(caster_ptr->element, 0);
+    auto name = get_element_name(caster_ptr->element, 0);
     bool b = is_elemental_genocide_effective(em_ptr->r_ptr, type);
 
     if (em_ptr->seen_msg)
@@ -1062,7 +1062,7 @@ bool has_element_resist(player_type *creature_ptr, ElementRealm realm, PLAYER_LE
     if (creature_ptr->pclass != CLASS_ELEMENTALIST)
         return FALSE;
 
-    auto prealm = static_cast<ElementRealm>(creature_ptr->realm1);
+    auto prealm = static_cast<ElementRealm>(creature_ptr->element);
     return (prealm == realm && creature_ptr->lev >= lev);
 }
 
@@ -1243,7 +1243,7 @@ byte select_element_realm(player_type *creature_ptr)
 void switch_element_racial(player_type *creature_ptr, rc_type *rc_ptr)
 {
     auto plev = creature_ptr->lev;
-    auto realm = static_cast<ElementRealm>(creature_ptr->realm1);
+    auto realm = static_cast<ElementRealm>(creature_ptr->element);
     switch (realm) {
     case ElementRealm::FIRE:
         strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("ライト・エリア", "Light area"));
@@ -1326,7 +1326,7 @@ static bool door_to_darkness(player_type *caster_ptr, POSITION dist);
  */
 bool switch_element_execution(player_type *creature_ptr)
 {
-    auto realm = static_cast<ElementRealm>(creature_ptr->realm1);
+    auto realm = static_cast<ElementRealm>(creature_ptr->element);
     PLAYER_LEVEL plev = creature_ptr->lev;
     DIRECTION dir;
 

--- a/src/object-hook/hook-magic.cpp
+++ b/src/object-hook/hook-magic.cpp
@@ -96,9 +96,6 @@ bool item_tester_hook_recharge(player_type *player_ptr, object_type *o_ptr)
  */
 bool item_tester_learn_spell(player_type *player_ptr, object_type *o_ptr)
 {
-    if (player_ptr->pclass == CLASS_ELEMENTALIST)
-        return FALSE;
-
     s32b choices = realm_choices2[player_ptr->pclass];
     if (player_ptr->pclass == CLASS_PRIEST) {
         if (is_good_realm(player_ptr->realm1)) {

--- a/src/object/object-info.cpp
+++ b/src/object/object-info.cpp
@@ -276,8 +276,6 @@ bool check_book_realm(player_type *owner_ptr, const tval_type book_tval, const O
 {
     if (book_tval < TV_LIFE_BOOK)
         return FALSE;
-    if (owner_ptr->pclass == CLASS_ELEMENTALIST)
-        return FALSE;
     if (owner_ptr->pclass == CLASS_SORCERER) {
         return is_magic(tval2realm(book_tval));
     } else if (owner_ptr->pclass == CLASS_RED_MAGE) {

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -694,7 +694,7 @@ void check_no_flowed(player_type *creature_ptr)
         return;
     }
 
-    if (!creature_ptr->realm1 || creature_ptr->pclass == CLASS_ELEMENTALIST) {
+    if (!creature_ptr->realm1) {
         creature_ptr->no_flowed = FALSE;
         return;
     }

--- a/src/player/player-status.h
+++ b/src/player/player-status.h
@@ -83,6 +83,7 @@ typedef struct player_type {
     player_personality_type pseikaku{}; /* Seikaku index */
     REALM_IDX realm1{}; /* First magic realm */
     REALM_IDX realm2{}; /* Second magic realm */
+    REALM_IDX element{}; //!< 元素使い領域番号 / Elementalist system index
     player_personality_type oops{}; /* Unused */
 
     DICE_SID hitdie{}; /* Hit dice (sides) */

--- a/src/racial/racial-draconian.cpp
+++ b/src/racial/racial-draconian.cpp
@@ -109,8 +109,8 @@ static void decide_breath_kind(player_type *creature_ptr, int *breath_type, conc
 
         break;
     case CLASS_ELEMENTALIST:
-        *breath_type = get_element_type(creature_ptr->realm1, 0);
-        *breath_type_description = get_element_name(creature_ptr->realm1, 0);
+        *breath_type = get_element_type(creature_ptr->element, 0);
+        *breath_type_description = get_element_name(creature_ptr->element, 0);
         break;
     default:
         break;

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -9,6 +9,20 @@
 #include "world/world.h"
 
 /*!
+ * @brief セーブデータに領域情報を書き込む / Write player realms
+ * @param creature_ptr プレーヤーへの参照ポインタ
+ * @return なし
+ */
+static void wr_relams(player_type *creature_ptr)
+{
+    if (creature_ptr->pclass == CLASS_ELEMENTALIST)
+        wr_byte((byte)creature_ptr->element);
+    else
+        wr_byte((byte)creature_ptr->realm1);
+    wr_byte((byte)creature_ptr->realm2);
+}
+
+/*!
  * @brief セーブデータにプレーヤー情報を書き込む / Write some "player" info
  * @param creature_ptr プレーヤーへの参照ポインタ
  * @return なし
@@ -27,8 +41,7 @@ void wr_player(player_type *creature_ptr)
     wr_byte((byte)creature_ptr->pclass);
     wr_byte((byte)creature_ptr->pseikaku);
     wr_byte((byte)creature_ptr->psex);
-    wr_byte((byte)creature_ptr->realm1);
-    wr_byte((byte)creature_ptr->realm2);
+    wr_relams(creature_ptr);
     wr_byte(0);
 
     wr_byte((byte)creature_ptr->hitdie);

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -92,12 +92,12 @@ static void display_player_basic_info(player_type *creature_ptr)
  */
 static void display_magic_realms(player_type *creature_ptr)
 {
-    if (creature_ptr->realm1 == 0)
+    if (creature_ptr->realm1 == REALM_NONE && creature_ptr->element == REALM_NONE)
         return;
 
     char tmp[64];
     if (creature_ptr->pclass == CLASS_ELEMENTALIST)
-        sprintf(tmp, "%s", get_element_title(creature_ptr->realm1));
+        sprintf(tmp, "%s", get_element_title(creature_ptr->element));
     else if (creature_ptr->realm2)
         sprintf(tmp, "%s, %s", realm_names[creature_ptr->realm1], realm_names[creature_ptr->realm2]);
     else

--- a/src/view/object-describer.cpp
+++ b/src/view/object-describer.cpp
@@ -98,8 +98,6 @@ void display_koff(player_type *owner_ptr, KIND_OBJECT_IDX k_idx)
     use_realm = tval2realm(q_ptr->tval);
 
     if (owner_ptr->realm1 || owner_ptr->realm2) {
-        if (owner_ptr->pclass == CLASS_ELEMENTALIST)
-            return;
         if ((use_realm != owner_ptr->realm1) && (use_realm != owner_ptr->realm2))
             return;
     } else {


### PR DESCRIPTION
元素使い系統を別プロパティとしてplayer_typeに設置。

Issueの#746に対応。(realm1がREALM_NONEになるのでヒットしなくなる)