### PR TITLE
[Fix/Feature] 種族の食料タイプを設定 #820

### DIFF
--- a/src/cmd-item/cmd-usestaff.cpp
+++ b/src/cmd-item/cmd-usestaff.cpp
@@ -283,8 +283,7 @@ int staff_effect(player_type *creature_ptr, OBJECT_SUBTYPE_VALUE sval, bool *use
 
     case SV_STAFF_NOTHING: {
         msg_print(_("何も起らなかった。", "Nothing happens."));
-        if (is_specific_player_race(creature_ptr, RACE_SKELETON) || is_specific_player_race(creature_ptr, RACE_GOLEM)
-            || is_specific_player_race(creature_ptr, RACE_ZOMBIE) || is_specific_player_race(creature_ptr, RACE_SPECTRE))
+        if (player_race_food(creature_ptr) == PlayerRaceFood::MANA)
             msg_print(_("もったいない事をしたような気がする。食べ物は大切にしなくては。", "What a waste.  It's your food!"));
         break;
     }

--- a/src/object-hook/hook-expendable.cpp
+++ b/src/object-hook/hook-expendable.cpp
@@ -28,11 +28,11 @@ bool item_tester_hook_eatable(player_type *player_ptr, object_type *o_ptr)
     if (o_ptr->tval == TV_FOOD)
         return TRUE;
 
-    if (is_specific_player_race(player_ptr, RACE_SKELETON) || is_specific_player_race(player_ptr, RACE_GOLEM)
-        || is_specific_player_race(player_ptr, RACE_ZOMBIE) || is_specific_player_race(player_ptr, RACE_SPECTRE)) {
+    auto food_type = player_race_food(player_ptr);
+    if (food_type == PlayerRaceFood::MANA) {
         if (o_ptr->tval == TV_STAFF || o_ptr->tval == TV_WAND)
             return TRUE;
-    } else if (is_specific_player_race(player_ptr, RACE_BALROG) || (mimic_info[player_ptr->mimic_form].MIMIC_FLAGS & MIMIC_IS_DEMON)) {
+    } else if (food_type == PlayerRaceFood::CORPSE) {
         if (o_ptr->tval == TV_CORPSE && o_ptr->sval == SV_CORPSE && angband_strchr("pht", r_info[o_ptr->pval].d_char))
             return TRUE;
     }
@@ -51,7 +51,7 @@ bool item_tester_hook_quaff(player_type *player_ptr, object_type *o_ptr)
     if (o_ptr->tval == TV_POTION)
         return TRUE;
 
-    if (is_specific_player_race(player_ptr, RACE_ANDROID) && (o_ptr->tval == TV_FLASK) && (o_ptr->sval == SV_FLASK_OIL))
+    if (player_race_food(player_ptr) == PlayerRaceFood::OIL && o_ptr->tval == TV_FLASK && o_ptr->sval == SV_FLASK_OIL)
         return TRUE;
 
     return FALSE;

--- a/src/player/mimic-info-table.cpp
+++ b/src/player/mimic-info-table.cpp
@@ -23,6 +23,7 @@ const player_race mimic_info[MAX_MIMIC_FORMS] =
 		0,
 		0x000000,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
 		{ },
 	},
 	{
@@ -36,6 +37,7 @@ const player_race mimic_info[MAX_MIMIC_FORMS] =
 		5,
 		0x000003,
 		PlayerRaceLife::DEMON,
+		PlayerRaceFood::CORPSE,
 		{
 			{ TR_RES_FIRE },
 			{ TR_RES_NETHER },
@@ -56,6 +58,7 @@ const player_race mimic_info[MAX_MIMIC_FORMS] =
 		20,
 		0x000003,
 		PlayerRaceLife::DEMON,
+		PlayerRaceFood::CORPSE,
 		{
 			{ TR_IM_FIRE },
 			{ TR_RES_COLD },
@@ -87,6 +90,7 @@ const player_race mimic_info[MAX_MIMIC_FORMS] =
 		5,
 		0x000005,
 		PlayerRaceLife::UNDEAD,
+		PlayerRaceFood::BLOOD,
 		{
 			{ TR_RES_COLD },
 			{ TR_RES_POIS },

--- a/src/player/player-race.cpp
+++ b/src/player/player-race.cpp
@@ -112,3 +112,15 @@ PlayerRaceLife player_race_life(player_type *creature_ptr, bool base_race)
     auto race_ptr = get_player_race_info(creature_ptr, base_race);
     return race_ptr->life;
 }
+
+/*!
+ * @brief 種族の食料形態を返す
+ * @param creature_ptr プレイヤー情報への参照ポインタ
+ * @param base_race ミミック中も元種族の情報を返すならtrue
+ * @return 食料形態
+ */
+PlayerRaceFood player_race_food(player_type *creature_ptr, bool base_race)
+{
+    auto race_ptr = get_player_race_info(creature_ptr, base_race);
+    return race_ptr->food;
+}

--- a/src/player/player-race.h
+++ b/src/player/player-race.h
@@ -1,8 +1,8 @@
 ﻿#pragma once
 
+#include <optional>
 #include <unordered_map>
 #include <vector>
-#include <optional>
 
 #include "object-enchant/tr-types.h"
 #include "player-ability/player-ability-types.h"
@@ -24,28 +24,49 @@
 #define MIMIC_IS_UNDEAD 0x00000004
 
 /*!
- * プレイヤー種族の生命形態
+ * @brief プレイヤー種族の生命形態
  */
 enum class PlayerRaceLife {
-    LIVING = 0, //生きている
-    UNDEAD = 1, //不死
-    DEMON = 2, //悪魔
-    NONLIVING = 3, //生きてない
+    LIVING = 0, //!< 生きている
+    UNDEAD = 1, //!< 不死
+    DEMON = 2, //!< 悪魔
+    NONLIVING = 3, //!< 生きてない
     MAX
 };
 
+/*!
+ * @brief プレイヤー種族の食料形態
+ */
+enum class PlayerRaceFood {
+    RATION = 0, //!< 食料
+    WATER = 1, //!< 水
+    OIL = 2, //!< 油
+    BLOOD = 3, //!< 血
+    MANA = 4, //!< 魔力
+    CORPSE = 5, //!< 死体(捧げる)
+    MAX
+};
+
+/*!
+ * @brief プレイヤー種族の条件設定構造体
+ */
 struct player_race_condition {
     tr_type type{};
     PLAYER_LEVEL level{};
     std::optional<player_class_type> pclass{};
     bool not_class{};
 
-    player_race_condition(tr_type t, PLAYER_LEVEL l = 1, const std::optional<player_class_type>& c = std::nullopt, bool nc = false)
-        : type(t), level(l), pclass(c), not_class(nc) {}
+    player_race_condition(tr_type t, PLAYER_LEVEL l = 1, const std::optional<player_class_type> &c = std::nullopt, bool nc = false)
+        : type(t)
+        , level(l)
+        , pclass(c)
+        , not_class(nc)
+    {
+    }
 };
 
 /*!
- * p@brief プレイヤー種族構造体 / Player racial info
+ * @brief プレイヤー種族構造体 / Player racial info
  */
 struct player_race {
     concptr title{}; //!< 種族名 / Title of race
@@ -76,7 +97,7 @@ struct player_race {
     byte m_m_wt{}; //!< 体重加算範囲(男) / mod weight (males)
 
     byte f_b_ht{}; //!< 身長最小値(女) / base height (females)
-    byte f_m_ht{}; //!< 身長加算範囲(女) / mod height (females)	 
+    byte f_m_ht{}; //!< 身長加算範囲(女) / mod height (females)
     byte f_b_wt{}; //!< 体重最小値(女) / base weight (females)
     byte f_m_wt{}; //!< 体重加算範囲(女) / mod weight (females)
 
@@ -84,6 +105,7 @@ struct player_race {
 
     u32b choice{}; //!< 似つかわしい職業(ミミック時はミミック種族属性) / Legal class choices
     PlayerRaceLife life{}; //!< 生命の形態
+    PlayerRaceFood food{}; //!< 食料の形態
 
     std::vector<player_race_condition> extra_flags;
 };
@@ -96,3 +118,4 @@ bool is_specific_player_race(player_type *creature_ptr, player_race_type prace);
 bool player_race_has_flag(player_type *creature_ptr, tr_type flag, bool base_race = false);
 void add_player_race_flags(player_type *creature_ptr, BIT_FLAGS *flags, bool base_race = false);
 PlayerRaceLife player_race_life(player_type *creature_ptr, bool base_race = false);
+PlayerRaceFood player_race_food(player_type *creature_ptr, bool base_race = false);

--- a/src/player/race-info-table.cpp
+++ b/src/player/race-info-table.cpp
@@ -35,6 +35,7 @@ const player_race race_info[MAX_RACES] =
 		0,
 		0x1FFFFFFF,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
 		{},
 	},
 	{
@@ -48,6 +49,7 @@ const player_race race_info[MAX_RACES] =
 		2,
 		0x1E77E7FF,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {},
     },
 	{
@@ -61,6 +63,7 @@ const player_race race_info[MAX_RACES] =
 		3,
 		0x1E77E75B,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_RES_LITE },
 		},
@@ -76,6 +79,7 @@ const player_race race_info[MAX_RACES] =
 		4,
 		0x1F6FFC0B,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_HOLD_EXP },
 		},
@@ -91,6 +95,7 @@ const player_race race_info[MAX_RACES] =
 		4,
 		0x1F67D60F,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_FREE_ACT },
 		},
