### PR TITLE
[Fix] 【バグ】fresh_onceを入れてマクロでターゲッティングするとモンスターの思い出サブウィンドウが更新されない #742

### DIFF
--- a/src/io/input-key-acceptor.cpp
+++ b/src/io/input-key-acceptor.cpp
@@ -1,5 +1,6 @@
 ﻿#include "io/input-key-acceptor.h"
 #include "cmd-io/macro-util.h"
+#include "core/stuff-handler.h"
 #include "core/window-redrawer.h"
 #include "game-option/input-options.h"
 #include "game-option/map-screen-options.h"
@@ -412,6 +413,10 @@ void start_term_fresh(void)
         if (angband_term[j])
             angband_term[j]->never_fresh = FALSE;
     }
+    p_ptr->window_flags |= PW_ALL;
+    handle_stuff(p_ptr);
+    term_fresh();
+    term_activate(angband_term[0]);
 }
 
 /*!

--- a/src/io/input-key-requester.cpp
+++ b/src/io/input-key-requester.cpp
@@ -211,12 +211,8 @@ void request_command(player_type *player_ptr, int shopping)
         if (!macro_running() && !command_new && auto_debug_save && (!inkey_next || *inkey_next == '\0')) {
             save_player(player_ptr, SAVE_TYPE_DEBUG);
         }
-        if (macro_running() && fresh_once) {
+        if (fresh_once && macro_running()) {
             stop_term_fresh();
-        } else {
-            start_term_fresh();
-            player_ptr->window_flags |= PW_MONSTER_LIST;
-            handle_stuff(player_ptr);
         }
 
         if (command_new) {


### PR DESCRIPTION
start_term_fresh()にて描画再開時にhandle_stuff()を呼んで全描画を更新するように変更した。
start_term_fresh()はinkey()でキー待ちになる度必ずコールされるので描写漏れがなくなることが期待できる。