### PR TITLE
[Fix] α19新規追加要素の修正(善良スレイ説明文、価格設定) #846

### DIFF
--- a/lib/edit/k_info.txt
+++ b/lib/edit/k_info.txt
@@ -6420,7 +6420,7 @@ N:672:魔法を防ぐクローク
 E:& Cloak~ of Magic Resistance
 G:(:s
 I:35:4:0
-W:1:0:10:3
+W:1:0:10:2500
 A:20/4:50/4
 P:1:0d0:0:0:0
 F:RES_CURSE

--- a/src/perception/identification.cpp
+++ b/src/perception/identification.cpp
@@ -318,7 +318,7 @@ bool screen_object(player_type *player_ptr, object_type *o_ptr, BIT_FLAGS mode)
         info[i++] = _("それは善良なる存在にとっての天敵である。", "It is a great bane of good monsters.");
     }
 
-    if (has_flag(flgs, TR_SLAY_EVIL)) {
+    if (has_flag(flgs, TR_SLAY_GOOD)) {
         info[i++] = _("それは善良なる存在に対して邪悪なる力で攻撃する。", "It fights against good with evil fury.");
     }
 


### PR DESCRIPTION
\*鑑定\*時に邪悪スレイがあると善良スレイの説明を表示し、善良スレイがあるときには出ていなかった。
魔法を防ぐクロークの価格設定がクロークのままだった。