### PR TITLE
[Feature] 床上のアイテムリストのスタック順を保持する #992

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -272,6 +272,7 @@
     <ClCompile Include="..\..\src\main-win\graphics-win.cpp" />
     <ClCompile Include="..\..\src\object-enchant\apply-magic-amulet.cpp" />
     <ClCompile Include="..\..\src\object-enchant\apply-magic-ring.cpp" />
+    <ClCompile Include="..\..\src\object\object-index-list.cpp" />
     <ClCompile Include="..\..\src\player-info\alignment.cpp" />
     <ClCompile Include="..\..\src\player-info\equipment-info.cpp" />
     <ClCompile Include="..\..\src\player-status\player-energy.cpp" />
@@ -948,6 +949,7 @@
     <ClInclude Include="..\..\src\main-win\graphics-win.h" />
     <ClInclude Include="..\..\src\object-enchant\apply-magic-amulet.h" />
     <ClInclude Include="..\..\src\object-enchant\apply-magic-ring.h" />
+    <ClInclude Include="..\..\src\object\object-index-list.h" />
     <ClInclude Include="..\..\src\player-info\alignment.h" />
     <ClInclude Include="..\..\src\player-info\equipment-info.h" />
     <ClInclude Include="..\..\src\player-status\player-energy.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2286,6 +2286,9 @@
     <ClCompile Include="..\..\src\system\object-type-definition.cpp">
       <Filter>system</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\object\object-index-list.cpp">
+      <Filter>object</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -4919,6 +4922,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\dungeon\dungeon-flag-mask.h">
       <Filter>dungeon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object\object-index-list.h">
+      <Filter>object</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -543,6 +543,7 @@ hengband_SOURCES = \
 	object/item-tester-hooker.cpp object/item-tester-hooker.h \
 	object/object-broken.cpp object/object-broken.h \
 	object/object-flags.cpp object/object-flags.h \
