### PR TITLE
[Refactor] 鍛冶効果情報をカスタマイズしやすく再設計

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -270,6 +270,7 @@
     <ClCompile Include="..\..\src\action\movement-execution.cpp" />
     <ClCompile Include="..\..\src\core\score-util.cpp" />
     <ClCompile Include="..\..\src\object-enchant\object-smith.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\smith-info.cpp" />
     <ClCompile Include="..\..\src\object-enchant\smith-tables.cpp" />
     <ClCompile Include="..\..\src\player-base\player-class.cpp" />
     <ClCompile Include="..\..\src\player-base\player-race.cpp" />
@@ -912,6 +913,7 @@
     <ClInclude Include="..\..\src\action\run-execution.h" />
     <ClInclude Include="..\..\src\load\savedata-old-flag-types.h" />
     <ClInclude Include="..\..\src\object-enchant\object-smith.h" />
+    <ClInclude Include="..\..\src\object-enchant\smith-info.h" />
     <ClInclude Include="..\..\src\object-enchant\smith-tables.h" />
     <ClInclude Include="..\..\src\object-enchant\smith-types.h" />
     <ClInclude Include="..\..\src\object-enchant\tr-flags.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2328,6 +2328,9 @@
     <ClCompile Include="..\..\src\player-base\player-class.cpp">
       <Filter>player-base</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\smith-info.cpp">
+      <Filter>object-enchant</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5009,6 +5012,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\player-base\player-class.h">
       <Filter>player-base</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\smith-info.h">
+      <Filter>object-enchant</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -592,6 +592,7 @@ hengband_SOURCES = \
 	object-enchant/object-smith.cpp object-enchant/object-smith.h \
 	object-enchant/item-apply-magic.h object-enchant/item-feeling.h \
 	object-enchant/old-ego-extra-values.h object-enchant/special-object-flags.h \
+	object-enchant/smith-info.cpp object-enchant/smith-info.h \
 	object-enchant/smith-tables.cpp object-enchant/smith-tables.h \
 	object-enchant/smith-types.h \
 	object-enchant/tr-flags.h \

--- a/src/object-enchant/object-smith.cpp
+++ b/src/object-enchant/object-smith.cpp
@@ -1,5 +1,5 @@
 ﻿#include "object-enchant/object-smith.h"
-#include "artifact/random-art-effects.h"
+#include "object-enchant/smith-info.h"
 #include "object-enchant/smith-tables.h"
 #include "object-enchant/smith-types.h"
 #include "object-enchant/special-object-flags.h"
@@ -56,13 +56,13 @@ Smith::Smith(player_type *player_ptr)
  * @param effect 情報を得る鍛冶効果
  * @return 鍛冶情報構造体へのポインタを保持する std::optional オブジェクトを返す
  */
-std::optional<const smith_info_type *> Smith::find_smith_info(SmithEffect effect)
+std::optional<const smith_info_base *> Smith::find_smith_info(SmithEffect effect)
 {
     // 何度も呼ぶので線形探索を避けるため鍛冶効果から鍛冶情報のテーブルを引けるmapを作成しておく。
-    static std::unordered_map<SmithEffect, const smith_info_type *> search_map;
+    static std::unordered_map<SmithEffect, const smith_info_base *> search_map;
     if (search_map.empty()) {
         for (const auto &info : smith_info_table) {
-            search_map.emplace(info.effect, &info);
+            search_map.emplace(info->effect, info.get());
         }
     }
 
@@ -216,7 +216,7 @@ TrFlags Smith::get_effect_tr_flags(SmithEffect effect)
         return {};
     }
 
-    return info.value()->add_flags;
+    return info.value()->tr_flags();
 }
 
 /*!
@@ -228,20 +228,12 @@ TrFlags Smith::get_effect_tr_flags(SmithEffect effect)
  */
 std::optional<random_art_activation_type> Smith::get_effect_activation(SmithEffect effect)
 {
-    switch (effect) {
-    case SmithEffect::TMP_RES_ACID:
-        return ACT_RESIST_ACID;
-    case SmithEffect::TMP_RES_ELEC:
-        return ACT_RESIST_ELEC;
-    case SmithEffect::TMP_RES_FIRE:
-        return ACT_RESIST_FIRE;
-    case SmithEffect::TMP_RES_COLD:
-        return ACT_RESIST_COLD;
-    case SmithEffect::EARTHQUAKE:
-        return ACT_QUAKE;
-    default:
+    auto info = find_smith_info(effect);
+    if (!info.has_value()) {
         return std::nullopt;
     }
+
+    return info.value()->activation_index();
 }
 
 /*!
@@ -272,8 +264,8 @@ std::vector<SmithEffect> Smith::get_effect_list(SmithCategory category)
     std::vector<SmithEffect> result;
 
     for (const auto &info : smith_info_table) {
-        if (info.category == category) {
-            result.push_back(info.effect);
+        if (info->category == category) {
+            result.push_back(info->effect);
         }
     }
 
@@ -453,39 +445,7 @@ bool Smith::add_essence(SmithEffect effect, object_type *o_ptr, int number)
         this->player_ptr->magic_num1[enum2i(essence)] -= total_consumption;
     }
 
-    if (effect == SmithEffect::SLAY_GLOVE) {
-        HIT_PROB get_to_h = ((number + 1) / 2 + randint0(number / 2 + 1));
-        HIT_POINT get_to_d = ((number + 1) / 2 + randint0(number / 2 + 1));
-        o_ptr->xtra4 = (get_to_h << 8) + get_to_d;
-        o_ptr->to_h += get_to_h;
-        o_ptr->to_d += get_to_d;
-    }
-
-    if (effect == SmithEffect::ATTACK) {
-        const auto max_val = this->player_ptr->lev / 5 + 5;
-        if ((o_ptr->to_h >= max_val) && (o_ptr->to_d >= max_val)) {
-            return false;
-        } else {
-            o_ptr->to_h = static_cast<HIT_PROB>(std::min(o_ptr->to_h + 1, max_val));
-            o_ptr->to_d = static_cast<HIT_POINT>(std::min(o_ptr->to_d + 1, max_val));
-        }
-    } else if (effect == SmithEffect::AC) {
-        const auto max_val = this->player_ptr->lev / 5 + 5;
-        if (o_ptr->to_a >= max_val) {
-            return false;
-        } else {
-            o_ptr->to_a = static_cast<ARMOUR_CLASS>(std::min(o_ptr->to_a + 1, max_val));
-        }
-    } else if (effect == SmithEffect::SUSTAIN) {
-        o_ptr->art_flags.set(TR_IGNORE_ACID);
-        o_ptr->art_flags.set(TR_IGNORE_ELEC);
-        o_ptr->art_flags.set(TR_IGNORE_FIRE);
-        o_ptr->art_flags.set(TR_IGNORE_COLD);
-    } else {
-        o_ptr->xtra3 = static_cast<decltype(o_ptr->xtra3)>(effect);
-    }
-
-    return true;
+    return info.value()->add_essence(this->player_ptr, o_ptr, number);
 }
 
 /*!
@@ -496,17 +456,13 @@ bool Smith::add_essence(SmithEffect effect, object_type *o_ptr, int number)
 void Smith::erase_essence(object_type *o_ptr) const
 {
     auto effect = Smith::object_effect(o_ptr);
-    if (effect == SmithEffect::SLAY_GLOVE) {
-        o_ptr->to_h -= (o_ptr->xtra4 >> 8);
-        o_ptr->to_d -= (o_ptr->xtra4 & 0x000f);
-        o_ptr->xtra4 = 0;
-        if (o_ptr->to_h < 0)
-            o_ptr->to_h = 0;
-        if (o_ptr->to_d < 0)
-            o_ptr->to_d = 0;
+    if (!effect.has_value()) {
+        return;
     }
-    o_ptr->xtra3 = 0;
-    auto flgs = object_flags(o_ptr);
-    if (flgs.has_none_of(TR_PVAL_FLAG_MASK))
-        o_ptr->pval = 0;
+    auto info = find_smith_info(effect.value());
+    if (!info.has_value()) {
+        return;
+    }
+
+    info.value()->erase_essence(o_ptr);
 }

--- a/src/object-enchant/object-smith.cpp
+++ b/src/object-enchant/object-smith.cpp
@@ -56,10 +56,10 @@ Smith::Smith(player_type *player_ptr)
  * @param effect 情報を得る鍛冶効果
  * @return 鍛冶情報構造体へのポインタを保持する std::optional オブジェクトを返す
  */
-std::optional<const smith_info_base *> Smith::find_smith_info(SmithEffect effect)
+std::optional<const ISmithInfo *> Smith::find_smith_info(SmithEffect effect)
 {
     // 何度も呼ぶので線形探索を避けるため鍛冶効果から鍛冶情報のテーブルを引けるmapを作成しておく。
-    static std::unordered_map<SmithEffect, const smith_info_base *> search_map;
+    static std::unordered_map<SmithEffect, const ISmithInfo *> search_map;
     if (search_map.empty()) {
         for (const auto &info : smith_info_table) {
             search_map.emplace(info->effect, info.get());

--- a/src/object-enchant/object-smith.h
+++ b/src/object-enchant/object-smith.h
@@ -10,7 +10,7 @@
 
 struct object_type;
 struct player_type;
-struct smith_info_type;
+class smith_info_base;
 struct essence_drain_type;
 class ItemTester;
 
@@ -48,12 +48,12 @@ public:
     int get_addable_count(SmithEffect smith_effect, int item_number) const;
 
 private:
-    static std::optional<const smith_info_type *> find_smith_info(SmithEffect effect);
+    static std::optional<const smith_info_base *> find_smith_info(SmithEffect effect);
 
     static const std::vector<SmithEssence> essence_list_order;
     static const std::unordered_map<SmithEssence, concptr> essence_to_name;
     static const std::vector<essence_drain_type> essence_drain_info_table;
-    static const std::vector<smith_info_type> smith_info_table;
+    static const std::vector<std::shared_ptr<smith_info_base>> smith_info_table;
 
     player_type *player_ptr;
 };

--- a/src/object-enchant/object-smith.h
+++ b/src/object-enchant/object-smith.h
@@ -10,7 +10,7 @@
 
 struct object_type;
 struct player_type;
-class smith_info_base;
+class ISmithInfo;
 struct essence_drain_type;
 class ItemTester;
 
@@ -48,12 +48,12 @@ public:
     int get_addable_count(SmithEffect smith_effect, int item_number) const;
 
 private:
-    static std::optional<const smith_info_base *> find_smith_info(SmithEffect effect);
+    static std::optional<const ISmithInfo *> find_smith_info(SmithEffect effect);
 
     static const std::vector<SmithEssence> essence_list_order;
     static const std::unordered_map<SmithEssence, concptr> essence_to_name;
     static const std::vector<essence_drain_type> essence_drain_info_table;
-    static const std::vector<std::shared_ptr<smith_info_base>> smith_info_table;
+    static const std::vector<std::shared_ptr<ISmithInfo>> smith_info_table;
 
     player_type *player_ptr;
 };

--- a/src/object-enchant/smith-info.cpp
+++ b/src/object-enchant/smith-info.cpp
@@ -1,0 +1,146 @@
+﻿#include "object-enchant/smith-info.h"
+#include "object/object-flags.h"
+#include "system/object-type-definition.h"
+#include "system/player-type-definition.h"
+
+smith_info_base::smith_info_base(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption)
+    : effect(effect)
+    , name(name)
+    , category(category)
+    , need_essences(std::move(need_essences))
+    , consumption(consumption)
+{
+}
+
+TrFlags smith_info_base::tr_flags() const
+{
+    return {};
+}
+
+std::optional<random_art_activation_type> smith_info_base::activation_index() const
+{
+    return std::nullopt;
+}
+
+basic_smith_info::basic_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption, TrFlags add_flags)
+    : smith_info_base(effect, name, category, std::move(need_essences), consumption)
+    , add_flags(add_flags)
+{
+}
+
+bool basic_smith_info::add_essence(player_type *, object_type *o_ptr, int) const
+{
+    o_ptr->xtra3 = static_cast<decltype(o_ptr->xtra3)>(effect);
+
+    return true;
+}
+
+void basic_smith_info::erase_essence(object_type *o_ptr) const
+{
+    o_ptr->xtra3 = 0;
+    auto flgs = object_flags(o_ptr);
+    if (flgs.has_none_of(TR_PVAL_FLAG_MASK))
+        o_ptr->pval = 0;
+}
+
+TrFlags basic_smith_info::tr_flags() const
+{
+    return this->add_flags;
+}
+
+activation_smith_info::activation_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption, TrFlags add_flags, random_art_activation_type act_idx)
+    : basic_smith_info(effect, name, category, std::move(need_essences), consumption, std::move(add_flags))
+    , act_idx(act_idx)
+{
+}
+
+TrFlags activation_smith_info::tr_flags() const
+{
+    return basic_smith_info::tr_flags().set(TR_ACTIVATE);
+}
+
+std::optional<random_art_activation_type> activation_smith_info::activation_index() const
+{
+    return this->act_idx;
+}
+
+enchant_weapon_smith_info::enchant_weapon_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption)
+    : smith_info_base(effect, name, category, std::move(need_essences), consumption)
+{
+}
+
+bool enchant_weapon_smith_info::add_essence(player_type *player_ptr, object_type *o_ptr, int) const
+{
+    const auto max_val = player_ptr->lev / 5 + 5;
+    if ((o_ptr->to_h >= max_val) && (o_ptr->to_d >= max_val)) {
+        return false;
+    }
+
+    o_ptr->to_h = static_cast<HIT_PROB>(std::min(o_ptr->to_h + 1, max_val));
+    o_ptr->to_d = static_cast<HIT_POINT>(std::min(o_ptr->to_d + 1, max_val));
+
+    return true;
+}
+
+enchant_armour_smith_info::enchant_armour_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption)
+    : smith_info_base(effect, name, category, std::move(need_essences), consumption)
+{
+}
+
+bool enchant_armour_smith_info::add_essence(player_type *player_ptr, object_type *o_ptr, int) const
+{
+    const auto max_val = player_ptr->lev / 5 + 5;
+    if (o_ptr->to_a >= max_val) {
+        return false;
+    }
+
+    o_ptr->to_a++;
+
+    return true;
+}
+
+sustain_smith_info::sustain_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption)
+    : smith_info_base(effect, name, category, std::move(need_essences), consumption)
+{
+}
+
+bool sustain_smith_info::add_essence(player_type *, object_type *o_ptr, int) const
+{
+    o_ptr->art_flags.set(TR_IGNORE_ACID);
+    o_ptr->art_flags.set(TR_IGNORE_ELEC);
+    o_ptr->art_flags.set(TR_IGNORE_FIRE);
+    o_ptr->art_flags.set(TR_IGNORE_COLD);
+
+    return true;
+}
+
+slaying_gloves_smith_info::slaying_gloves_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption)
+    : basic_smith_info(effect, name, category, std::move(need_essences), consumption, {})
+{
+}
+
+bool slaying_gloves_smith_info::add_essence(player_type *player_ptr, object_type *o_ptr, int number) const
+{
+    basic_smith_info::add_essence(player_ptr, o_ptr, number);
+
+    HIT_PROB get_to_h = ((number + 1) / 2 + randint0(number / 2 + 1));
+    HIT_POINT get_to_d = ((number + 1) / 2 + randint0(number / 2 + 1));
+    o_ptr->xtra4 = (get_to_h << 8) + get_to_d;
+    o_ptr->to_h += get_to_h;
+    o_ptr->to_d += get_to_d;
+
+    return true;
+}
+
+void slaying_gloves_smith_info::erase_essence(object_type *o_ptr) const
+{
+    basic_smith_info::erase_essence(o_ptr);
+
+    o_ptr->to_h -= (o_ptr->xtra4 >> 8);
+    o_ptr->to_d -= (o_ptr->xtra4 & 0x000f);
+    o_ptr->xtra4 = 0;
+    if (o_ptr->to_h < 0)
+        o_ptr->to_h = 0;
+    if (o_ptr->to_d < 0)
+        o_ptr->to_d = 0;
+}

