### PR TITLE
[Refactor] C_MAKEによる一時的バッファをstd::vectorで置き換える

### DIFF
--- a/src/action/activation-execution.cpp
+++ b/src/action/activation-execution.cpp
@@ -188,22 +188,17 @@ static bool activate_whistle(player_type *player_ptr, ae_type *ae_ptr)
         (void)SpellHex(player_ptr).stop_all_spells();
     }
 
-    MONSTER_IDX pet_ctr;
-    MONSTER_IDX *who;
-    int max_pet = 0;
-    C_MAKE(who, w_ptr->max_m_idx, MONSTER_IDX);
-    for (pet_ctr = player_ptr->current_floor_ptr->m_max - 1; pet_ctr >= 1; pet_ctr--)
+    std::vector<MONSTER_IDX> who;
+    for (MONSTER_IDX pet_ctr = player_ptr->current_floor_ptr->m_max - 1; pet_ctr >= 1; pet_ctr--)
         if (is_pet(&player_ptr->current_floor_ptr->m_list[pet_ctr]) && (player_ptr->riding != pet_ctr))
-            who[max_pet++] = pet_ctr;
+            who.push_back(pet_ctr);
 
     uint16_t dummy_why;
-    ang_sort(player_ptr, who, &dummy_why, max_pet, ang_sort_comp_pet, ang_sort_swap_hook);
-    for (MONSTER_IDX i = 0; i < max_pet; i++) {
-        pet_ctr = who[i];
+    ang_sort(player_ptr, who.data(), &dummy_why, who.size(), ang_sort_comp_pet, ang_sort_swap_hook);
+    for (auto pet_ctr : who) {
         teleport_monster_to(player_ptr, pet_ctr, player_ptr->y, player_ptr->x, 100, TELEPORT_PASSIVE);
     }
 
-    C_KILL(who, w_ptr->max_m_idx, MONSTER_IDX);
     ae_ptr->o_ptr->timeout = 100 + randint1(100);
     return true;
 }

--- a/src/cmd-io/cmd-lore.cpp
+++ b/src/cmd-io/cmd-lore.cpp
@@ -36,9 +36,6 @@
  */
 void do_cmd_query_symbol(player_type *player_ptr)
 {
-    MONRACE_IDX i;
-    int n;
-    MONRACE_IDX r_idx;
     char sym, query;
     char buf[256];
 
@@ -51,15 +48,15 @@ void do_cmd_query_symbol(player_type *player_ptr)
     bool recall = false;
 
     uint16_t why = 0;
-    MONRACE_IDX *who;
 
     if (!get_com(_("知りたい文字を入力して下さい(記号 or ^A全,^Uユ,^N非ユ,^R乗馬,^M名前): ",
                      "Enter character to be identified(^A:All,^U:Uniqs,^N:Non uniqs,^M:Name): "),
             &sym, false))
         return;
 
-    for (i = 0; ident_info[i]; ++i) {
-        if (sym == ident_info[i][0])
+    int ident_i;
+    for (ident_i = 0; ident_info[ident_i]; ++ident_i) {
+        if (sym == ident_info[ident_i][0])
             break;
     }
 
@@ -82,15 +79,14 @@ void do_cmd_query_symbol(player_type *player_ptr)
             return;
         }
         sprintf(buf, _("名前:%sにマッチ", "Monsters' names with \"%s\""), temp);
-    } else if (ident_info[i]) {
-        sprintf(buf, "%c - %s.", sym, ident_info[i] + 2);
+    } else if (ident_info[ident_i]) {
+        sprintf(buf, "%c - %s.", sym, ident_info[ident_i] + 2);
     } else {
         sprintf(buf, "%c - %s", sym, _("無効な文字", "Unknown Symbol"));
     }
 
     prt(buf, 0, 0);
-    C_MAKE(who, max_r_idx, MONRACE_IDX);
-    n = 0;
+    std::vector<MONRACE_IDX> who;
     for (const auto &r_ref : r_info) {
         if (!cheat_know && !r_ref.r_sights)
             continue;
@@ -133,15 +129,14 @@ void do_cmd_query_symbol(player_type *player_ptr)
 #else
             if (angband_strstr(temp2, temp))
 #endif
-                who[n++] = i;
+                who.push_back(r_ref.idx);
         }
 
         else if (all || (r_ref.d_char == sym))
-            who[n++] = i;
+            who.push_back(r_ref.idx);
     }
 
