### PR TITLE
[Fix] 種族アンドロイドで店舗でのアイテム強化した時の処理

### DIFF
--- a/src/market/building-enchanter.cpp
+++ b/src/market/building-enchanter.cpp
@@ -39,7 +39,8 @@ bool enchant_item(player_type *player_ptr, PRICE cost, HIT_PROB to_hit, HIT_POIN
         return false;
 
     char tmp_str[MAX_NLEN];
-    if (player_ptr->au < (cost * o_ptr->number)) {
+    const PRICE total_cost = cost * o_ptr->number;
+    if (player_ptr->au < total_cost) {
         describe_flavor(player_ptr, tmp_str, o_ptr, OD_NAME_ONLY);
         msg_format(_("%sを改良するだけのゴールドがありません！", "You do not have the gold to improve %s!"), tmp_str);
         return false;
@@ -76,12 +77,12 @@ bool enchant_item(player_type *player_ptr, PRICE cost, HIT_PROB to_hit, HIT_POIN
 
     describe_flavor(player_ptr, tmp_str, o_ptr, OD_NAME_AND_ENCHANT);
 #ifdef JP
-    msg_format("＄%dで%sに改良しました。", cost * o_ptr->number, tmp_str);
+    msg_format("＄%dで%sに改良しました。", total_cost, tmp_str);
 #else
-    msg_format("Improved into %s for %d gold.", tmp_str, cost * o_ptr->number);
+    msg_format("Improved into %s for %d gold.", tmp_str, total_cost);
 #endif
 
-    player_ptr->au -= (cost * o_ptr->number);
+    player_ptr->au -= total_cost;
     if (item >= INVEN_MAIN_HAND)
         calc_android_exp(player_ptr);
     return true;

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -530,8 +530,6 @@ bool enchant_equipment(player_type *caster_ptr, object_type *o_ptr, int n, int e
     set_bits(caster_ptr->update, PU_BONUS | PU_COMBINE | PU_REORDER);
     set_bits(caster_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_PLAYER | PW_FLOOR_ITEM_LIST);
 
-    calc_android_exp(caster_ptr);
-
     /* Success */
     return true;
 }


### PR DESCRIPTION
enchant_equipment 内でアンドロイドの装備によるLV計算処理
calc_android_exp が呼ばれており、種族がアンドロイドの場合
その中で最終的に handle_stuff が呼ばれてアイテムを重ねる
フラグなどの処理が行われてしまう。
結果として店舗でのアイテム強化処理の途中で強化した
アイテムが重なり、重なった後の分の数にしたがった料金が
所持金から引かれるため、所持金がマイナスになるという
バグが発生する。(Issues #1240)
所持金がマイナスにならなかった場合でも、重なった数の
分だけ、余分に料金を取られている。

enchant_equipment を呼び出した後でも calc_android_exp は
呼び出しているので、 enchant_equiptment 内では
calc_android_exp を呼び出さないようにする。
なお、他の enchant_equipment の呼び出しを一通り確認したが
アンドロイドの装備によるLVの再計算が必要な場合は
すべて enchant_equipment の呼び出し後に calc_android_exp を
呼び出しているため、enchant_equipment 内での呼び出しの
削除が他に影響することはないと思われる。

また、料金（単価×個数）を何度も計算しているのが
そもそもおかしいので、一度計算した値を変数に入れて
使用するようにする。