### PR TITLE
main-win.cpp でterm_dataに関する処理をmain-win-term.cpp/h へ移した

### DIFF
--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -573,14 +573,6 @@ static bool change_bg_mode(bg_mode new_mode, bool show_error = false, bool force
 }
 
 /*!
- * @brief Allow the user to lock this window.
- */
-static void term_window_pos(term_data *td, HWND hWnd)
-{
-    SetWindowPos(td->w, hWnd, 0, 0, 0, 0, SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE);
-}
-
-/*!
  * @brief Hack -- redraw a term_data
  */
 static void term_data_redraw(term_data *td)
@@ -1268,9 +1260,9 @@ static void init_windows(void)
         }
 
         if (td->posfix) {
-            term_window_pos(td, HWND_TOPMOST);
+            td->set_window_position(HWND_TOPMOST);
         } else {
-            term_window_pos(td, td->w);
+            td->set_window_position(td->w);
         }
     }
 
@@ -1578,10 +1570,10 @@ static void process_menus(player_type *player_ptr, WORD wCmd)
         td = &data[i];
         if (!td->posfix && td->visible) {
             td->posfix = true;
-            term_window_pos(td, HWND_TOPMOST);
+            td->set_window_position(HWND_TOPMOST);
         } else {
             td->posfix = false;
-            term_window_pos(td, data[0].w);
+            td->set_window_position(data[0].w);
         }
 
         break;
@@ -2244,7 +2236,7 @@ LRESULT PASCAL AngbandWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 
         for (int i = 1; i < MAX_TERM_DATA; i++) {
             if (!data[i].posfix)
-                term_window_pos(&data[i], hWnd);
+                (&data[i])->set_window_position(hWnd);
         }
 
         SetFocus(hWnd);

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -163,22 +163,10 @@ bool movie_in_progress = false;
 bool initialized = false;
 
 /*
- * Saved instance handle
- */
-static HINSTANCE hInstance;
-
-/*
- * Yellow brush for the cursor
- */
-static HBRUSH hbrYellow;
-
-/*
  * An icon
  */
 static HICON hIcon;
 
-/* bg */
-bg_mode current_bg_mode = bg_mode::BG_NONE;
 #define DEFAULT_BG_FILENAME "bg.bmp"
 char wallpaper_file[MAIN_WIN_MAX_PATH] = ""; //!< 壁紙ファイル名。
 
@@ -193,19 +181,9 @@ static bool keep_subwindows = true;
 static concptr ini_file = NULL;
 
 /*
- * Name of application
- */
-static LPCWSTR AppName = L"ANGBAND";
-
-/*
  * Name of sub-window type
  */
 static LPCWSTR AngList = L"AngList";
