### PR TITLE
Windows(Visual Studio)用の必要ヘッダファイルの調整

### DIFF
--- a/src/blue-magic/learnt-power-getter.cpp
+++ b/src/blue-magic/learnt-power-getter.cpp
@@ -32,6 +32,7 @@
 #include "view/display-messages.h"
 
 #include <algorithm>
+#include <iterator>
 #include <vector>
 
 typedef struct learnt_magic_type {

--- a/src/io-dump/special-class-dump.cpp
+++ b/src/io-dump/special-class-dump.cpp
@@ -21,6 +21,7 @@
 #include "util/flag-group.h"
 
 #include <algorithm>
+#include <iterator>
 #include <string>
 #include <vector>
 

--- a/src/main-win/main-win-cfg-reader.h
+++ b/src/main-win/main-win-cfg-reader.h
@@ -4,7 +4,7 @@
 
 #include <cstddef>
 #include <vector>
-#include <map>
+#include <unordered_map>
 #include <initializer_list>
 
 typedef uint cfg_key;

--- a/src/main-win/main-win-sound.cpp
+++ b/src/main-win/main-win-sound.cpp
@@ -14,6 +14,7 @@
 #include "main/sound-definitions-table.h"
 
 #include <memory>
+#include <queue>
 
 #include <mmsystem.h>
 

--- a/src/main-win/main-win-utils.cpp
+++ b/src/main-win/main-win-utils.cpp
@@ -9,6 +9,8 @@
 #include "main-win/main-win-define.h"
 #include "system/angband-version.h"
 
+#include <string>
+
 /*!
  * @brief (Windows固有)変愚蛮怒が起動済かどうかのチェック
  * @details

--- a/src/melee/melee-spell-flags-checker.cpp
+++ b/src/melee/melee-spell-flags-checker.cpp
@@ -27,6 +27,8 @@
 #include "system/player-type-definition.h"
 #include "target/projection-path-calculator.h"
 
+#include <iterator>
+
 static void decide_melee_spell_target(player_type *player_ptr, melee_spell_type *ms_ptr)
 {
     if ((player_ptr->pet_t_m_idx == 0) || !ms_ptr->pet)

--- a/src/mspell/mspell-attack.cpp
+++ b/src/mspell/mspell-attack.cpp
@@ -41,6 +41,8 @@
 #include "monster/monster-description-types.h"
 #endif
 
+#include <iterator>
+
 static void set_no_magic_mask(msa_type *msa_ptr)
 {
     if (!msa_ptr->no_inate)

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -35,7 +35,7 @@
 #include "monster/monster-description-types.h"
 #endif
 
-#include <bitset>
+#include <iterator>
 
 /*!< 呪術の最大詠唱数 */
 constexpr int MAX_KEEP = 4;

--- a/src/system/h-system.h
+++ b/src/system/h-system.h
@@ -9,8 +9,16 @@
 
 #pragma once
 
+#include <ctype.h>
+#include <errno.h>
 #include <fcntl.h>
+#include <memory.h>
 #include <stdarg.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
 #include <wctype.h>
 
 // clang-format off
@@ -18,14 +26,6 @@
 #ifdef WINDOWS
   #include <io.h>
 #else
-  #include <ctype.h>
-  #include <errno.h>
-  #include <memory.h>
-  #include <stddef.h>
-  #include <stdio.h>
-  #include <stdlib.h>
-  #include <string.h>
-  #include <time.h>
   #ifdef SET_UID
     #include <pwd.h>
     #include <sys/file.h>

--- a/src/wizard/wizard-spoiler.cpp
+++ b/src/wizard/wizard-spoiler.cpp
@@ -39,7 +39,10 @@
 #include "wizard/items-spoiler.h"
 #include "wizard/monster-info-spoiler.h"
 #include "wizard/spoiler-util.h"
+
+#include <algorithm>
 #include <array>
+#include <iterator>
 #include <set>
 #include <string>
 


### PR DESCRIPTION
h-system.h にある標準的なCのヘッダのインクルードはWINDOWSでもインクルードしておいてよいと思うので、WINDOWSでもインクルードされるようにします。
また、プリコンパイル済みヘッダの利用により、本来インクルードが必要なファイルがインクルードされていない状態になっているので、一旦プリコンパイル済みヘッダ無しでコンパイルを行い適宜ヘッダのインクルードを追加しました。