### PR TITLE
[Feature] 職業固有のデータを持てるようにするシステムの導入

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -993,6 +993,7 @@
     <ClInclude Include="..\..\src\player-info\alignment.h" />
     <ClInclude Include="..\..\src\player-info\class-specific-data.h" />
     <ClInclude Include="..\..\src\player-info\equipment-info.h" />
+    <ClInclude Include="..\..\src\player-info\force-trainer-data-type.h" />
     <ClInclude Include="..\..\src\player-info\smith-data-type.h" />
     <ClInclude Include="..\..\src\player-info\spell-hex-data-type.h" />
     <ClInclude Include="..\..\src\player-status\player-energy.h" />

--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -269,11 +269,13 @@
     <ClCompile Include="..\..\src\cmd-action\cmd-tunnel.cpp" />
     <ClCompile Include="..\..\src\action\movement-execution.cpp" />
     <ClCompile Include="..\..\src\core\score-util.cpp" />
+    <ClCompile Include="..\..\src\load\player-class-specific-data-loader.cpp" />
     <ClCompile Include="..\..\src\object-enchant\object-smith.cpp" />
     <ClCompile Include="..\..\src\object-enchant\smith-info.cpp" />
     <ClCompile Include="..\..\src\object-enchant\smith-tables.cpp" />
     <ClCompile Include="..\..\src\player-base\player-class.cpp" />
     <ClCompile Include="..\..\src\player-base\player-race.cpp" />
+    <ClCompile Include="..\..\src\save\player-class-specific-data-writer.cpp" />
     <ClCompile Include="..\..\src\system\grid-type-definition.cpp" />
     <ClCompile Include="..\..\src\grid\feature-action-flags.cpp" />
     <ClCompile Include="..\..\src\main-win\commandline-win.cpp" />
@@ -914,6 +916,7 @@
     <ClInclude Include="..\..\src\action\open-close-execution.h" />
     <ClInclude Include="..\..\src\action\open-util.h" />
     <ClInclude Include="..\..\src\action\run-execution.h" />
+    <ClInclude Include="..\..\src\load\player-class-specific-data-loader.h" />
     <ClInclude Include="..\..\src\load\savedata-old-flag-types.h" />
     <ClInclude Include="..\..\src\object-enchant\object-smith.h" />
     <ClInclude Include="..\..\src\object-enchant\smith-info.h" />
@@ -988,10 +991,14 @@
     <ClInclude Include="..\..\src\player-base\player-class.h" />
     <ClInclude Include="..\..\src\player-base\player-race.h" />
     <ClInclude Include="..\..\src\player-info\alignment.h" />
+    <ClInclude Include="..\..\src\player-info\class-specific-data.h" />
     <ClInclude Include="..\..\src\player-info\equipment-info.h" />
+    <ClInclude Include="..\..\src\player-info\smith-data-type.h" />
+    <ClInclude Include="..\..\src\player-info\spell-hex-data-type.h" />
     <ClInclude Include="..\..\src\player-status\player-energy.h" />
     <ClInclude Include="..\..\src\player-status\player-hand-types.h" />
     <ClInclude Include="..\..\src\main-win\main-win-utils.h" />
+    <ClInclude Include="..\..\src\save\player-class-specific-data-writer.h" />
     <ClInclude Include="..\..\src\store\cmd-store.h" />
     <ClInclude Include="..\..\src\cmd-io\cmd-floor.h" />
     <ClInclude Include="..\..\src\cmd-io\cmd-lore.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -5043,6 +5043,9 @@
     <ClInclude Include="..\..\src\player-info\class-specific-data.h">
       <Filter>player-info</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\player-info\force-trainer-data-type.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\player-info\smith-data-type.h">
       <Filter>player-info</Filter>
     </ClInclude>

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2340,6 +2340,12 @@
     <ClCompile Include="..\..\src\timed-effect\player-cut.cpp">
       <Filter>timed-effect</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\load\player-class-specific-data-loader.cpp">
+      <Filter>load</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\save\player-class-specific-data-writer.cpp">
+      <Filter>save</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5033,6 +5039,21 @@
     </ClInclude>
     <ClInclude Include="..\..\src\timed-effect\player-cut.h">
       <Filter>timed-effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\class-specific-data.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\smith-data-type.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\spell-hex-data-type.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\player-class-specific-data-loader.h">
