### PR TITLE
[Fix] プレイヤーが感知不能な場面の効果音を制限する

### DIFF
--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -629,14 +629,16 @@ ProjectResult project(player_type *caster_ptr, const MONSTER_IDX who, POSITION r
                         t_x = x_saver;
                     }
 
-                    sound(SOUND_REFLECT);
                     if (is_seen(caster_ptr, m_ptr)) {
+                        sound(SOUND_REFLECT);
                         if ((m_ptr->r_idx == MON_KENSHIROU) || (m_ptr->r_idx == MON_RAOU))
                             msg_print(_("「北斗神拳奥義・二指真空把！」", "The attack bounces!"));
                         else if (m_ptr->r_idx == MON_DIO)
                             msg_print(_("ディオ・ブランドーは指一本で攻撃を弾き返した！", "The attack bounces!"));
                         else
                             msg_print(_("攻撃は跳ね返った！", "The attack bounces!"));
+                    } else if (who <= 0) {
+                        sound(SOUND_REFLECT);
                     }
 
                     if (is_original_ap_and_seen(caster_ptr, m_ptr))

--- a/src/melee/melee-postprocess.cpp
+++ b/src/melee/melee-postprocess.cpp
@@ -146,15 +146,19 @@ static void print_monster_dead_by_monster(player_type *player_ptr, mam_pp_type *
     }
 
     if (mam_pp_ptr->note) {
+        sound_type kill_sound = monster_living(mam_pp_ptr->m_ptr->r_idx) ? SOUND_KILL : SOUND_N_KILL;
+        sound(kill_sound);
         msg_format(_("%^s%s", "%^s%s"), mam_pp_ptr->m_name, mam_pp_ptr->note);
         return;
     }
 
     if (!monster_living(mam_pp_ptr->m_ptr->r_idx)) {
+        sound(SOUND_N_KILL);
         msg_format(_("%^sは破壊された。", "%^s is destroyed."), mam_pp_ptr->m_name);
         return;
     }
 
+        sound(SOUND_KILL);
     msg_format(_("%^sは殺された。", "%^s is killed."), mam_pp_ptr->m_name);
 }
 
@@ -175,8 +179,6 @@ static bool check_monster_hp(player_type *player_ptr, mam_pp_type *mam_pp_ptr)
         return false;
     }
 
-    sound_type kill_sound = monster_living(mam_pp_ptr->m_ptr->r_idx) ? SOUND_KILL : SOUND_N_KILL;
-    sound(kill_sound);
     *(mam_pp_ptr->dead) = true;
     print_monster_dead_by_monster(player_ptr, mam_pp_ptr);
     monster_gain_exp(player_ptr, mam_pp_ptr->who, mam_pp_ptr->m_ptr->r_idx);

--- a/src/monster-floor/monster-summon.cpp
+++ b/src/monster-floor/monster-summon.cpp
@@ -1,6 +1,7 @@
 ﻿#include "monster-floor/monster-summon.h"
 #include "dungeon/dungeon-flag-types.h"
 #include "dungeon/dungeon.h"
+#include "floor/geometry.h"
 #include "floor/wild.h"
 #include "main/sound-definitions-table.h"
 #include "main/sound-of-music.h"
@@ -147,7 +148,25 @@ bool summon_specific(player_type *player_ptr, MONSTER_IDX who, POSITION y1, POSI
     }
 
     summon_specific_type = SUMMON_NONE;
-    sound(SOUND_SUMMON);
+
+    bool notice = false;
+    if (who <= 0) {
+        notice = true;
+    } else {
+        monster_type *m_ptr = &player_ptr->current_floor_ptr->m_list[who];
+        if (is_pet(m_ptr)) {
+            notice = true;
+        } else if (is_seen(player_ptr, m_ptr)) {
+            notice = true;
+        } else if (player_can_see_bold(player_ptr, x, y)) {
+            notice = true;
+        }
+    }
+
+    if (notice) {
+        sound(SOUND_SUMMON);
+    }
+
     return true;
 }
 

--- a/src/mspell/mspell-bolt.cpp
+++ b/src/mspell/mspell-bolt.cpp
@@ -11,6 +11,7 @@
 #include "mspell/mspell-util.h"
 #include "mspell/mspell.h"
 #include "spell/spell-types.h"
