### PR TITLE
[Feature] Win版にコマンドラインオプション追加（デバッグ用コンソール表示）

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -267,6 +267,7 @@
     <ClCompile Include="..\..\src\cmd-action\cmd-travel.cpp" />
     <ClCompile Include="..\..\src\cmd-action\cmd-tunnel.cpp" />
     <ClCompile Include="..\..\src\action\movement-execution.cpp" />
+    <ClCompile Include="..\..\src\main-win\commandline-win.cpp" />
     <ClCompile Include="..\..\src\main-win\graphics-win.cpp" />
     <ClCompile Include="..\..\src\player-info\alignment.cpp" />
     <ClCompile Include="..\..\src\player-info\equipment-info.cpp" />
@@ -938,6 +939,7 @@
     <ClInclude Include="..\..\src\cmd-action\cmd-travel.h" />
     <ClInclude Include="..\..\src\cmd-action\cmd-tunnel.h" />
     <ClInclude Include="..\..\src\action\movement-execution.h" />
+    <ClInclude Include="..\..\src\main-win\commandline-win.h" />
     <ClInclude Include="..\..\src\main-win\graphics-win.h" />
     <ClInclude Include="..\..\src\player-info\alignment.h" />
     <ClInclude Include="..\..\src\player-info\equipment-info.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2274,6 +2274,9 @@
     <ClCompile Include="..\..\src\main-win\main-win-utils.cpp">
       <Filter>main-win</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\main-win\commandline-win.cpp">
+      <Filter>main-win</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -4864,6 +4867,9 @@
       <Filter>store</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\main-win\main-win-utils.h">
+      <Filter>main-win</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main-win\commandline-win.h">
       <Filter>main-win</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\main-win\graphics-win.h">

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -920,6 +920,7 @@ hengband_SOURCES = \
 
 EXTRA_hengband_SOURCES = \
 	angband.ico angband.rc ang_eng.rc ang_jp.rc maid-x11.cpp main-win.cpp \
+	main-win/commandline-win.cpp main-win/commandline-win.h \
 	main-win/graphics-win.cpp main-win/graphics-win.h \
 	main-win/main-win-bg.cpp main-win/main-win-bg.h \
 	main-win/main-win-cfg-reader.cpp main-win/main-win-cfg-reader.h \

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -126,6 +126,7 @@
 
 #include <cstdlib>
 #include <locale>
+#include <string>
 
 #include <commdlg.h>
 #include <direct.h>
@@ -1498,20 +1499,20 @@ static void setup_menus(void)
 }
 
 /*
- * Check for double clicked (or dragged) savefile
- *
+ * @brief Check for double clicked (or dragged) savefile
+ * @details
  * Apparently, Windows copies the entire filename into the first
  * piece of the "command line string".  Perhaps we should extract
  * the "basename" of that filename and append it to the "save" dir.
+ * @param player_ptr pointer of player_type
+ * @param savefile_option savefile path
  */
