### PR TITLE
[Fix] #1138 あてどなくふらつく商人の説明文に誤訳、「魅力のアミュレット」ではなく「装飾のアミュレット」に修正した

### DIFF
--- a/lib/edit/r_info.txt
+++ b/lib/edit/r_info.txt
@@ -439,7 +439,7 @@ F:ONLY_GOLD | DROP_60 | DROP_SKELETON | DROP_CORPSE
 F:TAKE_ITEM | OPEN_DOOR | BASH_DOOR | WILD_TOWN | WILD_ONLY
 D:$The typical ponce around town, with purse jingling, and looking for more 
 D:$amulets of adornment to buy.
-D:町をふらつく典型的なクズで、財布をじゃらじゃらさせて、魅力のアミュレット
+D:町をふらつく典型的なクズで、財布をじゃらじゃらさせて、装飾のアミュレット
 D:を買おうと町を探し回っている。
 
 #J0#


### PR DESCRIPTION
タイトルの通りです、ご確認下さい