### PR TITLE
[Refactor] ビットフラグをFlagGroupに移行するコードに共通関数を使用する

### DIFF
--- a/src/load/item-loader.cpp
+++ b/src/load/item-loader.cpp
@@ -157,11 +157,7 @@ void rd_item(object_type *o_ptr)
         if (loading_savefile_version_is_older_than(5)) {
             uint32_t tmp32u;
             rd_u32b(&tmp32u);
-            std::bitset<32> rd_bits_cursed_flags(tmp32u);
-            for (size_t i = 0; i < std::min(o_ptr->curse_flags.size(), rd_bits_cursed_flags.size()); i++) {
-                auto f = static_cast<TRC>(i);
-                o_ptr->curse_flags[f] = rd_bits_cursed_flags[i];
-            }
+            migrate_bitflag_to_flaggroup(o_ptr->curse_flags, tmp32u);
         } else {
             rd_FlagGroup(o_ptr->curse_flags, rd_byte);
         }

--- a/src/load/load-util.h
+++ b/src/load/load-util.h
@@ -29,18 +29,19 @@ bool loading_savefile_version_is_older_than(uint32_t version);
  * @tparam FG FlagGroupクラスのテンプレート型引数等を含めた型
  * @tparam BitFlagType ビットフラグデータの型
  * @param flaggroup ビットフラグデータを反映させるFlagGroupオブジェクトの参照
- * @param bitflags ビットフラグデータの内容
- * @param start_pos ビットフラグデータを反映させるFlagGroupオブジェクトのフラグ番号開始位置
+ * @param bitflag ビットフラグデータの内容
+ * @param start_pos ビットフラグデータを反映させるFlagGroupオブジェクトのフラグ番号開始位置。省略した場合は0(先頭)。
+ * @param count_max ビットフラグデータから反映する最大ビット数。省略した場合はビットフラグデータ型のビット数(全ビットを反映する)。
  */
