### PR TITLE
[Refactor] object_flags関数のインターフェースを変更する

### DIFF
--- a/src/artifact/random-art-characteristics.cpp
+++ b/src/artifact/random-art-characteristics.cpp
@@ -146,8 +146,7 @@ void get_random_name(object_type *o_ptr, char *return_name, bool armour, int pow
 /*対邪平均ダメージの計算処理*/
 static HIT_POINT calc_arm_avgdamage(player_type *player_ptr, object_type *o_ptr)
 {
-    TrFlags flgs;
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
     HIT_POINT base, forced, vorpal;
     HIT_POINT s_evil = forced = vorpal = 0;
     HIT_POINT dam = base = (o_ptr->dd * o_ptr->ds + o_ptr->dd) / 2;
@@ -175,8 +174,7 @@ static HIT_POINT calc_arm_avgdamage(player_type *player_ptr, object_type *o_ptr)
 
 bool has_extreme_damage_rate(player_type *player_ptr, object_type *o_ptr)
 {
-    TrFlags flgs;
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
     if (has_flag(flgs, TR_VAMPIRIC)) {
         if (has_flag(flgs, TR_BLOWS) && (o_ptr->pval == 1) && (calc_arm_avgdamage(player_ptr, o_ptr) > 52)) {
             return true;

--- a/src/artifact/random-art-generator.cpp
+++ b/src/artifact/random-art-generator.cpp
@@ -43,8 +43,7 @@ static bool weakening_artifact(object_type *o_ptr)
 {
     KIND_OBJECT_IDX k_idx = lookup_kind(o_ptr->tval, o_ptr->sval);
     object_kind *k_ptr = &k_info[k_idx];
-    TrFlags flgs;
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
 
     if (has_flag(flgs, TR_KILL_EVIL)) {
         remove_flag(o_ptr->art_flags, TR_KILL_EVIL);

--- a/src/cmd-item/cmd-refill.cpp
+++ b/src/cmd-item/cmd-refill.cpp
@@ -35,12 +35,11 @@ static void do_cmd_refill_lamp(player_type *user_ptr)
     if (!o_ptr)
         return;
 
-    TrFlags flgs, flgs2;
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
 
     PlayerEnergy(user_ptr).set_player_turn_energy(50);
     j_ptr = &user_ptr->inventory_list[INVEN_LITE];
-    object_flags(j_ptr, flgs2);
+    auto flgs2 = object_flags(j_ptr);
     j_ptr->xtra4 += o_ptr->xtra4;
     msg_print(_("ランプに油を注いだ。", "You fuel your lamp."));
     if (has_flag(flgs, TR_DARK_SOURCE) && (j_ptr->xtra4 > 0)) {
@@ -73,12 +72,11 @@ static void do_cmd_refill_torch(player_type *user_ptr)
     if (!o_ptr)
         return;
 
-    TrFlags flgs, flgs2;
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
 
     PlayerEnergy(user_ptr).set_player_turn_energy(50);
     j_ptr = &user_ptr->inventory_list[INVEN_LITE];
-    object_flags(j_ptr, flgs2);
+    auto flgs2 = object_flags(j_ptr);
     j_ptr->xtra4 += o_ptr->xtra4 + 5;
     msg_print(_("松明を結合した。", "You combine the torches."));
     if (has_flag(flgs, TR_DARK_SOURCE) && (j_ptr->xtra4 > 0)) {

--- a/src/cmd-item/cmd-smith.cpp
+++ b/src/cmd-item/cmd-smith.cpp
@@ -233,7 +233,6 @@ static void drain_essence(player_type *creature_ptr)
     bool observe = false;
     int old_ds, old_dd, old_to_h, old_to_d, old_ac, old_to_a, old_pval, old_name2;
     TIME_EFFECT old_timeout;
-    TrFlags old_flgs, new_flgs;
     object_type *o_ptr;
     concptr q, s;
     POSITION iy, ix;
@@ -259,7 +258,7 @@ static void drain_essence(player_type *creature_ptr)
 
     PlayerEnergy(creature_ptr).set_player_turn_energy(100);
 
-    object_flags(o_ptr, old_flgs);
+    auto old_flgs = object_flags(o_ptr);
     if (has_flag(old_flgs, TR_KILL_DRAGON))
         add_flag(old_flgs, TR_SLAY_DRAGON);
     if (has_flag(old_flgs, TR_KILL_ANIMAL))
@@ -344,7 +343,7 @@ static void drain_essence(player_type *creature_ptr)
     object_aware(creature_ptr, o_ptr);
     object_known(o_ptr);
 
-    object_flags(o_ptr, new_flgs);
+    auto new_flgs = object_flags(o_ptr);
 
     for (i = 0; essence_info[i].add_name; i++) {
         essence_type *es_ptr = &essence_info[i];
@@ -994,7 +993,6 @@ static void erase_essence(player_type *creature_ptr)
     concptr q, s;
     object_type *o_ptr;
     GAME_TEXT o_name[MAX_NLEN];
-    TrFlags flgs;
 
     q = _("どのアイテムのエッセンスを消去しますか？", "Remove from which item? ");
     s = _("エッセンスを付加したアイテムがありません。", "You have nothing with added essence to remove.");
@@ -1019,7 +1017,7 @@ static void erase_essence(player_type *creature_ptr)
             o_ptr->to_d = 0;
     }
     o_ptr->xtra3 = 0;
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
     if (!(has_pval_flags(flgs)))
         o_ptr->pval = 0;
     msg_print(_("エッセンスを取り去った。", "You removed all essence you have added."));

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -85,9 +85,9 @@ static MULTIPLY calc_shot_damage_with_slay(
 
     monster_race *race_ptr = &r_info[monster_ptr->r_idx];
 
-    TrFlags flags, bow_flags, arrow_flags;
-    object_flags(arrow_ptr, arrow_flags);
-    object_flags(bow_ptr, bow_flags);
+    TrFlags flags{};
+    auto arrow_flags = object_flags(arrow_ptr);
+    auto bow_flags = object_flags(bow_ptr);
 
     for (int i = 0; i < TR_FLAG_SIZE; i++)
         flags[i] = bow_flags[i] | arrow_flags[i];

--- a/src/combat/slaying.cpp
+++ b/src/combat/slaying.cpp
@@ -150,8 +150,7 @@ MULTIPLY mult_brand(player_type *player_ptr, MULTIPLY mult, const TrFlags &flgs,
  */
 HIT_POINT calc_attack_damage_with_slay(player_type *attacker_ptr, object_type *o_ptr, HIT_POINT tdam, monster_type *m_ptr, combat_options mode, bool thrown)
 {
-    TrFlags flgs;
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
     torch_flags(o_ptr, flgs); /* torches has secret flags */
 
     if (!thrown) {

--- a/src/effect/effect-item.cpp
+++ b/src/effect/effect-item.cpp
@@ -67,8 +67,7 @@ bool affect_item(player_type *caster_ptr, MONSTER_IDX who, POSITION r, POSITION 
 #else
         bool plural = (o_ptr->number > 1);
 #endif
-        TrFlags flags;
-        object_flags(o_ptr, flags);
+        auto flags = object_flags(o_ptr);
         bool is_artifact = o_ptr->is_artifact();
         switch (typ) {
         case GF_ACID: {

--- a/src/flavor/flavor-describer.cpp
+++ b/src/flavor/flavor-describer.cpp
@@ -148,8 +148,7 @@ static void describe_bow(player_type *player_ptr, flavor_type *flavor_ptr)
     if (!(flavor_ptr->mode & OD_DEBUG)) {
         num_fire = calc_num_fire(player_ptr, flavor_ptr->o_ptr);
     } else {
-        TrFlags flgs;
-        object_flags(flavor_ptr->o_ptr, flgs);
+        auto flgs = object_flags(flavor_ptr->o_ptr);
         if (has_flag(flgs, TR_XTRA_SHOTS))
             num_fire += 100;
     }

--- a/src/flavor/flavor-util.cpp
+++ b/src/flavor/flavor-util.cpp
@@ -182,8 +182,7 @@ static bool has_flag_of(std::vector<flag_insc_table> &fi_vec, const TrFlags &flg
 char *get_ability_abbreviation(char *short_flavor, object_type *o_ptr, bool kanji, bool all)
 {
     char *prev_ptr = short_flavor;
-    TrFlags flgs;
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
     if (!all) {
         object_kind *k_ptr = &k_info[o_ptr->k_idx];
         for (int j = 0; j < TR_FLAG_SIZE; j++)

--- a/src/flavor/named-item-describer.cpp
+++ b/src/flavor/named-item-describer.cpp
@@ -25,7 +25,7 @@
 
 static void check_object_known_aware(flavor_type *flavor_ptr)
 {
-    object_flags(flavor_ptr->o_ptr, flavor_ptr->tr_flags);
+    flavor_ptr->tr_flags = object_flags(flavor_ptr->o_ptr);
     if (flavor_ptr->o_ptr->is_aware())
         flavor_ptr->aware = true;
 

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -141,8 +141,7 @@ void process_player_hp_mp(player_type *creature_ptr)
 
         object_type *o_ptr;
         o_ptr = &creature_ptr->inventory_list[INVEN_LITE];
-        TrFlags flgs;
-        object_flags(o_ptr, flgs);
+        auto flgs = object_flags(o_ptr);
 
         if (creature_ptr->inventory_list[INVEN_LITE].tval && !has_flag(flgs, TR_DARK_SOURCE) && !has_resist_lite(creature_ptr)) {
             GAME_TEXT o_name[MAX_NLEN];

--- a/src/info-reader/info-reader-util.h
+++ b/src/info-reader/info-reader-util.h
@@ -41,6 +41,23 @@ bool info_grab_one_flag(uint32_t &flags, const std::unordered_map<sview, T> &nam
  * @return 見つけたらtrue
  */
 template <typename T>
+bool info_grab_one_flag(TrFlags &flags, const std::unordered_map<sview, T> &names, sview what)
+{
+    if (auto it = names.find(what); it != names.end()) {
+        add_flag(flags, it->second);
+        return true;
+    }
+    return false;
+}
+
+/*!
+ * @brief infoフラグ文字列をフラグビットに変換する
+ * @param flags ビットフラグ配列
+ * @param names フラグ文字列変換表
+ * @param what フラグ文字列
+ * @return 見つけたらtrue
+ */
+template <typename T>
 bool info_grab_one_flag(uint32_t *flags, const std::unordered_map<sview, T> &names, sview what)
 {
     if (auto it = names.find(what); it != names.end()) {

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -70,8 +70,7 @@ static void choise_cursed_item(TRC flag, object_type *o_ptr, int *choices, int *
         return;
 
     tr_type cf = TR_STR;
-    TrFlags flgs;
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
     switch (flag) {
     case TRC::ADD_L_CURSE:
         cf = TR_ADD_L_CURSE;
@@ -169,12 +168,11 @@ static void curse_teleport(player_type *creature_ptr)
     object_type *o_ptr;
     int i_keep = 0, count = 0;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        TrFlags flgs;
         o_ptr = &creature_ptr->inventory_list[i];
         if (!o_ptr->k_idx)
             continue;
 
-        object_flags(o_ptr, flgs);
+        auto flgs = object_flags(o_ptr);
 
         if (!has_flag(flgs, TR_TELEPORT))
             continue;

--- a/src/knowledge/knowledge-inventory.cpp
+++ b/src/knowledge/knowledge-inventory.cpp
@@ -102,8 +102,7 @@ static bool check_item_knowledge(object_type *o_ptr, tval_type tval)
  */
 static void display_identified_resistances_flag(object_type *o_ptr, FILE *fff)
 {
-    TrFlags flags;
-    object_flags_known(o_ptr, flags);
+    auto flags = object_flags_known(o_ptr);
 
     print_im_or_res_flag(TR_IM_ACID, TR_RES_ACID, flags, fff);
     print_im_or_res_flag(TR_IM_ELEC, TR_RES_ELEC, flags, fff);

--- a/src/load/item-loader.cpp
+++ b/src/load/item-loader.cpp
@@ -235,9 +235,6 @@ void rd_item(object_type *o_ptr)
     if (!h_older_than(2, 1, 2, 4))
         return;
 
-    TrFlags flgs;
-    object_flags(o_ptr, flgs);
-
     if ((o_ptr->name2 == EGO_DARK) || (o_ptr->name2 == EGO_ANCIENT_CURSE) || (o_ptr->name1 == ART_NIGHT)) {
         add_flag(o_ptr->art_flags, TR_LITE_M1);
         remove_flag(o_ptr->art_flags, TR_LITE_1);

--- a/src/market/building-craft-fix.cpp
+++ b/src/market/building-craft-fix.cpp
@@ -38,10 +38,8 @@
  */
 static void give_one_ability_of_object(object_type *to_ptr, object_type *from_ptr)
 {
-    TrFlags to_flgs;
-    TrFlags from_flgs;
-    object_flags(to_ptr, to_flgs);
-    object_flags(from_ptr, from_flgs);
+    auto to_flgs = object_flags(to_ptr);
+    auto from_flgs = object_flags(from_ptr);
 
     int n = 0;
     int cand[TR_FLAG_MAX];

--- a/src/market/building-craft-weapon.cpp
+++ b/src/market/building-craft-weapon.cpp
@@ -118,7 +118,6 @@ static void show_weapon_dmg(int r, int c, int mindice, int maxdice, int blows, i
  */
 static void compare_weapon_aux(player_type *owner_ptr, object_type *o_ptr, int col, int r)
 {
-    TrFlags flgs;
     int blow = owner_ptr->num_blow[0];
     bool force = false;
     bool dokubari = false;
@@ -134,7 +133,7 @@ static void compare_weapon_aux(player_type *owner_ptr, object_type *o_ptr, int c
     int vorpal_div = 1;
     int dmg_bonus = o_ptr->to_d + owner_ptr->to_d[0];
 
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
     if ((o_ptr->tval == TV_SWORD) && (o_ptr->sval == SV_POISON_NEEDLE))
         dokubari = true;
 

--- a/src/mind/mind-priest.cpp
+++ b/src/mind/mind-priest.cpp
@@ -37,8 +37,7 @@ bool bless_weapon(player_type *caster_ptr)
 
     GAME_TEXT o_name[MAX_NLEN];
     describe_flavor(caster_ptr, o_name, o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
-    TrFlags flgs;
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
 
     if (o_ptr->is_cursed()) {
         if ((o_ptr->curse_flags.has(TRC::HEAVY_CURSE) && (randint1(100) < 33)) || has_flag(flgs, TR_ADD_L_CURSE) || has_flag(flgs, TR_ADD_H_CURSE)

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -49,7 +49,7 @@ static samurai_slaying_type *initialize_samurai_slaying_type(
     samurai_slaying_type *samurai_slaying_ptr, MULTIPLY mult, const TrFlags &flags, monster_type *m_ptr, combat_options mode, monster_race *r_ptr)
 {
     samurai_slaying_ptr->mult = mult;
-    std::copy_n(flags, TR_FLAG_SIZE, samurai_slaying_ptr->flags);
+    samurai_slaying_ptr->flags = flags;
     samurai_slaying_ptr->m_ptr = m_ptr;
     samurai_slaying_ptr->mode = mode;
     samurai_slaying_ptr->r_ptr = r_ptr;

--- a/src/monster-floor/monster-object.cpp
+++ b/src/monster-floor/monster-object.cpp
@@ -159,7 +159,6 @@ void update_object_by_monster_movement(player_type *target_ptr, turn_flags *turn
 
     turn_flags_ptr->do_take = (r_ptr->flags2 & RF2_TAKE_ITEM) != 0;
     for (auto it = g_ptr->o_idx_list.begin(); it != g_ptr->o_idx_list.end();) {
-        TrFlags flgs;
         BIT_FLAGS flg2 = 0L, flg3 = 0L, flgr = 0L;
         GAME_TEXT m_name[MAX_NLEN], o_name[MAX_NLEN];
         OBJECT_IDX this_o_idx = *it++;
@@ -171,7 +170,7 @@ void update_object_by_monster_movement(player_type *target_ptr, turn_flags *turn
                 continue;
         }
 
-        object_flags(o_ptr, flgs);
+        auto flgs = object_flags(o_ptr);
         describe_flavor(target_ptr, o_name, o_ptr, 0);
         monster_desc(target_ptr, m_name, m_ptr, MD_INDEF_HIDDEN);
         update_object_flags(flgs, &flg2, &flg3, &flgr);

--- a/src/object-activation/activation-breath.cpp
+++ b/src/object-activation/activation-breath.cpp
@@ -27,8 +27,7 @@ bool activate_dragon_breath(player_type *user_ptr, object_type *o_ptr)
     if (!get_aim_dir(user_ptr, &dir))
         return false;
 
-    TrFlags resistance_flags;
-    object_flags(o_ptr, resistance_flags);
+    auto resistance_flags = object_flags(o_ptr);
 
     int type[20];
     int n = 0;

--- a/src/object-enchant/object-curse.cpp
+++ b/src/object-enchant/object-curse.cpp
@@ -69,8 +69,7 @@ void curse_equipment(player_type *owner_ptr, PERCENTAGE chance, PERCENTAGE heavy
     object_type *o_ptr = &owner_ptr->inventory_list[INVEN_MAIN_HAND + randint0(12)];
     if (!o_ptr->k_idx)
         return;
-    TrFlags oflgs;
-    object_flags(o_ptr, oflgs);
+    auto oflgs = object_flags(o_ptr);
     GAME_TEXT o_name[MAX_NLEN];
     describe_flavor(owner_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
 

--- a/src/object-hook/hook-magic.cpp
+++ b/src/object-hook/hook-magic.cpp
@@ -19,7 +19,6 @@
  */
 bool item_tester_hook_use(player_type *player_ptr, const object_type *o_ptr)
 {
-    TrFlags flags;
     if (o_ptr->tval == player_ptr->tval_ammo)
         return true;
 
@@ -41,7 +40,7 @@ bool item_tester_hook_use(player_type *player_ptr, const object_type *o_ptr)
             return false;
         for (i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
             if (&player_ptr->inventory_list[i] == o_ptr) {
-                object_flags(o_ptr, flags);
+                auto flags = object_flags(o_ptr);
                 if (has_flag(flags, TR_ACTIVATE))
                     return true;
             }

--- a/src/object-hook/hook-weapon.cpp
+++ b/src/object-hook/hook-weapon.cpp
@@ -23,8 +23,7 @@ bool object_is_favorite(player_type *player_ptr, const object_type *o_ptr)
     /* Favorite weapons are varied depend on the class */
     switch (player_ptr->pclass) {
     case CLASS_PRIEST: {
-        TrFlags flgs;
-        object_flags_known(o_ptr, flgs);
+        auto flgs = object_flags_known(o_ptr);
 
         if (!has_flag(flgs, TR_BLESSED) && !(o_ptr->tval == TV_HAFTED))
             return false;
@@ -40,8 +39,7 @@ bool object_is_favorite(player_type *player_ptr, const object_type *o_ptr)
 
     case CLASS_BEASTMASTER:
     case CLASS_CAVALRY: {
-        TrFlags flgs;
-        object_flags_known(o_ptr, flgs);
+        auto flgs = object_flags_known(o_ptr);
 
         /* Is it known to be suitable to using while riding? */
         if (!(has_flag(flgs, TR_RIDING)))

--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -99,7 +99,7 @@ bool ObjectThrowEntity::check_can_throw()
 void ObjectThrowEntity::calc_throw_range()
 {
     this->q_ptr->copy_from(this->o_ptr);
-    object_flags(this->q_ptr, this->obj_flags);
+    this->obj_flags = object_flags(this->q_ptr);
     torch_flags(this->q_ptr, this->obj_flags);
     distribute_charges(this->o_ptr, this->q_ptr, 1);
     this->q_ptr->number = 1;

--- a/src/object/object-broken.cpp
+++ b/src/object/object-broken.cpp
@@ -211,10 +211,9 @@ bool BreakerCold::hates(object_type *o_ptr) const
  */
 bool ObjectBreaker::can_destroy(object_type *o_ptr) const
 {
-    TrFlags flgs;
     if (!this->hates(o_ptr))
         return false;
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
     if (has_flag(flgs, this->ignore_flg))
         return false;
     return true;

--- a/src/object/object-flags.cpp
+++ b/src/object/object-flags.cpp
@@ -94,20 +94,20 @@ TrFlags object_flags(const object_type *o_ptr)
  * @param o_ptr フラグ取得元のオブジェクト構造体ポインタ
  * @param flgs フラグ情報を受け取る配列
  */
-void object_flags_known(const object_type *o_ptr, TrFlags &flgs)
+TrFlags object_flags_known(const object_type *o_ptr)
 {
     bool spoil = false;
     object_kind *k_ptr = &k_info[o_ptr->k_idx];
-    flgs.fill(0U);
+    TrFlags flgs{};
 
     if (!o_ptr->is_aware())
-        return;
+        return flgs;
 
     /* Base object */
     flgs = k_ptr->flags;
 
     if (!o_ptr->is_known())
-        return;
+        return flgs;
 
     if (o_ptr->is_ego()) {
         ego_item_type *e_ptr = &e_info[o_ptr->name2];
@@ -137,7 +137,7 @@ void object_flags_known(const object_type *o_ptr, TrFlags &flgs)
     }
 
     if (!o_ptr->is_smith())
-        return;
+        return flgs;
 
     int add = o_ptr->xtra3 - 1;
     if (add < TR_FLAG_MAX) {
@@ -165,4 +165,6 @@ void object_flags_known(const object_type *o_ptr, TrFlags &flgs)
         add_flag(flgs, TR_RES_FIRE);
         add_flag(flgs, TR_RES_COLD);
     }
+
+    return flgs;
 }

--- a/src/object/object-flags.cpp
+++ b/src/object/object-flags.cpp
@@ -23,15 +23,10 @@ void object_flags(const object_type *o_ptr, TrFlags &flgs)
     object_kind *k_ptr = &k_info[o_ptr->k_idx];
 
     /* Base object */
-    for (int i = 0; i < TR_FLAG_SIZE; i++) {
-        flgs[i] = k_ptr->flags[i];
-    }
+    flgs = k_ptr->flags;
 
     if (o_ptr->is_fixed_artifact()) {
-        artifact_type *a_ptr = &a_info[o_ptr->name1];
-        for (int i = 0; i < TR_FLAG_SIZE; i++) {
-            flgs[i] = a_ptr->flags[i];
-        }
+        flgs = a_info[o_ptr->name1].flags;
     }
 
     if (o_ptr->is_ego()) {
@@ -101,17 +96,13 @@ void object_flags_known(const object_type *o_ptr, TrFlags &flgs)
 {
     bool spoil = false;
     object_kind *k_ptr = &k_info[o_ptr->k_idx];
-    for (int i = 0; i < TR_FLAG_SIZE; i++) {
-        flgs[i] = 0;
-    }
+    flgs.fill(0U);
 
     if (!o_ptr->is_aware())
         return;
 
     /* Base object */
-    for (int i = 0; i < TR_FLAG_SIZE; i++) {
-        flgs[i] = k_ptr->flags[i];
-    }
+    flgs = k_ptr->flags;
 
     if (!o_ptr->is_known())
         return;
@@ -134,11 +125,7 @@ void object_flags_known(const object_type *o_ptr, TrFlags &flgs)
 
     if (spoil || o_ptr->is_fully_known()) {
         if (o_ptr->is_fixed_artifact()) {
-            artifact_type *a_ptr = &a_info[o_ptr->name1];
-
-            for (int i = 0; i < TR_FLAG_SIZE; i++) {
-                flgs[i] = a_ptr->flags[i];
-            }
+            flgs = a_info[o_ptr->name1].flags;
         }
 
         /* Random artifact ! */

--- a/src/object/object-flags.cpp
+++ b/src/object/object-flags.cpp
@@ -18,12 +18,12 @@
  * @param o_ptr フラグ取得元のオブジェクト構造体ポインタ
  * @param flgs フラグ情報を受け取る配列
  */
-void object_flags(const object_type *o_ptr, TrFlags &flgs)
+TrFlags object_flags(const object_type *o_ptr)
 {
     object_kind *k_ptr = &k_info[o_ptr->k_idx];
 
     /* Base object */
-    flgs = k_ptr->flags;
+    auto flgs = k_ptr->flags;
 
     if (o_ptr->is_fixed_artifact()) {
         flgs = a_info[o_ptr->name1].flags;
@@ -84,6 +84,8 @@ void object_flags(const object_type *o_ptr, TrFlags &flgs)
             add_flag(flgs, TR_ACTIVATE);
         }
     }
+
+    return flgs;
 }
 
 /*!

--- a/src/object/object-flags.h
+++ b/src/object/object-flags.h
@@ -4,6 +4,5 @@
 #include "system/system-variables.h"
 
 struct object_type;;
-struct player_type;
 TrFlags object_flags(const object_type *o_ptr);
-void object_flags_known(const object_type *o_ptr, TrFlags &flgs);
+TrFlags object_flags_known(const object_type *o_ptr);

--- a/src/object/object-flags.h
+++ b/src/object/object-flags.h
@@ -5,5 +5,5 @@
 
 struct object_type;;
 struct player_type;
-void object_flags(const object_type *o_ptr, TrFlags &flgs);
+TrFlags object_flags(const object_type *o_ptr);
 void object_flags_known(const object_type *o_ptr, TrFlags &flgs);

--- a/src/object/object-info.cpp
+++ b/src/object/object-info.cpp
@@ -41,10 +41,9 @@
 static concptr item_activation_dragon_breath(object_type *o_ptr)
 {
     static char desc[256];
-    TrFlags flgs; /* for resistance flags */
     int n = 0;
 
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
     strcpy(desc, _("", "breathe "));
 
     for (int i = 0; dragonbreath_info[i].flag != 0; i++) {
@@ -169,8 +168,7 @@ static concptr item_activation_aux(object_type *o_ptr)
  */
 concptr activation_explanation(object_type *o_ptr)
 {
-    TrFlags flgs;
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
     if (!(has_flag(flgs, TR_ACTIVATE)))
         return (_("なし", "nothing"));
 

--- a/src/object/object-stack.cpp
+++ b/src/object/object-stack.cpp
@@ -188,9 +188,8 @@ int object_similar_part(const object_type *o_ptr, const object_type *j_ptr)
     }
     }
 
-    for (int i = 0; i < TR_FLAG_SIZE; i++)
-        if (o_ptr->art_flags[i] != j_ptr->art_flags[i])
-            return 0;
+    if (o_ptr->art_flags != j_ptr->art_flags)
+        return 0;
 
     if (o_ptr->curse_flags != j_ptr->curse_flags)
         return 0;

--- a/src/object/object-value-calc.cpp
+++ b/src/object/object-value-calc.cpp
@@ -23,9 +23,8 @@
 PRICE flag_cost(const object_type *o_ptr, int plusses)
 {
     PRICE total = 0;
-    TrFlags flgs;
     object_kind *k_ptr = &k_info[o_ptr->k_idx];
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
 
     /*
      * Exclude fixed flags of the base item.

--- a/src/object/object-value.cpp
+++ b/src/object/object-value.cpp
@@ -139,14 +139,13 @@ PRICE object_value(const object_type *o_ptr)
  */
 PRICE object_value_real(const object_type *o_ptr)
 {
-    TrFlags flgs;
     object_kind *k_ptr = &k_info[o_ptr->k_idx];
 
     if (!k_info[o_ptr->k_idx].cost)
         return (0L);
 
     PRICE value = k_info[o_ptr->k_idx].cost;
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
     if (o_ptr->is_fixed_artifact()) {
         artifact_type *a_ptr = &a_info[o_ptr->name1];
         if (!a_ptr->cost)

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -58,10 +58,9 @@ object_type *choose_warning_item(player_type *creature_ptr)
     /* Search Inventory */
     int number = 0;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        TrFlags flgs;
         object_type *o_ptr = &creature_ptr->inventory_list[i];
 
-        object_flags(o_ptr, flgs);
+        auto flgs = object_flags(o_ptr);
         if (has_flag(flgs, TR_WARNING)) {
             choices[number] = i;
             number++;

--- a/src/perception/identification.cpp
+++ b/src/perception/identification.cpp
@@ -35,14 +35,13 @@
  */
 bool screen_object(player_type *player_ptr, object_type *o_ptr, BIT_FLAGS mode)
 {
-    TrFlags flgs;
     char temp[70 * 20];
     concptr info[128];
     GAME_TEXT o_name[MAX_NLEN];
     char desc[256];
 
     int trivial_info = 0;
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
 
     shape_buffer(o_ptr->name1 ? a_info[o_ptr->name1].text.c_str() : k_info[o_ptr->k_idx].text.c_str(), 77 - 15, temp, sizeof(temp));
 

--- a/src/player-attack/player-attack.cpp
+++ b/src/player-attack/player-attack.cpp
@@ -482,7 +482,7 @@ static void apply_actual_attack(
     sound(SOUND_HIT);
     print_surprise_attack(pa_ptr);
 
-    object_flags(o_ptr, pa_ptr->flags);
+    pa_ptr->flags = object_flags(o_ptr);
     pa_ptr->chaos_effect = select_chaotic_effect(attacker_ptr, pa_ptr);
     pa_ptr->magical_effect = select_magical_brand_effect(attacker_ptr, pa_ptr);
     decide_blood_sucking(attacker_ptr, pa_ptr);

--- a/src/player-info/base-status-info.cpp
+++ b/src/player-info/base-status-info.cpp
@@ -10,12 +10,11 @@
 void set_equipment_influence(player_type *creature_ptr, self_info_type *self_ptr)
 {
     for (int k = INVEN_MAIN_HAND; k < INVEN_TOTAL; k++) {
-        TrFlags tflgs;
         object_type *o_ptr = &creature_ptr->inventory_list[k];
         if (o_ptr->k_idx == 0)
             continue;
 
-        object_flags(o_ptr, tflgs);
+        auto tflgs = object_flags(o_ptr);
         for (int j = 0; j < TR_FLAG_SIZE; j++)
             self_ptr->flags[j] |= tflgs[j];
     }

--- a/src/player-info/self-info-util.cpp
+++ b/src/player-info/self-info-util.cpp
@@ -3,8 +3,7 @@
 self_info_type *initialize_self_info_type(self_info_type *self_ptr)
 {
     self_ptr->line = 0;
-    for (int i = 0; i < TR_FLAG_SIZE; i++)
-        self_ptr->flags[i] = 0L;
+    self_ptr->flags.fill(0U);
 
     return self_ptr;
 }

--- a/src/player-status/player-status-base.cpp
+++ b/src/player-status/player-status-base.cpp
@@ -186,14 +186,13 @@ void PlayerStatusBase::set_locals()
 BIT_FLAGS PlayerStatusBase::equipments_flags(tr_type check_flag)
 {
     object_type *o_ptr;
-    TrFlags flgs;
     BIT_FLAGS result = 0L;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         o_ptr = &owner_ptr->inventory_list[i];
         if (!o_ptr->k_idx)
             continue;
 
-        object_flags(o_ptr, flgs);
+        auto flgs = object_flags(o_ptr);
 
         if (has_flag(flgs, check_flag))
             set_bits(result, convert_inventory_slot_type_to_flag_cause(static_cast<inventory_slot_type>(i)));
@@ -209,14 +208,13 @@ BIT_FLAGS PlayerStatusBase::equipments_flags(tr_type check_flag)
 BIT_FLAGS PlayerStatusBase::equipments_bad_flags(tr_type check_flag)
 {
     object_type *o_ptr;
-    TrFlags flgs;
     BIT_FLAGS result = 0L;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         o_ptr = &owner_ptr->inventory_list[i];
         if (!o_ptr->k_idx)
             continue;
 
-        object_flags(o_ptr, flgs);
+        auto flgs = object_flags(o_ptr);
 
         if (has_flag(flgs, check_flag)) {
             if (o_ptr->pval < 0) {
@@ -237,8 +235,7 @@ int16_t PlayerStatusBase::equipments_value()
     int16_t result = 0;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         object_type *o_ptr = &owner_ptr->inventory_list[i];
-        TrFlags flgs;
-        object_flags(o_ptr, flgs);
+        auto flgs = object_flags(o_ptr);
 
         if (!o_ptr->k_idx)
             continue;

--- a/src/player/permanent-resistances.cpp
+++ b/src/player/permanent-resistances.cpp
@@ -276,8 +276,7 @@ static void add_kata_flags(player_type *creature_ptr, TrFlags &flags)
  */
 void player_flags(player_type *creature_ptr, TrFlags &flags)
 {
-    for (int i = 0; i < TR_FLAG_SIZE; i++)
-        flags[i] = 0L;
+    flags.fill(0U);
 
     add_class_flags(creature_ptr, flags);
     add_player_race_flags(creature_ptr, flags);
@@ -289,10 +288,8 @@ void player_flags(player_type *creature_ptr, TrFlags &flags)
 
 void riding_flags(player_type *creature_ptr, TrFlags &flags, TrFlags &negative_flags)
 {
-    for (int i = 0; i < TR_FLAG_SIZE; i++) {
-        flags[i] = 0L;
-        negative_flags[i] = 0L;
-    }
+    flags.fill(0U);
+    negative_flags.fill(0U);
 
     if (!creature_ptr->riding)
         return;

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -110,8 +110,7 @@ static bool acid_minus_ac(player_type *creature_ptr)
 
     GAME_TEXT o_name[MAX_NLEN];
     describe_flavor(creature_ptr, o_name, o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
-    TrFlags flgs;
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
     if (o_ptr->ac + o_ptr->to_a <= 0) {
         msg_format(_("%sは既にボロボロだ！", "Your %s is already fully corroded!"), o_name);
         return false;

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -86,14 +86,13 @@ BIT_FLAGS convert_inventory_slot_type_to_flag_cause(inventory_slot_type inventor
 BIT_FLAGS check_equipment_flags(player_type *creature_ptr, tr_type tr_flag)
 {
     object_type *o_ptr;
-    TrFlags flgs;
     BIT_FLAGS result = 0L;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         o_ptr = &creature_ptr->inventory_list[i];
         if (!o_ptr->k_idx)
             continue;
 
-        object_flags(o_ptr, flgs);
+        auto flgs = object_flags(o_ptr);
 
         if (has_flag(flgs, tr_flag))
             set_bits(result, convert_inventory_slot_type_to_flag_cause(static_cast<inventory_slot_type>(i)));
@@ -762,14 +761,13 @@ BIT_FLAGS has_warning(player_type *creature_ptr)
 {
     BIT_FLAGS result = 0L;
     object_type *o_ptr;
-    TrFlags flgs;
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         o_ptr = &creature_ptr->inventory_list[i];
         if (!o_ptr->k_idx)
             continue;
 
-        object_flags(o_ptr, flgs);
+        auto flgs = object_flags(o_ptr);
 
         if (has_flag(flgs, TR_WARNING)) {
             if (!o_ptr->inscription || !(angband_strchr(quark_str(o_ptr->inscription), '$')))
@@ -1185,7 +1183,6 @@ BIT_FLAGS has_regenerate(player_type *creature_ptr)
 void update_curses(player_type *creature_ptr)
 {
     object_type *o_ptr;
-    TrFlags flgs;
     creature_ptr->cursed.clear();
     creature_ptr->cursed_special.clear();
 
@@ -1196,7 +1193,7 @@ void update_curses(player_type *creature_ptr)
         o_ptr = &creature_ptr->inventory_list[i];
         if (!o_ptr->k_idx)
             continue;
-        object_flags(o_ptr, flgs);
+        auto flgs = object_flags(o_ptr);
         if (has_flag(flgs, TR_AGGRAVATE))
             creature_ptr->cursed.set(TRC::AGGRAVATE);
         if (has_flag(flgs, TR_DRAIN_EXP))
@@ -1272,7 +1269,6 @@ BIT_FLAGS has_earthquake(player_type *creature_ptr)
 void update_extra_blows(player_type *creature_ptr)
 {
     object_type *o_ptr;
-    TrFlags flgs;
     creature_ptr->extra_blows[0] = creature_ptr->extra_blows[1] = 0;
 
     const melee_type melee_type = player_melee_type(creature_ptr);
@@ -1283,7 +1279,7 @@ void update_extra_blows(player_type *creature_ptr)
         if (!o_ptr->k_idx)
             continue;
 
-        object_flags(o_ptr, flgs);
+        auto flgs = object_flags(o_ptr);
         if (has_flag(flgs, TR_BLOWS)) {
             if ((i == INVEN_MAIN_HAND || i == INVEN_MAIN_RING) && !two_handed)
                 creature_ptr->extra_blows[0] += o_ptr->pval;
@@ -2032,9 +2028,8 @@ bool has_disable_two_handed_bonus(player_type *creature_ptr, int i)
  */
 bool is_wielding_icky_weapon(player_type *creature_ptr, int i)
 {
-    TrFlags flgs;
     auto *o_ptr = &creature_ptr->inventory_list[INVEN_MAIN_HAND + i];
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
 
     auto has_no_weapon = (o_ptr->tval == TV_NONE) || (o_ptr->tval == TV_SHIELD);
     if (creature_ptr->pclass == CLASS_PRIEST) {
@@ -2060,8 +2055,7 @@ bool is_wielding_icky_weapon(player_type *creature_ptr, int i)
 bool is_wielding_icky_riding_weapon(player_type *creature_ptr, int i)
 {
     auto *o_ptr = &creature_ptr->inventory_list[INVEN_MAIN_HAND + i];
-    TrFlags flgs;
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
     auto has_no_weapon = (o_ptr->tval == TV_NONE) || (o_ptr->tval == TV_SHIELD);
     auto is_suitable = o_ptr->is_lance() || has_flag(flgs, TR_RIDING);
     return (creature_ptr->riding > 0) && !has_no_weapon && !is_suitable;

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -809,11 +809,10 @@ static void update_max_mana(player_type *creature_ptr)
     }
 
     if (any_bits(mp_ptr->spell_xtra, extra_magic_glove_reduce_mana)) {
-        TrFlags flgs;
         creature_ptr->cumber_glove = false;
         object_type *o_ptr;
         o_ptr = &creature_ptr->inventory_list[INVEN_ARMS];
-        object_flags(o_ptr, flgs);
+        auto flgs = object_flags(o_ptr);
         if (o_ptr->k_idx && !(has_flag(flgs, TR_FREE_ACT)) && !(has_flag(flgs, TR_DEC_MANA)) && !(has_flag(flgs, TR_EASY_SPELL))
             && !((has_flag(flgs, TR_MAGIC_MASTERY)) && (o_ptr->pval > 0)) && !((has_flag(flgs, TR_DEX)) && (o_ptr->pval > 0))) {
             creature_ptr->cumber_glove = true;
@@ -989,7 +988,6 @@ static void update_max_mana(player_type *creature_ptr)
 int16_t calc_num_fire(player_type *creature_ptr, object_type *o_ptr)
 {
     int extra_shots = 0;
-    TrFlags flgs;
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         object_type *q_ptr;
@@ -1000,12 +998,12 @@ int16_t calc_num_fire(player_type *creature_ptr, object_type *o_ptr)
         if (i == INVEN_BOW)
             continue;
 
-        object_flags(q_ptr, flgs);
+        auto flgs = object_flags(q_ptr);
         if (has_flag(flgs, TR_XTRA_SHOTS))
             extra_shots++;
     }
 
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
     if (has_flag(flgs, TR_XTRA_SHOTS))
         extra_shots++;
 
@@ -1103,11 +1101,10 @@ static ACTION_SKILL_POWER calc_device_ability(player_type *creature_ptr)
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         object_type *o_ptr;
-        TrFlags flgs;
         o_ptr = &creature_ptr->inventory_list[i];
         if (!o_ptr->k_idx)
             continue;
-        object_flags(o_ptr, flgs);
+        auto flgs = object_flags(o_ptr);
         if (has_flag(flgs, TR_MAGIC_MASTERY))
             pow += 8 * o_ptr->pval;
     }
@@ -1209,11 +1206,10 @@ static ACTION_SKILL_POWER calc_search(player_type *creature_ptr)
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         object_type *o_ptr;
-        TrFlags flgs;
         o_ptr = &creature_ptr->inventory_list[i];
         if (!o_ptr->k_idx)
             continue;
-        object_flags(o_ptr, flgs);
+        auto flgs = object_flags(o_ptr);
         if (has_flag(flgs, TR_SEARCH))
             pow += (o_ptr->pval * 5);
     }
@@ -1257,11 +1253,10 @@ static ACTION_SKILL_POWER calc_search_freq(player_type *creature_ptr)
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         object_type *o_ptr;
-        TrFlags flgs;
         o_ptr = &creature_ptr->inventory_list[i];
         if (!o_ptr->k_idx)
             continue;
-        object_flags(o_ptr, flgs);
+        auto flgs = object_flags(o_ptr);
         if (has_flag(flgs, TR_SEARCH))
             pow += (o_ptr->pval * 5);
     }
@@ -1371,7 +1366,6 @@ static ACTION_SKILL_POWER calc_to_hit_throw(player_type *creature_ptr)
 static ACTION_SKILL_POWER calc_skill_dig(player_type *creature_ptr)
 {
     object_type *o_ptr;
-    TrFlags flgs;
 
     ACTION_SKILL_POWER pow;
 
@@ -1393,7 +1387,7 @@ static ACTION_SKILL_POWER calc_skill_dig(player_type *creature_ptr)
         o_ptr = &creature_ptr->inventory_list[i];
         if (!o_ptr->k_idx)
             continue;
-        object_flags(o_ptr, flgs);
+        auto flgs = object_flags(o_ptr);
         if (has_flag(flgs, TR_TUNNEL))
             pow += (o_ptr->pval * 20);
     }
@@ -1431,11 +1425,10 @@ static bool is_heavy_wield(player_type *creature_ptr, int i)
 static int16_t calc_num_blow(player_type *creature_ptr, int i)
 {
     object_type *o_ptr;
-    TrFlags flgs;
     int16_t num_blow = 1;
 
     o_ptr = &creature_ptr->inventory_list[INVEN_MAIN_HAND + i];
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
     if (has_melee_weapon(creature_ptr, INVEN_MAIN_HAND + i)) {
         if (o_ptr->k_idx && !creature_ptr->heavy_wield[i]) {
             int str_index, dex_index;
@@ -1578,11 +1571,10 @@ static int16_t calc_to_magic_chance(player_type *creature_ptr)
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         object_type *o_ptr;
-        TrFlags flgs;
         o_ptr = &creature_ptr->inventory_list[i];
         if (!o_ptr->k_idx)
             continue;
-        object_flags(o_ptr, flgs);
+
         if (o_ptr->curse_flags.has(TRC::HARD_SPELL)) {
             if (o_ptr->curse_flags.has(TRC::HEAVY_CURSE)) {
                 chance += 10;
@@ -1620,7 +1612,6 @@ static ARMOUR_CLASS calc_base_ac(player_type *creature_ptr)
 static ARMOUR_CLASS calc_to_ac(player_type *creature_ptr, bool is_real_value)
 {
     ARMOUR_CLASS ac = 0;
-    TrFlags flags;
     if (creature_ptr->yoiyami)
         return 0;
 
@@ -1649,7 +1640,7 @@ static ARMOUR_CLASS calc_to_ac(player_type *creature_ptr, bool is_real_value)
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         object_type *o_ptr;
         o_ptr = &creature_ptr->inventory_list[i];
-        object_flags(o_ptr, flags);
+        auto flags = object_flags(o_ptr);
         if (!o_ptr->k_idx)
             continue;
         if (is_real_value || o_ptr->is_known())
@@ -1792,10 +1783,9 @@ static ARMOUR_CLASS calc_to_ac(player_type *creature_ptr, bool is_real_value)
 int16_t calc_double_weapon_penalty(player_type *creature_ptr, INVENTORY_IDX slot)
 {
     int penalty = 0;
-    TrFlags flags;
 
     if (has_melee_weapon(creature_ptr, INVEN_MAIN_HAND) && has_melee_weapon(creature_ptr, INVEN_SUB_HAND)) {
-        object_flags(&creature_ptr->inventory_list[INVEN_SUB_HAND], flags);
+        auto flags = object_flags(&creature_ptr->inventory_list[INVEN_SUB_HAND]);
 
         penalty = ((100 - creature_ptr->skill_exp[SKILL_TWO_WEAPON] / 160) - (130 - creature_ptr->inventory_list[slot].weight) / 8);
         if (((creature_ptr->inventory_list[INVEN_MAIN_HAND].name1 == ART_QUICKTHORN) && (creature_ptr->inventory_list[INVEN_SUB_HAND].name1 == ART_TINYTHORN))
@@ -1965,8 +1955,7 @@ void put_equipment_warning(player_type *creature_ptr)
 static int16_t calc_to_damage(player_type *creature_ptr, INVENTORY_IDX slot, bool is_real_value)
 {
     object_type *o_ptr = &creature_ptr->inventory_list[slot];
-    TrFlags flgs;
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
 
     player_hand calc_hand = PLAYER_HAND_OTHER;
     if (slot == INVEN_MAIN_HAND)
@@ -2172,8 +2161,7 @@ static int16_t calc_to_hit(player_type *creature_ptr, INVENTORY_IDX slot, bool i
     /* Bonuses and penalties by weapon */
     if (has_melee_weapon(creature_ptr, slot)) {
         object_type *o_ptr = &creature_ptr->inventory_list[slot];
-        TrFlags flgs;
-        object_flags(o_ptr, flgs);
+        auto flgs = object_flags(o_ptr);
 
         int tval = o_ptr->tval - TV_WEAPON_BEGIN;
         OBJECT_SUBTYPE_VALUE sval = o_ptr->sval;
@@ -2344,11 +2332,8 @@ static int16_t calc_to_hit_bow(player_type *creature_ptr, bool is_real_value)
 
     {
         object_type *o_ptr;
-        TrFlags flgs;
         o_ptr = &creature_ptr->inventory_list[INVEN_BOW];
         if (o_ptr->k_idx) {
-            object_flags(o_ptr, flgs);
-
             if (o_ptr->curse_flags.has(TRC::LOW_MELEE)) {
                 if (o_ptr->curse_flags.has(TRC::HEAVY_CURSE)) {
                     pow -= 15;
@@ -2418,7 +2403,6 @@ static int16_t calc_to_hit_bow(player_type *creature_ptr, bool is_real_value)
 static int16_t calc_to_damage_misc(player_type *creature_ptr)
 {
     object_type *o_ptr;
-    TrFlags flgs;
 
     int16_t to_dam = 0;
 
@@ -2426,8 +2410,6 @@ static int16_t calc_to_damage_misc(player_type *creature_ptr)
         o_ptr = &creature_ptr->inventory_list[i];
         if (!o_ptr->k_idx)
             continue;
-
-        object_flags(o_ptr, flgs);
 
         int bonus_to_d = o_ptr->to_d;
         if (creature_ptr->pclass == CLASS_NINJA) {
@@ -2454,7 +2436,6 @@ static int16_t calc_to_damage_misc(player_type *creature_ptr)
 static int16_t calc_to_hit_misc(player_type *creature_ptr)
 {
     object_type *o_ptr;
-    TrFlags flgs;
 
     int16_t to_hit = 0;
 
@@ -2462,8 +2443,6 @@ static int16_t calc_to_hit_misc(player_type *creature_ptr)
         o_ptr = &creature_ptr->inventory_list[i];
         if (!o_ptr->k_idx)
             continue;
-
-        object_flags(o_ptr, flgs);
 
         int bonus_to_h = o_ptr->to_h;
         if (creature_ptr->pclass == CLASS_NINJA) {

--- a/src/player/race-resistances.cpp
+++ b/src/player/race-resistances.cpp
@@ -83,13 +83,12 @@ void known_obj_immunity(player_type *creature_ptr, TrFlags &flags)
     flags.fill(0U);
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        TrFlags o_flags;
         object_type *o_ptr;
         o_ptr = &creature_ptr->inventory_list[i];
         if (!o_ptr->k_idx)
             continue;
 
-        object_flags_known(o_ptr, o_flags);
+        auto o_flags = object_flags_known(o_ptr);
         if (has_flag(o_flags, TR_IM_ACID))
             add_flag(flags, TR_RES_ACID);
         if (has_flag(o_flags, TR_IM_ELEC))

--- a/src/player/race-resistances.cpp
+++ b/src/player/race-resistances.cpp
@@ -1,12 +1,12 @@
 ﻿#include "race-resistances.h"
 #include "inventory/inventory-slot-types.h"
+#include "mind/mind-elementalist.h"
 #include "mutation/mutation-flag-types.h"
-#include "player/player-race-types.h"
-#include "object/object-flags.h"
 #include "object-enchant/tr-types.h"
+#include "object/object-flags.h"
+#include "player/player-race-types.h"
 #include "player/player-race.h"
 #include "player/special-defense-types.h"
-#include "mind/mind-elementalist.h"
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
@@ -59,21 +59,20 @@ void player_immunity(player_type *creature_ptr, TrFlags &flags)
  */
 void tim_player_immunity(player_type *creature_ptr, TrFlags &flags)
 {
-	for (int i = 0; i < TR_FLAG_SIZE; i++)
-		flags[i] = 0L;
+    for (int i = 0; i < TR_FLAG_SIZE; i++)
+        flags[i] = 0L;
 
-	if (creature_ptr->special_defense & DEFENSE_ACID)
-		add_flag(flags, TR_RES_ACID);
-	if (creature_ptr->special_defense & DEFENSE_ELEC)
-		add_flag(flags, TR_RES_ELEC);
-	if (creature_ptr->special_defense & DEFENSE_FIRE)
-		add_flag(flags, TR_RES_FIRE);
-	if (creature_ptr->special_defense & DEFENSE_COLD)
-		add_flag(flags, TR_RES_COLD);
-	if (creature_ptr->wraith_form)
-		add_flag(flags, TR_RES_DARK);
+    if (creature_ptr->special_defense & DEFENSE_ACID)
+        add_flag(flags, TR_RES_ACID);
+    if (creature_ptr->special_defense & DEFENSE_ELEC)
+        add_flag(flags, TR_RES_ELEC);
+    if (creature_ptr->special_defense & DEFENSE_FIRE)
+        add_flag(flags, TR_RES_FIRE);
+    if (creature_ptr->special_defense & DEFENSE_COLD)
+        add_flag(flags, TR_RES_COLD);
+    if (creature_ptr->wraith_form)
+        add_flag(flags, TR_RES_DARK);
 }
-
 
 /*!
  * @brief プレイヤーの装備による免疫フラグを返す
@@ -84,24 +83,27 @@ void tim_player_immunity(player_type *creature_ptr, TrFlags &flags)
  */
 void known_obj_immunity(player_type *creature_ptr, TrFlags &flags)
 {
-	for (int i = 0; i < TR_FLAG_SIZE; i++)
-		flags[i] = 0L;
+    for (int i = 0; i < TR_FLAG_SIZE; i++)
+        flags[i] = 0L;
 
-	for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++)
-	{
-		TrFlags o_flags;
-		object_type *o_ptr;
-		o_ptr = &creature_ptr->inventory_list[i];
-		if (!o_ptr->k_idx) continue;
+    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+        TrFlags o_flags;
+        object_type *o_ptr;
+        o_ptr = &creature_ptr->inventory_list[i];
+        if (!o_ptr->k_idx)
+            continue;
 
-                object_flags_known(o_ptr, o_flags);
-                if (has_flag(o_flags, TR_IM_ACID)) add_flag(flags, TR_RES_ACID);
-		if (has_flag(o_flags, TR_IM_ELEC)) add_flag(flags, TR_RES_ELEC);
-		if (has_flag(o_flags, TR_IM_FIRE)) add_flag(flags, TR_RES_FIRE);
-		if (has_flag(o_flags, TR_IM_COLD)) add_flag(flags, TR_RES_COLD);
-	}
+        object_flags_known(o_ptr, o_flags);
+        if (has_flag(o_flags, TR_IM_ACID))
+            add_flag(flags, TR_RES_ACID);
+        if (has_flag(o_flags, TR_IM_ELEC))
+            add_flag(flags, TR_RES_ELEC);
+        if (has_flag(o_flags, TR_IM_FIRE))
+            add_flag(flags, TR_RES_FIRE);
+        if (has_flag(o_flags, TR_IM_COLD))
+            add_flag(flags, TR_RES_COLD);
+    }
 }
-
 
 /*!
  * @brief プレイヤーの種族による弱点フラグを返す
@@ -112,19 +114,18 @@ void known_obj_immunity(player_type *creature_ptr, TrFlags &flags)
  */
 void player_vulnerability_flags(player_type *creature_ptr, TrFlags &flags)
 {
-	for (int i = 0; i < TR_FLAG_SIZE; i++)
-		flags[i] = 0L;
+    for (int i = 0; i < TR_FLAG_SIZE; i++)
+        flags[i] = 0L;
 
-	if (creature_ptr->muta.has(MUTA::VULN_ELEM) || (creature_ptr->special_defense & KATA_KOUKIJIN))
-	{
-		add_flag(flags, TR_RES_ACID);
-		add_flag(flags, TR_RES_ELEC);
-		add_flag(flags, TR_RES_FIRE);
-		add_flag(flags, TR_RES_COLD);
-	}
+    if (creature_ptr->muta.has(MUTA::VULN_ELEM) || (creature_ptr->special_defense & KATA_KOUKIJIN)) {
+        add_flag(flags, TR_RES_ACID);
+        add_flag(flags, TR_RES_ELEC);
+        add_flag(flags, TR_RES_FIRE);
+        add_flag(flags, TR_RES_COLD);
+    }
 
-	if (player_race_has_flag(creature_ptr, TR_VUL_ACID))
-            add_flag(flags, TR_RES_ACID);
+    if (player_race_has_flag(creature_ptr, TR_VUL_ACID))
+        add_flag(flags, TR_RES_ACID);
     if (player_race_has_flag(creature_ptr, TR_VUL_COLD))
         add_flag(flags, TR_RES_COLD);
     if (player_race_has_flag(creature_ptr, TR_VUL_ELEC))

--- a/src/player/race-resistances.cpp
+++ b/src/player/race-resistances.cpp
@@ -20,9 +20,7 @@
  */
 void player_immunity(player_type *creature_ptr, TrFlags &flags)
 {
-    for (int i = 0; i < TR_FLAG_SIZE; i++) {
-        flags[i] = 0L;
-    }
+    flags.fill(0U);
 
     if (player_race_has_flag(creature_ptr, TR_IM_ACID))
         add_flag(flags, TR_RES_ACID);
@@ -59,8 +57,7 @@ void player_immunity(player_type *creature_ptr, TrFlags &flags)
  */
 void tim_player_immunity(player_type *creature_ptr, TrFlags &flags)
 {
-    for (int i = 0; i < TR_FLAG_SIZE; i++)
-        flags[i] = 0L;
+    flags.fill(0U);
 
     if (creature_ptr->special_defense & DEFENSE_ACID)
         add_flag(flags, TR_RES_ACID);
@@ -83,8 +80,7 @@ void tim_player_immunity(player_type *creature_ptr, TrFlags &flags)
  */
 void known_obj_immunity(player_type *creature_ptr, TrFlags &flags)
 {
-    for (int i = 0; i < TR_FLAG_SIZE; i++)
-        flags[i] = 0L;
+    flags.fill(0U);
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         TrFlags o_flags;
@@ -114,8 +110,7 @@ void known_obj_immunity(player_type *creature_ptr, TrFlags &flags)
  */
 void player_vulnerability_flags(player_type *creature_ptr, TrFlags &flags)
 {
-    for (int i = 0; i < TR_FLAG_SIZE; i++)
-        flags[i] = 0L;
+    flags.fill(0U);
 
     if (creature_ptr->muta.has(MUTA::VULN_ELEM) || (creature_ptr->special_defense & KATA_KOUKIJIN)) {
         add_flag(flags, TR_RES_ACID);

--- a/src/player/temporary-resistances.cpp
+++ b/src/player/temporary-resistances.cpp
@@ -28,8 +28,7 @@ void tim_player_flags(player_type *creature_ptr, TrFlags &flags)
     BIT_FLAGS race_class_flag = FLAG_CAUSE_CLASS;
     set_bits(race_class_flag, FLAG_CAUSE_RACE);
 
-    for (int i = 0; i < TR_FLAG_SIZE; i++)
-        flags[i] = 0L;
+    flags.fill(0U);
 
     if (is_oppose_acid(creature_ptr) && none_bits(has_immune_acid(creature_ptr), (race_class_flag | tmp_effect_flag)))
         add_flag(flags, TR_RES_ACID);

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -195,7 +195,6 @@ concptr do_hex_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
             concptr q, s;
             GAME_TEXT o_name[MAX_NLEN];
             object_type *o_ptr;
-            TrFlags f;
 
             q = _("どれを呪いますか？", "Which weapon do you curse?");
             s = _("武器を装備していない。", "You're not wielding a weapon.");
@@ -205,7 +204,7 @@ concptr do_hex_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
                 return "";
 
             describe_flavor(caster_ptr, o_name, o_ptr, OD_NAME_ONLY);
-            object_flags(o_ptr, f);
+            auto f = object_flags(o_ptr);
 
             if (!get_check(format(_("本当に %s を呪いますか？", "Do you curse %s, really？"), o_name)))
                 return "";
@@ -501,7 +500,6 @@ concptr do_hex_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
             concptr q, s;
             GAME_TEXT o_name[MAX_NLEN];
             object_type *o_ptr;
-            TrFlags f;
 
             q = _("どれを呪いますか？", "Which piece of armour do you curse?");
             s = _("防具を装備していない。", "You're not wearing any armor.");
@@ -512,7 +510,7 @@ concptr do_hex_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
 
             o_ptr = &caster_ptr->inventory_list[item];
             describe_flavor(caster_ptr, o_name, o_ptr, OD_NAME_ONLY);
-            object_flags(o_ptr, f);
+            auto f = object_flags(o_ptr);
 
             if (!get_check(format(_("本当に %s を呪いますか？", "Do you curse %s, really？"), o_name)))
                 return "";
@@ -700,7 +698,6 @@ concptr do_hex_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
         if (cast) {
             OBJECT_IDX item;
             concptr s, q;
-            TrFlags f;
             object_type *o_ptr;
 
             q = _("どの装備品から吸収しますか？", "Which cursed equipment do you drain mana from?");
@@ -710,7 +707,7 @@ concptr do_hex_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
             if (!o_ptr)
                 return "";
 
-            object_flags(o_ptr, f);
+            auto f = object_flags(o_ptr);
 
             caster_ptr->csp += (caster_ptr->lev / 5) + randint1(caster_ptr->lev / 5);
             if (has_flag(f, TR_TY_CURSE) || o_ptr->curse_flags.has(TRC::TY_CURSE))

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -651,7 +651,6 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
 
         if (cast) {
             int total_damage = 0, basedam, i;
-            TrFlags flgs;
             object_type *o_ptr;
             if (!get_aim_dir(caster_ptr, &dir))
                 return NULL;
@@ -664,7 +663,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
                 o_ptr = &caster_ptr->inventory_list[INVEN_MAIN_HAND + i];
                 basedam = (o_ptr->dd * (o_ptr->ds + 1)) * 50;
                 damage = o_ptr->to_d * 100;
-                object_flags(o_ptr, flgs);
+                auto flgs = object_flags(o_ptr);
                 if ((o_ptr->name1 == ART_VORPAL_BLADE) || (o_ptr->name1 == ART_CHAINSWORD)) {
                     /* vorpal blade */
                     basedam *= 5;
@@ -920,7 +919,6 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
         if (cast) {
             int total_damage = 0, basedam, i;
             POSITION y, x;
-            TrFlags flgs;
             object_type *o_ptr;
 
             if (!get_direction(caster_ptr, &dir, false, false))
@@ -943,7 +941,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
                 o_ptr = &caster_ptr->inventory_list[INVEN_MAIN_HAND + i];
                 basedam = (o_ptr->dd * (o_ptr->ds + 1)) * 50;
                 damage = o_ptr->to_d * 100;
-                object_flags(o_ptr, flgs);
+                auto flgs = object_flags(o_ptr);
                 if ((o_ptr->name1 == ART_VORPAL_BLADE) || (o_ptr->name1 == ART_CHAINSWORD)) {
                     /* vorpal blade */
                     basedam *= 5;

--- a/src/specific-object/bloody-moon.cpp
+++ b/src/specific-object/bloody-moon.cpp
@@ -17,8 +17,7 @@
  */
 void get_bloody_moon_flags(object_type *o_ptr)
 {
-    for (int i = 0; i < TR_FLAG_SIZE; i++)
-        o_ptr->art_flags[i] = a_info[ART_BLOOD].flags[i];
+    o_ptr->art_flags = a_info[ART_BLOOD].flags;
 
     int dummy = randint1(2) + randint1(2);
     for (int i = 0; i < dummy; i++) {

--- a/src/specific-object/death-scythe.cpp
+++ b/src/specific-object/death-scythe.cpp
@@ -135,13 +135,12 @@ static void death_scythe_reflection_critial_hit(player_attack_type *pa_ptr)
  */
 void process_death_scythe_reflection(player_type *attacker_ptr, player_attack_type *pa_ptr)
 {
-    TrFlags death_scythe_flags;
     sound(SOUND_HIT);
     msg_format(_("ミス！ %sにかわされた。", "You miss %s."), pa_ptr->m_name);
     msg_print(_("振り回した大鎌が自分自身に返ってきた！", "Your scythe returns to you!"));
 
     object_type *o_ptr = &attacker_ptr->inventory_list[INVEN_MAIN_HAND + pa_ptr->hand];
-    object_flags(o_ptr, death_scythe_flags);
+    auto death_scythe_flags = object_flags(o_ptr);
     pa_ptr->attack_damage = damroll(o_ptr->dd + attacker_ptr->to_dd[pa_ptr->hand], o_ptr->ds + attacker_ptr->to_ds[pa_ptr->hand]);
     int magnification = calc_death_scythe_reflection_magnification(attacker_ptr);
     compensate_death_scythe_reflection_magnification(attacker_ptr, &magnification, death_scythe_flags);

--- a/src/specific-object/torch.cpp
+++ b/src/specific-object/torch.cpp
@@ -77,8 +77,7 @@ void update_lite_radius(player_type *creature_ptr)
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         object_type *o_ptr;
         o_ptr = &creature_ptr->inventory_list[i];
-        TrFlags flgs;
-        object_flags(o_ptr, flgs);
+        auto flgs = object_flags(o_ptr);
 
         if (!o_ptr->k_idx)
             continue;

--- a/src/spell-kind/spells-teleport.cpp
+++ b/src/spell-kind/spells-teleport.cpp
@@ -515,14 +515,13 @@ void teleport_away_followable(player_type *tracer_ptr, MONSTER_IDX m_idx)
     if (tracer_ptr->muta.has(MUTA::VTELEPORT) || (tracer_ptr->pclass == CLASS_IMITATOR))
         follow = true;
     else {
-        TrFlags flgs;
         object_type *o_ptr;
         INVENTORY_IDX i;
 
         for (i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
             o_ptr = &tracer_ptr->inventory_list[i];
             if (o_ptr->k_idx && !o_ptr->is_cursed()) {
-                object_flags(o_ptr, flgs);
+                auto flgs = object_flags(o_ptr);
                 if (has_flag(flgs, TR_TELEPORT)) {
                     follow = true;
                     break;

--- a/src/spell-realm/spells-craft.cpp
+++ b/src/spell-realm/spells-craft.cpp
@@ -273,8 +273,6 @@ bool pulish_shield(player_type *caster_ptr)
 
     GAME_TEXT o_name[MAX_NLEN];
     describe_flavor(caster_ptr, o_name, o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
-    TrFlags flgs;
-    object_flags(o_ptr, flgs);
 
     bool is_pulish_successful = o_ptr->k_idx && !o_ptr->is_artifact() && !o_ptr->is_ego();
     is_pulish_successful &= !o_ptr->is_cursed();

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -251,8 +251,7 @@ bool curse_armor(player_type *owner_ptr)
     o_ptr->dd = 0;
     o_ptr->ds = 0;
 
-    for (int i = 0; i < TR_FLAG_SIZE; i++)
-        o_ptr->art_flags[i] = 0;
+    o_ptr->art_flags.fill(0U);
 
     /* Curse it */
     o_ptr->curse_flags.set(TRC::CURSED);

--- a/src/store/service-checker.cpp
+++ b/src/store/service-checker.cpp
@@ -23,8 +23,7 @@
  */
 static bool is_blessed_item(const object_type *o_ptr)
 {
-    TrFlags flgs;
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
     return has_flag(flgs, TR_BLESSED);
 }
 

--- a/src/store/store-util.cpp
+++ b/src/store/store-util.cpp
@@ -85,7 +85,7 @@ void store_delete(void)
 
     if ((st_ptr->stock[what].tval == TV_ROD) || (st_ptr->stock[what].tval == TV_WAND))
         st_ptr->stock[what].pval -= num * st_ptr->stock[what].pval / st_ptr->stock[what].number;
-    
+
     store_item_increase(what, -num);
     store_item_optimize(what);
 }
@@ -227,9 +227,8 @@ bool store_object_similar(object_type *o_ptr, object_type *j_ptr)
     if (o_ptr->is_artifact() || j_ptr->is_artifact())
         return false;
 
-    for (int i = 0; i < TR_FLAG_SIZE; i++)
-        if (o_ptr->art_flags[i] != j_ptr->art_flags[i])
-            return false;
+    if (o_ptr->art_flags != j_ptr->art_flags)
+        return false;
 
     if (o_ptr->xtra1 || j_ptr->xtra1)
         return false;

--- a/src/system/h-type.h
+++ b/src/system/h-type.h
@@ -33,6 +33,7 @@
  * </pre>
  */
 
+#include <array>
 #include <cassert>
 #include <stdint.h>
 
@@ -190,7 +191,7 @@ typedef int16_t ACTION_SKILL_POWER; /*!< 行動技能値 */
 
 typedef int16_t FEAT_PRIORITY; /*!< 地形の縮小表示優先順位 */
 
-using TrFlags = BIT_FLAGS[TR_FLAG_SIZE];
+using TrFlags = std::array<BIT_FLAGS, TR_FLAG_SIZE>;
 
 enum process_result {
     PROCESS_FALSE = 0,

--- a/src/system/object-type-definition.cpp
+++ b/src/system/object-type-definition.cpp
@@ -521,7 +521,6 @@ bool object_type::is_activatable() const
     if (!this->is_known())
         return false;
 
-    TrFlags flags;
-    object_flags(this, flags);
+    auto flags = object_flags(this);
     return has_flag(flags, TR_ACTIVATE);
 }

--- a/src/view/display-characteristic.cpp
+++ b/src/view/display-characteristic.cpp
@@ -106,11 +106,10 @@ static void process_cursed_equipment_characteristics(player_type *creature_ptr, 
 {
     int max_i = (mode & DP_WP) ? INVEN_BOW + 1 : INVEN_TOTAL;
     for (int i = INVEN_MAIN_HAND; i < max_i; i++) {
-        TrFlags flags;
         auto *o_ptr = &creature_ptr->inventory_list[i];
         auto is_known = o_ptr->is_known();
         auto is_sensed = is_known || o_ptr->ident & IDENT_SENSE;
-        object_flags_known(o_ptr, flags);
+        auto flags = object_flags_known(o_ptr);
 
         if (has_flag(flags, TR_ADD_L_CURSE) || has_flag(flags, TR_ADD_H_CURSE)) {
             if (is_known) {
@@ -156,9 +155,8 @@ static void process_light_equipment_characteristics(player_type *creature_ptr, a
 {
     int max_i = (mode & DP_WP) ? INVEN_BOW + 1 : INVEN_TOTAL;
     for (int i = INVEN_MAIN_HAND; i < max_i; i++) {
-        TrFlags flags;
         auto *o_ptr = &creature_ptr->inventory_list[i];
-        object_flags_known(o_ptr, flags);
+        auto flags = object_flags_known(o_ptr);
 
         auto b = false;
         for (auto flg : lite_flags) {
@@ -206,9 +204,8 @@ static void process_inventory_characteristic(player_type *creature_ptr, tr_type 
 {
     int max_i = (mode & DP_WP) ? INVEN_BOW + 1 : INVEN_TOTAL;
     for (int i = INVEN_MAIN_HAND; i < max_i; i++) {
-        TrFlags flags;
         auto *o_ptr = &creature_ptr->inventory_list[i];
-        object_flags_known(o_ptr, flags);
+        auto flags = object_flags_known(o_ptr);
 
         auto f_imm = flag_to_greater_flag.find(flag);
         if (f_imm != flag_to_greater_flag.end()) {

--- a/src/view/display-player-stat-info.cpp
+++ b/src/view/display-player-stat-info.cpp
@@ -196,12 +196,12 @@ static void compensate_stat_by_weapon(char *c, TERM_COLOR *a, object_type *o_ptr
  * @param row 行数
  * @param col 列数
  */
-static void display_equipments_compensation(player_type *creature_ptr, TrFlags &flags, int row, int *col)
+static void display_equipments_compensation(player_type *creature_ptr, int row, int *col)
 {
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         object_type *o_ptr;
         o_ptr = &creature_ptr->inventory_list[i];
-        object_flags_known(o_ptr, flags);
+        auto flags = object_flags_known(o_ptr);
         for (int stat = 0; stat < A_MAX; stat++) {
             TERM_COLOR a = TERM_SLATE;
             char c = '.';
@@ -318,12 +318,14 @@ static void change_display_by_mutation(player_type *creature_ptr, int stat, char
 /*!
  * @brief 能力値を走査し、突然変異 (と、つよしスペシャル)で補正をかける必要があればかける
  * @param creature_ptr プレーヤーへの参照ポインタ
- * @param stat 能力値番号
  * @param col 列数
  * @param row 行数
  */
-static void display_mutation_compensation(player_type *creature_ptr, const TrFlags &flags, int row, int col)
+static void display_mutation_compensation(player_type *creature_ptr, int row, int col)
 {
+    TrFlags flags;
+    player_flags(creature_ptr, flags);
+
     for (int stat = 0; stat < A_MAX; stat++) {
         byte a = TERM_SLATE;
         char c = '.';
@@ -368,8 +370,6 @@ void display_player_stat_info(player_type *creature_ptr)
     c_put_str(TERM_WHITE, "abcdefghijkl@", row, col);
     c_put_str(TERM_L_GREEN, _("能力修正", "Modification"), row - 1, col);
 
-    TrFlags flags;
-    display_equipments_compensation(creature_ptr, flags, row, &col);
-    player_flags(creature_ptr, flags);
-    display_mutation_compensation(creature_ptr, flags, row, col);
+    display_equipments_compensation(creature_ptr, row, &col);
+    display_mutation_compensation(creature_ptr, row, col);
 }

--- a/src/view/status-first-page.cpp
+++ b/src/view/status-first-page.cpp
@@ -245,7 +245,7 @@ static void calc_two_hands(player_type *creature_ptr, int *damage, int *to_h)
 {
     object_type *o_ptr;
     o_ptr = &creature_ptr->inventory_list[INVEN_BOW];
-    TrFlags flgs;
+
     for (int i = 0; i < 2; i++) {
         int basedam;
         damage[i] = creature_ptr->dis_to_d[i] * 100;
@@ -270,7 +270,7 @@ static void calc_two_hands(player_type *creature_ptr, int *damage, int *to_h)
         }
 
         basedam = ((o_ptr->dd + creature_ptr->to_dd[i]) * (o_ptr->ds + creature_ptr->to_ds[i] + 1)) * 50;
-        object_flags_known(o_ptr, flgs);
+        auto flgs = object_flags_known(o_ptr);
 
         bool impact = creature_ptr->impact != 0;
         basedam = calc_expect_crit(creature_ptr, o_ptr->weight, to_h[i], basedam, creature_ptr->dis_to_h[i], poison_needle, impact);

--- a/src/wizard/artifact-analyzer.cpp
+++ b/src/wizard/artifact-analyzer.cpp
@@ -60,14 +60,13 @@ static void analyze_general(player_type *player_ptr, object_type *o_ptr, char *d
  */
 static void analyze_pval(object_type *o_ptr, pval_info_type *pi_ptr)
 {
-    TrFlags flgs;
     concptr *affects_list;
     if (!o_ptr->pval) {
         pi_ptr->pval_desc[0] = '\0';
         return;
     }
 
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
     affects_list = pi_ptr->pval_affects;
     sprintf(pi_ptr->pval_desc, "%s%d", o_ptr->pval >= 0 ? "+" : "", o_ptr->pval);
     if (has_flag(flgs, TR_STR) && has_flag(flgs, TR_INT) && has_flag(flgs, TR_WIS) && has_flag(flgs, TR_DEX) && has_flag(flgs, TR_CON)
@@ -90,8 +89,7 @@ static void analyze_pval(object_type *o_ptr, pval_info_type *pi_ptr)
  */
 static void analyze_slay(object_type *o_ptr, concptr *slay_list)
 {
-    TrFlags flgs;
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
     slay_list = spoiler_flag_aux(flgs, slay_flags_desc, slay_list, N_ELEMENTS(slay_flags_desc));
     *slay_list = NULL;
 }
@@ -104,8 +102,7 @@ static void analyze_slay(object_type *o_ptr, concptr *slay_list)
  */
 static void analyze_brand(object_type *o_ptr, concptr *brand_list)
 {
-    TrFlags flgs;
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
     brand_list = spoiler_flag_aux(flgs, brand_flags_desc, brand_list, N_ELEMENTS(brand_flags_desc));
     *brand_list = NULL;
 }
@@ -118,8 +115,7 @@ static void analyze_brand(object_type *o_ptr, concptr *brand_list)
  */
 static void analyze_resist(object_type *o_ptr, concptr *resist_list)
 {
-    TrFlags flgs;
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
     resist_list = spoiler_flag_aux(flgs, resist_flags_desc, resist_list, N_ELEMENTS(resist_flags_desc));
     *resist_list = NULL;
 }
@@ -132,8 +128,7 @@ static void analyze_resist(object_type *o_ptr, concptr *resist_list)
  */
 static void analyze_immune(object_type *o_ptr, concptr *immune_list)
 {
-    TrFlags flgs;
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
     immune_list = spoiler_flag_aux(flgs, immune_flags_desc, immune_list, N_ELEMENTS(immune_flags_desc));
     *immune_list = NULL;
 }
@@ -146,8 +141,7 @@ static void analyze_immune(object_type *o_ptr, concptr *immune_list)
  */
 static void analyze_sustains(object_type *o_ptr, concptr *sustain_list)
 {
-    TrFlags flgs;
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
     if (has_flag(flgs, TR_SUST_STR) && has_flag(flgs, TR_SUST_INT) && has_flag(flgs, TR_SUST_WIS) && has_flag(flgs, TR_SUST_DEX)
         && has_flag(flgs, TR_SUST_CON) && has_flag(flgs, TR_SUST_CHR)) {
         *sustain_list++ = _("全能力", "All stats");
@@ -168,10 +162,9 @@ static void analyze_sustains(object_type *o_ptr, concptr *sustain_list)
  */
 static void analyze_misc_magic(object_type *o_ptr, concptr *misc_list)
 {
-    TrFlags flgs;
     char desc[256];
 
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
     misc_list = spoiler_flag_aux(flgs, misc_flags2_desc, misc_list, N_ELEMENTS(misc_flags2_desc));
     misc_list = spoiler_flag_aux(flgs, misc_flags3_desc, misc_list, N_ELEMENTS(misc_flags3_desc));
     POSITION rad = 0;

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -335,8 +335,7 @@ static void prt_binary(BIT_FLAGS flags, const int row, int col)
  */
 static void wiz_display_item(player_type *player_ptr, object_type *o_ptr)
 {
-    TrFlags flgs;
-    object_flags(o_ptr, flgs);
+    auto flgs = object_flags(o_ptr);
     int j = 13;
     for (int i = 1; i <= 23; i++)
         prt("", i, j - 2);


### PR DESCRIPTION
表題の通りです。
既存のインターフェースは

```c++
void object_flags(const object_type* o_ptr, TrFlags& flags);
```

で引数に渡したフラグ変数を変更してもらうものでしたが、

```c++
TrFlags object_flags(const object_type* o_ptr);
```

のほうが明らかにインターフェースとして明快なのでこの形に変更します。
また、この変更は今後の TrFlags の FlagGroup クラス化や、object_flags関数そのものを object_type::flags() のようなメンバ関数にしていく事も踏まえています。