### PR TITLE
呪術のおかしな挙動の修正

### DIFF
--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -665,8 +665,8 @@ concptr do_hex_spell(player_type *player_ptr, spell_hex_type spell, spell_type m
                 msg_format(_("%sの呪文の詠唱をやめた。", "Finish casting '%^s'."), exe_spell(player_ptr, REALM_HEX, HEX_RESTORE, SPELL_NAME));
                 SpellHex spell_hex(player_ptr);
                 spell_hex.reset_casting_flag(HEX_RESTORE);
-                if (spell_hex.get_casting_num() > 0) {
-                    player_ptr->action = ACTION_NONE;
+                if (!spell_hex.is_spelling_any()) {
+                    set_action(player_ptr, ACTION_NONE);
                 }
 
                 player_ptr->update |= (PU_BONUS | PU_HP | PU_MANA | PU_SPELLS);

--- a/src/status/action-setter.cpp
+++ b/src/status/action-setter.cpp
@@ -89,7 +89,10 @@ void set_action(player_type *player_ptr, uint8_t typ)
         stop_singing(player_ptr);
 
     if (prev_typ == ACTION_SPELL) {
-        (void)SpellHex(player_ptr).stop_spells_with_selection();
+        SpellHex spell_hex(player_ptr);
+        if (spell_hex.is_spelling_any()) {
+            spell_hex.stop_all_spells();
+        }
     }
 
     switch (player_ptr->action) {


### PR DESCRIPTION
## [Fix] 呪術の全復活で詠唱中断後に詠唱中の表示が残る

Fix #1708.
他に詠唱している呪文があるかどうかの判定が反転している。
正しい判定に修正して他に詠唱中の呪文がなければ ACTION_NONE をセットする
ようにする。

## [Fix] 呪術の中断時に不要なメッセージが出る

詠唱中の呪術がなくなった時、「呪文の詠唱を中断しました。」の後に「呪文を
詠唱していません。」と不要なメッセージが出る。
これは本来呪文を詠唱していないときに詠唱をやめるレイシャルを使用した時の
メッセージだが、リファクタリングでコールチェーンが変わった結果表示される
ようになってしまっている。
呪文の詠唱を中断しました。の後には呪文を詠唱していません。は表示されない
ようにする。