### PR TITLE
[Fix] 発動を付与した鍛冶アイテムのフラグをキャラクタ情報に表示する

### DIFF
--- a/src/object/object-flags.cpp
+++ b/src/object/object-flags.cpp
@@ -104,6 +104,9 @@ TrFlags object_flags_known(const object_type *o_ptr)
         auto tr_flags = Smith::get_effect_tr_flags(effect.value());
         flgs.set(tr_flags);
     }
+    if (Smith::object_activation(o_ptr).has_value()) {
+        flgs.set(TR_ACTIVATE);
+    }
 
     return flgs;
 }


### PR DESCRIPTION
Resolve #1740.
元々 object_flags_known では発動フラグの付加がわざわざ除かれていたので
それに倣っていたが、キャラクタ情報の発動フラグに表示されなくなるので
object_flags と同様に発動を付与した鍛冶アイテムには TR_ACTIVATE フラグを
付加するようにする。