### PR TITLE
ランダムクエスト報酬を改善した

### DIFF
--- a/src/dungeon/quest-completion-checker.cpp
+++ b/src/dungeon/quest-completion-checker.cpp
@@ -11,6 +11,7 @@
 #include "monster-race/monster-race.h"
 #include "monster/monster-info.h"
 #include "object-enchant/item-apply-magic.h"
+#include "object-enchant/object-ego.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
 #include "system/monster-race-definition.h"
@@ -249,8 +250,33 @@ void QuestCompletionChecker::make_reward(const Pos2D pos)
     auto dun_level = this->player_ptr->current_floor_ptr->dun_level;
     for (auto i = 0; i < (dun_level / 15) + 1; i++) {
         object_type item;
-        auto &r_ref = r_info[this->m_ptr->r_idx];
-        make_object(this->player_ptr, &item, AM_GOOD | AM_GREAT, r_ref.level);
-        (void)drop_near(this->player_ptr, &item, -1, pos.y, pos.x);
+        while (true) {
+            item.wipe();
+            auto &r_ref = r_info[this->m_ptr->r_idx];
+            make_object(this->player_ptr, &item, AM_GOOD | AM_GREAT, r_ref.level);
+            if (!this->check_quality(item)) {
+                continue;
+            }
+
+            (void)drop_near(this->player_ptr, &item, -1, pos.y, pos.x);
+            break;
+        }
     }
+}
+
+/*!
+ * @brief ランダムクエスト報酬の品質をチェックする
+ * @param item 生成された高級品への参照
+ * @return 十分な品質か否か
+ * @details 以下のものを弾く
+ * 1. 呪われれた装備品
+ * 2. 固定アーティファクト以外の矢弾
+ * 3. 穴掘りエゴの装備品
+ */
+bool QuestCompletionChecker::check_quality(object_type &item)
+{
+    auto is_good_reward = !item.is_cursed();
+    is_good_reward &= !item.is_ammo() || (item.is_ammo() && item.is_fixed_artifact());
+    is_good_reward &= item.name2 != EGO_DIGGING;
+    return is_good_reward;
 }

--- a/src/dungeon/quest-completion-checker.cpp
+++ b/src/dungeon/quest-completion-checker.cpp
@@ -8,10 +8,12 @@
 #include "grid/feature-flag-types.h"
 #include "grid/feature.h"
 #include "grid/grid.h"
+#include "monster-race/monster-race.h"
 #include "monster/monster-info.h"
 #include "object-enchant/item-apply-magic.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
+#include "system/monster-race-definition.h"
 #include "system/monster-type-definition.h"
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
@@ -247,7 +249,8 @@ void QuestCompletionChecker::make_reward(const Pos2D pos)
     auto dun_level = this->player_ptr->current_floor_ptr->dun_level;
     for (auto i = 0; i < (dun_level / 15) + 1; i++) {
         object_type item;
-        make_object(this->player_ptr, &item, AM_GOOD | AM_GREAT);
+        auto &r_ref = r_info[this->m_ptr->r_idx];
+        make_object(this->player_ptr, &item, AM_GOOD | AM_GREAT, r_ref.level);
         (void)drop_near(this->player_ptr, &item, -1, pos.y, pos.x);
     }
 }

--- a/src/dungeon/quest-completion-checker.h
+++ b/src/dungeon/quest-completion-checker.h
@@ -5,6 +5,7 @@
 #include <tuple>
 
 struct monster_type;
+struct object_type;
 struct player_type;
 struct quest_type;
 class QuestCompletionChecker {
@@ -30,4 +31,5 @@ private:
     int count_all_hostile_monsters();
     Pos2D make_stairs(const bool create_stairs);
     void make_reward(const Pos2D pos);
+    bool check_quality(object_type &item);
 };

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -81,40 +81,58 @@ static void object_mention(player_type *player_ptr, object_type *o_ptr)
     msg_format_wizard(player_ptr, CHEAT_OBJECT, _("%sを生成しました。", "%s was generated."), o_name);
 }
 
