### PR TITLE
Feature/refactor recall random quest failure

### DIFF
--- a/src/floor/pattern-walk.cpp
+++ b/src/floor/pattern-walk.cpp
@@ -32,7 +32,7 @@
  * @brief パターン終点到達時のテレポート処理を行う
  * @param creature_ptr プレーヤーへの参照ポインタ
  */
-static void pattern_teleport(player_type *creature_ptr)
+void pattern_teleport(player_type *creature_ptr)
 {
     DEPTH min_level = 0;
     DEPTH max_level = 99;

--- a/src/floor/pattern-walk.cpp
+++ b/src/floor/pattern-walk.cpp
@@ -27,6 +27,7 @@
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "world/world.h"
+#include "world/world-movement-processor.h"
 
 /*!
  * @brief パターン終点到達時のテレポート処理を行う
@@ -89,6 +90,9 @@ void pattern_teleport(player_type *creature_ptr)
      * and create a first saved floor
      */
     prepare_change_floor_mode(creature_ptr, CFM_FIRST_FLOOR);
+
+    check_random_quest_auto_failure(creature_ptr);
+
     creature_ptr->leaving = true;
 }
 

--- a/src/floor/pattern-walk.h
+++ b/src/floor/pattern-walk.h
@@ -5,3 +5,4 @@
 typedef struct player_type player_type;
 bool pattern_effect(player_type *creature_ptr);
 bool pattern_seq(player_type *creature_ptr, POSITION c_y, POSITION c_x, POSITION n_y, POSITION n_x);
+void pattern_teleport(player_type *creature_ptr);

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -13,6 +13,7 @@
 #include "effect/effect-processor.h"
 #include "floor/cave.h"
 #include "floor/floor-util.h"
+#include "floor/pattern-walk.h"
 #include "mind/mind-blue-mage.h"
 #include "monster-floor/monster-generator.h"
 #include "monster-floor/monster-summon.h"
@@ -38,6 +39,7 @@ debug_spell_command debug_spell_commands_list[SPELL_MAX] = {
     { 3, "true healing", { .spell3 = { true_healing } } },
     { 2, "drop weapons", { .spell2 = { drop_weapons } } },
     { 4, "ty curse", { .spell4 = { activate_ty_curse } } },
+    { 5, "pattern teleport", { .spell5 = { pattern_teleport } } },
 };
 
 /*!
@@ -71,6 +73,10 @@ bool wiz_debug_spell(player_type *creature_ptr)
             break;
         case 4:
             (*(debug_spell_commands_list[i].command_function.spell4.spell_function))(creature_ptr, true, &tmp_int);
+            return true;
+            break;
+        case 5:
+            (*(debug_spell_commands_list[i].command_function.spell5.spell_function))(creature_ptr);
             return true;
             break;
         default:

--- a/src/wizard/wizard-spells.h
+++ b/src/wizard/wizard-spells.h
@@ -3,7 +3,7 @@
 #include "system/angband.h"
 #include "spell/spell-types.h"
 
-#define SPELL_MAX 4
+#define SPELL_MAX 5
 
 typedef struct floor_type floor_type;
 typedef struct player_type player_type;
@@ -23,6 +23,10 @@ typedef union spell_functions {
     struct debug_spell_type4 { // 実質 ty curse
         bool (*spell_function)(player_type *, bool, int*);
     } spell4;
+
+    struct debug_spell_type5 {
+        void (*spell_function)(player_type *);
+    } spell5;
 
 } spell_functions;
 

--- a/src/world/world-movement-processor.cpp
+++ b/src/world/world-movement-processor.cpp
@@ -24,8 +24,11 @@
  * @brief プレイヤーの現在ダンジョンIDと階層に応じて、ダンジョン内ランクエの自動放棄を行う
  * @param creature_ptr プレーヤーへの参照ポインタ
  */
