### PR TITLE
[Refactor] 修行僧の構えを職業固有データに移動する

### DIFF
--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -311,7 +311,7 @@ bool do_cmd_attack(player_type *player_ptr, POSITION y, POSITION x, combat_optio
         msg_format(_("%^sは恐怖して逃げ出した！", "%^s flees in terror!"), m_name);
     }
 
-    if (PlayerClass(player_ptr).kata_is(SamuraiKata::IAI) && ((mode != HISSATSU_IAI) || mdeath)) {
+    if (PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::IAI) && ((mode != HISSATSU_IAI) || mdeath)) {
         set_action(player_ptr, ACTION_NONE);
     }
 

--- a/src/cmd-action/cmd-hissatsu.cpp
+++ b/src/cmd-action/cmd-hissatsu.cpp
@@ -326,7 +326,7 @@ void do_cmd_hissatsu(player_type *player_ptr)
         return;
     }
 
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU, SamuraiKata::IAI, SamuraiKata::FUUJIN, SamuraiKata::KOUKIJIN });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU, SamuraiStance::IAI, SamuraiStance::FUUJIN, SamuraiStance::KOUKIJIN });
 
     if (!get_hissatsu_power(player_ptr, &n))
         return;
@@ -373,7 +373,7 @@ void do_cmd_gain_hissatsu(player_type *player_ptr)
 
     bool gain = false;
 
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU, SamuraiKata::KOUKIJIN });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU, SamuraiStance::KOUKIJIN });
 
     if (cmd_limit_blind(player_ptr))
         return;

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -74,7 +74,7 @@ void do_cmd_go_up(player_type *player_ptr)
     grid_type *g_ptr = &player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x];
     feature_type *f_ptr = &f_info[g_ptr->feat];
     int up_num = 0;
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU });
 
     if (f_ptr->flags.has_not(FF::LESS)) {
         msg_print(_("ここには上り階段が見当たらない。", "I see no up staircase here."));
@@ -180,7 +180,7 @@ void do_cmd_go_down(player_type *player_ptr)
 {
     bool fall_trap = false;
     int down_num = 0;
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU });
 
     grid_type *g_ptr = &player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x];
     feature_type *f_ptr = &f_info[g_ptr->feat];
@@ -322,7 +322,7 @@ void do_cmd_walk(player_type *player_ptr, bool pickup)
         PlayerEnergy energy(player_ptr);
         energy.set_player_turn_energy(100);
         if (dir != 5) {
-            PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
+            PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU });
         }
 
         if (player_ptr->wild_mode) {
@@ -367,7 +367,7 @@ void do_cmd_run(player_type *player_ptr)
     if (cmd_limit_confused(player_ptr))
         return;
 
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU });
 
     if (get_rep_dir(player_ptr, &dir, false)) {
         player_ptr->running = (command_arg ? command_arg : 1000);

--- a/src/cmd-action/cmd-open-close.cpp
+++ b/src/cmd-action/cmd-open-close.cpp
@@ -95,7 +95,7 @@ void do_cmd_open(player_type *player_ptr)
     if (player_ptr->wild_mode)
         return;
 
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU });
 
     if (easy_open) {
         int num_doors = count_dt(player_ptr, &y, &x, is_closed_door, false);
@@ -152,7 +152,7 @@ void do_cmd_close(player_type *player_ptr)
     if (player_ptr->wild_mode)
         return;
 
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU });
 
     if (easy_open && (count_dt(player_ptr, &y, &x, is_open, false) == 1))
         command_dir = coords_to_dir(player_ptr, y, x);
@@ -198,7 +198,7 @@ void do_cmd_disarm(player_type *player_ptr)
     if (player_ptr->wild_mode)
         return;
 
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU });
 
     if (easy_disarm) {
         int num_traps = count_dt(player_ptr, &y, &x, is_trap, true);
@@ -266,7 +266,7 @@ void do_cmd_bash(player_type *player_ptr)
     if (player_ptr->wild_mode)
         return;
 
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU });
 
     if (command_arg) {
         command_rep = command_arg - 1;
@@ -337,7 +337,7 @@ void do_cmd_spike(player_type *player_ptr)
     if (player_ptr->wild_mode)
         return;
 
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU });
 
     if (!get_rep_dir(player_ptr, &dir, false))
         return;

--- a/src/cmd-action/cmd-others.cpp
+++ b/src/cmd-action/cmd-others.cpp
@@ -103,7 +103,7 @@ static bool exe_alter(player_type *player_ptr)
  */
 void do_cmd_alter(player_type *player_ptr)
 {
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU });
 
     if (command_arg) {
         command_rep = command_arg - 1;

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -205,7 +205,7 @@ bool do_cmd_riding(player_type *player_ptr, bool force)
     x = player_ptr->x + ddx[dir];
     g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
 
-   PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
+   PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU });
 
     if (player_ptr->riding) {
         /* Skip non-empty grids */

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -277,7 +277,7 @@ bool do_cmd_riding(player_type *player_ptr, bool force)
             msg_format(_("%sを起こした。", "You have woken %s up."), m_name);
         }
 
-        if (player_ptr->action == ACTION_KAMAE)
+        if (player_ptr->action == ACTION_MONK_STANCE)
             set_action(player_ptr, ACTION_NONE);
 
         player_ptr->riding = g_ptr->m_idx;

--- a/src/cmd-action/cmd-racial.cpp
+++ b/src/cmd-action/cmd-racial.cpp
@@ -437,7 +437,7 @@ void do_cmd_racial_power(player_type *player_ptr)
         return;
     }
 
-   PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU, SamuraiKata::KOUKIJIN });
+   PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU, SamuraiStance::KOUKIJIN });
 
     auto tmp_r = rc_type(player_ptr);
     auto *rc_ptr = &tmp_r;

--- a/src/cmd-action/cmd-shoot.cpp
+++ b/src/cmd-action/cmd-shoot.cpp
@@ -51,7 +51,7 @@ void do_cmd_fire(player_type *player_ptr, SPELL_IDX snipe_type)
         return;
     }
 
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU });
 
     concptr q = _("どれを撃ちますか? ", "Fire which item? ");
     concptr s = _("発射されるアイテムがありません。", "You have nothing to fire.");

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -626,7 +626,7 @@ void do_cmd_browse(player_type *player_ptr)
         return;
     }
 
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU });
 
     if (player_ptr->pclass == CLASS_FORCETRAINER) {
         if (player_has_no_spellbooks(player_ptr)) {
@@ -783,7 +783,7 @@ void do_cmd_study(player_type *player_ptr)
         return;
     }
 
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU });
 
 #ifdef JP
     if (player_ptr->new_spells < 10) {

--- a/src/cmd-action/cmd-tunnel.cpp
+++ b/src/cmd-action/cmd-tunnel.cpp
@@ -35,7 +35,7 @@
 void do_cmd_tunnel(player_type *player_ptr)
 {
     bool more = false;
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU });
 
     if (command_arg) {
         command_rep = command_arg - 1;

--- a/src/cmd-item/cmd-destroy.cpp
+++ b/src/cmd-item/cmd-destroy.cpp
@@ -196,7 +196,7 @@ static void exe_destroy_item(player_type *player_ptr, destroy_type *destroy_ptr)
  */
 void do_cmd_destroy(player_type *player_ptr)
 {
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU });
 
     object_type forge;
     destroy_type tmp_destroy;

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -337,7 +337,7 @@ void do_cmd_eat_food(player_type *player_ptr)
     OBJECT_IDX item;
     concptr q, s;
 
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU, SamuraiKata::KOUKIJIN });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU, SamuraiStance::KOUKIJIN });
 
     q = _("どれを食べますか? ", "Eat which item? ");
     s = _("食べ物がない。", "You have nothing to eat.");

--- a/src/cmd-item/cmd-equipment.cpp
+++ b/src/cmd-item/cmd-equipment.cpp
@@ -98,7 +98,7 @@ void do_cmd_wield(player_type *player_ptr)
     concptr act;
     GAME_TEXT o_name[MAX_NLEN];
     OBJECT_IDX need_switch_wielding = 0;
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU });
 
     concptr q = _("どれを装備しますか? ", "Wear/Wield which item? ");
     concptr s = _("装備可能なアイテムがない。", "You have nothing you can wear or wield.");
@@ -304,7 +304,7 @@ void do_cmd_takeoff(player_type *player_ptr)
 {
     OBJECT_IDX item;
     object_type *o_ptr;
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU });
 
     concptr q = _("どれを装備からはずしますか? ", "Take off which item? ");
     concptr s = _("はずせる装備がない。", "You are not wearing anything to take off.");

--- a/src/cmd-item/cmd-item.cpp
+++ b/src/cmd-item/cmd-item.cpp
@@ -111,7 +111,7 @@ void do_cmd_drop(player_type *player_ptr)
     OBJECT_IDX item;
     int amt = 1;
     object_type *o_ptr;
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU });
 
     concptr q = _("どのアイテムを落としますか? ", "Drop which item? ");
     concptr s = _("落とせるアイテムを持っていない。", "You have nothing to drop.");
@@ -235,7 +235,7 @@ void do_cmd_use(player_type *player_ptr)
     if (player_ptr->wild_mode || cmd_limit_arena(player_ptr))
         return;
 
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU, SamuraiKata::KOUKIJIN });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU, SamuraiStance::KOUKIJIN });
 
     concptr q = _("どれを使いますか？", "Use which item? ");
     concptr s = _("使えるものがありません。", "You have nothing to use.");
@@ -290,7 +290,7 @@ void do_cmd_activate(player_type *player_ptr)
     if (player_ptr->wild_mode || cmd_limit_arena(player_ptr))
         return;
 
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU, SamuraiKata::KOUKIJIN });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU, SamuraiStance::KOUKIJIN });
 
     concptr q = _("どのアイテムを始動させますか? ", "Activate which item? ");
     concptr s = _("始動できるアイテムを装備していない。", "You have nothing to activate.");

--- a/src/cmd-item/cmd-quaff.cpp
+++ b/src/cmd-item/cmd-quaff.cpp
@@ -32,7 +32,7 @@ void do_cmd_quaff_potion(player_type *player_ptr)
     if (!SpellHex(player_ptr).is_spelling_specific(HEX_INHALE) && cmd_limit_arena(player_ptr))
         return;
 
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU, SamuraiKata::KOUKIJIN });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU, SamuraiStance::KOUKIJIN });
 
     concptr q = _("どの薬を飲みますか? ", "Quaff which potion? ");
     concptr s = _("飲める薬がない。", "You have no potions to quaff.");

--- a/src/cmd-item/cmd-read.cpp
+++ b/src/cmd-item/cmd-read.cpp
@@ -30,7 +30,7 @@ void do_cmd_read_scroll(player_type *player_ptr)
     if (player_ptr->wild_mode || cmd_limit_arena(player_ptr))
         return;
 
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU, SamuraiKata::KOUKIJIN });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU, SamuraiStance::KOUKIJIN });
 
     if (cmd_limit_blind(player_ptr) || cmd_limit_confused(player_ptr))
         return;

--- a/src/cmd-item/cmd-refill.cpp
+++ b/src/cmd-item/cmd-refill.cpp
@@ -106,7 +106,7 @@ void do_cmd_refill(player_type *player_ptr)
     object_type *o_ptr;
     o_ptr = &player_ptr->inventory_list[INVEN_LITE];
 
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU });
 
     if (o_ptr->tval != TV_LITE)
         msg_print(_("光源を装備していない。", "You are not wielding a light."));

--- a/src/cmd-item/cmd-throw.cpp
+++ b/src/cmd-item/cmd-throw.cpp
@@ -46,7 +46,7 @@ bool ThrowCommand::do_cmd_throw(int mult, bool boomerang, OBJECT_IDX shuriken)
         return false;
     }
 
-    PlayerClass(this->player_ptr).break_kata({ SamuraiKata::MUSOU });
+    PlayerClass(this->player_ptr).break_samurai_stance({ SamuraiStance::MUSOU });
 
     object_type tmp_object;
     ObjectThrowEntity ote(this->player_ptr, &tmp_object, delay_factor, mult, boomerang, shuriken);

--- a/src/cmd-item/cmd-usestaff.cpp
+++ b/src/cmd-item/cmd-usestaff.cpp
@@ -295,7 +295,7 @@ void do_cmd_use_staff(player_type *player_ptr)
     if (cmd_limit_arena(player_ptr))
         return;
 
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU, SamuraiKata::KOUKIJIN });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU, SamuraiStance::KOUKIJIN });
 
     q = _("どの杖を使いますか? ", "Use which staff? ");
     s = _("使える杖がない。", "You have no staff to use.");

--- a/src/cmd-item/cmd-zaprod.cpp
+++ b/src/cmd-item/cmd-zaprod.cpp
@@ -273,7 +273,7 @@ void do_cmd_zap_rod(player_type *player_ptr)
         return;
     }
 
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU, SamuraiKata::KOUKIJIN });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU, SamuraiStance::KOUKIJIN });
 
     auto q = _("どのロッドを振りますか? ", "Zap which rod? ");
     auto s = _("使えるロッドがない。", "You have no rod to zap.");

--- a/src/cmd-item/cmd-zapwand.cpp
+++ b/src/cmd-item/cmd-zapwand.cpp
@@ -327,7 +327,7 @@ void do_cmd_aim_wand(player_type *player_ptr)
         return;
     if (cmd_limit_arena(player_ptr))
         return;
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU, SamuraiKata::KOUKIJIN });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU, SamuraiStance::KOUKIJIN });
 
     q = _("どの魔法棒で狙いますか? ", "Aim which wand? ");
     s = _("使える魔法棒がない。", "You have no wand to aim.");

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -248,7 +248,7 @@ void process_player(player_type *player_ptr)
         player_ptr->redraw |= PR_MANA;
     }
 
