### PR TITLE
[Refactor] ASCII文字↔整数の変換マクロ群を関数化する

### DIFF
--- a/src/util/int-char-converter.h
+++ b/src/util/int-char-converter.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "system/angband.h"
+
 /*
  * Allow use of "ASCII" and "EBCDIC" for "indexes", "digits",
  * and "Control-Characters".
@@ -8,9 +10,31 @@
  * all "digits" must be "digits".  Control characters can be made
  * from any legal characters.
  */
-#define A2I(X) ((X) - 'a')
-#define I2A(X) ((char)(X) + 'a')
-#define D2I(X) ((X) - '0')
-#define I2D(X) ((X) + '0')
-#define KTRL(X) ((X)&0x1F)
-#define ESCAPE '\033'
+
+constexpr uint8_t A2I(int ch)
+{
+    return ch - 'a';
+}
+
+constexpr char I2A(int i)
+{
+    return static_cast<char>(i + 'a');
+}
+
+constexpr uint8_t D2I(int ch)
+{
+    return ch - '0';
+}
+
+constexpr char I2D(int i)
+{
+    return static_cast<char>(i + '0');
+}
+
+template <typename T>
+constexpr T KTRL(T ch)
+{
+    return static_cast<T>(ch & 0x1F);
+}
+
+constexpr char ESCAPE = '\033';


### PR DESCRIPTION
int-char-converter.h に定義されている、ASCII文字と整数の変換を行うマクロを
関数にする。
まずマクロは特別に理由がなければ使用を避けるべきであるという点と、I2A等は
マクロであるため値が int であり、例えば std::stringstream に << 演算子で
I2A(0) などをそのまま入れると "a" ではなく "97" になってしまうといった
問題が避けられる。