### PR TITLE
[Refactor] 忍者のデータを職業固有データに移動する

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -1007,6 +1007,8 @@
     <ClInclude Include="..\..\src\player-info\force-trainer-data-type.h" />
     <ClInclude Include="..\..\src\player-info\magic-eater-data-type.h" />
     <ClInclude Include="..\..\src\player-info\mane-data-type.h" />
+    <ClInclude Include="..\..\src\player-info\monk-data-type.h" />
+    <ClInclude Include="..\..\src\player-info\ninja-data-type.h" />
     <ClInclude Include="..\..\src\player-info\samurai-data-type.h" />
     <ClInclude Include="..\..\src\player-info\smith-data-type.h" />
     <ClInclude Include="..\..\src\player-info\sniper-data-type.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -5100,6 +5100,12 @@
     <ClInclude Include="..\..\src\player-info\samurai-data-type.h">
       <Filter>player-info</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\player-info\monk-data-type.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player-info\ninja-data-type.h">
+      <Filter>player-info</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\src\wall.bmp" />

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -678,6 +678,7 @@ hengband_SOURCES = \
 	player-info/mimic-info-table.cpp player-info/mimic-info-table.h \
 	player-info/monk-data-type.h \
 	player-info/mutation-info.cpp player-info/mutation-info.h \
+	player-info/ninja-data-type.h \
 	player-info/race-ability-info.cpp player-info/race-ability-info.h \
 	player-info/race-info.cpp player-info/race-info.h \
 	player-info/race-types.h \

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -435,8 +435,7 @@ void do_cmd_rest(player_type *player_ptr)
     if (command_arg > 9999)
         command_arg = 9999;
 
-    if (player_ptr->special_defense & NINJA_S_STEALTH)
-        set_superstealth(player_ptr, false);
+    set_superstealth(player_ptr, false);
 
     PlayerEnergy(player_ptr).set_player_turn_energy(100);
     if (command_arg > 100)

--- a/src/dungeon/dungeon-processor.cpp
+++ b/src/dungeon/dungeon-processor.cpp
@@ -142,7 +142,7 @@ void process_dungeon(player_type *player_ptr, bool load_game)
 #endif
     }
 
-    if (!load_game && (player_ptr->special_defense & NINJA_S_STEALTH))
+    if (!load_game)
         set_superstealth(player_ptr, false);
 
     floor_ptr->monster_level = floor_ptr->base_level;

