### PR TITLE
[Fix] 【バグ】 撃った床上の矢/弾をnコマンドで繰り返し撃てる #962

### DIFF
--- a/src/io/input-key-requester.cpp
+++ b/src/io/input-key-requester.cpp
@@ -209,9 +209,6 @@ void request_command(player_type *player_ptr, int shopping)
     use_menu = FALSE;
 
     while (TRUE) {
-        if (!macro_running() && !command_new && auto_debug_save && (!inkey_next || *inkey_next == '\0')) {
-            save_player(player_ptr, SAVE_TYPE_DEBUG);
-        }
         if (fresh_once && macro_running()) {
             stop_term_fresh();
         }

--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -3,12 +3,14 @@
 #include "cmd-io/cmd-save.h"
 #include "core/disturbance.h"
 #include "core/magic-effects-timeout-reducer.h"
+#include "core/player-processor.h"
 #include "dungeon/dungeon.h"
 #include "floor/floor-events.h"
 #include "floor/floor-mode-changer.h"
 #include "floor/wild.h"
 #include "game-option/birth-options.h"
 #include "game-option/cheat-options.h"
+#include "game-option/game-play-options.h"
 #include "game-option/special-options.h"
 #include "game-option/text-display-options.h"
 #include "grid/feature.h"
@@ -17,6 +19,8 @@
 #include "hpmp/hp-mp-regenerator.h"
 #include "inventory/inventory-curse.h"
 #include "inventory/recharge-processor.h"
+#include "io/input-key-acceptor.h"
+#include "io/input-key-requester.h"
 #include "io/write-diary.h"
 #include "market/arena.h"
 #include "market/bounty.h"
@@ -29,6 +33,7 @@
 #include "perception/simple-perception.h"
 #include "player/digestion-processor.h"
 #include "player/player-status.h"
+#include "save/save.h"
 #include "store/store-owners.h"
 #include "store/store-util.h"
 #include "store/store.h"
@@ -118,6 +123,11 @@ void process_world(player_type *player_ptr)
 
     if (current_world_ptr->game_turn % TURNS_PER_TICK)
         return;
+
+    if (!macro_running() && !continuous_action_running(player_ptr) && !command_new && auto_debug_save && (!inkey_next || *inkey_next == '\0')
+        && !player_ptr->phase_out) {
+        save_player(player_ptr, SAVE_TYPE_DEBUG);
+    }
 
     if (autosave_t && autosave_freq && !player_ptr->phase_out) {
         if (!(current_world_ptr->game_turn % ((s32b)autosave_freq * TURNS_PER_TICK)))


### PR DESCRIPTION
自動セーブオプションがONのとき該当のバグが発生していることから、自動セーブオプションの挙動を修正する。
具体的にはこれまで想定されていなかったキー入力前のタイミングではなく、50ターン毎自動セーブと同様のタイミングで1ターン毎に自動セーブする。
1キー入力で複数回の自動セーブは当初の目的からすると過剰であるため、そのような自動セーブは抑制する。