### PR TITLE
[translation] For English prompts with get_check(), insert space, if it wasn't …

### DIFF
--- a/src/cmd-action/cmd-travel.cpp
+++ b/src/cmd-action/cmd-travel.cpp
@@ -139,7 +139,7 @@ static void travel_flow(player_type *creature_ptr, POSITION ty, POSITION tx)
 void do_cmd_travel(player_type *creature_ptr)
 {
     POSITION x, y;
-    if (travel.x != 0 && travel.y != 0 && get_check(_("トラベルを継続しますか？", "Do you continue to travel?"))) {
+    if (travel.x != 0 && travel.y != 0 && get_check(_("トラベルを継続しますか？", "Do you continue to travel? "))) {
         y = travel.y;
         x = travel.x;
     } else if (!tgt_pt(creature_ptr, &x, &y))

--- a/src/cmd-item/cmd-equipment.cpp
+++ b/src/cmd-item/cmd-equipment.cpp
@@ -198,7 +198,7 @@ void do_cmd_wield(player_type *creature_ptr)
         char dummy[MAX_NLEN + 100];
         describe_flavor(creature_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
         sprintf(dummy,
-            _("%sを装備すると吸血鬼になります。よろしいですか？", "%s will transform you into a vampire permanently when equipped. Do you become a vampire?"),
+            _("%sを装備すると吸血鬼になります。よろしいですか？", "%s will transform you into a vampire permanently when equipped. Do you become a vampire? "),
             o_name);
 
         if (!get_check(dummy))

--- a/src/cmd-item/cmd-magiceat.cpp
+++ b/src/cmd-item/cmd-magiceat.cpp
@@ -454,7 +454,7 @@ static OBJECT_SUBTYPE_VALUE select_magic_eater(player_type *creature_ptr, bool o
 				char tmp_val[160];
 
 				/* Prompt */
-				(void) strnfmt(tmp_val, 78, _("%sを使いますか？ ", "Use %s?"), k_info[lookup_kind(tval ,i)].name.c_str());
+				(void) strnfmt(tmp_val, 78, _("%sを使いますか？ ", "Use %s? "), k_info[lookup_kind(tval ,i)].name.c_str());
 
 				/* Belay that order */
 				if (!get_check(tmp_val)) continue;

--- a/src/market/building-quest.cpp
+++ b/src/market/building-quest.cpp
@@ -100,7 +100,7 @@ void castle_quest(player_type *player_ptr)
 
         put_str(_("このクエストは放棄することができます。", "You can give up this quest."), 12, 0);
 
-        if (!get_check(_("二度と受けられなくなりますが放棄しますか？", "Are you sure to give up this quest?")))
+        if (!get_check(_("二度と受けられなくなりますが放棄しますか？", "Are you sure to give up this quest? ")))
             return;
 
         clear_bldg(4, 18);

--- a/src/specific-object/muramasa.cpp
+++ b/src/specific-object/muramasa.cpp
@@ -11,7 +11,7 @@ bool activate_muramasa(player_type *user_ptr, object_type *o_ptr)
     if (o_ptr->name1 != ART_MURAMASA)
         return FALSE;
 
-    if (!get_check(_("本当に使いますか？", "Are you sure?!")))
+    if (!get_check(_("本当に使いますか？", "Are you sure?! ")))
         return TRUE;
 
     msg_print(_("村正が震えた．．．", "The Muramasa pulsates..."));

--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -53,7 +53,7 @@ static std::optional<PRICE> prompt_to_buy(player_type *player_ptr, object_type *
     msg_print(NULL);
 
     price_ask *= o_ptr->number;
-    concptr s = format(_("買値 $%ld で買いますか？", "Do you buy for $%ld?"), static_cast<long>(price_ask));
+    concptr s = format(_("買値 $%ld で買いますか？", "Do you buy for $%ld? "), static_cast<long>(price_ask));
     if (get_check_strict(player_ptr, s, CHECK_DEFAULT_Y)) {
         return price_ask;
     }

--- a/src/store/sell-order.cpp
+++ b/src/store/sell-order.cpp
@@ -68,7 +68,7 @@ static std::optional<PRICE> prompt_to_sell(player_type *player_ptr, object_type 
     }
 
     price_ask *= o_ptr->number;
-    concptr s = format(_("売値 $%ld で売りますか？", "Do you sell for $%ld?"), static_cast<long>(price_ask));
+    concptr s = format(_("売値 $%ld で売りますか？", "Do you sell for $%ld? "), static_cast<long>(price_ask));
     if (get_check_strict(player_ptr, s, CHECK_DEFAULT_Y)) {
         return price_ask;
     }

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -601,7 +601,7 @@ WishResult do_cmd_wishing(player_type *caster_ptr, int prob, bool allow_art, boo
         if (get_string(_("何をお望み？ ", "For what do you wish?"), buf, (MAX_NLEN - 1)))
             break;
         if (confirm) {
-            if (!get_check(_("何も願いません。本当によろしいですか？", "Do you wish nothing, really?")))
+            if (!get_check(_("何も願いません。本当によろしいですか？", "Do you wish nothing, really? ")))
                 continue;
         }
         return WishResult::NOTHING;


### PR DESCRIPTION
…already there, between the question mark and the expected values appended by get_check().  That's for readability and consistency with the large majority of the existing prompts.