### PR TITLE
[Fix] モンスターがテレポート追尾しない #1157

### DIFF
--- a/src/spell-kind/spells-teleport.cpp
+++ b/src/spell-kind/spells-teleport.cpp
@@ -374,12 +374,13 @@ bool teleport_player_aux(player_type *creature_ptr, POSITION dis, bool is_quantu
  */
 void teleport_player(player_type *creature_ptr, POSITION dis, BIT_FLAGS mode)
 {
+    const POSITION oy = creature_ptr->y;
+    const POSITION ox = creature_ptr->x;
+
     if (!teleport_player_aux(creature_ptr, dis, FALSE, static_cast<teleport_flags>(mode)))
         return;
 
     /* Monsters with teleport ability may follow the player */
-    POSITION oy = creature_ptr->y;
-    POSITION ox = creature_ptr->x;
     for (POSITION xx = -1; xx < 2; xx++) {
         for (POSITION yy = -1; yy < 2; yy++) {
             MONSTER_IDX tmp_m_idx = creature_ptr->current_floor_ptr->grid_array[oy + yy][ox + xx].m_idx;
@@ -387,10 +388,10 @@ void teleport_player(player_type *creature_ptr, POSITION dis, BIT_FLAGS mode)
                 monster_type *m_ptr = &creature_ptr->current_floor_ptr->m_list[tmp_m_idx];
                 monster_race *r_ptr = &r_info[m_ptr->r_idx];
 
-                bool is_resistible = r_ptr->ability_flags.has(RF_ABILITY::TPORT);
-                is_resistible &= (r_ptr->flagsr & RFR_RES_TELE) == 0;
-                is_resistible &= monster_csleep_remaining(m_ptr) == 0;
-                if (is_resistible) {
+                bool can_follow = r_ptr->ability_flags.has(RF_ABILITY::TPORT);
+                can_follow &= none_bits(r_ptr->flagsr, RFR_RES_TELE);
+                can_follow &= monster_csleep_remaining(m_ptr) == 0;
+                if (can_follow) {
                     teleport_monster_to(creature_ptr, tmp_m_idx, creature_ptr->y, creature_ptr->x, r_ptr->level, TELEPORT_SPONTANEOUS);
                 }
             }
@@ -407,12 +408,13 @@ void teleport_player(player_type *creature_ptr, POSITION dis, BIT_FLAGS mode)
  */
 void teleport_player_away(MONSTER_IDX m_idx, player_type *target_ptr, POSITION dis, bool is_quantum_effect)
 {
+    const POSITION oy = target_ptr->y;
+    const POSITION ox = target_ptr->x;
+
     if (!teleport_player_aux(target_ptr, dis, is_quantum_effect, TELEPORT_PASSIVE))
         return;
 
     /* Monsters with teleport ability may follow the player */
-    POSITION oy = target_ptr->y;
-    POSITION ox = target_ptr->x;
     for (POSITION xx = -1; xx < 2; xx++) {
         for (POSITION yy = -1; yy < 2; yy++) {
             MONSTER_IDX tmp_m_idx = target_ptr->current_floor_ptr->grid_array[oy + yy][ox + xx].m_idx;
@@ -426,10 +428,10 @@ void teleport_player_away(MONSTER_IDX m_idx, player_type *target_ptr, POSITION d
             monster_type *m_ptr = &target_ptr->current_floor_ptr->m_list[tmp_m_idx];
             monster_race *r_ptr = &r_info[m_ptr->r_idx];
 
-            bool is_resistible = r_ptr->ability_flags.has(RF_ABILITY::TPORT);
-            is_resistible &= (r_ptr->flagsr & RFR_RES_TELE) == 0;
-            is_resistible &= monster_csleep_remaining(m_ptr) == 0;
-            if (is_resistible) {
+            bool can_follow = r_ptr->ability_flags.has(RF_ABILITY::TPORT);
+            can_follow &= none_bits(r_ptr->flagsr, RFR_RES_TELE);
+            can_follow &= monster_csleep_remaining(m_ptr) == 0;
+            if (can_follow) {
                 teleport_monster_to(target_ptr, tmp_m_idx, target_ptr->y, target_ptr->x, r_ptr->level, TELEPORT_SPONTANEOUS);
             }
         }


### PR DESCRIPTION
テレポートした後の座標の周囲のモンスターをスキャン
しているのでついてこれるわけがない。
テレポート前の座標の周囲をスキャンするようにする。
また、is_resistible という変数名の意味が分かりづらい
ので can_follow に変更する。