### PR TITLE
[Feature] 鍛冶師のエッセンスを全て最大所持量にするデバッグコマンド

### DIFF
--- a/src/object-enchant/object-smith.cpp
+++ b/src/object-enchant/object-smith.cpp
@@ -418,7 +418,7 @@ Smith::DrainEssenceResult Smith::drain_essence(object_type *o_ptr)
         }
 
         auto i = enum2i(essence);
-        this->player_ptr->magic_num1[i] = std::min(20000, this->player_ptr->magic_num1[i] + drain_value);
+        this->player_ptr->magic_num1[i] = std::min(Smith::ESSENCE_AMOUNT_MAX, this->player_ptr->magic_num1[i] + drain_value);
         result.emplace_back(essence, drain_value);
     }
 

--- a/src/object-enchant/object-smith.h
+++ b/src/object-enchant/object-smith.h
@@ -47,6 +47,8 @@ public:
     void erase_essence(object_type *o_ptr) const;
     int get_addable_count(SmithEffect smith_effect, int item_number) const;
 
+    static constexpr int ESSENCE_AMOUNT_MAX = 20000;
+
 private:
     static std::optional<const ISmithInfo *> find_smith_info(SmithEffect effect);
 

--- a/src/wizard/cmd-wizard.cpp
+++ b/src/wizard/cmd-wizard.cpp
@@ -106,7 +106,7 @@ void display_debug_menu(int page, int max_page, int page_size, int max_line)
         ss << debug_menu_table[pos][0] << ") " << debug_menu_table[pos][1];
         put_str(ss.str().c_str(), r++, c);
     }
-    if (max_page > 0)
+    if (max_page > 1)
         put_str("-- more --", r++, c);
 }
 

--- a/src/wizard/cmd-wizard.cpp
+++ b/src/wizard/cmd-wizard.cpp
@@ -51,7 +51,7 @@ std::vector<std::vector<std::string>> debug_menu_table = {
     { "d", _("全感知", "Detection all") },
     { "D", _("次元の扉", "Dimension door") },
     { "e", _("能力値変更", "Modify player status") },
-    { "E", _("青魔法を全取得", "Make all blue magic learned") },
+    { "E", _("青魔法を全取得/エッセンスを全取得", "Learn all blue magics / Obtain all essences") },
     { "f", _("*鑑定*", "*Idenfity*") },
     { "F", _("地形ID変更", "Modify feature type under player") },
     { "G", _("ゲーム設定コマンドメニュー", "Modify game configurations") },
@@ -150,9 +150,16 @@ bool exe_cmd_debug(player_type *player_ptr, char cmd)
         wiz_change_status(player_ptr);
         break;
     case 'E':
-        if (player_ptr->pclass == CLASS_BLUE_MAGE)
+        switch (player_ptr->pclass) {
+        case CLASS_BLUE_MAGE:
             wiz_learn_blue_magic_all(player_ptr);
-
+            break;
+        case CLASS_SMITH:
+            wiz_fillup_all_smith_essences(player_ptr);
+            break;
+        default:
+            break;
+        }
         break;
     case 'f':
         identify_fully(player_ptr, false);

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -20,6 +20,7 @@
 #include "monster-floor/place-monster-types.h"
 #include "monster-race/race-ability-flags.h"
 #include "mutation/mutation-processor.h"
+#include "object-enchant/object-smith.h"
 #include "spell-kind/spells-launcher.h"
 #include "spell-kind/spells-teleport.h"
 #include "spell-kind/spells-random.h"
@@ -146,6 +147,16 @@ void wiz_learn_blue_magic_all(player_type *player_ptr)
         for (auto spell : spells) {
             player_ptr->magic_num2[enum2i(spell)] = 1;
         }
+    }
+}
+
+/*!
+ * @brief 鍛冶師の全てのエッセンスを最大所持量にする
+ */
+void wiz_fillup_all_smith_essences(player_type *player_ptr)
+{
+    for (auto essence : Smith::get_essence_list()) {
+        player_ptr->magic_num1[enum2i(essence)] = Smith::ESSENCE_AMOUNT_MAX;
     }
 }
 

--- a/src/wizard/wizard-spells.h
+++ b/src/wizard/wizard-spells.h
@@ -43,6 +43,7 @@ void wiz_dimension_door(player_type *player_ptr);
 void wiz_summon_horde(player_type *player_ptr);
 void wiz_teleport_back(player_type *player_ptr);
 void wiz_learn_blue_magic_all(player_type *player_ptr);
+void wiz_fillup_all_smith_essences(player_type *player_ptr);
 void wiz_summon_random_enemy(player_type *player_ptr, int num);
 void wiz_summon_specific_enemy(player_type *player_ptr, MONRACE_IDX r_idx);
 void wiz_summon_pet(player_type *player_ptr, MONRACE_IDX r_idx);


### PR DESCRIPTION
^A E で鍛冶師のエッセンスを全て最大所持量にするデバッグコマンドを
追加する。
職業鍛冶師でデバッグコマンドを実行すると、所持エッセンスがすべて
最大所持量になる。
（これまでの ^A E は青魔道士の時のみ青魔法をすべてラーニング済みに
するコマンド）

また、あわせて最大所持量を定数化しておく。