### PR TITLE
[Fix] 誤ってterm_dataへのポインタを初期化している

### DIFF
--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -1313,7 +1313,7 @@ static void init_windows(void)
 
     for (int i = 1; i < MAX_TERM_DATA; i++) {
         td = &data[i];
-        td = {};
+        *td = {};
         td->name = win_term_name[i];
         td->rows = 24;
         td->cols = 80;


### PR DESCRIPTION
Fix #1618.
WIPE マクロを排除した時に term_data 本体でなくポインタの方を初期化
するようにしてしまっていた。