### PR TITLE
BadStatusSetterクラスに mod_hoge() メソッドを定義した

### DIFF
--- a/src/action/open-close-execution.cpp
+++ b/src/action/open-close-execution.cpp
@@ -326,7 +326,7 @@ bool exe_bash(player_type *player_ptr, POSITION y, POSITION x, DIRECTION dir)
         more = true;
     } else {
         msg_print(_("体のバランスをくずしてしまった。", "You are off-balance."));
-        (void)BadStatusSetter(player_ptr).paralysis(player_ptr->paralyzed + 2 + randint0(2));
+        (void)BadStatusSetter(player_ptr).mod_paralysis(2 + randint0(2));
     }
 
     return more;

--- a/src/cmd-action/cmd-mind.cpp
+++ b/src/cmd-action/cmd-mind.cpp
@@ -207,7 +207,7 @@ static void check_mind_mindcrafter(player_type *player_ptr, cm_type *cm_ptr)
     BadStatusSetter bss(player_ptr);
     if (cm_ptr->b < 15) {
         msg_print(_("奇妙な光景が目の前で踊っている...", "Weird visions seem to dance before your eyes..."));
-        (void)bss.hallucination(player_ptr->hallucinated + 5 + randint1(10));
+        (void)bss.mod_hallucination(5 + randint1(10));
         return;
     }
 
@@ -244,7 +244,7 @@ static void check_mind_mirror_master(player_type *player_ptr, cm_type *cm_ptr)
 
     if (cm_ptr->b < 96) {
         msg_print(_("まわりのものがキラキラ輝いている！", "Your brain is addled!"));
-        (void)BadStatusSetter(player_ptr).hallucination(player_ptr->hallucinated + 5 + randint1(10));
+        (void)BadStatusSetter(player_ptr).mod_hallucination(5 + randint1(10));
         return;
     }
 

--- a/src/cmd-action/cmd-mind.cpp
+++ b/src/cmd-action/cmd-mind.cpp
@@ -336,7 +336,7 @@ static void mind_reflection(player_type *player_ptr, cm_type *cm_ptr)
 
     player_ptr->csp = MAX(0, player_ptr->csp - cm_ptr->mana_cost);
     msg_format(_("%sを集中しすぎて気を失ってしまった！", "You faint from the effort!"), cm_ptr->mind_explanation);
-    (void)BadStatusSetter(player_ptr).paralysis(player_ptr->paralyzed + randint1(5 * oops + 1));
+    (void)BadStatusSetter(player_ptr).mod_paralysis(randint1(5 * oops + 1));
     if (randint0(100) >= 50)
         return;
 

--- a/src/cmd-action/cmd-mind.cpp
+++ b/src/cmd-action/cmd-mind.cpp
@@ -213,7 +213,7 @@ static void check_mind_mindcrafter(player_type *player_ptr, cm_type *cm_ptr)
 
     if (cm_ptr->b < 45) {
         msg_print(_("あなたの頭は混乱した！", "Your brain is addled!"));
-        (void)bss.confusion(player_ptr->confused + randint1(8));
+        (void)bss.mod_confusion(randint1(8));
         return;
     }
 

--- a/src/cmd-action/cmd-mind.cpp
+++ b/src/cmd-action/cmd-mind.cpp
@@ -218,7 +218,7 @@ static void check_mind_mindcrafter(player_type *player_ptr, cm_type *cm_ptr)
     }
 
     if (cm_ptr->b < 90) {
-        (void)bss.stun(player_ptr->effects()->stun()->current() + randint1(8));
+        (void)bss.mod_stun(randint1(8));
         return;
     }
 