--- a/src/effect/effect-feature.cpp
+++ b/src/effect/effect-feature.cpp
@@ -331,9 +331,8 @@ bool affect_feature(player_type *player_ptr, MONSTER_IDX who, POSITION r, POSITI
         if (g_ptr->m_idx)
             update_monster(player_ptr, g_ptr->m_idx, false);
 
-        if (player_ptr->special_defense & NINJA_S_STEALTH) {
-            if (player_bold(player_ptr, y, x))
-                set_superstealth(player_ptr, false);
+        if (player_bold(player_ptr, y, x)) {
+            set_superstealth(player_ptr, false);
         }
 
         break;

--- a/src/floor/floor-events.cpp
+++ b/src/floor/floor-events.cpp
@@ -63,7 +63,7 @@ void day_break(player_type *player_ptr)
     player_ptr->update |= PU_MONSTERS | PU_MON_LITE;
     player_ptr->redraw |= PR_MAP;
     player_ptr->window_flags |= PW_OVERHEAD | PW_DUNGEON;
-    if (((player_ptr->special_defense & NINJA_S_STEALTH) != 0) && ((floor_ptr->grid_array[player_ptr->y][player_ptr->x].info & CAVE_GLOW) != 0))
+    if ((floor_ptr->grid_array[player_ptr->y][player_ptr->x].info & CAVE_GLOW) != 0)
         set_superstealth(player_ptr, false);
 }
 
@@ -94,7 +94,7 @@ void night_falls(player_type *player_ptr)
     player_ptr->redraw |= PR_MAP;
     player_ptr->window_flags |= PW_OVERHEAD | PW_DUNGEON;
 
-    if (((player_ptr->special_defense & NINJA_S_STEALTH) != 0) && ((floor_ptr->grid_array[player_ptr->y][player_ptr->x].info & CAVE_GLOW) != 0))
+    if ((floor_ptr->grid_array[player_ptr->y][player_ptr->x].info & CAVE_GLOW) != 0)
         set_superstealth(player_ptr, false);
 }
 

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -411,8 +411,7 @@ void leave_floor(player_type *player_ptr)
 {
     preserve_pet(player_ptr);
     remove_all_mirrors(player_ptr, false);
-    if (player_ptr->special_defense & NINJA_S_STEALTH)
-        set_superstealth(player_ptr, false);
+    set_superstealth(player_ptr, false);
 
     new_floor_id = 0;
 

--- a/src/grid/feature.cpp
+++ b/src/grid/feature.cpp
@@ -266,10 +266,8 @@ void cave_set_feat(player_type *player_ptr, POSITION y, POSITION x, FEAT_IDX fea
         update_local_illumination(player_ptr, yy, xx);
     }
 
-    if (player_ptr->special_defense & NINJA_S_STEALTH) {
-        if (floor_ptr->grid_array[player_ptr->y][player_ptr->x].info & CAVE_GLOW) {
-            set_superstealth(player_ptr, false);
-        }
+    if (floor_ptr->grid_array[player_ptr->y][player_ptr->x].info & CAVE_GLOW) {
+        set_superstealth(player_ptr, false);
     }
 }
 

--- a/src/load/player-class-specific-data-loader.cpp
+++ b/src/load/player-class-specific-data-loader.cpp
@@ -6,6 +6,7 @@
 #include "player-info/magic-eater-data-type.h"
 #include "player-info/mane-data-type.h"
 #include "player-info/monk-data-type.h"
+#include "player-info/ninja-data-type.h"
 #include "player-info/samurai-data-type.h"
 #include "player-info/smith-data-type.h"
 #include "player-info/sniper-data-type.h"
@@ -194,6 +195,20 @@ void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<monk_data_type> &
         byte tmp8u;
         rd_byte(&tmp8u);
         monk_data->stance = i2enum<MonkStance>(tmp8u);
+    }
+}
+
+void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<ninja_data_type> &ninja_data) const
+{
+    if (loading_savefile_version_is_older_than(9)) {
+        // 古いセーブファイルの忍者のデータは magic_num には保存されていないので読み捨てる
+        load_old_savfile_magic_num();
+    } else {
+        byte tmp8u;
+        rd_byte(&tmp8u);
+        ninja_data->kawarimi = tmp8u != 0;
+        rd_byte(&tmp8u);
+        ninja_data->s_stealth = tmp8u != 0;
     }
 }
 

--- a/src/load/player-class-specific-data-loader.h
+++ b/src/load/player-class-specific-data-loader.h
@@ -13,6 +13,7 @@ struct mane_data_type;
 struct sniper_data_type;
 struct samurai_data_type;
 struct monk_data_type;
+struct ninja_data_type;
 struct spell_hex_data_type;
 
 class PlayerClassSpecificDataLoader {
@@ -28,4 +29,5 @@ public:
     void operator()(std::shared_ptr<sniper_data_type> &sniper_data) const;
     void operator()(std::shared_ptr<samurai_data_type> &samurai_data) const;
     void operator()(std::shared_ptr<monk_data_type> &monk_data) const;
+    void operator()(std::shared_ptr<ninja_data_type> &ninja_data) const;
 };

--- a/src/monster-floor/monster-lite.cpp
+++ b/src/monster-floor/monster-lite.cpp
@@ -9,6 +9,8 @@
 #include "monster-race/monster-race.h"
 #include "monster-race/race-flags7.h"
 #include "monster/monster-status.h"
