### PR TITLE
[Refactor] スタックしたアイテムデータをstd::listで管理する

### DIFF
--- a/src/action/open-close-execution.cpp
+++ b/src/action/open-close-execution.cpp
@@ -100,7 +100,7 @@ bool exe_close(player_type *creature_ptr, POSITION y, POSITION x)
         return more;
 
     s16b closed_feat = feat_state(creature_ptr->current_floor_ptr, old_feat, FF_CLOSE);
-    if ((g_ptr->o_idx || (g_ptr->info & CAVE_OBJECT)) && (closed_feat != old_feat) && !has_flag(f_info[closed_feat].flags, FF_DROP)) {
+    if ((!g_ptr->o_idx_list.empty() || (g_ptr->info & CAVE_OBJECT)) && (closed_feat != old_feat) && !has_flag(f_info[closed_feat].flags, FF_DROP)) {
         msg_print(_("何かがつっかえて閉まらない。", "Something prevents it from closing."));
     } else {
         cave_alter_feat(creature_ptr, y, x, FF_CLOSE);

--- a/src/action/open-util.cpp
+++ b/src/action/open-util.cpp
@@ -22,11 +22,9 @@
 OBJECT_IDX chest_check(floor_type *floor_ptr, POSITION y, POSITION x, bool trapped)
 {
     grid_type *g_ptr = &floor_ptr->grid_array[y][x];
-    OBJECT_IDX this_o_idx, next_o_idx = 0;
-    for (this_o_idx = g_ptr->o_idx; this_o_idx; this_o_idx = next_o_idx) {
+    for (const auto this_o_idx : g_ptr->o_idx_list) {
         object_type *o_ptr;
         o_ptr = &floor_ptr->o_list[this_o_idx];
-        next_o_idx = o_ptr->next_o_idx;
         if ((o_ptr->tval == TV_CHEST)
             && (((!trapped) && (o_ptr->pval)) || /* non empty */
                 ((trapped) && (o_ptr->pval > 0)))) /* trapped only */

--- a/src/action/run-execution.cpp
+++ b/src/action/run-execution.cpp
@@ -211,7 +211,6 @@ static bool run_test(player_type *creature_ptr)
     DIRECTION check_dir = 0;
     int option = 0, option2 = 0;
     for (int i = -max; i <= max; i++) {
-        OBJECT_IDX this_o_idx, next_o_idx = 0;
         DIRECTION new_dir = cycle[chome[prev_dir] + i];
         int row = creature_ptr->y + ddy[new_dir];
         int col = creature_ptr->x + ddx[new_dir];
@@ -226,10 +225,9 @@ static bool run_test(player_type *creature_ptr)
                 return TRUE;
         }
 
-        for (this_o_idx = g_ptr->o_idx; this_o_idx; this_o_idx = next_o_idx) {
+        for (const auto this_o_idx : g_ptr->o_idx_list) {
             object_type *o_ptr;
             o_ptr = &floor_ptr->o_list[this_o_idx];
-            next_o_idx = o_ptr->next_o_idx;
             if (o_ptr->marked & OM_FOUND)
                 return TRUE;
         }

--- a/src/autopick/autopick.cpp
+++ b/src/autopick/autopick.cpp
@@ -62,21 +62,17 @@ static void autopick_delayed_alter_aux(player_type *player_ptr, INVENTORY_IDX it
  */
 void autopick_delayed_alter(player_type *owner_ptr)
 {
-    INVENTORY_IDX item;
-
     /*
      * Scan inventry in reverse order to prevent
      * skipping after inven_item_optimize()
      */
-    for (item = INVEN_TOTAL - 1; item >= 0; item--)
+    for (INVENTORY_IDX item = INVEN_TOTAL - 1; item >= 0; item--)
         autopick_delayed_alter_aux(owner_ptr, item);
 
-    floor_type *floor_ptr = owner_ptr->current_floor_ptr;
-    item = floor_ptr->grid_array[owner_ptr->y][owner_ptr->x].o_idx;
-    while (item) {
-        OBJECT_IDX next = floor_ptr->o_list[item].next_o_idx;
+    auto &grid = owner_ptr->current_floor_ptr->grid_array[owner_ptr->y][owner_ptr->x];
+    for (auto it = grid.o_idx_list.begin(); it != grid.o_idx_list.end();) {
+        INVENTORY_IDX item = *it++;
         autopick_delayed_alter_aux(owner_ptr, -item);
-        item = next;
     }
 
     // PW_FLOOR_ITEM_LISTは遅れるので即時更新
@@ -104,10 +100,9 @@ void autopick_alter_item(player_type *player_ptr, INVENTORY_IDX item, bool destr
  */
 void autopick_pickup_items(player_type *player_ptr, grid_type *g_ptr)
 {
-    OBJECT_IDX this_o_idx, next_o_idx = 0;
-    for (this_o_idx = g_ptr->o_idx; this_o_idx; this_o_idx = next_o_idx) {
+    for (auto it = g_ptr->o_idx_list.begin(); it != g_ptr->o_idx_list.end();) {
+        OBJECT_IDX this_o_idx = *it++;
         object_type *o_ptr = &player_ptr->current_floor_ptr->o_list[this_o_idx];
-        next_o_idx = o_ptr->next_o_idx;
         int idx = find_autopick_list(player_ptr, o_ptr);
         auto_inscribe_item(player_ptr, o_ptr, idx);
         if ((idx < 0) || (autopick_list[idx].action & (DO_AUTOPICK | DO_QUERY_AUTOPICK)) == 0) {

--- a/src/cmd-item/cmd-smith.cpp
+++ b/src/cmd-item/cmd-smith.cpp
@@ -238,7 +238,6 @@ static void drain_essence(player_type *creature_ptr)
     POSITION iy, ix;
     byte marked;
     ITEM_NUMBER number;
-    OBJECT_IDX next_o_idx;
 
     for (i = 0; i < sizeof(drain_value) / sizeof(int); i++)
         drain_value[i] = 0;
@@ -331,7 +330,6 @@ static void drain_essence(player_type *creature_ptr)
 
     iy = o_ptr->iy;
     ix = o_ptr->ix;
-    next_o_idx = o_ptr->next_o_idx;
     marked = o_ptr->marked;
     number = o_ptr->number;
 
@@ -339,7 +337,6 @@ static void drain_essence(player_type *creature_ptr)
 
     o_ptr->iy = iy;
     o_ptr->ix = ix;
-    o_ptr->next_o_idx = next_o_idx;
     o_ptr->marked = marked;
     o_ptr->number = number;
     if (o_ptr->tval == TV_DRAG_ARMOR)

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -863,11 +863,8 @@ void exe_fire(player_type *shooter_ptr, INVENTORY_IDX item, object_type *j_ptr, 
             /* Memorize monster */
             o_ptr->held_m_idx = m_idx;
 
-            /* Build a stack */
-            o_ptr->next_o_idx = m_ptr->hold_o_idx;
-
             /* Carry object */
-            m_ptr->hold_o_idx = o_idx;
+            m_ptr->hold_o_idx_list.push_front(o_idx);
         } else if (cave_has_flag_bold(shooter_ptr->current_floor_ptr, y, x, FF_PROJECT)) {
             /* Drop (or break) near that location */
             (void)drop_near(shooter_ptr, q_ptr, j, y, x);

--- a/src/core/object-compressor.cpp
+++ b/src/core/object-compressor.cpp
@@ -14,43 +14,26 @@
 #include "system/player-type-definition.h"
 #include "view/display-messages.h"
 
+#include <algorithm>
+
 /*!
- * @brief グローバルオブジェクト配列に対し指定範囲のオブジェクトを整理してIDの若い順に寄せる /
+ * @brief グローバルオブジェクト配列の要素番号i1のオブジェクトを要素番号i2に移動する /
  * Move an object from index i1 to index i2 in the object list
- * @param i1 整理したい配列の始点
- * @param i2 整理したい配列の終点
+ * @param i1 オブジェクト移動元の要素番号
+ * @param i2 オブジェクト移動先の要素番号
  */
 static void compact_objects_aux(floor_type *floor_ptr, OBJECT_IDX i1, OBJECT_IDX i2)
 {
     if (i1 == i2)
         return;
 
-    object_type *o_ptr;
-    for (OBJECT_IDX i = 1; i < floor_ptr->o_max; i++) {
-        o_ptr = &floor_ptr->o_list[i];
-        if (!o_ptr->k_idx)
-            continue;
+    object_type *o_ptr = &floor_ptr->o_list[i1];
 
-        if (o_ptr->next_o_idx == i1)
-            o_ptr->next_o_idx = i2;
-    }
+    // モンスター所為アイテムリストもしくは床上アイテムリストの要素番号i1をi2に書き換える
+    auto &list = get_o_idx_list_contains(floor_ptr, i1);
+    std::replace(list.begin(), list.end(), i1, i2);
 
-    o_ptr = &floor_ptr->o_list[i1];
-
-    if (object_is_held_monster(o_ptr)) {
-        monster_type *m_ptr;
-        m_ptr = &floor_ptr->m_list[o_ptr->held_m_idx];
-        if (m_ptr->hold_o_idx == i1)
-            m_ptr->hold_o_idx = i2;
-    } else {
-        POSITION y = o_ptr->iy;
-        POSITION x = o_ptr->ix;
-        grid_type *g_ptr;
-        g_ptr = &floor_ptr->grid_array[y][x];
-        if (g_ptr->o_idx == i1)
-            g_ptr->o_idx = i2;
-    }
-
+    // 要素番号i1のオブジェクトを要素番号i2に移動
     floor_ptr->o_list[i2] = floor_ptr->o_list[i1];
     object_wipe(o_ptr);
 }

--- a/src/dungeon/quest-completion-checker.cpp
+++ b/src/dungeon/quest-completion-checker.cpp
@@ -155,7 +155,7 @@ void check_quest_completion(player_type *player_ptr, monster_type *m_ptr)
 
     if (create_stairs) {
         POSITION ny, nx;
-        while (cave_has_flag_bold(floor_ptr, y, x, FF_PERMANENT) || floor_ptr->grid_array[y][x].o_idx || (floor_ptr->grid_array[y][x].info & CAVE_OBJECT)) {
+        while (cave_has_flag_bold(floor_ptr, y, x, FF_PERMANENT) || !floor_ptr->grid_array[y][x].o_idx_list.empty() || (floor_ptr->grid_array[y][x].info & CAVE_OBJECT)) {
             scatter(player_ptr, &ny, &nx, y, x, 1, PROJECT_NONE);
             y = ny;
             x = nx;

--- a/src/effect/effect-item.cpp
+++ b/src/effect/effect-item.cpp
@@ -46,8 +46,8 @@ bool affect_item(player_type *caster_ptr, MONSTER_IDX who, POSITION r, POSITION 
     bool known = player_has_los_bold(caster_ptr, y, x);
     who = who ? who : 0;
     dam = (dam + r) / (r + 1);
-    OBJECT_IDX next_o_idx = 0;
-    for (OBJECT_IDX this_o_idx = g_ptr->o_idx; this_o_idx != 0; this_o_idx = next_o_idx) {
+    for (auto it = g_ptr->o_idx_list.begin(); it != g_ptr->o_idx_list.end();) {
+        const OBJECT_IDX this_o_idx = *it++;
         object_type *o_ptr = &caster_ptr->current_floor_ptr->o_list[this_o_idx];
         bool ignore = FALSE;
         bool do_kill = FALSE;
@@ -57,7 +57,6 @@ bool affect_item(player_type *caster_ptr, MONSTER_IDX who, POSITION r, POSITION 
 #else
         bool plural = (o_ptr->number > 1);
 #endif
-        next_o_idx = o_ptr->next_o_idx;
         BIT_FLAGS flags[TR_FLAG_SIZE];
         object_flags(caster_ptr, o_ptr, flags);
         bool is_artifact = object_is_artifact(o_ptr);

--- a/src/floor/cave.cpp
+++ b/src/floor/cave.cpp
@@ -117,7 +117,7 @@ bool cave_has_flag_grid(grid_type *grid_ptr, int feature_flags) { return has_fla
 bool cave_clean_bold(floor_type *floor_ptr, POSITION y, POSITION x)
 {
     return cave_has_flag_bold(floor_ptr, y, x, FF_FLOOR) && ((floor_ptr->grid_array[y][x].info & CAVE_OBJECT) == 0)
-        && (floor_ptr->grid_array[y][x].o_idx == 0);
+        && floor_ptr->grid_array[y][x].o_idx_list.empty();
 }
 
 /*

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -71,8 +71,7 @@ static void drop_here(floor_type *floor_ptr, object_type *j_ptr, POSITION y, POS
     o_ptr->ix = x;
     o_ptr->held_m_idx = 0;
     grid_type *g_ptr = &floor_ptr->grid_array[y][x];
-    o_ptr->next_o_idx = g_ptr->o_idx;
-    g_ptr->o_idx = o_idx;
+    g_ptr->o_idx_list.push_front(o_idx);
 }
 
 static void generate_artifact(player_type *player_ptr, qtwg_type *qtwg_ptr, const ARTIFACT_IDX artifact_index)

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -107,7 +107,7 @@ static void set_pet_params(player_type *master_ptr, monster_race **r_ptr, const 
     m_ptr->current_floor_ptr = master_ptr->current_floor_ptr;
     m_ptr->ml = TRUE;
     m_ptr->mtimed[MTIMED_CSLEEP] = 0;
-    m_ptr->hold_o_idx = 0;
+    m_ptr->hold_o_idx_list.clear();
     m_ptr->target_y = 0;
     if (((*r_ptr)->flags1 & RF1_PREVENT_SUDDEN_MAGIC) && !ironman_nightmare) {
         m_ptr->mflag.set(MFLAG::PREVENT_MAGIC);

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -350,7 +350,7 @@ void clear_cave(player_type *player_ptr)
             grid_type *g_ptr = &floor_ptr->grid_array[y][x];
             g_ptr->info = 0;
             g_ptr->feat = 0;
-            g_ptr->o_idx = 0;
+            g_ptr->o_idx_list.clear();
             g_ptr->m_idx = 0;
             g_ptr->special = 0;
             g_ptr->mimic = 0;

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -180,21 +180,19 @@ bool make_gold(player_type *player_ptr, object_type *j_ptr)
 void delete_all_items_from_floor(player_type *player_ptr, POSITION y, POSITION x)
 {
     grid_type *g_ptr;
-    OBJECT_IDX this_o_idx, next_o_idx = 0;
     floor_type *floor_ptr = player_ptr->current_floor_ptr;
     if (!in_bounds(floor_ptr, y, x))
         return;
 
     g_ptr = &floor_ptr->grid_array[y][x];
-    for (this_o_idx = g_ptr->o_idx; this_o_idx; this_o_idx = next_o_idx) {
+    for (const auto this_o_idx : g_ptr->o_idx_list) {
         object_type *o_ptr;
         o_ptr = &floor_ptr->o_list[this_o_idx];
-        next_o_idx = o_ptr->next_o_idx;
         object_wipe(o_ptr);
         floor_ptr->o_cnt--;
     }
 
-    g_ptr->o_idx = 0;
+    g_ptr->o_idx_list.clear();
     lite_spot(player_ptr, y, x);
 }
 
@@ -273,61 +271,24 @@ void delete_object_idx(player_type *player_ptr, OBJECT_IDX o_idx)
  */
 void excise_object_idx(floor_type *floor_ptr, OBJECT_IDX o_idx)
 {
-    OBJECT_IDX this_o_idx, next_o_idx = 0;
-    OBJECT_IDX prev_o_idx = 0;
-    object_type *j_ptr;
-    j_ptr = &floor_ptr->o_list[o_idx];
+    auto &list = get_o_idx_list_contains(floor_ptr, o_idx);
+    list.remove(o_idx);
+}
 
-    if (object_is_held_monster(j_ptr)) {
-        monster_type *m_ptr;
-        m_ptr = &floor_ptr->m_list[j_ptr->held_m_idx];
-        for (this_o_idx = m_ptr->hold_o_idx; this_o_idx; this_o_idx = next_o_idx) {
-            object_type *o_ptr;
-            o_ptr = &floor_ptr->o_list[this_o_idx];
-            next_o_idx = o_ptr->next_o_idx;
-            if (this_o_idx != o_idx) {
-                prev_o_idx = this_o_idx;
-                continue;
-            }
+/*!
+ * @brief 指定したOBJECT_IDXを含むリスト(モンスター所持リスト or 床上スタックリスト)への参照を得る
+ * @param floo_ptr 現在フロアへの参照ポインタ
+ * @param o_idx 参照を得るリストに含まれるOBJECT_IDX
+ * @return o_idxを含む std::list<OBJECT_IDX> への参照
+ */
+std::list<OBJECT_IDX> &get_o_idx_list_contains(floor_type *floor_ptr, OBJECT_IDX o_idx)
+{
+    object_type *o_ptr = &floor_ptr->o_list[o_idx];
 
-            if (prev_o_idx == 0) {
-                m_ptr->hold_o_idx = next_o_idx;
-            } else {
-                object_type *k_ptr;
-                k_ptr = &floor_ptr->o_list[prev_o_idx];
-                k_ptr->next_o_idx = next_o_idx;
-            }
-
-            o_ptr->next_o_idx = 0;
-            break;
-        }
-
-        return;
-    }
-
-    grid_type *g_ptr;
-    POSITION y = j_ptr->iy;
-    POSITION x = j_ptr->ix;
-    g_ptr = &floor_ptr->grid_array[y][x];
-    for (this_o_idx = g_ptr->o_idx; this_o_idx; this_o_idx = next_o_idx) {
-        object_type *o_ptr;
-        o_ptr = &floor_ptr->o_list[this_o_idx];
-        next_o_idx = o_ptr->next_o_idx;
-        if (this_o_idx != o_idx) {
-            prev_o_idx = this_o_idx;
-            continue;
-        }
-
-        if (prev_o_idx == 0) {
-            g_ptr->o_idx = next_o_idx;
-        } else {
-            object_type *k_ptr;
-            k_ptr = &floor_ptr->o_list[prev_o_idx];
-            k_ptr->next_o_idx = next_o_idx;
-        }
-
-        o_ptr->next_o_idx = 0;
-        break;
+    if (object_is_held_monster(o_ptr)) {
+        return floor_ptr->m_list[o_ptr->held_m_idx].hold_o_idx_list;
+    } else {
+        return floor_ptr->grid_array[o_ptr->iy][o_ptr->ix].o_idx_list;
     }
 }
 
@@ -360,7 +321,6 @@ OBJECT_IDX drop_near(player_type *owner_ptr, object_type *j_ptr, PERCENTAGE chan
     POSITION dy, dx;
     POSITION ty, tx = 0;
     OBJECT_IDX o_idx = 0;
-    OBJECT_IDX this_o_idx, next_o_idx = 0;
     grid_type *g_ptr;
     GAME_TEXT o_name[MAX_NLEN];
     bool flag = FALSE;
@@ -407,10 +367,9 @@ OBJECT_IDX drop_near(player_type *owner_ptr, object_type *j_ptr, PERCENTAGE chan
                 continue;
 
             k = 0;
-            for (this_o_idx = g_ptr->o_idx; this_o_idx; this_o_idx = next_o_idx) {
+            for (const auto this_o_idx : g_ptr->o_idx_list) {
                 object_type *o_ptr;
                 o_ptr = &floor_ptr->o_list[this_o_idx];
-                next_o_idx = o_ptr->next_o_idx;
                 if (object_similar(o_ptr, j_ptr))
                     comb = TRUE;
 
@@ -515,10 +474,9 @@ OBJECT_IDX drop_near(player_type *owner_ptr, object_type *j_ptr, PERCENTAGE chan
     }
 
     g_ptr = &floor_ptr->grid_array[by][bx];
-    for (this_o_idx = g_ptr->o_idx; this_o_idx; this_o_idx = next_o_idx) {
+    for (const auto this_o_idx : g_ptr->o_idx_list) {
         object_type *o_ptr;
         o_ptr = &floor_ptr->o_list[this_o_idx];
-        next_o_idx = o_ptr->next_o_idx;
         if (object_similar(o_ptr, j_ptr)) {
             object_absorb(o_ptr, j_ptr);
             done = TRUE;
@@ -551,9 +509,7 @@ OBJECT_IDX drop_near(player_type *owner_ptr, object_type *j_ptr, PERCENTAGE chan
         j_ptr->iy = by;
         j_ptr->ix = bx;
         j_ptr->held_m_idx = 0;
-        j_ptr->next_o_idx = g_ptr->o_idx;
-
-        g_ptr->o_idx = o_idx;
+        g_ptr->o_idx_list.push_front(o_idx);
         done = TRUE;
     }
 

--- a/src/floor/floor-object.h
+++ b/src/floor/floor-object.h
@@ -3,6 +3,8 @@
 #include "object/tval-types.h"
 #include "system/angband.h"
 
+#include <list>
+
 typedef struct floor_type floor_type;
 typedef struct object_type object_type;
 typedef struct player_type player_type;
@@ -13,6 +15,7 @@ void floor_item_increase(player_type *owner_ptr, INVENTORY_IDX item, ITEM_NUMBER
 void floor_item_optimize(player_type *owner_ptr, INVENTORY_IDX item);
 void delete_object_idx(player_type *owner_ptr, OBJECT_IDX o_idx);
 void excise_object_idx(floor_type *floor_ptr, OBJECT_IDX o_idx);
+std::list<OBJECT_IDX> &get_o_idx_list_contains(floor_type *floor_ptr, OBJECT_IDX o_idx);
 OBJECT_IDX drop_near(player_type *owner_type, object_type *o_ptr, PERCENTAGE chance, POSITION y, POSITION x);
 void floor_item_charges(floor_type *owner_ptr, INVENTORY_IDX item);
 void floor_item_describe(player_type *player_ptr, INVENTORY_IDX item);

--- a/src/floor/floor-streams.cpp
+++ b/src/floor/floor-streams.cpp
@@ -336,13 +336,11 @@ void build_streamer(player_type *player_ptr, FEAT_IDX feat, int chance)
                 delete_monster(player_ptr, ty, tx);
             }
 
-            if (g_ptr->o_idx && !has_flag(streamer_ptr->flags, FF_DROP)) {
-                OBJECT_IDX this_o_idx, next_o_idx = 0;
+            if (!g_ptr->o_idx_list.empty() && !has_flag(streamer_ptr->flags, FF_DROP)) {
 
                 /* Scan all objects in the grid */
-                for (this_o_idx = g_ptr->o_idx; this_o_idx; this_o_idx = next_o_idx) {
+                for (const auto this_o_idx : g_ptr->o_idx_list) {
                     object_type *o_ptr = &floor_ptr->o_list[this_o_idx];
-                    next_o_idx = o_ptr->next_o_idx;
 
                     /* Hack -- Preserve unknown artifacts */
                     if (object_is_fixed_artifact(o_ptr)) {
@@ -430,7 +428,7 @@ void place_trees(player_type *player_ptr, POSITION x, POSITION y)
 
             if (g_ptr->info & CAVE_ICKY)
                 continue;
-            if (g_ptr->o_idx)
+            if (!g_ptr->o_idx_list.empty())
                 continue;
 
             /* Want square to be in the circle and accessable. */

--- a/src/floor/floor-util.cpp
+++ b/src/floor/floor-util.cpp
@@ -8,6 +8,7 @@
 #include "dungeon/quest.h"
 #include "effect/effect-characteristics.h"
 #include "floor/cave.h"
+#include "floor/floor-object.h"
 #include "floor/floor-town.h"
 #include "floor/geometry.h"
 #include "floor/line-of-sight.h"
@@ -131,20 +132,8 @@ void wipe_o_list(floor_type *floor_ptr)
             }
         }
 
-        if (object_is_held_monster(o_ptr)) {
-            monster_type *m_ptr;
-            m_ptr = &floor_ptr->m_list[o_ptr->held_m_idx];
-            m_ptr->hold_o_idx = 0;
-            object_wipe(o_ptr);
-            continue;
-        }
-
-        grid_type *g_ptr;
-        POSITION y = o_ptr->iy;
-        POSITION x = o_ptr->ix;
-
-        g_ptr = &floor_ptr->grid_array[y][x];
-        g_ptr->o_idx = 0;
+        auto &list = get_o_idx_list_contains(floor_ptr, i);
+        list.clear();
         object_wipe(o_ptr);
     }
 

--- a/src/floor/object-allocator.cpp
+++ b/src/floor/object-allocator.cpp
@@ -57,7 +57,7 @@ static bool alloc_stairs_aux(player_type *player_ptr, POSITION y, POSITION x, in
 {
     floor_type *floor_ptr = player_ptr->current_floor_ptr;
     grid_type *g_ptr = &floor_ptr->grid_array[y][x];
-    if (!is_floor_grid(g_ptr) || pattern_tile(floor_ptr, y, x) || (g_ptr->o_idx != 0) || (g_ptr->m_idx != 0) || next_to_walls(floor_ptr, y, x) < walls)
+    if (!is_floor_grid(g_ptr) || pattern_tile(floor_ptr, y, x) || !g_ptr->o_idx_list.empty() || (g_ptr->m_idx != 0) || next_to_walls(floor_ptr, y, x) < walls)
         return FALSE;
 
     return TRUE;
@@ -164,7 +164,7 @@ void alloc_object(player_type *owner_ptr, dap_type set, EFFECT_ID typ, int num)
             y = randint0(floor_ptr->height);
             x = randint0(floor_ptr->width);
             g_ptr = &floor_ptr->grid_array[y][x];
-            if (!is_floor_grid(g_ptr) || g_ptr->o_idx || g_ptr->m_idx)
+            if (!is_floor_grid(g_ptr) || !g_ptr->o_idx_list.empty() || g_ptr->m_idx)
                 continue;
 
             if (player_bold(owner_ptr, y, x))

--- a/src/floor/object-scanner.cpp
+++ b/src/floor/object-scanner.cpp
@@ -34,12 +34,10 @@ ITEM_NUMBER scan_floor_items(player_type *owner_ptr, OBJECT_IDX *items, POSITION
     if (!in_bounds(floor_ptr, y, x))
         return 0;
 
-    OBJECT_IDX this_o_idx, next_o_idx;
     ITEM_NUMBER num = 0;
-    for (this_o_idx = floor_ptr->grid_array[y][x].o_idx; this_o_idx; this_o_idx = next_o_idx) {
+    for (const auto this_o_idx : floor_ptr->grid_array[y][x].o_idx_list) {
         object_type *o_ptr;
         o_ptr = &floor_ptr->o_list[this_o_idx];
-        next_o_idx = o_ptr->next_o_idx;
         if ((mode & SCAN_FLOOR_ITEM_TESTER) && !item_tester_okay(owner_ptr, o_ptr, item_tester_tval))
             continue;
 

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -473,7 +473,6 @@ void print_rel(player_type *subject_ptr, SYMBOL_CODE c, TERM_COLOR a, POSITION y
 void note_spot(player_type *player_ptr, POSITION y, POSITION x)
 {
     grid_type *g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
-    OBJECT_IDX this_o_idx, next_o_idx = 0;
 
     /* Blind players see nothing */
     if (player_ptr->blind)
@@ -494,9 +493,8 @@ void note_spot(player_type *player_ptr, POSITION y, POSITION x)
     }
 
     /* Hack -- memorize objects */
-    for (this_o_idx = g_ptr->o_idx; this_o_idx; this_o_idx = next_o_idx) {
+    for (const auto this_o_idx : g_ptr->o_idx_list) {
         object_type *o_ptr = &player_ptr->current_floor_ptr->o_list[this_o_idx];
-        next_o_idx = o_ptr->next_o_idx;
 
         /* Memorize objects */
         o_ptr->marked |= OM_FOUND;

--- a/src/grid/grid.h
+++ b/src/grid/grid.h
@@ -17,6 +17,8 @@
 #include "spell/spells-util.h"
 #include "system/angband.h"
 
+#include <list>
+
 /*
  * A single "grid" in a Cave
  *
@@ -50,24 +52,24 @@ enum flow_type {
 };
 
 struct grid_type {
-    BIT_FLAGS info; /* Hack -- grid flags */
+    BIT_FLAGS info{}; /* Hack -- grid flags */
 
-    FEAT_IDX feat; /* Hack -- feature type */
-    OBJECT_IDX o_idx; /* Object in this grid */
-    MONSTER_IDX m_idx; /* Monster in this grid */
+    FEAT_IDX feat{}; /* Hack -- feature type */
+    std::list<OBJECT_IDX> o_idx_list; /* Object list in this grid */
+    MONSTER_IDX m_idx{}; /* Monster in this grid */
 
     /*! 地形の特別な情報を保存する / Special grid info
      * 具体的な使用一覧はクエスト行き階段の移行先クエストID、
      * 各ダンジョン入口の移行先ダンジョンID、
      *
      */
-    s16b special;
+    s16b special{};
 
-    FEAT_IDX mimic; /* Feature to mimic */
+    FEAT_IDX mimic{}; /* Feature to mimic */
 
-    byte costs[FLOW_MAX]; /* Hack -- cost of flowing */
-    byte dists[FLOW_MAX]; /* Hack -- distance from player */
-    byte when; /* Hack -- when cost was computed */
+    byte costs[FLOW_MAX]{}; /* Hack -- cost of flowing */
+    byte dists[FLOW_MAX]{}; /* Hack -- distance from player */
+    byte when{}; /* Hack -- when cost was computed */
 };
 
 /*  A structure type for terrain template of saving dungeon floor */

--- a/src/grid/object-placer.cpp
+++ b/src/grid/object-placer.cpp
@@ -28,7 +28,7 @@ void place_gold(player_type *player_ptr, POSITION y, POSITION x)
         return;
     if (!cave_drop_bold(floor_ptr, y, x))
         return;
-    if (g_ptr->o_idx)
+    if (!g_ptr->o_idx_list.empty())
         return;
 
     object_type forge;
@@ -48,9 +48,8 @@ void place_gold(player_type *player_ptr, POSITION y, POSITION x)
 
     o_ptr->iy = y;
     o_ptr->ix = x;
-    o_ptr->next_o_idx = g_ptr->o_idx;
+    g_ptr->o_idx_list.push_front(o_idx);
 
-    g_ptr->o_idx = o_idx;
     note_spot(player_ptr, y, x);
     lite_spot(player_ptr, y, x);
 }
@@ -74,7 +73,7 @@ void place_object(player_type *owner_ptr, POSITION y, POSITION x, BIT_FLAGS mode
     grid_type *g_ptr = &floor_ptr->grid_array[y][x];
     object_type forge;
     object_type *q_ptr;
-    if (!in_bounds(floor_ptr, y, x) || !cave_drop_bold(floor_ptr, y, x) || (g_ptr->o_idx != 0))
+    if (!in_bounds(floor_ptr, y, x) || !cave_drop_bold(floor_ptr, y, x) || !g_ptr->o_idx_list.empty())
         return;
 
     q_ptr = &forge;
@@ -97,9 +96,8 @@ void place_object(player_type *owner_ptr, POSITION y, POSITION x, BIT_FLAGS mode
 
     o_ptr->iy = y;
     o_ptr->ix = x;
-    o_ptr->next_o_idx = g_ptr->o_idx;
+    g_ptr->o_idx_list.push_front(o_idx);
 
-    g_ptr->o_idx = o_idx;
     note_spot(owner_ptr, y, x);
     lite_spot(owner_ptr, y, x);
 }

--- a/src/grid/stair.cpp
+++ b/src/grid/stair.cpp
@@ -23,7 +23,7 @@ void place_random_stairs(player_type *player_ptr, POSITION y, POSITION x)
     grid_type *g_ptr;
     floor_type *floor_ptr = player_ptr->current_floor_ptr;
     g_ptr = &floor_ptr->grid_array[y][x];
-    if (!is_floor_grid(g_ptr) || g_ptr->o_idx)
+    if (!is_floor_grid(g_ptr) || !g_ptr->o_idx_list.empty())
         return;
 
     if (!floor_ptr->dun_level)
@@ -66,11 +66,9 @@ bool cave_valid_bold(floor_type *floor_ptr, POSITION y, POSITION x)
     if (cave_has_flag_grid(g_ptr, FF_PERMANENT))
         return FALSE;
 
-    OBJECT_IDX next_o_idx = 0;
-    for (OBJECT_IDX this_o_idx = g_ptr->o_idx; this_o_idx; this_o_idx = next_o_idx) {
+    for (const auto this_o_idx : g_ptr->o_idx_list) {
         object_type *o_ptr;
         o_ptr = &floor_ptr->o_list[this_o_idx];
-        next_o_idx = o_ptr->next_o_idx;
         if (object_is_artifact(o_ptr))
             return FALSE;
     }

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -613,22 +613,20 @@ bool get_item_floor(player_type *owner_ptr, COMMAND_CODE *cp, concptr pmt, concp
         case '\n':
         case '\r':
         case '+': {
-            int i;
-            OBJECT_IDX o_idx;
+            OBJECT_IDX o_idx = 0;
             grid_type *g_ptr = &owner_ptr->current_floor_ptr->grid_array[owner_ptr->y][owner_ptr->x];
             if (command_wrk != (USE_FLOOR))
                 break;
 
-            o_idx = g_ptr->o_idx;
-            if (!(o_idx && owner_ptr->current_floor_ptr->o_list[o_idx].next_o_idx))
+            if (!g_ptr->o_idx_list.empty())
+                o_idx = g_ptr->o_idx_list.front();
+
+            if (g_ptr->o_idx_list.size() < 2)
                 break;
 
-            excise_object_idx(owner_ptr->current_floor_ptr, o_idx);
-            i = g_ptr->o_idx;
-            while (owner_ptr->current_floor_ptr->o_list[i].next_o_idx)
-                i = owner_ptr->current_floor_ptr->o_list[i].next_o_idx;
+            g_ptr->o_idx_list.pop_front();
+            g_ptr->o_idx_list.push_back(o_idx);
 
-            owner_ptr->current_floor_ptr->o_list[i].next_o_idx = o_idx;
             fis_ptr->floor_num
                 = scan_floor_items(owner_ptr, fis_ptr->floor_list, owner_ptr->y, owner_ptr->x, SCAN_FLOOR_ITEM_TESTER | SCAN_FLOOR_ONLY_MARKED, fis_ptr->tval);
             if (command_see) {

--- a/src/inventory/inventory-object.cpp
+++ b/src/inventory/inventory-object.cpp
@@ -331,7 +331,6 @@ s16b store_item_to_inventory(player_type *owner_ptr, object_type *o_ptr)
 
     object_copy(&owner_ptr->inventory_list[i], o_ptr);
     j_ptr = &owner_ptr->inventory_list[i];
-    j_ptr->next_o_idx = 0;
     j_ptr->held_m_idx = 0;
     j_ptr->iy = j_ptr->ix = 0;
     j_ptr->marked = OM_TOUCHED;

--- a/src/inventory/item-getter.cpp
+++ b/src/inventory/item-getter.cpp
@@ -237,11 +237,9 @@ bool get_item(player_type *owner_ptr, OBJECT_IDX *cp, concptr pmt, concptr str, 
     }
 
     if (item_selection_ptr->floor) {
-        for (item_selection_ptr->this_o_idx = owner_ptr->current_floor_ptr->grid_array[owner_ptr->y][owner_ptr->x].o_idx; item_selection_ptr->this_o_idx;
-             item_selection_ptr->this_o_idx = item_selection_ptr->next_o_idx) {
+        for (const auto this_o_idx : owner_ptr->current_floor_ptr->grid_array[owner_ptr->y][owner_ptr->x].o_idx_list) {
             object_type *o_ptr;
-            o_ptr = &owner_ptr->current_floor_ptr->o_list[item_selection_ptr->this_o_idx];
-            item_selection_ptr->next_o_idx = o_ptr->next_o_idx;
+            o_ptr = &owner_ptr->current_floor_ptr->o_list[this_o_idx];
             if ((item_tester_okay(owner_ptr, o_ptr, item_selection_ptr->tval) || (item_selection_ptr->mode & USE_FULL)) && (o_ptr->marked & OM_FOUND))
                 item_selection_ptr->allow_floor = TRUE;
         }
@@ -468,15 +466,13 @@ bool get_item(player_type *owner_ptr, OBJECT_IDX *cp, concptr pmt, concptr str, 
         }
         case '-': {
             if (item_selection_ptr->allow_floor) {
-                for (item_selection_ptr->this_o_idx = owner_ptr->current_floor_ptr->grid_array[owner_ptr->y][owner_ptr->x].o_idx;
-                     item_selection_ptr->this_o_idx; item_selection_ptr->this_o_idx = item_selection_ptr->next_o_idx) {
+                for (const auto this_o_idx : owner_ptr->current_floor_ptr->grid_array[owner_ptr->y][owner_ptr->x].o_idx_list) {
                     object_type *o_ptr;
-                    o_ptr = &owner_ptr->current_floor_ptr->o_list[item_selection_ptr->this_o_idx];
-                    item_selection_ptr->next_o_idx = o_ptr->next_o_idx;
+                    o_ptr = &owner_ptr->current_floor_ptr->o_list[this_o_idx];
                     if (!item_tester_okay(owner_ptr, o_ptr, item_selection_ptr->tval) && !(item_selection_ptr->mode & USE_FULL))
                         continue;
 
-                    item_selection_ptr->k = 0 - item_selection_ptr->this_o_idx;
+                    item_selection_ptr->k = 0 - this_o_idx;
                     if ((other_query_flag && !verify(owner_ptr, _("本当に", "Try"), item_selection_ptr->k))
                         || !get_item_allow(owner_ptr, item_selection_ptr->k))
                         continue;

--- a/src/inventory/item-selection-util.cpp
+++ b/src/inventory/item-selection-util.cpp
@@ -33,7 +33,6 @@ item_selection_type *initialize_item_selection_type(item_selection_type *item_se
     item_selection_ptr->cp = cp;
     item_selection_ptr->mode = mode;
     item_selection_ptr->tval = tval;
-    item_selection_ptr->next_o_idx = 0;
     item_selection_ptr->which = ' ';
     item_selection_ptr->oops = FALSE;
     item_selection_ptr->equip = FALSE;

--- a/src/inventory/item-selection-util.h
+++ b/src/inventory/item-selection-util.h
@@ -43,8 +43,6 @@ typedef struct item_selection_type {
     COMMAND_CODE *cp;
     BIT_FLAGS mode;
     tval_type tval;
-    OBJECT_IDX this_o_idx;
-    OBJECT_IDX next_o_idx;
     char which;
     OBJECT_IDX k;
     OBJECT_IDX i1;

--- a/src/inventory/player-inventory.cpp
+++ b/src/inventory/player-inventory.cpp
@@ -83,16 +83,16 @@ static bool py_pickup_floor_aux(player_type *owner_ptr)
  */
 void py_pickup_floor(player_type *owner_ptr, bool pickup)
 {
-    OBJECT_IDX this_o_idx, next_o_idx = 0;
     GAME_TEXT o_name[MAX_NLEN];
     object_type *o_ptr;
     int floor_num = 0;
     OBJECT_IDX floor_o_idx = 0;
     int can_pickup = 0;
-    for (this_o_idx = owner_ptr->current_floor_ptr->grid_array[owner_ptr->y][owner_ptr->x].o_idx; this_o_idx; this_o_idx = next_o_idx) {
+    auto &o_idx_list = owner_ptr->current_floor_ptr->grid_array[owner_ptr->y][owner_ptr->x].o_idx_list;
+    for (auto it = o_idx_list.begin(); it != o_idx_list.end();) {
+        const OBJECT_IDX this_o_idx = *it++;
         o_ptr = &owner_ptr->current_floor_ptr->o_list[this_o_idx];
         describe_flavor(owner_ptr, o_name, o_ptr, 0);
-        next_o_idx = o_ptr->next_o_idx;
         disturb(owner_ptr, FALSE, FALSE);
         if (o_ptr->tval == TV_GOLD) {
             msg_format(_(" $%ld の価値がある%sを見つけた。", "You have found %ld gold pieces worth of %s."), (long)o_ptr->pval, o_name);
@@ -250,13 +250,12 @@ void carry(player_type *creature_ptr, bool pickup)
         return;
     }
 
-    OBJECT_IDX next_o_idx = 0;
-    for (OBJECT_IDX this_o_idx = g_ptr->o_idx; this_o_idx; this_o_idx = next_o_idx) {
+    for (auto it = g_ptr->o_idx_list.begin(); it != g_ptr->o_idx_list.end();) {
+        const OBJECT_IDX this_o_idx = *it++;
         object_type *o_ptr;
         o_ptr = &creature_ptr->current_floor_ptr->o_list[this_o_idx];
         GAME_TEXT o_name[MAX_NLEN];
         describe_flavor(creature_ptr, o_name, o_ptr, 0);
-        next_o_idx = o_ptr->next_o_idx;
         disturb(creature_ptr, FALSE, FALSE);
         if (o_ptr->tval == TV_GOLD) {
             int value = (long)o_ptr->pval;

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -65,11 +65,9 @@ void do_cmd_knowledge_artifacts(player_type *player_ptr)
     for (POSITION y = 0; y < player_ptr->current_floor_ptr->height; y++) {
         for (POSITION x = 0; x < player_ptr->current_floor_ptr->width; x++) {
             grid_type *g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
-            OBJECT_IDX this_o_idx, next_o_idx = 0;
-            for (this_o_idx = g_ptr->o_idx; this_o_idx; this_o_idx = next_o_idx) {
+            for (const auto this_o_idx : g_ptr->o_idx_list) {
                 object_type *o_ptr;
                 o_ptr = &player_ptr->current_floor_ptr->o_list[this_o_idx];
-                next_o_idx = o_ptr->next_o_idx;
                 if (!object_is_fixed_artifact(o_ptr))
                     continue;
                 if (object_is_known(o_ptr))

--- a/src/load/floor-loader.cpp
+++ b/src/load/floor-loader.cpp
@@ -1,5 +1,6 @@
 ﻿#include "load/floor-loader.h"
 #include "floor/floor-generator.h"
+#include "floor/floor-object.h"
 #include "floor/floor-save-util.h"
 #include "game-option/birth-options.h"
 #include "grid/feature.h"
@@ -8,9 +9,9 @@
 #include "io/uid-checker.h"
 #include "load/angband-version-comparer.h"
 #include "load/item-loader.h"
-#include "load/monster-loader.h"
 #include "load/load-util.h"
 #include "load/load-v1-5-0.h"
+#include "load/monster-loader.h"
 #include "load/old-feature-types.h"
 #include "monster-race/monster-race.h"
 #include "monster/monster-info.h"
@@ -193,16 +194,8 @@ errr rd_saved_floor(player_type *player_ptr, saved_floor_type *sf_ptr)
         o_ptr = &floor_ptr->o_list[o_idx];
         rd_item(player_ptr, o_ptr);
 
-        if (object_is_held_monster(o_ptr)) {
-            monster_type *m_ptr;
-            m_ptr = &floor_ptr->m_list[o_ptr->held_m_idx];
-            o_ptr->next_o_idx = m_ptr->hold_o_idx;
-            m_ptr->hold_o_idx = o_idx;
-        } else {
-            grid_type *g_ptr = &floor_ptr->grid_array[o_ptr->iy][o_ptr->ix];
-            o_ptr->next_o_idx = g_ptr->o_idx;
-            g_ptr->o_idx = o_idx;
-        }
+        auto &list = get_o_idx_list_contains(floor_ptr, o_idx);
+        list.push_front(o_idx);
     }
 
     rd_u16b(&limit);

--- a/src/load/load-v1-5-0.cpp
+++ b/src/load/load-v1-5-0.cpp
@@ -8,6 +8,7 @@
 #include "load/load-v1-5-0.h"
 #include "cmd-item/cmd-smith.h"
 #include "dungeon/dungeon.h"
+#include "floor/floor-object.h"
 #include "game-option/birth-options.h"
 #include "grid/feature.h"
 #include "grid/grid.h"
@@ -39,8 +40,8 @@
 #include "sv-definition/sv-lite-types.h"
 #include "system/artifact-type-definition.h"
 #include "system/floor-type-definition.h"
-#include "system/object-type-definition.h"
 #include "system/monster-race-definition.h"
+#include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "util/quarks.h"
@@ -750,18 +751,9 @@ errr rd_dungeon_old(player_type *player_ptr)
         object_type *o_ptr;
         o_ptr = &floor_ptr->o_list[o_idx];
         rd_item(player_ptr, o_ptr);
-        if (object_is_held_monster(o_ptr)) {
-            monster_type *m_ptr;
-            m_ptr = &floor_ptr->m_list[o_ptr->held_m_idx];
-            o_ptr->next_o_idx = m_ptr->hold_o_idx;
-            m_ptr->hold_o_idx = o_idx;
-            continue;
-        }
 
-        grid_type *g_ptr;
-        g_ptr = &floor_ptr->grid_array[o_ptr->iy][o_ptr->ix];
-        o_ptr->next_o_idx = g_ptr->o_idx;
-        g_ptr->o_idx = o_idx;
+        auto &list = get_o_idx_list_contains(floor_ptr, o_idx);
+        list.push_front(o_idx);
     }
 
     rd_u16b(&limit);

--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -115,8 +115,7 @@ static void move_item_to_monster(player_type *target_ptr, monap_type *monap_ptr,
 
     j_ptr->marked = OM_TOUCHED;
     j_ptr->held_m_idx = monap_ptr->m_idx;
-    j_ptr->next_o_idx = monap_ptr->m_ptr->hold_o_idx;
-    monap_ptr->m_ptr->hold_o_idx = o_idx;
+    monap_ptr->m_ptr->hold_o_idx_list.push_front(o_idx);
 }
 
 /*!

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -417,7 +417,7 @@ bool process_monster_movement(player_type *target_ptr, turn_flags *turn_flags_pt
                 disturb(target_ptr, FALSE, TRUE);
         }
 
-        bool is_takable_or_killable = g_ptr->o_idx > 0;
+        bool is_takable_or_killable = !g_ptr->o_idx_list.empty();
         is_takable_or_killable &= (r_ptr->flags2 & (RF2_TAKE_ITEM | RF2_KILL_ITEM)) != 0;
 
         bool is_pickup_items = (target_ptr->pet_extra_flags & PF_PICKUP_ITEMS) != 0;

--- a/src/monster-floor/monster-remover.cpp
+++ b/src/monster-floor/monster-remover.cpp
@@ -67,11 +67,8 @@ void delete_monster_idx(player_type *player_ptr, MONSTER_IDX i)
         player_ptr->riding = 0;
 
     floor_ptr->grid_array[y][x].m_idx = 0;
-    OBJECT_IDX next_o_idx = 0;
-    for (OBJECT_IDX this_o_idx = m_ptr->hold_o_idx; this_o_idx; this_o_idx = next_o_idx) {
-        object_type *o_ptr;
-        o_ptr = &floor_ptr->o_list[this_o_idx];
-        next_o_idx = o_ptr->next_o_idx;
+    for (auto it = m_ptr->hold_o_idx_list.begin(); it != m_ptr->hold_o_idx_list.end();) {
+        const OBJECT_IDX this_o_idx = *it++;
         delete_object_idx(player_ptr, this_o_idx);
     }
 

--- a/src/monster/monster-compaction.cpp
+++ b/src/monster/monster-compaction.cpp
@@ -39,11 +39,9 @@ static void compact_monsters_aux(player_type *player_ptr, MONSTER_IDX i1, MONSTE
     g_ptr = &floor_ptr->grid_array[y][x];
     g_ptr->m_idx = i2;
 
-    OBJECT_IDX next_o_idx = 0;
-    for (OBJECT_IDX this_o_idx = m_ptr->hold_o_idx; this_o_idx; this_o_idx = next_o_idx) {
+    for (const auto this_o_idx : m_ptr->hold_o_idx_list) {
         object_type *o_ptr;
         o_ptr = &floor_ptr->o_list[this_o_idx];
-        next_o_idx = o_ptr->next_o_idx;
         o_ptr->held_m_idx = i2;
     }
 

--- a/src/mspell/mspell-checker.cpp
+++ b/src/mspell/mspell-checker.cpp
@@ -111,10 +111,8 @@ bool raise_possible(player_type *target_ptr, monster_type *m_ptr)
                 continue;
 
             g_ptr = &floor_ptr->grid_array[yy][xx];
-            OBJECT_IDX this_o_idx, next_o_idx = 0;
-            for (this_o_idx = g_ptr->o_idx; this_o_idx; this_o_idx = next_o_idx) {
+            for (const auto this_o_idx : g_ptr->o_idx_list) {
                 object_type *o_ptr = &floor_ptr->o_list[this_o_idx];
-                next_o_idx = o_ptr->next_o_idx;
                 if (o_ptr->tval == TV_CORPSE) {
                     if (!monster_has_hostile_align(target_ptr, m_ptr, 0, 0, &r_info[o_ptr->pval]))
                         return TRUE;

--- a/src/player-attack/attack-chaos-effect.cpp
+++ b/src/player-attack/attack-chaos-effect.cpp
@@ -242,16 +242,15 @@ static void attack_golden_hammer(player_type *attacker_ptr, player_attack_type *
 {
     floor_type *floor_ptr = attacker_ptr->current_floor_ptr;
     monster_type *target_ptr = &floor_ptr->m_list[pa_ptr->m_idx];
-    if (target_ptr->hold_o_idx == 0)
+    if (target_ptr->hold_o_idx_list.empty())
         return;
 
-    object_type *q_ptr = &floor_ptr->o_list[target_ptr->hold_o_idx];
+    object_type *q_ptr = &floor_ptr->o_list[target_ptr->hold_o_idx_list.front()];
     GAME_TEXT o_name[MAX_NLEN];
     describe_flavor(attacker_ptr, o_name, q_ptr, OD_NAME_ONLY);
     q_ptr->held_m_idx = 0;
     q_ptr->marked = OM_TOUCHED;
-    target_ptr->hold_o_idx = q_ptr->next_o_idx;
-    q_ptr->next_o_idx = 0;
+    target_ptr->hold_o_idx_list.pop_front();
     msg_format(_("%sを奪った。", "You snatched %s."), o_name);
     store_item_to_inventory(attacker_ptr, q_ptr);
 }

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -75,11 +75,9 @@ static void discover_hidden_things(player_type *creature_ptr, POSITION y, POSITI
         disturb(creature_ptr, FALSE, FALSE);
     }
 
-    OBJECT_IDX next_o_idx = 0;
-    for (OBJECT_IDX this_o_idx = g_ptr->o_idx; this_o_idx; this_o_idx = next_o_idx) {
+    for (const auto this_o_idx : g_ptr->o_idx_list) {
         object_type *o_ptr;
         o_ptr = &floor_ptr->o_list[this_o_idx];
-        next_o_idx = o_ptr->next_o_idx;
         if (o_ptr->tval != TV_CHEST)
             continue;
         if (!chest_traps[o_ptr->pval])

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -676,7 +676,6 @@ void check_no_flowed(player_type *creature_ptr)
 {
     object_type *o_ptr;
     bool has_sw = FALSE, has_kabe = FALSE;
-    OBJECT_IDX this_o_idx, next_o_idx = 0;
 
     creature_ptr->no_flowed = FALSE;
 
@@ -697,9 +696,8 @@ void check_no_flowed(player_type *creature_ptr)
             has_kabe = TRUE;
     }
 
-    for (this_o_idx = creature_ptr->current_floor_ptr->grid_array[creature_ptr->y][creature_ptr->x].o_idx; this_o_idx; this_o_idx = next_o_idx) {
+    for (const auto this_o_idx : creature_ptr->current_floor_ptr->grid_array[creature_ptr->y][creature_ptr->x].o_idx_list) {
         o_ptr = &creature_ptr->current_floor_ptr->o_list[this_o_idx];
-        next_o_idx = o_ptr->next_o_idx;
 
         if ((o_ptr->tval == TV_NATURE_BOOK) && (o_ptr->sval == 2))
             has_sw = TRUE;

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -2638,8 +2638,8 @@ bool player_has_no_spellbooks(player_type *creature_ptr)
     }
 
     floor_type *floor_ptr = creature_ptr->current_floor_ptr;
-    for (int i = floor_ptr->grid_array[creature_ptr->y][creature_ptr->x].o_idx; i; i = o_ptr->next_o_idx) {
-        o_ptr = &floor_ptr->o_list[i];
+    for (const auto this_o_idx : floor_ptr->grid_array[creature_ptr->y][creature_ptr->x].o_idx_list) {
+        o_ptr = &floor_ptr->o_list[this_o_idx];
         if (o_ptr->k_idx && any_bits(o_ptr->marked, OM_FOUND) && check_book_realm(creature_ptr, o_ptr->tval, o_ptr->sval))
             return FALSE;
     }

--- a/src/room/vault-builder.cpp
+++ b/src/room/vault-builder.cpp
@@ -89,7 +89,7 @@ void vault_objects(player_type *player_ptr, POSITION y, POSITION x, int num)
 
             grid_type *g_ptr;
             g_ptr = &floor_ptr->grid_array[j][k];
-            if (!is_floor_grid(g_ptr) || g_ptr->o_idx)
+            if (!is_floor_grid(g_ptr) || !g_ptr->o_idx_list.empty())
                 continue;
 
             if (randint0(100) < 75) {
@@ -133,7 +133,7 @@ static void vault_trap_aux(player_type *player_ptr, POSITION y, POSITION x, POSI
         }
 
         g_ptr = &floor_ptr->grid_array[y1][x1];
-        if (!is_floor_grid(g_ptr) || g_ptr->o_idx || g_ptr->m_idx)
+        if (!is_floor_grid(g_ptr) || !g_ptr->o_idx_list.empty() || g_ptr->m_idx)
             continue;
 
         place_trap(player_ptr, y1, x1);

--- a/src/spell-kind/spells-enchant.cpp
+++ b/src/spell-kind/spells-enchant.cpp
@@ -137,7 +137,6 @@ bool mundane_spell(player_type *owner_ptr, bool only_equip)
     msg_print(_("まばゆい閃光が走った！", "There is a bright flash of light!"));
     POSITION iy = o_ptr->iy;
     POSITION ix = o_ptr->ix;
-    OBJECT_IDX next_o_idx = o_ptr->next_o_idx;
     byte marked = o_ptr->marked;
     u16b inscription = o_ptr->inscription;
 
@@ -145,7 +144,6 @@ bool mundane_spell(player_type *owner_ptr, bool only_equip)
 
     o_ptr->iy = iy;
     o_ptr->ix = ix;
-    o_ptr->next_o_idx = next_o_idx;
     o_ptr->marked = marked;
     o_ptr->inscription = inscription;
 

--- a/src/spell-kind/spells-fetcher.cpp
+++ b/src/spell-kind/spells-fetcher.cpp
@@ -39,7 +39,7 @@ void fetch_item(player_type *caster_ptr, DIRECTION dir, WEIGHT wgt, bool require
     object_type *o_ptr;
     GAME_TEXT o_name[MAX_NLEN];
 
-    if (caster_ptr->current_floor_ptr->grid_array[caster_ptr->y][caster_ptr->x].o_idx) {
+    if (!caster_ptr->current_floor_ptr->grid_array[caster_ptr->y][caster_ptr->x].o_idx_list.empty()) {
         msg_print(_("自分の足の下にある物は取れません。", "You can't fetch when you're already standing on something."));
         return;
     }
@@ -55,7 +55,7 @@ void fetch_item(player_type *caster_ptr, DIRECTION dir, WEIGHT wgt, bool require
         }
 
         g_ptr = &caster_ptr->current_floor_ptr->grid_array[ty][tx];
-        if (!g_ptr->o_idx) {
+        if (g_ptr->o_idx_list.empty()) {
             msg_print(_("そこには何もありません。", "There is no object there."));
             return;
         }
@@ -79,7 +79,7 @@ void fetch_item(player_type *caster_ptr, DIRECTION dir, WEIGHT wgt, bool require
         tx = caster_ptr->x;
         bool is_first_loop = TRUE;
         g_ptr = &caster_ptr->current_floor_ptr->grid_array[ty][tx];
-        while (is_first_loop || !g_ptr->o_idx) {
+        while (is_first_loop || g_ptr->o_idx_list.empty()) {
             is_first_loop = FALSE;
             ty += ddy[dir];
             tx += ddx[dir];
@@ -91,17 +91,16 @@ void fetch_item(player_type *caster_ptr, DIRECTION dir, WEIGHT wgt, bool require
         }
     }
 
-    o_ptr = &caster_ptr->current_floor_ptr->o_list[g_ptr->o_idx];
+    o_ptr = &caster_ptr->current_floor_ptr->o_list[g_ptr->o_idx_list.front()];
     if (o_ptr->weight > wgt) {
         msg_print(_("そのアイテムは重過ぎます。", "The object is too heavy."));
         return;
     }
 
-    OBJECT_IDX i = g_ptr->o_idx;
-    g_ptr->o_idx = o_ptr->next_o_idx;
-    caster_ptr->current_floor_ptr->grid_array[caster_ptr->y][caster_ptr->x].o_idx = i; /* 'move' it */
+    OBJECT_IDX i = g_ptr->o_idx_list.front();
+    g_ptr->o_idx_list.pop_front();
+    caster_ptr->current_floor_ptr->grid_array[caster_ptr->y][caster_ptr->x].o_idx_list.push_front(i); /* 'move' it */
 
-    o_ptr->next_o_idx = 0;
     o_ptr->iy = caster_ptr->y;
     o_ptr->ix = caster_ptr->x;
 

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -329,13 +329,10 @@ bool destroy_area(player_type *caster_ptr, POSITION y1, POSITION x1, POSITION r,
 
             /* During generation, destroyed artifacts are "preserved" */
             if (preserve_mode || in_generate) {
-                OBJECT_IDX this_o_idx, next_o_idx = 0;
-
                 /* Scan all objects in the grid */
-                for (this_o_idx = g_ptr->o_idx; this_o_idx; this_o_idx = next_o_idx) {
+                for (const auto this_o_idx : g_ptr->o_idx_list) {
                     object_type *o_ptr;
                     o_ptr = &floor_ptr->o_list[this_o_idx];
-                    next_o_idx = o_ptr->next_o_idx;
 
                     /* Hack -- Preserve unknown artifacts */
                     if (object_is_fixed_artifact(o_ptr) && (!object_is_known(o_ptr) || in_generate)) {

--- a/src/system/monster-type-definition.h
+++ b/src/system/monster-type-definition.h
@@ -5,6 +5,8 @@
 #include "monster/smart-learn-types.h"
 #include "util/flag-group.h"
 
+#include <list>
+
 /*!
  * @brief Monster information, for a specific monster.
  * @Note
@@ -38,7 +40,7 @@ typedef struct monster_type {
 	EnumClassFlagGroup<MFLAG> mflag{};	/*!< モンスター個体に与えられた特殊フラグ1 (セーブ不要) / Extra monster flags */
 	EnumClassFlagGroup<MFLAG2> mflag2{};	/*!< モンスター個体に与えられた特殊フラグ2 (セーブ必要) / Extra monster flags */
 	bool ml{};		/*!< モンスターがプレイヤーにとって視認できるか(処理のためのテンポラリ変数) Monster is "visible" */
-	OBJECT_IDX hold_o_idx{};	/*!< モンスターが盗み処理により保持しているアイテム(object_type構造体自身がリスト構造を持つ) Object being held (if any) */
+	std::list<OBJECT_IDX> hold_o_idx_list{};	/*!< モンスターが所持しているアイテムのリスト / Object list being held (if any) */
 	POSITION target_y{};		/*!< モンスターの攻撃目標対象Y座標 / Can attack !los player */
 	POSITION target_x{};		/*!< モンスターの攻撃目標対象X座標 /  Can attack !los player */
 	STR_OFFSET nickname{};	/*!< ペットに与えられた名前の保存先文字列オフセット Monster's Nickname */

--- a/src/system/object-type-definition.h
+++ b/src/system/object-type-definition.h
@@ -40,7 +40,6 @@ typedef struct object_type {
 
     BIT_FLAGS art_flags[TR_FLAG_SIZE]; /* Extra Flags for ego and artifacts */
     BIT_FLAGS curse_flags; /* Flags for curse */
-    OBJECT_IDX next_o_idx; /* Next object in stack (if any) */
     MONSTER_IDX held_m_idx; /*!< アイテムを所持しているモンスターID (いないなら 0) / Monster holding us (if any) */
     ARTIFACT_BIAS_IDX artifact_bias; /*!< ランダムアーティファクト生成時のバイアスID */
 } object_type;

--- a/src/target/target-preparation.cpp
+++ b/src/target/target-preparation.cpp
@@ -83,11 +83,9 @@ static bool target_set_accept(player_type *creature_ptr, POSITION y, POSITION x)
             return TRUE;
     }
 
-    OBJECT_IDX next_o_idx = 0;
-    for (OBJECT_IDX this_o_idx = g_ptr->o_idx; this_o_idx; this_o_idx = next_o_idx) {
+    for (const auto this_o_idx : g_ptr->o_idx_list) {
         object_type *o_ptr;
         o_ptr = &floor_ptr->o_list[this_o_idx];
-        next_o_idx = o_ptr->next_o_idx;
         if (o_ptr->marked & OM_FOUND)
             return TRUE;
     }

--- a/src/util/sort.cpp
+++ b/src/util/sort.cpp
@@ -181,10 +181,10 @@ bool ang_sort_comp_importance(player_type *player_ptr, vptr u, vptr v, int a, in
     }
 
     /* An object get higher priority */
-    if (player_ptr->current_floor_ptr->grid_array[y[a]][x[a]].o_idx && !player_ptr->current_floor_ptr->grid_array[y[b]][x[b]].o_idx)
+    if (!player_ptr->current_floor_ptr->grid_array[y[a]][x[a]].o_idx_list.empty() && player_ptr->current_floor_ptr->grid_array[y[b]][x[b]].o_idx_list.empty())
         return TRUE;
 
-    if (!player_ptr->current_floor_ptr->grid_array[y[a]][x[a]].o_idx && player_ptr->current_floor_ptr->grid_array[y[b]][x[b]].o_idx)
+    if (player_ptr->current_floor_ptr->grid_array[y[a]][x[a]].o_idx_list.empty() && !player_ptr->current_floor_ptr->grid_array[y[b]][x[b]].o_idx_list.empty())
         return FALSE;
 
     /* Priority from the terrain */

--- a/src/view/display-map.cpp
+++ b/src/view/display-map.cpp
@@ -141,7 +141,6 @@ void map_info(player_type *player_ptr, POSITION y, POSITION x, TERM_COLOR *ap, S
 {
     floor_type *floor_ptr = player_ptr->current_floor_ptr;
     grid_type *g_ptr = &floor_ptr->grid_array[y][x];
-    OBJECT_IDX this_o_idx, next_o_idx = 0;
     FEAT_IDX feat = get_feat_mimic(g_ptr);
     feature_type *f_ptr = &f_info[feat];
     TERM_COLOR a;
@@ -244,10 +243,9 @@ void map_info(player_type *player_ptr, POSITION y, POSITION x, TERM_COLOR *ap, S
     if (player_ptr->image && one_in_(256))
         image_random(ap, cp);
 
-    for (this_o_idx = g_ptr->o_idx; this_o_idx; this_o_idx = next_o_idx) {
+    for (const auto this_o_idx : g_ptr->o_idx_list) {
         object_type *o_ptr;
         o_ptr = &floor_ptr->o_list[this_o_idx];
-        next_o_idx = o_ptr->next_o_idx;
         if (!(o_ptr->marked & OM_FOUND))
             continue;
 

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -544,12 +544,11 @@ static void display_floor_item_list(player_type *player_ptr, const int y, const 
 
     // (y,x) のアイテムを1行に1個ずつ書く。
     TERM_LEN term_y = 1;
-    for (OBJECT_IDX o_idx = g_ptr->o_idx; o_idx > 0;) {
+    for (const auto o_idx : g_ptr->o_idx_list) {
         object_type *const o_ptr = &floor_ptr->o_list[o_idx];
 
         // 未発見アイテムおよび金は対象外。
         if (none_bits(o_ptr->marked, OM_FOUND) || o_ptr->tval == TV_GOLD) {
-            o_idx = o_ptr->next_o_idx;
             continue;
         }
 
@@ -569,7 +568,6 @@ static void display_floor_item_list(player_type *player_ptr, const int y, const 
             term_addstr(-1, attr, line);
         }
 
-        o_idx = o_ptr->next_o_idx;
         ++term_y;
     }
 }

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -547,7 +547,6 @@ static void wiz_reroll_item(player_type *owner_ptr, object_type *o_ptr)
 
         q_ptr->iy = o_ptr->iy;
         q_ptr->ix = o_ptr->ix;
-        q_ptr->next_o_idx = o_ptr->next_o_idx;
         q_ptr->marked = o_ptr->marked;
     }
 


### PR DESCRIPTION
既存のコードでは床上やモンスターが所持しているスタックした
複数のアイテムを自前のリンクリストで管理している。
これを grid_type/monster_type のメンバにstd::listを持たせて
管理するようにする。

とりあえずドラフトなので比較のため既存コードをコメントアウトで残している箇所多数。