### PR TITLE
[Refactor] スポイラー出力に使用するアイテムのカテゴリ分けテーブル

### DIFF
--- a/src/io-dump/random-art-info-dumper.cpp
+++ b/src/io-dump/random-art-info-dumper.cpp
@@ -50,12 +50,12 @@ static void spoiler_print_randart(object_type *o_ptr, obj_desc_list *art_ptr)
  * @brief ランダムアーティファクト内容をスポイラー出力するサブルーチン /
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param o_ptr ランダムアーティファクトのオブジェクト構造体参照ポインタ
- * @param i 出力したい記録ランダムアーティファクトID
+ * @param tval 出力したいランダムアーティファクトの種類
  */
-static void spoil_random_artifact_aux(player_type *player_ptr, object_type *o_ptr, int i)
+static void spoil_random_artifact_aux(player_type *player_ptr, object_type *o_ptr, tval_type tval)
 {
     obj_desc_list artifact;
-    if (!o_ptr->is_known() || !o_ptr->art_name || o_ptr->tval != group_artifact[i].tval)
+    if (!o_ptr->is_known() || !o_ptr->art_name || o_ptr->tval != tval)
         return;
 
     random_artifact_analyze(player_ptr, o_ptr, &artifact);
@@ -81,27 +81,29 @@ void spoil_random_artifact(player_type *player_ptr, concptr fname)
 
     sprintf(buf, "Random artifacts list.\r");
     spoiler_underline(buf);
-    for (int j = 0; group_artifact[j].tval; j++) {
-        for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-            q_ptr = &player_ptr->inventory_list[i];
-            spoil_random_artifact_aux(player_ptr, q_ptr, j);
-        }
+    for (const auto &[tval_list, name] : group_artifact_list) {
+        for (auto tval : tval_list) {
+            for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+                q_ptr = &player_ptr->inventory_list[i];
+                spoil_random_artifact_aux(player_ptr, q_ptr, tval);
+            }
 
-        for (int i = 0; i < INVEN_PACK; i++) {
-            q_ptr = &player_ptr->inventory_list[i];
-            spoil_random_artifact_aux(player_ptr, q_ptr, j);
-        }
+            for (int i = 0; i < INVEN_PACK; i++) {
+                q_ptr = &player_ptr->inventory_list[i];
+                spoil_random_artifact_aux(player_ptr, q_ptr, tval);
+            }
 
-        store_ptr = &town_info[1].store[STORE_HOME];
-        for (int i = 0; i < store_ptr->stock_num; i++) {
-            q_ptr = &store_ptr->stock[i];
-            spoil_random_artifact_aux(player_ptr, q_ptr, j);
-        }
+            store_ptr = &town_info[1].store[STORE_HOME];
+            for (int i = 0; i < store_ptr->stock_num; i++) {
+                q_ptr = &store_ptr->stock[i];
+                spoil_random_artifact_aux(player_ptr, q_ptr, tval);
+            }
 
-        store_ptr = &town_info[1].store[STORE_MUSEUM];
-        for (int i = 0; i < store_ptr->stock_num; i++) {
-            q_ptr = &store_ptr->stock[i];
-            spoil_random_artifact_aux(player_ptr, q_ptr, j);
+            store_ptr = &town_info[1].store[STORE_MUSEUM];
+            for (int i = 0; i < store_ptr->stock_num; i++) {
+                q_ptr = &store_ptr->stock[i];
+                spoil_random_artifact_aux(player_ptr, q_ptr, tval);
+            }
         }
     }
 

--- a/src/wizard/fixed-artifacts-spoiler.cpp
+++ b/src/wizard/fixed-artifacts-spoiler.cpp
@@ -143,10 +143,6 @@ static void spoiler_print_art(obj_desc_list *art_ptr)
  */
 spoiler_output_status spoil_fixed_artifact(concptr fname)
 {
-    player_type dummy;
-    object_type forge;
-    object_type *q_ptr;
-    obj_desc_list artifact;
     char buf[1024];
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, fname);
     spoiler_file = angband_fopen(buf, "w");
@@ -155,24 +151,26 @@ spoiler_output_status spoil_fixed_artifact(concptr fname)
     }
 
     print_header();