+      <Filter>load</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\save\player-class-specific-data-writer.h">
+      <Filter>save</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -666,6 +666,7 @@ hengband_SOURCES = \
 	player-info/class-types.h \
 	player-info/class-info.cpp player-info/class-info.h \
 	player-info/equipment-info.cpp player-info/equipment-info.h \
+	player-info/force-trainer-data-type.h \
 	player-info/mimic-info-table.cpp player-info/mimic-info-table.h \
 	player-info/mutation-info.cpp player-info/mutation-info.h \
 	player-info/race-ability-info.cpp player-info/race-ability-info.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -356,6 +356,7 @@ hengband_SOURCES = \
 	load/lore-loader.cpp load/lore-loader.h \
 	load/option-loader.cpp load/option-loader.h \
 	load/player-attack-loader.cpp load/player-attack-loader.h \
+	load/player-class-specific-data-loader.cpp load/player-class-specific-data-loader.h \
 	load/player-info-loader.cpp load/player-info-loader.h \
 	load/savedata-flag-types.h \
 	load/savedata-old-flag-types.h \
@@ -673,6 +674,8 @@ hengband_SOURCES = \
 	player-info/resistance-info.cpp player-info/resistance-info.h \
 	player-info/self-info.cpp player-info/self-info.h \
 	player-info/self-info-util.cpp player-info/self-info-util.h \
+        player-info/smith-data-type.h \
+        player-info/spell-hex-data-type.h \
 	player-info/weapon-effect-info.cpp player-info/weapon-effect-info.h \
 	\
 	player-status/player-hand-types.h \
@@ -734,6 +737,7 @@ hengband_SOURCES = \
 	save/info-writer.cpp save/info-writer.h \
 	save/item-writer.cpp save/item-writer.h \
 	save/monster-writer.cpp save/monster-writer.h \
+	save/player-class-specific-data-writer.cpp save/player-class-specific-data-writer.h \
 	save/player-writer.cpp save/player-writer.h \
 	save/save.cpp save/save.h \
 	save/save-util.cpp save/save-util.h \

--- a/src/birth/birth-wizard.cpp
+++ b/src/birth/birth-wizard.cpp
@@ -21,6 +21,7 @@
 #include "io/input-key-acceptor.h"
 #include "main/sound-definitions-table.h"
 #include "main/sound-of-music.h"
+#include "player-base/player-class.h"
 #include "player-info/class-info.h"
 #include "player-info/race-info.h"
 #include "player/patron.h"
@@ -263,6 +264,8 @@ static bool let_player_build_character(player_type *player_ptr)
 
     if (!let_player_select_personality(player_ptr))
         return false;
+
+    PlayerClass(player_ptr).init_specific_data();
 
     return true;
 }

--- a/src/birth/quick-start.cpp
+++ b/src/birth/quick-start.cpp
@@ -4,6 +4,7 @@
 #include "birth/game-play-initializer.h"
 #include "core/player-update-types.h"
 #include "io/input-key-acceptor.h"
+#include "player-base/player-class.h"
 #include "player-info/class-info.h"
 #include "player-info/race-info.h"
 #include "player/player-personality.h"
@@ -153,6 +154,8 @@ void load_prev_data(player_type *player_ptr, bool swap)
     for (int i = 0; i < 8; i++) {
         player_ptr->vir_types[i] = previous_char.vir_types[i];
     }
+
+    PlayerClass(player_ptr).init_specific_data();
 
     for (int i = 0; i < 4; i++) {
         strcpy(player_ptr->history[i], previous_char.history[i]);

--- a/src/load/player-class-specific-data-loader.cpp
+++ b/src/load/player-class-specific-data-loader.cpp
@@ -1,6 +1,7 @@
 #include "load/player-class-specific-data-loader.h"
 #include "load/load-util.h"
 #include "player-info/smith-data-type.h"
+#include "player-info/force-trainer-data-type.h"
 #include "player-info/spell-hex-data-type.h"
 #include "util/enum-converter.h"
 
@@ -22,6 +23,15 @@ void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<smith_data_type> 
             }
             smith_data->essences[i2enum<SmithEssence>(essence)] = amount;
         }
