### PR TITLE
[Refactor] ものまね師の専用データを職業固有データに移動する

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -997,6 +997,7 @@
     <ClInclude Include="..\..\src\player-info\equipment-info.h" />
     <ClInclude Include="..\..\src\player-info\force-trainer-data-type.h" />
     <ClInclude Include="..\..\src\player-info\magic-eater-data-type.h" />
+    <ClInclude Include="..\..\src\player-info\mane-data-type.h" />
     <ClInclude Include="..\..\src\player-info\smith-data-type.h" />
     <ClInclude Include="..\..\src\player-info\spell-hex-data-type.h" />
     <ClInclude Include="..\..\src\player-status\player-energy.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -5064,6 +5064,9 @@
     <ClInclude Include="..\..\src\player-info\bard-data-type.h">
       <Filter>player-info</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\player-info\mane-data-type.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\src\wall.bmp" />

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -669,6 +669,7 @@ hengband_SOURCES = \
 	player-info/equipment-info.cpp player-info/equipment-info.h \
 	player-info/force-trainer-data-type.h \
 	player-info/magic-eater-data-type.cpp player-info/magic-eater-data-type.h \
+	player-info/mane-data-type.h \
 	player-info/mimic-info-table.cpp player-info/mimic-info-table.h \
 	player-info/mutation-info.cpp player-info/mutation-info.h \
 	player-info/race-ability-info.cpp player-info/race-ability-info.h \

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -143,12 +143,7 @@ void player_wipe_without_name(player_type *player_ptr)
     player_ptr->arena_number = 0;
     player_ptr->current_floor_ptr->inside_arena = false;
     player_ptr->current_floor_ptr->inside_quest = 0;
-    for (int i = 0; i < MAX_MANE; i++) {
-        player_ptr->mane_spell[i] = RF_ABILITY::MAX;
-        player_ptr->mane_dam[i] = 0;
-    }
 
-    player_ptr->mane_num = 0;
     player_ptr->exit_bldg = true;
     player_ptr->today_mon = 0;
     update_gambling_monsters(player_ptr);

--- a/src/blue-magic/blue-magic-checker.cpp
+++ b/src/blue-magic/blue-magic-checker.cpp
@@ -48,7 +48,7 @@ void learn_spell(player_type *player_ptr, RF_ABILITY monspell)
         msg_format(_("%sを学習した！", "You have learned %s!"), monster_power.name);
         gain_exp(player_ptr, monster_power.level * monster_power.smana);
         sound(SOUND_STUDY);
-        player_ptr->new_mane = true;
+        bluemage_data->new_magic_learned = true;
         player_ptr->redraw |= PR_STATE;
     }
 }

--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -37,6 +37,8 @@
 #include "monster/monster-processor.h"
 #include "monster/monster-status.h"
 #include "mspell/monster-power-table.h"
+#include "player-base/player-class.h"
+#include "player-info/mane-data-type.h"
 #include "player-status/player-energy.h"
 #include "player/player-status-table.h"
 #include "spell-kind/spells-launcher.h"
@@ -69,6 +71,8 @@
 #include "util/enum-converter.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
+
+#include <iterator>
 
 static int damage;
 
@@ -159,7 +163,9 @@ static int get_mane_power(player_type *player_ptr, int *sn, bool baigaesi)
     flag = false;
     redraw = false;
 
-    num = player_ptr->mane_num;
+    auto mane_data = PlayerClass(player_ptr).get_specific_data<mane_data_type>();
+
+    num = mane_data->mane_list.size();
 
     /* Build a prompt (accept all spells) */
     (void)strnfmt(out_val, 78, _("(%c-%c, '*'で一覧, ESC) どの%sをまねますか？", "(%c-%c, *=List, ESC=exit) Use which %s? "), I2A(0), I2A(num - 1), p);