--- a/src/cmd-action/cmd-shoot.cpp
+++ b/src/cmd-action/cmd-shoot.cpp
@@ -14,8 +14,6 @@
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
-#include "timed-effect/player-stun.h"
-#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
 /*!
@@ -74,6 +72,6 @@ void do_cmd_fire(player_type *player_ptr, SPELL_IDX snipe_type)
         msg_print(_("射撃の反動が体を襲った。", "The weapon's recoil stuns you. "));
         BadStatusSetter bss(player_ptr);
         (void)bss.mod_slowness(randint0(7) + 7, false);
-        (void)bss.stun(effects->stun()->current() + randint1(25));
+        (void)bss.mod_stun(randint1(25));
     }
 }

--- a/src/cmd-action/cmd-shoot.cpp
+++ b/src/cmd-action/cmd-shoot.cpp
@@ -73,7 +73,7 @@ void do_cmd_fire(player_type *player_ptr, SPELL_IDX snipe_type)
     if (snipe_type == SP_FINAL) {
         msg_print(_("射撃の反動が体を襲った。", "The weapon's recoil stuns you. "));
         BadStatusSetter bss(player_ptr);
-        (void)bss.slowness(player_ptr->slow + randint0(7) + 7, false);
+        (void)bss.mod_slowness(randint0(7) + 7, false);
         (void)bss.stun(effects->stun()->current() + randint1(25));
     }
 }

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -1353,7 +1353,7 @@ bool do_cmd_cast(player_type *player_ptr)
         player_ptr->csp = 0;
         player_ptr->csp_frac = 0;
         msg_print(_("精神を集中しすぎて気を失ってしまった！", "You faint from the effort!"));
-        (void)BadStatusSetter(player_ptr).paralysis(player_ptr->paralyzed + randint1(5 * oops + 1));
+        (void)BadStatusSetter(player_ptr).mod_paralysis(randint1(5 * oops + 1));
         switch (realm) {
         case REALM_LIFE:
             chg_virtue(player_ptr, V_VITALITY, -10);

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -72,7 +72,7 @@ bool exe_eat_food_type_object(player_type *player_ptr, object_type *o_ptr)
     case SV_FOOD_CONFUSION:
         return !has_resist_conf(player_ptr) && bss.mod_confusion(randint0(10) + 10);
     case SV_FOOD_HALLUCINATION:
-        return !has_resist_chaos(player_ptr) && bss.hallucination(player_ptr->hallucinated + randint0(250) + 250);
+        return !has_resist_chaos(player_ptr) && bss.mod_hallucination(randint0(250) + 250);
     case SV_FOOD_PARALYSIS:
         return !player_ptr->free_act && bss.mod_paralysis(randint0(10) + 10);
     case SV_FOOD_WEAKNESS:

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -66,7 +66,7 @@ bool exe_eat_food_type_object(player_type *player_ptr, object_type *o_ptr)
     case SV_FOOD_POISON:
         return (!(has_resist_pois(player_ptr) || is_oppose_pois(player_ptr))) && bss.poison(player_ptr->poisoned + randint0(10) + 10);
     case SV_FOOD_BLINDNESS:
-        return !has_resist_blind(player_ptr) && bss.blindness(player_ptr->blind + randint0(200) + 200);
+        return !has_resist_blind(player_ptr) && bss.mod_blindness(randint0(200) + 200);
     case SV_FOOD_PARANOIA:
         return !has_resist_fear(player_ptr) && bss.afraidness(player_ptr->afraid + randint0(10) + 10);
     case SV_FOOD_CONFUSION:

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -74,7 +74,7 @@ bool exe_eat_food_type_object(player_type *player_ptr, object_type *o_ptr)
     case SV_FOOD_HALLUCINATION:
         return !has_resist_chaos(player_ptr) && bss.hallucination(player_ptr->hallucinated + randint0(250) + 250);
     case SV_FOOD_PARALYSIS:
-        return !player_ptr->free_act && bss.paralysis(player_ptr->paralyzed + randint0(10) + 10);
+        return !player_ptr->free_act && bss.mod_paralysis(randint0(10) + 10);
     case SV_FOOD_WEAKNESS:
         take_hit(player_ptr, DAMAGE_NOESCAPE, damroll(6, 6), _("毒入り食料", "poisonous food"));
         (void)do_dec_stat(player_ptr, A_STR);

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -64,7 +64,7 @@ bool exe_eat_food_type_object(player_type *player_ptr, object_type *o_ptr)
     BadStatusSetter bss(player_ptr);
     switch (o_ptr->sval) {
     case SV_FOOD_POISON:
-        return (!(has_resist_pois(player_ptr) || is_oppose_pois(player_ptr))) && bss.poison(player_ptr->poisoned + randint0(10) + 10);
+        return (!(has_resist_pois(player_ptr) || is_oppose_pois(player_ptr))) && bss.mod_poison(randint0(10) + 10);
     case SV_FOOD_BLINDNESS:
         return !has_resist_blind(player_ptr) && bss.mod_blindness(randint0(200) + 200);
     case SV_FOOD_PARANOIA:

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -68,7 +68,7 @@ bool exe_eat_food_type_object(player_type *player_ptr, object_type *o_ptr)
     case SV_FOOD_BLINDNESS:
         return !has_resist_blind(player_ptr) && bss.mod_blindness(randint0(200) + 200);
     case SV_FOOD_PARANOIA:
-        return !has_resist_fear(player_ptr) && bss.afraidness(player_ptr->afraid + randint0(10) + 10);
+        return !has_resist_fear(player_ptr) && bss.mod_afraidness(randint0(10) + 10);
     case SV_FOOD_CONFUSION:
         return !has_resist_conf(player_ptr) && bss.mod_confusion(randint0(10) + 10);
     case SV_FOOD_HALLUCINATION:

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -70,7 +70,7 @@ bool exe_eat_food_type_object(player_type *player_ptr, object_type *o_ptr)
     case SV_FOOD_PARANOIA:
         return !has_resist_fear(player_ptr) && bss.afraidness(player_ptr->afraid + randint0(10) + 10);
     case SV_FOOD_CONFUSION:
-        return !has_resist_conf(player_ptr) && bss.confusion(player_ptr->confused + randint0(10) + 10);
+        return !has_resist_conf(player_ptr) && bss.mod_confusion(randint0(10) + 10);
     case SV_FOOD_HALLUCINATION:
         return !has_resist_chaos(player_ptr) && bss.hallucination(player_ptr->hallucinated + randint0(250) + 250);
     case SV_FOOD_PARALYSIS:

--- a/src/cmd-item/cmd-usestaff.cpp
+++ b/src/cmd-item/cmd-usestaff.cpp
@@ -86,7 +86,7 @@ int staff_effect(player_type *player_ptr, OBJECT_SUBTYPE_VALUE sval, bool *use_c
 
         break;
     case SV_STAFF_SLOWNESS: {
-        if (bss.slowness(player_ptr->slow + randint1(30) + 15, false))
+        if (bss.mod_slowness(randint1(30) + 15, false))
             ident = true;
         break;
     }

--- a/src/cmd-item/cmd-usestaff.cpp
+++ b/src/cmd-item/cmd-usestaff.cpp
@@ -75,7 +75,7 @@ int staff_effect(player_type *player_ptr, OBJECT_SUBTYPE_VALUE sval, bool *use_c
     switch (sval) {
     case SV_STAFF_DARKNESS:
         if (!has_resist_blind(player_ptr) && !has_resist_dark(player_ptr)) {
-            if (bss.blindness(player_ptr->blind + 3 + randint1(5))) {
+            if (bss.mod_blindness(3 + randint1(5))) {
                 ident = true;
             }
         }

--- a/src/core/magic-effects-timeout-reducer.cpp
+++ b/src/core/magic-effects-timeout-reducer.cpp
@@ -35,7 +35,7 @@ void reduce_magic_effects_timeout(player_type *player_ptr)
     BadStatusSetter bss(player_ptr);
     auto effects = player_ptr->effects();
     if (player_ptr->hallucinated) {
-        (void)bss.hallucination(player_ptr->hallucinated - dec_count);
+        (void)bss.mod_hallucination(-dec_count);
     }
 
     if (player_ptr->blind) {

--- a/src/core/magic-effects-timeout-reducer.cpp
+++ b/src/core/magic-effects-timeout-reducer.cpp
@@ -143,7 +143,7 @@ void reduce_magic_effects_timeout(player_type *player_ptr)
     }
 
     if (player_ptr->slow) {
-        (void)bss.slowness(player_ptr->slow - dec_count, true);
+        (void)bss.mod_slowness(-dec_count, true);
     }
 
     if (player_ptr->protevil) {

--- a/src/core/magic-effects-timeout-reducer.cpp
+++ b/src/core/magic-effects-timeout-reducer.cpp
@@ -228,6 +228,6 @@ void reduce_magic_effects_timeout(player_type *player_ptr)
             adjust = 0;
         }
 
-        (void)bss.cut(player_cut->current() - adjust);
+        (void)bss.mod_cut(-adjust);
     }
 }

--- a/src/core/magic-effects-timeout-reducer.cpp
+++ b/src/core/magic-effects-timeout-reducer.cpp
@@ -212,7 +212,7 @@ void reduce_magic_effects_timeout(player_type *player_ptr)
 
     if (player_ptr->poisoned) {
         int adjust = adj_con_fix[player_ptr->stat_index[A_CON]] + 1;
-        (void)bss.poison(player_ptr->poisoned - adjust);
+        (void)bss.mod_poison(-adjust);
     }
 
     auto player_stun = effects->stun();

--- a/src/core/magic-effects-timeout-reducer.cpp
+++ b/src/core/magic-effects-timeout-reducer.cpp
@@ -135,7 +135,7 @@ void reduce_magic_effects_timeout(player_type *player_ptr)
     }
 
     if (player_ptr->afraid) {
-        (void)bss.afraidness(player_ptr->afraid - dec_count);
+        (void)bss.mod_afraidness(-dec_count);
     }
 
     if (player_ptr->fast) {

--- a/src/core/magic-effects-timeout-reducer.cpp
+++ b/src/core/magic-effects-timeout-reducer.cpp
@@ -218,7 +218,7 @@ void reduce_magic_effects_timeout(player_type *player_ptr)
     auto player_stun = effects->stun();
     if (player_stun->is_stunned()) {
         int adjust = adj_con_fix[player_ptr->stat_index[A_CON]] + 1;
-        (void)bss.stun(player_stun->current() - adjust);
+        (void)bss.mod_stun(-adjust);
     }
 
     auto player_cut = effects->cut();

--- a/src/core/magic-effects-timeout-reducer.cpp
+++ b/src/core/magic-effects-timeout-reducer.cpp
@@ -127,7 +127,7 @@ void reduce_magic_effects_timeout(player_type *player_ptr)
     }
 
     if (player_ptr->paralyzed) {
-        (void)bss.paralysis(player_ptr->paralyzed - dec_count);
+        (void)bss.mod_paralysis(-dec_count);
     }
 
     if (player_ptr->confused) {

--- a/src/core/magic-effects-timeout-reducer.cpp
+++ b/src/core/magic-effects-timeout-reducer.cpp
@@ -131,7 +131,7 @@ void reduce_magic_effects_timeout(player_type *player_ptr)
     }
 
     if (player_ptr->confused) {
-        (void)bss.confusion(player_ptr->confused - dec_count);
+        (void)bss.mod_confusion(-dec_count);
     }
 
     if (player_ptr->afraid) {

--- a/src/core/magic-effects-timeout-reducer.cpp
+++ b/src/core/magic-effects-timeout-reducer.cpp
@@ -39,7 +39,7 @@ void reduce_magic_effects_timeout(player_type *player_ptr)
     }
 
     if (player_ptr->blind) {
-        (void)bss.blindness(player_ptr->blind - dec_count);
+        (void)bss.mod_blindness(-dec_count);
     }
 
     if (player_ptr->tim_invis) {

--- a/src/effect/effect-monster-charm.cpp
+++ b/src/effect/effect-monster-charm.cpp
@@ -26,8 +26,6 @@
 #include "system/monster-race-definition.h"
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
-#include "timed-effect/player-stun.h"
-#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 
@@ -217,7 +215,7 @@ static void effect_monster_domination_corrupted_addition(player_type *player_ptr
     BadStatusSetter bss(player_ptr);
     switch (randint1(4)) {
     case 1:
-        (void)bss.stun(player_ptr->effects()->stun()->current() + em_ptr->dam / 2);
+        (void)bss.mod_stun(em_ptr->dam / 2);
         return;
     case 2:
         (void)bss.mod_confusion(em_ptr->dam / 2);
@@ -226,7 +224,7 @@ static void effect_monster_domination_corrupted_addition(player_type *player_ptr
         if (any_bits(em_ptr->r_ptr->flags3, RF3_NO_FEAR)) {
             em_ptr->note = _("には効果がなかった。", " is unaffected.");
         } else {
-            (void)bss.mod_afraidness(em_ptr->dam);
+            (void)bss.mod_afraidness(static_cast<TIME_EFFECT>(em_ptr->dam));
         }
 
         return;

--- a/src/effect/effect-monster-charm.cpp
+++ b/src/effect/effect-monster-charm.cpp
@@ -226,7 +226,7 @@ static void effect_monster_domination_corrupted_addition(player_type *player_ptr
         if (any_bits(em_ptr->r_ptr->flags3, RF3_NO_FEAR)) {
             em_ptr->note = _("には効果がなかった。", " is unaffected.");
         } else {
-            (void)bss.afraidness(player_ptr->afraid + em_ptr->dam);
+            (void)bss.mod_afraidness(em_ptr->dam);
         }
 
         return;

--- a/src/effect/effect-monster-charm.cpp
+++ b/src/effect/effect-monster-charm.cpp
@@ -220,7 +220,7 @@ static void effect_monster_domination_corrupted_addition(player_type *player_ptr
         (void)bss.stun(player_ptr->effects()->stun()->current() + em_ptr->dam / 2);
         return;
     case 2:
-        (void)bss.confusion(player_ptr->confused + em_ptr->dam / 2);
+        (void)bss.mod_confusion(em_ptr->dam / 2);
         return;
     default:
         if (any_bits(em_ptr->r_ptr->flags3, RF3_NO_FEAR)) {

--- a/src/effect/effect-monster-psi.cpp
+++ b/src/effect/effect-monster-psi.cpp
@@ -113,7 +113,7 @@ static void effect_monster_psi_reflect_extra_effect(player_type *player_ptr, eff
         if (any_bits(em_ptr->r_ptr->flags3, RF3_NO_FEAR)) {
             em_ptr->note = _("には効果がなかった。", " is unaffected.");
         } else {
-            (void)bss.afraidness(player_ptr->afraid + 3 + randint1(em_ptr->dam));
+            (void)bss.mod_afraidness(3 + randint1(em_ptr->dam));
         }
 
         return;

--- a/src/effect/effect-monster-psi.cpp
+++ b/src/effect/effect-monster-psi.cpp
@@ -17,8 +17,6 @@
 #include "system/monster-race-definition.h"
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
-#include "timed-effect/player-stun.h"
-#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "world/world.h"
@@ -107,7 +105,7 @@ static void effect_monster_psi_reflect_extra_effect(player_type *player_ptr, eff
         (void)bss.mod_confusion(3 + randint1(em_ptr->dam));
         return;
     case 2:
-        (void)bss.stun(player_ptr->effects()->stun()->current() + randint1(em_ptr->dam));
+        (void)bss.mod_stun(randint1(em_ptr->dam));
         return;
     case 3:
         if (any_bits(em_ptr->r_ptr->flags3, RF3_NO_FEAR)) {

--- a/src/effect/effect-monster-psi.cpp
+++ b/src/effect/effect-monster-psi.cpp
@@ -119,7 +119,7 @@ static void effect_monster_psi_reflect_extra_effect(player_type *player_ptr, eff
         return;
     default:
         if (!player_ptr->free_act) {
-            (void)bss.paralysis(player_ptr->paralyzed + randint1(em_ptr->dam));
+            (void)bss.mod_paralysis(randint1(em_ptr->dam));
         }
 
         return;

--- a/src/effect/effect-monster-psi.cpp
+++ b/src/effect/effect-monster-psi.cpp
@@ -104,7 +104,7 @@ static void effect_monster_psi_reflect_extra_effect(player_type *player_ptr, eff
     BadStatusSetter bss(player_ptr);
     switch (randint1(4)) {
     case 1:
-        (void)bss.confusion(player_ptr->confused + 3 + randint1(em_ptr->dam));
+        (void)bss.mod_confusion(3 + randint1(em_ptr->dam));
         return;
     case 2:
         (void)bss.stun(player_ptr->effects()->stun()->current() + randint1(em_ptr->dam));

--- a/src/effect/effect-player-curse.cpp
+++ b/src/effect/effect-player-curse.cpp
@@ -8,8 +8,6 @@
 #include "status/bad-status-setter.h"
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
-#include "timed-effect/player-cut.h"
-#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 
@@ -55,6 +53,6 @@ void effect_player_curse_4(player_type *player_ptr, effect_player_type *ep_ptr)
 
     ep_ptr->get_damage = take_hit(player_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
     if (!check_multishadow(player_ptr)) {
-        (void)BadStatusSetter(player_ptr).cut(player_ptr->effects()->cut()->current() + damroll(10, 10));
+        (void)BadStatusSetter(player_ptr).mod_cut(damroll(10, 10));
     }
 }

--- a/src/effect/effect-player-oldies.cpp
+++ b/src/effect/effect-player-oldies.cpp
@@ -33,7 +33,7 @@ void effect_player_old_slow(player_type *player_ptr)
         msg_print(_("何か遅いもので攻撃された！", "You are hit by something slow!"));
     }
 
-    (void)BadStatusSetter(player_ptr).slowness(player_ptr->slow + randint0(4) + 4, false);
+    (void)BadStatusSetter(player_ptr).mod_slowness(randint0(4) + 4, false);
 }
 
 void effect_player_old_sleep(player_type *player_ptr, effect_player_type *ep_ptr)

--- a/src/effect/effect-player-oldies.cpp
+++ b/src/effect/effect-player-oldies.cpp
@@ -51,6 +51,6 @@ void effect_player_old_sleep(player_type *player_ptr, effect_player_type *ep_ptr
         sanity_blast(player_ptr, nullptr, false);
     }
 
-    (void)BadStatusSetter(player_ptr).paralysis(player_ptr->paralyzed + ep_ptr->dam);
+    (void)BadStatusSetter(player_ptr).mod_paralysis(static_cast<TIME_EFFECT>(ep_ptr->dam));
     ep_ptr->dam = 0;
 }

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -31,7 +31,6 @@
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
 #include "timed-effect/player-cut.h"
-#include "timed-effect/player-stun.h"
 #include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 #include "world/world.h"
@@ -145,8 +144,8 @@ void effect_player_plasma(player_type *player_ptr, effect_player_type *ep_ptr)
     ep_ptr->get_damage = take_hit(player_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 
     if (!has_resist_sound(player_ptr) && !check_multishadow(player_ptr)) {
-        int plus_stun = (randint1((ep_ptr->dam > 40) ? 35 : (ep_ptr->dam * 3 / 4 + 5)));
-        (void)BadStatusSetter(player_ptr).stun(player_ptr->effects()->stun()->current() + plus_stun);
+        TIME_EFFECT plus_stun = (randint1((ep_ptr->dam > 40) ? 35 : (ep_ptr->dam * 3 / 4 + 5)));
+        (void)BadStatusSetter(player_ptr).mod_stun(plus_stun);
     }
 
     if (!(has_resist_fire(player_ptr) || is_oppose_fire(player_ptr) || has_immune_fire(player_ptr)))
@@ -209,7 +208,7 @@ void effect_player_water(player_type *player_ptr, effect_player_type *ep_ptr)
     BadStatusSetter bss(player_ptr);
     if (!check_multishadow(player_ptr)) {
         if (!has_resist_sound(player_ptr) && !has_res_water) {
-            (void)bss.stun(player_ptr->effects()->stun()->current() + randint1(40));
+            (void)bss.mod_stun(randint1(40));
         }
 
         if (!has_resist_conf(player_ptr) && !has_res_water) {
@@ -285,8 +284,8 @@ void effect_player_sound(player_type *player_ptr, effect_player_type *ep_ptr)
     ep_ptr->dam = ep_ptr->dam * calc_sound_damage_rate(player_ptr, CALC_RAND) / 100;
 
     if (!has_resist_sound(player_ptr) && !check_multishadow(player_ptr)) {
-        int plus_stun = (randint1((ep_ptr->dam > 90) ? 35 : (ep_ptr->dam / 3 + 5)));
-        (void)BadStatusSetter(player_ptr).stun(player_ptr->effects()->stun()->current() + plus_stun);
+        TIME_EFFECT plus_stun = (randint1((ep_ptr->dam > 90) ? 35 : (ep_ptr->dam / 3 + 5)));
+        (void)BadStatusSetter(player_ptr).mod_stun(plus_stun);
     }
 
     if (!has_resist_sound(player_ptr) || one_in_(13))
@@ -343,7 +342,7 @@ void effect_player_force(player_type *player_ptr, effect_player_type *ep_ptr)
     if (player_ptr->blind)
         msg_print(_("運動エネルギーで攻撃された！", "You are hit by kinetic force!"));
     if (!has_resist_sound(player_ptr) && !check_multishadow(player_ptr)) {
-        (void)BadStatusSetter(player_ptr).stun(player_ptr->effects()->stun()->current() + randint1(20));
+        (void)BadStatusSetter(player_ptr).mod_stun(randint1(20));
     }
 
     ep_ptr->get_damage = take_hit(player_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
@@ -357,7 +356,7 @@ void effect_player_rocket(player_type *player_ptr, effect_player_type *ep_ptr)
 
     BadStatusSetter bss(player_ptr);
     if (!has_resist_sound(player_ptr) && !check_multishadow(player_ptr)) {
-        (void)bss.stun(player_ptr->effects()->stun()->current() + randint1(20));
+        (void)bss.mod_stun(randint1(20));
     }
 
     ep_ptr->dam = ep_ptr->dam * calc_rocket_damage_rate(player_ptr, CALC_RAND) / 100;
@@ -544,8 +543,8 @@ void effect_player_gravity(player_type *player_ptr, effect_player_type *ep_ptr)
         }
 
         if (!(has_resist_sound(player_ptr) || player_ptr->levitation)) {
-            auto plus_stun = (randint1((ep_ptr->dam > 90) ? 35 : (ep_ptr->dam / 3 + 5)));
-            (void)bss.stun(player_ptr->effects()->stun()->current() + plus_stun);
+            TIME_EFFECT plus_stun = (randint1((ep_ptr->dam > 90) ? 35 : (ep_ptr->dam / 3 + 5)));
+            (void)bss.mod_stun(plus_stun);
         }
     }
 
@@ -620,7 +619,7 @@ void effect_player_icee(player_type *player_ptr, effect_player_type *ep_ptr)
     }
 
     if (!has_resist_sound(player_ptr)) {
-        (void)bss.stun(player_ptr->effects()->stun()->current() + randint1(15));
+        (void)bss.mod_stun(randint1(15));
     }
 
     if ((!(has_resist_cold(player_ptr) || is_oppose_cold(player_ptr))) || one_in_(12)) {

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -61,7 +61,7 @@ void effect_player_poison(player_type *player_ptr, effect_player_type *ep_ptr)
     ep_ptr->get_damage = take_hit(player_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 
     if (!(double_resist || has_resist_pois(player_ptr)) && !check_multishadow(player_ptr)) {
-        (void)BadStatusSetter(player_ptr).poison(player_ptr->poisoned + randint0(ep_ptr->dam) + 10);
+        (void)BadStatusSetter(player_ptr).mod_poison(randint0(ep_ptr->dam) + 10);
     }
 }
 
@@ -77,7 +77,7 @@ void effect_player_nuke(player_type *player_ptr, effect_player_type *ep_ptr)
     if ((double_resist || has_resist_pois(player_ptr)) || check_multishadow(player_ptr))
         return;
 
-    (void)BadStatusSetter(player_ptr).poison(player_ptr->poisoned + randint0(ep_ptr->dam) + 10);
+    (void)BadStatusSetter(player_ptr).mod_poison(randint0(ep_ptr->dam) + 10);
     if (one_in_(5)) /* 6 */
     {
         msg_print(_("奇形的な変身を遂げた！", "You undergo a freakish metamorphosis!"));

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -379,7 +379,7 @@ void effect_player_inertial(player_type *player_ptr, effect_player_type *ep_ptr)
     }
 
     if (!check_multishadow(player_ptr)) {
-        (void)BadStatusSetter(player_ptr).slowness(player_ptr->slow + randint0(4) + 4, false);
+        (void)BadStatusSetter(player_ptr).mod_slowness(randint0(4) + 4, false);
     }
 
     ep_ptr->get_damage = take_hit(player_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
@@ -540,7 +540,7 @@ void effect_player_gravity(player_type *player_ptr, effect_player_type *ep_ptr)
         teleport_player(player_ptr, 5, TELEPORT_PASSIVE);
         BadStatusSetter bss(player_ptr);
         if (!player_ptr->levitation) {
-            (void)bss.slowness(player_ptr->slow + randint0(4) + 4, false);
+            (void)bss.mod_slowness(randint0(4) + 4, false);
         }
 
         if (!(has_resist_sound(player_ptr) || player_ptr->levitation)) {
@@ -653,7 +653,7 @@ void effect_player_void(player_type *player_ptr, effect_player_type *ep_ptr)
                                         : _("周辺の空間が歪んだ。", "Sight warps around you.");
     msg_print(effect_mes);
     if (!check_multishadow(player_ptr) && !player_ptr->levitation && !player_ptr->anti_tele) {
-        (void)BadStatusSetter(player_ptr).slowness(player_ptr->slow + randint0(4) + 4, false);
+        (void)BadStatusSetter(player_ptr).mod_slowness(randint0(4) + 4, false);
     }
 
     ep_ptr->dam = ep_ptr->dam * calc_void_damage_rate(player_ptr, CALC_RAND) / 100;
@@ -674,7 +674,7 @@ void effect_player_abyss(player_type *player_ptr, effect_player_type *ep_ptr)
     }
 
     if (!player_ptr->levitation) {
-        (void)bss.slowness(player_ptr->slow + randint0(4) + 4, false);
+        (void)bss.mod_slowness(randint0(4) + 4, false);
     }
 
     if (player_ptr->blind) {

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -390,7 +390,7 @@ void effect_player_lite(player_type *player_ptr, effect_player_type *ep_ptr)
     if (player_ptr->blind)
         msg_print(_("何かで攻撃された！", "You are hit by something!"));
     if (!player_ptr->blind && !has_resist_lite(player_ptr) && !has_resist_blind(player_ptr) && !check_multishadow(player_ptr)) {
-        (void)BadStatusSetter(player_ptr).blindness(player_ptr->blind + randint1(5) + 2);
+        (void)BadStatusSetter(player_ptr).mod_blindness(randint1(5) + 2);
     }
 
     ep_ptr->dam = ep_ptr->dam * calc_lite_damage_rate(player_ptr, CALC_RAND) / 100;
@@ -421,7 +421,7 @@ void effect_player_dark(player_type *player_ptr, effect_player_type *ep_ptr)
     ep_ptr->dam = ep_ptr->dam * calc_dark_damage_rate(player_ptr, CALC_RAND) / 100;
 
     if (!player_ptr->blind && !has_resist_dark(player_ptr) && !has_resist_blind(player_ptr) && !check_multishadow(player_ptr)) {
-        (void)BadStatusSetter(player_ptr).blindness(player_ptr->blind + randint1(5) + 2);
+        (void)BadStatusSetter(player_ptr).mod_blindness(randint1(5) + 2);
     }
 
     ep_ptr->get_damage = take_hit(player_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -213,7 +213,7 @@ void effect_player_water(player_type *player_ptr, effect_player_type *ep_ptr)
         }
 
         if (!has_resist_conf(player_ptr) && !has_res_water) {
-            (void)bss.confusion(player_ptr->confused + randint1(5) + 5);
+            (void)bss.mod_confusion(randint1(5) + 5);
         }
 
         if (one_in_(5) && !has_res_water) {
@@ -238,7 +238,7 @@ void effect_player_chaos(player_type *player_ptr, effect_player_type *ep_ptr)
 
     BadStatusSetter bss(player_ptr);
     if (!has_resist_conf(player_ptr)) {
-        (void)bss.confusion(player_ptr->confused + randint0(20) + 10);
+        (void)bss.mod_confusion(randint0(20) + 10);
     }
 
     if (!has_resist_chaos(player_ptr)) {
@@ -304,7 +304,7 @@ void effect_player_confusion(player_type *player_ptr, effect_player_type *ep_ptr
     ep_ptr->dam = ep_ptr->dam * calc_conf_damage_rate(player_ptr, CALC_RAND) / 100;
     BadStatusSetter bss(player_ptr);
     if (!has_resist_conf(player_ptr) && !check_multishadow(player_ptr)) {
-        (void)bss.confusion(player_ptr->confused + randint1(20) + 10);
+        (void)bss.mod_confusion(randint1(20) + 10);
     }
 
     ep_ptr->get_damage = take_hit(player_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
@@ -687,7 +687,7 @@ void effect_player_abyss(player_type *player_ptr, effect_player_type *ep_ptr)
     }
 
     if (!has_resist_conf(player_ptr)) {
-        (void)bss.confusion(player_ptr->confused + randint1(10));
+        (void)bss.mod_confusion(randint1(10));
     }
 
     if (!has_resist_fear(player_ptr)) {

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -691,6 +691,6 @@ void effect_player_abyss(player_type *player_ptr, effect_player_type *ep_ptr)
     }
 
     if (!has_resist_fear(player_ptr)) {
-        (void)bss.afraidness(player_ptr->afraid + randint1(10));
+        (void)bss.mod_afraidness(randint1(10));
     }
 }

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -242,7 +242,7 @@ void effect_player_chaos(player_type *player_ptr, effect_player_type *ep_ptr)
     }
 
     if (!has_resist_chaos(player_ptr)) {
-        (void)bss.hallucination(player_ptr->hallucinated + randint1(10));
+        (void)bss.mod_hallucination(randint1(10));
         if (one_in_(3)) {
             msg_print(_("あなたの身体はカオスの力で捻じ曲げられた！", "Your body is twisted by chaos!"));
             (void)gain_mutation(player_ptr, 0);
@@ -683,7 +683,7 @@ void effect_player_abyss(player_type *player_ptr, effect_player_type *ep_ptr)
 
     msg_print(_("深淵から何かがあなたを覗き込んでいる！", "Something gazes you from abyss!"));
     if (!has_resist_chaos(player_ptr)) {
-        (void)bss.hallucination(player_ptr->hallucinated + randint1(10));
+        (void)bss.mod_hallucination(randint1(10));
     }
 
     if (!has_resist_conf(player_ptr)) {

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -30,8 +30,6 @@
 #include "status/shape-changer.h"
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
-#include "timed-effect/player-cut.h"
-#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 
@@ -267,7 +265,7 @@ void effect_player_shards(player_type *player_ptr, effect_player_type *ep_ptr)
     ep_ptr->dam = ep_ptr->dam * calc_shards_damage_rate(player_ptr, CALC_RAND) / 100;
 
     if (!has_resist_shard(player_ptr) && !check_multishadow(player_ptr)) {
-        (void)BadStatusSetter(player_ptr).cut(player_ptr->effects()->cut()->current() + ep_ptr->dam);
+        (void)BadStatusSetter(player_ptr).mod_cut(static_cast<TIME_EFFECT>(ep_ptr->dam));
     }
 
     if (!has_resist_shard(player_ptr) || one_in_(13))
@@ -361,7 +359,7 @@ void effect_player_rocket(player_type *player_ptr, effect_player_type *ep_ptr)
 
     ep_ptr->dam = ep_ptr->dam * calc_rocket_damage_rate(player_ptr, CALC_RAND) / 100;
     if (!has_resist_shard(player_ptr) && !check_multishadow(player_ptr)) {
-        (void)bss.cut(player_ptr->effects()->cut()->current() + (ep_ptr->dam / 2));
+        (void)bss.mod_cut((ep_ptr->dam / 2));
     }
 
     if (!has_resist_shard(player_ptr) || one_in_(12)) {
@@ -615,7 +613,7 @@ void effect_player_icee(player_type *player_ptr, effect_player_type *ep_ptr)
 
     BadStatusSetter bss(player_ptr);
     if (!has_resist_shard(player_ptr)) {
-        (void)bss.cut(player_ptr->effects()->cut()->current() + damroll(5, 8));
+        (void)bss.mod_cut(damroll(5, 8));
     }
 
     if (!has_resist_sound(player_ptr)) {

--- a/src/effect/effect-player-spirit.cpp
+++ b/src/effect/effect-player-spirit.cpp
@@ -130,7 +130,7 @@ void effect_player_brain_smash(player_type *player_ptr, effect_player_type *ep_p
         (void)bss.mod_paralysis(randint0(4) + 4);
     }
 
-    (void)bss.slowness(player_ptr->slow + randint0(4) + 4, false);
+    (void)bss.mod_slowness(randint0(4) + 4, false);
 
     while (randint0(100 + ep_ptr->rlev / 2) > (MAX(5, player_ptr->skill_sav)))
         (void)do_dec_stat(player_ptr, A_INT);

--- a/src/effect/effect-player-spirit.cpp
+++ b/src/effect/effect-player-spirit.cpp
@@ -119,7 +119,7 @@ void effect_player_brain_smash(player_type *player_ptr, effect_player_type *ep_p
 
     BadStatusSetter bss(player_ptr);
     if (!has_resist_blind(player_ptr)) {
-        (void)bss.blindness(player_ptr->blind + 8 + randint0(8));
+        (void)bss.mod_blindness(8 + randint0(8));
     }
 
     if (!has_resist_conf(player_ptr)) {

--- a/src/effect/effect-player-spirit.cpp
+++ b/src/effect/effect-player-spirit.cpp
@@ -78,7 +78,7 @@ void effect_player_mind_blast(player_type *player_ptr, effect_player_type *ep_pt
     msg_print(_("霊的エネルギーで精神が攻撃された。", "Your mind is blasted by psionic energy."));
     BadStatusSetter bss(player_ptr);
     if (!has_resist_conf(player_ptr)) {
-        (void)bss.confusion(player_ptr->confused + randint0(4) + 4);
+        (void)bss.mod_confusion(randint0(4) + 4);
     }
 
     if (!has_resist_chaos(player_ptr) && one_in_(3)) {
@@ -123,7 +123,7 @@ void effect_player_brain_smash(player_type *player_ptr, effect_player_type *ep_p
     }
 
     if (!has_resist_conf(player_ptr)) {
-        (void)bss.confusion(player_ptr->confused + randint0(4) + 4);
+        (void)bss.mod_confusion(randint0(4) + 4);
     }
 
     if (!player_ptr->free_act) {

--- a/src/effect/effect-player-spirit.cpp
+++ b/src/effect/effect-player-spirit.cpp
@@ -82,7 +82,7 @@ void effect_player_mind_blast(player_type *player_ptr, effect_player_type *ep_pt
     }
 
     if (!has_resist_chaos(player_ptr) && one_in_(3)) {
-        (void)bss.hallucination(player_ptr->hallucinated + randint0(250) + 150);
+        (void)bss.mod_hallucination(randint0(250) + 150);
     }
 
     player_ptr->csp -= 50;
@@ -138,6 +138,6 @@ void effect_player_brain_smash(player_type *player_ptr, effect_player_type *ep_p
         (void)do_dec_stat(player_ptr, A_WIS);
 
     if (!has_resist_chaos(player_ptr)) {
-        (void)bss.hallucination(player_ptr->hallucinated + randint0(250) + 150);
+        (void)bss.mod_hallucination(randint0(250) + 150);
     }
 }

--- a/src/effect/effect-player-spirit.cpp
+++ b/src/effect/effect-player-spirit.cpp
@@ -127,7 +127,7 @@ void effect_player_brain_smash(player_type *player_ptr, effect_player_type *ep_p
     }
 
     if (!player_ptr->free_act) {
-        (void)bss.paralysis(player_ptr->paralyzed + randint0(4) + 4);
+        (void)bss.mod_paralysis(randint0(4) + 4);
     }
 
     (void)bss.slowness(player_ptr->slow + randint0(4) + 4, false);

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -324,7 +324,7 @@ static void hit_trap_pit(player_type *player_ptr, enum trap_type trap_feat_type)
     msg_format(_("%sが刺さった！", "You are impaled on %s!"), spike_name);
     dam = dam * 2;
     BadStatusSetter bss(player_ptr);
-    (void)bss.cut(player_ptr->effects()->cut()->current() + randint1(dam));
+    (void)bss.mod_cut(randint1(dam));
     if (trap_feat_type != TRAP_POISON_PIT) {
         take_hit(player_ptr, DAMAGE_NOESCAPE, dam, trap_name);
         return;

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -378,7 +378,7 @@ static void hit_trap_lose_stat(player_type *player_ptr, int stat)
 static void hit_trap_slow(player_type *player_ptr)
 {
     if (hit_trap_dart(player_ptr)) {
-        (void)BadStatusSetter(player_ptr).slowness(player_ptr->slow + randint0(20) + 20, false);
+        (void)BadStatusSetter(player_ptr).mod_slowness(randint0(20) + 20, false);
     }
 }
 

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -506,7 +506,7 @@ void hit_trap(player_type *player_ptr, bool break_trap)
     case TRAP_CONFUSE: {
         msg_print(_("きらめくガスに包み込まれた！", "A gas of scintillating colors surrounds you!"));
         if (has_resist_conf(player_ptr) == 0) {
-            (void)BadStatusSetter(player_ptr).confusion(player_ptr->confused + (TIME_EFFECT)randint0(20) + 10);
+            (void)BadStatusSetter(player_ptr).mod_confusion((TIME_EFFECT)randint0(20) + 10);
         }
 
         break;

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -499,7 +499,7 @@ void hit_trap(player_type *player_ptr, bool break_trap)
     case TRAP_BLIND:
         msg_print(_("黒いガスに包み込まれた！", "A black gas surrounds you!"));
         if (has_resist_blind(player_ptr) == 0) {
-            (void)BadStatusSetter(player_ptr).blindness(player_ptr->blind + (TIME_EFFECT)randint0(50) + 25);
+            (void)BadStatusSetter(player_ptr).mod_blindness(randint0(50) + 25);
         }
 
         break;

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -337,7 +337,7 @@ static void hit_trap_pit(player_type *player_ptr, enum trap_type trap_feat_type)
     }
 
     dam = dam * 2;
-    (void)bss.poison(player_ptr->poisoned + randint1(dam));
+    (void)bss.mod_poison(randint1(dam));
     take_hit(player_ptr, DAMAGE_NOESCAPE, dam, trap_name);
 }
 
@@ -515,7 +515,7 @@ void hit_trap(player_type *player_ptr, bool break_trap)
     case TRAP_POISON: {
         msg_print(_("刺激的な緑色のガスに包み込まれた！", "A pungent green gas surrounds you!"));
         if (has_resist_pois(player_ptr) == 0) {
-            (void)BadStatusSetter(player_ptr).poison(player_ptr->poisoned + (TIME_EFFECT)randint0(20) + 10);
+            (void)BadStatusSetter(player_ptr).mod_poison((TIME_EFFECT)randint0(20) + 10);
         }
 
         break;

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -533,7 +533,7 @@ void hit_trap(player_type *player_ptr, bool break_trap)
             sanity_blast(player_ptr, nullptr, false);
         }
 
-        (void)BadStatusSetter(player_ptr).paralysis(player_ptr->paralyzed + randint0(10) + 5);
+        (void)BadStatusSetter(player_ptr).mod_paralysis(randint0(10) + 5);
         break;
     }
 

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -506,7 +506,7 @@ void hit_trap(player_type *player_ptr, bool break_trap)
     case TRAP_CONFUSE: {
         msg_print(_("きらめくガスに包み込まれた！", "A gas of scintillating colors surrounds you!"));
         if (has_resist_conf(player_ptr) == 0) {
-            (void)BadStatusSetter(player_ptr).mod_confusion((TIME_EFFECT)randint0(20) + 10);
+            (void)BadStatusSetter(player_ptr).mod_confusion(randint0(20) + 10);
         }
 
         break;
@@ -515,7 +515,7 @@ void hit_trap(player_type *player_ptr, bool break_trap)
     case TRAP_POISON: {
         msg_print(_("刺激的な緑色のガスに包み込まれた！", "A pungent green gas surrounds you!"));
         if (has_resist_pois(player_ptr) == 0) {
-            (void)BadStatusSetter(player_ptr).mod_poison((TIME_EFFECT)randint0(20) + 10);
+            (void)BadStatusSetter(player_ptr).mod_poison(randint0(20) + 10);
         }
 
         break;

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -187,7 +187,7 @@ void process_player_hp_mp(player_type *player_ptr)
         if (deal_damege_by_feat(player_ptr, g_ptr, _("毒気を吸い込んだ！", "The gas poisons you!"), _("に毒された！", "poisons you!"), calc_acid_damage_rate,
                 [](player_type *player_ptr, int damage) {
                     if (!has_resist_pois(player_ptr))
-                        (void)BadStatusSetter(player_ptr).poison(player_ptr->poisoned + damage);
+                        (void)BadStatusSetter(player_ptr).mod_poison(static_cast<TIME_EFFECT>(damage));
                 })) {
             cave_no_regen = true;
             sound(SOUND_TERRAIN_DAMAGE);

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -317,7 +317,7 @@ static void curse_cowardice(player_type *player_ptr)
 
     disturb(player_ptr, false, true);
     msg_print(_("とても暗い... とても恐い！", "It's so dark... so scary!"));
-    (void)BadStatusSetter(player_ptr).afraidness(player_ptr->afraid + 13 + randint1(26));
+    (void)BadStatusSetter(player_ptr).mod_afraidness(13 + randint1(26));
 }
 
 /*!

--- a/src/mind/mind-blue-mage.cpp
+++ b/src/mind/mind-blue-mage.cpp
@@ -102,7 +102,7 @@ bool do_cmd_cast_learned(player_type *player_ptr)
         player_ptr->csp = 0;
         player_ptr->csp_frac = 0;
         msg_print(_("精神を集中しすぎて気を失ってしまった！", "You faint from the effort!"));
-        (void)BadStatusSetter(player_ptr).paralysis(player_ptr->paralyzed + randint1(5 * oops + 1));
+        (void)BadStatusSetter(player_ptr).mod_paralysis(randint1(5 * oops + 1));
         chg_virtue(player_ptr, V_KNOWLEDGE, -10);
         if (randint0(100) < 50) {
             bool perm = (randint0(100) < 25);

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -65,7 +65,6 @@
 #include "target/target-getter.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
-#include "timed-effect/player-cut.h"
 #include "timed-effect/player-stun.h"
 #include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
@@ -498,7 +497,7 @@ static bool cast_element_spell(player_type *player_ptr, SPELL_IDX spell_idx)
         return psychometry(player_ptr);
     case ElementSpells::CURE:
         (void)hp_player(player_ptr, damroll(2, 8));
-        (void)BadStatusSetter(player_ptr).cut(player_ptr->effects()->cut()->current() - 10);
+        (void)BadStatusSetter(player_ptr).mod_cut(10);
         break;
     case ElementSpells::BOLT_2ND:
         if (!get_aim_dir(player_ptr, &dir))

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -919,7 +919,7 @@ void do_cmd_element(player_type *player_ptr)
         player_ptr->csp = 0;
         player_ptr->csp_frac = 0;
         msg_print(_("精神を集中しすぎて気を失ってしまった！", "You faint from the effort!"));
-        (void)BadStatusSetter(player_ptr).paralysis(player_ptr->paralyzed + randint1(5 * oops + 1));
+        (void)BadStatusSetter(player_ptr).mod_paralysis(randint1(5 * oops + 1));
         chg_virtue(player_ptr, V_KNOWLEDGE, -10);
         if (randint0(100) < 50) {
             bool perm = (randint0(100) < 25);

--- a/src/monster-attack/monster-attack-lose.cpp
+++ b/src/monster-attack/monster-attack-lose.cpp
@@ -29,7 +29,7 @@ void calc_blow_disease(player_type *player_ptr, monap_type *monap_ptr)
     if (player_ptr->is_dead || check_multishadow(player_ptr))
         return;
 
-    if (!(has_resist_pois(player_ptr) || is_oppose_pois(player_ptr)) && BadStatusSetter(player_ptr).poison(player_ptr->poisoned + randint1(monap_ptr->rlev) + 5))
+    if (!(has_resist_pois(player_ptr) || is_oppose_pois(player_ptr)) && BadStatusSetter(player_ptr).mod_poison(randint1(monap_ptr->rlev) + 5))
         monap_ptr->obvious = true;
 
     bool disease_possibility = randint1(100) > calc_nuke_damage_rate(player_ptr);

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -50,8 +50,6 @@
 #include "system/monster-type-definition.h"
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
-#include "timed-effect/player-cut.h"
-#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 
@@ -170,7 +168,7 @@ static void calc_player_cut(player_type *player_ptr, monap_type *monap_ptr)
         return;
     }
 
-    auto cut_plus = 0;
+    TIME_EFFECT cut_plus = 0;
     auto criticality = calc_monster_critical(monap_ptr->d_dice, monap_ptr->d_side, monap_ptr->damage);
     switch (criticality) {
     case 0:
@@ -200,7 +198,7 @@ static void calc_player_cut(player_type *player_ptr, monap_type *monap_ptr)
     }
 
     if (cut_plus > 0) {
-        (void)BadStatusSetter(player_ptr).cut(player_ptr->effects()->cut()->current() + cut_plus);
+        (void)BadStatusSetter(player_ptr).mod_cut(cut_plus);
     }
 }
 

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -51,7 +51,6 @@
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
 #include "timed-effect/player-cut.h"
-#include "timed-effect/player-stun.h"
 #include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
@@ -211,7 +210,7 @@ static void calc_player_stun(player_type *player_ptr, monap_type *monap_ptr)
         return;
     }
 
-    auto stun_plus = 0;
+    TIME_EFFECT stun_plus = 0;
     auto criticality = calc_monster_critical(monap_ptr->d_dice, monap_ptr->d_side, monap_ptr->damage);
     switch (criticality) {
     case 0:
@@ -241,7 +240,7 @@ static void calc_player_stun(player_type *player_ptr, monap_type *monap_ptr)
     }
 
     if (stun_plus > 0) {
-        (void)BadStatusSetter(player_ptr).stun(player_ptr->effects()->stun()->current() + stun_plus);
+        (void)BadStatusSetter(player_ptr).mod_stun(stun_plus);
     }
 }
 

--- a/src/monster-attack/monster-attack-status.cpp
+++ b/src/monster-attack/monster-attack-status.cpp
@@ -35,7 +35,7 @@ void process_blind_attack(player_type *player_ptr, monap_type *monap_ptr)
         return;
     }
 
-    if (!BadStatusSetter(player_ptr).blindness(player_ptr->blind + 10 + randint1(monap_ptr->rlev))) {
+    if (!BadStatusSetter(player_ptr).mod_blindness(10 + randint1(monap_ptr->rlev))) {
         return;
     }
 

--- a/src/monster-attack/monster-attack-status.cpp
+++ b/src/monster-attack/monster-attack-status.cpp
@@ -17,7 +17,6 @@
 #include "system/monster-race-definition.h"
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
-#include "timed-effect/player-stun.h"
 #include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
@@ -128,8 +127,7 @@ void process_stun_attack(player_type *player_ptr, monap_type *monap_ptr)
     }
 
     auto *r_ptr = &r_info[monap_ptr->m_ptr->r_idx];
-    auto current_stun = player_ptr->effects()->stun()->current();
-    if (BadStatusSetter(player_ptr).stun(current_stun + 10 + randint1(r_ptr->level / 4))) {
+    if (BadStatusSetter(player_ptr).mod_stun(10 + randint1(r_ptr->level / 4))) {
         monap_ptr->obvious = true;
     }
 }

--- a/src/monster-attack/monster-attack-status.cpp
+++ b/src/monster-attack/monster-attack-status.cpp
@@ -65,7 +65,7 @@ void process_terrify_attack(player_type *player_ptr, monap_type *monap_ptr)
         return;
     }
 
-    if (BadStatusSetter(player_ptr).afraidness(player_ptr->afraid + 3 + randint1(monap_ptr->rlev))) {
+    if (BadStatusSetter(player_ptr).mod_afraidness(3 + randint1(monap_ptr->rlev))) {
         monap_ptr->obvious = true;
     }
 }

--- a/src/monster-attack/monster-attack-switcher.cpp
+++ b/src/monster-attack/monster-attack-switcher.cpp
@@ -146,7 +146,7 @@ static void calc_blow_confusion(player_type *player_ptr, monap_type *monap_ptr)
         return;
     }
 
-    if (!has_resist_conf(player_ptr) && !check_multishadow(player_ptr) && BadStatusSetter(player_ptr).confusion(player_ptr->confused + 3 + randint1(monap_ptr->rlev))) {
+    if (!has_resist_conf(player_ptr) && !check_multishadow(player_ptr) && BadStatusSetter(player_ptr).mod_confusion(3 + randint1(monap_ptr->rlev))) {
         monap_ptr->obvious = true;
     }
 

--- a/src/monster-attack/monster-attack-switcher.cpp
+++ b/src/monster-attack/monster-attack-switcher.cpp
@@ -42,7 +42,7 @@ static void calc_blow_poison(player_type *player_ptr, monap_type *monap_ptr)
         return;
 
     if (!(has_resist_pois(player_ptr) || is_oppose_pois(player_ptr)) && !check_multishadow(player_ptr)
-        && BadStatusSetter(player_ptr).poison(player_ptr->poisoned + randint1(monap_ptr->rlev) + 5))
+        && BadStatusSetter(player_ptr).mod_poison(randint1(monap_ptr->rlev) + 5))
         monap_ptr->obvious = true;
 
     monap_ptr->damage = monap_ptr->damage * calc_nuke_damage_rate(player_ptr) / 100;

--- a/src/monster-attack/monster-attack-switcher.cpp
+++ b/src/monster-attack/monster-attack-switcher.cpp
@@ -282,7 +282,7 @@ static void calc_blow_inertia(player_type *player_ptr, monap_type *monap_ptr)
     if (player_ptr->is_dead || check_multishadow(player_ptr))
         return;
 
-    if (BadStatusSetter(player_ptr).slowness(player_ptr->slow + 4 + randint0(monap_ptr->rlev / 10), false))
+    if (BadStatusSetter(player_ptr).mod_slowness(4 + randint0(monap_ptr->rlev / 10), false))
         monap_ptr->obvious = true;
 }
 

--- a/src/mspell/mspell-status.cpp
+++ b/src/mspell/mspell-status.cpp
@@ -485,7 +485,7 @@ MonsterSpellResult spell_RF5_SLOW(MONSTER_IDX m_idx, player_type *player_ptr, MO
             _("しかし効力を跳ね返した！", "You resist the effects!"), resist, saving_throw, TARGET_TYPE);
 
         if (!resist && !saving_throw) {
-            (void)BadStatusSetter(player_ptr).slowness(player_ptr->slow + randint0(4) + 4, false);
+            (void)BadStatusSetter(player_ptr).mod_slowness(randint0(4) + 4, false);
         }
 
         update_smart_learn(player_ptr, m_idx, DRS_FREE);

--- a/src/mspell/mspell-status.cpp
+++ b/src/mspell/mspell-status.cpp
@@ -240,7 +240,7 @@ MonsterSpellResult spell_RF5_SCARE(MONSTER_IDX m_idx, player_type *player_ptr, M
             _("しかし恐怖に侵されなかった。", "You refuse to be frightened."), resist, saving_throw, TARGET_TYPE);
 
         if (!resist && !saving_throw) {
-            (void)BadStatusSetter(player_ptr).afraidness(player_ptr->afraid + randint0(4) + 4);
+            (void)BadStatusSetter(player_ptr).mod_afraidness(randint0(4) + 4);
         }
 
         update_smart_learn(player_ptr, m_idx, DRS_FEAR);

--- a/src/mspell/mspell-status.cpp
+++ b/src/mspell/mspell-status.cpp
@@ -352,7 +352,7 @@ MonsterSpellResult spell_RF5_CONF(MONSTER_IDX m_idx, player_type *player_ptr, MO
             _("しかし幻覚にはだまされなかった。", "You disbelieve the feeble spell."), resist, saving_throw, TARGET_TYPE);
 
         if (!resist && !saving_throw) {
-            (void)BadStatusSetter(player_ptr).confusion(player_ptr->confused + randint0(4) + 4);
+            (void)BadStatusSetter(player_ptr).mod_confusion(randint0(4) + 4);
         }
 
         update_smart_learn(player_ptr, m_idx, DRS_CONF);

--- a/src/mspell/mspell-status.cpp
+++ b/src/mspell/mspell-status.cpp
@@ -403,7 +403,7 @@ MonsterSpellResult spell_RF5_HOLD(MONSTER_IDX m_idx, player_type *player_ptr, MO
             _("しかし効力を跳ね返した！", "You resist the effects!"), (bool)resist, saving_throw, TARGET_TYPE);
 
         if (!resist && !saving_throw) {
-            (void)BadStatusSetter(player_ptr).paralysis(player_ptr->paralyzed + randint0(4) + 4);
+            (void)BadStatusSetter(player_ptr).mod_paralysis(randint0(4) + 4);
         }
 
         update_smart_learn(player_ptr, m_idx, DRS_FREE);

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -131,7 +131,7 @@ void process_world_aux_mutation(player_type *player_ptr)
         if (!has_resist_fear(player_ptr)) {
             disturb(player_ptr, false, true);
             msg_print(_("とても暗い... とても恐い！", "It's so dark... so scary!"));
-            (void)bss.afraidness(player_ptr->afraid + 13 + randint1(26));
+            (void)bss.mod_afraidness(13 + randint1(26));
         }
     }
 

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -169,7 +169,7 @@ void process_world_aux_mutation(player_type *player_ptr)
             } else {
                 if (one_in_(3)) {
                     msg_print(_("き～れいなちょおちょらとんれいる～", "Thishcischs GooDSChtuff!"));
-                    (void)bss.hallucination(player_ptr->hallucinated + randint0(150) + 150);
+                    (void)bss.mod_hallucination(randint0(150) + 150);
                 }
             }
         }
@@ -179,7 +179,7 @@ void process_world_aux_mutation(player_type *player_ptr)
         if (!has_resist_chaos(player_ptr)) {
             disturb(player_ptr, false, true);
             player_ptr->redraw |= PR_EXTRA;
-            (void)bss.hallucination(player_ptr->hallucinated + randint0(50) + 20);
+            (void)bss.mod_hallucination(randint0(50) + 20);
         }
     }
 

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -152,7 +152,7 @@ void process_world_aux_mutation(player_type *player_ptr)
         }
 
         if (!has_resist_conf(player_ptr)) {
-            (void)bss.confusion(player_ptr->confused + randint0(20) + 15);
+            (void)bss.mod_confusion(randint0(20) + 15);
         }
 
         if (!has_resist_chaos(player_ptr)) {

--- a/src/object-use/quaff-execution.cpp
+++ b/src/object-use/quaff-execution.cpp
@@ -199,7 +199,7 @@ void exe_quaff_potion(player_type *player_ptr, INVENTORY_IDX item)
         }
         case SV_POTION_POISON:
             if (!(has_resist_pois(player_ptr) || is_oppose_pois(player_ptr))) {
-                if (BadStatusSetter(player_ptr).poison(player_ptr->poisoned + randint0(15) + 10)) {
+                if (BadStatusSetter(player_ptr).mod_poison(randint0(15) + 10)) {
                     ident = true;
                 }
             }

--- a/src/object-use/quaff-execution.cpp
+++ b/src/object-use/quaff-execution.cpp
@@ -76,7 +76,7 @@ static bool booze(player_type *player_ptr)
         return ident;
     }
 
-    if (one_in_(2) && bss.hallucination(player_ptr->hallucinated + randint0(150) + 150)) {
+    if (one_in_(2) && bss.mod_hallucination(randint0(150) + 150)) {
         ident = true;
     }
 

--- a/src/object-use/quaff-execution.cpp
+++ b/src/object-use/quaff-execution.cpp
@@ -193,7 +193,7 @@ void exe_quaff_potion(player_type *player_ptr, INVENTORY_IDX item)
 
             BadStatusSetter bss(player_ptr);
             (void)bss.poison(0);
-            (void)bss.paralysis(player_ptr->paralyzed + 4);
+            (void)bss.mod_paralysis(4);
             ident = true;
             break;
         }
@@ -228,7 +228,7 @@ void exe_quaff_potion(player_type *player_ptr, INVENTORY_IDX item)
                 sanity_blast(player_ptr, nullptr, false);
             }
 
-            if (BadStatusSetter(player_ptr).paralysis(player_ptr->paralyzed + randint0(4) + 4)) {
+            if (BadStatusSetter(player_ptr).mod_paralysis(randint0(4) + 4)) {
                 ident = true;
             }
 

--- a/src/object-use/quaff-execution.cpp
+++ b/src/object-use/quaff-execution.cpp
@@ -207,7 +207,7 @@ void exe_quaff_potion(player_type *player_ptr, INVENTORY_IDX item)
 
         case SV_POTION_BLINDNESS:
             if (!has_resist_blind(player_ptr)) {
-                if (BadStatusSetter(player_ptr).blindness(player_ptr->blind + randint0(100) + 100)) {
+                if (BadStatusSetter(player_ptr).mod_blindness(randint0(100) + 100)) {
                     ident = true;
                 }
             }

--- a/src/object-use/quaff-execution.cpp
+++ b/src/object-use/quaff-execution.cpp
@@ -49,8 +49,6 @@
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
-#include "timed-effect/player-cut.h"
-#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
 /*!
@@ -105,9 +103,8 @@ static bool detonation(player_type *player_ptr)
     msg_print(_("体の中で激しい爆発が起きた！", "Massive explosions rupture your body!"));
     take_hit(player_ptr, DAMAGE_NOESCAPE, damroll(50, 20), _("爆発の薬", "a potion of Detonation"));
     BadStatusSetter bss(player_ptr);
-    auto effects = player_ptr->effects();
     (void)bss.mod_stun(75);
-    (void)bss.cut(effects->cut()->current() + 5000);
+    (void)bss.mod_cut(5000);
     return true;
 }
 

--- a/src/object-use/quaff-execution.cpp
+++ b/src/object-use/quaff-execution.cpp
@@ -50,7 +50,6 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "timed-effect/player-cut.h"
-#include "timed-effect/player-stun.h"
 #include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
@@ -107,7 +106,7 @@ static bool detonation(player_type *player_ptr)
     take_hit(player_ptr, DAMAGE_NOESCAPE, damroll(50, 20), _("爆発の薬", "a potion of Detonation"));
     BadStatusSetter bss(player_ptr);
     auto effects = player_ptr->effects();
-    (void)bss.stun(effects->stun()->current() + 75);
+    (void)bss.mod_stun(75);
     (void)bss.cut(effects->cut()->current() + 5000);
     return true;
 }

--- a/src/object-use/read-execution.cpp
+++ b/src/object-use/read-execution.cpp
@@ -107,7 +107,7 @@ void exe_read(player_type *player_ptr, INVENTORY_IDX item, bool known)
         switch (o_ptr->sval) {
         case SV_SCROLL_DARKNESS: {
             if (!has_resist_blind(player_ptr) && !has_resist_dark(player_ptr))
-                (void)BadStatusSetter(player_ptr).blindness(player_ptr->blind + 3 + randint1(5));
+                (void)BadStatusSetter(player_ptr).mod_blindness(3 + randint1(5));
 
             if (unlite_area(player_ptr, 10, 3))
                 ident = true;

--- a/src/player/digestion-processor.cpp
+++ b/src/player/digestion-processor.cpp
@@ -55,7 +55,7 @@ void starve_player(player_type *player_ptr)
     if (!player_ptr->paralyzed && (randint0(100) < 10)) {
         msg_print(_("あまりにも空腹で気絶してしまった。", "You faint from the lack of food."));
         disturb(player_ptr, true, true);
-        (void)BadStatusSetter(player_ptr).paralysis(player_ptr->paralyzed + 1 + randint0(5));
+        (void)BadStatusSetter(player_ptr).mod_paralysis(1 + randint0(5));
     }
 
     if (player_ptr->food < PY_FOOD_STARVE) {

--- a/src/player/eldritch-horror.cpp
+++ b/src/player/eldritch-horror.cpp
@@ -123,7 +123,7 @@ void sanity_blast(player_type *player_ptr, monster_type *m_ptr, bool necro)
             msg_format(_("%s%sの顔を見てしまった！", "You behold the %s visage of %s!"), funny_desc[randint0(MAX_SAN_FUNNY)], m_name);
             if (one_in_(3)) {
                 msg_print(funny_comments[randint0(MAX_SAN_COMMENT)]);
-                BadStatusSetter(player_ptr).hallucination(player_ptr->hallucinated + randint1(r_ptr->level));
+                BadStatusSetter(player_ptr).mod_hallucination(randint1(r_ptr->level));
             }
 
             return;
@@ -173,7 +173,7 @@ void sanity_blast(player_type *player_ptr, monster_type *m_ptr, bool necro)
             msg_format(_("%s%sの顔を見てしまった！", "You behold the %s visage of %s!"), funny_desc[randint0(MAX_SAN_FUNNY)], m_name);
             if (one_in_(3)) {
                 msg_print(funny_comments[randint0(MAX_SAN_COMMENT)]);
-                BadStatusSetter(player_ptr).hallucination(player_ptr->hallucinated + randint1(r_ptr->level));
+                BadStatusSetter(player_ptr).mod_hallucination(randint1(r_ptr->level));
             }
 
             return;
@@ -264,7 +264,7 @@ void sanity_blast(player_type *player_ptr, monster_type *m_ptr, bool necro)
         }
 
         if (!has_resist_chaos(player_ptr) && one_in_(3)) {
-            (void)bss.hallucination(player_ptr->hallucinated + randint0(250) + 150);
+            (void)bss.mod_hallucination(randint0(250) + 150);
         }
 
         /*!< @todo いつからかは不明だがreturnとbreakが同時に存在している。どちらがデッドコードか不明瞭なので保留 */
@@ -282,7 +282,7 @@ void sanity_blast(player_type *player_ptr, monster_type *m_ptr, bool necro)
             (void)bss.mod_paralysis(randint0(4) + 4);
         }
         if (!has_resist_chaos(player_ptr)) {
-            (void)bss.hallucination(player_ptr->hallucinated + randint0(250) + 150);
+            (void)bss.mod_hallucination(randint0(250) + 150);
         }
 
         do {

--- a/src/player/eldritch-horror.cpp
+++ b/src/player/eldritch-horror.cpp
@@ -279,7 +279,7 @@ void sanity_blast(player_type *player_ptr, monster_type *m_ptr, bool necro)
             (void)bss.mod_confusion(randint0(4) + 4);
         }
         if (!player_ptr->free_act) {
-            (void)bss.paralysis(player_ptr->paralyzed + randint0(4) + 4);
+            (void)bss.mod_paralysis(randint0(4) + 4);
         }
         if (!has_resist_chaos(player_ptr)) {
             (void)bss.hallucination(player_ptr->hallucinated + randint0(250) + 150);

--- a/src/player/eldritch-horror.cpp
+++ b/src/player/eldritch-horror.cpp
@@ -260,7 +260,7 @@ void sanity_blast(player_type *player_ptr, monster_type *m_ptr, bool necro)
     case 12: {
         BadStatusSetter bss(player_ptr);
         if (!has_resist_conf(player_ptr)) {
-            (void)bss.confusion(player_ptr->confused + randint0(4) + 4);
+            (void)bss.mod_confusion(randint0(4) + 4);
         }
 
         if (!has_resist_chaos(player_ptr) && one_in_(3)) {
@@ -276,7 +276,7 @@ void sanity_blast(player_type *player_ptr, monster_type *m_ptr, bool necro)
     case 15: {
         BadStatusSetter bss(player_ptr);
         if (!has_resist_conf(player_ptr)) {
-            (void)bss.confusion(player_ptr->confused + randint0(4) + 4);
+            (void)bss.mod_confusion(randint0(4) + 4);
         }
         if (!player_ptr->free_act) {
             (void)bss.paralysis(player_ptr->paralyzed + randint0(4) + 4);

--- a/src/specific-object/chest.cpp
+++ b/src/specific-object/chest.cpp
@@ -192,7 +192,7 @@ void chest_trap(player_type *player_ptr, POSITION y, POSITION x, OBJECT_IDX o_id
     if (trap & (CHEST_PARALYZE)) {
         msg_print(_("突如吹き出した黄色いガスに包み込まれた！", "A puff of yellow gas surrounds you!"));
         if (!player_ptr->free_act) {
-            (void)BadStatusSetter(player_ptr).paralysis(player_ptr->paralyzed + 10 + randint1(20));
+            (void)BadStatusSetter(player_ptr).mod_paralysis(10 + randint1(20));
         }
     }
 
@@ -286,7 +286,7 @@ void chest_trap(player_type *player_ptr, POSITION y, POSITION x, OBJECT_IDX o_id
             
             if (one_in_(4)) {
                 if (!player_ptr->free_act) {
-                    (void)bss.paralysis(player_ptr->paralyzed + 2 + randint0(6));
+                    (void)bss.mod_paralysis(2 + randint0(6));
                 } else {
                     (void)bss.stun(effects->stun()->current() + 10 + randint0(100));
                 }

--- a/src/specific-object/chest.cpp
+++ b/src/specific-object/chest.cpp
@@ -26,7 +26,6 @@
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
 #include "timed-effect/player-cut.h"
-#include "timed-effect/player-stun.h"
 #include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
@@ -288,7 +287,7 @@ void chest_trap(player_type *player_ptr, POSITION y, POSITION x, OBJECT_IDX o_id
                 if (!player_ptr->free_act) {
                     (void)bss.mod_paralysis(2 + randint0(6));
                 } else {
-                    (void)bss.stun(effects->stun()->current() + 10 + randint0(100));
+                    (void)bss.mod_stun(10 + randint0(100));
                 }
 
                 continue;

--- a/src/specific-object/chest.cpp
+++ b/src/specific-object/chest.cpp
@@ -25,8 +25,6 @@
 #include "system/floor-type-definition.h"
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
-#include "timed-effect/player-cut.h"
-#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
 /*!< この値以降の小項目IDを持った箱は大型の箱としてドロップ数を増やす / Special "sval" limit -- first "large" chest */
@@ -277,9 +275,8 @@ void chest_trap(player_type *player_ptr, POSITION y, POSITION x, OBJECT_IDX o_id
             }
             
             BadStatusSetter bss(player_ptr);
-            auto effects = player_ptr->effects();
             if (one_in_(5)) {
-                (void)bss.cut(effects->cut()->current() + 200);
+                (void)bss.mod_cut(200);
                 continue;
             }
             

--- a/src/specific-object/chest.cpp
+++ b/src/specific-object/chest.cpp
@@ -184,7 +184,7 @@ void chest_trap(player_type *player_ptr, POSITION y, POSITION x, OBJECT_IDX o_id
     if (trap & (CHEST_POISON)) {
         msg_print(_("突如吹き出した緑色のガスに包み込まれた！", "A puff of green gas surrounds you!"));
         if (!(has_resist_pois(player_ptr) || is_oppose_pois(player_ptr))) {
-            (void)BadStatusSetter(player_ptr).poison(player_ptr->poisoned + 10 + randint1(20));
+            (void)BadStatusSetter(player_ptr).mod_poison(10 + randint1(20));
         }
     }
 

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -36,8 +36,6 @@
 #include "system/monster-race-definition.h"
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
-#include "timed-effect/player-stun.h"
-#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 
@@ -139,8 +137,6 @@ bool earthquake(player_type *player_ptr, POSITION cy, POSITION cx, POSITION r, M
             msg_print(_("あなたはひどい怪我を負った！", "You are severely crushed!"));
             damage = 200;
         } else {
-            auto effects = player_ptr->effects();
-            auto stun_value = effects->stun()->current();
             BadStatusSetter bss(player_ptr);
             switch (randint1(3)) {
             case 1: {
@@ -151,13 +147,13 @@ bool earthquake(player_type *player_ptr, POSITION cy, POSITION cx, POSITION r, M
             case 2: {
                 msg_print(_("岩石があなたに直撃した!", "You are bashed by rubble!"));
                 damage = damroll(10, 4);
-                (void)bss.stun(stun_value + randint1(50));
+                (void)bss.mod_stun(randint1(50));
                 break;
             }
             case 3: {
                 msg_print(_("あなたは床と壁との間に挟まれてしまった！", "You are crushed between the floor and ceiling!"));
                 damage = damroll(10, 4);
-                (void)bss.stun(stun_value + randint1(50));
+                (void)bss.mod_stun(randint1(50));
                 break;
             }
             }

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -444,7 +444,7 @@ bool destroy_area(player_type *player_ptr, POSITION y1, POSITION x1, POSITION r,
     if (flag) {
         msg_print(_("燃えるような閃光が発生した！", "There is a searing blast of light!"));
         if (!has_resist_blind(player_ptr) && !has_resist_lite(player_ptr)) {
-            (void)BadStatusSetter(player_ptr).blindness(player_ptr->blind + 10 + randint1(10));
+            (void)BadStatusSetter(player_ptr).mod_blindness(10 + randint1(10));
         }
     }
 

--- a/src/spell-kind/spells-random.cpp
+++ b/src/spell-kind/spells-random.cpp
@@ -183,7 +183,7 @@ bool activate_ty_curse(player_type *player_ptr, bool stop_ty, int *count)
             is_statue |= player_ptr->pclass == CLASS_BERSERKER;
             if (!is_statue) {
                 msg_print(_("彫像になった気分だ！", "You feel like a statue!"));
-                auto turns = player_ptr->free_act ? randint1(3) : randint1(13);
+                TIME_EFFECT turns = player_ptr->free_act ? randint1(3) : randint1(13);
                 (void)BadStatusSetter(player_ptr).mod_paralysis(turns);
                 stop_ty = true;
             }

--- a/src/spell-kind/spells-random.cpp
+++ b/src/spell-kind/spells-random.cpp
@@ -184,7 +184,7 @@ bool activate_ty_curse(player_type *player_ptr, bool stop_ty, int *count)
             if (!is_statue) {
                 msg_print(_("彫像になった気分だ！", "You feel like a statue!"));
                 auto turns = player_ptr->free_act ? randint1(3) : randint1(13);
-                (void)BadStatusSetter(player_ptr).paralysis(player_ptr->paralyzed + turns);
+                (void)BadStatusSetter(player_ptr).mod_paralysis(turns);
                 stop_ty = true;
             }
 

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -380,7 +380,7 @@ bool perilous_secrets(player_type *player_ptr)
             player_ptr->csp_frac = 0;
             msg_print(_("石を制御できない！", "You are too weak to control the stone!"));
             (void)bss.paralysis(player_ptr->paralyzed + randint1(5 * oops + 1));
-            (void)bss.confusion(player_ptr->confused + randint1(5 * oops + 1));
+            (void)bss.mod_confusion(randint1(5 * oops + 1));
         }
 
         player_ptr->redraw |= (PR_MANA);
@@ -389,7 +389,7 @@ bool perilous_secrets(player_type *player_ptr)
     take_hit(player_ptr, DAMAGE_LOSELIFE, damroll(1, 12), _("危険な秘密", "perilous secrets"));
 
     if (one_in_(5))
-        (void)bss.confusion(player_ptr->confused + randint1(10));
+        (void)bss.mod_confusion(randint1(10));
 
     if (one_in_(20))
         take_hit(player_ptr, DAMAGE_LOSELIFE, damroll(4, 10), _("危険な秘密", "perilous secrets"));

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -379,7 +379,7 @@ bool perilous_secrets(player_type *player_ptr)
             player_ptr->csp = 0;
             player_ptr->csp_frac = 0;
             msg_print(_("石を制御できない！", "You are too weak to control the stone!"));
-            (void)bss.paralysis(player_ptr->paralyzed + randint1(5 * oops + 1));
+            (void)bss.mod_paralysis(randint1(5 * oops + 1));
             (void)bss.mod_confusion(randint1(5 * oops + 1));
         }
 

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -571,9 +571,9 @@ bool cosmic_cast_off(player_type *player_ptr, object_type **o_ptr_ptr)
 
     /* Get effects */
     msg_print(_("「燃え上がれ俺の小宇宙！」", "You say, 'Burn up my cosmo!"));
-    int t = 20 + randint1(20);
+    TIME_EFFECT t = 20 + randint1(20);
     BadStatusSetter bss(player_ptr);
-    (void)bss.blindness(player_ptr->blind + t);
+    (void)bss.mod_blindness(t);
     (void)bss.afraidness(0);
     (void)set_tim_esp(player_ptr, player_ptr->tim_esp + t, false);
     (void)set_tim_regen(player_ptr, player_ptr->tim_regen + t, false);

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -347,7 +347,7 @@ bool cure_light_wounds(player_type *player_ptr, DICE_NUMBER dice, DICE_SID sides
         ident = true;
     }
 
-    if (bss.cut(player_ptr->effects()->cut()->current() - 10)) {
+    if (bss.mod_cut(-10)) {
         ident = true;
     }
 

--- a/src/spell/spells-summon.cpp
+++ b/src/spell/spells-summon.cpp
@@ -459,7 +459,7 @@ void cast_invoke_spirits(player_type *player_ptr, DIRECTION dir)
         (void)bss.afraidness(player_ptr->afraid + randint1(4) + 4);
     } else if (die < 26) {
         msg_print(_("あなたの頭に大量の幽霊たちの騒々しい声が押し寄せてきた...", "Your head is invaded by a horde of gibbering spectral voices..."));
-        (void)bss.confusion(player_ptr->confused + randint1(4) + 4);
+        (void)bss.mod_confusion(randint1(4) + 4);
     } else if (die < 31) {
         poly_monster(player_ptr, dir, plev);
     } else if (die < 36) {

--- a/src/spell/spells-summon.cpp
+++ b/src/spell/spells-summon.cpp
@@ -456,7 +456,7 @@ void cast_invoke_spirits(player_type *player_ptr, DIRECTION dir)
         chg_virtue(player_ptr, V_UNLIFE, 1);
     } else if (die < 14) {
         msg_print(_("名状し難い邪悪な存在があなたの心を通り過ぎて行った...", "An unnamable evil brushes against your mind..."));
-        (void)bss.afraidness(player_ptr->afraid + randint1(4) + 4);
+        (void)bss.mod_afraidness(randint1(4) + 4);
     } else if (die < 26) {
         msg_print(_("あなたの頭に大量の幽霊たちの騒々しい声が押し寄せてきた...", "Your head is invaded by a horde of gibbering spectral voices..."));
         (void)bss.mod_confusion(randint1(4) + 4);

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -166,6 +166,11 @@ bool BadStatusSetter::confusion(const TIME_EFFECT tmp_v)
     return true;
 }
 
+bool BadStatusSetter::mod_confusion(const TIME_EFFECT tmp_v)
+{
+    return this->confusion(this->player_ptr->confused + tmp_v);
+}
+
 /*!
  * @brief 毒の継続時間をセットする / Set "poisoned", notice observable changes
  * @param v 継続時間

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -467,6 +467,11 @@ bool BadStatusSetter::stun(const TIME_EFFECT tmp_v)
     return true;
 }
 
+bool BadStatusSetter::mod_stun(const TIME_EFFECT tmp_v)
+{
+    return this->stun(this->player_ptr->effects()->stun()->current() + tmp_v);
+}
+
 /*!
  * @brief 出血の継続時間をセットする / Set "cut", notice observable changes
  * @param v 継続時間

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -506,6 +506,11 @@ bool BadStatusSetter::cut(const TIME_EFFECT tmp_v)
     return true;
 }
 
+bool BadStatusSetter::mod_cut(const TIME_EFFECT tmp_v)
+{
+    return this->cut(this->player_ptr->effects()->cut()->current() + tmp_v);
+}
+
 bool BadStatusSetter::process_stun_effect(const short v)
 {
     auto old_rank = this->player_ptr->effects()->stun()->get_rank();

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -428,6 +428,11 @@ bool BadStatusSetter::slowness(const TIME_EFFECT tmp_v, bool do_dec)
     return true;
 }
 
+bool BadStatusSetter::mod_slowness(const TIME_EFFECT tmp_v, bool do_dec)
+{
+    return this->slowness(this->player_ptr->slow + tmp_v, do_dec);
+}
+
 /*!
  * @brief 朦朧の継続時間をセットする / Set "stun", notice observable changes
  * @param v 継続時間

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -379,6 +379,11 @@ bool BadStatusSetter::hallucination(const TIME_EFFECT tmp_v)
     return true;
 }
 
+bool BadStatusSetter::mod_hallucination(const TIME_EFFECT tmp_v)
+{
+    return this->hallucination(this->player_ptr->hallucinated + tmp_v);
+}
+
 /*!
  * @brief 減速の継続時間をセットする / Set "slow", notice observable changes
  * @param v 継続時間

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -266,6 +266,11 @@ bool BadStatusSetter::afraidness(const TIME_EFFECT tmp_v)
     return true;
 }
 
+bool BadStatusSetter::mod_afraidness(const TIME_EFFECT tmp_v)
+{
+    return this->afraidness(this->player_ptr->afraid + tmp_v);
+}
+
 /*!
  * @brief 麻痺の継続時間をセットする / Set "paralyzed", notice observable changes
  * @param v 継続時間

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -210,6 +210,11 @@ bool BadStatusSetter::poison(const TIME_EFFECT tmp_v)
     return true;
 }
 
+bool BadStatusSetter::mod_poison(const TIME_EFFECT tmp_v)
+{
+    return this->poison(this->player_ptr->poisoned + tmp_v);
+}
+
 /*!
  * @brief 恐怖の継続時間をセットする / Set "afraid", notice observable changes
  * @param v 継続時間

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -86,6 +86,11 @@ bool BadStatusSetter::blindness(const TIME_EFFECT tmp_v)
     return true;
 }
 
+bool BadStatusSetter::mod_blindness(const TIME_EFFECT tmp_v)
+{
+    return this->blindness(this->player_ptr->blind + tmp_v);
+}
+
 /*!
  * @brief 混乱の継続時間をセットする / Set "confused", notice observable changes
  * @param v 継続時間

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -321,6 +321,11 @@ bool BadStatusSetter::paralysis(const TIME_EFFECT tmp_v)
     return true;
 }
 
+bool BadStatusSetter::mod_paralysis(const TIME_EFFECT tmp_v)
+{
+    return this->paralysis(this->player_ptr->paralyzed + tmp_v);
+}
+
 /*!
  * @brief 幻覚の継続時間をセットする / Set "image", notice observable changes
  * @param v 継続時間

--- a/src/status/bad-status-setter.h
+++ b/src/status/bad-status-setter.h
@@ -17,6 +17,7 @@ public:
     bool blindness(const TIME_EFFECT tmp_v);
     bool mod_blindness(const TIME_EFFECT tmp_v);
     bool confusion(const TIME_EFFECT tmp_v);
+    bool mod_confusion(const TIME_EFFECT tmp_v);
     bool poison(const TIME_EFFECT tmp_v);
     bool afraidness(const TIME_EFFECT tmp_v);
     bool paralysis(const TIME_EFFECT tmp_v);

--- a/src/status/bad-status-setter.h
+++ b/src/status/bad-status-setter.h
@@ -29,6 +29,7 @@ public:
     bool slowness(const TIME_EFFECT tmp_v, bool do_dec);
     bool mod_slowness(const TIME_EFFECT tmp_v, bool do_dec);
     bool stun(const TIME_EFFECT tmp_v);
+    bool mod_stun(const TIME_EFFECT tmp_v);
     bool cut(const TIME_EFFECT tmp_v);
 
 private:

--- a/src/status/bad-status-setter.h
+++ b/src/status/bad-status-setter.h
@@ -27,6 +27,7 @@ public:
     bool hallucination(const TIME_EFFECT tmp_v);
     bool mod_hallucination(const TIME_EFFECT tmp_v);
     bool slowness(const TIME_EFFECT tmp_v, bool do_dec);
+    bool mod_slowness(const TIME_EFFECT tmp_v, bool do_dec);
     bool stun(const TIME_EFFECT tmp_v);
     bool cut(const TIME_EFFECT tmp_v);
 

--- a/src/status/bad-status-setter.h
+++ b/src/status/bad-status-setter.h
@@ -23,6 +23,7 @@ public:
     bool afraidness(const TIME_EFFECT tmp_v);
     bool mod_afraidness(const TIME_EFFECT tmp_v);
     bool paralysis(const TIME_EFFECT tmp_v);
+    bool mod_paralysis(const TIME_EFFECT tmp_v);
     bool hallucination(const TIME_EFFECT tmp_v);
     bool slowness(const TIME_EFFECT tmp_v, bool do_dec);
     bool stun(const TIME_EFFECT tmp_v);

--- a/src/status/bad-status-setter.h
+++ b/src/status/bad-status-setter.h
@@ -25,6 +25,7 @@ public:
     bool paralysis(const TIME_EFFECT tmp_v);
     bool mod_paralysis(const TIME_EFFECT tmp_v);
     bool hallucination(const TIME_EFFECT tmp_v);
+    bool mod_hallucination(const TIME_EFFECT tmp_v);
     bool slowness(const TIME_EFFECT tmp_v, bool do_dec);
     bool stun(const TIME_EFFECT tmp_v);
     bool cut(const TIME_EFFECT tmp_v);

--- a/src/status/bad-status-setter.h
+++ b/src/status/bad-status-setter.h
@@ -19,6 +19,7 @@ public:
     bool confusion(const TIME_EFFECT tmp_v);
     bool mod_confusion(const TIME_EFFECT tmp_v);
     bool poison(const TIME_EFFECT tmp_v);
+    bool mod_poison(const TIME_EFFECT tmp_v);
     bool afraidness(const TIME_EFFECT tmp_v);
     bool paralysis(const TIME_EFFECT tmp_v);
     bool hallucination(const TIME_EFFECT tmp_v);

--- a/src/status/bad-status-setter.h
+++ b/src/status/bad-status-setter.h
@@ -31,6 +31,7 @@ public:
     bool stun(const TIME_EFFECT tmp_v);
     bool mod_stun(const TIME_EFFECT tmp_v);
     bool cut(const TIME_EFFECT tmp_v);
+    bool mod_cut(const TIME_EFFECT tmp_v);
 
 private:
     player_type *player_ptr;

--- a/src/status/bad-status-setter.h
+++ b/src/status/bad-status-setter.h
@@ -21,6 +21,7 @@ public:
     bool poison(const TIME_EFFECT tmp_v);
     bool mod_poison(const TIME_EFFECT tmp_v);
     bool afraidness(const TIME_EFFECT tmp_v);
+    bool mod_afraidness(const TIME_EFFECT tmp_v);
     bool paralysis(const TIME_EFFECT tmp_v);
     bool hallucination(const TIME_EFFECT tmp_v);
     bool slowness(const TIME_EFFECT tmp_v, bool do_dec);

--- a/src/status/bad-status-setter.h
+++ b/src/status/bad-status-setter.h
@@ -15,6 +15,7 @@ public:
     virtual ~BadStatusSetter() = default;
     
     bool blindness(const TIME_EFFECT tmp_v);
+    bool mod_blindness(const TIME_EFFECT tmp_v);
     bool confusion(const TIME_EFFECT tmp_v);
     bool poison(const TIME_EFFECT tmp_v);
     bool afraidness(const TIME_EFFECT tmp_v);

--- a/src/status/shape-changer.cpp
+++ b/src/status/shape-changer.cpp
@@ -43,7 +43,7 @@ void do_poly_wounds(player_type *player_ptr)
     hp_player(player_ptr, change);
     BadStatusSetter bss(player_ptr);
     if (!nasty_effect) {
-        (void)bss.cut(player_cut->current() - (change / 2));
+        (void)bss.mod_cut(change / 2);
         return;
     }
 


### PR DESCRIPTION
BadStatusSetter::hoge(player\_ptr->hoge + x); を
BadStatusSetter::mod\_hoge(x); に置換しました
mod\_hoge() の方ではhoge() の呼び出しをラップしています

副次的にカプセル化が強まって、一部のヘッダインクルードを削除することができました
ご確認下さい