### PR TITLE
[Fix] 宝物庫の報酬がクエスト受注元でメッセージを出すたびに変わる

### DIFF
--- a/src/market/building-quest.cpp
+++ b/src/market/building-quest.cpp
@@ -90,7 +90,7 @@ void castle_quest(player_type *player_ptr)
         put_str(_("あなたは現在のクエストを終了させていません！", "You have not completed your current quest yet!"), 8, 0);
         put_str(_("CTRL-Qを使えばクエストの状態がチェックできます。", "Use CTRL-Q to check the status of your quest."), 9, 0);
 
-        get_questinfo(player_ptr, q_index, true);
+        get_questinfo(player_ptr, q_index, false);
         put_str(format(_("現在のクエスト「%s」", "Current quest is '%s'."), q_ptr->name), 11, 0);
 
         if (q_ptr->type != QUEST_TYPE_KILL_LEVEL || q_ptr->dungeon == 0) {


### PR DESCRIPTION
#607のエンバグによりクエストが初期化されていた。
#607実装中は修正箇所がtrue時になぜかうまく動作していなかったが、再度falseにして正常に動くことを確認。コードも確認した。