### PR TITLE
[Refactor] ビットフラグ操作マクロ群を関数に変更

### DIFF
--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -239,7 +239,7 @@ static errr exe_reading_savefile(player_type *creature_ptr)
     if (h_older_than(0, 4, 10))
         set_zangband_pet(creature_ptr);
     else
-        rd_s16b(&creature_ptr->pet_extra_flags);
+        rd_u16b(&creature_ptr->pet_extra_flags);
 
     if (!h_older_than(1, 0, 9)) {
         char *buf;

--- a/src/player/player-class.h
+++ b/src/player/player-class.h
@@ -22,7 +22,7 @@
 
 typedef struct player_magic {
     tval_type spell_book{}; /* Tval of spell books (if any) */
-    int spell_xtra{}; /* Something for later */
+    BIT_FLAGS8 spell_xtra{}; /* Something for later */
 
     int spell_stat{}; /* Stat for spells (if any)  */
     int spell_type{}; /* Spell type (mage/priest) */

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -285,7 +285,7 @@ WEIGHT calc_inventory_weight(player_type *creature_ptr)
  */
 static void update_bonuses(player_type *creature_ptr)
 {
-    int empty_hands_status = empty_hands(creature_ptr, true);
+    auto empty_hands_status = empty_hands(creature_ptr, true);
     object_type *o_ptr;
 
     /* Save the old vision stuff */

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -225,7 +225,7 @@ typedef struct player_type {
     s16b old_realm{}; /* Record of realm changes */
 
     s16b pet_follow_distance{}; /* Length of the imaginary "leash" for pets */
-    s16b pet_extra_flags{}; /* Various flags for controling pets */
+    BIT_FLAGS16 pet_extra_flags{}; /* Various flags for controling pets */
 
     MONSTER_IDX today_mon{}; //!< 日替わり賞金首を知っていればそのモンスターID、知らなければ 0
 

--- a/src/util/bit-flags-calculator.h
+++ b/src/util/bit-flags-calculator.h
@@ -1,13 +1,105 @@
 ﻿#pragma once
 
-#define reset_bits(FLAG, INDEX) ((FLAG) &= ~(INDEX))
-#define set_bits(FLAG, INDEX) ((FLAG) |= (INDEX))
-#define any_bits(FLAG, INDEX) (((FLAG) & (INDEX)) != 0)
-#define all_bits(FLAG, INDEX) (((FLAG) & (INDEX)) == (INDEX))
-#define none_bits(FLAG, INDEX) (((FLAG) & (INDEX)) == 0)
-#define match_bits(FLAG, INDEX, MATCH) (((FLAG) & (INDEX)) == (MATCH))
+#include <cassert>
+#include <type_traits>
+
 #define has_flag(ARRAY, INDEX) !!((ARRAY)[(INDEX) / 32] & (1UL << ((INDEX) % 32)))
 #define add_flag(ARRAY, INDEX) ((ARRAY)[(INDEX) / 32] |= (1UL << ((INDEX) % 32)))
 #define remove_flag(ARRAY, INDEX) ((ARRAY)[(INDEX) / 32] &= ~(1UL << ((INDEX) % 32)))
 #define is_pval_flag(INDEX) ((TR_STR <= (INDEX) && (INDEX) <= TR_MAGIC_MASTERY) || (TR_STEALTH <= (INDEX) && (INDEX) <= TR_BLOWS))
 #define has_pval_flags(ARRAY) !!((ARRAY)[0] & (0x00003f7f))
+
+template <typename T, typename U>
+void bit_flags_calculator_assert(T, [[maybe_unused]] U bits)
+{
+    static_assert(std::is_integral_v<T> || std::is_enum_v<T>);
+    if constexpr (std::is_integral_v<T>) {
+        static_assert(std::is_unsigned_v<T>);
+    }
+    if constexpr (sizeof(T) < sizeof(U)) {
+        assert(static_cast<T>(bits) == bits);
+    }
+}
+
+/*!
+ * @brief フラグ変数の指定したビットをセットする
+ *
+ * @param flag 操作の対象となるフラグ変数
+ * @param bits セットする対象のビットがONであるビットパターン
+ */
+template <typename T, typename U>
+void set_bits(T &flag, U bits)
+{
+    bit_flags_calculator_assert(flag, bits);
+    flag |= static_cast<T>(bits);
+}
+
+/*!
+ * @brief フラグ変数の指定したビットをリセットする
+ *
+ * @param flag 操作の対象となるフラグ変数
+ * @param bits リセットする対象のビットがONであるビットパターン
+ */
+template <typename T, typename U>
+void reset_bits(T &flag, U bits)
+{
+    bit_flags_calculator_assert(flag, bits);
+    flag &= ~static_cast<T>(bits);
+}
+
+/*!
+ * @brief フラグ変数の指定したビットがすべてONかどうか検査する
+ *
+ * @param flag 検査する対象となるフラグ変数
+ * @param bits 検査する対象のビットがONであるビットパターン
+ * @return bitsで指定したビットがすべてONであればtrue、そうでなければfalse
+ */
+template <typename T, typename U>
+bool all_bits(T flag, U bits)
+{
+    bit_flags_calculator_assert(flag, bits);
+    return (flag & static_cast<T>(bits)) == static_cast<T>(bits);
+}
+
+/*!
+ * @brief フラグ変数の指定したビットのいずれかがONかどうか検査する
+ *
+ * @param flag 検査する対象となるフラグ変数
+ * @param bits 検査する対象のビットがONであるビットパターン
+ * @return bitsで指定したビットのいずれかがONであればtrue、そうでなければfalse
+ */
+template <typename T, typename U>
+bool any_bits(T flag, U bits)
+{
+    bit_flags_calculator_assert(flag, bits);
+    return (flag & static_cast<T>(bits)) != 0;
+}
+
+/*!
+ * @brief フラグ変数の指定したビットがすべてOFFかどうか検査する
+ *
+ * @param flag 検査する対象となるフラグ変数
+ * @param bits 検査する対象のビットがONであるビットパターン
+ * @return bitsで指定したビットがすべてOFFであればtrue、そうでなければfalse
+ */
+template <typename T, typename U>
+bool none_bits(T flag, U bits)
+{
+    return !any_bits(flag, bits);
+}
+
+/*!
+ * @brief フラグ変数の指定したビットにおいて、指定したビットパターンとON/OFFがすべて一致するかどうかを検査する
+ *
+ * @param flag 検査する対象となるフラグ変数
+ * @param bits 検査する対象のビットがONであるビットパターン
+ * @param match bitsで指定したビットにおいて、ON/OFFがすべて一致するかどうか比較するビットパターン
+ * @return すべて一致すればtrue、そうでなければfalse
+ */
+template <typename T, typename U>
+bool match_bits(T flag, U bits, U match)
+{
+    bit_flags_calculator_assert(flag, bits);
+    bit_flags_calculator_assert(flag, match);
+    return (flag & static_cast<T>(bits)) == static_cast<T>(match);
+}


### PR DESCRIPTION
なるべくマクロの使用は避けるべきなので、ビットフラグ操作
マクロを関数に変更する。
対象: set_bits, reset_bits, any_bits, all_bits, none_bits, match_bits

また、関数化にあたり追加した引数型のアサーションにより
見つかったビットフラグとして扱っている符号付き変数を、
符号無し変数に変更する。