### PR TITLE
[Feature] MessageBox,GetSaveFileName APIをワイド文字列版へ移行

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -933,6 +933,7 @@
     <ClInclude Include="..\..\src\cmd-action\cmd-tunnel.h" />
     <ClInclude Include="..\..\src\action\movement-execution.h" />
     <ClInclude Include="..\..\src\main-win\read-graphics.h" />
+    <ClInclude Include="..\..\src\main-win\string-win.h" />
     <ClInclude Include="..\..\src\main-win\tile-info.h" />
     <ClInclude Include="..\..\src\store\cmd-store.h" />
     <ClInclude Include="..\..\src\cmd-io\cmd-floor.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -4857,6 +4857,9 @@
     <ClInclude Include="..\..\src\main-win\tile-info.h">
       <Filter>main-win</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\main-win\string-win.h">
+      <Filter>main-win</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\src\wall.bmp" />

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -105,6 +105,7 @@
 #include "main-win/main-win-music.h"
 #include "main-win/main-win-sound.h"
 #include "main-win/read-graphics.h"
+#include "main-win/string-win.h"
 #include "main-win/tile-info.h"
 #include "main/angband-initializer.h"
 #include "main/sound-of-music.h"
@@ -860,7 +861,8 @@ static errr term_user_win(int n)
     return 0;
 }
 
