### PR TITLE
[Refactor] マクロ関連の配列変数をstd::vectorにする

### DIFF
--- a/src/cmd-io/cmd-macro.cpp
+++ b/src/cmd-io/cmd-macro.cpp
@@ -150,6 +150,7 @@ void do_cmd_macros(player_type *player_ptr)
 {
     char tmp[1024];
     char buf[1024];
+    static char macro_buf[1024];
     FILE *auto_dump_stream;
     BIT_FLAGS mode = rogue_like_commands ? KEYMAP_MODE_ROGUE : KEYMAP_MODE_ORIG;
     screen_save();
@@ -210,10 +211,10 @@ void do_cmd_macros(player_type *player_ptr)
             if (k < 0) {
                 msg_print(_("そのキーにはマクロは定義されていません。", "Found no macro."));
             } else {
-                // マクロの作成時に参照するためmacro__bufにコピーする
-                strcpy(macro__buf, macro__act[k]);
+                // マクロの作成時に参照するためmacro_bufにコピーする
+                strcpy(macro_buf, macro__act[k].c_str());
                 // too long macro must die
-                strncpy(tmp, macro__buf, 80);
+                strncpy(tmp, macro_buf, 80);
                 tmp[80] = '\0';
                 ascii_to_text(buf, tmp);
                 prt(buf, 22, 0);
@@ -229,11 +230,11 @@ void do_cmd_macros(player_type *player_ptr)
                 22, 0);
             prt(_("マクロ行動: ", "Action: "), 20, 0);
             // 最後に参照したマクロデータを元に作成する（コピーを行えるように）
-            macro__buf[80] = '\0';
-            ascii_to_text(tmp, macro__buf);
+            macro_buf[80] = '\0';
+            ascii_to_text(tmp, macro_buf);
             if (askfor(tmp, 80)) {
-                text_to_ascii(macro__buf, tmp);
-                macro_add(buf, macro__buf);
+                text_to_ascii(macro_buf, tmp);
+                macro_add(buf, macro_buf);
                 msg_print(_("マクロを追加しました。", "Added a macro."));
             }
         } else if (key == '5') {
@@ -260,10 +261,10 @@ void do_cmd_macros(player_type *player_ptr)
             if (!act) {
                 msg_print(_("キー配置は定義されていません。", "Found no keymap."));
             } else {
-                // マクロの作成時に参照するためmacro__bufにコピーする
-                strcpy(macro__buf, act);
+                // マクロの作成時に参照するためmacro_bufにコピーする
+                strcpy(macro_buf, act);
                 // too long macro must die
-                strncpy(tmp, macro__buf, 80);
+                strncpy(tmp, macro_buf, 80);
                 tmp[80] = '\0';
                 ascii_to_text(buf, tmp);
                 prt(buf, 22, 0);
@@ -279,12 +280,12 @@ void do_cmd_macros(player_type *player_ptr)
                 22, 0);
             prt(_("行動: ", "Action: "), 20, 0);
             // 最後に参照したマクロデータを元に作成する（コピーを行えるように）
-            macro__buf[80] = '\0';
-            ascii_to_text(tmp, macro__buf);
+            macro_buf[80] = '\0';
+            ascii_to_text(tmp, macro_buf);
             if (askfor(tmp, 80)) {
-                text_to_ascii(macro__buf, tmp);
+                text_to_ascii(macro_buf, tmp);
                 string_free(keymap_act[mode][(byte)(buf[0])]);
-                keymap_act[mode][(byte)(buf[0])] = string_make(macro__buf);
+                keymap_act[mode][(byte)(buf[0])] = string_make(macro_buf);
                 msg_print(_("キー配置を追加しました。", "Added a keymap."));
             }
         } else if (key == '9') {
@@ -305,7 +306,7 @@ void do_cmd_macros(player_type *player_ptr)
             if (!askfor(buf, 80))
                 continue;
 
-            text_to_ascii(macro__buf, buf);
+            text_to_ascii(macro_buf, buf);
         } else {
             bell();
         }

--- a/src/cmd-io/macro-util.cpp
+++ b/src/cmd-io/macro-util.cpp
@@ -1,16 +1,13 @@
 ﻿#include "cmd-io/macro-util.h"
 
-/* Array of macro types [MACRO_MAX] */
-bool *macro__cmd;
-
 /* Current macro action [1024] */
-char *macro__buf;
+std::vector<char> macro__buf;
 
 /* Array of macro patterns [MACRO_MAX] */
-concptr *macro__pat;
+std::vector<std::string> macro__pat;
 
 /* Array of macro actions [MACRO_MAX] */
