### PR TITLE
[Feature] レイシャルパワーの説明文を表示できるようにする #625

### DIFF
--- a/src/cmd-action/cmd-racial.cpp
+++ b/src/cmd-action/cmd-racial.cpp
@@ -21,6 +21,7 @@
 #include "status/action-setter.h"
 #include "term/screen-processor.h"
 #include "util/int-char-converter.h"
+#include <string>
 
 static bool input_racial_power_selection(player_type *creature_ptr, rc_type *rc_ptr)
 {
@@ -119,7 +120,7 @@ static void select_racial_power(player_type *creature_ptr, rc_type *rc_ptr)
         }
 
         strcat(dummy,
-            format("%-23.23s %2d %4d %3d%%", rc_ptr->power_desc[ctr].racial_name, rc_ptr->power_desc[ctr].min_level, rc_ptr->power_desc[ctr].cost,
+            format("%-23.23s %2d %4d %3d%%", rc_ptr->power_desc[ctr].racial_name.c_str(), rc_ptr->power_desc[ctr].min_level, rc_ptr->power_desc[ctr].cost,
                 100 - racial_chance(creature_ptr, &rc_ptr->power_desc[ctr])));
         prt(dummy, y1, x1);
         ctr++;
@@ -173,7 +174,7 @@ static bool ask_invoke_racial_power(rc_type *rc_ptr)
         return TRUE;
 
     char tmp_val[160];
-    (void)strnfmt(tmp_val, 78, _("%sを使いますか？ ", "Use %s? "), rc_ptr->power_desc[rc_ptr->command_code].racial_name);
+    (void)strnfmt(tmp_val, 78, _("%sを使いますか？ ", "Use %s? "), rc_ptr->power_desc[rc_ptr->command_code].racial_name.c_str());
     return get_check(tmp_val);
 }
 

--- a/src/cmd-action/cmd-racial.cpp
+++ b/src/cmd-action/cmd-racial.cpp
@@ -20,97 +20,51 @@
 #include "racial/racial-util.h"
 #include "status/action-setter.h"
 #include "term/screen-processor.h"
+#include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 #include <string>
 
