### PR TITLE
Include sstream in wizard-item-modifier.cpp to avoid compiler error ...

### DIFF
--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -46,6 +46,7 @@
 #include "util/int-char-converter.h"
 #include "wizard/wizard-special-process.h"
 #include "world/world.h"
+#include <sstream>
 #include <vector>
 
 #define K_MAX_DEPTH 110 /*!< アイテムの階層毎生成率を表示する最大階 */


### PR DESCRIPTION
…when not using precompiled headers.