### PR TITLE
[Feature] 射撃命中音の効果音対応

### DIFF
--- a/lib/xtra/sound/sound.cfg
+++ b/lib/xtra/sound/sound.cfg
@@ -49,6 +49,9 @@ teleport =
 # 射撃時
 shoot = 
 
+# 射撃の命中音
+shoot_hit = 
+
 # 薬を飲んだ
 quaff = se_maoudamashii_se_drink01.wav
 

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -617,6 +617,7 @@ void exe_fire(player_type *shooter_ptr, INVENTORY_IDX item, object_type *j_ptr, 
 
             /* Monster here, Try to hit it */
             if (shooter_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+                sound(SOUND_SHOOT_HIT);
                 grid_type *c_mon_ptr = &shooter_ptr->current_floor_ptr->grid_array[y][x];
 
                 monster_type *m_ptr = &shooter_ptr->current_floor_ptr->m_list[c_mon_ptr->m_idx];

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -8,6 +8,8 @@
 #include "hpmp/hp-mp-processor.h"
 #include "inventory/inventory-damage.h"
 #include "inventory/inventory-slot-types.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "mind/mind-mirror-master.h"
 #include "monster-race/race-indice-types.h"
 #include "mutation/mutation-investor-remover.h"
@@ -116,6 +118,7 @@ void effect_player_hell_fire(player_type *target_ptr, effect_player_type *ep_ptr
 void effect_player_arrow(player_type *target_ptr, effect_player_type *ep_ptr)
 {
     if (target_ptr->blind) {
+        sound(SOUND_SHOOT_HIT);
         msg_print(_("何か鋭いもので攻撃された！", "You are hit by something sharp!"));
         ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
         return;
@@ -126,6 +129,7 @@ void effect_player_arrow(player_type *target_ptr, effect_player_type *ep_ptr)
         return;
     }
 
+    sound(SOUND_SHOOT_HIT);
     ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
 

--- a/src/main/sound-definitions-table.cpp
+++ b/src/main/sound-definitions-table.cpp
@@ -16,6 +16,7 @@ const concptr angband_sound_name[SOUND_MAX] = {
     "study",
     "teleport",
     "shoot",
+    "shoot_hit",
     "quaff",
     "zap",
     "walk",

--- a/src/main/sound-definitions-table.h
+++ b/src/main/sound-definitions-table.h
@@ -17,6 +17,7 @@ enum sound_type {
     SOUND_STUDY,
     SOUND_TELEPORT,
     SOUND_SHOOT,
+    SOUND_SHOOT_HIT,
     SOUND_QUAFF,
     SOUND_ZAP,
     SOUND_WALK, /*!< unused */

--- a/src/mspell/mspell-bolt.cpp
+++ b/src/mspell/mspell-bolt.cpp
@@ -31,7 +31,8 @@ MonsterSpellResult spell_RF4_SHOOT(player_type *target_ptr, POSITION y, POSITION
 
     const auto dam = monspell_damage(target_ptr, RF_ABILITY::SHOOT, m_idx, DAM_ROLL);
     const auto proj_res = bolt(target_ptr, m_idx, y, x, GF_ARROW, dam, TARGET_TYPE);
-    sound(SOUND_SHOOT);
+    // FIXME: モンスター射撃は必中のため、命中音のSOUND_SHOOT_HIT再生を優先する
+    //sound(SOUND_SHOOT);
 
     auto res = MonsterSpellResult::make_valid(dam);
     res.learnable = proj_res.affected_player;


### PR DESCRIPTION
~~sound.cfgはコメントを各項目に移動し、射撃命中音のshoot_hit項目を追加した。~~
~~enum sound_typeは順番を入れ替えやすいように明示的に初期化しない（先頭0、以降の項目は+1になる）。~~
Refactor分は #1147 でマージ済み

sound.cfgにshoot_hitの項目を追加した。
プレイヤーの射撃の命中時、モンスターの射撃がプレイヤーに命中時にこの効果音を再生する。