### PR TITLE
[Fix] Mac版Clangで display-messages.cpp のコンパイルエラー

### DIFF
--- a/src/view/display-messages.cpp
+++ b/src/view/display-messages.cpp
@@ -56,7 +56,7 @@ msg_sp make_message(T &&str)
 
     // 新たにメッセージを保持する msg_sp オブジェクトを生成し、検索用mapオブジェクトにも追加する
     auto new_msg = msg_sp(new std::string(std::forward<T>(str)), std::move(deleter));
-    message_map.emplace(new_msg.get(), std::weak_ptr(new_msg));
+    message_map.emplace(new_msg.get(), msg_wp(new_msg));
 
     return new_msg;
 }


### PR DESCRIPTION
軽微につき Issue なし。

std::weak_ptr のコンストラクタで型推論ができずにコンパイルエラーと
なるようなので、明示的に型を与えるようにする。