### PR TITLE
[Fix] 赤魔導士の連続魔で1回目でキャンセルできない、また2回目できちんとターゲット指定できない #905 #906

### DIFF
--- a/src/cmd-action/cmd-spell.h
+++ b/src/cmd-action/cmd-spell.h
@@ -28,4 +28,4 @@ concptr info_weight(WEIGHT weight);
 
 void do_cmd_browse(player_type *caster_ptr);
 void do_cmd_study(player_type *caster_ptr);
-void do_cmd_cast(player_type *caster_ptr);
+bool do_cmd_cast(player_type *caster_ptr);

--- a/src/io/input-key-processor.cpp
+++ b/src/io/input-key-processor.cpp
@@ -429,7 +429,7 @@ void process_command(player_type *creature_ptr)
                 else if (creature_ptr->pclass == CLASS_SNIPER)
                     do_cmd_snipe(creature_ptr);
                 else
-                    do_cmd_cast(creature_ptr);
+                    (void)do_cmd_cast(creature_ptr);
             }
         }
 

--- a/src/racial/racial-switcher.cpp
+++ b/src/racial/racial-switcher.cpp
@@ -201,11 +201,14 @@ bool switch_class_racial_execution(player_type *creature_ptr, const s32b command
             return FALSE;
 
         handle_stuff(creature_ptr);
-        do_cmd_cast(creature_ptr);
-        handle_stuff(creature_ptr);
-        if (!creature_ptr->paralyzed && !cmd_limit_cast(creature_ptr))
-            do_cmd_cast(creature_ptr);
+        if (!do_cmd_cast(creature_ptr))
+            return FALSE;
 
+        if (!creature_ptr->paralyzed && !cmd_limit_cast(creature_ptr)) {
+            handle_stuff(creature_ptr);
+            command_dir = 0;
+            (void)do_cmd_cast(creature_ptr);
+        }
         return TRUE;
     case CLASS_SAMURAI:
         if (command == -3) {


### PR DESCRIPTION
do_cmd_cast()に戻り値がないため、連続魔でキャンセルかどうか判定できていなかった。
また、1回目のターゲットを捨てていなかった。