### PR TITLE
[Linux/Unix] Include vector in player-race.h

### DIFF
--- a/src/player/player-race.h
+++ b/src/player/player-race.h
@@ -3,6 +3,7 @@
 #include "system/angband.h"
 #include "object-enchant/tr-types.h"
 #include <unordered_map>
+#include <vector>
 #include <optional>
 
 /*


### PR DESCRIPTION
That avoids a compiler error when not using precompiled headers.