### PR TITLE
[Fix] r_info.txt の英語名がロードされていない

### DIFF
--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -92,9 +92,11 @@ errr parse_r_info(std::string_view buf, angband_header *head)
         return PARSE_ERROR_MISSING_RECORD_HEADER;
     else if (tokens[0] == "E") {
         // E:name_en
-#ifndef JP
         if (tokens.size() < 2 || tokens[1].size() == 0)
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+#ifdef JP
+        r_ptr->E_name = tokens[1];
+#else
         r_ptr->name = tokens[1];
 #endif
     } else if (tokens[0] == "D") {


### PR DESCRIPTION
8c1ee0d91accd2d33b46ad0756a832ae71ef4c0d
上記コミットのパーサ書き換え時にモンスターの英語名の
E_name メンバへの読み込み自体が削除されている。
その結果、ゲーム上の直接的な影響は無いがスポイラー
ファイル mon-info.txt のモンスター名の英語表記の併記が
消えてしまっている。
元の通り E_name メンバに英語名をロードするようにする。