### PR TITLE
忍者以外でも変わり身で攻撃を回避する場合がある不具合を解消した

### DIFF
--- a/src/effect/effect-player.cpp
+++ b/src/effect/effect-player.cpp
@@ -123,8 +123,7 @@ static process_result check_continue_player_effect(player_type *player_ptr, effe
         return PROCESS_FALSE;
     }
 
-    auto is_kawarimi = any_bits(player_ptr->special_defense, NINJA_KAWARIMI);
-    is_kawarimi &= kawarimi(player_ptr, true);
+    auto is_kawarimi = kawarimi(player_ptr, true);
     auto is_effective = ep_ptr->dam > 0;
     is_effective &= randint0(55) < (player_ptr->lev * 3 / 5 + 20);
     is_effective &= ep_ptr->who > 0;
@@ -222,7 +221,7 @@ bool affect_player(MONSTER_IDX who, player_type *player_ptr, concptr who_name, i
     }
 
     disturb(player_ptr, true, true);
-    if ((player_ptr->special_defense & NINJA_KAWARIMI) && ep_ptr->dam && ep_ptr->who && (ep_ptr->who != player_ptr->riding)) {
+    if (ep_ptr->dam && ep_ptr->who && (ep_ptr->who != player_ptr->riding)) {
         (void)kawarimi(player_ptr, false);
     }
 

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -68,6 +68,10 @@
  */
 bool kawarimi(player_type *player_ptr, bool success)
 {
+    if (none_bits(player_ptr->special_defense, NINJA_KAWARIMI)) {
+        return false;
+    }
+
     object_type forge;
     object_type *q_ptr = &forge;
     if (player_ptr->is_dead) {

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -436,10 +436,10 @@ static bool process_monster_blows(player_type *player_ptr, monap_type *monap_ptr
 
             // 撃退失敗時は落馬処理、変わり身のテレポート処理を行う。
             check_fall_off_horse(player_ptr, monap_ptr);
-            if (player_ptr->special_defense & NINJA_KAWARIMI) {
-                // 変わり身のテレポートが成功したら攻撃を打ち切り、プレイヤーが離脱した旨を返す。
-                if (kawarimi(player_ptr, false))
-                    return true;
+
+            // 変わり身のテレポートが成功したら攻撃を打ち切り、プレイヤーが離脱した旨を返す。
+            if (kawarimi(player_ptr, false)) {
+                return true;
             }
         } else {
             // 命中しなかった。回避時の処理、思い出処理を行う。
@@ -498,9 +498,8 @@ bool make_attack_normal(player_type *player_ptr, MONSTER_IDX m_idx)
         }
     }
 
-    auto is_kawarimi = any_bits(player_ptr->special_defense, NINJA_KAWARIMI);
     auto can_activate_kawarimi = randint0(55) < (player_ptr->lev * 3 / 5 + 20);
-    if (is_kawarimi && can_activate_kawarimi && kawarimi(player_ptr, true)) {
+    if (can_activate_kawarimi && kawarimi(player_ptr, true)) {
         return true;
     }
 


### PR DESCRIPTION
掲題の通りです
そもそも変わり身状態か否かをkawarimi() の外側で判定することに意味がなかったので関数内に繰り込みました
ご確認下さい