### PR TITLE
[Fix] 鍛冶で遠隔武器や矢弾の命中/ダメージ修正を強化できない

### DIFF
--- a/src/object-enchant/smith-info.cpp
+++ b/src/object-enchant/smith-info.cpp
@@ -133,7 +133,7 @@ bool EnchantWeaponSmithInfo::add_essence(player_type *player_ptr, object_type *o
 
 bool EnchantWeaponSmithInfo::can_give_smith_effect(const object_type *o_ptr) const
 {
-    return o_ptr->allow_enchant_melee_weapon();
+    return o_ptr->allow_enchant_weapon();
 }
 
 EnchantArmourSmithInfo::EnchantArmourSmithInfo(SmithEffect effect, concptr name, SmithCategory category, std::vector<SmithEssence> need_essences, int consumption)


### PR DESCRIPTION
リファクタリング時に鍛冶をできるか判定する関数を間違っていた。
正しい関数に修正する。

とりあえず develop を元にPRを出しています。
HotFix案件であれば、release を元にしたブランチに差し替えます。