### PR TITLE
[Fix] Visual Studio の警告に対処

### DIFF
--- a/src/info-reader/artifact-reader.cpp
+++ b/src/info-reader/artifact-reader.cpp
@@ -53,7 +53,7 @@ errr parse_a_info(std::string_view buf, angband_header *head)
 
         error_idx = i;
         a_ptr = &a_info[i];
-        a_ptr->idx = i;
+        a_ptr->idx = static_cast<ARTIFACT_IDX>(i);
         a_ptr->flags.set(TR_IGNORE_ACID);
         a_ptr->flags.set(TR_IGNORE_ELEC);
         a_ptr->flags.set(TR_IGNORE_FIRE);

--- a/src/info-reader/dungeon-reader.cpp
+++ b/src/info-reader/dungeon-reader.cpp
@@ -102,7 +102,7 @@ errr parse_d_info(std::string_view buf, angband_header *head)
 
         error_idx = i;
         d_ptr = &d_info[i];
-        d_ptr->idx = i;
+        d_ptr->idx = static_cast<DUNGEON_IDX>(i);
 #ifdef JP
         d_ptr->name = tokens[2];
 #endif

--- a/src/info-reader/ego-reader.cpp
+++ b/src/info-reader/ego-reader.cpp
@@ -77,7 +77,7 @@ errr parse_e_info(std::string_view buf, angband_header *head)
 
         error_idx = i;
         e_ptr = &e_info[i];
-        e_ptr->idx = i;
+        e_ptr->idx = static_cast<EGO_IDX>(i);
 #ifdef JP
         e_ptr->name = tokens[2];
 #endif

--- a/src/info-reader/feature-reader.cpp
+++ b/src/info-reader/feature-reader.cpp
@@ -79,7 +79,7 @@ errr parse_f_info(std::string_view buf, angband_header *head)
 
         error_idx = i;
         f_ptr = &f_info[i];
-        f_ptr->idx = i;
+        f_ptr->idx = static_cast<FEAT_IDX>(i);
         f_ptr->tag = tokens[2];
 
         f_ptr->mimic = (FEAT_IDX)i;

--- a/src/info-reader/kind-reader.cpp
+++ b/src/info-reader/kind-reader.cpp
@@ -54,7 +54,7 @@ errr parse_k_info(std::string_view buf, angband_header *head)
 
         error_idx = i;
         k_ptr = &k_info[i];
-        k_ptr->idx = i;
+        k_ptr->idx = static_cast<KIND_OBJECT_IDX>(i);
 #ifdef JP
         k_ptr->name = tokens[2];
 #endif

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -85,7 +85,7 @@ errr parse_r_info(std::string_view buf, angband_header *head)
 
         error_idx = i;
         r_ptr = &r_info[i];
-        r_ptr->idx = i;
+        r_ptr->idx = static_cast<MONRACE_IDX>(i);
 #ifdef JP
         r_ptr->name = tokens[2];
 #endif

--- a/src/info-reader/vault-reader.cpp
+++ b/src/info-reader/vault-reader.cpp
@@ -32,7 +32,7 @@ errr parse_v_info(std::string_view buf, angband_header *head)
 
         error_idx = i;
         v_ptr = &v_info[i];
-        v_ptr->idx = i;
+        v_ptr->idx = static_cast<int16_t>(i);
         v_ptr->name = std::string(tokens[2]);
     } else if (!v_ptr)
         return PARSE_ERROR_MISSING_RECORD_HEADER;

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -145,7 +145,7 @@ static KIND_OBJECT_IDX collect_objects(int grp_cur, KIND_OBJECT_IDX object_idx[]
                     continue;
             }
 
-            auto k = std::reduce(std::begin(k_ref.chance), std::end(k_ref.chance));
+            auto k = std::reduce(std::begin(k_ref.chance), std::end(k_ref.chance), 0);
             if (!k)
                 continue;
         }

--- a/src/object-enchant/object-smith.h
+++ b/src/object-enchant/object-smith.h
@@ -14,7 +14,7 @@ class ISmithInfo;
 struct essence_drain_type;
 class ItemTester;
 
-enum class SmithEffect;
+enum class SmithEffect : int16_t;
 enum class SmithCategory;
 enum class SmithEssence;
 enum random_art_activation_type : uint8_t;

--- a/src/object-enchant/smith-info.h
+++ b/src/object-enchant/smith-info.h
@@ -7,7 +7,7 @@
 #include <optional>
 #include <vector>
 
-enum class SmithEffect;
+enum class SmithEffect : int16_t;
 enum class SmithCategory;
 enum class SmithEssence;
 enum random_art_activation_type : uint8_t;

--- a/src/object-enchant/smith-types.h
+++ b/src/object-enchant/smith-types.h
@@ -5,7 +5,7 @@
 /**
  * @brief アイテムに付与できる鍛冶効果の列挙体
  */
-enum class SmithEffect {
+enum class SmithEffect : int16_t {
     NONE = 0,
     STR = 1, //!< 腕力
     INT = 2, //!< 知能

--- a/src/system/object-type-definition.h
+++ b/src/system/object-type-definition.h
@@ -16,7 +16,7 @@
 
 #include <optional>
 
-enum class SmithEffect;
+enum class SmithEffect : int16_t;
 enum random_art_activation_type : uint8_t;
 
 struct player_type;


### PR DESCRIPTION
Visual Studio が出力している以下の警告に対処する。
- 各infoのidxメンバに代入する時の整数型のナローイング
- std::reduce の初期値を設定してない事による整数型のナローイング
- SmithEffect の値をセーブデータに格納する時の整数型のナローイング