-
-/*
- * The "complex" color values
- */
-static COLORREF win_clr[256];
 
 /*
  * Flag for macro trigger with dump ASCII
@@ -597,535 +575,6 @@ void term_inversed_area(HWND hWnd, int x, int y, int w, int h)
 }
 
 /*!
- * @brief Windows版ユーザ設定項目実装部(実装必須) /Interact with the User
- */
-static errr term_user_win(int n)
-{
-    (void)n;
-    return 0;
-}
-
-/*!
- * @brief カラーパレットの変更？
- */
-static void refresh_color_table()
-{
-    for (int i = 0; i < 256; i++) {
-        byte rv = angband_color_table[i][1];
-        byte gv = angband_color_table[i][2];
-        byte bv = angband_color_table[i][3];
-        win_clr[i] = PALETTERGB(rv, gv, bv);
-    }
-}
-
-/*!
- * @brief グラフィクスのモード変更
- */
-static void change_graphics_mode(graphics_mode mode)
-{
-    graphics_mode ret = graphic.change_graphics(mode);
-    if (ret != mode) {
-        plog(_("グラフィクスを初期化できません!", "Cannot initialize graphics!"));
-    }
-    arg_graphics = static_cast<byte>(ret);
-    use_graphics = (arg_graphics > 0);
-}
-
-/*!
- * @brief React to global changes
- */
-static errr term_xtra_win_react(player_type *player_ptr)
-{
-    refresh_color_table();
-
-    const byte current_mode = static_cast<byte>(graphic.get_mode());
-    if (current_mode != arg_graphics) {
-        change_graphics_mode(static_cast<graphics_mode>(arg_graphics));
-        reset_visuals(player_ptr);
-    }
-
-    for (int i = 0; i < MAX_TERM_DATA; i++) {
-        term_data *td = &data[i];
-        if ((td->cols != td->t.wid) || (td->rows != td->t.hgt)) {
-            td->rebuild();
-        }
-    }
-
-    return 0;
-}
-
-/*!
- * @brief Process at least one event
- */
-static errr term_xtra_win_event(int v)
-{
-    MSG msg;
-    if (v) {
-        if (GetMessage(&msg, NULL, 0, 0)) {
-            TranslateMessage(&msg);
-            DispatchMessage(&msg);
-        }
-    } else {
-        if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
-            TranslateMessage(&msg);
-            DispatchMessage(&msg);
-        }
-    }
-
-    return 0;
-}
-
-/*!
- * @brief Process all pending events
- */
-static errr term_xtra_win_flush(void)
-{
-    MSG msg;
-    while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
-        TranslateMessage(&msg);
-        DispatchMessage(&msg);
-    }
-
-    return 0;
-}
-
-/*!
- * @brief Hack -- clear the screen
- * @details
- * Make this more efficient
- */
-static errr term_xtra_win_clear(void)
-{
-    term_data *td = (term_data *)(Term->data);
-
-    RECT rc;
-    GetClientRect(td->w, &rc);
-
-    HDC hdc = td->get_hdc();
-    SetBkColor(hdc, RGB(0, 0, 0));
-    SelectObject(hdc, td->font_id);
-    ExtTextOut(hdc, 0, 0, ETO_OPAQUE, &rc, NULL, 0, NULL);
-
-    if (current_bg_mode != bg_mode::BG_NONE) {
-        rc.left = 0;
-        rc.top = 0;
-        draw_bg(hdc, &rc);
-    }
-
-    td->refresh();
-    return 0;
-}
-
-/*!
- * @brief Hack -- make a noise
- */
-static errr term_xtra_win_noise(void)
-{
-    MessageBeep(MB_ICONASTERISK);
-    return 0;
-}
-
-/*!
- * @brief Hack -- make a sound
- */
-static errr term_xtra_win_sound(int v)
-{
-    if (!use_sound)
-        return 1;
-    return play_sound(v);
-}
-
-/*!
- * @brief Hack -- play a music
- */
-static errr term_xtra_win_music(int n, int v)
-{
-    if (!use_music) {
-        return 1;
-    }
-
-    return main_win_music::play_music(n, v);
-}
-
-/*!
- * @brief Hack -- play a music matches a situation
- */
-static errr term_xtra_win_scene(int v)
-{
-    // TODO 場面に合った壁紙変更対応
-    if (!use_music) {
-        return 1;
-    }
-
-    return main_win_music::play_music_scene(v);
-}
-
-/*!
- * @brief Delay for "x" milliseconds
- */
-static int term_xtra_win_delay(int v)
-{
-    Sleep(v);
-    return 0;
-}
-
-/*!
- * @brief Do a "special thing"
- * @todo z-termに影響があるのでplayer_typeの追加は保留
- */
-static errr term_xtra_win(int n, int v)
-{
-    switch (n) {
-    case TERM_XTRA_NOISE: {
-        return (term_xtra_win_noise());
-    }
-    case TERM_XTRA_FRESH: {
-        term_data *td = (term_data *)(Term->data);
-        if (td->w)
-            UpdateWindow(td->w);
-        return 0;
-    }
-    case TERM_XTRA_MUSIC_BASIC:
-    case TERM_XTRA_MUSIC_DUNGEON:
-    case TERM_XTRA_MUSIC_QUEST:
-    case TERM_XTRA_MUSIC_TOWN:
-    case TERM_XTRA_MUSIC_MONSTER: {
-        return term_xtra_win_music(n, v);
-    }
-    case TERM_XTRA_MUSIC_MUTE: {
-        return main_win_music::stop_music();
-    }
-    case TERM_XTRA_SCENE: {
-        return term_xtra_win_scene(v);
-    }
-    case TERM_XTRA_SOUND: {
-        return (term_xtra_win_sound(v));
-    }
-    case TERM_XTRA_BORED: {
-        return (term_xtra_win_event(0));
-    }
-    case TERM_XTRA_EVENT: {
-        return (term_xtra_win_event(v));
-    }
-    case TERM_XTRA_FLUSH: {
-        return (term_xtra_win_flush());
-    }
-    case TERM_XTRA_CLEAR: {
-        return (term_xtra_win_clear());
-    }
-    case TERM_XTRA_REACT: {
-        return (term_xtra_win_react(p_ptr));
-    }
-    case TERM_XTRA_DELAY: {
-        return (term_xtra_win_delay(v));
-    }
-    }
-
-    return 1;
-}
-
-/*!
- * @brief Low level graphics (Assumes valid input).
- * @details
- * Draw a "cursor" at (x,y), using a "yellow box".
- */
-static errr term_curs_win(int x, int y)
-{
-    term_data *td = (term_data *)(Term->data);
-    int tile_wid, tile_hgt;
-    tile_wid = td->tile_wid;
-    tile_hgt = td->tile_hgt;
-
-    RECT rc;
-    rc.left = x * tile_wid + td->size_ow1;
-    rc.right = rc.left + tile_wid;
-    rc.top = y * tile_hgt + td->size_oh1;
-    rc.bottom = rc.top + tile_hgt;
-
-    HDC hdc = td->get_hdc();
-    FrameRect(hdc, &rc, hbrYellow);
-    td->refresh(&rc);
-    return 0;
-}
-
-/*!
- * @brief Low level graphics (Assumes valid input).
- * @details
- * Draw a "big cursor" at (x,y), using a "yellow box".
- */
-static errr term_bigcurs_win(int x, int y)
-{
-    term_data *td = (term_data *)(Term->data);
-    int tile_wid, tile_hgt;
-    tile_wid = td->tile_wid;
-    tile_hgt = td->tile_hgt;
-
-    RECT rc;
-    rc.left = x * tile_wid + td->size_ow1;
-    rc.right = rc.left + 2 * tile_wid;
-    rc.top = y * tile_hgt + td->size_oh1;
-    rc.bottom = rc.top + tile_hgt;
-
-    HDC hdc = td->get_hdc();
-    FrameRect(hdc, &rc, hbrYellow);
-    td->refresh(&rc);
-    return 0;
-}
-
-/*!
- * @brief Low level graphics (Assumes valid input).
- * @details
- * Erase a "block" of "n" characters starting at (x,y).
- */
-static errr term_wipe_win(int x, int y, int n)
-{
-    term_data *td = (term_data *)(Term->data);
-    RECT rc;
-    rc.left = x * td->tile_wid + td->size_ow1;
-    rc.right = rc.left + n * td->tile_wid;
-    rc.top = y * td->tile_hgt + td->size_oh1;
-    rc.bottom = rc.top + td->tile_hgt;
-
-    HDC hdc = td->get_hdc();
-    SetBkColor(hdc, RGB(0, 0, 0));
-    SelectObject(hdc, td->font_id);
-    if (current_bg_mode != bg_mode::BG_NONE)
-        draw_bg(hdc, &rc);
-    else
-        ExtTextOut(hdc, 0, 0, ETO_OPAQUE, &rc, NULL, 0, NULL);
-
-    td->refresh(&rc);
-    return 0;
-}
-
-/*!
- * @brief Low level graphics.  Assumes valid input.
- * @details
- * Draw several ("n") chars, with an attr, at a given location.
- *
- * All "graphic" data is handled by "term_pict_win()", below.
- *
- * One would think there is a more efficient method for telling a window
- * what color it should be using to draw with, but perhaps simply changing
- * it every time is not too inefficient.
- */
-static errr term_text_win(int x, int y, int n, TERM_COLOR a, concptr s)
-{
-    term_data *td = (term_data *)(Term->data);
-    static HBITMAP WALL;
-    static HBRUSH myBrush, oldBrush;
-    static HPEN oldPen;
-    static bool init_done = false;
-
-    if (!init_done) {
-        WALL = LoadBitmapW(hInstance, AppName);
-        myBrush = CreatePatternBrush(WALL);
-        init_done = true;
-    }
-
-    RECT rc{ static_cast<LONG>(x * td->tile_wid + td->size_ow1), static_cast<LONG>(y * td->tile_hgt + td->size_oh1),
-        static_cast<LONG>(rc.left + n * td->tile_wid), static_cast<LONG>(rc.top + td->tile_hgt) };
-    RECT rc_start = rc;
-
-    HDC hdc = td->get_hdc();
-    SetBkColor(hdc, RGB(0, 0, 0));
-    SetTextColor(hdc, win_clr[a]);
-
-    SelectObject(hdc, td->font_id);
-    if (current_bg_mode != bg_mode::BG_NONE)
-        SetBkMode(hdc, TRANSPARENT);
-
-    ExtTextOut(hdc, 0, 0, ETO_OPAQUE, &rc, NULL, 0, NULL);
-    if (current_bg_mode != bg_mode::BG_NONE)
-        draw_bg(hdc, &rc);
-
-    rc.left += ((td->tile_wid - td->font_wid) / 2);
-    rc.right = rc.left + td->font_wid;
-    rc.top += ((td->tile_hgt - td->font_hgt) / 2);
-    rc.bottom = rc.top + td->font_hgt;
-
-    for (int i = 0; i < n; i++) {
-#ifdef JP
-        if (use_bigtile && *(s + i) == "■"[0] && *(s + i + 1) == "■"[1]) {
-            rc.right += td->font_wid;
-            oldBrush = static_cast<HBRUSH>(SelectObject(hdc, myBrush));
-            oldPen = static_cast<HPEN>(SelectObject(hdc, GetStockObject(NULL_PEN)));
-            Rectangle(hdc, rc.left, rc.top, rc.right + 1, rc.bottom + 1);
-            SelectObject(hdc, oldBrush);
-            SelectObject(hdc, oldPen);
-            rc.right -= td->font_wid;
-            i++;
-            rc.left += 2 * td->tile_wid;
-            rc.right += 2 * td->tile_wid;
-        } else if (iskanji(*(s + i))) /* 2バイト文字 */
-        {
-            char tmp[] = { *(s + i), *(s + i + 1), '\0' };
-            to_wchar wc(tmp);
-            const auto *buf = wc.wc_str();
-            rc.right += td->font_wid;
-            if (buf == NULL)
-                ExtTextOutA(hdc, rc.left, rc.top, ETO_CLIPPED, &rc, s + i, 2, NULL);
-            else
-                ExtTextOutW(hdc, rc.left, rc.top, ETO_CLIPPED, &rc, buf, wcslen(buf), NULL);
-            rc.right -= td->font_wid;
-            i++;
-            rc.left += 2 * td->tile_wid;
-            rc.right += 2 * td->tile_wid;
-        } else if (*(s + i) == 127) {
-            oldBrush = static_cast<HBRUSH>(SelectObject(hdc, myBrush));
-            oldPen = static_cast<HPEN>(SelectObject(hdc, GetStockObject(NULL_PEN)));
-            Rectangle(hdc, rc.left, rc.top, rc.right + 1, rc.bottom + 1);
-            SelectObject(hdc, oldBrush);
-            SelectObject(hdc, oldPen);
-            rc.left += td->tile_wid;
-            rc.right += td->tile_wid;
-        } else {
-            ExtTextOutA(hdc, rc.left, rc.top, ETO_CLIPPED, &rc, s + i, 1, NULL);
-            rc.left += td->tile_wid;
-            rc.right += td->tile_wid;
-        }
-#else
-        if (*(s + i) == 127) {
-            oldBrush = static_cast<HBRUSH>(SelectObject(hdc, myBrush));
-            oldPen = static_cast<HPEN>(SelectObject(hdc, GetStockObject(NULL_PEN)));
-            Rectangle(hdc, rc.left, rc.top, rc.right + 1, rc.bottom + 1);
-            SelectObject(hdc, oldBrush);
-            SelectObject(hdc, oldPen);
-            rc.left += td->tile_wid;
-            rc.right += td->tile_wid;
-        } else {
-            ExtTextOutA(hdc, rc.left, rc.top, ETO_CLIPPED, &rc, s + i, 1, NULL);
-            rc.left += td->tile_wid;
-            rc.right += td->tile_wid;
-        }
-#endif
-    }
-
-    rc.left = rc_start.left;
-    rc.top = rc_start.top;
-    td->refresh(&rc);
-    return 0;
-}
-
-/*!
- * @brief Low level graphics.  Assumes valid input.
- * @details
- * Draw an array of "special" attr/char pairs at the given location.
- *
- * We use the "term_pict_win()" function for "graphic" data, which are
- * encoded by setting the "high-bits" of both the "attr" and the "char"
- * data.  We use the "attr" to represent the "row" of the main bitmap,
- * and the "char" to represent the "col" of the main bitmap.  The use
- * of this function is induced by the "higher_pict" flag.
- *
- * If "graphics" is not available, we simply "wipe" the given grids.
- */
-static errr term_pict_win(TERM_LEN x, TERM_LEN y, int n, const TERM_COLOR *ap, concptr cp, const TERM_COLOR *tap, concptr tcp)
-{
-    term_data *td = (term_data *)(Term->data);
-    int i;
-    HDC hdcMask = NULL;
-    if (!use_graphics) {
-        return (term_wipe_win(x, y, n));
-    }
-
-    const tile_info &infGraph = graphic.get_tile_info();
-    const bool has_mask = (infGraph.hBitmapMask != NULL);
-    TERM_LEN w1 = infGraph.CellWidth;
-    TERM_LEN h1 = infGraph.CellHeight;
-    TERM_LEN tw1 = infGraph.TileWidth;
-    TERM_LEN th1 = infGraph.TileHeight;
-    TERM_LEN w2, h2, tw2 = 0;
-    w2 = td->tile_wid;
-    h2 = td->tile_hgt;
-    tw2 = w2;
-    if (use_bigtile)
-        tw2 *= 2;
-
-    TERM_LEN x2 = x * w2 + td->size_ow1 + infGraph.OffsetX;
-    TERM_LEN y2 = y * h2 + td->size_oh1 + infGraph.OffsetY;
-    HDC hdc = td->get_hdc();
-    HDC hdcSrc = CreateCompatibleDC(hdc);
-    HBITMAP hbmSrcOld = static_cast<HBITMAP>(SelectObject(hdcSrc, infGraph.hBitmap));
-
-    if (has_mask) {
-        hdcMask = CreateCompatibleDC(hdc);
-        SelectObject(hdcMask, infGraph.hBitmapMask);
-    }
-
-    for (i = 0; i < n; i++, x2 += w2) {
-        TERM_COLOR a = ap[i];
-        char c = cp[i];
-        int row = (a & 0x7F);
-        int col = (c & 0x7F);
-        TERM_LEN x1 = col * w1;
-        TERM_LEN y1 = row * h1;
-
-        if (has_mask) {
-            TERM_LEN x3 = (tcp[i] & 0x7F) * w1;
-            TERM_LEN y3 = (tap[i] & 0x7F) * h1;
-            tw2 = tw2 * w1 / tw1;
-            h2 = h2 * h1 / th1;
-            if ((tw1 == tw2) && (th1 == h2)) {
-                BitBlt(hdc, x2, y2, tw2, h2, hdcSrc, x3, y3, SRCCOPY);
-                BitBlt(hdc, x2, y2, tw2, h2, hdcMask, x1, y1, SRCAND);
-                BitBlt(hdc, x2, y2, tw2, h2, hdcSrc, x1, y1, SRCPAINT);
-                continue;
-            }
-
-            SetStretchBltMode(hdc, COLORONCOLOR);
-            StretchBlt(hdc, x2, y2, tw2, h2, hdcMask, x3, y3, w1, h1, SRCAND);
-            StretchBlt(hdc, x2, y2, tw2, h2, hdcSrc, x3, y3, w1, h1, SRCPAINT);
-            if ((x1 != x3) || (y1 != y3)) {
-                StretchBlt(hdc, x2, y2, tw2, h2, hdcMask, x1, y1, w1, h1, SRCAND);
-                StretchBlt(hdc, x2, y2, tw2, h2, hdcSrc, x1, y1, w1, h1, SRCPAINT);
-            }
-
-            continue;
-        }
-
-        if ((w1 == tw2) && (h1 == h2)) {
-            BitBlt(hdc, x2, y2, tw2, h2, hdcSrc, x1, y1, SRCCOPY);
-            continue;
-        }
-
-        SetStretchBltMode(hdc, COLORONCOLOR);
-        StretchBlt(hdc, x2, y2, tw2, h2, hdcSrc, x1, y1, w1, h1, SRCCOPY);
-    }
-
-    SelectObject(hdcSrc, hbmSrcOld);
-    DeleteDC(hdcSrc);
-    if (has_mask) {
-        SelectObject(hdcMask, hbmSrcOld);
-        DeleteDC(hdcMask);
-    }
-
-    td->refresh();
-    return 0;
-}
-
-/*!
- * @brief Create and initialize a "term_data" given a title
- */
-static void term_data_link(term_data *td)
-{
-    term_type *t = &td->t;
-    term_init(t, td->cols, td->rows, FILE_READ_BUFF_SIZE);
-    t->soft_cursor = true;
-    t->higher_pict = true;
-    t->attr_blank = TERM_WHITE;
-    t->char_blank = ' ';
-    t->user_hook = term_user_win;
-    t->xtra_hook = term_xtra_win;
-    t->curs_hook = term_curs_win;
-    t->bigcurs_hook = term_bigcurs_win;
-    t->wipe_hook = term_wipe_win;
-    t->text_hook = term_text_win;
-    t->pict_hook = term_pict_win;
-    t->data = (vptr)(td);
-}
-
-/*!
  * @brief Create the windows
  * @details
  * First, instantiate the "default" values, then read the "ini_file"
@@ -1219,7 +668,7 @@ static void init_windows(void)
         }
         td->size_hack = false;
 
-        term_data_link(td);
+        td->link_data();
         angband_term[i] = &td->t;
 
         if (td->visible) {
@@ -1250,7 +699,7 @@ static void init_windows(void)
     td->resize_window();
     td->size_hack = false;
 
-    term_data_link(td);
+    td->link_data();
     angband_term[0] = &td->t;
     normsize.x = td->cols;
     normsize.y = td->rows;
@@ -1262,7 +711,7 @@ static void init_windows(void)
 
     SetWindowPos(td->w, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
     hbrYellow = CreateSolidBrush(win_clr[TERM_YELLOW]);
-    (void)term_xtra_win_flush();
+    (void)term_data::term_xtra_win_flush();
 }
 
 /*!
@@ -2492,9 +1941,9 @@ int WINAPI WinMain(
     }
     ReleaseDC(NULL, hdc);
 
-    refresh_color_table();
+    term_data::refresh_color_table();
     init_windows();
-    change_graphics_mode(static_cast<graphics_mode>(arg_graphics));
+    term_data::change_graphics_mode(static_cast<graphics_mode>(arg_graphics));
     change_bg_mode(current_bg_mode, true);
 
     // after term_data initialize

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -711,7 +711,7 @@ static void init_windows(void)
 
     SetWindowPos(td->w, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
     hbrYellow = CreateSolidBrush(win_clr[TERM_YELLOW]);
-    (void)term_data::term_xtra_win_flush();
+    (void)term_data::extra_win_flush();
 }
 
 /*!

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -573,22 +573,6 @@ static bool change_bg_mode(bg_mode new_mode, bool show_error = false, bool force
 }
 
 /*!
- * @brief Resize a window
- */
-static void term_window_resize(term_data *td)
-{
-    if (!td->w)
-        return;
-
-    SetWindowPos(td->w, 0, 0, 0, td->size_wid, td->size_hgt, SWP_NOMOVE | SWP_NOZORDER);
-    if (!td->size_hack) {
-        td->dispose_offscreen();
-        term_activate(&td->t);
-        term_redraw();
-    }
-}
-
-/*!
  * @brief Force the use of a new font for a term_data.
  * This function may be called before the "window" is ready.
  * This function returns zero only if everything succeeds.
@@ -644,7 +628,7 @@ static void term_change_font(term_data *td)
     td->tile_wid = td->font_wid;
     td->tile_hgt = td->font_hgt;
     td->adjust_size();
-    term_window_resize(td);
+    td->resize_window();
 }
 
 /*!
@@ -738,7 +722,7 @@ static void rebuild_term(term_data *td, bool resize_window = true)
     term_activate(&td->t);
     td->adjust_size();
     if (resize_window) {
-        term_window_resize(td);
+        td->resize_window();
     }
     td->dispose_offscreen();
     term_resize(td->cols, td->rows);
@@ -1310,7 +1294,7 @@ static void init_windows(void)
         if (!td->tile_hgt)
             td->tile_hgt = td->font_hgt;
         td->adjust_size();
-        term_window_resize(td);
+        td->resize_window();
     }
 
     /* Create sub windows */