@@ -186,8 +192,9 @@ static int get_mane_power(player_type *player_ptr, int *sn, bool baigaesi)
 
                 /* Dump the spells */
                 for (i = 0; i < num; i++) {
+                    const auto &mane = mane_data->mane_list[i];
                     /* Access the spell */
-                    spell = monster_powers[enum2i(player_ptr->mane_spell[i])];
+                    spell = monster_powers[enum2i(mane.spell)];
 
                     chance = spell.manefail;
 
@@ -199,7 +206,7 @@ static int get_mane_power(player_type *player_ptr, int *sn, bool baigaesi)
                     chance -= 3 * (adj_mag_stat[player_ptr->stat_index[spell.use_stat]] + adj_mag_stat[player_ptr->stat_index[A_DEX]] - 2) / 2;
 
                     if (spell.manedam)
-                        chance = chance * (baigaesi ? player_ptr->mane_dam[i] * 2 : player_ptr->mane_dam[i]) / spell.manedam;
+                        chance = chance * (baigaesi ? mane.damage * 2 : mane.damage) / spell.manedam;
 
                     chance += player_ptr->to_m_chance;
 
@@ -221,7 +228,7 @@ static int get_mane_power(player_type *player_ptr, int *sn, bool baigaesi)
                     }
 
                     /* Get info */
-                    mane_info(player_ptr, comment, player_ptr->mane_spell[i], (baigaesi ? player_ptr->mane_dam[i] * 2 : player_ptr->mane_dam[i]));
+                    mane_info(player_ptr, comment, mane.spell, (baigaesi ? mane.damage * 2 : mane.damage));
 
                     /* Dump the spell --(-- */
                     sprintf(psi_desc, "  %c) %-30s %3d%%%s", I2A(i), spell.name, chance, comment);
@@ -260,7 +267,7 @@ static int get_mane_power(player_type *player_ptr, int *sn, bool baigaesi)
         }
 
         /* Save the spell index */