-static bool input_racial_power_selection(player_type *creature_ptr, rc_type *rc_ptr)
-{
-    switch (rc_ptr->choice) {
-    case '0':
-        screen_load();
-        free_turn(creature_ptr);
-        return TRUE;
-    case '8':
-    case 'k':
-    case 'K':
-        rc_ptr->menu_line += (rc_ptr->size() - 1);
-        return FALSE;
-    case '2':
-    case 'j':
-    case 'J':
-        rc_ptr->menu_line++;
-        return FALSE;
-    case '6':
-    case 'l':
-    case 'L':
-    case '4':
-    case 'h':
-    case 'H':
-        if (rc_ptr->menu_line > 18)
-            rc_ptr->menu_line -= 18;
-        else if (rc_ptr->menu_line + 18 <= rc_ptr->size())
-            rc_ptr->menu_line += 18;
+#define RC_PAGE_SIZE 18
 
-        return FALSE;
-    case 'x':
-    case 'X':
-    case '\r':
-        rc_ptr->command_code = rc_ptr->menu_line - 1;
-        rc_ptr->ask = FALSE;
-        return FALSE;
-    default:
-        return FALSE;
-    }
+#define RC_CANCEL true
+#define RC_CONTINUE false
+
+static void racial_power_display_cursor(rc_type *rc_ptr)
+{
+    auto y = rc_ptr->menu_line % RC_PAGE_SIZE;
+    put_str(_(" 》 ", " >  "), 2 + y, 11);
 }
 
-static bool check_input_racial_power(player_type *creature_ptr, rc_type *rc_ptr)
+static void racial_power_erase_cursor(rc_type *rc_ptr)
 {
-    if (!use_menu || rc_ptr->choice == ' ')
-        return FALSE;
-
-    if (input_racial_power_selection(creature_ptr, rc_ptr))
-        return TRUE;
-
-    if (rc_ptr->menu_line > rc_ptr->size())
-        rc_ptr->menu_line -= rc_ptr->size();
-
-    return FALSE;
+    auto y = rc_ptr->menu_line % RC_PAGE_SIZE;
+    put_str(_("    ", "    "), 2 + y, 11);
 }
 
-static void display_racial_list(rc_type *rc_ptr, char *dummy)
+/*!
+ * @brief レイシャルパワー一覧を表示
+ * @param creature_ptr プレイヤー情報への参照ポインタ
+ * @param rc_ptr レイシャルパワー情報への参照ポインタ
+ * @return キャンセルしたらRC_CANCEL、それ以外ならRC_CONTINUE
+ */
+static void racial_power_display_list(player_type *creature_ptr, rc_type *rc_ptr)
 {
-    strcpy(dummy, "");
-    rc_ptr->redraw = TRUE;
-    if (!use_menu)
-        screen_save();
-
-    if (rc_ptr->size() < 18) {
-        prt(_("                            Lv   MP 失率", "                            Lv Cost Fail"), 1, 0);
-        return;
-    }
-
-    prt(_("                            Lv   MP 失率                            Lv   MP 失率",
-            "                            Lv Cost Fail                            Lv Cost Fail"),
-        1, 0);
-}
-
-static void select_racial_power(player_type *creature_ptr, rc_type *rc_ptr)
-{
+    TERM_LEN x = 11;
     char dummy[80];
-    display_racial_list(rc_ptr, dummy);
-    byte y = 2;
-    byte x = 0;
-    int ctr = 0;
-    while (ctr < rc_ptr->size()) {
-        TERM_LEN x1 = ((ctr < 18) ? x : x + 40);
-        TERM_LEN y1 = ((ctr < 18) ? y + ctr : y + ctr - 18);
-        if (use_menu) {
-            if (ctr == (rc_ptr->menu_line - 1))
-                strcpy(dummy, _(" 》 ", " >  "));
-            else
-                strcpy(dummy, "    ");
-        } else {
+    strcpy(dummy, "");
+
+    prt(_("                                   Lv   MP 失率 効果", "                               Lv   MP Fail Effect"), 1, x);
+
+    auto y = 0;
+    for (; y < RC_PAGE_SIZE; y++) {
+        auto ctr = RC_PAGE_SIZE * rc_ptr->page + y;
+        if (ctr >= rc_ptr->size())
+            break;
+
+        if (use_menu)
+            strcpy(dummy, "    ");
+        else {
             char letter;
             if (ctr < 26)
                 letter = I2A(ctr);
@@ -120,27 +74,129 @@ static void select_racial_power(player_type *creature_ptr, rc_type *rc_ptr)
             sprintf(dummy, " %c) ", letter);
         }
 
+        auto &rpi = rc_ptr->power_desc[ctr];
         strcat(dummy,
-            format("%-23.23s %2d %4d %3d%%", rc_ptr->power_desc[ctr].racial_name.c_str(), rc_ptr->power_desc[ctr].min_level, rc_ptr->power_desc[ctr].cost,
-                100 - racial_chance(creature_ptr, &rc_ptr->power_desc[ctr])));
-        prt(dummy, y1, x1);
-        ctr++;
+            format("%-30.30s %2d %4d %3d%% %s", rpi.racial_name.c_str(), rpi.min_level, rpi.cost, 100 - racial_chance(creature_ptr, &rc_ptr->power_desc[ctr]),
+                rpi.info.c_str()));
+
+        prt(dummy, 2 + y, x);
+    }
+
+    prt("", 2 + y, x);
+
+    if (use_menu)
+        racial_power_display_cursor(rc_ptr);
+}
+
+static void racial_power_add_index(player_type *creature_ptr, rc_type* rc_ptr, int i) {
+    auto n = rc_ptr->menu_line + i;
+    if (i < -1 || i > 1) {
+        if (n < 0 || n >= rc_ptr->size())
+            return;
+    }
+    if (n < 0)
+        n = rc_ptr->size() - 1;
+    if (n >= rc_ptr->size())
+        n = 0;
+
+    auto p = n / RC_PAGE_SIZE;
+    racial_power_erase_cursor(rc_ptr);
+    rc_ptr->menu_line = n;
+    if (rc_ptr->page != p) {
+        rc_ptr->page = p;
+        screen_load();
+        screen_save();
+        racial_power_display_list(creature_ptr, rc_ptr);
+    } else
+        racial_power_display_cursor(rc_ptr);
+}
+
+/*!
+ * @brief メニューによる選択のキーを処理する
+ * @param rc_ptr レイシャルパワー情報への参照ポインタ
+ */
+static bool racial_power_interpret_menu_keys(player_type *creature_ptr, rc_type *rc_ptr)
+{
+    switch (rc_ptr->choice) {
+    case '0':
+        return RC_CANCEL;
+    case '8':
+    case 'k':
+    case 'K':
+        racial_power_add_index(creature_ptr, rc_ptr, -1);
+        return RC_CONTINUE;
+    case '2':
+    case 'j':
+    case 'J':
+        racial_power_add_index(creature_ptr, rc_ptr, 1);
+        return RC_CONTINUE;
+    case '6':
+    case 'l':
+    case 'L':
+        racial_power_add_index(creature_ptr, rc_ptr, RC_PAGE_SIZE);
+        return RC_CONTINUE;
+    case '4':
+    case 'h':
+    case 'H':
+        racial_power_add_index(creature_ptr, rc_ptr, 0 - RC_PAGE_SIZE);
+        return RC_CONTINUE;
+    case 'x':
+    case 'X':
+    case '\r':
+        rc_ptr->command_code = (COMMAND_CODE)rc_ptr->menu_line;
+        rc_ptr->is_chosen = true;
+        rc_ptr->ask = false;
+        return RC_CONTINUE;
+    default:
+        return RC_CONTINUE;
     }
 }
 
-static bool check_racial_power_choice(player_type *creature_ptr, rc_type *rc_ptr)
+/*!
+ * @brief メニューからの選択決定を処理
+ * @param creature_ptr プレイヤー情報への参照ポインタ
+ * @param rc_ptr レイシャルパワー情報への参照ポインタ
+ * @return キャンセルしたらRC_CANCEL、それ以外ならRC_CONTINUE
+ */
+static bool racial_power_select_by_menu(player_type *creature_ptr, rc_type *rc_ptr)
 {
-    if ((rc_ptr->choice != ' ') && (rc_ptr->choice != '*') && (rc_ptr->choice != '?') && (!use_menu || !rc_ptr->ask))
-        return FALSE;
+    if (!use_menu || rc_ptr->choice == ' ')
+        return RC_CONTINUE;
 
-    if (!rc_ptr->redraw || use_menu) {
-        select_racial_power(creature_ptr, rc_ptr);
-        return TRUE;
+    if (racial_power_interpret_menu_keys(creature_ptr, rc_ptr))
+        return RC_CANCEL;
+
+    if (rc_ptr->menu_line > rc_ptr->size())
+        rc_ptr->menu_line -= rc_ptr->size();
+
+    return RC_CONTINUE;
+}
+
+/*!
+ * @brief レイシャルパワーの選択を解釈
+ * @param creature_ptr プレイヤー情報への参照ポインタ
+ * @param rc_ptr レイシャルパワー情報への参照ポインタ
+ * @return コマンド選択していたらtrue、していなかったらfalse
+ */
+static bool racial_power_interpret_choise(player_type *creature_ptr, rc_type *rc_ptr)
+{
+    if (use_menu)
+        return false;
+
+    if (rc_ptr->choice == ' ' || rc_ptr->choice == '*') {
+        rc_ptr->page++;
+        if (rc_ptr->page >= rc_ptr->max_page + (always_show_list ? 0 : 1))
+            rc_ptr->page = 0;
+        screen_load();
+        screen_save();
+        racial_power_display_list(creature_ptr, rc_ptr);
+        return false;
     }
 
-    rc_ptr->redraw = FALSE;
-    screen_load();
-    return TRUE;
+    if (rc_ptr->choice == '?')
+        return true;
+
+    return true;
 }
 
 static void decide_racial_command(rc_type *rc_ptr)
@@ -168,100 +224,130 @@ static bool ask_invoke_racial_power(rc_type *rc_ptr)
 {
     if ((rc_ptr->command_code < 0) || (rc_ptr->command_code >= rc_ptr->size())) {
         bell();
-        return FALSE;
+        return false;
     }
 
     if (!rc_ptr->ask)
-        return TRUE;
+        return true;
 
     char tmp_val[160];
     (void)strnfmt(tmp_val, 78, _("%sを使いますか？ ", "Use %s? "), rc_ptr->power_desc[rc_ptr->command_code].racial_name.c_str());
     return get_check(tmp_val);
 }
 
-static bool process_racial_power_choice(player_type *creature_ptr, rc_type *rc_ptr)
+/*!
+ * @brief レイシャルパワー選択処理のメインループ
+ * @param creature_ptr プレイヤー情報への参照ポインタ
+ * @param rc_ptr レイシャルパワー情報への参照ポインタ
+ * @return コマンド選択したらRC_CONTINUE、キャンセルしたらRC_CANCEL
+ */
+static bool racial_power_process_input(player_type *creature_ptr, rc_type *rc_ptr)
 {
     rc_ptr->choice = (always_show_list || use_menu) ? ESCAPE : 1;
-    while (!rc_ptr->flag) {
+
+    while (true) {
         if (rc_ptr->choice == ESCAPE)
             rc_ptr->choice = ' ';
         else if (!get_com(rc_ptr->out_val, &rc_ptr->choice, FALSE))
+            return RC_CANCEL;
+
+        if (racial_power_select_by_menu(creature_ptr, rc_ptr) == RC_CANCEL)
+            return RC_CANCEL;
+
+        if (rc_ptr->is_chosen)
             break;
 
-        if (check_input_racial_power(creature_ptr, rc_ptr))
-            return TRUE;
-
-        if (check_racial_power_choice(creature_ptr, rc_ptr))
-            continue;
-
-        decide_racial_command(rc_ptr);
-        if (!ask_invoke_racial_power(rc_ptr))
-            continue;
-
-        rc_ptr->flag = TRUE;
+        if (racial_power_interpret_choise(creature_ptr, rc_ptr)) {
+            decide_racial_command(rc_ptr);
+            if (ask_invoke_racial_power(rc_ptr))
+                break;
+        }
     }
 
-    return FALSE;
+    return RC_CONTINUE;
 }
 
-static bool repeat_racial_power(player_type *creature_ptr, rc_type *rc_ptr)
+/*!
+ * @brief レイシャル/クラスパワー選択を処理
+ * @param creature_ptr プレイヤー情報への参照ポインタ
+ * @param rc_ptr レイシャルパワー情報への参照ポインタ
+ * @return コマンド選択したらRC_CONTINUE、キャンセルしたらRC_CANCEL
+ */
+static bool racial_power_select_power(player_type *creature_ptr, rc_type *rc_ptr)
 {
-    if (repeat_pull(&rc_ptr->command_code) && (rc_ptr->command_code >= 0) && (rc_ptr->command_code < rc_ptr->size()))
-        return FALSE;
+    if (repeat_pull(&rc_ptr->command_code) && rc_ptr->command_code >= 0 && rc_ptr->command_code < rc_ptr->size())
+        return RC_CONTINUE;
+
+    screen_save();
 
     if (use_menu)
-        screen_save();
+        racial_power_display_list(creature_ptr, rc_ptr);
 
-    if (process_racial_power_choice(creature_ptr, rc_ptr))
-        return TRUE;
+    auto canceled = racial_power_process_input(creature_ptr, rc_ptr) == RC_CANCEL;
 
-    if (rc_ptr->redraw)
-        screen_load();
+    screen_load();
 
-    if (!rc_ptr->flag) {
-        free_turn(creature_ptr);
-        return TRUE;
-    }
+    if (canceled)
+        return RC_CANCEL;
 
     repeat_push(rc_ptr->command_code);
-    return FALSE;
+    return RC_CONTINUE;
 }
 
-static void check_cast_racial_power(player_type *creature_ptr, rc_type *rc_ptr)
+/*!
+ * @brief レイシャルパワーの使用を試みる
+ * @param creature_ptr プレイヤー情報への参照ポインタ
+ * @param rc_ptr レイシャルパワー情報への参照ポインタ
+ * @return なし
+ * @details
+ * 戻り値の代わりにrc_ptr->castに使用の有無を入れる。
+ */
+static void racial_power_cast_power(player_type *creature_ptr, rc_type *rc_ptr)
 {
-    switch (check_racial_level(creature_ptr, &rc_ptr->power_desc[rc_ptr->command_code])) {
-    case RACIAL_SUCCESS:
-        if (rc_ptr->power_desc[rc_ptr->command_code].number < 0)
-            rc_ptr->cast = exe_racial_power(creature_ptr, rc_ptr->power_desc[rc_ptr->command_code].number);
-        else
-            rc_ptr->cast = exe_mutation_power(creature_ptr, static_cast<MUTA>(rc_ptr->power_desc[rc_ptr->command_code].number));
+    auto *rpi_ptr = &rc_ptr->power_desc[rc_ptr->command_code];
 
+    switch (check_racial_level(creature_ptr, rpi_ptr)) {
+    case RACIAL_SUCCESS:
+        if (rpi_ptr->number < 0)
+            rc_ptr->cast = exe_racial_power(creature_ptr, rpi_ptr->number);
+        else
+            rc_ptr->cast = exe_mutation_power(creature_ptr, static_cast<MUTA>(rpi_ptr->number));
         break;
     case RACIAL_FAILURE:
-        rc_ptr->cast = TRUE;
+        rc_ptr->cast = true;
         break;
     case RACIAL_CANCEL:
-        rc_ptr->cast = FALSE;
+        rc_ptr->cast = false;
         break;
     }
 }
 
-static bool reduce_mana_by_racial(player_type *creature_ptr, rc_type *rc_ptr)
+/*!
+ * @brief レイシャルパワーのコストを減らす
+ * @param creature_ptr プレイヤー情報への参照ポインタ
+ * @param rc_ptr レイシャルパワー情報への参照ポインタ
+ * @return コストを減らしたらtrue、減らさなかったらfalse
+ * @details
+ * MPが足りない場合はHPを減らす。
+ * 戻り値はHP/MPの再描画が必要か判定するのに使用。
+ */
+static bool racial_power_reduce_mana(player_type *creature_ptr, rc_type *rc_ptr)
 {
     int racial_cost = rc_ptr->power_desc[rc_ptr->command_code].racial_cost;
     if (racial_cost == 0)
-        return FALSE;
+        return false;
 
     int actual_racial_cost = racial_cost / 2 + randint1(racial_cost / 2);
-    if (creature_ptr->csp >= actual_racial_cost) {
+
+    if (creature_ptr->csp >= actual_racial_cost)
         creature_ptr->csp -= actual_racial_cost;
-        return TRUE;
+    else {
+        actual_racial_cost -= creature_ptr->csp;
+        creature_ptr->csp = 0;
+        take_hit(creature_ptr, DAMAGE_USELIFE, actual_racial_cost, _("過度の集中", "concentrating too hard"));
     }
 
-    actual_racial_cost -= creature_ptr->csp;
-    creature_ptr->csp = 0;
-    take_hit(creature_ptr, DAMAGE_USELIFE, actual_racial_cost, _("過度の集中", "concentrating too hard"));
-    return TRUE;
+    return true;
 }
 
 /*!
@@ -282,39 +368,41 @@ void do_cmd_racial_power(player_type *creature_ptr)
     if (creature_ptr->special_defense & (KATA_MUSOU | KATA_KOUKIJIN))
         set_action(creature_ptr, ACTION_NONE);
 
-    rc_type tmp_r = rc_type(creature_ptr);
-    rc_type *rc_ptr = &tmp_r;
+    auto tmp_r = rc_type(creature_ptr);
+    auto *rc_ptr = &tmp_r;
+
     switch_class_racial(creature_ptr, rc_ptr);
+
     if (creature_ptr->mimic_form)
         set_mimic_racial_command(creature_ptr, rc_ptr);
     else
         set_race_racial_command(creature_ptr, rc_ptr);
 
     select_mutation_racial(creature_ptr, rc_ptr);
-    rc_ptr->flag = FALSE;
-    rc_ptr->redraw = FALSE;
 
     if (rc_ptr->size() == 0) {
         msg_print(_("特殊能力はありません。", "You have no special powers."));
         return;
     }
 
+    rc_ptr->max_page = 1 + (rc_ptr->size() - 1) / RC_PAGE_SIZE;
+    rc_ptr->page = use_menu ? 0 : -1;
+
     (void)strnfmt(rc_ptr->out_val, 78,
         _("(特殊能力 %c-%c, *'で一覧, ESCで中断) どの特殊能力を使いますか？", "(Powers %c-%c, *=List, ESC=exit) Use which power? "), I2A(0),
         (rc_ptr->size() <= 26) ? I2A(rc_ptr->size() - 1) : '0' + rc_ptr->size() - 27);
 
-    if (repeat_racial_power(creature_ptr, rc_ptr))
-        return;
+    if (racial_power_select_power(creature_ptr, rc_ptr) == RC_CONTINUE)
+        racial_power_cast_power(creature_ptr, rc_ptr);
 
-    check_cast_racial_power(creature_ptr, rc_ptr);
     if (!rc_ptr->cast) {
         free_turn(creature_ptr);
         return;
     }
 
-    if (!reduce_mana_by_racial(creature_ptr, rc_ptr))
+    if (!racial_power_reduce_mana(creature_ptr, rc_ptr))
         return;
 
-    creature_ptr->redraw |= PR_HP | PR_MANA;
-    creature_ptr->window_flags |= PW_PLAYER | PW_SPELL;
+    set_bits(creature_ptr->redraw, PR_HP | PR_MANA);
+    set_bits(creature_ptr->window_flags, PW_PLAYER | PW_SPELL);
 }

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -68,6 +68,8 @@ concptr KWD_RANGE = _("射程:", "rng ");
 concptr KWD_DURATION = _("期間:", "dur ");
 concptr KWD_SPHERE = _("範囲:", "range ");
 concptr KWD_HEAL = _("回復:", "heal ");
+concptr KWD_MANA = _("MP回復:", "heal SP ");
+concptr KWD_POWER _("効力:", "power ");
 concptr KWD_RANDOM = _("ランダム", "random");
 
 /*!

--- a/src/cmd-action/cmd-spell.h
+++ b/src/cmd-action/cmd-spell.h
@@ -2,12 +2,14 @@
 
 #include "system/angband.h"
 
-extern concptr KWD_DAM;
-extern concptr KWD_RANGE;
-extern concptr KWD_DURATION;
-extern concptr KWD_SPHERE;
-extern concptr KWD_HEAL;
-extern concptr KWD_RANDOM;
+extern concptr KWD_DAM; //!< 効果文字列: 損傷 / dam
+extern concptr KWD_RANGE; //!< 効果文字列: 射程 / dir
+extern concptr KWD_DURATION; //!< 効果文字列: 期間 / dur
+extern concptr KWD_SPHERE; //!< 効果文字列: 範囲 / range
+extern concptr KWD_HEAL; //!< 効果文字列: 回復 / heal
+extern concptr KWD_MANA; //!< 効果文字列: MP回復 / heal SP
+extern concptr KWD_POWER; //!< 効果文字列: 効力 / power
+extern concptr KWD_RANDOM; //!< 効果文字列: ランダム / random
 
 extern const u32b fake_spell_flags[4];
 

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -1256,6 +1256,7 @@ void switch_element_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case ElementRealm::ICE:
         rpi = rc_ptr->make_power(_("周辺フリーズ", "Sleep monsters"));
+        rpi.info = format("%s%d", KWD_POWER, 20 + plev * 3 / 2);
         rpi.min_level = 10;
         rpi.cost = 15;
         rpi.stat = A_WIS;
@@ -1264,6 +1265,7 @@ void switch_element_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case ElementRealm::SKY:
         rpi = rc_ptr->make_power(_("魔力充填", "Recharging"));
+        rpi.info = format("%s%d", KWD_POWER, 120);
         rpi.min_level = 20;
         rpi.cost = 15;
         rpi.stat = A_WIS;
@@ -1279,7 +1281,8 @@ void switch_element_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_CLASS_1);
         break;
     case ElementRealm::DARKNESS:
-        rpi = rc_ptr->make_power(format(_("闇の扉(半径%d)", "Door to darkness(rad %d)"), 15 + plev / 2));
+        rpi = rc_ptr->make_power(format(_("闇の扉", "Door to darkness"), 15 + plev / 2));
+        rpi.info = format("%s%d", KWD_SPHERE, 15 + plev / 2);
         rpi.min_level = 5;
         rpi.cost = 5 + plev / 7;
         rpi.stat = A_WIS;
@@ -1296,6 +1299,7 @@ void switch_element_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case ElementRealm::EARTH:
         rpi = rc_ptr->make_power(_("地震", "Earthquake"));
+        rpi.info = format("%s%d", KWD_SPHERE, 10);
         rpi.min_level = 25;
         rpi.cost = 15;
         rpi.stat = A_WIS;

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -1248,6 +1248,7 @@ void switch_element_racial(player_type *creature_ptr, rc_type *rc_ptr)
     switch (realm) {
     case ElementRealm::FIRE:
         rpi = rc_ptr->make_power(_("ライト・エリア", "Light area"));
+        rpi.text = _("光源が照らしている範囲か部屋全体を永久に明るくする。", "Lights up nearby area and the inside of a room permanently.");
         rpi.min_level = 3;
         rpi.cost = 5;
         rpi.stat = A_WIS;
@@ -1257,6 +1258,7 @@ void switch_element_racial(player_type *creature_ptr, rc_type *rc_ptr)
     case ElementRealm::ICE:
         rpi = rc_ptr->make_power(_("周辺フリーズ", "Sleep monsters"));
         rpi.info = format("%s%d", KWD_POWER, 20 + plev * 3 / 2);
+        rpi.text = _("視界内の全てのモンスターを眠らせる。抵抗されると無効。", "Attempts to put all monsters in sight to sleep.");
         rpi.min_level = 10;
         rpi.cost = 15;
         rpi.stat = A_WIS;
@@ -1266,6 +1268,7 @@ void switch_element_racial(player_type *creature_ptr, rc_type *rc_ptr)
     case ElementRealm::SKY:
         rpi = rc_ptr->make_power(_("魔力充填", "Recharging"));
         rpi.info = format("%s%d", KWD_POWER, 120);
+        rpi.text = _("杖/魔法棒の充填回数を増やすか、充填中のロッドの充填時間を減らす。", "Recharges staffs, wands or rods.");
         rpi.min_level = 20;
         rpi.cost = 15;
         rpi.stat = A_WIS;
@@ -1274,6 +1277,7 @@ void switch_element_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case ElementRealm::SEA:
         rpi = rc_ptr->make_power(_("岩石溶解", "Stone to mud"));
+        rpi.text = _("壁を溶かして床にする。", "Turns one rock square to mud.");
         rpi.min_level = 5;
         rpi.cost = 5;
         rpi.stat = A_WIS;
@@ -1291,6 +1295,7 @@ void switch_element_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case ElementRealm::CHAOS:
         rpi = rc_ptr->make_power(_("現実変容", "Alter reality"));
+        rpi.text = _("現在の階を再構成する。", "Recreates current dungeon level.");
         rpi.min_level = 35;
         rpi.cost = 30;
         rpi.stat = A_WIS;
@@ -1300,6 +1305,8 @@ void switch_element_racial(player_type *creature_ptr, rc_type *rc_ptr)
     case ElementRealm::EARTH:
         rpi = rc_ptr->make_power(_("地震", "Earthquake"));
         rpi.info = format("%s%d", KWD_SPHERE, 10);
+        rpi.text
+            = _("周囲のダンジョンを揺らし、壁と床をランダムに入れ変える。", "Shakes dungeon structure, and results in random swapping of floors and walls.");
         rpi.min_level = 25;
         rpi.cost = 15;
         rpi.stat = A_WIS;
@@ -1308,6 +1315,7 @@ void switch_element_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case ElementRealm::DEATH:
         rpi = rc_ptr->make_power(_("増殖阻止", "Sterilization"));
+        rpi.text = _("この階の増殖するモンスターが増殖できなくなる。", "Prevents any breeders on current level from breeding.");
         rpi.min_level = 5;
         rpi.cost = 5;
         rpi.stat = A_WIS;

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -1244,70 +1244,71 @@ void switch_element_racial(player_type *creature_ptr, rc_type *rc_ptr)
 {
     auto plev = creature_ptr->lev;
     auto realm = static_cast<ElementRealm>(creature_ptr->element);
+    rpi_type rpi;
     switch (realm) {
     case ElementRealm::FIRE:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("ライト・エリア", "Light area");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 3;
-        rc_ptr->power_desc[rc_ptr->num].cost = 5;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = 10;
-        rc_ptr->power_desc[rc_ptr->num++].number = -4;
+        rpi = rc_ptr->make_power(_("ライト・エリア", "Light area"));
+        rpi.min_level = 3;
+        rpi.cost = 5;
+        rpi.stat = A_WIS;
+        rpi.fail = 10;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_1);
         break;
     case ElementRealm::ICE:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("周辺フリーズ", "Sleep monsters");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 10;
-        rc_ptr->power_desc[rc_ptr->num].cost = 15;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = 25;
-        rc_ptr->power_desc[rc_ptr->num++].number = -4;
+        rpi = rc_ptr->make_power(_("周辺フリーズ", "Sleep monsters"));
+        rpi.min_level = 10;
+        rpi.cost = 15;
+        rpi.stat = A_WIS;
+        rpi.fail = 25;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_1);
         break;
     case ElementRealm::SKY:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("魔力充填", "Recharging");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 20;
-        rc_ptr->power_desc[rc_ptr->num].cost = 15;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = 25;
-        rc_ptr->power_desc[rc_ptr->num++].number = -4;
+        rpi = rc_ptr->make_power(_("魔力充填", "Recharging"));
+        rpi.min_level = 20;
+        rpi.cost = 15;
+        rpi.stat = A_WIS;
+        rpi.fail = 25;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_1);
         break;
     case ElementRealm::SEA:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("岩石溶解", "Stone to mud");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 5;
-        rc_ptr->power_desc[rc_ptr->num].cost = 5;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = 10;
-        rc_ptr->power_desc[rc_ptr->num++].number = -4;
+        rpi = rc_ptr->make_power(_("岩石溶解", "Stone to mud"));
+        rpi.min_level = 5;
+        rpi.cost = 5;
+        rpi.stat = A_WIS;
+        rpi.fail = 10;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_1);
         break;
     case ElementRealm::DARKNESS:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = format(_("闇の扉(半径%d)", "Door to darkness(rad %d)"), 15 + plev / 2);
-        rc_ptr->power_desc[rc_ptr->num].min_level = 5;
-        rc_ptr->power_desc[rc_ptr->num].cost = 5 + plev / 7;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = 20;
-        rc_ptr->power_desc[rc_ptr->num++].number = -4;
+        rpi = rc_ptr->make_power(format(_("闇の扉(半径%d)", "Door to darkness(rad %d)"), 15 + plev / 2));
+        rpi.min_level = 5;
+        rpi.cost = 5 + plev / 7;
+        rpi.stat = A_WIS;
+        rpi.fail = 20;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_1);
         break;
     case ElementRealm::CHAOS:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("現実変容", "Alter reality");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 35;
-        rc_ptr->power_desc[rc_ptr->num].cost = 30;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = 40;
-        rc_ptr->power_desc[rc_ptr->num++].number = -4;
+        rpi = rc_ptr->make_power(_("現実変容", "Alter reality"));
+        rpi.min_level = 35;
+        rpi.cost = 30;
+        rpi.stat = A_WIS;
+        rpi.fail = 40;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_1);
         break;
     case ElementRealm::EARTH:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("地震", "Earthquake");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 25;
-        rc_ptr->power_desc[rc_ptr->num].cost = 15;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = 20;
-        rc_ptr->power_desc[rc_ptr->num++].number = -4;
+        rpi = rc_ptr->make_power(_("地震", "Earthquake"));
+        rpi.min_level = 25;
+        rpi.cost = 15;
+        rpi.stat = A_WIS;
+        rpi.fail = 20;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_1);
         break;
     case ElementRealm::DEATH:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("増殖阻止", "Sterilization");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 5;
-        rc_ptr->power_desc[rc_ptr->num].cost = 5;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = 20;
-        rc_ptr->power_desc[rc_ptr->num++].number = -4;
+        rpi = rc_ptr->make_power(_("増殖阻止", "Sterilization"));
+        rpi.min_level = 5;
+        rpi.cost = 5;
+        rpi.stat = A_WIS;
+        rpi.fail = 20;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_1);
         break;
     default:
         break;

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -1246,7 +1246,7 @@ void switch_element_racial(player_type *creature_ptr, rc_type *rc_ptr)
     auto realm = static_cast<ElementRealm>(creature_ptr->element);
     switch (realm) {
     case ElementRealm::FIRE:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("ライト・エリア", "Light area"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("ライト・エリア", "Light area");
         rc_ptr->power_desc[rc_ptr->num].min_level = 3;
         rc_ptr->power_desc[rc_ptr->num].cost = 5;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -1254,7 +1254,7 @@ void switch_element_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -4;
         break;
     case ElementRealm::ICE:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("周辺フリーズ", "Sleep monsters"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("周辺フリーズ", "Sleep monsters");
         rc_ptr->power_desc[rc_ptr->num].min_level = 10;
         rc_ptr->power_desc[rc_ptr->num].cost = 15;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -1262,7 +1262,7 @@ void switch_element_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -4;
         break;
     case ElementRealm::SKY:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("魔力充填", "Recharging"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("魔力充填", "Recharging");
         rc_ptr->power_desc[rc_ptr->num].min_level = 20;
         rc_ptr->power_desc[rc_ptr->num].cost = 15;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -1270,7 +1270,7 @@ void switch_element_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -4;
         break;
     case ElementRealm::SEA:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("岩石溶解", "Stone to mud"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("岩石溶解", "Stone to mud");
         rc_ptr->power_desc[rc_ptr->num].min_level = 5;
         rc_ptr->power_desc[rc_ptr->num].cost = 5;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -1278,7 +1278,7 @@ void switch_element_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -4;
         break;
     case ElementRealm::DARKNESS:
-        sprintf(rc_ptr->power_desc[rc_ptr->num].racial_name, _("闇の扉(半径%d)", "Door to darkness(rad %d)"), 15 + plev / 2);
+        rc_ptr->power_desc[rc_ptr->num].racial_name = format(_("闇の扉(半径%d)", "Door to darkness(rad %d)"), 15 + plev / 2);
         rc_ptr->power_desc[rc_ptr->num].min_level = 5;
         rc_ptr->power_desc[rc_ptr->num].cost = 5 + plev / 7;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -1286,7 +1286,7 @@ void switch_element_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -4;
         break;
     case ElementRealm::CHAOS:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("現実変容", "Alter reality"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("現実変容", "Alter reality");
         rc_ptr->power_desc[rc_ptr->num].min_level = 35;
         rc_ptr->power_desc[rc_ptr->num].cost = 30;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -1294,7 +1294,7 @@ void switch_element_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -4;
         break;
     case ElementRealm::EARTH:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("地震", "Earthquake"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("地震", "Earthquake");
         rc_ptr->power_desc[rc_ptr->num].min_level = 25;
         rc_ptr->power_desc[rc_ptr->num].cost = 15;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -1302,7 +1302,7 @@ void switch_element_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -4;
         break;
     case ElementRealm::DEATH:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("増殖阻止", "Sterilization"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("増殖阻止", "Sterilization");
         rc_ptr->power_desc[rc_ptr->num].min_level = 5;
         rc_ptr->power_desc[rc_ptr->num].cost = 5;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;

--- a/src/racial/class-racial-switcher.cpp
+++ b/src/racial/class-racial-switcher.cpp
@@ -1,4 +1,5 @@
 ﻿#include "racial/class-racial-switcher.h"
+#include "cmd-action/cmd-spell.h"
 #include "mind/mind-elementalist.h"
 #include "racial/racial-util.h"
 #include "realm/realm-names-table.h"
@@ -30,6 +31,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
     case CLASS_MAGE:
     case CLASS_SORCERER:
         rpi = rc_ptr->make_power(_("魔力食い", "Eat Magic"));
+        rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl * 2);
         rpi.min_level = 25;
         rpi.cost = 1;
         rpi.stat = A_INT;
@@ -46,6 +48,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
             rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         } else {
             rpi = rc_ptr->make_power(_("召魂", "Evocation"));
+            rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl * 4);
             rpi.min_level = 42;
             rpi.cost = 40;
             rpi.stat = A_WIS;
@@ -56,6 +59,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case CLASS_ROGUE:
         rpi = rc_ptr->make_power(_("ヒット＆アウェイ", "Hit and Away"));
+        rpi.info = format("%s%d", KWD_SPHERE, 30);
         rpi.min_level = 8;
         rpi.cost = 12;
         rpi.stat = A_DEX;
@@ -74,6 +78,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
     case CLASS_PALADIN:
         if (is_good_realm(creature_ptr->realm1)) {
             rpi = rc_ptr->make_power(_("ホーリー・ランス", "Holy Lance"));
+            rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 3);
             rpi.min_level = 30;
             rpi.cost = 30;
             rpi.stat = A_WIS;
@@ -81,6 +86,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
             rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         } else {
             rpi = rc_ptr->make_power(_("ヘル・ランス", "Hell Lance"));
+            rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 3);
             rpi.min_level = 30;
             rpi.cost = 30;
             rpi.stat = A_WIS;
@@ -106,6 +112,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case CLASS_CHAOS_WARRIOR:
         rpi = rc_ptr->make_power(_("幻惑の光", "Confusing Light"));
+        rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl * 4);
         rpi.min_level = 40;
         rpi.cost = 50;
         rpi.stat = A_INT;
@@ -130,6 +137,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
     case CLASS_MINDCRAFTER:
     case CLASS_FORCETRAINER:
         rpi = rc_ptr->make_power(_("明鏡止水", "Clear Mind"));
+        rpi.info = format("%s%d", KWD_MANA, 3 + rc_ptr->lvl / 20);
         rpi.min_level = 15;
         rpi.cost = 0;
         rpi.stat = A_WIS;
@@ -161,6 +169,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case CLASS_BEASTMASTER:
         rpi = rc_ptr->make_power(_("生物支配", "Dominate a Living Thing"));
+        rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl);
         rpi.min_level = 1;
         rpi.cost = (creature_ptr->lev + 3) / 4;
         rpi.stat = A_CHR;
@@ -168,6 +177,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
 
         rpi = rc_ptr->make_power(_("真・生物支配", "Dominate Living Things"));
+        rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl);
         rpi.min_level = 30;
         rpi.cost = (creature_ptr->lev + 20) / 2;
         rpi.stat = A_CHR;
@@ -261,6 +271,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
 
         rpi = rc_ptr->make_power(_("静水", "Mirror Concentration"));
+        rpi.info = format("%s%d", KWD_MANA, 3 + rc_ptr->lvl / 20);
         rpi.min_level = 30;
         rpi.cost = 0;
         rpi.stat = A_INT;
@@ -285,6 +296,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case CLASS_ELEMENTALIST:
         rpi = rc_ptr->make_power(_("明鏡止水", "Clear Mind"));
+        rpi.info = format("%s%d", KWD_MANA, 3 + rc_ptr->lvl / 20);
         rpi.min_level = 15;
         rpi.cost = 0;
         rpi.stat = A_WIS;

--- a/src/racial/class-racial-switcher.cpp
+++ b/src/racial/class-racial-switcher.cpp
@@ -11,6 +11,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
     switch (creature_ptr->pclass) {
     case CLASS_WARRIOR:
         rpi = rc_ptr->make_power(_("剣の舞い", "Sword Dancing"));
+        rpi.text = _("ランダムな方向に数回攻撃する。", "Attacks some times to random directions.");
         rpi.min_level = 40;
         rpi.cost = 75;
         rpi.stat = A_DEX;
@@ -20,6 +21,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
     case CLASS_HIGH_MAGE:
         if (creature_ptr->realm1 == REALM_HEX) {
             rpi = rc_ptr->make_power(_("詠唱をやめる", "Stop spell casting"));
+            rpi.text = _("呪術の詠唱を全てやめる。", "Stops all casting hex spells.");
             rpi.min_level = 1;
             rpi.cost = 0;
             rpi.stat = A_INT;
@@ -32,6 +34,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
     case CLASS_SORCERER:
         rpi = rc_ptr->make_power(_("魔力食い", "Eat Magic"));
         rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl * 2);
+        rpi.text = _("魔法道具から魔力を吸収してMPを回復する。", "Absorbs mana from a magic device to heal your SP.");
         rpi.min_level = 25;
         rpi.cost = 1;
         rpi.stat = A_INT;
@@ -41,6 +44,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
     case CLASS_PRIEST:
         if (is_good_realm(creature_ptr->realm1)) {
             rpi = rc_ptr->make_power(_("武器祝福", "Bless Weapon"));
+            rpi.text = _("武器を祝福する。抵抗されることがある。", "Blesses a weapon. Some weapons can resist it.");
             rpi.min_level = 35;
             rpi.cost = 70;
             rpi.stat = A_WIS;
@@ -49,6 +53,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         } else {
             rpi = rc_ptr->make_power(_("召魂", "Evocation"));
             rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl * 4);
+            rpi.text = _("視界内の全てのモンスターにダメージを与え、恐怖させ、遠くへ飛ばす。", "Deals damage to all monster in your sight, makes them scared and tereports then away.");
             rpi.min_level = 42;
             rpi.cost = 40;
             rpi.stat = A_WIS;
@@ -60,6 +65,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
     case CLASS_ROGUE:
         rpi = rc_ptr->make_power(_("ヒット＆アウェイ", "Hit and Away"));
         rpi.info = format("%s%d", KWD_SPHERE, 30);
+        rpi.text = _("対象のモンスターを攻撃したあと短距離テレポートする。", "Attacks a monster then tereports you a short range.");
         rpi.min_level = 8;
         rpi.cost = 12;
         rpi.stat = A_DEX;
@@ -69,6 +75,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
     case CLASS_RANGER:
     case CLASS_SNIPER:
         rpi = rc_ptr->make_power(_("モンスター調査", "Probe Monster"));
+        rpi.text = _("モンスターの属性、残り体力、最大体力、スピード、正体を知る。", "Probes all monsters' alignment, HP, speed and their true character.");
         rpi.min_level = 15;
         rpi.cost = 20;
         rpi.stat = A_INT;
@@ -79,6 +86,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         if (is_good_realm(creature_ptr->realm1)) {
             rpi = rc_ptr->make_power(_("ホーリー・ランス", "Holy Lance"));
             rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 3);
+            rpi.text = _("聖なる炎のビームを放つ。", "Fires a beam of holy fire.");
             rpi.min_level = 30;
             rpi.cost = 30;
             rpi.stat = A_WIS;
@@ -87,6 +95,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         } else {
             rpi = rc_ptr->make_power(_("ヘル・ランス", "Hell Lance"));
             rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 3);
+            rpi.text = _("地獄の業火のビームを放つ。", "Fires a beam of hell fire.");
             rpi.min_level = 30;
             rpi.cost = 30;
             rpi.stat = A_WIS;
@@ -97,6 +106,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case CLASS_WARRIOR_MAGE:
         rpi = rc_ptr->make_power(_("変換: ＨＰ→ＭＰ", "Convert HP to SP"));
+        rpi.text = _("HPを少しMPに変換する。", "Transfers a few HP to SP.");
         rpi.min_level = 25;
         rpi.cost = 0;
         rpi.stat = A_INT;
@@ -104,6 +114,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
 
         rpi = rc_ptr->make_power(_("変換: ＭＰ→ＨＰ", "Convert SP to HP"));
+        rpi.text = _("MPを少しHPに変換する。", "Transfers a few SP to HP.");
         rpi.min_level = 25;
         rpi.cost = 0;
         rpi.stat = A_INT;
@@ -113,6 +124,8 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
     case CLASS_CHAOS_WARRIOR:
         rpi = rc_ptr->make_power(_("幻惑の光", "Confusing Light"));
         rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl * 4);
+        rpi.text = _("周辺のモンスターを減速・朦朧・混乱・朦朧・恐怖・睡眠させようとする。抵抗されると無効。",
+            "Tries to make all monsters in your sight slowed, stuned, confused, scared, sleeped.");
         rpi.min_level = 40;
         rpi.cost = 50;
         rpi.stat = A_INT;
@@ -121,6 +134,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case CLASS_MONK:
         rpi = rc_ptr->make_power(_("構える", "Assume a Stance"));
+        rpi.text = _("型に構えて特殊な能力を得る。", "Gains extra abilities with posing a 'kata'.");
         rpi.min_level = 25;
         rpi.cost = 0;
         rpi.stat = A_DEX;
@@ -128,6 +142,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
 
         rpi = rc_ptr->make_power(_("百裂拳", "Double Attack"));
+        rpi.text = _("対象に対して2回の打撃を行う。", "Melee attacks to a target monster two times.");
         rpi.min_level = 30;
         rpi.cost = 30;
         rpi.stat = A_STR;
@@ -138,6 +153,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
     case CLASS_FORCETRAINER:
         rpi = rc_ptr->make_power(_("明鏡止水", "Clear Mind"));
         rpi.info = format("%s%d", KWD_MANA, 3 + rc_ptr->lvl / 20);
+        rpi.text = _("精神を集中してMPを少し回復する。", "Concentrates deeply to heal your SP a little.");
         rpi.min_level = 15;
         rpi.cost = 0;
         rpi.stat = A_WIS;
@@ -146,6 +162,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case CLASS_TOURIST:
         rpi = rc_ptr->make_power(_("写真撮影", "Take a Photograph"));
+        rpi.text = _("対象のモンスター1体の写真を撮影する。", "Takes a picture of a monster.");
         rpi.min_level = 1;
         rpi.cost = 0;
         rpi.stat = A_DEX;
@@ -153,6 +170,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
 
         rpi = rc_ptr->make_power(_("真・鑑定", "Identify True"));
+        rpi.text = _("アイテムの持つ能力を完全に知る。", "*Identifies* an item.");
         rpi.min_level = 25;
         rpi.cost = 20;
         rpi.stat = A_INT;
@@ -161,6 +179,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case CLASS_IMITATOR:
         rpi = rc_ptr->make_power(_("倍返し", "Double Revenge"));
+        rpi.text = _("威力を倍にしてものまねを行う。", "Fires an imitation a damage of which you makes doubled.");
         rpi.min_level = 30;
         rpi.cost = 100;
         rpi.stat = A_DEX;
@@ -170,6 +189,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
     case CLASS_BEASTMASTER:
         rpi = rc_ptr->make_power(_("生物支配", "Dominate a Living Thing"));
         rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl);
+        rpi.text = _("1体のモンスターをペットにする。抵抗されると無効。", "Attempts to charm a monster.");
         rpi.min_level = 1;
         rpi.cost = (creature_ptr->lev + 3) / 4;
         rpi.stat = A_CHR;
@@ -178,6 +198,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
         rpi = rc_ptr->make_power(_("真・生物支配", "Dominate Living Things"));
         rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl);
+        rpi.text = _("周辺のモンスターをペットにする。抵抗されると無効。", "Attempts to charm a monsters in your sight.");
         rpi.min_level = 30;
         rpi.cost = (creature_ptr->lev + 20) / 2;
         rpi.stat = A_CHR;
@@ -186,6 +207,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case CLASS_ARCHER:
         rpi = rc_ptr->make_power(_("弾/矢の製造", "Create Ammo"));
+        rpi.text = _("弾または矢を製造する。原料となるアイテムが必要。", "Creates ammos from materials.");
         rpi.min_level = 1;
         rpi.cost = 0;
         rpi.stat = A_DEX;
@@ -194,6 +216,8 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case CLASS_MAGIC_EATER:
         rpi = rc_ptr->make_power(_("魔力の取り込み", "Absorb Magic"));
+        rpi.text = _("魔法道具を取りこんで魔力とする。取りこんだ魔法道具は取り出せない。",
+            "Absorbs a magic device as your mana. Cannot take out it from your mana later.");
         rpi.min_level = 1;
         rpi.cost = 0;
         rpi.stat = A_INT;
@@ -201,6 +225,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
 
         rpi = rc_ptr->make_power(_("強力発動", "Powerful Activation"));
+        rpi.text = _("取りこんだ魔法道具を威力を高めて使用する。", "Activates absorbed magic device powerfully.");
         rpi.min_level = 10;
         rpi.cost = 10 + (rc_ptr->lvl - 10) / 2;
         rpi.stat = A_INT;
@@ -209,6 +234,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case CLASS_BARD:
         rpi = rc_ptr->make_power(_("歌を止める", "Stop Singing"));
+        rpi.text = _("現在詠唱中の歌をやめる。", "Stops singing a song.");
         rpi.min_level = 1;
         rpi.cost = 0;
         rpi.stat = A_CHR;
@@ -217,6 +243,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case CLASS_RED_MAGE:
         rpi = rc_ptr->make_power(_("連続魔", "Double Magic"));
+        rpi.text = _("1回の行動で2つの呪文を詠唱する。", "Casts two spells in an action.");
         rpi.min_level = 48;
         rpi.cost = 20;
         rpi.stat = A_INT;
@@ -225,6 +252,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case CLASS_SAMURAI:
         rpi = rc_ptr->make_power(_("気合いため", "Concentration"));
+        rpi.text = _("気合を溜めてMPを増やす。上限値をある程度超えられる。", "Increases SP for Kendo over SP limit.");
         rpi.min_level = 1;
         rpi.cost = 0;
         rpi.stat = A_WIS;
@@ -232,6 +260,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
 
         rpi = rc_ptr->make_power(_("型", "Assume a Stance"));
+        rpi.text = _("型に構えて特殊な能力を得る。", "Gains extra abilities with posing a 'kata'.");
         rpi.min_level = 25;
         rpi.cost = 0;
         rpi.stat = A_DEX;
@@ -240,6 +269,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case CLASS_BLUE_MAGE:
         rpi = rc_ptr->make_power(_("ラーニング", "Learning"));
+        rpi.text = _("青魔法の学習を開始または終了する。学習中はMPを消費する。", "Starts or ends to learn blue magics. Pays SP for upkeep costs during it.");
         rpi.min_level = 1;
         rpi.cost = 0;
         rpi.stat = A_INT;
@@ -248,6 +278,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case CLASS_CAVALRY:
         rpi = rc_ptr->make_power(_("荒馬ならし", "Rodeo"));
+        rpi.text = _("対象のモンスターの無理やり乗馬しペットにする。", "Rides to target monster and tame it focibly.");
         rpi.min_level = 10;
         rpi.cost = 0;
         rpi.stat = A_STR;
@@ -256,6 +287,8 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case CLASS_BERSERKER:
         rpi = rc_ptr->make_power(_("帰還", "Recall"));
+        rpi.text = _("地上にいるときはダンジョンの最深階へ、ダンジョンにいるときは地上へと移動する。",
+            "Recalls player from dungeon to town or from town to the deepest level of dungeon.");
         rpi.min_level = 10;
         rpi.cost = 10;
         rpi.stat = A_DEX;
@@ -264,6 +297,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case CLASS_MIRROR_MASTER:
         rpi = rc_ptr->make_power(_("鏡割り", "Break Mirrors"));
+        rpi.text = _("現在の階に設置した鏡を全て割る。割られた鏡はなくなり、破片属性のボールが発生する。", "Destroys all mirrors located in current level. They are deleted from the level.");
         rpi.min_level = 1;
         rpi.cost = 0;
         rpi.stat = A_INT;
@@ -272,6 +306,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
         rpi = rc_ptr->make_power(_("静水", "Mirror Concentration"));
         rpi.info = format("%s%d", KWD_MANA, 3 + rc_ptr->lvl / 20);
+        rpi.info = _("精神を集中してMPを少し回復する。", "Concentrates deeply to heal your SP a little.");
         rpi.min_level = 30;
         rpi.cost = 0;
         rpi.stat = A_INT;
@@ -280,6 +315,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case CLASS_SMITH:
         rpi = rc_ptr->make_power(_("目利き", "Judgment"));
+        rpi.text = _("武器・矢弾・防具を鑑定する。", "Identifies an equipment or an ammo object.");
         rpi.min_level = 5;
         rpi.cost = 15;
         rpi.stat = A_INT;
@@ -288,6 +324,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case CLASS_NINJA:
         rpi = rc_ptr->make_power(_("速駆け", "Quick Walk"));
+        rpi.text = _("身体を酷使して素早く移動する。", "Moves quickly but cannot regenerate HP naturally.");
         rpi.min_level = 20;
         rpi.cost = 0;
         rpi.stat = A_DEX;
@@ -297,6 +334,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
     case CLASS_ELEMENTALIST:
         rpi = rc_ptr->make_power(_("明鏡止水", "Clear Mind"));
         rpi.info = format("%s%d", KWD_MANA, 3 + rc_ptr->lvl / 20);
+        rpi.text = _("精神を集中してMPを少し回復する。", "Concentrates deeply to heal your SP a little.");
         rpi.min_level = 15;
         rpi.cost = 0;
         rpi.stat = A_WIS;

--- a/src/racial/class-racial-switcher.cpp
+++ b/src/racial/class-racial-switcher.cpp
@@ -8,7 +8,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
 {
     switch (creature_ptr->pclass) {
     case CLASS_WARRIOR:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("剣の舞い", "Sword Dancing"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("剣の舞い", "Sword Dancing");
         rc_ptr->power_desc[rc_ptr->num].min_level = 40;
         rc_ptr->power_desc[rc_ptr->num].cost = 75;
         rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
@@ -17,7 +17,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case CLASS_HIGH_MAGE:
         if (creature_ptr->realm1 == REALM_HEX) {
-            strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("詠唱をやめる", "Stop spell casting"));
+            rc_ptr->power_desc[rc_ptr->num].racial_name = _("詠唱をやめる", "Stop spell casting");
             rc_ptr->power_desc[rc_ptr->num].min_level = 1;
             rc_ptr->power_desc[rc_ptr->num].cost = 0;
             rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
@@ -28,7 +28,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         /* Fall through */
     case CLASS_MAGE:
     case CLASS_SORCERER:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("魔力食い", "Eat Magic"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("魔力食い", "Eat Magic");
         rc_ptr->power_desc[rc_ptr->num].min_level = 25;
         rc_ptr->power_desc[rc_ptr->num].cost = 1;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
@@ -37,14 +37,14 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case CLASS_PRIEST:
         if (is_good_realm(creature_ptr->realm1)) {
-            strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("武器祝福", "Bless Weapon"));
+            rc_ptr->power_desc[rc_ptr->num].racial_name = _("武器祝福", "Bless Weapon");
             rc_ptr->power_desc[rc_ptr->num].min_level = 35;
             rc_ptr->power_desc[rc_ptr->num].cost = 70;
             rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
             rc_ptr->power_desc[rc_ptr->num].fail = 50;
             rc_ptr->power_desc[rc_ptr->num++].number = -3;
         } else {
-            strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("召魂", "Evocation"));
+            rc_ptr->power_desc[rc_ptr->num].racial_name = _("召魂", "Evocation");
             rc_ptr->power_desc[rc_ptr->num].min_level = 42;
             rc_ptr->power_desc[rc_ptr->num].cost = 40;
             rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -54,7 +54,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
         break;
     case CLASS_ROGUE:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("ヒット＆アウェイ", "Hit and Away"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("ヒット＆アウェイ", "Hit and Away");
         rc_ptr->power_desc[rc_ptr->num].min_level = 8;
         rc_ptr->power_desc[rc_ptr->num].cost = 12;
         rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
@@ -63,7 +63,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case CLASS_RANGER:
     case CLASS_SNIPER:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("モンスター調査", "Probe Monster"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("モンスター調査", "Probe Monster");
         rc_ptr->power_desc[rc_ptr->num].min_level = 15;
         rc_ptr->power_desc[rc_ptr->num].cost = 20;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
@@ -72,14 +72,14 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case CLASS_PALADIN:
         if (is_good_realm(creature_ptr->realm1)) {
-            strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("ホーリー・ランス", "Holy Lance"));
+            rc_ptr->power_desc[rc_ptr->num].racial_name = _("ホーリー・ランス", "Holy Lance");
             rc_ptr->power_desc[rc_ptr->num].min_level = 30;
             rc_ptr->power_desc[rc_ptr->num].cost = 30;
             rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
             rc_ptr->power_desc[rc_ptr->num].fail = 30;
             rc_ptr->power_desc[rc_ptr->num++].number = -3;
         } else {
-            strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("ヘル・ランス", "Hell Lance"));
+            rc_ptr->power_desc[rc_ptr->num].racial_name = _("ヘル・ランス", "Hell Lance");
             rc_ptr->power_desc[rc_ptr->num].min_level = 30;
             rc_ptr->power_desc[rc_ptr->num].cost = 30;
             rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -89,14 +89,14 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
         break;
     case CLASS_WARRIOR_MAGE:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("変換: ＨＰ→ＭＰ", "Convert HP to SP"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("変換: ＨＰ→ＭＰ", "Convert HP to SP");
         rc_ptr->power_desc[rc_ptr->num].min_level = 25;
         rc_ptr->power_desc[rc_ptr->num].cost = 0;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
         rc_ptr->power_desc[rc_ptr->num].fail = 10;
         rc_ptr->power_desc[rc_ptr->num++].number = -3;
 
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("変換: ＭＰ→ＨＰ", "Convert SP to HP"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("変換: ＭＰ→ＨＰ", "Convert SP to HP");
         rc_ptr->power_desc[rc_ptr->num].min_level = 25;
         rc_ptr->power_desc[rc_ptr->num].cost = 0;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
@@ -104,7 +104,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -4;
         break;
     case CLASS_CHAOS_WARRIOR:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("幻惑の光", "Confusing Light"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("幻惑の光", "Confusing Light");
         rc_ptr->power_desc[rc_ptr->num].min_level = 40;
         rc_ptr->power_desc[rc_ptr->num].cost = 50;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
@@ -112,14 +112,14 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -3;
         break;
     case CLASS_MONK:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("構える", "Assume a Stance"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("構える", "Assume a Stance");
         rc_ptr->power_desc[rc_ptr->num].min_level = 25;
         rc_ptr->power_desc[rc_ptr->num].cost = 0;
         rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
         rc_ptr->power_desc[rc_ptr->num].fail = 0;
         rc_ptr->power_desc[rc_ptr->num++].number = -3;
 
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("百裂拳", "Double Attack"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("百裂拳", "Double Attack");
         rc_ptr->power_desc[rc_ptr->num].min_level = 30;
         rc_ptr->power_desc[rc_ptr->num].cost = 30;
         rc_ptr->power_desc[rc_ptr->num].stat = A_STR;
@@ -128,7 +128,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case CLASS_MINDCRAFTER:
     case CLASS_FORCETRAINER:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("明鏡止水", "Clear Mind"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("明鏡止水", "Clear Mind");
         rc_ptr->power_desc[rc_ptr->num].min_level = 15;
         rc_ptr->power_desc[rc_ptr->num].cost = 0;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -136,14 +136,14 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -3;
         break;
     case CLASS_TOURIST:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("写真撮影", "Take a Photograph"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("写真撮影", "Take a Photograph");
         rc_ptr->power_desc[rc_ptr->num].min_level = 1;
         rc_ptr->power_desc[rc_ptr->num].cost = 0;
         rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
         rc_ptr->power_desc[rc_ptr->num].fail = 0;
         rc_ptr->power_desc[rc_ptr->num++].number = -3;
 
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("真・鑑定", "Identify True"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("真・鑑定", "Identify True");
         rc_ptr->power_desc[rc_ptr->num].min_level = 25;
         rc_ptr->power_desc[rc_ptr->num].cost = 20;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
@@ -151,7 +151,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -4;
         break;
     case CLASS_IMITATOR:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("倍返し", "Double Revenge"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("倍返し", "Double Revenge");
         rc_ptr->power_desc[rc_ptr->num].min_level = 30;
         rc_ptr->power_desc[rc_ptr->num].cost = 100;
         rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
@@ -159,14 +159,14 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -3;
         break;
     case CLASS_BEASTMASTER:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("生物支配", "Dominate a Living Thing"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("生物支配", "Dominate a Living Thing");
         rc_ptr->power_desc[rc_ptr->num].min_level = 1;
         rc_ptr->power_desc[rc_ptr->num].cost = (creature_ptr->lev + 3) / 4;
         rc_ptr->power_desc[rc_ptr->num].stat = A_CHR;
         rc_ptr->power_desc[rc_ptr->num].fail = 10;
         rc_ptr->power_desc[rc_ptr->num++].number = -3;
 
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("真・生物支配", "Dominate Living Things"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("真・生物支配", "Dominate Living Things");
         rc_ptr->power_desc[rc_ptr->num].min_level = 30;
         rc_ptr->power_desc[rc_ptr->num].cost = (creature_ptr->lev + 20) / 2;
         rc_ptr->power_desc[rc_ptr->num].stat = A_CHR;
@@ -174,7 +174,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -4;
         break;
     case CLASS_ARCHER:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("弾/矢の製造", "Create Ammo"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("弾/矢の製造", "Create Ammo");
         rc_ptr->power_desc[rc_ptr->num].min_level = 1;
         rc_ptr->power_desc[rc_ptr->num].cost = 0;
         rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
@@ -182,14 +182,14 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -3;
         break;
     case CLASS_MAGIC_EATER:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("魔力の取り込み", "Absorb Magic"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("魔力の取り込み", "Absorb Magic");
         rc_ptr->power_desc[rc_ptr->num].min_level = 1;
         rc_ptr->power_desc[rc_ptr->num].cost = 0;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
         rc_ptr->power_desc[rc_ptr->num].fail = 0;
         rc_ptr->power_desc[rc_ptr->num++].number = -3;
 
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("強力発動", "Powerful Activation"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("強力発動", "Powerful Activation");
         rc_ptr->power_desc[rc_ptr->num].min_level = 10;
         rc_ptr->power_desc[rc_ptr->num].cost = 10 + (rc_ptr->lvl - 10) / 2;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
@@ -197,7 +197,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -4;
         break;
     case CLASS_BARD:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("歌を止める", "Stop Singing"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("歌を止める", "Stop Singing");
         rc_ptr->power_desc[rc_ptr->num].min_level = 1;
         rc_ptr->power_desc[rc_ptr->num].cost = 0;
         rc_ptr->power_desc[rc_ptr->num].stat = A_CHR;
@@ -205,7 +205,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -3;
         break;
     case CLASS_RED_MAGE:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("連続魔", "Double Magic"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("連続魔", "Double Magic");
         rc_ptr->power_desc[rc_ptr->num].min_level = 48;
         rc_ptr->power_desc[rc_ptr->num].cost = 20;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
@@ -213,14 +213,14 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -3;
         break;
     case CLASS_SAMURAI:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("気合いため", "Concentration"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("気合いため", "Concentration");
         rc_ptr->power_desc[rc_ptr->num].min_level = 1;
         rc_ptr->power_desc[rc_ptr->num].cost = 0;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
         rc_ptr->power_desc[rc_ptr->num].fail = 0;
         rc_ptr->power_desc[rc_ptr->num++].number = -3;
 
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("型", "Assume a Stance"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("型", "Assume a Stance");
         rc_ptr->power_desc[rc_ptr->num].min_level = 25;
         rc_ptr->power_desc[rc_ptr->num].cost = 0;
         rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
@@ -228,7 +228,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -4;
         break;
     case CLASS_BLUE_MAGE:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("ラーニング", "Learning"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("ラーニング", "Learning");
         rc_ptr->power_desc[rc_ptr->num].min_level = 1;
         rc_ptr->power_desc[rc_ptr->num].cost = 0;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
@@ -236,7 +236,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -3;
         break;
     case CLASS_CAVALRY:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("荒馬ならし", "Rodeo"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("荒馬ならし", "Rodeo");
         rc_ptr->power_desc[rc_ptr->num].min_level = 10;
         rc_ptr->power_desc[rc_ptr->num].cost = 0;
         rc_ptr->power_desc[rc_ptr->num].stat = A_STR;
@@ -244,7 +244,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -3;
         break;
     case CLASS_BERSERKER:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("帰還", "Recall"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("帰還", "Recall");
         rc_ptr->power_desc[rc_ptr->num].min_level = 10;
         rc_ptr->power_desc[rc_ptr->num].cost = 10;
         rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
@@ -252,14 +252,14 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -3;
         break;
     case CLASS_MIRROR_MASTER:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("鏡割り", "Break Mirrors"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("鏡割り", "Break Mirrors");
         rc_ptr->power_desc[rc_ptr->num].min_level = 1;
         rc_ptr->power_desc[rc_ptr->num].cost = 0;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
         rc_ptr->power_desc[rc_ptr->num].fail = 0;
         rc_ptr->power_desc[rc_ptr->num++].number = -3;
 
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("静水", "Mirror Concentration"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("静水", "Mirror Concentration");
         rc_ptr->power_desc[rc_ptr->num].min_level = 30;
         rc_ptr->power_desc[rc_ptr->num].cost = 0;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
@@ -267,7 +267,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -4;
         break;
     case CLASS_SMITH:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("目利き", "Judgment"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("目利き", "Judgment");
         rc_ptr->power_desc[rc_ptr->num].min_level = 5;
         rc_ptr->power_desc[rc_ptr->num].cost = 15;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
@@ -275,7 +275,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -3;
         break;
     case CLASS_NINJA:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("速駆け", "Quick Walk"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("速駆け", "Quick Walk");
         rc_ptr->power_desc[rc_ptr->num].min_level = 20;
         rc_ptr->power_desc[rc_ptr->num].cost = 0;
         rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
@@ -283,7 +283,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -3;
         break;
     case CLASS_ELEMENTALIST:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("明鏡止水", "Clear Mind"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("明鏡止水", "Clear Mind");
         rc_ptr->power_desc[rc_ptr->num].min_level = 15;
         rc_ptr->power_desc[rc_ptr->num].cost = 0;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -293,7 +293,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         switch_element_racial(creature_ptr, rc_ptr);
         break;
     default:
-        strcpy(rc_ptr->power_desc[0].racial_name, _("(なし)", "(none)"));
+        rc_ptr->power_desc[0].racial_name = _("(なし)", "(none)");
         break;
     }
 }

--- a/src/racial/class-racial-switcher.cpp
+++ b/src/racial/class-racial-switcher.cpp
@@ -6,294 +6,294 @@
 
 void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
 {
+    rpi_type rpi;
     switch (creature_ptr->pclass) {
     case CLASS_WARRIOR:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("剣の舞い", "Sword Dancing");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 40;
-        rc_ptr->power_desc[rc_ptr->num].cost = 75;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
-        rc_ptr->power_desc[rc_ptr->num].fail = 35;
-        rc_ptr->power_desc[rc_ptr->num++].number = -3;
+        rpi = rc_ptr->make_power(_("剣の舞い", "Sword Dancing"));
+        rpi.min_level = 40;
+        rpi.cost = 75;
+        rpi.stat = A_DEX;
+        rpi.fail = 35;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         break;
     case CLASS_HIGH_MAGE:
         if (creature_ptr->realm1 == REALM_HEX) {
-            rc_ptr->power_desc[rc_ptr->num].racial_name = _("詠唱をやめる", "Stop spell casting");
-            rc_ptr->power_desc[rc_ptr->num].min_level = 1;
-            rc_ptr->power_desc[rc_ptr->num].cost = 0;
-            rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-            rc_ptr->power_desc[rc_ptr->num].fail = 0;
-            rc_ptr->power_desc[rc_ptr->num++].number = -3;
+            rpi = rc_ptr->make_power(_("詠唱をやめる", "Stop spell casting"));
+            rpi.min_level = 1;
+            rpi.cost = 0;
+            rpi.stat = A_INT;
+            rpi.fail = 0;
+            rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
             break;
         }
         /* Fall through */
     case CLASS_MAGE:
     case CLASS_SORCERER:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("魔力食い", "Eat Magic");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 25;
-        rc_ptr->power_desc[rc_ptr->num].cost = 1;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 25;
-        rc_ptr->power_desc[rc_ptr->num++].number = -3;
+        rpi = rc_ptr->make_power(_("魔力食い", "Eat Magic"));
+        rpi.min_level = 25;
+        rpi.cost = 1;
+        rpi.stat = A_INT;
+        rpi.fail = 25;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         break;
     case CLASS_PRIEST:
         if (is_good_realm(creature_ptr->realm1)) {
-            rc_ptr->power_desc[rc_ptr->num].racial_name = _("武器祝福", "Bless Weapon");
-            rc_ptr->power_desc[rc_ptr->num].min_level = 35;
-            rc_ptr->power_desc[rc_ptr->num].cost = 70;
-            rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-            rc_ptr->power_desc[rc_ptr->num].fail = 50;
-            rc_ptr->power_desc[rc_ptr->num++].number = -3;
+            rpi = rc_ptr->make_power(_("武器祝福", "Bless Weapon"));
+            rpi.min_level = 35;
+            rpi.cost = 70;
+            rpi.stat = A_WIS;
+            rpi.fail = 50;
+            rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         } else {
-            rc_ptr->power_desc[rc_ptr->num].racial_name = _("召魂", "Evocation");
-            rc_ptr->power_desc[rc_ptr->num].min_level = 42;
-            rc_ptr->power_desc[rc_ptr->num].cost = 40;
-            rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-            rc_ptr->power_desc[rc_ptr->num].fail = 35;
-            rc_ptr->power_desc[rc_ptr->num++].number = -3;
+            rpi = rc_ptr->make_power(_("召魂", "Evocation"));
+            rpi.min_level = 42;
+            rpi.cost = 40;
+            rpi.stat = A_WIS;
+            rpi.fail = 35;
+            rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         }
 
         break;
     case CLASS_ROGUE:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("ヒット＆アウェイ", "Hit and Away");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 8;
-        rc_ptr->power_desc[rc_ptr->num].cost = 12;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
-        rc_ptr->power_desc[rc_ptr->num].fail = 14;
-        rc_ptr->power_desc[rc_ptr->num++].number = -3;
+        rpi = rc_ptr->make_power(_("ヒット＆アウェイ", "Hit and Away"));
+        rpi.min_level = 8;
+        rpi.cost = 12;
+        rpi.stat = A_DEX;
+        rpi.fail = 14;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         break;
     case CLASS_RANGER:
     case CLASS_SNIPER:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("モンスター調査", "Probe Monster");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 15;
-        rc_ptr->power_desc[rc_ptr->num].cost = 20;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 12;
-        rc_ptr->power_desc[rc_ptr->num++].number = -3;
+        rpi = rc_ptr->make_power(_("モンスター調査", "Probe Monster"));
+        rpi.min_level = 15;
+        rpi.cost = 20;
+        rpi.stat = A_INT;
+        rpi.fail = 12;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         break;
     case CLASS_PALADIN:
         if (is_good_realm(creature_ptr->realm1)) {
-            rc_ptr->power_desc[rc_ptr->num].racial_name = _("ホーリー・ランス", "Holy Lance");
-            rc_ptr->power_desc[rc_ptr->num].min_level = 30;
-            rc_ptr->power_desc[rc_ptr->num].cost = 30;
-            rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-            rc_ptr->power_desc[rc_ptr->num].fail = 30;
-            rc_ptr->power_desc[rc_ptr->num++].number = -3;
+            rpi = rc_ptr->make_power(_("ホーリー・ランス", "Holy Lance"));
+            rpi.min_level = 30;
+            rpi.cost = 30;
+            rpi.stat = A_WIS;
+            rpi.fail = 30;
+            rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         } else {
-            rc_ptr->power_desc[rc_ptr->num].racial_name = _("ヘル・ランス", "Hell Lance");
-            rc_ptr->power_desc[rc_ptr->num].min_level = 30;
-            rc_ptr->power_desc[rc_ptr->num].cost = 30;
-            rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-            rc_ptr->power_desc[rc_ptr->num].fail = 30;
-            rc_ptr->power_desc[rc_ptr->num++].number = -3;
+            rpi = rc_ptr->make_power(_("ヘル・ランス", "Hell Lance"));
+            rpi.min_level = 30;
+            rpi.cost = 30;
+            rpi.stat = A_WIS;
+            rpi.fail = 30;
+            rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         }
 
         break;
     case CLASS_WARRIOR_MAGE:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("変換: ＨＰ→ＭＰ", "Convert HP to SP");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 25;
-        rc_ptr->power_desc[rc_ptr->num].cost = 0;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 10;
-        rc_ptr->power_desc[rc_ptr->num++].number = -3;
+        rpi = rc_ptr->make_power(_("変換: ＨＰ→ＭＰ", "Convert HP to SP"));
+        rpi.min_level = 25;
+        rpi.cost = 0;
+        rpi.stat = A_INT;
+        rpi.fail = 10;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
 
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("変換: ＭＰ→ＨＰ", "Convert SP to HP");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 25;
-        rc_ptr->power_desc[rc_ptr->num].cost = 0;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 10;
-        rc_ptr->power_desc[rc_ptr->num++].number = -4;
+        rpi = rc_ptr->make_power(_("変換: ＭＰ→ＨＰ", "Convert SP to HP"));
+        rpi.min_level = 25;
+        rpi.cost = 0;
+        rpi.stat = A_INT;
+        rpi.fail = 10;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_1);
         break;
     case CLASS_CHAOS_WARRIOR:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("幻惑の光", "Confusing Light");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 40;
-        rc_ptr->power_desc[rc_ptr->num].cost = 50;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 25;
-        rc_ptr->power_desc[rc_ptr->num++].number = -3;
+        rpi = rc_ptr->make_power(_("幻惑の光", "Confusing Light"));
+        rpi.min_level = 40;
+        rpi.cost = 50;
+        rpi.stat = A_INT;
+        rpi.fail = 25;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         break;
     case CLASS_MONK:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("構える", "Assume a Stance");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 25;
-        rc_ptr->power_desc[rc_ptr->num].cost = 0;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
-        rc_ptr->power_desc[rc_ptr->num].fail = 0;
-        rc_ptr->power_desc[rc_ptr->num++].number = -3;
+        rpi = rc_ptr->make_power(_("構える", "Assume a Stance"));
+        rpi.min_level = 25;
+        rpi.cost = 0;
+        rpi.stat = A_DEX;
+        rpi.fail = 0;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
 
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("百裂拳", "Double Attack");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 30;
-        rc_ptr->power_desc[rc_ptr->num].cost = 30;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_STR;
-        rc_ptr->power_desc[rc_ptr->num].fail = 20;
-        rc_ptr->power_desc[rc_ptr->num++].number = -4;
+        rpi = rc_ptr->make_power(_("百裂拳", "Double Attack"));
+        rpi.min_level = 30;
+        rpi.cost = 30;
+        rpi.stat = A_STR;
+        rpi.fail = 20;
+        rc_ptr->add_power(rpi, -4);
         break;
     case CLASS_MINDCRAFTER:
     case CLASS_FORCETRAINER:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("明鏡止水", "Clear Mind");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 15;
-        rc_ptr->power_desc[rc_ptr->num].cost = 0;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = 10;
-        rc_ptr->power_desc[rc_ptr->num++].number = -3;
+        rpi = rc_ptr->make_power(_("明鏡止水", "Clear Mind"));
+        rpi.min_level = 15;
+        rpi.cost = 0;
+        rpi.stat = A_WIS;
+        rpi.fail = 10;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         break;
     case CLASS_TOURIST:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("写真撮影", "Take a Photograph");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 1;
-        rc_ptr->power_desc[rc_ptr->num].cost = 0;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
-        rc_ptr->power_desc[rc_ptr->num].fail = 0;
-        rc_ptr->power_desc[rc_ptr->num++].number = -3;
+        rpi = rc_ptr->make_power(_("写真撮影", "Take a Photograph"));
+        rpi.min_level = 1;
+        rpi.cost = 0;
+        rpi.stat = A_DEX;
+        rpi.fail = 0;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
 
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("真・鑑定", "Identify True");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 25;
-        rc_ptr->power_desc[rc_ptr->num].cost = 20;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 20;
-        rc_ptr->power_desc[rc_ptr->num++].number = -4;
+        rpi = rc_ptr->make_power(_("真・鑑定", "Identify True"));
+        rpi.min_level = 25;
+        rpi.cost = 20;
+        rpi.stat = A_INT;
+        rpi.fail = 20;
+        rc_ptr->add_power(rpi, -4);
         break;
     case CLASS_IMITATOR:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("倍返し", "Double Revenge");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 30;
-        rc_ptr->power_desc[rc_ptr->num].cost = 100;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
-        rc_ptr->power_desc[rc_ptr->num].fail = 30;
-        rc_ptr->power_desc[rc_ptr->num++].number = -3;
+        rpi = rc_ptr->make_power(_("倍返し", "Double Revenge"));
+        rpi.min_level = 30;
+        rpi.cost = 100;
+        rpi.stat = A_DEX;
+        rpi.fail = 30;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         break;
     case CLASS_BEASTMASTER:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("生物支配", "Dominate a Living Thing");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 1;
-        rc_ptr->power_desc[rc_ptr->num].cost = (creature_ptr->lev + 3) / 4;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_CHR;
-        rc_ptr->power_desc[rc_ptr->num].fail = 10;
-        rc_ptr->power_desc[rc_ptr->num++].number = -3;
+        rpi = rc_ptr->make_power(_("生物支配", "Dominate a Living Thing"));
+        rpi.min_level = 1;
+        rpi.cost = (creature_ptr->lev + 3) / 4;
+        rpi.stat = A_CHR;
+        rpi.fail = 10;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
 
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("真・生物支配", "Dominate Living Things");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 30;
-        rc_ptr->power_desc[rc_ptr->num].cost = (creature_ptr->lev + 20) / 2;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_CHR;
-        rc_ptr->power_desc[rc_ptr->num].fail = 10;
-        rc_ptr->power_desc[rc_ptr->num++].number = -4;
+        rpi = rc_ptr->make_power(_("真・生物支配", "Dominate Living Things"));
+        rpi.min_level = 30;
+        rpi.cost = (creature_ptr->lev + 20) / 2;
+        rpi.stat = A_CHR;
+        rpi.fail = 10;
+        rc_ptr->add_power(rpi, -4);
         break;
     case CLASS_ARCHER:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("弾/矢の製造", "Create Ammo");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 1;
-        rc_ptr->power_desc[rc_ptr->num].cost = 0;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
-        rc_ptr->power_desc[rc_ptr->num].fail = 0;
-        rc_ptr->power_desc[rc_ptr->num++].number = -3;
+        rpi = rc_ptr->make_power(_("弾/矢の製造", "Create Ammo"));
+        rpi.min_level = 1;
+        rpi.cost = 0;
+        rpi.stat = A_DEX;
+        rpi.fail = 0;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         break;
     case CLASS_MAGIC_EATER:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("魔力の取り込み", "Absorb Magic");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 1;
-        rc_ptr->power_desc[rc_ptr->num].cost = 0;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 0;
-        rc_ptr->power_desc[rc_ptr->num++].number = -3;
+        rpi = rc_ptr->make_power(_("魔力の取り込み", "Absorb Magic"));
+        rpi.min_level = 1;
+        rpi.cost = 0;
+        rpi.stat = A_INT;
+        rpi.fail = 0;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
 
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("強力発動", "Powerful Activation");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 10;
-        rc_ptr->power_desc[rc_ptr->num].cost = 10 + (rc_ptr->lvl - 10) / 2;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 0;
-        rc_ptr->power_desc[rc_ptr->num++].number = -4;
+        rpi = rc_ptr->make_power(_("強力発動", "Powerful Activation"));
+        rpi.min_level = 10;
+        rpi.cost = 10 + (rc_ptr->lvl - 10) / 2;
+        rpi.stat = A_INT;
+        rpi.fail = 0;
+        rc_ptr->add_power(rpi, -4);
         break;
     case CLASS_BARD:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("歌を止める", "Stop Singing");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 1;
-        rc_ptr->power_desc[rc_ptr->num].cost = 0;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_CHR;
-        rc_ptr->power_desc[rc_ptr->num].fail = 0;
-        rc_ptr->power_desc[rc_ptr->num++].number = -3;
+        rpi = rc_ptr->make_power(_("歌を止める", "Stop Singing"));
+        rpi.min_level = 1;
+        rpi.cost = 0;
+        rpi.stat = A_CHR;
+        rpi.fail = 0;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         break;
     case CLASS_RED_MAGE:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("連続魔", "Double Magic");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 48;
-        rc_ptr->power_desc[rc_ptr->num].cost = 20;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 0;
-        rc_ptr->power_desc[rc_ptr->num++].number = -3;
+        rpi = rc_ptr->make_power(_("連続魔", "Double Magic"));
+        rpi.min_level = 48;
+        rpi.cost = 20;
+        rpi.stat = A_INT;
+        rpi.fail = 0;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         break;
     case CLASS_SAMURAI:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("気合いため", "Concentration");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 1;
-        rc_ptr->power_desc[rc_ptr->num].cost = 0;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = 0;
-        rc_ptr->power_desc[rc_ptr->num++].number = -3;
+        rpi = rc_ptr->make_power(_("気合いため", "Concentration"));
+        rpi.min_level = 1;
+        rpi.cost = 0;
+        rpi.stat = A_WIS;
+        rpi.fail = 0;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
 
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("型", "Assume a Stance");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 25;
-        rc_ptr->power_desc[rc_ptr->num].cost = 0;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
-        rc_ptr->power_desc[rc_ptr->num].fail = 0;
-        rc_ptr->power_desc[rc_ptr->num++].number = -4;
+        rpi = rc_ptr->make_power(_("型", "Assume a Stance"));
+        rpi.min_level = 25;
+        rpi.cost = 0;
+        rpi.stat = A_DEX;
+        rpi.fail = 0;
+        rc_ptr->add_power(rpi, -4);
         break;
     case CLASS_BLUE_MAGE:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("ラーニング", "Learning");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 1;
-        rc_ptr->power_desc[rc_ptr->num].cost = 0;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 0;
-        rc_ptr->power_desc[rc_ptr->num++].number = -3;
+        rpi = rc_ptr->make_power(_("ラーニング", "Learning"));
+        rpi.min_level = 1;
+        rpi.cost = 0;
+        rpi.stat = A_INT;
+        rpi.fail = 0;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         break;
     case CLASS_CAVALRY:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("荒馬ならし", "Rodeo");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 10;
-        rc_ptr->power_desc[rc_ptr->num].cost = 0;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_STR;
-        rc_ptr->power_desc[rc_ptr->num].fail = 10;
-        rc_ptr->power_desc[rc_ptr->num++].number = -3;
+        rpi = rc_ptr->make_power(_("荒馬ならし", "Rodeo"));
+        rpi.min_level = 10;
+        rpi.cost = 0;
+        rpi.stat = A_STR;
+        rpi.fail = 10;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         break;
     case CLASS_BERSERKER:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("帰還", "Recall");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 10;
-        rc_ptr->power_desc[rc_ptr->num].cost = 10;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
-        rc_ptr->power_desc[rc_ptr->num].fail = 20;
-        rc_ptr->power_desc[rc_ptr->num++].number = -3;
+        rpi = rc_ptr->make_power(_("帰還", "Recall"));
+        rpi.min_level = 10;
+        rpi.cost = 10;
+        rpi.stat = A_DEX;
+        rpi.fail = 20;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         break;
     case CLASS_MIRROR_MASTER:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("鏡割り", "Break Mirrors");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 1;
-        rc_ptr->power_desc[rc_ptr->num].cost = 0;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 0;
-        rc_ptr->power_desc[rc_ptr->num++].number = -3;
+        rpi = rc_ptr->make_power(_("鏡割り", "Break Mirrors"));
+        rpi.min_level = 1;
+        rpi.cost = 0;
+        rpi.stat = A_INT;
+        rpi.fail = 0;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
 
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("静水", "Mirror Concentration");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 30;
-        rc_ptr->power_desc[rc_ptr->num].cost = 0;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 20;
-        rc_ptr->power_desc[rc_ptr->num++].number = -4;
+        rpi = rc_ptr->make_power(_("静水", "Mirror Concentration"));
+        rpi.min_level = 30;
+        rpi.cost = 0;
+        rpi.stat = A_INT;
+        rpi.fail = 20;
+        rc_ptr->add_power(rpi, -4);
         break;
     case CLASS_SMITH:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("目利き", "Judgment");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 5;
-        rc_ptr->power_desc[rc_ptr->num].cost = 15;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 20;
-        rc_ptr->power_desc[rc_ptr->num++].number = -3;
+        rpi = rc_ptr->make_power(_("目利き", "Judgment"));
+        rpi.min_level = 5;
+        rpi.cost = 15;
+        rpi.stat = A_INT;
+        rpi.fail = 20;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         break;
     case CLASS_NINJA:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("速駆け", "Quick Walk");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 20;
-        rc_ptr->power_desc[rc_ptr->num].cost = 0;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
-        rc_ptr->power_desc[rc_ptr->num].fail = 0;
-        rc_ptr->power_desc[rc_ptr->num++].number = -3;
+        rpi = rc_ptr->make_power(_("速駆け", "Quick Walk"));
+        rpi.min_level = 20;
+        rpi.cost = 0;
+        rpi.stat = A_DEX;
+        rpi.fail = 0;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         break;
     case CLASS_ELEMENTALIST:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("明鏡止水", "Clear Mind");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 15;
-        rc_ptr->power_desc[rc_ptr->num].cost = 0;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = 10;
-        rc_ptr->power_desc[rc_ptr->num++].number = -3;
+        rpi = rc_ptr->make_power(_("明鏡止水", "Clear Mind"));
+        rpi.min_level = 15;
+        rpi.cost = 0;
+        rpi.stat = A_WIS;
+        rpi.fail = 10;
+        rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
 
         switch_element_racial(creature_ptr, rc_ptr);
         break;
     default:
-        rc_ptr->power_desc[0].racial_name = _("(なし)", "(none)");
         break;
     }
 }

--- a/src/racial/class-racial-switcher.h
+++ b/src/racial/class-racial-switcher.h
@@ -2,5 +2,5 @@
 
 #include "system/angband.h"
 
-typedef struct rc_type rc_type;
+struct rc_type;
 void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr);

--- a/src/racial/mutation-racial-selector.cpp
+++ b/src/racial/mutation-racial-selector.cpp
@@ -4,291 +4,293 @@
 
 void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 {
+    rpi_type rpi;
+
     if (creature_ptr->muta.has(MUTA::SPIT_ACID)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("酸の唾", "Spit Acid");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 9;
-        rc_ptr->power_desc[rc_ptr->num].cost = 9;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
-        rc_ptr->power_desc[rc_ptr->num].fail = 15;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::SPIT_ACID);
+        rpi = rc_ptr->make_power(_("酸の唾", "Spit Acid"));
+        rpi.min_level = 9;
+        rpi.cost = 9;
+        rpi.stat = A_DEX;
+        rpi.fail = 15;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::SPIT_ACID));
     }
 
     if (creature_ptr->muta.has(MUTA::BR_FIRE)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("炎のブレス", "Fire Breath");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 20;
-        rc_ptr->power_desc[rc_ptr->num].cost = rc_ptr->lvl;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
-        rc_ptr->power_desc[rc_ptr->num].fail = 18;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::BR_FIRE);
+        rpi = rc_ptr->make_power(_("炎のブレス", "Fire Breath"));
+        rpi.min_level = 20;
+        rpi.cost = rc_ptr->lvl;
+        rpi.stat = A_CON;
+        rpi.fail = 18;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::BR_FIRE));
     }
 
     if (creature_ptr->muta.has(MUTA::HYPN_GAZE)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("催眠睨み", "Hypnotic Gaze");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 12;
-        rc_ptr->power_desc[rc_ptr->num].cost = 12;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_CHR;
-        rc_ptr->power_desc[rc_ptr->num].fail = 18;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::HYPN_GAZE);
+        rpi = rc_ptr->make_power(_("催眠睨み", "Hypnotic Gaze"));
+        rpi.min_level = 12;
+        rpi.cost = 12;
+        rpi.stat = A_CHR;
+        rpi.fail = 18;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::HYPN_GAZE));
     }
 
     if (creature_ptr->muta.has(MUTA::TELEKINES)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("念動力", "Telekinesis");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 9;
-        rc_ptr->power_desc[rc_ptr->num].cost = 9;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = 14;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::TELEKINES);
+        rpi = rc_ptr->make_power(_("念動力", "Telekinesis"));
+        rpi.min_level = 9;
+        rpi.cost = 9;
+        rpi.stat = A_WIS;
+        rpi.fail = 14;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::TELEKINES));
     }
 
     if (creature_ptr->muta.has(MUTA::VTELEPORT)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("テレポート", "Teleport");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 7;
-        rc_ptr->power_desc[rc_ptr->num].cost = 7;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = 15;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::VTELEPORT);
+        rpi = rc_ptr->make_power(_("テレポート", "Teleport"));
+        rpi.min_level = 7;
+        rpi.cost = 7;
+        rpi.stat = A_WIS;
+        rpi.fail = 15;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::VTELEPORT));
     }
 
     if (creature_ptr->muta.has(MUTA::MIND_BLST)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("精神攻撃", "Mind Blast");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 5;
-        rc_ptr->power_desc[rc_ptr->num].cost = 3;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = 15;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::MIND_BLST);
+        rpi = rc_ptr->make_power(_("精神攻撃", "Mind Blast"));
+        rpi.min_level = 5;
+        rpi.cost = 3;
+        rpi.stat = A_WIS;
+        rpi.fail = 15;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::MIND_BLST));
     }
 
     if (creature_ptr->muta.has(MUTA::RADIATION)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("放射能", "Emit Radiation");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 15;
-        rc_ptr->power_desc[rc_ptr->num].cost = 15;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
-        rc_ptr->power_desc[rc_ptr->num].fail = 14;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::RADIATION);
+        rpi = rc_ptr->make_power(_("放射能", "Emit Radiation"));
+        rpi.min_level = 15;
+        rpi.cost = 15;
+        rpi.stat = A_CON;
+        rpi.fail = 14;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::RADIATION));
     }
 
     if (creature_ptr->muta.has(MUTA::VAMPIRISM)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("吸血", "Vampiric Drain");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 2;
-        rc_ptr->power_desc[rc_ptr->num].cost = 1 + (rc_ptr->lvl / 3);
-        rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
-        rc_ptr->power_desc[rc_ptr->num].fail = 9;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::VAMPIRISM);
+        rpi = rc_ptr->make_power(_("吸血", "Vampiric Drain"));
+        rpi.min_level = 2;
+        rpi.cost = 1 + (rc_ptr->lvl / 3);
+        rpi.stat = A_CON;
+        rpi.fail = 9;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::VAMPIRISM));
     }
 
     if (creature_ptr->muta.has(MUTA::SMELL_MET)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("金属嗅覚", "Smell Metal");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 3;
-        rc_ptr->power_desc[rc_ptr->num].cost = 2;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 12;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::SMELL_MET);
+        rpi = rc_ptr->make_power(_("金属嗅覚", "Smell Metal"));
+        rpi.min_level = 3;
+        rpi.cost = 2;
+        rpi.stat = A_INT;
+        rpi.fail = 12;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::SMELL_MET));
     }
 
     if (creature_ptr->muta.has(MUTA::SMELL_MON)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("敵臭嗅覚", "Smell Monsters");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 5;
-        rc_ptr->power_desc[rc_ptr->num].cost = 4;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 15;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::SMELL_MON);
+        rpi = rc_ptr->make_power(_("敵臭嗅覚", "Smell Monsters"));
+        rpi.min_level = 5;
+        rpi.cost = 4;
+        rpi.stat = A_INT;
+        rpi.fail = 15;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::SMELL_MON));
     }
 
     if (creature_ptr->muta.has(MUTA::BLINK)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("ショート・テレポート", "Blink");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 3;
-        rc_ptr->power_desc[rc_ptr->num].cost = 3;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = 12;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::BLINK);
+        rpi = rc_ptr->make_power(_("ショート・テレポート", "Blink"));
+        rpi.min_level = 3;
+        rpi.cost = 3;
+        rpi.stat = A_WIS;
+        rpi.fail = 12;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::BLINK));
     }
 
     if (creature_ptr->muta.has(MUTA::EAT_ROCK)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("岩食い", "Eat Rock");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 8;
-        rc_ptr->power_desc[rc_ptr->num].cost = 12;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
-        rc_ptr->power_desc[rc_ptr->num].fail = 18;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::EAT_ROCK);
+        rpi = rc_ptr->make_power(_("岩食い", "Eat Rock"));
+        rpi.min_level = 8;
+        rpi.cost = 12;
+        rpi.stat = A_CON;
+        rpi.fail = 18;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::EAT_ROCK));
     }
 
     if (creature_ptr->muta.has(MUTA::SWAP_POS)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("位置交換", "Swap Position");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 15;
-        rc_ptr->power_desc[rc_ptr->num].cost = 12;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
-        rc_ptr->power_desc[rc_ptr->num].fail = 16;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::SWAP_POS);
+        rpi = rc_ptr->make_power(_("位置交換", "Swap Position"));
+        rpi.min_level = 15;
+        rpi.cost = 12;
+        rpi.stat = A_DEX;
+        rpi.fail = 16;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::SWAP_POS));
     }
 
     if (creature_ptr->muta.has(MUTA::SHRIEK)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("叫び", "Shriek");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 20;
-        rc_ptr->power_desc[rc_ptr->num].cost = 14;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
-        rc_ptr->power_desc[rc_ptr->num].fail = 16;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::SHRIEK);
+        rpi = rc_ptr->make_power(_("叫び", "Shriek"));
+        rpi.min_level = 20;
+        rpi.cost = 14;
+        rpi.stat = A_CON;
+        rpi.fail = 16;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::SHRIEK));
     }
 
     if (creature_ptr->muta.has(MUTA::ILLUMINE)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("照明", "Illuminate");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 3;
-        rc_ptr->power_desc[rc_ptr->num].cost = 2;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 10;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::ILLUMINE);
+        rpi = rc_ptr->make_power(_("照明", "Illuminate"));
+        rpi.min_level = 3;
+        rpi.cost = 2;
+        rpi.stat = A_INT;
+        rpi.fail = 10;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::ILLUMINE));
     }
 
     if (creature_ptr->muta.has(MUTA::DET_CURSE)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("呪い感知", "Detect Curses");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 7;
-        rc_ptr->power_desc[rc_ptr->num].cost = 14;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = 14;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::DET_CURSE);
+        rpi = rc_ptr->make_power(_("呪い感知", "Detect Curses"));
+        rpi.min_level = 7;
+        rpi.cost = 14;
+        rpi.stat = A_WIS;
+        rpi.fail = 14;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::DET_CURSE));
     }
 
     if (creature_ptr->muta.has(MUTA::BERSERK)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("狂戦士化", "Berserk");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 8;
-        rc_ptr->power_desc[rc_ptr->num].cost = 8;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_STR;
-        rc_ptr->power_desc[rc_ptr->num].fail = 14;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::BERSERK);
+        rpi = rc_ptr->make_power(_("狂戦士化", "Berserk"));
+        rpi.min_level = 8;
+        rpi.cost = 8;
+        rpi.stat = A_STR;
+        rpi.fail = 14;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::BERSERK));
     }
 
     if (creature_ptr->muta.has(MUTA::POLYMORPH)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("変身", "Polymorph");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 18;
-        rc_ptr->power_desc[rc_ptr->num].cost = 20;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
-        rc_ptr->power_desc[rc_ptr->num].fail = 18;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::POLYMORPH);
+        rpi = rc_ptr->make_power(_("変身", "Polymorph"));
+        rpi.min_level = 18;
+        rpi.cost = 20;
+        rpi.stat = A_CON;
+        rpi.fail = 18;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::POLYMORPH));
     }
 
     if (creature_ptr->muta.has(MUTA::MIDAS_TCH)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("ミダスの手", "Midas Touch");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 10;
-        rc_ptr->power_desc[rc_ptr->num].cost = 5;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 12;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::MIDAS_TCH);
+        rpi = rc_ptr->make_power(_("ミダスの手", "Midas Touch"));
+        rpi.min_level = 10;
+        rpi.cost = 5;
+        rpi.stat = A_INT;
+        rpi.fail = 12;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::MIDAS_TCH));
     }
 
     if (creature_ptr->muta.has(MUTA::GROW_MOLD)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("カビ発生", "Grow Mold");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 1;
-        rc_ptr->power_desc[rc_ptr->num].cost = 6;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
-        rc_ptr->power_desc[rc_ptr->num].fail = 14;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::GROW_MOLD);
+        rpi = rc_ptr->make_power(_("カビ発生", "Grow Mold"));
+        rpi.min_level = 1;
+        rpi.cost = 6;
+        rpi.stat = A_CON;
+        rpi.fail = 14;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::GROW_MOLD));
     }
 
     if (creature_ptr->muta.has(MUTA::RESIST)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("エレメント耐性", "Resist Elements");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 10;
-        rc_ptr->power_desc[rc_ptr->num].cost = 12;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
-        rc_ptr->power_desc[rc_ptr->num].fail = 12;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::RESIST);
+        rpi = rc_ptr->make_power(_("エレメント耐性", "Resist Elements"));
+        rpi.min_level = 10;
+        rpi.cost = 12;
+        rpi.stat = A_CON;
+        rpi.fail = 12;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::RESIST));
     }
 
     if (creature_ptr->muta.has(MUTA::EARTHQUAKE)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("地震", "Earthquake");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 12;
-        rc_ptr->power_desc[rc_ptr->num].cost = 12;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_STR;
-        rc_ptr->power_desc[rc_ptr->num].fail = 16;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::EARTHQUAKE);
+        rpi = rc_ptr->make_power(_("地震", "Earthquake"));
+        rpi.min_level = 12;
+        rpi.cost = 12;
+        rpi.stat = A_STR;
+        rpi.fail = 16;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::EARTHQUAKE));
     }
 
     if (creature_ptr->muta.has(MUTA::EAT_MAGIC)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("魔力食い", "Eat Magic");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 17;
-        rc_ptr->power_desc[rc_ptr->num].cost = 1;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = 15;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::EAT_MAGIC);
+        rpi = rc_ptr->make_power(_("魔力食い", "Eat Magic"));
+        rpi.min_level = 17;
+        rpi.cost = 1;
+        rpi.stat = A_WIS;
+        rpi.fail = 15;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::EAT_MAGIC));
     }
 
     if (creature_ptr->muta.has(MUTA::WEIGH_MAG)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("魔力感知", "Weigh Magic");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 6;
-        rc_ptr->power_desc[rc_ptr->num].cost = 6;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 10;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::WEIGH_MAG);
+        rpi = rc_ptr->make_power(_("魔力感知", "Weigh Magic"));
+        rpi.min_level = 6;
+        rpi.cost = 6;
+        rpi.stat = A_INT;
+        rpi.fail = 10;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::WEIGH_MAG));
     }
 
     if (creature_ptr->muta.has(MUTA::STERILITY)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("増殖阻止", "Sterilize");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 12;
-        rc_ptr->power_desc[rc_ptr->num].cost = 23;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_CHR;
-        rc_ptr->power_desc[rc_ptr->num].fail = 15;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::STERILITY);
+        rpi = rc_ptr->make_power(_("増殖阻止", "Sterilize"));
+        rpi.min_level = 12;
+        rpi.cost = 23;
+        rpi.stat = A_CHR;
+        rpi.fail = 15;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::STERILITY));
     }
 
     if (creature_ptr->muta.has(MUTA::HIT_AND_AWAY)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("ヒット＆アウェイ", "Panic Hit");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 10;
-        rc_ptr->power_desc[rc_ptr->num].cost = 12;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
-        rc_ptr->power_desc[rc_ptr->num].fail = 14;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::HIT_AND_AWAY);
+        rpi = rc_ptr->make_power(_("ヒット＆アウェイ", "Panic Hit"));
+        rpi.min_level = 10;
+        rpi.cost = 12;
+        rpi.stat = A_DEX;
+        rpi.fail = 14;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::HIT_AND_AWAY));
     }
 
     if (creature_ptr->muta.has(MUTA::DAZZLE)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("眩惑", "Dazzle");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 7;
-        rc_ptr->power_desc[rc_ptr->num].cost = 15;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_CHR;
-        rc_ptr->power_desc[rc_ptr->num].fail = 8;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::DAZZLE);
+        rpi = rc_ptr->make_power(_("眩惑", "Dazzle"));
+        rpi.min_level = 7;
+        rpi.cost = 15;
+        rpi.stat = A_CHR;
+        rpi.fail = 8;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::DAZZLE));
     }
 
     if (creature_ptr->muta.has(MUTA::LASER_EYE)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("レーザー・アイ", "Laser Eye");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 7;
-        rc_ptr->power_desc[rc_ptr->num].cost = 10;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = 9;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::LASER_EYE);
+        rpi = rc_ptr->make_power(_("レーザー・アイ", "Laser Eye"));
+        rpi.min_level = 7;
+        rpi.cost = 10;
+        rpi.stat = A_WIS;
+        rpi.fail = 9;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::LASER_EYE));
     }
 
     if (creature_ptr->muta.has(MUTA::RECALL)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("帰還", "Recall");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 17;
-        rc_ptr->power_desc[rc_ptr->num].cost = 50;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 16;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::RECALL);
+        rpi = rc_ptr->make_power(_("帰還", "Recall"));
+        rpi.min_level = 17;
+        rpi.cost = 50;
+        rpi.stat = A_INT;
+        rpi.fail = 16;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::RECALL));
     }
 
     if (creature_ptr->muta.has(MUTA::BANISH)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("邪悪消滅", "Banish Evil");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 25;
-        rc_ptr->power_desc[rc_ptr->num].cost = 25;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = 18;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::BANISH);
+        rpi = rc_ptr->make_power(_("邪悪消滅", "Banish Evil"));
+        rpi.min_level = 25;
+        rpi.cost = 25;
+        rpi.stat = A_WIS;
+        rpi.fail = 18;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::BANISH));
     }
 
     if (creature_ptr->muta.has(MUTA::COLD_TOUCH)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("凍結の手", "Cold Touch");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 2;
-        rc_ptr->power_desc[rc_ptr->num].cost = 2;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
-        rc_ptr->power_desc[rc_ptr->num].fail = 11;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::COLD_TOUCH);
+        rpi = rc_ptr->make_power(_("凍結の手", "Cold Touch"));
+        rpi.min_level = 2;
+        rpi.cost = 2;
+        rpi.stat = A_CON;
+        rpi.fail = 11;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::COLD_TOUCH));
     }
 
     if (creature_ptr->muta.has(MUTA::LAUNCHER)) {
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("アイテム投げ", "Throw Object");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 1;
-        rc_ptr->power_desc[rc_ptr->num].cost = rc_ptr->lvl;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_STR;
-        rc_ptr->power_desc[rc_ptr->num].fail = 6;
-        rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::LAUNCHER);
+        rpi = rc_ptr->make_power(_("アイテム投げ", "Throw Object"));
+        rpi.min_level = 1;
+        rpi.cost = rc_ptr->lvl;
+        rpi.stat = A_STR;
+        rpi.fail = 6;
+        rc_ptr->add_power(rpi, static_cast<int>(MUTA::LAUNCHER));
     }
 }

