### PR TITLE
*_info 配列に対するループを range-based for に置き換える

### DIFF
--- a/src/artifact/fixed-art-generator.cpp
+++ b/src/artifact/fixed-art-generator.cpp
@@ -274,37 +274,35 @@ bool make_artifact(player_type *player_ptr, object_type *o_ptr)
     if (o_ptr->number != 1)
         return false;
 
-    for (ARTIFACT_IDX i = 0; i < max_a_idx; i++) {
-        auto a_ptr = &a_info[i];
-
-        if (a_ptr->name.empty())
+    for (const auto &a_ref : a_info) {
+        if (a_ref.name.empty())
             continue;
 
-        if (a_ptr->cur_num)
+        if (a_ref.cur_num)
             continue;
 
-        if (a_ptr->gen_flags.has(TRG::QUESTITEM))
+        if (a_ref.gen_flags.has(TRG::QUESTITEM))
             continue;
 
-        if (a_ptr->gen_flags.has(TRG::INSTA_ART))
+        if (a_ref.gen_flags.has(TRG::INSTA_ART))
             continue;
 
-        if (a_ptr->tval != o_ptr->tval)
+        if (a_ref.tval != o_ptr->tval)
             continue;
 
-        if (a_ptr->sval != o_ptr->sval)
+        if (a_ref.sval != o_ptr->sval)
             continue;
 
-        if (a_ptr->level > floor_ptr->dun_level) {
-            int d = (a_ptr->level - floor_ptr->dun_level) * 2;
+        if (a_ref.level > floor_ptr->dun_level) {
+            int d = (a_ref.level - floor_ptr->dun_level) * 2;
             if (!one_in_(d))
                 continue;
         }
 
-        if (!one_in_(a_ptr->rarity))
+        if (!one_in_(a_ref.rarity))
             continue;
 
-        o_ptr->name1 = i;
+        o_ptr->name1 = a_ref.idx;
         return true;
     }
 
@@ -337,38 +335,36 @@ bool make_artifact_special(player_type *player_ptr, object_type *o_ptr)
         return false;
 
     /*! @note 全固定アーティファクト中からIDの若い順に生成対象とその確率を走査する / Check the artifact list (just the "specials") */
-    for (ARTIFACT_IDX i = 0; i < max_a_idx; i++) {
-        auto a_ptr = &a_info[i];
-
+    for (const auto &a_ref : a_info) {
         /*! @note アーティファクト名が空の不正なデータは除外する / Skip "empty" artifacts */
-        if (a_ptr->name.empty())
+        if (a_ref.name.empty())
             continue;
 
         /*! @note 既に生成回数がカウントされたアーティファクト、QUESTITEMと非INSTA_ARTは除外 / Cannot make an artifact twice */
-        if (a_ptr->cur_num)
+        if (a_ref.cur_num)
             continue;
-        if (a_ptr->gen_flags.has(TRG::QUESTITEM))
+        if (a_ref.gen_flags.has(TRG::QUESTITEM))
             continue;
-        if (!(a_ptr->gen_flags.has(TRG::INSTA_ART)))
+        if (!(a_ref.gen_flags.has(TRG::INSTA_ART)))
             continue;
 
         /*! @note アーティファクト生成階が現在に対して足りない場合は高確率で1/(不足階層*2)を満たさないと生成リストに加えられない /
          *  XXX XXX Enforce minimum "depth" (loosely) */
-        if (a_ptr->level > floor_ptr->object_level) {
+        if (a_ref.level > floor_ptr->object_level) {
             /* @note  / Acquire the "out-of-depth factor". Roll for out-of-depth creation. */
-            int d = (a_ptr->level - floor_ptr->object_level) * 2;
+            int d = (a_ref.level - floor_ptr->object_level) * 2;
             if (!one_in_(d))
                 continue;
         }
 
         /*! @note 1/(レア度)の確率を満たさないと除外される / Artifact "rarity roll" */
-        if (!one_in_(a_ptr->rarity))
+        if (!one_in_(a_ref.rarity))
             continue;
 
         /*! @note INSTA_ART型固定アーティファクトのベースアイテムもチェック対象とする。ベースアイテムの生成階層が足りない場合1/(不足階層*5)
          * を満たさないと除外される。 / Find the base object. XXX XXX Enforce minimum "object" level (loosely). Acquire the "out-of-depth factor". Roll for
          * out-of-depth creation. */
-        k_idx = lookup_kind(a_ptr->tval, a_ptr->sval);
+        k_idx = lookup_kind(a_ref.tval, a_ref.sval);
         if (k_info[k_idx].level > floor_ptr->object_level) {
             int d = (k_info[k_idx].level - floor_ptr->object_level) * 5;
             if (!one_in_(d))
@@ -379,7 +375,7 @@ bool make_artifact_special(player_type *player_ptr, object_type *o_ptr)
          * Assign the template. Mega-Hack -- mark the item as an artifact. Hack: Some artifacts get random extra powers. Success. */
         o_ptr->prep(k_idx);
 
-        o_ptr->name1 = i;
+        o_ptr->name1 = a_ref.idx;
         return true;
     }
 

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -83,17 +83,19 @@ void player_wipe_without_name(player_type *player_ptr)
     }
 
     k_info_reset();
-    for (int i = 1; i < max_r_idx; i++) {
-        monster_race *r_ptr = &r_info[i];
-        r_ptr->cur_num = 0;
-        r_ptr->max_num = 100;
-        if (r_ptr->flags1 & RF1_UNIQUE)
-            r_ptr->max_num = 1;
-        else if (r_ptr->flags7 & RF7_NAZGUL)
-            r_ptr->max_num = MAX_NAZGUL_NUM;
+    for (auto &r_ref : r_info) {
+        if (r_ref.idx == 0) {
+            continue;
+        }
+        r_ref.cur_num = 0;
+        r_ref.max_num = 100;
+        if (r_ref.flags1 & RF1_UNIQUE)
+            r_ref.max_num = 1;
+        else if (r_ref.flags7 & RF7_NAZGUL)
+            r_ref.max_num = MAX_NAZGUL_NUM;
 
-        r_ptr->r_pkills = 0;
-        r_ptr->r_akills = 0;
+        r_ref.r_pkills = 0;
+        r_ref.r_akills = 0;
     }
 
     player_ptr->food = PY_FOOD_FULL - 1;

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -137,8 +137,8 @@ void player_wipe_without_name(player_type *player_ptr)
     player_ptr->pet_follow_distance = PET_FOLLOW_DIST;
     player_ptr->pet_extra_flags = (PF_TELEPORT | PF_ATTACK_SPELL | PF_SUMMON_SPELL);
 
-    for (int i = 0; i < w_ptr->max_d_idx; i++)
-        max_dlv[i] = 0;
+    for (const auto &d_ref : d_info)
+        max_dlv[d_ref.idx] = 0;
 
     player_ptr->visit = 1;
     player_ptr->wild_mode = false;

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -28,10 +28,9 @@
  */
 static void k_info_reset(void)
 {
-    for (int i = 0; i < max_k_idx; i++) {
-        object_kind *k_ptr = &k_info[i];
-        k_ptr->tried = false;
-        k_ptr->aware = false;
+    for (auto &k_ref : k_info) {
+        k_ref.tried = false;
+        k_ref.aware = false;
     }
 }
 

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -78,9 +78,8 @@ void player_wipe_without_name(player_type *player_ptr)
     for (int i = 0; i < INVEN_TOTAL; i++)
         (&player_ptr->inventory_list[i])->wipe();
 
-    for (int i = 0; i < max_a_idx; i++) {
-        artifact_type *a_ptr = &a_info[i];
-        a_ptr->cur_num = 0;
+    for (auto &a_ref : a_info) {
+        a_ref.cur_num = 0;
     }
 
     k_info_reset();

--- a/src/cmd-io/cmd-lore.cpp
+++ b/src/cmd-io/cmd-lore.cpp
@@ -90,18 +90,18 @@ void do_cmd_query_symbol(player_type *player_ptr)
 
     prt(buf, 0, 0);
     C_MAKE(who, max_r_idx, MONRACE_IDX);
-    for (n = 0, i = 1; i < max_r_idx; i++) {
-        monster_race *r_ptr = &r_info[i];
-        if (!cheat_know && !r_ptr->r_sights)
+    n = 0;
+    for (const auto &r_ref : r_info) {
+        if (!cheat_know && !r_ref.r_sights)
             continue;
 
-        if (norm && (r_ptr->flags1 & (RF1_UNIQUE)))
+        if (norm && (r_ref.flags1 & (RF1_UNIQUE)))
             continue;
 
-        if (uniq && !(r_ptr->flags1 & (RF1_UNIQUE)))
+        if (uniq && !(r_ref.flags1 & (RF1_UNIQUE)))
             continue;
 
-        if (ride && !(r_ptr->flags7 & (RF7_RIDING)))
+        if (ride && !(r_ref.flags7 & (RF7_RIDING)))
             continue;
 
         if (temp[0]) {
@@ -120,23 +120,23 @@ void do_cmd_query_symbol(player_type *player_ptr)
             }
 
 #ifdef JP
-            strcpy(temp2, r_ptr->E_name.c_str());
+            strcpy(temp2, r_ref.E_name.c_str());
 #else
-            strcpy(temp2, r_ptr->name.c_str());
+            strcpy(temp2, r_ref.name.c_str());
 #endif
             for (xx = 0; temp2[xx] && xx < MAX_MONSTER_NAME; xx++)
                 if (isupper(temp2[xx]))
                     temp2[xx] = (char)tolower(temp2[xx]);
 
 #ifdef JP
-            if (angband_strstr(temp2, temp) || angband_strstr(r_ptr->name.c_str(), temp))
+            if (angband_strstr(temp2, temp) || angband_strstr(r_ref.name.c_str(), temp))
 #else
             if (angband_strstr(temp2, temp))
 #endif
                 who[n++] = i;
         }
 
-        else if (all || (r_ptr->d_char == sym))
+        else if (all || (r_ref.d_char == sym))
             who[n++] = i;
     }
 

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -118,13 +118,12 @@ void do_cmd_visuals(player_type *player_ptr)
                 continue;
 
             auto_dump_printf(auto_dump_stream, _("\n# モンスターの[色/文字]の設定\n\n", "\n# Monster attr/char definitions\n\n"));
-            for (i = 0; i < max_r_idx; i++) {
-                monster_race *r_ptr = &r_info[i];
-                if (r_ptr->name.empty())
+            for (const auto& r_ref : r_info) {
+                if (r_ref.name.empty())
                     continue;
 
-                auto_dump_printf(auto_dump_stream, "# %s\n", r_ptr->name.c_str());
-                auto_dump_printf(auto_dump_stream, "R:%d:0x%02X/0x%02X\n\n", i, (byte)(r_ptr->x_attr), (byte)(r_ptr->x_char));
+                auto_dump_printf(auto_dump_stream, "# %s\n", r_ref.name.c_str());
+                auto_dump_printf(auto_dump_stream, "R:%d:0x%02X/0x%02X\n\n", i, (byte)(r_ref.x_attr), (byte)(r_ref.x_char));
             }
 
             close_auto_dump(&auto_dump_stream, mark);

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -144,22 +144,21 @@ void do_cmd_visuals(player_type *player_ptr)
                 continue;
 
             auto_dump_printf(auto_dump_stream, _("\n# アイテムの[色/文字]の設定\n\n", "\n# Object attr/char definitions\n\n"));
-            for (KIND_OBJECT_IDX k_idx = 0; k_idx < max_k_idx; k_idx++) {
+            for (const auto &k_ref : k_info) {
                 GAME_TEXT o_name[MAX_NLEN];
-                object_kind *k_ptr = &k_info[k_idx];
-                if (k_ptr->name.empty())
+                if (k_ref.name.empty())
                     continue;
 
-                if (!k_ptr->flavor) {
-                    strip_name(o_name, k_idx);
+                if (!k_ref.flavor) {
+                    strip_name(o_name, k_ref.idx);
                 } else {
                     object_type dummy;
-                    dummy.prep(k_idx);
+                    dummy.prep(k_ref.idx);
                     describe_flavor(player_ptr, o_name, &dummy, OD_FORCE_FLAVOR);
                 }
 
                 auto_dump_printf(auto_dump_stream, "# %s\n", o_name);
-                auto_dump_printf(auto_dump_stream, "K:%d:0x%02X/0x%02X\n\n", (int)k_idx, (byte)(k_ptr->x_attr), (byte)(k_ptr->x_char));
+                auto_dump_printf(auto_dump_stream, "K:%d:0x%02X/0x%02X\n\n", (int)k_ref.idx, (byte)(k_ref.x_attr), (byte)(k_ref.x_char));
             }
 
             close_auto_dump(&auto_dump_stream, mark);

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -177,17 +177,16 @@ void do_cmd_visuals(player_type *player_ptr)
                 continue;
 
             auto_dump_printf(auto_dump_stream, _("\n# 地形の[色/文字]の設定\n\n", "\n# Feature attr/char definitions\n\n"));
-            for (i = 0; i < max_f_idx; i++) {
-                feature_type *f_ptr = &f_info[i];
-                if (f_ptr->name.empty())
+            for (const auto &f_ref : f_info) {
+                if (f_ref.name.empty())
                     continue;
-                if (f_ptr->mimic != i)
+                if (f_ref.mimic != f_ref.idx)
                     continue;
 
-                auto_dump_printf(auto_dump_stream, "# %s\n", (f_ptr->name.c_str()));
-                auto_dump_printf(auto_dump_stream, "F:%d:0x%02X/0x%02X:0x%02X/0x%02X:0x%02X/0x%02X\n\n", i, (byte)(f_ptr->x_attr[F_LIT_STANDARD]),
-                    (byte)(f_ptr->x_char[F_LIT_STANDARD]), (byte)(f_ptr->x_attr[F_LIT_LITE]), (byte)(f_ptr->x_char[F_LIT_LITE]),
-                    (byte)(f_ptr->x_attr[F_LIT_DARK]), (byte)(f_ptr->x_char[F_LIT_DARK]));
+                auto_dump_printf(auto_dump_stream, "# %s\n", (f_ref.name.c_str()));
+                auto_dump_printf(auto_dump_stream, "F:%d:0x%02X/0x%02X:0x%02X/0x%02X:0x%02X/0x%02X\n\n", f_ref.idx, (byte)(f_ref.x_attr[F_LIT_STANDARD]),
+                    (byte)(f_ref.x_char[F_LIT_STANDARD]), (byte)(f_ref.x_attr[F_LIT_LITE]), (byte)(f_ref.x_char[F_LIT_LITE]),
+                    (byte)(f_ref.x_attr[F_LIT_DARK]), (byte)(f_ref.x_char[F_LIT_DARK]));
             }
 
             close_auto_dump(&auto_dump_stream, mark);

--- a/src/core/visuals-reseter.cpp
+++ b/src/core/visuals-reseter.cpp
@@ -21,10 +21,9 @@ void reset_visuals(player_type *player_ptr)
         }
     }
 
-    for (int i = 0; i < max_k_idx; i++) {
-        object_kind *k_ptr = &k_info[i];
-        k_ptr->x_attr = k_ptr->d_attr;
-        k_ptr->x_char = k_ptr->d_char;
+    for (auto &k_ref : k_info) {
+        k_ref.x_attr = k_ref.d_attr;
+        k_ref.x_char = k_ref.d_char;
     }
 
     for (int i = 0; i < max_r_idx; i++) {

--- a/src/core/visuals-reseter.cpp
+++ b/src/core/visuals-reseter.cpp
@@ -13,11 +13,10 @@
  */
 void reset_visuals(player_type *player_ptr)
 {
-    for (int i = 0; i < max_f_idx; i++) {
-        feature_type *f_ptr = &f_info[i];
+    for (auto &f_ref : f_info) {
         for (int j = 0; j < F_LIT_MAX; j++) {
-            f_ptr->x_attr[j] = f_ptr->d_attr[j];
-            f_ptr->x_char[j] = f_ptr->d_char[j];
+            f_ref.x_attr[j] = f_ref.d_attr[j];
+            f_ref.x_char[j] = f_ref.d_char[j];
         }
     }
 

--- a/src/core/visuals-reseter.cpp
+++ b/src/core/visuals-reseter.cpp
@@ -26,10 +26,9 @@ void reset_visuals(player_type *player_ptr)
         k_ref.x_char = k_ref.d_char;
     }
 
-    for (int i = 0; i < max_r_idx; i++) {
-        monster_race *r_ptr = &r_info[i];
-        r_ptr->x_attr = r_ptr->d_attr;
-        r_ptr->x_char = r_ptr->d_char;
+    for (auto &r_ref : r_info) {
+        r_ref.x_attr = r_ref.d_attr;
+        r_ref.x_char = r_ref.d_char;
     }
 
     concptr pref_file = use_graphics ? "graf.prf" : "font.prf";

--- a/src/dungeon/dungeon.cpp
+++ b/src/dungeon/dungeon.cpp
@@ -32,7 +32,6 @@ DEPTH *max_dlv;
 DUNGEON_IDX choose_dungeon(concptr note, POSITION y, POSITION x)
 {
     DUNGEON_IDX select_dungeon;
-    DUNGEON_IDX i;
     int num = 0;
     DUNGEON_IDX *dun;
 
@@ -51,24 +50,24 @@ DUNGEON_IDX choose_dungeon(concptr note, POSITION y, POSITION x)
     C_MAKE(dun, w_ptr->max_d_idx, DUNGEON_IDX);
 
     screen_save();
-    for (i = 1; i < w_ptr->max_d_idx; i++) {
+    for (const auto &d_ref : d_info) {
         char buf[80];
         bool seiha = false;
 
-        if (!d_info[i].maxdepth)
+        if (d_ref.idx == 0 || !d_ref.maxdepth)
             continue;
-        if (!max_dlv[i])
+        if (!max_dlv[d_ref.idx])
             continue;
-        if (d_info[i].final_guardian) {
-            if (!r_info[d_info[i].final_guardian].max_num)
+        if (d_ref.final_guardian) {
+            if (!r_info[d_ref.final_guardian].max_num)
                 seiha = true;
-        } else if (max_dlv[i] == d_info[i].maxdepth)
+        } else if (max_dlv[d_ref.idx] == d_ref.maxdepth)
             seiha = true;
 
         sprintf(buf, _("      %c) %c%-12s : 最大 %d 階", "      %c) %c%-16s : Max level %d"),
-            'a' + num, seiha ? '!' : ' ', d_info[i].name.c_str(), (int)max_dlv[i]);
+            'a' + num, seiha ? '!' : ' ', d_ref.name.c_str(), (int)max_dlv[d_ref.idx]);
         prt(buf, y + num, x);
-        dun[num++] = i;
+        dun[num++] = d_ref.idx;
     }
 
     if (!num) {
@@ -77,7 +76,7 @@ DUNGEON_IDX choose_dungeon(concptr note, POSITION y, POSITION x)
 
     prt(format(_("どのダンジョン%sしますか:", "Which dungeon do you %s?: "), note), 0, 0);
     while (true) {
-        i = inkey();
+        auto i = inkey();
         if ((i == ESCAPE) || !num) {
             /* Free the "dun" array */
             C_KILL(dun, w_ptr->max_d_idx, DUNGEON_IDX);

--- a/src/dungeon/dungeon.cpp
+++ b/src/dungeon/dungeon.cpp
@@ -22,7 +22,6 @@ std::vector<dungeon_type> d_info;
  */
 DEPTH *max_dlv;
 
-
 /*!
  * @brief これまでに入ったダンジョンの一覧を表示し、選択させる。
  * @param note ダンジョンに施す処理記述
@@ -32,76 +31,72 @@ DEPTH *max_dlv;
  */
 DUNGEON_IDX choose_dungeon(concptr note, POSITION y, POSITION x)
 {
-	DUNGEON_IDX select_dungeon;
-	DUNGEON_IDX i;
-	int num = 0;
-	DUNGEON_IDX *dun;
+    DUNGEON_IDX select_dungeon;
+    DUNGEON_IDX i;
+    int num = 0;
+    DUNGEON_IDX *dun;
 
-	/* Hack -- No need to choose dungeon in some case */
-	if (lite_town || vanilla_town || ironman_downward)
-	{
-		if (max_dlv[DUNGEON_ANGBAND]) return DUNGEON_ANGBAND;
-		else
-		{
-                    msg_format(_("まだ%sに入ったことはない。", "You haven't entered %s yet."), d_info[DUNGEON_ANGBAND].name.c_str());
-			msg_print(nullptr);
-			return 0;
-		}
-	}
+    /* Hack -- No need to choose dungeon in some case */
+    if (lite_town || vanilla_town || ironman_downward) {
+        if (max_dlv[DUNGEON_ANGBAND])
+            return DUNGEON_ANGBAND;
+        else {
+            msg_format(_("まだ%sに入ったことはない。", "You haven't entered %s yet."), d_info[DUNGEON_ANGBAND].name.c_str());
+            msg_print(nullptr);
+            return 0;
+        }
+    }
 
-	/* Allocate the "dun" array */
-	C_MAKE(dun, w_ptr->max_d_idx, DUNGEON_IDX);
+    /* Allocate the "dun" array */
+    C_MAKE(dun, w_ptr->max_d_idx, DUNGEON_IDX);
 
-	screen_save();
-	for (i = 1; i < w_ptr->max_d_idx; i++)
-	{
-		char buf[80];
-		bool seiha = false;
+    screen_save();
+    for (i = 1; i < w_ptr->max_d_idx; i++) {
+        char buf[80];
+        bool seiha = false;
 
-		if (!d_info[i].maxdepth) continue;
-		if (!max_dlv[i]) continue;
-		if (d_info[i].final_guardian)
-		{
-			if (!r_info[d_info[i].final_guardian].max_num) seiha = true;
-		}
-		else if (max_dlv[i] == d_info[i].maxdepth) seiha = true;
+        if (!d_info[i].maxdepth)
+            continue;
+        if (!max_dlv[i])
+            continue;
+        if (d_info[i].final_guardian) {
+            if (!r_info[d_info[i].final_guardian].max_num)
+                seiha = true;
+        } else if (max_dlv[i] == d_info[i].maxdepth)
+            seiha = true;
 
-		sprintf(buf, _("      %c) %c%-12s : 最大 %d 階", "      %c) %c%-16s : Max level %d"),
-			'a' + num, seiha ? '!' : ' ', d_info[i].name.c_str(), (int)max_dlv[i]);
-		prt(buf, y + num, x);
-		dun[num++] = i;
-	}
+        sprintf(buf, _("      %c) %c%-12s : 最大 %d 階", "      %c) %c%-16s : Max level %d"),
+            'a' + num, seiha ? '!' : ' ', d_info[i].name.c_str(), (int)max_dlv[i]);
+        prt(buf, y + num, x);
+        dun[num++] = i;
+    }
 
-	if (!num)
-	{
-		prt(_("      選べるダンジョンがない。", "      No dungeon is available."), y, x);
-	}
+    if (!num) {
+        prt(_("      選べるダンジョンがない。", "      No dungeon is available."), y, x);
+    }
 
-	prt(format(_("どのダンジョン%sしますか:", "Which dungeon do you %s?: "), note), 0, 0);
-	while (true)
-	{
-		i = inkey();
-		if ((i == ESCAPE) || !num)
-		{
-			/* Free the "dun" array */
-			C_KILL(dun, w_ptr->max_d_idx, DUNGEON_IDX);
+    prt(format(_("どのダンジョン%sしますか:", "Which dungeon do you %s?: "), note), 0, 0);
+    while (true) {
+        i = inkey();
+        if ((i == ESCAPE) || !num) {
+            /* Free the "dun" array */
+            C_KILL(dun, w_ptr->max_d_idx, DUNGEON_IDX);
 
-			screen_load();
-			return 0;
-		}
-		if (i >= 'a' && i < ('a' + num))
-		{
-			select_dungeon = dun[i - 'a'];
-			break;
-		}
-		else bell();
-	}
-	screen_load();
+            screen_load();
+            return 0;
+        }
+        if (i >= 'a' && i < ('a' + num)) {
+            select_dungeon = dun[i - 'a'];
+            break;
+        } else
+            bell();
+    }
+    screen_load();
 
-	/* Free the "dun" array */
-	C_KILL(dun, w_ptr->max_d_idx, DUNGEON_IDX);
+    /* Free the "dun" array */
+    C_KILL(dun, w_ptr->max_d_idx, DUNGEON_IDX);
 
-	return select_dungeon;
+    return select_dungeon;
 }
 
 /*!

--- a/src/flavor/object-flavor.cpp
+++ b/src/flavor/object-flavor.cpp
@@ -45,6 +45,8 @@
 #include "locale/english.h"
 #endif
 
+#include <utility>
+
 /*!
  * @brief 最初から簡易な名称が明らかになるベースアイテムの判定。 /  Certain items, if aware, are known instantly
  * @param i ベースアイテムID
@@ -192,18 +194,17 @@ static void shuffle_flavors(tval_type tval)
     KIND_OBJECT_IDX *k_idx_list;
     KIND_OBJECT_IDX k_idx_list_num = 0;
     C_MAKE(k_idx_list, max_k_idx, KIND_OBJECT_IDX);
-    for (KIND_OBJECT_IDX i = 0; i < max_k_idx; i++) {
-        object_kind *k_ptr = &k_info[i];
-        if (k_ptr->tval != tval)
+    for (const auto &k_ref : k_info) {
+        if (k_ref.tval != tval)
             continue;
 
-        if (!k_ptr->flavor)
+        if (!k_ref.flavor)
             continue;
 
-        if (k_ptr->flags.has(TR_FIXED_FLAVOR))
+        if (k_ref.flags.has(TR_FIXED_FLAVOR))
             continue;
 
-        k_idx_list[k_idx_list_num] = i;
+        k_idx_list[k_idx_list_num] = k_ref.idx;
         k_idx_list_num++;
     }
 
@@ -227,12 +228,11 @@ void flavor_init(void)
     uint32_t state_backup[4];
     Rand_state_backup(state_backup);
     Rand_state_set(w_ptr->seed_flavor);
-    for (KIND_OBJECT_IDX i = 0; i < max_k_idx; i++) {
-        object_kind *k_ptr = &k_info[i];
-        if (k_ptr->flavor_name.empty())
+    for (auto &k_ref : k_info) {
+        if (k_ref.flavor_name.empty())
             continue;
 
-        k_ptr->flavor = i;
+        k_ref.flavor = k_ref.idx;
     }
 
     shuffle_flavors(TV_RING);
@@ -244,15 +244,14 @@ void flavor_init(void)
     shuffle_flavors(TV_POTION);
     shuffle_flavors(TV_SCROLL);
     Rand_state_restore(state_backup);
-    for (KIND_OBJECT_IDX i = 1; i < max_k_idx; i++) {
-        object_kind *k_ptr = &k_info[i];
-        if (k_ptr->name.empty())
+    for (auto &k_ref : k_info) {
+        if (k_ref.idx == 0 || k_ref.name.empty())
             continue;
 
-        if (!k_ptr->flavor)
-            k_ptr->aware = true;
+        if (!k_ref.flavor)
+            k_ref.aware = true;
 
-        k_ptr->easy_know = object_easy_know(i);
+        k_ref.easy_know = object_easy_know(k_ref.idx);
     }
 }
 

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -335,8 +335,8 @@ void clear_cave(player_type *player_ptr)
     floor_ptr->o_max = 1;
     floor_ptr->o_cnt = 0;
 
-    for (int i = 1; i < max_r_idx; i++)
-        r_info[i].cur_num = 0;
+    for (auto &r_ref : r_info)
+        r_ref.cur_num = 0;
 
     (void)C_WIPE(floor_ptr->m_list, floor_ptr->m_max, monster_type);
     floor_ptr->m_max = 1;

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -724,12 +724,12 @@ parse_error_type parse_line_wilderness(player_type *player_ptr, char *buf, int x
         return PARSE_ERROR_UNDEFINED_DIRECTIVE;
     }
 
-    for (int i = 1; i < w_ptr->max_d_idx; i++) {
-        if (!d_info[i].maxdepth)
+    for (const auto &d_ref : d_info) {
+        if (d_ref.idx == 0 || !d_ref.maxdepth)
             continue;
-        wilderness[d_info[i].dy][d_info[i].dx].entrance = (byte)i;
-        if (!wilderness[d_info[i].dy][d_info[i].dx].town) {
-            wilderness[d_info[i].dy][d_info[i].dx].level = d_info[i].mindepth;
+        wilderness[d_ref.dy][d_ref.dx].entrance = static_cast<byte>(d_ref.idx);
+        if (!wilderness[d_ref.dy][d_ref.dx].town) {
+            wilderness[d_ref.dy][d_ref.dx].level = d_ref.mindepth;
         }
     }
 

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -295,26 +295,25 @@ static void dump_aux_monsters(player_type *player_ptr, FILE *fff)
     /* Count monster kills */
     long uniq_total = 0;
     long norm_total = 0;
-    for (MONRACE_IDX k = 1; k < max_r_idx; k++) {
+    for (const auto &r_ref : r_info) {
         /* Ignore unused index */
-        monster_race *r_ptr = &r_info[k];
-        if (r_ptr->name.empty())
+        if (r_ref.idx == 0 || r_ref.name.empty())
             continue;
 
-        if (r_ptr->flags1 & RF1_UNIQUE) {
-            bool dead = (r_ptr->max_num == 0);
+        if (r_ref.flags1 & RF1_UNIQUE) {
+            bool dead = (r_ref.max_num == 0);
             if (dead) {
                 norm_total++;
 
                 /* Add a unique monster to the list */
-                who[uniq_total++] = k;
+                who[uniq_total++] = r_ref.idx;
             }
 
             continue;
         }
 
-        if (r_ptr->r_pkills > 0) {
-            norm_total += r_ptr->r_pkills;
+        if (r_ref.r_pkills > 0) {
+            norm_total += r_ref.r_pkills;
         }
     }
 

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -161,20 +161,20 @@ static void dump_aux_last_message(player_type *player_ptr, FILE *fff)
 static void dump_aux_recall(FILE *fff)
 {
     fprintf(fff, _("\n  [帰還場所]\n\n", "\n  [Recall Depth]\n\n"));
-    for (int y = 1; y < w_ptr->max_d_idx; y++) {
+    for (const auto &d_ref : d_info) {
         bool seiha = false;
 
-        if (!d_info[y].maxdepth)
+        if (d_ref.idx == 0 || !d_ref.maxdepth)
             continue;
-        if (!max_dlv[y])
+        if (!max_dlv[d_ref.idx])
             continue;
-        if (d_info[y].final_guardian) {
-            if (!r_info[d_info[y].final_guardian].max_num)
+        if (d_ref.final_guardian) {
+            if (!r_info[d_ref.final_guardian].max_num)
                 seiha = true;
-        } else if (max_dlv[y] == d_info[y].maxdepth)
+        } else if (max_dlv[d_ref.idx] == d_ref.maxdepth)
             seiha = true;
 
-        fprintf(fff, _("   %c%-12s: %3d 階\n", "   %c%-16s: level %3d\n"), seiha ? '!' : ' ', d_info[y].name.c_str(), (int)max_dlv[y]);
+        fprintf(fff, _("   %c%-12s: %3d 階\n", "   %c%-16s: level %3d\n"), seiha ? '!' : ' ', d_ref.name.c_str(), (int)max_dlv[d_ref.idx]);
     }
 }
 

--- a/src/io/interpret-pref-file.cpp
+++ b/src/io/interpret-pref-file.cpp
@@ -13,8 +13,8 @@
 #include "io/gf-descriptions.h"
 #include "io/input-key-requester.h"
 #include "io/tokenizer.h"
-#include "object/object-kind.h"
 #include "monster-race/monster-race.h"
+#include "object/object-kind.h"
 #include "system/game-option-types.h"
 #include "system/monster-race-definition.h"
 #include "system/player-type-definition.h"
@@ -35,22 +35,25 @@ char *histpref_buf = nullptr;
  */
 static errr interpret_r_token(char *buf)
 {
-	char *zz[16];
-	if (tokenize(buf + 2, 3, zz, TOKENIZE_CHECKQUOTE) != 3) return 1;
+    char *zz[16];
+    if (tokenize(buf + 2, 3, zz, TOKENIZE_CHECKQUOTE) != 3)
+        return 1;
 
-	monster_race *r_ptr;
-	int i = (int)strtol(zz[0], nullptr, 0);
-	TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], nullptr, 0);
-	SYMBOL_CODE n2 = (SYMBOL_CODE)strtol(zz[2], nullptr, 0);
-	if (i >= max_r_idx) return 1;
+    monster_race *r_ptr;
+    int i = (int)strtol(zz[0], nullptr, 0);
+    TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], nullptr, 0);
+    SYMBOL_CODE n2 = (SYMBOL_CODE)strtol(zz[2], nullptr, 0);
+    if (i >= max_r_idx)
+        return 1;
 
-	r_ptr = &r_info[i];
-	if (n1 || (!(n2 & 0x80) && n2)) r_ptr->x_attr = n1; /* Allow TERM_DARK text */
-	if (n2) r_ptr->x_char = n2;
+    r_ptr = &r_info[i];
+    if (n1 || (!(n2 & 0x80) && n2))
+        r_ptr->x_attr = n1; /* Allow TERM_DARK text */
+    if (n2)
+        r_ptr->x_char = n2;
 
-	return 0;
+    return 0;
 }
-
 
 /*!
  * @brief Kトークンの解釈 / Process "K:<num>:<a>/<c>"  -- attr/char for object kinds
@@ -59,22 +62,25 @@ static errr interpret_r_token(char *buf)
  */
 static errr interpret_k_token(char *buf)
 {
-	char *zz[16];
-	if (tokenize(buf + 2, 3, zz, TOKENIZE_CHECKQUOTE) != 3) return 1;
+    char *zz[16];
+    if (tokenize(buf + 2, 3, zz, TOKENIZE_CHECKQUOTE) != 3)
+        return 1;
 
-	object_kind *k_ptr;
-	int i = (int)strtol(zz[0], nullptr, 0);
-	TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], nullptr, 0);
-	SYMBOL_CODE n2 = (SYMBOL_CODE)strtol(zz[2], nullptr, 0);
-	if (i >= max_k_idx) return 1;
+    object_kind *k_ptr;
+    int i = (int)strtol(zz[0], nullptr, 0);
+    TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], nullptr, 0);
+    SYMBOL_CODE n2 = (SYMBOL_CODE)strtol(zz[2], nullptr, 0);
+    if (i >= max_k_idx)
+        return 1;
 
-	k_ptr = &k_info[i];
-	if (n1 || (!(n2 & 0x80) && n2)) k_ptr->x_attr = n1; /* Allow TERM_DARK text */
-	if (n2) k_ptr->x_char = n2;
+    k_ptr = &k_info[i];
+    if (n1 || (!(n2 & 0x80) && n2))
+        k_ptr->x_attr = n1; /* Allow TERM_DARK text */
+    if (n2)
+        k_ptr->x_char = n2;
 
-	return 0;
+    return 0;
 }
-
 
 /*!
  * @brief トークン数によって地形の文字形と色を決定する
@@ -84,53 +90,50 @@ static errr interpret_k_token(char *buf)
  */
 static errr decide_feature_type(int i, int num, char **zz)
 {
-	feature_type *f_ptr;
-	f_ptr = &f_info[i];
+    feature_type *f_ptr;
+    f_ptr = &f_info[i];
 
-	TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], nullptr, 0);
-	SYMBOL_CODE n2 = (SYMBOL_CODE)strtol(zz[2], nullptr, 0);
-	if (n1 || (!(n2 & 0x80) && n2)) f_ptr->x_attr[F_LIT_STANDARD] = n1; /* Allow TERM_DARK text */
-	if (n2) f_ptr->x_char[F_LIT_STANDARD] = n2;
+    TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], nullptr, 0);
+    SYMBOL_CODE n2 = (SYMBOL_CODE)strtol(zz[2], nullptr, 0);
+    if (n1 || (!(n2 & 0x80) && n2))
+        f_ptr->x_attr[F_LIT_STANDARD] = n1; /* Allow TERM_DARK text */
+    if (n2)
+        f_ptr->x_char[F_LIT_STANDARD] = n2;
 
-	switch (num)
-	{
-	case 3:
-	{
-		/* No lighting support */
-		n1 = f_ptr->x_attr[F_LIT_STANDARD];
-		n2 = f_ptr->x_char[F_LIT_STANDARD];
-		for (int j = F_LIT_NS_BEGIN; j < F_LIT_MAX; j++)
-		{
-			f_ptr->x_attr[j] = n1;
-			f_ptr->x_char[j] = n2;
-		}
+    switch (num) {
+    case 3: {
+        /* No lighting support */
+        n1 = f_ptr->x_attr[F_LIT_STANDARD];
+        n2 = f_ptr->x_char[F_LIT_STANDARD];
+        for (int j = F_LIT_NS_BEGIN; j < F_LIT_MAX; j++) {
+            f_ptr->x_attr[j] = n1;
+            f_ptr->x_char[j] = n2;
+        }
 
-		return 0;
-	}
-	case 4:
-	{
-		/* Use default lighting */
-		apply_default_feat_lighting(f_ptr->x_attr, f_ptr->x_char);
-		return 0;
-	}
-	case F_LIT_MAX * 2 + 1:
-	{
-		/* Use desired lighting */
-		for (int j = F_LIT_NS_BEGIN; j < F_LIT_MAX; j++)
-		{
-			n1 = (TERM_COLOR)strtol(zz[j * 2 + 1], nullptr, 0);
-			n2 = (SYMBOL_CODE)strtol(zz[j * 2 + 2], nullptr, 0);
-			if (n1 || (!(n2 & 0x80) && n2)) f_ptr->x_attr[j] = n1; /* Allow TERM_DARK text */
-			if (n2) f_ptr->x_char[j] = n2;
-		}
+        return 0;
+    }
+    case 4: {
+        /* Use default lighting */
+        apply_default_feat_lighting(f_ptr->x_attr, f_ptr->x_char);
+        return 0;
+    }
+    case F_LIT_MAX * 2 + 1: {
+        /* Use desired lighting */
+        for (int j = F_LIT_NS_BEGIN; j < F_LIT_MAX; j++) {
+            n1 = (TERM_COLOR)strtol(zz[j * 2 + 1], nullptr, 0);
+            n2 = (SYMBOL_CODE)strtol(zz[j * 2 + 2], nullptr, 0);
+            if (n1 || (!(n2 & 0x80) && n2))
+                f_ptr->x_attr[j] = n1; /* Allow TERM_DARK text */
+            if (n2)
+                f_ptr->x_char[j] = n2;
+        }
 
-		return 0;
-	}
-	default:
-		return 0;
-	}
+        return 0;
+    }
+    default:
+        return 0;
+    }
 }
-
 
 /*!
  * @brief Fトークンの解釈 / Process "F:<num>:<a>/<c>" -- attr/char for terrain features
@@ -143,18 +146,20 @@ static errr decide_feature_type(int i, int num, char **zz)
  */
 static errr interpret_f_token(char *buf)
 {
-	char *zz[16];
-	int num = tokenize(buf + 2, F_LIT_MAX * 2 + 1, zz, TOKENIZE_CHECKQUOTE);
+    char *zz[16];
+    int num = tokenize(buf + 2, F_LIT_MAX * 2 + 1, zz, TOKENIZE_CHECKQUOTE);
 
-	if ((num != 3) && (num != 4) && (num != F_LIT_MAX * 2 + 1)) return 1;
-	else if ((num == 4) && !streq(zz[3], "LIT")) return 1;
+    if ((num != 3) && (num != 4) && (num != F_LIT_MAX * 2 + 1))
+        return 1;
+    else if ((num == 4) && !streq(zz[3], "LIT"))
+        return 1;
 
-	int i = (int)strtol(zz[0], nullptr, 0);
-	if (i >= max_f_idx) return 1;
+    int i = (int)strtol(zz[0], nullptr, 0);
+    if (i >= max_f_idx)
+        return 1;
 
-	return decide_feature_type(i, num, zz);
+    return decide_feature_type(i, num, zz);
 }
-
 
 /*!
  * @brief Fトークンの解釈 / Process "S:<num>:<a>/<c>" -- attr/char for special things
@@ -163,17 +168,17 @@ static errr interpret_f_token(char *buf)
  */
 static errr interpret_s_token(char *buf)
 {
-	char *zz[16];
-	if (tokenize(buf + 2, 3, zz, TOKENIZE_CHECKQUOTE) != 3) return 1;
+    char *zz[16];
+    if (tokenize(buf + 2, 3, zz, TOKENIZE_CHECKQUOTE) != 3)
+        return 1;
 
-	int j = (byte)strtol(zz[0], nullptr, 0);
-	TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], nullptr, 0);
-	SYMBOL_CODE n2 = (SYMBOL_CODE)strtol(zz[2], nullptr, 0);
-	misc_to_attr[j] = n1;
-	misc_to_char[j] = n2;
-	return 0;
+    int j = (byte)strtol(zz[0], nullptr, 0);
+    TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], nullptr, 0);
+    SYMBOL_CODE n2 = (SYMBOL_CODE)strtol(zz[2], nullptr, 0);
+    misc_to_attr[j] = n1;
+    misc_to_char[j] = n2;
+    return 0;
 }
-
 
 /*!
  * @brief Uトークンの解釈 / Process "U:<tv>:<a>/<c>" -- attr/char for unaware items
@@ -182,25 +187,25 @@ static errr interpret_s_token(char *buf)
  */
 static errr interpret_u_token(char *buf)
 {
-	char *zz[16];
-	if (tokenize(buf + 2, 3, zz, TOKENIZE_CHECKQUOTE) != 3) return 1;
+    char *zz[16];
+    if (tokenize(buf + 2, 3, zz, TOKENIZE_CHECKQUOTE) != 3)
+        return 1;
 
-	int j = (int)strtol(zz[0], nullptr, 0);
-	TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], nullptr, 0);
-	SYMBOL_CODE n2 = (SYMBOL_CODE)strtol(zz[2], nullptr, 0);
-	for (int i = 1; i < max_k_idx; i++)
-	{
-		object_kind *k_ptr = &k_info[i];
-		if (k_ptr->tval == j)
-		{
-			if (n1) k_ptr->d_attr = n1;
-			if (n2) k_ptr->d_char = n2;
-		}
-	}
+    int j = (int)strtol(zz[0], nullptr, 0);
+    TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], nullptr, 0);
+    SYMBOL_CODE n2 = (SYMBOL_CODE)strtol(zz[2], nullptr, 0);
+    for (int i = 1; i < max_k_idx; i++) {
+        object_kind *k_ptr = &k_info[i];
+        if (k_ptr->tval == j) {
+            if (n1)
+                k_ptr->d_attr = n1;
+            if (n2)
+                k_ptr->d_char = n2;
+        }
+    }
 
-	return 0;
+    return 0;
 }
-
 
 /*!
  * @brief Eトークンの解釈 / Process "E:<tv>:<a>" -- attribute for inventory objects
@@ -209,15 +214,16 @@ static errr interpret_u_token(char *buf)
  */
 static errr interpret_e_token(char *buf)
 {
-	char *zz[16];
-	if (tokenize(buf + 2, 2, zz, TOKENIZE_CHECKQUOTE) != 2) return 1;
+    char *zz[16];
+    if (tokenize(buf + 2, 2, zz, TOKENIZE_CHECKQUOTE) != 2)
+        return 1;
 
-	int j = (byte)strtol(zz[0], nullptr, 0) % 128;
-	TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], nullptr, 0);
-	if (n1) tval_to_attr[j] = n1;
-	return 0;
+    int j = (byte)strtol(zz[0], nullptr, 0) % 128;
+    TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], nullptr, 0);
+    if (n1)
+        tval_to_attr[j] = n1;
+    return 0;
 }
