### PR TITLE
[Fix] ペットに巻き込むなって言ってるのに巻き込む #1255

### DIFF
--- a/src/melee/melee-spell-flags-checker.cpp
+++ b/src/melee/melee-spell-flags-checker.cpp
@@ -133,7 +133,7 @@ static void check_melee_spell_distance(player_type *target_ptr, melee_spell_type
 {
     auto ball_mask_except_rocket = RF_ABILITY_BALL_MASK;
     ball_mask_except_rocket.reset(RF_ABILITY::ROCKET);
-    if (ms_ptr->ability_flags.has_any_of(ball_mask_except_rocket))
+    if (ms_ptr->ability_flags.has_none_of(ball_mask_except_rocket))
         return;
 
     POSITION real_y = ms_ptr->y;


### PR DESCRIPTION
ボール魔法を所持しているかどうかの真偽チェックが
反転しているため、巻き込むボール魔法を除外する
コードが動作していない。
真偽チェックを正しく修正する。