### PR TITLE
[Fix] ウィザードモードのID指定モンスター生成(N/n)が回数指定の事前入力のみを想定した仕様で手動指定が足りなかった

### DIFF
--- a/src/core/asking-player.cpp
+++ b/src/core/asking-player.cpp
@@ -16,6 +16,9 @@
 
 #include <climits>
 #include <algorithm>
+#include <iostream>
+#include <string>
+#include <sstream>
 
 /*
  * Get some string input at the cursor location.
@@ -413,4 +416,26 @@ void pause_line(int row)
 
     (void)inkey();
     prt("", row, 0);
+}
+
+bool get_value(const char *text, int min, int max, int *value)
+{
+    std::stringstream st;
+    int val;
+    char tmp_val[10] = "";
+    st << text << "(" << min << "-" << max << "): ";
+    int digit = std::max(std::to_string(min).length(), std::to_string(max).length());
+    while (true) {
+        if (!get_string(st.str().c_str(), tmp_val, digit))
+            return false;
+
+        val = atoi(tmp_val);
+
+        if (min <= val && max >= val) {
+            break;
+        }
+        msg_format(_("%dから%dの間で指定して下さい。", "It must be between %d to %d."), min, max);
+    }
+    *value = val;
+    return true;
 }

--- a/src/core/asking-player.h
+++ b/src/core/asking-player.h
@@ -19,3 +19,4 @@ bool get_check_strict(player_type *player_ptr, concptr prompt, BIT_FLAGS mode);
 bool get_com(concptr prompt, char *command, bool z_escape);
 QUANTITY get_quantity(concptr prompt, QUANTITY max);
 void pause_line(int row);
+bool get_value(const char *text, int min, int max, int *value);

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -219,19 +219,13 @@ void wiz_create_item(player_type *player_ptr)
 void wiz_create_named_art(player_type *player_ptr, ARTIFACT_IDX a_idx)
 {
     if (a_idx <= 0) {
-        char tmp[80] = "";
-        sprintf(tmp, "Artifact ID (1-%d): ", max_a_idx - 1);
-        char tmp_val[10] = "";
-        if (!get_string(tmp, tmp_val, 3))
+        int val;
+        if (!get_value("ArtifactID", 1, a_info.size() - 1, &val)) {
             return;
-
-        a_idx = (ARTIFACT_IDX)atoi(tmp_val);
+        }
+        a_idx = static_cast<ARTIFACT_IDX>(val);
     }
 
-    if (a_idx <= 0 || a_idx >= max_a_idx) {
-        msg_format(_("番号は1から%dの間で指定して下さい。", "ID must be between 1 to %d."), max_a_idx - 1);
-        return;
-    }
 
     (void)create_named_art(player_ptr, a_idx, player_ptr->y, player_ptr->x);
     msg_print("Allocated.");

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -19,6 +19,7 @@
 #include "monster-floor/monster-summon.h"
 #include "monster-floor/place-monster-types.h"
 #include "monster-race/race-ability-flags.h"
+#include "monster-race/monster-race.h"
 #include "mutation/mutation-processor.h"
 #include "object-enchant/object-smith.h"
 #include "spell-kind/spells-launcher.h"
@@ -181,6 +182,20 @@ void wiz_summon_random_enemy(player_type *player_ptr, int num)
  */
 void wiz_summon_specific_enemy(player_type *player_ptr, MONRACE_IDX r_idx)
 {
+    if (r_idx <= 0) {
+        char tmp[80] = "";
+        sprintf(tmp, "Monster ID (1-%d): ", max_r_idx - 1);
+        char tmp_val[10] = "";
+        if (!get_string(tmp, tmp_val, 4))
+            return;
+
+        r_idx = (MONRACE_IDX)atoi(tmp_val);
+    }
+
+    if (r_idx <= 0 || r_idx >= max_r_idx) {
+        msg_format(_("番号は1から%dの間で指定して下さい。", "ID must be between 1 to %d."), max_r_idx - 1);
+        return;
+    }
     (void)summon_named_creature(player_ptr, 0, player_ptr->y, player_ptr->x, r_idx, PM_ALLOW_SLEEP | PM_ALLOW_GROUP);
 }
 