-
 
 /*!
  * @brief Pトークンの解釈 / Process "P:<str>" -- normal macro
@@ -226,11 +232,10 @@ static errr interpret_e_token(char *buf)
  */
 static errr interpret_p_token(char *buf)
 {
-	char tmp[1024];
-	text_to_ascii(tmp, buf + 2);
-	return macro_add(tmp, macro__buf);
+    char tmp[1024];
+    text_to_ascii(tmp, buf + 2);
+    return macro_add(tmp, macro__buf);
 }
-
 
 /*!
  * @brief Cトークンの解釈 / Process "C:<str>" -- create keymap
@@ -239,22 +244,24 @@ static errr interpret_p_token(char *buf)
  */
 static errr interpret_c_token(char *buf)
 {
-	char *zz[16];
-	if (tokenize(buf + 2, 2, zz, TOKENIZE_CHECKQUOTE) != 2) return 1;
+    char *zz[16];
+    if (tokenize(buf + 2, 2, zz, TOKENIZE_CHECKQUOTE) != 2)
+        return 1;
 
-	int mode = strtol(zz[0], nullptr, 0);
-	if ((mode < 0) || (mode >= KEYMAP_MODES)) return 1;
+    int mode = strtol(zz[0], nullptr, 0);
+    if ((mode < 0) || (mode >= KEYMAP_MODES))
+        return 1;
 
-	char tmp[1024];
-	text_to_ascii(tmp, zz[1]);
-	if (!tmp[0] || tmp[1]) return 1;
+    char tmp[1024];
+    text_to_ascii(tmp, zz[1]);
+    if (!tmp[0] || tmp[1])
+        return 1;
 
-	int i = (byte)(tmp[0]);
-	string_free(keymap_act[mode][i]);
-	keymap_act[mode][i] = string_make(macro__buf);
-	return 0;
+    int i = (byte)(tmp[0]);
+    string_free(keymap_act[mode][i]);
+    keymap_act[mode][i] = string_make(macro__buf);
+    return 0;
 }
