### PR TITLE
[modify] GCCのバグを回避するため初期化リストの型を明示

### DIFF
--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -165,7 +165,7 @@ bool do_cmd_attack(player_type *attacker_ptr, POSITION y, POSITION x, combat_opt
     monster_race *r_ptr = &r_info[m_ptr->r_idx];
     GAME_TEXT m_name[MAX_NLEN];
 
-    const auto mutation_attack_methods = {MUTA::HORNS, MUTA::BEAK, MUTA::SCOR_TAIL, MUTA::TRUNK, MUTA::TENTACLES};
+    const std::initializer_list<MUTA> mutation_attack_methods = { MUTA::HORNS, MUTA::BEAK, MUTA::SCOR_TAIL, MUTA::TRUNK, MUTA::TENTACLES };
 
     disturb(attacker_ptr, FALSE, TRUE);
 


### PR DESCRIPTION
GCC バージョン8以前には、初期化リストの型推論時に要素の型に不要にconstを
付けてしまうというバグがあるため、GCC 8以前でコンパイルするとエラーとなる。
これを避けるために初期化リストの型を明示する。

Issue無し。