### PR TITLE
Doxygenコメントの「クリーチャー」を「プレーヤー」に変える

### DIFF
--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -1101,7 +1101,7 @@ int bow_tmul(OBJECT_SUBTYPE_VALUE sval)
 
 /*!
  * @brief 射撃時クリティカルによるダメージ期待値修正計算（スナイパーの集中処理と武器経験値） / critical happens at i / 10000
- * @param shooter_ptr 射撃を行うクリーチャー参照ポインタ
+ * @param shooter_ptr 射撃を行うプレーヤー参照ポインタ
  * @param plus_ammo 矢弾のダメージ修正
  * @param plus_bow 弓のダメージ修正
  * @return ダメージ期待値

--- a/src/core/scores.cpp
+++ b/src/core/scores.cpp
@@ -178,7 +178,7 @@ bool send_world_score(player_type *current_player_ptr, bool do_send, display_pla
  * @brief スコアの過去二十位内ランキングを表示する
  * Enters a players name on a hi-score table, if "legal", and in any
  * case, displays some relevant portion of the high score list.
- * @param current_player_ptr スコアに適用するための現在プレイヤークリーチャー参照ポインタ
+ * @param current_player_ptr プレーヤーへの参照ポインタ
  * @return エラーコード
  * @details
  * Assumes "signals_ignore_tstp()" has been called.

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -67,7 +67,7 @@
 
 /*!
  * @brief 新規フロアに入りたてのプレイヤーをランダムな場所に配置する / Returns random co-ordinates for player/monster/object
- * @param creature_ptr 配置したいクリーチャーの参照ポインタ
+ * @param creature_ptr 配置したいプレーヤーの参照ポインタ
  * @return 配置に成功したらTRUEを返す
  */
 bool new_player_spot(player_type *creature_ptr)
@@ -186,7 +186,7 @@ bool check_local_illumination(player_type *creature_ptr, POSITION y, POSITION x)
 
 /*!
  * @brief 指定された座標の照明状態を更新する / Update "local" illumination
- * @param creature_ptr 視界元のクリーチャー
+ * @param creature_ptr 視界元のプレーヤー
  * @param y 視界先y座標
  * @param x 視界先x座標
  */

--- a/src/mind/mind-magic-eater.cpp
+++ b/src/mind/mind-magic-eater.cpp
@@ -14,7 +14,7 @@
 
 /*!
  * @brief 魔道具術師の魔力取り込み処理
- * @param user_ptr アイテムを取り込むクリーチャー
+ * @param user_ptr アイテムを取り込むプレーヤー
  * @return 取り込みを実行したらTRUE、キャンセルしたらFALSEを返す
  */
 bool import_magic_device(player_type *user_ptr)

--- a/src/monster-floor/monster-lite.cpp
+++ b/src/monster-floor/monster-lite.cpp
@@ -22,7 +22,7 @@
 
 /*!
  * @brief モンスターによる光量状態更新 / Add a square to the changes array
- * @param subject_ptr 主観となるクリーチャーの参照ポインタ
+ * @param subject_ptr 主観となるプレーヤーの参照ポインタ
  * @param points 座標たちを記録する配列
  * @param y Y座標
  * @param x X座標

--- a/src/player-info/alignment.cpp
+++ b/src/player-info/alignment.cpp
@@ -22,7 +22,7 @@ PlayerAlignment::PlayerAlignment(player_type *creature_ptr)
 }
 
 /*!
- * @brief クリーチャーの抽象的善悪アライメントの表記を返す。 / Return alignment title
+ * @brief プレーヤーの抽象的善悪アライメントの表記を返す。 / Return alignment title
  * @param with_value 徳の情報と一緒に表示する時だけtrue
  * @return アライメントの表記を返す。
  */
