### PR TITLE
[Fix] r_info.txtのモンスターの呪文フラグで書式によってうまく読めない #1091

### DIFF
--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -235,7 +235,7 @@ errr parse_r_info(std::string_view buf, angband_header *head)
                 RARITY i;
                 info_set_value(i, s_tokens[2]);
                 r_ptr->freq_spell = 100 / i;
-                return PARSE_ERROR_NONE;
+                continue;
             }
 
             if (!grab_one_spell_flag(r_ptr, f))


### PR DESCRIPTION
#909のエンバグ。
これまで呪文確率の1_IN_Xはそれのみで1行に書かれていたため問題なかったが、最新の追加モンスターでは同じ行に呪文種別のフラグも記載されたため顕在化。