### PR TITLE
[Fix] 祝福による魔法防御上昇の誤り #1047

### DIFF
--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -1156,7 +1156,7 @@ static ACTION_SKILL_POWER calc_saving_throw(player_type *creature_ptr)
     if (has_resist_curse(creature_ptr))
         pow += 30;
 
-    if (creature_ptr->blessed)
+    if (creature_ptr->bless_blade)
         pow += 6 + (creature_ptr->lev - 1) / 10;
 
     pow += adj_wis_sav[creature_ptr->stat_index[A_WIS]];


### PR DESCRIPTION
参照するメンバ名がbless_bladeではなくblessedになっており
祝福された装備をしている時でなく一時的効果の祝福時に
魔法防御が上昇している。
本来の効果であるbless_bladeに修正する。