### PR TITLE
[Refactor] デバッグコマンドのメニューテーブルの型

### DIFF
--- a/src/wizard/cmd-wizard.cpp
+++ b/src/wizard/cmd-wizard.cpp
@@ -36,6 +36,7 @@
 #include "wizard/wizard-spoiler.h"
 #include <sstream>
 #include <string>
+#include <tuple>
 #include <vector>
 
 /*!
@@ -43,44 +44,44 @@
  * @details
  * 空き: A,B,E,I,J,k,K,L,M,q,Q,R,T,U,V,W,y,Y
  */
-std::vector<std::vector<std::string>> debug_menu_table = {
-    { "a", _("全状態回復", "Restore all status") },
-    { "b", _("現在のターゲットを引き寄せる", "Teleport target back") },
-    { "c", _("オブジェクト生成", "Create object") },
-    { "C", _("固定アーティファクト生成", "Create fixed artifact") },
-    { "d", _("全感知", "Detection all") },
-    { "D", _("次元の扉", "Dimension door") },
-    { "e", _("能力値変更", "Modify player status") },
-    { "E", _("青魔法を全取得/エッセンスを全取得", "Learn all blue magics / Obtain all essences") },
-    { "f", _("*鑑定*", "*Idenfity*") },
-    { "F", _("地形ID変更", "Modify feature type under player") },
-    { "G", _("ゲーム設定コマンドメニュー", "Modify game configurations") },
-    { "H", _("モンスターの群れ生成", "Summon monsters") },
-    { "i", _("鑑定", "Idenfity") },
-    { "I", _("アイテム設定コマンドメニュー", "Modify item configurations") },
-    { "j", _("指定ダンジョン階にワープ", "Jump to floor depth of target dungeon") },
-    { "k", _("指定ダメージ・半径0の指定属性のボールを自分に放つ", "Fire a zero ball to self") },
-    { "m", _("魔法の地図", "Magic mapping") },
-    { "n", _("指定モンスター生成", "Summon target monster") },
-    { "N", _("指定モンスターをペットとして生成", "Summon target monster as pet") },
-    { "o", _("オブジェクトの能力変更", "Modift object abilities") },
-    { "O", _("オプション設定をダンプ", "Dump current options") },
-    { "p", _("ショート・テレポート", "Phase door") },
-    { "P", _("プレイヤー設定変更メニュー", "Modify player configurations") },
-    { "r", _("カオスパトロンの報酬", "Get reward of chaos patron") },
-    { "s", _("フロア相当のモンスター召喚", "Summon monster which be in target depth") },
-    { "t", _("テレポート", "Teleport self") },
-    { "u", _("啓蒙(忍者以外)", "Wiz-lite all floor except Ninja") },
-    { "w", _("啓蒙(忍者配慮)", "Wiz-lite all floor") },
-    { "x", _("経験値を得る(指定可)", "Get experience") },
-    { "X", _("所持品を初期状態に戻す", "Return inventory to initial") },
-    { "y", _("ダメージ100万・半径0の射撃のボールを放つ", "Cast missile ball had power a million") },
-    { "Y", _("指定ダメージ・半径0の指定属性のボールを放つ", "Cast zero ball had power a thousand") },
-    { "z", _("近隣のモンスター消去", "Terminate near monsters") },
-    { "Z", _("フロアの全モンスター消去", "Terminate all monsters in floor") },
-    { "@", _("特殊スペルの発動", "Activate specified spells") },
-    { "\"", _("スポイラーのダンプ", "Dump spoiler") },
-    { "?", _("ヘルプ表示", "Help") },
+constexpr std::array debug_menu_table = {
+    std::make_tuple('a', _("全状態回復", "Restore all status")),
+    std::make_tuple('b', _("現在のターゲットを引き寄せる", "Teleport target back")),
+    std::make_tuple('c', _("オブジェクト生成", "Create object")),
+    std::make_tuple('C', _("固定アーティファクト生成", "Create fixed artifact")),
+    std::make_tuple('d', _("全感知", "Detection all")),
+    std::make_tuple('D', _("次元の扉", "Dimension door")),
+    std::make_tuple('e', _("能力値変更", "Modify player status")),
+    std::make_tuple('E', _("青魔法を全取得/エッセンスを全取得", "Learn all blue magics / Obtain all essences")),
+    std::make_tuple('f', _("*鑑定*", "*Idenfity*")),
+    std::make_tuple('F', _("地形ID変更", "Modify feature type under player")),
+    std::make_tuple('G', _("ゲーム設定コマンドメニュー", "Modify game configurations")),
+    std::make_tuple('H', _("モンスターの群れ生成", "Summon monsters")),
+    std::make_tuple('i', _("鑑定", "Idenfity")),
+    std::make_tuple('I', _("アイテム設定コマンドメニュー", "Modify item configurations")),
+    std::make_tuple('j', _("指定ダンジョン階にワープ", "Jump to floor depth of target dungeon")),
+    std::make_tuple('k', _("指定ダメージ・半径0の指定属性のボールを自分に放つ", "Fire a zero ball to self")),
+    std::make_tuple('m', _("魔法の地図", "Magic mapping")),
+    std::make_tuple('n', _("指定モンスター生成", "Summon target monster")),
+    std::make_tuple('N', _("指定モンスターをペットとして生成", "Summon target monster as pet")),
+    std::make_tuple('o', _("オブジェクトの能力変更", "Modift object abilities")),
+    std::make_tuple('O', _("オプション設定をダンプ", "Dump current options")),
+    std::make_tuple('p', _("ショート・テレポート", "Phase door")),
+    std::make_tuple('P', _("プレイヤー設定変更メニュー", "Modify player configurations")),
+    std::make_tuple('r', _("カオスパトロンの報酬", "Get reward of chaos patron")),
+    std::make_tuple('s', _("フロア相当のモンスター召喚", "Summon monster which be in target depth")),
+    std::make_tuple('t', _("テレポート", "Teleport self")),
+    std::make_tuple('u', _("啓蒙(忍者以外)", "Wiz-lite all floor except Ninja")),
+    std::make_tuple('w', _("啓蒙(忍者配慮)", "Wiz-lite all floor")),
+    std::make_tuple('x', _("経験値を得る(指定可)", "Get experience")),
+    std::make_tuple('X', _("所持品を初期状態に戻す", "Return inventory to initial")),
+    std::make_tuple('y', _("ダメージ100万・半径0の射撃のボールを放つ", "Cast missile ball had power a million")),
+    std::make_tuple('Y', _("指定ダメージ・半径0の指定属性のボールを放つ", "Cast zero ball had power a thousand")),
+    std::make_tuple('z', _("近隣のモンスター消去", "Terminate near monsters")),
+    std::make_tuple('Z', _("フロアの全モンスター消去", "Terminate all monsters in floor")),
+    std::make_tuple('@', _("特殊スペルの発動", "Activate specified spells")),
+    std::make_tuple('"', _("スポイラーのダンプ", "Dump spoiler")),
+    std::make_tuple('?', _("ヘルプ表示", "Help")),
 };
 
 /*!
@@ -103,7 +104,8 @@ void display_debug_menu(int page, int max_page, int page_size, int max_line)
             break;
 
         std::stringstream ss;
-        ss << debug_menu_table[pos][0] << ") " << debug_menu_table[pos][1];
+        const auto &[symbol, desc] = debug_menu_table[pos];
+        ss << symbol << ") " << desc;
         put_str(ss.str().c_str(), r++, c);
     }
     if (max_page > 1)

--- a/src/wizard/wizard-game-modifier.cpp
+++ b/src/wizard/wizard-game-modifier.cpp
@@ -22,9 +22,10 @@
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 #include "wizard/wizard-special-process.h"
-#include <string>
-#include <vector>
 #include <sstream>
+#include <string>
+#include <tuple>
+#include <vector>
 
 void wiz_enter_quest(player_type *player_ptr);
 void wiz_complete_quest(player_type *player_ptr);
@@ -33,12 +34,12 @@ void wiz_restore_monster_max_num();
 /*!
  * @brief ゲーム設定コマンド一覧表
  */
-std::vector<std::vector<std::string>> wizard_game_modifier_menu_table = {
-    { "t", _("プレイ時間変更", "Modify played time") },
-    { "q", _("現在のクエストを完了", "Complete current quest") },
-    { "Q", _("クエストに突入", "Enter quest") },
-    { "u", _("ユニーク/ナズグルの生存数を復元", "Restore living info of unique/nazgul") },
-    { "g", _("モンスター闘技場出場者更新", "Update gambling monster") },
+constexpr std::array wizard_game_modifier_menu_table = {
+    std::make_tuple('t', _("プレイ時間変更", "Modify played time")),
+    std::make_tuple('q', _("現在のクエストを完了", "Complete current quest")),
+    std::make_tuple('Q', _("クエストに突入", "Enter quest")),
+    std::make_tuple('u', _("ユニーク/ナズグルの生存数を復元", "Restore living info of unique/nazgul")),
+    std::make_tuple('g', _("モンスター闘技場出場者更新", "Update gambling monster")),
 };
 
 /*!
@@ -46,15 +47,14 @@ std::vector<std::vector<std::string>> wizard_game_modifier_menu_table = {
  */
 void display_wizard_game_modifier_menu()
 {
-    for (int y = 1; y < 6; y++)
+    for (auto y = 1U; y <= wizard_game_modifier_menu_table.size(); y++)
         term_erase(14, y, 64);
 
     int r = 1;
     int c = 15;
-    int sz = wizard_game_modifier_menu_table.size();
-    for (int i = 0; i < sz; i++) {
+    for (const auto &[symbol, desc] : wizard_game_modifier_menu_table) {
         std::stringstream ss;
-        ss << wizard_game_modifier_menu_table[i][0] << ") " << wizard_game_modifier_menu_table[i][1];
+        ss << symbol << ") " << desc;
         put_str(ss.str().c_str(), r++, c);
     }
 }

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -46,6 +46,7 @@
 #include <algorithm>
 #include <limits>
 #include <sstream>
+#include <tuple>
 #include <vector>
 
 #define K_MAX_DEPTH 110 /*!< アイテムの階層毎生成率を表示する最大階 */
@@ -54,18 +55,18 @@ namespace {
 /*!
  * @brief アイテム設定コマンド一覧表
  */
-std::vector<std::vector<std::string>> wizard_sub_menu_table = {
-    { "a", _("アーティファクト出現フラグリセット", "Restore aware flag of fixed artifact") },
-    { "A", _("アーティファクトを出現済みにする", "Make a fixed artifact awared") },
-    { "e", _("高級品獲得ドロップ", "Drop excellent object") },
-    { "f", _("*鑑定*", "*Idenfity*") },
-    { "i", _("鑑定", "Idenfity") },
-    { "I", _("インベントリ全*鑑定*", "Idenfity all objects fully in inventory") },
-    { "l", _("指定アイテム番号まで一括鑑定", "Make objects awared to target object id") },
-    { "g", _("上質なアイテムドロップ", "Drop good object") },
-    { "s", _("特別品獲得ドロップ", "Drop special object") },
-    { "w", _("願い", "Wishing") },
-    { "U", _("発動を変更する", "Modify item activation") },
+constexpr std::array wizard_sub_menu_table = {
+    std::make_tuple('a', _("アーティファクト出現フラグリセット", "Restore aware flag of fixed artifact")),
+    std::make_tuple('A', _("アーティファクトを出現済みにする", "Make a fixed artifact awared")),
+    std::make_tuple('e', _("高級品獲得ドロップ", "Drop excellent object")),
+    std::make_tuple('f', _("*鑑定*", "*Idenfity*")),
+    std::make_tuple('i', _("鑑定", "Idenfity")),
+    std::make_tuple('I', _("インベントリ全*鑑定*", "Idenfity all objects fully in inventory")),
+    std::make_tuple('l', _("指定アイテム番号まで一括鑑定", "Make objects awared to target object id")),
+    std::make_tuple('g', _("上質なアイテムドロップ", "Drop good object")),
+    std::make_tuple('s', _("特別品獲得ドロップ", "Drop special object")),
+    std::make_tuple('w', _("願い", "Wishing")),
+    std::make_tuple('U', _("発動を変更する", "Modify item activation")),
 };
 
 /*!
@@ -73,15 +74,14 @@ std::vector<std::vector<std::string>> wizard_sub_menu_table = {
  */
 void display_wizard_sub_menu()
 {
-    for (size_t y = 1; y <= wizard_sub_menu_table.size(); y++)
+    for (auto y = 1U; y <= wizard_sub_menu_table.size(); y++)
         term_erase(14, y, 64);
 
     int r = 1;
     int c = 15;
-    int sz = wizard_sub_menu_table.size();
-    for (int i = 0; i < sz; i++) {
+    for (const auto &[symbol, desc] : wizard_sub_menu_table) {
         std::stringstream ss;
-        ss << wizard_sub_menu_table[i][0] << ") " << wizard_sub_menu_table[i][1];
+        ss << symbol << ") " << desc;
         put_str(ss.str().c_str(), r++, c);
     }
 }

--- a/src/wizard/wizard-player-modifier.cpp
+++ b/src/wizard/wizard-player-modifier.cpp
@@ -14,22 +14,23 @@
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 #include "wizard/wizard-special-process.h"
-#include <string>
-#include <vector>
 #include <sstream>
+#include <string>
+#include <tuple>
+#include <vector>
 
 /*!
  * @brief プレイヤー設定コマンド一覧表
  */
-std::vector<std::vector<std::string>> wizard_player_modifier_menu_table = {
-    { "r", _("種族変更", "Change race") },
-    { "c", _("職業変更", "Change class") },
-    { "R", _("領域変更", "Change realms") },
-    { "e", _("能力変更", "Change status") },
-    { "k", _("自己分析", "Self knowledge") },
-    { "l", _("ライフレート変更", "Set new life rate") },
-    { "m", _("突然変異", "Get mutation") },
-    { "a", _("属性表示", "Print your alignment") },
+constexpr std::array wizard_player_modifier_menu_table = {
+    std::make_tuple('r', _("種族変更", "Change race")),
+    std::make_tuple('c', _("職業変更", "Change class")),
+    std::make_tuple('R', _("領域変更", "Change realms")),
+    std::make_tuple('e', _("能力変更", "Change status")),
+    std::make_tuple('k', _("自己分析", "Self knowledge")),
+    std::make_tuple('l', _("ライフレート変更", "Set new life rate")),
+    std::make_tuple('m', _("突然変異", "Get mutation")),
+    std::make_tuple('a', _("属性表示", "Print your alignment")),
 };
 
 /*!
@@ -37,15 +38,14 @@ std::vector<std::vector<std::string>> wizard_player_modifier_menu_table = {
  */
 void display_wizard_player_modifier_menu()
 {
-    for (int y = 1; y < 9; y++)
+    for (auto y = 1U; y <= wizard_player_modifier_menu_table.size(); y++)
         term_erase(14, y, 64);
 
     int r = 1;
     int c = 15;
-    int sz = wizard_player_modifier_menu_table.size();
-    for (int i = 0; i < sz; i++) {
+    for (const auto &[symbol, desc] : wizard_player_modifier_menu_table) {
         std::stringstream ss;
-        ss << wizard_player_modifier_menu_table[i][0] << ") " << wizard_player_modifier_menu_table[i][1];
+        ss << symbol << ") " << desc;
         put_str(ss.str().c_str(), r++, c);
     }
 }


### PR DESCRIPTION
std::vector<std::vector<std::string>> である必要はないので、
std::array<std::tuple<char, concptr>> にする。(std::array の推論補助を使用)
また、 constexpr 定数とする。

ちょっとした改善なのでIssue無し。
このあいだ、これこんな型の必要ある？という話が出てたので。
サブメニュー表示のコードも同じものがコピペされていてちょっとアレですがそちらはまたの機会ということで。