### PR TITLE
[Fix] ブラックマーケットが複数生成されないようにするコードが機能していない

### DIFF
--- a/src/room/rooms-city.cpp
+++ b/src/room/rooms-city.cpp
@@ -192,10 +192,13 @@ bool build_type16(player_type *player_ptr, dun_data_type *dd_ptr)
     int town_wid = rand_range(MIN_TOWN_WID, MAX_TOWN_WID);
     bool prevent_bm = false;
     floor_type *floor_ptr = player_ptr->current_floor_ptr;
+
+    // If already exist black market, prevent building
     for (y = 0; (y < floor_ptr->height) && !prevent_bm; y++) {
         for (x = 0; x < floor_ptr->width; x++) {
-            if (floor_ptr->grid_array[y][x].feat == static_cast<FEAT_IDX>(FF::STORE)) {
-                prevent_bm = (f_info[floor_ptr->grid_array[y][x].feat].subtype == STORE_BLACK);
+            const auto f_ptr = &f_info[floor_ptr->grid_array[y][x].feat];
+            if (f_ptr->flags.has(FF::STORE) && f_ptr->subtype == STORE_BLACK) {
+                prevent_bm = true;
                 break;
             }
         }

--- a/src/room/rooms-city.cpp
+++ b/src/room/rooms-city.cpp
@@ -187,26 +187,9 @@ bool build_type16(player_type *player_ptr, dun_data_type *dd_ptr)
         STORE_BOOK,
     };
     int n = sizeof stores / sizeof(int);
-    POSITION i, y, x, y1, x1, yval, xval;
+    POSITION y1, x1, yval, xval;
     int town_hgt = rand_range(MIN_TOWN_HGT, MAX_TOWN_HGT);
     int town_wid = rand_range(MIN_TOWN_WID, MAX_TOWN_WID);
-    bool prevent_bm = false;
-    floor_type *floor_ptr = player_ptr->current_floor_ptr;
-
-    // If already exist black market, prevent building
-    for (y = 0; (y < floor_ptr->height) && !prevent_bm; y++) {
-        for (x = 0; x < floor_ptr->width; x++) {
-            const auto f_ptr = &f_info[floor_ptr->grid_array[y][x].feat];
-            if (f_ptr->flags.has(FF::STORE) && f_ptr->subtype == STORE_BLACK) {
-                prevent_bm = true;
-                break;
-            }
-        }
-    }
-
-    for (i = 0; i < n; i++)
-        if ((stores[i] == STORE_BLACK) && prevent_bm)
-            stores[i] = stores[--n];
 
     if (!n)
         return false;


### PR DESCRIPTION
ダンジョンで地下街が生成された時にブラックマーケットがすでに存在する
場合は2軒目以降のブラックマーケットを生成しないようにする事を意図した
コードが存在するが、誤って f_info のインデックスと地形特性フラグを
比較しているため機能していない。
正しく f_info[].flags の内容をチェックするようにする。

なお、生成する部屋を選択するところで地下街が選択された場合は2つ目
以降の地下街の生成自体が抑制されるため、修正しても現状ではこの
コードが機能することはない。

軽微なので Issue なし。 #1385 の作業中に発見。コミットメッセージの通り、地下街が2つ以上生成される事が無いので現状は実質死に体のコードではあるが、バグはバグなので直しておく。
ちなみにログを確認したところ、地下街が導入された時点からすでにバグっていた模様。