+    }
+}
+
+void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<force_trainer_data_type> &force_trainer_data) const
+{
+    if (loading_savefile_version_is_older_than(9)) {
+        force_trainer_data->ki = this->magic_num1[0];
+    } else {
+        rd_s32b(&force_trainer_data->ki);
     }
 }
 

--- a/src/load/player-class-specific-data-loader.cpp
+++ b/src/load/player-class-specific-data-loader.cpp
@@ -1,4 +1,4 @@
-#include "load/player-class-specific-data-loader.h"
+﻿#include "load/player-class-specific-data-loader.h"
 #include "load/load-util.h"
 #include "player-info/smith-data-type.h"
 #include "player-info/force-trainer-data-type.h"
@@ -10,7 +10,7 @@ void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<smith_data_type> 
     if (loading_savefile_version_is_older_than(9)) {
         for (auto i = 0; i < MAX_SPELLS; ++i) {
             if (this->magic_num1[i] > 0) {
-                smith_data->essences[i2enum<SmithEssence>(i)] = this->magic_num1[i];
+                smith_data->essences[i2enum<SmithEssence>(i)] = static_cast<int16_t>(this->magic_num1[i]);
             }
         }
     } else {

--- a/src/load/player-class-specific-data-loader.cpp
+++ b/src/load/player-class-specific-data-loader.cpp
@@ -1,0 +1,43 @@
+#include "load/player-class-specific-data-loader.h"
+#include "load/load-util.h"
+#include "player-info/smith-data-type.h"
+#include "player-info/spell-hex-data-type.h"
+#include "util/enum-converter.h"
+
+void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<smith_data_type> &smith_data) const
+{
+    if (loading_savefile_version_is_older_than(9)) {
+        for (auto i = 0; i < MAX_SPELLS; ++i) {
+            if (this->magic_num1[i] > 0) {
+                smith_data->essences[i2enum<SmithEssence>(i)] = this->magic_num1[i];
+            }
+        }
+    } else {
+        while (true) {
+            int16_t essence, amount;
+            rd_s16b(&essence);
+            rd_s16b(&amount);
+            if (essence < 0 && amount < 0) {
+                break;
+            }
+            smith_data->essences[i2enum<SmithEssence>(essence)] = amount;
+        }
+    }
+}
+
+void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<spell_hex_data_type> &spell_hex_data) const
+{
+    if (loading_savefile_version_is_older_than(9)) {
+        migrate_bitflag_to_flaggroup(spell_hex_data->casting_spells, this->magic_num1[0]);
+        spell_hex_data->revenge_power = this->magic_num1[2];
+        spell_hex_data->revenge_type = i2enum<SpellHexRevengeType>(this->magic_num2[1]);
+        spell_hex_data->revenge_turn = this->magic_num2[2];
+    } else {
+        rd_FlagGroup(spell_hex_data->casting_spells, rd_byte);
+        rd_s32b(&spell_hex_data->revenge_power);
+        byte tmp8u;
+        rd_byte(&tmp8u);
+        spell_hex_data->revenge_type = i2enum<SpellHexRevengeType>(tmp8u);
+        rd_byte(&spell_hex_data->revenge_turn);
+    }
+}

--- a/src/load/player-class-specific-data-loader.h
+++ b/src/load/player-class-specific-data-loader.h
@@ -5,6 +5,7 @@
 
 struct no_class_specific_data;
 struct smith_data_type;
