### PR TITLE
Include system/h-basic.h in target/target-setter.h

### DIFF
--- a/src/target/target-describer.h
+++ b/src/target/target-describer.h
@@ -4,6 +4,6 @@
 
 extern bool show_gold_on_floor;
 
-enum target_type : uint8_t;
+enum target_type : unsigned int;
 typedef struct player_type player_type;
 char examine_grid(player_type *subject_ptr, const POSITION y, const POSITION x, target_type mode, concptr info);

--- a/src/target/target-setter.h
+++ b/src/target/target-setter.h
@@ -1,5 +1,5 @@
 ﻿#pragma once
 
-enum target_type : uint8_t;
+enum target_type : unsigned int;
 typedef struct player_type player_type;
 bool target_set(player_type *creature_ptr, target_type mode);

--- a/src/target/target-types.h
+++ b/src/target/target-types.h
@@ -1,7 +1,7 @@
 ﻿#pragma once
 
 /* target_set用関数の利用用途フラグ / Bit flags for the "target_set" function */
-enum target_type : uint8_t {
+enum target_type : unsigned int {
 	TARGET_KILL = 0x01, /*!< モンスターへの狙いをつける(視界内モンスターのみクエリ対象) / Target monsters */
     TARGET_LOOK = 0x02, /*!< "L"ookコマンド向けの既存情報確認向け(全ての有為な情報をクエリ対象) / Describe grid fully */
     TARGET_XTRA = 0x04, /*!< 現在未使用 / Currently unused flag */


### PR DESCRIPTION
That avoids a compiler error when compiling target/target-setter.cpp with Ubuntu 20.04's default g++ and no precompiled headers.  The error was "found ':' in nested-name-specifier, expected '::'" when compiling "enum target_type : uint8_t;", presumably because the compiler didn't recognize uint8_t as something appropriate for setting the size of the enum.