### PR TITLE
[English] In angband_fgets() replace nonprintables with '?' rather than strip them

### DIFF
--- a/src/util/angband-files.cpp
+++ b/src/util/angband-files.cpp
@@ -236,7 +236,7 @@ FILE *angband_fopen_temp(char *buf, int max)
  *
  * Read a string, without a newline, to a file
  *
- * Process tabs, strip internal non-printables
+ * Process tabs, replace internal non-printables with '?'
  */
 errr angband_fgets(FILE *fff, char *buf, huge n)
 {
@@ -281,6 +281,10 @@ errr angband_fgets(FILE *fff, char *buf, huge n)
 #endif
             else if (isprint((unsigned char)*s)) {
                 buf[i++] = *s;
+                if (i >= n)
+                    break;
+            } else {
+                buf[i++] = '?';
                 if (i >= n)
                     break;
             }


### PR DESCRIPTION
Without that, the changes to kind-reader.cpp in https://github.com/hengband/hengband/commit/8c1ee0d91accd2d33b46ad0756a832ae71ef4c0d cause the English version to bail out at line 117 of k_info.txt (the Japanese characters in that line are all ignored by the current version of angband_fgets() leaving an empty string that triggers a parsing error in kind-reader.cpp).