+struct force_trainer_data_type;
 struct spell_hex_data_type;
 
 class PlayerClassSpecificDataLoader {
@@ -20,6 +21,7 @@ public:
     void operator()(no_class_specific_data &) {}
     void operator()(std::shared_ptr<spell_hex_data_type> &spell_hex_data) const;
     void operator()(std::shared_ptr<smith_data_type> &smith_data) const;
+    void operator()(std::shared_ptr<force_trainer_data_type> &) const;
 
 private:
     int32_t (&magic_num1)[MAX_SPELLS];

--- a/src/load/player-class-specific-data-loader.h
+++ b/src/load/player-class-specific-data-loader.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "system/angband.h"
+#include "system/system-variables.h"
+
+struct no_class_specific_data;
+struct smith_data_type;
+struct spell_hex_data_type;
+
+class PlayerClassSpecificDataLoader {
+public:
+    PlayerClassSpecificDataLoader(int32_t (&magic_num1)[MAX_SPELLS], byte (&magic_num2)[MAX_SPELLS])
+        : magic_num1(magic_num1)
+        , magic_num2(magic_num2)
+    {
+    }
+    PlayerClassSpecificDataLoader(const PlayerClassSpecificDataLoader &) = delete;
+    PlayerClassSpecificDataLoader &operator=(const PlayerClassSpecificDataLoader &) = delete;
+
+    void operator()(no_class_specific_data &) {}
+    void operator()(std::shared_ptr<spell_hex_data_type> &spell_hex_data) const;
+    void operator()(std::shared_ptr<smith_data_type> &smith_data) const;
+
+private:
+    int32_t (&magic_num1)[MAX_SPELLS];
+    byte (&magic_num2)[MAX_SPELLS];
+};

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -9,10 +9,12 @@
 #include "load/load-v1-7-0.h"
 #include "load/load-zangband.h"
 #include "load/player-attack-loader.h"
+#include "load/player-class-specific-data-loader.h"
 #include "load/world-loader.h"
 #include "market/arena.h"
-#include "mutation/mutation-calculator.h"
 #include "monster-race/race-ability-flags.h"
+#include "mutation/mutation-calculator.h"
+#include "player-base/player-class.h"
 #include "player/attack-defense-types.h"
 #include "player/player-skill.h"
 #include "spell-realm/spells-song.h"
@@ -143,6 +145,10 @@ void rd_skills(player_type *player_ptr)
         set_zangband_spells(player_ptr);
     else
         set_spells(player_ptr);
+
+    PlayerClass(player_ptr).init_specific_data();
+    std::visit(PlayerClassSpecificDataLoader(player_ptr->magic_num1, player_ptr->magic_num2),
+        player_ptr->class_specific_data);
 
     if (music_singing_any(player_ptr))
         player_ptr->action = ACTION_SING;

--- a/src/object-enchant/object-smith.cpp
+++ b/src/object-enchant/object-smith.cpp
@@ -409,7 +409,7 @@ Smith::DrainEssenceResult Smith::drain_essence(object_type *o_ptr)
             continue;
         }
 
-        this->smith_data->essences[essence] = std::min(Smith::ESSENCE_AMOUNT_MAX, this->smith_data->essences[essence] + drain_value);
+        this->smith_data->essences[essence] = std::min<int16_t>(Smith::ESSENCE_AMOUNT_MAX, this->smith_data->essences[essence] + drain_value);
         result.emplace_back(essence, drain_value);
     }
 
@@ -433,7 +433,7 @@ bool Smith::add_essence(SmithEffect effect, object_type *o_ptr, int number)
 
     const auto total_consumption = this->get_essence_consumption(effect, o_ptr) * number;
     for (auto &&essence : info.value()->need_essences) {
-        this->smith_data->essences[essence] -= total_consumption;
+        this->smith_data->essences[essence] -= static_cast<int16_t>(total_consumption);
     }
 
     return info.value()->add_essence(this->player_ptr, o_ptr, number);

--- a/src/object-enchant/object-smith.h
+++ b/src/object-enchant/object-smith.h
@@ -13,6 +13,7 @@ struct player_type;
 class ISmithInfo;
 struct essence_drain_type;
 class ItemTester;
+struct smith_data_type;
 
 enum class SmithEffect : int16_t;
 enum class SmithCategory;
@@ -58,4 +59,5 @@ private:
     static const std::vector<std::shared_ptr<ISmithInfo>> smith_info_table;
 
     player_type *player_ptr;
+    std::shared_ptr<smith_data_type> smith_data;
 };

--- a/src/object-enchant/object-smith.h
+++ b/src/object-enchant/object-smith.h
@@ -17,7 +17,7 @@ struct smith_data_type;
 
 enum class SmithEffect : int16_t;
 enum class SmithCategory;
-enum class SmithEssence;
+enum class SmithEssence : int16_t;
 enum random_art_activation_type : uint8_t;
 
 /*!

--- a/src/object-enchant/smith-info.h
+++ b/src/object-enchant/smith-info.h
@@ -9,7 +9,7 @@
 
 enum class SmithEffect : int16_t;
 enum class SmithCategory;
-enum class SmithEssence;
+enum class SmithEssence : int16_t;
 enum random_art_activation_type : uint8_t;
 
 struct player_type;

--- a/src/object-enchant/smith-tables.h
+++ b/src/object-enchant/smith-tables.h
@@ -4,7 +4,7 @@
 
 #include <vector>
 
-enum class SmithEssence;
+enum class SmithEssence : int16_t;
 enum tr_type : int32_t;
 
 /*!

--- a/src/object-enchant/smith-types.h
+++ b/src/object-enchant/smith-types.h
@@ -181,7 +181,7 @@ enum class SmithCategory {
 /**
  * @brief 鍛冶エッセンスの列挙体
  */