--- a/src/object-enchant/smith-info.cpp
+++ b/src/object-enchant/smith-info.cpp
@@ -3,7 +3,7 @@
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
 
-smith_info_base::smith_info_base(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption)
+ISmithInfo::ISmithInfo(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption)
     : effect(effect)
     , name(name)
     , category(category)
@@ -12,30 +12,30 @@ smith_info_base::smith_info_base(SmithEffect effect, concptr name, SmithCategory
 {
 }
 
-TrFlags smith_info_base::tr_flags() const
+TrFlags ISmithInfo::tr_flags() const
 {
     return {};
 }
 
-std::optional<random_art_activation_type> smith_info_base::activation_index() const
+std::optional<random_art_activation_type> ISmithInfo::activation_index() const
 {
     return std::nullopt;
 }
 
-basic_smith_info::basic_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption, TrFlags add_flags)
-    : smith_info_base(effect, name, category, std::move(need_essences), consumption)
+BasicSmithInfo::BasicSmithInfo(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption, TrFlags add_flags)
+    : ISmithInfo(effect, name, category, std::move(need_essences), consumption)
     , add_flags(add_flags)
 {
 }
 
-bool basic_smith_info::add_essence(player_type *, object_type *o_ptr, int) const
+bool BasicSmithInfo::add_essence(player_type *, object_type *o_ptr, int) const
 {
     o_ptr->xtra3 = static_cast<decltype(o_ptr->xtra3)>(effect);
 
     return true;
 }
 
-void basic_smith_info::erase_essence(object_type *o_ptr) const
+void BasicSmithInfo::erase_essence(object_type *o_ptr) const
 {
     o_ptr->xtra3 = 0;
     auto flgs = object_flags(o_ptr);
@@ -43,33 +43,33 @@ void basic_smith_info::erase_essence(object_type *o_ptr) const
         o_ptr->pval = 0;
 }
 
-TrFlags basic_smith_info::tr_flags() const
+TrFlags BasicSmithInfo::tr_flags() const
 {
     return this->add_flags;
 }
 
-activation_smith_info::activation_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption, TrFlags add_flags, random_art_activation_type act_idx)
-    : basic_smith_info(effect, name, category, std::move(need_essences), consumption, std::move(add_flags))
+ActivationSmithInfo::ActivationSmithInfo(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption, TrFlags add_flags, random_art_activation_type act_idx)
+    : BasicSmithInfo(effect, name, category, std::move(need_essences), consumption, std::move(add_flags))
     , act_idx(act_idx)
 {
 }
 
-TrFlags activation_smith_info::tr_flags() const
+TrFlags ActivationSmithInfo::tr_flags() const
 {
-    return basic_smith_info::tr_flags().set(TR_ACTIVATE);
+    return BasicSmithInfo::tr_flags().set(TR_ACTIVATE);
 }
 
-std::optional<random_art_activation_type> activation_smith_info::activation_index() const
+std::optional<random_art_activation_type> ActivationSmithInfo::activation_index() const
 {
     return this->act_idx;
 }
 
-enchant_weapon_smith_info::enchant_weapon_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption)
-    : smith_info_base(effect, name, category, std::move(need_essences), consumption)
+EnchantWeaponSmithInfo::EnchantWeaponSmithInfo(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption)
+    : ISmithInfo(effect, name, category, std::move(need_essences), consumption)
 {
 }
 
