### PR TITLE
Revert "[Refactor] 不要なフォントファイルをリリースパッケージから除外する"

### DIFF
--- a/Build-Windows-Release-Package.ps1
+++ b/Build-Windows-Release-Package.ps1
@@ -31,7 +31,6 @@ function BuildPackage ($package_name, $package_unique_files, $build_conf) {
     Copy-Item -Verbose -Path .\lib\apex\h_scores.raw -Destination $hengbandDir\lib\apex
     Remove-Item -Verbose -Exclude delete.me -Recurse -Path $hengbandDir\lib\save\*, $hengbandDir\lib\user\*
     Remove-Item -Verbose -Exclude music.cfg -Path $hengbandDir\lib\xtra\music\*
-    Remove-Item -Verbose -Recurse -Force -Path $hengbandDir\lib\xtra\font
 
     # zipアーカイブ作成
     $package_path = Join-Path $(Get-Location) "${package_name}.zip"


### PR DESCRIPTION
This reverts commit 61ee1520e11f577698a9d9d2d8bf04412e85a73f.

fontフォルダ毎削除されたため、リリースパッケージ作成スクリプト内でfontフォルダを削除する必要がなくなりました。