### PR TITLE
[Feature] *_info 配列の要素のメンバに自身のindexを持たせる

### DIFF
--- a/src/dungeon/dungeon.h
+++ b/src/dungeon/dungeon.h
@@ -38,8 +38,9 @@ typedef struct feat_prob {
 
 /* A structure for the != dungeon types */
 typedef struct dungeon_type {
+    DUNGEON_IDX idx{};
 
-	std::string name; /* Name */
+    std::string name; /* Name */
     std::string text; /* Description */
 
 	POSITION dy{};

--- a/src/grid/feature.h
+++ b/src/grid/feature.h
@@ -34,6 +34,7 @@ typedef struct feature_state {
  * @brief 地形情報の構造体 / Information about terrain "features"
  */
 typedef struct feature_type {
+    FEAT_IDX idx{};
     std::string name; /*!< 地形名参照のためのネームバッファオフセット値 / Name (offset) */
     std::string text; /*!< 地形説明参照のためのネームバッファオフセット値 /  Text (offset) */
     std::string tag; /*!< 地形特性タグ参照のためのネームバッファオフセット値 /  Tag (offset) */

--- a/src/info-reader/artifact-reader.cpp
+++ b/src/info-reader/artifact-reader.cpp
@@ -53,6 +53,7 @@ errr parse_a_info(std::string_view buf, angband_header *head)
 
         error_idx = i;
         a_ptr = &a_info[i];
+        a_ptr->idx = i;
         a_ptr->flags.set(TR_IGNORE_ACID);
         a_ptr->flags.set(TR_IGNORE_ELEC);
         a_ptr->flags.set(TR_IGNORE_FIRE);

--- a/src/info-reader/dungeon-reader.cpp
+++ b/src/info-reader/dungeon-reader.cpp
@@ -102,6 +102,7 @@ errr parse_d_info(std::string_view buf, angband_header *head)
 
         error_idx = i;
         d_ptr = &d_info[i];
+        d_ptr->idx = i;
 #ifdef JP
         d_ptr->name = tokens[2];
 #endif

--- a/src/info-reader/ego-reader.cpp
+++ b/src/info-reader/ego-reader.cpp
@@ -77,6 +77,7 @@ errr parse_e_info(std::string_view buf, angband_header *head)
 
         error_idx = i;
         e_ptr = &e_info[i];
+        e_ptr->idx = i;
 #ifdef JP
         e_ptr->name = tokens[2];
 #endif

--- a/src/info-reader/feature-reader.cpp
+++ b/src/info-reader/feature-reader.cpp
@@ -79,6 +79,7 @@ errr parse_f_info(std::string_view buf, angband_header *head)
 
         error_idx = i;
         f_ptr = &f_info[i];
+        f_ptr->idx = i;
         f_ptr->tag = tokens[2];
 
         f_ptr->mimic = (FEAT_IDX)i;

--- a/src/info-reader/kind-reader.cpp
+++ b/src/info-reader/kind-reader.cpp
@@ -54,6 +54,7 @@ errr parse_k_info(std::string_view buf, angband_header *head)
 
         error_idx = i;
         k_ptr = &k_info[i];
+        k_ptr->idx = i;
 #ifdef JP
         k_ptr->name = tokens[2];
 #endif

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -85,6 +85,7 @@ errr parse_r_info(std::string_view buf, angband_header *head)
 
         error_idx = i;
         r_ptr = &r_info[i];
+        r_ptr->idx = i;
 #ifdef JP
         r_ptr->name = tokens[2];
 #endif

--- a/src/info-reader/vault-reader.cpp
+++ b/src/info-reader/vault-reader.cpp
@@ -32,6 +32,7 @@ errr parse_v_info(std::string_view buf, angband_header *head)
 
         error_idx = i;
         v_ptr = &v_info[i];
+        v_ptr->idx = i;
         v_ptr->name = std::string(tokens[2]);
     } else if (!v_ptr)
         return PARSE_ERROR_MISSING_RECORD_HEADER;

--- a/src/object-enchant/object-ego.h
+++ b/src/object-enchant/object-ego.h
@@ -233,6 +233,8 @@ struct ego_generate_type {
  * Information about "ego-items".
  */
 struct ego_item_type {
+    EGO_IDX idx{};
+
     std::string name; //!< エゴの名前
     std::string text; //!< フレーバーテキスト
 

--- a/src/object/object-kind.h
+++ b/src/object/object-kind.h
@@ -12,6 +12,8 @@
 #include <vector>
 
 typedef struct object_kind {
+    KIND_OBJECT_IDX idx{};
+
     std::string name; /*!< ベースアイテム名参照のためのネームバッファオフセット値 / Name (offset) */
     std::string text; /*!< 解説テキスト参照のためのネームバッファオフセット値 / Text (offset) */
     std::string flavor_name; /*!< 未確定名参照のためのネームバッファオフセット値 / Flavor name (offset) */

--- a/src/room/rooms-vault.h
+++ b/src/room/rooms-vault.h
@@ -5,6 +5,8 @@
 #include <vector>
 
 typedef struct vault_type {
+    int16_t idx;
+
     std::string name; /* Name (offset) */
     std::string text; /* Text (offset) */
 

--- a/src/system/artifact-type-definition.h
+++ b/src/system/artifact-type-definition.h
@@ -19,7 +19,9 @@
  * "max_num" is always "1" (if that artifact "exists")
  */
 typedef struct artifact_type {
-	std::string name;			/*!< アーティファクト名(headerオフセット参照) / Name (offset) */
+    ARTIFACT_IDX idx{};
+
+    std::string name; /*!< アーティファクト名(headerオフセット参照) / Name (offset) */
     std::string text; /*!< アーティファクト解説(headerオフセット参照) / Text (offset) */
 	tval_type tval{};		/*!< ベースアイテム大項目ID / Artifact type */
 	OBJECT_SUBTYPE_VALUE sval{};	/*!< ベースアイテム小項目ID / Artifact sub type */

--- a/src/system/monster-race-definition.h
+++ b/src/system/monster-race-definition.h
@@ -47,6 +47,7 @@ typedef struct monster_blow {
  * fields have a special prefix to aid in searching for them.
  */
 struct monster_race {
+    MONRACE_IDX idx{};
     std::string name; //!< 名前データのオフセット(日本語) /  Name offset(Japanese)
 #ifdef JP
     std::string E_name; //!< 名前データのオフセット(英語) /  Name offset(English)


### PR DESCRIPTION
配列のループ処理を range-based for で記述したいのに、中で要素の
index が必要な時に結局ループ変数を使用することになる。
自身のindexを持っておけば、それを参照すればよくなる。

とりあえずメンバを追加したのみです。これを使用しての range-based for への書き換えは追々気が向いたら。