### PR TITLE
[Fix] サブウインドウ更新毎に視界内モンスター表示処理が行われる

### DIFF
--- a/src/core/window-redrawer.cpp
+++ b/src/core/window-redrawer.cpp
@@ -256,9 +256,11 @@ void window_stuff(player_type *player_ptr)
         fix_player(player_ptr);
     }
 
-    // Always call without PW_MONSTER_LIST flag
-    player_ptr->window_flags &= ~(PW_MONSTER_LIST);
-    fix_monster_list(player_ptr);
+    // モンスターBGM対応のため、視界内モンスター表示のサブウインドウなし時も処理を行う
+    if (player_ptr->window_flags & (PW_MONSTER_LIST)) {
+        player_ptr->window_flags &= ~(PW_MONSTER_LIST);
+        fix_monster_list(player_ptr);
+    }
 
     if (window_flags & (PW_MESSAGE)) {
         player_ptr->window_flags &= ~(PW_MESSAGE);


### PR DESCRIPTION
#727 のモンスター遭遇BGM対応時のエンバグ。
PW_MONSTER_LISTフラグが立っている場合に処理を行うように修正した。