@@ -1327,7 +1311,7 @@ static void init_windows(void)
 
         td->size_hack = true;
         td->adjust_size();
-        term_window_resize(td);
+        td->resize_window();
 
         if (td->visible) {
             ShowWindow(td->w, SW_SHOW);
@@ -1362,7 +1346,7 @@ static void init_windows(void)
     /* Resize */
     td->size_hack = true;
     td->adjust_size();
-    term_window_resize(td);
+    td->resize_window();
     td->size_hack = false;
 
     term_data_link(td);
@@ -1676,7 +1660,7 @@ static void process_menus(player_type *player_ptr, WORD wCmd)
         td = &data[i];
         td->tile_wid += 1;
         td->adjust_size();
-        term_window_resize(td);
+        td->resize_window();
         break;
     }
     case IDM_WINDOW_D_WID_0:
@@ -1694,7 +1678,7 @@ static void process_menus(player_type *player_ptr, WORD wCmd)
         td = &data[i];
         td->tile_wid -= 1;
         td->adjust_size();
-        term_window_resize(td);
+        td->resize_window();
         break;
     }
     case IDM_WINDOW_I_HGT_0:
@@ -1712,7 +1696,7 @@ static void process_menus(player_type *player_ptr, WORD wCmd)
         td = &data[i];
         td->tile_hgt += 1;
         td->adjust_size();
-        term_window_resize(td);
+        td->resize_window();
         break;
     }
     case IDM_WINDOW_D_HGT_0:
@@ -1730,7 +1714,7 @@ static void process_menus(player_type *player_ptr, WORD wCmd)
         td = &data[i];
         td->tile_hgt -= 1;
         td->adjust_size();
