### PR TITLE
[Refactor] 自動拾い関連の配列変数を std::vector にする 

### DIFF
--- a/src/autopick/autopick-describer.cpp
+++ b/src/autopick/autopick-describer.cpp
@@ -532,10 +532,11 @@ void describe_autopick_en(char *buff, autopick_type *entry, autopick_describer *
  */
 void describe_autopick(char *buff, autopick_type *entry)
 {
+    //! @note autopick_describer::str は non-nullable、autopick_describer::insc は nullable という制約がある
     autopick_describer describer;
-    describer.str = entry->name;
+    describer.str = entry->name.c_str();
     describer.act = entry->action;
-    describer.insc = entry->insc;
+    describer.insc = entry->insc.empty() ? nullptr : entry->insc.c_str();
     describer.top = false;
     describer.before_n = 0;
     describer.body_str = _("アイテム", "items");

--- a/src/autopick/autopick-drawer.cpp
+++ b/src/autopick/autopick-drawer.cpp
@@ -270,8 +270,6 @@ void draw_text_editor(player_type *player_ptr, text_body_type *tb)
                 t += strlen(t) + 1;
             }
         }
-
-        autopick_free_entry(entry);
     }
 
     if (str1)

--- a/src/autopick/autopick-editor-util.cpp
+++ b/src/autopick/autopick-editor-util.cpp
@@ -165,7 +165,6 @@ void add_keyword(text_body_type *tb, BIT_FLAGS flg)
             continue;
 
         if (IS_FLG(flg)) {
-            autopick_free_entry(entry);
             continue;
         }
 

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -275,9 +275,9 @@ bool autopick_new_entry(autopick_type *entry, concptr str, bool allow_default)
         }
     }
 
-    entry->name = string_make(ptr);
+    entry->name = ptr;
     entry->action = act;
-    entry->insc = string_make(insc);
+    entry->insc = insc != nullptr ? insc : "";
 
     return true;
 }
