### PR TITLE
[Feature] screen_save()/screen_load()で多重に画面を保存する #891

### DIFF
--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -5,6 +5,7 @@
 #include <iterator>
 #include <functional>
 #include <map>
+#include <memory>
 #include <queue>
 #include <sstream>
 #include <stack>

--- a/src/term/screen-processor.cpp
+++ b/src/term/screen-processor.cpp
@@ -31,10 +31,11 @@ void flush(void) { inkey_xtra = TRUE; }
 void screen_save()
 {
     msg_print(NULL);
-    if (screen_depth++ == 0)
-        term_save();
+
+    term_save();
 
     current_world_ptr->character_icky_depth++;
+    screen_depth++;
 }
 
 /*
@@ -42,13 +43,26 @@ void screen_save()
  *
  * This function must match exactly one call to "screen_save()".
  */
-void screen_load()
+void screen_load(SCREEN_LOAD_OPT opt)
 {
     msg_print(NULL);
-    if (--screen_depth == 0)
-        term_load();
 
-    current_world_ptr->character_icky_depth--;
+    switch (opt) {
+    case SCREEN_LOAD_OPT::ONE:
+        term_load(false);
+        current_world_ptr->character_icky_depth--;
+        screen_depth--;
+        break;
+
+    case SCREEN_LOAD_OPT::ALL:
+        term_load(true);
+        current_world_ptr->character_icky_depth -= static_cast<byte>(screen_depth);
+        screen_depth = 0;
+        break;
+
+    default:
+        break;
+    }
 }
 
 /*

--- a/src/term/screen-processor.h
+++ b/src/term/screen-processor.h
@@ -2,10 +2,16 @@
 
 #include "system/angband.h"
 
+/** 画面情報保存スタックからの読み出しオプション */
+enum class SCREEN_LOAD_OPT {
+    ONE, //!< スタックの先頭のデータを1つ読み出す
+    ALL, //!< スタックからすべてのデータを読み出す(画面は最後に読み出したデータになる)
+};
+
 void move_cursor(int row, int col);
 void flush(void);
 void screen_save();
-void screen_load();
+void screen_load(SCREEN_LOAD_OPT opt = SCREEN_LOAD_OPT::ONE);
 void c_put_str(TERM_COLOR attr, concptr str, TERM_LEN row, TERM_LEN col);
 void put_str(concptr str, TERM_LEN row, TERM_LEN col);
 void c_prt(TERM_COLOR attr, concptr str, TERM_LEN row, TERM_LEN col);

--- a/src/term/z-term.cpp
+++ b/src/term/z-term.cpp
@@ -46,6 +46,18 @@ term_win::term_win(TERM_LEN w, TERM_LEN h)
 {
 }
 
+std::unique_ptr<term_win> term_win::create(TERM_LEN w, TERM_LEN h)
+{
+    // privateコンストラクタを呼び出すための補助クラス
+    struct impl : term_win {
+        impl(TERM_LEN w, TERM_LEN h)
+            : term_win(w, h)
+        {
+        }
+    };
+    return std::make_unique<impl>(w, h);
+}
+
 /*
  * Copy a "term_win" from another
  */
@@ -1845,7 +1857,7 @@ errr term_save(void)
     /* Create */
     if (!Term->mem) {
         /* Allocate window */
-        Term->mem = std::make_unique<term_win>(w, h);
+        Term->mem = term_win::create(w, h);
     }
 
     /* Grab */
@@ -1866,7 +1878,7 @@ errr term_load(void)
     /* Create */
     if (!Term->mem) {
         /* Allocate window */
-        Term->mem = std::make_unique<term_win>(w, h);
+        Term->mem = term_win::create(w, h);
     }
 
     /* Load */
@@ -1896,7 +1908,7 @@ errr term_exchange(void)
     /* Create */
     if (!Term->tmp) {
         /* Allocate window */
-        Term->tmp = std::make_unique<term_win>(w, h);
+        Term->tmp = term_win::create(w, h);
     }
 
     /* Swap */
@@ -1957,13 +1969,13 @@ errr term_resize(TERM_LEN w, TERM_LEN h)
     Term->x2 = std::vector<TERM_LEN>(h);
 
     /* Create new window */
-    Term->old = std::make_unique<term_win>(w, h);
+    Term->old = term_win::create(w, h);
 
     /* Save the contents */
     term_win_copy(Term->old, hold_old, wid, hgt);
 
     /* Create new window */