-
 
 /*!
  * @brief Vトークンの解釈 / Process "V:<num>:<kv>:<rv>:<gv>:<bv>" -- visual info
@@ -263,17 +270,17 @@ static errr interpret_c_token(char *buf)
  */
 static errr interpret_v_token(char *buf)
 {
-	char *zz[16];
-	if (tokenize(buf + 2, 5, zz, TOKENIZE_CHECKQUOTE) != 5) return 1;
+    char *zz[16];
+    if (tokenize(buf + 2, 5, zz, TOKENIZE_CHECKQUOTE) != 5)
+        return 1;
 
-	int i = (byte)strtol(zz[0], nullptr, 0);
-	angband_color_table[i][0] = (byte)strtol(zz[1], nullptr, 0);
-	angband_color_table[i][1] = (byte)strtol(zz[2], nullptr, 0);
-	angband_color_table[i][2] = (byte)strtol(zz[3], nullptr, 0);
-	angband_color_table[i][3] = (byte)strtol(zz[4], nullptr, 0);
-	return 0;
+    int i = (byte)strtol(zz[0], nullptr, 0);
+    angband_color_table[i][0] = (byte)strtol(zz[1], nullptr, 0);
+    angband_color_table[i][1] = (byte)strtol(zz[2], nullptr, 0);
+    angband_color_table[i][2] = (byte)strtol(zz[3], nullptr, 0);
+    angband_color_table[i][3] = (byte)strtol(zz[4], nullptr, 0);
+    return 0;
 }
