### PR TITLE
[Refactor] 青魔法のタイプを enum から enum class にする

### DIFF
--- a/src/blue-magic/blue-magic-checker.cpp
+++ b/src/blue-magic/blue-magic-checker.cpp
@@ -54,36 +54,33 @@ void learn_spell(player_type *player_ptr, RF_ABILITY monspell)
 }
 
 /*!
- * @brief モンスター特殊能力のフラグ配列から特定条件の魔法だけを抜き出す処理
+ * @brief モンスター特殊能力のフラグ配列から特定のタイプの能力だけを抜き出す処理
  * Extract monster spells mask for the given mode
- * @param f4 モンスター特殊能力の4番目のフラグ配列
- * @param f5 モンスター特殊能力の5番目のフラグ配列
- * @param f6 モンスター特殊能力の6番目のフラグ配列
- * @param mode 抜き出したい条件
- * @todo f4, f5, f6を構造体にまとめ直す
+ * @param ability_flags モンスター特殊能力のフラグ集合
+ * @param type 抜き出したいタイプ
  */
-void set_rf_masks(EnumClassFlagGroup<RF_ABILITY> &ability_flags, blue_magic_type mode)
+void set_rf_masks(EnumClassFlagGroup<RF_ABILITY> &ability_flags, BlueMagicType type)
 {
     ability_flags.clear();
 
-    switch (mode) {
-    case MONSPELL_TYPE_BOLT:
+    switch (type) {
+    case BlueMagicType::BOLT:
         ability_flags.set(RF_ABILITY_BOLT_MASK | RF_ABILITY_BEAM_MASK).reset(RF_ABILITY::ROCKET);
         break;
 
-    case MONSPELL_TYPE_BALL:
+    case BlueMagicType::BALL:
         ability_flags.set(RF_ABILITY_BALL_MASK).reset(RF_ABILITY_BREATH_MASK);
         break;
 
-    case MONSPELL_TYPE_BREATH:
+    case BlueMagicType::BREATH:
         ability_flags.set(RF_ABILITY_BREATH_MASK);
         break;
 
-    case MONSPELL_TYPE_SUMMON:
+    case BlueMagicType::SUMMON:
         ability_flags.set(RF_ABILITY_SUMMON_MASK);
         break;
 
-    case MONSPELL_TYPE_OTHER:
+    case BlueMagicType::OTHER:
         ability_flags.set(RF_ABILITY_ATTACK_MASK);
         ability_flags.reset(RF_ABILITY_BOLT_MASK | RF_ABILITY_BEAM_MASK | RF_ABILITY_BALL_MASK | RF_ABILITY_INDIRECT_MASK);
         break;

--- a/src/blue-magic/blue-magic-checker.h
+++ b/src/blue-magic/blue-magic-checker.h
@@ -8,8 +8,8 @@
 #include "monster-race/race-ability-flags.h"
 #include "util/flag-group.h"
 
-enum blue_magic_type : int;
+enum class BlueMagicType;
 
 struct player_type;
 void learn_spell(player_type *player_ptr, RF_ABILITY monspell);
-void set_rf_masks(EnumClassFlagGroup<RF_ABILITY> &ability_flags, blue_magic_type mode);
+void set_rf_masks(EnumClassFlagGroup<RF_ABILITY> &ability_flags, BlueMagicType type);

--- a/src/blue-magic/learnt-power-getter.cpp
+++ b/src/blue-magic/learnt-power-getter.cpp
@@ -184,7 +184,7 @@ static bool check_blue_magic_kind(learnt_magic_type *lm_ptr)
 static bool sweep_learnt_spells(learnt_magic_type *lm_ptr)
 {
     EnumClassFlagGroup<RF_ABILITY> ability_flags;
-    set_rf_masks(ability_flags, i2enum<blue_magic_type>(lm_ptr->mode));
+    set_rf_masks(ability_flags, i2enum<BlueMagicType>(lm_ptr->mode));
 
     EnumClassFlagGroup<RF_ABILITY>::get_flags(ability_flags, std::back_inserter(lm_ptr->blue_magics));
     lm_ptr->count = ability_flags.count();

--- a/src/io-dump/special-class-dump.cpp
+++ b/src/io-dump/special-class-dump.cpp
@@ -122,28 +122,28 @@ static void dump_smith(player_type *player_ptr, FILE *fff)
  * @param spell_type 魔法の種類
  * @param learnt_spell_ptr 学習済魔法のテーブル
  */
-static void add_monster_spell_type(char p[][80], int col, blue_magic_type spell_type, learnt_spell_table *learnt_spell_ptr)
+static void add_monster_spell_type(char p[][80], int col, BlueMagicType spell_type, learnt_spell_table *learnt_spell_ptr)
 {
     learnt_spell_ptr->ability_flags.clear();
     set_rf_masks(learnt_spell_ptr->ability_flags, spell_type);
     switch (spell_type) {
-    case MONSPELL_TYPE_BOLT:
+    case BlueMagicType::BOLT:
         strcat(p[col], _("\n     [ボルト型]\n", "\n     [Bolt  Type]\n"));
         break;
 
-    case MONSPELL_TYPE_BALL:
+    case BlueMagicType::BALL:
         strcat(p[col], _("\n     [ボール型]\n", "\n     [Ball  Type]\n"));
         break;
 
-    case MONSPELL_TYPE_BREATH:
+    case BlueMagicType::BREATH:
         strcat(p[col], _("\n     [ブレス型]\n", "\n     [  Breath  ]\n"));
         break;
 
-    case MONSPELL_TYPE_SUMMON:
+    case BlueMagicType::SUMMON:
         strcat(p[col], _("\n     [召喚魔法]\n", "\n     [Summonning]\n"));
         break;
 
-    case MONSPELL_TYPE_OTHER:
+    case BlueMagicType::OTHER:
         strcat(p[col], _("\n     [ その他 ]\n", "\n     [Other Type]\n"));
         break;
     }

--- a/src/mind/mind-blue-mage.h
+++ b/src/mind/mind-blue-mage.h
@@ -2,21 +2,21 @@
 
 #include <array>
 
-enum blue_magic_type : int {
-    MONSPELL_TYPE_BOLT = 1,
-    MONSPELL_TYPE_BALL = 2,
-    MONSPELL_TYPE_BREATH = 3,
-    MONSPELL_TYPE_SUMMON = 4,
-    MONSPELL_TYPE_OTHER = 5,
+enum class BlueMagicType {
+    BOLT = 1,
+    BALL = 2,
+    BREATH = 3,
+    SUMMON = 4,
+    OTHER = 5,
 };
 
 struct player_type;
 bool do_cmd_cast_learned(player_type *player_ptr);
 
 inline constexpr std::array BLUE_MAGIC_TYPE_LIST = {
-    MONSPELL_TYPE_BOLT,
-    MONSPELL_TYPE_BALL,
-    MONSPELL_TYPE_BREATH,
-    MONSPELL_TYPE_SUMMON,
-    MONSPELL_TYPE_OTHER,
+    BlueMagicType::BOLT,
+    BlueMagicType::BALL,
+    BlueMagicType::BREATH,
+    BlueMagicType::SUMMON,
+    BlueMagicType::OTHER,
 };


### PR DESCRIPTION
青魔法のタイプ blue_magic_type を enum から enum class に変更する。
それに関連して set_rf_masks の引数名を修正するとともに、Doxygen
コメントの内容がモンスター特殊能力の FlagGroup 化前の物だったので
現状に合わせて修正する。

https://github.com/hengband/hengband/pull/1628#pullrequestreview-763071815 でコメントされた内容に対応しました。
小修正につき Issue は無し。