### PR TITLE
[Feature] 究極の耐性と無双の型に新規耐性を追加

### DIFF
--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -1507,9 +1507,11 @@ BIT_FLAGS has_resist_time(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_TIME);
 
-    //! @todo 究極の耐性と無双の型で耐性を得られるようにすべき？
+    if (player_ptr->special_defense & KATA_MUSOU) {
+        result |= FLAG_CAUSE_BATTLE_FORM;
+    }
 
-    if (player_ptr->tim_res_time) {
+    if (player_ptr->ult_res || player_ptr->tim_res_time) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
@@ -1520,7 +1522,14 @@ BIT_FLAGS has_resist_water(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_WATER);
 
-    //! @todo 究極の耐性と無双の型で耐性を得られるようにすべき？
+    if (player_ptr->special_defense & KATA_MUSOU) {
+        result |= FLAG_CAUSE_BATTLE_FORM;
+    }
+
+    if (player_ptr->ult_res) {
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
+    }
+
 
     return result;
 }
@@ -1534,7 +1543,13 @@ BIT_FLAGS has_resist_curse(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_CURSE);
 
-    //! @todo 究極の耐性と無双の型で耐性を得られるようにすべき？
+    if (player_ptr->special_defense & KATA_MUSOU) {
+        result |= FLAG_CAUSE_BATTLE_FORM;
+    }
+
+    if (player_ptr->ult_res) {
+        result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
+    }
 
     return result;
 }


### PR DESCRIPTION
究極の耐性と無双の型はあらゆる一時耐性を得る特徴を持っているが、
最近新規に追加された耐性フラグの水・時間逆転・呪力に対応していない。
特徴からいってこれらの耐性も得られるべきだと思われるので追加する。

他と合わせておくため今回は set_bits は使っていません。
そもそも、こいつらもいい加減全部の耐性所持判定に書くのではなくまとめたいところ。