+static int get_base_floor(floor_type *floor_ptr, BIT_FLAGS mode, int rq_level)
+{
+    if (any_bits(mode, AM_GREAT)) {
+        if (rq_level > 0) {
+            return rq_level + 10 + randint1(10);
+        } else {
+            return floor_ptr->object_level + 15;
+        }
+    }
+
+    if (any_bits(mode, AM_GOOD)) {
+        return floor_ptr->object_level + 10;
+    }
+
+    return floor_ptr->object_level;
+}
+
 /*!
  * @brief 生成階に応じたベースアイテムの生成を行う。
  * Attempt to make an object (normal or good/great)
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param j_ptr 生成結果を収めたいオブジェクト構造体の参照ポインタ
  * @param mode オプションフラグ
- * @return 生成に成功したらTRUEを返す。
+ * @param rq_floor ランダムクエスト討伐対象のレベル
+ * @return アイテムの生成成功可否
  * @details
- * This routine plays nasty games to generate the "special artifacts".\n
- * This routine uses "floor_ptr->object_level" for the "generation level".\n
- * We assume that the given object has been "wiped".\n
+ * rq_levelは、ユニークのレベルであってランダムクエストの階層ではない
+ * ランダムクエストではない場合、-1が入る
  */
-bool make_object(player_type *player_ptr, object_type *j_ptr, BIT_FLAGS mode)
+bool make_object(player_type *player_ptr, object_type *j_ptr, BIT_FLAGS mode, int rq_level)
 {
     floor_type *floor_ptr = player_ptr->current_floor_ptr;
     PERCENTAGE prob = ((mode & AM_GOOD) ? 10 : 1000);
-    DEPTH base = ((mode & AM_GOOD) ? (floor_ptr->object_level + 10) : floor_ptr->object_level);
+    auto base = get_base_floor(floor_ptr, mode, rq_level);
     if (!one_in_(prob) || !make_artifact_special(player_ptr, j_ptr)) {
-        KIND_OBJECT_IDX k_idx;
-        if ((mode & AM_GOOD) && !get_obj_num_hook) {
+        if (any_bits(mode, AM_GOOD) && !get_obj_num_hook) {
             get_obj_num_hook = kind_is_good;
         }
 
-        if (get_obj_num_hook)
+        if (get_obj_num_hook) {
             get_obj_num_prep();
+        }
 
-        k_idx = get_obj_num(player_ptr, base, mode);
+        auto k_idx = get_obj_num(player_ptr, base, mode);
         if (get_obj_num_hook) {
             get_obj_num_hook = nullptr;
             get_obj_num_prep();
         }
 
-        if (!k_idx)
+        if (k_idx == 0) {
             return false;
+        }
 
         j_ptr->prep(k_idx);
     }
@@ -134,8 +152,9 @@ bool make_object(player_type *player_ptr, object_type *j_ptr, BIT_FLAGS mode)
         break;
     }
 
-    if (cheat_peek)
+    if (cheat_peek) {
         object_mention(player_ptr, j_ptr);
+    }
 
     return true;
 }

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -98,6 +98,17 @@ static int get_base_floor(floor_type *floor_ptr, BIT_FLAGS mode, int rq_level)
     return floor_ptr->object_level;
 }
 
