### PR TITLE
grid-type.cpp/h のリファクタリング＆メソッド移動

### DIFF
--- a/src/grid/feature.cpp
+++ b/src/grid/feature.cpp
@@ -196,9 +196,9 @@ FEAT_IDX feat_jammed_door_random(int door_type)
  */
 void cave_set_feat(player_type *player_ptr, POSITION y, POSITION x, FEAT_IDX feat)
 {
-    floor_type *floor_ptr = player_ptr->current_floor_ptr;
-    grid_type *g_ptr = &floor_ptr->grid_array[y][x];
-    feature_type *f_ptr = &f_info[feat];
+    auto *floor_ptr = player_ptr->current_floor_ptr;
+    auto *g_ptr = &floor_ptr->grid_array[y][x];
+    auto *f_ptr = &f_info[feat];
     if (!current_world_ptr->character_dungeon) {
         g_ptr->mimic = 0;
         g_ptr->feat = feat;
@@ -206,8 +206,9 @@ void cave_set_feat(player_type *player_ptr, POSITION y, POSITION x, FEAT_IDX fea
             for (DIRECTION i = 0; i < 9; i++) {
                 POSITION yy = y + ddy_ddd[i];
                 POSITION xx = x + ddx_ddd[i];
-                if (!in_bounds2(floor_ptr, yy, xx))
+                if (!in_bounds2(floor_ptr, yy, xx)) {
                     continue;
+                }
 
                 floor_ptr->grid_array[yy][xx].info |= CAVE_GLOW;
             }
@@ -224,38 +225,45 @@ void cave_set_feat(player_type *player_ptr, POSITION y, POSITION x, FEAT_IDX fea
     g_ptr->info &= ~(CAVE_OBJECT);
     if (old_mirror && d_info[floor_ptr->dungeon_idx].flags.has(DF::DARKNESS)) {
         g_ptr->info &= ~(CAVE_GLOW);
-        if (!view_torch_grids)
+        if (!view_torch_grids) {
             g_ptr->info &= ~(CAVE_MARK);
+        }
 
         update_local_illumination(player_ptr, y, x);
     }
 
-    if (f_ptr->flags.has_not(FF::REMEMBER))
+    if (f_ptr->flags.has_not(FF::REMEMBER)) {
         g_ptr->info &= ~(CAVE_MARK);
-    if (g_ptr->m_idx)
+    }
+
+    if (g_ptr->m_idx) {
         update_monster(player_ptr, g_ptr->m_idx, false);
+    }
 
     note_spot(player_ptr, y, x);
     lite_spot(player_ptr, y, x);
-    if (old_los ^ f_ptr->flags.has(FF::LOS))
+    if (old_los ^ f_ptr->flags.has(FF::LOS)) {
         player_ptr->update |= PU_VIEW | PU_LITE | PU_MON_LITE | PU_MONSTERS;
+    }
 
-    if (f_ptr->flags.has_not(FF::GLOW) || d_info[player_ptr->dungeon_idx].flags.has(DF::DARKNESS))
+    if (f_ptr->flags.has_not(FF::GLOW) || d_info[player_ptr->dungeon_idx].flags.has(DF::DARKNESS)) {
         return;
+    }
 
-    for (DIRECTION i = 0; i < 9; i++) {
+    for (auto i = 0; i < 9; i++) {
         POSITION yy = y + ddy_ddd[i];
         POSITION xx = x + ddx_ddd[i];
-        if (!in_bounds2(floor_ptr, yy, xx))
+        if (!in_bounds2(floor_ptr, yy, xx)) {
             continue;
+        }
 
-        grid_type *cc_ptr;
-        cc_ptr = &floor_ptr->grid_array[yy][xx];
+        auto *cc_ptr = &floor_ptr->grid_array[yy][xx];
         cc_ptr->info |= CAVE_GLOW;
-
         if (cc_ptr->is_view()) {
-            if (cc_ptr->m_idx)
+            if (cc_ptr->m_idx) {
                 update_monster(player_ptr, cc_ptr->m_idx, false);
+            }
+
             note_spot(player_ptr, yy, xx);
             lite_spot(player_ptr, yy, xx);
         }
@@ -264,8 +272,9 @@ void cave_set_feat(player_type *player_ptr, POSITION y, POSITION x, FEAT_IDX fea
     }
 
     if (player_ptr->special_defense & NINJA_S_STEALTH) {
-        if (floor_ptr->grid_array[player_ptr->y][player_ptr->x].info & CAVE_GLOW)
+        if (floor_ptr->grid_array[player_ptr->y][player_ptr->x].info & CAVE_GLOW) {
             set_superstealth(player_ptr, false);
+        }
     }
 }
 

--- a/src/grid/feature.cpp
+++ b/src/grid/feature.cpp
@@ -192,12 +192,6 @@ FEAT_IDX feat_jammed_door_random(int door_type)
 }
 
 /*
- * Determine if a "legal" grid is within "los" of the player *
- * Note the use of comparison to zero to force a "boolean" result
- */
-static bool player_has_los_grid(grid_type *g_ptr) { return (g_ptr->info & CAVE_VIEW) != 0; }
-
-/*
  * Change the "feat" flag for a grid, and notice/redraw the grid
  */
 void cave_set_feat(player_type *player_ptr, POSITION y, POSITION x, FEAT_IDX feat)
@@ -259,7 +253,7 @@ void cave_set_feat(player_type *player_ptr, POSITION y, POSITION x, FEAT_IDX fea
         cc_ptr = &floor_ptr->grid_array[yy][xx];
         cc_ptr->info |= CAVE_GLOW;
 
-        if (player_has_los_grid(cc_ptr)) {
+        if (cc_ptr->is_view()) {
             if (cc_ptr->m_idx)
                 update_monster(player_ptr, cc_ptr->m_idx, false);
             note_spot(player_ptr, yy, xx);

--- a/src/system/grid-type-definition.cpp
+++ b/src/system/grid-type-definition.cpp
@@ -10,67 +10,67 @@
  * @param X 指定X座標
  * @return FLOOR属性を持っているならばTRUE
  */
-bool grid_type::is_floor()
+bool grid_type::is_floor() const
 {
     return any_bits(this->info, CAVE_FLOOR);
 }
 
-bool grid_type::is_room()
+bool grid_type::is_room() const
 {
     return any_bits(this->info, CAVE_ROOM);
 }
 
-bool grid_type::is_extra()
+bool grid_type::is_extra() const
 {
     return any_bits(this->info, CAVE_EXTRA);
 }
 
-bool grid_type::is_inner()
+bool grid_type::is_inner() const
 {
     return any_bits(this->info, CAVE_INNER);
 }
 
-bool grid_type::is_outer()
+bool grid_type::is_outer() const
 {
     return any_bits(this->info, CAVE_OUTER);
 }
 
-bool grid_type::is_solid()
+bool grid_type::is_solid() const
 {
     return any_bits(this->info, CAVE_SOLID);
 }
 
-bool grid_type::is_icky()
+bool grid_type::is_icky() const
 {
     return any_bits(this->info, CAVE_ICKY);
 }
 
-bool grid_type::is_lite()
+bool grid_type::is_lite() const
 {
     return any_bits(this->info, CAVE_LITE);
 }
 
-bool grid_type::is_redraw()
+bool grid_type::is_redraw() const
 {
     return any_bits(this->info, CAVE_REDRAW);
 }
 
-bool grid_type::is_view()
+bool grid_type::is_view() const
 {
     return any_bits(this->info, CAVE_VIEW);
 }
 
-bool grid_type::is_object()
+bool grid_type::is_object() const
 {
     return any_bits(this->info, CAVE_OBJECT);
 }
 
-bool grid_type::is_mark()
+bool grid_type::is_mark() const
 {
     return any_bits(this->info, CAVE_MARK);
 }
 
-bool grid_type::is_mirror()
+bool grid_type::is_mirror() const
 {
     return this->is_object() && f_info[this->mimic].flags.has(FF::MIRROR);
 }
@@ -78,7 +78,7 @@ bool grid_type::is_mirror()
 /*
  *  @brief 守りのルーンで守られているかを返す
  */
-bool grid_type::is_rune_protection()
+bool grid_type::is_rune_protection() const
 {
     return this->is_object() && f_info[this->mimic].flags.has(FF::RUNE_PROTECTION);
 }
@@ -86,22 +86,22 @@ bool grid_type::is_rune_protection()
 /*
  *  @brief 爆発のルーンが仕掛けられているかを返す
  */
-bool grid_type::is_rune_explosion()
+bool grid_type::is_rune_explosion() const
 {
     return this->is_object() && f_info[this->mimic].flags.has(FF::RUNE_EXPLOSION);
 }
 
-byte grid_type::get_cost(monster_race *r_ptr)
+byte grid_type::get_cost(monster_race *r_ptr) const
 {
     return this->costs[get_grid_flow_type(r_ptr)];
 }
 
-byte grid_type::get_distance(monster_race *r_ptr)
+byte grid_type::get_distance(monster_race *r_ptr) const
 {
     return this->dists[get_grid_flow_type(r_ptr)];
 }
 
-flow_type grid_type::get_grid_flow_type(monster_race *r_ptr)
+flow_type grid_type::get_grid_flow_type(monster_race *r_ptr) const
 {
     return any_bits(r_ptr->flags7, RF7_CAN_FLY) ? FLOW_CAN_FLY : FLOW_NORMAL;
 }
@@ -111,12 +111,12 @@ flow_type grid_type::get_grid_flow_type(monster_race *r_ptr)
  * @param g_ptr グリッドへの参照ポインタ
  * @return 地形情報
  */
-FEAT_IDX grid_type::get_feat_mimic()
+FEAT_IDX grid_type::get_feat_mimic() const
 {
     return f_info[this->mimic ? this->mimic : this->feat].mimic;
 }
 
-bool grid_type::cave_has_flag(FF feature_flags)
+bool grid_type::cave_has_flag(FF feature_flags) const
 {
     return f_info[this->feat].flags.has(feature_flags);
 }
@@ -126,7 +126,7 @@ bool grid_type::cave_has_flag(FF feature_flags)
  * @param ch 指定するシンボル文字
  * @return シンボルが指定した記号か否か
  */
-bool grid_type::is_symbol(const int ch)
+bool grid_type::is_symbol(const int ch) const
 {
     return f_info[this->feat].x_char[0] == ch;
 }

--- a/src/system/grid-type-definition.cpp
+++ b/src/system/grid-type-definition.cpp
@@ -120,3 +120,13 @@ bool grid_type::cave_has_flag(FF feature_flags)
 {
     return f_info[this->feat].flags.has(feature_flags);
 }
+
+/*!
+ * @brief グリッドのシンボルが指定した記号かどうかを調べる
+ * @param ch 指定するシンボル文字
+ * @return シンボルが指定した記号か否か
+ */
+bool grid_type::is_symbol(const int ch)
+{
+    return f_info[this->feat].x_char[0] == ch;
+}

--- a/src/system/grid-type-definition.h
+++ b/src/system/grid-type-definition.h
@@ -67,27 +67,27 @@ public:
     byte dists[FLOW_MAX]{}; /* Hack -- distance from player */
     byte when{}; /* Hack -- when cost was computed */
 
-    bool is_floor();
-    bool is_room();
-    bool is_extra();
-    bool is_inner();
-    bool is_outer();
-    bool is_solid();
-    bool is_icky();
-    bool is_lite();
-    bool is_redraw();
-    bool is_view();
-    bool is_object();
-    bool is_mark();
-    bool is_mirror();
-    bool is_rune_protection();
-    bool is_rune_explosion();
-    byte get_cost(monster_race *r_ptr);
-    byte get_distance(monster_race *r_ptr);
-    FEAT_IDX get_feat_mimic();
-    bool cave_has_flag(FF feature_flags);
-    bool is_symbol(const int ch);
+    bool is_floor() const;
+    bool is_room() const;
+    bool is_extra() const;
+    bool is_inner() const;
+    bool is_outer() const;
+    bool is_solid() const;
+    bool is_icky() const;
+    bool is_lite() const;
+    bool is_redraw() const;
+    bool is_view() const;
+    bool is_object() const;
+    bool is_mark() const;
+    bool is_mirror() const;
+    bool is_rune_protection() const;
+    bool is_rune_explosion() const;
+    byte get_cost(monster_race *r_ptr) const;
+    byte get_distance(monster_race *r_ptr) const;
+    FEAT_IDX get_feat_mimic() const;
+    bool cave_has_flag(FF feature_flags) const;
+    bool is_symbol(const int ch) const;
 
 private:
-    flow_type get_grid_flow_type(monster_race *r_ptr);
+    flow_type get_grid_flow_type(monster_race *r_ptr) const;
 };

--- a/src/system/grid-type-definition.h
+++ b/src/system/grid-type-definition.h
@@ -86,6 +86,7 @@ public:
     byte get_distance(monster_race *r_ptr);
     FEAT_IDX get_feat_mimic();
     bool cave_has_flag(FF feature_flags);
+    bool is_symbol(const int ch);
 
 private:
     flow_type get_grid_flow_type(monster_race *r_ptr);

--- a/src/target/grid-selector.cpp
+++ b/src/target/grid-selector.cpp
@@ -80,33 +80,22 @@ static void tgt_pt_prepare(player_type *creature_ptr, std::vector<POSITION> &ys,
 }
 
 /*!
- * @brief グリッドのシンボルが指定した記号かどうかを調べる
- * @param g_ptr グリッド情報への参照ポインタ
- * @param ch 指定するシンボル文字
- * @return シンボルが指定した記号ならTRUE、そうでなければFALSE
- */
-static bool cave_is_symbol_grid(grid_type *g_ptr, char ch)
-{
-    return f_info[g_ptr->feat].x_char[0] == ch;
-}
-
-/*!
  * @brief 指定したシンボルのマスかどうかを判定するための条件式コールバック
  */
 std::unordered_map<int, std::function<bool(grid_type *)>> tgt_pt_symbol_call_back = {
     { '<', [](grid_type *g_ptr) { return g_ptr->cave_has_flag(FF::STAIRS) && g_ptr->cave_has_flag(FF::LESS); } },
     { '>', [](grid_type *g_ptr) { return g_ptr->cave_has_flag(FF::STAIRS) && g_ptr->cave_has_flag(FF::MORE); } },
     { '+', [](grid_type *g_ptr) { return g_ptr->cave_has_flag(FF::BLDG); } },
-    { '0', [](grid_type *g_ptr) { return g_ptr->cave_has_flag(FF::STORE) && cave_is_symbol_grid(g_ptr, '0'); } },
-    { '!', [](grid_type *g_ptr) { return g_ptr->cave_has_flag(FF::STORE) && cave_is_symbol_grid(g_ptr, '1'); } },
-    { '"', [](grid_type *g_ptr) { return g_ptr->cave_has_flag(FF::STORE) && cave_is_symbol_grid(g_ptr, '2'); } },
-    { '#', [](grid_type *g_ptr) { return g_ptr->cave_has_flag(FF::STORE) && cave_is_symbol_grid(g_ptr, '3'); } },
-    { '$', [](grid_type *g_ptr) { return g_ptr->cave_has_flag(FF::STORE) && cave_is_symbol_grid(g_ptr, '4'); } },
-    { '%', [](grid_type *g_ptr) { return g_ptr->cave_has_flag(FF::STORE) && cave_is_symbol_grid(g_ptr, '5'); } },
-    { '&', [](grid_type *g_ptr) { return g_ptr->cave_has_flag(FF::STORE) && cave_is_symbol_grid(g_ptr, '6'); } },
-    { '\'', [](grid_type *g_ptr) { return g_ptr->cave_has_flag(FF::STORE) && cave_is_symbol_grid(g_ptr, '7'); } },
-    { '(', [](grid_type *g_ptr) { return g_ptr->cave_has_flag(FF::STORE) && cave_is_symbol_grid(g_ptr, '8'); } },
-    { ')', [](grid_type *g_ptr) { return g_ptr->cave_has_flag(FF::STORE) && cave_is_symbol_grid(g_ptr, '9'); } },
+    { '0', [](grid_type *g_ptr) { return g_ptr->cave_has_flag(FF::STORE) && g_ptr->is_symbol('0'); } },
+    { '!', [](grid_type *g_ptr) { return g_ptr->cave_has_flag(FF::STORE) && g_ptr->is_symbol('1'); } },
+    { '"', [](grid_type *g_ptr) { return g_ptr->cave_has_flag(FF::STORE) && g_ptr->is_symbol('2'); } },
+    { '#', [](grid_type *g_ptr) { return g_ptr->cave_has_flag(FF::STORE) && g_ptr->is_symbol('3'); } },
+    { '$', [](grid_type *g_ptr) { return g_ptr->cave_has_flag(FF::STORE) && g_ptr->is_symbol('4'); } },
+    { '%', [](grid_type *g_ptr) { return g_ptr->cave_has_flag(FF::STORE) && g_ptr->is_symbol('5'); } },
+    { '&', [](grid_type *g_ptr) { return g_ptr->cave_has_flag(FF::STORE) && g_ptr->is_symbol('6'); } },
+    { '\'', [](grid_type *g_ptr) { return g_ptr->cave_has_flag(FF::STORE) && g_ptr->is_symbol('7'); } },
+    { '(', [](grid_type *g_ptr) { return g_ptr->cave_has_flag(FF::STORE) && g_ptr->is_symbol('8'); } },
+    { ')', [](grid_type *g_ptr) { return g_ptr->cave_has_flag(FF::STORE) && g_ptr->is_symbol('9'); } },
 };
 
 /*!

--- a/src/target/grid-selector.cpp
+++ b/src/target/grid-selector.cpp
@@ -9,7 +9,6 @@
 #include "game-option/input-options.h"
 #include "game-option/keymap-directory-getter.h"
 #include "grid/feature-flag-types.h"
-#include "grid/feature.h"
 #include "io/cursor.h"
 #include "io/input-key-acceptor.h"
 #include "io/screen-util.h"
@@ -114,48 +113,51 @@ struct tgt_pt_info {
     char ch; //<! 入力キー
     char prev_ch; //<! 前回入力キー
     std::function<bool(grid_type *)> callback; //<! 条件判定コールバック
+
+    void move_to_symbol(player_type *creature_ptr);
 };
 
 /*!
  * @brief 指定した記号のシンボルのグリッドにカーソルを移動する
  * @param creature_ptr プレイヤー情報への参照ポインタ
- * @param info 位置ターゲット指定情報構造体(参照渡し)
+ * @details 自分 (＠)の位置に戻ってくるような処理に見える.
+ * コールバックにも依る？
  */
-void tgt_pt_move_to_symbol(player_type *creature_ptr, tgt_pt_info &info)
+void tgt_pt_info::move_to_symbol(player_type *creature_ptr)
 {
-    if (!expand_list || info.ys.empty())
+    if (!expand_list || this->ys.empty())
         return;
 
     int dx, dy;
     int cx = (panel_col_min + panel_col_max) / 2;
     int cy = (panel_row_min + panel_row_max) / 2;
-    if (info.ch != info.prev_ch)
-        info.n = 0;
-    info.prev_ch = info.ch;
-    info.n++;
+    if (this->ch != this->prev_ch)
+        this->n = 0;
+    this->prev_ch = this->ch;
+    this->n++;
 
-    for (; info.n < size(info.ys); ++info.n) {
-        const POSITION y_cur = info.ys[info.n];
-        const POSITION x_cur = info.xs[info.n];
+    for (; this->n < size(this->ys); ++this->n) {
+        const POSITION y_cur = this->ys[this->n];
+        const POSITION x_cur = this->xs[this->n];
         grid_type *g_ptr = &creature_ptr->current_floor_ptr->grid_array[y_cur][x_cur];
-        if (info.callback(g_ptr))
+        if (this->callback(g_ptr))
             break;
     }
 
-    if (info.n == size(info.ys)) {
-        info.n = 0;
-        info.y = creature_ptr->y;
-        info.x = creature_ptr->x;
+    if (this->n == size(this->ys)) {
+        this->n = 0;
+        this->y = creature_ptr->y;
+        this->x = creature_ptr->x;
         verify_panel(creature_ptr);
         creature_ptr->update |= PU_MONSTERS;
         creature_ptr->redraw |= PR_MAP;
         creature_ptr->window_flags |= PW_OVERHEAD;
         handle_stuff(creature_ptr);
     } else {
-        info.y = info.ys[info.n];
-        info.x = info.xs[info.n];
-        dy = 2 * (info.y - cy) / info.hgt;
-        dx = 2 * (info.x - cx) / info.wid;
+        this->y = this->ys[this->n];
+        this->x = this->xs[this->n];
+        dy = 2 * (this->y - cy) / this->hgt;
+        dx = 2 * (this->x - cx) / this->wid;
         if (dy || dx)
             change_panel(creature_ptr, dy, dx);
     }
@@ -212,7 +214,7 @@ bool tgt_pt(player_type *creature_ptr, POSITION *x_ptr, POSITION *y_ptr)
         case '(':
         case ')': {
             info.callback = tgt_pt_symbol_call_back[info.ch];
-            tgt_pt_move_to_symbol(creature_ptr, info);
+            info.move_to_symbol(creature_ptr);
             break;
         }
         default: {
@@ -221,7 +223,7 @@ bool tgt_pt(player_type *creature_ptr, POSITION *x_ptr, POSITION *y_ptr)
                     if (info.ch != '0')
                         info.ch -= 16;
                     info.callback = tgt_pt_symbol_call_back[info.ch];
-                    tgt_pt_move_to_symbol(creature_ptr, info);
+                    info.move_to_symbol(creature_ptr);
                     break;
                 }
             } else {


### PR DESCRIPTION
現在grid_type 構造体に実装されているメソッド群は全てconst関数なのでconstを付けました
更にis_symbol() をgrid-selector.cpp/h から移してきました
ご確認下さい
(ついでですが、関連するメソッドtgt_pt_move_to_symbol() をtgt_ptr_into 構造体に押し込みました)