### PR TITLE
[fix] レイシャルパワーの一覧表示/非表示の切り替え

### DIFF
--- a/src/cmd-action/cmd-racial.cpp
+++ b/src/cmd-action/cmd-racial.cpp
@@ -218,7 +218,7 @@ static bool racial_power_interpret_choise(player_type *creature_ptr, rc_type *rc
 
     if (rc_ptr->choice == ' ' || rc_ptr->choice == '*') {
         rc_ptr->page++;
-        if (rc_ptr->page >= rc_ptr->max_page + (always_show_list ? 0 : 1))
+        if (rc_ptr->page > rc_ptr->max_page)
             rc_ptr->page = 0;
         screen_load();
         screen_save();


### PR DESCRIPTION
always_show_list が yes の時でもレイシャルコマンドで '*'
(もしくは ' ' ) を押した時に一覧表示/非表示が切り替わる
ようにする。
（魔法の一覧表示/非表示切り替えの挙動と合わせる）

https://github.com/hengband/hengband/pull/876#issuecomment-824876140 の件の修正。
Issue無し。