### PR TITLE
[Refactor] 種族関連の処理を PlayerRace クラスへ移動する

### DIFF
--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -12,6 +12,7 @@
 #include "monster-race/race-flags7.h"
 #include "object/object-kind.h"
 #include "pet/pet-util.h"
+#include "player-base/player-race.h"
 #include "player-info/race-info.h"
 #include "player-info/race-types.h"
 #include "player/digestion-processor.h"
@@ -206,7 +207,7 @@ void init_dungeon_quests(player_type *player_ptr)
  */
 void init_turn(player_type *player_ptr)
 {
-    if (player_race_life(player_ptr) == PlayerRaceLife::UNDEAD) {
+    if (PlayerRace(player_ptr).life() == PlayerRaceLife::UNDEAD) {
         w_ptr->game_turn = (TURNS_PER_TICK * 3 * TOWN_DAWN) / 4 + 1;
         w_ptr->game_turn_limit = TURNS_PER_TICK * TOWN_DAWN * MAX_DAYS + TURNS_PER_TICK * TOWN_DAWN * 3 / 4;
     } else {

--- a/src/cmd-building/cmd-inn.cpp
+++ b/src/cmd-building/cmd-inn.cpp
@@ -6,6 +6,7 @@
 #include "market/bounty.h"
 #include "market/building-actions-table.h"
 #include "player-base/player-class.h"
+#include "player-base/player-race.h"
 #include "player-info/magic-eater-data-type.h"
 #include "player-info/race-info.h"
 #include "player-info/race-types.h"
@@ -57,7 +58,7 @@ static bool is_healthy_stay(player_type *player_ptr)
 #ifdef JP
 static bool is_player_undead(player_type *player_ptr)
 {
-    return player_race_life(player_ptr, true) == PlayerRaceLife::UNDEAD;
+    return PlayerRace(player_ptr, true).life() == PlayerRaceLife::UNDEAD;
 }
 #endif
 

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -153,7 +153,7 @@ bool exe_eat_charge_of_magic_device(player_type *player_ptr, object_type *o_ptr,
     if (o_ptr->tval != TV_STAFF && o_ptr->tval != TV_WAND)
         return false;
 
-    if (player_race_food(player_ptr) == PlayerRaceFood::MANA) {
+    if (PlayerRace(player_ptr).food() == PlayerRaceFood::MANA) {
         concptr staff;
 
         if (o_ptr->tval == TV_STAFF && (item < 0) && (o_ptr->number > 1)) {
@@ -272,7 +272,7 @@ void exe_eat_food(player_type *player_ptr, INVENTORY_IDX item)
         return;
     }
 
-    auto food_type = player_race_food(player_ptr);
+    auto food_type = PlayerRace(player_ptr).food();
 
     /* Balrogs change humanoid corpses to energy */
     if (food_type == PlayerRaceFood::CORPSE && (o_ptr->tval == TV_CORPSE && o_ptr->sval == SV_CORPSE && angband_strchr("pht", r_info[o_ptr->pval].d_char))) {

--- a/src/cmd-item/cmd-usestaff.cpp
+++ b/src/cmd-item/cmd-usestaff.cpp
@@ -17,6 +17,7 @@
 #include "object/object-info.h"
 #include "object/object-kind.h"
 #include "perception/object-perception.h"
+#include "player-base/player-race.h"
 #include "player-info/class-info.h"
 #include "player-info/race-info.h"
 #include "player-info/race-types.h"
@@ -286,7 +287,7 @@ int staff_effect(player_type *player_ptr, OBJECT_SUBTYPE_VALUE sval, bool *use_c
 
     case SV_STAFF_NOTHING: {
         msg_print(_("何も起らなかった。", "Nothing happens."));
-        if (player_race_food(player_ptr) == PlayerRaceFood::MANA)
+        if (PlayerRace(player_ptr).food() == PlayerRaceFood::MANA)
             msg_print(_("もったいない事をしたような気がする。食べ物は大切にしなくては。", "What a waste.  It's your food!"));
         break;
     }

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -392,7 +392,8 @@ void effect_player_lite(player_type *player_ptr, effect_player_type *ep_ptr)
 
     ep_ptr->dam = ep_ptr->dam * calc_lite_damage_rate(player_ptr, CALC_RAND) / 100;
 
-    if (player_race_life(player_ptr) == PlayerRaceLife::UNDEAD && player_race_has_flag(player_ptr, TR_VUL_LITE)) {
+    PlayerRace race(player_ptr);
+    if (race.life() == PlayerRaceLife::UNDEAD && race.tr_flags().has(TR_VUL_LITE)) {
         if (!check_multishadow(player_ptr))
             msg_print(_("光で肉体が焦がされた！", "The light scorches your flesh!"));
     }

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -21,6 +21,7 @@
 #include "object-enchant/trc-types.h"
 #include "object/object-flags.h"
 #include "pet/pet-util.h"
+#include "player-base/player-race.h"
 #include "player-info/race-info.h"
 #include "player-info/race-types.h"
 #include "player/attack-defense-types.h"
@@ -123,7 +124,8 @@ void process_player_hp_mp(player_type *player_ptr)
         }
     }
 
-    if (player_race_life(player_ptr) == PlayerRaceLife::UNDEAD && player_race_has_flag(player_ptr, TR_VUL_LITE)) {
+    const PlayerRace race(player_ptr);
+    if (race.life() == PlayerRaceLife::UNDEAD && race.tr_flags().has(TR_VUL_LITE)) {
         if (!is_in_dungeon(player_ptr) && !has_resist_lite(player_ptr) && !is_invuln(player_ptr) && is_daytime()) {
             if ((player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x].info & (CAVE_GLOW | CAVE_MNDK)) == CAVE_GLOW) {
                 msg_print(_("日光があなたのアンデッドの肉体を焼き焦がした！", "The sun's rays scorch your undead flesh!"));
@@ -207,7 +209,7 @@ void process_player_hp_mp(player_type *player_ptr)
         HIT_POINT damage;
         if ((r_info[player_ptr->current_floor_ptr->m_list[player_ptr->riding].r_idx].flags2 & RF2_AURA_FIRE) && !has_immune_fire(player_ptr)) {
             damage = r_info[player_ptr->current_floor_ptr->m_list[player_ptr->riding].r_idx].level / 2;
-            if (player_race_has_flag(player_ptr, TR_VUL_FIRE))
+            if (race.tr_flags().has(TR_VUL_FIRE))
                 damage += damage / 3;
             if (has_resist_fire(player_ptr))
                 damage = damage / 3;
@@ -218,7 +220,7 @@ void process_player_hp_mp(player_type *player_ptr)
         }
         if ((r_info[player_ptr->current_floor_ptr->m_list[player_ptr->riding].r_idx].flags2 & RF2_AURA_ELEC) && !has_immune_elec(player_ptr)) {
             damage = r_info[player_ptr->current_floor_ptr->m_list[player_ptr->riding].r_idx].level / 2;
-            if (player_race_has_flag(player_ptr, TR_VUL_ELEC))
+            if (race.tr_flags().has(TR_VUL_ELEC))
                 damage += damage / 3;
             if (has_resist_elec(player_ptr))
                 damage = damage / 3;
@@ -229,7 +231,7 @@ void process_player_hp_mp(player_type *player_ptr)
         }
         if ((r_info[player_ptr->current_floor_ptr->m_list[player_ptr->riding].r_idx].flags3 & RF3_AURA_COLD) && !has_immune_cold(player_ptr)) {
             damage = r_info[player_ptr->current_floor_ptr->m_list[player_ptr->riding].r_idx].level / 2;
-            if (player_race_has_flag(player_ptr, TR_VUL_COLD))
+            if (race.tr_flags().has(TR_VUL_COLD))
                 damage += damage / 3;
             if (has_resist_cold(player_ptr))
                 damage = damage / 3;

--- a/src/mspell/high-resistance-checker.cpp
+++ b/src/mspell/high-resistance-checker.cpp
@@ -3,7 +3,6 @@
 #include "monster/smart-learn-types.h"
 #include "mspell/smart-mspell-util.h"
 #include "player-base/player-race.h"
-#include "player-info/race-info.h"
 #include "player/player-status-flags.h"
 #include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
@@ -92,7 +91,7 @@ static void check_dark_resistance(player_type *player_ptr, msr_type *msr_ptr)
     if (msr_ptr->smart.has_not(SM::RES_DARK))
         return;
 
-    if (player_race_has_flag(player_ptr, TR_IM_DARK)) {
+    if (PlayerRace(player_ptr).tr_flags().has(TR_IM_DARK)) {
         msr_ptr->ability_flags.reset(RF_ABILITY::BR_DARK);
         msr_ptr->ability_flags.reset(RF_ABILITY::BA_DARK);
         return;

--- a/src/object-hook/hook-expendable.cpp
+++ b/src/object-hook/hook-expendable.cpp
@@ -7,6 +7,7 @@
 #include "object-enchant/special-object-flags.h"
 #include "object/object-kind.h"
 #include "perception/object-perception.h"
+#include "player-base/player-race.h"
 #include "player-info/mimic-info-table.h"
 #include "sv-definition/sv-lite-types.h"
 #include "sv-definition/sv-other-types.h"
@@ -26,7 +27,7 @@ bool item_tester_hook_eatable(player_type *player_ptr, const object_type *o_ptr)
     if (o_ptr->tval == TV_FOOD)
         return true;
 
-    auto food_type = player_race_food(player_ptr);
+    auto food_type = PlayerRace(player_ptr).food();
     if (food_type == PlayerRaceFood::MANA) {
         if (o_ptr->tval == TV_STAFF || o_ptr->tval == TV_WAND)
             return true;
@@ -49,7 +50,7 @@ bool item_tester_hook_quaff(player_type *player_ptr, const object_type *o_ptr)
     if (o_ptr->tval == TV_POTION)
         return true;
 
-    if (player_race_food(player_ptr) == PlayerRaceFood::OIL && o_ptr->tval == TV_FLASK && o_ptr->sval == SV_FLASK_OIL)
+    if (PlayerRace(player_ptr).food() == PlayerRaceFood::OIL && o_ptr->tval == TV_FLASK && o_ptr->sval == SV_FLASK_OIL)
         return true;
 
     return false;

--- a/src/object-use/quaff-execution.cpp
+++ b/src/object-use/quaff-execution.cpp
@@ -177,7 +177,7 @@ void exe_quaff_potion(player_type *player_ptr, INVENTORY_IDX item)
 
         case SV_POTION_SALT_WATER: {
             msg_print(_("うぇ！思わず吐いてしまった。", "The potion makes you vomit!"));
-            switch (player_race_food(player_ptr)) {
+            switch (PlayerRace(player_ptr).food()) {
             case PlayerRaceFood::RATION:
             case PlayerRaceFood::WATER:
             case PlayerRaceFood::BLOOD:
@@ -597,7 +597,7 @@ void exe_quaff_potion(player_type *player_ptr, INVENTORY_IDX item)
     if (PlayerRace(player_ptr).equals(player_race_type::SKELETON))
         return; //!< @note スケルトンは水分で飢えを満たせない
 
-    switch (player_race_food(player_ptr)) {
+    switch (PlayerRace(player_ptr).food()) {
     case PlayerRaceFood::WATER:
         msg_print(_("水分を取り込んだ。", "You are moistened."));
         set_food(player_ptr, MIN(player_ptr->food + q_ptr->pval + MAX(0, q_ptr->pval * 10) + 2000, PY_FOOD_MAX - 1));

--- a/src/player-base/player-race.cpp
+++ b/src/player-base/player-race.cpp
@@ -6,12 +6,90 @@
  */
 #include "player-base/player-race.h"
 #include "player-info/mimic-info-table.h"
+#include "player/race-info-table.h"
 #include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 
-PlayerRace::PlayerRace(player_type *player_ptr)
+/*!
+ * @brief Construct a new Player Race:: Player Race object
+ *
+ * @param base_race true の場合、仮に変身している場合でも元の種族について扱う。 false の場合変身している種族について扱う。
+ * 引数を省略した場合は false
+ */
+PlayerRace::PlayerRace(player_type *player_ptr, bool base_race)
     : player_ptr(player_ptr)
+    , base_race(base_race)
 {
+}
+
+/*!
+ * @brief 種族固有の特性フラグを取得する
+ * @return
+ */
+TrFlags PlayerRace::tr_flags() const
+{
+    TrFlags flags;
+
+    auto race_ptr = this->get_info();
+    if (race_ptr->infra > 0)
+        flags.set(TR_INFRA);
+
+    for (auto &cond : race_ptr->extra_flags) {
+        if (player_ptr->lev < cond.level)
+            continue;
+        if (cond.pclass != std::nullopt) {
+            if (cond.not_class && player_ptr->pclass == cond.pclass)
+                continue;
+            if (!cond.not_class && player_ptr->pclass != cond.pclass)
+                continue;
+        }
+
+        flags.set(cond.type);
+    }
+
+    return flags;
+}
+
+/*!
+ * @brief プレイヤーの種族情報テーブルへのポインタを取得する
+ *
+ * @return プレイヤーの種族情報テーブルへのポインタ
+ */
+const player_race_info *PlayerRace::get_info() const
+{
+    if (this->base_race) {
+        return &race_info[enum2i(this->player_ptr->prace)];
+    }
+
+    switch (this->player_ptr->mimic_form) {
+    case MIMIC_DEMON:
+    case MIMIC_DEMON_LORD:
+    case MIMIC_VAMPIRE:
+        return &mimic_info[this->player_ptr->mimic_form];
+    default: // MIMIC_NONE or undefined
+        return &race_info[enum2i(this->player_ptr->prace)];
+    }
+}
+
+/*!
+ * @brief 種族の生命形態を返す
+ * @param player_ptr プレイヤー情報への参照ポインタ
+ * @return 生命形態
+ */
+PlayerRaceLife PlayerRace::life() const
+{
+    return this->get_info()->life;
+}
+
+/*!
+ * @brief 種族の食料形態を返す
+ * @param player_ptr プレイヤー情報への参照ポインタ
+ * @param base_race ミミック中も元種族の情報を返すならtrue
+ * @return 食料形態
+ */
+PlayerRaceFood PlayerRace::food() const
+{
+    return this->get_info()->food;
 }
 
 bool PlayerRace::is_mimic_nonliving() const

--- a/src/player-base/player-race.h
+++ b/src/player-base/player-race.h
@@ -1,12 +1,22 @@
 ﻿#pragma once
 
+#include "object-enchant/tr-flags.h"
+
 enum class player_race_type;
+enum class PlayerRaceLife;
+enum class PlayerRaceFood;
 struct player_type;
+struct player_race_info;
 class PlayerRace {
 public:
     PlayerRace() = delete;
-    PlayerRace(player_type *player_ptr);
+    PlayerRace(player_type *player_ptr, bool base_race = false);
     virtual ~PlayerRace() = default;
+
+    TrFlags tr_flags() const;
+    const player_race_info *get_info() const;
+    PlayerRaceLife life() const;
+    PlayerRaceFood food() const;
 
     bool is_mimic_nonliving() const;
     bool can_resist_cut() const;
@@ -14,4 +24,5 @@ public:
 
 private:
     player_type *player_ptr;
+    bool base_race;
 };

--- a/src/player-info/race-info.h
+++ b/src/player-info/race-info.h
@@ -113,7 +113,3 @@ extern const player_race_info *rp_ptr;
 
 struct player_type;
 SYMBOL_CODE get_summon_symbol_from_player(player_type *player_ptr);
-bool player_race_has_flag(player_type *player_ptr, tr_type flag, bool base_race = false);
-void add_player_race_flags(player_type *player_ptr, TrFlags &flags, bool base_race = false);
-PlayerRaceLife player_race_life(player_type *player_ptr, bool base_race = false);
-PlayerRaceFood player_race_food(player_type *player_ptr, bool base_race = false);

--- a/src/player-info/resistance-info.cpp
+++ b/src/player-info/resistance-info.cpp
@@ -8,6 +8,8 @@
 
 void set_element_resistance_info(player_type *player_ptr, self_info_type *self_ptr)
 {
+    const auto race_tr_flags = PlayerRace(player_ptr).tr_flags();
+
     if (has_immune_acid(player_ptr))
         self_ptr->info[self_ptr->line++] = _("あなたは酸に対する完全なる免疫を持っている。", "You are completely immune to acid.");
     else if (has_resist_acid(player_ptr) && is_oppose_acid(player_ptr))
@@ -15,7 +17,7 @@ void set_element_resistance_info(player_type *player_ptr, self_info_type *self_p
     else if (has_resist_acid(player_ptr) || is_oppose_acid(player_ptr))
         self_ptr->info[self_ptr->line++] = _("あなたは酸への耐性を持っている。", "You are resistant to acid.");
 
-    if (player_race_has_flag(player_ptr, TR_VUL_ACID) && !has_immune_acid(player_ptr))
+    if (race_tr_flags.has(TR_VUL_ACID) && !has_immune_acid(player_ptr))
         self_ptr->info[self_ptr->line++] = _("あなたは酸に弱い。", "You are susceptible to damage from acid.");
 
     if (has_immune_elec(player_ptr))
@@ -25,7 +27,7 @@ void set_element_resistance_info(player_type *player_ptr, self_info_type *self_p
     else if (has_resist_elec(player_ptr) || is_oppose_elec(player_ptr))
         self_ptr->info[self_ptr->line++] = _("あなたは電撃への耐性を持っている。", "You are resistant to lightning.");
 
-    if (player_race_has_flag(player_ptr, TR_VUL_ELEC) && !has_immune_elec(player_ptr))
+    if (race_tr_flags.has(TR_VUL_ELEC) && !has_immune_elec(player_ptr))
         self_ptr->info[self_ptr->line++] = _("あなたは電撃に弱い。", "You are susceptible to damage from lightning.");
 
     if (has_immune_fire(player_ptr))
@@ -35,7 +37,7 @@ void set_element_resistance_info(player_type *player_ptr, self_info_type *self_p
     else if (has_resist_fire(player_ptr) || is_oppose_fire(player_ptr))
         self_ptr->info[self_ptr->line++] = _("あなたは火への耐性を持っている。", "You are resistant to fire.");
 
-    if (player_race_has_flag(player_ptr, TR_VUL_FIRE) && !has_immune_fire(player_ptr))
+    if (race_tr_flags.has(TR_VUL_FIRE) && !has_immune_fire(player_ptr))
         self_ptr->info[self_ptr->line++] = _("あなたは火に弱い。", "You are susceptible to damage from fire.");
 
     if (has_immune_cold(player_ptr))
@@ -45,7 +47,7 @@ void set_element_resistance_info(player_type *player_ptr, self_info_type *self_p
     else if (has_resist_cold(player_ptr) || is_oppose_cold(player_ptr))
         self_ptr->info[self_ptr->line++] = _("あなたは冷気への耐性を持っている。", "You are resistant to cold.");
 
-    if (player_race_has_flag(player_ptr, TR_VUL_COLD) && !has_immune_cold(player_ptr))
+    if (race_tr_flags.has(TR_VUL_COLD) && !has_immune_cold(player_ptr))
         self_ptr->info[self_ptr->line++] = _("あなたは冷気に弱い。", "You are susceptible to damage from cold.");
 
     if (has_resist_pois(player_ptr) && is_oppose_pois(player_ptr))

--- a/src/player/eldritch-horror.cpp
+++ b/src/player/eldritch-horror.cpp
@@ -19,6 +19,7 @@
 #include "monster/monster-util.h"
 #include "monster/smart-learn-types.h"
 #include "mutation/mutation-flag-types.h"
+#include "player-base/player-race.h"
 #include "player-info/mimic-info-table.h"
 #include "player/player-status-flags.h"
 #include "player/player-status.h"
@@ -130,7 +131,7 @@ void sanity_blast(player_type *player_ptr, monster_type *m_ptr, bool necro)
         }
 
         see_eldritch_horror(m_name, r_ptr);
-        switch (player_race_life(player_ptr)) {
+        switch (PlayerRace(player_ptr).life()) {
         case PlayerRaceLife::DEMON:
             return;
         case PlayerRaceLife::UNDEAD:
@@ -180,7 +181,7 @@ void sanity_blast(player_type *player_ptr, monster_type *m_ptr, bool necro)
         }
 
         feel_eldritch_horror(desc, r_ptr);
-        switch (player_race_life(player_ptr)) {
+        switch (PlayerRace(player_ptr).life()) {
         case PlayerRaceLife::DEMON:
             if (saving_throw(20 + player_ptr->lev))
                 return;

--- a/src/player/permanent-resistances.cpp
+++ b/src/player/permanent-resistances.cpp
@@ -4,8 +4,8 @@
 #include "mutation/mutation-flag-types.h"
 #include "object-enchant/tr-types.h"
 #include "player-base/player-class.h"
+#include "player-base/player-race.h"
 #include "player-info/equipment-info.h"
-#include "player-info/race-info.h"
 #include "player-info/race-types.h"
 #include "player/player-personality-types.h"
 #include "player/player-status-flags.h"
@@ -147,7 +147,7 @@ void player_flags(player_type *player_ptr, TrFlags &flags)
     flags.clear();
 
     flags.set(PlayerClass(player_ptr).tr_flags());
-    add_player_race_flags(player_ptr, flags);
+    flags.set(PlayerRace(player_ptr).tr_flags());
 
     add_mutation_flags(player_ptr, flags);
     add_personality_flags(player_ptr, flags);

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -55,7 +55,7 @@ BIT_FLAGS common_cause_flags(player_type *player_ptr, tr_type tr_flag)
 {
     BIT_FLAGS result = check_equipment_flags(player_ptr, tr_flag);
 
-    if (player_race_has_flag(player_ptr, tr_flag)) {
+    if (PlayerRace(player_ptr).tr_flags().has(tr_flag)) {
         set_bits(result, FLAG_CAUSE_RACE);
     }
 
@@ -1697,7 +1697,7 @@ BIT_FLAGS has_lite(player_type *player_ptr)
         result |= FLAG_CAUSE_PERSONALITY;
     }
 
-    if (player_race_has_flag(player_ptr, TR_LITE_1))
+    if (PlayerRace(player_ptr).tr_flags().has(TR_LITE_1))
         result |= FLAG_CAUSE_RACE;
 
     if (player_ptr->ult_res) {

--- a/src/player/player-status-resist.cpp
+++ b/src/player/player-status-resist.cpp
@@ -233,8 +233,10 @@ PERCENTAGE calc_lite_damage_rate(player_type *player_ptr, rate_calc_type_mode mo
 {
     PERCENTAGE per = 100;
 
-    if (player_race_has_flag(player_ptr, TR_VUL_LITE)) {
-        switch (player_race_life(player_ptr)) {
+    PlayerRace race(player_ptr);
+
+    if (race.tr_flags().has(TR_VUL_LITE)) {
+        switch (race.life()) {
         case PlayerRaceLife::UNDEAD:
             per *= 2;
             break;

--- a/src/player/race-resistances.cpp
+++ b/src/player/race-resistances.cpp
@@ -4,6 +4,7 @@
 #include "mutation/mutation-flag-types.h"
 #include "object-enchant/tr-types.h"
 #include "object/object-flags.h"
+#include "player-base/player-class.h"
 #include "player-base/player-race.h"
 #include "player-info/race-info.h"
 #include "player/special-defense-types.h"
@@ -22,30 +23,21 @@ void player_immunity(player_type *player_ptr, TrFlags &flags)
 {
     flags.clear();
 
-    if (player_race_has_flag(player_ptr, TR_IM_ACID))
+    const auto p_flags = (PlayerRace(player_ptr).tr_flags() | PlayerClass(player_ptr).tr_flags());
+
+    if (p_flags.has(TR_IM_ACID))
         flags.set(TR_RES_ACID);
-    if (player_race_has_flag(player_ptr, TR_IM_COLD))
+    if (p_flags.has(TR_IM_COLD))
         flags.set(TR_RES_COLD);
-    if (player_race_has_flag(player_ptr, TR_IM_ELEC))
+    if (p_flags.has(TR_IM_ELEC))
         flags.set(TR_RES_ELEC);
-    if (player_race_has_flag(player_ptr, TR_IM_FIRE))
+    if (p_flags.has(TR_IM_FIRE))
         flags.set(TR_RES_FIRE);
+    if (p_flags.has(TR_IM_DARK))
+        flags.set(TR_RES_DARK);
 
     if (PlayerRace(player_ptr).equals(player_race_type::SPECTRE))
         flags.set(TR_RES_NETHER);
-    if (player_race_has_flag(player_ptr, TR_IM_DARK))
-        flags.set(TR_RES_DARK);
-
-    if (player_ptr->pclass == CLASS_ELEMENTALIST) {
-        if (has_element_resist(player_ptr, ElementRealm::FIRE, 30))
-            flags.set(TR_RES_FIRE);
-        if (has_element_resist(player_ptr, ElementRealm::SKY, 30))
-            flags.set(TR_RES_ELEC);
-        if (has_element_resist(player_ptr, ElementRealm::SEA, 30))
-            flags.set(TR_RES_ACID);
-        if (has_element_resist(player_ptr, ElementRealm::ICE, 30))
-            flags.set(TR_RES_COLD);
-    }
 }
 
 /*!
@@ -118,14 +110,16 @@ void player_vulnerability_flags(player_type *player_ptr, TrFlags &flags)
         flags.set(TR_RES_COLD);
     }
 
-    if (player_race_has_flag(player_ptr, TR_VUL_ACID))
+    const auto p_flags = PlayerRace(player_ptr).tr_flags();
+
+    if (p_flags.has(TR_VUL_ACID))
         flags.set(TR_RES_ACID);
-    if (player_race_has_flag(player_ptr, TR_VUL_COLD))
+    if (p_flags.has(TR_VUL_COLD))
         flags.set(TR_RES_COLD);
-    if (player_race_has_flag(player_ptr, TR_VUL_ELEC))
+    if (p_flags.has(TR_VUL_ELEC))
         flags.set(TR_RES_ELEC);
-    if (player_race_has_flag(player_ptr, TR_VUL_FIRE))
+    if (p_flags.has(TR_VUL_FIRE))
         flags.set(TR_RES_FIRE);
-    if (player_race_has_flag(player_ptr, TR_VUL_LITE))
+    if (p_flags.has(TR_VUL_LITE))
         flags.set(TR_RES_LITE);
 }

--- a/src/realm/realm-nature.cpp
+++ b/src/realm/realm-nature.cpp
@@ -10,6 +10,7 @@
 #include "monster-floor/place-monster-types.h"
 #include "object/object-kind-hook.h"
 #include "player-attack/player-attack.h"
+#include "player-base/player-race.h"
 #include "player-info/race-info.h"
 #include "player-info/race-types.h"
 #include "player/player-damage.h"
@@ -158,7 +159,8 @@ concptr do_nature_spell(player_type *player_ptr, SPELL_IDX spell, spell_type mod
             if (cast) {
                 lite_area(player_ptr, damroll(dice, sides), rad);
 
-                if (player_race_life(player_ptr) == PlayerRaceLife::UNDEAD && player_race_has_flag(player_ptr, TR_VUL_LITE) && !has_resist_lite(player_ptr)) {
+                PlayerRace race(player_ptr);
+                if (race.life() == PlayerRaceLife::UNDEAD && race.tr_flags().has(TR_VUL_LITE) && !has_resist_lite(player_ptr)) {
                     msg_print(_("日の光があなたの肉体を焦がした！", "The daylight scorches your flesh!"));
                     take_hit(player_ptr, DAMAGE_NOESCAPE, damroll(2, 2), _("日の光", "daylight"));
                 }
@@ -624,7 +626,8 @@ concptr do_nature_spell(player_type *player_ptr, SPELL_IDX spell, spell_type mod
                 chg_virtue(player_ptr, V_ENLIGHTEN, 1);
                 wiz_lite(player_ptr, false);
 
-                if (player_race_life(player_ptr) == PlayerRaceLife::UNDEAD && player_race_has_flag(player_ptr, TR_VUL_LITE) && !has_resist_lite(player_ptr)) {
+                PlayerRace race(player_ptr);
+                if (race.life() == PlayerRaceLife::UNDEAD && race.tr_flags().has(TR_VUL_LITE) && !has_resist_lite(player_ptr)) {
                     msg_print(_("日光があなたの肉体を焦がした！", "The sunlight scorches your flesh!"));
                     take_hit(player_ptr, DAMAGE_NOESCAPE, 50, _("日光", "sunlight"));
                 }


### PR DESCRIPTION
以下の種族関連の処理を PlayerRace クラスのメンバ関数にする。

- player_race_has_flag / add_player_race_flags
  → 内容がほぼ同一なので PlayerRace::tr_flags() にまとめる
- get_player_race_info
- player_race_life / player_face_food