### PR TITLE
もう使われていないプリプロの削除＠h-system.h

### DIFF
--- a/src/main-cap.cpp
+++ b/src/main-cap.cpp
@@ -41,15 +41,11 @@
  * Mega-Hack -- try to guess when "POSIX" is available.
  * If the user defines two of these, we will probably crash.
  */
-#  if defined(_POSIX_VERSION)
-#   define USE_TPOSIX
-#  else
-#   if defined(linux)
-#    define USE_TERMIO
-#   else
-#    define USE_TCHARS
-#   endif
-#  endif
+#ifdef _POSIX_VERSION
+  #define USE_TPOSIX
+#else
+  #define USE_TCHARS
+#endif
 
 /*
  * POSIX stuff

--- a/src/main-gcu.cpp
+++ b/src/main-gcu.cpp
@@ -207,11 +207,7 @@ static term_data data[MAX_TERM_DATA];
 #if defined(_POSIX_VERSION)
 #define USE_TPOSIX
 #else
-#if defined(linux)
-#define USE_TERMIO
-#else
 #define USE_TCHARS
-#endif
 #endif
 #endif
 

--- a/src/system/h-system.h
+++ b/src/system/h-system.h
@@ -19,49 +19,48 @@
 #ifndef INCLUDED_H_SYSTEM_H
 #define INCLUDED_H_SYSTEM_H
 
-#include <stdio.h>
 #include <ctype.h>
-#include <wctype.h>
 #include <errno.h>
 #include <stddef.h>
-# include <stdlib.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <wctype.h>
 
 #ifdef SET_UID
 
-# include <sys/types.h>
+#include <sys/types.h>
 
-# if defined(Pyramid) || defined(NCR3K) || defined(ibm032) || \
-     defined(__osf__) || defined(ISC) || defined(linux)
-#  include <sys/time.h>
-# endif
+#if defined(Pyramid) || defined(NCR3K) || defined(ibm032) || defined(__osf__) || defined(ISC) || defined(linux)
+#include <sys/time.h>
+#endif
 
-#  include <sys/timeb.h>
+#include <sys/timeb.h>
 
 #endif /* SET_UID */
 
 #include <time.h>
 
 #if defined(WINDOWS)
-# include <io.h>
+#include <io.h>
 #endif
 
 #if !defined(VM)
-# if defined(__TURBOC__) || defined(__WATCOMC__)
-#  include <mem.h>
-# else
-#  include <memory.h>
-# endif
+#if defined(__TURBOC__) || defined(__WATCOMC__)
+#include <mem.h>
+#else
+#include <memory.h>
+#endif
 #endif
 
 #include <fcntl.h>
 
 #ifdef SET_UID
 
-#include <sys/param.h>
-#include <sys/file.h>
 #include <pwd.h>
-#include <unistd.h>
+#include <sys/file.h>
+#include <sys/param.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 #endif /* SET_UID */
 

--- a/src/system/h-system.h
+++ b/src/system/h-system.h
@@ -33,7 +33,7 @@
 #include <sys/timeb.h>
 #include <sys/types.h>
 #include <unistd.h>
-#if defined(Pyramid) || defined(NCR3K) || defined(ibm032) || defined(__osf__) || defined(ISC) || defined(linux)
+#ifdef linux
 #include <sys/time.h>
 #endif
-#endif /* SET_UID */
+#endif

--- a/src/system/h-system.h
+++ b/src/system/h-system.h
@@ -34,9 +34,6 @@
     #include <sys/timeb.h>
     #include <sys/types.h>
     #include <unistd.h>
-    #ifdef linux
-      #include <sys/time.h>
-    #endif
   #endif
 #endif
 

--- a/src/system/h-system.h
+++ b/src/system/h-system.h
@@ -21,19 +21,23 @@
 #include <time.h>
 #include <wctype.h>
 
+// clang-format off
+
 #ifdef WINDOWS
-#include <io.h>
+  #include <io.h>
+#else
+  #ifdef SET_UID
+    #include <pwd.h>
+    #include <sys/file.h>
+    #include <sys/param.h>
+    #include <sys/stat.h>
+    #include <sys/timeb.h>
+    #include <sys/types.h>
+    #include <unistd.h>
+    #ifdef linux
+      #include <sys/time.h>
+    #endif
+  #endif
 #endif
 
