### PR TITLE
[Fix] 【バグ】 運搬中状態のヘヴィ・クロスボウで射撃すると異常終了 #1182

### DIFF
--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -371,9 +371,7 @@ static void update_bonuses(player_type *creature_ptr)
     o_ptr = &creature_ptr->inventory_list[INVEN_BOW];
     if (o_ptr->k_idx) {
         creature_ptr->tval_ammo = (byte)bow_tval_ammo(o_ptr);
-        if (o_ptr->k_idx && !is_heavy_shoot(creature_ptr, &creature_ptr->inventory_list[INVEN_BOW])) {
-            creature_ptr->num_fire = calc_num_fire(creature_ptr, o_ptr);
-        }
+        creature_ptr->num_fire = calc_num_fire(creature_ptr, o_ptr);
     }
 
     for (int i = 0; i < 2; i++) {
@@ -1010,11 +1008,14 @@ s16b calc_num_fire(player_type *creature_ptr, object_type *o_ptr)
         extra_shots++;
 
     int num = 0;
-    if (o_ptr->k_idx == 0 || is_heavy_shoot(creature_ptr, o_ptr))
+    if (o_ptr->k_idx == 0)
         return (s16b)num;
 
     num = 100;
     num += (extra_shots * 100);
+
+    if (is_heavy_shoot(creature_ptr, o_ptr))
+        return (s16b)num;
 
     tval_type tval_ammo = static_cast<tval_type>(bow_tval_ammo(o_ptr));
     if ((creature_ptr->pclass == CLASS_RANGER) && (tval_ammo == TV_ARROW)) {


### PR DESCRIPTION
射撃回数計算関数 calc_num_fire()内にて運搬中の射撃武器の回数計算に誤り。
運搬中は射撃回数でそれぞれの武器の初期値を使用するべきところで0を使用していた。
このため実際に運搬中に射撃を行うとゼロ除算が発生し強制終了の原因となっていた。
該当箇所を修正し、正常な値を返すようにする。
また、update_bonuses()内でcalc_num_fire()をコールする箇所に誤りがあったので合わせて修正する。