### PR TITLE
[Refactor] take_hit() と project() の未使用引数 monspell を削除

### DIFF
--- a/src/action/mutation-execution.cpp
+++ b/src/action/mutation-execution.cpp
@@ -201,7 +201,7 @@ bool exe_mutation_power(player_type *creature_ptr, MUTA power)
         return TRUE;
     case MUTA::STERILITY:
         msg_print(_("突然頭が痛くなった！", "You suddenly have a headache!"));
-        take_hit(creature_ptr, DAMAGE_LOSELIFE, randint1(17) + 17, _("禁欲を強いた疲労", "the strain of forcing abstinence"), -1);
+        take_hit(creature_ptr, DAMAGE_LOSELIFE, randint1(17) + 17, _("禁欲を強いた疲労", "the strain of forcing abstinence"));
         creature_ptr->current_floor_ptr->num_repro += MAX_REPRO;
         return TRUE;
     case MUTA::HIT_AND_AWAY:

--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -127,7 +127,7 @@ static void natural_attack(player_type *attacker_ptr, MONSTER_IDX m_idx, MUTA at
 
     switch (attack) {
     case MUTA::SCOR_TAIL:
-        project(attacker_ptr, 0, 0, m_ptr->fy, m_ptr->fx, k, GF_POIS, PROJECT_KILL, -1);
+        project(attacker_ptr, 0, 0, m_ptr->fy, m_ptr->fx, k, GF_POIS, PROJECT_KILL);
         *mdeath = (m_ptr->r_idx == 0);
         break;
     case MUTA::HORNS:

--- a/src/cmd-action/cmd-mind.cpp
+++ b/src/cmd-action/cmd-mind.cpp
@@ -208,7 +208,7 @@ static void check_mind_mindcrafter(player_type *caster_ptr, cm_type *cm_ptr)
 
     msg_format(_("%sの力が制御できない氾流となって解放された！", "Your mind unleashes its power in an uncontrollable storm!"), cm_ptr->mind_explanation);
     project(caster_ptr, PROJECT_WHO_UNCTRL_POWER, 2 + cm_ptr->plev / 10, caster_ptr->y, caster_ptr->x, cm_ptr->plev * 2, GF_MANA,
-        PROJECT_JUMP | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM, -1);
+        PROJECT_JUMP | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM);
     caster_ptr->csp = MAX(0, caster_ptr->csp - cm_ptr->plev * MAX(1, cm_ptr->plev / 10));
 }
 
@@ -234,7 +234,7 @@ static void check_mind_mirror_master(player_type *caster_ptr, cm_type *cm_ptr)
 
     msg_format(_("%sの力が制御できない氾流となって解放された！", "Your mind unleashes its power in an uncontrollable storm!"), cm_ptr->mind_explanation);
     project(caster_ptr, PROJECT_WHO_UNCTRL_POWER, 2 + cm_ptr->plev / 10, caster_ptr->y, caster_ptr->x, cm_ptr->plev * 2, GF_MANA,
-        PROJECT_JUMP | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM, -1);
+        PROJECT_JUMP | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM);
     caster_ptr->csp = MAX(0, caster_ptr->csp - cm_ptr->plev * MAX(1, cm_ptr->plev / 10));
 }
 
@@ -331,7 +331,7 @@ static void mind_reflection(player_type *caster_ptr, cm_type *cm_ptr)
 static void process_hard_concentration(player_type *caster_ptr, cm_type *cm_ptr)
 {
     if ((cm_ptr->use_mind == MIND_BERSERKER) || (cm_ptr->use_mind == MIND_NINJUTSU)) {
-        take_hit(caster_ptr, DAMAGE_USELIFE, cm_ptr->mana_cost, _("過度の集中", "concentrating too hard"), -1);
+        take_hit(caster_ptr, DAMAGE_USELIFE, cm_ptr->mana_cost, _("過度の集中", "concentrating too hard"));
         caster_ptr->redraw |= PR_HP;
         return;
     }

--- a/src/cmd-action/cmd-racial.cpp
+++ b/src/cmd-action/cmd-racial.cpp
@@ -258,7 +258,7 @@ static bool reduce_mana_by_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     actual_racial_cost -= creature_ptr->csp;
     creature_ptr->csp = 0;
-    take_hit(creature_ptr, DAMAGE_USELIFE, actual_racial_cost, _("過度の集中", "concentrating too hard"), -1);
+    take_hit(creature_ptr, DAMAGE_USELIFE, actual_racial_cost, _("過度の集中", "concentrating too hard"));
     return TRUE;
 }
 

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -1138,7 +1138,7 @@ void do_cmd_cast(player_type *caster_ptr)
                 sanity_blast(caster_ptr, 0, TRUE);
             } else {
                 msg_print(_("痛い！", "It hurts!"));
-                take_hit(caster_ptr, DAMAGE_LOSELIFE, damroll(o_ptr->sval + 1, 6), _("暗黒魔法の逆流", "a miscast Death spell"), -1);
+                take_hit(caster_ptr, DAMAGE_LOSELIFE, damroll(o_ptr->sval + 1, 6), _("暗黒魔法の逆流", "a miscast Death spell"));
 
                 if ((spell > 15) && one_in_(6) && !caster_ptr->hold_exp)
                     lose_exp(caster_ptr, spell * 250);

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -89,27 +89,27 @@ bool exe_eat_food_type_object(player_type *creature_ptr, object_type *o_ptr)
                 return TRUE;
         break;
     case SV_FOOD_WEAKNESS:
-        take_hit(creature_ptr, DAMAGE_NOESCAPE, damroll(6, 6), _("毒入り食料", "poisonous food"), -1);
+        take_hit(creature_ptr, DAMAGE_NOESCAPE, damroll(6, 6), _("毒入り食料", "poisonous food"));
         (void)do_dec_stat(creature_ptr, A_STR);
         return TRUE;
     case SV_FOOD_SICKNESS:
-        take_hit(creature_ptr, DAMAGE_NOESCAPE, damroll(6, 6), _("毒入り食料", "poisonous food"), -1);
+        take_hit(creature_ptr, DAMAGE_NOESCAPE, damroll(6, 6), _("毒入り食料", "poisonous food"));
         (void)do_dec_stat(creature_ptr, A_CON);
         return TRUE;
     case SV_FOOD_STUPIDITY:
-        take_hit(creature_ptr, DAMAGE_NOESCAPE, damroll(8, 8), _("毒入り食料", "poisonous food"), -1);
+        take_hit(creature_ptr, DAMAGE_NOESCAPE, damroll(8, 8), _("毒入り食料", "poisonous food"));
         (void)do_dec_stat(creature_ptr, A_INT);
         return TRUE;
     case SV_FOOD_NAIVETY:
-        take_hit(creature_ptr, DAMAGE_NOESCAPE, damroll(8, 8), _("毒入り食料", "poisonous food"), -1);
+        take_hit(creature_ptr, DAMAGE_NOESCAPE, damroll(8, 8), _("毒入り食料", "poisonous food"));
         (void)do_dec_stat(creature_ptr, A_WIS);
         return TRUE;
     case SV_FOOD_UNHEALTH:
-        take_hit(creature_ptr, DAMAGE_NOESCAPE, damroll(10, 10), _("毒入り食料", "poisonous food"), -1);
+        take_hit(creature_ptr, DAMAGE_NOESCAPE, damroll(10, 10), _("毒入り食料", "poisonous food"));
         (void)do_dec_stat(creature_ptr, A_CON);
         return TRUE;
     case SV_FOOD_DISEASE:
-        take_hit(creature_ptr, DAMAGE_NOESCAPE, damroll(10, 10), _("毒入り食料", "poisonous food"), -1);
+        take_hit(creature_ptr, DAMAGE_NOESCAPE, damroll(10, 10), _("毒入り食料", "poisonous food"));
         (void)do_dec_stat(creature_ptr, A_STR);
         return TRUE;
     case SV_FOOD_CURE_POISON:

--- a/src/combat/aura-counterattack.cpp
+++ b/src/combat/aura-counterattack.cpp
@@ -203,7 +203,7 @@ static void aura_shadow_by_monster_attack(player_type *target_ptr, monap_type *m
     for (int j = 0; j < 4; j++) {
         o_armed_ptr = &target_ptr->inventory_list[typ[j][0]];
         if ((o_armed_ptr->k_idx) && object_is_cursed(o_armed_ptr) && object_is_armour(target_ptr, o_armed_ptr))
-            project(target_ptr, 0, 0, monap_ptr->m_ptr->fy, monap_ptr->m_ptr->fx, (target_ptr->lev * 2), typ[j][1], flg, -1);
+            project(target_ptr, 0, 0, monap_ptr->m_ptr->fy, monap_ptr->m_ptr->fx, (target_ptr->lev * 2), typ[j][1], flg);
     }
 }
 

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -576,7 +576,7 @@ void exe_fire(player_type *shooter_ptr, INVENTORY_IDX item, object_type *j_ptr, 
 
             /* Sniper */
             if (snipe_type == SP_KILL_TRAP) {
-                project(shooter_ptr, 0, 0, ny, nx, 0, GF_KILL_TRAP, (PROJECT_JUMP | PROJECT_HIDE | PROJECT_GRID | PROJECT_ITEM), -1);
+                project(shooter_ptr, 0, 0, ny, nx, 0, GF_KILL_TRAP, (PROJECT_JUMP | PROJECT_HIDE | PROJECT_GRID | PROJECT_ITEM));
             }
 
             /* Sniper */
@@ -704,7 +704,7 @@ void exe_fire(player_type *shooter_ptr, INVENTORY_IDX item, object_type *j_ptr, 
                         u16b flg = (PROJECT_STOP | PROJECT_JUMP | PROJECT_KILL | PROJECT_GRID);
 
                         sound(SOUND_EXPLODE); /* No explode sound - use breath fire instead */
-                        project(shooter_ptr, 0, ((shooter_ptr->concent + 1) / 2 + 1), ny, nx, tdam, GF_MISSILE, flg, -1);
+                        project(shooter_ptr, 0, ((shooter_ptr->concent + 1) / 2 + 1), ny, nx, tdam, GF_MISSILE, flg);
                         break;
                     }
 

--- a/src/core/hp-mp-processor.cpp
+++ b/src/core/hp-mp-processor.cpp
@@ -69,15 +69,14 @@ static bool deal_damege_by_feat(player_type *creature_ptr, grid_type *g_ptr, con
     if (creature_ptr->levitation) {
         msg_print(msg_levitation);
 
-        take_hit(creature_ptr, DAMAGE_NOESCAPE, damage, format(_("%sの上に浮遊したダメージ", "flying over %s"),
-            f_info[get_feat_mimic(g_ptr)].name.c_str()), -1);
+        take_hit(creature_ptr, DAMAGE_NOESCAPE, damage, format(_("%sの上に浮遊したダメージ", "flying over %s"), f_info[get_feat_mimic(g_ptr)].name.c_str()));
 
         if (additional_effect != NULL)
             additional_effect(creature_ptr, damage);
     } else {
         concptr name = f_info[get_feat_mimic(&creature_ptr->current_floor_ptr->grid_array[creature_ptr->y][creature_ptr->x])].name.c_str();
         msg_format(_("%s%s！", "The %s %s!"), name, msg_normal);
-        take_hit(creature_ptr, DAMAGE_NOESCAPE, damage, name, -1);
+        take_hit(creature_ptr, DAMAGE_NOESCAPE, damage, name);
 
         if (additional_effect != NULL)
             additional_effect(creature_ptr, damage);
@@ -99,7 +98,7 @@ void process_player_hp_mp(player_type *creature_ptr)
     int upkeep_factor = 0;
     int regen_amount = PY_REGEN_NORMAL;
     if (creature_ptr->poisoned && !is_invuln(creature_ptr)) {
-        take_hit(creature_ptr, DAMAGE_NOESCAPE, 1, _("毒", "poison"), -1);
+        take_hit(creature_ptr, DAMAGE_NOESCAPE, 1, _("毒", "poison"));
     }
 
     if (creature_ptr->cut && !is_invuln(creature_ptr)) {
@@ -120,14 +119,14 @@ void process_player_hp_mp(player_type *creature_ptr)
             dam = 1;
         }
 
-        take_hit(creature_ptr, DAMAGE_NOESCAPE, dam, _("致命傷", "a fatal wound"), -1);
+        take_hit(creature_ptr, DAMAGE_NOESCAPE, dam, _("致命傷", "a fatal wound"));
     }
 
     if (is_specific_player_race(creature_ptr, RACE_VAMPIRE) || (creature_ptr->mimic_form == MIMIC_VAMPIRE)) {
         if (!is_in_dungeon(creature_ptr) && !has_resist_lite(creature_ptr) && !is_invuln(creature_ptr) && is_daytime()) {
             if ((creature_ptr->current_floor_ptr->grid_array[creature_ptr->y][creature_ptr->x].info & (CAVE_GLOW | CAVE_MNDK)) == CAVE_GLOW) {
                 msg_print(_("日光があなたのアンデッドの肉体を焼き焦がした！", "The sun's rays scorch your undead flesh!"));
-                take_hit(creature_ptr, DAMAGE_NOESCAPE, 1, _("日光", "sunlight"), -1);
+                take_hit(creature_ptr, DAMAGE_NOESCAPE, 1, _("日光", "sunlight"));
                 cave_no_regen = TRUE;
             }
         }
@@ -148,7 +147,7 @@ void process_player_hp_mp(player_type *creature_ptr)
             sprintf(ouch, _("%sを装備したダメージ", "wielding %s"), o_name);
 
             if (!is_invuln(creature_ptr))
-                take_hit(creature_ptr, DAMAGE_NOESCAPE, 1, ouch, -1);
+                take_hit(creature_ptr, DAMAGE_NOESCAPE, 1, ouch);
         }
     }
 
@@ -184,7 +183,7 @@ void process_player_hp_mp(player_type *creature_ptr)
         && !has_resist_water(creature_ptr)) {
         if (calc_inventory_weight(creature_ptr) > calc_weight_limit(creature_ptr)) {
             msg_print(_("溺れている！", "You are drowning!"));
-            take_hit(creature_ptr, DAMAGE_NOESCAPE, randint1(creature_ptr->lev), _("溺れ", "drowning"), -1);
+            take_hit(creature_ptr, DAMAGE_NOESCAPE, randint1(creature_ptr->lev), _("溺れ", "drowning"));
             cave_no_regen = TRUE;
         }
     }
@@ -200,7 +199,7 @@ void process_player_hp_mp(player_type *creature_ptr)
             if (is_oppose_fire(creature_ptr))
                 damage = damage / 3;
             msg_print(_("熱い！", "It's hot!"));
-            take_hit(creature_ptr, DAMAGE_NOESCAPE, damage, _("炎のオーラ", "Fire aura"), -1);
+            take_hit(creature_ptr, DAMAGE_NOESCAPE, damage, _("炎のオーラ", "Fire aura"));
         }
         if ((r_info[creature_ptr->current_floor_ptr->m_list[creature_ptr->riding].r_idx].flags2 & RF2_AURA_ELEC) && !has_immune_elec(creature_ptr)) {
             damage = r_info[creature_ptr->current_floor_ptr->m_list[creature_ptr->riding].r_idx].level / 2;
@@ -211,7 +210,7 @@ void process_player_hp_mp(player_type *creature_ptr)
             if (is_oppose_elec(creature_ptr))
                 damage = damage / 3;
             msg_print(_("痛い！", "It hurts!"));
-            take_hit(creature_ptr, DAMAGE_NOESCAPE, damage, _("電気のオーラ", "Elec aura"), -1);
+            take_hit(creature_ptr, DAMAGE_NOESCAPE, damage, _("電気のオーラ", "Elec aura"));
         }
         if ((r_info[creature_ptr->current_floor_ptr->m_list[creature_ptr->riding].r_idx].flags3 & RF3_AURA_COLD) && !has_immune_cold(creature_ptr)) {
             damage = r_info[creature_ptr->current_floor_ptr->m_list[creature_ptr->riding].r_idx].level / 2;
@@ -220,7 +219,7 @@ void process_player_hp_mp(player_type *creature_ptr)
             if (is_oppose_cold(creature_ptr))
                 damage = damage / 3;
             msg_print(_("冷たい！", "It's cold!"));
-            take_hit(creature_ptr, DAMAGE_NOESCAPE, damage, _("冷気のオーラ", "Cold aura"), -1);
+            take_hit(creature_ptr, DAMAGE_NOESCAPE, damage, _("冷気のオーラ", "Cold aura"));
         }
     }
 
@@ -245,7 +244,7 @@ void process_player_hp_mp(player_type *creature_ptr)
                 dam_desc = _("硬い岩", "solid rock");
             }
 
-            take_hit(creature_ptr, DAMAGE_NOESCAPE, 1 + (creature_ptr->lev / 5), dam_desc, -1);
+            take_hit(creature_ptr, DAMAGE_NOESCAPE, 1 + (creature_ptr->lev / 5), dam_desc);
         }
     }
 

--- a/src/effect/effect-feature.cpp
+++ b/src/effect/effect-feature.cpp
@@ -387,7 +387,7 @@ bool affect_feature(player_type *caster_ptr, MONSTER_IDX who, POSITION r, POSITI
             sound(SOUND_GLASS);
             remove_mirror(caster_ptr, y, x);
             project(caster_ptr, 0, 2, y, x, caster_ptr->lev / 2 + 5, GF_SHARDS,
-                (PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_JUMP | PROJECT_NO_HANGEKI), -1);
+                (PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_JUMP | PROJECT_NO_HANGEKI));
         }
 
         if (!has_flag(f_ptr->flags, FF_GLASS) || has_flag(f_ptr->flags, FF_PERMANENT) || (dam < 50))
@@ -408,7 +408,7 @@ bool affect_feature(player_type *caster_ptr, MONSTER_IDX who, POSITION r, POSITI
             sound(SOUND_GLASS);
             remove_mirror(caster_ptr, y, x);
             project(caster_ptr, 0, 2, y, x, caster_ptr->lev / 2 + 5, GF_SHARDS,
-                (PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_JUMP | PROJECT_NO_HANGEKI), -1);
+                (PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_JUMP | PROJECT_NO_HANGEKI));
         }
 
         if (!has_flag(f_ptr->flags, FF_GLASS) || has_flag(f_ptr->flags, FF_PERMANENT) || (dam < 200))

--- a/src/effect/effect-monster-psi.cpp
+++ b/src/effect/effect-monster-psi.cpp
@@ -144,7 +144,7 @@ static void effect_monster_psi_resist(player_type *caster_ptr, effect_monster_ty
 
     /* Injure +/- confusion */
     monster_desc(caster_ptr, em_ptr->killer, em_ptr->m_ptr, MD_WRONGDOER_NAME);
-    take_hit(caster_ptr, DAMAGE_ATTACK, em_ptr->dam, em_ptr->killer, -1);
+    take_hit(caster_ptr, DAMAGE_ATTACK, em_ptr->dam, em_ptr->killer);
     effect_monster_psi_reflect_extra_effect(caster_ptr, em_ptr);
     em_ptr->dam = 0;
 }
@@ -233,7 +233,7 @@ static void effect_monster_psi_drain_resist(player_type *caster_ptr, effect_mons
 
     monster_desc(caster_ptr, em_ptr->killer, em_ptr->m_ptr, MD_WRONGDOER_NAME);
     if (check_multishadow(caster_ptr)) {
-        take_hit(caster_ptr, DAMAGE_ATTACK, em_ptr->dam, em_ptr->killer, -1);
+        take_hit(caster_ptr, DAMAGE_ATTACK, em_ptr->dam, em_ptr->killer);
         em_ptr->dam = 0;
         return;
     }
@@ -245,7 +245,7 @@ static void effect_monster_psi_drain_resist(player_type *caster_ptr, effect_mons
 
     set_bits(caster_ptr->redraw, PR_MANA);
     set_bits(caster_ptr->window_flags, PW_SPELL);
-    take_hit(caster_ptr, DAMAGE_ATTACK, em_ptr->dam, em_ptr->killer, -1);
+    take_hit(caster_ptr, DAMAGE_ATTACK, em_ptr->dam, em_ptr->killer);
     em_ptr->dam = 0;
 }
 

--- a/src/effect/effect-player-curse.cpp
+++ b/src/effect/effect-player-curse.cpp
@@ -15,7 +15,7 @@ void effect_player_curse_1(player_type *target_ptr, effect_player_type *ep_ptr)
     } else {
         if (!check_multishadow(target_ptr))
             curse_equipment(target_ptr, 15, 0);
-        ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+        ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
     }
 }
 
@@ -26,7 +26,7 @@ void effect_player_curse_2(player_type *target_ptr, effect_player_type *ep_ptr)
     } else {
         if (!check_multishadow(target_ptr))
             curse_equipment(target_ptr, 25, MIN(ep_ptr->rlev / 2 - 15, 5));
-        ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+        ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
     }
 }
 
@@ -37,7 +37,7 @@ void effect_player_curse_3(player_type *target_ptr, effect_player_type *ep_ptr)
     } else {
         if (!check_multishadow(target_ptr))
             curse_equipment(target_ptr, 33, MIN(ep_ptr->rlev / 2 - 15, 15));
-        ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+        ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
     }
 }
 
@@ -46,7 +46,7 @@ void effect_player_curse_4(player_type *target_ptr, effect_player_type *ep_ptr)
     if ((randint0(100 + ep_ptr->rlev / 2) < target_ptr->skill_sav) && !(ep_ptr->m_ptr->r_idx == MON_KENSHIROU) && !check_multishadow(target_ptr)) {
         msg_print(_("しかし秘孔を跳ね返した！", "You resist the effects!"));
     } else {
-        ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+        ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
         if (!check_multishadow(target_ptr))
             (void)set_cut(target_ptr, target_ptr->cut + damroll(10, 10));
     }

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -31,12 +31,12 @@
 
 // 毒を除く4元素.
 void effect_player_elements(
-    player_type *target_ptr, effect_player_type *ep_ptr, concptr attack_message, HIT_POINT (*damage_func)(player_type *, HIT_POINT, concptr, int, bool))
+    player_type *target_ptr, effect_player_type *ep_ptr, concptr attack_message, HIT_POINT (*damage_func)(player_type *, HIT_POINT, concptr, bool))
 {
     if (target_ptr->blind)
         msg_print(attack_message);
 
-    ep_ptr->get_damage = (*damage_func)(target_ptr, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell, FALSE);
+    ep_ptr->get_damage = (*damage_func)(target_ptr, ep_ptr->dam, ep_ptr->killer, FALSE);
 }
 
 void effect_player_poison(player_type *target_ptr, effect_player_type *ep_ptr)
