### PR TITLE
[Fix] HPが再計算された時に体力ランクを不明にする

### DIFF
--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -244,6 +244,8 @@ void roll_hitdice(player_type *creature_ptr, spell_operation options)
             break;
     }
 
+    creature_ptr->knowledge &= ~(KNOW_HPRATE);
+
     PERCENTAGE percent
         = (int)(((long)creature_ptr->player_hp[PY_MAX_LEVEL - 1] * 200L) / (2 * creature_ptr->hitdie + ((PY_MAX_LEVEL - 1 + 3) * (creature_ptr->hitdie + 1))));
 
@@ -265,7 +267,6 @@ void roll_hitdice(player_type *creature_ptr, spell_operation options)
     }
 
     msg_print(_("体力ランクが変わった。", "Life rate has changed."));
-    creature_ptr->knowledge &= ~(KNOW_HPRATE);
 }
 
 bool life_stream(player_type *creature_ptr, bool message, bool virtue_change)


### PR DESCRIPTION
リファクタリングの結果、体力ランクが既知の状態でシャッフルの魔法や
新生の薬等でHPが再計算された時、再計算後もoptions引数の条件により
体力ランクが既知のままとなっている模様。
不自然なので、HP再計算時には必ず体力ランクの既知フラグをリセットする。