### PR TITLE
忍者の変わり身が意図せず発動する事象を修正した

### DIFF
--- a/src/effect/effect-player.cpp
+++ b/src/effect/effect-player.cpp
@@ -125,12 +125,11 @@ static process_result check_continue_player_effect(player_type *player_ptr, effe
         return PROCESS_FALSE;
     }
 
-    auto is_kawarimi = kawarimi(player_ptr, true);
     auto is_effective = ep_ptr->dam > 0;
     is_effective &= randint0(55) < (player_ptr->lev * 3 / 5 + 20);
     is_effective &= ep_ptr->who > 0;
     is_effective &= ep_ptr->who != player_ptr->riding;
-    if (is_kawarimi && is_effective) {
+    if (is_effective && kawarimi(player_ptr, true)) {
         return PROCESS_FALSE;
     }
 


### PR DESCRIPTION
掲題の通りです
原因は、「とにかく変わり身処理をして、それからモンスターからの打撃が当たったかどうか等を判定する」とリファクタリング作業中に順番が逆になっていたことでした
修正しましたのでご確認下さい