-enum class SmithEssence {
+enum class SmithEssence : int16_t {
     NONE = 0,
     STR = 1, //!< 腕力
     INT = 2, //!< 知能

--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -9,6 +9,7 @@
 #include "core/player-update-types.h"
 #include "player/attack-defense-types.h"
 #include "player/special-defense-types.h"
+#include "player-info/force-trainer-data-type.h"
 #include "player-info/smith-data-type.h"
 #include "player-info/spell-hex-data-type.h"
 #include "realm/realm-types.h"
@@ -64,6 +65,9 @@ void PlayerClass::init_specific_data()
     switch (this->player_ptr->pclass) {
     case CLASS_SMITH:
         this->player_ptr->class_specific_data = std::make_shared<smith_data_type>();
+        break;
+    case CLASS_FORCETRAINER:
+        this->player_ptr->class_specific_data = std::make_shared<force_trainer_data_type>();
         break;
     case CLASS_HIGH_MAGE:
         if (this->player_ptr->realm1 == REALM_HEX) {

--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -9,10 +9,13 @@
 #include "core/player-update-types.h"
 #include "player/attack-defense-types.h"
 #include "player/special-defense-types.h"
+#include "player-info/smith-data-type.h"
+#include "player-info/spell-hex-data-type.h"
+#include "realm/realm-types.h"
 #include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 
-PlayerClass::PlayerClass(player_type* player_ptr)
+PlayerClass::PlayerClass(player_type *player_ptr)
     : player_ptr(player_ptr)
 {
 }
@@ -50,4 +53,27 @@ bool PlayerClass::lose_balance()
     this->player_ptr->redraw |= PR_STATUS;
     this->player_ptr->action = ACTION_NONE;
     return true;
+}
+
+/**
+ * @brief プレイヤーの職業にで使用する職業固有データ領域を初期化する
+ * @details 事前条件: player_type の職業や領域が決定済みであること
+ */
+void PlayerClass::init_specific_data()
+{
+    switch (this->player_ptr->pclass) {
+    case CLASS_SMITH:
+        this->player_ptr->class_specific_data = std::make_shared<smith_data_type>();
+        break;
+    case CLASS_HIGH_MAGE:
+        if (this->player_ptr->realm1 == REALM_HEX) {
+            this->player_ptr->class_specific_data = std::make_shared<spell_hex_data_type>();
+        } else {
+            this->player_ptr->class_specific_data = no_class_specific_data();
+        }
+        break;
+    default:
+        this->player_ptr->class_specific_data = no_class_specific_data();
+        break;
+    }
 }

--- a/src/player-base/player-class.h
+++ b/src/player-base/player-class.h
@@ -1,6 +1,10 @@
 ﻿#pragma once
 
-struct player_type;
+#include "system/player-type-definition.h"
+
+#include <memory>
+#include <variant>
+
 class PlayerClass {
 public:
     PlayerClass() = delete;
@@ -12,6 +16,28 @@ public:
 
     bool lose_balance();
 
+    void init_specific_data();
+    template <typename T>
+    std::shared_ptr<T> get_specific_data() const;
+
 private:
     player_type *player_ptr;
 };
+
+/**
+ * @brief 職業固有データへのアクセスを取得する
+ * @details 事前条件: init_specifid_data を呼び出し職業固有データ領域の初期化を行っておくこと
+ *
+ * @tparam T 職業固有データの型
+ * @return 職業固有データTへのアクセスができる std::shared_ptr<T> を返す。
+ * プレイヤーが職業固有データTを使用できない職業の場合はなにも所有権を持たない std::shared_ptr<T> を返す。
+ */
+template <typename T>
+std::shared_ptr<T> PlayerClass::get_specific_data() const
+{
+    if (!std::holds_alternative<std::shared_ptr<T>>(this->player_ptr->class_specific_data)) {
+        return nullptr;
+    }
+
+    return std::get<std::shared_ptr<T>>(this->player_ptr->class_specific_data);
+}

--- a/src/player-info/bluemage-data-type.h
+++ b/src/player-info/bluemage-data-type.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "system/angband.h"
+
+#include "monster-race/race-ability-flags.h"
+#include "util/flag-group.h"
+
+struct bluemage_data_type {
+    EnumClassFlagGroup<RF_ABILITY> learnt_blue_magics;
+};

--- a/src/player-info/class-specific-data.h
+++ b/src/player-info/class-specific-data.h
@@ -6,12 +6,14 @@
 struct no_class_specific_data {
 };
 struct smith_data_type;
+struct force_trainer_data_type;
 struct spell_hex_data_type;
 
 using ClassSpecificData = std::variant<
 
     no_class_specific_data,
     std::shared_ptr<smith_data_type>,
+    std::shared_ptr<force_trainer_data_type>,
     std::shared_ptr<spell_hex_data_type>
 
     >;

--- a/src/player-info/class-specific-data.h
+++ b/src/player-info/class-specific-data.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <memory>
+#include <variant>
+
+struct no_class_specific_data {
+};
+struct smith_data_type;
+struct spell_hex_data_type;
+
+using ClassSpecificData = std::variant<
+
+    no_class_specific_data,
+    std::shared_ptr<smith_data_type>,
+    std::shared_ptr<spell_hex_data_type>
+
+    >;

--- a/src/player-info/force-trainer-data-type.h
+++ b/src/player-info/force-trainer-data-type.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "system/angband.h"
+
+struct force_trainer_data_type {
+    int32_t ki;
+};

--- a/src/player-info/smith-data-type.h
+++ b/src/player-info/smith-data-type.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "system/angband.h"
+
+#include <map>
+
+enum class SmithEssence;
+
+struct smith_data_type {
+    std::map<SmithEssence, int> essences;
+};

--- a/src/player-info/smith-data-type.h
+++ b/src/player-info/smith-data-type.h
@@ -4,8 +4,8 @@
 
 #include <map>
 
-enum class SmithEssence;
+enum class SmithEssence : int16_t;
 
 struct smith_data_type {
-    std::map<SmithEssence, int> essences;
+    std::map<SmithEssence, int16_t> essences;
 };

--- a/src/player-info/spell-hex-data-type.h
+++ b/src/player-info/spell-hex-data-type.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "system/angband.h"
+
+#include "realm/realm-hex-numbers.h"
+#include "util/flag-group.h"
+
+enum class SpellHexRevengeType : byte;
+
+using HexSpellFlagGroup = FlagGroup<spell_hex_type, HEX_MAX>;
+
+struct spell_hex_data_type {
+    HexSpellFlagGroup casting_spells;
+    SpellHexRevengeType revenge_type;
+    int32_t revenge_power;
+    byte revenge_turn;
+};

--- a/src/realm/realm-hex-numbers.h
+++ b/src/realm/realm-hex-numbers.h
@@ -37,4 +37,5 @@ enum spell_hex_type {
     HEX_SHADOW_MOVE = 29,
     HEX_ANTI_MAGIC = 30,
     HEX_REVENGE = 31,
+    HEX_MAX,
 };

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -880,6 +880,8 @@ concptr do_hex_spell(player_type *player_ptr, spell_hex_type spell, spell_type m
 
         break;
     }
+    case HEX_MAX:
+        break;
     }
 
     if (cast && should_continue) {

--- a/src/save/player-class-specific-data-writer.cpp
+++ b/src/save/player-class-specific-data-writer.cpp
@@ -1,5 +1,6 @@
 #include "save/player-class-specific-data-writer.h"
 #include "player-info/smith-data-type.h"
+#include "player-info/force-trainer-data-type.h"
 #include "player-info/spell-hex-data-type.h"
 #include "save/save-util.h"
 #include "util/enum-converter.h"
@@ -14,6 +15,11 @@ void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<smith_data_
     }
     wr_s16b(-1);
     wr_s16b(-1);
+}
+
+void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<force_trainer_data_type> &force_trainer_data) const
+{
+    wr_s32b(force_trainer_data->ki);
 }
 
 void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<spell_hex_data_type> &spell_hex_data) const

