### PR TITLE
[Refactor] 街・店舗・店舗のアイテム情報を std::vector もしくは std::unique_ptr にする

### DIFF
--- a/src/floor/floor-town.cpp
+++ b/src/floor/floor-town.cpp
@@ -1,7 +1,9 @@
 ﻿#include "floor/floor-town.h"
+#include "store/store-util.h"
+#include "system/object-type-definition.h"
 
 /* Maximum number of towns */
 int16_t max_towns;
 
 /* The towns [max_towns] */
-town_type *town_info;
+std::vector<town_type> town_info;

--- a/src/floor/floor-town.h
+++ b/src/floor/floor-town.h
@@ -2,18 +2,20 @@
 
 #include "system/angband.h"
 
-typedef struct store_type store_type;
+#include <vector>
+
+struct store_type;
 
 /*
  * A structure describing a town with
  * stores and buildings
  */
-typedef struct town_type {
-	GAME_TEXT name[32];
-	uint32_t seed;      /* Seed for RNG */
-	store_type *store;    /* The stores [MAX_STORES] */
-	byte numstores;
-} town_type;
+struct town_type {
+    GAME_TEXT name[32];
+    uint32_t seed; /* Seed for RNG */
+    std::vector<store_type> store; /* The stores [MAX_STORES] */
+    byte numstores;
+};
 
 extern int16_t max_towns;
-extern town_type *town_info;
+extern std::vector<town_type> town_info;

--- a/src/market/building-initializer.cpp
+++ b/src/market/building-initializer.cpp
@@ -16,9 +16,9 @@
  */
 errr init_towns(void)
 {
-    C_MAKE(town_info, max_towns, town_type);
+    town_info = std::vector<town_type>(max_towns);
     for (int i = 1; i < max_towns; i++) {
-        C_MAKE(town_info[i].store, MAX_STORES, store_type);
+        town_info[i].store = std::vector<store_type>(MAX_STORES);
         for (int j = 0; j < MAX_STORES; j++) {
             store_type *store_ptr = &town_info[i].store[j];
             if ((i > 1) && (j == STORE_MUSEUM || j == STORE_HOME))
@@ -30,7 +30,7 @@ errr init_towns(void)
              */
             store_ptr->stock_size = store_get_stock_max(i2enum<STORE_TYPE_IDX>(j));
 
-            C_MAKE(store_ptr->stock, store_ptr->stock_size, object_type);
+            store_ptr->stock = std::make_unique<object_type[]>(store_ptr->stock_size);
             if ((j == STORE_BLACK) || (j == STORE_HOME) || (j == STORE_MUSEUM))
                 continue;
 

--- a/src/store/store-util.h
+++ b/src/store/store-util.h
@@ -1,6 +1,8 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+
+#include <memory>
 #include <vector>
 
 #define STORE_OBJ_LEVEL 5 //!< 通常店舗の階層レベル / Magic Level for normal stores
@@ -38,7 +40,11 @@ struct store_type {
     store_k_idx table{};   //!< Table -- Legal item kinds
     int16_t stock_num{};      //!< Stock -- Number of entries
     int16_t stock_size{};     //!< Stock -- Total Size of Array
-    object_type *stock{};  //!< Stock -- Actual stock items
+    std::unique_ptr<object_type[]> stock{}; //!< Stock -- Actual stock items
+
+    store_type() = default;
+    store_type(const store_type &) = delete;
+    store_type &operator=(const store_type &) = delete;
 };
 
 extern int cur_store_num;


### PR DESCRIPTION
C_MAKE マクロの使用を避けるため、街・店舗の情報を std::vector で
保持する。店舗のアイテム情報は std::vector にすると town_type や
store_type を使用するすべてのファイルで object_type を定義する
ヘッダのインクルードが必要になり煩わしいので
std::unique_ptr<object_type[]> にする。