-        term_window_resize(td);
+        td->resize_window();
         break;
     }
     case IDM_WINDOW_KEEP_SUBWINDOWS: {

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -86,11 +86,7 @@
 #include "core/game-play.h"
 #include "core/player-processor.h"
 #include "core/score-util.h"
-#include "core/scores.h"
 #include "core/special-internal-keys.h"
-#include "core/stuff-handler.h"
-#include "core/visuals-reseter.h"
-#include "core/window-redrawer.h"
 #include "floor/floor-events.h"
 #include "game-option/runtime-arguments.h"
 #include "game-option/special-options.h"
@@ -100,8 +96,6 @@
 #include "io/signal-handlers.h"
 #include "io/write-diary.h"
 #include "main-win/commandline-win.h"
-#include "main-win/graphics-win.h"
-#include "main-win/main-win-bg.h"
 #include "main-win/main-win-file-utils.h"
 #include "main-win/main-win-mci.h"
 #include "main-win/main-win-menuitem.h"
@@ -113,27 +107,21 @@
 #include "main/sound-of-music.h"
 #include "monster-floor/monster-lite.h"
 #include "save/save.h"
-#include "system/angband.h"
 #include "system/player-type-definition.h"
-#include "system/system-variables.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 #include "util/angband-files.h"
-#include "util/int-char-converter.h"
 #include "util/string-processor.h"
 #include "view/display-messages.h"
 #include "view/display-scores.h"
-#include "wizard/spoiler-util.h"
 #include "wizard/wizard-spoiler.h"
 #include "world/world.h"
-
+#include <commdlg.h>
 #include <cstdlib>
+#include <direct.h>
 #include <locale>
 #include <string>
-
-#include <commdlg.h>
-#include <direct.h>
 
 /*
  * Window names

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -633,27 +633,6 @@ static void change_graphics_mode(graphics_mode mode)
 }
 
 /*!
- * @brief ターミナルのサイズ更新
- * @details 行数、列数の変更に対応する。
- * @param td term_dataのポインタ
- * @param resize_window trueの場合に再計算されたウインドウサイズにリサイズする
- */
-static void rebuild_term(term_data *td, bool resize_window = true)
-{
-    term_type *old = Term;
-    td->size_hack = true;
-    term_activate(&td->t);
-    td->adjust_size();
-    if (resize_window) {
-        td->resize_window();
-    }
-    td->dispose_offscreen();
-    term_resize(td->cols, td->rows);
-    td->size_hack = false;
-    term_activate(old);
-}
-
-/*!
  * @brief React to global changes
  */
 static errr term_xtra_win_react(player_type *player_ptr)
@@ -669,7 +648,7 @@ static errr term_xtra_win_react(player_type *player_ptr)
     for (int i = 0; i < MAX_TERM_DATA; i++) {
         term_data *td = &data[i];
         if ((td->cols != td->t.wid) || (td->rows != td->t.hgt)) {
-            rebuild_term(td);
+            td->rebuild();
         }
     }
 
@@ -1682,7 +1661,7 @@ static void process_menus(player_type *player_ptr, WORD wCmd)
     case IDM_OPTIONS_BIGTILE: {
         td = &data[0];
         arg_bigtile = !arg_bigtile;
-        rebuild_term(td);
+        td->rebuild();
         break;
     }
     case IDM_OPTIONS_MUSIC: {
@@ -1920,7 +1899,7 @@ static void fit_term_size_to_window(term_data *td, bool recalc_window_size = fal
             normsize.y = td->rows;
         }
 
-        rebuild_term(td, recalc_window_size);
+        td->rebuild(recalc_window_size);
 
         if (!td->is_main_term()) {
             p_ptr->window_flags = PW_ALL;

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -140,13 +140,6 @@
  */
 LPCWSTR win_term_name[] = { L"Hengband", L"Term-1", L"Term-2", L"Term-3", L"Term-4", L"Term-5", L"Term-6", L"Term-7" };
 
-#define MAX_TERM_DATA 8 //!< Maximum number of windows
-
-static term_data data[MAX_TERM_DATA]; //!< An array of term_data's
-static bool is_main_term(term_data *td)
-{
-    return (td == &data[0]);
-}
 static term_data *my_td; //!< Hack -- global "window creation" pointer
 POINT normsize; //!< Remember normal size of main window when maxmized
 
@@ -2050,14 +2043,14 @@ static void fit_term_size_to_window(term_data *td, bool recalc_window_size = fal
     if ((td->cols != cols) || (td->rows != rows)) {
         td->cols = cols;
         td->rows = rows;
-        if (is_main_term(td) && !IsZoomed(td->w) && !IsIconic(td->w)) {
+        if (td->is_main_term() && !IsZoomed(td->w) && !IsIconic(td->w)) {
             normsize.x = td->cols;
             normsize.y = td->rows;
         }
 
         rebuild_term(td, recalc_window_size);
 
-        if (!is_main_term(td)) {
+        if (!td->is_main_term()) {
             p_ptr->window_flags = PW_ALL;
             handle_stuff(p_ptr);
         }
@@ -2078,7 +2071,7 @@ static bool handle_window_resize(term_data *td, UINT uMsg, WPARAM wParam, LPARAM
 
     switch (uMsg) {
     case WM_GETMINMAXINFO: {
-        const bool is_main = is_main_term(td);
+        const bool is_main = td->is_main_term();
         const int min_cols = (is_main) ? 80 : 20;
         const int min_rows = (is_main) ? 24 : 3;
         const LONG w = min_cols * td->tile_wid + td->size_ow1 + td->size_ow2;

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -573,27 +573,6 @@ static bool change_bg_mode(bg_mode new_mode, bool show_error = false, bool force
 }
 
 /*!
- * @brief Allow the user to change the font for this window.
- */
-static void term_change_font(term_data *td)
-{
-    CHOOSEFONTW cf;
-    memset(&cf, 0, sizeof(cf));
-    cf.lStructSize = sizeof(cf);
-    cf.Flags = CF_SCREENFONTS | CF_FIXEDPITCHONLY | CF_NOVERTFONTS | CF_INITTOLOGFONTSTRUCT;
-    cf.lpLogFont = &(td->lf);
-
-    if (!ChooseFontW(&cf))
-        return;
-
-    td->force_font();
-    td->tile_wid = td->font_wid;
-    td->tile_hgt = td->font_hgt;
-    td->adjust_size();
-    td->resize_window();
-}
-
-/*!
  * @brief Allow the user to lock this window.
  */
 static void term_window_pos(term_data *td, HWND hWnd)
@@ -1582,7 +1561,7 @@ static void process_menus(player_type *player_ptr, WORD wCmd)
             break;
 
         td = &data[i];
-        term_change_font(td);
+        td->change_font();
         break;
     }
     case IDM_WINDOW_POS_1:

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -675,7 +675,7 @@ static void init_windows(void)
     td = &data[0];
     my_td = td;
     td->w = CreateWindowExW(
-        td->dwExStyle, AppName, _(L"変愚蛮怒", td->name), td->dwStyle, td->pos_x, td->pos_y, td->size_wid, td->size_hgt, HWND_DESKTOP, NULL, hInstance, NULL);
+        td->dwExStyle, application_name, _(L"変愚蛮怒", td->name), td->dwStyle, td->pos_x, td->pos_y, td->size_wid, td->size_hgt, HWND_DESKTOP, NULL, hInstance, NULL);
     my_td = NULL;
 
     if (!td->w)
@@ -1668,7 +1668,7 @@ static void hook_quit(concptr str)
     graphic.finalize();
     finalize_sound();
 
-    UnregisterClassW(AppName, hInstance);
+    UnregisterClassW(application_name, hInstance);
     if (hIcon)
         DestroyIcon(hIcon);
 
@@ -1790,11 +1790,11 @@ static void register_wndclass(void)
     wc.cbClsExtra = 0;
     wc.cbWndExtra = 4;
     wc.hInstance = hInstance;
-    wc.hIcon = hIcon = LoadIconW(hInstance, AppName);
+    wc.hIcon = hIcon = LoadIconW(hInstance, application_name);
     wc.hCursor = LoadCursor(NULL, IDC_ARROW);
     wc.hbrBackground = NULL;
-    wc.lpszMenuName = AppName;
-    wc.lpszClassName = AppName;
+    wc.lpszMenuName = application_name;
+    wc.lpszClassName = application_name;
 
     if (!RegisterClassW(&wc))
         exit(1);
@@ -1834,7 +1834,7 @@ int WINAPI WinMain(
             MessageBoxW(NULL, to_wchar(str).wc_str(), _(L"エラー！", L"Error"), MB_ICONEXCLAMATION | MB_OK | MB_ICONSTOP);
         }
 
-        UnregisterClassW(AppName, hInstance);
+        UnregisterClassW(application_name, hInstance);
         if (hIcon)
             DestroyIcon(hIcon);
 

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -573,16 +573,6 @@ static bool change_bg_mode(bg_mode new_mode, bool show_error = false, bool force
 }
 
 /*!
- * @brief Hack -- redraw a term_data
- */
-static void term_data_redraw(term_data *td)
-{
-    term_activate(&td->t);
-    term_redraw();
-    term_activate(term_screen);
-}
-
-/*!
  * @brief termの反転色表示
  */
 void term_inversed_area(HWND hWnd, int x, int y, int w, int h)
@@ -1531,7 +1521,7 @@ static void process_menus(player_type *player_ptr, WORD wCmd)
         if (!td->visible) {
             td->visible = true;
             ShowWindow(td->w, SW_SHOW);
-            term_data_redraw(td);
+            td->redraw_data();
         } else {
             td->visible = false;
             td->posfix = false;

--- a/src/main-win/main-win-term.cpp
+++ b/src/main-win/main-win-term.cpp
@@ -101,3 +101,41 @@ bool term_data::is_main_term()
 {
     return (this == &data[0]);
 }
+
+/*!
+ * @brief (Windows版固有実装) / Adjust the "size" for a window
+ */
+void term_data::adjust_size()
+{
+    if (this->cols < 1) {
+        this->cols = 1;
+    }
+
+    if (this->rows < 1) {
+        this->rows = 1;
+    }
+
+    TERM_LEN wid = this->cols * this->tile_wid + this->size_ow1 + this->size_ow2;
+    TERM_LEN hgt = this->rows * this->tile_hgt + this->size_oh1 + this->size_oh2;
+
+    RECT rw, rc;
+    if (this->w) {
+        GetWindowRect(this->w, &rw);
+        GetClientRect(this->w, &rc);
+
+        this->size_wid = (rw.right - rw.left) - (rc.right - rc.left) + wid;
+        this->size_hgt = (rw.bottom - rw.top) - (rc.bottom - rc.top) + hgt;
+
+        this->pos_x = rw.left;
+        this->pos_y = rw.top;
+    } else {
+        /* Tempolary calculation */
+        rc.left = 0;
+        rc.right = wid;
+        rc.top = 0;
+        rc.bottom = hgt;
+        AdjustWindowRectEx(&rc, this->dwStyle, TRUE, this->dwExStyle);
+        this->size_wid = rc.right - rc.left;
+        this->size_hgt = rc.bottom - rc.top;
+    }
+}

--- a/src/main-win/main-win-term.cpp
+++ b/src/main-win/main-win-term.cpp
@@ -5,12 +5,25 @@
 
 #include "main-win/main-win-term.h"
 #include "core/stuff-handler.h"
+#include "core/visuals-reseter.h"
 #include "core/window-redrawer.h"
+#include "game-option/runtime-arguments.h"
+#include "game-option/special-options.h"
+#include "main-win/main-win-music.h"
+#include "main-win/main-win-sound.h"
+#include "main-win/main-win-utils.h"
 #include "system/player-type-definition.h"
 #include "term/gameterm.h"
+#include "term/term-color-types.h"
+#include "util/angband-files.h"
 
-POINT normsize; //!< Remember normal size of main window when maxmized
+LPCWSTR AppName = L"ANGBAND";
+HINSTANCE hInstance;
+bg_mode current_bg_mode = bg_mode::BG_NONE;
+COLORREF win_clr[256];
+POINT normsize;
 term_data data[MAX_TERM_DATA];
+HBRUSH hbrYellow;
 
 /*!
  * @brief オフスクリーンのデバイスコンテキストを取得する
@@ -287,4 +300,533 @@ void term_data::fit_size_to_window(bool recalc_window_size)
 
     p_ptr->window_flags = PW_ALL;
     handle_stuff(p_ptr);
+}
+
+/*!
+ * @brief Create and initialize a "term_data" given a title
+ */
+void term_data::link_data()
+{
+    auto *link = &this->t;
+    term_init(link, this->cols, this->rows, FILE_READ_BUFF_SIZE);
+    link->soft_cursor = true;
+    link->higher_pict = true;
+    link->attr_blank = TERM_WHITE;
+    link->char_blank = ' ';
+    link->user_hook = this->term_user_win;
+    link->xtra_hook = this->term_xtra_win;
+    link->curs_hook = this->term_curs_win;
+    link->bigcurs_hook = this->term_bigcurs_win;
+    link->wipe_hook = this->term_wipe_win;
+    link->text_hook = this->term_text_win;
+    link->pict_hook = this->term_pict_win;
+    link->data = (vptr)(this);
+}
+
+/*!
+ * @brief Windows版ユーザ設定項目実装部(実装必須) /Interact with the User
+ */
+errr term_data::term_user_win(int n)
+{
+    (void)n;
+    return 0;
+}
+
+/*!
+ * @brief Low level graphics (Assumes valid input).
+ * @details
+ * Draw a "big cursor" at (x,y), using a "yellow box".
+ */
+errr term_data::term_bigcurs_win(int x, int y)
+{
+    term_data *td = (term_data *)(Term->data);
+    int tile_wid, tile_hgt;
+    tile_wid = td->tile_wid;
+    tile_hgt = td->tile_hgt;
+
+    RECT rc;
+    rc.left = x * tile_wid + td->size_ow1;
+    rc.right = rc.left + 2 * tile_wid;
+    rc.top = y * tile_hgt + td->size_oh1;
+    rc.bottom = rc.top + tile_hgt;
+
+    HDC hdc = td->get_hdc();
+    FrameRect(hdc, &rc, hbrYellow);
+    td->refresh(&rc);
+    return 0;
+}
+
+/*!
+ * @brief Low level graphics (Assumes valid input).
+ * @details
+ * Erase a "block" of "n" characters starting at (x,y).
+ */
+errr term_data::term_wipe_win(int x, int y, int n)
+{
+    term_data *td = (term_data *)(Term->data);
+    RECT rc;
+    rc.left = x * td->tile_wid + td->size_ow1;
+    rc.right = rc.left + n * td->tile_wid;
+    rc.top = y * td->tile_hgt + td->size_oh1;
+    rc.bottom = rc.top + td->tile_hgt;
+
+    HDC hdc = td->get_hdc();
+    SetBkColor(hdc, RGB(0, 0, 0));
+    SelectObject(hdc, td->font_id);
+    if (current_bg_mode != bg_mode::BG_NONE)
+        draw_bg(hdc, &rc);
+    else
+        ExtTextOut(hdc, 0, 0, ETO_OPAQUE, &rc, NULL, 0, NULL);
+
+    td->refresh(&rc);
+    return 0;
+}
+
+/*!
+ * @brief Low level graphics.  Assumes valid input.
+ * @details
+ * Draw several ("n") chars, with an attr, at a given location.
+ *
+ * All "graphic" data is handled by "term_pict_win()", below.
+ *
+ * One would think there is a more efficient method for telling a window
+ * what color it should be using to draw with, but perhaps simply changing
+ * it every time is not too inefficient.
+ */
+errr term_data::term_text_win(int x, int y, int n, TERM_COLOR a, concptr s)
+{
+    term_data *td = (term_data *)(Term->data);
+    static HBITMAP WALL;
+    static HBRUSH myBrush, oldBrush;
+    static HPEN oldPen;
+    static bool init_done = false;
+
+    if (!init_done) {
+        WALL = LoadBitmapW(hInstance, AppName);
+        myBrush = CreatePatternBrush(WALL);
+        init_done = true;
+    }
+
+    RECT rc{ static_cast<LONG>(x * td->tile_wid + td->size_ow1), static_cast<LONG>(y * td->tile_hgt + td->size_oh1),
+        static_cast<LONG>(rc.left + n * td->tile_wid), static_cast<LONG>(rc.top + td->tile_hgt) };
+    RECT rc_start = rc;
+
+    HDC hdc = td->get_hdc();
+    SetBkColor(hdc, RGB(0, 0, 0));
+    SetTextColor(hdc, win_clr[a]);
+
+    SelectObject(hdc, td->font_id);
+    if (current_bg_mode != bg_mode::BG_NONE)
+        SetBkMode(hdc, TRANSPARENT);
+
+    ExtTextOut(hdc, 0, 0, ETO_OPAQUE, &rc, NULL, 0, NULL);
+    if (current_bg_mode != bg_mode::BG_NONE)
+        draw_bg(hdc, &rc);
+
+    rc.left += ((td->tile_wid - td->font_wid) / 2);
+    rc.right = rc.left + td->font_wid;
+    rc.top += ((td->tile_hgt - td->font_hgt) / 2);
+    rc.bottom = rc.top + td->font_hgt;
+
+    for (int i = 0; i < n; i++) {
+#ifdef JP
+        if (use_bigtile && *(s + i) == "■"[0] && *(s + i + 1) == "■"[1]) {
+            rc.right += td->font_wid;
+            oldBrush = static_cast<HBRUSH>(SelectObject(hdc, myBrush));
+            oldPen = static_cast<HPEN>(SelectObject(hdc, GetStockObject(NULL_PEN)));
+            Rectangle(hdc, rc.left, rc.top, rc.right + 1, rc.bottom + 1);
+            SelectObject(hdc, oldBrush);
+            SelectObject(hdc, oldPen);
+            rc.right -= td->font_wid;
+            i++;
+            rc.left += 2 * td->tile_wid;
+            rc.right += 2 * td->tile_wid;
+        } else if (iskanji(*(s + i))) /* 2バイト文字 */
+        {
+            char tmp[] = { *(s + i), *(s + i + 1), '\0' };
+            to_wchar wc(tmp);
+            const auto *buf = wc.wc_str();
+            rc.right += td->font_wid;
+            if (buf == NULL)
+                ExtTextOutA(hdc, rc.left, rc.top, ETO_CLIPPED, &rc, s + i, 2, NULL);
+            else
+                ExtTextOutW(hdc, rc.left, rc.top, ETO_CLIPPED, &rc, buf, wcslen(buf), NULL);
+            rc.right -= td->font_wid;
+            i++;
+            rc.left += 2 * td->tile_wid;
+            rc.right += 2 * td->tile_wid;
+        } else if (*(s + i) == 127) {
+            oldBrush = static_cast<HBRUSH>(SelectObject(hdc, myBrush));
+            oldPen = static_cast<HPEN>(SelectObject(hdc, GetStockObject(NULL_PEN)));
+            Rectangle(hdc, rc.left, rc.top, rc.right + 1, rc.bottom + 1);
+            SelectObject(hdc, oldBrush);
+            SelectObject(hdc, oldPen);
+            rc.left += td->tile_wid;
+            rc.right += td->tile_wid;
+        } else {
+            ExtTextOutA(hdc, rc.left, rc.top, ETO_CLIPPED, &rc, s + i, 1, NULL);
+            rc.left += td->tile_wid;
+            rc.right += td->tile_wid;
+        }
+#else
+        if (*(s + i) == 127) {
+            oldBrush = static_cast<HBRUSH>(SelectObject(hdc, myBrush));
+            oldPen = static_cast<HPEN>(SelectObject(hdc, GetStockObject(NULL_PEN)));
+            Rectangle(hdc, rc.left, rc.top, rc.right + 1, rc.bottom + 1);
+            SelectObject(hdc, oldBrush);
+            SelectObject(hdc, oldPen);
+            rc.left += td->tile_wid;
+            rc.right += td->tile_wid;
+        } else {
+            ExtTextOutA(hdc, rc.left, rc.top, ETO_CLIPPED, &rc, s + i, 1, NULL);
+            rc.left += td->tile_wid;
+            rc.right += td->tile_wid;
+        }
+#endif
+    }
+
+    rc.left = rc_start.left;
+    rc.top = rc_start.top;
+    td->refresh(&rc);
+    return 0;
+}
+
+/*!
+ * @brief Low level graphics.  Assumes valid input.
+ * @details
+ * Draw an array of "special" attr/char pairs at the given location.
+ *
+ * We use the "term_pict_win()" function for "graphic" data, which are
+ * encoded by setting the "high-bits" of both the "attr" and the "char"
+ * data.  We use the "attr" to represent the "row" of the main bitmap,
+ * and the "char" to represent the "col" of the main bitmap.  The use
+ * of this function is induced by the "higher_pict" flag.
+ *
+ * If "graphics" is not available, we simply "wipe" the given grids.
+ */
+errr term_data::term_pict_win(TERM_LEN x, TERM_LEN y, int n, const TERM_COLOR *ap, concptr cp, const TERM_COLOR *tap, concptr tcp)
+{
+    term_data *td = (term_data *)(Term->data);
+    int i;
+    HDC hdcMask = NULL;
+    if (!use_graphics) {
+        return (term_wipe_win(x, y, n));
+    }
+
+    const tile_info &infGraph = graphic.get_tile_info();
+    const bool has_mask = (infGraph.hBitmapMask != NULL);
+    TERM_LEN w1 = infGraph.CellWidth;
+    TERM_LEN h1 = infGraph.CellHeight;
+    TERM_LEN tw1 = infGraph.TileWidth;
+    TERM_LEN th1 = infGraph.TileHeight;
+    TERM_LEN w2, h2, tw2 = 0;
+    w2 = td->tile_wid;
+    h2 = td->tile_hgt;
+    tw2 = w2;
+    if (use_bigtile)
+        tw2 *= 2;
+
+    TERM_LEN x2 = x * w2 + td->size_ow1 + infGraph.OffsetX;
+    TERM_LEN y2 = y * h2 + td->size_oh1 + infGraph.OffsetY;
+    HDC hdc = td->get_hdc();
+    HDC hdcSrc = CreateCompatibleDC(hdc);
+    HBITMAP hbmSrcOld = static_cast<HBITMAP>(SelectObject(hdcSrc, infGraph.hBitmap));
+
+    if (has_mask) {
+        hdcMask = CreateCompatibleDC(hdc);
+        SelectObject(hdcMask, infGraph.hBitmapMask);
+    }
+
+    for (i = 0; i < n; i++, x2 += w2) {
+        TERM_COLOR a = ap[i];
+        char c = cp[i];
+        int row = (a & 0x7F);
+        int col = (c & 0x7F);
+        TERM_LEN x1 = col * w1;
+        TERM_LEN y1 = row * h1;
+
+        if (has_mask) {
+            TERM_LEN x3 = (tcp[i] & 0x7F) * w1;
+            TERM_LEN y3 = (tap[i] & 0x7F) * h1;
+            tw2 = tw2 * w1 / tw1;
+            h2 = h2 * h1 / th1;
+            if ((tw1 == tw2) && (th1 == h2)) {
+                BitBlt(hdc, x2, y2, tw2, h2, hdcSrc, x3, y3, SRCCOPY);
+                BitBlt(hdc, x2, y2, tw2, h2, hdcMask, x1, y1, SRCAND);
+                BitBlt(hdc, x2, y2, tw2, h2, hdcSrc, x1, y1, SRCPAINT);
+                continue;
+            }
+
+            SetStretchBltMode(hdc, COLORONCOLOR);
+            StretchBlt(hdc, x2, y2, tw2, h2, hdcMask, x3, y3, w1, h1, SRCAND);
+            StretchBlt(hdc, x2, y2, tw2, h2, hdcSrc, x3, y3, w1, h1, SRCPAINT);
+            if ((x1 != x3) || (y1 != y3)) {
+                StretchBlt(hdc, x2, y2, tw2, h2, hdcMask, x1, y1, w1, h1, SRCAND);
+                StretchBlt(hdc, x2, y2, tw2, h2, hdcSrc, x1, y1, w1, h1, SRCPAINT);
+            }
+
+            continue;
+        }
+
+        if ((w1 == tw2) && (h1 == h2)) {
+            BitBlt(hdc, x2, y2, tw2, h2, hdcSrc, x1, y1, SRCCOPY);
+            continue;
+        }
+
+        SetStretchBltMode(hdc, COLORONCOLOR);
+        StretchBlt(hdc, x2, y2, tw2, h2, hdcSrc, x1, y1, w1, h1, SRCCOPY);
+    }
+
+    SelectObject(hdcSrc, hbmSrcOld);
+    DeleteDC(hdcSrc);
+    if (has_mask) {
+        SelectObject(hdcMask, hbmSrcOld);
+        DeleteDC(hdcMask);
+    }
+
+    td->refresh();
+    return 0;
+}
+
+/*!
+ * @brief カラーパレットの変更？
+ */
+void term_data::refresh_color_table()
+{
+    for (int i = 0; i < 256; i++) {
+        byte rv = angband_color_table[i][1];
+        byte gv = angband_color_table[i][2];
+        byte bv = angband_color_table[i][3];
+        win_clr[i] = PALETTERGB(rv, gv, bv);
+    }
+}
+
+/*!
+ * @brief グラフィクスのモード変更
+ */
+void term_data::change_graphics_mode(graphics_mode mode)
+{
+    graphics_mode ret = graphic.change_graphics(mode);
+    if (ret != mode) {
+        plog(_("グラフィクスを初期化できません!", "Cannot initialize graphics!"));
+    }
+    arg_graphics = static_cast<byte>(ret);
+    use_graphics = (arg_graphics > 0);
+}
+
+/*!
+ * @brief Process all pending events
+ */
+errr term_data::term_xtra_win_flush()
+{
+    MSG msg;
+    while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
+        TranslateMessage(&msg);
+        DispatchMessage(&msg);
+    }
+
+    return 0;
+}
+
+/*!
+ * @brief Hack -- clear the screen
+ * @details
+ * Make this more efficient
+ */
+errr term_data::term_xtra_win_clear(void)
+{
+    term_data *td = (term_data *)(Term->data);
+
+    RECT rc;
+    GetClientRect(td->w, &rc);
+
+    HDC hdc = td->get_hdc();
+    SetBkColor(hdc, RGB(0, 0, 0));
+    SelectObject(hdc, td->font_id);
+    ExtTextOut(hdc, 0, 0, ETO_OPAQUE, &rc, NULL, 0, NULL);
+
+    if (current_bg_mode != bg_mode::BG_NONE) {
+        rc.left = 0;
+        rc.top = 0;
+        draw_bg(hdc, &rc);
+    }
+
+    td->refresh();
+    return 0;
+}
+
+/*!
+ * @brief Hack -- make a noise
+ */
+errr term_data::term_xtra_win_noise(void)
+{
+    MessageBeep(MB_ICONASTERISK);
+    return 0;
+}
+
+/*!
+ * @brief Hack -- make a sound
+ */
+errr term_data::term_xtra_win_sound(int v)
+{
+    if (!use_sound)
+        return 1;
+    return play_sound(v);
+}
+
+/*!
+ * @brief Hack -- play a music
+ */
+errr term_data::term_xtra_win_music(int n, int v)
+{
+    if (!use_music) {
+        return 1;
+    }
+
+    return main_win_music::play_music(n, v);
+}
+
+/*!
+ * @brief Hack -- play a music matches a situation
+ */
+errr term_data::term_xtra_win_scene(int v)
+{
+    // TODO 場面に合った壁紙変更対応
+    if (!use_music) {
+        return 1;
+    }
+
+    return main_win_music::play_music_scene(v);
+}
+
+/*!
+ * @brief Delay for "x" milliseconds
+ */
+int term_data::term_xtra_win_delay(int v)
+{
+    Sleep(v);
+    return 0;
+}
+
+/*!
+ * @brief Do a "special thing"
+ * @todo z-termに影響があるのでplayer_typeの追加は保留
+ */
+errr term_data::term_xtra_win(int n, int v)
+{
+    switch (n) {
+    case TERM_XTRA_NOISE: {
+        return (term_xtra_win_noise());
+    }
+    case TERM_XTRA_FRESH: {
+        term_data *td = (term_data *)(Term->data);
+        if (td->w)
+            UpdateWindow(td->w);
+        return 0;
+    }
+    case TERM_XTRA_MUSIC_BASIC:
+    case TERM_XTRA_MUSIC_DUNGEON:
+    case TERM_XTRA_MUSIC_QUEST:
+    case TERM_XTRA_MUSIC_TOWN:
+    case TERM_XTRA_MUSIC_MONSTER: {
+        return term_xtra_win_music(n, v);
+    }
+    case TERM_XTRA_MUSIC_MUTE: {
+        return main_win_music::stop_music();
+    }
+    case TERM_XTRA_SCENE: {
+        return term_xtra_win_scene(v);
+    }
+    case TERM_XTRA_SOUND: {
+        return (term_xtra_win_sound(v));
+    }
+    case TERM_XTRA_BORED: {
+        return (term_xtra_win_event(0));
+    }
+    case TERM_XTRA_EVENT: {
+        return (term_xtra_win_event(v));
+    }
+    case TERM_XTRA_FLUSH: {
+        return (term_xtra_win_flush());
+    }
+    case TERM_XTRA_CLEAR: {
+        return (term_xtra_win_clear());
+    }
+    case TERM_XTRA_REACT: {
+        return (term_xtra_win_react(p_ptr));
+    }
+    case TERM_XTRA_DELAY: {
+        return (term_xtra_win_delay(v));
+    }
+    }
+
+    return 1;
+}
+
+/*!
+ * @brief Low level graphics (Assumes valid input).
+ * @details
+ * Draw a "cursor" at (x,y), using a "yellow box".
+ */
+errr term_data::term_curs_win(int x, int y)
+{
+    term_data *td = (term_data *)(Term->data);
+    int tile_wid, tile_hgt;
+    tile_wid = td->tile_wid;
+    tile_hgt = td->tile_hgt;
+
+    RECT rc;
+    rc.left = x * tile_wid + td->size_ow1;
+    rc.right = rc.left + tile_wid;
+    rc.top = y * tile_hgt + td->size_oh1;
+    rc.bottom = rc.top + tile_hgt;
+
+    HDC hdc = td->get_hdc();
+    FrameRect(hdc, &rc, hbrYellow);
+    td->refresh(&rc);
+    return 0;
+}
+
+/*!
+ * @brief React to global changes
+ */
+errr term_data::term_xtra_win_react(player_type *player_ptr)
+{
+    refresh_color_table();
+
+    const byte current_mode = static_cast<byte>(graphic.get_mode());
+    if (current_mode != arg_graphics) {
+        change_graphics_mode(static_cast<graphics_mode>(arg_graphics));
+        reset_visuals(player_ptr);
+    }
+
+    for (int i = 0; i < MAX_TERM_DATA; i++) {
+        term_data *td = &data[i];
+        if ((td->cols != td->t.wid) || (td->rows != td->t.hgt)) {
+            td->rebuild();
+        }
+    }
+
+    return 0;
+}
+
+/*!
+ * @brief Process at least one event
+ */
+errr term_data::term_xtra_win_event(int v)
+{
+    MSG msg;
+    if (v) {
+        if (GetMessage(&msg, NULL, 0, 0)) {
+            TranslateMessage(&msg);
+            DispatchMessage(&msg);
+        }
+    } else {
+        if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
+            TranslateMessage(&msg);
+            DispatchMessage(&msg);
+        }
+    }
+
+    return 0;
 }

--- a/src/main-win/main-win-term.cpp
+++ b/src/main-win/main-win-term.cpp
@@ -81,7 +81,7 @@ void double_buffering::dispose_offscreen()
  */
 HDC term_data::get_hdc()
 {
-    return graphics.get_hdc(this->w);
+    return this->graphics.get_hdc(this->w);
 }
 
 /*!
@@ -101,7 +101,7 @@ void term_data::refresh(const RECT *lpRect)
  */
 bool term_data::render(const RECT &rect)
 {
-    return graphics.render(rect);
+    return this->graphics.render(rect);
 }
 
 /*!
@@ -112,7 +112,7 @@ bool term_data::render(const RECT &rect)
  */
 void term_data::dispose_offscreen()
 {
-    graphics.dispose_offscreen();
+    this->graphics.dispose_offscreen();
 };
 
 bool term_data::is_main_term()
@@ -734,19 +734,19 @@ errr term_data::extra_win(int n, int v)
     case TERM_XTRA_SCENE:
         return extra_win_scene(v);
     case TERM_XTRA_SOUND:
-        return (extra_win_sound(v));
+        return extra_win_sound(v);
     case TERM_XTRA_BORED:
-        return (extra_win_event(0));
+        return extra_win_event(0);
     case TERM_XTRA_EVENT:
-        return (extra_win_event(v));
+        return extra_win_event(v);
     case TERM_XTRA_FLUSH:
-        return (extra_win_flush());
+        return extra_win_flush();
     case TERM_XTRA_CLEAR:
-        return (extra_win_clear());
+        return extra_win_clear();
     case TERM_XTRA_REACT:
-        return (extra_win_react(p_ptr));
+        return extra_win_react(p_ptr);
     case TERM_XTRA_DELAY:
-        return (extra_win_delay(v));
+        return extra_win_delay(v);
     default:
         return 1;
     }

--- a/src/main-win/main-win-term.cpp
+++ b/src/main-win/main-win-term.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "main-win/main-win-term.h"
+#include "term/gameterm.h"
 
 term_data data[MAX_TERM_DATA];
 
@@ -221,4 +222,14 @@ void term_data::change_font()
 void term_data::set_window_position(HWND hWnd)
 {
     SetWindowPos(this->w, hWnd, 0, 0, 0, 0, SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE);
+}
+
+/*!
+ * @brief Hack -- redraw a term_data
+ */
+void term_data::redraw_data()
+{
+    term_activate(&this->t);
+    term_redraw();
+    term_activate(term_screen);
 }

--- a/src/main-win/main-win-term.cpp
+++ b/src/main-win/main-win-term.cpp
@@ -48,9 +48,49 @@ bool double_buffering::render(const RECT &rect)
 void double_buffering::dispose_offscreen()
 {
     ::DeleteDC(this->offscreen);
-     this->offscreen = NULL;
+    this->offscreen = NULL;
     ::DeleteObject(this->bitmap);
-     this->bitmap = NULL;
+    this->bitmap = NULL;
     ::DeleteDC(this->display);
-     this->display = NULL;
+    this->display = NULL;
 }
+
+/*!
+ * @brief オフスクリーンHDC取得
+ * @return HDC
+ */
+HDC term_data::get_hdc()
+{
+    return graphics.get_hdc(this->w);
+}
+
+/*!
+ * @brief WM_PAINTでの描画が必要になる領域を設定する.
+ * @param lpRect 更新領域。NULLの場合はクライアント領域全体の描画が必要。
+ */
+void term_data::refresh(const RECT *lpRect)
+{
+    InvalidateRect(this->w, lpRect, FALSE);
+}
+
+/*!
+ * @brief オフスクリーン内容を表示画面に描画する
+ * @param rect 描画領域
+ * @retval true 描画した
+ * @retval false 描画なし（オフスクリーンが存在しない等）
+ */
+bool term_data::render(const RECT &rect)
+{
+    return graphics.render(rect);
+}
+
+/*!
+ * @brief オフスクリーンを破棄する
+ * @details
+ * リサイズ時にはオフスクリーンを破棄して
+ * 呼び出し元で画面の再描画を行う必要がある。
+ */
+void term_data::dispose_offscreen()
+{
+    graphics.dispose_offscreen();
+};

--- a/src/main-win/main-win-term.cpp
+++ b/src/main-win/main-win-term.cpp
@@ -841,34 +841,36 @@ bool term_data::handle_window_resize(UINT uMsg, WPARAM wParam, LPARAM lParam)
         const LONG tmp_height = min_rows * this->tile_hgt + this->size_oh1 + this->size_oh2 + 1;
         RECT rc{ 0, 0, tmp_width, tmp_height };
         AdjustWindowRectEx(&rc, this->dwStyle, TRUE, this->dwExStyle);
-
         auto *lpmmi = (MINMAXINFO *)lParam;
         lpmmi->ptMinTrackSize.x = rc.right - rc.left;
         lpmmi->ptMinTrackSize.y = rc.bottom - rc.top;
-
         return true;
     }
     case WM_EXITSIZEMOVE:
         this->fit_size_to_window(true);
         return true;
-    case WM_WINDOWPOSCHANGED: {
-        if (this->size_hack) {
-            return false;
-        }
-
-        auto *pos = (WINDOWPOS *)lParam;
-        if (none_bits(pos->flags, SWP_NOCOPYBITS | SWP_NOSIZE)) {
-            this->fit_size_to_window();
-            return true;
-        }
-
-        return false;
-    }
+    case WM_WINDOWPOSCHANGED:
+        return handle_window_position_change(lParam);
     case WM_SIZE:
         return handle_window_max_min(wParam);
     default:
         return false;
     }
+}
+
+bool term_data::handle_window_position_change(const LPARAM lParam)
+{
+    if (this->size_hack) {
+        return false;
+    }
+
+    auto *pos = (WINDOWPOS *)lParam;
+    if (none_bits(pos->flags, SWP_NOCOPYBITS | SWP_NOSIZE)) {
+        this->fit_size_to_window();
+        return true;
+    }
+
+    return false;
 }
 
 bool term_data::handle_window_max_min(const WPARAM wParam)

--- a/src/main-win/main-win-term.cpp
+++ b/src/main-win/main-win-term.cpp
@@ -214,3 +214,11 @@ void term_data::change_font()
     this->adjust_size();
     this->resize_window();
 }
+
+/*!
+ * @brief Allow the user to lock this window.
+ */
+void term_data::set_window_position(HWND hWnd)
+{
+    SetWindowPos(this->w, hWnd, 0, 0, 0, 0, SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE);
+}

--- a/src/main-win/main-win-term.cpp
+++ b/src/main-win/main-win-term.cpp
@@ -158,3 +158,38 @@ void term_data::adjust_size()
         this->size_hgt = rc.bottom - rc.top;
     }
 }
