### PR TITLE
[Refactor] 関数テンプレート i2enum を導入

### DIFF
--- a/src/birth/birth-select-class.cpp
+++ b/src/birth/birth-select-class.cpp
@@ -14,9 +14,9 @@ static const char p2 = ')';
 static TERM_COLOR birth_class_color(int cs)
 {
     if (cs < MAX_CLASS) {
-        if (is_retired_class(static_cast<player_class_type>(cs)))
+        if (is_retired_class(i2enum<player_class_type>(cs)))
             return TERM_L_DARK;
-        if (is_winner_class(static_cast<player_class_type>(cs)))
+        if (is_winner_class(i2enum<player_class_type>(cs)))
             return TERM_SLATE;
     }
     return TERM_WHITE;
@@ -190,7 +190,7 @@ bool get_player_class(player_type *player_ptr)
     if (!select_class(player_ptr, cur, sym, &k))
         return false;
 
-    player_ptr->pclass = static_cast<player_class_type>(k);
+    player_ptr->pclass = i2enum<player_class_type>(k);
     cp_ptr = &class_info[player_ptr->pclass];
     mp_ptr = &m_info[player_ptr->pclass];
     c_put_str(TERM_L_BLUE, cp_ptr->title, 5, 15);

--- a/src/birth/birth-select-race.cpp
+++ b/src/birth/birth-select-race.cpp
@@ -166,7 +166,7 @@ bool get_player_race(player_type *player_ptr)
     if (!select_race(player_ptr, sym, &k))
         return false;
 
-    player_ptr->prace = static_cast<player_race_type>(k);
+    player_ptr->prace = i2enum<player_race_type>(k);
     rp_ptr = &race_info[k];
     c_put_str(TERM_L_BLUE, rp_ptr->title, 4, 15);
     return true;

--- a/src/birth/birth-wizard.cpp
+++ b/src/birth/birth-wizard.cpp
@@ -150,7 +150,7 @@ static bool get_player_sex(player_type *player_ptr, char *buf)
         display_help_on_sex_select(player_ptr, c);
     }
 
-    player_ptr->psex = static_cast<player_sex>(k);
+    player_ptr->psex = i2enum<player_sex>(k);
     sp_ptr = &sex_info[player_ptr->psex];
     c_put_str(TERM_L_BLUE, sp_ptr->title, 3, 15);
     return true;

--- a/src/birth/inventory-initializer.cpp
+++ b/src/birth/inventory-initializer.cpp
@@ -186,7 +186,7 @@ void player_outfit(player_type *player_ptr)
         add_outfit(player_ptr, q_ptr);
     } else if (player_ptr->pclass == CLASS_SORCERER) {
         for (auto book_tval = enum2i(TV_LIFE_BOOK); book_tval <= enum2i(TV_LIFE_BOOK) + enum2i(MAX_MAGIC) - 1; book_tval++) {
-            q_ptr->prep(lookup_kind(static_cast<tval_type>(book_tval), 0));
+            q_ptr->prep(lookup_kind(i2enum<tval_type>(book_tval), 0));
             q_ptr->number = 1;
             add_outfit(player_ptr, q_ptr);
         }
@@ -259,7 +259,7 @@ void player_outfit(player_type *player_ptr)
         }
 
         q_ptr = &forge;
-        q_ptr->prep(lookup_kind(static_cast<tval_type>(tv), sv));
+        q_ptr->prep(lookup_kind(i2enum<tval_type>(tv), sv));
         if ((tv == TV_SWORD || tv == TV_HAFTED)
             && (player_ptr->pclass == CLASS_ROGUE && player_ptr->realm1 == REALM_DEATH)) /* Only assassins get a poisoned weapon */
             q_ptr->name2 = EGO_BRAND_POIS;

