### PR TITLE
[Fix] エッセンス抽出で割引率が消去される

### DIFF
--- a/src/object-enchant/object-smith.cpp
+++ b/src/object-enchant/object-smith.cpp
@@ -342,6 +342,7 @@ Smith::DrainEssenceResult Smith::drain_essence(object_type *o_ptr)
     o_ptr->ix = old_o.ix;
     o_ptr->marked = old_o.marked;
     o_ptr->number = old_o.number;
+    o_ptr->discount = old_o.discount;
 
     if (o_ptr->tval == TV_DRAG_ARMOR)
         o_ptr->timeout = old_o.timeout;


### PR DESCRIPTION
Fix #1575.
以前からこの仕様だったようだが、割引率が消去される正当な理由も無いので
エッセンス抽出では割引率は保持されるようにする。