--- a/src/save/player-class-specific-data-writer.cpp
+++ b/src/save/player-class-specific-data-writer.cpp
@@ -1,0 +1,25 @@
+#include "save/player-class-specific-data-writer.h"
+#include "player-info/smith-data-type.h"
+#include "player-info/spell-hex-data-type.h"
+#include "save/save-util.h"
+#include "util/enum-converter.h"
+
+void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<smith_data_type> &smith_data) const
+{
+    for (auto [essence, amount] : smith_data->essences) {
+        if (amount > 0) {
+            wr_s16b(enum2i(essence));
+            wr_s16b(amount);
+        }
+    }
+    wr_s16b(-1);
+    wr_s16b(-1);
+}
+
+void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<spell_hex_data_type> &spell_hex_data) const
+{
+    wr_FlagGroup(spell_hex_data->casting_spells, wr_byte);
+    wr_s32b(spell_hex_data->revenge_power);
+    wr_byte(enum2i(spell_hex_data->revenge_type));
+    wr_byte(spell_hex_data->revenge_turn);
+}

--- a/src/save/player-class-specific-data-writer.h
+++ b/src/save/player-class-specific-data-writer.h
@@ -5,10 +5,12 @@
 struct no_class_specific_data;
 struct spell_hex_data_type;
 struct smith_data_type;
