### PR TITLE
[Fix] 値切りシステム廃止後の売買のメッセージ統一を推進．

### DIFF
--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -53,9 +53,6 @@ static std::optional<PRICE> prompt_to_buy(player_type *player_ptr, object_type *
     if (!is_low_price)
         price_ask += price_ask / 10;
 
-    msg_print(_("すんなりとこの金額にまとまった。", "You quickly agree upon the price."));
-    msg_print(NULL);
-
     price_ask *= o_ptr->number;
     concptr s = format(_("買値 $%ld で買いますか？", "Do you buy for $%ld? "), static_cast<long>(price_ask));
     if (get_check_strict(player_ptr, s, CHECK_DEFAULT_Y)) {
@@ -226,7 +223,7 @@ void store_purchase(player_type *player_ptr)
 
     PRICE best = price_item(player_ptr, j_ptr, ot_ptr->inflate, false);
     if (o_ptr->number > 1) {
-        if ((cur_store_num != STORE_HOME) && (o_ptr->ident & IDENT_FIXED)) {
+        if (cur_store_num != STORE_HOME) {
             msg_format(_("一つにつき $%ldです。", "That costs %ld gold per item."), (long)(best));
         }
 

--- a/src/store/sell-order.cpp
+++ b/src/store/sell-order.cpp
@@ -57,17 +57,6 @@ static std::optional<PRICE> prompt_to_sell(player_type *player_ptr, object_type 
     if (!is_low_price)
         price_ask -= price_ask / 10;
 
-    auto max_price = (PRICE)ot_ptr->max_cost;
-
-    if (price_ask > max_price) {
-        msg_print(_("即座にこの金額にまとまった。", "You instantly agree upon the price."));
-        msg_print(NULL);
-        price_ask = max_price;
-    } else {
-        msg_print(_("すんなりとこの金額にまとまった。", "You quickly agree upon the price."));
-        msg_print(NULL);
-    }
-
     price_ask *= o_ptr->number;
     concptr s = format(_("売値 $%ld で売りますか？", "Do you sell for $%ld? "), static_cast<long>(price_ask));
     if (get_check_strict(player_ptr, s, CHECK_DEFAULT_Y)) {


### PR DESCRIPTION
ひとまずこれで売買価格固定/未固定でメッセージが変わらなくなったはず。固定フラグそのものを除くのは別Issueでリファクタリング扱いにでもする。