### PR TITLE
[Refactor] ファイル読み書き用のバッファを std::vector にする

### DIFF
--- a/src/main/angband-initializer.cpp
+++ b/src/main/angband-initializer.cpp
@@ -37,10 +37,6 @@
 #include "util/string-processor.h"
 #endif
 
-char *file_read__buf;
-char *file_read__swp;
-char *file_read__tmp;
-
 /*!
  * @brief 各データファイルを読み取るためのパスを取得する
  * Find the default paths to all of our important sub-directories.
@@ -214,9 +210,6 @@ static void put_title(void)
  */
 void init_angband(player_type *player_ptr, bool no_term)
 {
-    C_MAKE(file_read__buf, FILE_READ_BUFF_SIZE, char);
-    C_MAKE(file_read__swp, FILE_READ_BUFF_SIZE, char);
-    C_MAKE(file_read__tmp, FILE_READ_BUFF_SIZE, char);
     char buf[1024];
     path_build(buf, sizeof(buf), ANGBAND_DIR_FILE, _("news_j.txt", "news.txt"));
     int fd = fd_open(buf, O_RDONLY);

--- a/src/util/angband-files.cpp
+++ b/src/util/angband-files.cpp
@@ -248,11 +248,12 @@ errr angband_fgets(FILE *fff, char *buf, ulong n)
     // Reserve for null termination
     --n;
 
-    if (fgets(file_read__tmp, FILE_READ_BUFF_SIZE, fff)) {
+    std::vector<char> file_read__tmp(FILE_READ_BUFF_SIZE);
+    if (fgets(file_read__tmp.data(), file_read__tmp.size(), fff)) {
 #ifdef JP
-        guess_convert_to_system_encoding(file_read__tmp, FILE_READ_BUFF_SIZE);
+        guess_convert_to_system_encoding(file_read__tmp.data(), FILE_READ_BUFF_SIZE);
 #endif
-        for (s = file_read__tmp; *s; s++) {
+        for (s = file_read__tmp.data(); *s; s++) {
             if (*s == '\n') {
                 buf[i] = '\0';
                 return 0;

--- a/src/util/angband-files.h
+++ b/src/util/angband-files.h
@@ -32,9 +32,6 @@ extern int usleep(ulong usecs);
 #endif
 
 #define FILE_READ_BUFF_SIZE 65535
-extern char *file_read__buf;
-extern char *file_read__swp;
-extern char *file_read__tmp;
 
 errr path_parse(char *buf, int max, concptr file);
 errr path_build(char *buf, int max, concptr path, concptr file);


### PR DESCRIPTION
C_MAKE マクロの使用を避けるため、ファイル読み書き用のバッファを
std::vector にする。また、全くグローバルである必要が無いためローカル
変数にする。