### PR TITLE
[Feature] 勝利済み職業とユニークを倒した時間を記録する #784 #18

### DIFF
--- a/src/birth/birth-select-class.cpp
+++ b/src/birth/birth-select-class.cpp
@@ -6,8 +6,20 @@
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 #include "util/int-char-converter.h"
+#include "world/world.h"
 
 static const char p2 = ')';
+
+static TERM_COLOR birth_class_color(int cs)
+{
+    if (cs < MAX_CLASS) {
+        if (is_retired_class(static_cast<player_class_type>(cs)))
+            return TERM_L_DARK;
+        if (is_winner_class(static_cast<player_class_type>(cs)))
+            return TERM_SLATE;
+    }
+    return TERM_WHITE;
+}
 
 static void enumerate_class_list(char *sym)
 {
@@ -26,7 +38,7 @@ static void enumerate_class_list(char *sym)
         else
             sprintf(buf, "%c%c%s", sym[n], p2, str);
 
-        put_str(buf, 13 + (n / 4), 2 + 19 * (n % 4));
+        c_put_str(birth_class_color(n), buf, 13 + (n / 4), 2 + 19 * (n % 4));
     }
 }
 
@@ -35,7 +47,7 @@ static void display_class_stat(int cs, int *os, char *cur, char *sym)
     if (cs == *os)
         return;
 
