### PR TITLE
[Fix] ピット/ネストが生成されない #1189

### DIFF
--- a/src/info-reader/dungeon-reader.cpp
+++ b/src/info-reader/dungeon-reader.cpp
@@ -146,8 +146,8 @@ errr parse_d_info(std::string_view buf, angband_header *head)
         info_set_value(d_ptr->max_m_alloc_chance, tokens[6]);
         info_set_value(d_ptr->obj_good, tokens[7]);
         info_set_value(d_ptr->obj_great, tokens[8]);
-        info_set_value(d_ptr->pit, tokens[9]);
-        info_set_value(d_ptr->nest, tokens[10]);
+        info_set_value(d_ptr->pit, tokens[9], 16);
+        info_set_value(d_ptr->nest, tokens[10], 16);
     } else if (tokens[0] == "P") {
         // P:wild_y:wild_x
         if (tokens.size() < 3)


### PR DESCRIPTION
d_info.txt にピットとネストの生成許可フラグを16進数で
設定しているが、読み込み時に10進数として読んでいるため
すべて 0 になってしまい、絶対に生成されなくなっている。
正しく16進数として読み込むようにする。

#1122  で修正したのと同様のバグ。
念の為他の \*\_info.txt も含め 0x で始まる項目が他にないか確認したが、これで最後の模様。