### PR TITLE
[Fix] 生い立ちエディタの文字化け #946

### DIFF
--- a/src/term/z-form.cpp
+++ b/src/term/z-form.cpp
@@ -621,7 +621,7 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
 
             /* Save the character */
 #ifdef JP
-            if (iskanji(tmp[q])) {
+            if (q > 0 && iskanji(tmp[q])) {
                 if (tmp[q + 1]) {
                     buf[n++] = tmp[q++];
                 } else {


### PR DESCRIPTION
生い立ちエディタで2バイト文字を"%c%c"で1バイトずつ出力
するという想定外の使用方法がされているため、過去のコミット
7ee574d2c5244b61f8ec13c8d383a865630e00fb で文字化けが
発生するようになっていた。
2文字以上出力の時のみ、2バイト文字の前半で終了した時に
その部分を空白で置き換えるようにする。

#759 によるエンバグ。