### PR TITLE
[Fix] 静水のMP回復量表示の誤り #1266

### DIFF
--- a/src/racial/class-racial-switcher.cpp
+++ b/src/racial/class-racial-switcher.cpp
@@ -306,7 +306,7 @@ void switch_class_racial(player_type *creature_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
 
         rpi = rpi_type(_("静水", "Mirror Concentration"));
-        rpi.info = format("%s%d", KWD_MANA, 3 + rc_ptr->lvl / 20);
+        rpi.info = format("%s%d", KWD_MANA, 5 + rc_ptr->lvl * rc_ptr->lvl / 100);
         rpi.text = _("精神を集中してMPを少し回復する。", "Concentrates deeply to heal your SP a little.");
         rpi.min_level = 30;
         rpi.cost = 0;


### PR DESCRIPTION
おそらくコピペ後の修正漏れで明鏡止水の回復量になっている。
静水の実際の回復量を正しく表示するようにする。