### PR TITLE
[Fix] 機能的に無意味と判断されたexe_reading_savefile()中のrd_unique_info()の呼び出しと関数そのものを削除

### DIFF
--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -190,7 +190,6 @@ static errr exe_reading_savefile(player_type *player_ptr)
     rd_version_info();
     rd_dummy3();
     rd_system_info();
-    rd_unique_info();
     errr load_lore_result = load_lore();
     if (load_lore_result != 0)
         return load_lore_result;

--- a/src/load/quest-loader.cpp
+++ b/src/load/quest-loader.cpp
@@ -14,24 +14,6 @@
 #include "system/player-type-definition.h"
 #include "util/enum-converter.h"
 
-/*!
- * @brief ランダムクエスト情報の読み込み
- * @param なし
- * @details MAX_TRIES: ランダムクエストのモンスターを確定するために試行する回数 /
- * Maximum number of tries for selection of a proper quest monster
- */
-void rd_unique_info(void)
-{
-    const int MAX_TRIES = 100;
-    for (auto &r_ref : r_info) {
-        r_ref.max_num = MAX_TRIES;
-        if (r_ref.flags1 & RF1_UNIQUE)
-            r_ref.max_num = 1;
-        else if (r_ref.flags7 & RF7_NAZGUL)
-            r_ref.max_num = MAX_NAZGUL_NUM;
-    }
-}
-
 errr load_town(void)
 {
     uint16_t max_towns_load;

--- a/src/load/quest-loader.h
+++ b/src/load/quest-loader.h
@@ -6,4 +6,3 @@ struct player_type;
 errr load_town(void);
 errr load_quest_info(uint16_t *max_quests_load, byte *max_rquests_load);
 void analyze_quests(player_type *player_ptr, const uint16_t max_quests_load, const byte max_rquests_load);
-void rd_unique_info(void);


### PR DESCRIPTION
Discordで同意もらったので提題通り該当箇所を削除しました。ご確認ください。