-    for (int i = 0; group_artifact[i].tval; i++) {
-        if (group_artifact[i].name) {
-            spoiler_blanklines(2);
-            spoiler_underline(group_artifact[i].name);
-            spoiler_blanklines(1);
-        }
+    for (const auto &[tval_list, name] : group_artifact_list) {
+        spoiler_blanklines(2);
+        spoiler_underline(name);
+        spoiler_blanklines(1);
 
-        for (const auto &a_ref : a_info) {
-            if (a_ref.idx == 0 || a_ref.tval != group_artifact[i].tval)
-                continue;
+        for (auto tval : tval_list) {
+            for (const auto &a_ref : a_info) {
+                if (a_ref.tval != tval)
+                    continue;
 
-            q_ptr = &forge;
-            q_ptr->wipe();
-            if (!make_fake_artifact(q_ptr, a_ref.idx))
-                continue;
+                object_type obj;
+                obj.wipe();
+                if (!make_fake_artifact(&obj, a_ref.idx))
+                    continue;
 
-            object_analyze(&dummy, q_ptr, &artifact);
-            spoiler_print_art(&artifact);
+                player_type dummy;
+                obj_desc_list artifact;
+                object_analyze(&dummy, &obj, &artifact);
+                spoiler_print_art(&artifact);
+            }
         }
     }
 

--- a/src/wizard/items-spoiler.cpp
+++ b/src/wizard/items-spoiler.cpp
@@ -13,6 +13,8 @@
 #include "view/display-messages.h"
 #include "wizard/spoiler-util.h"
 
+#include <algorithm>
+
 /*!
  * @brief ベースアイテムの各情報を文字列化する /
  * Describe the kind
@@ -88,7 +90,6 @@ static void kind_info(player_type *player_ptr, char *buf, char *dam, char *wgt, 
  */
 spoiler_output_status spoil_obj_desc(concptr fname)
 {
-    player_type dummy;
     char buf[1024];
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, fname);
     spoiler_file = angband_fopen(buf, "w");
@@ -101,59 +102,39 @@ spoiler_output_status spoil_obj_desc(concptr fname)
     fprintf(spoiler_file, "Spoiler File -- Basic Items (%s)\n\n\n", title);
     fprintf(spoiler_file, "%-37s%8s%7s%5s %40s%9s\n", "Description", "Dam/AC", "Wgt", "Lev", "Chance", "Cost");
     fprintf(spoiler_file, "%-37s%8s%7s%5s %40s%9s\n", "-------------------------------------", "------", "---", "---", "----------------", "----");
-    int n = 0;
-    int group_start = 0;
-    KIND_OBJECT_IDX who[200];
-    for (int i = 0; true; i++) {
-        if (group_item[i].name) {
-            if (n) {
-                for (int s = 0; s < n - 1; s++) {
-                    for (int t = 0; t < n - 1; t++) {
-                        int i1 = t;
-                        int i2 = t + 1;
 
-                        DEPTH e1;
-                        DEPTH e2;
-
-                        PRICE t1;
-                        PRICE t2;
-
-                        kind_info(&dummy, nullptr, nullptr, nullptr, nullptr, &e1, &t1, who[i1]);
-                        kind_info(&dummy, nullptr, nullptr, nullptr, nullptr, &e2, &t2, who[i2]);
-
-                        if ((t1 > t2) || ((t1 == t2) && (e1 > e2))) {
-                            uint16_t tmp = who[i1];
-                            who[i1] = who[i2];
-                            who[i2] = tmp;
-                        }
-                    }
+    for (const auto &[tval_list, name] : group_item_list) {
+        std::vector<KIND_OBJECT_IDX> whats;
+        for (auto tval : tval_list) {
+            for (const auto &k_ref : k_info) {
+                if ((k_ref.tval == tval) && k_ref.gen_flags.has_not(TRG::INSTA_ART)) {
+                    whats.push_back(k_ref.idx);
                 }
-
-                fprintf(spoiler_file, "\n\n%s\n\n", group_item[group_start].name);
-                for (int s = 0; s < n; s++) {
-                    DEPTH e;
-                    PRICE v;
-                    char wgt[80];
-                    char chance[80];
-                    char dam[80];
-                    kind_info(&dummy, buf, dam, wgt, chance, &e, &v, who[s]);
-                    fprintf(spoiler_file, "  %-35s%8s%7s%5d %-40s%9ld\n", buf, dam, wgt, (int)e, chance, (long)(v));
-                }
-
-                n = 0;
             }
-
-            if (!group_item[i].tval)
-                break;
-
-            group_start = i;
+        }
+        if (whats.empty()) {
+            continue;
         }
 
-        for (const auto &k_ref : k_info) {
-            if ((k_ref.idx == 0) || (k_ref.tval != group_item[i].tval) || k_ref.gen_flags.has(TRG::INSTA_ART))
-                continue;
+        std::stable_sort(whats.begin(), whats.end(), [](auto k1_idx, auto k2_idx) {
+            player_type dummy;
+            DEPTH d1, d2;
+            PRICE p1, p2;
+            kind_info(&dummy, nullptr, nullptr, nullptr, nullptr, &d1, &p1, k1_idx);
+            kind_info(&dummy, nullptr, nullptr, nullptr, nullptr, &d2, &p2, k2_idx);
+            return (p1 != p2) ? p1 < p2 : d1 < d2;
+        });
 
-            who[n++] = k_ref.idx;
+        fprintf(spoiler_file, "\n\n%s\n\n", name);
+        for (const auto &k_idx : whats) {
+            DEPTH e;
+            PRICE v;
+            char wgt[80];
+            char chance[80];
+            char dam[80];
+            player_type dummy;
+            kind_info(&dummy, buf, dam, wgt, chance, &e, &v, k_idx);
+            fprintf(spoiler_file, "  %-35s%8s%7s%5d %-40s%9ld\n", buf, dam, wgt, static_cast<int>(e), chance, static_cast<long>(v));
         }
     }
 

--- a/src/wizard/spoiler-table.cpp
+++ b/src/wizard/spoiler-table.cpp
@@ -1,58 +1,70 @@
 ﻿#include "wizard/spoiler-table.h"
 
 /* The basic items categorized by type */
-grouper group_item[MAX_GROUPER_ITEM] = { { TV_SHOT, _("射撃物", "Ammo") }, { TV_ARROW, nullptr }, { TV_BOLT, nullptr }, { TV_BOW, _("弓", "Bows") },
-    { TV_DIGGING, _("武器", "Weapons") }, { TV_POLEARM, nullptr }, { TV_HAFTED, nullptr }, { TV_SWORD, nullptr }, { TV_SOFT_ARMOR, _("防具 (体)", "Armour (Body)") },
-    { TV_HARD_ARMOR, nullptr }, { TV_DRAG_ARMOR, nullptr }, { TV_BOOTS, _("防具 (その他)", "Armour (Misc)") }, { TV_GLOVES, nullptr }, { TV_HELM, nullptr },
-    { TV_CROWN, nullptr }, { TV_SHIELD, nullptr }, { TV_CLOAK, nullptr },
+const std::vector<grouper> group_item_list = {
+    { { TV_SHOT, TV_ARROW, TV_BOLT }, _("射撃物", "Ammo") },
+    { { TV_BOW }, _("弓", "Bows") },
+    { { TV_DIGGING, TV_POLEARM, TV_HAFTED, TV_SWORD }, _("武器", "Weapons") },
+    { { TV_SOFT_ARMOR, TV_HARD_ARMOR, TV_DRAG_ARMOR }, _("防具 (体)", "Armour (Body)") },
+    { { TV_BOOTS, TV_GLOVES, TV_HELM, TV_CROWN, TV_SHIELD, TV_CLOAK }, _("防具 (その他)", "Armour (Misc)") },
 
-    { TV_LITE, _("光源", "Light Sources") }, { TV_AMULET, _("アミュレット", "Amulets") }, { TV_RING, _("指輪", "Rings") }, { TV_STAFF, _("杖", "Staffs") },
-    { TV_WAND, _("魔法棒", "Wands") }, { TV_ROD, _("ロッド", "Rods") }, { TV_SCROLL, _("巻物", "Scrolls") }, { TV_POTION, _("薬", "Potions") },
-    { TV_FOOD, _("食料", "Food") },
+    { { TV_LITE }, _("光源", "Light Sources") },
+    { { TV_AMULET }, _("アミュレット", "Amulets") },
+    { { TV_RING }, _("指輪", "Rings") },
+    { { TV_STAFF }, _("杖", "Staffs") },
+    { { TV_WAND }, _("魔法棒", "Wands") },
+    { { TV_ROD }, _("ロッド", "Rods") },
+    { { TV_SCROLL }, _("巻物", "Scrolls") },
+    { { TV_POTION }, _("薬", "Potions") },
+    { { TV_FOOD }, _("食料", "Food") },
 
-    { TV_LIFE_BOOK, _("魔法書 (生命)", "Books (Life)") }, { TV_SORCERY_BOOK, _("魔法書 (仙術)", "Books (Sorcery)") },
-    { TV_NATURE_BOOK, _("魔法書 (自然)", "Books (Nature)") }, { TV_CHAOS_BOOK, _("魔法書 (カオス)", "Books (Chaos)") },
-    { TV_DEATH_BOOK, _("魔法書 (暗黒)", "Books (Death)") }, { TV_TRUMP_BOOK, _("魔法書 (トランプ)", "Books (Trump)") },
-    { TV_ARCANE_BOOK, _("魔法書 (秘術)", "Books (Arcane)") }, { TV_CRAFT_BOOK, _("魔法書 (匠)", "Books (Craft)") },
-    { TV_DEMON_BOOK, _("魔法書 (悪魔)", "Books (Daemon)") }, { TV_CRUSADE_BOOK, _("魔法書 (破邪)", "Books (Crusade)") },
-    { TV_MUSIC_BOOK, _("歌集", "Song Books") }, { TV_HISSATSU_BOOK, _("武芸の書", "Books (Kendo)") }, { TV_HEX_BOOK, _("魔法書 (呪術)", "Books (Hex)") },
+    { { TV_LIFE_BOOK }, _("魔法書 (生命)", "Books (Life)") },
+    { { TV_SORCERY_BOOK }, _("魔法書 (仙術)", "Books (Sorcery)") },
+    { { TV_NATURE_BOOK }, _("魔法書 (自然)", "Books (Nature)") },
+    { { TV_CHAOS_BOOK }, _("魔法書 (カオス)", "Books (Chaos)") },
+    { { TV_DEATH_BOOK }, _("魔法書 (暗黒)", "Books (Death)") },
+    { { TV_TRUMP_BOOK }, _("魔法書 (トランプ)", "Books (Trump)") },
+    { { TV_ARCANE_BOOK }, _("魔法書 (秘術)", "Books (Arcane)") },
+    { { TV_CRAFT_BOOK }, _("魔法書 (匠)", "Books (Craft)") },
+    { { TV_DEMON_BOOK }, _("魔法書 (悪魔)", "Books (Daemon)") },
+    { { TV_CRUSADE_BOOK }, _("魔法書 (破邪)", "Books (Crusade)") },
+    { { TV_MUSIC_BOOK }, _("歌集", "Song Books") },
+    { { TV_HISSATSU_BOOK }, _("武芸の書", "Books (Kendo)") },
+    { { TV_HEX_BOOK }, _("魔法書 (呪術)", "Books (Hex)") },
 
-    { TV_WHISTLE, _("笛", "Whistle") }, { TV_CAPTURE, _("キャプチャー・ボール", "Capture Ball") }, { TV_CARD, _("エクスプレスカード", "Express Card") },
+    { { TV_WHISTLE }, _("笛", "Whistle") },
+    { { TV_CAPTURE }, _("キャプチャー・ボール", "Capture Ball") },
+    { { TV_CARD }, _("エクスプレスカード", "Express Card") },
 
-    { TV_CHEST, _("箱", "Chests") },
+    { { TV_CHEST }, _("箱", "Chests") },
 
-    { TV_FIGURINE, _("人形", "Magical Figurines") }, { TV_STATUE, _("像", "Statues") }, { TV_CORPSE, _("死体", "Corpses") },
+    { { TV_FIGURINE }, _("人形", "Magical Figurines") },
+    { { TV_STATUE }, _("像", "Statues") },
+    { { TV_CORPSE }, _("死体", "Corpses") },
 
-    { TV_SKELETON, _("その他", "Misc") }, { TV_BOTTLE, nullptr }, { TV_JUNK, nullptr }, { TV_SPIKE, nullptr }, { TV_FLASK, nullptr }, { TV_PARCHMENT, nullptr },
-
-    { TV_NONE, "" } };
+    { { TV_SKELETON, TV_BOTTLE, TV_JUNK, TV_SPIKE, TV_FLASK, TV_PARCHMENT }, _("その他", "Misc") },
+};
 
 /* The artifacts categorized by type */
-grouper group_artifact[MAX_GROUPER_ARTIFACT] = {
-    { TV_SWORD, _("刀剣", "Edged Weapons") },
-    { TV_POLEARM, _("槍/斧", "Polearms") },
-    { TV_HAFTED, _("鈍器", "Hafted Weapons") },
-    { TV_DIGGING, _("シャベル/つるはし", "Shovels/Picks") },
-    { TV_BOW, _("飛び道具", "Bows") },
-    { TV_ARROW, _("矢", "Ammo") },
-    { TV_BOLT, nullptr },
+const std::vector<grouper> group_artifact_list = {
+    { { TV_SWORD }, _("刀剣", "Edged Weapons") },
+    { { TV_POLEARM }, _("槍/斧", "Polearms") },
+    { { TV_HAFTED }, _("鈍器", "Hafted Weapons") },
+    { { TV_DIGGING }, _("シャベル/つるはし", "Shovels/Picks") },
+    { { TV_BOW }, _("飛び道具", "Bows") },
+    { { TV_ARROW, TV_BOLT }, _("矢", "Ammo") },
 
-    { TV_SOFT_ARMOR, _("鎧", "Body Armor") },
-    { TV_HARD_ARMOR, nullptr },
-    { TV_DRAG_ARMOR, nullptr },
+    { { TV_SOFT_ARMOR, TV_HARD_ARMOR, TV_DRAG_ARMOR }, _("鎧", "Body Armor") },
 
-    { TV_CLOAK, _("クローク", "Cloaks") },
-    { TV_SHIELD, _("盾", "Shields") },
-    { TV_CARD, nullptr },
-    { TV_HELM, _("兜/冠", "Helms/Crowns") },
-    { TV_CROWN, nullptr },
-    { TV_GLOVES, _("籠手", "Gloves") },
-    { TV_BOOTS, _("靴", "Boots") },
+    { { TV_CLOAK }, _("クローク", "Cloaks") },
+    { { TV_SHIELD, TV_CARD }, _("盾", "Shields") },
+    { { TV_HELM, TV_CROWN }, _("兜/冠", "Helms/Crowns") },
+    { { TV_GLOVES }, _("籠手", "Gloves") },
+    { { TV_BOOTS }, _("靴", "Boots") },
 
-    { TV_LITE, _("光源", "Light Sources") },
-    { TV_AMULET, _("アミュレット", "Amulets") },
-    { TV_RING, _("指輪", "Rings") },
-    { TV_NONE, nullptr },
+    { { TV_LITE }, _("光源", "Light Sources") },
+    { { TV_AMULET }, _("アミュレット", "Amulets") },
+    { { TV_RING }, _("指輪", "Rings") },
 };
 
 flag_desc stat_flags_desc[MAX_STAT_FLAGS_DESCRIPTION] = { { TR_STR, _("腕力", "STR") }, { TR_INT, _("知能", "INT") }, { TR_WIS, _("賢さ", "WIS") },

--- a/src/wizard/spoiler-table.h
+++ b/src/wizard/spoiler-table.h
@@ -4,8 +4,8 @@
 #include "object/tval-types.h"
 #include "system/angband.h"
 
-#define MAX_GROUPER_ITEM 53
-#define MAX_GROUPER_ARTIFACT 21
+#include <vector>
+
 #define MAX_STAT_FLAGS_DESCRIPTION 6
 #define MAX_PVAL_FLAGS_DESCRIPTION 7
 #define MAX_SLAY_FLAGS_DESCRIPTION 20
@@ -17,10 +17,10 @@
 #define MAX_MISC3_FLAGS_DESCRIPTION 33
 
 /* A tval grouper */
-typedef struct grouper {
-    tval_type tval;
+struct grouper {
+    std::vector<tval_type> tval_set;
     concptr name;
-} grouper;
+};
 
 /*
  * Pair together a constant flag with a textual description.
@@ -33,8 +33,8 @@ typedef struct flag_desc {
     concptr desc;
 } flag_desc;
 
-extern grouper group_item[MAX_GROUPER_ITEM];
-extern grouper group_artifact[MAX_GROUPER_ARTIFACT];
+extern const std::vector<grouper> group_item_list;
+extern const std::vector<grouper> group_artifact_list;
 extern flag_desc stat_flags_desc[MAX_STAT_FLAGS_DESCRIPTION];
 extern flag_desc pval_flags1_desc[MAX_PVAL_FLAGS_DESCRIPTION];
 extern flag_desc slay_flags_desc[MAX_SLAY_FLAGS_DESCRIPTION];


### PR DESCRIPTION
アイテムおよびアーティファクトのスポイラーファイル出力に使用するカテゴリ
分け用のテーブルが直感的でないので、テーブルの定義と関連するコードをカテ
ゴリ分けとして直感的になるようにリファクタリングする。

修正前と後で、artifact.txt および object-desc.txt のdiffを取って全く同一である事を確認済みです。