@@ -106,6 +111,7 @@ const player_race race_info[MAX_RACES] =
 		5,
 		0x11890005,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_RES_BLIND },
 		},
@@ -121,6 +127,7 @@ const player_race race_info[MAX_RACES] =
 		3,
 		0x1DD8818D,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_RES_DARK },
 		},
@@ -136,6 +143,7 @@ const player_race race_info[MAX_RACES] =
 		3,
 		0x00880005,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_SUST_STR },
 			{ TR_REGEN, 15 },
@@ -155,6 +163,7 @@ const player_race race_info[MAX_RACES] =
 		0,
 		0x1FFFF7FF,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_SUST_CON },
 			{ TR_REGEN },
@@ -171,6 +180,7 @@ const player_race race_info[MAX_RACES] =
 		4,
 		0x1F77E75B,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_RES_LITE },
 			{ TR_SEE_INVIS },
@@ -187,6 +197,7 @@ const player_race race_info[MAX_RACES] =
 		0,
 		0x05C0A09D,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_RES_FEAR },
 		},
@@ -202,6 +213,7 @@ const player_race race_info[MAX_RACES] =
 		3,
 		0x10A80407,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_SUST_STR },
 			{ TR_RES_DARK },
@@ -218,6 +230,7 @@ const player_race race_info[MAX_RACES] =
 		3,
 		0x08880011,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_SUST_STR },
 			{ TR_RES_SHARDS },