-
 
 /*!
  * @brief X/Yトークンの解釈
@@ -286,41 +293,37 @@ static errr interpret_v_token(char *buf)
  */
 static errr interpret_xy_token(player_type *player_ptr, char *buf)
 {
-	for (int i = 0; option_info[i].o_desc; i++)
-	{
-		bool is_option = option_info[i].o_var != nullptr;
-		is_option &= option_info[i].o_text != nullptr;
-		is_option &= streq(option_info[i].o_text, buf + 2);
-		if (!is_option) continue;
+    for (int i = 0; option_info[i].o_desc; i++) {
+        bool is_option = option_info[i].o_var != nullptr;
+        is_option &= option_info[i].o_text != nullptr;
+        is_option &= streq(option_info[i].o_text, buf + 2);
+        if (!is_option)
+            continue;
 
-		int os = option_info[i].o_set;
-		int ob = option_info[i].o_bit;
+        int os = option_info[i].o_set;
+        int ob = option_info[i].o_bit;
 
-		if ((player_ptr->playing || w_ptr->character_xtra) &&
-			(OPT_PAGE_BIRTH == option_info[i].o_page) && !w_ptr->wizard)
-		{
-			msg_format(_("初期オプションは変更できません! '%s'", "Birth options can not changed! '%s'"), buf);
-			msg_print(nullptr);
-			return 0;
-		}
+        if ((player_ptr->playing || w_ptr->character_xtra) && (OPT_PAGE_BIRTH == option_info[i].o_page) && !w_ptr->wizard) {
+            msg_format(_("初期オプションは変更できません! '%s'", "Birth options can not changed! '%s'"), buf);
+            msg_print(nullptr);
+            return 0;
+        }
 
-		if (buf[0] == 'X')
-		{
-			option_flag[os] &= ~(1UL << ob);
-			(*option_info[i].o_var) = false;
-			return 0;
-		}
+        if (buf[0] == 'X') {
+            option_flag[os] &= ~(1UL << ob);
+            (*option_info[i].o_var) = false;
+            return 0;
+        }
 
-		option_flag[os] |= (1UL << ob);
-		(*option_info[i].o_var) = true;
-		return 0;
-	}
+        option_flag[os] |= (1UL << ob);
+        (*option_info[i].o_var) = true;
+        return 0;
+    }
 
-	msg_format(_("オプションの名前が正しくありません： %s", "Ignored invalid option: %s"), buf);
-	msg_print(nullptr);
-	return 0;
+    msg_format(_("オプションの名前が正しくありません： %s", "Ignored invalid option: %s"), buf);
+    msg_print(nullptr);
+    return 0;
 }
-
 
 /*!
  * @brief Zトークンの解釈 / Process "Z:<type>:<str>" -- set spell color
@@ -330,21 +333,21 @@ static errr interpret_xy_token(player_type *player_ptr, char *buf)
  */
 static errr interpret_z_token(char *buf)
 {
-	char *t = angband_strchr(buf + 2, ':');
-	if (!t) return 1;
+    char *t = angband_strchr(buf + 2, ':');
+    if (!t)
+        return 1;
 
-	*(t++) = '\0';
-	for (int i = 0; i < MAX_NAMED_NUM; i++)
-	{
-		if (!streq(gf_desc[i].name, buf + 2)) continue;
+    *(t++) = '\0';
+    for (int i = 0; i < MAX_NAMED_NUM; i++) {
+        if (!streq(gf_desc[i].name, buf + 2))
+            continue;
 
-		gf_color[gf_desc[i].num] = (TERM_COLOR)quark_add(t);
-		return 0;
-	}
+        gf_color[gf_desc[i].num] = (TERM_COLOR)quark_add(t);
+        return 0;
+    }
 
-	return 1;
+    return 1;
 }
