### PR TITLE
[Fix] ウィザードモードのクエスト突入機能が正しく動作するよう修正＆リファクタリング．

### DIFF
--- a/src/dungeon/quest.cpp
+++ b/src/dungeon/quest.cpp
@@ -309,6 +309,18 @@ void leave_tower_check(player_type *player_ptr)
     quest[QUEST_TOWER1].comptime = current_world_ptr->play_time;
 }
 
+/*! 
+ * @brief Player enters a new quest
+ */
+void exe_enter_quest(player_type *player_ptr, QUEST_IDX quest_idx)
+{
+    if (quest[quest_idx].type != QUEST_TYPE_RANDOM)
+        player_ptr->current_floor_ptr->dun_level = 1;
+    player_ptr->current_floor_ptr->inside_quest = quest_idx;
+
+    player_ptr->leaving = true;
+}
+
 /*!
  * @brief クエスト入り口にプレイヤーが乗った際の処理 / Do building commands
  * @param player_ptr プレーヤーへの参照ポインタ
@@ -333,15 +345,9 @@ void do_cmd_quest(player_type *player_ptr)
     else if (player_ptr->pseikaku == PERSONALITY_CHARGEMAN)
         msg_print(_("『全滅してやるぞ！』", "\"I'll annihilate THEM!\""));
 
-    /* Player enters a new quest */
     player_ptr->oldpy = 0;
     player_ptr->oldpx = 0;
-
     leave_quest_check(player_ptr);
 
-    if (quest[player_ptr->current_floor_ptr->inside_quest].type != QUEST_TYPE_RANDOM)
-        player_ptr->current_floor_ptr->dun_level = 1;
-    player_ptr->current_floor_ptr->inside_quest = player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x].special;
-
-    player_ptr->leaving = true;
+    exe_enter_quest(player_ptr, player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x].special);
 }

--- a/src/dungeon/quest.h
+++ b/src/dungeon/quest.h
@@ -95,4 +95,5 @@ QUEST_IDX quest_number(player_type *player_ptr, DEPTH level);
 QUEST_IDX random_quest_number(player_type *player_ptr, DEPTH level);
 void leave_quest_check(player_type *player_ptr);
 void leave_tower_check(player_type *player_ptr);
+void exe_enter_quest(player_type *player_ptr, QUEST_IDX quest_idx);
 void do_cmd_quest(player_type *player_ptr);

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -404,6 +404,7 @@ static bool parse_qtw_M(qtwg_type *qtwg_ptr, char **zz)
  * @param y 詳細不明
  * @param x 詳細不明
  * @return エラーコード
+ * @todo クエスト情報のみを読み込む手段と実際にフロアデータまで読み込む処理は分離したい
  */
 parse_error_type generate_fixed_map_floor(player_type *player_ptr, qtwg_type *qtwg_ptr, process_dungeon_file_pf parse_fixed_map)
 {

--- a/src/system/system-variables.cpp
+++ b/src/system/system-variables.cpp
@@ -24,7 +24,7 @@ const concptr copyright[5] =
 concptr ANGBAND_SYS = "xxx";
 concptr ANGBAND_KEYBOARD = _("JAPAN", "0");
 concptr ANGBAND_GRAF = "ascii";
-init_flags_type init_flags;
+init_flags_type init_flags; //!< @todo このグローバル変数何とかしたい
 
 /*!
  * Function hook to restrict "get_obj_num_prep()" function

--- a/src/wizard/wizard-game-modifier.cpp
+++ b/src/wizard/wizard-game-modifier.cpp
@@ -115,10 +115,12 @@ void wiz_enter_quest(player_type* creature_ptr)
     if ((tmp_int < 0) || (tmp_int >= max_q_idx))
         return;
 
+    init_flags = static_cast<init_flags_type>(INIT_SHOW_TEXT | INIT_ASSIGN);
     creature_ptr->current_floor_ptr->inside_quest = (QUEST_IDX)tmp_int;
     parse_fixed_map(creature_ptr, "q_info.txt", 0, 0, 0, 0);
     quest[tmp_int].status = QUEST_STATUS_TAKEN;
-    creature_ptr->current_floor_ptr->inside_quest = 0;
+    if (quest[tmp_int].dungeon == 0)
+        exe_enter_quest(creature_ptr, (QUEST_IDX)tmp_int);
 }
 
 /*!


### PR DESCRIPTION
改良の余地はまだあるが別件と合わせて別Issue化予定．

 * 階段で正規にダンジョンに突入する処理と統合．
 * ワーグクエストのようなダンジョンの階層に依存するクエスト以外では即座にクエストに飛ぶよう処理．