### PR TITLE
[Refactor] feat_state()がplayer_typeを必要とせず、floor_typeのみで事足りたので引数掃き出し。

### DIFF
--- a/src/action/open-close-execution.cpp
+++ b/src/action/open-close-execution.cpp
@@ -96,7 +96,7 @@ bool exe_close(player_type *creature_ptr, POSITION y, POSITION x)
     if (!has_flag(f_info[old_feat].flags, FF_CLOSE))
         return more;
 
-    s16b closed_feat = feat_state(creature_ptr, old_feat, FF_CLOSE);
+    s16b closed_feat = feat_state(creature_ptr->current_floor_ptr, old_feat, FF_CLOSE);
     if ((g_ptr->o_idx || (g_ptr->info & CAVE_OBJECT)) && (closed_feat != old_feat) && !has_flag(f_info[closed_feat].flags, FF_DROP)) {
         msg_print(_("何かがつっかえて閉まらない。", "Something prevents it from closing."));
     } else {
@@ -309,7 +309,7 @@ bool exe_bash(player_type *creature_ptr, POSITION y, POSITION x, DIRECTION dir)
     if (randint0(100) < temp) {
         msg_format(_("%sを壊した！", "The %s crashes open!"), name);
         sound(has_flag(f_ptr->flags, FF_GLASS) ? SOUND_GLASS : SOUND_OPENDOOR);
-        if ((randint0(100) < 50) || (feat_state(creature_ptr, g_ptr->feat, FF_OPEN) == g_ptr->feat) || has_flag(f_ptr->flags, FF_GLASS)) {
+        if ((randint0(100) < 50) || (feat_state(creature_ptr->current_floor_ptr, g_ptr->feat, FF_OPEN) == g_ptr->feat) || has_flag(f_ptr->flags, FF_GLASS)) {
             cave_alter_feat(creature_ptr, y, x, FF_BASH);
         } else {
             cave_alter_feat(creature_ptr, y, x, FF_OPEN);

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -315,9 +315,9 @@ static void update_new_floor_feature(player_type *creature_ptr, saved_floor_type
 
     grid_type *g_ptr = &creature_ptr->current_floor_ptr->grid_array[creature_ptr->y][creature_ptr->x];
     if ((creature_ptr->change_floor_mode & CFM_UP) && !quest_number(creature_ptr, creature_ptr->current_floor_ptr->dun_level))
-        g_ptr->feat = (creature_ptr->change_floor_mode & CFM_SHAFT) ? feat_state(creature_ptr, feat_down_stair, FF_SHAFT) : feat_down_stair;
+        g_ptr->feat = (creature_ptr->change_floor_mode & CFM_SHAFT) ? feat_state(creature_ptr->current_floor_ptr, feat_down_stair, FF_SHAFT) : feat_down_stair;
     else if ((creature_ptr->change_floor_mode & CFM_DOWN) && !ironman_downward)
-        g_ptr->feat = (creature_ptr->change_floor_mode & CFM_SHAFT) ? feat_state(creature_ptr, feat_up_stair, FF_SHAFT) : feat_up_stair;
+        g_ptr->feat = (creature_ptr->change_floor_mode & CFM_SHAFT) ? feat_state(creature_ptr->current_floor_ptr, feat_up_stair, FF_SHAFT) : feat_up_stair;
 
     g_ptr->mimic = 0;
     g_ptr->special = creature_ptr->floor_id;

--- a/src/floor/object-allocator.cpp
+++ b/src/floor/object-allocator.cpp
@@ -132,7 +132,7 @@ bool alloc_stairs(player_type *owner_ptr, FEAT_IDX feat, int num, int walls)
 
             g_ptr = &floor_ptr->grid_array[y][x];
             g_ptr->mimic = 0;
-            g_ptr->feat = (i < shaft_num) ? feat_state(owner_ptr, feat, FF_SHAFT) : feat;
+            g_ptr->feat = (i < shaft_num) ? feat_state(owner_ptr->current_floor_ptr, feat, FF_SHAFT) : feat;
             g_ptr->info &= ~(CAVE_FLOOR);
             break;
         }

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -267,7 +267,7 @@ void place_bound_perm_wall(player_type *player_ptr, grid_type *g_ptr)
 
         /* Hack -- Decline boundary walls with known treasure  */
         if ((has_flag(f_ptr->flags, FF_HAS_GOLD) || has_flag(f_ptr->flags, FF_HAS_ITEM)) && !has_flag(f_ptr->flags, FF_SECRET))
-            g_ptr->feat = feat_state(player_ptr, g_ptr->feat, FF_ENSECRET);
+            g_ptr->feat = feat_state(player_ptr->current_floor_ptr, g_ptr->feat, FF_ENSECRET);
 
         /* Set boundary mimic */
         g_ptr->mimic = g_ptr->feat;
@@ -912,13 +912,12 @@ byte grid_dist(grid_type *g_ptr, monster_race *r_ptr)
  * Take a feature, determine what that feature becomes
  * through applying the given action.
  */
-FEAT_IDX feat_state(player_type *player_ptr, FEAT_IDX feat, int action)
+FEAT_IDX feat_state(floor_type *floor_ptr, FEAT_IDX feat, int action)
 {
     feature_type *f_ptr = &f_info[feat];
     int i;
 
     /* Get the new feature */
-    floor_type *floor_ptr = player_ptr->current_floor_ptr;
     for (i = 0; i < MAX_FEAT_STATES; i++) {
         if (f_ptr->state[i].action == action)
             return conv_dungeon_feat(floor_ptr, f_ptr->state[i].result);
@@ -941,7 +940,7 @@ void cave_alter_feat(player_type *player_ptr, POSITION y, POSITION x, int action
     FEAT_IDX oldfeat = floor_ptr->grid_array[y][x].feat;
 
     /* Get the new feat */
-    FEAT_IDX newfeat = feat_state(player_ptr, oldfeat, action);
+    FEAT_IDX newfeat = feat_state(player_ptr->current_floor_ptr, oldfeat, action);
 
     /* No change */
     if (newfeat == oldfeat)
@@ -1136,7 +1135,10 @@ bool cave_player_teleportable_bold(player_type *player_ptr, POSITION y, POSITION
  * @param feat 地形ID
  * @return 開いた地形である場合TRUEを返す /  Return TRUE if the given feature is an open door
  */
-bool is_open(player_type *player_ptr, FEAT_IDX feat) { return has_flag(f_info[feat].flags, FF_CLOSE) && (feat != feat_state(player_ptr, feat, FF_CLOSE)); }
+bool is_open(player_type *player_ptr, FEAT_IDX feat)
+{
+    return has_flag(f_info[feat].flags, FF_CLOSE) && (feat != feat_state(player_ptr->current_floor_ptr, feat, FF_CLOSE));
+}
 
 /*!
  * @brief プレイヤーが地形踏破可能かを返す
@@ -1212,7 +1214,7 @@ void place_grid(player_type *player_ptr, grid_type *g_ptr, grid_bold_type gb_typ
     case GB_OUTER_NOPERM: {
         feature_type *f_ptr = &f_info[feat_wall_outer];
         if (permanent_wall(f_ptr)) {
-            g_ptr->feat = (s16b)feat_state(player_ptr, feat_wall_outer, FF_UNPERM);
+            g_ptr->feat = (s16b)feat_state(player_ptr->current_floor_ptr, feat_wall_outer, FF_UNPERM);
         } else {
             g_ptr->feat = feat_wall_outer;
         }
@@ -1236,7 +1238,7 @@ void place_grid(player_type *player_ptr, grid_type *g_ptr, grid_bold_type gb_typ
     case GB_SOLID_NOPERM: {
         feature_type *f_ptr = &f_info[feat_wall_solid];
         if ((g_ptr->info & CAVE_VAULT) && permanent_wall(f_ptr))
-            g_ptr->feat = (s16b)feat_state(player_ptr, feat_wall_solid, FF_UNPERM);
+            g_ptr->feat = (s16b)feat_state(player_ptr->current_floor_ptr, feat_wall_solid, FF_UNPERM);
         else
             g_ptr->feat = feat_wall_solid;
         g_ptr->info &= ~(CAVE_MASK);

--- a/src/grid/grid.h
+++ b/src/grid/grid.h
@@ -179,7 +179,7 @@ extern void lite_spot(player_type *player_ptr, POSITION y, POSITION x);
 extern void update_flow(player_type *subject_ptr);
 extern byte grid_cost(grid_type *g_ptr, monster_race *r_ptr);
 extern byte grid_dist(grid_type *g_ptr, monster_race *r_ptr);
-extern FEAT_IDX feat_state(player_type *player_ptr, FEAT_IDX feat, int action);
+extern FEAT_IDX feat_state(floor_type *floor_ptr, FEAT_IDX feat, int action);
 extern void cave_alter_feat(player_type *player_ptr, POSITION y, POSITION x, int action);
 extern void remove_mirror(player_type *caster_ptr, POSITION y, POSITION x);
 extern bool is_open(player_type *player_ptr, FEAT_IDX feat);

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -181,7 +181,7 @@ static bool process_door(player_type *target_ptr, turn_flags *turn_flags_ptr, mo
         return TRUE;
 
     if (turn_flags_ptr->did_bash_door
-        && ((randint0(100) < 50) || (feat_state(target_ptr, g_ptr->feat, FF_OPEN) == g_ptr->feat) || has_flag(f_ptr->flags, FF_GLASS))) {
+        && ((randint0(100) < 50) || (feat_state(target_ptr->current_floor_ptr, g_ptr->feat, FF_OPEN) == g_ptr->feat) || has_flag(f_ptr->flags, FF_GLASS))) {
         cave_alter_feat(target_ptr, ny, nx, FF_BASH);
         if (!monster_is_valid(m_ptr)) {
             target_ptr->update |= (PU_FLOW);

--- a/src/spell-kind/spells-grid.cpp
+++ b/src/spell-kind/spells-grid.cpp
@@ -133,11 +133,11 @@ void stair_creation(player_type *caster_ptr)
     dest_sf_ptr = get_sf_ptr(dest_floor_id);
     if (up) {
         cave_set_feat(caster_ptr, caster_ptr->y, caster_ptr->x,
-            (dest_sf_ptr->last_visit && (dest_sf_ptr->dun_level <= floor_ptr->dun_level - 2)) ? feat_state(caster_ptr, feat_up_stair, FF_SHAFT)
+            (dest_sf_ptr->last_visit && (dest_sf_ptr->dun_level <= floor_ptr->dun_level - 2)) ? feat_state(caster_ptr->current_floor_ptr, feat_up_stair, FF_SHAFT)
                                                                                               : feat_up_stair);
     } else {
         cave_set_feat(caster_ptr, caster_ptr->y, caster_ptr->x,
-            (dest_sf_ptr->last_visit && (dest_sf_ptr->dun_level >= floor_ptr->dun_level + 2)) ? feat_state(caster_ptr, feat_down_stair, FF_SHAFT)
+            (dest_sf_ptr->last_visit && (dest_sf_ptr->dun_level >= floor_ptr->dun_level + 2)) ? feat_state(caster_ptr->current_floor_ptr, feat_down_stair, FF_SHAFT)
                                                                                               : feat_down_stair);
     }
 

--- a/src/spell-realm/spells-chaos.cpp
+++ b/src/spell-realm/spells-chaos.cpp
@@ -135,7 +135,7 @@ bool vanish_dungeon(player_type *caster_ptr)
         g_ptr->info &= ~(CAVE_ROOM | CAVE_ICKY);
 
         if (g_ptr->mimic && has_flag(f_ptr->flags, FF_HURT_DISI)) {
-            g_ptr->mimic = feat_state(caster_ptr, g_ptr->mimic, FF_HURT_DISI);
+            g_ptr->mimic = feat_state(caster_ptr->current_floor_ptr, g_ptr->mimic, FF_HURT_DISI);
             if (!has_flag(f_info[g_ptr->mimic].flags, FF_REMEMBER))
                 g_ptr->info &= ~(CAVE_MARK);
         }
@@ -145,7 +145,7 @@ bool vanish_dungeon(player_type *caster_ptr)
         g_ptr->info &= ~(CAVE_ROOM | CAVE_ICKY);
 
         if (g_ptr->mimic && has_flag(f_ptr->flags, FF_HURT_DISI)) {
-            g_ptr->mimic = feat_state(caster_ptr, g_ptr->mimic, FF_HURT_DISI);
+            g_ptr->mimic = feat_state(caster_ptr->current_floor_ptr, g_ptr->mimic, FF_HURT_DISI);
             if (!has_flag(f_info[g_ptr->mimic].flags, FF_REMEMBER))
                 g_ptr->info &= ~(CAVE_MARK);
         }
@@ -158,7 +158,7 @@ bool vanish_dungeon(player_type *caster_ptr)
         g_ptr->info &= ~(CAVE_ROOM | CAVE_ICKY);
 
         if (g_ptr->mimic && has_flag(f_ptr->flags, FF_HURT_DISI)) {
-            g_ptr->mimic = feat_state(caster_ptr, g_ptr->mimic, FF_HURT_DISI);
+            g_ptr->mimic = feat_state(caster_ptr->current_floor_ptr, g_ptr->mimic, FF_HURT_DISI);
             if (!has_flag(f_info[g_ptr->mimic].flags, FF_REMEMBER))
                 g_ptr->info &= ~(CAVE_MARK);
         }
@@ -168,7 +168,7 @@ bool vanish_dungeon(player_type *caster_ptr)
         g_ptr->info &= ~(CAVE_ROOM | CAVE_ICKY);
 
         if (g_ptr->mimic && has_flag(f_ptr->flags, FF_HURT_DISI)) {
-            g_ptr->mimic = feat_state(caster_ptr, g_ptr->mimic, FF_HURT_DISI);
+            g_ptr->mimic = feat_state(caster_ptr->current_floor_ptr, g_ptr->mimic, FF_HURT_DISI);
             if (!has_flag(f_info[g_ptr->mimic].flags, FF_REMEMBER))
                 g_ptr->info &= ~(CAVE_MARK);
         }


### PR DESCRIPTION
こういう所からチマチマplayer_type通しを削除していく。