### PR TITLE
[Fix] 地形等のシンボルが常に初期化される問題の修正

### DIFF
--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -797,13 +797,16 @@ static errr term_xtra_win_react(player_type *player_ptr)
 {
     refresh_color_table();
 
-    const byte old_graphics = arg_graphics;
-    arg_graphics = static_cast<byte>(graphic.change_graphics(static_cast<graphics_mode>(arg_graphics)));
-    if (old_graphics != arg_graphics) {
-        plog(_("グラフィックスを初期化できません!", "Cannot initialize graphics!"));
+    const byte current_mode = static_cast<byte>(graphic.get_mode());
+    if (current_mode != arg_graphics) {
+        const byte old_graphics = arg_graphics;
+        arg_graphics = static_cast<byte>(graphic.change_graphics(static_cast<graphics_mode>(arg_graphics)));
+        if (old_graphics != arg_graphics) {
+            plog(_("グラフィクスを初期化できません!", "Cannot initialize graphics!"));
+        }
+        use_graphics = (arg_graphics > 0);
+        reset_visuals(player_ptr);
     }
-    use_graphics = (arg_graphics > 0);
-    reset_visuals(player_ptr);
 
     for (int i = 0; i < MAX_TERM_DATA; i++) {
         term_type *old = Term;

--- a/src/main-win/graphics-win.cpp
+++ b/src/main-win/graphics-win.cpp
@@ -152,6 +152,11 @@ graphics_mode change_graphics(graphics_mode arg)
 }
 }
 
+graphics_mode Graphics::get_mode(void)
+{
+    return current_graphics_mode;
+}
+
 graphics_mode Graphics::change_graphics(graphics_mode arg)
 {
     return Impl::change_graphics(arg);

--- a/src/main-win/graphics-win.h
+++ b/src/main-win/graphics-win.h
@@ -52,11 +52,17 @@ struct tile_info {
 };
 
 /*!
- * @brief グラフィックスのモード、タイル情報管理
+ * @brief グラフィクスのモード、タイル情報管理
  */
 class Graphics {
 public:
-    Graphics() {}
+    Graphics() = default;
+
+    /*!
+     * @brief 現在のモードを取得する
+     * @return 現在のモード
+     */
+    graphics_mode get_mode(void);
 
     /*!
      * @brief 指定モードのタイルに変更する / Change graphics (tile)


### PR DESCRIPTION
#936 のエンバグ。
reset_visuals関数（表示シンボルの初期化）はタイル表示時のみ呼び出す（以前のバージョンからの動作）ように修正した。
また、グラフィクス/グラフィックスの表記ゆれをメニューに合わせて「グラフィクス」に統一した。