### PR TITLE
[Fix] スナイパーの射撃術を使うとSOUND_SHOOTが不自然に鳴る

### DIFF
--- a/lib/xtra/sound/sound.cfg
+++ b/lib/xtra/sound/sound.cfg
@@ -4,56 +4,6 @@
 # ファイルはスペースで区切って16種類まで指定できます。
 # 複数指定した場合ランダムに選択されます。
 #
-# それぞれ以下の通りに対応しています。
-# hit      プレイヤーの攻撃、モンスターの攻撃（パンチ、キック等の一部の攻撃）
-# miss     プレイヤーの攻撃ミス
-# flee     モンスターが恐怖して逃げ出した
-# drop     アイテムドロップ時
-# kill     生命体モンスターを倒した
-# level    レベルアップ
-# death    プレイヤーの死亡時
-# study    魔法の学習時
-# teleport プレイヤー、モンスターのテレポート
-# shoot    射撃時
-# quaff    薬を飲んだ
-# zap      発動時、杖/ロッド/魔法棒の使用、剣術/超能力/ものまね/青魔法/元素魔法/その他技能の使用
-# tpother  テレポートアウェイ
-# hitwall  壁衝突（行く手に壁がある）
-# eat      食べた
-# store1   店主が悔しげにわめいている（店主が無価値アイテムを買い取った）
-# store2   店主が睨んでいる（店主が実際価格より高く買い取った）
-# store3   店主が大声で笑っている（店主が実際価格より安く買い取った）
-# store4   店主は満面に笑みをたたえている（店主が実際価格よりとても安く買い取った）
-# dig      掘るコマンド実行時
-# opendoor ドアを開けた、ドアの鍵をはずした、体当たりでドアを壊した
-# shutdoor ドアを閉めた
-# tplevel  レベルテレポート、帰還時、現実変容等のフロアリセット
-# scroll   巻物を読んだ
-# buy      お金を支払った
-# sell     お金を得た
-# warn     低ヒットポイント警告
-# n_kill   非生命体モンスターを倒した
-# bite     モンスターに噛まれた
-# claw     モンスターにひっかかれた、斬られた
-# summon   モンスターの召喚
-# breath   ブレス攻撃
-# evil     悪性のオーラに包み込まれた
-# touch    モンスターに触られた
-# sting    モンスターに刺された
-# crush    モンスターに体当たりされた、飲み込まれた
-# slime    モンスターの攻撃（体の上を這い回った、よだれをたらされた、唾を吐かれた、胞子を飛ばされた）
-# wail     モンスターに泣き叫ばれた
-# illegal  コマンドに対応していないキーを押した
-# fail     失敗した
-# fall     落とし戸に落ちた、空中から投げ落とした
-# pain     金的膝蹴りをくらわした
-# destitem アイテムを壊した
-# moan     金をせがまれた、モンスターの侮辱行為、マゴットのぼやき
-# show     モンスターの歌う攻撃
-# explode  爆発
-# glass    ガラス、鏡等が割れた
-# reflect  ボルトの反射
-#
 #
 # sound.cfg
 #
@@ -69,68 +19,192 @@
 # for a complete list of all the available event names.
 
 [Sound]
+# プレイヤーの攻撃、モンスターの攻撃（パンチ、キック等の一部の攻撃）
 hit = sword-slash3-r.wav
-miss = sword-gesture3-r.wav
-flee = sea-lion2-r.wav
-drop = 
-kill = se_maoudamashii_retro22.wav
-level = decision25r.wav
-death = drop1.wav
-study = 
-teleport =
-shoot = 
-quaff = se_maoudamashii_se_drink01.wav
-zap =
-tpother =
-hitwall = se_maoudamashii_battle07.wav
-eat = apple1-r.wav
-store1 = 
-store2 = 
-store3 = 
-store4 = 
-dig = 
-opendoor =
-shutdoor =
-tplevel =
-scroll =
-buy =
-sell =
-warn =
-n_kill =
-bite =
-claw =
-summon = enemy-advent1-r.wav
-breath =
-evil =
-touch =
-sting =
-crush =
-slime =
-wail =
-illegal =
-fail =
-fall =
-pain =
-destitem =
-moan =
-show =
-explode =
-glass =
-reflect = sword-clash1-r.wav
-hungry = 
-weak = 
-faint = 
-good_hit = 
-great_hit = 
-superb_hit = 
-star_great_hit =
-star_superb_hit =
-gouge_hit =
-maim_hit =
-carve_hit =
-cleave_hit =
-smite_hit =
-eviscerate_hit =
-shred_hit =
 
