### PR TITLE
[Feature] デバッグコマンドの固定アーティファクト生成をリストで選択する

### DIFF
--- a/src/wizard/cmd-wizard.cpp
+++ b/src/wizard/cmd-wizard.cpp
@@ -140,7 +140,7 @@ bool exe_cmd_debug(player_type *player_ptr, char cmd)
         wiz_create_item(player_ptr);
         break;
     case 'C':
-        wiz_create_named_art(player_ptr, command_arg);
+        wiz_create_named_art(player_ptr);
         break;
     case 'd':
         detect_all(player_ptr, DETECT_RAD_ALL * 3);

--- a/src/wizard/wizard-special-process.h
+++ b/src/wizard/wizard-special-process.h
@@ -5,7 +5,7 @@
 struct player_type;
 void wiz_cure_all(player_type *player_ptr);
 void wiz_create_item(player_type *player_ptr);
-void wiz_create_named_art(player_type *player_ptr, ARTIFACT_IDX a_idx);
+void wiz_create_named_art(player_type *player_ptr);
 void wiz_change_status(player_type *player_ptr);
 void wiz_create_feature(player_type *player_ptr);
 void wiz_jump_to_dungeon(player_type *player_ptr);


### PR DESCRIPTION
いちいち a_info.txt を見て固定アーティファクトのIDを調べるのがいいかげん
面倒くさくなった。
装備のカテゴリのリスト→アーティファクトのリストで選択できるようにする。

IDを入力する方式のものはこれがあれば要らないと思うので `^A C` を置き換えています。