### PR TITLE
[Fix] クラスパワーでtextをinfoに代入していた(鏡使い分)

### DIFF
--- a/src/cmd-action/cmd-racial.cpp
+++ b/src/cmd-action/cmd-racial.cpp
@@ -53,7 +53,7 @@ static void racial_power_erase_cursor(rc_type *rc_ptr)
 static void racial_power_display_list(player_type *creature_ptr, rc_type *rc_ptr)
 {
     TERM_LEN x = 11;
-    char dummy[80];
+    char dummy[256];
     strcpy(dummy, "");
 
     prt(_("                                   Lv   MP 失率 効果", "                               Lv   MP Fail Effect"), 1, x);

--- a/src/racial/class-racial-switcher.cpp
+++ b/src/racial/class-racial-switcher.cpp
@@ -306,7 +306,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
 
         rpi = rpi_type(_("静水", "Mirror Concentration"));
         rpi.info = format("%s%d", KWD_MANA, 3 + rc_ptr->lvl / 20);
-        rpi.info = _("精神を集中してMPを少し回復する。", "Concentrates deeply to heal your SP a little.");
+        rpi.text = _("精神を集中してMPを少し回復する。", "Concentrates deeply to heal your SP a little.");
         rpi.min_level = 30;
         rpi.cost = 0;
         rpi.stat = A_INT;


### PR DESCRIPTION
#861 の実装ミスが残っていた。Issueなし。