+#include "player-base/player-class.h"
+#include "player-info/ninja-data-type.h"
 #include "player/special-defense-types.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
@@ -307,7 +309,8 @@ void update_mon_lite(player_type *player_ptr)
 
     player_ptr->update |= PU_DELAY_VIS;
     player_ptr->monlite = (floor_ptr->grid_array[player_ptr->y][player_ptr->x].info & CAVE_MNLT) != 0;
-    if (!(player_ptr->special_defense & NINJA_S_STEALTH)) {
+    auto ninja_data = PlayerClass(player_ptr).get_specific_data<ninja_data_type>();
+    if (!ninja_data || !ninja_data->s_stealth) {
         player_ptr->old_monlite = player_ptr->monlite;
         return;
     }

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -108,9 +108,7 @@ bool MonsterDamageProcessor::genocide_chaos_patron()
 
     this->set_redraw();
     (void)set_monster_csleep(this->player_ptr, this->m_idx, 0);
-    if (this->player_ptr->special_defense & NINJA_S_STEALTH) {
-        set_superstealth(this->player_ptr, false);
-    }
+    set_superstealth(this->player_ptr, false);
 
     return this->m_idx == 0;
 }

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -52,6 +52,8 @@
 #include "mspell/mspell-judgement.h"
 #include "object-enchant/trc-types.h"
 #include "pet/pet-fall-off.h"
+#include "player-base/player-class.h"
+#include "player-info/ninja-data-type.h"
 #include "player/player-move.h"
 #include "player/player-skill.h"
 #include "player/player-status-flags.h"
@@ -190,7 +192,8 @@ void process_monster(player_type *player_ptr, MONSTER_IDX m_idx)
  */
 bool process_stealth(player_type *player_ptr, MONSTER_IDX m_idx)
 {
-    if ((player_ptr->special_defense & NINJA_S_STEALTH) == 0)
+    auto ninja_data = PlayerClass(player_ptr).get_specific_data<ninja_data_type>();
+    if (!ninja_data || !ninja_data->s_stealth)
         return true;
 
     monster_type *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];

--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -15,6 +15,7 @@
 #include "player-info/magic-eater-data-type.h"
 #include "player-info/mane-data-type.h"
 #include "player-info/monk-data-type.h"
+#include "player-info/ninja-data-type.h"
 #include "player-info/samurai-data-type.h"
 #include "player-info/smith-data-type.h"
 #include "player-info/sniper-data-type.h"
@@ -359,6 +360,9 @@ void PlayerClass::init_specific_data()
         break;
     case CLASS_MONK:
         this->player_ptr->class_specific_data = std::make_shared<monk_data_type>();