@@ -234,6 +247,7 @@ const player_race race_info[MAX_RACES] =
 		0,
 		0x123D4727,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_RES_CHAOS },
 		},
@@ -249,6 +263,7 @@ const player_race race_info[MAX_RACES] =
 		1,
 		0x00888005,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_RES_SOUND },
 		},
@@ -264,6 +279,7 @@ const player_race race_info[MAX_RACES] =
 		2,
 		0x1667360F,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_RES_ACID },
 			{ TR_IM_ACID, 20 },
@@ -280,6 +296,7 @@ const player_race race_info[MAX_RACES] =
 		2,
 		0x004D8011,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_RES_ACID },
 			{ TR_RES_CONF },
@@ -297,6 +314,7 @@ const player_race race_info[MAX_RACES] =
 		3,
 		0x1444A009,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_RES_POIS },
 		},
@@ -312,6 +330,7 @@ const player_race race_info[MAX_RACES] =
 		5,
 		0x1569040F,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_RES_DARK },
 			{ TR_RES_DISEN },
@@ -328,6 +347,7 @@ const player_race race_info[MAX_RACES] =
 		5,
 		0x1E77C7DF,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_RES_DARK },
 			{ TR_SEE_INVIS, 20 },
@@ -344,6 +364,7 @@ const player_race race_info[MAX_RACES] =
 		2,
 		0x07FFE757,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_RES_FIRE, 5 },
 			{ TR_RES_COLD, 10 },
@@ -364,6 +385,7 @@ const player_race race_info[MAX_RACES] =
 		4,
 		0x12334746,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_SUST_INT },
 			{ TR_SUST_WIS },
