### PR TITLE
新しい朦朧の仕様を実装した

### DIFF
--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -278,7 +278,7 @@ void process_player(player_type *player_ptr)
         PlayerEnergy energy(player_ptr);
         energy.reset_player_turn();
         auto effects = player_ptr->effects();
-        auto is_unconscious = effects->stun()->get_rank() == PlayerStunRank::UNCONSCIOUS;
+        auto is_unconscious = effects->stun()->is_unconscious();
         if (player_ptr->phase_out) {
             move_cursor_relative(player_ptr->y, player_ptr->x);
             command_cmd = SPECIAL_KEY_BUILDING;

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -278,12 +278,12 @@ void process_player(player_type *player_ptr)
         PlayerEnergy energy(player_ptr);
         energy.reset_player_turn();
         auto effects = player_ptr->effects();
-        auto is_unconscious = effects->stun()->is_unconscious();
+        auto is_knocked_out = effects->stun()->is_knocked_out();
         if (player_ptr->phase_out) {
             move_cursor_relative(player_ptr->y, player_ptr->x);
             command_cmd = SPECIAL_KEY_BUILDING;
             process_command(player_ptr);
-        } else if ((player_ptr->paralyzed || is_unconscious) && !cheat_immortal) {
+        } else if ((player_ptr->paralyzed || is_knocked_out) && !cheat_immortal) {
             energy.set_player_turn_energy(100);
         } else if (player_ptr->action == ACTION_REST) {
             if (player_ptr->resting > 0) {

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -176,7 +176,7 @@ static void calc_player_cut(player_type *player_ptr, monap_type *monap_ptr)
     }
 }
 
-static void calc_player_stun(player_type *player_ptr, monap_type *monap_ptr)
+static void process_player_stun(player_type *player_ptr, monap_type *monap_ptr)
 {
     if (monap_ptr->do_stun == 0) {
         return;
@@ -277,7 +277,7 @@ static bool process_monster_attack_hit(player_type *player_ptr, monap_type *mona
     switch_monster_blow_to_player(player_ptr, monap_ptr);
     select_cut_stun(monap_ptr);
     calc_player_cut(player_ptr, monap_ptr);
-    calc_player_stun(player_ptr, monap_ptr);
+    process_player_stun(player_ptr, monap_ptr);
     monster_explode(player_ptr, monap_ptr);
     process_aura_counterattack(player_ptr, monap_ptr);
     return true;

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -176,13 +176,58 @@ static void calc_player_cut(player_type *player_ptr, monap_type *monap_ptr)
     }
 }
 
+/*!
+ * @brief 能力値の実値を求める
+ * @param raw player_typeに格納されている生値
+ * @return 実値
+ * @details AD&Dの記法に則り、19以上の値を取らなくしているので、格納方法が面倒
+ */
+static int stat_value(const int raw)
+{
+    if (raw <= 18) {
+        return raw;
+    }
+
+    return (raw - 18) / 10 + 18;
+}
+
+/*!
+ * @brief 朦朧を蓄積させる
+ * @param player_ptr プレイヤーへの参照ポインタ
+ * @param monap_ptr モンスター打撃への参照ポインタ
+ * @details
+ * 痛恨の一撃ならば朦朧蓄積ランクを1上げる.
+ * 2%の確率で朦朧蓄積ランクを1上げる.
+ * 肉体のパラメータが合計80を超える水準に強化されていたら朦朧蓄積ランクを1下げる.
+ */
 static void process_player_stun(player_type *player_ptr, monap_type *monap_ptr)
 {
     if (monap_ptr->do_stun == 0) {
         return;
     }
 
-    auto accumulation_rank = PlayerStun::get_accumulation_rank(monap_ptr->d_dice * monap_ptr->d_side, monap_ptr->damage);
+    auto total = monap_ptr->d_dice * monap_ptr->d_side;
+    auto accumulation_rank = PlayerStun::get_accumulation_rank(total, monap_ptr->damage);
+    if (accumulation_rank == 0) {
+        return;
+    }
+
+    if ((total < monap_ptr->damage) && (accumulation_rank <= 6)) {
+        accumulation_rank++;
+    }
+
+    if (one_in_(50)) {
+        accumulation_rank++;
+    }
+
+    auto str = stat_value(player_ptr->stat_cur[A_STR]);
+    auto dex = stat_value(player_ptr->stat_cur[A_DEX]);
+    auto con = stat_value(player_ptr->stat_cur[A_CON]);
+    auto is_powerful_body = str + dex + con > 80;
+    if (is_powerful_body) {
+        accumulation_rank--;
+    }
+
     auto stun_plus = PlayerStun::get_accumulation(accumulation_rank);
     if (stun_plus > 0) {
         (void)BadStatusSetter(player_ptr).mod_stun(stun_plus);

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -564,7 +564,7 @@ void BadStatusSetter::decrease_int_wis(const short v)
     }
 
     msg_print(_("割れるような頭痛がする。", "A vicious blow hits your head."));
-    auto rand = randint0(3);
+    auto rand = randint0(5);
     switch (rand) {
     case 0:
         if (has_sustain_int(this->player_ptr) == 0) {
@@ -577,19 +577,21 @@ void BadStatusSetter::decrease_int_wis(const short v)
 
         return;
     case 1:
+    case 2:
         if (has_sustain_int(this->player_ptr) == 0) {
             (void)do_dec_stat(this->player_ptr, A_INT);
         }
         
         return;
-    case 2:
+    case 3:
+    case 4:
         if (has_sustain_wis(this->player_ptr) == 0) {
             (void)do_dec_stat(this->player_ptr, A_WIS);
         }
 
         return;
     default:
-        return;
+        throw("Invalid random number is specified!");
     }
 }
 

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -518,7 +518,7 @@ bool BadStatusSetter::process_stun_effect(const short v)
     }
     
     if (new_rank < old_rank) {
-        this->clear_head(new_rank);
+        this->clear_head();
         return true;
     }
 
@@ -542,9 +542,9 @@ void BadStatusSetter::process_stun_status(const PlayerStunRank new_rank, const s
     }
 }
 
-void BadStatusSetter::clear_head(const PlayerStunRank new_rank)
+void BadStatusSetter::clear_head()
 {
-    if (new_rank >= PlayerStunRank::NORMAL) {
+    if (this->player_ptr->effects()->stun()->is_stunned()) {
         return;
     }
 

--- a/src/status/bad-status-setter.h
+++ b/src/status/bad-status-setter.h
@@ -38,7 +38,7 @@ private:
 
     bool process_stun_effect(const short v);
     void process_stun_status(const PlayerStunRank new_rank, const short v);
-    void clear_head(const PlayerStunRank new_rank);
+    void clear_head();
     void decrease_int_wis(const short v);
     bool process_cut_effect(const short v);
     void decrease_charisma(const PlayerCutRank new_rank, const short v);

--- a/src/timed-effect/player-stun.cpp
+++ b/src/timed-effect/player-stun.cpp
@@ -1,6 +1,13 @@
 ﻿#include "timed-effect/player-stun.h"
 #include "system/angband.h"
 
+enum class PlayerStunRank {
+    NONE = 0,
+    NORMAL = 1,
+    HARD = 2,
+    UNCONSCIOUS = 3,
+};
+
 PlayerStunRank PlayerStun::get_rank(short value)
 {
     if (value > 100) {
@@ -189,6 +196,15 @@ short PlayerStun::get_damage_penalty() const
 bool PlayerStun::is_stunned() const
 {
     return this->get_rank() > PlayerStunRank::NONE;
+}
+
+/*!
+ * @brief プレイヤーが朦朧で行動不能かを返す
+ * @todo 新朦朧仕様に基づき、メソッド名をis_faint() に変更予定
+ */
+bool PlayerStun::is_unconscious() const
+{
+    return this->get_rank() > PlayerStunRank::UNCONSCIOUS;
 }
 
 std::tuple<term_color_type, std::string_view> PlayerStun::get_expr() const

--- a/src/timed-effect/player-stun.cpp
+++ b/src/timed-effect/player-stun.cpp
@@ -3,23 +3,33 @@
 
 enum class PlayerStunRank {
     NONE = 0,
-    NORMAL = 1,
-    HARD = 2,
-    UNCONSCIOUS = 3,
+    SLIGHT = 1,
+    NORMAL = 2,
+    HARD = 3,
+    UNCONSCIOUS = 4,
+    KNOCKED = 5,
 };
 
 PlayerStunRank PlayerStun::get_rank(short value)
 {
-    if (value > 100) {
+    if (value > 200) {
+        return PlayerStunRank::KNOCKED;
+    }
+
+    if (value > 150) {
         return PlayerStunRank::UNCONSCIOUS;
     }
 
-    if (value > 50) {
+    if (value > 100) {
         return PlayerStunRank::HARD;
     }
 
-    if (value > 0) {
+    if (value > 50) {
         return PlayerStunRank::NORMAL;
+    }
+
+    if (value > 0) {
+        return PlayerStunRank::SLIGHT;
     }
 
     return PlayerStunRank::NONE;
@@ -30,12 +40,16 @@ std::string_view PlayerStun::get_stun_mes(PlayerStunRank stun_rank)
     switch (stun_rank) {
     case PlayerStunRank::NONE:
         return "";
+    case PlayerStunRank::SLIGHT:
+        return _("意識が少しもうろうとしてきた。", "You have been slightly stunned.");
     case PlayerStunRank::NORMAL:
         return _("意識がもうろうとしてきた。", "You have been stunned.");
     case PlayerStunRank::HARD:
         return _("意識がひどくもうろうとしてきた。", "You have been heavily stunned.");
     case PlayerStunRank::UNCONSCIOUS:
-        return _("頭がクラクラして意識が遠のいてきた。", "You have been knocked out.");
+        return _("頭がクラクラして意識が遠のいてきた。", "You have been unconcious.");
+    case PlayerStunRank::KNOCKED:
+        return _("あなたはぶっ倒れた！", "You are knocked out!!");
     default:
         throw("Invalid StunRank was specified!");
     }
@@ -47,70 +61,71 @@ short PlayerStun::get_accumulation(int rank)
     case 0:
         return 0;
     case 1:
-        return randint1(5);
+        return randint1(10);
     case 2:
-        return randint1(5) + 10;
+        return randint1(10) + 10;
     case 3:
         return randint1(10) + 20;
     case 4:
-        return randint1(15) + 30;
+        return randint1(10) + 30;
     case 5:
-        return randint1(20) + 40;
+        return randint1(10) + 40;
     case 6:
-        return 80;
-    default:
-        return 150;
+        return randint1(10) + 50;
+    case 7:
+        return randint1(10) + 60;
+    default: // 8 or more.
+        return randint1(10) + 70;
     }
 }
 
 /*!
  * @brief モンスター打撃の朦朧蓄積ランクを返す.
- * @param total 痛恨の一撃でない場合の最大ダメージ (ダイスXdY に対し、X*Y)
+ * @param total 痛恨の一撃でない場合の最大ダメージ
  * @param dam プレイヤーに与えた実際のダメージ
  * @return 朦朧蓄積ランク
+ * @details
+ * totalは、ダイスXdY に対し、X*Y
+ * damageは、痛恨 かつ AC < 125 ならばtotalを超える可能性あり
  */
 int PlayerStun::get_accumulation_rank(int total, int damage)
 {
-    if (damage < total * 19 / 20) {
+    auto is_no_stun = damage < total * 19 / 20;
+    is_no_stun |= damage <= 20;
+    if (is_no_stun) {
         return 0;
     }
 
-    if ((damage < 20) && (damage <= randint0(100))) {
-        return 0;
+    if (damage > 256) {
+        return 8;
     }
 
-    auto max = 0;
-    if ((damage >= total) && (damage >= 40)) {
-        max++;
+    if (damage > 111) {
+        return 7;
     }
 
-    if (damage >= 20) {
-        while (randint0(100) < 2) {
-            max++;
-        }
+    if (damage > 96) {
+        return 6;
     }
 
-    if (damage > 45) {
-        return (6 + max);
+    if (damage > 81) {
+        return 5;
     }
 
-    if (damage > 33) {
-        return (5 + max);
+    if (damage > 66) {
+        return 4;
     }
 
-    if (damage > 25) {
-        return (4 + max);
+    if (damage > 51) {
+        return 3;
     }
 
-    if (damage > 18) {
-        return (3 + max);
+    if (damage > 36) {
+        return 2;
     }
 
-    if (damage > 11) {
-        return (2 + max);
-    }
-
-    return (1 + max);
+    // damage > 21.
+    return 1;
 }
 
 short PlayerStun::current() const
@@ -127,7 +142,7 @@ PlayerStunRank PlayerStun::get_rank() const
  * @brief 朦朧ランクに応じて魔法系の失率を上げる.
  * @return 失率
  * @details
- * 意識不明瞭ならばそもそも動けないのでこのメソッドを通らない.
+ * 昏倒ならばそもそも動けないのでこのメソッドを通らない.
  * しかし今後の拡張を考慮して100%としておく.
  */
 int PlayerStun::get_magic_chance_penalty() const
@@ -135,11 +150,15 @@ int PlayerStun::get_magic_chance_penalty() const
     switch (this->get_rank()) {
     case PlayerStunRank::NONE:
         return 0;
+    case PlayerStunRank::SLIGHT:
+        return 10;
     case PlayerStunRank::NORMAL:
-        return 15;
+        return 20;
     case PlayerStunRank::HARD:
-        return 25;
+        return 30;
     case PlayerStunRank::UNCONSCIOUS:
+        return 50;
+    case PlayerStunRank::KNOCKED:
         return 100;
     default:
         throw("Invalid stun rank is specified!");
@@ -157,12 +176,14 @@ int PlayerStun::get_item_chance_penalty() const
 {
     switch (this->get_rank()) {
     case PlayerStunRank::NONE:
-        return 0;
+    case PlayerStunRank::SLIGHT:
     case PlayerStunRank::NORMAL:
         return 0;
     case PlayerStunRank::HARD:
-        return 0;
+        return 5;
     case PlayerStunRank::UNCONSCIOUS:
+        return 10;
+    case PlayerStunRank::KNOCKED:
         return 100;
     default:
         throw("Invalid stun rank is specified!");
@@ -182,17 +203,25 @@ short PlayerStun::get_damage_penalty() const
     switch (this->get_rank()) {
     case PlayerStunRank::NONE:
         return 0;
-    case PlayerStunRank::NORMAL:
+    case PlayerStunRank::SLIGHT:
         return 5;
+    case PlayerStunRank::NORMAL:
+        return 10;
     case PlayerStunRank::HARD:
         return 20;
     case PlayerStunRank::UNCONSCIOUS:
+        return 40;
+    case PlayerStunRank::KNOCKED:
         return 100;
     default:
         throw("Invalid stun rank is specified!");
     }
 }
 
+/*!
+ * @brief プレイヤーが朦朧しているかを返す
+ * @return 朦朧状態ならばtrue、頭がハッキリしているならばfalse
+ */
 bool PlayerStun::is_stunned() const
 {
     return this->get_rank() > PlayerStunRank::NONE;
@@ -200,11 +229,11 @@ bool PlayerStun::is_stunned() const
 
 /*!
  * @brief プレイヤーが朦朧で行動不能かを返す
- * @todo 新朦朧仕様に基づき、メソッド名をis_faint() に変更予定
+ * @return 昏倒状態ならばtrue、それ以外ならばfalse
  */
-bool PlayerStun::is_unconscious() const
+bool PlayerStun::is_knocked_out() const
 {
-    return this->get_rank() > PlayerStunRank::UNCONSCIOUS;
+    return this->get_rank() == PlayerStunRank::KNOCKED;
 }
 
 std::tuple<term_color_type, std::string_view> PlayerStun::get_expr() const
@@ -212,12 +241,16 @@ std::tuple<term_color_type, std::string_view> PlayerStun::get_expr() const
     switch (this->get_rank()) {
     case PlayerStunRank::NONE: // dummy.
         return std::make_tuple(TERM_WHITE, "            ");
+    case PlayerStunRank::SLIGHT:
+        return std::make_tuple(TERM_WHITE, _("やや朦朧    ", "Slight stun "));
     case PlayerStunRank::NORMAL:
-        return std::make_tuple(TERM_ORANGE, _("朦朧        ", "Stun        "));
+        return std::make_tuple(TERM_YELLOW, _("朦朧        ", "Stun        "));
     case PlayerStunRank::HARD:
         return std::make_tuple(TERM_ORANGE, _("ひどく朦朧  ", "Heavy stun  "));
     case PlayerStunRank::UNCONSCIOUS:
-        return std::make_tuple(TERM_RED, _("意識不明瞭  ", "Knocked out "));
+        return std::make_tuple(TERM_RED, _("意識不明瞭  ", "Unconcious  "));
+    case PlayerStunRank::KNOCKED:
+        return std::make_tuple(TERM_VIOLET, _("昏倒        ", "Knocked out "));
     default:
         throw("Invalid stun rank is specified!");
     }

--- a/src/timed-effect/player-stun.h
+++ b/src/timed-effect/player-stun.h
@@ -4,13 +4,7 @@
 #include <string>
 #include <tuple>
 
-enum class PlayerStunRank {
-    NONE = 0,
-    NORMAL = 1,
-    HARD = 2,
-    UNCONSCIOUS = 3,
-};
-
+enum class PlayerStunRank;
 class PlayerStun {
 public:
     PlayerStun() = default;
@@ -27,6 +21,7 @@ public:
     int get_item_chance_penalty() const;
     short get_damage_penalty() const;
     bool is_stunned() const;
+    bool is_unconscious() const;
     std::tuple<term_color_type, std::string_view> get_expr() const;
     void set(short value);
     void reset();

--- a/src/timed-effect/player-stun.h
+++ b/src/timed-effect/player-stun.h
@@ -21,7 +21,7 @@ public:
     int get_item_chance_penalty() const;
     short get_damage_penalty() const;
     bool is_stunned() const;
-    bool is_unconscious() const;
+    bool is_knocked_out() const;
     std::tuple<term_color_type, std::string_view> get_expr() const;
     void set(short value);
     void reset();


### PR DESCRIPTION
掲題の通りです
今回は、直接打撃に基づく朦朧値の蓄積を緩やかにしました
それ以外 (例：轟音ブレス)は敢えて手つかずにすることで緩やかな蓄積となるように調整しました
手元で確認したところ、「Lv50のちからじまんサイクロプス戦士が宵闇のローブ＋両手に肉体強化の指輪を着ている」というレベルの極端な状況でない限り「昏倒＝行動不能」にはならないようになりました
また、そうであるが故にアイテム使用全般に失率を設けるのも妥当と判断しました
ご確認下さい