### PR TITLE
[Refactor] X11版のメモリ領域確保の方法を変更

### DIFF
--- a/src/maid-x11.cpp
+++ b/src/maid-x11.cpp
@@ -277,13 +277,13 @@ static XImage *ReadBMP(Display *dpy, char *Name)
     total = infoheader.biWidth * infoheader.biHeight * i;
 
     /* Allocate image memory */
-    C_MAKE(Data, total, char);
+    Data = (char*)malloc(total);
 
     Res = XCreateImage(dpy, visual, depth, ZPixmap, 0 /*offset*/, Data, infoheader.biWidth, infoheader.biHeight, 8 /*bitmap_pad*/, 0 /*bytes_per_line*/);
 
     /* Failure */
     if (Res == nullptr) {
-        C_KILL(Data, total, char);
+        free(Data);
         fclose(f);
         return nullptr;
     }


### PR DESCRIPTION
MAKE マクロの使用を避けるため、MAKE マクロで領域を確保しているポインタ変数を
std::unique_ptr に変更し、std::make_unique により領域を確保する。
XCreateImage に渡すデータ領域は、APIの使い方に従って malloc で確保するようにする。
(XDestroyImageがデータ領域まで解放するらしいので、newで確保した領域を渡すと
どうなるのか確信が持てないため。)