-#ifdef SET_UID
-#include <pwd.h>
-#include <sys/file.h>
-#include <sys/param.h>
-#include <sys/stat.h>
-#include <sys/timeb.h>
-#include <sys/types.h>
-#include <unistd.h>
-#ifdef linux
-#include <sys/time.h>
-#endif
-#endif
+// clang-format on

--- a/src/system/h-system.h
+++ b/src/system/h-system.h
@@ -16,49 +16,33 @@
  * because VMS does not use the "ASCII" character set.
  */
 
-#ifndef INCLUDED_H_SYSTEM_H
-#define INCLUDED_H_SYSTEM_H
+#pragma once
 
 #include <ctype.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <memory.h>
+#include <stdarg.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <time.h>
 #include <wctype.h>
 
-#ifdef SET_UID
-
-#include <sys/types.h>
-
-#if defined(Pyramid) || defined(NCR3K) || defined(ibm032) || defined(__osf__) || defined(ISC) || defined(linux)
-#include <sys/time.h>
-#endif
-
-#include <sys/timeb.h>
-
-#endif /* SET_UID */
-
-#include <time.h>
-
-#if defined(WINDOWS)
+#ifdef WINDOWS
 #include <io.h>
 #endif
 
-#include <memory.h>
-#include <fcntl.h>
-
 #ifdef SET_UID
-
 #include <pwd.h>
 #include <sys/file.h>
 #include <sys/param.h>
 #include <sys/stat.h>
+#include <sys/timeb.h>
+#include <sys/types.h>
 #include <unistd.h>
-
+#if defined(Pyramid) || defined(NCR3K) || defined(ibm032) || defined(__osf__) || defined(ISC) || defined(linux)
+#include <sys/time.h>
+#endif
 #endif /* SET_UID */
-
-#include <string.h>
-
-#include <stdarg.h>
-
-#endif /* INCLUDED_H_SYSTEM_H */

--- a/src/system/h-system.h
+++ b/src/system/h-system.h
@@ -44,14 +44,7 @@
 #include <io.h>
 #endif
 
-#if !defined(VM)
-#if defined(__TURBOC__) || defined(__WATCOMC__)
-#include <mem.h>
-#else
 #include <memory.h>
-#endif
-#endif
-
 #include <fcntl.h>
 
 #ifdef SET_UID

--- a/src/system/h-system.h
+++ b/src/system/h-system.h
@@ -9,16 +9,8 @@
 
 #pragma once
 
-#include <ctype.h>
-#include <errno.h>
 #include <fcntl.h>
-#include <memory.h>
 #include <stdarg.h>
-#include <stddef.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <time.h>
 #include <wctype.h>
 
 // clang-format off
@@ -26,6 +18,14 @@
 #ifdef WINDOWS
   #include <io.h>
 #else
+  #include <ctype.h>
+  #include <errno.h>
+  #include <memory.h>
+  #include <stddef.h>
+  #include <stdio.h>
+  #include <stdlib.h>
+  #include <string.h>
+  #include <time.h>
   #ifdef SET_UID
     #include <pwd.h>
     #include <sys/file.h>

--- a/src/system/h-system.h
+++ b/src/system/h-system.h
@@ -1,19 +1,10 @@
 ﻿/*!
  * @file h-system.h
  * @brief 変愚蛮怒用システムヘッダーファイル /
- * The most basic "include" file. This file simply includes other low level header files.
- * @date 2014/08/16
- * @author
- * 不明(変愚蛮怒スタッフ？)
- * @details
- * Include the basic "system" files.
- * Make sure all "system" constants/macros are defined.
- * Make sure all "system" functions have "extern" declarations.
- * This file is a big hack to make other files less of a hack.
- * This file has been rebuilt -- it may need a little more work.
- *
- * It is (very) unlikely that VMS will work without help, primarily
- * because VMS does not use the "ASCII" character set.
+ * The most basic "include" file.
+ * This file simply includes other low level header files.
+ * @date 2021/08/26
+ * @author Hourier
  */
 
 #pragma once


### PR DESCRIPTION
Turbo CやWatcom Cはもうサポート外なので削除しました
ご確認下さい
なお以下は放置中です、見たところlinux以外は不要な気もしますがハッキリしなかったのでそのままです
不要だと分かる方はコメントもらえると助かります
```
#if defined(Pyramid) || defined(NCR3K) || defined(ibm032) || defined(__osf__) || defined(ISC) || defined(linux)
```