+
+/*!
+ * @brief Force the use of a new font for a term_data.
+ * This function may be called before the "window" is ready.
+ * This function returns zero only if everything succeeds.
+ * @note that the "font name" must be capitalized!!!
+ */
+void term_data::force_font()
+{
+    if (this->font_id) {
+        DeleteObject(this->font_id);
+    }
+
+    this->font_id = CreateFontIndirectW(&(this->lf));
+    int wid = this->lf.lfWidth;
+    int hgt = this->lf.lfHeight;
+    if (!this->font_id) {
+        return;
+    }
+
+    if ((wid == 0) || (hgt == 0)) {
+        auto hdcDesktop = GetDC(HWND_DESKTOP);
+        auto hfOld = static_cast<HFONT>(SelectObject(hdcDesktop, this->font_id));
+        TEXTMETRIC tm;
+        GetTextMetrics(hdcDesktop, &tm);
+        SelectObject(hdcDesktop, hfOld);
+        ReleaseDC(HWND_DESKTOP, hdcDesktop);
+        wid = tm.tmAveCharWidth;
+        hgt = tm.tmHeight;
+    }
+
+    this->font_wid = wid;
+    this->font_hgt = hgt;
+    return;
+}

--- a/src/main-win/main-win-term.cpp
+++ b/src/main-win/main-win-term.cpp
@@ -18,7 +18,6 @@
 #include "util/angband-files.h"
 #include "util/bit-flags-calculator.h"
 
