### PR TITLE
chest.cpp/h のクラス化 w/ ChestTrapTypeの定義

### DIFF
--- a/src/action/open-close-execution.cpp
+++ b/src/action/open-close-execution.cpp
@@ -206,7 +206,7 @@ bool exe_disarm_chest(player_type *player_ptr, POSITION y, POSITION x, OBJECT_ID
         msg_print(_("トラップが見あたらない。", "I don't see any traps."));
     } else if (o_ptr->pval <= 0) {
         msg_print(_("箱にはトラップが仕掛けられていない。", "The chest is not trapped."));
-    } else if (!chest_traps[o_ptr->pval]) {
+    } else if (chest_traps[o_ptr->pval].none()) {
         msg_print(_("箱にはトラップが仕掛けられていない。", "The chest is not trapped."));
     } else if (randint0(100) < j) {
         msg_print(_("箱に仕掛けられていたトラップを解除した。", "You have disarmed the chest."));

--- a/src/action/open-close-execution.cpp
+++ b/src/action/open-close-execution.cpp
@@ -221,7 +221,7 @@ bool exe_disarm_chest(player_type *player_ptr, POSITION y, POSITION x, OBJECT_ID
     } else {
         msg_print(_("トラップを作動させてしまった！", "You set off a trap!"));
         sound(SOUND_FAIL);
-        chest_trap(player_ptr, y, x, o_idx);
+        Chest(player_ptr).chest_trap(y, x, o_idx);
     }
 
     return more;

--- a/src/action/open-util.cpp
+++ b/src/action/open-util.cpp
@@ -59,7 +59,7 @@ int count_chests(player_type *player_ptr, POSITION *y, POSITION *x, bool trapped
         if (o_ptr->pval == 0)
             continue;
 
-        if (trapped && (!o_ptr->is_known() || !chest_traps[o_ptr->pval]))
+        if (trapped && (!o_ptr->is_known() || chest_traps[o_ptr->pval].none()))
             continue;
 
         ++count;

--- a/src/cmd-action/cmd-open-close.cpp
+++ b/src/cmd-action/cmd-open-close.cpp
@@ -70,8 +70,9 @@ static bool exe_open_chest(player_type *player_ptr, POSITION y, POSITION x, OBJE
     }
 
     if (flag) {
-        chest_trap(player_ptr, y, x, o_idx);
-        chest_death(player_ptr, false, y, x, o_idx);
+        Chest chest(player_ptr);
+        chest.chest_trap(y, x, o_idx);
+        chest.chest_death(false, y, x, o_idx);
     }
 
     return more;

--- a/src/flavor/flavor-describer.cpp
+++ b/src/flavor/flavor-describer.cpp
@@ -39,40 +39,48 @@
 
 static void describe_chest_trap(flavor_type *flavor_ptr)
 {
-    switch (chest_traps[flavor_ptr->o_ptr->pval]) {
-    case 0:
+    auto trap_kinds = chest_traps[flavor_ptr->o_ptr->pval];
+    if (trap_kinds.count() >= 2) {
+        flavor_ptr->t = object_desc_str(flavor_ptr->t, _("(マルチ・トラップ)", " (Multiple Traps)"));
+        return;
+    }
+
+    auto trap_kind = trap_kinds.first();
+    if (!trap_kind.has_value()) {
         flavor_ptr->t = object_desc_str(flavor_ptr->t, _("(施錠)", " (Locked)"));
-        break;
-    case CHEST_LOSE_STR:
+        return;
+    }
+
+    switch (trap_kind.value()) {
+    case ChestTrapType::LOSE_STR:
         flavor_ptr->t = object_desc_str(flavor_ptr->t, _("(毒針)", " (Poison Needle)"));
         break;
-    case CHEST_LOSE_CON:
+    case ChestTrapType::LOSE_CON:
         flavor_ptr->t = object_desc_str(flavor_ptr->t, _("(毒針)", " (Poison Needle)"));
         break;
-    case CHEST_POISON:
+    case ChestTrapType::POISON:
         flavor_ptr->t = object_desc_str(flavor_ptr->t, _("(ガス・トラップ)", " (Gas Trap)"));
         break;
-    case CHEST_PARALYZE:
+    case ChestTrapType::PARALYZE:
         flavor_ptr->t = object_desc_str(flavor_ptr->t, _("(ガス・トラップ)", " (Gas Trap)"));
         break;
-    case CHEST_EXPLODE:
+    case ChestTrapType::EXPLODE:
         flavor_ptr->t = object_desc_str(flavor_ptr->t, _("(爆発装置)", " (Explosion Device)"));
         break;
-    case CHEST_SUMMON:
-    case CHEST_BIRD_STORM:
-    case CHEST_E_SUMMON:
-    case CHEST_H_SUMMON:
+    case ChestTrapType::SUMMON:
+    case ChestTrapType::BIRD_STORM:
+    case ChestTrapType::E_SUMMON:
+    case ChestTrapType::H_SUMMON:
         flavor_ptr->t = object_desc_str(flavor_ptr->t, _("(召喚のルーン)", " (Summoning Runes)"));
         break;
-    case CHEST_RUNES_OF_EVIL:
+    case ChestTrapType::RUNES_OF_EVIL:
         flavor_ptr->t = object_desc_str(flavor_ptr->t, _("(邪悪なルーン)", " (Gleaming Black Runes)"));
         break;
-    case CHEST_ALARM:
+    case ChestTrapType::ALARM:
         flavor_ptr->t = object_desc_str(flavor_ptr->t, _("(警報装置)", " (Alarm)"));
         break;
     default:
-        flavor_ptr->t = object_desc_str(flavor_ptr->t, _("(マルチ・トラップ)", " (Multiple Traps)"));
-        break;
+        throw("Invalid chest trap type is specified!");
     }
 }
 
@@ -90,7 +98,7 @@ static void describe_chest(flavor_type *flavor_ptr)
     }
 
     if (flavor_ptr->o_ptr->pval < 0) {
-        if (chest_traps[0 - flavor_ptr->o_ptr->pval])
+        if (chest_traps[0 - flavor_ptr->o_ptr->pval].any())
             flavor_ptr->t = object_desc_str(flavor_ptr->t, _("(解除済)", " (disarmed)"));
         else
             flavor_ptr->t = object_desc_str(flavor_ptr->t, _("(非施錠)", " (unlocked)"));

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -43,7 +43,6 @@
 #include "target/projection-path-calculator.h"
 #include "timed-effect/player-cut.h"
 #include "timed-effect/timed-effects.h"
-#include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 
@@ -60,71 +59,71 @@ static int16_t normal_traps[MAX_NORMAL_TRAPS];
  * Note that disarming a trap on a chest also removes the lock.
  * </pre>
  */
-const std::vector<int> chest_traps = {
-    0, /* 0 == empty */
-    (CHEST_POISON),
-    (CHEST_LOSE_STR),
-    (CHEST_LOSE_CON),
-    (CHEST_LOSE_STR),
-    (CHEST_LOSE_CON), /* 5 == best small wooden */
-    0,
-    (CHEST_ALARM),
-    (CHEST_ALARM),
-    (CHEST_LOSE_STR),
-    (CHEST_LOSE_CON),
-    (CHEST_POISON),
-    (CHEST_SCATTER),
-    (CHEST_LOSE_STR | CHEST_LOSE_CON),
-    (CHEST_LOSE_STR | CHEST_LOSE_CON),
-    (CHEST_SUMMON), /* 15 == best large wooden */
-    0,
-    (CHEST_ALARM),
-    (CHEST_SCATTER),
-    (CHEST_PARALYZE),
-    (CHEST_LOSE_STR | CHEST_LOSE_CON),
-    (CHEST_SUMMON),
-    (CHEST_PARALYZE),
-    (CHEST_LOSE_STR),
-    (CHEST_LOSE_CON),
-    (CHEST_EXPLODE), /* 25 == best small iron */
-    0,
-    (CHEST_E_SUMMON),
-    (CHEST_POISON | CHEST_LOSE_CON),
-    (CHEST_LOSE_STR | CHEST_LOSE_CON),
-    (CHEST_EXPLODE | CHEST_SUMMON),
-    (CHEST_BIRD_STORM),
-    (CHEST_POISON | CHEST_SUMMON),
-    (CHEST_E_SUMMON | CHEST_ALARM),
-    (CHEST_EXPLODE),
-    (CHEST_EXPLODE | CHEST_SUMMON), /* 35 == best large iron */
-    0,
-    (CHEST_SUMMON | CHEST_ALARM),
-    (CHEST_EXPLODE),
-    (CHEST_EXPLODE | CHEST_SUMMON),
-    (CHEST_EXPLODE | CHEST_SUMMON),
-    (CHEST_POISON | CHEST_PARALYZE),
-    (CHEST_EXPLODE),
-    (CHEST_BIRD_STORM),
-    (CHEST_EXPLODE | CHEST_E_SUMMON | CHEST_ALARM),
-    (CHEST_H_SUMMON), /* 45 == best small steel */
-    0,
-    (CHEST_EXPLODE | CHEST_SUMMON | CHEST_ALARM),
-    (CHEST_BIRD_STORM),
-    (CHEST_RUNES_OF_EVIL),
-    (CHEST_EXPLODE | CHEST_SUMMON | CHEST_ALARM),
-    (CHEST_BIRD_STORM | CHEST_ALARM),
-    (CHEST_H_SUMMON | CHEST_ALARM),
-    (CHEST_RUNES_OF_EVIL),
-    (CHEST_H_SUMMON | CHEST_SCATTER | CHEST_ALARM),
-    (CHEST_RUNES_OF_EVIL | CHEST_EXPLODE), /* 55 == best large steel */
-    (CHEST_EXPLODE | CHEST_SUMMON),
-    (CHEST_EXPLODE | CHEST_SUMMON),
-    (CHEST_EXPLODE | CHEST_SUMMON),
-    (CHEST_EXPLODE | CHEST_SUMMON),
-    (CHEST_EXPLODE | CHEST_SUMMON),
-    (CHEST_EXPLODE | CHEST_SUMMON),
-    (CHEST_EXPLODE | CHEST_SUMMON),
-    (CHEST_EXPLODE | CHEST_SUMMON),
+const std::vector<EnumClassFlagGroup<ChestTrapType>> chest_traps = {
+    { }, /* empty */
+    { ChestTrapType::POISON },
+    { ChestTrapType::LOSE_STR },
+    { ChestTrapType::LOSE_CON },
+    { ChestTrapType::LOSE_STR },
+    { ChestTrapType::LOSE_CON }, /* 5 == best small wooden */
+    { },
+    { ChestTrapType::ALARM },
+    { ChestTrapType::ALARM },
+    { ChestTrapType::LOSE_STR },
+    { ChestTrapType::LOSE_CON },
+    { ChestTrapType::POISON },
+    { ChestTrapType::SCATTER },
+    { ChestTrapType::LOSE_STR, ChestTrapType::LOSE_CON },
+    { ChestTrapType::LOSE_STR, ChestTrapType::LOSE_CON },
+    { ChestTrapType::SUMMON }, /* 15 == best large wooden */
+    { },
+    { ChestTrapType::ALARM },
+    { ChestTrapType::SCATTER },
+    { ChestTrapType::PARALYZE },
+    { ChestTrapType::LOSE_STR, ChestTrapType::LOSE_CON },
+    { ChestTrapType::SUMMON },
+    { ChestTrapType::PARALYZE },
+    { ChestTrapType::LOSE_STR },
+    { ChestTrapType::LOSE_CON },
+    { ChestTrapType::EXPLODE }, /* 25 == best small iron */
+    { },
+    { ChestTrapType::E_SUMMON },
+    { ChestTrapType::POISON, ChestTrapType::LOSE_CON },
+    { ChestTrapType::LOSE_STR, ChestTrapType::LOSE_CON },
+    { ChestTrapType::EXPLODE, ChestTrapType::SUMMON },
+    { ChestTrapType::BIRD_STORM },
+    { ChestTrapType::POISON, ChestTrapType::SUMMON },
+    { ChestTrapType::E_SUMMON, ChestTrapType::ALARM },
+    { ChestTrapType::EXPLODE },
+    { ChestTrapType::EXPLODE, ChestTrapType::SUMMON }, /* 35 == best large iron */
+    { },
+    { ChestTrapType::SUMMON, ChestTrapType::ALARM },
+    { ChestTrapType::EXPLODE },
+    { ChestTrapType::EXPLODE, ChestTrapType::SUMMON },
+    { ChestTrapType::EXPLODE, ChestTrapType::SUMMON },
+    { ChestTrapType::POISON, ChestTrapType::PARALYZE },
+    { ChestTrapType::EXPLODE },
+    { ChestTrapType::BIRD_STORM },
+    { ChestTrapType::EXPLODE, ChestTrapType::E_SUMMON, ChestTrapType::ALARM },
+    { ChestTrapType::H_SUMMON }, /* 45 == best small steel */
+    { },
+    { ChestTrapType::EXPLODE, ChestTrapType::SUMMON, ChestTrapType::ALARM },
+    { ChestTrapType::BIRD_STORM },
+    { ChestTrapType::RUNES_OF_EVIL },
+    { ChestTrapType::EXPLODE, ChestTrapType::SUMMON, ChestTrapType::ALARM },
+    { ChestTrapType::BIRD_STORM, ChestTrapType::ALARM },
+    { ChestTrapType::H_SUMMON, ChestTrapType::ALARM },
+    { ChestTrapType::RUNES_OF_EVIL },
+    { ChestTrapType::H_SUMMON, ChestTrapType::SCATTER, ChestTrapType::ALARM },
+    { ChestTrapType::RUNES_OF_EVIL, ChestTrapType::EXPLODE }, /* 55 == best large steel */
+    { ChestTrapType::EXPLODE, ChestTrapType::SUMMON },
+    { ChestTrapType::EXPLODE, ChestTrapType::SUMMON },
+    { ChestTrapType::EXPLODE, ChestTrapType::SUMMON },
+    { ChestTrapType::EXPLODE, ChestTrapType::SUMMON },
+    { ChestTrapType::EXPLODE, ChestTrapType::SUMMON },
+    { ChestTrapType::EXPLODE, ChestTrapType::SUMMON },
+    { ChestTrapType::EXPLODE, ChestTrapType::SUMMON },
+    { ChestTrapType::EXPLODE, ChestTrapType::SUMMON },
 };
 
 /*!

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -60,7 +60,7 @@ static int16_t normal_traps[MAX_NORMAL_TRAPS];
  * Note that disarming a trap on a chest also removes the lock.
  * </pre>
  */
-const int chest_traps[64] = {
+const std::vector<int> chest_traps = {
     0, /* 0 == empty */
     (CHEST_POISON),
     (CHEST_LOSE_STR),

--- a/src/grid/trap.h
+++ b/src/grid/trap.h
@@ -1,22 +1,28 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include "util/flag-group.h"
 
+// clang-format off
 /*!
  * 箱のトラップ定義 Chest trap flags
  */
-#define CHEST_LOSE_STR          0x0001 /*!< 箱のトラップ: STR減少の毒針 */
-#define CHEST_LOSE_CON          0x0002 /*!< 箱のトラップ: CON減少の毒針 */
-#define CHEST_POISON            0x0004 /*!< 箱のトラップ: 毒針 */
-#define CHEST_PARALYZE          0x0008 /*!< 箱のトラップ: 麻痺ガス */
-#define CHEST_EXPLODE           0x0010 /*!< 箱のトラップ: 爆発 */
-#define CHEST_SUMMON            0x0020 /*!< 箱のトラップ: 召喚のルーン(モンスター) */
-#define CHEST_SCATTER           0x0040 /*!< 箱のトラップ: アイテム散乱 */
-#define CHEST_E_SUMMON          0x0080 /*!< 箱のトラップ: 召喚のルーン(エレメンタル) */
-#define CHEST_BIRD_STORM        0x0100 /*!< 箱のトラップ: 召喚のルーン(鳥) */
-#define CHEST_H_SUMMON          0x0200 /*!< 箱のトラップ: 召喚のルーン(強敵)  */
-#define CHEST_RUNES_OF_EVIL     0x0400 /*!< 箱のトラップ: 邪悪なルーン */
-#define CHEST_ALARM             0x0800 /*!< 箱のトラップ: 警報装置 */
+enum class ChestTrapType : ushort {
+    LOSE_STR = 0,       /*!< 箱のトラップ: 腕力減少の毒針 */
+    LOSE_CON = 1,       /*!< 箱のトラップ: 器用さ減少の毒針 */
+    POISON = 2,         /*!< 箱のトラップ: 毒針 */
+    PARALYZE = 3,       /*!< 箱のトラップ: 麻痺ガス */
+    EXPLODE = 4,        /*!< 箱のトラップ: 爆発 */
+    SUMMON = 5,         /*!< 箱のトラップ: 召喚のルーン(モンスター) */
+    SCATTER = 6,        /*!< 箱のトラップ: アイテム散乱 */
+    E_SUMMON = 7,       /*!< 箱のトラップ: 召喚のルーン(エレメンタル) */
+    BIRD_STORM = 8,     /*!< 箱のトラップ: 召喚のルーン(鳥) */
+    H_SUMMON = 9,      /*!< 箱のトラップ: 召喚のルーン(強敵) */
+    RUNES_OF_EVIL = 10, /*!< 箱のトラップ: 邪悪なルーン */
+    ALARM = 11,         /*!< 箱のトラップ: 警報装置 */
+    MAX,
+};
+// clang-format on
 
 /* Types of normal traps */
 enum trap_type {
@@ -49,7 +55,7 @@ enum trap_type {
 };
 const int MAX_NORMAL_TRAPS = TRAP_ALARM + 1;
 
-extern const std::vector<int> chest_traps;
+extern const std::vector<EnumClassFlagGroup<ChestTrapType>> chest_traps;
 
 struct player_type;
 void init_normal_traps(void);

--- a/src/grid/trap.h
+++ b/src/grid/trap.h
@@ -49,7 +49,7 @@ enum trap_type {
 };
 const int MAX_NORMAL_TRAPS = TRAP_ALARM + 1;
 
-extern const int chest_traps[64];
+extern const std::vector<int> chest_traps;
 
 struct player_type;
 void init_normal_traps(void);

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -81,7 +81,7 @@ static void discover_hidden_things(player_type *player_ptr, POSITION y, POSITION
         o_ptr = &floor_ptr->o_list[this_o_idx];
         if (o_ptr->tval != TV_CHEST)
             continue;
-        if (!chest_traps[o_ptr->pval])
+        if (chest_traps[o_ptr->pval].none())
             continue;
         if (!o_ptr->is_known()) {
             msg_print(_("箱に仕掛けられたトラップを発見した！", "You have discovered a trap on the chest!"));

--- a/src/specific-object/chest.cpp
+++ b/src/specific-object/chest.cpp
@@ -30,6 +30,11 @@
 /*!< この値以降の小項目IDを持った箱は大型の箱としてドロップ数を増やす / Special "sval" limit -- first "large" chest */
 #define SV_CHEST_MIN_LARGE 4
 
+Chest::Chest(player_type *player_ptr)
+    : player_ptr(player_ptr)
+{
+}
+
 /*!
  * @brief 箱からアイテムを引き出す /
  * Allocates objects upon opening a chest    -BEN-
@@ -49,7 +54,7 @@
  * on the level on which the chest is generated.
  * </pre>
  */
-void chest_death(player_type *player_ptr, bool scatter, POSITION y, POSITION x, OBJECT_IDX o_idx)
+void Chest::chest_death(bool scatter, POSITION y, POSITION x, OBJECT_IDX o_idx)
 {
     int number;
 
@@ -59,7 +64,7 @@ void chest_death(player_type *player_ptr, bool scatter, POSITION y, POSITION x, 
     object_type forge;
     object_type *q_ptr;
 
-    floor_type *floor_ptr = player_ptr->current_floor_ptr;
+    floor_type *floor_ptr = this->player_ptr->current_floor_ptr;
     object_type *o_ptr = &floor_ptr->o_list[o_idx];
 
     /* Small chests often hold "gold" */
@@ -90,14 +95,14 @@ void chest_death(player_type *player_ptr, bool scatter, POSITION y, POSITION x, 
         /* Small chests often drop gold */
         if (small && (randint0(100) < 25)) {
             /* Make some gold */
-            if (!make_gold(player_ptr, q_ptr))
+            if (!make_gold(this->player_ptr, q_ptr))
                 continue;
         }
 
         /* Otherwise drop an item */
         else {
             /* Make a good object */
-            if (!make_object(player_ptr, q_ptr, mode))
+            if (!make_object(this->player_ptr, q_ptr, mode))
                 continue;
         }
 
@@ -110,11 +115,11 @@ void chest_death(player_type *player_ptr, bool scatter, POSITION y, POSITION x, 
                 x = randint0(MAX_WID);
 
                 /* Must be an empty floor. */
-                if (!is_cave_empty_bold(player_ptr, y, x))
+                if (!is_cave_empty_bold(this->player_ptr, y, x))
                     continue;
 
                 /* Place the object there. */
-                (void)drop_near(player_ptr, q_ptr, -1, y, x);
+                (void)drop_near(this->player_ptr, q_ptr, -1, y, x);
 
                 /* Done. */
                 break;
@@ -122,7 +127,7 @@ void chest_death(player_type *player_ptr, bool scatter, POSITION y, POSITION x, 
         }
         /* Normally, drop object near the chest. */
         else
-            (void)drop_near(player_ptr, q_ptr, -1, y, x);
+            (void)drop_near(this->player_ptr, q_ptr, -1, y, x);
     }
 
     /* Reset the object level */
@@ -148,11 +153,11 @@ void chest_death(player_type *player_ptr, bool scatter, POSITION y, POSITION x, 
  * Note that the chest itself is never destroyed.
  * </pre>
  */
-void chest_trap(player_type *player_ptr, POSITION y, POSITION x, OBJECT_IDX o_idx)
+void Chest::chest_trap(POSITION y, POSITION x, OBJECT_IDX o_idx)
 {
     int i, trap;
 
-    object_type *o_ptr = &player_ptr->current_floor_ptr->o_list[o_idx];
+    object_type *o_ptr = &this->player_ptr->current_floor_ptr->o_list[o_idx];
 
     int mon_level = o_ptr->xtra3;
 
@@ -166,30 +171,30 @@ void chest_trap(player_type *player_ptr, POSITION y, POSITION x, OBJECT_IDX o_id
     /* Lose strength */
     if (trap & (CHEST_LOSE_STR)) {
         msg_print(_("仕掛けられていた小さな針に刺されてしまった！", "A small needle has pricked you!"));
-        take_hit(player_ptr, DAMAGE_NOESCAPE, damroll(1, 4), _("毒針", "a poison needle"));
-        (void)do_dec_stat(player_ptr, A_STR);
+        take_hit(this->player_ptr, DAMAGE_NOESCAPE, damroll(1, 4), _("毒針", "a poison needle"));
+        (void)do_dec_stat(this->player_ptr, A_STR);
     }
 
     /* Lose constitution */
     if (trap & (CHEST_LOSE_CON)) {
         msg_print(_("仕掛けられていた小さな針に刺されてしまった！", "A small needle has pricked you!"));
-        take_hit(player_ptr, DAMAGE_NOESCAPE, damroll(1, 4), _("毒針", "a poison needle"));
-        (void)do_dec_stat(player_ptr, A_CON);
+        take_hit(this->player_ptr, DAMAGE_NOESCAPE, damroll(1, 4), _("毒針", "a poison needle"));
+        (void)do_dec_stat(this->player_ptr, A_CON);
     }
 
     /* Poison */
     if (trap & (CHEST_POISON)) {
         msg_print(_("突如吹き出した緑色のガスに包み込まれた！", "A puff of green gas surrounds you!"));
-        if (!(has_resist_pois(player_ptr) || is_oppose_pois(player_ptr))) {
-            (void)BadStatusSetter(player_ptr).mod_poison(10 + randint1(20));
+        if (!(has_resist_pois(this->player_ptr) || is_oppose_pois(this->player_ptr))) {
+            (void)BadStatusSetter(this->player_ptr).mod_poison(10 + randint1(20));
         }
     }
 
     /* Paralyze */
     if (trap & (CHEST_PARALYZE)) {
         msg_print(_("突如吹き出した黄色いガスに包み込まれた！", "A puff of yellow gas surrounds you!"));
-        if (!player_ptr->free_act) {
-            (void)BadStatusSetter(player_ptr).mod_paralysis(10 + randint1(20));
+        if (!this->player_ptr->free_act) {
+            (void)BadStatusSetter(this->player_ptr).mod_paralysis(10 + randint1(20));
         }
     }
 
@@ -198,10 +203,10 @@ void chest_trap(player_type *player_ptr, POSITION y, POSITION x, OBJECT_IDX o_id
         int num = 2 + randint1(3);
         msg_print(_("突如吹き出した煙に包み込まれた！", "You are enveloped in a cloud of smoke!"));
         for (i = 0; i < num; i++) {
-            if (randint1(100) < player_ptr->current_floor_ptr->dun_level)
-                activate_hi_summon(player_ptr, player_ptr->y, player_ptr->x, false);
+            if (randint1(100) < this->player_ptr->current_floor_ptr->dun_level)
+                activate_hi_summon(this->player_ptr, this->player_ptr->y, this->player_ptr->x, false);
             else
-                (void)summon_specific(player_ptr, 0, y, x, mon_level, SUMMON_NONE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
+                (void)summon_specific(this->player_ptr, 0, y, x, mon_level, SUMMON_NONE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
         }
     }
 
@@ -209,7 +214,7 @@ void chest_trap(player_type *player_ptr, POSITION y, POSITION x, OBJECT_IDX o_id
     if (trap & (CHEST_E_SUMMON)) {
         msg_print(_("宝を守るためにエレメンタルが現れた！", "Elemental beings appear to protect their treasures!"));
         for (i = 0; i < randint1(3) + 5; i++) {
-            (void)summon_specific(player_ptr, 0, y, x, mon_level, SUMMON_ELEMENTAL, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
+            (void)summon_specific(this->player_ptr, 0, y, x, mon_level, SUMMON_ELEMENTAL, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
         }
     }
 
@@ -218,10 +223,10 @@ void chest_trap(player_type *player_ptr, POSITION y, POSITION x, OBJECT_IDX o_id
         msg_print(_("鳥の群れがあなたを取り巻いた！", "A storm of birds swirls around you!"));
 
         for (i = 0; i < randint1(3) + 3; i++)
-            (void)fire_meteor(player_ptr, -1, GF_FORCE, y, x, o_ptr->pval / 5, 7);
+            (void)fire_meteor(this->player_ptr, -1, GF_FORCE, y, x, o_ptr->pval / 5, 7);
 
         for (i = 0; i < randint1(5) + o_ptr->pval / 5; i++) {
-            (void)summon_specific(player_ptr, 0, y, x, mon_level, SUMMON_BIRD, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
+            (void)summon_specific(this->player_ptr, 0, y, x, mon_level, SUMMON_BIRD, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
         }
     }
 
@@ -231,8 +236,8 @@ void chest_trap(player_type *player_ptr, POSITION y, POSITION x, OBJECT_IDX o_id
         if (one_in_(4)) {
             msg_print(_("炎と硫黄の雲の中に悪魔が姿を現した！", "Demons materialize in clouds of fire and brimstone!"));
             for (i = 0; i < randint1(3) + 2; i++) {
-                (void)fire_meteor(player_ptr, -1, GF_FIRE, y, x, 10, 5);
-                (void)summon_specific(player_ptr, 0, y, x, mon_level, SUMMON_DEMON, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
+                (void)fire_meteor(this->player_ptr, -1, GF_FIRE, y, x, 10, 5);
+                (void)summon_specific(this->player_ptr, 0, y, x, mon_level, SUMMON_DEMON, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
             }
         }
 
@@ -240,7 +245,7 @@ void chest_trap(player_type *player_ptr, POSITION y, POSITION x, OBJECT_IDX o_id
         else if (one_in_(3)) {
             msg_print(_("暗闇にドラゴンの影がぼんやりと現れた！", "Draconic forms loom out of the darkness!"));
             for (i = 0; i < randint1(3) + 2; i++) {
-                (void)summon_specific(player_ptr, 0, y, x, mon_level, SUMMON_DRAGON, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
+                (void)summon_specific(this->player_ptr, 0, y, x, mon_level, SUMMON_DRAGON, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
             }
         }
 
@@ -248,7 +253,7 @@ void chest_trap(player_type *player_ptr, POSITION y, POSITION x, OBJECT_IDX o_id
         else if (one_in_(2)) {
             msg_print(_("奇妙な姿の怪物が襲って来た！", "Creatures strange and twisted assault you!"));
             for (i = 0; i < randint1(5) + 3; i++) {
-                (void)summon_specific(player_ptr, 0, y, x, mon_level, SUMMON_HYBRID, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
+                (void)summon_specific(this->player_ptr, 0, y, x, mon_level, SUMMON_HYBRID, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
             }
         }
 
@@ -256,7 +261,7 @@ void chest_trap(player_type *player_ptr, POSITION y, POSITION x, OBJECT_IDX o_id
         else {
             msg_print(_("渦巻が合体し、破裂した！", "Vortices coalesce and wreak destruction!"));
             for (i = 0; i < randint1(3) + 2; i++) {
-                (void)summon_specific(player_ptr, 0, y, x, mon_level, SUMMON_VORTEX, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
+                (void)summon_specific(this->player_ptr, 0, y, x, mon_level, SUMMON_VORTEX, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
             }
         }
     }
@@ -265,23 +270,23 @@ void chest_trap(player_type *player_ptr, POSITION y, POSITION x, OBJECT_IDX o_id
     if ((trap & (CHEST_RUNES_OF_EVIL)) && o_ptr->k_idx) {
         msg_print(_("恐ろしい声が響いた:  「暗闇が汝をつつまん！」", "Hideous voices bid:  'Let the darkness have thee!'"));
         for (auto count = 4 + randint0(3); count > 0; count--) {
-            if (randint1(100 + o_ptr->pval * 2) <= player_ptr->skill_sav) {
+            if (randint1(100 + o_ptr->pval * 2) <= this->player_ptr->skill_sav) {
                 continue;
             }
 
             if (one_in_(6)) {
-                take_hit(player_ptr, DAMAGE_NOESCAPE, damroll(5, 20), _("破滅のトラップの宝箱", "a chest dispel-player trap"));
+                take_hit(this->player_ptr, DAMAGE_NOESCAPE, damroll(5, 20), _("破滅のトラップの宝箱", "a chest dispel-player trap"));
                 continue;
             }
             
-            BadStatusSetter bss(player_ptr);
+            BadStatusSetter bss(this->player_ptr);
             if (one_in_(5)) {
                 (void)bss.mod_cut(200);
                 continue;
             }
             
             if (one_in_(4)) {
-                if (!player_ptr->free_act) {
+                if (!this->player_ptr->free_act) {
                     (void)bss.mod_paralysis(2 + randint0(6));
                 } else {
                     (void)bss.mod_stun(10 + randint0(100));
@@ -291,28 +296,28 @@ void chest_trap(player_type *player_ptr, POSITION y, POSITION x, OBJECT_IDX o_id
             }
             
             if (one_in_(3)) {
-                apply_disenchant(player_ptr, 0);
+                apply_disenchant(this->player_ptr, 0);
                 continue;
             }
             
             if (one_in_(2)) {
-                (void)do_dec_stat(player_ptr, A_STR);
-                (void)do_dec_stat(player_ptr, A_DEX);
-                (void)do_dec_stat(player_ptr, A_CON);
-                (void)do_dec_stat(player_ptr, A_INT);
-                (void)do_dec_stat(player_ptr, A_WIS);
-                (void)do_dec_stat(player_ptr, A_CHR);
+                (void)do_dec_stat(this->player_ptr, A_STR);
+                (void)do_dec_stat(this->player_ptr, A_DEX);
+                (void)do_dec_stat(this->player_ptr, A_CON);
+                (void)do_dec_stat(this->player_ptr, A_INT);
+                (void)do_dec_stat(this->player_ptr, A_WIS);
+                (void)do_dec_stat(this->player_ptr, A_CHR);
                 continue;
             }
 
-            (void)fire_meteor(player_ptr, -1, GF_NETHER, y, x, 150, 1);
+            (void)fire_meteor(this->player_ptr, -1, GF_NETHER, y, x, 150, 1);
         }
     }
 
     /* Aggravate monsters. */
     if (trap & (CHEST_ALARM)) {
         msg_print(_("けたたましい音が鳴り響いた！", "An alarm sounds!"));
-        aggravate_monsters(player_ptr, 0);
+        aggravate_monsters(this->player_ptr, 0);
     }
 
     /* Explode */
@@ -321,12 +326,12 @@ void chest_trap(player_type *player_ptr, POSITION y, POSITION x, OBJECT_IDX o_id
         msg_print(_("箱の中の物はすべて粉々に砕け散った！", "Everything inside the chest is destroyed!"));
         o_ptr->pval = 0;
         sound(SOUND_EXPLODE);
-        take_hit(player_ptr, DAMAGE_ATTACK, damroll(5, 8), _("爆発する箱", "an exploding chest"));
+        take_hit(this->player_ptr, DAMAGE_ATTACK, damroll(5, 8), _("爆発する箱", "an exploding chest"));
     }
     /* Scatter contents. */
     if ((trap & (CHEST_SCATTER)) && o_ptr->k_idx) {
         msg_print(_("宝箱の中身はダンジョンじゅうに散乱した！", "The contents of the chest scatter all over the dungeon!"));
-        chest_death(player_ptr, true, y, x, o_idx);
+        this->chest_death(true, y, x, o_idx);
         o_ptr->pval = 0;
     }
 }

--- a/src/specific-object/chest.cpp
+++ b/src/specific-object/chest.cpp
@@ -155,7 +155,7 @@ void Chest::chest_death(bool scatter, POSITION y, POSITION x, OBJECT_IDX o_idx)
  */
 void Chest::chest_trap(POSITION y, POSITION x, OBJECT_IDX o_idx)
 {
-    int i, trap;
+    int i;
 
     object_type *o_ptr = &this->player_ptr->current_floor_ptr->o_list[o_idx];
 
@@ -166,24 +166,24 @@ void Chest::chest_trap(POSITION y, POSITION x, OBJECT_IDX o_idx)
         return;
 
     /* Obtain the traps */
-    trap = chest_traps[o_ptr->pval];
+    auto trap = chest_traps[o_ptr->pval];
 
     /* Lose strength */
-    if (trap & (CHEST_LOSE_STR)) {
+    if (trap.has(ChestTrapType::LOSE_STR)) {
         msg_print(_("仕掛けられていた小さな針に刺されてしまった！", "A small needle has pricked you!"));
         take_hit(this->player_ptr, DAMAGE_NOESCAPE, damroll(1, 4), _("毒針", "a poison needle"));
         (void)do_dec_stat(this->player_ptr, A_STR);
     }
 
     /* Lose constitution */
-    if (trap & (CHEST_LOSE_CON)) {
+    if (trap.has(ChestTrapType::LOSE_CON)) {
         msg_print(_("仕掛けられていた小さな針に刺されてしまった！", "A small needle has pricked you!"));
         take_hit(this->player_ptr, DAMAGE_NOESCAPE, damroll(1, 4), _("毒針", "a poison needle"));
         (void)do_dec_stat(this->player_ptr, A_CON);
     }
 
     /* Poison */
-    if (trap & (CHEST_POISON)) {
+    if (trap.has(ChestTrapType::POISON)) {
         msg_print(_("突如吹き出した緑色のガスに包み込まれた！", "A puff of green gas surrounds you!"));
         if (!(has_resist_pois(this->player_ptr) || is_oppose_pois(this->player_ptr))) {
             (void)BadStatusSetter(this->player_ptr).mod_poison(10 + randint1(20));
@@ -191,7 +191,7 @@ void Chest::chest_trap(POSITION y, POSITION x, OBJECT_IDX o_idx)
     }
 
     /* Paralyze */
-    if (trap & (CHEST_PARALYZE)) {
+    if (trap.has(ChestTrapType::PARALYZE)) {
         msg_print(_("突如吹き出した黄色いガスに包み込まれた！", "A puff of yellow gas surrounds you!"));
         if (!this->player_ptr->free_act) {
             (void)BadStatusSetter(this->player_ptr).mod_paralysis(10 + randint1(20));
@@ -199,7 +199,7 @@ void Chest::chest_trap(POSITION y, POSITION x, OBJECT_IDX o_idx)
     }
 
     /* Summon monsters */
-    if (trap & (CHEST_SUMMON)) {
+    if (trap.has(ChestTrapType::SUMMON)) {
         int num = 2 + randint1(3);
         msg_print(_("突如吹き出した煙に包み込まれた！", "You are enveloped in a cloud of smoke!"));
         for (i = 0; i < num; i++) {
@@ -211,7 +211,7 @@ void Chest::chest_trap(POSITION y, POSITION x, OBJECT_IDX o_idx)
     }
 
     /* Elemental summon. */
-    if (trap & (CHEST_E_SUMMON)) {
+    if (trap.has(ChestTrapType::E_SUMMON)) {
         msg_print(_("宝を守るためにエレメンタルが現れた！", "Elemental beings appear to protect their treasures!"));
         for (i = 0; i < randint1(3) + 5; i++) {
             (void)summon_specific(this->player_ptr, 0, y, x, mon_level, SUMMON_ELEMENTAL, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
@@ -219,7 +219,7 @@ void Chest::chest_trap(POSITION y, POSITION x, OBJECT_IDX o_idx)
     }
 
     /* Force clouds, then summon birds. */
-    if (trap & (CHEST_BIRD_STORM)) {
+    if (trap.has(ChestTrapType::BIRD_STORM)) {
         msg_print(_("鳥の群れがあなたを取り巻いた！", "A storm of birds swirls around you!"));
 
         for (i = 0; i < randint1(3) + 3; i++)
@@ -231,7 +231,7 @@ void Chest::chest_trap(POSITION y, POSITION x, OBJECT_IDX o_idx)
     }
 
     /* Various colorful summonings. */
-    if (trap & (CHEST_H_SUMMON)) {
+    if (trap.has(ChestTrapType::H_SUMMON)) {
         /* Summon demons. */
         if (one_in_(4)) {
             msg_print(_("炎と硫黄の雲の中に悪魔が姿を現した！", "Demons materialize in clouds of fire and brimstone!"));
@@ -267,7 +267,7 @@ void Chest::chest_trap(POSITION y, POSITION x, OBJECT_IDX o_idx)
     }
 
     /* Dispel player. */
-    if ((trap & (CHEST_RUNES_OF_EVIL)) && o_ptr->k_idx) {
+    if ((trap.has(ChestTrapType::RUNES_OF_EVIL)) && o_ptr->k_idx) {
         msg_print(_("恐ろしい声が響いた:  「暗闇が汝をつつまん！」", "Hideous voices bid:  'Let the darkness have thee!'"));
         for (auto count = 4 + randint0(3); count > 0; count--) {
             if (randint1(100 + o_ptr->pval * 2) <= this->player_ptr->skill_sav) {
@@ -315,13 +315,13 @@ void Chest::chest_trap(POSITION y, POSITION x, OBJECT_IDX o_idx)
     }
 
     /* Aggravate monsters. */
-    if (trap & (CHEST_ALARM)) {
+    if (trap.has(ChestTrapType::ALARM)) {
         msg_print(_("けたたましい音が鳴り響いた！", "An alarm sounds!"));
         aggravate_monsters(this->player_ptr, 0);
     }
 
     /* Explode */
-    if ((trap & (CHEST_EXPLODE)) && o_ptr->k_idx) {
+    if ((trap.has(ChestTrapType::EXPLODE)) && o_ptr->k_idx) {
         msg_print(_("突然、箱が爆発した！", "There is a sudden explosion!"));
         msg_print(_("箱の中の物はすべて粉々に砕け散った！", "Everything inside the chest is destroyed!"));
         o_ptr->pval = 0;
@@ -329,7 +329,7 @@ void Chest::chest_trap(POSITION y, POSITION x, OBJECT_IDX o_idx)
         take_hit(this->player_ptr, DAMAGE_ATTACK, damroll(5, 8), _("爆発する箱", "an exploding chest"));
     }
     /* Scatter contents. */
-    if ((trap & (CHEST_SCATTER)) && o_ptr->k_idx) {
+    if ((trap.has(ChestTrapType::SCATTER)) && o_ptr->k_idx) {
         msg_print(_("宝箱の中身はダンジョンじゅうに散乱した！", "The contents of the chest scatter all over the dungeon!"));
         this->chest_death(true, y, x, o_idx);
         o_ptr->pval = 0;

--- a/src/specific-object/chest.h
+++ b/src/specific-object/chest.h
@@ -3,5 +3,13 @@
 #include "system/angband.h"
 
 struct player_type;
-void chest_death(player_type *player_ptr, bool scatter, POSITION y, POSITION x, OBJECT_IDX o_idx);
-void chest_trap(player_type *player_ptr, POSITION y, POSITION x, OBJECT_IDX o_idx);
+class Chest {
+public:
+    Chest(player_type *player_ptr);
+    virtual ~Chest() = default;
+    void chest_death(bool scatter, POSITION y, POSITION x, OBJECT_IDX o_idx);
+    void chest_trap(POSITION y, POSITION x, OBJECT_IDX o_idx);
+
+private:
+    player_type *player_ptr;
+};


### PR DESCRIPTION
~~注：このブランチはコンパイルできません~~
コンパイルが通るように調整しました
証人クエやその他箱のデバッグ生成をした感じ、問題なさそうです
ご確認下さい

~~trap.h に定義されているChestTrapType (developではdefine定数の塊)ですが、chest\_traps にて配列 (このブランチにてvectorに変換)で定義されています
chest\_traps の実体はtrap.cpp にありますが、現在かなりの力技で定義しています
vector\<EnumClassFlagGroup\<ChestTrapType\>\> で定義したいところですが、vectorに変数名を宣言せずEnumClassFlagGroupを埋め込む記法がイマイチ分かっていません
お手数ですがご確認下さい~~