### PR TITLE
[Fix] Windows版でウインドウサイズ変更時に端の描画が残らないように修正

### DIFF
--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -864,10 +864,7 @@ static errr term_xtra_win_clear(void)
     term_data *td = (term_data *)(Term->data);
 
     RECT rc;
-    rc.left = td->size_ow1;
-    rc.right = rc.left + td->cols * td->tile_wid;
-    rc.top = td->size_oh1;
-    rc.bottom = rc.top + td->rows * td->tile_hgt;
+    GetClientRect(td->w, &rc);
 
     HDC hdc = GetDC(td->w);
     SetBkColor(hdc, RGB(0, 0, 0));
@@ -2279,8 +2276,8 @@ LRESULT PASCAL AngbandWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam
         }
         case SIZE_MAXIMIZED:
         case SIZE_RESTORED: {
-            TERM_LEN cols = (LOWORD(lParam) - td->size_ow1) / td->tile_wid;
-            TERM_LEN rows = (HIWORD(lParam) - td->size_oh1) / td->tile_hgt;
+            TERM_LEN cols = (LOWORD(lParam) - td->size_ow1 - td->size_ow2) / td->tile_wid;
+            TERM_LEN rows = (HIWORD(lParam) - td->size_oh1 - td->size_oh2) / td->tile_hgt;
             if ((td->cols != cols) || (td->rows != rows)) {
                 td->cols = cols;
                 td->rows = rows;
@@ -2393,8 +2390,8 @@ LRESULT PASCAL AngbandListProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPara
 
         td->size_hack = TRUE;
 
-        TERM_LEN cols = (LOWORD(lParam) - td->size_ow1) / td->tile_wid;
-        TERM_LEN rows = (HIWORD(lParam) - td->size_oh1) / td->tile_hgt;
+        TERM_LEN cols = (LOWORD(lParam) - td->size_ow1 - td->size_ow2) / td->tile_wid;
+        TERM_LEN rows = (HIWORD(lParam) - td->size_oh1 - td->size_oh2) / td->tile_hgt;
         if ((td->cols != cols) || (td->rows != rows)) {
             term_type *old_term = Term;
             td->cols = cols;


### PR DESCRIPTION
#966 の背景ブラシ省略によりクリア範囲がマージン分（上下左右各2ピクセル）狭くなり、ウインドウサイズ変更時に描画ゴミが出たりウインドウの外観が以前と異なっていた。

背景ブラシと同様の範囲（クライアント領域全体）をクリアするように修正した。
また、ウインドウサイズ変更時の行/列サイズ算出を修正した。TOP, LEFTのマージンだけでなくRIGHT, BOTTOMのマージンも考慮するように修正した。

Alpha21で発生する描画ゴミ
![before](https://user-images.githubusercontent.com/3318603/117237275-8e769c80-ae65-11eb-9dd1-430a83099030.png)

Alpha21でウインドウ端が黒くならない
![alpha21](https://user-images.githubusercontent.com/3318603/117237366-c8e03980-ae65-11eb-8f01-4d8a447d91fc.png)
