### PR TITLE
[Feature] clang-format の設定の ColumnLimit を 0 にする

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -44,7 +44,7 @@ BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeComma
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
-ColumnLimit: 160
+ColumnLimit: 0
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: false


### PR DESCRIPTION
適切な場所での改行を可能にし、勝手に1行に連結されるのを抑制する。