### PR TITLE
[Fix] 英語版ビルドエラー修正

### DIFF
--- a/src/main-win/main-win-cfg-reader.cpp
+++ b/src/main-win/main-win-cfg-reader.cpp
@@ -110,8 +110,10 @@ CfgData *CfgReader::read_sections(std::initializer_list<cfg_section> sections)
             GetPrivateProfileStringA(section.section_name, read_key, "", buf, MAIN_WIN_MAX_PATH, this->cfg_path.c_str());
             if (*buf != '\0') {
                 cfg_values *filenames = new cfg_values();
+#ifdef JP
                 // .cfg (UTF-8) to Shift-JIS
                 guess_convert_to_system_encoding(buf, MAIN_WIN_MAX_PATH);
+#endif
                 const int num = tokenize_whitespace(buf, SAMPLE_MAX, tokens);
                 for (int j = 0; j < num; j++) {
                     path_build(path, MAIN_WIN_MAX_PATH, dir, tokens[j]);


### PR DESCRIPTION
英語版ビルド時はguess_convert_to_system_encoding関数を使わないようにした。