### PR TITLE
[Refactor] 剣術家の型を職業固有データに移動する

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -1007,6 +1007,7 @@
     <ClInclude Include="..\..\src\player-info\force-trainer-data-type.h" />
     <ClInclude Include="..\..\src\player-info\magic-eater-data-type.h" />
     <ClInclude Include="..\..\src\player-info\mane-data-type.h" />
+    <ClInclude Include="..\..\src\player-info\samurai-data-type.h" />
     <ClInclude Include="..\..\src\player-info\smith-data-type.h" />
     <ClInclude Include="..\..\src\player-info\sniper-data-type.h" />
     <ClInclude Include="..\..\src\player-info\spell-hex-data-type.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -5100,6 +5100,9 @@
     <ClInclude Include="..\..\src\object-use\zapwand-execution.h">
       <Filter>object-use</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\player-info\samurai-data-type.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\src\wall.bmp" />

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -681,6 +681,7 @@ hengband_SOURCES = \
 	player-info/race-info.cpp player-info/race-info.h \
 	player-info/race-types.h \
 	player-info/resistance-info.cpp player-info/resistance-info.h \
+	player-info/samurai-data-type.h \
 	player-info/self-info.cpp player-info/self-info.h \
 	player-info/self-info-util.cpp player-info/self-info-util.h \
         player-info/smith-data-type.h \

--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -33,7 +33,9 @@
 #include "mutation/mutation-flag-types.h"
 #include "object/item-use-flags.h"
 #include "player-attack/player-attack.h"
+#include "player-base/player-class.h"
 #include "player-info/equipment-info.h"
+#include "player-info/samurai-data-type.h"
 #include "player-status/player-energy.h"
 #include "player-status/player-hand-types.h"
 #include "player/attack-defense-types.h"
@@ -309,7 +311,7 @@ bool do_cmd_attack(player_type *player_ptr, POSITION y, POSITION x, combat_optio
         msg_format(_("%^sは恐怖して逃げ出した！", "%^s flees in terror!"), m_name);
     }
 
-    if ((player_ptr->special_defense & KATA_IAI) && ((mode != HISSATSU_IAI) || mdeath)) {
+    if ((PlayerClass(player_ptr).get_kata() == SamuraiKata::IAI) && ((mode != HISSATSU_IAI) || mdeath)) {
         set_action(player_ptr, ACTION_NONE);
     }
 

--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -311,7 +311,7 @@ bool do_cmd_attack(player_type *player_ptr, POSITION y, POSITION x, combat_optio
         msg_format(_("%^sは恐怖して逃げ出した！", "%^s flees in terror!"), m_name);
     }
 
-    if ((PlayerClass(player_ptr).get_kata() == SamuraiKata::IAI) && ((mode != HISSATSU_IAI) || mdeath)) {
+    if (PlayerClass(player_ptr).kata_is(SamuraiKata::IAI) && ((mode != HISSATSU_IAI) || mdeath)) {
         set_action(player_ptr, ACTION_NONE);
     }
 

--- a/src/cmd-action/cmd-hissatsu.cpp
+++ b/src/cmd-action/cmd-hissatsu.cpp
@@ -27,7 +27,9 @@
 #include "monster-race/monster-race-hook.h"
 #include "object/item-tester-hooker.h"
 #include "object/item-use-flags.h"
+#include "player-base/player-class.h"
 #include "player-info/equipment-info.h"
+#include "player-info/samurai-data-type.h"
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
 #include "player/special-defense-types.h"
@@ -324,9 +326,7 @@ void do_cmd_hissatsu(player_type *player_ptr)
         return;
     }
 
-    if (player_ptr->special_defense & KATA_MASK) {
-        set_action(player_ptr, ACTION_NONE);
-    }
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU, SamuraiKata::IAI, SamuraiKata::FUUJIN, SamuraiKata::KOUKIJIN });
 
     if (!get_hissatsu_power(player_ptr, &n))
         return;
@@ -373,9 +373,7 @@ void do_cmd_gain_hissatsu(player_type *player_ptr)
 
     bool gain = false;
 
-    if (player_ptr->special_defense & (KATA_MUSOU | KATA_KOUKIJIN)) {
-        set_action(player_ptr, ACTION_NONE);
-    }
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU, SamuraiKata::KOUKIJIN });
 
     if (cmd_limit_blind(player_ptr))
         return;

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -26,6 +26,8 @@
 #include "mind/mind-ninja.h"
 #include "main/sound-definitions-table.h"
 #include "main/sound-of-music.h"
+#include "player-base/player-class.h"
+#include "player-info/samurai-data-type.h"
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
 #include "player/player-move.h"
@@ -72,8 +74,7 @@ void do_cmd_go_up(player_type *player_ptr)
     grid_type *g_ptr = &player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x];
     feature_type *f_ptr = &f_info[g_ptr->feat];
     int up_num = 0;
-    if (player_ptr->special_defense & KATA_MUSOU)
-        set_action(player_ptr, ACTION_NONE);
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
 
     if (f_ptr->flags.has_not(FF::LESS)) {
         msg_print(_("ここには上り階段が見当たらない。", "I see no up staircase here."));
@@ -179,8 +180,7 @@ void do_cmd_go_down(player_type *player_ptr)
 {
     bool fall_trap = false;
     int down_num = 0;
-    if (player_ptr->special_defense & KATA_MUSOU)
-        set_action(player_ptr, ACTION_NONE);
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
 
     grid_type *g_ptr = &player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x];
     feature_type *f_ptr = &f_info[g_ptr->feat];
@@ -321,8 +321,9 @@ void do_cmd_walk(player_type *player_ptr, bool pickup)
     if (get_rep_dir(player_ptr, &dir, false)) {
         PlayerEnergy energy(player_ptr);
         energy.set_player_turn_energy(100);
-        if ((dir != 5) && (player_ptr->special_defense & KATA_MUSOU))
-            set_action(player_ptr, ACTION_NONE);
+        if (dir != 5) {
+            PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
+        }
 
         if (player_ptr->wild_mode) {
             energy.mul_player_turn_energy((MAX_HGT + MAX_WID) / 2);
@@ -366,8 +367,7 @@ void do_cmd_run(player_type *player_ptr)
     if (cmd_limit_confused(player_ptr))
         return;
 
-    if (player_ptr->special_defense & KATA_MUSOU)
-        set_action(player_ptr, ACTION_NONE);
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
 
     if (get_rep_dir(player_ptr, &dir, false)) {
         player_ptr->running = (command_arg ? command_arg : 1000);

--- a/src/cmd-action/cmd-open-close.cpp
+++ b/src/cmd-action/cmd-open-close.cpp
@@ -12,6 +12,8 @@
 #include "inventory/inventory-object.h"
 #include "inventory/inventory-slot-types.h"
 #include "io/input-key-requester.h"
+#include "player-base/player-class.h"
+#include "player-info/samurai-data-type.h"
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
 #include "player/special-defense-types.h"
@@ -93,8 +95,7 @@ void do_cmd_open(player_type *player_ptr)
     if (player_ptr->wild_mode)
         return;
 
-    if (player_ptr->special_defense & KATA_MUSOU)
-        set_action(player_ptr, ACTION_NONE);
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
 
     if (easy_open) {
         int num_doors = count_dt(player_ptr, &y, &x, is_closed_door, false);
@@ -151,8 +152,7 @@ void do_cmd_close(player_type *player_ptr)
     if (player_ptr->wild_mode)
         return;
 
-    if (player_ptr->special_defense & KATA_MUSOU)
-        set_action(player_ptr, ACTION_NONE);
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
 
     if (easy_open && (count_dt(player_ptr, &y, &x, is_open, false) == 1))
         command_dir = coords_to_dir(player_ptr, y, x);
@@ -198,8 +198,7 @@ void do_cmd_disarm(player_type *player_ptr)
     if (player_ptr->wild_mode)
         return;
 
-    if (player_ptr->special_defense & KATA_MUSOU)
-        set_action(player_ptr, ACTION_NONE);
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
 
     if (easy_disarm) {
         int num_traps = count_dt(player_ptr, &y, &x, is_trap, true);
@@ -267,8 +266,7 @@ void do_cmd_bash(player_type *player_ptr)
     if (player_ptr->wild_mode)
         return;
 
-    if (player_ptr->special_defense & KATA_MUSOU)
-        set_action(player_ptr, ACTION_NONE);
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
 
     if (command_arg) {
         command_rep = command_arg - 1;
@@ -339,8 +337,7 @@ void do_cmd_spike(player_type *player_ptr)
     if (player_ptr->wild_mode)
         return;
 
-    if (player_ptr->special_defense & KATA_MUSOU)
-        set_action(player_ptr, ACTION_NONE);
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
 
     if (!get_rep_dir(player_ptr, &dir, false))
         return;

--- a/src/cmd-action/cmd-others.cpp
+++ b/src/cmd-action/cmd-others.cpp
@@ -25,6 +25,8 @@
 #include "io/write-diary.h"
 #include "main/music-definitions-table.h"
 #include "main/sound-of-music.h"
+#include "player-base/player-class.h"
+#include "player-info/samurai-data-type.h"
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
 #include "player/player-move.h"
@@ -101,8 +103,7 @@ static bool exe_alter(player_type *player_ptr)
  */
 void do_cmd_alter(player_type *player_ptr)
 {
-    if (player_ptr->special_defense & KATA_MUSOU)
-        set_action(player_ptr, ACTION_NONE);
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
 
     if (command_arg) {
         command_rep = command_arg - 1;

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -36,8 +36,10 @@
 #include "monster/smart-learn-types.h"
 #include "object-hook/hook-weapon.h"
 #include "pet/pet-util.h"
+#include "player-base/player-class.h"
 #include "player-info/class-info.h"
 #include "player-info/equipment-info.h"
+#include "player-info/samurai-data-type.h"
 #include "player-status/player-energy.h"
 #include "player-status/player-hand-types.h"
 #include "player/attack-defense-types.h"
@@ -203,8 +205,7 @@ bool do_cmd_riding(player_type *player_ptr, bool force)
     x = player_ptr->x + ddx[dir];
     g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
 
-    if (player_ptr->special_defense & KATA_MUSOU)
-        set_action(player_ptr, ACTION_NONE);
+   PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
 
     if (player_ptr->riding) {
         /* Skip non-empty grids */

--- a/src/cmd-action/cmd-racial.cpp
+++ b/src/cmd-action/cmd-racial.cpp
@@ -14,6 +14,8 @@
 #include "io/input-key-requester.h"
 #include "main/sound-of-music.h"
 #include "mutation/mutation-flag-types.h"
+#include "player-base/player-class.h"
+#include "player-info/samurai-data-type.h"
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
 #include "player/player-damage.h"
@@ -435,8 +437,7 @@ void do_cmd_racial_power(player_type *player_ptr)
         return;
     }
 
-    if (player_ptr->special_defense & (KATA_MUSOU | KATA_KOUKIJIN))
-        set_action(player_ptr, ACTION_NONE);
+   PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU, SamuraiKata::KOUKIJIN });
 
     auto tmp_r = rc_type(player_ptr);
     auto *rc_ptr = &tmp_r;

--- a/src/cmd-action/cmd-shoot.cpp
+++ b/src/cmd-action/cmd-shoot.cpp
@@ -6,6 +6,7 @@
 #include "object/item-tester-hooker.h"
 #include "object/item-use-flags.h"
 #include "player-base/player-class.h"
+#include "player-info/samurai-data-type.h"
 #include "player-info/sniper-data-type.h"
 #include "player/attack-defense-types.h"
 #include "player/special-defense-types.h"
@@ -50,8 +51,7 @@ void do_cmd_fire(player_type *player_ptr, SPELL_IDX snipe_type)
         return;
     }
 
-    if (player_ptr->special_defense & KATA_MUSOU)
-        set_action(player_ptr, ACTION_NONE);
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
 
     concptr q = _("どれを撃ちますか? ", "Fire which item? ");
     concptr s = _("発射されるアイテムがありません。", "You have nothing to fire.");

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -32,7 +32,9 @@
 #include "object/item-tester-hooker.h"
 #include "object/item-use-flags.h"
 #include "object/object-info.h"
+#include "player-base/player-class.h"
 #include "player-info/class-info.h"
+#include "player-info/samurai-data-type.h"
 #include "player-info/self-info.h"
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
@@ -624,9 +626,7 @@ void do_cmd_browse(player_type *player_ptr)
         return;
     }
 
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        set_action(player_ptr, ACTION_NONE);
-    }
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
 
     if (player_ptr->pclass == CLASS_FORCETRAINER) {
         if (player_has_no_spellbooks(player_ptr)) {
@@ -783,9 +783,7 @@ void do_cmd_study(player_type *player_ptr)
         return;
     }
 
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        set_action(player_ptr, ACTION_NONE);
-    }
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
 
 #ifdef JP
     if (player_ptr->new_spells < 10) {

--- a/src/cmd-action/cmd-tunnel.cpp
+++ b/src/cmd-action/cmd-tunnel.cpp
@@ -7,6 +7,8 @@
 #include "grid/feature.h"
 #include "grid/grid.h"
 #include "io/input-key-requester.h"
+#include "player-base/player-class.h"
+#include "player-info/samurai-data-type.h"
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
 #include "player/special-defense-types.h"
@@ -33,8 +35,7 @@
 void do_cmd_tunnel(player_type *player_ptr)
 {
     bool more = false;
-    if (player_ptr->special_defense & KATA_MUSOU)
-        set_action(player_ptr, ACTION_NONE);
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
 
     if (command_arg) {
         command_rep = command_arg - 1;

--- a/src/cmd-item/cmd-destroy.cpp
+++ b/src/cmd-item/cmd-destroy.cpp
@@ -20,6 +20,8 @@
 #include "object/item-use-flags.h"
 #include "object/object-stack.h"
 #include "object/object-value.h"
+#include "player-base/player-class.h"
+#include "player-info/samurai-data-type.h"
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
 #include "player/special-defense-types.h"
@@ -194,8 +196,7 @@ static void exe_destroy_item(player_type *player_ptr, destroy_type *destroy_ptr)
  */
 void do_cmd_destroy(player_type *player_ptr)
 {
-    if (player_ptr->special_defense & KATA_MUSOU)
-        set_action(player_ptr, ACTION_NONE);
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
 
     object_type forge;
     destroy_type tmp_destroy;

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -24,9 +24,11 @@
 #include "object/object-kind-hook.h"
 #include "object/object-kind.h"
 #include "perception/object-perception.h"
+#include "player-base/player-class.h"
 #include "player-base/player-race.h"
 #include "player-info/class-info.h"
 #include "player-info/mimic-info-table.h"
+#include "player-info/samurai-data-type.h"
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
 #include "player/digestion-processor.h"
@@ -335,9 +337,7 @@ void do_cmd_eat_food(player_type *player_ptr)
     OBJECT_IDX item;
     concptr q, s;
 
-    if (player_ptr->special_defense & (KATA_MUSOU | KATA_KOUKIJIN)) {
-        set_action(player_ptr, ACTION_NONE);
-    }
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU, SamuraiKata::KOUKIJIN });
 
     q = _("どれを食べますか? ", "Eat which item? ");
     s = _("食べ物がない。", "You have nothing to eat.");

--- a/src/cmd-item/cmd-equipment.cpp
+++ b/src/cmd-item/cmd-equipment.cpp
@@ -30,6 +30,8 @@
 #include "object/object-info.h"
 #include "object/object-mark-types.h"
 #include "perception/object-perception.h"
+#include "player-base/player-class.h"
+#include "player-info/samurai-data-type.h"
 #include "player-info/equipment-info.h"
 #include "player-status/player-energy.h"
 #include "player-status/player-hand-types.h"
@@ -96,8 +98,7 @@ void do_cmd_wield(player_type *player_ptr)
     concptr act;
     GAME_TEXT o_name[MAX_NLEN];
     OBJECT_IDX need_switch_wielding = 0;
-    if (player_ptr->special_defense & KATA_MUSOU)
-        set_action(player_ptr, ACTION_NONE);
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
 
     concptr q = _("どれを装備しますか? ", "Wear/Wield which item? ");
     concptr s = _("装備可能なアイテムがない。", "You have nothing you can wear or wield.");
@@ -303,8 +304,7 @@ void do_cmd_takeoff(player_type *player_ptr)
 {
     OBJECT_IDX item;
     object_type *o_ptr;
-    if (player_ptr->special_defense & KATA_MUSOU)
-        set_action(player_ptr, ACTION_NONE);
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
 
     concptr q = _("どれを装備からはずしますか? ", "Take off which item? ");
     concptr s = _("はずせる装備がない。", "You are not wearing anything to take off.");

--- a/src/cmd-item/cmd-item.cpp
+++ b/src/cmd-item/cmd-item.cpp
@@ -45,8 +45,10 @@
 #include "object/item-use-flags.h"
 #include "perception/identification.h"
 #include "perception/object-perception.h"
+#include "player-base/player-class.h"
 #include "player-info/class-info.h"
 #include "player-info/race-types.h"
+#include "player-info/samurai-data-type.h"
 #include "player-info/self-info.h"
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
@@ -109,8 +111,7 @@ void do_cmd_drop(player_type *player_ptr)
     OBJECT_IDX item;
     int amt = 1;
     object_type *o_ptr;
-    if (player_ptr->special_defense & KATA_MUSOU)
-        set_action(player_ptr, ACTION_NONE);
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
 
     concptr q = _("どのアイテムを落としますか? ", "Drop which item? ");
     concptr s = _("落とせるアイテムを持っていない。", "You have nothing to drop.");
@@ -234,8 +235,7 @@ void do_cmd_use(player_type *player_ptr)
     if (player_ptr->wild_mode || cmd_limit_arena(player_ptr))
         return;
 
-    if (player_ptr->special_defense & (KATA_MUSOU | KATA_KOUKIJIN))
-        set_action(player_ptr, ACTION_NONE);
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU, SamuraiKata::KOUKIJIN });
 
     concptr q = _("どれを使いますか？", "Use which item? ");
     concptr s = _("使えるものがありません。", "You have nothing to use.");
@@ -290,8 +290,7 @@ void do_cmd_activate(player_type *player_ptr)
     if (player_ptr->wild_mode || cmd_limit_arena(player_ptr))
         return;
 
-    if (player_ptr->special_defense & (KATA_MUSOU | KATA_KOUKIJIN))
-        set_action(player_ptr, ACTION_NONE);
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU, SamuraiKata::KOUKIJIN });
 
     concptr q = _("どのアイテムを始動させますか? ", "Activate which item? ");
     concptr s = _("始動できるアイテムを装備していない。", "You have nothing to activate.");

--- a/src/cmd-item/cmd-quaff.cpp
+++ b/src/cmd-item/cmd-quaff.cpp
@@ -11,6 +11,8 @@
 #include "object-use/quaff-execution.h"
 #include "object/item-tester-hooker.h"
 #include "object/item-use-flags.h"
+#include "player-base/player-class.h"
+#include "player-info/samurai-data-type.h"
 #include "player/attack-defense-types.h"
 #include "player/special-defense-types.h"
 #include "realm/realm-hex-numbers.h"
@@ -30,8 +32,7 @@ void do_cmd_quaff_potion(player_type *player_ptr)
     if (!SpellHex(player_ptr).is_spelling_specific(HEX_INHALE) && cmd_limit_arena(player_ptr))
         return;
 
-    if (player_ptr->special_defense & (KATA_MUSOU | KATA_KOUKIJIN))
-        set_action(player_ptr, ACTION_NONE);
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU, SamuraiKata::KOUKIJIN });
 
     concptr q = _("どの薬を飲みますか? ", "Quaff which potion? ");
     concptr s = _("飲める薬がない。", "You have no potions to quaff.");

--- a/src/cmd-item/cmd-read.cpp
+++ b/src/cmd-item/cmd-read.cpp
@@ -13,6 +13,8 @@
 #include "object/item-tester-hooker.h"
 #include "object/item-use-flags.h"
 #include "perception/object-perception.h"
+#include "player-base/player-class.h"
+#include "player-info/samurai-data-type.h"
 #include "player/attack-defense-types.h"
 #include "player/special-defense-types.h"
 #include "status/action-setter.h"
@@ -28,8 +30,7 @@ void do_cmd_read_scroll(player_type *player_ptr)
     if (player_ptr->wild_mode || cmd_limit_arena(player_ptr))
         return;
 
-    if (player_ptr->special_defense & (KATA_MUSOU | KATA_KOUKIJIN))
-        set_action(player_ptr, ACTION_NONE);
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU, SamuraiKata::KOUKIJIN });
 
     if (cmd_limit_blind(player_ptr) || cmd_limit_confused(player_ptr))
         return;

