### PR TITLE
[Fix] Windows版ファイル選択ダイアログでファイル名初期値が常に未設定

### DIFF
--- a/src/main-win/main-win-utils.cpp
+++ b/src/main-win/main-win-utils.cpp
@@ -82,6 +82,7 @@ void open_dir_in_explorer(char *filename)
 bool get_open_filename(OPENFILENAMEW *ofn, concptr dirname, char *filename, DWORD max_name_size)
 {
     std::vector<WCHAR> buf(max_name_size);
+    wcscpy(&buf[0], to_wchar(filename).wc_str());
     to_wchar wc_dir(dirname);
 
     // Overwrite struct data


### PR DESCRIPTION
セーブファイルを開くとき、 #1023 のエンバグでファイル名が設定されなくなっている。
以前と同様にファイル名の初期値を設定するようにした。