-concptr *macro__act;
+std::vector<std::string> macro__act;
 
 /* Number of active macros */
 int16_t macro__num;
@@ -93,7 +90,7 @@ int macro_find_ready(concptr pat)
         if (!prefix(pat, macro__pat[i]))
             continue;
 
-        t = strlen(macro__pat[i]);
+        t = macro__pat[i].size();
         if ((n >= 0) && (s > t))
             continue;
 
@@ -126,14 +123,12 @@ errr macro_add(concptr pat, concptr act)
         return -1;
 
     int n = macro_find_exact(pat);
-    if (n >= 0) {
-        string_free(macro__act[n]);
-    } else {
+    if (n < 0) {
         n = macro__num++;
-        macro__pat[n] = string_make(pat);
+        macro__pat[n] = pat;
     }
 
-    macro__act[n] = string_make(act);
+    macro__act[n] = act;
     macro__use[(byte)(pat[0])] = true;
     return 0;
 }

--- a/src/cmd-io/macro-util.h
+++ b/src/cmd-io/macro-util.h
@@ -2,13 +2,15 @@
 
 #include "system/angband.h"
 
-extern bool *macro__cmd;
-extern char *macro__buf;
+#include <string>
+#include <vector>
+
+extern std::vector<char> macro__buf;
 
 extern bool get_com_no_macros;
 
-extern concptr *macro__pat;
-extern concptr *macro__act;
+extern std::vector<std::string> macro__pat;
+extern std::vector<std::string> macro__act;
 extern int16_t macro__num;
 
 int macro_find_exact(concptr pat);

--- a/src/io/input-key-acceptor.cpp
+++ b/src/io/input-key-acceptor.cpp
@@ -157,7 +157,7 @@ static char inkey_aux(void)
         return (ch);
     }
 
