### PR TITLE
[Fix] 壁抜け対策のMFLAG2::NOFLOWが機能していない

### DIFF
--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -567,7 +567,7 @@ void sweep_monster_process(player_type *target_ptr)
         process_monster(target_ptr, i);
         reset_target(m_ptr);
         if (target_ptr->no_flowed && one_in_(3))
-            m_ptr->mflag2.has(MFLAG2::NOFLOW);
+            m_ptr->mflag2.set(MFLAG2::NOFLOW);
 
         if (!target_ptr->playing || target_ptr->is_dead || target_ptr->leaving)
             return;


### PR DESCRIPTION
該当のフラグをsetするべきところでsetされていない。
そのため、壁抜け@に対する変則ピラーダンス封じが機能していない。
以前と同様にフラグをsetすることで正常な挙動に戻す。