### PR TITLE
[Fix] Windows版のマルチバイト/ワイド文字列変換のメモリリーク修正

### DIFF
--- a/src/main-win/main-win-utils.h
+++ b/src/main-win/main-win-utils.h
@@ -50,7 +50,7 @@ protected:
 
     void kill()
     {
-        if (!buf) {
+        if (buf) {
             C_KILL(buf, buf_size, WCHAR);
             buf = NULL;
         }
@@ -100,7 +100,7 @@ protected:
 
     void kill()
     {
-        if (!buf) {
+        if (buf) {
             C_KILL(buf, buf_size, char);
             buf = NULL;
         }


### PR DESCRIPTION
漏れてた。
「タイルを２倍幅で表示」だと描画毎にメモリが溜まっていく。