### PR TITLE
player_type から時限ステータスを分離した (朦朧のみ)

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -566,6 +566,8 @@
     <ClCompile Include="..\..\src\target\target-getter.cpp" />
     <ClCompile Include="..\..\src\target\target-preparation.cpp" />
     <ClCompile Include="..\..\src\target\target-setter.cpp" />
+    <ClCompile Include="..\..\src\timed-effect\player-stun.cpp" />
+    <ClCompile Include="..\..\src\timed-effect\timed-effects.cpp" />
     <ClCompile Include="..\..\src\view\display-inventory.cpp" />
     <ClCompile Include="..\..\src\view\display-map.cpp" />
     <ClCompile Include="..\..\src\view\display-self-info.cpp" />
@@ -1291,6 +1293,8 @@
     <ClInclude Include="..\..\src\target\target-setter.h" />
     <ClInclude Include="..\..\src\target\target-types.h" />
     <ClInclude Include="..\..\src\term\screen-processor.h" />
+    <ClInclude Include="..\..\src\timed-effect\player-stun.h" />
+    <ClInclude Include="..\..\src\timed-effect\timed-effects.h" />
     <ClInclude Include="..\..\src\util\bit-flags-calculator.h" />
     <ClInclude Include="..\..\src\util\buffer-shaper.h" />
     <ClInclude Include="..\..\src\util\enum-converter.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2331,6 +2331,12 @@
     <ClCompile Include="..\..\src\object-enchant\smith-info.cpp">
       <Filter>object-enchant</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\timed-effect\timed-effects.cpp">
+      <Filter>timed-effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\timed-effect\player-stun.cpp">
+      <Filter>timed-effect</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5016,6 +5022,12 @@
     <ClInclude Include="..\..\src\object-enchant\smith-info.h">
       <Filter>object-enchant</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\timed-effect\timed-effects.h">
