### PR TITLE
[Refactor] floor_typeの配列的に扱うメンバ、荒野、クエスト、ダンジョン探索深度に std::vector を使用する

### DIFF
--- a/src/dungeon/dungeon.cpp
+++ b/src/dungeon/dungeon.cpp
@@ -20,7 +20,7 @@ std::vector<dungeon_type> d_info;
 /*
  * Maximum number of dungeon in d_info.txt
  */
-DEPTH *max_dlv;
+std::vector<DEPTH> max_dlv;
 
 /*!
  * @brief これまでに入ったダンジョンの一覧を表示し、選択させる。

--- a/src/dungeon/dungeon.h
+++ b/src/dungeon/dungeon.h
@@ -86,7 +86,7 @@ typedef struct dungeon_type {
 	int obj_good{};
 } dungeon_type;
 
-extern DEPTH *max_dlv;
+extern std::vector<DEPTH> max_dlv;
 extern std::vector<dungeon_type> d_info;
 
 struct player_type;

--- a/src/dungeon/quest.cpp
+++ b/src/dungeon/quest.cpp
@@ -36,7 +36,7 @@
 #include "view/display-messages.h"
 #include "world/world.h"
 
-quest_type *quest; /*!< Quest info */
+std::vector<quest_type> quest; /*!< Quest info */
 QUEST_IDX max_q_idx; /*!< Maximum number of quests */
 char quest_text[10][80]; /*!< Quest text */
 int quest_text_line; /*!< Current line of the quest text */

--- a/src/dungeon/quest.h
+++ b/src/dungeon/quest.h
@@ -2,6 +2,8 @@
 
 #include "system/angband.h"
 
+#include <vector>
+
 /*
  * Quest constants
  */
@@ -79,7 +81,7 @@ typedef struct quest_type {
 	REAL_TIME comptime;          /*!< クリア時ゲーム時間 /  quest clear time*/
 } quest_type;
 
