### PR TITLE
[feature] FlagGroupクラスを従来のenum型でも使えるようにする #856

### DIFF
--- a/src/blue-magic/blue-magic-checker.cpp
+++ b/src/blue-magic/blue-magic-checker.cpp
@@ -56,7 +56,7 @@ void learn_spell(player_type *learner_ptr, int monspell)
  * @return なし
  * @todo f4, f5, f6を構造体にまとめ直す
  */
-void set_rf_masks(FlagGroup<RF_ABILITY>& ability_flags, blue_magic_type mode)
+void set_rf_masks(EnumClassFlagGroup<RF_ABILITY> &ability_flags, blue_magic_type mode)
 {
     ability_flags.clear();
 

--- a/src/blue-magic/blue-magic-checker.h
+++ b/src/blue-magic/blue-magic-checker.h
@@ -6,7 +6,10 @@
 
 #include "system/angband.h"
 
+#include "monster-race/race-ability-flags.h"
+#include "util/flag-group.h"
+
 enum blue_magic_type : int;
 
 void learn_spell(player_type *learner_ptr, int monspell);
-void set_rf_masks(FlagGroup<RF_ABILITY>& ability_flags, blue_magic_type mode);
+void set_rf_masks(EnumClassFlagGroup<RF_ABILITY> &ability_flags, blue_magic_type mode);

--- a/src/blue-magic/learnt-power-getter.cpp
+++ b/src/blue-magic/learnt-power-getter.cpp
@@ -40,7 +40,7 @@ typedef struct learnt_magic_type {
     char choice;
     char out_val[160];
     char comment[80];
-    FlagGroup<RF_ABILITY> ability_flags;
+    EnumClassFlagGroup<RF_ABILITY> ability_flags;
     monster_power spell;
     int menu_line;
     bool flag;
@@ -179,7 +179,7 @@ static bool sweep_learnt_spells(player_type *caster_ptr, learnt_magic_type *lm_p
     set_rf_masks(lm_ptr->ability_flags, static_cast<blue_magic_type>(lm_ptr->mode));
 
     std::vector<RF_ABILITY> spells;
-    FlagGroup<RF_ABILITY>::get_flags(lm_ptr->ability_flags, std::back_inserter(spells));
+    EnumClassFlagGroup<RF_ABILITY>::get_flags(lm_ptr->ability_flags, std::back_inserter(spells));
     std::transform(spells.begin(), spells.end(), std::back_inserter(lm_ptr->blue_magics), [](RF_ABILITY ability) { return static_cast<int>(ability); });
     lm_ptr->count = lm_ptr->ability_flags.count();
 

--- a/src/dungeon/dungeon.h
+++ b/src/dungeon/dungeon.h
@@ -68,7 +68,7 @@ struct dungeon_type {
 	BIT_FLAGS mflags9{};
 	BIT_FLAGS mflagsr{};
 
-	FlagGroup<RF_ABILITY> m_ability_flags;
+	EnumClassFlagGroup<RF_ABILITY> m_ability_flags;
 
 	char r_char[5]{};		/* Monster race allowed */
 	KIND_OBJECT_IDX final_object{};	/* The object you'll find at the bottom */

--- a/src/info-reader/artifact-reader.cpp
+++ b/src/info-reader/artifact-reader.cpp
@@ -22,7 +22,7 @@ static errr grab_one_artifact_flag(artifact_type *a_ptr, concptr what)
         return 0;
     }
 
-    if (FlagGroup<TRG>::grab_one_flag(a_ptr->gen_flags, k_info_gen_flags, what))
+    if (EnumClassFlagGroup<TRG>::grab_one_flag(a_ptr->gen_flags, k_info_gen_flags, what))
         return 0;
 
     msg_format(_("未知の伝説のアイテム・フラグ '%s'。", "Unknown artifact flag '%s'."), what);

--- a/src/info-reader/dungeon-reader.cpp
+++ b/src/info-reader/dungeon-reader.cpp
@@ -69,7 +69,7 @@ static errr grab_one_basic_monster_flag(dungeon_type *d_ptr, concptr what)
  */
 static errr grab_one_spell_monster_flag(dungeon_type *d_ptr, concptr what)
 {
-    if (FlagGroup<RF_ABILITY>::grab_one_flag(d_ptr->m_ability_flags, r_info_ability_flags, what))
+    if (EnumClassFlagGroup<RF_ABILITY>::grab_one_flag(d_ptr->m_ability_flags, r_info_ability_flags, what))
         return 0;
 
     msg_format(_("未知のモンスター・フラグ '%s'。", "Unknown monster flag '%s'."), what);

--- a/src/info-reader/ego-reader.cpp
+++ b/src/info-reader/ego-reader.cpp
@@ -23,7 +23,7 @@ static bool grab_one_ego_item_flag(ego_item_type *e_ptr, concptr what)
         return 0;
     }
 
-    if (FlagGroup<TRG>::grab_one_flag(e_ptr->gen_flags, k_info_gen_flags, what))
+    if (EnumClassFlagGroup<TRG>::grab_one_flag(e_ptr->gen_flags, k_info_gen_flags, what))
         return 0;
 
     msg_format(_("未知の名のあるアイテム・フラグ '%s'。", "Unknown ego-item flag '%s'."), what);

--- a/src/info-reader/kind-reader.cpp
+++ b/src/info-reader/kind-reader.cpp
@@ -23,7 +23,7 @@ static errr grab_one_kind_flag(object_kind *k_ptr, concptr what)
         return 0;
     }
 
-    if (FlagGroup<TRG>::grab_one_flag(k_ptr->gen_flags, k_info_gen_flags, what))
+    if (EnumClassFlagGroup<TRG>::grab_one_flag(k_ptr->gen_flags, k_info_gen_flags, what))
         return 0;
 
     msg_format(_("未知のアイテム・フラグ '%s'。", "Unknown object flag '%s'."), what);

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -50,7 +50,7 @@ static errr grab_one_basic_flag(monster_race *r_ptr, concptr what)
  */
 static errr grab_one_spell_flag(monster_race *r_ptr, concptr what)
 {
-    if (FlagGroup<RF_ABILITY>::grab_one_flag(r_ptr->ability_flags, r_info_ability_flags, what))
+    if (EnumClassFlagGroup<RF_ABILITY>::grab_one_flag(r_ptr->ability_flags, r_info_ability_flags, what))
         return PARSE_ERROR_NONE;
 
     msg_format(_("未知のモンスター・フラグ '%s'。", "Unknown monster flag '%s'."), what);

--- a/src/io-dump/special-class-dump.cpp
+++ b/src/io-dump/special-class-dump.cpp
@@ -18,7 +18,7 @@
 #include <vector>
 
 typedef struct {
-    FlagGroup<RF_ABILITY> ability_flags;
+    EnumClassFlagGroup<RF_ABILITY> ability_flags;
 } learnt_spell_table;
 
 /*!
@@ -170,7 +170,7 @@ static void dump_blue_mage(player_type *creature_ptr, FILE *fff)
         add_monster_spell_type(p, col, static_cast<blue_magic_type>(spell_type), &learnt_magic);
 
         std::vector<RF_ABILITY> learnt_spells;
-        FlagGroup<RF_ABILITY>::get_flags(learnt_magic.ability_flags, std::back_inserter(learnt_spells));
+        EnumClassFlagGroup<RF_ABILITY>::get_flags(learnt_magic.ability_flags, std::back_inserter(learnt_spells));
 
         col++;
         bool pcol = FALSE;

--- a/src/lore/lore-util.h
+++ b/src/lore/lore-util.h
@@ -28,7 +28,7 @@ typedef struct lore_type {
     BIT_FLAGS flags1;
     BIT_FLAGS flags2;
     BIT_FLAGS flags3;
-    FlagGroup<RF_ABILITY> ability_flags;
+    EnumClassFlagGroup<RF_ABILITY> ability_flags;
 
     BIT_FLAGS flags7;
     BIT_FLAGS flagsr;

--- a/src/melee/melee-spell-flags-checker.cpp
+++ b/src/melee/melee-spell-flags-checker.cpp
@@ -298,7 +298,7 @@ static bool set_melee_spell_set(player_type *target_ptr, melee_spell_type *ms_pt
     if (ms_ptr->ability_flags.none())
         return FALSE;
 
-    FlagGroup<RF_ABILITY>::get_flags(ms_ptr->ability_flags, std::back_inserter(ms_ptr->spells));
+    EnumClassFlagGroup<RF_ABILITY>::get_flags(ms_ptr->ability_flags, std::back_inserter(ms_ptr->spells));
 
     return !ms_ptr->spells.empty() && target_ptr->playing && !target_ptr->is_dead && !target_ptr->leaving;
 }

--- a/src/melee/melee-spell-util.h
+++ b/src/melee/melee-spell-util.h
@@ -29,7 +29,7 @@ typedef struct melee_spell_type {
     bool pet;
     bool in_no_magic_dungeon;
     bool can_remember;
-    FlagGroup<RF_ABILITY> ability_flags;
+    EnumClassFlagGroup<RF_ABILITY> ability_flags;
 } melee_spell_type;
 
 melee_spell_type *initialize_melee_spell_type(player_type *target_ptr, melee_spell_type *ms_ptr, MONSTER_IDX m_idx);

--- a/src/monster-race/monster-race-hook.cpp
+++ b/src/monster-race/monster-race-hook.cpp
@@ -24,7 +24,7 @@ int vault_aux_race;
 char vault_aux_char;
 
 /*! ブレス属性に基づくドラゴンpit生成時条件マスク / Breath mask for "monster pit (dragon)" */
-FlagGroup<RF_ABILITY> vault_aux_dragon_mask4;
+EnumClassFlagGroup<RF_ABILITY> vault_aux_dragon_mask4;
 
 /*!
  * @brief pit/nestの基準となる単種モンスターを決める /

--- a/src/monster-race/monster-race-hook.h
+++ b/src/monster-race/monster-race-hook.h
@@ -2,9 +2,12 @@
 
 #include "system/angband.h"
 
+#include "monster-race/race-ability-flags.h"
+#include "util/flag-group.h"
+
 extern int vault_aux_race;
 extern char vault_aux_char;
-extern FlagGroup<RF_ABILITY> vault_aux_dragon_mask4;
+extern EnumClassFlagGroup<RF_ABILITY> vault_aux_dragon_mask4;
 
 bool mon_hook_quest(player_type *player_ptr, MONRACE_IDX r_idx);
 bool mon_hook_dungeon(player_type *player_ptr, MONRACE_IDX r_idx);

--- a/src/monster-race/race-ability-mask.cpp
+++ b/src/monster-race/race-ability-mask.cpp
@@ -2,7 +2,7 @@
 
 // clang-format off
 /* "summon" spells currently "summon" spells are included in "intelligent" and "indirect" */
-const FlagGroup<RF_ABILITY> RF_ABILITY_SUMMON_MASK = {
+const EnumClassFlagGroup<RF_ABILITY> RF_ABILITY_SUMMON_MASK = {
     RF_ABILITY::S_KIN, RF_ABILITY::S_CYBER, RF_ABILITY::S_MONSTER, RF_ABILITY::S_MONSTERS,
     RF_ABILITY::S_ANT, RF_ABILITY::S_SPIDER, RF_ABILITY::S_HOUND, RF_ABILITY::S_HYDRA,
     RF_ABILITY::S_ANGEL, RF_ABILITY::S_DEMON, RF_ABILITY::S_UNDEAD, RF_ABILITY::S_DRAGON,
@@ -10,8 +10,8 @@ const FlagGroup<RF_ABILITY> RF_ABILITY_SUMMON_MASK = {
 };
 
 /* Choose "intelligent" spells when desperate Including "summon" spells */
-const FlagGroup<RF_ABILITY> RF_ABILITY_INT_MASK =
-    FlagGroup<RF_ABILITY>(RF_ABILITY_SUMMON_MASK).set({
+const EnumClassFlagGroup<RF_ABILITY> RF_ABILITY_INT_MASK =
+    EnumClassFlagGroup<RF_ABILITY>(RF_ABILITY_SUMMON_MASK).set({
     RF_ABILITY::DISPEL, RF_ABILITY::HOLD, RF_ABILITY::SLOW, RF_ABILITY::CONF,
     RF_ABILITY::BLIND, RF_ABILITY::SCARE, RF_ABILITY::BLINK, RF_ABILITY::TPORT,
     RF_ABILITY::TELE_LEVEL, RF_ABILITY::TELE_AWAY, RF_ABILITY::HEAL, RF_ABILITY::INVULNER,
@@ -19,7 +19,7 @@ const FlagGroup<RF_ABILITY> RF_ABILITY_INT_MASK =
 });
 
 /* Spells that cannot be used while player riding on the monster */
-const FlagGroup<RF_ABILITY> RF_ABILITY_RIDING_MASK = {
+const EnumClassFlagGroup<RF_ABILITY> RF_ABILITY_RIDING_MASK = {
     RF_ABILITY::SHRIEK, RF_ABILITY::BLINK, RF_ABILITY::TPORT, RF_ABILITY::TRAPS,
     RF_ABILITY::DARKNESS, RF_ABILITY::SPECIAL,
 };
@@ -28,7 +28,7 @@ const FlagGroup<RF_ABILITY> RF_ABILITY_RIDING_MASK = {
  * "bolt" spells that may hurt fellow monsters
  * Currently "bolt" spells are included in "attack"
  */
-const FlagGroup<RF_ABILITY> RF_ABILITY_BOLT_MASK = {
+const EnumClassFlagGroup<RF_ABILITY> RF_ABILITY_BOLT_MASK = {
     RF_ABILITY::ROCKET, RF_ABILITY::SHOOT, RF_ABILITY::BO_ACID, RF_ABILITY::BO_ELEC,
     RF_ABILITY::BO_FIRE, RF_ABILITY::BO_COLD, RF_ABILITY::BO_NETH, RF_ABILITY::BO_WATE,
     RF_ABILITY::BO_MANA, RF_ABILITY::BO_PLAS, RF_ABILITY::BO_ICEE, RF_ABILITY::MISSILE,
@@ -38,7 +38,7 @@ const FlagGroup<RF_ABILITY> RF_ABILITY_BOLT_MASK = {
  * "beam" spells that may hurt fellow monsters
  * Currently "beam" spells are included in "attack"
  */
-const FlagGroup<RF_ABILITY> RF_ABILITY_BEAM_MASK = {
+const EnumClassFlagGroup<RF_ABILITY> RF_ABILITY_BEAM_MASK = {
     RF_ABILITY::PSY_SPEAR,
 };
 
@@ -46,7 +46,7 @@ const FlagGroup<RF_ABILITY> RF_ABILITY_BEAM_MASK = {
  * "ball" spells with radius 4 that may hurt friends
  * Currently "radius 4 ball" spells are included in "ball"
  */
-const FlagGroup<RF_ABILITY> RF_ABILITY_BIG_BALL_MASK = {
+const EnumClassFlagGroup<RF_ABILITY> RF_ABILITY_BIG_BALL_MASK = {
     RF_ABILITY::BA_CHAO, RF_ABILITY::BA_LITE, RF_ABILITY::BA_DARK, RF_ABILITY::BA_WATE,
     RF_ABILITY::BA_MANA,
 };
@@ -55,7 +55,7 @@ const FlagGroup<RF_ABILITY> RF_ABILITY_BIG_BALL_MASK = {
  * "breath" spells that may hurt friends
  * Currently "breath" spells are included in "ball" and "non-magic"
  */
-const FlagGroup<RF_ABILITY> RF_ABILITY_BREATH_MASK = {
+const EnumClassFlagGroup<RF_ABILITY> RF_ABILITY_BREATH_MASK = {
     RF_ABILITY::BR_ACID, RF_ABILITY::BR_ELEC, RF_ABILITY::BR_FIRE, RF_ABILITY::BR_COLD,
     RF_ABILITY::BR_POIS, RF_ABILITY::BR_NETH, RF_ABILITY::BR_LITE, RF_ABILITY::BR_DARK,
     RF_ABILITY::BR_CONF, RF_ABILITY::BR_SOUN, RF_ABILITY::BR_CHAO, RF_ABILITY::BR_DISE,
@@ -69,14 +69,14 @@ const FlagGroup<RF_ABILITY> RF_ABILITY_BREATH_MASK = {
  * Including "radius 4 ball" and "breath" spells
  * Currently "ball" spells are included in "attack"
  */
-const FlagGroup<RF_ABILITY> RF_ABILITY_BALL_MASK =
+const EnumClassFlagGroup<RF_ABILITY> RF_ABILITY_BALL_MASK =
     (RF_ABILITY_BIG_BALL_MASK | RF_ABILITY_BREATH_MASK).set({
     RF_ABILITY::ROCKET, RF_ABILITY::BA_NUKE, RF_ABILITY::BA_ACID, RF_ABILITY::BA_ELEC,
     RF_ABILITY::BA_FIRE, RF_ABILITY::BA_COLD, RF_ABILITY::BA_POIS, RF_ABILITY::BA_NETH,
 });
 
 /* "attack" spells including "bolt", "beam" and "ball" spells */
-const FlagGroup<RF_ABILITY> RF_ABILITY_ATTACK_MASK =
+const EnumClassFlagGroup<RF_ABILITY> RF_ABILITY_ATTACK_MASK =
     (RF_ABILITY_BOLT_MASK | RF_ABILITY_BEAM_MASK | RF_ABILITY_BALL_MASK).set({
     RF_ABILITY::DISPEL, RF_ABILITY::DRAIN_MANA, RF_ABILITY::MIND_BLAST, RF_ABILITY::BRAIN_SMASH,
     RF_ABILITY::CAUSE_1, RF_ABILITY::CAUSE_2, RF_ABILITY::CAUSE_3, RF_ABILITY::CAUSE_4,
@@ -86,14 +86,14 @@ const FlagGroup<RF_ABILITY> RF_ABILITY_ATTACK_MASK =
 });
 
 /* "indirect" spells Including "summon" spells */
-const FlagGroup<RF_ABILITY> RF_ABILITY_INDIRECT_MASK =
-    FlagGroup<RF_ABILITY>(RF_ABILITY_SUMMON_MASK).set({
+const EnumClassFlagGroup<RF_ABILITY> RF_ABILITY_INDIRECT_MASK =
+    EnumClassFlagGroup<RF_ABILITY>(RF_ABILITY_SUMMON_MASK).set({
     RF_ABILITY::SHRIEK, RF_ABILITY::HASTE, RF_ABILITY::HEAL, RF_ABILITY::INVULNER,
     RF_ABILITY::BLINK, RF_ABILITY::WORLD, RF_ABILITY::TPORT, RF_ABILITY::RAISE_DEAD,
 });
 
 /* "non-magic" spells including "breath" spells */
-const FlagGroup<RF_ABILITY> RF_ABILITY_NOMAGIC_MASK =
-    FlagGroup<RF_ABILITY>(RF_ABILITY_BREATH_MASK).set({
+const EnumClassFlagGroup<RF_ABILITY> RF_ABILITY_NOMAGIC_MASK =
+    EnumClassFlagGroup<RF_ABILITY>(RF_ABILITY_BREATH_MASK).set({
     RF_ABILITY::SHRIEK, RF_ABILITY::ROCKET, RF_ABILITY::SHOOT, RF_ABILITY::SPECIAL,
 });

--- a/src/monster-race/race-ability-mask.h
+++ b/src/monster-race/race-ability-mask.h
@@ -3,14 +3,14 @@
 #include "monster-race/race-ability-flags.h"
 #include "util/flag-group.h"
 
-extern const FlagGroup<RF_ABILITY> RF_ABILITY_SUMMON_MASK;
-extern const FlagGroup<RF_ABILITY> RF_ABILITY_INT_MASK;
-extern const FlagGroup<RF_ABILITY> RF_ABILITY_RIDING_MASK;
-extern const FlagGroup<RF_ABILITY> RF_ABILITY_BOLT_MASK;
-extern const FlagGroup<RF_ABILITY> RF_ABILITY_BEAM_MASK;
-extern const FlagGroup<RF_ABILITY> RF_ABILITY_BIG_BALL_MASK;
-extern const FlagGroup<RF_ABILITY> RF_ABILITY_BREATH_MASK;
-extern const FlagGroup<RF_ABILITY> RF_ABILITY_BALL_MASK;
-extern const FlagGroup<RF_ABILITY> RF_ABILITY_ATTACK_MASK;
-extern const FlagGroup<RF_ABILITY> RF_ABILITY_INDIRECT_MASK;
-extern const FlagGroup<RF_ABILITY> RF_ABILITY_NOMAGIC_MASK;
+extern const EnumClassFlagGroup<RF_ABILITY> RF_ABILITY_SUMMON_MASK;
+extern const EnumClassFlagGroup<RF_ABILITY> RF_ABILITY_INT_MASK;
+extern const EnumClassFlagGroup<RF_ABILITY> RF_ABILITY_RIDING_MASK;
+extern const EnumClassFlagGroup<RF_ABILITY> RF_ABILITY_BOLT_MASK;
+extern const EnumClassFlagGroup<RF_ABILITY> RF_ABILITY_BEAM_MASK;
+extern const EnumClassFlagGroup<RF_ABILITY> RF_ABILITY_BIG_BALL_MASK;
+extern const EnumClassFlagGroup<RF_ABILITY> RF_ABILITY_BREATH_MASK;
+extern const EnumClassFlagGroup<RF_ABILITY> RF_ABILITY_BALL_MASK;
+extern const EnumClassFlagGroup<RF_ABILITY> RF_ABILITY_ATTACK_MASK;
+extern const EnumClassFlagGroup<RF_ABILITY> RF_ABILITY_INDIRECT_MASK;
+extern const EnumClassFlagGroup<RF_ABILITY> RF_ABILITY_NOMAGIC_MASK;

--- a/src/monster/monster-processor-util.h
+++ b/src/monster/monster-processor-util.h
@@ -35,7 +35,7 @@ typedef struct {
 	BIT_FLAGS old_r_flags2;
 	BIT_FLAGS old_r_flags3;
 	BIT_FLAGS old_r_flagsr;
-	FlagGroup<RF_ABILITY> old_r_ability_flags;
+	EnumClassFlagGroup<RF_ABILITY> old_r_ability_flags;
 
 	byte old_r_blows0;
 	byte old_r_blows1;

--- a/src/mspell/improper-mspell-remover.cpp
+++ b/src/mspell/improper-mspell-remover.cpp
@@ -27,7 +27,7 @@ static void add_cheat_remove_flags(player_type *target_ptr, msr_type *msr_ptr)
  * @param f6p モンスター魔法のフラグリスト3
  * @return なし
  */
-void remove_bad_spells(MONSTER_IDX m_idx, player_type *target_ptr, FlagGroup<RF_ABILITY>& ability_flags)
+void remove_bad_spells(MONSTER_IDX m_idx, player_type *target_ptr, EnumClassFlagGroup<RF_ABILITY> &ability_flags)
 {
     msr_type tmp_msr;
     msr_type *msr_ptr = initialize_msr_type(target_ptr, &tmp_msr, m_idx, ability_flags);

--- a/src/mspell/improper-mspell-remover.h
+++ b/src/mspell/improper-mspell-remover.h
@@ -2,4 +2,7 @@
 
 #include "system/angband.h"
 
-void remove_bad_spells(MONSTER_IDX m_idx, player_type *target_ptr, FlagGroup<RF_ABILITY>& ability_flags);
+#include "monster-race/race-ability-flags.h"
+#include "util/flag-group.h"
+
+void remove_bad_spells(MONSTER_IDX m_idx, player_type *target_ptr, EnumClassFlagGroup<RF_ABILITY> &ability_flags);

--- a/src/mspell/mspell-attack-util.h
+++ b/src/mspell/mspell-attack-util.h
@@ -22,7 +22,7 @@ typedef struct msa_type {
     monster_type *m_ptr;
     monster_race *r_ptr;
     bool no_inate;
-    FlagGroup<RF_ABILITY> ability_flags;
+    EnumClassFlagGroup<RF_ABILITY> ability_flags;
     POSITION x;
     POSITION y;
     POSITION x_br_lite;

--- a/src/mspell/mspell-attack.cpp
+++ b/src/mspell/mspell-attack.cpp
@@ -109,7 +109,7 @@ static bool check_mspell_non_stupid(player_type *target_ptr, msa_type *msa_ptr)
 
 static void set_mspell_list(msa_type *msa_ptr)
 {
-    FlagGroup<RF_ABILITY>::get_flags(msa_ptr->ability_flags, std::back_inserter(msa_ptr->mspells));
+    EnumClassFlagGroup<RF_ABILITY>::get_flags(msa_ptr->ability_flags, std::back_inserter(msa_ptr->mspells));
 }
 
 static void describe_mspell_monster(player_type *target_ptr, msa_type *msa_ptr)

--- a/src/mspell/smart-mspell-util.cpp
+++ b/src/mspell/smart-mspell-util.cpp
@@ -4,7 +4,7 @@
 #include "system/floor-type-definition.h"
 #include "system/monster-type-definition.h"
 
-msr_type *initialize_msr_type(player_type *target_ptr, msr_type *msr_ptr, MONSTER_IDX m_idx, const FlagGroup<RF_ABILITY>& ability_flags)
+msr_type *initialize_msr_type(player_type *target_ptr, msr_type *msr_ptr, MONSTER_IDX m_idx, const EnumClassFlagGroup<RF_ABILITY> &ability_flags)
 {
     monster_type *m_ptr = &target_ptr->current_floor_ptr->m_list[m_idx];
     msr_ptr->r_ptr = &r_info[m_ptr->r_idx];

--- a/src/mspell/smart-mspell-util.h
+++ b/src/mspell/smart-mspell-util.h
@@ -10,9 +10,9 @@
 typedef struct monster_race monster_race;
 typedef struct msr_type {
     monster_race *r_ptr;
-    FlagGroup<RF_ABILITY> ability_flags;
-    FlagGroup<SM> smart;
+    EnumClassFlagGroup<RF_ABILITY> ability_flags;
+    EnumClassFlagGroup<SM> smart;
 } msr_type;
 
-msr_type *initialize_msr_type(player_type *target_ptr, msr_type *msr_ptr, MONSTER_IDX m_idx, const FlagGroup<RF_ABILITY> &ability_flags);
+msr_type *initialize_msr_type(player_type *target_ptr, msr_type *msr_ptr, MONSTER_IDX m_idx, const EnumClassFlagGroup<RF_ABILITY> &ability_flags);
 bool int_outof(monster_race *r_ptr, PERCENTAGE prob);

--- a/src/object-enchant/object-ego.cpp
+++ b/src/object-enchant/object-ego.cpp
@@ -63,7 +63,7 @@ byte get_random_ego(byte slot, bool good)
  * @param gen_flags 生成フラグ(参照渡し)
  * @return なし
  */
-static void ego_invest_curse(player_type* player_ptr, object_type* o_ptr, FlagGroup<TRG>& gen_flags)
+static void ego_invest_curse(player_type *player_ptr, object_type *o_ptr, EnumClassFlagGroup<TRG> &gen_flags)
 {
     if (gen_flags.has(TRG::CURSED))
         o_ptr->curse_flags |= (TRC_CURSED);
@@ -85,7 +85,7 @@ static void ego_invest_curse(player_type* player_ptr, object_type* o_ptr, FlagGr
  * @param gen_flags 生成フラグ(参照渡し)
  * @return なし
  */
-static void ego_invest_extra_abilities(object_type *o_ptr, FlagGroup<TRG> &gen_flags)
+static void ego_invest_extra_abilities(object_type *o_ptr, EnumClassFlagGroup<TRG> &gen_flags)
 {
     if (gen_flags.has(TRG::ONE_SUSTAIN))
         one_sustain(o_ptr);
@@ -131,7 +131,7 @@ static void ego_invest_extra_abilities(object_type *o_ptr, FlagGroup<TRG> &gen_f
  * @param gen_flags 生成フラグ(参照渡し)
  * @return なし
  */
-static void ego_interpret_extra_abilities(object_type *o_ptr, ego_item_type *e_ptr, FlagGroup<TRG> &gen_flags)
+static void ego_interpret_extra_abilities(object_type *o_ptr, ego_item_type *e_ptr, EnumClassFlagGroup<TRG> &gen_flags)
 {
     for (auto& xtra : e_ptr->xtra_flags) {
         if (xtra.mul == 0 || xtra.dev == 0)

--- a/src/object-enchant/object-ego.h
+++ b/src/object-enchant/object-ego.h
@@ -251,7 +251,7 @@ struct ego_item_type {
     PRICE cost{}; //!< コスト
 
     BIT_FLAGS flags[TR_FLAG_SIZE]{}; //!< 能力/耐性フラグ
-    FlagGroup<TRG> gen_flags; //!< 生成時適用フラグ
+    EnumClassFlagGroup<TRG> gen_flags; //!< 生成時適用フラグ
     std::vector<ego_generate_type> xtra_flags{}; //!< 追加能力/耐性フラグ
 
     IDX act_idx{}; //!< 発動番号 / Activative ability index

--- a/src/object/object-kind.h
+++ b/src/object/object-kind.h
@@ -34,7 +34,7 @@ typedef struct object_kind {
 
     BIT_FLAGS flags[TR_FLAG_SIZE]{}; /*!< ベースアイテムの基本特性ビット配列 / Flags */
 
-    FlagGroup<TRG> gen_flags; /*!< ベースアイテムの生成特性ビット配列 / flags for generate */
+    EnumClassFlagGroup<TRG> gen_flags; /*!< ベースアイテムの生成特性ビット配列 / flags for generate */
 
     DEPTH locale[4]{}; /*!< ベースアイテムの生成階テーブル / Allocation level(s) */
     PROB chance[4]{}; /*!< ベースアイテムの生成確率テーブル / Allocation chance(s) */

--- a/src/player/player-status.h
+++ b/src/player/player-status.h
@@ -198,7 +198,7 @@ typedef struct player_type {
 
     PATRON_IDX chaos_patron{};
 
-    FlagGroup<MUTA> muta{}; /*!< 突然変異 / mutations */
+    EnumClassFlagGroup<MUTA> muta{}; /*!< 突然変異 / mutations */
 
     s16b virtues[8]{};
     s16b vir_types[8]{};

--- a/src/system/artifact-type-definition.h
+++ b/src/system/artifact-type-definition.h
@@ -32,7 +32,7 @@ typedef struct artifact_type {
 	WEIGHT weight{};		/*!< 重量 / Weight */
 	PRICE cost{};			/*!< 基本価格 / Artifact "cost" */
 	BIT_FLAGS flags[TR_FLAG_SIZE]{};       /*! アイテムフラグ / Artifact Flags */
-	FlagGroup<TRG> gen_flags;		/*! アイテム生成フラグ / flags for generate */
+	EnumClassFlagGroup<TRG> gen_flags;	/*! アイテム生成フラグ / flags for generate */
 	DEPTH level{};		/*! 基本生成階 / Artifact level */
 	RARITY rarity{};		/*! レアリティ / Artifact rarity */
 	byte cur_num{};		/*! 現在の生成数 / Number created (0 or 1) */

--- a/src/system/monster-race-definition.h
+++ b/src/system/monster-race-definition.h
@@ -67,7 +67,7 @@ typedef struct monster_race {
     BIT_FLAGS flags8{}; /* Flags 8 (wilderness info) */
     BIT_FLAGS flags9{}; /* Flags 9 (drops info) */
     BIT_FLAGS flagsr{}; /* Flags R (resistances info) */
-    FlagGroup<RF_ABILITY> ability_flags; /* Ability Flags */
+    EnumClassFlagGroup<RF_ABILITY> ability_flags; /* Ability Flags */
     monster_blow blow[MAX_NUM_BLOWS]{}; /* Up to four blows per round */
     MONRACE_IDX reinforce_id[6]{};
     DICE_NUMBER reinforce_dd[6]{};
@@ -105,5 +105,5 @@ typedef struct monster_race {
     u32b r_flags2{}; /* Observed racial flags */
     u32b r_flags3{}; /* Observed racial flags */
     u32b r_flagsr{}; /* Observed racial resistance flags */
-    FlagGroup<RF_ABILITY> r_ability_flags; /* Observed racial ability flags */
+    EnumClassFlagGroup<RF_ABILITY> r_ability_flags; /* Observed racial ability flags */
 } monster_race;

--- a/src/system/monster-type-definition.h
+++ b/src/system/monster-type-definition.h
@@ -35,8 +35,8 @@ typedef struct monster_type {
 	SPEED mspeed{};	        /*!< モンスターの個体加速値 / Monster "speed" */
 	ACTION_ENERGY energy_need{};	/*!< モンスター次ターンまでに必要な行動エネルギー / Monster "energy" */
 	POSITION cdis{};		/*!< 現在のプレイヤーから距離(逐一計算を避けるためのテンポラリ変数) Current dis from player */
-	FlagGroup<MFLAG> mflag{};	/*!< モンスター個体に与えられた特殊フラグ1 (セーブ不要) / Extra monster flags */
-	FlagGroup<MFLAG2> mflag2{};	/*!< モンスター個体に与えられた特殊フラグ2 (セーブ必要) / Extra monster flags */
+	EnumClassFlagGroup<MFLAG> mflag{};	/*!< モンスター個体に与えられた特殊フラグ1 (セーブ不要) / Extra monster flags */
+	EnumClassFlagGroup<MFLAG2> mflag2{};	/*!< モンスター個体に与えられた特殊フラグ2 (セーブ必要) / Extra monster flags */
 	bool ml{};		/*!< モンスターがプレイヤーにとって視認できるか(処理のためのテンポラリ変数) Monster is "visible" */
 	OBJECT_IDX hold_o_idx{};	/*!< モンスターが盗み処理により保持しているアイテム(object_type構造体自身がリスト構造を持つ) Object being held (if any) */
 	POSITION target_y{};		/*!< モンスターの攻撃目標対象Y座標 / Can attack !los player */
@@ -45,6 +45,6 @@ typedef struct monster_type {
 	EXP exp{}; /*!< モンスターの現在所持経験値 */
 
 	/* TODO: クローン、ペット、有効化は意義が異なるので別変数に切り離すこと。save/loadのバージョン更新が面倒そうだけど */
-	FlagGroup<SM> smart{}; /*!< モンスターのプレイヤーに対する学習状態 / Field for "smart_learn" - Some bit-flags for the "smart" field */
+	EnumClassFlagGroup<SM> smart{}; /*!< モンスターのプレイヤーに対する学習状態 / Field for "smart_learn" - Some bit-flags for the "smart" field */
 	MONSTER_IDX parent_m_idx{}; /*!< 召喚主のモンスターID */
 } monster_type;

--- a/src/util/flag-group.h
+++ b/src/util/flag-group.h
@@ -5,19 +5,20 @@
 /**
  * @brief フラグ集合を扱う、FlagGroupクラス
  *
- * @tparam FlagType 扱うフラグ集合を定義したenum class型
+ * @tparam FlagType 扱うフラグ集合を定義したenum型 もしくは enum class型
+ * @tparam FlagTypeに列挙される値の最大値+1
  */
-template <typename FlagType>
+template <typename FlagType, FlagType MAX>
 class FlagGroup {
 private:
     /** フラグ集合のフラグ数 */
-    static constexpr auto FLAG_TYPE_MAX = static_cast<size_t>(FlagType::MAX);
+    static constexpr auto FLAG_TYPE_MAX = static_cast<size_t>(MAX);
 
 public:
     /**
      * @brief フラグ集合に含まれるフラグの種類数を返す
      *
-     * @return constexpr size_t フラグ集合に含まれるフラグの種類数
+     * @return フラグ集合に含まれるフラグの種類数
      */
     constexpr size_t size() const noexcept
     {
@@ -29,7 +30,7 @@ public:
      *
      * すべてのフラグがOFFの状態のFlagGroupクラスのインスタンスを生成する
      */
-    FlagGroup<FlagType>() = default;
+    FlagGroup() = default;
 
     /**
      * @brief FlagGroupクラスのコンストラクタ
@@ -39,7 +40,7 @@ public:
      *
      * @param il ONの状態で生成するフラグを指定した initializer_list
      */
-    FlagGroup<FlagType>(std::initializer_list<FlagType> il)
+    FlagGroup(std::initializer_list<FlagType> il)
     {
         set(il);
     }
@@ -55,7 +56,7 @@ public:
      * @param last 範囲の終了位置を示す入力イテレータ
      */
     template <typename InputIter>
-    FlagGroup<FlagType>(InputIter first, InputIter last)
+    FlagGroup(InputIter first, InputIter last)
     {
         set(first, last);
     }
@@ -63,9 +64,9 @@ public:
     /**
      * @brief フラグ集合に含まれるフラグをすべてOFFにする
      *
-     * @return FlagGroup<FlagType>& *thisを返す
+     * @return *thisを返す
      */
-    FlagGroup<FlagType> &clear() noexcept
+    FlagGroup<FlagType, MAX> &clear() noexcept
     {
         bs_.reset();
         return *this;
@@ -77,9 +78,9 @@ public:
      * @param flag 値をセットするフラグを指定する
      * @param val セットする値。trueならフラグをON、falseならフラグをOFFにする。
      *            引数を省略した場合はフラグをONにする。
-     * @return FlagGroup<FlagType>& *thisを返す
+     * @return *thisを返す
      */
-    FlagGroup<FlagType> &set(FlagType flag, bool val = true)
+    FlagGroup<FlagType, MAX> &set(FlagType flag, bool val = true)
     {
         bs_.set(static_cast<size_t>(flag), val);
         return *this;
@@ -91,10 +92,10 @@ public:
      * @tparam InputIter 入力イテレータの型
      * @param first 範囲の開始位置を示す入力イテレータ
      * @param last 範囲の終了位置を示す入力イテレータ
-     * @return FlagGroup<FlagType>& *thisを返す
+     * @return *thisを返す
      */
     template <typename InputIter>
-    FlagGroup<FlagType> &set(InputIter first, InputIter last)
+    FlagGroup<FlagType, MAX> &set(InputIter first, InputIter last)
     {
         static_assert(std::is_same<typename std::iterator_traits<InputIter>::value_type, FlagType>::value, "Iterator value type is invalid");
 
@@ -109,9 +110,9 @@ public:
      * @brief 指定したFlagGroupのインスンタンスのONになっているフラグをONにする
      *
      * @param rhs ONにするフラグがONになっているFlagGroupのインスタンス
-     * @return FlagGroup<FlagType>& *thisを返す
+     * @return *thisを返す
      */
-    FlagGroup<FlagType> &set(const FlagGroup<FlagType> &rhs)
+    FlagGroup<FlagType, MAX> &set(const FlagGroup<FlagType, MAX> &rhs)
     {
         bs_ |= rhs.bs_;
         return *this;
@@ -121,9 +122,9 @@ public:
      * @brief 指定したinitializer_listに含まれるフラグをONにする
      *
      * @param list ONにするフラグを列挙したinitializer_list
-     * @return FlagGroup<FlagType>& *thisを返す
+     * @return *thisを返す
      */
-    FlagGroup<FlagType> &set(std::initializer_list<FlagType> list)
+    FlagGroup<FlagType, MAX> &set(std::initializer_list<FlagType> list)
     {
         return set(std::begin(list), std::end(list));
     }
@@ -132,9 +133,9 @@ public:
      * @brief 指定したフラグをOFFにする
      *
      * @param flag OFFにするフラグを指定する
-     * @return FlagGroup<FlagType>& *thisを返す
+     * @return *thisを返す
      */
-    FlagGroup<FlagType> &reset(FlagType flag)
+    FlagGroup<FlagType, MAX> &reset(FlagType flag)
     {
         bs_.reset(static_cast<size_t>(flag));
         return *this;
@@ -146,10 +147,10 @@ public:
      * @tparam InputIter 入力イテレータの型
      * @param first 範囲の開始位置を示す入力イテレータ
      * @param last 範囲の終了位置を示す入力イテレータ
-     * @return FlagGroup<FlagType>& *thisを返す
+     * @return *thisを返す
      */
     template <typename InputIter>
-    FlagGroup<FlagType> &reset(InputIter first, InputIter last)
+    FlagGroup<FlagType, MAX> &reset(InputIter first, InputIter last)
     {
         static_assert(std::is_same<typename std::iterator_traits<InputIter>::value_type, FlagType>::value, "Iterator value type is invalid");
 
@@ -164,9 +165,9 @@ public:
      * @brief 指定したFlagGroupのインスンタンスのONになっているフラグをOFFにする
      *
      * @param rhs OFFにするフラグがONになっているFlagGroupのインスタンス
-     * @return FlagGroup<FlagType>& *thisを返す
+     * @return *thisを返す
      */
-    FlagGroup<FlagType> &reset(const FlagGroup<FlagType> &rhs)
+    FlagGroup<FlagType, MAX> &reset(const FlagGroup<FlagType, MAX> &rhs)
     {
         bs_ &= ~rhs.bs_;
         return *this;
@@ -176,9 +177,9 @@ public:
      * @brief 指定したinitializer_listに含まれるフラグをOFFにする
      *
      * @param list OFFにするフラグを列挙したinitializer_list
-     * @return FlagGroup<FlagType>& *thisを返す
+     * @return *thisを返す
      */
-    FlagGroup<FlagType> &reset(std::initializer_list<FlagType> list)
+    FlagGroup<FlagType, MAX> &reset(std::initializer_list<FlagType> list)
     {
         return reset(std::begin(list), std::end(list));
     }
@@ -187,7 +188,7 @@ public:
      * @brief 指定したフラグがONかOFFか調べる
      *
      * @param f 調べるフラグを指定する
-     * @return bool 指定したフラグがONならtrue、OFFならfalse
+     * @return 指定したフラグがONならtrue、OFFならfalse
      */
     bool has(FlagType f) const
     {
@@ -198,7 +199,7 @@ public:
      * @brief 指定したフラグがOFFかONか調べる
      *
      * @param f 調べるフラグを指定する
-     * @return bool 指定したフラグがOFFならtrue、ONならfalse
+     * @return 指定したフラグがOFFならtrue、ONならfalse
      */
     bool has_not(FlagType f) const
     {
@@ -208,8 +209,8 @@ public:
     /**
      * @brief フラグ集合のいずれかのフラグがONかどうかを調べる
      *
-     * @return bool フラグ集合のいずれかのフラグがONならtrue
-     *              フラグ集合のすべてのフラグがOFFならfalse
+     * @return フラグ集合のいずれかのフラグがONならtrue
+     *         フラグ集合のすべてのフラグがOFFならfalse
      */
     bool any() const noexcept
     {
@@ -219,8 +220,8 @@ public:
     /**
      * @brief フラグ集合のすべてのフラグがOFFかどうかを調べる
      *
-     * @return bool フラグ集合のすべてのフラグがOFFならtrue
-     *              フラグ集合のいずれかのフラグがONならfalse
+     * @return フラグ集合のすべてのフラグがOFFならtrue
+     *         フラグ集合のいずれかのフラグがONならfalse
      */
     bool none() const noexcept
     {
@@ -233,7 +234,7 @@ public:
      * @tparam InputIter 入力イテレータの型
      * @param first 範囲の開始位置を示す入力イテレータ
      * @param last 範囲の終了位置を示す入力イテレータ
-     * @return bool すべてのフラグがONであればtrue、そうでなければfalse
+     * @return すべてのフラグがONであればtrue、そうでなければfalse
      */
     template <typename InputIter>
     bool has_all_of(InputIter first, InputIter last) const
@@ -253,7 +254,7 @@ public:
      * @brief 指定したinitializer_listに含まれるフラグがすべてONかどうかを調べる
      *
      * @param list 調べるフラグを列挙したinitializer_list
-     * @return bool すべてのフラグがONであればtrue、そうでなければfalse
+     * @return すべてのフラグがONであればtrue、そうでなければfalse
      */
     bool has_all_of(std::initializer_list<FlagType> list) const
     {
@@ -264,9 +265,9 @@ public:
      * @brief 引数で指定したFlagGroupのインスンタンスのONになっているフラグがすべてONかどうかを調べる
      *
      * @param rhs FlagGroupのインスタンス
-     * @return bool すべてのフラグがONであればtrue、そうでなければfalse
+     * @return すべてのフラグがONであればtrue、そうでなければfalse
      */
-    bool has_all_of(const FlagGroup<FlagType> &rhs) const
+    bool has_all_of(const FlagGroup<FlagType, MAX> &rhs) const
     {
         return (bs_ & rhs.bs_) == rhs.bs_;
     }
@@ -277,7 +278,7 @@ public:
      * @tparam InputIter 入力イテレータの型
      * @param first 範囲の開始位置を示す入力イテレータ
      * @param last 範囲の終了位置を示す入力イテレータ
-     * @return bool いずれかのフラグがONであればtrue、そうでなければfalse
+     * @return いずれかのフラグがONであればtrue、そうでなければfalse
      */
     template <typename InputIter>
     bool has_any_of(InputIter first, InputIter last) const
@@ -297,7 +298,7 @@ public:
      * @brief 指定したinitializer_listに含まれるフラグのいずれかがONかどうかを調べる
      *
      * @param list 調べるフラグを列挙したinitializer_list
-     * @return bool いずれかのフラグがONであればtrue、そうでなければfalse
+     * @return いずれかのフラグがONであればtrue、そうでなければfalse
      */
     bool has_any_of(std::initializer_list<FlagType> list) const
     {
@@ -308,11 +309,11 @@ public:
      * @brief 引数で指定したFlagGroupのインスンタンスのONになっているフラグのいずれかがONかどうかを調べる
      *
      * @param rhs FlagGroupのインスタンス
-     * @return bool いずれかのフラグがONであればtrue、そうでなければfalse
+     * @return いずれかのフラグがONであればtrue、そうでなければfalse
      */
-    bool has_any_of(const FlagGroup<FlagType> &rhs) const
+    bool has_any_of(const FlagGroup<FlagType, MAX> &rhs) const
     {
-        return (bs_ & rhs.bs_) != 0;
+        return (bs_ & rhs.bs_).any();
     }
 
     /**
@@ -321,7 +322,7 @@ public:
      * @tparam InputIter 入力イテレータの型
      * @param first 範囲の開始位置を示す入力イテレータ
      * @param last 範囲の終了位置を示す入力イテレータ
-     * @return bool すべてのフラグがOFFであればtrue、そうでなければfalse
+     * @return すべてのフラグがOFFであればtrue、そうでなければfalse
      */
     template <typename InputIter>
     bool has_none_of(InputIter first, InputIter last) const
@@ -335,7 +336,7 @@ public:
      * @brief 指定したinitializer_listに含まれるフラグがすべてOFFかどうかを調べる
      *
      * @param list 調べるフラグを列挙したinitializer_list
-     * @return bool すべてのフラグがOFFであればtrue、そうでなければfalse
+     * @return すべてのフラグがOFFであればtrue、そうでなければfalse
      */
     bool has_none_of(std::initializer_list<FlagType> list) const
     {
@@ -346,9 +347,9 @@ public:
      * @brief 引数で指定したFlagGroupのインスンタンスのONになっているフラグがすべてOFFかどうかを調べる
      *
      * @param rhs FlagGroupのインスタンス
-     * @return bool すべてのフラグがOFFであればtrue、そうでなければfalse
+     * @return すべてのフラグがOFFであればtrue、そうでなければfalse
      */
-    bool has_none_of(const FlagGroup<FlagType> &rhs) const
+    bool has_none_of(const FlagGroup<FlagType, MAX> &rhs) const
     {
         return !has_any_of(rhs);
     }
@@ -356,7 +357,7 @@ public:
     /**
      * @brief フラグ集合のONになっているフラグの数を返す
      *
-     * @return size_t ONになっているフラグの数
+     * @return ONになっているフラグの数
      */
     size_t count() const noexcept
     {
@@ -369,7 +370,7 @@ public:
      * フラグ集合の上位番号から順に、フラグがONなら1、OFFなら0で表した文字列を返す。
      * 例: 5つのフラグ集合で、0:ON、1:OFF、2:OFF、3:ON、4:OFFの場合、"01001"
      *
-     * @return std::string フラグ集合の状態を表した文字列
+     * @return フラグ集合の状態を表した文字列
      */
     std::string str() const
     {
@@ -380,9 +381,9 @@ public:
      * @brief フラグ集合 *this と rhs が等値かどうかを調べる
      *
      * @param rhs 比較するフラグ集合
-     * @return bool すべてのフラグの状態が等しければtrue、そうでなければfalse
+     * @return すべてのフラグの状態が等しければtrue、そうでなければfalse
      */
-    bool operator==(const FlagGroup<FlagType> &rhs) const noexcept
+    bool operator==(const FlagGroup<FlagType, MAX> &rhs) const noexcept
     {
         return bs_ == rhs.bs_;
     }
@@ -391,9 +392,9 @@ public:
      * @brief フラグ集合 *this と rhs が非等値かどうかを調べる
      *
      * @param rhs 比較するフラグ集合
-     * @return bool いずれかのフラグの状態が等しくなければtrue、そうでなければfalse
+     * @return いずれかのフラグの状態が等しくなければtrue、そうでなければfalse
      */
-    bool operator!=(const FlagGroup<FlagType> &rhs) const noexcept
+    bool operator!=(const FlagGroup<FlagType, MAX> &rhs) const noexcept
     {
         return bs_ != rhs.bs_;
     }
@@ -404,9 +405,9 @@ public:
      * *this に対して、*this と rhs で共通してONのフラグをONのままにし、それ以外のフラグをOFFにする
      *
      * @param rhs 複合演算を行うフラグ集合
-     * @return FlagGroup<FlagType>& *thisを返す
+     * @return *thisを返す
      */
-    FlagGroup<FlagType> &operator&=(const FlagGroup<FlagType> &rhs) noexcept
+    FlagGroup<FlagType, MAX> &operator&=(const FlagGroup<FlagType, MAX> &rhs) noexcept
     {
         bs_ &= rhs.bs_;
         return *this;
@@ -418,16 +419,23 @@ public:
      * *this に対して、*this と rhs でどちらか一方でもONのフラグをONにし、それ以外のフラグをOFFにする
      *
      * @param rhs 複合演算を行うフラグ集合
-     * @return FlagGroup<FlagType>& *thisを返す
+     * @return *thisを返す
      */
-    FlagGroup<FlagType> &operator|=(const FlagGroup<FlagType> &rhs) noexcept
+    FlagGroup<FlagType, MAX> &operator|=(const FlagGroup<FlagType, MAX> &rhs) noexcept
     {
         bs_ |= rhs.bs_;
         return *this;
     }
 
+    /**
+     * @brief フラグ集合のONになっているフラグを出力イテレータに書き込む
+     *
+     * @tparam OutputIter フラグを書き込む出力イテレータの型
+     * @param flag_group 対象のフラグ集合
+     * @param start フラグを書き込む出力イテレータ
+     */
     template <typename OutputIter>
-    static void get_flags(const FlagGroup<FlagType>& flag_group, OutputIter start)
+    static void get_flags(const FlagGroup<FlagType, MAX> &flag_group, OutputIter start)
     {
         for (size_t i = 0; i < flag_group.size(); i++) {
             if (flag_group.bs_.test(i)) {
@@ -443,7 +451,7 @@ public:
      * @param rd_byte_func セーブファイルから1バイトデータを読み出す関数(rd_byte)へのポインタ
      */
     template <typename Func>
-    friend void rd_FlagGroup(FlagGroup<FlagType> &fg, Func rd_byte_func)
+    friend void rd_FlagGroup(FlagGroup<FlagType, MAX> &fg, Func rd_byte_func)
     {
         uint8_t tmp_l, tmp_h;
         rd_byte_func(&tmp_l);
@@ -470,7 +478,7 @@ public:
      * @param wr_byte_func セーブファイルに1バイトデータを書き込む関数(wr_byte)へのポインタ
      */
     template <typename Func>
-    friend void wr_FlagGroup(const FlagGroup<FlagType> &fg, Func wr_byte_func)
+    friend void wr_FlagGroup(const FlagGroup<FlagType, MAX> &fg, Func wr_byte_func)
     {
         const auto fg_size = static_cast<uint16_t>((fg.bs_.size() + 7) / 8);
         wr_byte_func(fg_size & 0xff);
@@ -496,11 +504,11 @@ public:
      * @param fg フラグをセットするフラグ集合
      * @param dict 文字列からフラグへのマップ
      * @param what マップの検索キー
-     * @return bool 検索キーでフラグが見つかり、フラグをセットした場合 true
-     *              見つからなかった場合 false
+     * @return 検索キーでフラグが見つかり、フラグをセットした場合 true
+     *         見つからなかった場合 false
      */
     template <typename Map>
-    static bool grab_one_flag(FlagGroup<FlagType> &fg, const Map &dict, std::string_view what)
+    static bool grab_one_flag(FlagGroup<FlagType, MAX> &fg, const Map &dict, std::string_view what)
     {
         auto it = dict.find(what);
         if (it == dict.end())
@@ -516,7 +524,7 @@ private:
      */
     class reference {
     public:
-        reference(std::bitset<FlagGroup::FLAG_TYPE_MAX> &flags, size_t pos)
+        reference(std::bitset<FLAG_TYPE_MAX> &flags, size_t pos)
             : bs_(flags)
             , pos_(pos)
         {
@@ -540,7 +548,7 @@ private:
         }
 
     private:
-        std::bitset<FlagGroup::FLAG_TYPE_MAX> &bs_;
+        std::bitset<FLAG_TYPE_MAX> &bs_;
         size_t pos_;
     };
 
@@ -549,7 +557,7 @@ public:
      * @brief 指定したフラグへのアクセスを提供するプロキシオブジェクトを取得する
      *
      * @param f プロキシオブジェクトを取得するフラグ
-     * @return reference 指定したフラグへのアクセスを提供するプロキシオブジェクト
+     * @return 指定したフラグへのアクセスを提供するプロキシオブジェクト
      */
     reference operator[](FlagType f)
     {
@@ -562,6 +570,16 @@ private:
 };
 
 /**
+ * @brief enum clsas 型に対してFlagGroupクラスを使用するエイリアステンプレート
+ *
+ * FlagGroupクラスのテンプレート引数に、使用する型として FlagType、列挙値の最大値として FlagType::MAX を渡す。
+ *
+ * @tparam FlagType FlagGroupクラスを使用する enum class 型
+ */
+template <typename FlagType>
+using EnumClassFlagGroup = FlagGroup<FlagType, FlagType::MAX>;
+
+/**
  * @brief フラグ集合 lhs と rhs に対して論理積(AND)を取ったフラグ集合を生成する
  *
  * lhs と rhs で共通してONのフラグがON、それ以外のフラグがOFFのフラグ集合を生成する
@@ -569,12 +587,12 @@ private:
  * @tparam FlagType 扱うフラグ集合を定義したenum class型
  * @param lhs フラグ集合1
  * @param rhs フラグ集合2
- * @return FlagGroup<FlagType> lhs と rhs の論理積を取ったフラグ集合
+ * @return lhs と rhs の論理積を取ったフラグ集合
  */
-template <typename FlagType>
-FlagGroup<FlagType> operator&(const FlagGroup<FlagType> &lhs, const FlagGroup<FlagType> &rhs) noexcept
+template <typename FlagType, FlagType MAX>
+FlagGroup<FlagType, MAX> operator&(const FlagGroup<FlagType, MAX> &lhs, const FlagGroup<FlagType, MAX> &rhs) noexcept
 {
-    return FlagGroup<FlagType>(lhs) &= rhs;
+    return FlagGroup<FlagType, MAX>(lhs) &= rhs;
 }
 
 /**
@@ -585,10 +603,10 @@ FlagGroup<FlagType> operator&(const FlagGroup<FlagType> &lhs, const FlagGroup<Fl
  * @tparam FlagType 扱うフラグ集合を定義したenum class型
  * @param lhs フラグ集合1
  * @param rhs フラグ集合2
- * @return FlagGroup<FlagType> lhs と rhs の論理積を取ったフラグ集合
+ * @return lhs と rhs の論理積を取ったフラグ集合
  */
-template <typename FlagType>
-FlagGroup<FlagType> operator|(const FlagGroup<FlagType> &lhs, const FlagGroup<FlagType> &rhs) noexcept
+template <typename FlagType, FlagType MAX>
+FlagGroup<FlagType, MAX> operator|(const FlagGroup<FlagType, MAX> &lhs, const FlagGroup<FlagType, MAX> &rhs) noexcept
 {
-    return FlagGroup<FlagType>(lhs) |= rhs;
+    return FlagGroup<FlagType, MAX>(lhs) |= rhs;
 }

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -126,12 +126,12 @@ void wiz_teleport_back(player_type *caster_ptr)
  */
 void wiz_learn_blue_magic_all(player_type *caster_ptr)
 {
-    FlagGroup<RF_ABILITY> ability_flags;
+    EnumClassFlagGroup<RF_ABILITY> ability_flags;
     for (int j = 1; j < A_MAX; j++) {
         set_rf_masks(ability_flags, static_cast<blue_magic_type>(j));
 
         std::vector<RF_ABILITY> spells;
-        FlagGroup<RF_ABILITY>::get_flags(ability_flags, std::back_inserter(spells));
+        EnumClassFlagGroup<RF_ABILITY>::get_flags(ability_flags, std::back_inserter(spells));
         for (auto spell : spells) {
             caster_ptr->magic_num2[static_cast<int>(spell)] = 1;
         }


### PR DESCRIPTION
FlagGroupクラスをenum class型だけでなく、enum型にも使用できるようにする。
テンプレートの定義を
template <typename FlagType, FlagType MAX>
FlagGroup;
のようにし、enum型では MAX にenumの中のMAXを定義している値を渡す。
従来のenum class型に対するFlagGroupは
template <typename FlagType>
using EnumClassFlagGroup = FlagGroup<FlagType, FlagType::MAX>;
というエイリアステンプレートとする。