### PR TITLE
[Feature] 効果音の追加v3.0.0 α28

### DIFF
--- a/lib/xtra/sound/sound.cfg
+++ b/lib/xtra/sound/sound.cfg
@@ -211,3 +211,9 @@ eviscerate_hit =
 # ヴォーパル 倍率1 細切れにした
 shred_hit = 
 
+# 装備した
+wield = 
+
+# 装備を外した
+take_off = 
+

--- a/src/cmd-item/cmd-equipment.cpp
+++ b/src/cmd-item/cmd-equipment.cpp
@@ -17,6 +17,8 @@
 #include "inventory/inventory-slot-types.h"
 #include "io/input-key-acceptor.h"
 #include "io/input-key-requester.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "object-enchant/item-feeling.h"
 #include "object-enchant/special-object-flags.h"
 #include "object-enchant/trc-types.h"
@@ -206,6 +208,7 @@ void do_cmd_wield(player_type *creature_ptr)
             return;
     }
 
+    sound(SOUND_WIELD);
     if (need_switch_wielding && !object_is_cursed(&creature_ptr->inventory_list[need_switch_wielding])) {
         object_type *slot_o_ptr = &creature_ptr->inventory_list[slot];
         object_type *switch_o_ptr = &creature_ptr->inventory_list[need_switch_wielding];
@@ -333,6 +336,7 @@ void do_cmd_takeoff(player_type *creature_ptr)
         }
     }
 
+    sound(SOUND_TAKE_OFF);
     energy.set_player_turn_energy(50);
     (void)inven_takeoff(creature_ptr, item, 255);
     verify_equip_slot(creature_ptr, item);

--- a/src/main/sound-definitions-table.cpp
+++ b/src/main/sound-definitions-table.cpp
@@ -88,4 +88,6 @@ const concptr angband_sound_name[SOUND_MAX] = {
     "smite_hit",
     "eviscerate_hit",
     "shred_hit",
+    "wield",
+    "take_off",
 };

--- a/src/main/sound-definitions-table.h
+++ b/src/main/sound-definitions-table.h
@@ -89,6 +89,8 @@ enum sound_type {
     SOUND_SMITE_HIT, /*!< vorpal hit - smite */
     SOUND_EVISCERATE_HIT, /*!< vorpal hit - eviscerate */
     SOUND_SHRED_HIT, /*!< vorpal hit - shred */
+    SOUND_WIELD,
+    SOUND_TAKE_OFF,
     SOUND_MAX, /*!< 効果音定義の最大数 / Maximum numbers of sound effect */
 };
 

--- a/src/mspell/mspell-bolt.cpp
+++ b/src/mspell/mspell-bolt.cpp
@@ -29,10 +29,9 @@ MonsterSpellResult spell_RF4_SHOOT(player_type *target_ptr, POSITION y, POSITION
     monspell_message(target_ptr, m_idx, t_idx, _("%^sが奇妙な音を発した。", "%^s makes a strange noise."), _("%^sが矢を放った。", "%^s fires an arrow."),
         _("%^sが%sに矢を放った。", "%^s fires an arrow at %s."), TARGET_TYPE);
 
+    sound(SOUND_SHOOT);
     const auto dam = monspell_damage(target_ptr, RF_ABILITY::SHOOT, m_idx, DAM_ROLL);
     const auto proj_res = bolt(target_ptr, m_idx, y, x, GF_ARROW, dam, TARGET_TYPE);
-    // FIXME: モンスター射撃は必中のため、命中音のSOUND_SHOOT_HIT再生を優先する
-    //sound(SOUND_SHOOT);
 
     auto res = MonsterSpellResult::make_valid(dam);
     res.learnable = proj_res.affected_player;

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -22,6 +22,8 @@
 #include "hpmp/hp-mp-processor.h"
 #include "inventory/inventory-object.h"
 #include "inventory/inventory-slot-types.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "mind/mind-force-trainer.h"
 #include "monster/monster-describer.h"
 #include "object/object-kind-hook.h"
@@ -499,6 +501,7 @@ bool cosmic_cast_off(player_type *creature_ptr, object_type **o_ptr_ptr)
     GAME_TEXT o_name[MAX_NLEN];
     describe_flavor(creature_ptr, o_name, &forge, OD_NAME_ONLY);
     msg_format(_("%sを脱ぎ捨てた。", "You cast off %s."), o_name);
+    sound(SOUND_TAKE_OFF);
 
     /* Get effects */
     msg_print(_("「燃え上がれ俺の小宇宙！」", "You say, 'Burn up my cosmo!"));


### PR DESCRIPTION
・モンスターからプレイヤーへの射撃効果音の復活
・装備した/装備を外した時の効果音を追加
　『ドラゴン・クロス』発動時にもSOUND_TAKE_OFFを鳴らす。