-        spell = monster_powers[enum2i(player_ptr->mane_spell[i])];
+        spell = monster_powers[enum2i(mane_data->mane_list[i].spell)];
 
         /* Verify it */
         if (ask) {
@@ -290,7 +297,7 @@ static int get_mane_power(player_type *player_ptr, int *sn, bool baigaesi)
     /* Save the choice */
     (*sn) = i;
 
-    damage = (baigaesi ? player_ptr->mane_dam[i] * 2 : player_ptr->mane_dam[i]);
+    damage = (baigaesi ? mane_data->mane_list[i].damage * 2 : mane_data->mane_list[i].damage);
 
     /* Success */
     return true;
@@ -1074,7 +1081,7 @@ static bool use_mane(player_type *player_ptr, RF_ABILITY spell)
  */
 bool do_cmd_mane(player_type *player_ptr, bool baigaesi)
 {
-    int n = 0, j;
+    int n = 0;
     PERCENTAGE chance;
     PERCENTAGE minfail = 0;
     PLAYER_LEVEL plev = player_ptr->lev;
@@ -1084,7 +1091,9 @@ bool do_cmd_mane(player_type *player_ptr, bool baigaesi)
     if (cmd_limit_confused(player_ptr))
         return false;
 
-    if (!player_ptr->mane_num) {
+    auto mane_data = PlayerClass(player_ptr).get_specific_data<mane_data_type>();
+
+    if (mane_data->mane_list.empty()) {
         msg_print(_("まねられるものが何もない！", "You don't remember any action!"));
         return false;
     }
@@ -1092,7 +1101,7 @@ bool do_cmd_mane(player_type *player_ptr, bool baigaesi)
     if (!get_mane_power(player_ptr, &n, baigaesi))
         return false;
 
-    spell = monster_powers[enum2i(player_ptr->mane_spell[n])];
+    spell = monster_powers[enum2i(mane_data->mane_list[n].spell)];
 
     /* Spell failure chance */
     chance = spell.manefail;
@@ -1130,16 +1139,12 @@ bool do_cmd_mane(player_type *player_ptr, bool baigaesi)
         sound(SOUND_FAIL);
     } else {
         sound(SOUND_ZAP);
-        cast = use_mane(player_ptr, player_ptr->mane_spell[n]);
+        cast = use_mane(player_ptr, mane_data->mane_list[n].spell);
         if (!cast)
             return false;
     }
 
-    player_ptr->mane_num--;
-    for (j = n; j < player_ptr->mane_num; j++) {
-        player_ptr->mane_spell[j] = player_ptr->mane_spell[j + 1];
-        player_ptr->mane_dam[j] = player_ptr->mane_dam[j + 1];
-    }
+    mane_data->mane_list.erase(std::next(mane_data->mane_list.begin(), n));
 
     PlayerEnergy(player_ptr).set_player_turn_energy(100);
 

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -37,6 +37,9 @@
 #include "monster/monster-update.h"
 #include "monster/monster-util.h"
 #include "mutation/mutation-investor-remover.h"
+#include "player-base/player-class.h"
+#include "player-info/bluemage-data-type.h"
+#include "player-info/mane-data-type.h"
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
 #include "player/eldritch-horror.h"
@@ -370,20 +373,18 @@ void process_player(player_type *player_ptr)
             }
 
             if (player_ptr->pclass == CLASS_IMITATOR) {
-                if (player_ptr->mane_num > (player_ptr->lev > 44 ? 3 : player_ptr->lev > 29 ? 2 : 1)) {
-                    player_ptr->mane_num--;
-                    for (int j = 0; j < player_ptr->mane_num; j++) {
-                        player_ptr->mane_spell[j] = player_ptr->mane_spell[j + 1];
-                        player_ptr->mane_dam[j] = player_ptr->mane_dam[j + 1];
-                    }
+                auto mane_data = PlayerClass(player_ptr).get_specific_data<mane_data_type>();
+                if (static_cast<int>(mane_data->mane_list.size()) > (player_ptr->lev > 44 ? 3 : player_ptr->lev > 29 ? 2 : 1)) {
+                    mane_data->mane_list.pop_front();
                 }
 
-                player_ptr->new_mane = false;
+                mane_data->new_mane = false;
                 player_ptr->redraw |= (PR_IMITATION);
             }
 
             if (player_ptr->action == ACTION_LEARN) {
-                player_ptr->new_mane = false;
+                auto mane_data = PlayerClass(player_ptr).get_specific_data<bluemage_data_type>();
+                mane_data->new_magic_learned = false;
                 player_ptr->redraw |= (PR_STATE);
             }
 

--- a/src/load/player-class-specific-data-loader.cpp
+++ b/src/load/player-class-specific-data-loader.cpp
@@ -4,6 +4,7 @@
 #include "player-info/bluemage-data-type.h"
 #include "player-info/force-trainer-data-type.h"
 #include "player-info/magic-eater-data-type.h"
+#include "player-info/mane-data-type.h"
 #include "player-info/smith-data-type.h"
 #include "player-info/spell-hex-data-type.h"
 #include "util/enum-converter.h"
@@ -139,6 +140,23 @@ void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<bard_data_type> &
         bird_data->interrputing_song = i2enum<realm_song_type>(tmp32s);
         rd_s32b(&bird_data->singing_duration);
         rd_byte(&bird_data->singing_song_spell_idx);
+    }
+}
+
+void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<mane_data_type> &mane_data) const
+{
+    if (loading_savefile_version_is_older_than(9)) {
+        // 古いセーブファイルのものまね師のデータは magic_num には保存されていないので読み捨てる
+        load_old_savfile_magic_num();
+    } else {
+        int16_t count;
+        rd_s16b(&count);
+        for (; count > 0; --count) {
+            int16_t spell, damage;
+            rd_s16b(&spell);
+            rd_s16b(&damage);
+            mane_data->mane_list.push_back({ i2enum<RF_ABILITY>(spell), damage });
+        }
     }
 }
 

--- a/src/load/player-class-specific-data-loader.h
+++ b/src/load/player-class-specific-data-loader.h
@@ -9,6 +9,7 @@ struct force_trainer_data_type;
 struct bluemage_data_type;
 struct magic_eater_data_type;
 struct bard_data_type;
+struct mane_data_type;
 struct spell_hex_data_type;
 
 class PlayerClassSpecificDataLoader {
@@ -20,4 +21,5 @@ public:
     void operator()(std::shared_ptr<bluemage_data_type> &bluemage_data) const;
     void operator()(std::shared_ptr<magic_eater_data_type> &magic_eater_data) const;
     void operator()(std::shared_ptr<bard_data_type> &bird_data) const;
+    void operator()(std::shared_ptr<mane_data_type> &mane_data) const;
 };

--- a/src/melee/melee-spell.cpp
+++ b/src/melee/melee-spell.cpp
@@ -11,6 +11,8 @@
 #include "mspell/mspell-checker.h"
 #include "mspell/mspell-util.h"
 #include "mspell/mspell.h"