-bool enchant_weapon_smith_info::add_essence(player_type *player_ptr, object_type *o_ptr, int) const
+bool EnchantWeaponSmithInfo::add_essence(player_type *player_ptr, object_type *o_ptr, int) const
 {
     const auto max_val = player_ptr->lev / 5 + 5;
     if ((o_ptr->to_h >= max_val) && (o_ptr->to_d >= max_val)) {
@@ -82,12 +82,12 @@ bool enchant_weapon_smith_info::add_essence(player_type *player_ptr, object_type
     return true;
 }
 
-enchant_armour_smith_info::enchant_armour_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption)
-    : smith_info_base(effect, name, category, std::move(need_essences), consumption)
+EnchantArmourSmithInfo::EnchantArmourSmithInfo(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption)
+    : ISmithInfo(effect, name, category, std::move(need_essences), consumption)
 {
 }
 
-bool enchant_armour_smith_info::add_essence(player_type *player_ptr, object_type *o_ptr, int) const
+bool EnchantArmourSmithInfo::add_essence(player_type *player_ptr, object_type *o_ptr, int) const
 {
     const auto max_val = player_ptr->lev / 5 + 5;
     if (o_ptr->to_a >= max_val) {
@@ -99,12 +99,12 @@ bool enchant_armour_smith_info::add_essence(player_type *player_ptr, object_type
     return true;
 }
 
-sustain_smith_info::sustain_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption)
-    : smith_info_base(effect, name, category, std::move(need_essences), consumption)
+SustainSmithInfo::SustainSmithInfo(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption)
+    : ISmithInfo(effect, name, category, std::move(need_essences), consumption)
 {
 }
 
-bool sustain_smith_info::add_essence(player_type *, object_type *o_ptr, int) const
+bool SustainSmithInfo::add_essence(player_type *, object_type *o_ptr, int) const
 {
     o_ptr->art_flags.set(TR_IGNORE_ACID);
     o_ptr->art_flags.set(TR_IGNORE_ELEC);
@@ -114,14 +114,14 @@ bool sustain_smith_info::add_essence(player_type *, object_type *o_ptr, int) con
     return true;
 }
 
-slaying_gloves_smith_info::slaying_gloves_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption)
-    : basic_smith_info(effect, name, category, std::move(need_essences), consumption, {})
+SlayingGlovesSmithInfo::SlayingGlovesSmithInfo(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption)
+    : BasicSmithInfo(effect, name, category, std::move(need_essences), consumption, {})
 {
 }
 
-bool slaying_gloves_smith_info::add_essence(player_type *player_ptr, object_type *o_ptr, int number) const
+bool SlayingGlovesSmithInfo::add_essence(player_type *player_ptr, object_type *o_ptr, int number) const
 {
-    basic_smith_info::add_essence(player_ptr, o_ptr, number);
+    BasicSmithInfo::add_essence(player_ptr, o_ptr, number);
 
     HIT_PROB get_to_h = ((number + 1) / 2 + randint0(number / 2 + 1));
     HIT_POINT get_to_d = ((number + 1) / 2 + randint0(number / 2 + 1));
@@ -132,9 +132,9 @@ bool slaying_gloves_smith_info::add_essence(player_type *player_ptr, object_type
     return true;
 }
 
-void slaying_gloves_smith_info::erase_essence(object_type *o_ptr) const
+void SlayingGlovesSmithInfo::erase_essence(object_type *o_ptr) const
 {
-    basic_smith_info::erase_essence(o_ptr);
+    BasicSmithInfo::erase_essence(o_ptr);
 
     o_ptr->to_h -= (o_ptr->xtra4 >> 8);
     o_ptr->to_d -= (o_ptr->xtra4 & 0x000f);

--- a/src/object-enchant/smith-info.h
+++ b/src/object-enchant/smith-info.h
@@ -18,9 +18,9 @@ struct object_type;
 /*!
  * @brief 鍛冶効果の情報の基底クラス
  */
-class smith_info_base {
+class ISmithInfo {
 public:
-    virtual ~smith_info_base() = default;
+    virtual ~ISmithInfo() = default;
 
     /*!
      * @brief 鍛冶効果を付与する
@@ -62,16 +62,16 @@ public:
     int consumption; //!< 能力を与えるのに必要な消費量(need_essencesに含まれるエッセンスそれぞれについてこの量を消費)
 
 protected:
-    smith_info_base(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption);
+    ISmithInfo(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption);
 };
 
 /*!
  * @brief 基本的な鍛冶効果の情報クラス
  * 多くの鍛冶効果が該当する、指定した特性フラグを与える鍛冶の情報を扱う
  */
-class basic_smith_info : public smith_info_base {
+class BasicSmithInfo : public ISmithInfo {
 public:
-    basic_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption, TrFlags add_flags);
+    BasicSmithInfo(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption, TrFlags add_flags);
     virtual bool add_essence(player_type *player_ptr, object_type *o_ptr, int number) const override;
     virtual void erase_essence(object_type *o_ptr) const override;
     virtual TrFlags tr_flags() const override;
@@ -84,9 +84,9 @@ private:
  * @brief 発動効果を付与する鍛冶効果の情報クラス
  * 発動効果を付与する（かつ、特性フラグを与える場合もある）鍛冶の情報を扱う
  */
-class activation_smith_info : public basic_smith_info {
+class ActivationSmithInfo : public BasicSmithInfo {
 public:
-    activation_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption, TrFlags add_flags, random_art_activation_type act_idx);
+    ActivationSmithInfo(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption, TrFlags add_flags, random_art_activation_type act_idx);
     virtual TrFlags tr_flags() const override;
     virtual std::optional<random_art_activation_type> activation_index() const override;
 
@@ -98,9 +98,9 @@ private:
  * @brief 武器強化を行う鍛冶情報のクラス
  * 武器の命中/ダメージ修正を強化する。鍛冶効果とは別枠で行うので鍛冶師の銘付きにはならない。
  */
-class enchant_weapon_smith_info : public smith_info_base {
+class EnchantWeaponSmithInfo : public ISmithInfo {
 public:
-    enchant_weapon_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption);
+    EnchantWeaponSmithInfo(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption);
     virtual bool add_essence(player_type *player_ptr, object_type *o_ptr, int number) const override;
     virtual void erase_essence(object_type *) const override {}
 };
@@ -109,9 +109,9 @@ public:
  * @brief 防具強化を行う鍛冶情報のクラス
  * 防具のAC修正を強化する。鍛冶効果とは別枠で行うので鍛冶師の銘付きにはならない。
  */
-class enchant_armour_smith_info : public smith_info_base {
+class EnchantArmourSmithInfo : public ISmithInfo {
 public:
-    enchant_armour_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption);
+    EnchantArmourSmithInfo(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption);
     virtual bool add_essence(player_type *player_ptr, object_type *o_ptr, int number) const override;
     virtual void erase_essence(object_type *) const override {}
 };
@@ -120,9 +120,9 @@ public:
  * @brief 装備保持を行う鍛冶情報のクラス
  * 四元素属性で破壊されないフラグを付与する。鍛冶効果とは別枠で行うので鍛冶師の銘付きにはならない。
  */
-class sustain_smith_info : public smith_info_base {
+class SustainSmithInfo : public ISmithInfo {
 public:
-    sustain_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption);
+    SustainSmithInfo(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption);
     virtual bool add_essence(player_type *player_ptr, object_type *o_ptr, int number) const override;
     virtual void erase_essence(object_type *) const override {}
 };
@@ -131,9 +131,9 @@ public:
  * @brief 殺戮の小手を作成する鍛冶情報のクラス
  * 小手に殺戮修正を付ける。(もともと殺戮修正のある小手は修正をさらに強化する)
  */
-class slaying_gloves_smith_info : public basic_smith_info {
+class SlayingGlovesSmithInfo : public BasicSmithInfo {
 public:
-    slaying_gloves_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption);
+    SlayingGlovesSmithInfo(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption);
     virtual bool add_essence(player_type *player_ptr, object_type *o_ptr, int number) const override;
     virtual void erase_essence(object_type *) const override;
 };

--- a/src/object-enchant/smith-info.h
+++ b/src/object-enchant/smith-info.h
@@ -1,0 +1,139 @@
+﻿#pragma once
+
+#include "system/angband.h"
+
+#include "object-enchant/tr-flags.h"
+
+#include <optional>
+#include <vector>
+
+enum class SmithEffect;
+enum class SmithCategory;
+enum class SmithEssence;
+enum random_art_activation_type : uint8_t;
+
+struct player_type;
+struct object_type;
+
+/*!
+ * @brief 鍛冶効果の情報の基底クラス
+ */
+class smith_info_base {
+public:
+    virtual ~smith_info_base() = default;
+
+    /*!
+     * @brief 鍛冶効果を付与する
+     *
+     * @param o_ptr 鍛冶効果の付与を行うアイテム構造体へのポインタ
+     * @param number 付与を行うエッセンスの個数
+     * @return 鍛冶効果の付与に成功した場合は true、失敗した場合は false
+     */
+    virtual bool add_essence(player_type *player_ptr, object_type *o_ptr, int number) const = 0;
+
+    /*!
+     * @brief 鍛冶効果を消去する
+     *
+     * @param o_ptr 鍛冶効果の消去を行うアイテム構造体へのポインタ
+     */
+    virtual void erase_essence(object_type *o_ptr) const = 0;
+
+    /*!
+     * @brief 鍛冶効果により与えられる特性フラグ(tr_type)のFlagGroupオブジェクトを取得する
+     * 基底クラスは空のFlagGroupオブジェクトを返す。派生クラスで必要に応じて鍛冶効果で与えられる特性フラグを返すようオーバーライドする。
+     *
+     * @return TrFlags 鍛冶効果により与えられる特性フラグ(tr_type)のFlagGroupオブジェクト
+     */
+    virtual TrFlags tr_flags() const;
+
+    /*!
+     * @brief 鍛冶効果により与えられる発動IDを取得する
+     * 基底クラスは std::nullopt を返す。派生クラスで必要に応じて鍛冶効果により与えられる発動IDを返すようオーバーライドする。
+     *
+     * @return std::optional<random_art_activation_type> 発動IDを保持する std::optional オブジェクト
+     * 発動効果が付与されない場合は std::nullopt
+     */
+    virtual std::optional<random_art_activation_type> activation_index() const;
+
+    SmithEffect effect; //!< 鍛冶で与える効果の種類
+    concptr name; //!< 鍛冶で与える能力の名称
+    SmithCategory category; //!< 鍛冶で与える能力が所属するグループ
+    std::vector<SmithEssence> need_essences; //!< 能力を与えるのに必要なエッセンスのリスト
+    int consumption; //!< 能力を与えるのに必要な消費量(need_essencesに含まれるエッセンスそれぞれについてこの量を消費)
+
+protected:
+    smith_info_base(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption);
+};
+
+/*!
+ * @brief 基本的な鍛冶効果の情報クラス
+ * 多くの鍛冶効果が該当する、指定した特性フラグを与える鍛冶の情報を扱う
+ */
+class basic_smith_info : public smith_info_base {
+public:
+    basic_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption, TrFlags add_flags);
+    virtual bool add_essence(player_type *player_ptr, object_type *o_ptr, int number) const override;
+    virtual void erase_essence(object_type *o_ptr) const override;
+    virtual TrFlags tr_flags() const override;
+
+private:
+    TrFlags add_flags; //!< 鍛冶で能力を与えることにより付与されるアイテム特性フラグ
+};
+
+/*!
+ * @brief 発動効果を付与する鍛冶効果の情報クラス
+ * 発動効果を付与する（かつ、特性フラグを与える場合もある）鍛冶の情報を扱う
+ */
+class activation_smith_info : public basic_smith_info {
+public:
+    activation_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption, TrFlags add_flags, random_art_activation_type act_idx);
+    virtual TrFlags tr_flags() const override;
+    virtual std::optional<random_art_activation_type> activation_index() const override;
+
+private:
+    random_art_activation_type act_idx; //!< 発動能力ID
+};
+
+/*!
+ * @brief 武器強化を行う鍛冶情報のクラス
+ * 武器の命中/ダメージ修正を強化する。鍛冶効果とは別枠で行うので鍛冶師の銘付きにはならない。
+ */
+class enchant_weapon_smith_info : public smith_info_base {
+public:
+    enchant_weapon_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption);
+    virtual bool add_essence(player_type *player_ptr, object_type *o_ptr, int number) const override;
+    virtual void erase_essence(object_type *) const override {}
+};
+
+/*!
+ * @brief 防具強化を行う鍛冶情報のクラス
+ * 防具のAC修正を強化する。鍛冶効果とは別枠で行うので鍛冶師の銘付きにはならない。
+ */
+class enchant_armour_smith_info : public smith_info_base {
+public:
+    enchant_armour_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption);
+    virtual bool add_essence(player_type *player_ptr, object_type *o_ptr, int number) const override;
+    virtual void erase_essence(object_type *) const override {}
+};
+
+/*!
+ * @brief 装備保持を行う鍛冶情報のクラス
+ * 四元素属性で破壊されないフラグを付与する。鍛冶効果とは別枠で行うので鍛冶師の銘付きにはならない。
+ */
+class sustain_smith_info : public smith_info_base {
+public:
+    sustain_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption);
+    virtual bool add_essence(player_type *player_ptr, object_type *o_ptr, int number) const override;
+    virtual void erase_essence(object_type *) const override {}
+};
+
+/*!
+ * @brief 殺戮の小手を作成する鍛冶情報のクラス
+ * 小手に殺戮修正を付ける。(もともと殺戮修正のある小手は修正をさらに強化する)
+ */
+class slaying_gloves_smith_info : public basic_smith_info {
+public:
+    slaying_gloves_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption);
+    virtual bool add_essence(player_type *player_ptr, object_type *o_ptr, int number) const override;
+    virtual void erase_essence(object_type *) const override;
+};

--- a/src/object-enchant/smith-tables.cpp
+++ b/src/object-enchant/smith-tables.cpp
@@ -1,9 +1,13 @@
 ﻿#include "object-enchant/smith-tables.h"
+#include "artifact/random-art-effects.h"
 #include "object-enchant/object-smith.h"
+#include "object-enchant/smith-info.h"
 #include "object-enchant/smith-types.h"
 #include "object-enchant/tr-flags.h"
 #include "object-enchant/tr-types.h"
 
+#include <memory>
+#include <unordered_map>
 #include <vector>
 
 /*!
@@ -326,119 +330,134 @@ const std::vector<essence_drain_type> Smith::essence_drain_info_table = {
     { TR_IM_DARK, {}, 0 },
 };
 
+namespace {
+
+template <typename T, typename... Args>
+std::shared_ptr<smith_info_base> make_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption, Args&&... args)
+{
+    return std::make_shared<T>(effect, name, category, std::move(need_essences), consumption, std::forward<Args>(args)...);
+}
+
+std::shared_ptr<smith_info_base> make_basic_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption, TrFlags add_flags)
+{
+    return make_info<basic_smith_info>(effect, name, category, std::move(need_essences), consumption, std::move(add_flags));
+}
+
+}
+
 /*!
  * @brief 鍛冶情報テーブル
  */
-const std::vector<smith_info_type> Smith::smith_info_table = {
-    { SmithEffect::NONE, _("なし", "None"), SmithCategory::NONE, { SmithEssence::NONE }, 0, {} },
+const std::vector<std::shared_ptr<smith_info_base>> Smith::smith_info_table = {
+    make_basic_smith_info(SmithEffect::NONE, _("なし", "None"), SmithCategory::NONE, std::vector<SmithEssence>{ SmithEssence::NONE }, 0, {}),
 
-    { SmithEffect::STR, _("腕力", "strength"), SmithCategory::PVAL, { SmithEssence::STR }, 20, { TR_STR } },
-    { SmithEffect::INT, _("知能", "intelligence"), SmithCategory::PVAL, { SmithEssence::INT }, 20, { TR_INT } },
-    { SmithEffect::WIS, _("賢さ", "wisdom"), SmithCategory::PVAL, { SmithEssence::WIS }, 20, { TR_WIS } },
-    { SmithEffect::DEX, _("器用さ", "dexterity"), SmithCategory::PVAL, { SmithEssence::DEX }, 20, { TR_DEX } },
-    { SmithEffect::CON, _("耐久力", "constitution"), SmithCategory::PVAL, { SmithEssence::CON }, 20, { TR_CON } },
-    { SmithEffect::CHR, _("魅力", "charisma"), SmithCategory::PVAL, { SmithEssence::CHR }, 20, { TR_CHR } },
+    make_basic_smith_info(SmithEffect::STR, _("腕力", "strength"), SmithCategory::PVAL, { SmithEssence::STR }, 20, { TR_STR }),
+    make_basic_smith_info(SmithEffect::INT, _("知能", "intelligence"), SmithCategory::PVAL, { SmithEssence::INT }, 20, { TR_INT }),
+    make_basic_smith_info(SmithEffect::WIS, _("賢さ", "wisdom"), SmithCategory::PVAL, { SmithEssence::WIS }, 20, { TR_WIS }),
+    make_basic_smith_info(SmithEffect::DEX, _("器用さ", "dexterity"), SmithCategory::PVAL, { SmithEssence::DEX }, 20, { TR_DEX }),
+    make_basic_smith_info(SmithEffect::CON, _("耐久力", "constitution"), SmithCategory::PVAL, { SmithEssence::CON }, 20, { TR_CON }),
+    make_basic_smith_info(SmithEffect::CHR, _("魅力", "charisma"), SmithCategory::PVAL, { SmithEssence::CHR }, 20, { TR_CHR }),
 
-    { SmithEffect::SUST_STR, _("腕力維持", "sustain strength"), SmithCategory::ABILITY, { SmithEssence::SUST_STATUS }, 15, { TR_SUST_STR } },
-    { SmithEffect::SUST_INT, _("知能維持", "sustain intelligence"), SmithCategory::ABILITY, { SmithEssence::SUST_STATUS }, 15, { TR_SUST_INT } },
-    { SmithEffect::SUST_WIS, _("賢さ維持", "sustain wisdom"), SmithCategory::ABILITY, { SmithEssence::SUST_STATUS }, 15, { TR_SUST_WIS } },
-    { SmithEffect::SUST_DEX, _("器用さ維持", "sustain dexterity"), SmithCategory::ABILITY, { SmithEssence::SUST_STATUS }, 15, { TR_SUST_DEX } },
-    { SmithEffect::SUST_CON, _("耐久力維持", "sustain constitution"), SmithCategory::ABILITY, { SmithEssence::SUST_STATUS }, 15, { TR_SUST_CON } },
-    { SmithEffect::SUST_CHR, _("魅力維持", "sustain charisma"), SmithCategory::ABILITY, { SmithEssence::SUST_STATUS }, 15, { TR_SUST_CHR } },
+    make_basic_smith_info(SmithEffect::SUST_STR, _("腕力維持", "sustain strength"), SmithCategory::ABILITY, { SmithEssence::SUST_STATUS }, 15, { TR_SUST_STR }),
+    make_basic_smith_info(SmithEffect::SUST_INT, _("知能維持", "sustain intelligence"), SmithCategory::ABILITY, { SmithEssence::SUST_STATUS }, 15, { TR_SUST_INT }),
+    make_basic_smith_info(SmithEffect::SUST_WIS, _("賢さ維持", "sustain wisdom"), SmithCategory::ABILITY, { SmithEssence::SUST_STATUS }, 15, { TR_SUST_WIS }),
+    make_basic_smith_info(SmithEffect::SUST_DEX, _("器用さ維持", "sustain dexterity"), SmithCategory::ABILITY, { SmithEssence::SUST_STATUS }, 15, { TR_SUST_DEX }),
+    make_basic_smith_info(SmithEffect::SUST_CON, _("耐久力維持", "sustain constitution"), SmithCategory::ABILITY, { SmithEssence::SUST_STATUS }, 15, { TR_SUST_CON }),
+    make_basic_smith_info(SmithEffect::SUST_CHR, _("魅力維持", "sustain charisma"), SmithCategory::ABILITY, { SmithEssence::SUST_STATUS }, 15, { TR_SUST_CHR }),
 
-    { SmithEffect::MAGIC_MASTERY, _("魔力支配", "magic mastery"), SmithCategory::PVAL, { SmithEssence::MAGIC_MASTERY }, 20, { TR_MAGIC_MASTERY } },
-    { SmithEffect::STEALTH, _("隠密", "stealth"), SmithCategory::PVAL, { SmithEssence::STEALTH }, 40, { TR_STEALTH } },
-    { SmithEffect::SEARCH, _("探索", "searching"), SmithCategory::PVAL, { SmithEssence::SEARCH }, 15, { TR_SEARCH } },
-    { SmithEffect::INFRA, _("赤外線視力", "infravision"), SmithCategory::PVAL, { SmithEssence::INFRA }, 15, { TR_INFRA } },
-    { SmithEffect::TUNNEL, _("採掘", "digging"), SmithCategory::PVAL, { SmithEssence::TUNNEL }, 15, { TR_TUNNEL } },
-    { SmithEffect::SPEED, _("スピード", "speed"), SmithCategory::PVAL, { SmithEssence::SPEED }, 12, { TR_SPEED } },
-    { SmithEffect::BLOWS, _("追加攻撃", "extra attack"), SmithCategory::WEAPON_ATTR, { SmithEssence::BLOWS }, 20, { TR_BLOWS } },
+    make_basic_smith_info(SmithEffect::MAGIC_MASTERY, _("魔力支配", "magic mastery"), SmithCategory::PVAL, { SmithEssence::MAGIC_MASTERY }, 20, { TR_MAGIC_MASTERY }),
+    make_basic_smith_info(SmithEffect::STEALTH, _("隠密", "stealth"), SmithCategory::PVAL, { SmithEssence::STEALTH }, 40, { TR_STEALTH }),
+    make_basic_smith_info(SmithEffect::SEARCH, _("探索", "searching"), SmithCategory::PVAL, { SmithEssence::SEARCH }, 15, { TR_SEARCH }),
+    make_basic_smith_info(SmithEffect::INFRA, _("赤外線視力", "infravision"), SmithCategory::PVAL, { SmithEssence::INFRA }, 15, { TR_INFRA }),
+    make_basic_smith_info(SmithEffect::TUNNEL, _("採掘", "digging"), SmithCategory::PVAL, { SmithEssence::TUNNEL }, 15, { TR_TUNNEL }),
+    make_basic_smith_info(SmithEffect::SPEED, _("スピード", "speed"), SmithCategory::PVAL, { SmithEssence::SPEED }, 12, { TR_SPEED }),
+    make_basic_smith_info(SmithEffect::BLOWS, _("追加攻撃", "extra attack"), SmithCategory::WEAPON_ATTR, { SmithEssence::BLOWS }, 20, { TR_BLOWS }),
 
-    { SmithEffect::CHAOTIC, _("カオス攻撃", "chaos brand"), SmithCategory::WEAPON_ATTR, { SmithEssence::CHAOTIC }, 15, { TR_CHAOTIC } },
-    { SmithEffect::VAMPIRIC, _("吸血攻撃", "vampiric brand"), SmithCategory::WEAPON_ATTR, { SmithEssence::VAMPIRIC }, 60, { TR_VAMPIRIC } },
-    { SmithEffect::EARTHQUAKE, _("地震発動", "quake activation"), SmithCategory::ETC, { SmithEssence::EATHQUAKE }, 15, { TR_EARTHQUAKE, TR_ACTIVATE } },
-    { SmithEffect::BRAND_POIS, _("毒殺", "poison brand"), SmithCategory::WEAPON_ATTR, { SmithEssence::BRAND_POIS }, 20, { TR_BRAND_POIS } },
-    { SmithEffect::BRAND_ACID, _("溶解", "acid brand"), SmithCategory::WEAPON_ATTR, { SmithEssence::BRAND_ACID }, 20, { TR_BRAND_ACID } },
-    { SmithEffect::BRAND_ELEC, _("電撃", "electric brand"), SmithCategory::WEAPON_ATTR, { SmithEssence::BRAND_ELEC }, 20, { TR_BRAND_ELEC } },
-    { SmithEffect::BRAND_FIRE, _("焼棄", "fire brand"), SmithCategory::WEAPON_ATTR, { SmithEssence::BRAND_FIRE }, 20, { TR_BRAND_FIRE } },
-    { SmithEffect::BRAND_COLD, _("凍結", "cold brand"), SmithCategory::WEAPON_ATTR, { SmithEssence::BRAND_COLD }, 20, { TR_BRAND_COLD } },
+    make_basic_smith_info(SmithEffect::CHAOTIC, _("カオス攻撃", "chaos brand"), SmithCategory::WEAPON_ATTR, { SmithEssence::CHAOTIC }, 15, { TR_CHAOTIC }),
+    make_basic_smith_info(SmithEffect::VAMPIRIC, _("吸血攻撃", "vampiric brand"), SmithCategory::WEAPON_ATTR, { SmithEssence::VAMPIRIC }, 60, { TR_VAMPIRIC }),
+    make_basic_smith_info(SmithEffect::BRAND_POIS, _("毒殺", "poison brand"), SmithCategory::WEAPON_ATTR, { SmithEssence::BRAND_POIS }, 20, { TR_BRAND_POIS }),
+    make_basic_smith_info(SmithEffect::BRAND_ACID, _("溶解", "acid brand"), SmithCategory::WEAPON_ATTR, { SmithEssence::BRAND_ACID }, 20, { TR_BRAND_ACID }),
+    make_basic_smith_info(SmithEffect::BRAND_ELEC, _("電撃", "electric brand"), SmithCategory::WEAPON_ATTR, { SmithEssence::BRAND_ELEC }, 20, { TR_BRAND_ELEC }),
+    make_basic_smith_info(SmithEffect::BRAND_FIRE, _("焼棄", "fire brand"), SmithCategory::WEAPON_ATTR, { SmithEssence::BRAND_FIRE }, 20, { TR_BRAND_FIRE }),
+    make_basic_smith_info(SmithEffect::BRAND_COLD, _("凍結", "cold brand"), SmithCategory::WEAPON_ATTR, { SmithEssence::BRAND_COLD }, 20, { TR_BRAND_COLD }),
 
-    { SmithEffect::IM_ACID, _("酸免疫", "acid immunity"), SmithCategory::RESISTANCE, { SmithEssence::IMMUNITY }, 20, { TR_IM_ACID } },
-    { SmithEffect::IM_ELEC, _("電撃免疫", "electric immunity"), SmithCategory::RESISTANCE, { SmithEssence::IMMUNITY }, 20, { TR_IM_ELEC } },
-    { SmithEffect::IM_FIRE, _("火炎免疫", "fire immunity"), SmithCategory::RESISTANCE, { SmithEssence::IMMUNITY }, 20, { TR_IM_FIRE } },
-    { SmithEffect::IM_COLD, _("冷気免疫", "cold immunity"), SmithCategory::RESISTANCE, { SmithEssence::IMMUNITY }, 20, { TR_IM_COLD } },
-    { SmithEffect::REFLECT, _("反射", "reflection"), SmithCategory::RESISTANCE, { SmithEssence::REFLECT }, 20, { TR_REFLECT } },
+    make_basic_smith_info(SmithEffect::IM_ACID, _("酸免疫", "acid immunity"), SmithCategory::RESISTANCE, { SmithEssence::IMMUNITY }, 20, { TR_IM_ACID }),
+    make_basic_smith_info(SmithEffect::IM_ELEC, _("電撃免疫", "electric immunity"), SmithCategory::RESISTANCE, { SmithEssence::IMMUNITY }, 20, { TR_IM_ELEC }),
+    make_basic_smith_info(SmithEffect::IM_FIRE, _("火炎免疫", "fire immunity"), SmithCategory::RESISTANCE, { SmithEssence::IMMUNITY }, 20, { TR_IM_FIRE }),
+    make_basic_smith_info(SmithEffect::IM_COLD, _("冷気免疫", "cold immunity"), SmithCategory::RESISTANCE, { SmithEssence::IMMUNITY }, 20, { TR_IM_COLD }),
+    make_basic_smith_info(SmithEffect::REFLECT, _("反射", "reflection"), SmithCategory::RESISTANCE, { SmithEssence::REFLECT }, 20, { TR_REFLECT }),
 
-    { SmithEffect::RES_ACID, _("耐酸", "resistance to acid"), SmithCategory::RESISTANCE, { SmithEssence::RES_ACID }, 15, { TR_RES_ACID } },
-    { SmithEffect::RES_ELEC, _("耐電撃", "resistance to electric"), SmithCategory::RESISTANCE, { SmithEssence::RES_ELEC }, 15, { TR_RES_ELEC } },
-    { SmithEffect::RES_FIRE, _("耐火炎", "resistance to fire"), SmithCategory::RESISTANCE, { SmithEssence::RES_FIRE }, 15, { TR_RES_FIRE } },
-    { SmithEffect::RES_COLD, _("耐冷気", "resistance to cold"), SmithCategory::RESISTANCE, { SmithEssence::RES_COLD }, 15, { TR_RES_COLD } },
-    { SmithEffect::RES_POIS, _("耐毒", "resistance to poison"), SmithCategory::RESISTANCE, { SmithEssence::RES_POIS }, 25, { TR_RES_POIS } },
-    { SmithEffect::RES_FEAR, _("耐恐怖", "resistance to fear"), SmithCategory::RESISTANCE, { SmithEssence::RES_FEAR }, 20, { TR_RES_FEAR } },
-    { SmithEffect::RES_LITE, _("耐閃光", "resistance to light"), SmithCategory::RESISTANCE, { SmithEssence::RES_LITE }, 20, { TR_RES_LITE } },
-    { SmithEffect::RES_DARK, _("耐暗黒", "resistance to dark"), SmithCategory::RESISTANCE, { SmithEssence::RES_DARK }, 20, { TR_RES_DARK } },
-    { SmithEffect::RES_BLIND, _("耐盲目", "resistance to blind"), SmithCategory::RESISTANCE, { SmithEssence::RES_BLIND }, 20, { TR_RES_BLIND } },
-    { SmithEffect::RES_CONF, _("耐混乱", "resistance to confusion"), SmithCategory::RESISTANCE, { SmithEssence::RES_CONF }, 20, { TR_RES_CONF } },
-    { SmithEffect::RES_SOUND, _("耐轟音", "resistance to sound"), SmithCategory::RESISTANCE, { SmithEssence::RES_SOUND }, 20, { TR_RES_SOUND } },
-    { SmithEffect::RES_SHARDS, _("耐破片", "resistance to shard"), SmithCategory::RESISTANCE, { SmithEssence::RES_SHARDS }, 20, { TR_RES_SHARDS } },
-    { SmithEffect::RES_NETHER, _("耐地獄", "resistance to nether"), SmithCategory::RESISTANCE, { SmithEssence::RES_NETHER }, 20, { TR_RES_NETHER } },
-    { SmithEffect::RES_NEXUS, _("耐因果混乱", "resistance to nexus"), SmithCategory::RESISTANCE, { SmithEssence::RES_NEXUS }, 20, { TR_RES_NEXUS } },
-    { SmithEffect::RES_CHAOS, _("耐カオス", "resistance to chaos"), SmithCategory::RESISTANCE, { SmithEssence::RES_CHAOS }, 20, { TR_RES_CHAOS } },
-    { SmithEffect::RES_DISEN, _("耐劣化", "resistance to disenchantment"), SmithCategory::RESISTANCE, { SmithEssence::RES_DISEN }, 20, { TR_RES_DISEN } },
+    make_basic_smith_info(SmithEffect::RES_ACID, _("耐酸", "resistance to acid"), SmithCategory::RESISTANCE, { SmithEssence::RES_ACID }, 15, { TR_RES_ACID }),
+    make_basic_smith_info(SmithEffect::RES_ELEC, _("耐電撃", "resistance to electric"), SmithCategory::RESISTANCE, { SmithEssence::RES_ELEC }, 15, { TR_RES_ELEC }),
+    make_basic_smith_info(SmithEffect::RES_FIRE, _("耐火炎", "resistance to fire"), SmithCategory::RESISTANCE, { SmithEssence::RES_FIRE }, 15, { TR_RES_FIRE }),
+    make_basic_smith_info(SmithEffect::RES_COLD, _("耐冷気", "resistance to cold"), SmithCategory::RESISTANCE, { SmithEssence::RES_COLD }, 15, { TR_RES_COLD }),
+    make_basic_smith_info(SmithEffect::RES_POIS, _("耐毒", "resistance to poison"), SmithCategory::RESISTANCE, { SmithEssence::RES_POIS }, 25, { TR_RES_POIS }),
+    make_basic_smith_info(SmithEffect::RES_FEAR, _("耐恐怖", "resistance to fear"), SmithCategory::RESISTANCE, { SmithEssence::RES_FEAR }, 20, { TR_RES_FEAR }),
+    make_basic_smith_info(SmithEffect::RES_LITE, _("耐閃光", "resistance to light"), SmithCategory::RESISTANCE, { SmithEssence::RES_LITE }, 20, { TR_RES_LITE }),
+    make_basic_smith_info(SmithEffect::RES_DARK, _("耐暗黒", "resistance to dark"), SmithCategory::RESISTANCE, { SmithEssence::RES_DARK }, 20, { TR_RES_DARK }),
+    make_basic_smith_info(SmithEffect::RES_BLIND, _("耐盲目", "resistance to blind"), SmithCategory::RESISTANCE, { SmithEssence::RES_BLIND }, 20, { TR_RES_BLIND }),
+    make_basic_smith_info(SmithEffect::RES_CONF, _("耐混乱", "resistance to confusion"), SmithCategory::RESISTANCE, { SmithEssence::RES_CONF }, 20, { TR_RES_CONF }),
+    make_basic_smith_info(SmithEffect::RES_SOUND, _("耐轟音", "resistance to sound"), SmithCategory::RESISTANCE, { SmithEssence::RES_SOUND }, 20, { TR_RES_SOUND }),
+    make_basic_smith_info(SmithEffect::RES_SHARDS, _("耐破片", "resistance to shard"), SmithCategory::RESISTANCE, { SmithEssence::RES_SHARDS }, 20, { TR_RES_SHARDS }),
+    make_basic_smith_info(SmithEffect::RES_NETHER, _("耐地獄", "resistance to nether"), SmithCategory::RESISTANCE, { SmithEssence::RES_NETHER }, 20, { TR_RES_NETHER }),
+    make_basic_smith_info(SmithEffect::RES_NEXUS, _("耐因果混乱", "resistance to nexus"), SmithCategory::RESISTANCE, { SmithEssence::RES_NEXUS }, 20, { TR_RES_NEXUS }),
+    make_basic_smith_info(SmithEffect::RES_CHAOS, _("耐カオス", "resistance to chaos"), SmithCategory::RESISTANCE, { SmithEssence::RES_CHAOS }, 20, { TR_RES_CHAOS }),
+    make_basic_smith_info(SmithEffect::RES_DISEN, _("耐劣化", "resistance to disenchantment"), SmithCategory::RESISTANCE, { SmithEssence::RES_DISEN }, 20, { TR_RES_DISEN }),
 
-    { SmithEffect::HOLD_EXP, _("経験値維持", "hold experience"), SmithCategory::ABILITY, { SmithEssence::HOLD_EXP }, 20, { TR_HOLD_EXP } },
-    { SmithEffect::FREE_ACT, _("麻痺知らず", "free action"), SmithCategory::ABILITY, { SmithEssence::FREE_ACT }, 20, { TR_FREE_ACT } },
-    { SmithEffect::WARNING, _("警告", "warning"), SmithCategory::ABILITY, { SmithEssence::WARNING }, 20, { TR_WARNING } },
-    { SmithEffect::LEVITATION, _("浮遊", "levitation"), SmithCategory::ABILITY, { SmithEssence::LEVITATION }, 20, { TR_LEVITATION } },
-    { SmithEffect::SEE_INVIS, _("可視透明", "see invisible"), SmithCategory::ABILITY, { SmithEssence::SEE_INVIS }, 20, { TR_SEE_INVIS } },
-    { SmithEffect::SLOW_DIGEST, _("遅消化", "slow digestion"), SmithCategory::ABILITY, { SmithEssence::SLOW_DIGEST }, 15, { TR_SLOW_DIGEST } },
-    { SmithEffect::REGEN, _("急速回復", "regeneration"), SmithCategory::ABILITY, { SmithEssence::REGEN }, 20, { TR_REGEN } },
-    { SmithEffect::TELEPORT, _("テレポート", "teleport"), SmithCategory::ABILITY, { SmithEssence::TELEPORT }, 25, { TR_TELEPORT } },
-    { SmithEffect::NO_MAGIC, _("反魔法", "anti magic"), SmithCategory::ABILITY, { SmithEssence::NO_MAGIC }, 15, { TR_NO_MAGIC } },
-    { SmithEffect::LITE, _("永久光源", "permanent light"), SmithCategory::ABILITY, { SmithEssence::LITE }, 15, { TR_LITE_1 } },
+    make_basic_smith_info(SmithEffect::HOLD_EXP, _("経験値維持", "hold experience"), SmithCategory::ABILITY, { SmithEssence::HOLD_EXP }, 20, { TR_HOLD_EXP }),
+    make_basic_smith_info(SmithEffect::FREE_ACT, _("麻痺知らず", "free action"), SmithCategory::ABILITY, { SmithEssence::FREE_ACT }, 20, { TR_FREE_ACT }),
+    make_basic_smith_info(SmithEffect::WARNING, _("警告", "warning"), SmithCategory::ABILITY, { SmithEssence::WARNING }, 20, { TR_WARNING }),
+    make_basic_smith_info(SmithEffect::LEVITATION, _("浮遊", "levitation"), SmithCategory::ABILITY, { SmithEssence::LEVITATION }, 20, { TR_LEVITATION }),
+    make_basic_smith_info(SmithEffect::SEE_INVIS, _("可視透明", "see invisible"), SmithCategory::ABILITY, { SmithEssence::SEE_INVIS }, 20, { TR_SEE_INVIS }),
+    make_basic_smith_info(SmithEffect::SLOW_DIGEST, _("遅消化", "slow digestion"), SmithCategory::ABILITY, { SmithEssence::SLOW_DIGEST }, 15, { TR_SLOW_DIGEST }),
+    make_basic_smith_info(SmithEffect::REGEN, _("急速回復", "regeneration"), SmithCategory::ABILITY, { SmithEssence::REGEN }, 20, { TR_REGEN }),
+    make_basic_smith_info(SmithEffect::TELEPORT, _("テレポート", "teleport"), SmithCategory::ABILITY, { SmithEssence::TELEPORT }, 25, { TR_TELEPORT }),
+    make_basic_smith_info(SmithEffect::NO_MAGIC, _("反魔法", "anti magic"), SmithCategory::ABILITY, { SmithEssence::NO_MAGIC }, 15, { TR_NO_MAGIC }),
+    make_basic_smith_info(SmithEffect::LITE, _("永久光源", "permanent light"), SmithCategory::ABILITY, { SmithEssence::LITE }, 15, { TR_LITE_1 }),
 
-    { SmithEffect::SLAY_EVIL, _("邪悪倍打", "slay evil"), SmithCategory::SLAYING, { SmithEssence::SLAY_EVIL }, 100, { TR_SLAY_EVIL } },
-    { SmithEffect::SLAY_ANIMAL, _("動物倍打", "slay animal"), SmithCategory::SLAYING, { SmithEssence::SLAY_ANIMAL }, 20, { TR_SLAY_ANIMAL } },
-    { SmithEffect::SLAY_UNDEAD, _("不死倍打", "slay undead"), SmithCategory::SLAYING, { SmithEssence::SLAY_UNDEAD }, 20, { TR_SLAY_UNDEAD } },
-    { SmithEffect::SLAY_DEMON, _("悪魔倍打", "slay demon"), SmithCategory::SLAYING, { SmithEssence::SLAY_DEMON }, 20, { TR_SLAY_DEMON } },
-    { SmithEffect::SLAY_ORC, _("オーク倍打", "slay orc"), SmithCategory::SLAYING, { SmithEssence::SLAY_ORC }, 20, { TR_SLAY_ORC } },
-    { SmithEffect::SLAY_TROLL, _("トロル倍打", "slay troll"), SmithCategory::SLAYING, { SmithEssence::SLAY_TROLL }, 20, { TR_SLAY_TROLL } },
-    { SmithEffect::SLAY_GIANT, _("巨人倍打", "slay giant"), SmithCategory::SLAYING, { SmithEssence::SLAY_GIANT }, 20, { TR_SLAY_GIANT } },
-    { SmithEffect::SLAY_DRAGON, _("竜倍打", "slay dragon"), SmithCategory::SLAYING, { SmithEssence::SLAY_DRAGON }, 20, { TR_SLAY_DRAGON } },
-    { SmithEffect::SLAY_HUMAN, _("人間倍打", "slay human"), SmithCategory::SLAYING, { SmithEssence::SLAY_HUMAN }, 20, { TR_SLAY_HUMAN } },
+    make_basic_smith_info(SmithEffect::SLAY_EVIL, _("邪悪倍打", "slay evil"), SmithCategory::SLAYING, { SmithEssence::SLAY_EVIL }, 100, { TR_SLAY_EVIL }),
+    make_basic_smith_info(SmithEffect::SLAY_ANIMAL, _("動物倍打", "slay animal"), SmithCategory::SLAYING, { SmithEssence::SLAY_ANIMAL }, 20, { TR_SLAY_ANIMAL }),
+    make_basic_smith_info(SmithEffect::SLAY_UNDEAD, _("不死倍打", "slay undead"), SmithCategory::SLAYING, { SmithEssence::SLAY_UNDEAD }, 20, { TR_SLAY_UNDEAD }),
+    make_basic_smith_info(SmithEffect::SLAY_DEMON, _("悪魔倍打", "slay demon"), SmithCategory::SLAYING, { SmithEssence::SLAY_DEMON }, 20, { TR_SLAY_DEMON }),
+    make_basic_smith_info(SmithEffect::SLAY_ORC, _("オーク倍打", "slay orc"), SmithCategory::SLAYING, { SmithEssence::SLAY_ORC }, 20, { TR_SLAY_ORC }),
+    make_basic_smith_info(SmithEffect::SLAY_TROLL, _("トロル倍打", "slay troll"), SmithCategory::SLAYING, { SmithEssence::SLAY_TROLL }, 20, { TR_SLAY_TROLL }),
+    make_basic_smith_info(SmithEffect::SLAY_GIANT, _("巨人倍打", "slay giant"), SmithCategory::SLAYING, { SmithEssence::SLAY_GIANT }, 20, { TR_SLAY_GIANT }),
+    make_basic_smith_info(SmithEffect::SLAY_DRAGON, _("竜倍打", "slay dragon"), SmithCategory::SLAYING, { SmithEssence::SLAY_DRAGON }, 20, { TR_SLAY_DRAGON }),
+    make_basic_smith_info(SmithEffect::SLAY_HUMAN, _("人間倍打", "slay human"), SmithCategory::SLAYING, { SmithEssence::SLAY_HUMAN }, 20, { TR_SLAY_HUMAN }),
 
-    { SmithEffect::KILL_EVIL, _("邪悪倍倍打", "kill evil"), SmithCategory::NONE, { SmithEssence::SLAY_EVIL }, 0, { TR_KILL_EVIL } }, // 強力すぎるため無効(SmithCategory::NONE)
-    { SmithEffect::KILL_ANIMAL, _("動物倍倍打", "kill animal"), SmithCategory::SLAYING, { SmithEssence::SLAY_ANIMAL }, 60, { TR_KILL_ANIMAL } },
-    { SmithEffect::KILL_UNDEAD, _("不死倍倍打", "kill undead"), SmithCategory::SLAYING, { SmithEssence::SLAY_UNDEAD }, 60, { TR_KILL_UNDEAD } },
-    { SmithEffect::KILL_DEMON, _("悪魔倍倍打", "kill demon"), SmithCategory::SLAYING, { SmithEssence::SLAY_DEMON }, 60, { TR_KILL_DEMON } },
-    { SmithEffect::KILL_ORC, _("オーク倍倍打", "kill orc"), SmithCategory::SLAYING, { SmithEssence::SLAY_ORC }, 60, { TR_KILL_ORC } },
-    { SmithEffect::KILL_TROLL, _("トロル倍倍打", "kill troll"), SmithCategory::SLAYING, { SmithEssence::SLAY_TROLL }, 60, { TR_KILL_TROLL } },
-    { SmithEffect::KILL_GIANT, _("巨人倍倍打", "kill giant"), SmithCategory::SLAYING, { SmithEssence::SLAY_GIANT }, 60, { TR_KILL_GIANT } },
-    { SmithEffect::KILL_DRAGON, _("竜倍倍打", "kill dragon"), SmithCategory::SLAYING, { SmithEssence::SLAY_DRAGON }, 60, { TR_KILL_DRAGON } },
-    { SmithEffect::KILL_HUMAN, _("人間倍倍打", "kill human"), SmithCategory::SLAYING, { SmithEssence::SLAY_HUMAN }, 60, { TR_KILL_HUMAN } },
+    make_basic_smith_info(SmithEffect::KILL_EVIL, _("邪悪倍倍打", "kill evil"), SmithCategory::NONE, { SmithEssence::SLAY_EVIL }, 0, { TR_KILL_EVIL }), // 強力すぎるため無効(SmithCategory:NONE)
+    make_basic_smith_info(SmithEffect::KILL_ANIMAL, _("動物倍倍打", "kill animal"), SmithCategory::SLAYING, { SmithEssence::SLAY_ANIMAL }, 60, { TR_KILL_ANIMAL }),
+    make_basic_smith_info(SmithEffect::KILL_UNDEAD, _("不死倍倍打", "kill undead"), SmithCategory::SLAYING, { SmithEssence::SLAY_UNDEAD }, 60, { TR_KILL_UNDEAD }),
+    make_basic_smith_info(SmithEffect::KILL_DEMON, _("悪魔倍倍打", "kill demon"), SmithCategory::SLAYING, { SmithEssence::SLAY_DEMON }, 60, { TR_KILL_DEMON }),
+    make_basic_smith_info(SmithEffect::KILL_ORC, _("オーク倍倍打", "kill orc"), SmithCategory::SLAYING, { SmithEssence::SLAY_ORC }, 60, { TR_KILL_ORC }),
+    make_basic_smith_info(SmithEffect::KILL_TROLL, _("トロル倍倍打", "kill troll"), SmithCategory::SLAYING, { SmithEssence::SLAY_TROLL }, 60, { TR_KILL_TROLL }),
+    make_basic_smith_info(SmithEffect::KILL_GIANT, _("巨人倍倍打", "kill giant"), SmithCategory::SLAYING, { SmithEssence::SLAY_GIANT }, 60, { TR_KILL_GIANT }),
+    make_basic_smith_info(SmithEffect::KILL_DRAGON, _("竜倍倍打", "kill dragon"), SmithCategory::SLAYING, { SmithEssence::SLAY_DRAGON }, 60, { TR_KILL_DRAGON }),
+    make_basic_smith_info(SmithEffect::KILL_HUMAN, _("人間倍倍打", "kill human"), SmithCategory::SLAYING, { SmithEssence::SLAY_HUMAN }, 60, { TR_KILL_HUMAN }),
 
-    { SmithEffect::TELEPATHY, _("テレパシー", "telepathy"), SmithCategory::ESP, { SmithEssence::TELEPATHY }, 15, { TR_TELEPATHY } },
-    { SmithEffect::ESP_ANIMAL, _("動物ESP", "sense animal"), SmithCategory::ESP, { SmithEssence::SLAY_ANIMAL }, 40, { TR_ESP_ANIMAL } },
-    { SmithEffect::ESP_UNDEAD, _("不死ESP", "sense undead"), SmithCategory::ESP, { SmithEssence::SLAY_UNDEAD }, 40, { TR_ESP_UNDEAD } },
-    { SmithEffect::ESP_DEMON, _("悪魔ESP", "sense demon"), SmithCategory::ESP, { SmithEssence::SLAY_DEMON }, 40, { TR_ESP_DEMON } },
-    { SmithEffect::ESP_ORC, _("オークESP", "sense orc"), SmithCategory::ESP, { SmithEssence::SLAY_ORC }, 40, { TR_ESP_ORC } },
-    { SmithEffect::ESP_TROLL, _("トロルESP", "sense troll"), SmithCategory::ESP, { SmithEssence::SLAY_TROLL }, 40, { TR_ESP_TROLL } },
-    { SmithEffect::ESP_GIANT, _("巨人ESP", "sense giant"), SmithCategory::ESP, { SmithEssence::SLAY_GIANT }, 40, { TR_ESP_GIANT } },
-    { SmithEffect::ESP_DRAGON, _("竜ESP", "sense dragon"), SmithCategory::ESP, { SmithEssence::SLAY_DRAGON }, 40, { TR_ESP_DRAGON } },
-    { SmithEffect::ESP_HUMAN, _("人間ESP", "sense human"), SmithCategory::ESP, { SmithEssence::SLAY_HUMAN }, 40, { TR_ESP_HUMAN } },
+    make_basic_smith_info(SmithEffect::TELEPATHY, _("テレパシー", "telepathy"), SmithCategory::ESP, { SmithEssence::TELEPATHY }, 15, { TR_TELEPATHY }),
+    make_basic_smith_info(SmithEffect::ESP_ANIMAL, _("動物ESP", "sense animal"), SmithCategory::ESP, { SmithEssence::SLAY_ANIMAL }, 40, { TR_ESP_ANIMAL }),
+    make_basic_smith_info(SmithEffect::ESP_UNDEAD, _("不死ESP", "sense undead"), SmithCategory::ESP, { SmithEssence::SLAY_UNDEAD }, 40, { TR_ESP_UNDEAD }),
+    make_basic_smith_info(SmithEffect::ESP_DEMON, _("悪魔ESP", "sense demon"), SmithCategory::ESP, { SmithEssence::SLAY_DEMON }, 40, { TR_ESP_DEMON }),
+    make_basic_smith_info(SmithEffect::ESP_ORC, _("オークESP", "sense orc"), SmithCategory::ESP, { SmithEssence::SLAY_ORC }, 40, { TR_ESP_ORC }),
+    make_basic_smith_info(SmithEffect::ESP_TROLL, _("トロルESP", "sense troll"), SmithCategory::ESP, { SmithEssence::SLAY_TROLL }, 40, { TR_ESP_TROLL }),
+    make_basic_smith_info(SmithEffect::ESP_GIANT, _("巨人ESP", "sense giant"), SmithCategory::ESP, { SmithEssence::SLAY_GIANT }, 40, { TR_ESP_GIANT }),
+    make_basic_smith_info(SmithEffect::ESP_DRAGON, _("竜ESP", "sense dragon"), SmithCategory::ESP, { SmithEssence::SLAY_DRAGON }, 40, { TR_ESP_DRAGON }),
+    make_basic_smith_info(SmithEffect::ESP_HUMAN, _("人間ESP", "sense human"), SmithCategory::ESP, { SmithEssence::SLAY_HUMAN }, 40, { TR_ESP_HUMAN }),
 
-    { SmithEffect::TMP_RES_ACID, _("酸耐性発動", "resist acid activation"), SmithCategory::ETC, { SmithEssence::RES_ACID }, 50, { TR_RES_ACID, TR_ACTIVATE } },
-    { SmithEffect::TMP_RES_ELEC, _("電撃耐性発動", "resist electricity activation"), SmithCategory::ETC, { SmithEssence::RES_ELEC }, 50, { TR_RES_ELEC, TR_ACTIVATE } },
-    { SmithEffect::TMP_RES_FIRE, _("火炎耐性発動", "resist fire activation"), SmithCategory::ETC, { SmithEssence::RES_FIRE }, 50, { TR_RES_FIRE, TR_ACTIVATE } },
-    { SmithEffect::TMP_RES_COLD, _("冷気耐性発動", "resist cold activation"), SmithCategory::ETC, { SmithEssence::RES_COLD }, 50, { TR_RES_COLD, TR_ACTIVATE } },
-    { SmithEffect::SH_FIRE, _("火炎オーラ", "fiery sheath"), SmithCategory::ETC, { SmithEssence::RES_FIRE, SmithEssence::BRAND_FIRE }, 50, { TR_RES_FIRE, TR_SH_FIRE } },
-    { SmithEffect::SH_ELEC, _("電撃オーラ", "electric sheath"), SmithCategory::ETC, { SmithEssence::RES_ELEC, SmithEssence::BRAND_ELEC }, 50, { TR_RES_ELEC, TR_SH_ELEC } },
-    { SmithEffect::SH_COLD, _("冷気オーラ", "sheath of coldness"), SmithCategory::ETC, { SmithEssence::RES_COLD, SmithEssence::BRAND_COLD }, 50, { TR_RES_COLD, TR_SH_COLD } },
+    make_info<activation_smith_info>(SmithEffect::EARTHQUAKE, _("地震発動", "quake activation"), SmithCategory::ETC, { SmithEssence::EATHQUAKE }, 15, TrFlags{ TR_EARTHQUAKE }, ACT_QUAKE),
+    make_info<activation_smith_info>(SmithEffect::TMP_RES_ACID, _("酸耐性発動", "resist acid activation"), SmithCategory::ETC, { SmithEssence::RES_ACID }, 50, TrFlags{ TR_RES_ACID }, ACT_RESIST_ACID),
+    make_info<activation_smith_info>(SmithEffect::TMP_RES_ELEC, _("電撃耐性発動", "resist electricity activation"), SmithCategory::ETC, { SmithEssence::RES_ELEC }, 50, TrFlags{ TR_RES_ELEC }, ACT_RESIST_ELEC),
+    make_info<activation_smith_info>(SmithEffect::TMP_RES_FIRE, _("火炎耐性発動", "resist fire activation"), SmithCategory::ETC, { SmithEssence::RES_FIRE }, 50, TrFlags{ TR_RES_FIRE }, ACT_RESIST_FIRE),
+    make_info<activation_smith_info>(SmithEffect::TMP_RES_COLD, _("冷気耐性発動", "resist cold activation"), SmithCategory::ETC, { SmithEssence::RES_COLD }, 50, TrFlags{ TR_RES_COLD }, ACT_RESIST_COLD),
+    make_basic_smith_info(SmithEffect::SH_FIRE, _("火炎オーラ", "fiery sheath"), SmithCategory::ETC, { SmithEssence::RES_FIRE, SmithEssence::BRAND_FIRE }, 50, { TR_RES_FIRE, TR_SH_FIRE }),
+    make_basic_smith_info(SmithEffect::SH_ELEC, _("電撃オーラ", "electric sheath"), SmithCategory::ETC, { SmithEssence::RES_ELEC, SmithEssence::BRAND_ELEC }, 50, { TR_RES_ELEC, TR_SH_ELEC }),
+    make_basic_smith_info(SmithEffect::SH_COLD, _("冷気オーラ", "sheath of coldness"), SmithCategory::ETC, { SmithEssence::RES_COLD, SmithEssence::BRAND_COLD }, 50, { TR_RES_COLD, TR_SH_COLD }),
 
-    { SmithEffect::RESISTANCE, _("全耐性", "resistance"), SmithCategory::RESISTANCE, { SmithEssence::RES_ACID, SmithEssence::RES_ELEC, SmithEssence::RES_FIRE, SmithEssence::RES_COLD }, 150, { TR_RES_ACID, TR_RES_ELEC, TR_RES_FIRE, TR_RES_COLD } },
-    { SmithEffect::SLAY_GLOVE, _("殺戮の小手", "gauntlets of slaying"), SmithCategory::WEAPON_ATTR, { SmithEssence::ATTACK }, 200, {} },
+    make_basic_smith_info(SmithEffect::RESISTANCE, _("全耐性", "resistance"), SmithCategory::RESISTANCE, { SmithEssence::RES_ACID, SmithEssence::RES_ELEC, SmithEssence::RES_FIRE, SmithEssence::RES_COLD }, 150, { TR_RES_ACID, TR_RES_ELEC, TR_RES_FIRE, TR_RES_COLD }),
+    make_info<slaying_gloves_smith_info>(SmithEffect::SLAY_GLOVE, _("殺戮の小手", "gauntlets of slaying"), SmithCategory::WEAPON_ATTR, { SmithEssence::ATTACK }, 200),
 
-    { SmithEffect::ATTACK, _("攻撃", "weapon enchant"), SmithCategory::ENCHANT, { SmithEssence::ATTACK }, 30, {} },
-    { SmithEffect::AC, _("防御", "armor enchant"), SmithCategory::ENCHANT, { SmithEssence::AC }, 15, {} },
-    { SmithEffect::SUSTAIN, _("装備保持", "elements proof"), SmithCategory::ENCHANT, { SmithEssence::RES_ACID, SmithEssence::RES_ELEC, SmithEssence::RES_FIRE, SmithEssence::RES_COLD }, 10, {} },
+    make_info<enchant_weapon_smith_info>(SmithEffect::ATTACK, _("攻撃", "weapon enchant"), SmithCategory::ENCHANT, { SmithEssence::ATTACK }, 30),
+    make_info<enchant_armour_smith_info>(SmithEffect::AC, _("防御", "armor enchant"), SmithCategory::ENCHANT, { SmithEssence::AC }, 15),
+    make_info<sustain_smith_info>(SmithEffect::SUSTAIN, _("装備保持", "elements proof"), SmithCategory::ENCHANT, { SmithEssence::RES_ACID, SmithEssence::RES_ELEC, SmithEssence::RES_FIRE, SmithEssence::RES_COLD }, 10),
 };

--- a/src/object-enchant/smith-tables.cpp
+++ b/src/object-enchant/smith-tables.cpp
@@ -333,14 +333,14 @@ const std::vector<essence_drain_type> Smith::essence_drain_info_table = {
 namespace {
 
 template <typename T, typename... Args>
-std::shared_ptr<smith_info_base> make_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption, Args&&... args)
+std::shared_ptr<ISmithInfo> make_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption, Args&&... args)
 {
     return std::make_shared<T>(effect, name, category, std::move(need_essences), consumption, std::forward<Args>(args)...);
 }
 
-std::shared_ptr<smith_info_base> make_basic_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption, TrFlags add_flags)
+std::shared_ptr<ISmithInfo> make_basic_smith_info(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption, TrFlags add_flags)
 {
-    return make_info<basic_smith_info>(effect, name, category, std::move(need_essences), consumption, std::move(add_flags));
+    return make_info<BasicSmithInfo>(effect, name, category, std::move(need_essences), consumption, std::move(add_flags));
 }
 
 }
