### PR TITLE
[Feature] easy_floor有効時にも財宝($)を拾う時にSOUND_SELL効果音を鳴らす

### DIFF
--- a/src/inventory/player-inventory.cpp
+++ b/src/inventory/player-inventory.cpp
@@ -95,6 +95,7 @@ void py_pickup_floor(player_type *owner_ptr, bool pickup)
         disturb(owner_ptr, FALSE, FALSE);
         if (o_ptr->tval == TV_GOLD) {
             msg_format(_(" $%ld の価値がある%sを見つけた。", "You have found %ld gold pieces worth of %s."), (long)o_ptr->pval, o_name);
+            sound(SOUND_SELL);
             owner_ptr->au += o_ptr->pval;
             owner_ptr->redraw |= (PR_GOLD);
             owner_ptr->window_flags |= (PW_PLAYER);


### PR DESCRIPTION
easy_floor有効時の拾う処理に効果音が含まれていなかったため追加した。