-static void check_for_save_file(player_type *player_ptr, LPSTR cmd_line)
+static void check_for_save_file(player_type *player_ptr, const std::string &savefile_option)
 {
-    char *s;
-    s = cmd_line;
-    if (!*s)
+    if (savefile_option.empty())
         return;
 
-    strcpy(savefile, s);
+    strcpy(savefile, savefile_option.c_str());
     validate_file(savefile);
     game_in_progress = TRUE;
     play_game(player_ptr, FALSE, FALSE);
@@ -2665,7 +2666,7 @@ int WINAPI WinMain(_In_ HINSTANCE hInst, [[maybe_unused]] _In_opt_ HINSTANCE hPr
     term_activate(term_screen);
     init_angband(p_ptr, FALSE);
     initialized = TRUE;
-    check_for_save_file(p_ptr, lpCmdLine);
+    check_for_save_file(p_ptr, command_line.get_savefile_option());
     prt(_("[ファイル] メニューの [新規] または [開く] を選択してください。", "[Choose 'New' or 'Open' from the 'File' menu]"), 23, _(8, 17));
     term_fresh();
 

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -97,6 +97,7 @@
 #include "io/record-play-movie.h"
 #include "io/signal-handlers.h"
 #include "io/write-diary.h"
+#include "main-win/commandline-win.h"
 #include "main-win/graphics-win.h"
 #include "main-win/main-win-bg.h"
 #include "main-win/main-win-file-utils.h"
@@ -2558,47 +2559,27 @@ static void init_stuff(void)
 }
 
 /*!
- * @brief コマンドラインから全スポイラー出力を行う
- * Create Spoiler files from Command Line
- * @return spoiler_output_status
+ * @brief 全スポイラー出力を行う
+ * Create Spoiler files
+ * @details スポイラー出力処理の成功、失敗に関わらずプロセスを終了する。
  */
-static spoiler_output_status create_debug_spoiler(LPSTR cmd_line)
+void create_debug_spoiler(void)
 {
-    char *s;
-    concptr option;
-    s = cmd_line;
-    if (!*s)
-        return SPOILER_OUTPUT_CANCEL;
-    option = "--output-spoilers";
-
-    if (strncmp(s, option, strlen(option)) != 0)
-        return SPOILER_OUTPUT_CANCEL;
-
     init_stuff();
     init_angband(p_ptr, TRUE);
 
-    return output_all_spoilers();
-}
-
-/*!
- * @brief コマンドラインオプション処理
- * @param lpCmdLine コマンドライン文字列(WinMainの第3引数)
- */
-static void handle_commandline(LPSTR lpCmdLine)
-{
-    switch (create_debug_spoiler(lpCmdLine)) {
+    switch (output_all_spoilers()) {
     case SPOILER_OUTPUT_SUCCESS:
         fprintf(stdout, "Successfully created a spoiler file.");
-        quit(NULL);
     case SPOILER_OUTPUT_FAIL_FOPEN:
         fprintf(stderr, "Cannot create spoiler file.");
-        quit(NULL);
     case SPOILER_OUTPUT_FAIL_FCLOSE:
         fprintf(stderr, "Cannot close spoiler file.");
-        quit(NULL);
     default:
         break;
     }
+
+    quit(NULL);
 }
 
 /*!
@@ -2642,7 +2623,7 @@ int WINAPI WinMain(_In_ HINSTANCE hInst, [[maybe_unused]] _In_opt_ HINSTANCE hPr
         return FALSE;
     }
 
-    handle_commandline(lpCmdLine);
+    command_line.handle();
     register_wndclass();
 
     // before term_data initialize

--- a/src/main-win/commandline-win.cpp
+++ b/src/main-win/commandline-win.cpp
@@ -1,0 +1,31 @@
+﻿/*!
+ * @file commandline-win.cpp
+ * @brief Windows版固有実装(コマンドライン)
+ */
+
+#include "main-win/commandline-win.h"
+#include "term/z-util.h"
+
+#include <windows.h>
+
+// interface object
+CommandLine command_line{};
+
+void CommandLine::handle(void)
+{
+    int argc;
+    LPWSTR *argv = ::CommandLineToArgvW(::GetCommandLineW(), &argc);
+    if (argv) {
+        for (int i = 1; i < argc; i++) {
+            if (wcscmp(argv[i], L"--output-spoilers") == 0) {
+                create_debug_spoiler();
+                continue;
+            }
+        }
+
+        ::LocalFree(argv);
+    } else {
+        fprintf(stdout, "CommandLineToArgvW failed.");
+        quit(NULL);
+    }
+}

--- a/src/main-win/commandline-win.cpp
+++ b/src/main-win/commandline-win.cpp
@@ -4,12 +4,32 @@
  */
 
 #include "main-win/commandline-win.h"
+#include "main-win/main-win-utils.h"
 #include "term/z-util.h"
 
+#include <iostream>
 #include <windows.h>
 
 // interface object
 CommandLine command_line{};
+
+namespace {
+// セーブファイル名
+std::string savefile_option;
+}
+
+/*!
+ * @brief コンソールを作成する
+ * @details
+ * 標準出力のみ対応。
+ */
+static void create_console(void)
+{
+    ::AllocConsole();
+    FILE *stream = NULL;
+    freopen_s(&stream, "CONOUT$", "w+", stdout);
+    std::cout << "Hengband debug console" << std::endl;
+}
 
 void CommandLine::handle(void)
 {
@@ -17,9 +37,20 @@ void CommandLine::handle(void)
     LPWSTR *argv = ::CommandLineToArgvW(::GetCommandLineW(), &argc);
     if (argv) {
         for (int i = 1; i < argc; i++) {
-            if (wcscmp(argv[i], L"--output-spoilers") == 0) {
+            fwprintf(stdout, L"argv[%d] : %s\n", i, argv[i]);
+            if (wcscmp(argv[i], L"--debug-console") == 0) {
+                create_console();
+                continue;
+            } else if (wcscmp(argv[i], L"--output-spoilers") == 0) {
                 create_debug_spoiler();
                 continue;
+            } else {
+                if (argv[i][0] != L'-') {
+                    // "-"で始まらない最初のオプションをセーブファイル名とみなす
+                    if (savefile_option.empty()) {
+                        savefile_option = to_multibyte(argv[i]).c_str();
+                    }
+                }
             }
         }
 
@@ -28,4 +59,9 @@ void CommandLine::handle(void)
         fprintf(stdout, "CommandLineToArgvW failed.");
         quit(NULL);
     }
+}
+
+const std::string &CommandLine::get_savefile_option(void)
+{
+    return savefile_option;
 }

--- a/src/main-win/commandline-win.h
+++ b/src/main-win/commandline-win.h
@@ -4,6 +4,8 @@
  * @brief Windows版固有実装(コマンドライン)ヘッダ
  */
 
+#include <string>
+
 /*!
  * @brief コマンドライン情報管理
  */
@@ -19,9 +21,18 @@ public:
      * コマンドラインオプションは以下の通り。
      * オプション | 内容
      * ---------- | ----
+     * --debug-console | デバッグ用コンソール表示を行う
      * --output-spoilers | 全スポイラー出力を行う
+     * 「-」で始まらない最初のオプション | セーブファイルパス
      */
     void handle(void);
+
+    /*!
+     * @brief セーブファイル名取得
+     * @details 事前にhandle()を呼び出していること。
+     * @return コマンドラインで指定されているセーブファイル名。設定されていなければ空文字列を返す。
+     */
+    const std::string &get_savefile_option(void);
 };
 
 /*!

--- a/src/main-win/commandline-win.h
+++ b/src/main-win/commandline-win.h
@@ -1,0 +1,32 @@
+﻿#pragma once
+/*!
+ * @file commandline-win.h
+ * @brief Windows版固有実装(コマンドライン)ヘッダ
+ */
+
+/*!
+ * @brief コマンドライン情報管理
+ */
+class CommandLine {
+public:
+    CommandLine() = default;
+    ~CommandLine() = default;
+    void operator=(const CommandLine &) = delete;
+
+    /*!
+     * @brief コマンドラインオプション処理
+     * @details
+     * コマンドラインオプションは以下の通り。
+     * オプション | 内容
+     * ---------- | ----
+     * --output-spoilers | 全スポイラー出力を行う
+     */
+    void handle(void);
+};
+
+/*!
+ * コマンドライン情報管理
+ */
+extern CommandLine command_line;
+
+extern void create_debug_spoiler(void);


### PR DESCRIPTION
printfデバッグ用にコンソールを出すオプション（--debug-console）を追加する。
コンソールには標準出力が表示される。

システムロケールUTF-8の動作確認が手間なので、デバッガに頼らない手軽な確認方法を追加したい。