### PR TITLE
[Fix] 指定した時だけキー入力待ち時の再描画を行う

### DIFF
--- a/src/io/input-key-acceptor.cpp
+++ b/src/io/input-key-acceptor.cpp
@@ -181,10 +181,10 @@ static char inkey_aux(void)
 
 /*
  * @brief キー入力を受け付けるメインルーチン / Get a keypress from the user.
- * @param なし
+ * @param do_all_term_refresh trueであれば強制的にhandle_stuffと再描画を行う。デフォルト false
  * return キーを表すコード
  */
-char inkey(void)
+char inkey(bool do_all_term_refresh)
 {
     char ch = 0;
     bool done = FALSE;
@@ -222,7 +222,10 @@ char inkey(void)
 
         if (!done && (0 != term_inkey(&kk, FALSE, FALSE))) {
             start_term_fresh();
-            all_term_fresh(x, y);
+            if (do_all_term_refresh)
+                all_term_fresh(x, y);
+            else
+                term_fresh();
             current_world_ptr->character_saved = FALSE;
 
             signal_count = 0;

--- a/src/io/input-key-acceptor.h
+++ b/src/io/input-key-acceptor.h
@@ -27,7 +27,7 @@ extern bool inkey_flag;
 extern int num_more;
 extern concptr inkey_next;
 
-char inkey(void);
+char inkey(bool do_all_term_refresh = false);
 int inkey_special(bool numpad_cursor);
 void start_term_fresh(void);
 void stop_term_fresh(void);

--- a/src/io/input-key-requester.cpp
+++ b/src/io/input-key-requester.cpp
@@ -224,7 +224,7 @@ void request_command(player_type *player_ptr, int shopping)
             num_more = 0;
             inkey_flag = TRUE;
             term_fresh();
-            cmd = inkey();
+            cmd = inkey(true);
             if (!shopping && command_menu && ((cmd == '\r') || (cmd == '\n') || (cmd == 'x') || (cmd == 'X')) && !keymap_act[mode][(byte)(cmd)])
                 cmd = inkey_from_menu(player_ptr);
         }


### PR DESCRIPTION
#754 でキー入力待ち時に強制的に再描画(および諸処のゲーム情報の更新)を
行うようになったが、意図しないタイミングで再描画が行われる事により
様々なエンバグが発生している。
これに対処するため、強制的に再描画するかどうかの引数を inkey() に設け、
とりあえずやっても問題ないタイミングと思われる request_command() での
inkey() でのみ強制的な再描画を行うようにする。