### PR TITLE
[Fix] サブウィンドウサイズの高さが足りない場合に装備/持ち物一覧で落ちる #840

### DIFF
--- a/src/view/display-inventory.cpp
+++ b/src/view/display-inventory.cpp
@@ -168,7 +168,7 @@ void display_inventory(player_type *owner_ptr, tval_type tval)
             attr = TERM_L_DARK;
         }
 
-        if (do_disp && show_item_graph) {
+        if (show_item_graph) {
             TERM_COLOR a = object_attr(o_ptr);
             SYMBOL_CODE c = object_char(o_ptr);
             term_queue_bigchar(cur_col, i, a, c, 0, 0);

--- a/src/view/display-inventory.cpp
+++ b/src/view/display-inventory.cpp
@@ -138,6 +138,7 @@ void display_inventory(player_type *owner_ptr, tval_type tval)
         return;
 
     term_get_size(&wid, &hgt);
+
     for (i = 0; i < INVEN_PACK; i++) {
         auto o_ptr = &owner_ptr->inventory_list[i];
         if (!o_ptr->k_idx)
@@ -146,6 +147,9 @@ void display_inventory(player_type *owner_ptr, tval_type tval)
     }
 
     for (i = 0; i < z; i++) {
+        if (i >= hgt)
+            break;
+
         auto o_ptr = &owner_ptr->inventory_list[i];
         auto do_disp = item_tester_okay(owner_ptr, o_ptr, tval);
         strcpy(tmp_val, "   ");

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -258,7 +258,7 @@ static void display_equipment(player_type *owner_ptr, tval_type tval)
         if (o_ptr->timeout)
             attr = TERM_L_DARK;
 
-        if (do_disp && show_item_graph) {
+        if (show_item_graph) {
             TERM_COLOR a = object_attr(o_ptr);
             SYMBOL_CODE c = object_char(o_ptr);
             term_queue_bigchar(cur_col, cur_row, a, c, 0, 0);

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -228,6 +228,10 @@ static void display_equipment(player_type *owner_ptr, tval_type tval)
     char tmp_val[80];
     GAME_TEXT o_name[MAX_NLEN];
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+        int cur_row = i - INVEN_MAIN_HAND;
+        if (cur_row >= hgt)
+            break;
+
         auto o_ptr = &owner_ptr->inventory_list[i];
         auto do_disp = owner_ptr->select_ring_slot ? is_ring_slot(i) : item_tester_okay(owner_ptr, o_ptr, tval);
         strcpy(tmp_val, "   ");
@@ -237,7 +241,6 @@ static void display_equipment(player_type *owner_ptr, tval_type tval)
             tmp_val[1] = ')';
         }
 
-        int cur_row = i - INVEN_MAIN_HAND;
         int cur_col = 3;
         term_erase(cur_col, cur_row, 255);
         term_putstr(0, cur_row, cur_col, TERM_WHITE, tmp_val);


### PR DESCRIPTION
サブウィンドウのサイズが十分であれば、落ちることはない。

合わせて、サブウィンドウの装備/持ち物一覧で選択時に選択不能のアイテムでシンボルが消えて表示位置がずれるのを修正。