### PR TITLE
[Fix] ウィザードモードでのpval99999入力ハングの修正

### DIFF
--- a/src/flavor/flavor-util.cpp
+++ b/src/flavor/flavor-util.cpp
@@ -74,24 +74,18 @@ char *object_desc_str(char *t, concptr s)
  * @param t 保管先文字列ポインタ
  * @param n コピーしたい数値
  * @details
- * Print an unsigned number "n" into a string "t", as if by
+ * Print an unsigned number "n" into a string "t", actually by
  * sprintf(t, "%u", n), and return a pointer to the terminator.
  */
 char *object_desc_num(char *t, uint n)
 {
-    /* loop */
-    uint p;
-    for (p = 1; n >= p * 10; p = p * 10)
-        ;
-
-    while (p >= 1) {
-        *t++ = '0' + n / p;
-        n = n % p;
-        p = p / 10;
+    int ret = sprintf(t, "%u", n);
+    if (ret < 0) {
+        // error
+        ret = 0;
+        *t = '\0';
     }
-
-    *t = '\0';
-    return t;
+    return t + ret;
 }
 
 /*!

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -45,6 +45,7 @@
 #include "util/int-char-converter.h"
 #include "wizard/wizard-special-process.h"
 #include "world/world.h"
+#include <algorithm>
 #include <sstream>
 #include <vector>
 
@@ -85,6 +86,17 @@ void display_wizard_sub_menu()
         put_str(ss.str().c_str(), r++, c);
     }
 }
+}
+
+/*!
+ * @brief キャスト先の型の最小値、最大値でclampする。
+ */
+template <typename T>
+T clamp_cast(int val)
+{
+    return static_cast<T>(std::clamp(val,
+        static_cast<int>(std::numeric_limits<T>::min()),
+        static_cast<int>(std::numeric_limits<T>::max())));
 }
 
 void wiz_restore_aware_flag_of_fixed_arfifact(ARTIFACT_IDX a_idx, bool aware = false);
@@ -573,28 +585,28 @@ static void wiz_tweak_item(player_type *player_ptr, object_type *o_ptr)
     if (!get_string(p, tmp_val, 5))
         return;
 
-    o_ptr->pval = (s16b)atoi(tmp_val);
+    o_ptr->pval = clamp_cast<s16b>(atoi(tmp_val));
     wiz_display_item(player_ptr, o_ptr);
     p = "Enter new 'to_a' setting: ";
     sprintf(tmp_val, "%d", o_ptr->to_a);
     if (!get_string(p, tmp_val, 5))
         return;
 
-    o_ptr->to_a = (s16b)atoi(tmp_val);
+    o_ptr->to_a = clamp_cast<s16b>(atoi(tmp_val));
     wiz_display_item(player_ptr, o_ptr);
     p = "Enter new 'to_h' setting: ";
     sprintf(tmp_val, "%d", o_ptr->to_h);
     if (!get_string(p, tmp_val, 5))
         return;
 
-    o_ptr->to_h = (s16b)atoi(tmp_val);
+    o_ptr->to_h = clamp_cast<s16b>(atoi(tmp_val));
     wiz_display_item(player_ptr, o_ptr);
     p = "Enter new 'to_d' setting: ";
     sprintf(tmp_val, "%d", (int)o_ptr->to_d);
     if (!get_string(p, tmp_val, 5))
         return;
 
-    o_ptr->to_d = (s16b)atoi(tmp_val);
+    o_ptr->to_d = clamp_cast<s16b>(atoi(tmp_val));
     wiz_display_item(player_ptr, o_ptr);
 }
 


### PR DESCRIPTION
- sprintf風にuintの値を文字列に変換するobject_desc_num関数で、値によっては無限ループ？に陥る問題を修正した。
- pval値は符号付16ビットなので、入力値がこの範囲を超えないように制限する。
最大値より大きい入力は最大値、最小値より小さい値は最小値で受け取るようにした。