### PR TITLE
[Fix] グラフィクスモードの初期化をTERM_XTRA_REACTに依存せず起動時に行う

### DIFF
--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -788,6 +788,19 @@ static void refresh_color_table()
 }
 
 /*!
+ * @brief グラフィクスのモード変更
+ */
+static void change_graphics_mode(graphics_mode mode)
+{
+    graphics_mode ret = graphic.change_graphics(mode);
+    if (ret != mode) {
+        plog(_("グラフィクスを初期化できません!", "Cannot initialize graphics!"));
+    }
+    arg_graphics = static_cast<byte>(ret);
+    use_graphics = (arg_graphics > 0);
+}
+
+/*!
  * @brief React to global changes
  */
 static errr term_xtra_win_react(player_type *player_ptr)
@@ -796,12 +809,7 @@ static errr term_xtra_win_react(player_type *player_ptr)
 
     const byte current_mode = static_cast<byte>(graphic.get_mode());
     if (current_mode != arg_graphics) {
-        const byte old_graphics = arg_graphics;
-        arg_graphics = static_cast<byte>(graphic.change_graphics(static_cast<graphics_mode>(arg_graphics)));
-        if (old_graphics != arg_graphics) {
-            plog(_("グラフィクスを初期化できません!", "Cannot initialize graphics!"));
-        }
-        use_graphics = (arg_graphics > 0);
+        change_graphics_mode(static_cast<graphics_mode>(arg_graphics));
         reset_visuals(player_ptr);
     }
 
@@ -2670,6 +2678,7 @@ int WINAPI WinMain(
 
     refresh_color_table();
     init_windows();
+    change_graphics_mode(static_cast<graphics_mode>(arg_graphics));
     change_bg_mode(current_bg_mode, true);
 
     // after term_data initialize


### PR DESCRIPTION
TERM_XTRA_REACTでの処理は表示シンボルのリセットを伴うため、起動時にグラフィクスモードの初期化（シンボルリセットなし）を行う。

この変更により、タイル表示で起動の度に表示シンボルがリセットされることがなくなる。