### PR TITLE
アイテム破損関数のクラス化

### DIFF
--- a/src/effect/effect-item.cpp
+++ b/src/effect/effect-item.cpp
@@ -72,7 +72,7 @@ bool affect_item(player_type *caster_ptr, MONSTER_IDX who, POSITION r, POSITION 
         bool is_artifact = object_is_artifact(o_ptr);
         switch (typ) {
         case GF_ACID: {
-            if (hates_acid(o_ptr)) {
+            if (BreakerAcid().hates(o_ptr)) {
                 do_kill = true;
                 note_kill = _("融けてしまった！", (plural ? " melt!" : " melts!"));
                 if (has_flag(flags, TR_IGNORE_ACID))
@@ -82,7 +82,7 @@ bool affect_item(player_type *caster_ptr, MONSTER_IDX who, POSITION r, POSITION 
             break;
         }
         case GF_ELEC: {
-            if (hates_elec(o_ptr)) {
+            if (BreakerElec().hates(o_ptr)) {
                 do_kill = true;
                 note_kill = _("壊れてしまった！", (plural ? " are destroyed!" : " is destroyed!"));
                 if (has_flag(flags, TR_IGNORE_ELEC))
@@ -92,7 +92,7 @@ bool affect_item(player_type *caster_ptr, MONSTER_IDX who, POSITION r, POSITION 
             break;
         }
         case GF_FIRE: {
-            if (hates_fire(o_ptr)) {
+            if (BreakerFire().hates(o_ptr)) {
                 do_kill = true;
                 note_kill = _("燃えてしまった！", (plural ? " burn up!" : " burns up!"));
                 if (has_flag(flags, TR_IGNORE_FIRE))
@@ -102,7 +102,7 @@ bool affect_item(player_type *caster_ptr, MONSTER_IDX who, POSITION r, POSITION 
             break;
         }
         case GF_COLD: {
-            if (hates_cold(o_ptr)) {
+            if (BreakerCold().hates(o_ptr)) {
                 note_kill = _("砕け散ってしまった！", (plural ? " shatter!" : " shatters!"));
                 do_kill = true;
                 if (has_flag(flags, TR_IGNORE_COLD))
@@ -112,14 +112,14 @@ bool affect_item(player_type *caster_ptr, MONSTER_IDX who, POSITION r, POSITION 
             break;
         }
         case GF_PLASMA: {
-            if (hates_fire(o_ptr)) {
+            if (BreakerFire().hates(o_ptr)) {
                 do_kill = true;
                 note_kill = _("燃えてしまった！", (plural ? " burn up!" : " burns up!"));
                 if (has_flag(flags, TR_IGNORE_FIRE))
                     ignore = true;
             }
 
-            if (hates_elec(o_ptr)) {
+            if (BreakerElec().hates(o_ptr)) {
                 ignore = false;
                 do_kill = true;
                 note_kill = _("壊れてしまった！", (plural ? " are destroyed!" : " is destroyed!"));
@@ -130,14 +130,14 @@ bool affect_item(player_type *caster_ptr, MONSTER_IDX who, POSITION r, POSITION 
             break;
         }
         case GF_METEOR: {
-            if (hates_fire(o_ptr)) {
+            if (BreakerFire().hates(o_ptr)) {
                 do_kill = true;
                 note_kill = _("燃えてしまった！", (plural ? " burn up!" : " burns up!"));
                 if (has_flag(flags, TR_IGNORE_FIRE))
                     ignore = true;
             }
 
-            if (hates_cold(o_ptr)) {
+            if (BreakerCold().hates(o_ptr)) {
                 ignore = false;
                 do_kill = true;
                 note_kill = _("砕け散ってしまった！", (plural ? " shatter!" : " shatters!"));
@@ -151,7 +151,7 @@ bool affect_item(player_type *caster_ptr, MONSTER_IDX who, POSITION r, POSITION 
         case GF_SHARDS:
         case GF_FORCE:
         case GF_SOUND: {
-            if (hates_cold(o_ptr)) {
+            if (BreakerCold().hates(o_ptr)) {
                 note_kill = _("砕け散ってしまった！", (plural ? " shatter!" : " shatters!"));
                 do_kill = true;
             }

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -84,7 +84,7 @@ void effect_player_nuke(player_type *target_ptr, effect_player_type *ep_ptr)
     }
 
     if (one_in_(6))
-        inventory_damage(target_ptr, set_acid_destroy, 2);
+        inventory_damage(target_ptr, BreakerAcid(), 2);
 }
 
 void effect_player_missile(player_type *target_ptr, effect_player_type *ep_ptr)
@@ -146,7 +146,7 @@ void effect_player_plasma(player_type *target_ptr, effect_player_type *ep_ptr)
     }
 
     if (!(has_resist_fire(target_ptr) || is_oppose_fire(target_ptr) || has_immune_fire(target_ptr)))
-        inventory_damage(target_ptr, set_acid_destroy, 3);
+        inventory_damage(target_ptr, BreakerAcid(), 3);
 }
 
 /*!
@@ -210,7 +210,7 @@ void effect_player_water(player_type *target_ptr, effect_player_type *ep_ptr)
         }
 
         if (one_in_(5) && !has_res_water) {
-            inventory_damage(target_ptr, set_cold_destroy, 3);
+            inventory_damage(target_ptr, BreakerCold(), 3);
         }
     }
 
@@ -244,8 +244,8 @@ void effect_player_chaos(player_type *target_ptr, effect_player_type *ep_ptr)
     }
 
     if (!has_resist_chaos(target_ptr) || one_in_(9)) {
-        inventory_damage(target_ptr, set_elec_destroy, 2);
-        inventory_damage(target_ptr, set_fire_destroy, 2);
+        inventory_damage(target_ptr, BreakerElec(), 2);
+        inventory_damage(target_ptr, BreakerFire(), 2);
     }
 
     ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
@@ -263,7 +263,7 @@ void effect_player_shards(player_type *target_ptr, effect_player_type *ep_ptr)
     }
 
     if (!has_resist_shard(target_ptr) || one_in_(13))
-        inventory_damage(target_ptr, set_cold_destroy, 2);
+        inventory_damage(target_ptr, BreakerCold(), 2);
 
     ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
@@ -281,7 +281,7 @@ void effect_player_sound(player_type *target_ptr, effect_player_type *ep_ptr)
     }
 
     if (!has_resist_sound(target_ptr) || one_in_(13))
-        inventory_damage(target_ptr, set_cold_destroy, 2);
+        inventory_damage(target_ptr, BreakerCold(), 2);
 
     ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
@@ -354,7 +354,7 @@ void effect_player_rocket(player_type *target_ptr, effect_player_type *ep_ptr)
     }
 
     if (!has_resist_shard(target_ptr) || one_in_(12)) {
-        inventory_damage(target_ptr, set_cold_destroy, 3);
+        inventory_damage(target_ptr, BreakerCold(), 3);
     }
 
     ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
@@ -532,7 +532,7 @@ void effect_player_gravity(player_type *target_ptr, effect_player_type *ep_ptr)
     ep_ptr->dam = ep_ptr->dam * calc_gravity_damage_rate(target_ptr, CALC_RAND) / 100;
 
     if (!target_ptr->levitation || one_in_(13)) {
-        inventory_damage(target_ptr, set_cold_destroy, 2);
+        inventory_damage(target_ptr, BreakerCold(), 2);
     }
 
     ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
@@ -579,8 +579,8 @@ void effect_player_meteor(player_type *target_ptr, effect_player_type *ep_ptr)
     ep_ptr->get_damage = take_hit(target_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
     if (!has_resist_shard(target_ptr) || one_in_(13)) {
         if (!has_immune_fire(target_ptr))
-            inventory_damage(target_ptr, set_fire_destroy, 2);
-        inventory_damage(target_ptr, set_cold_destroy, 2);
+            inventory_damage(target_ptr, BreakerFire(), 2);
+        inventory_damage(target_ptr, BreakerCold(), 2);
     }
 }
 
@@ -603,7 +603,7 @@ void effect_player_icee(player_type *target_ptr, effect_player_type *ep_ptr)
 
     if ((!(has_resist_cold(target_ptr) || is_oppose_cold(target_ptr))) || one_in_(12)) {
         if (!has_immune_cold(target_ptr))
-            inventory_damage(target_ptr, set_cold_destroy, 3);
+            inventory_damage(target_ptr, BreakerCold(), 3);
     }
 }
 
@@ -639,7 +639,7 @@ void effect_player_void(player_type *target_ptr, effect_player_type *ep_ptr)
     ep_ptr->dam = ep_ptr->dam * calc_void_damage_rate(target_ptr, CALC_RAND) / 100;
 
     if (!target_ptr->levitation || one_in_(13)) {
-        inventory_damage(target_ptr, set_cold_destroy, 2);
+        inventory_damage(target_ptr, BreakerCold(), 2);
     }
 }
 

--- a/src/inventory/inventory-damage.cpp
+++ b/src/inventory/inventory-damage.cpp
@@ -16,7 +16,7 @@
 #include "view/display-messages.h"
 
 /*!
- * @brief アイテムを指定確率で破損させる /
+ * @brief 手持ちのアイテムを指定確率で破損させる /
  * Destroys a type of item on a given percent chance
  * @param player_ptr プレーヤーへの参照ポインタ
  * @param typ 破損判定関数ポインタ
@@ -26,7 +26,7 @@
  * Destruction taken from "melee.c" code for "stealing".
  * New-style wands and rods handled correctly. -LM-
  */
-void inventory_damage(player_type *player_ptr, inven_func typ, int perc)
+void inventory_damage(player_type *player_ptr, const ObjectBreaker& breaker, int perc)
 {
     INVENTORY_IDX i;
     int j, amt;
@@ -47,7 +47,7 @@ void inventory_damage(player_type *player_ptr, inven_func typ, int perc)
             continue;
 
         /* Give this item slot a shot at death */
-        if (!(*typ)(o_ptr))
+        if (!breaker.can_destroy(o_ptr))
             continue;
 
         /* Count the casualties */

--- a/src/inventory/inventory-damage.h
+++ b/src/inventory/inventory-damage.h
@@ -1,10 +1,11 @@
 ﻿#pragma once
 
+#include "object/object-broken.h"
+
 /*
  * This seems like a pretty standard "typedef"
  */
 typedef struct object_type object_type;
 typedef struct player_type player_type;
-typedef int (*inven_func)(object_type *);
 
-void inventory_damage(player_type *creature_ptr, inven_func typ, int perc);
+void inventory_damage(player_type *creature_ptr, const ObjectBreaker& breaker, int perc);

--- a/src/object/object-broken.cpp
+++ b/src/object/object-broken.cpp
@@ -50,7 +50,7 @@ BreakerCold::BreakerCold()
  * Does a given class of objects (usually) hate acid?
  * Note that acid can either melt or corrode something.
  */
-bool BreakerAcid::hates(object_type *o_ptr)
+bool BreakerAcid::hates(object_type *o_ptr) const
 {
     /* Analyze the type */
     switch (o_ptr->tval) {
@@ -104,7 +104,7 @@ bool BreakerAcid::hates(object_type *o_ptr)
  * @param o_ptr アイテムの情報参照ポインタ
  * @return 破損するならばTRUEを返す
  */
-bool BreakerElec::hates(object_type *o_ptr)
+bool BreakerElec::hates(object_type *o_ptr) const
 {
     switch (o_ptr->tval) {
     case TV_RING:
@@ -128,7 +128,7 @@ bool BreakerElec::hates(object_type *o_ptr)
  * Hafted/Polearm weapons have wooden shafts.
  * Arrows/Bows are mostly wooden.
  */
-bool BreakerFire::hates(object_type *o_ptr)
+bool BreakerFire::hates(object_type *o_ptr) const
 {
     /* Analyze the type */
     switch (o_ptr->tval) {
@@ -186,7 +186,7 @@ bool BreakerFire::hates(object_type *o_ptr)
  * @param o_ptr アイテムの情報参照ポインタ
  * @return 破損するならばTRUEを返す
  */
-bool BreakerCold::hates(object_type *o_ptr)
+bool BreakerCold::hates(object_type *o_ptr) const
 {
     switch (o_ptr->tval) {
     case TV_POTION:
@@ -209,7 +209,7 @@ bool BreakerCold::hates(object_type *o_ptr)
  * @return 破損するならばTRUEを返す
  * @todo 統合を検討
  */
-int ObjectBreaker::set_destroy(object_type *o_ptr)
+int ObjectBreaker::can_destroy(object_type *o_ptr) const
 {
     TrFlags flgs;
     if (!this->hates(o_ptr))

--- a/src/object/object-broken.cpp
+++ b/src/object/object-broken.cpp
@@ -16,6 +16,26 @@
 #include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 
+ObjectBreaker::ObjectBreaker(tr_type ignore_flg)
+    : ignore_flg(ignore_flg)
+{}
+
+BreakerAcid::BreakerAcid()
+    : ObjectBreaker(TR_IGNORE_ACID)
+{}
+
+BreakerElec::BreakerElec()
+    : ObjectBreaker(TR_IGNORE_ELEC)
+{}
+
+BreakerFire::BreakerFire()
+    : ObjectBreaker(TR_IGNORE_FIRE)
+{}
+
+BreakerCold::BreakerCold()
+    : ObjectBreaker(TR_IGNORE_COLD)
+{}
+
 /*!
  * @brief アイテムが酸で破損するかどうかを判定する
  * @param o_ptr アイテムの情報参照ポインタ
@@ -25,7 +45,7 @@
  * Does a given class of objects (usually) hate acid?
  * Note that acid can either melt or corrode something.
  */
-bool hates_acid(object_type *o_ptr)
+bool BreakerAcid::hates(object_type *o_ptr)
 {
     /* Analyze the type */
     switch (o_ptr->tval) {
@@ -79,7 +99,7 @@ bool hates_acid(object_type *o_ptr)
  * @param o_ptr アイテムの情報参照ポインタ
  * @return 破損するならばTRUEを返す
  */
-bool hates_elec(object_type *o_ptr)
+bool BreakerElec::hates(object_type *o_ptr)
 {
     switch (o_ptr->tval) {
     case TV_RING:
@@ -103,7 +123,7 @@ bool hates_elec(object_type *o_ptr)
  * Hafted/Polearm weapons have wooden shafts.
  * Arrows/Bows are mostly wooden.
  */
-bool hates_fire(object_type *o_ptr)
+bool BreakerFire::hates(object_type *o_ptr)
 {
     /* Analyze the type */
     switch (o_ptr->tval) {
@@ -161,7 +181,7 @@ bool hates_fire(object_type *o_ptr)
  * @param o_ptr アイテムの情報参照ポインタ
  * @return 破損するならばTRUEを返す
  */
-bool hates_cold(object_type *o_ptr)
+bool BreakerCold::hates(object_type *o_ptr)
 {
     switch (o_ptr->tval) {
     case TV_POTION:
@@ -178,73 +198,19 @@ bool hates_cold(object_type *o_ptr)
 }
 
 /*!
- * @brief アイテムが酸で破損するかどうかを判定する(メインルーチン) /
- * Melt something
+ * @brief アイテムが属性で破損するかどうかを判定する(メインルーチン) /
+ * Destroy things
  * @param o_ptr アイテムの情報参照ポインタ
  * @return 破損するならばTRUEを返す
  * @todo 統合を検討
  */
-int set_acid_destroy(object_type *o_ptr)
+int ObjectBreaker::set_destroy(player_type *owner_ptr, object_type *o_ptr)
 {
     TrFlags flgs;
-    if (!hates_acid(o_ptr))
+    if (!this->hates(o_ptr))
         return false;
-    object_flags(o_ptr, flgs);
-    if (has_flag(flgs, TR_IGNORE_ACID))
-        return false;
-    return true;
-}
-
-/*!
- * @brief アイテムが電撃で破損するかどうかを判定する(メインルーチン) /
- * Electrical damage
- * @param o_ptr アイテムの情報参照ポインタ
- * @return 破損するならばTRUEを返す
- * @todo 統合を検討
- */
-int set_elec_destroy(object_type *o_ptr)
-{
-    TrFlags flgs;
-    if (!hates_elec(o_ptr))
-        return false;
-    object_flags(o_ptr, flgs);
-    if (has_flag(flgs, TR_IGNORE_ELEC))
-        return false;
-    return true;
-}
-
-/*!
- * @brief アイテムが火炎で破損するかどうかを判定する(メインルーチン) /
- * Burn something
- * @param o_ptr アイテムの情報参照ポインタ
- * @return 破損するならばTRUEを返す
- * @todo 統合を検討
- */
-int set_fire_destroy(object_type *o_ptr)
-{
-    TrFlags flgs;
-    if (!hates_fire(o_ptr))
-        return false;
-    object_flags(o_ptr, flgs);
-    if (has_flag(flgs, TR_IGNORE_FIRE))
-        return false;
-    return true;
-}
-
-/*!
- * @brief アイテムが冷気で破損するかどうかを判定する(メインルーチン) /
- * Freeze things
- * @param o_ptr アイテムの情報参照ポインタ
- * @return 破損するならばTRUEを返す
- * @todo 統合を検討
- */
-int set_cold_destroy(object_type *o_ptr)
-{
-    TrFlags flgs;
-    if (!hates_cold(o_ptr))
-        return false;
-    object_flags(o_ptr, flgs);
-    if (has_flag(flgs, TR_IGNORE_COLD))
+    object_flags(owner_ptr, o_ptr, flgs);
+    if (has_flag(flgs, this->ignore_flg))
         return false;
     return true;
 }

--- a/src/object/object-broken.cpp
+++ b/src/object/object-broken.cpp
@@ -209,7 +209,7 @@ bool BreakerCold::hates(object_type *o_ptr) const
  * @return 破損するならばTRUEを返す
  * @todo 統合を検討
  */
-int ObjectBreaker::can_destroy(object_type *o_ptr) const
+bool ObjectBreaker::can_destroy(object_type *o_ptr) const
 {
     TrFlags flgs;
     if (!this->hates(o_ptr))

--- a/src/object/object-broken.cpp
+++ b/src/object/object-broken.cpp
@@ -18,23 +18,28 @@
 
 ObjectBreaker::ObjectBreaker(tr_type ignore_flg)
     : ignore_flg(ignore_flg)
-{}
+{
+}
 
 BreakerAcid::BreakerAcid()
     : ObjectBreaker(TR_IGNORE_ACID)
-{}
+{
+}
 
 BreakerElec::BreakerElec()
     : ObjectBreaker(TR_IGNORE_ELEC)
-{}
+{
+}
 
 BreakerFire::BreakerFire()
     : ObjectBreaker(TR_IGNORE_FIRE)
-{}
+{
+}
 
 BreakerCold::BreakerCold()
     : ObjectBreaker(TR_IGNORE_COLD)
-{}
+{
+}
 
 /*!
  * @brief アイテムが酸で破損するかどうかを判定する
@@ -204,12 +209,12 @@ bool BreakerCold::hates(object_type *o_ptr)
  * @return 破損するならばTRUEを返す
  * @todo 統合を検討
  */
-int ObjectBreaker::set_destroy(player_type *owner_ptr, object_type *o_ptr)
+int ObjectBreaker::set_destroy(object_type *o_ptr)
 {
     TrFlags flgs;
     if (!this->hates(o_ptr))
         return false;
-    object_flags(owner_ptr, o_ptr, flgs);
+    object_flags(o_ptr, flgs);
     if (has_flag(flgs, this->ignore_flg))
         return false;
     return true;

--- a/src/object/object-broken.h
+++ b/src/object/object-broken.h
@@ -10,10 +10,12 @@ bool potion_smash_effect(player_type *owner_ptr, MONSTER_IDX who, POSITION y, PO
 PERCENTAGE breakage_chance(player_type *owner_ptr, object_type *o_ptr, bool has_archer_bonus, SPELL_IDX snipe_type);
 
 class ObjectBreaker {
-public:
+protected:
     ObjectBreaker(tr_type ignore_flg);
     ObjectBreaker() = delete;
     virtual ~ObjectBreaker() = default;
+
+public:
     int set_destroy(object_type *o_ptr);
     virtual bool hates(object_type *o_ptr) = 0;
 

--- a/src/object/object-broken.h
+++ b/src/object/object-broken.h
@@ -16,7 +16,7 @@ protected:
     virtual ~ObjectBreaker() = default;
 
 public:
-    int can_destroy(object_type *o_ptr) const;
+    bool can_destroy(object_type *o_ptr) const;
     virtual bool hates(object_type *o_ptr) const = 0;
 
 private:

--- a/src/object/object-broken.h
+++ b/src/object/object-broken.h
@@ -16,8 +16,8 @@ protected:
     virtual ~ObjectBreaker() = default;
 
 public:
-    int set_destroy(object_type *o_ptr);
-    virtual bool hates(object_type *o_ptr) = 0;
+    int can_destroy(object_type *o_ptr) const;
+    virtual bool hates(object_type *o_ptr) const = 0;
 
 private:
     tr_type ignore_flg;
@@ -27,26 +27,26 @@ class BreakerAcid : public ObjectBreaker {
 public:
     BreakerAcid();
     virtual ~BreakerAcid() = default;
-    bool hates(object_type *o_ptr);
+    bool hates(object_type *o_ptr) const;
 };
 
 class BreakerElec : public ObjectBreaker {
 public:
     BreakerElec();
     virtual ~BreakerElec() = default;
-    bool hates(object_type *o_ptr);
+    bool hates(object_type *o_ptr) const;
 };
 
 class BreakerFire : public ObjectBreaker {
 public:
     BreakerFire();
     virtual ~BreakerFire() = default;
-    bool hates(object_type *o_ptr);
+    bool hates(object_type *o_ptr) const;
 };
 
 class BreakerCold : public ObjectBreaker {
 public:
     BreakerCold();
     virtual ~BreakerCold() = default;
-    bool hates(object_type *o_ptr);
+    bool hates(object_type *o_ptr) const;
 };

--- a/src/object/object-broken.h
+++ b/src/object/object-broken.h
@@ -5,17 +5,6 @@
 
 typedef struct object_type object_type;
 typedef struct player_type player_type;
-<<<<<<< HEAD
-bool hates_acid(object_type *o_ptr);
-bool hates_elec(object_type *o_ptr);
-bool hates_fire(object_type *o_ptr);
-bool hates_cold(object_type *o_ptr);
-int set_acid_destroy(object_type *o_ptr);
-int set_elec_destroy(object_type *o_ptr);
-int set_fire_destroy(object_type *o_ptr);
-int set_cold_destroy(object_type *o_ptr);
-=======
->>>>>>> 25e2ef4b0 ([Refactor]set_****_destroy()が同じ動きなのでクラス化)
 
 bool potion_smash_effect(player_type *owner_ptr, MONSTER_IDX who, POSITION y, POSITION x, KIND_OBJECT_IDX k_idx);
 PERCENTAGE breakage_chance(player_type *owner_ptr, object_type *o_ptr, bool has_archer_bonus, SPELL_IDX snipe_type);
@@ -25,7 +14,7 @@ public:
     ObjectBreaker(tr_type ignore_flg);
     ObjectBreaker() = delete;
     virtual ~ObjectBreaker() = default;
-    int set_destroy(player_type *owner_ptr, object_type *o_ptr);
+    int set_destroy(object_type *o_ptr);
     virtual bool hates(object_type *o_ptr) = 0;
 
 private:

--- a/src/object/object-broken.h
+++ b/src/object/object-broken.h
@@ -1,9 +1,11 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include "object-enchant/tr-types.h"
 
 typedef struct object_type object_type;
 typedef struct player_type player_type;
+<<<<<<< HEAD
 bool hates_acid(object_type *o_ptr);
 bool hates_elec(object_type *o_ptr);
 bool hates_fire(object_type *o_ptr);
@@ -12,6 +14,48 @@ int set_acid_destroy(object_type *o_ptr);
 int set_elec_destroy(object_type *o_ptr);
 int set_fire_destroy(object_type *o_ptr);
 int set_cold_destroy(object_type *o_ptr);
+=======
+>>>>>>> 25e2ef4b0 ([Refactor]set_****_destroy()が同じ動きなのでクラス化)
 
 bool potion_smash_effect(player_type *owner_ptr, MONSTER_IDX who, POSITION y, POSITION x, KIND_OBJECT_IDX k_idx);
 PERCENTAGE breakage_chance(player_type *owner_ptr, object_type *o_ptr, bool has_archer_bonus, SPELL_IDX snipe_type);
+
+class ObjectBreaker {
+public:
+    ObjectBreaker(tr_type ignore_flg);
+    ObjectBreaker() = delete;
+    virtual ~ObjectBreaker() = default;
+    int set_destroy(player_type *owner_ptr, object_type *o_ptr);
+    virtual bool hates(object_type *o_ptr) = 0;
+
+private:
+    tr_type ignore_flg;
+};
+
+class BreakerAcid : public ObjectBreaker {
+public:
+    BreakerAcid();
+    virtual ~BreakerAcid() = default;
+    bool hates(object_type *o_ptr);
+};
+
+class BreakerElec : public ObjectBreaker {
+public:
+    BreakerElec();
+    virtual ~BreakerElec() = default;
+    bool hates(object_type *o_ptr);
+};
+
+class BreakerFire : public ObjectBreaker {
+public:
+    BreakerFire();
+    virtual ~BreakerFire() = default;
+    bool hates(object_type *o_ptr);
+};
+
+class BreakerCold : public ObjectBreaker {
+public:
+    BreakerCold();
+    virtual ~BreakerCold() = default;
+    bool hates(object_type *o_ptr);
+};

--- a/src/object/object-broken.h
+++ b/src/object/object-broken.h
@@ -13,9 +13,9 @@ class ObjectBreaker {
 protected:
     ObjectBreaker(tr_type ignore_flg);
     ObjectBreaker() = delete;
-    virtual ~ObjectBreaker() = default;
 
 public:
+    virtual ~ObjectBreaker() = default;
     bool can_destroy(object_type *o_ptr) const;
     virtual bool hates(object_type *o_ptr) const = 0;
 

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -159,7 +159,7 @@ HIT_POINT acid_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, boo
 
     HIT_POINT get_damage = take_hit(creature_ptr, aura ? DAMAGE_NOESCAPE : DAMAGE_ATTACK, dam, kb_str);
     if (!aura && !(double_resist && has_resist_acid(creature_ptr)))
-        inventory_damage(creature_ptr, set_acid_destroy, inv);
+        inventory_damage(creature_ptr, BreakerAcid(), inv);
 
     return get_damage;
 }
@@ -191,7 +191,7 @@ HIT_POINT elec_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, boo
 
     HIT_POINT get_damage = take_hit(creature_ptr, aura ? DAMAGE_NOESCAPE : DAMAGE_ATTACK, dam, kb_str);
     if (!aura && !(double_resist && has_resist_elec(creature_ptr)))
-        inventory_damage(creature_ptr, set_elec_destroy, inv);
+        inventory_damage(creature_ptr, BreakerElec(), inv);
 
     return get_damage;
 }
@@ -223,7 +223,7 @@ HIT_POINT fire_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, boo
 
     HIT_POINT get_damage = take_hit(creature_ptr, aura ? DAMAGE_NOESCAPE : DAMAGE_ATTACK, dam, kb_str);
     if (!aura && !(double_resist && has_resist_fire(creature_ptr)))
-        inventory_damage(creature_ptr, set_fire_destroy, inv);
+        inventory_damage(creature_ptr, BreakerFire(), inv);
 
     return get_damage;
 }
@@ -253,7 +253,7 @@ HIT_POINT cold_dam(player_type *creature_ptr, HIT_POINT dam, concptr kb_str, boo
 
     HIT_POINT get_damage = take_hit(creature_ptr, aura ? DAMAGE_NOESCAPE : DAMAGE_ATTACK, dam, kb_str);
     if (!aura && !(double_resist && has_resist_cold(creature_ptr)))
-        inventory_damage(creature_ptr, set_cold_destroy, inv);
+        inventory_damage(creature_ptr, BreakerCold(), inv);
 
     return get_damage;
 }


### PR DESCRIPTION
詳細は #1398 参照
アイテム破損関数のポインタを引数に使ってるinventory_damage() もクラスのconst 参照に変えてます