### PR TITLE
[Fix] ダンプに過去に使えた領域が記録されない #1205

### DIFF
--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -397,7 +397,7 @@ static void dump_aux_race_history(player_type *creature_ptr, FILE *fff)
  */
 static void dump_aux_realm_history(player_type *creature_ptr, FILE *fff)
 {
-    if (creature_ptr->old_realm)
+    if (creature_ptr->old_realm == 0)
         return;
 
     fputc('\n', fff);


### PR DESCRIPTION
過去に使えた領域をビット位置で保存する変数の判定が
反転しているのが原因。
ビットが立っていない場合にスキップするのが正しい。