--- a/src/racial/mutation-racial-selector.cpp
+++ b/src/racial/mutation-racial-selector.cpp
@@ -10,6 +10,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     if (creature_ptr->muta.has(MUTA::SPIT_ACID)) {
         rpi = rc_ptr->make_power(_("酸の唾", "Spit Acid"));
         rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl);
+        rpi.text = _("酸のボールを放つ", "Fires a boll of acid.");
         rpi.min_level = 9;
         rpi.cost = 9;
         rpi.stat = A_DEX;
@@ -20,6 +21,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     if (creature_ptr->muta.has(MUTA::BR_FIRE)) {
         rpi = rc_ptr->make_power(_("炎のブレス", "Fire Breath"));
         rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl);
+        rpi.text = _("火炎のブレスを放つ", "Fires a breath of fire.");
         rpi.min_level = 20;
         rpi.cost = rc_ptr->lvl;
         rpi.stat = A_CON;
@@ -30,6 +32,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     if (creature_ptr->muta.has(MUTA::HYPN_GAZE)) {
         rpi = rc_ptr->make_power(_("催眠睨み", "Hypnotic Gaze"));
         rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl);
+        rpi.text = _("モンスター1体をペットにする。抵抗されると無効。", "Attempts to charm a monster.");
         rpi.min_level = 12;
         rpi.cost = 12;
         rpi.stat = A_CHR;
