### PR TITLE
[Fix] キー入力後に常に@の足元のアイテムがサブウィンドウに表示される

### DIFF
--- a/src/core/window-redrawer.cpp
+++ b/src/core/window-redrawer.cpp
@@ -287,7 +287,6 @@ void window_stuff(player_type *player_ptr)
 
     if (any_bits(window_flags, PW_FLOOR_ITEM_LIST)) {
         reset_bits(player_ptr->window_flags, PW_FLOOR_ITEM_LIST);
-        // ウィンドウサイズ変更に対応できず。カーソル位置を取る必要がある。
-        fix_floor_item_list(player_ptr, player_ptr->y, player_ptr->x);
+        print_floor_item_list(player_ptr);
     }
 }

--- a/src/io/input-key-acceptor.cpp
+++ b/src/io/input-key-acceptor.cpp
@@ -223,6 +223,9 @@ char inkey(void)
         if (!done && (0 != term_inkey(&kk, FALSE, FALSE))) {
             start_term_fresh();
             all_term_fresh(x, y);
+            if (fresh_once)
+                stop_term_fresh();
+
             current_world_ptr->character_saved = FALSE;
 
             signal_count = 0;

--- a/src/window/display-sub-windows.h
+++ b/src/window/display-sub-windows.h
@@ -15,5 +15,6 @@ void fix_overhead(player_type *player_ptr);
 void fix_dungeon(player_type *player_ptr);
 void fix_monster(player_type *player_ptr);
 void fix_object(player_type *player_ptr);
+void print_floor_item_list(player_type *player_ptr);
 void fix_floor_item_list(player_type *player_ptr, const int y, const int x);
 void toggle_inventory_equipment(player_type *owner_ptr);

--- a/src/world/world.h
+++ b/src/world/world.h
@@ -1,6 +1,8 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include "util/point-2d.h"
+#include <optional>
 
 #define MAX_BOUNTY 20
 
@@ -61,6 +63,7 @@ struct world_type {
 
     DUNGEON_IDX max_d_idx;
 
+    std::optional<Pos2D> itemlist_pos{}; /*!< 床上アイテム描写用の現在座標 / Floor item list location */
 };
 
 extern world_type *current_world_ptr;


### PR DESCRIPTION
#754で顕在化した問題。fix_floor_item_list()でサブウィンドウを更新するとき、更新座標がどこにも保存されないのでfresh_onceオプション等で別のタイミングで画面更新を行った場合、@の足元のアイテム一覧がサブウィンドウに表示される。
 current_world_ptrにこの描写で使用する座標を保存するように変更して対処。