### PR TITLE
Fix Debian Buster compilation for std::function

### DIFF
--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -39,6 +39,7 @@
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "world/world.h"
+#include <functional>
 
 /*!
  * @brief 地形によるダメージを与える / Deal damage from feature.

--- a/src/info-reader/general-parser.h
+++ b/src/info-reader/general-parser.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include <functional>
 #include <string_view>
 
 enum parse_error_type : int;

--- a/src/target/grid-selector.cpp
+++ b/src/target/grid-selector.cpp
@@ -21,6 +21,7 @@
 #include "util/sort.h"
 #include "view/display-messages.h"
 #include "window/main-window-util.h"
+#include <functional>
 #include <unordered_map>
 #include <vector>
 


### PR DESCRIPTION
On Debian Buster (gcc is 8.3.0) with the source configured with "--disable-worldscore --disable-pch", floor/fixed-map-generator.cpp, hpmp/hp-mp-processor.cpp, info-reader/general-parser.cpp, main/info-initializer.cpp, and target/grid-selector.cpp fail to compile because of a missing definition for std::function.  Those compiled without problems on GitHub's ubuntu-latest runner.

This change works around that by include functional in more places so std::function will be visible where it is used.