+# プレイヤーの攻撃ミス
+miss = sword-gesture3-r.wav
+
+# モンスターが恐怖して逃げ出した
+flee = sea-lion2-r.wav
+
+# アイテムドロップ時
+drop = 
+
+# 生命体モンスターを倒した
+kill = se_maoudamashii_retro22.wav
+
+# レベルアップ
+level = decision25r.wav
+
+# プレイヤーの死亡時
+death = drop1.wav
+
+# 魔法の学習時
+study = 
+
+# プレイヤー、モンスターのテレポート
+teleport = 
+
+# 射撃時
+shoot = 
+
+# 薬を飲んだ
+quaff = se_maoudamashii_se_drink01.wav
+
+# 発動時、杖/ロッド/魔法棒の使用、剣術/超能力/ものまね/青魔法/元素魔法/その他技能の使用
+zap = 
+
+# テレポートアウェイ
+tpother = 
+
+# 壁衝突（行く手に壁がある）
+hitwall = se_maoudamashii_battle07.wav
+
+# 食べた
+eat = apple1-r.wav
+
+# 店主が悔しげにわめいている（店主が無価値アイテムを買い取った）
+store1 = 
+
+# 店主が睨んでいる（店主が実際価格より高く買い取った）
+store2 = 
+
+# 店主が大声で笑っている（店主が実際価格より安く買い取った）
+store3 = 
+
+# 店主は満面に笑みをたたえている（店主が実際価格よりとても安く買い取った）
+store4 = 
+
+# 掘るコマンド実行時
+dig = 
+
+# ドアを開けた、ドアの鍵をはずした、体当たりでドアを壊した
+opendoor = 
+
+# ドアを閉めた
+shutdoor = 
+
+# レベルテレポート、帰還時、現実変容等のフロアリセット
+tplevel = 
+
+# 巻物を読んだ
+scroll = 
+
+# お金を支払った
+buy = 
+
+# お金を得た
+sell = 
+
+# 低ヒットポイント警告
+warn = 
+
+# 非生命体モンスターを倒した
+n_kill = 
+
+# モンスターに噛まれた
+bite = 
+
+# モンスターにひっかかれた、斬られた
+claw = 
+
+# モンスターの召喚
+summon = enemy-advent1-r.wav
+
+# ブレス攻撃
+breath = 
+
+# 悪性のオーラに包み込まれた
+evil = 
+
+# モンスターに触られた
+touch = 
+
+# モンスターに刺された
+sting = 
+
+# モンスターに体当たりされた、飲み込まれた
+crush = 
+
+# モンスターの攻撃（体の上を這い回った、よだれをたらされた、唾を吐かれた、胞子を飛ばされた）
+slime = 
+
+# モンスターに泣き叫ばれた
+wail = 
+
+# コマンドに対応していないキーを押した
+illegal = 
+
+# 失敗した
+fail = 
+
+# 落とし戸に落ちた、空中から投げ落とした
+fall = 
+
+# 金的膝蹴りをくらわした
+pain = 
+
+# アイテムを壊した
+destitem = 
+
+# 金をせがまれた、モンスターの侮辱行為、マゴットのぼやき
+moan = 
+
+# モンスターの歌う攻撃
+show = 
+
+# 爆発
+explode = 
+
+# ガラス、鏡等が割れた
+glass = 
+
+# ボルトの反射
+reflect = sword-clash1-r.wav
+
+# 空腹 お腹が空いてきた
+hungry = 
+
+# 空腹 お腹が空いて倒れそうだ
+weak = 
+
+# 空腹 あまりにも空腹で気を失ってしまった
+faint = 
+
+# クリティカル 強度1 手ごたえがあった
+good_hit = 
+
+# クリティカル 強度2 かなりの手ごたえがあった
+great_hit = 
+
+# クリティカル 強度3 会心の一撃だ
+superb_hit = 
+
+# クリティカル 強度4 最高の会心の一撃だ
+star_great_hit = 
+
+# クリティカル 強度5 比類なき最高の会心の一撃だ
+star_superb_hit = 
+
+# ヴォーパル 倍率2 斬った
+gouge_hit = 
+
+# ヴォーパル 倍率3 ぶった斬った
+maim_hit = 
+
+# ヴォーパル 倍率4 メッタ斬りにした
+carve_hit = 
+
+# ヴォーパル 倍率5 メッタメタに斬った
+cleave_hit = 
+
+# ヴォーパル 倍率6 刺身にした
+smite_hit = 
+
+# ヴォーパル 倍率7 斬って斬って斬りまくった
+eviscerate_hit = 
+
+# ヴォーパル 倍率1 細切れにした
+shred_hit = 
 

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -469,6 +469,9 @@ void exe_fire(player_type *shooter_ptr, INVENTORY_IDX item, object_type *j_ptr, 
         return;
     }
 