@@ -51,7 +51,7 @@ void effect_player_poison(player_type *target_ptr, effect_player_type *ep_ptr)
         do_dec_stat(target_ptr, A_CON);
     }
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 
     if (!(double_resist || has_resist_pois(target_ptr)) && !check_multishadow(target_ptr))
         set_poisoned(target_ptr, target_ptr->poisoned + randint0(ep_ptr->dam) + 10);
@@ -65,7 +65,7 @@ void effect_player_nuke(player_type *target_ptr, effect_player_type *ep_ptr)
 
     ep_ptr->dam = ep_ptr->dam * calc_pois_damage_rate(target_ptr) / 100;
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
     if ((double_resist || has_resist_pois(target_ptr)) || check_multishadow(target_ptr))
         return;
 
@@ -88,7 +88,7 @@ void effect_player_missile(player_type *target_ptr, effect_player_type *ep_ptr)
     if (target_ptr->blind)
         msg_print(_("何かで攻撃された！", "You are hit by something!"));
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
 
 void effect_player_holy_fire(player_type *target_ptr, effect_player_type *ep_ptr)
@@ -98,7 +98,7 @@ void effect_player_holy_fire(player_type *target_ptr, effect_player_type *ep_ptr
 
     ep_ptr->dam = ep_ptr->dam * calc_holy_fire_damage_rate(target_ptr, CALC_RAND) / 100;
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
 
 void effect_player_hell_fire(player_type *target_ptr, effect_player_type *ep_ptr)
@@ -108,14 +108,14 @@ void effect_player_hell_fire(player_type *target_ptr, effect_player_type *ep_ptr
 
     ep_ptr->dam = ep_ptr->dam * calc_hell_fire_damage_rate(target_ptr, CALC_RAND) / 100;
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
 
 void effect_player_arrow(player_type *target_ptr, effect_player_type *ep_ptr)
 {
     if (target_ptr->blind) {
         msg_print(_("何か鋭いもので攻撃された！", "You are hit by something sharp!"));
-        ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+        ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
         return;
     }
 
@@ -124,7 +124,7 @@ void effect_player_arrow(player_type *target_ptr, effect_player_type *ep_ptr)
         return;
     }
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
 
 void effect_player_plasma(player_type *target_ptr, effect_player_type *ep_ptr)
@@ -132,7 +132,7 @@ void effect_player_plasma(player_type *target_ptr, effect_player_type *ep_ptr)
     if (target_ptr->blind)
         msg_print(_("何かとても熱いもので攻撃された！", "You are hit by something *HOT*!"));
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 
     if (!has_resist_sound(target_ptr) && !check_multishadow(target_ptr)) {
         int plus_stun = (randint1((ep_ptr->dam > 40) ? 35 : (ep_ptr->dam * 3 / 4 + 5)));
@@ -173,7 +173,7 @@ void effect_player_nether(player_type *target_ptr, effect_player_type *ep_ptr)
     if (!has_resist_neth(target_ptr) && !evaded)
         drain_exp(target_ptr, 200 + (target_ptr->exp / 100), 200 + (target_ptr->exp / 1000), 75);
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
 
 /*!
@@ -189,7 +189,7 @@ void effect_player_water(player_type *target_ptr, effect_player_type *ep_ptr)
     if (target_ptr->blind)
         msg_print(_("何か湿ったもので攻撃された！", "You are hit by something wet!"));
     if (check_multishadow(target_ptr)) {
-        ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+        ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
         return;
     }
 
@@ -210,7 +210,7 @@ void effect_player_water(player_type *target_ptr, effect_player_type *ep_ptr)
         }
     }
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
 
 void effect_player_chaos(player_type *target_ptr, effect_player_type *ep_ptr)
@@ -221,7 +221,7 @@ void effect_player_chaos(player_type *target_ptr, effect_player_type *ep_ptr)
     ep_ptr->dam = ep_ptr->dam * calc_chaos_damage_rate(target_ptr, CALC_RAND) / 100;
 
     if (check_multishadow(target_ptr)) {
-        ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+        ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
         return;
     }
 
@@ -244,7 +244,7 @@ void effect_player_chaos(player_type *target_ptr, effect_player_type *ep_ptr)
         inventory_damage(target_ptr, set_fire_destroy, 2);
     }
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
 
 void effect_player_shards(player_type *target_ptr, effect_player_type *ep_ptr)
@@ -261,7 +261,7 @@ void effect_player_shards(player_type *target_ptr, effect_player_type *ep_ptr)
     if (!has_resist_shard(target_ptr) || one_in_(13))
         inventory_damage(target_ptr, set_cold_destroy, 2);
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
 
 void effect_player_sound(player_type *target_ptr, effect_player_type *ep_ptr)
@@ -279,7 +279,7 @@ void effect_player_sound(player_type *target_ptr, effect_player_type *ep_ptr)
     if (!has_resist_sound(target_ptr) || one_in_(13))
         inventory_damage(target_ptr, set_cold_destroy, 2);
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
 
 void effect_player_confusion(player_type *target_ptr, effect_player_type *ep_ptr)
@@ -293,7 +293,7 @@ void effect_player_confusion(player_type *target_ptr, effect_player_type *ep_ptr
         (void)set_confused(target_ptr, target_ptr->confused + randint1(20) + 10);
     }
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
 
 void effect_player_disenchant(player_type *target_ptr, effect_player_type *ep_ptr)
@@ -307,7 +307,7 @@ void effect_player_disenchant(player_type *target_ptr, effect_player_type *ep_pt
         (void)apply_disenchant(target_ptr, 0);
     }
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
 
 void effect_player_nexus(player_type *target_ptr, effect_player_type *ep_ptr)
@@ -321,7 +321,7 @@ void effect_player_nexus(player_type *target_ptr, effect_player_type *ep_ptr)
         apply_nexus(ep_ptr->m_ptr, target_ptr);
     }
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
 
 void effect_player_force(player_type *target_ptr, effect_player_type *ep_ptr)
@@ -332,7 +332,7 @@ void effect_player_force(player_type *target_ptr, effect_player_type *ep_ptr)
         (void)set_stun(target_ptr, target_ptr->stun + randint1(20));
     }
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
 
 void effect_player_rocket(player_type *target_ptr, effect_player_type *ep_ptr)
@@ -353,7 +353,7 @@ void effect_player_rocket(player_type *target_ptr, effect_player_type *ep_ptr)
         inventory_damage(target_ptr, set_cold_destroy, 3);
     }
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
 
 void effect_player_inertial(player_type *target_ptr, effect_player_type *ep_ptr)
@@ -363,7 +363,7 @@ void effect_player_inertial(player_type *target_ptr, effect_player_type *ep_ptr)
     if (!check_multishadow(target_ptr))
         (void)set_slow(target_ptr, target_ptr->slow + randint0(4) + 4, FALSE);
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
 
 void effect_player_lite(player_type *target_ptr, effect_player_type *ep_ptr)
@@ -381,7 +381,7 @@ void effect_player_lite(player_type *target_ptr, effect_player_type *ep_ptr)
             msg_print(_("光で肉体が焦がされた！", "The light scorches your flesh!"));
     }
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 
     if (!target_ptr->wraith_form || check_multishadow(target_ptr))
         return;
@@ -405,7 +405,7 @@ void effect_player_dark(player_type *target_ptr, effect_player_type *ep_ptr)
         (void)set_blind(target_ptr, target_ptr->blind + randint1(5) + 2);
     }
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
 
 static void effect_player_time_one_disability(player_type *target_ptr)
@@ -504,7 +504,7 @@ void effect_player_time(player_type *target_ptr, effect_player_type *ep_ptr)
     if (has_resist_time(target_ptr) && !evaded)
         msg_print(_("時間が通り過ぎていく気がする。", "You feel as if time is passing you by."));
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 
     if (!has_resist_time(target_ptr) && !evaded)
         effect_player_time_addition(target_ptr);
@@ -532,7 +532,7 @@ void effect_player_gravity(player_type *target_ptr, effect_player_type *ep_ptr)
         inventory_damage(target_ptr, set_cold_destroy, 2);
     }
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
 
 void effect_player_disintegration(player_type *target_ptr, effect_player_type *ep_ptr)
@@ -540,7 +540,7 @@ void effect_player_disintegration(player_type *target_ptr, effect_player_type *e
     if (target_ptr->blind)
         msg_print(_("純粋なエネルギーで攻撃された！", "You are hit by pure energy!"));
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
 
 void effect_player_death_ray(player_type *target_ptr, effect_player_type *ep_ptr)
@@ -549,7 +549,7 @@ void effect_player_death_ray(player_type *target_ptr, effect_player_type *ep_ptr
         msg_print(_("何か非常に冷たいもので攻撃された！", "You are hit by something extremely cold!"));
 
     ep_ptr->dam = ep_ptr->dam * calc_deathray_damage_rate(target_ptr, CALC_RAND) / 100;
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
 
 void effect_player_mana(player_type *target_ptr, effect_player_type *ep_ptr)
@@ -557,7 +557,7 @@ void effect_player_mana(player_type *target_ptr, effect_player_type *ep_ptr)
     if (target_ptr->blind)
         msg_print(_("魔法のオーラで攻撃された！", "You are hit by an aura of magic!"));
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
 
 void effect_player_psy_spear(player_type *target_ptr, effect_player_type *ep_ptr)
@@ -565,7 +565,7 @@ void effect_player_psy_spear(player_type *target_ptr, effect_player_type *ep_ptr
     if (target_ptr->blind)
         msg_print(_("エネルギーの塊で攻撃された！", "You are hit by an energy!"));
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_FORCE, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_FORCE, ep_ptr->dam, ep_ptr->killer);
 }
 
 void effect_player_meteor(player_type *target_ptr, effect_player_type *ep_ptr)
@@ -573,7 +573,7 @@ void effect_player_meteor(player_type *target_ptr, effect_player_type *ep_ptr)
     if (target_ptr->blind)
         msg_print(_("何かが空からあなたの頭上に落ちてきた！", "Something falls from the sky on you!"));
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
     if (!has_resist_shard(target_ptr) || one_in_(13)) {
         if (!has_immune_fire(target_ptr))
             inventory_damage(target_ptr, set_fire_destroy, 2);
@@ -586,7 +586,7 @@ void effect_player_icee(player_type *target_ptr, effect_player_type *ep_ptr)
     if (target_ptr->blind)
         msg_print(_("何か鋭く冷たいもので攻撃された！", "You are hit by something sharp and cold!"));
 
-    ep_ptr->get_damage = cold_dam(target_ptr, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell, FALSE);
+    ep_ptr->get_damage = cold_dam(target_ptr, ep_ptr->dam, ep_ptr->killer, FALSE);
     if (check_multishadow(target_ptr))
         return;
 
@@ -614,7 +614,7 @@ void effect_player_hand_doom(player_type *target_ptr, effect_player_type *ep_ptr
             curse_equipment(target_ptr, 40, 20);
         }
 
-        ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->m_name, ep_ptr->monspell);
+        ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->m_name);
 
         if (target_ptr->chp < 1)
             target_ptr->chp = 1;

--- a/src/effect/effect-player-resist-hurt.h
+++ b/src/effect/effect-player-resist-hurt.h
@@ -3,7 +3,7 @@
 #include "system/angband.h"
 #include "effect/effect-player-util.h"
 
-void effect_player_elements(player_type *target_ptr, effect_player_type *ep_ptr, concptr attack_message, HIT_POINT (*damage_func)(player_type *, HIT_POINT, concptr, int, bool));
+void effect_player_elements(player_type *target_ptr, effect_player_type *ep_ptr, concptr attack_message, HIT_POINT (*damage_func)(player_type *, HIT_POINT, concptr, bool));
 void effect_player_poison(player_type *target_ptr, effect_player_type *ep_ptr);
 void effect_player_nuke(player_type *target_ptr, effect_player_type *ep_ptr);
 void effect_player_missile(player_type *target_ptr, effect_player_type *ep_ptr);

--- a/src/effect/effect-player-spirit.cpp
+++ b/src/effect/effect-player-spirit.cpp
@@ -68,7 +68,7 @@ void effect_player_mind_blast(player_type *target_ptr, effect_player_type *ep_pt
     }
 
     if (check_multishadow(target_ptr)) {
-        ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+        ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
         return;
     }
 
@@ -88,7 +88,7 @@ void effect_player_mind_blast(player_type *target_ptr, effect_player_type *ep_pt
     }
 
     target_ptr->redraw |= PR_MANA;
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
 
 void effect_player_brain_smash(player_type *target_ptr, effect_player_type *ep_ptr)
@@ -109,7 +109,7 @@ void effect_player_brain_smash(player_type *target_ptr, effect_player_type *ep_p
         target_ptr->redraw |= PR_MANA;
     }
 
-    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer, ep_ptr->monspell);
+    ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
     if (check_multishadow(target_ptr))
         return;
 

--- a/src/effect/effect-player-util.h
+++ b/src/effect/effect-player-util.h
@@ -14,5 +14,4 @@ typedef struct effect_player_type {
     HIT_POINT dam;
     EFFECT_ID effect_type;
     BIT_FLAGS flag;
-    int monspell;
 } effect_player_type;

--- a/src/effect/effect-player.cpp
+++ b/src/effect/effect-player.cpp
@@ -159,7 +159,7 @@ enum ep_check_result {
  * @return 初期化後の構造体ポインタ
  */
 static effect_player_type *initialize_effect_player(
-    effect_player_type *ep_ptr, MONSTER_IDX who, HIT_POINT dam, EFFECT_ID effect_type, BIT_FLAGS flag, int monspell)
+    effect_player_type *ep_ptr, MONSTER_IDX who, HIT_POINT dam, EFFECT_ID effect_type, BIT_FLAGS flag)
 {
     ep_ptr->rlev = 0;
     ep_ptr->m_ptr = NULL;
@@ -168,7 +168,6 @@ static effect_player_type *initialize_effect_player(
     ep_ptr->dam = dam;
     ep_ptr->effect_type = effect_type;
     ep_ptr->flag = flag;
-    ep_ptr->monspell = monspell;
     return ep_ptr;
 }
 
@@ -215,7 +214,7 @@ static bool process_bolt_reflection(player_type *target_ptr, effect_player_type 
         t_x = target_ptr->x - 1 + randint1(3);
     }
 
-    (*project)(target_ptr, 0, 0, t_y, t_x, ep_ptr->dam, ep_ptr->effect_type, (PROJECT_STOP | PROJECT_KILL | PROJECT_REFLECTABLE), ep_ptr->monspell);
+    (*project)(target_ptr, 0, 0, t_y, t_x, ep_ptr->dam, ep_ptr->effect_type, (PROJECT_STOP | PROJECT_KILL | PROJECT_REFLECTABLE));
     disturb(target_ptr, TRUE, TRUE);
     return TRUE;
 }
@@ -292,10 +291,10 @@ static void describe_effect_source(player_type *target_ptr, effect_player_type *
  * @return 何か一つでも効力があればTRUEを返す / TRUE if any "effects" of the projection were observed, else FALSE
  */
 bool affect_player(MONSTER_IDX who, player_type *target_ptr, concptr who_name, int r, POSITION y, POSITION x, HIT_POINT dam, EFFECT_ID effect_type,
-    BIT_FLAGS flag, int monspell, project_func project)
+    BIT_FLAGS flag, project_func project)
 {
     effect_player_type tmp_effect;
-    effect_player_type *ep_ptr = initialize_effect_player(&tmp_effect, who, dam, effect_type, flag, monspell);
+    effect_player_type *ep_ptr = initialize_effect_player(&tmp_effect, who, dam, effect_type, flag);
     ep_check_result check_result = check_continue_player_effect(target_ptr, ep_ptr, y, x, project);
     if (check_result != EP_CHECK_CONTINUE)
         return (bool)check_result;
@@ -312,7 +311,7 @@ bool affect_player(MONSTER_IDX who, player_type *target_ptr, concptr who_name, i
         GAME_TEXT m_name_self[MAX_MONSTER_NAME];
         monster_desc(target_ptr, m_name_self, ep_ptr->m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE | MD_OBJECTIVE);
         msg_format(_("攻撃が%s自身を傷つけた！", "The attack of %s has wounded %s!"), ep_ptr->m_name, m_name_self);
-        (*project)(target_ptr, 0, 0, ep_ptr->m_ptr->fy, ep_ptr->m_ptr->fx, ep_ptr->get_damage, GF_MISSILE, PROJECT_KILL, -1);
+        (*project)(target_ptr, 0, 0, ep_ptr->m_ptr->fy, ep_ptr->m_ptr->fx, ep_ptr->get_damage, GF_MISSILE, PROJECT_KILL);
         if (target_ptr->tim_eyeeye)
             set_tim_eyeeye(target_ptr, target_ptr->tim_eyeeye - 5, TRUE);
     }

--- a/src/effect/effect-player.h
+++ b/src/effect/effect-player.h
@@ -5,7 +5,7 @@
 struct ProjectResult;
 
 using project_func = ProjectResult (*)(
-    player_type *caster_ptr, MONSTER_IDX who, POSITION rad, POSITION y, POSITION x, HIT_POINT dam, EFFECT_ID typ, BIT_FLAGS flag, int monspell);
+    player_type *caster_ptr, MONSTER_IDX who, POSITION rad, POSITION y, POSITION x, HIT_POINT dam, EFFECT_ID typ, BIT_FLAGS flag);
 
 bool affect_player(MONSTER_IDX who, player_type *target_ptr, concptr who_name, int r, POSITION y, POSITION x, HIT_POINT dam, EFFECT_ID typ, BIT_FLAGS flag,
-    int monspell, project_func project);
+    project_func project);

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -81,7 +81,7 @@ static void next_mirror(player_type *creature_ptr, POSITION *next_y, POSITION *n
  * @todo 引数にそのまま再代入していてカオスすぎる。直すのは簡単ではない
  */
 ProjectResult project(player_type *caster_ptr, const MONSTER_IDX who, POSITION rad, POSITION y, POSITION x, const HIT_POINT dam, const EFFECT_ID typ,
-    BIT_FLAGS flag, const int monspell)
+    BIT_FLAGS flag)
 {
     int dist;
     POSITION y1;
@@ -640,7 +640,7 @@ ProjectResult project(player_type *caster_ptr, const MONSTER_IDX who, POSITION r
                     else
                         flag |= PROJECT_PLAYER;
 
-                    project(caster_ptr, caster_ptr->current_floor_ptr->grid_array[y][x].m_idx, 0, t_y, t_x, dam, typ, flag, monspell);
+                    project(caster_ptr, caster_ptr->current_floor_ptr->grid_array[y][x].m_idx, 0, t_y, t_x, dam, typ, flag);
                     continue;
                 }
             }
@@ -778,7 +778,7 @@ ProjectResult project(player_type *caster_ptr, const MONSTER_IDX who, POSITION r
                 }
             }
 
-            if (affect_player(who, caster_ptr, who_name, effective_dist, y, x, dam, typ, flag, monspell, project)) {
+            if (affect_player(who, caster_ptr, who_name, effective_dist, y, x, dam, typ, flag, project)) {
                 res.notice = TRUE;
                 res.affected_player = TRUE;
             }

--- a/src/effect/effect-processor.h
+++ b/src/effect/effect-processor.h
@@ -11,4 +11,4 @@ struct ProjectResult {
 };
 
 ProjectResult project(player_type *caster_ptr, const MONSTER_IDX who, POSITION rad, POSITION y, POSITION x, const HIT_POINT dam, const EFFECT_ID typ,
-    BIT_FLAGS flag, const int monspell);
+    BIT_FLAGS flag);

--- a/src/floor/pattern-walk.cpp
+++ b/src/floor/pattern-walk.cpp
@@ -132,14 +132,14 @@ bool pattern_effect(player_type *creature_ptr)
 
     case PATTERN_TILE_WRECKED:
         if (!is_invuln(creature_ptr))
-            take_hit(creature_ptr, DAMAGE_NOESCAPE, 200, _("壊れた「パターン」を歩いたダメージ", "walking the corrupted Pattern"), -1);
+            take_hit(creature_ptr, DAMAGE_NOESCAPE, 200, _("壊れた「パターン」を歩いたダメージ", "walking the corrupted Pattern"));
         break;
 
     default:
         if (is_specific_player_race(creature_ptr, RACE_AMBERITE) && !one_in_(2))
             return TRUE;
         else if (!is_invuln(creature_ptr))
-            take_hit(creature_ptr, DAMAGE_NOESCAPE, damroll(1, 3), _("「パターン」を歩いたダメージ", "walking the Pattern"), -1);
+            take_hit(creature_ptr, DAMAGE_NOESCAPE, damroll(1, 3), _("「パターン」を歩いたダメージ", "walking the Pattern"));
         break;
     }
 

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -979,7 +979,7 @@ void cave_alter_feat(player_type *player_ptr, POSITION y, POSITION x, int action
 
         if (has_flag(old_f_ptr->flags, FF_GLASS) && current_world_ptr->character_dungeon) {
             project(player_ptr, PROJECT_WHO_GLASS_SHARDS, 1, y, x, MIN(floor_ptr->dun_level, 100) / 4, GF_SHARDS,
-                (PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_HIDE | PROJECT_JUMP | PROJECT_NO_HANGEKI), -1);
+                (PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_HIDE | PROJECT_JUMP | PROJECT_NO_HANGEKI));
         }
     }
 }

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -334,7 +334,7 @@ static void hit_trap_pit(player_type *trapped_ptr, int trap_feat_type)
         }
     }
 
-    take_hit(trapped_ptr, DAMAGE_NOESCAPE, dam, trap_name, -1);
+    take_hit(trapped_ptr, DAMAGE_NOESCAPE, dam, trap_name);
 }
 
 /*!
@@ -347,7 +347,7 @@ static bool hit_trap_dart(player_type *target_ptr)
 
     if (check_hit_from_monster_to_player(target_ptr, 125)) {
         msg_print(_("小さなダーツが飛んできて刺さった！", "A small dart hits you!"));
-        take_hit(target_ptr, DAMAGE_ATTACK, damroll(1, 4), _("ダーツの罠", "a dart trap"), -1);
+        take_hit(target_ptr, DAMAGE_ATTACK, damroll(1, 4), _("ダーツの罠", "a dart trap"));
         if (!check_multishadow(target_ptr))
             hit = TRUE;
     } else {
@@ -432,7 +432,7 @@ void hit_trap(player_type *trapped_ptr, bool break_trap)
             dam = damroll(2, 8);
             name = _("落とし戸", "a trap door");
 
-            take_hit(trapped_ptr, DAMAGE_NOESCAPE, dam, name, -1);
+            take_hit(trapped_ptr, DAMAGE_NOESCAPE, dam, name);
 
             /* Still alive and autosave enabled */
             if (autosave_l && (trapped_ptr->chp >= 0))
