### PR TITLE
object-enchant/object-smith.h include unordered_map

### DIFF
--- a/src/object-enchant/object-smith.h
+++ b/src/object-enchant/object-smith.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <optional>
+#include <unordered_map>
 
 struct object_type;
 struct player_type;


### PR DESCRIPTION
That way compiling without precompiled headers works.  Resolves #1505 .