### PR TITLE
[Refactor] スナイパーの専用データを職業固有データに移動する

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -1000,6 +1000,7 @@
     <ClInclude Include="..\..\src\player-info\magic-eater-data-type.h" />
     <ClInclude Include="..\..\src\player-info\mane-data-type.h" />
     <ClInclude Include="..\..\src\player-info\smith-data-type.h" />
+    <ClInclude Include="..\..\src\player-info\sniper-data-type.h" />
     <ClInclude Include="..\..\src\player-info\spell-hex-data-type.h" />
     <ClInclude Include="..\..\src\player-status\player-energy.h" />
     <ClInclude Include="..\..\src\player-status\player-hand-types.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -5073,6 +5073,9 @@
     <ClInclude Include="..\..\src\specific-object\stone-of-lore.h">
       <Filter>specific-object</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\player-info\sniper-data-type.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\src\wall.bmp" />

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -680,6 +680,7 @@ hengband_SOURCES = \
 	player-info/self-info.cpp player-info/self-info.h \
 	player-info/self-info-util.cpp player-info/self-info-util.h \
         player-info/smith-data-type.h \
+	player-info/sniper-data-type.h \
         player-info/spell-hex-data-type.h \
 	player-info/weapon-effect-info.cpp player-info/weapon-effect-info.h \
 	\

--- a/src/cmd-action/cmd-shoot.cpp
+++ b/src/cmd-action/cmd-shoot.cpp
@@ -5,6 +5,8 @@
 #include "mind/snipe-types.h"
 #include "object/item-tester-hooker.h"
 #include "object/item-use-flags.h"
+#include "player-base/player-class.h"
+#include "player-info/sniper-data-type.h"
 #include "player/attack-defense-types.h"
 #include "player/special-defense-types.h"
 #include "spell-kind/spells-teleport.h"
