### PR TITLE
[feature] cheat_knowオン時にモンスターの種族IDを表示する

### DIFF
--- a/src/view/display-lore.cpp
+++ b/src/view/display-lore.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "view/display-lore.h"
+#include "game-option/cheat-options.h"
 #include "game-option/text-display-options.h"
 #include "lore/lore-calculator.h"
 #include "lore/lore-util.h"
@@ -59,6 +60,9 @@ void roff_top(MONRACE_IDX r_idx)
         term_addstr(-1, TERM_WHITE, "The ");
     }
 #endif
+
+    if (cheat_know)
+        term_addstr(-1, TERM_WHITE, format("[%d]", r_idx));
 
     term_addstr(-1, TERM_WHITE, (r_ptr->name.c_str()));
 


### PR DESCRIPTION
Issueなし。
デバッグ時に特定のモンスターを呼びたい時に、いちいち種族IDをr_info.txtやdiscordのbotで調べるのが面倒なので、思い出で表示されていれば便利かなと。

![image](https://user-images.githubusercontent.com/1501750/116684166-952b8c80-a9eb-11eb-983b-481172bf457c.png)