+#include "player-base/player-class.h"
+#include "player-info/mane-data-type.h"
 #include "spell-realm/spells-hex.h"
 #include "system/floor-type-definition.h"
 #include "system/monster-race-definition.h"
@@ -61,18 +63,14 @@ static void process_special_melee_spell(player_type *player_ptr, melee_spell_typ
     if (!is_special_magic)
         return;
 
-    if (player_ptr->mane_num == MAX_MANE) {
-        player_ptr->mane_num--;
-        for (int i = 0; i < player_ptr->mane_num - 1; i++) {
-            player_ptr->mane_spell[i] = player_ptr->mane_spell[i + 1];
-            player_ptr->mane_dam[i] = player_ptr->mane_dam[i + 1];
-        }
+    auto mane_data = PlayerClass(player_ptr).get_specific_data<mane_data_type>();
+
+    if (mane_data->mane_list.size() == MAX_MANE) {
+        mane_data->mane_list.pop_front();
     }
 
-    player_ptr->mane_spell[player_ptr->mane_num] = ms_ptr->thrown_spell;
-    player_ptr->mane_dam[player_ptr->mane_num] = ms_ptr->dam;
-    player_ptr->mane_num++;
-    player_ptr->new_mane = true;
+    mane_data->mane_list.push_back({ ms_ptr->thrown_spell, ms_ptr->dam });
+    mane_data->new_mane = true;
 
     player_ptr->redraw |= PR_IMITATION;
 }

--- a/src/mspell/mspell-attack.cpp
+++ b/src/mspell/mspell-attack.cpp
@@ -24,6 +24,8 @@
 #include "mspell/mspell-selector.h"
 #include "mspell/mspell-util.h"
 #include "mspell/mspell.h"
+#include "player-base/player-class.h"
+#include "player-info/mane-data-type.h"
 #include "player/attack-defense-types.h"
 #include "spell-kind/spells-world.h"
 #include "spell-realm/spells-hex.h"
@@ -263,18 +265,14 @@ static void check_mspell_imitation(player_type *player_ptr, msa_type *msa_ptr)
     if (msa_ptr->thrown_spell == RF_ABILITY::SPECIAL)
         return;
 
-    if (player_ptr->mane_num == MAX_MANE) {
-        player_ptr->mane_num--;
-        for (int i = 0; i < player_ptr->mane_num; i++) {
-            player_ptr->mane_spell[i] = player_ptr->mane_spell[i + 1];
-            player_ptr->mane_dam[i] = player_ptr->mane_dam[i + 1];
-        }
+    auto mane_data = PlayerClass(player_ptr).get_specific_data<mane_data_type>();
+
+    if (mane_data->mane_list.size() == MAX_MANE) {
+        mane_data->mane_list.pop_front();
     }
 
-    player_ptr->mane_spell[player_ptr->mane_num] = msa_ptr->thrown_spell;
-    player_ptr->mane_dam[player_ptr->mane_num] = msa_ptr->dam;
-    player_ptr->mane_num++;
-    player_ptr->new_mane = true;
+    mane_data->mane_list.push_back({ msa_ptr->thrown_spell, msa_ptr->dam });
+    mane_data->new_mane = true;
     player_ptr->redraw |= PR_IMITATION;
 }
 

--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -11,6 +11,7 @@
 #include "player-info/bluemage-data-type.h"
 #include "player-info/force-trainer-data-type.h"
 #include "player-info/magic-eater-data-type.h"
+#include "player-info/mane-data-type.h"
 #include "player-info/smith-data-type.h"
 #include "player-info/spell-hex-data-type.h"
 #include "player/attack-defense-types.h"
@@ -80,6 +81,9 @@ void PlayerClass::init_specific_data()
         break;
     case CLASS_BARD:
         this->player_ptr->class_specific_data = std::make_shared<bard_data_type>();
+        break;
+    case CLASS_IMITATOR:
+        this->player_ptr->class_specific_data = std::make_shared<mane_data_type>();
         break;
     case CLASS_HIGH_MAGE:
         if (this->player_ptr->realm1 == REALM_HEX) {

--- a/src/player-info/bluemage-data-type.h
+++ b/src/player-info/bluemage-data-type.h
@@ -7,4 +7,5 @@
 
 struct bluemage_data_type {
     EnumClassFlagGroup<RF_ABILITY> learnt_blue_magics{};
+    bool new_magic_learned{};
 };

--- a/src/player-info/class-specific-data.h
+++ b/src/player-info/class-specific-data.h
@@ -10,6 +10,7 @@ struct force_trainer_data_type;
 struct bluemage_data_type;
 struct magic_eater_data_type;
 struct bard_data_type;
+struct mane_data_type;
 struct spell_hex_data_type;
 
 using ClassSpecificData = std::variant<
@@ -20,6 +21,7 @@ using ClassSpecificData = std::variant<
     std::shared_ptr<bluemage_data_type>,
     std::shared_ptr<magic_eater_data_type>,
     std::shared_ptr<bard_data_type>,
+    std::shared_ptr<mane_data_type>,
     std::shared_ptr<spell_hex_data_type>
 
     >;

--- a/src/player-info/mane-data-type.h
+++ b/src/player-info/mane-data-type.h
@@ -1,0 +1,19 @@
+﻿#pragma once
+
+#include "system/angband.h"
+
+#include <deque>
+
+constexpr int MAX_MANE = 16;
+
+enum class RF_ABILITY;
+
+struct mane_data_type {
+    struct mane_type {
+        RF_ABILITY spell{};
+        HIT_POINT damage{};
+    };
+
+    std::deque<mane_type> mane_list{};
+    bool new_mane{};
+};

--- a/src/save/player-class-specific-data-writer.cpp
+++ b/src/save/player-class-specific-data-writer.cpp
@@ -3,6 +3,7 @@
 #include "player-info/bluemage-data-type.h"
 #include "player-info/force-trainer-data-type.h"
 #include "player-info/magic-eater-data-type.h"
+#include "player-info/mane-data-type.h"
 #include "player-info/smith-data-type.h"
 #include "player-info/spell-hex-data-type.h"
 #include "save/save-util.h"
@@ -50,6 +51,16 @@ void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<bard_data_t
     wr_s32b(enum2i(bird_data->interrputing_song));
     wr_s32b(bird_data->singing_duration);
     wr_byte(bird_data->singing_song_spell_idx);
+}
+
+void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<mane_data_type> &mane_data) const
+{
+    wr_s16b(static_cast<int16_t>(mane_data->mane_list.size()));
+
+    for (const auto &mane : mane_data->mane_list) {
+        wr_s16b(static_cast<int16_t>(mane.spell));
+        wr_s16b(static_cast<int16_t>(mane.damage));
+    }
 }
 
 void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<spell_hex_data_type> &spell_hex_data) const