-    if (PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU)) {
+    if (PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::MUSOU)) {
         if (player_ptr->csp < 3) {
             set_action(player_ptr, ACTION_NONE);
         } else {

--- a/src/effect/effect-player.cpp
+++ b/src/effect/effect-player.cpp
@@ -79,7 +79,7 @@ static bool process_bolt_reflection(player_type *player_ptr, effect_player_type 
     std::string mes;
     if (player_ptr->blind) {
         mes = _("何かが跳ね返った！", "Something bounces!");
-    } else if (PlayerClass(player_ptr).kata_is(SamuraiKata::FUUJIN)) {
+    } else if (PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::FUUJIN)) {
         mes = _("風の如く武器を振るって弾き返した！", "The attack bounces!");
     } else {
         mes = _("攻撃が跳ね返った！", "The attack bounces!");

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -286,7 +286,7 @@ void process_player_hp_mp(player_type *player_ptr)
         if (player_ptr->regenerate) {
             regen_amount = regen_amount * 2;
         }
-        if (!PlayerClass(player_ptr).monk_stance_is(MonkStance::NONE) || !PlayerClass(player_ptr).kata_is(SamuraiKata::NONE)) {
+        if (!PlayerClass(player_ptr).monk_stance_is(MonkStance::NONE) || !PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::NONE)) {
             regen_amount /= 2;
         }
         if (player_ptr->cursed.has(TRC::SLOW_REGEN)) {
@@ -299,7 +299,7 @@ void process_player_hp_mp(player_type *player_ptr)
     }
 
     upkeep_factor = calculate_upkeep(player_ptr);
-    if ((player_ptr->action == ACTION_LEARN) || (player_ptr->action == ACTION_HAYAGAKE) || PlayerClass(player_ptr).kata_is(SamuraiKata::KOUKIJIN)) {
+    if ((player_ptr->action == ACTION_LEARN) || (player_ptr->action == ACTION_HAYAGAKE) || PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::KOUKIJIN)) {
         upkeep_factor += 100;
     }
 

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -23,6 +23,7 @@
 #include "pet/pet-util.h"
 #include "player-base/player-class.h"
 #include "player-base/player-race.h"
+#include "player-info/monk-data-type.h"
 #include "player-info/race-info.h"
 #include "player-info/race-types.h"
 #include "player-info/samurai-data-type.h"
@@ -285,7 +286,7 @@ void process_player_hp_mp(player_type *player_ptr)
         if (player_ptr->regenerate) {
             regen_amount = regen_amount * 2;
         }
-        if ((player_ptr->special_defense & (KAMAE_MASK)) || !PlayerClass(player_ptr).kata_is(SamuraiKata::NONE)) {
+        if (!PlayerClass(player_ptr).kamae_is(MonkKamae::NONE) || !PlayerClass(player_ptr).kata_is(SamuraiKata::NONE)) {
             regen_amount /= 2;
         }
         if (player_ptr->cursed.has(TRC::SLOW_REGEN)) {

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -286,7 +286,7 @@ void process_player_hp_mp(player_type *player_ptr)
         if (player_ptr->regenerate) {
             regen_amount = regen_amount * 2;
         }
-        if (!PlayerClass(player_ptr).kamae_is(MonkKamae::NONE) || !PlayerClass(player_ptr).kata_is(SamuraiKata::NONE)) {
+        if (!PlayerClass(player_ptr).monk_stance_is(MonkStance::NONE) || !PlayerClass(player_ptr).kata_is(SamuraiKata::NONE)) {
             regen_amount /= 2;
         }
         if (player_ptr->cursed.has(TRC::SLOW_REGEN)) {

--- a/src/hpmp/hp-mp-regenerator.cpp
+++ b/src/hpmp/hp-mp-regenerator.cpp
@@ -28,7 +28,7 @@ int wild_regen = 20;
  */
 void regenhp(player_type *player_ptr, int percent)
 {
-    if (PlayerClass(player_ptr).kata_is(SamuraiKata::KOUKIJIN))
+    if (PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::KOUKIJIN))
         return;
     if (player_ptr->action == ACTION_HAYAGAKE)
         return;

--- a/src/io/input-key-processor.cpp
+++ b/src/io/input-key-processor.cpp
@@ -614,7 +614,7 @@ void process_command(player_type *player_ptr)
     case '`': {
         if (!player_ptr->wild_mode)
             do_cmd_travel(player_ptr);
-        PlayerClass(player_ptr).break_kata({ SamuraiKata::MUSOU });
+        PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::MUSOU });
 
         break;
     }

--- a/src/load/player-attack-loader.cpp
+++ b/src/load/player-attack-loader.cpp
@@ -22,8 +22,8 @@ void rd_special_attack(player_type *player_ptr)
 
 void rd_special_action(player_type *player_ptr)
 {
-    if (!PlayerClass(player_ptr).kamae_is(MonkKamae::NONE)) {
-        player_ptr->action = ACTION_KAMAE;
+    if (!PlayerClass(player_ptr).monk_stance_is(MonkStance::NONE)) {
+        player_ptr->action = ACTION_MONK_STANCE;
         return;
     }
 

--- a/src/load/player-attack-loader.cpp
+++ b/src/load/player-attack-loader.cpp
@@ -3,6 +3,7 @@
 #include "load/load-util.h"
 #include "load/load-zangband.h"
 #include "player-base/player-class.h"
+#include "player-info/monk-data-type.h"
 #include "player-info/samurai-data-type.h"
 #include "player/attack-defense-types.h"
 #include "player/special-defense-types.h"
@@ -21,7 +22,7 @@ void rd_special_attack(player_type *player_ptr)
 
 void rd_special_action(player_type *player_ptr)
 {
-    if (player_ptr->special_attack & KAMAE_MASK) {
+    if (!PlayerClass(player_ptr).kamae_is(MonkKamae::NONE)) {
         player_ptr->action = ACTION_KAMAE;
         return;
     }

--- a/src/load/player-attack-loader.cpp
+++ b/src/load/player-attack-loader.cpp
@@ -27,8 +27,8 @@ void rd_special_action(player_type *player_ptr)
         return;
     }
 
-    if (!PlayerClass(player_ptr).kata_is(SamuraiKata::NONE)) {
-        player_ptr->action = ACTION_KATA;
+    if (!PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::NONE)) {
+        player_ptr->action = ACTION_SAMURAI_STANCE;
     }
 }
 

--- a/src/load/player-class-specific-data-loader.cpp
+++ b/src/load/player-class-specific-data-loader.cpp
@@ -5,6 +5,7 @@
 #include "player-info/force-trainer-data-type.h"
 #include "player-info/magic-eater-data-type.h"
 #include "player-info/mane-data-type.h"
+#include "player-info/monk-data-type.h"
 #include "player-info/samurai-data-type.h"
 #include "player-info/smith-data-type.h"
 #include "player-info/sniper-data-type.h"
@@ -181,9 +182,18 @@ void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<samurai_data_type
         byte tmp8u;
         rd_byte(&tmp8u);
         samurai_data->kata = i2enum<SamuraiKata>(tmp8u);
-        if (samurai_data->kata != SamuraiKata::NONE) {
-            
-        }
+    }
+}
+
+void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<monk_data_type> &monk_data) const
+{
+    if (loading_savefile_version_is_older_than(9)) {
+        // 古いセーブファイルの修行僧のデータは magic_num には保存されていないので読み捨てる
+        load_old_savfile_magic_num();
+    } else {
+        byte tmp8u;
+        rd_byte(&tmp8u);
+        monk_data->kamae = i2enum<MonkKamae>(tmp8u);
     }
 }
 

--- a/src/load/player-class-specific-data-loader.cpp
+++ b/src/load/player-class-specific-data-loader.cpp
@@ -181,7 +181,7 @@ void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<samurai_data_type
     } else {
         byte tmp8u;
         rd_byte(&tmp8u);
-        samurai_data->kata = i2enum<SamuraiKata>(tmp8u);
+        samurai_data->stance = i2enum<SamuraiStance>(tmp8u);
     }
 }
 

--- a/src/load/player-class-specific-data-loader.cpp
+++ b/src/load/player-class-specific-data-loader.cpp
@@ -193,7 +193,7 @@ void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<monk_data_type> &
     } else {
         byte tmp8u;
         rd_byte(&tmp8u);
-        monk_data->kamae = i2enum<MonkKamae>(tmp8u);
+        monk_data->stance = i2enum<MonkStance>(tmp8u);
     }
 }
 

--- a/src/load/player-class-specific-data-loader.h
+++ b/src/load/player-class-specific-data-loader.h
@@ -12,6 +12,7 @@ struct bard_data_type;
 struct mane_data_type;
 struct sniper_data_type;
 struct samurai_data_type;
+struct monk_data_type;
 struct spell_hex_data_type;
 
 class PlayerClassSpecificDataLoader {
@@ -26,4 +27,5 @@ public:
     void operator()(std::shared_ptr<mane_data_type> &mane_data) const;
     void operator()(std::shared_ptr<sniper_data_type> &sniper_data) const;
     void operator()(std::shared_ptr<samurai_data_type> &samurai_data) const;
+    void operator()(std::shared_ptr<monk_data_type> &monk_data) const;
 };

