### PR TITLE
店舗の価格交渉削除後に残っている問題の修正

### DIFF
--- a/src/object-enchant/special-object-flags.h
+++ b/src/object-enchant/special-object-flags.h
@@ -5,7 +5,7 @@
  */
 enum sof_type {
     IDENT_SENSE = 0x01, /* Item has been "sensed" */
-    IDENT_FIXED = 0x02, /* Item has been "haggled" */
+    IDENT_XXX02 = 0x02,
     IDENT_EMPTY = 0x04, /* Item charges are known */
     IDENT_KNOWN = 0x08, /* Item abilities are known */
     IDENT_STORE = 0x10, /* Item is storebought !!!! */

--- a/src/store/pricing.cpp
+++ b/src/store/pricing.cpp
@@ -62,5 +62,8 @@ PRICE price_item(player_type *player_ptr, object_type *o_ptr, int greed, bool fl
     if (price <= 0L)
         return 1L;
 
+    if (price >= LOW_PRICE_THRESHOLD)
+        price += (flip ? -1 : 1) * price / 10;
+
     return price;
 }

--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -48,10 +48,6 @@
 static std::optional<PRICE> prompt_to_buy(player_type *player_ptr, object_type *o_ptr)
 {
     auto price_ask = price_item(player_ptr, o_ptr, ot_ptr->inflate, false);
-    auto is_low_price = price_ask < LOW_PRICE_THRESHOLD;
-
-    if (!is_low_price)
-        price_ask += price_ask / 10;
 
     price_ask *= o_ptr->number;
     concptr s = format(_("買値 $%ld で買いますか？", "Do you buy for $%ld? "), static_cast<long>(price_ask));

--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -249,25 +249,18 @@ void store_purchase(player_type *player_ptr)
 
     COMMAND_CODE item_new;
     PRICE price;
-    if (o_ptr->ident & (IDENT_FIXED)) {
-        price = (best * j_ptr->number);
-    } else {
-        GAME_TEXT o_name[MAX_NLEN];
-        describe_flavor(player_ptr, o_name, j_ptr, 0);
-        msg_format(_("%s(%c)を購入する。", "Buying %s (%c)."), o_name, I2A(item));
-        msg_print(NULL);
+    GAME_TEXT o_name[MAX_NLEN];
+    describe_flavor(player_ptr, o_name, j_ptr, 0);
+    msg_format(_("%s(%c)を購入する。", "Buying %s (%c)."), o_name, I2A(item));
+    msg_print(NULL);
 
-        auto res = prompt_to_buy(player_ptr, j_ptr);
-        if (st_ptr->store_open >= current_world_ptr->game_turn)
-            return;
-        if (!res)
-            return;
+    auto res = prompt_to_buy(player_ptr, j_ptr);
+    if (st_ptr->store_open >= current_world_ptr->game_turn)
+        return;
+    if (!res)
+        return;
 
-        price = res.value();
-    }
-
-    if (price == (best * j_ptr->number))
-        o_ptr->ident |= (IDENT_FIXED);
+    price = res.value();
 
     if (player_ptr->au < price) {
         msg_print(_("お金が足りません。", "You do not have enough gold."));
@@ -284,9 +277,7 @@ void store_purchase(player_type *player_ptr)
     player_ptr->au -= price;
     store_prt_gold(player_ptr);
     object_aware(player_ptr, j_ptr);
-    j_ptr->ident &= ~(IDENT_FIXED);
 
-    GAME_TEXT o_name[MAX_NLEN];
     describe_flavor(player_ptr, o_name, j_ptr, 0);
     msg_format(_("%sを $%ldで購入しました。", "You bought %s for %ld gold."), o_name, (long)price);
 

--- a/src/store/sell-order.cpp
+++ b/src/store/sell-order.cpp
@@ -53,6 +53,7 @@ static std::optional<PRICE> prompt_to_sell(player_type *player_ptr, object_type 
 {
     auto price_ask = price_item(player_ptr, o_ptr, ot_ptr->inflate, true);
 
+    price_ask = std::min(price_ask, ot_ptr->max_cost);
     price_ask *= o_ptr->number;
     concptr s = format(_("売値 $%ld で売りますか？", "Do you sell for $%ld? "), static_cast<long>(price_ask));
     if (get_check_strict(player_ptr, s, CHECK_DEFAULT_Y)) {

--- a/src/store/sell-order.cpp
+++ b/src/store/sell-order.cpp
@@ -52,10 +52,6 @@
 static std::optional<PRICE> prompt_to_sell(player_type *player_ptr, object_type *o_ptr)
 {
     auto price_ask = price_item(player_ptr, o_ptr, ot_ptr->inflate, true);
-    auto is_low_price = price_ask < LOW_PRICE_THRESHOLD;
-
-    if (!is_low_price)
-        price_ask -= price_ask / 10;
 
     price_ask *= o_ptr->number;
     concptr s = format(_("売値 $%ld で売りますか？", "Do you sell for $%ld? "), static_cast<long>(price_ask));

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -278,7 +278,6 @@ void store_shuffle(player_type *player_ptr, int which)
             continue;
 
         o_ptr->discount = 50;
-        o_ptr->ident &= ~(IDENT_FIXED);
         o_ptr->inscription = quark_add(_("売出中", "on sale"));
     }
 }

--- a/src/view/display-store.cpp
+++ b/src/view/display-store.cpp
@@ -96,17 +96,9 @@ void display_entry(player_type *player_ptr, int pos)
         put_str(out_val, i + 6, _(60, 61));
     }
 
-    s32b x;
-    if (o_ptr->ident & IDENT_FIXED) {
-        x = price_item(player_ptr, o_ptr, ot_ptr->inflate, false);
-        (void)sprintf(out_val, _("%9ld固", "%9ld F"), (long)x);
-        put_str(out_val, i + 6, 68);
-        return;
-    }
+    const auto price = price_item(player_ptr, o_ptr, ot_ptr->inflate, false);
 
-    x = price_item(player_ptr, o_ptr, ot_ptr->inflate, false);
-
-    (void)sprintf(out_val, "%9ld  ", (long)x);
+    (void)sprintf(out_val, "%9ld  ", (long)price);
     put_str(out_val, i + 6, 68);
 }
 

--- a/src/view/display-store.cpp
+++ b/src/view/display-store.cpp
@@ -105,8 +105,6 @@ void display_entry(player_type *player_ptr, int pos)
     }
 
     x = price_item(player_ptr, o_ptr, ot_ptr->inflate, false);
-    if (x >= LOW_PRICE_THRESHOLD)
-        x += x / 10;
 
     (void)sprintf(out_val, "%9ld  ", (long)x);
     put_str(out_val, i + 6, 68);


### PR DESCRIPTION
以下の問題を修正する。

- #1257 
- #1252 
- 価格交渉削除前の仕様で価格交渉で最大限に値切れた時に付与されていた IDENT_FIXED フラグを削除する。これにより店舗の価格表示の後ろに「固」が表示されることがなくなる。