### PR TITLE
[Fix] 力の杖のレアリティ設定のtypoを修正

### DIFF
--- a/lib/edit/k_info.txt
+++ b/lib/edit/k_info.txt
@@ -3476,7 +3476,7 @@ E:Power:Walnut
 G:_:u
 I:55:25:5
 W:70:0:50:4000
-A:50/4:60:4:70/2
+A:50/4:60/4:70/2
 P:0:1d2:0:0:0
 D:$It does 150 damage to all monsters in sight when you use it.
 D:それは使うと視界内のモンスターに150のダメージを与える。
@@ -6420,7 +6420,7 @@ N:672:魔法を防ぐクローク
 E:& Cloak~ of Magic Resistance
 G:(:s
 I:35:4:0
-W:1:0:10:2500
+W:20:0:10:2500
 A:20/4:50/4
 P:1:0d0:0:0:0
 F:RES_CURSE


### PR DESCRIPTION
合わせて魔法を防ぐクロークのアイテムレベルを修正。

前回レビューでobject-desc.txtを出力したにもかかわらず見逃していた。
レア度が60/+100、4/+100されてしまうので修正。
Issueなし。