@@ -480,14 +480,14 @@ void hit_trap(player_type *trapped_ptr, bool break_trap)
     case TRAP_FIRE: {
         msg_print(_("炎に包まれた！", "You are enveloped in flames!"));
         dam = damroll(4, 6);
-        (void)fire_dam(trapped_ptr, dam, _("炎のトラップ", "a fire trap"), -1, FALSE);
+        (void)fire_dam(trapped_ptr, dam, _("炎のトラップ", "a fire trap"), FALSE);
         break;
     }
 
     case TRAP_ACID: {
         msg_print(_("酸が吹きかけられた！", "You are splashed with acid!"));
         dam = damroll(4, 6);
-        (void)acid_dam(trapped_ptr, dam, _("酸のトラップ", "an acid trap"), -1, FALSE);
+        (void)acid_dam(trapped_ptr, dam, _("酸のトラップ", "an acid trap"), FALSE);
         break;
     }
 
@@ -548,7 +548,7 @@ void hit_trap(player_type *trapped_ptr, bool break_trap)
     case TRAP_TRAPS: {
         msg_print(_("まばゆい閃光が走った！", "There is a bright flash of light!"));
         /* Make some new traps */
-        project(trapped_ptr, 0, 1, y, x, 0, GF_MAKE_TRAP, PROJECT_HIDE | PROJECT_JUMP | PROJECT_GRID, -1);
+        project(trapped_ptr, 0, 1, y, x, 0, GF_MAKE_TRAP, PROJECT_HIDE | PROJECT_JUMP | PROJECT_GRID);
 
         break;
     }
@@ -563,9 +563,9 @@ void hit_trap(player_type *trapped_ptr, bool break_trap)
 
     case TRAP_OPEN: {
         msg_print(_("大音響と共にまわりの壁が崩れた！", "Suddenly, surrounding walls are opened!"));
-        (void)project(trapped_ptr, 0, 3, y, x, 0, GF_DISINTEGRATE, PROJECT_GRID | PROJECT_HIDE, -1);
-        (void)project(trapped_ptr, 0, 3, y, x - 4, 0, GF_DISINTEGRATE, PROJECT_GRID | PROJECT_HIDE, -1);
-        (void)project(trapped_ptr, 0, 3, y, x + 4, 0, GF_DISINTEGRATE, PROJECT_GRID | PROJECT_HIDE, -1);
+        (void)project(trapped_ptr, 0, 3, y, x, 0, GF_DISINTEGRATE, PROJECT_GRID | PROJECT_HIDE);
+        (void)project(trapped_ptr, 0, 3, y, x - 4, 0, GF_DISINTEGRATE, PROJECT_GRID | PROJECT_HIDE);
+        (void)project(trapped_ptr, 0, 3, y, x + 4, 0, GF_DISINTEGRATE, PROJECT_GRID | PROJECT_HIDE);
         aggravate_monsters(trapped_ptr, 0);
 
         break;

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -305,7 +305,7 @@ static void curse_drain_hp(player_type *creature_ptr)
     GAME_TEXT o_name[MAX_NLEN];
     describe_flavor(creature_ptr, o_name, choose_cursed_obj_name(creature_ptr, TRC_DRAIN_HP), (OD_OMIT_PREFIX | OD_NAME_ONLY));
     msg_format(_("%sはあなたの体力を吸収した！", "Your %s drains HP from you!"), o_name);
-    take_hit(creature_ptr, DAMAGE_LOSELIFE, MIN(creature_ptr->lev * 2, 100), o_name, -1);
+    take_hit(creature_ptr, DAMAGE_LOSELIFE, MIN(creature_ptr->lev * 2, 100), o_name);
 }
 
 static void curse_drain_mp(player_type *creature_ptr)
@@ -372,5 +372,5 @@ void execute_cursed_items_effect(player_type *creature_ptr)
     else
         msg_print(_("なにかがあなたの体力を吸収した！", "Something drains life from you!"));
 
-    take_hit(creature_ptr, DAMAGE_LOSELIFE, MIN(creature_ptr->lev, 50), _("審判の宝石", "the Jewel of Judgement"), -1);
+    take_hit(creature_ptr, DAMAGE_LOSELIFE, MIN(creature_ptr->lev, 50), _("審判の宝石", "the Jewel of Judgement"));
 }

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -61,11 +61,10 @@ static void process_blow_effect(player_type *subject_ptr, mam_type *mam_ptr)
     switch (mam_ptr->effect_type) {
     case BLOW_EFFECT_TYPE_FEAR:
         project(subject_ptr, mam_ptr->m_idx, 0, mam_ptr->t_ptr->fy, mam_ptr->t_ptr->fx, mam_ptr->damage, GF_TURN_ALL,
-            PROJECT_KILL | PROJECT_STOP | PROJECT_AIMED, -1);
+            PROJECT_KILL | PROJECT_STOP | PROJECT_AIMED);
         break;
     case BLOW_EFFECT_TYPE_SLEEP:
-        project(subject_ptr, mam_ptr->m_idx, 0, mam_ptr->t_ptr->fy, mam_ptr->t_ptr->fx, r_ptr->level, GF_OLD_SLEEP, PROJECT_KILL | PROJECT_STOP | PROJECT_AIMED,
-            -1);
+        project(subject_ptr, mam_ptr->m_idx, 0, mam_ptr->t_ptr->fy, mam_ptr->t_ptr->fx, r_ptr->level, GF_OLD_SLEEP, PROJECT_KILL | PROJECT_STOP | PROJECT_AIMED);
         break;
     case BLOW_EFFECT_TYPE_HEAL:
         heal_monster_by_melee(subject_ptr, mam_ptr);
@@ -92,7 +91,7 @@ static void aura_fire_by_melee(player_type *subject_ptr, mam_type *mam_ptr)
         tr_ptr->r_flags2 |= RF2_AURA_FIRE;
 
     project(subject_ptr, mam_ptr->t_idx, 0, mam_ptr->m_ptr->fy, mam_ptr->m_ptr->fx, damroll(1 + ((tr_ptr->level) / 26), 1 + ((tr_ptr->level) / 17)), GF_FIRE,
-        PROJECT_KILL | PROJECT_STOP | PROJECT_AIMED, -1);
+        PROJECT_KILL | PROJECT_STOP | PROJECT_AIMED);
 }
 
 static void aura_cold_by_melee(player_type *subject_ptr, mam_type *mam_ptr)
@@ -114,7 +113,7 @@ static void aura_cold_by_melee(player_type *subject_ptr, mam_type *mam_ptr)
         tr_ptr->r_flags3 |= RF3_AURA_COLD;
 
     project(subject_ptr, mam_ptr->t_idx, 0, mam_ptr->m_ptr->fy, mam_ptr->m_ptr->fx, damroll(1 + ((tr_ptr->level) / 26), 1 + ((tr_ptr->level) / 17)), GF_COLD,
-        PROJECT_KILL | PROJECT_STOP | PROJECT_AIMED, -1);
+        PROJECT_KILL | PROJECT_STOP | PROJECT_AIMED);
 }
 
 static void aura_elec_by_melee(player_type *subject_ptr, mam_type *mam_ptr)
@@ -136,7 +135,7 @@ static void aura_elec_by_melee(player_type *subject_ptr, mam_type *mam_ptr)
         tr_ptr->r_flags2 |= RF2_AURA_ELEC;
 
     project(subject_ptr, mam_ptr->t_idx, 0, mam_ptr->m_ptr->fy, mam_ptr->m_ptr->fx, damroll(1 + ((tr_ptr->level) / 26), 1 + ((tr_ptr->level) / 17)), GF_ELEC,
-        PROJECT_KILL | PROJECT_STOP | PROJECT_AIMED, -1);
+        PROJECT_KILL | PROJECT_STOP | PROJECT_AIMED);
 }
 
 static bool check_same_monster(player_type *subject_ptr, mam_type *mam_ptr)
@@ -196,7 +195,7 @@ static void process_monster_attack_effect(player_type *subject_ptr, mam_type *ma
 
     if (!mam_ptr->explode)
         project(subject_ptr, mam_ptr->m_idx, 0, mam_ptr->t_ptr->fy, mam_ptr->t_ptr->fx, mam_ptr->damage, mam_ptr->pt,
-            PROJECT_KILL | PROJECT_STOP | PROJECT_AIMED, -1);
+            PROJECT_KILL | PROJECT_STOP | PROJECT_AIMED);
 
     process_blow_effect(subject_ptr, mam_ptr);
     if (!mam_ptr->touched)

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -570,7 +570,7 @@ static bool cast_element_spell(player_type *caster_ptr, SPELL_IDX spell_idx)
                 if (!player_bold(caster_ptr, y, x))
                     break;
             }
-            project(caster_ptr, 0, 0, y, x, damroll(6 + plev / 8, 7), typ, (PROJECT_BEAM | PROJECT_THRU | PROJECT_GRID | PROJECT_KILL), -1);
+            project(caster_ptr, 0, 0, y, x, damroll(6 + plev / 8, 7), typ, (PROJECT_BEAM | PROJECT_THRU | PROJECT_GRID | PROJECT_KILL));
         }
         break;
     case ElementSpells::STORM_2ND:
@@ -874,7 +874,7 @@ static bool try_cast_element_spell(player_type *caster_ptr, SPELL_IDX spell_idx,
             "Elemental power unleashes its power in an uncontrollable storm!"));
         project(caster_ptr, PROJECT_WHO_UNCTRL_POWER, 2 + plev / 10, caster_ptr->y, caster_ptr->x, plev * 2,
             get_element_types(caster_ptr->element)[0],
-            PROJECT_JUMP | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM, -1);
+            PROJECT_JUMP | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM);
         caster_ptr->csp = MAX(0, caster_ptr->csp - caster_ptr->msp * 10 / (20 + randint1(10)));
 
         take_turn(caster_ptr, 100);
@@ -1335,7 +1335,7 @@ bool switch_element_execution(player_type *creature_ptr)
         (void)lite_area(creature_ptr, damroll(2, plev / 2), plev / 10);
         break;
     case ElementRealm::ICE:
-        (void)project(creature_ptr, 0, 5, creature_ptr->y, creature_ptr->x, 1, GF_COLD, PROJECT_ITEM, -1);
+        (void)project(creature_ptr, 0, 5, creature_ptr->y, creature_ptr->x, 1, GF_COLD, PROJECT_ITEM);
         (void)project_all_los(creature_ptr, GF_OLD_SLEEP, 20 + plev * 3 / 2);
         break;
     case ElementRealm::SKY:

--- a/src/mind/mind-force-trainer.cpp
+++ b/src/mind/mind-force-trainer.cpp
@@ -275,7 +275,7 @@ bool cast_force_spell(player_type *caster_ptr, mind_force_trainer_type spell)
         if (randint1(get_current_ki(caster_ptr)) > (plev * 4 + 120)) {
             msg_print(_("気が暴走した！", "The Force exploded!"));
             fire_ball(caster_ptr, GF_MANA, 0, get_current_ki(caster_ptr) / 2, 10);
-            take_hit(caster_ptr, DAMAGE_LOSELIFE, caster_ptr->magic_num1[0] / 2, _("気の暴走", "Explosion of the Force"), -1);
+            take_hit(caster_ptr, DAMAGE_LOSELIFE, caster_ptr->magic_num1[0] / 2, _("気の暴走", "Explosion of the Force"));
         } else
             return TRUE;
 

--- a/src/mind/mind-mindcrafter.cpp
+++ b/src/mind/mind-mindcrafter.cpp
@@ -217,7 +217,7 @@ bool cast_mindcrafter_spell(player_type *caster_ptr, mind_mindcrafter_type spell
     case MIND_WAVE:
         msg_print(_("精神を捻じ曲げる波動を発生させた！", "Mind-warping forces emanate from your brain!"));
         if (plev < 25)
-            project(caster_ptr, 0, 2 + plev / 10, caster_ptr->y, caster_ptr->x, (plev * 3), GF_PSI, PROJECT_KILL, -1);
+            project(caster_ptr, 0, 2 + plev / 10, caster_ptr->y, caster_ptr->x, (plev * 3), GF_PSI, PROJECT_KILL);
         else
             (void)mindblast_monsters(caster_ptr, randint1(plev * ((plev - 5) / 10 + 1)));
 

--- a/src/mind/mind-mirror-master.cpp
+++ b/src/mind/mind-mirror-master.cpp
@@ -91,7 +91,7 @@ void remove_all_mirrors(player_type *caster_ptr, bool explode)
                 continue;
 
             project(caster_ptr, 0, 2, y, x, caster_ptr->lev / 2 + 5, GF_SHARDS,
-                (PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_JUMP | PROJECT_NO_HANGEKI), -1);
+                (PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_JUMP | PROJECT_NO_HANGEKI));
         }
     }
 }
@@ -474,7 +474,7 @@ bool cast_mirror_spell(player_type *caster_ptr, mind_mirror_master_type spell)
             for (y = 0; y < caster_ptr->current_floor_ptr->height; y++)
                 if (is_mirror_grid(&caster_ptr->current_floor_ptr->grid_array[y][x]))
                     project(caster_ptr, 0, 2, y, x, (HIT_POINT)plev, GF_OLD_SLEEP,
-                        (PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_JUMP | PROJECT_NO_HANGEKI), -1);
+                        (PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_JUMP | PROJECT_NO_HANGEKI));
 
         break;
     case SEEKER_RAY:

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -456,7 +456,7 @@ bool cast_ninja_spell(player_type *caster_ptr, mind_ninja_type spell)
                     break;
             }
 
-            project(caster_ptr, 0, 0, y, x, damroll(6 + plev / 8, 10), typ, (PROJECT_BEAM | PROJECT_THRU | PROJECT_GRID | PROJECT_KILL), -1);
+            project(caster_ptr, 0, 0, y, x, damroll(6 + plev / 8, 10), typ, (PROJECT_BEAM | PROJECT_THRU | PROJECT_GRID | PROJECT_KILL));
         }
 
         break;

--- a/src/mind/mind-warrior-mage.cpp
+++ b/src/mind/mind-warrior-mage.cpp
@@ -6,7 +6,7 @@
 
 bool comvert_hp_to_mp(player_type *creature_ptr)
 {
-    int gain_sp = take_hit(creature_ptr, DAMAGE_USELIFE, creature_ptr->lev, _("ＨＰからＭＰへの無謀な変換", "thoughtless conversion from HP to SP"), -1) / 5;
+    int gain_sp = take_hit(creature_ptr, DAMAGE_USELIFE, creature_ptr->lev, _("ＨＰからＭＰへの無謀な変換", "thoughtless conversion from HP to SP")) / 5;
     if (!gain_sp) {
         msg_print(_("変換に失敗した。", "You failed to convert."));
         creature_ptr->redraw |= (PR_HP | PR_MANA);

--- a/src/monster-attack/monster-attack-lose.cpp
+++ b/src/monster-attack/monster-attack-lose.cpp
@@ -25,7 +25,7 @@ void calc_blow_disease(player_type *target_ptr, monap_type *monap_ptr)
     if (is_oppose_pois(target_ptr))
         monap_ptr->damage = monap_ptr->damage * (randint1(4) + 4) / 9;
 
-    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
     if (target_ptr->is_dead || check_multishadow(target_ptr))
         return;
 
@@ -54,7 +54,7 @@ void calc_blow_lose_strength(player_type *target_ptr, monap_type *monap_ptr)
     if (has_sustain_str(target_ptr))
         monap_ptr->get_damage = monap_ptr->get_damage * (randint1(4) + 4) / 9;
 
-    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
     if (target_ptr->is_dead || check_multishadow(target_ptr))
         return;
 
@@ -73,7 +73,7 @@ void calc_blow_lose_intelligence(player_type *target_ptr, monap_type *monap_ptr)
     if (has_sustain_int(target_ptr))
         monap_ptr->get_damage = monap_ptr->get_damage * (randint1(4) + 4) / 9;
 
-    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
     if (target_ptr->is_dead || check_multishadow(target_ptr))
         return;
 
@@ -92,7 +92,7 @@ void calc_blow_lose_wisdom(player_type *target_ptr, monap_type *monap_ptr)
     if (has_sustain_wis(target_ptr))
         monap_ptr->get_damage = monap_ptr->get_damage * (randint1(4) + 4) / 9;
 
-    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
     if (target_ptr->is_dead || check_multishadow(target_ptr))
         return;
 
@@ -111,7 +111,7 @@ void calc_blow_lose_dexterity(player_type *target_ptr, monap_type *monap_ptr)
     if (has_sustain_dex(target_ptr))
         monap_ptr->get_damage = monap_ptr->get_damage * (randint1(4) + 4) / 9;
 
-    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
     if (target_ptr->is_dead || check_multishadow(target_ptr))
         return;
 
@@ -130,7 +130,7 @@ void calc_blow_lose_constitution(player_type *target_ptr, monap_type *monap_ptr)
     if (has_sustain_con(target_ptr))
         monap_ptr->get_damage = monap_ptr->get_damage * (randint1(4) + 4) / 9;
 
-    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
     if (target_ptr->is_dead || check_multishadow(target_ptr))
         return;
 
@@ -149,7 +149,7 @@ void calc_blow_lose_charisma(player_type *target_ptr, monap_type *monap_ptr)
     if (has_sustain_chr(target_ptr))
         monap_ptr->get_damage = monap_ptr->get_damage * (randint1(4) + 4) / 9;
 
-    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
     if (target_ptr->is_dead || check_multishadow(target_ptr))
         return;
 
@@ -185,7 +185,7 @@ void calc_blow_lose_all(player_type *target_ptr, monap_type *monap_ptr)
         damage_ratio -= 3;
 
     monap_ptr->damage = monap_ptr->damage * damage_ratio / 100;
-    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
     if (target_ptr->is_dead || check_multishadow(target_ptr))
         return;
 

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -467,7 +467,7 @@ static void eyes_on_eyes(player_type *target_ptr, monap_type *monap_ptr)
     monster_desc(target_ptr, m_name_self, monap_ptr->m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE | MD_OBJECTIVE);
     msg_format("The attack of %s has wounded %s!", monap_ptr->m_name, m_name_self);
 #endif
-    project(target_ptr, 0, 0, monap_ptr->m_ptr->fy, monap_ptr->m_ptr->fx, monap_ptr->get_damage, GF_MISSILE, PROJECT_KILL, -1);
+    project(target_ptr, 0, 0, monap_ptr->m_ptr->fy, monap_ptr->m_ptr->fx, monap_ptr->get_damage, GF_MISSILE, PROJECT_KILL);
     if (target_ptr->tim_eyeeye)
         set_tim_eyeeye(target_ptr, target_ptr->tim_eyeeye - 5, TRUE);
 }

--- a/src/monster-attack/monster-attack-switcher.cpp
+++ b/src/monster-attack/monster-attack-switcher.cpp
@@ -43,7 +43,7 @@ static void calc_blow_poison(player_type *target_ptr, monap_type *monap_ptr)
         monap_ptr->obvious = TRUE;
 
     monap_ptr->damage = monap_ptr->damage * calc_nuke_damage_rate(target_ptr) / 100;
-    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
     update_smart_learn(target_ptr, monap_ptr->m_idx, DRS_POIS);
 }
 
@@ -66,7 +66,7 @@ static void calc_blow_disenchant(player_type *target_ptr, monap_type *monap_ptr)
     if (has_resist_disen(target_ptr))
         monap_ptr->damage = monap_ptr->damage * (randint1(4) + 4) / 9;
 
-    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
     update_smart_learn(target_ptr, monap_ptr->m_idx, DRS_DISEN);
 }
 
@@ -91,7 +91,7 @@ static void calc_blow_un_power(player_type *target_ptr, monap_type *monap_ptr)
         damage_ratio -= 75;
 
     monap_ptr->damage = monap_ptr->damage * damage_ratio / 1000;
-    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
     if (target_ptr->is_dead || check_multishadow(target_ptr))
         return;
 
@@ -118,7 +118,7 @@ static void calc_blow_blind(player_type *target_ptr, monap_type *monap_ptr)
     if (has_resist_blind(target_ptr))
         monap_ptr->damage = monap_ptr->damage * (randint1(4) + 3) / 8;
 
-    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
     if (target_ptr->is_dead)
         return;
 
@@ -140,7 +140,7 @@ static void calc_blow_confusion(player_type *target_ptr, monap_type *monap_ptr)
     if (has_resist_conf(target_ptr))
         monap_ptr->damage = monap_ptr->damage * (randint1(4) + 3) / 8;
 
-    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
     if (target_ptr->is_dead)
         return;
 
@@ -161,7 +161,7 @@ static void calc_blow_fear(player_type *target_ptr, monap_type *monap_ptr)
     if (has_resist_fear(target_ptr))
         monap_ptr->damage = monap_ptr->damage * (randint1(4) + 3) / 8;
 
-    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
     if (target_ptr->is_dead)
         return;
 
@@ -180,7 +180,7 @@ static void calc_blow_paralysis(player_type *target_ptr, monap_type *monap_ptr)
     if (has_free_act(target_ptr))
         monap_ptr->damage = monap_ptr->damage * (randint1(4) + 3) / 8;
 
-    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
     if (target_ptr->is_dead)
         return;
 
