### PR TITLE
[Fix] Cコマンドで永久光源欄の@列に . を表示し忘れている

### DIFF
--- a/src/view/display-characteristic.cpp
+++ b/src/view/display-characteristic.cpp
@@ -188,6 +188,8 @@ static void process_light_equipment_characteristics(player_type *creature_ptr, a
             return;
         }
     }
+
+    char_stat.syms.emplace_back(".");
 }
 
 /*!


### PR DESCRIPTION
軽微につきIssueなし。
![20210503](https://user-images.githubusercontent.com/3948323/116819840-e040cd80-abac-11eb-9e5b-3645ad252d79.png)
