### PR TITLE
[Fix] ユーザー操作での.prfファイル読み込みをANGBAND_DIR_USERからに限定する

### DIFF
--- a/src/cmd-io/cmd-dump.cpp
+++ b/src/cmd-io/cmd-dump.cpp
@@ -84,7 +84,7 @@ void do_cmd_colors(player_type *creature_ptr)
             if (!askfor(tmp, 70))
                 continue;
 
-            (void)process_pref_file(creature_ptr, tmp);
+            (void)process_pref_file(creature_ptr, tmp, true);
             term_xtra(TERM_XTRA_REACT, 0);
             term_redraw();
         } else if (i == '2') {

--- a/src/cmd-io/cmd-macro.cpp
+++ b/src/cmd-io/cmd-macro.cpp
@@ -185,7 +185,7 @@ void do_cmd_macros(player_type *creature_ptr)
             if (!askfor(tmp, 80))
                 continue;
 
-            errr err = process_pref_file(creature_ptr, tmp);
+            errr err = process_pref_file(creature_ptr, tmp, true);
             if (-2 == err)
                 msg_format(_("標準の設定ファイル'%s'を読み込みました。", "Loaded default '%s'."), tmp);
             else if (err)

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -101,7 +101,7 @@ void do_cmd_visuals(player_type *creature_ptr)
             if (!askfor(tmp, 70))
                 continue;
 
-            (void)process_pref_file(creature_ptr, tmp);
+            (void)process_pref_file(creature_ptr, tmp, true);
             need_redraw = TRUE;
             break;
         }

--- a/src/io/read-pref-file.cpp
+++ b/src/io/read-pref-file.cpp
@@ -140,6 +140,7 @@ static errr process_pref_file_aux(player_type *creature_ptr, concptr name, int p
  * Process the "user pref file" with the given name
  * @param creature_ptr プレーヤーへの参照ポインタ
  * @param name 読み込むファイル名
+ * @param only_user_dir trueを指定するとANGBAND_DIR_USERからの読み込みのみ行う
  * @return エラーコード
  * @details
  * <pre>
@@ -148,14 +149,17 @@ static errr process_pref_file_aux(player_type *creature_ptr, concptr name, int p
  * allow conditional evaluation and filename inclusion.
  * </pre>
  */
-errr process_pref_file(player_type *creature_ptr, concptr name)
+errr process_pref_file(player_type *creature_ptr, concptr name, bool only_user_dir)
 {
     char buf[1024];
-    path_build(buf, sizeof(buf), ANGBAND_DIR_PREF, name);
+    errr err1 = 0;
+    if (!only_user_dir) {
+        path_build(buf, sizeof(buf), ANGBAND_DIR_PREF, name);
 
-    errr err1 = process_pref_file_aux(creature_ptr, buf, PREF_TYPE_NORMAL);
-    if (err1 > 0)
-        return err1;
+        err1 = process_pref_file_aux(creature_ptr, buf, PREF_TYPE_NORMAL);
+        if (err1 > 0)
+            return err1;
+    }
 
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, name);
     errr err2 = process_pref_file_aux(creature_ptr, buf, PREF_TYPE_NORMAL);

--- a/src/io/read-pref-file.h
+++ b/src/io/read-pref-file.h
@@ -6,7 +6,7 @@ extern char auto_dump_header[];
 extern char auto_dump_footer[];
 
 typedef struct player_type player_type;
-errr process_pref_file(player_type *creature_ptr, concptr name);
+errr process_pref_file(player_type *creature_ptr, concptr name, bool only_user_dir = false);
 errr process_autopick_file(player_type *creature_ptr, concptr name);
 errr process_histpref_file(player_type *creature_ptr, concptr name);
 bool read_histpref(player_type *creature_ptr);


### PR DESCRIPTION
同名ファイルがANGBAND_DIR_PREFに存在する場合に読み込めないため、カラーの設定/マクロの設定/画面表示の設定での「ユーザー設定ファイルのロード」はANGBAND_DIR_USERからに限定する。