### PR TITLE
[Refactor] 意味もなく引き回しているprocess_autopick_file_command引数の削除

### DIFF
--- a/src/autopick/autopick-reader-writer.cpp
+++ b/src/autopick/autopick-reader-writer.cpp
@@ -15,7 +15,7 @@ void autopick_load_pref(player_type *player_ptr, bool disp_mes)
 	GAME_TEXT buf[80];
 	init_autopick();
 	angband_strcpy(buf, pickpref_filename(player_ptr, PT_WITH_PNAME), sizeof(buf));
-	errr err = process_autopick_file(player_ptr, buf, process_autopick_file_command);
+	errr err = process_autopick_file(player_ptr, buf);
 	if (err == 0 && disp_mes)
 	{
 		msg_format(_("%sを読み込みました。", "Loaded '%s'."), buf);
@@ -24,7 +24,7 @@ void autopick_load_pref(player_type *player_ptr, bool disp_mes)
 	if (err < 0)
 	{
 		angband_strcpy(buf, pickpref_filename(player_ptr, PT_DEFAULT), sizeof(buf));
-		err = process_autopick_file(player_ptr, buf, process_autopick_file_command);
+		err = process_autopick_file(player_ptr, buf);
 		if (err == 0 && disp_mes)
 		{
 			msg_format(_("%sを読み込みました。", "Loaded '%s'."), buf);

--- a/src/birth/birth-wizard.cpp
+++ b/src/birth/birth-wizard.cpp
@@ -524,16 +524,15 @@ static bool display_auto_roller(player_type *creature_ptr, chara_limit_type char
 /*!
  * @brief 名前と生い立ちを設定する
  * @param creature_ptr プレーヤーへの参照ポインタ
- * @param process_autopick_file_command 自動拾いコマンドへの関数ポインタ
  * @return なし
  * @details ついでにステータス限界もここで決めている
  */
-static void set_name_history(player_type *creature_ptr, void (*process_autopick_file_command)(char *))
+static void set_name_history(player_type *creature_ptr)
 {
     clear_from(23);
     get_name(creature_ptr);
     process_player_name(creature_ptr, current_world_ptr->creating_savefile);
-    edit_history(creature_ptr, process_autopick_file_command);
+    edit_history(creature_ptr);
     get_max_stats(creature_ptr);
     get_virtues(creature_ptr);
     prt(_("[ 'Q' 中断, 'S' 初めから, Enter ゲーム開始 ]", "['Q'uit, 'S'tart over, or Enter to continue]"), 23, _(14, 10));
@@ -547,7 +546,7 @@ static void set_name_history(player_type *creature_ptr, void (*process_autopick_
  * expensive CPU wise.  And it cuts down on player stupidity.
  * @return なし
  */
-bool player_birth_wizard(player_type *creature_ptr, void (*process_autopick_file_command)(char *))
+bool player_birth_wizard(player_type *creature_ptr)
 {
     display_initial_birth_message(creature_ptr);
     const char p2 = ')';
@@ -583,7 +582,7 @@ bool player_birth_wizard(player_type *creature_ptr, void (*process_autopick_file
     if (!display_auto_roller(creature_ptr, chara_limit))
         return FALSE;
 
-    set_name_history(creature_ptr, process_autopick_file_command);
+    set_name_history(creature_ptr);
     char c = inkey();
     if (c == 'Q')
         birth_quit();

--- a/src/birth/birth-wizard.h
+++ b/src/birth/birth-wizard.h
@@ -2,4 +2,4 @@
 
 #include "system/angband.h"
 
-bool player_birth_wizard(player_type *creature_ptr, void (*process_autopick_file_command)(char *));
+bool player_birth_wizard(player_type *creature_ptr);

--- a/src/birth/character-builder.cpp
+++ b/src/birth/character-builder.cpp
@@ -72,7 +72,7 @@ static void write_birth_diary(player_type *creature_ptr)
  * fields, so we must be sure to clear them first.
  * @return なし
  */
-void player_birth(player_type *creature_ptr, void (*process_autopick_file_command)(char *))
+void player_birth(player_type *creature_ptr)
 {
     current_world_ptr->play_time = 0;
     wipe_monsters_list(creature_ptr);
@@ -80,7 +80,7 @@ void player_birth(player_type *creature_ptr, void (*process_autopick_file_comman
     if (!ask_quick_start(creature_ptr)) {
         play_music(TERM_XTRA_MUSIC_BASIC, MUSIC_BASIC_DEFAULT);
         while (TRUE) {
-            if (player_birth_wizard(creature_ptr, process_autopick_file_command))
+            if (player_birth_wizard(creature_ptr))
                 break;
 
             player_wipe_without_name(creature_ptr);

--- a/src/birth/character-builder.h
+++ b/src/birth/character-builder.h
@@ -2,4 +2,4 @@
 
 #include "system/angband.h"
 
-void player_birth(player_type *creature_ptr, void(*process_autopick_file_command)(char*));
+void player_birth(player_type *creature_ptr);

--- a/src/birth/history-editor.cpp
+++ b/src/birth/history-editor.cpp
@@ -12,10 +12,9 @@
 /*!
  * @brief 生い立ちメッセージを編集する。/Character background edit-mode
  * @param creature_ptr プレーヤーへの参照ポインタ
- * @param process_autopick_file_command 自動拾いファイルコマンドへの関数ポインタ
  * @return なし
  */
-void edit_history(player_type *creature_ptr, void (*process_autopick_file_command)(char *))
+void edit_history(player_type *creature_ptr)
 {
     char old_history[4][60];
     for (int i = 0; i < 4; i++) {
@@ -114,7 +113,7 @@ void edit_history(player_type *creature_ptr, void (*process_autopick_file_comman
 
             break;
         } else if (c == KTRL('A')) {
-            if (read_histpref(creature_ptr, process_autopick_file_command)) {
+            if (read_histpref(creature_ptr)) {
 #ifdef JP
                 if ((x > 0) && (iskanji2(creature_ptr->history[y], x - 1)))
                     x--;

--- a/src/birth/history-editor.h
+++ b/src/birth/history-editor.h
@@ -2,4 +2,4 @@
 
 #include "system/angband.h"
 
-void edit_history(player_type *creature_ptr, void (*process_autopick_file_command)(char *));
+void edit_history(player_type *creature_ptr);

--- a/src/cmd-io/cmd-autopick.cpp
+++ b/src/cmd-io/cmd-autopick.cpp
@@ -205,7 +205,7 @@ void do_cmd_edit_autopick(player_type *player_ptr)
 	string_free(tb->last_destroyed);
 	kill_yank_chain(tb);
 
-	process_autopick_file(player_ptr, buf, process_autopick_file_command);
+	process_autopick_file(player_ptr, buf);
 	current_world_ptr->start_time = (u32b)time(NULL);
 	cx_save = tb->cx;
 	cy_save = tb->cy;

--- a/src/cmd-io/cmd-dump.cpp
+++ b/src/cmd-io/cmd-dump.cpp
@@ -57,7 +57,7 @@ void do_cmd_pref(player_type *creature_ptr)
 /*
  * Interact with "colors"
  */
-void do_cmd_colors(player_type *creature_ptr, void (*process_autopick_file_command)(char *))
+void do_cmd_colors(player_type *creature_ptr)
 {
     int i;
     char tmp[160];
@@ -82,7 +82,7 @@ void do_cmd_colors(player_type *creature_ptr, void (*process_autopick_file_comma
             if (!askfor(tmp, 70))
                 continue;
 
-            (void)process_pref_file(creature_ptr, tmp, process_autopick_file_command);
+            (void)process_pref_file(creature_ptr, tmp);
             term_xtra(TERM_XTRA_REACT, 0);
             term_redraw();
         } else if (i == '2') {

--- a/src/cmd-io/cmd-dump.h
+++ b/src/cmd-io/cmd-dump.h
@@ -3,7 +3,7 @@
 #include "system/angband.h"
 
 void do_cmd_pref(player_type *creature_ptr);
-void do_cmd_colors(player_type *creature_ptr, void(*process_autopick_file_command)(char*));
+void do_cmd_colors(player_type *creature_ptr);
 void do_cmd_note(void);
 void do_cmd_version(void);
 void do_cmd_feeling(player_type *creature_ptr);

--- a/src/cmd-io/cmd-macro.cpp
+++ b/src/cmd-io/cmd-macro.cpp
@@ -156,7 +156,7 @@ static errr keymap_dump(concptr fname)
  * Could use some helpful instructions on this page.
  * </pre>
  */
-void do_cmd_macros(player_type *creature_ptr, void(*process_autopick_file_command)(char*))
+void do_cmd_macros(player_type *creature_ptr)
 {
 	char tmp[1024];
 	char buf[1024];
@@ -193,7 +193,7 @@ void do_cmd_macros(player_type *creature_ptr, void(*process_autopick_file_comman
 			sprintf(tmp, "%s.prf", creature_ptr->base_name);
 			if (!askfor(tmp, 80)) continue;
 
-			errr err = process_pref_file(creature_ptr, tmp, process_autopick_file_command);
+			errr err = process_pref_file(creature_ptr, tmp);
 			if (-2 == err)
 				msg_format(_("標準の設定ファイル'%s'を読み込みました。", "Loaded default '%s'."), tmp);
 			else if (err)

--- a/src/cmd-io/cmd-macro.h
+++ b/src/cmd-io/cmd-macro.h
@@ -2,4 +2,4 @@
 
 #include "system/angband.h"
 
-void do_cmd_macros(player_type *creature_ptr, void (*process_autopick_file_command)(char *));
+void do_cmd_macros(player_type *creature_ptr);

--- a/src/cmd-io/cmd-process-screen.cpp
+++ b/src/cmd-io/cmd-process-screen.cpp
@@ -336,15 +336,14 @@ static bool do_cmd_save_screen_text(int wid, int hgt)
 /*!
  * @brief 記念撮影のためにグラフィック使用をOFFにする
  * @param creature_ptr プレーヤーへの参照ポインタ
- * @param handle_stuff 画面更新用の関数ポインタ
  * @return 記念撮影直前のグラフィックオプション
  */
-static bool update_use_graphics(player_type *creature_ptr, void(*process_autopick_file_command)(char*))
+static bool update_use_graphics(player_type *creature_ptr)
 {
 	if (!use_graphics) return TRUE;
 
 	use_graphics = FALSE;
-	reset_visuals(creature_ptr, process_autopick_file_command);
+	reset_visuals(creature_ptr);
 	creature_ptr->redraw |= (PR_WIPE | PR_BASIC | PR_EXTRA | PR_MAP | PR_EQUIPPY);
 	handle_stuff(creature_ptr);
 	return FALSE;
@@ -354,10 +353,9 @@ static bool update_use_graphics(player_type *creature_ptr, void(*process_autopic
 /*
  * Save a screen dump to a file
  * @param creature_ptr プレーヤーへの参照ポインタ
- * @param handle_stuff 画面更新用の関数ポインタ
  * @return なし
  */
-void do_cmd_save_screen(player_type *creature_ptr, void(*process_autopick_file_command)(char*))
+void do_cmd_save_screen(player_type *creature_ptr)
 {
 	prt(_("記念撮影しますか？ [(y)es/(h)tml/(n)o] ", "Save screen dump? [(y)es/(h)tml/(n)o] "), 0, 0);
 	bool html_dump;
@@ -366,7 +364,7 @@ void do_cmd_save_screen(player_type *creature_ptr, void(*process_autopick_file_c
 	int wid, hgt;
 	term_get_size(&wid, &hgt);
 
-	bool old_use_graphics = update_use_graphics(creature_ptr, process_autopick_file_command);
+	bool old_use_graphics = update_use_graphics(creature_ptr);
 
 	if (html_dump)
 	{
@@ -381,7 +379,7 @@ void do_cmd_save_screen(player_type *creature_ptr, void(*process_autopick_file_c
 	if (old_use_graphics) return;
 
 	use_graphics = TRUE;
-	reset_visuals(creature_ptr, process_autopick_file_command);
+	reset_visuals(creature_ptr);
 	creature_ptr->redraw |= (PR_WIPE | PR_BASIC | PR_EXTRA | PR_MAP | PR_EQUIPPY);
 	handle_stuff(creature_ptr);
 }

--- a/src/cmd-io/cmd-process-screen.h
+++ b/src/cmd-io/cmd-process-screen.h
@@ -3,5 +3,5 @@
 #include "system/angband.h"
 
 void do_cmd_save_screen_html_aux(char *filename, int message);
-void do_cmd_save_screen(player_type *creature_ptr, void(*process_autopick_file_command)(char*));
+void do_cmd_save_screen(player_type *creature_ptr);
 void do_cmd_load_screen(void);

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -74,7 +74,7 @@ static void print_visuals_menu(concptr choice_msg)
 /*
  * Interact with "visuals"
  */
-void do_cmd_visuals(player_type *creature_ptr, void (*process_autopick_file_command)(char *))
+void do_cmd_visuals(player_type *creature_ptr)
 {
     FILE *auto_dump_stream;
     char tmp[160];
@@ -100,7 +100,7 @@ void do_cmd_visuals(player_type *creature_ptr, void (*process_autopick_file_comm
             if (!askfor(tmp, 70))
                 continue;
 
-            (void)process_pref_file(creature_ptr, tmp, process_autopick_file_command);
+            (void)process_pref_file(creature_ptr, tmp);
             need_redraw = TRUE;
             break;
         }
@@ -425,7 +425,7 @@ void do_cmd_visuals(player_type *creature_ptr, void (*process_autopick_file_comm
         }
         case 'R':
         case 'r':
-            reset_visuals(creature_ptr, process_autopick_file_command);
+            reset_visuals(creature_ptr);
             msg_print(_("画面上の[色/文字]を初期値にリセットしました。", "Visual attr/char tables reset."));
             need_redraw = TRUE;
             break;

--- a/src/cmd-visual/cmd-visuals.h
+++ b/src/cmd-visual/cmd-visuals.h
@@ -2,4 +2,4 @@
 
 #include "system/angband.h"
 
-void do_cmd_visuals(player_type *creature_ptr, void(*process_autopick_file_command)(char*));
+void do_cmd_visuals(player_type *creature_ptr);

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -167,7 +167,7 @@ static void init_world_floor_info(player_type *player_ptr)
     write_level = TRUE;
     current_world_ptr->seed_flavor = randint0(0x10000000);
     current_world_ptr->seed_town = randint0(0x10000000);
-    player_birth(player_ptr, process_autopick_file_command);
+    player_birth(player_ptr);
     counts_write(player_ptr, 2, 0);
     player_ptr->count = 0;
     load = FALSE;
@@ -399,7 +399,7 @@ static void process_game_turn(player_type *player_ptr)
 void play_game(player_type *player_ptr, bool new_game, bool browsing_movie)
 {
     if (browsing_movie) {
-        reset_visuals(player_ptr, process_autopick_file_command);
+        reset_visuals(player_ptr);
         browse_movie();
         return;
     }
@@ -419,7 +419,7 @@ void play_game(player_type *player_ptr, bool new_game, bool browsing_movie)
 
     generate_world(player_ptr, new_game);
     player_ptr->playing = TRUE;
-    reset_visuals(player_ptr, process_autopick_file_command);
+    reset_visuals(player_ptr);
     load_all_pref_files(player_ptr);
     if (new_game)
         player_outfit(player_ptr);

--- a/src/core/visuals-reseter.cpp
+++ b/src/core/visuals-reseter.cpp
@@ -8,10 +8,9 @@
 /*!
  * @brief オブジェクト、地形の表示シンボルなど初期化する / Reset the "visual" lists
  * @param owner_ptr プレーヤーへの参照ポインタ
- * @param process_autopick_file_command 自動拾いファイル読み込みへの関数ポインタ
  * @return なし
  */
-void reset_visuals(player_type *owner_ptr, void (*process_autopick_file_command)(char *))
+void reset_visuals(player_type *owner_ptr)
 {
     for (int i = 0; i < max_f_idx; i++) {
         feature_type *f_ptr = &f_info[i];
@@ -36,7 +35,7 @@ void reset_visuals(player_type *owner_ptr, void (*process_autopick_file_command)
     concptr pref_file = use_graphics ? "graf.prf" : "font.prf";
     concptr base_name = use_graphics ? "graf-%s.prf" : "font-%s.prf";
     char buf[1024];
-    process_pref_file(owner_ptr, pref_file, process_autopick_file_command);
+    process_pref_file(owner_ptr, pref_file);
     sprintf(buf, base_name, owner_ptr->base_name);
-    process_pref_file(owner_ptr, buf, process_autopick_file_command);
+    process_pref_file(owner_ptr, buf);
 }

--- a/src/core/visuals-reseter.h
+++ b/src/core/visuals-reseter.h
@@ -2,4 +2,4 @@
 
 #include "system/angband.h"
 
-void reset_visuals(player_type *owner_ptr, void (*process_autopick_file_command)(char *));
+void reset_visuals(player_type *owner_ptr);

--- a/src/io/input-key-processor.cpp
+++ b/src/io/input-key-processor.cpp
@@ -545,16 +545,16 @@ void process_command(player_type *creature_ptr)
         break;
     }
     case '@': {
-        do_cmd_macros(creature_ptr, process_autopick_file_command);
+        do_cmd_macros(creature_ptr);
         break;
     }
     case '%': {
-        do_cmd_visuals(creature_ptr, process_autopick_file_command);
+        do_cmd_visuals(creature_ptr);
         do_cmd_redraw(creature_ptr);
         break;
     }
     case '&': {
-        do_cmd_colors(creature_ptr, process_autopick_file_command);
+        do_cmd_colors(creature_ptr);
         do_cmd_redraw(creature_ptr);
         break;
     }
@@ -623,7 +623,7 @@ void process_command(player_type *creature_ptr)
         break;
     }
     case ')': {
-        do_cmd_save_screen(creature_ptr, process_autopick_file_command);
+        do_cmd_save_screen(creature_ptr);
         break;
     }
     case ']': {

--- a/src/io/read-pref-file.cpp
+++ b/src/io/read-pref-file.cpp
@@ -52,7 +52,7 @@ static int auto_dump_line_num;
  * @return エラーコード
  * @todo 関数名を変更する
  */
-static errr process_pref_file_aux(player_type *creature_ptr, concptr name, int preftype, void (*process_autopick_file_command)(char *))
+static errr process_pref_file_aux(player_type *creature_ptr, concptr name, int preftype)
 {
     FILE *fp;
     fp = angband_fopen(name, "r");
@@ -99,13 +99,13 @@ static errr process_pref_file_aux(player_type *creature_ptr, concptr name, int p
             depth_count++;
             switch (preftype) {
             case PREF_TYPE_AUTOPICK:
-                (void)process_autopick_file(creature_ptr, file_read__buf + 2, process_autopick_file_command);
+                (void)process_autopick_file(creature_ptr, file_read__buf + 2);
                 break;
             case PREF_TYPE_HISTPREF:
-                (void)process_histpref_file(creature_ptr, file_read__buf + 2, process_autopick_file_command);
+                (void)process_histpref_file(creature_ptr, file_read__buf + 2);
                 break;
             default:
-                (void)process_pref_file(creature_ptr, file_read__buf + 2, process_autopick_file_command);
+                (void)process_pref_file(creature_ptr, file_read__buf + 2);
                 break;
             }
 
@@ -118,7 +118,7 @@ static errr process_pref_file_aux(player_type *creature_ptr, concptr name, int p
             if (preftype != PREF_TYPE_AUTOPICK)
                 break;
 
-            (*process_autopick_file_command)(file_read__buf);
+            process_autopick_file_command(file_read__buf);
             err = 0;
         }
     }
@@ -148,17 +148,17 @@ static errr process_pref_file_aux(player_type *creature_ptr, concptr name, int p
  * allow conditional evaluation and filename inclusion.
  * </pre>
  */
-errr process_pref_file(player_type *creature_ptr, concptr name, void (*process_autopick_file_command)(char *))
+errr process_pref_file(player_type *creature_ptr, concptr name)
 {
     char buf[1024];
     path_build(buf, sizeof(buf), ANGBAND_DIR_PREF, name);
 
-    errr err1 = process_pref_file_aux(creature_ptr, buf, PREF_TYPE_NORMAL, process_autopick_file_command);
+    errr err1 = process_pref_file_aux(creature_ptr, buf, PREF_TYPE_NORMAL);
     if (err1 > 0)
         return err1;
 
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, name);
-    errr err2 = process_pref_file_aux(creature_ptr, buf, PREF_TYPE_NORMAL, process_autopick_file_command);
+    errr err2 = process_pref_file_aux(creature_ptr, buf, PREF_TYPE_NORMAL);
     if (err2 < 0 && !err1)
         return -2;
 
@@ -171,11 +171,11 @@ errr process_pref_file(player_type *creature_ptr, concptr name, void (*process_a
  * @param name ファイル名
  * @details
  */
-errr process_autopick_file(player_type *creature_ptr, concptr name, void (*process_autopick_file_command)(char *))
+errr process_autopick_file(player_type *creature_ptr, concptr name)
 {
     char buf[1024];
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, name);
-    errr err = process_pref_file_aux(creature_ptr, buf, PREF_TYPE_AUTOPICK, process_autopick_file_command);
+    errr err = process_pref_file_aux(creature_ptr, buf, PREF_TYPE_AUTOPICK);
     return err;
 }
 
@@ -187,7 +187,7 @@ errr process_autopick_file(player_type *creature_ptr, concptr name, void (*proce
  * @return エラーコード
  * @details
  */
-errr process_histpref_file(player_type *creature_ptr, concptr name, void (*process_autopick_file_command)(char *))
+errr process_histpref_file(player_type *creature_ptr, concptr name)
 {
     bool old_character_xtra = current_world_ptr->character_xtra;
     char buf[1024];
@@ -195,7 +195,7 @@ errr process_histpref_file(player_type *creature_ptr, concptr name, void (*proce
 
     /* Hack -- prevent modification birth options in this file */
     current_world_ptr->character_xtra = TRUE;
-    errr err = process_pref_file_aux(creature_ptr, buf, PREF_TYPE_HISTPREF, process_autopick_file_command);
+    errr err = process_pref_file_aux(creature_ptr, buf, PREF_TYPE_HISTPREF);
     current_world_ptr->character_xtra = old_character_xtra;
     return err;
 }
@@ -276,23 +276,23 @@ void load_all_pref_files(player_type *player_ptr)
 {
     char buf[1024];
     sprintf(buf, "user.prf");
-    process_pref_file(player_ptr, buf, process_autopick_file_command);
+    process_pref_file(player_ptr, buf);
     sprintf(buf, "user-%s.prf", ANGBAND_SYS);
-    process_pref_file(player_ptr, buf, process_autopick_file_command);
+    process_pref_file(player_ptr, buf);
     sprintf(buf, "%s.prf", rp_ptr->title);
-    process_pref_file(player_ptr, buf, process_autopick_file_command);
+    process_pref_file(player_ptr, buf);
     sprintf(buf, "%s.prf", cp_ptr->title);
-    process_pref_file(player_ptr, buf, process_autopick_file_command);
+    process_pref_file(player_ptr, buf);
     sprintf(buf, "%s.prf", player_ptr->base_name);
-    process_pref_file(player_ptr, buf, process_autopick_file_command);
+    process_pref_file(player_ptr, buf);
     if (player_ptr->realm1 != REALM_NONE) {
         sprintf(buf, "%s.prf", realm_names[player_ptr->realm1]);
-        process_pref_file(player_ptr, buf, process_autopick_file_command);
+        process_pref_file(player_ptr, buf);
     }
 
     if (player_ptr->realm2 != REALM_NONE) {
         sprintf(buf, "%s.prf", realm_names[player_ptr->realm2]);
-        process_pref_file(player_ptr, buf, process_autopick_file_command);
+        process_pref_file(player_ptr, buf);
     }
 
     autopick_load_pref(player_ptr, FALSE);
@@ -302,7 +302,7 @@ void load_all_pref_files(player_type *player_ptr)
  * @brief 生い立ちメッセージをファイルからロードする。
  * @return なし
  */
-bool read_histpref(player_type *creature_ptr, void (*process_autopick_file_command)(char *))
+bool read_histpref(player_type *creature_ptr)
 {
     char buf[80];
     errr err;
@@ -318,11 +318,11 @@ bool read_histpref(player_type *creature_ptr, void (*process_autopick_file_comma
     histpref_buf = histbuf;
 
     sprintf(buf, _("histedit-%s.prf", "histpref-%s.prf"), creature_ptr->base_name);
-    err = process_histpref_file(creature_ptr, buf, process_autopick_file_command);
+    err = process_histpref_file(creature_ptr, buf);
 
     if (0 > err) {
         strcpy(buf, _("histedit.prf", "histpref.prf"));
-        err = process_histpref_file(creature_ptr, buf, process_autopick_file_command);
+        err = process_histpref_file(creature_ptr, buf);
     }
 
     if (err) {

--- a/src/io/read-pref-file.h
+++ b/src/io/read-pref-file.h
@@ -5,10 +5,10 @@
 extern char auto_dump_header[];
 extern char auto_dump_footer[];
 
-errr process_pref_file(player_type *creature_ptr, concptr name, void(*process_autopick_file_command)(char*));
-errr process_autopick_file(player_type *creature_ptr, concptr name, void(*process_autopick_file_command)(char*));
-errr process_histpref_file(player_type *creature_ptr, concptr name, void(*process_autopick_file_command)(char*));
-bool read_histpref(player_type *creature_ptr, void (*process_autopick_file_command)(char *));
+errr process_pref_file(player_type *creature_ptr, concptr name);
+errr process_autopick_file(player_type *creature_ptr, concptr name);
+errr process_histpref_file(player_type *creature_ptr, concptr name);
+bool read_histpref(player_type *creature_ptr);
 
 void auto_dump_printf(FILE *auto_dump_stream, concptr fmt, ...);
 bool open_auto_dump(FILE **fpp, concptr buf, concptr mark);

--- a/src/io/report.cpp
+++ b/src/io/report.cpp
@@ -272,7 +272,7 @@ static errr make_dump(player_type *creature_ptr, BUF *dumpbuf, void (*update_pla
  * @brief スクリーンダンプを作成する/ Make screen dump to buffer
  * @return 作成したスクリーンダンプの参照ポインタ
  */
-concptr make_screen_dump(player_type *creature_ptr, void (*process_autopick_file_command)(char *))
+concptr make_screen_dump(player_type *creature_ptr)
 {
     static concptr html_head[] = {
         "<html>\n<body text=\"#ffffff\" bgcolor=\"#000000\">\n",
@@ -300,7 +300,7 @@ concptr make_screen_dump(player_type *creature_ptr, void (*process_autopick_file
         msg_print(NULL);
 
         use_graphics = FALSE;
-        reset_visuals(creature_ptr, process_autopick_file_command);
+        reset_visuals(creature_ptr);
 
         creature_ptr->redraw |= (PR_WIPE | PR_BASIC | PR_EXTRA | PR_MAP | PR_EQUIPPY);
         handle_stuff(creature_ptr);
@@ -389,7 +389,7 @@ concptr make_screen_dump(player_type *creature_ptr, void (*process_autopick_file
         return ret;
 
     use_graphics = TRUE;
-    reset_visuals(creature_ptr, process_autopick_file_command);
+    reset_visuals(creature_ptr);
 
     creature_ptr->redraw |= (PR_WIPE | PR_BASIC | PR_EXTRA | PR_MAP | PR_EQUIPPY);
     handle_stuff(creature_ptr);

--- a/src/io/report.h
+++ b/src/io/report.h
@@ -8,5 +8,5 @@ extern concptr screen_dump;
 #include "io/files-util.h"
 
 extern errr report_score(player_type *creature_ptr, void(*update_playtime)(void), display_player_pf display_player);
-extern concptr make_screen_dump(player_type *creature_ptr, void(*process_autopick_file_command)(char*));
+extern concptr make_screen_dump(player_type *creature_ptr);
 #endif

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -1034,7 +1034,7 @@ static errr term_xtra_win_react(player_type *player_ptr)
         }
 
         use_graphics = (arg_graphics > 0);
-        reset_visuals(player_ptr, process_autopick_file_command);
+        reset_visuals(player_ptr);
     }
 
     for (int i = 0; i < MAX_TERM_DATA; i++) {
@@ -2917,7 +2917,7 @@ static spoiler_output_status create_debug_spoiler(LPSTR cmd_line)
         return SPOILER_OUTPUT_CANCEL;
 
     init_stuff();
-    init_angband(p_ptr, process_autopick_file_command, TRUE);
+    init_angband(p_ptr, TRUE);
 
     return output_all_spoilers();
 }
@@ -3053,7 +3053,7 @@ int WINAPI WinMain(_In_ HINSTANCE hInst, _In_opt_ HINSTANCE hPrevInst, _In_ LPST
 
     signals_init();
     term_activate(term_screen);
-    init_angband(p_ptr, process_autopick_file_command, FALSE);
+    init_angband(p_ptr, FALSE);
     initialized = TRUE;
     check_for_save_file(p_ptr, lpCmdLine);
     prt(_("[ファイル] メニューの [新規] または [開く] を選択してください。", "[Choose 'New' or 'Open' from the 'File' menu]"), 23, _(8, 17));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,6 @@
  * are included in all such copies.
  */
 
-#include "autopick/autopick-pref-processor.h"
 #include "core/asking-player.h"
 #include "core/game-play.h"
 #include "core/scores.h"
@@ -287,7 +286,7 @@ static bool parse_long_opt(const char *opt)
 
     if (strcmp(opt + 2, "output-spoilers") == 0) {
         init_stuff();
-        init_angband(p_ptr, process_autopick_file_command, TRUE);
+        init_angband(p_ptr, TRUE);
         switch (output_all_spoilers()) {
         case SPOILER_OUTPUT_SUCCESS:
             puts("Successfully created a spoiler file.");
@@ -568,7 +567,7 @@ int main(int argc, char *argv[])
     signals_init();
 
     /* Initialize */
-    init_angband(p_ptr, process_autopick_file_command, FALSE);
+    init_angband(p_ptr, FALSE);
 
     /* Wait for response */
     pause_line(23);

--- a/src/main/angband-initializer.cpp
+++ b/src/main/angband-initializer.cpp
@@ -212,12 +212,11 @@ static void put_title(void)
 /*!
  * @brief 全ゲームデータ読み込みのメインルーチン /
  * @param player_ptr プレーヤーへの参照ポインタ
- * @param process_autopick_file_command 自動拾いファイル読み込み関数への関数ポインタ
  * @param no_term TRUEならゲーム画面無しの状態で初期化を行う。
  *                コマンドラインからスポイラーの出力のみを行う時の使用を想定する。
  * @return なし
  */
-void init_angband(player_type *player_ptr, process_autopick_file_command_pf process_autopick_file_command, bool no_term)
+void init_angband(player_type *player_ptr, bool no_term)
 {
     C_MAKE(file_read__buf, FILE_READ_BUFF_SIZE, char);
     C_MAKE(file_read__swp, FILE_READ_BUFF_SIZE, char);
@@ -343,8 +342,8 @@ void init_angband(player_type *player_ptr, process_autopick_file_command_pf proc
 
     init_note(_("[ユーザー設定ファイルを初期化しています...]", "[Initializing user pref files...]"));
     strcpy(buf, "pref.prf");
-    process_pref_file(player_ptr, buf, process_autopick_file_command);
+    process_pref_file(player_ptr, buf);
     sprintf(buf, "pref-%s.prf", ANGBAND_SYS);
-    process_pref_file(player_ptr, buf, process_autopick_file_command);
+    process_pref_file(player_ptr, buf);
     init_note(_("[初期化終了]", "[Initialization complete]"));
 }

--- a/src/main/angband-initializer.h
+++ b/src/main/angband-initializer.h
@@ -14,8 +14,7 @@
 
 #include "system/angband.h"
 
-typedef void (*process_autopick_file_command_pf)(char *);
-void init_angband(player_type *player_ptr, process_autopick_file_command_pf process_autopick_file_command, bool no_term);
+void init_angband(player_type *player_ptr, bool no_term);
 void init_file_paths(char *path, char *varpath);
 
 #endif /* INCLUDED_INIT_H */

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -794,7 +794,7 @@ bool mon_take_hit(player_type *target_ptr, MONSTER_IDX m_idx, HIT_POINT dam, boo
 
 #ifdef WORLD_SCORE
             if (m_ptr->r_idx == MON_SERPENT) {
-                screen_dump = make_screen_dump(target_ptr, process_autopick_file_command);
+                screen_dump = make_screen_dump(target_ptr);
             }
 #endif
         }

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -370,7 +370,7 @@ int take_hit(player_type *creature_ptr, int damage_type, HIT_POINT damage, concp
             play_music(TERM_XTRA_MUSIC_BASIC, MUSIC_BASIC_GAMEOVER);
 
 #ifdef WORLD_SCORE
-            screen_dump = make_screen_dump(creature_ptr, process_autopick_file_command);
+            screen_dump = make_screen_dump(creature_ptr);
 #endif
             if (seppuku) {
                 strcpy(creature_ptr->died_from, hit_from);
@@ -412,7 +412,7 @@ int take_hit(player_type *creature_ptr, int damage_type, HIT_POINT damage, concp
             exe_write_diary(creature_ptr, DIARY_DESCRIPTION, 1, "\n\n\n\n");
             flush();
             if (get_check_strict(creature_ptr, _("画面を保存しますか？", "Dump the screen? "), CHECK_NO_HISTORY))
-                do_cmd_save_screen(creature_ptr, process_autopick_file_command);
+                do_cmd_save_screen(creature_ptr);
 
             flush();
             if (creature_ptr->last_message)
@@ -499,7 +499,7 @@ int take_hit(player_type *creature_ptr, int damage_type, HIT_POINT damage, concp
                     term_putstr(w - 1, h - 1, 1, TERM_WHITE, " ");
                     flush();
 #ifdef WORLD_SCORE
-                    screen_dump = make_screen_dump(creature_ptr, process_autopick_file_command);
+                    screen_dump = make_screen_dump(creature_ptr);
 #endif
                     (void)inkey();
                 } else

--- a/src/store/store-key-processor.cpp
+++ b/src/store/store-key-processor.cpp
@@ -199,19 +199,19 @@ void store_process_command(player_type *client_ptr)
     }
     case '@': {
         client_ptr->town_num = old_town_num;
-        do_cmd_macros(client_ptr, process_autopick_file_command);
+        do_cmd_macros(client_ptr);
         client_ptr->town_num = inner_town_num;
         break;
     }
     case '%': {
         client_ptr->town_num = old_town_num;
-        do_cmd_visuals(client_ptr, process_autopick_file_command);
+        do_cmd_visuals(client_ptr);
         client_ptr->town_num = inner_town_num;
         break;
     }
     case '&': {
         client_ptr->town_num = old_town_num;
-        do_cmd_colors(client_ptr, process_autopick_file_command);
+        do_cmd_colors(client_ptr);
         client_ptr->town_num = inner_town_num;
         break;
     }
@@ -255,7 +255,7 @@ void store_process_command(player_type *client_ptr)
         break;
     }
     case ')': {
-        do_cmd_save_screen(client_ptr, process_autopick_file_command);
+        do_cmd_save_screen(client_ptr);
         break;
     }
     default: {


### PR DESCRIPTION
関数ポインタの引数は環境毎に実装を変えているのかと思ったら違った。
大元は caafd849860b282746496542e76e05eb68a13f19 のコミット。
１か所で他所の関数をそのまま呼ぶのを嫌い、関数ポインタの引数として付け加えることをmain-win.cppにまで延々とさかのぼって行っているのだった。
お題目の依存性を取り除けていないし、逆にまき散らかしているので実質revertする。