### PR TITLE
[Fix] 呪術ハイメイジで詠唱一時中断後に詠唱を再開しなくなっている

### DIFF
--- a/src/mspell/mspell-dispel.cpp
+++ b/src/mspell/mspell-dispel.cpp
@@ -81,11 +81,19 @@ static void dispel_player(player_type *player_ptr)
         msg_print(_("手の輝きがなくなった。", "Your hands stop glowing."));
     }
 
-    if (music_singing_any(player_ptr) || SpellHex(player_ptr).is_spelling_any()) {
-        concptr str = (music_singing_any(player_ptr)) ? _("歌", "singing") : _("呪文", "casting");
-        set_interrupting_song_effect(player_ptr, get_singing_song_effect(player_ptr));
-        set_singing_song_effect(player_ptr, MUSIC_NONE);
-        msg_format(_("%sが途切れた。", "Your %s is interrupted."), str);
+    auto song_interruption = music_singing_any(player_ptr);
+    auto spellhex_interruption = SpellHex(player_ptr).is_spelling_any();
+
+    if (song_interruption || spellhex_interruption) {
+        if (song_interruption) {
+            set_interrupting_song_effect(player_ptr, get_singing_song_effect(player_ptr));
+            set_singing_song_effect(player_ptr, MUSIC_NONE);
+            msg_print(_("歌が途切れた。", "Your singing is interrupted."));
+        }
+        if (spellhex_interruption) {
+            SpellHex(player_ptr).interrupt_spelling();
+            msg_print(_("呪文が途切れた。", "Your casting is interrupted."));
+        }
 
         player_ptr->action = ACTION_NONE;
         player_ptr->update |= (PU_BONUS | PU_HP | PU_MONSTERS);

--- a/src/player-info/spell-hex-data-type.h
+++ b/src/player-info/spell-hex-data-type.h
@@ -11,6 +11,7 @@ using HexSpellFlagGroup = FlagGroup<spell_hex_type, HEX_MAX>;
 
 struct spell_hex_data_type {
     HexSpellFlagGroup casting_spells;
+    HexSpellFlagGroup interrupting_spells;
     SpellHexRevengeType revenge_type;
     int32_t revenge_power;
     byte revenge_turn;

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -176,7 +176,7 @@ void SpellHex::decrease_mana()
         return;
     }
 
-    if (!this->is_spelling_any() && !this->player_ptr->magic_num1[1]) {
+    if (this->spell_hex_data->casting_spells.none() && this->spell_hex_data->interrupting_spells.none()) {
         return;
     }
 
@@ -232,21 +232,13 @@ bool SpellHex::process_mana_cost(const bool need_restart)
 
 bool SpellHex::check_restart()
 {
-    return false;
-
-    //! @todo 現状呪術で magic_num1[1] が 0 以外になる事が無いように思える。
-    // spell_hex_data->casting_spells にかかわるのでそのまま残しておくことができないので
-    // プリプロで無効にしておき、常にfalse を返すようにしておく
-    // どういう意図だったのか作成者に確認の必要あり？
-#if 0
-    if (this->player_ptr->magic_num1[1] == 0) {
+    if (this->spell_hex_data->interrupting_spells.none()) {
         return false;
     }
 
-    this->spell_hex_data->casting_spells = this->player_ptr->magic_num1[1];
-    this->player_ptr->magic_num1[1] = 0;
+    this->spell_hex_data->casting_spells = this->spell_hex_data->interrupting_spells;
+    this->spell_hex_data->interrupting_spells.clear();
     return true;
-#endif
 }
 
 int SpellHex::calc_need_mana()
@@ -401,6 +393,12 @@ bool SpellHex::is_spelling_specific(int hex) const
 bool SpellHex::is_spelling_any() const
 {
     return this->spell_hex_data && (this->get_casting_num() > 0);
+}
+
+void SpellHex::interrupt_spelling()
+{
+    this->spell_hex_data->interrupting_spells = this->spell_hex_data->casting_spells;
+    this->spell_hex_data->casting_spells.clear();
 }
 
 /*!

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -29,6 +29,7 @@ public:
     bool check_hex_barrier(MONSTER_IDX m_idx, spell_hex_type type) const;
     bool is_spelling_specific(int hex) const;
     bool is_spelling_any() const;
+    void interrupt_spelling();
     void eyes_on_eyes();
     void thief_teleport();
     void set_casting_flag(spell_hex_type type);


### PR DESCRIPTION
呪術ハイメイジのデータで謎だった magic_num1[1] は、吟遊詩人の詠唱一時
中断処理と共用されている事が分かった。職業固有データに分離した事で一時
中断後に詠唱を再開しなくなってしまっている。
呪術ハイメイジ専用の一時中断する SpellHex::interrupt_spelling を実装し、
呪術ハイメイジの時はそちらを呼ぶことで詠唱の一時中断～再開の処理を
行うようにする。