-static void refresh_color_table() {
+static void refresh_color_table()
+{
     for (int i = 0; i < 256; i++) {
         byte rv = angband_color_table[i][1];
         byte gv = angband_color_table[i][2];
@@ -2005,21 +2007,22 @@ static void process_menus(player_type *player_ptr, WORD wCmd)
         break;
     }
     case IDM_DUMP_SCREEN_HTML: {
-        static char buf[1024] = "";
-        memset(&ofn, 0, sizeof(ofn));
-        ofn.lStructSize = sizeof(ofn);
-        ofn.hwndOwner = data[0].w;
-        ofn.lpstrFilter = "HTML Files (*.html)\0*.html\0";
-        ofn.nFilterIndex = 1;
-        ofn.lpstrFile = buf;
-        ofn.nMaxFile = 1023;
-        ofn.lpstrDefExt = "html";
-        ofn.lpstrInitialDir = NULL;
-        ofn.lpstrTitle = _("HTMLでスクリーンダンプを保存", "Save screen dump as HTML.");
-        ofn.Flags = OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT;
+        OPENFILENAMEW ofnw;
+        std::vector<WCHAR> buf(MAIN_WIN_MAX_PATH + 1);
+        memset(&ofnw, 0, sizeof(ofnw));
+        ofnw.lStructSize = sizeof(ofnw);
+        ofnw.hwndOwner = data[0].w;
+        ofnw.lpstrFilter = L"HTML Files (*.html)\0*.html\0";
+        ofnw.nFilterIndex = 1;
+        ofnw.lpstrFile = &buf[0];
+        ofnw.nMaxFile = MAIN_WIN_MAX_PATH;
+        ofnw.lpstrDefExt = L"html";
+        ofnw.lpstrInitialDir = NULL;
+        ofnw.lpstrTitle = _(L"HTMLでスクリーンダンプを保存", L"Save screen dump as HTML.");
+        ofnw.Flags = OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT;
 
-        if (GetSaveFileName(&ofn)) {
-            do_cmd_save_screen_html_aux(buf, 0);
+        if (GetSaveFileNameW(&ofnw)) {
+            do_cmd_save_screen_html_aux(to_multibyte(&buf[0]).c_str(), 0);
         }
 
         break;
@@ -2565,11 +2568,7 @@ LRESULT PASCAL AngbandListProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPara
 static void hack_plog(concptr str)
 {
     if (str) {
-#ifdef JP
-        MessageBox(NULL, str, "警告！", MB_ICONEXCLAMATION | MB_OK);
-#else
-        MessageBox(NULL, str, "Warning", MB_ICONEXCLAMATION | MB_OK);
-#endif
+        MessageBoxW(NULL, to_wchar(str).wc_str(), _(L"警告！", L"Warning"), MB_ICONEXCLAMATION | MB_OK);
     }
 }
 
@@ -2579,11 +2578,7 @@ static void hack_plog(concptr str)
 static void hack_quit(concptr str)
 {
     if (str) {
-#ifdef JP
-        MessageBox(NULL, str, "エラー！", MB_ICONEXCLAMATION | MB_OK | MB_ICONSTOP);
-#else
-        MessageBox(NULL, str, "Error", MB_ICONEXCLAMATION | MB_OK | MB_ICONSTOP);
-#endif
+        MessageBoxW(NULL, to_wchar(str).wc_str(), _(L"エラー！", L"Error"), MB_ICONEXCLAMATION | MB_OK | MB_ICONSTOP);
     }
 
     UnregisterClass(AppName, hInstance);
@@ -2599,11 +2594,7 @@ static void hack_quit(concptr str)
 static void hook_plog(concptr str)
 {
     if (str) {
-#ifdef JP
-        MessageBox(data[0].w, str, "警告！", MB_ICONEXCLAMATION | MB_OK);
-#else
-        MessageBox(data[0].w, str, "Warning", MB_ICONEXCLAMATION | MB_OK);
-#endif
+        MessageBoxW(data[0].w, to_wchar(str).wc_str(), _(L"警告！", L"Warning"), MB_ICONEXCLAMATION | MB_OK);
     }
 }
 
@@ -2613,11 +2604,7 @@ static void hook_plog(concptr str)
 static void hook_quit(concptr str)
 {
     if (str) {
-#ifdef JP
-        MessageBox(data[0].w, str, "エラー！", MB_ICONEXCLAMATION | MB_OK | MB_ICONSTOP);
-#else
-        MessageBox(data[0].w, str, "Error", MB_ICONEXCLAMATION | MB_OK | MB_ICONSTOP);
-#endif
+        MessageBoxW(data[0].w, to_wchar(str).wc_str(), _(L"エラー！", L"Error"), MB_ICONEXCLAMATION | MB_OK | MB_ICONSTOP);
     }
 
     save_prefs();
@@ -2743,8 +2730,8 @@ int WINAPI WinMain(_In_ HINSTANCE hInst, _In_opt_ HINSTANCE hPrevInst, _In_ LPST
     setlocale(LC_ALL, "ja_JP");
     hInstance = hInst;
     if (is_already_running()) {
-        MessageBox(
-            NULL, _("変愚蛮怒はすでに起動しています。", "Hengband is already running."), _("エラー！", "Error"), MB_ICONEXCLAMATION | MB_OK | MB_ICONSTOP);
+        MessageBoxW(
+            NULL, _(L"変愚蛮怒はすでに起動しています。", L"Hengband is already running."), _(L"エラー！", L"Error"), MB_ICONEXCLAMATION | MB_OK | MB_ICONSTOP);
         return FALSE;
     }
 

--- a/src/main-win/string-win.h
+++ b/src/main-win/string-win.h
@@ -1,0 +1,108 @@
+﻿#pragma once
+/*!
+ * @file string-win.h
+ * @brief Windows版固有実装(文字列)ヘッダ
+ */
+
+#include "term/z-virt.h"
+
+#include <windows.h>
+
+/*!
+ * @brief 文字列をワイド文字列へ変換するクラス
+ */
+class to_wchar {
+public:
+    to_wchar(const char *src)
+        : buf(NULL)
+        , buf_size(0)
+    {
+        if (!src)
+            return;
+
+        int size = ::MultiByteToWideChar(932, 0, src, -1, buf, 0);
+        if (size > 0) {
+            buf_size = size + 1;
+            C_MAKE(buf, buf_size, WCHAR);
+            if (::MultiByteToWideChar(932, 0, src, -1, buf, buf_size) == 0) {
+                // fail
+                kill();
+            }
+        }
+    }
+
+    virtual ~to_wchar()
+    {
+        kill();
+    }
+
+    to_wchar(const to_wchar &) = delete;
+    to_wchar &operator=(const to_wchar &) = delete;
+
+    WCHAR *wc_str()
+    {
+        return buf;
+    }
+
+protected:
+    WCHAR *buf;
+    uint buf_size;
+
+    void kill()
+    {
+        if (!buf) {
+            C_KILL(buf, buf_size, WCHAR);
+            buf = NULL;
+        }
+    }
+};
+
+
+/*!
+ * @brief ワイド文字列をマルチバイト文字列へ変換するクラス
+ */
+class to_multibyte {
+public:
+    to_multibyte(const WCHAR *src)
+        : buf(NULL)
+        , buf_size(0)
+    {
+        if (!src)
+            return;
+
+        int size = ::WideCharToMultiByte(CP_ACP, 0, src, -1, buf, 0, NULL, NULL);
+        if (size > 0) {
+            buf_size = size + 1;
+            C_MAKE(buf, buf_size, char);
+            if (::WideCharToMultiByte(CP_ACP, 0, src, -1, buf, buf_size, NULL, NULL) == 0) {
+                // fail
+                kill();
+            }
+        }
+    }
+
+    virtual ~to_multibyte()
+    {
+        kill();
+    }
+
+    to_multibyte(const to_multibyte &) = delete;
+    char* &operator=(const char* &) = delete;
+
+    char *c_str()
+    {
+        return buf;
+    }
+
+protected:
+    char *buf;
+    uint buf_size;
+
+    void kill()
+    {
+        if (!buf) {
+            C_KILL(buf, buf_size, char);
+            buf = NULL;
+        }
+    }
+};


### PR DESCRIPTION
#896 の中で影響の少ないAPIからワイド文字列版へ移行してみた。

「ベータ:ワールドワイド言語サポートでUnicode UTF-8を使用」にチェックを入れた環境（システムロケールがUTF-8）でもメッセージボックスと「画面をHTMLで保存」は文字化けなく動作している。