@@ -193,6 +208,21 @@ void wiz_summon_specific_enemy(player_type *player_ptr, MONRACE_IDX r_idx)
  */
 void wiz_summon_pet(player_type *player_ptr, MONRACE_IDX r_idx)
 {
+    if (r_idx <= 0) {
+        char tmp[80] = "";
+        sprintf(tmp, "Monster ID (1-%d): ", max_r_idx - 1);
+        char tmp_val[10] = "";
+        if (!get_string(tmp, tmp_val, 4))
+            return;
+
+        r_idx = (MONRACE_IDX)atoi(tmp_val);
+    }
+
+    if (r_idx <= 0 || r_idx >= max_r_idx) {
+        msg_format(_("番号は1から%dの間で指定して下さい。", "ID must be between 1 to %d."), max_r_idx - 1);
+        return;
+    }
+
     (void)summon_named_creature(player_ptr, 0, player_ptr->y, player_ptr->x, r_idx, PM_ALLOW_SLEEP | PM_ALLOW_GROUP | PM_FORCE_PET);
 }
 

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -30,6 +30,7 @@
 #include "spell/summon-types.h"
 #include "system/floor-type-definition.h"
 #include "system/player-type-definition.h"
+#include "system/monster-race-definition.h"
 #include "target/grid-selector.h"
 #include "target/target-checker.h"
 #include "target/target-getter.h"
@@ -183,18 +184,11 @@ void wiz_summon_random_enemy(player_type *player_ptr, int num)
 void wiz_summon_specific_enemy(player_type *player_ptr, MONRACE_IDX r_idx)
 {
     if (r_idx <= 0) {
-        char tmp[80] = "";
-        sprintf(tmp, "Monster ID (1-%d): ", max_r_idx - 1);
-        char tmp_val[10] = "";
-        if (!get_string(tmp, tmp_val, 4))
+        int val;
+        if(!get_value("MonsterID", 1, r_info.size() - 1, &val)) {
             return;
-
-        r_idx = (MONRACE_IDX)atoi(tmp_val);
-    }
-
-    if (r_idx <= 0 || r_idx >= max_r_idx) {
-        msg_format(_("番号は1から%dの間で指定して下さい。", "ID must be between 1 to %d."), max_r_idx - 1);
-        return;
+        }
+        r_idx = static_cast<MONRACE_IDX>(val);
     }
     (void)summon_named_creature(player_ptr, 0, player_ptr->y, player_ptr->x, r_idx, PM_ALLOW_SLEEP | PM_ALLOW_GROUP);
 }
@@ -209,20 +203,12 @@ void wiz_summon_specific_enemy(player_type *player_ptr, MONRACE_IDX r_idx)
 void wiz_summon_pet(player_type *player_ptr, MONRACE_IDX r_idx)
 {
     if (r_idx <= 0) {
-        char tmp[80] = "";
-        sprintf(tmp, "Monster ID (1-%d): ", max_r_idx - 1);
-        char tmp_val[10] = "";
-        if (!get_string(tmp, tmp_val, 4))
+        int val;
+        if (!get_value("MonsterID", 1, r_info.size() - 1, &val)) {
             return;
-
-        r_idx = (MONRACE_IDX)atoi(tmp_val);
+        }
+        r_idx = static_cast<MONRACE_IDX>(val);
     }
-
-    if (r_idx <= 0 || r_idx >= max_r_idx) {
-        msg_format(_("番号は1から%dの間で指定して下さい。", "ID must be between 1 to %d."), max_r_idx - 1);
-        return;
-    }
-
     (void)summon_named_creature(player_ptr, 0, player_ptr->y, player_ptr->x, r_idx, PM_ALLOW_SLEEP | PM_ALLOW_GROUP | PM_FORCE_PET);
 }
 


### PR DESCRIPTION
アーティファクト生成(C)同様の仕様を追加。