### PR TITLE
[Fix] 床上のアイテムのエッセンスを抽出するとスタック順が変わる

### DIFF
--- a/src/system/object-type-definition.cpp
+++ b/src/system/object-type-definition.cpp
@@ -41,7 +41,9 @@ void object_type::copy_from(object_type *j_ptr)
 void object_type::prep(player_type *player_ptr, KIND_OBJECT_IDX ko_idx)
 {
     object_kind *k_ptr = &k_info[ko_idx];
+    auto old_stack_idx = this->stack_idx;
     wipe();
+    this->stack_idx = old_stack_idx;
     this->k_idx = ko_idx;
     this->tval = k_ptr->tval;
     this->sval = k_ptr->sval;


### PR DESCRIPTION
66e2ed76dce76b461cbcdbfb78bb3cda6ca989c5 で床上にスタックした
アイテムの順序を保持するようにしたが、エッセンス抽出に伴う
object_type::prep の呼び出しでスタック順序を保持するメンバ変数
stack_idx もクリアされてしまっているため、順序が変わってしまう。
凡庸化の処理でも同様の現象が起きるものと思われる。
対策として、object_type::prep を呼び出しても stack_idx は保持
されるようにする。