### PR TITLE
[Refactor] TRフラグ変数の配列型を型エイリアス化

### DIFF
--- a/src/action/throw-util.h
+++ b/src/action/throw-util.h
@@ -38,7 +38,7 @@ typedef struct it_type {
     bool return_when_thrown;
     GAME_TEXT o_name[MAX_NLEN];
     int msec;
-    BIT_FLAGS obj_flags[TR_FLAG_SIZE];
+    TrFlags obj_flags;
     bool come_back;
     bool do_drop;
     grid_type *g_ptr;

--- a/src/artifact/random-art-characteristics.cpp
+++ b/src/artifact/random-art-characteristics.cpp
@@ -157,7 +157,7 @@ void get_random_name(object_type *o_ptr, char *return_name, bool armour, int pow
 /*対邪平均ダメージの計算処理*/
 static HIT_POINT calc_arm_avgdamage(player_type *player_ptr, object_type *o_ptr)
 {
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     object_flags(player_ptr, o_ptr, flgs);
     HIT_POINT base, forced, vorpal;
     HIT_POINT s_evil = forced = vorpal = 0;
@@ -186,7 +186,7 @@ static HIT_POINT calc_arm_avgdamage(player_type *player_ptr, object_type *o_ptr)
 
 bool has_extreme_damage_rate(player_type *player_ptr, object_type *o_ptr)
 {
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     object_flags(player_ptr, o_ptr, flgs);
     if (has_flag(flgs, TR_VAMPIRIC)) {
         if (has_flag(flgs, TR_BLOWS) && (o_ptr->pval == 1) && (calc_arm_avgdamage(player_ptr, o_ptr) > 52)) {

--- a/src/artifact/random-art-generator.cpp
+++ b/src/artifact/random-art-generator.cpp
@@ -43,7 +43,7 @@ static bool weakening_artifact(player_type *player_ptr, object_type *o_ptr)
 {
     KIND_OBJECT_IDX k_idx = lookup_kind(o_ptr->tval, o_ptr->sval);
     object_kind *k_ptr = &k_info[k_idx];
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     object_flags(player_ptr, o_ptr, flgs);
 
     if (has_flag(flgs, TR_KILL_EVIL)) {

--- a/src/cmd-item/cmd-refill.cpp
+++ b/src/cmd-item/cmd-refill.cpp
@@ -36,7 +36,7 @@ static void do_cmd_refill_lamp(player_type *user_ptr)
     if (!o_ptr)
         return;
 
-    BIT_FLAGS flgs[TR_FLAG_SIZE], flgs2[TR_FLAG_SIZE];
+    TrFlags flgs, flgs2;
     object_flags(user_ptr, o_ptr, flgs);
 
     PlayerEnergy(user_ptr).set_player_turn_energy(50);
@@ -75,7 +75,7 @@ static void do_cmd_refill_torch(player_type *user_ptr)
     if (!o_ptr)
         return;
 
-    BIT_FLAGS flgs[TR_FLAG_SIZE], flgs2[TR_FLAG_SIZE];
+    TrFlags flgs, flgs2;
     object_flags(user_ptr, o_ptr, flgs);
 
     PlayerEnergy(user_ptr).set_player_turn_energy(50);

--- a/src/cmd-item/cmd-smith.cpp
+++ b/src/cmd-item/cmd-smith.cpp
@@ -231,7 +231,7 @@ static void drain_essence(player_type *creature_ptr)
     bool observe = false;
     int old_ds, old_dd, old_to_h, old_to_d, old_ac, old_to_a, old_pval, old_name2;
     TIME_EFFECT old_timeout;
-    BIT_FLAGS old_flgs[TR_FLAG_SIZE], new_flgs[TR_FLAG_SIZE];
+    TrFlags old_flgs, new_flgs;
     object_type *o_ptr;
     concptr q, s;
     POSITION iy, ix;
@@ -991,7 +991,7 @@ static void erase_essence(player_type *creature_ptr)
     concptr q, s;
     object_type *o_ptr;
     GAME_TEXT o_name[MAX_NLEN];
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
 
     item_tester_hook = object_is_smith;
 

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -85,7 +85,7 @@ static MULTIPLY calc_shot_damage_with_slay(
 
     monster_race *race_ptr = &r_info[monster_ptr->r_idx];
 
-    BIT_FLAGS flags[TR_FLAG_SIZE], bow_flags[TR_FLAG_SIZE], arrow_flags[TR_FLAG_SIZE];
+    TrFlags flags, bow_flags, arrow_flags;
     object_flags(sniper_ptr, arrow_ptr, arrow_flags);
     object_flags(sniper_ptr, bow_ptr, bow_flags);
 

--- a/src/combat/slaying.cpp
+++ b/src/combat/slaying.cpp
@@ -28,7 +28,7 @@
  * @param m_ptr 目標モンスターの構造体参照ポインタ
  * @return スレイング加味後の倍率(/10倍)
  */
-MULTIPLY mult_slaying(player_type *player_ptr, MULTIPLY mult, const BIT_FLAGS *flgs, monster_type *m_ptr)
+MULTIPLY mult_slaying(player_type *player_ptr, MULTIPLY mult, const TrFlags &flgs, monster_type *m_ptr)
 {
     static const struct slay_table_t {
         int slay_flag;
@@ -86,7 +86,7 @@ MULTIPLY mult_slaying(player_type *player_ptr, MULTIPLY mult, const BIT_FLAGS *f
  * @param m_ptr 目標モンスターの構造体参照ポインタ
  * @return スレイング加味後の倍率(/10倍)
  */
-MULTIPLY mult_brand(player_type *player_ptr, MULTIPLY mult, const BIT_FLAGS *flgs, monster_type *m_ptr)
+MULTIPLY mult_brand(player_type *player_ptr, MULTIPLY mult, const TrFlags &flgs, monster_type *m_ptr)
 {
     static const struct brand_table_t {
         int brand_flag;
@@ -150,7 +150,7 @@ MULTIPLY mult_brand(player_type *player_ptr, MULTIPLY mult, const BIT_FLAGS *flg
  */
 HIT_POINT calc_attack_damage_with_slay(player_type *attacker_ptr, object_type *o_ptr, HIT_POINT tdam, monster_type *m_ptr, combat_options mode, bool thrown)
 {
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     object_flags(attacker_ptr, o_ptr, flgs);
     torch_flags(o_ptr, flgs); /* torches has secret flags */
 

--- a/src/combat/slaying.h
+++ b/src/combat/slaying.h
@@ -6,6 +6,6 @@
 typedef struct monster_type monster_type;
 typedef struct object_type object_type;
 typedef struct player_type player_type;
-MULTIPLY mult_slaying(player_type *player_ptr, MULTIPLY mult, const BIT_FLAGS *flgs, monster_type *m_ptr);
-MULTIPLY mult_brand(player_type *player_ptr, MULTIPLY mult, const BIT_FLAGS *flgs, monster_type *m_ptr);
+MULTIPLY mult_slaying(player_type *player_ptr, MULTIPLY mult, const TrFlags &flgs, monster_type *m_ptr);
+MULTIPLY mult_brand(player_type *player_ptr, MULTIPLY mult, const TrFlags &flgs, monster_type *m_ptr);
 HIT_POINT calc_attack_damage_with_slay(player_type *attacker_ptr, object_type *o_ptr, HIT_POINT tdam, monster_type *m_ptr, combat_options mode, bool thrown);

--- a/src/effect/effect-item.cpp
+++ b/src/effect/effect-item.cpp
@@ -67,7 +67,7 @@ bool affect_item(player_type *caster_ptr, MONSTER_IDX who, POSITION r, POSITION 
 #else
         bool plural = (o_ptr->number > 1);
 #endif
-        BIT_FLAGS flags[TR_FLAG_SIZE];
+        TrFlags flags;
         object_flags(caster_ptr, o_ptr, flags);
         bool is_artifact = object_is_artifact(o_ptr);
         switch (typ) {

--- a/src/flavor/flavor-describer.cpp
+++ b/src/flavor/flavor-describer.cpp
@@ -150,7 +150,7 @@ static void describe_bow(player_type *player_ptr, flavor_type *flavor_ptr)
     if (!(flavor_ptr->mode & OD_DEBUG)) {
         num_fire = calc_num_fire(player_ptr, flavor_ptr->o_ptr);
     } else {
-        BIT_FLAGS flgs[TR_FLAG_SIZE];
+        TrFlags flgs;
         object_flags(player_ptr, flavor_ptr->o_ptr, flgs);
         if (has_flag(flgs, TR_XTRA_SHOTS))
             num_fire += 100;

--- a/src/flavor/flavor-util.cpp
+++ b/src/flavor/flavor-util.cpp
@@ -141,7 +141,7 @@ static void add_inscription(char **short_flavor, concptr str) { *short_flavor = 
  * sprintf(t, "%+d", n), and return a pointer to the terminator.
  * Note that we always print a sign, either "+" or "-".
  */
-static char *inscribe_flags_aux(std::vector<flag_insc_table>& fi_vec, BIT_FLAGS flgs[TR_FLAG_SIZE], bool kanji, char *ptr)
+static char *inscribe_flags_aux(std::vector<flag_insc_table> &fi_vec, const TrFlags &flgs, bool kanji, char *ptr)
 {
 #ifdef JP
 #else
@@ -162,7 +162,7 @@ static char *inscribe_flags_aux(std::vector<flag_insc_table>& fi_vec, BIT_FLAGS 
  * @param flgs 対応するオブジェクトのフラグ文字列
  * @return 1つでも該当の特性があったらTRUEを返す。
  */
-static bool has_flag_of(std::vector<flag_insc_table>& fi_vec, BIT_FLAGS flgs[TR_FLAG_SIZE])
+static bool has_flag_of(std::vector<flag_insc_table> &fi_vec, const TrFlags &flgs)
 {
     for (flag_insc_table &fi : fi_vec)
         if (has_flag(flgs, fi.flag) && (fi.except_flag == -1 || !has_flag(flgs, fi.except_flag)))
@@ -182,7 +182,7 @@ static bool has_flag_of(std::vector<flag_insc_table>& fi_vec, BIT_FLAGS flgs[TR_
 char *get_ability_abbreviation(player_type *player_ptr, char *short_flavor, object_type *o_ptr, bool kanji, bool all)
 {
     char *prev_ptr = short_flavor;
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     object_flags(player_ptr, o_ptr, flgs);
     if (!all) {
         object_kind *k_ptr = &k_info[o_ptr->k_idx];
@@ -457,6 +457,12 @@ char *object_desc_count_japanese(char *t, object_type *o_ptr)
 }
 #endif
 
-bool has_lite_flag(BIT_FLAGS *flags) { return has_flag(flags, TR_LITE_1) || has_flag(flags, TR_LITE_2) || has_flag(flags, TR_LITE_3); }
+bool has_lite_flag(const TrFlags &flags)
+{
+    return has_flag(flags, TR_LITE_1) || has_flag(flags, TR_LITE_2) || has_flag(flags, TR_LITE_3);
+}
 
-bool has_dark_flag(BIT_FLAGS *flags) { return has_flag(flags, TR_LITE_M1) || has_flag(flags, TR_LITE_M2) || has_flag(flags, TR_LITE_M3); }
+bool has_dark_flag(const TrFlags &flags)
+{
+    return has_flag(flags, TR_LITE_M1) || has_flag(flags, TR_LITE_M2) || has_flag(flags, TR_LITE_M3);
+}

--- a/src/flavor/flavor-util.h
+++ b/src/flavor/flavor-util.h
@@ -31,7 +31,7 @@ typedef struct flavor_type {
     char tmp_val[MAX_NLEN + 160];
     char tmp_val2[MAX_NLEN + 10];
     char fake_insc_buf[30];
-    BIT_FLAGS tr_flags[TR_FLAG_SIZE];
+    TrFlags tr_flags;
     object_type *bow_ptr;
     object_kind *k_ptr;
     object_kind *flavor_k_ptr;
@@ -46,8 +46,8 @@ char *object_desc_num(char *t, uint n);
 char *object_desc_int(char *t, int v);
 char *get_ability_abbreviation(player_type *player_ptr, char *ptr, object_type *o_ptr, bool kanji, bool all);
 void get_inscription(player_type *player_ptr, char *buff, object_type *o_ptr);
-bool has_lite_flag(BIT_FLAGS *flags);
-bool has_dark_flag(BIT_FLAGS *flags);
+bool has_lite_flag(const TrFlags &flags);
+bool has_dark_flag(const TrFlags &flags);
 
 #ifdef JP
 char *object_desc_count_japanese(char *t, object_type *o_ptr);

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -141,7 +141,7 @@ void process_player_hp_mp(player_type *creature_ptr)
 
         object_type *o_ptr;
         o_ptr = &creature_ptr->inventory_list[INVEN_LITE];
-        BIT_FLAGS flgs[TR_FLAG_SIZE];
+        TrFlags flgs;
         object_flags(creature_ptr, o_ptr, flgs);
 
         if (creature_ptr->inventory_list[INVEN_LITE].tval && !has_flag(flgs, TR_DARK_SOURCE) && !has_resist_lite(creature_ptr)) {

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -70,7 +70,7 @@ static void choise_cursed_item(player_type *creature_ptr, TRC flag, object_type 
         return;
 
     tr_type cf = TR_STR;
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     object_flags(creature_ptr, o_ptr, flgs);
     switch (flag) {
     case TRC::ADD_L_CURSE:
@@ -169,7 +169,7 @@ static void curse_teleport(player_type *creature_ptr)
     object_type *o_ptr;
     int i_keep = 0, count = 0;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        BIT_FLAGS flgs[TR_FLAG_SIZE];
+        TrFlags flgs;
         o_ptr = &creature_ptr->inventory_list[i];
         if (!o_ptr->k_idx)
             continue;

--- a/src/knowledge/knowledge-inventory.cpp
+++ b/src/knowledge/knowledge-inventory.cpp
@@ -42,7 +42,7 @@ static concptr inven_res_label = _(
  * @param flags 耐性配列へのポインタ
  * @param fff 一時ファイルへのポインタ
  */
-static void print_im_or_res_flag(int immunity, int resistance, BIT_FLAGS *flags, FILE *fff)
+static void print_im_or_res_flag(int immunity, int resistance, const TrFlags &flags, FILE *fff)
 {
     fputs(has_flag(flags, immunity) ? IM_FLAG_STR : (has_flag(flags, resistance) ? HAS_FLAG_STR : NO_FLAG_STR), fff);
 }
@@ -53,7 +53,10 @@ static void print_im_or_res_flag(int immunity, int resistance, BIT_FLAGS *flags,
  * @param flags 耐性配列へのポインタ
  * @param fff 一時ファイルへのポインタ
  */
-static void print_flag(int tr, BIT_FLAGS *flags, FILE *fff) { fputs(has_flag(flags, tr) ? HAS_FLAG_STR : NO_FLAG_STR, fff); }
+static void print_flag(int tr, const TrFlags &flags, FILE *fff)
+{
+    fputs(has_flag(flags, tr) ? HAS_FLAG_STR : NO_FLAG_STR, fff);
+}
 
 /*!
  * @brief 特殊なアイテムかどうかを調べる
@@ -99,7 +102,7 @@ static bool check_item_knowledge(object_type *o_ptr, tval_type tval)
  */
 static void display_identified_resistances_flag(player_type *creature_ptr, object_type *o_ptr, FILE *fff)
 {
-    BIT_FLAGS flags[TR_FLAG_SIZE];
+    TrFlags flags;
     object_flags_known(creature_ptr, o_ptr, flags);
 
     print_im_or_res_flag(TR_IM_ACID, TR_RES_ACID, flags, fff);

--- a/src/load/item-loader.cpp
+++ b/src/load/item-loader.cpp
@@ -235,7 +235,7 @@ void rd_item(player_type *player_ptr, object_type *o_ptr)
     if (!h_older_than(2, 1, 2, 4))
         return;
 
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     object_flags(player_ptr, o_ptr, flgs);
 
     if ((o_ptr->name2 == EGO_DARK) || (o_ptr->name2 == EGO_ANCIENT_CURSE) || (o_ptr->name1 == ART_NIGHT)) {

--- a/src/market/building-craft-fix.cpp
+++ b/src/market/building-craft-fix.cpp
@@ -38,8 +38,8 @@
  */
 static void give_one_ability_of_object(player_type *player_ptr, object_type *to_ptr, object_type *from_ptr)
 {
-    BIT_FLAGS to_flgs[TR_FLAG_SIZE];
-    BIT_FLAGS from_flgs[TR_FLAG_SIZE];
+    TrFlags to_flgs;
+    TrFlags from_flgs;
     object_flags(player_ptr, to_ptr, to_flgs);
     object_flags(player_ptr, from_ptr, from_flgs);
 

--- a/src/market/building-craft-weapon.cpp
+++ b/src/market/building-craft-weapon.cpp
@@ -118,7 +118,7 @@ static void show_weapon_dmg(int r, int c, int mindice, int maxdice, int blows, i
  */
 static void compare_weapon_aux(player_type *owner_ptr, object_type *o_ptr, int col, int r)
 {
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     int blow = owner_ptr->num_blow[0];
     bool force = false;
     bool dokubari = false;

--- a/src/mind/mind-priest.cpp
+++ b/src/mind/mind-priest.cpp
@@ -39,7 +39,7 @@ bool bless_weapon(player_type *caster_ptr)
 
     GAME_TEXT o_name[MAX_NLEN];
     describe_flavor(caster_ptr, o_name, o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     object_flags(caster_ptr, o_ptr, flgs);
 
     if (object_is_cursed(o_ptr)) {

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -39,17 +39,17 @@
 
 typedef struct samurai_slaying_type {
     MULTIPLY mult;
-    BIT_FLAGS *flags;
+    TrFlags flags;
     monster_type *m_ptr;
     combat_options mode;
     monster_race *r_ptr;
 } samurai_slaying_type;
 
 static samurai_slaying_type *initialize_samurai_slaying_type(
-    samurai_slaying_type *samurai_slaying_ptr, MULTIPLY mult, BIT_FLAGS *flags, monster_type *m_ptr, combat_options mode, monster_race *r_ptr)
+    samurai_slaying_type *samurai_slaying_ptr, MULTIPLY mult, const TrFlags &flags, monster_type *m_ptr, combat_options mode, monster_race *r_ptr)
 {
     samurai_slaying_ptr->mult = mult;
-    samurai_slaying_ptr->flags = flags;
+    std::copy_n(flags, TR_FLAG_SIZE, samurai_slaying_ptr->flags);
     samurai_slaying_ptr->m_ptr = m_ptr;
     samurai_slaying_ptr->mode = mode;
     samurai_slaying_ptr->r_ptr = r_ptr;
@@ -280,7 +280,7 @@ static void hissatsu_keiun_kininken(player_type *attacker_ptr, samurai_slaying_t
  * @param mode 剣術のスレイ型ID
  * @return スレイの倍率(/10倍)
  */
-MULTIPLY mult_hissatsu(player_type *attacker_ptr, MULTIPLY mult, BIT_FLAGS *flags, monster_type *m_ptr, combat_options mode)
+MULTIPLY mult_hissatsu(player_type *attacker_ptr, MULTIPLY mult, const TrFlags &flags, monster_type *m_ptr, combat_options mode)
 {
     monster_race *r_ptr = &r_info[m_ptr->r_idx];
     samurai_slaying_type tmp_slaying;

--- a/src/mind/mind-samurai.h
+++ b/src/mind/mind-samurai.h
@@ -7,7 +7,7 @@ typedef struct monap_type monap_type;
 typedef struct monster_type monster_type;
 typedef struct player_attack_type player_attack_type;
 typedef struct player_type player_type;
-MULTIPLY mult_hissatsu(player_type *attacker_ptr, MULTIPLY mult, BIT_FLAGS *flgs, monster_type *m_ptr, combat_options mode);
+MULTIPLY mult_hissatsu(player_type *attacker_ptr, MULTIPLY mult, const TrFlags &flgs, monster_type *m_ptr, combat_options mode);
 void concentration(player_type *creature_ptr);
 bool choose_kata(player_type* creature_ptr);
 int calc_attack_quality(player_type *attacker_ptr, player_attack_type *pa_ptr);

--- a/src/monster-floor/monster-object.cpp
+++ b/src/monster-floor/monster-object.cpp
@@ -34,7 +34,7 @@
 /*!
  * @brief オブジェクトのフラグを更新する
  */
-static void update_object_flags(BIT_FLAGS *flgs, BIT_FLAGS *flg2, BIT_FLAGS *flg3, BIT_FLAGS *flgr)
+static void update_object_flags(const TrFlags &flgs, BIT_FLAGS *flg2, BIT_FLAGS *flg3, BIT_FLAGS *flgr)
 {
     if (has_flag(flgs, TR_SLAY_DRAGON))
         *flg3 |= (RF3_DRAGON);
@@ -159,7 +159,8 @@ void update_object_by_monster_movement(player_type *target_ptr, turn_flags *turn
 
     turn_flags_ptr->do_take = (r_ptr->flags2 & RF2_TAKE_ITEM) != 0;
     for (auto it = g_ptr->o_idx_list.begin(); it != g_ptr->o_idx_list.end();) {
-        BIT_FLAGS flgs[TR_FLAG_SIZE], flg2 = 0L, flg3 = 0L, flgr = 0L;
+        TrFlags flgs;
+        BIT_FLAGS flg2 = 0L, flg3 = 0L, flgr = 0L;
         GAME_TEXT m_name[MAX_NLEN], o_name[MAX_NLEN];
         OBJECT_IDX this_o_idx = *it++;
         object_type *o_ptr = &target_ptr->current_floor_ptr->o_list[this_o_idx];

--- a/src/object-activation/activation-breath.cpp
+++ b/src/object-activation/activation-breath.cpp
@@ -27,7 +27,7 @@ bool activate_dragon_breath(player_type *user_ptr, object_type *o_ptr)
     if (!get_aim_dir(user_ptr, &dir))
         return false;
 
-    BIT_FLAGS resistance_flags[TR_FLAG_SIZE];
+    TrFlags resistance_flags;
     object_flags(user_ptr, o_ptr, resistance_flags);
 
     int type[20];

--- a/src/object-enchant/object-curse.cpp
+++ b/src/object-enchant/object-curse.cpp
@@ -68,7 +68,7 @@ void curse_equipment(player_type *owner_ptr, PERCENTAGE chance, PERCENTAGE heavy
     object_type *o_ptr = &owner_ptr->inventory_list[INVEN_MAIN_HAND + randint0(12)];
     if (!o_ptr->k_idx)
         return;
-    BIT_FLAGS oflgs[TR_FLAG_SIZE];
+    TrFlags oflgs;
     object_flags(owner_ptr, o_ptr, oflgs);
     GAME_TEXT o_name[MAX_NLEN];
     describe_flavor(owner_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));

--- a/src/object-enchant/object-ego.h
+++ b/src/object-enchant/object-ego.h
@@ -253,7 +253,7 @@ struct ego_item_type {
 
     PRICE cost{}; //!< コスト
 
-    BIT_FLAGS flags[TR_FLAG_SIZE]{}; //!< 能力/耐性フラグ
+    TrFlags flags{}; //!< 能力/耐性フラグ
     EnumClassFlagGroup<TRG> gen_flags; //!< 生成時適用フラグ
     std::vector<ego_generate_type> xtra_flags{}; //!< 追加能力/耐性フラグ
 

--- a/src/object-hook/hook-magic.cpp
+++ b/src/object-hook/hook-magic.cpp
@@ -21,7 +21,7 @@ bool item_tester_hook_activate(player_type *player_ptr, object_type *o_ptr)
     /* Unused */
     (void)player_ptr;
 
-    BIT_FLAGS flags[TR_FLAG_SIZE];
+    TrFlags flags;
     if (!object_is_known(o_ptr))
         return false;
 
@@ -43,7 +43,7 @@ bool item_tester_hook_use(player_type *player_ptr, object_type *o_ptr)
     /* Unused */
     (void)player_ptr;
 
-    BIT_FLAGS flags[TR_FLAG_SIZE];
+    TrFlags flags;
     if (o_ptr->tval == player_ptr->tval_ammo)
         return true;
 

--- a/src/object-hook/hook-weapon.cpp
+++ b/src/object-hook/hook-weapon.cpp
@@ -123,7 +123,7 @@ bool object_is_favorite(player_type *player_ptr, object_type *o_ptr)
     /* Favorite weapons are varied depend on the class */
     switch (player_ptr->pclass) {
     case CLASS_PRIEST: {
-        BIT_FLAGS flgs[TR_FLAG_SIZE];
+        TrFlags flgs;
         object_flags_known(player_ptr, o_ptr, flgs);
 
         if (!has_flag(flgs, TR_BLESSED) && !(o_ptr->tval == TV_HAFTED))
@@ -140,7 +140,7 @@ bool object_is_favorite(player_type *player_ptr, object_type *o_ptr)
 
     case CLASS_BEASTMASTER:
     case CLASS_CAVALRY: {
-        BIT_FLAGS flgs[TR_FLAG_SIZE];
+        TrFlags flgs;
         object_flags_known(player_ptr, o_ptr, flgs);
 
         /* Is it known to be suitable to using while riding? */

--- a/src/object/object-broken.cpp
+++ b/src/object/object-broken.cpp
@@ -186,7 +186,7 @@ bool hates_cold(object_type *o_ptr)
  */
 int set_acid_destroy(player_type *owner_ptr, object_type *o_ptr)
 {
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     if (!hates_acid(o_ptr))
         return false;
     object_flags(owner_ptr, o_ptr, flgs);
@@ -204,7 +204,7 @@ int set_acid_destroy(player_type *owner_ptr, object_type *o_ptr)
  */
 int set_elec_destroy(player_type *owner_ptr, object_type *o_ptr)
 {
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     if (!hates_elec(o_ptr))
         return false;
     object_flags(owner_ptr, o_ptr, flgs);
@@ -222,7 +222,7 @@ int set_elec_destroy(player_type *owner_ptr, object_type *o_ptr)
  */
 int set_fire_destroy(player_type *owner_ptr, object_type *o_ptr)
 {
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     if (!hates_fire(o_ptr))
         return false;
     object_flags(owner_ptr, o_ptr, flgs);
@@ -240,7 +240,7 @@ int set_fire_destroy(player_type *owner_ptr, object_type *o_ptr)
  */
 int set_cold_destroy(player_type *owner_ptr, object_type *o_ptr)
 {
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     if (!hates_cold(o_ptr))
         return false;
     object_flags(owner_ptr, o_ptr, flgs);

--- a/src/object/object-flags.cpp
+++ b/src/object/object-flags.cpp
@@ -18,7 +18,7 @@
  * @param o_ptr フラグ取得元のオブジェクト構造体ポインタ
  * @param flgs フラグ情報を受け取る配列
  */
-void object_flags(player_type *player_ptr, object_type *o_ptr, BIT_FLAGS flgs[TR_FLAG_SIZE])
+void object_flags(player_type *player_ptr, object_type *o_ptr, TrFlags &flgs)
 {
     object_kind *k_ptr = &k_info[o_ptr->k_idx];
 
@@ -97,7 +97,7 @@ void object_flags(player_type *player_ptr, object_type *o_ptr, BIT_FLAGS flgs[TR
  * @param o_ptr フラグ取得元のオブジェクト構造体ポインタ
  * @param flgs フラグ情報を受け取る配列
  */
-void object_flags_known(player_type *player_ptr, object_type *o_ptr, BIT_FLAGS flgs[TR_FLAG_SIZE])
+void object_flags_known(player_type *player_ptr, object_type *o_ptr, TrFlags &flgs)
 {
     bool spoil = false;
     object_kind *k_ptr = &k_info[o_ptr->k_idx];

--- a/src/object/object-flags.h
+++ b/src/object/object-flags.h
@@ -5,5 +5,5 @@
 
 typedef struct object_type object_type;
 typedef struct player_type player_type;
-void object_flags(player_type *player_ptr, object_type *o_ptr, BIT_FLAGS flgs[TR_FLAG_SIZE]);
-void object_flags_known(player_type *player_ptr, object_type *o_ptr, BIT_FLAGS flgs[TR_FLAG_SIZE]);
+void object_flags(player_type *player_ptr, object_type *o_ptr, TrFlags &flgs);
+void object_flags_known(player_type *player_ptr, object_type *o_ptr, TrFlags &flgs);

--- a/src/object/object-info.cpp
+++ b/src/object/object-info.cpp
@@ -41,7 +41,7 @@
 static concptr item_activation_dragon_breath(player_type *owner_ptr, object_type *o_ptr)
 {
     static char desc[256];
-    BIT_FLAGS flgs[TR_FLAG_SIZE]; /* for resistance flags */
+    TrFlags flgs; /* for resistance flags */
     int n = 0;
 
     object_flags(owner_ptr, o_ptr, flgs);
@@ -169,7 +169,7 @@ static concptr item_activation_aux(player_type *owner_ptr, object_type *o_ptr)
  */
 concptr activation_explanation(player_type *owner_ptr, object_type *o_ptr)
 {
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     object_flags(owner_ptr, o_ptr, flgs);
     if (!(has_flag(flgs, TR_ACTIVATE)))
         return (_("なし", "nothing"));

--- a/src/object/object-kind.h
+++ b/src/object/object-kind.h
@@ -33,7 +33,7 @@ typedef struct object_kind {
 
     PRICE cost{}; /*!< ベースアイテムの基本価値 / Object "base cost" */
 
-    BIT_FLAGS flags[TR_FLAG_SIZE]{}; /*!< ベースアイテムの基本特性ビット配列 / Flags */
+    TrFlags flags{}; /*!< ベースアイテムの基本特性ビット配列 / Flags */
 
     EnumClassFlagGroup<TRG> gen_flags; /*!< ベースアイテムの生成特性ビット配列 / flags for generate */
 

--- a/src/object/object-value-calc.cpp
+++ b/src/object/object-value-calc.cpp
@@ -23,7 +23,7 @@
 PRICE flag_cost(player_type *player_ptr, object_type *o_ptr, int plusses)
 {
     PRICE total = 0;
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     object_kind *k_ptr = &k_info[o_ptr->k_idx];
     object_flags(player_ptr, o_ptr, flgs);
 

--- a/src/object/object-value.cpp
+++ b/src/object/object-value.cpp
@@ -139,7 +139,7 @@ PRICE object_value(player_type *player_ptr, object_type *o_ptr)
  */
 PRICE object_value_real(player_type *player_ptr, object_type *o_ptr)
 {
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     object_kind *k_ptr = &k_info[o_ptr->k_idx];
 
     if (!k_info[o_ptr->k_idx].cost)

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -58,7 +58,7 @@ object_type *choose_warning_item(player_type *creature_ptr)
     /* Search Inventory */
     int number = 0;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        BIT_FLAGS flgs[TR_FLAG_SIZE];
+        TrFlags flgs;
         object_type *o_ptr = &creature_ptr->inventory_list[i];
 
         object_flags(creature_ptr, o_ptr, flgs);

--- a/src/perception/identification.cpp
+++ b/src/perception/identification.cpp
@@ -35,7 +35,7 @@
  */
 bool screen_object(player_type *player_ptr, object_type *o_ptr, BIT_FLAGS mode)
 {
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     char temp[70 * 20];
     concptr info[128];
     GAME_TEXT o_name[MAX_NLEN];

--- a/src/player-attack/player-attack-util.h
+++ b/src/player-attack/player-attack-util.h
@@ -44,7 +44,7 @@ typedef struct player_attack_type {
     const martial_arts *ma_ptr{}; //!< マーシャルアーツ種別
     HIT_POINT attack_damage{}; //!< 累積ダメージ
     int num_blow{}; //!< 打撃回数
-    BIT_FLAGS flags[TR_FLAG_SIZE]{}; //!< 武器フラグ
+    TrFlags flags{}; //!< 武器フラグ
     chaotic_effect chaos_effect{}; //!< カオス効果
     MagicalBrandEffect magical_effect{}; //!< 魔術効果
     bool *fear{}; //!< 恐怖したかどうか

--- a/src/player-info/base-status-info.cpp
+++ b/src/player-info/base-status-info.cpp
@@ -10,7 +10,7 @@
 void set_equipment_influence(player_type *creature_ptr, self_info_type *self_ptr)
 {
     for (int k = INVEN_MAIN_HAND; k < INVEN_TOTAL; k++) {
-        uint32_t tflgs[TR_FLAG_SIZE];
+        TrFlags tflgs;
         object_type *o_ptr = &creature_ptr->inventory_list[k];
         if (o_ptr->k_idx == 0)
             continue;

--- a/src/player-info/self-info-util.h
+++ b/src/player-info/self-info-util.h
@@ -7,7 +7,7 @@ typedef struct self_info_type {
     int line;
     char v_string[8][128];
     char s_string[6][128];
-    BIT_FLAGS flags[TR_FLAG_SIZE];
+    TrFlags flags;
     char plev_buf[80];
     char buf[2][80];
     concptr info[220];

--- a/src/player-status/player-status-base.cpp
+++ b/src/player-status/player-status-base.cpp
@@ -186,7 +186,7 @@ void PlayerStatusBase::set_locals()
 BIT_FLAGS PlayerStatusBase::equipments_flags(tr_type check_flag)
 {
     object_type *o_ptr;
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     BIT_FLAGS result = 0L;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         o_ptr = &owner_ptr->inventory_list[i];
@@ -209,7 +209,7 @@ BIT_FLAGS PlayerStatusBase::equipments_flags(tr_type check_flag)
 BIT_FLAGS PlayerStatusBase::equipments_bad_flags(tr_type check_flag)
 {
     object_type *o_ptr;
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     BIT_FLAGS result = 0L;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         o_ptr = &owner_ptr->inventory_list[i];
@@ -237,7 +237,7 @@ int16_t PlayerStatusBase::equipments_value()
     int16_t result = 0;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         object_type *o_ptr = &owner_ptr->inventory_list[i];
-        BIT_FLAGS flgs[TR_FLAG_SIZE];
+        TrFlags flgs;
         object_flags(owner_ptr, o_ptr, flgs);
 
         if (!o_ptr->k_idx)

--- a/src/player/permanent-resistances.cpp
+++ b/src/player/permanent-resistances.cpp
@@ -19,7 +19,7 @@
  * @param flags 耐性フラグの配列
  * @todo 最終的にplayer-status系列と統合する
  */
-static void add_class_flags(player_type *creature_ptr, BIT_FLAGS *flags)
+static void add_class_flags(player_type *creature_ptr, TrFlags &flags)
 {
     switch (creature_ptr->pclass) {
     case CLASS_WARRIOR: {
@@ -152,7 +152,7 @@ static void add_class_flags(player_type *creature_ptr, BIT_FLAGS *flags)
  * @param flags 耐性フラグの配列
  * @todo 最終的にplayer-status系列と統合する
  */
-static void add_mutation_flags(player_type *creature_ptr, BIT_FLAGS *flags)
+static void add_mutation_flags(player_type *creature_ptr, TrFlags &flags)
 {
     if (creature_ptr->muta.none())
         return;
@@ -186,7 +186,7 @@ static void add_mutation_flags(player_type *creature_ptr, BIT_FLAGS *flags)
  * @param flags 耐性フラグの配列
  * @todo 最終的にplayer-status系列と統合する
  */
-static void add_personality_flags(player_type *creature_ptr, BIT_FLAGS *flags)
+static void add_personality_flags(player_type *creature_ptr, TrFlags &flags)
 {
     if (creature_ptr->pseikaku == PERSONALITY_SEXY)
         add_flag(flags, TR_AGGRAVATE);
@@ -211,7 +211,7 @@ static void add_personality_flags(player_type *creature_ptr, BIT_FLAGS *flags)
  * @param flags 耐性フラグの配列
  * @todo 最終的にplayer-status系列と統合する
  */
-static void add_kata_flags(player_type *creature_ptr, BIT_FLAGS *flags)
+static void add_kata_flags(player_type *creature_ptr, TrFlags &flags)
 {
     if (creature_ptr->special_defense & KATA_FUUJIN)
         add_flag(flags, TR_REFLECT);
@@ -274,7 +274,7 @@ static void add_kata_flags(player_type *creature_ptr, BIT_FLAGS *flags)
  * Obtain the "flags" for the player as if he was an item
  * @todo 最終的にplayer-status系列と統合する
  */
-void player_flags(player_type *creature_ptr, BIT_FLAGS *flags)
+void player_flags(player_type *creature_ptr, TrFlags &flags)
 {
     for (int i = 0; i < TR_FLAG_SIZE; i++)
         flags[i] = 0L;
@@ -287,7 +287,7 @@ void player_flags(player_type *creature_ptr, BIT_FLAGS *flags)
     add_kata_flags(creature_ptr, flags);
 }
 
-void riding_flags(player_type *creature_ptr, BIT_FLAGS *flags, BIT_FLAGS *negative_flags)
+void riding_flags(player_type *creature_ptr, TrFlags &flags, TrFlags &negative_flags)
 {
     for (int i = 0; i < TR_FLAG_SIZE; i++) {
         flags[i] = 0L;

--- a/src/player/permanent-resistances.h
+++ b/src/player/permanent-resistances.h
@@ -3,5 +3,5 @@
 #include "system/angband.h"
 
 typedef struct player_type player_type;
-void player_flags(player_type *creature_ptr, BIT_FLAGS *flags);
-void riding_flags(player_type *creature_ptr, BIT_FLAGS *flags, BIT_FLAGS *negative_flags);
+void player_flags(player_type *creature_ptr, TrFlags &flags);
+void riding_flags(player_type *creature_ptr, TrFlags &flags, TrFlags &negative_flags);

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -110,7 +110,7 @@ static bool acid_minus_ac(player_type *creature_ptr)
 
     GAME_TEXT o_name[MAX_NLEN];
     describe_flavor(creature_ptr, o_name, o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     object_flags(creature_ptr, o_ptr, flgs);
     if (o_ptr->ac + o_ptr->to_a <= 0) {
         msg_format(_("%sは既にボロボロだ！", "Your %s is already fully corroded!"), o_name);

--- a/src/player/player-race.cpp
+++ b/src/player/player-race.cpp
@@ -83,7 +83,7 @@ bool player_race_has_flag(player_type *creature_ptr, tr_type flag, bool base_rac
  * @param flags フラグ配列へのポインタ
  * @param base_race ベース種族の情報を返すならtrue、ミミック擬態中の種族を返すならfalse
  */
-void add_player_race_flags(player_type *creature_ptr, BIT_FLAGS *flags, bool base_race)
+void add_player_race_flags(player_type *creature_ptr, TrFlags &flags, bool base_race)
 {
     auto race_ptr = get_player_race_info(creature_ptr, base_race);
     if (race_ptr->infra > 0)

--- a/src/player/player-race.h
+++ b/src/player/player-race.h
@@ -115,6 +115,6 @@ typedef struct player_type player_type;
 SYMBOL_CODE get_summon_symbol_from_player(player_type *creature_ptr);
 bool is_specific_player_race(player_type *creature_ptr, player_race_type prace);
 bool player_race_has_flag(player_type *creature_ptr, tr_type flag, bool base_race = false);
-void add_player_race_flags(player_type *creature_ptr, BIT_FLAGS *flags, bool base_race = false);
+void add_player_race_flags(player_type *creature_ptr, TrFlags &flags, bool base_race = false);
 PlayerRaceLife player_race_life(player_type *creature_ptr, bool base_race = false);
 PlayerRaceFood player_race_food(player_type *creature_ptr, bool base_race = false);

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -86,7 +86,7 @@ BIT_FLAGS convert_inventory_slot_type_to_flag_cause(inventory_slot_type inventor
 BIT_FLAGS check_equipment_flags(player_type *creature_ptr, tr_type tr_flag)
 {
     object_type *o_ptr;
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     BIT_FLAGS result = 0L;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         o_ptr = &creature_ptr->inventory_list[i];
@@ -762,7 +762,7 @@ BIT_FLAGS has_warning(player_type *creature_ptr)
 {
     BIT_FLAGS result = 0L;
     object_type *o_ptr;
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         o_ptr = &creature_ptr->inventory_list[i];
@@ -1185,7 +1185,7 @@ BIT_FLAGS has_regenerate(player_type *creature_ptr)
 void update_curses(player_type *creature_ptr)
 {
     object_type *o_ptr;
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     creature_ptr->cursed.clear();
     creature_ptr->cursed_special.clear();
 
@@ -1272,7 +1272,7 @@ BIT_FLAGS has_earthquake(player_type *creature_ptr)
 void update_extra_blows(player_type *creature_ptr)
 {
     object_type *o_ptr;
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     creature_ptr->extra_blows[0] = creature_ptr->extra_blows[1] = 0;
 
     const melee_type melee_type = player_melee_type(creature_ptr);
@@ -2032,7 +2032,7 @@ bool has_disable_two_handed_bonus(player_type *creature_ptr, int i)
  */
 bool has_icky_wield_weapon(player_type *creature_ptr, int i)
 {
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     object_type *o_ptr = &creature_ptr->inventory_list[INVEN_MAIN_HAND + i];
     object_flags(creature_ptr, o_ptr, flgs);
 
@@ -2058,7 +2058,7 @@ bool has_icky_wield_weapon(player_type *creature_ptr, int i)
 bool has_riding_wield_weapon(player_type *creature_ptr, int i)
 {
     object_type *o_ptr;
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     o_ptr = &creature_ptr->inventory_list[INVEN_MAIN_HAND + i];
     object_flags(creature_ptr, o_ptr, flgs);
     if (creature_ptr->riding != 0 && !(o_ptr->tval == TV_POLEARM) && ((o_ptr->sval == SV_LANCE) || (o_ptr->sval == SV_HEAVY_LANCE))

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -808,7 +808,7 @@ static void update_max_mana(player_type *creature_ptr)
     }
 
     if (any_bits(mp_ptr->spell_xtra, extra_magic_glove_reduce_mana)) {
-        BIT_FLAGS flgs[TR_FLAG_SIZE];
+        TrFlags flgs;
         creature_ptr->cumber_glove = false;
         object_type *o_ptr;
         o_ptr = &creature_ptr->inventory_list[INVEN_ARMS];
@@ -988,7 +988,7 @@ static void update_max_mana(player_type *creature_ptr)
 int16_t calc_num_fire(player_type *creature_ptr, object_type *o_ptr)
 {
     int extra_shots = 0;
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         object_type *q_ptr;
@@ -1102,7 +1102,7 @@ static ACTION_SKILL_POWER calc_device_ability(player_type *creature_ptr)
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         object_type *o_ptr;
-        BIT_FLAGS flgs[TR_FLAG_SIZE];
+        TrFlags flgs;
         o_ptr = &creature_ptr->inventory_list[i];
         if (!o_ptr->k_idx)
             continue;
@@ -1208,7 +1208,7 @@ static ACTION_SKILL_POWER calc_search(player_type *creature_ptr)
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         object_type *o_ptr;
-        BIT_FLAGS flgs[TR_FLAG_SIZE];
+        TrFlags flgs;
         o_ptr = &creature_ptr->inventory_list[i];
         if (!o_ptr->k_idx)
             continue;
@@ -1256,7 +1256,7 @@ static ACTION_SKILL_POWER calc_search_freq(player_type *creature_ptr)
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         object_type *o_ptr;
-        BIT_FLAGS flgs[TR_FLAG_SIZE];
+        TrFlags flgs;
         o_ptr = &creature_ptr->inventory_list[i];
         if (!o_ptr->k_idx)
             continue;
@@ -1370,7 +1370,7 @@ static ACTION_SKILL_POWER calc_to_hit_throw(player_type *creature_ptr)
 static ACTION_SKILL_POWER calc_skill_dig(player_type *creature_ptr)
 {
     object_type *o_ptr;
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
 
     ACTION_SKILL_POWER pow;
 
@@ -1430,7 +1430,7 @@ static bool is_heavy_wield(player_type *creature_ptr, int i)
 static int16_t calc_num_blow(player_type *creature_ptr, int i)
 {
     object_type *o_ptr;
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     int16_t num_blow = 1;
 
     o_ptr = &creature_ptr->inventory_list[INVEN_MAIN_HAND + i];
@@ -1577,7 +1577,7 @@ static int16_t calc_to_magic_chance(player_type *creature_ptr)
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         object_type *o_ptr;
-        BIT_FLAGS flgs[TR_FLAG_SIZE];
+        TrFlags flgs;
         o_ptr = &creature_ptr->inventory_list[i];
         if (!o_ptr->k_idx)
             continue;
@@ -1618,7 +1618,7 @@ static ARMOUR_CLASS calc_base_ac(player_type *creature_ptr)
 static ARMOUR_CLASS calc_to_ac(player_type *creature_ptr, bool is_real_value)
 {
     ARMOUR_CLASS ac = 0;
-    BIT_FLAGS flags[TR_FLAG_SIZE];
+    TrFlags flags;
     if (creature_ptr->yoiyami)
         return 0;
 
@@ -1790,7 +1790,7 @@ static ARMOUR_CLASS calc_to_ac(player_type *creature_ptr, bool is_real_value)
 int16_t calc_double_weapon_penalty(player_type *creature_ptr, INVENTORY_IDX slot)
 {
     int penalty = 0;
-    BIT_FLAGS flags[TR_FLAG_SIZE];
+    TrFlags flags;
 
     if (has_melee_weapon(creature_ptr, INVEN_MAIN_HAND) && has_melee_weapon(creature_ptr, INVEN_SUB_HAND)) {
         object_flags(creature_ptr, &creature_ptr->inventory_list[INVEN_SUB_HAND], flags);
@@ -1963,7 +1963,7 @@ void put_equipment_warning(player_type *creature_ptr)
 static int16_t calc_to_damage(player_type *creature_ptr, INVENTORY_IDX slot, bool is_real_value)
 {
     object_type *o_ptr = &creature_ptr->inventory_list[slot];
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     object_flags(creature_ptr, o_ptr, flgs);
 
     player_hand calc_hand = PLAYER_HAND_OTHER;
@@ -2170,7 +2170,7 @@ static int16_t calc_to_hit(player_type *creature_ptr, INVENTORY_IDX slot, bool i
     /* Bonuses and penalties by weapon */
     if (has_melee_weapon(creature_ptr, slot)) {
         object_type *o_ptr = &creature_ptr->inventory_list[slot];
-        BIT_FLAGS flgs[TR_FLAG_SIZE];
+        TrFlags flgs;
         object_flags(creature_ptr, o_ptr, flgs);
 
         int tval = o_ptr->tval - TV_WEAPON_BEGIN;
@@ -2343,7 +2343,7 @@ static int16_t calc_to_hit_bow(player_type *creature_ptr, bool is_real_value)
 
     {
         object_type *o_ptr;
-        BIT_FLAGS flgs[TR_FLAG_SIZE];
+        TrFlags flgs;
         o_ptr = &creature_ptr->inventory_list[INVEN_BOW];
         if (o_ptr->k_idx) {
             object_flags(creature_ptr, o_ptr, flgs);
@@ -2417,7 +2417,7 @@ static int16_t calc_to_hit_bow(player_type *creature_ptr, bool is_real_value)
 static int16_t calc_to_damage_misc(player_type *creature_ptr)
 {
     object_type *o_ptr;
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
 
     int16_t to_dam = 0;
 
@@ -2453,7 +2453,7 @@ static int16_t calc_to_damage_misc(player_type *creature_ptr)
 static int16_t calc_to_hit_misc(player_type *creature_ptr)
 {
     object_type *o_ptr;
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
 
     int16_t to_hit = 0;
 

--- a/src/player/race-resistances.cpp
+++ b/src/player/race-resistances.cpp
@@ -18,13 +18,13 @@
  * @todo
  * xtra1.c周りと多重実装になっているのを何とかする
  */
-void player_immunity(player_type *creature_ptr, BIT_FLAGS *flags)
+void player_immunity(player_type *creature_ptr, TrFlags &flags)
 {
     for (int i = 0; i < TR_FLAG_SIZE; i++) {
         flags[i] = 0L;
     }
 
-	if (player_race_has_flag(creature_ptr, TR_IM_ACID))
+    if (player_race_has_flag(creature_ptr, TR_IM_ACID))
         add_flag(flags, TR_RES_ACID);
     if (player_race_has_flag(creature_ptr, TR_IM_COLD))
         add_flag(flags, TR_RES_COLD);
@@ -50,7 +50,6 @@ void player_immunity(player_type *creature_ptr, BIT_FLAGS *flags)
     }
 }
 
-
 /*!
  * @brief プレイヤーの一時的魔法効果による免疫フラグを返す
  * @param creature_ptr プレーヤーへの参照ポインタ
@@ -58,7 +57,7 @@ void player_immunity(player_type *creature_ptr, BIT_FLAGS *flags)
  * @todo
  * xtra1.c周りと多重実装になっているのを何とかする
  */
-void tim_player_immunity(player_type *creature_ptr, BIT_FLAGS *flags)
+void tim_player_immunity(player_type *creature_ptr, TrFlags &flags)
 {
 	for (int i = 0; i < TR_FLAG_SIZE; i++)
 		flags[i] = 0L;
@@ -83,14 +82,14 @@ void tim_player_immunity(player_type *creature_ptr, BIT_FLAGS *flags)
  * @todo
  * xtra1.c周りと多重実装になっているのを何とかする
  */
-void known_obj_immunity(player_type *creature_ptr, BIT_FLAGS *flags)
+void known_obj_immunity(player_type *creature_ptr, TrFlags &flags)
 {
 	for (int i = 0; i < TR_FLAG_SIZE; i++)
 		flags[i] = 0L;
 
 	for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++)
 	{
-		uint32_t o_flags[TR_FLAG_SIZE];
+		TrFlags o_flags;
 		object_type *o_ptr;
 		o_ptr = &creature_ptr->inventory_list[i];
 		if (!o_ptr->k_idx) continue;
@@ -111,7 +110,7 @@ void known_obj_immunity(player_type *creature_ptr, BIT_FLAGS *flags)
  * @todo
  * xtra1.c周りと多重実装になっているのを何とかする
  */
-void player_vulnerability_flags(player_type *creature_ptr, BIT_FLAGS *flags)
+void player_vulnerability_flags(player_type *creature_ptr, TrFlags &flags)
 {
 	for (int i = 0; i < TR_FLAG_SIZE; i++)
 		flags[i] = 0L;

--- a/src/player/race-resistances.h
+++ b/src/player/race-resistances.h
@@ -3,7 +3,7 @@
 #include "system/angband.h"
 
 typedef struct player_type player_type;
-void player_immunity(player_type *creature_ptr, BIT_FLAGS *flags);
-void tim_player_immunity(player_type *creature_ptr, BIT_FLAGS *flags);
-void known_obj_immunity(player_type *creature_ptr, BIT_FLAGS *flags);
-void player_vulnerability_flags(player_type *creature_ptr, BIT_FLAGS *flags);
+void player_immunity(player_type *creature_ptr, TrFlags &flags);
+void tim_player_immunity(player_type *creature_ptr, TrFlags &flags);
+void known_obj_immunity(player_type *creature_ptr, TrFlags &flags);
+void player_vulnerability_flags(player_type *creature_ptr, TrFlags &flags);

--- a/src/player/temporary-resistances.cpp
+++ b/src/player/temporary-resistances.cpp
@@ -21,7 +21,7 @@
  * @todo
  * xtra1.c周りと多重実装になっているのを何とかする
  */
-void tim_player_flags(player_type *creature_ptr, BIT_FLAGS *flags)
+void tim_player_flags(player_type *creature_ptr, TrFlags &flags)
 {
     BIT_FLAGS tmp_effect_flag = FLAG_CAUSE_MAGIC_TIME_EFFECT;
     set_bits(tmp_effect_flag, FLAG_CAUSE_BATTLE_FORM);

--- a/src/player/temporary-resistances.h
+++ b/src/player/temporary-resistances.h
@@ -3,4 +3,4 @@
 #include "system/angband.h"
 
 typedef struct player_type player_type;
-void tim_player_flags(player_type *creature_ptr, BIT_FLAGS *flags);
+void tim_player_flags(player_type *creature_ptr, TrFlags &flags);

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -195,7 +195,7 @@ concptr do_hex_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
             concptr q, s;
             GAME_TEXT o_name[MAX_NLEN];
             object_type *o_ptr;
-            uint32_t f[TR_FLAG_SIZE];
+            TrFlags f;
 
             item_tester_hook = item_tester_hook_weapon_except_bow;
             q = _("どれを呪いますか？", "Which weapon do you curse?");
@@ -502,7 +502,7 @@ concptr do_hex_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
             concptr q, s;
             GAME_TEXT o_name[MAX_NLEN];
             object_type *o_ptr;
-            uint32_t f[TR_FLAG_SIZE];
+            TrFlags f;
 
             item_tester_hook = object_is_armour;
             q = _("どれを呪いますか？", "Which piece of armour do you curse?");
@@ -702,7 +702,7 @@ concptr do_hex_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
         if (cast) {
             OBJECT_IDX item;
             concptr s, q;
-            uint32_t f[TR_FLAG_SIZE];
+            TrFlags f;
             object_type *o_ptr;
 
             item_tester_hook = item_tester_hook_cursed;

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -651,7 +651,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
 
         if (cast) {
             int total_damage = 0, basedam, i;
-            BIT_FLAGS flgs[TR_FLAG_SIZE];
+            TrFlags flgs;
             object_type *o_ptr;
             if (!get_aim_dir(caster_ptr, &dir))
                 return NULL;
@@ -920,7 +920,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
         if (cast) {
             int total_damage = 0, basedam, i;
             POSITION y, x;
-            BIT_FLAGS flgs[TR_FLAG_SIZE];
+            TrFlags flgs;
             object_type *o_ptr;
 
             if (!get_direction(caster_ptr, &dir, false, false))

--- a/src/specific-object/death-scythe.cpp
+++ b/src/specific-object/death-scythe.cpp
@@ -84,7 +84,7 @@ static int calc_death_scythe_reflection_magnification(player_type *attacker_ptr)
  * @param magnification ダメージ倍率
  * @param death_scythe_flags 死の大鎌に関するオブジェクトフラグ配列
  */
-static void compensate_death_scythe_reflection_magnification(player_type *attacker_ptr, int *magnification, BIT_FLAGS *death_scythe_flags)
+static void compensate_death_scythe_reflection_magnification(player_type *attacker_ptr, int *magnification, const TrFlags &death_scythe_flags)
 {
     if ((attacker_ptr->alignment < 0) && (*magnification < 20))
         *magnification = 20;
@@ -135,7 +135,7 @@ static void death_scythe_reflection_critial_hit(player_attack_type *pa_ptr)
  */
 void process_death_scythe_reflection(player_type *attacker_ptr, player_attack_type *pa_ptr)
 {
-    BIT_FLAGS death_scythe_flags[TR_FLAG_SIZE];
+    TrFlags death_scythe_flags;
     sound(SOUND_HIT);
     msg_format(_("ミス！ %sにかわされた。", "You miss %s."), pa_ptr->m_name);
     msg_print(_("振り回した大鎌が自分自身に返ってきた！", "Your scythe returns to you!"));

--- a/src/specific-object/torch.cpp
+++ b/src/specific-object/torch.cpp
@@ -25,7 +25,7 @@
  * @param o_ptr 投擲するオブジェクトの構造体参照ポインタ
  * @param flgs 特別に追加するフラグを返す参照ポインタ
  */
-void torch_flags(object_type *o_ptr, BIT_FLAGS *flgs)
+void torch_flags(object_type *o_ptr, TrFlags &flgs)
 {
     if ((o_ptr->tval != TV_LITE) || (o_ptr->sval != SV_LITE_TORCH) || (o_ptr->xtra4 <= 0))
         return;
@@ -77,7 +77,7 @@ void update_lite_radius(player_type *creature_ptr)
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         object_type *o_ptr;
         o_ptr = &creature_ptr->inventory_list[i];
-        BIT_FLAGS flgs[TR_FLAG_SIZE];
+        TrFlags flgs;
         object_flags(creature_ptr, o_ptr, flgs);
 
         if (!o_ptr->k_idx)

--- a/src/specific-object/torch.h
+++ b/src/specific-object/torch.h
@@ -4,7 +4,7 @@
 
 typedef struct object_type object_type;
 typedef struct player_type player_type;
-void torch_flags(object_type *o_ptr, BIT_FLAGS *flgs);
+void torch_flags(object_type *o_ptr, TrFlags &flgs);
 void torch_dice(object_type *o_ptr, DICE_NUMBER *dd, DICE_SID *ds);
 void torch_lost_fuel(object_type *o_ptr);
 void update_lite_radius(player_type *creature_ptr);

--- a/src/spell-kind/spells-teleport.cpp
+++ b/src/spell-kind/spells-teleport.cpp
@@ -515,7 +515,7 @@ void teleport_away_followable(player_type *tracer_ptr, MONSTER_IDX m_idx)
     if (tracer_ptr->muta.has(MUTA::VTELEPORT) || (tracer_ptr->pclass == CLASS_IMITATOR))
         follow = true;
     else {
-        BIT_FLAGS flgs[TR_FLAG_SIZE];
+        TrFlags flgs;
         object_type *o_ptr;
         INVENTORY_IDX i;
 

--- a/src/spell-realm/spells-craft.cpp
+++ b/src/spell-realm/spells-craft.cpp
@@ -273,7 +273,7 @@ bool pulish_shield(player_type *caster_ptr)
 
     GAME_TEXT o_name[MAX_NLEN];
     describe_flavor(caster_ptr, o_name, o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     object_flags(caster_ptr, o_ptr, flgs);
 
     bool is_pulish_successful = o_ptr->k_idx && !object_is_artifact(o_ptr) && !object_is_ego(o_ptr);

--- a/src/store/service-checker.cpp
+++ b/src/store/service-checker.cpp
@@ -23,7 +23,7 @@
  */
 static bool is_blessed_item(player_type *player_ptr, object_type *o_ptr)
 {
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     object_flags(player_ptr, o_ptr, flgs);
     return has_flag(flgs, TR_BLESSED);
 }

--- a/src/system/artifact-type-definition.h
+++ b/src/system/artifact-type-definition.h
@@ -31,7 +31,7 @@ typedef struct artifact_type {
 	DICE_SID ds{};	/*!< ダイス値 / Damage when hits */
 	WEIGHT weight{};		/*!< 重量 / Weight */
 	PRICE cost{};			/*!< 基本価格 / Artifact "cost" */
-	BIT_FLAGS flags[TR_FLAG_SIZE]{};       /*! アイテムフラグ / Artifact Flags */
+	TrFlags flags{};       /*! アイテムフラグ / Artifact Flags */
 	EnumClassFlagGroup<TRG> gen_flags;	/*! アイテム生成フラグ / flags for generate */
 	DEPTH level{};		/*! 基本生成階 / Artifact level */
 	RARITY rarity{};		/*! レアリティ / Artifact rarity */

--- a/src/system/h-type.h
+++ b/src/system/h-type.h
@@ -59,6 +59,8 @@ typedef int errr;
 #define MAX_NLEN 160 /*!< Maximum length of object's name */
 #define MAX_MONSTER_NAME 160 /*!< モンスター名称の最大バイト数 / Max characters of monster's name */
 
+constexpr ssize_t TR_FLAG_SIZE = 5;
+
 /*!
  * @brief 符号なし整数の簡潔な定義
  */
@@ -189,6 +191,8 @@ typedef int16_t ACTION_SKILL_POWER; /*!< 行動技能値 */
 typedef byte FF_FLAGS_IDX; /*!< 地形特性ID */
 
 typedef int16_t FEAT_PRIORITY; /*!< 地形の縮小表示優先順位 */
+
+using TrFlags = BIT_FLAGS[TR_FLAG_SIZE];
 
 enum process_result {
     PROCESS_FALSE = 0,

--- a/src/system/object-type-definition.h
+++ b/src/system/object-type-definition.h
@@ -49,7 +49,7 @@ typedef struct object_type {
     uint16_t art_name{}; /*!< Artifact name (random artifacts) */
     byte feeling{}; /*!< Game generated inscription number (eg, pseudo-id) */
 
-    BIT_FLAGS art_flags[TR_FLAG_SIZE]{}; /*!< Extra Flags for ego and artifacts */
+    TrFlags art_flags{}; /*!< Extra Flags for ego and artifacts */
     EnumClassFlagGroup<TRC> curse_flags{}; /*!< Flags for curse */
     MONSTER_IDX held_m_idx{}; /*!< アイテムを所持しているモンスターID (いないなら 0) / Monster holding us (if any) */
     int artifact_bias{}; /*!< ランダムアーティファクト生成時のバイアスID */

--- a/src/system/system-variables.h
+++ b/src/system/system-variables.h
@@ -5,7 +5,6 @@
 #define MAX_NAZGUL_NUM 5
 #define SCREEN_BUF_MAX_SIZE (1024 * 1024) /*!< Max size of screen dump buffer */
 #define PY_MAX_LEVEL 50 /*!< プレイヤーレベルの最大値 / Maximum level */
-#define TR_FLAG_SIZE 5
 #define PY_MAX_EXP 99999999L /*!< プレイヤー経験値の最大値 / Maximum exp */
 #define MAX_SPELLS 108
 

--- a/src/view/display-characteristic.cpp
+++ b/src/view/display-characteristic.cpp
@@ -27,14 +27,14 @@
 #include <unordered_map>
 
 struct all_player_flags {
-    BIT_FLAGS player_flags[TR_FLAG_SIZE]{};
-    BIT_FLAGS tim_player_flags[TR_FLAG_SIZE]{};
-    BIT_FLAGS player_imm[TR_FLAG_SIZE]{};
-    BIT_FLAGS tim_player_imm[TR_FLAG_SIZE]{};
-    BIT_FLAGS player_vuln[TR_FLAG_SIZE]{};
-    BIT_FLAGS known_obj_imm[TR_FLAG_SIZE]{};
-    BIT_FLAGS riding_flags[TR_FLAG_SIZE]{};
-    BIT_FLAGS riding_negative_flags[TR_FLAG_SIZE]{};
+    TrFlags player_flags{};
+    TrFlags tim_player_flags{};
+    TrFlags player_imm{};
+    TrFlags tim_player_imm{};
+    TrFlags player_vuln{};
+    TrFlags known_obj_imm{};
+    TrFlags riding_flags{};
+    TrFlags riding_negative_flags{};
 };
 
 /*!
@@ -106,7 +106,7 @@ static void process_cursed_equipment_characteristics(player_type *creature_ptr, 
 {
     int max_i = (mode & DP_WP) ? INVEN_BOW + 1 : INVEN_TOTAL;
     for (int i = INVEN_MAIN_HAND; i < max_i; i++) {
-        BIT_FLAGS flags[TR_FLAG_SIZE];
+        TrFlags flags;
         auto *o_ptr = &creature_ptr->inventory_list[i];
         auto is_known = object_is_known(o_ptr);
         auto is_sensed = is_known || o_ptr->ident & IDENT_SENSE;
@@ -156,7 +156,7 @@ static void process_light_equipment_characteristics(player_type *creature_ptr, a
 {
     int max_i = (mode & DP_WP) ? INVEN_BOW + 1 : INVEN_TOTAL;
     for (int i = INVEN_MAIN_HAND; i < max_i; i++) {
-        BIT_FLAGS flags[TR_FLAG_SIZE];
+        TrFlags flags;
         auto *o_ptr = &creature_ptr->inventory_list[i];
         object_flags_known(creature_ptr, o_ptr, flags);
 
@@ -206,7 +206,7 @@ static void process_inventory_characteristic(player_type *creature_ptr, tr_type 
 {
     int max_i = (mode & DP_WP) ? INVEN_BOW + 1 : INVEN_TOTAL;
     for (int i = INVEN_MAIN_HAND; i < max_i; i++) {
-        BIT_FLAGS flags[TR_FLAG_SIZE];
+        TrFlags flags;
         auto *o_ptr = &creature_ptr->inventory_list[i];
         object_flags_known(creature_ptr, o_ptr, flags);
 

--- a/src/view/display-player-stat-info.cpp
+++ b/src/view/display-player-stat-info.cpp
@@ -168,7 +168,7 @@ static void process_stats(player_type *creature_ptr, int row, int stat_col)
  * @param stat 能力値番号
  * @param flags 装備品に立っているフラグ
  */
-static void compensate_stat_by_weapon(char *c, TERM_COLOR *a, object_type *o_ptr, int stat, BIT_FLAGS *flags)
+static void compensate_stat_by_weapon(char *c, TERM_COLOR *a, object_type *o_ptr, int stat, const TrFlags &flags)
 {
     *c = '*';
 
@@ -196,7 +196,7 @@ static void compensate_stat_by_weapon(char *c, TERM_COLOR *a, object_type *o_ptr
  * @param row 行数
  * @param col 列数
  */
-static void display_equipments_compensation(player_type *creature_ptr, BIT_FLAGS *flags, int row, int *col)
+static void display_equipments_compensation(player_type *creature_ptr, TrFlags &flags, int row, int *col)
 {
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         object_type *o_ptr;
@@ -322,7 +322,7 @@ static void change_display_by_mutation(player_type *creature_ptr, int stat, char
  * @param col 列数
  * @param row 行数
  */
-static void display_mutation_compensation(player_type *creature_ptr, BIT_FLAGS *flags, int row, int col)
+static void display_mutation_compensation(player_type *creature_ptr, const TrFlags &flags, int row, int col)
 {
     for (int stat = 0; stat < A_MAX; stat++) {
         byte a = TERM_SLATE;
@@ -368,7 +368,7 @@ void display_player_stat_info(player_type *creature_ptr)
     c_put_str(TERM_WHITE, "abcdefghijkl@", row, col);
     c_put_str(TERM_L_GREEN, _("能力修正", "Modification"), row - 1, col);
 
-    BIT_FLAGS flags[TR_FLAG_SIZE];
+    TrFlags flags;
     display_equipments_compensation(creature_ptr, flags, row, &col);
     player_flags(creature_ptr, flags);
     display_mutation_compensation(creature_ptr, flags, row, col);

--- a/src/view/status-first-page.cpp
+++ b/src/view/status-first-page.cpp
@@ -128,7 +128,7 @@ static bool calc_weapon_one_hand(object_type *o_ptr, int hand, int *damage, int 
  * @param flgs オブジェクトフラグ群
  * @return 強化後の素手ダメージ
  */
-static int strengthen_basedam(player_type *creature_ptr, object_type *o_ptr, int basedam, BIT_FLAGS *flgs)
+static int strengthen_basedam(player_type *creature_ptr, object_type *o_ptr, int basedam, const TrFlags &flgs)
 {
     if (object_is_fully_known(o_ptr) && ((o_ptr->name1 == ART_VORPAL_BLADE) || (o_ptr->name1 == ART_CHAINSWORD))) {
         /* vorpal blade */
@@ -245,7 +245,7 @@ static void calc_two_hands(player_type *creature_ptr, int *damage, int *to_h)
 {
     object_type *o_ptr;
     o_ptr = &creature_ptr->inventory_list[INVEN_BOW];
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     for (int i = 0; i < 2; i++) {
         int basedam;
         damage[i] = creature_ptr->dis_to_d[i] * 100;

--- a/src/wizard/artifact-analyzer.cpp
+++ b/src/wizard/artifact-analyzer.cpp
@@ -31,7 +31,7 @@
  * The possibly updated description pointer is returned.
  * </pre>
  */
-static concptr *spoiler_flag_aux(const BIT_FLAGS art_flags[TR_FLAG_SIZE], const flag_desc *flag_ptr, concptr *desc_ptr, const int n_elmnts)
+static concptr *spoiler_flag_aux(const TrFlags &art_flags, const flag_desc *flag_ptr, concptr *desc_ptr, const int n_elmnts)
 {
     for (int i = 0; i < n_elmnts; ++i)
         if (has_flag(art_flags, flag_ptr[i].flag))
@@ -60,7 +60,7 @@ static void analyze_general(player_type *player_ptr, object_type *o_ptr, char *d
  */
 static void analyze_pval(player_type *player_ptr, object_type *o_ptr, pval_info_type *pi_ptr)
 {
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     concptr *affects_list;
     if (!o_ptr->pval) {
         pi_ptr->pval_desc[0] = '\0';
@@ -90,7 +90,7 @@ static void analyze_pval(player_type *player_ptr, object_type *o_ptr, pval_info_
  */
 static void analyze_slay(player_type *player_ptr, object_type *o_ptr, concptr *slay_list)
 {
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     object_flags(player_ptr, o_ptr, flgs);
     slay_list = spoiler_flag_aux(flgs, slay_flags_desc, slay_list, N_ELEMENTS(slay_flags_desc));
     *slay_list = NULL;
@@ -104,7 +104,7 @@ static void analyze_slay(player_type *player_ptr, object_type *o_ptr, concptr *s
  */
 static void analyze_brand(player_type *player_ptr, object_type *o_ptr, concptr *brand_list)
 {
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     object_flags(player_ptr, o_ptr, flgs);
     brand_list = spoiler_flag_aux(flgs, brand_flags_desc, brand_list, N_ELEMENTS(brand_flags_desc));
     *brand_list = NULL;
@@ -118,7 +118,7 @@ static void analyze_brand(player_type *player_ptr, object_type *o_ptr, concptr *
  */
 static void analyze_resist(player_type *player_ptr, object_type *o_ptr, concptr *resist_list)
 {
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     object_flags(player_ptr, o_ptr, flgs);
     resist_list = spoiler_flag_aux(flgs, resist_flags_desc, resist_list, N_ELEMENTS(resist_flags_desc));
     *resist_list = NULL;
@@ -132,7 +132,7 @@ static void analyze_resist(player_type *player_ptr, object_type *o_ptr, concptr 
  */
 static void analyze_immune(player_type *player_ptr, object_type *o_ptr, concptr *immune_list)
 {
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     object_flags(player_ptr, o_ptr, flgs);
     immune_list = spoiler_flag_aux(flgs, immune_flags_desc, immune_list, N_ELEMENTS(immune_flags_desc));
     *immune_list = NULL;
@@ -146,7 +146,7 @@ static void analyze_immune(player_type *player_ptr, object_type *o_ptr, concptr 
  */
 static void analyze_sustains(player_type *player_ptr, object_type *o_ptr, concptr *sustain_list)
 {
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     object_flags(player_ptr, o_ptr, flgs);
     if (has_flag(flgs, TR_SUST_STR) && has_flag(flgs, TR_SUST_INT) && has_flag(flgs, TR_SUST_WIS) && has_flag(flgs, TR_SUST_DEX)
         && has_flag(flgs, TR_SUST_CON) && has_flag(flgs, TR_SUST_CHR)) {
@@ -168,7 +168,7 @@ static void analyze_sustains(player_type *player_ptr, object_type *o_ptr, concpt
  */
 static void analyze_misc_magic(player_type *player_ptr, object_type *o_ptr, concptr *misc_list)
 {
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     char desc[256];
 
     object_flags(player_ptr, o_ptr, flgs);

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -335,7 +335,7 @@ static void prt_binary(BIT_FLAGS flags, const int row, int col)
  */
 static void wiz_display_item(player_type *player_ptr, object_type *o_ptr)
 {
-    BIT_FLAGS flgs[TR_FLAG_SIZE];
+    TrFlags flgs;
     object_flags(player_ptr, o_ptr, flgs);
     int j = 13;
     for (int i = 1; i <= 23; i++)


### PR DESCRIPTION
TRフラグを持つ変数は BIT_FLAGS flags[TR_FLAG_SIZE] のように
宣言されているが、 読みやすさ・扱いやすさの両面を考慮して
TrFlags = BIT_FLAGS[TR_FLAG_SIZE] の型エイリアスを用意し、
TrFlags flags のように変数宣言できるようにする。

また、これらの変数を受け取る関数は引数をBIT_FLAGS型の
ポインタからTrFlagsの参照で受け取るように変更する。
f(BIT_FLAGS* flags) → f(TrFlag &flags)

最終的にはクラス化したいが、ひとまず最初のステップとして。