### PR TITLE
spells-hex.cpp/h のクラス化＆メソッド分割

### DIFF
--- a/src/action/activation-execution.cpp
+++ b/src/action/activation-execution.cpp
@@ -184,8 +184,9 @@ static bool activate_whistle(player_type *user_ptr, ae_type *ae_ptr)
     if (music_singing_any(user_ptr))
         stop_singing(user_ptr);
 
-    if (hex_spelling_any(user_ptr))
-        stop_hex_spell_all(user_ptr);
+    if (hex_spelling_any(user_ptr)) {
+        (void)RealmHex(user_ptr).stop_hex_spell_all();
+    }
 
     MONSTER_IDX pet_ctr;
     MONSTER_IDX *who;

--- a/src/action/activation-execution.cpp
+++ b/src/action/activation-execution.cpp
@@ -184,8 +184,8 @@ static bool activate_whistle(player_type *user_ptr, ae_type *ae_ptr)
     if (music_singing_any(user_ptr))
         stop_singing(user_ptr);
 
-    if (RealmHex(user_ptr).hex_spelling_any()) {
-        (void)RealmHex(user_ptr).stop_hex_spell_all();
+    if (RealmHex(user_ptr).is_spelling_any()) {
+        (void)RealmHex(user_ptr).stop_all_spells();
     }
 
     MONSTER_IDX pet_ctr;

--- a/src/action/activation-execution.cpp
+++ b/src/action/activation-execution.cpp
@@ -184,7 +184,7 @@ static bool activate_whistle(player_type *user_ptr, ae_type *ae_ptr)
     if (music_singing_any(user_ptr))
         stop_singing(user_ptr);
 
-    if (hex_spelling_any(user_ptr)) {
+    if (RealmHex(user_ptr).hex_spelling_any()) {
         (void)RealmHex(user_ptr).stop_hex_spell_all();
     }
 

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -396,8 +396,9 @@ void do_cmd_rest(player_type *creature_ptr)
     if ((creature_ptr->pclass == CLASS_BARD) && ((get_singing_song_effect(creature_ptr) != 0) || (get_interrupting_song_effect(creature_ptr) != 0)))
         stop_singing(creature_ptr);
 
-    if (hex_spelling_any(creature_ptr)) {
-        (void)RealmHex(creature_ptr).stop_hex_spell_all();
+    RealmHex realm_hex(creature_ptr);
+    if (realm_hex.hex_spelling_any()) {
+        (void)realm_hex.stop_hex_spell_all();
     }
 
     if (command_arg <= 0) {

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -396,8 +396,9 @@ void do_cmd_rest(player_type *creature_ptr)
     if ((creature_ptr->pclass == CLASS_BARD) && ((get_singing_song_effect(creature_ptr) != 0) || (get_interrupting_song_effect(creature_ptr) != 0)))
         stop_singing(creature_ptr);
 
-    if (hex_spelling_any(creature_ptr))
-        stop_hex_spell_all(creature_ptr);
+    if (hex_spelling_any(creature_ptr)) {
+        (void)RealmHex(creature_ptr).stop_hex_spell_all();
+    }
 
     if (command_arg <= 0) {
         concptr p = _("休憩 (0-9999, '*' で HP/MP全快, '&' で必要なだけ): ", "Rest (0-9999, '*' for HP/SP, '&' as needed): ");

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -397,8 +397,8 @@ void do_cmd_rest(player_type *creature_ptr)
         stop_singing(creature_ptr);
 
     RealmHex realm_hex(creature_ptr);
-    if (realm_hex.hex_spelling_any()) {
-        (void)realm_hex.stop_hex_spell_all();
+    if (realm_hex.is_spelling_any()) {
+        (void)realm_hex.stop_all_spells();
     }
 
     if (command_arg <= 0) {

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -1015,12 +1015,12 @@ bool do_cmd_cast(player_type *caster_ptr)
         return false;
 
     if (caster_ptr->realm1 == REALM_HEX) {
-        if (RealmHex(caster_ptr).hex_spell_fully()) {
+        if (RealmHex(caster_ptr).is_using_full_capacity()) {
             auto flag = false;
             msg_print(_("これ以上新しい呪文を詠唱することはできない。", "Can not cast more spells."));
             flush();
             if (caster_ptr->lev >= 35) {
-                flag = RealmHex(caster_ptr).stop_hex_spell();
+                flag = RealmHex(caster_ptr).stop_one_spell();
             }
 
             if (!flag) {
@@ -1092,7 +1092,7 @@ bool do_cmd_cast(player_type *caster_ptr)
 
     use_realm = tval2realm(o_ptr->tval);
     if (use_realm == REALM_HEX) {
-        if (RealmHex(caster_ptr).hex_spelling(spell)) {
+        if (RealmHex(caster_ptr).is_spelling_specific(spell)) {
             msg_print(_("その呪文はすでに詠唱中だ。", "You are already casting it."));
             return false;
         }

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -1092,7 +1092,7 @@ bool do_cmd_cast(player_type *caster_ptr)
 
     use_realm = tval2realm(o_ptr->tval);
     if (use_realm == REALM_HEX) {
-        if (hex_spelling(caster_ptr, spell)) {
+        if (RealmHex(caster_ptr).hex_spelling(spell)) {
             msg_print(_("その呪文はすでに詠唱中だ。", "You are already casting it."));
             return false;
         }

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -1015,7 +1015,7 @@ bool do_cmd_cast(player_type *caster_ptr)
         return false;
 
     if (caster_ptr->realm1 == REALM_HEX) {
-        if (RealmHex(caster_ptr).is_using_full_capacity()) {
+        if (RealmHex(caster_ptr).is_casting_full_capacity()) {
             auto flag = false;
             msg_print(_("これ以上新しい呪文を詠唱することはできない。", "Can not cast more spells."));
             flush();

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -1015,7 +1015,7 @@ bool do_cmd_cast(player_type *caster_ptr)
         return false;
 
     if (caster_ptr->realm1 == REALM_HEX) {
-        if (hex_spell_fully(caster_ptr)) {
+        if (RealmHex(caster_ptr).hex_spell_fully()) {
             auto flag = false;
             msg_print(_("これ以上新しい呪文を詠唱することはできない。", "Can not cast more spells."));
             flush();

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -1016,13 +1016,16 @@ bool do_cmd_cast(player_type *caster_ptr)
 
     if (caster_ptr->realm1 == REALM_HEX) {
         if (hex_spell_fully(caster_ptr)) {
-            bool flag = false;
+            auto flag = false;
             msg_print(_("これ以上新しい呪文を詠唱することはできない。", "Can not cast more spells."));
             flush();
-            if (caster_ptr->lev >= 35)
-                flag = stop_hex_spell(caster_ptr);
-            if (!flag)
+            if (caster_ptr->lev >= 35) {
+                flag = RealmHex(caster_ptr).stop_hex_spell();
+            }
+
+            if (!flag) {
                 return false;
+            }
         }
     }
 

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -261,8 +261,8 @@ void exe_eat_food(player_type *creature_ptr, INVENTORY_IDX item)
         stop_singing(creature_ptr);
 
     RealmHex realm_hex(creature_ptr);
-    if (realm_hex.hex_spelling_any()) {
-        (void)realm_hex.stop_hex_spell_all();
+    if (realm_hex.is_spelling_any()) {
+        (void)realm_hex.stop_all_spells();
     }
 
     object_type *o_ptr = ref_item(creature_ptr, item);

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -259,8 +259,10 @@ void exe_eat_food(player_type *creature_ptr, INVENTORY_IDX item)
 {
     if (music_singing_any(creature_ptr))
         stop_singing(creature_ptr);
-    if (hex_spelling_any(creature_ptr))
-        stop_hex_spell_all(creature_ptr);
+
+    if (hex_spelling_any(creature_ptr)) {
+        (void)RealmHex(creature_ptr).stop_hex_spell_all();
+    }
 
     object_type *o_ptr = ref_item(creature_ptr, item);
 

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -260,8 +260,9 @@ void exe_eat_food(player_type *creature_ptr, INVENTORY_IDX item)
     if (music_singing_any(creature_ptr))
         stop_singing(creature_ptr);
 
-    if (hex_spelling_any(creature_ptr)) {
-        (void)RealmHex(creature_ptr).stop_hex_spell_all();
+    RealmHex realm_hex(creature_ptr);
+    if (realm_hex.hex_spelling_any()) {
+        (void)realm_hex.stop_hex_spell_all();
     }
 
     object_type *o_ptr = ref_item(creature_ptr, item);

--- a/src/cmd-item/cmd-quaff.cpp
+++ b/src/cmd-item/cmd-quaff.cpp
@@ -27,7 +27,7 @@ void do_cmd_quaff_potion(player_type *creature_ptr)
     if (creature_ptr->wild_mode)
         return;
 
-    if (!RealmHex(creature_ptr).hex_spelling(HEX_INHAIL) && cmd_limit_arena(creature_ptr))
+    if (!RealmHex(creature_ptr).is_spelling_specific(HEX_INHAIL) && cmd_limit_arena(creature_ptr))
         return;
 
     if (creature_ptr->special_defense & (KATA_MUSOU | KATA_KOUKIJIN))

--- a/src/cmd-item/cmd-quaff.cpp
+++ b/src/cmd-item/cmd-quaff.cpp
@@ -27,7 +27,7 @@ void do_cmd_quaff_potion(player_type *creature_ptr)
     if (creature_ptr->wild_mode)
         return;
 
-    if (!hex_spelling(creature_ptr, HEX_INHAIL) && cmd_limit_arena(creature_ptr))
+    if (!RealmHex(creature_ptr).hex_spelling(HEX_INHAIL) && cmd_limit_arena(creature_ptr))
         return;
 
     if (creature_ptr->special_defense & (KATA_MUSOU | KATA_KOUKIJIN))

--- a/src/combat/aura-counterattack.cpp
+++ b/src/combat/aura-counterattack.cpp
@@ -177,7 +177,7 @@ static void aura_force_by_monster_attack(player_type *target_ptr, monap_type *mo
 
 static void aura_shadow_by_monster_attack(player_type *target_ptr, monap_type *monap_ptr)
 {
-    if (!RealmHex(target_ptr).hex_spelling(HEX_SHADOW_CLOAK) || !monap_ptr->alive || target_ptr->is_dead)
+    if (!RealmHex(target_ptr).is_spelling_specific(HEX_SHADOW_CLOAK) || !monap_ptr->alive || target_ptr->is_dead)
         return;
 
     HIT_POINT dam = 1;

--- a/src/combat/aura-counterattack.cpp
+++ b/src/combat/aura-counterattack.cpp
@@ -177,7 +177,7 @@ static void aura_force_by_monster_attack(player_type *target_ptr, monap_type *mo
 
 static void aura_shadow_by_monster_attack(player_type *target_ptr, monap_type *monap_ptr)
 {
-    if (!hex_spelling(target_ptr, HEX_SHADOW_CLOAK) || !monap_ptr->alive || target_ptr->is_dead)
+    if (!RealmHex(target_ptr).hex_spelling(HEX_SHADOW_CLOAK) || !monap_ptr->alive || target_ptr->is_dead)
         return;
 
     HIT_POINT dam = 1;

--- a/src/combat/slaying.cpp
+++ b/src/combat/slaying.cpp
@@ -166,7 +166,7 @@ HIT_POINT calc_attack_damage_with_slay(player_type *attacker_ptr, object_type *o
             flgs.set(TR_BRAND_POIS);
     }
 
-    if (RealmHex(attacker_ptr).hex_spelling(HEX_RUNESWORD))
+    if (RealmHex(attacker_ptr).is_spelling_specific(HEX_RUNESWORD))
         flgs.set(TR_SLAY_GOOD);
 
     MULTIPLY mult = 10;

--- a/src/combat/slaying.cpp
+++ b/src/combat/slaying.cpp
@@ -166,7 +166,7 @@ HIT_POINT calc_attack_damage_with_slay(player_type *attacker_ptr, object_type *o
             flgs.set(TR_BRAND_POIS);
     }
 
-    if (hex_spelling(attacker_ptr, HEX_RUNESWORD))
+    if (RealmHex(attacker_ptr).hex_spelling(HEX_RUNESWORD))
         flgs.set(TR_SLAY_GOOD);
 
     MULTIPLY mult = 10;

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -421,12 +421,17 @@ void process_upkeep_with_speed(player_type *creature_ptr)
         return;
 
     while (creature_ptr->enchant_energy_need <= 0) {
-        if (!load)
+        if (!load) {
             check_music(creature_ptr);
-        if (!load)
-            check_hex(creature_ptr);
-        if (!load)
+        }
+
+        if (!load) {
+            RealmHex(creature_ptr).check_hex();
+        }
+
+        if (!load) {
             revenge_spell(creature_ptr);
+        }
 
         creature_ptr->enchant_energy_need += ENERGY_NEED();
     }

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -425,12 +425,13 @@ void process_upkeep_with_speed(player_type *creature_ptr)
             check_music(creature_ptr);
         }
 
+        auto realm_hex = RealmHex(creature_ptr);
         if (!load) {
-            RealmHex(creature_ptr).check_hex();
+            realm_hex.check_hex();
         }
 
         if (!load) {
-            revenge_spell(creature_ptr);
+            realm_hex.revenge_spell();
         }
 
         creature_ptr->enchant_energy_need += ENERGY_NEED();

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -427,11 +427,11 @@ void process_upkeep_with_speed(player_type *creature_ptr)
 
         auto realm_hex = RealmHex(creature_ptr);
         if (!load) {
-            realm_hex.check_hex();
+            realm_hex.decrease_mana();
         }
 
         if (!load) {
-            realm_hex.revenge_spell();
+            realm_hex.continue_revenge();
         }
 
         creature_ptr->enchant_energy_need += ENERGY_NEED();

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -425,7 +425,7 @@ void process_upkeep_with_speed(player_type *creature_ptr)
             check_music(creature_ptr);
         }
 
-        auto realm_hex = RealmHex(creature_ptr);
+        RealmHex realm_hex(creature_ptr);
         if (!load) {
             realm_hex.decrease_mana();
         }

--- a/src/effect/effect-player.cpp
+++ b/src/effect/effect-player.cpp
@@ -309,7 +309,7 @@ bool affect_player(MONSTER_IDX who, player_type *target_ptr, concptr who_name, i
     switch_effects_player(target_ptr, ep_ptr);
 
     RealmHex(target_ptr).revenge_store(ep_ptr->get_damage);
-    if ((target_ptr->tim_eyeeye || hex_spelling(target_ptr, HEX_EYE_FOR_EYE)) && (ep_ptr->get_damage > 0) && !target_ptr->is_dead && (ep_ptr->who > 0)) {
+    if ((target_ptr->tim_eyeeye || RealmHex(target_ptr).hex_spelling(HEX_EYE_FOR_EYE)) && (ep_ptr->get_damage > 0) && !target_ptr->is_dead && (ep_ptr->who > 0)) {
         GAME_TEXT m_name_self[MAX_MONSTER_NAME];
         monster_desc(target_ptr, m_name_self, ep_ptr->m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE | MD_OBJECTIVE);
         msg_format(_("攻撃が%s自身を傷つけた！", "The attack of %s has wounded %s!"), ep_ptr->m_name, m_name_self);

--- a/src/effect/effect-player.cpp
+++ b/src/effect/effect-player.cpp
@@ -308,8 +308,8 @@ bool affect_player(MONSTER_IDX who, player_type *target_ptr, concptr who_name, i
     describe_effect_source(target_ptr, ep_ptr, who_name);
     switch_effects_player(target_ptr, ep_ptr);
 
-    RealmHex(target_ptr).revenge_store(ep_ptr->get_damage);
-    if ((target_ptr->tim_eyeeye || RealmHex(target_ptr).hex_spelling(HEX_EYE_FOR_EYE)) && (ep_ptr->get_damage > 0) && !target_ptr->is_dead && (ep_ptr->who > 0)) {
+    RealmHex(target_ptr).store_vengeful_damage(ep_ptr->get_damage);
+    if ((target_ptr->tim_eyeeye || RealmHex(target_ptr).is_spelling_specific(HEX_EYE_FOR_EYE)) && (ep_ptr->get_damage > 0) && !target_ptr->is_dead && (ep_ptr->who > 0)) {
         GAME_TEXT m_name_self[MAX_MONSTER_NAME];
         monster_desc(target_ptr, m_name_self, ep_ptr->m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE | MD_OBJECTIVE);
         msg_format(_("攻撃が%s自身を傷つけた！", "The attack of %s has wounded %s!"), ep_ptr->m_name, m_name_self);

--- a/src/effect/effect-player.cpp
+++ b/src/effect/effect-player.cpp
@@ -308,7 +308,7 @@ bool affect_player(MONSTER_IDX who, player_type *target_ptr, concptr who_name, i
     describe_effect_source(target_ptr, ep_ptr, who_name);
     switch_effects_player(target_ptr, ep_ptr);
 
-    revenge_store(target_ptr, ep_ptr->get_damage);
+    RealmHex(target_ptr).revenge_store(ep_ptr->get_damage);
     if ((target_ptr->tim_eyeeye || hex_spelling(target_ptr, HEX_EYE_FOR_EYE)) && (ep_ptr->get_damage > 0) && !target_ptr->is_dead && (ep_ptr->who > 0)) {
         GAME_TEXT m_name_self[MAX_MONSTER_NAME];
         monster_desc(target_ptr, m_name_self, ep_ptr->m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE | MD_OBJECTIVE);

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -887,8 +887,9 @@ bool change_wild_mode(player_type *creature_ptr, bool encount)
     energy.set_player_turn_energy(1000);
     creature_ptr->oldpx = creature_ptr->x;
     creature_ptr->oldpy = creature_ptr->y;
-    if (hex_spelling_any(creature_ptr))
-        stop_hex_spell_all(creature_ptr);
+    if (hex_spelling_any(creature_ptr)) {
+        (void)RealmHex(creature_ptr).stop_hex_spell_all();
+    }
 
     set_action(creature_ptr, ACTION_NONE);
     creature_ptr->wild_mode = true;

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -888,8 +888,8 @@ bool change_wild_mode(player_type *creature_ptr, bool encount)
     creature_ptr->oldpx = creature_ptr->x;
     creature_ptr->oldpy = creature_ptr->y;
     RealmHex realm_hex(creature_ptr);
-    if (realm_hex.hex_spelling_any()) {
-        realm_hex.stop_hex_spell_all();
+    if (realm_hex.is_spelling_any()) {
+        realm_hex.stop_all_spells();
     }
 
     set_action(creature_ptr, ACTION_NONE);

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -887,8 +887,9 @@ bool change_wild_mode(player_type *creature_ptr, bool encount)
     energy.set_player_turn_energy(1000);
     creature_ptr->oldpx = creature_ptr->x;
     creature_ptr->oldpy = creature_ptr->y;
-    if (hex_spelling_any(creature_ptr)) {
-        (void)RealmHex(creature_ptr).stop_hex_spell_all();
+    RealmHex realm_hex(creature_ptr);
+    if (realm_hex.hex_spelling_any()) {
+        realm_hex.stop_hex_spell_all();
     }
 
     set_action(creature_ptr, ACTION_NONE);

--- a/src/market/building-craft-weapon.cpp
+++ b/src/market/building-craft-weapon.cpp
@@ -141,7 +141,7 @@ static void compare_weapon_aux(player_type *owner_ptr, object_type *o_ptr, int c
     mindam = calc_expect_crit(owner_ptr, o_ptr->weight, o_ptr->to_h, mindice, owner_ptr->to_h[0], dokubari, impact);
     maxdam = calc_expect_crit(owner_ptr, o_ptr->weight, o_ptr->to_h, maxdice, owner_ptr->to_h[0], dokubari, impact);
     show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("会心:", "Critical:"), TERM_L_RED);
-    if ((flgs.has(TR_VORPAL) || RealmHex(owner_ptr).hex_spelling(HEX_RUNESWORD))) {
+    if ((flgs.has(TR_VORPAL) || RealmHex(owner_ptr).is_spelling_specific(HEX_RUNESWORD))) {
         if ((o_ptr->name1 == ART_VORPAL_BLADE) || (o_ptr->name1 == ART_CHAINSWORD)) {
             vorpal_mult = 5;
             vorpal_div = 3;

--- a/src/market/building-craft-weapon.cpp
+++ b/src/market/building-craft-weapon.cpp
@@ -141,7 +141,7 @@ static void compare_weapon_aux(player_type *owner_ptr, object_type *o_ptr, int c
     mindam = calc_expect_crit(owner_ptr, o_ptr->weight, o_ptr->to_h, mindice, owner_ptr->to_h[0], dokubari, impact);
     maxdam = calc_expect_crit(owner_ptr, o_ptr->weight, o_ptr->to_h, maxdice, owner_ptr->to_h[0], dokubari, impact);
     show_weapon_dmg(r++, col, mindam, maxdam, blow, dmg_bonus, _("会心:", "Critical:"), TERM_L_RED);
-    if ((flgs.has(TR_VORPAL) || hex_spelling(owner_ptr, HEX_RUNESWORD))) {
+    if ((flgs.has(TR_VORPAL) || RealmHex(owner_ptr).hex_spelling(HEX_RUNESWORD))) {
         if ((o_ptr->name1 == ART_VORPAL_BLADE) || (o_ptr->name1 == ART_CHAINSWORD)) {
             vorpal_mult = 5;
             vorpal_div = 3;

--- a/src/melee/melee-spell.cpp
+++ b/src/melee/melee-spell.cpp
@@ -41,7 +41,7 @@ static bool try_melee_spell(player_type *target_ptr, melee_spell_type *ms_ptr)
 
 static bool disturb_melee_spell(player_type *target_ptr, melee_spell_type *ms_ptr)
 {
-    if (spell_is_inate(ms_ptr->thrown_spell) || !RealmHex(target_ptr).magic_barrier(ms_ptr->m_idx))
+    if (spell_is_inate(ms_ptr->thrown_spell) || !RealmHex(target_ptr).check_hex_barrier(ms_ptr->m_idx, HEX_ANTI_MAGIC))
         return false;
 
     if (ms_ptr->see_m)

--- a/src/melee/melee-spell.cpp
+++ b/src/melee/melee-spell.cpp
@@ -41,7 +41,7 @@ static bool try_melee_spell(player_type *target_ptr, melee_spell_type *ms_ptr)
 
 static bool disturb_melee_spell(player_type *target_ptr, melee_spell_type *ms_ptr)
 {
-    if (spell_is_inate(ms_ptr->thrown_spell) || !magic_barrier(target_ptr, ms_ptr->m_idx))
+    if (spell_is_inate(ms_ptr->thrown_spell) || !RealmHex(target_ptr).magic_barrier(ms_ptr->m_idx))
         return false;
 
     if (ms_ptr->see_m)

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -230,7 +230,7 @@ static void process_melee(player_type *subject_ptr, mam_type *mam_ptr)
 
 static void thief_runaway_by_melee(player_type *subject_ptr, mam_type *mam_ptr)
 {
-    if (RealmHex(subject_ptr).teleport_barrier(mam_ptr->m_idx)) {
+    if (RealmHex(subject_ptr).check_hex_barrier(mam_ptr->m_idx, HEX_ANTI_TELE)) {
         if (mam_ptr->see_m) {
             msg_print(_("泥棒は笑って逃げ...ようとしたがバリアに防がれた。", "The thief flees laughing...? But a magic barrier obstructs it."));
         } else if (mam_ptr->known) {

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -230,7 +230,7 @@ static void process_melee(player_type *subject_ptr, mam_type *mam_ptr)
 
 static void thief_runaway_by_melee(player_type *subject_ptr, mam_type *mam_ptr)
 {
-    if (teleport_barrier(subject_ptr, mam_ptr->m_idx)) {
+    if (RealmHex(subject_ptr).teleport_barrier(mam_ptr->m_idx)) {
         if (mam_ptr->see_m) {
             msg_print(_("泥棒は笑って逃げ...ようとしたがバリアに防がれた。", "The thief flees laughing...? But a magic barrier obstructs it."));
         } else if (mam_ptr->known) {

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -461,7 +461,7 @@ static bool process_monster_blows(player_type *target_ptr, monap_type *monap_ptr
  */
 static void eyes_on_eyes(player_type *target_ptr, monap_type *monap_ptr)
 {
-    if (((target_ptr->tim_eyeeye == 0) && !RealmHex(target_ptr).hex_spelling(HEX_EYE_FOR_EYE)) || (monap_ptr->get_damage == 0) || target_ptr->is_dead)
+    if (((target_ptr->tim_eyeeye == 0) && !RealmHex(target_ptr).is_spelling_specific(HEX_EYE_FOR_EYE)) || (monap_ptr->get_damage == 0) || target_ptr->is_dead)
         return;
 
 #ifdef JP
@@ -491,7 +491,7 @@ static void thief_teleport(player_type *target_ptr, monap_type *monap_ptr)
 
 static void postprocess_monster_blows(player_type *target_ptr, monap_type *monap_ptr)
 {
-    RealmHex(target_ptr).revenge_store(monap_ptr->get_damage);
+    RealmHex(target_ptr).store_vengeful_damage(monap_ptr->get_damage);
     eyes_on_eyes(target_ptr, monap_ptr);
     musou_counterattack(target_ptr, monap_ptr);
     thief_teleport(target_ptr, monap_ptr);

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -482,7 +482,7 @@ static void thief_teleport(player_type *target_ptr, monap_type *monap_ptr)
     if (!monap_ptr->blinked || !monap_ptr->alive || target_ptr->is_dead)
         return;
 
-    if (teleport_barrier(target_ptr, monap_ptr->m_idx)) {
+    if (RealmHex(target_ptr).teleport_barrier(monap_ptr->m_idx)) {
         msg_print(_("泥棒は笑って逃げ...ようとしたがバリアに防がれた。", "The thief flees laughing...? But a magic barrier obstructs it."));
     } else {
         msg_print(_("泥棒は笑って逃げた！", "The thief flees laughing!"));

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -492,7 +492,7 @@ static void thief_teleport(player_type *target_ptr, monap_type *monap_ptr)
 
 static void postprocess_monster_blows(player_type *target_ptr, monap_type *monap_ptr)
 {
-    revenge_store(target_ptr, monap_ptr->get_damage);
+    RealmHex(target_ptr).revenge_store(monap_ptr->get_damage);
     eyes_on_eyes(target_ptr, monap_ptr);
     musou_counterattack(target_ptr, monap_ptr);
     thief_teleport(target_ptr, monap_ptr);

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -44,7 +44,6 @@
 #include "player/player-damage.h"
 #include "player/player-skill.h"
 #include "player/special-defense-types.h"
-#include "realm/realm-hex-numbers.h"
 #include "spell-kind/spells-teleport.h"
 #include "spell-realm/spells-crusade.h"
 #include "spell-realm/spells-hex.h"
@@ -482,7 +481,7 @@ static void thief_teleport(player_type *target_ptr, monap_type *monap_ptr)
     if (!monap_ptr->blinked || !monap_ptr->alive || target_ptr->is_dead)
         return;
 
-    if (RealmHex(target_ptr).teleport_barrier(monap_ptr->m_idx)) {
+    if (RealmHex(target_ptr).check_hex_barrier(monap_ptr->m_idx, HEX_ANTI_TELE)) {
         msg_print(_("泥棒は笑って逃げ...ようとしたがバリアに防がれた。", "The thief flees laughing...? But a magic barrier obstructs it."));
     } else {
         msg_print(_("泥棒は笑って逃げた！", "The thief flees laughing!"));

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -461,7 +461,7 @@ static bool process_monster_blows(player_type *target_ptr, monap_type *monap_ptr
  */
 static void eyes_on_eyes(player_type *target_ptr, monap_type *monap_ptr)
 {
-    if (((target_ptr->tim_eyeeye == 0) && !hex_spelling(target_ptr, HEX_EYE_FOR_EYE)) || (monap_ptr->get_damage == 0) || target_ptr->is_dead)
+    if (((target_ptr->tim_eyeeye == 0) && !RealmHex(target_ptr).hex_spelling(HEX_EYE_FOR_EYE)) || (monap_ptr->get_damage == 0) || target_ptr->is_dead)
         return;
 
 #ifdef JP

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -410,7 +410,7 @@ bool decide_monster_multiplication(player_type *target_ptr, MONSTER_IDX m_idx, P
         }
     }
 
-    if (multiply_barrier(target_ptr, m_idx))
+    if (RealmHex(target_ptr).multiply_barrier(m_idx))
         k = 8;
 
     if ((k < 4) && (!k || !randint0(k * MON_MULT_ADJ))) {

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -410,7 +410,7 @@ bool decide_monster_multiplication(player_type *target_ptr, MONSTER_IDX m_idx, P
         }
     }
 
-    if (RealmHex(target_ptr).multiply_barrier(m_idx))
+    if (RealmHex(target_ptr).check_hex_barrier(m_idx, HEX_ANTI_MULTI))
         k = 8;
 
     if ((k < 4) && (!k || !randint0(k * MON_MULT_ADJ))) {

--- a/src/mspell/mspell-attack.cpp
+++ b/src/mspell/mspell-attack.cpp
@@ -188,7 +188,7 @@ static bool check_mspell_unexploded(player_type *target_ptr, msa_type *msa_ptr)
         return true;
     }
 
-    if (!spell_is_inate(msa_ptr->thrown_spell) && RealmHex(target_ptr).magic_barrier(msa_ptr->m_idx)) {
+    if (!spell_is_inate(msa_ptr->thrown_spell) && RealmHex(target_ptr).check_hex_barrier(msa_ptr->m_idx, HEX_ANTI_MAGIC)) {
         msg_format(_("反魔法バリアが%^sの呪文をかき消した。", "Anti magic barrier cancels the spell which %^s casts."), msa_ptr->m_name);
         return true;
     }

--- a/src/mspell/mspell-attack.cpp
+++ b/src/mspell/mspell-attack.cpp
@@ -188,7 +188,7 @@ static bool check_mspell_unexploded(player_type *target_ptr, msa_type *msa_ptr)
         return true;
     }
 
-    if (!spell_is_inate(msa_ptr->thrown_spell) && magic_barrier(target_ptr, msa_ptr->m_idx)) {
+    if (!spell_is_inate(msa_ptr->thrown_spell) && RealmHex(target_ptr).magic_barrier(msa_ptr->m_idx)) {
         msg_format(_("反魔法バリアが%^sの呪文をかき消した。", "Anti magic barrier cancels the spell which %^s casts."), msa_ptr->m_name);
         return true;
     }

--- a/src/mspell/mspell-dispel.cpp
+++ b/src/mspell/mspell-dispel.cpp
@@ -81,7 +81,7 @@ static void dispel_player(player_type *creature_ptr)
         msg_print(_("手の輝きがなくなった。", "Your hands stop glowing."));
     }
 
-    if (music_singing_any(creature_ptr) || RealmHex(creature_ptr).hex_spelling_any()) {
+    if (music_singing_any(creature_ptr) || RealmHex(creature_ptr).is_spelling_any()) {
         concptr str = (music_singing_any(creature_ptr)) ? _("歌", "singing") : _("呪文", "casting");
         set_interrupting_song_effect(creature_ptr, get_singing_song_effect(creature_ptr));
         set_singing_song_effect(creature_ptr, MUSIC_NONE);

--- a/src/mspell/mspell-dispel.cpp
+++ b/src/mspell/mspell-dispel.cpp
@@ -81,7 +81,7 @@ static void dispel_player(player_type *creature_ptr)
         msg_print(_("手の輝きがなくなった。", "Your hands stop glowing."));
     }
 
-    if (music_singing_any(creature_ptr) || hex_spelling_any(creature_ptr)) {
+    if (music_singing_any(creature_ptr) || RealmHex(creature_ptr).hex_spelling_any()) {
         concptr str = (music_singing_any(creature_ptr)) ? _("歌", "singing") : _("呪文", "casting");
         set_interrupting_song_effect(creature_ptr, get_singing_song_effect(creature_ptr));
         set_singing_song_effect(creature_ptr, MUSIC_NONE);

--- a/src/mspell/mspell-floor.cpp
+++ b/src/mspell/mspell-floor.cpp
@@ -108,7 +108,7 @@ MonsterSpellResult spell_RF6_BLINK(player_type *target_ptr, MONSTER_IDX m_idx, i
     if (TARGET_TYPE == MONSTER_TO_PLAYER)
         disturb(target_ptr, true, true);
 
-    if (!is_quantum_effect && teleport_barrier(target_ptr, m_idx)) {
+    if (!is_quantum_effect && RealmHex(target_ptr).teleport_barrier(m_idx)) {
         if (see_monster(target_ptr, m_idx))
             msg_format(_("魔法のバリアが%^sのテレポートを邪魔した。", "Magic barrier obstructs teleporting of %^s."), m_name);
         return res;
@@ -142,7 +142,7 @@ MonsterSpellResult spell_RF6_TPORT(player_type *target_ptr, MONSTER_IDX m_idx, i
 
     if (TARGET_TYPE == MONSTER_TO_PLAYER)
         disturb(target_ptr, true, true);
-    if (teleport_barrier(target_ptr, m_idx)) {
+    if (RealmHex(target_ptr).teleport_barrier(m_idx)) {
         if (see_monster(target_ptr, m_idx))
             msg_format(_("魔法のバリアが%^sのテレポートを邪魔した。", "Magic barrier obstructs teleporting of %^s."), m_name);
         return res;

--- a/src/mspell/mspell-floor.cpp
+++ b/src/mspell/mspell-floor.cpp
@@ -108,7 +108,7 @@ MonsterSpellResult spell_RF6_BLINK(player_type *target_ptr, MONSTER_IDX m_idx, i
     if (TARGET_TYPE == MONSTER_TO_PLAYER)
         disturb(target_ptr, true, true);
 
-    if (!is_quantum_effect && RealmHex(target_ptr).teleport_barrier(m_idx)) {
+    if (!is_quantum_effect && RealmHex(target_ptr).check_hex_barrier(m_idx, HEX_ANTI_TELE)) {
         if (see_monster(target_ptr, m_idx))
             msg_format(_("魔法のバリアが%^sのテレポートを邪魔した。", "Magic barrier obstructs teleporting of %^s."), m_name);
         return res;
@@ -142,7 +142,7 @@ MonsterSpellResult spell_RF6_TPORT(player_type *target_ptr, MONSTER_IDX m_idx, i
 
     if (TARGET_TYPE == MONSTER_TO_PLAYER)
         disturb(target_ptr, true, true);
-    if (RealmHex(target_ptr).teleport_barrier(m_idx)) {
+    if (RealmHex(target_ptr).check_hex_barrier(m_idx, HEX_ANTI_TELE)) {
         if (see_monster(target_ptr, m_idx))
             msg_format(_("魔法のバリアが%^sのテレポートを邪魔した。", "Magic barrier obstructs teleporting of %^s."), m_name);
         return res;

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -395,8 +395,8 @@ void process_world_aux_mutation(player_type *creature_ptr)
             stop_singing(creature_ptr);
 
         RealmHex realm_hex(creature_ptr);
-        if (realm_hex.hex_spelling_any()) {
-            (void)realm_hex.stop_hex_spell_all();
+        if (realm_hex.is_spelling_any()) {
+            (void)realm_hex.stop_all_spells();
         }
     }
 

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -394,8 +394,9 @@ void process_world_aux_mutation(player_type *creature_ptr)
         if (music_singing_any(creature_ptr))
             stop_singing(creature_ptr);
 
-        if (hex_spelling_any(creature_ptr))
-            stop_hex_spell_all(creature_ptr);
+        if (hex_spelling_any(creature_ptr)) {
+            (void)RealmHex(creature_ptr).stop_hex_spell_all();
+        }
     }
 
     if (creature_ptr->muta.has(MUTA::WALK_SHAD) && !creature_ptr->anti_magic && one_in_(12000) && !creature_ptr->current_floor_ptr->inside_arena)

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -394,8 +394,9 @@ void process_world_aux_mutation(player_type *creature_ptr)
         if (music_singing_any(creature_ptr))
             stop_singing(creature_ptr);
 
-        if (hex_spelling_any(creature_ptr)) {
-            (void)RealmHex(creature_ptr).stop_hex_spell_all();
+        RealmHex realm_hex(creature_ptr);
+        if (realm_hex.hex_spelling_any()) {
+            (void)realm_hex.stop_hex_spell_all();
         }
     }
 

--- a/src/object-activation/activation-breath.cpp
+++ b/src/object-activation/activation-breath.cpp
@@ -46,8 +46,9 @@ bool activate_dragon_breath(player_type *user_ptr, object_type *o_ptr)
     if (music_singing_any(user_ptr))
         stop_singing(user_ptr);
 
-    if (hex_spelling_any(user_ptr))
-        stop_hex_spell_all(user_ptr);
+    if (hex_spelling_any(user_ptr)) {
+        (void)RealmHex(user_ptr).stop_hex_spell_all();
+    }
 
     int t = randint0(n);
     msg_format(_("あなたは%sのブレスを吐いた。", "You breathe %s."), name[t]);

--- a/src/object-activation/activation-breath.cpp
+++ b/src/object-activation/activation-breath.cpp
@@ -46,8 +46,8 @@ bool activate_dragon_breath(player_type *user_ptr, object_type *o_ptr)
     if (music_singing_any(user_ptr))
         stop_singing(user_ptr);
 
-    if (RealmHex(user_ptr).hex_spelling_any()) {
-        (void)RealmHex(user_ptr).stop_hex_spell_all();
+    if (RealmHex(user_ptr).is_spelling_any()) {
+        (void)RealmHex(user_ptr).stop_all_spells();
     }
 
     int t = randint0(n);

--- a/src/object-activation/activation-breath.cpp
+++ b/src/object-activation/activation-breath.cpp
@@ -46,7 +46,7 @@ bool activate_dragon_breath(player_type *user_ptr, object_type *o_ptr)
     if (music_singing_any(user_ptr))
         stop_singing(user_ptr);
 
-    if (hex_spelling_any(user_ptr)) {
+    if (RealmHex(user_ptr).hex_spelling_any()) {
         (void)RealmHex(user_ptr).stop_hex_spell_all();
     }
 

--- a/src/object-activation/activation-others.cpp
+++ b/src/object-activation/activation-others.cpp
@@ -89,7 +89,7 @@ bool activate_scare(player_type *user_ptr)
     if (music_singing_any(user_ptr))
         stop_singing(user_ptr);
 
-    if (hex_spelling_any(user_ptr)) {
+    if (RealmHex(user_ptr).hex_spelling_any()) {
         (void)RealmHex(user_ptr).stop_hex_spell_all();
     }
 

--- a/src/object-activation/activation-others.cpp
+++ b/src/object-activation/activation-others.cpp
@@ -89,8 +89,8 @@ bool activate_scare(player_type *user_ptr)
     if (music_singing_any(user_ptr))
         stop_singing(user_ptr);
 
-    if (RealmHex(user_ptr).hex_spelling_any()) {
-        (void)RealmHex(user_ptr).stop_hex_spell_all();
+    if (RealmHex(user_ptr).is_spelling_any()) {
+        (void)RealmHex(user_ptr).stop_all_spells();
     }
 
     msg_print(_("あなたは力強い突風を吹き鳴らした。周囲の敵が震え上っている!", "You wind a mighty blast; your enemies tremble!"));

--- a/src/object-activation/activation-others.cpp
+++ b/src/object-activation/activation-others.cpp
@@ -89,8 +89,9 @@ bool activate_scare(player_type *user_ptr)
     if (music_singing_any(user_ptr))
         stop_singing(user_ptr);
 
-    if (hex_spelling_any(user_ptr))
-        stop_hex_spell_all(user_ptr);
+    if (hex_spelling_any(user_ptr)) {
+        (void)RealmHex(user_ptr).stop_hex_spell_all();
+    }
 
     msg_print(_("あなたは力強い突風を吹き鳴らした。周囲の敵が震え上っている!", "You wind a mighty blast; your enemies tremble!"));
     (void)turn_monsters(user_ptr, (3 * user_ptr->lev / 2) + 10);

--- a/src/object-use/quaff-execution.cpp
+++ b/src/object-use/quaff-execution.cpp
@@ -133,8 +133,9 @@ void exe_quaff_potion(player_type *creature_ptr, INVENTORY_IDX item)
     if (music_singing_any(creature_ptr))
         stop_singing(creature_ptr);
 
-    if (hex_spelling_any(creature_ptr) && !hex_spelling(creature_ptr, HEX_INHAIL))
-        stop_hex_spell_all(creature_ptr);
+    if (hex_spelling_any(creature_ptr) && !hex_spelling(creature_ptr, HEX_INHAIL)) {
+        (void)RealmHex(creature_ptr).stop_hex_spell_all();
+    }
 
     o_ptr = ref_item(creature_ptr, item);
     q_ptr = &forge;

--- a/src/object-use/quaff-execution.cpp
+++ b/src/object-use/quaff-execution.cpp
@@ -133,7 +133,7 @@ void exe_quaff_potion(player_type *creature_ptr, INVENTORY_IDX item)
     if (music_singing_any(creature_ptr))
         stop_singing(creature_ptr);
 
-    if (hex_spelling_any(creature_ptr) && !hex_spelling(creature_ptr, HEX_INHAIL)) {
+    if (hex_spelling_any(creature_ptr) && !RealmHex(creature_ptr).hex_spelling(HEX_INHAIL)) {
         (void)RealmHex(creature_ptr).stop_hex_spell_all();
     }
 

--- a/src/object-use/quaff-execution.cpp
+++ b/src/object-use/quaff-execution.cpp
@@ -134,8 +134,8 @@ void exe_quaff_potion(player_type *creature_ptr, INVENTORY_IDX item)
         stop_singing(creature_ptr);
 
     RealmHex realm_hex(creature_ptr);
-    if (realm_hex.hex_spelling_any() && !realm_hex.hex_spelling(HEX_INHAIL)) {
-        (void)RealmHex(creature_ptr).stop_hex_spell_all();
+    if (realm_hex.is_spelling_any() && !realm_hex.is_spelling_specific(HEX_INHAIL)) {
+        (void)RealmHex(creature_ptr).stop_all_spells();
     }
 
     o_ptr = ref_item(creature_ptr, item);

--- a/src/object-use/quaff-execution.cpp
+++ b/src/object-use/quaff-execution.cpp
@@ -133,7 +133,8 @@ void exe_quaff_potion(player_type *creature_ptr, INVENTORY_IDX item)
     if (music_singing_any(creature_ptr))
         stop_singing(creature_ptr);
 
-    if (hex_spelling_any(creature_ptr) && !RealmHex(creature_ptr).hex_spelling(HEX_INHAIL)) {
+    RealmHex realm_hex(creature_ptr);
+    if (realm_hex.hex_spelling_any() && !realm_hex.hex_spelling(HEX_INHAIL)) {
         (void)RealmHex(creature_ptr).stop_hex_spell_all();
     }
 

--- a/src/object-use/read-execution.cpp
+++ b/src/object-use/read-execution.cpp
@@ -96,8 +96,8 @@ void exe_read(player_type *creature_ptr, INVENTORY_IDX item, bool known)
         stop_singing(creature_ptr);
 
     RealmHex realm_hex(creature_ptr);
-    if (realm_hex.hex_spelling_any() && ((creature_ptr->lev < 35) || realm_hex.hex_spell_fully())) {
-        (void)RealmHex(creature_ptr).stop_hex_spell_all();
+    if (realm_hex.is_spelling_any() && ((creature_ptr->lev < 35) || realm_hex.is_using_full_capacity())) {
+        (void)RealmHex(creature_ptr).stop_all_spells();
     }
 
     ident = false;

--- a/src/object-use/read-execution.cpp
+++ b/src/object-use/read-execution.cpp
@@ -96,7 +96,7 @@ void exe_read(player_type *creature_ptr, INVENTORY_IDX item, bool known)
         stop_singing(creature_ptr);
 
     RealmHex realm_hex(creature_ptr);
-    if (realm_hex.is_spelling_any() && ((creature_ptr->lev < 35) || realm_hex.is_using_full_capacity())) {
+    if (realm_hex.is_spelling_any() && ((creature_ptr->lev < 35) || realm_hex.is_casting_full_capacity())) {
         (void)RealmHex(creature_ptr).stop_all_spells();
     }
 

--- a/src/object-use/read-execution.cpp
+++ b/src/object-use/read-execution.cpp
@@ -95,7 +95,8 @@ void exe_read(player_type *creature_ptr, INVENTORY_IDX item, bool known)
     if (music_singing_any(creature_ptr))
         stop_singing(creature_ptr);
 
-    if (hex_spelling_any(creature_ptr) && ((creature_ptr->lev < 35) || RealmHex(creature_ptr).hex_spell_fully())) {
+    RealmHex realm_hex(creature_ptr);
+    if (realm_hex.hex_spelling_any() && ((creature_ptr->lev < 35) || realm_hex.hex_spell_fully())) {
         (void)RealmHex(creature_ptr).stop_hex_spell_all();
     }
 

--- a/src/object-use/read-execution.cpp
+++ b/src/object-use/read-execution.cpp
@@ -95,7 +95,7 @@ void exe_read(player_type *creature_ptr, INVENTORY_IDX item, bool known)
     if (music_singing_any(creature_ptr))
         stop_singing(creature_ptr);
 
-    if (hex_spelling_any(creature_ptr) && ((creature_ptr->lev < 35) || hex_spell_fully(creature_ptr))) {
+    if (hex_spelling_any(creature_ptr) && ((creature_ptr->lev < 35) || RealmHex(creature_ptr).hex_spell_fully())) {
         (void)RealmHex(creature_ptr).stop_hex_spell_all();
     }
 

--- a/src/object-use/read-execution.cpp
+++ b/src/object-use/read-execution.cpp
@@ -95,8 +95,9 @@ void exe_read(player_type *creature_ptr, INVENTORY_IDX item, bool known)
     if (music_singing_any(creature_ptr))
         stop_singing(creature_ptr);
 
-    if (hex_spelling_any(creature_ptr) && ((creature_ptr->lev < 35) || hex_spell_fully(creature_ptr)))
-        stop_hex_spell_all(creature_ptr);
+    if (hex_spelling_any(creature_ptr) && ((creature_ptr->lev < 35) || hex_spell_fully(creature_ptr))) {
+        (void)RealmHex(creature_ptr).stop_hex_spell_all();
+    }
 
     ident = false;
     lev = k_info[o_ptr->k_idx].level;

--- a/src/player-ability/player-constitution.cpp
+++ b/src/player-ability/player-constitution.cpp
@@ -55,7 +55,7 @@ int16_t PlayerConstitution::time_effect_value()
     int16_t result = 0;
 
     if (this->owner_ptr->realm1 == REALM_HEX) {
-        if (hex_spelling(this->owner_ptr, HEX_BUILDING)) {
+        if (RealmHex(this->owner_ptr).hex_spelling(HEX_BUILDING)) {
             result += 4;
         }
     }

--- a/src/player-ability/player-constitution.cpp
+++ b/src/player-ability/player-constitution.cpp
@@ -55,7 +55,7 @@ int16_t PlayerConstitution::time_effect_value()
     int16_t result = 0;
 
     if (this->owner_ptr->realm1 == REALM_HEX) {
-        if (RealmHex(this->owner_ptr).hex_spelling(HEX_BUILDING)) {
+        if (RealmHex(this->owner_ptr).is_spelling_specific(HEX_BUILDING)) {
             result += 4;
         }
     }

--- a/src/player-ability/player-dexterity.cpp
+++ b/src/player-ability/player-dexterity.cpp
@@ -55,7 +55,7 @@ int16_t PlayerDexterity::time_effect_value()
     int16_t result = 0;
 
     if (this->owner_ptr->realm1 == REALM_HEX) {
-        if (RealmHex(this->owner_ptr).hex_spelling(HEX_BUILDING)) {
+        if (RealmHex(this->owner_ptr).is_spelling_specific(HEX_BUILDING)) {
             result += 4;
         }
     }

--- a/src/player-ability/player-dexterity.cpp
+++ b/src/player-ability/player-dexterity.cpp
@@ -55,7 +55,7 @@ int16_t PlayerDexterity::time_effect_value()
     int16_t result = 0;
 
     if (this->owner_ptr->realm1 == REALM_HEX) {
-        if (hex_spelling(this->owner_ptr, HEX_BUILDING)) {
+        if (RealmHex(this->owner_ptr).hex_spelling(HEX_BUILDING)) {
             result += 4;
         }
     }

--- a/src/player-ability/player-strength.cpp
+++ b/src/player-ability/player-strength.cpp
@@ -57,10 +57,11 @@ int16_t PlayerStrength::time_effect_value()
     int16_t result = 0;
 
     if (this->owner_ptr->realm1 == REALM_HEX) {
-        if (hex_spelling(this->owner_ptr, HEX_XTRA_MIGHT)) {
+        RealmHex realm_hex(this->owner_ptr);
+        if (realm_hex.hex_spelling(HEX_XTRA_MIGHT)) {
             result += 4;
         }
-        if (hex_spelling(this->owner_ptr, HEX_BUILDING)) {
+        if (realm_hex.hex_spelling(HEX_BUILDING)) {
             result += 4;
         }
     }

--- a/src/player-ability/player-strength.cpp
+++ b/src/player-ability/player-strength.cpp
@@ -58,10 +58,10 @@ int16_t PlayerStrength::time_effect_value()
 
     if (this->owner_ptr->realm1 == REALM_HEX) {
         RealmHex realm_hex(this->owner_ptr);
-        if (realm_hex.hex_spelling(HEX_XTRA_MIGHT)) {
+        if (realm_hex.is_spelling_specific(HEX_XTRA_MIGHT)) {
             result += 4;
         }
-        if (realm_hex.hex_spelling(HEX_BUILDING)) {
+        if (realm_hex.is_spelling_specific(HEX_BUILDING)) {
             result += 4;
         }
     }

--- a/src/player-attack/attack-chaos-effect.cpp
+++ b/src/player-attack/attack-chaos-effect.cpp
@@ -269,7 +269,7 @@ void change_monster_stat(player_type *attacker_ptr, player_attack_type *pa_ptr, 
     object_type *o_ptr = &attacker_ptr->inventory_list[INVEN_MAIN_HAND + pa_ptr->hand];
 
     if (any_bits(attacker_ptr->special_attack, ATTACK_CONFUSE) || pa_ptr->chaos_effect == CE_CONFUSION || pa_ptr->mode == HISSATSU_CONF
-        || hex_spelling(attacker_ptr, HEX_CONFUSION))
+        || RealmHex(attacker_ptr).hex_spelling(HEX_CONFUSION))
         attack_confuse(attacker_ptr, pa_ptr);
 
     if (pa_ptr->magical_effect == MagicalBrandEffect::STUN)

--- a/src/player-attack/attack-chaos-effect.cpp
+++ b/src/player-attack/attack-chaos-effect.cpp
@@ -269,7 +269,7 @@ void change_monster_stat(player_type *attacker_ptr, player_attack_type *pa_ptr, 
     object_type *o_ptr = &attacker_ptr->inventory_list[INVEN_MAIN_HAND + pa_ptr->hand];
 
     if (any_bits(attacker_ptr->special_attack, ATTACK_CONFUSE) || pa_ptr->chaos_effect == CE_CONFUSION || pa_ptr->mode == HISSATSU_CONF
-        || RealmHex(attacker_ptr).hex_spelling(HEX_CONFUSION))
+        || RealmHex(attacker_ptr).is_spelling_specific(HEX_CONFUSION))
         attack_confuse(attacker_ptr, pa_ptr);
 
     if (pa_ptr->magical_effect == MagicalBrandEffect::STUN)

--- a/src/player-attack/blood-sucking-processor.cpp
+++ b/src/player-attack/blood-sucking-processor.cpp
@@ -30,7 +30,7 @@ void decide_blood_sucking(player_type *attacker_ptr, player_attack_type *pa_ptr)
     bool is_blood_sucker = pa_ptr->flags.has(TR_VAMPIRIC);
     is_blood_sucker |= pa_ptr->chaos_effect == CE_VAMPIRIC;
     is_blood_sucker |= pa_ptr->mode == HISSATSU_DRAIN;
-    is_blood_sucker |= hex_spelling(attacker_ptr, HEX_VAMP_BLADE);
+    is_blood_sucker |= RealmHex(attacker_ptr).hex_spelling(HEX_VAMP_BLADE);
     if (!is_blood_sucker)
         return;
 
@@ -103,7 +103,7 @@ static void drain_result(player_type *attacker_ptr, player_attack_type *pa_ptr, 
 
     int drain_heal = damroll(2, pa_ptr->drain_result / 6);
 
-    if (hex_spelling(attacker_ptr, HEX_VAMP_BLADE))
+    if (RealmHex(attacker_ptr).hex_spelling(HEX_VAMP_BLADE))
         drain_heal *= 2;
 
     if (cheat_xtra) {

--- a/src/player-attack/blood-sucking-processor.cpp
+++ b/src/player-attack/blood-sucking-processor.cpp
@@ -30,7 +30,7 @@ void decide_blood_sucking(player_type *attacker_ptr, player_attack_type *pa_ptr)
     bool is_blood_sucker = pa_ptr->flags.has(TR_VAMPIRIC);
     is_blood_sucker |= pa_ptr->chaos_effect == CE_VAMPIRIC;
     is_blood_sucker |= pa_ptr->mode == HISSATSU_DRAIN;
-    is_blood_sucker |= RealmHex(attacker_ptr).hex_spelling(HEX_VAMP_BLADE);
+    is_blood_sucker |= RealmHex(attacker_ptr).is_spelling_specific(HEX_VAMP_BLADE);
     if (!is_blood_sucker)
         return;
 
@@ -103,7 +103,7 @@ static void drain_result(player_type *attacker_ptr, player_attack_type *pa_ptr, 
 
     int drain_heal = damroll(2, pa_ptr->drain_result / 6);
 
-    if (RealmHex(attacker_ptr).hex_spelling(HEX_VAMP_BLADE))
+    if (RealmHex(attacker_ptr).is_spelling_specific(HEX_VAMP_BLADE))
         drain_heal *= 2;
 
     if (cheat_xtra) {

--- a/src/player-attack/player-attack.cpp
+++ b/src/player-attack/player-attack.cpp
@@ -488,9 +488,8 @@ static void apply_actual_attack(
     decide_blood_sucking(attacker_ptr, pa_ptr);
 
     // process_monk_attackの中でplayer_type->magic_num1[0] を書き換えているので、ここでhex_spelling() の判定をしないとダメ.
-    bool vorpal_cut
-        = (pa_ptr->flags.has(TR_VORPAL) || hex_spelling(attacker_ptr, HEX_RUNESWORD)) && (randint1(vorpal_chance * 3 / 2) == 1) && !is_zantetsu_nullified;
-
+    bool vorpal_cut = (pa_ptr->flags.has(TR_VORPAL) || RealmHex(attacker_ptr).hex_spelling(HEX_RUNESWORD)) && (randint1(vorpal_chance * 3 / 2) == 1)
+        && !is_zantetsu_nullified;
     calc_attack_damage(attacker_ptr, pa_ptr, do_quake, vorpal_cut, vorpal_chance);
     apply_damage_bonus(attacker_ptr, pa_ptr);
     apply_damage_negative_effect(pa_ptr, is_zantetsu_nullified, is_ej_nullified);

--- a/src/player-attack/player-attack.cpp
+++ b/src/player-attack/player-attack.cpp
@@ -487,8 +487,8 @@ static void apply_actual_attack(
     pa_ptr->magical_effect = select_magical_brand_effect(attacker_ptr, pa_ptr);
     decide_blood_sucking(attacker_ptr, pa_ptr);
 
-    // process_monk_attackの中でplayer_type->magic_num1[0] を書き換えているので、ここでhex_spelling() の判定をしないとダメ.
-    bool vorpal_cut = (pa_ptr->flags.has(TR_VORPAL) || RealmHex(attacker_ptr).hex_spelling(HEX_RUNESWORD)) && (randint1(vorpal_chance * 3 / 2) == 1)
+    // process_monk_attackの中でplayer_type->magic_num1[0] を書き換えているので、ここでis_spelling_specific() の判定をしないとダメ.
+    bool vorpal_cut = (pa_ptr->flags.has(TR_VORPAL) || RealmHex(attacker_ptr).is_spelling_specific(HEX_RUNESWORD)) && (randint1(vorpal_chance * 3 / 2) == 1)
         && !is_zantetsu_nullified;
     calc_attack_damage(attacker_ptr, pa_ptr, do_quake, vorpal_cut, vorpal_chance);
     apply_damage_bonus(attacker_ptr, pa_ptr);

--- a/src/player-status/player-speed.cpp
+++ b/src/player-status/player-speed.cpp
@@ -208,7 +208,7 @@ int16_t PlayerSpeed::time_effect_value()
     }
 
     if (this->owner_ptr->realm1 == REALM_HEX) {
-        if (hex_spelling(this->owner_ptr, HEX_SHOCK_CLOAK)) {
+        if (RealmHex(this->owner_ptr).hex_spelling(HEX_SHOCK_CLOAK)) {
             result += 3;
         }
     }

--- a/src/player-status/player-speed.cpp
+++ b/src/player-status/player-speed.cpp
@@ -208,7 +208,7 @@ int16_t PlayerSpeed::time_effect_value()
     }
 
     if (this->owner_ptr->realm1 == REALM_HEX) {
-        if (RealmHex(this->owner_ptr).hex_spelling(HEX_SHOCK_CLOAK)) {
+        if (RealmHex(this->owner_ptr).is_spelling_specific(HEX_SHOCK_CLOAK)) {
             result += 3;
         }
     }

--- a/src/player-status/player-stealth.cpp
+++ b/src/player-status/player-stealth.cpp
@@ -113,7 +113,7 @@ int16_t PlayerStealth::time_effect_value()
 {
     int16_t result = 0;
     if (this->owner_ptr->realm1 == REALM_HEX) {
-        if (RealmHex(this->owner_ptr).hex_spelling_any())
+        if (RealmHex(this->owner_ptr).is_spelling_any())
             result -= (1 + casting_hex_num(this->owner_ptr));
     }
     if (is_shero(this->owner_ptr)) {

--- a/src/player-status/player-stealth.cpp
+++ b/src/player-status/player-stealth.cpp
@@ -113,7 +113,7 @@ int16_t PlayerStealth::time_effect_value()
 {
     int16_t result = 0;
     if (this->owner_ptr->realm1 == REALM_HEX) {
-        if (hex_spelling_any(this->owner_ptr))
+        if (RealmHex(this->owner_ptr).hex_spelling_any())
             result -= (1 + casting_hex_num(this->owner_ptr));
     }
     if (is_shero(this->owner_ptr)) {

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -494,7 +494,7 @@ BIT_FLAGS has_esp_evil(player_type *creature_ptr)
 {
     BIT_FLAGS result = 0L;
     if (creature_ptr->realm1 == REALM_HEX) {
-        if (RealmHex(creature_ptr).hex_spelling(HEX_DETECT_EVIL))
+        if (RealmHex(creature_ptr).is_spelling_specific(HEX_DETECT_EVIL))
             result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
     result |= check_equipment_flags(creature_ptr, TR_ESP_EVIL);
@@ -801,7 +801,7 @@ BIT_FLAGS has_sh_fire(player_type *creature_ptr)
         result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
-    if (RealmHex(creature_ptr).hex_spelling(HEX_DEMON_AURA) || creature_ptr->ult_res || creature_ptr->tim_sh_fire) {
+    if (RealmHex(creature_ptr).is_spelling_specific(HEX_DEMON_AURA) || creature_ptr->ult_res || creature_ptr->tim_sh_fire) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -819,7 +819,7 @@ BIT_FLAGS has_sh_elec(player_type *creature_ptr)
     if (creature_ptr->muta.has(MUTA::ELEC_TOUC))
         result |= FLAG_CAUSE_MUTATION;
 
-    if (RealmHex(creature_ptr).hex_spelling(HEX_SHOCK_CLOAK) || creature_ptr->ult_res) {
+    if (RealmHex(creature_ptr).is_spelling_specific(HEX_SHOCK_CLOAK) || creature_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -842,7 +842,7 @@ BIT_FLAGS has_sh_cold(player_type *creature_ptr)
         result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
-    if (creature_ptr->ult_res || RealmHex(creature_ptr).hex_spelling(HEX_ICE_ARMOR)) {
+    if (creature_ptr->ult_res || RealmHex(creature_ptr).is_spelling_specific(HEX_ICE_ARMOR)) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -1167,7 +1167,7 @@ BIT_FLAGS has_regenerate(player_type *creature_ptr)
         result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
-    if (RealmHex(creature_ptr).hex_spelling(HEX_DEMON_AURA) || creature_ptr->ult_res || creature_ptr->tim_regen) {
+    if (RealmHex(creature_ptr).is_spelling_specific(HEX_DEMON_AURA) || creature_ptr->ult_res || creature_ptr->tim_regen) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -494,7 +494,7 @@ BIT_FLAGS has_esp_evil(player_type *creature_ptr)
 {
     BIT_FLAGS result = 0L;
     if (creature_ptr->realm1 == REALM_HEX) {
-        if (hex_spelling(creature_ptr, HEX_DETECT_EVIL))
+        if (RealmHex(creature_ptr).hex_spelling(HEX_DETECT_EVIL))
             result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
     result |= check_equipment_flags(creature_ptr, TR_ESP_EVIL);
@@ -801,7 +801,7 @@ BIT_FLAGS has_sh_fire(player_type *creature_ptr)
         result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
-    if (hex_spelling(creature_ptr, HEX_DEMON_AURA) || creature_ptr->ult_res || creature_ptr->tim_sh_fire) {
+    if (RealmHex(creature_ptr).hex_spelling(HEX_DEMON_AURA) || creature_ptr->ult_res || creature_ptr->tim_sh_fire) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -819,7 +819,7 @@ BIT_FLAGS has_sh_elec(player_type *creature_ptr)
     if (creature_ptr->muta.has(MUTA::ELEC_TOUC))
         result |= FLAG_CAUSE_MUTATION;
 
-    if (hex_spelling(creature_ptr, HEX_SHOCK_CLOAK) || creature_ptr->ult_res) {
+    if (RealmHex(creature_ptr).hex_spelling(HEX_SHOCK_CLOAK) || creature_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -842,7 +842,7 @@ BIT_FLAGS has_sh_cold(player_type *creature_ptr)
         result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
-    if (creature_ptr->ult_res || hex_spelling(creature_ptr, HEX_ICE_ARMOR)) {
+    if (creature_ptr->ult_res || RealmHex(creature_ptr).hex_spelling(HEX_ICE_ARMOR)) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -1167,7 +1167,7 @@ BIT_FLAGS has_regenerate(player_type *creature_ptr)
         result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
-    if (hex_spelling(creature_ptr, HEX_DEMON_AURA) || creature_ptr->ult_res || creature_ptr->tim_regen) {
+    if (RealmHex(creature_ptr).hex_spelling(HEX_DEMON_AURA) || creature_ptr->ult_res || creature_ptr->tim_regen) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -2969,7 +2969,7 @@ void stop_mouth(player_type *caster_ptr)
     if (music_singing_any(caster_ptr))
         stop_singing(caster_ptr);
 
-    if (hex_spelling_any(caster_ptr)) {
+    if (RealmHex(caster_ptr).hex_spelling_any()) {
         (void)RealmHex(caster_ptr).stop_hex_spell_all();
     }
 }

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -491,9 +491,9 @@ static void update_max_hitpoints(player_type *creature_ptr)
         mhp += 30;
     if (creature_ptr->tsuyoshi)
         mhp += 50;
-    if (RealmHex(creature_ptr).hex_spelling(HEX_XTRA_MIGHT))
+    if (RealmHex(creature_ptr).is_spelling_specific(HEX_XTRA_MIGHT))
         mhp += 15;
-    if (RealmHex(creature_ptr).hex_spelling(HEX_BUILDING))
+    if (RealmHex(creature_ptr).is_spelling_specific(HEX_BUILDING))
         mhp += 60;
     if (creature_ptr->mhp == mhp)
         return;
@@ -1442,7 +1442,7 @@ static int16_t calc_num_blow(player_type *creature_ptr, int i)
                 mul = 4;
             }
 
-            if (RealmHex(creature_ptr).hex_spelling(HEX_XTRA_MIGHT) || RealmHex(creature_ptr).hex_spelling(HEX_BUILDING)) {
+            if (RealmHex(creature_ptr).is_spelling_specific(HEX_XTRA_MIGHT) || RealmHex(creature_ptr).is_spelling_specific(HEX_BUILDING)) {
                 num++;
                 wgt /= 2;
                 mul += 2;
@@ -1710,7 +1710,7 @@ static ARMOUR_CLASS calc_to_ac(player_type *creature_ptr, bool is_real_value)
     }
 
     if (creature_ptr->realm1 == REALM_HEX) {
-        if (RealmHex(creature_ptr).hex_spelling(HEX_ICE_ARMOR)) {
+        if (RealmHex(creature_ptr).is_spelling_specific(HEX_ICE_ARMOR)) {
             ac += 30;
         }
 
@@ -1995,7 +1995,7 @@ static int16_t calc_to_damage(player_type *creature_ptr, INVENTORY_IDX slot, boo
     }
 
     if ((creature_ptr->realm1 == REALM_HEX) && o_ptr->is_cursed()) {
-        if (RealmHex(creature_ptr).hex_spelling(HEX_RUNESWORD)) {
+        if (RealmHex(creature_ptr).is_spelling_specific(HEX_RUNESWORD)) {
             if (o_ptr->curse_flags.has(TRC::CURSED)) {
                 damage += 5;
             }
@@ -2937,7 +2937,7 @@ long calc_score(player_type *creature_ptr)
  */
 bool is_blessed(player_type *creature_ptr)
 {
-    return creature_ptr->blessed || music_singing(creature_ptr, MUSIC_BLESS) || RealmHex(creature_ptr).hex_spelling(HEX_BLESS);
+    return creature_ptr->blessed || music_singing(creature_ptr, MUSIC_BLESS) || RealmHex(creature_ptr).is_spelling_specific(HEX_BLESS);
 }
 
 bool is_tim_esp(player_type *creature_ptr)
@@ -2969,8 +2969,8 @@ void stop_mouth(player_type *caster_ptr)
     if (music_singing_any(caster_ptr))
         stop_singing(caster_ptr);
 
-    if (RealmHex(caster_ptr).hex_spelling_any()) {
-        (void)RealmHex(caster_ptr).stop_hex_spell_all();
+    if (RealmHex(caster_ptr).is_spelling_any()) {
+        (void)RealmHex(caster_ptr).stop_all_spells();
     }
 }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -2968,8 +2968,10 @@ void stop_mouth(player_type *caster_ptr)
 {
     if (music_singing_any(caster_ptr))
         stop_singing(caster_ptr);
-    if (hex_spelling_any(caster_ptr))
-        stop_hex_spell_all(caster_ptr);
+
+    if (hex_spelling_any(caster_ptr)) {
+        (void)RealmHex(caster_ptr).stop_hex_spell_all();
+    }
 }
 
 bool is_fast(player_type *creature_ptr)

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -491,9 +491,9 @@ static void update_max_hitpoints(player_type *creature_ptr)
         mhp += 30;
     if (creature_ptr->tsuyoshi)
         mhp += 50;
-    if (hex_spelling(creature_ptr, HEX_XTRA_MIGHT))
+    if (RealmHex(creature_ptr).hex_spelling(HEX_XTRA_MIGHT))
         mhp += 15;
-    if (hex_spelling(creature_ptr, HEX_BUILDING))
+    if (RealmHex(creature_ptr).hex_spelling(HEX_BUILDING))
         mhp += 60;
     if (creature_ptr->mhp == mhp)
         return;
@@ -1442,7 +1442,7 @@ static int16_t calc_num_blow(player_type *creature_ptr, int i)
                 mul = 4;
             }
 
-            if (hex_spelling(creature_ptr, HEX_XTRA_MIGHT) || hex_spelling(creature_ptr, HEX_BUILDING)) {
+            if (RealmHex(creature_ptr).hex_spelling(HEX_XTRA_MIGHT) || RealmHex(creature_ptr).hex_spelling(HEX_BUILDING)) {
                 num++;
                 wgt /= 2;
                 mul += 2;
@@ -1710,7 +1710,7 @@ static ARMOUR_CLASS calc_to_ac(player_type *creature_ptr, bool is_real_value)
     }
 
     if (creature_ptr->realm1 == REALM_HEX) {
-        if (hex_spelling(creature_ptr, HEX_ICE_ARMOR)) {
+        if (RealmHex(creature_ptr).hex_spelling(HEX_ICE_ARMOR)) {
             ac += 30;
         }
 
@@ -1995,7 +1995,7 @@ static int16_t calc_to_damage(player_type *creature_ptr, INVENTORY_IDX slot, boo
     }
 
     if ((creature_ptr->realm1 == REALM_HEX) && o_ptr->is_cursed()) {
-        if (hex_spelling(creature_ptr, HEX_RUNESWORD)) {
+        if (RealmHex(creature_ptr).hex_spelling(HEX_RUNESWORD)) {
             if (o_ptr->curse_flags.has(TRC::CURSED)) {
                 damage += 5;
             }
@@ -2937,7 +2937,7 @@ long calc_score(player_type *creature_ptr)
  */
 bool is_blessed(player_type *creature_ptr)
 {
-    return creature_ptr->blessed || music_singing(creature_ptr, MUSIC_BLESS) || hex_spelling(creature_ptr, HEX_BLESS);
+    return creature_ptr->blessed || music_singing(creature_ptr, MUSIC_BLESS) || RealmHex(creature_ptr).hex_spelling(HEX_BLESS);
 }
 
 bool is_tim_esp(player_type *creature_ptr)

--- a/src/racial/racial-switcher.cpp
+++ b/src/racial/racial-switcher.cpp
@@ -92,7 +92,7 @@ bool switch_class_racial_execution(player_type *creature_ptr, const int32_t comm
         return sword_dancing(creature_ptr);
     case CLASS_HIGH_MAGE:
         if (creature_ptr->realm1 == REALM_HEX) {
-            auto retval = RealmHex(creature_ptr).stop_hex_spell();
+            auto retval = RealmHex(creature_ptr).stop_one_spell();
             if (retval) {
                 PlayerEnergy(creature_ptr).set_player_turn_energy(10);
             }

--- a/src/racial/racial-switcher.cpp
+++ b/src/racial/racial-switcher.cpp
@@ -92,7 +92,7 @@ bool switch_class_racial_execution(player_type *creature_ptr, const int32_t comm
         return sword_dancing(creature_ptr);
     case CLASS_HIGH_MAGE:
         if (creature_ptr->realm1 == REALM_HEX) {
-            bool retval = stop_hex_spell(creature_ptr);
+            auto retval = RealmHex(creature_ptr).stop_hex_spell();
             if (retval) {
                 PlayerEnergy(creature_ptr).set_player_turn_energy(10);
             }

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -238,15 +238,7 @@ void RealmHex::gain_exp_from_hex()
             continue;
         }
 
-        auto *floor_ptr = this->caster_ptr->current_floor_ptr;
-        if (this->caster_ptr->spell_exp[spell] < SPELL_EXP_MASTER) {
-            auto gain_condition = one_in_(5);
-            gain_condition &= (floor_ptr->dun_level + 5) > this->caster_ptr->lev;
-            gain_condition &= floor_ptr->dun_level > s_ptr->slevel;
-            if (gain_condition) {
-                this->caster_ptr->spell_exp[spell]++;
-            }
-        }
+        this->gain_exp_master(spell, s_ptr);
     }
 }
 
@@ -282,6 +274,21 @@ bool RealmHex::gain_exp_expert(const int spell, const magic_type *s_ptr)
     }
 
     return true;
+}
+
+void RealmHex::gain_exp_master(const int spell, const magic_type *s_ptr)
+{
+    if (this->caster_ptr->spell_exp[spell] >= SPELL_EXP_MASTER) {
+        return;
+    }
+
+    auto *floor_ptr = this->caster_ptr->current_floor_ptr;
+    auto gain_condition = one_in_(5);
+    gain_condition &= (floor_ptr->dun_level + 5) > this->caster_ptr->lev;
+    gain_condition &= floor_ptr->dun_level > s_ptr->slevel;
+    if (gain_condition) {
+        this->caster_ptr->spell_exp[spell]++;
+    }
 }
 
 /*!

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -325,7 +325,7 @@ void RealmHex::revenge_spell()
  * @brief 復讐ダメージの追加を行う
  * @param dam 蓄積されるダメージ量
  */
-void revenge_store(player_type *caster_ptr, HIT_POINT dam)
+void RealmHex::revenge_store(HIT_POINT dam)
 {
     if (caster_ptr->realm1 != REALM_HEX)
         return;

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -30,23 +30,23 @@ RealmHex::RealmHex(player_type *caster_ptr)
 /*!
  * @brief プレイヤーが詠唱中の全呪術を停止する
  */
-bool stop_hex_spell_all(player_type *caster_ptr)
+bool RealmHex::stop_hex_spell_all()
 {
     SPELL_IDX i;
 
     for (i = 0; i < 32; i++) {
-        if (hex_spelling(caster_ptr, i))
-            exe_spell(caster_ptr, REALM_HEX, i, SPELL_STOP);
+        if (hex_spelling(this->caster_ptr, i))
+            exe_spell(this->caster_ptr, REALM_HEX, i, SPELL_STOP);
     }
 
-    casting_hex_flags(caster_ptr) = 0;
-    casting_hex_num(caster_ptr) = 0;
+    casting_hex_flags(this->caster_ptr) = 0;
+    casting_hex_num(this->caster_ptr) = 0;
 
-    if (caster_ptr->action == ACTION_SPELL)
-        set_action(caster_ptr, ACTION_NONE);
+    if (this->caster_ptr->action == ACTION_SPELL)
+        set_action(this->caster_ptr, ACTION_NONE);
 
-    caster_ptr->update |= (PU_BONUS | PU_HP | PU_MANA | PU_SPELLS);
-    caster_ptr->redraw |= (PR_EXTRA | PR_HP | PR_MANA);
+    this->caster_ptr->update |= (PU_BONUS | PU_HP | PU_MANA | PU_SPELLS);
+    this->caster_ptr->redraw |= (PR_EXTRA | PR_HP | PR_MANA);
 
     return true;
 }
@@ -62,7 +62,7 @@ bool RealmHex::stop_hex_spell()
     }
 
     if ((casting_hex_num(this->caster_ptr) == 1) || (this->caster_ptr->lev < 35)) {
-        return stop_hex_spell_all(this->caster_ptr);
+        return this->stop_hex_spell_all();
     }
 
     char out_val[160];
@@ -107,7 +107,7 @@ bool RealmHex::select_spell_stopping(int *sp, char *out_val, char *choice)
         /* All */
         if (*choice == 'l') {
             screen_load();
-            return stop_hex_spell_all(this->caster_ptr);
+            return this->stop_hex_spell_all();
         }
 
         if ((*choice < I2A(0)) || (*choice > I2A(casting_hex_num(this->caster_ptr) - 1))) {
@@ -150,7 +150,7 @@ void RealmHex::check_hex()
 
     auto need_restart = this->check_restart();
     if (this->caster_ptr->anti_magic) {
-        stop_hex_spell_all(this->caster_ptr);
+        this->stop_hex_spell_all();
         return;
     }
 
@@ -174,7 +174,7 @@ void RealmHex::process_mana_cost(const bool need_restart)
 
     auto enough_mana = s64b_cmp(this->caster_ptr->csp, this->caster_ptr->csp_frac, need_mana, need_mana_frac) < 0;
     if (!enough_mana) {
-        stop_hex_spell_all(this->caster_ptr);
+        this->stop_hex_spell_all();
         return;
     }
 

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -134,7 +134,7 @@ bool RealmHex::select_spell_stopping(int *sp, char *out_val, char *choice)
  * @brief 一定時間毎に呪術で消費するMPを処理する /
  * Upkeeping hex spells Called from dungeon.c
  */
-void check_hex(player_type *caster_ptr)
+void RealmHex::check_hex()
 {
     int spell;
     MANA_POINT need_mana;
@@ -142,57 +142,57 @@ void check_hex(player_type *caster_ptr)
     bool res = false;
 
     /* Spells spelled by player */
-    if (caster_ptr->realm1 != REALM_HEX)
+    if (this->caster_ptr->realm1 != REALM_HEX)
         return;
-    if (!casting_hex_flags(caster_ptr) && !caster_ptr->magic_num1[1])
+    if (!casting_hex_flags(this->caster_ptr) && !this->caster_ptr->magic_num1[1])
         return;
 
-    if (caster_ptr->magic_num1[1]) {
-        caster_ptr->magic_num1[0] = caster_ptr->magic_num1[1];
-        caster_ptr->magic_num1[1] = 0;
+    if (this->caster_ptr->magic_num1[1]) {
+        this->caster_ptr->magic_num1[0] = this->caster_ptr->magic_num1[1];
+        this->caster_ptr->magic_num1[1] = 0;
         res = true;
     }
 
     /* Stop all spells when anti-magic ability is given */
-    if (caster_ptr->anti_magic) {
-        stop_hex_spell_all(caster_ptr);
+    if (this->caster_ptr->anti_magic) {
+        stop_hex_spell_all(this->caster_ptr);
         return;
     }
 
     need_mana = 0;
     for (spell = 0; spell < 32; spell++) {
-        if (hex_spelling(caster_ptr, spell)) {
+        if (hex_spelling(this->caster_ptr, spell)) {
             const magic_type *s_ptr;
             s_ptr = &technic_info[REALM_HEX - MIN_TECHNIC][spell];
-            need_mana += mod_need_mana(caster_ptr, s_ptr->smana, spell, REALM_HEX);
+            need_mana += mod_need_mana(this->caster_ptr, s_ptr->smana, spell, REALM_HEX);
         }
     }
 
     /* Culcurates final mana cost */
     need_mana_frac = 0;
     s64b_div(&need_mana, &need_mana_frac, 0, 3); /* Divide by 3 */
-    need_mana += (casting_hex_num(caster_ptr) - 1);
+    need_mana += (casting_hex_num(this->caster_ptr) - 1);
 
     /* Not enough mana */
-    if (s64b_cmp(caster_ptr->csp, caster_ptr->csp_frac, need_mana, need_mana_frac) < 0) {
-        stop_hex_spell_all(caster_ptr);
+    if (s64b_cmp(this->caster_ptr->csp, this->caster_ptr->csp_frac, need_mana, need_mana_frac) < 0) {
+        stop_hex_spell_all(this->caster_ptr);
         return;
     }
 
     /* Enough mana */
     else {
-        s64b_sub(&(caster_ptr->csp), &(caster_ptr->csp_frac), need_mana, need_mana_frac);
+        s64b_sub(&(this->caster_ptr->csp), &(this->caster_ptr->csp_frac), need_mana, need_mana_frac);
 
-        caster_ptr->redraw |= PR_MANA;
+        this->caster_ptr->redraw |= PR_MANA;
         if (res) {
             msg_print(_("詠唱を再開した。", "You restart casting."));
 
-            caster_ptr->action = ACTION_SPELL;
+            this->caster_ptr->action = ACTION_SPELL;
 
-            caster_ptr->update |= (PU_BONUS | PU_HP);
-            caster_ptr->redraw |= (PR_MAP | PR_STATUS | PR_STATE);
-            caster_ptr->update |= (PU_MONSTERS);
-            caster_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
+            this->caster_ptr->update |= (PU_BONUS | PU_HP);
+            this->caster_ptr->redraw |= (PR_MAP | PR_STATUS | PR_STATE);
+            this->caster_ptr->update |= (PU_MONSTERS);
+            this->caster_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
         }
     }
 
@@ -200,30 +200,30 @@ void check_hex(player_type *caster_ptr)
     for (spell = 0; spell < 32; spell++) {
         const magic_type *s_ptr;
 
-        if (!hex_spelling(caster_ptr, spell))
+        if (!hex_spelling(this->caster_ptr, spell))
             continue;
 
         s_ptr = &technic_info[REALM_HEX - MIN_TECHNIC][spell];
 
-        if (caster_ptr->spell_exp[spell] < SPELL_EXP_BEGINNER)
-            caster_ptr->spell_exp[spell] += 5;
-        else if (caster_ptr->spell_exp[spell] < SPELL_EXP_SKILLED) {
-            if (one_in_(2) && (caster_ptr->current_floor_ptr->dun_level > 4) && ((caster_ptr->current_floor_ptr->dun_level + 10) > caster_ptr->lev))
-                caster_ptr->spell_exp[spell] += 1;
-        } else if (caster_ptr->spell_exp[spell] < SPELL_EXP_EXPERT) {
-            if (one_in_(5) && ((caster_ptr->current_floor_ptr->dun_level + 5) > caster_ptr->lev)
-                && ((caster_ptr->current_floor_ptr->dun_level + 5) > s_ptr->slevel))
-                caster_ptr->spell_exp[spell] += 1;
-        } else if (caster_ptr->spell_exp[spell] < SPELL_EXP_MASTER) {
-            if (one_in_(5) && ((caster_ptr->current_floor_ptr->dun_level + 5) > caster_ptr->lev) && (caster_ptr->current_floor_ptr->dun_level > s_ptr->slevel))
-                caster_ptr->spell_exp[spell] += 1;
+        if (this->caster_ptr->spell_exp[spell] < SPELL_EXP_BEGINNER)
+            this->caster_ptr->spell_exp[spell] += 5;
+        else if (this->caster_ptr->spell_exp[spell] < SPELL_EXP_SKILLED) {
+            if (one_in_(2) && (this->caster_ptr->current_floor_ptr->dun_level > 4) && ((this->caster_ptr->current_floor_ptr->dun_level + 10) > this->caster_ptr->lev))
+                this->caster_ptr->spell_exp[spell] += 1;
+        } else if (this->caster_ptr->spell_exp[spell] < SPELL_EXP_EXPERT) {
+            if (one_in_(5) && ((this->caster_ptr->current_floor_ptr->dun_level + 5) > this->caster_ptr->lev)
+                && ((this->caster_ptr->current_floor_ptr->dun_level + 5) > s_ptr->slevel))
+                this->caster_ptr->spell_exp[spell] += 1;
+        } else if (this->caster_ptr->spell_exp[spell] < SPELL_EXP_MASTER) {
+            if (one_in_(5) && ((this->caster_ptr->current_floor_ptr->dun_level + 5) > this->caster_ptr->lev) && (this->caster_ptr->current_floor_ptr->dun_level > s_ptr->slevel))
+                this->caster_ptr->spell_exp[spell] += 1;
         }
     }
 
     /* Do any effects of continual spells */
     for (spell = 0; spell < 32; spell++) {
-        if (hex_spelling(caster_ptr, spell)) {
-            exe_spell(caster_ptr, REALM_HEX, spell, SPELL_CONT);
+        if (hex_spelling(this->caster_ptr, spell)) {
+            exe_spell(this->caster_ptr, REALM_HEX, spell, SPELL_CONT);
         }
     }
 }

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -94,20 +94,8 @@ bool RealmHex::stop_hex_spell()
  */
 bool RealmHex::select_spell_stopping(int *sp, char *out_val, char *choice)
 {
-    auto y = 1;
-    auto x = 20;
     while (true) {
-        auto n = 0;
-        term_erase(x, y, 255);
-        prt(_("     名前", "     Name"), y, x + 5);
-        for (auto spell = 0; spell < 32; spell++) {
-            if (hex_spelling(this->caster_ptr, spell)) {
-                term_erase(x, y + n + 1, 255);
-                put_str(format("%c)  %s", I2A(n), exe_spell(this->caster_ptr, REALM_HEX, spell, SPELL_NAME)), y + n + 1, x + 2);
-                sp[n++] = spell;
-            }
-        }
-
+        this->display_spells_list(sp);
         if (!get_com(out_val, choice, true)) {
             return false;
         }
@@ -130,9 +118,24 @@ bool RealmHex::select_spell_stopping(int *sp, char *out_val, char *choice)
     }
 }
 
+void RealmHex::display_spells_list(int *sp)
+{
+    constexpr auto y = 1;
+    constexpr auto x = 20;
+    auto n = 0;
+    term_erase(x, y, 255);
+    prt(_("     名前", "     Name"), y, x + 5);
+    for (auto spell = 0; spell < 32; spell++) {
+        if (hex_spelling(this->caster_ptr, spell)) {
+            term_erase(x, y + n + 1, 255);
+            put_str(format("%c)  %s", I2A(n), exe_spell(this->caster_ptr, REALM_HEX, spell, SPELL_NAME)), y + n + 1, x + 2);
+            sp[n++] = spell;
+        }
+    }
+}
+
 /*!
- * @brief 一定時間毎に呪術で消費するMPを処理する /
- * Upkeeping hex spells Called from dungeon.c
+ * @brief 一定時間毎に呪術で消費するMPを処理する
  */
 void RealmHex::check_hex()
 {
@@ -146,8 +149,6 @@ void RealmHex::check_hex()
     }
 
     auto need_restart = this->check_restart();
-
-    /* Stop all spells when anti-magic ability is given */
     if (this->caster_ptr->anti_magic) {
         stop_hex_spell_all(this->caster_ptr);
         return;
@@ -167,8 +168,6 @@ void RealmHex::check_hex()
 void RealmHex::process_mana_cost(const bool need_restart)
 {
     auto need_mana = this->calc_need_mana();
-
-    /* Culcurates final mana cost */
     uint need_mana_frac = 0;
     s64b_div(&need_mana, &need_mana_frac, 0, 3); /* Divide by 3 */
     need_mana += (casting_hex_num(this->caster_ptr) - 1);

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -351,7 +351,7 @@ bool RealmHex::teleport_barrier(MONSTER_IDX m_idx)
  * @param m_idx 判定の対象となるモンスターID
  * @return 反魔法の効果が適用されるならTRUEを返す
  */
-bool magic_barrier(player_type *caster_ptr, MONSTER_IDX m_idx)
+bool RealmHex::magic_barrier(MONSTER_IDX m_idx)
 {
     monster_type *m_ptr = &caster_ptr->current_floor_ptr->m_list[m_idx];
     monster_race *r_ptr = &r_info[m_ptr->r_idx];

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -154,51 +154,7 @@ void RealmHex::check_hex()
     }
 
     this->process_mana_cost(need_restart);
-        
-    /* Gain experiences of spelling spells */
-    for (auto spell = 0; spell < 32; spell++) {
-        if (!hex_spelling(this->caster_ptr, spell)) {
-            continue;
-        }
-
-        const auto *s_ptr = &technic_info[REALM_HEX - MIN_TECHNIC][spell];
-        if (this->caster_ptr->spell_exp[spell] < SPELL_EXP_BEGINNER) {
-            this->caster_ptr->spell_exp[spell] += 5;
-            continue;
-        }
-
-        auto *floor_ptr = this->caster_ptr->current_floor_ptr;
-        if (this->caster_ptr->spell_exp[spell] < SPELL_EXP_SKILLED) {
-            auto condition = one_in_(2);
-            condition &= floor_ptr->dun_level > 4;
-            condition &= (floor_ptr->dun_level + 10) > this->caster_ptr->lev;
-            if (condition) {
-                this->caster_ptr->spell_exp[spell]++;
-            }
-
-            continue;
-        }
-
-        if (this->caster_ptr->spell_exp[spell] < SPELL_EXP_EXPERT) {
-            auto condition = one_in_(5);
-            condition &= (floor_ptr->dun_level + 5) > this->caster_ptr->lev;
-            condition &= (floor_ptr->dun_level + 5) > s_ptr->slevel;
-            if (condition) {
-                this->caster_ptr->spell_exp[spell]++;
-            }
-
-            continue;
-        }
-
-        if (this->caster_ptr->spell_exp[spell] < SPELL_EXP_MASTER) {
-            auto condition = one_in_(5);
-            condition &= (floor_ptr->dun_level + 5) > this->caster_ptr->lev;
-            condition &= floor_ptr->dun_level > s_ptr->slevel;
-            if (condition) {
-                this->caster_ptr->spell_exp[spell]++;
-            }
-        }
-    }
+    this->gain_exp_from_hex();        
 
     /* Do any effects of continual spells */
     for (auto spell = 0; spell < 32; spell++) {
@@ -259,6 +215,53 @@ int RealmHex::calc_need_mana()
     }
 
     return need_mana;
+}
+
+void RealmHex::gain_exp_from_hex()
+{
+    for (auto spell = 0; spell < 32; spell++) {
+        if (!hex_spelling(this->caster_ptr, spell)) {
+            continue;
+        }
+
+        const auto *s_ptr = &technic_info[REALM_HEX - MIN_TECHNIC][spell];
+        if (this->caster_ptr->spell_exp[spell] < SPELL_EXP_BEGINNER) {
+            this->caster_ptr->spell_exp[spell] += 5;
+            continue;
+        }
+
+        auto *floor_ptr = this->caster_ptr->current_floor_ptr;
+        if (this->caster_ptr->spell_exp[spell] < SPELL_EXP_SKILLED) {
+            auto gain_condition = one_in_(2);
+            gain_condition &= floor_ptr->dun_level > 4;
+            gain_condition &= (floor_ptr->dun_level + 10) > this->caster_ptr->lev;
+            if (gain_condition) {
+                this->caster_ptr->spell_exp[spell]++;
+            }
+
+            continue;
+        }
+
+        if (this->caster_ptr->spell_exp[spell] < SPELL_EXP_EXPERT) {
+            auto gain_condition = one_in_(5);
+            gain_condition &= (floor_ptr->dun_level + 5) > this->caster_ptr->lev;
+            gain_condition &= (floor_ptr->dun_level + 5) > s_ptr->slevel;
+            if (gain_condition) {
+                this->caster_ptr->spell_exp[spell]++;
+            }
+
+            continue;
+        }
+
+        if (this->caster_ptr->spell_exp[spell] < SPELL_EXP_MASTER) {
+            auto gain_condition = one_in_(5);
+            gain_condition &= (floor_ptr->dun_level + 5) > this->caster_ptr->lev;
+            gain_condition &= floor_ptr->dun_level > s_ptr->slevel;
+            if (gain_condition) {
+                this->caster_ptr->spell_exp[spell]++;
+            }
+        }
+    }
 }
 
 /*!

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -55,7 +55,7 @@ bool RealmHex::stop_hex_spell_all()
  */
 bool RealmHex::stop_hex_spell()
 {
-    if (!hex_spelling_any(this->caster_ptr)) {
+    if (!RealmHex(this->caster_ptr).hex_spelling_any()) {
         msg_print(_("呪文を詠唱していません。", "You are not casting a spell."));
         return false;
     }
@@ -354,7 +354,7 @@ bool RealmHex::hex_spelling(int hex) const
     return (this->caster_ptr->realm1 == REALM_HEX) && any_bits(check, 1U << hex);
 }
 
-bool hex_spelling_any(player_type *caster_ptr)
+bool RealmHex::hex_spelling_any() const
 {
     return (caster_ptr->realm1 == REALM_HEX) && (caster_ptr->magic_num1[0] != 0);
 }

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -335,39 +335,16 @@ void RealmHex::revenge_store(HIT_POINT dam)
 }
 
 /*!
- * @brief 反テレポート結界の判定
+ * @brief 呪術結界の判定
  * @param m_idx 判定の対象となるモンスターID
- * @return 反テレポートの効果が適用されるならTRUEを返す
+ * @return 呪術の効果が適用されるならTRUEを返す
+ * @details v3.0.0現在は反テレポート・反魔法・反増殖の3種類
  */
-bool RealmHex::teleport_barrier(MONSTER_IDX m_idx)
+bool RealmHex::check_hex_barrier(MONSTER_IDX m_idx, realm_hex_type type) const
 {
     const auto *m_ptr = &this->caster_ptr->current_floor_ptr->m_list[m_idx];
     const auto *r_ptr = &r_info[m_ptr->r_idx];
-    return hex_spelling(this->caster_ptr, HEX_ANTI_TELE) && ((this->caster_ptr->lev * 3 / 2) >= randint1(r_ptr->level));
-}
-
-/*!
- * @brief 反魔法結界の判定
- * @param m_idx 判定の対象となるモンスターID
- * @return 反魔法の効果が適用されるならTRUEを返す
- */
-bool RealmHex::magic_barrier(MONSTER_IDX m_idx)
-{
-    const auto *m_ptr = &this->caster_ptr->current_floor_ptr->m_list[m_idx];
-    const auto *r_ptr = &r_info[m_ptr->r_idx];
-    return hex_spelling(this->caster_ptr, HEX_ANTI_MAGIC) && ((this->caster_ptr->lev * 3 / 2) >= randint1(r_ptr->level));
-}
-
-/*!
- * @brief 反増殖結界の判定
- * @param m_idx 判定の対象となるモンスターID
- * @return 反増殖の効果が適用されるならTRUEを返す
- */
-bool RealmHex::multiply_barrier(MONSTER_IDX m_idx)
-{
-    const auto *m_ptr = &this->caster_ptr->current_floor_ptr->m_list[m_idx];
-    const auto *r_ptr = &r_info[m_ptr->r_idx];
-    return hex_spelling(this->caster_ptr, HEX_ANTI_MULTI) && ((this->caster_ptr->lev * 3 / 2) >= randint1(r_ptr->level));
+    return hex_spelling(this->caster_ptr, type) && ((this->caster_ptr->lev * 3 / 2) >= randint1(r_ptr->level));
 }
 
 bool hex_spelling(player_type *caster_ptr, int hex)

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -70,7 +70,7 @@ bool RealmHex::stop_one_spell()
     screen_save();
     std::vector<int> sp(MAX_KEEP);
     char choice = 0;
-    auto flag = select_spell_stopping(sp, out_val, &choice);
+    auto flag = select_spell_stopping(sp, out_val, choice);
     screen_load();
     if (flag) {
         auto n = sp.at(A2I(choice));
@@ -91,25 +91,25 @@ bool RealmHex::stop_one_spell()
  * @param choice 選択した呪文
  * @return 選択が完了したらtrue、キャンセルならばfalse
  */
-bool RealmHex::select_spell_stopping(std::vector<int> &sp, char *out_val, char *choice)
+bool RealmHex::select_spell_stopping(std::vector<int> &sp, char *out_val, char &choice)
 {
     while (true) {
         this->display_spells_list(sp);
-        if (!get_com(out_val, choice, true)) {
+        if (!get_com(out_val, &choice, true)) {
             return false;
         }
 
-        if (isupper(*choice)) {
-            *choice = static_cast<char>(tolower(*choice));
+        if (isupper(choice)) {
+            choice = static_cast<char>(tolower(choice));
         }
 
         /* All */
-        if (*choice == 'l') {
+        if (choice == 'l') {
             screen_load();
             return this->stop_all_spells();
         }
 
-        if ((*choice < I2A(0)) || (*choice > I2A(casting_hex_num(this->caster_ptr) - 1))) {
+        if ((choice < I2A(0)) || (choice > I2A(casting_hex_num(this->caster_ptr) - 1))) {
             continue;
         }
 

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -327,12 +327,11 @@ void RealmHex::revenge_spell()
  */
 void RealmHex::revenge_store(HIT_POINT dam)
 {
-    if (caster_ptr->realm1 != REALM_HEX)
+    if ((this->caster_ptr->realm1 != REALM_HEX) || (hex_revenge_turn(this->caster_ptr) <= 0)) {
         return;
-    if (hex_revenge_turn(caster_ptr) <= 0)
-        return;
+    }
 
-    hex_revenge_power(caster_ptr) += dam;
+    hex_revenge_power(this->caster_ptr) += dam;
 }
 
 /*!

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -339,7 +339,7 @@ void RealmHex::revenge_store(HIT_POINT dam)
  * @param m_idx 判定の対象となるモンスターID
  * @return 反テレポートの効果が適用されるならTRUEを返す
  */
-bool teleport_barrier(player_type *caster_ptr, MONSTER_IDX m_idx)
+bool RealmHex::teleport_barrier(MONSTER_IDX m_idx)
 {
     monster_type *m_ptr = &caster_ptr->current_floor_ptr->m_list[m_idx];
     monster_race *r_ptr = &r_info[m_ptr->r_idx];

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -224,7 +224,6 @@ void RealmHex::gain_exp_from_hex()
             continue;
         }
 
-        const auto *s_ptr = &technic_info[REALM_HEX - MIN_TECHNIC][spell];
         if (this->caster_ptr->spell_exp[spell] < SPELL_EXP_BEGINNER) {
             this->caster_ptr->spell_exp[spell] += 5;
             continue;
@@ -234,11 +233,11 @@ void RealmHex::gain_exp_from_hex()
             continue;
         }
 
-        if (this->gain_exp_expert(spell, s_ptr)) {
+        if (this->gain_exp_expert(spell)) {
             continue;
         }
 
-        this->gain_exp_master(spell, s_ptr);
+        this->gain_exp_master(spell);
     }
 }
 
@@ -259,12 +258,13 @@ bool RealmHex::gain_exp_skilled(const int spell)
     return true;
 }
 
-bool RealmHex::gain_exp_expert(const int spell, const magic_type *s_ptr)
+bool RealmHex::gain_exp_expert(const int spell)
 {
     if (this->caster_ptr->spell_exp[spell] >= SPELL_EXP_EXPERT) {
         return false;
     }
 
+    const auto *s_ptr = &technic_info[REALM_HEX - MIN_TECHNIC][spell];
     auto *floor_ptr = this->caster_ptr->current_floor_ptr;
     auto gain_condition = one_in_(5);
     gain_condition &= (floor_ptr->dun_level + 5) > this->caster_ptr->lev;
@@ -276,12 +276,13 @@ bool RealmHex::gain_exp_expert(const int spell, const magic_type *s_ptr)
     return true;
 }
 
-void RealmHex::gain_exp_master(const int spell, const magic_type *s_ptr)
+void RealmHex::gain_exp_master(const int spell)
 {
     if (this->caster_ptr->spell_exp[spell] >= SPELL_EXP_MASTER) {
         return;
     }
 
+    const auto *s_ptr = &technic_info[REALM_HEX - MIN_TECHNIC][spell];
     auto *floor_ptr = this->caster_ptr->current_floor_ptr;
     auto gain_condition = one_in_(5);
     gain_condition &= (floor_ptr->dun_level + 5) > this->caster_ptr->lev;

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -293,14 +293,11 @@ void RealmHex::gain_exp_master(const int spell)
  * @brief プレイヤーの呪術詠唱枠がすでに最大かどうかを返す
  * @return すでに全枠を利用しているならTRUEを返す
  */
-bool RealmHex::hex_spell_fully()
+bool RealmHex::hex_spell_fully() const
 {
-    int k_max = 0;
-    k_max = (caster_ptr->lev / 15) + 1;
+    auto k_max = (this->caster_ptr->lev / 15) + 1;
     k_max = MIN(k_max, MAX_KEEP);
-    if (casting_hex_num(caster_ptr) < k_max)
-        return false;
-    return true;
+    return casting_hex_num(this->caster_ptr) >= k_max;
 }
 
 /*!

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -363,7 +363,7 @@ bool RealmHex::magic_barrier(MONSTER_IDX m_idx)
  * @param m_idx 判定の対象となるモンスターID
  * @return 反増殖の効果が適用されるならTRUEを返す
  */
-bool multiply_barrier(player_type *caster_ptr, MONSTER_IDX m_idx)
+bool RealmHex::multiply_barrier(MONSTER_IDX m_idx)
 {
     monster_type *m_ptr = &caster_ptr->current_floor_ptr->m_list[m_idx];
     monster_race *r_ptr = &r_info[m_ptr->r_idx];

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -365,15 +365,9 @@ bool RealmHex::magic_barrier(MONSTER_IDX m_idx)
  */
 bool RealmHex::multiply_barrier(MONSTER_IDX m_idx)
 {
-    monster_type *m_ptr = &caster_ptr->current_floor_ptr->m_list[m_idx];
-    monster_race *r_ptr = &r_info[m_ptr->r_idx];
-
-    if (!hex_spelling(caster_ptr, HEX_ANTI_MULTI))
-        return false;
-    if ((caster_ptr->lev * 3 / 2) < randint1(r_ptr->level))
-        return false;
-
-    return true;
+    const auto *m_ptr = &this->caster_ptr->current_floor_ptr->m_list[m_idx];
+    const auto *r_ptr = &r_info[m_ptr->r_idx];
+    return hex_spelling(this->caster_ptr, HEX_ANTI_MULTI) && ((this->caster_ptr->lev * 3 / 2) >= randint1(r_ptr->level));
 }
 
 bool hex_spelling(player_type *caster_ptr, int hex)

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -17,6 +17,7 @@
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 
@@ -349,7 +350,8 @@ bool RealmHex::check_hex_barrier(MONSTER_IDX m_idx, realm_hex_type type) const
 
 bool RealmHex::hex_spelling(int hex) const
 {
-    return (caster_ptr->realm1 == REALM_HEX) && (caster_ptr->magic_num1[0] & (1UL << (hex)));
+    auto check = static_cast<uint32_t>(this->caster_ptr->magic_num1[0]);
+    return (this->caster_ptr->realm1 == REALM_HEX) && any_bits(check, 1U << hex);
 }
 
 bool hex_spelling_any(player_type *caster_ptr)

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -33,7 +33,7 @@ RealmHex::RealmHex(player_type *caster_ptr)
 bool RealmHex::stop_hex_spell_all()
 {
     for (auto i = 0; i < 32; i++) {
-        if (hex_spelling(this->caster_ptr, i)) {
+        if (this->hex_spelling(i)) {
             exe_spell(this->caster_ptr, REALM_HEX, i, SPELL_STOP);
         }
     }
@@ -124,7 +124,7 @@ void RealmHex::display_spells_list(int *sp)
     term_erase(x, y, 255);
     prt(_("     名前", "     Name"), y, x + 5);
     for (auto spell = 0; spell < 32; spell++) {
-        if (hex_spelling(this->caster_ptr, spell)) {
+        if (this->hex_spelling(spell)) {
             term_erase(x, y + n + 1, 255);
             put_str(format("%c)  %s", I2A(n), exe_spell(this->caster_ptr, REALM_HEX, spell, SPELL_NAME)), y + n + 1, x + 2);
             sp[n++] = spell;
@@ -157,7 +157,7 @@ void RealmHex::check_hex()
 
     /* Do any effects of continual spells */
     for (auto spell = 0; spell < 32; spell++) {
-        if (hex_spelling(this->caster_ptr, spell)) {
+        if (this->hex_spelling(spell)) {
             exe_spell(this->caster_ptr, REALM_HEX, spell, SPELL_CONT);
         }
     }
@@ -205,7 +205,7 @@ int RealmHex::calc_need_mana()
 {
     auto need_mana = 0;
     for (auto spell = 0; spell < 32; spell++) {
-        if (hex_spelling(this->caster_ptr, spell)) {
+        if (this->hex_spelling(spell)) {
             const auto *s_ptr = &technic_info[REALM_HEX - MIN_TECHNIC][spell];
             need_mana += mod_need_mana(this->caster_ptr, s_ptr->smana, spell, REALM_HEX);
         }
@@ -217,7 +217,7 @@ int RealmHex::calc_need_mana()
 void RealmHex::gain_exp_from_hex()
 {
     for (auto spell = 0; spell < 32; spell++) {
-        if (!hex_spelling(this->caster_ptr, spell)) {
+        if (!this->hex_spelling(spell)) {
             continue;
         }
 
@@ -344,10 +344,10 @@ bool RealmHex::check_hex_barrier(MONSTER_IDX m_idx, realm_hex_type type) const
 {
     const auto *m_ptr = &this->caster_ptr->current_floor_ptr->m_list[m_idx];
     const auto *r_ptr = &r_info[m_ptr->r_idx];
-    return hex_spelling(this->caster_ptr, type) && ((this->caster_ptr->lev * 3 / 2) >= randint1(r_ptr->level));
+    return this->hex_spelling(type) && ((this->caster_ptr->lev * 3 / 2) >= randint1(r_ptr->level));
 }
 
-bool hex_spelling(player_type *caster_ptr, int hex)
+bool RealmHex::hex_spelling(int hex) const
 {
     return (caster_ptr->realm1 == REALM_HEX) && (caster_ptr->magic_num1[0] & (1UL << (hex)));
 }

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -341,15 +341,9 @@ void RealmHex::revenge_store(HIT_POINT dam)
  */
 bool RealmHex::teleport_barrier(MONSTER_IDX m_idx)
 {
-    monster_type *m_ptr = &caster_ptr->current_floor_ptr->m_list[m_idx];
-    monster_race *r_ptr = &r_info[m_ptr->r_idx];
-
-    if (!hex_spelling(caster_ptr, HEX_ANTI_TELE))
-        return false;
-    if ((caster_ptr->lev * 3 / 2) < randint1(r_ptr->level))
-        return false;
-
-    return true;
+    const auto *m_ptr = &this->caster_ptr->current_floor_ptr->m_list[m_idx];
+    const auto *r_ptr = &r_info[m_ptr->r_idx];
+    return hex_spelling(this->caster_ptr, HEX_ANTI_TELE) && ((this->caster_ptr->lev * 3 / 2) >= randint1(r_ptr->level));
 }
 
 /*!

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -305,18 +305,19 @@ bool RealmHex::hex_spell_fully() const
  */
 void RealmHex::revenge_spell()
 {
-    if (caster_ptr->realm1 != REALM_HEX)
+    if ((this->caster_ptr->realm1 != REALM_HEX) || (hex_revenge_turn(this->caster_ptr) <= 0)) {
         return;
-    if (hex_revenge_turn(caster_ptr) <= 0)
-        return;
+    }
 
-    switch (hex_revenge_type(caster_ptr)) {
+    switch (hex_revenge_type(this->caster_ptr)) {
     case 1:
-        exe_spell(caster_ptr, REALM_HEX, HEX_PATIENCE, SPELL_CONT);
-        break;
+        exe_spell(this->caster_ptr, REALM_HEX, HEX_PATIENCE, SPELL_CONT);
+        return;
     case 2:
-        exe_spell(caster_ptr, REALM_HEX, HEX_REVENGE, SPELL_CONT);
-        break;
+        exe_spell(this->caster_ptr, REALM_HEX, HEX_REVENGE, SPELL_CONT);
+        return;
+    default:
+        return;
     }
 }
 

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -56,69 +56,68 @@ bool stop_hex_spell_all(player_type *caster_ptr)
  */
 bool RealmHex::stop_hex_spell()
 {
-    int spell;
-    char choice = 0;
-    char out_val[160];
-    bool flag = false;
-    TERM_LEN y = 1;
-    TERM_LEN x = 20;
-    int sp[MAX_KEEP];
-
     if (!hex_spelling_any(this->caster_ptr)) {
         msg_print(_("呪文を詠唱していません。", "You are not casting a spell."));
         return false;
     }
-
-    /* Stop all spells */
-    else if ((casting_hex_num(this->caster_ptr) == 1) || (this->caster_ptr->lev < 35)) {
+    
+    if ((casting_hex_num(this->caster_ptr) == 1) || (this->caster_ptr->lev < 35)) {
         return stop_hex_spell_all(this->caster_ptr);
-    } else {
-        strnfmt(out_val, 78, _("どの呪文の詠唱を中断しますか？(呪文 %c-%c, 'l'全て, ESC)", "Which spell do you stop casting? (Spell %c-%c, 'l' to all, ESC)"),
-            I2A(0), I2A(casting_hex_num(this->caster_ptr) - 1));
+    }
 
-        screen_save();
+    char out_val[160];
+    strnfmt(out_val, 78, _("どの呪文の詠唱を中断しますか？(呪文 %c-%c, 'l'全て, ESC)", "Which spell do you stop casting? (Spell %c-%c, 'l' to all, ESC)"),
+        I2A(0), I2A(casting_hex_num(this->caster_ptr) - 1));
+    screen_save();
 
-        while (!flag) {
-            int n = 0;
-            term_erase(x, y, 255);
-            prt(_("     名前", "     Name"), y, x + 5);
-            for (spell = 0; spell < 32; spell++) {
-                if (hex_spelling(this->caster_ptr, spell)) {
-                    term_erase(x, y + n + 1, 255);
-                    put_str(format("%c)  %s", I2A(n), exe_spell(this->caster_ptr, REALM_HEX, spell, SPELL_NAME)), y + n + 1, x + 2);
-                    sp[n++] = spell;
-                }
+    char choice = 0;
+    auto flag = false;
+    auto y = 1;
+    auto x = 20;
+    int sp[MAX_KEEP]{};
+    while (!flag) {
+        auto n = 0;
+        term_erase(x, y, 255);
+        prt(_("     名前", "     Name"), y, x + 5);
+        for (auto spell = 0; spell < 32; spell++) {
+            if (hex_spelling(this->caster_ptr, spell)) {
+                term_erase(x, y + n + 1, 255);
+                put_str(format("%c)  %s", I2A(n), exe_spell(this->caster_ptr, REALM_HEX, spell, SPELL_NAME)), y + n + 1, x + 2);
+                sp[n++] = spell;
             }
-
-            if (!get_com(out_val, &choice, true))
-                break;
-            if (isupper(choice))
-                choice = (char)tolower(choice);
-
-            if (choice == 'l') /* All */
-            {
-                screen_load();
-                return stop_hex_spell_all(this->caster_ptr);
-            }
-            if ((choice < I2A(0)) || (choice > I2A(casting_hex_num(this->caster_ptr) - 1)))
-                continue;
-            flag = true;
         }
+
+        if (!get_com(out_val, &choice, true)) {
+            break;
+        }
+
+        if (isupper(choice)) {
+            choice = (char)tolower(choice);
+        }
+
+         /* All */
+        if (choice == 'l') {
+            screen_load();
+            return stop_hex_spell_all(this->caster_ptr);
+        }
+
+        if ((choice < I2A(0)) || (choice > I2A(casting_hex_num(this->caster_ptr) - 1))) {
+            continue;
+        }
+
+        flag = true;
     }
 
     screen_load();
-
     if (flag) {
-        int n = sp[A2I(choice)];
-
+        auto n = sp[A2I(choice)];
         exe_spell(this->caster_ptr, REALM_HEX, n, SPELL_STOP);
         casting_hex_flags(this->caster_ptr) &= ~(1UL << n);
         casting_hex_num(this->caster_ptr)--;
     }
 
-    this->caster_ptr->update |= (PU_BONUS | PU_HP | PU_MANA | PU_SPELLS);
-    this->caster_ptr->redraw |= (PR_EXTRA | PR_HP | PR_MANA);
-
+    this->caster_ptr->update |= PU_BONUS | PU_HP | PU_MANA | PU_SPELLS;
+    this->caster_ptr->redraw |= PR_EXTRA | PR_HP | PR_MANA;
     return flag;
 }
 

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -234,18 +234,11 @@ void RealmHex::gain_exp_from_hex()
             continue;
         }
 
-        auto *floor_ptr = this->caster_ptr->current_floor_ptr;
-        if (this->caster_ptr->spell_exp[spell] < SPELL_EXP_EXPERT) {
-            auto gain_condition = one_in_(5);
-            gain_condition &= (floor_ptr->dun_level + 5) > this->caster_ptr->lev;
-            gain_condition &= (floor_ptr->dun_level + 5) > s_ptr->slevel;
-            if (gain_condition) {
-                this->caster_ptr->spell_exp[spell]++;
-            }
-
+        if (this->gain_exp_expert(spell, s_ptr)) {
             continue;
         }
 
+        auto *floor_ptr = this->caster_ptr->current_floor_ptr;
         if (this->caster_ptr->spell_exp[spell] < SPELL_EXP_MASTER) {
             auto gain_condition = one_in_(5);
             gain_condition &= (floor_ptr->dun_level + 5) > this->caster_ptr->lev;
@@ -271,6 +264,23 @@ bool RealmHex::gain_exp_skilled(const int spell)
         this->caster_ptr->spell_exp[spell]++;
     }
     
+    return true;
+}
+
+bool RealmHex::gain_exp_expert(const int spell, const magic_type *s_ptr)
+{
+    if (this->caster_ptr->spell_exp[spell] >= SPELL_EXP_EXPERT) {
+        return false;
+    }
+
+    auto *floor_ptr = this->caster_ptr->current_floor_ptr;
+    auto gain_condition = one_in_(5);
+    gain_condition &= (floor_ptr->dun_level + 5) > this->caster_ptr->lev;
+    gain_condition &= (floor_ptr->dun_level + 5) > s_ptr->slevel;
+    if (gain_condition) {
+        this->caster_ptr->spell_exp[spell]++;
+    }
+
     return true;
 }
 

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -293,7 +293,7 @@ void RealmHex::gain_exp_master(const int spell)
  * @brief プレイヤーの呪術詠唱枠がすでに最大かどうかを返す
  * @return すでに全枠を利用しているならTRUEを返す
  */
-bool hex_spell_fully(player_type *caster_ptr)
+bool RealmHex::hex_spell_fully()
 {
     int k_max = 0;
     k_max = (caster_ptr->lev / 15) + 1;

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -32,22 +32,20 @@ RealmHex::RealmHex(player_type *caster_ptr)
  */
 bool RealmHex::stop_hex_spell_all()
 {
-    SPELL_IDX i;
-
-    for (i = 0; i < 32; i++) {
-        if (hex_spelling(this->caster_ptr, i))
+    for (auto i = 0; i < 32; i++) {
+        if (hex_spelling(this->caster_ptr, i)) {
             exe_spell(this->caster_ptr, REALM_HEX, i, SPELL_STOP);
+        }
     }
 
     casting_hex_flags(this->caster_ptr) = 0;
     casting_hex_num(this->caster_ptr) = 0;
-
-    if (this->caster_ptr->action == ACTION_SPELL)
+    if (this->caster_ptr->action == ACTION_SPELL) {
         set_action(this->caster_ptr, ACTION_NONE);
+    }
 
-    this->caster_ptr->update |= (PU_BONUS | PU_HP | PU_MANA | PU_SPELLS);
-    this->caster_ptr->redraw |= (PR_EXTRA | PR_HP | PR_MANA);
-
+    this->caster_ptr->update |= PU_BONUS | PU_HP | PU_MANA | PU_SPELLS;
+    this->caster_ptr->redraw |= PR_EXTRA | PR_HP | PR_MANA;
     return true;
 }
 

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -303,7 +303,7 @@ bool RealmHex::hex_spell_fully() const
 /*!
  * @brief 一定ゲームターン毎に復讐処理の残り期間の判定を行う
  */
-void revenge_spell(player_type *caster_ptr)
+void RealmHex::revenge_spell()
 {
     if (caster_ptr->realm1 != REALM_HEX)
         return;

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -230,18 +230,11 @@ void RealmHex::gain_exp_from_hex()
             continue;
         }
 
-        auto *floor_ptr = this->caster_ptr->current_floor_ptr;
-        if (this->caster_ptr->spell_exp[spell] < SPELL_EXP_SKILLED) {
-            auto gain_condition = one_in_(2);
-            gain_condition &= floor_ptr->dun_level > 4;
-            gain_condition &= (floor_ptr->dun_level + 10) > this->caster_ptr->lev;
-            if (gain_condition) {
-                this->caster_ptr->spell_exp[spell]++;
-            }
-
+        if (this->gain_exp_skilled(spell)) {
             continue;
         }
 
+        auto *floor_ptr = this->caster_ptr->current_floor_ptr;
         if (this->caster_ptr->spell_exp[spell] < SPELL_EXP_EXPERT) {
             auto gain_condition = one_in_(5);
             gain_condition &= (floor_ptr->dun_level + 5) > this->caster_ptr->lev;
@@ -262,6 +255,23 @@ void RealmHex::gain_exp_from_hex()
             }
         }
     }
+}
+
+bool RealmHex::gain_exp_skilled(const int spell)
+{
+    if (this->caster_ptr->spell_exp[spell] >= SPELL_EXP_SKILLED) {
+        return false;
+    }
+
+    auto *floor_ptr = this->caster_ptr->current_floor_ptr;
+    auto gain_condition = one_in_(2);
+    gain_condition &= floor_ptr->dun_level > 4;
+    gain_condition &= (floor_ptr->dun_level + 10) > this->caster_ptr->lev;
+    if (gain_condition) {
+        this->caster_ptr->spell_exp[spell]++;
+    }
+    
+    return true;
 }
 
 /*!

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -22,6 +22,11 @@
 
 #define MAX_KEEP 4 /*!<呪術の最大詠唱数 */
 
+RealmHex::RealmHex(player_type *caster_ptr)
+    : caster_ptr(caster_ptr)
+{
+}
+
 /*!
  * @brief プレイヤーが詠唱中の全呪術を停止する
  */
@@ -286,14 +291,14 @@ bool teleport_barrier(player_type *caster_ptr, MONSTER_IDX m_idx)
  * @param m_idx 判定の対象となるモンスターID
  * @return 反魔法の効果が適用されるならTRUEを返す
  */
-bool magic_barrier(player_type *target_ptr, MONSTER_IDX m_idx)
+bool magic_barrier(player_type *caster_ptr, MONSTER_IDX m_idx)
 {
-    monster_type *m_ptr = &target_ptr->current_floor_ptr->m_list[m_idx];
+    monster_type *m_ptr = &caster_ptr->current_floor_ptr->m_list[m_idx];
     monster_race *r_ptr = &r_info[m_ptr->r_idx];
 
-    if (!hex_spelling(target_ptr, HEX_ANTI_MAGIC))
+    if (!hex_spelling(caster_ptr, HEX_ANTI_MAGIC))
         return false;
-    if ((target_ptr->lev * 3 / 2) < randint1(r_ptr->level))
+    if ((caster_ptr->lev * 3 / 2) < randint1(r_ptr->level))
         return false;
 
     return true;

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -33,6 +33,10 @@ RealmHex::RealmHex(player_type *caster_ptr)
             this->spells.push_back(spell);
         }
     }
+
+    if (this->spells.size() > MAX_KEEP) {
+        throw("Invalid numbers of hex magics keep!");
+    }
 }
 
 /*!
@@ -77,7 +81,7 @@ bool RealmHex::stop_one_spell()
     auto flag = select_spell_stopping(out_val, choice);
     screen_load();
     if (flag) {
-        auto n = this->spells.at(A2I(choice));
+        auto n = this->spells[A2I(choice)];
         exe_spell(this->caster_ptr, REALM_HEX, n, SPELL_STOP);
         casting_hex_flags(this->caster_ptr) &= ~(1UL << n);
         casting_hex_num(this->caster_ptr)--;

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -54,7 +54,7 @@ bool stop_hex_spell_all(player_type *caster_ptr)
 /*!
  * @brief プレイヤーが詠唱中の呪術から一つを選んで停止する
  */
-bool stop_hex_spell(player_type *caster_ptr)
+bool RealmHex::stop_hex_spell()
 {
     int spell;
     char choice = 0;
@@ -64,17 +64,17 @@ bool stop_hex_spell(player_type *caster_ptr)
     TERM_LEN x = 20;
     int sp[MAX_KEEP];
 
-    if (!hex_spelling_any(caster_ptr)) {
+    if (!hex_spelling_any(this->caster_ptr)) {
         msg_print(_("呪文を詠唱していません。", "You are not casting a spell."));
         return false;
     }
 
     /* Stop all spells */
-    else if ((casting_hex_num(caster_ptr) == 1) || (caster_ptr->lev < 35)) {
-        return stop_hex_spell_all(caster_ptr);
+    else if ((casting_hex_num(this->caster_ptr) == 1) || (this->caster_ptr->lev < 35)) {
+        return stop_hex_spell_all(this->caster_ptr);
     } else {
         strnfmt(out_val, 78, _("どの呪文の詠唱を中断しますか？(呪文 %c-%c, 'l'全て, ESC)", "Which spell do you stop casting? (Spell %c-%c, 'l' to all, ESC)"),
-            I2A(0), I2A(casting_hex_num(caster_ptr) - 1));
+            I2A(0), I2A(casting_hex_num(this->caster_ptr) - 1));
 
         screen_save();
 
@@ -83,9 +83,9 @@ bool stop_hex_spell(player_type *caster_ptr)
             term_erase(x, y, 255);
             prt(_("     名前", "     Name"), y, x + 5);
             for (spell = 0; spell < 32; spell++) {
-                if (hex_spelling(caster_ptr, spell)) {
+                if (hex_spelling(this->caster_ptr, spell)) {
                     term_erase(x, y + n + 1, 255);
-                    put_str(format("%c)  %s", I2A(n), exe_spell(caster_ptr, REALM_HEX, spell, SPELL_NAME)), y + n + 1, x + 2);
+                    put_str(format("%c)  %s", I2A(n), exe_spell(this->caster_ptr, REALM_HEX, spell, SPELL_NAME)), y + n + 1, x + 2);
                     sp[n++] = spell;
                 }
             }
@@ -98,9 +98,9 @@ bool stop_hex_spell(player_type *caster_ptr)
             if (choice == 'l') /* All */
             {
                 screen_load();
-                return stop_hex_spell_all(caster_ptr);
+                return stop_hex_spell_all(this->caster_ptr);
             }
-            if ((choice < I2A(0)) || (choice > I2A(casting_hex_num(caster_ptr) - 1)))
+            if ((choice < I2A(0)) || (choice > I2A(casting_hex_num(this->caster_ptr) - 1)))
                 continue;
             flag = true;
         }
@@ -111,13 +111,13 @@ bool stop_hex_spell(player_type *caster_ptr)
     if (flag) {
         int n = sp[A2I(choice)];
 
-        exe_spell(caster_ptr, REALM_HEX, n, SPELL_STOP);
-        casting_hex_flags(caster_ptr) &= ~(1UL << n);
-        casting_hex_num(caster_ptr)--;
+        exe_spell(this->caster_ptr, REALM_HEX, n, SPELL_STOP);
+        casting_hex_flags(this->caster_ptr) &= ~(1UL << n);
+        casting_hex_num(this->caster_ptr)--;
     }
 
-    caster_ptr->update |= (PU_BONUS | PU_HP | PU_MANA | PU_SPELLS);
-    caster_ptr->redraw |= (PR_EXTRA | PR_HP | PR_MANA);
+    this->caster_ptr->update |= (PU_BONUS | PU_HP | PU_MANA | PU_SPELLS);
+    this->caster_ptr->redraw |= (PR_EXTRA | PR_HP | PR_MANA);
 
     return flag;
 }

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -68,12 +68,12 @@ bool RealmHex::stop_hex_spell()
     strnfmt(out_val, 78, _("どの呪文の詠唱を中断しますか？(呪文 %c-%c, 'l'全て, ESC)", "Which spell do you stop casting? (Spell %c-%c, 'l' to all, ESC)"),
         I2A(0), I2A(casting_hex_num(this->caster_ptr) - 1));
     screen_save();
-    int sp[MAX_KEEP]{};
+    std::vector<int> sp(MAX_KEEP);
     char choice = 0;
     auto flag = select_spell_stopping(sp, out_val, &choice);
     screen_load();
     if (flag) {
-        auto n = sp[A2I(choice)];
+        auto n = sp.at(A2I(choice));
         exe_spell(this->caster_ptr, REALM_HEX, n, SPELL_STOP);
         casting_hex_flags(this->caster_ptr) &= ~(1UL << n);
         casting_hex_num(this->caster_ptr)--;
@@ -91,7 +91,7 @@ bool RealmHex::stop_hex_spell()
  * @param choice 選択した呪文
  * @return 選択が完了したらtrue、キャンセルならばfalse
  */
-bool RealmHex::select_spell_stopping(int *sp, char *out_val, char *choice)
+bool RealmHex::select_spell_stopping(std::vector<int> &sp, char *out_val, char *choice)
 {
     while (true) {
         this->display_spells_list(sp);
@@ -117,7 +117,7 @@ bool RealmHex::select_spell_stopping(int *sp, char *out_val, char *choice)
     }
 }
 
-void RealmHex::display_spells_list(int *sp)
+void RealmHex::display_spells_list(std::vector<int> &sp)
 {
     constexpr auto y = 1;
     constexpr auto x = 20;
@@ -128,7 +128,7 @@ void RealmHex::display_spells_list(int *sp)
         if (this->hex_spelling(spell)) {
             term_erase(x, y + n + 1, 255);
             put_str(format("%c)  %s", I2A(n), exe_spell(this->caster_ptr, REALM_HEX, spell, SPELL_NAME)), y + n + 1, x + 2);
-            sp[n++] = spell;
+            sp.at(n++) = spell;
         }
     }
 }

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -353,15 +353,9 @@ bool RealmHex::teleport_barrier(MONSTER_IDX m_idx)
  */
 bool RealmHex::magic_barrier(MONSTER_IDX m_idx)
 {
-    monster_type *m_ptr = &caster_ptr->current_floor_ptr->m_list[m_idx];
-    monster_race *r_ptr = &r_info[m_ptr->r_idx];
-
-    if (!hex_spelling(caster_ptr, HEX_ANTI_MAGIC))
-        return false;
-    if ((caster_ptr->lev * 3 / 2) < randint1(r_ptr->level))
-        return false;
-
-    return true;
+    const auto *m_ptr = &this->caster_ptr->current_floor_ptr->m_list[m_idx];
+    const auto *r_ptr = &r_info[m_ptr->r_idx];
+    return hex_spelling(this->caster_ptr, HEX_ANTI_MAGIC) && ((this->caster_ptr->lev * 3 / 2) >= randint1(r_ptr->level));
 }
 
 /*!

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -13,6 +13,7 @@ public:
     void check_hex();
     bool stop_hex_spell_all();
     bool hex_spell_fully() const;
+    void revenge_spell();
 
 private:
     player_type *caster_ptr;
@@ -28,7 +29,6 @@ private:
     void gain_exp_master(const int spell);
 };
 
-void revenge_spell(player_type *caster_ptr);
 void revenge_store(player_type *caster_ptr, HIT_POINT dam);
 bool teleport_barrier(player_type *caster_ptr, MONSTER_IDX m_idx);
 bool magic_barrier(player_type *caster_ptr, MONSTER_IDX m_idx);

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -23,8 +23,9 @@ public:
 private:
     player_type *caster_ptr;
 
-    bool select_spell_stopping(std::vector<int> &sp, char *out_val, char &choice);
-    void display_spells_list(std::vector<int> &sp);
+    bool select_spell_stopping(const std::vector<int> &spells, char *out_val, char &choice);
+    std::vector<int> make_spells_list();
+    void display_spells_list(const std::vector<int> &spells);
     void process_mana_cost(const bool need_restart);
     bool check_restart();
     int calc_need_mana();

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -23,7 +23,7 @@ public:
 private:
     player_type *caster_ptr;
 
-    bool select_spell_stopping(std::vector<int> &sp, char *out_val, char *choice);
+    bool select_spell_stopping(std::vector<int> &sp, char *out_val, char &choice);
     void display_spells_list(std::vector<int> &sp);
     void process_mana_cost(const bool need_restart);
     bool check_restart();

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -2,6 +2,7 @@
 
 #include "system/angband.h"
 
+struct magic_type;
 struct player_type;
 class RealmHex {
 public:
@@ -21,6 +22,7 @@ private:
     int calc_need_mana();
     void gain_exp_from_hex();
     bool gain_exp_skilled(const int spell);
+    bool gain_exp_expert(const int spell, const magic_type *s_ptr);
 };
 
 bool stop_hex_spell_all(player_type *caster_ptr);

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include "realm/realm-hex-numbers.h"
 
 struct player_type;
 class RealmHex {
@@ -15,9 +16,7 @@ public:
     bool hex_spell_fully() const;
     void revenge_spell();
     void revenge_store(HIT_POINT dam);
-    bool teleport_barrier(MONSTER_IDX m_idx);
-    bool magic_barrier(MONSTER_IDX m_idx);
-    bool multiply_barrier(MONSTER_IDX m_idx);
+    bool check_hex_barrier(MONSTER_IDX m_idx, realm_hex_type type) const;
 
 private:
     player_type *caster_ptr;

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -16,6 +16,7 @@ public:
     void revenge_spell();
     void revenge_store(HIT_POINT dam);
     bool teleport_barrier(MONSTER_IDX m_idx);
+    bool magic_barrier(MONSTER_IDX m_idx);
 
 private:
     player_type *caster_ptr;
@@ -31,7 +32,6 @@ private:
     void gain_exp_master(const int spell);
 };
 
-bool magic_barrier(player_type *caster_ptr, MONSTER_IDX m_idx);
 bool multiply_barrier(player_type *caster_ptr, MONSTER_IDX m_idx);
 bool hex_spelling(player_type *caster_ptr, int hex);
 bool hex_spelling_any(player_type *caster_ptr);

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -10,6 +10,7 @@ public:
     virtual ~RealmHex() = default;
 
     bool stop_hex_spell();
+    void check_hex();
 
 private:
     player_type *caster_ptr;
@@ -18,7 +19,6 @@ private:
 };
 
 bool stop_hex_spell_all(player_type *caster_ptr);
-void check_hex(player_type *caster_ptr);
 bool hex_spell_fully(player_type *caster_ptr);
 void revenge_spell(player_type *caster_ptr);
 void revenge_store(player_type *caster_ptr, HIT_POINT dam);

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -15,6 +15,7 @@ public:
     bool hex_spell_fully() const;
     void revenge_spell();
     void revenge_store(HIT_POINT dam);
+    bool teleport_barrier(MONSTER_IDX m_idx);
 
 private:
     player_type *caster_ptr;
@@ -30,7 +31,6 @@ private:
     void gain_exp_master(const int spell);
 };
 
-bool teleport_barrier(player_type *caster_ptr, MONSTER_IDX m_idx);
 bool magic_barrier(player_type *caster_ptr, MONSTER_IDX m_idx);
 bool multiply_barrier(player_type *caster_ptr, MONSTER_IDX m_idx);
 bool hex_spelling(player_type *caster_ptr, int hex);

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -23,8 +23,8 @@ public:
 private:
     player_type *caster_ptr;
 
-    bool select_spell_stopping(int *sp, char *out_val, char *choice);
-    void display_spells_list(int *sp);
+    bool select_spell_stopping(std::vector<int> &sp, char *out_val, char *choice);
+    void display_spells_list(std::vector<int> &sp);
     void process_mana_cost(const bool need_restart);
     bool check_restart();
     int calc_need_mana();

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -19,6 +19,7 @@ private:
     void process_mana_cost(const bool need_restart);
     bool check_restart();
     int calc_need_mana();
+    void gain_exp_from_hex();
 };
 
 bool stop_hex_spell_all(player_type *caster_ptr);

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -22,10 +22,10 @@ public:
 
 private:
     player_type *caster_ptr;
-
-    bool select_spell_stopping(const std::vector<int> &spells, char *out_val, char &choice);
-    std::vector<int> make_spells_list();
-    void display_spells_list(const std::vector<int> &spells);
+    std::vector<int> spells;
+    
+    bool select_spell_stopping(char *out_val, char &choice);
+    void display_spells_list();
     bool process_mana_cost(const bool need_restart);
     bool check_restart();
     int calc_need_mana();

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -16,7 +16,9 @@ private:
     player_type *caster_ptr;
 
     bool select_spell_stopping(int *sp, char *out_val, char *choice);
+    void process_mana_cost(const bool need_restart);
     bool check_restart();
+    int calc_need_mana();
 };
 
 bool stop_hex_spell_all(player_type *caster_ptr);

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -16,6 +16,7 @@ private:
     player_type *caster_ptr;
 
     bool select_spell_stopping(int *sp, char *out_val, char *choice);
+    void display_spells_list(int *sp);
     void process_mana_cost(const bool need_restart);
     bool check_restart();
     int calc_need_mana();

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -26,7 +26,7 @@ private:
     bool select_spell_stopping(const std::vector<int> &spells, char *out_val, char &choice);
     std::vector<int> make_spells_list();
     void display_spells_list(const std::vector<int> &spells);
-    void process_mana_cost(const bool need_restart);
+    bool process_mana_cost(const bool need_restart);
     bool check_restart();
     int calc_need_mana();
     void gain_exp_from_hex();

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -11,6 +11,7 @@ public:
 
     bool stop_hex_spell();
     void check_hex();
+    bool stop_hex_spell_all();
 
 private:
     player_type *caster_ptr;
@@ -26,7 +27,6 @@ private:
     void gain_exp_master(const int spell);
 };
 
-bool stop_hex_spell_all(player_type *caster_ptr);
 bool hex_spell_fully(player_type *caster_ptr);
 void revenge_spell(player_type *caster_ptr);
 void revenge_store(player_type *caster_ptr, HIT_POINT dam);

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -18,6 +18,7 @@ public:
     void revenge_store(HIT_POINT dam);
     bool check_hex_barrier(MONSTER_IDX m_idx, realm_hex_type type) const;
     bool hex_spelling(int hex) const;
+    bool hex_spelling_any() const;
 
 private:
     player_type *caster_ptr;
@@ -32,8 +33,6 @@ private:
     bool gain_exp_expert(const int spell);
     void gain_exp_master(const int spell);
 };
-
-bool hex_spelling_any(player_type *caster_ptr);
 
 #define casting_hex_flags(P_PTR) ((P_PTR)->magic_num1[0])
 #define casting_hex_num(P_PTR) ((P_PTR)->magic_num2[0])

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -3,6 +3,16 @@
 #include "system/angband.h"
 
 struct player_type;
+class RealmHex {
+public:
+    RealmHex() = delete;
+    RealmHex(player_type *caster_ptr);
+    virtual ~RealmHex() = default;
+
+private:
+    player_type *caster_ptr;
+};
+
 bool stop_hex_spell_all(player_type *caster_ptr);
 bool stop_hex_spell(player_type *caster_ptr);
 void check_hex(player_type *caster_ptr);
@@ -10,10 +20,11 @@ bool hex_spell_fully(player_type *caster_ptr);
 void revenge_spell(player_type *caster_ptr);
 void revenge_store(player_type *caster_ptr, HIT_POINT dam);
 bool teleport_barrier(player_type *caster_ptr, MONSTER_IDX m_idx);
-bool magic_barrier(player_type *target_ptr, MONSTER_IDX m_idx);
+bool magic_barrier(player_type *caster_ptr, MONSTER_IDX m_idx);
 bool multiply_barrier(player_type *caster_ptr, MONSTER_IDX m_idx);
-bool hex_spelling(player_type *caster_type, int hex);
-bool hex_spelling_any(player_type *caster_type);
+bool hex_spelling(player_type *caster_ptr, int hex);
+bool hex_spelling_any(player_type *caster_ptr);
+
 #define casting_hex_flags(P_PTR) ((P_PTR)->magic_num1[0])
 #define casting_hex_num(P_PTR) ((P_PTR)->magic_num2[0])
 #define hex_revenge_power(P_PTR) ((P_PTR)->magic_num1[2])

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -20,6 +20,7 @@ private:
     bool check_restart();
     int calc_need_mana();
     void gain_exp_from_hex();
+    bool gain_exp_skilled(const int spell);
 };
 
 bool stop_hex_spell_all(player_type *caster_ptr);

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -2,7 +2,6 @@
 
 #include "system/angband.h"
 
-struct magic_type;
 struct player_type;
 class RealmHex {
 public:
@@ -22,8 +21,8 @@ private:
     int calc_need_mana();
     void gain_exp_from_hex();
     bool gain_exp_skilled(const int spell);
-    bool gain_exp_expert(const int spell, const magic_type *s_ptr);
-    void gain_exp_master(const int spell, const magic_type *s_ptr);
+    bool gain_exp_expert(const int spell);
+    void gain_exp_master(const int spell);
 };
 
 bool stop_hex_spell_all(player_type *caster_ptr);

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -9,12 +9,13 @@ public:
     RealmHex(player_type *caster_ptr);
     virtual ~RealmHex() = default;
 
+    bool stop_hex_spell();
+
 private:
     player_type *caster_ptr;
 };
 
 bool stop_hex_spell_all(player_type *caster_ptr);
-bool stop_hex_spell(player_type *caster_ptr);
 void check_hex(player_type *caster_ptr);
 bool hex_spell_fully(player_type *caster_ptr);
 void revenge_spell(player_type *caster_ptr);

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -17,6 +17,7 @@ public:
     void revenge_spell();
     void revenge_store(HIT_POINT dam);
     bool check_hex_barrier(MONSTER_IDX m_idx, realm_hex_type type) const;
+    bool hex_spelling(int hex) const;
 
 private:
     player_type *caster_ptr;
@@ -32,7 +33,6 @@ private:
     void gain_exp_master(const int spell);
 };
 
-bool hex_spelling(player_type *caster_ptr, int hex);
 bool hex_spelling_any(player_type *caster_ptr);
 
 #define casting_hex_flags(P_PTR) ((P_PTR)->magic_num1[0])

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -13,7 +13,7 @@ public:
     bool stop_one_spell();
     void decrease_mana();
     bool stop_all_spells();
-    bool is_using_full_capacity() const;
+    bool is_casting_full_capacity() const;
     void continue_revenge();
     void store_vengeful_damage(HIT_POINT dam);
     bool check_hex_barrier(MONSTER_IDX m_idx, realm_hex_type type) const;
@@ -22,10 +22,10 @@ public:
 
 private:
     player_type *caster_ptr;
-    std::vector<int> spells;
+    std::vector<int> casting_spells;
     
     bool select_spell_stopping(char *out_val, char &choice);
-    void display_spells_list();
+    void display_casting_spells_list();
     bool process_mana_cost(const bool need_restart);
     bool check_restart();
     int calc_need_mana();

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -17,6 +17,7 @@ public:
     void revenge_store(HIT_POINT dam);
     bool teleport_barrier(MONSTER_IDX m_idx);
     bool magic_barrier(MONSTER_IDX m_idx);
+    bool multiply_barrier(MONSTER_IDX m_idx);
 
 private:
     player_type *caster_ptr;
@@ -32,7 +33,6 @@ private:
     void gain_exp_master(const int spell);
 };
 
-bool multiply_barrier(player_type *caster_ptr, MONSTER_IDX m_idx);
 bool hex_spelling(player_type *caster_ptr, int hex);
 bool hex_spelling_any(player_type *caster_ptr);
 

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -12,7 +12,7 @@ public:
     bool stop_hex_spell();
     void check_hex();
     bool stop_hex_spell_all();
-    bool hex_spell_fully();
+    bool hex_spell_fully() const;
 
 private:
     player_type *caster_ptr;

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -23,6 +23,7 @@ private:
     void gain_exp_from_hex();
     bool gain_exp_skilled(const int spell);
     bool gain_exp_expert(const int spell, const magic_type *s_ptr);
+    void gain_exp_master(const int spell, const magic_type *s_ptr);
 };
 
 bool stop_hex_spell_all(player_type *caster_ptr);

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -10,15 +10,15 @@ public:
     RealmHex(player_type *caster_ptr);
     virtual ~RealmHex() = default;
 
-    bool stop_hex_spell();
-    void check_hex();
-    bool stop_hex_spell_all();
-    bool hex_spell_fully() const;
-    void revenge_spell();
-    void revenge_store(HIT_POINT dam);
+    bool stop_one_spell();
+    void decrease_mana();
+    bool stop_all_spells();
+    bool is_using_full_capacity() const;
+    void continue_revenge();
+    void store_vengeful_damage(HIT_POINT dam);
     bool check_hex_barrier(MONSTER_IDX m_idx, realm_hex_type type) const;
-    bool hex_spelling(int hex) const;
-    bool hex_spelling_any() const;
+    bool is_spelling_specific(int hex) const;
+    bool is_spelling_any() const;
 
 private:
     player_type *caster_ptr;

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -16,6 +16,7 @@ private:
     player_type *caster_ptr;
 
     bool select_spell_stopping(int *sp, char *out_val, char *choice);
+    bool check_restart();
 };
 
 bool stop_hex_spell_all(player_type *caster_ptr);

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -13,6 +13,8 @@ public:
 
 private:
     player_type *caster_ptr;
+
+    bool select_spell_stopping(int *sp, char *out_val, char *choice);
 };
 
 bool stop_hex_spell_all(player_type *caster_ptr);

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -14,6 +14,7 @@ public:
     bool stop_hex_spell_all();
     bool hex_spell_fully() const;
     void revenge_spell();
+    void revenge_store(HIT_POINT dam);
 
 private:
     player_type *caster_ptr;
@@ -29,7 +30,6 @@ private:
     void gain_exp_master(const int spell);
 };
 
-void revenge_store(player_type *caster_ptr, HIT_POINT dam);
 bool teleport_barrier(player_type *caster_ptr, MONSTER_IDX m_idx);
 bool magic_barrier(player_type *caster_ptr, MONSTER_IDX m_idx);
 bool multiply_barrier(player_type *caster_ptr, MONSTER_IDX m_idx);

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -12,6 +12,7 @@ public:
     bool stop_hex_spell();
     void check_hex();
     bool stop_hex_spell_all();
+    bool hex_spell_fully();
 
 private:
     player_type *caster_ptr;
@@ -27,7 +28,6 @@ private:
     void gain_exp_master(const int spell);
 };
 
-bool hex_spell_fully(player_type *caster_ptr);
 void revenge_spell(player_type *caster_ptr);
 void revenge_store(player_type *caster_ptr, HIT_POINT dam);
 bool teleport_barrier(player_type *caster_ptr, MONSTER_IDX m_idx);

--- a/src/status/action-setter.cpp
+++ b/src/status/action-setter.cpp
@@ -83,8 +83,9 @@ void set_action(player_type *creature_ptr, uint8_t typ)
     if (prev_typ == ACTION_SING)
         stop_singing(creature_ptr);
 
-    if (prev_typ == ACTION_SPELL)
-        stop_hex_spell(creature_ptr);
+    if (prev_typ == ACTION_SPELL) {
+        (void)RealmHex(creature_ptr).stop_hex_spell();
+    }
 
     switch (creature_ptr->action) {
     case ACTION_SEARCH: {

--- a/src/status/action-setter.cpp
+++ b/src/status/action-setter.cpp
@@ -84,7 +84,7 @@ void set_action(player_type *creature_ptr, uint8_t typ)
         stop_singing(creature_ptr);
 
     if (prev_typ == ACTION_SPELL) {
-        (void)RealmHex(creature_ptr).stop_hex_spell();
+        (void)RealmHex(creature_ptr).stop_one_spell();
     }
 
     switch (creature_ptr->action) {

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -119,8 +119,9 @@ bool set_confused(player_type *creature_ptr, TIME_EFFECT v)
             if (creature_ptr->concent)
                 reset_concentration(creature_ptr, true);
 
-            if (hex_spelling_any(creature_ptr)) {
-                (void)RealmHex(creature_ptr).stop_hex_spell_all();
+            RealmHex realm_hex(creature_ptr);
+            if (realm_hex.hex_spelling_any()) {
+                (void)realm_hex.stop_hex_spell_all();
             }
 
             notice = true;
@@ -253,8 +254,9 @@ bool set_paralyzed(player_type *creature_ptr, TIME_EFFECT v)
             if (creature_ptr->concent)
                 reset_concentration(creature_ptr, true);
 
-            if (hex_spelling_any(creature_ptr)) {
-                (void)RealmHex(creature_ptr).stop_hex_spell_all();
+            RealmHex realm_hex(creature_ptr);
+            if (realm_hex.hex_spelling_any()) {
+                (void)realm_hex.stop_hex_spell_all();
             }
 
             creature_ptr->counter = false;
@@ -451,8 +453,9 @@ bool set_stun(player_type *creature_ptr, TIME_EFFECT v)
         if (creature_ptr->concent)
             reset_concentration(creature_ptr, true);
 
-        if (hex_spelling_any(creature_ptr)) {
-            (void)RealmHex(creature_ptr).stop_hex_spell_all();
+        RealmHex realm_hex(creature_ptr);
+        if (realm_hex.hex_spelling_any()) {
+            (void)realm_hex.stop_hex_spell_all();
         }
 
         notice = true;

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -119,8 +119,9 @@ bool set_confused(player_type *creature_ptr, TIME_EFFECT v)
             if (creature_ptr->concent)
                 reset_concentration(creature_ptr, true);
 
-            if (hex_spelling_any(creature_ptr))
-                stop_hex_spell_all(creature_ptr);
+            if (hex_spelling_any(creature_ptr)) {
+                (void)RealmHex(creature_ptr).stop_hex_spell_all();
+            }
 
             notice = true;
             creature_ptr->counter = false;
@@ -251,8 +252,10 @@ bool set_paralyzed(player_type *creature_ptr, TIME_EFFECT v)
             msg_print(_("体が麻痺してしまった！", "You are paralyzed!"));
             if (creature_ptr->concent)
                 reset_concentration(creature_ptr, true);
-            if (hex_spelling_any(creature_ptr))
-                stop_hex_spell_all(creature_ptr);
+
+            if (hex_spelling_any(creature_ptr)) {
+                (void)RealmHex(creature_ptr).stop_hex_spell_all();
+            }
 
             creature_ptr->counter = false;
             notice = true;
@@ -447,8 +450,10 @@ bool set_stun(player_type *creature_ptr, TIME_EFFECT v)
 
         if (creature_ptr->concent)
             reset_concentration(creature_ptr, true);
-        if (hex_spelling_any(creature_ptr))
-            stop_hex_spell_all(creature_ptr);
+
+        if (hex_spelling_any(creature_ptr)) {
+            (void)RealmHex(creature_ptr).stop_hex_spell_all();
+        }
 
         notice = true;
     } else if (new_aux < old_aux) {

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -120,8 +120,8 @@ bool set_confused(player_type *creature_ptr, TIME_EFFECT v)
                 reset_concentration(creature_ptr, true);
 
             RealmHex realm_hex(creature_ptr);
-            if (realm_hex.hex_spelling_any()) {
-                (void)realm_hex.stop_hex_spell_all();
+            if (realm_hex.is_spelling_any()) {
+                (void)realm_hex.stop_all_spells();
             }
 
             notice = true;
@@ -255,8 +255,8 @@ bool set_paralyzed(player_type *creature_ptr, TIME_EFFECT v)
                 reset_concentration(creature_ptr, true);
 
             RealmHex realm_hex(creature_ptr);
-            if (realm_hex.hex_spelling_any()) {
-                (void)realm_hex.stop_hex_spell_all();
+            if (realm_hex.is_spelling_any()) {
+                (void)realm_hex.stop_all_spells();
             }
 
             creature_ptr->counter = false;
@@ -454,8 +454,8 @@ bool set_stun(player_type *creature_ptr, TIME_EFFECT v)
             reset_concentration(creature_ptr, true);
 
         RealmHex realm_hex(creature_ptr);
-        if (realm_hex.hex_spelling_any()) {
-            (void)realm_hex.stop_hex_spell_all();
+        if (realm_hex.is_spelling_any()) {
+            (void)realm_hex.stop_all_spells();
         }
 
         notice = true;

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -538,39 +538,39 @@ void print_status(player_type *creature_ptr)
         ADD_BAR_FLAG(BAR_EYEEYE);
 
     if (creature_ptr->realm1 == REALM_HEX) {
-        if (hex_spelling(creature_ptr, HEX_BLESS))
+        if (RealmHex(creature_ptr).hex_spelling(HEX_BLESS))
             ADD_BAR_FLAG(BAR_BLESSED);
-        if (hex_spelling(creature_ptr, HEX_DEMON_AURA)) {
+        if (RealmHex(creature_ptr).hex_spelling(HEX_DEMON_AURA)) {
             ADD_BAR_FLAG(BAR_SHFIRE);
             ADD_BAR_FLAG(BAR_REGENERATION);
         }
-        if (hex_spelling(creature_ptr, HEX_XTRA_MIGHT))
+        if (RealmHex(creature_ptr).hex_spelling(HEX_XTRA_MIGHT))
             ADD_BAR_FLAG(BAR_MIGHT);
-        if (hex_spelling(creature_ptr, HEX_DETECT_EVIL))
+        if (RealmHex(creature_ptr).hex_spelling(HEX_DETECT_EVIL))
             ADD_BAR_FLAG(BAR_ESP_EVIL);
-        if (hex_spelling(creature_ptr, HEX_ICE_ARMOR))
+        if (RealmHex(creature_ptr).hex_spelling(HEX_ICE_ARMOR))
             ADD_BAR_FLAG(BAR_SHCOLD);
-        if (hex_spelling(creature_ptr, HEX_RUNESWORD))
+        if (RealmHex(creature_ptr).hex_spelling(HEX_RUNESWORD))
             ADD_BAR_FLAG(BAR_RUNESWORD);
-        if (hex_spelling(creature_ptr, HEX_BUILDING))
+        if (RealmHex(creature_ptr).hex_spelling(HEX_BUILDING))
             ADD_BAR_FLAG(BAR_BUILD);
-        if (hex_spelling(creature_ptr, HEX_ANTI_TELE))
+        if (RealmHex(creature_ptr).hex_spelling(HEX_ANTI_TELE))
             ADD_BAR_FLAG(BAR_ANTITELE);
-        if (hex_spelling(creature_ptr, HEX_SHOCK_CLOAK))
+        if (RealmHex(creature_ptr).hex_spelling(HEX_SHOCK_CLOAK))
             ADD_BAR_FLAG(BAR_SHELEC);
-        if (hex_spelling(creature_ptr, HEX_SHADOW_CLOAK))
+        if (RealmHex(creature_ptr).hex_spelling(HEX_SHADOW_CLOAK))
             ADD_BAR_FLAG(BAR_SHSHADOW);
-        if (hex_spelling(creature_ptr, HEX_CONFUSION))
+        if (RealmHex(creature_ptr).hex_spelling(HEX_CONFUSION))
             ADD_BAR_FLAG(BAR_ATTKCONF);
-        if (hex_spelling(creature_ptr, HEX_EYE_FOR_EYE))
+        if (RealmHex(creature_ptr).hex_spelling(HEX_EYE_FOR_EYE))
             ADD_BAR_FLAG(BAR_EYEEYE);
-        if (hex_spelling(creature_ptr, HEX_ANTI_MULTI))
+        if (RealmHex(creature_ptr).hex_spelling(HEX_ANTI_MULTI))
             ADD_BAR_FLAG(BAR_ANTIMULTI);
-        if (hex_spelling(creature_ptr, HEX_VAMP_BLADE))
+        if (RealmHex(creature_ptr).hex_spelling(HEX_VAMP_BLADE))
             ADD_BAR_FLAG(BAR_VAMPILIC);
-        if (hex_spelling(creature_ptr, HEX_ANTI_MAGIC))
+        if (RealmHex(creature_ptr).hex_spelling(HEX_ANTI_MAGIC))
             ADD_BAR_FLAG(BAR_ANTIMAGIC);
-        if (hex_spelling(creature_ptr, HEX_CURE_LIGHT) || hex_spelling(creature_ptr, HEX_CURE_SERIOUS) || hex_spelling(creature_ptr, HEX_CURE_CRITICAL))
+        if (RealmHex(creature_ptr).hex_spelling(HEX_CURE_LIGHT) || RealmHex(creature_ptr).hex_spelling(HEX_CURE_SERIOUS) || RealmHex(creature_ptr).hex_spelling(HEX_CURE_CRITICAL))
             ADD_BAR_FLAG(BAR_CURE);
 
         if (hex_revenge_turn(creature_ptr)) {

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -538,39 +538,39 @@ void print_status(player_type *creature_ptr)
         ADD_BAR_FLAG(BAR_EYEEYE);
 
     if (creature_ptr->realm1 == REALM_HEX) {
-        if (RealmHex(creature_ptr).hex_spelling(HEX_BLESS))
+        if (RealmHex(creature_ptr).is_spelling_specific(HEX_BLESS))
             ADD_BAR_FLAG(BAR_BLESSED);
-        if (RealmHex(creature_ptr).hex_spelling(HEX_DEMON_AURA)) {
+        if (RealmHex(creature_ptr).is_spelling_specific(HEX_DEMON_AURA)) {
             ADD_BAR_FLAG(BAR_SHFIRE);
             ADD_BAR_FLAG(BAR_REGENERATION);
         }
-        if (RealmHex(creature_ptr).hex_spelling(HEX_XTRA_MIGHT))
+        if (RealmHex(creature_ptr).is_spelling_specific(HEX_XTRA_MIGHT))
             ADD_BAR_FLAG(BAR_MIGHT);
-        if (RealmHex(creature_ptr).hex_spelling(HEX_DETECT_EVIL))
+        if (RealmHex(creature_ptr).is_spelling_specific(HEX_DETECT_EVIL))
             ADD_BAR_FLAG(BAR_ESP_EVIL);
-        if (RealmHex(creature_ptr).hex_spelling(HEX_ICE_ARMOR))
+        if (RealmHex(creature_ptr).is_spelling_specific(HEX_ICE_ARMOR))
             ADD_BAR_FLAG(BAR_SHCOLD);
-        if (RealmHex(creature_ptr).hex_spelling(HEX_RUNESWORD))
+        if (RealmHex(creature_ptr).is_spelling_specific(HEX_RUNESWORD))
             ADD_BAR_FLAG(BAR_RUNESWORD);
-        if (RealmHex(creature_ptr).hex_spelling(HEX_BUILDING))
+        if (RealmHex(creature_ptr).is_spelling_specific(HEX_BUILDING))
             ADD_BAR_FLAG(BAR_BUILD);
-        if (RealmHex(creature_ptr).hex_spelling(HEX_ANTI_TELE))
+        if (RealmHex(creature_ptr).is_spelling_specific(HEX_ANTI_TELE))
             ADD_BAR_FLAG(BAR_ANTITELE);
-        if (RealmHex(creature_ptr).hex_spelling(HEX_SHOCK_CLOAK))
+        if (RealmHex(creature_ptr).is_spelling_specific(HEX_SHOCK_CLOAK))
             ADD_BAR_FLAG(BAR_SHELEC);
-        if (RealmHex(creature_ptr).hex_spelling(HEX_SHADOW_CLOAK))
+        if (RealmHex(creature_ptr).is_spelling_specific(HEX_SHADOW_CLOAK))
             ADD_BAR_FLAG(BAR_SHSHADOW);
-        if (RealmHex(creature_ptr).hex_spelling(HEX_CONFUSION))
+        if (RealmHex(creature_ptr).is_spelling_specific(HEX_CONFUSION))
             ADD_BAR_FLAG(BAR_ATTKCONF);
-        if (RealmHex(creature_ptr).hex_spelling(HEX_EYE_FOR_EYE))
+        if (RealmHex(creature_ptr).is_spelling_specific(HEX_EYE_FOR_EYE))
             ADD_BAR_FLAG(BAR_EYEEYE);
-        if (RealmHex(creature_ptr).hex_spelling(HEX_ANTI_MULTI))
+        if (RealmHex(creature_ptr).is_spelling_specific(HEX_ANTI_MULTI))
             ADD_BAR_FLAG(BAR_ANTIMULTI);
-        if (RealmHex(creature_ptr).hex_spelling(HEX_VAMP_BLADE))
+        if (RealmHex(creature_ptr).is_spelling_specific(HEX_VAMP_BLADE))
             ADD_BAR_FLAG(BAR_VAMPILIC);
-        if (RealmHex(creature_ptr).hex_spelling(HEX_ANTI_MAGIC))
+        if (RealmHex(creature_ptr).is_spelling_specific(HEX_ANTI_MAGIC))
             ADD_BAR_FLAG(BAR_ANTIMAGIC);
-        if (RealmHex(creature_ptr).hex_spelling(HEX_CURE_LIGHT) || RealmHex(creature_ptr).hex_spelling(HEX_CURE_SERIOUS) || RealmHex(creature_ptr).hex_spelling(HEX_CURE_CRITICAL))
+        if (RealmHex(creature_ptr).is_spelling_specific(HEX_CURE_LIGHT) || RealmHex(creature_ptr).is_spelling_specific(HEX_CURE_SERIOUS) || RealmHex(creature_ptr).is_spelling_specific(HEX_CURE_CRITICAL))
             ADD_BAR_FLAG(BAR_CURE);
 
         if (hex_revenge_turn(creature_ptr)) {

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -367,6 +367,92 @@ void print_imitation(player_type *player_ptr)
 }
 
 /*!
+ * @brief 画面下部に表示すべき呪術の呪文をリストアップする
+ * @param creature_ptr プレーヤーへの参照ポインタ
+ * @bar_flags 表示可否を決めるためのフラグ群
+ */
+static void add_hex_status_flags(player_type *creature_ptr, BIT_FLAGS *bar_flags)
+{
+    if (creature_ptr->realm1 != REALM_HEX) {
+        return;
+    }
+
+    RealmHex realm_hex(creature_ptr);
+    if (realm_hex.is_spelling_specific(HEX_BLESS)) {
+        ADD_BAR_FLAG(BAR_BLESSED);
+    }
+
+    if (realm_hex.is_spelling_specific(HEX_DEMON_AURA)) {
+        ADD_BAR_FLAG(BAR_SHFIRE);
+        ADD_BAR_FLAG(BAR_REGENERATION);
+    }
+
+    if (realm_hex.is_spelling_specific(HEX_XTRA_MIGHT)) {
+        ADD_BAR_FLAG(BAR_MIGHT);
+    }
+
+    if (realm_hex.is_spelling_specific(HEX_DETECT_EVIL)) {
+        ADD_BAR_FLAG(BAR_ESP_EVIL);
+    }
+
+    if (realm_hex.is_spelling_specific(HEX_ICE_ARMOR)) {
+        ADD_BAR_FLAG(BAR_SHCOLD);
+    }
+
+    if (realm_hex.is_spelling_specific(HEX_RUNESWORD)) {
+        ADD_BAR_FLAG(BAR_RUNESWORD);
+    }
+
+    if (realm_hex.is_spelling_specific(HEX_BUILDING)) {
+        ADD_BAR_FLAG(BAR_BUILD);
+    }
+
+    if (realm_hex.is_spelling_specific(HEX_ANTI_TELE)) {
+        ADD_BAR_FLAG(BAR_ANTITELE);
+    }
+
+    if (realm_hex.is_spelling_specific(HEX_SHOCK_CLOAK)) {
+        ADD_BAR_FLAG(BAR_SHELEC);
+    }
+
+    if (realm_hex.is_spelling_specific(HEX_SHADOW_CLOAK)) {
+        ADD_BAR_FLAG(BAR_SHSHADOW);
+    }
+
+    if (realm_hex.is_spelling_specific(HEX_CONFUSION)) {
+        ADD_BAR_FLAG(BAR_ATTKCONF);
+    }
+
+    if (realm_hex.is_spelling_specific(HEX_EYE_FOR_EYE)) {
+        ADD_BAR_FLAG(BAR_EYEEYE);
+    }
+
+    if (realm_hex.is_spelling_specific(HEX_ANTI_MULTI)) {
+        ADD_BAR_FLAG(BAR_ANTIMULTI);
+    }
+
+    if (realm_hex.is_spelling_specific(HEX_VAMP_BLADE)) {
+        ADD_BAR_FLAG(BAR_VAMPILIC);
+    }
+
+    if (realm_hex.is_spelling_specific(HEX_ANTI_MAGIC)) {
+        ADD_BAR_FLAG(BAR_ANTIMAGIC);
+    }
+
+    if (realm_hex.is_spelling_specific(HEX_CURE_LIGHT) || realm_hex.is_spelling_specific(HEX_CURE_SERIOUS)
+        || realm_hex.is_spelling_specific(HEX_CURE_CRITICAL)) {
+        ADD_BAR_FLAG(BAR_CURE);
+    }
+
+    if (hex_revenge_turn(creature_ptr)) {
+        if (hex_revenge_type(creature_ptr) == 1)
+            ADD_BAR_FLAG(BAR_PATIENCE);
+        if (hex_revenge_type(creature_ptr) == 2)
+            ADD_BAR_FLAG(BAR_REVENGE);
+    }
+}
+
+/*!
  * @brief 下部に状態表示を行う / Show status bar
  */
 void print_status(player_type *creature_ptr)
@@ -537,51 +623,7 @@ void print_status(player_type *creature_ptr)
     if (creature_ptr->tim_eyeeye)
         ADD_BAR_FLAG(BAR_EYEEYE);
 
-    if (creature_ptr->realm1 == REALM_HEX) {
-        RealmHex realm_hex(creature_ptr);
-        if (realm_hex.is_spelling_specific(HEX_BLESS))
-            ADD_BAR_FLAG(BAR_BLESSED);
-        if (realm_hex.is_spelling_specific(HEX_DEMON_AURA)) {
-            ADD_BAR_FLAG(BAR_SHFIRE);
-            ADD_BAR_FLAG(BAR_REGENERATION);
-        }
-        if (realm_hex.is_spelling_specific(HEX_XTRA_MIGHT))
-            ADD_BAR_FLAG(BAR_MIGHT);
-        if (realm_hex.is_spelling_specific(HEX_DETECT_EVIL))
-            ADD_BAR_FLAG(BAR_ESP_EVIL);
-        if (realm_hex.is_spelling_specific(HEX_ICE_ARMOR))
-            ADD_BAR_FLAG(BAR_SHCOLD);
-        if (realm_hex.is_spelling_specific(HEX_RUNESWORD))
-            ADD_BAR_FLAG(BAR_RUNESWORD);
-        if (realm_hex.is_spelling_specific(HEX_BUILDING))
-            ADD_BAR_FLAG(BAR_BUILD);
-        if (realm_hex.is_spelling_specific(HEX_ANTI_TELE))
-            ADD_BAR_FLAG(BAR_ANTITELE);
-        if (realm_hex.is_spelling_specific(HEX_SHOCK_CLOAK))
-            ADD_BAR_FLAG(BAR_SHELEC);
-        if (realm_hex.is_spelling_specific(HEX_SHADOW_CLOAK))
-            ADD_BAR_FLAG(BAR_SHSHADOW);
-        if (realm_hex.is_spelling_specific(HEX_CONFUSION))
-            ADD_BAR_FLAG(BAR_ATTKCONF);
-        if (realm_hex.is_spelling_specific(HEX_EYE_FOR_EYE))
-            ADD_BAR_FLAG(BAR_EYEEYE);
-        if (realm_hex.is_spelling_specific(HEX_ANTI_MULTI))
-            ADD_BAR_FLAG(BAR_ANTIMULTI);
-        if (realm_hex.is_spelling_specific(HEX_VAMP_BLADE))
-            ADD_BAR_FLAG(BAR_VAMPILIC);
-        if (realm_hex.is_spelling_specific(HEX_ANTI_MAGIC))
-            ADD_BAR_FLAG(BAR_ANTIMAGIC);
-        if (realm_hex.is_spelling_specific(HEX_CURE_LIGHT) || realm_hex.is_spelling_specific(HEX_CURE_SERIOUS) || realm_hex.is_spelling_specific(HEX_CURE_CRITICAL))
-            ADD_BAR_FLAG(BAR_CURE);
-
-        if (hex_revenge_turn(creature_ptr)) {
-            if (hex_revenge_type(creature_ptr) == 1)
-                ADD_BAR_FLAG(BAR_PATIENCE);
-            if (hex_revenge_type(creature_ptr) == 2)
-                ADD_BAR_FLAG(BAR_REVENGE);
-        }
-    }
-
+    add_hex_status_flags(creature_ptr, bar_flags);
     TERM_LEN col = 0, num = 0;
     for (int i = 0; stat_bars[i].sstr; i++) {
         if (IS_BAR_FLAG(i)) {

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -538,39 +538,40 @@ void print_status(player_type *creature_ptr)
         ADD_BAR_FLAG(BAR_EYEEYE);
 
     if (creature_ptr->realm1 == REALM_HEX) {
-        if (RealmHex(creature_ptr).is_spelling_specific(HEX_BLESS))
+        RealmHex realm_hex(creature_ptr);
+        if (realm_hex.is_spelling_specific(HEX_BLESS))
             ADD_BAR_FLAG(BAR_BLESSED);
-        if (RealmHex(creature_ptr).is_spelling_specific(HEX_DEMON_AURA)) {
+        if (realm_hex.is_spelling_specific(HEX_DEMON_AURA)) {
             ADD_BAR_FLAG(BAR_SHFIRE);
             ADD_BAR_FLAG(BAR_REGENERATION);
         }
-        if (RealmHex(creature_ptr).is_spelling_specific(HEX_XTRA_MIGHT))
+        if (realm_hex.is_spelling_specific(HEX_XTRA_MIGHT))
             ADD_BAR_FLAG(BAR_MIGHT);
-        if (RealmHex(creature_ptr).is_spelling_specific(HEX_DETECT_EVIL))
+        if (realm_hex.is_spelling_specific(HEX_DETECT_EVIL))
             ADD_BAR_FLAG(BAR_ESP_EVIL);
-        if (RealmHex(creature_ptr).is_spelling_specific(HEX_ICE_ARMOR))
+        if (realm_hex.is_spelling_specific(HEX_ICE_ARMOR))
             ADD_BAR_FLAG(BAR_SHCOLD);
-        if (RealmHex(creature_ptr).is_spelling_specific(HEX_RUNESWORD))
+        if (realm_hex.is_spelling_specific(HEX_RUNESWORD))
             ADD_BAR_FLAG(BAR_RUNESWORD);
-        if (RealmHex(creature_ptr).is_spelling_specific(HEX_BUILDING))
+        if (realm_hex.is_spelling_specific(HEX_BUILDING))
             ADD_BAR_FLAG(BAR_BUILD);
-        if (RealmHex(creature_ptr).is_spelling_specific(HEX_ANTI_TELE))
+        if (realm_hex.is_spelling_specific(HEX_ANTI_TELE))
             ADD_BAR_FLAG(BAR_ANTITELE);
-        if (RealmHex(creature_ptr).is_spelling_specific(HEX_SHOCK_CLOAK))
+        if (realm_hex.is_spelling_specific(HEX_SHOCK_CLOAK))
             ADD_BAR_FLAG(BAR_SHELEC);
-        if (RealmHex(creature_ptr).is_spelling_specific(HEX_SHADOW_CLOAK))
+        if (realm_hex.is_spelling_specific(HEX_SHADOW_CLOAK))
             ADD_BAR_FLAG(BAR_SHSHADOW);
-        if (RealmHex(creature_ptr).is_spelling_specific(HEX_CONFUSION))
+        if (realm_hex.is_spelling_specific(HEX_CONFUSION))
             ADD_BAR_FLAG(BAR_ATTKCONF);
-        if (RealmHex(creature_ptr).is_spelling_specific(HEX_EYE_FOR_EYE))
+        if (realm_hex.is_spelling_specific(HEX_EYE_FOR_EYE))
             ADD_BAR_FLAG(BAR_EYEEYE);
-        if (RealmHex(creature_ptr).is_spelling_specific(HEX_ANTI_MULTI))
+        if (realm_hex.is_spelling_specific(HEX_ANTI_MULTI))
             ADD_BAR_FLAG(BAR_ANTIMULTI);
-        if (RealmHex(creature_ptr).is_spelling_specific(HEX_VAMP_BLADE))
+        if (realm_hex.is_spelling_specific(HEX_VAMP_BLADE))
             ADD_BAR_FLAG(BAR_VAMPILIC);
-        if (RealmHex(creature_ptr).is_spelling_specific(HEX_ANTI_MAGIC))
+        if (realm_hex.is_spelling_specific(HEX_ANTI_MAGIC))
             ADD_BAR_FLAG(BAR_ANTIMAGIC);
-        if (RealmHex(creature_ptr).is_spelling_specific(HEX_CURE_LIGHT) || RealmHex(creature_ptr).is_spelling_specific(HEX_CURE_SERIOUS) || RealmHex(creature_ptr).is_spelling_specific(HEX_CURE_CRITICAL))
+        if (realm_hex.is_spelling_specific(HEX_CURE_LIGHT) || realm_hex.is_spelling_specific(HEX_CURE_SERIOUS) || realm_hex.is_spelling_specific(HEX_CURE_CRITICAL))
             ADD_BAR_FLAG(BAR_CURE);
 
         if (hex_revenge_turn(creature_ptr)) {


### PR DESCRIPTION
掲題の通りです
本題はmonap_type にメソッドを定義してクラス化する予定でしたが、その過程で「目には目を」の反撃効果やら反テレポートによる盗み逃げ防止効果やらが見つかりました
monap_type だけクラス化しても片手落ち感が半端なかったのと、eyes_on_eyes() はspell-hex.cpp/h へ移すべきとの思いから、先にこのファイルをクラス化することとしました
中途半端に関数を集めたままほったらかしにされていたのでついでに (というか作業の大半)メソッド分割・改名も行いました
ご確認下さい