### PR TITLE
[Fix] ダークエルフの種族レイシャルパワーが表示されない #758

### DIFF
--- a/src/term/z-form.cpp
+++ b/src/term/z-form.cpp
@@ -620,6 +620,17 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
                 break;
 
             /* Save the character */
+#ifdef JP
+            if (iskanji(tmp[q])) {
+                if (tmp[q + 1]) {
+                    buf[n++] = tmp[q++];
+                } else {
+                    // 最後の文字が2バイト文字の前半で終わる場合は空白で置き換えて終了する
+                    buf[n++] = ' ';
+                    break;
+                }
+            }
+#endif
             buf[n++] = tmp[q];
         }
     }


### PR DESCRIPTION
formatで文字列を生成した時に、桁数制限により2バイト文字の前半で
文字列がターミネートされてしまうのが原因なので、2バイト文字の
前半で文字列が終了している場合はその部分を空白に置き換える。