### PR TITLE
痛恨の一撃を食らった時に朦朧値が正しく蓄積しない不具合を修正した

### DIFF
--- a/src/monster-attack/monster-attack-switcher.cpp
+++ b/src/monster-attack/monster-attack-switcher.cpp
@@ -309,10 +309,10 @@ void switch_monster_blow_to_player(player_type *player_ptr, monap_type *monap_pt
         break;
     case RBE_SUPERHURT: { /* AC軽減あり / Player armor reduces total damage */
         if (((randint1(monap_ptr->rlev * 2 + 300) > (monap_ptr->ac + 200)) || one_in_(13)) && !check_multishadow(player_ptr)) {
-            int tmp_damage = monap_ptr->damage - (monap_ptr->damage * ((monap_ptr->ac < 150) ? monap_ptr->ac : 150) / 250);
+            monap_ptr->damage -= (monap_ptr->damage * ((monap_ptr->ac < 150) ? monap_ptr->ac : 150) / 250);
             msg_print(_("痛恨の一撃！", "It was a critical hit!"));
-            tmp_damage = MAX(monap_ptr->damage, tmp_damage * 2);
-            monap_ptr->get_damage += take_hit(player_ptr, DAMAGE_ATTACK, tmp_damage, monap_ptr->ddesc);
+            monap_ptr->damage = MAX(monap_ptr->damage, monap_ptr->damage * 2);
+            monap_ptr->get_damage += take_hit(player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
             break;
         }
     }


### PR DESCRIPTION
掲題の通りです
本来はmonap->damage へ値を格納してそれを朦朧値の蓄積に使用するのが正しいのですが、誤ってローカル変数で痛恨のダメージを計算していました
ご確認下さい