### PR TITLE
[Fix] メッセージ履歴が正しく保存されない

### DIFF
--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -101,7 +101,7 @@ static bool wr_savefile_new(player_type *player_ptr, save_type type)
 
     wr_u32b(tmp32u);
     for (int i = tmp32u - 1; i >= 0; i--)
-        wr_string(message_str((s16b)i));
+        wr_string(message_str(i));
 
     u16b tmp16u = max_r_idx;
     wr_u16b(tmp16u);


### PR DESCRIPTION
不要なキャストにより32768件目以降のメッセージ履歴にアクセス
できておらず、結果として32767件までしかメッセージ履歴が保存
されない。
(MESSAGE_MAX が 81920件なので、65536件目以降は再び(0件目
からのメッセージが)保存されるようになるが、現状のメッセージ
履歴処理関数の仕様ではこの件数を超えることはまずあり得ない)
意図したものとは思えないのでキャストを取り除く。