--- a/src/mind/mind-monk.cpp
+++ b/src/mind/mind-monk.cpp
@@ -14,11 +14,11 @@
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 
-static void set_stance(player_type *player_ptr, const MonkKamae new_stance)
+static void set_stance(player_type *player_ptr, const MonkStance new_stance)
 {
-    set_action(player_ptr, ACTION_KAMAE);
+    set_action(player_ptr, ACTION_MONK_STANCE);
     PlayerClass pc(player_ptr);
-    if (pc.kamae_is(new_stance)) {
+    if (pc.monk_stance_is(new_stance)) {
         msg_print(_("構え直した。", "You reassume a stance."));
         return;
     }
@@ -26,7 +26,7 @@ static void set_stance(player_type *player_ptr, const MonkKamae new_stance)
     player_ptr->update |= PU_BONUS;
     player_ptr->redraw |= PR_STATE;
     msg_format(_("%sの構えをとった。", "You assume the %s stance."), monk_stances[enum2i(new_stance) - 1].desc);
-    pc.set_kamae(new_stance);
+    pc.set_monk_stance(new_stance);
 }
 
 /*!
@@ -51,7 +51,7 @@ bool choose_monk_stance(player_type *player_ptr)
     prt("", 1, 0);
     prt(_("        どの構えをとりますか？", "        Choose Stance: "), 1, 14);
 
-    auto new_stance = MonkKamae::NONE;
+    auto new_stance = MonkStance::NONE;
     while (true) {
         char choice = inkey();
         if (choice == ESCAPE) {
@@ -60,7 +60,7 @@ bool choose_monk_stance(player_type *player_ptr)
         }
         
         if ((choice == 'a') || (choice == 'A')) {
-            if (player_ptr->action == ACTION_KAMAE) {
+            if (player_ptr->action == ACTION_MONK_STANCE) {
                 set_action(player_ptr, ACTION_NONE);
             } else
                 msg_print(_("もともと構えていない。", "You are not in a special stance."));
@@ -69,16 +69,16 @@ bool choose_monk_stance(player_type *player_ptr)
         }
         
         if ((choice == 'b') || (choice == 'B')) {
-            new_stance = MonkKamae::GENBU;
+            new_stance = MonkStance::GENBU;
             break;
         } else if (((choice == 'c') || (choice == 'C')) && (player_ptr->lev > 29)) {
-            new_stance = MonkKamae::BYAKKO;
+            new_stance = MonkStance::BYAKKO;
             break;
         } else if (((choice == 'd') || (choice == 'D')) && (player_ptr->lev > 34)) {
-            new_stance = MonkKamae::SEIRYU;
+            new_stance = MonkStance::SEIRYU;
             break;
         } else if (((choice == 'e') || (choice == 'E')) && (player_ptr->lev > 39)) {
-            new_stance = MonkKamae::SUZAKU;
+            new_stance = MonkStance::SUZAKU;
             break;
         }
     }

--- a/src/mind/mind-monk.cpp
+++ b/src/mind/mind-monk.cpp
@@ -4,6 +4,8 @@
 #include "core/player-update-types.h"
 #include "io/input-key-acceptor.h"
 #include "mind/stances-table.h"
+#include "player-base/player-class.h"
+#include "player-info/monk-data-type.h"
 #include "player/attack-defense-types.h"
 #include "player/special-defense-types.h"
 #include "status/action-setter.h"
@@ -12,19 +14,19 @@
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 
-static void set_stance(player_type *player_ptr, const int new_stance)
+static void set_stance(player_type *player_ptr, const MonkKamae new_stance)
 {
     set_action(player_ptr, ACTION_KAMAE);
-    if (player_ptr->special_defense & (KAMAE_GENBU << new_stance)) {
+    PlayerClass pc(player_ptr);
+    if (pc.kamae_is(new_stance)) {
         msg_print(_("構え直した。", "You reassume a stance."));
         return;
     }
 
-    player_ptr->special_defense &= ~(KAMAE_MASK);
     player_ptr->update |= PU_BONUS;
     player_ptr->redraw |= PR_STATE;
-    msg_format(_("%sの構えをとった。", "You assume the %s stance."), monk_stances[new_stance].desc);
-    player_ptr->special_defense |= (KAMAE_GENBU << new_stance);
+    msg_format(_("%sの構えをとった。", "You assume the %s stance."), monk_stances[enum2i(new_stance) - 1].desc);
+    pc.set_kamae(new_stance);
 }
 
 /*!
@@ -38,7 +40,7 @@ bool choose_monk_stance(player_type *player_ptr)
 
     screen_save();
     prt(_(" a) 構えをとく", " a) No form"), 2, 20);
-    for (int i = 0; i < MAX_KAMAE; i++) {
+    for (auto i = 0U; i < monk_stances.size(); i++) {
         if (player_ptr->lev >= monk_stances[i].min_level) {
             char buf[80];
             sprintf(buf, " %c) %-12s  %s", I2A(i + 1), monk_stances[i].desc, monk_stances[i].info);
@@ -49,7 +51,7 @@ bool choose_monk_stance(player_type *player_ptr)
     prt("", 1, 0);
     prt(_("        どの構えをとりますか？", "        Choose Stance: "), 1, 14);
 
-    int new_stance = 0;
+    auto new_stance = MonkKamae::NONE;
     while (true) {
         char choice = inkey();
         if (choice == ESCAPE) {
@@ -67,16 +69,16 @@ bool choose_monk_stance(player_type *player_ptr)
         }
         
         if ((choice == 'b') || (choice == 'B')) {
-            new_stance = 0;
+            new_stance = MonkKamae::GENBU;
             break;
         } else if (((choice == 'c') || (choice == 'C')) && (player_ptr->lev > 29)) {
-            new_stance = 1;
+            new_stance = MonkKamae::BYAKKO;
             break;
         } else if (((choice == 'd') || (choice == 'D')) && (player_ptr->lev > 34)) {
-            new_stance = 2;
+            new_stance = MonkKamae::SEIRYU;
             break;
         } else if (((choice == 'e') || (choice == 'E')) && (player_ptr->lev > 39)) {
-            new_stance = 3;
+            new_stance = MonkKamae::SUZAKU;
             break;
         }
     }

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -315,7 +315,7 @@ void concentration(player_type *player_ptr)
         return;
     }
 
-    if (!PlayerClass(player_ptr).kata_is(SamuraiKata::NONE)) {
+    if (!PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::NONE)) {
         msg_print(_("今は構えに集中している。", "You're already concentrating on your stance."));
         return;
     }
@@ -335,7 +335,7 @@ void concentration(player_type *player_ptr)
  * @brief 剣術家の型設定処理
  * @return 型を変化させたらTRUE、型の構え不能かキャンセルしたらFALSEを返す。
  */
-bool choose_kata(player_type *player_ptr)
+bool choose_samurai_stance(player_type *player_ptr)
 {
     char choice;
     char buf[80];
@@ -366,7 +366,7 @@ bool choose_kata(player_type *player_ptr)
     prt("", 1, 0);
     prt(_("        どの型で構えますか？", "        Choose Stance: "), 1, 14);
 
-    SamuraiKata new_kata = SamuraiKata::NONE;
+    SamuraiStance new_stance = SamuraiStance::NONE;
     while (true) {
         choice = inkey();
 
@@ -374,34 +374,34 @@ bool choose_kata(player_type *player_ptr)
             screen_load();
             return false;
         } else if ((choice == 'a') || (choice == 'A')) {
-            if (player_ptr->action == ACTION_KATA) {
+            if (player_ptr->action == ACTION_SAMURAI_STANCE) {
                 set_action(player_ptr, ACTION_NONE);
             } else
                 msg_print(_("もともと構えていない。", "You are not in a special stance."));
             screen_load();
             return true;
         } else if ((choice == 'b') || (choice == 'B')) {
-            new_kata = SamuraiKata::IAI;
+            new_stance = SamuraiStance::IAI;
             break;
         } else if (((choice == 'c') || (choice == 'C')) && (player_ptr->lev > 29)) {
-            new_kata = SamuraiKata::FUUJIN;
+            new_stance = SamuraiStance::FUUJIN;
             break;
         } else if (((choice == 'd') || (choice == 'D')) && (player_ptr->lev > 34)) {
-            new_kata = SamuraiKata::KOUKIJIN;
+            new_stance = SamuraiStance::KOUKIJIN;
             break;
         } else if (((choice == 'e') || (choice == 'E')) && (player_ptr->lev > 39)) {
-            new_kata = SamuraiKata::MUSOU;
+            new_stance = SamuraiStance::MUSOU;
             break;
         }
     }
 
-    set_action(player_ptr, ACTION_KATA);
-    if (PlayerClass(player_ptr).kata_is(new_kata)) {
+    set_action(player_ptr, ACTION_SAMURAI_STANCE);
+    if (PlayerClass(player_ptr).samurai_stance_is(new_stance)) {
         msg_print(_("構え直した。", "You reassume a stance."));
     } else {
         player_ptr->update |= (PU_BONUS | PU_MONSTERS);
-        msg_format(_("%sの型で構えた。", "You assume the %s stance."), samurai_stances[enum2i(new_kata) - 1].desc);
-        PlayerClass(player_ptr).set_kata(new_kata);
+        msg_format(_("%sの型で構えた。", "You assume the %s stance."), samurai_stances[enum2i(new_stance) - 1].desc);
+        PlayerClass(player_ptr).set_samurai_stance(new_stance);
     }
 
     player_ptr->redraw |= (PR_STATE | PR_STATUS);
@@ -423,7 +423,7 @@ int calc_attack_quality(player_type *player_ptr, player_attack_type *pa_ptr)
     if (pa_ptr->mode == HISSATSU_IAI)
         chance += 60;
 
-    if (PlayerClass(player_ptr).kata_is(SamuraiKata::KOUKIJIN)) {
+    if (PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::KOUKIJIN)) {
         chance += 150;
     }
 
@@ -473,7 +473,7 @@ void mineuchi(player_type *player_ptr, player_attack_type *pa_ptr)
  */
 void musou_counterattack(player_type *player_ptr, monap_type *monap_ptr)
 {
-    if ((!player_ptr->counter && !PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU)) || !monap_ptr->alive || player_ptr->is_dead || !monap_ptr->m_ptr->ml
+    if ((!player_ptr->counter && !PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::MUSOU)) || !monap_ptr->alive || player_ptr->is_dead || !monap_ptr->m_ptr->ml
         || (player_ptr->csp <= 7))
         return;
 

--- a/src/mind/mind-samurai.h
+++ b/src/mind/mind-samurai.h
@@ -11,7 +11,7 @@ struct player_attack_type;
 struct player_type;
 MULTIPLY mult_hissatsu(player_type *player_ptr, MULTIPLY mult, const TrFlags &flgs, monster_type *m_ptr, combat_options mode);
 void concentration(player_type *player_ptr);
-bool choose_kata(player_type* player_ptr);
+bool choose_samurai_stance(player_type* player_ptr);
 int calc_attack_quality(player_type *player_ptr, player_attack_type *pa_ptr);
 void mineuchi(player_type *player_ptr, player_attack_type *pa_ptr);
 void musou_counterattack(player_type *player_ptr, monap_type *monap_ptr);

--- a/src/mind/monk-attack.cpp
+++ b/src/mind/monk-attack.cpp
@@ -21,6 +21,8 @@
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
 #include "player-attack/player-attack-util.h"
+#include "player-base/player-class.h"
+#include "player-info/monk-data-type.h"
 #include "player/attack-defense-types.h"
 #include "player/special-defense-types.h"
 #include "system/floor-type-definition.h"
@@ -70,13 +72,14 @@ static int calc_stun_resistance(player_attack_type *pa_ptr)
  */
 static int calc_max_blow_selection_times(player_type *player_ptr)
 {
-    if (player_ptr->special_defense & KAMAE_BYAKKO)
+    PlayerClass pc(player_ptr);
+    if (pc.kamae_is(MonkKamae::BYAKKO))
         return (player_ptr->lev < 3 ? 1 : player_ptr->lev / 3);
 
-    if (player_ptr->special_defense & KAMAE_SUZAKU)
+    if (pc.kamae_is(MonkKamae::SUZAKU))
         return 1;
 
-    if (player_ptr->special_defense & KAMAE_GENBU)
+    if (pc.kamae_is(MonkKamae::GENBU))
         return 1;
 
     return player_ptr->lev < 7 ? 1 : player_ptr->lev / 7;
@@ -159,7 +162,7 @@ static int process_monk_additional_effect(player_attack_type *pa_ptr, int *stun_
 static WEIGHT calc_monk_attack_weight(player_type *player_ptr)
 {
     WEIGHT weight = 8;
-    if (player_ptr->special_defense & KAMAE_SUZAKU)
+    if (PlayerClass(player_ptr).kamae_is(MonkKamae::SUZAKU))
         weight = 4;
 
     if ((player_ptr->pclass == CLASS_FORCETRAINER) && (get_current_ki(player_ptr) != 0)) {

--- a/src/mind/monk-attack.cpp
+++ b/src/mind/monk-attack.cpp
@@ -73,13 +73,13 @@ static int calc_stun_resistance(player_attack_type *pa_ptr)
 static int calc_max_blow_selection_times(player_type *player_ptr)
 {
     PlayerClass pc(player_ptr);
-    if (pc.kamae_is(MonkKamae::BYAKKO))
+    if (pc.monk_stance_is(MonkStance::BYAKKO))
         return (player_ptr->lev < 3 ? 1 : player_ptr->lev / 3);
 
-    if (pc.kamae_is(MonkKamae::SUZAKU))
+    if (pc.monk_stance_is(MonkStance::SUZAKU))
         return 1;
 
-    if (pc.kamae_is(MonkKamae::GENBU))
+    if (pc.monk_stance_is(MonkStance::GENBU))
         return 1;
 
     return player_ptr->lev < 7 ? 1 : player_ptr->lev / 7;
@@ -162,7 +162,7 @@ static int process_monk_additional_effect(player_attack_type *pa_ptr, int *stun_
 static WEIGHT calc_monk_attack_weight(player_type *player_ptr)
 {
     WEIGHT weight = 8;
-    if (PlayerClass(player_ptr).kamae_is(MonkKamae::SUZAKU))
+    if (PlayerClass(player_ptr).monk_stance_is(MonkStance::SUZAKU))
         weight = 4;
 
     if ((player_ptr->pclass == CLASS_FORCETRAINER) && (get_current_ki(player_ptr) != 0)) {

--- a/src/mind/stances-table.cpp
+++ b/src/mind/stances-table.cpp
@@ -3,7 +3,7 @@
 /*!
  * @brief 修行僧の構え能力テーブル
  */
-const blow_stance monk_stances[MAX_KAMAE] = {
+const std::vector<blow_stance> monk_stances = {
     { _("玄武", "Genbu"), 25, _("", "(Black Tortoise) ") },
     { _("白虎", "Byakko"), 30, _("", "(White Tiger) ") },
     { _("青竜", "Seiryuu"), 35, _("", "(Blue Dragon) ") },

--- a/src/mind/stances-table.h
+++ b/src/mind/stances-table.h
@@ -11,5 +11,5 @@ typedef struct blow_stance {
     concptr info;
 } blow_stance;
 
-extern const blow_stance monk_stances[MAX_KAMAE];
+extern const std::vector<blow_stance> monk_stances;
 extern const std::vector<blow_stance> samurai_stances;

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -471,7 +471,7 @@ static void postprocess_monster_blows(player_type *player_ptr, monap_type *monap
         msg_format(_("%^sは恐怖で逃げ出した！", "%^s flees in terror!"), monap_ptr->m_name);
     }
 
-    PlayerClass(player_ptr).break_kata({ SamuraiKata::IAI });
+    PlayerClass(player_ptr).break_samurai_stance({ SamuraiStance::IAI });
 }
 
 /*!
@@ -491,7 +491,7 @@ bool make_attack_normal(player_type *player_ptr, MONSTER_IDX m_idx)
     monap_ptr->rlev = ((r_ptr->level >= 1) ? r_ptr->level : 1);
     monster_desc(player_ptr, monap_ptr->m_name, monap_ptr->m_ptr, 0);
     monster_desc(player_ptr, monap_ptr->ddesc, monap_ptr->m_ptr, MD_WRONGDOER_NAME);
-    if (PlayerClass(player_ptr).kata_is(SamuraiKata::IAI)) {
+    if (PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::IAI)) {
         msg_format(_("相手が襲いかかる前に素早く武器を振るった。", "You took sen, drew and cut in one motion before %s moved."), monap_ptr->m_name);
         if (do_cmd_attack(player_ptr, monap_ptr->m_ptr->fy, monap_ptr->m_ptr->fx, HISSATSU_IAI)) {
             return true;

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -233,7 +233,7 @@ static bool update_weird_telepathy(player_type *player_ptr, um_type *um_ptr, MON
 static void update_telepathy_sight(player_type *player_ptr, um_type *um_ptr, MONSTER_IDX m_idx)
 {
     monster_race *r_ptr = &r_info[um_ptr->m_ptr->r_idx];
-    if (PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU)) {
+    if (PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::MUSOU)) {
         um_ptr->flag = true;
         um_ptr->m_ptr->mflag.set(MFLAG::ESP);
         if (is_original_ap(um_ptr->m_ptr) && !player_ptr->hallucinated)

--- a/src/player-ability/player-charisma.cpp
+++ b/src/player-ability/player-charisma.cpp
@@ -33,7 +33,7 @@ int16_t PlayerCharisma::battleform_value()
 {
     int16_t result = 0;
 
-    if (PlayerClass(player_ptr).kata_is(SamuraiKata::KOUKIJIN)) {
+    if (PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::KOUKIJIN)) {
         result += 5;
     }
 

--- a/src/player-ability/player-constitution.cpp
+++ b/src/player-ability/player-constitution.cpp
@@ -86,11 +86,11 @@ int16_t PlayerConstitution::battleform_value()
         result += 5;
     }
 
-    if (pc.kamae_is(MonkKamae::BYAKKO)) {
+    if (pc.monk_stance_is(MonkStance::BYAKKO)) {
         result -= 3;
-    } else if (pc.kamae_is(MonkKamae::GENBU)) {
+    } else if (pc.monk_stance_is(MonkStance::GENBU)) {
         result += 3;
-    } else if (pc.kamae_is(MonkKamae::SUZAKU)) {
+    } else if (pc.monk_stance_is(MonkStance::SUZAKU)) {
         result -= 2;
     }
     if (this->player_ptr->tsuyoshi) {

--- a/src/player-ability/player-constitution.cpp
+++ b/src/player-ability/player-constitution.cpp
@@ -4,6 +4,7 @@
 #include "player-base/player-class.h"
 #include "player-base/player-race.h"
 #include "player-info/class-info.h"
+#include "player-info/monk-data-type.h"
 #include "player-info/samurai-data-type.h"
 #include "player/player-personality.h"
 #include "player/race-info-table.h"
@@ -80,15 +81,16 @@ int16_t PlayerConstitution::battleform_value()
 {
     int16_t result = 0;
 
-    if (PlayerClass(player_ptr).kata_is(SamuraiKata::KOUKIJIN)) {
+    PlayerClass pc(player_ptr);
+    if (pc.kata_is(SamuraiKata::KOUKIJIN)) {
         result += 5;
     }
 
-    if (any_bits(this->player_ptr->special_defense, KAMAE_BYAKKO)) {
+    if (pc.kamae_is(MonkKamae::BYAKKO)) {
         result -= 3;
-    } else if (any_bits(this->player_ptr->special_defense, KAMAE_GENBU)) {
+    } else if (pc.kamae_is(MonkKamae::GENBU)) {
         result += 3;
-    } else if (any_bits(this->player_ptr->special_defense, KAMAE_SUZAKU)) {
+    } else if (pc.kamae_is(MonkKamae::SUZAKU)) {
         result -= 2;
     }
     if (this->player_ptr->tsuyoshi) {

--- a/src/player-ability/player-constitution.cpp
+++ b/src/player-ability/player-constitution.cpp
@@ -82,7 +82,7 @@ int16_t PlayerConstitution::battleform_value()
     int16_t result = 0;
 
     PlayerClass pc(player_ptr);
-    if (pc.kata_is(SamuraiKata::KOUKIJIN)) {
+    if (pc.samurai_stance_is(SamuraiStance::KOUKIJIN)) {
         result += 5;
     }
 

--- a/src/player-ability/player-dexterity.cpp
+++ b/src/player-ability/player-dexterity.cpp
@@ -85,11 +85,11 @@ int16_t PlayerDexterity::battleform_value()
         result += 5;
     }
 
-    if (pc.kamae_is(MonkKamae::BYAKKO)) {
+    if (pc.monk_stance_is(MonkStance::BYAKKO)) {
         result += 2;
-    } else if (pc.kamae_is(MonkKamae::GENBU)) {
+    } else if (pc.monk_stance_is(MonkStance::GENBU)) {
         result -= 2;
-    } else if (pc.kamae_is(MonkKamae::SUZAKU)) {
+    } else if (pc.monk_stance_is(MonkStance::SUZAKU)) {
         result += 2;
     }
 

--- a/src/player-ability/player-dexterity.cpp
+++ b/src/player-ability/player-dexterity.cpp
@@ -81,7 +81,7 @@ int16_t PlayerDexterity::battleform_value()
     int16_t result = 0;
 
     PlayerClass pc(player_ptr);
-    if (pc.kata_is(SamuraiKata::KOUKIJIN)) {
+    if (pc.samurai_stance_is(SamuraiStance::KOUKIJIN)) {
         result += 5;
     }
 

--- a/src/player-ability/player-dexterity.cpp
+++ b/src/player-ability/player-dexterity.cpp
@@ -4,6 +4,7 @@
 #include "player-base/player-class.h"
 #include "player-base/player-race.h"
 #include "player-info/class-info.h"
+#include "player-info/monk-data-type.h"
 #include "player-info/samurai-data-type.h"
 #include "player/player-personality.h"
 #include "player/race-info-table.h"
@@ -79,15 +80,16 @@ int16_t PlayerDexterity::battleform_value()
 {
     int16_t result = 0;
 
-    if (PlayerClass(player_ptr).kata_is(SamuraiKata::KOUKIJIN)) {
+    PlayerClass pc(player_ptr);
+    if (pc.kata_is(SamuraiKata::KOUKIJIN)) {
         result += 5;
     }
 
-    if (any_bits(this->player_ptr->special_defense, KAMAE_BYAKKO)) {
+    if (pc.kamae_is(MonkKamae::BYAKKO)) {
         result += 2;
-    } else if (any_bits(this->player_ptr->special_defense, KAMAE_GENBU)) {
+    } else if (pc.kamae_is(MonkKamae::GENBU)) {
         result -= 2;
-    } else if (any_bits(this->player_ptr->special_defense, KAMAE_SUZAKU)) {
+    } else if (pc.kamae_is(MonkKamae::SUZAKU)) {
         result += 2;
     }
 

--- a/src/player-ability/player-intelligence.cpp
+++ b/src/player-ability/player-intelligence.cpp
@@ -3,6 +3,7 @@
 #include "object/object-flags.h"
 #include "player-base/player-class.h"
 #include "player-info/class-info.h"
+#include "player-info/monk-data-type.h"
 #include "player-info/mimic-info-table.h"
 #include "player-info/samurai-data-type.h"
 #include "player/player-personality.h"
@@ -35,13 +36,14 @@ int16_t PlayerIntelligence::battleform_value()
 {
     int16_t result = 0;
 
-    if (PlayerClass(player_ptr).kata_is(SamuraiKata::KOUKIJIN)) {
+    PlayerClass pc(player_ptr);
+    if (pc.kata_is(SamuraiKata::KOUKIJIN)) {
         result += 5;
     }
 
-    if (any_bits(this->player_ptr->special_defense, KAMAE_GENBU)) {
+    if (pc.kamae_is(MonkKamae::GENBU)) {
         result -= 1;
-    } else if (any_bits(this->player_ptr->special_defense, KAMAE_SUZAKU)) {
+    } else if (pc.kamae_is(MonkKamae::SUZAKU)) {
         result += 1;
     }
 

--- a/src/player-ability/player-intelligence.cpp
+++ b/src/player-ability/player-intelligence.cpp
@@ -37,7 +37,7 @@ int16_t PlayerIntelligence::battleform_value()
     int16_t result = 0;
 
     PlayerClass pc(player_ptr);
-    if (pc.kata_is(SamuraiKata::KOUKIJIN)) {
+    if (pc.samurai_stance_is(SamuraiStance::KOUKIJIN)) {
         result += 5;
     }
 

--- a/src/player-ability/player-intelligence.cpp
+++ b/src/player-ability/player-intelligence.cpp
@@ -41,9 +41,9 @@ int16_t PlayerIntelligence::battleform_value()
         result += 5;
     }
 
-    if (pc.kamae_is(MonkKamae::GENBU)) {
+    if (pc.monk_stance_is(MonkStance::GENBU)) {
         result -= 1;
-    } else if (pc.kamae_is(MonkKamae::SUZAKU)) {
+    } else if (pc.monk_stance_is(MonkStance::SUZAKU)) {
         result += 1;
     }
 

--- a/src/player-ability/player-strength.cpp
+++ b/src/player-ability/player-strength.cpp
@@ -90,7 +90,7 @@ int16_t PlayerStrength::battleform_value()
     int16_t result = 0;
 
     PlayerClass pc(player_ptr);
-    if (pc.kata_is(SamuraiKata::KOUKIJIN)) {
+    if (pc.samurai_stance_is(SamuraiStance::KOUKIJIN)) {
         result += 5;
     }
 

--- a/src/player-ability/player-strength.cpp
+++ b/src/player-ability/player-strength.cpp
@@ -3,6 +3,7 @@
 #include "object/object-flags.h"
 #include "player-base/player-class.h"
 #include "player-base/player-race.h"
+#include "player-info/monk-data-type.h"
 #include "player-info/samurai-data-type.h"
 #include "player/player-personality.h"
 #include "player/race-info-table.h"
@@ -88,13 +89,14 @@ int16_t PlayerStrength::battleform_value()
 {
     int16_t result = 0;
 
-    if (PlayerClass(player_ptr).kata_is(SamuraiKata::KOUKIJIN)) {
+    PlayerClass pc(player_ptr);
+    if (pc.kata_is(SamuraiKata::KOUKIJIN)) {
         result += 5;
     }
 
-    if (any_bits(this->player_ptr->special_defense, KAMAE_BYAKKO)) {
+    if (pc.kamae_is(MonkKamae::BYAKKO)) {
         result += 2;
-    } else if (any_bits(this->player_ptr->special_defense, KAMAE_SUZAKU)) {
+    } else if (pc.kamae_is(MonkKamae::SUZAKU)) {
         result -= 2;
     }
 

--- a/src/player-ability/player-strength.cpp
+++ b/src/player-ability/player-strength.cpp
@@ -94,9 +94,9 @@ int16_t PlayerStrength::battleform_value()
         result += 5;
     }
 
-    if (pc.kamae_is(MonkKamae::BYAKKO)) {
+    if (pc.monk_stance_is(MonkStance::BYAKKO)) {
         result += 2;
-    } else if (pc.kamae_is(MonkKamae::SUZAKU)) {
+    } else if (pc.monk_stance_is(MonkStance::SUZAKU)) {
         result -= 2;
     }
 

--- a/src/player-ability/player-wisdom.cpp
+++ b/src/player-ability/player-wisdom.cpp
@@ -39,9 +39,9 @@ int16_t PlayerWisdom::battleform_value()
         result += 5;
     }
 
-    if (pc.kamae_is(MonkKamae::GENBU)) {
+    if (pc.monk_stance_is(MonkStance::GENBU)) {
         result -= 1;
-    } else if (pc.kamae_is(MonkKamae::SUZAKU)) {
+    } else if (pc.monk_stance_is(MonkStance::SUZAKU)) {
         result += 1;
     }
 

--- a/src/player-ability/player-wisdom.cpp
+++ b/src/player-ability/player-wisdom.cpp
@@ -35,7 +35,7 @@ int16_t PlayerWisdom::battleform_value()
     int16_t result = 0;
 
     PlayerClass pc(player_ptr);
-    if (pc.kata_is(SamuraiKata::KOUKIJIN)) {
+    if (pc.samurai_stance_is(SamuraiStance::KOUKIJIN)) {
         result += 5;
     }
 

--- a/src/player-ability/player-wisdom.cpp
+++ b/src/player-ability/player-wisdom.cpp
@@ -4,6 +4,7 @@
 #include "player-base/player-class.h"
 #include "player-info/class-info.h"
 #include "player-info/mimic-info-table.h"
+#include "player-info/monk-data-type.h"
 #include "player-info/samurai-data-type.h"
 #include "player/player-personality.h"
 #include "player/race-info-table.h"
@@ -33,13 +34,14 @@ int16_t PlayerWisdom::battleform_value()
 {
     int16_t result = 0;
 
-    if (PlayerClass(player_ptr).kata_is(SamuraiKata::KOUKIJIN)) {
+    PlayerClass pc(player_ptr);
+    if (pc.kata_is(SamuraiKata::KOUKIJIN)) {
         result += 5;
     }
 
-    if (any_bits(this->player_ptr->special_defense, KAMAE_GENBU)) {
+    if (pc.kamae_is(MonkKamae::GENBU)) {
         result -= 1;
-    } else if (any_bits(this->player_ptr->special_defense, KAMAE_SUZAKU)) {
+    } else if (pc.kamae_is(MonkKamae::SUZAKU)) {
         result += 1;
     }
 

--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -201,14 +201,14 @@ TrFlags PlayerClass::form_tr_flags() const
         break;
     }
 
-    switch (this->get_kamae()) {
-    case MonkKamae::GENBU:
+    switch (this->get_monk_stance()) {
+    case MonkStance::GENBU:
         flags.set(TR_REFLECT);
         break;
-    case MonkKamae::SUZAKU:
+    case MonkStance::SUZAKU:
         flags.set(TR_LEVITATION);
         break;
-    case MonkKamae::SEIRYU:
+    case MonkStance::SEIRYU:
         flags.set({ TR_RES_ACID, TR_RES_ELEC, TR_RES_FIRE, TR_RES_COLD, TR_RES_POIS });
         flags.set({ TR_SH_FIRE, TR_SH_ELEC, TR_SH_COLD });
         flags.set(TR_LEVITATION);
@@ -301,29 +301,29 @@ void PlayerClass::set_kata(SamuraiKata kata) const
     samurai_data->kata = kata;
 }
 
-MonkKamae PlayerClass::get_kamae() const
+MonkStance PlayerClass::get_monk_stance() const
 {
     auto monk_data = this->get_specific_data<monk_data_type>();
     if (!monk_data) {
-        return MonkKamae::NONE;
+        return MonkStance::NONE;
     }
 
-    return monk_data->kamae;
+    return monk_data->stance;
 }
 
-bool PlayerClass::kamae_is(MonkKamae kamae) const
+bool PlayerClass::monk_stance_is(MonkStance stance) const
 {
-    return this->get_kamae() == kamae;
+    return this->get_monk_stance() == stance;
 }
 
-void PlayerClass::set_kamae(MonkKamae kamae) const
+void PlayerClass::set_monk_stance(MonkStance stance) const
 {
     auto monk_data = this->get_specific_data<monk_data_type>();
     if (!monk_data) {
         return;
     }
 
-    monk_data->kamae = kamae;
+    monk_data->stance = stance;
 }
 
 /**

--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -14,6 +14,7 @@
 #include "player-info/force-trainer-data-type.h"
 #include "player-info/magic-eater-data-type.h"
 #include "player-info/mane-data-type.h"
+#include "player-info/monk-data-type.h"
 #include "player-info/samurai-data-type.h"
 #include "player-info/smith-data-type.h"
 #include "player-info/sniper-data-type.h"
@@ -200,6 +201,22 @@ TrFlags PlayerClass::form_tr_flags() const
         break;
     }
 
+    switch (this->get_kamae()) {
+    case MonkKamae::GENBU:
+        flags.set(TR_REFLECT);
+        break;
+    case MonkKamae::SUZAKU:
+        flags.set(TR_LEVITATION);
+        break;
+    case MonkKamae::SEIRYU:
+        flags.set({ TR_RES_ACID, TR_RES_ELEC, TR_RES_FIRE, TR_RES_COLD, TR_RES_POIS });
+        flags.set({ TR_SH_FIRE, TR_SH_ELEC, TR_SH_COLD });
+        flags.set(TR_LEVITATION);
+        break;
+    default:
+        break;
+    }
+
     return flags;
 }
 
@@ -284,6 +301,31 @@ void PlayerClass::set_kata(SamuraiKata kata) const
     samurai_data->kata = kata;
 }
 
+MonkKamae PlayerClass::get_kamae() const
+{
+    auto monk_data = this->get_specific_data<monk_data_type>();
+    if (!monk_data) {
+        return MonkKamae::NONE;
+    }
+
+    return monk_data->kamae;
+}
+
+bool PlayerClass::kamae_is(MonkKamae kamae) const
+{
+    return this->get_kamae() == kamae;
+}
+
+void PlayerClass::set_kamae(MonkKamae kamae) const
+{
+    auto monk_data = this->get_specific_data<monk_data_type>();
+    if (!monk_data) {
+        return;
+    }
+
+    monk_data->kamae = kamae;
+}
+
 /**
  * @brief プレイヤーの職業にで使用する職業固有データ領域を初期化する
  * @details 事前条件: player_type の職業や領域が決定済みであること
@@ -314,6 +356,9 @@ void PlayerClass::init_specific_data()
         break;
     case CLASS_SAMURAI:
         this->player_ptr->class_specific_data = std::make_shared<samurai_data_type>();
+        break;
+    case CLASS_MONK:
+        this->player_ptr->class_specific_data = std::make_shared<monk_data_type>();
         break;
     case CLASS_HIGH_MAGE:
         if (this->player_ptr->realm1 == REALM_HEX) {

--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -179,13 +179,13 @@ TrFlags PlayerClass::form_tr_flags() const
 {
     TrFlags flags;
 
-    switch (this->get_kata()) {
-    case SamuraiKata::FUUJIN:
+    switch (this->get_samurai_stance()) {
+    case SamuraiStance::FUUJIN:
         if (!this->player_ptr->blind) {
             flags.set(TR_REFLECT);
         }
         break;
-    case SamuraiKata::MUSOU:
+    case SamuraiStance::MUSOU:
         flags.set({ TR_RES_ACID, TR_RES_ELEC, TR_RES_FIRE, TR_RES_COLD, TR_RES_POIS });
         flags.set({ TR_REFLECT, TR_RES_FEAR, TR_RES_LITE, TR_RES_DARK, TR_RES_BLIND, TR_RES_CONF,
             TR_RES_SOUND, TR_RES_SHARDS, TR_RES_NETHER, TR_RES_NEXUS, TR_RES_CHAOS, TR_RES_DISEN,
@@ -194,7 +194,7 @@ TrFlags PlayerClass::form_tr_flags() const
         flags.set({ TR_SH_FIRE, TR_SH_ELEC, TR_SH_COLD });
         flags.set({ TR_SUST_STR, TR_SUST_INT, TR_SUST_WIS, TR_SUST_DEX, TR_SUST_CON, TR_SUST_CHR });
         break;
-    case SamuraiKata::KOUKIJIN:
+    case SamuraiStance::KOUKIJIN:
         flags.set({ TR_VUL_ACID, TR_VUL_ELEC, TR_VUL_FIRE, TR_VUL_COLD });
         break;
     default:
@@ -242,11 +242,11 @@ bool PlayerClass::lose_balance()
         return false;
     }
 
-    if (this->kata_is(SamuraiKata::NONE)) {
+    if (this->samurai_stance_is(SamuraiStance::NONE)) {
         return false;
     }
 
-    this->set_kata(SamuraiKata::NONE);
+    this->set_samurai_stance(SamuraiStance::NONE);
     this->player_ptr->update |= PU_BONUS;
     this->player_ptr->update |= PU_MONSTERS;
     this->player_ptr->redraw |= PR_STATE;
@@ -255,50 +255,50 @@ bool PlayerClass::lose_balance()
     return true;
 }
 
-SamuraiKata PlayerClass::get_kata() const
+SamuraiStance PlayerClass::get_samurai_stance() const
 {
     auto samurai_data = this->get_specific_data<samurai_data_type>();
     if (!samurai_data) {
-        return SamuraiKata::NONE;
+        return SamuraiStance::NONE;
     }
 
-    return samurai_data->kata;
+    return samurai_data->stance;
 }
 
-bool PlayerClass::kata_is(SamuraiKata kata) const
+bool PlayerClass::samurai_stance_is(SamuraiStance stance) const
 {
-    return this->get_kata() == kata;
+    return this->get_samurai_stance() == stance;
 }
 
 /**
  * @brief 剣術家の型を崩す
  *
- * @param kata_list 崩す型を指定する。取っている型が指定された型に含まれない場合は崩さない。
+ * @param stance_list 崩す型を指定する。取っている型が指定された型に含まれない場合は崩さない。
  */
-void PlayerClass::break_kata(std::initializer_list<SamuraiKata> kata_list)
+void PlayerClass::break_samurai_stance(std::initializer_list<SamuraiStance> stance_list)
 {
     auto samurai_data = this->get_specific_data<samurai_data_type>();
     if (!samurai_data) {
         return;
     }
 
-    for (auto kata : kata_list) {
-        if (samurai_data->kata == kata) {
+    for (auto stance : stance_list) {
+        if (samurai_data->stance == stance) {
             set_action(player_ptr, ACTION_NONE);
-            samurai_data->kata = SamuraiKata::NONE;
+            samurai_data->stance = SamuraiStance::NONE;
             break;
         }
     }
 }
 
-void PlayerClass::set_kata(SamuraiKata kata) const
+void PlayerClass::set_samurai_stance(SamuraiStance stance) const
 {
     auto samurai_data = this->get_specific_data<samurai_data_type>();
     if (!samurai_data) {
         return;
     }
 
-    samurai_data->kata = kata;
+    samurai_data->stance = stance;
 }
 
 MonkStance PlayerClass::get_monk_stance() const

--- a/src/player-base/player-class.h
+++ b/src/player-base/player-class.h
@@ -10,6 +10,7 @@
 #include <variant>
 
 enum class SamuraiKata : uint8_t;
+enum class MonkKamae : uint8_t;
 
 class PlayerClass {
 public:
@@ -28,6 +29,10 @@ public:
     SamuraiKata get_kata() const;
     bool kata_is(SamuraiKata kata) const;
     void set_kata(SamuraiKata kata) const;
+
+    MonkKamae get_kamae() const;
+    bool kamae_is(MonkKamae kamae) const;
+    void set_kamae(MonkKamae kamae) const;
 
     void init_specific_data();
     template <typename T>

--- a/src/player-base/player-class.h
+++ b/src/player-base/player-class.h
@@ -10,7 +10,7 @@
 #include <variant>
 
 enum class SamuraiKata : uint8_t;
-enum class MonkKamae : uint8_t;
+enum class MonkStance : uint8_t;
 
 class PlayerClass {
 public:
@@ -30,9 +30,9 @@ public:
     bool kata_is(SamuraiKata kata) const;
     void set_kata(SamuraiKata kata) const;
 
-    MonkKamae get_kamae() const;
-    bool kamae_is(MonkKamae kamae) const;
-    void set_kamae(MonkKamae kamae) const;
+    MonkStance get_monk_stance() const;
+    bool monk_stance_is(MonkStance stance) const;
+    void set_monk_stance(MonkStance stance) const;
 
     void init_specific_data();
     template <typename T>

--- a/src/player-base/player-class.h
+++ b/src/player-base/player-class.h
@@ -9,7 +9,7 @@
 #include <memory>
 #include <variant>
 
-enum class SamuraiKata : uint8_t;
+enum class SamuraiStance : uint8_t;
 enum class MonkStance : uint8_t;
 
 class PlayerClass {
@@ -25,10 +25,10 @@ public:
     bool is_wizard() const;
 
     bool lose_balance();
-    void break_kata(std::initializer_list<SamuraiKata> kata_list);
-    SamuraiKata get_kata() const;
-    bool kata_is(SamuraiKata kata) const;
-    void set_kata(SamuraiKata kata) const;
+    void break_samurai_stance(std::initializer_list<SamuraiStance> stance_list);
+    SamuraiStance get_samurai_stance() const;
+    bool samurai_stance_is(SamuraiStance stance) const;
+    void set_samurai_stance(SamuraiStance stance) const;
 
     MonkStance get_monk_stance() const;
     bool monk_stance_is(MonkStance stance) const;

--- a/src/player-info/class-specific-data.h
+++ b/src/player-info/class-specific-data.h
@@ -13,6 +13,7 @@ struct bard_data_type;
 struct mane_data_type;
 struct sniper_data_type;
 struct samurai_data_type;
+struct monk_data_type;
 struct spell_hex_data_type;
 
 using ClassSpecificData = std::variant<
@@ -26,6 +27,7 @@ using ClassSpecificData = std::variant<
     std::shared_ptr<mane_data_type>,
     std::shared_ptr<sniper_data_type>,
     std::shared_ptr<samurai_data_type>,
+    std::shared_ptr<monk_data_type>,
     std::shared_ptr<spell_hex_data_type>
 
     >;

--- a/src/player-info/monk-data-type.h
+++ b/src/player-info/monk-data-type.h
@@ -1,0 +1,15 @@
+﻿#pragma once
+
+#include "system/angband.h"
+
+enum class MonkKamae : uint8_t {
+    NONE = 0,
+    GENBU = 1, //!< 玄武の構え
+    BYAKKO = 2, //!< 白虎の構え
+    SEIRYU = 3, //!< 青竜の構え
+    SUZAKU = 4, //!< 朱雀の構え
+};
+
+struct monk_data_type {
+    MonkKamae kamae{};
+};

--- a/src/player-info/monk-data-type.h
+++ b/src/player-info/monk-data-type.h
@@ -2,7 +2,7 @@
 
 #include "system/angband.h"
 
-enum class MonkKamae : uint8_t {
+enum class MonkStance : uint8_t {
     NONE = 0,
     GENBU = 1, //!< 玄武の構え
     BYAKKO = 2, //!< 白虎の構え
@@ -11,5 +11,5 @@ enum class MonkKamae : uint8_t {
 };
 
 struct monk_data_type {
-    MonkKamae kamae{};
+    MonkStance stance{};
 };

--- a/src/player-info/samurai-data-type.h
+++ b/src/player-info/samurai-data-type.h
@@ -2,7 +2,7 @@
 
 #include "system/angband.h"
 
-enum class SamuraiKata : uint8_t {
+enum class SamuraiStance : uint8_t {
     NONE = 0,
     IAI = 1, //!< 居合の型
     FUUJIN = 2, //!< 風塵の型
@@ -11,5 +11,5 @@ enum class SamuraiKata : uint8_t {
 };
 
 struct samurai_data_type {
-    SamuraiKata kata{};
+    SamuraiStance stance{};
 };

--- a/src/player-status/player-speed.cpp
+++ b/src/player-status/player-speed.cpp
@@ -8,8 +8,10 @@
 #include "mutation/mutation-flag-types.h"
 #include "object-enchant/tr-types.h"
 #include "object/object-flags.h"
+#include "player-base/player-class.h"
 #include "player-base/player-race.h"
 #include "player-info/equipment-info.h"
+#include "player-info/monk-data-type.h"
 #include "player-info/race-info.h"
 #include "player/attack-defense-types.h"
 #include "player/digestion-processor.h"
@@ -234,7 +236,7 @@ int16_t PlayerSpeed::time_effect_value()
 int16_t PlayerSpeed::battleform_value()
 {
     int16_t result = 0;
-    if (any_bits(this->player_ptr->special_defense, KAMAE_SUZAKU))
+    if (PlayerClass(player_ptr).kamae_is(MonkKamae::SUZAKU))
         result += 10;
     return result;
 }

--- a/src/player-status/player-speed.cpp
+++ b/src/player-status/player-speed.cpp
@@ -236,7 +236,7 @@ int16_t PlayerSpeed::time_effect_value()
 int16_t PlayerSpeed::battleform_value()
 {
     int16_t result = 0;
-    if (PlayerClass(player_ptr).kamae_is(MonkKamae::SUZAKU))
+    if (PlayerClass(player_ptr).monk_stance_is(MonkStance::SUZAKU))
         result += 10;
     return result;
 }

--- a/src/player/attack-defense-types.h
+++ b/src/player/attack-defense-types.h
@@ -21,7 +21,7 @@ enum special_defense_type {
     ACTION_LEARN = 3, /*!< 持続行動: 青魔法ラーニング */
     ACTION_FISH = 4, /*!< 持続行動: 釣り */
     ACTION_MONK_STANCE = 5, /*!< 持続行動: 修行僧の構え */
-    ACTION_KATA = 6, /*!< 持続行動: 剣術家の型 */
+    ACTION_SAMURAI_STANCE = 6, /*!< 持続行動: 剣術家の型 */
     ACTION_SING = 7, /*!< 持続行動: 歌 */
     ACTION_HAYAGAKE = 8, /*!< 持続行動: 早駆け */
     ACTION_SPELL = 9, /*!< 持続行動: 呪術 */

--- a/src/player/attack-defense-types.h
+++ b/src/player/attack-defense-types.h
@@ -20,7 +20,7 @@ enum special_defense_type {
     ACTION_REST = 2, /*!< 持続行動: 休憩 */
     ACTION_LEARN = 3, /*!< 持続行動: 青魔法ラーニング */
     ACTION_FISH = 4, /*!< 持続行動: 釣り */
-    ACTION_KAMAE = 5, /*!< 持続行動: 修行僧の構え */
+    ACTION_MONK_STANCE = 5, /*!< 持続行動: 修行僧の構え */
     ACTION_KATA = 6, /*!< 持続行動: 剣術家の型 */
     ACTION_SING = 7, /*!< 持続行動: 歌 */
     ACTION_HAYAGAKE = 8, /*!< 持続行動: 早駆け */

--- a/src/player/digestion-processor.cpp
+++ b/src/player/digestion-processor.cpp
@@ -37,7 +37,7 @@ void starve_player(player_type *player_ptr)
         if (player_ptr->regenerate)
             digestion += 20;
         PlayerClass pc(player_ptr);
-        if (!pc.monk_stance_is(MonkStance::NONE) || !pc.kata_is(SamuraiKata::NONE))
+        if (!pc.monk_stance_is(MonkStance::NONE) || !pc.samurai_stance_is(SamuraiStance::NONE))
             digestion += 20;
         if (player_ptr->cursed.has(TRC::FAST_DIGEST))
             digestion += 30;

--- a/src/player/digestion-processor.cpp
+++ b/src/player/digestion-processor.cpp
@@ -11,6 +11,7 @@
 #include "main/sound-of-music.h"
 #include "object-enchant/trc-types.h"
 #include "player-base/player-class.h"
+#include "player-info/monk-data-type.h"
 #include "player-info/samurai-data-type.h"
 #include "player/player-damage.h"
 #include "player/player-status.h"
@@ -35,7 +36,8 @@ void starve_player(player_type *player_ptr)
         int digestion = SPEED_TO_ENERGY(player_ptr->pspeed);
         if (player_ptr->regenerate)
             digestion += 20;
-        if ((player_ptr->special_defense & (KAMAE_MASK)) || !PlayerClass(player_ptr).kata_is(SamuraiKata::NONE))
+        PlayerClass pc(player_ptr);
+        if (!pc.kamae_is(MonkKamae::NONE) || !pc.kata_is(SamuraiKata::NONE))
             digestion += 20;
         if (player_ptr->cursed.has(TRC::FAST_DIGEST))
             digestion += 30;

--- a/src/player/digestion-processor.cpp
+++ b/src/player/digestion-processor.cpp
@@ -37,7 +37,7 @@ void starve_player(player_type *player_ptr)
         if (player_ptr->regenerate)
             digestion += 20;
         PlayerClass pc(player_ptr);
-        if (!pc.kamae_is(MonkKamae::NONE) || !pc.kata_is(SamuraiKata::NONE))
+        if (!pc.monk_stance_is(MonkStance::NONE) || !pc.kata_is(SamuraiKata::NONE))
             digestion += 20;
         if (player_ptr->cursed.has(TRC::FAST_DIGEST))
             digestion += 30;

--- a/src/player/permanent-resistances.cpp
+++ b/src/player/permanent-resistances.cpp
@@ -74,31 +74,6 @@ static void add_personality_flags(player_type *player_ptr, TrFlags &flags)
 }
 
 /*!
- * @brief 剣術家の型による耐性フラグを返す
- * @param player_ptr プレイヤーへの参照ポインタ
- * @param flags 耐性フラグの配列
- * @todo 最終的にplayer-status系列と統合する
- */
-static void add_kata_flags(player_type *player_ptr, TrFlags &flags)
-{
-    if (player_ptr->special_defense & KAMAE_GENBU)
-        flags.set(TR_REFLECT);
-    if (player_ptr->special_defense & KAMAE_SUZAKU)
-        flags.set(TR_LEVITATION);
-    if (player_ptr->special_defense & KAMAE_SEIRYU) {
-        flags.set(TR_RES_FIRE);
-        flags.set(TR_RES_COLD);
-        flags.set(TR_RES_ACID);
-        flags.set(TR_RES_ELEC);
-        flags.set(TR_RES_POIS);
-        flags.set(TR_LEVITATION);
-        flags.set(TR_SH_FIRE);
-        flags.set(TR_SH_ELEC);
-        flags.set(TR_SH_COLD);
-    }
-}
-
-/*!
  * @brief プレイヤーの職業、種族に応じた耐性フラグを返す
  * Prints ratings on certain abilities
  * @param player_ptr プレイヤーへの参照ポインタ
@@ -116,7 +91,6 @@ void player_flags(player_type *player_ptr, TrFlags &flags)
 
     add_mutation_flags(player_ptr, flags);
     add_personality_flags(player_ptr, flags);
-    add_kata_flags(player_ptr, flags);
 }
 
 void riding_flags(player_type *player_ptr, TrFlags &flags, TrFlags &negative_flags)

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -281,7 +281,7 @@ int take_hit(player_type *player_ptr, int damage_type, HIT_POINT damage, concptr
 
     if (player_ptr->sutemi)
         damage *= 2;
-    if (PlayerClass(player_ptr).kata_is(SamuraiKata::IAI))
+    if (PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::IAI))
         damage += (damage + 4) / 5;
 
     if (damage_type != DAMAGE_USELIFE) {
@@ -321,7 +321,7 @@ int take_hit(player_type *player_ptr, int damage_type, HIT_POINT damage, concptr
             }
         }
 
-        if (PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU)) {
+        if (PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::MUSOU)) {
             damage /= 2;
             if ((damage == 0) && one_in_(2))
                 damage = 1;

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -745,10 +745,6 @@ BIT_FLAGS has_reflect(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_REFLECT);
 
-    if (player_ptr->special_defense & KAMAE_GENBU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
-
     if (player_ptr->ult_res || player_ptr->wraith_form || player_ptr->magicdef || player_ptr->tim_reflect) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
@@ -799,10 +795,6 @@ BIT_FLAGS has_sh_fire(player_type *player_ptr)
         result |= FLAG_CAUSE_MUTATION;
     }
 
-    if (player_ptr->special_defense & KAMAE_SEIRYU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
-
     if (SpellHex(player_ptr).is_spelling_specific(HEX_DEMON_AURA) || player_ptr->ult_res || player_ptr->tim_sh_fire) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
@@ -821,20 +813,12 @@ BIT_FLAGS has_sh_elec(player_type *player_ptr)
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
 
-    if (player_ptr->special_defense & KAMAE_SEIRYU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
-
     return result;
 }
 
 BIT_FLAGS has_sh_cold(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_SH_COLD);
-
-    if (player_ptr->special_defense & KAMAE_SEIRYU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
 
     if (player_ptr->ult_res || SpellHex(player_ptr).is_spelling_specific(HEX_ICE_ARMOR)) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
@@ -970,10 +954,6 @@ BIT_FLAGS has_levitation(player_type *player_ptr)
 
     if (player_ptr->muta.has(MUTA::WINGS)) {
         result |= FLAG_CAUSE_MUTATION;
-    }
-
-    if (player_ptr->special_defense & KAMAE_SEIRYU || player_ptr->special_defense & KAMAE_SUZAKU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
     }
 
     if (player_ptr->ult_res || player_ptr->magicdef) {
@@ -1152,10 +1132,6 @@ BIT_FLAGS has_resist_acid(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_ACID);
 
-    if (player_ptr->special_defense & KAMAE_SEIRYU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
-
     if (player_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
@@ -1179,10 +1155,6 @@ BIT_FLAGS has_vuln_acid(player_type *player_ptr)
 BIT_FLAGS has_resist_elec(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_ELEC);
-
-    if (player_ptr->special_defense & KAMAE_SEIRYU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
 
     if (player_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
@@ -1208,10 +1180,6 @@ BIT_FLAGS has_resist_fire(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_FIRE);
 
-    if (player_ptr->special_defense & KAMAE_SEIRYU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
-
     if (player_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
@@ -1236,10 +1204,6 @@ BIT_FLAGS has_resist_cold(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_COLD);
 
-    if (player_ptr->special_defense & KAMAE_SEIRYU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
-
     if (player_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
     }
@@ -1263,10 +1227,6 @@ BIT_FLAGS has_vuln_cold(player_type *player_ptr)
 BIT_FLAGS has_resist_pois(player_type *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_POIS);
-
-    if (player_ptr->special_defense & KAMAE_SEIRYU) {
-        result |= FLAG_CAUSE_BATTLE_FORM;
-    }
 
     if (player_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -1480,7 +1480,7 @@ static int16_t calc_num_blow(player_type *player_ptr, int i)
             else if ((player_ptr->pclass == CLASS_ROGUE) && (o_ptr->weight < 50) && (player_ptr->stat_index[A_DEX] >= 30))
                 num_blow++;
 
-            if (PlayerClass(player_ptr).kata_is(SamuraiKata::FUUJIN))
+            if (PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::FUUJIN))
                 num_blow -= 1;
 
             if ((o_ptr->tval == TV_SWORD) && (o_ptr->sval == SV_POISON_NEEDLE))
@@ -1745,11 +1745,11 @@ static ARMOUR_CLASS calc_to_ac(player_type *player_ptr, bool is_real_value)
         ac -= 40;
     } else if (pc.monk_stance_is(MonkStance::SEIRYU)) {
         ac -= 50;
-    } else if (pc.kata_is(SamuraiKata::KOUKIJIN)) {
+    } else if (pc.samurai_stance_is(SamuraiStance::KOUKIJIN)) {
         ac -= 50;
     }
 
-    if (player_ptr->ult_res || (pc.kata_is(SamuraiKata::MUSOU))) {
+    if (player_ptr->ult_res || (pc.samurai_stance_is(SamuraiStance::MUSOU))) {
         ac += 100;
     } else if (player_ptr->tsubureru || player_ptr->shield || player_ptr->magicdef) {
         ac += 50;

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -60,6 +60,7 @@
 #include "player-info/class-info.h"
 #include "player-info/equipment-info.h"
 #include "player-info/mimic-info-table.h"
+#include "player-info/monk-data-type.h"
 #include "player-info/samurai-data-type.h"
 #include "player-info/sniper-data-type.h"
 #include "player-status/player-basic-statistics.h"
@@ -353,7 +354,7 @@ static void update_bonuses(player_type *player_ptr)
 
     player_ptr->lite = has_lite(player_ptr);
 
-    if (any_bits(player_ptr->special_defense, KAMAE_MASK)) {
+    if (!PlayerClass(player_ptr).kamae_is(MonkKamae::NONE)) {
         if (none_bits(empty_hands_status, EMPTY_HAND_MAIN)) {
             set_action(player_ptr, ACTION_NONE);
         }
@@ -1526,13 +1527,14 @@ static int16_t calc_num_blow(player_type *player_ptr, int i)
         if (heavy_armor(player_ptr) && (player_ptr->pclass != CLASS_BERSERKER))
             num_blow /= 2;
 
-        if (any_bits(player_ptr->special_defense, KAMAE_GENBU)) {
+        PlayerClass pc(player_ptr);
+        if (pc.kamae_is(MonkKamae::GENBU)) {
             num_blow -= 2;
             if ((player_ptr->pclass == CLASS_MONK) && (player_ptr->lev > 42))
                 num_blow--;
             if (num_blow < 0)
                 num_blow = 0;
-        } else if (any_bits(player_ptr->special_defense, KAMAE_SUZAKU)) {
+        } else if (pc.kamae_is(MonkKamae::SUZAKU)) {
             num_blow /= 2;
         }
 
@@ -1737,11 +1739,11 @@ static ARMOUR_CLASS calc_to_ac(player_type *player_ptr, bool is_real_value)
     }
 
     PlayerClass pc(player_ptr);
-    if (any_bits(player_ptr->special_defense, KAMAE_GENBU)) {
+    if (pc.kamae_is(MonkKamae::GENBU)) {
         ac += (player_ptr->lev * player_ptr->lev) / 50;
-    } else if (any_bits(player_ptr->special_defense, KAMAE_BYAKKO)) {
+    } else if (pc.kamae_is(MonkKamae::BYAKKO)) {
         ac -= 40;
-    } else if (any_bits(player_ptr->special_defense, KAMAE_SEIRYU)) {
+    } else if (pc.kamae_is(MonkKamae::SEIRYU)) {
         ac -= 50;
     } else if (pc.kata_is(SamuraiKata::KOUKIJIN)) {
         ac -= 50;
@@ -2084,7 +2086,7 @@ static int16_t calc_to_damage(player_type *player_ptr, INVENTORY_IDX slot, bool 
     }
 
     // 朱雀の構えをとっているとき、格闘ダメージに -(レベル)/6 の修正を得る。
-    if (any_bits(player_ptr->special_defense, KAMAE_SUZAKU)) {
+    if (PlayerClass(player_ptr).kamae_is(MonkKamae::SUZAKU)) {
         if (is_martial_arts_mode(player_ptr) && calc_hand == PLAYER_HAND_MAIN) {
             damage -= (player_ptr->lev / 6);
         }
@@ -2310,7 +2312,7 @@ static int16_t calc_to_hit(player_type *player_ptr, INVENTORY_IDX slot, bool is_
     hit -= calc_double_weapon_penalty(player_ptr, slot);
 
     // 朱雀の構えをとっているとき、格闘命中に -(レベル)/3 の修正を得る。
-    if (any_bits(player_ptr->special_defense, KAMAE_SUZAKU)) {
+    if (PlayerClass(player_ptr).kamae_is(MonkKamae::SUZAKU)) {
         if (is_martial_arts_mode(player_ptr) && calc_hand == PLAYER_HAND_MAIN) {
             hit -= (player_ptr->lev / 3);
         }

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -354,7 +354,7 @@ static void update_bonuses(player_type *player_ptr)
 
     player_ptr->lite = has_lite(player_ptr);
 
-    if (!PlayerClass(player_ptr).kamae_is(MonkKamae::NONE)) {
+    if (!PlayerClass(player_ptr).monk_stance_is(MonkStance::NONE)) {
         if (none_bits(empty_hands_status, EMPTY_HAND_MAIN)) {
             set_action(player_ptr, ACTION_NONE);
         }
@@ -1528,13 +1528,13 @@ static int16_t calc_num_blow(player_type *player_ptr, int i)
             num_blow /= 2;
 
         PlayerClass pc(player_ptr);
-        if (pc.kamae_is(MonkKamae::GENBU)) {
+        if (pc.monk_stance_is(MonkStance::GENBU)) {
             num_blow -= 2;
             if ((player_ptr->pclass == CLASS_MONK) && (player_ptr->lev > 42))
                 num_blow--;
             if (num_blow < 0)
                 num_blow = 0;
-        } else if (pc.kamae_is(MonkKamae::SUZAKU)) {
+        } else if (pc.monk_stance_is(MonkStance::SUZAKU)) {
             num_blow /= 2;
         }
 
@@ -1739,11 +1739,11 @@ static ARMOUR_CLASS calc_to_ac(player_type *player_ptr, bool is_real_value)
     }
 
     PlayerClass pc(player_ptr);
-    if (pc.kamae_is(MonkKamae::GENBU)) {
+    if (pc.monk_stance_is(MonkStance::GENBU)) {
         ac += (player_ptr->lev * player_ptr->lev) / 50;
-    } else if (pc.kamae_is(MonkKamae::BYAKKO)) {
+    } else if (pc.monk_stance_is(MonkStance::BYAKKO)) {
         ac -= 40;
-    } else if (pc.kamae_is(MonkKamae::SEIRYU)) {
+    } else if (pc.monk_stance_is(MonkStance::SEIRYU)) {
         ac -= 50;
     } else if (pc.kata_is(SamuraiKata::KOUKIJIN)) {
         ac -= 50;
@@ -2086,7 +2086,7 @@ static int16_t calc_to_damage(player_type *player_ptr, INVENTORY_IDX slot, bool 
     }
 
     // 朱雀の構えをとっているとき、格闘ダメージに -(レベル)/6 の修正を得る。
-    if (PlayerClass(player_ptr).kamae_is(MonkKamae::SUZAKU)) {
+    if (PlayerClass(player_ptr).monk_stance_is(MonkStance::SUZAKU)) {
         if (is_martial_arts_mode(player_ptr) && calc_hand == PLAYER_HAND_MAIN) {
             damage -= (player_ptr->lev / 6);
         }
@@ -2312,7 +2312,7 @@ static int16_t calc_to_hit(player_type *player_ptr, INVENTORY_IDX slot, bool is_
     hit -= calc_double_weapon_penalty(player_ptr, slot);
 
     // 朱雀の構えをとっているとき、格闘命中に -(レベル)/3 の修正を得る。
-    if (PlayerClass(player_ptr).kamae_is(MonkKamae::SUZAKU)) {
+    if (PlayerClass(player_ptr).monk_stance_is(MonkStance::SUZAKU)) {
         if (is_martial_arts_mode(player_ptr) && calc_hand == PLAYER_HAND_MAIN) {
             hit -= (player_ptr->lev / 3);
         }

--- a/src/player/race-resistances.cpp
+++ b/src/player/race-resistances.cpp
@@ -104,7 +104,7 @@ void player_vulnerability_flags(player_type *player_ptr, TrFlags &flags)
 {
     flags.clear();
 
-    if (player_ptr->muta.has(MUTA::VULN_ELEM) || PlayerClass(player_ptr).kata_is(SamuraiKata::KOUKIJIN)) {
+    if (player_ptr->muta.has(MUTA::VULN_ELEM) || PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::KOUKIJIN)) {
         flags.set(TR_RES_ACID);
         flags.set(TR_RES_ELEC);
         flags.set(TR_RES_FIRE);

--- a/src/player/special-defense-types.h
+++ b/src/player/special-defense-types.h
@@ -6,13 +6,6 @@ enum special_defence {
     DEFENSE_FIRE = 0x00000004, /*!< プレイヤーのステータス:火炎免疫 */
     DEFENSE_COLD = 0x00000008, /*!< プレイヤーのステータス:冷気免疫 */
     DEFENSE_POIS = 0x00000010, /*!< プレイヤーのステータス:毒免疫 */
-    KAMAE_GENBU = 0x00000020, /*!< プレイヤーのステータス:玄武の構え */
-    KAMAE_BYAKKO = 0x00000040, /*!< プレイヤーのステータス:白虎の構え */
-    KAMAE_SEIRYU = 0x00000080, /*!< プレイヤーのステータス:青竜の構え */
-    KAMAE_SUZAKU = 0x00000100, /*!< プレイヤーのステータス:朱雀の構え */
     NINJA_KAWARIMI = 0x00002000, /*!< プレイヤーのステータス:変わり身 */
     NINJA_S_STEALTH = 0x00004000, /*!< プレイヤーのステータス:超隠密 */
 };
-
-#define MAX_KAMAE 4 /*!< 修行僧の構え最大数 */
-#define KAMAE_MASK (KAMAE_GENBU | KAMAE_BYAKKO | KAMAE_SEIRYU | KAMAE_SUZAKU) /*!< 修行僧の構えビット配列 */

--- a/src/racial/racial-switcher.cpp
+++ b/src/racial/racial-switcher.cpp
@@ -230,7 +230,7 @@ bool switch_class_racial_execution(player_type *player_ptr, const int32_t comman
             return false;
         }
 
-        if (!choose_kata(player_ptr))
+        if (!choose_samurai_stance(player_ptr))
             return false;
 
         set_bits(player_ptr->update, PU_BONUS);

--- a/src/save/player-class-specific-data-writer.cpp
+++ b/src/save/player-class-specific-data-writer.cpp
@@ -78,7 +78,7 @@ void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<samurai_dat
 
 void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<monk_data_type> &monk_data) const
 {
-    wr_byte(enum2i(monk_data->kamae));
+    wr_byte(enum2i(monk_data->stance));
 }
 
 void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<spell_hex_data_type> &spell_hex_data) const

--- a/src/save/player-class-specific-data-writer.cpp
+++ b/src/save/player-class-specific-data-writer.cpp
@@ -4,6 +4,7 @@
 #include "player-info/force-trainer-data-type.h"
 #include "player-info/magic-eater-data-type.h"
 #include "player-info/mane-data-type.h"
+#include "player-info/monk-data-type.h"
 #include "player-info/samurai-data-type.h"
 #include "player-info/smith-data-type.h"
 #include "player-info/sniper-data-type.h"
@@ -73,6 +74,11 @@ void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<sniper_data
 void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<samurai_data_type> &samurai_data) const
 {
     wr_byte(enum2i(samurai_data->kata));
+}
+
+void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<monk_data_type> &monk_data) const
+{
+    wr_byte(enum2i(monk_data->kamae));
 }
 
 void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<spell_hex_data_type> &spell_hex_data) const

--- a/src/save/player-class-specific-data-writer.cpp
+++ b/src/save/player-class-specific-data-writer.cpp
@@ -73,7 +73,7 @@ void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<sniper_data
 
 void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<samurai_data_type> &samurai_data) const
 {
-    wr_byte(enum2i(samurai_data->kata));
+    wr_byte(enum2i(samurai_data->stance));
 }
 
 void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<monk_data_type> &monk_data) const

--- a/src/save/player-class-specific-data-writer.h
+++ b/src/save/player-class-specific-data-writer.h
@@ -12,6 +12,7 @@ struct bard_data_type;
 struct mane_data_type;
 struct sniper_data_type;
 struct samurai_data_type;
+struct monk_data_type;
 
 class PlayerClassSpecificDataWriter {
 public:
@@ -25,4 +26,5 @@ public:
     void operator()(const std::shared_ptr<mane_data_type> &mane_data) const;
     void operator()(const std::shared_ptr<sniper_data_type> &sniper_data) const;
     void operator()(const std::shared_ptr<samurai_data_type> &samurai_data) const;
+    void operator()(const std::shared_ptr<monk_data_type> &monk_data) const;
 };

--- a/src/status/action-setter.cpp
+++ b/src/status/action-setter.cpp
@@ -29,7 +29,7 @@
 /*!
  * @brief プレイヤーの継続行動を設定する。
  * @param typ 継続行動のID\n
- * #ACTION_NONE / #ACTION_SEARCH / #ACTION_REST / #ACTION_LEARN / #ACTION_FISH / #ACTION_MONK_STANCE / #ACTION_KATA / #ACTION_SING / #ACTION_HAYAGAKE / #ACTION_SPELL
+ * #ACTION_NONE / #ACTION_SEARCH / #ACTION_REST / #ACTION_LEARN / #ACTION_FISH / #ACTION_MONK_STANCE / #ACTION_SAMURAI_STANCE / #ACTION_SING / #ACTION_HAYAGAKE / #ACTION_SPELL
  * から選択。
  */
 void set_action(player_type *player_ptr, uint8_t typ)
@@ -60,9 +60,9 @@ void set_action(player_type *player_ptr, uint8_t typ)
         PlayerClass(player_ptr).set_monk_stance(MonkStance::NONE);
         break;
     }
-    case ACTION_KATA: {
+    case ACTION_SAMURAI_STANCE: {
         msg_print(_("型を崩した。", "You stop assuming the special stance."));
-        PlayerClass(player_ptr).set_kata(SamuraiKata::NONE);
+        PlayerClass(player_ptr).set_samurai_stance(SamuraiStance::NONE);
         player_ptr->update |= (PU_MONSTERS);
         player_ptr->redraw |= (PR_STATUS);
         break;

--- a/src/status/action-setter.cpp
+++ b/src/status/action-setter.cpp
@@ -29,7 +29,7 @@
 /*!
  * @brief プレイヤーの継続行動を設定する。
  * @param typ 継続行動のID\n
- * #ACTION_NONE / #ACTION_SEARCH / #ACTION_REST / #ACTION_LEARN / #ACTION_FISH / #ACTION_KAMAE / #ACTION_KATA / #ACTION_SING / #ACTION_HAYAGAKE / #ACTION_SPELL
+ * #ACTION_NONE / #ACTION_SEARCH / #ACTION_REST / #ACTION_LEARN / #ACTION_FISH / #ACTION_MONK_STANCE / #ACTION_KATA / #ACTION_SING / #ACTION_HAYAGAKE / #ACTION_SPELL
  * から選択。
  */
 void set_action(player_type *player_ptr, uint8_t typ)
@@ -55,9 +55,9 @@ void set_action(player_type *player_ptr, uint8_t typ)
         bluemage_data->new_magic_learned = false;
         break;
     }
-    case ACTION_KAMAE: {
+    case ACTION_MONK_STANCE: {
         msg_print(_("構えをといた。", "You stop assuming the special stance."));
-        PlayerClass(player_ptr).set_kamae(MonkKamae::NONE);
+        PlayerClass(player_ptr).set_monk_stance(MonkStance::NONE);
         break;
     }
     case ACTION_KATA: {

--- a/src/status/action-setter.cpp
+++ b/src/status/action-setter.cpp
@@ -16,6 +16,7 @@
 #include "core/player-update-types.h"
 #include "player-base/player-class.h"
 #include "player-info/bluemage-data-type.h"
+#include "player-info/monk-data-type.h"
 #include "player-info/samurai-data-type.h"
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
@@ -56,7 +57,7 @@ void set_action(player_type *player_ptr, uint8_t typ)
     }
     case ACTION_KAMAE: {
         msg_print(_("構えをといた。", "You stop assuming the special stance."));
-        player_ptr->special_defense &= ~(KAMAE_MASK);
+        PlayerClass(player_ptr).set_kamae(MonkKamae::NONE);
         break;
     }
     case ACTION_KATA: {

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -10,6 +10,7 @@
 #include "player-base/player-class.h"
 #include "player-base/player-race.h"
 #include "player-info/bluemage-data-type.h"
+#include "player-info/monk-data-type.h"
 #include "player/attack-defense-types.h"
 #include "player/player-status-flags.h"
 #include "player/player-status.h"
@@ -119,7 +120,7 @@ bool BadStatusSetter::confusion(const TIME_EFFECT tmp_v)
             }
             if (this->player_ptr->action == ACTION_KAMAE) {
                 msg_print(_("構えがとけた。", "You lose your stance."));
-                this->player_ptr->special_defense &= ~(KAMAE_MASK);
+                PlayerClass(player_ptr).set_kamae(MonkKamae::NONE);
                 this->player_ptr->update |= PU_BONUS;
                 this->player_ptr->redraw |= PR_STATE;
                 this->player_ptr->action = ACTION_NONE;

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -118,9 +118,9 @@ bool BadStatusSetter::confusion(const TIME_EFFECT tmp_v)
                 this->player_ptr->redraw |= PR_STATE;
                 this->player_ptr->action = ACTION_NONE;
             }
-            if (this->player_ptr->action == ACTION_KAMAE) {
+            if (this->player_ptr->action == ACTION_MONK_STANCE) {
                 msg_print(_("構えがとけた。", "You lose your stance."));
-                PlayerClass(player_ptr).set_kamae(MonkKamae::NONE);
+                PlayerClass(player_ptr).set_monk_stance(MonkStance::NONE);
                 this->player_ptr->update |= PU_BONUS;
                 this->player_ptr->redraw |= PR_STATE;
                 this->player_ptr->action = ACTION_NONE;

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -124,7 +124,7 @@ bool BadStatusSetter::confusion(const TIME_EFFECT tmp_v)
                 this->player_ptr->update |= PU_BONUS;
                 this->player_ptr->redraw |= PR_STATE;
                 this->player_ptr->action = ACTION_NONE;
-            } else if (this->player_ptr->action == ACTION_KATA) {
+            } else if (this->player_ptr->action == ACTION_SAMURAI_STANCE) {
                 msg_print(_("型が崩れた。", "You lose your stance."));
                 PlayerClass(player_ptr).lose_balance();
             }

--- a/src/status/element-resistance.cpp
+++ b/src/status/element-resistance.cpp
@@ -36,7 +36,7 @@ bool set_oppose_acid(player_type *player_ptr, TIME_EFFECT v, bool do_dec)
         }
     } else {
         if (player_ptr->oppose_acid && !music_singing(player_ptr, MUSIC_RESIST) &&
-            !PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU)) {
+            !PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::MUSOU)) {
             msg_print(_("酸への耐性が薄れた気がする。", "You feel less resistant to acid."));
             notice = true;
         }
@@ -78,7 +78,7 @@ bool set_oppose_elec(player_type *player_ptr, TIME_EFFECT v, bool do_dec)
         }
     } else {
         if (player_ptr->oppose_elec && !music_singing(player_ptr, MUSIC_RESIST) &&
-            !PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU)) {
+            !PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::MUSOU)) {
             msg_print(_("電撃への耐性が薄れた気がする。", "You feel less resistant to electricity."));
             notice = true;
         }
@@ -121,7 +121,7 @@ bool set_oppose_fire(player_type *player_ptr, TIME_EFFECT v, bool do_dec)
         }
     } else {
         if (player_ptr->oppose_fire && !music_singing(player_ptr, MUSIC_RESIST) &&
-            !PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU)) {
+            !PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::MUSOU)) {
             msg_print(_("火への耐性が薄れた気がする。", "You feel less resistant to fire."));
             notice = true;
         }
@@ -162,7 +162,7 @@ bool set_oppose_cold(player_type *player_ptr, TIME_EFFECT v, bool do_dec)
         }
     } else {
         if (player_ptr->oppose_cold && !music_singing(player_ptr, MUSIC_RESIST) &&
-            !PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU)) {
+            !PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::MUSOU)) {
             msg_print(_("冷気への耐性が薄れた気がする。", "You feel less resistant to cold."));
             notice = true;
         }
@@ -205,7 +205,7 @@ bool set_oppose_pois(player_type *player_ptr, TIME_EFFECT v, bool do_dec)
         }
     } else {
         if (player_ptr->oppose_pois && !music_singing(player_ptr, MUSIC_RESIST) &&
-            !PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU)) {
+            !PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::MUSOU)) {
             msg_print(_("毒への耐性が薄れた気がする。", "You feel less resistant to poison."));
             notice = true;
         }
@@ -224,28 +224,28 @@ bool set_oppose_pois(player_type *player_ptr, TIME_EFFECT v, bool do_dec)
 
 bool is_oppose_acid(player_type *player_ptr)
 {
-    return player_ptr->oppose_acid || music_singing(player_ptr, MUSIC_RESIST) || PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU);
+    return player_ptr->oppose_acid || music_singing(player_ptr, MUSIC_RESIST) || PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::MUSOU);
 }
 
 bool is_oppose_elec(player_type *player_ptr)
 {
-    return player_ptr->oppose_elec || music_singing(player_ptr, MUSIC_RESIST) || PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU);
+    return player_ptr->oppose_elec || music_singing(player_ptr, MUSIC_RESIST) || PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::MUSOU);
 }
 
 bool is_oppose_fire(player_type *player_ptr)
 {
     return player_ptr->oppose_fire || music_singing(player_ptr, MUSIC_RESIST)
-        || (PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU) || (player_ptr->mimic_form == MIMIC_DEMON)
+        || (PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::MUSOU) || (player_ptr->mimic_form == MIMIC_DEMON)
             || (PlayerRace(player_ptr).equals(player_race_type::BALROG) && player_ptr->lev > 44));
 }
 
 bool is_oppose_cold(player_type *player_ptr)
 {
-    return player_ptr->oppose_cold || music_singing(player_ptr, MUSIC_RESIST) || PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU);
+    return player_ptr->oppose_cold || music_singing(player_ptr, MUSIC_RESIST) || PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::MUSOU);
 }
 
 bool is_oppose_pois(player_type *player_ptr)
 {
     return player_ptr->oppose_pois || music_singing(player_ptr, MUSIC_RESIST)
-        || (PlayerClass(player_ptr).kata_is(SamuraiKata::MUSOU) || (player_ptr->pclass == CLASS_NINJA && player_ptr->lev > 44));
+        || (PlayerClass(player_ptr).samurai_stance_is(SamuraiStance::MUSOU) || (player_ptr->pclass == CLASS_NINJA && player_ptr->lev > 44));
 }