+struct force_trainer_data_type;
 
 class PlayerClassSpecificDataWriter {
 public:
     void operator()(const no_class_specific_data &) const {}
     void operator()(const std::shared_ptr<spell_hex_data_type> &spell_hex_data) const;
     void operator()(const std::shared_ptr<smith_data_type> &smith_data) const;
+    void operator()(const std::shared_ptr<force_trainer_data_type> &force_trainer_data) const;
 };

--- a/src/save/player-class-specific-data-writer.h
+++ b/src/save/player-class-specific-data-writer.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <memory>
+
+struct no_class_specific_data;
+struct spell_hex_data_type;
+struct smith_data_type;
+
+class PlayerClassSpecificDataWriter {
+public:
+    void operator()(const no_class_specific_data &) const {}
+    void operator()(const std::shared_ptr<spell_hex_data_type> &spell_hex_data) const;
+    void operator()(const std::shared_ptr<smith_data_type> &smith_data) const;
+};

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -3,6 +3,7 @@
 #include "dungeon/dungeon.h"
 #include "game-option/birth-options.h"
 #include "save/info-writer.h"
+#include "save/player-class-specific-data-writer.h"
 #include "save/save-util.h"
 #include "system/building-type-definition.h"
 #include "system/floor-type-definition.h"
@@ -11,6 +12,8 @@
 #include "timed-effect/player-stun.h"
 #include "timed-effect/timed-effects.h"
 #include "world/world.h"
+
+#include <variant>
 
 /*!
  * @brief セーブデータに領域情報を書き込む / Write player realms
@@ -87,6 +90,8 @@ void wr_player(player_type *player_ptr)
 
     for (int i = 0; i < MAX_SPELLS; i++)
         wr_byte(player_ptr->magic_num2[i]);
+
+    std::visit(PlayerClassSpecificDataWriter(), player_ptr->class_specific_data);
 
     wr_byte((byte)player_ptr->start_race);
     wr_s32b(player_ptr->old_race1);

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -12,6 +12,7 @@ enum class SpellHexRevengeType : byte {
 
 struct monap_type;
 struct player_type;
+struct spell_hex_data_type;
 class SpellHex {
 public:
     SpellHex() = delete;
@@ -44,7 +45,8 @@ private:
     player_type *player_ptr;
     std::vector<int> casting_spells;
     monap_type *monap_ptr = nullptr;
-    
+    std::shared_ptr<spell_hex_data_type> spell_hex_data;
+
     std::tuple<bool, bool, char> select_spell_stopping(char *out_val);
     void display_casting_spells_list();
     bool process_mana_cost(const bool need_restart);

--- a/src/system/angband-version.h
+++ b/src/system/angband-version.h
@@ -22,7 +22,7 @@
 /*!
  * @brief セーブファイルのバージョン(3.0.0から導入)
  */
