### PR TITLE
'NULL' を 'nullptr' に変える (Win32APIを除く)

### DIFF
--- a/src/action/action-limited.cpp
+++ b/src/action/action-limited.cpp
@@ -24,7 +24,7 @@ bool cmd_limit_cast(player_type *creature_ptr)
 {
     if (is_in_dungeon(creature_ptr) && (d_info[creature_ptr->dungeon_idx].flags.has(DF::NO_MAGIC))) {
         msg_print(_("ダンジョンが魔法を吸収した！", "The dungeon absorbs all attempted magic!"));
-        msg_print(NULL);
+        msg_print(nullptr);
         return true;
     }
 
@@ -75,7 +75,7 @@ bool cmd_limit_arena(player_type *creature_ptr)
 {
     if (creature_ptr->current_floor_ptr->inside_arena) {
         msg_print(_("アリーナが魔法を吸収した！", "The arena absorbs all attempted magic!"));
-        msg_print(NULL);
+        msg_print(nullptr);
         return true;
     }
 

--- a/src/action/activation-execution.cpp
+++ b/src/action/activation-execution.cpp
@@ -56,7 +56,7 @@ static void decide_activation_level(ae_type *ae_ptr)
 
     if (ae_ptr->o_ptr->is_random_artifact()) {
         const activation_type *const act_ptr = find_activation_info(ae_ptr->o_ptr);
-        if (act_ptr != NULL)
+        if (act_ptr != nullptr)
             ae_ptr->lev = act_ptr->level;
 
         return;

--- a/src/artifact/artifact-info.cpp
+++ b/src/artifact/artifact-info.cpp
@@ -61,9 +61,9 @@ const activation_type *find_activation_info(const object_type *o_ptr)
 {
     const int index = activation_index(o_ptr);
     const activation_type *p;
-    for (p = activation_info; p->flag != NULL; ++p)
+    for (p = activation_info; p->flag != nullptr; ++p)
         if (p->index == index)
             return p;
 
-    return NULL;
+    return nullptr;
 }

--- a/src/autopick/autopick-drawer.cpp
+++ b/src/autopick/autopick-drawer.cpp
@@ -195,7 +195,7 @@ void draw_text_editor(player_type *player_ptr, text_body_type *tb)
         return;
 
     autopick_type an_entry, *entry = &an_entry;
-    concptr str1 = NULL, str2 = NULL;
+    concptr str1 = nullptr, str2 = nullptr;
     for (int j = 0; j < DESCRIPT_HGT; j++) {
         term_erase(0, tb->hgt + 2 + j, tb->wid);
     }

--- a/src/autopick/autopick-editor-command.cpp
+++ b/src/autopick/autopick-editor-command.cpp
@@ -60,7 +60,7 @@ ape_quittance do_editor_command(player_type *player_ptr, text_body_type *tb, int
         break;
     }
     case EC_HELP: {
-        (void)show_file(player_ptr, true, _("jeditor.txt", "editor.txt"), NULL, 0, 0);
+        (void)show_file(player_ptr, true, _("jeditor.txt", "editor.txt"), nullptr, 0, 0);
         tb->dirty_flags |= DIRTY_SCREEN;
         break;
     }
@@ -335,7 +335,7 @@ ape_quittance do_editor_command(player_type *player_ptr, text_body_type *tb, int
 
         if (tb->old_com_id != com_id) {
             kill_yank_chain(tb);
-            tb->yank = NULL;
+            tb->yank = nullptr;
         }
 
         if (tb->cx < len) {
@@ -405,7 +405,7 @@ ape_quittance do_editor_command(player_type *player_ptr, text_body_type *tb, int
             for (i = tb->cy; tb->lines_list[i + 1]; i++)
                 tb->lines_list[i] = tb->lines_list[i + 1];
 
-            tb->lines_list[i] = NULL;
+            tb->lines_list[i] = nullptr;
             tb->cy--;
             tb->dirty_flags |= DIRTY_ALL;
             tb->dirty_flags |= DIRTY_EXPRESSION;

--- a/src/autopick/autopick-editor-util.cpp
+++ b/src/autopick/autopick-editor-util.cpp
@@ -204,14 +204,14 @@ static chain_str_type *new_chain_str(concptr str)
     size_t len = strlen(str);
     auto *chain = static_cast<chain_str_type *>(std::malloc(sizeof(chain_str_type) + len * sizeof(char)));
     strcpy(chain->s, str);
-    chain->next = NULL;
+    chain->next = nullptr;
     return chain;
 }
 
 void kill_yank_chain(text_body_type *tb)
 {
     chain_str_type *chain = tb->yank;
-    tb->yank = NULL;
+    tb->yank = nullptr;
     tb->yank_eol = true;
 
     while (chain) {

--- a/src/autopick/autopick-editor-util.cpp
+++ b/src/autopick/autopick-editor-util.cpp
@@ -226,7 +226,7 @@ void kill_yank_chain(text_body_type *tb)
 void add_str_to_yank(text_body_type *tb, concptr str)
 {
     tb->yank_eol = false;
-    if (NULL == tb->yank) {
+    if (tb->yank == nullptr) {
         tb->yank = new_chain_str(str);
         return;
     }

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -81,7 +81,7 @@ bool autopick_new_entry(autopick_type *entry, concptr str, bool allow_default)
         break;
     }
 
-    concptr insc = NULL;
+    concptr insc = nullptr;
     char buf[MAX_LINELEN];
     int i;
     for (i = 0; *str; i++) {
@@ -113,7 +113,7 @@ bool autopick_new_entry(autopick_type *entry, concptr str, bool allow_default)
 
     concptr prev_ptr, ptr;
     ptr = prev_ptr = buf;
-    concptr old_ptr = NULL;
+    concptr old_ptr = nullptr;
     while (old_ptr != ptr) {
         old_ptr = ptr;
         if (MATCH_KEY(KEY_ALL))
@@ -647,7 +647,7 @@ bool entry_from_choosed_object(player_type *player_ptr, autopick_type *entry)
     concptr q = _("どのアイテムを登録しますか? ", "Enter which item? ");
     concptr s = _("アイテムを持っていない。", "You have nothing to enter.");
     object_type *o_ptr;
-    o_ptr = choose_object(player_ptr, NULL, q, s, USE_INVEN | USE_FLOOR | USE_EQUIP);
+    o_ptr = choose_object(player_ptr, nullptr, q, s, USE_INVEN | USE_FLOOR | USE_EQUIP);
     if (!o_ptr)
         return false;
 

--- a/src/autopick/autopick-finder.cpp
+++ b/src/autopick/autopick-finder.cpp
@@ -58,7 +58,7 @@ bool get_object_for_search(player_type *player_ptr, object_type **o_handle, conc
     concptr q = _("どのアイテムを検索しますか? ", "Enter which item? ");
     concptr s = _("アイテムを持っていない。", "You have nothing to enter.");
     object_type *o_ptr;
-    o_ptr = choose_object(player_ptr, NULL, q, s, USE_INVEN | USE_FLOOR | USE_EQUIP);
+    o_ptr = choose_object(player_ptr, nullptr, q, s, USE_INVEN | USE_FLOOR | USE_EQUIP);
     if (!o_ptr)
         return false;
 
@@ -172,7 +172,7 @@ byte get_string_for_search(player_type *player_ptr, object_type **o_handle, conc
                 return (back ? -1 : 1);
             string_free(*search_strp);
             *search_strp = string_make(buf);
-            *o_handle = NULL;
+            *o_handle = nullptr;
             return (back ? -1 : 1);
 
         case KTRL('i'):
@@ -233,9 +233,9 @@ byte get_string_for_search(player_type *player_ptr, object_type **o_handle, conc
             c = (char)skey;
             if (color != TERM_WHITE) {
                 if (color == TERM_L_GREEN) {
-                    *o_handle = NULL;
+                    *o_handle = nullptr;
                     string_free(*search_strp);
-                    *search_strp = NULL;
+                    *search_strp = nullptr;
                 }
 
                 buf[0] = '\0';
@@ -275,13 +275,13 @@ byte get_string_for_search(player_type *player_ptr, object_type **o_handle, conc
         }
         }
 
-        if (*o_handle == NULL || color == TERM_L_GREEN)
+        if (*o_handle == nullptr || color == TERM_L_GREEN)
             continue;
 
-        *o_handle = NULL;
+        *o_handle = nullptr;
         buf[0] = '\0';
         string_free(*search_strp);
-        *search_strp = NULL;
+        *search_strp = nullptr;
     }
 }
 

--- a/src/autopick/autopick-inserter-killer.cpp
+++ b/src/autopick/autopick-inserter-killer.cpp
@@ -218,7 +218,7 @@ void kill_line_segment(text_body_type *tb, int y, int x0, int x1, bool whole)
         int i;
         for (i = y; tb->lines_list[i + 1]; i++)
             tb->lines_list[i] = tb->lines_list[i + 1];
-        tb->lines_list[i] = NULL;
+        tb->lines_list[i] = nullptr;
 
         tb->dirty_flags |= DIRTY_EXPRESSION;
 

--- a/src/autopick/autopick-menu-data-table.cpp
+++ b/src/autopick/autopick-menu-data-table.cpp
@@ -237,4 +237,4 @@ command_menu_type menu_data[MENU_DATA_NUM] = { { MN_HELP, 0, -1, EC_HELP }, { MN
 
     { MN_DELETE_CHAR, -1, 0x7F, EC_DELETE_CHAR },
 
-    { NULL, -1, -1, 0 } };
+    { nullptr, -1, -1, 0 } };

--- a/src/autopick/autopick-reader-writer.cpp
+++ b/src/autopick/autopick-reader-writer.cpp
@@ -50,7 +50,7 @@ concptr pickpref_filename(player_type *player_ptr, int filename_mode)
         return format("%s-%s.prf", namebase, player_ptr->base_name);
 
     default:
-        return NULL;
+        return nullptr;
     }
 }
 
@@ -59,7 +59,7 @@ concptr pickpref_filename(player_type *player_ptr, int filename_mode)
  */
 static concptr *read_text_lines(concptr filename)
 {
-    concptr *lines_list = NULL;
+    concptr *lines_list = nullptr;
     FILE *fff;
 
     int lines = 0;
@@ -68,7 +68,7 @@ static concptr *read_text_lines(concptr filename)
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, filename);
     fff = angband_fopen(buf, "r");
     if (!fff)
-        return NULL;
+        return nullptr;
 
     C_MAKE(lines_list, MAX_LINES, concptr);
     while (angband_fgets(fff, buf, sizeof(buf)) == 0) {
@@ -91,14 +91,14 @@ static void prepare_default_pickpref(player_type *player_ptr)
 {
     const concptr messages[] = { _("あなたは「自動拾いエディタ」を初めて起動しました。", "You have activated the Auto-Picker Editor for the first time."),
         _("自動拾いのユーザー設定ファイルがまだ書かれていないので、", "Since user pref file for autopick is not yet created,"),
-        _("基本的な自動拾い設定ファイルをlib/pref/picktype.prfからコピーします。", "the default setting is loaded from lib/pref/pickpref.prf ."), NULL };
+        _("基本的な自動拾い設定ファイルをlib/pref/picktype.prfからコピーします。", "the default setting is loaded from lib/pref/pickpref.prf ."), nullptr };
 
     concptr filename = pickpref_filename(player_ptr, PT_DEFAULT);
     for (int i = 0; messages[i]; i++) {
         msg_print(messages[i]);
     }
 
-    msg_print(NULL);
+    msg_print(nullptr);
     char buf[1024];
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, filename);
     FILE *user_fp;

--- a/src/autopick/autopick-registry.cpp
+++ b/src/autopick/autopick-registry.cpp
@@ -48,7 +48,7 @@ static bool clear_auto_register(player_type *player_ptr)
     if (!tmp_fff) {
         fclose(pref_fff);
         msg_format(_("一時ファイル %s を作成できませんでした。", "Failed to create temporary file %s."), tmp_file);
-        msg_print(NULL);
+        msg_print(nullptr);
         return false;
     }
 
@@ -174,7 +174,7 @@ bool autopick_autoregister(player_type *player_ptr, object_type *o_ptr)
     pref_fff = angband_fopen(pref_file, "a");
     if (!pref_fff) {
         msg_format(_("%s を開くことができませんでした。", "Failed to open %s."), pref_file);
-        msg_print(NULL);
+        msg_print(nullptr);
         return false;
     }
 

--- a/src/autopick/autopick-util.cpp
+++ b/src/autopick/autopick-util.cpp
@@ -15,7 +15,7 @@
  */
 int max_autopick = 0; /*!< 現在登録している自動拾い/破壊設定の数 */
 int max_max_autopick = 0; /*!< 自動拾い/破壊設定の限界数 */
-autopick_type *autopick_list = NULL; /*!< 自動拾い/破壊設定構造体のポインタ配列 */
+autopick_type *autopick_list = nullptr; /*!< 自動拾い/破壊設定構造体のポインタ配列 */
 
 /*!
  * @brief Automatically destroy an item if it is to be destroyed
@@ -32,8 +32,8 @@ void autopick_free_entry(autopick_type *entry)
 {
     string_free(entry->name);
     string_free(entry->insc);
-    entry->name = NULL;
-    entry->insc = NULL;
+    entry->name = nullptr;
+    entry->insc = nullptr;
 }
 
 /*!

--- a/src/birth/birth-util.cpp
+++ b/src/birth/birth-util.cpp
@@ -10,7 +10,7 @@
  */
 void birth_quit(void)
 {
-    quit(NULL);
+    quit(nullptr);
 }
 
 /*!
@@ -21,7 +21,7 @@ void birth_quit(void)
 void show_help(player_type* creature_ptr, concptr helpfile)
 {
     screen_save();
-    (void)show_file(creature_ptr, true, helpfile, NULL, 0, 0);
+    (void)show_file(creature_ptr, true, helpfile, nullptr, 0, 0);
     screen_load();
 }
 

--- a/src/birth/character-builder.cpp
+++ b/src/birth/character-builder.cpp
@@ -52,7 +52,7 @@ static void write_birth_diary(player_type *creature_ptr)
     message_add("  ");
 
     exe_write_diary(creature_ptr, DIARY_GAMESTART, 1, _("-------- 新規ゲーム開始 --------", "------- Started New Game -------"));
-    exe_write_diary(creature_ptr, DIARY_DIALY, 0, NULL);
+    exe_write_diary(creature_ptr, DIARY_DIALY, 0, nullptr);
     char buf[80];
     sprintf(buf, _("%s性別に%sを選択した。", "%schose %s gender."), indent, sex_info[creature_ptr->psex].title);
     exe_write_diary(creature_ptr, DIARY_DESCRIPTION, 1, buf);

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -51,7 +51,7 @@ void player_wipe_without_name(player_type *creature_ptr)
     if (creature_ptr->last_message)
         string_free(creature_ptr->last_message);
 
-    if (creature_ptr->inventory_list != NULL)
+    if (creature_ptr->inventory_list != nullptr)
         C_KILL(creature_ptr->inventory_list, INVEN_TOTAL, object_type);
 
     (void)WIPE(creature_ptr, player_type);

--- a/src/birth/inventory-initializer.cpp
+++ b/src/birth/inventory-initializer.cpp
@@ -93,7 +93,7 @@ static void decide_initial_items(player_type *creature_ptr, object_type *q_ptr)
         break;
     case player_race_type::BALROG:
         /* Demon can drain vitality from humanoid corpse */
-        get_mon_num_prep(creature_ptr, monster_hook_human, NULL);
+        get_mon_num_prep(creature_ptr, monster_hook_human, nullptr);
         for (int i = rand_range(3, 4); i > 0; i--) {
             q_ptr->prep(lookup_kind(TV_CORPSE, SV_CORPSE));
             q_ptr->pval = get_mon_num(creature_ptr, 0, 2, 0);

--- a/src/birth/quick-start.cpp
+++ b/src/birth/quick-start.cpp
@@ -38,7 +38,7 @@ bool ask_quick_start(player_type *creature_ptr)
         put_str(_("クイック・スタートを使いますか？[y/N]", "Use quick start? [y/N]"), 14, 10);
         c = inkey();
         if (c == 'Q')
-            quit(NULL);
+            quit(nullptr);
         else if (c == 'S')
             return false;
         else if (c == '?')

--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -145,7 +145,7 @@ static void natural_attack(player_type *attacker_ptr, MONSTER_IDX m_idx, MUTA at
     case MUTA::TENTACLES:
     default: {
         MonsterDamageProcessor mdp(attacker_ptr, m_idx, k, fear);
-        *mdeath = mdp.mon_take_hit(NULL);
+        *mdeath = mdp.mon_take_hit(nullptr);
         break;
     }
     }

--- a/src/cmd-action/cmd-hissatsu.cpp
+++ b/src/cmd-action/cmd-hissatsu.cpp
@@ -339,7 +339,7 @@ void do_cmd_hissatsu(player_type *creature_ptr)
             flush();
         /* Warning */
         msg_print(_("ＭＰが足りません。", "You do not have enough mana to use this power."));
-        msg_print(NULL);
+        msg_print(nullptr);
         return;
     }
 

--- a/src/cmd-action/cmd-others.cpp
+++ b/src/cmd-action/cmd-others.cpp
@@ -171,7 +171,7 @@ void do_cmd_suicide(player_type *creature_ptr)
     if (creature_ptr->last_message)
         string_free(creature_ptr->last_message);
 
-    creature_ptr->last_message = NULL;
+    creature_ptr->last_message = nullptr;
     creature_ptr->playing = false;
     creature_ptr->is_dead = true;
     creature_ptr->leaving = true;

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -345,7 +345,7 @@ static void do_name_pet(player_type *creature_ptr)
         monster_desc(creature_ptr, m_name, m_ptr, 0);
 
         msg_format(_("%sに名前をつける。", "Name %s."), m_name);
-        msg_print(NULL);
+        msg_print(nullptr);
 
         /* Start with nothing */
         strcpy(out_val, "");

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -797,7 +797,7 @@ void do_cmd_study(player_type *caster_ptr)
     msg_format("You can learn %d new %s%s.", caster_ptr->new_spells, p, (caster_ptr->new_spells == 1 ? "" : "s"));
 #endif
 
-    msg_print(NULL);
+    msg_print(nullptr);
 
     /* Restrict choices to "useful" books */
     auto item_tester = get_learnable_spellbook_tester(caster_ptr);

--- a/src/cmd-building/cmd-building.cpp
+++ b/src/cmd-building/cmd-building.cpp
@@ -83,7 +83,7 @@ bool reinit_wilderness = false;
 static void town_history(player_type *player_ptr)
 {
     screen_save();
-    (void)show_file(player_ptr, true, _("jbldg.txt", "bldg.txt"), NULL, 0, 0);
+    (void)show_file(player_ptr, true, _("jbldg.txt", "bldg.txt"), nullptr, 0, 0);
     screen_load();
 }
 
@@ -227,7 +227,7 @@ static void bldg_process_command(player_type *player_ptr, building_type *bldg, i
         }
 
         msg_print(_("治すべき突然変異が無い。", "You have no mutations."));
-        msg_print(NULL);
+        msg_print(nullptr);
         break;
     }
 

--- a/src/cmd-building/cmd-inn.cpp
+++ b/src/cmd-building/cmd-inn.cpp
@@ -44,7 +44,7 @@ static bool is_healthy_stay(player_type *customer_ptr)
 	if (!customer_ptr->poisoned && !customer_ptr->cut) return true;
 
 	msg_print(_("あなたに必要なのは部屋ではなく、治療者です。", "You need a healer, not a room."));
-	msg_print(NULL);
+	msg_print(nullptr);
 	msg_print(_("すみません、でもうちで誰かに死なれちゃ困りますんで。", "Sorry, but I don't want anyone dying in here."));
 	return false;
 }
@@ -109,7 +109,7 @@ static bool has_a_nightmare(player_type *customer_ptr)
 
 	while (true)
 	{
-		sanity_blast(customer_ptr, NULL, false);
+		sanity_blast(customer_ptr, nullptr, false);
 		if (!one_in_(3)) break;
 	}
 
@@ -200,7 +200,7 @@ static bool stay_inn(player_type *customer_ptr)
 
 	if ((prev_hour >= 18) && (prev_hour <= 23)) {
 		determine_daily_bounty(customer_ptr, false); /* Update daily bounty */
-		exe_write_diary(customer_ptr, DIARY_DIALY, 0, NULL);
+		exe_write_diary(customer_ptr, DIARY_DIALY, 0, nullptr);
 	}
 
 	customer_ptr->chp = customer_ptr->mhp;

--- a/src/cmd-io/cmd-autopick.cpp
+++ b/src/cmd-io/cmd-autopick.cpp
@@ -103,10 +103,10 @@ void do_cmd_edit_autopick(player_type *player_ptr)
 	tb->old_wid = tb->old_hgt = -1;
 	tb->old_com_id = 0;
 
-	tb->yank = NULL;
-	tb->search_o_ptr = NULL;
-	tb->search_str = NULL;
-	tb->last_destroyed = NULL;
+	tb->yank = nullptr;
+	tb->search_o_ptr = nullptr;
+	tb->search_str = nullptr;
+	tb->last_destroyed = nullptr;
 	tb->dirty_flags = DIRTY_ALL | DIRTY_MODE | DIRTY_EXPRESSION;
 	tb->dirty_line = -1;
 	tb->filename_mode = PT_DEFAULT;
@@ -207,7 +207,7 @@ void do_cmd_edit_autopick(player_type *player_ptr)
 	kill_yank_chain(tb);
 
 	process_autopick_file(player_ptr, buf);
-	current_world_ptr->start_time = (uint32_t)time(NULL);
+	current_world_ptr->start_time = (uint32_t)time(nullptr);
 	cx_save = tb->cx;
 	cy_save = tb->cy;
 }

--- a/src/cmd-io/cmd-diary.cpp
+++ b/src/cmd-io/cmd-diary.cpp
@@ -87,7 +87,7 @@ static void do_cmd_erase_diary(void)
 {
     GAME_TEXT file_name[MAX_NLEN];
     char buf[256];
-    FILE *fff = NULL;
+    FILE *fff = nullptr;
 
     if (!get_check(_("本当に記録を消去しますか？", "Do you really want to delete all your records? ")))
         return;
@@ -103,7 +103,7 @@ static void do_cmd_erase_diary(void)
         msg_format(_("%s の消去に失敗しました。", "failed to delete %s."), buf);
     }
 
-    msg_print(NULL);
+    msg_print(nullptr);
 }
 
 /*!

--- a/src/cmd-io/cmd-gameoption.cpp
+++ b/src/cmd-io/cmd-gameoption.cpp
@@ -155,7 +155,7 @@ static void do_cmd_options_autosave(player_type *player_ptr, concptr info)
         }
 
         case '?': {
-            (void)show_file(player_ptr, true, _("joption.txt#Autosave", "option.txt#Autosave"), NULL, 0, 0);
+            (void)show_file(player_ptr, true, _("joption.txt#Autosave", "option.txt#Autosave"), nullptr, 0, 0);
             term_clear();
             break;
         }
@@ -284,7 +284,7 @@ static void do_cmd_options_win(player_type *player_ptr)
             set_window_flag(x, y);
             break;
         case '?':
-            (void)show_file(player_ptr, true, _("joption.txt#Window", "option.txt#Window"), NULL, 0, 0);
+            (void)show_file(player_ptr, true, _("joption.txt#Window", "option.txt#Window"), nullptr, 0, 0);
             term_clear();
             break;
         default:
@@ -387,7 +387,7 @@ static void do_cmd_options_cheat(player_type *player_ptr, concptr info)
         }
         case '?': {
             strnfmt(buf, sizeof(buf), _("joption.txt#%s", "option.txt#%s"), cheat_info[k].o_text);
-            (void)show_file(player_ptr, true, buf, NULL, 0, 0);
+            (void)show_file(player_ptr, true, buf, nullptr, 0, 0);
             term_clear();
             break;
         }
@@ -560,7 +560,7 @@ void do_cmd_options(player_type *player_ptr)
                 if (k == ESCAPE)
                     break;
                 else if (k == '?') {
-                    (void)show_file(player_ptr, true, _("joption.txt#BaseDelay", "option.txt#BaseDelay"), NULL, 0, 0);
+                    (void)show_file(player_ptr, true, _("joption.txt#BaseDelay", "option.txt#BaseDelay"), nullptr, 0, 0);
                     term_clear();
                 } else if (isdigit(k))
                     delay_factor = D2I(k);
@@ -581,7 +581,7 @@ void do_cmd_options(player_type *player_ptr)
                 if (k == ESCAPE)
                     break;
                 else if (k == '?') {
-                    (void)show_file(player_ptr, true, _("joption.txt#Hitpoint", "option.txt#Hitpoint"), NULL, 0, 0);
+                    (void)show_file(player_ptr, true, _("joption.txt#Hitpoint", "option.txt#Hitpoint"), nullptr, 0, 0);
                     term_clear();
                 } else if (isdigit(k))
                     hitpoint_warn = D2I(k);
@@ -602,7 +602,7 @@ void do_cmd_options(player_type *player_ptr)
                 if (k == ESCAPE)
                     break;
                 else if (k == '?') {
-                    (void)show_file(player_ptr, true, _("joption.txt#Manapoint", "option.txt#Manapoint"), NULL, 0, 0);
+                    (void)show_file(player_ptr, true, _("joption.txt#Manapoint", "option.txt#Manapoint"), nullptr, 0, 0);
                     term_clear();
                 } else if (isdigit(k))
                     mana_warn = D2I(k);
@@ -613,7 +613,7 @@ void do_cmd_options(player_type *player_ptr)
             break;
         }
         case '?':
-            (void)show_file(player_ptr, true, _("joption.txt", "option.txt"), NULL, 0, 0);
+            (void)show_file(player_ptr, true, _("joption.txt", "option.txt"), nullptr, 0, 0);
             term_clear();
             break;
         default: {
@@ -727,7 +727,7 @@ void do_cmd_options_aux(player_type *player_ptr, game_option_types page, concptr
         }
         case '?': {
             strnfmt(buf, sizeof(buf), _("joption.txt#%s", "option.txt#%s"), option_info[opt[k]].o_text);
-            (void)show_file(player_ptr, true, buf, NULL, 0, 0);
+            (void)show_file(player_ptr, true, buf, nullptr, 0, 0);
             term_clear();
             break;
         }

--- a/src/cmd-io/cmd-help.cpp
+++ b/src/cmd-io/cmd-help.cpp
@@ -12,6 +12,6 @@
 void do_cmd_help(player_type *creature_ptr)
 {
 	screen_save();
-	(void)show_file(creature_ptr, true, _("jhelp.hlp", "help.hlp"), NULL, 0, 0);
+	(void)show_file(creature_ptr, true, _("jhelp.hlp", "help.hlp"), nullptr, 0, 0);
 	screen_load();
 }

--- a/src/cmd-io/cmd-macro.cpp
+++ b/src/cmd-io/cmd-macro.cpp
@@ -292,7 +292,7 @@ void do_cmd_macros(player_type *creature_ptr)
             prt(_("押すキー: ", "Keypress: "), 18, 0);
             do_cmd_macro_aux_keymap(buf);
             string_free(keymap_act[mode][(byte)(buf[0])]);
-            keymap_act[mode][(byte)(buf[0])] = NULL;
+            keymap_act[mode][(byte)(buf[0])] = nullptr;
             msg_print(_("キー配置を削除しました。", "Removed a keymap."));
         } else if (key == '0') {
             prt(_("コマンド: マクロ行動の入力", "Command: Enter a new action"), 16, 0);

--- a/src/cmd-io/cmd-process-screen.cpp
+++ b/src/cmd-io/cmd-process-screen.cpp
@@ -70,7 +70,7 @@ static void screen_dump_one_line(int wid, int y, FILE *fff)
 	char c = ' ';
 	for (TERM_LEN x = 0; x < wid - 1; x++)
 	{
-		concptr cc = NULL;
+		concptr cc = nullptr;
 		(void)(term_what(x, y, &a, &c));
 		switch (c)
 		{
@@ -132,7 +132,7 @@ static bool check_screen_html_can_open(FILE *fff, char *filename, int message)
 	if (message == 0) return false;
 
 	msg_format(_("ファイル %s を開けませんでした。", "Failed to open file %s."), filename);
-	msg_print(NULL);
+	msg_print(nullptr);
 	return false;
 }
 
@@ -204,7 +204,7 @@ void do_cmd_save_screen_html_aux(char *filename, int message)
 	if (message)
 	{
 		msg_print(_("画面(記念撮影)をファイルに書き出しました。", "Screen dump saved."));
-		msg_print(NULL);
+		msg_print(nullptr);
 	}
 
 	if (message)
@@ -224,7 +224,7 @@ static void do_cmd_save_screen_html(void)
 		return;
 	path_build(buf, sizeof(buf), ANGBAND_DIR_USER, tmp);
 
-	msg_print(NULL);
+	msg_print(nullptr);
 
 	do_cmd_save_screen_html_aux(buf, 1);
 }
@@ -272,7 +272,7 @@ static bool check_screen_text_can_open(FILE *fff, char buf[])
 	if (fff) return true;
 
 	msg_format(_("ファイル %s を開けませんでした。", "Failed to open file %s."), buf);
-	msg_print(NULL);
+	msg_print(nullptr);
 	return false;
 }
 
@@ -325,7 +325,7 @@ static bool do_cmd_save_screen_text(int wid, int hgt)
 	fprintf(fff, "\n");
 	angband_fclose(fff);
 	msg_print(_("画面(記念撮影)をファイルに書き出しました。", "Screen dump saved."));
-	msg_print(NULL);
+	msg_print(nullptr);
 	screen_load();
 	return true;
 }
@@ -464,7 +464,7 @@ void do_cmd_load_screen(void)
 	if (!fff)
 	{
 		msg_format(_("%s を開くことができませんでした。", "Failed to open %s."), buf);
-		msg_print(NULL);
+		msg_print(nullptr);
 		return;
 	}
 

--- a/src/cmd-io/cmd-save.cpp
+++ b/src/cmd-io/cmd-save.cpp
@@ -25,7 +25,7 @@ void do_cmd_save_game(player_type *creature_ptr, int is_autosave)
     else
         disturb(creature_ptr, true, true);
 
-    msg_print(NULL);
+    msg_print(nullptr);
     handle_stuff(creature_ptr);
     prt(_("ゲームをセーブしています...", "Saving game..."), 0, 0);
     term_fresh();

--- a/src/cmd-io/macro-util.cpp
+++ b/src/cmd-io/macro-util.cpp
@@ -107,7 +107,7 @@ int macro_find_ready(concptr pat)
 /*
  * Add a macro definition (or redefinition).
  *
- * We should use "act == NULL" to "remove" a macro, but this might make it
+ * We should use "act == nullptr" to "remove" a macro, but this might make it
  * impossible to save the "removal" of a macro definition.
  *
  * We should consider refusing to allow macros which contain existing macros,

--- a/src/cmd-item/cmd-destroy.cpp
+++ b/src/cmd-item/cmd-destroy.cpp
@@ -59,7 +59,7 @@ static bool check_destory_item(player_type *creature_ptr, destroy_type *destroy_
 
     describe_flavor(creature_ptr, destroy_ptr->o_name, destroy_ptr->o_ptr, OD_OMIT_PREFIX);
     sprintf(destroy_ptr->out_val, _("本当に%sを壊しますか? [y/n/Auto]", "Really destroy %s? [y/n/Auto]"), destroy_ptr->o_name);
-    msg_print(NULL);
+    msg_print(nullptr);
     message_add(destroy_ptr->out_val);
     creature_ptr->window_flags |= PW_MESSAGE;
     handle_stuff(creature_ptr);
@@ -88,7 +88,7 @@ static bool select_destroying_item(player_type *creature_ptr, destroy_type *dest
     concptr q = _("どのアイテムを壊しますか? ", "Destroy which item? ");
     concptr s = _("壊せるアイテムを持っていない。", "You have nothing to destroy.");
     destroy_ptr->o_ptr = choose_object(creature_ptr, &destroy_ptr->item, q, s, USE_INVEN | USE_FLOOR);
-    if (destroy_ptr->o_ptr == NULL)
+    if (destroy_ptr->o_ptr == nullptr)
         return false;
 
     if (!check_destory_item(creature_ptr, destroy_ptr))
@@ -97,7 +97,7 @@ static bool select_destroying_item(player_type *creature_ptr, destroy_type *dest
     if (destroy_ptr->o_ptr->number <= 1)
         return true;
 
-    destroy_ptr->amt = get_quantity(NULL, destroy_ptr->o_ptr->number);
+    destroy_ptr->amt = get_quantity(nullptr, destroy_ptr->o_ptr->number);
     return destroy_ptr->amt > 0;
 }
 

--- a/src/cmd-item/cmd-item.cpp
+++ b/src/cmd-item/cmd-item.cpp
@@ -123,7 +123,7 @@ void do_cmd_drop(player_type *creature_ptr)
     }
 
     if (o_ptr->number > 1) {
-        amt = get_quantity(NULL, o_ptr->number);
+        amt = get_quantity(nullptr, o_ptr->number);
         if (amt <= 0)
             return;
     }
@@ -207,7 +207,7 @@ void do_cmd_inscribe(player_type *creature_ptr)
 
     describe_flavor(creature_ptr, o_name, o_ptr, OD_OMIT_INSCRIPTION);
     msg_format(_("%sに銘を刻む。", "Inscribing %s."), o_name);
-    msg_print(NULL);
+    msg_print(nullptr);
     strcpy(out_val, "");
     if (o_ptr->inscription)
         strcpy(out_val, quark_str(o_ptr->inscription));

--- a/src/cmd-item/cmd-magiceat.cpp
+++ b/src/cmd-item/cmd-magiceat.cpp
@@ -441,7 +441,7 @@ static OBJECT_SUBTYPE_VALUE select_magic_eater(player_type *creature_ptr, bool o
             if (tval == TV_ROD) {
                 if (creature_ptr->magic_num1[ext + i] > k_info[lookup_kind(tval, i)].pval * (creature_ptr->magic_num2[ext + i] - 1) * EATER_ROD_CHARGE) {
                     msg_print(_("その魔法はまだ充填している最中だ。", "The magic is still charging."));
-                    msg_print(NULL);
+                    msg_print(nullptr);
                     if (use_menu)
                         ask = true;
                     continue;
@@ -449,7 +449,7 @@ static OBJECT_SUBTYPE_VALUE select_magic_eater(player_type *creature_ptr, bool o
             } else {
                 if (creature_ptr->magic_num1[ext + i] < EATER_CHARGE) {
                     msg_print(_("その魔法は使用回数が切れている。", "The magic has no charges left."));
-                    msg_print(NULL);
+                    msg_print(nullptr);
                     if (use_menu)
                         ask = true;
                     continue;

--- a/src/cmd-item/cmd-smith.cpp
+++ b/src/cmd-item/cmd-smith.cpp
@@ -98,7 +98,7 @@ static essence_type essence_info[] = { { TR_STR, "腕力", 4, TR_STR, 20 }, { TR
     { ESSENCE_SH_COLD, "冷気オーラ", 7, -1, 50 }, { ESSENCE_RESISTANCE, "全耐性", 2, -1, 150 }, { ESSENCE_SUSTAIN, "装備保持", 10, -1, 10 },
     { ESSENCE_SLAY_GLOVE, "殺戮の小手", 1, TR_ES_ATTACK, 200 },
 
-    { -1, NULL, 0, -1, 0 } };
+    { -1, nullptr, 0, -1, 0 } };
 #else
 static essence_type essence_info[] = { { TR_STR, "strength", 4, TR_STR, 20 }, { TR_INT, "intelligence", 4, TR_INT, 20 }, { TR_WIS, "wisdom", 4, TR_WIS, 20 },
     { TR_DEX, "dexterity", 4, TR_DEX, 20 }, { TR_CON, "constitution", 4, TR_CON, 20 }, { TR_CHR, "charisma", 4, TR_CHR, 20 },
@@ -150,7 +150,7 @@ static essence_type essence_info[] = { { TR_STR, "strength", 4, TR_STR, 20 }, { 
     { ESSENCE_RESISTANCE, "resistance", 2, -1, 150 }, { ESSENCE_SUSTAIN, "elements proof", 10, -1, 10 },
     { ESSENCE_SLAY_GLOVE, "gauntlets of slaying", 1, TR_ES_ATTACK, 200 },
 
-    { -1, NULL, 0, -1, 0 } };
+    { -1, nullptr, 0, -1, 0 } };
 #endif
 
 /*!
@@ -164,7 +164,7 @@ concptr essence_name[] = { "腕力", "知能", "賢さ", "器用さ", "耐久力
     "", "", "反魔法", "", "", "警告", "", "", "", "浮遊", "永久光源", "可視透明", "テレパシー", "遅消化", "急速回復", "", "", "", "", "", "", "", "",
     "テレポート", "", "", "攻撃", "防御",
 
-    NULL };
+    nullptr };
 
 #else
 
@@ -176,7 +176,7 @@ concptr essence_name[] = { "strength", "intelligen.", "wisdom", "dexterity", "co
     "", "anti magic", "", "", "warning", "", "", "", "levitation", "perm. light", "see invis.", "telepathy", "slow dige.", "regen.", "", "", "", "", "", "", "",
     "", "teleport", "", "", "weapon enc.", "armor enc.",
 
-    NULL };
+    nullptr };
 #endif
 
 static concptr const kaji_tips[5] = {
@@ -435,7 +435,7 @@ static void drain_essence(player_type *creature_ptr)
 
             creature_ptr->magic_num1[i] += drain_value[i];
             creature_ptr->magic_num1[i] = MIN(20000, creature_ptr->magic_num1[i]);
-            msg_print(NULL);
+            msg_print(nullptr);
             msg_format("%s...%d%s", essence_name[i], drain_value[i], _("。", ". "));
         }
     }

--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -162,7 +162,7 @@ void do_cmd_messages(int num_now)
 	char shower_str[81];
 	char finder_str[81];
 	char back_str[81];
-	concptr shower = NULL;
+	concptr shower = nullptr;
 	int wid, hgt;
 	term_get_size(&wid, &hgt);
 	int num_lines = hgt - 4;
@@ -183,7 +183,7 @@ void do_cmd_messages(int num_now)
 			if (!shower || !shower[0]) continue;
 
 			concptr str = msg;
-			while ((str = angband_strstr(str, shower)) != NULL)
+			while ((str = angband_strstr(str, shower)) != nullptr)
 			{
 				int len = strlen(shower);
 				term_putstr(str - msg, num_lines + 1 - j, len, TERM_YELLOW, shower);
@@ -208,7 +208,7 @@ void do_cmd_messages(int num_now)
 			prt(_("強調: ", "Show: "), hgt - 1, 0);
 			strcpy(back_str, shower_str);
 			if (askfor(shower_str, 80))
-				shower = shower_str[0] ? shower_str : NULL;
+				shower = shower_str[0] ? shower_str : nullptr;
 			else
 				strcpy(shower_str, back_str);
 
@@ -225,7 +225,7 @@ void do_cmd_messages(int num_now)
 			}
 			else if (!finder_str[0])
 			{
-				shower = NULL;
+				shower = nullptr;
 				continue;
 			}
 

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -40,7 +40,7 @@ static bool cmd_visuals_aux(int i, IDX *num, IDX max)
         if (!get_string(format("Input new number(0-%d): ", max - 1), str, 4))
             return false;
 
-        IDX tmp = (IDX)strtol(str, NULL, 0);
+        IDX tmp = (IDX)strtol(str, nullptr, 0);
         if (tmp >= 0 && tmp < max)
             *num = tmp;
     } else if (isupper(i))
@@ -88,7 +88,7 @@ void do_cmd_visuals(player_type *creature_ptr)
     screen_save();
     while (true) {
         term_clear();
-        print_visuals_menu(NULL);
+        print_visuals_menu(nullptr);
         int i = inkey();
         if (i == ESCAPE)
             break;

--- a/src/core/asking-player.cpp
+++ b/src/core/asking-player.cpp
@@ -214,7 +214,7 @@ bool askfor(char *buf, int len) { return askfor_aux(buf, len, true); }
 bool get_string(concptr prompt, char *buf, int len)
 {
     bool res;
-    msg_print(NULL);
+    msg_print(nullptr);
     prt(prompt, 0, 0);
     res = askfor(buf, len);
     prt("", 0, 0);
@@ -261,7 +261,7 @@ bool get_check_strict(player_type *player_ptr, concptr prompt, BIT_FLAGS mode)
         num_more = 0;
     }
 
-    msg_print(NULL);
+    msg_print(nullptr);
 
     prt(buf, 0, 0);
     if (!(mode & CHECK_NO_HISTORY) && player_ptr->playing) {
@@ -320,7 +320,7 @@ bool get_check_strict(player_type *player_ptr, concptr prompt, BIT_FLAGS mode)
  */
 bool get_com(concptr prompt, char *command, bool z_escape)
 {
-    msg_print(NULL);
+    msg_print(nullptr);
     prt(prompt, 0, 0);
     if (get_com_no_macros)
         *command = (char)inkey_special(false);
@@ -377,7 +377,7 @@ QUANTITY get_quantity(concptr prompt, QUANTITY max)
         prompt = tmp;
     }
 
-    msg_print(NULL);
+    msg_print(nullptr);
     prt(prompt, 0, 0);
     amt = 1;
     sprintf(buf, "%d", amt);

--- a/src/core/game-closer.cpp
+++ b/src/core/game-closer.cpp
@@ -143,7 +143,7 @@ void close_game(player_type *player_ptr)
 {
     bool do_send = true;
     handle_stuff(player_ptr);
-    msg_print(NULL);
+    msg_print(nullptr);
     flush();
     signals_ignore_tstp();
 
@@ -178,7 +178,7 @@ void close_game(player_type *player_ptr)
         if (!player_ptr->wait_report_score)
             (void)top_twenty(player_ptr);
     } else if (highscore_fd >= 0) {
-        display_scores(0, 10, -1, NULL);
+        display_scores(0, 10, -1, nullptr);
     }
 
     clear_floor(player_ptr);

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -119,7 +119,7 @@ static void send_waiting_record(player_type *player_ptr)
     player_ptr->update |= (PU_BONUS | PU_HP | PU_MANA | PU_SPELLS);
     update_creature(player_ptr);
     player_ptr->is_dead = true;
-    current_world_ptr->start_time = (uint32_t)time(NULL);
+    current_world_ptr->start_time = (uint32_t)time(nullptr);
     signals_ignore_tstp();
     current_world_ptr->character_icky_depth = 1;
     path_build(buf, sizeof(buf), ANGBAND_DIR_APEX, "scores.raw");
@@ -213,7 +213,7 @@ static void reset_world_info(player_type *player_ptr)
     current_world_ptr->timewalk_m_idx = 0;
     player_ptr->now_damaged = false;
     now_message = 0;
-    current_world_ptr->start_time = time(NULL) - 1;
+    current_world_ptr->start_time = time(nullptr) - 1;
     record_o_name[0] = '\0';
 }
 
@@ -381,7 +381,7 @@ static void process_game_turn(player_type *player_ptr)
         if (!player_ptr->is_dead)
             wipe_monsters_list(player_ptr);
 
-        msg_print(NULL);
+        msg_print(nullptr);
         load_game = false;
         decide_arena_death(player_ptr);
         if (player_ptr->is_dead)
@@ -442,5 +442,5 @@ void play_game(player_type *player_ptr, bool new_game, bool browsing_movie)
     select_floor_music(player_ptr);
     process_game_turn(player_ptr);
     close_game(player_ptr);
-    quit(NULL);
+    quit(nullptr);
 }

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -65,12 +65,12 @@ static void process_fishing(player_type *creature_ptr)
     if (one_in_(1000)) {
         MONRACE_IDX r_idx;
         bool success = false;
-        get_mon_num_prep(creature_ptr, monster_is_fishing_target, NULL);
+        get_mon_num_prep(creature_ptr, monster_is_fishing_target, nullptr);
         r_idx = get_mon_num(creature_ptr, 0,
             is_in_dungeon(creature_ptr) ? creature_ptr->current_floor_ptr->dun_level
                                                        : wilderness[creature_ptr->wilderness_y][creature_ptr->wilderness_x].level,
             0);
-        msg_print(NULL);
+        msg_print(nullptr);
         if (r_idx && one_in_(2)) {
             POSITION y, x;
             y = creature_ptr->y + ddy[creature_ptr->fishing_dir];
@@ -385,7 +385,7 @@ void process_player(player_type *creature_ptr)
                 creature_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
 
                 msg_print(_("「時は動きだす…」", "You feel time flowing around you once more."));
-                msg_print(NULL);
+                msg_print(nullptr);
                 creature_ptr->timewalk = false;
                 creature_ptr->energy_need = ENERGY_NEED();
 

--- a/src/core/scores.cpp
+++ b/src/core/scores.cpp
@@ -270,13 +270,13 @@ errr top_twenty(player_type *current_player_ptr)
 
     /* Hack -- Display the top fifteen scores */
     if (j < 10) {
-        display_scores(0, 15, j, NULL);
+        display_scores(0, 15, j, nullptr);
         return 0;
     }
 
     /* Display the scores surrounding the player */
-    display_scores(0, 5, j, NULL);
-    display_scores(j - 2, j + 7, j, NULL);
+    display_scores(0, 5, j, nullptr);
+    display_scores(j - 2, j + 7, j, nullptr);
     return 0;
 }
 
@@ -293,7 +293,7 @@ errr predict_score(player_type *current_player_ptr)
     /* No score file */
     if (highscore_fd < 0) {
         msg_print(_("スコア・ファイルが使用できません。", "Score file unavailable."));
-        msg_print(NULL);
+        msg_print(nullptr);
         return 0;
     }
 
@@ -344,7 +344,7 @@ errr predict_score(player_type *current_player_ptr)
         return 0;
     }
 
-    display_scores(0, 5, -1, NULL);
+    display_scores(0, 5, -1, nullptr);
     display_scores(j - 2, j + 7, j, &the_score);
     return 0;
 }
@@ -363,7 +363,7 @@ void show_highclass(player_type *current_player_ptr)
 
     if (highscore_fd < 0) {
         msg_print(_("スコア・ファイルが使用できません。", "Score file unavailable."));
-        msg_print(NULL);
+        msg_print(nullptr);
         return;
     }
 
@@ -441,7 +441,7 @@ void race_score(player_type *current_player_ptr, int race_num)
 
     if (highscore_fd < 0) {
         msg_print(_("スコア・ファイルが使用できません。", "Score file unavailable."));
-        msg_print(NULL);
+        msg_print(nullptr);
         return;
     }
 
@@ -502,7 +502,7 @@ void race_legends(player_type *current_player_ptr)
     for (int i = 0; i < MAX_RACES; i++) {
         race_score(current_player_ptr, i);
         msg_print(_("何かキーを押すとゲームに戻ります", "Hit any key to continue"));
-        msg_print(NULL);
+        msg_print(nullptr);
         for (int j = 5; j < 19; j++)
             prt("", j, 0);
     }
@@ -519,35 +519,35 @@ bool check_score(player_type *current_player_ptr)
     /* No score file */
     if (highscore_fd < 0) {
         msg_print(_("スコア・ファイルが使用できません。", "Score file unavailable."));
-        msg_print(NULL);
+        msg_print(nullptr);
         return false;
     }
 
     /* Wizard-mode pre-empts scoring */
     if (current_world_ptr->noscore & 0x000F) {
         msg_print(_("ウィザード・モードではスコアが記録されません。", "Score not registered for wizards."));
-        msg_print(NULL);
+        msg_print(nullptr);
         return false;
     }
 
     /* Cheaters are not scored */
     if (current_world_ptr->noscore & 0xFF00) {
         msg_print(_("詐欺をやった人はスコアが記録されません。", "Score not registered for cheaters."));
-        msg_print(NULL);
+        msg_print(nullptr);
         return false;
     }
 
     /* Interupted */
     if (!current_world_ptr->total_winner && streq(current_player_ptr->died_from, _("強制終了", "Interrupting"))) {
         msg_print(_("強制終了のためスコアが記録されません。", "Score not registered due to interruption."));
-        msg_print(NULL);
+        msg_print(nullptr);
         return false;
     }
 
     /* Quitter */
     if (!current_world_ptr->total_winner && streq(current_player_ptr->died_from, _("途中終了", "Quitting"))) {
         msg_print(_("途中終了のためスコアが記録されません。", "Score not registered due to quitting."));
-        msg_print(NULL);
+        msg_print(nullptr);
         return false;
     }
     return true;

--- a/src/core/show-file.cpp
+++ b/src/core/show-file.cpp
@@ -41,7 +41,7 @@ static void show_file_aux_line(concptr str, int cy, concptr shower)
         str_tolower(lcstr);
 
         ptr = angband_strstr(lcstr, shower);
-        textcolor = (ptr == NULL) ? TERM_L_DARK : TERM_WHITE;
+        textcolor = (ptr == nullptr) ? TERM_L_DARK : TERM_WHITE;
     }
 
     int cx = 0;
@@ -148,7 +148,7 @@ bool show_file(player_type *creature_ptr, bool show_version, concptr name, concp
     strcpy(filename, name);
     int n = strlen(filename);
 
-    concptr tag = NULL;
+    concptr tag = nullptr;
     for (int i = 0; i < n; i++) {
         if (filename[i] == '#') {
             filename[i] = '\0';
@@ -158,7 +158,7 @@ bool show_file(player_type *creature_ptr, bool show_version, concptr name, concp
     }
 
     name = filename;
-    FILE *fff = NULL;
+    FILE *fff = nullptr;
     char path[1024];
     if (what) {
         strcpy(caption, what);
@@ -191,7 +191,7 @@ bool show_file(player_type *creature_ptr, bool show_version, concptr name, concp
 
     if (!fff) {
         msg_format(_("'%s'をオープンできません。", "Cannot open '%s'."), name);
-        msg_print(NULL);
+        msg_print(nullptr);
 
         return true;
     }
@@ -241,8 +241,8 @@ bool show_file(player_type *creature_ptr, bool show_version, concptr name, concp
 
     term_clear();
 
-    concptr find = NULL;
-    concptr shower = NULL;
+    concptr find = nullptr;
+    concptr shower = nullptr;
     while (true) {
         if (line >= size - rows)
               line = size - rows;
@@ -284,7 +284,7 @@ bool show_file(player_type *creature_ptr, bool show_version, concptr name, concp
                     continue;
             }
 
-            find = NULL;
+            find = nullptr;
             show_file_aux_line(str, row_count + 2, shower);
             row_count++;
         }
@@ -297,7 +297,7 @@ bool show_file(player_type *creature_ptr, bool show_version, concptr name, concp
         if (find) {
             bell();
             line = back;
-            find = NULL;
+            find = nullptr;
             continue;
         }
 
@@ -330,7 +330,7 @@ bool show_file(player_type *creature_ptr, bool show_version, concptr name, concp
         switch (skey) {
         case '?':
             if (strcmp(name, _("jhelpinfo.txt", "helpinfo.txt")) != 0)
-                show_file(creature_ptr, true, _("jhelpinfo.txt", "helpinfo.txt"), NULL, 0, mode);
+                show_file(creature_ptr, true, _("jhelpinfo.txt", "helpinfo.txt"), nullptr, 0, mode);
             break;
         case '=':
             prt(_("強調: ", "Show: "), hgt - 1, 0);
@@ -342,7 +342,7 @@ bool show_file(player_type *creature_ptr, bool show_version, concptr name, concp
                     str_tolower(shower_str);
                     shower = shower_str;
                 } else
-                    shower = NULL;
+                    shower = nullptr;
             } else
                 strcpy(shower_str, back_str);
             break;
@@ -359,7 +359,7 @@ bool show_file(player_type *creature_ptr, bool show_version, concptr name, concp
                     str_tolower(finder_str);
                     shower = finder_str;
                 } else
-                    shower = NULL;
+                    shower = nullptr;
             } else
                 strcpy(finder_str, back_str);
             break;
@@ -388,7 +388,7 @@ bool show_file(player_type *creature_ptr, bool show_version, concptr name, concp
             strcpy(tmp, _("jhelp.hlp", "help.hlp"));
 
             if (askfor(tmp, 80)) {
-                if (!show_file(creature_ptr, true, tmp, NULL, 0, mode))
+                if (!show_file(creature_ptr, true, tmp, nullptr, 0, mode))
                     skey = 'q';
             }
 
@@ -444,7 +444,7 @@ bool show_file(player_type *creature_ptr, bool show_version, concptr name, concp
 
             if ((key > -1) && hook[key][0]) {
                 /* Recurse on that file */
-                if (!show_file(creature_ptr, true, hook[key], NULL, 0, mode))
+                if (!show_file(creature_ptr, true, hook[key], nullptr, 0, mode))
                     skey = 'q';
             }
         }

--- a/src/core/window-redrawer.cpp
+++ b/src/core/window-redrawer.cpp
@@ -74,7 +74,7 @@ void redraw_stuff(player_type *creature_ptr)
 
     if (creature_ptr->redraw & (PR_WIPE)) {
         creature_ptr->redraw &= ~(PR_WIPE);
-        msg_print(NULL);
+        msg_print(nullptr);
         term_clear();
     }
 

--- a/src/dungeon/dungeon-processor.cpp
+++ b/src/dungeon/dungeon-processor.cpp
@@ -87,7 +87,7 @@ void process_dungeon(player_type *player_ptr, bool load_game)
     if ((max_dlv[player_ptr->dungeon_idx] < floor_ptr->dun_level) && !floor_ptr->inside_quest) {
         max_dlv[player_ptr->dungeon_idx] = floor_ptr->dun_level;
         if (record_maxdepth)
-            exe_write_diary(player_ptr, DIARY_MAXDEAPTH, floor_ptr->dun_level, NULL);
+            exe_write_diary(player_ptr, DIARY_MAXDEAPTH, floor_ptr->dun_level, nullptr);
     }
 
     (void)calculate_upkeep(player_ptr);
@@ -117,7 +117,7 @@ void process_dungeon(player_type *player_ptr, bool load_game)
             update_gambling_monsters(player_ptr);
         } else {
             msg_print(_("試合開始！", "Ready..Fight!"));
-            msg_print(NULL);
+            msg_print(nullptr);
         }
     }
 

--- a/src/dungeon/dungeon.cpp
+++ b/src/dungeon/dungeon.cpp
@@ -44,7 +44,7 @@ DUNGEON_IDX choose_dungeon(concptr note, POSITION y, POSITION x)
 		else
 		{
                     msg_format(_("まだ%sに入ったことはない。", "You haven't entered %s yet."), d_info[DUNGEON_ANGBAND].name.c_str());
-			msg_print(NULL);
+			msg_print(nullptr);
 			return 0;
 		}
 	}

--- a/src/dungeon/quest.cpp
+++ b/src/dungeon/quest.cpp
@@ -59,7 +59,7 @@ static concptr find_quest[] = {
  */
 void determine_random_questor(player_type *player_ptr, quest_type *q_ptr)
 {
-    get_mon_num_prep(player_ptr, mon_hook_quest, NULL);
+    get_mon_num_prep(player_ptr, mon_hook_quest, nullptr);
 
     MONRACE_IDX r_idx;
     while (true) {
@@ -125,11 +125,11 @@ void complete_quest(player_type *player_ptr, QUEST_IDX quest_num)
     switch (q_ptr->type) {
     case QUEST_TYPE_RANDOM:
         if (record_rand_quest)
-            exe_write_diary(player_ptr, DIARY_RAND_QUEST_C, quest_num, NULL);
+            exe_write_diary(player_ptr, DIARY_RAND_QUEST_C, quest_num, nullptr);
         break;
     default:
         if (record_fix_quest)
-            exe_write_diary(player_ptr, DIARY_FIX_QUEST_C, quest_num, NULL);
+            exe_write_diary(player_ptr, DIARY_FIX_QUEST_C, quest_num, nullptr);
         break;
     }
 
@@ -140,7 +140,7 @@ void complete_quest(player_type *player_ptr, QUEST_IDX quest_num)
 
     play_music(TERM_XTRA_MUSIC_BASIC, MUSIC_BASIC_QUEST_CLEAR);
     msg_print(_("クエストを達成した！", "You just completed your quest!"));
-    msg_print(NULL);
+    msg_print(nullptr);
 }
 
 /*!
@@ -176,7 +176,7 @@ void quest_discovery(QUEST_IDX q_idx)
     strcpy(name, (r_ptr->name.c_str()));
 
     msg_print(find_quest[rand_range(0, 4)]);
-    msg_print(NULL);
+    msg_print(nullptr);
 
     if (q_num != 1) {
 #ifdef JP
@@ -281,12 +281,12 @@ void leave_quest_check(player_type *player_ptr)
     /* Record finishing a quest */
     if (q_ptr->type == QUEST_TYPE_RANDOM) {
         if (record_rand_quest)
-            exe_write_diary(player_ptr, DIARY_RAND_QUEST_F, leaving_quest, NULL);
+            exe_write_diary(player_ptr, DIARY_RAND_QUEST_F, leaving_quest, nullptr);
         return;
     }
 
     if (record_fix_quest)
-        exe_write_diary(player_ptr, DIARY_FIX_QUEST_F, leaving_quest, NULL);
+        exe_write_diary(player_ptr, DIARY_FIX_QUEST_F, leaving_quest, nullptr);
 }
 
 /*!

--- a/src/effect/effect-feature.cpp
+++ b/src/effect/effect-feature.cpp
@@ -115,7 +115,7 @@ bool affect_feature(player_type *caster_ptr, MONSTER_IDX who, POSITION r, POSITI
             message = _("消滅した", "vanished.");
             break;
         default:
-            message = NULL;
+            message = nullptr;
             break;
         }
 

--- a/src/effect/effect-item.cpp
+++ b/src/effect/effect-item.cpp
@@ -59,7 +59,7 @@ bool affect_item(player_type *caster_ptr, MONSTER_IDX who, POSITION r, POSITION 
         object_type *o_ptr = &caster_ptr->current_floor_ptr->o_list[this_o_idx];
         bool ignore = false;
         bool do_kill = false;
-        concptr note_kill = NULL;
+        concptr note_kill = nullptr;
 
 #ifdef JP
 #else

--- a/src/effect/effect-monster-charm.cpp
+++ b/src/effect/effect-monster-charm.cpp
@@ -238,7 +238,7 @@ static void effect_monster_domination_corrupted(player_type *caster_ptr, effect_
         return;
     }
 
-    em_ptr->note = NULL;
+    em_ptr->note = nullptr;
     msg_format(_("%^sの堕落した精神は攻撃を跳ね返した！",
                    (em_ptr->seen ? "%^s's corrupted mind backlashes your attack!" : "%^ss corrupted mind backlashes your attack!")),
         em_ptr->m_name);

--- a/src/effect/effect-monster-psi.cpp
+++ b/src/effect/effect-monster-psi.cpp
@@ -78,7 +78,7 @@ static bool reflects_psi_with_currupted_mind(player_type *caster_ptr, effect_mon
     if (!is_corrupted)
         return false;
 
-    em_ptr->note = NULL;
+    em_ptr->note = nullptr;
     msg_format(_("%^sの堕落した精神は攻撃を跳ね返した！",
                    (em_ptr->seen ? "%^s's corrupted mind backlashes your attack!" : "%^ss corrupted mind backlashes your attack!")),
         em_ptr->m_name);

--- a/src/effect/effect-monster-util.cpp
+++ b/src/effect/effect-monster-util.cpp
@@ -61,7 +61,7 @@ effect_monster_type *initialize_effect_monster(player_type *caster_ptr, effect_m
 	floor_type *floor_ptr = caster_ptr->current_floor_ptr;
 	em_ptr->g_ptr = &floor_ptr->grid_array[em_ptr->y][em_ptr->x];
 	em_ptr->m_ptr = &floor_ptr->m_list[em_ptr->g_ptr->m_idx];
-	em_ptr->m_caster_ptr = (em_ptr->who > 0) ? &floor_ptr->m_list[em_ptr->who] : NULL;
+	em_ptr->m_caster_ptr = (em_ptr->who > 0) ? &floor_ptr->m_list[em_ptr->who] : nullptr;
 	em_ptr->r_ptr = &r_info[em_ptr->m_ptr->r_idx];
 	em_ptr->seen = em_ptr->m_ptr->ml;
         em_ptr->seen_msg = is_seen(caster_ptr, em_ptr->m_ptr);
@@ -79,7 +79,7 @@ effect_monster_type *initialize_effect_monster(player_type *caster_ptr, effect_m
 	em_ptr->do_time = 0;
 	em_ptr->heal_leper = false;
 	em_ptr->photo = 0;
-	em_ptr->note = NULL;
+	em_ptr->note = nullptr;
 	em_ptr->note_dies = extract_note_dies(real_r_idx(em_ptr->m_ptr));
 	em_ptr->caster_lev = (em_ptr->who > 0) ? r_info[em_ptr->m_caster_ptr->r_idx].level : (caster_ptr->lev * 2);
 	return em_ptr;

--- a/src/effect/effect-player-oldies.cpp
+++ b/src/effect/effect-player-oldies.cpp
@@ -47,7 +47,7 @@ void effect_player_old_sleep(player_type *target_ptr, effect_player_type *ep_ptr
         msg_print(_("恐ろしい光景が頭に浮かんできた。", "A horrible vision enters your mind."));
 
         /* Have some nightmares */
-        sanity_blast(target_ptr, NULL, false);
+        sanity_blast(target_ptr, nullptr, false);
     }
 
     set_paralyzed(target_ptr, target_ptr->paralyzed + ep_ptr->dam);

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -415,7 +415,7 @@ void effect_player_dark(player_type *target_ptr, effect_player_type *ep_ptr)
 static void effect_player_time_one_disability(player_type *target_ptr)
 {
     int k = 0;
-    concptr act = NULL;
+    concptr act = nullptr;
     switch (randint1(6)) {
     case 1:
         k = A_STR;

--- a/src/effect/effect-player.cpp
+++ b/src/effect/effect-player.cpp
@@ -165,7 +165,7 @@ enum ep_check_result {
 static effect_player_type *initialize_effect_player(effect_player_type *ep_ptr, MONSTER_IDX who, HIT_POINT dam, EFFECT_ID effect_type, BIT_FLAGS flag)
 {
     ep_ptr->rlev = 0;
-    ep_ptr->m_ptr = NULL;
+    ep_ptr->m_ptr = nullptr;
     ep_ptr->get_damage = 0;
     ep_ptr->who = who;
     ep_ptr->dam = dam;

--- a/src/flavor/flag-inscriptions-table.cpp
+++ b/src/flavor/flag-inscriptions-table.cpp
@@ -9,7 +9,7 @@
 
 /*! @brief アイテムの価値記述テーブル */
 const concptr game_inscriptions[MAX_GAME_INSCRIPTIONS] = {
-    NULL, /* FEEL_NONE */
+    nullptr, /* FEEL_NONE */
     _("壊れている", "broken"), /* FEEL_BROKEN */
     _("恐ろしい", "terrible"), /* FEEL_TERRIBLE */
     _("無価値", "worthless"), /* FEEL_WORTHLESS */

--- a/src/flavor/named-item-describer.cpp
+++ b/src/flavor/named-item-describer.cpp
@@ -318,10 +318,10 @@ static void describe_artifact_body_en(flavor_type *flavor_ptr)
  */
 static void describe_inscription(flavor_type *flavor_ptr)
 {
-    for (flavor_ptr->s0 = NULL; *flavor_ptr->s || flavor_ptr->s0;) {
+    for (flavor_ptr->s0 = nullptr; *flavor_ptr->s || flavor_ptr->s0;) {
         if (!*flavor_ptr->s) {
             flavor_ptr->s = flavor_ptr->s0 + 1;
-            flavor_ptr->s0 = NULL;
+            flavor_ptr->s0 = nullptr;
         } else if ((*flavor_ptr->s == '#') && !flavor_ptr->s0) {
             flavor_ptr->s0 = flavor_ptr->s;
             flavor_ptr->s = flavor_ptr->modstr;

--- a/src/floor/cave-generator.cpp
+++ b/src/floor/cave-generator.cpp
@@ -383,7 +383,7 @@ bool cave_gen(player_type *player_ptr, concptr *why)
     floor_type *floor_ptr = player_ptr->current_floor_ptr;
     reset_lite_area(floor_ptr);
     set_floor_and_wall(floor_ptr->dungeon_idx);
-    get_mon_num_prep(player_ptr, get_monster_hook(player_ptr), NULL);
+    get_mon_num_prep(player_ptr, get_monster_hook(player_ptr), nullptr);
 
     dun_data_type tmp_dd;
     dun_data_type *dd_ptr = initialize_dun_data_type(&tmp_dd, why);

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -251,9 +251,9 @@ static void generate_fixed_floor(player_type *player_ptr)
     floor_ptr->object_level = floor_ptr->base_level;
     floor_ptr->monster_level = floor_ptr->base_level;
     if (record_stair)
-        exe_write_diary(player_ptr, DIARY_TO_QUEST, floor_ptr->inside_quest, NULL);
+        exe_write_diary(player_ptr, DIARY_TO_QUEST, floor_ptr->inside_quest, nullptr);
 
-    get_mon_num_prep(player_ptr, get_monster_hook(player_ptr), NULL);
+    get_mon_num_prep(player_ptr, get_monster_hook(player_ptr), nullptr);
     init_flags = INIT_CREATE_DUNGEON;
     parse_fixed_map(player_ptr, "q_info.txt", 0, 0, MAX_HGT, MAX_WID);
 }
@@ -460,7 +460,7 @@ void generate_floor(player_type *player_ptr)
     set_floor_and_wall(floor_ptr->dungeon_idx);
     for (int num = 0; true; num++) {
         bool okay = true;
-        concptr why = NULL;
+        concptr why = nullptr;
         clear_cave(player_ptr);
         player_ptr->x = player_ptr->y = 0;
         if (floor_ptr->inside_arena)

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -360,7 +360,7 @@ static void refresh_new_floor_id(player_type *creature_ptr, grid_type *g_ptr)
         return;
 
     new_floor_id = get_new_floor_id(creature_ptr);
-    if ((g_ptr != NULL) && !feat_uses_special(g_ptr->feat))
+    if ((g_ptr != nullptr) && !feat_uses_special(g_ptr->feat))
         g_ptr->special = new_floor_id;
 }
 
@@ -377,7 +377,7 @@ static void update_upper_lower_or_floor_id(player_type *creature_ptr, saved_floo
 
 static void exe_leave_floor(player_type *creature_ptr, saved_floor_type *sf_ptr)
 {
-    grid_type *g_ptr = NULL;
+    grid_type *g_ptr = nullptr;
     set_grid_by_leaving_floor(creature_ptr, &g_ptr);
     jump_floors(creature_ptr);
     exit_to_wilderness(creature_ptr);
@@ -440,7 +440,7 @@ void jump_floor(player_type *creature_ptr, DUNGEON_IDX dun_idx, DEPTH depth)
     creature_ptr->wild_mode = false;
     leave_quest_check(creature_ptr);
     if (record_stair)
-        exe_write_diary(creature_ptr, DIARY_WIZ_TELE, 0, NULL);
+        exe_write_diary(creature_ptr, DIARY_WIZ_TELE, 0, nullptr);
 
     creature_ptr->current_floor_ptr->inside_quest = 0;
     PlayerEnergy(creature_ptr).reset_player_turn();

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -110,7 +110,7 @@ bool make_object(player_type *owner_ptr, object_type *j_ptr, BIT_FLAGS mode)
 
         k_idx = get_obj_num(owner_ptr, base, mode);
         if (get_obj_num_hook) {
-            get_obj_num_hook = NULL;
+            get_obj_num_hook = nullptr;
             get_obj_num_prep();
         }
 
@@ -593,13 +593,13 @@ object_type *choose_object(player_type *owner_ptr, OBJECT_IDX *idx, concptr q, c
     FixItemTesterSetter setter(item_tester);
 
     if (!get_item(owner_ptr, &item, q, s, option, item_tester))
-        return NULL;
+        return nullptr;
 
     if (idx)
         *idx = item;
 
     if (item == INVEN_FORCE)
-        return NULL;
+        return nullptr;
 
     return ref_item(owner_ptr, item);
 }

--- a/src/floor/floor-save.cpp
+++ b/src/floor/floor-save.cpp
@@ -70,7 +70,7 @@ void init_saved_floors(player_type *creature_ptr, bool force)
 
     max_floor_id = 1;
     latest_visit_mark = 1;
-    saved_floor_file_sign = (uint32_t)time(NULL);
+    saved_floor_file_sign = (uint32_t)time(nullptr);
     new_floor_id = 0;
     creature_ptr->change_floor_mode = 0;
 }
@@ -98,12 +98,12 @@ void clear_saved_floor_files(player_type *creature_ptr)
 /*!
  * @brief 保存フロアIDから参照ポインタを得る / Get a pointer for an item of the saved_floors array.
  * @param floor_id 保存フロアID
- * @return IDに対応する保存フロアのポインタ、ない場合はNULLを返す。
+ * @return IDに対応する保存フロアのポインタ、ない場合はnullptrを返す。
  */
 saved_floor_type *get_sf_ptr(FLOOR_IDX floor_id)
 {
     if (!floor_id)
-        return NULL;
+        return nullptr;
 
     for (int i = 0; i < MAX_SAVED_FLOORS; i++) {
         saved_floor_type *sf_ptr = &saved_floors[i];
@@ -111,7 +111,7 @@ saved_floor_type *get_sf_ptr(FLOOR_IDX floor_id)
             return sf_ptr;
     }
 
-    return NULL;
+    return nullptr;
 }
 
 /*!
@@ -164,7 +164,7 @@ static FLOOR_IDX find_oldest_floor_idx(player_type *creature_ptr)
  */
 FLOOR_IDX get_new_floor_id(player_type *creature_ptr)
 {
-    saved_floor_type *sf_ptr = NULL;
+    saved_floor_type *sf_ptr = nullptr;
     FLOOR_IDX fl_idx;
     for (fl_idx = 0; fl_idx < MAX_SAVED_FLOORS; fl_idx++) {
         sf_ptr = &saved_floors[fl_idx];

--- a/src/floor/pattern-walk.cpp
+++ b/src/floor/pattern-walk.cpp
@@ -80,7 +80,7 @@ void pattern_teleport(player_type *creature_ptr)
     creature_ptr->current_floor_ptr->dun_level = command_arg;
     leave_quest_check(creature_ptr);
     if (record_stair)
-        exe_write_diary(creature_ptr, DIARY_PAT_TELE, 0, NULL);
+        exe_write_diary(creature_ptr, DIARY_PAT_TELE, 0, nullptr);
 
     creature_ptr->current_floor_ptr->inside_quest = 0;
     PlayerEnergy(creature_ptr).reset_player_turn();

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -385,7 +385,7 @@ void wilderness_gen(player_type *creature_ptr)
     parse_fixed_map(creature_ptr, "w_info.txt", 0, 0, current_world_ptr->max_wild_y, current_world_ptr->max_wild_x);
     POSITION x = creature_ptr->wilderness_x;
     POSITION y = creature_ptr->wilderness_y;
-    get_mon_num_prep(creature_ptr, get_monster_hook(creature_ptr), NULL);
+    get_mon_num_prep(creature_ptr, get_monster_hook(creature_ptr), nullptr);
 
     /* North border */
     generate_area(creature_ptr, y - 1, x, true, false);

--- a/src/game-option/option-types-table.cpp
+++ b/src/game-option/option-types-table.cpp
@@ -294,7 +294,7 @@ const std::array<const option_type, MAX_OPTION_INFO> option_info = {{
     { &record_named_pet, false, OPT_PAGE_PLAYRECORD, 4, 23, "record_named_pet", _("名前つきペットの情報を記録する", "Record information about named pets") },
 
     /*** End of Table ***/
-    { NULL, 0, 0, 0, 0, NULL, NULL }
+    { nullptr, 0, 0, 0, 0, nullptr, nullptr }
 }};
 
 /*!

--- a/src/game-option/option-types-table.h
+++ b/src/game-option/option-types-table.h
@@ -5,12 +5,12 @@
 
 /*
  * Available "options"
- *	- Address of actual option variable (or NULL)
+ *	- Address of actual option variable (or nullptr)
  *	- Normal Value (TRUE or FALSE)
  *	- Option Page Number (or zero)
  *	- Savefile Set (or zero)
  *	- Savefile Bit in that set
- *	- Textual name (or NULL)
+ *	- Textual name (or nullptr)
  *	- Textual description
  */
 struct option_type {

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -534,7 +534,7 @@ void hit_trap(player_type *trapped_ptr, bool break_trap)
                 msg_print(_("身の毛もよだつ光景が頭に浮かんだ。", "A horrible vision enters your mind."));
 
                 /* Have some nightmares */
-                sanity_blast(trapped_ptr, NULL, false);
+                sanity_blast(trapped_ptr, nullptr, false);
             }
             (void)set_paralyzed(trapped_ptr, trapped_ptr->paralyzed + randint0(10) + 5);
         }

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -80,14 +80,14 @@ static bool deal_damege_by_feat(player_type *creature_ptr, grid_type *g_ptr, con
 
         take_hit(creature_ptr, DAMAGE_NOESCAPE, damage, format(_("%sの上に浮遊したダメージ", "flying over %s"), f_info[g_ptr->get_feat_mimic()].name.c_str()));
 
-        if (additional_effect != NULL)
+        if (additional_effect != nullptr)
             additional_effect(creature_ptr, damage);
     } else {
         concptr name = f_info[creature_ptr->current_floor_ptr->grid_array[creature_ptr->y][creature_ptr->x].get_feat_mimic()].name.c_str();
         msg_format(_("%s%s！", "The %s %s!"), name, msg_normal);
         take_hit(creature_ptr, DAMAGE_NOESCAPE, damage, name);
 
-        if (additional_effect != NULL)
+        if (additional_effect != nullptr)
             additional_effect(creature_ptr, damage);
     }
 
@@ -160,22 +160,22 @@ void process_player_hp_mp(player_type *creature_ptr)
 
     if (f_ptr->flags.has(FF::LAVA) && !is_invuln(creature_ptr) && !has_immune_fire(creature_ptr)) {
         cave_no_regen = deal_damege_by_feat(
-            creature_ptr, g_ptr, _("熱で火傷した！", "The heat burns you!"), _("で火傷した！", "burns you!"), calc_fire_damage_rate, NULL);
+            creature_ptr, g_ptr, _("熱で火傷した！", "The heat burns you!"), _("で火傷した！", "burns you!"), calc_fire_damage_rate, nullptr);
     }
 
     if (f_ptr->flags.has(FF::COLD_PUDDLE) && !is_invuln(creature_ptr) && !has_immune_cold(creature_ptr)) {
         cave_no_regen = deal_damege_by_feat(
-            creature_ptr, g_ptr, _("冷気に覆われた！", "The cold engulfs you!"), _("に凍えた！", "frostbites you!"), calc_cold_damage_rate, NULL);
+            creature_ptr, g_ptr, _("冷気に覆われた！", "The cold engulfs you!"), _("に凍えた！", "frostbites you!"), calc_cold_damage_rate, nullptr);
     }
 
     if (f_ptr->flags.has(FF::ELEC_PUDDLE) && !is_invuln(creature_ptr) && !has_immune_elec(creature_ptr)) {
         cave_no_regen = deal_damege_by_feat(
-            creature_ptr, g_ptr, _("電撃を受けた！", "The electricity shocks you!"), _("に感電した！", "shocks you!"), calc_elec_damage_rate, NULL);
+            creature_ptr, g_ptr, _("電撃を受けた！", "The electricity shocks you!"), _("に感電した！", "shocks you!"), calc_elec_damage_rate, nullptr);
     }
 
     if (f_ptr->flags.has(FF::ACID_PUDDLE) && !is_invuln(creature_ptr) && !has_immune_acid(creature_ptr)) {
         cave_no_regen = deal_damege_by_feat(
-            creature_ptr, g_ptr, _("酸が飛び散った！", "The acid melts you!"), _("に溶かされた！", "melts you!"), calc_acid_damage_rate, NULL);
+            creature_ptr, g_ptr, _("酸が飛び散った！", "The acid melts you!"), _("に溶かされた！", "melts you!"), calc_acid_damage_rate, nullptr);
     }
 
     if (f_ptr->flags.has(FF::POISON_PUDDLE) && !is_invuln(creature_ptr)) {
@@ -298,13 +298,13 @@ void process_player_hp_mp(player_type *creature_ptr)
     if ((creature_ptr->csp == 0) && (creature_ptr->csp_frac == 0)) {
         while (upkeep_factor > 100) {
             msg_print(_("こんなに多くのペットを制御できない！", "Too many pets to control at once!"));
-            msg_print(NULL);
+            msg_print(nullptr);
             do_cmd_pet_dismiss(creature_ptr);
 
             upkeep_factor = calculate_upkeep(creature_ptr);
 
             msg_format(_("維持ＭＰは %d%%", "Upkeep: %d%% mana."), upkeep_factor);
-            msg_print(NULL);
+            msg_print(nullptr);
         }
     }
 

--- a/src/info-reader/artifact-reader.cpp
+++ b/src/info-reader/artifact-reader.cpp
@@ -37,7 +37,7 @@ static bool grab_one_artifact_flag(artifact_type *a_ptr, std::string_view what)
  */
 errr parse_a_info(std::string_view buf, angband_header *head)
 {
-    static artifact_type *a_ptr = NULL;
+    static artifact_type *a_ptr = nullptr;
     const auto &tokens = str_split(buf, ':', false, 10);
 
     if (tokens[0] == "N") {

--- a/src/info-reader/dungeon-reader.cpp
+++ b/src/info-reader/dungeon-reader.cpp
@@ -86,7 +86,7 @@ static bool grab_one_spell_monster_flag(dungeon_type *d_ptr, std::string_view wh
  */
 errr parse_d_info(std::string_view buf, angband_header *head)
 {
-    static dungeon_type *d_ptr = NULL;
+    static dungeon_type *d_ptr = nullptr;
     const auto &tokens = str_split(buf, ':', false);
 
     if (tokens[0] == "N") {

--- a/src/info-reader/ego-reader.cpp
+++ b/src/info-reader/ego-reader.cpp
@@ -59,7 +59,7 @@ static bool grab_ego_generate_flags(ego_generate_type &xtra, std::string_view wh
  */
 errr parse_e_info(std::string_view buf, angband_header *head)
 {
-    static ego_item_type *e_ptr = NULL;
+    static ego_item_type *e_ptr = nullptr;
     const auto &tokens = str_split(buf, ':', false, 10);
 
     error_idx = 0; //!< @note 順不同で登録しているため

--- a/src/info-reader/feature-reader.cpp
+++ b/src/info-reader/feature-reader.cpp
@@ -60,7 +60,7 @@ static bool grab_one_feat_action(feature_type *f_ptr, std::string_view what, int
  */
 errr parse_f_info(std::string_view buf, angband_header *head)
 {
-    static feature_type *f_ptr = NULL;
+    static feature_type *f_ptr = nullptr;
     const auto &tokens = str_split(buf, ':', false, 10);
 
     if (tokens[0] == "N") {

--- a/src/info-reader/fixed-map-parser.cpp
+++ b/src/info-reader/fixed-map-parser.cpp
@@ -237,7 +237,7 @@ parse_error_type parse_fixed_map(player_type *player_ptr, concptr name, int ymin
     char buf[1024];
     path_build(buf, sizeof(buf), ANGBAND_DIR_EDIT, name);
     FILE *fp = angband_fopen(buf, "r");
-    if (fp == NULL)
+    if (fp == nullptr)
         return PARSE_ERROR_GENERIC;
 
     int num = -1;
@@ -273,7 +273,7 @@ parse_error_type parse_fixed_map(player_type *player_ptr, concptr name, int ymin
         concptr oops = (((err > 0) && (err < PARSE_ERROR_MAX)) ? err_str[err] : "unknown");
         msg_format("Error %d (%s) at line %d of '%s'.", err, oops, num, name);
         msg_format(_("'%s'を解析中。", "Parsing '%s'."), buf);
-        msg_print(NULL);
+        msg_print(nullptr);
     }
 
     angband_fclose(fp);

--- a/src/info-reader/info-reader-util.cpp
+++ b/src/info-reader/info-reader-util.cpp
@@ -16,7 +16,7 @@ int error_line; /*!< データ読み込み/初期化時に汎用的にエラー�
 byte grab_one_activation_flag(concptr what)
 {
     for (int i = 0;; i++) {
-        if (activation_info[i].flag == NULL)
+        if (activation_info[i].flag == nullptr)
             break;
 
         if (streq(what, activation_info[i].flag)) {

--- a/src/info-reader/kind-reader.cpp
+++ b/src/info-reader/kind-reader.cpp
@@ -38,7 +38,7 @@ static bool grab_one_kind_flag(object_kind *k_ptr, std::string_view what)
  */
 errr parse_k_info(std::string_view buf, angband_header *head)
 {
-    static object_kind *k_ptr = NULL;
+    static object_kind *k_ptr = nullptr;
     const auto &tokens = str_split(buf, ':', false, 10);
 
     if (tokens[0] == "N") {

--- a/src/info-reader/magic-reader.cpp
+++ b/src/info-reader/magic-reader.cpp
@@ -40,7 +40,7 @@ const std::unordered_map<std::string_view, int> name_to_stat = {
  */
 errr parse_m_info(std::string_view buf, angband_header *head)
 {
-    static player_magic *m_ptr = NULL;
+    static player_magic *m_ptr = nullptr;
     static int realm, magic_idx = 0, readable = 0;
     const auto &tokens = str_split(buf, ':', false, 7);
 

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -69,7 +69,7 @@ static bool grab_one_spell_flag(monster_race *r_ptr, std::string_view what)
  */
 errr parse_r_info(std::string_view buf, angband_header *head)
 {
-    static monster_race *r_ptr = NULL;
+    static monster_race *r_ptr = nullptr;
     const auto &tokens = str_split(buf, ':', true, 10);
 
     if (tokens[0] == "N") {

--- a/src/info-reader/skill-reader.cpp
+++ b/src/info-reader/skill-reader.cpp
@@ -25,7 +25,7 @@ const std::unordered_map<int, int> level_to_exp = {
  */
 errr parse_s_info(std::string_view buf, angband_header *head)
 {
-    static skill_table *s_ptr = NULL;
+    static skill_table *s_ptr = nullptr;
     const auto &tokens = str_split(buf, ':', false, 5);
 
     if (tokens[0] == "N") {

--- a/src/info-reader/vault-reader.cpp
+++ b/src/info-reader/vault-reader.cpp
@@ -14,7 +14,7 @@
  */
 errr parse_v_info(std::string_view buf, angband_header *head)
 {
-    static vault_type *v_ptr = NULL;
+    static vault_type *v_ptr = nullptr;
     const auto &tokens = str_split(buf, ':', false, 5);
 
     if (tokens[0] == "N") {

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -202,7 +202,7 @@ bool get_item_floor(player_type *owner_ptr, COMMAND_CODE *cp, concptr pmt, concp
     if (check_floor_item_tag(owner_ptr, fis_ptr, &prev_tag, item_tester))
         return true;
 
-    msg_print(NULL);
+    msg_print(nullptr);
     handle_stuff(owner_ptr);
     test_inventory_floor(owner_ptr, fis_ptr, item_tester);
     fis_ptr->done = false;

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -132,14 +132,14 @@ static void choise_cursed_item(TRC flag, object_type *o_ptr, int *choices, int *
  * @brief 現在呪いを保持している装備品を一つランダムに探し出す / Choose one of items that have cursed flag
  * @param flag 探し出したい呪いフラグ配列
  * @return 該当の呪いが一つでもあった場合にランダムに選ばれた装備品のオブジェクト構造体参照ポインタを返す。\n
- * 呪いがない場合NULLを返す。
+ * 呪いがない場合nullptrを返す。
  */
 object_type *choose_cursed_obj_name(player_type *creature_ptr, TRC flag)
 {
     int choices[INVEN_TOTAL - INVEN_MAIN_HAND];
     int number = 0;
     if (creature_ptr->cursed.has_not(flag))
-        return NULL;
+        return nullptr;
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         object_type *o_ptr = &creature_ptr->inventory_list[i];

--- a/src/inventory/item-getter.cpp
+++ b/src/inventory/item-getter.cpp
@@ -199,7 +199,7 @@ bool get_item(player_type *owner_ptr, OBJECT_IDX *cp, concptr pmt, concptr str, 
     if (check_item_tag(owner_ptr, item_selection_ptr, &prev_tag, item_tester))
         return true;
 
-    msg_print(NULL);
+    msg_print(nullptr);
     item_selection_ptr->done = false;
     item_selection_ptr->item = false;
     item_selection_ptr->i1 = 0;

--- a/src/io-dump/dump-remover.cpp
+++ b/src/io-dump/dump-remover.cpp
@@ -28,7 +28,7 @@ void remove_auto_dump(concptr orig_file, concptr auto_dump_mark)
 	orig_fff = angband_fopen(orig_file, "r");
 	if (!orig_fff) return;
 
-	FILE *tmp_fff = NULL;
+	FILE *tmp_fff = nullptr;
 	char tmp_file[FILE_NAME_SIZE];
 	if (!open_temporary_file(&tmp_fff, tmp_file)) return;
 

--- a/src/io-dump/dump-util.cpp
+++ b/src/io-dump/dump-util.cpp
@@ -144,10 +144,10 @@ bool visual_mode_command(char ch, bool *visual_list_ptr,
 bool open_temporary_file(FILE **fff, char *file_name)
 {
 	*fff = angband_fopen_temp(file_name, FILE_NAME_SIZE);
-	if (*fff != NULL) return true;
+	if (*fff != nullptr) return true;
 
 	msg_format(_("一時ファイル %s を作成できませんでした。", "Failed to create temporary file %s."), file_name);
-	msg_print(NULL);
+	msg_print(nullptr);
 	return false;
 }
 

--- a/src/io/files-util.cpp
+++ b/src/io/files-util.cpp
@@ -70,7 +70,7 @@ errr file_character(player_type *creature_ptr, concptr name, display_player_pf d
             fd = -1;
     }
 
-    FILE *fff = NULL;
+    FILE *fff = nullptr;
     if (fd < 0)
         fff = angband_fopen(buf, "w");
 
@@ -83,7 +83,7 @@ errr file_character(player_type *creature_ptr, concptr name, display_player_pf d
     make_character_dump(creature_ptr, fff, display_player);
     angband_fclose(fff);
     msg_print(_("キャラクタ情報のファイルへの書き出しに成功しました。", "Character dump successful."));
-    msg_print(NULL);
+    msg_print(nullptr);
     return 0;
 }
 

--- a/src/io/inet.cpp
+++ b/src/io/inet.cpp
@@ -147,7 +147,7 @@ static void restore_signal(void)
     val0.it_value.tv_usec = 0;
 
     /* アラーム解除 */
-    setitimer(ITIMER_REAL, &val0, NULL);
+    setitimer(ITIMER_REAL, &val0, nullptr);
     signal(SIGALRM, sig_alm_saved);
     signal(SIGINT, sig_int_saved);
 #endif
@@ -197,7 +197,7 @@ int connect_server(int timeout, concptr host, int port)
     sig_alm_saved = signal(SIGALRM, interrupt_report);
 
     /* タイムアウトの時間を設定 */
-    setitimer(ITIMER_REAL, &val, NULL);
+    setitimer(ITIMER_REAL, &val, nullptr);
 #else
     /* Unused in Windows */
     (void)timeout;
@@ -205,7 +205,7 @@ int connect_server(int timeout, concptr host, int port)
 
     /* プロキシが設定されていればプロキシに繋ぐ */
     if (proxy && proxy[0]) {
-        if ((hp = gethostbyname(proxy)) == NULL) {
+        if ((hp = gethostbyname(proxy)) == nullptr) {
 #ifdef JP
             errstr = "エラー: プロキシのアドレスが不正です";
 #else
@@ -216,7 +216,7 @@ int connect_server(int timeout, concptr host, int port)
 
             return -1;
         }
-    } else if ((hp = gethostbyname(host)) == NULL) {
+    } else if ((hp = gethostbyname(host)) == nullptr) {
 #ifdef JP
         errstr = "エラー: サーバのアドレスが不正です";
 #else

--- a/src/io/input-key-acceptor.cpp
+++ b/src/io/input-key-acceptor.cpp
@@ -23,7 +23,7 @@ int num_more = 0;
  * trigger any macros, and cannot be bypassed by the Borg.  It is used
  * in Angband to handle "keymaps".
  */
-concptr inkey_next = NULL;
+concptr inkey_next = nullptr;
 
 /* Save macro trigger string for use in inkey_special() */
 static char inkey_macro_trigger_string[1024];
@@ -196,7 +196,7 @@ char inkey(bool do_all_term_refresh)
         return (ch);
     }
 
-    inkey_next = NULL;
+    inkey_next = nullptr;
     if (inkey_xtra) {
         parse_macro = false;
         parse_under = false;
@@ -299,7 +299,7 @@ int inkey_special(bool numpad_cursor)
     } modifier_key_list[] = {
         { "shift-", SKEY_MOD_SHIFT },
         { "control-", SKEY_MOD_CONTROL },
-        { NULL, 0 },
+        { nullptr, 0 },
     };
 
     static const struct {
@@ -331,7 +331,7 @@ int inkey_special(bool numpad_cursor)
         { true, "KP_3]", SKEY_PGDOWN },
         { true, "KP_7]", SKEY_TOP },
         { true, "KP_1]", SKEY_BOTTOM },
-        { false, NULL, 0 },
+        { false, nullptr, 0 },
     };
 
     static const struct {
@@ -346,7 +346,7 @@ int inkey_special(bool numpad_cursor)
         { "4~", SKEY_BOTTOM },
         { "5~", SKEY_PGUP },
         { "6~", SKEY_PGDOWN },
-        { NULL, 0 },
+        { nullptr, 0 },
     };
 
     char buf[1024];

--- a/src/io/input-key-processor.cpp
+++ b/src/io/input-key-processor.cpp
@@ -110,7 +110,7 @@ bool enter_wizard_mode(player_type *player_ptr)
 
         msg_print(_("ウィザードモードはデバッグと実験のためのモードです。 ", "Wizard mode is for debugging and experimenting."));
         msg_print(_("一度ウィザードモードに入るとスコアは記録されません。", "The game will not be scored if you enter wizard mode."));
-        msg_print(NULL);
+        msg_print(nullptr);
         if (!get_check(_("本当にウィザードモードに入りたいのですか? ", "Are you sure you want to enter wizard mode? "))) {
             return false;
         }
@@ -139,7 +139,7 @@ static bool enter_debug_mode(player_type *player_ptr)
 
         msg_print(_("デバッグ・コマンドはデバッグと実験のためのコマンドです。 ", "The debug commands are for debugging and experimenting."));
         msg_print(_("デバッグ・コマンドを使うとスコアは記録されません。", "The game will not be scored if you use debug commands."));
-        msg_print(NULL);
+        msg_print(nullptr);
         if (!get_check(_("本当にデバッグ・コマンドを使いますか? ", "Are you sure you want to use debug commands? "))) {
             return false;
         }
@@ -386,7 +386,7 @@ void process_command(player_type *creature_ptr)
         if (floor_ptr->dun_level && d_info[creature_ptr->dungeon_idx].flags.has(DF::NO_MAGIC) && (creature_ptr->pclass != CLASS_BERSERKER)
             && (creature_ptr->pclass != CLASS_SMITH)) {
             msg_print(_("ダンジョンが魔法を吸収した！", "The dungeon absorbs all attempted magic!"));
-            msg_print(NULL);
+            msg_print(nullptr);
             break;
         }
         

--- a/src/io/input-key-requester.cpp
+++ b/src/io/input-key-requester.cpp
@@ -322,7 +322,7 @@ void request_command(player_type *player_ptr, int shopping)
 #ifdef JP
     for (int i = 0; i < 256; i++) {
         concptr s;
-        if ((s = keymap_act[mode][i]) != NULL) {
+        if ((s = keymap_act[mode][i]) != nullptr) {
             if (*s == command_cmd && *(s + 1) == 0) {
                 caretcmd = i;
                 break;

--- a/src/io/interpret-pref-file.cpp
+++ b/src/io/interpret-pref-file.cpp
@@ -26,7 +26,7 @@
 
 #define MAX_MACRO_CHARS 16128 // 1つのマクロキー押下で実行可能なコマンド最大数 (エスケープシーケンス含む).
 
-char *histpref_buf = NULL;
+char *histpref_buf = nullptr;
 
 /*!
  * @brief Rトークンの解釈 / Process "R:<num>:<a>/<c>" -- attr/char for monster races
@@ -39,9 +39,9 @@ static errr interpret_r_token(char *buf)
 	if (tokenize(buf + 2, 3, zz, TOKENIZE_CHECKQUOTE) != 3) return 1;
 
 	monster_race *r_ptr;
-	int i = (int)strtol(zz[0], NULL, 0);
-	TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], NULL, 0);
-	SYMBOL_CODE n2 = (SYMBOL_CODE)strtol(zz[2], NULL, 0);
+	int i = (int)strtol(zz[0], nullptr, 0);
+	TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], nullptr, 0);
+	SYMBOL_CODE n2 = (SYMBOL_CODE)strtol(zz[2], nullptr, 0);
 	if (i >= max_r_idx) return 1;
 
 	r_ptr = &r_info[i];
@@ -63,9 +63,9 @@ static errr interpret_k_token(char *buf)
 	if (tokenize(buf + 2, 3, zz, TOKENIZE_CHECKQUOTE) != 3) return 1;
 
 	object_kind *k_ptr;
-	int i = (int)strtol(zz[0], NULL, 0);
-	TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], NULL, 0);
-	SYMBOL_CODE n2 = (SYMBOL_CODE)strtol(zz[2], NULL, 0);
+	int i = (int)strtol(zz[0], nullptr, 0);
+	TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], nullptr, 0);
+	SYMBOL_CODE n2 = (SYMBOL_CODE)strtol(zz[2], nullptr, 0);
 	if (i >= max_k_idx) return 1;
 
 	k_ptr = &k_info[i];
@@ -87,8 +87,8 @@ static errr decide_feature_type(int i, int num, char **zz)
 	feature_type *f_ptr;
 	f_ptr = &f_info[i];
 
-	TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], NULL, 0);
-	SYMBOL_CODE n2 = (SYMBOL_CODE)strtol(zz[2], NULL, 0);
+	TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], nullptr, 0);
+	SYMBOL_CODE n2 = (SYMBOL_CODE)strtol(zz[2], nullptr, 0);
 	if (n1 || (!(n2 & 0x80) && n2)) f_ptr->x_attr[F_LIT_STANDARD] = n1; /* Allow TERM_DARK text */
 	if (n2) f_ptr->x_char[F_LIT_STANDARD] = n2;
 
@@ -118,8 +118,8 @@ static errr decide_feature_type(int i, int num, char **zz)
 		/* Use desired lighting */
 		for (int j = F_LIT_NS_BEGIN; j < F_LIT_MAX; j++)
 		{
-			n1 = (TERM_COLOR)strtol(zz[j * 2 + 1], NULL, 0);
-			n2 = (SYMBOL_CODE)strtol(zz[j * 2 + 2], NULL, 0);
+			n1 = (TERM_COLOR)strtol(zz[j * 2 + 1], nullptr, 0);
+			n2 = (SYMBOL_CODE)strtol(zz[j * 2 + 2], nullptr, 0);
 			if (n1 || (!(n2 & 0x80) && n2)) f_ptr->x_attr[j] = n1; /* Allow TERM_DARK text */
 			if (n2) f_ptr->x_char[j] = n2;
 		}
@@ -149,7 +149,7 @@ static errr interpret_f_token(char *buf)
 	if ((num != 3) && (num != 4) && (num != F_LIT_MAX * 2 + 1)) return 1;
 	else if ((num == 4) && !streq(zz[3], "LIT")) return 1;
 
-	int i = (int)strtol(zz[0], NULL, 0);
+	int i = (int)strtol(zz[0], nullptr, 0);
 	if (i >= max_f_idx) return 1;
 
 	return decide_feature_type(i, num, zz);
@@ -166,9 +166,9 @@ static errr interpret_s_token(char *buf)
 	char *zz[16];
 	if (tokenize(buf + 2, 3, zz, TOKENIZE_CHECKQUOTE) != 3) return 1;
 
-	int j = (byte)strtol(zz[0], NULL, 0);
-	TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], NULL, 0);
-	SYMBOL_CODE n2 = (SYMBOL_CODE)strtol(zz[2], NULL, 0);
+	int j = (byte)strtol(zz[0], nullptr, 0);
+	TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], nullptr, 0);
+	SYMBOL_CODE n2 = (SYMBOL_CODE)strtol(zz[2], nullptr, 0);
 	misc_to_attr[j] = n1;
 	misc_to_char[j] = n2;
 	return 0;
@@ -185,9 +185,9 @@ static errr interpret_u_token(char *buf)
 	char *zz[16];
 	if (tokenize(buf + 2, 3, zz, TOKENIZE_CHECKQUOTE) != 3) return 1;
 
-	int j = (int)strtol(zz[0], NULL, 0);
-	TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], NULL, 0);
-	SYMBOL_CODE n2 = (SYMBOL_CODE)strtol(zz[2], NULL, 0);
+	int j = (int)strtol(zz[0], nullptr, 0);
+	TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], nullptr, 0);
+	SYMBOL_CODE n2 = (SYMBOL_CODE)strtol(zz[2], nullptr, 0);
 	for (int i = 1; i < max_k_idx; i++)
 	{
 		object_kind *k_ptr = &k_info[i];
@@ -212,8 +212,8 @@ static errr interpret_e_token(char *buf)
 	char *zz[16];
 	if (tokenize(buf + 2, 2, zz, TOKENIZE_CHECKQUOTE) != 2) return 1;
 
-	int j = (byte)strtol(zz[0], NULL, 0) % 128;
-	TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], NULL, 0);
+	int j = (byte)strtol(zz[0], nullptr, 0) % 128;
+	TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], nullptr, 0);
 	if (n1) tval_to_attr[j] = n1;
 	return 0;
 }
@@ -242,7 +242,7 @@ static errr interpret_c_token(char *buf)
 	char *zz[16];
 	if (tokenize(buf + 2, 2, zz, TOKENIZE_CHECKQUOTE) != 2) return 1;
 
-	int mode = strtol(zz[0], NULL, 0);
+	int mode = strtol(zz[0], nullptr, 0);
 	if ((mode < 0) || (mode >= KEYMAP_MODES)) return 1;
 
 	char tmp[1024];
@@ -266,11 +266,11 @@ static errr interpret_v_token(char *buf)
 	char *zz[16];
 	if (tokenize(buf + 2, 5, zz, TOKENIZE_CHECKQUOTE) != 5) return 1;
 
-	int i = (byte)strtol(zz[0], NULL, 0);
-	angband_color_table[i][0] = (byte)strtol(zz[1], NULL, 0);
-	angband_color_table[i][1] = (byte)strtol(zz[2], NULL, 0);
-	angband_color_table[i][2] = (byte)strtol(zz[3], NULL, 0);
-	angband_color_table[i][3] = (byte)strtol(zz[4], NULL, 0);
+	int i = (byte)strtol(zz[0], nullptr, 0);
+	angband_color_table[i][0] = (byte)strtol(zz[1], nullptr, 0);
+	angband_color_table[i][1] = (byte)strtol(zz[2], nullptr, 0);
+	angband_color_table[i][2] = (byte)strtol(zz[3], nullptr, 0);
+	angband_color_table[i][3] = (byte)strtol(zz[4], nullptr, 0);
 	return 0;
 }
 
@@ -288,8 +288,8 @@ static errr interpret_xy_token(player_type *creature_ptr, char *buf)
 {
 	for (int i = 0; option_info[i].o_desc; i++)
 	{
-		bool is_option = option_info[i].o_var != NULL;
-		is_option &= option_info[i].o_text != NULL;
+		bool is_option = option_info[i].o_var != nullptr;
+		is_option &= option_info[i].o_text != nullptr;
 		is_option &= streq(option_info[i].o_text, buf + 2);
 		if (!is_option) continue;
 
@@ -300,7 +300,7 @@ static errr interpret_xy_token(player_type *creature_ptr, char *buf)
 			(OPT_PAGE_BIRTH == option_info[i].o_page) && !current_world_ptr->wizard)
 		{
 			msg_format(_("初期オプションは変更できません! '%s'", "Birth options can not changed! '%s'"), buf);
-			msg_print(NULL);
+			msg_print(nullptr);
 			return 0;
 		}
 
@@ -317,7 +317,7 @@ static errr interpret_xy_token(player_type *creature_ptr, char *buf)
 	}
 
 	msg_format(_("オプションの名前が正しくありません： %s", "Ignored invalid option: %s"), buf);
-	msg_print(NULL);
+	msg_print(nullptr);
 	return 0;
 }
 
@@ -354,11 +354,11 @@ static errr interpret_z_token(char *buf)
  */
 static errr decide_template_modifier(int tok, char **zz)
 {
-	if (macro_template != NULL)
+	if (macro_template != nullptr)
 	{
 		int macro_modifier_length = strlen(macro_modifier_chr);
 		string_free(macro_template);
-		macro_template = NULL;
+		macro_template = nullptr;
 		string_free(macro_modifier_chr);
 		for (int i = 0; i < macro_modifier_length; i++)
 		{

--- a/src/io/read-pref-file.cpp
+++ b/src/io/read-pref-file.cpp
@@ -128,7 +128,7 @@ static errr process_pref_file_aux(player_type *creature_ptr, concptr name, int p
         /* ToDo: Add better error messages */
         msg_format(_("ファイル'%s'の%d行でエラー番号%dのエラー。", "Error %d in line %d of file '%s'."), _(name, err), line, _(err, name));
         msg_format(_("('%s'を解析中)", "Parsing '%s'"), file_read__swp);
-        msg_print(NULL);
+        msg_print(nullptr);
     }
 
     angband_fclose(fp);
@@ -240,7 +240,7 @@ bool open_auto_dump(FILE **fpp, concptr buf, concptr mark)
     *fpp = angband_fopen(buf, "a");
     if (!fpp) {
         msg_format(_("%s を開くことができませんでした。", "Failed to open %s."), buf);
-        msg_print(NULL);
+        msg_print(nullptr);
         return false;
     }
 
@@ -328,13 +328,13 @@ bool read_histpref(player_type *creature_ptr)
 
     if (err) {
         msg_print(_("生い立ち設定ファイルの読み込みに失敗しました。", "Failed to load background history preference."));
-        msg_print(NULL);
-        histpref_buf = NULL;
+        msg_print(nullptr);
+        histpref_buf = nullptr;
         return false;
     } else if (!histpref_buf[0]) {
         msg_print(_("有効な生い立ち設定はこのファイルにありません。", "There does not exist valid background history preference."));
-        msg_print(NULL);
-        histpref_buf = NULL;
+        msg_print(nullptr);
+        histpref_buf = nullptr;
         return false;
     }
 
@@ -370,6 +370,6 @@ bool read_histpref(player_type *creature_ptr)
         creature_ptr->history[i][59] = '\0';
     }
 
-    histpref_buf = NULL;
+    histpref_buf = nullptr;
     return true;
 }

--- a/src/io/record-play-movie.cpp
+++ b/src/io/record-play-movie.cpp
@@ -84,7 +84,7 @@ static errr init_buffer(void)
     ring.wptr = ring.rptr = ring.inlen = 0;
     fresh_queue.time[0] = 0;
     ring.buf = static_cast<char*>(malloc(RINGBUF_SIZE));
-    if (ring.buf == NULL)
+    if (ring.buf == nullptr)
         return -1;
 
     return 0;
@@ -97,7 +97,7 @@ static long get_current_time(void)
     return timeGetTime() / 100;
 #else
     struct timeval tv;
-    gettimeofday(&tv, NULL);
+    gettimeofday(&tv, nullptr);
 
     return (tv.tv_sec * 10 + tv.tv_usec / 100000);
 #endif

--- a/src/io/report.cpp
+++ b/src/io/report.cpp
@@ -294,7 +294,7 @@ concptr make_screen_dump(player_type *creature_ptr)
     BUF *screen_buf;
     screen_buf = buf_new();
     if (screen_buf == NULL)
-        return (NULL);
+        return nullptr;
 
     bool old_use_graphics = use_graphics;
     if (old_use_graphics) {

--- a/src/io/report.cpp
+++ b/src/io/report.cpp
@@ -39,7 +39,7 @@
 #endif
 #include <curl/curl.h>
 
-concptr screen_dump = NULL;
+concptr screen_dump = nullptr;
 
 /*
  * internet resource value
@@ -73,14 +73,14 @@ static BUF *buf_new(void)
     BUF *p;
     p = static_cast<BUF*>(malloc(sizeof(BUF)));
     if (!p)
-        return NULL;
+        return nullptr;
 
     p->size = 0;
     p->max_size = BUFSIZE;
     p->data = static_cast<char*>(malloc(BUFSIZE));
     if (!p->data) {
         free(p);
-        return NULL;
+        return nullptr;
     }
 
     return p;
@@ -107,7 +107,7 @@ static int buf_append(BUF *buf, concptr data, size_t size)
 {
     while (buf->size + size > buf->max_size) {
         char *tmp;
-        if ((tmp = static_cast<char*>(malloc(buf->max_size * 2))) == NULL)
+        if ((tmp = static_cast<char*>(malloc(buf->max_size * 2))) == nullptr)
             return -1;
 
         memcpy(tmp, buf->data, buf->max_size);
@@ -172,11 +172,11 @@ static bool http_post(concptr url, BUF *buf)
 {
     bool succeeded = false;
     CURL *curl = curl_easy_init();
-    if (curl == NULL) {
+    if (curl == nullptr) {
         return false;
     }
 
-    struct curl_slist *slist = NULL;
+    struct curl_slist *slist = nullptr;
     slist = curl_slist_append(slist,
 #ifdef JP
 #ifdef SJIS
@@ -249,7 +249,7 @@ static errr make_dump(player_type *creature_ptr, BUF *dumpbuf, display_player_pf
 #else
         msg_format("Failed to create temporary file %s.", file_name);
 #endif
-        msg_print(NULL);
+        msg_print(nullptr);
         return 1;
     }
 
@@ -293,13 +293,13 @@ concptr make_screen_dump(player_type *creature_ptr)
     /* Alloc buffer */
     BUF *screen_buf;
     screen_buf = buf_new();
-    if (screen_buf == NULL)
+    if (screen_buf == nullptr)
         return nullptr;
 
     bool old_use_graphics = use_graphics;
     if (old_use_graphics) {
         /* Clear -more- prompt first */
-        msg_print(NULL);
+        msg_print(nullptr);
 
         use_graphics = false;
         reset_visuals(creature_ptr);
@@ -322,7 +322,7 @@ concptr make_screen_dump(player_type *creature_ptr)
         SYMBOL_CODE c = ' ';
         for (int x = 0; x < wid - 1; x++) {
             int rv, gv, bv;
-            concptr cc = NULL;
+            concptr cc = nullptr;
             /* Get the attr/char */
             (void)(term_what(x, y, &a, &c));
 
@@ -376,7 +376,7 @@ concptr make_screen_dump(player_type *creature_ptr)
     /* Screen dump size is too big ? */
     concptr ret;
     if (screen_buf->size + 1 > SCREEN_BUF_MAX_SIZE) {
-        ret = NULL;
+        ret = nullptr;
     } else {
         /* Terminate string */
         buf_append(screen_buf, "", 1);
@@ -461,5 +461,5 @@ bool report_score(player_type *creature_ptr, display_player_pf display_player)
     }
 }
 #else
-concptr screen_dump = NULL;
+concptr screen_dump = nullptr;
 #endif /* WORLD_SCORE */

--- a/src/io/signal-handlers.cpp
+++ b/src/io/signal-handlers.cpp
@@ -64,7 +64,7 @@ static void handle_signal_simple(int sig)
 {
     (void)signal(sig, SIG_IGN);
     if (!current_world_ptr->character_generated || current_world_ptr->character_saved)
-        quit(NULL);
+        quit(nullptr);
 
     signal_count++;
     if (p_ptr->is_dead) {
@@ -121,7 +121,7 @@ static void handle_signal_abort(int sig)
 
     (void)signal(sig, SIG_IGN);
     if (!current_world_ptr->character_generated || current_world_ptr->character_saved)
-        quit(NULL);
+        quit(nullptr);
 
     forget_lite(p_ptr->current_floor_ptr);
     forget_view(p_ptr->current_floor_ptr);

--- a/src/io/write-diary.cpp
+++ b/src/io/write-diary.cpp
@@ -63,7 +63,7 @@ static bool open_diary_file(FILE **fff, bool *disable_diary)
 	if (*fff) return true;
 
 	msg_format(_("%s を開くことができませんでした。プレイ記録を一時停止します。", "Failed to open %s. Play-Record is disabled temporarily."), buf);
-	msg_format(NULL);
+	msg_format(nullptr);
 	*disable_diary = true;
 	return false;
 }
@@ -192,7 +192,7 @@ errr exe_write_diary(player_type *creature_ptr, int type, int num, concptr note)
 		creature_ptr->current_floor_ptr->inside_quest = old_quest;
 	}
 
-	FILE *fff = NULL;
+	FILE *fff = nullptr;
 	if (!open_diary_file(&fff, &disable_diary)) return -1;
 
 	concptr note_level = "";

--- a/src/knowledge/knowledge-autopick.cpp
+++ b/src/knowledge/knowledge-autopick.cpp
@@ -32,7 +32,7 @@ void do_cmd_reload_autopick(player_type *creature_ptr)
  */
 void do_cmd_knowledge_autopick(player_type *creature_ptr)
 {
-    FILE *fff = NULL;
+    FILE *fff = nullptr;
     GAME_TEXT file_name[FILE_NAME_SIZE];
     if (!open_temporary_file(&fff, file_name))
         return;

--- a/src/knowledge/knowledge-experiences.cpp
+++ b/src/knowledge/knowledge-experiences.cpp
@@ -26,7 +26,7 @@
  */
 void do_cmd_knowledge_weapon_exp(player_type *creature_ptr)
 {
-    FILE *fff = NULL;
+    FILE *fff = nullptr;
     GAME_TEXT file_name[FILE_NAME_SIZE];
     if (!open_temporary_file(&fff, file_name))
         return;
@@ -72,7 +72,7 @@ void do_cmd_knowledge_weapon_exp(player_type *creature_ptr)
  */
 void do_cmd_knowledge_spell_exp(player_type *creature_ptr)
 {
-    FILE *fff = NULL;
+    FILE *fff = nullptr;
     GAME_TEXT file_name[FILE_NAME_SIZE];
     if (!open_temporary_file(&fff, file_name))
         return;
@@ -156,7 +156,7 @@ void do_cmd_knowledge_skill_exp(player_type *creature_ptr)
     char skill_name[SKILL_MAX][20] = { _("マーシャルアーツ", "Martial Arts    "), _("二刀流          ", "Dual Wielding   "),
         _("乗馬            ", "Riding          "), _("盾              ", "Shield          ") };
 
-    FILE *fff = NULL;
+    FILE *fff = nullptr;
     char file_name[FILE_NAME_SIZE];
     if (!open_temporary_file(&fff, file_name))
         return;

--- a/src/knowledge/knowledge-features.cpp
+++ b/src/knowledge/knowledge-features.cpp
@@ -106,7 +106,7 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
     FEAT_IDX *feat_idx;
     C_MAKE(feat_idx, max_f_idx, FEAT_IDX);
 
-    concptr feature_group_text[] = { "terrains", NULL };
+    concptr feature_group_text[] = { "terrains", nullptr };
     int len;
     int max = 0;
     int grp_cnt = 0;
@@ -117,7 +117,7 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
     byte char_left = 0;
     TERM_LEN browser_rows = hgt - 8;
     if (direct_f_idx < 0) {
-        for (FEAT_IDX i = 0; feature_group_text[i] != NULL; i++) {
+        for (FEAT_IDX i = 0; feature_group_text[i] != nullptr; i++) {
             len = strlen(feature_group_text[i]);
             if (len > max)
                 max = len;
@@ -344,7 +344,7 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
  */
 void do_cmd_knowledge_dungeon(player_type *creature_ptr)
 {
-    FILE *fff = NULL;
+    FILE *fff = nullptr;
     GAME_TEXT file_name[FILE_NAME_SIZE];
     if (!open_temporary_file(&fff, file_name))
         return;

--- a/src/knowledge/knowledge-inventory.cpp
+++ b/src/knowledge/knowledge-inventory.cpp
@@ -275,7 +275,7 @@ static void show_home_equipment_resistances(player_type *creature_ptr, tval_type
  */
 void do_cmd_knowledge_inventory(player_type *creature_ptr)
 {
-    FILE *fff = NULL;
+    FILE *fff = nullptr;
     GAME_TEXT file_name[FILE_NAME_SIZE];
     if (!open_temporary_file(&fff, file_name))
         return;

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -39,7 +39,7 @@
  */
 void do_cmd_knowledge_artifacts(player_type *player_ptr)
 {
-    FILE *fff = NULL;
+    FILE *fff = nullptr;
     GAME_TEXT file_name[FILE_NAME_SIZE];
     if (!open_temporary_file(&fff, file_name))
         return;
@@ -236,7 +236,7 @@ static void desc_obj_fake(player_type *creature_ptr, KIND_OBJECT_IDX k_idx)
         return;
 
     msg_print(_("特に変わったところはないようだ。", "You see nothing special."));
-    msg_print(NULL);
+    msg_print(nullptr);
 }
 
 /**
@@ -265,7 +265,7 @@ void do_cmd_knowledge_objects(player_type *creature_ptr, bool *need_redraw, bool
     int grp_cnt = 0;
     if (direct_k_idx < 0) {
         mode = visual_only ? 0x03 : 0x01;
-        for (IDX i = 0; object_group_text[i] != NULL; i++) {
+        for (IDX i = 0; object_group_text[i] != nullptr; i++) {
             len = strlen(object_group_text[i]);
             if (len > max)
                 max = len;

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -111,7 +111,7 @@ static IDX collect_monsters(player_type *creature_ptr, IDX grp_cur, IDX mon_idx[
  */
 void do_cmd_knowledge_pets(player_type *creature_ptr)
 {
-    FILE *fff = NULL;
+    FILE *fff = nullptr;
     GAME_TEXT file_name[FILE_NAME_SIZE];
     if (!open_temporary_file(&fff, file_name))
         return;
@@ -152,7 +152,7 @@ void do_cmd_knowledge_pets(player_type *creature_ptr)
  */
 void do_cmd_knowledge_kill_count(player_type *creature_ptr)
 {
-    FILE *fff = NULL;
+    FILE *fff = nullptr;
     GAME_TEXT file_name[FILE_NAME_SIZE];
     if (!open_temporary_file(&fff, file_name))
         return;
@@ -313,7 +313,7 @@ void do_cmd_knowledge_monsters(player_type *creature_ptr, bool *need_redraw, boo
     if (direct_r_idx < 0) {
         mode = visual_only ? MONSTER_LORE_DEBUG : MONSTER_LORE_NORMAL;
         int len;
-        for (IDX i = 0; monster_group_text[i] != NULL; i++) {
+        for (IDX i = 0; monster_group_text[i] != nullptr; i++) {
             len = strlen(monster_group_text[i]);
             if (len > max)
                 max = len;
@@ -475,7 +475,7 @@ void do_cmd_knowledge_monsters(player_type *creature_ptr, bool *need_redraw, boo
  */
 void do_cmd_knowledge_bounty(player_type *creature_ptr)
 {
-    FILE *fff = NULL;
+    FILE *fff = nullptr;
     GAME_TEXT file_name[FILE_NAME_SIZE];
     if (!open_temporary_file(&fff, file_name))
         return;

--- a/src/knowledge/knowledge-mutations.cpp
+++ b/src/knowledge/knowledge-mutations.cpp
@@ -15,7 +15,7 @@
  */
 void do_cmd_knowledge_mutations(player_type *creature_ptr)
 {
-    FILE *fff = NULL;
+    FILE *fff = nullptr;
     GAME_TEXT file_name[FILE_NAME_SIZE];
     if (!open_temporary_file(&fff, file_name))
         return;

--- a/src/knowledge/knowledge-quests.cpp
+++ b/src/knowledge/knowledge-quests.cpp
@@ -287,7 +287,7 @@ static void do_cmd_knowledge_quests_wiz_random(FILE *fff)
  */
 void do_cmd_knowledge_quests(player_type *creature_ptr)
 {
-    FILE *fff = NULL;
+    FILE *fff = nullptr;
     GAME_TEXT file_name[FILE_NAME_SIZE];
     if (!open_temporary_file(&fff, file_name))
         return;

--- a/src/knowledge/knowledge-self.cpp
+++ b/src/knowledge/knowledge-self.cpp
@@ -32,7 +32,7 @@
  */
 void do_cmd_knowledge_virtues(player_type *creature_ptr)
 {
-    FILE *fff = NULL;
+    FILE *fff = nullptr;
     GAME_TEXT file_name[FILE_NAME_SIZE];
     if (!open_temporary_file(&fff, file_name))
         return;
@@ -167,7 +167,7 @@ static void dump_winner_classes(FILE *fff)
  */
 void do_cmd_knowledge_stat(player_type *creature_ptr)
 {
-    FILE *fff = NULL;
+    FILE *fff = nullptr;
     GAME_TEXT file_name[FILE_NAME_SIZE];
     if (!open_temporary_file(&fff, file_name))
         return;
@@ -211,7 +211,7 @@ void do_cmd_knowledge_home(player_type *player_ptr)
 {
     parse_fixed_map(player_ptr, "w_info.txt", 0, 0, current_world_ptr->max_wild_y, current_world_ptr->max_wild_x);
 
-    FILE *fff = NULL;
+    FILE *fff = nullptr;
     GAME_TEXT file_name[FILE_NAME_SIZE];
     if (!open_temporary_file(&fff, file_name))
         return;

--- a/src/knowledge/knowledge-uniques.cpp
+++ b/src/knowledge/knowledge-uniques.cpp
@@ -133,7 +133,7 @@ void do_cmd_knowledge_uniques(player_type *creature_ptr, bool is_alive)
 {
     unique_list_type tmp_list;
     unique_list_type *unique_list_ptr = initialize_unique_lsit_type(&tmp_list, is_alive);
-    FILE *fff = NULL;
+    FILE *fff = nullptr;
     GAME_TEXT file_name[FILE_NAME_SIZE];
     if (!open_temporary_file(&fff, file_name))
         return;

--- a/src/knowledge/monster-group-table.cpp
+++ b/src/knowledge/monster-group-table.cpp
@@ -24,7 +24,7 @@ concptr monster_group_text[] = {
     "Lich", "Multi-Headed Reptile", "Mystery Living", "Ogre", "Giant Humanoid", "Quylthulg", "Reptile/Amphibian", "Spider/Scorpion/Tick", "Troll", "Vampire",
     "Wight/Wraith/etc", "Xorn/Xaren/etc", "Yeti", "Zephyr Hound", "Mimic", "Wall/Plant/Gas", "Mushroom patch", "Ball", "Player",
 #endif
-    NULL
+    nullptr
 };
 
 /*
@@ -33,4 +33,4 @@ concptr monster_group_text[] = {
  */
 concptr monster_group_char[] = { (char *)-1L, (char *)-2L, (char *)-3L, (char *)-4L, "a", "b", "c", "dD", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o",
     "pt", "q", "r", "s", "uU", "v", "w", "y", "z", "A", "B", "C", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "V", "W", "X",
-    "Y", "Z", "!$&()+./=>?[\\]`{|~", "#%", ",", "*", "@", NULL };
+    "Y", "Z", "!$&()+./=>?[\\]`{|~", "#%", ",", "*", "@", nullptr };

--- a/src/knowledge/object-group-table.cpp
+++ b/src/knowledge/object-group-table.cpp
@@ -17,7 +17,7 @@ concptr object_group_text[MAX_OBJECT_GROUP_TEXT] = { _("キノコ", "Mushrooms")
     _("鈍器", "Blunt Weapons"), _("長柄武器", "Polearms"), _("採掘道具", "Diggers"), _("飛び道具", "Bows"), _("弾", "Shots"), _("矢", "Arrows"),
     _("ボルト", "Bolts"), _("軽装鎧", "Soft Armor"), _("重装鎧", "Hard Armor"), _("ドラゴン鎧", "Dragon Armor"), _("盾", "Shields"), _("クローク", "Cloaks"),
     _("籠手", "Gloves"), _("ヘルメット", "Helms"), _("冠", "Crowns"), _("ブーツ", "Boots"), _("魔法書", "Spellbooks"), _("財宝", "Treasure"),
-    _("何か", "Something"), NULL };
+    _("何か", "Something"), nullptr };
 
 /*
  * TVALs of items in each group

--- a/src/load/dungeon-loader.cpp
+++ b/src/load/dungeon-loader.cpp
@@ -44,7 +44,7 @@ static errr rd_dungeon(player_type *player_ptr)
     byte num;
     rd_byte(&num);
     if (num == 0) {
-        err = rd_saved_floor(player_ptr, NULL);
+        err = rd_saved_floor(player_ptr, nullptr);
     } else {
         for (int i = 0; i < num; i++) {
             saved_floor_type *sf_ptr = &saved_floors[i];

--- a/src/load/floor-loader.cpp
+++ b/src/load/floor-loader.cpp
@@ -290,7 +290,7 @@ bool load_floor(player_type *player_ptr, saved_floor_type *sf_ptr, BIT_FLAGS mod
     kanji_code = 1;
 #endif
 
-    FILE *old_fff = NULL;
+    FILE *old_fff = nullptr;
     byte old_xor_byte = 0;
     uint32_t old_v_check = 0;
     uint32_t old_x_check = 0;

--- a/src/load/inventory-loader.cpp
+++ b/src/load/inventory-loader.cpp
@@ -23,7 +23,7 @@ static errr rd_inventory(player_type *player_ptr)
     player_ptr->inven_cnt = 0;
     player_ptr->equip_cnt = 0;
 
-    if (player_ptr->inventory_list != NULL)
+    if (player_ptr->inventory_list != nullptr)
         C_KILL(player_ptr->inventory_list, INVEN_TOTAL, object_type);
     C_MAKE(player_ptr->inventory_list, INVEN_TOTAL, object_type);
 

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -304,7 +304,7 @@ bool load_savedata(player_type *player_ptr, bool *new_game)
 #ifndef WINDOWS
     if (access(savefile, 0) < 0) {
         msg_print(_("セーブファイルがありません。", "Savefile does not exist."));
-        msg_print(NULL);
+        msg_print(nullptr);
         *new_game = true;
         return true;
     }
@@ -341,7 +341,7 @@ bool load_savedata(player_type *player_ptr, bool *new_game)
 
     if (err) {
         msg_format("%s: %s", what, savefile);
-        msg_print(NULL);
+        msg_print(nullptr);
         return false;
     }
 
@@ -367,7 +367,7 @@ bool load_savedata(player_type *player_ptr, bool *new_game)
         msg_format(_("エラー(%s)がバージョン%d.%d.%d.%d 用セーブファイル読み込み中に発生。", "Error (%s) reading %d.%d.%d.% savefile."), what,
             current_world_ptr->h_ver_major, current_world_ptr->h_ver_minor, current_world_ptr->h_ver_patch, current_world_ptr->h_ver_extra);
 
-        msg_print(NULL);
+        msg_print(nullptr);
         return false;
     }
 

--- a/src/locale/japanese.cpp
+++ b/src/locale/japanese.cpp
@@ -36,7 +36,7 @@ static const convert_key s2j_table[] = { { "mb", "nb" }, { "mp", "np" }, { "mv",
     { "za", "ザ" }, { "zi", "ジ" }, { "zu", "ズ" }, { "ze", "ゼ" }, { "zo", "ゾ" }, { "dh", "ズ" }, { "ch", "フ" }, { "th", "ス" }, { "b", "ブ" },
     { "c", "ク" }, { "d", "ド" }, { "f", "フ" }, { "g", "グ" }, { "h", "フ" }, { "j", "ジュ" }, { "k", "ク" }, { "l", "ル" }, { "m", "ム" }, { "n", "ン" },
     { "p", "プ" }, { "q", "ク" }, { "r", "ル" }, { "s", "ス" }, { "t", "ト" }, { "v", "ヴ" }, { "w", "ウ" }, { "y", "イ" }, { "a", "ア" }, { "i", "イ" },
-    { "u", "ウ" }, { "e", "エ" }, { "o", "オ" }, { "-", "ー" }, { NULL, NULL } };
+    { "u", "ウ" }, { "e", "エ" }, { "o", "オ" }, { "-", "ー" }, { nullptr, nullptr } };
 
 /*!
  * @brief シンダリンを日本語の読みに変換する
@@ -54,7 +54,7 @@ void sindarin_to_kana(char *kana, concptr sindarin)
         if (isupper(kana[idx]))
             kana[idx] = (char)tolower(kana[idx]);
 
-    for (idx = 0; s2j_table[idx].key1 != NULL; idx++) {
+    for (idx = 0; s2j_table[idx].key1 != nullptr; idx++) {
         concptr pat1 = s2j_table[idx].key1;
         concptr pat2 = s2j_table[idx].key2;
         int len = strlen(pat1);
@@ -126,7 +126,7 @@ static const struct jverb_table_t {
     { "ぶ", { "び", "んで", "んだ" } },
     { "む", { "み", "んで", "んだ" } },
     { "る", { "り", "って", "った" } },
-    { NULL, { "そして", "ことにより", "ことや" } },
+    { nullptr, { "そして", "ことにより", "ことや" } },
 };
 
 /*!
@@ -151,7 +151,7 @@ void jverb(concptr in, char *out, int flag)
         }
     }
 
-    if (p->from == NULL)
+    if (p->from == nullptr)
         strcpy(&out[in_len], p->to[flag - 1]);
 }
 
@@ -418,7 +418,7 @@ static void ms_to_jis_unicode(char *str)
  */
 int utf8_to_euc(char *utf8_str, size_t utf8_str_len, char *euc_buf, size_t euc_buf_len)
 {
-    static iconv_t cd = NULL;
+    static iconv_t cd = nullptr;
     if (!cd)
         cd = iconv_open("EUC-JP", "UTF-8");
 
@@ -447,7 +447,7 @@ int utf8_to_euc(char *utf8_str, size_t utf8_str_len, char *euc_buf, size_t euc_b
  */
 int euc_to_utf8(const char *euc_str, size_t euc_str_len, char *utf8_buf, size_t utf8_buf_len)
 {
-    static iconv_t cd = NULL;
+    static iconv_t cd = nullptr;
     if (!cd)
         cd = iconv_open("UTF-8", "EUC-JP");
 
@@ -493,7 +493,7 @@ static bool utf8_to_sys(char *utf8_str, char *sys_str_buffer, size_t sys_str_buf
     }
 
     /* UTF-8 -> SJIS(CP932) */
-    if (WideCharToMultiByte(932, 0, utf16buf, -1, sys_str_buffer, sys_str_buflen, NULL, NULL) == 0) {
+    if (WideCharToMultiByte(932, 0, utf16buf, -1, sys_str_buffer, sys_str_buflen, nullptr, nullptr) == 0) {
         C_KILL(utf16buf, input_len, WCHAR);
         return false;
     }
@@ -522,7 +522,7 @@ void guess_convert_to_system_encoding(char *strbuf, int buflen)
         angband_strcpy(work, strbuf, buflen);
         if (!utf8_to_sys(work, strbuf, buflen)) {
             msg_print("警告:文字コードの変換に失敗しました");
-            msg_print(NULL);
+            msg_print(nullptr);
         }
         C_KILL(work, buflen, char);
     }

--- a/src/lore/combat-types-setter.cpp
+++ b/src/lore/combat-types-setter.cpp
@@ -8,7 +8,7 @@
 void set_monster_blow_method(lore_type *lore_ptr, int m)
 {
     rbm_type method = lore_ptr->r_ptr->blow[m].method;
-    lore_ptr->p = NULL;
+    lore_ptr->p = nullptr;
     lore_ptr->pc = TERM_WHITE;
     switch (method) {
     case RBM_HIT:
@@ -111,7 +111,7 @@ void set_monster_blow_method(lore_type *lore_ptr, int m)
 void set_monster_blow_effect(lore_type *lore_ptr, int m)
 {
     rbe_type effect = lore_ptr->r_ptr->blow[m].effect;
-    lore_ptr->q = NULL;
+    lore_ptr->q = nullptr;
     lore_ptr->qc = TERM_WHITE;
     switch (effect) {
     case RBE_SUPERHURT:

--- a/src/maid-x11.cpp
+++ b/src/maid-x11.cpp
@@ -222,7 +222,7 @@ static XImage *ReadBMP(Display *dpy, char *Name)
 
     /* No such file */
     if (f == NULL) {
-        return (NULL);
+        return nullptr;
     }
 
     /* Read the "BITMAPFILEHEADER" */
@@ -285,7 +285,7 @@ static XImage *ReadBMP(Display *dpy, char *Name)
     if (Res == NULL) {
         C_KILL(Data, total, char);
         fclose(f);
-        return (NULL);
+        return nullptr;
     }
 
     for (y = 0; y < static_cast<int>(infoheader.biHeight); y++) {

--- a/src/maid-x11.cpp
+++ b/src/maid-x11.cpp
@@ -73,7 +73,7 @@ static unsigned long create_pixel(Display *dpy, byte red, byte green, byte blue)
     XColor xcolour;
     if (!gamma_table_ready) {
         concptr str = getenv("ANGBAND_X11_GAMMA");
-        if (str != NULL)
+        if (str != nullptr)
             gamma_val = atoi(str);
 
         gamma_table_ready = true;
@@ -203,7 +203,7 @@ static XImage *ReadBMP(Display *dpy, char *Name)
     BITMAPFILEHEADER fileheader;
     BITMAPINFOHEADER infoheader;
 
-    XImage *Res = NULL;
+    XImage *Res = nullptr;
 
     char *Data;
 
@@ -221,7 +221,7 @@ static XImage *ReadBMP(Display *dpy, char *Name)
     f = fopen(Name, "r");
 
     /* No such file */
-    if (f == NULL) {
+    if (f == nullptr) {
         return nullptr;
     }
 
@@ -282,7 +282,7 @@ static XImage *ReadBMP(Display *dpy, char *Name)
     Res = XCreateImage(dpy, visual, depth, ZPixmap, 0 /*offset*/, Data, infoheader.biWidth, infoheader.biHeight, 8 /*bitmap_pad*/, 0 /*bytes_per_line*/);
 
     /* Failure */
-    if (Res == NULL) {
+    if (Res == nullptr) {
         C_KILL(Data, total, char);
         fclose(f);
         return nullptr;

--- a/src/maid-x11.cpp
+++ b/src/maid-x11.cpp
@@ -10,8 +10,8 @@
 
 #ifdef USE_X11
 
-#include <math.h>
 #include "main/x11-gamma-builder.h"
+#include <math.h>
 
 /*
  * This file defines some "XImage" manipulation functions for X11.
@@ -26,8 +26,6 @@
  * which will have already "included" several relevant header files.
  */
 
-
-
 #ifndef IsModifierKey
 
 /*
@@ -37,26 +35,19 @@
  * Also appears in "main-x11.c".
  */
 
-#define IsKeypadKey(keysym) \
-  (((unsigned)(keysym) >= XK_KP_Space) && ((unsigned)(keysym) <= XK_KP_Equal))
+#define IsKeypadKey(keysym) (((unsigned)(keysym) >= XK_KP_Space) && ((unsigned)(keysym) <= XK_KP_Equal))
 
-#define IsCursorKey(keysym) \
-  (((unsigned)(keysym) >= XK_Home)     && ((unsigned)(keysym) <  XK_Select))
+#define IsCursorKey(keysym) (((unsigned)(keysym) >= XK_Home) && ((unsigned)(keysym) < XK_Select))
 
-#define IsPFKey(keysym) \
-  (((unsigned)(keysym) >= XK_KP_F1)     && ((unsigned)(keysym) <= XK_KP_F4))
+#define IsPFKey(keysym) (((unsigned)(keysym) >= XK_KP_F1) && ((unsigned)(keysym) <= XK_KP_F4))
 
-#define IsFunctionKey(keysym) \
-  (((unsigned)(keysym) >= XK_F1)       && ((unsigned)(keysym) <= XK_F35))
+#define IsFunctionKey(keysym) (((unsigned)(keysym) >= XK_F1) && ((unsigned)(keysym) <= XK_F35))
 
-#define IsMiscFunctionKey(keysym) \
-  (((unsigned)(keysym) >= XK_Select)   && ((unsigned)(keysym) <  XK_KP_Space))
+#define IsMiscFunctionKey(keysym) (((unsigned)(keysym) >= XK_Select) && ((unsigned)(keysym) < XK_KP_Space))
 
-#define IsModifierKey(keysym) \
-  (((unsigned)(keysym) >= XK_Shift_L)  && ((unsigned)(keysym) <= XK_Hyper_R))
+#define IsModifierKey(keysym) (((unsigned)(keysym) >= XK_Shift_L) && ((unsigned)(keysym) <= XK_Hyper_R))
 
 #endif /* IsModifierKey */
-
 
 /*
  * Checks if the keysym is a special key or a normal key
@@ -64,13 +55,10 @@
  *
  * Also appears in "main-x11.c".
  */
-#define IsSpecialKey(keysym) \
-  ((unsigned)(keysym) >= 0xFF00)
-
+#define IsSpecialKey(keysym) ((unsigned)(keysym) >= 0xFF00)
 
 static bool gamma_table_ready = true;
 static int gamma_val = 0;
-
 
 /*
  * Hack -- Convert an RGB value to an X11 Pixel, or die.
@@ -81,130 +69,120 @@ static XftColor create_pixel(Display *dpy, byte red, byte green, byte blue)
 static unsigned long create_pixel(Display *dpy, byte red, byte green, byte blue)
 #endif
 {
-	Colormap cmap = DefaultColormapOfScreen(DefaultScreenOfDisplay(dpy));
-	XColor xcolour;
-	if (!gamma_table_ready)
-	{
-		concptr str = getenv("ANGBAND_X11_GAMMA");
-		if (str != NULL) gamma_val = atoi(str);
-		
-		gamma_table_ready = true;
-		
-		/* Only need to build the table if gamma exists */
-		if (gamma_val) build_gamma_table(gamma_val);
-	}
+    Colormap cmap = DefaultColormapOfScreen(DefaultScreenOfDisplay(dpy));
+    XColor xcolour;
+    if (!gamma_table_ready) {
+        concptr str = getenv("ANGBAND_X11_GAMMA");
+        if (str != NULL)
+            gamma_val = atoi(str);
 
-	/* Hack -- Gamma Correction */
-	if (gamma_val > 0)
-	{
-		red = gamma_table[red];
-		green = gamma_table[green];
-		blue = gamma_table[blue];
-	}
+        gamma_table_ready = true;
 
-	/* Build the color */
-	
-	xcolour.red = red * 255;
-	xcolour.green = green * 255;
-	xcolour.blue = blue * 255;
-	xcolour.flags = DoRed | DoGreen | DoBlue;
+        /* Only need to build the table if gamma exists */
+        if (gamma_val)
+            build_gamma_table(gamma_val);
+    }
+
+    /* Hack -- Gamma Correction */
+    if (gamma_val > 0) {
+        red = gamma_table[red];
+        green = gamma_table[green];
+        blue = gamma_table[blue];
+    }
+
+    /* Build the color */
+
+    xcolour.red = red * 255;
+    xcolour.green = green * 255;
+    xcolour.blue = blue * 255;
+    xcolour.flags = DoRed | DoGreen | DoBlue;
 
 #ifdef USE_XFT
-	XftColor color;
-	XRenderColor xcol;
-	xcol.red = xcolour.red;
-	xcol.green = xcolour.green;
-	xcol.blue = xcolour.blue;
-	xcol.alpha = 0xFFFF;
-	if (!XftColorAllocValue(dpy, DefaultVisual(dpy, 0), cmap, &xcol, &color))
-	{
-		quit_fmt("Couldn't allocate bitmap color '#%02x%02x%02x'\n",
-			 red, green, blue);
-	}
+    XftColor color;
+    XRenderColor xcol;
+    xcol.red = xcolour.red;
+    xcol.green = xcolour.green;
+    xcol.blue = xcolour.blue;
+    xcol.alpha = 0xFFFF;
+    if (!XftColorAllocValue(dpy, DefaultVisual(dpy, 0), cmap, &xcol, &color)) {
+        quit_fmt("Couldn't allocate bitmap color '#%02x%02x%02x'\n", red, green, blue);
+    }
 
-	return color;
+    return color;
 #else
-	/* Attempt to Allocate the Parsed color */
-	if (!(XAllocColor(dpy, cmap, &xcolour)))
-	{
-		quit_fmt("Couldn't allocate bitmap color '#%02x%02x%02x'\n",
-			 red, green, blue);
-	}
+    /* Attempt to Allocate the Parsed color */
+    if (!(XAllocColor(dpy, cmap, &xcolour))) {
+        quit_fmt("Couldn't allocate bitmap color '#%02x%02x%02x'\n", red, green, blue);
+    }
 
-	return (xcolour.pixel);
+    return (xcolour.pixel);
 #endif
 }
-
 
 #ifndef USE_XFT
 
 /*
  * The Win32 "BITMAPFILEHEADER" type.
  */
-typedef struct BITMAPFILEHEADER
-{
-	uint16_t bfType;
-	uint32_t bfSize;
-	uint16_t bfReserved1;
-	uint16_t bfReserved2;
-	uint32_t bfOffBits;
+typedef struct BITMAPFILEHEADER {
+    uint16_t bfType;
+    uint32_t bfSize;
+    uint16_t bfReserved1;
+    uint16_t bfReserved2;
+    uint32_t bfOffBits;
 } BITMAPFILEHEADER;
 
 /*
  * The Win32 "BITMAPINFOHEADER" type.
  */
-typedef struct BITMAPINFOHEADER
-{
-	uint32_t biSize;
-	uint32_t biWidth;
-	uint32_t biHeight;
-	uint16_t biPlanes;
-	uint16_t biBitCount;
-	uint32_t biCompresion;
-	uint32_t biSizeImage;
-	uint32_t biXPelsPerMeter;
-	uint32_t biYPelsPerMeter;
-	uint32_t biClrUsed;
-	uint32_t biClrImportand;
+typedef struct BITMAPINFOHEADER {
+    uint32_t biSize;
+    uint32_t biWidth;
+    uint32_t biHeight;
+    uint16_t biPlanes;
+    uint16_t biBitCount;
+    uint32_t biCompresion;
+    uint32_t biSizeImage;
+    uint32_t biXPelsPerMeter;
+    uint32_t biYPelsPerMeter;
+    uint32_t biClrUsed;
+    uint32_t biClrImportand;
 } BITMAPINFOHEADER;
 
 /*
  * The Win32 "RGBQUAD" type.
  */
-typedef struct RGBQUAD
-{
-	unsigned char b, g, r;
-	unsigned char filler;
+typedef struct RGBQUAD {
+    unsigned char b, g, r;
+    unsigned char filler;
 } RGBQUAD;
-
 
 /*** Helper functions for system independent file loading. ***/
 
 static byte get_byte(FILE *fff)
 {
-	/* Get a character, and return it */
-	return (getc(fff) & 0xFF);
+    /* Get a character, and return it */
+    return (getc(fff) & 0xFF);
 }
 
 static void rd_byte(FILE *fff, byte *ip)
 {
-	*ip = get_byte(fff);
+    *ip = get_byte(fff);
 }
 
 static void rd_u16b(FILE *fff, uint16_t *ip)
 {
-	(*ip) = get_byte(fff);
-	(*ip) |= ((uint16_t)(get_byte(fff)) << 8);
+    (*ip) = get_byte(fff);
+    (*ip) |= ((uint16_t)(get_byte(fff)) << 8);
 }
 
 static void rd_u32b(FILE *fff, uint32_t *ip)
 {
-	(*ip) = get_byte(fff);
-	(*ip) |= ((uint32_t)(get_byte(fff)) << 8);
-	(*ip) |= ((uint32_t)(get_byte(fff)) << 16);
-	(*ip) |= ((uint32_t)(get_byte(fff)) << 24);
+    (*ip) = get_byte(fff);
+    (*ip) |= ((uint32_t)(get_byte(fff)) << 8);
+    (*ip) |= ((uint32_t)(get_byte(fff)) << 16);
+    (*ip) |= ((uint32_t)(get_byte(fff)) << 24);
 }
-
 
 /*
  * Read a Win32 BMP file.
@@ -216,153 +194,136 @@ static void rd_u32b(FILE *fff, uint32_t *ip)
  */
 static XImage *ReadBMP(Display *dpy, char *Name)
 {
-	Visual *visual = DefaultVisual(dpy, DefaultScreen(dpy));
+    Visual *visual = DefaultVisual(dpy, DefaultScreen(dpy));
 
-	int depth = DefaultDepth(dpy, DefaultScreen(dpy));
+    int depth = DefaultDepth(dpy, DefaultScreen(dpy));
 
-	FILE *f;
+    FILE *f;
 
-	BITMAPFILEHEADER fileheader;
-	BITMAPINFOHEADER infoheader;
+    BITMAPFILEHEADER fileheader;
+    BITMAPINFOHEADER infoheader;
 
-	XImage *Res = NULL;
+    XImage *Res = NULL;
 
-	char *Data;
+    char *Data;
 
-	int ncol;
+    int ncol;
 
-	int total;
+    int total;
 
-	int i, j;
+    int i, j;
 
-	int x, y;
+    int x, y;
 
-	unsigned long clr_pixels[256];
+    unsigned long clr_pixels[256];
 
+    /* Open the BMP file */
+    f = fopen(Name, "r");
 
-	/* Open the BMP file */
-	f = fopen(Name, "r");
+    /* No such file */
+    if (f == NULL) {
+        return (NULL);
+    }
 
-	/* No such file */
-	if (f == NULL)
-	{
-		return (NULL);
-	}
+    /* Read the "BITMAPFILEHEADER" */
+    rd_u16b(f, &(fileheader.bfType));
+    rd_u32b(f, &(fileheader.bfSize));
+    rd_u16b(f, &(fileheader.bfReserved1));
+    rd_u16b(f, &(fileheader.bfReserved2));
+    rd_u32b(f, &(fileheader.bfOffBits));
 
-	/* Read the "BITMAPFILEHEADER" */
-	rd_u16b(f, &(fileheader.bfType));
-	rd_u32b(f, &(fileheader.bfSize));
-	rd_u16b(f, &(fileheader.bfReserved1));
-	rd_u16b(f, &(fileheader.bfReserved2));
-	rd_u32b(f, &(fileheader.bfOffBits));
+    /* Read the "BITMAPINFOHEADER" */
+    rd_u32b(f, &(infoheader.biSize));
+    rd_u32b(f, &(infoheader.biWidth));
+    rd_u32b(f, &(infoheader.biHeight));
+    rd_u16b(f, &(infoheader.biPlanes));
+    rd_u16b(f, &(infoheader.biBitCount));
+    rd_u32b(f, &(infoheader.biCompresion));
+    rd_u32b(f, &(infoheader.biSizeImage));
+    rd_u32b(f, &(infoheader.biXPelsPerMeter));
+    rd_u32b(f, &(infoheader.biYPelsPerMeter));
+    rd_u32b(f, &(infoheader.biClrUsed));
+    rd_u32b(f, &(infoheader.biClrImportand));
 
-	/* Read the "BITMAPINFOHEADER" */
-	rd_u32b(f, &(infoheader.biSize));
-	rd_u32b(f, &(infoheader.biWidth));
-	rd_u32b(f, &(infoheader.biHeight));
-	rd_u16b(f, &(infoheader.biPlanes));
-	rd_u16b(f, &(infoheader.biBitCount));
-	rd_u32b(f, &(infoheader.biCompresion));
-	rd_u32b(f, &(infoheader.biSizeImage));
-	rd_u32b(f, &(infoheader.biXPelsPerMeter));
-	rd_u32b(f, &(infoheader.biYPelsPerMeter));
-	rd_u32b(f, &(infoheader.biClrUsed));
-	rd_u32b(f, &(infoheader.biClrImportand));
+    /* Verify the header */
+    if (feof(f) || (fileheader.bfType != 19778) || (infoheader.biSize != 40)) {
+        quit_fmt("Incorrect BMP file format %s", Name);
+    }
 
-	/* Verify the header */
-	if (feof(f) ||
-	    (fileheader.bfType != 19778) ||
-	    (infoheader.biSize != 40))
-	{
-		quit_fmt("Incorrect BMP file format %s", Name);
-	}
+    /* The two headers above occupy 54 bytes total */
+    /* The "bfOffBits" field says where the data starts */
+    /* The "biClrUsed" field does not seem to be reliable */
+    /* Compute number of colors recorded */
+    ncol = (fileheader.bfOffBits - 54) / 4;
 
-	/* The two headers above occupy 54 bytes total */
-	/* The "bfOffBits" field says where the data starts */
-	/* The "biClrUsed" field does not seem to be reliable */
-	/* Compute number of colors recorded */
-	ncol = (fileheader.bfOffBits - 54) / 4;
+    for (i = 0; i < ncol; i++) {
+        RGBQUAD clrg;
 
-	for (i = 0; i < ncol; i++)
-	{
-		RGBQUAD clrg;
+        /* Read an "RGBQUAD" */
+        rd_byte(f, &(clrg.b));
+        rd_byte(f, &(clrg.g));
+        rd_byte(f, &(clrg.r));
+        rd_byte(f, &(clrg.filler));
 
-		/* Read an "RGBQUAD" */
-		rd_byte(f, &(clrg.b));
-		rd_byte(f, &(clrg.g));
-		rd_byte(f, &(clrg.r));
-		rd_byte(f, &(clrg.filler));
-		
-		/* Analyze the color */
-		clr_pixels[i] = create_pixel(dpy, clrg.r, clrg.g, clrg.b);
-	}
+        /* Analyze the color */
+        clr_pixels[i] = create_pixel(dpy, clrg.r, clrg.g, clrg.b);
+    }
 
-	/* Determine total bytes needed for image */
-	i = 1;
-	j = (depth - 1) >> 2;
-	while (j >>= 1) i <<= 1;
-	total = infoheader.biWidth * infoheader.biHeight * i;
+    /* Determine total bytes needed for image */
+    i = 1;
+    j = (depth - 1) >> 2;
+    while (j >>= 1)
+        i <<= 1;
+    total = infoheader.biWidth * infoheader.biHeight * i;
 
-	/* Allocate image memory */
-	C_MAKE(Data, total, char);
+    /* Allocate image memory */
+    C_MAKE(Data, total, char);
 
-	Res = XCreateImage(dpy, visual, depth, ZPixmap, 0 /*offset*/,
-			   Data, infoheader.biWidth, infoheader.biHeight,
-			   8 /*bitmap_pad*/, 0 /*bytes_per_line*/);
+    Res = XCreateImage(dpy, visual, depth, ZPixmap, 0 /*offset*/, Data, infoheader.biWidth, infoheader.biHeight, 8 /*bitmap_pad*/, 0 /*bytes_per_line*/);
 
-	/* Failure */
-	if (Res == NULL)
-	{
-		C_KILL(Data, total, char);
-		fclose(f);
-		return (NULL);
-	}
+    /* Failure */
+    if (Res == NULL) {
+        C_KILL(Data, total, char);
+        fclose(f);
+        return (NULL);
+    }
 
-	for (y = 0; y < static_cast<int>(infoheader.biHeight); y++)
-	{
-		int y2 = infoheader.biHeight - y - 1;
+    for (y = 0; y < static_cast<int>(infoheader.biHeight); y++) {
+        int y2 = infoheader.biHeight - y - 1;
 
-		for (x = 0; x < static_cast<int>(infoheader.biWidth); x++)
-		{
-			int ch = getc(f);
+        for (x = 0; x < static_cast<int>(infoheader.biWidth); x++) {
+            int ch = getc(f);
 
-			/* Verify not at end of file XXX XXX */
-			if (feof(f)) quit_fmt("Unexpected end of file in %s", Name);
+            /* Verify not at end of file XXX XXX */
+            if (feof(f))
+                quit_fmt("Unexpected end of file in %s", Name);
 
-			if (infoheader.biBitCount == 24)
-			{
-				int c2 = getc(f);
-				int c3 = getc(f);
+            if (infoheader.biBitCount == 24) {
+                int c2 = getc(f);
+                int c3 = getc(f);
 
-				/* Verify not at end of file XXX XXX */
-				if (feof(f)) quit_fmt("Unexpected end of file in %s", Name);
+                /* Verify not at end of file XXX XXX */
+                if (feof(f))
+                    quit_fmt("Unexpected end of file in %s", Name);
 
-				XPutPixel(Res, x, y2, create_pixel(dpy, ch, c2, c3));
-			}
-			else if (infoheader.biBitCount == 8)
-			{
-				XPutPixel(Res, x, y2, clr_pixels[ch]);
-			}
-			else if (infoheader.biBitCount == 4)
-			{
-				XPutPixel(Res, x, y2, clr_pixels[ch / 16]);
-				x++;
-				XPutPixel(Res, x, y2, clr_pixels[ch % 16]);
-			}
-			else
-			{
-				/* Technically 1 bit is legal too */
-				quit_fmt("Illegal biBitCount %d in %s",
-					 infoheader.biBitCount, Name);
-			}
-		}
-	}
+                XPutPixel(Res, x, y2, create_pixel(dpy, ch, c2, c3));
+            } else if (infoheader.biBitCount == 8) {
+                XPutPixel(Res, x, y2, clr_pixels[ch]);
+            } else if (infoheader.biBitCount == 4) {
+                XPutPixel(Res, x, y2, clr_pixels[ch / 16]);
+                x++;
+                XPutPixel(Res, x, y2, clr_pixels[ch % 16]);
+            } else {
+                /* Technically 1 bit is legal too */
+                quit_fmt("Illegal biBitCount %d in %s", infoheader.biBitCount, Name);
+            }
+        }
+    }
 
-	fclose(f);
+    fclose(f);
 
-	return Res;
+    return Res;
 }
-
 
 /* ========================================================*/
 /* Code for smooth icon rescaling from Uwe Siems, Jan 2000 */
@@ -373,19 +334,16 @@ static XImage *ReadBMP(Display *dpy, char *Name)
  */
 #define MAX_ICON_WIDTH 32
 
-
 /* some static variables for composing and decomposing pixel values into
  * red, green and blue values
  */
 static unsigned long redMask, greenMask, blueMask;
 static int redShift, greenShift, blueShift;
 
-
 /*
  * Use smooth rescaling?
  */
 static bool smoothRescaling = true;
-
 
 /*
  * GetScaledRow reads a scan from the given XImage, scales it smoothly
@@ -395,141 +353,120 @@ static bool smoothRescaling = true;
  * x, y is the position, iw is the input width and ow the output width
  * redScan, greenScan and blueScan must be sufficiently sized
  */
-static void GetScaledRow(XImage *Im, int x, int y, int iw, int ow,
-			 unsigned long *redScan, unsigned long *greenScan,
-			 unsigned long *blueScan)
+static void GetScaledRow(XImage *Im, int x, int y, int iw, int ow, unsigned long *redScan, unsigned long *greenScan, unsigned long *blueScan)
 {
-	int xi, si, sifrac, ci, cifrac, addWhole, addFrac;
-	unsigned long pix;
-	int prevRed, prevGreen, prevBlue, nextRed, nextGreen, nextBlue;
-	bool getNextPix;
+    int xi, si, sifrac, ci, cifrac, addWhole, addFrac;
+    unsigned long pix;
+    int prevRed, prevGreen, prevBlue, nextRed, nextGreen, nextBlue;
+    bool getNextPix;
 
-	if (iw == ow)
-	{
-		/* unscaled */
-		for (xi = 0; xi < ow; xi++)
-		{
-			pix = XGetPixel(Im, x + xi, y);
-			redScan   [xi] = (pix >> redShift) & redMask;
-			greenScan [xi] = (pix >> greenShift) & greenMask;
-			blueScan  [xi] = (pix >> blueShift) & blueMask;
-		}
-	}
-	else if (iw < ow)
-	{
-		/* scaling by subsampling (grow) */
-		iw--;
-		ow--;
-		/* read first pixel: */
-		pix = XGetPixel(Im, x, y);
-		nextRed   = (pix >> redShift) & redMask;
-		nextGreen = (pix >> greenShift) & greenMask;
-		nextBlue  = (pix >> blueShift) & blueMask;
-		prevRed   = nextRed;
-		prevGreen = nextGreen;
-		prevBlue  = nextBlue;
-		/* si and sifrac give the subsampling position: */
-		si = x;
-		sifrac = 0;
-		/* getNextPix tells us, that we need the next pixel */
-		getNextPix = true;
+    if (iw == ow) {
+        /* unscaled */
+        for (xi = 0; xi < ow; xi++) {
+            pix = XGetPixel(Im, x + xi, y);
+            redScan[xi] = (pix >> redShift) & redMask;
+            greenScan[xi] = (pix >> greenShift) & greenMask;
+            blueScan[xi] = (pix >> blueShift) & blueMask;
+        }
+    } else if (iw < ow) {
+        /* scaling by subsampling (grow) */
+        iw--;
+        ow--;
+        /* read first pixel: */
+        pix = XGetPixel(Im, x, y);
+        nextRed = (pix >> redShift) & redMask;
+        nextGreen = (pix >> greenShift) & greenMask;
+        nextBlue = (pix >> blueShift) & blueMask;
+        prevRed = nextRed;
+        prevGreen = nextGreen;
+        prevBlue = nextBlue;
+        /* si and sifrac give the subsampling position: */
+        si = x;
+        sifrac = 0;
+        /* getNextPix tells us, that we need the next pixel */
+        getNextPix = true;
 
-		for (xi = 0; xi <= ow; xi++)
-		{
-			if (getNextPix)
-			{
-				prevRed   = nextRed;
-				prevGreen = nextGreen;
-				prevBlue  = nextBlue;
-				if (xi < ow)
-				{
-					/* only get next pixel if in same icon */
-					pix = XGetPixel(Im, si + 1, y);
-					nextRed   = (pix >> redShift) & redMask;
-					nextGreen = (pix >> greenShift) & greenMask;
-					nextBlue  = (pix >> blueShift) & blueMask;
-				}
-			}
+        for (xi = 0; xi <= ow; xi++) {
+            if (getNextPix) {
+                prevRed = nextRed;
+                prevGreen = nextGreen;
+                prevBlue = nextBlue;
+                if (xi < ow) {
+                    /* only get next pixel if in same icon */
+                    pix = XGetPixel(Im, si + 1, y);
+                    nextRed = (pix >> redShift) & redMask;
+                    nextGreen = (pix >> greenShift) & greenMask;
+                    nextBlue = (pix >> blueShift) & blueMask;
+                }
+            }
 
-			/* calculate subsampled color values: */
-			/* division by ow occurs in ScaleIcon */
-			redScan   [xi] = prevRed   * (ow - sifrac) + nextRed   * sifrac;
-			greenScan [xi] = prevGreen * (ow - sifrac) + nextGreen * sifrac;
-			blueScan  [xi] = prevBlue  * (ow - sifrac) + nextBlue  * sifrac;
+            /* calculate subsampled color values: */
+            /* division by ow occurs in ScaleIcon */
+            redScan[xi] = prevRed * (ow - sifrac) + nextRed * sifrac;
+            greenScan[xi] = prevGreen * (ow - sifrac) + nextGreen * sifrac;
+            blueScan[xi] = prevBlue * (ow - sifrac) + nextBlue * sifrac;
 
-			/* advance sampling position: */
-			sifrac += iw;
-			if (sifrac >= ow)
-			{
-				si++;
-				sifrac -= ow;
-				getNextPix = true;
-			}
-			else
-			{
-				getNextPix = true;
-			}
-
-		}
-	}
-	else
-	{
-		/* scaling by averaging (shrink) */
-		/* width of an output pixel in input pixels: */
-		addWhole = iw / ow;
-		addFrac = iw % ow;
-		/* start position of the first output pixel: */
-		si = x;
-		sifrac = 0;
-		/* get first input pixel: */
-		pix = XGetPixel(Im, x, y);
-		nextRed   = (pix >> redShift) & redMask;
-		nextGreen = (pix >> greenShift) & greenMask;
-		nextBlue  = (pix >> blueShift) & blueMask;
-		for (xi = 0; xi < ow; xi++)
-		{
-			/* find endpoint of the current output pixel: */
-			ci = si + addWhole;
-			cifrac = sifrac + addFrac;
-			if (cifrac >= ow)
-			{
-				ci++;
-				cifrac -= ow;
-			}
-			/* take fraction of current input pixel (starting segment): */
-			redScan[xi]   = nextRed   * (ow - sifrac);
-			greenScan[xi] = nextGreen * (ow - sifrac);
-			blueScan[xi]  = nextBlue  * (ow - sifrac);
-			si++;
-			/* add values for whole pixels: */
-			while (si < ci)
-			{
-				pix = XGetPixel(Im, si, y);
-				redScan[xi]   += ((pix >> redShift) & redMask)	 *ow;
-				greenScan[xi] += ((pix >> greenShift) & greenMask) *ow;
-				blueScan[xi]  += ((pix >> blueShift) & blueMask)   *ow;
-				si++;
-			}
-			/* add fraction of current input pixel (ending segment): */
-			if (xi < ow - 1)
-			{
-				/* only get next pixel if still in icon: */
-				pix = XGetPixel(Im, si, y);
-				nextRed   = (pix >> redShift) & redMask;
-				nextGreen = (pix >> greenShift) & greenMask;
-				nextBlue  = (pix >> blueShift) & blueMask;
-			}
-			sifrac = cifrac;
-			if (sifrac > 0)
-			{
-				redScan[xi]   += nextRed   * sifrac;
-				greenScan[xi] += nextGreen * sifrac;
-				blueScan[xi]  += nextBlue  * sifrac;
-			}
-		}
-	}
+            /* advance sampling position: */
+            sifrac += iw;
+            if (sifrac >= ow) {
+                si++;
+                sifrac -= ow;
+                getNextPix = true;
+            } else {
+                getNextPix = true;
+            }
+        }
+    } else {
+        /* scaling by averaging (shrink) */
+        /* width of an output pixel in input pixels: */
+        addWhole = iw / ow;
+        addFrac = iw % ow;
+        /* start position of the first output pixel: */
+        si = x;
+        sifrac = 0;
+        /* get first input pixel: */
+        pix = XGetPixel(Im, x, y);
+        nextRed = (pix >> redShift) & redMask;
+        nextGreen = (pix >> greenShift) & greenMask;
+        nextBlue = (pix >> blueShift) & blueMask;
+        for (xi = 0; xi < ow; xi++) {
+            /* find endpoint of the current output pixel: */
+            ci = si + addWhole;
+            cifrac = sifrac + addFrac;
+            if (cifrac >= ow) {
+                ci++;
+                cifrac -= ow;
+            }
+            /* take fraction of current input pixel (starting segment): */
+            redScan[xi] = nextRed * (ow - sifrac);
+            greenScan[xi] = nextGreen * (ow - sifrac);
+            blueScan[xi] = nextBlue * (ow - sifrac);
+            si++;
+            /* add values for whole pixels: */
+            while (si < ci) {
+                pix = XGetPixel(Im, si, y);
+                redScan[xi] += ((pix >> redShift) & redMask) * ow;
+                greenScan[xi] += ((pix >> greenShift) & greenMask) * ow;
+                blueScan[xi] += ((pix >> blueShift) & blueMask) * ow;
+                si++;
+            }
+            /* add fraction of current input pixel (ending segment): */
+            if (xi < ow - 1) {
+                /* only get next pixel if still in icon: */
+                pix = XGetPixel(Im, si, y);
+                nextRed = (pix >> redShift) & redMask;
+                nextGreen = (pix >> greenShift) & greenMask;
+                nextBlue = (pix >> blueShift) & blueMask;
+            }
+            sifrac = cifrac;
+            if (sifrac > 0) {
+                redScan[xi] += nextRed * sifrac;
+                greenScan[xi] += nextGreen * sifrac;
+                blueScan[xi] += nextBlue * sifrac;
+            }
+        }
+    }
 }
-
 
 /*
  * PutRGBScan takes arrays for red, green and blue and writes pixel values
@@ -537,22 +474,17 @@ static void GetScaledRow(XImage *Im, int x, int y, int iw, int ow,
  * pixels to write and div is the value by which all red/green/blue values
  * are divided first.
  */
-static void PutRGBScan(XImage *Im, int x, int y, int w, int div,
-		       unsigned long *redScan, unsigned long *greenScan,
-		       unsigned long *blueScan)
+static void PutRGBScan(XImage *Im, int x, int y, int w, int div, unsigned long *redScan, unsigned long *greenScan, unsigned long *blueScan)
 {
-	int xi;
-	unsigned long pix;
-	unsigned long adj = div / 2;
-	for (xi = 0; xi < w; xi++)
-	{
-		pix = (((((redScan[xi] + adj) / div) & redMask) << redShift) +
-		       ((((greenScan[xi] + adj) / div) & greenMask) << greenShift) +
-		       ((((blueScan[xi] + adj) / div) & blueMask) << blueShift));
-		XPutPixel(Im, x + xi, y, pix);
-	}
+    int xi;
+    unsigned long pix;
+    unsigned long adj = div / 2;
+    for (xi = 0; xi < w; xi++) {
+        pix = (((((redScan[xi] + adj) / div) & redMask) << redShift) + ((((greenScan[xi] + adj) / div) & greenMask) << greenShift)
+            + ((((blueScan[xi] + adj) / div) & blueMask) << blueShift));
+        XPutPixel(Im, x + xi, y, pix);
+    }
 }
-
 
 /*
  * ScaleIcon transfers an area from XImage ImIn, locate (x1,y1) to ImOut,
@@ -563,332 +495,271 @@ static void PutRGBScan(XImage *Im, int x, int y, int w, int div,
  * This even allows icons to be scaled differently in horizontal and
  * vertical directions (eg. shrink horizontal, grow vertical).
  */
-static void ScaleIcon(XImage *ImIn, XImage *ImOut,
-		      int x1, int y1, int x2, int y2,
-		      int ix, int iy, int ox, int oy)
+static void ScaleIcon(XImage *ImIn, XImage *ImOut, int x1, int y1, int x2, int y2, int ix, int iy, int ox, int oy)
 {
-	int div;
-	int xi, yi, si, sifrac, ci, cifrac, addWhole, addFrac;
+    int div;
+    int xi, yi, si, sifrac, ci, cifrac, addWhole, addFrac;
 
-	/* buffers for pixel rows: */
-	unsigned long prevRed   [MAX_ICON_WIDTH];
-	unsigned long prevGreen [MAX_ICON_WIDTH];
-	unsigned long prevBlue  [MAX_ICON_WIDTH];
-	unsigned long nextRed   [MAX_ICON_WIDTH];
-	unsigned long nextGreen [MAX_ICON_WIDTH];
-	unsigned long nextBlue  [MAX_ICON_WIDTH];
-	unsigned long tempRed   [MAX_ICON_WIDTH];
-	unsigned long tempGreen [MAX_ICON_WIDTH];
-	unsigned long tempBlue  [MAX_ICON_WIDTH];
+    /* buffers for pixel rows: */
+    unsigned long prevRed[MAX_ICON_WIDTH];
+    unsigned long prevGreen[MAX_ICON_WIDTH];
+    unsigned long prevBlue[MAX_ICON_WIDTH];
+    unsigned long nextRed[MAX_ICON_WIDTH];
+    unsigned long nextGreen[MAX_ICON_WIDTH];
+    unsigned long nextBlue[MAX_ICON_WIDTH];
+    unsigned long tempRed[MAX_ICON_WIDTH];
+    unsigned long tempGreen[MAX_ICON_WIDTH];
+    unsigned long tempBlue[MAX_ICON_WIDTH];
 
-	bool getNextRow;
+    bool getNextRow;
 
-	/* get divider value for the horizontal scaling: */
-	if (ix == ox)
-		div = 1;
-	else if (ix < ox)
-		div = ox - 1;
-	else
-		div = ix;
+    /* get divider value for the horizontal scaling: */
+    if (ix == ox)
+        div = 1;
+    else if (ix < ox)
+        div = ox - 1;
+    else
+        div = ix;
 
-	if (iy == oy)
-	{
-		/* no scaling needed vertically: */
-		for (yi = 0; yi < oy; yi++)
-		{
-			GetScaledRow(ImIn, x1, y1 + yi, ix, ox,
-				     tempRed, tempGreen, tempBlue);
-			PutRGBScan(ImOut, x2, y2 + yi, ox, div,
-				   tempRed, tempGreen, tempBlue);
-		}
-	}
-	else if (iy < oy)
-	{
-		/* scaling by subsampling (grow): */
-		iy--;
-		oy--;
-		div *= oy;
-		/* get first row: */
-		GetScaledRow(ImIn, x1, y1, ix, ox, nextRed, nextGreen, nextBlue);
-		/* si and sifrac give the subsampling position: */
-		si = y1;
-		sifrac = 0;
-		/* getNextRow tells us, that we need the next row */
-		getNextRow = true;
-		for (yi = 0; yi <= oy; yi++)
-		{
-			if (getNextRow)
-			{
-				for (xi = 0; xi < ox; xi++)
-				{
-					prevRed[xi]   = nextRed[xi];
-					prevGreen[xi] = nextGreen[xi];
-					prevBlue[xi]  = nextBlue[xi];
-				}
-				if (yi < oy)
-				{
-					/* only get next row if in same icon */
-					GetScaledRow(ImIn, x1, si + 1, ix, ox,
-						     nextRed, nextGreen, nextBlue);
-				}
-			}
+    if (iy == oy) {
+        /* no scaling needed vertically: */
+        for (yi = 0; yi < oy; yi++) {
+            GetScaledRow(ImIn, x1, y1 + yi, ix, ox, tempRed, tempGreen, tempBlue);
+            PutRGBScan(ImOut, x2, y2 + yi, ox, div, tempRed, tempGreen, tempBlue);
+        }
+    } else if (iy < oy) {
+        /* scaling by subsampling (grow): */
+        iy--;
+        oy--;
+        div *= oy;
+        /* get first row: */
+        GetScaledRow(ImIn, x1, y1, ix, ox, nextRed, nextGreen, nextBlue);
+        /* si and sifrac give the subsampling position: */
+        si = y1;
+        sifrac = 0;
+        /* getNextRow tells us, that we need the next row */
+        getNextRow = true;
+        for (yi = 0; yi <= oy; yi++) {
+            if (getNextRow) {
+                for (xi = 0; xi < ox; xi++) {
+                    prevRed[xi] = nextRed[xi];
+                    prevGreen[xi] = nextGreen[xi];
+                    prevBlue[xi] = nextBlue[xi];
+                }
+                if (yi < oy) {
+                    /* only get next row if in same icon */
+                    GetScaledRow(ImIn, x1, si + 1, ix, ox, nextRed, nextGreen, nextBlue);
+                }
+            }
 
-			/* calculate subsampled color values: */
-			/* division by oy occurs in PutRGBScan */
-			for (xi = 0; xi < ox; xi++)
-			{
-				tempRed[xi] = (prevRed[xi] * (oy - sifrac) +
-					       nextRed[xi] * sifrac);
-				tempGreen[xi] = (prevGreen[xi] * (oy - sifrac) +
-						 nextGreen[xi] * sifrac);
-				tempBlue[xi] = (prevBlue[xi] * (oy - sifrac) +
-						nextBlue[xi] * sifrac);
-			}
+            /* calculate subsampled color values: */
+            /* division by oy occurs in PutRGBScan */
+            for (xi = 0; xi < ox; xi++) {
+                tempRed[xi] = (prevRed[xi] * (oy - sifrac) + nextRed[xi] * sifrac);
+                tempGreen[xi] = (prevGreen[xi] * (oy - sifrac) + nextGreen[xi] * sifrac);
+                tempBlue[xi] = (prevBlue[xi] * (oy - sifrac) + nextBlue[xi] * sifrac);
+            }
 
-			/* write row to output image: */
-			PutRGBScan(ImOut, x2, y2 + yi, ox, div,
-				   tempRed, tempGreen, tempBlue);
+            /* write row to output image: */
+            PutRGBScan(ImOut, x2, y2 + yi, ox, div, tempRed, tempGreen, tempBlue);
 
-			/* advance sampling position: */
-			sifrac += iy;
-			if (sifrac >= oy)
-			{
-				si++;
-				sifrac -= oy;
-				getNextRow = true;
-			}
-			else
-			{
-				getNextRow = true;
-			}
-
-		}
-	}
-	else
-	{
-		/* scaling by averaging (shrink) */
-		div *= iy;
-		/* height of a output row in input rows: */
-		addWhole = iy / oy;
-		addFrac = iy % oy;
-		/* start position of the first output row: */
-		si = y1;
-		sifrac = 0;
-		/* get first input row: */
-		GetScaledRow(ImIn, x1, y1, ix, ox, nextRed, nextGreen, nextBlue);
-		for (yi = 0; yi < oy; yi++)
-		{
-			/* find endpoint of the current output row: */
-			ci = si + addWhole;
-			cifrac = sifrac + addFrac;
-			if (cifrac >= oy)
-			{
-				ci++;
-				cifrac -= oy;
-			}
-			/* take fraction of current input row (starting segment): */
-			for (xi = 0; xi < ox; xi++)
-			{
-				tempRed[xi]   = nextRed[xi]   * (oy - sifrac);
-				tempGreen[xi] = nextGreen[xi] * (oy - sifrac);
-				tempBlue[xi]  = nextBlue[xi]  * (oy - sifrac);
-			}
-			si++;
-			/* add values for whole pixels: */
-			while (si < ci)
-			{
-				GetScaledRow(ImIn, x1, si, ix, ox,
-					     nextRed, nextGreen, nextBlue);
-				for (xi = 0; xi < ox; xi++)
-				{
-					tempRed[xi]   += nextRed[xi]   * oy;
-					tempGreen[xi] += nextGreen[xi] * oy;
-					tempBlue[xi]  += nextBlue[xi]  * oy;
-				}
-				si++;
-			}
-			/* add fraction of current input row (ending segment): */
-			if (yi < oy - 1)
-			{
-				/* only get next row if still in icon: */
-				GetScaledRow(ImIn, x1, si, ix, ox,
-					     nextRed, nextGreen, nextBlue);
-			}
-			sifrac = cifrac;
-			for (xi = 0; xi < ox; xi++)
-			{
-				tempRed[xi]   += nextRed[xi]   * sifrac;
-				tempGreen[xi] += nextGreen[xi] * sifrac;
-				tempBlue[xi]  += nextBlue[xi]  * sifrac;
-			}
-			/* write row to output image: */
-			PutRGBScan(ImOut, x2, y2 + yi, ox, div,
-				   tempRed, tempGreen, tempBlue);
-		}
-	}
+            /* advance sampling position: */
+            sifrac += iy;
+            if (sifrac >= oy) {
+                si++;
+                sifrac -= oy;
+                getNextRow = true;
+            } else {
+                getNextRow = true;
+            }
+        }
+    } else {
+        /* scaling by averaging (shrink) */
+        div *= iy;
+        /* height of a output row in input rows: */
+        addWhole = iy / oy;
+        addFrac = iy % oy;
+        /* start position of the first output row: */
+        si = y1;
+        sifrac = 0;
+        /* get first input row: */
+        GetScaledRow(ImIn, x1, y1, ix, ox, nextRed, nextGreen, nextBlue);
+        for (yi = 0; yi < oy; yi++) {
+            /* find endpoint of the current output row: */
+            ci = si + addWhole;
+            cifrac = sifrac + addFrac;
+            if (cifrac >= oy) {
+                ci++;
+                cifrac -= oy;
+            }
+            /* take fraction of current input row (starting segment): */
+            for (xi = 0; xi < ox; xi++) {
+                tempRed[xi] = nextRed[xi] * (oy - sifrac);
+                tempGreen[xi] = nextGreen[xi] * (oy - sifrac);
+                tempBlue[xi] = nextBlue[xi] * (oy - sifrac);
+            }
+            si++;
+            /* add values for whole pixels: */
+            while (si < ci) {
+                GetScaledRow(ImIn, x1, si, ix, ox, nextRed, nextGreen, nextBlue);
+                for (xi = 0; xi < ox; xi++) {
+                    tempRed[xi] += nextRed[xi] * oy;
+                    tempGreen[xi] += nextGreen[xi] * oy;
+                    tempBlue[xi] += nextBlue[xi] * oy;
+                }
+                si++;
+            }
+            /* add fraction of current input row (ending segment): */
+            if (yi < oy - 1) {
+                /* only get next row if still in icon: */
+                GetScaledRow(ImIn, x1, si, ix, ox, nextRed, nextGreen, nextBlue);
+            }
+            sifrac = cifrac;
+            for (xi = 0; xi < ox; xi++) {
+                tempRed[xi] += nextRed[xi] * sifrac;
+                tempGreen[xi] += nextGreen[xi] * sifrac;
+                tempBlue[xi] += nextBlue[xi] * sifrac;
+            }
+            /* write row to output image: */
+            PutRGBScan(ImOut, x2, y2 + yi, ox, div, tempRed, tempGreen, tempBlue);
+        }
+    }
 }
 
-
-
-static XImage *ResizeImageSmooth(Display *dpy, XImage *Im,
-				 int ix, int iy, int ox, int oy)
+static XImage *ResizeImageSmooth(Display *dpy, XImage *Im, int ix, int iy, int ox, int oy)
 {
-	Visual *visual = DefaultVisual(dpy, DefaultScreen(dpy));
+    Visual *visual = DefaultVisual(dpy, DefaultScreen(dpy));
 
-	int width1, height1, width2, height2;
-	int x1, x2, y1, y2;
+    int width1, height1, width2, height2;
+    int x1, x2, y1, y2;
 
-	XImage *Tmp;
+    XImage *Tmp;
 
-	char *Data;
+    char *Data;
 
-	width1 = Im->width;
-	height1 = Im->height;
+    width1 = Im->width;
+    height1 = Im->height;
 
-	width2 = ox * width1 / ix;
-	height2 = oy * height1 / iy;
+    width2 = ox * width1 / ix;
+    height2 = oy * height1 / iy;
 
-	Data = (char *)malloc(width2 * height2 * Im->bits_per_pixel / 8);
+    Data = (char *)malloc(width2 * height2 * Im->bits_per_pixel / 8);
 
-	Tmp = XCreateImage(dpy, visual,
-			   Im->depth, ZPixmap, 0, Data, width2, height2,
-			   32, 0);
+    Tmp = XCreateImage(dpy, visual, Im->depth, ZPixmap, 0, Data, width2, height2, 32, 0);
 
-	/* compute values for decomposing pixel into color values: */
-	redMask = Im->red_mask;
-	redShift = 0;
-	while ((redMask & 1) == 0)
-	{
-	    redShift++;
-	    redMask >>= 1;
-	}
-	greenMask = Im->green_mask;
-	greenShift = 0;
-	while ((greenMask & 1) == 0)
-	{
-	    greenShift++;
-	    greenMask >>= 1;
-	}
-	blueMask = Im->blue_mask;
-	blueShift = 0;
-	while ((blueMask & 1) == 0)
-	{
-	    blueShift++;
-	    blueMask >>= 1;
-	}
+    /* compute values for decomposing pixel into color values: */
+    redMask = Im->red_mask;
+    redShift = 0;
+    while ((redMask & 1) == 0) {
+        redShift++;
+        redMask >>= 1;
+    }
+    greenMask = Im->green_mask;
+    greenShift = 0;
+    while ((greenMask & 1) == 0) {
+        greenShift++;
+        greenMask >>= 1;
+    }
+    blueMask = Im->blue_mask;
+    blueShift = 0;
+    while ((blueMask & 1) == 0) {
+        blueShift++;
+        blueMask >>= 1;
+    }
 
-	/* scale each icon: */
-	for (y1 = 0, y2 = 0; (y1 < height1) && (y2 < height2); y1 += iy, y2 += oy)
-	{
-		for (x1 = 0, x2 = 0; (x1 < width1) && (x2 < width2); x1 += ix, x2 += ox)
-		{
-			ScaleIcon(Im, Tmp, x1, y1, x2, y2,
-				  ix, iy, ox, oy);
-		}
-	}
+    /* scale each icon: */
+    for (y1 = 0, y2 = 0; (y1 < height1) && (y2 < height2); y1 += iy, y2 += oy) {
+        for (x1 = 0, x2 = 0; (x1 < width1) && (x2 < width2); x1 += ix, x2 += ox) {
+            ScaleIcon(Im, Tmp, x1, y1, x2, y2, ix, iy, ox, oy);
+        }
+    }
 
-	return Tmp;
+    return Tmp;
 }
-
 
 /*
  * Resize an image. XXX XXX XXX
  *
  * Also appears in "main-xaw.c".
  */
-static XImage *ResizeImage(Display *dpy, XImage *Im,
-			   int ix, int iy, int ox, int oy)
+static XImage *ResizeImage(Display *dpy, XImage *Im, int ix, int iy, int ox, int oy)
 {
-	Visual *visual = DefaultVisual(dpy, DefaultScreen(dpy));
+    Visual *visual = DefaultVisual(dpy, DefaultScreen(dpy));
 
-	int width1, height1, width2, height2;
-	volatile int x1, x2, y1, y2, Tx, Ty;
-	volatile int *px1, *px2, *dx1, *dx2;
-	volatile int *py1, *py2, *dy1, *dy2;
+    int width1, height1, width2, height2;
+    volatile int x1, x2, y1, y2, Tx, Ty;
+    volatile int *px1, *px2, *dx1, *dx2;
+    volatile int *py1, *py2, *dy1, *dy2;
 
-	XImage *Tmp;
+    XImage *Tmp;
 
-	char *Data;
+    char *Data;
 
-	if (smoothRescaling && (ix != ox || iy != oy) &&
-	    visual->c_class == TrueColor)
-	{
-	    return ResizeImageSmooth(dpy, Im, ix, iy, ox, oy);
-	}
+    if (smoothRescaling && (ix != ox || iy != oy) && visual->c_class == TrueColor) {
+        return ResizeImageSmooth(dpy, Im, ix, iy, ox, oy);
+    }
 
-	width1 = Im->width;
-	height1 = Im->height;
+    width1 = Im->width;
+    height1 = Im->height;
 
-	width2 = ox * width1 / ix;
-	height2 = oy * height1 / iy;
+    width2 = ox * width1 / ix;
+    height2 = oy * height1 / iy;
 
-	Data = (char *)malloc(width2 * height2 * Im->bits_per_pixel / 8);
+    Data = (char *)malloc(width2 * height2 * Im->bits_per_pixel / 8);
 
-	Tmp = XCreateImage(dpy, visual,
-			   Im->depth, ZPixmap, 0, Data, width2, height2,
-			   32, 0);
+    Tmp = XCreateImage(dpy, visual, Im->depth, ZPixmap, 0, Data, width2, height2, 32, 0);
 
-	if (ix > ox)
-	{
-		px1 = &x1;
-		px2 = &x2;
-		dx1 = &ix;
-		dx2 = &ox;
-	}
-	else
-	{
-		px1 = &x2;
-		px2 = &x1;
-		dx1 = &ox;
-		dx2 = &ix;
-	}
+    if (ix > ox) {
+        px1 = &x1;
+        px2 = &x2;
+        dx1 = &ix;
+        dx2 = &ox;
+    } else {
+        px1 = &x2;
+        px2 = &x1;
+        dx1 = &ox;
+        dx2 = &ix;
+    }
 
-	if (iy > oy)
-	{
-		py1 = &y1;
-		py2 = &y2;
-		dy1 = &iy;
-		dy2 = &oy;
-	}
-	else
-	{
-		py1 = &y2;
-		py2 = &y1;
-		dy1 = &oy;
-		dy2 = &iy;
-	}
+    if (iy > oy) {
+        py1 = &y1;
+        py2 = &y2;
+        dy1 = &iy;
+        dy2 = &oy;
+    } else {
+        py1 = &y2;
+        py2 = &y1;
+        dy1 = &oy;
+        dy2 = &iy;
+    }
 
-	Ty = *dy1/2;
+    Ty = *dy1 / 2;
 
-	for (y1 = 0, y2 = 0; (y1 < height1) && (y2 < height2); )
-	{
-		Tx = *dx1/2;
+    for (y1 = 0, y2 = 0; (y1 < height1) && (y2 < height2);) {
+        Tx = *dx1 / 2;
 
-		for (x1 = 0, x2 = 0; (x1 < width1) && (x2 < width2); )
-		{
-			XPutPixel(Tmp, x2, y2, XGetPixel(Im, x1, y1));
+        for (x1 = 0, x2 = 0; (x1 < width1) && (x2 < width2);) {
+            XPutPixel(Tmp, x2, y2, XGetPixel(Im, x1, y1));
 
-			(*px1)++;
+            (*px1)++;
 
-			Tx -= *dx2;
-			if (Tx < 0)
-			{
-				Tx += *dx1;
-				(*px2)++;
-			}
-		}
+            Tx -= *dx2;
+            if (Tx < 0) {
+                Tx += *dx1;
+                (*px2)++;
+            }
+        }
 
-		(*py1)++;
+        (*py1)++;
 
-		Ty -= *dy2;
-		if (Ty < 0)
-		{
-			Ty += *dy1;
-			(*py2)++;
-		}
-	}
+        Ty -= *dy2;
+        if (Ty < 0) {
+            Ty += *dy1;
+            (*py2)++;
+        }
+    }
 
-	return Tmp;
+    return Tmp;
 }
 
 #endif /* !USE_XFT */

--- a/src/main-cap.cpp
+++ b/src/main-cap.cpp
@@ -2,11 +2,10 @@
 
 /* Purpose: Support for "term.c" using "termcap" calls */
 
-#include "system/angband.h"
 #include "io/exit-panic.h"
+#include "system/angband.h"
 
 #ifdef USE_CAP
-
 
 /*
  * This file is a total hack, but is often very helpful.  :-)
@@ -27,12 +26,11 @@
  * This file incorrectly handles output to column 80, I think.
  */
 
-
 /*
  * Require a "system"
  */
 #if !defined(USE_TERMCAP) && !defined(USE_HARDCODE)
-# define USE_TERMCAP
+#define USE_TERMCAP
 #endif
 
 /*
@@ -42,38 +40,37 @@
  * If the user defines two of these, we will probably crash.
  */
 #ifdef _POSIX_VERSION
-  #define USE_TPOSIX
+#define USE_TPOSIX
 #else
-  #define USE_TCHARS
+#define USE_TCHARS
 #endif
 
 /*
  * POSIX stuff
  */
 #ifdef USE_TPOSIX
-# include <sys/ioctl.h>
-# include <termios.h>
+#include <sys/ioctl.h>
+#include <termios.h>
 #endif
 
 /*
  * One version needs these files
  */
 #ifdef USE_TERMIO
-# include <sys/ioctl.h>
-# include <termio.h>
+#include <sys/ioctl.h>
+#include <termio.h>
 #endif
 
 /*
  * The other needs these files
  */
 #ifdef USE_TCHARS
-# include <sys/ioctl.h>
-# include <sys/resource.h>
-# include <sys/param.h>
-# include <sys/file.h>
-# include <sys/types.h>
+#include <sys/file.h>
+#include <sys/ioctl.h>
+#include <sys/param.h>
+#include <sys/resource.h>
+#include <sys/types.h>
 #endif
-
 
 /*
  * XXX XXX Hack -- POSIX uses "O_NONBLOCK" instead of "O_NDELAY"
@@ -82,11 +79,8 @@
  * which checks for the result of the "read()" command.
  */
 #ifndef O_NDELAY
-# define O_NDELAY O_NONBLOCK
+#define O_NDELAY O_NONBLOCK
 #endif
-
-
-
 
 #ifdef USE_TERMCAP
 
@@ -94,47 +88,44 @@
  * Termcap string information
  */
 
-static char blob[1024];		/* The "termcap" entry */
-static char area[1024];		/* The string extraction buffer */
-static char *next = area;	/* The current "index" into "area" */
-static char *desc;		/* The terminal name */
+static char blob[1024]; /* The "termcap" entry */
+static char area[1024]; /* The string extraction buffer */
+static char *next = area; /* The current "index" into "area" */
+static char *desc; /* The terminal name */
 
 #endif
-
 
 /*
  * Pointers into the "area"
  */
 
-static char *cm;	/* Move cursor */
-static char *ch;	/* Move cursor to horizontal location */
-static char *cv;	/* Move cursor to vertical location */
-static char *ho;	/* Move cursor to top left */
-static char *ll;	/* Move cursor to bottom left */
-static char *cs;	/* Set scroll area */
-static char *cl;	/* Clear screen */
-static char *cd;	/* Clear to end of display */
-static char *ce;	/* Clear to end of line */
-static char *cr;	/* Move to start of line */
-static char *so;	/* Turn on standout */
-static char *se;	/* Turn off standout */
-static char *md;	/* Turn on bold */
-static char *me;	/* Turn off bold */
-static char *vi;	/* Cursor - invisible */
-static char *ve;	/* Cursor - normal */
-static char *vs;	/* Cursor - bright */
-
+static char *cm; /* Move cursor */
+static char *ch; /* Move cursor to horizontal location */
+static char *cv; /* Move cursor to vertical location */
+static char *ho; /* Move cursor to top left */
+static char *ll; /* Move cursor to bottom left */
+static char *cs; /* Set scroll area */
+static char *cl; /* Clear screen */
+static char *cd; /* Clear to end of display */
+static char *ce; /* Clear to end of line */
+static char *cr; /* Move to start of line */
+static char *so; /* Turn on standout */
+static char *se; /* Turn off standout */
+static char *md; /* Turn on bold */
+static char *me; /* Turn off bold */
+static char *vi; /* Cursor - invisible */
+static char *ve; /* Cursor - normal */
+static char *vs; /* Cursor - bright */
 
 /*
  * State variables
  */
 
-static int rows;	/* Screen size (Y) */
-static int cols;	/* Screen size (X) */
-static int curx;	/* Cursor location (X) */
-static int cury;	/* Cursor location (Y) */
-static int curv;	/* Cursor visibility */
-
+static int rows; /* Screen size (Y) */
+static int cols; /* Screen size (X) */
+static int curx; /* Cursor location (X) */
+static int cury; /* Cursor location (Y) */
+static int curv; /* Cursor visibility */
 
 /*
  * Extern functions
@@ -143,36 +134,34 @@ extern char *getenv();
 extern char *tgoto();
 extern char *tgetstr();
 
-
 /*
  * Write some chars to the terminal
  */
 static void ewrite(char *str)
 {
-	int numtowrite, numwritten;
+    int numtowrite, numwritten;
 
-	/* See how much work we have */
-	numtowrite = strlen(str);
+    /* See how much work we have */
+    numtowrite = strlen(str);
 
-	/* Write until done */
-	while (numtowrite > 0)
-	{
-		/* Try to write the chars */
-		numwritten = write(1, str, numtowrite);
+    /* Write until done */
+    while (numtowrite > 0) {
+        /* Try to write the chars */
+        numwritten = write(1, str, numtowrite);
 
-		/* Handle FIFOs and EINTR */
-		if (numwritten < 0) numwritten = 0;
+        /* Handle FIFOs and EINTR */
+        if (numwritten < 0)
+            numwritten = 0;
 
-		/* See what we completed */
-		numtowrite -= numwritten;
-		str += numwritten;
+        /* See what we completed */
+        numtowrite -= numwritten;
+        str += numwritten;
 
-		/* Hack -- sleep if not done */
-		if (numtowrite > 0) sleep(1);
-	}
+        /* Hack -- sleep if not done */
+        if (numtowrite > 0)
+            sleep(1);
+    }
 }
-
-
 
 #ifdef USE_TERMCAP
 
@@ -181,22 +170,22 @@ static char *write_buffer_ptr;
 
 static void output_one(char c)
 {
-	*write_buffer_ptr++ = c;
+    *write_buffer_ptr++ = c;
 }
 
 static void tp(char *s)
 {
-	/* Dump the string into us */
-	write_buffer_ptr = write_buffer;
+    /* Dump the string into us */
+    write_buffer_ptr = write_buffer;
 
-	/* Write the string with padding */
-	tputs (s, 1, output_one);
+    /* Write the string with padding */
+    tputs(s, 1, output_one);
 
-	/* Finish the string */
-	*write_buffer_ptr = '\0';
+    /* Finish the string */
+    *write_buffer_ptr = '\0';
 
-	/* Dump the recorded buffer */
-	ewrite (write_buffer);
+    /* Dump the recorded buffer */
+    ewrite(write_buffer);
 }
 
 #endif
@@ -205,23 +194,18 @@ static void tp(char *s)
 
 static void tp(char *s)
 {
-	ewrite(s);
+    ewrite(s);
 }
 
 #endif
-
-
-
-
-
-
 
 /*
  * Clear the screen
  */
 static void do_cl(void)
 {
-	if (cl) tp (cl);
+    if (cl)
+        tp(cl);
 }
 
 /*
@@ -229,34 +213,28 @@ static void do_cl(void)
  */
 static void do_ce(void)
 {
-	if (ce) tp(ce);
+    if (ce)
+        tp(ce);
 }
-
 
 /*
  * Set the cursor visibility (0 = invis, 1 = normal, 2 = bright)
  */
 static void curs_set(int vis)
 {
-	char *v = NULL;
+    char *v = NULL;
 
-	if (!vis)
-	{
-		v = vi;
-	}
-	else if (vis > 1)
-	{
-		v = vs ? vs : ve;
-	}
-	else
-	{
-		v = ve ? ve : vs;
-	}
+    if (!vis) {
+        v = vi;
+    } else if (vis > 1) {
+        v = vs ? vs : ve;
+    } else {
+        v = ve ? ve : vs;
+    }
 
-	if (v) tp(v);
+    if (v)
+        tp(v);
 }
-
-
 
 /*
  * Restrict scrolling to within these rows
@@ -265,18 +243,16 @@ static void do_cs(int y1, int y2)
 {
 
 #ifdef USE_TERMCAP
-	if (cs) tp(tgoto(cs, y2, y1));
+    if (cs)
+        tp(tgoto(cs, y2, y1));
 #endif
 
 #ifdef USE_HARDCODE
-	char temp[64];
-	sprintf(temp, cs, y1, y2);
-	tp (temp);
+    char temp[64];
+    sprintf(temp, cs, y1, y2);
+    tp(temp);
 #endif
-
 }
-
-
 
 /*
  * Go to the given screen location directly
@@ -285,17 +261,16 @@ static void do_cm(int x, int y)
 {
 
 #ifdef USE_TERMCAP
-	if (cm) tp(tgoto(cm, x, y));
+    if (cm)
+        tp(tgoto(cm, x, y));
 #endif
 
 #ifdef USE_HARDCODE
-	char temp[64];
-	sprintf(temp, cm, y+1, x+1);
-	tp(temp);
+    char temp[64];
+    sprintf(temp, cm, y + 1, x + 1);
+    tp(temp);
 #endif
-
 }
-
 
 /*
  * Go to the given screen location in a "clever" manner
@@ -304,24 +279,26 @@ static void do_cm(int x, int y)
  */
 static void do_move(int x1, int y1, int x2, int y2)
 {
-	/* Hack -- unknown start location */
-	if ((x1 == x2) && (y1 == y2)) do_cm(x2, y2);
+    /* Hack -- unknown start location */
+    if ((x1 == x2) && (y1 == y2))
+        do_cm(x2, y2);
 
-	/* Left edge */
-	else if (x2 == 0)
-	{
-		if ((y2 <= 0) && ho) tp(ho);
-		else if ((y2 >= rows-1) && ll) tp(ll);
-		else if ((y2 == y1) && cr) tp(cr);
-		else do_cm(x2, y2);
-	}
+    /* Left edge */
+    else if (x2 == 0) {
+        if ((y2 <= 0) && ho)
+            tp(ho);
+        else if ((y2 >= rows - 1) && ll)
+            tp(ll);
+        else if ((y2 == y1) && cr)
+            tp(cr);
+        else
+            do_cm(x2, y2);
+    }
 
-	/* Default -- go directly there */
-	else do_cm(x2, y2);
+    /* Default -- go directly there */
+    else
+        do_cm(x2, y2);
 }
-
-
-
 
 /*
  * Help initialize this file (see below)
@@ -331,98 +308,101 @@ errr init_cap_aux(void)
 
 #ifdef USE_TERMCAP
 
-	/* Get the terminal name (if possible) */
-	desc = getenv("TERM");
-	if (!desc) return (1);
+    /* Get the terminal name (if possible) */
+    desc = getenv("TERM");
+    if (!desc)
+        return (1);
 
-	/* Get the terminal info */
-	if (tgetent(blob, desc) != 1) return (2);
+    /* Get the terminal info */
+    if (tgetent(blob, desc) != 1)
+        return (2);
 
-	/* Get the (initial) columns and rows, or default */
-	if ((cols = tgetnum("co")) == -1) cols = 80;
-	if ((rows = tgetnum("li")) == -1) rows = 24;
+    /* Get the (initial) columns and rows, or default */
+    if ((cols = tgetnum("co")) == -1)
+        cols = 80;
+    if ((rows = tgetnum("li")) == -1)
+        rows = 24;
 
-	/* Find out how to move the cursor to a given location */
-	cm = tgetstr("cm", &next);
-	if (!cm) return (10);
+    /* Find out how to move the cursor to a given location */
+    cm = tgetstr("cm", &next);
+    if (!cm)
+        return (10);
 
-	/* Find out how to move the cursor to a given position */
-	ch = tgetstr("ch", &next);
-	cv = tgetstr("cv", &next);
+    /* Find out how to move the cursor to a given position */
+    ch = tgetstr("ch", &next);
+    cv = tgetstr("cv", &next);
 
-	/* Find out how to "home" the screen */
-	ho = tgetstr("ho", &next);
+    /* Find out how to "home" the screen */
+    ho = tgetstr("ho", &next);
 
-	/* Find out how to "last-line" the screen */
-	ll = tgetstr("ll", &next);
+    /* Find out how to "last-line" the screen */
+    ll = tgetstr("ll", &next);
 
-	/* Find out how to do a "carriage return" */
-	cr = tgetstr("cr", &next);
-	if (!cr) cr = "\r";
+    /* Find out how to do a "carriage return" */
+    cr = tgetstr("cr", &next);
+    if (!cr)
+        cr = "\r";
 
-	/* Find out how to clear the screen */
-	cl = tgetstr("cl", &next);
-	if (!cl) return (11);
+    /* Find out how to clear the screen */
+    cl = tgetstr("cl", &next);
+    if (!cl)
+        return (11);
 
-	/* Find out how to clear to the end of display */
-	cd = tgetstr("cd", &next);
+    /* Find out how to clear to the end of display */
+    cd = tgetstr("cd", &next);
 
-	/* Find out how to clear to the end of the line */
-	ce = tgetstr("ce", &next);
+    /* Find out how to clear to the end of the line */
+    ce = tgetstr("ce", &next);
 
-	/* Find out how to scroll (set the scroll region) */
-	cs = tgetstr("cs", &next);
+    /* Find out how to scroll (set the scroll region) */
+    cs = tgetstr("cs", &next);
 
-	/* Find out how to hilite */
-	so = tgetstr("so", &next);
-	se = tgetstr("se", &next);
-	if (!so || !se) so = se = NULL;
+    /* Find out how to hilite */
+    so = tgetstr("so", &next);
+    se = tgetstr("se", &next);
+    if (!so || !se)
+        so = se = NULL;
 
-	/* Find out how to bold */
-	md = tgetstr("md", &next);
-	me = tgetstr("me", &next);
-	if (!md || !me) md = me = NULL;
+    /* Find out how to bold */
+    md = tgetstr("md", &next);
+    me = tgetstr("me", &next);
+    if (!md || !me)
+        md = me = NULL;
 
-	/* Check the cursor visibility stuff */
-	vi = tgetstr("vi", &next);
-	vs = tgetstr("vs", &next);
-	ve = tgetstr("ve", &next);
+    /* Check the cursor visibility stuff */
+    vi = tgetstr("vi", &next);
+    vs = tgetstr("vs", &next);
+    ve = tgetstr("ve", &next);
 
 #endif
 
 #ifdef USE_HARDCODE
 
-	/* Assume some defualt information */
-	rows = 24;
-	cols = 80;
+    /* Assume some defualt information */
+    rows = 24;
+    cols = 80;
 
-	/* Clear screen */
-	cl = "\033[2J\033[H";	/* --]--]-- */
+    /* Clear screen */
+    cl = "\033[2J\033[H"; /* --]--]-- */
 
-	/* Clear to end of line */
-	ce = "\033[K";	/* --]-- */
+    /* Clear to end of line */
+    ce = "\033[K"; /* --]-- */
 
-	/* Hilite on/off */
-	so = "\033[7m";	/* --]-- */
-	se = "\033[m";	/* --]-- */
+    /* Hilite on/off */
+    so = "\033[7m"; /* --]-- */
+    se = "\033[m"; /* --]-- */
 
-	/* Scroll region */
-	cs = "\033[%d;%dr";	/* --]-- */
+    /* Scroll region */
+    cs = "\033[%d;%dr"; /* --]-- */
 
-	/* Move cursor */
-	cm = "\033[%d;%dH";	/* --]-- */
+    /* Move cursor */
+    cm = "\033[%d;%dH"; /* --]-- */
 
 #endif
 
-	/* Success */
-	return (0);
+    /* Success */
+    return (0);
 }
-
-
-
-
-
-
 
 /*
  * Save the "normal" and "angband" terminal settings
@@ -430,48 +410,43 @@ errr init_cap_aux(void)
 
 #ifdef USE_TPOSIX
 
-static struct termios  norm_termios;
+static struct termios norm_termios;
 
-static struct termios  game_termios;
+static struct termios game_termios;
 
 #endif
 
 #ifdef USE_TERMIO
 
-static struct termio  norm_termio;
+static struct termio norm_termio;
 
-static struct termio  game_termio;
+static struct termio game_termio;
 
 #endif
 
 #ifdef USE_TCHARS
 
-static struct sgttyb  norm_ttyb;
-static struct tchars  norm_tchars;
+static struct sgttyb norm_ttyb;
+static struct tchars norm_tchars;
 static struct ltchars norm_ltchars;
-static int            norm_local_chars;
+static int norm_local_chars;
 
-static struct sgttyb  game_ttyb;
-static struct tchars  game_tchars;
+static struct sgttyb game_ttyb;
+static struct tchars game_tchars;
 static struct ltchars game_ltchars;
-static int            game_local_chars;
+static int game_local_chars;
 
 #endif
-
-
 
 /*
  * Are we active?  Not really needed.
  */
 static int active = false;
 
-
 /*
  * The main screen (no sub-screens)
  */
 static term term_screen_body;
-
-
 
 /*
  * Place the "keymap" into its "normal" state
@@ -481,30 +456,28 @@ static void keymap_norm(void)
 
 #ifdef USE_TPOSIX
 
-	/* restore the saved values of the special chars */
-	(void)tcsetattr(0, TCSAFLUSH, &norm_termios);
+    /* restore the saved values of the special chars */
+    (void)tcsetattr(0, TCSAFLUSH, &norm_termios);
 
 #endif
 
 #ifdef USE_TERMIO
 
-	/* restore the saved values of the special chars */
-	(void)ioctl(0, TCSETA, (char *)&norm_termio);
+    /* restore the saved values of the special chars */
+    (void)ioctl(0, TCSETA, (char *)&norm_termio);
 
 #endif
 
 #ifdef USE_TCHARS
 
-	/* restore the saved values of the special chars */
-	(void)ioctl(0, TIOCSETP, (char *)&norm_ttyb);
-	(void)ioctl(0, TIOCSETC, (char *)&norm_tchars);
-	(void)ioctl(0, TIOCSLTC, (char *)&norm_ltchars);
-	(void)ioctl(0, TIOCLSET, (char *)&norm_local_chars);
+    /* restore the saved values of the special chars */
+    (void)ioctl(0, TIOCSETP, (char *)&norm_ttyb);
+    (void)ioctl(0, TIOCSETC, (char *)&norm_tchars);
+    (void)ioctl(0, TIOCSLTC, (char *)&norm_ltchars);
+    (void)ioctl(0, TIOCLSET, (char *)&norm_local_chars);
 
 #endif
-
 }
-
 
 /*
  * Place the "keymap" into the "game" state
@@ -514,30 +487,28 @@ static void keymap_game(void)
 
 #ifdef USE_TPOSIX
 
-	/* restore the saved values of the special chars */
-	(void)tcsetattr(0, TCSAFLUSH, &game_termios);
+    /* restore the saved values of the special chars */
+    (void)tcsetattr(0, TCSAFLUSH, &game_termios);
 
 #endif
 
 #ifdef USE_TERMIO
 
-	/* restore the saved values of the special chars */
-	(void)ioctl(0, TCSETA, (char *)&game_termio);
+    /* restore the saved values of the special chars */
+    (void)ioctl(0, TCSETA, (char *)&game_termio);
 
 #endif
 
 #ifdef USE_TCHARS
 
-	/* restore the saved values of the special chars */
-	(void)ioctl(0, TIOCSETP, (char *)&game_ttyb);
-	(void)ioctl(0, TIOCSETC, (char *)&game_tchars);
-	(void)ioctl(0, TIOCSLTC, (char *)&game_ltchars);
-	(void)ioctl(0, TIOCLSET, (char *)&game_local_chars);
+    /* restore the saved values of the special chars */
+    (void)ioctl(0, TIOCSETP, (char *)&game_ttyb);
+    (void)ioctl(0, TIOCSETC, (char *)&game_tchars);
+    (void)ioctl(0, TIOCSLTC, (char *)&game_ltchars);
+    (void)ioctl(0, TIOCLSET, (char *)&game_local_chars);
 
 #endif
-
 }
-
 
 /*
  * Save the normal keymap
@@ -547,30 +518,28 @@ static void keymap_norm_prepare(void)
 
 #ifdef USE_TPOSIX
 
-	/* Get the normal keymap */
-	tcgetattr(0, &norm_termios);
+    /* Get the normal keymap */
+    tcgetattr(0, &norm_termios);
 
 #endif
 
 #ifdef USE_TERMIO
 
-	/* Get the normal keymap */
-	(void)ioctl(0, TCGETA, (char *)&norm_termio);
+    /* Get the normal keymap */
+    (void)ioctl(0, TCGETA, (char *)&norm_termio);
 
 #endif
 
 #ifdef USE_TCHARS
 
-	/* Get the normal keymap */
-	(void)ioctl(0, TIOCGETP, (char *)&norm_ttyb);
-	(void)ioctl(0, TIOCGETC, (char *)&norm_tchars);
-	(void)ioctl(0, TIOCGLTC, (char *)&norm_ltchars);
-	(void)ioctl(0, TIOCLGET, (char *)&norm_local_chars);
+    /* Get the normal keymap */
+    (void)ioctl(0, TIOCGETP, (char *)&norm_ttyb);
+    (void)ioctl(0, TIOCGETC, (char *)&norm_tchars);
+    (void)ioctl(0, TIOCGLTC, (char *)&norm_ltchars);
+    (void)ioctl(0, TIOCLGET, (char *)&norm_local_chars);
 
 #endif
-
 }
-
 
 /*
  * Save the keymaps (normal and game)
@@ -580,226 +549,215 @@ static void keymap_game_prepare(void)
 
 #ifdef USE_TPOSIX
 
-	/* Acquire the current mapping */
-	tcgetattr(0, &game_termios);
+    /* Acquire the current mapping */
+    tcgetattr(0, &game_termios);
 
-	/* Force "Ctrl-C" to interupt */
-	game_termios.c_cc[VINTR] = (char)3;
+    /* Force "Ctrl-C" to interupt */
+    game_termios.c_cc[VINTR] = (char)3;
 
-	/* Force "Ctrl-Z" to suspend */
-	game_termios.c_cc[VSUSP] = (char)26;
+    /* Force "Ctrl-Z" to suspend */
+    game_termios.c_cc[VSUSP] = (char)26;
 
-	/* Hack -- Leave "VSTART/VSTOP" alone */
+    /* Hack -- Leave "VSTART/VSTOP" alone */
 
-	/* Disable the standard control characters */
-	game_termios.c_cc[VQUIT] = (char)-1;
-	game_termios.c_cc[VERASE] = (char)-1;
-	game_termios.c_cc[VKILL] = (char)-1;
-	game_termios.c_cc[VEOF] = (char)-1;
-	game_termios.c_cc[VEOL] = (char)-1;
+    /* Disable the standard control characters */
+    game_termios.c_cc[VQUIT] = (char)-1;
+    game_termios.c_cc[VERASE] = (char)-1;
+    game_termios.c_cc[VKILL] = (char)-1;
+    game_termios.c_cc[VEOF] = (char)-1;
+    game_termios.c_cc[VEOL] = (char)-1;
 
-	/* Normally, block until a character is read */
-	game_termios.c_cc[VMIN] = 1;
-	game_termios.c_cc[VTIME] = 0;
+    /* Normally, block until a character is read */
+    game_termios.c_cc[VMIN] = 1;
+    game_termios.c_cc[VTIME] = 0;
 
-	/* Hack -- Turn off "echo" and "canonical" mode */
-	game_termios.c_lflag &= ~(ECHO | ICANON);
+    /* Hack -- Turn off "echo" and "canonical" mode */
+    game_termios.c_lflag &= ~(ECHO | ICANON);
 
-	/* Turn off flow control */
-	game_termios.c_iflag &= ~IXON;
+    /* Turn off flow control */
+    game_termios.c_iflag &= ~IXON;
 
 #endif
 
 #ifdef USE_TERMIO
 
-	/* Acquire the current mapping */
-	(void)ioctl(0, TCGETA, (char *)&game_termio);
+    /* Acquire the current mapping */
+    (void)ioctl(0, TCGETA, (char *)&game_termio);
 
-	/* Force "Ctrl-C" to interupt */
-	game_termio.c_cc[VINTR] = (char)3;
+    /* Force "Ctrl-C" to interupt */
+    game_termio.c_cc[VINTR] = (char)3;
 
-	/* Force "Ctrl-Z" to suspend */
-	game_termio.c_cc[VSUSP] = (char)26;
+    /* Force "Ctrl-Z" to suspend */
+    game_termio.c_cc[VSUSP] = (char)26;
 
-	/* Hack -- Leave "VSTART/VSTOP" alone */
+    /* Hack -- Leave "VSTART/VSTOP" alone */
 
-	/* Disable the standard control characters */
-	game_termio.c_cc[VQUIT] = (char)-1;
-	game_termio.c_cc[VERASE] = (char)-1;
-	game_termio.c_cc[VKILL] = (char)-1;
-	game_termio.c_cc[VEOF] = (char)-1;
-	game_termio.c_cc[VEOL] = (char)-1;
+    /* Disable the standard control characters */
+    game_termio.c_cc[VQUIT] = (char)-1;
+    game_termio.c_cc[VERASE] = (char)-1;
+    game_termio.c_cc[VKILL] = (char)-1;
+    game_termio.c_cc[VEOF] = (char)-1;
+    game_termio.c_cc[VEOL] = (char)-1;
 
-	/* Normally, block until a character is read */
-	game_termio.c_cc[VMIN] = 1;
-	game_termio.c_cc[VTIME] = 0;
+    /* Normally, block until a character is read */
+    game_termio.c_cc[VMIN] = 1;
+    game_termio.c_cc[VTIME] = 0;
 
-	/* Hack -- Turn off "echo" and "canonical" mode */
-	game_termio.c_lflag &= ~(ECHO | ICANON);
+    /* Hack -- Turn off "echo" and "canonical" mode */
+    game_termio.c_lflag &= ~(ECHO | ICANON);
 
-	/* Turn off flow control */
-	game_termio.c_iflag &= ~IXON;
+    /* Turn off flow control */
+    game_termio.c_iflag &= ~IXON;
 
 #endif
 
 #ifdef USE_TCHARS
 
-	/* Get the default game characters */
-	(void)ioctl(0, TIOCGETP, (char *)&game_ttyb);
-	(void)ioctl(0, TIOCGETC, (char *)&game_tchars);
-	(void)ioctl(0, TIOCGLTC, (char *)&game_ltchars);
-	(void)ioctl(0, TIOCLGET, (char *)&game_local_chars);
+    /* Get the default game characters */
+    (void)ioctl(0, TIOCGETP, (char *)&game_ttyb);
+    (void)ioctl(0, TIOCGETC, (char *)&game_tchars);
+    (void)ioctl(0, TIOCGLTC, (char *)&game_ltchars);
+    (void)ioctl(0, TIOCLGET, (char *)&game_local_chars);
 
-	/* Force interupt (^C) */
-	game_tchars.t_intrc = (char)3;
+    /* Force interupt (^C) */
+    game_tchars.t_intrc = (char)3;
 
-	/* Force start/stop (^Q, ^S) */
-	game_tchars.t_startc = (char)17;
-	game_tchars.t_stopc = (char)19;
+    /* Force start/stop (^Q, ^S) */
+    game_tchars.t_startc = (char)17;
+    game_tchars.t_stopc = (char)19;
 
-	/* Cancel some things */
-	game_tchars.t_quitc = (char)-1;
-	game_tchars.t_eofc = (char)-1;
-	game_tchars.t_brkc = (char)-1;
+    /* Cancel some things */
+    game_tchars.t_quitc = (char)-1;
+    game_tchars.t_eofc = (char)-1;
+    game_tchars.t_brkc = (char)-1;
 
-	/* Force suspend (^Z) */
-	game_ltchars.t_suspc = (char)26;
+    /* Force suspend (^Z) */
+    game_ltchars.t_suspc = (char)26;
 
-	/* Cancel some things */
-	game_ltchars.t_dsuspc = (char)-1;
-	game_ltchars.t_rprntc = (char)-1;
-	game_ltchars.t_flushc = (char)-1;
-	game_ltchars.t_werasc = (char)-1;
-	game_ltchars.t_lnextc = (char)-1;
+    /* Cancel some things */
+    game_ltchars.t_dsuspc = (char)-1;
+    game_ltchars.t_rprntc = (char)-1;
+    game_ltchars.t_flushc = (char)-1;
+    game_ltchars.t_werasc = (char)-1;
+    game_ltchars.t_lnextc = (char)-1;
 
-	/* XXX XXX XXX XXX Verify this before use */
-	/* Hack -- Turn off "echo" and "canonical" mode */
-	/* game_termios.c_lflag &= ~(ECHO | ICANON); */
-	game_ttyb.flag &= ~(ECHO | ICANON);
+    /* XXX XXX XXX XXX Verify this before use */
+    /* Hack -- Turn off "echo" and "canonical" mode */
+    /* game_termios.c_lflag &= ~(ECHO | ICANON); */
+    game_ttyb.flag &= ~(ECHO | ICANON);
 
-	/* XXX XXX XXX  Should maybe turn off flow control too.  How? */
+    /* XXX XXX XXX  Should maybe turn off flow control too.  How? */
 
 #endif
-
 }
-
-
-
-
-
-
-
 
 /*
  * Suspend/Resume
  */
 static errr Term_xtra_cap_alive(int v)
 {
-	/* Suspend */
-	if (!v)
-	{
-		if (!active) return (1);
+    /* Suspend */
+    if (!v) {
+        if (!active)
+            return (1);
 
-		/* Hack -- make sure the cursor is visible */
-		curs_set(1);
+        /* Hack -- make sure the cursor is visible */
+        curs_set(1);
 
-		/* Move to bottom right */
-		do_move(0, rows - 1, 0, rows - 1);
+        /* Move to bottom right */
+        do_move(0, rows - 1, 0, rows - 1);
 
-		/* Go to normal keymap mode */
-		keymap_norm();
+        /* Go to normal keymap mode */
+        keymap_norm();
 
-		/* No longer active */
-		active = false;
-	}
+        /* No longer active */
+        active = false;
+    }
 
-	/* Resume */
-	else
-	{
-		if (active) return (1);
+    /* Resume */
+    else {
+        if (active)
+            return (1);
 
-		/* Hack -- restore the cursor location */
-		do_move(curx, cury, curx, cury);
+        /* Hack -- restore the cursor location */
+        do_move(curx, cury, curx, cury);
 
-		/* Hack -- restore the cursor visibility */
-		curs_set(curv);
+        /* Hack -- restore the cursor visibility */
+        curs_set(curv);
 
-		/* Go to angband keymap mode */
-		keymap_game();
+        /* Go to angband keymap mode */
+        keymap_game();
 
-		/* Now we are active */
-		active = true;
-	}
+        /* Now we are active */
+        active = true;
+    }
 
-	/* Success */
-	return (0);
+    /* Success */
+    return (0);
 }
-
-
 
 /*
  * Process an event
  */
 static errr Term_xtra_cap_event(int v)
 {
-	int i, arg;
-	char buf[2];
+    int i, arg;
+    char buf[2];
 
-	/* Wait */
-	if (v)
-	{
-		/* Wait for one byte */
-		i = read(0, buf, 1);
+    /* Wait */
+    if (v) {
+        /* Wait for one byte */
+        i = read(0, buf, 1);
 
-		/* Hack -- Handle "errors" */
-		if ((i <= 0) && (errno != EINTR)) exit_game_panic(p_ptr);
-	}
+        /* Hack -- Handle "errors" */
+        if ((i <= 0) && (errno != EINTR))
+            exit_game_panic(p_ptr);
+    }
 
-	/* Do not wait */
-	else
-	{
-		/* Get the current flags for stdin */
-		if ((arg = fcntl(0, F_GETFL, 0)) < 1) return (1);
+    /* Do not wait */
+    else {
+        /* Get the current flags for stdin */
+        if ((arg = fcntl(0, F_GETFL, 0)) < 1)
+            return (1);
 
-		/* Tell stdin not to block */
-		if (fcntl(0, F_SETFL, arg | O_NDELAY) < 0) return (1);
+        /* Tell stdin not to block */
+        if (fcntl(0, F_SETFL, arg | O_NDELAY) < 0)
+            return (1);
 
-		/* Read one byte, if possible */
-		i = read(0, buf, 1);
+        /* Read one byte, if possible */
+        i = read(0, buf, 1);
 
-		/* Replace the flags for stdin */
-		if (fcntl(0, F_SETFL, arg)) return (1);
-	}
+        /* Replace the flags for stdin */
+        if (fcntl(0, F_SETFL, arg))
+            return (1);
+    }
 
-	/* No keys ready */
-	if ((i != 1) || (!buf[0])) return (1);
+    /* No keys ready */
+    if ((i != 1) || (!buf[0]))
+        return (1);
 
-	/* Enqueue the keypress */
-	Term_keypress(buf[0]);
+    /* Enqueue the keypress */
+    Term_keypress(buf[0]);
 
-	/* Success */
-	return (0);
+    /* Success */
+    return (0);
 }
-
-
-
 
 /*
  * Actually move the hardware cursor
  */
 static errr Term_curs_cap(int x, int y)
 {
-	/* Literally move the cursor */
-	do_move(curx, cury, x, y);
+    /* Literally move the cursor */
+    do_move(curx, cury, x, y);
 
-	/* Save the cursor location */
-	curx = x;
-	cury = y;
+    /* Save the cursor location */
+    curx = x;
+    cury = y;
 
-	/* Success */
-	return (0);
+    /* Success */
+    return (0);
 }
-
 
 /*
  * Erase a grid of space
@@ -810,234 +768,213 @@ static errr Term_curs_cap(int x, int y)
  */
 static errr Term_wipe_cap(int x, int y, int n)
 {
-	int dx;
+    int dx;
 
-	/* Place the cursor */
-	Term_curs_cap(x, y);
+    /* Place the cursor */
+    Term_curs_cap(x, y);
 
-	/* Wipe to end of line */
-	if (x + n >= 80)
-	{
-		do_ce();
-	}
+    /* Wipe to end of line */
+    if (x + n >= 80) {
+        do_ce();
+    }
 
-	/* Wipe region */
-	else
-	{
-		for (dx = 0; dx < n; ++dx)
-		{
-			putc(' ', stdout);
-			curx++;
-		}
-	}
+    /* Wipe region */
+    else {
+        for (dx = 0; dx < n; ++dx) {
+            putc(' ', stdout);
+            curx++;
+        }
+    }
 
-	/* Success */
-	return (0);
+    /* Success */
+    return (0);
 }
-
 
 /*
  * Place some text on the screen using an attribute
  */
 static errr Term_text_cap(int x, int y, int n, byte a, concptr s)
 {
-	int i;
+    int i;
 
-	/* Move the cursor */
-	Term_curs_cap(x, y);
+    /* Move the cursor */
+    Term_curs_cap(x, y);
 
-	/* Dump the text, advance the cursor */
-	for (i = 0; s[i]; i++)
-	{
-		/* Dump the char */
-		putc(s[i], stdout);
+    /* Dump the text, advance the cursor */
+    for (i = 0; s[i]; i++) {
+        /* Dump the char */
+        putc(s[i], stdout);
 
-		/* Advance cursor 'X', and wrap */
-		if (++curx >= cols)
-		{
-			/* Reset cursor 'X' */
-			curx = 0;
+        /* Advance cursor 'X', and wrap */
+        if (++curx >= cols) {
+            /* Reset cursor 'X' */
+            curx = 0;
 
-			/* Hack -- Advance cursor 'Y', and wrap */
-			if (++cury == rows) cury = 0;
-		}
-	}
+            /* Hack -- Advance cursor 'Y', and wrap */
+            if (++cury == rows)
+                cury = 0;
+        }
+    }
 
-	/* Success */
-	return (0);
+    /* Success */
+    return (0);
 }
-
 
 /*
  * Handle a "special request"
  */
 static errr Term_xtra_cap(int n, int v)
 {
-	/* Analyze the request */
-	switch (n)
-	{
-		/* Clear the screen */
-		case TERM_XTRA_CLEAR:
-		do_cl();
-		do_move(0, 0, 0, 0);
-		return (0);
+    /* Analyze the request */
+    switch (n) {
+    /* Clear the screen */
+    case TERM_XTRA_CLEAR:
+        do_cl();
+        do_move(0, 0, 0, 0);
+        return (0);
 
-		/* Make a noise */
-		case TERM_XTRA_NOISE:
-		(void)write(1, "\007", 1);
-		return (0);
+    /* Make a noise */
+    case TERM_XTRA_NOISE:
+        (void)write(1, "\007", 1);
+        return (0);
 
-		/* Change the cursor visibility */
-		case TERM_XTRA_SHAPE:
-		curv = v;
-		curs_set(v);
-		return (0);
+    /* Change the cursor visibility */
+    case TERM_XTRA_SHAPE:
+        curv = v;
+        curs_set(v);
+        return (0);
 
-		/* Suspend/Resume */
-		case TERM_XTRA_ALIVE:
-		return (Term_xtra_cap_alive(v));
+    /* Suspend/Resume */
+    case TERM_XTRA_ALIVE:
+        return (Term_xtra_cap_alive(v));
 
-		/* Process events */
-		case TERM_XTRA_EVENT:
-		return (Term_xtra_cap_event(v));
+    /* Process events */
+    case TERM_XTRA_EVENT:
+        return (Term_xtra_cap_event(v));
 
-		/* Flush events */
-		case TERM_XTRA_FLUSH:
-		while (!Term_xtra_cap_event(false));
-		return (0);
+    /* Flush events */
+    case TERM_XTRA_FLUSH:
+        while (!Term_xtra_cap_event(false))
+            ;
+        return (0);
 
-		/* Delay */
-		case TERM_XTRA_DELAY:
-		usleep(1000 * v);
-		return (0);
-	}
+    /* Delay */
+    case TERM_XTRA_DELAY:
+        usleep(1000 * v);
+        return (0);
+    }
 
-	/* Not parsed */
-	return (1);
+    /* Not parsed */
+    return (1);
 }
-
-
-
 
 /*
  * Init a "term" for this file
  */
 static void Term_init_cap(term *t)
 {
-	if (active) return;
+    if (active)
+        return;
 
-	/* Assume cursor at top left */
-	curx = 0;
-	cury = 0;
+    /* Assume cursor at top left */
+    curx = 0;
+    cury = 0;
 
-	/* Assume visible cursor */
-	curv = 1;
+    /* Assume visible cursor */
+    curv = 1;
 
-	/* Clear the screen */
-	do_cl();
+    /* Clear the screen */
+    do_cl();
 
-	/* Hack -- visible cursor */
-	curs_set(1);
+    /* Hack -- visible cursor */
+    curs_set(1);
 
-	/* Assume active */
-	active = true;
+    /* Assume active */
+    active = true;
 }
-
 
 /*
  * Nuke a "term" for this file
  */
 static void Term_nuke_cap(term *t)
 {
-	if (!active) return;
+    if (!active)
+        return;
 
-	/* Hack -- make sure the cursor is visible */
-	curs_set(1);
+    /* Hack -- make sure the cursor is visible */
+    curs_set(1);
 
-	/* Move to bottom right */
-	do_move(0, rows - 1, 0, rows - 1);
+    /* Move to bottom right */
+    do_move(0, rows - 1, 0, rows - 1);
 
-	/* Normal keymap */
-	keymap_norm();
+    /* Normal keymap */
+    keymap_norm();
 
-	/* No longer active */
-	active = false;
+    /* No longer active */
+    active = false;
 }
-
-
-
-
-
-
-
-
-
 
 /*
  * Prepare this file for Angband usage
  */
 errr init_cap(void)
 {
-	term *t = &term_screen_body;
+    term *t = &term_screen_body;
 
+    /*** Initialize ***/
 
-	/*** Initialize ***/
+    /* Initialize the screen */
+    if (init_cap_aux())
+        return (-1);
 
-	/* Initialize the screen */
-	if (init_cap_aux()) return (-1);
+    /* Hack -- Require large screen, or Quit with message */
+    if ((rows < 24) || (cols < 80))
+        quit("Screen too small!");
 
-	/* Hack -- Require large screen, or Quit with message */
-	if ((rows < 24) || (cols < 80)) quit("Screen too small!");
+    /*** Prepare to play ***/
 
+    /* Extract the normal keymap */
+    keymap_norm_prepare();
 
-	/*** Prepare to play ***/
+    /* Extract the game keymap */
+    keymap_game_prepare();
 
-	/* Extract the normal keymap */
-	keymap_norm_prepare();
+    /* Hack -- activate the game keymap */
+    keymap_game();
 
-	/* Extract the game keymap */
-	keymap_game_prepare();
+    /* Hack -- Do NOT buffer stdout */
+    setbuf(stdout, NULL);
 
-	/* Hack -- activate the game keymap */
-	keymap_game();
+    /*** Now prepare the term ***/
 
-	/* Hack -- Do NOT buffer stdout */
-	setbuf(stdout, NULL);
+    /* Initialize the term */
+    term_init(t, 80, 24, 256);
 
+    /* Avoid the bottom right corner */
+    t->icky_corner = true;
 
-	/*** Now prepare the term ***/
+    /* Erase with "white space" */
+    t->attr_blank = TERM_WHITE;
+    t->char_blank = ' ';
 
-	/* Initialize the term */
-	term_init(t, 80, 24, 256);
+    /* Set some hooks */
+    t->init_hook = Term_init_cap;
+    t->nuke_hook = Term_nuke_cap;
 
-	/* Avoid the bottom right corner */
-	t->icky_corner = true;
+    /* Set some more hooks */
+    t->text_hook = Term_text_cap;
+    t->wipe_hook = Term_wipe_cap;
+    t->curs_hook = Term_curs_cap;
+    t->xtra_hook = Term_xtra_cap;
 
-	/* Erase with "white space" */
-	t->attr_blank = TERM_WHITE;
-	t->char_blank = ' ';
+    /* Save the term */
+    term_screen = t;
 
-	/* Set some hooks */
-	t->init_hook = Term_init_cap;
-	t->nuke_hook = Term_nuke_cap;
+    /* Activate it */
+    Term_activate(term_screen);
 
-	/* Set some more hooks */
-	t->text_hook = Term_text_cap;
-	t->wipe_hook = Term_wipe_cap;
-	t->curs_hook = Term_curs_cap;
-	t->xtra_hook = Term_xtra_cap;
-
-	/* Save the term */
-	term_screen = t;
-
-	/* Activate it */
-	Term_activate(term_screen);
-
-	/* Success */
-	return (0);
+    /* Success */
+    return (0);
 }
 
-
 #endif /* USE_CAP */
-
-

--- a/src/main-cap.cpp
+++ b/src/main-cap.cpp
@@ -222,7 +222,7 @@ static void do_ce(void)
  */
 static void curs_set(int vis)
 {
-    char *v = NULL;
+    char *v = nullptr;
 
     if (!vis) {
         v = vi;
@@ -361,13 +361,13 @@ errr init_cap_aux(void)
     so = tgetstr("so", &next);
     se = tgetstr("se", &next);
     if (!so || !se)
-        so = se = NULL;
+        so = se = nullptr;
 
     /* Find out how to bold */
     md = tgetstr("md", &next);
     me = tgetstr("me", &next);
     if (!md || !me)
-        md = me = NULL;
+        md = me = nullptr;
 
     /* Check the cursor visibility stuff */
     vi = tgetstr("vi", &next);
@@ -943,7 +943,7 @@ errr init_cap(void)
     keymap_game();
 
     /* Hack -- Do NOT buffer stdout */
-    setbuf(stdout, NULL);
+    setbuf(stdout, nullptr);
 
     /*** Now prepare the term ***/
 

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -64,7 +64,7 @@
  * <p>
  * The various "warning" messages assume the existance of the "screen.w"
  * window, I think, and only a few calls actually check for its existance,
- * this may be okay since "NULL" means "on top of all windows". (?)  The
+ * this may be okay since "nullptr" means "on top of all windows". (?)  The
  * user must never be allowed to "hide" the main window, or the "menubar"
  * will disappear.
  * </p>
@@ -199,7 +199,7 @@ static bool keep_subwindows = true;
 /*
  * Full path to ANGBAND.INI
  */
-static concptr ini_file = NULL;
+static concptr ini_file = nullptr;
 
 /*
  * Name of application
@@ -1598,7 +1598,7 @@ static void process_menus(player_type *player_ptr, WORD wCmd)
             break;
         }
 
-        quit(NULL);
+        quit(nullptr);
         break;
     }
     case IDM_FILE_SCORE: {
@@ -1610,7 +1610,7 @@ static void process_menus(player_type *player_ptr, WORD wCmd)
         } else {
             screen_save();
             term_clear();
-            display_scores(0, MAX_HISCORES, -1, NULL);
+            display_scores(0, MAX_HISCORES, -1, nullptr);
             (void)fd_close(highscore_fd);
             highscore_fd = -1;
             screen_load();
@@ -1877,7 +1877,7 @@ static void process_menus(player_type *player_ptr, WORD wCmd)
         ofn.lpstrTitle = _(L"壁紙を選んでね。", L"Choose wall paper.");
         ofn.Flags = OFN_FILEMUSTEXIST | OFN_HIDEREADONLY;
 
-        if (get_open_filename(&ofn, NULL, wallpaper_file, MAIN_WIN_MAX_PATH)) {
+        if (get_open_filename(&ofn, nullptr, wallpaper_file, MAIN_WIN_MAX_PATH)) {
             change_bg_mode(bg_mode::BG_ONE, true, true);
         }
         break;
@@ -2314,7 +2314,7 @@ LRESULT PASCAL AngbandWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam
     }
     case WM_CLOSE: {
         if (!game_in_progress || !current_world_ptr->character_generated) {
-            quit(NULL);
+            quit(nullptr);
             return 0;
         }
 
@@ -2332,7 +2332,7 @@ LRESULT PASCAL AngbandWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam
     }
     case WM_QUERYENDSESSION: {
         if (!game_in_progress || !current_world_ptr->character_generated) {
-            quit(NULL);
+            quit(nullptr);
             return 0;
         }
 
@@ -2345,11 +2345,11 @@ LRESULT PASCAL AngbandWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam
         signals_ignore_tstp();
         (void)strcpy(p_ptr->died_from, _("(緊急セーブ)", "(panic save)"));
         (void)save_player(p_ptr, SAVE_TYPE_CLOSE_GAME);
-        quit(NULL);
+        quit(nullptr);
         return 0;
     }
     case WM_QUIT: {
-        quit(NULL);
+        quit(nullptr);
         return 0;
     }
     case WM_COMMAND: {
@@ -2607,7 +2607,7 @@ void create_debug_spoiler(void)
         break;
     }
 
-    quit(NULL);
+    quit(nullptr);
 }
 
 /*!
@@ -2727,7 +2727,7 @@ int WINAPI WinMain(
         play_game(p_ptr, false, false);
     }
 
-    quit(NULL);
+    quit(nullptr);
     return 0;
 }
 #endif /* WINDOWS */

--- a/src/main-win/commandline-win.cpp
+++ b/src/main-win/commandline-win.cpp
@@ -26,7 +26,7 @@ std::string savefile_option;
 static void create_console(void)
 {
     ::AllocConsole();
-    FILE *stream = NULL;
+    FILE *stream = nullptr;
     freopen_s(&stream, "CONOUT$", "w+", stdout);
     std::cout << "Hengband debug console" << std::endl;
 }
@@ -57,7 +57,7 @@ void CommandLine::handle(void)
         ::LocalFree(argv);
     } else {
         fprintf(stdout, "CommandLineToArgvW failed.");
-        quit(NULL);
+        quit(nullptr);
     }
 }
 

--- a/src/main-win/graphics-win.cpp
+++ b/src/main-win/graphics-win.cpp
@@ -79,7 +79,7 @@ graphics_mode change_graphics(graphics_mode arg)
     char buf[MAIN_WIN_MAX_PATH];
     BYTE wid, hgt, twid, thgt, ox, oy;
     concptr name;
-    concptr name_mask = NULL;
+    concptr name_mask = nullptr;
 
     infGraph.delete_bitmap();
 

--- a/src/main-win/main-win-cfg-reader.cpp
+++ b/src/main-win/main-win-cfg-reader.cpp
@@ -35,11 +35,11 @@ static cfg_key make_cfg_key(int type, int val)
  * @brief マップのキーに対応する値を取得する
  * @param key1_type the "actions" value of "term_xtra()". see:z-term.h TERM_XTRA_xxxxx
  * @param key2_val the 2nd parameter of "term_xtra()"
- * @return キーに対応する値を返す。登録されていない場合はNULLを返す。
+ * @return キーに対応する値を返す。登録されていない場合はnullptrを返す。
  */
 static cfg_values *get_map_value(cfg_map *map, int key1_type, int key2_val)
 {
-    cfg_values *value = NULL;
+    cfg_values *value = nullptr;
     auto ite = map->find(make_cfg_key(key1_type, key2_val));
     if (ite != map->end()) {
         value = ite->second;
@@ -51,13 +51,13 @@ static cfg_values *get_map_value(cfg_map *map, int key1_type, int key2_val)
  * @brief 登録されている中からランダムに選択する
  * @param type the "actions" value of "term_xtra()". see:z-term.h TERM_XTRA_xxxxx
  * @param val the 2nd parameter of "term_xtra()"
- * @return キーに対応する値、複数のファイル名の中からからランダムに返す。登録されていない場合はNULLを返す。
+ * @return キーに対応する値、複数のファイル名の中からからランダムに返す。登録されていない場合はnullptrを返す。
  */
 concptr CfgData::get_rand(int key1_type, int key2_val)
 {
     cfg_values *filenames = get_map_value(this->map, key1_type, key2_val);
     if (!filenames) {
-        return NULL;
+        return nullptr;
     }
 
     return filenames->at(Rand_external(filenames->size()));
@@ -107,7 +107,7 @@ CfgData *CfgReader::read_sections(std::initializer_list<cfg_section> sections)
         bool has_data = false;
         int index = 0;
         concptr read_key;
-        while ((read_key = section.key_at(index, key_buf)) != NULL) {
+        while ((read_key = section.key_at(index, key_buf)) != nullptr) {
             GetPrivateProfileStringA(section.section_name, read_key, "", buf, MAIN_WIN_MAX_PATH, this->cfg_path.c_str());
             if (*buf != '\0') {
                 cfg_values *filenames = new cfg_values();

--- a/src/main-win/main-win-cfg-reader.h
+++ b/src/main-win/main-win-cfg-reader.h
@@ -19,7 +19,7 @@ using key_name_func = concptr (*)(int, char *);
  * action-typeはaction_typeメンバで指定する。
  * key_name_funcにより、action-valと.cfg内の読取対象キーの対応を取る。
  * key_name_funcの引数にaction-valが渡され、対応する読取対象キーを返す。
- * key_name_func引数のaction-valは0から1,2,3...と順に呼ばれ、key_name_funcがNULLを返すまで続ける。
+ * key_name_func引数のaction-valは0から1,2,3...と順に呼ばれ、key_name_funcがnullptrを返すまで続ける。
  */
 struct cfg_section {
 
@@ -32,8 +32,8 @@ struct cfg_section {
      * *action-val : the 2nd parameter of "term_xtra()"
      */
     key_name_func key_at;
-    //! 1つでもデータを読み込めた場合にtrueを設定する。（NULLの場合を除く）
-    bool *has_data = NULL;
+    //! 1つでもデータを読み込めた場合にtrueを設定する。（nullptrの場合を除く）
+    bool *has_data = nullptr;
 };
 
 class CfgData {

--- a/src/main-win/main-win-music.cpp
+++ b/src/main-win/main-win-music.cpp
@@ -48,7 +48,7 @@ static concptr basic_key_at(int index, char *buf)
     (void)buf;
 
     if (index >= MUSIC_BASIC_MAX)
-        return NULL;
+        return nullptr;
 
     return angband_music_basic_name[index];
 }
@@ -67,7 +67,7 @@ static inline DUNGEON_IDX get_dungeon_count()
 static concptr dungeon_key_at(int index, char *buf)
 {
     if (index >= get_dungeon_count())
-        return NULL;
+        return nullptr;
 
     sprintf(buf, "dungeon%03d", index);
     return buf;
@@ -87,7 +87,7 @@ static inline QUEST_IDX get_quest_count()
 static concptr quest_key_at(int index, char *buf)
 {
     if (index >= get_quest_count())
-        return NULL;
+        return nullptr;
 
     sprintf(buf, "quest%03d", index);
     return buf;
@@ -107,7 +107,7 @@ static inline int16_t get_town_count()
 static concptr town_key_at(int index, char *buf)
 {
     if (index >= get_town_count())
-        return NULL;
+        return nullptr;
 
     sprintf(buf, "town%03d", index);
     return buf;
@@ -127,7 +127,7 @@ static inline MONRACE_IDX get_monster_count()
 static concptr monster_key_at(int index, char *buf)
 {
     if (index >= get_monster_count())
-        return NULL;
+        return nullptr;
 
     sprintf(buf, "monster%04d", index);
     return buf;

--- a/src/main-win/main-win-sound.cpp
+++ b/src/main-win/main-win-sound.cpp
@@ -67,7 +67,7 @@ struct sound_res {
             ::waveOutUnprepareHeader(hwo, &wh, sizeof(WAVEHDR));
             ::waveOutClose(hwo);
             hwo = NULL;
-            wh.lpData = nullptr;
+            wh.lpData = NULL;
         }
     }
 };
@@ -147,7 +147,7 @@ static bool play_sound_impl(char *filename)
     auto wf = reader.get_waveformat();
 
     auto data_buffer = reader.read_data();
-    if (data_buffer == nullptr)
+    if (data_buffer == NULL)
         return false;
 
     return add_sound_queue(wf, data_buffer, reader.get_data_chunk()->cksize);
@@ -164,7 +164,7 @@ static concptr sound_key_at(int index, char *buf)
     (void)buf;
 
     if (index >= SOUND_MAX)
-        return NULL;
+        return nullptr;
 
     return angband_sound_name[index];
 }

--- a/src/main-x11.cpp
+++ b/src/main-x11.cpp
@@ -962,7 +962,7 @@ static errr Infofnt_text_non(int x, int y, concptr str, int len)
 /*
  * Hack -- cursor color
  */
-static infoclr * xor_ ;
+static infoclr *xor_;
 
 /*
  * Actual color table
@@ -1184,7 +1184,10 @@ static void sort_co_ord(co_ord *min, co_ord *max, const co_ord *b, const co_ord 
 /*
  * Remove the selection by redrawing it.
  */
-static void mark_selection_clear(int x1, int y1, int x2, int y2) { term_redraw_section(x1, y1, x2, y2); }
+static void mark_selection_clear(int x1, int y1, int x2, int y2)
+{
+    term_redraw_section(x1, y1, x2, y2);
+}
 
 /*
  * Select an area by drawing a grey box around it.
@@ -1867,7 +1870,8 @@ static errr Term_curs_x11(int x, int y)
         XftDrawRect(Infowin->draw, &xor_->fg, x * Infofnt->wid + Infowin->ox, y * Infofnt->hgt + Infowin->oy, Infofnt->wid - 1, Infofnt->hgt - 1);
         XftDrawRect(Infowin->draw, &xor_->fg, x * Infofnt->wid + Infowin->ox + 1, y * Infofnt->hgt + Infowin->oy + 1, Infofnt->wid - 3, Infofnt->hgt - 3);
 #else
-        XDrawRectangle(Metadpy->dpy, Infowin->win, xor_->gc, x * Infofnt->wid + Infowin->ox, y * Infofnt->hgt + Infowin->oy, Infofnt->wid - 1, Infofnt->hgt - 1);
+        XDrawRectangle(
+            Metadpy->dpy, Infowin->win, xor_->gc, x * Infofnt->wid + Infowin->ox, y * Infofnt->hgt + Infowin->oy, Infofnt->wid - 1, Infofnt->hgt - 1);
         XDrawRectangle(
             Metadpy->dpy, Infowin->win, xor_->gc, x * Infofnt->wid + Infowin->ox + 1, y * Infofnt->hgt + Infowin->oy + 1, Infofnt->wid - 3, Infofnt->hgt - 3);
 #endif
@@ -2071,7 +2075,10 @@ static void IMDestroyCallback(XIM xim, XPointer client_data, XPointer call_data)
 }
 #endif
 
-static char force_lower(char a) { return ((isupper((a))) ? tolower((a)) : (a)); }
+static char force_lower(char a)
+{
+    return ((isupper((a))) ? tolower((a)) : (a));
+}
 
 /*
  * Initialize a term_data

--- a/src/main-x11.cpp
+++ b/src/main-x11.cpp
@@ -348,15 +348,15 @@ struct infofnt {
 #define Metadpy_set(M) Metadpy = M
 
 /* Initialize 'M' using Display 'D' */
-#define Metadpy_init_dpy(D) Metadpy_init_2(D, cNULL)
+#define Metadpy_init_dpy(D) Metadpy_init_2(D, cnullptr)
 
 /* Initialize 'M' using a Display named 'N' */
-#define Metadpy_init_name(N) Metadpy_init_2((Display *)(NULL), N)
+#define Metadpy_init_name(N) Metadpy_init_2((Display *)(nullptr), N)
 
 /* Initialize 'M' using the standard Display */
 #define Metadpy_init() Metadpy_init_name("")
 
-/* Init an infowin by giving father as an (info_win*) (or NULL), and data */
+/* Init an infowin by giving father as an (info_win*) (or nullptr), and data */
 #define Infowin_init_dad(D, X, Y, W, H, B, FG, BG) Infowin_init_data(((D) ? ((D)->win) : (Window)(None)), X, Y, W, H, B, FG, BG)
 
 /* Init a top level infowin by pos,size,bord,Colors */
@@ -397,24 +397,24 @@ static metadpy metadpy_default;
  * The "current" variables
  */
 static metadpy *Metadpy = &metadpy_default;
-static infowin *Infowin = (infowin *)(NULL);
+static infowin *Infowin = (infowin *)(nullptr);
 #ifdef USE_XIM
-static infowin *Focuswin = (infowin *)(NULL);
+static infowin *Focuswin = (infowin *)(nullptr);
 #endif
-static infoclr *Infoclr = (infoclr *)(NULL);
-static infofnt *Infofnt = (infofnt *)(NULL);
+static infoclr *Infoclr = (infoclr *)(nullptr);
+static infofnt *Infofnt = (infofnt *)(nullptr);
 
 /*
  * Init the current metadpy, with various initialization stuff.
  *
  * Inputs:
- *	dpy:  The Display* to use (if NULL, create it)
- *	name: The name of the Display (if NULL, the current)
+ *	dpy:  The Display* to use (if nullptr, create it)
+ *	name: The name of the Display (if nullptr, the current)
  *
  * Notes:
- *	If 'name' is NULL, but 'dpy' is set, extract name from dpy
- *	If 'dpy' is NULL, then Create the named Display
- *	If 'name' is NULL, and so is 'dpy', use current Display
+ *	If 'name' is nullptr, but 'dpy' is set, extract name from dpy
+ *	If 'dpy' is nullptr, then Create the named Display
+ *	If 'name' is nullptr, and so is 'dpy', use current Display
  *
  * Return -1 if no Display given, and none can be opened.
  */
@@ -620,7 +620,7 @@ static errr Infowin_wipe(void)
 }
 
 /*
- * A NULL terminated pair list of legal "operation names"
+ * A nullptr terminated pair list of legal "operation names"
  *
  * Pairs of values, first is texttual name, second is the string
  * holding the decimal value that the operation corresponds to.
@@ -648,7 +648,7 @@ static concptr opcode_pairs[] =
     "+copyInverted", "12",
     "+orInverted", "13",
     "+nand", "14",
-    NULL
+    nullptr
 };
 // clang-format on
 
@@ -1078,10 +1078,10 @@ static void react_keypress(XKeyEvent *xev)
             valid_keysym = false;
         }
     } else {
-        n = XLookupString(ev, buf, 125, &ks, NULL);
+        n = XLookupString(ev, buf, 125, &ks, nullptr);
     }
 #else
-    n = XLookupString(ev, buf, 125, &ks, NULL);
+    n = XLookupString(ev, buf, 125, &ks, nullptr);
 #endif
 
     buf[n] = '\0';
@@ -1543,8 +1543,8 @@ static errr CheckEvent(bool wait)
 
     XEvent xev_body, *xev = &xev_body;
 
-    term_data *td = NULL;
-    infowin *iwin = NULL;
+    term_data *td = nullptr;
+    infowin *iwin = nullptr;
 
     int i;
 
@@ -2001,22 +2001,22 @@ static void IMInstantiateCallback(Display *display, XPointer unused1, XPointer u
 {
     XIM xim;
     XIMCallback ximcallback;
-    XIMStyles *xim_styles = NULL;
+    XIMStyles *xim_styles = nullptr;
     int i;
 
     (void)unused1;
     (void)unused2;
 
-    xim = XOpenIM(display, NULL, NULL, NULL);
+    xim = XOpenIM(display, nullptr, nullptr, nullptr);
     if (!xim) {
         printf("can't open IM\n");
         return;
     }
 
     ximcallback.callback = IMDestroyCallback;
-    ximcallback.client_data = NULL;
-    XSetIMValues(xim, XNDestroyCallback, &ximcallback, NULL);
-    XGetIMValues(xim, XNQueryInputStyle, &xim_styles, NULL);
+    ximcallback.client_data = nullptr;
+    XSetIMValues(xim, XNDestroyCallback, &ximcallback, nullptr);
+    XGetIMValues(xim, XNQueryInputStyle, &xim_styles, nullptr);
     for (i = 0; i < xim_styles->count_styles; i++) {
         if (xim_styles->supported_styles[i] == (XIMPreeditNothing | XIMStatusNothing))
             break;
@@ -2034,13 +2034,13 @@ static void IMInstantiateCallback(Display *display, XPointer unused1, XPointer u
         infowin *iwin = data[i].win;
         if (!iwin)
             continue;
-        iwin->xic = XCreateIC(xim, XNInputStyle, (XIMPreeditNothing | XIMStatusNothing), XNClientWindow, iwin->win, XNFocusWindow, iwin->win, NULL);
+        iwin->xic = XCreateIC(xim, XNInputStyle, (XIMPreeditNothing | XIMStatusNothing), XNClientWindow, iwin->win, XNFocusWindow, iwin->win, nullptr);
         if (!iwin->xic) {
             printf("Can't create input context for Term%d\n", i);
             continue;
         }
 
-        if (XGetICValues(iwin->xic, XNFilterEvents, &iwin->xic_mask, NULL) != NULL) {
+        if (XGetICValues(iwin->xic, XNFilterEvents, &iwin->xic_mask, nullptr) != nullptr) {
             iwin->xic_mask = 0L;
         }
 
@@ -2056,8 +2056,8 @@ static void IMDestroyCallback(XIM xim, XPointer client_data, XPointer call_data)
     (void)xim;
     (void)client_data;
 
-    if (call_data == NULL) {
-        XRegisterIMInstantiateCallback(Metadpy->dpy, NULL, NULL, NULL, IMInstantiateCallback, NULL);
+    if (call_data == nullptr) {
+        XRegisterIMInstantiateCallback(Metadpy->dpy, nullptr, nullptr, nullptr, IMInstantiateCallback, nullptr);
     }
 
     for (i = 0; i < MAX_TERM_DATA; i++) {
@@ -2068,10 +2068,10 @@ static void IMDestroyCallback(XIM xim, XPointer client_data, XPointer call_data)
             XSelectInput(Metadpy->dpy, iwin->win, iwin->mask);
             iwin->xic_mask = 0L;
         }
-        iwin->xic = NULL;
+        iwin->xic = nullptr;
     }
 
-    Metadpy->xim = NULL;
+    Metadpy->xim = nullptr;
 }
 #endif
 
@@ -2156,21 +2156,21 @@ static errr term_data_init(term_data *td, int i)
 
     sprintf(buf, "ANGBAND_X11_AT_X_%d", i);
     str = getenv(buf);
-    x = (str != NULL) ? atoi(str) : -1;
+    x = (str != nullptr) ? atoi(str) : -1;
 
     sprintf(buf, "ANGBAND_X11_AT_Y_%d", i);
     str = getenv(buf);
-    y = (str != NULL) ? atoi(str) : -1;
+    y = (str != nullptr) ? atoi(str) : -1;
 
     sprintf(buf, "ANGBAND_X11_COLS_%d", i);
     str = getenv(buf);
-    val = (str != NULL) ? atoi(str) : -1;
+    val = (str != nullptr) ? atoi(str) : -1;
     if (val > 0)
         cols = val;
 
     sprintf(buf, "ANGBAND_X11_ROWS_%d", i);
     str = getenv(buf);
-    val = (str != NULL) ? atoi(str) : -1;
+    val = (str != nullptr) ? atoi(str) : -1;
     if (val > 0)
         rows = val;
 
@@ -2183,13 +2183,13 @@ static errr term_data_init(term_data *td, int i)
 
     sprintf(buf, "ANGBAND_X11_IBOX_%d", i);
     str = getenv(buf);
-    val = (str != NULL) ? atoi(str) : -1;
+    val = (str != nullptr) ? atoi(str) : -1;
     if (val > 0)
         ox = val;
 
     sprintf(buf, "ANGBAND_X11_IBOY_%d", i);
     str = getenv(buf);
-    val = (str != NULL) ? atoi(str) : -1;
+    val = (str != nullptr) ? atoi(str) : -1;
     if (val > 0)
         oy = val;
 
@@ -2215,7 +2215,7 @@ static errr term_data_init(term_data *td, int i)
     Infowin->oy = oy;
     ch = XAllocClassHint();
 
-    if (ch == NULL)
+    if (ch == nullptr)
         quit("XAllocClassHint failed");
 
     strcpy(res_name, name);
@@ -2227,7 +2227,7 @@ static errr term_data_init(term_data *td, int i)
 
     XSetClassHint(Metadpy->dpy, Infowin->win, ch);
     sh = XAllocSizeHints();
-    if (sh == NULL)
+    if (sh == nullptr)
         quit("XAllocSizeHints failed");
 
     if (i == 0) {
@@ -2255,7 +2255,7 @@ static errr term_data_init(term_data *td, int i)
 
 #ifdef USE_XIM
     wh = XAllocWMHints();
-    if (wh == NULL)
+    if (wh == nullptr)
         quit("XAllocWMHints failed");
     wh->flags = InputHint;
     wh->input = True;
@@ -2347,13 +2347,13 @@ errr init_x11(int argc, char *argv[])
     setlocale(LC_ALL, "");
 
 #ifdef DEFAULT_LOCALE
-    if (!strcmp(setlocale(LC_ALL, NULL), "C")) {
+    if (!strcmp(setlocale(LC_ALL, nullptr), "C")) {
         printf("try default locale \"%s\"\n", DEFAULT_LOCALE);
         setlocale(LC_ALL, DEFAULT_LOCALE);
     }
 #endif
 
-    if (!strcmp(setlocale(LC_ALL, NULL), "C")) {
+    if (!strcmp(setlocale(LC_ALL, nullptr), "C")) {
         printf("WARNING: Locale is not supported. Non-english font may be displayed incorrectly.\n");
     }
 
@@ -2408,7 +2408,7 @@ errr init_x11(int argc, char *argv[])
             p = XSetLocaleModifiers("@im=");
         }
     }
-    XRegisterIMInstantiateCallback(Metadpy->dpy, NULL, NULL, NULL, IMInstantiateCallback, NULL);
+    XRegisterIMInstantiateCallback(Metadpy->dpy, nullptr, nullptr, nullptr, IMInstantiateCallback, nullptr);
 #endif
 
     if (arg_sound)

--- a/src/main-xaw.cpp
+++ b/src/main-xaw.cpp
@@ -5,28 +5,25 @@
 
 #ifdef USE_XAW
 
-#include "system/angband.h"
 #include "game-option/runtime-arguments.h"
+#include "system/angband.h"
 #include "util/int-char-converter.h"
 
 #ifndef __MAKEDEPEND__
-#include <X11/Xlib.h>
-#include <X11/StringDefs.h>
-#include <X11/Xutil.h>
-#include <X11/Intrinsic.h>
-#include <X11/Shell.h>
-#include <X11/keysym.h>
-#include <X11/keysymdef.h>
-#include <X11/IntrinsicP.h>
 #include <X11/CoreP.h>
+#include <X11/Intrinsic.h>
+#include <X11/IntrinsicP.h>
+#include <X11/Shell.h>
 #include <X11/ShellP.h>
 #include <X11/StringDefs.h>
-#include <X11/Xaw/SimpleP.h>
 #include <X11/Xaw/Simple.h>
+#include <X11/Xaw/SimpleP.h>
 #include <X11/Xaw/XawInit.h>
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <X11/keysym.h>
+#include <X11/keysymdef.h>
 #endif /* __MAKEDEPEND__ */
-
-
 
 /*****************************************************
  *
@@ -120,30 +117,30 @@ angband*color1: #000000
  */
 
 /* New resource names */
-#define XtNstartRows        "startRows"
-#define XtNstartColumns     "startColumns"
-#define XtNminRows          "minRows"
-#define XtNminColumns       "minColumns"
-#define XtNmaxRows          "maxRows"
-#define XtNmaxColumns       "maxColumns"
-#define XtNinternalBorder   "internalBorder"
-#define XtNcolor0           "color0"
-#define XtNcolor1           "color1"
-#define XtNcolor2           "color2"
-#define XtNcolor3           "color3"
-#define XtNcolor4           "color4"
-#define XtNcolor5           "color5"
-#define XtNcolor6           "color6"
-#define XtNcolor7           "color7"
-#define XtNcolor8           "color8"
-#define XtNcolor9           "color9"
-#define XtNcolor10          "color10"
-#define XtNcolor11          "color11"
-#define XtNcolor12          "color12"
-#define XtNcolor13          "color13"
-#define XtNcolor14          "color14"
-#define XtNcolor15          "color15"
-#define XtNredrawCallback   "redrawCallback"
+#define XtNstartRows "startRows"
+#define XtNstartColumns "startColumns"
+#define XtNminRows "minRows"
+#define XtNminColumns "minColumns"
+#define XtNmaxRows "maxRows"
+#define XtNmaxColumns "maxColumns"
+#define XtNinternalBorder "internalBorder"
+#define XtNcolor0 "color0"
+#define XtNcolor1 "color1"
+#define XtNcolor2 "color2"
+#define XtNcolor3 "color3"
+#define XtNcolor4 "color4"
+#define XtNcolor5 "color5"
+#define XtNcolor6 "color6"
+#define XtNcolor7 "color7"
+#define XtNcolor8 "color8"
+#define XtNcolor9 "color9"
+#define XtNcolor10 "color10"
+#define XtNcolor11 "color11"
+#define XtNcolor12 "color12"
+#define XtNcolor13 "color13"
+#define XtNcolor14 "color14"
+#define XtNcolor15 "color15"
+#define XtNredrawCallback "redrawCallback"
 
 /* External definitions */
 #define COLOR_XOR 16
@@ -157,66 +154,55 @@ typedef struct AngbandRec *AngbandWidget;
 
 typedef struct AngbandClassRec *AngbandWidgetClass;
 
-
 /*
  * New fields for the Angband widget record
  */
 
-struct AngbandPart
-{
-	/* Settable resources */
-	int               start_rows;
-	int               start_columns;
-	int               min_rows;
-	int               min_columns;
-	int               max_rows;
-	int               max_columns;
-	int               internal_border;
-	String            font;
-	Pixel             color[NUM_COLORS];
-	XtCallbackList    redraw_callbacks;
+struct AngbandPart {
+    /* Settable resources */
+    int start_rows;
+    int start_columns;
+    int min_rows;
+    int min_columns;
+    int max_rows;
+    int max_columns;
+    int internal_border;
+    String font;
+    Pixel color[NUM_COLORS];
+    XtCallbackList redraw_callbacks;
 
-	/* Private state */
-	XFontStruct       *fnt;
-	Dimension         fontheight;
-	Dimension         fontwidth;
-	Dimension         fontascent;
-	GC                gc[NUM_COLORS+1];  /* Includes a special 'xor' color */
-
+    /* Private state */
+    XFontStruct *fnt;
+    Dimension fontheight;
+    Dimension fontwidth;
+    Dimension fontascent;
+    GC gc[NUM_COLORS + 1]; /* Includes a special 'xor' color */
 };
-
 
 /*
  * Full instance record declaration
  */
-struct AngbandRec
-{
-	CorePart          core;
-	SimplePart        simple;
-	AngbandPart       angband;
+struct AngbandRec {
+    CorePart core;
+    SimplePart simple;
+    AngbandPart angband;
 };
-
 
 /*
  * New fields for the Angband widget class record
  */
-struct AngbandClassPart
-{
-	int               dummy;
+struct AngbandClassPart {
+    int dummy;
 };
-
 
 /*
  * Full class record declaration
  */
-struct AngbandClassRec
-{
-	CoreClassPart     core_class;
-	SimpleClassPart   simple_class;
-	AngbandClassPart  angband_class;
+struct AngbandClassRec {
+    CoreClassPart core_class;
+    SimpleClassPart simple_class;
+    AngbandClassPart angband_class;
 };
-
-
 
 /* Angband widget, Created by Torbjn Lindgren (tl@cd.chalmers.se) */
 
@@ -227,7 +213,6 @@ struct AngbandClassRec
  * Pixmaps creates big performance problems for some really old X
  * terminals (such as 3/50's running Xkernel).
  */
-
 
 /*
  * The default colors used is based on the ones used in main-mac.c.
@@ -243,165 +228,118 @@ struct AngbandClassRec
 /*
  * Fallback resources for Angband widget
  */
-static XtResource resources[] =
-{
-	{ XtNstartRows, XtCValue, XtRInt, sizeof(int),
-	offset(start_rows), XtRImmediate, (XtPointer) 24 },
-	{ XtNstartColumns, XtCValue, XtRInt, sizeof(int),
-	offset(start_columns), XtRImmediate, (XtPointer) 80 },
-	{ XtNminRows, XtCValue, XtRInt, sizeof(int),
-	offset(min_rows), XtRImmediate, (XtPointer) 1 },
-	{ XtNminColumns, XtCValue, XtRInt, sizeof(int),
-	offset(min_columns), XtRImmediate, (XtPointer) 1 },
-	{ XtNmaxRows, XtCValue, XtRInt, sizeof(int),
-	offset(max_rows), XtRImmediate, (XtPointer) 24 },
-	{ XtNmaxColumns, XtCValue, XtRInt, sizeof(int),
-	offset(max_columns), XtRImmediate, (XtPointer) 80 },
-	{ XtNinternalBorder, XtCValue, XtRInt, sizeof(int),
-	offset(internal_border), XtRImmediate, (XtPointer) 2 },
-	{ XtNfont, XtCFont, XtRString, sizeof(char *),
-	offset(font), XtRString, "9x15" },
-	{ XtNcolor0, XtCColor, XtRPixel, sizeof(Pixel),
-	offset(color[0]), XtRString, "black" },
-	{ XtNcolor1, XtCColor, XtRPixel, sizeof(Pixel),
-	offset(color[1]), XtRString, "white" },
-	{ XtNcolor2, XtCColor, XtRPixel, sizeof(Pixel),
-	offset(color[2]), XtRString, "#d7d7d7" },
-	{ XtNcolor3, XtCColor, XtRPixel, sizeof(Pixel),
-	offset(color[3]), XtRString, "#ff9200" },
-	{ XtNcolor4, XtCColor, XtRPixel, sizeof(Pixel),
-	offset(color[4]), XtRString, "#ff0000" },
-	{ XtNcolor5, XtCColor, XtRPixel, sizeof(Pixel),
-	offset(color[5]), XtRString, "#00cd00" },
-	{ XtNcolor6, XtCColor, XtRPixel, sizeof(Pixel),
-	offset(color[6]), XtRString, "#0000fe" },
-	{ XtNcolor7, XtCColor, XtRPixel, sizeof(Pixel),
-	offset(color[7]), XtRString, "#c86400" },
-	{ XtNcolor8, XtCColor, XtRPixel, sizeof(Pixel),
-	offset(color[8]), XtRString, "#a3a3a3" },
-	{ XtNcolor9, XtCColor, XtRPixel, sizeof(Pixel),
-	offset(color[9]), XtRString, "#ebebeb" },
-	{ XtNcolor10, XtCColor, XtRPixel, sizeof(Pixel),
-	offset(color[10]), XtRString, "#a500ff" },
-	{ XtNcolor11, XtCColor, XtRPixel, sizeof(Pixel),
-	offset(color[11]), XtRString, "#fffd00" },
-	{ XtNcolor12, XtCColor, XtRPixel, sizeof(Pixel),
-	offset(color[12]), XtRString, "#ff00bc" },
-	{ XtNcolor13, XtCColor, XtRPixel, sizeof(Pixel),
-	offset(color[13]), XtRString, "#00ff00" },
-	{ XtNcolor14, XtCColor, XtRPixel, sizeof(Pixel),
-	offset(color[14]), XtRString, "#00c8ff" },
-	{ XtNcolor15, XtCColor, XtRPixel, sizeof(Pixel),
-	offset(color[15]), XtRString, "#ffcc80" },
+static XtResource resources[] = { { XtNstartRows, XtCValue, XtRInt, sizeof(int), offset(start_rows), XtRImmediate, (XtPointer)24 },
+    { XtNstartColumns, XtCValue, XtRInt, sizeof(int), offset(start_columns), XtRImmediate, (XtPointer)80 },
+    { XtNminRows, XtCValue, XtRInt, sizeof(int), offset(min_rows), XtRImmediate, (XtPointer)1 },
+    { XtNminColumns, XtCValue, XtRInt, sizeof(int), offset(min_columns), XtRImmediate, (XtPointer)1 },
+    { XtNmaxRows, XtCValue, XtRInt, sizeof(int), offset(max_rows), XtRImmediate, (XtPointer)24 },
+    { XtNmaxColumns, XtCValue, XtRInt, sizeof(int), offset(max_columns), XtRImmediate, (XtPointer)80 },
+    { XtNinternalBorder, XtCValue, XtRInt, sizeof(int), offset(internal_border), XtRImmediate, (XtPointer)2 },
+    { XtNfont, XtCFont, XtRString, sizeof(char *), offset(font), XtRString, "9x15" },
+    { XtNcolor0, XtCColor, XtRPixel, sizeof(Pixel), offset(color[0]), XtRString, "black" },
+    { XtNcolor1, XtCColor, XtRPixel, sizeof(Pixel), offset(color[1]), XtRString, "white" },
+    { XtNcolor2, XtCColor, XtRPixel, sizeof(Pixel), offset(color[2]), XtRString, "#d7d7d7" },
+    { XtNcolor3, XtCColor, XtRPixel, sizeof(Pixel), offset(color[3]), XtRString, "#ff9200" },
+    { XtNcolor4, XtCColor, XtRPixel, sizeof(Pixel), offset(color[4]), XtRString, "#ff0000" },
+    { XtNcolor5, XtCColor, XtRPixel, sizeof(Pixel), offset(color[5]), XtRString, "#00cd00" },
+    { XtNcolor6, XtCColor, XtRPixel, sizeof(Pixel), offset(color[6]), XtRString, "#0000fe" },
+    { XtNcolor7, XtCColor, XtRPixel, sizeof(Pixel), offset(color[7]), XtRString, "#c86400" },
+    { XtNcolor8, XtCColor, XtRPixel, sizeof(Pixel), offset(color[8]), XtRString, "#a3a3a3" },
+    { XtNcolor9, XtCColor, XtRPixel, sizeof(Pixel), offset(color[9]), XtRString, "#ebebeb" },
+    { XtNcolor10, XtCColor, XtRPixel, sizeof(Pixel), offset(color[10]), XtRString, "#a500ff" },
+    { XtNcolor11, XtCColor, XtRPixel, sizeof(Pixel), offset(color[11]), XtRString, "#fffd00" },
+    { XtNcolor12, XtCColor, XtRPixel, sizeof(Pixel), offset(color[12]), XtRString, "#ff00bc" },
+    { XtNcolor13, XtCColor, XtRPixel, sizeof(Pixel), offset(color[13]), XtRString, "#00ff00" },
+    { XtNcolor14, XtCColor, XtRPixel, sizeof(Pixel), offset(color[14]), XtRString, "#00c8ff" },
+    { XtNcolor15, XtCColor, XtRPixel, sizeof(Pixel), offset(color[15]), XtRString, "#ffcc80" },
 
-	{ XtNredrawCallback, XtCCallback, XtRCallback, sizeof(XtPointer),
-	offset(redraw_callbacks), XtRCallback, (XtPointer)NULL }
-};
+    { XtNredrawCallback, XtCCallback, XtRCallback, sizeof(XtPointer), offset(redraw_callbacks), XtRCallback, (XtPointer)NULL } };
 
 #undef offset
 
 /* Forward declarations for Widget functions */
 static void Initialize(AngbandWidget request, AngbandWidget new);
 static void Redisplay(AngbandWidget w, XEvent *event, Region region);
-static Boolean SetValues(AngbandWidget current, AngbandWidget request,
-			 AngbandWidget new, ArgList args, Cardinal *num_args);
+static Boolean SetValues(AngbandWidget current, AngbandWidget request, AngbandWidget new, ArgList args, Cardinal *num_args);
 static void Destroy(AngbandWidget widget);
 
 /* Forward declaration for internal functions */
 static void calculateSizeHints(AngbandWidget new);
-static XFontStruct *getFont(AngbandWidget widget,
-			    String font, Boolean fallback);
-
+static XFontStruct *getFont(AngbandWidget widget, String font, Boolean fallback);
 
 /* Class record constanst */
-AngbandClassRec angbandClassRec =
-{
-	{
-		/* Core class fields initialization */
-#define superclass              (&simpleClassRec)
-		/* superclass           */      (WidgetClass) superclass,
-		/* class_name           */      "Angband",
-		/* widget_size          */      sizeof(AngbandRec),
-		/* class_initialize     */      NULL,
-		/* class_part_initialize*/      NULL,
-		/* class_inited         */      false,
-		/* initialize           */      (XtInitProc) Initialize,
-		/* initialize_hook      */      NULL,
-		/* realize              */      XtInheritRealize,
-		/* actions              */      NULL,
-		/* num_actions          */      0,
-		/* resources            */      resources,
-		/* num_resources        */      XtNumber(resources),
-		/* xrm_class            */      NULLQUARK,
-		/* compress_motion      */      true,
-		/* compress_exposure    */      XtExposeCompressMultiple,
-		/* compress_enterleave  */      true,
-		/* visible_interest     */      false,
-		/* destroy              */      (XtWidgetProc) Destroy,
-		/* resize               */      NULL,
-		/* expose               */      (XtExposeProc) Redisplay,
-		/* set_values           */      (XtSetValuesFunc) SetValues,
-		/* set_values_hook      */      NULL,
-		/* set_values_almost    */      XtInheritSetValuesAlmost,
-		/* get_values_hook      */      NULL,
-		/* accept_focus         */      NULL,
-		/* version              */      XtVersion,
-		/* callback_private     */      NULL,
-		/* tm_table             */      NULL,
-		/* query_geometry       */      NULL,
-		/* display_accelerator  */      XtInheritDisplayAccelerator,
-		/* extension            */      NULL
-	},
-	/* Simple class fields initialization */
-	{
-		/* change_sensitive     */      XtInheritChangeSensitive
-	},
-	/* Angband class fields initialization */
-	{
-		/* nothing              */      0
-	}
-};
+AngbandClassRec angbandClassRec = { {
+/* Core class fields initialization */
+#define superclass (&simpleClassRec)
+                                        /* superclass           */ (WidgetClass)superclass,
+                                        /* class_name           */ "Angband",
+                                        /* widget_size          */ sizeof(AngbandRec),
+                                        /* class_initialize     */ NULL,
+                                        /* class_part_initialize*/ NULL,
+                                        /* class_inited         */ false,
+                                        /* initialize           */ (XtInitProc)Initialize,
+                                        /* initialize_hook      */ NULL,
+                                        /* realize              */ XtInheritRealize,
+                                        /* actions              */ NULL,
+                                        /* num_actions          */ 0,
+                                        /* resources            */ resources,
+                                        /* num_resources        */ XtNumber(resources),
+                                        /* xrm_class            */ NULLQUARK,
+                                        /* compress_motion      */ true,
+                                        /* compress_exposure    */ XtExposeCompressMultiple,
+                                        /* compress_enterleave  */ true,
+                                        /* visible_interest     */ false,
+                                        /* destroy              */ (XtWidgetProc)Destroy,
+                                        /* resize               */ NULL,
+                                        /* expose               */ (XtExposeProc)Redisplay,
+                                        /* set_values           */ (XtSetValuesFunc)SetValues,
+                                        /* set_values_hook      */ NULL,
+                                        /* set_values_almost    */ XtInheritSetValuesAlmost,
+                                        /* get_values_hook      */ NULL,
+                                        /* accept_focus         */ NULL,
+                                        /* version              */ XtVersion,
+                                        /* callback_private     */ NULL,
+                                        /* tm_table             */ NULL,
+                                        /* query_geometry       */ NULL,
+                                        /* display_accelerator  */ XtInheritDisplayAccelerator,
+                                        /* extension            */ NULL },
+    /* Simple class fields initialization */
+    { /* change_sensitive     */ XtInheritChangeSensitive },
+    /* Angband class fields initialization */
+    { /* nothing              */ 0 } };
 
 /* Class record pointer */
-WidgetClass angbandWidgetClass = (WidgetClass) &angbandClassRec;
-
+WidgetClass angbandWidgetClass = (WidgetClass)&angbandClassRec;
 
 /*
  * Public procedures
  */
-static void AngbandOutputText(AngbandWidget widget, int x, int y,
-			      String txt, int len, int color)
+static void AngbandOutputText(AngbandWidget widget, int x, int y, String txt, int len, int color)
 {
-	/* Do nothing if the string is null */
-	if (!txt || !*txt)
-		return;
+    /* Do nothing if the string is null */
+    if (!txt || !*txt)
+        return;
 
-	/* Check the lenght, and fix it if it's below zero */
-	if (len < 0)
-		len = strlen(txt);
+    /* Check the lenght, and fix it if it's below zero */
+    if (len < 0)
+        len = strlen(txt);
 
-	/* Figure out where to place the text */
-	y = y * widget->angband.fontheight + widget->angband.fontascent +
-	widget->angband.internal_border;
-	x = x * widget->angband.fontwidth + widget->angband.internal_border;
+    /* Figure out where to place the text */
+    y = y * widget->angband.fontheight + widget->angband.fontascent + widget->angband.internal_border;
+    x = x * widget->angband.fontwidth + widget->angband.internal_border;
 
-	/* Place the string */
-	XDrawImageString (XtDisplay(widget), XtWindow(widget),
-			  widget->angband.gc[color], x, y, txt, len);
+    /* Place the string */
+    XDrawImageString(XtDisplay(widget), XtWindow(widget), widget->angband.gc[color], x, y, txt, len);
 }
 
-static void AngbandClearArea(AngbandWidget widget,
-			     int x, int y, int w, int h, int color)
+static void AngbandClearArea(AngbandWidget widget, int x, int y, int w, int h, int color)
 {
-	/* Figure out which area to clear */
-	y = y * widget->angband.fontheight + widget->angband.internal_border;
-	x = x * widget->angband.fontwidth + widget->angband.internal_border;
+    /* Figure out which area to clear */
+    y = y * widget->angband.fontheight + widget->angband.internal_border;
+    x = x * widget->angband.fontwidth + widget->angband.internal_border;
 
-	/* Clear the area */
-	XFillRectangle(XtDisplay(widget), XtWindow(widget),
-		       widget->angband.gc[color],
-		       x, y, widget->angband.fontwidth*w,
-		       widget->angband.fontheight*h);
+    /* Clear the area */
+    XFillRectangle(XtDisplay(widget), XtWindow(widget), widget->angband.gc[color], x, y, widget->angband.fontwidth * w, widget->angband.fontheight * h);
 }
 
 /*
@@ -417,57 +355,47 @@ static void AngbandClearArea(AngbandWidget widget,
  */
 static void Initialize(AngbandWidget request, AngbandWidget new)
 {
-	XGCValues gcv;
-	int depth = DefaultDepthOfScreen(XtScreen((Widget) new));
-	TopLevelShellWidget parent =
-	(TopLevelShellWidget)XtParent((Widget) new);
-	int n;
+    XGCValues gcv;
+    int depth = DefaultDepthOfScreen(XtScreen((Widget) new));
+    TopLevelShellWidget parent = (TopLevelShellWidget)XtParent((Widget) new);
+    int n;
 
-	/* Fix the background color */
-	new->core.background_pixel = new->angband.color[0];
+    /* Fix the background color */
+    new->core.background_pixel = new->angband.color[0];
 
-	/* Get some information about the font */
-	new->angband.fnt = getFont(new, new->angband.font, TRUE);
-	new->angband.fontheight = new->angband.fnt->ascent +
-	new->angband.fnt->descent;
-	new->angband.fontwidth = new->angband.fnt->max_bounds.width;
-	new->angband.fontascent = new->angband.fnt->ascent;
+    /* Get some information about the font */
+    new->angband.fnt = getFont(new, new->angband.font, TRUE);
+    new->angband.fontheight = new->angband.fnt->ascent + new->angband.fnt->descent;
+    new->angband.fontwidth = new->angband.fnt->max_bounds.width;
+    new->angband.fontascent = new->angband.fnt->ascent;
 
-	/* Create and initialize the graphics contexts */ /* GXset? */
-	gcv.font = new->angband.fnt->fid;
-	gcv.graphics_exposures = FALSE;
-	gcv.background = new->angband.color[0];
-	for (n = 0; n < NUM_COLORS; n++)
-	{
-		if (depth == 1 && n >= 1)
-			gcv.foreground = new->angband.color[1];
-		else
-			gcv.foreground = new->angband.color[n];
-		new->angband.gc[n] = XtGetGC((Widget)new, GCFont | GCForeground |
-					     GCBackground | GCGraphicsExposures,
-					     &gcv);
-	}
+    /* Create and initialize the graphics contexts */ /* GXset? */
+    gcv.font = new->angband.fnt->fid;
+    gcv.graphics_exposures = FALSE;
+    gcv.background = new->angband.color[0];
+    for (n = 0; n < NUM_COLORS; n++) {
+        if (depth == 1 && n >= 1)
+            gcv.foreground = new->angband.color[1];
+        else
+            gcv.foreground = new->angband.color[n];
+        new->angband.gc[n] = XtGetGC((Widget) new, GCFont | GCForeground | GCBackground | GCGraphicsExposures, &gcv);
+    }
 
-	/* Create a special GC for highlighting */
-	gcv.foreground = BlackPixelOfScreen(XtScreen((Widget)new)) ^
-	WhitePixelOfScreen(XtScreen((Widget)new));
-	gcv.function = GXxor;
-	new->angband.gc[NUM_COLORS] = XtGetGC((Widget)new, GCFunction |
-					      GCGraphicsExposures |
-					      GCForeground, &gcv);
+    /* Create a special GC for highlighting */
+    gcv.foreground = BlackPixelOfScreen(XtScreen((Widget) new)) ^ WhitePixelOfScreen(XtScreen((Widget) new));
+    gcv.function = GXxor;
+    new->angband.gc[NUM_COLORS] = XtGetGC((Widget) new, GCFunction | GCGraphicsExposures | GCForeground, &gcv);
 
-	/* Calculate window geometry */
-	new->core.height = new->angband.start_rows * new->angband.fontheight +
-	2 * new->angband.internal_border;
-	new->core.width = new->angband.start_columns * new->angband.fontwidth +
-	2 * new->angband.internal_border;
+    /* Calculate window geometry */
+    new->core.height = new->angband.start_rows *new->angband.fontheight + 2 * new->angband.internal_border;
+    new->core.width = new->angband.start_columns *new->angband.fontwidth + 2 * new->angband.internal_border;
 
-	/* We need to be able to resize the Widget if the user want's to
-	change font on the fly! */
-	parent->shell.allow_shell_resize = TRUE;
+    /* We need to be able to resize the Widget if the user want's to
+    change font on the fly! */
+    parent->shell.allow_shell_resize = TRUE;
 
-	/* Calculates all the size hints */
-	calculateSizeHints(new);
+    /* Calculates all the size hints */
+    calculateSizeHints(new);
 }
 
 /*
@@ -477,14 +405,14 @@ static void Initialize(AngbandWidget request, AngbandWidget new)
  */
 static void Destroy(AngbandWidget widget)
 {
-	int n;
+    int n;
 
-	/* Free all GC's */
-	for (n = 0; n < NUM_COLORS+1; n++)
-		XtReleaseGC((Widget)widget, widget->angband.gc[n]);
+    /* Free all GC's */
+    for (n = 0; n < NUM_COLORS + 1; n++)
+        XtReleaseGC((Widget)widget, widget->angband.gc[n]);
 
-	/* Free the font */
-	XFreeFont(XtDisplay((Widget)widget), widget->angband.fnt);
+    /* Free the font */
+    XFreeFont(XtDisplay((Widget)widget), widget->angband.fnt);
 }
 
 /*
@@ -493,8 +421,8 @@ static void Destroy(AngbandWidget widget)
  */
 static void Redisplay(AngbandWidget widget, XEvent *event, Region region)
 {
-	if (XtHasCallbacks((Widget)widget, XtNredrawCallback) == XtCallbackHasSome)
-		XtCallCallbacks((Widget)widget, XtNredrawCallback, NULL);
+    if (XtHasCallbacks((Widget)widget, XtNredrawCallback) == XtCallbackHasSome)
+        XtCallCallbacks((Widget)widget, XtNredrawCallback, NULL);
 }
 
 /*
@@ -502,116 +430,94 @@ static void Redisplay(AngbandWidget widget, XEvent *event, Region region)
  * The entire widget is redrawn if any of those parameters change (all
  * can potentially have effects that spans the whole widget).
  */
-static Boolean SetValues(AngbandWidget current, AngbandWidget request,
-			 AngbandWidget new, ArgList args,
-			 Cardinal *num_args)
+static Boolean SetValues(AngbandWidget current, AngbandWidget request, AngbandWidget new, ArgList args, Cardinal *num_args)
 {
-	int depth = DefaultDepthOfScreen(XtScreen((Widget) new));
-	Boolean font_changed = FALSE;
-	Boolean border_changed = FALSE;
-	Boolean color_changed = FALSE;
-	XGCValues gcv;
-	int height, width;
-	int n;
+    int depth = DefaultDepthOfScreen(XtScreen((Widget) new));
+    Boolean font_changed = FALSE;
+    Boolean border_changed = FALSE;
+    Boolean color_changed = FALSE;
+    XGCValues gcv;
+    int height, width;
+    int n;
 
-	/* Changed font? */
-	if (current->angband.font != new->angband.font)
-	{
-		/* Check if the font exists */
-		new->angband.fnt = getFont(new, new->angband.font, FALSE);
+    /* Changed font? */
+    if (current->angband.font != new->angband.font) {
+        /* Check if the font exists */
+        new->angband.fnt = getFont(new, new->angband.font, FALSE);
 
-		/* The font didn't exist */
-		if (new->angband.fnt == NULL)
-		{
-			new->angband.fnt = current->angband.fnt;
-			new->angband.font = current->angband.font;
-			XtWarning("Couldn't find the request font!");
-		}
-		else
-		{
-			font_changed = TRUE;
-			/* Free the old font */
-			XFreeFont(XtDisplay((Widget)new), current->angband.fnt);
-			/* Update font information */
-			new->angband.fontheight = new->angband.fnt->ascent +
-			new->angband.fnt->descent;
-			new->angband.fontwidth = new->angband.fnt->max_bounds.width;
-			new->angband.fontascent = new->angband.fnt->ascent;
-		}
-	}
+        /* The font didn't exist */
+        if (new->angband.fnt == NULL) {
+            new->angband.fnt = current->angband.fnt;
+            new->angband.font = current->angband.font;
+            XtWarning("Couldn't find the request font!");
+        } else {
+            font_changed = TRUE;
+            /* Free the old font */
+            XFreeFont(XtDisplay((Widget) new), current->angband.fnt);
+            /* Update font information */
+            new->angband.fontheight = new->angband.fnt->ascent + new->angband.fnt->descent;
+            new->angband.fontwidth = new->angband.fnt->max_bounds.width;
+            new->angband.fontascent = new->angband.fnt->ascent;
+        }
+    }
 
-	/* Check all colors, if one or more has changed the redo all GC's */
-	for (n = 0; n < NUM_COLORS; n++)
-		if (current->angband.color[n] != new->angband.color[n])
-			color_changed = TRUE;
+    /* Check all colors, if one or more has changed the redo all GC's */
+    for (n = 0; n < NUM_COLORS; n++)
+        if (current->angband.color[n] != new->angband.color[n])
+            color_changed = TRUE;
 
-	/* Change all GC's if color or font has changed */
-	if (color_changed || font_changed)
-	{
-		gcv.font = new->angband.fnt->fid;
-		gcv.graphics_exposures = FALSE;
-		gcv.background = new->angband.color[0];
+    /* Change all GC's if color or font has changed */
+    if (color_changed || font_changed) {
+        gcv.font = new->angband.fnt->fid;
+        gcv.graphics_exposures = FALSE;
+        gcv.background = new->angband.color[0];
 
-		/* Do all GC's */
-		for (n = 0; n < NUM_COLORS; n++)
-		{
-			if (depth == 1 && n >= 1)
-				gcv.foreground = new->angband.color[1];
-			else
-				gcv.foreground = new->angband.color[n];
-			/* Release the old GC */
-			XtReleaseGC((Widget)current, current->angband.gc[n]);
-			/* Get the new GC */
-			new->angband.gc[n] = XtGetGC((Widget)new, GCFont | GCForeground |
-						     GCBackground | GCGraphicsExposures,
-						     &gcv);
-		}
+        /* Do all GC's */
+        for (n = 0; n < NUM_COLORS; n++) {
+            if (depth == 1 && n >= 1)
+                gcv.foreground = new->angband.color[1];
+            else
+                gcv.foreground = new->angband.color[n];
+            /* Release the old GC */
+            XtReleaseGC((Widget)current, current->angband.gc[n]);
+            /* Get the new GC */
+            new->angband.gc[n] = XtGetGC((Widget) new, GCFont | GCForeground | GCBackground | GCGraphicsExposures, &gcv);
+        }
 
-		/* Replace the old XOR/highlighting GC */
-		gcv.foreground = BlackPixelOfScreen(XtScreen((Widget)new)) ^
-		WhitePixelOfScreen(XtScreen((Widget)new));
-		gcv.function = GXxor;
-		XtReleaseGC((Widget)current, current->angband.gc[NUM_COLORS]);
-		new->angband.gc[NUM_COLORS] = XtGetGC((Widget)new, GCFunction |
-						      GCGraphicsExposures |
-						      GCForeground, &gcv);
-		/* Fix the background color */
-		new->core.background_pixel = new->angband.color[0];
-	}
+        /* Replace the old XOR/highlighting GC */
+        gcv.foreground = BlackPixelOfScreen(XtScreen((Widget) new)) ^ WhitePixelOfScreen(XtScreen((Widget) new));
+        gcv.function = GXxor;
+        XtReleaseGC((Widget)current, current->angband.gc[NUM_COLORS]);
+        new->angband.gc[NUM_COLORS] = XtGetGC((Widget) new, GCFunction | GCGraphicsExposures | GCForeground, &gcv);
+        /* Fix the background color */
+        new->core.background_pixel = new->angband.color[0];
+    }
 
-	/* Check if internal border width has changed, used later */
-	if (current->angband.internal_border != new->angband.internal_border)
-		border_changed = TRUE;
+    /* Check if internal border width has changed, used later */
+    if (current->angband.internal_border != new->angband.internal_border)
+        border_changed = TRUE;
 
+    /* If the font or the internal border has changed, all geometry
+    has to be recalculated */
+    if (font_changed || border_changed) {
+        /* Change window size */
+        height = (current->core.height - 2 * current->angband.internal_border) / current->angband.fontheight * new->angband.fontheight
+            + 2 * current->angband.internal_border;
+        width = (current->core.width - 2 * current->angband.internal_border) / current->angband.fontwidth * new->angband.fontwidth
+            + 2 * new->angband.internal_border;
 
-	/* If the font or the internal border has changed, all geometry
-	has to be recalculated */
-	if (font_changed || border_changed)
-	{
-		/* Change window size */
-		height = (current->core.height - 2 * current->angband.internal_border) /
-		current->angband.fontheight * new->angband.fontheight +
-		2 * current->angband.internal_border;
-		width = (current->core.width -  2 * current->angband.internal_border) /
-		current->angband.fontwidth * new->angband.fontwidth +
-		2 * new->angband.internal_border;
+        /* Get the new width */
+        if (XtMakeResizeRequest((Widget) new, width, height, NULL, NULL) == XtGeometryNo) {
+            /* Not allowed */
+            XtWarning("Size change denied!");
+        } else {
+            /* Recalculate size hints */
+            calculateSizeHints(new);
+        }
+    }
 
-		/* Get the new width */
-		if (XtMakeResizeRequest((Widget)new, width, height, NULL, NULL) ==
-		    XtGeometryNo)
-		{
-			/* Not allowed */
-			XtWarning("Size change denied!");
-		}
-		else
-		{
-			/* Recalculate size hints */
-			calculateSizeHints(new);
-		}
-	}
-
-	/* Tell it to redraw the widget if anything has changed */
-	return (font_changed || color_changed || border_changed);
+    /* Tell it to redraw the widget if anything has changed */
+    return (font_changed || color_changed || border_changed);
 }
 
 /*
@@ -619,60 +525,47 @@ static Boolean SetValues(AngbandWidget current, AngbandWidget request,
  */
 static void calculateSizeHints(AngbandWidget new)
 {
-	TopLevelShellWidget parent =
-	(TopLevelShellWidget)XtParent((Widget) new);
+    TopLevelShellWidget parent = (TopLevelShellWidget)XtParent((Widget) new);
 
-	/* Calculate minimum size */
-	parent->wm.size_hints.min_height =
-	new->angband.min_rows * new->angband.fontheight +
-	2 * new->angband.internal_border;
-	parent->wm.size_hints.min_width =
-	new->angband.min_columns * new->angband.fontwidth +
-	2 * new->angband.internal_border;
-	parent->wm.size_hints.flags |= PMinSize;
+    /* Calculate minimum size */
+    parent->wm.size_hints.min_height = new->angband.min_rows *new->angband.fontheight + 2 * new->angband.internal_border;
+    parent->wm.size_hints.min_width = new->angband.min_columns *new->angband.fontwidth + 2 * new->angband.internal_border;
+    parent->wm.size_hints.flags |= PMinSize;
 
-	/* Calculate maximum size */
-	parent->wm.size_hints.max_height =
-	new->angband.max_rows * new->angband.fontheight +
-	2 * new->angband.internal_border;
-	parent->wm.size_hints.max_width =
-	new->angband.max_columns * new->angband.fontwidth +
-	2 * new->angband.internal_border;
-	parent->wm.size_hints.flags |= PMaxSize;
+    /* Calculate maximum size */
+    parent->wm.size_hints.max_height = new->angband.max_rows *new->angband.fontheight + 2 * new->angband.internal_border;
+    parent->wm.size_hints.max_width = new->angband.max_columns *new->angband.fontwidth + 2 * new->angband.internal_border;
+    parent->wm.size_hints.flags |= PMaxSize;
 
-	/* Calculate increment size */
-	parent->wm.size_hints.height_inc = new->angband.fontheight;
-	parent->wm.size_hints.width_inc = new->angband.fontwidth;
-	parent->wm.size_hints.flags |= PResizeInc;
+    /* Calculate increment size */
+    parent->wm.size_hints.height_inc = new->angband.fontheight;
+    parent->wm.size_hints.width_inc = new->angband.fontwidth;
+    parent->wm.size_hints.flags |= PResizeInc;
 
-	/* Calculate base size */
-	parent->wm.base_height = 2 * new->angband.internal_border;
-	parent->wm.base_width = 2 * new->angband.internal_border;
-	parent->wm.size_hints.flags |= PBaseSize;
+    /* Calculate base size */
+    parent->wm.base_height = 2 * new->angband.internal_border;
+    parent->wm.base_width = 2 * new->angband.internal_border;
+    parent->wm.size_hints.flags |= PBaseSize;
 }
 
 /*
  * Load a font
  */
-static XFontStruct *getFont(AngbandWidget widget,
-			    String font, Boolean fallback)
+static XFontStruct *getFont(AngbandWidget widget, String font, Boolean fallback)
 {
-	Display *dpy = XtDisplay((Widget) widget);
-	char buf[256];
-	XFontStruct *fnt = NULL;
+    Display *dpy = XtDisplay((Widget)widget);
+    char buf[256];
+    XFontStruct *fnt = NULL;
 
-	if (!(fnt = XLoadQueryFont(dpy, font)) && fallback)
-	{
-		sprintf(buf, "Can't find the font \"%s\", trying fixed\n", font);
-		XtWarning(buf);
-		if (!(fnt = XLoadQueryFont(dpy, "fixed")))
-			XtError("Can't fint the font \"fixed\"!, bailing out\n");
-	}
+    if (!(fnt = XLoadQueryFont(dpy, font)) && fallback) {
+        sprintf(buf, "Can't find the font \"%s\", trying fixed\n", font);
+        XtWarning(buf);
+        if (!(fnt = XLoadQueryFont(dpy, "fixed")))
+            XtError("Can't fint the font \"fixed\"!, bailing out\n");
+    }
 
-	return fnt;
+    return fnt;
 }
-
-
 
 /*** The non-widget code ****/
 
@@ -683,35 +576,25 @@ static XFontStruct *getFont(AngbandWidget widget,
  * These were stolen from one of the X11 header files
  */
 
-#define IsKeypadKey(keysym) \
-  (((unsigned)(keysym) >= XK_KP_Space) && ((unsigned)(keysym) <= XK_KP_Equal))
+#define IsKeypadKey(keysym) (((unsigned)(keysym) >= XK_KP_Space) && ((unsigned)(keysym) <= XK_KP_Equal))
 
-#define IsCursorKey(keysym) \
-  (((unsigned)(keysym) >= XK_Home)     && ((unsigned)(keysym) <  XK_Select))
+#define IsCursorKey(keysym) (((unsigned)(keysym) >= XK_Home) && ((unsigned)(keysym) < XK_Select))
 
-#define IsPFKey(keysym) \
-  (((unsigned)(keysym) >= XK_KP_F1)     && ((unsigned)(keysym) <= XK_KP_F4))
+#define IsPFKey(keysym) (((unsigned)(keysym) >= XK_KP_F1) && ((unsigned)(keysym) <= XK_KP_F4))
 
-#define IsFunctionKey(keysym) \
-  (((unsigned)(keysym) >= XK_F1)       && ((unsigned)(keysym) <= XK_F35))
+#define IsFunctionKey(keysym) (((unsigned)(keysym) >= XK_F1) && ((unsigned)(keysym) <= XK_F35))
 
-#define IsMiscFunctionKey(keysym) \
-  (((unsigned)(keysym) >= XK_Select)   && ((unsigned)(keysym) <  XK_KP_Space))
+#define IsMiscFunctionKey(keysym) (((unsigned)(keysym) >= XK_Select) && ((unsigned)(keysym) < XK_KP_Space))
 
-#define IsModifierKey(keysym) \
-  (((unsigned)(keysym) >= XK_Shift_L)  && ((unsigned)(keysym) <= XK_Hyper_R))
+#define IsModifierKey(keysym) (((unsigned)(keysym) >= XK_Shift_L) && ((unsigned)(keysym) <= XK_Hyper_R))
 
 #endif
-
 
 /*
  * Checks if the keysym is a special key or a normal key
  * Assume that XK_MISCELLANY keysyms are special
  */
-#define IsSpecialKey(keysym) \
-  ((unsigned)(keysym) >= 0xFF00)
-
-
+#define IsSpecialKey(keysym) ((unsigned)(keysym) >= 0xFF00)
 
 /*
  * Maximum number of windows XXX XXX XXX XXX
@@ -731,11 +614,10 @@ static XFontStruct *getFont(AngbandWidget widget,
 /*
  * A structure for each "term"
  */
-struct term_data
-{
-	term t;
+struct term_data {
+    term t;
 
-	AngbandWidget widget;
+    AngbandWidget widget;
 };
 
 /*
@@ -743,61 +625,21 @@ struct term_data
  */
 static term_data data[MAX_TERM_DATA];
 
-char *termNames[MAX_TERM_DATA] =
-{
-    "angband",
-    "mirror",
-    "recall",
-    "choice",
-    "term-4",
-    "term-5",
-    "term-6",
-    "term-7"
-};
+char *termNames[MAX_TERM_DATA] = { "angband", "mirror", "recall", "choice", "term-4", "term-5", "term-6", "term-7" };
 
-Arg specialArgs[TERM_FALLBACKS][SPECIAL_FALLBACKS] =
-{
+Arg specialArgs[TERM_FALLBACKS][SPECIAL_FALLBACKS] = {
     /* The main screen */
-    {
-	{ XtNstartRows,    24},
-	{ XtNstartColumns, 80},
-	{ XtNminRows,      24},
-	{ XtNminColumns,   80},
-	{ XtNmaxRows,      24},
-	{ XtNmaxColumns,   80}
-    },
+    { { XtNstartRows, 24 }, { XtNstartColumns, 80 }, { XtNminRows, 24 }, { XtNminColumns, 80 }, { XtNmaxRows, 24 }, { XtNmaxColumns, 80 } },
 
     /* The "mirror" window */
-    {
-	{ XtNstartRows,    24},
-	{ XtNstartColumns, 80},
-	{ XtNminRows,      1},
-	{ XtNminColumns,   1},
-	{ XtNmaxRows,      24},
-	{ XtNmaxColumns,   80}
-    },
+    { { XtNstartRows, 24 }, { XtNstartColumns, 80 }, { XtNminRows, 1 }, { XtNminColumns, 1 }, { XtNmaxRows, 24 }, { XtNmaxColumns, 80 } },
 
     /* The "recall" window */
-    {
-	{ XtNstartRows,    8},
-	{ XtNstartColumns, 80},
-	{ XtNminRows,      1},
-	{ XtNminColumns,   1},
-	{ XtNmaxRows,      24},
-	{ XtNmaxColumns,   80}
-    }
+    { { XtNstartRows, 8 }, { XtNstartColumns, 80 }, { XtNminRows, 1 }, { XtNminColumns, 1 }, { XtNmaxRows, 24 }, { XtNmaxColumns, 80 } }
 };
 
-Arg defaultArgs[TERM_FALLBACKS] =
-{
-	{ XtNstartRows,    24},
-	{ XtNstartColumns, 80},
-	{ XtNminRows,      1},
-	{ XtNminColumns,   1},
-	{ XtNmaxRows,      24},
-	{ XtNmaxColumns,   80}
-};
-
+Arg defaultArgs[TERM_FALLBACKS]
+    = { { XtNstartRows, 24 }, { XtNstartColumns, 80 }, { XtNminRows, 1 }, { XtNminColumns, 1 }, { XtNmaxRows, 24 }, { XtNmaxColumns, 80 } };
 
 /*
  * The application context
@@ -807,46 +649,29 @@ XtAppContext appcon;
 /*
  * User changable information about widgets
  */
-static String fallback[] =
-{
-	"Angband.angband.iconName:            Angband",
-	"Angband.angband.title:               Angband",
-	"Angband.mirror.iconName:             Mirror",
-	"Angband.mirror.title:                Mirror",
-	"Angband.recall.iconName:             Recall",
-	"Angband.recall.title:                Recall",
-	"Angband.choice.iconName:             Choice",
-	"Angband.choice.title:                Choice",
-	"Angband.term-4.iconName:	      Term 4",
-	"Angband.term-4.title:		      Term 4",
-	"Angband.term-5.iconName:	      Term 5",
-	"Angband.term-5.title:		      Term 5",
-	"Angband.term-6.iconName:	      Term 6",
-	"Angband.term-6.title:		      Term 6",
-	"Angband.term-7.iconName:	      Term 7",
-	"Angband.term-7.title:		      Term 7",
-	NULL
-};
-
-
+static String fallback[] = { "Angband.angband.iconName:            Angband", "Angband.angband.title:               Angband",
+    "Angband.mirror.iconName:             Mirror", "Angband.mirror.title:                Mirror", "Angband.recall.iconName:             Recall",
+    "Angband.recall.title:                Recall", "Angband.choice.iconName:             Choice", "Angband.choice.title:                Choice",
+    "Angband.term-4.iconName:	      Term 4", "Angband.term-4.title:		      Term 4", "Angband.term-5.iconName:	      Term 5",
+    "Angband.term-5.title:		      Term 5", "Angband.term-6.iconName:	      Term 6", "Angband.term-6.title:		      Term 6",
+    "Angband.term-7.iconName:	      Term 7", "Angband.term-7.title:		      Term 7", NULL };
 
 /*
  * Do a redraw
  */
-static void react_redraw(Widget widget,
-			 XtPointer client_data, XtPointer call_data)
+static void react_redraw(Widget widget, XtPointer client_data, XtPointer call_data)
 {
-	term_data *old_td = (term_data*)(Term->data);
-	term_data *td = (term_data*)client_data;
+    term_data *old_td = (term_data *)(Term->data);
+    term_data *td = (term_data *)client_data;
 
-	/* Activate the proper Term */
-	Term_activate(&td->t);
+    /* Activate the proper Term */
+    Term_activate(&td->t);
 
-	/* Request a redraw */
-	Term_redraw();
+    /* Request a redraw */
+    Term_redraw();
 
-	/* Activate the old Term */
-	Term_activate(&old_td->t);
+    /* Activate the old Term */
+    Term_activate(&old_td->t);
 }
 
 /*
@@ -854,317 +679,291 @@ static void react_redraw(Widget widget,
  */
 static void react_keypress(XKeyEvent *ev)
 {
-	int i, n, mc, ms, mo, mx;
+    int i, n, mc, ms, mo, mx;
 
-	KeySym ks;
+    KeySym ks;
 
-	char buf[128];
-	char msg[128];
+    char buf[128];
+    char msg[128];
 
+    /* Check for "normal" keypresses */
+    n = XLookupString(ev, buf, 125, &ks, NULL);
 
-	/* Check for "normal" keypresses */
-	n = XLookupString(ev, buf, 125, &ks, NULL);
+    /* Terminate */
+    buf[n] = '\0';
 
-	/* Terminate */
-	buf[n] = '\0';
+    /* Extract four "modifier flags" */
+    mc = (ev->state & ControlMask) ? TRUE : FALSE;
+    ms = (ev->state & ShiftMask) ? TRUE : FALSE;
+    mo = (ev->state & Mod1Mask) ? TRUE : FALSE;
+    mx = (ev->state & Mod2Mask) ? TRUE : FALSE;
 
-	/* Extract four "modifier flags" */
-	mc = (ev->state & ControlMask) ? TRUE : FALSE;
-	ms = (ev->state & ShiftMask) ? TRUE : FALSE;
-	mo = (ev->state & Mod1Mask) ? TRUE : FALSE;
-	mx = (ev->state & Mod2Mask) ? TRUE : FALSE;
+    /* Hack -- Ignore "modifier keys" */
+    if (IsModifierKey(ks))
+        return;
 
-	/* Hack -- Ignore "modifier keys" */
-	if (IsModifierKey(ks)) return;
+    /* Normal keys with no modifiers */
+    if (n && !mo && !mx && !IsSpecialKey(ks)) {
+        /* Enqueue the normal key(s) */
+        for (i = 0; buf[i]; i++)
+            Term_keypress(buf[i]);
 
-	/* Normal keys with no modifiers */
-	if (n && !mo && !mx && !IsSpecialKey(ks))
-	{
-		/* Enqueue the normal key(s) */
-		for (i = 0; buf[i]; i++) Term_keypress(buf[i]);
+        /* All done */
+        return;
+    }
 
-		/* All done */
-		return;
-	}
+    /* Handle a few standard keys */
+    switch (ks) {
+    case XK_Escape:
+        Term_keypress(ESCAPE);
+        return;
 
-	/* Handle a few standard keys */
-	switch (ks)
-	{
-		case XK_Escape:
-		Term_keypress(ESCAPE); return;
+    case XK_Return:
+        Term_keypress('\r');
+        return;
 
-		case XK_Return:
-		Term_keypress('\r'); return;
+    case XK_Tab:
+        Term_keypress('\t');
+        return;
 
-		case XK_Tab:
-		Term_keypress('\t'); return;
+    case XK_Delete:
+    case XK_BackSpace:
+        Term_keypress('\010');
+        return;
+    }
 
-		case XK_Delete:
-		case XK_BackSpace:
-		Term_keypress('\010'); return;
-	}
+    /* Hack -- Use the KeySym */
+    if (ks) {
+        sprintf(msg, "%c%s%s%s%s_%lX%c", 31, mc ? "N" : "", ms ? "S" : "", mo ? "O" : "", mx ? "M" : "", (unsigned long)(ks), 13);
+    }
 
-	/* Hack -- Use the KeySym */
-	if (ks)
-	{
-		sprintf(msg, "%c%s%s%s%s_%lX%c", 31,
-			mc ? "N" : "", ms ? "S" : "",
-			mo ? "O" : "", mx ? "M" : "",
-			(unsigned long)(ks), 13);
-	}
+    /* Hack -- Use the Keycode */
+    else {
+        sprintf(msg, "%c%s%s%s%sK_%X%c", 31, mc ? "N" : "", ms ? "S" : "", mo ? "O" : "", mx ? "M" : "", ev->keycode, 13);
+    }
 
-	/* Hack -- Use the Keycode */
-	else
-	{
-		sprintf(msg, "%c%s%s%s%sK_%X%c", 31,
-			mc ? "N" : "", ms ? "S" : "",
-			mo ? "O" : "", mx ? "M" : "",
-			ev->keycode, 13);
-	}
+    /* Enqueue the "fake" string */
+    for (i = 0; msg[i]; i++)
+        Term_keypress(msg[i]);
 
-	/* Enqueue the "fake" string */
-	for (i = 0; msg[i]; i++)
-		Term_keypress(msg[i]);
+    /* Hack -- dump an "extra" string */
+    if (n) {
+        /* Start the "extra" string */
+        Term_keypress(28);
 
-	/* Hack -- dump an "extra" string */
-	if (n)
-	{
-		/* Start the "extra" string */
-		Term_keypress(28);
+        /* Enqueue the "real" string */
+        for (i = 0; buf[i]; i++)
+            Term_keypress(buf[i]);
 
-		/* Enqueue the "real" string */
-		for (i = 0; buf[i]; i++)
-			Term_keypress(buf[i]);
-
-		/* End the "extra" string */
-		Term_keypress(28);
-	}
+        /* End the "extra" string */
+        Term_keypress(28);
+    }
 }
 
-
-static void handle_event (Widget widget, XtPointer client_data, XEvent *event,
-			  Boolean *continue_to_dispatch)
+static void handle_event(Widget widget, XtPointer client_data, XEvent *event, Boolean *continue_to_dispatch)
 {
-	term_data *old_td = (term_data*)(Term->data);
-	term_data *td = (term_data *)client_data;
+    term_data *old_td = (term_data *)(Term->data);
+    term_data *td = (term_data *)client_data;
 
-	/* Continue to process the event by default */
-	*continue_to_dispatch = TRUE;
+    /* Continue to process the event by default */
+    *continue_to_dispatch = TRUE;
 
-	/* Activate the Term */
-	Term_activate(&td->t);
+    /* Activate the Term */
+    Term_activate(&td->t);
 
-	switch (event->type)
-	{
-		case KeyPress:
-		react_keypress(&(event->xkey));
-		*continue_to_dispatch = FALSE; /* We took care of the event */
-		break;
+    switch (event->type) {
+    case KeyPress:
+        react_keypress(&(event->xkey));
+        *continue_to_dispatch = FALSE; /* We took care of the event */
+        break;
 
-		default:
-		break;  /* Huh? Shouldn't happen! */
-	}
+    default:
+        break; /* Huh? Shouldn't happen! */
+    }
 
-	/* Activate the old term */
-	Term_activate(&old_td->t);
+    /* Activate the old term */
+    Term_activate(&old_td->t);
 
-	return;
+    return;
 }
-
 
 /*
  * Process an event (or just check for one)
  */
 errr CheckEvent(bool wait)
 {
-	XEvent event;
+    XEvent event;
 
-	/* No events ready, and told to just check */
-	if (!wait && !XtAppPending(appcon)) return 1;
+    /* No events ready, and told to just check */
+    if (!wait && !XtAppPending(appcon))
+        return 1;
 
-	/* Process */
-	while (1)
-	{
-		XtAppNextEvent(appcon, &event);
-		XtDispatchEvent(&event);
-		if (!XtAppPending(appcon)) break;
-	}
+    /* Process */
+    while (1) {
+        XtAppNextEvent(appcon, &event);
+        XtDispatchEvent(&event);
+        if (!XtAppPending(appcon))
+            break;
+    }
 
-	return (0);
+    return (0);
 }
-
 
 /*
  * Handle a "special request"
  */
 static errr Term_xtra_xaw(int n, int v)
 {
-	int i;
+    int i;
 
-	/* Handle a subset of the legal requests */
-	switch (n)
-	{
-		/* Make a noise */
-		case TERM_XTRA_NOISE:
-		XBell(XtDisplay((Widget)data[0].widget), 100);
-		return (0);
+    /* Handle a subset of the legal requests */
+    switch (n) {
+    /* Make a noise */
+    case TERM_XTRA_NOISE:
+        XBell(XtDisplay((Widget)data[0].widget), 100);
+        return (0);
 
-		/* Flush the output */
-		case TERM_XTRA_FRESH:
-		XFlush(XtDisplay((Widget)data[0].widget));
-		/* Nonblock event-check so the flushed events can be showed */
-		CheckEvent(FALSE);
-		return (0);
+    /* Flush the output */
+    case TERM_XTRA_FRESH:
+        XFlush(XtDisplay((Widget)data[0].widget));
+        /* Nonblock event-check so the flushed events can be showed */
+        CheckEvent(FALSE);
+        return (0);
 
-		/* Process random events */
-		case TERM_XTRA_BORED:
-		return (CheckEvent(0));
+    /* Process random events */
+    case TERM_XTRA_BORED:
+        return (CheckEvent(0));
 
-		/* Process events */
-		case TERM_XTRA_EVENT:
-		return (CheckEvent(v));
+    /* Process events */
+    case TERM_XTRA_EVENT:
+        return (CheckEvent(v));
 
-		/* Flush events */
-		case TERM_XTRA_FLUSH:
-		while (!CheckEvent(FALSE));
-		return (0);
+    /* Flush events */
+    case TERM_XTRA_FLUSH:
+        while (!CheckEvent(FALSE))
+            ;
+        return (0);
 
-		/* Delay */
-		case TERM_XTRA_DELAY:
-		usleep(1000 * v);
-		return (0);
+    /* Delay */
+    case TERM_XTRA_DELAY:
+        usleep(1000 * v);
+        return (0);
 
-		/* Clear the window */
-		case TERM_XTRA_CLEAR:
-		for (i=0; i<MAX_TERM_DATA; i++) {
-		    if (Term == &data[i].t)
-			XClearWindow(XtDisplay((Widget)data[i].widget),
-				     XtWindow((Widget)data[i].widget));
-		}
-		return (0);
-	}
+    /* Clear the window */
+    case TERM_XTRA_CLEAR:
+        for (i = 0; i < MAX_TERM_DATA; i++) {
+            if (Term == &data[i].t)
+                XClearWindow(XtDisplay((Widget)data[i].widget), XtWindow((Widget)data[i].widget));
+        }
+        return (0);
+    }
 
-	/* Unknown */
-	return (1);
+    /* Unknown */
+    return (1);
 }
-
-
 
 /*
  * Erase a number of characters
  */
 static errr Term_wipe_xaw(int x, int y, int n)
 {
-	term_data *td = (term_data*)(Term->data);
+    term_data *td = (term_data *)(Term->data);
 
-	/* Erase using color 0 */
-	AngbandClearArea(td->widget, x, y, n, 1, 0);
+    /* Erase using color 0 */
+    AngbandClearArea(td->widget, x, y, n, 1, 0);
 
-	/* Success */
-	return (0);
+    /* Success */
+    return (0);
 }
-
-
 
 /*
  * Draw the cursor (XXX by hiliting)
  */
 static errr Term_curs_xaw(int x, int y)
 {
-	term_data *td = (term_data*)(Term->data);
+    term_data *td = (term_data *)(Term->data);
 
-	/* Hilite the cursor character */
-	AngbandClearArea(td->widget, x, y, 1, 1, COLOR_XOR);
+    /* Hilite the cursor character */
+    AngbandClearArea(td->widget, x, y, 1, 1, COLOR_XOR);
 
-	/* Success */
-	return (0);
+    /* Success */
+    return (0);
 }
-
 
 /*
  * Draw a number of characters
  */
 static errr Term_text_xaw(int x, int y, int n, byte a, concptr s)
 {
-	term_data *td = (term_data*)(Term->data);
+    term_data *td = (term_data *)(Term->data);
 
-	/* Draw the text */
-	AngbandOutputText(td->widget, x, y, (String)s, n, (a & 0x0F));
+    /* Draw the text */
+    AngbandOutputText(td->widget, x, y, (String)s, n, (a & 0x0F));
 
-	/* Success */
-	return (0);
+    /* Success */
+    return (0);
 }
-
 
 /*
  * Raise a term
  */
 static void term_raise(term_data win)
 {
-	Widget widget = (Widget)win.widget;
+    Widget widget = (Widget)win.widget;
 
-	XRaiseWindow(XtDisplay(XtParent(widget)), XtWindow(XtParent(widget)));
+    XRaiseWindow(XtDisplay(XtParent(widget)), XtWindow(XtParent(widget)));
 }
-
 
 /*
  * Initialize a term_data
  */
-static errr term_data_init(term_data *td, Widget topLevel,
-			   int key_buf, String name,
-			   ArgList widget_arg, Cardinal widget_arg_no)
+static errr term_data_init(term_data *td, Widget topLevel, int key_buf, String name, ArgList widget_arg, Cardinal widget_arg_no)
 {
-	Widget parent;
-	term *t = &td->t;
+    Widget parent;
+    term *t = &td->t;
 
-	/* Create the shell widget */
-	parent = XtCreatePopupShell(name, topLevelShellWidgetClass, topLevel,
-				    NULL, 0);
+    /* Create the shell widget */
+    parent = XtCreatePopupShell(name, topLevelShellWidgetClass, topLevel, NULL, 0);
 
-	/* Create the interior widget */
-	td->widget = (AngbandWidget)
-	XtCreateManagedWidget (name, angbandWidgetClass,
-			       parent, widget_arg, widget_arg_no);
+    /* Create the interior widget */
+    td->widget = (AngbandWidget)XtCreateManagedWidget(name, angbandWidgetClass, parent, widget_arg, widget_arg_no);
 
-	/* Initialize the term (full size) */
-	term_init(t, 80, 24, key_buf);
+    /* Initialize the term (full size) */
+    term_init(t, 80, 24, key_buf);
 
-	/* Use a "soft" cursor */
-	t->soft_cursor = TRUE;
+    /* Use a "soft" cursor */
+    t->soft_cursor = TRUE;
 
-	/* Erase with "white space" */
-	t->attr_blank = TERM_WHITE;
-	t->char_blank = ' ';
+    /* Erase with "white space" */
+    t->attr_blank = TERM_WHITE;
+    t->char_blank = ' ';
 
-	/* Hooks */
-	t->xtra_hook = Term_xtra_xaw;
-	t->curs_hook = Term_curs_xaw;
-	t->wipe_hook = Term_wipe_xaw;
-	t->text_hook = Term_text_xaw;
+    /* Hooks */
+    t->xtra_hook = Term_xtra_xaw;
+    t->curs_hook = Term_curs_xaw;
+    t->wipe_hook = Term_wipe_xaw;
+    t->text_hook = Term_text_xaw;
 
-	/* Save the data */
-	t->data = td;
+    /* Save the data */
+    t->data = td;
 
-	/* Register the keypress event handler */
-	XtAddEventHandler((Widget)td->widget, KeyPressMask,
-			  False, (XtEventHandler) handle_event, td);
+    /* Register the keypress event handler */
+    XtAddEventHandler((Widget)td->widget, KeyPressMask, False, (XtEventHandler)handle_event, td);
 
-	/* Redraw callback */
-	XtAddCallback((Widget)td->widget, XtNredrawCallback,
-		      react_redraw, td);
+    /* Redraw callback */
+    XtAddCallback((Widget)td->widget, XtNredrawCallback, react_redraw, td);
 
-	/* Realize the widget */
-	XtRealizeWidget(parent);
+    /* Realize the widget */
+    XtRealizeWidget(parent);
 
-	/* Make it visible */
-	XtPopup(parent, XtGrabNone);
+    /* Make it visible */
+    XtPopup(parent, XtGrabNone);
 
-	/* Activate (important) */
-	Term_activate(t);
+    /* Activate (important) */
+    Term_activate(t);
 
-	return 0;
+    return 0;
 }
-
 
 /*
  * Initialization function for an X Athena Widget module to Angband
@@ -1176,58 +975,52 @@ static errr term_data_init(term_data *td, Widget topLevel,
  */
 errr init_xaw(void)
 {
-	int argc, i;
-	char *argv[2];
-	Widget topLevel;
-	Display *dpy;
+    int argc, i;
+    char *argv[2];
+    Widget topLevel;
+    Display *dpy;
 
+    /* One fake argument */
+    argc = 1;
 
-	/* One fake argument */
-	argc = 1;
+    /* Save the program name */
+    argv[0] = argv0;
 
-	/* Save the program name */
-	argv[0] = argv0;
+    /* Terminate */
+    argv[1] = NULL;
 
-	/* Terminate */
-	argv[1] = NULL;
+    /* Attempt to open the local display */
+    dpy = XOpenDisplay("");
 
+    /* Failure -- assume no X11 available */
+    if (!dpy)
+        return (-1);
 
-	/* Attempt to open the local display */
-	dpy = XOpenDisplay("");
-
-	/* Failure -- assume no X11 available */
-	if (!dpy) return (-1);
-
-	/* Close the local display */
-	XCloseDisplay(dpy);
-
+    /* Close the local display */
+    XCloseDisplay(dpy);
 
 #ifdef USE_XAW_LANG
-	/* Support locale processing */
-	XtSetLanguageProc(NULL, NULL, NULL);
+    /* Support locale processing */
+    XtSetLanguageProc(NULL, NULL, NULL);
 #endif
 
-	/* Initialize the toolkit */
-	topLevel = XtAppInitialize (&appcon, "Angband", NULL, 0, &argc, argv,
-				    fallback, NULL, 0);
+    /* Initialize the toolkit */
+    topLevel = XtAppInitialize(&appcon, "Angband", NULL, 0, &argc, argv, fallback, NULL, 0);
 
-	/* Initialize the windows */
-	for (i=0; i<MAX_TERM_DATA; i++) {
-	    term_data_init (&data[i], topLevel, 1024, termNames[i],
-			    i<SPECIAL_FALLBACKS ? specialArgs[i] : defaultArgs,
-			    TERM_FALLBACKS);
-	    angband_term[i] = Term;
-	}
+    /* Initialize the windows */
+    for (i = 0; i < MAX_TERM_DATA; i++) {
+        term_data_init(&data[i], topLevel, 1024, termNames[i], i < SPECIAL_FALLBACKS ? specialArgs[i] : defaultArgs, TERM_FALLBACKS);
+        angband_term[i] = Term;
+    }
 
-	/* Activate the "Angband" window screen */
-	Term_activate(&data[0].t);
+    /* Activate the "Angband" window screen */
+    Term_activate(&data[0].t);
 
-	/* Raise the "Angband" window */
-	term_raise(data[0]);
+    /* Raise the "Angband" window */
+    term_raise(data[0]);
 
-	/* Success */
-	return (0);
+    /* Success */
+    return (0);
 }
 
 #endif
-

--- a/src/main-xaw.cpp
+++ b/src/main-xaw.cpp
@@ -39,8 +39,8 @@ background          Background         Pixel           XtDefaultBackground
 border              BorderColor        Pixel           XtDefaultForeground
 borderWidth         BorderWidth        Dimension       1
 cursor              Cursor             Cursor          None
-cursorName          Cursor             String          NULL
-destroyCallback     Callback           Pointer         NULL
+cursorName          Cursor             String          nullptr
+destroyCallback     Callback           Pointer         nullptr
 height              Height             Dimension       0
 insensitiveBorder   Insensitive        Pixmap          Gray
 mappedWhenManaged   MappedWhenManaged  Boolean         True
@@ -253,7 +253,7 @@ static XtResource resources[] = { { XtNstartRows, XtCValue, XtRInt, sizeof(int),
     { XtNcolor14, XtCColor, XtRPixel, sizeof(Pixel), offset(color[14]), XtRString, "#00c8ff" },
     { XtNcolor15, XtCColor, XtRPixel, sizeof(Pixel), offset(color[15]), XtRString, "#ffcc80" },
 
-    { XtNredrawCallback, XtCCallback, XtRCallback, sizeof(XtPointer), offset(redraw_callbacks), XtRCallback, (XtPointer)NULL } };
+    { XtNredrawCallback, XtCCallback, XtRCallback, sizeof(XtPointer), offset(redraw_callbacks), XtRCallback, (XtPointer)nullptr } };
 
 #undef offset
 
@@ -274,35 +274,35 @@ AngbandClassRec angbandClassRec = { {
                                         /* superclass           */ (WidgetClass)superclass,
                                         /* class_name           */ "Angband",
                                         /* widget_size          */ sizeof(AngbandRec),
-                                        /* class_initialize     */ NULL,
-                                        /* class_part_initialize*/ NULL,
+                                        /* class_initialize     */ nullptr,
+                                        /* class_part_initialize*/ nullptr,
                                         /* class_inited         */ false,
                                         /* initialize           */ (XtInitProc)Initialize,
-                                        /* initialize_hook      */ NULL,
+                                        /* initialize_hook      */ nullptr,
                                         /* realize              */ XtInheritRealize,
-                                        /* actions              */ NULL,
+                                        /* actions              */ nullptr,
                                         /* num_actions          */ 0,
                                         /* resources            */ resources,
                                         /* num_resources        */ XtNumber(resources),
-                                        /* xrm_class            */ NULLQUARK,
+                                        /* xrm_class            */ nullptrQUARK,
                                         /* compress_motion      */ true,
                                         /* compress_exposure    */ XtExposeCompressMultiple,
                                         /* compress_enterleave  */ true,
                                         /* visible_interest     */ false,
                                         /* destroy              */ (XtWidgetProc)Destroy,
-                                        /* resize               */ NULL,
+                                        /* resize               */ nullptr,
                                         /* expose               */ (XtExposeProc)Redisplay,
                                         /* set_values           */ (XtSetValuesFunc)SetValues,
-                                        /* set_values_hook      */ NULL,
+                                        /* set_values_hook      */ nullptr,
                                         /* set_values_almost    */ XtInheritSetValuesAlmost,
-                                        /* get_values_hook      */ NULL,
-                                        /* accept_focus         */ NULL,
+                                        /* get_values_hook      */ nullptr,
+                                        /* accept_focus         */ nullptr,
                                         /* version              */ XtVersion,
-                                        /* callback_private     */ NULL,
-                                        /* tm_table             */ NULL,
-                                        /* query_geometry       */ NULL,
+                                        /* callback_private     */ nullptr,
+                                        /* tm_table             */ nullptr,
+                                        /* query_geometry       */ nullptr,
                                         /* display_accelerator  */ XtInheritDisplayAccelerator,
-                                        /* extension            */ NULL },
+                                        /* extension            */ nullptr },
     /* Simple class fields initialization */
     { /* change_sensitive     */ XtInheritChangeSensitive },
     /* Angband class fields initialization */
@@ -422,7 +422,7 @@ static void Destroy(AngbandWidget widget)
 static void Redisplay(AngbandWidget widget, XEvent *event, Region region)
 {
     if (XtHasCallbacks((Widget)widget, XtNredrawCallback) == XtCallbackHasSome)
-        XtCallCallbacks((Widget)widget, XtNredrawCallback, NULL);
+        XtCallCallbacks((Widget)widget, XtNredrawCallback, nullptr);
 }
 
 /*
@@ -446,7 +446,7 @@ static Boolean SetValues(AngbandWidget current, AngbandWidget request, AngbandWi
         new->angband.fnt = getFont(new, new->angband.font, FALSE);
 
         /* The font didn't exist */
-        if (new->angband.fnt == NULL) {
+        if (new->angband.fnt == nullptr) {
             new->angband.fnt = current->angband.fnt;
             new->angband.font = current->angband.font;
             XtWarning("Couldn't find the request font!");
@@ -507,7 +507,7 @@ static Boolean SetValues(AngbandWidget current, AngbandWidget request, AngbandWi
             + 2 * new->angband.internal_border;
 
         /* Get the new width */
-        if (XtMakeResizeRequest((Widget) new, width, height, NULL, NULL) == XtGeometryNo) {
+        if (XtMakeResizeRequest((Widget) new, width, height, nullptr, nullptr) == XtGeometryNo) {
             /* Not allowed */
             XtWarning("Size change denied!");
         } else {
@@ -555,7 +555,7 @@ static XFontStruct *getFont(AngbandWidget widget, String font, Boolean fallback)
 {
     Display *dpy = XtDisplay((Widget)widget);
     char buf[256];
-    XFontStruct *fnt = NULL;
+    XFontStruct *fnt = nullptr;
 
     if (!(fnt = XLoadQueryFont(dpy, font)) && fallback) {
         sprintf(buf, "Can't find the font \"%s\", trying fixed\n", font);
@@ -654,7 +654,7 @@ static String fallback[] = { "Angband.angband.iconName:            Angband", "An
     "Angband.recall.title:                Recall", "Angband.choice.iconName:             Choice", "Angband.choice.title:                Choice",
     "Angband.term-4.iconName:	      Term 4", "Angband.term-4.title:		      Term 4", "Angband.term-5.iconName:	      Term 5",
     "Angband.term-5.title:		      Term 5", "Angband.term-6.iconName:	      Term 6", "Angband.term-6.title:		      Term 6",
-    "Angband.term-7.iconName:	      Term 7", "Angband.term-7.title:		      Term 7", NULL };
+    "Angband.term-7.iconName:	      Term 7", "Angband.term-7.title:		      Term 7", nullptr };
 
 /*
  * Do a redraw
@@ -687,7 +687,7 @@ static void react_keypress(XKeyEvent *ev)
     char msg[128];
 
     /* Check for "normal" keypresses */
-    n = XLookupString(ev, buf, 125, &ks, NULL);
+    n = XLookupString(ev, buf, 125, &ks, nullptr);
 
     /* Terminate */
     buf[n] = '\0';
@@ -923,7 +923,7 @@ static errr term_data_init(term_data *td, Widget topLevel, int key_buf, String n
     term *t = &td->t;
 
     /* Create the shell widget */
-    parent = XtCreatePopupShell(name, topLevelShellWidgetClass, topLevel, NULL, 0);
+    parent = XtCreatePopupShell(name, topLevelShellWidgetClass, topLevel, nullptr, 0);
 
     /* Create the interior widget */
     td->widget = (AngbandWidget)XtCreateManagedWidget(name, angbandWidgetClass, parent, widget_arg, widget_arg_no);
@@ -987,7 +987,7 @@ errr init_xaw(void)
     argv[0] = argv0;
 
     /* Terminate */
-    argv[1] = NULL;
+    argv[1] = nullptr;
 
     /* Attempt to open the local display */
     dpy = XOpenDisplay("");
@@ -1001,11 +1001,11 @@ errr init_xaw(void)
 
 #ifdef USE_XAW_LANG
     /* Support locale processing */
-    XtSetLanguageProc(NULL, NULL, NULL);
+    XtSetLanguageProc(nullptr, nullptr, nullptr);
 #endif
 
     /* Initialize the toolkit */
-    topLevel = XtAppInitialize(&appcon, "Angband", NULL, 0, &argc, argv, fallback, NULL, 0);
+    topLevel = XtAppInitialize(&appcon, "Angband", nullptr, 0, &argc, argv, fallback, nullptr, 0);
 
     /* Initialize the windows */
     for (i = 0; i < MAX_TERM_DATA; i++) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -279,7 +279,7 @@ static void display_usage(const char *program)
 #endif /* USE_CAP */
 
     /* Actually abort the process */
-    quit(NULL);
+    quit(nullptr);
 }
 
 /*
@@ -299,7 +299,7 @@ static bool parse_long_opt(const char *opt)
     switch (output_all_spoilers()) {
     case spoiler_output_status::SPOILER_OUTPUT_SUCCESS:
         puts("Successfully created a spoiler file.");
-        quit(NULL);
+        quit(nullptr);
         break;
     case spoiler_output_status::SPOILER_OUTPUT_FAIL_FOPEN:
         quit("Cannot create spoiler file.");
@@ -328,7 +328,7 @@ int main(int argc, char *argv[])
     bool done = false;
     bool new_game = false;
     int show_score = 0;
-    concptr mstr = NULL;
+    concptr mstr = nullptr;
     bool args = true;
 
     /* Save the "program name" XXX XXX XXX */
@@ -509,7 +509,7 @@ int main(int argc, char *argv[])
     /* Hack -- Forget standard args */
     if (args) {
         argc = 1;
-        argv[1] = NULL;
+        argv[1] = nullptr;
     }
 
     /* Process the player name */
@@ -583,7 +583,7 @@ int main(int argc, char *argv[])
     play_game(p_ptr, new_game, browsing_movie);
 
     /* Quit */
-    quit(NULL);
+    quit(nullptr);
 
     /* Exit */
     return (0);

--- a/src/main/angband-initializer.cpp
+++ b/src/main/angband-initializer.cpp
@@ -100,7 +100,7 @@ void init_file_paths(char *libpath, char *varpath)
     strcpy(libtail, "xtra");
     ANGBAND_DIR_XTRA = string_make(libpath);
 
-    time_t now = time(NULL);
+    time_t now = time(nullptr);
     struct tm *t = localtime(&now);
     char tmp[128];
     strftime(tmp, sizeof(tmp), "%Y-%m-%d-%H-%M-%S", t);

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -100,7 +100,7 @@ static errr init_info(concptr filename, angband_header &head, std::vector<InfoTy
 #endif
         msg_format(_("レコード %d は '%s' エラーがあります。", "Record %d contains a '%s' error."), error_idx, oops);
         msg_format(_("構文 '%s'。", "Parsing '%s'."), buf);
-        msg_print(NULL);
+        msg_print(nullptr);
         quit(format(_("'%s.txt'ファイルにエラー", "Error in '%s.txt' file."), filename));
     }
 
@@ -129,7 +129,7 @@ errr init_f_info()
 errr init_k_info()
 {
     init_header(&k_head, max_k_idx);
-    return init_info("k_info", k_head, k_info, parse_k_info, NULL);
+    return init_info("k_info", k_head, k_info, parse_k_info, nullptr);
 }
 
 /*!
@@ -140,7 +140,7 @@ errr init_k_info()
 errr init_a_info()
 {
     init_header(&a_head, max_a_idx);
-    return init_info("a_info", a_head, a_info, parse_a_info, NULL);
+    return init_info("a_info", a_head, a_info, parse_a_info, nullptr);
 }
 
 /*!
@@ -151,7 +151,7 @@ errr init_a_info()
 errr init_e_info()
 {
     init_header(&e_head, max_e_idx);
-    return init_info("e_info", e_head, e_info, parse_e_info, NULL);
+    return init_info("e_info", e_head, e_info, parse_e_info, nullptr);
 }
 
 /*!
@@ -162,7 +162,7 @@ errr init_e_info()
 errr init_r_info()
 {
     init_header(&r_head, max_r_idx);
-    return init_info("r_info", r_head, r_info, parse_r_info, NULL);
+    return init_info("r_info", r_head, r_info, parse_r_info, nullptr);
 }
 
 /*!
@@ -173,7 +173,7 @@ errr init_r_info()
 errr init_d_info()
 {
     init_header(&d_head, current_world_ptr->max_d_idx);
-    return init_info("d_info", d_head, d_info, parse_d_info, NULL);
+    return init_info("d_info", d_head, d_info, parse_d_info, nullptr);
 }
 
 /*!
@@ -187,7 +187,7 @@ errr init_d_info()
 errr init_v_info()
 {
     init_header(&v_head, max_v_idx);
-    return init_info("v_info", v_head, v_info, parse_v_info, NULL);
+    return init_info("v_info", v_head, v_info, parse_v_info, nullptr);
 }
 
 /*!
@@ -198,7 +198,7 @@ errr init_v_info()
 errr init_s_info()
 {
     init_header(&s_head, MAX_CLASS);
-    return init_info("s_info", s_head, s_info, parse_s_info, NULL);
+    return init_info("s_info", s_head, s_info, parse_s_info, nullptr);
 }
 
 /*!
@@ -209,5 +209,5 @@ errr init_s_info()
 errr init_m_info()
 {
     init_header(&m_head, MAX_CLASS);
-    return init_info("m_info", m_head, m_info, parse_m_info, NULL);
+    return init_info("m_info", m_head, m_info, parse_m_info, nullptr);
 }

--- a/src/main/init-error-messages-table.cpp
+++ b/src/main/init-error-messages-table.cpp
@@ -9,7 +9,7 @@
  * エラーメッセージの名称定義 / Standard error message text
  */
 concptr err_str[PARSE_ERROR_MAX] = {
-    NULL,
+    nullptr,
     _("文法エラー", "parse error"),
     _("古いファイル", "obsolete file"),
     _("記録ヘッダがない", "missing record header"),

--- a/src/main/scene-table-monster.cpp
+++ b/src/main/scene-table-monster.cpp
@@ -41,7 +41,7 @@ inline static bool is_unknown_monster(monster_race *ap_r_ptr)
 
 void clear_scene_target_monster()
 {
-    scene_target_monster.ap_r_ptr = NULL;
+    scene_target_monster.ap_r_ptr = nullptr;
 }
 
 static GAME_TURN get_game_turn()
@@ -60,7 +60,7 @@ static GAME_TURN get_game_turn()
  */
 void set_temp_mute_scene_monster(int sec)
 {
-    scene_target_monster.mute_until = (uint32_t)time(NULL) + sec;
+    scene_target_monster.mute_until = (uint32_t)time(nullptr) + sec;
 }
 
 /*!
@@ -70,7 +70,7 @@ void set_temp_mute_scene_monster(int sec)
  */
 inline static bool can_mute_scene_monster()
 {
-    return (scene_target_monster.mute_until > time(NULL));
+    return (scene_target_monster.mute_until > time(nullptr));
 }
 
 /*!

--- a/src/market/arena.cpp
+++ b/src/market/arena.cpp
@@ -47,7 +47,7 @@ static bool process_ostensible_arena_victory(player_type *player_ptr)
     prt("", 11, 0);
     player_ptr->au += 1000000L;
     msg_print(_("スペースキーで続行", "Press the space bar to continue"));
-    msg_print(NULL);
+    msg_print(nullptr);
     player_ptr->arena_number++;
     return true;
 }
@@ -64,19 +64,19 @@ static bool battle_metal_babble(player_type *player_ptr)
 
     if (player_ptr->arena_number >= MAX_ARENA_MONS + 2) {
         msg_print(_("あなたはアリーナに入り、しばらくの間栄光にひたった。", "You enter the arena briefly and bask in your glory."));
-        msg_print(NULL);
+        msg_print(nullptr);
         return true;
     }
 
     msg_print(_("君のために最強の挑戦者を用意しておいた。", "The strongest challenger is waiting for you."));
-    msg_print(NULL);
+    msg_print(nullptr);
     if (!get_check(_("挑戦するかね？", "Do you fight? "))) {
         msg_print(_("残念だ。", "We are disappointed."));
         return true;
     }
 
     msg_print(_("死ぬがよい。", "Die, maggots."));
-    msg_print(NULL);
+    msg_print(nullptr);
 
     player_ptr->exit_bldg = false;
     reset_tim_flags(player_ptr);
@@ -100,7 +100,7 @@ static void go_to_arena(player_type *player_ptr)
 
     if (player_ptr->riding && (player_ptr->pclass != CLASS_BEASTMASTER) && (player_ptr->pclass != CLASS_CAVALRY)) {
         msg_print(_("ペットに乗ったままではアリーナへ入れさせてもらえなかった。", "You don't have permission to enter with pet."));
-        msg_print(NULL);
+        msg_print(nullptr);
         return;
     }
 
@@ -153,7 +153,7 @@ void arena_comm(player_type *player_ptr, int cmd)
         screen_save();
 
         /* Peruse the on_defeat_arena_monster help file */
-        (void)show_file(player_ptr, true, _("arena_j.txt", "arena.txt"), NULL, 0, 0);
+        (void)show_file(player_ptr, true, _("arena_j.txt", "arena.txt"), nullptr, 0, 0);
         screen_load();
         break;
     }
@@ -194,7 +194,7 @@ void update_gambling_monsters(player_type *player_ptr)
             MONRACE_IDX r_idx;
             int j;
             while (true) {
-                get_mon_num_prep(player_ptr, monster_can_entry_arena, NULL);
+                get_mon_num_prep(player_ptr, monster_can_entry_arena, nullptr);
                 r_idx = get_mon_num(player_ptr, 0, mon_level, GMN_ARENA);
                 if (!r_idx)
                     continue;
@@ -289,7 +289,7 @@ bool monster_arena_comm(player_type *player_ptr)
     /* No money */
     if (player_ptr->au <= 1) {
         msg_print(_("おい！おまえ一文なしじゃないか！こっから出ていけ！", "Hey! You don't have gold - get out of here!"));
-        msg_print(NULL);
+        msg_print(nullptr);
         screen_load();
         return false;
     }
@@ -357,7 +357,7 @@ bool monster_arena_comm(player_type *player_ptr)
     if (wager > player_ptr->au) {
         msg_print(_("おい！金が足りないじゃないか！出ていけ！", "Hey! You don't have the gold - get out of here!"));
 
-        msg_print(NULL);
+        msg_print(nullptr);
         screen_load();
         return false;
     } else if (wager > maxbet) {
@@ -369,7 +369,7 @@ bool monster_arena_comm(player_type *player_ptr)
         wager = 1;
     }
 
-    msg_print(NULL);
+    msg_print(nullptr);
     battle_odds = MAX(wager + 1, wager * battle_odds / 100);
     kakekin = wager;
     player_ptr->au -= wager;

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -189,7 +189,7 @@ bool exchange_cash(player_type *player_ptr)
         return true;
 
     msg_print(_("賞金を得られそうなものは持っていなかった。", "You have nothing."));
-    msg_print(NULL);
+    msg_print(nullptr);
     return false;
 }
 

--- a/src/market/building-craft-fix.cpp
+++ b/src/market/building-craft-fix.cpp
@@ -138,7 +138,7 @@ static PRICE repair_broken_weapon_aux(player_type *player_ptr, PRICE bcost)
     if (player_ptr->au < cost) {
         describe_flavor(player_ptr, basenm, o_ptr, OD_NAME_ONLY);
         msg_format(_("%sを修復するだけのゴールドがありません！", "You do not have the gold to repair %s!"), basenm);
-        msg_print(NULL);
+        msg_print(nullptr);
         return 0;
     }
 
@@ -257,7 +257,7 @@ static PRICE repair_broken_weapon_aux(player_type *player_ptr, PRICE bcost)
 #else
     msg_format("Repaired into %s for %d gold.", basenm, cost);
 #endif
-    msg_print(NULL);
+    msg_print(nullptr);
     o_ptr->ident &= ~(IDENT_BROKEN);
     o_ptr->discount = 99;
 

--- a/src/market/building-craft-weapon.cpp
+++ b/src/market/building-craft-weapon.cpp
@@ -412,7 +412,7 @@ PRICE compare_weapons(player_type *customer_ptr, PRICE bcost)
 
         if (total + cost > customer_ptr->au) {
             msg_print(_("お金が足りません！", "You don't have enough money!"));
-            msg_print(NULL);
+            msg_print(nullptr);
             continue;
         }
 
@@ -425,7 +425,7 @@ PRICE compare_weapons(player_type *customer_ptr, PRICE bcost)
 
         if (i2_ptr == o_ptr[0] || (n == 2 && i2_ptr == o_ptr[1])) {
             msg_print(_("表示中の武器は選べません！", "Select a different weapon than those displayed."));
-            msg_print(NULL);
+            msg_print(nullptr);
             continue;
         }
 

--- a/src/market/building-quest.cpp
+++ b/src/market/building-quest.cpp
@@ -103,7 +103,7 @@ void castle_quest(player_type *player_ptr)
 
         clear_bldg(4, 18);
         msg_print(_("放棄しました。", "You gave up."));
-        msg_print(NULL);
+        msg_print(nullptr);
         record_quest_final_status(q_ptr, player_ptr->lev, QUEST_STATUS_FAILED);
     }
 

--- a/src/market/building-recharger.cpp
+++ b/src/market/building-recharger.cpp
@@ -57,7 +57,7 @@ void building_recharge(player_type *player_ptr)
     char tmp_str[MAX_NLEN];
     if (!o_ptr->is_known()) {
         msg_format(_("充填する前に鑑定されている必要があります！", "The item must be identified first!"));
-        msg_print(NULL);
+        msg_print(nullptr);
 
         if ((player_ptr->au >= 50) && get_check(_("＄50で鑑定しますか？ ", "Identify for 50 gold? ")))
 
@@ -221,13 +221,13 @@ void building_recharge_all(player_type *player_ptr)
 
     if (!total_cost) {
         msg_print(_("充填する必要はありません。", "No need to recharge."));
-        msg_print(NULL);
+        msg_print(nullptr);
         return;
     }
 
     if (player_ptr->au < total_cost) {
         msg_format(_("すべてのアイテムを再充填するには＄%d 必要です！", "You need %d gold to recharge all items!"), total_cost);
-        msg_print(NULL);
+        msg_print(nullptr);
         return;
     }
 
@@ -271,7 +271,7 @@ void building_recharge_all(player_type *player_ptr)
     }
 
     msg_format(_("＄%d で再充填しました。", "You pay %d gold."), total_cost);
-    msg_print(NULL);
+    msg_print(nullptr);
     player_ptr->update |= (PU_COMBINE | PU_REORDER);
     player_ptr->window_flags |= (PW_INVEN);
     player_ptr->au -= total_cost;

--- a/src/market/play-gamble.cpp
+++ b/src/market/play-gamble.cpp
@@ -32,14 +32,14 @@ bool gamble_comm(player_type *player_ptr, int cmd)
     screen_save();
 
     if (cmd == BACT_GAMBLE_RULES) {
-        (void)show_file(player_ptr, true, _("jgambling.txt", "gambling.txt"), NULL, 0, 0);
+        (void)show_file(player_ptr, true, _("jgambling.txt", "gambling.txt"), nullptr, 0, 0);
         screen_load();
         return true;
     }
 
     if (player_ptr->au < 1) {
         msg_print(_("おい！おまえ一文なしじゃないか！こっから出ていけ！", "Hey! You don't have gold - get out of here!"));
-        msg_print(NULL);
+        msg_print(nullptr);
         screen_load();
         return false;
     }
@@ -56,7 +56,7 @@ bool gamble_comm(player_type *player_ptr, int cmd)
      * the int16_t value returned by get_quantity().
      */
     if (!get_string(tmp_str, out_val, 32)) {
-        msg_print(NULL);
+        msg_print(nullptr);
         screen_load();
         return true;
     }
@@ -67,7 +67,7 @@ bool gamble_comm(player_type *player_ptr, int cmd)
     wager = atol(p);
     if (wager > player_ptr->au) {
         msg_print(_("おい！金が足りないじゃないか！出ていけ！", "Hey! You don't have the gold - get out of here!"));
-        msg_print(NULL);
+        msg_print(nullptr);
         screen_load();
         return false;
     } else if (wager > maxbet) {
@@ -77,7 +77,7 @@ bool gamble_comm(player_type *player_ptr, int cmd)
         msg_print(_("ＯＫ、１ゴールドからはじめよう。", "Ok, we'll start with 1 gold."));
         wager = 1;
     }
-    msg_print(NULL);
+    msg_print(nullptr);
     win = 0;
     odds = 0;
     oldgold = player_ptr->au;
@@ -126,7 +126,7 @@ bool gamble_comm(player_type *player_ptr, int cmd)
                 do {
                     msg_print(_("なにかキーを押すともう一回振ります。", "Hit any key to roll again"));
 
-                    msg_print(NULL);
+                    msg_print(nullptr);
                     roll1 = randint1(6);
                     roll2 = randint1(6);
                     roll3 = roll1 + roll2;
@@ -161,7 +161,7 @@ bool gamble_comm(player_type *player_ptr, int cmd)
                 msg_print(_("ＯＫ、9番にしとくぜ。", "Ok, I'll put you down for 9."));
                 choice = 9;
             }
-            msg_print(NULL);
+            msg_print(nullptr);
             roll1 = randint0(10);
             sprintf(tmp_str, _("ルーレットは回り、止まった。勝者は %d番だ。", "The wheel spins to a stop and the winner is %d"), roll1);
             prt(tmp_str, 13, 3);
@@ -270,7 +270,7 @@ bool gamble_comm(player_type *player_ptr, int cmd)
         prt("", 18, 37);
         if (wager > player_ptr->au) {
             msg_print(_("おい！金が足りないじゃないか！ここから出て行け！", "Hey! You don't have the gold - get out of here!"));
-            msg_print(NULL);
+            msg_print(nullptr);
 
             /* Get out here */
             break;
@@ -286,7 +286,7 @@ bool gamble_comm(player_type *player_ptr, int cmd)
         chg_virtue(player_ptr, V_CHANCE, -3);
     }
 
-    msg_print(NULL);
+    msg_print(nullptr);
     screen_load();
     return true;
 }

--- a/src/melee/melee-postprocess.cpp
+++ b/src/melee/melee-postprocess.cpp
@@ -248,7 +248,7 @@ static void fall_off_horse_by_melee(player_type *player_ptr, mam_pp_type *mam_pp
  * @param dam ダメージ量
  * @param dead 目標となったモンスターの死亡状態を返す参照ポインタ
  * @param fear 目標となったモンスターの恐慌状態を返す参照ポインタ
- * @param note 目標モンスターが死亡した場合の特別メッセージ(NULLならば標準表示を行う)
+ * @param note 目標モンスターが死亡した場合の特別メッセージ(nullptrならば標準表示を行う)
  * @param who 打撃を行ったモンスターの参照ID
  * @todo 打撃が当たった時の後処理 (爆発持ちのモンスターを爆発させる等)なので、関数名を変更する必要あり
  */

--- a/src/melee/melee-spell-util.cpp
+++ b/src/melee/melee-spell-util.cpp
@@ -21,7 +21,7 @@ melee_spell_type *initialize_melee_spell_type(player_type *target_ptr, melee_spe
     ms_ptr->dam = 0;
     floor_type *floor_ptr = target_ptr->current_floor_ptr;
     ms_ptr->m_ptr = &floor_ptr->m_list[m_idx];
-    ms_ptr->t_ptr = NULL;
+    ms_ptr->t_ptr = nullptr;
     ms_ptr->r_ptr = &r_info[ms_ptr->m_ptr->r_idx];
     ms_ptr->see_m = is_seen(target_ptr, ms_ptr->m_ptr);
     ms_ptr->maneable = player_has_los_bold(target_ptr, ms_ptr->m_ptr->fy, ms_ptr->m_ptr->fx);

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -171,7 +171,7 @@ static void redraw_health_bar(player_type *subject_ptr, mam_type *mam_ptr)
 static void describe_silly_melee(mam_type *mam_ptr)
 {
     char temp[MAX_NLEN];
-    if ((mam_ptr->act == NULL) || !mam_ptr->see_either)
+    if ((mam_ptr->act == nullptr) || !mam_ptr->see_either)
         return;
 
 #ifdef JP

--- a/src/mind/mind-berserker.cpp
+++ b/src/mind/mind-berserker.cpp
@@ -55,7 +55,7 @@ bool cast_berserk_spell(player_type *caster_ptr, mind_berserker_type spell)
         x += ddx[dir];
         if (player_can_enter(caster_ptr, caster_ptr->current_floor_ptr->grid_array[y][x].feat, 0)
             && !is_trap(caster_ptr, caster_ptr->current_floor_ptr->grid_array[y][x].feat) && !caster_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
-            msg_print(NULL);
+            msg_print(nullptr);
             (void)move_player_effect(caster_ptr, y, x, MPE_FORGET_FLOW | MPE_HANDLE_STUFF | MPE_DONT_PICKUP);
         }
 

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -1102,7 +1102,7 @@ static void display_realm_cursor(int i, int n, term_color_type color)
 static int interpret_realm_select_key(int cs, int n, char c)
 {
     if (c == 'Q')
-        quit(NULL);
+        quit(nullptr);
 
     if (c == '8')
         if (cs >= 5)

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -396,7 +396,7 @@ bool cast_ninja_spell(player_type *caster_ptr, mind_ninja_type spell)
         set_oppose_fire(caster_ptr, (TIME_EFFECT)plev, false);
         break;
     case NYUSIN:
-        return rush_attack(caster_ptr, NULL);
+        return rush_attack(caster_ptr, nullptr);
     case SYURIKEN_SPREADING: {
         for (int i = 0; i < 8; i++) {
             OBJECT_IDX slot;

--- a/src/mind/mind-warrior.cpp
+++ b/src/mind/mind-warrior.cpp
@@ -30,7 +30,7 @@ bool hit_and_away(player_type *caster_ptr)
     }
 
     msg_print(_("その方向にはモンスターはいません。", "You don't see any monster in this direction"));
-    msg_print(NULL);
+    msg_print(nullptr);
     return false;
 }
 

--- a/src/mind/monk-attack.cpp
+++ b/src/mind/monk-attack.cpp
@@ -248,7 +248,7 @@ bool double_attack(player_type *creature_ptr)
     POSITION x = creature_ptr->x + ddx[dir];
     if (!creature_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
         msg_print(_("その方向にはモンスターはいません。", "You don't see any monster in this direction"));
-        msg_print(NULL);
+        msg_print(nullptr);
         return true;
     }
 

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -131,7 +131,7 @@ static bool effect_protecion_from_evil(player_type *target_ptr, monap_type *mona
 
 static void describe_silly_attacks(monap_type *monap_ptr)
 {
-    if (monap_ptr->act == NULL)
+    if (monap_ptr->act == nullptr)
         return;
 
     if (monap_ptr->do_silly_attack) {
@@ -253,7 +253,7 @@ static void monster_explode(player_type *target_ptr, monap_type *monap_ptr)
 
     sound(SOUND_EXPLODE);
     MonsterDamageProcessor mdp(target_ptr, monap_ptr->m_idx, monap_ptr->m_ptr->hp + 1, &monap_ptr->fear);
-    if (mdp.mon_take_hit(NULL)) {
+    if (mdp.mon_take_hit(nullptr)) {
         monap_ptr->blinked = false;
         monap_ptr->alive = false;
     }
@@ -397,7 +397,7 @@ static bool process_monster_blows(player_type *target_ptr, monap_type *monap_ptr
     for (int ap_cnt = 0; ap_cnt < MAX_NUM_BLOWS; ap_cnt++) {
         monap_ptr->obvious = false;
         monap_ptr->damage = 0;
-        monap_ptr->act = NULL;
+        monap_ptr->act = nullptr;
         monap_ptr->effect = r_ptr->blow[ap_cnt].effect;
         monap_ptr->method = r_ptr->blow[ap_cnt].method;
         monap_ptr->d_dice = r_ptr->blow[ap_cnt].d_dice;

--- a/src/monster-attack/monster-attack-util.cpp
+++ b/src/monster-attack/monster-attack-util.cpp
@@ -17,7 +17,7 @@ monap_type *initialize_monap_type(player_type *target_ptr, monap_type *monap_ptr
     monap_ptr->m_idx = m_idx;
     floor_type *floor_ptr = target_ptr->current_floor_ptr;
     monap_ptr->m_ptr = &floor_ptr->m_list[m_idx];
-    monap_ptr->act = NULL;
+    monap_ptr->act = nullptr;
     monap_ptr->touched = false;
     monap_ptr->explode = false;
     monap_ptr->do_silly_attack = one_in_(2) && target_ptr->image;

--- a/src/monster-floor/monster-generator.cpp
+++ b/src/monster-floor/monster-generator.cpp
@@ -242,7 +242,7 @@ static bool place_monster_can_escort(player_type *player_ptr, MONRACE_IDX r_idx)
         return false;
 
     if (r_ptr->flags7 & RF7_FRIENDLY) {
-        if (monster_has_hostile_align(player_ptr, NULL, 1, -1, z_ptr))
+        if (monster_has_hostile_align(player_ptr, nullptr, 1, -1, z_ptr))
             return false;
     }
 
@@ -367,7 +367,7 @@ bool alloc_horde(player_type *player_ptr, POSITION y, POSITION x, summon_specifi
     floor_type *floor_ptr = player_ptr->current_floor_ptr;
     MONRACE_IDX r_idx = 0;
     int attempts = 1000;
-    monster_race *r_ptr = NULL;
+    monster_race *r_ptr = nullptr;
     while (--attempts) {
         r_idx = get_mon_num(player_ptr, 0, floor_ptr->monster_level, 0);
         if (!r_idx)

--- a/src/monster-floor/monster-summon.cpp
+++ b/src/monster-floor/monster-summon.cpp
@@ -51,7 +51,7 @@ static bool summon_specific_okay(player_type *player_ptr, MONRACE_IDX r_idx)
         if (monster_has_hostile_align(player_ptr, m_ptr, 0, 0, r_ptr))
             return false;
     } else if (summon_specific_who < 0) {
-        if (monster_has_hostile_align(player_ptr, NULL, 10, -10, r_ptr) && !one_in_(ABS(player_ptr->alignment) / 2 + 1))
+        if (monster_has_hostile_align(player_ptr, nullptr, 10, -10, r_ptr) && !one_in_(ABS(player_ptr->alignment) / 2 + 1))
             return false;
     }
 
@@ -62,7 +62,7 @@ static bool summon_specific_okay(player_type *player_ptr, MONRACE_IDX r_idx)
         return true;
 
     if ((summon_specific_who < 0) && ((r_ptr->flags1 & RF1_UNIQUE) || (r_ptr->flags7 & RF7_NAZGUL))
-        && monster_has_hostile_align(player_ptr, NULL, 10, -10, r_ptr))
+        && monster_has_hostile_align(player_ptr, nullptr, 10, -10, r_ptr))
         return false;
 
     if ((r_ptr->flags7 & RF7_CHAMELEON) && d_info[player_ptr->dungeon_idx].flags.has(DF::CHAMELEON))

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -89,7 +89,7 @@ static MONRACE_IDX initial_r_appearance(player_type *player_ptr, MONRACE_IDX r_i
     if (none_bits(r_info[r_idx].flags7, RF7_TANUKI))
         return r_idx;
 
-    get_mon_num_prep(player_ptr, monster_hook_tanuki, NULL);
+    get_mon_num_prep(player_ptr, monster_hook_tanuki, nullptr);
     int attempts = 1000;
     DEPTH min = MIN(floor_ptr->base_level - 5, 50);
     while (--attempts) {
@@ -221,7 +221,7 @@ static void warn_unique_generation(player_type *player_ptr, MONRACE_IDX r_idx)
         color = _("白く", "white");
 
     o_ptr = choose_warning_item(player_ptr);
-    if (o_ptr != NULL) {
+    if (o_ptr != nullptr) {
         describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
         msg_format(_("%sは%s光った。", "%s glows %s."), o_name, color);
     } else {
@@ -324,7 +324,7 @@ bool place_monster_one(player_type *player_ptr, MONSTER_IDX who, POSITION y, POS
     if (any_bits(mode, PM_FORCE_PET)) {
         set_pet(player_ptr, m_ptr);
     } else if (((who == 0) && any_bits(r_ptr->flags7, RF7_FRIENDLY)) || is_friendly_idx(player_ptr, who) || any_bits(mode, PM_FORCE_FRIENDLY)) {
-        if (!monster_has_hostile_align(player_ptr, NULL, 0, -1, r_ptr) && !player_ptr->current_floor_ptr->inside_arena)
+        if (!monster_has_hostile_align(player_ptr, nullptr, 0, -1, r_ptr) && !player_ptr->current_floor_ptr->inside_arena)
             set_friendly(m_ptr);
     }
 

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -153,7 +153,7 @@ static void on_dead_sacred_treasures(player_type *player_ptr, monster_death_type
         return;
 
     ARTIFACT_IDX a_idx = 0;
-    artifact_type *a_ptr = NULL;
+    artifact_type *a_ptr = nullptr;
     do {
         switch (randint0(3)) {
         case 0:
@@ -376,7 +376,7 @@ static bool make_equipment(player_type *player_ptr, object_type *q_ptr, const BI
  * @brief 死亡時ドロップとしてランダムアーティファクトのみを生成する
  * @param player_ptr プレーヤーへの参照ポインタ
  * @param md_ptr モンスター撃破構造体への参照ポインタ
- * @param object_hook_pf アイテム種別指定、特になければNULLで良い
+ * @param object_hook_pf アイテム種別指定、特になければnullptrで良い
  * @return なし
  * @details
  * 最初のアイテム生成でいきなり☆が生成された場合を除き、中途半端な☆ (例：呪われている)は生成しない.
@@ -386,7 +386,7 @@ static void on_dead_random_artifact(player_type *player_ptr, monster_death_type 
 {
     object_type forge;
     object_type *q_ptr = &forge;
-    auto is_object_hook_null = object_hook_pf == NULL;
+    auto is_object_hook_null = object_hook_pf == nullptr;
     auto drop_mode = md_ptr->mo_mode | AM_NO_FIXED_ART;
     while (true) {
         // make_object() の中でアイテム種別をキャンセルしている

--- a/src/monster-race/monster-race-hook.cpp
+++ b/src/monster-race/monster-race-hook.cpp
@@ -35,9 +35,9 @@ EnumClassFlagGroup<RF_ABILITY> vault_aux_dragon_mask4;
  */
 void vault_prep_clone(player_type *player_ptr)
 {
-    get_mon_num_prep(player_ptr, vault_aux_simple, NULL);
+    get_mon_num_prep(player_ptr, vault_aux_simple, nullptr);
     vault_aux_race = get_mon_num(player_ptr, 0, player_ptr->current_floor_ptr->dun_level + 10, 0);
-    get_mon_num_prep(player_ptr, NULL, NULL);
+    get_mon_num_prep(player_ptr, nullptr, nullptr);
 }
 
 /*!
@@ -46,9 +46,9 @@ void vault_prep_clone(player_type *player_ptr)
  */
 void vault_prep_symbol(player_type *player_ptr)
 {
-    get_mon_num_prep(player_ptr, vault_aux_simple, NULL);
+    get_mon_num_prep(player_ptr, vault_aux_simple, nullptr);
     MONRACE_IDX r_idx = get_mon_num(player_ptr, 0, player_ptr->current_floor_ptr->dun_level + 10, 0);
-    get_mon_num_prep(player_ptr, NULL, NULL);
+    get_mon_num_prep(player_ptr, nullptr, nullptr);
     vault_aux_char = r_info[r_idx].d_char;
 }
 

--- a/src/monster/monster-info.cpp
+++ b/src/monster/monster-info.cpp
@@ -199,7 +199,7 @@ bool are_enemies(player_type *player_ptr, monster_type *m_ptr, monster_type *n_p
  * @param r_ptr モンスター種族情報の構造体参照ポインタ
  * @return プレイヤーに敵意を持つならばTRUEを返す
  * @details
- * If user is player, m_ptr == NULL.
+ * If user is player, m_ptr == nullptr.
  */
 bool monster_has_hostile_align(player_type *player_ptr, monster_type *m_ptr, int pa_good, int pa_evil, monster_race *r_ptr)
 {
@@ -261,7 +261,7 @@ bool is_mimicry(monster_type *m_ptr)
 
     monster_race *r_ptr = &r_info[m_ptr->ap_r_idx];
 
-    if (angband_strchr("/|\\()[]=$,.!?&`#%<>+~", r_ptr->d_char) == NULL)
+    if (angband_strchr("/|\\()[]=$,.!?&`#%<>+~", r_ptr->d_char) == nullptr)
         return false;
 
     if (none_bits(r_ptr->flags1, RF1_NEVER_MOVE) && !monster_csleep_remaining(m_ptr)) {

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -298,9 +298,9 @@ void choose_new_monster(player_type *player_ptr, MONSTER_IDX m_idx, bool born, M
 
         chameleon_change_m_idx = m_idx;
         if (old_unique)
-            get_mon_num_prep(player_ptr, monster_hook_chameleon_lord, NULL);
+            get_mon_num_prep(player_ptr, monster_hook_chameleon_lord, nullptr);
         else
-            get_mon_num_prep(player_ptr, monster_hook_chameleon, NULL);
+            get_mon_num_prep(player_ptr, monster_hook_chameleon, nullptr);
 
         if (old_unique)
             level = r_info[MON_CHAMELEON_K].level;

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -310,7 +310,7 @@ void process_angar(player_type *target_ptr, MONSTER_IDX m_idx, bool see_m)
         gets_angry = true;
 
     if (is_pet(m_ptr)
-        && ((((r_ptr->flags1 & RF1_UNIQUE) || (r_ptr->flags7 & RF7_NAZGUL)) && monster_has_hostile_align(target_ptr, NULL, 10, -10, r_ptr))
+        && ((((r_ptr->flags1 & RF1_UNIQUE) || (r_ptr->flags7 & RF7_NAZGUL)) && monster_has_hostile_align(target_ptr, nullptr, 10, -10, r_ptr))
             || (r_ptr->flagsr & RFR_RES_ALL)))
         gets_angry = true;
 

--- a/src/monster/monster-status-setter.cpp
+++ b/src/monster/monster-status-setter.cpp
@@ -378,7 +378,7 @@ bool set_monster_timewalk(player_type *target_ptr, int num, MONRACE_IDX who, boo
         }
 
         msg_format(mes, m_name);
-        msg_print(NULL);
+        msg_print(nullptr);
     }
 
     current_world_ptr->timewalk_m_idx = hack_m_idx;
@@ -413,7 +413,7 @@ bool set_monster_timewalk(player_type *target_ptr, int num, MONRACE_IDX who, boo
         }
 
         msg_print(mes);
-        msg_print(NULL);
+        msg_print(nullptr);
     }
 
     handle_stuff(target_ptr);

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -288,8 +288,8 @@ monsterrace_hook_type get_monster_hook2(player_type *player_ptr, POSITION y, POS
 /*!
  * @brief モンスター生成テーブルの重みを指定条件に従って変更する。
  * @param player_ptr
- * @param hook1 生成制約関数1 (NULL の場合、制約なし)
- * @param hook2 生成制約関数2 (NULL の場合、制約なし)
+ * @param hook1 生成制約関数1 (nullptr の場合、制約なし)
+ * @param hook2 生成制約関数2 (nullptr の場合、制約なし)
  * @param restrict_to_dungeon 現在プレイヤーのいるダンジョンの制約を適用するか
  * @return 常に 0
  *
@@ -386,8 +386,8 @@ static errr do_get_mon_num_prep(player_type *player_ptr, const monsterrace_hook_
 /*!
  * @brief モンスター生成テーブルの重み修正
  * @param player_ptr
- * @param hook1 生成制約関数1 (NULL の場合、制約なし)
- * @param hook2 生成制約関数2 (NULL の場合、制約なし)
+ * @param hook1 生成制約関数1 (nullptr の場合、制約なし)
+ * @param hook2 生成制約関数2 (nullptr の場合、制約なし)
  * @return 常に 0
  *
  * get_mon_num() を呼ぶ前に get_mon_num_prep() 系関数のいずれかを呼ぶこと。
@@ -405,5 +405,5 @@ errr get_mon_num_prep(player_type *player_ptr, const monsterrace_hook_type hook1
  */
 errr get_mon_num_prep_bounty(player_type *player_ptr)
 {
-    return do_get_mon_num_prep(player_ptr, NULL, NULL, false);
+    return do_get_mon_num_prep(player_ptr, nullptr, nullptr, false);
 }

--- a/src/mspell/mspell-damage-calculator.cpp
+++ b/src/mspell/mspell-damage-calculator.cpp
@@ -494,7 +494,7 @@ HIT_POINT monspell_bluemage_damage(player_type *target_ptr, RF_ABILITY ms_type, 
 {
     int hp = target_ptr->chp;
     int shoot_dd = 1, shoot_ds = 1, shoot_base = 0;
-    object_type *o_ptr = NULL;
+    object_type *o_ptr = nullptr;
 
     if (has_melee_weapon(target_ptr, INVEN_MAIN_HAND))
         o_ptr = &target_ptr->inventory_list[INVEN_MAIN_HAND];

--- a/src/mspell/specified-summon.cpp
+++ b/src/mspell/specified-summon.cpp
@@ -178,7 +178,7 @@ MONSTER_NUMBER summon_NAZGUL(player_type *target_ptr, POSITION y, POSITION x, MO
     else
         msg_format(_("%^sが魔法で幽鬼戦隊を召喚した！", "%^s magically summons rangers of Nazgul!"), m_name);
 
-    msg_print(NULL);
+    msg_print(nullptr);
 
     int count = 0;
     for (int k = 0; k < 30; k++) {
@@ -208,11 +208,11 @@ MONSTER_NUMBER summon_NAZGUL(player_type *target_ptr, POSITION y, POSITION x, MO
         else
             msg_format(_("「同じく%d号、ナズグル・ブラック！」", "Another one says 'Number %d, Nazgul-Black!'"), count);
 
-        msg_print(NULL);
+        msg_print(nullptr);
     }
 
     msg_format(_("「%d人そろって、リングレンジャー！」", "They say 'The %d meets! We are the Ring-Ranger!'."), count);
-    msg_print(NULL);
+    msg_print(nullptr);
     return count;
 }
 

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -137,7 +137,7 @@ void process_world_aux_mutation(player_type *creature_ptr)
         if (!has_resist_nexus(creature_ptr) && creature_ptr->muta.has_not(MUTA::VTELEPORT) && !creature_ptr->anti_tele) {
             disturb(creature_ptr, false, true);
             msg_print(_("あなたの位置は突然ひじょうに不確定になった...", "Your position suddenly seems very uncertain..."));
-            msg_print(NULL);
+            msg_print(nullptr);
             teleport_player(creature_ptr, 40, TELEPORT_PASSIVE);
         }
     }
@@ -155,7 +155,7 @@ void process_world_aux_mutation(player_type *creature_ptr)
 
         if (!has_resist_chaos(creature_ptr)) {
             if (one_in_(20)) {
-                msg_print(NULL);
+                msg_print(nullptr);
                 if (one_in_(3))
                     lose_all_info(creature_ptr);
                 else
@@ -184,7 +184,7 @@ void process_world_aux_mutation(player_type *creature_ptr)
     if (creature_ptr->muta.has(MUTA::FLATULENT) && (randint1(3000) == 13)) {
         disturb(creature_ptr, false, true);
         msg_print(_("ブゥーーッ！おっと。", "BRRAAAP! Oops."));
-        msg_print(NULL);
+        msg_print(nullptr);
         fire_ball(creature_ptr, GF_POIS, 0, creature_ptr->lev, 3);
     }
 
@@ -195,7 +195,7 @@ void process_world_aux_mutation(player_type *creature_ptr)
             "Magical energy flows through you! You must release it!"));
 
         flush();
-        msg_print(NULL);
+        msg_print(nullptr);
         (void)get_hack_dir(creature_ptr, &dire);
         fire_ball(creature_ptr, GF_MANA, dire, creature_ptr->lev * 2, 3);
     }
@@ -235,7 +235,7 @@ void process_world_aux_mutation(player_type *creature_ptr)
             }
         }
 
-        msg_print(NULL);
+        msg_print(nullptr);
     }
 
     if (creature_ptr->muta.has(MUTA::BANISH_ALL) && one_in_(9000)) {
@@ -252,14 +252,14 @@ void process_world_aux_mutation(player_type *creature_ptr)
             msg_print(_("店の主人が丘に向かって走っている！", "You see one of the shopkeepers running for the hills!"));
             store_shuffle(creature_ptr, n);
         }
-        msg_print(NULL);
+        msg_print(nullptr);
     }
 
     if (creature_ptr->muta.has(MUTA::EAT_LIGHT) && one_in_(3000)) {
         object_type *o_ptr;
 
         msg_print(_("影につつまれた。", "A shadow passes over you."));
-        msg_print(NULL);
+        msg_print(nullptr);
 
         if ((creature_ptr->current_floor_ptr->grid_array[creature_ptr->y][creature_ptr->x].info & (CAVE_GLOW | CAVE_MNDK)) == CAVE_GLOW) {
             hp_player(creature_ptr, 10);
@@ -301,7 +301,7 @@ void process_world_aux_mutation(player_type *creature_ptr)
     if (creature_ptr->muta.has(MUTA::RAW_CHAOS) && !creature_ptr->anti_magic && one_in_(8000)) {
         disturb(creature_ptr, false, true);
         msg_print(_("周りの空間が歪んでいる気がする！", "You feel the world warping around you!"));
-        msg_print(NULL);
+        msg_print(nullptr);
         fire_ball(creature_ptr, GF_CHAOS, 0, creature_ptr->lev, 8);
     }
 
@@ -313,7 +313,7 @@ void process_world_aux_mutation(player_type *creature_ptr)
     if (creature_ptr->muta.has(MUTA::WRAITH) && !creature_ptr->anti_magic && one_in_(3000)) {
         disturb(creature_ptr, false, true);
         msg_print(_("非物質化した！", "You feel insubstantial!"));
-        msg_print(NULL);
+        msg_print(nullptr);
         set_wraith_form(creature_ptr, randint1(creature_ptr->lev / 2) + (creature_ptr->lev / 2), false);
     }
 
@@ -357,7 +357,7 @@ void process_world_aux_mutation(player_type *creature_ptr)
         if (!sustained) {
             disturb(creature_ptr, false, true);
             msg_print(_("自分が衰弱していくのが分かる！", "You can feel yourself wasting away!"));
-            msg_print(NULL);
+            msg_print(nullptr);
             (void)dec_stat(creature_ptr, which_stat, randint1(6) + 6, one_in_(3));
         }
     }
@@ -389,7 +389,7 @@ void process_world_aux_mutation(player_type *creature_ptr)
     if (creature_ptr->muta.has(MUTA::NAUSEA) && !creature_ptr->slow_digest && one_in_(9000)) {
         disturb(creature_ptr, false, true);
         msg_print(_("胃が痙攣し、食事を失った！", "Your stomach roils, and you lose your lunch!"));
-        msg_print(NULL);
+        msg_print(nullptr);
         set_food(creature_ptr, PY_FOOD_WEAK);
         if (music_singing_any(creature_ptr))
             stop_singing(creature_ptr);
@@ -431,7 +431,7 @@ void process_world_aux_mutation(player_type *creature_ptr)
     if (creature_ptr->muta.has(MUTA::INVULN) && !creature_ptr->anti_magic && one_in_(5000)) {
         disturb(creature_ptr, false, true);
         msg_print(_("無敵な気がする！", "You feel invincible!"));
-        msg_print(NULL);
+        msg_print(nullptr);
         (void)set_invuln(creature_ptr, randint1(8) + 8, false);
     }
 
@@ -472,12 +472,12 @@ void process_world_aux_mutation(player_type *creature_ptr)
 bool drop_weapons(player_type *creature_ptr)
 {
     INVENTORY_IDX slot = 0;
-    object_type *o_ptr = NULL;
+    object_type *o_ptr = nullptr;
 
     if (creature_ptr->wild_mode)
         return false;
 
-    msg_print(NULL);
+    msg_print(nullptr);
     if (has_melee_weapon(creature_ptr, INVEN_MAIN_HAND)) {
         slot = INVEN_MAIN_HAND;
         o_ptr = &creature_ptr->inventory_list[INVEN_MAIN_HAND];

--- a/src/object-enchant/activation-info-table.cpp
+++ b/src/object-enchant/activation-info-table.cpp
@@ -152,5 +152,5 @@ const activation_type activation_info[MAX_ACTIVATION_TYPE] = {
     { "ELBERETH", ACT_ELBERETH, 10, 30000, { 75, 0 }, _("エルベレスの結界", "Rune of Elbereth") },
     { "DETECT_TREASURE", ACT_DETECT_TREASURE, 10, 3000, {35, 0}, _("財宝感知", "detect treasure") },
 
-    { NULL, 0, 0, 0, { 0, 0 }, "" },
+    { nullptr, 0, 0, 0, { 0, 0 }, "" },
 };

--- a/src/object-enchant/apply-magic-others.cpp
+++ b/src/object-enchant/apply-magic-others.cpp
@@ -163,7 +163,7 @@ void apply_magic_others(player_type *owner_ptr, object_type *o_ptr, int power)
             match = RF9_DROP_CORPSE;
         }
 
-        get_mon_num_prep(owner_ptr, item_monster_okay, NULL);
+        get_mon_num_prep(owner_ptr, item_monster_okay, nullptr);
         while (true) {
             i = get_mon_num(owner_ptr, 0, floor_ptr->dun_level, 0);
             r_ptr = &r_info[i];

--- a/src/object-enchant/dragon-breaths-table.cpp
+++ b/src/object-enchant/dragon-breaths-table.cpp
@@ -20,5 +20,5 @@ const dragonbreath_type dragonbreath_info[] = {
 	{ TR_RES_NETHER, GF_NETHER, _("地獄", "nether") },
 	{ TR_RES_CHAOS, GF_CHAOS, _("カオス", "chaos") },
 	{ TR_RES_DISEN, GF_DISENCHANT, _("劣化", "disenchantment") },
-	{ TR_STR, 0, NULL }
+	{ TR_STR, 0, nullptr }
 };

--- a/src/object-use/quaff-execution.cpp
+++ b/src/object-use/quaff-execution.cpp
@@ -216,7 +216,7 @@ void exe_quaff_potion(player_type *creature_ptr, INVENTORY_IDX item)
                     msg_print(_("恐ろしい光景が頭に浮かんできた。", "A horrible vision enters your mind."));
 
                     /* Have some nightmares */
-                    sanity_blast(creature_ptr, NULL, false);
+                    sanity_blast(creature_ptr, nullptr, false);
                 }
                 if (set_paralyzed(creature_ptr, creature_ptr->paralyzed + randint0(4) + 4)) {
                     ident = true;
@@ -470,7 +470,7 @@ void exe_quaff_potion(player_type *creature_ptr, INVENTORY_IDX item)
             msg_print(_("更なる啓蒙を感じた...", "You begin to feel more enlightened..."));
             chg_virtue(creature_ptr, V_KNOWLEDGE, 1);
             chg_virtue(creature_ptr, V_ENLIGHTEN, 2);
-            msg_print(NULL);
+            msg_print(nullptr);
             wiz_lite(creature_ptr, false);
             (void)do_inc_stat(creature_ptr, A_INT);
             (void)do_inc_stat(creature_ptr, A_WIS);
@@ -487,7 +487,7 @@ void exe_quaff_potion(player_type *creature_ptr, INVENTORY_IDX item)
 
         case SV_POTION_SELF_KNOWLEDGE:
             msg_print(_("自分自身のことが少しは分かった気がする...", "You begin to know yourself a little better..."));
-            msg_print(NULL);
+            msg_print(nullptr);
             self_knowledge(creature_ptr);
             ident = true;
             break;
@@ -541,7 +541,7 @@ void exe_quaff_potion(player_type *creature_ptr, INVENTORY_IDX item)
 
         case SV_POTION_TSUYOSHI:
             msg_print(_("「オクレ兄さん！」", "Brother OKURE!"));
-            msg_print(NULL);
+            msg_print(nullptr);
             creature_ptr->tsuyoshi = 1;
             (void)set_tsuyoshi(creature_ptr, 0, true);
             if (!has_resist_chaos(creature_ptr)) {

--- a/src/object-use/read-execution.cpp
+++ b/src/object-use/read-execution.cpp
@@ -440,9 +440,9 @@ void exe_read(player_type *creature_ptr, INVENTORY_IDX item, bool known)
         }
         case SV_SCROLL_RUMOR: {
             msg_print(_("巻物にはメッセージが書かれている:", "There is message on the scroll. It says:"));
-            msg_print(NULL);
+            msg_print(nullptr);
             display_rumor(creature_ptr, true);
-            msg_print(NULL);
+            msg_print(nullptr);
             msg_print(_("巻物は煙を立てて消え去った！", "The scroll disappears in a puff of smoke!"));
             ident = true;
             break;
@@ -478,11 +478,11 @@ void exe_read(player_type *creature_ptr, INVENTORY_IDX item, bool known)
         used_up = false;
     } else if (o_ptr->name1 == ART_POWER) {
         msg_print(_("「一つの指輪は全てを統べ、", "'One Ring to rule them all, "));
-        msg_print(NULL);
+        msg_print(nullptr);
         msg_print(_("一つの指輪は全てを見つけ、", "One Ring to find them, "));
-        msg_print(NULL);
+        msg_print(nullptr);
         msg_print(_("一つの指輪は全てを捕らえて", "One Ring to bring them all "));
-        msg_print(NULL);
+        msg_print(nullptr);
         msg_print(_("暗闇の中に繋ぎとめる。」", "and in the darkness bind them.'"));
         used_up = false;
     } else if (o_ptr->tval == TV_PARCHMENT) {

--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -88,7 +88,7 @@ bool ObjectThrowEntity::check_can_throw()
 
     if (this->creature_ptr->current_floor_ptr->inside_arena && !this->boomerang && (this->o_ptr->tval != TV_SPIKE)) {
         msg_print(_("アリーナではアイテムを使えない！", "You're in the arena now. This is hand-to-hand!"));
-        msg_print(NULL);
+        msg_print(nullptr);
         return false;
     }
 

--- a/src/object/object-info.cpp
+++ b/src/object/object-info.cpp
@@ -162,7 +162,7 @@ static concptr item_activation_aux(object_type *o_ptr)
 
 /*!
  * @brief オブジェクトの発動効果名称を返す（メインルーチン） /
- * Determine the "Activation" (if any) for an artifact Return a string, or NULL for "no activation"
+ * Determine the "Activation" (if any) for an artifact Return a string, or nullptr for "no activation"
  * @param o_ptr 名称を取得する元のオブジェクト構造体参照ポインタ
  * @return concptr 発動名称を返す文字列ポインタ
  */

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -53,7 +53,7 @@ object_type *choose_warning_item(player_type *creature_ptr)
 
     /* Paranoia -- Player has no warning ability */
     if (!creature_ptr->warning)
-        return NULL;
+        return nullptr;
 
     /* Search Inventory */
     int number = 0;
@@ -68,7 +68,7 @@ object_type *choose_warning_item(player_type *creature_ptr)
     }
 
     /* Choice one of them */
-    return number ? &creature_ptr->inventory_list[choices[randint0(number)]] : NULL;
+    return number ? &creature_ptr->inventory_list[choices[randint0(number)]] : nullptr;
 }
 
 /*!
@@ -494,7 +494,7 @@ bool process_warning(player_type *creature_ptr, POSITION xx, POSITION yy)
         return true;
 
     object_type *o_ptr = choose_warning_item(creature_ptr);
-    if (o_ptr != NULL)
+    if (o_ptr != nullptr)
         describe_flavor(creature_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     else
         strcpy(o_name, _("体", "body")); /* Warning ability without item */

--- a/src/perception/simple-perception.cpp
+++ b/src/perception/simple-perception.cpp
@@ -398,7 +398,7 @@ void sense_inventory2(player_type *creature_ptr)
 }
 
 /*!
- * @brief 重度擬似鑑定の判断処理 / Return a "feeling" (or NULL) about an item.  Method 1 (Heavy).
+ * @brief 重度擬似鑑定の判断処理 / Return a "feeling" (or nullptr) about an item.  Method 1 (Heavy).
  * @param o_ptr 擬似鑑定を行うオブジェクトの参照ポインタ。
  * @return 擬似鑑定結果のIDを返す。
  */
@@ -433,7 +433,7 @@ item_feel_type pseudo_value_check_heavy(object_type *o_ptr)
 }
 
 /*!
- * @brief 軽度擬似鑑定の判断処理 / Return a "feeling" (or NULL) about an item.  Method 2 (Light).
+ * @brief 軽度擬似鑑定の判断処理 / Return a "feeling" (or nullptr) about an item.  Method 2 (Light).
  * @param o_ptr 擬似鑑定を行うオブジェクトの参照ポインタ。
  * @return 擬似鑑定結果のIDを返す。
  */

--- a/src/player-attack/attack-chaos-effect.cpp
+++ b/src/player-attack/attack-chaos-effect.cpp
@@ -153,11 +153,11 @@ static void attack_dispel(player_type *attacker_ptr, player_attack_type *pa_ptr)
 static void attack_probe(player_type *attacker_ptr, player_attack_type *pa_ptr)
 {
     msg_print(_("刃が敵を調査した...", "The blade probed your enemy..."));
-    msg_print(NULL);
+    msg_print(nullptr);
     char buf[256];
     probed_monster_info(buf, attacker_ptr, pa_ptr->m_ptr, pa_ptr->r_ptr);
     msg_print(buf);
-    msg_print(NULL);
+    msg_print(nullptr);
     (void)lore_do_probe(attacker_ptr, pa_ptr->r_idx);
 }
 

--- a/src/player-attack/player-attack.cpp
+++ b/src/player-attack/player-attack.cpp
@@ -437,7 +437,7 @@ static void apply_damage_negative_effect(player_attack_type *pa_ptr, bool is_zan
 static bool check_fear_death(player_type *attacker_ptr, player_attack_type *pa_ptr, const int num, const bool is_lowlevel)
 {
     MonsterDamageProcessor mdp(attacker_ptr, pa_ptr->m_idx, pa_ptr->attack_damage, pa_ptr->fear);
-    if (!mdp.mon_take_hit(NULL))
+    if (!mdp.mon_take_hit(nullptr))
         return false;
 
     *(pa_ptr->mdeath) = true;

--- a/src/player/eldritch-horror.cpp
+++ b/src/player/eldritch-horror.cpp
@@ -81,7 +81,7 @@ static void feel_eldritch_horror(concptr desc, monster_race *r_ptr)
 
 /*!
  * @brief ELDRITCH_HORRORによるプレイヤーの精神破壊処理
- * @param m_ptr ELDRITCH_HORRORを引き起こしたモンスターの参照ポインタ。薬・罠・魔法の影響ならNULL
+ * @param m_ptr ELDRITCH_HORRORを引き起こしたモンスターの参照ポインタ。薬・罠・魔法の影響ならnullptr
  * @param necro 暗黒領域魔法の詠唱失敗によるものならばTRUEを返す
  */
 void sanity_blast(player_type *creature_ptr, monster_type *m_ptr, bool necro)
@@ -145,11 +145,11 @@ void sanity_blast(player_type *creature_ptr, monster_type *m_ptr, bool necro)
         monster_race *r_ptr;
         GAME_TEXT m_name[MAX_NLEN];
         concptr desc;
-        get_mon_num_prep(creature_ptr, get_nightmare, NULL);
+        get_mon_num_prep(creature_ptr, get_nightmare, nullptr);
         r_ptr = &r_info[get_mon_num(creature_ptr, 0, MAX_DEPTH, 0)];
         power = r_ptr->level + 10;
         desc = r_ptr->name.c_str();
-        get_mon_num_prep(creature_ptr, NULL, NULL);
+        get_mon_num_prep(creature_ptr, nullptr, nullptr);
 #ifdef JP
 #else
 

--- a/src/player/patron.cpp
+++ b/src/player/patron.cpp
@@ -155,7 +155,7 @@ void gain_level_reward(player_type *creature_ptr, int chosen_reward)
     char wrath_reason[32] = "";
     int nasty_chance = 6;
     int type, effect;
-    concptr reward = NULL;
+    concptr reward = nullptr;
     GAME_TEXT o_name[MAX_NLEN];
 
     int count = 0;

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -80,7 +80,7 @@
  */
 static bool acid_minus_ac(player_type *creature_ptr)
 {
-    object_type *o_ptr = NULL;
+    object_type *o_ptr = nullptr;
     switch (randint1(7)) {
     case 1:
         o_ptr = &creature_ptr->inventory_list[INVEN_MAIN_HAND];
@@ -105,7 +105,7 @@ static bool acid_minus_ac(player_type *creature_ptr)
         break;
     }
 
-    if ((o_ptr == NULL) || (o_ptr->k_idx == 0) || !o_ptr->is_armour())
+    if ((o_ptr == nullptr) || (o_ptr->k_idx == 0) || !o_ptr->is_armour())
         return false;
 
     GAME_TEXT o_name[MAX_NLEN];
@@ -361,7 +361,7 @@ int take_hit(player_type *creature_ptr, int damage_type, HIT_POINT damage, concp
         if (creature_ptr->current_floor_ptr->inside_arena) {
             concptr m_name = r_info[arena_info[creature_ptr->arena_number].r_idx].name.c_str();
             msg_format(_("あなたは%sの前に敗れ去った。", "You are beaten by %s."), m_name);
-            msg_print(NULL);
+            msg_print(nullptr);
             if (record_arena)
                 exe_write_diary(creature_ptr, DIARY_ARENA, -1 - creature_ptr->arena_number, m_name);
         } else {
@@ -424,7 +424,7 @@ int take_hit(player_type *creature_ptr, int damage_type, HIT_POINT damage, concp
             if (creature_ptr->last_message)
                 string_free(creature_ptr->last_message);
 
-            creature_ptr->last_message = NULL;
+            creature_ptr->last_message = nullptr;
             if (!last_words) {
 #ifdef JP
                 msg_format("あなたは%sました。", android ? "壊れ" : "死に");
@@ -432,7 +432,7 @@ int take_hit(player_type *creature_ptr, int damage_type, HIT_POINT damage, concp
                 msg_print(android ? "You are broken." : "You die.");
 #endif
 
-                msg_print(NULL);
+                msg_print(nullptr);
             } else {
                 if (winning_seppuku) {
                     get_rnd_line(_("seppuku_j.txt", "seppuku.txt"), 0, death_message);
@@ -480,20 +480,20 @@ int take_hit(player_type *creature_ptr, int damage_type, HIT_POINT damage, concp
                         str += 2;
 
                     str2 = angband_strstr(str, "」");
-                    if (str2 != NULL)
+                    if (str2 != nullptr)
                         *str2 = '\0';
 
                     i = 0;
                     while (i < 9) {
                         str2 = angband_strstr(str, " ");
-                        if (str2 == NULL)
+                        if (str2 == nullptr)
                             len = strlen(str);
                         else
                             len = str2 - str;
 
                         if (len != 0) {
                             term_putstr_v(w * 3 / 4 - 2 - msg_pos_x[i] * 2, msg_pos_y[i], len, TERM_WHITE, str);
-                            if (str2 == NULL)
+                            if (str2 == nullptr)
                                 break;
                             i++;
                         }
@@ -535,7 +535,7 @@ int take_hit(player_type *creature_ptr, int damage_type, HIT_POINT damage, concp
             creature_ptr->now_damaged = true;
 
         msg_print(_("*** 警告:低ヒット・ポイント！ ***", "*** LOW HITPOINT WARNING! ***"));
-        msg_print(NULL);
+        msg_print(nullptr);
         flush();
     }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -2720,7 +2720,7 @@ void check_experience(player_type *creature_ptr)
             }
             level_inc_stat = true;
 
-            exe_write_diary(creature_ptr, DIARY_LEVELUP, creature_ptr->lev, NULL);
+            exe_write_diary(creature_ptr, DIARY_LEVELUP, creature_ptr->lev, nullptr);
         }
 
         sound(SOUND_LEVEL);

--- a/src/player/process-death.cpp
+++ b/src/player/process-death.cpp
@@ -370,7 +370,7 @@ static void export_player_info(player_type *creature_ptr, display_player_pf disp
  */
 static void file_character_auto(player_type *creature_ptr, display_player_pf display_player)
 {
-    time_t now_t = time(NULL);
+    time_t now_t = time(nullptr);
     struct tm *now_tm = localtime(&now_t);
 
     char datetime[32];

--- a/src/realm/realm-arcane.cpp
+++ b/src/realm/realm-arcane.cpp
@@ -30,7 +30,7 @@
  * @param caster_ptr プレーヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SPELL_NAME / SPELL_DESC / SPELL_INFO / SPELL_CAST)
- * @return SPELL_NAME / SPELL_DESC / SPELL_INFO 時には文字列ポインタを返す。SPELL_CAST時はNULL文字列を返す。
+ * @return SPELL_NAME / SPELL_DESC / SPELL_INFO 時には文字列ポインタを返す。SPELL_CAST時はnullptr文字列を返す。
  */
 concptr do_arcane_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
 {
@@ -58,7 +58,7 @@ concptr do_arcane_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_bolt_or_beam(caster_ptr, beam_chance(caster_ptr) - 10, GF_ELEC, dir, damroll(dice, sides));
             }
@@ -74,7 +74,7 @@ concptr do_arcane_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
         {
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 wizard_lock(caster_ptr, dir);
             }
@@ -164,7 +164,7 @@ concptr do_arcane_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
         {
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 destroy_door(caster_ptr, dir);
             }
@@ -409,7 +409,7 @@ concptr do_arcane_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
         {
             if (cast) {
                 if (!ident_spell(caster_ptr, false))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;
@@ -430,7 +430,7 @@ concptr do_arcane_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 wall_to_mud(caster_ptr, dir, 20 + randint1(30));
             }
@@ -452,7 +452,7 @@ concptr do_arcane_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 msg_print(_("光線が放たれた。", "A line of light appears."));
                 lite_line(caster_ptr, dir, damroll(6, 8));
@@ -514,7 +514,7 @@ concptr do_arcane_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
         {
             if (cast) {
                 if (!get_check(_("本当に他の階にテレポートしますか？", "Are you sure? (Teleport Level)")))
-                    return NULL;
+                    return nullptr;
                 teleport_level(caster_ptr, 0);
             }
         }
@@ -534,7 +534,7 @@ concptr do_arcane_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_beam(caster_ptr, GF_AWAY_ALL, dir, power);
             }
@@ -558,7 +558,7 @@ concptr do_arcane_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
                 int type;
 
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 switch (randint1(4)) {
                 case 1:
@@ -615,7 +615,7 @@ concptr do_arcane_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
             if (cast) {
                 if (!recall_player(caster_ptr, randint0(21) + 15))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;

--- a/src/realm/realm-chaos.cpp
+++ b/src/realm/realm-chaos.cpp
@@ -30,7 +30,7 @@
  * @param caster_ptr プレーヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SPELL_NAME / SPELL_DESC / SPELL_INFO / SPELL_CAST)
- * @return SPELL_NAME / SPELL_DESC / SPELL_INFO 時には文字列ポインタを返す。SPELL_CAST時はNULL文字列を返す。
+ * @return SPELL_NAME / SPELL_DESC / SPELL_INFO 時には文字列ポインタを返す。SPELL_CAST時はnullptr文字列を返す。
  */
 concptr do_chaos_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
 {
@@ -58,7 +58,7 @@ concptr do_chaos_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_bolt_or_beam(caster_ptr, beam_chance(caster_ptr) - 10, GF_MISSILE, dir, damroll(dice, sides));
             }
@@ -142,7 +142,7 @@ concptr do_chaos_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_ball(caster_ptr, GF_MISSILE, dir, damroll(dice, sides) + base, rad);
 
@@ -170,7 +170,7 @@ concptr do_chaos_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_bolt_or_beam(caster_ptr, beam_chance(caster_ptr), GF_FIRE, dir, damroll(dice, sides));
             }
@@ -192,7 +192,7 @@ concptr do_chaos_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_ball(caster_ptr, GF_DISINTEGRATE, dir, damroll(dice, sides), 0);
             }
@@ -230,7 +230,7 @@ concptr do_chaos_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
             if (cast) {
 
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 cast_wonder(caster_ptr, dir);
             }
@@ -252,7 +252,7 @@ concptr do_chaos_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_bolt_or_beam(caster_ptr, beam_chance(caster_ptr), GF_CHAOS, dir, damroll(dice, sides));
             }
@@ -294,7 +294,7 @@ concptr do_chaos_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_beam(caster_ptr, GF_MANA, dir, damroll(dice, sides));
             }
@@ -316,7 +316,7 @@ concptr do_chaos_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_ball(caster_ptr, GF_FIRE, dir, dam, rad);
             }
@@ -337,7 +337,7 @@ concptr do_chaos_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_beam(caster_ptr, GF_AWAY_ALL, dir, power);
             }
@@ -375,7 +375,7 @@ concptr do_chaos_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_ball(caster_ptr, GF_CHAOS, dir, dam, rad);
             }
@@ -396,7 +396,7 @@ concptr do_chaos_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 poly_monster(caster_ptr, dir, plev);
             }
@@ -436,7 +436,7 @@ concptr do_chaos_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
                 return info_power(power);
             if (cast) {
                 if (!recharge(caster_ptr, power))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;
@@ -456,7 +456,7 @@ concptr do_chaos_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_ball(caster_ptr, GF_DISINTEGRATE, dir, dam, rad);
             }
@@ -497,7 +497,7 @@ concptr do_chaos_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 msg_print(_("ロケット発射！", "You launch a rocket!"));
                 fire_rocket(caster_ptr, GF_ROCKET, dir, dam, rad);
@@ -546,7 +546,7 @@ concptr do_chaos_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
                 fire_beam(caster_ptr, GF_GRAVITY, dir, damroll(dice, sides));
             }
         }
@@ -615,7 +615,7 @@ concptr do_chaos_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
         {
             if (cast) {
                 if (!get_check(_("変身します。よろしいですか？", "You will polymorph yourself. Are you sure? ")))
-                    return NULL;
+                    return nullptr;
                 do_poly_self(caster_ptr);
             }
         }
@@ -636,7 +636,7 @@ concptr do_chaos_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
                 fire_ball(caster_ptr, GF_MANA, dir, dam, rad);
             }
         }
@@ -657,7 +657,7 @@ concptr do_chaos_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_ball(caster_ptr, GF_CHAOS, dir, dam, rad);
             }

--- a/src/realm/realm-craft.cpp
+++ b/src/realm/realm-craft.cpp
@@ -24,7 +24,7 @@
  * @brief 匠領域魔法の各処理を行う
  * @param spell 魔法ID
  * @param mode 処理内容 (SPELL_NAME / SPELL_DESC / SPELL_INFO / SPELL_CAST)
- * @return SPELL_NAME / SPELL_DESC / SPELL_INFO 時には文字列ポインタを返す。SPELL_CAST時はNULL文字列を返す。
+ * @return SPELL_NAME / SPELL_DESC / SPELL_INFO 時には文字列ポインタを返す。SPELL_CAST時はnullptr文字列を返す。
  */
 concptr do_craft_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
 {
@@ -308,7 +308,7 @@ concptr do_craft_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!choose_ele_attack(caster_ptr))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;
@@ -470,7 +470,7 @@ concptr do_craft_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
         {
             if (cast) {
                 if (!mundane_spell(caster_ptr, true))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;
@@ -496,7 +496,7 @@ concptr do_craft_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
         {
             if (cast) {
                 if (!identify_fully(caster_ptr, false))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;
@@ -510,7 +510,7 @@ concptr do_craft_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
         {
             if (cast) {
                 if (!enchant_spell(caster_ptr, randint0(4) + 1, randint0(4) + 1, 0))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;
@@ -524,7 +524,7 @@ concptr do_craft_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
         {
             if (cast) {
                 if (!enchant_spell(caster_ptr, 0, 0, randint0(3) + 2))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;
@@ -566,7 +566,7 @@ concptr do_craft_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!choose_ele_immune(caster_ptr, base + randint1(base)))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;

--- a/src/realm/realm-crusade.cpp
+++ b/src/realm/realm-crusade.cpp
@@ -36,7 +36,7 @@
  * @param caster_ptr プレーヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SPELL_NAME / SPELL_DESC / SPELL_INFO / SPELL_CAST)
- * @return SPELL_NAME / SPELL_DESC / SPELL_INFO 時には文字列ポインタを返す。SPELL_CAST時はNULL文字列を返す。
+ * @return SPELL_NAME / SPELL_DESC / SPELL_INFO 時には文字列ポインタを返す。SPELL_CAST時はnullptr文字列を返す。
  */
 concptr do_crusade_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
 {
@@ -61,7 +61,7 @@ concptr do_crusade_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
                 return info_damage(dice, sides, 0);
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
                 fire_bolt_or_beam(caster_ptr, beam_chance(caster_ptr) - 10, GF_ELEC, dir, damroll(dice, sides));
             }
         }
@@ -105,7 +105,7 @@ concptr do_crusade_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
                 return info_power(power);
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
                 fear_monster(caster_ptr, dir, power);
             }
         }
@@ -153,7 +153,7 @@ concptr do_crusade_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
                 return info_multi_damage_dice(dice, sides);
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
                 fire_blast(caster_ptr, GF_LITE, dir, dice, sides, 10, 3);
             }
         }
@@ -185,7 +185,7 @@ concptr do_crusade_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
                 return info_power(power);
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
                 fire_ball(caster_ptr, GF_AWAY_EVIL, dir, power, 0);
             }
         }
@@ -213,7 +213,7 @@ concptr do_crusade_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_ball(caster_ptr, GF_HOLY_FIRE, dir, damroll(dice, sides) + base, rad);
             }
@@ -301,7 +301,7 @@ concptr do_crusade_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
                 fire_bolt(caster_ptr, GF_ELEC, dir, dam);
             }
         }
@@ -340,7 +340,7 @@ concptr do_crusade_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
         {
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 destroy_door(caster_ptr, dir);
             }
@@ -361,7 +361,7 @@ concptr do_crusade_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
                 stasis_evil(caster_ptr, dir);
             }
         }
@@ -451,7 +451,7 @@ concptr do_crusade_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_ball(caster_ptr, GF_LITE, dir, dam, rad);
             }
@@ -587,7 +587,7 @@ concptr do_crusade_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
 
             if (cast) {
                 if (!cast_wrath_of_the_god(caster_ptr, dam, rad))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;

--- a/src/realm/realm-death.cpp
+++ b/src/realm/realm-death.cpp
@@ -33,7 +33,7 @@
  * @param caster_ptr プレーヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SPELL_NAME / SPELL_DESC / SPELL_INFO / SPELL_CAST)
- * @return SPELL_NAME / SPELL_DESC / SPELL_INFO 時には文字列ポインタを返す。SPELL_CAST時はNULL文字列を返す。
+ * @return SPELL_NAME / SPELL_DESC / SPELL_INFO 時には文字列ポインタを返す。SPELL_CAST時はnullptr文字列を返す。
  */
 concptr do_death_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
 {
@@ -81,7 +81,7 @@ concptr do_death_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 /*
                  * A radius-0 ball may (1) be aimed at
@@ -143,7 +143,7 @@ concptr do_death_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_ball(caster_ptr, GF_POIS, dir, dam, rad);
             }
@@ -164,7 +164,7 @@ concptr do_death_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 sleep_monster(caster_ptr, dir, plev);
             }
@@ -204,7 +204,7 @@ concptr do_death_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fear_monster(caster_ptr, dir, plev);
                 stun_monster(caster_ptr, dir, plev);
@@ -226,7 +226,7 @@ concptr do_death_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 control_one_undead(caster_ptr, dir, plev);
             }
@@ -255,7 +255,7 @@ concptr do_death_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_ball(caster_ptr, GF_HYPODYNAMIA, dir, damroll(dice, sides) + base, rad);
             }
@@ -277,7 +277,7 @@ concptr do_death_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_bolt_or_beam(caster_ptr, beam_chance(caster_ptr), GF_NETHER, dir, damroll(dice, sides));
             }
@@ -317,7 +317,7 @@ concptr do_death_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_ball_hide(caster_ptr, GF_GENOCIDE, dir, power, 0);
             }
@@ -356,7 +356,7 @@ concptr do_death_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
                 HIT_POINT dam = base + damroll(dice, sides);
 
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 if (hypodynamic_bolt(caster_ptr, dir, dam)) {
                     chg_virtue(caster_ptr, V_SACRIFICE, -1);
@@ -447,7 +447,7 @@ concptr do_death_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 cast_invoke_spirits(caster_ptr, dir);
             }
@@ -469,7 +469,7 @@ concptr do_death_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_bolt_or_beam(caster_ptr, beam_chance(caster_ptr), GF_DARK, dir, damroll(dice, sides));
             }
@@ -526,7 +526,7 @@ concptr do_death_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
                 int i;
 
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 chg_virtue(caster_ptr, V_SACRIFICE, -1);
                 chg_virtue(caster_ptr, V_VITALITY, -1);
@@ -572,7 +572,7 @@ concptr do_death_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_ball(caster_ptr, GF_DARK, dir, dam, rad);
             }
@@ -588,7 +588,7 @@ concptr do_death_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
         {
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 death_ray(caster_ptr, dir, plev);
             }
@@ -614,10 +614,10 @@ concptr do_death_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
             if (cast) {
                 if (randint1(50) > plev) {
                     if (!ident_spell(caster_ptr, false))
-                        return NULL;
+                        return nullptr;
                 } else {
                     if (!identify_fully(caster_ptr, false))
-                        return NULL;
+                        return nullptr;
                 }
             }
         }
@@ -690,7 +690,7 @@ concptr do_death_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_ball(caster_ptr, GF_HELL_FIRE, dir, dam, rad);
                 take_hit(caster_ptr, DAMAGE_USELIFE, 20 + randint1(30), _("地獄の劫火の呪文を唱えた疲労", "the strain of casting Hellfire"));

--- a/src/realm/realm-demon.cpp
+++ b/src/realm/realm-demon.cpp
@@ -33,7 +33,7 @@
  * @param caster_ptr プレーヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SPELL_NAME / SPELL_DESC / SPELL_INFO / SPELL_CAST)
- * @return SPELL_NAME / SPELL_DESC / SPELL_INFO 時には文字列ポインタを返す。SPELL_CAST時はNULL文字列を返す。
+ * @return SPELL_NAME / SPELL_DESC / SPELL_INFO 時には文字列ポインタを返す。SPELL_CAST時はnullptr文字列を返す。
  */
 concptr do_daemon_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
 {
@@ -61,7 +61,7 @@ concptr do_daemon_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_bolt_or_beam(caster_ptr, beam_chance(caster_ptr) - 10, GF_MISSILE, dir, damroll(dice, sides));
             }
@@ -138,7 +138,7 @@ concptr do_daemon_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fear_monster(caster_ptr, dir, power);
                 stun_monster(caster_ptr, dir, power);
@@ -161,7 +161,7 @@ concptr do_daemon_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_bolt_or_beam(caster_ptr, beam_chance(caster_ptr), GF_NETHER, dir, damroll(dice, sides));
             }
@@ -205,7 +205,7 @@ concptr do_daemon_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_ball(caster_ptr, GF_HELL_FIRE, dir, damroll(dice, sides) + base, rad);
             }
@@ -226,7 +226,7 @@ concptr do_daemon_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 control_one_demon(caster_ptr, dir, plev);
             }
@@ -284,7 +284,7 @@ concptr do_daemon_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_bolt_or_beam(caster_ptr, beam_chance(caster_ptr), GF_PLASMA, dir, damroll(dice, sides));
             }
@@ -306,7 +306,7 @@ concptr do_daemon_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_ball(caster_ptr, GF_FIRE, dir, dam, rad);
             }
@@ -341,7 +341,7 @@ concptr do_daemon_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_ball(caster_ptr, GF_NETHER, dir, dam, rad);
             }
@@ -441,7 +441,7 @@ concptr do_daemon_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_ball(caster_ptr, GF_PLASMA, dir, dam, rad);
             }
@@ -503,7 +503,7 @@ concptr do_daemon_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
                 fire_ball(caster_ptr, GF_NEXUS, dir, dam, rad);
             }
         }
@@ -518,7 +518,7 @@ concptr do_daemon_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
         {
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
                 else
                     msg_print(_("<破滅の手>を放った！", "You invoke the Hand of Doom!"));
 
@@ -606,7 +606,7 @@ concptr do_daemon_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
         {
             if (cast) {
                 if (!cast_summon_greater_demon(caster_ptr))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;
@@ -626,7 +626,7 @@ concptr do_daemon_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_ball(caster_ptr, GF_NETHER, dir, dam, rad);
             }
@@ -649,7 +649,7 @@ concptr do_daemon_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_ball_hide(caster_ptr, GF_BLOOD_CURSE, dir, dam, rad);
                 take_hit(caster_ptr, DAMAGE_USELIFE, 20 + randint1(30), _("血の呪い", "Blood curse"));

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -98,7 +98,7 @@ static bool item_tester_hook_weapon_except_bow(player_type *player_ptr, const ob
  * @brief 呪術領域魔法の各処理を行う
  * @param spell 魔法ID
  * @param mode 処理内容 (SPELL_NAME / SPELL_DESC / SPELL_INFO / SPELL_CAST / SPELL_CONT / SPELL_STOP)
- * @return SPELL_NAME / SPELL_DESC / SPELL_INFO 時には文字列ポインタを返す。SPELL_CAST / SPELL_CONT / SPELL_STOP 時はNULL文字列を返す。
+ * @return SPELL_NAME / SPELL_DESC / SPELL_INFO 時には文字列ポインタを返す。SPELL_CAST / SPELL_CONT / SPELL_STOP 時はnullptr文字列を返す。
  */
 concptr do_hex_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
 {
@@ -284,7 +284,7 @@ concptr do_hex_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
 
             if (hex_revenge_turn(caster_ptr) > 0) {
                 msg_print(_("すでに我慢をしている。", "You are already biding your time for vengeance."));
-                return NULL;
+                return nullptr;
             }
 
             hex_revenge_type(caster_ptr) = 1;
@@ -470,7 +470,7 @@ concptr do_hex_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
             return info_power(power);
         if (cast) {
             if (!recharge(caster_ptr, power))
-                return NULL;
+                return nullptr;
             add = false;
         }
         break;
@@ -574,10 +574,10 @@ concptr do_hex_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
 
             if (!o_ptr->k_idx) {
                 msg_print(_("クロークを身につけていない！", "You are not wearing a cloak."));
-                return NULL;
+                return nullptr;
             } else if (!o_ptr->is_cursed()) {
                 msg_print(_("クロークは呪われていない！", "Your cloak is not cursed."));
-                return NULL;
+                return nullptr;
             } else {
                 msg_print(_("影のオーラを身にまとった。", "You are enveloped by a shadowy aura!"));
             }
@@ -839,7 +839,7 @@ concptr do_hex_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
 
             if (hex_revenge_turn(caster_ptr) > 0) {
                 msg_print(_("すでに復讐は宣告済みだ。", "You've already declared your revenge."));
-                return NULL;
+                return nullptr;
             }
 
             hex_revenge_type(caster_ptr) = 2;

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -61,7 +61,7 @@
  * @param caster_ptr プレーヤーへの参照ポインタ
  * @param spell 剣術ID
  * @param mode 処理内容 (SPELL_NAME / SPELL_DESC / SPELL_CAST)
- * @return SPELL_NAME / SPELL_DESC 時には文字列ポインタを返す。SPELL_CAST時はNULL文字列を返す。
+ * @return SPELL_NAME / SPELL_DESC 時には文字列ポインタを返す。SPELL_CAST時はnullptr文字列を返す。
  */
 concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
 {
@@ -82,7 +82,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
         if (cast) {
             project_length = 2;
             if (!get_aim_dir(caster_ptr, &dir))
-                return NULL;
+                return nullptr;
 
             project_hook(caster_ptr, GF_ATTACK, dir, HISSATSU_2, PROJECT_STOP | PROJECT_KILL);
         }
@@ -99,9 +99,9 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
             POSITION y, x;
 
             if (!get_direction(caster_ptr, &dir, false, false))
-                return NULL;
+                return nullptr;
             if (dir == 5)
-                return NULL;
+                return nullptr;
 
             for (cdir = 0; cdir < 8; cdir++) {
                 if (cdd[cdir] == dir)
@@ -109,7 +109,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
             }
 
             if (cdir == 8)
-                return NULL;
+                return nullptr;
 
             y = caster_ptr->y + ddy_cdd[cdir];
             x = caster_ptr->x + ddx_cdd[cdir];
@@ -143,7 +143,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
 
         if (cast) {
             if (!ThrowCommand(caster_ptr).do_cmd_throw(1, true, -1))
-                return NULL;
+                return nullptr;
         }
         break;
 
@@ -157,9 +157,9 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
             POSITION y, x;
 
             if (!get_direction(caster_ptr, &dir, false, false))
-                return NULL;
+                return nullptr;
             if (dir == 5)
-                return NULL;
+                return nullptr;
 
             y = caster_ptr->y + ddy[dir];
             x = caster_ptr->x + ddx[dir];
@@ -168,7 +168,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
                 do_cmd_attack(caster_ptr, y, x, HISSATSU_FIRE);
             else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return NULL;
+                return nullptr;
             }
         }
         break;
@@ -194,9 +194,9 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
             POSITION y, x;
 
             if (!get_direction(caster_ptr, &dir, false, false))
-                return NULL;
+                return nullptr;
             if (dir == 5)
-                return NULL;
+                return nullptr;
 
             y = caster_ptr->y + ddy[dir];
             x = caster_ptr->x + ddx[dir];
@@ -205,7 +205,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
                 do_cmd_attack(caster_ptr, y, x, HISSATSU_MINEUCHI);
             else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return NULL;
+                return nullptr;
             }
         }
         break;
@@ -220,7 +220,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
         if (cast) {
             if (caster_ptr->riding) {
                 msg_print(_("乗馬中には無理だ。", "You cannot do it when riding."));
-                return NULL;
+                return nullptr;
             }
             msg_print(_("相手の攻撃に対して身構えた。", "You prepare to counterattack."));
             caster_ptr->counter = true;
@@ -239,20 +239,20 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
 
             if (caster_ptr->riding) {
                 msg_print(_("乗馬中には無理だ。", "You cannot do it when riding."));
-                return NULL;
+                return nullptr;
             }
 
             if (!get_direction(caster_ptr, &dir, false, false))
-                return NULL;
+                return nullptr;
 
             if (dir == 5)
-                return NULL;
+                return nullptr;
             y = caster_ptr->y + ddy[dir];
             x = caster_ptr->x + ddx[dir];
 
             if (!caster_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return NULL;
+                return nullptr;
             }
 
             do_cmd_attack(caster_ptr, y, x, HISSATSU_NONE);
@@ -266,7 +266,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
 
             if (player_can_enter(caster_ptr, caster_ptr->current_floor_ptr->grid_array[y][x].feat, 0)
                 && !is_trap(caster_ptr, caster_ptr->current_floor_ptr->grid_array[y][x].feat) && !caster_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
-                msg_print(NULL);
+                msg_print(nullptr);
                 (void)move_player_effect(caster_ptr, y, x, MPE_FORGET_FLOW | MPE_HANDLE_STUFF | MPE_DONT_PICKUP);
             }
         }
@@ -282,9 +282,9 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
             POSITION y, x;
 
             if (!get_direction(caster_ptr, &dir, false, false))
-                return NULL;
+                return nullptr;
             if (dir == 5)
-                return NULL;
+                return nullptr;
 
             y = caster_ptr->y + ddy[dir];
             x = caster_ptr->x + ddx[dir];
@@ -293,7 +293,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
                 do_cmd_attack(caster_ptr, y, x, HISSATSU_POISON);
             else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return NULL;
+                return nullptr;
             }
         }
         break;
@@ -309,9 +309,9 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
             POSITION y, x;
 
             if (!get_direction(caster_ptr, &dir, false, false))
-                return NULL;
+                return nullptr;
             if (dir == 5)
-                return NULL;
+                return nullptr;
 
             y = caster_ptr->y + ddy[dir];
             x = caster_ptr->x + ddx[dir];
@@ -320,7 +320,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
                 do_cmd_attack(caster_ptr, y, x, HISSATSU_ZANMA);
             else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return NULL;
+                return nullptr;
             }
         }
         break;
@@ -335,9 +335,9 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
             POSITION y, x;
 
             if (!get_direction(caster_ptr, &dir, false, false))
-                return NULL;
+                return nullptr;
             if (dir == 5)
-                return NULL;
+                return nullptr;
 
             y = caster_ptr->y + ddy[dir];
             x = caster_ptr->x + ddx[dir];
@@ -346,7 +346,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
                 do_cmd_attack(caster_ptr, y, x, HISSATSU_NONE);
             else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return NULL;
+                return nullptr;
             }
             if (d_info[caster_ptr->dungeon_idx].flags.has(DF::NO_MELEE)) {
                 return "";
@@ -398,10 +398,10 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
         if (cast) {
             if (plev > 44) {
                 if (!identify_fully(caster_ptr, true))
-                    return NULL;
+                    return nullptr;
             } else {
                 if (!ident_spell(caster_ptr, true))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;
@@ -416,9 +416,9 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
             POSITION y, x;
 
             if (!get_direction(caster_ptr, &dir, false, false))
-                return NULL;
+                return nullptr;
             if (dir == 5)
-                return NULL;
+                return nullptr;
 
             y = caster_ptr->y + ddy[dir];
             x = caster_ptr->x + ddx[dir];
@@ -446,9 +446,9 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
             POSITION y, x;
 
             if (!get_direction(caster_ptr, &dir, false, false))
-                return NULL;
+                return nullptr;
             if (dir == 5)
-                return NULL;
+                return nullptr;
 
             y = caster_ptr->y + ddy[dir];
             x = caster_ptr->x + ddx[dir];
@@ -457,7 +457,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
                 do_cmd_attack(caster_ptr, y, x, HISSATSU_COLD);
             else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return NULL;
+                return nullptr;
             }
         }
         break;
@@ -473,9 +473,9 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
             POSITION y, x;
 
             if (!get_direction(caster_ptr, &dir, false, false))
-                return NULL;
+                return nullptr;
             if (dir == 5)
-                return NULL;
+                return nullptr;
 
             y = caster_ptr->y + ddy[dir];
             x = caster_ptr->x + ddx[dir];
@@ -484,7 +484,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
                 do_cmd_attack(caster_ptr, y, x, HISSATSU_KYUSHO);
             else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return NULL;
+                return nullptr;
             }
         }
         break;
@@ -499,9 +499,9 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
             POSITION y, x;
 
             if (!get_direction(caster_ptr, &dir, false, false))
-                return NULL;
+                return nullptr;
             if (dir == 5)
-                return NULL;
+                return nullptr;
 
             y = caster_ptr->y + ddy[dir];
             x = caster_ptr->x + ddx[dir];
@@ -510,7 +510,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
                 do_cmd_attack(caster_ptr, y, x, HISSATSU_MAJIN);
             else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return NULL;
+                return nullptr;
             }
         }
         break;
@@ -526,9 +526,9 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
             POSITION y, x;
 
             if (!get_direction(caster_ptr, &dir, false, false))
-                return NULL;
+                return nullptr;
             if (dir == 5)
-                return NULL;
+                return nullptr;
 
             y = caster_ptr->y + ddy[dir];
             x = caster_ptr->x + ddx[dir];
@@ -537,7 +537,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
                 do_cmd_attack(caster_ptr, y, x, HISSATSU_SUTEMI);
             else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return NULL;
+                return nullptr;
             }
             caster_ptr->sutemi = true;
         }
@@ -553,9 +553,9 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
             POSITION y, x;
 
             if (!get_direction(caster_ptr, &dir, false, false))
-                return NULL;
+                return nullptr;
             if (dir == 5)
-                return NULL;
+                return nullptr;
 
             y = caster_ptr->y + ddy[dir];
             x = caster_ptr->x + ddx[dir];
@@ -564,7 +564,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
                 do_cmd_attack(caster_ptr, y, x, HISSATSU_ELEC);
             else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return NULL;
+                return nullptr;
             }
         }
         break;
@@ -576,8 +576,8 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
             return _("素早く相手に近寄り攻撃する。", "Steps close to a monster and attacks at the same time.");
 
         if (cast) {
-            if (!rush_attack(caster_ptr, NULL))
-                return NULL;
+            if (!rush_attack(caster_ptr, nullptr))
+                return nullptr;
         }
         break;
 
@@ -629,9 +629,9 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
             POSITION y, x;
 
             if (!get_direction(caster_ptr, &dir, false, false))
-                return NULL;
+                return nullptr;
             if (dir == 5)
-                return NULL;
+                return nullptr;
 
             y = caster_ptr->y + ddy[dir];
             x = caster_ptr->x + ddx[dir];
@@ -653,7 +653,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
             int total_damage = 0, basedam, i;
             object_type *o_ptr;
             if (!get_aim_dir(caster_ptr, &dir))
-                return NULL;
+                return nullptr;
             msg_print(_("武器を大きく振り下ろした。", "You swing your weapon downward."));
             for (i = 0; i < 2; i++) {
                 int damage;
@@ -707,9 +707,9 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
             int i;
 
             if (!get_direction(caster_ptr, &dir, false, false))
-                return NULL;
+                return nullptr;
             if (dir == 5)
-                return NULL;
+                return nullptr;
 
             for (i = 0; i < 3; i++) {
                 POSITION y, x;
@@ -726,7 +726,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
                     do_cmd_attack(caster_ptr, y, x, HISSATSU_3DAN);
                 else {
                     msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                    return NULL;
+                    return nullptr;
                 }
 
                 if (d_info[caster_ptr->dungeon_idx].flags.has(DF::NO_MELEE)) {
@@ -746,7 +746,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
                 if (!monster_can_enter(caster_ptr, ny, nx, &r_info[m_ptr->r_idx], 0)) {
                     /* -more- */
                     if (i < 2)
-                        msg_print(NULL);
+                        msg_print(nullptr);
                     continue;
                 }
 
@@ -773,7 +773,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
 
                 /* -more- */
                 if (i < 2)
-                    msg_print(NULL);
+                    msg_print(nullptr);
             }
         }
         break;
@@ -789,9 +789,9 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
             POSITION y, x;
 
             if (!get_direction(caster_ptr, &dir, false, false))
-                return NULL;
+                return nullptr;
             if (dir == 5)
-                return NULL;
+                return nullptr;
 
             y = caster_ptr->y + ddy[dir];
             x = caster_ptr->x + ddx[dir];
@@ -800,7 +800,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
                 do_cmd_attack(caster_ptr, y, x, HISSATSU_DRAIN);
             else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return NULL;
+                return nullptr;
             }
         }
         break;
@@ -848,7 +848,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
             } while (caster_ptr->csp > mana_cost_per_monster);
 
             if (is_new)
-                return NULL;
+                return nullptr;
 
             /* Restore reserved mana */
             caster_ptr->csp += technic_info[REALM_HISSATSU - MIN_TECHNIC][26].smana;
@@ -866,7 +866,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
             POSITION y, x;
 
             if (!tgt_pt(caster_ptr, &x, &y))
-                return NULL;
+                return nullptr;
 
             if (!cave_player_teleportable_bold(caster_ptr, y, x, TELEPORT_SPONTANEOUS) || (distance(y, x, caster_ptr->y, caster_ptr->x) > MAX_SIGHT / 2)
                 || !projectable(caster_ptr, caster_ptr->y, caster_ptr->x, y, x)) {
@@ -892,7 +892,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
             POSITION x, y;
 
             if (!get_rep_dir(caster_ptr, &dir, false))
-                return NULL;
+                return nullptr;
 
             y = caster_ptr->y + ddy[dir];
             x = caster_ptr->x + ddx[dir];
@@ -905,7 +905,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
                 }
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "You don't see any monster in this direction"));
-                return NULL;
+                return nullptr;
             }
         }
         break;
@@ -922,9 +922,9 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
             object_type *o_ptr;
 
             if (!get_direction(caster_ptr, &dir, false, false))
-                return NULL;
+                return nullptr;
             if (dir == 5)
-                return NULL;
+                return nullptr;
 
             y = caster_ptr->y + ddy[dir];
             x = caster_ptr->x + ddx[dir];
@@ -972,9 +972,9 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
             POSITION y, x;
 
             if (!get_direction(caster_ptr, &dir, false, false))
-                return NULL;
+                return nullptr;
             if (dir == 5)
-                return NULL;
+                return nullptr;
 
             y = caster_ptr->y + ddy[dir];
             x = caster_ptr->x + ddx[dir];
@@ -983,7 +983,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
                 do_cmd_attack(caster_ptr, y, x, HISSATSU_UNDEAD);
             else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return NULL;
+                return nullptr;
             }
             take_hit(caster_ptr, DAMAGE_NOESCAPE, 100 + randint1(100), _("慶雲鬼忍剣を使った衝撃", "exhaustion on using Keiun-Kininken"));
         }
@@ -998,7 +998,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
         if (cast) {
             int i;
             if (!get_check(_("本当に自殺しますか？", "Do you really want to commit suicide? ")))
-                return NULL;
+                return nullptr;
             /* Special Verification for suicide */
             prt(_("確認のため '@' を押して下さい。", "Please verify SUICIDE by typing the '@' sign: "), 0, 0);
 
@@ -1006,7 +1006,7 @@ concptr do_hissatsu_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type m
             i = inkey();
             prt("", 0, 0);
             if (i != '@')
-                return NULL;
+                return nullptr;
             if (current_world_ptr->total_winner) {
                 take_hit(caster_ptr, DAMAGE_FORCE, 9999, "Seppuku");
                 current_world_ptr->total_winner = true;

--- a/src/realm/realm-life.cpp
+++ b/src/realm/realm-life.cpp
@@ -28,7 +28,7 @@
  * @param caster_ptr プレーヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SPELL_NAME / SPELL_DESC / SPELL_INFO / SPELL_CAST)
- * @return SPELL_NAME / SPELL_DESC / SPELL_INFO 時には文字列ポインタを返す。SPELL_CAST時はNULL文字列を返す。
+ * @return SPELL_NAME / SPELL_DESC / SPELL_INFO 時には文字列ポインタを返す。SPELL_CAST時はnullptr文字列を返す。
  */
 concptr do_life_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
 {
@@ -87,7 +87,7 @@ concptr do_life_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
                 fire_ball_hide(caster_ptr, GF_WOUNDS, dir, damroll(dice, sides), 0);
             }
         }
@@ -196,7 +196,7 @@ concptr do_life_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
                 fire_ball_hide(caster_ptr, GF_WOUNDS, dir, damroll(dice, sides), 0);
             }
         }
@@ -318,7 +318,7 @@ concptr do_life_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
         {
             if (cast) {
                 if (!ident_spell(caster_ptr, false))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;
@@ -375,7 +375,7 @@ concptr do_life_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
                 fire_ball_hide(caster_ptr, GF_WOUNDS, dir, damroll(dice, sides), 0);
             }
         }
@@ -397,7 +397,7 @@ concptr do_life_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
 
             if (cast) {
                 if (!recall_player(caster_ptr, randint0(21) + 15))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;
@@ -544,7 +544,7 @@ concptr do_life_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
         {
             if (cast) {
                 if (!identify_fully(caster_ptr, false))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;

--- a/src/realm/realm-nature.cpp
+++ b/src/realm/realm-nature.cpp
@@ -45,7 +45,7 @@
  * @param caster_ptr プレーヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SPELL_NAME / SPELL_DESC / SPELL_INFO / SPELL_CAST)
- * @return SPELL_NAME / SPELL_DESC / SPELL_INFO 時には文字列ポインタを返す。SPELL_CAST時はNULL文字列を返す。
+ * @return SPELL_NAME / SPELL_DESC / SPELL_INFO 時には文字列ポインタを返す。SPELL_CAST時はnullptr文字列を返す。
  */
 concptr do_nature_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
 {
@@ -94,7 +94,7 @@ concptr do_nature_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
                 project_length = range;
 
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_beam(caster_ptr, GF_ELEC, dir, damroll(dice, sides));
             }
@@ -180,7 +180,7 @@ concptr do_nature_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 charm_animal(caster_ptr, dir, plev);
             }
@@ -246,7 +246,7 @@ concptr do_nature_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 wall_to_mud(caster_ptr, dir, 20 + randint1(30));
             }
@@ -268,7 +268,7 @@ concptr do_nature_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
                 fire_bolt_or_beam(caster_ptr, beam_chance(caster_ptr) - 10, GF_COLD, dir, damroll(dice, sides));
             }
         }
@@ -313,7 +313,7 @@ concptr do_nature_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
                 fire_bolt_or_beam(caster_ptr, beam_chance(caster_ptr) - 10, GF_FIRE, dir, damroll(dice, sides));
             }
         }
@@ -334,7 +334,7 @@ concptr do_nature_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
                 msg_print(_("太陽光線が現れた。", "A line of sunlight appears."));
                 lite_line(caster_ptr, dir, damroll(6, 8));
             }
@@ -478,7 +478,7 @@ concptr do_nature_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
         {
             if (cast) {
                 if (!identify_fully(caster_ptr, false))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;
@@ -505,7 +505,7 @@ concptr do_nature_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
         {
             if (cast) {
                 if (!rustproof(caster_ptr))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;
@@ -553,7 +553,7 @@ concptr do_nature_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_ball(caster_ptr, GF_COLD, dir, dam, rad);
             }
@@ -575,7 +575,7 @@ concptr do_nature_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
                 fire_ball(caster_ptr, GF_ELEC, dir, dam, rad);
                 break;
             }
@@ -597,7 +597,7 @@ concptr do_nature_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mod
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
                 fire_ball(caster_ptr, GF_WATER, dir, dam, rad);
             }
         }

--- a/src/realm/realm-song.cpp
+++ b/src/realm/realm-song.cpp
@@ -53,7 +53,7 @@ static void start_singing(player_type *caster_ptr, SPELL_IDX spell, int32_t song
  * @param caster_ptr プレーヤーへの参照ポインタ
  * @param spell 歌ID
  * @param mode 処理内容 (SPELL_NAME / SPELL_DESC / SPELL_INFO / SPELL_CAST / SPELL_FAIL / SPELL_CONT / SPELL_STOP)
- * @return SPELL_NAME / SPELL_DESC / SPELL_INFO 時には文字列ポインタを返す。SPELL_CAST / SPELL_FAIL / SPELL_CONT / SPELL_STOP 時はNULL文字列を返す。
+ * @return SPELL_NAME / SPELL_DESC / SPELL_INFO 時には文字列ポインタを返す。SPELL_CAST / SPELL_FAIL / SPELL_CONT / SPELL_STOP 時はnullptr文字列を返す。
  */
 concptr do_music_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
 {
@@ -138,7 +138,7 @@ concptr do_music_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_bolt(caster_ptr, GF_SOUND, dir, damroll(dice, sides));
             }
@@ -732,7 +732,7 @@ concptr do_music_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_beam(caster_ptr, GF_SOUND, dir, damroll(dice, sides));
             }
@@ -956,7 +956,7 @@ concptr do_music_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_ball(caster_ptr, GF_SOUND, dir, damroll(dice, sides), rad);
             }

--- a/src/realm/realm-sorcery.cpp
+++ b/src/realm/realm-sorcery.cpp
@@ -30,7 +30,7 @@
  * @param caster_ptr プレーヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SPELL_NAME / SPELL_DESC / SPELL_INFO / SPELL_CAST)
- * @return SPELL_NAME / SPELL_DESC / SPELL_INFO 時には文字列ポインタを返す。SPELL_CAST時はNULL文字列を返す。
+ * @return SPELL_NAME / SPELL_DESC / SPELL_INFO 時には文字列ポインタを返す。SPELL_CAST時はnullptr文字列を返す。
  */
 concptr do_sorcery_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
 {
@@ -133,7 +133,7 @@ concptr do_sorcery_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 confuse_monster(caster_ptr, dir, power);
             }
@@ -172,7 +172,7 @@ concptr do_sorcery_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 sleep_monster(caster_ptr, dir, plev);
             }
@@ -193,7 +193,7 @@ concptr do_sorcery_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
 
             if (cast) {
                 if (!recharge(caster_ptr, power))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;
@@ -225,7 +225,7 @@ concptr do_sorcery_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
         {
             if (cast) {
                 if (!ident_spell(caster_ptr, false))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;
@@ -244,7 +244,7 @@ concptr do_sorcery_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 slow_monster(caster_ptr, dir, plev);
             }
@@ -283,7 +283,7 @@ concptr do_sorcery_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_beam(caster_ptr, GF_AWAY_ALL, dir, power);
             }
@@ -337,7 +337,7 @@ concptr do_sorcery_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
         {
             if (cast) {
                 if (!identify_fully(caster_ptr, false))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;
@@ -376,7 +376,7 @@ concptr do_sorcery_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 charm_monster(caster_ptr, dir, plev);
             }
@@ -411,7 +411,7 @@ concptr do_sorcery_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
         {
             if (cast) {
                 if (!tele_town(caster_ptr))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;
@@ -439,7 +439,7 @@ concptr do_sorcery_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
         {
             if (cast) {
                 if (!get_check(_("本当に他の階にテレポートしますか？", "Are you sure? (Teleport Level)")))
-                    return NULL;
+                    return nullptr;
                 teleport_level(caster_ptr, 0);
             }
         }
@@ -461,7 +461,7 @@ concptr do_sorcery_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
 
             if (cast) {
                 if (!recall_player(caster_ptr, randint0(21) + 15))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;
@@ -481,7 +481,7 @@ concptr do_sorcery_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
             if (cast) {
                 msg_print(_("次元の扉が開いた。目的地を選んで下さい。", "You open a dimensional gate. Choose a destination."));
                 if (!dimension_door(caster_ptr))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;
@@ -534,7 +534,7 @@ concptr do_sorcery_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fetch_item(caster_ptr, dir, weight, false);
             }
@@ -595,7 +595,7 @@ concptr do_sorcery_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mo
         {
             if (cast) {
                 if (!alchemy(caster_ptr))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;

--- a/src/realm/realm-trump.cpp
+++ b/src/realm/realm-trump.cpp
@@ -33,7 +33,7 @@
  * @param caster_ptr プレーヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SPELL_NAME / SPELL_DESC / SPELL_INFO / SPELL_CAST)
- * @return SPELL_NAME / SPELL_DESC / SPELL_INFO 時には文字列ポインタを返す。SPELL_CAST時はNULL文字列を返す。
+ * @return SPELL_NAME / SPELL_DESC / SPELL_INFO 時には文字列ポインタを返す。SPELL_CAST時はnullptr文字列を返す。
  */
 concptr do_trump_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode)
 {
@@ -108,7 +108,7 @@ concptr do_trump_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
         {
             if (cast) {
                 if (!reset_recall(caster_ptr))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;
@@ -164,7 +164,7 @@ concptr do_trump_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fire_beam(caster_ptr, GF_AWAY_ALL, dir, power);
             }
@@ -204,7 +204,7 @@ concptr do_trump_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!get_aim_dir(caster_ptr, &dir))
-                    return NULL;
+                    return nullptr;
 
                 fetch_item(caster_ptr, dir, weight, false);
             }
@@ -224,7 +224,7 @@ concptr do_trump_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
                 if (cast) {
                     if (!target_set(caster_ptr, TARGET_KILL))
-                        return NULL;
+                        return nullptr;
                     x = target_col;
                     y = target_row;
                 } else {
@@ -286,7 +286,7 @@ concptr do_trump_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
                 target_pet = old_target_pet;
 
                 if (!result)
-                    return NULL;
+                    return nullptr;
 
                 speed_monster(caster_ptr, dir, plev);
             }
@@ -302,7 +302,7 @@ concptr do_trump_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
         {
             if (cast) {
                 if (!get_check(_("本当に他の階にテレポートしますか？", "Are you sure? (Teleport Level)")))
-                    return NULL;
+                    return nullptr;
                 teleport_level(caster_ptr, 0);
             }
         }
@@ -323,7 +323,7 @@ concptr do_trump_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
             if (cast) {
                 msg_print(_("次元の扉が開いた。目的地を選んで下さい。", "You open a dimensional gate. Choose a destination."));
                 if (!dimension_door(caster_ptr))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;
@@ -344,7 +344,7 @@ concptr do_trump_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
 
             if (cast) {
                 if (!recall_player(caster_ptr, randint0(21) + 15))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;
@@ -386,7 +386,7 @@ concptr do_trump_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
                 project_length = 0;
 
                 if (!result)
-                    return NULL;
+                    return nullptr;
 
                 teleport_swap(caster_ptr, dir);
             }
@@ -540,7 +540,7 @@ concptr do_trump_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
         {
             if (cast) {
                 if (!identify_fully(caster_ptr, false))
-                    return NULL;
+                    return nullptr;
             }
         }
         break;
@@ -570,7 +570,7 @@ concptr do_trump_spell(player_type *caster_ptr, SPELL_IDX spell, spell_type mode
                 target_pet = old_target_pet;
 
                 if (!result)
-                    return NULL;
+                    return nullptr;
 
                 heal_monster(caster_ptr, dir, heal);
             }

--- a/src/room/rooms-pit-nest.cpp
+++ b/src/room/rooms-pit-nest.cpp
@@ -177,15 +177,15 @@ static void ang_sort_swap_nest_mon_info(player_type *player_ptr, vptr u, vptr v,
  */
 std::vector<nest_pit_type> nest_types = {
     { _("クローン", "clone"), vault_aux_clone, vault_prep_clone, 5, 3 },
-    { _("ゼリー", "jelly"), vault_aux_jelly, NULL, 5, 6 },
+    { _("ゼリー", "jelly"), vault_aux_jelly, nullptr, 5, 6 },
     { _("シンボル(善)", "symbol good"), vault_aux_symbol_g, vault_prep_symbol, 25, 2 },
     { _("シンボル(悪)", "symbol evil"), vault_aux_symbol_e, vault_prep_symbol, 25, 2 },
-    { _("ミミック", "mimic"), vault_aux_mimic, NULL, 30, 4 },
-    { _("狂気", "lovecraftian"), vault_aux_cthulhu, NULL, 70, 2 },
-    { _("犬小屋", "kennel"), vault_aux_kennel, NULL, 45, 4 },
-    { _("動物園", "animal"), vault_aux_animal, NULL, 35, 5 },
-    { _("教会", "chapel"), vault_aux_chapel_g, NULL, 75, 4 },
-    { _("アンデッド", "undead"), vault_aux_undead, NULL, 75, 5 },
+    { _("ミミック", "mimic"), vault_aux_mimic, nullptr, 30, 4 },
+    { _("狂気", "lovecraftian"), vault_aux_cthulhu, nullptr, 70, 2 },
+    { _("犬小屋", "kennel"), vault_aux_kennel, nullptr, 45, 4 },
+    { _("動物園", "animal"), vault_aux_animal, nullptr, 35, 5 },
+    { _("教会", "chapel"), vault_aux_chapel_g, nullptr, 75, 4 },
+    { _("アンデッド", "undead"), vault_aux_undead, nullptr, 75, 5 },
 };
 
 /*!
@@ -239,7 +239,7 @@ bool build_type5(player_type *player_ptr, dun_data_type *dd_ptr)
     /* Process a preparation function if necessary */
     if (n_ptr->prep_func)
         (*(n_ptr->prep_func))(player_ptr);
-    get_mon_num_prep(player_ptr, n_ptr->hook_func, NULL);
+    get_mon_num_prep(player_ptr, n_ptr->hook_func, nullptr);
 
     align.sub_align = SUB_ALIGN_NEUTRAL;
 
@@ -247,7 +247,7 @@ bool build_type5(player_type *player_ptr, dun_data_type *dd_ptr)
     for (i = 0; i < NUM_NEST_MON_TYPE; i++) {
         MONRACE_IDX r_idx = 0;
         int attempts = 100;
-        monster_race *r_ptr = NULL;
+        monster_race *r_ptr = nullptr;
 
         while (attempts--) {
             /* Get a (hard) monster type */
@@ -370,7 +370,7 @@ bool build_type5(player_type *player_ptr, dun_data_type *dd_ptr)
     }
 
     if (cheat_room) {
-        ang_sort(player_ptr, nest_mon_info, NULL, NUM_NEST_MON_TYPE, ang_sort_comp_nest_mon_info, ang_sort_swap_nest_mon_info);
+        ang_sort(player_ptr, nest_mon_info, nullptr, NUM_NEST_MON_TYPE, ang_sort_comp_nest_mon_info, ang_sort_swap_nest_mon_info);
 
         /* Dump the entries (prevent multi-printing) */
         for (i = 0; i < NUM_NEST_MON_TYPE; i++) {
@@ -394,16 +394,16 @@ bool build_type5(player_type *player_ptr, dun_data_type *dd_ptr)
  * @brief 生成するPitの情報テーブル
  */
 std::vector<nest_pit_type> pit_types = {
-    { _("オーク", "orc"), vault_aux_orc, NULL, 5, 6 },
-    { _("トロル", "troll"), vault_aux_troll, NULL, 20, 6 },
-    { _("巨人", "giant"), vault_aux_giant, NULL, 50, 6 },
-    { _("狂気", "lovecraftian"), vault_aux_cthulhu, NULL, 80, 2 },
+    { _("オーク", "orc"), vault_aux_orc, nullptr, 5, 6 },
+    { _("トロル", "troll"), vault_aux_troll, nullptr, 20, 6 },
+    { _("巨人", "giant"), vault_aux_giant, nullptr, 50, 6 },
+    { _("狂気", "lovecraftian"), vault_aux_cthulhu, nullptr, 80, 2 },
     { _("シンボル(善)", "symbol good"), vault_aux_symbol_g, vault_prep_symbol, 70, 1 },
     { _("シンボル(悪)", "symbol evil"), vault_aux_symbol_e, vault_prep_symbol, 70, 1 },
-    { _("教会", "chapel"), vault_aux_chapel_g, NULL, 65, 2 },
+    { _("教会", "chapel"), vault_aux_chapel_g, nullptr, 65, 2 },
     { _("ドラゴン", "dragon"), vault_aux_dragon, vault_prep_dragon, 70, 6 },
-    { _("デーモン", "demon"), vault_aux_demon, NULL, 80, 6 },
-    { _("ダークエルフ", "dark elf"), vault_aux_dark_elf, NULL, 45, 4 },
+    { _("デーモン", "demon"), vault_aux_demon, nullptr, 80, 6 },
+    { _("ダークエルフ", "dark elf"), vault_aux_dark_elf, nullptr, 45, 4 },
 };
 
 /*!
@@ -466,7 +466,7 @@ bool build_type6(player_type *player_ptr, dun_data_type *dd_ptr)
     /* Process a preparation function if necessary */
     if (n_ptr->prep_func)
         (*(n_ptr->prep_func))(player_ptr);
-    get_mon_num_prep(player_ptr, n_ptr->hook_func, NULL);
+    get_mon_num_prep(player_ptr, n_ptr->hook_func, nullptr);
 
     align.sub_align = SUB_ALIGN_NEUTRAL;
 
@@ -474,7 +474,7 @@ bool build_type6(player_type *player_ptr, dun_data_type *dd_ptr)
     for (i = 0; i < 16; i++) {
         MONRACE_IDX r_idx = 0;
         int attempts = 100;
-        monster_race *r_ptr = NULL;
+        monster_race *r_ptr = nullptr;
 
         while (attempts--) {
             /* Get a (hard) monster type */
@@ -779,7 +779,7 @@ bool build_type13(player_type *player_ptr, dun_data_type *dd_ptr)
     for (i = 0; i < 16; i++) {
         MONRACE_IDX r_idx = 0;
         int attempts = 100;
-        monster_race *r_ptr = NULL;
+        monster_race *r_ptr = nullptr;
 
         while (attempts--) {
             /* Get a (hard) monster type */

--- a/src/room/rooms-special.cpp
+++ b/src/room/rooms-special.cpp
@@ -88,7 +88,7 @@ bool build_type15(player_type *player_ptr, dun_data_type *dd_ptr)
     case 1: /* 4 lite breathers + potion */
     {
         DIRECTION dir1, dir2;
-        get_mon_num_prep(player_ptr, vault_aux_lite, NULL);
+        get_mon_num_prep(player_ptr, vault_aux_lite, nullptr);
 
         /* Place fixed lite berathers */
         for (dir1 = 4; dir1 < 8; dir1++) {
@@ -153,7 +153,7 @@ bool build_type15(player_type *player_ptr, dun_data_type *dd_ptr)
         g_ptr = &floor_ptr->grid_array[y2 - 1][x2 - 1];
         place_grid(player_ptr, g_ptr, GB_INNER);
         g_ptr->feat = feat_glass_wall;
-        get_mon_num_prep(player_ptr, vault_aux_lite, NULL);
+        get_mon_num_prep(player_ptr, vault_aux_lite, nullptr);
 
         r_idx = get_mon_num(player_ptr, 0, floor_ptr->dun_level, 0);
         if (r_idx)
@@ -211,7 +211,7 @@ bool build_type15(player_type *player_ptr, dun_data_type *dd_ptr)
             g_ptr->feat = feat_glass_wall;
         }
 
-        get_mon_num_prep(player_ptr, vault_aux_shards, NULL);
+        get_mon_num_prep(player_ptr, vault_aux_shards, nullptr);
 
         /* Place shard berathers */
         for (dir1 = 4; dir1 < 8; dir1++) {

--- a/src/room/rooms-vault.cpp
+++ b/src/room/rooms-vault.cpp
@@ -608,7 +608,7 @@ static void build_vault(
  */
 bool build_type7(player_type *player_ptr, dun_data_type *dd_ptr)
 {
-    vault_type *v_ptr = NULL;
+    vault_type *v_ptr = nullptr;
     int dummy;
     POSITION x, y;
     POSITION xval, yval;
@@ -1149,7 +1149,7 @@ bool build_type10(player_type *player_ptr, dun_data_type *dd_ptr)
  */
 bool build_type17(player_type *player_ptr, dun_data_type *dd_ptr)
 {
-    vault_type *v_ptr = NULL;
+    vault_type *v_ptr = nullptr;
     int dummy;
     POSITION x, y;
     POSITION xval, yval;

--- a/src/save/floor-writer.cpp
+++ b/src/save/floor-writer.cpp
@@ -183,7 +183,7 @@ bool wr_dungeon(player_type *player_ptr)
     if (!player_ptr->floor_id) {
         /* No array elements */
         wr_byte(0);
-        wr_saved_floor(player_ptr, NULL);
+        wr_saved_floor(player_ptr, nullptr);
         return true;
     }
 
@@ -253,7 +253,7 @@ static bool save_floor_aux(player_type *player_ptr, saved_floor_type *sf_ptr)
  */
 bool save_floor(player_type *player_ptr, saved_floor_type *sf_ptr, BIT_FLAGS mode)
 {
-    FILE *old_fff = NULL;
+    FILE *old_fff = nullptr;
     byte old_xor_byte = 0;
     uint32_t old_v_stamp = 0;
     uint32_t old_x_stamp = 0;
@@ -270,7 +270,7 @@ bool save_floor(player_type *player_ptr, saved_floor_type *sf_ptr, BIT_FLAGS mod
     safe_setuid_grab(player_ptr);
     fd_kill(floor_savefile);
     safe_setuid_drop();
-    saving_savefile = NULL;
+    saving_savefile = nullptr;
     safe_setuid_grab(player_ptr);
 
     int fd = fd_make(floor_savefile, 0644);

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -238,7 +238,7 @@ static bool save_player_aux(player_type *player_ptr, char *name, save_type type)
     safe_setuid_drop();
 
     bool is_save_successful = false;
-    saving_savefile = NULL;
+    saving_savefile = nullptr;
     if (fd >= 0) {
         (void)fd_close(fd);
         safe_setuid_grab(player_ptr);

--- a/src/spell-kind/spells-detection.cpp
+++ b/src/spell-kind/spells-detection.cpp
@@ -613,7 +613,7 @@ bool detect_monsters_xxx(player_type *caster_ptr, POSITION range, uint32_t match
         }
 
         msg_format(_("%sの存在を感じとった！", "You sense the presence of %s!"), desc_monsters);
-        msg_print(NULL);
+        msg_print(nullptr);
     }
 
     return flag;

--- a/src/spell-kind/spells-sight.cpp
+++ b/src/spell-kind/spells-sight.cpp
@@ -443,7 +443,7 @@ bool probing(player_type *caster_ptr)
 
         if (!probe)
             msg_print(_("調査中...", "Probing..."));
-        msg_print(NULL);
+        msg_print(nullptr);
 
         probed_monster_info(buf, caster_ptr, m_ptr, r_ptr);
         prt(buf, 0, 0);
@@ -462,7 +462,7 @@ bool probing(player_type *caster_ptr)
             plural_aux(buf);
             msg_format("You now know more about %s.", buf);
 #endif
-            msg_print(NULL);
+            msg_print(nullptr);
         }
 
         probe = true;

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -117,7 +117,7 @@ void teleport_level(player_type *creature_ptr, MONSTER_IDX m_idx)
             }
 
             if (record_stair)
-                exe_write_diary(creature_ptr, DIARY_TELEPORT_LEVEL, 1, NULL);
+                exe_write_diary(creature_ptr, DIARY_TELEPORT_LEVEL, 1, nullptr);
 
             if (autosave_l)
                 do_cmd_save_game(creature_ptr, true);
@@ -143,7 +143,7 @@ void teleport_level(player_type *creature_ptr, MONSTER_IDX m_idx)
 
         if (m_idx <= 0) {
             if (record_stair)
-                exe_write_diary(creature_ptr, DIARY_TELEPORT_LEVEL, -1, NULL);
+                exe_write_diary(creature_ptr, DIARY_TELEPORT_LEVEL, -1, nullptr);
 
             if (autosave_l)
                 do_cmd_save_game(creature_ptr, true);
@@ -165,7 +165,7 @@ void teleport_level(player_type *creature_ptr, MONSTER_IDX m_idx)
 
         if (m_idx <= 0) {
             if (record_stair)
-                exe_write_diary(creature_ptr, DIARY_TELEPORT_LEVEL, -1, NULL);
+                exe_write_diary(creature_ptr, DIARY_TELEPORT_LEVEL, -1, nullptr);
 
             if (autosave_l)
                 do_cmd_save_game(creature_ptr, true);
@@ -184,7 +184,7 @@ void teleport_level(player_type *creature_ptr, MONSTER_IDX m_idx)
 
         if (m_idx <= 0) {
             if (record_stair)
-                exe_write_diary(creature_ptr, DIARY_TELEPORT_LEVEL, 1, NULL);
+                exe_write_diary(creature_ptr, DIARY_TELEPORT_LEVEL, 1, nullptr);
             if (autosave_l)
                 do_cmd_save_game(creature_ptr, true);
 
@@ -277,7 +277,7 @@ bool tele_town(player_type *caster_ptr)
 
     if (num == 0) {
         msg_print(_("まだ行けるところがない。", "You have not yet visited any town."));
-        msg_print(NULL);
+        msg_print(nullptr);
         screen_load();
         return false;
     }

--- a/src/spell-realm/spells-craft.cpp
+++ b/src/spell-realm/spells-craft.cpp
@@ -266,7 +266,7 @@ bool pulish_shield(player_type *caster_ptr)
 
     OBJECT_IDX item;
     object_type *o_ptr = choose_object(caster_ptr, &item, q, s, USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT, TvalItemTester(TV_SHIELD));
-    if (o_ptr == NULL)
+    if (o_ptr == nullptr)
         return false;
 
     GAME_TEXT o_name[MAX_NLEN];

--- a/src/spell-realm/spells-nature.cpp
+++ b/src/spell-realm/spells-nature.cpp
@@ -23,7 +23,7 @@ bool rustproof(player_type *caster_ptr)
     concptr s = _("錆止めできるものがありません。", "You have nothing to rustproof.");
     OBJECT_IDX item;
     object_type *o_ptr = choose_object(caster_ptr, &item, q, s, USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT, FuncItemTester(&object_type::is_armour));
-    if (o_ptr == NULL)
+    if (o_ptr == nullptr)
         return false;
 
     GAME_TEXT o_name[MAX_NLEN];

--- a/src/spell-realm/spells-sorcery.cpp
+++ b/src/spell-realm/spells-sorcery.cpp
@@ -36,7 +36,7 @@ bool alchemy(player_type *caster_ptr)
 
     int amt = 1;
     if (o_ptr->number > 1) {
-        amt = get_quantity(NULL, o_ptr->number);
+        amt = get_quantity(nullptr, o_ptr->number);
         if (amt <= 0)
             return false;
     }

--- a/src/spell/spells-execution.cpp
+++ b/src/spell/spells-execution.cpp
@@ -20,7 +20,7 @@
  * @param realm 魔法領域のID
  * @param spell 各領域の魔法ID
  * @param mode 求める処理
- * @return 各領域魔法に各種テキストを求めた場合は文字列参照ポインタ、そうでない場合はNULLポインタを返す。
+ * @return 各領域魔法に各種テキストを求めた場合は文字列参照ポインタ、そうでない場合はnullptrポインタを返す。
  */
 concptr exe_spell(player_type *caster_ptr, int16_t realm, SPELL_IDX spell, spell_type mode)
 {
@@ -41,5 +41,5 @@ concptr exe_spell(player_type *caster_ptr, int16_t realm, SPELL_IDX spell, spell
 	case REALM_HEX:      return do_hex_spell(caster_ptr, spell, mode);
 	}
 
-	return NULL;
+	return nullptr;
 }

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -626,7 +626,7 @@ void brand_weapon(player_type *caster_ptr, int brand_type)
     GAME_TEXT o_name[MAX_NLEN];
     describe_flavor(caster_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
 
-    concptr act = NULL;
+    concptr act = nullptr;
     switch (brand_type) {
     case 17:
         if (o_ptr->tval == TV_SWORD) {

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -205,7 +205,7 @@ bool time_walk(player_type *creature_ptr)
     creature_ptr->timewalk = true;
     msg_print(_("「時よ！」", "You yell 'Time!'"));
     //	msg_print(_("「『ザ・ワールド』！時は止まった！」", "You yell 'The World! Time has stopped!'"));
-    msg_print(NULL);
+    msg_print(nullptr);
 
     creature_ptr->energy_need -= 1000 + (100 + creature_ptr->csp - 50) * TURNS_PER_TICK / 10;
     creature_ptr->redraw |= (PR_MAP);

--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -224,7 +224,7 @@ void store_purchase(player_type *player_ptr)
             msg_format(_("一つにつき $%ldです。", "That costs %ld gold per item."), (long)(best));
         }
 
-        amt = get_quantity(NULL, o_ptr->number);
+        amt = get_quantity(nullptr, o_ptr->number);
         if (amt <= 0)
             return;
     }
@@ -253,7 +253,7 @@ void store_purchase(player_type *player_ptr)
     GAME_TEXT o_name[MAX_NLEN];
     describe_flavor(player_ptr, o_name, j_ptr, 0);
     msg_format(_("%s(%c)を購入する。", "Buying %s (%c)."), o_name, I2A(item));
-    msg_print(NULL);
+    msg_print(nullptr);
 
     auto res = prompt_to_buy(player_ptr, j_ptr);
     if (st_ptr->store_open >= current_world_ptr->game_turn)

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -60,7 +60,7 @@ void display_rumor(player_type *player_ptr, bool ex)
         return;
     }
 
-    concptr rumor_eff_format = NULL;
+    concptr rumor_eff_format = nullptr;
     char fullname[1024] = "";
     if (strcmp(zz[0], "ARTIFACT") == 0) {
         ARTIFACT_IDX a_idx;
@@ -130,7 +130,7 @@ void display_rumor(player_type *player_ptr, bool ex)
     concptr rumor_msg = rumor_bind_name(zz[2], fullname);
     msg_print(rumor_msg);
     if (rumor_eff_format) {
-        msg_print(NULL);
+        msg_print(nullptr);
         msg_format(rumor_eff_format, fullname);
     }
 }

--- a/src/store/sell-order.cpp
+++ b/src/store/sell-order.cpp
@@ -103,7 +103,7 @@ void store_sell(player_type *owner_ptr)
 
     int amt = 1;
     if (o_ptr->number > 1) {
-        amt = get_quantity(NULL, o_ptr->number);
+        amt = get_quantity(nullptr, o_ptr->number);
         if (amt <= 0)
             return;
     }
@@ -131,7 +131,7 @@ void store_sell(player_type *owner_ptr)
     bool placed = false;
     if ((cur_store_num != STORE_HOME) && (cur_store_num != STORE_MUSEUM)) {
         msg_format(_("%s(%c)を売却する。", "Selling %s (%c)."), o_name, index_to_label(item));
-        msg_print(NULL);
+        msg_print(nullptr);
 
         auto res = prompt_to_sell(owner_ptr, q_ptr);
         placed = res.has_value();

--- a/src/store/service-checker.cpp
+++ b/src/store/service-checker.cpp
@@ -104,7 +104,7 @@ static bool check_store_temple(const object_type *o_ptr)
     case TV_STATUE: {
         monster_race *r_ptr = &r_info[o_ptr->pval];
         if (!(r_ptr->flags3 & RF3_EVIL))
-            if (((r_ptr->flags3 & RF3_GOOD) != 0) || ((r_ptr->flags3 & RF3_ANIMAL) != 0) || (angband_strchr("?!", r_ptr->d_char) != NULL))
+            if (((r_ptr->flags3 & RF3_GOOD) != 0) || ((r_ptr->flags3 & RF3_ANIMAL) != 0) || (angband_strchr("?!", r_ptr->d_char) != nullptr))
                 return true;
     }
         /* Fall through */

--- a/src/store/store-util.cpp
+++ b/src/store/store-util.cpp
@@ -18,7 +18,7 @@
 #include "world/world-object.h"
 
 int cur_store_num = 0;
-store_type *st_ptr = NULL;
+store_type *st_ptr = nullptr;
 
 /*!
  * @brief 店舗のオブジェクト数を増やす /

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -38,7 +38,7 @@
 int store_top = 0;
 int store_bottom = 0;
 int xtra_stock = 0;
-const owner_type *ot_ptr = NULL;
+const owner_type *ot_ptr = nullptr;
 int16_t old_town_num = 0;
 int16_t inner_town_num = 0;
 
@@ -153,7 +153,7 @@ int get_stock(COMMAND_CODE *com_val, concptr pmt, int i, int j)
     if (repeat_pull(com_val) && (*com_val >= i) && (*com_val <= j))
         return true;
 
-    msg_print(NULL);
+    msg_print(nullptr);
     *com_val = (-1);
     char lo = I2A(i);
     char hi = (j > 25) ? toupper(I2A(j - 26)) : I2A(j);

--- a/src/term/gameterm.cpp
+++ b/src/term/gameterm.cpp
@@ -116,7 +116,7 @@ const concptr window_flag_desc[32] =
 	_("呪文一覧", "Display spell list"),
 	_("キャラクタ情報", "Display character"),
 	_("視界内のモンスター表示", "Display monsters in sight"),
-	NULL,
+	nullptr,
 	_("メッセージ", "Display messages"),
 	_("ダンジョン全体図", "Display overhead view"),
 	_("モンスターの思い出", "Display monster recall"),
@@ -124,25 +124,25 @@ const concptr window_flag_desc[32] =
 	_("自分の周囲を表示", "Display dungeon view"),
 	_("記念撮影", "Display snap-shot"),
 	_("足元/床上のアイテム一覧", "Display items on floor"),
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr
 };
 
 
@@ -346,7 +346,7 @@ const concptr ident_info[] =
 	"~:Fluid terrain (or miscellaneous item)",
 #endif
 
-	NULL
+	nullptr
 };
 
 /*

--- a/src/term/screen-processor.cpp
+++ b/src/term/screen-processor.cpp
@@ -30,7 +30,7 @@ void flush(void) { inkey_xtra = true; }
  */
 void screen_save()
 {
-    msg_print(NULL);
+    msg_print(nullptr);
 
     term_save();
 
@@ -45,7 +45,7 @@ void screen_save()
  */
 void screen_load(SCREEN_LOAD_OPT opt)
 {
-    msg_print(NULL);
+    msg_print(nullptr);
 
     switch (opt) {
     case SCREEN_LOAD_OPT::ONE:

--- a/src/term/z-form.cpp
+++ b/src/term/z-form.cpp
@@ -107,7 +107,7 @@
  * Format("%s", concptr s)
  *   Append the string "s".
  *   Do not use the "+" or "0" flags.
- *   Note that a "NULL" value of "s" is converted to the empty string.
+ *   Note that a "nullptr" value of "s" is converted to the empty string.
  *
  * Format("%V", vptr v)
  *   Note -- possibly significant mode flag
@@ -121,7 +121,7 @@
  *
  *
  * For examples below, assume "int n = 0; int m = 100; char buf[100];",
- * plus "char *s = NULL;", and unknown values "char *txt; int i;".
+ * plus "char *s = nullptr;", and unknown values "char *txt; int i;".
  *
  * For example: "n = strnfmt(buf, -1, "(Max %d)", i);" will have a
  * similar effect as "sprintf(buf, "(Max %d)", i); n = strlen(buf);".
@@ -554,7 +554,7 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
             /* Access next argument */
             arg = va_arg(vp, concptr);
 
-            /* Hack -- convert NULL to EMPTY */
+            /* Hack -- convert nullptr to EMPTY */
             if (!arg)
                 arg = "";
 
@@ -648,7 +648,7 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
  */
 char *vformat(concptr fmt, va_list vp)
 {
-    static char *format_buf = NULL;
+    static char *format_buf = nullptr;
     static ulong format_len = 0;
 
     /* Initial allocation */

--- a/src/term/z-rand.cpp
+++ b/src/term/z-rand.cpp
@@ -124,7 +124,7 @@ void Rand_state_init(void)
 
     HCRYPTPROV hProvider;
 
-    CryptAcquireContext(&hProvider, NULL, NULL, PROV_RSA_FULL, 0);
+    CryptAcquireContext(&hProvider, nullptr, nullptr, PROV_RSA_FULL, 0);
 
     do {
         CryptGenRandom(hProvider, sizeof(Rand_state[0]) * 4, (BYTE *)Rand_state);
@@ -135,7 +135,7 @@ void Rand_state_init(void)
 #else
 
     /* Basic seed */
-    uint32_t seed = (time(NULL));
+    uint32_t seed = (time(nullptr));
 #ifdef SET_UID
     /* Mutate the seed on Unix machines */
     seed = ((seed >> 3) * (getpid() << 1));
@@ -365,7 +365,7 @@ int32_t Rand_external(int32_t m)
 
     if (!initialized) {
         /* Initialize with new seed */
-        uint32_t seed = (uint32_t)time(NULL);
+        uint32_t seed = (uint32_t)time(nullptr);
         Rand_seed(seed, Rand_state_external);
         initialized = true;
     }

--- a/src/term/z-term.cpp
+++ b/src/term/z-term.cpp
@@ -31,7 +31,7 @@
 #endif
 
 /* The current "term" */
-term_type *Term = NULL;
+term_type *Term = nullptr;
 
 /*** Local routines ***/
 

--- a/src/term/z-util.cpp
+++ b/src/term/z-util.cpp
@@ -16,7 +16,7 @@
 /*
  * Convenient storage of the program name
  */
-concptr argv0 = NULL;
+concptr argv0 = nullptr;
 
 
 /*
@@ -65,7 +65,7 @@ bool prefix(concptr s, concptr t)
 /*
  * Redefinable "plog" action
  */
-void (*plog_aux)(concptr) = NULL;
+void (*plog_aux)(concptr) = nullptr;
 
 /*
  * Print (or log) a "warning" message (ala "perror()")
@@ -85,10 +85,10 @@ void plog(concptr str)
 /*
  * Redefinable "quit" action
  */
-void (*quit_aux)(concptr) = NULL;
+void (*quit_aux)(concptr) = nullptr;
 
 /*
- * Exit (ala "exit()").  If 'str' is NULL, do "exit(0)".
+ * Exit (ala "exit()").  If 'str' is nullptr, do "exit(0)".
  * If 'str' begins with "+" or "-", do "exit(atoi(str))".
  * Otherwise, plog() 'str' and exit with an error code of -1.
  * But always use 'quit_aux', if set, before anything else.
@@ -116,7 +116,7 @@ void quit(concptr str)
 /*
  * Redefinable "core" action
  */
-void (*core_aux)(concptr) = NULL;
+void (*core_aux)(concptr) = nullptr;
 
 /*
  * Dump a core file, after printing a warning message
@@ -124,7 +124,7 @@ void (*core_aux)(concptr) = NULL;
  */
 void core(concptr str)
 {
-	char *crash = NULL;
+	char *crash = nullptr;
 
 	/* Use the aux function */
 	if (core_aux) (*core_aux)(str);

--- a/src/term/z-virt.h
+++ b/src/term/z-virt.h
@@ -171,10 +171,10 @@ inline T *free_impl(T *p)
 /* Load a thing of type T, at location P1, from another, at location P2 */
 #define COPY(P1, P2, T) (copy_impl<T>(P1, P2))
 
-/* Free an array of N things of type T at P, return NULL */
+/* Free an array of N things of type T at P, return nullptr */
 #define C_FREE(P, N, T) (c_free_impl<T>(P, N))
 
-/* Free one thing of type T at P, return NULL */
+/* Free one thing of type T at P, return nullptr */
 #define FREE(P, T) (free_impl<T>(P))
 
 /* Allocate, and return, an array of type T[N] */
@@ -195,10 +195,10 @@ inline T *free_impl(T *p)
 /* Allocate a wiped thing of type T, assign to pointer P */
 #define MAKE(P, T) ((P) = ZNEW(T))
 
-/* Free an array of type T[N], at location P, and set P to NULL */
+/* Free an array of type T[N], at location P, and set P to nullptr */
 #define C_KILL(P, N, T) ((P) = C_FREE(P, N, T))
 
-/* Free a thing of type T, at location P, and set P to NULL */
+/* Free a thing of type T, at location P, and set P to nullptr */
 #define KILL(P, T) ((P) = FREE(P, T))
 
 /**** Available functions ****/

--- a/src/util/angband-files.cpp
+++ b/src/util/angband-files.cpp
@@ -195,7 +195,7 @@ FILE *angband_fopen(concptr file, concptr mode)
 {
     char buf[1024];
     if (path_parse(buf, 1024, file))
-        return (NULL);
+        return nullptr;
 
     return (fopen(buf, mode));
 }
@@ -218,7 +218,7 @@ FILE *angband_fopen_temp(char *buf, int max)
     strncpy(buf, "/tmp/anXXXXXX", max);
     int fd = mkstemp(buf);
     if (fd < 0)
-        return (NULL);
+        return nullptr;
 
     return (fdopen(fd, "w"));
 }
@@ -226,7 +226,7 @@ FILE *angband_fopen_temp(char *buf, int max)
 FILE *angband_fopen_temp(char *buf, int max)
 {
     if (path_temp(buf, max))
-        return (NULL);
+        return nullptr;
     return (angband_fopen(buf, "w"));
 }
 #endif /* HAVE_MKSTEMP */

--- a/src/util/angband-files.cpp
+++ b/src/util/angband-files.cpp
@@ -19,7 +19,7 @@ int usleep(ulong usecs)
 
     int nfds = 0;
 
-    fd_set *no_fds = NULL;
+    fd_set *no_fds = nullptr;
     if (usecs > 4000000L)
         core(_("不当な usleep() 呼び出し", "Illegal usleep() call"));
 
@@ -141,7 +141,7 @@ errr path_parse(char *buf, int max, concptr file)
  */
 static errr path_temp(char *buf, int max)
 {
-    concptr s = tmpnam(NULL);
+    concptr s = tmpnam(nullptr);
     if (!s)
         return -1;
 

--- a/src/util/quarks.cpp
+++ b/src/util/quarks.cpp
@@ -46,9 +46,9 @@ concptr quark_str(STR_OFFSET i)
 {
     concptr q;
 
-    /* Return NULL for an invalid index */
+    /* Return nullptr for an invalid index */
     if ((i < 1) || (i >= quark__num))
-        return NULL;
+        return nullptr;
 
     /* Access the quark */
     q = quark__str[i];

--- a/src/util/sort.cpp
+++ b/src/util/sort.cpp
@@ -133,12 +133,12 @@ bool ang_sort_comp_importance(player_type *player_ptr, vptr u, vptr v, int a, in
     if (ca_ptr->m_idx && ma_ptr->ml)
         ap_ra_ptr = &r_info[ma_ptr->ap_r_idx];
     else
-        ap_ra_ptr = NULL;
+        ap_ra_ptr = nullptr;
 
     if (cb_ptr->m_idx && mb_ptr->ml)
         ap_rb_ptr = &r_info[mb_ptr->ap_r_idx];
     else
-        ap_rb_ptr = NULL;
+        ap_rb_ptr = nullptr;
 
     if (ap_ra_ptr && !ap_rb_ptr)
         return true;

--- a/src/util/string-processor.cpp
+++ b/src/util/string-processor.cpp
@@ -9,7 +9,7 @@
 const char hexsym[16] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
 
 int max_macrotrigger = 0; /*!< 現在登録中のマクロ(トリガー)の数 */
-concptr macro_template = NULL; /*!< Angband設定ファイルのT: タグ情報から読み込んだ長いTコードを処理するために利用する文字列ポインタ */
+concptr macro_template = nullptr; /*!< Angband設定ファイルのT: タグ情報から読み込んだ長いTコードを処理するために利用する文字列ポインタ */
 concptr macro_modifier_chr; /*!< &x# で指定されるマクロトリガーに関する情報を記録する文字列ポインタ */
 concptr macro_modifier_name[MAX_MACRO_MOD]; /*!< マクロ上で取り扱う特殊キーを文字列上で表現するためのフォーマットを記録した文字列ポインタ配列 */
 concptr macro_trigger_name[MAX_MACRO_TRIG]; /*!< マクロのトリガーコード */
@@ -100,7 +100,7 @@ static void trigger_text_to_ascii(char **bufptr, concptr *strptr)
     int shiftstatus = 0;
     concptr key_code;
 
-    if (macro_template == NULL)
+    if (macro_template == nullptr)
         return;
 
     for (i = 0; macro_modifier_chr[i]; i++)
@@ -245,7 +245,7 @@ static bool trigger_ascii_to_text(char **bufptr, concptr *strptr)
     concptr str = *strptr;
     char key_code[100];
     int i;
-    if (macro_template == NULL)
+    if (macro_template == nullptr)
         return false;
 
     *s++ = '\\';
@@ -461,7 +461,7 @@ char *angband_strstr(concptr haystack, concptr needle)
         }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 /*
@@ -481,7 +481,7 @@ char *angband_strchr(concptr ptr, char ch)
 #endif
     }
 
-    return NULL;
+    return nullptr;
 }
 
 /*!

--- a/src/view/display-lore-attacks.cpp
+++ b/src/view/display-lore-attacks.cpp
@@ -36,7 +36,7 @@ static void display_monster_blow_jp(lore_type *lore_ptr, int attack_numbers, int
     }
 
     /* XXしてYYし/XXしてYYする/XXし/XXする */
-    if (lore_ptr->q != NULL)
+    if (lore_ptr->q != nullptr)
         jverb(lore_ptr->p, lore_ptr->jverb_buf, JVERB_TO);
     else if (attack_numbers != lore_ptr->count - 1)
         jverb(lore_ptr->p, lore_ptr->jverb_buf, JVERB_AND);
@@ -76,13 +76,13 @@ static void display_monster_blow_en(lore_type *lore_ptr, int attack_numbers, int
         hooked_roff(", and ");
     }
 
-    if (lore_ptr->p == NULL) {
+    if (lore_ptr->p == nullptr) {
         lore_ptr->p = "do something weird";
         lore_ptr->pc = TERM_VIOLET;
     }
 
     hook_c_roff(lore_ptr->pc, lore_ptr->p);
-    if (lore_ptr->q != NULL) {
+    if (lore_ptr->q != nullptr) {
         hooked_roff(" to ");
         hook_c_roff(lore_ptr->qc, lore_ptr->q);
         if (d1 && d2 && (lore_ptr->know_everything || know_damage(lore_ptr->r_idx, m))) {

--- a/src/view/display-lore-drops.cpp
+++ b/src/view/display-lore-drops.cpp
@@ -30,7 +30,7 @@ void display_monster_drop_quality(lore_type* lore_ptr)
         lore_ptr->sin = false;
 #endif
     } else {
-        lore_ptr->drop_quality = NULL;
+        lore_ptr->drop_quality = nullptr;
     }
 }
 
@@ -47,7 +47,7 @@ void display_monster_drop_items(lore_type *lore_ptr)
     lore_ptr->sin = false;
 #endif
 
-    if (lore_ptr->drop_quality != NULL)
+    if (lore_ptr->drop_quality != nullptr)
         hooked_roff(lore_ptr->drop_quality);
 
     hooked_roff(_("アイテム", " object"));
@@ -69,7 +69,7 @@ void display_monster_drop_golds(lore_type *lore_ptr)
 
 #ifdef JP
 #else
-    if (lore_ptr->drop_quality == NULL)
+    if (lore_ptr->drop_quality == nullptr)
         lore_ptr->sin = false;
 
     if (lore_ptr->sin)
@@ -78,7 +78,7 @@ void display_monster_drop_golds(lore_type *lore_ptr)
     lore_ptr->sin = false;
 #endif
 
-    if (lore_ptr->drop_quality != NULL)
+    if (lore_ptr->drop_quality != nullptr)
         hooked_roff(lore_ptr->drop_quality);
 
     hooked_roff(_("財宝", " treasure"));

--- a/src/view/display-messages.cpp
+++ b/src/view/display-messages.cpp
@@ -238,7 +238,7 @@ static void msg_flush(player_type *player_ptr, int x)
 
 void msg_erase(void)
 {
-    msg_print(NULL);
+    msg_print(nullptr);
 }
 
 /*!
@@ -259,11 +259,11 @@ void msg_erase(void)
  *
  * Note that we must be very careful about using the
  * "msg_print()" functions without explicitly calling the special
- * "msg_print(NULL)" function, since this may result in the loss
+ * "msg_print(nullptr)" function, since this may result in the loss
  * of information if the screen is cleared, or if anything is
  * displayed on the top line.
  *
- * Note that "msg_print(NULL)" will clear the top line
+ * Note that "msg_print(nullptr)" will clear the top line
  * even if no messages are pending.  This is probably a hack.
  * @todo ここのp_ptrを削除するのは破滅的に作業が増えるので保留
  */

--- a/src/view/display-scores.cpp
+++ b/src/view/display-scores.cpp
@@ -84,7 +84,7 @@ void display_scores(int from, int to, int note, high_score *score)
             if ((note == j) && score) {
                 the_score = (*score);
                 attr = TERM_L_GREEN;
-                score = NULL;
+                score = nullptr;
                 note = -1;
                 j--;
             } else if (highscore_seek(j) || highscore_read(&the_score)) {
@@ -216,9 +216,9 @@ void display_scores(int from, int to)
     }
     
     term_clear();
-    display_scores(from, to, -1, NULL);
+    display_scores(from, to, -1, nullptr);
     (void)fd_close(highscore_fd);
     highscore_fd = -1;
-    quit(NULL);
+    quit(nullptr);
 }
 #endif

--- a/src/view/status-bars-table.cpp
+++ b/src/view/status-bars-table.cpp
@@ -33,4 +33,4 @@ stat_bar stat_bars[MAX_STAT_BARS] = { { TERM_YELLOW, _("つ", "Ts"), _("つよ�
     { TERM_SLATE, _("宣", "Rv"), _("宣告", "Revenge") }, { TERM_L_DARK, _("剣", "Rs"), _("魔剣化", "RuneSword") },
     { TERM_RED, _("吸", "Vm"), _("吸血打撃", "Vampiric") }, { TERM_WHITE, _("回", "Cu"), _("回復", "Cure") },
     { TERM_L_DARK, _("感", "ET"), _("邪悪感知", "EvilTele") }, { TERM_VIOLET, _("視", "NSi"), _("暗視", "NgtSgt") },
-    { 0, NULL, NULL } };
+    { 0, nullptr, nullptr } };

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -146,7 +146,7 @@ static void print_monster_line(TERM_LEN x, TERM_LEN y, monster_type *m_ptr, int 
 void print_monster_list(floor_type *floor_ptr, const std::vector<MONSTER_IDX> &monster_list, TERM_LEN x, TERM_LEN y, TERM_LEN max_lines)
 {
     TERM_LEN line = y;
-    monster_type *last_mons = NULL;
+    monster_type *last_mons = nullptr;
     int n_same = 0;
     size_t i;
     for (i = 0; i < monster_list.size(); i++) {
@@ -514,18 +514,18 @@ void fix_object(player_type *player_ptr)
  * @brief 床上のモンスター情報を返す
  * @param floor_ptr 階の情報への参照ポインタ
  * @param grid_prt 座標グリッドの情報への参照ポインタ
- * @return モンスターが見える場合にはモンスター情報への参照ポインタ、それ以外はNULL
+ * @return モンスターが見える場合にはモンスター情報への参照ポインタ、それ以外はnullptr
  * @details
  * Lookコマンドでカーソルを合わせた場合に合わせてミミックは考慮しない。
  */
 static monster_type *monster_on_floor_items(const floor_type *floor_ptr, const grid_type *g_ptr)
 {
     if (g_ptr->m_idx == 0)
-        return NULL;
+        return nullptr;
 
     monster_type *m_ptr = &floor_ptr->m_list[g_ptr->m_idx];
     if (!monster_is_valid(m_ptr) || !m_ptr->ml)
-        return NULL;
+        return nullptr;
 
     return m_ptr;
 }
@@ -557,7 +557,7 @@ static void display_floor_item_list(player_type *player_ptr, const int y, const 
     // 先頭行を書く。
     if (player_bold(player_ptr, y, x))
         sprintf(line, _("(X:%03d Y:%03d) あなたの足元のアイテム一覧", "Items at (%03d,%03d) under you"), x, y);
-    else if (const auto *m_ptr = monster_on_floor_items(floor_ptr, g_ptr); m_ptr != NULL) {
+    else if (const auto *m_ptr = monster_on_floor_items(floor_ptr, g_ptr); m_ptr != nullptr) {
         if (player_ptr->image) {
             sprintf(line, _("(X:%03d Y:%03d) 何か奇妙な物の足元の発見済みアイテム一覧", "Found items at (%03d,%03d) under something strange"), x, y);
         } else {

--- a/src/window/main-window-util.cpp
+++ b/src/window/main-window-util.cpp
@@ -35,11 +35,11 @@ int feat_priority; /*!< マップ縮小表示時に表示すべき地形の優�
 
 static concptr simplify_list[][2] = {
 #ifdef JP
-    { "の魔法書", "" }, { NULL, NULL }
+    { "の魔法書", "" }, { nullptr, nullptr }
 #else
     { "^Ring of ", "=" }, { "^Amulet of ", "\"" }, { "^Scroll of ", "?" }, { "^Scroll titled ", "?" }, { "^Wand of ", "-" }, { "^Rod of ", "-" },
     { "^Staff of ", "_" }, { "^Potion of ", "!" }, { " Spellbook ", "" }, { "^Book of ", "" }, { " Magic [", "[" }, { " Book [", "[" }, { " Arts [", "[" },
-    { "^Set of ", "" }, { "^Pair of ", "" }, { NULL, NULL }
+    { "^Set of ", "" }, { "^Pair of ", "" }, { nullptr, nullptr }
 #endif
 };
 
@@ -215,7 +215,7 @@ void display_map(player_type *player_ptr, int *cy, int *cx)
     vector<vector<SYMBOL_CODE>> mc(hgt + 2, vector<SYMBOL_CODE>(wid + 2, ' '));
     vector<vector<byte>> mp(hgt + 2, vector<byte>(wid + 2, 0));
     vector<vector<int>> match_autopick_yx(hgt + 2, vector<int>(wid + 2, -1));
-    vector<vector<object_type *>> object_autopick_yx(hgt + 2, vector<object_type *>(wid + 2, NULL));
+    vector<vector<object_type *>> object_autopick_yx(hgt + 2, vector<object_type *>(wid + 2, nullptr));
 
     vector<vector<TERM_COLOR>> bigma(floor_ptr->height + 2, vector<TERM_COLOR>(floor_ptr->width + 2, TERM_WHITE));
     vector<vector<SYMBOL_CODE>> bigmc(floor_ptr->height + 2, vector<SYMBOL_CODE>(floor_ptr->width + 2, ' '));
@@ -227,7 +227,7 @@ void display_map(player_type *player_ptr, int *cy, int *cx)
             y = j / yrat + 1;
 
             match_autopick = -1;
-            autopick_obj = NULL;
+            autopick_obj = nullptr;
             feat_priority = -1;
             map_info(player_ptr, j, i, &ta, &tc, &ta, &tc);
             tp = (byte)feat_priority;

--- a/src/wizard/artifact-analyzer.cpp
+++ b/src/wizard/artifact-analyzer.cpp
@@ -78,7 +78,7 @@ static void analyze_pval(object_type *o_ptr, pval_info_type *pi_ptr)
     }
 
     affects_list = spoiler_flag_aux(flgs, pval_flags1_desc, affects_list, N_ELEMENTS(pval_flags1_desc));
-    *affects_list = NULL;
+    *affects_list = nullptr;
 }
 
 /*!
@@ -91,7 +91,7 @@ static void analyze_slay(object_type *o_ptr, concptr *slay_list)
 {
     auto flgs = object_flags(o_ptr);
     slay_list = spoiler_flag_aux(flgs, slay_flags_desc, slay_list, N_ELEMENTS(slay_flags_desc));
-    *slay_list = NULL;
+    *slay_list = nullptr;
 }
 
 /*!
@@ -104,7 +104,7 @@ static void analyze_brand(object_type *o_ptr, concptr *brand_list)
 {
     auto flgs = object_flags(o_ptr);
     brand_list = spoiler_flag_aux(flgs, brand_flags_desc, brand_list, N_ELEMENTS(brand_flags_desc));
-    *brand_list = NULL;
+    *brand_list = nullptr;
 }
 
 /*!
@@ -117,7 +117,7 @@ static void analyze_resist(object_type *o_ptr, concptr *resist_list)
 {
     auto flgs = object_flags(o_ptr);
     resist_list = spoiler_flag_aux(flgs, resist_flags_desc, resist_list, N_ELEMENTS(resist_flags_desc));
-    *resist_list = NULL;
+    *resist_list = nullptr;
 }
 
 /*!
@@ -130,7 +130,7 @@ static void analyze_immune(object_type *o_ptr, concptr *immune_list)
 {
     auto flgs = object_flags(o_ptr);
     immune_list = spoiler_flag_aux(flgs, immune_flags_desc, immune_list, N_ELEMENTS(immune_flags_desc));
-    *immune_list = NULL;
+    *immune_list = nullptr;
 }
 
 /*!
@@ -150,7 +150,7 @@ static void analyze_sustains(object_type *o_ptr, concptr *sustain_list)
         sustain_list = spoiler_flag_aux(flgs, sustain_flags_desc, sustain_list, N_ELEMENTS(sustain_flags_desc));
     }
 
-    *sustain_list = NULL;
+    *sustain_list = nullptr;
 }
 
 /*!
@@ -219,7 +219,7 @@ static void analyze_misc_magic(object_type *o_ptr, concptr *misc_list)
     if (has_flag(flgs, TR_ADD_H_CURSE))
         *misc_list++ = _("強力な呪いを増やす", "Heavily Cursing");
 
-    *misc_list = NULL;
+    *misc_list = nullptr;
 }
 
 /*!

--- a/src/wizard/fixed-artifacts-spoiler.cpp
+++ b/src/wizard/fixed-artifacts-spoiler.cpp
@@ -20,7 +20,7 @@
 void spoiler_outlist(concptr header, concptr *list, char separator)
 {
     char line[MAX_LINE_LEN + 20], buf[80];
-    if (*list == NULL)
+    if (*list == nullptr)
         return;
 
     strcpy(line, spoiler_indent);

--- a/src/wizard/items-spoiler.cpp
+++ b/src/wizard/items-spoiler.cpp
@@ -118,8 +118,8 @@ spoiler_output_status spoil_obj_desc(concptr fname)
                         PRICE t1;
                         PRICE t2;
 
-                        kind_info(&dummy, NULL, NULL, NULL, NULL, &e1, &t1, who[i1]);
-                        kind_info(&dummy, NULL, NULL, NULL, NULL, &e2, &t2, who[i2]);
+                        kind_info(&dummy, nullptr, nullptr, nullptr, nullptr, &e1, &t1, who[i1]);
+                        kind_info(&dummy, nullptr, nullptr, nullptr, nullptr, &e2, &t2, who[i2]);
 
                         if ((t1 > t2) || ((t1 == t2) && (e1 > e2))) {
                             uint16_t tmp = who[i1];

--- a/src/wizard/monster-info-spoiler.cpp
+++ b/src/wizard/monster-info-spoiler.cpp
@@ -252,7 +252,7 @@ spoiler_output_status spoil_mon_info(concptr fname)
         sprintf(buf, "Exp:%ld\n", (long)(r_ptr->mexp));
         spoil_out(buf);
         output_monster_spoiler(who[i], roff_func);
-        spoil_out(NULL);
+        spoil_out(nullptr);
     }
 
     C_KILL(who, max_r_idx, int16_t);

--- a/src/wizard/spoiler-table.cpp
+++ b/src/wizard/spoiler-table.cpp
@@ -1,10 +1,10 @@
 ﻿#include "wizard/spoiler-table.h"
 
 /* The basic items categorized by type */
-grouper group_item[MAX_GROUPER_ITEM] = { { TV_SHOT, _("射撃物", "Ammo") }, { TV_ARROW, NULL }, { TV_BOLT, NULL }, { TV_BOW, _("弓", "Bows") },
-    { TV_DIGGING, _("武器", "Weapons") }, { TV_POLEARM, NULL }, { TV_HAFTED, NULL }, { TV_SWORD, NULL }, { TV_SOFT_ARMOR, _("防具 (体)", "Armour (Body)") },
-    { TV_HARD_ARMOR, NULL }, { TV_DRAG_ARMOR, NULL }, { TV_BOOTS, _("防具 (その他)", "Armour (Misc)") }, { TV_GLOVES, NULL }, { TV_HELM, NULL },
-    { TV_CROWN, NULL }, { TV_SHIELD, NULL }, { TV_CLOAK, NULL },
+grouper group_item[MAX_GROUPER_ITEM] = { { TV_SHOT, _("射撃物", "Ammo") }, { TV_ARROW, nullptr }, { TV_BOLT, nullptr }, { TV_BOW, _("弓", "Bows") },
+    { TV_DIGGING, _("武器", "Weapons") }, { TV_POLEARM, nullptr }, { TV_HAFTED, nullptr }, { TV_SWORD, nullptr }, { TV_SOFT_ARMOR, _("防具 (体)", "Armour (Body)") },
+    { TV_HARD_ARMOR, nullptr }, { TV_DRAG_ARMOR, nullptr }, { TV_BOOTS, _("防具 (その他)", "Armour (Misc)") }, { TV_GLOVES, nullptr }, { TV_HELM, nullptr },
+    { TV_CROWN, nullptr }, { TV_SHIELD, nullptr }, { TV_CLOAK, nullptr },
 
     { TV_LITE, _("光源", "Light Sources") }, { TV_AMULET, _("アミュレット", "Amulets") }, { TV_RING, _("指輪", "Rings") }, { TV_STAFF, _("杖", "Staffs") },
     { TV_WAND, _("魔法棒", "Wands") }, { TV_ROD, _("ロッド", "Rods") }, { TV_SCROLL, _("巻物", "Scrolls") }, { TV_POTION, _("薬", "Potions") },
@@ -23,7 +23,7 @@ grouper group_item[MAX_GROUPER_ITEM] = { { TV_SHOT, _("射撃物", "Ammo") }, { 
 
     { TV_FIGURINE, _("人形", "Magical Figurines") }, { TV_STATUE, _("像", "Statues") }, { TV_CORPSE, _("死体", "Corpses") },
 
-    { TV_SKELETON, _("その他", "Misc") }, { TV_BOTTLE, NULL }, { TV_JUNK, NULL }, { TV_SPIKE, NULL }, { TV_FLASK, NULL }, { TV_PARCHMENT, NULL },
+    { TV_SKELETON, _("その他", "Misc") }, { TV_BOTTLE, nullptr }, { TV_JUNK, nullptr }, { TV_SPIKE, nullptr }, { TV_FLASK, nullptr }, { TV_PARCHMENT, nullptr },
 
     { TV_NONE, "" } };
 
@@ -35,24 +35,24 @@ grouper group_artifact[MAX_GROUPER_ARTIFACT] = {
     { TV_DIGGING, _("シャベル/つるはし", "Shovels/Picks") },
     { TV_BOW, _("飛び道具", "Bows") },
     { TV_ARROW, _("矢", "Ammo") },
-    { TV_BOLT, NULL },
+    { TV_BOLT, nullptr },
 
     { TV_SOFT_ARMOR, _("鎧", "Body Armor") },
-    { TV_HARD_ARMOR, NULL },
-    { TV_DRAG_ARMOR, NULL },
+    { TV_HARD_ARMOR, nullptr },
+    { TV_DRAG_ARMOR, nullptr },
 
     { TV_CLOAK, _("クローク", "Cloaks") },
     { TV_SHIELD, _("盾", "Shields") },
-    { TV_CARD, NULL },
+    { TV_CARD, nullptr },
     { TV_HELM, _("兜/冠", "Helms/Crowns") },
-    { TV_CROWN, NULL },
+    { TV_CROWN, nullptr },
     { TV_GLOVES, _("籠手", "Gloves") },
     { TV_BOOTS, _("靴", "Boots") },
 
     { TV_LITE, _("光源", "Light Sources") },
     { TV_AMULET, _("アミュレット", "Amulets") },
     { TV_RING, _("指輪", "Rings") },
-    { TV_NONE, NULL },
+    { TV_NONE, nullptr },
 };
 
 flag_desc stat_flags_desc[MAX_STAT_FLAGS_DESCRIPTION] = { { TR_STR, _("腕力", "STR") }, { TR_INT, _("知能", "INT") }, { TR_WIS, _("賢さ", "WIS") },

--- a/src/wizard/spoiler-util.cpp
+++ b/src/wizard/spoiler-util.cpp
@@ -6,7 +6,7 @@ const int max_evolution_depth = 64;
 concptr spoiler_indent = "    ";
 
 /* The spoiler file being created */
-FILE *spoiler_file = NULL;
+FILE *spoiler_file = nullptr;
 
 /*!
  * @brief ファイルポインタ先に同じ文字を複数出力する /
@@ -56,7 +56,7 @@ void spoil_out(concptr str)
 #endif
 
     static char *roff_p = roff_buf;
-    static char *roff_s = NULL;
+    static char *roff_s = nullptr;
     static bool waiting_output = false;
     if (!str) {
         if (waiting_output) {
@@ -77,7 +77,7 @@ void spoil_out(concptr str)
         }
 
         roff_p = roff_buf;
-        roff_s = NULL;
+        roff_s = nullptr;
         roff_buf[0] = '\0';
         return;
     }
@@ -170,7 +170,7 @@ void spoil_out(concptr str)
             else
                 strcpy(roff_waiting_buf, roff_buf);
 
-            roff_s = NULL;
+            roff_s = nullptr;
             roff_p = roff_buf;
 #ifdef JP
             if (cbak != ' ')

--- a/src/wizard/spoiler-util.h
+++ b/src/wizard/spoiler-util.h
@@ -37,7 +37,7 @@ typedef struct obj_desc_list {
     concptr misc_magic[N_ELEMENTS(misc_flags2_desc) + N_ELEMENTS(misc_flags3_desc) + 1 /* Permanent Light */
         + 1 /* TY curse */
         + 1 /* type of curse */
-        + 1]; /* sentinel NULL */
+        + 1]; /* sentinel nullptr */
 
     char addition[80]; /* Additional ability or resistance */
     concptr activation; /* A string describing an artifact's activation */

--- a/src/wizard/tval-descriptions-table.cpp
+++ b/src/wizard/tval-descriptions-table.cpp
@@ -14,7 +14,7 @@ tval_desc tvals[MAX_TVAL_DESCRIPTIONS] = { { TV_SWORD, "Sword" }, { TV_POLEARM, 
     { TV_CRUSADE_BOOK, "Crusade Spellbook" }, { TV_MUSIC_BOOK, "Music Spellbook" }, { TV_HISSATSU_BOOK, "Book of Kendo" }, { TV_HEX_BOOK, "Hex Spellbook" },
     { TV_PARCHMENT, "Parchment" }, { TV_WHISTLE, "Whistle" }, { TV_SPIKE, "Spikes" }, { TV_DIGGING, "Digger" }, { TV_CHEST, "Chest" },
     { TV_CAPTURE, "Capture Ball" }, { TV_CARD, "Express Card" }, { TV_FIGURINE, "Magical Figurine" }, { TV_STATUE, "Statue" }, { TV_CORPSE, "Corpse" },
-    { TV_FOOD, "Food" }, { TV_FLASK, "Flask" }, { TV_JUNK, "Junk" }, { TV_SKELETON, "Skeleton" }, { 0, NULL } };
+    { TV_FOOD, "Food" }, { TV_FLASK, "Flask" }, { TV_JUNK, "Junk" }, { TV_SKELETON, "Skeleton" }, { 0, nullptr } };
 
 /*!
  * 選択処理用キーコード /

--- a/src/wizard/wizard-game-modifier.cpp
+++ b/src/wizard/wizard-game-modifier.cpp
@@ -131,7 +131,7 @@ void wiz_complete_quest(player_type *creature_ptr)
 {
     if (!creature_ptr->current_floor_ptr->inside_quest) {
         msg_print("No current quest");
-        msg_print(NULL);
+        msg_print(nullptr);
         return;
     }
 
@@ -158,7 +158,7 @@ void wiz_restore_monster_max_num()
     monster_race *r_ptr = &r_info[r_idx];
     if (r_ptr->name.empty()) {
         msg_print("そのモンスターは存在しません。");
-        msg_print(NULL);
+        msg_print(nullptr);
         return;
     }
 
@@ -170,7 +170,7 @@ void wiz_restore_monster_max_num()
 
     if (n == 0) {
         msg_print("出現数に制限がないモンスターです。");
-        msg_print(NULL);
+        msg_print(nullptr);
         return;
     }
 
@@ -181,5 +181,5 @@ void wiz_restore_monster_max_num()
     std::stringstream ss;
     ss << r_ptr->name << _("の出現数を復元しました。", " can appear again now.");
     msg_print(ss.str().c_str());
-    msg_print(NULL);
+    msg_print(nullptr);
 }

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -431,7 +431,7 @@ static void wiz_statistics(player_type *caster_ptr, object_type *o_ptr)
             test_roll = atol(tmp_val);
         test_roll = MAX(1, test_roll);
         msg_format("Creating a lot of %s items. Base level = %d.", quality, caster_ptr->current_floor_ptr->dun_level);
-        msg_print(NULL);
+        msg_print(nullptr);
 
         correct = matches = better = worse = other = 0;
         for (i = 0; i <= test_roll; i++) {
@@ -470,7 +470,7 @@ static void wiz_statistics(player_type *caster_ptr, object_type *o_ptr)
         }
 
         msg_format(q, i, correct, matches, better, worse, other);
-        msg_print(NULL);
+        msg_print(nullptr);
     }
 
     if (o_ptr->is_fixed_artifact())
@@ -755,7 +755,7 @@ WishResult do_cmd_wishing(player_type *caster_ptr, int prob, bool allow_art, boo
         "corrodeproof",
         "fixed",
 #endif
-        NULL,
+        nullptr,
     };
 
     char buf[MAX_NLEN] = "\0";
@@ -801,7 +801,7 @@ WishResult do_cmd_wishing(player_type *caster_ptr, int prob, bool allow_art, boo
         blessed = true;
     }
 
-    for (int i = 0; fixed_str[i] != NULL; i++) {
+    for (int i = 0; fixed_str[i] != nullptr; i++) {
         int len = strlen(fixed_str[i]);
         if (!strncmp(str, fixed_str[i], len)) {
             str = ltrim(str + len);

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -589,9 +589,9 @@ void wiz_dump_options(void)
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, "opt_info.txt");
     FILE *fff;
     fff = angband_fopen(buf, "a");
-    if (fff == NULL) {
+    if (fff == nullptr) {
         msg_format(_("ファイル %s を開けませんでした。", "Failed to open file %s."), buf);
-        msg_print(NULL);
+        msg_print(nullptr);
         return;
     }
 
@@ -703,7 +703,7 @@ void cheat_death(player_type *creature_ptr)
 
     current_world_ptr->noscore |= 0x0001;
     msg_print(_("ウィザードモードに念を送り、死を欺いた。", "You invoke wizard mode and cheat death."));
-    msg_print(NULL);
+    msg_print(nullptr);
 
     creature_ptr->is_dead = false;
     (void)life_stream(creature_ptr, false, false);

--- a/src/wizard/wizard-spoiler.cpp
+++ b/src/wizard/wizard-spoiler.cpp
@@ -150,7 +150,7 @@ static spoiler_output_status spoil_mon_evol(concptr fname)
         }
     }
 
-    ang_sort(&dummy, evol_tree, NULL, max_r_idx, ang_sort_comp_evol_tree, ang_sort_swap_evol_tree);
+    ang_sort(&dummy, evol_tree, nullptr, max_r_idx, ang_sort_comp_evol_tree, ang_sort_swap_evol_tree);
     for (i = 0; i < max_r_idx; i++) {
         r_idx = evol_tree[i][0];
         if (!r_idx)

--- a/src/world/world-movement-processor.cpp
+++ b/src/world/world-movement-processor.cpp
@@ -69,7 +69,7 @@ void execute_recall(player_type *creature_ptr)
         if (creature_ptr->dungeon_idx)
             creature_ptr->recall_dungeon = creature_ptr->dungeon_idx;
         if (record_stair)
-            exe_write_diary(creature_ptr, DIARY_RECALL, floor_ptr->dun_level, NULL);
+            exe_write_diary(creature_ptr, DIARY_RECALL, floor_ptr->dun_level, nullptr);
 
         floor_ptr->dun_level = 0;
         creature_ptr->dungeon_idx = 0;
@@ -84,7 +84,7 @@ void execute_recall(player_type *creature_ptr)
     msg_print(_("下に引きずり降ろされる感じがする！", "You feel yourself yanked downwards!"));
     creature_ptr->dungeon_idx = creature_ptr->recall_dungeon;
     if (record_stair)
-        exe_write_diary(creature_ptr, DIARY_RECALL, floor_ptr->dun_level, NULL);
+        exe_write_diary(creature_ptr, DIARY_RECALL, floor_ptr->dun_level, nullptr);
 
     floor_ptr->dun_level = max_dlv[creature_ptr->dungeon_idx];
     if (floor_ptr->dun_level < 1)

--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -78,7 +78,7 @@ void WorldTurnProcessor::process_world()
     process_world_monsters();
     if (!this->hour && !this->min) {
         if (this->min != prev_min) {
-            exe_write_diary(this->player_ptr, DIARY_DIALY, 0, NULL);
+            exe_write_diary(this->player_ptr, DIARY_DIALY, 0, nullptr);
             determine_daily_bounty(this->player_ptr, false);
         }
     }
@@ -151,7 +151,7 @@ void WorldTurnProcessor::process_monster_arena()
 
     if (number_mon == 0) {
         msg_print(_("相打ちに終わりました。", "Nothing survived."));
-        msg_print(NULL);
+        msg_print(nullptr);
         this->player_ptr->energy_need = 0;
         update_gambling_monsters(this->player_ptr);
         return;
@@ -171,7 +171,7 @@ void WorldTurnProcessor::process_monster_arena_winner(int win_m_idx)
     auto *wm_ptr = &this->player_ptr->current_floor_ptr->m_list[win_m_idx];
     monster_desc(this->player_ptr, m_name, wm_ptr, 0);
     msg_format(_("%sが勝利した！", "%s won!"), m_name);
-    msg_print(NULL);
+    msg_print(nullptr);
 
     if (win_m_idx == (sel_monster + 1)) {
         msg_print(_("おめでとうございます。", "Congratulations."));
@@ -181,7 +181,7 @@ void WorldTurnProcessor::process_monster_arena_winner(int win_m_idx)
         msg_print(_("残念でした。", "You lost gold."));
     }
 
-    msg_print(NULL);
+    msg_print(nullptr);
     this->player_ptr->energy_need = 0;
     update_gambling_monsters(this->player_ptr);
 }
@@ -195,7 +195,7 @@ void WorldTurnProcessor::process_monster_arena_draw()
 
     msg_print(_("申し訳ありませんが、この勝負は引き分けとさせていただきます。", "Sorry, but this battle ended in a draw."));
     this->player_ptr->au += kakekin;
-    msg_print(NULL);
+    msg_print(nullptr);
     this->player_ptr->energy_need = 0;
     update_gambling_monsters(this->player_ptr);
 }

--- a/src/world/world.cpp
+++ b/src/world/world.cpp
@@ -55,7 +55,7 @@ void extract_day_hour_min(player_type *player_ptr, int *day, int *hour, int *min
 void update_playtime(void)
 {
     if (current_world_ptr->start_time != 0) {
-        uint32_t tmp = (uint32_t)time(NULL);
+        uint32_t tmp = (uint32_t)time(nullptr);
         current_world_ptr->play_time += (tmp - current_world_ptr->start_time);
         current_world_ptr->start_time = tmp;
     }


### PR DESCRIPTION
掲題の通りです
間に合ったので投下します

以下の文字列を順番に置換していき、残ったものを全文grepで調査しました
結果、リソースやリテラルで"NULL" が使われている箇所は見つかりませんでした
- '(NULL)'
- 'NULL;'
- '= NULL'
- '(NULL, '
- ', NULL, '
- ', NULL)'
- '{ NULL, '
- ', NULL }'

このため、「NULL」を全て「nullptr」へ機械置換し、その後Win32API部分だけをNULLに戻しました
ご確認下さい
備考1：VS2019の置換機能は単語の厳密な一致を検出できるので、例えば「MON_NULL」は置換対象にならない
備考2：Doxygen等のコメント類はどっちでもいいので、Win32API関係以外は無視した