### PR TITLE
[Fix] 【バグ】 足元のアイテムを複数拾おうとした時にサブウィンドウ：あなたの足元のアイテム一覧が更新されない #995

### DIFF
--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -262,6 +262,8 @@ void delete_object_idx(player_type *player_ptr, OBJECT_IDX o_idx)
 
     object_wipe(j_ptr);
     floor_ptr->o_cnt--;
+
+    set_bits(player_ptr->window_flags, PW_FLOOR_ITEM_LIST);
 }
 
 /*!


### PR DESCRIPTION
複数のアイテムを拾った場合、その間にサブウィンドウ描画フラグ
PW_FLOOR_ITEM_LIST が ON にならないために足元のアイテム一覧が
更新されない。
さらに元を辿れば delete_object_idx() でフロアのアイテムが削除された
時は床上のアイテム一覧の更新の可能性があるはずなので、
delete_object_idx() で PW_FLOOR_ITEM_LIST を ON にするようにする。