+	object/object-index-list.cpp object/object-index-list.h \
 	object/object-info.cpp object/object-info.h \
 	object/object-kind.cpp object/object-kind.h \
 	object/object-kind-hook.cpp object/object-kind-hook.h \

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -863,7 +863,7 @@ void exe_fire(player_type *shooter_ptr, INVENTORY_IDX item, object_type *j_ptr, 
             o_ptr->held_m_idx = m_idx;
 
             /* Carry object */
-            m_ptr->hold_o_idx_list.add(o_idx);
+            m_ptr->hold_o_idx_list.add(shooter_ptr->current_floor_ptr, o_idx);
         } else if (cave_has_flag_bold(shooter_ptr->current_floor_ptr, y, x, FF_PROJECT)) {
             /* Drop (or break) near that location */
             (void)drop_near(shooter_ptr, q_ptr, j, y, x);

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -863,7 +863,7 @@ void exe_fire(player_type *shooter_ptr, INVENTORY_IDX item, object_type *j_ptr, 
             o_ptr->held_m_idx = m_idx;
 
             /* Carry object */
-            m_ptr->hold_o_idx_list.push_front(o_idx);
+            m_ptr->hold_o_idx_list.add(o_idx);
         } else if (cave_has_flag_bold(shooter_ptr->current_floor_ptr, y, x, FF_PROJECT)) {
             /* Drop (or break) near that location */
             (void)drop_near(shooter_ptr, q_ptr, j, y, x);

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -70,7 +70,7 @@ static void drop_here(floor_type *floor_ptr, object_type *j_ptr, POSITION y, POS
     o_ptr->ix = x;
     o_ptr->held_m_idx = 0;
     grid_type *g_ptr = &floor_ptr->grid_array[y][x];
-    g_ptr->o_idx_list.add(o_idx);
+    g_ptr->o_idx_list.add(floor_ptr, o_idx);
 }
 
 static void generate_artifact(player_type *player_ptr, qtwg_type *qtwg_ptr, const ARTIFACT_IDX artifact_index)

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -70,7 +70,7 @@ static void drop_here(floor_type *floor_ptr, object_type *j_ptr, POSITION y, POS
     o_ptr->ix = x;
     o_ptr->held_m_idx = 0;
     grid_type *g_ptr = &floor_ptr->grid_array[y][x];
-    g_ptr->o_idx_list.push_front(o_idx);
+    g_ptr->o_idx_list.add(o_idx);
 }
 
 static void generate_artifact(player_type *player_ptr, qtwg_type *qtwg_ptr, const ARTIFACT_IDX artifact_index)

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -511,7 +511,7 @@ OBJECT_IDX drop_near(player_type *owner_ptr, object_type *j_ptr, PERCENTAGE chan
         j_ptr->iy = by;
         j_ptr->ix = bx;
         j_ptr->held_m_idx = 0;
-        g_ptr->o_idx_list.add(o_idx);
+        g_ptr->o_idx_list.add(floor_ptr, o_idx);
         done = TRUE;
     }
 

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -281,9 +281,9 @@ void excise_object_idx(floor_type *floor_ptr, OBJECT_IDX o_idx)
  * @brief 指定したOBJECT_IDXを含むリスト(モンスター所持リスト or 床上スタックリスト)への参照を得る
  * @param floo_ptr 現在フロアへの参照ポインタ
  * @param o_idx 参照を得るリストに含まれるOBJECT_IDX
- * @return o_idxを含む std::list<OBJECT_IDX> への参照
+ * @return o_idxを含む ObjectIndexList への参照
  */
-std::list<OBJECT_IDX> &get_o_idx_list_contains(floor_type *floor_ptr, OBJECT_IDX o_idx)
+ObjectIndexList &get_o_idx_list_contains(floor_type *floor_ptr, OBJECT_IDX o_idx)
 {
     object_type *o_ptr = &floor_ptr->o_list[o_idx];
 
@@ -511,7 +511,7 @@ OBJECT_IDX drop_near(player_type *owner_ptr, object_type *j_ptr, PERCENTAGE chan
         j_ptr->iy = by;
         j_ptr->ix = bx;
         j_ptr->held_m_idx = 0;
-        g_ptr->o_idx_list.push_front(o_idx);
+        g_ptr->o_idx_list.add(o_idx);
         done = TRUE;
     }
 

--- a/src/floor/floor-object.h
+++ b/src/floor/floor-object.h
@@ -3,7 +3,7 @@
 #include "object/tval-types.h"
 #include "system/angband.h"
 
-#include <list>
+class ObjectIndexList;
 
 typedef struct floor_type floor_type;
 typedef struct object_type object_type;
@@ -15,7 +15,7 @@ void floor_item_increase(player_type *owner_ptr, INVENTORY_IDX item, ITEM_NUMBER
 void floor_item_optimize(player_type *owner_ptr, INVENTORY_IDX item);
 void delete_object_idx(player_type *owner_ptr, OBJECT_IDX o_idx);
 void excise_object_idx(floor_type *floor_ptr, OBJECT_IDX o_idx);
-std::list<OBJECT_IDX> &get_o_idx_list_contains(floor_type *floor_ptr, OBJECT_IDX o_idx);
+ObjectIndexList &get_o_idx_list_contains(floor_type *floor_ptr, OBJECT_IDX o_idx);
 OBJECT_IDX drop_near(player_type *owner_type, object_type *o_ptr, PERCENTAGE chance, POSITION y, POSITION x);
 void floor_item_charges(floor_type *owner_ptr, INVENTORY_IDX item);
 void floor_item_describe(player_type *player_ptr, INVENTORY_IDX item);

--- a/src/floor/floor-util.cpp
+++ b/src/floor/floor-util.cpp
@@ -120,7 +120,7 @@ void forget_flow(floor_type *floor_ptr)
  */
 void wipe_o_list(floor_type *floor_ptr)
 {
-    for (int i = 1; i < floor_ptr->o_max; i++) {
+    for (OBJECT_IDX i = 1; i < floor_ptr->o_max; i++) {
         object_type *o_ptr = &floor_ptr->o_list[i];
         if (!object_is_valid(o_ptr))
             continue;

--- a/src/grid/grid.h
+++ b/src/grid/grid.h
@@ -14,10 +14,10 @@
  * included in all such copies.
  */
 
-#include "spell/spells-util.h"
 #include "system/angband.h"
 
-#include <list>
+#include "spell/spells-util.h"
+#include "object/object-index-list.h"
 
 /*
  * A single "grid" in a Cave
@@ -55,7 +55,7 @@ struct grid_type {
     BIT_FLAGS info{}; /* Hack -- grid flags */
 
     FEAT_IDX feat{}; /* Hack -- feature type */
-    std::list<OBJECT_IDX> o_idx_list; /* Object list in this grid */
+    ObjectIndexList o_idx_list; /* Object list in this grid */
     MONSTER_IDX m_idx{}; /* Monster in this grid */
 
     /*! 地形の特別な情報を保存する / Special grid info

--- a/src/grid/object-placer.cpp
+++ b/src/grid/object-placer.cpp
@@ -47,7 +47,7 @@ void place_gold(player_type *player_ptr, POSITION y, POSITION x)
 
     o_ptr->iy = y;
     o_ptr->ix = x;
-    g_ptr->o_idx_list.add(o_idx);
+    g_ptr->o_idx_list.add(floor_ptr, o_idx);
 
     note_spot(player_ptr, y, x);
     lite_spot(player_ptr, y, x);
@@ -95,7 +95,7 @@ void place_object(player_type *owner_ptr, POSITION y, POSITION x, BIT_FLAGS mode
 
     o_ptr->iy = y;
     o_ptr->ix = x;
-    g_ptr->o_idx_list.add(o_idx);
+    g_ptr->o_idx_list.add(floor_ptr, o_idx);
 
     note_spot(owner_ptr, y, x);
     lite_spot(owner_ptr, y, x);

--- a/src/grid/object-placer.cpp
+++ b/src/grid/object-placer.cpp
@@ -47,7 +47,7 @@ void place_gold(player_type *player_ptr, POSITION y, POSITION x)
 
     o_ptr->iy = y;
     o_ptr->ix = x;
-    g_ptr->o_idx_list.push_front(o_idx);
+    g_ptr->o_idx_list.add(o_idx);
 
     note_spot(player_ptr, y, x);
     lite_spot(player_ptr, y, x);
@@ -95,7 +95,7 @@ void place_object(player_type *owner_ptr, POSITION y, POSITION x, BIT_FLAGS mode
 
     o_ptr->iy = y;
     o_ptr->ix = x;
-    g_ptr->o_idx_list.push_front(o_idx);
+    g_ptr->o_idx_list.add(o_idx);
 
     note_spot(owner_ptr, y, x);
     lite_spot(owner_ptr, y, x);

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -620,7 +620,9 @@ bool get_item_floor(player_type *owner_ptr, COMMAND_CODE *cp, concptr pmt, concp
             if (g_ptr->o_idx_list.size() < 2)
                 break;
 
-            g_ptr->o_idx_list.rotate(owner_ptr->current_floor_ptr);
+            const auto next_o_idx = fis_ptr->floor_list[1];
+            while (g_ptr->o_idx_list.front() != next_o_idx)
+                g_ptr->o_idx_list.rotate(owner_ptr->current_floor_ptr);
 
             owner_ptr->window_flags |= PW_FLOOR_ITEM_LIST;
             window_stuff(owner_ptr);

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -622,6 +622,9 @@ bool get_item_floor(player_type *owner_ptr, COMMAND_CODE *cp, concptr pmt, concp
 
             g_ptr->o_idx_list.rotate(owner_ptr->current_floor_ptr);
 
+            owner_ptr->window_flags |= PW_FLOOR_ITEM_LIST;
+            window_stuff(owner_ptr);
+
             fis_ptr->floor_num
                 = scan_floor_items(owner_ptr, fis_ptr->floor_list, owner_ptr->y, owner_ptr->x, SCAN_FLOOR_ITEM_TESTER | SCAN_FLOOR_ONLY_MARKED, fis_ptr->tval);
             if (command_see) {

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -613,19 +613,14 @@ bool get_item_floor(player_type *owner_ptr, COMMAND_CODE *cp, concptr pmt, concp
         case '\n':
         case '\r':
         case '+': {
-            OBJECT_IDX o_idx = 0;
             grid_type *g_ptr = &owner_ptr->current_floor_ptr->grid_array[owner_ptr->y][owner_ptr->x];
             if (command_wrk != (USE_FLOOR))
                 break;
 
-            if (!g_ptr->o_idx_list.empty())
-                o_idx = g_ptr->o_idx_list.front();
-
             if (g_ptr->o_idx_list.size() < 2)
                 break;
 
-            g_ptr->o_idx_list.pop_front();
-            g_ptr->o_idx_list.push_back(o_idx);
+            g_ptr->o_idx_list.rotate();
 
             fis_ptr->floor_num
                 = scan_floor_items(owner_ptr, fis_ptr->floor_list, owner_ptr->y, owner_ptr->x, SCAN_FLOOR_ITEM_TESTER | SCAN_FLOOR_ONLY_MARKED, fis_ptr->tval);

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -620,7 +620,7 @@ bool get_item_floor(player_type *owner_ptr, COMMAND_CODE *cp, concptr pmt, concp
             if (g_ptr->o_idx_list.size() < 2)
                 break;
 
-            g_ptr->o_idx_list.rotate();
+            g_ptr->o_idx_list.rotate(owner_ptr->current_floor_ptr);
 
             fis_ptr->floor_num
                 = scan_floor_items(owner_ptr, fis_ptr->floor_list, owner_ptr->y, owner_ptr->x, SCAN_FLOOR_ITEM_TESTER | SCAN_FLOOR_ONLY_MARKED, fis_ptr->tval);

--- a/src/load/floor-loader.cpp
+++ b/src/load/floor-loader.cpp
@@ -195,7 +195,7 @@ errr rd_saved_floor(player_type *player_ptr, saved_floor_type *sf_ptr)
         rd_item(player_ptr, o_ptr);
 
         auto &list = get_o_idx_list_contains(floor_ptr, o_idx);
-        list.push_front(o_idx);
+        list.add(o_idx);
     }
 
     rd_u16b(&limit);

--- a/src/load/floor-loader.cpp
+++ b/src/load/floor-loader.cpp
@@ -195,7 +195,7 @@ errr rd_saved_floor(player_type *player_ptr, saved_floor_type *sf_ptr)
         rd_item(player_ptr, o_ptr);
 
         auto &list = get_o_idx_list_contains(floor_ptr, o_idx);
-        list.add(o_idx);
+        list.add(floor_ptr, o_idx, o_ptr->stack_idx);
     }
 
     rd_u16b(&limit);

--- a/src/load/item-loader.cpp
+++ b/src/load/item-loader.cpp
@@ -201,6 +201,11 @@ void rd_item(player_type *player_ptr, object_type *o_ptr)
     else
         o_ptr->feeling = 0;
 
+    if (flags & SAVE_ITEM_STACK_IDX)
+        rd_s16b(&o_ptr->stack_idx);
+    else
+        o_ptr->stack_idx = 0;
+
     if (flags & SAVE_ITEM_INSCRIPTION) {
         char buf[128];
         rd_string(buf, sizeof(buf));

--- a/src/load/load-v1-5-0.cpp
+++ b/src/load/load-v1-5-0.cpp
@@ -753,7 +753,7 @@ errr rd_dungeon_old(player_type *player_ptr)
         rd_item(player_ptr, o_ptr);
 
         auto &list = get_o_idx_list_contains(floor_ptr, o_idx);
-        list.add(o_idx);
+        list.add(floor_ptr, o_idx);
     }
 
     rd_u16b(&limit);

--- a/src/load/load-v1-5-0.cpp
+++ b/src/load/load-v1-5-0.cpp
@@ -753,7 +753,7 @@ errr rd_dungeon_old(player_type *player_ptr)
         rd_item(player_ptr, o_ptr);
 
         auto &list = get_o_idx_list_contains(floor_ptr, o_idx);
-        list.push_front(o_idx);
+        list.add(o_idx);
     }
 
     rd_u16b(&limit);

--- a/src/load/savedata-flag-types.h
+++ b/src/load/savedata-flag-types.h
@@ -30,6 +30,7 @@ enum savedata_item_flag_type {
 	SAVE_ITEM_INSCRIPTION = 0x04000000,
 	SAVE_ITEM_ART_NAME = 0x08000000,
 	SAVE_ITEM_ART_FLAGS4 = 0x10000000,
+	SAVE_ITEM_STACK_IDX = 0x20000000,
 };
 
 enum savedata_monster_flag_type {

--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -114,7 +114,7 @@ static void move_item_to_monster(player_type *target_ptr, monap_type *monap_ptr,
 
     j_ptr->marked = OM_TOUCHED;
     j_ptr->held_m_idx = monap_ptr->m_idx;
-    monap_ptr->m_ptr->hold_o_idx_list.add(o_idx);
+    monap_ptr->m_ptr->hold_o_idx_list.add(target_ptr->current_floor_ptr, o_idx);
 }
 
 /*!

--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -114,7 +114,7 @@ static void move_item_to_monster(player_type *target_ptr, monap_type *monap_ptr,
 
     j_ptr->marked = OM_TOUCHED;
     j_ptr->held_m_idx = monap_ptr->m_idx;
-    monap_ptr->m_ptr->hold_o_idx_list.push_front(o_idx);
+    monap_ptr->m_ptr->hold_o_idx_list.add(o_idx);
 }
 
 /*!

--- a/src/monster-floor/monster-object.cpp
+++ b/src/monster-floor/monster-object.cpp
@@ -127,7 +127,7 @@ static void monster_pickup_object(player_type *target_ptr, turn_flags *turn_flag
         o_ptr->marked &= OM_TOUCHED;
         o_ptr->iy = o_ptr->ix = 0;
         o_ptr->held_m_idx = m_idx;
-        m_ptr->hold_o_idx_list.add(this_o_idx);
+        m_ptr->hold_o_idx_list.add(target_ptr->current_floor_ptr, this_o_idx);
         return;
     }
 

--- a/src/monster-floor/monster-object.cpp
+++ b/src/monster-floor/monster-object.cpp
@@ -127,7 +127,7 @@ static void monster_pickup_object(player_type *target_ptr, turn_flags *turn_flag
         o_ptr->marked &= OM_TOUCHED;
         o_ptr->iy = o_ptr->ix = 0;
         o_ptr->held_m_idx = m_idx;
-        m_ptr->hold_o_idx_list.push_front(this_o_idx);
+        m_ptr->hold_o_idx_list.add(this_o_idx);
         return;
     }
 

--- a/src/object/object-index-list.cpp
+++ b/src/object/object-index-list.cpp
@@ -1,8 +1,20 @@
 ﻿#include "object/object-index-list.h"
+#include "system/floor-type-definition.h"
+#include "system/object-type-definition.h"
 
-void ObjectIndexList::add(OBJECT_IDX o_idx)
+#include <algorithm>
+
+void ObjectIndexList::add(floor_type *floor_ptr, OBJECT_IDX o_idx, IDX stack_idx)
 {
-    o_idx_list_.push_front(o_idx);
+    if (stack_idx <= 0) {
+        stack_idx = o_idx_list_.empty() ? 1 : floor_ptr->o_list[o_idx_list_.front()].stack_idx + 1;
+    }
+
+    auto it = std::partition_point(
+        o_idx_list_.begin(), o_idx_list_.end(), [floor_ptr, stack_idx](IDX idx) { return floor_ptr->o_list[idx].stack_idx > stack_idx; });
+
+    o_idx_list_.insert(it, o_idx);
+    floor_ptr->o_list[o_idx].stack_idx = stack_idx;
 }
 
 void ObjectIndexList::remove(OBJECT_IDX o_idx)
@@ -10,11 +22,17 @@ void ObjectIndexList::remove(OBJECT_IDX o_idx)
     o_idx_list_.remove(o_idx);
 }
 
-void ObjectIndexList::rotate()
+void ObjectIndexList::rotate(floor_type *floor_ptr)
 {
     if (o_idx_list_.size() < 2)
         return;
 
     o_idx_list_.push_back(o_idx_list_.front());
     o_idx_list_.pop_front();
+
+    for (const auto o_idx : o_idx_list_) {
+        floor_ptr->o_list[o_idx].stack_idx++;
+    }
+
+    floor_ptr->o_list[o_idx_list_.back()].stack_idx = 1;
 }

--- a/src/object/object-index-list.cpp
+++ b/src/object/object-index-list.cpp
@@ -1,0 +1,20 @@
+﻿#include "object/object-index-list.h"
+
+void ObjectIndexList::add(OBJECT_IDX o_idx)
+{
+    o_idx_list_.push_front(o_idx);
+}
+
+void ObjectIndexList::remove(OBJECT_IDX o_idx)
+{
+    o_idx_list_.remove(o_idx);
+}
+
+void ObjectIndexList::rotate()
+{
+    if (o_idx_list_.size() < 2)
+        return;
+
+    o_idx_list_.push_back(o_idx_list_.front());
+    o_idx_list_.pop_front();
+}

--- a/src/object/object-index-list.h
+++ b/src/object/object-index-list.h
@@ -1,0 +1,78 @@
+﻿#pragma once
+
+#include "system/angband.h"
+
+#include <list>
+
+/**
+ * @brief アイテムリスト(床上スタック/モンスター所持)を管理するクラス
+ */
+class ObjectIndexList {
+public:
+    /**
+     * @brief デフォルトコンストラクタ
+     */
+    ObjectIndexList() = default;
+
+    /**
+     * @brief アイテムリストにフロア全体のアイテム配列上の指定した要素番号のアイテムを追加する
+     *
+     * @param o_idx 追加するアイテムのフロア全体のアイテム配列上の要素番号
+     */
+    void add(OBJECT_IDX o_idx);
+
+    /**
+     * @brief アイテムリストからフロア全体のアイテム配列上の指定した要素番号のアイテムを削除する
+     *
+     * @param o_idx 削除するアイテムのフロア全体のアイテム配列上の要素番号
+     */
+    void remove(OBJECT_IDX o_idx);
+
+    /**
+     * @brief アイテムリストの先頭のアイテムを最後尾に移動させる
+     */
+    void rotate();
+
+    //
+    // 以下のメソッドは内部で保持している std::list オブジェクトに対して使用できる同名のメソッド
+    //
+    auto empty() const noexcept
+    {
+        return o_idx_list_.empty();
+    }
+    auto size() const noexcept
+    {
+        return o_idx_list_.size();
+    }
+    void clear() noexcept
+    {
+        o_idx_list_.clear();
+    }
+    auto &front() noexcept
+    {
+        return o_idx_list_.front();
+    }
+    void pop_front() noexcept
+    {
+        return o_idx_list_.pop_front();
+    }
+    auto begin() noexcept
+    {
+        return o_idx_list_.begin();
+    }
+    auto end() noexcept
+    {
+        return o_idx_list_.end();
+    }
+    auto begin() const noexcept
+    {
+        return o_idx_list_.begin();
+    }
+    auto end() const noexcept
+    {
+        return o_idx_list_.end();
+    }
+
+private:
+    std::list<OBJECT_IDX> o_idx_list_;
+};

--- a/src/object/object-index-list.h
+++ b/src/object/object-index-list.h
@@ -4,8 +4,12 @@
 
 #include <list>
 
+struct floor_type;
+
 /**
  * @brief アイテムリスト(床上スタック/モンスター所持)を管理するクラス
+ *
+ * @details object_type 自体を保持するのではなく、フロア全体の object_type 配列上のアイテムの要素番号を保持する
  */
 class ObjectIndexList {
 public:
@@ -17,9 +21,18 @@ public:
     /**
      * @brief アイテムリストにフロア全体のアイテム配列上の指定した要素番号のアイテムを追加する
      *
+     * @details
+     * stack_idx が非負数の場合、アイテムリストの stack_idx で指定した位置に追加する。
+     * (リストに含まれるアイテムの stack_idx は降順で並んでいるものと想定し、その順序を崩さない位置に追加する)
+     *
+     * stack_idx が0または負数の場合、アイテムリストの先頭に追加する。
+     * また、追加したアイテムの stack_idx を追加前のアイテムリストの先頭のアイテムの stack_idx + 1 にする。
+     *
+     * @param floor_ptr 追加するアイテムが存在するフロアへのポインタ
      * @param o_idx 追加するアイテムのフロア全体のアイテム配列上の要素番号
+     * @param stack_idx アイテムリストに追加する位置(デフォルト:0)
      */
-    void add(OBJECT_IDX o_idx);
+    void add(floor_type *floor_ptr, OBJECT_IDX o_idx, IDX stack_idx = 0);
 
     /**
      * @brief アイテムリストからフロア全体のアイテム配列上の指定した要素番号のアイテムを削除する
@@ -30,8 +43,13 @@ public:
 
     /**
      * @brief アイテムリストの先頭のアイテムを最後尾に移動させる
+     *
+     * @details
+     * アイテムリストに含まれる各アイテムの stack_idx の降順を崩さないようにするため、
+     * 先頭のアイテムを最後尾に移動した後各アイテムの stack_idx は1ずつインクリメントされ、
+     * 最後尾に移動したアイテムの stack_idx は 1 になる。
      */
-    void rotate();
+    void rotate(floor_type *floor_ptr);
 
     //
     // 以下のメソッドは内部で保持している std::list オブジェクトに対して使用できる同名のメソッド

--- a/src/save/item-writer.cpp
+++ b/src/save/item-writer.cpp
@@ -94,6 +94,9 @@ static void write_item_flags(object_type *o_ptr, BIT_FLAGS *flags)
     if (o_ptr->art_name)
         *flags |= SAVE_ITEM_ART_NAME;
 
+    if (o_ptr->stack_idx)
+        *flags |= SAVE_ITEM_STACK_IDX;
+
     wr_u32b(*flags);
 }
 
@@ -171,6 +174,9 @@ static void write_item_info(object_type *o_ptr, const BIT_FLAGS flags)
 
     if (flags & SAVE_ITEM_FEELING)
         wr_byte(o_ptr->feeling);
+
+    if (flags & SAVE_ITEM_STACK_IDX)
+        wr_s16b(o_ptr->stack_idx);
 }
 
 /*!

--- a/src/spell-kind/spells-fetcher.cpp
+++ b/src/spell-kind/spells-fetcher.cpp
@@ -99,7 +99,7 @@ void fetch_item(player_type *caster_ptr, DIRECTION dir, WEIGHT wgt, bool require
 
     OBJECT_IDX i = g_ptr->o_idx_list.front();
     g_ptr->o_idx_list.pop_front();
-    caster_ptr->current_floor_ptr->grid_array[caster_ptr->y][caster_ptr->x].o_idx_list.push_front(i); /* 'move' it */
+    caster_ptr->current_floor_ptr->grid_array[caster_ptr->y][caster_ptr->x].o_idx_list.add(i); /* 'move' it */
 
     o_ptr->iy = caster_ptr->y;
     o_ptr->ix = caster_ptr->x;

--- a/src/spell-kind/spells-fetcher.cpp
+++ b/src/spell-kind/spells-fetcher.cpp
@@ -99,7 +99,7 @@ void fetch_item(player_type *caster_ptr, DIRECTION dir, WEIGHT wgt, bool require
 
     OBJECT_IDX i = g_ptr->o_idx_list.front();
     g_ptr->o_idx_list.pop_front();
-    caster_ptr->current_floor_ptr->grid_array[caster_ptr->y][caster_ptr->x].o_idx_list.add(i); /* 'move' it */
+    caster_ptr->current_floor_ptr->grid_array[caster_ptr->y][caster_ptr->x].o_idx_list.add(caster_ptr->current_floor_ptr, i); /* 'move' it */
 
     o_ptr->iy = caster_ptr->y;
     o_ptr->ix = caster_ptr->x;

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -2,10 +2,12 @@
 #include <algorithm>
 #include <array>
 #include <bitset>
-#include <iterator>
 #include <functional>
+#include <iterator>
+#include <list>
 #include <map>
 #include <memory>
+#include <optional>
 #include <queue>
 #include <sstream>
 #include <stack>

--- a/src/system/monster-type-definition.h
+++ b/src/system/monster-type-definition.h
@@ -3,9 +3,8 @@
 #include "monster/monster-flag-types.h"
 #include "monster/monster-timed-effect-types.h"
 #include "monster/smart-learn-types.h"
+#include "object/object-index-list.h"
 #include "util/flag-group.h"
-
-#include <list>
 
 /*!
  * @brief Monster information, for a specific monster.
@@ -40,7 +39,7 @@ typedef struct monster_type {
 	EnumClassFlagGroup<MFLAG> mflag{};	/*!< モンスター個体に与えられた特殊フラグ1 (セーブ不要) / Extra monster flags */
 	EnumClassFlagGroup<MFLAG2> mflag2{};	/*!< モンスター個体に与えられた特殊フラグ2 (セーブ必要) / Extra monster flags */
 	bool ml{};		/*!< モンスターがプレイヤーにとって視認できるか(処理のためのテンポラリ変数) Monster is "visible" */
-	std::list<OBJECT_IDX> hold_o_idx_list{};	/*!< モンスターが所持しているアイテムのリスト / Object list being held (if any) */
+	ObjectIndexList hold_o_idx_list{};	/*!< モンスターが所持しているアイテムのリスト / Object list being held (if any) */
 	POSITION target_y{};		/*!< モンスターの攻撃目標対象Y座標 / Can attack !los player */
 	POSITION target_x{};		/*!< モンスターの攻撃目標対象X座標 /  Can attack !los player */
 	STR_OFFSET nickname{};	/*!< ペットに与えられた名前の保存先文字列オフセット Monster's Nickname */

--- a/src/system/object-type-definition.h
+++ b/src/system/object-type-definition.h
@@ -16,6 +16,7 @@ typedef struct object_type {
     KIND_OBJECT_IDX k_idx; /* Kind index (zero if "dead") */
     POSITION iy; /* Y-position on map, or zero */
     POSITION ix; /* X-position on map, or zero */
+    IDX stack_idx; /*!< このアイテムを含むアイテムリスト内の位置(降順) */
     tval_type tval; /* Item type (from kind) */
 
     OBJECT_SUBTYPE_VALUE sval; /* Item sub-type (from kind) */

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -351,14 +351,10 @@ static char describe_footing_many_items(player_type *subject_ptr, eg_type *eg_pt
         if (eg_ptr->query != '\n' && eg_ptr->query != '\r')
             return eg_ptr->query;
 
-        OBJECT_IDX o_idx = 0;
-        if (!eg_ptr->g_ptr->o_idx_list.empty())
-            o_idx = eg_ptr->g_ptr->o_idx_list.front();
         if (eg_ptr->g_ptr->o_idx_list.size() < 2)
             continue;
 
-        eg_ptr->g_ptr->o_idx_list.pop_front();
-        eg_ptr->g_ptr->o_idx_list.push_back(o_idx);
+        eg_ptr->g_ptr->o_idx_list.rotate();
     }
 }
 

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -354,7 +354,7 @@ static char describe_footing_many_items(player_type *subject_ptr, eg_type *eg_pt
         if (eg_ptr->g_ptr->o_idx_list.size() < 2)
             continue;
 
-        eg_ptr->g_ptr->o_idx_list.rotate();
+        eg_ptr->g_ptr->o_idx_list.rotate(subject_ptr->current_floor_ptr);
     }
 }
 

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -37,6 +37,7 @@
 #include "view/display-lore.h"
 #include "view/display-messages.h"
 #include "view/display-monster-status.h"
+#include "window/display-sub-windows.h"
 #include "world/world.h"
 #ifdef JP
 #else
@@ -355,6 +356,9 @@ static char describe_footing_many_items(player_type *subject_ptr, eg_type *eg_pt
             continue;
 
         eg_ptr->g_ptr->o_idx_list.rotate(subject_ptr->current_floor_ptr);
+
+        // ターゲットしている床の座標を渡す必要があるので、window_stuff経由ではなく直接呼び出す
+        fix_floor_item_list(subject_ptr, eg_ptr->y, eg_ptr->x);
     }
 }
 


### PR DESCRIPTION
## ⚠️注意 
セーブファイルのバージョンは上がりませんが、アイテムセーブフラグ `SAVE_ITEM_STACK_IDX` を新たに導入しているので過去のセーブファイルとの互換性はなくなります

----

object_type にアイテムリスト中の位置を記録するメンバ stack_idx
を設け、セーブファイルに記録するようにする事でセーブ/ロードを
行っても床上のアイテムリストの順序が変化しないようにする。
