### PR TITLE
[Refactor/Fix] 職業専用データのメンバに初期化子をつける

### DIFF
--- a/src/player-info/bard-data-type.h
+++ b/src/player-info/bard-data-type.h
@@ -5,8 +5,8 @@
 enum realm_song_type : int;
 
 struct bard_data_type {
-    realm_song_type singing_song; //!< 現在歌っている歌
-    realm_song_type interrputing_song; //!< 中断中の歌(魔力消去などで途切れた後に再開するのに使用)
-    int32_t singing_duration; //!< 現在の歌を継続して歌っている期間
-    byte singing_song_spell_idx; //!< 現在歌っている歌の魔法書(歌集)における要素番号
+    realm_song_type singing_song{}; //!< 現在歌っている歌
+    realm_song_type interrputing_song{}; //!< 中断中の歌(魔力消去などで途切れた後に再開するのに使用)
+    int32_t singing_duration{}; //!< 現在の歌を継続して歌っている期間
+    byte singing_song_spell_idx{}; //!< 現在歌っている歌の魔法書(歌集)における要素番号
 };

--- a/src/player-info/bluemage-data-type.h
+++ b/src/player-info/bluemage-data-type.h
@@ -6,5 +6,5 @@
 #include "util/flag-group.h"
 
 struct bluemage_data_type {
-    EnumClassFlagGroup<RF_ABILITY> learnt_blue_magics;
+    EnumClassFlagGroup<RF_ABILITY> learnt_blue_magics{};
 };

--- a/src/player-info/force-trainer-data-type.h
+++ b/src/player-info/force-trainer-data-type.h
@@ -3,5 +3,5 @@
 #include "system/angband.h"
 
 struct force_trainer_data_type {
-    int32_t ki;
+    int32_t ki{};
 };

--- a/src/player-info/magic-eater-data-type.h
+++ b/src/player-info/magic-eater-data-type.h
@@ -13,16 +13,16 @@ inline constexpr int32_t EATER_ROD_CHARGE = 0x10L;
 
 struct magic_eater_data_type {
     struct magic_type {
-        int32_t charge; //!< 充填量 (杖/魔法棒とロッドで仕様が異なる)
-        byte count; //!< 取り込んだ回数(杖/魔法棒)もしくは本数(ロッド)
+        int32_t charge{}; //!< 充填量 (杖/魔法棒とロッドで仕様が異なる)
+        byte count{}; //!< 取り込んだ回数(杖/魔法棒)もしくは本数(ロッド)
     };
 
     magic_eater_data_type();
 
-    std::vector<magic_type> staves; //!< 杖のデータ
-    std::vector<magic_type> wands; //!< 魔法棒のデータ
-    std::vector<magic_type> rods; //!< ロッドのデータ
-    inline static std::vector<magic_type> none; //!< いずれの魔道具でもないダミー
+    std::vector<magic_type> staves{}; //!< 杖のデータ
+    std::vector<magic_type> wands{}; //!< 魔法棒のデータ
+    std::vector<magic_type> rods{}; //!< ロッドのデータ
+    inline static std::vector<magic_type> none{}; //!< いずれの魔道具でもないダミー
 
     std::vector<magic_type> &get_item_group(tval_type tval);
 };

--- a/src/player-info/smith-data-type.h
+++ b/src/player-info/smith-data-type.h
@@ -7,5 +7,5 @@
 enum class SmithEssence : int16_t;
 
 struct smith_data_type {
-    std::map<SmithEssence, int16_t> essences;
+    std::map<SmithEssence, int16_t> essences{};
 };

--- a/src/player-info/spell-hex-data-type.h
+++ b/src/player-info/spell-hex-data-type.h
@@ -10,9 +10,9 @@ enum class SpellHexRevengeType : byte;
 using HexSpellFlagGroup = FlagGroup<spell_hex_type, HEX_MAX>;
 
 struct spell_hex_data_type {
-    HexSpellFlagGroup casting_spells;
-    HexSpellFlagGroup interrupting_spells;
-    SpellHexRevengeType revenge_type;
-    int32_t revenge_power;
-    byte revenge_turn;
+    HexSpellFlagGroup casting_spells{};
+    HexSpellFlagGroup interrupting_spells{};
+    SpellHexRevengeType revenge_type{};
+    int32_t revenge_power{};
+    byte revenge_turn{};
 };


### PR DESCRIPTION
職業専用データのメンバに初期化子をつけていなかったが、組み込み型の
メンバは初期値が不定になるかもしれない。ひとまず組み込み型以外も
含めすべて {} を付けて確実にデフォルト値で初期化されるようにしておく。