### PR TITLE
鍛冶コマンドの複数ページ対応/いくつかの鍛冶効果を追加

### DIFF
--- a/src/object-enchant/object-smith.cpp
+++ b/src/object-enchant/object-smith.cpp
@@ -182,25 +182,15 @@ int Smith::get_essence_consumption(SmithEffect effect, const object_type *o_ptr)
  */
 std::unique_ptr<ItemTester> Smith::get_item_tester(SmithEffect effect)
 {
-    auto category = SmithCategory::NONE;
-    if (auto info = find_smith_info(effect); info.has_value()) {
-        category = info.value()->category;
+    auto info = find_smith_info(effect);
+    if (!info.has_value()) {
+        return std::make_unique<TvalItemTester>(TV_NONE);
     }
 
-    if (effect == SmithEffect::SLAY_GLOVE) {
-        return std::make_unique<TvalItemTester>(TV_GLOVES);
-    }
-    if (category == SmithCategory::WEAPON_ATTR || category == SmithCategory::SLAYING) {
-        return std::make_unique<FuncItemTester>(&object_type::is_melee_ammo);
-    }
-    if (effect == SmithEffect::ATTACK) {
-        return std::make_unique<FuncItemTester>(&object_type::allow_enchant_weapon);
-    }
-    if (effect == SmithEffect::AC) {
-        return std::make_unique<FuncItemTester>(&object_type::is_armour);
-    }
-
-    return std::make_unique<FuncItemTester>(&object_type::is_weapon_armour_ammo);
+    auto tester_func = [i = info.value()](const object_type *o_ptr) {
+        return i->can_give_smith_effect(o_ptr);
+    };
+    return std::make_unique<FuncItemTester>(tester_func);
 }
 
 /*!

--- a/src/object-enchant/smith-info.cpp
+++ b/src/object-enchant/smith-info.cpp
@@ -101,8 +101,12 @@ bool EnchantWeaponSmithInfo::add_essence(player_type *player_ptr, object_type *o
         return false;
     }
 
-    o_ptr->to_h = static_cast<HIT_PROB>(std::min(o_ptr->to_h + 1, max_val));
-    o_ptr->to_d = static_cast<HIT_POINT>(std::min(o_ptr->to_d + 1, max_val));
+    if (o_ptr->to_h < max_val) {
+        o_ptr->to_h++;
+    }
+    if (o_ptr->to_d < max_val) {
+        o_ptr->to_d++;
+    }
 
     return true;
 }

--- a/src/object-enchant/smith-info.cpp
+++ b/src/object-enchant/smith-info.cpp
@@ -1,4 +1,6 @@
 ﻿#include "object-enchant/smith-info.h"
+#include "object-enchant/smith-types.h"
+#include "object-enchant/tr-types.h"
 #include "object/object-flags.h"
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
@@ -48,6 +50,29 @@ TrFlags BasicSmithInfo::tr_flags() const
     return this->add_flags;
 }
 
+bool BasicSmithInfo::can_give_smith_effect(const object_type *o_ptr) const
+{
+    /*!
+     * @note 固定orランダムアーティファクトもしくはすでに鍛冶済みでないかを最初にチェックし、
+     * 残る具体的な絞り込みは BasicSmithInfo::can_give_smith_effect_impl およびその派生クラスで
+     * オーバーライドした関数にて行う
+     */
+    if (o_ptr->is_artifact() || o_ptr->is_smith()) {
+        return false;
+    }
+
+    return this->can_give_smith_effect_impl(o_ptr);
+}
+
+bool BasicSmithInfo::can_give_smith_effect_impl(const object_type *o_ptr) const
+{
+    if (this->category == SmithCategory::WEAPON_ATTR || this->category == SmithCategory::SLAYING) {
+        return o_ptr->is_melee_ammo();
+    }
+
+    return o_ptr->is_weapon_armour_ammo();
+}
+
 ActivationSmithInfo::ActivationSmithInfo(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption, TrFlags add_flags, random_art_activation_type act_idx)
     : BasicSmithInfo(effect, name, category, std::move(need_essences), consumption, std::move(add_flags))
     , act_idx(act_idx)