@@ -19,8 +21,7 @@
 /*!
  * @brief 射撃処理のメインルーチン
  * @param player_ptr プレイヤーへの参照ポインタ
- * @param snipe_type ？？？
- * @todo Doxygenの加筆求む
+ * @param snipe_type スナイパーの射撃術の種類
  */
 void do_cmd_fire(player_type *player_ptr, SPELL_IDX snipe_type)
 {
@@ -64,8 +65,10 @@ void do_cmd_fire(player_type *player_ptr, SPELL_IDX snipe_type)
     if (!player_ptr->is_fired || player_ptr->pclass != CLASS_SNIPER)
         return;
 
-    if (snipe_type == SP_AWAY)
-        teleport_player(player_ptr, 10 + (player_ptr->concent * 2), TELEPORT_SPONTANEOUS);
+    if (snipe_type == SP_AWAY) {
+        auto sniper_data = PlayerClass(player_ptr).get_specific_data<sniper_data_type>();
+        teleport_player(player_ptr, 10 + (sniper_data->concent * 2), TELEPORT_SPONTANEOUS);
+    }
 
     auto effects = player_ptr->effects();
     if (snipe_type == SP_FINAL) {

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -46,7 +46,9 @@
 #include "object/object-info.h"
 #include "object/object-kind.h"
 #include "object/object-mark-types.h"
+#include "player-base/player-class.h"
 #include "player-info/class-info.h"
+#include "player-info/sniper-data-type.h"
 #include "player-status/player-energy.h"
 #include "player/player-personality-types.h"
 #include "player/player-skill.h"
@@ -446,13 +448,13 @@ void exe_fire(player_type *player_ptr, INVENTORY_IDX item, object_type *j_ptr, S
     tdam_base *= tmul;
     tdam_base /= 100;
 
+    auto sniper_data = PlayerClass(player_ptr).get_specific_data<sniper_data_type>();
+    auto sniper_concent = sniper_data ? sniper_data->concent : 0;
+
     /* Base range */
     tdis = 13 + tmul / 80;
     if ((j_ptr->sval == SV_LIGHT_XBOW) || (j_ptr->sval == SV_HEAVY_XBOW)) {
-        if (player_ptr->concent)
-            tdis -= (5 - (player_ptr->concent + 1) / 2);
-        else
-            tdis -= 5;
+        tdis -= (5 - (sniper_concent + 1) / 2);
     }
 
     project_length = tdis + 1;
@@ -502,7 +504,7 @@ void exe_fire(player_type *player_ptr, INVENTORY_IDX item, object_type *j_ptr, S
 
     /* Sniper - Difficult to shot twice at 1 turn */
     if (snipe_type == SP_DOUBLE)
-        player_ptr->concent = (player_ptr->concent + 1) / 2;
+        sniper_concent = (sniper_concent + 1) / 2;
 
     /* Sniper - Repeat shooting when double shots */
     for (i = 0; i < ((snipe_type == SP_DOUBLE) ? 2 : 1); i++) {
@@ -670,8 +672,7 @@ void exe_fire(player_type *player_ptr, INVENTORY_IDX item, object_type *j_ptr, S
                     auto base_dam = tdam; //!< @note 補正前の与えるダメージ(無傷、全ての耐性など)
 
                     /* Get extra damage from concentration */
-                    if (player_ptr->concent)
-                        tdam = boost_concentration_damage(player_ptr, tdam);
+                    tdam = boost_concentration_damage(player_ptr, tdam);
 
                     /* Handle unseen monster */
                     if (!visible) {
@@ -696,7 +697,7 @@ void exe_fire(player_type *player_ptr, INVENTORY_IDX item, object_type *j_ptr, S
                     }
 
                     if (snipe_type == SP_NEEDLE) {
-                        if ((randint1(randint1(r_ptr->level / (3 + player_ptr->concent)) + (8 - player_ptr->concent)) == 1)
+                        if ((randint1(randint1(r_ptr->level / (3 + sniper_concent)) + (8 - sniper_concent)) == 1)
                             && none_bits(r_ptr->flags1, RF1_UNIQUE) && none_bits(r_ptr->flags7, RF7_UNIQUE2)) {
                             GAME_TEXT m_name[MAX_NLEN];
 
@@ -732,7 +733,7 @@ void exe_fire(player_type *player_ptr, INVENTORY_IDX item, object_type *j_ptr, S
                         uint16_t flg = (PROJECT_STOP | PROJECT_JUMP | PROJECT_KILL | PROJECT_GRID);
 
                         sound(SOUND_EXPLODE); /* No explode sound - use breath fire instead */
-                        project(player_ptr, 0, ((player_ptr->concent + 1) / 2 + 1), ny, nx, base_dam, GF_MISSILE, flg);
+                        project(player_ptr, 0, ((sniper_concent + 1) / 2 + 1), ny, nx, base_dam, GF_MISSILE, flg);
                         break;
                     }
 
@@ -752,7 +753,7 @@ void exe_fire(player_type *player_ptr, INVENTORY_IDX item, object_type *j_ptr, S
                     /* No death */
                     else {
                         /* STICK TO */
-                        if (q_ptr->is_fixed_artifact() && (player_ptr->pclass != CLASS_SNIPER || player_ptr->concent == 0)) {
+                        if (q_ptr->is_fixed_artifact() && (sniper_concent == 0)) {
                             GAME_TEXT m_name[MAX_NLEN];
 
                             monster_desc(player_ptr, m_name, m_ptr, 0);
@@ -828,10 +829,8 @@ void exe_fire(player_type *player_ptr, INVENTORY_IDX item, object_type *j_ptr, S
                 }
 
                 /* Sniper */
-                if (snipe_type == SP_PIERCE) {
-                    if (player_ptr->concent < 1)
-                        break;
-                    player_ptr->concent--;
+                if (snipe_type == SP_PIERCE && sniper_concent > 0) {
+                    sniper_concent--;
                     continue;
                 }
 
@@ -882,8 +881,7 @@ void exe_fire(player_type *player_ptr, INVENTORY_IDX item, object_type *j_ptr, S
     }
 
     /* Sniper - Loose his/her concentration after any shot */
-    if (player_ptr->concent)
-        reset_concentration(player_ptr, false);
+    reset_concentration(player_ptr, false);
 }
 
 /*!
@@ -905,8 +903,11 @@ bool test_hit_fire(player_type *player_ptr, int chance, monster_type *m_ptr, int
     /* Percentile dice */
     k = randint1(100);
 
+    auto sniper_data = PlayerClass(player_ptr).get_specific_data<sniper_data_type>();
+    auto sniper_concent = sniper_data ? sniper_data->concent : 0;
+
     /* Snipers with high-concentration reduce instant miss percentage.*/
-    k += player_ptr->concent;
+    k += sniper_concent;
 
     /* Hack -- Instant miss or hit */
     if (k <= 5)
@@ -923,10 +924,7 @@ bool test_hit_fire(player_type *player_ptr, int chance, monster_type *m_ptr, int
         return false;
 
     ac = r_ptr->ac;
-    if (player_ptr->concent) {
-        ac *= (8 - player_ptr->concent);
-        ac /= 8;
-    }
+    ac = ac * (8 - sniper_concent) / 8;
 
     if (m_ptr->r_idx == MON_GOEMON && !monster_csleep_remaining(m_ptr))
         ac *= 3;
@@ -971,14 +969,16 @@ HIT_POINT critical_shot(player_type *player_ptr, WEIGHT weight, int plus_ammo, i
     else
         i = (player_ptr->skill_thb + ((player_ptr->weapon_exp[0][j_ptr->sval] - (WEAPON_EXP_MASTER / 2)) / 200 + i) * BTH_PLUS_ADJ);
 
+    auto sniper_data = PlayerClass(player_ptr).get_specific_data<sniper_data_type>();
+    auto sniper_concent = sniper_data ? sniper_data->concent : 0;
+
     /* Snipers can shot more critically with crossbows */
-    if (player_ptr->concent)
-        i += ((i * player_ptr->concent) / 5);
+    i += ((i * sniper_concent) / 5);
     if ((player_ptr->pclass == CLASS_SNIPER) && (player_ptr->tval_ammo == TV_BOLT))
         i *= 2;
 
     /* Good bow makes more critical */
-    i += plus_bow * 8 * (player_ptr->concent ? player_ptr->concent + 5 : 5);
+    i += plus_bow * 8 * (sniper_concent + 5);
 
     /* Critical hit */
     if (randint1(10000) <= i) {
@@ -1120,14 +1120,16 @@ HIT_POINT calc_crit_ratio_shot(player_type *player_ptr, HIT_POINT plus_ammo, HIT
     else
         i = (player_ptr->skill_thb + ((player_ptr->weapon_exp[0][j_ptr->sval] - (WEAPON_EXP_MASTER / 2)) / 200 + i) * BTH_PLUS_ADJ);
 
+    auto sniper_data = PlayerClass(player_ptr).get_specific_data<sniper_data_type>();
+    auto sniper_concent = sniper_data ? sniper_data->concent : 0;
+
     /* Snipers can shot more critically with crossbows */
-    if (player_ptr->concent)
-        i += ((i * player_ptr->concent) / 5);
+    i += ((i * sniper_concent) / 5);
     if ((player_ptr->pclass == CLASS_SNIPER) && (player_ptr->tval_ammo == TV_BOLT))
         i *= 2;
 
     /* Good bow makes more critical */
-    i += plus_bow * 8 * (player_ptr->concent ? player_ptr->concent + 5 : 5);
+    i += plus_bow * 8 * (sniper_concent + 5);
 
     if (i < 0)
         i = 0;

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -40,6 +40,7 @@
 #include "player-base/player-class.h"
 #include "player-info/bluemage-data-type.h"
 #include "player-info/mane-data-type.h"
+#include "player-info/sniper-data-type.h"
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
 #include "player/eldritch-horror.h"
@@ -407,7 +408,8 @@ void process_player(player_type *player_ptr)
             break;
         }
 
-        if (player_ptr->energy_use && player_ptr->reset_concent)
+        auto sniper_data = PlayerClass(player_ptr).get_specific_data<sniper_data_type>();
+        if (player_ptr->energy_use && sniper_data && sniper_data->reset_concent)
             reset_concentration(player_ptr, true);
 
         if (player_ptr->leaving)

--- a/src/flavor/flavor-describer.cpp
+++ b/src/flavor/flavor-describer.cpp
@@ -258,8 +258,7 @@ static void describe_bow_power(player_type *player_ptr, flavor_type *flavor_ptr)
     tmul = tmul * (100 + (int)(adj_str_td[player_ptr->stat_index[A_STR]]) - 128);
     flavor_ptr->avgdam *= tmul;
     flavor_ptr->avgdam /= (100 * 10);
-    if (player_ptr->concent)
-        flavor_ptr->avgdam = boost_concentration_damage(player_ptr, flavor_ptr->avgdam);
+    flavor_ptr->avgdam = boost_concentration_damage(player_ptr, flavor_ptr->avgdam);
 
     if (flavor_ptr->avgdam < 0)
         flavor_ptr->avgdam = 0;

--- a/src/io/input-key-processor.cpp
+++ b/src/io/input-key-processor.cpp
@@ -74,7 +74,9 @@
 #include "mind/mind-sniper.h"
 #include "mind/mind-weaponsmith.h"
 #include "mind/snipe-types.h"
+#include "player-base/player-class.h"
 #include "player-info/class-info.h"
+#include "player-info/sniper-data-type.h"
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
 #include "player/digestion-processor.h"
@@ -132,8 +134,10 @@ void process_command(player_type *player_ptr)
     COMMAND_CODE old_now_message = now_message;
     repeat_check();
     now_message = 0;
-    if ((player_ptr->pclass == CLASS_SNIPER) && (player_ptr->concent))
-        player_ptr->reset_concent = true;
+    auto sniper_data = PlayerClass(player_ptr).get_specific_data<sniper_data_type>();
+    if (sniper_data && sniper_data->concent > 0) {
+        sniper_data->reset_concent = true;
+    }
 
     floor_type *floor_ptr = player_ptr->current_floor_ptr;
     switch (command_cmd) {

--- a/src/load/player-class-specific-data-loader.cpp
+++ b/src/load/player-class-specific-data-loader.cpp
@@ -6,6 +6,7 @@
 #include "player-info/magic-eater-data-type.h"
 #include "player-info/mane-data-type.h"
 #include "player-info/smith-data-type.h"
+#include "player-info/sniper-data-type.h"
 #include "player-info/spell-hex-data-type.h"
 #include "util/enum-converter.h"
 
@@ -157,6 +158,16 @@ void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<mane_data_type> &
             rd_s16b(&damage);
             mane_data->mane_list.push_back({ i2enum<RF_ABILITY>(spell), damage });
         }
+    }
+}
+
+void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<sniper_data_type> &sniper_data) const
+{
+    if (loading_savefile_version_is_older_than(9)) {
+        // 古いセーブファイルのスナイパーのデータは magic_num には保存されていないので読み捨てる
+        load_old_savfile_magic_num();
+    } else {
+        rd_s16b(&sniper_data->concent);
     }
 }
 

--- a/src/load/player-class-specific-data-loader.h
+++ b/src/load/player-class-specific-data-loader.h
@@ -10,6 +10,7 @@ struct bluemage_data_type;
 struct magic_eater_data_type;
 struct bard_data_type;
 struct mane_data_type;
+struct sniper_data_type;
 struct spell_hex_data_type;
 
 class PlayerClassSpecificDataLoader {
@@ -17,9 +18,10 @@ public:
     void operator()(no_class_specific_data &) const;
     void operator()(std::shared_ptr<spell_hex_data_type> &spell_hex_data) const;
     void operator()(std::shared_ptr<smith_data_type> &smith_data) const;
-    void operator()(std::shared_ptr<force_trainer_data_type> &) const;
+    void operator()(std::shared_ptr<force_trainer_data_type> &force_trainer_data) const;
     void operator()(std::shared_ptr<bluemage_data_type> &bluemage_data) const;
     void operator()(std::shared_ptr<magic_eater_data_type> &magic_eater_data) const;
     void operator()(std::shared_ptr<bard_data_type> &bird_data) const;
     void operator()(std::shared_ptr<mane_data_type> &mane_data) const;
+    void operator()(std::shared_ptr<sniper_data_type> &sniper_data) const;
 };

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -15,6 +15,7 @@
 #include "mutation/mutation-calculator.h"
 #include "player-base/player-class.h"
 #include "player-info/mane-data-type.h"
+#include "player-info/sniper-data-type.h"
 #include "player/attack-defense-types.h"
 #include "player/player-skill.h"
 #include "spell-realm/spells-song.h"
@@ -455,7 +456,16 @@ static void rd_player_status(player_type *player_ptr)
     rd_dungeons(player_ptr);
     strip_bytes(8);
     rd_s16b(&player_ptr->sc);
-    rd_s16b(&player_ptr->concent);
+    if (loading_savefile_version_is_older_than(9)) {
+        auto sniper_data = PlayerClass(player_ptr).get_specific_data<sniper_data_type>();
+        if (sniper_data) {
+            rd_s16b(&sniper_data->concent);
+        } else {
+            // 職業がスナイパーではないので読み捨てる
+            int16_t tmp16s;
+            rd_s16b(&tmp16s);
+        }
+    }
     rd_bad_status(player_ptr);
     rd_energy(player_ptr);
     rd_status(player_ptr);

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -28,6 +28,8 @@
 #include "monster/monster-processor-util.h"
 #include "monster/monster-status.h"
 #include "monster/smart-learn-types.h"
+#include "player-base/player-class.h"
+#include "player-info/sniper-data-type.h"
 #include "player/player-move.h"
 #include "player/player-status-flags.h"
 #include "player/special-defense-types.h"
@@ -402,7 +404,8 @@ static void decide_sight_invisible_monster(player_type *player_ptr, um_type *um_
     if (!player_has_los_bold(player_ptr, um_ptr->fy, um_ptr->fx) || player_ptr->blind)
         return;
 
-    if (player_ptr->concent >= CONCENT_RADAR_THRESHOLD) {
+    auto sniper_data = PlayerClass(player_ptr).get_specific_data<sniper_data_type>();
+    if (sniper_data && (sniper_data->concent >= CONCENT_RADAR_THRESHOLD)) {
         um_ptr->easy = true;
         um_ptr->flag = true;
     }

--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -13,6 +13,7 @@
 #include "player-info/magic-eater-data-type.h"
 #include "player-info/mane-data-type.h"
 #include "player-info/smith-data-type.h"
+#include "player-info/sniper-data-type.h"
 #include "player-info/spell-hex-data-type.h"
 #include "player/attack-defense-types.h"
 #include "player/special-defense-types.h"
@@ -84,6 +85,9 @@ void PlayerClass::init_specific_data()
         break;
     case CLASS_IMITATOR:
         this->player_ptr->class_specific_data = std::make_shared<mane_data_type>();
+        break;
+    case CLASS_SNIPER:
+        this->player_ptr->class_specific_data = std::make_shared<sniper_data_type>();
         break;
     case CLASS_HIGH_MAGE:
         if (this->player_ptr->realm1 == REALM_HEX) {

--- a/src/player-info/class-specific-data.h
+++ b/src/player-info/class-specific-data.h
@@ -11,6 +11,7 @@ struct bluemage_data_type;
 struct magic_eater_data_type;
 struct bard_data_type;
 struct mane_data_type;
+struct sniper_data_type;
 struct spell_hex_data_type;
 
 using ClassSpecificData = std::variant<
@@ -22,6 +23,7 @@ using ClassSpecificData = std::variant<
     std::shared_ptr<magic_eater_data_type>,
     std::shared_ptr<bard_data_type>,
     std::shared_ptr<mane_data_type>,
+    std::shared_ptr<sniper_data_type>,
     std::shared_ptr<spell_hex_data_type>
 
     >;

--- a/src/player-info/sniper-data-type.h
+++ b/src/player-info/sniper-data-type.h
@@ -1,0 +1,11 @@
+﻿#pragma once
+
+#include "system/angband.h"
+
+constexpr int16_t CONCENT_RADAR_THRESHOLD = 2;
+constexpr int16_t CONCENT_TELE_THRESHOLD = 5;
+
+struct sniper_data_type {
+    int16_t concent{}; //!< Concentration level
+    bool reset_concent{}; //!< Concentration reset flag
+};

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -54,11 +54,13 @@
 #include "object/object-mark-types.h"
 #include "perception/object-perception.h"
 #include "pet/pet-util.h"
+#include "player-base/player-class.h"
 #include "player-base/player-race.h"
 #include "player-info/alignment.h"
 #include "player-info/class-info.h"
 #include "player-info/equipment-info.h"
 #include "player-info/mimic-info-table.h"
+#include "player-info/sniper-data-type.h"
 #include "player-status/player-basic-statistics.h"
 #include "player-status/player-hand-types.h"
 #include "player-status/player-infravision.h"
@@ -2924,7 +2926,9 @@ bool is_blessed(player_type *player_ptr)
 
 bool is_tim_esp(player_type *player_ptr)
 {
-    return player_ptr->tim_esp || music_singing(player_ptr, MUSIC_MIND) || (player_ptr->concent >= CONCENT_TELE_THRESHOLD);
+    auto sniper_data = PlayerClass(player_ptr).get_specific_data<sniper_data_type>();
+    auto sniper_concent = sniper_data ? sniper_data->concent : 0;
+    return player_ptr->tim_esp || music_singing(player_ptr, MUSIC_MIND) || (sniper_concent >= CONCENT_TELE_THRESHOLD);
 }
 
 bool is_tim_stealth(player_type *player_ptr)
@@ -2934,7 +2938,9 @@ bool is_tim_stealth(player_type *player_ptr)
 
 bool is_time_limit_esp(player_type *player_ptr)
 {
-    return player_ptr->tim_esp || music_singing(player_ptr, MUSIC_MIND) || (player_ptr->concent >= CONCENT_TELE_THRESHOLD);
+    auto sniper_data = PlayerClass(player_ptr).get_specific_data<sniper_data_type>();
+    auto sniper_concent = sniper_data ? sniper_data->concent : 0;
+    return player_ptr->tim_esp || music_singing(player_ptr, MUSIC_MIND) || (sniper_concent >= CONCENT_TELE_THRESHOLD);
 }
 
 bool is_time_limit_stealth(player_type *player_ptr)

--- a/src/save/player-class-specific-data-writer.cpp
+++ b/src/save/player-class-specific-data-writer.cpp
@@ -5,6 +5,7 @@
 #include "player-info/magic-eater-data-type.h"
 #include "player-info/mane-data-type.h"
 #include "player-info/smith-data-type.h"
+#include "player-info/sniper-data-type.h"
 #include "player-info/spell-hex-data-type.h"
 #include "save/save-util.h"
 #include "util/enum-converter.h"
@@ -61,6 +62,11 @@ void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<mane_data_t
         wr_s16b(static_cast<int16_t>(mane.spell));
         wr_s16b(static_cast<int16_t>(mane.damage));
     }
+}
+
+void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<sniper_data_type> &sniper_data) const
+{
+    wr_s16b(sniper_data->concent);
 }
 
 void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<spell_hex_data_type> &spell_hex_data) const

--- a/src/save/player-class-specific-data-writer.h
+++ b/src/save/player-class-specific-data-writer.h
@@ -10,6 +10,7 @@ struct bluemage_data_type;
 struct magic_eater_data_type;
 struct bard_data_type;
 struct mane_data_type;
+struct sniper_data_type;
 
 class PlayerClassSpecificDataWriter {
 public:
@@ -21,4 +22,5 @@ public:
     void operator()(const std::shared_ptr<magic_eater_data_type> &magic_eater_data) const;
     void operator()(const std::shared_ptr<bard_data_type> &bird_data) const;
     void operator()(const std::shared_ptr<mane_data_type> &mane_data) const;
+    void operator()(const std::shared_ptr<sniper_data_type> &sniper_data) const;
 };

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -131,7 +131,6 @@ void wr_player(player_type *player_ptr)
     wr_s16b(0);
     wr_s16b(0);
     wr_s16b(player_ptr->sc);
-    wr_s16b(player_ptr->concent);
 
     auto effects = player_ptr->effects();
     wr_s16b(0); /* old "rest" */

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -134,8 +134,7 @@ bool BadStatusSetter::confusion(const TIME_EFFECT tmp_v)
             }
 
             /* Sniper */
-            if (this->player_ptr->concent)
-                reset_concentration(this->player_ptr, true);
+            reset_concentration(this->player_ptr, true);
 
             SpellHex spell_hex(this->player_ptr);
             if (spell_hex.is_spelling_any()) {
@@ -289,9 +288,7 @@ bool BadStatusSetter::paralysis(const TIME_EFFECT tmp_v)
     if (v > 0) {
         if (!this->player_ptr->paralyzed) {
             msg_print(_("体が麻痺してしまった！", "You are paralyzed!"));
-            if (this->player_ptr->concent) {
-                reset_concentration(this->player_ptr, true);
-            }
+            reset_concentration(this->player_ptr, true);
 
             SpellHex spell_hex(this->player_ptr);
             if (spell_hex.is_spelling_any()) {
@@ -350,9 +347,7 @@ bool BadStatusSetter::hallucination(const TIME_EFFECT tmp_v)
         set_tsuyoshi(this->player_ptr, 0, true);
         if (!this->player_ptr->hallucinated) {
             msg_print(_("ワーオ！何もかも虹色に見える！", "Oh, wow! Everything looks so cosmic now!"));
-            if (this->player_ptr->concent) {
-                reset_concentration(this->player_ptr, true);
-            }
+            reset_concentration(this->player_ptr, true);
 
             this->player_ptr->counter = false;
             notice = true;
@@ -539,9 +534,7 @@ void BadStatusSetter::process_stun_status(const PlayerStunRank new_rank, const s
         msg_print(_("型が崩れた。", "You lose your stance."));
     }
 
-    if (this->player_ptr->concent) {
-        reset_concentration(this->player_ptr, true);
-    }
+    reset_concentration(this->player_ptr, true);
 
     SpellHex spell_hex(this->player_ptr);
     if (spell_hex.is_spelling_any()) {

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -190,10 +190,6 @@ public:
 
     ClassSpecificData class_specific_data;
 
-#define CONCENT_RADAR_THRESHOLD 2
-#define CONCENT_TELE_THRESHOLD 5
-    int16_t concent{}; /* Sniper's concentration level */
-
     HIT_POINT player_hp[PY_MAX_LEVEL]{};
     char died_from[MAX_MONSTER_NAME]{}; /* What killed the player */
     concptr last_message{}; /* Last message on death or retirement */
@@ -206,8 +202,6 @@ public:
     bool now_damaged{};
     bool ambush_flag{};
     BIT_FLAGS change_floor_mode{}; /*!<フロア移行処理に関するフラグ / Mode flags for changing floor */
-
-    bool reset_concent{}; /* Concentration reset flag */
 
     MONSTER_IDX riding{}; /* Riding on a monster of this index */
 

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -6,6 +6,7 @@
 #include "player-base/player-class.h"
 #include "player-info/bluemage-data-type.h"
 #include "player-info/mane-data-type.h"
+#include "player-info/sniper-data-type.h"
 #include "player/attack-defense-types.h"
 #include "player/digestion-processor.h"
 #include "player/player-status-table.h"
@@ -464,8 +465,8 @@ void print_status(player_type *player_ptr)
     if (player_ptr->tim_invis)
         ADD_BAR_FLAG(BAR_SENSEUNSEEN);
 
-    if (player_ptr->concent >= CONCENT_RADAR_THRESHOLD)
-    {
+    auto sniper_data = PlayerClass(player_ptr).get_specific_data<sniper_data_type>();
+    if (sniper_data && (sniper_data->concent >= CONCENT_RADAR_THRESHOLD)) {
         ADD_BAR_FLAG(BAR_SENSEUNSEEN);
         ADD_BAR_FLAG(BAR_NIGHTSIGHT);
     }


### PR DESCRIPTION
player_type にスナイパーしか使用しない集中度と集中度リセットフラグが
あるので、職業固有データ sniper_data_type を定義して移動させる。

職業固有データの分離の続き。スナイパーを見落としていた。
また、集中度0とそうでない時の不要な分岐が多々見受けられたので、それも修正しています。