-LPCWSTR AppName = L"ANGBAND";
 HINSTANCE hInstance;
 bg_mode current_bg_mode = bg_mode::BG_NONE;
 COLORREF win_clr[256];
@@ -403,7 +402,7 @@ errr term_data::text_win(int x, int y, int n, TERM_COLOR a, concptr s)
     static bool init_done = false;
 
     if (!init_done) {
-        WALL = LoadBitmapW(hInstance, AppName);
+        WALL = LoadBitmapW(hInstance, application_name);
         myBrush = CreatePatternBrush(WALL);
         init_done = true;
     }

--- a/src/main-win/main-win-term.cpp
+++ b/src/main-win/main-win-term.cpp
@@ -828,24 +828,13 @@ errr term_data::extra_win_event(int v)
  */
 bool term_data::handle_window_resize(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-    if (!this->w) {
+    if (this->w == NULL) {
         return false;
     }
 
     switch (uMsg) {
-    case WM_GETMINMAXINFO: {
-        const bool is_main = this->is_main_term();
-        const int min_cols = (is_main) ? 80 : 20;
-        const int min_rows = (is_main) ? 24 : 3;
-        const LONG tmp_width = min_cols * this->tile_wid + this->size_ow1 + this->size_ow2;
-        const LONG tmp_height = min_rows * this->tile_hgt + this->size_oh1 + this->size_oh2 + 1;
-        RECT rc{ 0, 0, tmp_width, tmp_height };
-        AdjustWindowRectEx(&rc, this->dwStyle, TRUE, this->dwExStyle);
-        auto *lpmmi = (MINMAXINFO *)lParam;
-        lpmmi->ptMinTrackSize.x = rc.right - rc.left;
-        lpmmi->ptMinTrackSize.y = rc.bottom - rc.top;
-        return true;
-    }
+    case WM_GETMINMAXINFO:
+        return handle_window_get_info(lParam);
     case WM_EXITSIZEMOVE:
         this->fit_size_to_window(true);
         return true;
@@ -856,6 +845,21 @@ bool term_data::handle_window_resize(UINT uMsg, WPARAM wParam, LPARAM lParam)
     default:
         return false;
     }
+}
+
+bool term_data::handle_window_get_info(const LPARAM lParam)
+{
+    const bool is_main = this->is_main_term();
+    const int min_cols = (is_main) ? 80 : 20;
+    const int min_rows = (is_main) ? 24 : 3;
+    const LONG tmp_width = min_cols * this->tile_wid + this->size_ow1 + this->size_ow2;
+    const LONG tmp_height = min_rows * this->tile_hgt + this->size_oh1 + this->size_oh2 + 1;
+    RECT rc{ 0, 0, tmp_width, tmp_height };
+    AdjustWindowRectEx(&rc, this->dwStyle, TRUE, this->dwExStyle);
+    auto *lpmmi = (MINMAXINFO *)lParam;
+    lpmmi->ptMinTrackSize.x = rc.right - rc.left;
+    lpmmi->ptMinTrackSize.y = rc.bottom - rc.top;
+    return true;
 }
 
 bool term_data::handle_window_position_change(const LPARAM lParam)

--- a/src/main-win/main-win-term.cpp
+++ b/src/main-win/main-win-term.cpp
@@ -193,3 +193,24 @@ void term_data::force_font()
     this->font_hgt = hgt;
     return;
 }
+
+/*!
+ * @brief Allow the user to change the font for this window.
+ */
+void term_data::change_font()
+{
+    CHOOSEFONTW cf;
+    memset(&cf, 0, sizeof(cf));
+    cf.lStructSize = sizeof(cf);
+    cf.Flags = CF_SCREENFONTS | CF_FIXEDPITCHONLY | CF_NOVERTFONTS | CF_INITTOLOGFONTSTRUCT;
+    cf.lpLogFont = &(this->lf);
+
+    if (!ChooseFontW(&cf))
+        return;
+
+    this->force_font();
+    this->tile_wid = this->font_wid;
+    this->tile_hgt = this->font_hgt;
+    this->adjust_size();
+    this->resize_window();
+}

--- a/src/main-win/main-win-term.cpp
+++ b/src/main-win/main-win-term.cpp
@@ -233,3 +233,24 @@ void term_data::redraw_data()
     term_redraw();
     term_activate(term_screen);
 }
+
+/*!
+ * @brief ターミナルのサイズ更新
+ * @details 行数、列数の変更に対応する。
+ * @param td term_dataのポインタ
+ * @param resize_window trueの場合に再計算されたウインドウサイズにリサイズする
+ */
+void term_data::rebuild(bool resize_window)
+{
+    term_type *old = Term;
+    this->size_hack = true;
+    term_activate(&this->t);
+    this->adjust_size();
+    if (resize_window) {
+        this->resize_window();
+    }
+    this->dispose_offscreen();
+    term_resize(this->cols, this->rows);
+    this->size_hack = false;
+    term_activate(old);
+}

--- a/src/main-win/main-win-term.cpp
+++ b/src/main-win/main-win-term.cpp
@@ -5,6 +5,8 @@
 
 #include "main-win/main-win-term.h"
 
+term_data data[MAX_TERM_DATA];
+
 /*!
  * @brief オフスクリーンのデバイスコンテキストを取得する
  * @param hWnd ウインドウハンドル
@@ -94,3 +96,8 @@ void term_data::dispose_offscreen()
 {
     graphics.dispose_offscreen();
 };
+
+bool term_data::is_main_term()
+{
+    return (this == &data[0]);
+}

--- a/src/main-win/main-win-term.cpp
+++ b/src/main-win/main-win-term.cpp
@@ -103,6 +103,25 @@ bool term_data::is_main_term()
 }
 
 /*!
+ * @brief Resize a window
+ */
+void term_data::resize_window()
+{
+    if (!this->w) {
+        return;
+    }
+
+    SetWindowPos(this->w, 0, 0, 0, this->size_wid, this->size_hgt, SWP_NOMOVE | SWP_NOZORDER);
+    if (this->size_hack) {
+        return;
+    }
+
+    this->dispose_offscreen();
+    term_activate(&this->t);
+    term_redraw();
+}
+
+/*!
  * @brief (Windows版固有実装) / Adjust the "size" for a window
  */
 void term_data::adjust_size()

--- a/src/main-win/main-win-term.cpp
+++ b/src/main-win/main-win-term.cpp
@@ -313,20 +313,20 @@ void term_data::link_data()
     link->higher_pict = true;
     link->attr_blank = TERM_WHITE;
     link->char_blank = ' ';