@@ -142,8 +142,8 @@ void PlayerAlignment::reset_alignment()
 }
 
 /*!
- * @brief クリーチャーの抽象的善悪アライメントの表記名のみを返す。 / Return only alignment title
- * @param creature_ptr 算出するクリーチャーの参照ポインタ。
+ * @brief プレーヤーの抽象的善悪アライメントの表記名のみを返す。 / Return only alignment title
+ * @param creature_ptr 算出するプレーヤーの参照ポインタ。
  * @return アライメントの表記名
  */
 concptr PlayerAlignment::alignment_label()

--- a/src/player/permanent-resistances.cpp
+++ b/src/player/permanent-resistances.cpp
@@ -268,7 +268,7 @@ static void add_kata_flags(player_type *creature_ptr, TrFlags &flags)
 /*!
  * @brief プレイヤーの職業、種族に応じた耐性フラグを返す
  * Prints ratings on certain abilities
- * @param creature_ptr 参照元クリーチャーポインタ
+ * @param creature_ptr 参照元プレーヤーポインタ
  * @param flags フラグを保管する配列
  * @details
  * Obtain the "flags" for the player as if he was an item

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -578,7 +578,7 @@ static void process_aura_damage(monster_type *m_ptr, player_type *touched_ptr, b
 /*!
  * @brief 敵オーラによるプレイヤーのダメージ処理
  * @param m_ptr オーラを持つモンスターの構造体参照ポインタ
- * @param touched_ptr オーラを持つ相手に振れたクリーチャーの参照ポインタ
+ * @param touched_ptr オーラを持つ相手に振れたプレーヤーの参照ポインタ
  */
 void touch_zap_player(monster_type *m_ptr, player_type *touched_ptr)
 {

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -151,7 +151,7 @@ BIT_FLAGS player_flags_brand_cold(player_type *creature_ptr)
 
 /*!
  * @brief プレイヤーの所持するフラグのうち、tr_flagに対応するものを返す
- * @param creature_ptr 判定対象のクリーチャー参照ポインタ
+ * @param creature_ptr 判定対象のプレーヤー参照ポインタ
  * @param tr_flag 要求する装備フラグ
  */
 BIT_FLAGS get_player_flags(player_type *creature_ptr, tr_type tr_flag)
@@ -429,7 +429,7 @@ BIT_FLAGS get_player_flags(player_type *creature_ptr, tr_type tr_flag)
 }
 
 /*!
- * @brief クリーチャーが壁破壊進行を持っているかを返す。
+ * @brief プレーヤーが壁破壊進行を持っているかを返す。
  */
 bool has_kill_wall(player_type *creature_ptr)
 {
@@ -448,8 +448,8 @@ bool has_kill_wall(player_type *creature_ptr)
 }
 
 /*!
- * @brief クリーチャーが壁通過を持っているかを返す。
- * @param creature_ptr 判定対象のクリーチャー参照ポインタ
+ * @brief プレーヤーが壁通過を持っているかを返す。
+ * @param creature_ptr 判定対象のプレーヤー参照ポインタ
  * @return 持っていたらTRUE
  * @details
  * * 時限で幽体化、壁抜けをもつか種族幽霊ならばひとまずTRUE。
@@ -474,8 +474,8 @@ bool has_pass_wall(player_type *creature_ptr)
 }
 
 /*!
- * @brief クリーチャーが強力射を持っているかを返す。
- * @param creature_ptr 判定対象のクリーチャー参照ポインタ
+ * @brief プレーヤーが強力射を持っているかを返す。
+ * @param creature_ptr 判定対象のプレーヤー参照ポインタ
  * @return 持っていたら所持前提ビットフラグを返す。
  */
 BIT_FLAGS has_xtra_might(player_type *creature_ptr)