-extern quest_type *quest;
+extern std::vector<quest_type> quest;
 extern QUEST_IDX max_q_idx;
 extern char quest_text[10][80];
 extern int quest_text_line;

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -331,14 +331,14 @@ void wipe_generate_random_floor_flags(floor_type *floor_ptr)
 void clear_cave(player_type *player_ptr)
 {
     floor_type *floor_ptr = player_ptr->current_floor_ptr;
-    (void)C_WIPE(floor_ptr->o_list, floor_ptr->o_max, object_type);
+    std::fill_n(floor_ptr->o_list.begin(), floor_ptr->o_max, object_type{});
     floor_ptr->o_max = 1;
     floor_ptr->o_cnt = 0;
 
     for (auto &r_ref : r_info)
         r_ref.cur_num = 0;
 
-    (void)C_WIPE(floor_ptr->m_list, floor_ptr->m_max, monster_type);
+    std::fill_n(floor_ptr->m_list.begin(), floor_ptr->m_max, monster_type{});
     floor_ptr->m_max = 1;
     floor_ptr->m_cnt = 0;
     for (int i = 0; i < MAX_MTIMED; i++)

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -205,7 +205,7 @@ void delete_all_items_from_floor(player_type *player_ptr, POSITION y, POSITION x
  */
 void floor_item_increase(player_type *player_ptr, INVENTORY_IDX item, ITEM_NUMBER num)
 {
-    const floor_type *floor_ptr = player_ptr->current_floor_ptr;
+    floor_type *floor_ptr = player_ptr->current_floor_ptr;
 
     object_type *o_ptr = &floor_ptr->o_list[item];
     num += o_ptr->number;

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -50,7 +50,7 @@
 
 #define MAX_FEAT_IN_TERRAIN 18
 
-wilderness_type **wilderness;
+std::vector<std::vector<wilderness_type>> wilderness;
 bool generate_encounter;
 
 typedef struct border_type {
@@ -759,10 +759,7 @@ typedef wilderness_type *wilderness_type_ptr;
  */
 errr init_wilderness(void)
 {
-    C_MAKE(wilderness, w_ptr->max_wild_y, wilderness_type_ptr);
-    C_MAKE(wilderness[0], w_ptr->max_wild_x * w_ptr->max_wild_y, wilderness_type);
-    for (int i = 1; i < w_ptr->max_wild_y; i++)
-        wilderness[i] = wilderness[0] + i * w_ptr->max_wild_x;
+    wilderness.assign(w_ptr->max_wild_y, std::vector<wilderness_type>(w_ptr->max_wild_x));
 
     generate_encounter = false;
     return 0;

--- a/src/floor/wild.h
+++ b/src/floor/wild.h
@@ -2,6 +2,8 @@
 
 #include "system/angband.h"
 
+#include <vector>
+
 #define NO_TOWN 6
 #define SECRET_TOWN 5
 
@@ -36,7 +38,7 @@ typedef struct wilderness_type {
 	byte entrance;
 } wilderness_type;
 
-extern wilderness_type **wilderness;
+extern std::vector<std::vector<wilderness_type>> wilderness;
 
 struct player_type;
 void set_floor_and_wall(DUNGEON_IDX type);

--- a/src/main/game-data-initializer.cpp
+++ b/src/main/game-data-initializer.cpp
@@ -39,9 +39,9 @@ static const int MACRO_MAX = 256;
  */
 errr init_quests(void)
 {
-    C_MAKE(quest, max_q_idx, quest_type);
-    for (int i = 0; i < max_q_idx; i++)
-        quest[i].status = QUEST_STATUS_UNTAKEN;
+    quest.assign(max_q_idx, {});
+    for (auto &q_ref : quest)
+        q_ref.status = QUEST_STATUS_UNTAKEN;
 
     return 0;
 }
@@ -55,14 +55,13 @@ errr init_other(player_type *player_ptr)
 {
     player_ptr->current_floor_ptr = &floor_info; // TODO:本当はこんなところで初期化したくない
     floor_type *floor_ptr = player_ptr->current_floor_ptr;
-    C_MAKE(floor_ptr->o_list, w_ptr->max_o_idx, object_type);
-    C_MAKE(floor_ptr->m_list, w_ptr->max_m_idx, monster_type);
-    for (int i = 0; i < MAX_MTIMED; i++)
-        C_MAKE(floor_ptr->mproc_list[i], w_ptr->max_m_idx, int16_t);
+    floor_ptr->o_list.assign(w_ptr->max_o_idx, {});
+    floor_ptr->m_list.assign(w_ptr->max_m_idx, {});
+    for (auto &list : floor_ptr->mproc_list)
+        list.assign(w_ptr->max_m_idx, {});
 
-    C_MAKE(max_dlv, w_ptr->max_d_idx, DEPTH);
-    for (int i = 0; i < MAX_HGT; i++)
-        C_MAKE(floor_ptr->grid_array[i], MAX_WID, grid_type);
+    max_dlv.assign(w_ptr->max_d_idx, {});
+    floor_ptr->grid_array.assign(MAX_HGT, std::vector<grid_type>(MAX_WID));
 
     C_MAKE(macro__pat, MACRO_MAX, concptr);
     C_MAKE(macro__act, MACRO_MAX, concptr);

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -101,7 +101,7 @@ HIT_POINT mon_damage_mod(player_type *player_ptr, monster_type *m_ptr, HIT_POINT
  */
 int get_mproc_idx(floor_type *floor_ptr, MONSTER_IDX m_idx, int mproc_type)
 {
-    int16_t *cur_mproc_list = floor_ptr->mproc_list[mproc_type];
+    const auto &cur_mproc_list = floor_ptr->mproc_list[mproc_type];
     for (int i = floor_ptr->mproc_max[mproc_type] - 1; i >= 0; i--) {
         if (cur_mproc_list[i] == m_idx) {
             return i;
@@ -344,7 +344,7 @@ static void process_monsters_mtimed_aux(player_type *player_ptr, MONSTER_IDX m_i
 void process_monsters_mtimed(player_type *player_ptr, int mtimed_idx)
 {
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    auto *cur_mproc_list = floor_ptr->mproc_list[mtimed_idx];
+    const auto &cur_mproc_list = floor_ptr->mproc_list[mtimed_idx];
 
     /* Hack -- calculate the "player noise" */
     if (mtimed_idx == MTIMED_CSLEEP) {

--- a/src/system/floor-type-definition.h
+++ b/src/system/floor-type-definition.h
@@ -5,12 +5,14 @@
 #include "monster/monster-timed-effect-types.h"
 #include "system/angband.h"
 
+#include <vector>
+
 struct grid_type;;
 struct object_type;;
 struct monster_type;
 typedef struct floor_type {
     DUNGEON_IDX dungeon_idx;
-    grid_type *grid_array[MAX_HGT];
+    std::vector<std::vector<grid_type>> grid_array;
     DEPTH dun_level; /*!< 現在の実ダンジョン階層 base_level の参照元となる / Current dungeon level */
     DEPTH base_level; /*!< 基本生成レベル、後述のobject_level, monster_levelの参照元となる / Base dungeon level */
     DEPTH object_level; /*!< アイテムの生成レベル、 base_level を起点に一時変更する時に参照 / Current object creation level */
@@ -21,15 +23,15 @@ typedef struct floor_type {
 
     GAME_TURN generated_turn; /* Turn when level began */
 
-    object_type *o_list; /*!< The array of dungeon items [max_o_idx] */
+    std::vector<object_type> o_list; /*!< The array of dungeon items [max_o_idx] */
     OBJECT_IDX o_max; /* Number of allocated objects */
     OBJECT_IDX o_cnt; /* Number of live objects */
 
-    monster_type *m_list; /*!< The array of dungeon monsters [max_m_idx] */
+    std::vector<monster_type> m_list; /*!< The array of dungeon monsters [max_m_idx] */
     MONSTER_IDX m_max; /* Number of allocated monsters */
     MONSTER_IDX m_cnt; /* Number of live monsters */
 
-    int16_t *mproc_list[MAX_MTIMED]; /*!< The array to process dungeon monsters[max_m_idx] */
+    std::vector<int16_t> mproc_list[MAX_MTIMED]; /*!< The array to process dungeon monsters[max_m_idx] */
     int16_t mproc_max[MAX_MTIMED]; /*!< Number of monsters to be processed */
 
     POSITION_IDX lite_n; //!< Array of grids lit by player lite

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -518,12 +518,12 @@ void fix_object(player_type *player_ptr)
  * @details
  * Lookコマンドでカーソルを合わせた場合に合わせてミミックは考慮しない。
  */
-static monster_type *monster_on_floor_items(const floor_type *floor_ptr, const grid_type *g_ptr)
+static const monster_type *monster_on_floor_items(floor_type *floor_ptr, const grid_type *g_ptr)
 {
     if (g_ptr->m_idx == 0)
         return nullptr;
 
-    monster_type *m_ptr = &floor_ptr->m_list[g_ptr->m_idx];
+    auto m_ptr = &floor_ptr->m_list[g_ptr->m_idx];
     if (!monster_is_valid(m_ptr) || !m_ptr->ml)
         return nullptr;
 
@@ -550,7 +550,7 @@ static void display_floor_item_list(player_type *player_ptr, const int y, const 
     term_clear();
     term_gotoxy(0, 0);
 
-    const auto *floor_ptr = player_ptr->current_floor_ptr;
+    auto *floor_ptr = player_ptr->current_floor_ptr;
     const auto *g_ptr = &floor_ptr->grid_array[y][x];
     char line[1024];
 


### PR DESCRIPTION
配列へのポインタからvectorになったので const性の厳密さが増したため、一部 const修飾を外す必要がありました。
（本来const引数でOKなはずの関数の引数がconstじゃないせいなのですが、それを修正すると芋づる式に大量に修正しないといけないので断念）