### PR TITLE
[Refactor] player_type::inventory_list の型を shared_ptr<object_type[]> に変更

### DIFF
--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -50,14 +50,12 @@ void player_wipe_without_name(player_type *player_ptr)
     if (player_ptr->last_message)
         string_free(player_ptr->last_message);
 
-    if (player_ptr->inventory_list != nullptr)
-        C_KILL(player_ptr->inventory_list, INVEN_TOTAL, object_type);
-
     (void)WIPE(player_ptr, player_type);
 
     // TODO: キャラ作成からゲーム開始までに  current_floor_ptr を参照しなければならない処理は今後整理して外す。
     player_ptr->current_floor_ptr = &floor_info;
-    C_MAKE(player_ptr->inventory_list, INVEN_TOTAL, object_type);
+    //! @todo std::make_shared の配列対応版は C++20 から
+    player_ptr->inventory_list = std::shared_ptr<object_type[]>{ new object_type[INVEN_TOTAL] };
     for (int i = 0; i < 4; i++)
         strcpy(player_ptr->history[i], "");
 

--- a/src/load/inventory-loader.cpp
+++ b/src/load/inventory-loader.cpp
@@ -23,9 +23,8 @@ static errr rd_inventory(player_type *player_ptr)
     player_ptr->inven_cnt = 0;
     player_ptr->equip_cnt = 0;
 
-    if (player_ptr->inventory_list != nullptr)
-        C_KILL(player_ptr->inventory_list, INVEN_TOTAL, object_type);
-    C_MAKE(player_ptr->inventory_list, INVEN_TOTAL, object_type);
+    //! @todo std::make_shared の配列対応版は C++20 から
+    player_ptr->inventory_list = std::shared_ptr<object_type[]>{ new object_type[INVEN_TOTAL] };
 
     int slot = 0;
     while (true) {

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -242,7 +242,7 @@ public:
     byte feeling{}; /* Most recent dungeon feeling */
     int32_t feeling_turn{}; /* The turn of the last dungeon feeling */
 
-    object_type *inventory_list{}; /* The player's inventory */
+    std::shared_ptr<object_type[]> inventory_list{}; /* The player's inventory */
     int16_t inven_cnt{}; /* Number of items in inventory */
     int16_t equip_cnt{}; /* Number of items in equipment */
 


### PR DESCRIPTION
C_MAKE を排除するために配列をSTLのコンテナに変更する作業を進めていますが、まとめてPRを出すと変更量が多くてレビューが大変になるので小分けして出すことにします。

C_MAKE マクロの使用を避けるため、player_type::inventory_list の型を
単なるポインタから shared_ptr<object_type[]> へ変更する。
vector にすると player_type 型を使用するすべてのファイルで
object_type を定義したヘッダのインクルードが必要になってあまりに
煩わしいので、shared_ptr を使用することにする。