@@ -348,7 +348,7 @@ std::shared_ptr<smith_info_base> make_basic_smith_info(SmithEffect effect, concp
 /*!
  * @brief 鍛冶情報テーブル
  */
-const std::vector<std::shared_ptr<smith_info_base>> Smith::smith_info_table = {
+const std::vector<std::shared_ptr<ISmithInfo>> Smith::smith_info_table = {
     make_basic_smith_info(SmithEffect::NONE, _("なし", "None"), SmithCategory::NONE, std::vector<SmithEssence>{ SmithEssence::NONE }, 0, {}),
 
     make_basic_smith_info(SmithEffect::STR, _("腕力", "strength"), SmithCategory::PVAL, { SmithEssence::STR }, 20, { TR_STR }),
@@ -445,19 +445,19 @@ const std::vector<std::shared_ptr<smith_info_base>> Smith::smith_info_table = {
     make_basic_smith_info(SmithEffect::ESP_DRAGON, _("竜ESP", "sense dragon"), SmithCategory::ESP, { SmithEssence::SLAY_DRAGON }, 40, { TR_ESP_DRAGON }),
     make_basic_smith_info(SmithEffect::ESP_HUMAN, _("人間ESP", "sense human"), SmithCategory::ESP, { SmithEssence::SLAY_HUMAN }, 40, { TR_ESP_HUMAN }),
 
-    make_info<activation_smith_info>(SmithEffect::EARTHQUAKE, _("地震発動", "quake activation"), SmithCategory::ETC, { SmithEssence::EATHQUAKE }, 15, TrFlags{ TR_EARTHQUAKE }, ACT_QUAKE),
-    make_info<activation_smith_info>(SmithEffect::TMP_RES_ACID, _("酸耐性発動", "resist acid activation"), SmithCategory::ETC, { SmithEssence::RES_ACID }, 50, TrFlags{ TR_RES_ACID }, ACT_RESIST_ACID),
-    make_info<activation_smith_info>(SmithEffect::TMP_RES_ELEC, _("電撃耐性発動", "resist electricity activation"), SmithCategory::ETC, { SmithEssence::RES_ELEC }, 50, TrFlags{ TR_RES_ELEC }, ACT_RESIST_ELEC),
-    make_info<activation_smith_info>(SmithEffect::TMP_RES_FIRE, _("火炎耐性発動", "resist fire activation"), SmithCategory::ETC, { SmithEssence::RES_FIRE }, 50, TrFlags{ TR_RES_FIRE }, ACT_RESIST_FIRE),
-    make_info<activation_smith_info>(SmithEffect::TMP_RES_COLD, _("冷気耐性発動", "resist cold activation"), SmithCategory::ETC, { SmithEssence::RES_COLD }, 50, TrFlags{ TR_RES_COLD }, ACT_RESIST_COLD),
+    make_info<ActivationSmithInfo>(SmithEffect::EARTHQUAKE, _("地震発動", "quake activation"), SmithCategory::ETC, { SmithEssence::EATHQUAKE }, 15, TrFlags{ TR_EARTHQUAKE }, ACT_QUAKE),
+    make_info<ActivationSmithInfo>(SmithEffect::TMP_RES_ACID, _("酸耐性発動", "resist acid activation"), SmithCategory::ETC, { SmithEssence::RES_ACID }, 50, TrFlags{ TR_RES_ACID }, ACT_RESIST_ACID),
+    make_info<ActivationSmithInfo>(SmithEffect::TMP_RES_ELEC, _("電撃耐性発動", "resist electricity activation"), SmithCategory::ETC, { SmithEssence::RES_ELEC }, 50, TrFlags{ TR_RES_ELEC }, ACT_RESIST_ELEC),
+    make_info<ActivationSmithInfo>(SmithEffect::TMP_RES_FIRE, _("火炎耐性発動", "resist fire activation"), SmithCategory::ETC, { SmithEssence::RES_FIRE }, 50, TrFlags{ TR_RES_FIRE }, ACT_RESIST_FIRE),
+    make_info<ActivationSmithInfo>(SmithEffect::TMP_RES_COLD, _("冷気耐性発動", "resist cold activation"), SmithCategory::ETC, { SmithEssence::RES_COLD }, 50, TrFlags{ TR_RES_COLD }, ACT_RESIST_COLD),
     make_basic_smith_info(SmithEffect::SH_FIRE, _("火炎オーラ", "fiery sheath"), SmithCategory::ETC, { SmithEssence::RES_FIRE, SmithEssence::BRAND_FIRE }, 50, { TR_RES_FIRE, TR_SH_FIRE }),
     make_basic_smith_info(SmithEffect::SH_ELEC, _("電撃オーラ", "electric sheath"), SmithCategory::ETC, { SmithEssence::RES_ELEC, SmithEssence::BRAND_ELEC }, 50, { TR_RES_ELEC, TR_SH_ELEC }),
     make_basic_smith_info(SmithEffect::SH_COLD, _("冷気オーラ", "sheath of coldness"), SmithCategory::ETC, { SmithEssence::RES_COLD, SmithEssence::BRAND_COLD }, 50, { TR_RES_COLD, TR_SH_COLD }),
 
     make_basic_smith_info(SmithEffect::RESISTANCE, _("全耐性", "resistance"), SmithCategory::RESISTANCE, { SmithEssence::RES_ACID, SmithEssence::RES_ELEC, SmithEssence::RES_FIRE, SmithEssence::RES_COLD }, 150, { TR_RES_ACID, TR_RES_ELEC, TR_RES_FIRE, TR_RES_COLD }),
-    make_info<slaying_gloves_smith_info>(SmithEffect::SLAY_GLOVE, _("殺戮の小手", "gauntlets of slaying"), SmithCategory::WEAPON_ATTR, { SmithEssence::ATTACK }, 200),
+    make_info<SlayingGlovesSmithInfo>(SmithEffect::SLAY_GLOVE, _("殺戮の小手", "gauntlets of slaying"), SmithCategory::WEAPON_ATTR, { SmithEssence::ATTACK }, 200),
 
-    make_info<enchant_weapon_smith_info>(SmithEffect::ATTACK, _("攻撃", "weapon enchant"), SmithCategory::ENCHANT, { SmithEssence::ATTACK }, 30),
-    make_info<enchant_armour_smith_info>(SmithEffect::AC, _("防御", "armor enchant"), SmithCategory::ENCHANT, { SmithEssence::AC }, 15),
-    make_info<sustain_smith_info>(SmithEffect::SUSTAIN, _("装備保持", "elements proof"), SmithCategory::ENCHANT, { SmithEssence::RES_ACID, SmithEssence::RES_ELEC, SmithEssence::RES_FIRE, SmithEssence::RES_COLD }, 10),
+    make_info<EnchantWeaponSmithInfo>(SmithEffect::ATTACK, _("攻撃", "weapon enchant"), SmithCategory::ENCHANT, { SmithEssence::ATTACK }, 30),
+    make_info<EnchantArmourSmithInfo>(SmithEffect::AC, _("防御", "armor enchant"), SmithCategory::ENCHANT, { SmithEssence::AC }, 15),
+    make_info<SustainSmithInfo>(SmithEffect::SUSTAIN, _("装備保持", "elements proof"), SmithCategory::ENCHANT, { SmithEssence::RES_ACID, SmithEssence::RES_ELEC, SmithEssence::RES_FIRE, SmithEssence::RES_COLD }, 10),
 };

--- a/src/object-enchant/smith-tables.h
+++ b/src/object-enchant/smith-tables.h
@@ -2,13 +2,10 @@
 
 #include "system/angband.h"
 
-#include "object-enchant/tr-flags.h"
-
 #include <vector>
 
-enum class SmithEffect;
-enum class SmithCategory;
 enum class SmithEssence;
+enum tr_type : int32_t;
 
 /*!
  * @brief エッセンス抽出情報構造体
@@ -17,16 +14,4 @@ struct essence_drain_type {
     tr_type tr_flag; //!< 抽出する対象アイテムの持つ特性フラグ
     std::vector<SmithEssence> essences; //!< 抽出されるエッセンスのリスト
     int amount; //! エッセンス抽出量。ただしマイナスのものは抽出時のペナルティ源として扱う
-};
-
-/*!
- * @brief 鍛冶情報の構造体
- */
-struct smith_info_type {
-    SmithEffect effect; //!< 鍛冶で与える効果の種類
-    concptr name; //!< 鍛冶で与える能力の名称
-    SmithCategory category; //!< 鍛冶で与える能力が所属するグループ
-    std::vector<SmithEssence> need_essences; //!< 能力を与えるのに必要なエッセンスのリスト
-    int consumption; //!< 能力を与えるのに必要な消費量(need_essencesに含まれるエッセンスそれぞれについてこの量を消費)
-    TrFlags add_flags; //!< 鍛冶で能力を与えることにより付与されるアイテム特性フラグ
 };


### PR DESCRIPTION
鍛冶情報を、単純な一種の構造体から smith_info_base を基底クラスと
した派生クラスを作成し、鍛冶効果の内容をカスタマイズしやすくする。
ひとまず既存の鍛冶効果の実現のため下記のクラスを作成した。

- basic_smith_info: 特性フラグを付与(最も基礎的な効果)
- activation_smith_info: 発動効果を付与
- slaying_glove_smith_info: 殺戮の小手の鍛冶専用
- enchant_weapon_smith_info: 武器の命中/ダメージ修正の強化
- enchant_armour_smith_info: 防具のAC修正の強化
- sustain_smith_info: 装備保持効果