### PR TITLE
[Fix] フェーズアウト状態(カジノ闘技場観戦)時にプレイヤーがテレポートアウェイ効果の影響そのものを受けないよう修正．

### DIFF
--- a/src/spell-kind/spells-teleport.cpp
+++ b/src/spell-kind/spells-teleport.cpp
@@ -408,6 +408,9 @@ void teleport_player(player_type *creature_ptr, POSITION dis, BIT_FLAGS mode)
  */
 void teleport_player_away(MONSTER_IDX m_idx, player_type *target_ptr, POSITION dis, bool is_quantum_effect)
 {
+    if (target_ptr->phase_out)
+        return;
+
     const POSITION oy = target_ptr->y;
     const POSITION ox = target_ptr->x;
 


### PR DESCRIPTION
根本としてテレポートアウェイ効果をフェーズアウト状態には一切受けないように修正した。同効果が将来にデバッグや、新能力に利用することを想定した上の修正案。
闘技場のモンスターに点Pやlainが出ることが珍しいと思うので、実際問題が抑止されているかはprocess_quantum_effect()内を少しいじってどんなモンスターでも量子的効果を起こすようにしてから試してもらえれば。