@@ -382,6 +404,7 @@ const player_race race_info[MAX_RACES] =
 		3,
 		0x1DB537CB,
 		PlayerRaceLife::DEMON,
+		PlayerRaceFood::RATION,
         {
 			{ TR_RES_FIRE },
 			{ TR_SEE_INVIS, 10 },
@@ -398,6 +421,7 @@ const player_race race_info[MAX_RACES] =
 		4,
 		0x00800001,
 		PlayerRaceLife::NONLIVING,
+		PlayerRaceFood::MANA,
         {
 			{ TR_RES_POIS },
 			{ TR_SEE_INVIS },
@@ -417,6 +441,7 @@ const player_race race_info[MAX_RACES] =
 		2,
 		0x0234070F,
 		PlayerRaceLife::UNDEAD,
+		PlayerRaceFood::MANA,
 		{
 			{ TR_RES_COLD, 10 },
 			{ TR_RES_POIS },
@@ -436,6 +461,7 @@ const player_race race_info[MAX_RACES] =
 		2,
 		0x00800001,
 		PlayerRaceLife::UNDEAD,
+		PlayerRaceFood::MANA,
 		{
 			{ TR_RES_COLD, 5 },
 			{ TR_RES_POIS },
@@ -456,6 +482,7 @@ const player_race race_info[MAX_RACES] =
 		5,
 		0x067DC7FF,
 		PlayerRaceLife::UNDEAD,
+		PlayerRaceFood::BLOOD,
 		{
 			{ TR_RES_COLD },
 			{ TR_RES_POIS },
@@ -477,6 +504,7 @@ const player_race race_info[MAX_RACES] =
 		5,
 		0x0631474A,
 		PlayerRaceLife::UNDEAD,
+		PlayerRaceFood::MANA,
 		{
 			{ TR_RES_COLD },
 			{ TR_RES_POIS },
@@ -500,6 +528,7 @@ const player_race race_info[MAX_RACES] =
 		4,
 		0x1623F65E,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_RES_LITE },
 			{ TR_LEVITATION },
@@ -517,6 +546,7 @@ const player_race race_info[MAX_RACES] =
 		0,
 		0x057887CF,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_RES_CONF },
 			{ TR_RES_SOUND },
@@ -533,6 +563,7 @@ const player_race race_info[MAX_RACES] =
 		  0,
 		0x10010005,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::WATER,
         {
 			{ TR_VUL_FIRE }
 		},
@@ -548,6 +579,7 @@ const player_race race_info[MAX_RACES] =
 		3,
 		0x1779F777,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_SEE_INVIS },
 			{ TR_LEVITATION },
@@ -564,6 +596,7 @@ const player_race race_info[MAX_RACES] =
 		5,
 		0x07EDC4DB,
 		PlayerRaceLife::DEMON,
+		PlayerRaceFood::CORPSE,
         {
 			{ TR_RES_FIRE },
 			{ TR_RES_NETHER },
@@ -582,6 +615,7 @@ const player_race race_info[MAX_RACES] =
 		0,
 		0x1FFFF7FF,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_SUST_CON },
 		},
@@ -597,6 +631,7 @@ const player_race race_info[MAX_RACES] =
 		  4,
 		0x1E33C7DF,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_VUL_LITE },
 			{ TR_LEVITATION },
@@ -613,6 +648,7 @@ const player_race race_info[MAX_RACES] =
 		0,
 		0x0C18B7AD,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_RES_CONF },
 		},
@@ -628,6 +664,7 @@ const player_race race_info[MAX_RACES] =
 		0,
 		0x00800001,
 		PlayerRaceLife::NONLIVING,
+		PlayerRaceFood::OIL,
         {
 			{ TR_VUL_ELEC },
 			{ TR_RES_POIS },
@@ -647,6 +684,7 @@ const player_race race_info[MAX_RACES] =
 		2,
 		0x1E77E7FF,
 		PlayerRaceLife::LIVING,
+		PlayerRaceFood::RATION,
         {
 			{ TR_RES_WATER },
 		},


### PR DESCRIPTION
インプの生命が悪魔タイプで生者ではないため、食料であまり栄養が取れなくなっていた(#820のエンバグ)のを修正。