-void check_random_quest_auto_failure(player_type *creature_ptr) {
-    if (creature_ptr->dungeon_idx != DUNGEON_ANGBAND) return;
+void check_random_quest_auto_failure(player_type *creature_ptr)
+{
+    if (creature_ptr->dungeon_idx != DUNGEON_ANGBAND) {
+        return;
+    }
     for (auto i = MIN_RANDOM_QUEST; i < MAX_RANDOM_QUEST + 1; i++) {
         auto q_ptr = &quest[i];
         if ((q_ptr->type == QUEST_TYPE_RANDOM) && (q_ptr->status == QUEST_STATUS_TAKEN) && (q_ptr->level < creature_ptr->current_floor_ptr->dun_level)) {

--- a/src/world/world-movement-processor.cpp
+++ b/src/world/world-movement-processor.cpp
@@ -25,16 +25,15 @@
  * @param creature_ptr プレーヤーへの参照ポインタ
  */
 void check_random_quest_auto_failure(player_type *creature_ptr) {
-    if (creature_ptr->dungeon_idx == DUNGEON_ANGBAND) {
-        for (int i = MIN_RANDOM_QUEST; i < MAX_RANDOM_QUEST + 1; i++) {
-            quest_type *const q_ptr = &quest[i];
-            if ((q_ptr->type == QUEST_TYPE_RANDOM) && (q_ptr->status == QUEST_STATUS_TAKEN) && (q_ptr->level < creature_ptr->current_floor_ptr->dun_level)) {
-                q_ptr->status = QUEST_STATUS_FAILED;
-                q_ptr->complev = (byte)creature_ptr->lev;
-                update_playtime();
-                q_ptr->comptime = current_world_ptr->play_time;
-                r_info[q_ptr->r_idx].flags1 &= ~(RF1_QUESTOR);
-            }
+    if (creature_ptr->dungeon_idx != DUNGEON_ANGBAND) return;
+    for (auto i = MIN_RANDOM_QUEST; i < MAX_RANDOM_QUEST + 1; i++) {
+        auto q_ptr = &quest[i];
+        if ((q_ptr->type == QUEST_TYPE_RANDOM) && (q_ptr->status == QUEST_STATUS_TAKEN) && (q_ptr->level < creature_ptr->current_floor_ptr->dun_level)) {
+            q_ptr->status = QUEST_STATUS_FAILED;
+            q_ptr->complev = (byte)creature_ptr->lev;
+            update_playtime();
+            q_ptr->comptime = current_world_ptr->play_time;
+            r_info[q_ptr->r_idx].flags1 &= ~(RF1_QUESTOR);
         }
     }
 }

--- a/src/world/world-movement-processor.cpp
+++ b/src/world/world-movement-processor.cpp
@@ -19,6 +19,26 @@
 #include "view/display-messages.h"
 #include "world/world.h"
 
+
+/*!
+ * @brief プレイヤーの現在ダンジョンIDと階層に応じて、ダンジョン内ランクエの自動放棄を行う
+ * @param creature_ptr プレーヤーへの参照ポインタ
+ */
+void check_random_quest_auto_failure(player_type *creature_ptr) {
+    if (creature_ptr->dungeon_idx == DUNGEON_ANGBAND) {
+        for (int i = MIN_RANDOM_QUEST; i < MAX_RANDOM_QUEST + 1; i++) {
+            quest_type *const q_ptr = &quest[i];
+            if ((q_ptr->type == QUEST_TYPE_RANDOM) && (q_ptr->status == QUEST_STATUS_TAKEN) && (q_ptr->level < creature_ptr->current_floor_ptr->dun_level)) {
+                q_ptr->status = QUEST_STATUS_FAILED;
+                q_ptr->complev = (byte)creature_ptr->lev;
+                update_playtime();
+                q_ptr->comptime = current_world_ptr->play_time;
+                r_info[q_ptr->r_idx].flags1 &= ~(RF1_QUESTOR);
+            }
+        }
+    }
+}
+
 /*!
  * @brief 10ゲームターンが進行するごとに帰還の残り時間カウントダウンと発動を処理する。
  * / Handle involuntary movement once every 10 game turns
@@ -94,19 +114,7 @@ void execute_recall(player_type *creature_ptr)
     prepare_change_floor_mode(creature_ptr, CFM_FIRST_FLOOR);
     creature_ptr->leaving = true;
 
-    if (creature_ptr->dungeon_idx == DUNGEON_ANGBAND) {
-        for (int i = MIN_RANDOM_QUEST; i < MAX_RANDOM_QUEST + 1; i++) {
-            quest_type *const q_ptr = &quest[i];
-            if ((q_ptr->type == QUEST_TYPE_RANDOM) && (q_ptr->status == QUEST_STATUS_TAKEN) && (q_ptr->level < floor_ptr->dun_level)) {
-                q_ptr->status = QUEST_STATUS_FAILED;
-                q_ptr->complev = (byte)creature_ptr->lev;
-                update_playtime();
-                q_ptr->comptime = current_world_ptr->play_time;
-                r_info[q_ptr->r_idx].flags1 &= ~(RF1_QUESTOR);
-            }
-        }
-    }
-
+    check_random_quest_auto_failure(creature_ptr);
     sound(SOUND_TPLEVEL);
 }
 

--- a/src/world/world-movement-processor.cpp
+++ b/src/world/world-movement-processor.cpp
@@ -94,19 +94,16 @@ void execute_recall(player_type *creature_ptr)
     prepare_change_floor_mode(creature_ptr, CFM_FIRST_FLOOR);
     creature_ptr->leaving = true;
 
-    if (creature_ptr->dungeon_idx != DUNGEON_ANGBAND) {
-        sound(SOUND_TPLEVEL);
-        return;
-    }
-
-    for (int i = MIN_RANDOM_QUEST; i < MAX_RANDOM_QUEST + 1; i++) {
-        quest_type *const q_ptr = &quest[i];
-        if ((q_ptr->type == QUEST_TYPE_RANDOM) && (q_ptr->status == QUEST_STATUS_TAKEN) && (q_ptr->level < floor_ptr->dun_level)) {
-            q_ptr->status = QUEST_STATUS_FAILED;
-            q_ptr->complev = (byte)creature_ptr->lev;
-            update_playtime();
-            q_ptr->comptime = current_world_ptr->play_time;
-            r_info[q_ptr->r_idx].flags1 &= ~(RF1_QUESTOR);
+    if (creature_ptr->dungeon_idx == DUNGEON_ANGBAND) {
+        for (int i = MIN_RANDOM_QUEST; i < MAX_RANDOM_QUEST + 1; i++) {
+            quest_type *const q_ptr = &quest[i];
+            if ((q_ptr->type == QUEST_TYPE_RANDOM) && (q_ptr->status == QUEST_STATUS_TAKEN) && (q_ptr->level < floor_ptr->dun_level)) {
+                q_ptr->status = QUEST_STATUS_FAILED;
+                q_ptr->complev = (byte)creature_ptr->lev;
+                update_playtime();
+                q_ptr->comptime = current_world_ptr->play_time;
+                r_info[q_ptr->r_idx].flags1 &= ~(RF1_QUESTOR);
+            }
         }
     }
 

--- a/src/world/world-movement-processor.h
+++ b/src/world/world-movement-processor.h
@@ -1,5 +1,6 @@
 ﻿#pragma once
 
 typedef struct player_type player_type;
-void execute_recall(player_type* creature_ptr);
+void check_random_quest_auto_failure(player_type *creature_ptr);
+void execute_recall(player_type *creature_ptr);
 void execute_floor_reset(player_type* creature_ptr);


### PR DESCRIPTION
本修正で、トランプの塔のテレポートのランクエ自動失敗処理をパターンVaultでのテレポートにも充てるよう修正しました。
コードレビューの焦点やテスト手順は以下の通りでお願いします。

- [ ] トランプの塔からのレベル指定テレポートで従来通り間のランクエが即座に自動失敗するか．
- [ ] ウィザードモードの@コマンドで"pattern teleport"と入力することでパターンVaultの終着点ワープが再現出来ているか．
- [ ] パターンVaultの終着点ワープでも間のランクエが即座に自動失敗になるか。