### PR TITLE
[Fix] ラッキーマンが変異を他に持たない状態でも突然変異一覧に表示できるよう修正.

### DIFF
--- a/src/io/mutations-dump.cpp
+++ b/src/io/mutations-dump.cpp
@@ -18,7 +18,7 @@ void dump_mutations(player_type *creature_ptr, FILE *out_file)
     if (!out_file)
         return;
 
-    if (creature_ptr->muta.any()) {
+    if (creature_ptr->muta.any() || has_good_luck(creature_ptr)) {
         if (creature_ptr->muta.has(MUTA::SPIT_ACID))
             fprintf(out_file, _(" あなたは酸を吹きかけることができる。(ダメージ レベルX1)\n", " You can spit acid (dam lvl).\n"));
 

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -25,6 +25,7 @@
 #include "player/player-sex.h"
 #include "player/player-status-table.h"
 #include "player/player-status.h"
+#include "player/player-status-flags.h"
 #include "realm/realm-names-table.h"
 #include "status-first-page.h"
 #include "system/floor-type-definition.h"
@@ -299,7 +300,7 @@ static void display_current_floor(char *statmsg)
  */
 void display_player(player_type *creature_ptr, int mode)
 {
-    if (creature_ptr->muta.any() && display_mutations)
+    if ((creature_ptr->muta.any() || has_good_luck(creature_ptr)) && display_mutations)
         mode = (mode % 6);
     else
         mode = (mode % 5);


### PR DESCRIPTION
これで2.2.1の頃と同じ挙動に治ったはずなのでチェックよろしくお願いします。