-
 
 /*!
  * @brief Tトークンの解釈 / Process "T:<template>:<modifier chr>:<modifier name>:..." for 4 tokens
@@ -354,43 +357,40 @@ static errr interpret_z_token(char *buf)
  */
 static errr decide_template_modifier(int tok, char **zz)
 {
-	if (macro_template != nullptr)
-	{
-		int macro_modifier_length = strlen(macro_modifier_chr);
-		string_free(macro_template);
-		macro_template = nullptr;
-		string_free(macro_modifier_chr);
-		for (int i = 0; i < macro_modifier_length; i++)
-		{
-			string_free(macro_modifier_name[i]);
-		}
+    if (macro_template != nullptr) {
+        int macro_modifier_length = strlen(macro_modifier_chr);
+        string_free(macro_template);
+        macro_template = nullptr;
+        string_free(macro_modifier_chr);
+        for (int i = 0; i < macro_modifier_length; i++) {
+            string_free(macro_modifier_name[i]);
+        }
 
-		for (int i = 0; i < max_macrotrigger; i++)
-		{
-			string_free(macro_trigger_name[i]);
-			string_free(macro_trigger_keycode[0][i]);
-			string_free(macro_trigger_keycode[1][i]);
-		}
+        for (int i = 0; i < max_macrotrigger; i++) {
+            string_free(macro_trigger_name[i]);
+            string_free(macro_trigger_keycode[0][i]);
+            string_free(macro_trigger_keycode[1][i]);
+        }
 
-		max_macrotrigger = 0;
-	}
+        max_macrotrigger = 0;
+    }
 
-	if (*zz[0] == '\0') return 0;
+    if (*zz[0] == '\0')
+        return 0;
 
-	int zz_length = strlen(zz[1]);
-	zz_length = MIN(MAX_MACRO_MOD, zz_length);
-	if (2 + zz_length != tok) return 1;
+    int zz_length = strlen(zz[1]);
+    zz_length = MIN(MAX_MACRO_MOD, zz_length);
+    if (2 + zz_length != tok)
+        return 1;
 
-	macro_template = string_make(zz[0]);
-	macro_modifier_chr = string_make(zz[1]);
-	for (int i = 0; i < zz_length; i++)
-	{
-		macro_modifier_name[i] = string_make(zz[2 + i]);
-	}
+    macro_template = string_make(zz[0]);
+    macro_modifier_chr = string_make(zz[1]);
+    for (int i = 0; i < zz_length; i++) {
+        macro_modifier_name[i] = string_make(zz[2 + i]);
+    }
 
-	return 0;
+    return 0;
 }
-
 
 /*!
  * @brief Tトークンの解釈 / Process "T:<trigger>:<keycode>:<shift-keycode>" for 2 or 3 tokens
@@ -400,37 +400,34 @@ static errr decide_template_modifier(int tok, char **zz)
  */
 static errr interpret_macro_keycodes(int tok, char **zz)
 {
-	char buf_aux[MAX_MACRO_CHARS];
-	char *t, *s;
-	if (max_macrotrigger >= MAX_MACRO_TRIG)
-	{
-		msg_print(_("マクロトリガーの設定が多すぎます!", "Too many macro triggers!"));
-		return 1;
-	}
+    char buf_aux[MAX_MACRO_CHARS];
+    char *t, *s;
+    if (max_macrotrigger >= MAX_MACRO_TRIG) {
+        msg_print(_("マクロトリガーの設定が多すぎます!", "Too many macro triggers!"));
+        return 1;
+    }
 
-	int m = max_macrotrigger;
-	max_macrotrigger++;
-	t = buf_aux;
-	s = zz[0];
-	while (*s)
-	{
-		if ('\\' == *s) s++;
-		*t++ = *s++;
-	}
+    int m = max_macrotrigger;
+    max_macrotrigger++;
+    t = buf_aux;
+    s = zz[0];
+    while (*s) {
+        if ('\\' == *s)
+            s++;
+        *t++ = *s++;
+    }
 
-	*t = '\0';
-	macro_trigger_name[m] = string_make(buf_aux);
-	macro_trigger_keycode[0][m] = string_make(zz[1]);
-	if (tok == 3)
-	{
-		macro_trigger_keycode[1][m] = string_make(zz[2]);
-		return 0;
-	}
+    *t = '\0';
+    macro_trigger_name[m] = string_make(buf_aux);
+    macro_trigger_keycode[0][m] = string_make(zz[1]);
+    if (tok == 3) {
+        macro_trigger_keycode[1][m] = string_make(zz[2]);
+        return 0;
+    }
 
-	macro_trigger_keycode[1][m] = string_make(zz[1]);
-	return 0;
+    macro_trigger_keycode[1][m] = string_make(zz[1]);
+    return 0;
 }
-
 
 /*!
  * @brief Tトークンの個数調査 (解釈はサブルーチンで) / Initialize macro trigger names and a template
@@ -440,14 +437,15 @@ static errr interpret_macro_keycodes(int tok, char **zz)
  */
 static errr interpret_t_token(char *buf)
 {
-	char *zz[16];
-	int tok = tokenize(buf + 2, 2 + MAX_MACRO_MOD, zz, 0);
-	if (tok >= 4) return decide_template_modifier(tok, zz);
-	if (tok < 2) return 0;
+    char *zz[16];
+    int tok = tokenize(buf + 2, 2 + MAX_MACRO_MOD, zz, 0);
+    if (tok >= 4)
+        return decide_template_modifier(tok, zz);
+    if (tok < 2)
+        return 0;
 
-	return interpret_macro_keycodes(tok, zz);
+    return interpret_macro_keycodes(tok, zz);
 }
