### PR TITLE
[Refactor] 魔道具術師の固有データを magic_num から分離する

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -275,6 +275,7 @@
     <ClCompile Include="..\..\src\object-enchant\smith-tables.cpp" />
     <ClCompile Include="..\..\src\player-base\player-class.cpp" />
     <ClCompile Include="..\..\src\player-base\player-race.cpp" />
+    <ClCompile Include="..\..\src\player-info\magic-eater-data-type.cpp" />
     <ClCompile Include="..\..\src\save\player-class-specific-data-writer.cpp" />
     <ClCompile Include="..\..\src\system\grid-type-definition.cpp" />
     <ClCompile Include="..\..\src\grid\feature-action-flags.cpp" />
@@ -995,6 +996,7 @@
     <ClInclude Include="..\..\src\player-info\class-specific-data.h" />
     <ClInclude Include="..\..\src\player-info\equipment-info.h" />
     <ClInclude Include="..\..\src\player-info\force-trainer-data-type.h" />
+    <ClInclude Include="..\..\src\player-info\magic-eater-data-type.h" />
     <ClInclude Include="..\..\src\player-info\smith-data-type.h" />
     <ClInclude Include="..\..\src\player-info\spell-hex-data-type.h" />
     <ClInclude Include="..\..\src\player-status\player-energy.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2346,6 +2346,9 @@
     <ClCompile Include="..\..\src\save\player-class-specific-data-writer.cpp">
       <Filter>save</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\player-info\magic-eater-data-type.cpp">
+      <Filter>player-info</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5060,6 +5063,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\save\player-class-specific-data-writer.h">
       <Filter>save</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\magic-eater-data-type.h">
+      <Filter>player-info</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -669,6 +669,7 @@ hengband_SOURCES = \
 	player-info/class-specific-data.h \
 	player-info/equipment-info.cpp player-info/equipment-info.h \
 	player-info/force-trainer-data-type.h \
+	player-info/magic-eater-data-type.cpp player-info/magic-eater-data-type.h \
 	player-info/mimic-info-table.cpp player-info/mimic-info-table.h \
 	player-info/mutation-info.cpp player-info/mutation-info.h \
 	player-info/race-ability-info.cpp player-info/race-ability-info.h \

--- a/src/cmd-building/cmd-inn.cpp
+++ b/src/cmd-building/cmd-inn.cpp
@@ -5,6 +5,8 @@
 #include "io/write-diary.h"
 #include "market/bounty.h"
 #include "market/building-actions-table.h"
+#include "player-base/player-class.h"
+#include "player-info/magic-eater-data-type.h"
 #include "player-info/race-info.h"
 #include "player-info/race-types.h"
 #include "player/digestion-processor.h"
