### PR TITLE
[Fix] 見えていないモンスターのダメージメッセージが不自然に流れる。 / Unnatural message by damage of unseen monsters.

### DIFF
--- a/src/effect/effect-monster.cpp
+++ b/src/effect/effect-monster.cpp
@@ -492,7 +492,7 @@ static void effect_damage_gives_bad_status(player_type *caster_ptr, effect_monst
 {
     int tmp_damage = em_ptr->dam;
     em_ptr->dam = mon_damage_mod(caster_ptr, em_ptr->m_ptr, em_ptr->dam, (bool)(em_ptr->effect_type == GF_PSY_SPEAR));
-    if ((tmp_damage > 0) && (em_ptr->dam == 0))
+    if ((tmp_damage > 0) && (em_ptr->dam == 0) && em_ptr->seen)
         em_ptr->note = _("はダメージを受けていない。", " is unharmed.");
 
     if (em_ptr->dam > em_ptr->m_ptr->hp)

--- a/src/monster/monster-describer.cpp
+++ b/src/monster/monster-describer.cpp
@@ -256,10 +256,13 @@ void message_pain(player_type *player_ptr, MONSTER_IDX m_idx, HIT_POINT dam)
 
     GAME_TEXT m_name[MAX_NLEN];
 
+
     monster_desc(player_ptr, m_name, m_ptr, 0);
 
     if (dam == 0) {
-        msg_format(_("%^sはダメージを受けていない。", "%^s is unharmed."), m_name);
+        if (m_ptr->ml) {
+            msg_format(_("%^sはダメージを受けていない。", "%^s is unharmed."), m_name);
+        }
         return;
     }
 


### PR DESCRIPTION
ひとまず対応してみた。視認できていないモンスターは死ぬまでダメージ状況見えてなくていいと思うのでそこも意図して。