### PR TITLE
[Fix] cheat_know + Wizardモードで2重にモンスター種族IDが表示

### DIFF
--- a/src/view/display-lore.cpp
+++ b/src/view/display-lore.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "view/display-lore.h"
+#include "game-option/cheat-options.h"
 #include "game-option/text-display-options.h"
 #include "lore/lore-calculator.h"
 #include "lore/lore-util.h"
@@ -59,6 +60,12 @@ void roff_top(MONRACE_IDX r_idx)
     }
 #endif
 
+    if (current_world_ptr->wizard || cheat_know) {
+        term_addstr(-1, TERM_WHITE, "[");
+        term_addstr(-1, TERM_L_BLUE, format("%d", r_idx));
+        term_addstr(-1, TERM_WHITE, "] ");
+    }
+
     term_addstr(-1, TERM_WHITE, (r_ptr->name.c_str()));
 
     term_addstr(-1, TERM_WHITE, " ('");
@@ -68,15 +75,6 @@ void roff_top(MONRACE_IDX r_idx)
     term_addstr(-1, TERM_WHITE, "/('");
     term_add_bigch(a2, c2);
     term_addstr(-1, TERM_WHITE, "'):");
-
-    if (!current_world_ptr->wizard)
-        return;
-
-    char buf[16];
-    sprintf(buf, "%d", r_idx);
-    term_addstr(-1, TERM_WHITE, " (");
-    term_addstr(-1, TERM_L_BLUE, buf);
-    term_addch(TERM_WHITE, ')');
 }
 
 /*!

--- a/src/view/display-lore.cpp
+++ b/src/view/display-lore.cpp
@@ -5,7 +5,6 @@
  */
 
 #include "view/display-lore.h"
-#include "game-option/cheat-options.h"
 #include "game-option/text-display-options.h"
 #include "lore/lore-calculator.h"
 #include "lore/lore-util.h"
@@ -59,9 +58,6 @@ void roff_top(MONRACE_IDX r_idx)
         term_addstr(-1, TERM_WHITE, "The ");
     }
 #endif
-
-    if (cheat_know)
-        term_addstr(-1, TERM_WHITE, format("[%d]", r_idx));
 
     term_addstr(-1, TERM_WHITE, (r_ptr->name.c_str()));
 


### PR DESCRIPTION
元々Wizardモードの時にモンスター種族IDが表示される仕様だった
ので、cheat_knowオプションでのモンスター種族ID表示を追加した
ことで2重に表示されてしまっている。
デバッグ用途としては全モンスターの思い出とその種族IDは同時に
欲しいので、cheat_knowがONの時にも表示する仕様とする。
名前が長いモンスターだと種族IDが確認できない可能性があるので、
表示箇所は従来のWizardモードでの位置である名前の後ろではなく、
行頭への表示を採用する。