### PR TITLE
[Fix] 武器祝福で簡易鑑定状態がリセットされない

### DIFF
--- a/src/mind/mind-priest.cpp
+++ b/src/mind/mind-priest.cpp
@@ -61,7 +61,7 @@ bool bless_weapon(player_type *caster_ptr)
 #endif
         o_ptr->curse_flags.clear();
         set_bits(o_ptr->ident, IDENT_SENSE);
-        set_bits(o_ptr->feeling, FEEL_NONE);
+        o_ptr->feeling = FEEL_NONE;
         set_bits(caster_ptr->update, PU_BONUS);
         set_bits(caster_ptr->window_flags, PW_EQUIP | PW_FLOOR_ITEM_LIST);
     }


### PR DESCRIPTION
ビットフラグでない変数に対しビット操作を誤って行っており
簡易鑑定状態がリセットされないので、武器祝福が成功しても
簡易鑑定状態が「呪われている」のままとなってしまう。
ビット操作ではなく代入に修正する。