-constexpr uint32_t SAVEFILE_VERSION = 8;
+constexpr uint32_t SAVEFILE_VERSION = 9;
 
 /*!
  * @brief バージョンが開発版が安定版かを返す(廃止予定)

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -4,6 +4,7 @@
 #include "object-enchant/trc-types.h"
 #include "object/tval-types.h"
 #include "player-ability/player-ability-types.h"
+#include "player-info/class-specific-data.h"
 #include "player-info/class-types.h"
 #include "player-info/race-types.h"
 #include "player/player-personality-types.h"
@@ -97,7 +98,7 @@ public:
     TIME_EFFECT afraid{}; /* Timed -- Fear */
     TIME_EFFECT hallucinated{}; /* Timed -- Hallucination */
     TIME_EFFECT poisoned{}; /* Timed -- Poisoned */
-    
+
     TIME_EFFECT protevil{}; /* Timed -- Protection */
     TIME_EFFECT invuln{}; /* Timed -- Invulnerable */
     TIME_EFFECT ult_res{}; /* Timed -- Ultimate Resistance */
@@ -187,6 +188,8 @@ public:
     SUB_EXP spell_exp[64]{}; /* Proficiency of spells */
     SUB_EXP weapon_exp[5][64]{}; /* Proficiency of weapons */
     SUB_EXP skill_exp[MAX_SKILLS]{}; /* Proficiency of misc. skill */
+
+    ClassSpecificData class_specific_data;
 
     // @todo uint32_tで定義したいが可能か？
     int32_t magic_num1[MAX_SPELLS]{}; /*!< Array for non-spellbook type magic */

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -4,8 +4,6 @@
  * @author Hourier
  */
 
-#include <vector>
-
 #include "wizard/wizard-spells.h"
 #include "blue-magic/blue-magic-checker.h"
 #include "core/asking-player.h"
@@ -22,9 +20,11 @@
 #include "monster-race/monster-race.h"
 #include "mutation/mutation-processor.h"
 #include "object-enchant/object-smith.h"
+#include "player-base/player-class.h"
+#include "player-info/smith-data-type.h"
 #include "spell-kind/spells-launcher.h"
-#include "spell-kind/spells-teleport.h"
 #include "spell-kind/spells-random.h"
+#include "spell-kind/spells-teleport.h"
 #include "spell-realm/spells-chaos.h"
 #include "spell/spells-status.h"
 #include "spell/summon-types.h"
@@ -37,6 +37,8 @@
 #include "util/enum-converter.h"
 #include "util/flag-group.h"
 #include "view/display-messages.h"
+
+#include <vector>
 
 debug_spell_command debug_spell_commands_list[SPELL_MAX] = {
     { 2, "vanish dungeon", { .spell2 = { vanish_dungeon } } },
@@ -157,8 +159,13 @@ void wiz_learn_blue_magic_all(player_type *player_ptr)
  */
 void wiz_fillup_all_smith_essences(player_type *player_ptr)
 {
+    auto smith_data = PlayerClass(player_ptr).get_specific_data<smith_data_type>();
+    if (!smith_data) {
+        return;
+    }
+
     for (auto essence : Smith::get_essence_list()) {
-        player_ptr->magic_num1[enum2i(essence)] = Smith::ESSENCE_AMOUNT_MAX;
+        smith_data->essences[essence] = Smith::ESSENCE_AMOUNT_MAX;
     }
 }
 
@@ -239,7 +246,6 @@ void wiz_kill_enemy(player_type *player_ptr, HIT_POINT dam, EFFECT_ID effect_idx
 
         effect_idx = (EFFECT_ID)atoi(tmp_val);
     }
-
 
     if (effect_idx <= GF_NONE || effect_idx >= MAX_GF) {
         msg_format(_("番号は1から%dの間で指定して下さい。", "ID must be between 1 to %d."), MAX_GF - 1);


### PR DESCRIPTION
現在職業固有のデータを持たせる時、 magic_num1, magic_num2 という
共通の配列を好き勝手に使用していてコードの可読性が大きく損なわれている。
これを職業ごとにデータを持てるようにしてコードの可読性を向上させ、
またフレキシブルなデータ構造を使えるようにする。

まず手始めとして職業固有データを持たせるシステム導入と同時に、鍛冶師と
呪術ハイメイジにおける固有データの分離を行った。

大枠が完成したのでPRを出します。ご意見等いただければ。
他に現場 magic_num1, magic_num2 を使っている職業

- 魔道具術師
- 青魔道士
- 吟遊詩人
- 練気術師
- 鏡使い（？）