+#include "system/floor-type-definition.h"
 #include "system/player-type-definition.h"
 
 /*!
@@ -26,10 +27,14 @@
  */
 MonsterSpellResult spell_RF4_SHOOT(player_type *target_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int TARGET_TYPE)
 {
-    monspell_message(target_ptr, m_idx, t_idx, _("%^sが奇妙な音を発した。", "%^s makes a strange noise."), _("%^sが矢を放った。", "%^s fires an arrow."),
+    bool notice = monspell_message(target_ptr, m_idx, t_idx, _("%^sが奇妙な音を発した。", "%^s makes a strange noise."),
+        _("%^sが矢を放った。", "%^s fires an arrow."),
         _("%^sが%sに矢を放った。", "%^s fires an arrow at %s."), TARGET_TYPE);
 
-    sound(SOUND_SHOOT);
+    if (notice) {
+        sound(SOUND_SHOOT);
+    }
+
     const auto dam = monspell_damage(target_ptr, RF_ABILITY::SHOOT, m_idx, DAM_ROLL);
     const auto proj_res = bolt(target_ptr, m_idx, y, x, GF_ARROW, dam, TARGET_TYPE);
 

--- a/src/mspell/mspell-breath.cpp
+++ b/src/mspell/mspell-breath.cpp
@@ -209,7 +209,9 @@ MonsterSpellResult spell_RF4_BREATH(player_type *target_ptr, int GF_TYPE, POSITI
     if (mon_to_mon && known && !see_either)
         floor_ptr->monster_noise = true;
 
-    sound(SOUND_BREATH);
+    if (known || see_either)
+        sound(SOUND_BREATH);
+
     const auto proj_res = breath(target_ptr, y, x, m_idx, GF_TYPE, dam, 0, true, TARGET_TYPE);
     if (smart_learn_aux && mon_to_player)
         update_smart_learn(target_ptr, m_idx, drs_type);

--- a/src/mspell/mspell-special.cpp
+++ b/src/mspell/mspell-special.cpp
@@ -159,6 +159,10 @@ static MonsterSpellResult spell_RF6_SPECIAL_B(player_type *target_ptr, POSITION 
         return MonsterSpellResult::make_valid();
     }
 
+    if (direct) {
+        sound(SOUND_FALL);
+    }
+
     simple_monspell_message(target_ptr, m_idx, t_idx, _("%^sがあなたを掴んで空中から投げ落とした。", "%^s snatches you, soars into the sky, and drops you."),
         _("%^sが%sを掴んで空中から投げ落とした。", "%^s snatches %s, soars into the sky, and releases its grip."), TARGET_TYPE);
 
@@ -169,8 +173,6 @@ static MonsterSpellResult spell_RF6_SPECIAL_B(player_type *target_ptr, POSITION 
         teleport_player_to(target_ptr, m_ptr->fy, m_ptr->fx, static_cast<teleport_flags>(TELEPORT_NONMAGICAL | TELEPORT_PASSIVE));
     else
         teleport_monster_to(target_ptr, t_idx, m_ptr->fy, m_ptr->fx, 100, static_cast<teleport_flags>(TELEPORT_NONMAGICAL | TELEPORT_PASSIVE));
-
-    sound(SOUND_FALL);
 
     if ((monster_to_player && target_ptr->levitation) || (monster_to_monster && (tr_ptr->flags7 & RF7_CAN_FLY))) {
         simple_monspell_message(target_ptr, m_idx, t_idx, _("あなたは静かに着地した。", "You float gently down to the ground."),

--- a/src/mspell/mspell-util.cpp
+++ b/src/mspell/mspell-util.cpp
@@ -45,9 +45,11 @@ bool monster_near_player(floor_type* floor_ptr, MONSTER_IDX m_idx, MONSTER_IDX t
  * @param msg4 msg_flagがFALSEで、モンスターを対象とする場合のメッセージ
  * @param msg_flag_aux メッセージを分岐するためのフラグ
  * @param TARGET_TYPE プレイヤーを対象とする場合MONSTER_TO_PLAYER、モンスターを対象とする場合MONSTER_TO_MONSTER
+ * @return メッセージを表示した場合trueを返す。
  */
-void monspell_message_base(player_type* target_ptr, MONSTER_IDX m_idx, MONSTER_IDX t_idx, concptr msg1, concptr msg2, concptr msg3, concptr msg4, bool msg_flag_aux, int TARGET_TYPE)
+bool monspell_message_base(player_type* target_ptr, MONSTER_IDX m_idx, MONSTER_IDX t_idx, concptr msg1, concptr msg2, concptr msg3, concptr msg4, bool msg_flag_aux, int TARGET_TYPE)
 {
+    bool notice = false;
     floor_type* floor_ptr = target_ptr->current_floor_ptr;
     bool known = monster_near_player(floor_ptr, m_idx, t_idx);
     bool see_either = see_monster(target_ptr, m_idx) || see_monster(target_ptr, t_idx);
@@ -61,20 +63,27 @@ void monspell_message_base(player_type* target_ptr, MONSTER_IDX m_idx, MONSTER_I
         disturb(target_ptr, true, true);
 
     if (msg_flag_aux) {
-        if (mon_to_player)
+        if (mon_to_player) {
             msg_format(msg1, m_name);
-        else if (mon_to_mon && known && see_either)
+            notice = true;
+        } else if (mon_to_mon && known && see_either) {
             msg_format(msg2, m_name);
+            notice = true;
+        }
     } else {
         if (mon_to_player) {
             msg_format(msg3, m_name);
+            notice = true;
         } else if (mon_to_mon && known && see_either) {
             msg_format(msg4, m_name, t_name);
+            notice = true;
         }
     }
 
     if (mon_to_mon && known && !see_either)
         floor_ptr->monster_noise = true;
+
+    return notice;
 }
 
 /*!
@@ -86,10 +95,11 @@ void monspell_message_base(player_type* target_ptr, MONSTER_IDX m_idx, MONSTER_I
 * @param msg2 プレイヤーが盲目でなく、プレイヤーを対象とする場合のメッセージ
 * @param msg3 プレイヤーが盲目でなく、モンスター対象とする場合のメッセージ
 * @param TARGET_TYPE プレイヤーを対象とする場合MONSTER_TO_PLAYER、モンスターを対象とする場合MONSTER_TO_MONSTER
-*/
-void monspell_message(player_type* target_ptr, MONSTER_IDX m_idx, MONSTER_IDX t_idx, concptr msg1, concptr msg2, concptr msg3, int TARGET_TYPE)
+ * @return メッセージを表示した場合trueを返す。
+ */
+bool monspell_message(player_type* target_ptr, MONSTER_IDX m_idx, MONSTER_IDX t_idx, concptr msg1, concptr msg2, concptr msg3, int TARGET_TYPE)
 {
-    monspell_message_base(target_ptr, m_idx, t_idx, msg1, msg1, msg2, msg3, target_ptr->blind > 0, TARGET_TYPE);
+    return monspell_message_base(target_ptr, m_idx, t_idx, msg1, msg1, msg2, msg3, target_ptr->blind > 0, TARGET_TYPE);
 }
 
 /*!

--- a/src/mspell/mspell-util.h
+++ b/src/mspell/mspell-util.h
@@ -15,6 +15,6 @@ typedef struct floor_type floor_type;
 typedef struct player_type player_type;
 bool see_monster(player_type *player_ptr, MONSTER_IDX m_idx);
 bool monster_near_player(floor_type* floor_ptr, MONSTER_IDX m_idx, MONSTER_IDX t_idx);
-void monspell_message_base(player_type* target_ptr, MONSTER_IDX m_idx, MONSTER_IDX t_idx, concptr msg1, concptr msg2, concptr msg3, concptr msg4, bool msg_flag_aux, int TARGET_TYPE);
-void monspell_message(player_type* target_ptr, MONSTER_IDX m_idx, MONSTER_IDX t_idx, concptr msg1, concptr msg2, concptr msg3, int TARGET_TYPE);
+bool monspell_message_base(player_type* target_ptr, MONSTER_IDX m_idx, MONSTER_IDX t_idx, concptr msg1, concptr msg2, concptr msg3, concptr msg4, bool msg_flag_aux, int TARGET_TYPE);
+bool monspell_message(player_type* target_ptr, MONSTER_IDX m_idx, MONSTER_IDX t_idx, concptr msg1, concptr msg2, concptr msg3, int TARGET_TYPE);
 void simple_monspell_message(player_type* target_ptr, MONSTER_IDX m_idx, MONSTER_IDX t_idx, concptr msg1, concptr msg2, int TARGET_TYPE);

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -208,7 +208,8 @@ void teleport_level(player_type *creature_ptr, MONSTER_IDX m_idx)
     }
 
     delete_monster_idx(creature_ptr, m_idx);
-    sound(SOUND_TPLEVEL);
+    if (see_m)
+        sound(SOUND_TPLEVEL);
 }
 
 bool teleport_level_other(player_type *caster_ptr)


### PR DESCRIPTION
プレイヤーから見えないところで見えない場所へのモンスター召喚が行われた等、不自然な効果音の再生を行わないようにする。

-  SOUND_REFLECT：反射したモンスターが見える場合か、プレイヤーorペットが発射したボルトが反射された場合に再生する
-  SOUND_KILL（SOUND_N_KILL）：対象が見えない場合は再生しない
-  SOUND_SUMMON：召喚主がプレイヤーorペット、召喚主のモンスターが見える、召喚目標地点が見える場合に再生する。
-  SOUND_SHOOT：モンスターAからモンスターBへの射撃は、プレイヤーから近くてAB両方見える場合に再生する。
-  SOUND_BREATH：プレイヤーがブレスを吐くモンスターと近いか、ブレス対象が見える場合に再生する。
-  SOUND_FALL：対象がプレイヤーの場合に再生する。
-  SOUND_TPLEVEL：モンスター対象のレベルテレポートは対象が見える場合に再生する。