--- a/src/cmd-item/cmd-refill.cpp
+++ b/src/cmd-item/cmd-refill.cpp
@@ -8,6 +8,8 @@
 #include "object-hook/hook-expendable.h"
 #include "object/item-tester-hooker.h"
 #include "object/item-use-flags.h"
+#include "player-base/player-class.h"
+#include "player-info/samurai-data-type.h"
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
 #include "player/special-defense-types.h"
@@ -103,8 +105,8 @@ void do_cmd_refill(player_type *player_ptr)
 {
     object_type *o_ptr;
     o_ptr = &player_ptr->inventory_list[INVEN_LITE];
-    if (player_ptr->special_defense & KATA_MUSOU)
-        set_action(player_ptr, ACTION_NONE);
+
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
 
     if (o_ptr->tval != TV_LITE)
         msg_print(_("光源を装備していない。", "You are not wielding a light."));

--- a/src/cmd-item/cmd-throw.cpp
+++ b/src/cmd-item/cmd-throw.cpp
@@ -9,6 +9,8 @@
 #include "game-option/special-options.h"
 #include "inventory/inventory-slot-types.h"
 #include "object/object-broken.h"
+#include "player-base/player-class.h"
+#include "player-info/samurai-data-type.h"
 #include "player/attack-defense-types.h"
 #include "player/special-defense-types.h"
 #include "specific-object/torch.h"
@@ -44,9 +46,7 @@ bool ThrowCommand::do_cmd_throw(int mult, bool boomerang, OBJECT_IDX shuriken)
         return false;
     }
 
-    if (this->player_ptr->special_defense & KATA_MUSOU) {
-        set_action(this->player_ptr, ACTION_NONE);
-    }
+    PlayerClass(this->player_ptr).break_kata({ SamuraiKata::MUSOU });
 
     object_type tmp_object;
     ObjectThrowEntity ote(this->player_ptr, &tmp_object, delay_factor, mult, boomerang, shuriken);

--- a/src/cmd-item/cmd-usestaff.cpp
+++ b/src/cmd-item/cmd-usestaff.cpp
@@ -6,10 +6,12 @@
 #include "object-use/use-execution.h"
 #include "object/item-tester-hooker.h"
 #include "object/item-use-flags.h"
+#include "player-base/player-class.h"
 #include "player-base/player-race.h"
 #include "player-info/class-info.h"
 #include "player-info/race-info.h"
 #include "player-info/race-types.h"
+#include "player-info/samurai-data-type.h"
 #include "player/attack-defense-types.h"
 #include "player/player-status-flags.h"
 #include "player/special-defense-types.h"
@@ -293,9 +295,7 @@ void do_cmd_use_staff(player_type *player_ptr)
     if (cmd_limit_arena(player_ptr))
         return;
 
-    if (player_ptr->special_defense & (KATA_MUSOU | KATA_KOUKIJIN)) {
-        set_action(player_ptr, ACTION_NONE);
-    }
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU, SamuraiKata::KOUKIJIN });
 
     q = _("どの杖を使いますか? ", "Use which staff? ");
     s = _("使える杖がない。", "You have no staff to use.");

--- a/src/cmd-item/cmd-zaprod.cpp
+++ b/src/cmd-item/cmd-zaprod.cpp
@@ -5,7 +5,9 @@
 #include "object-use/zaprod-execution.h"
 #include "object/item-tester-hooker.h"
 #include "object/item-use-flags.h"
+#include "player-base/player-class.h"
 #include "player-info/class-info.h"
+#include "player-info/samurai-data-type.h"
 #include "player/attack-defense-types.h"
 #include "player/special-defense-types.h"
 #include "spell-kind/spells-beam.h"
@@ -271,9 +273,7 @@ void do_cmd_zap_rod(player_type *player_ptr)
         return;
     }
 
-    if (player_ptr->special_defense & (KATA_MUSOU | KATA_KOUKIJIN)) {
-        set_action(player_ptr, ACTION_NONE);
-    }
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU, SamuraiKata::KOUKIJIN });
 
     auto q = _("どのロッドを振りますか? ", "Zap which rod? ");
     auto s = _("使えるロッドがない。", "You have no rod to zap.");

--- a/src/cmd-item/cmd-zapwand.cpp
+++ b/src/cmd-item/cmd-zapwand.cpp
@@ -16,7 +16,9 @@
 #include "object/object-info.h"
 #include "object/object-kind.h"
 #include "perception/object-perception.h"
+#include "player-base/player-class.h"
 #include "player-info/class-info.h"
+#include "player-info/samurai-data-type.h"
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
 #include "player/special-defense-types.h"
@@ -325,9 +327,7 @@ void do_cmd_aim_wand(player_type *player_ptr)
         return;
     if (cmd_limit_arena(player_ptr))
         return;
-    if (player_ptr->special_defense & (KATA_MUSOU | KATA_KOUKIJIN)) {
-        set_action(player_ptr, ACTION_NONE);
-    }
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU, SamuraiKata::KOUKIJIN });
 
     q = _("どの魔法棒で狙いますか? ", "Aim which wand? ");
     s = _("使える魔法棒がない。", "You have no wand to aim.");

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -248,7 +248,7 @@ void process_player(player_type *player_ptr)
         player_ptr->redraw |= PR_MANA;
     }
 