--- a/src/blue-magic/learnt-power-getter.cpp
+++ b/src/blue-magic/learnt-power-getter.cpp
@@ -178,7 +178,7 @@ static bool check_blue_magic_kind(learnt_magic_type *lm_ptr)
 
 static bool sweep_learnt_spells(player_type *player_ptr, learnt_magic_type *lm_ptr)
 {
-    set_rf_masks(lm_ptr->ability_flags, static_cast<blue_magic_type>(lm_ptr->mode));
+    set_rf_masks(lm_ptr->ability_flags, i2enum<blue_magic_type>(lm_ptr->mode));
 
     std::vector<RF_ABILITY> spells;
     EnumClassFlagGroup<RF_ABILITY>::get_flags(lm_ptr->ability_flags, std::back_inserter(spells));
@@ -310,7 +310,7 @@ static void describe_blue_magic_name(player_type *player_ptr, learnt_magic_type 
 
         lm_ptr->spell = monster_powers[lm_ptr->blue_magics[lm_ptr->blue_magic_num]];
         calculate_blue_magic_success_probability(player_ptr, lm_ptr);
-        learnt_info(player_ptr, lm_ptr->comment, static_cast<RF_ABILITY>(lm_ptr->blue_magics[lm_ptr->blue_magic_num]));
+        learnt_info(player_ptr, lm_ptr->comment, i2enum<RF_ABILITY>(lm_ptr->blue_magics[lm_ptr->blue_magic_num]));
         close_blue_magic_name(lm_ptr);
         strcat(lm_ptr->psi_desc, format(" %-26s %3d %3d%%%s", lm_ptr->spell.name, lm_ptr->need_mana, lm_ptr->chance, lm_ptr->comment));
         prt(lm_ptr->psi_desc, lm_ptr->y + lm_ptr->blue_magic_num + 1, lm_ptr->x);

--- a/src/cmd-action/cmd-mind.cpp
+++ b/src/cmd-action/cmd-mind.cpp
@@ -275,22 +275,22 @@ static bool switch_mind_class(player_type *player_ptr, cm_type *cm_ptr)
 {
     switch (cm_ptr->use_mind) {
     case mind_kind_type::MINDCRAFTER:
-        cm_ptr->cast = cast_mindcrafter_spell(player_ptr, static_cast<mind_mindcrafter_type>(cm_ptr->n));
+        cm_ptr->cast = cast_mindcrafter_spell(player_ptr, i2enum<mind_mindcrafter_type>(cm_ptr->n));
         return true;
     case mind_kind_type::KI:
-        cm_ptr->cast = cast_force_spell(player_ptr, static_cast<mind_force_trainer_type>(cm_ptr->n));
+        cm_ptr->cast = cast_force_spell(player_ptr, i2enum<mind_force_trainer_type>(cm_ptr->n));
         return true;
     case mind_kind_type::BERSERKER:
-        cm_ptr->cast = cast_berserk_spell(player_ptr, static_cast<mind_berserker_type>(cm_ptr->n));
+        cm_ptr->cast = cast_berserk_spell(player_ptr, i2enum<mind_berserker_type>(cm_ptr->n));
         return true;
     case mind_kind_type::MIRROR_MASTER:
         if (player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x].is_mirror())
             cm_ptr->on_mirror = true;
 
-        cm_ptr->cast = cast_mirror_spell(player_ptr, static_cast<mind_mirror_master_type>(cm_ptr->n));
+        cm_ptr->cast = cast_mirror_spell(player_ptr, i2enum<mind_mirror_master_type>(cm_ptr->n));
         return true;
     case mind_kind_type::NINJUTSU:
-        cm_ptr->cast = cast_ninja_spell(player_ptr, static_cast<mind_ninja_type>(cm_ptr->n));
+        cm_ptr->cast = cast_ninja_spell(player_ptr, i2enum<mind_ninja_type>(cm_ptr->n));
         return true;
     default:
         msg_format(_("謎の能力:%d, %d", "Mystery power:%d, %d"), cm_ptr->use_mind, cm_ptr->n);

--- a/src/cmd-action/cmd-racial.cpp
+++ b/src/cmd-action/cmd-racial.cpp
@@ -380,7 +380,7 @@ static void racial_power_cast_power(player_type *player_ptr, rc_type *rc_ptr)
         if (rpi_ptr->number < 0)
             rc_ptr->cast = exe_racial_power(player_ptr, rpi_ptr->number);
         else
-            rc_ptr->cast = exe_mutation_power(player_ptr, static_cast<MUTA>(rpi_ptr->number));
+            rc_ptr->cast = exe_mutation_power(player_ptr, i2enum<MUTA>(rpi_ptr->number));
         break;
     case RACIAL_FAILURE:
         rc_ptr->cast = true;

--- a/src/cmd-io/cmd-gameoption.cpp
+++ b/src/cmd-io/cmd-gameoption.cpp
@@ -176,7 +176,7 @@ static void do_cmd_options_autosave(player_type *player_ptr, concptr info)
  */
 static bool has_window_flag(int x, int y)
 {
-    auto flag = static_cast<window_redraw_type>(1UL << y);
+    auto flag = i2enum<window_redraw_type>(1UL << y);
     return any_bits(window_flag[x], flag);
 }
 
@@ -189,7 +189,7 @@ static bool has_window_flag(int x, int y)
  */
 static void set_window_flag(int x, int y)
 {
-    auto flag = static_cast<window_redraw_type>(1UL << y);
+    auto flag = i2enum<window_redraw_type>(1UL << y);
     if (any_bits(PW_ALL, flag))
         set_bits(window_flag[x], flag);
 }
@@ -202,7 +202,7 @@ static void clear_window_flag(int x, int y)
 {
     window_flag[x] = 0;
 
-    auto flag = static_cast<window_redraw_type>(1UL << y);
+    auto flag = i2enum<window_redraw_type>(1UL << y);
     for (int i = 0; i < 8; i++) {
         reset_bits(window_flag[i], flag);
     }

--- a/src/effect/effect-monster-switcher.cpp
+++ b/src/effect/effect-monster-switcher.cpp
@@ -449,7 +449,7 @@ process_result switch_effects_monster(player_type *player_ptr, effect_monster_ty
     case GF_CAPTURE:
         return effect_monster_capture(player_ptr, em_ptr);
     case GF_ATTACK:
-        return (process_result)do_cmd_attack(player_ptr, em_ptr->y, em_ptr->x, static_cast<combat_options>(em_ptr->dam));
+        return (process_result)do_cmd_attack(player_ptr, em_ptr->y, em_ptr->x, i2enum<combat_options>(em_ptr->dam));
     case GF_ENGETSU:
         return effect_monster_engetsu(player_ptr, em_ptr);
     case GF_GENOCIDE:

--- a/src/effect/effect-monster.cpp
+++ b/src/effect/effect-monster.cpp
@@ -468,7 +468,7 @@ static void effect_damage_makes_teleport(player_type *player_ptr, effect_monster
     if (!em_ptr->who)
         chg_virtue(player_ptr, V_VALOUR, -1);
 
-    teleport_flags tflag = static_cast<teleport_flags>((!em_ptr->who ? TELEPORT_DEC_VALOUR : TELEPORT_SPONTANEOUS) | TELEPORT_PASSIVE);
+    teleport_flags tflag = i2enum<teleport_flags>((!em_ptr->who ? TELEPORT_DEC_VALOUR : TELEPORT_SPONTANEOUS) | TELEPORT_PASSIVE);
     teleport_away(player_ptr, em_ptr->g_ptr->m_idx, em_ptr->do_dist, tflag);
 
     em_ptr->y = em_ptr->m_ptr->fy;

--- a/src/flavor/flavor-util.cpp
+++ b/src/flavor/flavor-util.cpp
@@ -9,6 +9,7 @@
 #include "system/artifact-type-definition.h"
 #include "system/object-type-definition.h"
 #include "util/bit-flags-calculator.h"
+#include "util/enum-converter.h"
 #include "util/quarks.h"
 
 flavor_type *initialize_flavor_type(flavor_type *flavor_ptr, char *buf, object_type *o_ptr, BIT_FLAGS mode)
@@ -148,7 +149,7 @@ static char *inscribe_flags_aux(std::vector<flag_insc_table> &fi_vec, const TrFl
 #endif
 
     for (flag_insc_table &fi : fi_vec)
-        if (flgs.has(fi.flag) && (fi.except_flag == -1 || flgs.has_not(static_cast<tr_type>(fi.except_flag))))
+        if (flgs.has(fi.flag) && (fi.except_flag == -1 || flgs.has_not(i2enum<tr_type>(fi.except_flag))))
             add_inscription(&ptr, _(kanji ? fi.japanese : fi.english, fi.english));
 
     return ptr;
@@ -164,7 +165,7 @@ static char *inscribe_flags_aux(std::vector<flag_insc_table> &fi_vec, const TrFl
 static bool has_flag_of(std::vector<flag_insc_table> &fi_vec, const TrFlags &flgs)
 {
     for (flag_insc_table &fi : fi_vec)
-        if (flgs.has(fi.flag) && (fi.except_flag == -1 || flgs.has_not(static_cast<tr_type>(fi.except_flag))))
+        if (flgs.has(fi.flag) && (fi.except_flag == -1 || flgs.has_not(i2enum<tr_type>(fi.except_flag))))
             return true;
 
     return false;

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -439,7 +439,7 @@ parse_error_type generate_fixed_map_floor(player_type *player_ptr, qtwg_type *qt
         return PARSE_ERROR_NONE;
     }
 
-    parse_error_type parse_result_Q = static_cast<parse_error_type>(parse_qtw_Q(qtwg_ptr, zz));
+    parse_error_type parse_result_Q = i2enum<parse_error_type>(parse_qtw_Q(qtwg_ptr, zz));
     if (parse_result_Q != PARSE_CONTINUE)
         return parse_result_Q;
 

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -297,7 +297,7 @@ static void generate_area(player_type *player_ptr, POSITION y, POSITION x, bool 
     if (player_ptr->town_num) {
         init_buildings();
         if (border || corner)
-            init_flags = static_cast<init_flags_type>(INIT_CREATE_DUNGEON | INIT_ONLY_FEATURES);
+            init_flags = i2enum<init_flags_type>(INIT_CREATE_DUNGEON | INIT_ONLY_FEATURES);
         else
             init_flags = INIT_CREATE_DUNGEON;
 
@@ -648,7 +648,7 @@ parse_error_type parse_line_wilderness(player_type *player_ptr, char *buf, int x
             int index = zz[0][0];
 
             if (num > 1)
-                w_letter[index].terrain = static_cast<wt_type>(atoi(zz[1]));
+                w_letter[index].terrain = i2enum<wt_type>(atoi(zz[1]));
             else
                 w_letter[index].terrain = TERRAIN_EDGE;
 

--- a/src/info-reader/general-parser.cpp
+++ b/src/info-reader/general-parser.cpp
@@ -233,7 +233,7 @@ parse_error_type parse_line_building(char *buf)
         int n;
         n = tokenize(s + 2, MAX_CLASS, zz, 0);
         for (int i = 0; i < MAX_CLASS; i++) {
-            building[index].member_class[i] = static_cast<player_class_type>((i < n) ? atoi(zz[i]) : 1);
+            building[index].member_class[i] = i2enum<player_class_type>((i < n) ? atoi(zz[i]) : 1);
         }
 
         break;
@@ -242,7 +242,7 @@ parse_error_type parse_line_building(char *buf)
         int n;
         n = tokenize(s + 2, MAX_RACES, zz, 0);
         for (int i = 0; i < MAX_RACES; i++) {
-            building[index].member_race[i] = static_cast<player_race_type>((i < n) ? atoi(zz[i]) : 1);
+            building[index].member_race[i] = i2enum<player_race_type>((i < n) ? atoi(zz[i]) : 1);
         }
 
         break;

--- a/src/io-dump/special-class-dump.cpp
+++ b/src/io-dump/special-class-dump.cpp
@@ -165,7 +165,7 @@ static void dump_blue_mage(player_type *player_ptr, FILE *fff)
     for (int spell_type = 1; spell_type < 6; spell_type++) {
         col++;
         learnt_spell_table learnt_magic;
-        add_monster_spell_type(p, col, static_cast<blue_magic_type>(spell_type), &learnt_magic);
+        add_monster_spell_type(p, col, i2enum<blue_magic_type>(spell_type), &learnt_magic);
 
         std::vector<RF_ABILITY> learnt_spells;
         EnumClassFlagGroup<RF_ABILITY>::get_flags(learnt_magic.ability_flags, std::back_inserter(learnt_spells));

--- a/src/knowledge/knowledge-inventory.cpp
+++ b/src/knowledge/knowledge-inventory.cpp
@@ -284,9 +284,9 @@ void do_cmd_knowledge_inventory(player_type *player_ptr)
     int label_number = 0;
     for (int tval = TV_WEARABLE_BEGIN; tval <= TV_WEARABLE_END; tval++) {
         reset_label_number(&label_number, fff);
-        show_wearing_equipment_resistances(player_ptr, static_cast<tval_type>(tval), &label_number, fff);
-        show_holding_equipment_resistances(player_ptr, static_cast<tval_type>(tval), &label_number, fff);
-        show_home_equipment_resistances(player_ptr, static_cast<tval_type>(tval), &label_number, fff);
+        show_wearing_equipment_resistances(player_ptr, i2enum<tval_type>(tval), &label_number, fff);
+        show_holding_equipment_resistances(player_ptr, i2enum<tval_type>(tval), &label_number, fff);
+        show_home_equipment_resistances(player_ptr, i2enum<tval_type>(tval), &label_number, fff);
     }
 
     angband_fclose(fff);

--- a/src/knowledge/knowledge-self.cpp
+++ b/src/knowledge/knowledge-self.cpp
@@ -139,13 +139,13 @@ static void dump_winner_classes(FILE *fff)
     std::string s = "";
     std::string l = "";
     for (int c = 0; c < MAX_CLASS; c++) {
-        if (current_world_ptr->sf_winner.has_not(static_cast<player_class_type>(c)))
+        if (current_world_ptr->sf_winner.has_not(i2enum<player_class_type>(c)))
             continue;
 
         auto &cl = class_info[c];
         auto t = std::string(cl.title);
 
-        if (current_world_ptr->sf_retired.has_not(static_cast<player_class_type>(c)))
+        if (current_world_ptr->sf_retired.has_not(i2enum<player_class_type>(c)))
             t = "(" + t + ")";
 
         if (l.size() + t.size() + 2 > max_len) {

--- a/src/load/birth-loader.cpp
+++ b/src/load/birth-loader.cpp
@@ -18,7 +18,7 @@ void load_quick_start(void)
 
     byte tmp8u;
     rd_byte(&tmp8u);
-    previous_char.psex = static_cast<player_sex>(tmp8u);
+    previous_char.psex = i2enum<player_sex>(tmp8u);
     rd_byte(&tmp8u);
     previous_char.prace = (player_race_type)tmp8u;
     rd_byte(&tmp8u);

--- a/src/load/load-v1-5-0.cpp
+++ b/src/load/load-v1-5-0.cpp
@@ -70,7 +70,7 @@ void rd_item_old(object_type *o_ptr)
 
     /* Type/Subtype */
     rd_byte(&tmp8u);
-    o_ptr->tval = static_cast<tval_type>(tmp8u);
+    o_ptr->tval = i2enum<tval_type>(tmp8u);
     rd_byte(&tmp8u);
     o_ptr->sval = tmp8u;
 
@@ -130,9 +130,9 @@ void rd_item_old(object_type *o_ptr)
         o_ptr->curse_flags.clear();
         if (o_ptr->ident & 0x40) {
             o_ptr->curse_flags.set(TRC::CURSED);
-            if (o_ptr->art_flags.has(static_cast<tr_type>(94)))
+            if (o_ptr->art_flags.has(i2enum<tr_type>(94)))
                 o_ptr->curse_flags.set(TRC::HEAVY_CURSE);
-            if (o_ptr->art_flags.has(static_cast<tr_type>(95)))
+            if (o_ptr->art_flags.has(i2enum<tr_type>(95)))
                 o_ptr->curse_flags.set(TRC::PERMA_CURSE);
             if (o_ptr->is_fixed_artifact()) {
                 artifact_type *a_ptr = &a_info[o_ptr->name1];
@@ -148,7 +148,7 @@ void rd_item_old(object_type *o_ptr)
                     o_ptr->curse_flags.set(TRC::PERMA_CURSE);
             }
         }
-        o_ptr->art_flags.reset({ static_cast<tr_type>(93), static_cast<tr_type>(94), static_cast<tr_type>(95) });
+        o_ptr->art_flags.reset({ i2enum<tr_type>(93), i2enum<tr_type>(94), i2enum<tr_type>(95) });
     } else {
         uint32_t tmp32u;
         rd_u32b(&tmp32u);
@@ -439,7 +439,7 @@ void rd_monster_old(player_type *player_ptr, monster_type *m_ptr)
     m_ptr->mflag2[MFLAG2::CLONED] = rd_bits_smart[22];
     m_ptr->mflag2[MFLAG2::PET] = rd_bits_smart[23];
     m_ptr->mflag2[MFLAG2::FRIENDLY] = rd_bits_smart[28];
-    m_ptr->smart.reset(static_cast<SM>(22)).reset(static_cast<SM>(23)).reset(static_cast<SM>(28));
+    m_ptr->smart.reset(i2enum<SM>(22)).reset(i2enum<SM>(23)).reset(i2enum<SM>(28));
 
     if (h_older_than(0, 4, 5)) {
         m_ptr->exp = 0;

--- a/src/load/monster-loader.cpp
+++ b/src/load/monster-loader.cpp
@@ -126,7 +126,7 @@ void rd_monster(player_type *player_ptr, monster_type *m_ptr)
             m_ptr->mflag2[MFLAG2::CLONED] = rd_bits[22];
             m_ptr->mflag2[MFLAG2::PET] = rd_bits[23];
             m_ptr->mflag2[MFLAG2::FRIENDLY] = rd_bits[28];
-            m_ptr->smart.reset(static_cast<SM>(22)).reset(static_cast<SM>(23)).reset(static_cast<SM>(28));
+            m_ptr->smart.reset(i2enum<SM>(22)).reset(i2enum<SM>(23)).reset(i2enum<SM>(28));
         } else {
             rd_FlagGroup(m_ptr->smart, rd_byte);
         }

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -71,7 +71,7 @@ void rd_base_info(player_type *player_ptr)
     player_ptr->pseikaku = (player_personality_type)tmp8u;
 
     rd_byte(&tmp8u);
-    player_ptr->psex = static_cast<player_sex>(tmp8u);
+    player_ptr->psex = i2enum<player_sex>(tmp8u);
 
     rd_realms(player_ptr);
 
@@ -228,7 +228,7 @@ static void set_imitation(player_type *player_ptr)
     for (int i = 0; i < MAX_MANE; i++) {
         int16_t tmp16s;
         rd_s16b(&tmp16s);
-        player_ptr->mane_spell[i] = static_cast<RF_ABILITY>(tmp16s);
+        player_ptr->mane_spell[i] = i2enum<RF_ABILITY>(tmp16s);
         rd_s16b(&tmp16s);
         player_ptr->mane_dam[i] = (SPELL_IDX)tmp16s;
     }

--- a/src/load/store-loader.cpp
+++ b/src/load/store-loader.cpp
@@ -101,7 +101,7 @@ static errr rd_store(player_type *player_ptr, int town_number, int store_number)
 
         rd_item(q_ptr);
 
-        auto stock_max = store_get_stock_max(static_cast<STORE_TYPE_IDX>(store_number));
+        auto stock_max = store_get_stock_max(i2enum<STORE_TYPE_IDX>(store_number));
         if (store_ptr->stock_num >= stock_max)
             continue;
 

--- a/src/market/building-craft-fix.cpp
+++ b/src/market/building-craft-fix.cpp
@@ -59,7 +59,7 @@ static void give_one_ability_of_object(object_type *to_ptr, object_type *from_pt
         case TR_FIXED_FLAVOR:
             break;
         default:
-            auto tr_flag = static_cast<tr_type>(i);
+            auto tr_flag = i2enum<tr_type>(i);
             if (from_flgs.has(tr_flag) && to_flgs.has_not(tr_flag)) {
                 if (!(TR_PVAL_FLAG_MASK.has(tr_flag) && (from_ptr->pval < 1)))
                     cand[n++] = tr_flag;

--- a/src/market/building-initializer.cpp
+++ b/src/market/building-initializer.cpp
@@ -28,7 +28,7 @@ errr init_towns(void)
              * 我が家が 20 ページまで使える隠し機能のための準備。
              * オプションが有効でもそうでなくても一応スペースを作っておく。
              */
-            store_ptr->stock_size = store_get_stock_max(static_cast<STORE_TYPE_IDX>(j));
+            store_ptr->stock_size = store_get_stock_max(i2enum<STORE_TYPE_IDX>(j));
 
             C_MAKE(store_ptr->stock, store_ptr->stock_size, object_type);
             if ((j == STORE_BLACK) || (j == STORE_HOME) || (j == STORE_MUSEUM))
@@ -40,7 +40,7 @@ errr init_towns(void)
                 if (tv == 0)
                     break;
 
-                KIND_OBJECT_IDX k_idx = lookup_kind(static_cast<tval_type>(tv), sv);
+                KIND_OBJECT_IDX k_idx = lookup_kind(i2enum<tval_type>(tv), sv);
 
                 if (k_idx == 0)
                     continue;
@@ -54,7 +54,7 @@ errr init_towns(void)
                 if (tv == 0)
                     break;
 
-                KIND_OBJECT_IDX k_idx = lookup_kind(static_cast<tval_type>(tv), sv);
+                KIND_OBJECT_IDX k_idx = lookup_kind(i2enum<tval_type>(tv), sv);
 
                 if (k_idx == 0)
                     continue;

--- a/src/market/building-quest.cpp
+++ b/src/market/building-quest.cpp
@@ -35,7 +35,7 @@ static void get_questinfo(player_type *player_ptr, IDX questnum, bool do_init)
 
     init_flags = INIT_SHOW_TEXT;
     if (do_init)
-        init_flags = static_cast<init_flags_type>(init_flags | INIT_ASSIGN);
+        init_flags = i2enum<init_flags_type>(init_flags | INIT_ASSIGN);
 
     parse_fixed_map(player_ptr, "q_info.txt", 0, 0, 0, 0);
     floor_ptr->inside_quest = old_quest;

--- a/src/mind/mind-archer.cpp
+++ b/src/mind/mind-archer.cpp
@@ -37,7 +37,7 @@ static bool select_ammo_creation_type(ammo_creation_type &type, PLAYER_LEVEL ple
 {
     COMMAND_CODE code;
     if (repeat_pull(&code)) {
-        type = static_cast<ammo_creation_type>(code);
+        type = i2enum<ammo_creation_type>(code);
         switch (type) {
         case AMMO_SHOT:
         case AMMO_ARROW:

--- a/src/mind/mind-blue-mage.cpp
+++ b/src/mind/mind-blue-mage.cpp
@@ -79,7 +79,7 @@ bool do_cmd_cast_learned(player_type *player_ptr)
         chance = 95;
 
     chance = mod_spell_chance_2(player_ptr, chance);
-    const auto spell_type = static_cast<RF_ABILITY>(n);
+    const auto spell_type = i2enum<RF_ABILITY>(n);
     if (randint0(100) < chance) {
         if (flush_failure)
             flush();

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -294,7 +294,7 @@ static element_text_list element_texts = {
  */
 concptr get_element_title(int realm_idx)
 {
-    auto realm = static_cast<ElementRealm>(realm_idx);
+    auto realm = i2enum<ElementRealm>(realm_idx);
     return element_types.at(realm).title.data();
 }
 
@@ -305,7 +305,7 @@ concptr get_element_title(int realm_idx)
  */
 static std::array<spells_type, 3> get_element_types(int realm_idx)
 {
-    auto realm = static_cast<ElementRealm>(realm_idx);
+    auto realm = i2enum<ElementRealm>(realm_idx);
     return element_types.at(realm).type;
 }
 
@@ -328,7 +328,7 @@ spells_type get_element_type(int realm_idx, int n)
  */
 static spells_type get_element_spells_type(player_type *player_ptr, int n)
 {
-    auto realm = element_types.at(static_cast<ElementRealm>(player_ptr->element));
+    auto realm = element_types.at(i2enum<ElementRealm>(player_ptr->element));
     auto t = realm.type.at(n);
     if (realm.extra.find(t) != realm.extra.end()) {
         if (randint0(100) < player_ptr->lev * 2)
@@ -344,7 +344,7 @@ static spells_type get_element_spells_type(player_type *player_ptr, int n)
  */
 static std::array<std::string_view, 3> get_element_names(int realm_idx)
 {
-    auto realm = static_cast<ElementRealm>(realm_idx);
+    auto realm = i2enum<ElementRealm>(realm_idx);
     return element_types.at(realm).name;
 }
 
@@ -367,8 +367,8 @@ concptr get_element_name(int realm_idx, int n)
  */
 static concptr get_element_tip(player_type *player_ptr, int spell_idx)
 {
-    auto realm = static_cast<ElementRealm>(player_ptr->element);
-    auto spell = static_cast<ElementSpells>(spell_idx);
+    auto realm = i2enum<ElementRealm>(player_ptr->element);
+    auto spell = i2enum<ElementSpells>(spell_idx);
     auto elem = element_powers.at(spell).elem;
     return format(element_tips.at(spell).data(), element_types.at(realm).name[elem].data());
 }
@@ -382,7 +382,7 @@ static concptr get_element_tip(player_type *player_ptr, int spell_idx)
 static int get_elemental_elem(player_type *player_ptr, int spell_idx)
 {
     (void)player_ptr;
-    auto spell = static_cast<ElementSpells>(spell_idx);
+    auto spell = i2enum<ElementSpells>(spell_idx);
     return element_powers.at(spell).elem;
 }
 
@@ -395,7 +395,7 @@ static int get_elemental_elem(player_type *player_ptr, int spell_idx)
 static mind_type get_elemental_info(player_type *player_ptr, int spell_idx)
 {
     (void)player_ptr;
-    auto spell = static_cast<ElementSpells>(spell_idx);
+    auto spell = i2enum<ElementSpells>(spell_idx);
     return element_powers.at(spell).info;
 }
 
@@ -409,7 +409,7 @@ static mind_type get_elemental_info(player_type *player_ptr, int spell_idx)
 void get_element_effect_info(player_type *player_ptr, int spell_idx, char *p)
 {
     PLAYER_LEVEL plev = player_ptr->lev;
-    auto spell = static_cast<ElementSpells>(spell_idx);
+    auto spell = i2enum<ElementSpells>(spell_idx);
     int dam = 0;
 
     switch (spell) {
@@ -470,7 +470,7 @@ void get_element_effect_info(player_type *player_ptr, int spell_idx, char *p)
  */
 static bool cast_element_spell(player_type *player_ptr, SPELL_IDX spell_idx)
 {
-    auto spell = static_cast<ElementSpells>(spell_idx);
+    auto spell = i2enum<ElementSpells>(spell_idx);
     auto power = element_powers.at(spell);
     spells_type typ;
     DIRECTION dir;
@@ -1065,7 +1065,7 @@ bool has_element_resist(player_type *player_ptr, ElementRealm realm, PLAYER_LEVE
     if (player_ptr->pclass != CLASS_ELEMENTALIST)
         return false;
 
-    auto prealm = static_cast<ElementRealm>(player_ptr->element);
+    auto prealm = i2enum<ElementRealm>(player_ptr->element);
     return (prealm == realm && player_ptr->lev >= lev);
 }
 
@@ -1085,7 +1085,7 @@ static void display_realm_cursor(int i, int n, term_color_type color)
         name = _("ランダム", "Random");
     } else {
         sym = I2A(i);
-        name = element_types.at(static_cast<ElementRealm>(i + 1)).title.data();
+        name = element_types.at(i2enum<ElementRealm>(i + 1)).title.data();
     }
     sprintf(cur, "%c) %s", sym, name);
 
@@ -1215,7 +1215,7 @@ byte select_element_realm(player_type *player_ptr)
         if (realm_idx == 255)
             break;
 
-        auto realm = static_cast<ElementRealm>(realm_idx);
+        auto realm = i2enum<ElementRealm>(realm_idx);
         char temp[80 * 5];
         shape_buffer(element_texts.at(realm).data(), 74, temp, sizeof(temp));
         concptr t = temp;
@@ -1244,7 +1244,7 @@ byte select_element_realm(player_type *player_ptr)
 void switch_element_racial(player_type *player_ptr, rc_type *rc_ptr)
 {
     auto plev = player_ptr->lev;
-    auto realm = static_cast<ElementRealm>(player_ptr->element);
+    auto realm = i2enum<ElementRealm>(player_ptr->element);
     rpi_type rpi;
     switch (realm) {
     case ElementRealm::FIRE:
@@ -1340,7 +1340,7 @@ static bool door_to_darkness(player_type *player_ptr, POSITION dist);
  */
 bool switch_element_execution(player_type *player_ptr)
 {
-    auto realm = static_cast<ElementRealm>(player_ptr->element);
+    auto realm = i2enum<ElementRealm>(player_ptr->element);
     PLAYER_LEVEL plev = player_ptr->lev;
     DIRECTION dir;
 

--- a/src/mind/mind-weaponsmith.cpp
+++ b/src/mind/mind-weaponsmith.cpp
@@ -701,7 +701,7 @@ void do_cmd_kaji(player_type *player_ptr, bool only_browse)
         mode = choose_essence();
         if (mode == 0)
             break;
-        add_essence(player_ptr, static_cast<SmithCategory>(mode));
+        add_essence(player_ptr, i2enum<SmithCategory>(mode));
         break;
     case 5:
         add_essence(player_ptr, SmithCategory::ENCHANT);

--- a/src/mspell/mspell-special.cpp
+++ b/src/mspell/mspell-special.cpp
@@ -170,9 +170,9 @@ static MonsterSpellResult spell_RF6_SPECIAL_B(player_type *player_ptr, POSITION 
     HIT_POINT dam = damroll(4, 8);
 
     if (monster_to_player || t_idx == player_ptr->riding)
-        teleport_player_to(player_ptr, m_ptr->fy, m_ptr->fx, static_cast<teleport_flags>(TELEPORT_NONMAGICAL | TELEPORT_PASSIVE));
+        teleport_player_to(player_ptr, m_ptr->fy, m_ptr->fx, i2enum<teleport_flags>(TELEPORT_NONMAGICAL | TELEPORT_PASSIVE));
     else
-        teleport_monster_to(player_ptr, t_idx, m_ptr->fy, m_ptr->fx, 100, static_cast<teleport_flags>(TELEPORT_NONMAGICAL | TELEPORT_PASSIVE));
+        teleport_monster_to(player_ptr, t_idx, m_ptr->fy, m_ptr->fx, 100, i2enum<teleport_flags>(TELEPORT_NONMAGICAL | TELEPORT_PASSIVE));
 
     if ((monster_to_player && player_ptr->levitation) || (monster_to_monster && (tr_ptr->flags7 & RF7_CAN_FLY))) {
         simple_monspell_message(player_ptr, m_idx, t_idx, _("あなたは静かに着地した。", "You float gently down to the ground."),

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -160,7 +160,7 @@ void process_world_aux_mutation(player_type *player_ptr)
                     lose_all_info(player_ptr);
                 else
                     wiz_dark(player_ptr);
-                (void)teleport_player_aux(player_ptr, 100, false, static_cast<teleport_flags>(TELEPORT_NONMAGICAL | TELEPORT_PASSIVE));
+                (void)teleport_player_aux(player_ptr, 100, false, i2enum<teleport_flags>(TELEPORT_NONMAGICAL | TELEPORT_PASSIVE));
                 wiz_dark(player_ptr);
                 msg_print(_("あなたは見知らぬ場所で目が醒めた...頭が痛い。", "You wake up somewhere with a sore head..."));
                 msg_print(_("何も覚えていない。どうやってここに来たかも分からない！", "You can't remember a thing or how you got here!"));

--- a/src/object-enchant/object-curse.cpp
+++ b/src/object-enchant/object-curse.cpp
@@ -31,7 +31,7 @@ TRC get_curse(int power, object_type *o_ptr)
     TRC new_curse;
 
     while (true) {
-        new_curse = static_cast<TRC>(rand_range(enum2i(TRC::TY_CURSE), enum2i(TRC::MAX) - 1));
+        new_curse = i2enum<TRC>(rand_range(enum2i(TRC::TY_CURSE), enum2i(TRC::MAX) - 1));
         if (power == 2) {
             if (TRC_HEAVY_MASK.has_not(new_curse))
                 continue;

--- a/src/object-enchant/object-smith.cpp
+++ b/src/object-enchant/object-smith.cpp
@@ -235,7 +235,7 @@ std::optional<random_art_activation_type> Smith::get_effect_activation(SmithEffe
  */
 std::optional<SmithEffect> Smith::object_effect(const object_type *o_ptr)
 {
-    auto effect = static_cast<SmithEffect>(o_ptr->xtra3);
+    auto effect = i2enum<SmithEffect>(o_ptr->xtra3);
     if (!o_ptr->is_weapon_armour_ammo() || effect == SmithEffect::NONE) {
         return std::nullopt;
     }

--- a/src/object-use/quaff-execution.cpp
+++ b/src/object-use/quaff-execution.cpp
@@ -83,7 +83,7 @@ static bool booze(player_type *player_ptr)
         else
             wiz_dark(player_ptr);
 
-        (void)teleport_player_aux(player_ptr, 100, false, static_cast<teleport_flags>(TELEPORT_NONMAGICAL | TELEPORT_PASSIVE));
+        (void)teleport_player_aux(player_ptr, 100, false, i2enum<teleport_flags>(TELEPORT_NONMAGICAL | TELEPORT_PASSIVE));
         wiz_dark(player_ptr);
         msg_print(_("知らない場所で目が醒めた。頭痛がする。", "You wake up somewhere with a sore head..."));
         msg_print(_("何も思い出せない。どうやってここへ来たのかも分からない！", "You can't remember a thing or how you got here!"));

--- a/src/player-status/player-status-base.cpp
+++ b/src/player-status/player-status-base.cpp
@@ -195,7 +195,7 @@ BIT_FLAGS PlayerStatusBase::equipments_flags(tr_type check_flag)
         auto flgs = object_flags(o_ptr);
 
         if (flgs.has(check_flag))
-            set_bits(result, convert_inventory_slot_type_to_flag_cause(static_cast<inventory_slot_type>(i)));
+            set_bits(result, convert_inventory_slot_type_to_flag_cause(i2enum<inventory_slot_type>(i)));
     }
     return result;
 }
@@ -218,7 +218,7 @@ BIT_FLAGS PlayerStatusBase::equipments_bad_flags(tr_type check_flag)
 
         if (flgs.has(check_flag)) {
             if (o_ptr->pval < 0) {
-                set_bits(result, convert_inventory_slot_type_to_flag_cause(static_cast<inventory_slot_type>(i)));
+                set_bits(result, convert_inventory_slot_type_to_flag_cause(i2enum<inventory_slot_type>(i)));
             }
         }
     }

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -93,7 +93,7 @@ BIT_FLAGS check_equipment_flags(player_type *player_ptr, tr_type tr_flag)
         auto flgs = object_flags(o_ptr);
 
         if (flgs.has(tr_flag))
-            set_bits(result, convert_inventory_slot_type_to_flag_cause(static_cast<inventory_slot_type>(i)));
+            set_bits(result, convert_inventory_slot_type_to_flag_cause(i2enum<inventory_slot_type>(i)));
     }
     return result;
 }
@@ -769,7 +769,7 @@ BIT_FLAGS has_warning(player_type *player_ptr)
 
         if (flgs.has(TR_WARNING)) {
             if (!o_ptr->inscription || !(angband_strchr(quark_str(o_ptr->inscription), '$')))
-                set_bits(result, convert_inventory_slot_type_to_flag_cause(static_cast<inventory_slot_type>(i)));
+                set_bits(result, convert_inventory_slot_type_to_flag_cause(i2enum<inventory_slot_type>(i)));
         }
     }
     return result;

--- a/src/player/temporary-resistances.cpp
+++ b/src/player/temporary-resistances.cpp
@@ -42,7 +42,7 @@ void tim_player_flags(player_type *player_ptr, TrFlags &flags)
         flags.set(TR_RES_POIS);
 
     for (int test_flag = 0; test_flag < TR_FLAG_MAX; test_flag++) {
-        if (any_bits(get_player_flags(player_ptr, static_cast<tr_type>(test_flag)), tmp_effect_flag))
-            flags.set(static_cast<tr_type>(test_flag));
+        if (any_bits(get_player_flags(player_ptr, i2enum<tr_type>(test_flag)), tmp_effect_flag))
+            flags.set(i2enum<tr_type>(test_flag));
     }
 }

--- a/src/specific-object/bloody-moon.cpp
+++ b/src/specific-object/bloody-moon.cpp
@@ -23,13 +23,13 @@ void get_bloody_moon_flags(object_type *o_ptr)
     for (int i = 0; i < dummy; i++) {
         int flag = randint0(26);
         if (flag >= 20)
-            o_ptr->art_flags.set(static_cast<tr_type>(TR_KILL_UNDEAD + flag - 20));
+            o_ptr->art_flags.set(i2enum<tr_type>(TR_KILL_UNDEAD + flag - 20));
         else if (flag == 19)
             o_ptr->art_flags.set(TR_KILL_ANIMAL);
         else if (flag == 18)
             o_ptr->art_flags.set(TR_SLAY_HUMAN);
         else
-            o_ptr->art_flags.set(static_cast<tr_type>(TR_CHAOTIC + flag));
+            o_ptr->art_flags.set(i2enum<tr_type>(TR_CHAOTIC + flag));
     }
 
     dummy = randint1(2);
@@ -39,9 +39,9 @@ void get_bloody_moon_flags(object_type *o_ptr)
     for (int i = 0; i < 2; i++) {
         int tmp = randint0(11);
         if (tmp < A_MAX)
-            o_ptr->art_flags.set(static_cast<tr_type>(TR_STR + tmp));
+            o_ptr->art_flags.set(i2enum<tr_type>(TR_STR + tmp));
         else
-            o_ptr->art_flags.set(static_cast<tr_type>(TR_STEALTH + tmp - 6));
+            o_ptr->art_flags.set(i2enum<tr_type>(TR_STEALTH + tmp - 6));
     }
 }
 

--- a/src/spell-kind/spells-random.cpp
+++ b/src/spell-kind/spells-random.cpp
@@ -315,7 +315,7 @@ void wild_magic(player_type *player_ptr, int spell)
     case 35:
         for (int counter = 0; counter < 8; counter++) {
             (void)summon_specific(
-                player_ptr, 0, player_ptr->y, player_ptr->x, (floor_ptr->dun_level * 3) / 2, static_cast<summon_type>(type), (PM_ALLOW_GROUP | PM_NO_PET));
+                player_ptr, 0, player_ptr->y, player_ptr->x, (floor_ptr->dun_level * 3) / 2, i2enum<summon_type>(type), (PM_ALLOW_GROUP | PM_NO_PET));
         }
 
         break;

--- a/src/spell-kind/spells-teleport.cpp
+++ b/src/spell-kind/spells-teleport.cpp
@@ -377,7 +377,7 @@ void teleport_player(player_type *player_ptr, POSITION dis, BIT_FLAGS mode)
     const POSITION oy = player_ptr->y;
     const POSITION ox = player_ptr->x;
 
-    if (!teleport_player_aux(player_ptr, dis, false, static_cast<teleport_flags>(mode)))
+    if (!teleport_player_aux(player_ptr, dis, false, i2enum<teleport_flags>(mode)))
         return;
 
     /* Monsters with teleport ability may follow the player */

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -107,7 +107,7 @@ bool SpellHex::stop_spells_with_selection()
     if (is_selected) {
         auto n = this->casting_spells[A2I(choice)];
         exe_spell(this->player_ptr, REALM_HEX, n, SPELL_STOP);
-        this->reset_casting_flag(static_cast<spell_hex_type>(n));
+        this->reset_casting_flag(i2enum<spell_hex_type>(n));
     }
 
     this->player_ptr->update |= PU_BONUS | PU_HP | PU_MANA | PU_SPELLS;
@@ -497,7 +497,7 @@ void SpellHex::set_revenge_turn(byte turn, bool substitution)
 
 SpellHexRevengeType SpellHex::get_revenge_type() const
 {
-    return static_cast<SpellHexRevengeType>(this->player_ptr->magic_num2[1]);
+    return i2enum<SpellHexRevengeType>(this->player_ptr->magic_num2[1]);
 }
 
 void SpellHex::set_revenge_type(SpellHexRevengeType type)

--- a/src/spell-realm/spells-trump.cpp
+++ b/src/spell-realm/spells-trump.cpp
@@ -95,7 +95,7 @@ void cast_shuffle(player_type *player_ptr)
     if (die < 30) {
         msg_print(_("奇妙なモンスターの絵だ。", "It's the picture of a strange monster."));
         trump_summoning(player_ptr, 1, false, player_ptr->y, player_ptr->x, (floor_ptr->dun_level * 3 / 2),
-            static_cast<summon_type>(SUMMON_UNIQUE + randint1(6)), PM_ALLOW_GROUP | PM_ALLOW_UNIQUE);
+            i2enum<summon_type>(SUMMON_UNIQUE + randint1(6)), PM_ALLOW_GROUP | PM_ALLOW_UNIQUE);
         return;
     }
 

--- a/src/spell/spells-execution.cpp
+++ b/src/spell/spells-execution.cpp
@@ -38,7 +38,7 @@ concptr exe_spell(player_type *player_ptr, int16_t realm, SPELL_IDX spell, spell
 	case REALM_CRUSADE:  return do_crusade_spell(player_ptr, spell, mode);
 	case REALM_MUSIC:    return do_music_spell(player_ptr, spell, mode);
 	case REALM_HISSATSU: return do_hissatsu_spell(player_ptr, spell, mode);
-	case REALM_HEX:      return do_hex_spell(player_ptr, static_cast<spell_hex_type>(spell), mode);
+	case REALM_HEX:      return do_hex_spell(player_ptr, i2enum<spell_hex_type>(spell), mode);
 	}
 
 	return nullptr;

--- a/src/target/target-setter.cpp
+++ b/src/target/target-setter.cpp
@@ -515,7 +515,7 @@ static void sweep_target_grids(player_type *player_ptr, ts_type *ts_ptr)
         fix_floor_item_list(player_ptr, ts_ptr->y, ts_ptr->x);
 
         /* Describe and Prompt (enable "TARGET_LOOK") */
-        while ((ts_ptr->query = examine_grid(player_ptr, ts_ptr->y, ts_ptr->x, static_cast<target_type>(ts_ptr->mode | TARGET_LOOK), ts_ptr->info)) == 0)
+        while ((ts_ptr->query = examine_grid(player_ptr, ts_ptr->y, ts_ptr->x, i2enum<target_type>(ts_ptr->mode | TARGET_LOOK), ts_ptr->info)) == 0)
             ;
 
         ts_ptr->distance = 0;

--- a/src/util/enum-converter.h
+++ b/src/util/enum-converter.h
@@ -5,14 +5,31 @@
 /*!
  * @brief 列挙型を基底型の整数値に変換する
  *
- * @tparam T 列挙型(enum もしくは enum class)
+ * @tparam EnumType 列挙型(enum もしくは enum class)
  * @param enum_val 変換する列挙型の値
  * @return 変換した基底型の整数値
  */
-template <typename T>
-constexpr std::underlying_type_t<T> enum2i(T enum_val)
+template <typename EnumType>
+constexpr std::underlying_type_t<EnumType> enum2i(EnumType enum_val)
 {
-    static_assert(std::is_enum_v<T>);
+    static_assert(std::is_enum_v<EnumType>);
 
-    return static_cast<std::underlying_type_t<T>>(enum_val);
+    return static_cast<std::underlying_type_t<EnumType>>(enum_val);
+}
+
+/*!
+ * @brief 整数値を列挙型の値に変換する
+ *
+ * @tparam EnumType 変換先の列挙型
+ * @tparam IntegerType 変換元の整数値の型
+ * @param integer_val 変換する整数値
+ * @return 変換した列挙型の値
+ */
+template <typename EnumType, typename IntegerType>
+constexpr EnumType i2enum(IntegerType integer_val)
+{
+    static_assert(std::is_integral_v<IntegerType>);
+    static_assert(std::is_enum_v<EnumType>);
+
+    return static_cast<EnumType>(integer_val);
 }

--- a/src/wizard/wizard-game-modifier.cpp
+++ b/src/wizard/wizard-game-modifier.cpp
@@ -115,7 +115,7 @@ void wiz_enter_quest(player_type* player_ptr)
     if ((tmp_int < 0) || (tmp_int >= max_q_idx))
         return;
 
-    init_flags = static_cast<init_flags_type>(INIT_SHOW_TEXT | INIT_ASSIGN);
+    init_flags = i2enum<init_flags_type>(INIT_SHOW_TEXT | INIT_ASSIGN);
     player_ptr->current_floor_ptr->inside_quest = (QUEST_IDX)tmp_int;
     parse_fixed_map(player_ptr, "q_info.txt", 0, 0, 0, 0);
     quest[tmp_int].status = QUEST_STATUS_TAKEN;

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -337,7 +337,7 @@ static void wiz_display_item(player_type *player_ptr, object_type *o_ptr)
     auto get_seq_32bits = [](const TrFlags &flgs, uint start) {
         BIT_FLAGS result = 0U;
         for (auto i = 0U; i < 32 && start + i < flgs.size(); i++) {
-            if (flgs.has(static_cast<tr_type>(start + i))) {
+            if (flgs.has(i2enum<tr_type>(start + i))) {
                 result |= 1U << i;
             }
         }

--- a/src/wizard/wizard-player-modifier.cpp
+++ b/src/wizard/wizard-player-modifier.cpp
@@ -85,7 +85,7 @@ void wizard_player_modifier(player_type *player_ptr)
         (void)gain_mutation(player_ptr, command_arg);
         break;
     case 'n':
-        roll_hitdice(player_ptr, static_cast<spell_operation>(SPOP_DISPLAY_MES | SPOP_DEBUG));
+        roll_hitdice(player_ptr, i2enum<spell_operation>(SPOP_DISPLAY_MES | SPOP_DEBUG));
         break;
     case 'r':
         wiz_reset_race(player_ptr);

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -137,7 +137,7 @@ KIND_OBJECT_IDX wiz_create_itemtype(void)
     if ((num < 0) || (num >= max_num))
         return 0;
 
-    tval_type tval = static_cast<tval_type>(tvals[num].tval);
+    tval_type tval = i2enum<tval_type>(tvals[num].tval);
     concptr tval_desc = tvals[num].desc;
     term_clear();
     num = 0;
@@ -513,7 +513,7 @@ void wiz_reset_race(player_type *player_ptr)
     if (tmp_int < 0 || tmp_int >= MAX_RACES)
         return;
 
-    player_ptr->prace = static_cast<player_race_type>(tmp_int);
+    player_ptr->prace = i2enum<player_race_type>(tmp_int);
     rp_ptr = &race_info[enum2i(player_ptr->prace)];
 
     player_ptr->window_flags |= PW_PLAYER;
@@ -541,7 +541,7 @@ void wiz_reset_class(player_type *player_ptr)
     if (tmp_int < 0 || tmp_int >= MAX_CLASS)
         return;
 
-    player_ptr->pclass = static_cast<player_class_type>(tmp_int);
+    player_ptr->pclass = i2enum<player_class_type>(tmp_int);
     cp_ptr = &class_info[player_ptr->pclass];
     mp_ptr = &m_info[player_ptr->pclass];
     player_ptr->window_flags |= PW_PLAYER;

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -140,7 +140,7 @@ void wiz_learn_blue_magic_all(player_type *player_ptr)
 {
     EnumClassFlagGroup<RF_ABILITY> ability_flags;
     for (int j = 1; j < A_MAX; j++) {
-        set_rf_masks(ability_flags, static_cast<blue_magic_type>(j));
+        set_rf_masks(ability_flags, i2enum<blue_magic_type>(j));
 
         std::vector<RF_ABILITY> spells;
         EnumClassFlagGroup<RF_ABILITY>::get_flags(ability_flags, std::back_inserter(spells));


### PR DESCRIPTION
引数に受け取った整数値をテンプレートパラメータで指定したenum型の値に
変換する関数テンプレート i2enum を導入し、現在の static_cast により
enum型の値に置換している部分を i2enum で置き換える。

開発者各位：
今後は enum(enum class)型↔整数型 の変換をする時は enum2i、 i2enum を使用するようにしてください。