### PR TITLE
[Feature] 鍛冶で岩石溶解の発動付加のエッセンス消費量を増やす

### DIFF
--- a/src/object-enchant/smith-tables.cpp
+++ b/src/object-enchant/smith-tables.cpp
@@ -495,7 +495,7 @@ const std::vector<std::shared_ptr<ISmithInfo>> Smith::smith_info_table = {
     make_info<ActivationSmithInfo>(SmithEffect::ACT_PHASE_DOOR, _("ショート・テレポート", "blink"), SmithCategory::ACTIVATION, { SmithEssence::TELEPORT }, 30, RandomArtActType::PHASE_DOOR),
     make_info<ActivationSmithInfo>(SmithEffect::ACT_TELEPORT, _("テレポート", "teleport"), SmithCategory::ACTIVATION, { SmithEssence::TELEPORT }, 40, RandomArtActType::TELEPORT),
     make_info<ActivationSmithInfo>(SmithEffect::ACT_SPEED, _("スピード", "speed"), SmithCategory::ACTIVATION, { SmithEssence::SPEED }, 25, RandomArtActType::SPEED),
-    make_info<ActivationSmithInfo>(SmithEffect::ACT_STONE_MUD, _("岩石溶解", "stone to mud"), SmithCategory::ACTIVATION, { SmithEssence::TUNNEL }, 25, RandomArtActType::STONE_MUD),
+    make_info<ActivationSmithInfo>(SmithEffect::ACT_STONE_MUD, _("岩石溶解", "stone to mud"), SmithCategory::ACTIVATION, { SmithEssence::TUNNEL }, 100, RandomArtActType::STONE_MUD),
     make_info<ActivationSmithInfo>(SmithEffect::ACT_LIGHT, _("イルミネーション", "light area"), SmithCategory::ACTIVATION, { SmithEssence::LITE }, 30, RandomArtActType::LIGHT),
     make_info<ActivationSmithInfo>(SmithEffect::ACT_MAP_LIGHT, _("魔法の地図と光", "light & map area"), SmithCategory::ACTIVATION, { SmithEssence::SEARCH, SmithEssence::LITE }, 30, RandomArtActType::MAP_LIGHT),
     make_info<ActivationSmithInfo>(SmithEffect::ACT_DETECT_ALL, _("全感知", "detection"), SmithCategory::ACTIVATION, { SmithEssence::SEARCH, SmithEssence::TELEPATHY }, 30, RandomArtActType::DETECT_ALL),


### PR DESCRIPTION
適当に25にしていたが、消費量が少なすぎるという意見があった。
採掘+1あたり10を消費する事を考えると採掘+2.5相当で3ターン毎に岩石溶解が
発動できるのは確かにバランスが悪いと思われるので、エッセンス消費量を100
とする。