@@ -486,8 +486,8 @@ BIT_FLAGS has_xtra_might(player_type *creature_ptr)
 }
 
 /*!
- * @brief クリーチャーが邪悪感知を持っているかを返す。
- * @param creature_ptr 判定対象のクリーチャー参照ポインタ
+ * @brief プレーヤーが邪悪感知を持っているかを返す。
+ * @param creature_ptr 判定対象のプレーヤー参照ポインタ
  * @return 持っていたら所持前提ビットフラグを返す。
  */
 BIT_FLAGS has_esp_evil(player_type *creature_ptr)
@@ -502,8 +502,8 @@ BIT_FLAGS has_esp_evil(player_type *creature_ptr)
 }
 
 /*!
- * @brief クリーチャーが自然界の動物感知を持っているかを返す。
- * @param creature_ptr 判定対象のクリーチャー参照ポインタ
+ * @brief プレーヤーが自然界の動物感知を持っているかを返す。
+ * @param creature_ptr 判定対象のプレーヤー参照ポインタ
  * @return 持っていたら所持前提ビットフラグを返す。
  */
 BIT_FLAGS has_esp_animal(player_type *creature_ptr)
@@ -512,8 +512,8 @@ BIT_FLAGS has_esp_animal(player_type *creature_ptr)
 }
 
 /*!
- * @brief クリーチャーがアンデッド感知を持っているかを返す。
- * @param creature_ptr 判定対象のクリーチャー参照ポインタ
+ * @brief プレーヤーがアンデッド感知を持っているかを返す。
+ * @param creature_ptr 判定対象のプレーヤー参照ポインタ
  * @return 持っていたら所持前提ビットフラグを返す。
  */
 BIT_FLAGS has_esp_undead(player_type *creature_ptr)
@@ -522,8 +522,8 @@ BIT_FLAGS has_esp_undead(player_type *creature_ptr)
 }
 
 /*!
- * @brief クリーチャーが悪魔感知を持っているかを返す。
- * @param creature_ptr 判定対象のクリーチャー参照ポインタ
+ * @brief プレーヤーが悪魔感知を持っているかを返す。
+ * @param creature_ptr 判定対象のプレーヤー参照ポインタ
  * @return 持っていたら所持前提ビットフラグを返す。
  */
 BIT_FLAGS has_esp_demon(player_type *creature_ptr)
@@ -532,8 +532,8 @@ BIT_FLAGS has_esp_demon(player_type *creature_ptr)
 }
 
 /*!
- * @brief クリーチャーがオーク感知を持っているかを返す。
- * @param creature_ptr 判定対象のクリーチャー参照ポインタ
+ * @brief プレーヤーがオーク感知を持っているかを返す。
+ * @param creature_ptr 判定対象のプレーヤー参照ポインタ
  * @return 持っていたら所持前提ビットフラグを返す。
  */
 BIT_FLAGS has_esp_orc(player_type *creature_ptr)
@@ -542,8 +542,8 @@ BIT_FLAGS has_esp_orc(player_type *creature_ptr)
 }
 
 /*!
- * @brief クリーチャーがトロル感知を持っているかを返す。
- * @param creature_ptr 判定対象のクリーチャー参照ポインタ
+ * @brief プレーヤーがトロル感知を持っているかを返す。
+ * @param creature_ptr 判定対象のプレーヤー参照ポインタ
  * @return 持っていたら所持前提ビットフラグを返す。
  */
 BIT_FLAGS has_esp_troll(player_type *creature_ptr)
@@ -552,8 +552,8 @@ BIT_FLAGS has_esp_troll(player_type *creature_ptr)
 }
 
 /*!
- * @brief クリーチャーが巨人感知を持っているかを返す。
- * @param creature_ptr 判定対象のクリーチャー参照ポインタ
+ * @brief プレーヤーが巨人感知を持っているかを返す。
+ * @param creature_ptr 判定対象のプレーヤー参照ポインタ
  * @return 持っていたら所持前提ビットフラグを返す。
  */
 BIT_FLAGS has_esp_giant(player_type *creature_ptr)