+      <Filter>timed-effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\timed-effect\player-stun.h">
+      <Filter>timed-effect</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\src\wall.bmp" />
@@ -5234,6 +5246,9 @@
     </Filter>
     <Filter Include="player-base">
       <UniqueIdentifier>{0bd4660d-028e-44be-a5fe-c7cc7d3d00c2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="timed-effect">
+      <UniqueIdentifier>{b9e618e1-f780-4f5f-9413-d0270ac53660}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -872,6 +872,9 @@ hengband_SOURCES = \
 	term/z-term.cpp term/z-term.h term/z-util.cpp term/z-util.h \
 	term/z-virt.cpp term/z-virt.h \
 	\
+	timed-effect/player-stun.cpp timed-effect/player-stun.h \
+	timed-effect/timed-effects.cpp timed-effect/timed-effects.h \
+	\
 	util/angband-files.cpp util/angband-files.h \
 	util/buffer-shaper.cpp util/buffer-shaper.h \
 	util/bit-flags-calculator.h \

--- a/src/action/action-limited.cpp
+++ b/src/action/action-limited.cpp
@@ -63,7 +63,7 @@ bool cmd_limit_image(player_type *player_ptr)
 
 bool cmd_limit_stun(player_type *player_ptr)
 {
-    if (player_ptr->stun) {
+    if (player_ptr->effects()->stun()->is_stunned()) {
         msg_print(_("頭が朦朧としていて集中できない！", "You are too stunned!"));
         return true;
     }

--- a/src/action/action-limited.cpp
+++ b/src/action/action-limited.cpp
@@ -14,6 +14,8 @@
 #include "system/floor-type-definition.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
 /*!

--- a/src/action/movement-execution.cpp
+++ b/src/action/movement-execution.cpp
@@ -160,8 +160,10 @@ void exe_movement(player_type *player_ptr, DIRECTION dir, bool do_pickup, bool b
     bool do_past = false;
     if (g_ptr->m_idx && (m_ptr->ml || p_can_enter || p_can_kill_walls)) {
         monster_race *r_ptr = &r_info[m_ptr->r_idx];
+        auto effects = player_ptr->effects();
+        auto is_stunned = effects->stun()->is_stunned();
         if (!is_hostile(m_ptr)
-            && !(player_ptr->confused || player_ptr->image || !m_ptr->ml || player_ptr->stun
+            && !(player_ptr->confused || player_ptr->image || !m_ptr->ml || is_stunned
                 || (player_ptr->muta.has(MUTA::BERS_RAGE) && is_shero(player_ptr)))
             && pattern_seq(player_ptr, player_ptr->y, player_ptr->x, y, x) && (p_can_enter || p_can_kill_walls)) {
             (void)set_monster_csleep(player_ptr, g_ptr->m_idx, 0);
@@ -271,10 +273,13 @@ void exe_movement(player_type *player_ptr, DIRECTION dir, bool do_pickup, bool b
                 lite_spot(player_ptr, y, x);
             }
         } else {
+            auto effects = player_ptr->effects();
+            auto is_stunned = effects->stun()->is_stunned();
             if (boundary_floor(g_ptr, f_ptr, mimic_f_ptr)) {
                 msg_print(_("それ以上先には進めない。", "You cannot go any more."));
-                if (!(player_ptr->confused || player_ptr->stun || player_ptr->image))
+                if (!(player_ptr->confused || is_stunned || player_ptr->image)) {
                     energy.reset_player_turn();
+                }
             } else {
                 if (easy_open && is_closed_door(player_ptr, feat) && easy_open_door(player_ptr, y, x))
                     return;
@@ -284,7 +289,7 @@ void exe_movement(player_type *player_ptr, DIRECTION dir, bool do_pickup, bool b
 #else
                 msg_format("There is %s %s blocking your way.", is_a_vowel(name[0]) ? "an" : "a", name);
 #endif
-                if (!(player_ptr->confused || player_ptr->stun || player_ptr->image))
+                if (!(player_ptr->confused || is_stunned || player_ptr->image))
                     energy.reset_player_turn();
             }
         }
@@ -295,8 +300,11 @@ void exe_movement(player_type *player_ptr, DIRECTION dir, bool do_pickup, bool b
     }
 
     if (can_move && !pattern_seq(player_ptr, player_ptr->y, player_ptr->x, y, x)) {
-        if (!(player_ptr->confused || player_ptr->stun || player_ptr->image))
+        auto effects = player_ptr->effects();
+        auto is_stunned = effects->stun()->is_stunned();
+        if (!(player_ptr->confused || is_stunned || player_ptr->image)) {
             energy.reset_player_turn();
+        }
 
         disturb(player_ptr, false, true);
         can_move = false;

--- a/src/action/movement-execution.cpp
+++ b/src/action/movement-execution.cpp
@@ -40,6 +40,8 @@
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
 #include "system/object-type-definition.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #ifdef JP

--- a/src/action/racial-execution.cpp
+++ b/src/action/racial-execution.cpp
@@ -48,8 +48,9 @@ PERCENTAGE racial_chance(player_type *player_ptr, rpi_type *rpi_ptr)
     if (difficulty == 0)
         return 100;
 
-    if (player_ptr->stun) {
-        difficulty += (PERCENTAGE)player_ptr->stun;
+    auto player_stun = player_ptr->effects()->stun();
+    if (player_stun->is_stunned()) {
+        difficulty += player_stun->current();
     } else if (player_ptr->lev > rpi_ptr->min_level) {
         PERCENTAGE lev_adj = (PERCENTAGE)((player_ptr->lev - rpi_ptr->min_level) / 3);
         if (lev_adj > 10)
@@ -88,8 +89,9 @@ static void adjust_racial_power_difficulty(player_type *player_ptr, rpi_type *rp
     if (*difficulty == 0)
         return;
 
-    if (player_ptr->stun) {
-        *difficulty += player_ptr->stun;
+    auto player_stun = player_ptr->effects()->stun();
+    if (player_stun->is_stunned()) {
+        *difficulty += player_stun->current();
     } else if (player_ptr->lev > rpi_ptr->min_level) {
         int lev_adj = ((player_ptr->lev - rpi_ptr->min_level) / 3);
         if (lev_adj > 10)

--- a/src/action/racial-execution.cpp
+++ b/src/action/racial-execution.cpp
@@ -15,6 +15,8 @@
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
 /*!

--- a/src/blue-magic/blue-magic-checker.cpp
+++ b/src/blue-magic/blue-magic-checker.cpp
@@ -20,6 +20,8 @@
 #include "status/experience.h"
 #include "system/angband.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
 /*!

--- a/src/blue-magic/blue-magic-checker.cpp
+++ b/src/blue-magic/blue-magic-checker.cpp
@@ -34,7 +34,10 @@ void learn_spell(player_type *player_ptr, int monspell)
         return;
     if (player_ptr->magic_num2[monspell])
         return;
-    if (player_ptr->confused || player_ptr->blind || player_ptr->image || player_ptr->stun || player_ptr->paralyzed)
+
+    auto effects = player_ptr->effects();
+    auto is_stunned = effects->stun()->is_stunned();
+    if (player_ptr->confused || player_ptr->blind || player_ptr->image || is_stunned || player_ptr->paralyzed)
         return;
     if (randint1(player_ptr->lev + 70) > monster_powers[monspell].level + 40) {
         player_ptr->magic_num2[monspell] = 1;

--- a/src/blue-magic/learnt-power-getter.cpp
+++ b/src/blue-magic/learnt-power-getter.cpp
@@ -22,6 +22,8 @@
 #include "spell/spell-info.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "util/enum-converter.h"
 #include "util/flag-group.h"
 #include "util/int-char-converter.h"
@@ -275,7 +277,7 @@ static void calculate_blue_magic_success_probability(player_type *player_ptr, le
         lm_ptr->chance = minfail;
 
     auto player_stun = player_ptr->effects()->stun();
-    lm_ptr->chance += player_stun->decrease_chance();
+    lm_ptr->chance += player_stun->get_chance_penalty();
     if (lm_ptr->chance > 95) {
         lm_ptr->chance = 95;
     }

--- a/src/blue-magic/learnt-power-getter.cpp
+++ b/src/blue-magic/learnt-power-getter.cpp
@@ -274,13 +274,11 @@ static void calculate_blue_magic_success_probability(player_type *player_ptr, le
     if (lm_ptr->chance < minfail)
         lm_ptr->chance = minfail;
 
-    if (player_ptr->stun > 50)
-        lm_ptr->chance += 25;
-    else if (player_ptr->stun)
-        lm_ptr->chance += 15;
-
-    if (lm_ptr->chance > 95)
+    auto player_stun = player_ptr->effects()->stun();
+    lm_ptr->chance += player_stun->decrease_chance();
+    if (lm_ptr->chance > 95) {
         lm_ptr->chance = 95;
+    }
 
     lm_ptr->chance = mod_spell_chance_2(player_ptr, lm_ptr->chance);
 }

--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -50,6 +50,7 @@
 #include "system/monster-type-definition.h"
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
+#include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "wizard/wizard-messages.h"
 
@@ -189,7 +190,9 @@ bool do_cmd_attack(player_type *player_ptr, POSITION y, POSITION x, combat_optio
         health_track(player_ptr, g_ptr->m_idx);
     }
 
-    if ((r_ptr->flags1 & RF1_FEMALE) && !(player_ptr->stun || player_ptr->confused || player_ptr->image || !m_ptr->ml)) {
+    auto effects = player_ptr->effects();
+    auto is_stunned = effects->stun()->is_stunned();
+    if (any_bits(r_ptr->flags1, RF1_FEMALE) && !(is_stunned || player_ptr->confused || player_ptr->image || !m_ptr->ml)) {
         if ((player_ptr->inventory_list[INVEN_MAIN_HAND].name1 == ART_ZANTETSU) || (player_ptr->inventory_list[INVEN_SUB_HAND].name1 == ART_ZANTETSU)) {
             msg_print(_("拙者、おなごは斬れぬ！", "I can not attack women!"));
             return false;
@@ -202,7 +205,7 @@ bool do_cmd_attack(player_type *player_ptr, POSITION y, POSITION x, combat_optio
     }
 
     bool stormbringer = false;
-    if (!is_hostile(m_ptr) && !(player_ptr->stun || player_ptr->confused || player_ptr->image || is_shero(player_ptr) || !m_ptr->ml)) {
+    if (!is_hostile(m_ptr) && !(is_stunned || player_ptr->confused || player_ptr->image || is_shero(player_ptr) || !m_ptr->ml)) {
         if (player_ptr->inventory_list[INVEN_MAIN_HAND].name1 == ART_STORMBRINGER)
             stormbringer = true;
         if (player_ptr->inventory_list[INVEN_SUB_HAND].name1 == ART_STORMBRINGER)

--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -50,6 +50,8 @@
 #include "system/monster-type-definition.h"
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "wizard/wizard-messages.h"

--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -212,15 +212,11 @@ static int get_mane_power(player_type *player_ptr, int *sn, bool baigaesi)
                     if (chance < minfail)
                         chance = minfail;
 
-                    /* Stunning makes spells harder */
-                    if (player_ptr->stun > 50)
-                        chance += 25;
-                    else if (player_ptr->stun)
-                        chance += 15;
-
-                    /* Always a 5 percent chance of working */
-                    if (chance > 95)
+                    auto player_stun = player_ptr->effects()->stun();
+                    chance += player_stun->decrease_chance();
+                    if (chance > 95) {
                         chance = 95;
+                    }
 
                     /* Get info */
                     mane_info(player_ptr, comment, player_ptr->mane_spell[i], (baigaesi ? player_ptr->mane_dam[i] * 2 : player_ptr->mane_dam[i]));
@@ -1116,15 +1112,11 @@ bool do_cmd_mane(player_type *player_ptr, bool baigaesi)
     if (chance < minfail)
         chance = minfail;
 
-    /* Stunning makes spells harder */
-    if (player_ptr->stun > 50)
-        chance += 25;
-    else if (player_ptr->stun)
-        chance += 15;
-
-    /* Always a 5 percent chance of working */
-    if (chance > 95)
+    auto player_stun = player_ptr->effects()->stun();
+    chance += player_stun->decrease_chance();
+    if (chance > 95) {
         chance = 95;
+    }
 
     /* Failed spell */
     if (randint0(100) < chance) {

--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -64,6 +64,8 @@
 #include "target/target-setter.h"
 #include "target/target-types.h"
 #include "term/screen-processor.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "util/enum-converter.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
@@ -213,7 +215,7 @@ static int get_mane_power(player_type *player_ptr, int *sn, bool baigaesi)
                         chance = minfail;
 
                     auto player_stun = player_ptr->effects()->stun();
-                    chance += player_stun->decrease_chance();
+                    chance += player_stun->get_chance_penalty();
                     if (chance > 95) {
                         chance = 95;
                     }
@@ -1113,7 +1115,7 @@ bool do_cmd_mane(player_type *player_ptr, bool baigaesi)
         chance = minfail;
 
     auto player_stun = player_ptr->effects()->stun();
-    chance += player_stun->decrease_chance();
+    chance += player_stun->get_chance_penalty();
     if (chance > 95) {
         chance = 95;
     }

--- a/src/cmd-action/cmd-mind.cpp
+++ b/src/cmd-action/cmd-mind.cpp
@@ -217,7 +217,7 @@ static void check_mind_mindcrafter(player_type *player_ptr, cm_type *cm_ptr)
     }
 
     if (cm_ptr->b < 90) {
-        set_stun(player_ptr, player_ptr->stun + randint1(8));
+        set_stun(player_ptr, player_ptr->effects()->stun()->current() + randint1(8));
         return;
     }
 

--- a/src/cmd-action/cmd-mind.cpp
+++ b/src/cmd-action/cmd-mind.cpp
@@ -47,6 +47,8 @@
 #include "system/grid-type-definition.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "util/buffer-shaper.h"
 #include "util/enum-converter.h"
 #include "view/display-messages.h"
@@ -176,7 +178,7 @@ static void decide_mind_chance(player_type *player_ptr, cm_type *cm_ptr)
         cm_ptr->chance = cm_ptr->minfail;
 
     auto player_stun = player_ptr->effects()->stun();
-    cm_ptr->chance += player_stun->decrease_chance();
+    cm_ptr->chance += player_stun->get_chance_penalty();
 
     if (cm_ptr->use_mind != mind_kind_type::KI)
         return;

--- a/src/cmd-action/cmd-mind.cpp
+++ b/src/cmd-action/cmd-mind.cpp
@@ -175,10 +175,8 @@ static void decide_mind_chance(player_type *player_ptr, cm_type *cm_ptr)
     if (cm_ptr->chance < cm_ptr->minfail)
         cm_ptr->chance = cm_ptr->minfail;
 
-    if (player_ptr->stun > 50)
-        cm_ptr->chance += 25;
-    else if (player_ptr->stun)
-        cm_ptr->chance += 15;
+    auto player_stun = player_ptr->effects()->stun();
+    cm_ptr->chance += player_stun->decrease_chance();
 
     if (cm_ptr->use_mind != mind_kind_type::KI)
         return;

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -429,8 +429,10 @@ void do_cmd_rest(player_type *player_ptr)
     if (command_arg > 100)
         chg_virtue(player_ptr, V_DILIGENCE, -1);
 
+    auto effects = player_ptr->effects();
+    auto is_stunned = effects->stun()->is_stunned();
     if ((player_ptr->chp == player_ptr->mhp) && (player_ptr->csp == player_ptr->msp) && !player_ptr->blind && !player_ptr->confused
-        && !player_ptr->poisoned && !player_ptr->afraid && !player_ptr->stun && !player_ptr->cut && !player_ptr->slow && !player_ptr->paralyzed
+        && !player_ptr->poisoned && !player_ptr->afraid && !is_stunned && !player_ptr->cut && !player_ptr->slow && !player_ptr->paralyzed
         && !player_ptr->image && !player_ptr->word_recall && !player_ptr->alter_reality)
         chg_virtue(player_ptr, V_DILIGENCE, -1);
 

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -36,6 +36,8 @@
 #include "system/grid-type-definition.h"
 #include "system/player-type-definition.h"
 #include "target/target-getter.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 

--- a/src/cmd-action/cmd-shoot.cpp
+++ b/src/cmd-action/cmd-shoot.cpp
@@ -67,9 +67,10 @@ void do_cmd_fire(player_type *player_ptr, SPELL_IDX snipe_type)
     if (snipe_type == SP_AWAY)
         teleport_player(player_ptr, 10 + (player_ptr->concent * 2), TELEPORT_SPONTANEOUS);
 
+    auto effects = player_ptr->effects();
     if (snipe_type == SP_FINAL) {
         msg_print(_("射撃の反動が体を襲った。", "The weapon's recoil stuns you. "));
         (void)set_slow(player_ptr, player_ptr->slow + randint0(7) + 7, false);
-        (void)set_stun(player_ptr, player_ptr->stun + randint1(25));
+        (void)set_stun(player_ptr, effects->stun()->current() + randint1(25));
     }
 }

--- a/src/cmd-action/cmd-shoot.cpp
+++ b/src/cmd-action/cmd-shoot.cpp
@@ -14,6 +14,8 @@
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
 /*!

--- a/src/cmd-building/cmd-inn.cpp
+++ b/src/cmd-building/cmd-inn.cpp
@@ -117,9 +117,10 @@ static bool has_a_nightmare(player_type *player_ptr)
  */
 static void back_to_health(player_type *player_ptr)
 {
+    auto effects = player_ptr->effects();
     set_blind(player_ptr, 0);
     set_confused(player_ptr, 0);
-    player_ptr->stun = 0;
+    effects->stun()->reset();
     player_ptr->chp = player_ptr->mhp;
     player_ptr->csp = player_ptr->msp;
 }

--- a/src/cmd-building/cmd-inn.cpp
+++ b/src/cmd-building/cmd-inn.cpp
@@ -12,6 +12,8 @@
 #include "status/bad-status-setter.h"
 #include "store/rumor.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 

--- a/src/cmd-item/cmd-magiceat.cpp
+++ b/src/cmd-item/cmd-magiceat.cpp
@@ -77,6 +77,8 @@
 #include "target/target-getter.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "util/buffer-shaper.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
@@ -279,7 +281,7 @@ static OBJECT_SUBTYPE_VALUE select_magic_eater(player_type *player_ptr, bool onl
                 chance = mod_spell_chance_1(player_ptr, chance);
                 chance = MAX(chance, adj_mag_fail[player_ptr->stat_index[mp_ptr->spell_stat]]);
                 auto player_stun = player_ptr->effects()->stun();
-                chance += player_stun->decrease_chance();
+                chance += player_stun->get_chance_penalty();
                 if (chance > 95) {
                     chance = 95;
                 }
@@ -530,7 +532,7 @@ bool do_cmd_magic_eater(player_type *player_ptr, bool only_browse, bool powerful
     chance = mod_spell_chance_1(player_ptr, chance);
     chance = MAX(chance, adj_mag_fail[player_ptr->stat_index[mp_ptr->spell_stat]]);
     auto player_stun = player_ptr->effects()->stun();
-    chance += player_stun->decrease_chance();
+    chance += player_stun->get_chance_penalty();
     if (chance > 95) {
         chance = 95;
     }

--- a/src/cmd-item/cmd-magiceat.cpp
+++ b/src/cmd-item/cmd-magiceat.cpp
@@ -278,14 +278,11 @@ static OBJECT_SUBTYPE_VALUE select_magic_eater(player_type *player_ptr, bool onl
                 }
                 chance = mod_spell_chance_1(player_ptr, chance);
                 chance = MAX(chance, adj_mag_fail[player_ptr->stat_index[mp_ptr->spell_stat]]);
-                /* Stunning makes spells harder */
-                if (player_ptr->stun > 50)
-                    chance += 25;
-                else if (player_ptr->stun)
-                    chance += 15;
-
-                if (chance > 95)
+                auto player_stun = player_ptr->effects()->stun();
+                chance += player_stun->decrease_chance();
+                if (chance > 95) {
                     chance = 95;
+                }
 
                 chance = mod_spell_chance_2(player_ptr, chance);
 
@@ -532,14 +529,11 @@ bool do_cmd_magic_eater(player_type *player_ptr, bool only_browse, bool powerful
     }
     chance = mod_spell_chance_1(player_ptr, chance);
     chance = MAX(chance, adj_mag_fail[player_ptr->stat_index[mp_ptr->spell_stat]]);
-    /* Stunning makes spells harder */
-    if (player_ptr->stun > 50)
-        chance += 25;
-    else if (player_ptr->stun)
-        chance += 15;
-
-    if (chance > 95)
+    auto player_stun = player_ptr->effects()->stun();
+    chance += player_stun->decrease_chance();
+    if (chance > 95) {
         chance = 95;
+    }
 
     chance = mod_spell_chance_2(player_ptr, chance);
 

--- a/src/core/magic-effects-timeout-reducer.cpp
+++ b/src/core/magic-effects-timeout-reducer.cpp
@@ -29,6 +29,7 @@ void reduce_magic_effects_timeout(player_type *player_ptr)
         (void)set_mimic(player_ptr, player_ptr->tim_mimic - 1, player_ptr->mimic_form, true);
     }
 
+    auto effects = player_ptr->effects();
     if (player_ptr->image) {
         (void)set_image(player_ptr, player_ptr->image - dec_count);
     }
@@ -210,9 +211,10 @@ void reduce_magic_effects_timeout(player_type *player_ptr)
         (void)set_poisoned(player_ptr, player_ptr->poisoned - adjust);
     }
 
-    if (player_ptr->stun) {
+    auto player_stun = effects->stun();
+    if (player_stun->is_stunned()) {
         int adjust = adj_con_fix[player_ptr->stat_index[A_CON]] + 1;
-        (void)set_stun(player_ptr, player_ptr->stun - adjust);
+        (void)set_stun(player_ptr, player_stun->current() - adjust);
     }
 
     if (player_ptr->cut) {

--- a/src/core/magic-effects-timeout-reducer.cpp
+++ b/src/core/magic-effects-timeout-reducer.cpp
@@ -17,6 +17,8 @@
 #include "status/sight-setter.h"
 #include "status/temporary-resistance.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 
 /*!
  * @brief 10ゲームターンが進行するごとに魔法効果の残りターンを減らしていく処理

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -51,6 +51,8 @@
 #include "system/monster-race-definition.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "window/display-sub-windows.h"
@@ -270,7 +272,7 @@ void process_player(player_type *player_ptr)
         PlayerEnergy energy(player_ptr);
         energy.reset_player_turn();
         auto effects = player_ptr->effects();
-        auto is_unconscious = effects->stun()->get_rank() == StunRank::UNCONSCIOUS;
+        auto is_unconscious = effects->stun()->get_rank() == PlayerStunRank::UNCONSCIOUS;
         if (player_ptr->phase_out) {
             move_cursor_relative(player_ptr->y, player_ptr->x);
             command_cmd = SPECIAL_KEY_BUILDING;

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -148,8 +148,10 @@ void process_player(player_type *player_ptr)
                 set_action(player_ptr, ACTION_NONE);
             }
         } else if (player_ptr->resting == COMMAND_ARG_REST_UNTIL_DONE) {
+            auto effects = player_ptr->effects();
+            auto is_stunned = effects->stun()->is_stunned();
             if ((player_ptr->chp == player_ptr->mhp) && (player_ptr->csp >= player_ptr->msp) && !player_ptr->blind && !player_ptr->confused
-                && !player_ptr->poisoned && !player_ptr->afraid && !player_ptr->stun && !player_ptr->cut && !player_ptr->slow
+                && !player_ptr->poisoned && !player_ptr->afraid && !is_stunned && !player_ptr->cut && !player_ptr->slow
                 && !player_ptr->paralyzed && !player_ptr->image && !player_ptr->word_recall && !player_ptr->alter_reality) {
                 set_action(player_ptr, ACTION_NONE);
             }
@@ -267,11 +269,13 @@ void process_player(player_type *player_ptr)
 
         PlayerEnergy energy(player_ptr);
         energy.reset_player_turn();
+        auto effects = player_ptr->effects();
+        auto is_unconscious = effects->stun()->get_rank() == StunRank::UNCONSCIOUS;
         if (player_ptr->phase_out) {
             move_cursor_relative(player_ptr->y, player_ptr->x);
             command_cmd = SPECIAL_KEY_BUILDING;
             process_command(player_ptr);
-        } else if ((player_ptr->paralyzed || player_ptr->stun >= 100) && !cheat_immortal) {
+        } else if ((player_ptr->paralyzed || is_unconscious) && !cheat_immortal) {
             energy.set_player_turn_energy(100);
         } else if (player_ptr->action == ACTION_REST) {
             if (player_ptr->resting > 0) {

--- a/src/effect/effect-monster-charm.cpp
+++ b/src/effect/effect-monster-charm.cpp
@@ -26,6 +26,8 @@
 #include "system/monster-race-definition.h"
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 

--- a/src/effect/effect-monster-charm.cpp
+++ b/src/effect/effect-monster-charm.cpp
@@ -214,7 +214,7 @@ static void effect_monster_domination_corrupted_addition(player_type *player_ptr
 {
     switch (randint1(4)) {
     case 1:
-        set_stun(player_ptr, player_ptr->stun + em_ptr->dam / 2);
+        set_stun(player_ptr, player_ptr->effects()->stun()->current() + em_ptr->dam / 2);
         break;
     case 2:
         set_confused(player_ptr, player_ptr->confused + em_ptr->dam / 2);

--- a/src/effect/effect-monster-psi.cpp
+++ b/src/effect/effect-monster-psi.cpp
@@ -17,6 +17,8 @@
 #include "system/monster-race-definition.h"
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "world/world.h"

--- a/src/effect/effect-monster-psi.cpp
+++ b/src/effect/effect-monster-psi.cpp
@@ -103,7 +103,7 @@ static void effect_monster_psi_reflect_extra_effect(player_type *player_ptr, eff
         set_confused(player_ptr, player_ptr->confused + 3 + randint1(em_ptr->dam));
         break;
     case 2:
-        set_stun(player_ptr, player_ptr->stun + randint1(em_ptr->dam));
+        set_stun(player_ptr, player_ptr->effects()->stun()->current() + randint1(em_ptr->dam));
         break;
     case 3: {
         if (any_bits(em_ptr->r_ptr->flags3, RF3_NO_FEAR))

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -30,6 +30,8 @@
 #include "status/shape-changer.h"
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -142,7 +142,7 @@ void effect_player_plasma(player_type *player_ptr, effect_player_type *ep_ptr)
 
     if (!has_resist_sound(player_ptr) && !check_multishadow(player_ptr)) {
         int plus_stun = (randint1((ep_ptr->dam > 40) ? 35 : (ep_ptr->dam * 3 / 4 + 5)));
-        (void)set_stun(player_ptr, player_ptr->stun + plus_stun);
+        (void)set_stun(player_ptr, player_ptr->effects()->stun()->current() + plus_stun);
     }
 
     if (!(has_resist_fire(player_ptr) || is_oppose_fire(player_ptr) || has_immune_fire(player_ptr)))
@@ -203,7 +203,7 @@ void effect_player_water(player_type *player_ptr, effect_player_type *ep_ptr)
 
     if (!check_multishadow(player_ptr)) {
         if (!has_resist_sound(player_ptr) && !has_res_water) {
-            set_stun(player_ptr, player_ptr->stun + randint1(40));
+            set_stun(player_ptr, player_ptr->effects()->stun()->current() + randint1(40));
         }
         if (!has_resist_conf(player_ptr) && !has_res_water) {
             set_confused(player_ptr, player_ptr->confused + randint1(5) + 5);
@@ -277,7 +277,7 @@ void effect_player_sound(player_type *player_ptr, effect_player_type *ep_ptr)
 
     if (!has_resist_sound(player_ptr) && !check_multishadow(player_ptr)) {
         int plus_stun = (randint1((ep_ptr->dam > 90) ? 35 : (ep_ptr->dam / 3 + 5)));
-        (void)set_stun(player_ptr, player_ptr->stun + plus_stun);
+        (void)set_stun(player_ptr, player_ptr->effects()->stun()->current() + plus_stun);
     }
 
     if (!has_resist_sound(player_ptr) || one_in_(13))
@@ -333,7 +333,7 @@ void effect_player_force(player_type *player_ptr, effect_player_type *ep_ptr)
     if (player_ptr->blind)
         msg_print(_("運動エネルギーで攻撃された！", "You are hit by kinetic force!"));
     if (!has_resist_sound(player_ptr) && !check_multishadow(player_ptr)) {
-        (void)set_stun(player_ptr, player_ptr->stun + randint1(20));
+        (void)set_stun(player_ptr, player_ptr->effects()->stun()->current() + randint1(20));
     }
 
     ep_ptr->get_damage = take_hit(player_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
@@ -344,7 +344,7 @@ void effect_player_rocket(player_type *player_ptr, effect_player_type *ep_ptr)
     if (player_ptr->blind)
         msg_print(_("爆発があった！", "There is an explosion!"));
     if (!has_resist_sound(player_ptr) && !check_multishadow(player_ptr)) {
-        (void)set_stun(player_ptr, player_ptr->stun + randint1(20));
+        (void)set_stun(player_ptr, player_ptr->effects()->stun()->current() + randint1(20));
     }
 
     ep_ptr->dam = ep_ptr->dam * calc_rocket_damage_rate(player_ptr, CALC_RAND) / 100;
@@ -525,7 +525,7 @@ void effect_player_gravity(player_type *player_ptr, effect_player_type *ep_ptr)
             (void)set_slow(player_ptr, player_ptr->slow + randint0(4) + 4, false);
         if (!(has_resist_sound(player_ptr) || player_ptr->levitation)) {
             int plus_stun = (randint1((ep_ptr->dam > 90) ? 35 : (ep_ptr->dam / 3 + 5)));
-            (void)set_stun(player_ptr, player_ptr->stun + plus_stun);
+            (void)set_stun(player_ptr, player_ptr->effects()->stun()->current() + plus_stun);
         }
     }
 
@@ -598,7 +598,7 @@ void effect_player_icee(player_type *player_ptr, effect_player_type *ep_ptr)
     }
 
     if (!has_resist_sound(player_ptr)) {
-        (void)set_stun(player_ptr, player_ptr->stun + randint1(15));
+        (void)set_stun(player_ptr, player_ptr->effects()->stun()->current() + randint1(15));
     }
 
     if ((!(has_resist_cold(player_ptr) || is_oppose_cold(player_ptr))) || one_in_(12)) {

--- a/src/floor/pattern-walk.cpp
+++ b/src/floor/pattern-walk.cpp
@@ -173,7 +173,9 @@ bool pattern_seq(player_type *player_ptr, POSITION c_y, POSITION c_x, POSITION n
     int pattern_type_cur = is_pattern_tile_cur ? cur_f_ptr->subtype : NOT_PATTERN_TILE;
     int pattern_type_new = is_pattern_tile_new ? new_f_ptr->subtype : NOT_PATTERN_TILE;
     if (pattern_type_new == PATTERN_TILE_START) {
-        if (!is_pattern_tile_cur && !player_ptr->confused && !player_ptr->stun && !player_ptr->image) {
+        auto effects = player_ptr->effects();
+        auto is_stunned = effects->stun()->is_stunned();
+        if (!is_pattern_tile_cur && !player_ptr->confused && !is_stunned && !player_ptr->image) {
             if (get_check(_("パターンの上を歩き始めると、全てを歩かなければなりません。いいですか？",
                     "If you start walking the Pattern, you must walk the whole way. Ok? ")))
                 return true;

--- a/src/floor/pattern-walk.cpp
+++ b/src/floor/pattern-walk.cpp
@@ -23,6 +23,8 @@
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "world/world-movement-processor.h"

--- a/src/load/item-loader.cpp
+++ b/src/load/item-loader.cpp
@@ -214,11 +214,11 @@ void rd_item(object_type *o_ptr)
         o_ptr->stack_idx = 0;
 
     if (any_bits(flags, SAVE_ITEM_SMITH) && !loading_savefile_version_is_older_than(7)) {
-        int16_t tmp16s;
         rd_s16b(&tmp16s);
         if (tmp16s > 0) {
             o_ptr->smith_effect = static_cast<SmithEffect>(tmp16s);
         }
+
         rd_s16b(&tmp16s);
         if (tmp16s > 0) {
             o_ptr->smith_act_idx = static_cast<random_art_activation_type>(tmp16s);

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -348,7 +348,8 @@ static void rd_status(player_type *player_ptr)
     rd_s16b(&player_ptr->slow);
     rd_s16b(&player_ptr->afraid);
     rd_s16b(&player_ptr->cut);
-    rd_s16b(&player_ptr->stun);
+    int16_t tmp16s = player_ptr->effects()->stun()->current();
+    rd_s16b(&tmp16s);
     rd_s16b(&player_ptr->poisoned);
     rd_s16b(&player_ptr->image);
     rd_s16b(&player_ptr->protevil);

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -18,6 +18,8 @@
 #include "spell-realm/spells-song.h"
 #include "system/floor-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "world/world.h"
 
 /*!

--- a/src/mind/mind-blue-mage.cpp
+++ b/src/mind/mind-blue-mage.cpp
@@ -70,13 +70,11 @@ bool do_cmd_cast_learned(player_type *player_ptr)
     if (chance < minfail)
         chance = minfail;
 
-    if (player_ptr->stun > 50)
-        chance += 25;
-    else if (player_ptr->stun)
-        chance += 15;
-
-    if (chance > 95)
+    auto player_stun = player_ptr->effects()->stun();
+    chance += player_stun->decrease_chance();
+    if (chance > 95) {
         chance = 95;
+    }
 
     chance = mod_spell_chance_2(player_ptr, chance);
     const auto spell_type = i2enum<RF_ABILITY>(n);

--- a/src/mind/mind-blue-mage.cpp
+++ b/src/mind/mind-blue-mage.cpp
@@ -20,6 +20,8 @@
 #include "status/base-status.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
 /*!
@@ -71,7 +73,7 @@ bool do_cmd_cast_learned(player_type *player_ptr)
         chance = minfail;
 
     auto player_stun = player_ptr->effects()->stun();
-    chance += player_stun->decrease_chance();
+    chance += player_stun->get_chance_penalty();
     if (chance > 95) {
         chance = 95;
     }

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -633,11 +633,8 @@ static PERCENTAGE decide_element_chance(player_type *player_ptr, mind_type spell
     if (chance < minfail)
         chance = minfail;
 
-    if (player_ptr->stun > 50)
-        chance += 25;
-    else if (player_ptr->stun)
-        chance += 15;
-
+    auto player_stun = player_ptr->effects()->stun();
+    chance += player_stun->decrease_chance();
     if (heavy_armor(player_ptr))
         chance += 5;
 

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -65,6 +65,8 @@
 #include "target/target-getter.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "util/buffer-shaper.h"
 #include "util/enum-converter.h"
@@ -634,7 +636,7 @@ static PERCENTAGE decide_element_chance(player_type *player_ptr, mind_type spell
         chance = minfail;
 
     auto player_stun = player_ptr->effects()->stun();
-    chance += player_stun->decrease_chance();
+    chance += player_stun->get_chance_penalty();
     if (heavy_armor(player_ptr))
         chance += 5;
 

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -55,6 +55,8 @@
 #include "target/projection-path-calculator.h"
 #include "target/target-checker.h"
 #include "target/target-getter.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -68,13 +68,18 @@ bool kawarimi(player_type *player_ptr, bool success)
 {
     object_type forge;
     object_type *q_ptr = &forge;
+    if (player_ptr->is_dead) {
+        return false;
+    }
 
-    if (player_ptr->is_dead)
+    auto effects = player_ptr->effects();
+    if (player_ptr->confused || player_ptr->blind || player_ptr->paralyzed || player_ptr->image) {
         return false;
-    if (player_ptr->confused || player_ptr->blind || player_ptr->paralyzed || player_ptr->image)
+    }
+
+    if (effects->stun()->current() > randint0(200)) {
         return false;
-    if (randint0(200) < player_ptr->stun)
-        return false;
+    }
 
     if (!success && one_in_(3)) {
         msg_print(_("変わり身失敗！逃げられなかった。", "Kawarimi failed! You couldn't run away."));

--- a/src/mind/mind-power-getter.cpp
+++ b/src/mind/mind-power-getter.cpp
@@ -16,6 +16,8 @@
 #include "player/player-status-table.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "util/enum-converter.h"
 #include "util/int-char-converter.h"
 
@@ -301,7 +303,7 @@ void MindPowerGetter::calculate_mind_chance(bool *has_weapon)
     }
 
     auto player_stun = this->player_ptr->effects()->stun();
-    this->chance += player_stun->decrease_chance();
+    this->chance += player_stun->get_chance_penalty();
     add_ki_chance();
     if (this->chance > 95) {
         this->chance = 95;

--- a/src/mind/mind-power-getter.cpp
+++ b/src/mind/mind-power-getter.cpp
@@ -300,12 +300,8 @@ void MindPowerGetter::calculate_mind_chance(bool *has_weapon)
         this->chance = minfail;
     }
 
-    if (this->player_ptr->stun > 50) {
-        this->chance += 25;
-    } else if (this->player_ptr->stun) {
-        this->chance += 15;
-    }
-
+    auto player_stun = this->player_ptr->effects()->stun();
+    this->chance += player_stun->decrease_chance();
     add_ki_chance();
     if (this->chance > 95) {
         this->chance = 95;

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -339,7 +339,8 @@ bool choose_kata(player_type *player_ptr)
     if (cmd_limit_confused(player_ptr))
         return false;
 
-    if (player_ptr->stun) {
+    auto effects = player_ptr->effects();
+    if (effects->stun()->is_stunned()) {
         msg_print(_("意識がはっきりとしない。", "You are not clear-headed"));
         return false;
     }

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -33,6 +33,8 @@
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"

--- a/src/mind/monk-attack.cpp
+++ b/src/mind/monk-attack.cpp
@@ -99,7 +99,9 @@ static int select_blow(player_type *player_ptr, player_attack_type *pa_ptr, int 
                 min_level = pa_ptr->ma_ptr->min_level;
         } while ((min_level > player_ptr->lev) || (randint1(player_ptr->lev) < pa_ptr->ma_ptr->chance));
 
-        if ((pa_ptr->ma_ptr->min_level <= old_ptr->min_level) || player_ptr->stun || player_ptr->confused) {
+        auto effects = player_ptr->effects();
+        auto is_stunned = effects->stun()->is_stunned();
+        if ((pa_ptr->ma_ptr->min_level <= old_ptr->min_level) || is_stunned || player_ptr->confused) {
             pa_ptr->ma_ptr = old_ptr;
             continue;
         }

--- a/src/mind/monk-attack.cpp
+++ b/src/mind/monk-attack.cpp
@@ -29,6 +29,8 @@
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
 #include "target/target-getter.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "util/string-processor.h"
 #include "view/display-messages.h"
 #include "world/world.h"

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -238,7 +238,7 @@ static void calc_player_stun(player_type *player_ptr, monap_type *monap_ptr)
     }
 
     if (stun_plus > 0) {
-        (void)set_stun(player_ptr, player_ptr->stun + stun_plus);
+        (void)set_stun(player_ptr, player_ptr->effects()->stun()->current() + stun_plus);
     }
 }
 

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -50,6 +50,8 @@
 #include "system/monster-type-definition.h"
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 

--- a/src/monster-attack/monster-attack-status.cpp
+++ b/src/monster-attack/monster-attack-status.cpp
@@ -126,7 +126,7 @@ void process_stun_attack(player_type *player_ptr, monap_type *monap_ptr)
     }
 
     auto *r_ptr = &r_info[monap_ptr->m_ptr->r_idx];
-    if (set_stun(player_ptr, player_ptr->stun + 10 + randint1(r_ptr->level / 4)))
+    if (set_stun(player_ptr, player_ptr->effects()->stun()->current() + 10 + randint1(r_ptr->level / 4)))
         monap_ptr->obvious = true;
 }
 

--- a/src/monster-attack/monster-attack-status.cpp
+++ b/src/monster-attack/monster-attack-status.cpp
@@ -17,6 +17,8 @@
 #include "system/monster-race-definition.h"
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
 void process_blind_attack(player_type *player_ptr, monap_type *monap_ptr)

--- a/src/object-use/quaff-execution.cpp
+++ b/src/object-use/quaff-execution.cpp
@@ -101,7 +101,7 @@ static bool detonation(player_type *player_ptr)
 {
     msg_print(_("体の中で激しい爆発が起きた！", "Massive explosions rupture your body!"));
     take_hit(player_ptr, DAMAGE_NOESCAPE, damroll(50, 20), _("爆発の薬", "a potion of Detonation"));
-    (void)set_stun(player_ptr, player_ptr->stun + 75);
+    (void)set_stun(player_ptr, player_ptr->effects()->stun()->current() + 75);
     (void)set_cut(player_ptr, player_ptr->cut + 5000);
     return true;
 }

--- a/src/object-use/quaff-execution.cpp
+++ b/src/object-use/quaff-execution.cpp
@@ -49,6 +49,8 @@
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
 /*!

--- a/src/player-info/self-info.cpp
+++ b/src/player-info/self-info.cpp
@@ -27,6 +27,8 @@
 #include "player/player-status.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-self-info.h"
 
 static void set_bad_status_info(player_type *player_ptr, self_info_type *self_ptr)

--- a/src/player-info/self-info.cpp
+++ b/src/player-info/self-info.cpp
@@ -31,6 +31,7 @@
 
 static void set_bad_status_info(player_type *player_ptr, self_info_type *self_ptr)
 {
+    auto effects = player_ptr->effects();
     if (player_ptr->blind)
         self_ptr->info[self_ptr->line++] = _("あなたは目が見えない。", "You cannot see.");
 
@@ -43,7 +44,8 @@ static void set_bad_status_info(player_type *player_ptr, self_info_type *self_pt
     if (player_ptr->cut)
         self_ptr->info[self_ptr->line++] = _("あなたは出血している。", "You are bleeding.");
 
-    if (player_ptr->stun)
+    auto is_stunned = effects->stun()->is_stunned();
+    if (is_stunned)
         self_ptr->info[self_ptr->line++] = _("あなたはもうろうとしている。", "You are stunned.");
 
     if (player_ptr->poisoned)

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -100,6 +100,8 @@
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "util/enum-converter.h"
 #include "util/quarks.h"
@@ -1969,7 +1971,7 @@ static int16_t calc_to_damage(player_type *player_ptr, INVENTORY_IDX slot, bool 
     }
 
     auto player_stun = player_ptr->effects()->stun();
-    damage -= player_stun->decrease_damage();
+    damage -= player_stun->get_damage_penalty();
     if ((player_ptr->pclass == CLASS_PRIEST) && (flgs.has_not(TR_BLESSED)) && ((o_ptr->tval == TV_SWORD) || (o_ptr->tval == TV_POLEARM))) {
         damage -= 2;
     } else if (player_ptr->pclass == CLASS_BERSERKER) {
@@ -2114,7 +2116,7 @@ static int16_t calc_to_hit(player_type *player_ptr, INVENTORY_IDX slot, bool is_
     }
 
     auto player_stun = player_ptr->effects()->stun();
-    hit -= player_stun->decrease_damage();
+    hit -= player_stun->get_damage_penalty();
     player_hand calc_hand = PLAYER_HAND_OTHER;
     if (slot == INVEN_MAIN_HAND)
         calc_hand = PLAYER_HAND_MAIN;
@@ -2335,7 +2337,7 @@ static int16_t calc_to_hit_bow(player_type *player_ptr, bool is_real_value)
     }
 
     auto player_stun = player_ptr->effects()->stun();
-    pow -= player_stun->decrease_damage();
+    pow -= player_stun->get_damage_penalty();
     if (is_blessed(player_ptr)) {
         pow += 10;
     }
@@ -2410,7 +2412,7 @@ static int16_t calc_to_damage_misc(player_type *player_ptr)
     }
 
     auto player_stun = player_ptr->effects()->stun();
-    to_dam -= player_stun->decrease_damage();
+    to_dam -= player_stun->get_damage_penalty();
     to_dam += ((int)(adj_str_td[player_ptr->stat_index[A_STR]]) - 128);
     return to_dam;
 }
@@ -2447,7 +2449,7 @@ static int16_t calc_to_hit_misc(player_type *player_ptr)
     }
 
     auto player_stun = player_ptr->effects()->stun();
-    to_hit -= player_stun->decrease_damage();
+    to_hit -= player_stun->get_damage_penalty();
     to_hit += ((int)(adj_dex_th[player_ptr->stat_index[A_DEX]]) - 128);
     to_hit += ((int)(adj_str_th[player_ptr->stat_index[A_STR]]) - 128);
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -1968,12 +1968,8 @@ static int16_t calc_to_damage(player_type *player_ptr, INVENTORY_IDX slot, bool 
         damage += 3 + (player_ptr->lev / 5);
     }
 
-    if (player_ptr->stun > 50) {
-        damage -= 20;
-    } else if (player_ptr->stun) {
-        damage -= 5;
-    }
-
+    auto player_stun = player_ptr->effects()->stun();
+    damage -= player_stun->decrease_damage();
     if ((player_ptr->pclass == CLASS_PRIEST) && (flgs.has_not(TR_BLESSED)) && ((o_ptr->tval == TV_SWORD) || (o_ptr->tval == TV_POLEARM))) {
         damage -= 2;
     } else if (player_ptr->pclass == CLASS_BERSERKER) {
@@ -2117,12 +2113,8 @@ static int16_t calc_to_hit(player_type *player_ptr, INVENTORY_IDX slot, bool is_
         hit += 12;
     }
 
-    if (player_ptr->stun > 50) {
-        hit -= 20;
-    } else if (player_ptr->stun) {
-        hit -= 5;
-    }
-
+    auto player_stun = player_ptr->effects()->stun();
+    hit -= player_stun->decrease_damage();
     player_hand calc_hand = PLAYER_HAND_OTHER;
     if (slot == INVEN_MAIN_HAND)
         calc_hand = PLAYER_HAND_MAIN;
@@ -2342,12 +2334,8 @@ static int16_t calc_to_hit_bow(player_type *player_ptr, bool is_real_value)
         }
     }
 
-    if (player_ptr->stun > 50) {
-        pow -= 20;
-    } else if (player_ptr->stun) {
-        pow -= 5;
-    }
-
+    auto player_stun = player_ptr->effects()->stun();
+    pow -= player_stun->decrease_damage();
     if (is_blessed(player_ptr)) {
         pow += 10;
     }
@@ -2421,12 +2409,8 @@ static int16_t calc_to_damage_misc(player_type *player_ptr)
         to_dam += 3 + (player_ptr->lev / 5);
     }
 
-    if (player_ptr->stun > 50) {
-        to_dam -= 20;
-    } else if (player_ptr->stun) {
-        to_dam -= 5;
-    }
-
+    auto player_stun = player_ptr->effects()->stun();
+    to_dam -= player_stun->decrease_damage();
     to_dam += ((int)(adj_str_td[player_ptr->stat_index[A_STR]]) - 128);
     return to_dam;
 }
@@ -2462,12 +2446,8 @@ static int16_t calc_to_hit_misc(player_type *player_ptr)
         to_hit += 12;
     }
 
-    if (player_ptr->stun > 50) {
-        to_hit -= 20;
-    } else if (player_ptr->stun) {
-        to_hit -= 5;
-    }
-
+    auto player_stun = player_ptr->effects()->stun();
+    to_hit -= player_stun->decrease_damage();
     to_hit += ((int)(adj_dex_th[player_ptr->stat_index[A_DEX]]) - 128);
     to_hit += ((int)(adj_str_th[player_ptr->stat_index[A_STR]]) - 128);
 

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -7,6 +7,8 @@
 #include "system/building-type-definition.h"
 #include "system/floor-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "world/world.h"
 
 /*!

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -136,6 +136,7 @@ void wr_player(player_type *player_ptr)
     wr_s16b(player_ptr->sc);
     wr_s16b(player_ptr->concent);
 
+    auto effects = player_ptr->effects();
     wr_s16b(0); /* old "rest" */
     wr_s16b(player_ptr->blind);
     wr_s16b(player_ptr->paralyzed);
@@ -149,7 +150,7 @@ void wr_player(player_type *player_ptr)
     wr_s16b(player_ptr->slow);
     wr_s16b(player_ptr->afraid);
     wr_s16b(player_ptr->cut);
-    wr_s16b(player_ptr->stun);
+    wr_s16b(effects->stun()->current());
     wr_s16b(player_ptr->poisoned);
     wr_s16b(player_ptr->image);
     wr_s16b(player_ptr->protevil);

--- a/src/specific-object/chest.cpp
+++ b/src/specific-object/chest.cpp
@@ -25,6 +25,8 @@
 #include "system/floor-type-definition.h"
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
 /*!< この値以降の小項目IDを持った箱は大型の箱としてドロップ数を増やす / Special "sval" limit -- first "large" chest */

--- a/src/specific-object/chest.cpp
+++ b/src/specific-object/chest.cpp
@@ -276,10 +276,12 @@ void chest_trap(player_type *player_ptr, POSITION y, POSITION x, OBJECT_IDX o_id
                 else if (one_in_(5))
                     (void)set_cut(player_ptr, player_ptr->cut + 200);
                 else if (one_in_(4)) {
-                    if (!player_ptr->free_act)
+                    auto effects = player_ptr->effects(); // @todo paralyzed と共通化の予定あり.
+                    if (!player_ptr->free_act) {
                         (void)set_paralyzed(player_ptr, player_ptr->paralyzed + 2 + randint0(6));
-                    else
-                        (void)set_stun(player_ptr, player_ptr->stun + 10 + randint0(100));
+                    } else {
+                        (void)set_stun(player_ptr, effects->stun()->current() + 10 + randint0(100));
+                    }
                 } else if (one_in_(3))
                     apply_disenchant(player_ptr, 0);
                 else if (one_in_(2)) {

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -137,6 +137,8 @@ bool earthquake(player_type *player_ptr, POSITION cy, POSITION cx, POSITION r, M
             msg_print(_("あなたはひどい怪我を負った！", "You are severely crushed!"));
             damage = 200;
         } else {
+            auto effects = player_ptr->effects();
+            auto stun_value = effects->stun()->current();
             switch (randint1(3)) {
             case 1: {
                 msg_print(_("降り注ぐ岩をうまく避けた！", "You nimbly dodge the blast!"));
@@ -146,13 +148,13 @@ bool earthquake(player_type *player_ptr, POSITION cy, POSITION cx, POSITION r, M
             case 2: {
                 msg_print(_("岩石があなたに直撃した!", "You are bashed by rubble!"));
                 damage = damroll(10, 4);
-                (void)set_stun(player_ptr, player_ptr->stun + randint1(50));
+                (void)set_stun(player_ptr, stun_value + randint1(50));
                 break;
             }
             case 3: {
                 msg_print(_("あなたは床と壁との間に挟まれてしまった！", "You are crushed between the floor and ceiling!"));
                 damage = damroll(10, 4);
-                (void)set_stun(player_ptr, player_ptr->stun + randint1(50));
+                (void)set_stun(player_ptr, stun_value + randint1(50));
                 break;
             }
             }

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -36,6 +36,8 @@
 #include "system/monster-race-definition.h"
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 

--- a/src/spell/spell-info.cpp
+++ b/src/spell/spell-info.cpp
@@ -193,13 +193,11 @@ PERCENTAGE spell_chance(player_type *player_ptr, SPELL_IDX spell, int16_t use_re
     if (chance < minfail)
         chance = minfail;
 
-    if (player_ptr->stun > 50)
-        chance += 25;
-    else if (player_ptr->stun)
-        chance += 15;
-
-    if (chance > 95)
+    auto player_stun = player_ptr->effects()->stun();
+    chance += player_stun->decrease_chance();
+    if (chance > 95) {
         chance = 95;
+    }
 
     if ((use_realm == player_ptr->realm1) || (use_realm == player_ptr->realm2) || (player_ptr->pclass == CLASS_SORCERER)
         || (player_ptr->pclass == CLASS_RED_MAGE)) {

--- a/src/spell/spell-info.cpp
+++ b/src/spell/spell-info.cpp
@@ -14,6 +14,8 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
@@ -194,7 +196,7 @@ PERCENTAGE spell_chance(player_type *player_ptr, SPELL_IDX spell, int16_t use_re
         chance = minfail;
 
     auto player_stun = player_ptr->effects()->stun();
-    chance += player_stun->decrease_chance();
+    chance += player_stun->get_chance_penalty();
     if (chance > 95) {
         chance = 95;
     }

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -442,15 +442,17 @@ bool set_stun(player_type *player_ptr, TIME_EFFECT v)
         notice = true;
     }
 
-    player_ptr->stun = v;
-
-    if (!notice)
+    player_stun->set(v);
+    if (!notice) {
         return false;
+    }
 
-    if (disturb_state)
+    if (disturb_state) {
         disturb(player_ptr, false, false);
-    player_ptr->update |= (PU_BONUS);
-    player_ptr->redraw |= (PR_STUN);
+    }
+
+    player_ptr->update |= PU_BONUS;
+    player_ptr->redraw |= PR_STUN;
     handle_stuff(player_ptr);
     return true;
 }

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -383,7 +383,6 @@ bool set_slow(player_type *player_ptr, TIME_EFFECT v, bool do_dec)
  */
 bool set_stun(player_type *player_ptr, TIME_EFFECT v)
 {
-    int old_aux, new_aux;
     bool notice = false;
     v = (v > 10000) ? 10000 : (v < 0) ? 0 : v;
     if (player_ptr->is_dead)
@@ -391,39 +390,12 @@ bool set_stun(player_type *player_ptr, TIME_EFFECT v)
     if (PlayerRace(player_ptr).equals(player_race_type::GOLEM) || PlayerClass(player_ptr).can_resist_stun())
         v = 0;
 
-    if (player_ptr->stun > 100) {
-        old_aux = 3;
-    } else if (player_ptr->stun > 50) {
-        old_aux = 2;
-    } else if (player_ptr->stun > 0) {
-        old_aux = 1;
-    } else {
-        old_aux = 0;
-    }
-
-    if (v > 100) {
-        new_aux = 3;
-    } else if (v > 50) {
-        new_aux = 2;
-    } else if (v > 0) {
-        new_aux = 1;
-    } else {
-        new_aux = 0;
-    }
-
+    auto player_stun = player_ptr->effects()->stun();
+    auto old_aux = player_stun->get_rank();
+    auto new_aux = player_stun->get_rank(v);
     if (new_aux > old_aux) {
-        switch (new_aux) {
-        case 1:
-            msg_print(_("意識がもうろうとしてきた。", "You have been stunned."));
-            break;
-        case 2:
-            msg_print(_("意識がひどくもうろうとしてきた。", "You have been heavily stunned."));
-            break;
-        case 3:
-            msg_print(_("頭がクラクラして意識が遠のいてきた。", "You have been knocked out."));
-            break;
-        }
-
+        auto stun_mes = player_stun->get_stun_mes(new_aux);
+        msg_print(stun_mes.data());
         if (randint1(1000) < v || one_in_(16)) {
             msg_print(_("割れるような頭痛がする。", "A vicious blow hits your head."));
 
@@ -461,7 +433,7 @@ bool set_stun(player_type *player_ptr, TIME_EFFECT v)
 
         notice = true;
     } else if (new_aux < old_aux) {
-        if (new_aux == 0) {
+        if (new_aux == StunRank::NONE) {
             msg_print(_("やっと朦朧状態から回復した。", "You are no longer stunned."));
             if (disturb_state)
                 disturb(player_ptr, false, false);

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -17,6 +17,8 @@
 #include "status/base-status.h"
 #include "status/buff-setter.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
 /*!
@@ -392,9 +394,9 @@ bool set_stun(player_type *player_ptr, TIME_EFFECT v)
 
     auto player_stun = player_ptr->effects()->stun();
     auto old_aux = player_stun->get_rank();
-    auto new_aux = player_stun->get_rank(v);
+    auto new_aux = PlayerStun::get_rank(v);
     if (new_aux > old_aux) {
-        auto stun_mes = player_stun->get_stun_mes(new_aux);
+        auto stun_mes = PlayerStun::get_stun_mes(new_aux);
         msg_print(stun_mes.data());
         if (randint1(1000) < v || one_in_(16)) {
             msg_print(_("割れるような頭痛がする。", "A vicious blow hits your head."));
@@ -433,7 +435,7 @@ bool set_stun(player_type *player_ptr, TIME_EFFECT v)
 
         notice = true;
     } else if (new_aux < old_aux) {
-        if (new_aux == StunRank::NONE) {
+        if (new_aux == PlayerStunRank::NONE) {
             msg_print(_("やっと朦朧状態から回復した。", "You are no longer stunned."));
             if (disturb_state)
                 disturb(player_ptr, false, false);

--- a/src/status/buff-setter.cpp
+++ b/src/status/buff-setter.cpp
@@ -18,6 +18,8 @@
 #include "status/buff-setter.h"
 #include "status/element-resistance.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
 /*!

--- a/src/status/buff-setter.cpp
+++ b/src/status/buff-setter.cpp
@@ -25,6 +25,7 @@
  */
 void reset_tim_flags(player_type *player_ptr)
 {
+    auto effects = player_ptr->effects();
     player_ptr->fast = 0; /* Timed -- Fast */
     player_ptr->lightspeed = 0;
     player_ptr->slow = 0; /* Timed -- Slow */
@@ -35,7 +36,7 @@ void reset_tim_flags(player_type *player_ptr)
     player_ptr->image = 0; /* Timed -- Hallucination */
     player_ptr->poisoned = 0; /* Timed -- Poisoned */
     player_ptr->cut = 0; /* Timed -- Cut */
-    player_ptr->stun = 0; /* Timed -- Stun */
+    effects->stun()->reset();
 
     player_ptr->protevil = 0; /* Timed -- Protection */
     player_ptr->invuln = 0; /* Timed -- Invulnerable */

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -1,4 +1,6 @@
 ﻿#include "system/player-type-definition.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 
 /*!
  * @brief プレイヤー構造体実体 / Static player info record
@@ -9,6 +11,11 @@ player_type p_body;
  * @brief プレイヤー構造体へのグローバル参照ポインタ / Pointer to the player info
  */
 player_type *p_ptr = &p_body;
+
+player_type::player_type()
+    : timed_effects(std::make_shared<TimedEffects>())
+{
+}
 
 std::shared_ptr<TimedEffects> player_type::effects() const
 {

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -9,3 +9,8 @@ player_type p_body;
  * @brief プレイヤー構造体へのグローバル参照ポインタ / Pointer to the player info
  */
 player_type *p_ptr = &p_body;
+
+std::shared_ptr<TimedEffects> player_type::effects() const
+{
+    return this->timed_effects;
+}

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -10,6 +10,7 @@
 #include "player/player-sex.h"
 #include "system/angband.h"
 #include "system/system-variables.h"
+#include "timed-effect/timed-effects.h"
 #include "util/flag-group.h"
 
 #define MAX_SKILLS 10
@@ -19,8 +20,9 @@ enum class RF_ABILITY;
 
 struct floor_type;
 struct object_type;
-;
-typedef struct player_type {
+class TimedEffects;
+struct player_type {
+public:
     int player_uid{};
     int player_euid{};
     int player_egid{};
@@ -423,6 +425,11 @@ typedef struct player_type {
     POSITION x{}; /*!< ダンジョンの現在X座標 / Player location in dungeon */
     GAME_TEXT name[32]{}; /*!< 現在のプレイヤー名 / Current player's character name */
     char base_name[32]{}; /*!< Stripped version of "player_name" */
-} player_type;
+
+    std::shared_ptr<TimedEffects> effects() const;
+
+private:
+    std::shared_ptr<TimedEffects> timed_effects = std::shared_ptr<TimedEffects>(new TimedEffects());
+};
 
 extern player_type *p_ptr;

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -10,7 +10,6 @@
 #include "player/player-sex.h"
 #include "system/angband.h"
 #include "system/system-variables.h"
-#include "timed-effect/timed-effects.h"
 #include "util/flag-group.h"
 
 #define MAX_SKILLS 10
@@ -23,6 +22,7 @@ struct object_type;
 class TimedEffects;
 struct player_type {
 public:
+    player_type();
     int player_uid{};
     int player_euid{};
     int player_egid{};
@@ -428,7 +428,7 @@ public:
     std::shared_ptr<TimedEffects> effects() const;
 
 private:
-    std::shared_ptr<TimedEffects> timed_effects = std::shared_ptr<TimedEffects>(new TimedEffects());
+    std::shared_ptr<TimedEffects> timed_effects;
 };
 
 extern player_type *p_ptr;

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -98,8 +98,7 @@ public:
     TIME_EFFECT image{}; /* Timed -- Hallucination */
     TIME_EFFECT poisoned{}; /* Timed -- Poisoned */
     TIME_EFFECT cut{}; /* Timed -- Cut */
-    TIME_EFFECT stun{}; /* Timed -- Stun */
-
+    
     TIME_EFFECT protevil{}; /* Timed -- Protection */
     TIME_EFFECT invuln{}; /* Timed -- Invulnerable */
     TIME_EFFECT ult_res{}; /* Timed -- Ultimate Resistance */

--- a/src/timed-effect/player-stun.cpp
+++ b/src/timed-effect/player-stun.cpp
@@ -1,8 +1,30 @@
 ﻿#include "timed-effect/player-stun.h"
 
-short PlayerStun::current()
+short PlayerStun::current() const
 {
     return this->stun;
+}
+
+StunRank PlayerStun::get_rank() const
+{
+    return this->get_rank(this->stun);
+}
+
+StunRank PlayerStun::get_rank(short value) const
+{
+    if (value > 100) {
+        return StunRank::UNCONSCIOUS;
+    }
+
+    if (value > 50) {
+        return StunRank::HARD;
+    }
+
+    if (value > 0) {
+        return StunRank::NORMAL;
+    }
+
+    return StunRank::NONE;
 }
 
 void PlayerStun::set(short value)

--- a/src/timed-effect/player-stun.cpp
+++ b/src/timed-effect/player-stun.cpp
@@ -52,4 +52,10 @@ int PlayerStun::decrease_chance() const
 
 void PlayerStun::set(short value)
 {
+    this->stun = value;
+}
+
+void PlayerStun::reset()
+{
+    this->set(0);
 }

--- a/src/timed-effect/player-stun.cpp
+++ b/src/timed-effect/player-stun.cpp
@@ -67,6 +67,30 @@ int PlayerStun::decrease_chance() const
     }
 }
 
+/*!
+ * @brief 朦朧ランクに応じてダメージ量 or 命中率を下げる.
+ * @return 朦朧ならば5、ひどく朦朧ならば20.
+ * @details
+ * 呼び出し元で減算しているのでこのメソッドでは正値.
+ * 意識不明瞭ならばそもそも動けないのでこのメソッドを通らない.
+ * しかし今後の拡張を考慮して100としておく.
+ */
+short PlayerStun::decrease_damage() const
+{
+    switch (this->get_rank()) {
+    case StunRank::NONE:
+        return 0;
+    case StunRank::NORMAL:
+        return 5;
+    case StunRank::HARD:
+        return 20;
+    case StunRank::UNCONSCIOUS:
+        return 100;
+    default:
+        throw("Invalid stun rank is specified!");
+    }
+}
+
 bool PlayerStun::is_stunned() const
 {
     return this->get_rank() > StunRank::NONE;

--- a/src/timed-effect/player-stun.cpp
+++ b/src/timed-effect/player-stun.cpp
@@ -6,38 +6,38 @@ short PlayerStun::current() const
     return this->stun;
 }
 
-StunRank PlayerStun::get_rank() const
+PlayerStunRank PlayerStun::get_rank() const
 {
     return this->get_rank(this->stun);
 }
 
-StunRank PlayerStun::get_rank(short value) const
+PlayerStunRank PlayerStun::get_rank(short value)
 {
     if (value > 100) {
-        return StunRank::UNCONSCIOUS;
+        return PlayerStunRank::UNCONSCIOUS;
     }
 
     if (value > 50) {
-        return StunRank::HARD;
+        return PlayerStunRank::HARD;
     }
 
     if (value > 0) {
-        return StunRank::NORMAL;
+        return PlayerStunRank::NORMAL;
     }
 
-    return StunRank::NONE;
+    return PlayerStunRank::NONE;
 }
 
-std::string_view PlayerStun::get_stun_mes(StunRank stun_rank) const
+std::string_view PlayerStun::get_stun_mes(PlayerStunRank stun_rank)
 {
     switch (stun_rank) {
-    case StunRank::NONE:
+    case PlayerStunRank::NONE:
         return "";
-    case StunRank::NORMAL:
+    case PlayerStunRank::NORMAL:
         return _("意識がもうろうとしてきた。", "You have been stunned.");
-    case StunRank::HARD:
+    case PlayerStunRank::HARD:
         return _("意識がひどくもうろうとしてきた。", "You have been heavily stunned.");
-    case StunRank::UNCONSCIOUS:
+    case PlayerStunRank::UNCONSCIOUS:
         return _("頭がクラクラして意識が遠のいてきた。", "You have been knocked out.");
     default:
         throw("Invalid StunRank was specified!");
@@ -51,16 +51,16 @@ std::string_view PlayerStun::get_stun_mes(StunRank stun_rank) const
  * 意識不明瞭ならばそもそも動けないのでこのメソッドを通らない.
  * しかし今後の拡張を考慮して100%としておく.
  */
-int PlayerStun::decrease_chance() const
+int PlayerStun::get_chance_penalty() const
 {
     switch (this->get_rank()) {
-    case StunRank::NONE:
+    case PlayerStunRank::NONE:
         return 0;
-    case StunRank::NORMAL:
+    case PlayerStunRank::NORMAL:
         return 15;
-    case StunRank::HARD:
+    case PlayerStunRank::HARD:
         return 25;
-    case StunRank::UNCONSCIOUS:
+    case PlayerStunRank::UNCONSCIOUS:
         return 100;
     default:
         throw("Invalid stun rank is specified!");
@@ -75,16 +75,16 @@ int PlayerStun::decrease_chance() const
  * 意識不明瞭ならばそもそも動けないのでこのメソッドを通らない.
  * しかし今後の拡張を考慮して100としておく.
  */
-short PlayerStun::decrease_damage() const
+short PlayerStun::get_damage_penalty() const
 {
     switch (this->get_rank()) {
-    case StunRank::NONE:
+    case PlayerStunRank::NONE:
         return 0;
-    case StunRank::NORMAL:
+    case PlayerStunRank::NORMAL:
         return 5;
-    case StunRank::HARD:
+    case PlayerStunRank::HARD:
         return 20;
-    case StunRank::UNCONSCIOUS:
+    case PlayerStunRank::UNCONSCIOUS:
         return 100;
     default:
         throw("Invalid stun rank is specified!");
@@ -93,19 +93,19 @@ short PlayerStun::decrease_damage() const
 
 bool PlayerStun::is_stunned() const
 {
-    return this->get_rank() > StunRank::NONE;
+    return this->get_rank() > PlayerStunRank::NONE;
 }
 
 std::tuple<term_color_type, std::string_view> PlayerStun::get_expr() const
 {
     switch (this->get_rank()) {
-    case StunRank::NONE: // dummy.
+    case PlayerStunRank::NONE: // dummy.
         return std::make_tuple(TERM_WHITE, "            ");
-    case StunRank::NORMAL:
+    case PlayerStunRank::NORMAL:
         return std::make_tuple(TERM_ORANGE, _("朦朧        ", "Stun        "));
-    case StunRank::HARD:
+    case PlayerStunRank::HARD:
         return std::make_tuple(TERM_ORANGE, _("ひどく朦朧  ", "Heavy stun  "));
-    case StunRank::UNCONSCIOUS:
+    case PlayerStunRank::UNCONSCIOUS:
         return std::make_tuple(TERM_RED, _("意識不明瞭  ", "Knocked out "));
     default:
         throw("Invalid stun rank is specified!");

--- a/src/timed-effect/player-stun.cpp
+++ b/src/timed-effect/player-stun.cpp
@@ -27,6 +27,29 @@ StunRank PlayerStun::get_rank(short value) const
     return StunRank::NONE;
 }
 
+/*!
+ * @brief 朦朧ランクに応じて各種失率を上げる.
+ * @return 朦朧ならば15%、ひどく朦朧ならば25%.
+ * @details
+ * 意識不明瞭ならばそもそも動けないのでこのメソッドを通らない.
+ * しかし今後の拡張を考慮して100%としておく.
+ */
+int PlayerStun::decrease_chance() const
+{
+    switch (this->get_rank()) {
+    case StunRank::NONE:
+        return 0;
+    case StunRank::NORMAL:
+        return 15;
+    case StunRank::HARD:
+        return 25;
+    case StunRank::UNCONSCIOUS:
+        return 100;
+    default:
+        throw("Invalid stun rank is specified!");
+    }
+}
+
 void PlayerStun::set(short value)
 {
 }

--- a/src/timed-effect/player-stun.cpp
+++ b/src/timed-effect/player-stun.cpp
@@ -1,5 +1,5 @@
 ﻿#include "timed-effect/player-stun.h"
-#include "locale/language-switcher.h"
+#include "system/angband.h"
 
 short PlayerStun::current() const
 {

--- a/src/timed-effect/player-stun.cpp
+++ b/src/timed-effect/player-stun.cpp
@@ -67,6 +67,11 @@ int PlayerStun::decrease_chance() const
     }
 }
 
+bool PlayerStun::is_stunned() const
+{
+    return this->get_rank() > StunRank::NONE;
+}
+
 void PlayerStun::set(short value)
 {
     this->stun = value;

--- a/src/timed-effect/player-stun.cpp
+++ b/src/timed-effect/player-stun.cpp
@@ -96,6 +96,22 @@ bool PlayerStun::is_stunned() const
     return this->get_rank() > StunRank::NONE;
 }
 
+std::tuple<term_color_type, std::string_view> PlayerStun::get_expr() const
+{
+    switch (this->get_rank()) {
+    case StunRank::NONE: // dummy.
+        return std::make_tuple(TERM_WHITE, "            ");
+    case StunRank::NORMAL:
+        return std::make_tuple(TERM_ORANGE, _("朦朧        ", "Stun        "));
+    case StunRank::HARD:
+        return std::make_tuple(TERM_ORANGE, _("ひどく朦朧  ", "Heavy stun  "));
+    case StunRank::UNCONSCIOUS:
+        return std::make_tuple(TERM_RED, _("意識不明瞭  ", "Knocked out "));
+    default:
+        throw("Invalid stun rank is specified!");
+    }
+}
+
 void PlayerStun::set(short value)
 {
     this->stun = value;

--- a/src/timed-effect/player-stun.cpp
+++ b/src/timed-effect/player-stun.cpp
@@ -1,4 +1,5 @@
 ﻿#include "timed-effect/player-stun.h"
+#include "locale/language-switcher.h"
 
 short PlayerStun::current() const
 {
@@ -25,6 +26,22 @@ StunRank PlayerStun::get_rank(short value) const
     }
 
     return StunRank::NONE;
+}
+
+std::string_view PlayerStun::get_stun_mes(StunRank stun_rank) const
+{
+    switch (stun_rank) {
+    case StunRank::NONE:
+        return "";
+    case StunRank::NORMAL:
+        return _("意識がもうろうとしてきた。", "You have been stunned.");
+    case StunRank::HARD:
+        return _("意識がひどくもうろうとしてきた。", "You have been heavily stunned.");
+    case StunRank::UNCONSCIOUS:
+        return _("頭がクラクラして意識が遠のいてきた。", "You have been knocked out.");
+    default:
+        throw("Invalid StunRank was specified!");
+    }
 }
 
 /*!

--- a/src/timed-effect/player-stun.cpp
+++ b/src/timed-effect/player-stun.cpp
@@ -1,0 +1,10 @@
+﻿#include "timed-effect/player-stun.h"
+
+short PlayerStun::current()
+{
+    return this->stun;
+}
+
+void PlayerStun::set(short value)
+{
+}

--- a/src/timed-effect/player-stun.h
+++ b/src/timed-effect/player-stun.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <tuple>
 
-enum class StunRank {
+enum class PlayerStunRank {
     NONE = 0,
     NORMAL = 1,
     HARD = 2,
@@ -16,12 +16,13 @@ public:
     PlayerStun() = default;
     virtual ~PlayerStun() = default;
 
+    static PlayerStunRank get_rank(short value);
+    static std::string_view get_stun_mes(PlayerStunRank stun_rank);
+    
     short current() const;
-    StunRank get_rank() const;
-    StunRank get_rank(short value) const;
-    std::string_view get_stun_mes(StunRank stun_rank) const;
-    int decrease_chance() const;
-    short decrease_damage() const;
+    PlayerStunRank get_rank() const;
+    int get_chance_penalty() const;
+    short get_damage_penalty() const;
     bool is_stunned() const;
     std::tuple<term_color_type, std::string_view> get_expr() const;
     void reset();

--- a/src/timed-effect/player-stun.h
+++ b/src/timed-effect/player-stun.h
@@ -19,6 +19,7 @@ public:
     StunRank get_rank(short value) const;
     std::string_view get_stun_mes(StunRank stun_rank) const;
     int decrease_chance() const;
+    bool is_stunned() const;
     void reset();
     void set(short value);
 

--- a/src/timed-effect/player-stun.h
+++ b/src/timed-effect/player-stun.h
@@ -15,6 +15,7 @@ public:
     short current() const;
     StunRank get_rank() const;
     StunRank get_rank(short value) const;
+    int decrease_chance() const;
     void set(short value);
 
 private:

--- a/src/timed-effect/player-stun.h
+++ b/src/timed-effect/player-stun.h
@@ -1,11 +1,20 @@
 ﻿#pragma once
 
+enum class StunRank {
+    NONE = 0,
+    NORMAL = 1,
+    HARD = 2,
+    UNCONSCIOUS = 3,
+};
+
 class PlayerStun {
 public:
     PlayerStun() = default;
     virtual ~PlayerStun() = default;
 
-    short current();
+    short current() const;
+    StunRank get_rank() const;
+    StunRank get_rank(short value) const;
     void set(short value);
 
 private:

--- a/src/timed-effect/player-stun.h
+++ b/src/timed-effect/player-stun.h
@@ -1,0 +1,13 @@
+﻿#pragma once
+
+class PlayerStun {
+public:
+    PlayerStun() = default;
+    virtual ~PlayerStun() = default;
+
+    short current();
+    void set(short value);
+
+private:
+    short stun = 0;
+};

--- a/src/timed-effect/player-stun.h
+++ b/src/timed-effect/player-stun.h
@@ -1,6 +1,8 @@
 ﻿#pragma once
 
+#include "term/term-color-types.h"
 #include <string>
+#include <tuple>
 
 enum class StunRank {
     NONE = 0,
@@ -21,6 +23,7 @@ public:
     int decrease_chance() const;
     short decrease_damage() const;
     bool is_stunned() const;
+    std::tuple<term_color_type, std::string_view> get_expr() const;
     void reset();
     void set(short value);
 

--- a/src/timed-effect/player-stun.h
+++ b/src/timed-effect/player-stun.h
@@ -19,6 +19,7 @@ public:
     StunRank get_rank(short value) const;
     std::string_view get_stun_mes(StunRank stun_rank) const;
     int decrease_chance() const;
+    short decrease_damage() const;
     bool is_stunned() const;
     void reset();
     void set(short value);

--- a/src/timed-effect/player-stun.h
+++ b/src/timed-effect/player-stun.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include <string>
+
 enum class StunRank {
     NONE = 0,
     NORMAL = 1,
@@ -15,6 +17,7 @@ public:
     short current() const;
     StunRank get_rank() const;
     StunRank get_rank(short value) const;
+    std::string_view get_stun_mes(StunRank stun_rank) const;
     int decrease_chance() const;
     void reset();
     void set(short value);

--- a/src/timed-effect/player-stun.h
+++ b/src/timed-effect/player-stun.h
@@ -16,6 +16,7 @@ public:
     StunRank get_rank() const;
     StunRank get_rank(short value) const;
     int decrease_chance() const;
+    void reset();
     void set(short value);
 
 private:

--- a/src/timed-effect/timed-effects.cpp
+++ b/src/timed-effect/timed-effects.cpp
@@ -1,0 +1,6 @@
+﻿#include "timed-effect/timed-effects.h"
+
+std::shared_ptr<PlayerStun> TimedEffects::stun() const
+{
+    return this->player_stun;
+}

--- a/src/timed-effect/timed-effects.cpp
+++ b/src/timed-effect/timed-effects.cpp
@@ -1,4 +1,10 @@
 ﻿#include "timed-effect/timed-effects.h"
+#include "timed-effect/player-stun.h"
+
+TimedEffects::TimedEffects()
+    : player_stun(std::make_shared<PlayerStun>())
+{
+}
 
 std::shared_ptr<PlayerStun> TimedEffects::stun() const
 {

--- a/src/timed-effect/timed-effects.h
+++ b/src/timed-effect/timed-effects.h
@@ -1,16 +1,15 @@
 ﻿#pragma once
 
-#include "timed-effect/player-stun.h"
 #include <memory>
 
 class PlayerStun;
 class TimedEffects {
 public:
-    TimedEffects() = default;
+    TimedEffects();
     virtual ~TimedEffects() = default;
 
     std::shared_ptr<PlayerStun> stun() const;
 
 private:
-    std::shared_ptr<PlayerStun> player_stun = std::shared_ptr<PlayerStun>(new PlayerStun());
+    std::shared_ptr<PlayerStun> player_stun;
 };

--- a/src/timed-effect/timed-effects.h
+++ b/src/timed-effect/timed-effects.h
@@ -1,0 +1,16 @@
+﻿#pragma once
+
+#include "timed-effect/player-stun.h"
+#include <memory>
+
+class PlayerStun;
+class TimedEffects {
+public:
+    TimedEffects() = default;
+    virtual ~TimedEffects() = default;
+
+    std::shared_ptr<PlayerStun> stun() const;
+
+private:
+    std::shared_ptr<PlayerStun> player_stun = std::shared_ptr<PlayerStun>(new PlayerStun());
+};

--- a/src/window/display-sub-window-spells.cpp
+++ b/src/window/display-sub-window-spells.cpp
@@ -14,6 +14,8 @@
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 
@@ -113,7 +115,7 @@ static void display_spell_list(player_type *player_ptr)
                 chance = minfail;
 
             auto player_stun = player_ptr->effects()->stun();
-            chance += player_stun->decrease_chance();
+            chance += player_stun->get_chance_penalty();
             if (chance > 95) {
                 chance = 95;
             }

--- a/src/window/display-sub-window-spells.cpp
+++ b/src/window/display-sub-window-spells.cpp
@@ -112,13 +112,11 @@ static void display_spell_list(player_type *player_ptr)
             if (chance < minfail)
                 chance = minfail;
 
-            if (player_ptr->stun > 50)
-                chance += 25;
-            else if (player_ptr->stun)
-                chance += 15;
-
-            if (chance > 95)
+            auto player_stun = player_ptr->effects()->stun();
+            chance += player_stun->decrease_chance();
+            if (chance > 95) {
                 chance = 95;
+            }
 
             mindcraft_info(player_ptr, comment, use_mind, i);
             sprintf(psi_desc, "  %c) %-30s%2d %4d %3d%%%s", I2A(i), spell.name, spell.min_lev, spell.mana_cost, chance, comment);

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -15,6 +15,8 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "timed-effect/player-stun.h"
+#include "timed-effect/timed-effects.h"
 #include "window/main-window-row-column.h"
 #include "view/status-bars-table.h"
 #include "world/world.h"

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -106,10 +106,12 @@ void print_cut(player_type *player_ptr)
 
 /*!
  * @brief プレイヤーの朦朧状態を表示する
+ * @param player_ptr プレイヤーへの参照ポインタ
+ * @todo TERM値のenumと文字列はPlayerStunの中へ入れ、ここは可能な限り軽くする.
  */
 void print_stun(player_type *player_ptr)
 {
-    int s = player_ptr->stun;
+    int s = player_ptr->effects()->stun()->current();
     if (s > 100) {
         c_put_str(TERM_RED, _("意識不明瞭  ", "Knocked out "), ROW_STUN, COL_STUN);
         return;

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -107,27 +107,17 @@ void print_cut(player_type *player_ptr)
 /*!
  * @brief プレイヤーの朦朧状態を表示する
  * @param player_ptr プレイヤーへの参照ポインタ
- * @todo TERM値のenumと文字列はPlayerStunの中へ入れ、ここは可能な限り軽くする.
  */
 void print_stun(player_type *player_ptr)
 {
-    int s = player_ptr->effects()->stun()->current();
-    if (s > 100) {
-        c_put_str(TERM_RED, _("意識不明瞭  ", "Knocked out "), ROW_STUN, COL_STUN);
+    auto player_stun = player_ptr->effects()->stun();
+    if (!player_stun->is_stunned()) {
+        put_str("            ", ROW_STUN, COL_STUN);
         return;
     }
 
-    if (s > 50) {
-        c_put_str(TERM_ORANGE, _("ひどく朦朧  ", "Heavy stun  "), ROW_STUN, COL_STUN);
-        return;
-    }
-
-    if (s) {
-        c_put_str(TERM_ORANGE, _("朦朧        ", "Stun        "), ROW_STUN, COL_STUN);
-        return;
-    }
-
-    put_str("            ", ROW_STUN, COL_STUN);
+    auto [color, stat] = player_stun->get_expr();
+    c_put_str(color, stat.data(), ROW_STUN, COL_STUN);
 }
 
 /*!


### PR DESCRIPTION
#553 の前段対応で、#1498 の設計変更を実施しました
ご確認下さい
- TimedEffectsは、今後paralyzed やconfused 等、各種時限効果を移していく予定です。それによりplayer\_type を軽くすることを意図します
- 朦朧の蓄積に関する仕様は現行のままです。おかしい点があればご連絡下さい
- 本当はフィールド変数はunique\_ptr にした方がいいのかもしれませんが、player\_type でそこまでやると影響が大きすぎるのと、各種演算子オーバーライドが面倒だったのでスルーしました
- ある意味一番面倒なset\_stun() について、このブランチで弄るのは差分が増えすぎるので丁重に放置中です