### PR TITLE
Fix monster/monster-damage.cpp compilation when world score disabled

### DIFF
--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -13,6 +13,7 @@
 #include "core/stuff-handler.h"
 #include "game-option/birth-options.h"
 #include "game-option/play-record-options.h"
+#include "io/files-util.h"
 #include "io/report.h"
 #include "io/write-diary.h"
 #include "main/sound-definitions-table.h"
@@ -46,11 +47,6 @@
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "world/world.h"
-
-#if JP
-#else
-#include "io/files-util.h"
-#endif
 
 /*
  * @brief コンストラクタ


### PR DESCRIPTION
With the ubuntu-latest runner on GitHub and the source configured with "--disable-worldscore --disable-pch", monster/monster-damage.cpp fails to compile because of no prototype for get_rnd_line().  A log from a failed compilation is here, https://github.com/backwardsEric/hengband/runs/3274556727?check_suite_focus=true .

This change resolves that by always including io/files-util.h in monster/monster-damage.cpp regardless of if JP is set.