@@ -130,21 +132,23 @@ static void back_to_health(player_type *player_ptr)
 }
 
 /*!
- * @brief 魔力喰いの残り回数回復(本当？ 要調査)
+ * @brief 魔道具術師の取り込んだ魔法をすべて完全に回復した状態にする
  * @param player_ptr プレイヤーへの参照ポインタ
  */
 static void charge_magic_eating_energy(player_type *player_ptr)
 {
-    if (player_ptr->pclass != CLASS_MAGIC_EATER)
+    auto magic_eater_data = PlayerClass(player_ptr).get_specific_data<magic_eater_data_type>();
+    if (!magic_eater_data) {
         return;
-
-    int i;
-    for (i = 0; i < 72; i++) {
-        player_ptr->magic_num1[i] = player_ptr->magic_num2[i] * EATER_CHARGE;
     }
 
-    for (; i < MAX_SPELLS; i++) {
-        player_ptr->magic_num1[i] = 0;
+    for (auto tval : { TV_STAFF, TV_WAND }) {
+        for (auto &item : magic_eater_data->get_item_group(tval)) {
+            item.charge = item.count * EATER_CHARGE;
+        }
+    }
+    for (auto &item : magic_eater_data->get_item_group(TV_ROD)) {
+        item.charge = 0;
     }
 }
 

--- a/src/cmd-item/cmd-magiceat.cpp
+++ b/src/cmd-item/cmd-magiceat.cpp
@@ -67,7 +67,9 @@
 #include "main/sound-of-music.h"
 #include "object/object-kind-hook.h"
 #include "object/object-kind.h"
+#include "player-base/player-class.h"
 #include "player-info/class-info.h"
+#include "player-info/magic-eater-data-type.h"
 #include "player-status/player-energy.h"
 #include "player/player-status-table.h"
 #include "spell/spell-info.h"
@@ -83,14 +85,60 @@
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 
+#include <algorithm>
+#include <optional>
+#include <tuple>
+
+static std::optional<std::tuple<tval_type, OBJECT_SUBTYPE_VALUE>> check_magic_eater_spell_repeat(magic_eater_data_type *magic_eater_data)
+{
+    COMMAND_CODE sn;
+    if (!repeat_pull(&sn)) {
+        return std::nullopt;
+    }
+
+    tval_type tval = TV_NONE;
+    if (EATER_STAFF_BASE <= sn && sn < EATER_STAFF_BASE + EATER_ITEM_GROUP_SIZE) {
+        tval = TV_STAFF;
+    } else if (EATER_WAND_BASE <= sn && sn < EATER_WAND_BASE + EATER_ITEM_GROUP_SIZE) {
+        tval = TV_WAND;
+    } else if (EATER_ROD_BASE <= sn && sn < EATER_ROD_BASE + EATER_ITEM_GROUP_SIZE) {
+        tval = TV_ROD;
+    }
+
+    const auto &item_group = magic_eater_data->get_item_group(tval);
+    auto sval = sn % EATER_ITEM_GROUP_SIZE;
+    if (sval >= static_cast<int>(item_group.size())) {
+        return std::nullopt;
+    }
+
+    auto &item = item_group[sval];
+    /* Verify the spell */
+    switch (tval) {
+    case TV_ROD:
+        if (item.charge <= k_info[lookup_kind(TV_ROD, sval)].pval * (item.count - 1) * EATER_ROD_CHARGE) {
+            return std::make_tuple(tval, sval);
+        }
+        break;
+    case TV_STAFF:
+    case TV_WAND:
+        if (item.charge >= EATER_CHARGE) {
+            return std::make_tuple(tval, sval);
+        }
+        break;
+    default:
+        break;
+    }
+
+    return std::nullopt;
+}
+
 /*!
  * @brief 魔道具術師の取り込んだ魔力一覧から選択/閲覧する /
  * @param only_browse 閲覧するだけならばTRUE
  * @return 選択した魔力のID、キャンセルならば-1を返す
  */
-static OBJECT_SUBTYPE_VALUE select_magic_eater(player_type *player_ptr, bool only_browse)
+static std::optional<std::tuple<tval_type, OBJECT_SUBTYPE_VALUE>> select_magic_eater(player_type *player_ptr, bool only_browse)
 {
-    OBJECT_SUBTYPE_VALUE ext = 0;
     char choice;
     bool flag, request_list;
     tval_type tval = TV_NONE;
@@ -100,24 +148,11 @@ static OBJECT_SUBTYPE_VALUE select_magic_eater(player_type *player_ptr, bool onl
 
     int menu_line = (use_menu ? 1 : 0);
 
-    COMMAND_CODE sn;
-    if (repeat_pull(&sn)) {
-        /* Verify the spell */
-        if (sn >= EATER_EXT * 2
-            && !(player_ptr->magic_num1[sn] > k_info[lookup_kind(TV_ROD, sn - EATER_EXT * 2)].pval * (player_ptr->magic_num2[sn] - 1) * EATER_ROD_CHARGE))
-            return sn;
-        else if (sn < EATER_EXT * 2 && !(player_ptr->magic_num1[sn] < EATER_CHARGE))
-            return sn;
-    }
+    auto magic_eater_data = PlayerClass(player_ptr).get_specific_data<magic_eater_data_type>();
 
-    for (i = 0; i < MAX_SPELLS; i++) {
-        if (player_ptr->magic_num2[i])
-            break;
-    }
-
-    if (i == MAX_SPELLS) {
-        msg_print(_("魔法を覚えていない！", "You don't have any magic!"));
-        return -1;
+    if (auto result = check_magic_eater_spell_repeat(magic_eater_data.get());
+        result.has_value()) {
+        return result;
     }
 
     if (use_menu) {
@@ -145,7 +180,7 @@ static OBJECT_SUBTYPE_VALUE select_magic_eater(player_type *player_ptr, bool onl
             case 'z':
             case 'Z':
                 screen_load();
-                return -1;
+                return std::nullopt;
             case '2':
             case 'j':
             case 'J':
@@ -159,7 +194,6 @@ static OBJECT_SUBTYPE_VALUE select_magic_eater(player_type *player_ptr, bool onl
             case '\r':
             case 'x':
             case 'X':
-                ext = (menu_line - 1) * EATER_EXT;
                 if (menu_line == 1)
                     tval = TV_STAFF;
                 else if (menu_line == 2)
@@ -175,35 +209,34 @@ static OBJECT_SUBTYPE_VALUE select_magic_eater(player_type *player_ptr, bool onl
     } else {
         while (true) {
             if (!get_com(_("[A] 杖, [B] 魔法棒, [C] ロッド:", "[A] staff, [B] wand, [C] rod:"), &choice, true)) {
-                return -1;
+                return std::nullopt;
             }
             if (choice == 'A' || choice == 'a') {
-                ext = 0;
                 tval = TV_STAFF;
                 break;
             }
             if (choice == 'B' || choice == 'b') {
-                ext = EATER_EXT;
                 tval = TV_WAND;
                 break;
             }
             if (choice == 'C' || choice == 'c') {
-                ext = EATER_EXT * 2;
                 tval = TV_ROD;
                 break;
             }
         }
     }
-    for (i = ext; i < ext + EATER_EXT; i++) {
-        if (player_ptr->magic_num2[i]) {
-            if (use_menu)
-                menu_line = i - ext + 1;
-            break;
-        }
-    }
-    if (i == ext + EATER_EXT) {
+
+    const auto &item_group = magic_eater_data->get_item_group(tval);
+
+    if (auto it = std::find_if(item_group.begin(), item_group.end(),
+            [](const auto &item) { return item.count > 0; });
+        it == item_group.end()) {
         msg_print(_("その種類の魔法は覚えていない！", "You don't have that type of magic!"));
-        return -1;
+        return std::nullopt;
+    } else {
+        if (use_menu) {
+            menu_line = 1 + std::distance(std::begin(item_group), it);
+        }
     }
 
     /* Nothing chosen yet */
@@ -217,6 +250,7 @@ static OBJECT_SUBTYPE_VALUE select_magic_eater(player_type *player_ptr, bool onl
 
     request_list = always_show_list;
 
+    const int ITEM_GROUP_SIZE = item_group.size();
     while (!flag) {
         /* Show the list */
         if (request_list || use_menu) {
@@ -248,8 +282,9 @@ static OBJECT_SUBTYPE_VALUE select_magic_eater(player_type *player_ptr, bool onl
 #endif
 
             /* Print list */
-            for (ctr = 0; ctr < EATER_EXT; ctr++) {
-                if (!player_ptr->magic_num2[ctr + ext])
+            for (ctr = 0; ctr < ITEM_GROUP_SIZE; ctr++) {
+                auto &item = item_group[ctr];
+                if (item.count == 0)
                     continue;
 
                 k_idx = lookup_kind(tval, ctr);
@@ -269,8 +304,8 @@ static OBJECT_SUBTYPE_VALUE select_magic_eater(player_type *player_ptr, bool onl
                         letter = '0' + ctr - 26;
                     sprintf(dummy, "%c)", letter);
                 }
-                x1 = ((ctr < EATER_EXT / 2) ? x : x + 40);
-                y1 = ((ctr < EATER_EXT / 2) ? y + ctr : y + ctr - EATER_EXT / 2);
+                x1 = ((ctr < ITEM_GROUP_SIZE / 2) ? x : x + 40);
+                y1 = ((ctr < ITEM_GROUP_SIZE / 2) ? y + ctr : y + ctr - ITEM_GROUP_SIZE / 2);
                 level = (tval == TV_ROD ? k_info[k_idx].level * 5 / 6 - 5 : k_info[k_idx].level);
                 chance = level * 4 / 5 + 20;
                 chance -= 3 * (adj_mag_stat[player_ptr->stat_index[mp_ptr->spell_stat]] - 1);
@@ -294,16 +329,15 @@ static OBJECT_SUBTYPE_VALUE select_magic_eater(player_type *player_ptr, bool onl
                     if (tval == TV_ROD) {
                         strcat(dummy,
                             format(_(" %-22.22s 充填:%2d/%2d%3d%%", " %-22.22s   (%2d/%2d) %3d%%"), k_info[k_idx].name.c_str(),
-                                player_ptr->magic_num1[ctr + ext] ? (player_ptr->magic_num1[ctr + ext] - 1) / (EATER_ROD_CHARGE * k_info[k_idx].pval) + 1
-                                                                    : 0,
-                                player_ptr->magic_num2[ctr + ext], chance));
-                        if (player_ptr->magic_num1[ctr + ext] > k_info[k_idx].pval * (player_ptr->magic_num2[ctr + ext] - 1) * EATER_ROD_CHARGE)
+                                item.charge ? (item.charge - 1) / (EATER_ROD_CHARGE * k_info[k_idx].pval) + 1 : 0,
+                                item.count, chance));
+                        if (item.charge > k_info[k_idx].pval * (item.count - 1) * EATER_ROD_CHARGE)
                             col = TERM_RED;
                     } else {
                         strcat(dummy,
-                            format(" %-22.22s    %2d/%2d %3d%%", k_info[k_idx].name.c_str(), (int16_t)(player_ptr->magic_num1[ctr + ext] / EATER_CHARGE),
-                                player_ptr->magic_num2[ctr + ext], chance));
-                        if (player_ptr->magic_num1[ctr + ext] < EATER_CHARGE)
+                            format(" %-22.22s    %2d/%2d %3d%%", k_info[k_idx].name.c_str(), (int16_t)(item.charge / EATER_CHARGE),
+                                item.count, chance));
+                        if (item.charge < EATER_CHARGE)
                             col = TERM_RED;
                     }
                 } else
@@ -319,17 +353,17 @@ static OBJECT_SUBTYPE_VALUE select_magic_eater(player_type *player_ptr, bool onl
             switch (choice) {
             case '0': {
                 screen_load();
-                return 0;
+                return std::nullopt;
             }
 
             case '8':
             case 'k':
             case 'K': {
                 do {
-                    menu_line += EATER_EXT - 1;
-                    if (menu_line > EATER_EXT)
-                        menu_line -= EATER_EXT;
-                } while (!player_ptr->magic_num2[menu_line + ext - 1]);
+                    menu_line += ITEM_GROUP_SIZE - 1;
+                    if (menu_line > ITEM_GROUP_SIZE)
+                        menu_line -= ITEM_GROUP_SIZE;
+                } while (item_group[menu_line - 1].count == 0);
                 break;
             }
 
@@ -338,9 +372,9 @@ static OBJECT_SUBTYPE_VALUE select_magic_eater(player_type *player_ptr, bool onl
             case 'J': {
                 do {
                     menu_line++;
-                    if (menu_line > EATER_EXT)
-                        menu_line -= EATER_EXT;
-                } while (!player_ptr->magic_num2[menu_line + ext - 1]);
+                    if (menu_line > ITEM_GROUP_SIZE)
+                        menu_line -= ITEM_GROUP_SIZE;
+                } while (item_group[menu_line - 1].count == 0);
                 break;
             }
 
@@ -353,19 +387,19 @@ static OBJECT_SUBTYPE_VALUE select_magic_eater(player_type *player_ptr, bool onl
                 bool reverse = false;
                 if ((choice == '4') || (choice == 'h') || (choice == 'H'))
                     reverse = true;
-                if (menu_line > EATER_EXT / 2) {
-                    menu_line -= EATER_EXT / 2;
+                if (menu_line > ITEM_GROUP_SIZE / 2) {
+                    menu_line -= ITEM_GROUP_SIZE / 2;
                     reverse = true;
                 } else
-                    menu_line += EATER_EXT / 2;
-                while (!player_ptr->magic_num2[menu_line + ext - 1]) {
+                    menu_line += ITEM_GROUP_SIZE / 2;
+                while (item_group[menu_line - 1].count == 0) {
                     if (reverse) {
                         menu_line--;
                         if (menu_line < 2)
                             reverse = false;
                     } else {
                         menu_line++;
-                        if (menu_line > EATER_EXT - 1)
+                        if (menu_line > ITEM_GROUP_SIZE - 1)
                             reverse = true;
                     }
                 }
@@ -420,7 +454,7 @@ static OBJECT_SUBTYPE_VALUE select_magic_eater(player_type *player_ptr, bool onl
         }
 
         /* Totally Illegal */
-        if ((i < 0) || (i > EATER_EXT) || !player_ptr->magic_num2[i + ext]) {
+        if ((i < 0) || (i > ITEM_GROUP_SIZE) || item_group[i].count == 0) {
             bell();
             continue;
         }
@@ -437,8 +471,9 @@ static OBJECT_SUBTYPE_VALUE select_magic_eater(player_type *player_ptr, bool onl
                 if (!get_check(tmp_val))
                     continue;
             }
+            auto &item = item_group[i];
             if (tval == TV_ROD) {
-                if (player_ptr->magic_num1[ext + i] > k_info[lookup_kind(tval, i)].pval * (player_ptr->magic_num2[ext + i] - 1) * EATER_ROD_CHARGE) {
+                if (item.charge > k_info[lookup_kind(tval, i)].pval * (item.count - 1) * EATER_ROD_CHARGE) {
                     msg_print(_("その魔法はまだ充填している最中だ。", "The magic is still charging."));
                     msg_print(nullptr);
                     if (use_menu)
@@ -446,7 +481,7 @@ static OBJECT_SUBTYPE_VALUE select_magic_eater(player_type *player_ptr, bool onl
                     continue;
                 }
             } else {
-                if (player_ptr->magic_num1[ext + i] < EATER_CHARGE) {
+                if (item.charge < EATER_CHARGE) {
                     msg_print(_("その魔法は使用回数が切れている。", "The magic has no charges left."));
                     msg_print(nullptr);
                     if (use_menu)
@@ -482,10 +517,25 @@ static OBJECT_SUBTYPE_VALUE select_magic_eater(player_type *player_ptr, bool onl
     screen_load();
 
     if (!flag)
-        return -1;
+        return std::nullopt;
 
-    repeat_push(ext + i);
-    return ext + i;
+    COMMAND_CODE base = 0;
+    switch (tval) {
+    case TV_STAFF:
+        base = EATER_STAFF_BASE;
+        break;
+    case TV_WAND:
+        base = EATER_WAND_BASE;
+        break;
+    case TV_ROD:
+        base = EATER_ROD_BASE;
+    default:
+        break;
+    }
+
+    repeat_push(base + i);
+
+    return std::make_tuple(tval, i);
 }
 
 /*!
@@ -497,29 +547,18 @@ static OBJECT_SUBTYPE_VALUE select_magic_eater(player_type *player_ptr, bool onl
  */
 bool do_cmd_magic_eater(player_type *player_ptr, bool only_browse, bool powerful)
 {
-    tval_type tval;
-    OBJECT_SUBTYPE_VALUE sval;
     bool use_charge = true;
 
     if (cmd_limit_confused(player_ptr))
         return false;
 
-    auto item = select_magic_eater(player_ptr, only_browse);
+    auto result = select_magic_eater(player_ptr, only_browse);
     PlayerEnergy energy(player_ptr);
-    if (item == -1) {
+    if (!result.has_value()) {
         energy.reset_player_turn();
         return false;
     }
-    if (item >= EATER_EXT * 2) {
-        tval = TV_ROD;
-        sval = item - EATER_EXT * 2;
-    } else if (item >= EATER_EXT) {
-        tval = TV_WAND;
-        sval = item - EATER_EXT;
-    } else {
-        tval = TV_STAFF;
-        sval = item;
-    }
+    auto [tval, sval] = result.value();
 
     auto k_idx = lookup_kind(tval, sval);
     auto level = (tval == TV_ROD ? k_info[k_idx].level * 5 / 6 - 5 : k_info[k_idx].level);
@@ -573,11 +612,14 @@ bool do_cmd_magic_eater(player_type *player_ptr, bool only_browse, bool powerful
             chg_virtue(player_ptr, V_CHANCE, 1);
     }
 
+    auto magic_eater_data = PlayerClass(player_ptr).get_specific_data<magic_eater_data_type>();
+    auto &item = magic_eater_data->get_item_group(tval)[sval];
+
     energy.set_player_turn_energy(100);
     if (tval == TV_ROD)
-        player_ptr->magic_num1[item] += k_info[k_idx].pval * EATER_ROD_CHARGE;
+        item.charge += k_info[k_idx].pval * EATER_ROD_CHARGE;
     else
-        player_ptr->magic_num1[item] -= EATER_CHARGE;
+        item.charge -= EATER_CHARGE;
 
     return true;
 }

--- a/src/cmd-item/cmd-magiceat.h
+++ b/src/cmd-item/cmd-magiceat.h
@@ -1,8 +1,4 @@
 ﻿#pragma once
 
-#define EATER_EXT 36
-#define EATER_CHARGE 0x10000L
-#define EATER_ROD_CHARGE 0x10L
-
 struct player_type;
 bool do_cmd_magic_eater(player_type *player_ptr, bool only_browse, bool powerful);

--- a/src/load/player-class-specific-data-loader.h
+++ b/src/load/player-class-specific-data-loader.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "system/angband.h"
 #include "system/system-variables.h"
@@ -7,6 +7,7 @@ struct no_class_specific_data;
 struct smith_data_type;
 struct force_trainer_data_type;
 struct bluemage_data_type;
+struct magic_eater_data_type;
 struct spell_hex_data_type;
 
 class PlayerClassSpecificDataLoader {
@@ -24,6 +25,7 @@ public:
     void operator()(std::shared_ptr<smith_data_type> &smith_data) const;
     void operator()(std::shared_ptr<force_trainer_data_type> &) const;
     void operator()(std::shared_ptr<bluemage_data_type> &bluemage_data) const;
+    void operator()(std::shared_ptr<magic_eater_data_type> &magic_eater_data) const;
 
 private:
     int32_t (&magic_num1)[MAX_SPELLS];

--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -9,6 +9,7 @@
 #include "core/player-update-types.h"
 #include "player-info/bluemage-data-type.h"
 #include "player-info/force-trainer-data-type.h"
+#include "player-info/magic-eater-data-type.h"
 #include "player-info/smith-data-type.h"
 #include "player-info/spell-hex-data-type.h"
 #include "player/attack-defense-types.h"
@@ -72,6 +73,9 @@ void PlayerClass::init_specific_data()
         break;
     case CLASS_BLUE_MAGE:
         this->player_ptr->class_specific_data = std::make_shared<bluemage_data_type>();
+        break;
+    case CLASS_MAGIC_EATER:
+        this->player_ptr->class_specific_data = std::make_shared<magic_eater_data_type>();
         break;
     case CLASS_HIGH_MAGE:
         if (this->player_ptr->realm1 == REALM_HEX) {

--- a/src/player-info/bluemage-data-type.h
+++ b/src/player-info/bluemage-data-type.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "system/angband.h"
 

--- a/src/player-info/class-specific-data.h
+++ b/src/player-info/class-specific-data.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <memory>
 #include <variant>
@@ -8,6 +8,7 @@ struct no_class_specific_data {
 struct smith_data_type;
 struct force_trainer_data_type;
 struct bluemage_data_type;
+struct magic_eater_data_type;
 struct spell_hex_data_type;
 
 using ClassSpecificData = std::variant<
@@ -16,6 +17,7 @@ using ClassSpecificData = std::variant<
     std::shared_ptr<smith_data_type>,
     std::shared_ptr<force_trainer_data_type>,
     std::shared_ptr<bluemage_data_type>,
+    std::shared_ptr<magic_eater_data_type>,
     std::shared_ptr<spell_hex_data_type>
 
     >;

--- a/src/player-info/force-trainer-data-type.h
+++ b/src/player-info/force-trainer-data-type.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "system/angband.h"
 

--- a/src/player-info/magic-eater-data-type.cpp
+++ b/src/player-info/magic-eater-data-type.cpp
@@ -1,0 +1,32 @@
+﻿#include "player-info/magic-eater-data-type.h"
+#include "sv-definition/sv-rod-types.h"
+#include "sv-definition/sv-staff-types.h"
+#include "sv-definition/sv-wand-types.h"
+
+magic_eater_data_type::magic_eater_data_type()
+    : staves(SV_STAFF_MAX)
+    , wands(SV_WAND_MAX)
+    , rods(SV_ROD_MAX)
+{
+}
+
+/*!
+ * @brief 指定した種類の取り込んだ魔道具のデータの配列を取得する
+ *
+ * @param tval 魔道具の種類(TV_STAFF/TV_WAND/TV_ROD)を指定する
+ * @return tvalで指定した種類の取り込んだ魔道具のデータ配列の参照
+ */
+std::vector<magic_eater_data_type::magic_type> &magic_eater_data_type::get_item_group(tval_type tval)
+{
+    switch (tval) {
+    case TV_STAFF:
+        return this->staves;
+    case TV_WAND:
+        return this->wands;
+    case TV_ROD:
+        return this->rods;
+    default:
+        // ダミーデータ。通常使用されることはない。
+        return magic_eater_data_type::none;
+    }
+}

--- a/src/player-info/magic-eater-data-type.h
+++ b/src/player-info/magic-eater-data-type.h
@@ -1,0 +1,28 @@
+﻿#pragma once
+
+#include "system/angband.h"
+
+#include "object/tval-types.h"
+
+inline constexpr int EATER_ITEM_GROUP_SIZE = 256; //!< 魔道具1種あたりの最大数
+inline constexpr int EATER_STAFF_BASE = 0; //!< 杖の開始番号(繰り返しコマンド用)
+inline constexpr int EATER_WAND_BASE = EATER_STAFF_BASE + EATER_ITEM_GROUP_SIZE; //!< 魔法棒の開始番号(繰り返しコマンド用)
+inline constexpr int EATER_ROD_BASE = EATER_WAND_BASE + EATER_ITEM_GROUP_SIZE; //!< ロッドの開始番号(繰り返しコマンド用)
+inline constexpr int32_t EATER_CHARGE = 0x10000L;
+inline constexpr int32_t EATER_ROD_CHARGE = 0x10L;
+
+struct magic_eater_data_type {
+    struct magic_type {
+        int32_t charge; //!< 充填量 (杖/魔法棒とロッドで仕様が異なる)
+        byte count; //!< 取り込んだ回数(杖/魔法棒)もしくは本数(ロッド)
+    };
+
+    magic_eater_data_type();
+
+    std::vector<magic_type> staves; //!< 杖のデータ
+    std::vector<magic_type> wands; //!< 魔法棒のデータ
+    std::vector<magic_type> rods; //!< ロッドのデータ
+    inline static std::vector<magic_type> none; //!< いずれの魔道具でもないダミー
+
+    std::vector<magic_type> &get_item_group(tval_type tval);
+};

--- a/src/player-info/smith-data-type.h
+++ b/src/player-info/smith-data-type.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "system/angband.h"
 

--- a/src/player-info/spell-hex-data-type.h
+++ b/src/player-info/spell-hex-data-type.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "system/angband.h"
 

--- a/src/save/player-class-specific-data-writer.cpp
+++ b/src/save/player-class-specific-data-writer.cpp
@@ -1,6 +1,7 @@
-#include "save/player-class-specific-data-writer.h"
+﻿#include "save/player-class-specific-data-writer.h"
 #include "player-info/bluemage-data-type.h"
 #include "player-info/force-trainer-data-type.h"
+#include "player-info/magic-eater-data-type.h"
 #include "player-info/smith-data-type.h"
 #include "player-info/spell-hex-data-type.h"
 #include "save/save-util.h"
@@ -26,6 +27,20 @@ void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<force_train
 void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<bluemage_data_type> &bluemage_data) const
 {
     wr_FlagGroup(bluemage_data->learnt_blue_magics, wr_byte);
+}
+
+void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<magic_eater_data_type> &magic_eater_data) const
+{
+    auto write_item_group = [](const auto &item_group) {
+        wr_u16b(static_cast<uint16_t>(item_group.size()));
+        for (const auto &item : item_group) {
+            wr_s32b(item.charge);
+            wr_byte(item.count);
+        }
+    };
+    write_item_group(magic_eater_data->staves);
+    write_item_group(magic_eater_data->wands);
+    write_item_group(magic_eater_data->rods);
 }
 
 void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<spell_hex_data_type> &spell_hex_data) const

--- a/src/save/player-class-specific-data-writer.h
+++ b/src/save/player-class-specific-data-writer.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <memory>
 
@@ -7,6 +7,7 @@ struct spell_hex_data_type;
 struct smith_data_type;
 struct force_trainer_data_type;
 struct bluemage_data_type;
+struct magic_eater_data_type;
 
 class PlayerClassSpecificDataWriter {
 public:
@@ -15,4 +16,5 @@ public:
     void operator()(const std::shared_ptr<smith_data_type> &smith_data) const;
     void operator()(const std::shared_ptr<force_trainer_data_type> &force_trainer_data) const;
     void operator()(const std::shared_ptr<bluemage_data_type> &bluemage_data) const;
+    void operator()(const std::shared_ptr<magic_eater_data_type> &magic_eater_data) const;
 };

--- a/src/sv-definition/sv-rod-types.h
+++ b/src/sv-definition/sv-rod-types.h
@@ -33,4 +33,5 @@ enum sv_rod_type {
     SV_ROD_HAVOC = 28,
     SV_ROD_STONE_TO_MUD = 29,
     SV_ROD_AGGRAVATE = 30,
+    SV_ROD_MAX,
 };

--- a/src/sv-definition/sv-staff-types.h
+++ b/src/sv-definition/sv-staff-types.h
@@ -35,4 +35,5 @@ enum sv_staff_type {
     SV_STAFF_ANIMATE_DEAD = 30,
     SV_STAFF_MSTORM = 31,
     SV_STAFF_NOTHING = 32,
+    SV_STAFF_MAX,
 };

--- a/src/sv-definition/sv-wand-types.h
+++ b/src/sv-definition/sv-wand-types.h
@@ -34,4 +34,5 @@ enum sv_wand_type {
     SV_WAND_ROCKETS = 29,
     SV_WAND_STRIKING = 30,
     SV_WAND_GENOCIDE = 31,
+    SV_WAND_MAX,
 };


### PR DESCRIPTION
引き続き、魔道具術師の固有データの分離。
また、 #1633 も副次的に修正される。
それから、これまで追加していた職業固有データのヘッダファイルに BOM が付いていなかったので付けておいた。
（いいかげん VSCode のワークスペース設定で規定のファイルエンコーディングを BOM 付きUTF-8にしておく。）