### PR TITLE
サブウィンドウでのアイテム選択記号の絞り込みを復活させる

### DIFF
--- a/src/core/window-redrawer.cpp
+++ b/src/core/window-redrawer.cpp
@@ -236,12 +236,12 @@ void window_stuff(player_type *player_ptr)
 
     if (window_flags & (PW_INVEN)) {
         player_ptr->window_flags &= ~(PW_INVEN);
-        fix_inventory(player_ptr, AllMatchItemTester());
+        fix_inventory(player_ptr);
     }
 
     if (window_flags & (PW_EQUIP)) {
         player_ptr->window_flags &= ~(PW_EQUIP);
-        fix_equip(player_ptr, AllMatchItemTester());
+        fix_equip(player_ptr);
     }
 
     if (window_flags & (PW_SPELL)) {

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -41,6 +41,7 @@
 #include "target/projection-path-calculator.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
+#include "window/display-sub-windows.h"
 #include "wizard/wizard-messages.h"
 #include "world/world-object.h"
 #include "world/world.h"
@@ -590,6 +591,8 @@ object_type *choose_object(player_type *owner_ptr, OBJECT_IDX *idx, concptr q, c
 
     if (idx)
         *idx = INVEN_NONE;
+
+    FixItemTesterSetter setter(item_tester);
 
     if (!get_item(owner_ptr, &item, q, s, option, item_tester))
         return NULL;

--- a/src/object/item-tester-hooker.h
+++ b/src/object/item-tester-hooker.h
@@ -3,6 +3,7 @@
 #include "object/tval-types.h"
 
 #include <functional>
+#include <memory>
 
 struct object_type;
 struct player_type;
@@ -14,6 +15,7 @@ class ItemTester {
 public:
     virtual ~ItemTester() = default;
     bool okay(const object_type *o_ptr) const;
+    virtual std::unique_ptr<ItemTester> clone() const = 0;
 
 protected:
     ItemTester() = default;
@@ -29,6 +31,11 @@ class AllMatchItemTester : public ItemTester {
 public:
     AllMatchItemTester() = default;
 
+    virtual std::unique_ptr<ItemTester> clone() const
+    {
+        return std::make_unique<AllMatchItemTester>(*this);
+    }
+
 private:
     virtual bool okay_impl(const object_type *) const
     {
@@ -43,6 +50,11 @@ class TvalItemTester : public ItemTester {
 public:
     explicit TvalItemTester(tval_type tval);
 
+    virtual std::unique_ptr<ItemTester> clone() const
+    {
+        return std::make_unique<TvalItemTester>(*this);
+    }
+
 private:
     virtual bool okay_impl(const object_type *o_ptr) const;
 
@@ -56,6 +68,11 @@ class FuncItemTester : public ItemTester {
 public:
     explicit FuncItemTester(std::function<bool(const object_type *)> test_func);
     explicit FuncItemTester(std::function<bool(player_type *, const object_type *)> test_func, player_type *player_ptr);
+
+    virtual std::unique_ptr<ItemTester> clone() const
+    {
+        return std::make_unique<FuncItemTester>(*this);
+    }
 
 private:
     virtual bool okay_impl(const object_type *o_ptr) const;

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -48,11 +48,24 @@
 #include <sstream>
 #include <string>
 
+/*! サブウィンドウ表示用の ItemTester オブジェクト */
+static std::unique_ptr<ItemTester> fix_item_tester = std::make_unique<AllMatchItemTester>();
+
+FixItemTesterSetter::FixItemTesterSetter(const ItemTester& item_tester)
+{
+    fix_item_tester = item_tester.clone();
+}
+
+FixItemTesterSetter::~FixItemTesterSetter()
+{
+    fix_item_tester = std::make_unique<AllMatchItemTester>();
+}
+
 /*!
  * @brief サブウィンドウに所持品一覧を表示する / Hack -- display inventory in sub-windows
  * @param player_ptr プレーヤーへの参照ポインタ
  */
-void fix_inventory(player_type *player_ptr, const ItemTester &item_tester)
+void fix_inventory(player_type *player_ptr)
 {
     for (int j = 0; j < 8; j++) {
         term_type *old = Term;
@@ -63,7 +76,7 @@ void fix_inventory(player_type *player_ptr, const ItemTester &item_tester)
             continue;
 
         term_activate(angband_term[j]);
-        display_inventory(player_ptr, item_tester);
+        display_inventory(player_ptr, *fix_item_tester);
         term_fresh();
         term_activate(old);
     }
@@ -291,7 +304,7 @@ static void display_equipment(player_type *owner_ptr, const ItemTester& item_tes
  * Hack -- display equipment in sub-windows
  * @param player_ptr プレーヤーへの参照ポインタ
  */
-void fix_equip(player_type *player_ptr, const ItemTester &item_tester)
+void fix_equip(player_type *player_ptr)
 {
     for (int j = 0; j < 8; j++) {
         term_type *old = Term;
@@ -301,7 +314,7 @@ void fix_equip(player_type *player_ptr, const ItemTester &item_tester)
             continue;
 
         term_activate(angband_term[j]);
-        display_equipment(player_ptr, item_tester);
+        display_equipment(player_ptr, *fix_item_tester);
         term_fresh();
         term_activate(old);
     }

--- a/src/window/display-sub-windows.h
+++ b/src/window/display-sub-windows.h
@@ -7,10 +7,10 @@
 typedef struct floor_type floor_type;
 typedef struct player_type player_type;
 class ItemTester;
-void fix_inventory(player_type *player_ptr, const ItemTester &item_tester);
+void fix_inventory(player_type *player_ptr);
 void print_monster_list(floor_type *floor_ptr, const std::vector<MONSTER_IDX> &monster_list, TERM_LEN x, TERM_LEN y, TERM_LEN max_lines);
 void fix_monster_list(player_type *player_ptr);
-void fix_equip(player_type *player_ptr, const ItemTester &item_tester);
+void fix_equip(player_type *player_ptr);
 void fix_player(player_type *player_ptr);
 void fix_message(void);
 void fix_overhead(player_type *player_ptr);
@@ -19,3 +19,24 @@ void fix_monster(player_type *player_ptr);
 void fix_object(player_type *player_ptr);
 void fix_floor_item_list(player_type *player_ptr, const int y, const int x);
 void toggle_inventory_equipment(player_type *owner_ptr);
+
+/*!
+ * @brief サブウィンドウ表示用の ItemTester オブジェクトを設定するクラス
+ *
+ * @details オブジェクトが生存している間コンストラクタで指定した ItemTester オブジェクトにより
+ * アイテム表示が絞り込まれるようになる。
+ * オブジェクトが破棄されるとデストラクタによりサブウィンドウ表示用 ItemTester オブジェクトは
+ * AllMatchItemTester(全てのアイテムを表示)のインスタンスがセットされる。
+ * なお、現状の仕様はアイテム表示の絞り込みとは、アイテムの先頭に表示されるアルファベットの
+ * 選択記号が表示されるか否かの違いであり、アイテムそのものの表示が絞り込まれるわけではない。
+ */
+class FixItemTesterSetter {
+public:
+    explicit FixItemTesterSetter(const ItemTester &item_tester);
+    ~FixItemTesterSetter();
+
+    FixItemTesterSetter(const FixItemTesterSetter &) = delete;
+    FixItemTesterSetter &operator=(const FixItemTesterSetter &) = delete;
+    FixItemTesterSetter(FixItemTesterSetter &&) = delete;
+    FixItemTesterSetter &operator=(FixItemTesterSetter &&) = delete;
+};


### PR DESCRIPTION
ItemTester クラスによるリファクタリングによりアイテム選択記号が絞り込まれなくなっているので、その機能を復活させる。