### PR TITLE
[Fix] 維持のない能力値アップが明るい緑でなく深い緑で表示される

### DIFF
--- a/src/view/display-player-stat-info.cpp
+++ b/src/view/display-player-stat-info.cpp
@@ -206,7 +206,7 @@ static void display_equipments_compensation(player_type *player_ptr, int row, in
             TERM_COLOR a = TERM_SLATE;
             char c = '.';
             if (flags.has(TR_STATUS_LIST[stat])) {
-                compensate_stat_by_weapon(&c, &a, o_ptr, TR_STATUS_LIST[stat], flags);
+                compensate_stat_by_weapon(&c, &a, o_ptr, TR_SUST_STATUS_LIST[stat], flags);
             } else if (flags.has(TR_SUST_STATUS_LIST[stat])) {
                 a = TERM_GREEN;
                 c = 's';


### PR DESCRIPTION
Fix #1602.
特性フラグを FlagGroup 化した時にロジックを読み間違えて能力値維持フラグを
渡すべきところを能力値アップフラグを渡すようにしてしまっていた。
正しく能力値維持を渡すように修正する。