### PR TITLE
[Fix] m_info.txt の xtra フラグが正しく読めていない

### DIFF
--- a/src/info-reader/info-reader-util.h
+++ b/src/info-reader/info-reader-util.h
@@ -56,7 +56,7 @@ bool info_grab_one_flag(u32b *flags, const std::unordered_map<sview, T> &names, 
  * @val 値
  */
 template <typename T>
-void info_set_value(T &arg, const std::string &val)
+void info_set_value(T &arg, const std::string &val, int base = 10)
 {
-    arg = static_cast<T>(std::stoi(val));
+    arg = static_cast<T>(std::stoi(val, nullptr, base));
 }

--- a/src/info-reader/magic-reader.cpp
+++ b/src/info-reader/magic-reader.cpp
@@ -75,7 +75,7 @@ errr parse_m_info(std::string_view buf, angband_header *head)
 
         m_ptr->spell_stat = stat->second;
 
-        info_set_value(m_ptr->spell_xtra, tokens[3]);
+        info_set_value(m_ptr->spell_xtra, tokens[3], 16);
         info_set_value(m_ptr->spell_type, tokens[4]);
         info_set_value(m_ptr->spell_first, tokens[5]);
         info_set_value(m_ptr->spell_weight, tokens[6]);


### PR DESCRIPTION
m_info.txt の xtra フラグは 0x05 のような16進数で記述しているが
10進数として std::stoi に渡しているため正しく値が読めず 0 に
なってしまっている。
info_set_value() に基数を指定する引数を追加し、 xtra フラグは
16進数として読むようにする。

#1119 #1120 の原因。
その他に、同様の原因により最低失敗率 5% が反映されていない問題も修正。