### PR TITLE
Feature/fix endless dec status

### DIFF
--- a/src/spell-kind/blood-curse.cpp
+++ b/src/spell-kind/blood-curse.cpp
@@ -117,11 +117,12 @@ void blood_curse_to_enemy(player_type *caster_ptr, MONSTER_IDX m_idx)
             /* Fall through */
         case 26:
         case 27:
-        case 28: {
+        case 28:
+        default: {
             if (one_in_(13)) {
                 for (int i = 0; i < A_MAX; i++) {
                     do {
-                        (void)do_dec_stat(caster_ptr, i); //FIXED
+                        (void)do_dec_stat(caster_ptr, i);
                     } while(one_in_(2));
                 }
             } else {

--- a/src/spell-kind/blood-curse.cpp
+++ b/src/spell-kind/blood-curse.cpp
@@ -120,10 +120,9 @@ void blood_curse_to_enemy(player_type *caster_ptr, MONSTER_IDX m_idx)
         case 28: {
             if (one_in_(13)) {
                 for (int i = 0; i < A_MAX; i++) {
-                    bool is_first_dec_stat = true;
-                    while (is_first_dec_stat || one_in_(2)) {
-                        (void)do_dec_stat(caster_ptr, i);
-                    }
+                    do {
+                        (void)do_dec_stat(caster_ptr, i); //FIXED
+                    } while(one_in_(2));
                 }
             } else {
                 (void)do_dec_stat(caster_ptr, randint0(6));

--- a/src/spell-kind/spells-random.cpp
+++ b/src/spell-kind/spells-random.cpp
@@ -220,7 +220,7 @@ bool activate_ty_curse(player_type *target_ptr, bool stop_ty, int *count)
         default:
             for (int i = 0; i < A_MAX; i++) {
                 do {
-                    (void)do_dec_stat(target_ptr, i); //FIXED
+                    (void)do_dec_stat(target_ptr, i);
                 } while(one_in_(2));
             }
         }

--- a/src/spell-kind/spells-random.cpp
+++ b/src/spell-kind/spells-random.cpp
@@ -219,11 +219,9 @@ bool activate_ty_curse(player_type *target_ptr, bool stop_ty, int *count)
             /* Fall through */
         default:
             for (int i = 0; i < A_MAX; i++) {
-                bool is_first_dec_stat = true;
-                while (is_first_dec_stat || one_in_(2)) {
-                    is_first_dec_stat = false;
-                    (void)do_dec_stat(target_ptr, i);
-                }
+                do {
+                    (void)do_dec_stat(target_ptr, i); //FIXED
+                } while(one_in_(2));
             }
         }
     }

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -21,6 +21,7 @@
 #include "mutation/mutation-processor.h"
 #include "spell-kind/spells-launcher.h"
 #include "spell-kind/spells-teleport.h"
+#include "spell-kind/spells-random.h"
 #include "spell-realm/spells-chaos.h"
 #include "spell/spells-status.h"
 #include "spell/summon-types.h"
@@ -36,6 +37,7 @@ debug_spell_command debug_spell_commands_list[SPELL_MAX] = {
     { 2, "vanish dungeon", { .spell2 = { vanish_dungeon } } },
     { 3, "true healing", { .spell3 = { true_healing } } },
     { 2, "drop weapons", { .spell2 = { drop_weapons } } },
+    { 4, "ty curse", { .spell4 = { activate_ty_curse } } },
 };
 
 /*!
@@ -65,6 +67,10 @@ bool wiz_debug_spell(player_type *creature_ptr)
                 return false;
             tmp_int = atoi(tmp_val);
             (*(debug_spell_commands_list[i].command_function.spell3.spell_function))(creature_ptr, tmp_int);
+            return true;
+            break;
+        case 4:
+            (*(debug_spell_commands_list[i].command_function.spell4.spell_function))(creature_ptr, true, &tmp_int);
             return true;
             break;
         default:

--- a/src/wizard/wizard-spells.h
+++ b/src/wizard/wizard-spells.h
@@ -3,7 +3,7 @@
 #include "system/angband.h"
 #include "spell/spell-types.h"
 
-#define SPELL_MAX 3
+#define SPELL_MAX 4
 
 typedef struct floor_type floor_type;
 typedef struct player_type player_type;
@@ -19,6 +19,10 @@ typedef union spell_functions {
     struct debug_spell_type3 {
         bool (*spell_function)(player_type *, HIT_POINT);
     } spell3;
+
+    struct debug_spell_type4 { // 実質 ty curse
+        bool (*spell_function)(player_type *, bool, int*);
+    } spell4;
 
 } spell_functions;
 


### PR DESCRIPTION
血の呪いのペナルティ効果やTY_CURSEそれぞれ無限になっていたのを修正．こっちでどちらもチェックしたが、
レビュアーもテストしたければ以下のようにすればすぐテストできる。

* 血の呪いのswitchのrand値を一時的に大きくして魔法を実際に撃つ
* activate_ty_curse内のswitchのrand値を一時的に大きくしてウィザードモードの@コマンドでty curseと打ち込む