-    Term->scr = std::make_unique<term_win>(w, h);
+    Term->scr = term_win::create(w, h);
 
     /* Save the contents */
     term_win_copy(Term->scr, hold_scr, wid, hgt);
@@ -1971,7 +1983,7 @@ errr term_resize(TERM_LEN w, TERM_LEN h)
     /* If needed */
     if (hold_mem) {
         /* Create new window */
-        Term->mem = std::make_unique<term_win>(w, h);
+        Term->mem = term_win::create(w, h);
 
         /* Save the contents */
         term_win_copy(Term->mem, hold_mem, wid, hgt);
@@ -1980,7 +1992,7 @@ errr term_resize(TERM_LEN w, TERM_LEN h)
     /* If needed */
     if (hold_tmp) {
         /* Create new window */
-        Term->tmp = std::make_unique<term_win>(w, h);
+        Term->tmp = term_win::create(w, h);
 
         /* Save the contents */
         term_win_copy(Term->tmp, hold_tmp, wid, hgt);
@@ -2112,10 +2124,10 @@ errr term_init(term_type *t, TERM_LEN w, TERM_LEN h, int k)
     t->x2.resize(h);
 
     /* Allocate "displayed" */
-    t->old = std::make_unique<term_win>(w, h);
+    t->old = term_win::create(w, h);
 
     /* Allocate "requested" */
-    t->scr = std::make_unique<term_win>(w, h);
+    t->scr = term_win::create(w, h);
 
     /* Assume change */
     for (TERM_LEN y = 0; y < h; y++) {

--- a/src/term/z-term.h
+++ b/src/term/z-term.h
@@ -24,6 +24,8 @@
 class term_win {
 public:
     static std::unique_ptr<term_win> create(TERM_LEN w, TERM_LEN h);
+    std::unique_ptr<term_win> clone() const;
+    void resize(TERM_LEN w, TERM_LEN h);
 
     bool cu{}, cv{}; //!< Cursor Useless / Visible codes
     TERM_LEN cx{}, cy{}; //!< Cursor Location (see "Useless")

--- a/src/term/z-term.h
+++ b/src/term/z-term.h
@@ -15,6 +15,7 @@
 #include "system/h-basic.h"
 
 #include <memory>
+#include <stack>
 #include <vector>
 
 /*!
@@ -83,7 +84,7 @@ struct term_type {
     std::unique_ptr<term_win> scr; //!< Requested screen image
 
     std::unique_ptr<term_win> tmp; //!< Temporary screen image
-    std::unique_ptr<term_win> mem; //!< Memorized screen image
+    std::stack<std::unique_ptr<term_win>> mem_stack; //!< Memorized screen image stack
 
     void (*init_hook)(term_type *t){}; //!< Hook for init - ing the term
     void (*nuke_hook)(term_type *t){}; //!< Hook for nuke - ing the term
@@ -185,7 +186,7 @@ errr term_key_push(int k);
 errr term_inkey(char *ch, bool wait, bool take);
 
 errr term_save(void);
-errr term_load(void);
+errr term_load(bool load_all);
 
 errr term_exchange(void);
 

--- a/src/term/z-term.h
+++ b/src/term/z-term.h
@@ -20,8 +20,9 @@
 /*!
  * @brief A term_win is a "window" for a Term
  */
-struct term_win {
-    term_win(TERM_LEN w, TERM_LEN h);
+class term_win {
+public:
+    static std::unique_ptr<term_win> create(TERM_LEN w, TERM_LEN h);
 
     bool cu{}, cv{}; //!< Cursor Useless / Visible codes
     TERM_LEN cx{}, cy{}; //!< Cursor Location (see "Useless")
@@ -31,6 +32,9 @@ struct term_win {
 
     std::vector<std::vector<TERM_COLOR>> ta; //!< Note that the attr pair at(x, y) is a[y][x]
     std::vector<std::vector<char>> tc; //!< Note that the char pair at(x, y) is c[y][x]
+
+private:
+    term_win(TERM_LEN w, TERM_LEN h);
 };
 
 /*!


### PR DESCRIPTION
従来はscreen_save()/screen_load()で保存できる画面は1画面のみだったが、
複数の画面遷移を行き来したい場合に1画面のみでは不便なため、
多重に画面を保存できるようにする。