### PR TITLE
[Fix] Windows版の2バイト文字描画を最適化

### DIFF
--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -1125,7 +1125,9 @@ static errr term_text_win(int x, int y, int n, TERM_COLOR a, concptr s)
             rc.right += 2 * td->tile_wid;
         } else if (iskanji(*(s + i))) /* 2バイト文字 */
         {
-            const auto *buf = to_wchar(s + i).wc_str();
+            char tmp[] = { *(s + i), *(s + i + 1), '\0' };
+            to_wchar wc(tmp);
+            const auto *buf = wc.wc_str();
             rc.right += td->font_wid;
             if (buf == NULL)
                 ExtTextOutA(hdc, rc.left, rc.top, ETO_CLIPPED, &rc, s + i, 2, NULL);


### PR DESCRIPTION
2バイト文字を描画する時に、描画する文字以外もUTF-16変換を行っていたため「タイルを2倍幅で表示」では顕著に遅くなっていたと考えられる。
描画する文字のみUTF-16変換を行うようにした。