### PR TITLE
Change English description for HUNGRY blows

### DIFF
--- a/src/lore/combat-types-setter.cpp
+++ b/src/lore/combat-types-setter.cpp
@@ -254,7 +254,7 @@ void set_monster_blow_effect(lore_type *lore_ptr, int m)
         lore_ptr->qc = TERM_ORANGE;
         break;
     case RBE_HUNGRY:
-        lore_ptr->q = _("空腹を進行させる", "be hangry");
+        lore_ptr->q = _("空腹を進行させる", "increase hunger");
         lore_ptr->qc = TERM_L_BLUE;
         break;
     case RBE_FLAVOR:


### PR DESCRIPTION
Avoids a spelling mistake and implies an action rather than a state.