### PR TITLE
[Add] プリコンパイルヘッダをいくつか追加

### DIFF
--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -7,12 +7,16 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <numeric>
 #include <optional>
 #include <queue>
+#include <set>
 #include <sstream>
 #include <stack>
 #include <string>
 #include <string_view>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
+#include <variant>
 #include <vector>


### PR DESCRIPTION
GCC/Clang ではほぼ効果がなかったですが、VSだとフルビルドにかかる時間が手元のマシンで75秒→60秒程度に短縮されるようなので、追加しておきます。