-    concptr pat = macro__pat[k];
+    concptr pat = macro__pat[k].c_str();
     n = strlen(pat);
     while (p > n) {
         if (term_key_push(buf[--p]))
@@ -168,7 +168,7 @@ static char inkey_aux(void)
     if (term_key_push(30))
         return 0;
 
-    concptr act = macro__act[k];
+    concptr act = macro__act[k].c_str();
 
     n = strlen(act);
     while (n > 0) {

--- a/src/io/interpret-pref-file.cpp
+++ b/src/io/interpret-pref-file.cpp
@@ -233,7 +233,7 @@ static errr interpret_p_token(char *buf)
 {
     char tmp[1024];
     text_to_ascii(tmp, buf + 2);
-    return macro_add(tmp, macro__buf);
+    return macro_add(tmp, macro__buf.data());
 }
 
 /*!
@@ -258,7 +258,7 @@ static errr interpret_c_token(char *buf)
 
     int i = (byte)(tmp[0]);
     string_free(keymap_act[mode][i]);
-    keymap_act[mode][i] = string_make(macro__buf);
+    keymap_act[mode][i] = string_make(macro__buf.data());
     return 0;
 }
 
@@ -494,7 +494,7 @@ errr interpret_pref_file(player_type *player_ptr, char *buf)
         return interpret_e_token(buf);
     case 'A': {
         /* Process "A:<str>" -- save an "action" for later */
-        text_to_ascii(macro__buf, buf + 2);
+        text_to_ascii(macro__buf.data(), buf + 2);
         return 0;
     }
     case 'P':

--- a/src/main/game-data-initializer.cpp
+++ b/src/main/game-data-initializer.cpp
@@ -63,10 +63,9 @@ errr init_other(player_type *player_ptr)
     max_dlv.assign(w_ptr->max_d_idx, {});
     floor_ptr->grid_array.assign(MAX_HGT, std::vector<grid_type>(MAX_WID));
 
-    C_MAKE(macro__pat, MACRO_MAX, concptr);
-    C_MAKE(macro__act, MACRO_MAX, concptr);
-    C_MAKE(macro__cmd, MACRO_MAX, bool);
-    C_MAKE(macro__buf, FILE_READ_BUFF_SIZE, char);
+    macro__pat.assign(MACRO_MAX, {});
+    macro__act.assign(MACRO_MAX, {});
+    macro__buf.assign(FILE_READ_BUFF_SIZE, {});
     quark_init();
 
     for (int i = 0; option_info[i].o_desc; i++) {

--- a/src/term/z-util.cpp
+++ b/src/term/z-util.cpp
@@ -22,42 +22,31 @@ concptr argv0 = nullptr;
 /*
  * Determine if string "t" is equal to string "t"
  */
-bool streq(concptr a, concptr b)
+bool streq(std::string_view a, std::string_view b)
 {
-	return (!strcmp(a, b));
+    return a == b;
 }
-
 
 /*
  * Determine if string "t" is a suffix of string "s"
  */
-bool suffix(concptr s, concptr t)
+bool suffix(std::string_view s, std::string_view t)
 {
-	int tlen = strlen(t);
-	int slen = strlen(s);
+    //! @todo C++20 では ends_with が使用可能
+    if (t.size() > s.size()) {
+        return false;
+    }
 
-	/* Check for incompatible lengths */
-	if (tlen > slen) return false;
-
-	/* Compare "t" to the end of "s" */
-	return (!strcmp(s + slen - tlen, t));
+    return s.compare(s.size() - t.size(), s.npos, t) == 0;
 }
-
 
 /*
  * Determine if string "t" is a prefix of string "s"
  */
-bool prefix(concptr s, concptr t)
+bool prefix(std::string_view s, std::string_view t)
 {
-	/* Scan "t" */
-	while (*t)
-	{
-		/* Compare content and length */
-		if (*t++ != *s++) return false;
-	}
-
-	/* Matched, we have a prefix */
-	return true;
+    //! @todo C++20 では starts_with が使用可能
+    return s.substr(0, t.size()) == t;
 }
 
 

--- a/src/term/z-util.h
+++ b/src/term/z-util.h
@@ -13,6 +13,7 @@
 
 #include "system/h-basic.h"
 
+#include <string_view>
 
 /*
  * Extremely basic stuff, like global temp and constant variables.
@@ -36,10 +37,9 @@ extern void (*core_aux)(concptr);
 /**** Available Functions ****/
 
 /* Test equality, prefix, suffix */
-extern bool streq(concptr s, concptr t);
-extern bool prefix(concptr s, concptr t);
-extern bool suffix(concptr s, concptr t);
-
+extern bool streq(std::string_view s, std::string_view t);
+extern bool prefix(std::string_view s, std::string_view t);
+extern bool suffix(std::string_view s, std::string_view t);
 
 /* Print an error message */
 extern void plog(concptr str);
@@ -85,4 +85,3 @@ extern void s64b_mod(int32_t *A1, uint32_t *A2, int32_t B1, uint32_t B2);
 
 extern int count_bits(BIT_FLAGS x);
 extern int mysqrt(int n);
-

--- a/src/util/string-processor.cpp
+++ b/src/util/string-processor.cpp
@@ -181,9 +181,10 @@ static void trigger_text_to_ascii(char **bufptr, concptr *strptr)
  * parsing "\xFF" into a (signed) char.  Whoever thought of making
  * the "sign" of a "char" undefined is a complete moron.  Oh well.
  */
-void text_to_ascii(char *buf, concptr str)
+void text_to_ascii(char *buf, std::string_view sv)
 {
     char *s = buf;
+    auto str = sv.data();
     while (*str) {
         if (*str == '\\') {
             str++;
@@ -305,9 +306,10 @@ static bool trigger_ascii_to_text(char **bufptr, concptr *strptr)
 /*
  * Hack -- convert a string into a printable form
  */
-void ascii_to_text(char *buf, concptr str)
+void ascii_to_text(char *buf, std::string_view sv)
 {
     char *s = buf;
+    auto str = sv.data();
     while (*str) {
         byte i = (byte)(*str++);
         if (i == 31) {

--- a/src/util/string-processor.h
+++ b/src/util/string-processor.h
@@ -21,8 +21,8 @@ extern concptr macro_modifier_name[MAX_MACRO_MOD];
 extern concptr macro_trigger_name[MAX_MACRO_TRIG];
 extern concptr macro_trigger_keycode[2][MAX_MACRO_TRIG];
 
-void text_to_ascii(char *buf, concptr str);
-void ascii_to_text(char *buf, concptr str);
+void text_to_ascii(char *buf, std::string_view sv);
+void ascii_to_text(char *buf, std::string_view sv);
 size_t angband_strcpy(char *buf, concptr src, size_t bufsize);
 size_t angband_strcat(char *buf, concptr src, size_t bufsize);
 char *angband_strstr(concptr haystack, concptr needle);


### PR DESCRIPTION
マクロ関連の配列変数を std::vector にするにあたり、以下の変更も行っています。

- マクロの内容を std::string で持つ
- マクロに関連する concptr を受け取る関数を std::string_view を受け取るように変更
- マクロ設定コマンドの編集バッファを従来のマクロバッファから分離