@@ -82,6 +107,11 @@ bool EnchantWeaponSmithInfo::add_essence(player_type *player_ptr, object_type *o
     return true;
 }
 
+bool EnchantWeaponSmithInfo::can_give_smith_effect(const object_type *o_ptr) const
+{
+    return o_ptr->allow_enchant_melee_weapon();
+}
+
 EnchantArmourSmithInfo::EnchantArmourSmithInfo(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption)
     : ISmithInfo(effect, name, category, std::move(need_essences), consumption)
 {
@@ -99,6 +129,11 @@ bool EnchantArmourSmithInfo::add_essence(player_type *player_ptr, object_type *o
     return true;
 }
 
+bool EnchantArmourSmithInfo::can_give_smith_effect(const object_type *o_ptr) const
+{
+    return o_ptr->is_armour();
+}
+
 SustainSmithInfo::SustainSmithInfo(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption)
     : ISmithInfo(effect, name, category, std::move(need_essences), consumption)
 {
@@ -112,6 +147,11 @@ bool SustainSmithInfo::add_essence(player_type *, object_type *o_ptr, int) const
     o_ptr->art_flags.set(TR_IGNORE_COLD);
 
     return true;
+}
+
+bool SustainSmithInfo::can_give_smith_effect(const object_type *o_ptr) const
+{
+    return o_ptr->is_weapon_armour_ammo();
 }
 
 SlayingGlovesSmithInfo::SlayingGlovesSmithInfo(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption)
@@ -143,4 +183,9 @@ void SlayingGlovesSmithInfo::erase_essence(object_type *o_ptr) const
         o_ptr->to_h = 0;
     if (o_ptr->to_d < 0)
         o_ptr->to_d = 0;
+}
+
+bool SlayingGlovesSmithInfo::can_give_smith_effect_impl(const object_type *o_ptr) const
+{
+    return o_ptr->tval == TV_GLOVES;
 }

--- a/src/object-enchant/smith-info.h
+++ b/src/object-enchant/smith-info.h
@@ -55,6 +55,14 @@ public:
      */
     virtual std::optional<random_art_activation_type> activation_index() const;
 
+    /*!
+     * @brief 鍛冶を行えるアイテムかどうかを調べる
+     *
+     * @param o_ptr 鍛冶を行うアイテム構造体へのポインタ
+     * @return 鍛冶を行えるなら true、そうでなければ false
+     */
+    virtual bool can_give_smith_effect(const object_type *o_ptr) const = 0;
+
     SmithEffect effect; //!< 鍛冶で与える効果の種類
     concptr name; //!< 鍛冶で与える能力の名称
     SmithCategory category; //!< 鍛冶で与える能力が所属するグループ
@@ -75,8 +83,10 @@ public:
     virtual bool add_essence(player_type *player_ptr, object_type *o_ptr, int number) const override;
     virtual void erase_essence(object_type *o_ptr) const override;
     virtual TrFlags tr_flags() const override;
+    virtual bool can_give_smith_effect(const object_type *o_ptr) const final override;
 
 private:
+    virtual bool can_give_smith_effect_impl(const object_type *o_ptr) const;
     TrFlags add_flags; //!< 鍛冶で能力を与えることにより付与されるアイテム特性フラグ
 };
 
@@ -103,6 +113,7 @@ public:
     EnchantWeaponSmithInfo(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption);
     virtual bool add_essence(player_type *player_ptr, object_type *o_ptr, int number) const override;
     virtual void erase_essence(object_type *) const override {}
