### PR TITLE
[Fix] モンスターボールで広域マップ移動が重くなる

### DIFF
--- a/src/hpmp/hp-mp-regenerator.cpp
+++ b/src/hpmp/hp-mp-regenerator.cpp
@@ -227,8 +227,9 @@ void regenerate_captured_monsters(player_type *creature_ptr)
 
     if (heal) {
         creature_ptr->update |= (PU_COMBINE);
-        creature_ptr->window_flags |= (PW_INVEN);
-        creature_ptr->window_flags |= (PW_EQUIP);
+        // FIXME 広域マップ移動で1歩毎に何度も再描画されて重くなる。現在はボール中モンスターのHP回復でボールの表示は変わらないためコメントアウトする。
+        //creature_ptr->window_flags |= (PW_INVEN);
+        //creature_ptr->window_flags |= (PW_EQUIP);
         wild_regen = 20;
     }
 }


### PR DESCRIPTION
ボール中モンスターのHP自然回復処理で描画フラグが立つため、広域マップ移動が重くなっていた。
現在は、モンスターのHP回復がモンスターボールの表示に影響することがないため、描画フラグ処理をコメントアウトすることで解消する。