### PR TITLE
[Fix] @param と @details の綴りミス置換.

### DIFF
--- a/src/birth/birth-wizard.cpp
+++ b/src/birth/birth-wizard.cpp
@@ -477,7 +477,7 @@ static bool display_auto_roller_result(player_type *creature_ptr, bool prev, cha
  * @brief オートロールを回して結果を表示し、その数値に決めるかさらに回すか確認する。
  * @param creature_ptr プレーヤーへの参照ポインタ
  * @param chara_limit 社会的地位の要求水準
- * @detail 2つめの結果以降は、'p'キーで1つ前のロール結果に戻せる。
+ * @details 2つめの結果以降は、'p'キーで1つ前のロール結果に戻せる。
  */
 static bool display_auto_roller(player_type *creature_ptr, chara_limit_type chara_limit)
 {

--- a/src/core/hp-mp-processor.cpp
+++ b/src/core/hp-mp-processor.cpp
@@ -34,12 +34,12 @@
 
 /*!
  * @brief 地形によるダメージを与える / Deal damage from feature.
- * @params creature_ptr プレイヤー情報への参照ポインタ
- * @params g_ptr 現在の床の情報への参照ポインタ
- * @params msg_levitation 浮遊時にダメージを受けた場合に表示するメッセージ
- * @params msg_normal 通常時にダメージを受けた場合に表示するメッセージの述部
- * @params 耐性等によるダメージレートを計算する関数
- * @patams ダメージを受けた際の追加処理を行う関数
+ * @param creature_ptr プレイヤー情報への参照ポインタ
+ * @param g_ptr 現在の床の情報への参照ポインタ
+ * @param msg_levitation 浮遊時にダメージを受けた場合に表示するメッセージ
+ * @param msg_normal 通常時にダメージを受けた場合に表示するメッセージの述部
+ * @param 耐性等によるダメージレートを計算する関数
+ * @param ダメージを受けた際の追加処理を行う関数
  * @return ダメージを与えたらTRUE、なければFALSE
  * @details
  * ダメージを受けた場合、自然回復できない。

--- a/src/effect/effect-monster-psi.cpp
+++ b/src/effect/effect-monster-psi.cpp
@@ -40,7 +40,7 @@ static bool resisted_psi_because_empty_mind(player_type *caster_ptr, effect_mons
  * @brief 異質な精神のモンスター及び強力なモンスターのPsi攻撃に対する耐性を発動する
  * @param em_ptr モンスター効果への参照ポインタ
  * @return 耐性を発動した場合TRUE、そうでなければFALSE
- * @detail
+ * @details
  * 以下のいずれかの場合は耐性がある
  * 1) STUPIDまたはWIERD_MINDである
  * 2) ANIMALである
@@ -63,7 +63,7 @@ static bool resisted_psi_because_weird_mind_or_powerful(effect_monster_type *em_
  * @param caster_ptr プレイヤーへの参照ポインタ
  * @param em_ptr モンスター効果への参照ポインタ
  * @return ダメージ反射を発動した場合TRUE、そうでなければFALSE
- * @detail
+ * @details
  * 以下の条件を満たす場合に 1/2 の確率でダメージ反射する
  * 1) UNDEADまたはDEMONである
  * 2) レベルが詠唱者の レベル/2 より大きい
@@ -86,7 +86,7 @@ static bool reflects_psi_with_currupted_mind(player_type *caster_ptr, effect_mon
  * @param caster_ptr プレイヤーへの参照ポインタ
  * @param em_ptr モンスター効果への参照ポインタ
  * @return なし
- * @detail
+ * @details
  * 効果は、混乱、朦朧、恐怖、麻痺
  * 3/4の確率または影分身時はダメージ及び追加効果はない。
  */
@@ -123,7 +123,7 @@ static void effect_monster_psi_reflect_extra_effect(player_type *caster_ptr, eff
  * @param caster_ptr プレイヤーへの参照ポインタ
  * @param em_ptr モンスター効果への参照ポインタ
  * @return なし
- * @detail
+ * @details
  * 耐性を発動した精神の堕落したモンスターは効力を跳ね返すことがある。
  */
 static void effect_monster_psi_resist(player_type *caster_ptr, effect_monster_type *em_ptr)
@@ -154,7 +154,7 @@ static void effect_monster_psi_resist(player_type *caster_ptr, effect_monster_ty
  * @param caster_ptr プレイヤーへの参照ポインタ
  * @param em_ptr モンスター効果への参照ポインタ
  * @return なし
- * @detail
+ * @details
  * 効果は、混乱、朦朧、恐怖、麻痺(各耐性無効)
  * ダメージがないか3/4の確率で効果なし
  */
@@ -185,7 +185,7 @@ static void effect_monster_psi_extra_effect(effect_monster_type *em_ptr)
  * @param caster_ptr プレイヤーへの参照ポインタ
  * @param em_ptr モンスター効果への参照ポインタ
  * @return PROICESS_CONTINUE
- * @detail
+ * @details
  * 視界による影響を発動する。
  * モンスターの耐性とそれに不随した効果を発動する。
  */
@@ -212,7 +212,7 @@ process_result effect_monster_psi(player_type *caster_ptr, effect_monster_type *
  * @param caster_ptr プレイヤーへの参照ポインタ
  * @param em_ptr モンスター効果への参照ポインタ
  * @return なし
- * @detail
+ * @details
  * 耐性を発動した精神の堕落したモンスターは効力を跳ね返すことがある。
  */
 static void effect_monster_psi_drain_resist(player_type *caster_ptr, effect_monster_type *em_ptr)
@@ -273,7 +273,7 @@ static void effect_monster_psi_drain_change_power(player_type *caster_ptr, effec
  * @param caster_ptr プレイヤーへの参照ポインタ
  * @param em_ptr モンスター効果への参照ポインタ
  * @return PROICESS_CONTINUE
- * @detail
+ * @details
  * ダメージがないか3/4の確率で追加効果なし
  */
 process_result effect_monster_psi_drain(player_type *caster_ptr, effect_monster_type *em_ptr)
@@ -294,7 +294,7 @@ process_result effect_monster_psi_drain(player_type *caster_ptr, effect_monster_
  * @param caster_ptr プレイヤーへの参照ポインタ
  * @param em_ptr モンスター効果への参照ポインタ
  * @return PROICESS_CONTINUE
- * @detail
+ * @details
  * 朦朧＋ショートテレポートアウェイ
  */
 process_result effect_monster_telekinesis(player_type *caster_ptr, effect_monster_type *em_ptr)

--- a/src/effect/effect-monster-resist-hurt.cpp
+++ b/src/effect/effect-monster-resist-hurt.cpp
@@ -575,7 +575,7 @@ process_result effect_monster_icee_bolt(player_type *caster_ptr, effect_monster_
  * @param caster_ptr プレイヤー情報への参照ポインタ
  * @em_ptr 魔法効果情報への参照ポインタ
  * @return 効果処理を続けるかどうか
- * @detail
+ * @details
  * 量子生物に倍打、壁抜けに1.5倍打、テレポート耐性が耐性
  */
 process_result effect_monster_void(player_type* caster_ptr, effect_monster_type* em_ptr)
@@ -619,7 +619,7 @@ process_result effect_monster_void(player_type* caster_ptr, effect_monster_type*
  * @param caster_ptr プレイヤー情報への参照ポインタ
  * @em_ptr 魔法効果情報への参照ポインタ
  * @return 効果処理を続けるかどうか
- * @detail
+ * @details
  * 飛ばないテレポート耐性に1.25倍打、暗黒耐性が耐性
  * 1/3で追加に混乱か恐怖
  */

--- a/src/effect/effect-monster-switcher.cpp
+++ b/src/effect/effect-monster-switcher.cpp
@@ -139,7 +139,7 @@ process_result effect_monster_hand_doom(effect_monster_type *em_ptr)
  * @brief 剣術「幻惑」の効果をモンスターに与える
  * @param caster_ptr プレイヤーの情報へのポインタ
  * @param effect_monster_type モンスターの効果情報へのポインタ
- * @detail
+ * @details
  * 精神のないモンスター、寝ているモンスターには無効。
  * 3回試行し、それぞれ2/5で失敗。
  * 寝た場合は試行終了。

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -148,7 +148,7 @@ void effect_player_plasma(player_type *target_ptr, effect_player_type *ep_ptr)
  * @param target_ptr プレイヤー情報への参照ポインタ
  * @param em_ptr プレイヤー効果情報への参照ポインタ
  * @return なし
- * @detail
+ * @details
  * 幽霊は回復する。追加効果で経験値吸収。
  */
 
@@ -181,7 +181,7 @@ void effect_player_nether(player_type *target_ptr, effect_player_type *ep_ptr)
  * @param target_ptr プレイヤー情報への参照ポインタ
  * @param em_ptr プレイヤー効果情報への参照ポインタ
  * @return なし
- * @detail
+ * @details
  * 追加効果で朦朧と混乱、冷気同様のインベントリ破壊。
  */
 void effect_player_water(player_type *target_ptr, effect_player_type *ep_ptr)

--- a/src/load/angband-version-comparer.cpp
+++ b/src/load/angband-version-comparer.cpp
@@ -41,7 +41,7 @@ bool h_older_than(byte major, byte minor, byte patch, byte extra)
  * @param minor マイナーバージョン値
  * @param patch パッチバージョン値
  * @return 現在のバージョンより値が古いならtrue
- * @detail
+ * @details
  * 旧バージョン比較の互換性のためにのみ保持。
  */
 bool h_older_than(byte major, byte minor, byte patch)

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -1054,7 +1054,7 @@ process_result effect_monster_elemental_genocide(player_type *caster_ptr, effect
  * @param realm 領域
  * @param lev プレイヤーレベル
  * @return 見合うならTRUE、そうでなければFALSE
- * @detail
+ * @details
  * レベルに応じて取得する耐性などの判定に使用する
  */
 bool has_element_resist(player_type *creature_ptr, ElementRealm realm, PLAYER_LEVEL lev)

--- a/src/monster-attack/monster-attack-switcher.cpp
+++ b/src/monster-attack/monster-attack-switcher.cpp
@@ -31,7 +31,7 @@
  * @param target_ptr プレーヤーへの参照ポインタ
  * @param monap_ptr モンスターからプレーヤーへの直接攻撃構造体への参照ポインタ
  * @return なし
- * @detail 減衰の計算式がpoisではなくnukeなのは仕様 (1/3では減衰が強すぎると判断したため)
+ * @details 減衰の計算式がpoisではなくnukeなのは仕様 (1/3では減衰が強すぎると判断したため)
  */
 static void calc_blow_poison(player_type *target_ptr, monap_type *monap_ptr)
 {

--- a/src/monster-floor/monster-summon.cpp
+++ b/src/monster-floor/monster-summon.cpp
@@ -90,7 +90,7 @@ static bool is_dead_summoning(summon_type type)
  * @brief 荒野のレベルを含めた階層レベルを返す
  * @param player_ptr プレーヤーへの参照ポインタ
  * @return 階層レベル
- * @detail
+ * @details
  * ダンジョン及びクエストはdun_level>0となる。
  * 荒野はdun_level==0なので、その場合荒野レベルを返す。
  */

--- a/src/player-info/race-ability-info.cpp
+++ b/src/player-info/race-ability-info.cpp
@@ -5,7 +5,7 @@
  * @brief レイシャルパワーの説明文を表示する
  * @param creature_ptr プレイヤー情報へのポインタ
  * @param self_ptr 自己分析情報へのポインタ
- * @detail
+ * @details
  *  使用可能レベル以上を条件とする。
  */
 void set_race_ability_info(player_type *creature_ptr, self_info_type *self_ptr)

--- a/src/player-status/player-basic-statistics.cpp
+++ b/src/player-status/player-basic-statistics.cpp
@@ -36,7 +36,7 @@ s16b PlayerBasicStatistics::get_value()
 
 /*!
  * @brief 基礎ステータス補正計算 - 種族
- * @params 計算するステータスの種類
+ * @param 計算するステータスの種類
  * @return ステータス補正値
  * @details
  * * 種族によるステータス修正値。
@@ -54,7 +54,7 @@ s16b PlayerBasicStatistics::race_value()
 
 /*!
  * @brief ステータス補正計算 - 職業
- * @params 計算するステータスの種類
+ * @param 計算するステータスの種類
  * @return ステータス補正値
  * @details
  * * 職業によるステータス修正値
@@ -67,7 +67,7 @@ s16b PlayerBasicStatistics::class_value()
 
 /*!
  * @brief ステータス補正計算 - 性格
- * @params 計算するステータスの種類
+ * @param 計算するステータスの種類
  * @return ステータス補正値
  * @details
  * * 性格によるステータス修正値
@@ -112,7 +112,7 @@ void PlayerBasicStatistics::update_top_status()
 
 /*!
  * @brief ステータス現在値更新の例外処理
- * @params 通常処理されたステータスの値
+ * @param 通常処理されたステータスの値
  * @returns 例外処理されたステータスの値
  * @details
  * * owner_ptrのステータス現在値を更新する際の例外処理

--- a/src/player-status/player-charisma.cpp
+++ b/src/player-status/player-charisma.cpp
@@ -108,7 +108,7 @@ BIT_FLAGS PlayerCharisma::get_bad_flags()
 
 /*!
  * @brief ステータス現在値更新の例外処理
- * @params 通常処理されたステータスの値
+ * @param 通常処理されたステータスの値
  * @returns 例外処理されたステータスの値
  * @details
  * * MUT3_ILL_NORMを保持しているときの例外処理。

--- a/src/player-status/player-status-base.cpp
+++ b/src/player-status/player-status-base.cpp
@@ -179,7 +179,7 @@ void PlayerStatusBase::set_locals()
 
 /*!
  * @brief 判定するflagを持つ装備品に対応するBIT_FLAGSを返す
- * @params check_flag 判定するtr_type
+ * @param check_flag 判定するtr_type
  * @return 判定結果のBIT_FLAGS
  */
 BIT_FLAGS PlayerStatusBase::equipments_flags(tr_type check_flag)
@@ -202,7 +202,7 @@ BIT_FLAGS PlayerStatusBase::equipments_flags(tr_type check_flag)
 
 /*!
  * @brief 判定するflagを持ち、pvalが負の装備品に対応するBIT_FLAGSを返す
- * @params check_flag 判定するtr_type
+ * @param check_flag 判定するtr_type
  * @return 判定結果のBIT_FLAGS
  */
 BIT_FLAGS PlayerStatusBase::equipments_bad_flags(tr_type check_flag)
@@ -290,7 +290,7 @@ s16b PlayerStatusBase::action_value()
 
 /*!
  * @brief 値を直接変更する例外処理。
- * @params value 単純加算された修正値の合計
+ * @param value 単純加算された修正値の合計
  * @details
  * * 派生クラスで必要とされる例外処理でoverrideされる
  * @return 直接変更された値。このままmin-max処理され最終的なvalueになる。

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -2043,7 +2043,7 @@ melee_type player_melee_type(player_type *creature_ptr)
  * @brief 利き手で攻撃可能かどうかを判定する
  *        利き手で攻撃可能とは、利き手に武器を持っているか、
  *        利き手が素手かつ左手も素手もしくは盾を装備している事を意味する。
- * @detail Includes martial arts and hand combats as weapons.
+ * @details Includes martial arts and hand combats as weapons.
  */
 bool can_attack_with_main_hand(player_type *creature_ptr)
 {
@@ -2059,7 +2059,7 @@ bool can_attack_with_main_hand(player_type *creature_ptr)
 /*
  * @brief 非利き手で攻撃可能かどうかを判定する
  *        非利き手で攻撃可能とは、非利き手に武器を持っている事に等しい
- * @detail Exclude martial arts and hand combats from weapons.
+ * @details Exclude martial arts and hand combats from weapons.
  */
 bool can_attack_with_sub_hand(player_type *creature_ptr)
 {
@@ -2115,7 +2115,7 @@ BIT_FLAGS has_lite(player_type *creature_ptr)
 
 /*
  * @brief 両手持ちボーナスがもらえないかどうかを判定する。 / Does *not * get two hand wielding bonus.
- * @detail
+ * @details
  *  Only can get hit bonuses when wieids an enough light weapon which is lighter than 5 times of weight limit.
  *  If its weight is 10 times heavier or more than weight limit, gets hit penalty in calc_to_hit().
  */

--- a/src/room/rooms-pit-nest.cpp
+++ b/src/room/rooms-pit-nest.cpp
@@ -646,7 +646,7 @@ bool build_type6(player_type *player_ptr, dun_data_type *dd_ptr)
 // clang-format off
 /*!
  * @brief 開門トラップのモンスター配置テーブル
- * @detail
+ * @details
  * 中央からの相対座標(X,Y)、モンスターの強さ
  */
 const int place_table_trapped_pit[TRAPPED_PIT_MONSTER_PLACE_MAX][3] = {

--- a/src/spell-kind/spells-detection.cpp
+++ b/src/spell-kind/spells-detection.cpp
@@ -76,7 +76,7 @@ static bool detect_feat_flag(player_type *caster_ptr, POSITION range, int flag, 
  * @param range 効果範囲
  * @param known 感知外範囲を超える警告フラグを立てる場合TRUEを返す
  * @return 効力があった場合TRUEを返す
- * @detail
+ * @details
  * 吟遊詩人による感知についてはFALSEを返す
  */
 bool detect_traps(player_type *caster_ptr, POSITION range, bool known)

--- a/src/spell-realm/spells-chaos.cpp
+++ b/src/spell-realm/spells-chaos.cpp
@@ -95,7 +95,7 @@ void call_the_void(player_type *caster_ptr)
  * @brief 虚無招来によるフロア中の全壁除去処理 /
  * Vanish all walls in this floor
  * @param caster_ptr プレーヤーへの参照ポインタ
- * @params caster_ptr 術者の参照ポインタ
+ * @param caster_ptr 術者の参照ポインタ
  * @return 実際に処理が反映された場合TRUE
  */
 bool vanish_dungeon(player_type *caster_ptr)

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -463,7 +463,7 @@ bool fishing(player_type *creature_ptr)
  * @param creature_ptr プレイヤー情報への参照ポインタ
  * @param o_ptr_ptr 脱ぐ装備品への参照ポインタのポインタ
  * @return 脱いだらTRUE、脱がなかったらFALSE
- * @detail
+ * @details
  * 脱いで落とした装備にtimeoutを設定するために装備品のアドレスを返す。
  */
 bool cosmic_cast_off(player_type *creature_ptr, object_type **o_ptr_ptr)

--- a/src/store/articles-on-sale.cpp
+++ b/src/store/articles-on-sale.cpp
@@ -17,7 +17,7 @@
 
 /*!
  * @brief 店舗で常時販売するオブジェクトを定義する 
- * @detail
+ * @details
  * 上から優先して配置する。
  * 重複して同じ商品を設定した場合、数量が増える。
  * 17エントリーまで設定可能。(最後は TV_NONE で止める)
@@ -111,7 +111,7 @@ store_stock_item_type store_regular_table[MAX_STORES][STORE_MAX_KEEP] =
 
 /*!
  * @brief 店舗でランダム販売するオブジェクトを定義する
- * @detail tval/svalのペア
+ * @details tval/svalのペア
  */
 store_stock_item_type store_table[MAX_STORES][STORE_CHOICES] =
 {

--- a/src/target/grid-selector.cpp
+++ b/src/target/grid-selector.cpp
@@ -107,7 +107,7 @@ std::unordered_map<int, std::function<bool(grid_type*)>> tgt_pt_symbol_call_back
 
 /*!
  * @brief 位置ターゲット指定情報構造体
- * @detail
+ * @details
  * ang_sort() を利用する関係上、y/x 座標それぞれについて配列を作る。
  */
 struct tgt_pt_info {

--- a/src/util/string-processor.cpp
+++ b/src/util/string-processor.cpp
@@ -506,7 +506,7 @@ char *rtrim(char *p)
  * @param s2 比較先文字列ポインタ
  * @param len 比較する長さ
  * @return 等しい場合は0、p1が大きい場合は-1、p2が大きい場合は1
- * @detail
+ * @details
  * strncmpの後方から比較する版
  */
 int strrncmp(const char *s1, const char *s2, int len)

--- a/src/view/display-lore.cpp
+++ b/src/view/display-lore.cpp
@@ -194,7 +194,7 @@ static void display_no_killed(lore_type *lore_ptr)
  * @brief 生存数制限のあるモンスターの最大生存数を表示する
  * @param lore_ptr モンスターの思い出構造体への参照ポインタ
  * @return なし
- * @detail
+ * @details
  * 一度も倒したことのないモンスターの情報は不明。
  */
 static void display_number_of_nazguls(lore_type *lore_ptr)

--- a/src/view/display-messages.cpp
+++ b/src/view/display-messages.cpp
@@ -53,7 +53,7 @@ s32b message_num(void)
 
 /*!
  * @brief 過去のゲームメッセージを返す。 / Recall the "text" of a saved message
- * @params age メッセージの世代
+ * @param age メッセージの世代
  * @return メッセージの文字列ポインタ
  */
 concptr message_str(int age)
@@ -69,7 +69,7 @@ concptr message_str(int age)
 
 /*!
  * @brief ゲームメッセージをログに追加する。 / Add a new message, with great efficiency
- * @params str 保存したいメッセージ
+ * @param str 保存したいメッセージ
  * @return なし
  */
 void message_add(concptr str)

--- a/src/wizard/cmd-wizard.cpp
+++ b/src/wizard/cmd-wizard.cpp
@@ -40,7 +40,7 @@
 
 /*!
  * @brief デバグコマンド一覧表
- * @detail
+ * @details
  * 空き: A,B,E,I,J,k,K,L,M,q,Q,R,T,U,V,W,y,Y
  */
 std::vector<std::vector<std::string>> debug_menu_table = {


### PR DESCRIPTION
多数ミスっててドキュメントに適用されないものが多数あったのでとにかく機械的に置換.