@@ -291,7 +291,8 @@ void autopick_entry_from_object(player_type *player_ptr, autopick_type *entry, o
     bool name = true;
     GAME_TEXT name_str[MAX_NLEN + 32];
     name_str[0] = '\0';
-    entry->insc = string_make(quark_str(o_ptr->inscription));
+    auto insc = quark_str(o_ptr->inscription);
+    entry->insc = insc != nullptr ? insc : "";
     entry->action = DO_AUTOPICK | DO_DISPLAY;
     entry->flag[0] = entry->flag[1] = 0L;
     entry->dice = 0;
@@ -451,7 +452,7 @@ void autopick_entry_from_object(player_type *player_ptr, autopick_type *entry, o
 
     if (!name) {
         str_tolower(name_str);
-        entry->name = string_make(name_str);
+        entry->name = name_str;
         return;
     }
 
@@ -464,7 +465,7 @@ void autopick_entry_from_object(player_type *player_ptr, autopick_type *entry, o
      */
     sprintf(name_str, "%s%s", is_hat_added ? "^" : "", o_name);
     str_tolower(name_str);
-    entry->name = string_make(name_str);
+    entry->name = name_str;
 }
 
 /*!
@@ -594,7 +595,7 @@ concptr autopick_line_from_entry(autopick_type *entry)
     else if (!IS_FLG(FLG_ARTIFACT))
         sepa_flag = false;
 
-    if (entry->name && entry->name[0]) {
+    if (!entry->name.empty()) {
         if (sepa_flag)
             strcat(buf, ":");
 
@@ -610,7 +611,7 @@ concptr autopick_line_from_entry(autopick_type *entry)
         buf[i] = '\0';
     }
 
-    if (!entry->insc)
+    if (entry->insc.empty())
         return string_make(buf);
 
     int i, j = 0;
@@ -635,7 +636,6 @@ concptr autopick_line_from_entry(autopick_type *entry)
 concptr autopick_line_from_entry_kill(autopick_type *entry)
 {
     concptr ptr = autopick_line_from_entry(entry);
-    autopick_free_entry(entry);
     return ptr;
 }
 

--- a/src/autopick/autopick-finder.cpp
+++ b/src/autopick/autopick-finder.cpp
@@ -41,7 +41,7 @@ int find_autopick_list(player_type *player_ptr, object_type *o_ptr)
 
     describe_flavor(player_ptr, o_name, o_ptr, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NO_PLURAL));
     str_tolower(o_name);
-    for (int i = 0; i < max_autopick; i++) {
+    for (auto i = 0U; i < autopick_list.size(); i++) {
         autopick_type *entry = &autopick_list[i];
         if (is_autopick_match(player_ptr, o_ptr, entry, o_name))
             return i;
@@ -311,7 +311,6 @@ void search_for_object(player_type *player_ptr, text_body_type *tb, object_type 
             continue;
 
         match = is_autopick_match(player_ptr, o_ptr, entry, o_name);
-        autopick_free_entry(entry);
         if (!match)
             continue;
 

--- a/src/autopick/autopick-initializer.cpp
+++ b/src/autopick/autopick-initializer.cpp
@@ -9,19 +9,9 @@
 void init_autopick(void)
 {
     static const char easy_autopick_inscription[] = "(:=g";
+
+    autopick_list.clear();
     autopick_type entry;
-    int i;
-
-    if (!autopick_list) {
-        max_max_autopick = MAX_AUTOPICK_DEFAULT;
-        C_MAKE(autopick_list, max_max_autopick, autopick_type);
-        max_autopick = 0;
-    }
-
-    for (i = 0; i < max_autopick; i++)
-        autopick_free_entry(&autopick_list[i]);
-
-    max_autopick = 0;
     autopick_new_entry(&entry, easy_autopick_inscription, true);
-    autopick_list[max_autopick++] = entry;
+    autopick_list.push_back(std::move(entry));
 }

--- a/src/autopick/autopick-matcher.cpp
+++ b/src/autopick/autopick-matcher.cpp
@@ -34,7 +34,7 @@
  */
 bool is_autopick_match(player_type *player_ptr, object_type *o_ptr, autopick_type *entry, concptr o_name)
 {
-    concptr ptr = entry->name;
+    concptr ptr = entry->name.c_str();
     if (IS_FLG(FLG_UNAWARE) && o_ptr->is_aware())
         return false;
 

--- a/src/autopick/autopick-pref-processor.cpp
+++ b/src/autopick/autopick-pref-processor.cpp
@@ -8,7 +8,7 @@
  */
 void process_autopick_file_command(char *buf)
 {
-    autopick_type an_entry, *entry = &an_entry;
+    autopick_type entry;
     int i;
     for (i = 0; buf[i]; i++) {
 #ifdef JP
@@ -22,16 +22,15 @@ void process_autopick_file_command(char *buf)
     }
 
     buf[i] = 0;
-    if (!autopick_new_entry(entry, buf, false))
+    if (!autopick_new_entry(&entry, buf, false))
         return;
 
-    for (i = 0; i < max_autopick; i++) {
-        if (!strcmp(entry->name, autopick_list[i].name) && entry->flag[0] == autopick_list[i].flag[0] && entry->flag[1] == autopick_list[i].flag[1]
-            && entry->dice == autopick_list[i].dice && entry->bonus == autopick_list[i].bonus) {
-            autopick_free_entry(entry);
+    for (const auto &item : autopick_list) {
+        if ((entry.name == item.name) && entry.flag[0] == item.flag[0] && entry.flag[1] == item.flag[1]
+            && entry.dice == item.dice && entry.bonus == item.bonus) {
             return;
         }
     }
 
-    add_autopick_list(entry);
+    autopick_list.push_back(std::move(entry));
 }

--- a/src/autopick/autopick-reader-writer.cpp
+++ b/src/autopick/autopick-reader-writer.cpp
@@ -57,9 +57,8 @@ concptr pickpref_filename(player_type *player_ptr, int filename_mode)
 /*!
  * @brief Read whole lines of a file to memory
  */
-static concptr *read_text_lines(concptr filename)
+static std::vector<concptr> read_text_lines(concptr filename)
 {
-    concptr *lines_list = nullptr;
     FILE *fff;
 
     int lines = 0;
@@ -68,9 +67,9 @@ static concptr *read_text_lines(concptr filename)
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, filename);
     fff = angband_fopen(buf, "r");
     if (!fff)
-        return nullptr;
+        return {};
 
-    C_MAKE(lines_list, MAX_LINES, concptr);
+    std::vector<concptr> lines_list(MAX_LINES);
     while (angband_fgets(fff, buf, sizeof(buf)) == 0) {
         lines_list[lines++] = string_make(buf);
         if (is_greater_autopick_max_line(lines))
@@ -133,28 +132,27 @@ static void prepare_default_pickpref(player_type *player_ptr)
  * @brief Read an autopick prefence file to memory
  * Prepare default if no user file is found
  */
-concptr *read_pickpref_text_lines(player_type *player_ptr, int *filename_mode_p)
+std::vector<concptr> read_pickpref_text_lines(player_type *player_ptr, int *filename_mode_p)
 {
     /* Try a filename with player name */
     *filename_mode_p = PT_WITH_PNAME;
     char buf[1024];
     strcpy(buf, pickpref_filename(player_ptr, *filename_mode_p));
-    concptr *lines_list;
-    lines_list = read_text_lines(buf);
+    std::vector<concptr> lines_list = read_text_lines(buf);
 
-    if (!lines_list) {
+    if (lines_list.empty()) {
         *filename_mode_p = PT_DEFAULT;
         strcpy(buf, pickpref_filename(player_ptr, *filename_mode_p));
         lines_list = read_text_lines(buf);
     }
 
-    if (!lines_list) {
+    if (lines_list.empty()) {
         prepare_default_pickpref(player_ptr);
         lines_list = read_text_lines(buf);
     }
 
-    if (!lines_list) {
-        C_MAKE(lines_list, MAX_LINES, concptr);
+    if (lines_list.empty()) {
+        lines_list.resize(MAX_LINES);
         lines_list[0] = string_make("");
     }
 

--- a/src/autopick/autopick-reader-writer.h
+++ b/src/autopick/autopick-reader-writer.h
@@ -2,8 +2,10 @@
 
 #include "system/angband.h"
 
+#include <vector>
+
 struct player_type;
 void autopick_load_pref(player_type *player_ptr, bool disp_mes);
-concptr *read_pickpref_text_lines(player_type *player_ptr, int *filename_mode_p);
+std::vector<concptr> read_pickpref_text_lines(player_type *player_ptr, int *filename_mode_p);
 bool write_text_lines(concptr filename, concptr *lines_list);
 concptr pickpref_filename(player_type *player_ptr, int filename_mode);

--- a/src/autopick/autopick-registry.cpp
+++ b/src/autopick/autopick-registry.cpp
@@ -190,7 +190,7 @@ bool autopick_autoregister(player_type *player_ptr, object_type *o_ptr)
 
     autopick_entry_from_object(player_ptr, entry, o_ptr);
     entry->action = DO_AUTODESTROY;
-    add_autopick_list(entry);
+    autopick_list.push_back(*entry);
 
     concptr tmp = autopick_line_from_entry(entry);
     fprintf(pref_fff, "%s\n", tmp);

--- a/src/autopick/autopick-util.cpp
+++ b/src/autopick/autopick-util.cpp
@@ -13,9 +13,7 @@
 /*!
  * @brief 自動拾い/破壊設定のリストに関する変数 / List for auto-picker/destroyer entries
  */
-int max_autopick = 0; /*!< 現在登録している自動拾い/破壊設定の数 */
-int max_max_autopick = 0; /*!< 自動拾い/破壊設定の限界数 */
-autopick_type *autopick_list = nullptr; /*!< 自動拾い/破壊設定構造体のポインタ配列 */
+std::vector<autopick_type> autopick_list; /*!< 自動拾い/破壊設定構造体の配列 */
 
 /*!
  * @brief Automatically destroy an item if it is to be destroyed
@@ -26,27 +24,15 @@ autopick_type *autopick_list = nullptr; /*!< 自動拾い/破壊設定構造体�
 object_type autopick_last_destroyed_object;
 
 /*!
- * @brief A function to delete entry
- */
-void autopick_free_entry(autopick_type *entry)
-{
-    string_free(entry->name);
-    string_free(entry->insc);
-    entry->name = nullptr;
-    entry->insc = nullptr;
-}
-
-/*!
  * @brief Free memory of lines_list.
  */
-void free_text_lines(concptr *lines_list)
+void free_text_lines(std::vector<concptr> &lines_list)
 {
     for (int lines = 0; lines_list[lines]; lines++) {
         string_free(lines_list[lines]);
     }
 
-    /* free list of pointers */
-    C_FREE(lines_list, MAX_LINES, concptr);
+    lines_list.clear();
 }
 
 /*!
@@ -68,33 +54,15 @@ int get_com_id(char key)
  */
 void auto_inscribe_item(player_type *player_ptr, object_type *o_ptr, int idx)
 {
-    if (idx < 0 || !autopick_list[idx].insc)
+    if (idx < 0 || autopick_list[idx].insc.empty())
         return;
 
     if (!o_ptr->inscription)
-        o_ptr->inscription = quark_add(autopick_list[idx].insc);
+        o_ptr->inscription = quark_add(autopick_list[idx].insc.c_str());
 
     player_ptr->window_flags |= (PW_EQUIP | PW_INVEN);
     player_ptr->update |= (PU_BONUS);
     player_ptr->update |= (PU_COMBINE);
-}
-
-/*!
- * @brief Add one line to autopick_list[]
- */
-void add_autopick_list(autopick_type *entry)
-{
-    if (max_autopick >= max_max_autopick) {
-        int old_max_max_autopick = max_max_autopick;
-        autopick_type *old_autopick_list = autopick_list;
-        max_max_autopick += MAX_AUTOPICK_DEFAULT;
-        C_MAKE(autopick_list, max_max_autopick, autopick_type);
-        (void)C_COPY(autopick_list, old_autopick_list, old_max_max_autopick, autopick_type);
-        C_KILL(old_autopick_list, old_max_max_autopick, autopick_type);
-    }
-
-    autopick_list[max_autopick] = *entry;
-    max_autopick++;
 }
 
 /*!

--- a/src/autopick/autopick-util.h
+++ b/src/autopick/autopick-util.h
@@ -2,6 +2,9 @@
 
 #include "system/angband.h"
 
+#include <string>
+#include <vector>
+
 #define MAX_LINELEN 1024
 #define MAX_AUTOPICK_DEFAULT 200
 #define MAX_YANK MAX_LINELEN
@@ -22,8 +25,8 @@
  * @brief 自動拾い/破壊設定データの構造体 / A structure type for entry of auto-picker/destroyer
  */
 typedef struct autopick_type {
-    concptr name; /*!< 自動拾い/破壊定義の名称一致基準 / Items which have 'name' as part of its name match */
-    concptr insc; /*!< 対象となったアイテムに自動で刻む内容 / Items will be auto-inscribed as 'insc' */
+    std::string name; /*!< 自動拾い/破壊定義の名称一致基準 / Items which have 'name' as part of its name match */
+    std::string insc; /*!< 対象となったアイテムに自動で刻む内容 / Items will be auto-inscribed as 'insc' */
     BIT_FLAGS flag[2]; /*!< キーワードに関する汎用的な条件フラグ / Misc. keyword to be matched */
     byte action; /*!< 対象のアイテムを拾う/破壊/放置するかの指定フラグ / Auto-pickup or Destroy or Leave items */
     byte dice; /*!< 武器のダイス値基準値 / Weapons which have more than 'dice' dice match */
@@ -60,7 +63,7 @@ typedef struct text_body_type {
     chain_str_type *yank;
     bool yank_eol;
 
-    concptr *lines_list;
+    std::vector<concptr> lines_list;
     byte states[MAX_LINES];
 
     uint16_t dirty_flags;
@@ -74,17 +77,13 @@ typedef struct text_body_type {
 /*
  *  List for auto-picker/destroyer entries
  */
-extern int max_autopick;
-extern int max_max_autopick;
-extern autopick_type *autopick_list;
+extern std::vector<autopick_type> autopick_list;
 extern object_type autopick_last_destroyed_object;
 
 struct player_type;
-void autopick_free_entry(autopick_type *entry);
-void free_text_lines(concptr *lines_list);
+void free_text_lines(std::vector<concptr> &lines_list);
 int get_com_id(char key);
 void auto_inscribe_item(player_type *player_ptr, object_type *o_ptr, int idx);
-void add_autopick_list(autopick_type *entry);
 int count_line(text_body_type *tb);
 
 /*!

--- a/src/autopick/autopick-util.h
+++ b/src/autopick/autopick-util.h
@@ -10,64 +10,65 @@
 #define PT_DEFAULT 0
 #define PT_WITH_PNAME 1
 
-#define MARK_MARK     0x01
+#define MARK_MARK 0x01
 #define MARK_BY_SHIFT 0x02
 
-#define LSTAT_BYPASS        0x01
-#define LSTAT_EXPRESSION    0x02
-#define LSTAT_AUTOREGISTER  0x04
+#define LSTAT_BYPASS 0x01
+#define LSTAT_EXPRESSION 0x02
+#define LSTAT_AUTOREGISTER 0x04
 
 /*!
  * @struct autopick_type
  * @brief 自動拾い/破壊設定データの構造体 / A structure type for entry of auto-picker/destroyer
  */
 typedef struct autopick_type {
-	concptr name;          /*!< 自動拾い/破壊定義の名称一致基準 / Items which have 'name' as part of its name match */
-	concptr insc;          /*!< 対象となったアイテムに自動で刻む内容 / Items will be auto-inscribed as 'insc' */
-	BIT_FLAGS flag[2];       /*!< キーワードに関する汎用的な条件フラグ / Misc. keyword to be matched */
-	byte action;        /*!< 対象のアイテムを拾う/破壊/放置するかの指定フラグ / Auto-pickup or Destroy or Leave items */
-	byte dice;          /*!< 武器のダイス値基準値 / Weapons which have more than 'dice' dice match */
-	byte bonus;         /*!< アイテムのボーナス基準値 / Items which have more than 'bonus' magical bonus match */
+    concptr name; /*!< 自動拾い/破壊定義の名称一致基準 / Items which have 'name' as part of its name match */
+    concptr insc; /*!< 対象となったアイテムに自動で刻む内容 / Items will be auto-inscribed as 'insc' */
+    BIT_FLAGS flag[2]; /*!< キーワードに関する汎用的な条件フラグ / Misc. keyword to be matched */
+    byte action; /*!< 対象のアイテムを拾う/破壊/放置するかの指定フラグ / Auto-pickup or Destroy or Leave items */
+    byte dice; /*!< 武器のダイス値基準値 / Weapons which have more than 'dice' dice match */
+    byte bonus; /*!< アイテムのボーナス基準値 / Items which have more than 'bonus' magical bonus match */
 } autopick_type;
 
 /*
  * Struct for yank buffer
  */
 typedef struct chain_str {
-	struct chain_str *next;
-	char s[1];
+    struct chain_str *next;
+    char s[1];
 } chain_str_type;
 
 /*
  * Data struct for text editor
  */
-struct object_type;;
+struct object_type;
+;
 typedef struct text_body_type {
-	int wid, hgt;
-	int cx, cy;
-	int upper, left;
-	int old_wid, old_hgt;
-	int old_cy;
-	int old_upper, old_left;
-	int mx, my;
-	byte mark;
+    int wid, hgt;
+    int cx, cy;
+    int upper, left;
+    int old_wid, old_hgt;
+    int old_cy;
+    int old_upper, old_left;
+    int mx, my;
+    byte mark;
 
-	object_type *search_o_ptr;
-	concptr search_str;
-	concptr last_destroyed;
+    object_type *search_o_ptr;
+    concptr search_str;
+    concptr last_destroyed;
 
-	chain_str_type *yank;
-	bool yank_eol;
+    chain_str_type *yank;
+    bool yank_eol;
 
-	concptr *lines_list;
-	byte states[MAX_LINES];
+    concptr *lines_list;
+    byte states[MAX_LINES];
 
-	uint16_t dirty_flags;
-	int dirty_line;
-	int filename_mode;
-	int old_com_id;
+    uint16_t dirty_flags;
+    int dirty_line;
+    int filename_mode;
+    int old_com_id;
 
-	bool changed;
+    bool changed;
 } text_body_type;
 
 /*

--- a/src/cmd-io/cmd-autopick.cpp
+++ b/src/cmd-io/cmd-autopick.cpp
@@ -199,7 +199,7 @@ void do_cmd_edit_autopick(player_type *player_ptr)
 	strcpy(buf, pickpref_filename(player_ptr, tb->filename_mode));
 
 	if (quit == APE_QUIT_AND_SAVE)
-		write_text_lines(buf, tb->lines_list);
+		write_text_lines(buf, tb->lines_list.data());
 
 	free_text_lines(tb->lines_list);
 	string_free(tb->search_str);

--- a/src/cmd-visual/cmd-map.cpp
+++ b/src/cmd-visual/cmd-map.cpp
@@ -22,7 +22,7 @@ void do_cmd_view_map(player_type *player_ptr)
 
     int cy, cx;
     display_map(player_ptr, &cy, &cx);
-    if ((max_autopick == 0) || player_ptr->wild_mode) {
+    if (autopick_list.empty() || player_ptr->wild_mode) {
         put_str(_("何かキーを押すとゲームに戻ります", "Hit any key to continue"), 23, 30);
         move_cursor(cy, cx);
         inkey(true);

--- a/src/knowledge/knowledge-autopick.cpp
+++ b/src/knowledge/knowledge-autopick.cpp
@@ -37,15 +37,16 @@ void do_cmd_knowledge_autopick(player_type *player_ptr)
     if (!open_temporary_file(&fff, file_name))
         return;
 
-    if (!max_autopick) {
+    if (autopick_list.empty()) {
         fprintf(fff, _("自動破壊/拾いには何も登録されていません。", "No preference for auto picker/destroyer."));
     } else {
-        fprintf(fff, _("   自動拾い/破壊には現在 %d行登録されています。\n\n", "   There are %d registered lines for auto picker/destroyer.\n\n"), max_autopick);
+        fprintf(fff, _("   自動拾い/破壊には現在 %d行登録されています。\n\n", "   There are %d registered lines for auto picker/destroyer.\n\n"),
+            static_cast<int>(autopick_list.size()));
     }
 
-    for (int k = 0; k < max_autopick; k++) {
+    for (auto &item : autopick_list) {
         concptr tmp;
-        byte act = autopick_list[k].action;
+        byte act = item.action;
         if (act & DONT_AUTOPICK) {
             tmp = _("放置", "Leave");
         } else if (act & DO_AUTODESTROY) {
@@ -61,7 +62,7 @@ void do_cmd_knowledge_autopick(player_type *player_ptr)
         else
             fprintf(fff, "%11s", format("(%s)", tmp));
 
-        tmp = autopick_line_from_entry(&autopick_list[k]);
+        tmp = autopick_line_from_entry(&item);
         fprintf(fff, " %s", tmp);
         string_free(tmp);
         fprintf(fff, "\n");


### PR DESCRIPTION
C_MAKE の使用を避けるため、自動拾い設定リスト autopick_list と、
自動拾いエディタのテキスト領域 text_body_type::lines_list を
std::vector にする。
また、string_make によるメモリリークを避けるため autopick_type の
メンバ name と insc を std::string に変更する。
これにより autopick_free_entry 関数は不要となるので削除する。