### PR TITLE
[Fix] mutation-flag-types.h のインクルード関係

### DIFF
--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -1,5 +1,6 @@
 ﻿#pragma once
 
+#include "mutation/mutation-flag-types.h"
 #include "player-ability/player-ability-types.h"
 #include "player/player-race-types.h"
 #include "player/player-class-types.h"
@@ -11,7 +12,6 @@
 #define MAX_SKILLS 10
 #define MAX_MANE 16
 
-enum class MUTA;
 enum class RF_ABILITY;
 
 typedef struct floor_type floor_type;

--- a/src/util/flag-group.h
+++ b/src/util/flag-group.h
@@ -2,8 +2,6 @@
 
 #include <bitset>
 
-#include "mutation/mutation-flag-types.h"
-
 /**
  * @brief フラグ集合を扱う、FlagGroupクラス
  *


### PR DESCRIPTION
e3d1038fa79f9c612575e800db357f1d8f11d482 でインクルード
関係の修正が行われているが、flag-group.h で
mutation-flag-types.h をインクルードするのは明らかに変なので
player-type-definition.h へ移動する。

軽微な修正につき Issue 無し。