@@ -562,8 +562,8 @@ BIT_FLAGS has_esp_giant(player_type *creature_ptr)
 }
 
 /*!
- * @brief クリーチャーがドラゴン感知を持っているかを返す。
- * @param creature_ptr 判定対象のクリーチャー参照ポインタ
+ * @brief プレーヤーがドラゴン感知を持っているかを返す。
+ * @param creature_ptr 判定対象のプレーヤー参照ポインタ
  * @return 持っていたら所持前提ビットフラグを返す。
  */
 BIT_FLAGS has_esp_dragon(player_type *creature_ptr)
@@ -572,8 +572,8 @@ BIT_FLAGS has_esp_dragon(player_type *creature_ptr)
 }
 
 /*!
- * @brief クリーチャーが人間感知を持っているかを返す。
- * @param creature_ptr 判定対象のクリーチャー参照ポインタ
+ * @brief プレーヤーが人間感知を持っているかを返す。
+ * @param creature_ptr 判定対象のプレーヤー参照ポインタ
  * @return 持っていたら所持前提ビットフラグを返す。
  */
 BIT_FLAGS has_esp_human(player_type *creature_ptr)
@@ -582,8 +582,8 @@ BIT_FLAGS has_esp_human(player_type *creature_ptr)
 }
 
 /*!
- * @brief クリーチャーが善良感知を持っているかを返す。
- * @param creature_ptr 判定対象のクリーチャー参照ポインタ
+ * @brief プレーヤーが善良感知を持っているかを返す。
+ * @param creature_ptr 判定対象のプレーヤー参照ポインタ
  * @return 持っていたら所持前提ビットフラグを返す。
  */
 BIT_FLAGS has_esp_good(player_type *creature_ptr)
@@ -592,8 +592,8 @@ BIT_FLAGS has_esp_good(player_type *creature_ptr)
 }
 
 /*!
- * @brief クリーチャーが無生物感知を持っているかを返す。
- * @param creature_ptr 判定対象のクリーチャー参照ポインタ
+ * @brief プレーヤーが無生物感知を持っているかを返す。
+ * @param creature_ptr 判定対象のプレーヤー参照ポインタ
  * @return 持っていたら所持前提ビットフラグを返す。
  */
 BIT_FLAGS has_esp_nonliving(player_type *creature_ptr)
@@ -602,8 +602,8 @@ BIT_FLAGS has_esp_nonliving(player_type *creature_ptr)
 }
 
 /*!
- * @brief クリーチャーがユニーク感知を持っているかを返す。
- * @param creature_ptr 判定対象のクリーチャー参照ポインタ
+ * @brief プレーヤーがユニーク感知を持っているかを返す。
+ * @param creature_ptr 判定対象のプレーヤー参照ポインタ
  * @return 持っていたら所持前提ビットフラグを返す。
  */
 BIT_FLAGS has_esp_unique(player_type *creature_ptr)
@@ -612,8 +612,8 @@ BIT_FLAGS has_esp_unique(player_type *creature_ptr)
 }
 
 /*!
- * @brief クリーチャーがテレパシーを持っているかを返す。
- * @param creature_ptr 判定対象のクリーチャー参照ポインタ
+ * @brief プレーヤーがテレパシーを持っているかを返す。
+ * @param creature_ptr 判定対象のプレーヤー参照ポインタ
  * @return 持っていたら所持前提ビットフラグを返す。
  */
 BIT_FLAGS has_esp_telepathy(player_type *creature_ptr)

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -182,7 +182,7 @@ int riding_exp_level(int riding_exp)
 }
 
 /*!
- * @brief クリーチャーの呪文レベルの抽象的ランクを返す。 / Return proficiency level of spells
+ * @brief プレーヤーの呪文レベルの抽象的ランクを返す。 / Return proficiency level of spells
  * @param spell_exp 経験値
  * @return ランク値
  */