@@ -206,7 +206,7 @@ static void calc_blow_drain_exp(player_type *target_ptr, monap_type *monap_ptr, 
         damage_ratio -= 75;
 
     monap_ptr->damage = monap_ptr->damage * damage_ratio / 1000;
-    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
     if (target_ptr->is_dead || check_multishadow(target_ptr))
         return;
 
@@ -228,7 +228,7 @@ static void calc_blow_time(player_type *target_ptr, monap_type *monap_ptr)
     if (has_resist_time(target_ptr))
         monap_ptr->damage = monap_ptr->damage * (randint1(4) + 4) / 9;
 
-    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
 }
 
 /*!
@@ -244,7 +244,7 @@ static void calc_blow_drain_life(player_type *target_ptr, monap_type *monap_ptr)
     if (target_ptr->hold_exp)
         monap_ptr->damage = monap_ptr->damage * 9 / 10;
 
-    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
     if (target_ptr->is_dead || check_multishadow(target_ptr))
         return;
 
@@ -281,7 +281,7 @@ static void calc_blow_inertia(player_type *target_ptr, monap_type *monap_ptr)
     if ((target_ptr->fast > 0) || (target_ptr->pspeed >= 130))
         monap_ptr->damage = monap_ptr->damage * (randint1(4) + 4) / 9;
 
-    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+    monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
     if (target_ptr->is_dead || check_multishadow(target_ptr))
         return;
 
@@ -302,7 +302,7 @@ void switch_monster_blow_to_player(player_type *target_ptr, monap_type *monap_pt
             int tmp_damage = monap_ptr->damage - (monap_ptr->damage * ((monap_ptr->ac < 150) ? monap_ptr->ac : 150) / 250);
             msg_print(_("痛恨の一撃！", "It was a critical hit!"));
             tmp_damage = MAX(monap_ptr->damage, tmp_damage * 2);
-            monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, tmp_damage, monap_ptr->ddesc, -1);
+            monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, tmp_damage, monap_ptr->ddesc);
             break;
         }
     }
@@ -310,7 +310,7 @@ void switch_monster_blow_to_player(player_type *target_ptr, monap_type *monap_pt
     case RBE_HURT: { /* AC軽減あり / Player armor reduces total damage */
         monap_ptr->obvious = TRUE;
         monap_ptr->damage -= (monap_ptr->damage * ((monap_ptr->ac < 150) ? monap_ptr->ac : 150) / 250);
-        monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+        monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
         break;
     }
     case RBE_POISON:
@@ -323,7 +323,7 @@ void switch_monster_blow_to_player(player_type *target_ptr, monap_type *monap_pt
         calc_blow_un_power(target_ptr, monap_ptr);
         break;
     case RBE_EAT_GOLD:
-        monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+        monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
         if (monster_confused_remaining(monap_ptr->m_ptr) || target_ptr->is_dead || check_multishadow(target_ptr))
             break;
 
@@ -331,7 +331,7 @@ void switch_monster_blow_to_player(player_type *target_ptr, monap_type *monap_pt
         process_eat_gold(target_ptr, monap_ptr);
         break;
     case RBE_EAT_ITEM: {
-        monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+        monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
         if (!check_eat_item(target_ptr, monap_ptr))
             break;
 
@@ -340,7 +340,7 @@ void switch_monster_blow_to_player(player_type *target_ptr, monap_type *monap_pt
     }
 
     case RBE_EAT_FOOD: {
-        monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+        monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
         if (target_ptr->is_dead || check_multishadow(target_ptr))
             break;
 
@@ -349,7 +349,7 @@ void switch_monster_blow_to_player(player_type *target_ptr, monap_type *monap_pt
     }
     case RBE_EAT_LITE: {
         monap_ptr->o_ptr = &target_ptr->inventory_list[INVEN_LITE];
-        monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+        monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
         if (target_ptr->is_dead || check_multishadow(target_ptr))
             break;
 
@@ -362,7 +362,7 @@ void switch_monster_blow_to_player(player_type *target_ptr, monap_type *monap_pt
 
         monap_ptr->obvious = TRUE;
         msg_print(_("酸を浴びせられた！", "You are covered in acid!"));
-        monap_ptr->get_damage += acid_dam(target_ptr, monap_ptr->damage, monap_ptr->ddesc, -1, FALSE);
+        monap_ptr->get_damage += acid_dam(target_ptr, monap_ptr->damage, monap_ptr->ddesc, FALSE);
         update_creature(target_ptr);
         update_smart_learn(target_ptr, monap_ptr->m_idx, DRS_ACID);
         break;
@@ -373,7 +373,7 @@ void switch_monster_blow_to_player(player_type *target_ptr, monap_type *monap_pt
 
         monap_ptr->obvious = TRUE;
         msg_print(_("電撃を浴びせられた！", "You are struck by electricity!"));
-        monap_ptr->get_damage += elec_dam(target_ptr, monap_ptr->damage, monap_ptr->ddesc, -1, FALSE);
+        monap_ptr->get_damage += elec_dam(target_ptr, monap_ptr->damage, monap_ptr->ddesc, FALSE);
         update_smart_learn(target_ptr, monap_ptr->m_idx, DRS_ELEC);
         break;
     }
@@ -383,7 +383,7 @@ void switch_monster_blow_to_player(player_type *target_ptr, monap_type *monap_pt
 
         monap_ptr->obvious = TRUE;
         msg_print(_("全身が炎に包まれた！", "You are enveloped in flames!"));
-        monap_ptr->get_damage += fire_dam(target_ptr, monap_ptr->damage, monap_ptr->ddesc, -1, FALSE);
+        monap_ptr->get_damage += fire_dam(target_ptr, monap_ptr->damage, monap_ptr->ddesc, FALSE);
         update_smart_learn(target_ptr, monap_ptr->m_idx, DRS_FIRE);
         break;
     }
@@ -393,7 +393,7 @@ void switch_monster_blow_to_player(player_type *target_ptr, monap_type *monap_pt
 
         monap_ptr->obvious = TRUE;
         msg_print(_("全身が冷気で覆われた！", "You are covered with frost!"));
-        monap_ptr->get_damage += cold_dam(target_ptr, monap_ptr->damage, monap_ptr->ddesc, -1, FALSE);
+        monap_ptr->get_damage += cold_dam(target_ptr, monap_ptr->damage, monap_ptr->ddesc, FALSE);
         update_smart_learn(target_ptr, monap_ptr->m_idx, DRS_COLD);
         break;
     }
@@ -433,7 +433,7 @@ void switch_monster_blow_to_player(player_type *target_ptr, monap_type *monap_pt
     case RBE_SHATTER: { /* AC軽減あり / Player armor reduces total damage */
         monap_ptr->obvious = TRUE;
         monap_ptr->damage -= (monap_ptr->damage * ((monap_ptr->ac < 150) ? monap_ptr->ac : 150) / 250);
-        monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+        monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
         if (monap_ptr->damage > 23 || monap_ptr->explode)
             earthquake(target_ptr, monap_ptr->m_ptr->fy, monap_ptr->m_ptr->fx, 8, monap_ptr->m_idx);
 
@@ -467,7 +467,7 @@ void switch_monster_blow_to_player(player_type *target_ptr, monap_type *monap_pt
         calc_blow_inertia(target_ptr, monap_ptr);
         break;
     case RBE_STUN:
-        monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc, -1);
+        monap_ptr->get_damage += take_hit(target_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
         if (target_ptr->is_dead)
             break;
 

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -67,7 +67,7 @@ static void on_dead_explosion(player_type *player_ptr, monster_death_type *md_pt
         DICE_NUMBER d_dice = md_ptr->r_ptr->blow[i].d_dice;
         DICE_SID d_side = md_ptr->r_ptr->blow[i].d_side;
         HIT_POINT damage = damroll(d_dice, d_side);
-        (void)project(player_ptr, md_ptr->m_idx, 3, md_ptr->md_y, md_ptr->md_x, damage, typ, flg, -1);
+        (void)project(player_ptr, md_ptr->m_idx, 3, md_ptr->md_y, md_ptr->md_x, damage, typ, flg);
         break;
     }
 }

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -258,7 +258,7 @@ static bool process_explosive_rune(player_type *target_ptr, turn_flags *turn_fla
         if (g_ptr->info & CAVE_MARK) {
             msg_print(_("ルーンが爆発した！", "The rune explodes!"));
             BIT_FLAGS project_flags = PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_JUMP | PROJECT_NO_HANGEKI;
-            project(target_ptr, 0, 2, ny, nx, 2 * (target_ptr->lev + damroll(7, 7)), GF_MANA, project_flags, -1);
+            project(target_ptr, 0, 2, ny, nx, 2 * (target_ptr->lev + damroll(7, 7)), GF_MANA, project_flags);
         }
     } else {
         msg_print(_("爆発のルーンは解除された。", "An explosive rune was disarmed."));

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -391,7 +391,7 @@ bool place_monster_one(player_type *player_ptr, MONSTER_IDX who, POSITION y, POS
         if (g_ptr->info & CAVE_MARK) {
             msg_print(_("ルーンが爆発した！", "The rune explodes!"));
             project(player_ptr, 0, 2, y, x, 2 * (player_ptr->lev + damroll(7, 7)), GF_MANA,
-                (PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_JUMP | PROJECT_NO_HANGEKI), -1);
+                (PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_JUMP | PROJECT_NO_HANGEKI));
         }
     } else {
         msg_print(_("爆発のルーンは解除された。", "An explosive rune was disarmed."));

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -142,7 +142,7 @@ static void on_dead_unmaker(player_type *player_ptr, monster_death_type *md_ptr)
         msg_format(_("%sは辺りにログルスの残り香を撒き散らした！", "%^s sprinkled the remaining incense from Logrus!"), m_name);
     }
 
-    (void)project(player_ptr, md_ptr->m_idx, 6, md_ptr->md_y, md_ptr->md_x, 100, GF_CHAOS, PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL, -1);
+    (void)project(player_ptr, md_ptr->m_idx, 6, md_ptr->md_y, md_ptr->md_x, 100, GF_CHAOS, PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL);
 }
 
 static void on_dead_sacred_treasures(player_type *player_ptr, monster_death_type *md_ptr)
@@ -233,7 +233,7 @@ static void on_dead_rolento(player_type *player_ptr, monster_death_type *md_ptr)
         msg_format(_("%sは手榴弾を抱えて自爆した！", "%^s blew himself up with grenades!"), m_name);
     }
 
-    (void)project(player_ptr, md_ptr->m_idx, 3, md_ptr->md_y, md_ptr->md_x, damroll(20, 10), GF_FIRE, PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL, -1);
+    (void)project(player_ptr, md_ptr->m_idx, 3, md_ptr->md_y, md_ptr->md_x, damroll(20, 10), GF_FIRE, PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL);
 }
 
 static void on_dead_aqua_illusion(player_type *player_ptr, monster_death_type *md_ptr)

--- a/src/mspell/mspell-ball.cpp
+++ b/src/mspell/mspell-ball.cpp
@@ -32,7 +32,7 @@ MonsterSpellResult spell_RF4_BA_NUKE(player_type *target_ptr, POSITION y, POSITI
         _("%^sが%sに放射能球を放った。", "%^s casts a ball of radiation at %s."), TARGET_TYPE);
 
     const auto dam = monspell_damage(target_ptr, (MS_BALL_NUKE), m_idx, DAM_ROLL);
-    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_NUKE, dam, 2, FALSE, MS_BALL_NUKE, TARGET_TYPE);
+    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_NUKE, dam, 2, FALSE, TARGET_TYPE);
     if (TARGET_TYPE == MONSTER_TO_PLAYER)
         update_smart_learn(target_ptr, m_idx, DRS_POIS);
 
@@ -59,7 +59,7 @@ MonsterSpellResult spell_RF4_BA_CHAO(player_type *target_ptr, POSITION y, POSITI
         _("%^sが純ログルスを放った。", "%^s invokes a raw Logrus."), _("%^sが%sに純ログルスを放った。", "%^s invokes raw Logrus upon %s."), TARGET_TYPE);
 
     const auto dam = monspell_damage(target_ptr, (MS_BALL_CHAOS), m_idx, DAM_ROLL);
-    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_CHAOS, dam, 4, FALSE, MS_BALL_CHAOS, TARGET_TYPE);
+    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_CHAOS, dam, 4, FALSE, TARGET_TYPE);
     if (TARGET_TYPE == MONSTER_TO_PLAYER)
         update_smart_learn(target_ptr, m_idx, DRS_CHAOS);
 
@@ -88,7 +88,7 @@ MonsterSpellResult spell_RF5_BA_ACID(player_type *target_ptr, POSITION y, POSITI
 
     const auto rad = monster_is_powerful(target_ptr->current_floor_ptr, m_idx) ? 4 : 2;
     const auto dam = monspell_damage(target_ptr, (MS_BALL_ACID), m_idx, DAM_ROLL);
-    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_ACID, dam, rad, FALSE, MS_BALL_ACID, TARGET_TYPE);
+    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_ACID, dam, rad, FALSE, TARGET_TYPE);
     if (TARGET_TYPE == MONSTER_TO_PLAYER)
         update_smart_learn(target_ptr, m_idx, DRS_ACID);
 
@@ -117,7 +117,7 @@ MonsterSpellResult spell_RF5_BA_ELEC(player_type *target_ptr, POSITION y, POSITI
 
     const auto rad = monster_is_powerful(target_ptr->current_floor_ptr, m_idx) ? 4 : 2;
     const auto dam = monspell_damage(target_ptr, (MS_BALL_ELEC), m_idx, DAM_ROLL);
-    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_ELEC, dam, rad, FALSE, MS_BALL_ELEC, TARGET_TYPE);
+    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_ELEC, dam, rad, FALSE, TARGET_TYPE);
     if (TARGET_TYPE == MONSTER_TO_PLAYER)
         update_smart_learn(target_ptr, m_idx, DRS_ELEC);
 
@@ -153,7 +153,7 @@ MonsterSpellResult spell_RF5_BA_FIRE(player_type *target_ptr, POSITION y, POSITI
 
     const auto rad = monster_is_powerful(target_ptr->current_floor_ptr, m_idx) ? 4 : 2;
     const auto dam = monspell_damage(target_ptr, (MS_BALL_FIRE), m_idx, DAM_ROLL);
-    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_FIRE, dam, rad, FALSE, MS_BALL_FIRE, TARGET_TYPE);
+    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_FIRE, dam, rad, FALSE, TARGET_TYPE);
     if (TARGET_TYPE == MONSTER_TO_PLAYER)
         update_smart_learn(target_ptr, m_idx, DRS_FIRE);
 
@@ -182,7 +182,7 @@ MonsterSpellResult spell_RF5_BA_COLD(player_type *target_ptr, POSITION y, POSITI
 
     const auto rad = monster_is_powerful(target_ptr->current_floor_ptr, m_idx) ? 4 : 2;
     const auto dam = monspell_damage(target_ptr, (MS_BALL_COLD), m_idx, DAM_ROLL);
-    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_COLD, dam, rad, FALSE, MS_BALL_COLD, TARGET_TYPE);
+    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_COLD, dam, rad, FALSE, TARGET_TYPE);
     if (TARGET_TYPE == MONSTER_TO_PLAYER)
         update_smart_learn(target_ptr, m_idx, DRS_COLD);
 
@@ -209,7 +209,7 @@ MonsterSpellResult spell_RF5_BA_POIS(player_type *target_ptr, POSITION y, POSITI
         _("%^sが%sに向かって悪臭雲の呪文を唱えた。", "%^s casts a stinking cloud at %s."), TARGET_TYPE);
 
     const auto dam = monspell_damage(target_ptr, (MS_BALL_POIS), m_idx, DAM_ROLL);
-    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_POIS, dam, 2, FALSE, MS_BALL_POIS, TARGET_TYPE);
+    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_POIS, dam, 2, FALSE, TARGET_TYPE);
     if (TARGET_TYPE == MONSTER_TO_PLAYER)
         update_smart_learn(target_ptr, m_idx, DRS_POIS);
 
@@ -236,7 +236,7 @@ MonsterSpellResult spell_RF5_BA_NETH(player_type *target_ptr, POSITION y, POSITI
         _("%^sが%sに向かって地獄球の呪文を唱えた。", "%^s casts a nether ball at %s."), TARGET_TYPE);
 
     const auto dam = monspell_damage(target_ptr, (MS_BALL_NETHER), m_idx, DAM_ROLL);
-    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_NETHER, dam, 2, FALSE, MS_BALL_NETHER, TARGET_TYPE);
+    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_NETHER, dam, 2, FALSE, TARGET_TYPE);
     if (TARGET_TYPE == MONSTER_TO_PLAYER)
         update_smart_learn(target_ptr, m_idx, DRS_NETH);
 
@@ -276,7 +276,7 @@ MonsterSpellResult spell_RF5_BA_WATE(player_type *target_ptr, POSITION y, POSITI
     }
 
     const auto dam = monspell_damage(target_ptr, (MS_BALL_WATER), m_idx, DAM_ROLL);
-    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_WATER, dam, 4, FALSE, MS_BALL_WATER, TARGET_TYPE);
+    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_WATER, dam, 4, FALSE, TARGET_TYPE);
 
     auto res = MonsterSpellResult::make_valid(dam);
     res.learnable = proj_res.affected_player;
@@ -302,7 +302,7 @@ MonsterSpellResult spell_RF5_BA_MANA(player_type *target_ptr, POSITION y, POSITI
         TARGET_TYPE);
 
     const auto dam = monspell_damage(target_ptr, (MS_BALL_MANA), m_idx, DAM_ROLL);
-    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_MANA, dam, 4, FALSE, MS_BALL_MANA, TARGET_TYPE);
+    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_MANA, dam, 4, FALSE, TARGET_TYPE);
 
     auto res = MonsterSpellResult::make_valid(dam);
     res.learnable = proj_res.affected_player;
@@ -328,7 +328,7 @@ MonsterSpellResult spell_RF5_BA_DARK(player_type *target_ptr, POSITION y, POSITI
         _("%^sが%sに対して暗黒の嵐の呪文を念じた。", "%^s invokes a darkness storm upon %s."), TARGET_TYPE);
 
     const auto dam = monspell_damage(target_ptr, (MS_BALL_DARK), m_idx, DAM_ROLL);
-    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_DARK, dam, 4, FALSE, MS_BALL_DARK, TARGET_TYPE);
+    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_DARK, dam, 4, FALSE, TARGET_TYPE);
     if (TARGET_TYPE == MONSTER_TO_PLAYER)
         update_smart_learn(target_ptr, m_idx, DRS_DARK);
 
@@ -356,7 +356,7 @@ MonsterSpellResult spell_RF5_BA_LITE(player_type *target_ptr, POSITION y, POSITI
         _("%^sが%sに対してスターバーストの呪文を念じた。", "%^s invokes a starburst upon %s."), TARGET_TYPE);
 
     const auto dam = monspell_damage(target_ptr, (MS_STARBURST), m_idx, DAM_ROLL);
-    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_LITE, dam, 4, FALSE, MS_STARBURST, TARGET_TYPE);
+    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_LITE, dam, 4, FALSE, TARGET_TYPE);
     if (TARGET_TYPE == MONSTER_TO_PLAYER)
         update_smart_learn(target_ptr, m_idx, DRS_LITE);
 

--- a/src/mspell/mspell-bolt.cpp
+++ b/src/mspell/mspell-bolt.cpp
@@ -29,7 +29,7 @@ MonsterSpellResult spell_RF4_SHOOT(player_type *target_ptr, POSITION y, POSITION
         _("%^sが%sに矢を放った。", "%^s fires an arrow at %s."), TARGET_TYPE);
 
     const auto dam = monspell_damage(target_ptr, (MS_SHOOT), m_idx, DAM_ROLL);
-    const auto proj_res = bolt(target_ptr, m_idx, y, x, GF_ARROW, dam, MS_SHOOT, TARGET_TYPE);
+    const auto proj_res = bolt(target_ptr, m_idx, y, x, GF_ARROW, dam, TARGET_TYPE);
     sound(SOUND_SHOOT);
 
     auto res = MonsterSpellResult::make_valid(dam);
@@ -56,7 +56,7 @@ MonsterSpellResult spell_RF5_BO_ACID(player_type *target_ptr, POSITION y, POSITI
         _("%sが%sに向かってアシッド・ボルトの呪文を唱えた。", "%^s casts an acid bolt at %s."), TARGET_TYPE);
 
     const auto dam = monspell_damage(target_ptr, (MS_BOLT_ACID), m_idx, DAM_ROLL);