+    virtual bool can_give_smith_effect(const object_type *o_ptr) const override;
 };
 
 /*!
@@ -114,6 +125,7 @@ public:
     EnchantArmourSmithInfo(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption);
     virtual bool add_essence(player_type *player_ptr, object_type *o_ptr, int number) const override;
     virtual void erase_essence(object_type *) const override {}
+    virtual bool can_give_smith_effect(const object_type *o_ptr) const override;
 };
 
 /*!
@@ -125,6 +137,7 @@ public:
     SustainSmithInfo(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption);
     virtual bool add_essence(player_type *player_ptr, object_type *o_ptr, int number) const override;
     virtual void erase_essence(object_type *) const override {}
+    virtual bool can_give_smith_effect(const object_type *o_ptr) const override;
 };
 
 /*!
@@ -136,4 +149,7 @@ public:
     SlayingGlovesSmithInfo(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption);
     virtual bool add_essence(player_type *player_ptr, object_type *o_ptr, int number) const override;
     virtual void erase_essence(object_type *) const override;
+
+private:
+    virtual bool can_give_smith_effect_impl(const object_type *o_ptr) const override;
 };

--- a/src/object-enchant/smith-types.h
+++ b/src/object-enchant/smith-types.h
@@ -60,6 +60,9 @@ enum class SmithEffect {
     RES_NEXUS = 83, //!< 耐因果混乱
     RES_CHAOS = 84, //!< 耐カオス
     RES_DISEN = 85, //!< 耐劣化
+    RES_WATER = 86, //!< 耐水
+    RES_TIME = 87, //!< 耐時間逆転
+    RES_CURSE = 88, //!< 耐呪力
 
     HOLD_EXP = 100, //!< 経験値維持
     FREE_ACT = 101, //!< 麻痺知らず
@@ -81,7 +84,7 @@ enum class SmithEffect {
     SLAY_GIANT = 126, //!< 巨人倍打
     SLAY_DRAGON = 127, //!< 竜倍打
     SLAY_HUMAN = 128, //!< 人間倍打
-    /* @todo GOOD */
+    SLAY_GOOD = 129, //!< 善良倍打
 
     KILL_EVIL = 140, //!< 邪悪倍倍打
     KILL_ANIMAL = 141, //!< 動物倍倍打
@@ -92,6 +95,7 @@ enum class SmithEffect {
     KILL_GIANT = 146, //!< 巨人倍倍打
     KILL_DRAGON = 147, //!< 竜倍倍打
     KILL_HUMAN = 148, //!< 人間倍倍打
+    KILL_GOOD = 149, //!< 善良倍倍打
 
     TELEPATHY = 160, //!< テレパシー
     ESP_ANIMAL = 161, //!< 動物ESP
@@ -102,6 +106,7 @@ enum class SmithEffect {
     ESP_GIANT = 166, //!< 巨人ESP
     ESP_DRAGON = 167, //!< 竜ESP
     ESP_HUMAN = 168, //!< 人間ESP
+    ESP_GOOD = 169, //!< 善良ESP
 
     TMP_RES_ACID = 200, //!< 酸耐性発動
     TMP_RES_ELEC = 201, //!< 電撃耐性発動
@@ -202,6 +207,11 @@ enum class SmithEssence {
     SLAY_GIANT = 58, //!< 巨人倍打
     SLAY_DRAGON = 59, //!< 竜倍打
     SLAY_HUMAN = 60, //!< 人間倍打
+    SLAY_GOOD = 61, //!< 善良倍打
+
+    RES_WATER = 62, //!< 耐水
+    RES_TIME = 63, //!< 耐時間逆転
+    RES_CURSE = 64, //!< 耐呪力
 
     ATTACK = 100, //!< 攻撃
     AC = 101, //!< 防御


### PR DESCRIPTION
鍛冶効果を追加するにあたり、エッセンス一覧や付与画面が1画面に収まりきらなくなるので複数ページに対応させました。
また、複数ページ対応の動作を見るに当たり実際に増やして確認する必要があるので、同じPRにてかねてから予定していた以下の鍛冶エッセンスの追加を行います。

- 耐水（水耐性）
- 耐時間逆転（時間逆転耐性）
- 耐呪力（呪力耐性）
- 善良倍打（善良スレイ/\*善良スレイ\*/善良ESP）