-    c_put_str(TERM_WHITE, cur, 13 + (*os / 4), 2 + 19 * (*os % 4));
+    c_put_str(birth_class_color(*os), cur, 13 + (*os / 4), 2 + 19 * (*os % 4));
     put_str("                                   ", 3, 40);
     if (cs == MAX_CLASS) {
         sprintf(cur, "%c%c%s", '*', p2, _("ランダム", "Random"));
@@ -108,9 +120,9 @@ static bool select_class(player_type *creature_ptr, char *cur, char *sym, int *k
             break;
 
         char buf[80];
-        sprintf(buf, _("職業を選んで下さい (%c-%c) ('='初期オプション設定): ", "Choose a class (%c-%c) ('=' for options): "), sym[0], sym[MAX_CLASS - 1]);
+        sprintf(buf, _("職業を選んで下さい (%c-%c) ('='初期オプション設定, 灰色:勝利済): ", "Choose a class (%c-%c) ('=' for options, Gray is winner): "), sym[0], sym[MAX_CLASS - 1]);
 
-        put_str(buf, 10, 10);
+        put_str(buf, 10, 6);
         char c = inkey();
         if (c == 'Q')
             birth_quit();

--- a/src/cmd-action/cmd-others.cpp
+++ b/src/cmd-action/cmd-others.cpp
@@ -172,11 +172,13 @@ void do_cmd_suicide(player_type *creature_ptr)
         string_free(creature_ptr->last_message);
 
     creature_ptr->last_message = NULL;
-    accept_winner_message(creature_ptr);
     creature_ptr->playing = FALSE;
     creature_ptr->is_dead = TRUE;
     creature_ptr->leaving = TRUE;
-    if (!current_world_ptr->total_winner) {
+    if (current_world_ptr->total_winner) {
+        accept_winner_message(creature_ptr);
+        add_retired_class(creature_ptr->pclass);
+    } else {
         play_music(TERM_XTRA_MUSIC_BASIC, MUSIC_BASIC_GAMEOVER);
         exe_write_diary(creature_ptr, DIARY_DESCRIPTION, 0, _("ダンジョンの探索に絶望して自殺した。", "gave up all hope to commit suicide."));
         exe_write_diary(creature_ptr, DIARY_GAMESTART, 1, _("-------- ゲームオーバー --------", "--------   Game  Over   --------"));

--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -105,7 +105,8 @@ void do_cmd_player_status(player_type *creature_ptr)
 			{
 				if (tmp[0] && (tmp[0] != ' '))
 				{
-					file_character(creature_ptr, tmp, update_playtime, display_player);
+					update_playtime();
+					file_character(creature_ptr, tmp, display_player);
 				}
 			}
 		}

--- a/src/core/game-closer.cpp
+++ b/src/core/game-closer.cpp
@@ -28,7 +28,7 @@ static void clear_floor(player_type *player_ptr)
 
 static void send_world_score_on_closing(player_type *player_ptr, bool do_send)
 {
-    if (send_world_score(player_ptr, do_send, update_playtime, display_player))
+    if (send_world_score(player_ptr, do_send, display_player))
         return;
 
     if (!get_check_strict(
@@ -93,6 +93,9 @@ void close_game(player_type *player_ptr)
         kingly(player_ptr);
 
     if (!cheat_save || get_check(_("死んだデータをセーブしますか？ ", "Save death? "))) {
+        update_playtime();
+        current_world_ptr->sf_play_time += current_world_ptr->play_time;
+
         if (!save_player(player_ptr, SAVE_TYPE_CLOSE_GAME))
             msg_print(_("セーブ失敗！", "death save failed!"));
     } else
@@ -100,7 +103,7 @@ void close_game(player_type *player_ptr)
 
     print_tomb(player_ptr);
     flush();
-    show_death_info(player_ptr, update_playtime, display_player);
+    show_death_info(player_ptr, display_player);
     term_clear();
     if (check_score(player_ptr)) {
         send_world_score_on_closing(player_ptr, do_send);

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -121,7 +121,7 @@ static void send_waiting_record(player_type *player_ptr)
 
     /* 町名消失バグ対策(#38205)のためここで世界マップ情報を読み出す */
     parse_fixed_map(player_ptr, "w_info.txt", 0, 0, current_world_ptr->max_wild_y, current_world_ptr->max_wild_x);
-    bool success = send_world_score(player_ptr, TRUE, update_playtime, display_player);
+    bool success = send_world_score(player_ptr, TRUE, display_player);
     if (!success && !get_check_strict(player_ptr, _("スコア登録を諦めますか？", "Do you give up score registration? "), CHECK_NO_HISTORY)) {
         prt(_("引き続き待機します。", "standing by for future registration..."), 0, 0);
         (void)inkey();

--- a/src/core/scores.cpp
+++ b/src/core/scores.cpp
@@ -438,7 +438,7 @@ void display_scores(int from, int to)
  * @return 転送が成功したらTRUEを返す
  * @todo プリプロが邪魔していて最初のif文を削除すると到達不能コードが発生する
  */
-bool send_world_score(player_type *current_player_ptr, bool do_send, void(*update_playtime)(void), display_player_pf display_player)
+bool send_world_score(player_type *current_player_ptr, bool do_send, display_player_pf display_player)
 {
 #ifdef WORLD_SCORE
 	if (send_score && do_send)
@@ -459,7 +459,7 @@ bool send_world_score(player_type *current_player_ptr, bool do_send, void(*updat
 		prt(_("送信中．．", "Sending..."), 0, 0);
 		term_fresh();
 		screen_save();
-		err = report_score(current_player_ptr, update_playtime, display_player);
+		err = report_score(current_player_ptr, display_player);
 		screen_load();
 		if (err) return FALSE;
 

--- a/src/core/scores.h
+++ b/src/core/scores.h
@@ -42,7 +42,7 @@ extern int highscore_fd;
 void display_scores_aux(int from, int to, int note, high_score *score);
 void display_scores(int from, int to);
 void kingly(player_type *winner_ptr);
-bool send_world_score(player_type *current_player_ptr, bool do_send, void(*update_playtime)(void), display_player_pf display_player);
+bool send_world_score(player_type *current_player_ptr, bool do_send, display_player_pf display_player);
 errr top_twenty(player_type *current_player_ptr);
 errr predict_score(player_type *current_player_ptr);
 void race_legends(player_type *current_player_ptr);

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -348,9 +348,16 @@ static void dump_aux_monsters(player_type *creature_ptr, FILE *fff)
     ang_sort(creature_ptr, who, &why, uniq_total, ang_sort_comp_hook, ang_sort_swap_hook);
     fprintf(fff, _("\n《上位%ld体のユニーク・モンスター》\n", "\n< Unique monsters top %ld >\n"), MIN(uniq_total, 10));
 
+    char buf[80];
     for (MONRACE_IDX k = uniq_total - 1; k >= 0 && k >= uniq_total - 10; k--) {
         monster_race *r_ptr = &r_info[who[k]];
-        fprintf(fff, _("  %-40s (レベル%3d)\n", "  %-40s (level %3d)\n"), r_ptr->name.c_str(), (int)r_ptr->level);
+        if (r_ptr->defeat_level && r_ptr->defeat_time)
+            sprintf(buf, _(" - レベル%2d - %d:%02d:%02d", " - level %2d - %d:%02d:%02d"), r_ptr->defeat_level, r_ptr->defeat_time / (60 * 60),
+                (r_ptr->defeat_time / 60) % 60, r_ptr->defeat_time % 60);
+        else
+            buf[0] = '\0';
+
+        fprintf(fff, _("  %-40s (レベル%3d)%s\n", "  %-40s (level %3d)%s\n"), r_ptr->name.c_str(), (int)r_ptr->level, buf);
     }
 
     C_KILL(who, max_r_idx, s16b);

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -568,12 +568,11 @@ static concptr get_check_sum(void)
  * @param fff ファイルポインタ
  * @return エラーコード
  */
-void make_character_dump(player_type *creature_ptr, FILE *fff, void (*update_playtime)(void), display_player_pf display_player)
+void make_character_dump(player_type *creature_ptr, FILE *fff, display_player_pf display_player)
 {
     char title[127];
     put_version(title);
     fprintf(fff, _("  [%s キャラクタ情報]\n\n", "  [%s Character Dump]\n\n"), title);
-    (*update_playtime)();
 
     dump_aux_player_status(creature_ptr, fff, display_player);
     dump_aux_last_message(creature_ptr, fff);

--- a/src/io-dump/character-dump.h
+++ b/src/io-dump/character-dump.h
@@ -3,4 +3,4 @@
 #include "system/angband.h"
 #include "io/files-util.h"
 
-void make_character_dump(player_type *creature_ptr, FILE *fff, void(*update_playtime)(void), display_player_pf display_player);
+void make_character_dump(player_type *creature_ptr, FILE *fff, display_player_pf display_player);

--- a/src/io/files-util.cpp
+++ b/src/io/files-util.cpp
@@ -55,7 +55,7 @@ char debug_savefile[1024];
  * Allow the "full" flag to dump additional info,
  * and trigger its usage from various places in the code.
  */
-errr file_character(player_type *creature_ptr, concptr name, update_playtime_pf update_playtime, display_player_pf display_player)
+errr file_character(player_type *creature_ptr, concptr name, display_player_pf display_player)
 {
     char buf[1024];
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, name);
@@ -78,7 +78,7 @@ errr file_character(player_type *creature_ptr, concptr name, update_playtime_pf 
         return -1;
     }
 
-    make_character_dump(creature_ptr, fff, update_playtime, display_player);
+    make_character_dump(creature_ptr, fff, display_player);
     angband_fclose(fff);
     msg_print(_("キャラクタ情報のファイルへの書き出しに成功しました。", "Character dump successful."));
     msg_print(NULL);

--- a/src/io/files-util.h
+++ b/src/io/files-util.h
@@ -24,7 +24,7 @@ extern concptr ANGBAND_DIR_XTRA;
 typedef void(*display_player_pf)(player_type*, int);
 typedef void(*update_playtime_pf)(void);
 
-extern errr file_character(player_type *creature_ptr, concptr name, update_playtime_pf update_playtime, display_player_pf display_player);
+extern errr file_character(player_type *creature_ptr, concptr name, display_player_pf display_player);
 extern errr get_rnd_line(concptr file_name, int entry, char *output);
 void read_dead_file(char* buf, size_t buf_size);
 

--- a/src/io/report.cpp
+++ b/src/io/report.cpp
@@ -233,7 +233,7 @@ static bool http_post(concptr url, BUF *buf)
  * @param dumpbuf 伝送内容バッファ
  * @return エラーコード
  */
-static errr make_dump(player_type *creature_ptr, BUF *dumpbuf, void (*update_playtime)(void), display_player_pf display_player)
+static errr make_dump(player_type *creature_ptr, BUF *dumpbuf, display_player_pf display_player)
 {
     char buf[1024];
     FILE *fff;
@@ -252,7 +252,7 @@ static errr make_dump(player_type *creature_ptr, BUF *dumpbuf, void (*update_pla
     }
 
     /* 一旦一時ファイルを作る。通常のダンプ出力と共通化するため。 */
-    make_character_dump(creature_ptr, fff, update_playtime, display_player);
+    make_character_dump(creature_ptr, fff, display_player);
     angband_fclose(fff);
 
     /* Open for read */
@@ -402,7 +402,7 @@ concptr make_screen_dump(player_type *creature_ptr)
  * @return 正常終了の時0、異常があったら1
  * @todo メッセージは言語選択の関数マクロで何とかならんか？
  */
-errr report_score(player_type *creature_ptr, void (*update_playtime)(void), display_player_pf display_player)
+errr report_score(player_type *creature_ptr, display_player_pf display_player)
 {
     BUF *score;
     score = buf_new();
@@ -440,7 +440,7 @@ errr report_score(player_type *creature_ptr, void (*update_playtime)(void), disp
     buf_sprintf(score, "killer: %s\n", creature_ptr->died_from);
     buf_sprintf(score, "-----charcter dump-----\n");
 
-    make_dump(creature_ptr, score, update_playtime, display_player);
+    make_dump(creature_ptr, score, display_player);
 
     if (screen_dump) {
         buf_sprintf(score, "-----screen shot-----\n");

--- a/src/io/report.h
+++ b/src/io/report.h
@@ -7,6 +7,6 @@ extern concptr screen_dump;
 #ifdef WORLD_SCORE
 #include "io/files-util.h"
 
-extern errr report_score(player_type *creature_ptr, void(*update_playtime)(void), display_player_pf display_player);
+extern errr report_score(player_type *creature_ptr, display_player_pf display_player);
 extern concptr make_screen_dump(player_type *creature_ptr);
 #endif

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -197,13 +197,20 @@ void do_cmd_knowledge_kill_count(player_type *creature_ptr)
     }
 
     u16b why = 2;
+    char buf[80];
     ang_sort(creature_ptr, who, &why, n, ang_sort_comp_hook, ang_sort_swap_hook);
     for (int k = 0; k < n; k++) {
         monster_race *r_ptr = &r_info[who[k]];
         if (any_bits(r_ptr->flags1, RF1_UNIQUE)) {
             bool dead = (r_ptr->max_num == 0);
             if (dead) {
-                fprintf(fff, "     %s\n", r_ptr->name.c_str());
+                if (r_ptr->defeat_level && r_ptr->defeat_time)
+                    sprintf(buf, _(" - レベル%2d - %d:%02d:%02d", " - level %2d - %d:%02d:%02d"), r_ptr->defeat_level, r_ptr->defeat_time / (60 * 60),
+                        (r_ptr->defeat_time / 60) % 60, r_ptr->defeat_time % 60);
+                else
+                    buf[0] = '\0';
+
+                fprintf(fff, "     %s%s\n", r_ptr->name.c_str(), buf);
                 total++;
             }
 

--- a/src/knowledge/knowledge-uniques.cpp
+++ b/src/knowledge/knowledge-uniques.cpp
@@ -108,9 +108,17 @@ static void display_uniques(unique_list_type *unique_list_ptr, FILE *fff)
         fputs(no_unique_desc, fff);
     }
 
+    char buf[80];
     for (int k = 0; k < unique_list_ptr->n; k++) {
         monster_race *r_ptr = &r_info[unique_list_ptr->who[k]];
-        fprintf(fff, _("     %s (レベル%d)\n", "     %s (level %d)\n"), r_ptr->name.c_str(), (int)r_ptr->level);
+
+        if (r_ptr->defeat_level && r_ptr->defeat_time)
+            sprintf(buf, _(" - レベル%2d - %d:%02d:%02d", " - level %2d - %d:%02d:%02d"), r_ptr->defeat_level, r_ptr->defeat_time / (60 * 60),
+                (r_ptr->defeat_time / 60) % 60, r_ptr->defeat_time % 60);
+        else
+            buf[0] = '\0';
+
+        fprintf(fff, _("     %s (レベル%d)%s\n", "     %s (level %d)%s\n"), r_ptr->name.c_str(), (int)r_ptr->level, buf);
     }
 }
 

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -84,18 +84,8 @@ static void rd_winner_class()
     if (loading_savefile_version_is_older_than(4))
         return;
 
-    s16b flag_size;
-    rd_s16b(&flag_size);
-    for (int i = 0; i < flag_size; i++) {
-        if (i == CLASS_FLAG_SIZE)
-            break;
-        rd_u32b(&current_world_ptr->sf_winner[i]);
-    }
-    for (int i = 0; i < flag_size; i++) {
-        if (i == CLASS_FLAG_SIZE)
-            break;
-        rd_u32b(&current_world_ptr->sf_retired[i]);
-    }
+    rd_FlagGroup(current_world_ptr->sf_winner, rd_byte);
+    rd_FlagGroup(current_world_ptr->sf_retired, rd_byte);
 }
 
 static void load_player_world(player_type *creature_ptr)

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -76,8 +76,31 @@ static errr load_town_quest(player_type *creature_ptr)
     return analyze_wilderness();
 }
 
+/*!
+ * @brief 勝利した職業フラグをロードする
+ */
+static void rd_winner_class()
+{
+    if (loading_savefile_version_is_older_than(4))
+        return;
+
+    s16b flag_size;
+    rd_s16b(&flag_size);
+    for (int i = 0; i < flag_size; i++) {
+        if (i == CLASS_FLAG_SIZE)
+            break;
+        rd_u32b(&current_world_ptr->sf_winner[i]);
+    }
+    for (int i = 0; i < flag_size; i++) {
+        if (i == CLASS_FLAG_SIZE)
+            break;
+        rd_u32b(&current_world_ptr->sf_retired[i]);
+    }
+}
+
 static void load_player_world(player_type *creature_ptr)
 {
+    rd_winner_class();
     rd_base_info(creature_ptr);
     rd_player_info(creature_ptr);
     rd_byte((byte *)&preserve_mode);

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -77,6 +77,17 @@ static errr load_town_quest(player_type *creature_ptr)
 }
 
 /*!
+ * @brief 合計のプレイ時間をロードする
+ */
+static void rd_total_play_time()
+{
+    if (loading_savefile_version_is_older_than(4))
+        return;
+
+    rd_u32b(&current_world_ptr->sf_play_time);
+}
+
+/*!
  * @brief 勝利した職業フラグをロードする
  */
 static void rd_winner_class()
@@ -90,6 +101,7 @@ static void rd_winner_class()
 
 static void load_player_world(player_type *creature_ptr)
 {
+    rd_total_play_time();
     rd_winner_class();
     rd_base_info(creature_ptr);
     rd_player_info(creature_ptr);

--- a/src/load/lore-loader.cpp
+++ b/src/load/lore-loader.cpp
@@ -84,6 +84,12 @@ void rd_lore(monster_race *r_ptr, MONRACE_IDX r_idx)
     r_ptr->max_num = (MONSTER_NUMBER)tmp8u;
 
     rd_s16b(&r_ptr->floor_id);
+
+    if (!loading_savefile_version_is_older_than(4)) {
+        rd_s16b(&r_ptr->defeat_level);
+        rd_u32b(&r_ptr->defeat_time);
+    }
+
     rd_byte(&tmp8u);
 
     r_ptr->r_flags1 &= r_ptr->flags1;

--- a/src/monster-floor/monster-death-util.h
+++ b/src/monster-floor/monster-death-util.h
@@ -1,9 +1,9 @@
-#pragma once
+﻿#pragma once
 
 #include "system/angband.h"
 
 typedef struct monster_type monster_type;
-typedef struct monster_race monster_race;
+struct monster_race;
 typedef struct monster_death_type {
     MONSTER_IDX m_idx;
     monster_type *m_ptr;

--- a/src/mspell/mspell-attack-util.h
+++ b/src/mspell/mspell-attack-util.h
@@ -16,7 +16,7 @@ enum mspell_lite_type {
 
 // Monster Spell Attack.
 typedef struct monster_type monster_type;
-typedef struct monster_race monster_race;
+struct monster_race;
 typedef struct msa_type {
     MONSTER_IDX m_idx;
     monster_type *m_ptr;

--- a/src/mspell/smart-mspell-util.h
+++ b/src/mspell/smart-mspell-util.h
@@ -7,7 +7,7 @@
 #include "util/flag-group.h"
 
 // Monster Spell Remover.
-typedef struct monster_race monster_race;
+struct monster_race;
 typedef struct msr_type {
     monster_race *r_ptr;
     EnumClassFlagGroup<RF_ABILITY> ability_flags;

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -389,6 +389,7 @@ int take_hit(player_type *creature_ptr, int damage_type, HIT_POINT damage, concp
 
             current_world_ptr->total_winner = FALSE;
             if (winning_seppuku) {
+                add_retired_class(creature_ptr->pclass);
                 exe_write_diary(creature_ptr, DIARY_DESCRIPTION, 0, _("勝利の後切腹した。", "committed seppuku after the winning."));
             } else {
                 char buf[20];

--- a/src/player/process-death.cpp
+++ b/src/player/process-death.cpp
@@ -353,7 +353,7 @@ static void show_dead_home_items(player_type *creature_ptr)
  * @param file_character ステータスダンプへのコールバック
  * @return なし
  */
-static void export_player_info(player_type *creature_ptr, update_playtime_pf update_playtime, display_player_pf display_player)
+static void export_player_info(player_type *creature_ptr, display_player_pf display_player)
 {
     prt(_("キャラクターの記録をファイルに書き出すことができます。", "You may now dump a character record to one or more files."), 21, 0);
     prt(_("リターンキーでキャラクターを見ます。ESCで中断します。", "Then, hit RETURN to see the character, or ESC to abort."), 22, 0);
@@ -367,7 +367,7 @@ static void export_player_info(player_type *creature_ptr, update_playtime_pf upd
             break;
 
         screen_save();
-        (void)file_character(creature_ptr, out_val, update_playtime, display_player);
+        (void)file_character(creature_ptr, out_val, display_player);
         screen_load();
     }
 }
@@ -376,7 +376,7 @@ static void export_player_info(player_type *creature_ptr, update_playtime_pf upd
  * @brief 自動的にプレイヤーステータスをファイルダンプ出力する
  * @return なし
  */
-static void file_character_auto(player_type *creature_ptr, update_playtime_pf update_playtime, display_player_pf display_player)
+static void file_character_auto(player_type *creature_ptr, display_player_pf display_player)
 {
     time_t now_t = time(NULL);
     struct tm *now_tm = localtime(&now_t);
@@ -388,20 +388,17 @@ static void file_character_auto(player_type *creature_ptr, update_playtime_pf up
     strnfmt(filename, sizeof(filename), "%s_Autodump_%s.txt", p_ptr->name, datetime);
 
     screen_save();
-    (void)file_character(creature_ptr, filename, update_playtime, display_player);
+    (void)file_character(creature_ptr, filename, display_player);
     screen_load();
 }
 
 /*!
  * @brief 死亡、引退時の簡易ステータス表示
  * @param creature_ptr プレーヤーへの参照ポインタ
- * @param handle_stuff 更新処理チェックへのコールバック
- * @param file_character ステータスダンプへのコールバック
- * @param update_playtime プレイ時間更新処理へのコールバック
  * @param display_player ステータス表示へのコールバック
  * @return なし
  */
-void show_death_info(player_type *creature_ptr, update_playtime_pf update_playtime, display_player_pf display_player)
+void show_death_info(player_type *creature_ptr, display_player_pf display_player)
 {
     inventory_aware(creature_ptr);
     home_aware(creature_ptr);
@@ -412,10 +409,9 @@ void show_death_info(player_type *creature_ptr, update_playtime_pf update_playti
     msg_erase();
 
     if (auto_dump)
-        file_character_auto(creature_ptr, update_playtime, display_player);
+        file_character_auto(creature_ptr, display_player);
 
-    export_player_info(creature_ptr, update_playtime, display_player);
-    (*update_playtime)();
+    export_player_info(creature_ptr, display_player);
     (*display_player)(creature_ptr, 0);
     prt(_("何かキーを押すとさらに情報が続きます (ESCで中断): ", "Hit any key to see more information (ESC to abort): "), 23, 0);
     if (inkey() == ESCAPE)

--- a/src/player/process-death.h
+++ b/src/player/process-death.h
@@ -1,7 +1,7 @@
-#pragma once
+﻿#pragma once
 
 #include "system/angband.h"
 #include "io/files-util.h"
 
 void print_tomb(player_type *dead_ptr);
-void show_death_info(player_type *creature_ptr, update_playtime_pf update_playtime, display_player_pf display_player);
+void show_death_info(player_type *creature_ptr, display_player_pf display_player);

--- a/src/save/monster-writer.cpp
+++ b/src/save/monster-writer.cpp
@@ -186,5 +186,8 @@ void wr_lore(MONRACE_IDX r_idx)
 
     wr_byte((byte)r_ptr->max_num);
     wr_s16b(r_ptr->floor_id);
+
+    wr_s16b(r_ptr->defeat_level);
+    wr_u32b(r_ptr->defeat_time);
     wr_byte(0);
 }

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -160,12 +160,8 @@ static bool wr_savefile_new(player_type *player_ptr, save_type type)
         wr_s16b(a_ptr->floor_id);
     }
 
-    wr_s16b(CLASS_FLAG_SIZE);
-    for (int i = 0; i < CLASS_FLAG_SIZE; i++)
-        wr_u32b(current_world_ptr->sf_winner[i]);
-
-    for (int i = 0; i < CLASS_FLAG_SIZE; i++)
-        wr_u32b(current_world_ptr->sf_retired[i]);
+    wr_FlagGroup(current_world_ptr->sf_winner, wr_byte);
+    wr_FlagGroup(current_world_ptr->sf_retired, wr_byte);
 
     wr_player(player_ptr);
     tmp16u = PY_MAX_LEVEL;

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -160,6 +160,13 @@ static bool wr_savefile_new(player_type *player_ptr, save_type type)
         wr_s16b(a_ptr->floor_id);
     }
 
+    wr_s16b(CLASS_FLAG_SIZE);
+    for (int i = 0; i < CLASS_FLAG_SIZE; i++)
+        wr_u32b(current_world_ptr->sf_winner[i]);
+
+    for (int i = 0; i < CLASS_FLAG_SIZE; i++)
+        wr_u32b(current_world_ptr->sf_retired[i]);
+
     wr_player(player_ptr);
     tmp16u = PY_MAX_LEVEL;
     wr_u16b(tmp16u);

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -160,6 +160,7 @@ static bool wr_savefile_new(player_type *player_ptr, save_type type)
         wr_s16b(a_ptr->floor_id);
     }
 
+    wr_u32b(current_world_ptr->sf_play_time);
     wr_FlagGroup(current_world_ptr->sf_winner, wr_byte);
     wr_FlagGroup(current_world_ptr->sf_retired, wr_byte);
 

--- a/src/system/angband-version.h
+++ b/src/system/angband-version.h
@@ -22,7 +22,7 @@
 /*!
  * @brief セーブファイルのバージョン(3.0.0から導入)
  */
-constexpr u32b SAVEFILE_VERSION = 3;
+constexpr u32b SAVEFILE_VERSION = 4;
 
 /*!
  * @brief バージョンが開発版が安定版かを返す(廃止予定)

--- a/src/system/monster-race-definition.h
+++ b/src/system/monster-race-definition.h
@@ -107,4 +107,6 @@ struct monster_race {
     u32b r_flags3{}; //!< Observed racial flags
     u32b r_flagsr{}; //!< 見た耐性フラグ / Observed racial resistance flags
     EnumClassFlagGroup<RF_ABILITY> r_ability_flags; //!< 見た能力フラグ(魔法/ブレス) / Observed racial ability flags
+    PLAYER_LEVEL defeat_level{}; //!< 倒したレベル(ユニーク用) / player level at which defeated this race
+    REAL_TIME defeat_time{}; //!< 倒した時間(ユニーク用) / time at which defeated this race
 };

--- a/src/system/monster-race-definition.h
+++ b/src/system/monster-race-definition.h
@@ -25,7 +25,9 @@ typedef struct monster_blow {
     DICE_SID d_side{};
 } monster_blow;
 
-/*
+/*!
+ * @brief モンスター種族の定義構造体
+ * @details
  * Monster "race" information, including racial memories
  *
  * Note that "d_attr" and "d_char" are used for MORE than "visual" stuff.
@@ -44,66 +46,65 @@ typedef struct monster_blow {
  * monster recall (no knowledge of spells, etc).  All of the "recall"
  * fields have a special prefix to aid in searching for them.
  */
-
-typedef struct monster_race {
-    std::string name; /*!< 名前データのオフセット(日本語) /  Name offset(Japanese) */
+struct monster_race {
+    std::string name; //!< 名前データのオフセット(日本語) /  Name offset(Japanese)
 #ifdef JP
-    std::string E_name; /*!< 名前データのオフセット(英語) /  Name offset(English) */
+    std::string E_name; //!< 名前データのオフセット(英語) /  Name offset(English)
 #endif
-    std::string text; /*!< 思い出テキストのオフセット / Lore text offset */
-    DICE_NUMBER hdice{}; /*!< HPのダイス数 / Creatures hit dice count */
-    DICE_SID hside{}; /*!< HPのダイス面数 / Creatures hit dice sides */
-    ARMOUR_CLASS ac{}; /*!< アーマークラス / Armour Class */
-    SLEEP_DEGREE sleep{}; /*!< 睡眠値 / Inactive counter (base) */
-    POSITION aaf{}; /*!< 感知範囲(1-100スクエア) / Area affect radius (1-100) */
-    SPEED speed{}; /*!< 加速(110で+0) / Speed (normally 110) */
-    EXP mexp{}; /*!< 殺害時基本経験値 / Exp value for kill */
-    BIT_FLAGS16 extra{}; /*!< 未使用 /  Unused (for now) */
-    RARITY freq_spell{}; /*!< 魔法＆特殊能力仕様頻度(1/n) /  Spell frequency */
-    BIT_FLAGS flags1{}; /* Flags 1 (general) */
-    BIT_FLAGS flags2{}; /* Flags 2 (abilities) */
-    BIT_FLAGS flags3{}; /* Flags 3 (race/resist) */
-    BIT_FLAGS flags7{}; /* Flags 7 (movement related abilities) */
-    BIT_FLAGS flags8{}; /* Flags 8 (wilderness info) */
-    BIT_FLAGS flags9{}; /* Flags 9 (drops info) */
-    BIT_FLAGS flagsr{}; /* Flags R (resistances info) */
-    EnumClassFlagGroup<RF_ABILITY> ability_flags; /* Ability Flags */
-    monster_blow blow[MAX_NUM_BLOWS]{}; /* Up to four blows per round */
-    MONRACE_IDX reinforce_id[6]{};
-    DICE_NUMBER reinforce_dd[6]{};
-    DICE_SID reinforce_ds[6]{};
-    ARTIFACT_IDX artifact_id[4]{}; /* 特定アーティファクトドロップID */
-    RARITY artifact_rarity[4]{}; /* 特定アーティファクトレア度 */
-    PERCENTAGE artifact_percent[4]{}; /* 特定アーティファクトドロップ率 */
-    PERCENTAGE arena_ratio{}; /* モンスター闘技場の掛け金倍率修正値(%基準 / 0=100%) / The adjustment ratio for gambling monster */
-    MONRACE_IDX next_r_idx{};
-    EXP next_exp{};
-    DEPTH level{}; /* Level of creature */
-    RARITY rarity{}; /* Rarity of creature */
-    TERM_COLOR d_attr{}; /* Default monster attribute */
-    SYMBOL_CODE d_char{}; /* Default monster character */
-    TERM_COLOR x_attr{}; /* Desired monster attribute */
-    SYMBOL_CODE x_char{}; /* Desired monster character */
-    MONSTER_NUMBER max_num{}; /* Maximum population allowed per level */
-    MONSTER_NUMBER cur_num{}; /* Monster population on current level */
-    FLOOR_IDX floor_id{}; /* Location of unique monster */
-    MONSTER_NUMBER r_sights{}; /* Count sightings of this monster */
-    MONSTER_NUMBER r_deaths{}; /* Count deaths from this monster */
-    MONSTER_NUMBER r_pkills{}; /* Count visible monsters killed in this life */
-    MONSTER_NUMBER r_akills{}; /* Count all monsters killed in this life */
-    MONSTER_NUMBER r_tkills{}; /* Count monsters killed in all lives */
-    byte r_wake{}; /* Number of times woken up (?) */
-    byte r_ignore{}; /* Number of times ignored (?) */
+    std::string text; //!< 思い出テキストのオフセット / Lore text offset
+    DICE_NUMBER hdice{}; //!< HPのダイス数 / Creatures hit dice count
+    DICE_SID hside{}; //!< HPのダイス面数 / Creatures hit dice sides
+    ARMOUR_CLASS ac{}; //!< アーマークラス / Armour Class
+    SLEEP_DEGREE sleep{}; //!< 睡眠値 / Inactive counter (base)
+    POSITION aaf{}; //!< 感知範囲(1-100スクエア) / Area affect radius (1-100)
+    SPEED speed{}; //!< 加速(110で+0) / Speed (normally 110)
+    EXP mexp{}; //!< 殺害時基本経験値 / Exp value for kill
+    BIT_FLAGS16 extra{}; //!< 未使用 /  Unused (for now)
+    RARITY freq_spell{}; //!< 魔法＆特殊能力仕様頻度(1/n) /  Spell frequency
+    BIT_FLAGS flags1{}; //!< Flags 1 (general)
+    BIT_FLAGS flags2{}; //!< Flags 2 (abilities)
+    BIT_FLAGS flags3{}; //!< Flags 3 (race/resist)
+    BIT_FLAGS flags7{}; //!< Flags 7 (movement related abilities)
+    BIT_FLAGS flags8{}; //!< Flags 8 (wilderness info)
+    BIT_FLAGS flags9{}; //!< Flags 9 (drops info)
+    BIT_FLAGS flagsr{}; //!< 耐性フラグ / Flags R (resistances info)
+    EnumClassFlagGroup<RF_ABILITY> ability_flags; //!< 能力フラグ(魔法/ブレス) / Ability Flags
+    monster_blow blow[MAX_NUM_BLOWS]{}; //!< 打撃能力定義 / Up to four blows per round
+    MONRACE_IDX reinforce_id[6]{}; //!< 指定護衛モンスター種族ID(6種まで)
+    DICE_NUMBER reinforce_dd[6]{}; //!< 指定護衛数ダイス数
+    DICE_SID reinforce_ds[6]{}; //!< 指定護衛数ダイス面
+    ARTIFACT_IDX artifact_id[4]{}; //!< 特定アーティファクトドロップID
+    RARITY artifact_rarity[4]{}; //!< 特定アーティファクトレア度
+    PERCENTAGE artifact_percent[4]{}; //!< 特定アーティファクトドロップ率
+    PERCENTAGE arena_ratio{}; //!< モンスター闘技場の掛け金倍率修正値(%基準 / 0=100%) / The adjustment ratio for gambling monster
+    MONRACE_IDX next_r_idx{}; //!< 進化先モンスター種族ID
+    EXP next_exp{}; //!< 進化に必要な経験値
+    DEPTH level{}; //!< レベル / Level of creature
+    RARITY rarity{}; //!< レアリティ / Rarity of creature
+    TERM_COLOR d_attr{}; //!< デフォルトの表示色 / Default monster attribute
+    SYMBOL_CODE d_char{}; //!< デフォルトの表示文字 / Default monster character
+    TERM_COLOR x_attr{}; //!< 設定した表示色(またはタイル位置Y) / Desired monster attribute
+    SYMBOL_CODE x_char{}; //!< 設定した表示文字(またはタイル位置X) / Desired monster character
+    MONSTER_NUMBER max_num{}; //!< 階に最大存在できる数 / Maximum population allowed per level
+    MONSTER_NUMBER cur_num{}; //!< 階に現在いる数 / Monster population on current level
+    FLOOR_IDX floor_id{}; //!< 存在している保存階ID /  Location of unique monster
+    MONSTER_NUMBER r_sights{}; //!< 見えている数 / Count sightings of this monster
+    MONSTER_NUMBER r_deaths{}; //!< このモンスターに殺された人数 / Count deaths from this monster
+    MONSTER_NUMBER r_pkills{}; //!< このゲームで倒すのを見た数 / Count visible monsters killed in this life
+    MONSTER_NUMBER r_akills{}; //!< このゲームで倒した数 / Count all monsters killed in this life
+    MONSTER_NUMBER r_tkills{}; //!< 全ゲームで倒した数 / Count monsters killed in all lives
+    byte r_wake{}; //!< @に気づいて起きた数 / Number of times woken up (?)
+    byte r_ignore{}; //!< @に気づいていない数 / Number of times ignored (?)
 #define MR1_EVOLUTION 0x01
-    byte r_xtra1{}; /* Something */
-    byte r_xtra2{}; /* Something (unused) */
-    ITEM_NUMBER r_drop_gold{}; /*!< これまでに撃破時に落とした財宝の数 / Max number of gold dropped at once */
-    ITEM_NUMBER r_drop_item{}; /*!< これまでに撃破時に落としたアイテムの数 / Max number of item dropped at once */
-    byte r_cast_spell{}; /* Max number of other spells seen */
-    byte r_blows[MAX_NUM_BLOWS]{}; /* Number of times each blow type was seen */
-    u32b r_flags1{}; /* Observed racial flags */
-    u32b r_flags2{}; /* Observed racial flags */
-    u32b r_flags3{}; /* Observed racial flags */
-    u32b r_flagsr{}; /* Observed racial resistance flags */
-    EnumClassFlagGroup<RF_ABILITY> r_ability_flags; /* Observed racial ability flags */
-} monster_race;
+    byte r_xtra1{}; //!< 特殊な思い出フラグ(進化) / Something
+    byte r_xtra2{}; //!< 未使用 / Something (unused)
+    ITEM_NUMBER r_drop_gold{}; //!< これまでに撃破時に落とした財宝の数 / Max number of gold dropped at once
+    ITEM_NUMBER r_drop_item{}; //!< これまでに撃破時に落としたアイテムの数 / Max number of item dropped at once
+    byte r_cast_spell{}; //!< 使った魔法/ブレスの種類数 /  Max unique number of spells seen
+    byte r_blows[MAX_NUM_BLOWS]{}; //!< 受けた打撃 /  Number of times each blow type was seen
+    u32b r_flags1{}; //!< Observed racial flags
+    u32b r_flags2{}; //!< Observed racial flags
+    u32b r_flags3{}; //!< Observed racial flags
+    u32b r_flagsr{}; //!< 見た耐性フラグ / Observed racial resistance flags
+    EnumClassFlagGroup<RF_ABILITY> r_ability_flags; //!< 見た能力フラグ(魔法/ブレス) / Observed racial ability flags
+};

--- a/src/system/monster-type-definition.h
+++ b/src/system/monster-type-definition.h
@@ -13,7 +13,7 @@
  * of objects (if any) being carried by the monster (see above).
  */
 typedef struct floor_type floor_type;
-typedef struct monster_race monster_race;
+struct monster_race;
 typedef struct monster_type {
 	MONRACE_IDX r_idx{};		/*!< モンスターの実種族ID (これが0の時は死亡扱いになる) / Monster race index 0 = dead. */
 	MONRACE_IDX ap_r_idx{};	/*!< モンスターの外見種族ID（あやしい影、たぬき、ジュラル星人誤認などにより変化する）Monster race appearance index */

--- a/src/world/world.cpp
+++ b/src/world/world.cpp
@@ -1,5 +1,6 @@
 ﻿#include "world/world.h"
 #include "player/player-race-types.h"
+#include "util/bit-flags-calculator.h"
 
 world_type world;
 world_type *current_world_ptr = &world;
@@ -57,4 +58,42 @@ void update_playtime(void)
         current_world_ptr->play_time += (tmp - current_world_ptr->start_time);
         current_world_ptr->start_time = tmp;
     }
+}
+
+/*!
+ * @brief 勝利したクラスを追加する
+ */
+void add_winner_class(player_class_type c)
+{
+    if (!current_world_ptr->noscore)
+	    add_flag(current_world_ptr->sf_winner, c);
+}
+
+/*!
+ * @brief 引退したクラスを追加する
+ */
+void add_retired_class(player_class_type c)
+{
+    if (!current_world_ptr->noscore)
+        add_flag(current_world_ptr->sf_retired, c);
+}
+
+/*!
+ * @brief 勝利したクラスか判定する
+ */
+bool is_winner_class(player_class_type c)
+{
+    if (c == MAX_CLASS)
+        return false;
+    return has_flag(current_world_ptr->sf_winner, c);
+}
+
+/*!
+ * @brief 引退したクラスか判定する
+ */
+bool is_retired_class(player_class_type c)
+{
+    if (c == MAX_CLASS)
+        return false;
+    return has_flag(current_world_ptr->sf_retired, c);
 }

--- a/src/world/world.cpp
+++ b/src/world/world.cpp
@@ -66,7 +66,7 @@ void update_playtime(void)
 void add_winner_class(player_class_type c)
 {
     if (!current_world_ptr->noscore)
-	    add_flag(current_world_ptr->sf_winner, c);
+        current_world_ptr->sf_winner.set(c);
 }
 
 /*!
@@ -75,7 +75,7 @@ void add_winner_class(player_class_type c)
 void add_retired_class(player_class_type c)
 {
     if (!current_world_ptr->noscore)
-        add_flag(current_world_ptr->sf_retired, c);
+        current_world_ptr->sf_retired.set(c);
 }
 
 /*!
@@ -85,7 +85,7 @@ bool is_winner_class(player_class_type c)
 {
     if (c == MAX_CLASS)
         return false;
-    return has_flag(current_world_ptr->sf_winner, c);
+    return current_world_ptr->sf_winner.has(c);
 }
 
 /*!
@@ -95,5 +95,5 @@ bool is_retired_class(player_class_type c)
 {
     if (c == MAX_CLASS)
         return false;
-    return has_flag(current_world_ptr->sf_retired, c);
+    return current_world_ptr->sf_retired.has(c);
 }

--- a/src/world/world.h
+++ b/src/world/world.h
@@ -3,6 +3,7 @@
 #include "system/angband.h"
 
 #define MAX_BOUNTY 20
+#define CLASS_FLAG_SIZE 1 + MAX_CLASS / 32
 
 /*!
  * @brief 世界情報構造体
@@ -43,6 +44,8 @@ struct world_type {
     u32b sf_when; //!< 作成日時 / Created Date
     u16b sf_lives; //!< このセーブファイルで何人プレイしたか / Number of past "lives" with this file
     u16b sf_saves; //!< 現在のプレイで何回セーブしたか / Number of "saves" during this life
+    BIT_FLAGS sf_winner[CLASS_FLAG_SIZE];
+    BIT_FLAGS sf_retired[CLASS_FLAG_SIZE];
 
     bool character_generated; /* The character exists */
     bool character_dungeon; /* The character has a dungeon */
@@ -68,3 +71,7 @@ extern world_type *current_world_ptr;
 bool is_daytime(void);
 void extract_day_hour_min(player_type *player_ptr, int *day, int *hour, int *min);
 void update_playtime(void);
+void add_winner_class(player_class_type c);
+void add_retired_class(player_class_type c);
+bool is_winner_class(player_class_type c);
+bool is_retired_class(player_class_type c);

--- a/src/world/world.h
+++ b/src/world/world.h
@@ -3,67 +3,65 @@
 #include "system/angband.h"
 
 #define MAX_BOUNTY 20
-#define CLASS_FLAG_SIZE 1 + MAX_CLASS / 32
 
 /*!
  * @brief 世界情報構造体
  */
 struct world_type {
 
-    POSITION max_wild_x; /*!< Maximum size of the wilderness */
-    POSITION max_wild_y; /*!< Maximum size of the wilderness */
-    GAME_TURN game_turn; /*!< 画面表示上のゲーム時間基準となるターン / Current game turn */
-    GAME_TURN game_turn_limit; /*!< game_turnの最大値 / Limit of game_turn */
-    GAME_TURN dungeon_turn; /*!< NASTY生成の計算に関わる内部ターン値 / Game turn in dungeon */
-    GAME_TURN dungeon_turn_limit; /*!< dungeon_turnの最大値 / Limit of game_turn in dungeon */
-    GAME_TURN arena_start_turn; /*!< 闘技場賭博の開始ターン値 */
-    u32b start_time;
-    u16b noscore; /* Cheating flags */
-    u16b total_winner; /* Total winner */
+    POSITION max_wild_x{}; /*!< Maximum size of the wilderness */
+    POSITION max_wild_y{}; /*!< Maximum size of the wilderness */
+    GAME_TURN game_turn{}; /*!< 画面表示上のゲーム時間基準となるターン / Current game turn */
+    GAME_TURN game_turn_limit{}; /*!< game_turnの最大値 / Limit of game_turn */
+    GAME_TURN dungeon_turn{}; /*!< NASTY生成の計算に関わる内部ターン値 / Game turn in dungeon */
+    GAME_TURN dungeon_turn_limit{}; /*!< dungeon_turnの最大値 / Limit of game_turn in dungeon */
+    GAME_TURN arena_start_turn{}; /*!< 闘技場賭博の開始ターン値 */
+    u32b start_time{};
+    u16b noscore{}; /* Cheating flags */
+    u16b total_winner{}; /* Total winner */
 
-    MONSTER_IDX timewalk_m_idx; /*!< 現在時間停止を行っているモンスターのID */
+    MONSTER_IDX timewalk_m_idx{}; /*!< 現在時間停止を行っているモンスターのID */
 
-    MONRACE_IDX bounty_r_idx[MAX_BOUNTY];
-    MONSTER_IDX today_mon; //!< 実際の日替わり賞金首
+    MONRACE_IDX bounty_r_idx[MAX_BOUNTY]{};
+    MONSTER_IDX today_mon{}; //!< 実際の日替わり賞金首
 
-    u32b play_time; /*!< 実プレイ時間 */
+    u32b play_time{}; /*!< 実プレイ時間 */
 
-    u32b seed_flavor; /* Hack -- consistent object colors */
-    u32b seed_town; /* Hack -- consistent town layout */
+    u32b seed_flavor{}; /* Hack -- consistent object colors */
+    u32b seed_town{}; /* Hack -- consistent town layout */
 
-    bool is_loading_now; /*!< ロード処理中フラグ...ロード直後にcalc_bonus()時の徳変化、及びsanity_blast()による異常を抑止する */
+    bool is_loading_now{}; /*!< ロード処理中フラグ...ロード直後にcalc_bonus()時の徳変化、及びsanity_blast()による異常を抑止する */
 
-    byte h_ver_major; //!< 変愚蛮怒バージョン(メジャー番号) / Hengband version (major ver.)
-    byte h_ver_minor; //!< 変愚蛮怒バージョン(マイナー番号) / Hengband version (minor ver.)
-    byte h_ver_patch; //!< 変愚蛮怒バージョン(パッチ番号) / Hengband version (patch ver.)
-    byte h_ver_extra; //!< 変愚蛮怒バージョン(エクストラ番号) / Hengband version (extra ver.)
+    byte h_ver_major{}; //!< 変愚蛮怒バージョン(メジャー番号) / Hengband version (major ver.)
+    byte h_ver_minor{}; //!< 変愚蛮怒バージョン(マイナー番号) / Hengband version (minor ver.)
+    byte h_ver_patch{}; //!< 変愚蛮怒バージョン(パッチ番号) / Hengband version (patch ver.)
+    byte h_ver_extra{}; //!< 変愚蛮怒バージョン(エクストラ番号) / Hengband version (extra ver.)
 
-    byte sf_extra; //!< セーブファイルエンコードキー(XOR)
+    byte sf_extra{}; //!< セーブファイルエンコードキー(XOR)
 
-    u32b sf_system; //!< OS情報 / OS information
-    u32b sf_when; //!< 作成日時 / Created Date
-    u16b sf_lives; //!< このセーブファイルで何人プレイしたか / Number of past "lives" with this file
-    u16b sf_saves; //!< 現在のプレイで何回セーブしたか / Number of "saves" during this life
-    BIT_FLAGS sf_winner[CLASS_FLAG_SIZE];
-    BIT_FLAGS sf_retired[CLASS_FLAG_SIZE];
+    u32b sf_system{}; //!< OS情報 / OS information
+    u32b sf_when{}; //!< 作成日時 / Created Date
+    u16b sf_lives{}; //!< このセーブファイルで何人プレイしたか / Number of past "lives" with this file
+    u16b sf_saves{}; //!< 現在のプレイで何回セーブしたか / Number of "saves" during this life
+    FlagGroup<player_class_type, MAX_CLASS> sf_winner{};
+    FlagGroup<player_class_type, MAX_CLASS> sf_retired{};
 
-    bool character_generated; /* The character exists */
-    bool character_dungeon; /* The character has a dungeon */
-    bool character_loaded; /* The character was loaded from a savefile */
-    bool character_saved; /* The character was just saved to a savefile */
+    bool character_generated{}; /* The character exists */
+    bool character_dungeon{}; /* The character has a dungeon */
+    bool character_loaded{}; /* The character was loaded from a savefile */
+    bool character_saved{}; /* The character was just saved to a savefile */
 
-    byte character_icky_depth; /* The game is in an icky full screen mode */
-    bool character_xtra; /* The game is in an icky startup mode */
+    byte character_icky_depth{}; /* The game is in an icky full screen mode */
+    bool character_xtra{}; /* The game is in an icky startup mode */
 
-    bool creating_savefile; /* New savefile is currently created */
+    bool creating_savefile{}; /* New savefile is currently created */
 
-    bool wizard; /* This world under wizard mode */
+    bool wizard{}; /* This world under wizard mode */
 
-    OBJECT_IDX max_o_idx; /*!< Maximum number of objects in the level */
-    MONSTER_IDX max_m_idx; /*!< Maximum number of monsters in the level */
+    OBJECT_IDX max_o_idx{}; /*!< Maximum number of objects in the level */
+    MONSTER_IDX max_m_idx{}; /*!< Maximum number of monsters in the level */
 
-    DUNGEON_IDX max_d_idx;
-
+    DUNGEON_IDX max_d_idx{};
 };
 
 extern world_type *current_world_ptr;

--- a/src/world/world.h
+++ b/src/world/world.h
@@ -43,8 +43,9 @@ struct world_type {
     u32b sf_when{}; //!< 作成日時 / Created Date
     u16b sf_lives{}; //!< このセーブファイルで何人プレイしたか / Number of past "lives" with this file
     u16b sf_saves{}; //!< 現在のプレイで何回セーブしたか / Number of "saves" during this life
-    FlagGroup<player_class_type, MAX_CLASS> sf_winner{};
-    FlagGroup<player_class_type, MAX_CLASS> sf_retired{};
+    u32b sf_play_time{}; //!< このセーブファイルで遊んだ合計のプレイ時間
+    FlagGroup<player_class_type, MAX_CLASS> sf_winner{}; //!< このセーブファイルで*勝利*した職業
+    FlagGroup<player_class_type, MAX_CLASS> sf_retired{}; //!< このセーブファイルで引退した職業
 
     bool character_generated{}; /* The character exists */
     bool character_dungeon{}; /* The character has a dungeon */


### PR DESCRIPTION
**注意！**
このブランチを適用するとセーブデータバージョンが3から4に上がります。
テストの際はセーブデータをバックアップするなど対応をお願いします。

-----

ユニークを倒したレベルと時間を記録してダンプ等にも出す。
勝利した職業をマークして職業選択時の色を変える(勝利したけど引退せず死亡も微妙に色が違う)