-    const auto proj_res = bolt(target_ptr, m_idx, y, x, GF_ACID, dam, MS_BOLT_ACID, TARGET_TYPE);
+    const auto proj_res = bolt(target_ptr, m_idx, y, x, GF_ACID, dam, TARGET_TYPE);
     if (TARGET_TYPE == MONSTER_TO_PLAYER) {
         update_smart_learn(target_ptr, m_idx, DRS_ACID);
         update_smart_learn(target_ptr, m_idx, DRS_REFLECT);
@@ -86,7 +86,7 @@ MonsterSpellResult spell_RF5_BO_ELEC(player_type *target_ptr, POSITION y, POSITI
         _("%^sが%sに向かってサンダー・ボルトの呪文を唱えた。", "%^s casts a lightning bolt at %s."), TARGET_TYPE);
 
     const auto dam = monspell_damage(target_ptr, (MS_BOLT_ELEC), m_idx, DAM_ROLL);
-    const auto proj_res = bolt(target_ptr, m_idx, y, x, GF_ELEC, dam, MS_BOLT_ELEC, TARGET_TYPE);
+    const auto proj_res = bolt(target_ptr, m_idx, y, x, GF_ELEC, dam, TARGET_TYPE);
     if (TARGET_TYPE == MONSTER_TO_PLAYER) {
         update_smart_learn(target_ptr, m_idx, DRS_ELEC);
         update_smart_learn(target_ptr, m_idx, DRS_REFLECT);
@@ -116,7 +116,7 @@ MonsterSpellResult spell_RF5_BO_FIRE(player_type *target_ptr, POSITION y, POSITI
         _("%^sが%sに向かってファイア・ボルトの呪文を唱えた。", "%^s casts a fire bolt at %s."), TARGET_TYPE);
 
     const auto dam = monspell_damage(target_ptr, (MS_BOLT_FIRE), m_idx, DAM_ROLL);
-    const auto proj_res = bolt(target_ptr, m_idx, y, x, GF_FIRE, dam, MS_BOLT_FIRE, TARGET_TYPE);
+    const auto proj_res = bolt(target_ptr, m_idx, y, x, GF_FIRE, dam, TARGET_TYPE);
     if (TARGET_TYPE == MONSTER_TO_PLAYER) {
         update_smart_learn(target_ptr, m_idx, DRS_FIRE);
         update_smart_learn(target_ptr, m_idx, DRS_REFLECT);
@@ -146,7 +146,7 @@ MonsterSpellResult spell_RF5_BO_COLD(player_type *target_ptr, POSITION y, POSITI
         _("%^sが%sに向かってアイス・ボルトの呪文を唱えた。", "%^s casts a frost bolt at %s."), TARGET_TYPE);
 
     const auto dam = monspell_damage(target_ptr, (MS_BOLT_COLD), m_idx, DAM_ROLL);
-    const auto proj_res = bolt(target_ptr, m_idx, y, x, GF_COLD, dam, MS_BOLT_COLD, TARGET_TYPE);
+    const auto proj_res = bolt(target_ptr, m_idx, y, x, GF_COLD, dam, TARGET_TYPE);
     if (TARGET_TYPE == MONSTER_TO_PLAYER) {
         update_smart_learn(target_ptr, m_idx, DRS_COLD);
         update_smart_learn(target_ptr, m_idx, DRS_REFLECT);
@@ -175,7 +175,7 @@ MonsterSpellResult spell_RF5_BO_NETH(player_type *target_ptr, POSITION y, POSITI
         _("%^sが%sに向かって地獄の矢の呪文を唱えた。", "%^s casts a nether bolt at %s."), TARGET_TYPE);
 
     const auto dam = monspell_damage(target_ptr, (MS_BOLT_NETHER), m_idx, DAM_ROLL);
-    const auto proj_res = bolt(target_ptr, m_idx, y, x, GF_NETHER, dam, MS_BOLT_NETHER, TARGET_TYPE);
+    const auto proj_res = bolt(target_ptr, m_idx, y, x, GF_NETHER, dam, TARGET_TYPE);
     if (TARGET_TYPE == MONSTER_TO_PLAYER) {
         update_smart_learn(target_ptr, m_idx, DRS_NETH);
         update_smart_learn(target_ptr, m_idx, DRS_REFLECT);
@@ -205,7 +205,7 @@ MonsterSpellResult spell_RF5_BO_WATE(player_type *target_ptr, POSITION y, POSITI
         _("%^sが%sに向かってウォーター・ボルトの呪文を唱えた。", "%^s casts a water bolt at %s."), TARGET_TYPE);
 
     const auto dam = monspell_damage(target_ptr, (MS_BOLT_WATER), m_idx, DAM_ROLL);
-    const auto proj_res = bolt(target_ptr, m_idx, y, x, GF_WATER, dam, MS_BOLT_WATER, TARGET_TYPE);
+    const auto proj_res = bolt(target_ptr, m_idx, y, x, GF_WATER, dam, TARGET_TYPE);
     if (TARGET_TYPE == MONSTER_TO_PLAYER) {
         update_smart_learn(target_ptr, m_idx, DRS_REFLECT);
     }
@@ -233,7 +233,7 @@ MonsterSpellResult spell_RF5_BO_MANA(player_type *target_ptr, POSITION y, POSITI
         _("%^sが%sに向かって魔力の矢の呪文を唱えた。", "%^s casts a mana bolt at %s."), TARGET_TYPE);
 
     const auto dam = monspell_damage(target_ptr, (MS_BOLT_MANA), m_idx, DAM_ROLL);
-    const auto proj_res = bolt(target_ptr, m_idx, y, x, GF_MANA, dam, MS_BOLT_MANA, TARGET_TYPE);
+    const auto proj_res = bolt(target_ptr, m_idx, y, x, GF_MANA, dam, TARGET_TYPE);
     if (TARGET_TYPE == MONSTER_TO_PLAYER) {
         update_smart_learn(target_ptr, m_idx, DRS_REFLECT);
     }
@@ -262,7 +262,7 @@ MonsterSpellResult spell_RF5_BO_PLAS(player_type *target_ptr, POSITION y, POSITI
         _("%^sが%sに向かってプラズマ・ボルトの呪文を唱えた。", "%^s casts a plasma bolt at %s."), TARGET_TYPE);
 
     const auto dam = monspell_damage(target_ptr, (MS_BOLT_PLASMA), m_idx, DAM_ROLL);
-    const auto proj_res = bolt(target_ptr, m_idx, y, x, GF_PLASMA, dam, MS_BOLT_PLASMA, TARGET_TYPE);
+    const auto proj_res = bolt(target_ptr, m_idx, y, x, GF_PLASMA, dam, TARGET_TYPE);
     if (TARGET_TYPE == MONSTER_TO_PLAYER) {
         update_smart_learn(target_ptr, m_idx, DRS_REFLECT);
     }
@@ -290,7 +290,7 @@ MonsterSpellResult spell_RF5_BO_ICEE(player_type *target_ptr, POSITION y, POSITI
         _("%^sが%sに向かって極寒の矢の呪文を唱えた。", "%^s casts an ice bolt at %s."), TARGET_TYPE);
 
     const auto dam = monspell_damage(target_ptr, (MS_BOLT_ICE), m_idx, DAM_ROLL);
-    const auto proj_res = bolt(target_ptr, m_idx, y, x, GF_ICE, dam, MS_BOLT_ICE, TARGET_TYPE);
+    const auto proj_res = bolt(target_ptr, m_idx, y, x, GF_ICE, dam, TARGET_TYPE);
     if (TARGET_TYPE == MONSTER_TO_PLAYER) {
         update_smart_learn(target_ptr, m_idx, DRS_COLD);
         update_smart_learn(target_ptr, m_idx, DRS_REFLECT);
@@ -320,7 +320,7 @@ MonsterSpellResult spell_RF5_MISSILE(player_type *target_ptr, POSITION y, POSITI
         _("%^sが%sに向かってマジック・ミサイルの呪文を唱えた。", "%^s casts a magic missile at %s."), TARGET_TYPE);
 
     const auto dam = monspell_damage(target_ptr, (MS_MAGIC_MISSILE), m_idx, DAM_ROLL);
-    const auto proj_res = bolt(target_ptr, m_idx, y, x, GF_MISSILE, dam, MS_MAGIC_MISSILE, TARGET_TYPE);
+    const auto proj_res = bolt(target_ptr, m_idx, y, x, GF_MISSILE, dam, TARGET_TYPE);
     if (TARGET_TYPE == MONSTER_TO_PLAYER) {
         update_smart_learn(target_ptr, m_idx, DRS_REFLECT);
     }

--- a/src/mspell/mspell-breath.cpp
+++ b/src/mspell/mspell-breath.cpp
@@ -55,7 +55,7 @@ static bool spell_RF4_BREATH_special_message(MONSTER_IDX r_idx, int GF_TYPE, con
  */
 MonsterSpellResult spell_RF4_BREATH(player_type *target_ptr, int GF_TYPE, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int TARGET_TYPE)
 {
-    HIT_POINT dam, ms_type, drs_type = 0;
+    HIT_POINT dam, drs_type = 0;
     concptr type_s;
     bool smart_learn_aux = TRUE;
     floor_type *floor_ptr = target_ptr->current_floor_ptr;
@@ -72,140 +72,117 @@ MonsterSpellResult spell_RF4_BREATH(player_type *target_ptr, int GF_TYPE, POSITI
     case GF_ACID:
         dam = monspell_damage(target_ptr, (MS_BR_ACID), m_idx, DAM_ROLL);
         type_s = _("酸", "acid");
-        ms_type = MS_BR_ACID;
         drs_type = DRS_ACID;
         break;
     case GF_ELEC:
         dam = monspell_damage(target_ptr, (MS_BR_ELEC), m_idx, DAM_ROLL);
         type_s = _("稲妻", "lightning");
-        ms_type = MS_BR_ELEC;
         drs_type = DRS_ELEC;
         break;
     case GF_FIRE:
         dam = monspell_damage(target_ptr, (MS_BR_FIRE), m_idx, DAM_ROLL);
         type_s = _("火炎", "fire");
-        ms_type = MS_BR_FIRE;
         drs_type = DRS_FIRE;
         break;
     case GF_COLD:
         dam = monspell_damage(target_ptr, (MS_BR_COLD), m_idx, DAM_ROLL);
         type_s = _("冷気", "frost");
-        ms_type = MS_BR_COLD;
         drs_type = DRS_COLD;
         break;
     case GF_POIS:
         dam = monspell_damage(target_ptr, (MS_BR_POIS), m_idx, DAM_ROLL);
         type_s = _("ガス", "gas");
-        ms_type = MS_BR_POIS;
         drs_type = DRS_POIS;
         break;
     case GF_NETHER:
         dam = monspell_damage(target_ptr, (MS_BR_NETHER), m_idx, DAM_ROLL);
         type_s = _("地獄", "nether");
-        ms_type = MS_BR_NETHER;
         drs_type = DRS_NETH;
         break;
     case GF_LITE:
         dam = monspell_damage(target_ptr, (MS_BR_LITE), m_idx, DAM_ROLL);
         type_s = _("閃光", "light");
-        ms_type = MS_BR_LITE;
         drs_type = DRS_LITE;
         break;
     case GF_DARK:
         dam = monspell_damage(target_ptr, (MS_BR_DARK), m_idx, DAM_ROLL);
         type_s = _("暗黒", "darkness");
-        ms_type = MS_BR_DARK;
         drs_type = DRS_DARK;
         break;
     case GF_CONFUSION:
         dam = monspell_damage(target_ptr, (MS_BR_CONF), m_idx, DAM_ROLL);
         type_s = _("混乱", "confusion");
-        ms_type = MS_BR_CONF;
         drs_type = DRS_CONF;
         break;
     case GF_SOUND:
         dam = monspell_damage(target_ptr, (MS_BR_SOUND), m_idx, DAM_ROLL);
         type_s = _("轟音", "sound");
-        ms_type = MS_BR_SOUND;
         drs_type = DRS_SOUND;
         break;
     case GF_CHAOS:
         dam = monspell_damage(target_ptr, (MS_BR_CHAOS), m_idx, DAM_ROLL);
         type_s = _("カオス", "chaos");
-        ms_type = MS_BR_CHAOS;
         drs_type = DRS_CHAOS;
         break;
     case GF_DISENCHANT:
         dam = monspell_damage(target_ptr, (MS_BR_DISEN), m_idx, DAM_ROLL);
         type_s = _("劣化", "disenchantment");
-        ms_type = MS_BR_DISEN;
         drs_type = DRS_DISEN;
         break;
     case GF_NEXUS:
         dam = monspell_damage(target_ptr, (MS_BR_NEXUS), m_idx, DAM_ROLL);
         type_s = _("因果混乱", "nexus");
-        ms_type = MS_BR_NEXUS;
         drs_type = DRS_NEXUS;
         break;
     case GF_TIME:
         dam = monspell_damage(target_ptr, (MS_BR_TIME), m_idx, DAM_ROLL);
         type_s = _("時間逆転", "time");
-        ms_type = MS_BR_TIME;
         smart_learn_aux = FALSE;
         break;
     case GF_INERTIAL:
         dam = monspell_damage(target_ptr, (MS_BR_INERTIA), m_idx, DAM_ROLL);
         type_s = _("遅鈍", "inertia");
-        ms_type = MS_BR_INERTIA;
         smart_learn_aux = FALSE;
         break;
     case GF_GRAVITY:
         dam = monspell_damage(target_ptr, (MS_BR_GRAVITY), m_idx, DAM_ROLL);
         type_s = _("重力", "gravity");
-        ms_type = MS_BR_GRAVITY;
         smart_learn_aux = FALSE;
         break;
     case GF_SHARDS:
         dam = monspell_damage(target_ptr, (MS_BR_SHARDS), m_idx, DAM_ROLL);
         type_s = _("破片", "shards");
-        ms_type = MS_BR_SHARDS;
         drs_type = DRS_SHARD;
         break;
     case GF_PLASMA:
         dam = monspell_damage(target_ptr, (MS_BR_PLASMA), m_idx, DAM_ROLL);
         type_s = _("プラズマ", "plasma");
-        ms_type = MS_BR_PLASMA;
         smart_learn_aux = FALSE;
         break;
     case GF_FORCE:
         dam = monspell_damage(target_ptr, (MS_BR_FORCE), m_idx, DAM_ROLL);
         type_s = _("フォース", "force");
-        ms_type = MS_BR_FORCE;
         smart_learn_aux = FALSE;
         break;
     case GF_MANA:
         dam = monspell_damage(target_ptr, (MS_BR_MANA), m_idx, DAM_ROLL);
         type_s = _("魔力", "mana");
-        ms_type = MS_BR_MANA;
         smart_learn_aux = FALSE;
         break;
     case GF_NUKE:
         dam = monspell_damage(target_ptr, (MS_BR_NUKE), m_idx, DAM_ROLL);
         type_s = _("放射性廃棄物", "toxic waste");
-        ms_type = MS_BR_NUKE;
         drs_type = DRS_POIS;
         break;
     case GF_DISINTEGRATE:
         dam = monspell_damage(target_ptr, (MS_BR_DISI), m_idx, DAM_ROLL);
         type_s = _("分解", "disintegration");
-        ms_type = MS_BR_DISI;
         smart_learn_aux = FALSE;
         break;
     default:
         /* Do not reach here */
         dam = 0;
         type_s = _("不明", "Unknown");
-        ms_type = MS_BR_ACID;
         smart_learn_aux = FALSE;
         break;
     }
@@ -230,7 +207,7 @@ MonsterSpellResult spell_RF4_BREATH(player_type *target_ptr, int GF_TYPE, POSITI
         floor_ptr->monster_noise = TRUE;
 
     sound(SOUND_BREATH);
-    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_TYPE, dam, 0, TRUE, ms_type, TARGET_TYPE);
+    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_TYPE, dam, 0, TRUE, TARGET_TYPE);
     if (smart_learn_aux && mon_to_player)
         update_smart_learn(target_ptr, m_idx, drs_type);
 

--- a/src/mspell/mspell-checker.cpp
+++ b/src/mspell/mspell-checker.cpp
@@ -184,7 +184,7 @@ bool clean_shot(player_type *target_ptr, POSITION y1, POSITION x1, POSITION y2, 
  * @param monspell モンスター魔法のID
  * @param target_type モンスターからモンスターへ撃つならMONSTER_TO_MONSTER、モンスターからプレイヤーならMONSTER_TO_PLAYER
  */
-ProjectResult bolt(player_type *target_ptr, MONSTER_IDX m_idx, POSITION y, POSITION x, EFFECT_ID typ, int dam_hp, int monspell, int target_type)
+ProjectResult bolt(player_type *target_ptr, MONSTER_IDX m_idx, POSITION y, POSITION x, EFFECT_ID typ, int dam_hp, int target_type)
 {
     BIT_FLAGS flg = 0;
     switch (target_type) {
@@ -199,7 +199,7 @@ ProjectResult bolt(player_type *target_ptr, MONSTER_IDX m_idx, POSITION y, POSIT
     if (typ != GF_ARROW)
         flg |= PROJECT_REFLECTABLE;
 
-    return project(target_ptr, m_idx, 0, y, x, dam_hp, typ, flg, monspell);
+    return project(target_ptr, m_idx, 0, y, x, dam_hp, typ, flg);
 }
 
 /*!
@@ -213,7 +213,7 @@ ProjectResult bolt(player_type *target_ptr, MONSTER_IDX m_idx, POSITION y, POSIT
  * @param monspell モンスター魔法のID
  * @param target_type モンスターからモンスターへ撃つならMONSTER_TO_MONSTER、モンスターからプレイヤーならMONSTER_TO_PLAYER
  */
-ProjectResult beam(player_type *target_ptr, MONSTER_IDX m_idx, POSITION y, POSITION x, EFFECT_ID typ, int dam_hp, int monspell, int target_type)
+ProjectResult beam(player_type *target_ptr, MONSTER_IDX m_idx, POSITION y, POSITION x, EFFECT_ID typ, int dam_hp, int target_type)
 {
     BIT_FLAGS flg = 0;
     switch (target_type) {
@@ -225,7 +225,7 @@ ProjectResult beam(player_type *target_ptr, MONSTER_IDX m_idx, POSITION y, POSIT
         break;
     }
 
-    return project(target_ptr, m_idx, 0, y, x, dam_hp, typ, flg, monspell);
+    return project(target_ptr, m_idx, 0, y, x, dam_hp, typ, flg);
 }
 
 /*!
@@ -243,7 +243,7 @@ ProjectResult beam(player_type *target_ptr, MONSTER_IDX m_idx, POSITION y, POSIT
  * @param target_type モンスターからモンスターへ撃つならMONSTER_TO_MONSTER、モンスターからプレイヤーならMONSTER_TO_PLAYER
  */
 ProjectResult breath(
-    player_type *target_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx, EFFECT_ID typ, int dam_hp, POSITION rad, bool breath, int monspell, int target_type)
+    player_type *target_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx, EFFECT_ID typ, int dam_hp, POSITION rad, bool breath, int target_type)
 {
     monster_type *m_ptr = &target_ptr->current_floor_ptr->m_list[m_idx];
     monster_race *r_ptr = &r_info[m_ptr->r_idx];
@@ -279,7 +279,7 @@ ProjectResult breath(
         break;
     }
 
-    return project(target_ptr, m_idx, rad, y, x, dam_hp, typ, flg, monspell);
+    return project(target_ptr, m_idx, rad, y, x, dam_hp, typ, flg);
 }
 
 /*!

--- a/src/mspell/mspell-checker.h
+++ b/src/mspell/mspell-checker.h
@@ -10,7 +10,7 @@ bool clean_shot(player_type *target_ptr, POSITION y1, POSITION x1, POSITION y2, 
 bool summon_possible(player_type *target_ptr, POSITION y1, POSITION x1);
 bool raise_possible(player_type *target_ptr, monster_type *m_ptr);
 bool spell_is_inate(RF_ABILITY spell);
-ProjectResult beam(player_type *target_ptr, MONSTER_IDX m_idx, POSITION y, POSITION x, EFFECT_ID typ, int dam_hp, int monspell, int target_type);
-ProjectResult bolt(player_type *target_ptr, MONSTER_IDX m_idx, POSITION y, POSITION x, EFFECT_ID typ, int dam_hp, int monspell, int target_type);
+ProjectResult beam(player_type *target_ptr, MONSTER_IDX m_idx, POSITION y, POSITION x, EFFECT_ID typ, int dam_hp, int target_type);
+ProjectResult bolt(player_type *target_ptr, MONSTER_IDX m_idx, POSITION y, POSITION x, EFFECT_ID typ, int dam_hp, int target_type);
 ProjectResult breath(
-    player_type *target_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx, EFFECT_ID typ, int dam_hp, POSITION rad, bool breath, int monspell, int target_type);
+    player_type *target_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx, EFFECT_ID typ, int dam_hp, POSITION rad, bool breath, int target_type);

--- a/src/mspell/mspell-curse.cpp
+++ b/src/mspell/mspell-curse.cpp
@@ -28,7 +28,7 @@
  * @param TARGET_TYPE プレイヤーを対象とする場合MONSTER_TO_PLAYER、モンスターを対象とする場合MONSTER_TO_MONSTER
  */
 static MonsterSpellResult spell_RF5_CAUSE(player_type *target_ptr, int GF_TYPE, HIT_POINT dam, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx,
-    concptr msg1, concptr msg2, concptr msg3, int MS_TYPE, int TARGET_TYPE)
+    concptr msg1, concptr msg2, concptr msg3, int TARGET_TYPE)
 {
     auto res = MonsterSpellResult::make_valid(dam);
     res.learnable = TARGET_TYPE == MONSTER_TO_PLAYER;
@@ -43,7 +43,7 @@ static MonsterSpellResult spell_RF5_CAUSE(player_type *target_ptr, int GF_TYPE, 
             msg_format(msg1, m_name);
         else
             msg_format(msg2, m_name);
-        breath(target_ptr, y, x, m_idx, GF_TYPE, dam, 0, FALSE, MS_TYPE, TARGET_TYPE);
+        breath(target_ptr, y, x, m_idx, GF_TYPE, dam, 0, FALSE, TARGET_TYPE);
         return res;
     }
 
@@ -55,7 +55,7 @@ static MonsterSpellResult spell_RF5_CAUSE(player_type *target_ptr, int GF_TYPE, 
         }
     }
 
-    breath(target_ptr, y, x, m_idx, GF_TYPE, dam, 0, FALSE, MS_TYPE, TARGET_TYPE);
+    breath(target_ptr, y, x, m_idx, GF_TYPE, dam, 0, FALSE, TARGET_TYPE);
 
     return res;
 }
@@ -79,7 +79,7 @@ MonsterSpellResult spell_RF5_CAUSE_1(player_type *target_ptr, POSITION y, POSITI
 
     const auto dam = monspell_damage(target_ptr, (MS_CAUSE_1), m_idx, DAM_ROLL);
 
-    return spell_RF5_CAUSE(target_ptr, GF_CAUSE_1, dam, y, x, m_idx, t_idx, msg1, msg2, msg3, MS_CAUSE_1, TARGET_TYPE);
+    return spell_RF5_CAUSE(target_ptr, GF_CAUSE_1, dam, y, x, m_idx, t_idx, msg1, msg2, msg3, TARGET_TYPE);
 }
 
 /*!
@@ -101,7 +101,7 @@ MonsterSpellResult spell_RF5_CAUSE_2(player_type *target_ptr, POSITION y, POSITI
 
     const auto dam = monspell_damage(target_ptr, (MS_CAUSE_2), m_idx, DAM_ROLL);
 
-    return spell_RF5_CAUSE(target_ptr, GF_CAUSE_2, dam, y, x, m_idx, t_idx, msg1, msg2, msg3, MS_CAUSE_2, TARGET_TYPE);
+    return spell_RF5_CAUSE(target_ptr, GF_CAUSE_2, dam, y, x, m_idx, t_idx, msg1, msg2, msg3, TARGET_TYPE);
 }
 
 /*!
@@ -123,7 +123,7 @@ MonsterSpellResult spell_RF5_CAUSE_3(player_type *target_ptr, POSITION y, POSITI
 
     const auto dam = monspell_damage(target_ptr, (MS_CAUSE_3), m_idx, DAM_ROLL);
 
-    return spell_RF5_CAUSE(target_ptr, GF_CAUSE_3, dam, y, x, m_idx, t_idx, msg1, msg2, msg3, MS_CAUSE_3, TARGET_TYPE);
+    return spell_RF5_CAUSE(target_ptr, GF_CAUSE_3, dam, y, x, m_idx, t_idx, msg1, msg2, msg3, TARGET_TYPE);
 }
 
 /*!
@@ -145,5 +145,5 @@ MonsterSpellResult spell_RF5_CAUSE_4(player_type *target_ptr, POSITION y, POSITI
 
     const auto dam = monspell_damage(target_ptr, (MS_CAUSE_4), m_idx, DAM_ROLL);
 
-    return spell_RF5_CAUSE(target_ptr, GF_CAUSE_4, dam, y, x, m_idx, t_idx, msg1, msg2, msg3, MS_CAUSE_4, TARGET_TYPE);
+    return spell_RF5_CAUSE(target_ptr, GF_CAUSE_4, dam, y, x, m_idx, t_idx, msg1, msg2, msg3, TARGET_TYPE);
 }

--- a/src/mspell/mspell-floor.cpp
+++ b/src/mspell/mspell-floor.cpp
@@ -398,10 +398,10 @@ MonsterSpellResult spell_RF6_DARKNESS(player_type *target_ptr, POSITION y, POSIT
         }
     } else if (monster_to_monster) {
         if (can_use_lite_area) {
-            (void)project(target_ptr, m_idx, 3, y, x, 0, GF_LITE_WEAK, PROJECT_GRID | PROJECT_KILL, -1);
+            (void)project(target_ptr, m_idx, 3, y, x, 0, GF_LITE_WEAK, PROJECT_GRID | PROJECT_KILL);
             lite_room(target_ptr, y, x);
         } else {
-            (void)project(target_ptr, m_idx, 3, y, x, 0, GF_DARK_WEAK, PROJECT_GRID | PROJECT_KILL, MS_DARKNESS);
+            (void)project(target_ptr, m_idx, 3, y, x, 0, GF_DARK_WEAK, PROJECT_GRID | PROJECT_KILL);
             unlite_room(target_ptr, y, x);
         }
     }

--- a/src/mspell/mspell-particularity.cpp
+++ b/src/mspell/mspell-particularity.cpp
@@ -36,7 +36,7 @@ MonsterSpellResult spell_RF4_ROCKET(player_type *target_ptr, POSITION y, POSITIO
         _("%^sが%sにロケットを発射した。", "%^s fires a rocket at %s."), TARGET_TYPE);
 
     const auto dam = monspell_damage(target_ptr, (MS_ROCKET), m_idx, DAM_ROLL);
-    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_ROCKET, dam, 2, FALSE, MS_ROCKET, TARGET_TYPE);
+    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_ROCKET, dam, 2, FALSE, TARGET_TYPE);
     if (TARGET_TYPE == MONSTER_TO_PLAYER)
         update_smart_learn(target_ptr, m_idx, DRS_SHARD);
 
@@ -65,10 +65,10 @@ MonsterSpellResult spell_RF6_HAND_DOOM(player_type *target_ptr, POSITION y, POSI
     ProjectResult proj_res;
     if (TARGET_TYPE == MONSTER_TO_PLAYER) {
         const auto dam = monspell_damage(target_ptr, (MS_HAND_DOOM), m_idx, DAM_ROLL);
-        proj_res = breath(target_ptr, y, x, m_idx, GF_HAND_DOOM, dam, 0, FALSE, MS_HAND_DOOM, MONSTER_TO_PLAYER);
+        proj_res = breath(target_ptr, y, x, m_idx, GF_HAND_DOOM, dam, 0, FALSE, MONSTER_TO_PLAYER);
     } else if (TARGET_TYPE == MONSTER_TO_MONSTER) {
         const auto dam = 20; /* Dummy power */
-        proj_res = breath(target_ptr, y, x, m_idx, GF_HAND_DOOM, dam, 0, FALSE, MS_HAND_DOOM, MONSTER_TO_MONSTER);
+        proj_res = breath(target_ptr, y, x, m_idx, GF_HAND_DOOM, dam, 0, FALSE, MONSTER_TO_MONSTER);
     }
 
     auto res = MonsterSpellResult::make_valid();
@@ -93,7 +93,7 @@ MonsterSpellResult spell_RF6_PSY_SPEAR(player_type *target_ptr, POSITION y, POSI
         _("%^sが%sに向かって光の剣を放った。", "%^s throw a Psycho-spear at %s."), TARGET_TYPE);
 
     const auto dam = monspell_damage(target_ptr, (MS_PSY_SPEAR), m_idx, DAM_ROLL);
-    const auto proj_res = beam(target_ptr, m_idx, y, x, GF_PSY_SPEAR, dam, MS_PSY_SPEAR, MONSTER_TO_PLAYER);
+    const auto proj_res = beam(target_ptr, m_idx, y, x, GF_PSY_SPEAR, dam, MONSTER_TO_PLAYER);
 
     auto res = MonsterSpellResult::make_valid(dam);
     res.learnable = proj_res.affected_player;

--- a/src/mspell/mspell-special.cpp
+++ b/src/mspell/mspell-special.cpp
@@ -179,12 +179,12 @@ static MonsterSpellResult spell_RF6_SPECIAL_B(player_type *target_ptr, POSITION 
     }
 
     if (monster_to_player || (monster_to_monster && target_ptr->riding == t_idx)) {
-        int get_damage = take_hit(target_ptr, DAMAGE_NOESCAPE, dam, m_name, -1);
+        int get_damage = take_hit(target_ptr, DAMAGE_NOESCAPE, dam, m_name);
         if (target_ptr->tim_eyeeye && get_damage > 0 && !target_ptr->is_dead) {
             GAME_TEXT m_name_self[MAX_MONSTER_NAME];
             monster_desc(target_ptr, m_name_self, m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE | MD_OBJECTIVE);
             msg_format(_("攻撃が%s自身を傷つけた！", "The attack of %s has wounded %s!"), m_name, m_name_self);
-            project(target_ptr, 0, 0, m_ptr->fy, m_ptr->fx, get_damage, GF_MISSILE, PROJECT_KILL, -1);
+            project(target_ptr, 0, 0, m_ptr->fy, m_ptr->fx, get_damage, GF_MISSILE, PROJECT_KILL);
             set_tim_eyeeye(target_ptr, target_ptr->tim_eyeeye - 5, TRUE);
         }
     }

--- a/src/mspell/mspell-status.cpp
+++ b/src/mspell/mspell-status.cpp
@@ -123,7 +123,7 @@ MonsterSpellResult spell_RF5_DRAIN_MANA(player_type *target_ptr, POSITION y, POS
     }
 
     const auto dam = monspell_damage(target_ptr, (MS_DRAIN_MANA), m_idx, DAM_ROLL);
-    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_DRAIN_MANA, dam, 0, FALSE, MS_DRAIN_MANA, TARGET_TYPE);
+    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_DRAIN_MANA, dam, 0, FALSE, TARGET_TYPE);
     if (TARGET_TYPE == MONSTER_TO_PLAYER)
         update_smart_learn(target_ptr, m_idx, DRS_MANA);
 
@@ -163,7 +163,7 @@ MonsterSpellResult spell_RF5_MIND_BLAST(player_type *target_ptr, POSITION y, POS
     }
 
     const auto dam = monspell_damage(target_ptr, (MS_MIND_BLAST), m_idx, DAM_ROLL);
-    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_MIND_BLAST, dam, 0, FALSE, MS_MIND_BLAST, TARGET_TYPE);
+    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_MIND_BLAST, dam, 0, FALSE, TARGET_TYPE);
 
     auto res = MonsterSpellResult::make_valid(dam);
     res.learnable = proj_res.affected_player;
@@ -201,7 +201,7 @@ MonsterSpellResult spell_RF5_BRAIN_SMASH(player_type *target_ptr, POSITION y, PO
     }
 
     const auto dam = monspell_damage(target_ptr, (MS_BRAIN_SMASH), m_idx, DAM_ROLL);
-    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_BRAIN_SMASH, dam, 0, FALSE, MS_BRAIN_SMASH, TARGET_TYPE);
+    const auto proj_res = breath(target_ptr, y, x, m_idx, GF_BRAIN_SMASH, dam, 0, FALSE, TARGET_TYPE);
 
     auto res = MonsterSpellResult::make_valid(dam);
     res.learnable = proj_res.affected_player;

--- a/src/mspell/specified-summon.cpp
+++ b/src/mspell/specified-summon.cpp
@@ -78,7 +78,7 @@ MONSTER_NUMBER summon_guardian(player_type *target_ptr, POSITION y, POSITION x, 
         if (mon_to_player)
             fire_ball_hide(target_ptr, GF_WATER_FLOW, 0, 3, 8);
         else if (mon_to_mon)
-            project(target_ptr, t_idx, 8, y, x, 3, GF_WATER_FLOW, PROJECT_GRID | PROJECT_HIDE, -1);
+            project(target_ptr, t_idx, 8, y, x, 3, GF_WATER_FLOW, PROJECT_GRID | PROJECT_HIDE);
     }
 
     int count = 0;

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -451,14 +451,14 @@ void process_world_aux_mutation(player_type *creature_ptr)
 
             creature_ptr->csp += healing;
             creature_ptr->redraw |= (PR_HP | PR_MANA);
-            take_hit(creature_ptr, DAMAGE_LOSELIFE, healing, _("頭に昇った血", "blood rushing to the head"), -1);
+            take_hit(creature_ptr, DAMAGE_LOSELIFE, healing, _("頭に昇った血", "blood rushing to the head"));
         }
     }
 
     if (creature_ptr->muta.has(MUTA::DISARM) && one_in_(10000)) {
         disturb(creature_ptr, FALSE, TRUE);
         msg_print(_("足がもつれて転んだ！", "You trip over your own feet!"));
-        take_hit(creature_ptr, DAMAGE_NOESCAPE, randint1(creature_ptr->wt / 6), _("転倒", "tripping"), -1);
+        take_hit(creature_ptr, DAMAGE_NOESCAPE, randint1(creature_ptr->wt / 6), _("転倒", "tripping"));
         drop_weapons(creature_ptr);
     }
 }

