### PR TITLE
[Feature] モンスター・ボールを武器と交換できるようにする

### DIFF
--- a/src/cmd-item/cmd-equipment.cpp
+++ b/src/cmd-item/cmd-equipment.cpp
@@ -124,7 +124,8 @@ void do_cmd_wield(player_type *player_ptr)
                 need_switch_wielding = INVEN_SUB_HAND;
         } else if (has_melee_weapon(player_ptr, INVEN_SUB_HAND))
             slot = INVEN_MAIN_HAND;
-        else if (o_ptr_mh->k_idx && !o_ptr_mh->is_melee_weapon() && o_ptr_sh->k_idx && !o_ptr_sh->is_melee_weapon()) {
+        else if (o_ptr_mh->k_idx && o_ptr_sh->k_idx &&
+                 ((o_ptr->tval == TV_CAPTURE) || (!o_ptr_mh->is_melee_weapon() && !o_ptr_sh->is_melee_weapon()))) {
             q = _("どちらの手に装備しますか?", "Equip which hand? ");
             s = _("おっと。", "Oops.");
             if (!choose_object(player_ptr, &slot, q, s, (USE_EQUIP), FuncItemTester(&object_type::is_wieldable_in_etheir_hand)))


### PR DESCRIPTION
Resolve #1442.
現状、武器と盾を装備している時はモンスター・ボールを装備すると強制的に
盾と交換されてしまう。
一発で武器と交換できてはならない理由はないので交換できるようにする。