@@ -44,6 +47,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 #else
         rpi.info = format("max wgt %d", rc_ptr->lvl * 10);
 #endif
+        rpi.text = _("アイテムを自分の足元へ移動させる。", "Pulls a distant item close to you.");
         rpi.min_level = 9;
         rpi.cost = 9;
         rpi.stat = A_WIS;
@@ -54,6 +58,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     if (creature_ptr->muta.has(MUTA::VTELEPORT)) {
         rpi = rc_ptr->make_power(_("テレポート", "Teleport"));
         rpi.info = format("%s%d", KWD_SPHERE, 10 + rc_ptr->lvl * 4);
+        rpi.text = _("遠距離のテレポートをする。", "Teleports you a long distance.");
         rpi.min_level = 7;
         rpi.cost = 7;
         rpi.stat = A_WIS;
@@ -64,6 +69,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     if (creature_ptr->muta.has(MUTA::MIND_BLST)) {
         rpi = rc_ptr->make_power(_("精神攻撃", "Mind Blast"));
         rpi.info = format("%s%dd%", KWD_DAM, 3 + (rc_ptr->lvl - 1) / 5, 3);
+        rpi.text = _("モンスター1体に精神攻撃を行う。", "Deals a PSI damage to a monster.");
         rpi.min_level = 5;
         rpi.cost = 3;
         rpi.stat = A_WIS;
@@ -74,6 +80,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     if (creature_ptr->muta.has(MUTA::RADIATION)) {
         rpi = rc_ptr->make_power(_("放射能", "Emit Radiation"));
         rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
+        rpi.text = _("自分を中心とする放射性廃棄物のボールを放つ。", "Bursst nuke ball.");
         rpi.min_level = 15;
         rpi.cost = 15;
         rpi.stat = A_CON;
@@ -84,6 +91,8 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     if (creature_ptr->muta.has(MUTA::VAMPIRISM)) {
         rpi = rc_ptr->make_power(_("吸血", "Vampiric Drain"));
         rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
+        rpi.text = _("隣接したモンスター1体から生命力を吸い取る。吸い取った生命力によって満腹度があがる。",
+            "Drains and transfers HP from a monster near by you. You will also gain nutritional sustenance from this.");
         rpi.min_level = 2;
         rpi.cost = 1 + (rc_ptr->lvl / 3);
         rpi.stat = A_CON;
@@ -93,6 +102,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::SMELL_MET)) {
         rpi = rc_ptr->make_power(_("金属嗅覚", "Smell Metal"));
+        rpi.text = _("周辺の鉱物を感知する。", "Detects all treasurely walls in your vicinity.");
         rpi.min_level = 3;
         rpi.cost = 2;
         rpi.stat = A_INT;
@@ -102,6 +112,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::SMELL_MON)) {
         rpi = rc_ptr->make_power(_("敵臭嗅覚", "Smell Monsters"));
+        rpi.text = _("近くの全ての見えるモンスターを感知する。", "Detects all monsters in your vicinity unless invisible.");
         rpi.min_level = 5;
         rpi.cost = 4;
         rpi.stat = A_INT;
@@ -112,6 +123,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     if (creature_ptr->muta.has(MUTA::BLINK)) {
         rpi = rc_ptr->make_power(_("ショート・テレポート", "Blink"));
         rpi.info = format("%s%d", KWD_SPHERE, 10);
+        rpi.text = _("近距離のテレポートをする。", "Teleports you a short distance.");
         rpi.min_level = 3;
         rpi.cost = 3;
         rpi.stat = A_WIS;
@@ -121,6 +133,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::EAT_ROCK)) {
         rpi = rc_ptr->make_power(_("岩食い", "Eat Rock"));
+        rpi.text = _("対象の壁を食料のように食べる。", "Eats a wall as rations.");
         rpi.min_level = 8;
         rpi.cost = 12;
         rpi.stat = A_CON;
@@ -131,6 +144,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     if (creature_ptr->muta.has(MUTA::SWAP_POS)) {
         rpi = rc_ptr->make_power(_("位置交換", "Swap Position"));
         rpi.info = format("%s%d", KWD_SPHERE, 10 + rc_ptr->lvl * 3 / 2);
+        rpi.text = _("対象のモンスター1体を位置を交換する。", "Swaps positions between you and a target monster.");
         rpi.min_level = 15;
         rpi.cost = 12;
         rpi.stat = A_DEX;
@@ -140,6 +154,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::SHRIEK)) {
         rpi = rc_ptr->make_power(_("叫び", "Shriek"));
+        rpi.text = _("自分を中心とする轟音のボールを放ち、周辺の敵を怒らせる。", "Bursts a sound ball and aggravates all monsters around you. ");
         rpi.min_level = 20;
         rpi.cost = 14;
         rpi.stat = A_CON;
@@ -149,6 +164,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::ILLUMINE)) {
         rpi = rc_ptr->make_power(_("照明", "Illuminate"));
+        rpi.text = _("光源が照らしている範囲か部屋全体を永久に明るくする。", "Lights up nearby area and the inside of a room permanently.");
         rpi.min_level = 3;
         rpi.cost = 2;
         rpi.stat = A_INT;
@@ -158,6 +174,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::DET_CURSE)) {
         rpi = rc_ptr->make_power(_("呪い感知", "Detect Curses"));
+        rpi.text = _("持ち物及び装備の中の呪われたアイテムを感知する。", "Feels curses of objects in your inventory.");
         rpi.min_level = 7;
         rpi.cost = 14;
         rpi.stat = A_WIS;
@@ -168,6 +185,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     if (creature_ptr->muta.has(MUTA::BERSERK)) {
         rpi = rc_ptr->make_power(_("狂戦士化", "Berserk"));
         rpi.info = format("%s%d+d%d", KWD_DURATION, 25, 25);
+        rpi.text = _("狂戦士化し、恐怖を除去する。防御力が少し低下する。", "Gives a bonus to hit and HP, immunity to fear for a while. But decreases AC.");
         rpi.min_level = 8;
         rpi.cost = 8;
         rpi.stat = A_STR;
@@ -177,6 +195,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::POLYMORPH)) {
         rpi = rc_ptr->make_power(_("変身", "Polymorph"));
+        rpi.text = _("別の種族に変身する。", "Morphs you to another race.");
         rpi.min_level = 18;
         rpi.cost = 20;
         rpi.stat = A_CON;
@@ -186,6 +205,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::MIDAS_TCH)) {
         rpi = rc_ptr->make_power(_("ミダスの手", "Midas Touch"));
+        rpi.text = _("アイテム1つをお金に変える。", "Turns an item into 1/3 of its value in gold.");
         rpi.min_level = 10;
         rpi.cost = 5;
         rpi.stat = A_INT;
@@ -195,6 +215,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::GROW_MOLD)) {
         rpi = rc_ptr->make_power(_("カビ発生", "Grow Mold"));
+        rpi.text = _("モルドを召喚する。", "Summons molds.");
         rpi.min_level = 1;
         rpi.cost = 6;
         rpi.stat = A_CON;
@@ -205,6 +226,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     if (creature_ptr->muta.has(MUTA::RESIST)) {
         rpi = rc_ptr->make_power(_("エレメント耐性", "Resist Elements"));
         rpi.info = format("%s%d+d%d", KWD_DURATION, 20, 20);
+        rpi.text = _("1つ以上の元素の一時耐性を得る。", "Gains one or more resitances for elements.");
         rpi.min_level = 10;
         rpi.cost = 12;
         rpi.stat = A_CON;
@@ -215,6 +237,8 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     if (creature_ptr->muta.has(MUTA::EARTHQUAKE)) {
         rpi = rc_ptr->make_power(_("地震", "Earthquake"));
         rpi.info = format("%s%d", KWD_SPHERE, 10);
+        rpi.text
+            = _("周囲のダンジョンを揺らし、壁と床をランダムに入れ変える。", "Shakes dungeon structure, and results in random swapping of floors and walls.");
         rpi.min_level = 12;
         rpi.cost = 12;
         rpi.stat = A_STR;
@@ -225,6 +249,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     if (creature_ptr->muta.has(MUTA::EAT_MAGIC)) {
         rpi = rc_ptr->make_power(_("魔力食い", "Eat Magic"));
         rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl * 2);
+        rpi.text = _("魔法道具から魔力を吸収してMPを回復する。", "Absorbs mana from a magic device to heal your SP.");
         rpi.min_level = 17;
         rpi.cost = 1;
         rpi.stat = A_WIS;
@@ -234,6 +259,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::WEIGH_MAG)) {
         rpi = rc_ptr->make_power(_("魔力感知", "Weigh Magic"));
+        rpi.text = _("現在得ている一時的な魔法の能力を知る。", "Reports all temporary magical abilities.");
         rpi.min_level = 6;
         rpi.cost = 6;
         rpi.stat = A_INT;
@@ -243,6 +269,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::STERILITY)) {
         rpi = rc_ptr->make_power(_("増殖阻止", "Sterilize"));
+        rpi.text = _("この階の増殖するモンスターが増殖できなくなる。", "Prevents any breeders on current level from breeding.");
         rpi.min_level = 12;
         rpi.cost = 23;
         rpi.stat = A_CHR;
@@ -253,6 +280,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     if (creature_ptr->muta.has(MUTA::HIT_AND_AWAY)) {
         rpi = rc_ptr->make_power(_("ヒット＆アウェイ", "Panic Hit"));
         rpi.info = format("%s%d", KWD_SPHERE, 30);
+        rpi.text = _("対象のモンスターを攻撃したあと短距離テレポートする。", "Attacks a monster then tereports you a short range.");
         rpi.min_level = 10;
         rpi.cost = 12;
         rpi.stat = A_DEX;
@@ -263,6 +291,8 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     if (creature_ptr->muta.has(MUTA::DAZZLE)) {
         rpi = rc_ptr->make_power(_("眩惑", "Dazzle"));
         rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl * 4);
+        rpi.text = _("周辺のモンスターを混乱・朦朧・恐怖させようとする。抵抗されると無効。",
+            "Tries to make all monsters in your sight confused, stuned, scared.");
         rpi.min_level = 7;
         rpi.cost = 15;
         rpi.stat = A_CHR;
@@ -273,6 +303,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     if (creature_ptr->muta.has(MUTA::LASER_EYE)) {
         rpi = rc_ptr->make_power(_("レーザー・アイ", "Laser Eye"));
         rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
+        rpi.text = _("閃光のビームを放つ。", "Fires a beam of light.");
         rpi.min_level = 7;
         rpi.cost = 10;
         rpi.stat = A_WIS;
@@ -282,6 +313,8 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::RECALL)) {
         rpi = rc_ptr->make_power(_("帰還", "Recall"));
+        rpi.text = _("地上にいるときはダンジョンの最深階へ、ダンジョンにいるときは地上へと移動する。",
+            "Recalls player from dungeon to town or from town to the deepest level of dungeon.");
         rpi.min_level = 17;
         rpi.cost = 50;
         rpi.stat = A_INT;
@@ -292,6 +325,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     if (creature_ptr->muta.has(MUTA::BANISH)) {
         rpi = rc_ptr->make_power(_("邪悪消滅", "Banish Evil"));
         rpi.info = format("%s%d", KWD_POWER, 50 + rc_ptr->lvl);
+        rpi.text = _("邪悪なモンスター1体を階から消滅させる。", "Erase a evil monster from current level.");
         rpi.min_level = 25;
         rpi.cost = 25;
         rpi.stat = A_WIS;
@@ -302,6 +336,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     if (creature_ptr->muta.has(MUTA::COLD_TOUCH)) {
         rpi = rc_ptr->make_power(_("凍結の手", "Cold Touch"));
         rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
+        rpi.text = _("冷気のビームを放つ。", "Fires a beam of cold.");
         rpi.min_level = 2;
         rpi.cost = 2;
         rpi.stat = A_CON;
@@ -311,6 +346,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::LAUNCHER)) {
         rpi = rc_ptr->make_power(_("アイテム投げ", "Throw Object"));
+        rpi.text = _("強力な威力で物を投げる。", "Throws an object strongly.");
         rpi.min_level = 1;
         rpi.cost = rc_ptr->lvl;
         rpi.stat = A_STR;

--- a/src/racial/mutation-racial-selector.cpp
+++ b/src/racial/mutation-racial-selector.cpp
@@ -5,7 +5,7 @@
 void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 {
     if (creature_ptr->muta.has(MUTA::SPIT_ACID)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("酸の唾", "Spit Acid"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("酸の唾", "Spit Acid");
         rc_ptr->power_desc[rc_ptr->num].min_level = 9;
         rc_ptr->power_desc[rc_ptr->num].cost = 9;
         rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
@@ -14,7 +14,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::BR_FIRE)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("炎のブレス", "Fire Breath"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("炎のブレス", "Fire Breath");
         rc_ptr->power_desc[rc_ptr->num].min_level = 20;
         rc_ptr->power_desc[rc_ptr->num].cost = rc_ptr->lvl;
         rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
@@ -23,7 +23,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::HYPN_GAZE)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("催眠睨み", "Hypnotic Gaze"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("催眠睨み", "Hypnotic Gaze");
         rc_ptr->power_desc[rc_ptr->num].min_level = 12;
         rc_ptr->power_desc[rc_ptr->num].cost = 12;
         rc_ptr->power_desc[rc_ptr->num].stat = A_CHR;
@@ -32,7 +32,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::TELEKINES)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("念動力", "Telekinesis"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("念動力", "Telekinesis");
         rc_ptr->power_desc[rc_ptr->num].min_level = 9;
         rc_ptr->power_desc[rc_ptr->num].cost = 9;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -41,7 +41,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::VTELEPORT)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("テレポート", "Teleport"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("テレポート", "Teleport");
         rc_ptr->power_desc[rc_ptr->num].min_level = 7;
         rc_ptr->power_desc[rc_ptr->num].cost = 7;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -50,7 +50,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::MIND_BLST)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("精神攻撃", "Mind Blast"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("精神攻撃", "Mind Blast");
         rc_ptr->power_desc[rc_ptr->num].min_level = 5;
         rc_ptr->power_desc[rc_ptr->num].cost = 3;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -59,7 +59,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::RADIATION)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("放射能", "Emit Radiation"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("放射能", "Emit Radiation");
         rc_ptr->power_desc[rc_ptr->num].min_level = 15;
         rc_ptr->power_desc[rc_ptr->num].cost = 15;
         rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
@@ -68,16 +68,16 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::VAMPIRISM)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("吸血", "Vampiric Drain"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("吸血", "Vampiric Drain");
         rc_ptr->power_desc[rc_ptr->num].min_level = 2;
-        rc_ptr->power_desc[rc_ptr->num].cost = (1 + (rc_ptr->lvl / 3));
+        rc_ptr->power_desc[rc_ptr->num].cost = 1 + (rc_ptr->lvl / 3);
         rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
         rc_ptr->power_desc[rc_ptr->num].fail = 9;
         rc_ptr->power_desc[rc_ptr->num++].number = static_cast<int>(MUTA::VAMPIRISM);
     }
 
     if (creature_ptr->muta.has(MUTA::SMELL_MET)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("金属嗅覚", "Smell Metal"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("金属嗅覚", "Smell Metal");
         rc_ptr->power_desc[rc_ptr->num].min_level = 3;
         rc_ptr->power_desc[rc_ptr->num].cost = 2;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
@@ -86,7 +86,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::SMELL_MON)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("敵臭嗅覚", "Smell Monsters"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("敵臭嗅覚", "Smell Monsters");
         rc_ptr->power_desc[rc_ptr->num].min_level = 5;
         rc_ptr->power_desc[rc_ptr->num].cost = 4;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
@@ -95,7 +95,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::BLINK)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("ショート・テレポート", "Blink"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("ショート・テレポート", "Blink");
         rc_ptr->power_desc[rc_ptr->num].min_level = 3;
         rc_ptr->power_desc[rc_ptr->num].cost = 3;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -104,7 +104,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::EAT_ROCK)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("岩食い", "Eat Rock"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("岩食い", "Eat Rock");
         rc_ptr->power_desc[rc_ptr->num].min_level = 8;
         rc_ptr->power_desc[rc_ptr->num].cost = 12;
         rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
@@ -113,7 +113,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::SWAP_POS)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("位置交換", "Swap Position"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("位置交換", "Swap Position");
         rc_ptr->power_desc[rc_ptr->num].min_level = 15;
         rc_ptr->power_desc[rc_ptr->num].cost = 12;
         rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
@@ -122,7 +122,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::SHRIEK)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("叫び", "Shriek"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("叫び", "Shriek");
         rc_ptr->power_desc[rc_ptr->num].min_level = 20;
         rc_ptr->power_desc[rc_ptr->num].cost = 14;
         rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
@@ -131,7 +131,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::ILLUMINE)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("照明", "Illuminate"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("照明", "Illuminate");
         rc_ptr->power_desc[rc_ptr->num].min_level = 3;
         rc_ptr->power_desc[rc_ptr->num].cost = 2;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
@@ -140,7 +140,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::DET_CURSE)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("呪い感知", "Detect Curses"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("呪い感知", "Detect Curses");
         rc_ptr->power_desc[rc_ptr->num].min_level = 7;
         rc_ptr->power_desc[rc_ptr->num].cost = 14;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -149,7 +149,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::BERSERK)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("狂戦士化", "Berserk"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("狂戦士化", "Berserk");
         rc_ptr->power_desc[rc_ptr->num].min_level = 8;
         rc_ptr->power_desc[rc_ptr->num].cost = 8;
         rc_ptr->power_desc[rc_ptr->num].stat = A_STR;
@@ -158,7 +158,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::POLYMORPH)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("変身", "Polymorph"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("変身", "Polymorph");
         rc_ptr->power_desc[rc_ptr->num].min_level = 18;
         rc_ptr->power_desc[rc_ptr->num].cost = 20;
         rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
@@ -167,7 +167,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::MIDAS_TCH)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("ミダスの手", "Midas Touch"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("ミダスの手", "Midas Touch");
         rc_ptr->power_desc[rc_ptr->num].min_level = 10;
         rc_ptr->power_desc[rc_ptr->num].cost = 5;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
@@ -176,7 +176,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::GROW_MOLD)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("カビ発生", "Grow Mold"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("カビ発生", "Grow Mold");
         rc_ptr->power_desc[rc_ptr->num].min_level = 1;
         rc_ptr->power_desc[rc_ptr->num].cost = 6;
         rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
@@ -185,7 +185,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::RESIST)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("エレメント耐性", "Resist Elements"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("エレメント耐性", "Resist Elements");
         rc_ptr->power_desc[rc_ptr->num].min_level = 10;
         rc_ptr->power_desc[rc_ptr->num].cost = 12;
         rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
@@ -194,7 +194,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::EARTHQUAKE)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("地震", "Earthquake"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("地震", "Earthquake");
         rc_ptr->power_desc[rc_ptr->num].min_level = 12;
         rc_ptr->power_desc[rc_ptr->num].cost = 12;
         rc_ptr->power_desc[rc_ptr->num].stat = A_STR;
@@ -203,7 +203,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::EAT_MAGIC)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("魔力食い", "Eat Magic"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("魔力食い", "Eat Magic");
         rc_ptr->power_desc[rc_ptr->num].min_level = 17;
         rc_ptr->power_desc[rc_ptr->num].cost = 1;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -212,7 +212,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::WEIGH_MAG)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("魔力感知", "Weigh Magic"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("魔力感知", "Weigh Magic");
         rc_ptr->power_desc[rc_ptr->num].min_level = 6;
         rc_ptr->power_desc[rc_ptr->num].cost = 6;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
@@ -221,7 +221,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::STERILITY)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("増殖阻止", "Sterilize"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("増殖阻止", "Sterilize");
         rc_ptr->power_desc[rc_ptr->num].min_level = 12;
         rc_ptr->power_desc[rc_ptr->num].cost = 23;
         rc_ptr->power_desc[rc_ptr->num].stat = A_CHR;
@@ -230,7 +230,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::HIT_AND_AWAY)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("ヒット＆アウェイ", "Panic Hit"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("ヒット＆アウェイ", "Panic Hit");
         rc_ptr->power_desc[rc_ptr->num].min_level = 10;
         rc_ptr->power_desc[rc_ptr->num].cost = 12;
         rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
@@ -239,7 +239,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::DAZZLE)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("眩惑", "Dazzle"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("眩惑", "Dazzle");
         rc_ptr->power_desc[rc_ptr->num].min_level = 7;
         rc_ptr->power_desc[rc_ptr->num].cost = 15;
         rc_ptr->power_desc[rc_ptr->num].stat = A_CHR;
@@ -248,7 +248,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::LASER_EYE)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("レーザー・アイ", "Laser Eye"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("レーザー・アイ", "Laser Eye");
         rc_ptr->power_desc[rc_ptr->num].min_level = 7;
         rc_ptr->power_desc[rc_ptr->num].cost = 10;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -257,7 +257,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::RECALL)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("帰還", "Recall"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("帰還", "Recall");
         rc_ptr->power_desc[rc_ptr->num].min_level = 17;
         rc_ptr->power_desc[rc_ptr->num].cost = 50;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
@@ -266,7 +266,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::BANISH)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("邪悪消滅", "Banish Evil"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("邪悪消滅", "Banish Evil");
         rc_ptr->power_desc[rc_ptr->num].min_level = 25;
         rc_ptr->power_desc[rc_ptr->num].cost = 25;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -275,7 +275,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::COLD_TOUCH)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("凍結の手", "Cold Touch"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("凍結の手", "Cold Touch");
         rc_ptr->power_desc[rc_ptr->num].min_level = 2;
         rc_ptr->power_desc[rc_ptr->num].cost = 2;
         rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
@@ -284,7 +284,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
     }
 
     if (creature_ptr->muta.has(MUTA::LAUNCHER)) {
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("アイテム投げ", "Throw Object"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("アイテム投げ", "Throw Object");
         rc_ptr->power_desc[rc_ptr->num].min_level = 1;
         rc_ptr->power_desc[rc_ptr->num].cost = rc_ptr->lvl;
         rc_ptr->power_desc[rc_ptr->num].stat = A_STR;

--- a/src/racial/mutation-racial-selector.cpp
+++ b/src/racial/mutation-racial-selector.cpp
@@ -1,4 +1,5 @@
 ﻿#include "racial/mutation-racial-selector.h"
+#include "cmd-action/cmd-spell.h"
 #include "mutation/mutation-flag-types.h"
 #include "racial/racial-util.h"
 
@@ -8,6 +9,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::SPIT_ACID)) {
         rpi = rc_ptr->make_power(_("酸の唾", "Spit Acid"));
+        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl);
         rpi.min_level = 9;
         rpi.cost = 9;
         rpi.stat = A_DEX;
@@ -17,6 +19,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::BR_FIRE)) {
         rpi = rc_ptr->make_power(_("炎のブレス", "Fire Breath"));
+        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl);
         rpi.min_level = 20;
         rpi.cost = rc_ptr->lvl;
         rpi.stat = A_CON;
@@ -26,6 +29,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::HYPN_GAZE)) {
         rpi = rc_ptr->make_power(_("催眠睨み", "Hypnotic Gaze"));
+        rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl);
         rpi.min_level = 12;
         rpi.cost = 12;
         rpi.stat = A_CHR;
@@ -35,6 +39,11 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::TELEKINES)) {
         rpi = rc_ptr->make_power(_("念動力", "Telekinesis"));
+#ifdef JP
+        rpi.info = format("最大重量: %d.%dkg", lbtokg1(rc_ptr->lvl * 10), lbtokg2(rc_ptr->lvl * 10));
+#else
+        rpi.info = format("max wgt %d", rc_ptr->lvl * 10);
+#endif
         rpi.min_level = 9;
         rpi.cost = 9;
         rpi.stat = A_WIS;
@@ -44,6 +53,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::VTELEPORT)) {
         rpi = rc_ptr->make_power(_("テレポート", "Teleport"));
+        rpi.info = format("%s%d", KWD_SPHERE, 10 + rc_ptr->lvl * 4);
         rpi.min_level = 7;
         rpi.cost = 7;
         rpi.stat = A_WIS;
@@ -53,6 +63,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::MIND_BLST)) {
         rpi = rc_ptr->make_power(_("精神攻撃", "Mind Blast"));
+        rpi.info = format("%s%dd%", KWD_DAM, 3 + (rc_ptr->lvl - 1) / 5, 3);
         rpi.min_level = 5;
         rpi.cost = 3;
         rpi.stat = A_WIS;
@@ -62,6 +73,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::RADIATION)) {
         rpi = rc_ptr->make_power(_("放射能", "Emit Radiation"));
+        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
         rpi.min_level = 15;
         rpi.cost = 15;
         rpi.stat = A_CON;
@@ -71,6 +83,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::VAMPIRISM)) {
         rpi = rc_ptr->make_power(_("吸血", "Vampiric Drain"));
+        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
         rpi.min_level = 2;
         rpi.cost = 1 + (rc_ptr->lvl / 3);
         rpi.stat = A_CON;
@@ -98,6 +111,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::BLINK)) {
         rpi = rc_ptr->make_power(_("ショート・テレポート", "Blink"));
+        rpi.info = format("%s%d", KWD_SPHERE, 10);
         rpi.min_level = 3;
         rpi.cost = 3;
         rpi.stat = A_WIS;
@@ -116,6 +130,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::SWAP_POS)) {
         rpi = rc_ptr->make_power(_("位置交換", "Swap Position"));
+        rpi.info = format("%s%d", KWD_SPHERE, 10 + rc_ptr->lvl * 3 / 2);
         rpi.min_level = 15;
         rpi.cost = 12;
         rpi.stat = A_DEX;
@@ -152,6 +167,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::BERSERK)) {
         rpi = rc_ptr->make_power(_("狂戦士化", "Berserk"));
+        rpi.info = format("%s%d+d%d", KWD_DURATION, 25, 25);
         rpi.min_level = 8;
         rpi.cost = 8;
         rpi.stat = A_STR;
@@ -188,6 +204,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::RESIST)) {
         rpi = rc_ptr->make_power(_("エレメント耐性", "Resist Elements"));
+        rpi.info = format("%s%d+d%d", KWD_DURATION, 20, 20);
         rpi.min_level = 10;
         rpi.cost = 12;
         rpi.stat = A_CON;
@@ -197,6 +214,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::EARTHQUAKE)) {
         rpi = rc_ptr->make_power(_("地震", "Earthquake"));
+        rpi.info = format("%s%d", KWD_SPHERE, 10);
         rpi.min_level = 12;
         rpi.cost = 12;
         rpi.stat = A_STR;
@@ -206,6 +224,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::EAT_MAGIC)) {
         rpi = rc_ptr->make_power(_("魔力食い", "Eat Magic"));
+        rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl * 2);
         rpi.min_level = 17;
         rpi.cost = 1;
         rpi.stat = A_WIS;
