### PR TITLE
[Fix] 生い立ちエディタの文字化け修正

### DIFF
--- a/src/birth/history-editor.cpp
+++ b/src/birth/history-editor.cpp
@@ -45,9 +45,10 @@ void edit_history(player_type *creature_ptr)
             put_str(creature_ptr->history[i], i + 12, 10);
         }
 #ifdef JP
-        if (iskanji2(creature_ptr->history[y], x))
-            c_put_str(TERM_L_BLUE, format("%c%c", creature_ptr->history[y][x], creature_ptr->history[y][x + 1]), y + 12, x + 10);
-        else
+        if (iskanji2(creature_ptr->history[y], x)) {
+            char kanji[3] = { creature_ptr->history[y][x], creature_ptr->history[y][x + 1], '\0' };
+            c_put_str(TERM_L_BLUE, format("%s", kanji), y + 12, x + 10);
+        } else
 #endif
             c_put_str(TERM_L_BLUE, format("%c", creature_ptr->history[y][x]), y + 12, x + 10);
 

--- a/src/term/z-form.cpp
+++ b/src/term/z-form.cpp
@@ -621,7 +621,7 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
 
             /* Save the character */
 #ifdef JP
-            if (q > 0 && iskanji(tmp[q])) {
+            if (iskanji(tmp[q])) {
                 if (tmp[q + 1]) {
                     buf[n++] = tmp[q++];
                 } else {


### PR DESCRIPTION
#948 での修正は他に影響が出ているためRevertして、生い立ちエディタ処理の方を修正した。