### PR TITLE
[Fix] +2以上の追加攻撃の鍛冶ができてしまう

### DIFF
--- a/src/mind/mind-weaponsmith.cpp
+++ b/src/mind/mind-weaponsmith.cpp
@@ -471,8 +471,8 @@ static void add_essence(player_type *player_ptr, SmithCategory mode)
         if (o_ptr->pval < 0) {
             msg_print(_("このアイテムの能力修正を強化することはできない。", "You cannot increase magic number of this item."));
             return;
-        } else if (effect_flags.has(TR_BLOWS) && o_ptr->pval > 1) {
-            if (!get_check(_("修正値は1になります。よろしいですか？", "The magic number of this weapon will become 1. Are you sure? "))) {
+        } else if (effect_flags.has(TR_BLOWS)) {
+            if ((o_ptr->pval > 1) && !get_check(_("修正値は1になります。よろしいですか？", "The magic number of this weapon will become 1. Are you sure? "))) {
                 return;
             }
             o_ptr->pval = 1;


### PR DESCRIPTION
リファクタリング時にpvalの判定の位置を誤ったため、追加攻撃の
エッセンスを付与する時に個数を選べるようになってしまっていた。
そもそも数値の制限が必要かどうかをインターフェース処理側で
行っている設計がおかしいがそれは今後の課題とし、ひとまず
追加攻撃を付与する時はpvalが1に制限されるようにする。