--- a/src/object-activation/activation-bolt-ball.cpp
+++ b/src/object-activation/activation-bolt-ball.cpp
@@ -317,7 +317,7 @@ bool activate_ball_lite(player_type *user_ptr, concptr name)
                 break;
         }
 
-        project(user_ptr, 0, 3, y, x, 150, GF_ELEC, PROJECT_THRU | PROJECT_STOP | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL, -1);
+        project(user_ptr, 0, 3, y, x, 150, GF_ELEC, PROJECT_THRU | PROJECT_STOP | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL);
     }
 
     return TRUE;

--- a/src/object-activation/activation-others.cpp
+++ b/src/object-activation/activation-others.cpp
@@ -119,7 +119,7 @@ bool activate_judgement(player_type *user_ptr, concptr name)
     wiz_lite(user_ptr, FALSE);
 
     msg_format(_("%sはあなたの体力を奪った...", "The %s drains your vitality..."), name);
-    take_hit(user_ptr, DAMAGE_LOSELIFE, damroll(3, 8), _("審判の宝石", "the Jewel of Judgement"), -1);
+    take_hit(user_ptr, DAMAGE_LOSELIFE, damroll(3, 8), _("審判の宝石", "the Jewel of Judgement"));
 
     (void)detect_traps(user_ptr, DETECT_RAD_DEFAULT, TRUE);
     (void)detect_doors(user_ptr, DETECT_RAD_DEFAULT);
@@ -181,7 +181,7 @@ bool activate_cure_lw(player_type *user_ptr)
 bool activate_grand_cross(player_type *user_ptr)
 {
     msg_print(_("「闇に還れ！」", "You say, 'Return to darkness!'"));
-    (void)project(user_ptr, 0, 8, user_ptr->y, user_ptr->x, (randint1(100) + 200) * 2, GF_HOLY_FIRE, PROJECT_KILL | PROJECT_ITEM | PROJECT_GRID, -1);
+    (void)project(user_ptr, 0, 8, user_ptr->y, user_ptr->x, (randint1(100) + 200) * 2, GF_HOLY_FIRE, PROJECT_KILL | PROJECT_ITEM | PROJECT_GRID);
     return TRUE;
 }
 

--- a/src/object-activation/activation-switcher.cpp
+++ b/src/object-activation/activation-switcher.cpp
@@ -350,7 +350,7 @@ bool switch_activation(player_type *user_ptr, object_type **o_ptr_ptr, const act
         return activate_teleport_level(user_ptr);
     case ACT_STRAIN_HASTE:
         msg_format(_("%sはあなたの体力を奪った...", "The %s drains your vitality..."), name);
-        take_hit(user_ptr, DAMAGE_LOSELIFE, damroll(3, 8), _("加速した疲労", "the strain of haste"), -1);
+        take_hit(user_ptr, DAMAGE_LOSELIFE, damroll(3, 8), _("加速した疲労", "the strain of haste"));
         (void)set_fast(user_ptr, user_ptr->fast + 25 + randint1(25), FALSE);
         return TRUE;
     case ACT_FISHING:

--- a/src/object-use/quaff-execution.cpp
+++ b/src/object-use/quaff-execution.cpp
@@ -97,7 +97,7 @@ static bool booze(player_type *creature_ptr)
 static bool detonation(player_type *creature_ptr)
 {
     msg_print(_("体の中で激しい爆発が起きた！", "Massive explosions rupture your body!"));
-    take_hit(creature_ptr, DAMAGE_NOESCAPE, damroll(50, 20), _("爆発の薬", "a potion of Detonation"), -1);
+    take_hit(creature_ptr, DAMAGE_NOESCAPE, damroll(50, 20), _("爆発の薬", "a potion of Detonation"));
     (void)set_stun(creature_ptr, creature_ptr->stun + 75);
     (void)set_cut(creature_ptr, creature_ptr->cut + 5000);
     return TRUE;
@@ -230,7 +230,7 @@ void exe_quaff_potion(player_type *creature_ptr, INVENTORY_IDX item)
 
         case SV_POTION_RUINATION:
             msg_print(_("身も心も弱ってきて、精気が抜けていくようだ。", "Your nerves and muscles feel weak and lifeless!"));
-            take_hit(creature_ptr, DAMAGE_LOSELIFE, damroll(10, 10), _("破滅の薬", "a potion of Ruination"), -1);
+            take_hit(creature_ptr, DAMAGE_LOSELIFE, damroll(10, 10), _("破滅の薬", "a potion of Ruination"));
 
             (void)dec_stat(creature_ptr, A_DEX, 25, TRUE);
             (void)dec_stat(creature_ptr, A_WIS, 25, TRUE);
@@ -279,7 +279,7 @@ void exe_quaff_potion(player_type *creature_ptr, INVENTORY_IDX item)
             chg_virtue(creature_ptr, V_VITALITY, -1);
             chg_virtue(creature_ptr, V_UNLIFE, 5);
             msg_print(_("死の予感が体中を駆けめぐった。", "A feeling of Death flows through your body."));
-            take_hit(creature_ptr, DAMAGE_LOSELIFE, 5000, _("死の薬", "a potion of Death"), -1);
+            take_hit(creature_ptr, DAMAGE_LOSELIFE, 5000, _("死の薬", "a potion of Death"));
             ident = TRUE;
             break;
 

--- a/src/object-use/read-execution.cpp
+++ b/src/object-use/read-execution.cpp
@@ -414,7 +414,7 @@ void exe_read(player_type *creature_ptr, INVENTORY_IDX item, bool known)
         case SV_SCROLL_FIRE: {
             fire_ball(creature_ptr, GF_FIRE, 0, 666, 4);
             if (!(is_oppose_fire(creature_ptr) || has_resist_fire(creature_ptr) || has_immune_fire(creature_ptr)))
-                take_hit(creature_ptr, DAMAGE_NOESCAPE, 50 + randint1(50), _("炎の巻物", "a Scroll of Fire"), -1);
+                take_hit(creature_ptr, DAMAGE_NOESCAPE, 50 + randint1(50), _("炎の巻物", "a Scroll of Fire"));
 
             ident = TRUE;
             break;
@@ -422,7 +422,7 @@ void exe_read(player_type *creature_ptr, INVENTORY_IDX item, bool known)
         case SV_SCROLL_ICE: {
             fire_ball(creature_ptr, GF_ICE, 0, 777, 4);
             if (!(is_oppose_cold(creature_ptr) || has_resist_cold(creature_ptr) || has_immune_cold(creature_ptr)))
-                take_hit(creature_ptr, DAMAGE_NOESCAPE, 100 + randint1(100), _("氷の巻物", "a Scroll of Ice"), -1);
+                take_hit(creature_ptr, DAMAGE_NOESCAPE, 100 + randint1(100), _("氷の巻物", "a Scroll of Ice"));
 
             ident = TRUE;
             break;
@@ -430,7 +430,7 @@ void exe_read(player_type *creature_ptr, INVENTORY_IDX item, bool known)
         case SV_SCROLL_CHAOS: {
             fire_ball(creature_ptr, GF_CHAOS, 0, 1000, 4);
             if (!has_resist_chaos(creature_ptr))
-                take_hit(creature_ptr, DAMAGE_NOESCAPE, 111 + randint1(111), _("ログルスの巻物", "a Scroll of Logrus"), -1);
+                take_hit(creature_ptr, DAMAGE_NOESCAPE, 111 + randint1(111), _("ログルスの巻物", "a Scroll of Logrus"));
 
             ident = TRUE;
             break;

--- a/src/object/object-broken.cpp
+++ b/src/object/object-broken.cpp
@@ -419,7 +419,7 @@ bool potion_smash_effect(player_type *owner_ptr, MONSTER_IDX who, POSITION y, PO
 		break;
 	}
 
-	(void)project(owner_ptr, who, radius, y, x, dam, dt, (PROJECT_JUMP | PROJECT_ITEM | PROJECT_KILL), -1);
+	(void)project(owner_ptr, who, radius, y, x, dam, dt, (PROJECT_JUMP | PROJECT_ITEM | PROJECT_KILL));
 	return angry;
 }
 

--- a/src/pet/pet-fall-off.cpp
+++ b/src/pet/pet-fall-off.cpp
@@ -138,7 +138,7 @@ bool process_fall_off_horse(player_type *creature_ptr, HIT_POINT dam, bool force
         if (!sn) {
             monster_desc(creature_ptr, m_name, m_ptr, 0);
             msg_format(_("%sから振り落とされそうになって、壁にぶつかった。", "You have nearly fallen from %s but bumped into a wall."), m_name);
-            take_hit(creature_ptr, DAMAGE_NOESCAPE, r_ptr->level + 3, _("壁への衝突", "bumping into a wall"), -1);
+            take_hit(creature_ptr, DAMAGE_NOESCAPE, r_ptr->level + 3, _("壁への衝突", "bumping into a wall"));
             return FALSE;
         }
 
@@ -169,7 +169,7 @@ bool process_fall_off_horse(player_type *creature_ptr, HIT_POINT dam, bool force
         monster_desc(creature_ptr, m_name, m_ptr, 0);
         msg_format(_("%sから落ちたが、空中でうまく体勢を立て直して着地した。", "You are thrown from %s but make a good landing."), m_name);
     } else {
-        take_hit(creature_ptr, DAMAGE_NOESCAPE, r_ptr->level + 3, _("落馬", "Falling from riding"), -1);
+        take_hit(creature_ptr, DAMAGE_NOESCAPE, r_ptr->level + 3, _("落馬", "Falling from riding"));
         fall_dam = TRUE;
     }
 

--- a/src/player/digestion-processor.cpp
+++ b/src/player/digestion-processor.cpp
@@ -58,7 +58,7 @@ void starve_player(player_type *creature_ptr)
     if (creature_ptr->food < PY_FOOD_STARVE) {
         HIT_POINT dam = (PY_FOOD_STARVE - creature_ptr->food) / 10;
         if (!is_invuln(creature_ptr))
-            take_hit(creature_ptr, DAMAGE_LOSELIFE, dam, _("空腹", "starvation"), -1);
+            take_hit(creature_ptr, DAMAGE_LOSELIFE, dam, _("空腹", "starvation"));
     }
 }
 

--- a/src/player/patron.cpp
+++ b/src/player/patron.cpp
@@ -373,7 +373,7 @@ void gain_level_reward(player_type *creature_ptr, int chosen_reward)
             msg_print(_("「苦しむがよい、無能な愚か者よ！」", "'Suffer, pathetic fool!'"));
 
             fire_ball(creature_ptr, GF_DISINTEGRATE, 0, creature_ptr->lev * 4, 4);
-            take_hit(creature_ptr, DAMAGE_NOESCAPE, creature_ptr->lev * 4, wrath_reason, -1);
+            take_hit(creature_ptr, DAMAGE_NOESCAPE, creature_ptr->lev * 4, wrath_reason);
             reward = _("分解の球が発生した。", "generating disintegration ball");
             break;
 
@@ -468,7 +468,7 @@ void gain_level_reward(player_type *creature_ptr, int chosen_reward)
             msg_format(_("%sの声が轟き渡った:", "The voice of %s thunders:"), chaos_patrons[creature_ptr->chaos_patron]);
             msg_print(_("「死ぬがよい、下僕よ！」", "'Die, mortal!'"));
 
-            take_hit(creature_ptr, DAMAGE_LOSELIFE, creature_ptr->lev * 4, wrath_reason, -1);
+            take_hit(creature_ptr, DAMAGE_LOSELIFE, creature_ptr->lev * 4, wrath_reason);
             for (int stat = 0; stat < A_MAX; stat++) {
                 (void)dec_stat(creature_ptr, stat, 10 + randint1(15), FALSE);
             }

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -135,7 +135,7 @@ static bool acid_minus_ac(player_type *creature_ptr)
  * @return 修正HPダメージ量
  * @details 酸オーラは存在しないが関数ポインタのために引数だけは用意している
  */
-HIT_POINT acid_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, int monspell, bool aura)
+HIT_POINT acid_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, bool aura)
 {
     int inv = (dam < 30) ? 1 : (dam < 60) ? 2 : 3;
     bool double_resist = is_oppose_acid(creature_ptr);
@@ -151,7 +151,7 @@ HIT_POINT acid_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, int
             dam = (dam + 1) / 2;
     }
 
-    HIT_POINT get_damage = take_hit(creature_ptr, aura ? DAMAGE_NOESCAPE : DAMAGE_ATTACK, dam, kb_str, monspell);
+    HIT_POINT get_damage = take_hit(creature_ptr, aura ? DAMAGE_NOESCAPE : DAMAGE_ATTACK, dam, kb_str);
     if (!aura && !(double_resist && has_resist_acid(creature_ptr)))
         inventory_damage(creature_ptr, set_acid_destroy, inv);
 
@@ -168,7 +168,7 @@ HIT_POINT acid_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, int
  * @param aura オーラよるダメージが原因ならばTRUE
  * @return 修正HPダメージ量
  */
-HIT_POINT elec_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, int monspell, bool aura)
+HIT_POINT elec_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, bool aura)
 {
     int inv = (dam < 30) ? 1 : (dam < 60) ? 2 : 3;
     bool double_resist = is_oppose_elec(creature_ptr);
@@ -183,7 +183,7 @@ HIT_POINT elec_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, int
             (void)do_dec_stat(creature_ptr, A_DEX);
     }
 