-
 
 /*!
  * @brief 設定ファイルの各行から各種テキスト情報を取得する /
@@ -474,50 +472,48 @@ static errr interpret_t_token(char *buf)
  */
 errr interpret_pref_file(player_type *player_ptr, char *buf)
 {
-	if (buf[1] != ':') return 1;
+    if (buf[1] != ':')
+        return 1;
 
-	switch (buf[0])
-	{
-	case 'H':
-	{
-		/* Process "H:<history>" */
-		add_history_from_pref_line(buf + 2);
-		return 0;
-	}
-	case 'R':
-		return interpret_r_token(buf);
-	case 'K':
-		return interpret_k_token(buf);
-	case 'F':
-		return interpret_f_token(buf);
-	case 'S':
-		return interpret_s_token(buf);
-	case 'U':
-		return interpret_u_token(buf);
-	case 'E':
-		return interpret_e_token(buf);
-	case 'A':
-	{
-		/* Process "A:<str>" -- save an "action" for later */
-		text_to_ascii(macro__buf, buf + 2);
-		return 0;
-	}
-	case 'P':
-		return interpret_p_token(buf);
-	case 'C':
-		return interpret_c_token(buf);
-	case 'V':
-		return interpret_v_token(buf);
-	case 'X':
-	case 'Y':
-		return interpret_xy_token(player_ptr, buf);
-	case 'Z':
-		return interpret_z_token(buf);
-	case 'T':
-		return interpret_t_token(buf);
-	default:
-		return 1;
-	}
+    switch (buf[0]) {
+    case 'H': {
+        /* Process "H:<history>" */
+        add_history_from_pref_line(buf + 2);
+        return 0;
+    }
+    case 'R':
+        return interpret_r_token(buf);
+    case 'K':
+        return interpret_k_token(buf);
+    case 'F':
+        return interpret_f_token(buf);
+    case 'S':
+        return interpret_s_token(buf);
+    case 'U':
+        return interpret_u_token(buf);
+    case 'E':
+        return interpret_e_token(buf);
+    case 'A': {
+        /* Process "A:<str>" -- save an "action" for later */
+        text_to_ascii(macro__buf, buf + 2);
+        return 0;
+    }
+    case 'P':
+        return interpret_p_token(buf);
+    case 'C':
+        return interpret_c_token(buf);
+    case 'V':
+        return interpret_v_token(buf);
+    case 'X':
+    case 'Y':
+        return interpret_xy_token(player_ptr, buf);
+    case 'Z':
+        return interpret_z_token(buf);
+    case 'T':
+        return interpret_t_token(buf);
+    default:
+        return 1;
+    }
 }
 
 /*!

--- a/src/io/interpret-pref-file.cpp
+++ b/src/io/interpret-pref-file.cpp
@@ -194,13 +194,12 @@ static errr interpret_u_token(char *buf)
     int j = (int)strtol(zz[0], nullptr, 0);
     TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], nullptr, 0);
     SYMBOL_CODE n2 = (SYMBOL_CODE)strtol(zz[2], nullptr, 0);
-    for (int i = 1; i < max_k_idx; i++) {
-        object_kind *k_ptr = &k_info[i];
-        if (k_ptr->tval == j) {
+    for (auto &k_ref : k_info) {
+        if (k_ref.idx > 0 && k_ref.tval == j) {
             if (n1)
-                k_ptr->d_attr = n1;
+                k_ref.d_attr = n1;
             if (n2)
-                k_ptr->d_char = n2;
+                k_ref.d_char = n2;
         }
     }
 

--- a/src/knowledge/knowledge-experiences.cpp
+++ b/src/knowledge/knowledge-experiences.cpp
@@ -34,17 +34,15 @@ void do_cmd_knowledge_weapon_exp(player_type *player_ptr)
     for (int i = 0; i < 5; i++) {
         for (int num = 0; num < 64; num++) {
             char tmp[30];
-            for (KIND_OBJECT_IDX j = 0; j < max_k_idx; j++) {
-                object_kind *k_ptr = &k_info[j];
-
-                if ((k_ptr->tval != TV_SWORD - i) || (k_ptr->sval != num))
+            for (const auto &k_ref : k_info) {
+                if ((k_ref.tval != TV_SWORD - i) || (k_ref.sval != num))
                     continue;
-                if ((k_ptr->tval == TV_BOW) && (k_ptr->sval == SV_CRIMSON || k_ptr->sval == SV_HARP))
+                if ((k_ref.tval == TV_BOW) && (k_ref.sval == SV_CRIMSON || k_ref.sval == SV_HARP))
                     continue;
 
                 SUB_EXP weapon_exp = player_ptr->weapon_exp[4 - i][num];
                 SUB_EXP weapon_max = s_info[player_ptr->pclass].w_max[4 - i][num];
-                strip_name(tmp, j);
+                strip_name(tmp, k_ref.idx);
                 fprintf(fff, "%-25s ", tmp);
                 if (show_actual_value)
                     fprintf(fff, "%4d/%4d ", MIN(weapon_exp, weapon_max), weapon_max);

--- a/src/knowledge/knowledge-features.cpp
+++ b/src/knowledge/knowledge-features.cpp
@@ -349,20 +349,20 @@ void do_cmd_knowledge_dungeon(player_type *player_ptr)
     if (!open_temporary_file(&fff, file_name))
         return;
 
-    for (int i = 1; i < w_ptr->max_d_idx; i++) {
+    for (const auto &d_ref : d_info) {
         bool seiha = false;
 
-        if (!d_info[i].maxdepth)
+        if (d_ref.idx == 0 || !d_ref.maxdepth)
             continue;
-        if (!max_dlv[i])
+        if (!max_dlv[d_ref.idx])
             continue;
-        if (d_info[i].final_guardian) {
-            if (!r_info[d_info[i].final_guardian].max_num)
+        if (d_ref.final_guardian) {
+            if (!r_info[d_ref.final_guardian].max_num)
                 seiha = true;
-        } else if (max_dlv[i] == d_info[i].maxdepth)
+        } else if (max_dlv[d_ref.idx] == d_ref.maxdepth)
             seiha = true;
 
-        fprintf(fff, _("%c%-12s :  %3d 階\n", "%c%-16s :  level %3d\n"), seiha ? '!' : ' ', d_info[i].name.c_str(), (int)max_dlv[i]);
+        fprintf(fff, _("%c%-12s :  %3d 階\n", "%c%-16s :  level %3d\n"), seiha ? '!' : ' ', d_ref.name.c_str(), (int)max_dlv[d_ref.idx]);
     }
 
     angband_fclose(fff);

--- a/src/knowledge/knowledge-features.cpp
+++ b/src/knowledge/knowledge-features.cpp
@@ -29,14 +29,13 @@
 static FEAT_IDX collect_features(FEAT_IDX *feat_idx, BIT_FLAGS8 mode)
 {
     FEAT_IDX feat_cnt = 0;
-    for (FEAT_IDX i = 0; i < max_f_idx; i++) {
-        feature_type *f_ptr = &f_info[i];
-        if (f_ptr->name.empty())
+    for (const auto &f_ref : f_info) {
+        if (f_ref.name.empty())
             continue;
-        if (f_ptr->mimic != i)
+        if (f_ref.mimic != f_ref.idx)
             continue;
 
-        feat_idx[feat_cnt++] = i;
+        feat_idx[feat_cnt++] = f_ref.idx;
         if (mode & 0x01)
             break;
     }

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -51,15 +51,14 @@ void do_cmd_knowledge_artifacts(player_type *player_ptr)
     bool *okay;
     C_MAKE(okay, max_a_idx, bool);
 
-    for (ARTIFACT_IDX k = 0; k < max_a_idx; k++) {
-        artifact_type *a_ptr = &a_info[k];
-        okay[k] = false;
-        if (a_ptr->name.empty())
+    for (const auto &a_ref : a_info) {
+        okay[a_ref.idx] = false;
+        if (a_ref.name.empty())
             continue;
-        if (!a_ptr->cur_num)
+        if (!a_ref.cur_num)
             continue;
 
-        okay[k] = true;
+        okay[a_ref.idx] = true;
     }
 
     for (POSITION y = 0; y < player_ptr->current_floor_ptr->height; y++) {
@@ -91,9 +90,9 @@ void do_cmd_knowledge_artifacts(player_type *player_ptr)
     }
 
     int n = 0;
-    for (ARTIFACT_IDX k = 0; k < max_a_idx; k++) {
-        if (okay[k])
-            who[n++] = k;
+    for (const auto &a_ref : a_info) {
+        if (okay[a_ref.idx])
+            who[n++] = a_ref.idx;
     }
 
     uint16_t why = 3;

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -32,6 +32,8 @@
 #include "view/display-messages.h"
 #include "world/world.h"
 
+#include <numeric>
+
 /*! 
  * @brief Check the status of "artifacts"
  * @param player_ptr プレイヤーへの参照ポインタ
@@ -132,33 +134,30 @@ static KIND_OBJECT_IDX collect_objects(int grp_cur, KIND_OBJECT_IDX object_idx[]
 {
     KIND_OBJECT_IDX object_cnt = 0;
     byte group_tval = object_group_tval[grp_cur];
-    for (KIND_OBJECT_IDX i = 0; i < max_k_idx; i++) {
-        object_kind *k_ptr = &k_info[i];
-        if (k_ptr->name.empty())
+    for (const auto &k_ref : k_info) {
+        if (k_ref.name.empty())
             continue;
 
         if (!(mode & 0x02)) {
             if (!w_ptr->wizard) {
-                if (!k_ptr->flavor)
+                if (!k_ref.flavor)
                     continue;
-                if (!k_ptr->aware)
+                if (!k_ref.aware)
                     continue;
             }
 
-            int k = 0;
-            for (int j = 0; j < 4; j++)
-                k += k_ptr->chance[j];
+            auto k = std::reduce(std::begin(k_ref.chance), std::end(k_ref.chance));
             if (!k)
                 continue;
         }
 
         if (TV_LIFE_BOOK == group_tval) {
-            if (TV_LIFE_BOOK <= k_ptr->tval && k_ptr->tval <= TV_HEX_BOOK) {
-                object_idx[object_cnt++] = i;
+            if (TV_LIFE_BOOK <= k_ref.tval && k_ref.tval <= TV_HEX_BOOK) {
+                object_idx[object_cnt++] = k_ref.idx;
             } else
                 continue;
-        } else if (k_ptr->tval == group_tval) {
-            object_idx[object_cnt++] = i;
+        } else if (k_ref.tval == group_tval) {
+            object_idx[object_cnt++] = k_ref.idx;
         } else
             continue;
 

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -58,24 +58,23 @@ static IDX collect_monsters(player_type *player_ptr, IDX grp_cur, IDX mon_idx[],
     bool grp_amberite = (monster_group_char[grp_cur] == (char *)-4L);
 
     IDX mon_cnt = 0;
-    for (IDX i = 0; i < max_r_idx; i++) {
-        monster_race *r_ptr = &r_info[i];
-        if (r_ptr->name.empty())
+    for (const auto &r_ref : r_info) {
+        if (r_ref.name.empty())
             continue;
-        if (((mode != MONSTER_LORE_DEBUG) && (mode != MONSTER_LORE_RESEARCH)) && !cheat_know && !r_ptr->r_sights)
+        if (((mode != MONSTER_LORE_DEBUG) && (mode != MONSTER_LORE_RESEARCH)) && !cheat_know && !r_ref.r_sights)
             continue;
 
         if (grp_unique) {
-            if (none_bits(r_ptr->flags1, RF1_UNIQUE))
+            if (none_bits(r_ref.flags1, RF1_UNIQUE))
                 continue;
         } else if (grp_riding) {
-            if (none_bits(r_ptr->flags7, RF7_RIDING))
+            if (none_bits(r_ref.flags7, RF7_RIDING))
                 continue;
         } else if (grp_wanted) {
             bool wanted = false;
             for (int j = 0; j < MAX_BOUNTY; j++) {
-                if (w_ptr->bounty_r_idx[j] == i || w_ptr->bounty_r_idx[j] - 10000 == i
-                    || (player_ptr->today_mon && player_ptr->today_mon == i)) {
+                if (w_ptr->bounty_r_idx[j] == r_ref.idx || w_ptr->bounty_r_idx[j] - 10000 == r_ref.idx
+                    || (player_ptr->today_mon && player_ptr->today_mon == r_ref.idx)) {
                     wanted = true;
                     break;
                 }
@@ -84,14 +83,14 @@ static IDX collect_monsters(player_type *player_ptr, IDX grp_cur, IDX mon_idx[],
             if (!wanted)
                 continue;
         } else if (grp_amberite) {
-            if (none_bits(r_ptr->flags3, RF3_AMBERITE))
+            if (none_bits(r_ref.flags3, RF3_AMBERITE))
                 continue;
         } else {
-            if (!angband_strchr(group_char, r_ptr->d_char))
+            if (!angband_strchr(group_char, r_ref.d_char))
                 continue;
         }
 
-        mon_idx[mon_cnt++] = i;
+        mon_idx[mon_cnt++] = r_ref.idx;
         if (mode == MONSTER_LORE_NORMAL)
             break;
         if (mode == MONSTER_LORE_DEBUG)
@@ -157,23 +156,17 @@ void do_cmd_knowledge_kill_count(player_type *player_ptr)
     if (!open_temporary_file(&fff, file_name))
         return;
 
-    MONRACE_IDX *who;
-    C_MAKE(who, max_r_idx, MONRACE_IDX);
     int32_t total = 0;
-    for (int kk = 1; kk < max_r_idx; kk++) {
-        monster_race *r_ptr = &r_info[kk];
-
-        if (any_bits(r_ptr->flags1, RF1_UNIQUE)) {
-            bool dead = (r_ptr->max_num == 0);
+    for (const auto &r_ref : r_info) {
+        if (any_bits(r_ref.flags1, RF1_UNIQUE)) {
+            bool dead = (r_ref.max_num == 0);
 
             if (dead) {
                 total++;
             }
         } else {
-            MONSTER_NUMBER this_monster = r_ptr->r_pkills;
-
-            if (this_monster > 0) {
-                total += this_monster;
+            if (r_ref.r_pkills > 0) {
+                total += r_ref.r_pkills;
             }
         }
     }
@@ -187,19 +180,18 @@ void do_cmd_knowledge_kill_count(player_type *player_ptr)
         fprintf(fff, "You have defeated %ld %s.\n\n", (long int)total, (total == 1) ? "enemy" : "enemies");
 #endif
 
+    std::vector<MONRACE_IDX> who;
     total = 0;
-    int n = 0;
-    for (MONRACE_IDX i = 1; i < max_r_idx; i++) {
-        monster_race *r_ptr = &r_info[i];
-        if (!r_ptr->name.empty())
-            who[n++] = i;
+    for (const auto &r_ref : r_info) {
+        if (r_ref.idx > 0 && !r_ref.name.empty())
+            who.push_back(r_ref.idx);
     }
 
     uint16_t why = 2;
     char buf[80];
-    ang_sort(player_ptr, who, &why, n, ang_sort_comp_hook, ang_sort_swap_hook);
-    for (int k = 0; k < n; k++) {
-        monster_race *r_ptr = &r_info[who[k]];
+    ang_sort(player_ptr, who.data(), &why, who.size(), ang_sort_comp_hook, ang_sort_swap_hook);
+    for (auto r_idx : who) {
+        monster_race *r_ptr = &r_info[r_idx];
         if (any_bits(r_ptr->flags1, RF1_UNIQUE)) {
             bool dead = (r_ptr->max_num == 0);
             if (dead) {
@@ -247,7 +239,6 @@ void do_cmd_knowledge_kill_count(player_type *player_ptr)
     fprintf(fff, "   Total: %lu creature%s killed.\n", (ulong)total, (total == 1 ? "" : "s"));
 #endif
 
-    C_KILL(who, max_r_idx, int16_t);
     angband_fclose(fff);
     (void)show_file(player_ptr, true, file_name, _("倒した敵の数", "Kill Count"), 0, 0);
     fd_kill(file_name);

--- a/src/knowledge/knowledge-uniques.cpp
+++ b/src/knowledge/knowledge-uniques.cpp
@@ -139,13 +139,15 @@ void do_cmd_knowledge_uniques(player_type *player_ptr, bool is_alive)
         return;
 
     C_MAKE(unique_list_ptr->who, max_r_idx, MONRACE_IDX);
-    for (IDX i = 1; i < max_r_idx; i++) {
-        monster_race *r_ptr = &r_info[i];
-        if (!sweep_uniques(r_ptr, unique_list_ptr->is_alive))
+    for (auto &r_ref : r_info) {
+        if (r_ref.idx == 0) {
+            continue;
+        }
+        if (!sweep_uniques(&r_ref, unique_list_ptr->is_alive))
             continue;
 
-        if (r_ptr->level) {
-            int lev = (r_ptr->level - 1) / 10;
+        if (r_ref.level) {
+            int lev = (r_ref.level - 1) / 10;
             if (lev < 10) {
                 unique_list_ptr->num_uniques[lev]++;
                 if (unique_list_ptr->max_lev < lev)
@@ -155,7 +157,7 @@ void do_cmd_knowledge_uniques(player_type *player_ptr, bool is_alive)
         } else
             unique_list_ptr->num_uniques_surface++;
 
-        unique_list_ptr->who[unique_list_ptr->n++] = i;
+        unique_list_ptr->who[unique_list_ptr->n++] = r_ref.idx;
     }
 
     ang_sort(player_ptr, unique_list_ptr->who, &unique_list_ptr->why, unique_list_ptr->n, ang_sort_comp_hook, ang_sort_swap_hook);

--- a/src/load/quest-loader.cpp
+++ b/src/load/quest-loader.cpp
@@ -22,13 +22,12 @@
 void rd_unique_info(void)
 {
     const int MAX_TRIES = 100;
-    for (int i = 0; i < max_r_idx; i++) {
-        monster_race *r_ptr = &r_info[i];
-        r_ptr->max_num = MAX_TRIES;
-        if (r_ptr->flags1 & RF1_UNIQUE)
-            r_ptr->max_num = 1;
-        else if (r_ptr->flags7 & RF7_NAZGUL)
-            r_ptr->max_num = MAX_NAZGUL_NUM;
+    for (auto &r_ref : r_info) {
+        r_ref.max_num = MAX_TRIES;
+        if (r_ref.flags1 & RF1_UNIQUE)
+            r_ref.max_num = 1;
+        else if (r_ref.flags7 & RF7_NAZGUL)
+            r_ref.max_num = MAX_NAZGUL_NUM;
     }
 }
 

--- a/src/main/angband-initializer.cpp
+++ b/src/main/angband-initializer.cpp
@@ -297,9 +297,9 @@ void init_angband(player_type *player_ptr, bool no_term)
     if (init_d_info())
         quit(_("ダンジョン初期化不能", "Cannot initialize dungeon"));
 
-    for (int i = 1; i < w_ptr->max_d_idx; i++)
-        if (d_info[i].final_guardian)
-            r_info[d_info[i].final_guardian].flags7 |= RF7_GUARDIAN;
+    for (const auto &d_ref : d_info)
+        if (d_ref.idx > 0 && d_ref.final_guardian)
+            r_info[d_ref.final_guardian].flags7 |= RF7_GUARDIAN;
 
     init_note(_("[データの初期化中... (魔法)]", "[Initializing arrays... (magic)]"));
     if (init_m_info())

--- a/src/main/game-data-initializer.cpp
+++ b/src/main/game-data-initializer.cpp
@@ -162,9 +162,11 @@ errr init_alloc(void)
     monster_race *r_ptr;
     tag_type *elements;
     C_MAKE(elements, max_r_idx, tag_type);
-    for (int i = 1; i < max_r_idx; i++) {
-        elements[i].tag = r_info[i].level;
-        elements[i].index = i;
+    for (const auto &r_ref : r_info) {
+        if (r_ref.idx > 0) {
+            elements[r_ref.idx].tag = r_ref.level;
+            elements[r_ref.idx].index = r_ref.idx;
+        }
     }
 
     tag_sort(elements, max_r_idx);

--- a/src/main/game-data-initializer.cpp
+++ b/src/main/game-data-initializer.cpp
@@ -106,23 +106,19 @@ errr init_other(player_type *player_ptr)
  */
 errr init_object_alloc(void)
 {
-    int16_t aux[MAX_DEPTH];
-    (void)C_WIPE(aux, MAX_DEPTH, int16_t);
+    int16_t aux[MAX_DEPTH] = {};
 
-    int16_t num[MAX_DEPTH];
-    (void)C_WIPE(num, MAX_DEPTH, int16_t);
+    int16_t num[MAX_DEPTH] = {};
 
     if (alloc_kind_table)
         C_KILL(alloc_kind_table, alloc_kind_size, alloc_entry);
 
     alloc_kind_size = 0;
-    for (int i = 1; i < max_k_idx; i++) {
-        object_kind *k_ptr;
-        k_ptr = &k_info[i];
+    for (const auto &k_ref : k_info) {
         for (int j = 0; j < 4; j++) {
-            if (k_ptr->chance[j]) {
+            if (k_ref.chance[j]) {
                 alloc_kind_size++;
-                num[k_ptr->locale[j]]++;
+                num[k_ref.locale[j]]++;
             }
         }
     }
@@ -136,18 +132,16 @@ errr init_object_alloc(void)
     C_MAKE(alloc_kind_table, alloc_kind_size, alloc_entry);
     alloc_entry *table;
     table = alloc_kind_table;
-    for (int i = 1; i < max_k_idx; i++) {
-        object_kind *k_ptr;
-        k_ptr = &k_info[i];
+    for (const auto &k_ref : k_info) {
         for (int j = 0; j < 4; j++) {
-            if (k_ptr->chance[j] == 0)
+            if (k_ref.chance[j] == 0)
                 continue;
 
-            int x = k_ptr->locale[j];
-            int p = (100 / k_ptr->chance[j]);
+            int x = k_ref.locale[j];
+            int p = (100 / k_ref.chance[j]);
             int y = (x > 0) ? num[x - 1] : 0;
             int z = y + aux[x];
-            table[z].index = (KIND_OBJECT_IDX)i;
+            table[z].index = k_ref.idx;
             table[z].level = (DEPTH)x;
             table[z].prob1 = (PROB)p;
             table[z].prob2 = (PROB)p;

--- a/src/market/arena.cpp
+++ b/src/market/arena.cpp
@@ -171,9 +171,9 @@ void update_gambling_monsters(player_type *player_ptr)
     int power[4];
     bool tekitou;
 
-    for (i = 0; i < w_ptr->max_d_idx; i++) {
-        if (max_dl < max_dlv[i])
-            max_dl = max_dlv[i];
+    for (const auto &d_ref : d_info) {
+        if (max_dl < max_dlv[d_ref.idx])
+            max_dl = max_dlv[d_ref.idx];
     }
 
     mon_level = randint1(MIN(max_dl, 122)) + 5;

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -270,13 +270,13 @@ void show_bounty(void)
  */
 void determine_daily_bounty(player_type *player_ptr, bool conv_old)
 {
-    int max_dl = 3, i;
+    int max_dl = 3;
     if (!conv_old) {
-        for (i = 0; i < w_ptr->max_d_idx; i++) {
-            if (max_dlv[i] < d_info[i].mindepth)
+        for (const auto &d_ref : d_info) {
+            if (max_dlv[d_ref.idx] < d_ref.mindepth)
                 continue;
-            if (max_dl < max_dlv[i])
-                max_dl = max_dlv[i];
+            if (max_dl < max_dlv[d_ref.idx])
+                max_dl = max_dlv[d_ref.idx];
         }
     } else {
         max_dl = MAX(max_dlv[DUNGEON_ANGBAND], 3);

--- a/src/market/building-craft-fix.cpp
+++ b/src/market/building-craft-fix.cpp
@@ -147,18 +147,16 @@ static PRICE repair_broken_weapon_aux(player_type *player_ptr, PRICE bcost)
     if (o_ptr->sval == SV_BROKEN_DAGGER) {
         int n = 1;
         k_idx = 0;
-        for (KIND_OBJECT_IDX j = 1; j < max_k_idx; j++) {
-            object_kind *k_aux_ptr = &k_info[j];
-
-            if (k_aux_ptr->tval != TV_SWORD)
+        for (const auto &k_ref : k_info) {
+            if (k_ref.tval != TV_SWORD)
                 continue;
-            if ((k_aux_ptr->sval == SV_BROKEN_DAGGER) || (k_aux_ptr->sval == SV_BROKEN_SWORD) || (k_aux_ptr->sval == SV_POISON_NEEDLE))
+            if ((k_ref.sval == SV_BROKEN_DAGGER) || (k_ref.sval == SV_BROKEN_SWORD) || (k_ref.sval == SV_POISON_NEEDLE))
                 continue;
-            if (k_aux_ptr->weight > 99)
+            if (k_ref.weight > 99)
                 continue;
 
             if (one_in_(n)) {
-                k_idx = j;
+                k_idx = k_ref.idx;
                 n++;
             }
         }

--- a/src/market/building-monster.cpp
+++ b/src/market/building-monster.cpp
@@ -89,20 +89,18 @@ bool research_mon(player_type *player_ptr)
 
     /* Collect matching monsters */
     int n = 0;
-    for (i = 1; i < max_r_idx; i++) {
-        monster_race *r_ptr = &r_info[i];
-
+    for (const auto &r_ref : r_info) {
         /* Empty monster */
-        if (r_ptr->name.empty())
+        if (r_ref.idx == 0 || r_ref.name.empty())
             continue;
 
         /* XTRA HACK WHATSEARCH */
         /* Require non-unique monsters if needed */
-        if (norm && (r_ptr->flags1 & (RF1_UNIQUE)))
+        if (norm && (r_ref.flags1 & (RF1_UNIQUE)))
             continue;
 
         /* Require unique monsters if needed */
-        if (uniq && !(r_ptr->flags1 & (RF1_UNIQUE)))
+        if (uniq && !(r_ref.flags1 & (RF1_UNIQUE)))
             continue;
 
         /* 名前検索 */
@@ -120,9 +118,9 @@ bool research_mon(player_type *player_ptr)
 
             char temp2[MAX_MONSTER_NAME];
 #ifdef JP
-            strcpy(temp2, r_ptr->E_name.c_str());
+            strcpy(temp2, r_ref.E_name.c_str());
 #else
-            strcpy(temp2, r_ptr->name.c_str());
+            strcpy(temp2, r_ref.name.c_str());
 #endif
             for (int xx = 0; temp2[xx] && xx < 80; xx++) {
                 if (isupper(temp2[xx]))
@@ -130,12 +128,12 @@ bool research_mon(player_type *player_ptr)
             }
 
 #ifdef JP
-            if (angband_strstr(temp2, temp) || angband_strstr(r_ptr->name.c_str(), temp))
+            if (angband_strstr(temp2, temp) || angband_strstr(r_ref.name.c_str(), temp))
 #else
             if (angband_strstr(temp2, temp))
 #endif
                 who[n++] = i;
-        } else if (all || (r_ptr->d_char == sym)) {
+        } else if (all || (r_ref.d_char == sym)) {
             who[n++] = i;
         }
     }

--- a/src/monster-floor/monster-remover.cpp
+++ b/src/monster-floor/monster-remover.cpp
@@ -132,8 +132,8 @@ void wipe_monsters_list(player_type *player_ptr)
      * counters of monsters in party_mon[] are required to prevent multiple
      * generation of unique monster who is the minion of player.
      */
-    for (int i = 1; i < max_r_idx; i++)
-        r_info[i].cur_num = 0;
+    for (auto &r_ref : r_info)
+        r_ref.cur_num = 0;
 
     floor_ptr->m_max = 1;
     floor_ptr->m_cnt = 0;

--- a/src/object-enchant/object-ego.cpp
+++ b/src/object-enchant/object-ego.cpp
@@ -38,15 +38,14 @@ EGO_IDX max_e_idx;
 byte get_random_ego(byte slot, bool good)
 {
     ProbabilityTable<EGO_IDX> prob_table;
-    for (EGO_IDX i = 1; i < max_e_idx; i++) {
-        ego_item_type *e_ptr = &e_info[i];
-        if (e_ptr->slot != slot || e_ptr->rarity <= 0)
+    for (const auto &e_ref : e_info) {
+        if (e_ref.idx == 0 || e_ref.slot != slot || e_ref.rarity <= 0)
             continue;
 
-        bool worthless = e_ptr->rating == 0 || e_ptr->gen_flags.has_any_of({ TRG::CURSED, TRG::HEAVY_CURSE, TRG::PERMA_CURSE });
+        bool worthless = e_ref.rating == 0 || e_ref.gen_flags.has_any_of({ TRG::CURSED, TRG::HEAVY_CURSE, TRG::PERMA_CURSE });
 
         if (good != worthless) {
-            prob_table.entry_item(i, (255 / e_ptr->rarity));
+            prob_table.entry_item(e_ref.idx, (255 / e_ref.rarity));
         }
     }
 

--- a/src/object/object-kind-hook.cpp
+++ b/src/object/object-kind-hook.cpp
@@ -190,18 +190,17 @@ KIND_OBJECT_IDX lookup_kind(tval_type tval, OBJECT_SUBTYPE_VALUE sval)
 {
     int num = 0;
     KIND_OBJECT_IDX bk = 0;
-    for (KIND_OBJECT_IDX k = 1; k < max_k_idx; k++) {
-        object_kind *k_ptr = &k_info[k];
-        if (k_ptr->tval != tval)
+    for (const auto& k_ref : k_info) {
+        if (k_ref.tval != tval)
             continue;
 
-        if (k_ptr->sval == sval)
-            return k;
+        if (k_ref.sval == sval)
+            return k_ref.idx;
 
         if ((sval != SV_ANY) || !one_in_(++num))
             continue;
 
-        bk = k;
+        bk = k_ref.idx;
     }
 
     if (sval == SV_ANY)

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -2874,9 +2874,9 @@ long calc_score(player_type *player_ptr)
         mult = 5;
 
     DEPTH max_dl = 0;
-    for (int i = 0; i < w_ptr->max_d_idx; i++)
-        if (max_dlv[i] > max_dl)
-            max_dl = max_dlv[i];
+    for (const auto &d_ref : d_info)
+        if (max_dl < max_dlv[d_ref.idx])
+            max_dl = max_dlv[d_ref.idx];
 
     uint32_t point_l = (player_ptr->max_max_exp + (100 * max_dl));
     uint32_t point_h = point_l / 0x10000L;

--- a/src/room/rooms-city.cpp
+++ b/src/room/rooms-city.cpp
@@ -13,6 +13,8 @@
 #include "util/bit-flags-calculator.h"
 #include "wizard/wizard-messages.h"
 
+#include <algorithm>
+
 static ugbldg_type *ugbldg;
 
 /*
@@ -108,7 +110,6 @@ static void build_stores(player_type *player_ptr, POSITION ltcy, POSITION ltcx, 
 {
     int i;
     POSITION y, x;
-    FEAT_IDX j;
     ugbldg_type *cur_ugbldg;
 
     for (i = 0; i < n; i++) {
@@ -147,15 +148,12 @@ static void build_stores(player_type *player_ptr, POSITION ltcy, POSITION ltcx, 
             break;
         }
 
-        for (j = 0; j < max_f_idx; j++) {
-            if (f_info[j].flags.has(FF::STORE)) {
-                if (f_info[j].subtype == stores[i])
-                    break;
-            }
-        }
-
-        if (j < max_f_idx) {
-            cave_set_feat(player_ptr, ltcy + y, ltcx + x, j);
+        if (auto it = std::find_if(f_info.begin(), f_info.end(),
+                [subtype = stores[i]](const feature_type &f_ref) {
+                    return f_ref.flags.has(FF::STORE) && (f_ref.subtype == subtype);
+                });
+            it != f_info.end()) {
+            cave_set_feat(player_ptr, ltcy + y, ltcx + x, (*it).idx);
             store_init(NO_TOWN, stores[i]);
         }
     }

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -124,14 +124,16 @@ void amusement(player_type *player_ptr, POSITION y1, POSITION x1, int num, bool 
         fixed_art = (amuse_info[i].flag & AMS_FIXED_ART);
 
         if (insta_art || fixed_art) {
-            for (a_idx = 1; a_idx < max_a_idx; a_idx++) {
-                if (insta_art && !a_info[a_idx].gen_flags.has(TRG::INSTA_ART))
+            for (const auto &a_ref : a_info) {
+                if (a_ref.idx == 0)
                     continue;
-                if (a_info[a_idx].tval != k_info[k_idx].tval)
+                if (insta_art && !a_ref.gen_flags.has(TRG::INSTA_ART))
                     continue;
-                if (a_info[a_idx].sval != k_info[k_idx].sval)
+                if (a_ref.tval != k_info[k_idx].tval)
                     continue;
-                if (a_info[a_idx].cur_num > 0)
+                if (a_ref.sval != k_info[k_idx].sval)
+                    continue;
+                if (a_ref.cur_num > 0)
                     continue;
                 break;
             }

--- a/src/wizard/fixed-artifacts-spoiler.cpp
+++ b/src/wizard/fixed-artifacts-spoiler.cpp
@@ -162,14 +162,13 @@ spoiler_output_status spoil_fixed_artifact(concptr fname)
             spoiler_blanklines(1);
         }
 
-        for (ARTIFACT_IDX j = 1; j < max_a_idx; ++j) {
-            artifact_type *a_ptr = &a_info[j];
-            if (a_ptr->tval != group_artifact[i].tval)
+        for (const auto &a_ref : a_info) {
+            if (a_ref.idx == 0 || a_ref.tval != group_artifact[i].tval)
                 continue;
 
             q_ptr = &forge;
             q_ptr->wipe();
-            if (!make_fake_artifact(q_ptr, j))
+            if (!make_fake_artifact(q_ptr, a_ref.idx))
                 continue;
 
             object_analyze(&dummy, q_ptr, &artifact);

--- a/src/wizard/items-spoiler.cpp
+++ b/src/wizard/items-spoiler.cpp
@@ -25,7 +25,7 @@
  * @param val 価値を返すバッファ参照ポインタ
  * @param k ベースアイテムID
  */
-static void kind_info(player_type *player_ptr, char *buf, char *dam, char *wgt, char *chance, DEPTH *lev, PRICE *val, OBJECT_IDX k)
+static void kind_info(player_type *player_ptr, char *buf, char *dam, char *wgt, char *chance, DEPTH *lev, PRICE *val, KIND_OBJECT_IDX k)
 {
     object_type forge;
     object_type *q_ptr = &forge;
@@ -103,7 +103,7 @@ spoiler_output_status spoil_obj_desc(concptr fname)
     fprintf(spoiler_file, "%-37s%8s%7s%5s %40s%9s\n", "-------------------------------------", "------", "---", "---", "----------------", "----");
     int n = 0;
     int group_start = 0;
-    OBJECT_IDX who[200];
+    KIND_OBJECT_IDX who[200];
     for (int i = 0; true; i++) {
         if (group_item[i].name) {
             if (n) {
@@ -149,12 +149,11 @@ spoiler_output_status spoil_obj_desc(concptr fname)
             group_start = i;
         }
 
-        for (int k = 1; k < max_k_idx; k++) {
-            object_kind *k_ptr = &k_info[k];
-            if ((k_ptr->tval != group_item[i].tval) || k_ptr->gen_flags.has(TRG::INSTA_ART))
+        for (const auto &k_ref : k_info) {
+            if ((k_ref.idx == 0) || (k_ref.tval != group_item[i].tval) || k_ref.gen_flags.has(TRG::INSTA_ART))
                 continue;
 
-            who[n++] = (uint16_t)k;
+            who[n++] = k_ref.idx;
         }
     }
 

--- a/src/wizard/monster-info-spoiler.cpp
+++ b/src/wizard/monster-info-spoiler.cpp
@@ -105,10 +105,9 @@ spoiler_output_status spoil_mon_desc(concptr fname, std::function<bool(const mon
         "---", "---", "---", "-----", "-----", "-------------------");
 
     int n = 0;
-    for (auto i = 1; i < max_r_idx; i++) {
-        monster_race *r_ptr = &r_info[i];
-        if (!r_ptr->name.empty())
-            who[n++] = (int16_t)i;
+    for (const auto &r_ref : r_info) {
+        if (r_ref.idx > 0 && !r_ref.name.empty())
+            who[n++] = r_ref.idx;
     }
 
     ang_sort(&dummy, who, &why, n, ang_sort_comp_hook, ang_sort_swap_hook);
@@ -203,10 +202,9 @@ spoiler_output_status spoil_mon_info(concptr fname)
     MONRACE_IDX *who;
     C_MAKE(who, max_r_idx, MONRACE_IDX);
     int n = 0;
-    for (int i = 1; i < max_r_idx; i++) {
-        monster_race *r_ptr = &r_info[i];
-        if (!r_ptr->name.empty())
-            who[n++] = (int16_t)i;
+    for (const auto &r_ref : r_info) {
+        if (r_ref.idx > 0 && !r_ref.name.empty())
+            who[n++] = r_ref.idx;
     }
 
     uint16_t why = 2;

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -883,23 +883,22 @@ WishResult do_cmd_wishing(player_type *player_ptr, int prob, bool allow_art, boo
             KIND_OBJECT_IDX k_idx = k_ids.back();
             o_ptr->prep(k_idx);
 
-            for (EGO_IDX k = 1; k < max_e_idx; k++) {
-                ego_item_type *e_ptr = &e_info[k];
-                if (e_ptr->name.empty())
+            for (const auto &e_ref : e_info) {
+                if (e_ref.idx == 0 || e_ref.name.empty())
                     continue;
 
-                strcpy(o_name, e_ptr->name.c_str());
+                strcpy(o_name, e_ref.name.c_str());
 #ifndef JP
                 str_tolower(o_name);
 #endif
                 if (cheat_xtra)
-                    msg_format("Mathcing ego No.%d %s...", k, o_name);
+                    msg_format("mathcing ego no.%d %s...", e_ref.idx, o_name);
 
                 if (_(!strncmp(str, o_name, strlen(o_name)), !strrncmp(str, o_name, strlen(o_name)))) {
-                    if (is_slot_able_to_be_ego(player_ptr, o_ptr) != e_ptr->slot)
+                    if (is_slot_able_to_be_ego(player_ptr, o_ptr) != e_ref.slot)
                         continue;
 
-                    e_ids.push_back(k);
+                    e_ids.push_back(e_ref.idx);
                 }
             }
         }

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -913,24 +913,23 @@ WishResult do_cmd_wishing(player_type *player_ptr, int prob, bool allow_art, boo
 
         int len;
         int mlen = 0;
-        for (ARTIFACT_IDX i = 1; i < max_a_idx; i++) {
-            artifact_type *a_ptr = &a_info[i];
-            if (a_ptr->name.empty())
+        for (const auto &a_ref : a_info) {
+            if (a_ref.idx == 0 || a_ref.name.empty())
                 continue;
 
-            KIND_OBJECT_IDX k_idx = lookup_kind(a_ptr->tval, a_ptr->sval);
+            KIND_OBJECT_IDX k_idx = lookup_kind(a_ref.tval, a_ref.sval);
             if (!k_idx)
                 continue;
 
             o_ptr->prep(k_idx);
-            o_ptr->name1 = i;
+            o_ptr->name1 = a_ref.idx;
 
             describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
 #ifndef JP
             str_tolower(o_name);
 #endif
             a_str = a_desc;
-            strcpy(a_desc, a_ptr->name.c_str());
+            strcpy(a_desc, a_ref.name.c_str());
 
             if (*a_str == '$')
                 a_str++;
@@ -964,14 +963,14 @@ WishResult do_cmd_wishing(player_type *player_ptr, int prob, bool allow_art, boo
 #endif
 
             if (cheat_xtra)
-                msg_format("Matching artifact No.%d %s(%s)", i, a_desc, _(&o_name[2], o_name));
+                msg_format("Matching artifact No.%d %s(%s)", a_ref.idx, a_desc, _(&o_name[2], o_name));
 
-            std::vector<const char *> l = { a_str, a_ptr->name.c_str(), _(&o_name[2], o_name) };
+            std::vector<const char *> l = { a_str, a_ref.name.c_str(), _(&o_name[2], o_name) };
             for (size_t c = 0; c < l.size(); c++) {
                 if (!strcmp(str, l.at(c))) {
                     len = strlen(l.at(c));
                     if (len > mlen) {
-                        a_ids.push_back(i);
+                        a_ids.push_back(a_ref.idx);
                         mlen = len;
                     }
                 }
@@ -1008,11 +1007,10 @@ WishResult do_cmd_wishing(player_type *player_ptr, int prob, bool allow_art, boo
         artifact_type *a_ptr;
         ARTIFACT_IDX a_idx = 0;
         if (k_ptr->gen_flags.has(TRG::INSTA_ART)) {
-            for (ARTIFACT_IDX i = 1; i < max_a_idx; i++) {
-                a_ptr = &a_info[i];
-                if (a_ptr->tval != k_ptr->tval || a_ptr->sval != k_ptr->sval)
+            for (const auto &a_ref : a_info) {
+                if (a_ref.idx == 0 || a_ref.tval != k_ptr->tval || a_ref.sval != k_ptr->sval)
                     continue;
-                a_idx = i;
+                a_idx = a_ref.idx;
                 break;
             }
         }

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -857,24 +857,23 @@ WishResult do_cmd_wishing(player_type *player_ptr, int prob, bool allow_art, boo
     if (exam_base) {
         int len;
         int max_len = 0;
-        for (KIND_OBJECT_IDX k = 1; k < max_k_idx; k++) {
-            object_kind *k_ptr = &k_info[k];
-            if (k_ptr->name.empty())
+        for (const auto &k_ref : k_info) {
+            if (k_ref.idx == 0 || k_ref.name.empty())
                 continue;
 
-            o_ptr->prep(k);
+            o_ptr->prep(k_ref.idx);
             describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
 #ifndef JP
             str_tolower(o_name);
 #endif
             if (cheat_xtra)
-                msg_format("Matching object No.%d %s", k, o_name);
+                msg_format("Matching object No.%d %s", k_ref.idx, o_name);
 
             len = strlen(o_name);
 
             if (_(!strrncmp(str, o_name, len), !strncmp(str, o_name, len))) {
                 if (len > max_len) {
-                    k_ids.push_back(k);
+                    k_ids.push_back(k_ref.idx);
                     max_len = len;
                 }
             }

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -193,11 +193,11 @@ void wiz_create_item(player_type *player_ptr)
         return;
 
     if (k_info[k_idx].gen_flags.has(TRG::INSTA_ART)) {
-        for (ARTIFACT_IDX i = 1; i < max_a_idx; i++) {
-            if ((a_info[i].tval != k_info[k_idx].tval) || (a_info[i].sval != k_info[k_idx].sval))
+        for (const auto &a_ref : a_info) {
+            if ((a_ref.idx == 0) || (a_ref.tval != k_info[k_idx].tval) || (a_ref.sval != k_info[k_idx].sval))
                 continue;
 
-            (void)create_named_art(player_ptr, i, player_ptr->y, player_ptr->x);
+            (void)create_named_art(player_ptr, a_ref.idx, player_ptr->y, player_ptr->x);
             msg_print("Allocated(INSTA_ART).");
             return;
         }

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -143,18 +143,20 @@ KIND_OBJECT_IDX wiz_create_itemtype(void)
     num = 0;
     KIND_OBJECT_IDX choice[80];
     char buf[160];
-    for (KIND_OBJECT_IDX i = 1; (num < 80) && (i < max_k_idx); i++) {
-        object_kind *k_ptr = &k_info[i];
-        if (k_ptr->tval != tval)
+    for (const auto& k_ref : k_info) {
+        if (num >= 80) {
+            break;
+        }
+        if (k_ref.idx == 0 || k_ref.tval != tval)
             continue;
 
         row = 2 + (num % 20);
         col = 20 * (num / 20);
         ch = listsym[num];
         strcpy(buf, "                    ");
-        strip_name(buf, i);
+        strip_name(buf, k_ref.idx);
         prt(format("[%c] %s", ch, buf), row, col);
-        choice[num++] = i;
+        choice[num++] = k_ref.idx;
     }
 
     max_num = num;
@@ -485,11 +487,10 @@ void wiz_learn_items_all(player_type *player_ptr)
 {
     object_type forge;
     object_type *q_ptr;
-    for (KIND_OBJECT_IDX i = 1; i < max_k_idx; i++) {
-        object_kind *k_ptr = &k_info[i];
-        if (k_ptr->level <= command_arg) {
+    for (const auto &k_ref : k_info) {
+        if (k_ref.idx > 0 && k_ref.level <= command_arg) {
             q_ptr = &forge;
-            q_ptr->prep(i);
+            q_ptr->prep(k_ref.idx);
             object_aware(player_ptr, q_ptr);
         }
     }

--- a/src/wizard/wizard-spoiler.cpp
+++ b/src/wizard/wizard-spoiler.cpp
@@ -52,10 +52,9 @@ static auto get_mon_evol_roots(void)
 {
     std::set<MONRACE_IDX> evol_parents;
     std::set<MONRACE_IDX> evol_children;
-    for (auto r_idx = 1; r_idx < max_r_idx; ++r_idx) {
-        const auto &r_ref = r_info[r_idx];
+    for (const auto &r_ref : r_info) {
         if (r_ref.next_r_idx > 0) {
-            evol_parents.emplace(r_idx);
+            evol_parents.emplace(r_ref.idx);
             evol_children.emplace(r_ref.next_r_idx);
         }
     }

--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -280,17 +280,16 @@ void WorldTurnProcessor::shuffle_shopkeeper()
         }
     } while (true);
 
-    for (auto i = 1; i < max_f_idx; i++) {
-        auto *f_ptr = &f_info[i];
-        if (f_ptr->name.empty() || f_ptr->flags.has_not(FF::STORE))
+    for (const auto &f_ref : f_info) {
+        if (f_ref.name.empty() || f_ref.flags.has_not(FF::STORE))
             continue;
 
-        if (f_ptr->subtype != n) {
+        if (f_ref.subtype != n) {
             continue;
         }
 
         if (cheat_xtra) {
-            msg_format(_("%sの店主をシャッフルします。", "Shuffle a Shopkeeper of %s."), f_ptr->name.c_str());
+            msg_format(_("%sの店主をシャッフルします。", "Shuffle a Shopkeeper of %s."), f_ref.name.c_str());
         }
 
         store_shuffle(this->player_ptr, n);


### PR DESCRIPTION
*_info 配列に対して、ループ変数を使用して [0 or 1, max\_\*\_idx) のループ処理を行っている箇所を、range-based for を使用して置き換えました。
変数名は参照になるので、`*_ptr`からの類推で `*_ref`としています。

ほぼ単純な置き換えに終始していますが、以下2点イレギュラーな点があります。

- src/room/rooms-city.cpp: 処理内容が該当の要素を検索する事だったのでstd::find_ifを使用したコードに変更
- src/knowledge/knowledge-items.cpp: 配列の合計を行うコードをループによる加算から std::reduce に変更

個別のIssueは立てず C++以降 Project の一環とします。