### PR TITLE
Include <array> so template deduction works for the modifier tables …

### DIFF
--- a/src/wizard/wizard-game-modifier.cpp
+++ b/src/wizard/wizard-game-modifier.cpp
@@ -22,6 +22,7 @@
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 #include "wizard/wizard-special-process.h"
+#include <array>
 #include <sstream>
 #include <string>
 #include <tuple>

--- a/src/wizard/wizard-player-modifier.cpp
+++ b/src/wizard/wizard-player-modifier.cpp
@@ -14,6 +14,7 @@
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 #include "wizard/wizard-special-process.h"
+#include <array>
 #include <sstream>
 #include <string>
 #include <tuple>


### PR DESCRIPTION
…when precompiled headers are not used.  Resolves https://github.com/hengband/hengband/issues/1610 .