-    HIT_POINT get_damage = take_hit(creature_ptr, aura ? DAMAGE_NOESCAPE : DAMAGE_ATTACK, dam, kb_str, monspell);
+    HIT_POINT get_damage = take_hit(creature_ptr, aura ? DAMAGE_NOESCAPE : DAMAGE_ATTACK, dam, kb_str);
     if (!aura && !(double_resist && has_resist_elec(creature_ptr)))
         inventory_damage(creature_ptr, set_elec_destroy, inv);
 
@@ -200,7 +200,7 @@ HIT_POINT elec_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, int
  * @param aura オーラよるダメージが原因ならばTRUE
  * @return 修正HPダメージ量
  */
-HIT_POINT fire_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, int monspell, bool aura)
+HIT_POINT fire_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, bool aura)
 {
     int inv = (dam < 30) ? 1 : (dam < 60) ? 2 : 3;
     bool double_resist = is_oppose_fire(creature_ptr);
@@ -215,7 +215,7 @@ HIT_POINT fire_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, int
             (void)do_dec_stat(creature_ptr, A_STR);
     }
 
-    HIT_POINT get_damage = take_hit(creature_ptr, aura ? DAMAGE_NOESCAPE : DAMAGE_ATTACK, dam, kb_str, monspell);
+    HIT_POINT get_damage = take_hit(creature_ptr, aura ? DAMAGE_NOESCAPE : DAMAGE_ATTACK, dam, kb_str);
     if (!aura && !(double_resist && has_resist_fire(creature_ptr)))
         inventory_damage(creature_ptr, set_fire_destroy, inv);
 
@@ -232,7 +232,7 @@ HIT_POINT fire_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, int
  * @param aura オーラよるダメージが原因ならばTRUE
  * @return 修正HPダメージ量
  */
-HIT_POINT cold_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, int monspell, bool aura)
+HIT_POINT cold_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, bool aura)
 {
     int inv = (dam < 30) ? 1 : (dam < 60) ? 2 : 3;
     bool double_resist = is_oppose_cold(creature_ptr);
@@ -245,7 +245,7 @@ HIT_POINT cold_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, int
             (void)do_dec_stat(creature_ptr, A_STR);
     }
 
-    HIT_POINT get_damage = take_hit(creature_ptr, aura ? DAMAGE_NOESCAPE : DAMAGE_ATTACK, dam, kb_str, monspell);
+    HIT_POINT get_damage = take_hit(creature_ptr, aura ? DAMAGE_NOESCAPE : DAMAGE_ATTACK, dam, kb_str);
     if (!aura && !(double_resist && has_resist_cold(creature_ptr)))
         inventory_damage(creature_ptr, set_cold_destroy, inv);
 
@@ -261,10 +261,8 @@ HIT_POINT cold_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, int
  * the game when he dies, since the "You die." message is shown before
  * setting the player to "dead".
  */
-int take_hit(player_type *creature_ptr, int damage_type, HIT_POINT damage, concptr hit_from, int monspell)
+int take_hit(player_type *creature_ptr, int damage_type, HIT_POINT damage, concptr hit_from)
 {
-    (void)monspell; // unused
-
     int old_chp = creature_ptr->chp;
 
     char death_message[1024];
@@ -551,7 +549,7 @@ int take_hit(player_type *creature_ptr, int damage_type, HIT_POINT damage, concp
  * @return なし
  */
 static void process_aura_damage(monster_type *m_ptr, player_type *touched_ptr, bool immune, int flags_offset, int r_flags_offset, u32b aura_flag,
-    HIT_POINT (*dam_func)(player_type *creature_type, HIT_POINT dam, concptr kb_str, int monspell, bool aura), concptr message)
+    HIT_POINT (*dam_func)(player_type *creature_type, HIT_POINT dam, concptr kb_str, bool aura), concptr message)
 {
     monster_race *r_ptr = &r_info[m_ptr->r_idx];
     if (!(atoffset(BIT_FLAGS, r_ptr, flags_offset) & aura_flag) || immune)
@@ -562,7 +560,7 @@ static void process_aura_damage(monster_type *m_ptr, player_type *touched_ptr, b
 
     monster_desc(touched_ptr, mon_name, m_ptr, MD_WRONGDOER_NAME);
     msg_print(message);
-    dam_func(touched_ptr, aura_damage, mon_name, -1, TRUE);
+    dam_func(touched_ptr, aura_damage, mon_name, TRUE);
 
     if (is_original_ap_and_seen(touched_ptr, m_ptr))
         atoffset(BIT_FLAGS, r_ptr, r_flags_offset) |= aura_flag;

--- a/src/player/player-damage.h
+++ b/src/player/player-damage.h
@@ -9,10 +9,10 @@
 #define DAMAGE_ATTACK   4
 #define DAMAGE_NOESCAPE 5
 #define DAMAGE_USELIFE  6
-extern int take_hit(player_type *creature_ptr, int damage_type, HIT_POINT damage, concptr kb_str, int monspell);
+extern int take_hit(player_type *creature_ptr, int damage_type, HIT_POINT damage, concptr kb_str);
 
-HIT_POINT acid_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, int monspell, bool aura);
-HIT_POINT elec_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, int monspell, bool aura);
-HIT_POINT fire_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, int monspell, bool aura);
-HIT_POINT cold_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, int monspell, bool aura);
+HIT_POINT acid_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, bool aura);
+HIT_POINT elec_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, bool aura);
+HIT_POINT fire_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, bool aura);
+HIT_POINT cold_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, bool aura);
 void touch_zap_player(monster_type *m_ptr, player_type *touched_ptr);

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -190,7 +190,7 @@ bool move_player_effect(player_type *creature_ptr, POSITION ny, POSITION nx, BIT
 
     if (mpe_mode & MPE_ENERGY_USE) {
         if (music_singing(creature_ptr, MUSIC_WALL)) {
-            (void)project(creature_ptr, 0, 0, creature_ptr->y, creature_ptr->x, (60 + creature_ptr->lev), GF_DISINTEGRATE, PROJECT_KILL | PROJECT_ITEM, -1);
+            (void)project(creature_ptr, 0, 0, creature_ptr->y, creature_ptr->x, (60 + creature_ptr->lev), GF_DISINTEGRATE, PROJECT_KILL | PROJECT_ITEM);
             if (!player_bold(creature_ptr, ny, nx) || creature_ptr->is_dead || creature_ptr->leaving)
                 return FALSE;
         }

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -2925,7 +2925,7 @@ void wreck_the_pattern(player_type *creature_ptr)
     msg_print(_("何か恐ろしい事が起こった！", "Something terrible happens!"));
 
     if (!is_invuln(creature_ptr))
-        take_hit(creature_ptr, DAMAGE_NOESCAPE, damroll(10, 8), _("パターン損壊", "corrupting the Pattern"), -1);
+        take_hit(creature_ptr, DAMAGE_NOESCAPE, damroll(10, 8), _("パターン損壊", "corrupting the Pattern"));
 
     int to_ruin = randint1(45) + 35;
     while (to_ruin--) {

--- a/src/realm/realm-chaos.cpp
+++ b/src/realm/realm-chaos.cpp
@@ -273,7 +273,7 @@ concptr do_chaos_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 msg_print(_("ドーン！部屋が揺れた！", "BOOM! Shake the room!"));
-                project(caster_ptr, 0, rad, caster_ptr->y, caster_ptr->x, dam, GF_SOUND, PROJECT_KILL | PROJECT_ITEM, -1);
+                project(caster_ptr, 0, rad, caster_ptr->y, caster_ptr->x, dam, GF_SOUND, PROJECT_KILL | PROJECT_ITEM);
             }
         }
         break;

--- a/src/realm/realm-crusade.cpp
+++ b/src/realm/realm-crusade.cpp
@@ -608,7 +608,7 @@ concptr do_crusade_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
             if (info)
                 return format(_("回%d/損%d+%d", "h%d/dm%d+%d"), heal, d_dam, b_dam / 2);
             if (cast) {
-                project(caster_ptr, 0, 1, caster_ptr->y, caster_ptr->x, b_dam, GF_HOLY_FIRE, PROJECT_KILL, -1);
+                project(caster_ptr, 0, 1, caster_ptr->y, caster_ptr->x, b_dam, GF_HOLY_FIRE, PROJECT_KILL);
                 dispel_monsters(caster_ptr, d_dam);
                 slow_monsters(caster_ptr, plev);
                 stun_monsters(caster_ptr, power);

--- a/src/realm/realm-death.cpp
+++ b/src/realm/realm-death.cpp
@@ -298,7 +298,7 @@ concptr do_death_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
                 return info_damage(0, 0, dam / 2);
 
             if (cast) {
-                project(caster_ptr, 0, rad, caster_ptr->y, caster_ptr->x, dam, GF_POIS, PROJECT_KILL | PROJECT_ITEM, -1);
+                project(caster_ptr, 0, rad, caster_ptr->y, caster_ptr->x, dam, GF_POIS, PROJECT_KILL | PROJECT_ITEM);
             }
         }
         break;
@@ -693,7 +693,7 @@ concptr do_death_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
                     return NULL;
 
                 fire_ball(caster_ptr, GF_HELL_FIRE, dir, dam, rad);
-                take_hit(caster_ptr, DAMAGE_USELIFE, 20 + randint1(30), _("地獄の劫火の呪文を唱えた疲労", "the strain of casting Hellfire"), -1);
+                take_hit(caster_ptr, DAMAGE_USELIFE, 20 + randint1(30), _("地獄の劫火の呪文を唱えた疲労", "the strain of casting Hellfire"));
             }
         }
         break;

--- a/src/realm/realm-demon.cpp
+++ b/src/realm/realm-demon.cpp
@@ -651,7 +651,7 @@ concptr do_daemon_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
                     return NULL;
 
                 fire_ball_hide(caster_ptr, GF_BLOOD_CURSE, dir, dam, rad);
-                take_hit(caster_ptr, DAMAGE_USELIFE, 20 + randint1(30), _("血の呪い", "Blood curse"), -1);
+                take_hit(caster_ptr, DAMAGE_USELIFE, 20 + randint1(30), _("血の呪い", "Blood curse"));
             }
         }
         break;

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -297,7 +297,7 @@ concptr do_hex_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
                 msg_print(_("我慢が解かれた！", "My patience is at an end!"));
                 if (power) {
                     project(
-                        caster_ptr, 0, rad, caster_ptr->y, caster_ptr->x, power, GF_HELL_FIRE, (PROJECT_STOP | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL), -1);
+                        caster_ptr, 0, rad, caster_ptr->y, caster_ptr->x, power, GF_HELL_FIRE, (PROJECT_STOP | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL));
                 }
                 if (current_world_ptr->wizard) {
                     msg_format(_("%d点のダメージを返した。", "You return %d damage."), power);

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -871,7 +871,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
                 msg_print(_("不思議な力がテレポートを防いだ！", "A mysterious force prevents you from teleporting!"));
                 break;
             }
-            project(caster_ptr, 0, 0, y, x, HISSATSU_ISSEN, GF_ATTACK, PROJECT_BEAM | PROJECT_KILL, -1);
+            project(caster_ptr, 0, 0, y, x, HISSATSU_ISSEN, GF_ATTACK, PROJECT_BEAM | PROJECT_KILL);
             teleport_player_to(caster_ptr, y, x, TELEPORT_SPONTANEOUS);
         }
         break;
@@ -952,7 +952,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
                 total_damage += (damage / 100);
             }
             project(caster_ptr, 0, (cave_has_flag_bold(caster_ptr->current_floor_ptr, y, x, FF_PROJECT) ? 5 : 0), y, x, total_damage * 3 / 2, GF_METEOR,
-                PROJECT_KILL | PROJECT_JUMP | PROJECT_ITEM, -1);
+                PROJECT_KILL | PROJECT_JUMP | PROJECT_ITEM);
         }
         break;
 
@@ -980,7 +980,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
                 return NULL;
             }
-            take_hit(caster_ptr, DAMAGE_NOESCAPE, 100 + randint1(100), _("慶雲鬼忍剣を使った衝撃", "exhaustion on using Keiun-Kininken"), -1);
+            take_hit(caster_ptr, DAMAGE_NOESCAPE, 100 + randint1(100), _("慶雲鬼忍剣を使った衝撃", "exhaustion on using Keiun-Kininken"));
         }
         break;
 
@@ -1003,11 +1003,11 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
             if (i != '@')
                 return NULL;
             if (current_world_ptr->total_winner) {
-                take_hit(caster_ptr, DAMAGE_FORCE, 9999, "Seppuku", -1);
+                take_hit(caster_ptr, DAMAGE_FORCE, 9999, "Seppuku");
                 current_world_ptr->total_winner = TRUE;
             } else {
                 msg_print(_("武士道とは、死ぬことと見つけたり。", "The meaning of bushido is found in death."));
-                take_hit(caster_ptr, DAMAGE_FORCE, 9999, "Seppuku", -1);
+                take_hit(caster_ptr, DAMAGE_FORCE, 9999, "Seppuku");
             }
         }
         break;

--- a/src/realm/realm-nature.cpp
+++ b/src/realm/realm-nature.cpp
@@ -160,7 +160,7 @@ concptr do_nature_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
                 if ((is_specific_player_race(caster_ptr, RACE_VAMPIRE) || (caster_ptr->mimic_form == MIMIC_VAMPIRE)) && !has_resist_lite(caster_ptr)) {
                     msg_print(_("日の光があなたの肉体を焦がした！", "The daylight scorches your flesh!"));
-                    take_hit(caster_ptr, DAMAGE_NOESCAPE, damroll(2, 2), _("日の光", "daylight"), -1);
+                    take_hit(caster_ptr, DAMAGE_NOESCAPE, damroll(2, 2), _("日の光", "daylight"));
                 }
             }
         }
@@ -625,7 +625,7 @@ concptr do_nature_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
                 if ((is_specific_player_race(caster_ptr, RACE_VAMPIRE) || (caster_ptr->mimic_form == MIMIC_VAMPIRE)) && !has_resist_lite(caster_ptr)) {
                     msg_print(_("日光があなたの肉体を焦がした！", "The sunlight scorches your flesh!"));
-                    take_hit(caster_ptr, DAMAGE_NOESCAPE, 50, _("日光", "sunlight"), -1);
+                    take_hit(caster_ptr, DAMAGE_NOESCAPE, 50, _("日光", "sunlight"));
                 }
             }
         }
@@ -663,7 +663,7 @@ concptr do_nature_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
             if (cast) {
                 dispel_monsters(caster_ptr, d_dam);
                 earthquake(caster_ptr, caster_ptr->y, caster_ptr->x, q_rad, 0);
-                project(caster_ptr, 0, b_rad, caster_ptr->y, caster_ptr->x, b_dam, GF_DISINTEGRATE, PROJECT_KILL | PROJECT_ITEM, -1);
+                project(caster_ptr, 0, b_rad, caster_ptr->y, caster_ptr->x, b_dam, GF_DISINTEGRATE, PROJECT_KILL | PROJECT_ITEM);
             }
         }
         break;

--- a/src/realm/realm-song.cpp
+++ b/src/realm/realm-song.cpp
@@ -405,7 +405,7 @@ concptr do_music_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
              * MP不足で鑑定が発動される前に歌が中断してしまうのを防止。
              */
             if (cont || cast) {
-                project(caster_ptr, 0, rad, caster_ptr->y, caster_ptr->x, 0, GF_IDENTIFY, PROJECT_ITEM, -1);
+                project(caster_ptr, 0, rad, caster_ptr->y, caster_ptr->x, 0, GF_IDENTIFY, PROJECT_ITEM);
             }
         }
 
@@ -559,7 +559,7 @@ concptr do_music_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
              * MP不足で効果が発動される前に歌が中断してしまうのを防止。
              */
             if (cont || cast) {
-                project(caster_ptr, 0, 0, caster_ptr->y, caster_ptr->x, 0, GF_DISINTEGRATE, PROJECT_KILL | PROJECT_ITEM | PROJECT_HIDE, -1);
+                project(caster_ptr, 0, 0, caster_ptr->y, caster_ptr->x, 0, GF_DISINTEGRATE, PROJECT_KILL | PROJECT_ITEM | PROJECT_HIDE);
             }
         }
         break;
@@ -647,7 +647,7 @@ concptr do_music_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 msg_print(_("歌が空間を歪めた．．．", "Reality whirls wildly as you sing a dizzying melody..."));
-                project(caster_ptr, 0, rad, caster_ptr->y, caster_ptr->x, power, GF_AWAY_ALL, PROJECT_KILL, -1);
+                project(caster_ptr, 0, rad, caster_ptr->y, caster_ptr->x, power, GF_AWAY_ALL, PROJECT_KILL);
             }
         }
         break;

--- a/src/specific-object/chest.cpp
+++ b/src/specific-object/chest.cpp
@@ -171,7 +171,7 @@ void chest_trap(player_type *target_ptr, POSITION y, POSITION x, OBJECT_IDX o_id
 	if (trap & (CHEST_LOSE_STR))
 	{
 		msg_print(_("仕掛けられていた小さな針に刺されてしまった！", "A small needle has pricked you!"));
-		take_hit(target_ptr, DAMAGE_NOESCAPE, damroll(1, 4), _("毒針", "a poison needle"), -1);
+		take_hit(target_ptr, DAMAGE_NOESCAPE, damroll(1, 4), _("毒針", "a poison needle"));
 		(void)do_dec_stat(target_ptr, A_STR);
 	}
 
@@ -179,7 +179,7 @@ void chest_trap(player_type *target_ptr, POSITION y, POSITION x, OBJECT_IDX o_id
 	if (trap & (CHEST_LOSE_CON))
 	{
 		msg_print(_("仕掛けられていた小さな針に刺されてしまった！", "A small needle has pricked you!"));
-		take_hit(target_ptr, DAMAGE_NOESCAPE, damroll(1, 4), _("毒針", "a poison needle"), -1);
+		take_hit(target_ptr, DAMAGE_NOESCAPE, damroll(1, 4), _("毒針", "a poison needle"));
 		(void)do_dec_stat(target_ptr, A_CON);
 	}
 
@@ -299,7 +299,7 @@ void chest_trap(player_type *target_ptr, POSITION y, POSITION x, OBJECT_IDX o_id
 			/* ...but a high saving throw does help a little. */
 			if (randint1(100 + o_ptr->pval * 2) > target_ptr->skill_sav)
 			{
-				if (one_in_(6)) take_hit(target_ptr, DAMAGE_NOESCAPE, damroll(5, 20), _("破滅のトラップの宝箱", "a chest dispel-player trap"), -1);
+				if (one_in_(6))	take_hit(target_ptr, DAMAGE_NOESCAPE, damroll(5, 20), _("破滅のトラップの宝箱", "a chest dispel-player trap"));
 				else if (one_in_(5)) (void)set_cut(target_ptr,target_ptr->cut + 200);
 				else if (one_in_(4))
 				{
@@ -339,7 +339,7 @@ void chest_trap(player_type *target_ptr, POSITION y, POSITION x, OBJECT_IDX o_id
 		msg_print(_("箱の中の物はすべて粉々に砕け散った！", "Everything inside the chest is destroyed!"));
 		o_ptr->pval = 0;
 		sound(SOUND_EXPLODE);
-		take_hit(target_ptr, DAMAGE_ATTACK, damroll(5, 8), _("爆発する箱", "an exploding chest"), -1);
+		take_hit(target_ptr, DAMAGE_ATTACK, damroll(5, 8), _("爆発する箱", "an exploding chest"));
 	}
 	/* Scatter contents. */
 	if ((trap & (CHEST_SCATTER)) && o_ptr->k_idx)

--- a/src/specific-object/death-crimson.cpp
+++ b/src/specific-object/death-crimson.cpp
@@ -44,7 +44,7 @@ static bool fire_crimson(player_type *shooter_ptr)
 
     BIT_FLAGS flg = PROJECT_STOP | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL;
     for (int i = 0; i < num; i++)
-        (void)project(shooter_ptr, 0, shooter_ptr->lev / 20 + 1, ty, tx, shooter_ptr->lev * shooter_ptr->lev * 6 / 50, GF_ROCKET, flg, -1);
+        (void)project(shooter_ptr, 0, shooter_ptr->lev / 20 + 1, ty, tx, shooter_ptr->lev * shooter_ptr->lev * 6 / 50, GF_ROCKET, flg);
 
     return TRUE;
 }

--- a/src/specific-object/death-scythe.cpp
+++ b/src/specific-object/death-scythe.cpp
@@ -153,6 +153,6 @@ void process_death_scythe_reflection(player_type *attacker_ptr, player_attack_ty
     if (pa_ptr->attack_damage < 0)
         pa_ptr->attack_damage = 0;
 
-    take_hit(attacker_ptr, DAMAGE_FORCE, pa_ptr->attack_damage, _("死の大鎌", "Death scythe"), -1);
+    take_hit(attacker_ptr, DAMAGE_FORCE, pa_ptr->attack_damage, _("死の大鎌", "Death scythe"));
     handle_stuff(attacker_ptr);
 }

--- a/src/spell-kind/blood-curse.cpp
+++ b/src/spell-kind/blood-curse.cpp
@@ -42,7 +42,7 @@ void blood_curse_to_enemy(player_type *caster_ptr, MONSTER_IDX m_idx)
             if (!count) {
                 int extra_dam = damroll(10, 10);
                 msg_print(_("純粋な魔力の次元への扉が開いた！", "A portal opens to a plane of raw mana!"));
-                project(caster_ptr, 0, 8, m_ptr->fy, m_ptr->fx, extra_dam, GF_MANA, curse_flg, -1);
+                project(caster_ptr, 0, 8, m_ptr->fy, m_ptr->fx, extra_dam, GF_MANA, curse_flg);
                 if (!one_in_(6))
                     break;
             }
@@ -63,7 +63,7 @@ void blood_curse_to_enemy(player_type *caster_ptr, MONSTER_IDX m_idx)
         case 10:
         case 11:
             msg_print(_("エネルギーのうねりを感じた！", "You feel a surge of energy!"));
-            project(caster_ptr, 0, 7, m_ptr->fy, m_ptr->fx, 50, GF_DISINTEGRATE, curse_flg, -1);
+            project(caster_ptr, 0, 7, m_ptr->fy, m_ptr->fx, 50, GF_DISINTEGRATE, curse_flg);
             if (!one_in_(6))
                 break;
             /* Fall through */

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -166,7 +166,7 @@ bool earthquake(player_type *caster_ptr, POSITION cy, POSITION cx, POSITION r, M
                 killer = _("地震", "an earthquake");
             }
 
-            take_hit(caster_ptr, DAMAGE_ATTACK, damage, killer, -1);
+            take_hit(caster_ptr, DAMAGE_ATTACK, damage, killer);
         }
     }
 

--- a/src/spell-kind/spells-genocide.cpp
+++ b/src/spell-kind/spells-genocide.cpp
@@ -94,7 +94,7 @@ bool genocide_aux(player_type *caster_ptr, MONSTER_IDX m_idx, int power, bool pl
     }
 
     if (player_cast) {
-        take_hit(caster_ptr, DAMAGE_GENO, randint1(dam_side), format(_("%^sの呪文を唱えた疲労", "the strain of casting %^s"), spell_name), -1);
+        take_hit(caster_ptr, DAMAGE_GENO, randint1(dam_side), format(_("%^sの呪文を唱えた疲労", "the strain of casting %^s"), spell_name));
     }
 
     move_cursor_relative(caster_ptr->y, caster_ptr->x);

--- a/src/spell-kind/spells-launcher.cpp
+++ b/src/spell-kind/spells-launcher.cpp
@@ -35,7 +35,7 @@ bool fire_ball(player_type *caster_ptr, EFFECT_ID typ, DIRECTION dir, HIT_POINT 
         ty = target_row;
     }
 
-    return project(caster_ptr, 0, rad, ty, tx, dam, typ, flg, -1).notice;
+    return project(caster_ptr, 0, rad, ty, tx, dam, typ, flg).notice;
 }
 
 /*!
@@ -83,7 +83,7 @@ bool fire_rocket(player_type *caster_ptr, EFFECT_ID typ, DIRECTION dir, HIT_POIN
     }
 
     BIT_FLAGS flg = PROJECT_STOP | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL;
-    return project(caster_ptr, 0, rad, ty, tx, dam, typ, flg, -1).notice;
+    return project(caster_ptr, 0, rad, ty, tx, dam, typ, flg).notice;
 }
 
 /*!
@@ -112,7 +112,7 @@ bool fire_ball_hide(player_type *caster_ptr, EFFECT_ID typ, DIRECTION dir, HIT_P
         ty = target_row;
     }
 
-    return project(caster_ptr, 0, rad, ty, tx, dam, typ, flg, -1).notice;
+    return project(caster_ptr, 0, rad, ty, tx, dam, typ, flg).notice;
 }
 
 /*!
@@ -137,7 +137,7 @@ bool fire_ball_hide(player_type *caster_ptr, EFFECT_ID typ, DIRECTION dir, HIT_P
 bool fire_meteor(player_type *caster_ptr, MONSTER_IDX who, EFFECT_ID typ, POSITION y, POSITION x, HIT_POINT dam, POSITION rad)
 {
     BIT_FLAGS flg = PROJECT_STOP | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL;
-    return project(caster_ptr, who, rad, y, x, dam, typ, flg, -1).notice;
+    return project(caster_ptr, who, rad, y, x, dam, typ, flg).notice;
 }
 
 /*!
@@ -180,7 +180,7 @@ bool fire_blast(player_type *caster_ptr, EFFECT_ID typ, DIRECTION dir, DICE_NUMB
         }
 
         /* Analyze the "dir" and the "target". */
-        const auto proj_res = project(caster_ptr, 0, 0, y, x, damroll(dd, ds), typ, flg, -1);
+        const auto proj_res = project(caster_ptr, 0, 0, y, x, damroll(dd, ds), typ, flg);
         if (!proj_res.notice)
             result = FALSE;
     }
