### PR TITLE
[Fix] #1426 サブウィンドウのアイテム欄の記号が表示されない

### DIFF
--- a/src/core/window-redrawer.cpp
+++ b/src/core/window-redrawer.cpp
@@ -8,6 +8,7 @@
 #include "core/stuff-handler.h"
 #include "floor/floor-util.h"
 #include "game-option/option-flags.h"
+#include "object/item-tester-hooker.h"
 #include "player/player-race.h"
 #include "system/player-type-definition.h"
 #include "term/gameterm.h"
@@ -235,12 +236,12 @@ void window_stuff(player_type *player_ptr)
 
     if (window_flags & (PW_INVEN)) {
         player_ptr->window_flags &= ~(PW_INVEN);
-        fix_inventory(player_ptr, TV_NONE); // TODO:2.2.2 まともなtval参照手段を確保
+        fix_inventory(player_ptr, AllMatchItemTester());
     }
 
     if (window_flags & (PW_EQUIP)) {
         player_ptr->window_flags &= ~(PW_EQUIP);
-        fix_equip(player_ptr, TV_NONE); // TODO:2.2.2 まともなtval参照手段を確保
+        fix_equip(player_ptr, AllMatchItemTester());
     }
 
     if (window_flags & (PW_SPELL)) {

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -52,7 +52,7 @@
  * @brief サブウィンドウに所持品一覧を表示する / Hack -- display inventory in sub-windows
  * @param player_ptr プレーヤーへの参照ポインタ
  */
-void fix_inventory(player_type *player_ptr, tval_type item_tester_tval)
+void fix_inventory(player_type *player_ptr, const ItemTester &item_tester)
 {
     for (int j = 0; j < 8; j++) {
         term_type *old = Term;
@@ -63,7 +63,7 @@ void fix_inventory(player_type *player_ptr, tval_type item_tester_tval)
             continue;
 
         term_activate(angband_term[j]);
-        display_inventory(player_ptr, TvalItemTester(item_tester_tval));
+        display_inventory(player_ptr, item_tester);
         term_fresh();
         term_activate(old);
     }
@@ -291,7 +291,7 @@ static void display_equipment(player_type *owner_ptr, const ItemTester& item_tes
  * Hack -- display equipment in sub-windows
  * @param player_ptr プレーヤーへの参照ポインタ
  */
-void fix_equip(player_type *player_ptr, tval_type item_tester_tval)
+void fix_equip(player_type *player_ptr, const ItemTester &item_tester)
 {
     for (int j = 0; j < 8; j++) {
         term_type *old = Term;
@@ -301,7 +301,7 @@ void fix_equip(player_type *player_ptr, tval_type item_tester_tval)
             continue;
 
         term_activate(angband_term[j]);
-        display_equipment(player_ptr, TvalItemTester(item_tester_tval));
+        display_equipment(player_ptr, item_tester);
         term_fresh();
         term_activate(old);
     }

--- a/src/window/display-sub-windows.h
+++ b/src/window/display-sub-windows.h
@@ -1,16 +1,16 @@
 ﻿#pragma once
 
 #include "system/angband.h"
-#include "object/tval-types.h"
 
 #include <vector>
 
 typedef struct floor_type floor_type;
 typedef struct player_type player_type;
-void fix_inventory(player_type *player_ptr, tval_type item_tester_tval);
+class ItemTester;
+void fix_inventory(player_type *player_ptr, const ItemTester &item_tester);
 void print_monster_list(floor_type *floor_ptr, const std::vector<MONSTER_IDX> &monster_list, TERM_LEN x, TERM_LEN y, TERM_LEN max_lines);
 void fix_monster_list(player_type *player_ptr);
-void fix_equip(player_type *player_ptr, tval_type item_tester_tval);
+void fix_equip(player_type *player_ptr, const ItemTester &item_tester);
 void fix_player(player_type *player_ptr);
 void fix_message(void);
 void fix_overhead(player_type *player_ptr);


### PR DESCRIPTION
サブウィンドウにアイテムや装備の一覧を表示する関数 fix_\* を
リファクタリング時に TvalItemTester を使用するように修正したが、
第2引数は現状 TV_NONE で呼び出されておりこれはリファクタリング
前の仕様ではすべてのアイテムにマッチするというものだった。

そもそも第2引数が TV_NONE 固定なのに用意された経緯は不明だが、
とりあえずこれらの関数では ItemTester を受け取るように修正し、
呼び出し側は ItemTester に AllMatchItemTester を設定してリファクタ
リング以前の仕様に従うようにする。