### PR TITLE
[Feature] Windows版の描画にダブルバッファリング導入

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -270,6 +270,7 @@
     <ClCompile Include="..\..\src\core\score-util.cpp" />
     <ClCompile Include="..\..\src\main-win\commandline-win.cpp" />
     <ClCompile Include="..\..\src\main-win\graphics-win.cpp" />
+    <ClCompile Include="..\..\src\main-win\main-win-term.cpp" />
     <ClCompile Include="..\..\src\object-enchant\apply-magic-amulet.cpp" />
     <ClCompile Include="..\..\src\object-enchant\apply-magic-ring.cpp" />
     <ClCompile Include="..\..\src\object\object-index-list.cpp" />
@@ -947,6 +948,7 @@
     <ClInclude Include="..\..\src\dungeon\dungeon-flag-mask.h" />
     <ClInclude Include="..\..\src\main-win\commandline-win.h" />
     <ClInclude Include="..\..\src\main-win\graphics-win.h" />
+    <ClInclude Include="..\..\src\main-win\main-win-term.h" />
     <ClInclude Include="..\..\src\object-enchant\apply-magic-amulet.h" />
     <ClInclude Include="..\..\src\object-enchant\apply-magic-ring.h" />
     <ClInclude Include="..\..\src\object\object-index-list.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2289,6 +2289,9 @@
     <ClCompile Include="..\..\src\object\object-index-list.cpp">
       <Filter>object</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\main-win\main-win-term.cpp">
+      <Filter>main-win</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -4922,6 +4925,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\object\object-index-list.h">
       <Filter>object</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main-win\main-win-term.h">
+      <Filter>main-win</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -936,6 +936,7 @@ EXTRA_hengband_SOURCES = \
 	main-win/main-win-mmsystem.h \
 	main-win/main-win-music.cpp main-win/main-win-music.h \
 	main-win/main-win-sound.cpp main-win/main-win-sound.h \
+	main-win/main-win-term.cpp main-win/main-win-term.h \
 	main-win/main-win-tokenizer.cpp main-win/main-win-tokenizer.h \
 	main-win/main-win-utils.cpp main-win/main-win-utils.h \
 	wall.bmp \

--- a/src/main-win/main-win-term.cpp
+++ b/src/main-win/main-win-term.cpp
@@ -1,0 +1,56 @@
+﻿/*!
+ * @file main-win-term.cpp
+ * @brief Windows版固有実装(ターミナル)
+ */
+
+#include "main-win/main-win-term.h"
+
+/*!
+ * @brief オフスクリーンのデバイスコンテキストを取得する
+ * @param hWnd ウインドウハンドル
+ * @return デバイスコンテキスト
+ */
+HDC double_buffering::get_hdc(HWND hWnd)
+{
+    if (!this->offscreen) {
+        RECT rc;
+        this->display = ::GetDC(hWnd);
+        ::GetClientRect(hWnd, &rc);
+        this->bitmap = ::CreateCompatibleBitmap(this->display, rc.right, rc.bottom);
+        this->offscreen = ::CreateCompatibleDC(this->display);
+        ::SelectObject(this->offscreen, this->bitmap);
+    }
+    return this->offscreen;
+}
+
+/*!
+ * @brief オフスクリーン内容を表示画面に描画する
+ * @param rect 描画範囲
+ * @retval true 描画した
+ * @retval false 描画なし。オフスクリーンが存在しない。
+ */
+bool double_buffering::render(const RECT &rect)
+{
+    if (this->offscreen) {
+        ::BitBlt(this->display, rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top, this->offscreen, rect.left, rect.top, SRCCOPY);
+        return true;
+    } else {
+        return false;
+    }
+}
+
+/*!
+ * @brief オフスクリーンを破棄する。
+ * @details
+ * リサイズ時にはオフスクリーンを破棄して
+ * 呼び出し元で画面の再描画を行う必要がある。
+ */
+void double_buffering::dispose_offscreen()
+{
+    ::DeleteDC(this->offscreen);
+     this->offscreen = NULL;
+    ::DeleteObject(this->bitmap);
+     this->bitmap = NULL;
+    ::DeleteDC(this->display);
+     this->display = NULL;
+}