@@ -242,7 +242,7 @@ static bool is_heavy_shoot(player_type *creature_ptr, object_type *o_ptr)
 
 /*!
  * @brief 所持品総重量を計算する
- * @param creature_ptr 計算対象となるクリーチャーの参照ポインタ
+ * @param creature_ptr 計算対象となるプレーヤーの参照ポインタ
  * @return 総重量
  */
 WEIGHT calc_inventory_weight(player_type *creature_ptr)
@@ -1044,7 +1044,7 @@ int16_t calc_num_fire(player_type *creature_ptr, object_type *o_ptr)
 
 /*!
  * @brief 解除能力計算
- * @param creature_ptr 計算するクリーチャーの参照ポインタ
+ * @param creature_ptr 計算するプレーヤーの参照ポインタ
  * @return 解除能力
  * @details
  * * 種族/職業/性格による加算
@@ -1073,7 +1073,7 @@ static ACTION_SKILL_POWER calc_disarming(player_type *creature_ptr)
 
 /*!
  * @brief 魔道具使用能力計算
- * @param creature_ptr 計算するクリーチャーの参照ポインタ
+ * @param creature_ptr 計算するプレーヤーの参照ポインタ
  * @return 魔道具使用能力
  * @details
  * * 種族/職業/性格による加算
@@ -1117,7 +1117,7 @@ static ACTION_SKILL_POWER calc_device_ability(player_type *creature_ptr)
 
 /*!
  * @brief 魔法防御計算
- * @param creature_ptr 計算するクリーチャーの参照ポインタ
+ * @param creature_ptr 計算するプレーヤーの参照ポインタ
  * @return 魔法防御
  * @details
  * * 種族/職業/性格による加算
@@ -1178,7 +1178,7 @@ static ACTION_SKILL_POWER calc_saving_throw(player_type *creature_ptr)
 
 /*!
  * @brief 探索深度計算
- * @param creature_ptr 計算するクリーチャーの参照ポインタ
+ * @param creature_ptr 計算するプレーヤーの参照ポインタ
  * @return 探索深度
  * @details
  * * 種族/職業/性格による加算
@@ -1225,7 +1225,7 @@ static ACTION_SKILL_POWER calc_search(player_type *creature_ptr)
 
 /*!
  * @brief 探索頻度計算
- * @param creature_ptr 計算するクリーチャーの参照ポインタ
+ * @param creature_ptr 計算するプレーヤーの参照ポインタ
  * @return 探索頻度
  * @details
  * * 種族/職業/性格による加算
@@ -1272,7 +1272,7 @@ static ACTION_SKILL_POWER calc_search_freq(player_type *creature_ptr)
 
 /*!
  * @brief 打撃命中能力計算
- * @param creature_ptr 計算するクリーチャーの参照ポインタ
+ * @param creature_ptr 計算するプレーヤーの参照ポインタ
  * @return 打撃命中能力
  * @details
  * * 種族/職業/性格による加算とレベルによる追加加算
@@ -1296,7 +1296,7 @@ static ACTION_SKILL_POWER calc_to_hit_melee(player_type *creature_ptr)
 
 /*!
  * @brief 射撃命中能力計算
- * @param creature_ptr 計算するクリーチャーの参照ポインタ
+ * @param creature_ptr 計算するプレーヤーの参照ポインタ
  * @return 射撃命中能力
  * @details
  * * 種族/職業/性格による加算とレベルによる追加加算
@@ -1320,7 +1320,7 @@ static ACTION_SKILL_POWER calc_to_hit_shoot(player_type *creature_ptr)
 
 /*!
  * @brief 投擲命中能力計算
- * @param creature_ptr 計算するクリーチャーの参照ポインタ
+ * @param creature_ptr 計算するプレーヤーの参照ポインタ
  * @return 投擲命中能力
  * @details
  * * 種族/職業/性格による加算とレベルによる追加加算
@@ -1350,7 +1350,7 @@ static ACTION_SKILL_POWER calc_to_hit_throw(player_type *creature_ptr)
 
 /*!
  * @brief 掘削能力計算
- * @param creature_ptr 計算するクリーチャーの参照ポインタ
+ * @param creature_ptr 計算するプレーヤーの参照ポインタ
  * @return 掘削能力値
  * @details
  * * エントが素手の場合のプラス修正
@@ -1545,7 +1545,7 @@ static int16_t calc_num_blow(player_type *creature_ptr, int i)
 
 /*!
  * @brief 魔法失敗値計算
- * @param creature_ptr 計算するクリーチャーの参照ポインタ
+ * @param creature_ptr 計算するプレーヤーの参照ポインタ
  * @return 魔法失敗値
  * @details
  * * 性格なまけものなら加算(+10)
@@ -1767,7 +1767,7 @@ static ARMOUR_CLASS calc_to_ac(player_type *creature_ptr, bool is_real_value)
 
 /*!
  * @brief 二刀流ペナルティ量計算
- * @param creature_ptr 計算するクリーチャーの参照ポインタ
+ * @param creature_ptr 計算するプレーヤーの参照ポインタ
  * @param slot ペナルティ量を計算する武器スロット
  * @return 二刀流ペナルティ量
  * @details

--- a/src/specific-object/death-crimson.cpp
+++ b/src/specific-object/death-crimson.cpp
@@ -12,7 +12,7 @@
 
 /*!
  * @brief クリムゾンを発射する / Fire Crimson, evoluting gun.
- @ @param shooter_ptr 射撃を行うクリーチャー参照
+ @ @param shooter_ptr 射撃を行うプレーヤー参照
  * @return キャンセルした場合 false.
  * @details
  * Need to analyze size of the window.

--- a/src/store/store-key-processor.cpp
+++ b/src/store/store-key-processor.cpp
@@ -41,7 +41,7 @@ bool leave_store = false;
 /*!
  * @brief 店舗処理コマンド選択のメインルーチン /
  * Process a command in a store
- * @param client_ptr 顧客となるクリーチャーの参照ポインタ
+ * @param client_ptr 顧客となるプレーヤーの参照ポインタ
  * @note
  * <pre>
  * Note that we must allow the use of a few "special" commands

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -1,11 +1,11 @@
 ﻿#include "system/player-type-definition.h"
 
 /*!
- * @brief プレイヤー用のクリーチャー構造体実体 / Static player info record
+ * @brief プレイヤー用のプレーヤー構造体実体 / Static player info record
  */
 player_type p_body;
 
 /*!
- * @brief プレイヤー用のクリーチャー構造体参照ポインタ / Pointer to the player info
+ * @brief プレイヤー用のプレーヤー構造体参照ポインタ / Pointer to the player info
  */
 player_type *p_ptr = &p_body;

--- a/src/window/display-sub-window-spells.cpp
+++ b/src/window/display-sub-window-spells.cpp
@@ -18,7 +18,7 @@
 #include "view/display-messages.h"
 
 /*!
- * @brief クリーチャー全既知呪文を表示する /
+ * @brief プレーヤー全既知呪文を表示する /
  * Hack -- Display all known spells in a window
  * @param caster_ptr 術者の参照ポインタ
  * return なし


### PR DESCRIPTION
#1479 の前処理
以下の理由により単発でPRを出します
ご確認下さい

player_type 構造体へのポインタは「creature_ptr」だったり「owner_ptr」だったり一定しないが、これはそれぞれの変数名ごとに統一を図ろうとした動きの残骸らしい
現状は辛うじて、モンスター種族番号0が＠に割り当てられている辺りが共通点か
この動きは廃止されたので、もはや「creature_ptr」等を分割する必要が消えた
上記チケットへの本番対応は2万行以上の差分が出るようなのでもはやコメント修正は誤差だが、それでもノイズは少ない方が良い