### PR TITLE
[Refactor] max_*_idx を廃止する

### DIFF
--- a/lib/edit/misc.txt
+++ b/lib/edit/misc.txt
@@ -12,30 +12,8 @@ M:WX:99
 # Maximum y size of the wilderness
 M:WY:66
 
-# Maximum number of monsters in r_info.txt
-M:R:1347
-
-# Maximum number of items in k_info.txt
-M:K:675
-
-# Maximum number of vaults in v_info.txt
-M:V:173
-
-# Maximum number of terrain features in f_info.txt
-M:F:255
-
-# Maximum number of artifacts in a_info.txt
-M:A:269
-
-# Maximum number of ego-items in e_info.txt
-M:E:255
-
-# Maximum number of dungeon types in d_info.txt
-M:D:32
-
 # Maximum size for "o_list[]"
 M:O:1024
 
 # Maximum size for "m_list[]"
 M:M:1024
-

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -230,7 +230,7 @@ void do_cmd_visuals(player_type *player_ptr)
                 case 'n': {
                     IDX prev_r = r;
                     do {
-                        if (!cmd_visuals_aux(i, &r, max_r_idx)) {
+                        if (!cmd_visuals_aux(i, &r, static_cast<IDX>(r_info.size()))) {
                             r = prev_r;
                             break;
                         }
@@ -300,7 +300,7 @@ void do_cmd_visuals(player_type *player_ptr)
                 case 'n': {
                     IDX prev_k = k;
                     do {
-                        if (!cmd_visuals_aux(i, &k, max_k_idx)) {
+                        if (!cmd_visuals_aux(i, &k, static_cast<IDX>(k_info.size()))) {
                             k = prev_k;
                             break;
                         }
@@ -373,7 +373,7 @@ void do_cmd_visuals(player_type *player_ptr)
                 case 'n': {
                     IDX prev_f = f;
                     do {
-                        if (!cmd_visuals_aux(i, &f, max_f_idx)) {
+                        if (!cmd_visuals_aux(i, &f, static_cast<IDX>(f_info.size()))) {
                             f = prev_f;
                             break;
                         }

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -364,20 +364,6 @@ static bool parse_qtw_M(qtwg_type *qtwg_ptr, char **zz)
         max_towns = static_cast<int16_t>(atoi(zz[1]));
     } else if (zz[0][0] == 'Q') {
         max_q_idx = (QUEST_IDX)atoi(zz[1]);
-    } else if (zz[0][0] == 'R') {
-        max_r_idx = (MONRACE_IDX)atoi(zz[1]);
-    } else if (zz[0][0] == 'K') {
-        max_k_idx = (KIND_OBJECT_IDX)atoi(zz[1]);
-    } else if (zz[0][0] == 'V') {
-        max_v_idx = static_cast<int16_t>(atoi(zz[1]));
-    } else if (zz[0][0] == 'F') {
-        max_f_idx = (FEAT_IDX)atoi(zz[1]);
-    } else if (zz[0][0] == 'A') {
-        max_a_idx = (ARTIFACT_IDX)atoi(zz[1]);
-    } else if (zz[0][0] == 'E') {
-        max_e_idx = (EGO_IDX)atoi(zz[1]);
-    } else if (zz[0][0] == 'D') {
-        w_ptr->max_d_idx = (DUNGEON_IDX)atoi(zz[1]);
     } else if (zz[0][0] == 'O') {
         w_ptr->max_o_idx = (OBJECT_IDX)atoi(zz[1]);
     } else if (zz[0][0] == 'M') {

--- a/src/grid/feature.cpp
+++ b/src/grid/feature.cpp
@@ -115,11 +115,6 @@ FEAT_IDX feat_wall_inner;
 FEAT_IDX feat_wall_solid;
 FEAT_IDX feat_ground_type[100], feat_wall_type[100];
 
-/*
- * Maximum number of terrain features in f_info.txt
- */
-FEAT_IDX max_f_idx;
-
 /*!
  * @brief 地形が罠持ちであるかの判定を行う。 / Return TRUE if the given feature is a trap
  * @param feat 地形情報のID

--- a/src/grid/feature.h
+++ b/src/grid/feature.h
@@ -53,7 +53,6 @@ typedef struct feature_type {
     SYMBOL_CODE x_char[F_LIT_MAX]{}; /*!< 設定変更後の地形シンボルアルファベット / Desired feature character */
 } feature_type;
 
-extern FEAT_IDX max_f_idx;
 extern std::vector<feature_type> f_info;
 
 /*** Terrain feature variables ***/

--- a/src/info-reader/artifact-reader.cpp
+++ b/src/info-reader/artifact-reader.cpp
@@ -35,7 +35,7 @@ static bool grab_one_artifact_flag(artifact_type *a_ptr, std::string_view what)
  * @param head ヘッダ構造体
  * @return エラーコード
  */
-errr parse_a_info(std::string_view buf, angband_header *head)
+errr parse_a_info(std::string_view buf, angband_header *)
 {
     static artifact_type *a_ptr = nullptr;
     const auto &tokens = str_split(buf, ':', false, 10);
@@ -48,8 +48,9 @@ errr parse_a_info(std::string_view buf, angband_header *head)
         auto i = std::stoi(tokens[1]);
         if (i < error_idx)
             return PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
-        if (i >= head->info_num)
-            return PARSE_ERROR_OUT_OF_BOUNDS;
+        if (i >= static_cast<int>(a_info.size())) {
+            a_info.resize(i + 1);
+        }
 
         error_idx = i;
         a_ptr = &a_info[i];

--- a/src/info-reader/dungeon-reader.cpp
+++ b/src/info-reader/dungeon-reader.cpp
@@ -84,7 +84,7 @@ static bool grab_one_spell_monster_flag(dungeon_type *d_ptr, std::string_view wh
  * @param head ヘッダ構造体
  * @return エラーコード
  */
-errr parse_d_info(std::string_view buf, angband_header *head)
+errr parse_d_info(std::string_view buf, angband_header *)
 {
     static dungeon_type *d_ptr = nullptr;
     const auto &tokens = str_split(buf, ':', false);
@@ -97,8 +97,9 @@ errr parse_d_info(std::string_view buf, angband_header *head)
         auto i = std::stoi(tokens[1]);
         if (i < error_idx)
             return PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
-        if (i >= head->info_num)
-            return PARSE_ERROR_OUT_OF_BOUNDS;
+        if (i >= static_cast<int>(d_info.size())) {
+            d_info.resize(i + 1);
+        }
 
         error_idx = i;
         d_ptr = &d_info[i];

--- a/src/info-reader/ego-reader.cpp
+++ b/src/info-reader/ego-reader.cpp
@@ -57,7 +57,7 @@ static bool grab_ego_generate_flags(ego_generate_type &xtra, std::string_view wh
  * @param head ヘッダ構造体
  * @return エラーコード
  */
-errr parse_e_info(std::string_view buf, angband_header *head)
+errr parse_e_info(std::string_view buf, angband_header *)
 {
     static ego_item_type *e_ptr = nullptr;
     const auto &tokens = str_split(buf, ':', false, 10);
@@ -72,8 +72,9 @@ errr parse_e_info(std::string_view buf, angband_header *head)
         auto i = std::stoi(tokens[1]);
         if (i < error_idx)
             return PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
-        if (i >= head->info_num)
-            return PARSE_ERROR_OUT_OF_BOUNDS;
+        if (i >= static_cast<int>(e_info.size())) {
+            e_info.resize(i + 1);
+        }
 
         error_idx = i;
         e_ptr = &e_info[i];

--- a/src/info-reader/feature-reader.cpp
+++ b/src/info-reader/feature-reader.cpp
@@ -58,7 +58,7 @@ static bool grab_one_feat_action(feature_type *f_ptr, std::string_view what, int
  * @param head ヘッダ構造体
  * @return エラーコード
  */
-errr parse_f_info(std::string_view buf, angband_header *head)
+errr parse_f_info(std::string_view buf, angband_header *)
 {
     static feature_type *f_ptr = nullptr;
     const auto &tokens = str_split(buf, ':', false, 10);
@@ -74,8 +74,9 @@ errr parse_f_info(std::string_view buf, angband_header *head)
         auto i = std::stoi(tokens[1]);
         if (i < error_idx)
             return PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
-        if (i >= head->info_num)
-            return PARSE_ERROR_OUT_OF_BOUNDS;
+        if (i >= static_cast<int>(f_info.size())) {
+            f_info.resize(i + 1);
+        }
 
         error_idx = i;
         f_ptr = &f_info[i];

--- a/src/info-reader/kind-reader.cpp
+++ b/src/info-reader/kind-reader.cpp
@@ -36,7 +36,7 @@ static bool grab_one_kind_flag(object_kind *k_ptr, std::string_view what)
  * @param head ヘッダ構造体
  * @return エラーコード
  */
-errr parse_k_info(std::string_view buf, angband_header *head)
+errr parse_k_info(std::string_view buf, angband_header *)
 {
     static object_kind *k_ptr = nullptr;
     const auto &tokens = str_split(buf, ':', false, 10);
@@ -49,8 +49,9 @@ errr parse_k_info(std::string_view buf, angband_header *head)
         auto i = std::stoi(tokens[1]);
         if (i < error_idx)
             return PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
-        if (i >= head->info_num)
-            return PARSE_ERROR_OUT_OF_BOUNDS;
+        if (i >= static_cast<int>(k_info.size())) {
+            k_info.resize(i + 1);
+        }
 
         error_idx = i;
         k_ptr = &k_info[i];

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -67,7 +67,7 @@ static bool grab_one_spell_flag(monster_race *r_ptr, std::string_view what)
  * @param head ヘッダ構造体
  * @return エラーコード
  */
-errr parse_r_info(std::string_view buf, angband_header *head)
+errr parse_r_info(std::string_view buf, angband_header *)
 {
     static monster_race *r_ptr = nullptr;
     const auto &tokens = str_split(buf, ':', true, 10);
@@ -80,8 +80,9 @@ errr parse_r_info(std::string_view buf, angband_header *head)
         auto i = std::stoi(tokens[1]);
         if (i < error_idx)
             return PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
-        if (i >= head->info_num)
-            return PARSE_ERROR_OUT_OF_BOUNDS;
+        if (i >= static_cast<int>(r_info.size())) {
+            r_info.resize(i + 1);
+        }
 
         error_idx = i;
         r_ptr = &r_info[i];

--- a/src/info-reader/vault-reader.cpp
+++ b/src/info-reader/vault-reader.cpp
@@ -12,7 +12,7 @@
  * @param head ヘッダ構造体
  * @return エラーコード
  */
-errr parse_v_info(std::string_view buf, angband_header *head)
+errr parse_v_info(std::string_view buf, angband_header *)
 {
     static vault_type *v_ptr = nullptr;
     const auto &tokens = str_split(buf, ':', false, 5);
@@ -27,8 +27,9 @@ errr parse_v_info(std::string_view buf, angband_header *head)
         auto i = std::stoi(tokens[1]);
         if (i < error_idx)
             return PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
-        if (i >= head->info_num)
-            return PARSE_ERROR_OUT_OF_BOUNDS;
+        if (i >= static_cast<int>(v_info.size())) {
+            v_info.resize(i + 1);
+        }
 
         error_idx = i;
         v_ptr = &v_info[i];

--- a/src/io/interpret-pref-file.cpp
+++ b/src/io/interpret-pref-file.cpp
@@ -43,7 +43,7 @@ static errr interpret_r_token(char *buf)
     int i = (int)strtol(zz[0], nullptr, 0);
     TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], nullptr, 0);
     SYMBOL_CODE n2 = (SYMBOL_CODE)strtol(zz[2], nullptr, 0);
-    if (i >= max_r_idx)
+    if (i >= static_cast<int>(r_info.size()))
         return 1;
 
     r_ptr = &r_info[i];
@@ -70,7 +70,7 @@ static errr interpret_k_token(char *buf)
     int i = (int)strtol(zz[0], nullptr, 0);
     TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], nullptr, 0);
     SYMBOL_CODE n2 = (SYMBOL_CODE)strtol(zz[2], nullptr, 0);
-    if (i >= max_k_idx)
+    if (i >= static_cast<int>(k_info.size()))
         return 1;
 
     k_ptr = &k_info[i];
@@ -155,7 +155,7 @@ static errr interpret_f_token(char *buf)
         return 1;
 
     int i = (int)strtol(zz[0], nullptr, 0);
-    if (i >= max_f_idx)
+    if (i >= static_cast<int>(f_info.size()))
         return 1;
 
     return decide_feature_type(i, num, zz);

--- a/src/load/item-loader.cpp
+++ b/src/load/item-loader.cpp
@@ -305,8 +305,8 @@ errr load_item(void)
     object_kind *k_ptr;
     object_kind dummy;
     byte tmp8u;
-    for (int i = 0; i < loading_max_k_idx; i++) {
-        if (i < max_k_idx)
+    for (auto i = 0U; i < loading_max_k_idx; i++) {
+        if (i < k_info.size())
             k_ptr = &k_info[i];
         else
             k_ptr = &dummy;
@@ -332,8 +332,8 @@ errr load_artifact(void)
     artifact_type *a_ptr;
     artifact_type dummy;
     byte tmp8u;
-    for (int i = 0; i < loading_max_a_idx; i++) {
-        if (i < max_a_idx)
+    for (auto i = 0U; i < loading_max_a_idx; i++) {
+        if (i < a_info.size())
             a_ptr = &a_info[i];
         else
             a_ptr = &dummy;

--- a/src/load/lore-loader.cpp
+++ b/src/load/lore-loader.cpp
@@ -104,8 +104,8 @@ errr load_lore(void)
 
     monster_race *r_ptr;
     monster_race dummy;
-    for (int i = 0; i < loading_max_r_idx; i++) {
-        if (i < max_r_idx)
+    for (auto i = 0U; i < loading_max_r_idx; i++) {
+        if (i < r_info.size())
             r_ptr = &r_info[i];
         else
             r_ptr = &dummy;

--- a/src/load/world-loader.cpp
+++ b/src/load/world-loader.cpp
@@ -13,11 +13,15 @@
 
 static void rd_hengband_dungeons(void)
 {
-    byte max = d_info.size();
+    byte max;
     rd_byte(&max);
     int16_t tmp16s;
-    for (int i = 0; i < max; i++) {
+    for (auto i = 0U; i < max; i++) {
         rd_s16b(&tmp16s);
+        if (i >= d_info.size()){
+            continue;
+        }
+
         max_dlv[i] = tmp16s;
         if (max_dlv[i] > d_info[i].maxdepth)
             max_dlv[i] = d_info[i].maxdepth;

--- a/src/load/world-loader.cpp
+++ b/src/load/world-loader.cpp
@@ -13,7 +13,7 @@
 
 static void rd_hengband_dungeons(void)
 {
-    byte max = (byte)w_ptr->max_d_idx;
+    byte max = d_info.size();
     rd_byte(&max);
     int16_t tmp16s;
     for (int i = 0; i < max; i++) {

--- a/src/main-win/main-win-music.cpp
+++ b/src/main-win/main-win-music.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "main-win/main-win-music.h"
+#include "dungeon/dungeon.h"
 #include "dungeon/quest.h"
 #include "floor/floor-town.h"
 #include "main-win/main-win-define.h"
@@ -15,6 +16,7 @@
 #include "main/scene-table.h"
 #include "main/sound-of-music.h"
 #include "monster-race/monster-race.h"
+#include "system/monster-race-definition.h"
 #include "term/z-term.h"
 #include "util/angband-files.h"
 #include "world/world.h"
@@ -55,7 +57,7 @@ static concptr basic_key_at(int index, char *buf)
 
 static inline DUNGEON_IDX get_dungeon_count()
 {
-    return w_ptr->max_d_idx;
+    return static_cast<DUNGEON_IDX>(d_info.size());
 }
 
 /*!
@@ -115,7 +117,7 @@ static concptr town_key_at(int index, char *buf)
 
 static inline MONRACE_IDX get_monster_count()
 {
-    return max_r_idx;
+    return static_cast<MONRACE_IDX>(r_info.size());
 }
 
 /*!

--- a/src/main/game-data-initializer.cpp
+++ b/src/main/game-data-initializer.cpp
@@ -60,7 +60,7 @@ errr init_other(player_type *player_ptr)
     for (auto &list : floor_ptr->mproc_list)
         list.assign(w_ptr->max_m_idx, {});
 
-    max_dlv.assign(w_ptr->max_d_idx, {});
+    max_dlv.assign(d_info.size(), {});
     floor_ptr->grid_array.assign(MAX_HGT, std::vector<grid_type>(MAX_WID));
 
     macro__pat.assign(MACRO_MAX, {});
@@ -162,7 +162,7 @@ errr init_alloc(void)
 
     tag_sort(elements.data(), elements.size());
     alloc_race_table.assign(r_info.size(), {});
-    for (int i = 1; i < max_r_idx; i++) {
+    for (auto i = 1U; i < r_info.size(); i++) {
         auto r_ptr = &r_info[elements[i].index];
         if (r_ptr->rarity == 0)
             continue;

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -60,7 +60,7 @@ errr init_misc(player_type *player_ptr)
  * @param len データの長さ
  * @return エラーコード
  */
-static void init_header(angband_header *head, IDX num)
+static void init_header(angband_header *head, IDX num = 0)
 {
     head->checksum = 0;
     head->info_num = (IDX)num;
@@ -107,6 +107,9 @@ static errr init_info(concptr filename, angband_header &head, std::vector<InfoTy
         quit(format(_("'%s.txt'ファイルにエラー", "Error in '%s.txt' file."), filename));
     }
 
+    info.shrink_to_fit();
+    head.info_num = static_cast<uint16_t>(info.size());
+
     if (retouch)
         (*retouch)(&head);
 
@@ -120,7 +123,7 @@ static errr init_info(concptr filename, angband_header &head, std::vector<InfoTy
  */
 errr init_f_info()
 {
-    init_header(&f_head, max_f_idx);
+    init_header(&f_head);
     return init_info("f_info", f_head, f_info, parse_f_info, retouch_f_info);
 }
 
@@ -131,7 +134,7 @@ errr init_f_info()
  */
 errr init_k_info()
 {
-    init_header(&k_head, max_k_idx);
+    init_header(&k_head);
     return init_info("k_info", k_head, k_info, parse_k_info, nullptr);
 }
 
@@ -142,7 +145,7 @@ errr init_k_info()
  */
 errr init_a_info()
 {
-    init_header(&a_head, max_a_idx);
+    init_header(&a_head);
     return init_info("a_info", a_head, a_info, parse_a_info, nullptr);
 }
 
@@ -153,7 +156,7 @@ errr init_a_info()
  */
 errr init_e_info()
 {
-    init_header(&e_head, max_e_idx);
+    init_header(&e_head);
     return init_info("e_info", e_head, e_info, parse_e_info, nullptr);
 }
 
@@ -164,7 +167,7 @@ errr init_e_info()
  */
 errr init_r_info()
 {
-    init_header(&r_head, max_r_idx);
+    init_header(&r_head);
     return init_info("r_info", r_head, r_info, parse_r_info, nullptr);
 }
 
@@ -175,7 +178,7 @@ errr init_r_info()
  */
 errr init_d_info()
 {
-    init_header(&d_head, w_ptr->max_d_idx);
+    init_header(&d_head);
     return init_info("d_info", d_head, d_info, parse_d_info, nullptr);
 }
 
@@ -189,7 +192,7 @@ errr init_d_info()
  */
 errr init_v_info()
 {
-    init_header(&v_head, max_v_idx);
+    init_header(&v_head);
     return init_info("v_info", v_head, v_info, parse_v_info, nullptr);
 }
 

--- a/src/monster-floor/monster-summon.cpp
+++ b/src/monster-floor/monster-summon.cpp
@@ -182,7 +182,7 @@ bool summon_specific(player_type *player_ptr, MONSTER_IDX who, POSITION y1, POSI
  */
 bool summon_named_creature(player_type *player_ptr, MONSTER_IDX who, POSITION oy, POSITION ox, MONRACE_IDX r_idx, BIT_FLAGS mode)
 {
-    if ((r_idx <= 0) || (r_idx >= max_r_idx)) {
+    if ((r_idx <= 0) || (r_idx >= static_cast<MONRACE_IDX>(r_info.size()))) {
         return false;
     }
     

--- a/src/monster-race/monster-race.cpp
+++ b/src/monster-race/monster-race.cpp
@@ -3,6 +3,3 @@
 
 /* The monster race arrays */
 std::vector<monster_race> r_info;
-
-/* Maximum number of monsters in r_info.txt */
-MONRACE_IDX max_r_idx;

--- a/src/monster-race/monster-race.h
+++ b/src/monster-race/monster-race.h
@@ -6,4 +6,3 @@
 
 struct monster_race;
 extern std::vector<monster_race> r_info;
-extern MONRACE_IDX max_r_idx;

--- a/src/monster/monster-describer.cpp
+++ b/src/monster/monster-describer.cpp
@@ -40,7 +40,7 @@ void monster_desc(player_type *player_ptr, char *desc, monster_type *m_ptr, BIT_
             monster_race *hallu_race;
 
             do {
-                hallu_race = &r_info[randint1(max_r_idx - 1)];
+                hallu_race = &r_info[randint1(r_info.size() - 1)];
             } while (hallu_race->name.empty() || (hallu_race->flags1 & RF1_UNIQUE));
 
             strcpy(silly_name, (hallu_race->name.c_str()));

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -487,7 +487,7 @@ void monster_gain_exp(player_type *player_ptr, MONSTER_IDX m_idx, MONRACE_IDX s_
             if (player_ptr->hallucinated) {
                 monster_race *hallu_race;
                 do {
-                    hallu_race = &r_info[randint1(max_r_idx - 1)];
+                    hallu_race = &r_info[randint1(r_info.size() - 1)];
                 } while (hallu_race->name.empty() || any_bits(hallu_race->flags1, RF1_UNIQUE));
                 msg_format(_("%sは%sに進化した。", "%^s evolved into %s."), m_name, hallu_race->name.c_str());
             } else {

--- a/src/object-enchant/apply-magic-others.cpp
+++ b/src/object-enchant/apply-magic-others.cpp
@@ -127,7 +127,7 @@ void apply_magic_others(player_type *player_ptr, object_type *o_ptr, int power)
         int check;
         monster_race *r_ptr;
         while (true) {
-            i = randint1(max_r_idx - 1);
+            i = randint1(r_info.size() - 1);
 
             if (!item_monster_okay(player_ptr, i))
                 continue;
@@ -187,7 +187,7 @@ void apply_magic_others(player_type *player_ptr, object_type *o_ptr, int power)
         PARAMETER_VALUE i = 1;
         monster_race *r_ptr;
         while (true) {
-            i = randint1(max_r_idx - 1);
+            i = randint1(r_info.size() - 1);
             r_ptr = &r_info[i];
             if (!r_ptr->rarity)
                 continue;

--- a/src/object-enchant/object-ego.cpp
+++ b/src/object-enchant/object-ego.cpp
@@ -23,11 +23,6 @@
  */
 std::vector<ego_item_type> e_info;
 
-/*
- * Maximum number of ego-items in e_info.txt
- */
-EGO_IDX max_e_idx;
-
 /*!
  * @brief アイテムのエゴをレア度の重みに合わせてランダムに選択する
  * Choose random ego type

--- a/src/object-enchant/object-ego.h
+++ b/src/object-enchant/object-ego.h
@@ -263,7 +263,6 @@ struct ego_item_type {
     IDX act_idx{}; //!< 発動番号 / Activative ability index
 };
 
-extern EGO_IDX max_e_idx;
 extern std::vector<ego_item_type> e_info;
 
 struct object_type;;

--- a/src/object/object-kind.cpp
+++ b/src/object/object-kind.cpp
@@ -16,11 +16,6 @@
 std::vector<object_kind> k_info;
 
 /*
- * Maximum number of items in k_info.txt
- */
-KIND_OBJECT_IDX max_k_idx;
-
-/*
  * Return the "char" for a given item.
  * Use "flavor" if available.
  * Default to user definitions.

--- a/src/object/object-kind.h
+++ b/src/object/object-kind.h
@@ -61,7 +61,6 @@ typedef struct object_kind {
 } object_kind;
 
 extern std::vector<object_kind> k_info;
-extern KIND_OBJECT_IDX max_k_idx;
 
 struct object_type;
 SYMBOL_CODE object_char(object_type *o_ptr);

--- a/src/room/rooms-vault.cpp
+++ b/src/room/rooms-vault.cpp
@@ -618,7 +618,7 @@ bool build_type7(player_type *player_ptr, dun_data_type *dd_ptr)
     /* Pick a lesser vault */
     for (dummy = 0; dummy < SAFE_MAX_ATTEMPTS; dummy++) {
         /* Access a random vault record */
-        v_ptr = &v_info[randint0(max_v_idx)];
+        v_ptr = &v_info[randint0(v_info.size())];
 
         /* Accept the first lesser vault */
         if (v_ptr->typ == 7)
@@ -686,7 +686,7 @@ bool build_type8(player_type *player_ptr, dun_data_type *dd_ptr)
     /* Pick a greater vault */
     for (dummy = 0; dummy < SAFE_MAX_ATTEMPTS; dummy++) {
         /* Access a random vault record */
-        v_ptr = &v_info[randint0(max_v_idx)];
+        v_ptr = &v_info[randint0(v_info.size())];
 
         /* Accept the first greater vault */
         if (v_ptr->typ == 8)
@@ -1156,7 +1156,7 @@ bool build_type17(player_type *player_ptr, dun_data_type *dd_ptr)
     /* Pick a lesser vault */
     for (dummy = 0; dummy < SAFE_MAX_ATTEMPTS; dummy++) {
         /* Access a random vault record */
-        v_ptr = &v_info[randint0(max_v_idx)];
+        v_ptr = &v_info[randint0(v_info.size())];
 
         /* Accept the special fix room. */
         if (v_ptr->typ == 17)

--- a/src/room/rooms-vault.cpp
+++ b/src/room/rooms-vault.cpp
@@ -42,11 +42,6 @@
 std::vector<vault_type> v_info;
 
 /*
- * Maximum number of vaults in v_info.txt
- */
-int16_t max_v_idx;
-
-/*
  * This function creates a random vault that looks like a collection of bubbles.
  * It works by getting a set of coordinates that represent the center of each
  * bubble.  The entire room is made by seeing which bubble center is closest. If

--- a/src/room/rooms-vault.h
+++ b/src/room/rooms-vault.h
@@ -17,7 +17,6 @@ typedef struct vault_type {
 } vault_type;
 
 extern std::vector<vault_type> v_info;
-extern int16_t max_v_idx;
 
 struct dun_data_type;
 struct player_type;

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -126,7 +126,7 @@ void wr_player(player_type *player_ptr)
     wr_u32b(player_ptr->csp_frac);
     wr_s16b(player_ptr->max_plv);
 
-    byte tmp8u = (byte)w_ptr->max_d_idx;
+    byte tmp8u = (byte)d_info.size();
     wr_byte(tmp8u);
     for (int i = 0; i < tmp8u; i++)
         wr_s16b((int16_t)max_dlv[i]);

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -36,6 +36,7 @@
 #include "store/store-util.h"
 #include "system/angband-version.h"
 #include "system/artifact-type-definition.h"
+#include "system/monster-race-definition.h"
 #include "system/player-type-definition.h"
 #include "util/angband-files.h"
 #include "view/display-messages.h"
@@ -103,12 +104,12 @@ static bool wr_savefile_new(player_type *player_ptr, save_type type)
     for (int i = tmp32u - 1; i >= 0; i--)
         wr_string(message_str(i));
 
-    uint16_t tmp16u = max_r_idx;
+    uint16_t tmp16u = static_cast<uint16_t>(r_info.size());
     wr_u16b(tmp16u);
     for (MONRACE_IDX r_idx = 0; r_idx < tmp16u; r_idx++)
         wr_lore(r_idx);
 
-    tmp16u = max_k_idx;
+    tmp16u = static_cast<uint16_t>(k_info.size());
     wr_u16b(tmp16u);
     for (KIND_OBJECT_IDX k_idx = 0; k_idx < tmp16u; k_idx++)
         wr_perception(k_idx);
@@ -154,7 +155,7 @@ static bool wr_savefile_new(player_type *player_ptr, save_type type)
         for (int j = 0; j < w_ptr->max_wild_y; j++)
             wr_u32b(wilderness[j][i].seed);
 
-    tmp16u = max_a_idx;
+    tmp16u = static_cast<uint16_t>(a_info.size());
     wr_u16b(tmp16u);
     for (int i = 0; i < tmp16u; i++) {
         artifact_type *a_ptr = &a_info[i];

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -138,7 +138,7 @@ void amusement(player_type *player_ptr, POSITION y1, POSITION x1, int num, bool 
                 break;
             }
 
-            if (a_idx >= max_a_idx)
+            if (a_idx >= static_cast<ARTIFACT_IDX>(a_info.size()))
                 continue;
         }
 

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -66,7 +66,7 @@ void display_rumor(player_type *player_ptr, bool ex)
         ARTIFACT_IDX a_idx;
         artifact_type *a_ptr;
         while (true) {
-            a_idx = rumor_num(zz[1], max_a_idx);
+            a_idx = rumor_num(zz[1], static_cast<IDX>(a_info.size()));
 
             a_ptr = &a_info[a_idx];
             if (!a_ptr->name.empty())
@@ -83,7 +83,7 @@ void display_rumor(player_type *player_ptr, bool ex)
     } else if (strcmp(zz[0], "MONSTER") == 0) {
         monster_race *r_ptr;
         while (true) {
-            MONRACE_IDX r_idx = rumor_num(zz[1], max_r_idx);
+            MONRACE_IDX r_idx = rumor_num(zz[1], static_cast<IDX>(r_info.size()));
             r_ptr = &r_info[r_idx];
             if (!r_ptr->name.empty())
                 break;
@@ -98,7 +98,7 @@ void display_rumor(player_type *player_ptr, bool ex)
         DUNGEON_IDX d_idx;
         dungeon_type *d_ptr;
         while (true) {
-            d_idx = rumor_num(zz[1], w_ptr->max_d_idx);
+            d_idx = rumor_num(zz[1], static_cast<IDX>(d_info.size()));
             d_ptr = &d_info[d_idx];
             if (!d_ptr->name.empty())
                 break;

--- a/src/system/artifact-type-definition.cpp
+++ b/src/system/artifact-type-definition.cpp
@@ -4,8 +4,3 @@
  * The artifact arrays
  */
 std::vector<artifact_type> a_info;
-
-/*
- * Maximum number of artifacts in a_info.txt
- */
-ARTIFACT_IDX max_a_idx;

--- a/src/system/artifact-type-definition.h
+++ b/src/system/artifact-type-definition.h
@@ -45,4 +45,3 @@ typedef struct artifact_type {
 } artifact_type;
 
 extern std::vector<artifact_type> a_info;
-extern ARTIFACT_IDX max_a_idx;

--- a/src/view/display-map.cpp
+++ b/src/view/display-map.cpp
@@ -41,7 +41,7 @@ char image_monster_hack[MAX_IMAGE_MONSTER_HACK] = "abcdefghijklmnopqrstuvwxyzABC
 static void image_object(TERM_COLOR *ap, SYMBOL_CODE *cp)
 {
     if (use_graphics) {
-        object_kind *k_ptr = &k_info[randint1(max_k_idx - 1)];
+        object_kind *k_ptr = &k_info[randint1(k_info.size() - 1)];
         *cp = k_ptr->x_char;
         *ap = k_ptr->x_attr;
         return;
@@ -60,7 +60,7 @@ static void image_object(TERM_COLOR *ap, SYMBOL_CODE *cp)
 static void image_monster(TERM_COLOR *ap, SYMBOL_CODE *cp)
 {
     if (use_graphics) {
-        monster_race *r_ptr = &r_info[randint1(max_r_idx - 1)];
+        monster_race *r_ptr = &r_info[randint1(r_info.size() - 1)];
         *cp = r_ptr->x_char;
         *ap = r_ptr->x_attr;
         return;
@@ -357,7 +357,7 @@ void map_info(player_type *player_ptr, POSITION y, POSITION x, TERM_COLOR *ap, S
 
     if (r_ptr->flags1 & RF1_SHAPECHANGER) {
         if (use_graphics) {
-            monster_race *tmp_r_ptr = &r_info[randint1(max_r_idx - 1)];
+            monster_race *tmp_r_ptr = &r_info[randint1(r_info.size() - 1)];
             *cp = tmp_r_ptr->x_char;
             *ap = tmp_r_ptr->x_attr;
         } else {

--- a/src/wizard/wizard-game-modifier.cpp
+++ b/src/wizard/wizard-game-modifier.cpp
@@ -145,14 +145,14 @@ void wiz_restore_monster_max_num()
     MONRACE_IDX r_idx = command_arg;
     if (r_idx <= 0) {
         std::stringstream ss;
-        ss << "Monster race (1-" << max_r_idx << "): ";
+        ss << "Monster race (1-" << r_info.size() << "): ";
 
         char tmp_val[160] = "\0";
         if (!get_string(ss.str().c_str(), tmp_val, 5))
             return;
 
         r_idx = (MONRACE_IDX)atoi(tmp_val);
-        if (r_idx <= 0 || r_idx >= max_r_idx)
+        if (r_idx <= 0 || r_idx >= static_cast<MONRACE_IDX>(r_info.size()))
             return;
     }
 

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -174,7 +174,7 @@ void wiz_restore_aware_flag_of_fixed_arfifact(ARTIFACT_IDX a_idx, bool aware)
 {
     if (a_idx <= 0) {
         char tmp[80] = "";
-        sprintf(tmp, "Artifact ID (1-%d): ", max_a_idx - 1);
+        sprintf(tmp, "Artifact ID (1-%d): ", static_cast<int>(a_info.size()) - 1);
         char tmp_val[10] = "";
         if (!get_string(tmp, tmp_val, 3))
             return;
@@ -182,8 +182,8 @@ void wiz_restore_aware_flag_of_fixed_arfifact(ARTIFACT_IDX a_idx, bool aware)
         a_idx = (ARTIFACT_IDX)atoi(tmp_val);
     }
 
-    if (a_idx <= 0 || a_idx >= max_a_idx) {
-        msg_format(_("番号は1から%dの間で指定して下さい。", "ID must be between 1 to %d."), max_a_idx - 1);
+    if (a_idx <= 0 || a_idx >= static_cast<ARTIFACT_IDX>(a_info.size())) {
+        msg_format(_("番号は1から%dの間で指定して下さい。", "ID must be between 1 to %d."), a_info.size() - 1);
         return;
     }
 

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -220,7 +220,7 @@ void wiz_create_named_art(player_type *player_ptr, ARTIFACT_IDX a_idx)
 {
     if (a_idx <= 0) {
         char tmp[80] = "";
-        sprintf(tmp, "Artifact ID (1-%d): ", max_a_idx - 1);
+        sprintf(tmp, "Artifact ID (1-%d): ", static_cast<int>(a_info.size()) - 1);
         char tmp_val[10] = "";
         if (!get_string(tmp, tmp_val, 3))
             return;
@@ -228,8 +228,8 @@ void wiz_create_named_art(player_type *player_ptr, ARTIFACT_IDX a_idx)
         a_idx = (ARTIFACT_IDX)atoi(tmp_val);
     }
 
-    if (a_idx <= 0 || a_idx >= max_a_idx) {
-        msg_format(_("番号は1から%dの間で指定して下さい。", "ID must be between 1 to %d."), max_a_idx - 1);
+    if (a_idx <= 0 || a_idx >= static_cast<ARTIFACT_IDX>(a_info.size())) {
+        msg_format(_("番号は1から%dの間で指定して下さい。", "ID must be between 1 to %d."), a_info.size() - 1);
         return;
     }
 
@@ -342,8 +342,8 @@ void wiz_create_feature(player_type *player_ptr)
     FEAT_IDX tmp_feat = (FEAT_IDX)atoi(tmp_val);
     if (tmp_feat < 0)
         tmp_feat = 0;
-    else if (tmp_feat >= max_f_idx)
-        tmp_feat = max_f_idx - 1;
+    else if (tmp_feat >= static_cast<FEAT_IDX>(f_info.size()))
+        tmp_feat = static_cast<FEAT_IDX>(f_info.size()) - 1;
 
     static int prev_mimic = 0;
     sprintf(tmp_val, "%d", prev_mimic);
@@ -354,8 +354,8 @@ void wiz_create_feature(player_type *player_ptr)
     FEAT_IDX tmp_mimic = (FEAT_IDX)atoi(tmp_val);
     if (tmp_mimic < 0)
         tmp_mimic = 0;
-    else if (tmp_mimic >= max_f_idx)
-        tmp_mimic = max_f_idx - 1;
+    else if (tmp_mimic >= static_cast<FEAT_IDX>(f_info.size()))
+        tmp_mimic = static_cast<FEAT_IDX>(f_info.size()) - 1;
 
     cave_set_feat(player_ptr, y, x, tmp_feat);
     g_ptr->mimic = (int16_t)tmp_mimic;
@@ -385,7 +385,7 @@ void wiz_create_feature(player_type *player_ptr)
 static bool select_debugging_floor(player_type *player_ptr, int dungeon_type)
 {
     auto max_depth = d_info[dungeon_type].maxdepth;
-    if ((max_depth == 0) || (dungeon_type > w_ptr->max_d_idx)) {
+    if ((max_depth == 0) || (dungeon_type > static_cast<int>(d_info.size()))) {
         dungeon_type = DUNGEON_ANGBAND;
     }
 

--- a/src/world/world.h
+++ b/src/world/world.h
@@ -63,8 +63,6 @@ struct world_type {
 
     OBJECT_IDX max_o_idx{}; /*!< Maximum number of objects in the level */
     MONSTER_IDX max_m_idx{}; /*!< Maximum number of monsters in the level */
-
-    DUNGEON_IDX max_d_idx{};
 };
 
 extern world_type *w_ptr;


### PR DESCRIPTION
\*\_info を std::vector にしたことで \*\_info.size() を見れば良くなったので以下の ma\_\*\_Idx を廃止する。

a_info, d_info, e_info, f_info, k_info, r_info, v_info 

misc.txt からも削除し、テキストファイルをパースしながら *_info を必要なサイズに拡張する。