-template <typename FG, typename BitFlagType>
-void migrate_bitflag_to_flaggroup(FG &flaggroup, BitFlagType bitflags, uint start_pos = 0)
+template <typename FG, typename BitFlagType, size_t BIT_COUNT = sizeof(BitFlagType) * 8>
+void migrate_bitflag_to_flaggroup(FG &flaggroup, BitFlagType bitflag, uint start_pos = 0, size_t count_max = BIT_COUNT)
 {
     if (start_pos >= flaggroup.size()) {
         return;
     }
 
-    std::bitset<sizeof(BitFlagType) * 8> bs(bitflags);
-    for (size_t i = 0, count = std::min(flaggroup.size() - start_pos, bs.size()); i < count; i++) {
+    std::bitset<BIT_COUNT> bs(bitflag);
+    for (size_t i = 0, count = std::min(flaggroup.size() - start_pos, count_max); i < count; i++) {
         auto f = static_cast<typename FG::flag_type>(start_pos + i);
         flaggroup[f] = bs[i];
     }

--- a/src/load/load-v1-5-0.cpp
+++ b/src/load/load-v1-5-0.cpp
@@ -153,11 +153,7 @@ void rd_item_old(object_type *o_ptr)
     } else {
         uint32_t tmp32u;
         rd_u32b(&tmp32u);
-        std::bitset<32> rd_bits_cursed_flags(tmp32u);
-        for (size_t i = 0; i < std::min(o_ptr->curse_flags.size(), rd_bits_cursed_flags.size()); i++) {
-            auto f = static_cast<TRC>(i);
-            o_ptr->curse_flags[f] = rd_bits_cursed_flags[i];
-        }
+        migrate_bitflag_to_flaggroup(o_ptr->curse_flags, tmp32u);
     }
 
     rd_s16b(&o_ptr->held_m_idx);
@@ -436,14 +432,11 @@ void rd_monster_old(player_type *player_ptr, monster_type *m_ptr)
 
     uint32_t tmp32u;
     rd_u32b(&tmp32u);
-    std::bitset<32> rd_bits_smart(tmp32u);
-    for (size_t i = 0; i < std::min(m_ptr->smart.size(), rd_bits_smart.size()); i++) {
-        auto f = static_cast<SM>(i);
-        m_ptr->smart[f] = rd_bits_smart[i];
-    }
+    migrate_bitflag_to_flaggroup(m_ptr->smart, tmp32u);
 
     // 3.0.0Alpha10以前のSM_CLONED(ビット位置22)、SM_PET(23)、SM_FRIEDLY(28)をMFLAG2に移行する
     // ビット位置の定義はなくなるので、ビット位置の値をハードコードする。
+    std::bitset<32> rd_bits_smart(tmp32u);
     m_ptr->mflag2[MFLAG2::CLONED] = rd_bits_smart[22];
     m_ptr->mflag2[MFLAG2::PET] = rd_bits_smart[23];
     m_ptr->mflag2[MFLAG2::FRIENDLY] = rd_bits_smart[28];
@@ -464,11 +457,7 @@ void rd_monster_old(player_type *player_ptr, monster_type *m_ptr)
     } else {
         rd_byte(&tmp8u);
         constexpr auto base = enum2i(MFLAG2::KAGE);
-        std::bitset<7> rd_bits_mflag2(tmp8u);
-        for (size_t i = 0; i < std::min(m_ptr->mflag2.size(), rd_bits_mflag2.size()); ++i) {
-            auto f = static_cast<MFLAG2>(base + i);
-            m_ptr->mflag2[f] = rd_bits_mflag2[i];
-        }
+        migrate_bitflag_to_flaggroup(m_ptr->mflag2, tmp8u, base, 7);
     }
 
     if (h_older_than(1, 0, 12)) {

--- a/src/load/lore-loader.cpp
+++ b/src/load/lore-loader.cpp
@@ -70,16 +70,9 @@ void rd_lore(monster_race *r_ptr, MONRACE_IDX r_idx)
         else
             rd_u32b(&r_ptr->r_flagsr);
 
-        auto migrate = [r_ptr](uint32_t f, int start_idx) {
-            std::bitset<32> flag_bits(f);
-            for (size_t i = 0; i < flag_bits.size(); i++) {
-                auto ability = static_cast<RF_ABILITY>(start_idx + i);
-                r_ptr->r_ability_flags[ability] = flag_bits[i];
-            }
-        };
-        migrate(f4, 0);
-        migrate(f5, 32);
-        migrate(f6, 64);
+        migrate_bitflag_to_flaggroup(r_ptr->r_ability_flags, f4, sizeof(uint32_t) * 8 * 0);
+        migrate_bitflag_to_flaggroup(r_ptr->r_ability_flags, f5, sizeof(uint32_t) * 8 * 1);
+        migrate_bitflag_to_flaggroup(r_ptr->r_ability_flags, f6, sizeof(uint32_t) * 8 * 2);
     } else {
         rd_u32b(&r_ptr->r_flagsr);
         rd_FlagGroup(r_ptr->r_ability_flags, rd_byte);

--- a/src/load/monster-loader.cpp
+++ b/src/load/monster-loader.cpp
@@ -118,14 +118,11 @@ void rd_monster(player_type *player_ptr, monster_type *m_ptr)
         if (loading_savefile_version_is_older_than(2)) {
             uint32_t tmp32u;
             rd_u32b(&tmp32u);
-            std::bitset<32> rd_bits(tmp32u);
-            for (size_t i = 0; i < std::min(m_ptr->smart.size(), rd_bits.size()); i++) {
-                auto f = static_cast<SM>(i);
-                m_ptr->smart[f] = rd_bits[i];
-            }
+            migrate_bitflag_to_flaggroup(m_ptr->smart, tmp32u);
 
             // 3.0.0Alpha10以前のSM_CLONED(ビット位置22)、SM_PET(23)、SM_FRIEDLY(28)をMFLAG2に移行する
             // ビット位置の定義はなくなるので、ビット位置の値をハードコードする。
+            std::bitset<32> rd_bits(tmp32u);
             m_ptr->mflag2[MFLAG2::CLONED] = rd_bits[22];
             m_ptr->mflag2[MFLAG2::PET] = rd_bits[23];
             m_ptr->mflag2[MFLAG2::FRIENDLY] = rd_bits[28];
@@ -148,11 +145,7 @@ void rd_monster(player_type *player_ptr, monster_type *m_ptr)
         if (loading_savefile_version_is_older_than(2)) {
             rd_byte(&tmp8u);
             constexpr auto base = enum2i(MFLAG2::KAGE);
-            std::bitset<7> rd_bits(tmp8u);
-            for (size_t i = 0; i < std::min(m_ptr->mflag2.size(), rd_bits.size()); ++i) {
-                auto f = static_cast<MFLAG2>(base + i);
-                m_ptr->mflag2[f] = rd_bits[i];
-            }
+            migrate_bitflag_to_flaggroup(m_ptr->mflag2, tmp8u, base, 7);
         } else {
             rd_FlagGroup(m_ptr->mflag2, rd_byte);
         }

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -419,14 +419,7 @@ static void set_mutations(player_type *creature_ptr)
         for (int i = 0; i < 3; i++) {
             uint32_t tmp32u;
             rd_u32b(&tmp32u);
-            std::bitset<32> rd_bits(tmp32u);
-            for (size_t j = 0; j < rd_bits.size(); j++) {
-                size_t pos = i * rd_bits.size() + j;
-                if (pos < creature_ptr->muta.size()) {
-                    auto f = static_cast<MUTA>(pos);
-                    creature_ptr->muta[f] = rd_bits[j];
-                }
-            }
+            migrate_bitflag_to_flaggroup(creature_ptr->muta, tmp32u, i * 32);
         }
     } else {
         rd_FlagGroup(creature_ptr->muta, rd_byte);


### PR DESCRIPTION
これまで個別に実装していたビットフラグをFlagGroupに移行するコードを、
TrFlagsをFlagGroupにした時にに導入した migrate_bitflag_to_flaggroup 関数に
より共通化する。

今後他のフラグをFlagGroup化する場合も使えるはず。