@@ -233,6 +252,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::HIT_AND_AWAY)) {
         rpi = rc_ptr->make_power(_("ヒット＆アウェイ", "Panic Hit"));
+        rpi.info = format("%s%d", KWD_SPHERE, 30);
         rpi.min_level = 10;
         rpi.cost = 12;
         rpi.stat = A_DEX;
@@ -242,6 +262,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::DAZZLE)) {
         rpi = rc_ptr->make_power(_("眩惑", "Dazzle"));
+        rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl * 4);
         rpi.min_level = 7;
         rpi.cost = 15;
         rpi.stat = A_CHR;
@@ -251,6 +272,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::LASER_EYE)) {
         rpi = rc_ptr->make_power(_("レーザー・アイ", "Laser Eye"));
+        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
         rpi.min_level = 7;
         rpi.cost = 10;
         rpi.stat = A_WIS;
@@ -269,6 +291,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::BANISH)) {
         rpi = rc_ptr->make_power(_("邪悪消滅", "Banish Evil"));
+        rpi.info = format("%s%d", KWD_POWER, 50 + rc_ptr->lvl);
         rpi.min_level = 25;
         rpi.cost = 25;
         rpi.stat = A_WIS;
@@ -278,6 +301,7 @@ void select_mutation_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
     if (creature_ptr->muta.has(MUTA::COLD_TOUCH)) {
         rpi = rc_ptr->make_power(_("凍結の手", "Cold Touch"));
+        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
         rpi.min_level = 2;
         rpi.cost = 2;
         rpi.stat = A_CON;

--- a/src/racial/race-racial-command-setter.cpp
+++ b/src/racial/race-racial-command-setter.cpp
@@ -7,7 +7,7 @@ void set_mimic_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
     switch (creature_ptr->mimic_form) {
     case MIMIC_DEMON:
     case MIMIC_DEMON_LORD:
-        sprintf(rc_ptr->power_desc[rc_ptr->num].racial_name, _("地獄/火炎のブレス (ダメージ %d)", "Nether or Fire Breath (dam %d)"), rc_ptr->lvl * 3);
+        rc_ptr->power_desc[rc_ptr->num].racial_name = format(_("地獄/火炎のブレス (ダメージ %d)", "Nether or Fire Breath (dam %d)"), rc_ptr->lvl * 3);
         rc_ptr->power_desc[rc_ptr->num].min_level = 15;
         rc_ptr->power_desc[rc_ptr->num].cost = 10 + rc_ptr->lvl / 3;
         rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
@@ -15,7 +15,7 @@ void set_mimic_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -1;
         break;
     case MIMIC_VAMPIRE:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("吸血", "Vampiric Drain"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name, _("吸血", "Vampiric Drain");
         rc_ptr->power_desc[rc_ptr->num].min_level = 2;
         rc_ptr->power_desc[rc_ptr->num].cost = 1 + (rc_ptr->lvl / 3);
         rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
@@ -29,7 +29,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
 {
     switch (creature_ptr->prace) {
     case RACE_DWARF:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("ドアと罠 感知", "Detect Doors+Traps"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("ドアと罠 感知", "Detect Doors+Traps");
         rc_ptr->power_desc[rc_ptr->num].min_level = 5;
         rc_ptr->power_desc[rc_ptr->num].cost = 5;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -37,7 +37,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -1;
         break;
     case RACE_NIBELUNG:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("ドアと罠 感知", "Detect Doors+Traps"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("ドアと罠 感知", "Detect Doors+Traps");
         rc_ptr->power_desc[rc_ptr->num].min_level = 10;
         rc_ptr->power_desc[rc_ptr->num].cost = 5;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -45,7 +45,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -1;
         break;
     case RACE_HOBBIT:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("食糧生成", "Create Food"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("食糧生成", "Create Food");
         rc_ptr->power_desc[rc_ptr->num].min_level = 15;
         rc_ptr->power_desc[rc_ptr->num].cost = 10;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
@@ -53,7 +53,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -1;
         break;
     case RACE_GNOME:
-        sprintf(rc_ptr->power_desc[rc_ptr->num].racial_name, _("ショート・テレポート", "Blink"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("ショート・テレポート", "Blink");
         rc_ptr->power_desc[rc_ptr->num].min_level = 5;
         rc_ptr->power_desc[rc_ptr->num].cost = 5;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
@@ -61,7 +61,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -1;
         break;
     case RACE_HALF_ORC:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("恐怖除去", "Remove Fear"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("恐怖除去", "Remove Fear");
         rc_ptr->power_desc[rc_ptr->num].min_level = 3;
         rc_ptr->power_desc[rc_ptr->num].cost = 5;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -69,7 +69,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -1;
         break;
     case RACE_HALF_TROLL:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("狂戦士化", "Berserk"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("狂戦士化", "Berserk");
         rc_ptr->power_desc[rc_ptr->num].min_level = 10;
         rc_ptr->power_desc[rc_ptr->num].cost = 12;
         rc_ptr->power_desc[rc_ptr->num].stat = A_STR;
@@ -77,7 +77,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -1;
         break;
     case RACE_BARBARIAN:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("狂戦士化", "Berserk"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("狂戦士化", "Berserk");
         rc_ptr->power_desc[rc_ptr->num].min_level = 8;
         rc_ptr->power_desc[rc_ptr->num].cost = 10;
         rc_ptr->power_desc[rc_ptr->num].stat = A_STR;
@@ -85,14 +85,14 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -1;
         break;
     case RACE_AMBERITE:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("シャドウ・シフト", "Shadow Shifting"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("シャドウ・シフト", "Shadow Shifting");
         rc_ptr->power_desc[rc_ptr->num].min_level = 30;
         rc_ptr->power_desc[rc_ptr->num].cost = 50;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
         rc_ptr->power_desc[rc_ptr->num].fail = 50;
         rc_ptr->power_desc[rc_ptr->num++].number = -1;
 
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("パターン・ウォーク", "Pattern Mindwalking"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("パターン・ウォーク", "Pattern Mindwalking");
         rc_ptr->power_desc[rc_ptr->num].min_level = 40;
         rc_ptr->power_desc[rc_ptr->num].cost = 75;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -100,7 +100,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -2;
         break;
     case RACE_HALF_OGRE:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("爆発のルーン", "Explosive Rune"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("爆発のルーン", "Explosive Rune");
         rc_ptr->power_desc[rc_ptr->num].min_level = 25;
         rc_ptr->power_desc[rc_ptr->num].cost = 35;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
@@ -108,7 +108,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -1;
         break;
     case RACE_HALF_GIANT:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("岩石溶解", "Stone to Mud"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("岩石溶解", "Stone to Mud");
         rc_ptr->power_desc[rc_ptr->num].min_level = 20;
         rc_ptr->power_desc[rc_ptr->num].cost = 10;
         rc_ptr->power_desc[rc_ptr->num].stat = A_STR;
@@ -116,7 +116,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -1;
         break;
     case RACE_HALF_TITAN:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("スキャン・モンスター", "Probing"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("スキャン・モンスター", "Probing");
         rc_ptr->power_desc[rc_ptr->num].min_level = 15;
         rc_ptr->power_desc[rc_ptr->num].cost = 10;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
@@ -124,7 +124,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -1;
         break;
     case RACE_CYCLOPS:
-        sprintf(rc_ptr->power_desc[rc_ptr->num].racial_name, _("岩石投げ（ダメージ %d）", "Throw Boulder (dam %d)"), (3 * rc_ptr->lvl) / 2);
+        rc_ptr->power_desc[rc_ptr->num].racial_name = format(_("岩石投げ（ダメージ %d）", "Throw Boulder (dam %d)"), (3 * rc_ptr->lvl) / 2);
         rc_ptr->power_desc[rc_ptr->num].min_level = 20;
         rc_ptr->power_desc[rc_ptr->num].cost = 15;
         rc_ptr->power_desc[rc_ptr->num].stat = A_STR;
@@ -132,7 +132,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -1;
         break;
     case RACE_YEEK:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("モンスター恐慌", "Scare Monster"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("モンスター恐慌", "Scare Monster");
         rc_ptr->power_desc[rc_ptr->num].min_level = 15;
         rc_ptr->power_desc[rc_ptr->num].cost = 15;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -140,7 +140,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -1;
         break;
     case RACE_SPECTRE:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("モンスター恐慌", "Scare Monster"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("モンスター恐慌", "Scare Monster");
         rc_ptr->power_desc[rc_ptr->num].min_level = 4;
         rc_ptr->power_desc[rc_ptr->num].cost = 6;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
@@ -148,7 +148,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -1;
         break;
     case RACE_KLACKON:
-        sprintf(rc_ptr->power_desc[rc_ptr->num].racial_name, _("酸の唾 (ダメージ %d)", "Spit Acid (dam %d)"), rc_ptr->lvl);
+        rc_ptr->power_desc[rc_ptr->num].racial_name = format(_("酸の唾 (ダメージ %d)", "Spit Acid (dam %d)"), rc_ptr->lvl);
         rc_ptr->power_desc[rc_ptr->num].min_level = 9;
         rc_ptr->power_desc[rc_ptr->num].cost = 9;
         rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
@@ -156,7 +156,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -1;
         break;
     case RACE_KOBOLD:
-        sprintf(rc_ptr->power_desc[rc_ptr->num].racial_name, _("毒のダーツ (ダメージ %d)", "Poison Dart (dam %d)"), rc_ptr->lvl);
+        rc_ptr->power_desc[rc_ptr->num].racial_name = format(_("毒のダーツ (ダメージ %d)", "Poison Dart (dam %d)"), rc_ptr->lvl);
         rc_ptr->power_desc[rc_ptr->num].min_level = 12;
         rc_ptr->power_desc[rc_ptr->num].cost = 8;
         rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
@@ -164,8 +164,8 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -1;
         break;
     case RACE_DARK_ELF:
-        sprintf(
-            rc_ptr->power_desc[rc_ptr->num].racial_name, _("マジック・ミサイル (ダメージ %dd%d)", "Magic Missile (dm %dd%d)"), 3 + ((rc_ptr->lvl - 1) / 5), 4);
+        rc_ptr->power_desc[rc_ptr->num].racial_name
+            = format(_("マジック・ミサイル (ダメージ %dd%d)", "Magic Missile (dm %dd%d)"), 3 + ((rc_ptr->lvl - 1) / 5), 4);
         rc_ptr->power_desc[rc_ptr->num].min_level = 2;
         rc_ptr->power_desc[rc_ptr->num].cost = 2;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
@@ -173,7 +173,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -1;
         break;
     case RACE_DRACONIAN:
-        sprintf(rc_ptr->power_desc[rc_ptr->num].racial_name, _("ブレス (ダメージ %d)", "Breath Weapon (dam %d)"), rc_ptr->lvl * 2);
+        rc_ptr->power_desc[rc_ptr->num].racial_name = format(_("ブレス (ダメージ %d)", "Breath Weapon (dam %d)"), rc_ptr->lvl * 2);
         rc_ptr->power_desc[rc_ptr->num].min_level = 1;
         rc_ptr->power_desc[rc_ptr->num].cost = rc_ptr->lvl;
         rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
@@ -181,7 +181,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -1;
         break;
     case RACE_MIND_FLAYER:
-        sprintf(rc_ptr->power_desc[rc_ptr->num].racial_name, _("精神攻撃 (ダメージ %d)", "Mind Blast (dam %d)"), rc_ptr->lvl);
+        rc_ptr->power_desc[rc_ptr->num].racial_name = format(_("精神攻撃 (ダメージ %d)", "Mind Blast (dam %d)"), rc_ptr->lvl);
         rc_ptr->power_desc[rc_ptr->num].min_level = 15;
         rc_ptr->power_desc[rc_ptr->num].cost = 12;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
@@ -189,7 +189,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -1;
         break;
     case RACE_IMP:
-        sprintf(rc_ptr->power_desc[rc_ptr->num].racial_name, _("ファイア・ボルト/ボール (ダメージ %d)", "Fire Bolt/Ball (dam %d)"), rc_ptr->lvl);
+        rc_ptr->power_desc[rc_ptr->num].racial_name = format(_("ファイア・ボルト/ボール (ダメージ %d)", "Fire Bolt/Ball (dam %d)"), rc_ptr->lvl);
         rc_ptr->power_desc[rc_ptr->num].min_level = 9;
         rc_ptr->power_desc[rc_ptr->num].cost = 15;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -197,7 +197,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -1;
         break;
     case RACE_GOLEM:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("肌石化 (期間 1d20+30)", "Stone Skin (dur 1d20+30)"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("肌石化 (期間 1d20+30)", "Stone Skin (dur 1d20+30)");
         rc_ptr->power_desc[rc_ptr->num].min_level = 20;
         rc_ptr->power_desc[rc_ptr->num].cost = 15;
         rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
@@ -206,7 +206,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case RACE_SKELETON:
     case RACE_ZOMBIE:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("経験値復活", "Restore Experience"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("経験値復活", "Restore Experience");
         rc_ptr->power_desc[rc_ptr->num].min_level = 30;
         rc_ptr->power_desc[rc_ptr->num].cost = 30;
         rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
@@ -214,7 +214,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -1;
         break;
     case RACE_VAMPIRE:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("吸血", "Vampiric Drain"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("吸血", "Vampiric Drain");
         rc_ptr->power_desc[rc_ptr->num].min_level = 2;
         rc_ptr->power_desc[rc_ptr->num].cost = 1 + (rc_ptr->lvl / 3);
         rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
@@ -222,7 +222,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -1;
         break;
     case RACE_SPRITE:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("眠り粉", "Sleeping Dust"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("眠り粉", "Sleeping Dust");
         rc_ptr->power_desc[rc_ptr->num].min_level = 12;
         rc_ptr->power_desc[rc_ptr->num].cost = 12;
         rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
@@ -230,7 +230,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -1;
         break;
     case RACE_BALROG:
-        sprintf(rc_ptr->power_desc[rc_ptr->num].racial_name, _("地獄/火炎のブレス (ダメージ %d)", "Nether or Fire Breath (dam %d)"), rc_ptr->lvl * 3);
+        rc_ptr->power_desc[rc_ptr->num].racial_name = format(_("地獄/火炎のブレス (ダメージ %d)", "Nether or Fire Breath (dam %d)"), rc_ptr->lvl * 3);
         rc_ptr->power_desc[rc_ptr->num].min_level = 15;
         rc_ptr->power_desc[rc_ptr->num].cost = 10 + rc_ptr->lvl / 3;
         rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
@@ -238,7 +238,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->power_desc[rc_ptr->num++].number = -1;
         break;
     case RACE_KUTAR:
-        strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("横に伸びる", "Expand Horizontally (dur 30+1d20)"));
+        rc_ptr->power_desc[rc_ptr->num].racial_name = _("横に伸びる", "Expand Horizontally (dur 30+1d20)");
         rc_ptr->power_desc[rc_ptr->num].min_level = 20;
         rc_ptr->power_desc[rc_ptr->num].cost = 15;
         rc_ptr->power_desc[rc_ptr->num].stat = A_CHR;
@@ -247,27 +247,27 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case RACE_ANDROID:
         if (creature_ptr->lev < 10) {
-            strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("レイガン", "Ray Gun"));
+            rc_ptr->power_desc[rc_ptr->num].racial_name = _("レイガン", "Ray Gun");
             rc_ptr->power_desc[rc_ptr->num].min_level = 1;
             rc_ptr->power_desc[rc_ptr->num].cost = 7;
             rc_ptr->power_desc[rc_ptr->num].fail = 8;
         } else if (creature_ptr->lev < 25) {
-            strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("ブラスター", "Blaster"));
+            rc_ptr->power_desc[rc_ptr->num].racial_name = _("ブラスター", "Blaster");
             rc_ptr->power_desc[rc_ptr->num].min_level = 10;
             rc_ptr->power_desc[rc_ptr->num].cost = 13;
             rc_ptr->power_desc[rc_ptr->num].fail = 10;
         } else if (creature_ptr->lev < 35) {
-            strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("バズーカ", "Bazooka"));
+            rc_ptr->power_desc[rc_ptr->num].racial_name = _("バズーカ", "Bazooka");
             rc_ptr->power_desc[rc_ptr->num].min_level = 25;
             rc_ptr->power_desc[rc_ptr->num].cost = 26;
             rc_ptr->power_desc[rc_ptr->num].fail = 12;
         } else if (creature_ptr->lev < 45) {
-            strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("ビームキャノン", "Beam Cannon"));
+            rc_ptr->power_desc[rc_ptr->num].racial_name = _("ビームキャノン", "Beam Cannon");
             rc_ptr->power_desc[rc_ptr->num].min_level = 35;
             rc_ptr->power_desc[rc_ptr->num].cost = 40;
             rc_ptr->power_desc[rc_ptr->num].fail = 15;
         } else {
-            strcpy(rc_ptr->power_desc[rc_ptr->num].racial_name, _("ロケット", "Rocket"));
+            rc_ptr->power_desc[rc_ptr->num].racial_name = _("ロケット", "Rocket");
             rc_ptr->power_desc[rc_ptr->num].min_level = 45;
             rc_ptr->power_desc[rc_ptr->num].cost = 60;
             rc_ptr->power_desc[rc_ptr->num].fail = 18;

--- a/src/racial/race-racial-command-setter.cpp
+++ b/src/racial/race-racial-command-setter.cpp
@@ -4,276 +4,277 @@
 
 void set_mimic_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
 {
+    rpi_type rpi;
     switch (creature_ptr->mimic_form) {
     case MIMIC_DEMON:
     case MIMIC_DEMON_LORD:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = format(_("地獄/火炎のブレス (ダメージ %d)", "Nether or Fire Breath (dam %d)"), rc_ptr->lvl * 3);
-        rc_ptr->power_desc[rc_ptr->num].min_level = 15;
-        rc_ptr->power_desc[rc_ptr->num].cost = 10 + rc_ptr->lvl / 3;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
-        rc_ptr->power_desc[rc_ptr->num].fail = 20;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(format(_("地獄/火炎のブレス (ダメージ %d)", "Nether or Fire Breath (dam %d)"), rc_ptr->lvl * 3));
+        rpi.min_level = 15;
+        rpi.cost = 10 + rc_ptr->lvl / 3;
+        rpi.stat = A_CON;
+        rpi.fail = 20;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case MIMIC_VAMPIRE:
-        rc_ptr->power_desc[rc_ptr->num].racial_name, _("吸血", "Vampiric Drain");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 2;
-        rc_ptr->power_desc[rc_ptr->num].cost = 1 + (rc_ptr->lvl / 3);
-        rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
-        rc_ptr->power_desc[rc_ptr->num].fail = 9;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(_("吸血", "Vampiric Drain"));
+        rpi.min_level = 2;
+        rpi.cost = 1 + (rc_ptr->lvl / 3);
+        rpi.stat = A_CON;
+        rpi.fail = 9;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     }
 }
 
 void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
 {
+    rpi_type rpi;
     switch (creature_ptr->prace) {
     case RACE_DWARF:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("ドアと罠 感知", "Detect Doors+Traps");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 5;
-        rc_ptr->power_desc[rc_ptr->num].cost = 5;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = 12;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(_("ドアと罠 感知", "Detect Doors+Traps"));
+        rpi.min_level = 5;
+        rpi.cost = 5;
+        rpi.stat = A_WIS;
+        rpi.fail = 12;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_NIBELUNG:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("ドアと罠 感知", "Detect Doors+Traps");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 10;
-        rc_ptr->power_desc[rc_ptr->num].cost = 5;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = 10;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(_("ドアと罠 感知", "Detect Doors+Traps"));
+        rpi.min_level = 10;
+        rpi.cost = 5;
+        rpi.stat = A_WIS;
+        rpi.fail = 10;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_HOBBIT:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("食糧生成", "Create Food");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 15;
-        rc_ptr->power_desc[rc_ptr->num].cost = 10;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 10;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(_("食糧生成", "Create Food"));
+        rpi.min_level = 15;
+        rpi.cost = 10;
+        rpi.stat = A_INT;
+        rpi.fail = 10;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_GNOME:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("ショート・テレポート", "Blink");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 5;
-        rc_ptr->power_desc[rc_ptr->num].cost = 5;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 12;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(_("ショート・テレポート", "Blink"));
+        rpi.min_level = 5;
+        rpi.cost = 5;
+        rpi.stat = A_INT;
+        rpi.fail = 12;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_HALF_ORC:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("恐怖除去", "Remove Fear");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 3;
-        rc_ptr->power_desc[rc_ptr->num].cost = 5;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = rc_ptr->is_warrior ? 5 : 10;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(_("恐怖除去", "Remove Fear"));
+        rpi.min_level = 3;
+        rpi.cost = 5;
+        rpi.stat = A_WIS;
+        rpi.fail = rc_ptr->is_warrior ? 5 : 10;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_HALF_TROLL:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("狂戦士化", "Berserk");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 10;
-        rc_ptr->power_desc[rc_ptr->num].cost = 12;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_STR;
-        rc_ptr->power_desc[rc_ptr->num].fail = rc_ptr->is_warrior ? 6 : 12;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(_("狂戦士化", "Berserk"));
+        rpi.min_level = 10;
+        rpi.cost = 12;
+        rpi.stat = A_STR;
+        rpi.fail = rc_ptr->is_warrior ? 6 : 12;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_BARBARIAN:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("狂戦士化", "Berserk");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 8;
-        rc_ptr->power_desc[rc_ptr->num].cost = 10;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_STR;
-        rc_ptr->power_desc[rc_ptr->num].fail = rc_ptr->is_warrior ? 6 : 12;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(_("狂戦士化", "Berserk"));
+        rpi.min_level = 8;
+        rpi.cost = 10;
+        rpi.stat = A_STR;
+        rpi.fail = rc_ptr->is_warrior ? 6 : 12;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_AMBERITE:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("シャドウ・シフト", "Shadow Shifting");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 30;
-        rc_ptr->power_desc[rc_ptr->num].cost = 50;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 50;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(_("シャドウ・シフト", "Shadow Shifting"));
+        rpi.min_level = 30;
+        rpi.cost = 50;
+        rpi.stat = A_INT;
+        rpi.fail = 50;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
 
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("パターン・ウォーク", "Pattern Mindwalking");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 40;
-        rc_ptr->power_desc[rc_ptr->num].cost = 75;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = 50;
-        rc_ptr->power_desc[rc_ptr->num++].number = -2;
+        rpi = rc_ptr->make_power(_("パターン・ウォーク", "Pattern Mindwalking"));
+        rpi.min_level = 40;
+        rpi.cost = 75;
+        rpi.stat = A_WIS;
+        rpi.fail = 50;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_1);
         break;
     case RACE_HALF_OGRE:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("爆発のルーン", "Explosive Rune");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 25;
-        rc_ptr->power_desc[rc_ptr->num].cost = 35;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 15;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(_("爆発のルーン", "Explosive Rune"));
+        rpi.min_level = 25;
+        rpi.cost = 35;
+        rpi.stat = A_INT;
+        rpi.fail = 15;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_HALF_GIANT:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("岩石溶解", "Stone to Mud");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 20;
-        rc_ptr->power_desc[rc_ptr->num].cost = 10;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_STR;
-        rc_ptr->power_desc[rc_ptr->num].fail = 12;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(_("岩石溶解", "Stone to Mud"));
+        rpi.min_level = 20;
+        rpi.cost = 10;
+        rpi.stat = A_STR;
+        rpi.fail = 12;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_HALF_TITAN:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("スキャン・モンスター", "Probing");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 15;
-        rc_ptr->power_desc[rc_ptr->num].cost = 10;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 12;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(_("スキャン・モンスター", "Probing"));
+        rpi.min_level = 15;
+        rpi.cost = 10;
+        rpi.stat = A_INT;
+        rpi.fail = 12;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_CYCLOPS:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = format(_("岩石投げ（ダメージ %d）", "Throw Boulder (dam %d)"), (3 * rc_ptr->lvl) / 2);
-        rc_ptr->power_desc[rc_ptr->num].min_level = 20;
-        rc_ptr->power_desc[rc_ptr->num].cost = 15;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_STR;
-        rc_ptr->power_desc[rc_ptr->num].fail = 12;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(format(_("岩石投げ（ダメージ %d）", "Throw Boulder (dam %d)"), (3 * rc_ptr->lvl) / 2));
+        rpi.min_level = 20;
+        rpi.cost = 15;
+        rpi.stat = A_STR;
+        rpi.fail = 12;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_YEEK:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("モンスター恐慌", "Scare Monster");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 15;
-        rc_ptr->power_desc[rc_ptr->num].cost = 15;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = 10;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(_("モンスター恐慌", "Scare Monster"));
+        rpi.min_level = 15;
+        rpi.cost = 15;
+        rpi.stat = A_WIS;
+        rpi.fail = 10;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_SPECTRE:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("モンスター恐慌", "Scare Monster");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 4;
-        rc_ptr->power_desc[rc_ptr->num].cost = 6;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 3;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(_("モンスター恐慌", "Scare Monster"));
+        rpi.min_level = 4;
+        rpi.cost = 6;
+        rpi.stat = A_INT;
+        rpi.fail = 3;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_KLACKON:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = format(_("酸の唾 (ダメージ %d)", "Spit Acid (dam %d)"), rc_ptr->lvl);
-        rc_ptr->power_desc[rc_ptr->num].min_level = 9;
-        rc_ptr->power_desc[rc_ptr->num].cost = 9;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
-        rc_ptr->power_desc[rc_ptr->num].fail = 14;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(format(_("酸の唾 (ダメージ %d)", "Spit Acid (dam %d)"), rc_ptr->lvl));
+        rpi.min_level = 9;
+        rpi.cost = 9;
+        rpi.stat = A_DEX;
+        rpi.fail = 14;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_KOBOLD:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = format(_("毒のダーツ (ダメージ %d)", "Poison Dart (dam %d)"), rc_ptr->lvl);
-        rc_ptr->power_desc[rc_ptr->num].min_level = 12;
-        rc_ptr->power_desc[rc_ptr->num].cost = 8;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_DEX;
-        rc_ptr->power_desc[rc_ptr->num].fail = 14;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(format(_("毒のダーツ (ダメージ %d)", "Poison Dart (dam %d)"), rc_ptr->lvl));
+        rpi.min_level = 12;
+        rpi.cost = 8;
+        rpi.stat = A_DEX;
+        rpi.fail = 14;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_DARK_ELF:
-        rc_ptr->power_desc[rc_ptr->num].racial_name
-            = format(_("マジック・ミサイル (ダメージ %dd%d)", "Magic Missile (dm %dd%d)"), 3 + ((rc_ptr->lvl - 1) / 5), 4);
-        rc_ptr->power_desc[rc_ptr->num].min_level = 2;
-        rc_ptr->power_desc[rc_ptr->num].cost = 2;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 9;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(format(_("マジック・ミサイル (ダメージ %dd%d)", "Magic Missile (dm %dd%d)"), 3 + ((rc_ptr->lvl - 1) / 5), 4));
+        rpi.min_level = 2;
+        rpi.cost = 2;
+        rpi.stat = A_INT;
+        rpi.fail = 9;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_DRACONIAN:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = format(_("ブレス (ダメージ %d)", "Breath Weapon (dam %d)"), rc_ptr->lvl * 2);
-        rc_ptr->power_desc[rc_ptr->num].min_level = 1;
-        rc_ptr->power_desc[rc_ptr->num].cost = rc_ptr->lvl;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
-        rc_ptr->power_desc[rc_ptr->num].fail = 12;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(format(_("ブレス (ダメージ %d)", "Breath Weapon (dam %d)"), rc_ptr->lvl * 2));
+        rpi.min_level = 1;
+        rpi.cost = rc_ptr->lvl;
+        rpi.stat = A_CON;
+        rpi.fail = 12;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_MIND_FLAYER:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = format(_("精神攻撃 (ダメージ %d)", "Mind Blast (dam %d)"), rc_ptr->lvl);
-        rc_ptr->power_desc[rc_ptr->num].min_level = 15;
-        rc_ptr->power_desc[rc_ptr->num].cost = 12;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 14;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(format(_("精神攻撃 (ダメージ %d)", "Mind Blast (dam %d)"), rc_ptr->lvl));
+        rpi.min_level = 15;
+        rpi.cost = 12;
+        rpi.stat = A_INT;
+        rpi.fail = 14;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_IMP:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = format(_("ファイア・ボルト/ボール (ダメージ %d)", "Fire Bolt/Ball (dam %d)"), rc_ptr->lvl);
-        rc_ptr->power_desc[rc_ptr->num].min_level = 9;
-        rc_ptr->power_desc[rc_ptr->num].cost = 15;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = 15;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(format(_("ファイア・ボルト/ボール (ダメージ %d)", "Fire Bolt/Ball (dam %d)"), rc_ptr->lvl));
+        rpi.min_level = 9;
+        rpi.cost = 15;
+        rpi.stat = A_WIS;
+        rpi.fail = 15;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_GOLEM:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("肌石化 (期間 1d20+30)", "Stone Skin (dur 1d20+30)");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 20;
-        rc_ptr->power_desc[rc_ptr->num].cost = 15;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
-        rc_ptr->power_desc[rc_ptr->num].fail = 8;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(_("肌石化 (期間 1d20+30)", "Stone Skin (dur 1d20+30)"));
+        rpi.min_level = 20;
+        rpi.cost = 15;
+        rpi.stat = A_CON;
+        rpi.fail = 8;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_SKELETON:
     case RACE_ZOMBIE:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("経験値復活", "Restore Experience");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 30;
-        rc_ptr->power_desc[rc_ptr->num].cost = 30;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_WIS;
-        rc_ptr->power_desc[rc_ptr->num].fail = 18;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(_("経験値復活", "Restore Experience"));
+        rpi.min_level = 30;
+        rpi.cost = 30;
+        rpi.stat = A_WIS;
+        rpi.fail = 18;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_VAMPIRE:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("吸血", "Vampiric Drain");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 2;
-        rc_ptr->power_desc[rc_ptr->num].cost = 1 + (rc_ptr->lvl / 3);
-        rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
-        rc_ptr->power_desc[rc_ptr->num].fail = 9;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(_("吸血", "Vampiric Drain"));
+        rpi.min_level = 2;
+        rpi.cost = 1 + (rc_ptr->lvl / 3);
+        rpi.stat = A_CON;
+        rpi.fail = 9;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_SPRITE:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("眠り粉", "Sleeping Dust");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 12;
-        rc_ptr->power_desc[rc_ptr->num].cost = 12;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_INT;
-        rc_ptr->power_desc[rc_ptr->num].fail = 15;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(_("眠り粉", "Sleeping Dust"));
+        rpi.min_level = 12;
+        rpi.cost = 12;
+        rpi.stat = A_INT;
+        rpi.fail = 15;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_BALROG:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = format(_("地獄/火炎のブレス (ダメージ %d)", "Nether or Fire Breath (dam %d)"), rc_ptr->lvl * 3);
-        rc_ptr->power_desc[rc_ptr->num].min_level = 15;
-        rc_ptr->power_desc[rc_ptr->num].cost = 10 + rc_ptr->lvl / 3;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_CON;
-        rc_ptr->power_desc[rc_ptr->num].fail = 20;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(format(_("地獄/火炎のブレス (ダメージ %d)", "Nether or Fire Breath (dam %d)"), rc_ptr->lvl * 3));
+        rpi.min_level = 15;
+        rpi.cost = 10 + rc_ptr->lvl / 3;
+        rpi.stat = A_CON;
+        rpi.fail = 20;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_KUTAR:
-        rc_ptr->power_desc[rc_ptr->num].racial_name = _("横に伸びる", "Expand Horizontally (dur 30+1d20)");
-        rc_ptr->power_desc[rc_ptr->num].min_level = 20;
-        rc_ptr->power_desc[rc_ptr->num].cost = 15;
-        rc_ptr->power_desc[rc_ptr->num].stat = A_CHR;
-        rc_ptr->power_desc[rc_ptr->num].fail = 8;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi = rc_ptr->make_power(_("横に伸びる", "Expand Horizontally (dur 30+1d20)"));
+        rpi.min_level = 20;
+        rpi.cost = 15;
+        rpi.stat = A_CHR;
+        rpi.fail = 8;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_ANDROID:
         if (creature_ptr->lev < 10) {
-            rc_ptr->power_desc[rc_ptr->num].racial_name = _("レイガン", "Ray Gun");
-            rc_ptr->power_desc[rc_ptr->num].min_level = 1;
-            rc_ptr->power_desc[rc_ptr->num].cost = 7;
-            rc_ptr->power_desc[rc_ptr->num].fail = 8;
+            rpi = rc_ptr->make_power(_("レイガン", "Ray Gun"));
+            rpi.min_level = 1;
+            rpi.cost = 7;
+            rpi.fail = 8;
         } else if (creature_ptr->lev < 25) {
-            rc_ptr->power_desc[rc_ptr->num].racial_name = _("ブラスター", "Blaster");
-            rc_ptr->power_desc[rc_ptr->num].min_level = 10;
-            rc_ptr->power_desc[rc_ptr->num].cost = 13;
-            rc_ptr->power_desc[rc_ptr->num].fail = 10;
+            rpi = rc_ptr->make_power(_("ブラスター", "Blaster"));
+            rpi.min_level = 10;
+            rpi.cost = 13;
+            rpi.fail = 10;
         } else if (creature_ptr->lev < 35) {
-            rc_ptr->power_desc[rc_ptr->num].racial_name = _("バズーカ", "Bazooka");
-            rc_ptr->power_desc[rc_ptr->num].min_level = 25;
-            rc_ptr->power_desc[rc_ptr->num].cost = 26;
-            rc_ptr->power_desc[rc_ptr->num].fail = 12;
+            rpi = rc_ptr->make_power(_("バズーカ", "Bazooka"));
+            rpi.min_level = 25;
+            rpi.cost = 26;
+            rpi.fail = 12;
         } else if (creature_ptr->lev < 45) {
-            rc_ptr->power_desc[rc_ptr->num].racial_name = _("ビームキャノン", "Beam Cannon");
-            rc_ptr->power_desc[rc_ptr->num].min_level = 35;
-            rc_ptr->power_desc[rc_ptr->num].cost = 40;
-            rc_ptr->power_desc[rc_ptr->num].fail = 15;
+            rpi = rc_ptr->make_power(_("ビームキャノン", "Beam Cannon"));
+            rpi.min_level = 35;
+            rpi.cost = 40;
+            rpi.fail = 15;
         } else {
-            rc_ptr->power_desc[rc_ptr->num].racial_name = _("ロケット", "Rocket");
-            rc_ptr->power_desc[rc_ptr->num].min_level = 45;
-            rc_ptr->power_desc[rc_ptr->num].cost = 60;
-            rc_ptr->power_desc[rc_ptr->num].fail = 18;
+            rpi = rc_ptr->make_power(_("ロケット", "Rocket"));
+            rpi.min_level = 45;
+            rpi.cost = 60;
+            rpi.fail = 18;
         }
-        rc_ptr->power_desc[rc_ptr->num].stat = A_STR;
-        rc_ptr->power_desc[rc_ptr->num++].number = -1;
+        rpi.stat = A_STR;
+        rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     default:
         break;

--- a/src/racial/race-racial-command-setter.cpp
+++ b/src/racial/race-racial-command-setter.cpp
@@ -1,4 +1,5 @@
 ﻿#include "racial/race-racial-command-setter.h"
+#include "cmd-action/cmd-spell.h"
 #include "player/player-race.h"
 #include "racial/racial-util.h"
 
@@ -8,7 +9,8 @@ void set_mimic_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
     switch (creature_ptr->mimic_form) {
     case MIMIC_DEMON:
     case MIMIC_DEMON_LORD:
-        rpi = rc_ptr->make_power(format(_("地獄/火炎のブレス (ダメージ %d)", "Nether or Fire Breath (dam %d)"), rc_ptr->lvl * 3));
+        rpi = rc_ptr->make_power(_("地獄/火炎のブレス", "Nether or Fire Breath"));
+        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 3);
         rpi.min_level = 15;
         rpi.cost = 10 + rc_ptr->lvl / 3;
         rpi.stat = A_CON;
@@ -17,6 +19,7 @@ void set_mimic_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case MIMIC_VAMPIRE:
         rpi = rc_ptr->make_power(_("吸血", "Vampiric Drain"));
+        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
         rpi.min_level = 2;
         rpi.cost = 1 + (rc_ptr->lvl / 3);
         rpi.stat = A_CON;
@@ -56,6 +59,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case RACE_GNOME:
         rpi = rc_ptr->make_power(_("ショート・テレポート", "Blink"));
+        rpi.info = format("%s%d", KWD_SPHERE, 10);
         rpi.min_level = 5;
         rpi.cost = 5;
         rpi.stat = A_INT;
@@ -72,6 +76,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case RACE_HALF_TROLL:
         rpi = rc_ptr->make_power(_("狂戦士化", "Berserk"));
+        rpi.info = format("%s%d+d%d", KWD_DURATION, 10, rc_ptr->lvl);
         rpi.min_level = 10;
         rpi.cost = 12;
         rpi.stat = A_STR;
@@ -80,6 +85,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case RACE_BARBARIAN:
         rpi = rc_ptr->make_power(_("狂戦士化", "Berserk"));
+        rpi.info = format("%s%d+d%d", KWD_DURATION, 10, rc_ptr->lvl);
         rpi.min_level = 8;
         rpi.cost = 10;
         rpi.stat = A_STR;
@@ -126,7 +132,8 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_CYCLOPS:
-        rpi = rc_ptr->make_power(format(_("岩石投げ（ダメージ %d）", "Throw Boulder (dam %d)"), (3 * rc_ptr->lvl) / 2));
+        rpi = rc_ptr->make_power(_("岩石投げ", "Throw Boulder"));
+        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 3 / 2);
         rpi.min_level = 20;
         rpi.cost = 15;
         rpi.stat = A_STR;
@@ -150,7 +157,8 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_KLACKON:
-        rpi = rc_ptr->make_power(format(_("酸の唾 (ダメージ %d)", "Spit Acid (dam %d)"), rc_ptr->lvl));
+        rpi = rc_ptr->make_power(_("酸の唾", "Spit Acid"));
+        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl);
         rpi.min_level = 9;
         rpi.cost = 9;
         rpi.stat = A_DEX;
@@ -158,7 +166,8 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_KOBOLD:
-        rpi = rc_ptr->make_power(format(_("毒のダーツ (ダメージ %d)", "Poison Dart (dam %d)"), rc_ptr->lvl));
+        rpi = rc_ptr->make_power(_("毒のダーツ", "Poison Dart"));
+        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl);
         rpi.min_level = 12;
         rpi.cost = 8;
         rpi.stat = A_DEX;
@@ -166,7 +175,8 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_DARK_ELF:
-        rpi = rc_ptr->make_power(format(_("マジック・ミサイル (ダメージ %dd%d)", "Magic Missile (dm %dd%d)"), 3 + ((rc_ptr->lvl - 1) / 5), 4));
+        rpi = rc_ptr->make_power(_("マジック・ミサイル", "Magic Missile"));
+        rpi.info = format("%s%dd%d", KWD_DAM, 3 + ((rc_ptr->lvl - 1) / 5), 4);
         rpi.min_level = 2;
         rpi.cost = 2;
         rpi.stat = A_INT;
@@ -174,7 +184,8 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_DRACONIAN:
-        rpi = rc_ptr->make_power(format(_("ブレス (ダメージ %d)", "Breath Weapon (dam %d)"), rc_ptr->lvl * 2));
+        rpi = rc_ptr->make_power(_("ブレス", "Breath Weapon"));
+        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
         rpi.min_level = 1;
         rpi.cost = rc_ptr->lvl;
         rpi.stat = A_CON;
@@ -182,7 +193,8 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_MIND_FLAYER:
-        rpi = rc_ptr->make_power(format(_("精神攻撃 (ダメージ %d)", "Mind Blast (dam %d)"), rc_ptr->lvl));
+        rpi = rc_ptr->make_power(_("精神攻撃", "Mind Blast"));
+        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl);
         rpi.min_level = 15;
         rpi.cost = 12;
         rpi.stat = A_INT;
@@ -190,7 +202,11 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_IMP:
-        rpi = rc_ptr->make_power(format(_("ファイア・ボルト/ボール (ダメージ %d)", "Fire Bolt/Ball (dam %d)"), rc_ptr->lvl));
+        if (rc_ptr->lvl > 30)
+            rpi = rc_ptr->make_power(_("ファイア・ボール", "Fire Ball"));
+        else
+            rpi = rc_ptr->make_power(_("ファイア・ボルト", "Fire Bolt"));
+        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl);
         rpi.min_level = 9;
         rpi.cost = 15;
         rpi.stat = A_WIS;
@@ -198,7 +214,8 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_GOLEM:
-        rpi = rc_ptr->make_power(_("肌石化 (期間 1d20+30)", "Stone Skin (dur 1d20+30)"));
+        rpi = rc_ptr->make_power(_("肌石化", "Stone Skin"));
+        rpi.info = format("%s%d+d%d", KWD_DURATION, 30, 20);
         rpi.min_level = 20;
         rpi.cost = 15;
         rpi.stat = A_CON;
@@ -216,6 +233,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case RACE_VAMPIRE:
         rpi = rc_ptr->make_power(_("吸血", "Vampiric Drain"));
+        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
         rpi.min_level = 2;
         rpi.cost = 1 + (rc_ptr->lvl / 3);
         rpi.stat = A_CON;
@@ -224,6 +242,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case RACE_SPRITE:
         rpi = rc_ptr->make_power(_("眠り粉", "Sleeping Dust"));
+        rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl);
         rpi.min_level = 12;
         rpi.cost = 12;
         rpi.stat = A_INT;
@@ -231,7 +250,8 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_BALROG:
-        rpi = rc_ptr->make_power(format(_("地獄/火炎のブレス (ダメージ %d)", "Nether or Fire Breath (dam %d)"), rc_ptr->lvl * 3));
+        rpi = rc_ptr->make_power(_("地獄/火炎のブレス", "Nether or Fire Breath"));
+        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 3);
         rpi.min_level = 15;
         rpi.cost = 10 + rc_ptr->lvl / 3;
         rpi.stat = A_CON;
@@ -239,7 +259,8 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_KUTAR:
-        rpi = rc_ptr->make_power(_("横に伸びる", "Expand Horizontally (dur 30+1d20)"));
+        rpi = rc_ptr->make_power(_("横に伸びる", "Expand Horizontally"));
+        rpi.info = format("%s%d+d%d", KWD_DURATION, 30, 20);
         rpi.min_level = 20;
         rpi.cost = 15;
         rpi.stat = A_CHR;
@@ -249,26 +270,31 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
     case RACE_ANDROID:
         if (creature_ptr->lev < 10) {
             rpi = rc_ptr->make_power(_("レイガン", "Ray Gun"));
+            rpi.info = format("%s%d", KWD_DAM, (rc_ptr->lvl + 1) / 2);
             rpi.min_level = 1;
             rpi.cost = 7;
             rpi.fail = 8;
         } else if (creature_ptr->lev < 25) {
             rpi = rc_ptr->make_power(_("ブラスター", "Blaster"));
+            rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl);
             rpi.min_level = 10;
             rpi.cost = 13;
             rpi.fail = 10;
         } else if (creature_ptr->lev < 35) {
             rpi = rc_ptr->make_power(_("バズーカ", "Bazooka"));
+            rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
             rpi.min_level = 25;
             rpi.cost = 26;
             rpi.fail = 12;
         } else if (creature_ptr->lev < 45) {
             rpi = rc_ptr->make_power(_("ビームキャノン", "Beam Cannon"));
+            rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
             rpi.min_level = 35;
             rpi.cost = 40;
             rpi.fail = 15;
         } else {
             rpi = rc_ptr->make_power(_("ロケット", "Rocket"));
+            rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 5);
             rpi.min_level = 45;
             rpi.cost = 60;
             rpi.fail = 18;

--- a/src/racial/race-racial-command-setter.cpp
+++ b/src/racial/race-racial-command-setter.cpp
@@ -11,6 +11,7 @@ void set_mimic_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
     case MIMIC_DEMON_LORD:
         rpi = rc_ptr->make_power(_("地獄/火炎のブレス", "Nether or Fire Breath"));
         rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 3);
+        rpi.text = _("火炎または地獄のブレスを放つ。", "Fires a breath of fire or nether.");
         rpi.min_level = 15;
         rpi.cost = 10 + rc_ptr->lvl / 3;
         rpi.stat = A_CON;
@@ -20,6 +21,8 @@ void set_mimic_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
     case MIMIC_VAMPIRE:
         rpi = rc_ptr->make_power(_("吸血", "Vampiric Drain"));
         rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
+        rpi.text = _("隣接したモンスター1体から生命力を吸い取る。吸い取った生命力によって満腹度があがる。",
+            "Drains and transfers HP from a monster near by you. You will also gain nutritional sustenance from this.");
         rpi.min_level = 2;
         rpi.cost = 1 + (rc_ptr->lvl / 3);
         rpi.stat = A_CON;
@@ -35,6 +38,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
     switch (creature_ptr->prace) {
     case RACE_DWARF:
         rpi = rc_ptr->make_power(_("ドアと罠 感知", "Detect Doors+Traps"));
+        rpi.text = _("近くの全ての扉と罠、階段を感知する。", "Detects traps, doors, and stairs in your vicinity.");
         rpi.min_level = 5;
         rpi.cost = 5;
         rpi.stat = A_WIS;
@@ -43,6 +47,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case RACE_NIBELUNG:
         rpi = rc_ptr->make_power(_("ドアと罠 感知", "Detect Doors+Traps"));
+        rpi.text = _("近くの全ての扉と罠、階段を感知する。", "Detects traps, doors, and stairs in your vicinity.");
         rpi.min_level = 10;
         rpi.cost = 5;
         rpi.stat = A_WIS;
@@ -51,6 +56,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case RACE_HOBBIT:
         rpi = rc_ptr->make_power(_("食糧生成", "Create Food"));
+        rpi.text = _("食料を一つ作り出す。", "Produces a Ration of Food.");
         rpi.min_level = 15;
         rpi.cost = 10;
         rpi.stat = A_INT;
@@ -60,6 +66,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
     case RACE_GNOME:
         rpi = rc_ptr->make_power(_("ショート・テレポート", "Blink"));
         rpi.info = format("%s%d", KWD_SPHERE, 10);
+        rpi.text = _("近距離のテレポートをする。", "Teleports you a short distance.");
         rpi.min_level = 5;
         rpi.cost = 5;
         rpi.stat = A_INT;
@@ -68,6 +75,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case RACE_HALF_ORC:
         rpi = rc_ptr->make_power(_("恐怖除去", "Remove Fear"));
+        rpi.text = _("恐怖を取り除く。", "Removes fear.");
         rpi.min_level = 3;
         rpi.cost = 5;
         rpi.stat = A_WIS;
@@ -77,6 +85,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
     case RACE_HALF_TROLL:
         rpi = rc_ptr->make_power(_("狂戦士化", "Berserk"));
         rpi.info = format("%s%d+d%d", KWD_DURATION, 10, rc_ptr->lvl);
+        rpi.text = _("狂戦士化し、恐怖を除去する。防御力が少し低下する。", "Gives a bonus to hit and HP, immunity to fear for a while. But decreases AC.");
         rpi.min_level = 10;
         rpi.cost = 12;
         rpi.stat = A_STR;
@@ -86,6 +95,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
     case RACE_BARBARIAN:
         rpi = rc_ptr->make_power(_("狂戦士化", "Berserk"));
         rpi.info = format("%s%d+d%d", KWD_DURATION, 10, rc_ptr->lvl);
+        rpi.text = _("狂戦士化し、恐怖を除去する。防御力が少し低下する。", "Gives a bonus to hit and HP, immunity to fear for a while. But decreases AC.");
         rpi.min_level = 8;
         rpi.cost = 10;
         rpi.stat = A_STR;
@@ -94,6 +104,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case RACE_AMBERITE:
         rpi = rc_ptr->make_power(_("シャドウ・シフト", "Shadow Shifting"));
+        rpi.text = _("現在の階を再構成する。", "Recreates current dungeon level.");
         rpi.min_level = 30;
         rpi.cost = 50;
         rpi.stat = A_INT;
@@ -101,6 +112,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_RACE_0);
 
         rpi = rc_ptr->make_power(_("パターン・ウォーク", "Pattern Mindwalking"));
+        rpi.text = _("すべてのステータスと経験値を回復する。", "Restores all stats and experience.");
         rpi.min_level = 40;
         rpi.cost = 75;
         rpi.stat = A_WIS;
@@ -109,6 +121,8 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case RACE_HALF_OGRE:
         rpi = rc_ptr->make_power(_("爆発のルーン", "Explosive Rune"));
+        rpi.text = _("自分のいる床の上に、モンスターが上を通ろうとすると爆発するルーンを描く。",
+            "Sets a rune on the floor beneath you which exprodes if a monster through upon it. Monsters can try to disarm it.");
         rpi.min_level = 25;
         rpi.cost = 35;
         rpi.stat = A_INT;
@@ -117,6 +131,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case RACE_HALF_GIANT:
         rpi = rc_ptr->make_power(_("岩石溶解", "Stone to Mud"));
+        rpi.text = _("壁を溶かして床にする。", "Turns one rock square to mud.");
         rpi.min_level = 20;
         rpi.cost = 10;
         rpi.stat = A_STR;
@@ -125,6 +140,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case RACE_HALF_TITAN:
         rpi = rc_ptr->make_power(_("スキャン・モンスター", "Probing"));
+        rpi.text = _("モンスターの属性、残り体力、最大体力、スピード、正体を知る。", "Probes all monsters' alignment, HP, speed and their true character.");
         rpi.min_level = 15;
         rpi.cost = 10;
         rpi.stat = A_INT;
@@ -134,6 +150,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
     case RACE_CYCLOPS:
         rpi = rc_ptr->make_power(_("岩石投げ", "Throw Boulder"));
         rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 3 / 2);
+        rpi.text = _("弱い魔法のボールを放つ", "Fires a weak boll of magic.");
         rpi.min_level = 20;
         rpi.cost = 15;
         rpi.stat = A_STR;
@@ -142,6 +159,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case RACE_YEEK:
         rpi = rc_ptr->make_power(_("モンスター恐慌", "Scare Monster"));
+        rpi.text = _("モンスター1体を恐怖させる。抵抗されると無効。", "Attempts to scare a monster.");
         rpi.min_level = 15;
         rpi.cost = 15;
         rpi.stat = A_WIS;
@@ -150,6 +168,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         break;
     case RACE_SPECTRE:
         rpi = rc_ptr->make_power(_("モンスター恐慌", "Scare Monster"));
+        rpi.text = _("モンスター1体を恐怖させる。抵抗されると無効。", "Attempts to scare a monster.");
         rpi.min_level = 4;
         rpi.cost = 6;
         rpi.stat = A_INT;
@@ -159,6 +178,10 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
     case RACE_KLACKON:
         rpi = rc_ptr->make_power(_("酸の唾", "Spit Acid"));
         rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl);
+        if (rc_ptr->lvl >= 25)
+            rpi.text = _("酸のボールを放つ", "Fires a boll of acid.");
+        else
+            rpi.text = _("酸の矢を放つ", "Fires a bolt of acid.");
         rpi.min_level = 9;
         rpi.cost = 9;
         rpi.stat = A_DEX;
@@ -168,6 +191,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
     case RACE_KOBOLD:
         rpi = rc_ptr->make_power(_("毒のダーツ", "Poison Dart"));
         rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl);
+        rpi.text = _("毒の矢を放つ", "Fires a bolt of poison.");
         rpi.min_level = 12;
         rpi.cost = 8;
         rpi.stat = A_DEX;
@@ -177,6 +201,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
     case RACE_DARK_ELF:
         rpi = rc_ptr->make_power(_("マジック・ミサイル", "Magic Missile"));
         rpi.info = format("%s%dd%d", KWD_DAM, 3 + ((rc_ptr->lvl - 1) / 5), 4);
+        rpi.text = _("弱い魔法の矢を放つ。", "Fires a weak bolt of magic.");
         rpi.min_level = 2;
         rpi.cost = 2;
         rpi.stat = A_INT;
@@ -186,6 +211,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
     case RACE_DRACONIAN:
         rpi = rc_ptr->make_power(_("ブレス", "Breath Weapon"));
         rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
+        rpi.text = _("元素のブレスを放つ", "Fires a breath of an element.");
         rpi.min_level = 1;
         rpi.cost = rc_ptr->lvl;
         rpi.stat = A_CON;
@@ -195,6 +221,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
     case RACE_MIND_FLAYER:
         rpi = rc_ptr->make_power(_("精神攻撃", "Mind Blast"));
         rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl);
+        rpi.text = _("モンスター1体に精神攻撃を行う。", "Deals a PSI damage to a monster.");
         rpi.min_level = 15;
         rpi.cost = 12;
         rpi.stat = A_INT;
@@ -202,10 +229,13 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_RACE_0);
         break;
     case RACE_IMP:
-        if (rc_ptr->lvl > 30)
+        if (rc_ptr->lvl > 30) {
             rpi = rc_ptr->make_power(_("ファイア・ボール", "Fire Ball"));
-        else
+            rpi.text = _("火炎のボールを放つ。", "Fires a ball of fire.");
+        } else {
             rpi = rc_ptr->make_power(_("ファイア・ボルト", "Fire Bolt"));
+            rpi.text = _("火炎の矢を放つ。", "Fires a bolt of fire.");
+        }
         rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl);
         rpi.min_level = 9;
         rpi.cost = 15;
@@ -216,6 +246,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
     case RACE_GOLEM:
         rpi = rc_ptr->make_power(_("肌石化", "Stone Skin"));
         rpi.info = format("%s%d+d%d", KWD_DURATION, 30, 20);
+        rpi.text = _("一定期間防御力を高める。", "Increases your AC temporary");
         rpi.min_level = 20;
         rpi.cost = 15;
         rpi.stat = A_CON;
@@ -225,6 +256,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
     case RACE_SKELETON:
     case RACE_ZOMBIE:
         rpi = rc_ptr->make_power(_("経験値復活", "Restore Experience"));
+        rpi.text = _("経験値を回復する。", "Restores experience.");
         rpi.min_level = 30;
         rpi.cost = 30;
         rpi.stat = A_WIS;
@@ -234,6 +266,8 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
     case RACE_VAMPIRE:
         rpi = rc_ptr->make_power(_("吸血", "Vampiric Drain"));
         rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
+        rpi.text = _("隣接したモンスター1体から生命力を吸い取る。吸い取った生命力によって満腹度があがる。",
+            "Drains and transfers HP from a monster near by you. You will also gain nutritional sustenance from this.");
         rpi.min_level = 2;
         rpi.cost = 1 + (rc_ptr->lvl / 3);
         rpi.stat = A_CON;
@@ -243,6 +277,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
     case RACE_SPRITE:
         rpi = rc_ptr->make_power(_("眠り粉", "Sleeping Dust"));
         rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl);
+        rpi.text = _("モンスター1体を眠らせる。抵抗されると無効。", "Attempts to put a monster to sleep.");
         rpi.min_level = 12;
         rpi.cost = 12;
         rpi.stat = A_INT;
@@ -252,6 +287,7 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
     case RACE_BALROG:
         rpi = rc_ptr->make_power(_("地獄/火炎のブレス", "Nether or Fire Breath"));
         rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 3);
+        rpi.text = _("火炎または地獄のブレスを放つ。", "Fires a breath of fire or nether.");
         rpi.min_level = 15;
         rpi.cost = 10 + rc_ptr->lvl / 3;
         rpi.stat = A_CON;
@@ -261,6 +297,8 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
     case RACE_KUTAR:
         rpi = rc_ptr->make_power(_("横に伸びる", "Expand Horizontally"));
         rpi.info = format("%s%d+d%d", KWD_DURATION, 30, 20);
+        rpi.text = _("横に伸びて防御力を高める。魔法防御力は低下する。",
+            "Expands your body horizontally then increases AC, but decreases your magic resistance for curses.");
         rpi.min_level = 20;
         rpi.cost = 15;
         rpi.stat = A_CHR;
@@ -271,30 +309,35 @@ void set_race_racial_command(player_type *creature_ptr, rc_type *rc_ptr)
         if (creature_ptr->lev < 10) {
             rpi = rc_ptr->make_power(_("レイガン", "Ray Gun"));
             rpi.info = format("%s%d", KWD_DAM, (rc_ptr->lvl + 1) / 2);
+            rpi.text = _("弱い魔法の矢を放つ。", "Fires a weak bolt of magic.");
             rpi.min_level = 1;
             rpi.cost = 7;
             rpi.fail = 8;
         } else if (creature_ptr->lev < 25) {
             rpi = rc_ptr->make_power(_("ブラスター", "Blaster"));
             rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl);
+            rpi.text = _("弱い魔法の矢を放つ。", "Fires a weak bolt of magic.");
             rpi.min_level = 10;
             rpi.cost = 13;
             rpi.fail = 10;
         } else if (creature_ptr->lev < 35) {
             rpi = rc_ptr->make_power(_("バズーカ", "Bazooka"));
             rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
+            rpi.text = _("弱い魔法のボールを放つ。", "Fires a weak ball of magic.");
             rpi.min_level = 25;
             rpi.cost = 26;
             rpi.fail = 12;
         } else if (creature_ptr->lev < 45) {
             rpi = rc_ptr->make_power(_("ビームキャノン", "Beam Cannon"));
             rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
+            rpi.text = _("弱い魔法のビームを放つ。", "Fires a beam bolt of magic.");
             rpi.min_level = 35;
             rpi.cost = 40;
             rpi.fail = 15;
         } else {
             rpi = rc_ptr->make_power(_("ロケット", "Rocket"));
             rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 5);
+            rpi.text = _("ロケットを放つ。", "Fires a magic rocket.");
             rpi.min_level = 45;
             rpi.cost = 60;
             rpi.fail = 18;

--- a/src/racial/racial-util.cpp
+++ b/src/racial/racial-util.cpp
@@ -10,10 +10,6 @@ rc_type *initialize_rc_type(player_type *creature_ptr, rc_type *rc_ptr)
     rc_ptr->cast = FALSE;
     rc_ptr->is_warrior = (creature_ptr->pclass == CLASS_WARRIOR || creature_ptr->pclass == CLASS_BERSERKER);
     rc_ptr->menu_line = use_menu ? 1 : 0;
-    for (int i = 0; i < MAX_RACIAL_POWERS; i++) {
-        strcpy(rc_ptr->power_desc[i].racial_name, "");
-        rc_ptr->power_desc[i].number = 0;
-    }
 
     return rc_ptr;
 }

--- a/src/racial/racial-util.cpp
+++ b/src/racial/racial-util.cpp
@@ -1,15 +1,28 @@
 ﻿#include "racial/racial-util.h"
 #include "io/input-key-requester.h"
 
-rc_type *initialize_rc_type(player_type *creature_ptr, rc_type *rc_ptr)
+rc_type::rc_type(player_type *creature_ptr)
 {
-    rc_ptr->num = 0;
-    rc_ptr->command_code = 0;
-    rc_ptr->ask = TRUE;
-    rc_ptr->lvl = creature_ptr->lev;
-    rc_ptr->cast = FALSE;
-    rc_ptr->is_warrior = (creature_ptr->pclass == CLASS_WARRIOR || creature_ptr->pclass == CLASS_BERSERKER);
-    rc_ptr->menu_line = use_menu ? 1 : 0;
+    this->ask = true;
+    this->lvl = creature_ptr->lev;
+    this->is_warrior = (creature_ptr->pclass == CLASS_WARRIOR || creature_ptr->pclass == CLASS_BERSERKER);
+    this->menu_line = use_menu ? 1 : 0;
+}
 
-    return rc_ptr;
+rpi_type rc_type::make_power(std::string name)
+{
+    auto rpi = rpi_type();
+    rpi.racial_name = name;
+    return rpi;
+}
+
+void rc_type::add_power(rpi_type& rpi, int number)
+{
+    rpi.number = number;
+    this->power_desc.emplace_back(rpi);
+}
+
+COMMAND_CODE rc_type::size()
+{
+    return (COMMAND_CODE)this->power_desc.size();
 }

--- a/src/racial/racial-util.cpp
+++ b/src/racial/racial-util.cpp
@@ -6,7 +6,6 @@ rc_type::rc_type(player_type *creature_ptr)
     this->ask = true;
     this->lvl = creature_ptr->lev;
     this->is_warrior = (creature_ptr->pclass == CLASS_WARRIOR || creature_ptr->pclass == CLASS_BERSERKER);
-    this->menu_line = use_menu ? 1 : 0;
 }
 
 rpi_type rc_type::make_power(std::string name)

--- a/src/racial/racial-util.h
+++ b/src/racial/racial-util.h
@@ -19,6 +19,7 @@ enum rc_index : int {
  */
 struct rpi_type {
     std::string racial_name{}; //!< パワー名
+    std::string info{}; //!< パワー情報
     PLAYER_LEVEL min_level{}; //!< 使用可能最小レベル
     int cost{}; //!< コスト
     int stat{}; //!< 使用に必要な能力値
@@ -33,11 +34,12 @@ struct rpi_type {
 struct rc_type {
     std::vector<rpi_type> power_desc{}; //!< パワー定義配列
     COMMAND_CODE command_code{}; //!< 使用しようとしているパワー番号
+    int page{}; //!< 表示中のページ
+    int max_page{}; //!< ページ数
     int ask{}; //!< 選択後確認するかどうか
     PLAYER_LEVEL lvl{}; //!< プレイヤーレベル
     bool is_warrior{}; //!< 戦士/狂戦士かどうか
-    bool flag{}; //!< パワーを選んだかどうか
-    bool redraw{}; //!< 再描画するかどうか
+    bool is_chosen{}; //!< 選択したかどうか
     bool cast{}; //!< パワーが使用されたかどうか
     char choice{}; //!< コマンドキー
     char out_val[160]{}; //!< 出力文字列用バッファ

--- a/src/racial/racial-util.h
+++ b/src/racial/racial-util.h
@@ -2,39 +2,71 @@
 
 #include "system/angband.h"
 #include <string>
-#include <array>
+#include <vector>
 
-#define MAX_RACIAL_POWERS 36
+/*!
+ * @brief レイシャル/クラスパワー呼び出し番号
+ */
+enum rc_index : int {
+    RC_IDX_RACE_0 = -1, //!< 種族0
+    RC_IDX_RACE_1 = -2, //!< 種族1
+    RC_IDX_CLASS_0 = -3, //!< 職業0
+    RC_IDX_CLASS_1 = -4, //!< 職業1
+};
 
 /*!
  * レイシャル/クラスパワー定義構造体
  */
 struct rpi_type {
-    std::string racial_name{};
-    PLAYER_LEVEL min_level{}; //!<体得レベル
-    int cost{};
-    int stat{};
-    PERCENTAGE fail{};
-    int number{};
-    int racial_cost{};
+    std::string racial_name{}; //!< パワー名
+    PLAYER_LEVEL min_level{}; //!< 使用可能最小レベル
+    int cost{}; //!< コスト
+    int stat{}; //!< 使用に必要な能力値
+    PERCENTAGE fail{}; //!< 難易度(失敗率)
+    int number{}; //!< 呼び出し番号
+    int racial_cost{}; //!< @todo 種族コスト、おそらく不要
 };
 
 /*!
  * レイシャル/クラスパワー管理構造体
  */
 struct rc_type {
-    std::array<rpi_type, MAX_RACIAL_POWERS> power_desc{};
-    int num{};
-    COMMAND_CODE command_code{};
-    int ask{};
-    PLAYER_LEVEL lvl{};
-    bool flag{};
-    bool redraw{};
-    bool cast{};
-    bool is_warrior{};
-    char choice{};
-    char out_val[160]{};
-    int menu_line{};
-};
+    std::vector<rpi_type> power_desc{}; //!< パワー定義配列
+    COMMAND_CODE command_code{}; //!< 使用しようとしているパワー番号
+    int ask{}; //!< 選択後確認するかどうか
+    PLAYER_LEVEL lvl{}; //!< プレイヤーレベル
+    bool is_warrior{}; //!< 戦士/狂戦士かどうか
+    bool flag{}; //!< パワーを選んだかどうか
+    bool redraw{}; //!< 再描画するかどうか
+    bool cast{}; //!< パワーが使用されたかどうか
+    char choice{}; //!< コマンドキー
+    char out_val[160]{}; //!< 出力文字列用バッファ
+    int menu_line{}; //!< 現在選択中の行
 
-rc_type *initialize_rc_type(player_type *creature_ptr, rc_type *rc_ptr);
+    /*!
+     * @brief コンストラクタ
+     * @param creature_ptr プレイヤー情報への参照ポインタ
+     * @return 管理構造体
+     */
+    rc_type(player_type *creature_prt);
+
+    /*!
+     * @brief 指定したパワー名のレイシャル/クラスパワー定義構造体を返す
+     * @param name パワー名
+     * @return パワー定義構造体
+     */
+    rpi_type make_power(std::string name);
+
+    /*!
+     * @brief レイシャル/クラスパワー定義を追加
+     * @param rpi レイシャル/クラスパワー定義(参照渡し)
+     * @param number 呼び出し番号
+     */
+    void add_power(rpi_type &rpi, int number);
+
+    /*!
+     * @brief レイシャル/クラスパワー数を返す
+     * @return パワー数
+     */
+    COMMAND_CODE size();
+};

--- a/src/racial/racial-util.h
+++ b/src/racial/racial-util.h
@@ -20,6 +20,7 @@ enum rc_index : int {
 struct rpi_type {
     std::string racial_name{}; //!< パワー名
     std::string info{}; //!< パワー情報
+    std::string text{}; //パワー説明文
     PLAYER_LEVEL min_level{}; //!< 使用可能最小レベル
     int cost{}; //!< コスト
     int stat{}; //!< 使用に必要な能力値
@@ -34,6 +35,7 @@ struct rpi_type {
 struct rc_type {
     std::vector<rpi_type> power_desc{}; //!< パワー定義配列
     COMMAND_CODE command_code{}; //!< 使用しようとしているパワー番号
+    bool browse_mode{}; //!< 閲覧のみかどうか
     int page{}; //!< 表示中のページ
     int max_page{}; //!< ページ数
     int ask{}; //!< 選択後確認するかどうか

--- a/src/racial/racial-util.h
+++ b/src/racial/racial-util.h
@@ -1,34 +1,40 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include <string>
+#include <array>
 
 #define MAX_RACIAL_POWERS 36
 
-/* Racial Power Info / レイシャル・パワー情報の構造体定義 */
-typedef struct rpi_type {
-    GAME_TEXT racial_name[MAX_NLEN];
-    PLAYER_LEVEL min_level; //!<体得レベル
-    int cost;
-    int stat;
-    PERCENTAGE fail;
-    int number;
-    int racial_cost;
-} rpi_type;
+/*!
+ * レイシャル/クラスパワー定義構造体
+ */
+struct rpi_type {
+    std::string racial_name{};
+    PLAYER_LEVEL min_level{}; //!<体得レベル
+    int cost{};
+    int stat{};
+    PERCENTAGE fail{};
+    int number{};
+    int racial_cost{};
+};
 
-// Racial Command.
-typedef struct rc_type {
-    rpi_type power_desc[MAX_RACIAL_POWERS];
-    int num;
-    COMMAND_CODE command_code;
-    int ask;
-    PLAYER_LEVEL lvl;
-    bool flag;
-    bool redraw;
-    bool cast;
-    bool is_warrior;
-    char choice;
-    char out_val[160];
-    int menu_line;
-} rc_type;
+/*!
+ * レイシャル/クラスパワー管理構造体
+ */
+struct rc_type {
+    std::array<rpi_type, MAX_RACIAL_POWERS> power_desc{};
+    int num{};
+    COMMAND_CODE command_code{};
+    int ask{};
+    PLAYER_LEVEL lvl{};
+    bool flag{};
+    bool redraw{};
+    bool cast{};
+    bool is_warrior{};
+    char choice{};
+    char out_val[160]{};
+    int menu_line{};
+};
 
 rc_type *initialize_rc_type(player_type *creature_ptr, rc_type *rc_ptr);

--- a/src/realm/realm-sorcery.cpp
+++ b/src/realm/realm-sorcery.cpp
@@ -233,7 +233,7 @@ concptr do_sorcery_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
         if (name)
             return _("スロウ・モンスター", "Slow Monster");
         if (desc)
-            return _("モンスター1体を減速さる。抵抗されると無効。", "Attempts to slow a monster.");
+            return _("モンスター1体を減速させる。抵抗されると無効。", "Attempts to slow a monster.");
 
         {
             int power = plev;


### PR DESCRIPTION
レイシャル/クラスパワーを選択する画面で説明文を表示できるようにする。
現在の想定では、大文字で選んで確認が出るときに説明文を出るようにしたい。
もしくは、何かキーを押して閲覧モードに切り替える。

それにともなって、レイシャル/クラスパワー画面のインターフェースをできる限り魔法の呪文選択画面に近づける。
今回は超能力系のものに合わせる。(将来的には選択処理を統一化できるとよいかも)

まずは、レイシャルクラスパワー定義と一覧表示/入力の部分を改修したのでドラフトとしてアップする。