-    link->user_hook = this->term_user_win;
-    link->xtra_hook = this->term_xtra_win;
-    link->curs_hook = this->term_curs_win;
-    link->bigcurs_hook = this->term_bigcurs_win;
-    link->wipe_hook = this->term_wipe_win;
-    link->text_hook = this->term_text_win;
-    link->pict_hook = this->term_pict_win;
+    link->user_hook = this->user_win;
+    link->xtra_hook = this->extra_win;
+    link->curs_hook = this->curs_win;
+    link->bigcurs_hook = this->bigcurs_win;
+    link->wipe_hook = this->wipe_win;
+    link->text_hook = this->text_win;
+    link->pict_hook = this->pict_win;
     link->data = (vptr)(this);
 }
 
 /*!
  * @brief Windows版ユーザ設定項目実装部(実装必須) /Interact with the User
  */
-errr term_data::term_user_win(int n)
+errr term_data::user_win(int n)
 {
     (void)n;
     return 0;
@@ -337,7 +337,7 @@ errr term_data::term_user_win(int n)
  * @details
  * Draw a "big cursor" at (x,y), using a "yellow box".
  */
-errr term_data::term_bigcurs_win(int x, int y)
+errr term_data::bigcurs_win(int x, int y)
 {
     term_data *td = (term_data *)(Term->data);
     int tile_wid, tile_hgt;
@@ -361,7 +361,7 @@ errr term_data::term_bigcurs_win(int x, int y)
  * @details
  * Erase a "block" of "n" characters starting at (x,y).
  */
-errr term_data::term_wipe_win(int x, int y, int n)
+errr term_data::wipe_win(int x, int y, int n)
 {
     term_data *td = (term_data *)(Term->data);
     RECT rc;
@@ -393,7 +393,7 @@ errr term_data::term_wipe_win(int x, int y, int n)
  * what color it should be using to draw with, but perhaps simply changing
  * it every time is not too inefficient.
  */
-errr term_data::term_text_win(int x, int y, int n, TERM_COLOR a, concptr s)
+errr term_data::text_win(int x, int y, int n, TERM_COLOR a, concptr s)
 {
     term_data *td = (term_data *)(Term->data);
     static HBITMAP WALL;
@@ -504,13 +504,13 @@ errr term_data::term_text_win(int x, int y, int n, TERM_COLOR a, concptr s)
  *
  * If "graphics" is not available, we simply "wipe" the given grids.
  */
-errr term_data::term_pict_win(TERM_LEN x, TERM_LEN y, int n, const TERM_COLOR *ap, concptr cp, const TERM_COLOR *tap, concptr tcp)
+errr term_data::pict_win(TERM_LEN x, TERM_LEN y, int n, const TERM_COLOR *ap, concptr cp, const TERM_COLOR *tap, concptr tcp)
 {
     term_data *td = (term_data *)(Term->data);
     int i;
     HDC hdcMask = NULL;
     if (!use_graphics) {
-        return (term_wipe_win(x, y, n));
+        return (wipe_win(x, y, n));
     }
 
     const tile_info &infGraph = graphic.get_tile_info();
@@ -617,7 +617,7 @@ void term_data::change_graphics_mode(graphics_mode mode)
 /*!
  * @brief Process all pending events
  */
-errr term_data::term_xtra_win_flush()
+errr term_data::extra_win_flush()
 {
     MSG msg;
     while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
@@ -633,7 +633,7 @@ errr term_data::term_xtra_win_flush()
  * @details
  * Make this more efficient
  */
-errr term_data::term_xtra_win_clear(void)
+errr term_data::extra_win_clear(void)
 {
     term_data *td = (term_data *)(Term->data);
 
@@ -658,7 +658,7 @@ errr term_data::term_xtra_win_clear(void)
 /*!
  * @brief Hack -- make a noise
  */
-errr term_data::term_xtra_win_noise(void)
+errr term_data::extra_win_noise(void)
 {
     MessageBeep(MB_ICONASTERISK);
     return 0;
@@ -667,7 +667,7 @@ errr term_data::term_xtra_win_noise(void)
 /*!
  * @brief Hack -- make a sound
  */
-errr term_data::term_xtra_win_sound(int v)
+errr term_data::extra_win_sound(int v)
 {
     if (!use_sound)
         return 1;
@@ -677,7 +677,7 @@ errr term_data::term_xtra_win_sound(int v)
 /*!
  * @brief Hack -- play a music
  */
-errr term_data::term_xtra_win_music(int n, int v)
+errr term_data::extra_win_music(int n, int v)
 {
     if (!use_music) {
         return 1;
@@ -689,7 +689,7 @@ errr term_data::term_xtra_win_music(int n, int v)
 /*!
  * @brief Hack -- play a music matches a situation
  */
-errr term_data::term_xtra_win_scene(int v)
+errr term_data::extra_win_scene(int v)
 {
     // TODO 場面に合った壁紙変更対応
     if (!use_music) {
@@ -702,7 +702,7 @@ errr term_data::term_xtra_win_scene(int v)
 /*!
  * @brief Delay for "x" milliseconds
  */
-int term_data::term_xtra_win_delay(int v)
+int term_data::extra_win_delay(int v)
 {
     Sleep(v);
     return 0;
@@ -712,12 +712,11 @@ int term_data::term_xtra_win_delay(int v)
  * @brief Do a "special thing"
  * @todo z-termに影響があるのでplayer_typeの追加は保留
  */
-errr term_data::term_xtra_win(int n, int v)
+errr term_data::extra_win(int n, int v)
 {
     switch (n) {
-    case TERM_XTRA_NOISE: {
-        return (term_xtra_win_noise());
-    }
+    case TERM_XTRA_NOISE:
+        return (extra_win_noise());
     case TERM_XTRA_FRESH: {
         term_data *td = (term_data *)(Term->data);
         if (td->w)
@@ -728,39 +727,29 @@ errr term_data::term_xtra_win(int n, int v)
     case TERM_XTRA_MUSIC_DUNGEON:
     case TERM_XTRA_MUSIC_QUEST:
     case TERM_XTRA_MUSIC_TOWN:
-    case TERM_XTRA_MUSIC_MONSTER: {
-        return term_xtra_win_music(n, v);
-    }
-    case TERM_XTRA_MUSIC_MUTE: {
+    case TERM_XTRA_MUSIC_MONSTER:
+        return extra_win_music(n, v);
+    case TERM_XTRA_MUSIC_MUTE:
         return main_win_music::stop_music();
+    case TERM_XTRA_SCENE:
+        return extra_win_scene(v);
+    case TERM_XTRA_SOUND:
+        return (extra_win_sound(v));
+    case TERM_XTRA_BORED:
+        return (extra_win_event(0));
+    case TERM_XTRA_EVENT:
+        return (extra_win_event(v));
+    case TERM_XTRA_FLUSH:
+        return (extra_win_flush());
+    case TERM_XTRA_CLEAR:
+        return (extra_win_clear());
+    case TERM_XTRA_REACT:
+        return (extra_win_react(p_ptr));
+    case TERM_XTRA_DELAY:
+        return (extra_win_delay(v));
+    default:
+        return 1;
     }
-    case TERM_XTRA_SCENE: {
-        return term_xtra_win_scene(v);
-    }
-    case TERM_XTRA_SOUND: {
-        return (term_xtra_win_sound(v));
-    }
-    case TERM_XTRA_BORED: {
-        return (term_xtra_win_event(0));
-    }
-    case TERM_XTRA_EVENT: {
-        return (term_xtra_win_event(v));
-    }
-    case TERM_XTRA_FLUSH: {
-        return (term_xtra_win_flush());
-    }
-    case TERM_XTRA_CLEAR: {
-        return (term_xtra_win_clear());
-    }
-    case TERM_XTRA_REACT: {
-        return (term_xtra_win_react(p_ptr));
-    }
-    case TERM_XTRA_DELAY: {
-        return (term_xtra_win_delay(v));
-    }
-    }
-
-    return 1;
 }
 
 /*!
@@ -768,7 +757,7 @@ errr term_data::term_xtra_win(int n, int v)
  * @details
  * Draw a "cursor" at (x,y), using a "yellow box".
  */
-errr term_data::term_curs_win(int x, int y)
+errr term_data::curs_win(int x, int y)
 {
     term_data *td = (term_data *)(Term->data);
     int tile_wid, tile_hgt;
@@ -790,7 +779,7 @@ errr term_data::term_curs_win(int x, int y)
 /*!
  * @brief React to global changes
  */
-errr term_data::term_xtra_win_react(player_type *player_ptr)
+errr term_data::extra_win_react(player_type *player_ptr)
 {
     refresh_color_table();
 
@@ -813,7 +802,7 @@ errr term_data::term_xtra_win_react(player_type *player_ptr)
 /*!
  * @brief Process at least one event
  */
-errr term_data::term_xtra_win_event(int v)
+errr term_data::extra_win_event(int v)
 {
     MSG msg;
     if (v) {

--- a/src/main-win/main-win-term.h
+++ b/src/main-win/main-win-term.h
@@ -114,6 +114,7 @@ struct term_data {
     void rebuild(bool resize_window = true);
     void fit_size_to_window(bool recalc_window_size = false);
     void link_data();
+    bool handle_window_resize(UINT uMsg, WPARAM wParam, LPARAM lParam);
 
 private:
     static errr term_user_win(int n);

--- a/src/main-win/main-win-term.h
+++ b/src/main-win/main-win-term.h
@@ -93,6 +93,7 @@ struct term_data {
     bool is_main_term();
     void resize_window();
     void adjust_size();
+    void force_font();
 };
 
 constexpr int MAX_TERM_DATA = 8; //!< Maximum number of windows

--- a/src/main-win/main-win-term.h
+++ b/src/main-win/main-win-term.h
@@ -95,6 +95,7 @@ struct term_data {
     void adjust_size();
     void force_font();
     void change_font();
+    void set_window_position(HWND hWnd);
 };
 
 constexpr int MAX_TERM_DATA = 8; //!< Maximum number of windows

--- a/src/main-win/main-win-term.h
+++ b/src/main-win/main-win-term.h
@@ -91,6 +91,7 @@ struct term_data {
     bool render(const RECT &rect);
     void dispose_offscreen();
     bool is_main_term();
+    void resize_window();
     void adjust_size();
 };
 

--- a/src/main-win/main-win-term.h
+++ b/src/main-win/main-win-term.h
@@ -96,7 +96,7 @@ struct term_data {
 
     double_buffering graphics{};
 
-    static errr term_xtra_win_flush();
+    static errr extra_win_flush();
     static void refresh_color_table();
     static void change_graphics_mode(graphics_mode mode);
 
@@ -117,21 +117,21 @@ struct term_data {
     bool handle_window_resize(UINT uMsg, WPARAM wParam, LPARAM lParam);
 
 private:
-    static errr term_user_win(int n);
-    static errr term_xtra_win(int n, int v);
-    static errr term_curs_win(int x, int y);
-    static errr term_bigcurs_win(int x, int y);
-    static errr term_wipe_win(int x, int y, int n);
-    static errr term_text_win(int x, int y, int n, TERM_COLOR a, concptr s);
-    static errr term_pict_win(TERM_LEN x, TERM_LEN y, int n, const TERM_COLOR *ap, concptr cp, const TERM_COLOR *tap, concptr tcp);
-    static errr term_xtra_win_react(player_type *player_ptr);
-    static errr term_xtra_win_event(int v);
-    static errr term_xtra_win_clear(void);
-    static errr term_xtra_win_noise(void);
-    static errr term_xtra_win_sound(int v);
-    static errr term_xtra_win_music(int n, int v);
-    static errr term_xtra_win_scene(int v);
-    static int term_xtra_win_delay(int v);
+    static errr user_win(int n);
+    static errr extra_win(int n, int v);
+    static errr curs_win(int x, int y);
+    static errr bigcurs_win(int x, int y);
+    static errr wipe_win(int x, int y, int n);
+    static errr text_win(int x, int y, int n, TERM_COLOR a, concptr s);
+    static errr pict_win(TERM_LEN x, TERM_LEN y, int n, const TERM_COLOR *ap, concptr cp, const TERM_COLOR *tap, concptr tcp);
+    static errr extra_win_react(player_type *player_ptr);
+    static errr extra_win_event(int v);
+    static errr extra_win_clear(void);
+    static errr extra_win_noise(void);
+    static errr extra_win_sound(int v);
+    static errr extra_win_music(int n, int v);
+    static errr extra_win_scene(int v);
+    static int extra_win_delay(int v);
 };
 
 constexpr int MAX_TERM_DATA = 8; //!< Maximum number of windows

--- a/src/main-win/main-win-term.h
+++ b/src/main-win/main-win-term.h
@@ -33,11 +33,15 @@ protected:
 };
 
 constexpr LPCWSTR application_name = L"ANGBAND";
+constexpr int MAX_TERM_DATA = 8; //!< Maximum number of windows
 extern HINSTANCE hInstance; // Saved instance handle.
 extern bg_mode current_bg_mode;
 extern COLORREF win_clr[256]; // The "complex" color values.
 extern POINT normsize; //!< Remember normal size of main window when maxmized.
 extern HBRUSH hbrYellow; // Yellow brush for the cursor.
+
+struct term_data;
+extern term_data data[MAX_TERM_DATA]; //!< An array of term_data's
 
 /*!
  * @struct term_data
@@ -58,6 +62,11 @@ extern HBRUSH hbrYellow; // Yellow brush for the cursor.
  */
 struct player_type;
 struct term_data {
+    term_data() = default; //!< デフォルトコンストラクタ
+    term_data(const term_data &) = delete; //!< コピー禁止
+    term_data &operator=(term_data &) = delete; //!< 代入演算子禁止
+    term_data &operator=(term_data &&) = default; //!< move代入
+
     term_type t{};
     LPCWSTR name{};
     HWND w{};
@@ -86,14 +95,7 @@ struct term_data {
     int tile_hgt{}; //!< タイル縦幅
 
     LOGFONTW lf{};
-
     bool posfix{};
-
-    term_data() = default; //!< デフォルトコンストラクタ
-    term_data(const term_data &) = delete; //!< コピー禁止
-    term_data &operator=(term_data &) = delete; //!< 代入演算子禁止
-    term_data &operator=(term_data &&) = default; //!< move代入
-
     double_buffering graphics{};
 
     static errr extra_win_flush();
@@ -103,8 +105,6 @@ struct term_data {
     HDC get_hdc();
     void refresh(const RECT *lpRect = NULL);
     bool render(const RECT &rect);
-    void dispose_offscreen();
-    bool is_main_term();
     void resize_window();
     void adjust_size();
     void force_font();
@@ -133,10 +133,9 @@ private:
     static errr extra_win_scene(int v);
     static int extra_win_delay(int v);
 
+    void dispose_offscreen();
+    bool is_main_term();
     bool handle_window_get_info(const LPARAM lParam);
     bool handle_window_position_change(const LPARAM lParam);
     bool handle_window_max_min(const WPARAM wParam);
 };
-
-constexpr int MAX_TERM_DATA = 8; //!< Maximum number of windows
-extern term_data data[MAX_TERM_DATA]; //!< An array of term_data's

--- a/src/main-win/main-win-term.h
+++ b/src/main-win/main-win-term.h
@@ -96,6 +96,7 @@ struct term_data {
     void force_font();
     void change_font();
     void set_window_position(HWND hWnd);
+    void redraw_data();
 };
 
 constexpr int MAX_TERM_DATA = 8; //!< Maximum number of windows

--- a/src/main-win/main-win-term.h
+++ b/src/main-win/main-win-term.h
@@ -90,4 +90,8 @@ struct term_data {
     void refresh(const RECT *lpRect = NULL);
     bool render(const RECT &rect);
     void dispose_offscreen();
+    bool is_main_term();
 };
+
+constexpr int MAX_TERM_DATA = 8; //!< Maximum number of windows
+extern term_data data[MAX_TERM_DATA]; //!< An array of term_data's

--- a/src/main-win/main-win-term.h
+++ b/src/main-win/main-win-term.h
@@ -86,41 +86,8 @@ struct term_data {
     term_data &operator=(term_data &&) = default; //!< move代入
 
     double_buffering graphics{};
-    /*!
-     * @brief オフスクリーンHDC取得
-     * @return HDC
-     */
-    HDC get_hdc()
-    {
-        return graphics.get_hdc(this->w);
-    };
-    /*!
-     * @brief WM_PAINTでの描画が必要になる領域を設定する.
-     * @param lpRect 更新領域。NULLの場合はクライアント領域全体の描画が必要。
-     */
-    void refresh(const RECT *lpRect = NULL)
-    {
-        InvalidateRect(this->w, lpRect, FALSE);
-    };
-    /*!
-     * @brief オフスクリーン内容を表示画面に描画する
-     * @param rect 描画領域
-     * @retval true 描画した
-     * @retval false 描画なし（オフスクリーンが存在しない等）
-     */
-    bool render(const RECT &rect)
-    {
-        return graphics.render(rect);
-    };
-    /*!
-     * @brief オフスクリーンを破棄する
-     * @details
-     * リサイズ時にはオフスクリーンを破棄して
-     * 呼び出し元で画面の再描画を行う必要がある。
-     */
-    void dispose_offscreen()
-    {
-        graphics.dispose_offscreen();
-    };
+    HDC get_hdc();
+    void refresh(const RECT *lpRect = NULL);
+    bool render(const RECT &rect);
+    void dispose_offscreen();
 };
-

--- a/src/main-win/main-win-term.h
+++ b/src/main-win/main-win-term.h
@@ -94,6 +94,7 @@ struct term_data {
     void resize_window();
     void adjust_size();
     void force_font();
+    void change_font();
 };
 
 constexpr int MAX_TERM_DATA = 8; //!< Maximum number of windows

--- a/src/main-win/main-win-term.h
+++ b/src/main-win/main-win-term.h
@@ -6,7 +6,6 @@
 
 #include "term/z-term.h"
 #include "system/h-type.h"
-
 #include <windows.h>
 
 /*!
@@ -30,6 +29,8 @@ protected:
     HBITMAP bitmap;
     HDC offscreen;
 };
+
+extern POINT normsize;
 
 /*!
  * @struct term_data
@@ -98,6 +99,7 @@ struct term_data {
     void set_window_position(HWND hWnd);
     void redraw_data();
     void rebuild(bool resize_window = true);
+    void fit_size_to_window(bool recalc_window_size = false);
 };
 
 constexpr int MAX_TERM_DATA = 8; //!< Maximum number of windows

--- a/src/main-win/main-win-term.h
+++ b/src/main-win/main-win-term.h
@@ -91,6 +91,7 @@ struct term_data {
     bool render(const RECT &rect);
     void dispose_offscreen();
     bool is_main_term();
+    void adjust_size();
 };
 
 constexpr int MAX_TERM_DATA = 8; //!< Maximum number of windows

--- a/src/main-win/main-win-term.h
+++ b/src/main-win/main-win-term.h
@@ -97,6 +97,7 @@ struct term_data {
     void change_font();
     void set_window_position(HWND hWnd);
     void redraw_data();
+    void rebuild(bool resize_window = true);
 };
 
 constexpr int MAX_TERM_DATA = 8; //!< Maximum number of windows

--- a/src/main-win/main-win-term.h
+++ b/src/main-win/main-win-term.h
@@ -132,6 +132,7 @@ private:
     static errr extra_win_music(int n, int v);
     static errr extra_win_scene(int v);
     static int extra_win_delay(int v);
+    bool handle_window_max_min(const WPARAM wParam);
 };
 
 constexpr int MAX_TERM_DATA = 8; //!< Maximum number of windows

--- a/src/main-win/main-win-term.h
+++ b/src/main-win/main-win-term.h
@@ -132,6 +132,7 @@ private:
     static errr extra_win_music(int n, int v);
     static errr extra_win_scene(int v);
     static int extra_win_delay(int v);
+    bool handle_window_position_change(const LPARAM lParam);
     bool handle_window_max_min(const WPARAM wParam);
 };
 

--- a/src/main-win/main-win-term.h
+++ b/src/main-win/main-win-term.h
@@ -4,8 +4,10 @@
  * @brief Windows版固有実装(ターミナル)ヘッダ
  */
 
-#include "term/z-term.h"
+#include "main-win/graphics-win.h"
+#include "main-win/main-win-bg.h"
 #include "system/h-type.h"
+#include "term/z-term.h"
 #include <windows.h>
 
 /*!
@@ -30,7 +32,12 @@ protected:
     HDC offscreen;
 };
 
-extern POINT normsize;
+extern LPCWSTR AppName; // Name of application.
+extern HINSTANCE hInstance; // Saved instance handle.
+extern bg_mode current_bg_mode;
+extern COLORREF win_clr[256]; // The "complex" color values.
+extern POINT normsize; //!< Remember normal size of main window when maxmized.
+extern HBRUSH hbrYellow; // Yellow brush for the cursor.
 
 /*!
  * @struct term_data
@@ -49,6 +56,7 @@ extern POINT normsize;
  * the user.
  * </p>
  */
+struct player_type;
 struct term_data {
     term_type t{};
     LPCWSTR name{};
@@ -87,6 +95,11 @@ struct term_data {
     term_data &operator=(term_data &&) = default; //!< move代入
 
     double_buffering graphics{};
+
+    static errr term_xtra_win_flush();
+    static void refresh_color_table();
+    static void change_graphics_mode(graphics_mode mode);
+
     HDC get_hdc();
     void refresh(const RECT *lpRect = NULL);
     bool render(const RECT &rect);
@@ -100,6 +113,24 @@ struct term_data {
     void redraw_data();
     void rebuild(bool resize_window = true);
     void fit_size_to_window(bool recalc_window_size = false);
+    void link_data();
+
+private:
+    static errr term_user_win(int n);
+    static errr term_xtra_win(int n, int v);
+    static errr term_curs_win(int x, int y);
+    static errr term_bigcurs_win(int x, int y);
+    static errr term_wipe_win(int x, int y, int n);
+    static errr term_text_win(int x, int y, int n, TERM_COLOR a, concptr s);
+    static errr term_pict_win(TERM_LEN x, TERM_LEN y, int n, const TERM_COLOR *ap, concptr cp, const TERM_COLOR *tap, concptr tcp);
+    static errr term_xtra_win_react(player_type *player_ptr);
+    static errr term_xtra_win_event(int v);
+    static errr term_xtra_win_clear(void);
+    static errr term_xtra_win_noise(void);
+    static errr term_xtra_win_sound(int v);
+    static errr term_xtra_win_music(int n, int v);
+    static errr term_xtra_win_scene(int v);
+    static int term_xtra_win_delay(int v);
 };
 
 constexpr int MAX_TERM_DATA = 8; //!< Maximum number of windows

--- a/src/main-win/main-win-term.h
+++ b/src/main-win/main-win-term.h
@@ -132,6 +132,8 @@ private:
     static errr extra_win_music(int n, int v);
     static errr extra_win_scene(int v);
     static int extra_win_delay(int v);
+
+    bool handle_window_get_info(const LPARAM lParam);
     bool handle_window_position_change(const LPARAM lParam);
     bool handle_window_max_min(const WPARAM wParam);
 };

--- a/src/main-win/main-win-term.h
+++ b/src/main-win/main-win-term.h
@@ -32,7 +32,7 @@ protected:
     HDC offscreen;
 };
 
-extern LPCWSTR AppName; // Name of application.
+constexpr LPCWSTR application_name = L"ANGBAND";
 extern HINSTANCE hInstance; // Saved instance handle.
 extern bg_mode current_bg_mode;
 extern COLORREF win_clr[256]; // The "complex" color values.


### PR DESCRIPTION
掲題の通りです、ご確認下さい
今回の変更は、単にmain-win.cpp が長すぎるから分割したかった部分もありますが、C++移行の一環として、今後termの差し替えを行いやすくなることも想定しています
こちらの環境では、ウィンドウの大きさ変更程度の基本的な動作は確認できました
誠に勝手ながら、term関係は有識者でいらっしゃるshimitei氏の方が詳しいですのでレビュアーに割り当てます
(実際にApproveするかはお任せします)

大量のstaticメソッドがpublic/privateに入っていますが、これはlink_data() にてterm_typeのメソッド登録を行う都合のためです
他のクラスやグローバル空間に置くことも検討しましたが、term_dataの中で定義するのが一番簡潔だったために入れ込みました