### PR TITLE
[Fix] 矢弾に効果の無いエッセンスが付与できてしまう

### DIFF
--- a/src/object-enchant/smith-info.cpp
+++ b/src/object-enchant/smith-info.cpp
@@ -76,6 +76,9 @@ bool BasicSmithInfo::can_give_smith_effect_impl(const object_type *o_ptr) const
     if (this->effect == SmithEffect::EASY_2WEAPON) {
         return (o_ptr->tval == TV_GLOVES);
     }
+    if (this->category == SmithCategory::WEAPON_ATTR && o_ptr->is_ammo()) {
+        return this->add_flags.has_any_of({ TR_BRAND_ACID, TR_BRAND_ELEC, TR_BRAND_FIRE, TR_BRAND_COLD, TR_BRAND_POIS });
+    }
     if (this->category == SmithCategory::WEAPON_ATTR || this->category == SmithCategory::SLAYING) {
         return o_ptr->is_melee_ammo();
     }


### PR DESCRIPTION
以前からのおかしな仕様として、矢弾の類に無効な武器属性（追加攻撃や
カオス攻撃など）を付けることができてしまう。
付けても特に効果は無いので通常プレイわざわざ付ける事はないが、不親切
なので武器属性付与では効果のあるもの（四属性と毒攻撃）以外では矢弾が
付与の候補に選ばれないようにする。