### PR TITLE
[Fix] 文字2倍幅表示のときにMMマップを表示するとクラッシュ #990

### DIFF
--- a/src/window/main-window-util.cpp
+++ b/src/window/main-window-util.cpp
@@ -184,6 +184,7 @@ static void display_shortened_item_name(player_type *player_ptr, object_type *o_
  * @return なし
  * @details
  * メインウィンドウ('M'コマンド)、サブウィンドウ兼(縮小図)用。
+ * use_bigtile時に横の描画列数は1/2になる。
  */
 void display_map(player_type *player_ptr, int *cy, int *cx)
 {
@@ -196,12 +197,14 @@ void display_map(player_type *player_ptr, int *cy, int *cx)
 
     bool old_view_special_lite = view_special_lite;
     bool old_view_granite_lite = view_granite_lite;
+
+    TERM_LEN border_width = use_bigtile ? 2 : 1; //!< @note 枠線幅
     TERM_LEN hgt, wid, yrat, xrat;
     term_get_size(&wid, &hgt);
     hgt -= 2;
-    wid -= 14;
+    wid -= 12 + border_width * 2; //!< @note 描画桁数(枠線抜)
     if (use_bigtile)
-        wid /= 2;
+        wid = wid / 2 - 1;
 
     floor_type *floor_ptr = player_ptr->current_floor_ptr;
     yrat = (floor_ptr->height + hgt - 1) / hgt;


### PR DESCRIPTION
MMマップ作成ルーチンで横幅の計算が1桁(ないしは2桁)多いため、Term表示バッファの領域外にアクセスしている。

MMマップ作成ルーチンの修正(横幅計算ないしはその後の生成部分)をきちんとするのが正しい対応だが、現象としては上記なので。