--- a/src/view/display-player-middle.cpp
+++ b/src/view/display-player-middle.cpp
@@ -72,15 +72,15 @@ static void display_sub_hand(player_type *player_ptr)
         return;
 
     PlayerClass pc(player_ptr);
-    if (pc.kamae_is(MonkKamae::NONE)) {
+    if (pc.monk_stance_is(MonkStance::NONE)) {
         display_player_one_line(ENTRY_POSTURE, _("構えなし", "none"), TERM_YELLOW);
         return;
     }
 
-    uint kamae_num = enum2i(pc.get_kamae()) - 1;
+    uint stance_num = enum2i(pc.get_monk_stance()) - 1;
 
-    if (kamae_num < monk_stances.size()) {
-        display_player_one_line(ENTRY_POSTURE, format(_("%sの構え", "%s form"), monk_stances[kamae_num].desc), TERM_YELLOW);
+    if (stance_num < monk_stances.size()) {
+        display_player_one_line(ENTRY_POSTURE, format(_("%sの構え", "%s form"), monk_stances[stance_num].desc), TERM_YELLOW);
     }
 }
 

--- a/src/view/display-player-middle.cpp
+++ b/src/view/display-player-middle.cpp
@@ -7,7 +7,9 @@
 #include "monster/monster-status.h"
 #include "object-enchant/special-object-flags.h"
 #include "perception/object-perception.h"
+#include "player-base/player-class.h"
 #include "player-info/equipment-info.h"
+#include "player-info/monk-data-type.h"
 #include "player-info/race-types.h"
 #include "player-status/player-hand-types.h"
 #include "player/attack-defense-types.h"
@@ -69,18 +71,15 @@ static void display_sub_hand(player_type *player_ptr)
     if ((player_ptr->pclass != CLASS_MONK) || ((empty_hands(player_ptr, true) & EMPTY_HAND_MAIN) == 0))
         return;
 
-    if ((player_ptr->special_defense & KAMAE_MASK) == 0) {
+    PlayerClass pc(player_ptr);
+    if (pc.kamae_is(MonkKamae::NONE)) {
         display_player_one_line(ENTRY_POSTURE, _("構えなし", "none"), TERM_YELLOW);
         return;
     }
 
-    int kamae_num;
-    for (kamae_num = 0; kamae_num < MAX_KAMAE; kamae_num++) {
-        if ((player_ptr->special_defense >> kamae_num) & KAMAE_GENBU)
-            break;
-    }
+    uint kamae_num = enum2i(pc.get_kamae()) - 1;
 
-    if (kamae_num < MAX_KAMAE) {
+    if (kamae_num < monk_stances.size()) {
         display_player_one_line(ENTRY_POSTURE, format(_("%sの構え", "%s form"), monk_stances[kamae_num].desc), TERM_YELLOW);
     }
 }

--- a/src/view/status-first-page.cpp
+++ b/src/view/status-first-page.cpp
@@ -83,9 +83,9 @@ static bool calc_weapon_damage_limit(player_type *player_ptr, int hand, int *dam
     if (player_ptr->pclass == CLASS_FORCETRAINER)
         level = MAX(1, level - 3);
     PlayerClass pc(player_ptr);
-    if (pc.kamae_is(MonkKamae::BYAKKO))
+    if (pc.monk_stance_is(MonkStance::BYAKKO))
         *basedam = monk_ave_damage[level][1];
-    else if (pc.kamae_is(MonkKamae::GENBU) || pc.kamae_is(MonkKamae::SUZAKU))
+    else if (pc.monk_stance_is(MonkStance::GENBU) || pc.monk_stance_is(MonkStance::SUZAKU))
         *basedam = monk_ave_damage[level][2];
     else
         *basedam = monk_ave_damage[level][0];

--- a/src/view/status-first-page.cpp
+++ b/src/view/status-first-page.cpp
@@ -17,7 +17,9 @@
 #include "object-enchant/tr-types.h"
 #include "object/object-flags.h"
 #include "perception/object-perception.h"
+#include "player-base/player-class.h"
 #include "player-info/equipment-info.h"
+#include "player-info/monk-data-type.h"
 #include "player-status/player-hand-types.h"
 #include "player/player-status-flags.h"
 #include "player/special-defense-types.h"
@@ -80,9 +82,10 @@ static bool calc_weapon_damage_limit(player_type *player_ptr, int hand, int *dam
 
     if (player_ptr->pclass == CLASS_FORCETRAINER)
         level = MAX(1, level - 3);
-    if (player_ptr->special_defense & KAMAE_BYAKKO)
+    PlayerClass pc(player_ptr);
+    if (pc.kamae_is(MonkKamae::BYAKKO))
         *basedam = monk_ave_damage[level][1];
-    else if (player_ptr->special_defense & (KAMAE_GENBU | KAMAE_SUZAKU))
+    else if (pc.kamae_is(MonkKamae::GENBU) || pc.kamae_is(MonkKamae::SUZAKU))
         *basedam = monk_ave_damage[level][2];
     else
         *basedam = monk_ave_damage[level][0];

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -211,10 +211,10 @@ void print_state(player_type *player_ptr)
         }
         break;
     }
-    case ACTION_KATA: {
-        if (auto kata = PlayerClass(player_ptr).get_kata();
-            kata != SamuraiKata::NONE) {
-            strcpy(text, samurai_stances[enum2i(kata) - 1].desc);
+    case ACTION_SAMURAI_STANCE: {
+        if (auto stance = PlayerClass(player_ptr).get_samurai_stance();
+            stance != SamuraiStance::NONE) {
+            strcpy(text, samurai_stances[enum2i(stance) - 1].desc);
         }
         break;
     }

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -188,26 +188,26 @@ void print_state(player_type *player_ptr)
         strcpy(text, _("釣り", "fish"));
         break;
     }
-    case ACTION_KAMAE: {
-        if (auto kamae = PlayerClass(player_ptr).get_kamae();
-            kamae != MonkKamae::NONE) {
-            switch (kamae) {
-            case MonkKamae::GENBU:
+    case ACTION_MONK_STANCE: {
+        if (auto stance = PlayerClass(player_ptr).get_monk_stance();
+            stance != MonkStance::NONE) {
+            switch (stance) {
+            case MonkStance::GENBU:
                 attr = TERM_GREEN;
                 break;
-            case MonkKamae::BYAKKO:
+            case MonkStance::BYAKKO:
                 attr = TERM_WHITE;
                 break;
-            case MonkKamae::SEIRYU:
+            case MonkStance::SEIRYU:
                 attr = TERM_L_BLUE;
                 break;
-            case MonkKamae::SUZAKU:
+            case MonkStance::SUZAKU:
                 attr = TERM_L_RED;
                 break;
             default:
                 break;
             }
-            strcpy(text, monk_stances[enum2i(kamae) - 1].desc);
+            strcpy(text, monk_stances[enum2i(stance) - 1].desc);
         }
         break;
     }

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -6,6 +6,7 @@
 #include "player-base/player-class.h"
 #include "player-info/bluemage-data-type.h"
 #include "player-info/mane-data-type.h"
+#include "player-info/monk-data-type.h"
 #include "player-info/samurai-data-type.h"
 #include "player-info/sniper-data-type.h"
 #include "player/attack-defense-types.h"
@@ -188,26 +189,26 @@ void print_state(player_type *player_ptr)
         break;
     }
     case ACTION_KAMAE: {
-        int i;
-        for (i = 0; i < MAX_KAMAE; i++)
-            if (player_ptr->special_defense & (KAMAE_GENBU << i))
+        if (auto kamae = PlayerClass(player_ptr).get_kamae();
+            kamae != MonkKamae::NONE) {
+            switch (kamae) {
+            case MonkKamae::GENBU:
+                attr = TERM_GREEN;
                 break;
-        switch (i) {
-        case 0:
-            attr = TERM_GREEN;
-            break;
-        case 1:
-            attr = TERM_WHITE;
-            break;
-        case 2:
-            attr = TERM_L_BLUE;
-            break;
-        case 3:
-            attr = TERM_L_RED;
-            break;
+            case MonkKamae::BYAKKO:
+                attr = TERM_WHITE;
+                break;
+            case MonkKamae::SEIRYU:
+                attr = TERM_L_BLUE;
+                break;
+            case MonkKamae::SUZAKU:
+                attr = TERM_L_RED;
+                break;
+            default:
+                break;
+            }
+            strcpy(text, monk_stances[enum2i(kamae) - 1].desc);
         }
-
-        strcpy(text, monk_stances[i].desc);
         break;
     }
     case ACTION_KATA: {


### PR DESCRIPTION
修行僧の職業固有データ monk_data_type を定義し、修行僧の構えの状態を
player_ptr::special_defence から samurai_data_type::kamae に移動する。
剣術家の型と同様に、get_kamae/set_kamae/kamae_is のヘルパ関数を使用する。
さらにこれも剣術家の型と同様に、構えで得られる特性フラグを PlayerClass::
form_tr_flags()で取得できるようにし、has_*() のような特性フラグにおける
構えのチェックをこの関数から得られる特性フラグのチェックに集約する。