+        break;
+    case CLASS_NINJA:
+        this->player_ptr->class_specific_data = std::make_shared<ninja_data_type>();
         break;
     case CLASS_HIGH_MAGE:
         if (this->player_ptr->realm1 == REALM_HEX) {

--- a/src/player-info/class-specific-data.h
+++ b/src/player-info/class-specific-data.h
@@ -14,6 +14,7 @@ struct mane_data_type;
 struct sniper_data_type;
 struct samurai_data_type;
 struct monk_data_type;
+struct ninja_data_type;
 struct spell_hex_data_type;
 
 using ClassSpecificData = std::variant<
@@ -28,6 +29,7 @@ using ClassSpecificData = std::variant<
     std::shared_ptr<sniper_data_type>,
     std::shared_ptr<samurai_data_type>,
     std::shared_ptr<monk_data_type>,
+    std::shared_ptr<ninja_data_type>,
     std::shared_ptr<spell_hex_data_type>
 
     >;

--- a/src/player-info/ninja-data-type.h
+++ b/src/player-info/ninja-data-type.h
@@ -1,0 +1,8 @@
+﻿#pragma once
+
+#include "system/angband.h"
+
+struct ninja_data_type {
+    bool kawarimi{}; //!< 変わり身状態か否か
+    bool s_stealth{}; //!< 超隠密状態か否か
+};

--- a/src/player/special-defense-types.h
+++ b/src/player/special-defense-types.h
@@ -6,6 +6,4 @@ enum special_defence {
     DEFENSE_FIRE = 0x00000004, /*!< プレイヤーのステータス:火炎免疫 */
     DEFENSE_COLD = 0x00000008, /*!< プレイヤーのステータス:冷気免疫 */
     DEFENSE_POIS = 0x00000010, /*!< プレイヤーのステータス:毒免疫 */
-    NINJA_KAWARIMI = 0x00002000, /*!< プレイヤーのステータス:変わり身 */
-    NINJA_S_STEALTH = 0x00004000, /*!< プレイヤーのステータス:超隠密 */
 };

--- a/src/save/player-class-specific-data-writer.cpp
+++ b/src/save/player-class-specific-data-writer.cpp
@@ -5,6 +5,7 @@
 #include "player-info/magic-eater-data-type.h"
 #include "player-info/mane-data-type.h"
 #include "player-info/monk-data-type.h"
+#include "player-info/ninja-data-type.h"
 #include "player-info/samurai-data-type.h"
 #include "player-info/smith-data-type.h"
 #include "player-info/sniper-data-type.h"
@@ -79,6 +80,12 @@ void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<samurai_dat
 void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<monk_data_type> &monk_data) const
 {
     wr_byte(enum2i(monk_data->stance));
+}
+
+void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<ninja_data_type> &ninja_data) const
+{
+    wr_byte(ninja_data->kawarimi ? 1 : 0);
+    wr_byte(ninja_data->s_stealth ? 1 : 0);
 }
 
 void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<spell_hex_data_type> &spell_hex_data) const

--- a/src/save/player-class-specific-data-writer.h
+++ b/src/save/player-class-specific-data-writer.h
@@ -13,6 +13,7 @@ struct mane_data_type;
 struct sniper_data_type;
 struct samurai_data_type;
 struct monk_data_type;
+struct ninja_data_type;
 
 class PlayerClassSpecificDataWriter {
 public:
@@ -27,4 +28,5 @@ public:
     void operator()(const std::shared_ptr<sniper_data_type> &sniper_data) const;
     void operator()(const std::shared_ptr<samurai_data_type> &samurai_data) const;
     void operator()(const std::shared_ptr<monk_data_type> &monk_data) const;
+    void operator()(const std::shared_ptr<ninja_data_type> &ninja_data) const;
 };

--- a/src/specific-object/torch.cpp
+++ b/src/specific-object/torch.cpp
@@ -135,8 +135,9 @@ void update_lite_radius(player_type *player_ptr)
     player_ptr->update |= PU_LITE | PU_MON_LITE | PU_MONSTERS;
     player_ptr->old_lite = player_ptr->cur_lite;
 
