### PR TITLE
[Fix] 鍛冶で矢弾を強化する時エッセンス数が足りているのに不足していると判定される

### DIFF
--- a/src/mind/mind-weaponsmith.cpp
+++ b/src/mind/mind-weaponsmith.cpp
@@ -285,7 +285,7 @@ static void display_smith_effect_list(const Smith &smith, const std::vector<Smit
             snprintf(str, sizeof(str), "%-49s  (\?\?)/%d", title.str().c_str(), consumption);
         }
 
-        auto col = (smith.get_addable_count(effect, 1) > 0) ? TERM_WHITE : TERM_RED;
+        auto col = (smith.get_addable_count(effect) > 0) ? TERM_WHITE : TERM_RED;
         c_prt(col, str, ctr + 2, x);
     }
 }
@@ -415,7 +415,7 @@ static void add_essence(player_type *player_ptr, SmithCategory mode)
 
             effect_idx = page * effect_num_per_page + i;
             /* Totally Illegal */
-            if ((effect_idx < 0) || (effect_idx >= smith_effect_list_max) || smith.get_addable_count(smith_effect_list[effect_idx], 1) <= 0) {
+            if ((effect_idx < 0) || (effect_idx >= smith_effect_list_max) || smith.get_addable_count(smith_effect_list[effect_idx]) <= 0) {
                 bell();
                 continue;
             }
@@ -462,7 +462,7 @@ static void add_essence(player_type *player_ptr, SmithCategory mode)
         msg_format(_("%d個あるのでエッセンスは%d必要です。", "For %d items, it will take %d essences."), o_ptr->number, use_essence);
     }
 
-    if (smith.get_addable_count(effect, o_ptr->number) == 0) {
+    if (smith.get_addable_count(effect, o_ptr) == 0) {
         msg_print(_("エッセンスが足りない。", "You don't have enough essences."));
         return;
     }
@@ -481,7 +481,7 @@ static void add_essence(player_type *player_ptr, SmithCategory mode)
         } else if (o_ptr->pval == 0) {
             char tmp[80];
             char tmp_val[8];
-            auto limit = std::min(5, smith.get_addable_count(effect, o_ptr->number));
+            auto limit = std::min(5, smith.get_addable_count(effect, o_ptr));
 
             sprintf(tmp, _("いくつ付加しますか？ (1-%d): ", "Enchant how many? (1-%d): "), limit);
             strcpy(tmp_val, "1");
@@ -503,7 +503,7 @@ static void add_essence(player_type *player_ptr, SmithCategory mode)
 
     msg_format(_("エッセンスを%d個使用します。", "It will take %d essences."), use_essence * add_essence_count);
 
-    if (smith.get_addable_count(effect, o_ptr->number) < add_essence_count) {
+    if (smith.get_addable_count(effect, o_ptr) < add_essence_count) {
         msg_print(_("エッセンスが足りない。", "You don't have enough essences."));
         return;
     }

--- a/src/object-enchant/object-smith.cpp
+++ b/src/object-enchant/object-smith.cpp
@@ -256,17 +256,19 @@ std::vector<SmithEffect> Smith::get_effect_list(SmithCategory category)
  * @brief 指定した鍛冶効果のエッセンスを付与できる回数を取得する
  *
  * @param effect 鍛冶効果
- * @param item_number 同時に付与するスタックしたアイテム数。スタックしている場合アイテム数倍の数だけエッセンスが必要となる。
+ * @param o_ptr 鍛冶効果を付与するアイテムへのポインタ。nullptrの場合はデフォルトの消費量での回数が返される。
  * @return エッセンスを付与できる回数を返す
  */
-int Smith::get_addable_count(SmithEffect effect, int item_number) const
+int Smith::get_addable_count(SmithEffect effect, const object_type *o_ptr) const
 {
     auto info = find_smith_info(effect);
     if (!info.has_value()) {
         return 0;
     }
 
-    return addable_count(this->player_ptr, info.value()->need_essences, info.value()->consumption * item_number);
+    auto consumption = Smith::get_essence_consumption(effect, o_ptr);
+
+    return addable_count(this->player_ptr, info.value()->need_essences, consumption);
 }
 
 /*!

--- a/src/object-enchant/object-smith.h
+++ b/src/object-enchant/object-smith.h
@@ -45,7 +45,7 @@ public:
     DrainEssenceResult drain_essence(object_type *o_ptr);
     bool add_essence(SmithEffect effect, object_type *o_ptr, int consumption);
     void erase_essence(object_type *o_ptr) const;
-    int get_addable_count(SmithEffect smith_effect, int item_number) const;
+    int get_addable_count(SmithEffect smith_effect, const object_type *o_ptr = nullptr) const;
 
     static constexpr int ESSENCE_AMOUNT_MAX = 20000;
 


### PR DESCRIPTION
Fix #1577.
エッセンス付与可能回数を取得する、Smith::get_addable_count で矢弾のような1個
あたりの消費量が変化するアイテムが考慮されていないのが原因。
get_addable_coount にアイテムへのポインタを受け取るようにし、アイテム1個
あたりの消費量に基づいた付与可能回数が得られるように修正する。
エッセンス選択画面ではアイテムが確定していないので、矢1本だけを強化する時に
エッセンスが足りているのに選択不可能な問題は残っているが、以前からそうだし
先にアイテムを選択するようにするなど大幅なインターフェース変更が必要なので
とりあえずおいておく。