### PR TITLE
[Fix] シンボルエディタで右端の移動がおかしい

### DIFF
--- a/src/io-dump/dump-util.cpp
+++ b/src/io-dump/dump-util.cpp
@@ -123,8 +123,8 @@ bool visual_mode_command(char ch, bool *visual_list_ptr,
 
 		*cur_attr_ptr = a;
 		*cur_char_ptr = c;
-		if ((ddx[d] < 0) && *char_left_ptr > MAX(0, (int)c - 10)) (*char_left_ptr)--;
-		if ((ddx[d] > 0) && *char_left_ptr + eff_width < MIN(0xff, (int)c + 10)) (*char_left_ptr)++;
+		if ((ddx[d] < 0) && *char_left_ptr > MAX(0, (unsigned char)c - 10)) (*char_left_ptr)--;
+		if ((ddx[d] > 0) && *char_left_ptr + eff_width < MIN(0xff, (unsigned char)c + 10)) (*char_left_ptr)++;
 		if ((ddy[d] < 0) && *attr_top_ptr > MAX(0, (int)(a & 0x7f) - 4)) (*attr_top_ptr)--;
 		if ((ddy[d] > 0) && *attr_top_ptr + height < MIN(0x7f, (a & 0x7f) + 4)) (*attr_top_ptr)++;
 

--- a/src/knowledge/knowledge-features.cpp
+++ b/src/knowledge/knowledge-features.cpp
@@ -64,7 +64,7 @@ static void display_feature_list(int col, int row, int per_page, FEAT_IDX *feat_
         c_prt(attr, f_ptr->name.c_str(), row_i, col);
         if (per_page == 1) {
             c_prt(attr, format("(%s)", lighting_level_str[lighting_level]), row_i, col + 1 + f_ptr->name.size());
-            c_prt(attr, format("%02x/%02x", f_ptr->x_attr[lighting_level], f_ptr->x_char[lighting_level]), row_i,
+            c_prt(attr, format("%02x/%02x", f_ptr->x_attr[lighting_level], (unsigned char)f_ptr->x_char[lighting_level]), row_i,
                 f_idx_col - ((current_world_ptr->wizard || visual_only) ? 6 : 2));
         }
         if (current_world_ptr->wizard || visual_only) {


### PR DESCRIPTION
地形等のシンボルエディタで、カーソルが豆腐(127)の位置を超えた時に処理がおかしくなっていた。
座標をcharで管理しているため、負になっていた。