-    if (!n) {
-        C_KILL(who, max_r_idx, MONRACE_IDX);
+    if (who.empty()) {
         return;
     }
 
@@ -149,24 +144,23 @@ void do_cmd_query_symbol(player_type *player_ptr)
     query = inkey();
     prt(buf, 0, 0);
     why = 2;
-    ang_sort(player_ptr, who, &why, n, ang_sort_comp_hook, ang_sort_swap_hook);
+    ang_sort(player_ptr, who.data(), &why, who.size(), ang_sort_comp_hook, ang_sort_swap_hook);
     if (query == 'k') {
         why = 4;
         query = 'y';
     }
 
     if (query != 'y') {
-        C_KILL(who, max_r_idx, MONRACE_IDX);
         return;
     }
 
     if (why == 4) {
-        ang_sort(player_ptr, who, &why, n, ang_sort_comp_hook, ang_sort_swap_hook);
+        ang_sort(player_ptr, who.data(), &why, who.size(), ang_sort_comp_hook, ang_sort_swap_hook);
     }
 
-    i = n - 1;
+    auto i = who.size() - 1;
     while (true) {
-        r_idx = who[i];
+        auto r_idx = who[i];
         monster_race_track(player_ptr, r_idx);
         handle_stuff(player_ptr);
         while (true) {
@@ -191,20 +185,19 @@ void do_cmd_query_symbol(player_type *player_ptr)
             break;
 
         if (query == '-') {
-            if (++i == n) {
+            if (++i == who.size()) {
                 i = 0;
                 if (!expand_list)
                     break;
             }
         } else {
             if (i-- == 0) {
-                i = n - 1;
+                i = who.size() - 1;
                 if (!expand_list)
                     break;
             }
         }
     }
 
-    C_KILL(who, max_r_idx, MONRACE_IDX);
     prt(buf, 0, 0);
 }

--- a/src/flavor/object-flavor.cpp
+++ b/src/flavor/object-flavor.cpp
@@ -191,9 +191,7 @@ void get_table_sindarin(char *out_string)
  */
 static void shuffle_flavors(tval_type tval)
 {
-    KIND_OBJECT_IDX *k_idx_list;
-    KIND_OBJECT_IDX k_idx_list_num = 0;
-    C_MAKE(k_idx_list, max_k_idx, KIND_OBJECT_IDX);
+    std::vector<KIND_OBJECT_IDX> k_idx_list;
     for (const auto &k_ref : k_info) {
         if (k_ref.tval != tval)
             continue;
@@ -204,19 +202,14 @@ static void shuffle_flavors(tval_type tval)
         if (k_ref.flags.has(TR_FIXED_FLAVOR))
             continue;
 
-        k_idx_list[k_idx_list_num] = k_ref.idx;
-        k_idx_list_num++;
+        k_idx_list.push_back(k_ref.idx);
     }
 
-    for (KIND_OBJECT_IDX i = 0; i < k_idx_list_num; i++) {
-        object_kind *k1_ptr = &k_info[k_idx_list[i]];
-        object_kind *k2_ptr = &k_info[k_idx_list[randint0(k_idx_list_num)]];
-        int16_t tmp = k1_ptr->flavor;
-        k1_ptr->flavor = k2_ptr->flavor;
-        k2_ptr->flavor = tmp;
+    for (auto k_idx : k_idx_list) {
+        object_kind *k1_ptr = &k_info[k_idx];
+        object_kind *k2_ptr = &k_info[k_idx_list[randint0(k_idx_list.size())]];
+        std::swap(k1_ptr->flavor, k2_ptr->flavor);
     }
-
-    C_KILL(k_idx_list, max_k_idx, int16_t);
 }
 
 /*!

--- a/src/knowledge/knowledge-features.cpp
+++ b/src/knowledge/knowledge-features.cpp
@@ -102,8 +102,7 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
     TERM_LEN wid, hgt;
     term_get_size(&wid, &hgt);
 
-    FEAT_IDX *feat_idx;
-    C_MAKE(feat_idx, max_f_idx, FEAT_IDX);
+    std::vector<FEAT_IDX> feat_idx(f_info.size());
 
     concptr feature_group_text[] = { "terrains", nullptr };
     int len;
@@ -121,7 +120,7 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
             if (len > max)
                 max = len;
 
-            if (collect_features(feat_idx, 0x01)) {
+            if (collect_features(feat_idx.data(), 0x01)) {
                 grp_idx[grp_cnt++] = i;
             }
         }
@@ -198,7 +197,7 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
             display_group_list(0, 6, max, browser_rows, grp_idx, feature_group_text, grp_cur, grp_top);
             if (old_grp_cur != grp_cur) {
                 old_grp_cur = grp_cur;
-                feat_cnt = collect_features(feat_idx, 0x00);
+                feat_cnt = collect_features(feat_idx.data(), 0x00);
             }
 
             while (feat_cur < feat_top)
@@ -208,10 +207,10 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
         }
 
         if (!visual_list) {
-            display_feature_list(max + 3, 6, browser_rows, feat_idx, feat_cur, feat_top, visual_only, F_LIT_STANDARD);
+            display_feature_list(max + 3, 6, browser_rows, feat_idx.data(), feat_cur, feat_top, visual_only, F_LIT_STANDARD);
         } else {
             feat_top = feat_cur;
-            display_feature_list(max + 3, 6, 1, feat_idx, feat_cur, feat_top, visual_only, *lighting_level);
+            display_feature_list(max + 3, 6, 1, feat_idx.data(), feat_cur, feat_top, visual_only, *lighting_level);
             display_visual_list(max + 3, 7, browser_rows - 1, wid - (max + 3), attr_top, char_left);
         }
 
@@ -334,8 +333,6 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
         }
         }
     }
-
-    C_KILL(feat_idx, max_f_idx, FEAT_IDX);
 }
 
 /*

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -289,8 +289,7 @@ void do_cmd_knowledge_monsters(player_type *player_ptr, bool *need_redraw, bool 
 {
     TERM_LEN wid, hgt;
     term_get_size(&wid, &hgt);
-    IDX *mon_idx;
-    C_MAKE(mon_idx, max_r_idx, MONRACE_IDX);
+    std::vector<MONRACE_IDX> mon_idx(r_info.size());
 
     int max = 0;
     IDX grp_cnt = 0;
@@ -309,7 +308,7 @@ void do_cmd_knowledge_monsters(player_type *player_ptr, bool *need_redraw, bool 
             if (len > max)
                 max = len;
 
-            if ((monster_group_char[i] == ((char *)-1L)) || collect_monsters(player_ptr, i, mon_idx, mode)) {
+            if ((monster_group_char[i] == ((char *)-1L)) || collect_monsters(player_ptr, i, mon_idx.data(), mode)) {
                 grp_idx[grp_cnt++] = i;
             }
         }
@@ -369,7 +368,7 @@ void do_cmd_knowledge_monsters(player_type *player_ptr, bool *need_redraw, bool 
             display_group_list(0, 6, max, browser_rows, grp_idx, monster_group_text, grp_cur, grp_top);
             if (old_grp_cur != grp_cur) {
                 old_grp_cur = grp_cur;
-                mon_cnt = collect_monsters(player_ptr, grp_idx[grp_cur], mon_idx, mode);
+                mon_cnt = collect_monsters(player_ptr, grp_idx[grp_cur], mon_idx.data(), mode);
             }
 
             while (mon_cur < mon_top)
@@ -379,10 +378,10 @@ void do_cmd_knowledge_monsters(player_type *player_ptr, bool *need_redraw, bool 
         }
 
         if (!visual_list) {
-            display_monster_list(max + 3, 6, browser_rows, mon_idx, mon_cur, mon_top, visual_only);
+            display_monster_list(max + 3, 6, browser_rows, mon_idx.data(), mon_cur, mon_top, visual_only);
         } else {
             mon_top = mon_cur;
-            display_monster_list(max + 3, 6, 1, mon_idx, mon_cur, mon_top, visual_only);
+            display_monster_list(max + 3, 6, 1, mon_idx.data(), mon_cur, mon_top, visual_only);
             display_visual_list(max + 3, 7, browser_rows - 1, wid - (max + 3), attr_top, char_left);
         }
 
@@ -456,8 +455,6 @@ void do_cmd_knowledge_monsters(player_type *player_ptr, bool *need_redraw, bool 
         }
         }
     }
-
-    C_KILL(mon_idx, max_r_idx, MONRACE_IDX);
 }
 
 /*

--- a/src/knowledge/knowledge-quests.cpp
+++ b/src/knowledge/knowledge-quests.cpp
@@ -25,6 +25,8 @@
 #include "util/sort.h"
 #include "world/world.h"
 
+#include <numeric>
+
 /*!
  * @brief Check on the status of an active quest
  * @param player_ptr プレイヤーへの参照ポインタ
@@ -292,20 +294,17 @@ void do_cmd_knowledge_quests(player_type *player_ptr)
     if (!open_temporary_file(&fff, file_name))
         return;
 
-    IDX *quest_num;
-    C_MAKE(quest_num, max_q_idx, QUEST_IDX);
-
-    for (IDX i = 1; i < max_q_idx; i++)
-        quest_num[i] = i;
+    std::vector<QUEST_IDX> quest_num(max_q_idx);
+    std::iota(quest_num.begin(), quest_num.end(), static_cast<QUEST_IDX>(0));
 
     int dummy;
-    ang_sort(player_ptr, quest_num, &dummy, max_q_idx, ang_sort_comp_quest_num, ang_sort_swap_quest_num);
+    ang_sort(player_ptr, quest_num.data(), &dummy, quest_num.size(), ang_sort_comp_quest_num, ang_sort_swap_quest_num);
 
     do_cmd_knowledge_quests_current(player_ptr, fff);
     fputc('\n', fff);
-    do_cmd_knowledge_quests_completed(player_ptr, fff, quest_num);
+    do_cmd_knowledge_quests_completed(player_ptr, fff, quest_num.data());
     fputc('\n', fff);
-    do_cmd_knowledge_quests_failed(player_ptr, fff, quest_num);
+    do_cmd_knowledge_quests_failed(player_ptr, fff, quest_num.data());
     if (w_ptr->wizard) {
         fputc('\n', fff);
         do_cmd_knowledge_quests_wiz_random(fff);
@@ -314,5 +313,4 @@ void do_cmd_knowledge_quests(player_type *player_ptr)
     angband_fclose(fff);
     (void)show_file(player_ptr, true, file_name, _("クエスト達成状況", "Quest status"), 0, 0);
     fd_kill(file_name);
-    C_KILL(quest_num, max_q_idx, QUEST_IDX);
 }

--- a/src/knowledge/knowledge-uniques.cpp
+++ b/src/knowledge/knowledge-uniques.cpp
@@ -18,13 +18,12 @@
 typedef struct unique_list_type {
     bool is_alive;
     uint16_t why;
-    IDX *who;
+    std::vector<MONRACE_IDX> who;
     int num_uniques[10];
     int num_uniques_surface;
     int num_uniques_over100;
     int num_uniques_total;
     int max_lev;
-    int n;
 } unique_list_type;
 
 unique_list_type *initialize_unique_lsit_type(unique_list_type *unique_list_ptr, bool is_alive)
@@ -35,7 +34,6 @@ unique_list_type *initialize_unique_lsit_type(unique_list_type *unique_list_ptr,
     unique_list_ptr->num_uniques_over100 = 0;
     unique_list_ptr->num_uniques_total = 0;
     unique_list_ptr->max_lev = -1;
-    unique_list_ptr->n = 0;
     for (IDX i = 0; i < 10; i++)
         unique_list_ptr->num_uniques[i] = 0;
 
@@ -111,8 +109,8 @@ static void display_uniques(unique_list_type *unique_list_ptr, FILE *fff)
     }
 
     char buf[80];
-    for (int k = 0; k < unique_list_ptr->n; k++) {
-        monster_race *r_ptr = &r_info[unique_list_ptr->who[k]];
+    for (auto r_idx : unique_list_ptr->who) {
+        monster_race *r_ptr = &r_info[r_idx];
 
         if (r_ptr->defeat_level && r_ptr->defeat_time)
             sprintf(buf, _(" - レベル%2d - %d:%02d:%02d", " - level %2d - %d:%02d:%02d"), r_ptr->defeat_level, r_ptr->defeat_time / (60 * 60),
@@ -138,7 +136,6 @@ void do_cmd_knowledge_uniques(player_type *player_ptr, bool is_alive)
     if (!open_temporary_file(&fff, file_name))
         return;
 
-    C_MAKE(unique_list_ptr->who, max_r_idx, MONRACE_IDX);
     for (auto &r_ref : r_info) {
         if (r_ref.idx == 0) {
             continue;
@@ -157,12 +154,11 @@ void do_cmd_knowledge_uniques(player_type *player_ptr, bool is_alive)
         } else
             unique_list_ptr->num_uniques_surface++;
 
-        unique_list_ptr->who[unique_list_ptr->n++] = r_ref.idx;
+        unique_list_ptr->who.push_back(r_ref.idx);
     }
 
-    ang_sort(player_ptr, unique_list_ptr->who, &unique_list_ptr->why, unique_list_ptr->n, ang_sort_comp_hook, ang_sort_swap_hook);
+    ang_sort(player_ptr, unique_list_ptr->who.data(), &unique_list_ptr->why, unique_list_ptr->who.size(), ang_sort_comp_hook, ang_sort_swap_hook);
     display_uniques(unique_list_ptr, fff);
-    C_KILL(unique_list_ptr->who, max_r_idx, int16_t);
     angband_fclose(fff);
     concptr title_desc
         = unique_list_ptr->is_alive ? _("まだ生きているユニーク・モンスター", "Alive Uniques") : _("もう撃破したユニーク・モンスター", "Dead Uniques");

--- a/src/load/floor-loader.cpp
+++ b/src/load/floor-loader.cpp
@@ -44,7 +44,6 @@
  */
 errr rd_saved_floor(player_type *player_ptr, saved_floor_type *sf_ptr)
 {
-    grid_template_type *templates;
     floor_type *floor_ptr = player_ptr->current_floor_ptr;
     clear_cave(player_ptr);
     player_ptr->x = player_ptr->y = 0;
@@ -111,24 +110,23 @@ errr rd_saved_floor(player_type *player_ptr, saved_floor_type *sf_ptr)
 
     uint16_t limit;
     rd_u16b(&limit);
-    C_MAKE(templates, limit, grid_template_type);
+    std::vector<grid_template_type> templates(limit);
 
-    for (int i = 0; i < limit; i++) {
-        grid_template_type *ct_ptr = &templates[i];
+    for (auto &ct_ref : templates) {
         rd_u16b(&tmp16u);
-        ct_ptr->info = (BIT_FLAGS)tmp16u;
+        ct_ref.info = (BIT_FLAGS)tmp16u;
         if (h_older_than(1, 7, 0, 2)) {
             byte tmp8u;
             rd_byte(&tmp8u);
-            ct_ptr->feat = (int16_t)tmp8u;
+            ct_ref.feat = (int16_t)tmp8u;
             rd_byte(&tmp8u);
-            ct_ptr->mimic = (int16_t)tmp8u;
+            ct_ref.mimic = (int16_t)tmp8u;
         } else {
-            rd_s16b(&ct_ptr->feat);
-            rd_s16b(&ct_ptr->mimic);
+            rd_s16b(&ct_ref.feat);
+            rd_s16b(&ct_ref.mimic);
         }
 
-        rd_s16b(&ct_ptr->special);
+        rd_s16b(&ct_ref.special);
     }
 
     POSITION ymax = floor_ptr->height;
@@ -180,7 +178,6 @@ errr rd_saved_floor(player_type *player_ptr, saved_floor_type *sf_ptr)
         }
     }
 
-    C_KILL(templates, limit, grid_template_type);
     rd_u16b(&limit);
     if (limit > w_ptr->max_o_idx)
         return 151;

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -240,12 +240,10 @@ static errr exe_reading_savefile(player_type *player_ptr)
         rd_u16b(&player_ptr->pet_extra_flags);
 
     if (!h_older_than(1, 0, 9)) {
-        char *buf;
-        C_MAKE(buf, SCREEN_BUF_MAX_SIZE, char);
-        rd_string(buf, SCREEN_BUF_MAX_SIZE);
+        std::vector<char> buf(SCREEN_BUF_MAX_SIZE);
+        rd_string(buf.data(), SCREEN_BUF_MAX_SIZE);
         if (buf[0])
-            screen_dump = string_make(buf);
-        C_KILL(buf, SCREEN_BUF_MAX_SIZE, char);
+            screen_dump = string_make(buf.data());
     }
 
     errr restore_dungeon_result = restore_dungeon(player_ptr);

--- a/src/locale/japanese.cpp
+++ b/src/locale/japanese.cpp
@@ -164,11 +164,10 @@ void sjis2euc(char *str)
 {
     int i;
     unsigned char c1, c2;
-    unsigned char *tmp;
 
     int len = strlen(str);
 
-    C_MAKE(tmp, len + 1, byte);
+    std::vector<char> tmp(len + 1);
 
     for (i = 0; i < len; i++) {
         c1 = str[i];
@@ -188,9 +187,7 @@ void sjis2euc(char *str)
             tmp[i] = c1;
     }
     tmp[len] = 0;
-    strcpy(str, (char *)tmp);
-
-    C_KILL(tmp, len + 1, byte);
+    strcpy(str, tmp.data());
 }
 
 /*!
@@ -202,11 +199,10 @@ void euc2sjis(char *str)
 {
     int i;
     unsigned char c1, c2;
-    unsigned char *tmp;
 
     int len = strlen(str);
 
-    C_MAKE(tmp, len + 1, byte);
+    std::vector<char> tmp(len + 1);
 
     for (i = 0; i < len; i++) {
         c1 = str[i];
@@ -227,9 +223,7 @@ void euc2sjis(char *str)
             tmp[i] = c1;
     }
     tmp[len] = 0;
-    strcpy(str, (char *)tmp);
-
-    C_KILL(tmp, len + 1, byte);
+    strcpy(str, tmp.data());
 }
 
 /*!
@@ -481,24 +475,20 @@ static bool utf8_to_sys(char *utf8_str, char *sys_str_buffer, size_t sys_str_buf
 
 #elif defined(SJIS) && defined(WINDOWS)
 
-    LPWSTR utf16buf;
     int input_len = strlen(utf8_str) + 1; /* include termination character */
 
-    C_MAKE(utf16buf, input_len, WCHAR);
+    std::vector<WCHAR> utf16buf(input_len);
 
     /* UTF-8 -> UTF-16 */
-    if (MultiByteToWideChar(CP_UTF8, 0, utf8_str, input_len, utf16buf, input_len) == 0) {
-        C_KILL(utf16buf, input_len, WCHAR);
+    if (MultiByteToWideChar(CP_UTF8, 0, utf8_str, input_len, utf16buf.data(), input_len) == 0) {
         return false;
     }
 
     /* UTF-8 -> SJIS(CP932) */
-    if (WideCharToMultiByte(932, 0, utf16buf, -1, sys_str_buffer, sys_str_buflen, nullptr, nullptr) == 0) {
-        C_KILL(utf16buf, input_len, WCHAR);
+    if (WideCharToMultiByte(932, 0, utf16buf.data(), -1, sys_str_buffer, sys_str_buflen, nullptr, nullptr) == 0) {
         return false;
     }
 
-    C_KILL(utf16buf, input_len, WCHAR);
     return true;
 
 #endif
@@ -517,14 +507,12 @@ void guess_convert_to_system_encoding(char *strbuf, int buflen)
         return;
 
     if (is_utf8_str(strbuf)) {
-        char *work;
-        C_MAKE(work, buflen, char);
-        angband_strcpy(work, strbuf, buflen);
-        if (!utf8_to_sys(work, strbuf, buflen)) {
+        std::vector<char> work(buflen);
+        angband_strcpy(work.data(), strbuf, buflen);
+        if (!utf8_to_sys(work.data(), strbuf, buflen)) {
             msg_print("警告:文字コードの変換に失敗しました");
             msg_print(nullptr);
         }
-        C_KILL(work, buflen, char);
     }
 }
 

--- a/src/main/game-data-initializer.cpp
+++ b/src/main/game-data-initializer.cpp
@@ -159,9 +159,7 @@ errr init_object_alloc(void)
  */
 errr init_alloc(void)
 {
-    monster_race *r_ptr;
-    tag_type *elements;
-    C_MAKE(elements, max_r_idx, tag_type);
+    std::vector<tag_type> elements(r_info.size());
     for (const auto &r_ref : r_info) {
         if (r_ref.idx > 0) {
             elements[r_ref.idx].tag = r_ref.level;
@@ -169,11 +167,11 @@ errr init_alloc(void)
         }
     }
 
-    tag_sort(elements, max_r_idx);
+    tag_sort(elements.data(), elements.size());
     alloc_race_size = max_r_idx;
     C_MAKE(alloc_race_table, alloc_race_size, alloc_entry);
     for (int i = 1; i < max_r_idx; i++) {
-        r_ptr = &r_info[elements[i].index];
+        auto r_ptr = &r_info[elements[i].index];
         if (r_ptr->rarity == 0)
             continue;
 
@@ -185,7 +183,6 @@ errr init_alloc(void)
         alloc_race_table[i].prob2 = (PROB)p;
     }
 
-    C_KILL(elements, max_r_idx, tag_type);
     (void)init_object_alloc();
     return 0;
 }

--- a/src/room/rooms-city.cpp
+++ b/src/room/rooms-city.cpp
@@ -15,23 +15,18 @@
 
 #include <algorithm>
 
-static ugbldg_type *ugbldg;
-
 /*
  * Precalculate buildings' location of underground arcade
  */
-static bool precalc_ugarcade(int town_hgt, int town_wid, int n)
+static bool precalc_ugarcade(int town_hgt, int town_wid, int n, std::vector<ugbldg_type>& ugbldg)
 {
     POSITION i, y, x, center_y, center_x;
     int tmp, attempt = 10000;
     POSITION max_bldg_hgt = 3 * town_hgt / MAX_TOWN_HGT;
     POSITION max_bldg_wid = 5 * town_wid / MAX_TOWN_WID;
     ugbldg_type *cur_ugbldg;
-    bool **ugarcade_used, abort;
-    C_MAKE(ugarcade_used, town_hgt, bool *);
-    C_MAKE(*ugarcade_used, town_hgt * town_wid, bool);
-    for (y = 1; y < town_hgt; y++)
-        ugarcade_used[y] = *ugarcade_used + y * town_wid;
+    std::vector<std::vector<bool>> ugarcade_used(town_hgt, std::vector<bool>(town_wid));
+    bool abort;
 
     for (i = 0; i < n; i++) {
         cur_ugbldg = &ugbldg[i];
@@ -69,8 +64,6 @@ static bool precalc_ugarcade(int town_hgt, int town_wid, int n)
         }
     }
 
-    C_KILL(*ugarcade_used, town_hgt * town_wid, bool);
-    C_KILL(ugarcade_used, town_hgt, bool *);
     return i == n;
 }
 
@@ -106,11 +99,11 @@ static void generate_fill_perm_bold(player_type *player_ptr, POSITION y1, POSITI
  * @note
  * Note: ltcy and ltcx indicate "left top corner".
  */
-static void build_stores(player_type *player_ptr, POSITION ltcy, POSITION ltcx, int stores[], int n)
+static void build_stores(player_type *player_ptr, POSITION ltcy, POSITION ltcx, int stores[], int n, const std::vector<ugbldg_type>& ugbldg)
 {
     int i;
     POSITION y, x;
-    ugbldg_type *cur_ugbldg;
+    const ugbldg_type *cur_ugbldg;
 
     for (i = 0; i < n; i++) {
         cur_ugbldg = &ugbldg[i];
@@ -192,22 +185,19 @@ bool build_type16(player_type *player_ptr, dun_data_type *dd_ptr)
     if (!n)
         return false;
 
-    C_MAKE(ugbldg, n, ugbldg_type);
-    if (!precalc_ugarcade(town_hgt, town_wid, n)) {
-        C_KILL(ugbldg, n, ugbldg_type);
+    std::vector<ugbldg_type> ugbldg(n);
+    if (!precalc_ugarcade(town_hgt, town_wid, n, ugbldg)) {
         return false;
     }
 
     if (!find_space(player_ptr, dd_ptr, &yval, &xval, town_hgt + 4, town_wid + 4)) {
-        C_KILL(ugbldg, n, ugbldg_type);
         return false;
     }
 
     y1 = yval - (town_hgt / 2);
     x1 = xval - (town_wid / 2);
     generate_room_floor(player_ptr, y1 + town_hgt / 3, x1 + town_wid / 3, y1 + town_hgt * 2 / 3, x1 + town_wid * 2 / 3, false);
-    build_stores(player_ptr, y1, x1, stores, n);
+    build_stores(player_ptr, y1, x1, stores, n, ugbldg);
     msg_print_wizard(player_ptr, CHEAT_DUNGEON, _("地下街を生成しました", "Underground arcade was generated."));
-    C_KILL(ugbldg, n, ugbldg_type);
     return true;
 }

--- a/src/room/rooms-maze-vault.cpp
+++ b/src/room/rooms-maze-vault.cpp
@@ -130,11 +130,8 @@ void build_maze_vault(player_type *player_ptr, POSITION x0, POSITION y0, POSITIO
     int n = dy + 1;
     int num_vertices = m * n;
 
-    int *visited;
-    C_MAKE(visited, num_vertices, int);
-    r_visit(player_ptr, y1, x1, y2, x2, randint0(num_vertices), 0, visited);
+    std::vector<int> visited(num_vertices);
+    r_visit(player_ptr, y1, x1, y2, x2, randint0(num_vertices), 0, visited.data());
     if (is_vault)
         fill_treasure(player_ptr, x1, x2, y1, y2, randint1(5));
-
-    C_KILL(visited, num_vertices, int);
 }

--- a/src/room/rooms-vault.cpp
+++ b/src/room/rooms-vault.cpp
@@ -938,7 +938,6 @@ static void build_mini_c_vault(player_type *player_ptr, POSITION x0, POSITION y0
     POSITION dy, dx;
     POSITION y1, x1, y2, x2, y, x, total;
     int m, n, num_vertices;
-    int *visited;
 
     msg_print_wizard(player_ptr, CHEAT_DUNGEON, _("小型チェッカーランダムVaultを生成しました。", "Mini Checker Board Vault."));
 
@@ -1006,10 +1005,10 @@ static void build_mini_c_vault(player_type *player_ptr, POSITION x0, POSITION y0
     num_vertices = m * n;
 
     /* initialize array of visited vertices */
-    C_MAKE(visited, num_vertices, int);
+    std::vector<int> visited(num_vertices);
 
     /* traverse the graph to create a spannng tree, pick a random root */
-    r_visit(player_ptr, y1, x1, y2, x2, randint0(num_vertices), 0, visited);
+    r_visit(player_ptr, y1, x1, y2, x2, randint0(num_vertices), 0, visited.data());
 
     /* Make it look like a checker board vault */
     for (x = x1; x <= x2; x++) {
@@ -1037,8 +1036,6 @@ static void build_mini_c_vault(player_type *player_ptr, POSITION x0, POSITION y0
 
     /* Fill with monsters and treasure, highest difficulty */
     fill_treasure(player_ptr, x1, x2, y1, y2, 10);
-
-    C_KILL(visited, num_vertices, int);
 }
 
 /* Build a castle */

--- a/src/term/z-form.cpp
+++ b/src/term/z-form.cpp
@@ -648,38 +648,30 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
  */
 char *vformat(concptr fmt, va_list vp)
 {
-    static char *format_buf = nullptr;
-    static ulong format_len = 0;
-
     /* Initial allocation */
-    if (!format_buf) {
-        format_len = 1024;
-        C_MAKE(format_buf, format_len, char);
-    }
+    static std::vector<char> format_buf(1024);
 
     /* Null format yields last result */
     if (!fmt)
-        return (format_buf);
+        return format_buf.data();
 
     /* Keep going until successful */
     while (true) {
         uint len;
 
         /* Build the string */
-        len = vstrnfmt(format_buf, format_len, fmt, vp);
+        len = vstrnfmt(format_buf.data(), format_buf.size(), fmt, vp);
 
         /* Success */
-        if (len < format_len - 1)
+        if (len < format_buf.size() - 1)
             break;
 
         /* Grow the buffer */
-        C_KILL(format_buf, format_len, char);
-        format_len = format_len * 2;
-        C_MAKE(format_buf, format_len, char);
+        format_buf.resize(format_buf.size() * 2);
     }
 
     /* Return the new buffer */
-    return (format_buf);
+    return format_buf.data();
 }
 
 /*

--- a/src/wizard/monster-info-spoiler.cpp
+++ b/src/wizard/monster-info-spoiler.cpp
@@ -76,7 +76,6 @@ spoiler_output_status spoil_mon_desc(concptr fname, std::function<bool(const mon
 {
     player_type dummy;
     uint16_t why = 2;
-    MONRACE_IDX *who;
     char buf[1024];
     char nam[MAX_MONSTER_NAME + 10]; // ユニークには[U] が付くので少し伸ばす
     char lev[80];
@@ -94,7 +93,6 @@ spoiler_output_status spoil_mon_desc(concptr fname, std::function<bool(const mon
     char title[200];
     put_version(title);
 
-    C_MAKE(who, max_r_idx, MONRACE_IDX);
     fprintf(spoiler_file, "Monster Spoilers for %s\n", title);
     fprintf(spoiler_file, "------------------------------------------\n\n");
     fprintf(spoiler_file, "%-45.45s%4s %4s %4s %7s %7s  %19.19s\n", "Name", "Lev", "Rar", "Spd", "Hp", "Ac", "Visual Info");
@@ -104,15 +102,15 @@ spoiler_output_status spoil_mon_desc(concptr fname, std::function<bool(const mon
         "----------",
         "---", "---", "---", "-----", "-----", "-------------------");
 
-    int n = 0;
+    std::vector<MONRACE_IDX> who;
     for (const auto &r_ref : r_info) {
         if (r_ref.idx > 0 && !r_ref.name.empty())
-            who[n++] = r_ref.idx;
+            who.push_back(r_ref.idx);
     }
 
-    ang_sort(&dummy, who, &why, n, ang_sort_comp_hook, ang_sort_swap_hook);
-    for (auto i = 0; i < n; i++) {
-        monster_race *r_ptr = &r_info[who[i]];
+    ang_sort(&dummy, who.data(), &why, who.size(), ang_sort_comp_hook, ang_sort_swap_hook);
+    for (auto r_idx : who) {
+        monster_race *r_ptr = &r_info[r_idx];
         concptr name = r_ptr->name.c_str();
         if (filter_monster && !filter_monster(r_ptr)) {
             continue;
@@ -161,7 +159,6 @@ spoiler_output_status spoil_mon_desc(concptr fname, std::function<bool(const mon
     }
 
     fprintf(spoiler_file, "\n");
-    C_KILL(who, max_r_idx, int16_t);
     return ferror(spoiler_file) || angband_fclose(spoiler_file) ? spoiler_output_status::SPOILER_OUTPUT_FAIL_FCLOSE
                                                                 : spoiler_output_status::SPOILER_OUTPUT_SUCCESS;
 }
@@ -199,18 +196,16 @@ spoiler_output_status spoil_mon_info(concptr fname)
     spoil_out(buf);
     spoil_out("------------------------------------------\n\n");
 
-    MONRACE_IDX *who;
-    C_MAKE(who, max_r_idx, MONRACE_IDX);
-    int n = 0;
+    std::vector<MONRACE_IDX> who;
     for (const auto &r_ref : r_info) {
         if (r_ref.idx > 0 && !r_ref.name.empty())
-            who[n++] = r_ref.idx;
+            who.push_back(r_ref.idx);
     }
 
     uint16_t why = 2;
-    ang_sort(&dummy, who, &why, n, ang_sort_comp_hook, ang_sort_swap_hook);
-    for (int i = 0; i < n; i++) {
-        monster_race *r_ptr = &r_info[who[i]];
+    ang_sort(&dummy, who.data(), &why, who.size(), ang_sort_comp_hook, ang_sort_swap_hook);
+    for (auto r_idx : who) {
+        monster_race *r_ptr = &r_info[r_idx];
         BIT_FLAGS flags1 = r_ptr->flags1;
         if (any_bits(flags1, RF1_UNIQUE)) {
             spoil_out("[U] ");
@@ -225,7 +220,7 @@ spoiler_output_status spoil_mon_info(concptr fname)
         spoil_out(buf);
         sprintf(buf, "=== ");
         spoil_out(buf);
-        sprintf(buf, "Num:%d  ", who[i]);
+        sprintf(buf, "Num:%d  ", r_idx);
         spoil_out(buf);
         sprintf(buf, "Lev:%d  ", (int)r_ptr->level);
         spoil_out(buf);
@@ -249,11 +244,10 @@ spoiler_output_status spoil_mon_info(concptr fname)
         spoil_out(buf);
         sprintf(buf, "Exp:%ld\n", (long)(r_ptr->mexp));
         spoil_out(buf);
-        output_monster_spoiler(who[i], roff_func);
+        output_monster_spoiler(r_idx, roff_func);
         spoil_out(nullptr);
     }
 
-    C_KILL(who, max_r_idx, int16_t);
     return ferror(spoiler_file) || angband_fclose(spoiler_file) ? spoiler_output_status::SPOILER_OUTPUT_FAIL_FCLOSE
                                                                 : spoiler_output_status::SPOILER_OUTPUT_SUCCESS;
 }

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -596,11 +596,7 @@ void wiz_dump_options(void)
         return;
     }
 
-    int **exist;
-    C_MAKE(exist, NUM_O_SET, int *);
-    C_MAKE(*exist, NUM_O_BIT * NUM_O_SET, int);
-    for (int i = 1; i < NUM_O_SET; i++)
-        exist[i] = *exist + i * NUM_O_BIT;
+    std::vector<std::vector<int>> exist(NUM_O_SET, std::vector<int>(NUM_O_BIT));
 
     for (int i = 0; option_info[i].o_desc; i++) {
         const option_type *ot_ptr = &option_info[i];
@@ -626,8 +622,6 @@ void wiz_dump_options(void)
         fputc('\n', fff);
     }
 
-    C_KILL(*exist, NUM_O_BIT * NUM_O_SET, int);
-    C_KILL(exist, NUM_O_SET, int *);
     angband_fclose(fff);
     msg_format(_("オプションbit使用状況をファイル %s に書き出しました。", "Option bits usage dump saved to file %s."), buf);
 }


### PR DESCRIPTION
C_MAKE マクロが使用されている箇所のうち、一時的なバッファ用途の物
(同一スコープでC_KILLが呼ばれている)を std::vector で置き換える。

まずは恒常的に使用する領域ではないものについて、 std::vector によるバッファ確保に置き換えました。