### PR TITLE
[Fix] 魔法を防ぐクロークのsvalがクロークと同じだった

### DIFF
--- a/lib/edit/k_info.txt
+++ b/lib/edit/k_info.txt
@@ -6419,7 +6419,7 @@ F:SHOW_MODS | INSTA_ART
 N:672:魔法を防ぐクローク
 E:& Cloak~ of Magic Resistance
 G:(:s
-I:35:1:0
+I:35:4:0
 W:1:0:10:3
 A:20/4:50/4
 P:1:0d0:0:0:0


### PR DESCRIPTION
Issueなし。変更漏れだったもよう。