--- a/src/main-win/main-win-term.h
+++ b/src/main-win/main-win-term.h
@@ -1,0 +1,126 @@
+﻿#pragma once
+/*!
+ * @file main-win-term.h
+ * @brief Windows版固有実装(ターミナル)ヘッダ
+ */
+
+#include "term/z-term.h"
+#include "system/h-type.h"
+
+#include <windows.h>
+
+/*!
+ * @brief ダブルバッファリング
+ */
+class double_buffering {
+public:
+    double_buffering()
+        : display(NULL)
+        , bitmap(NULL)
+        , offscreen(NULL)
+    {
+    }
+
+    HDC get_hdc(HWND);
+    bool render(const RECT &rect);
+    void dispose_offscreen();
+
+protected:
+    HDC display;
+    HBITMAP bitmap;
+    HDC offscreen;
+};
+
+/*!
+ * @struct term_data
+ * @brief ターム情報構造体 / Extra "term" data
+ * @details
+ * <p>
+ * pos_x / pos_y は各タームの左上点座標を指す。
+ * </p>
+ * <p>
+ * tile_wid / tile_hgt は[ウィンドウ]メニューのタイルの幅/高さを～を
+ * 1ドットずつ調整するステータスを指す。
+ * また、フォントを変更すると都度自動調整される。
+ * </p>
+ * <p>
+ * Note the use of "font_want" for the names of the font file requested by
+ * the user.
+ * </p>
+ */
+struct term_data {
+    term_type t{};
+    LPCWSTR name{};
+    HWND w{};
+    DWORD dwStyle{};
+    DWORD dwExStyle{};
+
+    TERM_LEN rows{}; /* int -> uint */
+    TERM_LEN cols{};
+
+    uint pos_x{}; //!< タームの左上X座標
+    uint pos_y{}; //!< タームの左上Y座標
+    uint size_wid{};
+    uint size_hgt{};
+    uint size_ow1{};
+    uint size_oh1{};
+    uint size_ow2{};
+    uint size_oh2{};
+
+    bool size_hack{};
+    bool visible{};
+    concptr font_want{};
+    HFONT font_id{};
+    int font_wid{}; //!< フォント横幅
+    int font_hgt{}; //!< フォント縦幅
+    int tile_wid{}; //!< タイル横幅
+    int tile_hgt{}; //!< タイル縦幅
+
+    LOGFONTW lf{};
+
+    bool posfix{};
+
+    term_data() = default; //!< デフォルトコンストラクタ
+    term_data(const term_data &) = delete; //!< コピー禁止
+    term_data &operator=(term_data &) = delete; //!< 代入演算子禁止
+    term_data &operator=(term_data &&) = default; //!< move代入
+
+    double_buffering graphics{};
+    /*!
+     * @brief オフスクリーンHDC取得
+     * @return HDC
+     */
+    HDC get_hdc()
+    {
+        return graphics.get_hdc(this->w);
+    };
+    /*!
+     * @brief WM_PAINTでの描画が必要になる領域を設定する.
+     * @param lpRect 更新領域。NULLの場合はクライアント領域全体の描画が必要。
+     */
+    void refresh(const RECT *lpRect = NULL)
+    {
+        InvalidateRect(this->w, lpRect, FALSE);
+    };
+    /*!
+     * @brief オフスクリーン内容を表示画面に描画する
+     * @param rect 描画領域
+     * @retval true 描画した
+     * @retval false 描画なし（オフスクリーンが存在しない等）
+     */
+    bool render(const RECT &rect)
+    {
+        return graphics.render(rect);
+    };
+    /*!
+     * @brief オフスクリーンを破棄する
+     * @details
+     * リサイズ時にはオフスクリーンを破棄して
+     * 呼び出し元で画面の再描画を行う必要がある。
+     */
+    void dispose_offscreen()
+    {
+        graphics.dispose_offscreen();
+    };
+};
+


### PR DESCRIPTION
描画はオフスクリーンに対して行い、表示画面への描画回数を減らす。

描画するものがあればオフスクリーンに描画し、InvalidateRectを呼び出しておく。
InvalidateRectはWM_PAINTメッセージを生成するため、
WM_PAINTの処理でオフスクリーンから表示画面へ描画する。

WM_PAINTを待つとタイトル画面の初期化中メッセージは表示されないので
TERM_XTRA_FRESHでUpdateWindowする。
UpdateWindowは即WM_PAINTを処理するAPI。

WM_PAINTがオフスクリーンから描画するだけになるため
再描画の意味でInvalidateRectを使っていたところはterm_redrawに置き換える。
他にはウインドウのリサイズが起きたらオフスクリーンを破棄して再描画する。

ターミナルの行数、列数に変化が無い場合はterm_redraw、
行数、列数が変わる場合はterm_resize（中でterm_redrawされる）を使う。

#980 との違い等は以下の通り。
- 方向性や手法は同じ。描画はオフスクリーンに対して行い、表示画面への描画回数を減らすことで高速化する。
- Windows仕様によりそった処理を行う。InvalidateRectに領域を渡すとOS側でクリッピングした領域をBeginPaintで受け取れるので自前で描画対象領域を処理しなくて良い。WM_EXITSIZEMOVEでウインドウサイズ変更おしまいを受け取れるので、オプションなしにウインドウサイズ変更時には再描画する。
- ターミナルのhookを活用する。TERM_XTRA_FRESHで画面更新すると矢の軌跡も再描画もうまく処理できる。resize_hookは内部で使われているためmain-winから使えない。
- ロジックをダブルバッファリングクラスやメソッドに分割する。