--- a/src/save/player-class-specific-data-writer.h
+++ b/src/save/player-class-specific-data-writer.h
@@ -9,6 +9,7 @@ struct force_trainer_data_type;
 struct bluemage_data_type;
 struct magic_eater_data_type;
 struct bard_data_type;
+struct mane_data_type;
 
 class PlayerClassSpecificDataWriter {
 public:
@@ -19,4 +20,5 @@ public:
     void operator()(const std::shared_ptr<bluemage_data_type> &bluemage_data) const;
     void operator()(const std::shared_ptr<magic_eater_data_type> &magic_eater_data) const;
     void operator()(const std::shared_ptr<bard_data_type> &bird_data) const;
+    void operator()(const std::shared_ptr<mane_data_type> &mane_data) const;
 };

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -91,12 +91,7 @@ void wr_player(player_type *player_ptr)
     wr_s32b(player_ptr->old_race1);
     wr_s32b(player_ptr->old_race2);
     wr_s16b(player_ptr->old_realm);
-    for (int i = 0; i < MAX_MANE; i++) {
-        wr_s16b((int16_t)player_ptr->mane_spell[i]);
-        wr_s16b((int16_t)player_ptr->mane_dam[i]);
-    }
 
-    wr_s16b(player_ptr->mane_num);
     for (int i = 0; i < MAX_BOUNTY; i++)
         wr_s16b(w_ptr->bounty_r_idx[i]);
 

--- a/src/status/action-setter.cpp
+++ b/src/status/action-setter.cpp
@@ -14,6 +14,8 @@
 #include "status/action-setter.h"
 #include "core/player-redraw-types.h"
 #include "core/player-update-types.h"