-    if ((player_ptr->cur_lite > 0) && (player_ptr->special_defense & NINJA_S_STEALTH))
+    if (player_ptr->cur_lite > 0) {
         set_superstealth(player_ptr, false);
+    }
 }
 
 /*

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -348,9 +348,8 @@ bool earthquake(player_type *player_ptr, POSITION cy, POSITION cx, POSITION r, M
     player_ptr->update |= (PU_UN_VIEW | PU_UN_LITE | PU_VIEW | PU_LITE | PU_FLOW | PU_MON_LITE | PU_MONSTERS);
     player_ptr->redraw |= (PR_HEALTH | PR_UHEALTH | PR_MAP);
     player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
-    if (player_ptr->special_defense & NINJA_S_STEALTH) {
-        if (floor_ptr->grid_array[player_ptr->y][player_ptr->x].info & CAVE_GLOW)
-            set_superstealth(player_ptr, false);
+    if (floor_ptr->grid_array[player_ptr->y][player_ptr->x].info & CAVE_GLOW) {
+        set_superstealth(player_ptr, false);
     }
 
     return true;

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -121,9 +121,8 @@ void wiz_lite(player_type *player_ptr, bool ninja)
     player_ptr->redraw |= (PR_MAP);
     player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
 
-    if (player_ptr->special_defense & NINJA_S_STEALTH) {
-        if (player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x].info & CAVE_GLOW)
-            set_superstealth(player_ptr, false);
+    if (player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x].info & CAVE_GLOW) {
+        set_superstealth(player_ptr, false);
     }
 }
 
@@ -455,9 +454,8 @@ bool destroy_area(player_type *player_ptr, POSITION y1, POSITION x1, POSITION r,
     player_ptr->redraw |= (PR_MAP);
     player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
 
-    if (player_ptr->special_defense & NINJA_S_STEALTH) {
-        if (floor_ptr->grid_array[player_ptr->y][player_ptr->x].info & CAVE_GLOW)
-            set_superstealth(player_ptr, false);
+    if (floor_ptr->grid_array[player_ptr->y][player_ptr->x].info & CAVE_GLOW) {
+        set_superstealth(player_ptr, false);
     }
 
     return true;

--- a/src/spell-kind/spells-lite.cpp
+++ b/src/spell-kind/spells-lite.cpp
@@ -318,9 +318,8 @@ void lite_room(player_type *player_ptr, const POSITION y1, const POSITION x1)
     cave_temp_room_lite(player_ptr, points);
 
     // 超隠密状態の更新。
-    if (player_ptr->special_defense & NINJA_S_STEALTH) {
-        if (floor_ptr->grid_array[player_ptr->y][player_ptr->x].info & CAVE_GLOW)
-            set_superstealth(player_ptr, false);
+    if (floor_ptr->grid_array[player_ptr->y][player_ptr->x].info & CAVE_GLOW) {
+        set_superstealth(player_ptr, false);
     }
 }
 

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -7,6 +7,7 @@
 #include "player-info/bluemage-data-type.h"
 #include "player-info/mane-data-type.h"
 #include "player-info/monk-data-type.h"
+#include "player-info/ninja-data-type.h"
 #include "player-info/samurai-data-type.h"
 #include "player-info/sniper-data-type.h"
 #include "player/attack-defense-types.h"
@@ -513,7 +514,8 @@ void print_status(player_type *player_ptr)
     if (player_ptr->shield)
         ADD_BAR_FLAG(BAR_STONESKIN);
 
-    if (player_ptr->special_defense & NINJA_KAWARIMI)
+    auto ninja_data = PlayerClass(player_ptr).get_specific_data<ninja_data_type>();
+    if (ninja_data && ninja_data->kawarimi)
         ADD_BAR_FLAG(BAR_KAWARIMI);
 
     if (player_ptr->special_defense & DEFENSE_ACID)
@@ -582,7 +584,7 @@ void print_status(player_type *player_ptr)
         ADD_BAR_FLAG(BAR_ATTKACID);
     if (player_ptr->special_attack & ATTACK_POIS)
         ADD_BAR_FLAG(BAR_ATTKPOIS);
-    if (player_ptr->special_defense & NINJA_S_STEALTH)
+    if (ninja_data && ninja_data->s_stealth)
         ADD_BAR_FLAG(BAR_SUPERSTEALTH);
 
     if (player_ptr->tim_sh_fire)


### PR DESCRIPTION
忍者特有の超隠密・変わり身の発動中かどうかのフラグを忍者の職業固有データ
ninja_data_type を定義して移動させる。
早駆けについは player_type::action だけで制御できるようなのでそのままに
しておく。
また、超隠密状態を解除する処理 set_superstealth(player_ptr, false) を呼ぶ
時に事前に超隠密状態かどうかをチェックしているが、set_superstealthの内部
でも超隠密状態かどうかチェックされており、超隠密状態でなければ何も起きない
ので、呼ぶ前のチェックをすべて削除する。