### PR TITLE
[Fix] vcxprojから存在しないファイルの記述を削除する

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -939,7 +939,6 @@
     <ClInclude Include="..\..\src\cmd-action\cmd-tunnel.h" />
     <ClInclude Include="..\..\src\action\movement-execution.h" />
     <ClInclude Include="..\..\src\main-win\graphics-win.h" />
-    <ClInclude Include="..\..\src\main-win\string-win.h" />
     <ClInclude Include="..\..\src\player-info\alignment.h" />
     <ClInclude Include="..\..\src\player-info\equipment-info.h" />
     <ClInclude Include="..\..\src\player-status\player-energy.h" />


### PR DESCRIPTION
#947 の漏れ。
Hengband.vcxprojからmain-win\string-win.hの記述を削除した。

存在しないファイルがHengband.vcxprojに書かれていても特にエラーも警告も出ないようだ。