+#include "player-base/player-class.h"
+#include "player-info/bluemage-data-type.h"
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
 #include "player/special-defense-types.h"
@@ -47,7 +49,8 @@ void set_action(player_type *player_ptr, uint8_t typ)
     }
     case ACTION_LEARN: {
         msg_print(_("学習をやめた。", "You stop learning."));
-        player_ptr->new_mane = false;
+        auto bluemage_data = PlayerClass(player_ptr).get_specific_data<bluemage_data_type>();
+        bluemage_data->new_magic_learned = false;
         break;
     }
     case ACTION_KAMAE: {

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -9,6 +9,7 @@
 #include "mind/mind-sniper.h"
 #include "player-base/player-class.h"
 #include "player-base/player-race.h"
+#include "player-info/bluemage-data-type.h"
 #include "player/attack-defense-types.h"
 #include "player/player-status-flags.h"
 #include "player/player-status.h"
@@ -110,7 +111,8 @@ bool BadStatusSetter::confusion(const TIME_EFFECT tmp_v)
 
             if (this->player_ptr->action == ACTION_LEARN) {
                 msg_print(_("学習が続けられない！", "You cannot continue learning!"));
-                this->player_ptr->new_mane = false;
+                auto bluemage_data = PlayerClass(player_ptr).get_specific_data<bluemage_data_type>();
+                bluemage_data->new_magic_learned = false;
 
                 this->player_ptr->redraw |= PR_STATE;
                 this->player_ptr->action = ACTION_NONE;

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -14,7 +14,6 @@
 #include "util/flag-group.h"
 
 #define MAX_SKILLS 10
-#define MAX_MANE 16
 
 enum class RF_ABILITY;
 
@@ -190,11 +189,6 @@ public:
     SUB_EXP skill_exp[MAX_SKILLS]{}; /* Proficiency of misc. skill */
 
     ClassSpecificData class_specific_data;
-
-    RF_ABILITY mane_spell[MAX_MANE]{};
-    HIT_POINT mane_dam[MAX_MANE]{};
-    int16_t mane_num{};
-    bool new_mane{};
 
 #define CONCENT_RADAR_THRESHOLD 2
 #define CONCENT_TELE_THRESHOLD 5

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -2,6 +2,9 @@
 #include "io/input-key-requester.h"
 #include "mind/stances-table.h"
 #include "monster/monster-status.h"
+#include "player-base/player-class.h"
+#include "player-info/bluemage-data-type.h"
+#include "player-info/mane-data-type.h"
 #include "player/attack-defense-types.h"
 #include "player/digestion-processor.h"
 #include "player/player-status-table.h"
@@ -173,7 +176,8 @@ void print_state(player_type *player_ptr)
 
     case ACTION_LEARN: {
         strcpy(text, _("学習", "lear"));
-        if (player_ptr->new_mane)
+        auto bluemage_data = PlayerClass(player_ptr).get_specific_data<bluemage_data_type>();
+        if (bluemage_data->new_magic_learned)
             attr = TERM_L_RED;
         break;
     }
@@ -323,12 +327,14 @@ void print_imitation(player_type *player_ptr)
     if (player_ptr->pclass != CLASS_IMITATOR)
         return;
 
-    if (player_ptr->mane_num == 0) {
+    auto mane_data = PlayerClass(player_ptr).get_specific_data<mane_data_type>();
+
+    if (mane_data->mane_list.size() == 0) {
         put_str("    ", row_study, col_study);
         return;
     }
 
-    TERM_COLOR attr = player_ptr->new_mane ? TERM_L_RED : TERM_WHITE;
+    TERM_COLOR attr = mane_data->new_mane ? TERM_L_RED : TERM_WHITE;
     c_put_str(attr, _("まね", "Imit"), row_study, col_study);
 }
 


### PR DESCRIPTION
player_type にものまね師しか使わない専用のメンバがあるので、職業固有
データ mane_data_type を定義してメンバを移動させる。
また例によって new_mane が青魔道士の学習フラグと共有されていたので、
青魔道士の専用データと別々に分離する。
さらに覚えているものまねのリストを単純な配列からSTLコンテナにして
コードを読みやすくする。