### PR TITLE
敵対モンスターの友好モンスター召喚時のバグについて

### DIFF
--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -318,7 +318,7 @@ bool place_monster_one(player_type *player_ptr, MONSTER_IDX who, POSITION y, POS
     m_ptr->ml = false;
     if (mode & PM_FORCE_PET) {
         set_pet(player_ptr, m_ptr);
-    } else if ((r_ptr->flags7 & RF7_FRIENDLY) || (mode & PM_FORCE_FRIENDLY) || is_friendly_idx(player_ptr, who)) {
+    } else if (!who && (r_ptr->flags7 & RF7_FRIENDLY) || is_friendly_idx(player_ptr, who) || (mode & PM_FORCE_FRIENDLY)) {
         if (!monster_has_hostile_align(player_ptr, NULL, 0, -1, r_ptr) && !player_ptr->current_floor_ptr->inside_arena)
             set_friendly(m_ptr);
     }

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -318,7 +318,7 @@ bool place_monster_one(player_type *player_ptr, MONSTER_IDX who, POSITION y, POS
     m_ptr->ml = false;
     if (mode & PM_FORCE_PET) {
         set_pet(player_ptr, m_ptr);
-    } else if ((r_ptr->flags7 & RF7_FRIENDLY) && is_friendly_idx(player_ptr, who) || (mode & PM_FORCE_FRIENDLY)) {
+    } else if ((!who && (r_ptr->flags7 & RF7_FRIENDLY)) || is_friendly_idx(player_ptr, who) || (mode & PM_FORCE_FRIENDLY)) {
         if (!monster_has_hostile_align(player_ptr, NULL, 0, -1, r_ptr) && !player_ptr->current_floor_ptr->inside_arena)
             set_friendly(m_ptr);
     }

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -318,7 +318,7 @@ bool place_monster_one(player_type *player_ptr, MONSTER_IDX who, POSITION y, POS
     m_ptr->ml = false;
     if (mode & PM_FORCE_PET) {
         set_pet(player_ptr, m_ptr);
-    } else if (!who && (r_ptr->flags7 & RF7_FRIENDLY) || is_friendly_idx(player_ptr, who) || (mode & PM_FORCE_FRIENDLY)) {
+    } else if ((r_ptr->flags7 & RF7_FRIENDLY) && is_friendly_idx(player_ptr, who) || (mode & PM_FORCE_FRIENDLY)) {
         if (!monster_has_hostile_align(player_ptr, NULL, 0, -1, r_ptr) && !player_ptr->current_floor_ptr->inside_arena)
             set_friendly(m_ptr);
     }


### PR DESCRIPTION
#1241 
モンスター生成処理の際、友好化の条件が「モンスターが友好的な特性を持つ場合、"または"召喚主が友好、または強制的に友好にする場合」という処理だったため、モンスターが友好の特性を持つかどうかの判定を自然生成（whoが0）の時にのみするように変更するのはいかがでしょうか。
これであれば召喚主が敵対している場合は普段友好なモンスターも召喚された際に敵対して生成されます。