### PR TITLE
calc_monster_critical() を廃止してPlayerCut/PlayerStun::get_accumulation()/get_accumulation_rank() に個別定義した

### DIFF
--- a/src/combat/attack-criticality.cpp
+++ b/src/combat/attack-criticality.cpp
@@ -75,51 +75,6 @@ HIT_POINT critical_norm(player_type *player_ptr, WEIGHT weight, int plus, HIT_PO
 }
 
 /*!
- * @brief モンスター打撃のクリティカルランクを返す /
- * Critical blow. All hits that do 95% of total possible damage,
- * @param dice モンスター打撃のダイス数
- * @param sides モンスター打撃の最大ダイス目
- * @param dam プレイヤーに与えたダメージ
- * @details
- * and which also do at least 20 damage, or, sometimes, N damage.
- * This is used only to determine "cuts" and "stuns".
- */
-int calc_monster_critical(DICE_NUMBER dice, DICE_SID sides, HIT_POINT dam)
-{
-    int total = dice * sides;
-    if (dam < total * 19 / 20)
-        return 0;
-
-    if ((dam < 20) && (randint0(100) >= dam))
-        return 0;
-
-    int max = 0;
-    if ((dam >= total) && (dam >= 40))
-        max++;
-
-    if (dam >= 20)
-        while (randint0(100) < 2)
-            max++;
-
-    if (dam > 45)
-        return (6 + max);
-
-    if (dam > 33)
-        return (5 + max);
-
-    if (dam > 25)
-        return (4 + max);
-
-    if (dam > 18)
-        return (3 + max);
-
-    if (dam > 11)
-        return (2 + max);
-
-    return (1 + max);
-}
-
-/*!
  * @brief 忍者ヒットで急所を突く
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param pa_ptr 直接攻撃構造体への参照ポインタ

--- a/src/combat/attack-criticality.h
+++ b/src/combat/attack-criticality.h
@@ -10,5 +10,4 @@ struct player_attack_type;
 struct player_type;
 std::tuple<HIT_POINT, concptr, sound_type> apply_critical_norm_damage(int k, HIT_POINT base_dam);
 HIT_POINT critical_norm(player_type *player_ptr, WEIGHT weight, int plus, HIT_POINT dam, int16_t meichuu, combat_options mode, bool impact = false);
-int calc_monster_critical(DICE_NUMBER dice, DICE_SID sides, HIT_POINT dam);
 void critical_attack(player_type *player_ptr, player_attack_type *pa_ptr);

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -50,6 +50,7 @@
 #include "system/monster-type-definition.h"
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-cut.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 
@@ -168,35 +169,7 @@ static void calc_player_cut(player_type *player_ptr, monap_type *monap_ptr)
         return;
     }
 
-    TIME_EFFECT cut_plus = 0;
-    auto criticality = calc_monster_critical(monap_ptr->d_dice, monap_ptr->d_side, monap_ptr->damage);
-    switch (criticality) {
-    case 0:
-        cut_plus = 0;
-        break;
-    case 1:
-        cut_plus = randint1(5);
-        break;
-    case 2:
-        cut_plus = randint1(5) + 5;
-        break;
-    case 3:
-        cut_plus = randint1(20) + 20;
-        break;
-    case 4:
-        cut_plus = randint1(50) + 50;
-        break;
-    case 5:
-        cut_plus = randint1(100) + 100;
-        break;
-    case 6:
-        cut_plus = 300;
-        break;
-    default:
-        cut_plus = 500;
-        break;
-    }
-
+    auto cut_plus = PlayerCut::get_accumulation(monap_ptr->d_dice * monap_ptr->d_side, monap_ptr->damage);
     if (cut_plus > 0) {
         (void)BadStatusSetter(player_ptr).mod_cut(cut_plus);
     }

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -51,6 +51,7 @@
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
 #include "timed-effect/player-cut.h"
+#include "timed-effect/player-stun.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 
@@ -181,35 +182,8 @@ static void calc_player_stun(player_type *player_ptr, monap_type *monap_ptr)
         return;
     }
 
-    TIME_EFFECT stun_plus = 0;
-    auto criticality = calc_monster_critical(monap_ptr->d_dice, monap_ptr->d_side, monap_ptr->damage);
-    switch (criticality) {
-    case 0:
-        stun_plus = 0;
-        break;
-    case 1:
-        stun_plus = randint1(5);
-        break;
-    case 2:
-        stun_plus = randint1(5) + 10;
-        break;
-    case 3:
-        stun_plus = randint1(10) + 20;
-        break;
-    case 4:
-        stun_plus = randint1(15) + 30;
-        break;
-    case 5:
-        stun_plus = randint1(20) + 40;
-        break;
-    case 6:
-        stun_plus = 80;
-        break;
-    default:
-        stun_plus = 150;
-        break;
-    }
-
+    auto accumulation_rank = PlayerStun::get_accumulation_rank(monap_ptr->d_dice * monap_ptr->d_side, monap_ptr->damage);
+    auto stun_plus = PlayerStun::get_accumulation(accumulation_rank);
     if (stun_plus > 0) {
         (void)BadStatusSetter(player_ptr).mod_stun(stun_plus);
     }

--- a/src/timed-effect/player-cut.cpp
+++ b/src/timed-effect/player-cut.cpp
@@ -1,6 +1,35 @@
 ﻿#include "timed-effect/player-cut.h"
 #include "system/angband.h"
 
+/*!
+ * @brief モンスター打撃による切り傷値を返す.
+ * @param total 痛恨の一撃でない場合の最大ダメージ (ダイスXdY に対し、X*Y)
+ * @param dam プレイヤーに与えた実際のダメージ
+ * @return 切り傷値
+ */
+short PlayerCut::get_accumulation(int total, int damage)
+{
+    auto rank = get_accumulation_rank(total, damage);
+    switch (rank) {
+    case 0:
+        return 0;
+    case 1:
+        return randint1(5);
+    case 2:
+        return randint1(5) + 5;
+    case 3:
+        return randint1(20) + 20;
+    case 4:
+        return randint1(50) + 50;
+    case 5:
+        return randint1(100) + 100;
+    case 6:
+        return 300;
+    default: // 7 or more.
+        return 500;
+    }
+}
+
 PlayerCutRank PlayerCut::get_rank(short value)
 {
     if (value > 1000) {
@@ -129,4 +158,55 @@ void PlayerCut::set(short value)
 void PlayerCut::reset()
 {
     this->set(0);
+}
+
+/*!
+ * @brief モンスター打撃の切り傷蓄積ランクを返す.
+ * @param total 痛恨の一撃でない場合の最大ダメージ (ダイスXdY に対し、X*Y)
+ * @param dam プレイヤーに与えた実際のダメージ
+ * @return 切り傷蓄積ランク
+ * @details v3.0.0 Alpha40時点では朦朧と異なりv2.2.1までの仕様と同一
+ */
+int PlayerCut::get_accumulation_rank(int total, int damage)
+{
+    if (damage < total * 19 / 20) {
+        return 0;
+    }
+
+    if ((damage < 20) && (damage <= randint0(100))) {
+        return 0;
+    }
+
+    auto max = 0;
+    if ((damage >= total) && (damage >= 40)) {
+        max++;
+    }
+
+    if (damage >= 20) {
+        while (randint0(100) < 2) {
+            max++;
+        }
+    }
+
+    if (damage > 45) {
+        return (6 + max);
+    }
+
+    if (damage > 33) {
+        return (5 + max);
+    }
+
+    if (damage > 25) {
+        return (4 + max);
+    }
+
+    if (damage > 18) {
+        return (3 + max);
+    }
+
+    if (damage > 11) {
+        return (2 + max);
+    }
+
+    return (1 + max);
 }

--- a/src/timed-effect/player-cut.cpp
+++ b/src/timed-effect/player-cut.cpp
@@ -1,35 +1,6 @@
 ﻿#include "timed-effect/player-cut.h"
 #include "system/angband.h"
 
-/*!
- * @brief モンスター打撃による切り傷値を返す.
- * @param total 痛恨の一撃でない場合の最大ダメージ (ダイスXdY に対し、X*Y)
- * @param dam プレイヤーに与えた実際のダメージ
- * @return 切り傷値
- */
-short PlayerCut::get_accumulation(int total, int damage)
-{
-    auto rank = get_accumulation_rank(total, damage);
-    switch (rank) {
-    case 0:
-        return 0;
-    case 1:
-        return randint1(5);
-    case 2:
-        return randint1(5) + 5;
-    case 3:
-        return randint1(20) + 20;
-    case 4:
-        return randint1(50) + 50;
-    case 5:
-        return randint1(100) + 100;
-    case 6:
-        return 300;
-    default: // 7 or more.
-        return 500;
-    }
-}
-
 PlayerCutRank PlayerCut::get_rank(short value)
 {
     if (value > 1000) {
@@ -84,6 +55,35 @@ std::string_view PlayerCut::get_cut_mes(PlayerCutRank stun_rank)
         return _("致命的な傷を負ってしまった。", "You have been given a mortal wound.");
     default:
         throw("Invalid StunRank was specified!");
+    }
+}
+
+/*!
+ * @brief モンスター打撃による切り傷値を返す.
+ * @param total 痛恨の一撃でない場合の最大ダメージ (ダイスXdY に対し、X*Y)
+ * @param dam プレイヤーに与えた実際のダメージ
+ * @return 切り傷値
+ */
+short PlayerCut::get_accumulation(int total, int damage)
+{
+    auto rank = get_accumulation_rank(total, damage);
+    switch (rank) {
+    case 0:
+        return 0;
+    case 1:
+        return randint1(5);
+    case 2:
+        return randint1(5) + 5;
+    case 3:
+        return randint1(20) + 20;
+    case 4:
+        return randint1(50) + 50;
+    case 5:
+        return randint1(100) + 100;
+    case 6:
+        return 300;
+    default: // 7 or more.
+        return 500;
     }
 }
 

--- a/src/timed-effect/player-cut.h
+++ b/src/timed-effect/player-cut.h
@@ -22,6 +22,7 @@ public:
 
     static PlayerCutRank get_rank(short value);
     static std::string_view get_cut_mes(PlayerCutRank stun_rank);
+    static short get_accumulation(int total, int damage);
 
     short current() const;
     PlayerCutRank get_rank() const;
@@ -33,4 +34,6 @@ public:
 
 private:
     short cut = 0;
+
+    static int get_accumulation_rank(int total, int damage);
 };

--- a/src/timed-effect/player-stun.cpp
+++ b/src/timed-effect/player-stun.cpp
@@ -44,6 +44,78 @@ std::string_view PlayerStun::get_stun_mes(PlayerStunRank stun_rank)
     }
 }
 
