### PR TITLE
モンスターが下に走る現象の修正と関数名の変更

### DIFF
--- a/src/monster-floor/monster-sweep-grid.cpp
+++ b/src/monster-floor/monster-sweep-grid.cpp
@@ -344,7 +344,7 @@ bool MonsterSweepGrid::sweep_ranged_attack_grid(POSITION *yp, POSITION *xp)
 
         auto *g_ptr = &floor_ptr->grid_array[y][x];
         this->cost = (int)g_ptr->get_cost(r_ptr);
-        if (this->calc_run_cost(y, x, now_cost)) {
+        if (!this->is_best_cost(y, x, now_cost)) {
             continue;
         }
 
@@ -356,7 +356,7 @@ bool MonsterSweepGrid::sweep_ranged_attack_grid(POSITION *yp, POSITION *xp)
     return this->best != 999;
 }
 
-bool MonsterSweepGrid::calc_run_cost(const POSITION y, const POSITION x, const int now_cost)
+bool MonsterSweepGrid::is_best_cost(const POSITION y, const POSITION x, const int now_cost)
 {
     auto *floor_ptr = this->target_ptr->current_floor_ptr;
     auto *r_ptr = &r_info[floor_ptr->m_list[this->m_idx].r_idx];

--- a/src/monster-floor/monster-sweep-grid.h
+++ b/src/monster-floor/monster-sweep-grid.h
@@ -29,5 +29,5 @@ private:
     void search_room_to_run(POSITION *y, POSITION *x);
     void search_pet_runnable_grid(POSITION *y, POSITION *x, bool no_flow);
     void determine_when_cost(POSITION *yp, POSITION *xp, POSITION y1, POSITION x1, const bool use_scent);
-    bool calc_run_cost(const POSITION y, const POSITION x, const int now_cost);
+    bool is_best_cost(const POSITION y, const POSITION x, const int now_cost);
 };


### PR DESCRIPTION
ざっくり言えば「最小コストでない移動のみする」って挙動になってのが原因でした
あとcalc_run_cost()という関数名は適切でないので修正