### PR TITLE
[Feature] 固定アーティファクト『ドラゴンころし』の追加

### DIFF
--- a/lib/edit/a_info.txt
+++ b/lib/edit/a_info.txt
@@ -4451,3 +4451,14 @@ F:INT | WIS | HIDE_TYPE | INSTA_ART
 F:RES_CURSE | RES_BLIND
 F:TELEPATHY | DEC_MANA | REFLECT | BLESSED
 D:賢者マーリンの魔法の鏡だ。鏡を通じて賢者の助けを得ることができるだろう。
+
+N:266:『ドラゴンころし』
+E:'Dragon slayer'
+I:23:25:0
+W:30:100:500:100000
+F:IMPACT
+P:0:8d8:0:15:10
+D:それは剣というにはあまりにも大きすぎた。
+D:大きく、分厚く、重く、そして大雑把すぎた。
+D:それはまさに鉄塊だった
+

--- a/lib/edit/misc.txt
+++ b/lib/edit/misc.txt
@@ -25,7 +25,7 @@ M:V:173
 M:F:255
 
 # Maximum number of artifacts in a_info.txt
-M:A:266
+M:A:267
 
 # Maximum number of ego-items in e_info.txt
 M:E:255

--- a/lib/edit/t0000001.txt
+++ b/lib/edit/t0000001.txt
@@ -400,10 +400,10 @@ F:@:FLOOR:3:0:0:0:141
 F:a:BUILDING_0:3
 F:@:FLOOR:3:0:0:0:148
 
-# Quest 27 rewarding (Warrior and Berserker get The Glaive of Pain)
+# Quest 27 rewarding (Warrior and Berserker get 'Dragon Slayer')
 ?:[AND [EQU $QUEST27 3] [EQU $CLASS Warrior Berserker] ]
 F:a:BUILDING_0:3
-F:@:FLOOR:3:0:0:0:94
+F:@:FLOOR:3:0:0:0:266
 
 # Quest 27 rewarding (Cavalry gets Don Quixote)
 ?:[AND [EQU $QUEST27 3] [EQU $CLASS Cavalry] ]

--- a/lib/edit/t_lite.txt
+++ b/lib/edit/t_lite.txt
@@ -269,10 +269,10 @@ F:!:FLOOR:3:0:0:0:141
 F:b:BUILDING_1:3:0:0:0:0:NONE:15
 F:!:FLOOR:3:0:0:0:148
 
-# Quest 27 rewarding (Warrior and Berserker get The Glaive of Pain)
+# Quest 27 rewarding (Warrior and Berserker get 'Dragon Slayer')
 ?:[AND [EQU $QUEST27 3] [EQU $CLASS Warrior Berserker] ]
 F:b:BUILDING_1:3:0:0:0:0:NONE:15
-F:!:FLOOR:3:0:0:0:94
+F:!:FLOOR:3:0:0:0:266
 
 # Quest 27 rewarding (Cavalry gets GaeBolg)
 ?:[AND [EQU $QUEST27 3] [EQU $CLASS Cavalry] ]


### PR DESCRIPTION
★苦痛のグレイブ相当の武器として実装し、戦士/狂戦士の古い城報酬にする。