-    if (PlayerClass(player_ptr).get_kata() == SamuraiKata::MUSOU) {
+    if (PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU)) {
         if (player_ptr->csp < 3) {
             set_action(player_ptr, ACTION_NONE);
         } else {

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -40,6 +40,7 @@
 #include "player-base/player-class.h"
 #include "player-info/bluemage-data-type.h"
 #include "player-info/mane-data-type.h"
+#include "player-info/samurai-data-type.h"
 #include "player-info/sniper-data-type.h"
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
@@ -247,14 +248,12 @@ void process_player(player_type *player_ptr)
         player_ptr->redraw |= PR_MANA;
     }
 
-    if (player_ptr->special_defense & KATA_MASK) {
-        if (player_ptr->special_defense & KATA_MUSOU) {
-            if (player_ptr->csp < 3) {
-                set_action(player_ptr, ACTION_NONE);
-            } else {
-                player_ptr->csp -= 2;
-                player_ptr->redraw |= (PR_MANA);
-            }
+    if (PlayerClass(player_ptr).get_kata() == SamuraiKata::MUSOU) {
+        if (player_ptr->csp < 3) {
+            set_action(player_ptr, ACTION_NONE);
+        } else {
+            player_ptr->csp -= 2;
+            player_ptr->redraw |= (PR_MANA);
         }
     }
 

--- a/src/effect/effect-player.cpp
+++ b/src/effect/effect-player.cpp
@@ -79,7 +79,7 @@ static bool process_bolt_reflection(player_type *player_ptr, effect_player_type 
     std::string mes;
     if (player_ptr->blind) {
         mes = _("何かが跳ね返った！", "Something bounces!");
-    } else if (PlayerClass(player_ptr).get_kata() == SamuraiKata::FUUJIN) {
+    } else if (PlayerClass(player_ptr).kata_is(SamuraiKata::FUUJIN)) {
         mes = _("風の如く武器を振るって弾き返した！", "The attack bounces!");
     } else {
         mes = _("攻撃が跳ね返った！", "The attack bounces!");

--- a/src/effect/effect-player.cpp
+++ b/src/effect/effect-player.cpp
@@ -18,6 +18,8 @@
 #include "monster-race/monster-race.h"
 #include "monster/monster-describer.h"
 #include "monster/monster-description-types.h"
+#include "player-base/player-class.h"
+#include "player-info/samurai-data-type.h"
 #include "player/player-status-flags.h"
 #include "player/special-defense-types.h"
 #include "realm/realm-hex-numbers.h"
@@ -64,7 +66,7 @@ static effect_player_type *initialize_effect_player(effect_player_type *ep_ptr, 
  */
 static bool process_bolt_reflection(player_type *player_ptr, effect_player_type *ep_ptr, project_func project)
 {
-    auto can_reflect = (has_reflect(player_ptr) != 0) || (any_bits(player_ptr->special_defense, KATA_FUUJIN) && !player_ptr->blind);
+    auto can_reflect = (has_reflect(player_ptr) != 0);
     can_reflect &= any_bits(ep_ptr->flag, PROJECT_REFLECTABLE);
     can_reflect &= !one_in_(10);
     if (!can_reflect) {
@@ -77,7 +79,7 @@ static bool process_bolt_reflection(player_type *player_ptr, effect_player_type 
     std::string mes;
     if (player_ptr->blind) {
         mes = _("何かが跳ね返った！", "Something bounces!");
-    } else if (any_bits(player_ptr->special_defense, KATA_FUUJIN)) {
+    } else if (PlayerClass(player_ptr).get_kata() == SamuraiKata::FUUJIN) {
         mes = _("風の如く武器を振るって弾き返した！", "The attack bounces!");
     } else {
         mes = _("攻撃が跳ね返った！", "The attack bounces!");

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -285,7 +285,7 @@ void process_player_hp_mp(player_type *player_ptr)
         if (player_ptr->regenerate) {
             regen_amount = regen_amount * 2;
         }
-        if ((player_ptr->special_defense & (KAMAE_MASK)) || PlayerClass(player_ptr).get_kata() != SamuraiKata::NONE) {
+        if ((player_ptr->special_defense & (KAMAE_MASK)) || !PlayerClass(player_ptr).kata_is(SamuraiKata::NONE)) {
             regen_amount /= 2;
         }
         if (player_ptr->cursed.has(TRC::SLOW_REGEN)) {
@@ -298,7 +298,7 @@ void process_player_hp_mp(player_type *player_ptr)
     }
 
     upkeep_factor = calculate_upkeep(player_ptr);
-    if ((player_ptr->action == ACTION_LEARN) || (player_ptr->action == ACTION_HAYAGAKE) || (PlayerClass(player_ptr).get_kata() == SamuraiKata::KOUKIJIN)) {
+    if ((player_ptr->action == ACTION_LEARN) || (player_ptr->action == ACTION_HAYAGAKE) || PlayerClass(player_ptr).kata_is(SamuraiKata::KOUKIJIN)) {
         upkeep_factor += 100;
     }
 

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -21,9 +21,11 @@
 #include "object-enchant/trc-types.h"
 #include "object/object-flags.h"
 #include "pet/pet-util.h"
+#include "player-base/player-class.h"
 #include "player-base/player-race.h"
 #include "player-info/race-info.h"
 #include "player-info/race-types.h"
+#include "player-info/samurai-data-type.h"
 #include "player/attack-defense-types.h"
 #include "player/digestion-processor.h"
 #include "player/player-damage.h"
@@ -283,7 +285,7 @@ void process_player_hp_mp(player_type *player_ptr)
         if (player_ptr->regenerate) {
             regen_amount = regen_amount * 2;
         }
-        if (player_ptr->special_defense & (KAMAE_MASK | KATA_MASK)) {
+        if ((player_ptr->special_defense & (KAMAE_MASK)) || PlayerClass(player_ptr).get_kata() != SamuraiKata::NONE) {
             regen_amount /= 2;
         }
         if (player_ptr->cursed.has(TRC::SLOW_REGEN)) {
@@ -296,7 +298,7 @@ void process_player_hp_mp(player_type *player_ptr)
     }
 
     upkeep_factor = calculate_upkeep(player_ptr);
-    if ((player_ptr->action == ACTION_LEARN) || (player_ptr->action == ACTION_HAYAGAKE) || (player_ptr->special_defense & KATA_KOUKIJIN)) {
+    if ((player_ptr->action == ACTION_LEARN) || (player_ptr->action == ACTION_HAYAGAKE) || (PlayerClass(player_ptr).get_kata() == SamuraiKata::KOUKIJIN)) {
         upkeep_factor += 100;
     }
 

--- a/src/hpmp/hp-mp-regenerator.cpp
+++ b/src/hpmp/hp-mp-regenerator.cpp
@@ -28,7 +28,7 @@ int wild_regen = 20;
  */
 void regenhp(player_type *player_ptr, int percent)
 {
-    if (PlayerClass(player_ptr).get_kata() == SamuraiKata::KOUKIJIN)
+    if (PlayerClass(player_ptr).kata_is(SamuraiKata::KOUKIJIN))
         return;
     if (player_ptr->action == ACTION_HAYAGAKE)
         return;

--- a/src/hpmp/hp-mp-regenerator.cpp
+++ b/src/hpmp/hp-mp-regenerator.cpp
@@ -9,6 +9,7 @@
 #include "monster/monster-status.h"
 #include "player-base/player-class.h"
 #include "player-info/magic-eater-data-type.h"
+#include "player-info/samurai-data-type.h"
 #include "player/attack-defense-types.h"
 #include "player/player-status-table.h"
 #include "player/special-defense-types.h"
@@ -27,7 +28,7 @@ int wild_regen = 20;
  */
 void regenhp(player_type *player_ptr, int percent)
 {
-    if (player_ptr->special_defense & KATA_KOUKIJIN)
+    if (PlayerClass(player_ptr).get_kata() == SamuraiKata::KOUKIJIN)
         return;
     if (player_ptr->action == ACTION_HAYAGAKE)
         return;

--- a/src/io/input-key-processor.cpp
+++ b/src/io/input-key-processor.cpp
@@ -76,6 +76,7 @@
 #include "mind/snipe-types.h"
 #include "player-base/player-class.h"
 #include "player-info/class-info.h"
+#include "player-info/samurai-data-type.h"
 #include "player-info/sniper-data-type.h"
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
@@ -613,9 +614,7 @@ void process_command(player_type *player_ptr)
     case '`': {
         if (!player_ptr->wild_mode)
             do_cmd_travel(player_ptr);
-        if (player_ptr->special_defense & KATA_MUSOU) {
-            set_action(player_ptr, ACTION_NONE);
-        }
+        PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
 
         break;
     }

--- a/src/load/player-attack-loader.cpp
+++ b/src/load/player-attack-loader.cpp
@@ -26,7 +26,7 @@ void rd_special_action(player_type *player_ptr)
         return;
     }
 
-    if (PlayerClass(player_ptr).get_kata() != SamuraiKata::NONE) {
+    if (!PlayerClass(player_ptr).kata_is(SamuraiKata::NONE)) {
         player_ptr->action = ACTION_KATA;
     }
 }

--- a/src/load/player-attack-loader.cpp
+++ b/src/load/player-attack-loader.cpp
@@ -2,6 +2,8 @@
 #include "load/angband-version-comparer.h"
 #include "load/load-util.h"
 #include "load/load-zangband.h"
+#include "player-base/player-class.h"
+#include "player-info/samurai-data-type.h"
 #include "player/attack-defense-types.h"
 #include "player/special-defense-types.h"
 #include "system/player-type-definition.h"
@@ -24,8 +26,9 @@ void rd_special_action(player_type *player_ptr)
         return;
     }
 
-    if (player_ptr->special_attack & KATA_MASK)
+    if (PlayerClass(player_ptr).get_kata() != SamuraiKata::NONE) {
         player_ptr->action = ACTION_KATA;
+    }
 }
 
 void rd_special_defense(player_type *player_ptr)

--- a/src/load/player-class-specific-data-loader.cpp
+++ b/src/load/player-class-specific-data-loader.cpp
@@ -5,6 +5,7 @@
 #include "player-info/force-trainer-data-type.h"
 #include "player-info/magic-eater-data-type.h"
 #include "player-info/mane-data-type.h"
+#include "player-info/samurai-data-type.h"
 #include "player-info/smith-data-type.h"
 #include "player-info/sniper-data-type.h"
 #include "player-info/spell-hex-data-type.h"
@@ -168,6 +169,21 @@ void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<sniper_data_type>
         load_old_savfile_magic_num();
     } else {
         rd_s16b(&sniper_data->concent);
+    }
+}
+
+void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<samurai_data_type> &samurai_data) const
+{
+    if (loading_savefile_version_is_older_than(9)) {
+        // 古いセーブファイルの剣術家のデータは magic_num には保存されていないので読み捨てる
+        load_old_savfile_magic_num();
+    } else {
+        byte tmp8u;
+        rd_byte(&tmp8u);
+        samurai_data->kata = i2enum<SamuraiKata>(tmp8u);
+        if (samurai_data->kata != SamuraiKata::NONE) {
+            
+        }
     }
 }
 

--- a/src/load/player-class-specific-data-loader.h
+++ b/src/load/player-class-specific-data-loader.h
@@ -11,6 +11,7 @@ struct magic_eater_data_type;
 struct bard_data_type;
 struct mane_data_type;
 struct sniper_data_type;
+struct samurai_data_type;
 struct spell_hex_data_type;
 
 class PlayerClassSpecificDataLoader {
@@ -24,4 +25,5 @@ public:
     void operator()(std::shared_ptr<bard_data_type> &bird_data) const;
     void operator()(std::shared_ptr<mane_data_type> &mane_data) const;
     void operator()(std::shared_ptr<sniper_data_type> &sniper_data) const;
+    void operator()(std::shared_ptr<samurai_data_type> &samurai_data) const;
 };

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -315,7 +315,7 @@ void concentration(player_type *player_ptr)
         return;
     }
 
-    if (PlayerClass(player_ptr).get_kata() != SamuraiKata::NONE) {
+    if (!PlayerClass(player_ptr).kata_is(SamuraiKata::NONE)) {
         msg_print(_("今は構えに集中している。", "You're already concentrating on your stance."));
         return;
     }
@@ -396,7 +396,7 @@ bool choose_kata(player_type *player_ptr)
     }
 
     set_action(player_ptr, ACTION_KATA);
-    if (PlayerClass(player_ptr).get_kata() == new_kata) {
+    if (PlayerClass(player_ptr).kata_is(new_kata)) {
         msg_print(_("構え直した。", "You reassume a stance."));
     } else {
         player_ptr->update |= (PU_BONUS | PU_MONSTERS);
@@ -423,7 +423,7 @@ int calc_attack_quality(player_type *player_ptr, player_attack_type *pa_ptr)
     if (pa_ptr->mode == HISSATSU_IAI)
         chance += 60;
 
-    if (PlayerClass(player_ptr).get_kata() == SamuraiKata::KOUKIJIN) {
+    if (PlayerClass(player_ptr).kata_is(SamuraiKata::KOUKIJIN)) {
         chance += 150;
     }
 
@@ -473,7 +473,7 @@ void mineuchi(player_type *player_ptr, player_attack_type *pa_ptr)
  */
 void musou_counterattack(player_type *player_ptr, monap_type *monap_ptr)
 {
-    if ((!player_ptr->counter && (PlayerClass(player_ptr).get_kata() != SamuraiKata::MUSOU)) || !monap_ptr->alive || player_ptr->is_dead || !monap_ptr->m_ptr->ml
+    if ((!player_ptr->counter && !PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU)) || !monap_ptr->alive || player_ptr->is_dead || !monap_ptr->m_ptr->ml
         || (player_ptr->csp <= 7))
         return;
 

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -25,6 +25,8 @@
 #include "object-enchant/tr-types.h"
 #include "pet/pet-util.h"
 #include "player-attack/player-attack-util.h"
+#include "player-base/player-class.h"
+#include "player-info/samurai-data-type.h"
 #include "player/attack-defense-types.h"
 #include "status/action-setter.h"
 #include "system/grid-type-definition.h"
@@ -313,7 +315,7 @@ void concentration(player_type *player_ptr)
         return;
     }
 
-    if (player_ptr->special_defense & KATA_MASK) {
+    if (PlayerClass(player_ptr).get_kata() != SamuraiKata::NONE) {
         msg_print(_("今は構えに集中している。", "You're already concentrating on your stance."));
         return;
     }
@@ -336,8 +338,6 @@ void concentration(player_type *player_ptr)
 bool choose_kata(player_type *player_ptr)
 {
     char choice;
-    int new_kata = 0;
-    int i;
     char buf[80];
 
     if (cmd_limit_confused(player_ptr))
@@ -356,7 +356,7 @@ bool choose_kata(player_type *player_ptr)
 
     screen_save();
     prt(_(" a) 型を崩す", " a) No Form"), 2, 20);
-    for (i = 0; i < MAX_KATA; i++) {
+    for (auto i = 0U; i < samurai_stances.size(); i++) {
         if (player_ptr->lev >= samurai_stances[i].min_level) {
             sprintf(buf, _(" %c) %sの型    %s", " %c) Stance of %-12s  %s"), I2A(i + 1), samurai_stances[i].desc, samurai_stances[i].info);
             prt(buf, 3 + i, 20);
@@ -366,6 +366,7 @@ bool choose_kata(player_type *player_ptr)
     prt("", 1, 0);
     prt(_("        どの型で構えますか？", "        Choose Stance: "), 1, 14);
 
+    SamuraiKata new_kata = SamuraiKata::NONE;
     while (true) {
         choice = inkey();
 
@@ -380,28 +381,27 @@ bool choose_kata(player_type *player_ptr)
             screen_load();
             return true;
         } else if ((choice == 'b') || (choice == 'B')) {
-            new_kata = 0;
+            new_kata = SamuraiKata::IAI;
             break;
         } else if (((choice == 'c') || (choice == 'C')) && (player_ptr->lev > 29)) {
-            new_kata = 1;
+            new_kata = SamuraiKata::FUUJIN;
             break;
         } else if (((choice == 'd') || (choice == 'D')) && (player_ptr->lev > 34)) {
-            new_kata = 2;
+            new_kata = SamuraiKata::KOUKIJIN;
             break;
         } else if (((choice == 'e') || (choice == 'E')) && (player_ptr->lev > 39)) {
-            new_kata = 3;
+            new_kata = SamuraiKata::MUSOU;
             break;
         }
     }
 
     set_action(player_ptr, ACTION_KATA);
-    if (player_ptr->special_defense & (KATA_IAI << new_kata)) {
+    if (PlayerClass(player_ptr).get_kata() == new_kata) {
         msg_print(_("構え直した。", "You reassume a stance."));
     } else {
-        player_ptr->special_defense &= ~(KATA_MASK);
         player_ptr->update |= (PU_BONUS | PU_MONSTERS);
-        msg_format(_("%sの型で構えた。", "You assume the %s stance."), samurai_stances[new_kata].desc);
-        player_ptr->special_defense |= (KATA_IAI << new_kata);
+        msg_format(_("%sの型で構えた。", "You assume the %s stance."), samurai_stances[enum2i(new_kata) - 1].desc);
+        PlayerClass(player_ptr).set_kata(new_kata);
     }
 
     player_ptr->redraw |= (PR_STATE | PR_STATUS);
@@ -423,8 +423,9 @@ int calc_attack_quality(player_type *player_ptr, player_attack_type *pa_ptr)
     if (pa_ptr->mode == HISSATSU_IAI)
         chance += 60;
 
-    if (player_ptr->special_defense & KATA_KOUKIJIN)
+    if (PlayerClass(player_ptr).get_kata() == SamuraiKata::KOUKIJIN) {
         chance += 150;
+    }
 
     if (player_ptr->sutemi)
         chance = MAX(chance * 3 / 2, chance + 60);
@@ -472,7 +473,7 @@ void mineuchi(player_type *player_ptr, player_attack_type *pa_ptr)
  */
 void musou_counterattack(player_type *player_ptr, monap_type *monap_ptr)
 {
-    if ((!player_ptr->counter && ((player_ptr->special_defense & KATA_MUSOU) == 0)) || !monap_ptr->alive || player_ptr->is_dead || !monap_ptr->m_ptr->ml
+    if ((!player_ptr->counter && (PlayerClass(player_ptr).get_kata() != SamuraiKata::MUSOU)) || !monap_ptr->alive || player_ptr->is_dead || !monap_ptr->m_ptr->ml
         || (player_ptr->csp <= 7))
         return;
 

--- a/src/mind/stances-table.cpp
+++ b/src/mind/stances-table.cpp
@@ -13,7 +13,7 @@ const blow_stance monk_stances[MAX_KAMAE] = {
 /*!
  * @brief 剣術家の構え能力テーブル
  */
-const blow_stance samurai_stances[MAX_KATA] = {
+const std::vector<blow_stance> samurai_stances = {
     { _("居合", "Iai"), 25, "" },
     { _("風塵", "Huujin"), 30, "" },
     { _("降鬼", "Kouki"), 35, "" },

--- a/src/mind/stances-table.h
+++ b/src/mind/stances-table.h
@@ -3,6 +3,8 @@
 #include "player/special-defense-types.h"
 #include "system/angband.h"
 
+#include <vector>
+
 typedef struct blow_stance {
     concptr desc; /* A verbose stance description */
     PLAYER_LEVEL min_level; /* Minimum level to use */
@@ -10,4 +12,4 @@ typedef struct blow_stance {
 } blow_stance;
 
 extern const blow_stance monk_stances[MAX_KAMAE];
-extern const blow_stance samurai_stances[MAX_KATA];
+extern const std::vector<blow_stance> samurai_stances;

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -38,6 +38,8 @@
 #include "object-hook/hook-armor.h"
 #include "object/item-tester-hooker.h"
 #include "pet/pet-fall-off.h"
+#include "player-base/player-class.h"
+#include "player-info/samurai-data-type.h"
 #include "player/attack-defense-types.h"
 #include "player/player-damage.h"
 #include "player/player-skill.h"
@@ -469,9 +471,7 @@ static void postprocess_monster_blows(player_type *player_ptr, monap_type *monap
         msg_format(_("%^sは恐怖で逃げ出した！", "%^s flees in terror!"), monap_ptr->m_name);
     }
 
-    if (player_ptr->special_defense & KATA_IAI) {
-        set_action(player_ptr, ACTION_NONE);
-    }
+    PlayerClass(player_ptr).break_kata({ SamuraiKata::IAI });
 }
 
 /*!
@@ -491,7 +491,7 @@ bool make_attack_normal(player_type *player_ptr, MONSTER_IDX m_idx)
     monap_ptr->rlev = ((r_ptr->level >= 1) ? r_ptr->level : 1);
     monster_desc(player_ptr, monap_ptr->m_name, monap_ptr->m_ptr, 0);
     monster_desc(player_ptr, monap_ptr->ddesc, monap_ptr->m_ptr, MD_WRONGDOER_NAME);
-    if (any_bits(player_ptr->special_defense, KATA_IAI)) {
+    if (PlayerClass(player_ptr).get_kata() == SamuraiKata::IAI) {
         msg_format(_("相手が襲いかかる前に素早く武器を振るった。", "You took sen, drew and cut in one motion before %s moved."), monap_ptr->m_name);
         if (do_cmd_attack(player_ptr, monap_ptr->m_ptr->fy, monap_ptr->m_ptr->fx, HISSATSU_IAI)) {
             return true;

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -491,7 +491,7 @@ bool make_attack_normal(player_type *player_ptr, MONSTER_IDX m_idx)
     monap_ptr->rlev = ((r_ptr->level >= 1) ? r_ptr->level : 1);
     monster_desc(player_ptr, monap_ptr->m_name, monap_ptr->m_ptr, 0);
     monster_desc(player_ptr, monap_ptr->ddesc, monap_ptr->m_ptr, MD_WRONGDOER_NAME);
-    if (PlayerClass(player_ptr).get_kata() == SamuraiKata::IAI) {
+    if (PlayerClass(player_ptr).kata_is(SamuraiKata::IAI)) {
         msg_format(_("相手が襲いかかる前に素早く武器を振るった。", "You took sen, drew and cut in one motion before %s moved."), monap_ptr->m_name);
         if (do_cmd_attack(player_ptr, monap_ptr->m_ptr->fy, monap_ptr->m_ptr->fx, HISSATSU_IAI)) {
             return true;

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -233,7 +233,7 @@ static bool update_weird_telepathy(player_type *player_ptr, um_type *um_ptr, MON
 static void update_telepathy_sight(player_type *player_ptr, um_type *um_ptr, MONSTER_IDX m_idx)
 {
     monster_race *r_ptr = &r_info[um_ptr->m_ptr->r_idx];
-    if (PlayerClass(player_ptr).get_kata() == SamuraiKata::MUSOU) {
+    if (PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU)) {
         um_ptr->flag = true;
         um_ptr->m_ptr->mflag.set(MFLAG::ESP);
         if (is_original_ap(um_ptr->m_ptr) && !player_ptr->hallucinated)

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -29,6 +29,7 @@
 #include "monster/monster-status.h"
 #include "monster/smart-learn-types.h"
 #include "player-base/player-class.h"
+#include "player-info/samurai-data-type.h"
 #include "player-info/sniper-data-type.h"
 #include "player/player-move.h"
 #include "player/player-status-flags.h"
@@ -232,7 +233,7 @@ static bool update_weird_telepathy(player_type *player_ptr, um_type *um_ptr, MON
 static void update_telepathy_sight(player_type *player_ptr, um_type *um_ptr, MONSTER_IDX m_idx)
 {
     monster_race *r_ptr = &r_info[um_ptr->m_ptr->r_idx];
-    if (player_ptr->special_defense & KATA_MUSOU) {
+    if (PlayerClass(player_ptr).get_kata() == SamuraiKata::MUSOU) {
         um_ptr->flag = true;
         um_ptr->m_ptr->mflag.set(MFLAG::ESP);
         if (is_original_ap(um_ptr->m_ptr) && !player_ptr->hallucinated)

--- a/src/player-ability/player-charisma.cpp
+++ b/src/player-ability/player-charisma.cpp
@@ -33,7 +33,7 @@ int16_t PlayerCharisma::battleform_value()
 {
     int16_t result = 0;
 
-    if (PlayerClass(player_ptr).get_kata() == SamuraiKata::KOUKIJIN) {
+    if (PlayerClass(player_ptr).kata_is(SamuraiKata::KOUKIJIN)) {
         result += 5;
     }
 

--- a/src/player-ability/player-charisma.cpp
+++ b/src/player-ability/player-charisma.cpp
@@ -1,8 +1,10 @@
 ﻿#include "player-ability/player-charisma.h"
 #include "mutation/mutation-flag-types.h"
 #include "object/object-flags.h"
+#include "player-base/player-class.h"
 #include "player-info/class-info.h"
 #include "player-info/mimic-info-table.h"
+#include "player-info/samurai-data-type.h"
 #include "player/player-personality.h"
 #include "player/race-info-table.h"
 #include "player/special-defense-types.h"
@@ -31,7 +33,7 @@ int16_t PlayerCharisma::battleform_value()
 {
     int16_t result = 0;
 
-    if (any_bits(this->player_ptr->special_defense, KATA_KOUKIJIN)) {
+    if (PlayerClass(player_ptr).get_kata() == SamuraiKata::KOUKIJIN) {
         result += 5;
     }
 

--- a/src/player-ability/player-constitution.cpp
+++ b/src/player-ability/player-constitution.cpp
@@ -80,7 +80,7 @@ int16_t PlayerConstitution::battleform_value()
 {
     int16_t result = 0;
 
-    if (PlayerClass(player_ptr).get_kata() == SamuraiKata::KOUKIJIN) {
+    if (PlayerClass(player_ptr).kata_is(SamuraiKata::KOUKIJIN)) {
         result += 5;
     }
 

--- a/src/player-ability/player-constitution.cpp
+++ b/src/player-ability/player-constitution.cpp
@@ -1,8 +1,10 @@
 ﻿#include "player-ability/player-constitution.h"
 #include "mutation/mutation-flag-types.h"
 #include "object/object-flags.h"
+#include "player-base/player-class.h"
 #include "player-base/player-race.h"
 #include "player-info/class-info.h"
+#include "player-info/samurai-data-type.h"
 #include "player/player-personality.h"
 #include "player/race-info-table.h"
 #include "player/special-defense-types.h"
@@ -78,7 +80,7 @@ int16_t PlayerConstitution::battleform_value()
 {
     int16_t result = 0;
 
-    if (any_bits(this->player_ptr->special_defense, KATA_KOUKIJIN)) {
+    if (PlayerClass(player_ptr).get_kata() == SamuraiKata::KOUKIJIN) {
         result += 5;
     }
 

--- a/src/player-ability/player-dexterity.cpp
+++ b/src/player-ability/player-dexterity.cpp
@@ -1,8 +1,10 @@
 ﻿#include "player-ability/player-dexterity.h"
 #include "mutation/mutation-flag-types.h"
 #include "object/object-flags.h"
+#include "player-base/player-class.h"
 #include "player-base/player-race.h"
 #include "player-info/class-info.h"
+#include "player-info/samurai-data-type.h"
 #include "player/player-personality.h"
 #include "player/race-info-table.h"
 #include "player/special-defense-types.h"
@@ -77,7 +79,7 @@ int16_t PlayerDexterity::battleform_value()
 {
     int16_t result = 0;
 
-    if (any_bits(this->player_ptr->special_defense, KATA_KOUKIJIN)) {
+    if (PlayerClass(player_ptr).get_kata() == SamuraiKata::KOUKIJIN) {
         result += 5;
     }
 

--- a/src/player-ability/player-dexterity.cpp
+++ b/src/player-ability/player-dexterity.cpp
@@ -79,7 +79,7 @@ int16_t PlayerDexterity::battleform_value()
 {
     int16_t result = 0;
 
-    if (PlayerClass(player_ptr).get_kata() == SamuraiKata::KOUKIJIN) {
+    if (PlayerClass(player_ptr).kata_is(SamuraiKata::KOUKIJIN)) {
         result += 5;
     }
 

--- a/src/player-ability/player-intelligence.cpp
+++ b/src/player-ability/player-intelligence.cpp
@@ -35,7 +35,7 @@ int16_t PlayerIntelligence::battleform_value()
 {
     int16_t result = 0;
 
-    if (PlayerClass(player_ptr).get_kata() == SamuraiKata::KOUKIJIN) {
+    if (PlayerClass(player_ptr).kata_is(SamuraiKata::KOUKIJIN)) {
         result += 5;
     }
 

--- a/src/player-ability/player-intelligence.cpp
+++ b/src/player-ability/player-intelligence.cpp
@@ -1,8 +1,10 @@
 ﻿#include "player-ability/player-intelligence.h"
 #include "mutation/mutation-flag-types.h"
 #include "object/object-flags.h"
+#include "player-base/player-class.h"
 #include "player-info/class-info.h"
 #include "player-info/mimic-info-table.h"
+#include "player-info/samurai-data-type.h"
 #include "player/player-personality.h"
 #include "player/race-info-table.h"
 #include "player/special-defense-types.h"
@@ -33,7 +35,7 @@ int16_t PlayerIntelligence::battleform_value()
 {
     int16_t result = 0;
 
-    if (any_bits(this->player_ptr->special_defense, KATA_KOUKIJIN)) {
+    if (PlayerClass(player_ptr).get_kata() == SamuraiKata::KOUKIJIN) {
         result += 5;
     }
 

--- a/src/player-ability/player-strength.cpp
+++ b/src/player-ability/player-strength.cpp
@@ -1,12 +1,14 @@
 ﻿#include "player-ability/player-strength.h"
 #include "mutation/mutation-flag-types.h"
 #include "object/object-flags.h"
+#include "player-base/player-class.h"
 #include "player-base/player-race.h"
-#include "realm/realm-types.h"
+#include "player-info/samurai-data-type.h"
 #include "player/player-personality.h"
 #include "player/race-info-table.h"
 #include "player/special-defense-types.h"
 #include "realm/realm-hex-numbers.h"
+#include "realm/realm-types.h"
 #include "spell-realm/spells-hex.h"
 #include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
@@ -86,7 +88,7 @@ int16_t PlayerStrength::battleform_value()
 {
     int16_t result = 0;
 
-    if (any_bits(this->player_ptr->special_defense, KATA_KOUKIJIN)) {
+    if (PlayerClass(player_ptr).get_kata() == SamuraiKata::KOUKIJIN) {
         result += 5;
     }
 

--- a/src/player-ability/player-strength.cpp
+++ b/src/player-ability/player-strength.cpp
@@ -88,7 +88,7 @@ int16_t PlayerStrength::battleform_value()
 {
     int16_t result = 0;
 
-    if (PlayerClass(player_ptr).get_kata() == SamuraiKata::KOUKIJIN) {
+    if (PlayerClass(player_ptr).kata_is(SamuraiKata::KOUKIJIN)) {
         result += 5;
     }
 

--- a/src/player-ability/player-wisdom.cpp
+++ b/src/player-ability/player-wisdom.cpp
@@ -33,7 +33,7 @@ int16_t PlayerWisdom::battleform_value()
 {
     int16_t result = 0;
 
-    if (PlayerClass(player_ptr).get_kata() == SamuraiKata::KOUKIJIN) {
+    if (PlayerClass(player_ptr).kata_is(SamuraiKata::KOUKIJIN)) {
         result += 5;
     }
 

--- a/src/player-ability/player-wisdom.cpp
+++ b/src/player-ability/player-wisdom.cpp
@@ -1,8 +1,10 @@
 ﻿#include "player-ability/player-wisdom.h"
 #include "mutation/mutation-flag-types.h"
 #include "object/object-flags.h"
+#include "player-base/player-class.h"
 #include "player-info/class-info.h"
 #include "player-info/mimic-info-table.h"
+#include "player-info/samurai-data-type.h"
 #include "player/player-personality.h"
 #include "player/race-info-table.h"
 #include "player/special-defense-types.h"
@@ -31,7 +33,7 @@ int16_t PlayerWisdom::battleform_value()
 {
     int16_t result = 0;
 
-    if (any_bits(this->player_ptr->special_defense, KATA_KOUKIJIN)) {
+    if (PlayerClass(player_ptr).get_kata() == SamuraiKata::KOUKIJIN) {
         result += 5;
     }
 

--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -225,7 +225,7 @@ bool PlayerClass::lose_balance()
         return false;
     }
 
-    if (this->get_kata() == SamuraiKata::NONE) {
+    if (this->kata_is(SamuraiKata::NONE)) {
         return false;
     }
 
@@ -246,6 +246,11 @@ SamuraiKata PlayerClass::get_kata() const
     }
 
     return samurai_data->kata;
+}
+
+bool PlayerClass::kata_is(SamuraiKata kata) const
+{
+    return this->get_kata() == kata;
 }
 
 /**

--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -2,7 +2,6 @@
  * @brief プレイヤーの職業クラスに基づく耐性・能力の判定処理等を行うクラス
  * @date 2021/09/08
  * @author Hourier
- * @details 本クラス作成時点で責務に対する余裕はかなりあるので、適宜ここへ移してくること.
  */
 #include "player-base/player-class.h"
 #include "core/player-redraw-types.h"
@@ -15,6 +14,7 @@
 #include "player-info/force-trainer-data-type.h"
 #include "player-info/magic-eater-data-type.h"
 #include "player-info/mane-data-type.h"
+#include "player-info/samurai-data-type.h"
 #include "player-info/smith-data-type.h"
 #include "player-info/sniper-data-type.h"
 #include "player-info/spell-hex-data-type.h"
@@ -22,6 +22,7 @@
 #include "player/player-status-flags.h"
 #include "player/special-defense-types.h"
 #include "realm/realm-types.h"
+#include "status/action-setter.h"
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
@@ -81,8 +82,7 @@ TrFlags PlayerClass::tr_flags() const
         if (heavy_armor(this->player_ptr)) {
             flags.set(TR_SPEED);
         } else {
-            if ((!this->player_ptr->inventory_list[INVEN_MAIN_HAND].k_idx || can_attack_with_main_hand(this->player_ptr))
-                && (!this->player_ptr->inventory_list[INVEN_SUB_HAND].k_idx || can_attack_with_sub_hand(this->player_ptr)))
+            if ((!this->player_ptr->inventory_list[INVEN_MAIN_HAND].k_idx || can_attack_with_main_hand(this->player_ptr)) && (!this->player_ptr->inventory_list[INVEN_SUB_HAND].k_idx || can_attack_with_sub_hand(this->player_ptr)))
                 flags.set(TR_SPEED);
             if (plev > 24 && !this->player_ptr->is_icky_wield[0] && !this->player_ptr->is_icky_wield[1])
                 flags.set(TR_FREE_ACT);
@@ -174,6 +174,35 @@ TrFlags PlayerClass::tr_flags() const
     return flags;
 }
 
+TrFlags PlayerClass::form_tr_flags() const
+{
+    TrFlags flags;
+
+    switch (this->get_kata()) {
+    case SamuraiKata::FUUJIN:
+        if (!this->player_ptr->blind) {
+            flags.set(TR_REFLECT);
+        }
+        break;
+    case SamuraiKata::MUSOU:
+        flags.set({ TR_RES_ACID, TR_RES_ELEC, TR_RES_FIRE, TR_RES_COLD, TR_RES_POIS });
+        flags.set({ TR_REFLECT, TR_RES_FEAR, TR_RES_LITE, TR_RES_DARK, TR_RES_BLIND, TR_RES_CONF,
+            TR_RES_SOUND, TR_RES_SHARDS, TR_RES_NETHER, TR_RES_NEXUS, TR_RES_CHAOS, TR_RES_DISEN,
+            TR_RES_WATER, TR_RES_TIME, TR_RES_CURSE });
+        flags.set({ TR_HOLD_EXP, TR_FREE_ACT, TR_LEVITATION, TR_LITE_1, TR_SEE_INVIS, TR_TELEPATHY, TR_SLOW_DIGEST, TR_REGEN });
+        flags.set({ TR_SH_FIRE, TR_SH_ELEC, TR_SH_COLD });
+        flags.set({ TR_SUST_STR, TR_SUST_INT, TR_SUST_WIS, TR_SUST_DEX, TR_SUST_CON, TR_SUST_CHR });
+        break;
+    case SamuraiKata::KOUKIJIN:
+        flags.set({ TR_VUL_ACID, TR_VUL_ELEC, TR_VUL_FIRE, TR_VUL_COLD });
+        break;
+    default:
+        break;
+    }
+
+    return flags;
+}
+
 bool PlayerClass::can_resist_stun() const
 {
     return (this->player_ptr->pclass == CLASS_BERSERKER) && (this->player_ptr->lev > 34);
@@ -196,17 +225,58 @@ bool PlayerClass::lose_balance()
         return false;
     }
 
-    if (none_bits(this->player_ptr->special_defense, KATA_MASK)) {
+    if (this->get_kata() == SamuraiKata::NONE) {
         return false;
     }
 
-    reset_bits(this->player_ptr->special_defense, KATA_MASK);
+    this->set_kata(SamuraiKata::NONE);
     this->player_ptr->update |= PU_BONUS;
     this->player_ptr->update |= PU_MONSTERS;
     this->player_ptr->redraw |= PR_STATE;
     this->player_ptr->redraw |= PR_STATUS;
     this->player_ptr->action = ACTION_NONE;
     return true;
+}
+
+SamuraiKata PlayerClass::get_kata() const
+{
+    auto samurai_data = this->get_specific_data<samurai_data_type>();
+    if (!samurai_data) {
+        return SamuraiKata::NONE;
+    }
+
+    return samurai_data->kata;
+}
+
+/**
+ * @brief 剣術家の型を崩す
+ *
+ * @param kata_list 崩す型を指定する。取っている型が指定された型に含まれない場合は崩さない。
+ */
+void PlayerClass::break_kata(std::initializer_list<SamuraiKata> kata_list)
+{
+    auto samurai_data = this->get_specific_data<samurai_data_type>();
+    if (!samurai_data) {
+        return;
+    }
+
+    for (auto kata : kata_list) {
+        if (samurai_data->kata == kata) {
+            set_action(player_ptr, ACTION_NONE);
+            samurai_data->kata = SamuraiKata::NONE;
+            break;
+        }
+    }
+}
+
+void PlayerClass::set_kata(SamuraiKata kata) const
+{
+    auto samurai_data = this->get_specific_data<samurai_data_type>();
+    if (!samurai_data) {
+        return;
+    }
+
+    samurai_data->kata = kata;
 }
 
 /**
@@ -236,6 +306,9 @@ void PlayerClass::init_specific_data()
         break;
     case CLASS_SNIPER:
         this->player_ptr->class_specific_data = std::make_shared<sniper_data_type>();
+        break;
+    case CLASS_SAMURAI:
+        this->player_ptr->class_specific_data = std::make_shared<samurai_data_type>();
         break;
     case CLASS_HIGH_MAGE:
         if (this->player_ptr->realm1 == REALM_HEX) {

--- a/src/player-base/player-class.h
+++ b/src/player-base/player-class.h
@@ -26,6 +26,7 @@ public:
     bool lose_balance();
     void break_kata(std::initializer_list<SamuraiKata> kata_list);
     SamuraiKata get_kata() const;
+    bool kata_is(SamuraiKata kata) const;
     void set_kata(SamuraiKata kata) const;
 
     void init_specific_data();

--- a/src/player-base/player-class.h
+++ b/src/player-base/player-class.h
@@ -1,10 +1,15 @@
 ﻿#pragma once
 
+#include "system/angband.h"
+
 #include "object-enchant/tr-flags.h"
 #include "system/player-type-definition.h"
 
+#include <initializer_list>
 #include <memory>
 #include <variant>
+
+enum class SamuraiKata : uint8_t;
 
 class PlayerClass {
 public:
@@ -13,11 +18,15 @@ public:
     virtual ~PlayerClass() = default;
 
     TrFlags tr_flags() const;
+    TrFlags form_tr_flags() const;
 
     bool can_resist_stun() const;
     bool is_wizard() const;
 
     bool lose_balance();
+    void break_kata(std::initializer_list<SamuraiKata> kata_list);
+    SamuraiKata get_kata() const;
+    void set_kata(SamuraiKata kata) const;
 
     void init_specific_data();
     template <typename T>

--- a/src/player-info/class-specific-data.h
+++ b/src/player-info/class-specific-data.h
@@ -12,6 +12,7 @@ struct magic_eater_data_type;
 struct bard_data_type;
 struct mane_data_type;
 struct sniper_data_type;
+struct samurai_data_type;
 struct spell_hex_data_type;
 
 using ClassSpecificData = std::variant<
@@ -24,6 +25,7 @@ using ClassSpecificData = std::variant<
     std::shared_ptr<bard_data_type>,
     std::shared_ptr<mane_data_type>,
     std::shared_ptr<sniper_data_type>,
+    std::shared_ptr<samurai_data_type>,
     std::shared_ptr<spell_hex_data_type>
 
     >;

--- a/src/player-info/samurai-data-type.h
+++ b/src/player-info/samurai-data-type.h
@@ -1,0 +1,15 @@
+﻿#pragma once
+
+#include "system/angband.h"
+
+enum class SamuraiKata : uint8_t {
+    NONE = 0,
+    IAI = 1, //!< 居合の型
+    FUUJIN = 2, //!< 風塵の型
+    KOUKIJIN = 3, //!< 降鬼陣の型
+    MUSOU = 4, //!< 無想の型
+};
+
+struct samurai_data_type {
+    SamuraiKata kata{};
+};

--- a/src/player/digestion-processor.cpp
+++ b/src/player/digestion-processor.cpp
@@ -10,6 +10,8 @@
 #include "main/sound-definitions-table.h"
 #include "main/sound-of-music.h"
 #include "object-enchant/trc-types.h"
+#include "player-base/player-class.h"
+#include "player-info/samurai-data-type.h"
 #include "player/player-damage.h"
 #include "player/player-status.h"
 #include "player/special-defense-types.h"
@@ -33,7 +35,7 @@ void starve_player(player_type *player_ptr)
         int digestion = SPEED_TO_ENERGY(player_ptr->pspeed);
         if (player_ptr->regenerate)
             digestion += 20;
-        if (player_ptr->special_defense & (KAMAE_MASK | KATA_MASK))
+        if ((player_ptr->special_defense & (KAMAE_MASK)) || (PlayerClass(player_ptr).get_kata() != SamuraiKata::NONE))
             digestion += 20;
         if (player_ptr->cursed.has(TRC::FAST_DIGEST))
             digestion += 30;

--- a/src/player/digestion-processor.cpp
+++ b/src/player/digestion-processor.cpp
@@ -35,7 +35,7 @@ void starve_player(player_type *player_ptr)
         int digestion = SPEED_TO_ENERGY(player_ptr->pspeed);
         if (player_ptr->regenerate)
             digestion += 20;
-        if ((player_ptr->special_defense & (KAMAE_MASK)) || (PlayerClass(player_ptr).get_kata() != SamuraiKata::NONE))
+        if ((player_ptr->special_defense & (KAMAE_MASK)) || !PlayerClass(player_ptr).kata_is(SamuraiKata::NONE))
             digestion += 20;
         if (player_ptr->cursed.has(TRC::FAST_DIGEST))
             digestion += 30;

--- a/src/player/permanent-resistances.cpp
+++ b/src/player/permanent-resistances.cpp
@@ -81,8 +81,6 @@ static void add_personality_flags(player_type *player_ptr, TrFlags &flags)
  */
 static void add_kata_flags(player_type *player_ptr, TrFlags &flags)
 {
-    if (player_ptr->special_defense & KATA_FUUJIN)
-        flags.set(TR_REFLECT);
     if (player_ptr->special_defense & KAMAE_GENBU)
         flags.set(TR_REFLECT);
     if (player_ptr->special_defense & KAMAE_SUZAKU)
@@ -98,39 +96,6 @@ static void add_kata_flags(player_type *player_ptr, TrFlags &flags)
         flags.set(TR_SH_ELEC);
         flags.set(TR_SH_COLD);
     }
-
-    if ((player_ptr->special_defense & KATA_MUSOU) == 0)
-        return;
-
-    flags.set(TR_RES_FEAR);
-    flags.set(TR_RES_LITE);
-    flags.set(TR_RES_DARK);
-    flags.set(TR_RES_BLIND);
-    flags.set(TR_RES_CONF);
-    flags.set(TR_RES_SOUND);
-    flags.set(TR_RES_SHARDS);
-    flags.set(TR_RES_NETHER);
-    flags.set(TR_RES_NEXUS);
-    flags.set(TR_RES_CHAOS);
-    flags.set(TR_RES_DISEN);
-    flags.set(TR_REFLECT);
-    flags.set(TR_HOLD_EXP);
-    flags.set(TR_FREE_ACT);
-    flags.set(TR_SH_FIRE);
-    flags.set(TR_SH_ELEC);
-    flags.set(TR_SH_COLD);
-    flags.set(TR_LEVITATION);
-    flags.set(TR_LITE_1);
-    flags.set(TR_SEE_INVIS);
-    flags.set(TR_TELEPATHY);
-    flags.set(TR_SLOW_DIGEST);
-    flags.set(TR_REGEN);
-    flags.set(TR_SUST_STR);
-    flags.set(TR_SUST_INT);
-    flags.set(TR_SUST_WIS);
-    flags.set(TR_SUST_DEX);
-    flags.set(TR_SUST_CON);
-    flags.set(TR_SUST_CHR);
 }
 
 /*!

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -43,8 +43,10 @@
 #include "object/item-tester-hooker.h"
 #include "object/object-broken.h"
 #include "object/object-flags.h"
+#include "player-base/player-class.h"
 #include "player-info/class-info.h"
 #include "player-info/race-types.h"
+#include "player-info/samurai-data-type.h"
 #include "player/player-personality-types.h"
 #include "player/player-status-flags.h"
 #include "player/player-status-resist.h"
@@ -279,7 +281,7 @@ int take_hit(player_type *player_ptr, int damage_type, HIT_POINT damage, concptr
 
     if (player_ptr->sutemi)
         damage *= 2;
-    if (player_ptr->special_defense & KATA_IAI)
+    if (PlayerClass(player_ptr).get_kata() == SamuraiKata::IAI)
         damage += (damage + 4) / 5;
 
     if (damage_type != DAMAGE_USELIFE) {
@@ -319,7 +321,7 @@ int take_hit(player_type *player_ptr, int damage_type, HIT_POINT damage, concptr
             }
         }
 
-        if (player_ptr->special_defense & KATA_MUSOU) {
+        if (PlayerClass(player_ptr).get_kata() == SamuraiKata::MUSOU) {
             damage /= 2;
             if ((damage == 0) && one_in_(2))
                 damage = 1;

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -281,7 +281,7 @@ int take_hit(player_type *player_ptr, int damage_type, HIT_POINT damage, concptr
 
     if (player_ptr->sutemi)
         damage *= 2;
-    if (PlayerClass(player_ptr).get_kata() == SamuraiKata::IAI)
+    if (PlayerClass(player_ptr).kata_is(SamuraiKata::IAI))
         damage += (damage + 4) / 5;
 
     if (damage_type != DAMAGE_USELIFE) {
@@ -321,7 +321,7 @@ int take_hit(player_type *player_ptr, int damage_type, HIT_POINT damage, concptr
             }
         }
 
-        if (PlayerClass(player_ptr).get_kata() == SamuraiKata::MUSOU) {
+        if (PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU)) {
             damage /= 2;
             if ((damage == 0) && one_in_(2))
                 damage = 1;

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -63,6 +63,10 @@ BIT_FLAGS common_cause_flags(player_type *player_ptr, tr_type tr_flag)
         set_bits(result, FLAG_CAUSE_CLASS);
     }
 
+    if (PlayerClass(player_ptr).form_tr_flags().has(tr_flag)) {
+        set_bits(result, FLAG_CAUSE_BATTLE_FORM);
+    }
+
     return result;
 }
 
@@ -645,9 +649,6 @@ BIT_FLAGS has_esp_telepathy(player_type *player_ptr)
     if (is_time_limit_esp(player_ptr) || player_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
 
     if (player_ptr->muta.has(MUTA::ESP)) {
         result |= FLAG_CAUSE_MUTATION;
@@ -744,7 +745,7 @@ BIT_FLAGS has_reflect(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_REFLECT);
 
-    if (player_ptr->special_defense & KAMAE_GENBU || player_ptr->special_defense & KATA_MUSOU) {
+    if (player_ptr->special_defense & KAMAE_GENBU) {
         result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
@@ -798,7 +799,7 @@ BIT_FLAGS has_sh_fire(player_type *player_ptr)
         result |= FLAG_CAUSE_MUTATION;
     }
 
-    if (player_ptr->special_defense & KAMAE_SEIRYU || player_ptr->special_defense & KATA_MUSOU) {
+    if (player_ptr->special_defense & KAMAE_SEIRYU) {
         result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
@@ -820,7 +821,7 @@ BIT_FLAGS has_sh_elec(player_type *player_ptr)
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
-    if (player_ptr->special_defense & KAMAE_SEIRYU || (player_ptr->special_defense & KATA_MUSOU)) {
+    if (player_ptr->special_defense & KAMAE_SEIRYU) {
         result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
@@ -831,7 +832,7 @@ BIT_FLAGS has_sh_cold(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_SH_COLD);
 
-    if (player_ptr->special_defense & KAMAE_SEIRYU || player_ptr->special_defense & KATA_MUSOU) {
+    if (player_ptr->special_defense & KAMAE_SEIRYU) {
         result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
@@ -860,10 +861,6 @@ BIT_FLAGS has_hold_exp(player_type *player_ptr)
         result |= FLAG_CAUSE_PERSONALITY;
     }
 
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
-
     if (player_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
@@ -874,10 +871,6 @@ BIT_FLAGS has_hold_exp(player_type *player_ptr)
 BIT_FLAGS has_see_inv(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_SEE_INVIS);
-
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
 
     if (player_ptr->ult_res || player_ptr->tim_invis) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
@@ -902,10 +895,6 @@ BIT_FLAGS has_free_act(player_type *player_ptr)
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
-
     return result;
 }
 
@@ -915,10 +904,6 @@ BIT_FLAGS has_sustain_str(player_type *player_ptr)
 
     if (player_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
-    }
-
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     return result;
@@ -932,10 +917,6 @@ BIT_FLAGS has_sustain_int(player_type *player_ptr)
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
-
     return result;
 }
 
@@ -945,10 +926,6 @@ BIT_FLAGS has_sustain_wis(player_type *player_ptr)
 
     if (player_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
-    }
-
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     return result;
@@ -962,10 +939,6 @@ BIT_FLAGS has_sustain_dex(player_type *player_ptr)
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
-
     return result;
 }
 
@@ -975,10 +948,6 @@ BIT_FLAGS has_sustain_con(player_type *player_ptr)
 
     if (player_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
-    }
-
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     return result;
@@ -992,10 +961,6 @@ BIT_FLAGS has_sustain_chr(player_type *player_ptr)
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
-
     return result;
 }
 
@@ -1007,7 +972,7 @@ BIT_FLAGS has_levitation(player_type *player_ptr)
         result |= FLAG_CAUSE_MUTATION;
     }
 
-    if (player_ptr->special_defense & KAMAE_SEIRYU || player_ptr->special_defense & KAMAE_SUZAKU || (player_ptr->special_defense & KATA_MUSOU)) {
+    if (player_ptr->special_defense & KAMAE_SEIRYU || player_ptr->special_defense & KAMAE_SUZAKU) {
         result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
@@ -1046,10 +1011,6 @@ BIT_FLAGS has_slow_digest(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_SLOW_DIGEST);
 
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
-
     if (player_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
@@ -1063,10 +1024,6 @@ BIT_FLAGS has_regenerate(player_type *player_ptr)
 
     if (player_ptr->muta.has(MUTA::REGEN))
         result |= FLAG_CAUSE_MUTATION;
-
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
 
     if (SpellHex(player_ptr).is_spelling_specific(HEX_DEMON_AURA) || player_ptr->ult_res || player_ptr->tim_regen) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
@@ -1195,7 +1152,7 @@ BIT_FLAGS has_resist_acid(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_ACID);
 
-    if (player_ptr->special_defense & KAMAE_SEIRYU || player_ptr->special_defense & KATA_MUSOU) {
+    if (player_ptr->special_defense & KAMAE_SEIRYU) {
         result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
@@ -1216,10 +1173,6 @@ BIT_FLAGS has_vuln_acid(player_type *player_ptr)
         result |= FLAG_CAUSE_MUTATION;
     }
 
-    if (player_ptr->special_defense & KATA_KOUKIJIN) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
-
     return result;
 }
 
@@ -1227,7 +1180,7 @@ BIT_FLAGS has_resist_elec(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_ELEC);
 
-    if (player_ptr->special_defense & KAMAE_SEIRYU || player_ptr->special_defense & KATA_MUSOU) {
+    if (player_ptr->special_defense & KAMAE_SEIRYU) {
         result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
@@ -1248,10 +1201,6 @@ BIT_FLAGS has_vuln_elec(player_type *player_ptr)
         result |= FLAG_CAUSE_MUTATION;
     }
 
-    if (player_ptr->special_defense & KATA_KOUKIJIN) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
-
     return result;
 }
 
@@ -1259,7 +1208,7 @@ BIT_FLAGS has_resist_fire(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_FIRE);
 
-    if (player_ptr->special_defense & KAMAE_SEIRYU || player_ptr->special_defense & KATA_MUSOU) {
+    if (player_ptr->special_defense & KAMAE_SEIRYU) {
         result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
@@ -1280,10 +1229,6 @@ BIT_FLAGS has_vuln_fire(player_type *player_ptr)
         result |= FLAG_CAUSE_MUTATION;
     }
 
-    if (player_ptr->special_defense & KATA_KOUKIJIN) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
-
     return result;
 }
 
@@ -1291,7 +1236,7 @@ BIT_FLAGS has_resist_cold(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_COLD);
 
-    if (player_ptr->special_defense & KAMAE_SEIRYU || player_ptr->special_defense & KATA_MUSOU) {
+    if (player_ptr->special_defense & KAMAE_SEIRYU) {
         result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
@@ -1312,10 +1257,6 @@ BIT_FLAGS has_vuln_cold(player_type *player_ptr)
         result |= FLAG_CAUSE_MUTATION;
     }
 
-    if (player_ptr->special_defense & KATA_KOUKIJIN) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
-
     return result;
 }
 
@@ -1323,7 +1264,7 @@ BIT_FLAGS has_resist_pois(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_POIS);
 
-    if (player_ptr->special_defense & KAMAE_SEIRYU || player_ptr->special_defense & KATA_MUSOU) {
+    if (player_ptr->special_defense & KAMAE_SEIRYU) {
         result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
@@ -1346,20 +1287,12 @@ BIT_FLAGS has_resist_conf(player_type *player_ptr)
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
-
     return result;
 }
 
 BIT_FLAGS has_resist_sound(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_SOUND);
-
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
 
     if (player_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
@@ -1371,10 +1304,6 @@ BIT_FLAGS has_resist_sound(player_type *player_ptr)
 BIT_FLAGS has_resist_lite(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_LITE);
-
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
 
     if (player_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
@@ -1398,10 +1327,6 @@ BIT_FLAGS has_resist_dark(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_DARK);
 
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
-
     if (player_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
@@ -1412,10 +1337,6 @@ BIT_FLAGS has_resist_dark(player_type *player_ptr)
 BIT_FLAGS has_resist_chaos(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_CHAOS);
-
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
 
     if (player_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
@@ -1428,10 +1349,6 @@ BIT_FLAGS has_resist_disen(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_DISEN);
 
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
-
     if (player_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
@@ -1443,10 +1360,6 @@ BIT_FLAGS has_resist_shard(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_SHARDS);
 
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
-
     if (player_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
@@ -1457,10 +1370,6 @@ BIT_FLAGS has_resist_shard(player_type *player_ptr)
 BIT_FLAGS has_resist_nexus(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_NEXUS);
-
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
 
     if (player_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
@@ -1477,10 +1386,6 @@ BIT_FLAGS has_resist_blind(player_type *player_ptr)
         result |= FLAG_CAUSE_PERSONALITY;
     }
 
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
-
     if (player_ptr->ult_res || player_ptr->magicdef) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
@@ -1491,10 +1396,6 @@ BIT_FLAGS has_resist_blind(player_type *player_ptr)
 BIT_FLAGS has_resist_neth(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_NETHER);
-
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
 
     if (player_ptr->ult_res || player_ptr->tim_res_nether) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
@@ -1507,10 +1408,6 @@ BIT_FLAGS has_resist_time(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_TIME);
 
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
-
     if (player_ptr->ult_res || player_ptr->tim_res_time) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
@@ -1521,10 +1418,6 @@ BIT_FLAGS has_resist_time(player_type *player_ptr)
 BIT_FLAGS has_resist_water(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_WATER);
-
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
 
     if (player_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
@@ -1543,10 +1436,6 @@ BIT_FLAGS has_resist_curse(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_CURSE);
 
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
-
     if (player_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
@@ -1560,10 +1449,6 @@ BIT_FLAGS has_resist_fear(player_type *player_ptr)
 
     if (player_ptr->muta.has(MUTA::FEARLESS))
         result |= FLAG_CAUSE_MUTATION;
-
-    if ((player_ptr->special_defense & KATA_MUSOU)) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
 
     if (is_hero(player_ptr) || is_shero(player_ptr) || player_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
@@ -1717,10 +1602,6 @@ BIT_FLAGS has_lite(player_type *player_ptr)
 
     if (player_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
-    }
-
-    if (player_ptr->special_defense & KATA_MUSOU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     result |= has_sh_fire(player_ptr);

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -60,6 +60,7 @@
 #include "player-info/class-info.h"
 #include "player-info/equipment-info.h"
 #include "player-info/mimic-info-table.h"
+#include "player-info/samurai-data-type.h"
 #include "player-info/sniper-data-type.h"
 #include "player-status/player-basic-statistics.h"
 #include "player-status/player-hand-types.h"
@@ -1478,7 +1479,7 @@ static int16_t calc_num_blow(player_type *player_ptr, int i)
             else if ((player_ptr->pclass == CLASS_ROGUE) && (o_ptr->weight < 50) && (player_ptr->stat_index[A_DEX] >= 30))
                 num_blow++;
 
-            if (any_bits(player_ptr->special_defense, KATA_FUUJIN))
+            if (PlayerClass(player_ptr).get_kata() == SamuraiKata::FUUJIN)
                 num_blow -= 1;
 
             if ((o_ptr->tval == TV_SWORD) && (o_ptr->sval == SV_POISON_NEEDLE))
@@ -1735,17 +1736,18 @@ static ARMOUR_CLASS calc_to_ac(player_type *player_ptr, bool is_real_value)
         }
     }
 
+    PlayerClass pc(player_ptr);
     if (any_bits(player_ptr->special_defense, KAMAE_GENBU)) {
         ac += (player_ptr->lev * player_ptr->lev) / 50;
     } else if (any_bits(player_ptr->special_defense, KAMAE_BYAKKO)) {
         ac -= 40;
     } else if (any_bits(player_ptr->special_defense, KAMAE_SEIRYU)) {
         ac -= 50;
-    } else if (any_bits(player_ptr->special_defense, KATA_KOUKIJIN)) {
+    } else if (pc.get_kata() == SamuraiKata::KOUKIJIN) {
         ac -= 50;
     }
 
-    if (player_ptr->ult_res || (any_bits(player_ptr->special_defense, KATA_MUSOU))) {
+    if (player_ptr->ult_res || (pc.get_kata() == SamuraiKata::MUSOU)) {
         ac += 100;
     } else if (player_ptr->tsubureru || player_ptr->shield || player_ptr->magicdef) {
         ac += 50;

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -1479,7 +1479,7 @@ static int16_t calc_num_blow(player_type *player_ptr, int i)
             else if ((player_ptr->pclass == CLASS_ROGUE) && (o_ptr->weight < 50) && (player_ptr->stat_index[A_DEX] >= 30))
                 num_blow++;
 
-            if (PlayerClass(player_ptr).get_kata() == SamuraiKata::FUUJIN)
+            if (PlayerClass(player_ptr).kata_is(SamuraiKata::FUUJIN))
                 num_blow -= 1;
 
             if ((o_ptr->tval == TV_SWORD) && (o_ptr->sval == SV_POISON_NEEDLE))
@@ -1743,11 +1743,11 @@ static ARMOUR_CLASS calc_to_ac(player_type *player_ptr, bool is_real_value)
         ac -= 40;
     } else if (any_bits(player_ptr->special_defense, KAMAE_SEIRYU)) {
         ac -= 50;
-    } else if (pc.get_kata() == SamuraiKata::KOUKIJIN) {
+    } else if (pc.kata_is(SamuraiKata::KOUKIJIN)) {
         ac -= 50;
     }
 
-    if (player_ptr->ult_res || (pc.get_kata() == SamuraiKata::MUSOU)) {
+    if (player_ptr->ult_res || (pc.kata_is(SamuraiKata::MUSOU))) {
         ac += 100;
     } else if (player_ptr->tsubureru || player_ptr->shield || player_ptr->magicdef) {
         ac += 50;

--- a/src/player/race-resistances.cpp
+++ b/src/player/race-resistances.cpp
@@ -104,7 +104,7 @@ void player_vulnerability_flags(player_type *player_ptr, TrFlags &flags)
 {
     flags.clear();
 
-    if (player_ptr->muta.has(MUTA::VULN_ELEM) || (PlayerClass(player_ptr).get_kata() == SamuraiKata::KOUKIJIN)) {
+    if (player_ptr->muta.has(MUTA::VULN_ELEM) || PlayerClass(player_ptr).kata_is(SamuraiKata::KOUKIJIN)) {
         flags.set(TR_RES_ACID);
         flags.set(TR_RES_ELEC);
         flags.set(TR_RES_FIRE);

--- a/src/player/race-resistances.cpp
+++ b/src/player/race-resistances.cpp
@@ -7,6 +7,7 @@
 #include "player-base/player-class.h"
 #include "player-base/player-race.h"
 #include "player-info/race-info.h"
+#include "player-info/samurai-data-type.h"
 #include "player/special-defense-types.h"
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
@@ -103,7 +104,7 @@ void player_vulnerability_flags(player_type *player_ptr, TrFlags &flags)
 {
     flags.clear();
 
-    if (player_ptr->muta.has(MUTA::VULN_ELEM) || (player_ptr->special_defense & KATA_KOUKIJIN)) {
+    if (player_ptr->muta.has(MUTA::VULN_ELEM) || (PlayerClass(player_ptr).get_kata() == SamuraiKata::KOUKIJIN)) {
         flags.set(TR_RES_ACID);
         flags.set(TR_RES_ELEC);
         flags.set(TR_RES_FIRE);

--- a/src/player/special-defense-types.h
+++ b/src/player/special-defense-types.h
@@ -10,16 +10,9 @@ enum special_defence {
     KAMAE_BYAKKO = 0x00000040, /*!< プレイヤーのステータス:白虎の構え */
     KAMAE_SEIRYU = 0x00000080, /*!< プレイヤーのステータス:青竜の構え */
     KAMAE_SUZAKU = 0x00000100, /*!< プレイヤーのステータス:朱雀の構え */
-    KATA_IAI = 0x00000200, /*!< プレイヤーのステータス:居合 */
-    KATA_FUUJIN = 0x00000400, /*!< プレイヤーのステータス:風塵 */
-    KATA_KOUKIJIN = 0x00000800, /*!< プレイヤーのステータス:降鬼陣 */
-    KATA_MUSOU = 0x00001000, /*!< プレイヤーのステータス:無想 */
     NINJA_KAWARIMI = 0x00002000, /*!< プレイヤーのステータス:変わり身 */
     NINJA_S_STEALTH = 0x00004000, /*!< プレイヤーのステータス:超隠密 */
 };
 
 #define MAX_KAMAE 4 /*!< 修行僧の構え最大数 */
 #define KAMAE_MASK (KAMAE_GENBU | KAMAE_BYAKKO | KAMAE_SEIRYU | KAMAE_SUZAKU) /*!< 修行僧の構えビット配列 */
-
-#define MAX_KATA 4 /*!< 修行僧の型最大数 */
-#define KATA_MASK (KATA_IAI | KATA_FUUJIN | KATA_KOUKIJIN | KATA_MUSOU) /*!< 修行僧の型ビット配列 */

--- a/src/save/player-class-specific-data-writer.cpp
+++ b/src/save/player-class-specific-data-writer.cpp
@@ -4,6 +4,7 @@
 #include "player-info/force-trainer-data-type.h"
 #include "player-info/magic-eater-data-type.h"
 #include "player-info/mane-data-type.h"
+#include "player-info/samurai-data-type.h"
 #include "player-info/smith-data-type.h"
 #include "player-info/sniper-data-type.h"
 #include "player-info/spell-hex-data-type.h"
@@ -67,6 +68,11 @@ void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<mane_data_t
 void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<sniper_data_type> &sniper_data) const
 {
     wr_s16b(sniper_data->concent);
+}
+
+void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<samurai_data_type> &samurai_data) const
+{
+    wr_byte(enum2i(samurai_data->kata));
 }
 
 void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<spell_hex_data_type> &spell_hex_data) const

--- a/src/save/player-class-specific-data-writer.h
+++ b/src/save/player-class-specific-data-writer.h
@@ -11,6 +11,7 @@ struct magic_eater_data_type;
 struct bard_data_type;
 struct mane_data_type;
 struct sniper_data_type;
+struct samurai_data_type;
 
 class PlayerClassSpecificDataWriter {
 public:
@@ -23,4 +24,5 @@ public:
     void operator()(const std::shared_ptr<bard_data_type> &bird_data) const;
     void operator()(const std::shared_ptr<mane_data_type> &mane_data) const;
     void operator()(const std::shared_ptr<sniper_data_type> &sniper_data) const;
+    void operator()(const std::shared_ptr<samurai_data_type> &samurai_data) const;
 };

--- a/src/status/action-setter.cpp
+++ b/src/status/action-setter.cpp
@@ -16,6 +16,7 @@
 #include "core/player-update-types.h"
 #include "player-base/player-class.h"
 #include "player-info/bluemage-data-type.h"
+#include "player-info/samurai-data-type.h"
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
 #include "player/special-defense-types.h"
@@ -60,7 +61,7 @@ void set_action(player_type *player_ptr, uint8_t typ)
     }
     case ACTION_KATA: {
         msg_print(_("型を崩した。", "You stop assuming the special stance."));
-        player_ptr->special_defense &= ~(KATA_MASK);
+        PlayerClass(player_ptr).set_kata(SamuraiKata::NONE);
         player_ptr->update |= (PU_MONSTERS);
         player_ptr->redraw |= (PR_STATUS);
         break;

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -125,12 +125,7 @@ bool BadStatusSetter::confusion(const TIME_EFFECT tmp_v)
                 this->player_ptr->action = ACTION_NONE;
             } else if (this->player_ptr->action == ACTION_KATA) {
                 msg_print(_("型が崩れた。", "You lose your stance."));
-                this->player_ptr->special_defense &= ~(KATA_MASK);
-                this->player_ptr->update |= PU_BONUS;
-                this->player_ptr->update |= PU_MONSTERS;
-                this->player_ptr->redraw |= PR_STATE;
-                this->player_ptr->redraw |= PR_STATUS;
-                this->player_ptr->action = ACTION_NONE;
+                PlayerClass(player_ptr).lose_balance();
             }
 
             /* Sniper */
@@ -232,14 +227,8 @@ bool BadStatusSetter::afraidness(const TIME_EFFECT tmp_v)
     if (v > 0) {
         if (!this->player_ptr->afraid) {
             msg_print(_("何もかも恐くなってきた！", "You are terrified!"));
-            if (this->player_ptr->special_defense & KATA_MASK) {
+            if (PlayerClass(this->player_ptr).lose_balance()) {
                 msg_print(_("型が崩れた。", "You lose your stance."));
-                this->player_ptr->special_defense &= ~(KATA_MASK);
-                this->player_ptr->update |= PU_BONUS;
-                this->player_ptr->update |= PU_MONSTERS;
-                this->player_ptr->redraw |= PR_STATE;
-                this->player_ptr->redraw |= PR_STATUS;
-                this->player_ptr->action = ACTION_NONE;
             }
 
             notice = true;

--- a/src/status/element-resistance.cpp
+++ b/src/status/element-resistance.cpp
@@ -36,7 +36,7 @@ bool set_oppose_acid(player_type *player_ptr, TIME_EFFECT v, bool do_dec)
         }
     } else {
         if (player_ptr->oppose_acid && !music_singing(player_ptr, MUSIC_RESIST) &&
-            (PlayerClass(player_ptr).get_kata() != SamuraiKata::MUSOU)) {
+            !PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU)) {
             msg_print(_("酸への耐性が薄れた気がする。", "You feel less resistant to acid."));
             notice = true;
         }
@@ -78,7 +78,7 @@ bool set_oppose_elec(player_type *player_ptr, TIME_EFFECT v, bool do_dec)
         }
     } else {
         if (player_ptr->oppose_elec && !music_singing(player_ptr, MUSIC_RESIST) &&
-            (PlayerClass(player_ptr).get_kata() != SamuraiKata::MUSOU)) {
+            !PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU)) {
             msg_print(_("電撃への耐性が薄れた気がする。", "You feel less resistant to electricity."));
             notice = true;
         }
@@ -121,7 +121,7 @@ bool set_oppose_fire(player_type *player_ptr, TIME_EFFECT v, bool do_dec)
         }
     } else {
         if (player_ptr->oppose_fire && !music_singing(player_ptr, MUSIC_RESIST) &&
-            (PlayerClass(player_ptr).get_kata() != SamuraiKata::MUSOU)) {
+            !PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU)) {
             msg_print(_("火への耐性が薄れた気がする。", "You feel less resistant to fire."));
             notice = true;
         }
@@ -162,7 +162,7 @@ bool set_oppose_cold(player_type *player_ptr, TIME_EFFECT v, bool do_dec)
         }
     } else {
         if (player_ptr->oppose_cold && !music_singing(player_ptr, MUSIC_RESIST) &&
-            (PlayerClass(player_ptr).get_kata() != SamuraiKata::MUSOU)) {
+            !PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU)) {
             msg_print(_("冷気への耐性が薄れた気がする。", "You feel less resistant to cold."));
             notice = true;
         }
@@ -205,7 +205,7 @@ bool set_oppose_pois(player_type *player_ptr, TIME_EFFECT v, bool do_dec)
         }
     } else {
         if (player_ptr->oppose_pois && !music_singing(player_ptr, MUSIC_RESIST) &&
-            (PlayerClass(player_ptr).get_kata() != SamuraiKata::MUSOU)) {
+            !PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU)) {
             msg_print(_("毒への耐性が薄れた気がする。", "You feel less resistant to poison."));
             notice = true;
         }
@@ -224,28 +224,28 @@ bool set_oppose_pois(player_type *player_ptr, TIME_EFFECT v, bool do_dec)
 
 bool is_oppose_acid(player_type *player_ptr)
 {
-    return player_ptr->oppose_acid || music_singing(player_ptr, MUSIC_RESIST) || (PlayerClass(player_ptr).get_kata() == SamuraiKata::MUSOU);
+    return player_ptr->oppose_acid || music_singing(player_ptr, MUSIC_RESIST) || PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU);
 }
 
 bool is_oppose_elec(player_type *player_ptr)
 {
-    return player_ptr->oppose_elec || music_singing(player_ptr, MUSIC_RESIST) || (PlayerClass(player_ptr).get_kata() == SamuraiKata::MUSOU);
+    return player_ptr->oppose_elec || music_singing(player_ptr, MUSIC_RESIST) || PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU);
 }
 
 bool is_oppose_fire(player_type *player_ptr)
 {
     return player_ptr->oppose_fire || music_singing(player_ptr, MUSIC_RESIST)
-        || ((PlayerClass(player_ptr).get_kata() == SamuraiKata::MUSOU) || (player_ptr->mimic_form == MIMIC_DEMON)
+        || (PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU) || (player_ptr->mimic_form == MIMIC_DEMON)
             || (PlayerRace(player_ptr).equals(player_race_type::BALROG) && player_ptr->lev > 44));
 }
 
 bool is_oppose_cold(player_type *player_ptr)
 {
-    return player_ptr->oppose_cold || music_singing(player_ptr, MUSIC_RESIST) || (PlayerClass(player_ptr).get_kata() == SamuraiKata::MUSOU);
+    return player_ptr->oppose_cold || music_singing(player_ptr, MUSIC_RESIST) || PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU);
 }
 
 bool is_oppose_pois(player_type *player_ptr)
 {
     return player_ptr->oppose_pois || music_singing(player_ptr, MUSIC_RESIST)
-        || ((PlayerClass(player_ptr).get_kata() == SamuraiKata::MUSOU) || (player_ptr->pclass == CLASS_NINJA && player_ptr->lev > 44));
+        || (PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU) || (player_ptr->pclass == CLASS_NINJA && player_ptr->lev > 44));
 }

--- a/src/status/element-resistance.cpp
+++ b/src/status/element-resistance.cpp
@@ -3,8 +3,10 @@
 #include "core/player-redraw-types.h"
 #include "core/stuff-handler.h"
 #include "game-option/disturbance-options.h"
+#include "player-base/player-class.h"
 #include "player-base/player-race.h"
 #include "player-info/race-info.h"
+#include "player-info/samurai-data-type.h"
 #include "player/special-defense-types.h"
 #include "realm/realm-song-numbers.h"
 #include "spell-realm/spells-song.h"
@@ -33,7 +35,8 @@ bool set_oppose_acid(player_type *player_ptr, TIME_EFFECT v, bool do_dec)
             notice = true;
         }
     } else {
-        if (player_ptr->oppose_acid && !music_singing(player_ptr, MUSIC_RESIST) && !(player_ptr->special_defense & KATA_MUSOU)) {
+        if (player_ptr->oppose_acid && !music_singing(player_ptr, MUSIC_RESIST) &&
+            (PlayerClass(player_ptr).get_kata() != SamuraiKata::MUSOU)) {
             msg_print(_("酸への耐性が薄れた気がする。", "You feel less resistant to acid."));
             notice = true;
         }
@@ -74,7 +77,8 @@ bool set_oppose_elec(player_type *player_ptr, TIME_EFFECT v, bool do_dec)
             notice = true;
         }
     } else {
-        if (player_ptr->oppose_elec && !music_singing(player_ptr, MUSIC_RESIST) && !(player_ptr->special_defense & KATA_MUSOU)) {
+        if (player_ptr->oppose_elec && !music_singing(player_ptr, MUSIC_RESIST) &&
+            (PlayerClass(player_ptr).get_kata() != SamuraiKata::MUSOU)) {
             msg_print(_("電撃への耐性が薄れた気がする。", "You feel less resistant to electricity."));
             notice = true;
         }
@@ -116,7 +120,8 @@ bool set_oppose_fire(player_type *player_ptr, TIME_EFFECT v, bool do_dec)
             notice = true;
         }
     } else {
-        if (player_ptr->oppose_fire && !music_singing(player_ptr, MUSIC_RESIST) && !(player_ptr->special_defense & KATA_MUSOU)) {
+        if (player_ptr->oppose_fire && !music_singing(player_ptr, MUSIC_RESIST) &&
+            (PlayerClass(player_ptr).get_kata() != SamuraiKata::MUSOU)) {
             msg_print(_("火への耐性が薄れた気がする。", "You feel less resistant to fire."));
             notice = true;
         }
@@ -156,7 +161,8 @@ bool set_oppose_cold(player_type *player_ptr, TIME_EFFECT v, bool do_dec)
             notice = true;
         }
     } else {
-        if (player_ptr->oppose_cold && !music_singing(player_ptr, MUSIC_RESIST) && !(player_ptr->special_defense & KATA_MUSOU)) {
+        if (player_ptr->oppose_cold && !music_singing(player_ptr, MUSIC_RESIST) &&
+            (PlayerClass(player_ptr).get_kata() != SamuraiKata::MUSOU)) {
             msg_print(_("冷気への耐性が薄れた気がする。", "You feel less resistant to cold."));
             notice = true;
         }
@@ -198,7 +204,8 @@ bool set_oppose_pois(player_type *player_ptr, TIME_EFFECT v, bool do_dec)
             notice = true;
         }
     } else {
-        if (player_ptr->oppose_pois && !music_singing(player_ptr, MUSIC_RESIST) && !(player_ptr->special_defense & KATA_MUSOU)) {
+        if (player_ptr->oppose_pois && !music_singing(player_ptr, MUSIC_RESIST) &&
+            (PlayerClass(player_ptr).get_kata() != SamuraiKata::MUSOU)) {
             msg_print(_("毒への耐性が薄れた気がする。", "You feel less resistant to poison."));
             notice = true;
         }
@@ -217,28 +224,28 @@ bool set_oppose_pois(player_type *player_ptr, TIME_EFFECT v, bool do_dec)
 
 bool is_oppose_acid(player_type *player_ptr)
 {
-    return player_ptr->oppose_acid || music_singing(player_ptr, MUSIC_RESIST) || (player_ptr->special_defense & KATA_MUSOU);
+    return player_ptr->oppose_acid || music_singing(player_ptr, MUSIC_RESIST) || (PlayerClass(player_ptr).get_kata() == SamuraiKata::MUSOU);
 }
 
 bool is_oppose_elec(player_type *player_ptr)
 {
-    return player_ptr->oppose_elec || music_singing(player_ptr, MUSIC_RESIST) || (player_ptr->special_defense & KATA_MUSOU);
+    return player_ptr->oppose_elec || music_singing(player_ptr, MUSIC_RESIST) || (PlayerClass(player_ptr).get_kata() == SamuraiKata::MUSOU);
 }
 
 bool is_oppose_fire(player_type *player_ptr)
 {
     return player_ptr->oppose_fire || music_singing(player_ptr, MUSIC_RESIST)
-        || (player_ptr->special_defense & KATA_MUSOU || (player_ptr->mimic_form == MIMIC_DEMON)
+        || ((PlayerClass(player_ptr).get_kata() == SamuraiKata::MUSOU) || (player_ptr->mimic_form == MIMIC_DEMON)
             || (PlayerRace(player_ptr).equals(player_race_type::BALROG) && player_ptr->lev > 44));
 }
 
 bool is_oppose_cold(player_type *player_ptr)
 {
-    return player_ptr->oppose_cold || music_singing(player_ptr, MUSIC_RESIST) || (player_ptr->special_defense & KATA_MUSOU);
+    return player_ptr->oppose_cold || music_singing(player_ptr, MUSIC_RESIST) || (PlayerClass(player_ptr).get_kata() == SamuraiKata::MUSOU);
 }
 
 bool is_oppose_pois(player_type *player_ptr)
 {
     return player_ptr->oppose_pois || music_singing(player_ptr, MUSIC_RESIST)
-        || (player_ptr->special_defense & KATA_MUSOU || (player_ptr->pclass == CLASS_NINJA && player_ptr->lev > 44));
+        || ((PlayerClass(player_ptr).get_kata() == SamuraiKata::MUSOU) || (player_ptr->pclass == CLASS_NINJA && player_ptr->lev > 44));
 }

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -6,6 +6,7 @@
 #include "player-base/player-class.h"
 #include "player-info/bluemage-data-type.h"
 #include "player-info/mane-data-type.h"
+#include "player-info/samurai-data-type.h"
 #include "player-info/sniper-data-type.h"
 #include "player/attack-defense-types.h"
 #include "player/digestion-processor.h"
@@ -23,8 +24,8 @@
 #include "timed-effect/player-cut.h"
 #include "timed-effect/player-stun.h"
 #include "timed-effect/timed-effects.h"
-#include "window/main-window-row-column.h"
 #include "view/status-bars-table.h"
+#include "window/main-window-row-column.h"
 
 /*!
  * @brief 32ビット変数配列の指定位置のビットフラグを1にする。
@@ -210,12 +211,10 @@ void print_state(player_type *player_ptr)
         break;
     }
     case ACTION_KATA: {
-        int i;
-        for (i = 0; i < MAX_KATA; i++)
-            if (player_ptr->special_defense & (KATA_IAI << i))
-                break;
-
-        strcpy(text, samurai_stances[i].desc);
+        if (auto kata = PlayerClass(player_ptr).get_kata();
+            kata != SamuraiKata::NONE) {
+            strcpy(text, samurai_stances[enum2i(kata) - 1].desc);
+        }
         break;
     }
     case ACTION_SING: {


### PR DESCRIPTION
剣術家の職業固有データ samurai_data_type を定義し、剣術家の型の状態を
player_ptr::special_defence から samurai_data_type::kata に移動する。
使用している箇所が多く毎回 get_specific_info を呼ぶのは煩わしいので、
以下のヘルパ関数を PlayerClass に用意する。

- get_kata: 現在構えている型を取得する
- set_kata: 指定した型で構える
- break_kata: 指定した型の構えをしている場合型を崩す

また、構えている型から得られる特性フラグを PlayerClass::form_tr_flags()
で取得できるようにし、has_*() のような特性フラグにおける型のチェックを
この関数から得られる特性フラグのチェックに集約する。

無想の型でコマンドを実行した時に型を崩す処理が至るところにあるため変更ファイルがかなり多くなっています。
また、型の状態のセーブファイルのマイグレーションは、型を使用した状態で中断したセーブファイルでバージョンアップするというようなまずやらないような事のためにコードが特殊化されるのは割に合わないと判断したため、実装していません。
もし型を使用した状態でバージョンアップした場合は型が解除された状態になります。