+short PlayerStun::get_accumulation(int rank)
+{
+    switch (rank) {
+    case 0:
+        return 0;
+    case 1:
+        return randint1(5);
+    case 2:
+        return randint1(5) + 10;
+    case 3:
+        return randint1(10) + 20;
+    case 4:
+        return randint1(15) + 30;
+    case 5:
+        return randint1(20) + 40;
+    case 6:
+        return 80;
+    default:
+        return 150;
+    }
+}
+
+/*!
+ * @brief モンスター打撃の朦朧蓄積ランクを返す.
+ * @param total 痛恨の一撃でない場合の最大ダメージ (ダイスXdY に対し、X*Y)
+ * @param dam プレイヤーに与えた実際のダメージ
+ * @return 朦朧蓄積ランク
+ */
+int PlayerStun::get_accumulation_rank(int total, int damage)
+{
+    if (damage < total * 19 / 20) {
+        return 0;
+    }
+
+    if ((damage < 20) && (damage <= randint0(100))) {
+        return 0;
+    }
+
+    auto max = 0;
+    if ((damage >= total) && (damage >= 40)) {
+        max++;
+    }
+
+    if (damage >= 20) {
+        while (randint0(100) < 2) {
+            max++;
+        }
+    }
+
+    if (damage > 45) {
+        return (6 + max);
+    }
+
+    if (damage > 33) {
+        return (5 + max);
+    }
+
+    if (damage > 25) {
+        return (4 + max);
+    }
+
+    if (damage > 18) {
+        return (3 + max);
+    }
+
+    if (damage > 11) {
+        return (2 + max);
+    }
+
+    return (1 + max);
+}
+
 /*!
  * @brief 朦朧ランクに応じて各種失率を上げる.
  * @return 朦朧ならば15%、ひどく朦朧ならば25%.

--- a/src/timed-effect/player-stun.cpp
+++ b/src/timed-effect/player-stun.cpp
@@ -1,16 +1,6 @@
 ﻿#include "timed-effect/player-stun.h"
 #include "system/angband.h"
 
-short PlayerStun::current() const
-{
-    return this->stun;
-}
-
-PlayerStunRank PlayerStun::get_rank() const
-{
-    return this->get_rank(this->stun);
-}
-
 PlayerStunRank PlayerStun::get_rank(short value)
 {
     if (value > 100) {
@@ -114,6 +104,16 @@ int PlayerStun::get_accumulation_rank(int total, int damage)
     }
 
     return (1 + max);
+}
+
+short PlayerStun::current() const
+{
+    return this->stun;
+}
+
+PlayerStunRank PlayerStun::get_rank() const
+{
+    return this->get_rank(this->stun);
 }
 
 /*!

--- a/src/timed-effect/player-stun.h
+++ b/src/timed-effect/player-stun.h
@@ -27,8 +27,8 @@ public:
     short get_damage_penalty() const;
     bool is_stunned() const;
     std::tuple<term_color_type, std::string_view> get_expr() const;
-    void reset();
     void set(short value);
+    void reset();
 
 private:
     short stun = 0;

--- a/src/timed-effect/player-stun.h
+++ b/src/timed-effect/player-stun.h
@@ -18,7 +18,9 @@ public:
 
     static PlayerStunRank get_rank(short value);
     static std::string_view get_stun_mes(PlayerStunRank stun_rank);
-    
+    static short get_accumulation(int rank);
+    static int get_accumulation_rank(int total, int damage);
+
     short current() const;
     PlayerStunRank get_rank() const;
     int get_chance_penalty() const;


### PR DESCRIPTION
#553 の前段作業です
ご確認下さい
- カプセル化と設計上の呼び出し関係を維持する (具体的にはPlayerCut/Stunにplayer\_ptrへの参照を保持させない)ため、calc\_player\_cut/stun() についてはmonster\_attack\_player.cppに残しています
- 切り傷の方は蓄積ランクの補正を行う予定はないので、取得メソッドをprivateにしています
- 朦朧の方は今後新仕様に基づく補正を行うので、取得メソッドをpublicにしています