+static void set_ammo_quantity(object_type *j_ptr)
+{
+    auto is_ammo = j_ptr->tval == TV_SPIKE;
+    is_ammo |= j_ptr->tval == TV_SHOT;
+    is_ammo |= j_ptr->tval == TV_ARROW;
+    is_ammo |= j_ptr->tval == TV_BOLT;
+    if (is_ammo && !j_ptr->is_fixed_artifact()) {
+        j_ptr->number = damroll(6, 7);
+    }
+}
+
 /*!
  * @brief 生成階に応じたベースアイテムの生成を行う。
  * Attempt to make an object (normal or good/great)
@@ -138,20 +149,7 @@ bool make_object(player_type *player_ptr, object_type *j_ptr, BIT_FLAGS mode, in
     }
 
     apply_magic_to_object(player_ptr, j_ptr, floor_ptr->object_level, mode);
-    switch (j_ptr->tval) {
-    case TV_SPIKE:
-    case TV_SHOT:
-    case TV_ARROW:
-    case TV_BOLT:
-        if (!j_ptr->name1) {
-            j_ptr->number = (byte)damroll(6, 7);
-        }
-    
-        break;
-    default:
-        break;
-    }
-
+    set_ammo_quantity(j_ptr);
     if (cheat_peek) {
         object_mention(player_ptr, j_ptr);
     }

--- a/src/floor/floor-object.h
+++ b/src/floor/floor-object.h
@@ -9,7 +9,7 @@ struct floor_type;
 struct object_type;;
 struct player_type;
 class ItemTester;
-bool make_object(player_type *player_ptr, object_type *j_ptr, BIT_FLAGS mode);
+bool make_object(player_type *player_ptr, object_type *j_ptr, BIT_FLAGS mode, int rq_level);
 bool make_gold(player_type *player_ptr, object_type *j_ptr);
 void delete_all_items_from_floor(player_type *player_ptr, POSITION y, POSITION x);
 void floor_item_increase(player_type *player_ptr, INVENTORY_IDX item, ITEM_NUMBER num);

--- a/src/grid/object-placer.cpp
+++ b/src/grid/object-placer.cpp
@@ -77,7 +77,7 @@ void place_object(player_type *player_ptr, POSITION y, POSITION x, BIT_FLAGS mod
 
     q_ptr = &forge;
     q_ptr->wipe();
-    if (!make_object(player_ptr, q_ptr, mode))
+    if (!make_object(player_ptr, q_ptr, mode, -1))
         return;
 
     OBJECT_IDX o_idx = o_pop(floor_ptr);

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -289,7 +289,7 @@ static void drop_items_golds(player_type *player_ptr, monster_death_type *md_ptr
 
             dump_gold++;
         } else {
-            if (!make_object(player_ptr, q_ptr, md_ptr->mo_mode))
+            if (!make_object(player_ptr, q_ptr, md_ptr->mo_mode, -1))
                 continue;
 
             dump_item++;

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -122,7 +122,7 @@ static void on_dead_raal(player_type *player_ptr, monster_death_type *md_ptr)
     else
         get_obj_num_hook = kind_is_book;
 
-    make_object(player_ptr, q_ptr, md_ptr->mo_mode);
+    make_object(player_ptr, q_ptr, md_ptr->mo_mode, -1);
     (void)drop_near(player_ptr, q_ptr, -1, md_ptr->md_y, md_ptr->md_x);
 }
 
@@ -342,7 +342,7 @@ static void on_dead_big_raven(player_type *player_ptr, monster_death_type *md_pt
 static bool make_equipment(player_type *player_ptr, object_type *q_ptr, const BIT_FLAGS drop_mode, const bool is_object_hook_null)
 {
     q_ptr->wipe();
-    (void)make_object(player_ptr, q_ptr, drop_mode);
+    (void)make_object(player_ptr, q_ptr, drop_mode, -1);
     if (!is_object_hook_null) {
         return true;
     }
@@ -436,7 +436,7 @@ static void drop_specific_item_on_dead(player_type *player_ptr, monster_death_ty
     object_type *q_ptr = &forge;
     q_ptr->wipe();
     get_obj_num_hook = object_hook_pf;
-    (void)make_object(player_ptr, q_ptr, md_ptr->mo_mode);
+    (void)make_object(player_ptr, q_ptr, md_ptr->mo_mode, -1);
     (void)drop_near(player_ptr, q_ptr, -1, md_ptr->md_y, md_ptr->md_x);
 }
 

--- a/src/specific-object/chest.cpp
+++ b/src/specific-object/chest.cpp
@@ -102,7 +102,7 @@ void Chest::chest_death(bool scatter, POSITION y, POSITION x, OBJECT_IDX o_idx)
         /* Otherwise drop an item */
         else {
             /* Make a good object */
-            if (!make_object(this->player_ptr, q_ptr, mode))
+            if (!make_object(this->player_ptr, q_ptr, mode, -1))
                 continue;
         }
 

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -192,7 +192,7 @@ void acquirement(player_type *player_ptr, POSITION y1, POSITION x1, int num, boo
         i_ptr->wipe();
 
         /* Make a good (or great) object (if possible) */
-        if (!make_object(player_ptr, i_ptr, mode))
+        if (!make_object(player_ptr, i_ptr, mode, -1))
             continue;
 
         if (known) {

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -447,7 +447,7 @@ static void wiz_statistics(player_type *player_ptr, object_type *o_ptr)
             object_type forge;
             object_type *q_ptr = &forge;
             q_ptr->wipe();
-            make_object(player_ptr, q_ptr, mode);
+            make_object(player_ptr, q_ptr, mode, -1);
             if (q_ptr->is_fixed_artifact())
                 a_info[q_ptr->name1].cur_num = 0;
 


### PR DESCRIPTION
#1725 の後段作業で、#1413 の本体です
チケット内の仕様通りに実装しました
添付のファイルをロードし、目の前にいる『ハルコン』へ^Ay*t で一撃死させると破邪の矢の生成をスキップします
ステップ実行でご確認下さい
[DEBUGGER_破邪の矢除外.zip](https://github.com/hengband/hengband/files/7273435/DEBUGGER_.zip)