@@ -270,5 +270,5 @@ bool project_hook(player_type *caster_ptr, EFFECT_ID typ, DIRECTION dir, HIT_POI
         ty = target_row;
     }
 
-    return project(caster_ptr, 0, 0, ty, tx, dam, typ, flg, -1).notice;
+    return project(caster_ptr, 0, 0, ty, tx, dam, typ, flg).notice;
 }

--- a/src/spell-kind/spells-lite.cpp
+++ b/src/spell-kind/spells-lite.cpp
@@ -385,7 +385,7 @@ bool starlight(player_type *caster_ptr, bool magic)
         }
 
         project(caster_ptr, 0, 0, y, x, damroll(6 + caster_ptr->lev / 8, 10), GF_LITE_WEAK,
-            (PROJECT_BEAM | PROJECT_THRU | PROJECT_GRID | PROJECT_KILL | PROJECT_LOS), -1);
+            (PROJECT_BEAM | PROJECT_THRU | PROJECT_GRID | PROJECT_KILL | PROJECT_LOS));
     }
 
     return TRUE;
@@ -410,7 +410,7 @@ bool lite_area(player_type *caster_ptr, HIT_POINT dam, POSITION rad)
     }
 
     BIT_FLAGS flg = PROJECT_GRID | PROJECT_KILL;
-    (void)project(caster_ptr, 0, rad, caster_ptr->y, caster_ptr->x, dam, GF_LITE_WEAK, flg, -1);
+    (void)project(caster_ptr, 0, rad, caster_ptr->y, caster_ptr->x, dam, GF_LITE_WEAK, flg);
 
     lite_room(caster_ptr, caster_ptr->y, caster_ptr->x);
 
@@ -431,7 +431,7 @@ bool unlite_area(player_type *caster_ptr, HIT_POINT dam, POSITION rad)
     }
 
     BIT_FLAGS flg = PROJECT_GRID | PROJECT_KILL;
-    (void)project(caster_ptr, 0, rad, caster_ptr->y, caster_ptr->x, dam, GF_DARK_WEAK, flg, -1);
+    (void)project(caster_ptr, 0, rad, caster_ptr->y, caster_ptr->x, dam, GF_DARK_WEAK, flg);
 
     unlite_room(caster_ptr, caster_ptr->y, caster_ptr->x);
 

--- a/src/spell-kind/spells-neighbor.cpp
+++ b/src/spell-kind/spells-neighbor.cpp
@@ -19,7 +19,7 @@
 bool door_creation(player_type *caster_ptr, POSITION y, POSITION x)
 {
     BIT_FLAGS flg = PROJECT_GRID | PROJECT_ITEM | PROJECT_HIDE;
-    return project(caster_ptr, 0, 1, y, x, 0, GF_MAKE_DOOR, flg, -1).notice;
+    return project(caster_ptr, 0, 1, y, x, 0, GF_MAKE_DOOR, flg).notice;
 }
 
 /*!
@@ -32,7 +32,7 @@ bool door_creation(player_type *caster_ptr, POSITION y, POSITION x)
 bool trap_creation(player_type *caster_ptr, POSITION y, POSITION x)
 {
     BIT_FLAGS flg = PROJECT_GRID | PROJECT_ITEM | PROJECT_HIDE;
-    return project(caster_ptr, 0, 1, y, x, 0, GF_MAKE_TRAP, flg, -1).notice;
+    return project(caster_ptr, 0, 1, y, x, 0, GF_MAKE_TRAP, flg).notice;
 }
 
 /*!
@@ -43,7 +43,7 @@ bool trap_creation(player_type *caster_ptr, POSITION y, POSITION x)
 bool tree_creation(player_type *caster_ptr, POSITION y, POSITION x)
 {
     BIT_FLAGS flg = PROJECT_GRID | PROJECT_ITEM | PROJECT_HIDE;
-    return project(caster_ptr, 0, 1, y, x, 0, GF_MAKE_TREE, flg, -1).notice;
+    return project(caster_ptr, 0, 1, y, x, 0, GF_MAKE_TREE, flg).notice;
 }
 
 /*!
@@ -54,7 +54,7 @@ bool tree_creation(player_type *caster_ptr, POSITION y, POSITION x)
 bool create_rune_protection_area(player_type *caster_ptr, POSITION y, POSITION x)
 {
     BIT_FLAGS flg = PROJECT_GRID | PROJECT_ITEM;
-    return project(caster_ptr, 0, 1, y, x, 0, GF_MAKE_RUNE_PROTECTION, flg, -1).notice;
+    return project(caster_ptr, 0, 1, y, x, 0, GF_MAKE_RUNE_PROTECTION, flg).notice;
 }
 
 /*!
@@ -65,7 +65,7 @@ bool create_rune_protection_area(player_type *caster_ptr, POSITION y, POSITION x
 bool wall_stone(player_type *caster_ptr)
 {
     BIT_FLAGS flg = PROJECT_GRID | PROJECT_ITEM | PROJECT_HIDE;
-    bool dummy = project(caster_ptr, 0, 1, caster_ptr->y, caster_ptr->x, 0, GF_STONE_WALL, flg, -1).notice;
+    bool dummy = project(caster_ptr, 0, 1, caster_ptr->y, caster_ptr->x, 0, GF_STONE_WALL, flg).notice;
     caster_ptr->update |= (PU_FLOW);
     caster_ptr->redraw |= (PR_MAP);
     return dummy;
@@ -79,7 +79,7 @@ bool wall_stone(player_type *caster_ptr)
 bool destroy_doors_touch(player_type *caster_ptr)
 {
     BIT_FLAGS flg = PROJECT_GRID | PROJECT_ITEM | PROJECT_HIDE;
-    return project(caster_ptr, 0, 1, caster_ptr->y, caster_ptr->x, 0, GF_KILL_DOOR, flg, -1).notice;
+    return project(caster_ptr, 0, 1, caster_ptr->y, caster_ptr->x, 0, GF_KILL_DOOR, flg).notice;
 }
 
 /*!
@@ -90,7 +90,7 @@ bool destroy_doors_touch(player_type *caster_ptr)
 bool disarm_traps_touch(player_type *caster_ptr)
 {
     BIT_FLAGS flg = PROJECT_GRID | PROJECT_ITEM | PROJECT_HIDE;
-    return project(caster_ptr, 0, 1, caster_ptr->y, caster_ptr->x, 0, GF_KILL_TRAP, flg, -1).notice;
+    return project(caster_ptr, 0, 1, caster_ptr->y, caster_ptr->x, 0, GF_KILL_TRAP, flg).notice;
 }
 
 /*!
@@ -101,7 +101,7 @@ bool disarm_traps_touch(player_type *caster_ptr)
 bool sleep_monsters_touch(player_type *caster_ptr)
 {
     BIT_FLAGS flg = PROJECT_KILL | PROJECT_HIDE;
-    return project(caster_ptr, 0, 1, caster_ptr->y, caster_ptr->x, caster_ptr->lev, GF_OLD_SLEEP, flg, -1).notice;
+    return project(caster_ptr, 0, 1, caster_ptr->y, caster_ptr->x, caster_ptr->lev, GF_OLD_SLEEP, flg).notice;
 }
 
 /*!
@@ -115,7 +115,7 @@ bool sleep_monsters_touch(player_type *caster_ptr)
 bool animate_dead(player_type *caster_ptr, MONSTER_IDX who, POSITION y, POSITION x)
 {
     BIT_FLAGS flg = PROJECT_ITEM | PROJECT_HIDE;
-    return project(caster_ptr, who, 5, y, x, 0, GF_ANIM_DEAD, flg, -1).notice;
+    return project(caster_ptr, who, 5, y, x, 0, GF_ANIM_DEAD, flg).notice;
 }
 
 /*!
@@ -137,7 +137,7 @@ void wall_breaker(player_type *caster_ptr)
                 break;
         }
 
-        project(caster_ptr, 0, 0, y, x, 20 + randint1(30), GF_KILL_WALL, (PROJECT_BEAM | PROJECT_THRU | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL), -1);
+        project(caster_ptr, 0, 0, y, x, 20 + randint1(30), GF_KILL_WALL, (PROJECT_BEAM | PROJECT_THRU | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL));
         return;
     }
 
@@ -155,6 +155,6 @@ void wall_breaker(player_type *caster_ptr)
                 break;
         }
 
-        project(caster_ptr, 0, 0, y, x, 20 + randint1(30), GF_KILL_WALL, (PROJECT_BEAM | PROJECT_THRU | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL), -1);
+        project(caster_ptr, 0, 0, y, x, 20 + randint1(30), GF_KILL_WALL, (PROJECT_BEAM | PROJECT_THRU | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL));
     }
 }

--- a/src/spell-kind/spells-pet.cpp
+++ b/src/spell-kind/spells-pet.cpp
@@ -57,7 +57,7 @@ void discharge_minion(player_type *caster_ptr)
             dam = (dam - 400) / 2 + 400;
         if (dam > 800)
             dam = 800;
-        project(caster_ptr, i, 2 + (r_ptr->level / 20), m_ptr->fy, m_ptr->fx, dam, GF_PLASMA, PROJECT_STOP | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL, -1);
+        project(caster_ptr, i, 2 + (r_ptr->level / 20), m_ptr->fy, m_ptr->fx, dam, GF_PLASMA, PROJECT_STOP | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL);
 
         if (record_named_pet && m_ptr->nickname) {
             GAME_TEXT m_name[MAX_NLEN];

--- a/src/spell-kind/spells-random.cpp
+++ b/src/spell-kind/spells-random.cpp
@@ -111,8 +111,8 @@ bool activate_ty_curse(player_type *target_ptr, bool stop_ty, int *count)
             if (!(*count)) {
                 HIT_POINT dam = damroll(10, 10);
                 msg_print(_("純粋な魔力の次元への扉が開いた！", "A portal opens to a plane of raw mana!"));
-                project(target_ptr, 0, 8, target_ptr->y, target_ptr->x, dam, GF_MANA, flg, -1);
-                take_hit(target_ptr, DAMAGE_NOESCAPE, dam, _("純粋な魔力の解放", "released pure mana"), -1);
+                project(target_ptr, 0, 8, target_ptr->y, target_ptr->x, dam, GF_MANA, flg);
+                take_hit(target_ptr, DAMAGE_NOESCAPE, dam, _("純粋な魔力の解放", "released pure mana"));
                 if (!one_in_(6))
                     break;
             }
@@ -132,8 +132,8 @@ bool activate_ty_curse(player_type *target_ptr, bool stop_ty, int *count)
             msg_print(_("エネルギーのうねりを感じた！", "You feel a surge of energy!"));
             wall_breaker(target_ptr);
             if (!randint0(7)) {
-                project(target_ptr, 0, 7, target_ptr->y, target_ptr->x, 50, GF_KILL_WALL, flg, -1);
-                take_hit(target_ptr, DAMAGE_NOESCAPE, 50, _("エネルギーのうねり", "surge of energy"), -1);
+                project(target_ptr, 0, 7, target_ptr->y, target_ptr->x, 50, GF_KILL_WALL, flg);
+                take_hit(target_ptr, DAMAGE_NOESCAPE, 50, _("エネルギーのうねり", "surge of energy"));
             }
 
             if (!one_in_(6))

--- a/src/spell-kind/spells-sight.cpp
+++ b/src/spell-kind/spells-sight.cpp
@@ -67,7 +67,7 @@ bool project_all_los(player_type *caster_ptr, EFFECT_ID typ, HIT_POINT dam)
         POSITION y = m_ptr->fy;
         POSITION x = m_ptr->fx;
 
-        if (project(caster_ptr, 0, 0, y, x, dam, typ, flg, -1).notice)
+        if (project(caster_ptr, 0, 0, y, x, dam, typ, flg).notice)
             obvious = TRUE;
     }
 

--- a/src/spell-realm/spells-chaos.cpp
+++ b/src/spell-realm/spells-chaos.cpp
@@ -80,7 +80,7 @@ void call_the_void(player_type *caster_ptr)
     if (one_in_(666)) {
         if (!vanish_dungeon(caster_ptr))
             msg_print(_("ダンジョンは一瞬静まり返った。", "The dungeon becomes quiet for a moment."));
-        take_hit(caster_ptr, DAMAGE_NOESCAPE, 100 + randint1(150), _("自殺的な虚無招来", "a suicidal Call the Void"), -1);
+        take_hit(caster_ptr, DAMAGE_NOESCAPE, 100 + randint1(150), _("自殺的な虚無招来", "a suicidal Call the Void"));
         return;
     }
 
@@ -88,7 +88,7 @@ void call_the_void(player_type *caster_ptr)
         msg_print(_("ダンジョンが崩壊した...", "The dungeon collapses..."));
     else
         msg_print(_("ダンジョンは大きく揺れた。", "The dungeon trembles."));
-    take_hit(caster_ptr, DAMAGE_NOESCAPE, 100 + randint1(150), _("自殺的な虚無招来", "a suicidal Call the Void"), -1);
+    take_hit(caster_ptr, DAMAGE_NOESCAPE, 100 + randint1(150), _("自殺的な虚無招来", "a suicidal Call the Void"));
 }
 
 /*!
@@ -219,6 +219,6 @@ void cast_meteor(player_type *caster_ptr, HIT_POINT dam, POSITION rad)
         if (count > 20)
             continue;
 
-        project(caster_ptr, 0, rad, y, x, dam, GF_METEOR, PROJECT_KILL | PROJECT_JUMP | PROJECT_ITEM, -1);
+        project(caster_ptr, 0, rad, y, x, dam, GF_METEOR, PROJECT_KILL | PROJECT_JUMP | PROJECT_ITEM);
     }
 }

--- a/src/spell-realm/spells-crusade.cpp
+++ b/src/spell-realm/spells-crusade.cpp
@@ -94,7 +94,7 @@ bool cast_wrath_of_the_god(player_type *caster_ptr, HIT_POINT dam, POSITION rad)
             || !in_disintegration_range(caster_ptr->current_floor_ptr, ty, tx, y, x))
             continue;
 
-        project(caster_ptr, 0, rad, y, x, dam, GF_DISINTEGRATE, PROJECT_JUMP | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL, -1);
+        project(caster_ptr, 0, rad, y, x, dam, GF_DISINTEGRATE, PROJECT_JUMP | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL);
     }
 
     return TRUE;

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -392,13 +392,13 @@ bool perilous_secrets(player_type *user_ptr)
         user_ptr->redraw |= (PR_MANA);
     }
 
-    take_hit(user_ptr, DAMAGE_LOSELIFE, damroll(1, 12), _("危険な秘密", "perilous secrets"), -1);
+    take_hit(user_ptr, DAMAGE_LOSELIFE, damroll(1, 12), _("危険な秘密", "perilous secrets"));
 
     if (one_in_(5))
         (void)set_confused(user_ptr, user_ptr->confused + randint1(10));
 
     if (one_in_(20))
-        take_hit(user_ptr, DAMAGE_LOSELIFE, damroll(4, 10), _("危険な秘密", "perilous secrets"), -1);
+        take_hit(user_ptr, DAMAGE_LOSELIFE, damroll(4, 10), _("危険な秘密", "perilous secrets"));
 
     return TRUE;
 }

--- a/src/spell/spells-staff-only.cpp
+++ b/src/spell/spells-staff-only.cpp
@@ -52,7 +52,7 @@ bool unleash_mana_storm(player_type *creature_ptr, bool powerful)
 {
     msg_print(_("強力な魔力が敵を引き裂いた！", "Mighty magics rend your enemies!"));
     project(creature_ptr, 0, (powerful ? 7 : 5), creature_ptr->y, creature_ptr->x, (randint1(200) + (powerful ? 500 : 300)) * 2, GF_MANA,
-        PROJECT_KILL | PROJECT_ITEM | PROJECT_GRID, -1);
+        PROJECT_KILL | PROJECT_ITEM | PROJECT_GRID);
 
     bool is_special_class = creature_ptr->pclass != CLASS_MAGE;
     is_special_class &= creature_ptr->pclass != CLASS_HIGH_MAGE;
@@ -61,7 +61,7 @@ bool unleash_mana_storm(player_type *creature_ptr, bool powerful)
     is_special_class &= creature_ptr->pclass != CLASS_BLUE_MAGE;
     is_special_class &= creature_ptr->pclass != CLASS_ELEMENTALIST;
     if (is_special_class)
-        (void)take_hit(creature_ptr, DAMAGE_NOESCAPE, 50, _("コントロールし難い強力な魔力の解放", "unleashing magics too mighty to control"), -1);
+        (void)take_hit(creature_ptr, DAMAGE_NOESCAPE, 50, _("コントロールし難い強力な魔力の解放", "unleashing magics too mighty to control"));
 
     return TRUE;
 }

--- a/src/status/shape-changer.cpp
+++ b/src/status/shape-changer.cpp
@@ -38,7 +38,7 @@ void do_poly_wounds(player_type *creature_ptr)
     hp_player(creature_ptr, change);
     if (Nasty_effect) {
         msg_print(_("新たな傷ができた！", "A new wound was created!"));
-        take_hit(creature_ptr, DAMAGE_LOSELIFE, change / 2, _("変化した傷", "a polymorphed wound"), -1);
+        take_hit(creature_ptr, DAMAGE_LOSELIFE, change / 2, _("変化した傷", "a polymorphed wound"));
         set_cut(creature_ptr, change);
     } else {
         set_cut(creature_ptr, creature_ptr->cut - (change / 2));
@@ -167,7 +167,7 @@ void do_poly_self(player_type *creature_ptr)
         }
         if (one_in_(6)) {
             msg_print(_("現在の姿で生きていくのは困難なようだ！", "You find living difficult in your present form!"));
-            take_hit(creature_ptr, DAMAGE_LOSELIFE, damroll(randint1(10), creature_ptr->lev), _("致命的な突然変異", "a lethal mutation"), -1);
+            take_hit(creature_ptr, DAMAGE_LOSELIFE, damroll(randint1(10), creature_ptr->lev), _("致命的な突然変異", "a lethal mutation"));
 
             power -= 10;
         }


### PR DESCRIPTION
この引数はかつて青魔法のラーニング判定で使用されていたが、
ラーニング関連のコードの書き直しによって使われなくなった。
ラーニングできないダメージ源の時に -1 を与える必要があり、
そこら中の take_hit() や project() で -1 が引数として渡されていて
コードが見苦しいのでこの際削除してしまう。

追記: 
`MS_*` と `RF_ABILITY::*` を統合するのにもひっかかって邪魔なので。