+    if (snipe_type != SP_NONE)
+        sound(SOUND_ZAP);
+
     /* Predict the "target" location */
     tx = shooter_ptr->x + 99 * ddx[dir];
     ty = shooter_ptr->y + 99 * ddy[dir];

--- a/src/main/sound-definitions-table.cpp
+++ b/src/main/sound-definitions-table.cpp
@@ -6,7 +6,6 @@
 #include "main/sound-definitions-table.h"
 
 const concptr angband_sound_name[SOUND_MAX] = {
-    "dummy",
     "hit",
     "miss",
     "flee",
@@ -87,5 +86,5 @@ const concptr angband_sound_name[SOUND_MAX] = {
     "cleave_hit",
     "smite_hit",
     "eviscerate_hit",
-    "shred_hit ",
+    "shred_hit",
 };

--- a/src/main/sound-definitions-table.h
+++ b/src/main/sound-definitions-table.h
@@ -7,88 +7,88 @@
 #include "system/angband.h"
 
 enum sound_type {
-    SOUND_HIT = 1,
-    SOUND_MISS = 2,
-    SOUND_FLEE = 3,
-    SOUND_DROP = 4,
-    SOUND_KILL = 5,
-    SOUND_LEVEL = 6,
-    SOUND_DEATH = 7,
-    SOUND_STUDY = 8,
-    SOUND_TELEPORT = 9,
-    SOUND_SHOOT = 10,
-    SOUND_QUAFF = 11,
-    SOUND_ZAP = 12,
-    SOUND_WALK = 13, /*!< unused */
-    SOUND_TPOTHER = 14,
-    SOUND_HITWALL = 15,
-    SOUND_EAT = 16,
-    SOUND_STORE1 = 17,
-    SOUND_STORE2 = 18,
-    SOUND_STORE3 = 19,
-    SOUND_STORE4 = 20,
-    SOUND_DIG = 21,
-    SOUND_OPENDOOR = 22,
-    SOUND_SHUTDOOR = 23,
-    SOUND_TPLEVEL = 24,
-    SOUND_SCROLL = 25,
-    SOUND_BUY = 26,
-    SOUND_SELL = 27,
-    SOUND_WARN = 28,
-    SOUND_ROCKET = 29, /*!< (unused) Somebody's shooting rockets */
-    SOUND_N_KILL = 30, /*!< The player kills a non-living/undead monster */
-    SOUND_U_KILL = 31, /*!< (unused) The player kills a unique*/
-    SOUND_QUEST = 32, /*!< (unused) The player has just completed a quest */
-    SOUND_HEAL = 33, /*!< (unused) The player was healed a little bit */
-    SOUND_X_HEAL = 34, /*!< (unused) The player was healed full health */
-    SOUND_BITE = 35, /*!< A monster bites you */
-    SOUND_CLAW = 36, /*!< A monster claws you */
-    SOUND_M_SPELL = 37, /*!< (unused) A monster casts a miscellaneous spell */
-    SOUND_SUMMON = 38, /*!< A monster casts a summoning spell  */
-    SOUND_BREATH = 39, /*!< A monster breathes */
-    SOUND_BALL = 40, /*!< (unused) A monster casts a ball / bolt spell */
-    SOUND_M_HEAL = 41, /*!< (unused) A monster heals itself somehow */
-    SOUND_ATK_SPELL = 42, /*!< (unused) A monster casts a misc. offensive spell */
-    SOUND_EVIL = 43, /*!< Something nasty has just happened! */
-    SOUND_TOUCH = 44, /*!< A monster touches you */
-    SOUND_STING = 45, /*!< A monster stings you */
-    SOUND_CRUSH = 46, /*!< A monster crushes / envelopes you */
-    SOUND_SLIME = 47, /*!< A monster drools/spits/etc on you */
-    SOUND_WAIL = 48, /*!< A monster wails */
-    SOUND_WINNER = 49, /*!< (unused) Just won the game! */
-    SOUND_FIRE = 50, /*!< (unused) An item was burned  */
-    SOUND_ACID = 51, /*!< (unused) An item was destroyed by acid */
-    SOUND_ELEC = 52, /*!< (unused) An item was destroyed by electricity */
-    SOUND_COLD = 53, /*!< (unused) An item was shattered */
-    SOUND_ILLEGAL = 54, /*!< Illegal command attempted */
-    SOUND_FAIL = 55, /*!< Fail to get a spell off / activate an item */
-    SOUND_WAKEUP = 56, /*!< (unused) A monster wakes up */
-    SOUND_INVULN = 57, /*!< (unused) Invulnerability! */
-    SOUND_FALL = 58, /*!< Falling through a trapdoor... */
-    SOUND_PAIN = 59, /*!< A monster is in pain! */
-    SOUND_DESTITEM = 60, /*!< An item was destroyed by misc. means */
-    SOUND_MOAN = 61, /*!< A monster makes a moan/beg/insult attack */
-    SOUND_SHOW = 62, /*!< A monster makes a "show" attack */
-    SOUND_UNUSED = 63, /*!< (unused) (no sound for gaze attacks) */
-    SOUND_EXPLODE = 64, /*!< Something (or somebody) explodes */
-    SOUND_GLASS = 65, /*!< A glass feature was crashed */
-    SOUND_REFLECT = 66, /*!< A bolt was reflected */
-    SOUND_HUNGRY = 67, /*!< getting hungry */
-    SOUND_WEAK = 68, /*!< getting weak from hunger */
-    SOUND_FAINT = 69, /*!< getting faint from hunger */
-    SOUND_GOOD_HIT = 70, /*!< critical hit - good */
-    SOUND_GREAT_HIT = 71, /*!< critical hit - great */
-    SOUND_SUPERB_HIT = 72, /*!< critical hit - superb */
-    SOUND_STAR_GREAT_HIT = 73, /*!< critical hit - *great* */
-    SOUND_STAR_SUPERB_HIT = 74, /*!< critical hit - *superb* */
-    SOUND_GOUGE_HIT = 75, /*!< vorpal hit - gouge */
-    SOUND_MAIM_HIT = 76, /*!< vorpal hit - maim */
-    SOUND_CARVE_HIT = 77, /*!< vorpal hit - carve */
-    SOUND_CLEAVE_HIT = 78, /*!< vorpal hit - cleave */
-    SOUND_SMITE_HIT = 79, /*!< vorpal hit - smite */
-    SOUND_EVISCERATE_HIT = 80, /*!< vorpal hit - eviscerate */
-    SOUND_SHRED_HIT = 81, /*!< vorpal hit - shred */
-    SOUND_MAX = 82, /*!< 効果音定義の最大数 / Maximum numbers of sound effect */
+    SOUND_HIT,
+    SOUND_MISS,
+    SOUND_FLEE,
+    SOUND_DROP,
+    SOUND_KILL,
+    SOUND_LEVEL,
+    SOUND_DEATH,
+    SOUND_STUDY,
+    SOUND_TELEPORT,
+    SOUND_SHOOT,
+    SOUND_QUAFF,
+    SOUND_ZAP,
+    SOUND_WALK, /*!< unused */
+    SOUND_TPOTHER,
+    SOUND_HITWALL,
+    SOUND_EAT,
+    SOUND_STORE1,
+    SOUND_STORE2,
+    SOUND_STORE3,
+    SOUND_STORE4,
+    SOUND_DIG,
+    SOUND_OPENDOOR,
+    SOUND_SHUTDOOR,
+    SOUND_TPLEVEL,
+    SOUND_SCROLL,
+    SOUND_BUY,
+    SOUND_SELL,
+    SOUND_WARN,
+    SOUND_ROCKET, /*!< (unused) Somebody's shooting rockets */
+    SOUND_N_KILL, /*!< The player kills a non-living/undead monster */
+    SOUND_U_KILL, /*!< (unused) The player kills a unique*/
+    SOUND_QUEST, /*!< (unused) The player has just completed a quest */
+    SOUND_HEAL, /*!< (unused) The player was healed a little bit */
+    SOUND_X_HEAL, /*!< (unused) The player was healed full health */
+    SOUND_BITE, /*!< A monster bites you */
+    SOUND_CLAW, /*!< A monster claws you */
+    SOUND_M_SPELL, /*!< (unused) A monster casts a miscellaneous spell */
+    SOUND_SUMMON, /*!< A monster casts a summoning spell  */
+    SOUND_BREATH, /*!< A monster breathes */
+    SOUND_BALL, /*!< (unused) A monster casts a ball / bolt spell */
+    SOUND_M_HEAL, /*!< (unused) A monster heals itself somehow */
+    SOUND_ATK_SPELL, /*!< (unused) A monster casts a misc. offensive spell */
+    SOUND_EVIL, /*!< Something nasty has just happened! */
+    SOUND_TOUCH, /*!< A monster touches you */
+    SOUND_STING, /*!< A monster stings you */
+    SOUND_CRUSH, /*!< A monster crushes / envelopes you */
+    SOUND_SLIME, /*!< A monster drools/spits/etc on you */
+    SOUND_WAIL, /*!< A monster wails */
+    SOUND_WINNER, /*!< (unused) Just won the game! */
+    SOUND_FIRE, /*!< (unused) An item was burned  */
+    SOUND_ACID, /*!< (unused) An item was destroyed by acid */
+    SOUND_ELEC, /*!< (unused) An item was destroyed by electricity */
+    SOUND_COLD, /*!< (unused) An item was shattered */
+    SOUND_ILLEGAL, /*!< Illegal command attempted */
+    SOUND_FAIL, /*!< Fail to get a spell off / activate an item */
+    SOUND_WAKEUP, /*!< (unused) A monster wakes up */
+    SOUND_INVULN, /*!< (unused) Invulnerability! */
+    SOUND_FALL, /*!< Falling through a trapdoor... */
+    SOUND_PAIN, /*!< A monster is in pain! */
+    SOUND_DESTITEM, /*!< An item was destroyed by misc. means */
+    SOUND_MOAN, /*!< A monster makes a moan/beg/insult attack */
+    SOUND_SHOW, /*!< A monster makes a "show" attack */
+    SOUND_UNUSED, /*!< (unused) (no sound for gaze attacks) */
+    SOUND_EXPLODE, /*!< Something (or somebody) explodes */
+    SOUND_GLASS, /*!< A glass feature was crashed */
+    SOUND_REFLECT, /*!< A bolt was reflected */
+    SOUND_HUNGRY, /*!< getting hungry */
+    SOUND_WEAK, /*!< getting weak from hunger */
+    SOUND_FAINT, /*!< getting faint from hunger */
+    SOUND_GOOD_HIT, /*!< critical hit - good */
+    SOUND_GREAT_HIT, /*!< critical hit - great */
+    SOUND_SUPERB_HIT, /*!< critical hit - superb */
+    SOUND_STAR_GREAT_HIT, /*!< critical hit - *great* */
+    SOUND_STAR_SUPERB_HIT, /*!< critical hit - *superb* */
+    SOUND_GOUGE_HIT, /*!< vorpal hit - gouge */
+    SOUND_MAIM_HIT, /*!< vorpal hit - maim */
+    SOUND_CARVE_HIT, /*!< vorpal hit - carve */
+    SOUND_CLEAVE_HIT, /*!< vorpal hit - cleave */
+    SOUND_SMITE_HIT, /*!< vorpal hit - smite */
+    SOUND_EVISCERATE_HIT, /*!< vorpal hit - eviscerate */
+    SOUND_SHRED_HIT, /*!< vorpal hit - shred */
+    SOUND_MAX, /*!< 効果音定義の最大数 / Maximum numbers of sound effect */
 };
 
 extern const concptr angband_sound_name[SOUND_MAX];

--- a/src/mind/mind-sniper.cpp
+++ b/src/mind/mind-sniper.cpp
@@ -503,6 +503,7 @@ static bool cast_sniper_spell(player_type *sniper_ptr, int spell)
     /* spell code */
     switch (spell) {
     case 0: /* Concentration */
+        sound(SOUND_ZAP);
         if (!snipe_concentrate(sniper_ptr))
             return FALSE;
         PlayerEnergy(sniper_ptr).set_player_turn_energy(100);
@@ -580,7 +581,6 @@ void do_cmd_snipe(player_type *sniper_ptr)
     if (!get_snipe_power(sniper_ptr, &n, FALSE))
         return;
 
-    sound(SOUND_SHOOT);
     cast = cast_sniper_spell(sniper_ptr, n);
 
     if (!cast)


### PR DESCRIPTION
射撃術使用時の効果音をSOUND_SHOOTからSOUND_ZAPに変更し、再生タイミングを変更しました。
「精神集中」は選択時、他は方向を決めた時に再生します。
※Windows版は効果音を複数同時に再生できないため、SOUND_ZAP再生後にSOUND_SHOOTが再生されると聞こえません。

ついでにsound.cfgの空腹、クリティカル、ヴォーパル各項目にコメントを追加しました。
ヴォーパル倍率1（細切れにした）の項目名が"shred_hit "と後ろに不要なスペースが入っていたので削除しました。