### PR TITLE
乱数生成に STL を使用する

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -576,6 +576,7 @@
     <ClCompile Include="..\..\src\timed-effect\player-cut.cpp" />
     <ClCompile Include="..\..\src\timed-effect\player-stun.cpp" />
     <ClCompile Include="..\..\src\timed-effect\timed-effects.cpp" />
+    <ClCompile Include="..\..\src\util\rng-xoshiro.cpp" />
     <ClCompile Include="..\..\src\view\display-inventory.cpp" />
     <ClCompile Include="..\..\src\view\display-map.cpp" />
     <ClCompile Include="..\..\src\view\display-self-info.cpp" />
@@ -1719,6 +1720,7 @@
     <ClInclude Include="..\..\src\term\term-color-types.h" />
     <ClInclude Include="..\..\src\util\angband-files.h" />
     <ClInclude Include="..\..\src\util\object-sort.h" />
+    <ClInclude Include="..\..\src\util\rng-xoshiro.h" />
     <ClInclude Include="..\..\src\util\string-processor.h" />
     <ClInclude Include="..\..\src\util\tag-sorter.h" />
     <ClInclude Include="..\..\src\view\display-birth.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2361,6 +2361,9 @@
     <ClCompile Include="..\..\src\object-use\zapwand-execution.cpp">
       <Filter>object-use</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\util\rng-xoshiro.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5105,6 +5108,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\player-info\ninja-data-type.h">
       <Filter>player-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\rng-xoshiro.h">
+      <Filter>util</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -903,6 +903,7 @@ hengband_SOURCES = \
 	util/point-2d.h \
 	util/probability-table.h \
 	util/quarks.cpp util/quarks.h \
+	util/rng-xoshiro.cpp util/rng-xoshiro.h \
 	util/sort.cpp util/sort.h \
 	util/string-processor.cpp util/string-processor.h \
 	util/tag-sorter.cpp util/tag-sorter.h \

--- a/src/flavor/object-flavor.cpp
+++ b/src/flavor/object-flavor.cpp
@@ -218,9 +218,8 @@ static void shuffle_flavors(tval_type tval)
  */
 void flavor_init(void)
 {
-    uint32_t state_backup[4];
-    Rand_state_backup(state_backup);
-    Rand_state_set(w_ptr->seed_flavor);
+    const auto state_backup = w_ptr->rng.get_state();
+    w_ptr->rng.set_state(w_ptr->seed_flavor);
     for (auto &k_ref : k_info) {
         if (k_ref.flavor_name.empty())
             continue;
@@ -236,7 +235,7 @@ void flavor_init(void)
     shuffle_flavors(TV_FOOD);
     shuffle_flavors(TV_POTION);
     shuffle_flavors(TV_SCROLL);
-    Rand_state_restore(state_backup);
+    w_ptr->rng.set_state(state_backup);
     for (auto &k_ref : k_info) {
         if (k_ref.idx == 0 || k_ref.name.empty())
             continue;

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -229,9 +229,8 @@ static void generate_wilderness_area(floor_type *floor_ptr, int terrain, uint32_
         return;
     }
 
-    uint32_t state_backup[4];
-    Rand_state_backup(state_backup);
-    Rand_state_set(seed);
+    const auto state_backup = w_ptr->rng.get_state();
+    w_ptr->rng.set_state(seed);
     int table_size = sizeof(terrain_table[0]) / sizeof(int16_t);
     if (!corner)
         for (POSITION y1 = 0; y1 < MAX_HGT; y1++)
@@ -247,7 +246,7 @@ static void generate_wilderness_area(floor_type *floor_ptr, int terrain, uint32_
         floor_ptr->grid_array[MAX_HGT - 2][1].feat = terrain_table[terrain][floor_ptr->grid_array[MAX_HGT - 2][1].feat];
         floor_ptr->grid_array[1][MAX_WID - 2].feat = terrain_table[terrain][floor_ptr->grid_array[1][MAX_WID - 2].feat];
         floor_ptr->grid_array[MAX_HGT - 2][MAX_WID - 2].feat = terrain_table[terrain][floor_ptr->grid_array[MAX_HGT - 2][MAX_WID - 2].feat];
-        Rand_state_restore(state_backup);
+        w_ptr->rng.set_state(state_backup);
         return;
     }
 
@@ -265,7 +264,7 @@ static void generate_wilderness_area(floor_type *floor_ptr, int terrain, uint32_
         for (POSITION x1 = 1; x1 < MAX_WID - 1; x1++)
             floor_ptr->grid_array[y1][x1].feat = terrain_table[terrain][floor_ptr->grid_array[y1][x1].feat];
 
-    Rand_state_restore(state_backup);
+    w_ptr->rng.set_state(state_backup);
 }
 
 /*!
@@ -356,14 +355,13 @@ static void generate_area(player_type *player_ptr, POSITION y, POSITION x, bool 
     if (!is_winner)
         return;
 
-    uint32_t state_backup[4];
-    Rand_state_backup(state_backup);
-    Rand_state_set(wilderness[y][x].seed);
+    const auto state_backup = w_ptr->rng.get_state();
+    w_ptr->rng.set_state(wilderness[y][x].seed);
     int dy = rand_range(6, floor_ptr->height - 6);
     int dx = rand_range(6, floor_ptr->width - 6);
     floor_ptr->grid_array[dy][dx].feat = feat_entrance;
     floor_ptr->grid_array[dy][dx].special = wilderness[y][x].entrance;
-    Rand_state_restore(state_backup);
+    w_ptr->rng.set_state(state_backup);
 }
 
 /* Border of the wilderness area */

--- a/src/load/info-loader.cpp
+++ b/src/load/info-loader.cpp
@@ -53,9 +53,18 @@ void rd_randomizer(void)
 {
     uint16_t tmp16u;
     rd_u16b(&tmp16u);
-    rd_u16b(&Rand_place);
-    for (int i = 0; i < RAND_DEG; i++)
-        rd_u32b(&Rand_state[i]);
+    rd_u16b(&tmp16u);
+
+    Xoshiro128StarStar::state_type state;
+    for (auto &s : state) {
+        rd_u32b(&s);
+    }
+    w_ptr->rng.set_state(state);
+
+    uint32_t tmp32u;
+    for (int i = state.size(); i < RAND_DEG; i++) {
+        rd_u32b(&tmp32u);
+    }
 }
 
 /*!

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -460,7 +460,7 @@ static void on_dead_chest_mimic(player_type *player_ptr, monster_death_type *md_
         break;
     case MON_CHEST_MIMIC_11:
         mimic_inside = MON_CHEST_MIMIC_04;
-        num_summons = next_bool() ? 3 : 2;
+        num_summons = one_in_(2) ? 3 : 2;
         break;
     default:
         mimic_inside = (monster_race_type)-1;

--- a/src/mspell/specified-summon.cpp
+++ b/src/mspell/specified-summon.cpp
@@ -220,7 +220,7 @@ MONSTER_NUMBER summon_APOCRYPHA(player_type *player_ptr, POSITION y, POSITION x,
 {
     int count = 0;
     int num = 4 + randint1(4);
-    summon_type followers = next_bool() ? SUMMON_APOCRYPHA_FOLLOWERS : SUMMON_APOCRYPHA_DRAGONS;
+    summon_type followers = one_in_(2) ? SUMMON_APOCRYPHA_FOLLOWERS : SUMMON_APOCRYPHA_DRAGONS;
     for (int k = 0; k < num; k++)
         count += summon_specific(player_ptr, m_idx, y, x, 200, followers, PM_ALLOW_UNIQUE);
 

--- a/src/object-enchant/apply-magic-ring.cpp
+++ b/src/object-enchant/apply-magic-ring.cpp
@@ -411,7 +411,7 @@ void RingEnchanter::give_high_ego_index()
     case SV_RING_DAMAGE:
     case SV_RING_ACCURACY:
     case SV_RING_SLAYING:
-        if (next_bool()) {
+        if (one_in_(2)) {
             break;
         }
 
@@ -432,7 +432,7 @@ void RingEnchanter::give_high_ego_index()
         this->o_ptr->name2 = EGO_RING_HERO;
         break;
     case SV_RING_SHOTS:
-        if (next_bool()) {
+        if (one_in_(2)) {
             break;
         }
 
@@ -445,7 +445,7 @@ void RingEnchanter::give_high_ego_index()
         this->o_ptr->name2 = EGO_RING_TELE_AWAY;
         break;
     case SV_RING_RES_BLINDNESS:
-        this->o_ptr->name2 = next_bool() ? EGO_RING_RES_LITE : EGO_RING_RES_DARK;
+        this->o_ptr->name2 = one_in_(2) ? EGO_RING_RES_LITE : EGO_RING_RES_DARK;
         break;
     case SV_RING_LORDLY:
         if (!one_in_(20)) {
@@ -457,21 +457,21 @@ void RingEnchanter::give_high_ego_index()
         this->o_ptr->name2 = EGO_RING_TRUE;
         break;
     case SV_RING_FLAMES:
-        if (next_bool()) {
+        if (one_in_(2)) {
             break;
         }
 
         this->o_ptr->name2 = EGO_RING_DRAGON_F;
         break;
     case SV_RING_ICE:
-        if (next_bool()) {
+        if (one_in_(2)) {
             break;
         }
 
         this->o_ptr->name2 = EGO_RING_DRAGON_C;
         break;
     case SV_RING_WARNING:
-        if (next_bool()) {
+        if (one_in_(2)) {
             break;
         }
 

--- a/src/save/info-writer.cpp
+++ b/src/save/info-writer.cpp
@@ -36,9 +36,14 @@ void wr_store(store_type *store_ptr)
 void wr_randomizer(void)
 {
     wr_u16b(0);
-    wr_u16b(Rand_place);
-    for (int i = 0; i < RAND_DEG; i++)
-        wr_u32b(Rand_state[i]);
+    wr_u16b(0);
+    const auto &state = w_ptr->rng.get_state();
+    for (const auto s : state) {
+        wr_u32b(s);
+    }
+    for (int i = state.size(); i < RAND_DEG; i++) {
+        wr_u32b(0);
+    }
 }
 
 /*!

--- a/src/term/z-rand.cpp
+++ b/src/term/z-rand.cpp
@@ -18,6 +18,7 @@
 #include "util/rng-xoshiro.h"
 #include "world/world.h"
 
+#include <cmath>
 #include <optional>
 #include <random>
 
@@ -110,114 +111,13 @@ int rand_range(int a, int b)
 }
 
 /*
- * The number of entries in the "randnor_table"
- */
-#define RANDNOR_NUM 256
-
-/*
- * The standard deviation of the "randnor_table"
- */
-#define RANDNOR_STD 64
-
-/*
- * The normal distribution table for the "randnor()" function (below)
- */
-static constexpr int16_t randnor_table[RANDNOR_NUM] = {
-    // clang-format off
-	206,     613,    1022,    1430,		1838,	 2245,	  2652,	   3058,
-	3463,    3867,    4271,    4673,	5075,	 5475,	  5874,	   6271,
-	6667,    7061,    7454,    7845,	8234,	 8621,	  9006,	   9389,
-	9770,   10148,   10524,   10898,   11269,	11638,	 12004,	  12367,
-	12727,   13085,   13440,   13792,   14140,	14486,	 14828,	  15168,
-	15504,   15836,   16166,   16492,   16814,	17133,	 17449,	  17761,
-	18069,   18374,   18675,   18972,   19266,	19556,	 19842,	  20124,
-	20403,   20678,   20949,   21216,   21479,	21738,	 21994,	  22245,
-
-	22493,   22737,   22977,   23213,   23446,	23674,	 23899,	  24120,
-	24336,   24550,   24759,   24965,   25166,	25365,	 25559,	  25750,
-	25937,   26120,   26300,   26476,   26649,	26818,	 26983,	  27146,
-	27304,   27460,   27612,   27760,   27906,	28048,	 28187,	  28323,
-	28455,   28585,   28711,   28835,   28955,	29073,	 29188,	  29299,
-	29409,   29515,   29619,   29720,   29818,	29914,	 30007,	  30098,
-	30186,   30272,   30356,   30437,   30516,	30593,	 30668,	  30740,
-	30810,   30879,   30945,   31010,   31072,	31133,	 31192,	  31249,
-
-	31304,   31358,   31410,   31460,   31509,	31556,	 31601,	  31646,
-	31688,   31730,   31770,   31808,   31846,	31882,	 31917,	  31950,
-	31983,   32014,   32044,   32074,   32102,	32129,	 32155,	  32180,
-	32205,   32228,   32251,   32273,   32294,	32314,	 32333,	  32352,
-	32370,   32387,   32404,   32420,   32435,	32450,	 32464,	  32477,
-	32490,   32503,   32515,   32526,   32537,	32548,	 32558,	  32568,
-	32577,   32586,   32595,   32603,   32611,	32618,	 32625,	  32632,
-	32639,   32645,   32651,   32657,   32662,	32667,	 32672,	  32677,
-
-	32682,   32686,   32690,   32694,   32698,	32702,	 32705,	  32708,
-	32711,   32714,   32717,   32720,   32722,	32725,	 32727,	  32729,
-	32731,   32733,   32735,   32737,   32739,	32740,	 32742,	  32743,
-	32745,   32746,   32747,   32748,   32749,	32750,	 32751,	  32752,
-	32753,   32754,   32755,   32756,   32757,	32757,	 32758,	  32758,
-	32759,   32760,   32760,   32761,   32761,	32761,	 32762,	  32762,
-	32763,   32763,   32763,   32764,   32764,	32764,	 32764,	  32765,
-	32765,   32765,   32765,   32766,   32766,	32766,	 32766,	  32767,
-    // clang-format on
-};
-
-/*
  * Generate a random integer number of NORMAL distribution
- *
- * The table above is used to generate a pseudo-normal distribution,
- * in a manner which is much faster than calling a transcendental
- * function to calculate a true normal distribution.
- *
- * Basically, entry 64*N in the table above represents the number of
- * times out of 32767 that a random variable with normal distribution
- * will fall within N standard deviations of the mean.  That is, about
- * 68 percent of the time for N=1 and 95 percent of the time for N=2.
- *
- * The table above contains a "faked" final entry which allows us to
- * pretend that all values in a normal distribution are strictly less
- * than four standard deviations away from the mean.  This results in
- * "conservative" distribution of approximately 1/32768 values.
- *
- * Note that the binary search takes up to 16 quick iterations.
  */
 int16_t randnor(int mean, int stand)
 {
-    int16_t tmp;
-    int16_t offset;
-
-    int16_t low = 0;
-    int16_t high = RANDNOR_NUM;
-    if (stand < 1)
-        return (int16_t)(mean);
-
-    /* Roll for probability */
-    tmp = (int16_t)randint0(32768);
-
-    /* Binary Search */
-    while (low < high) {
-        int mid = (low + high) >> 1;
-
-        /* Move right if forced */
-        if (randnor_table[mid] < tmp) {
-            low = mid + 1;
-        }
-
-        /* Move left otherwise */
-        else {
-            high = (int16_t)mid;
-        }
-    }
-
-    /* Convert the index into an offset */
-    offset = (long)stand * (long)low / RANDNOR_STD;
-
-    /* One half should be negative */
-    if (randint0(100) < 50)
-        return (mean - offset);
-
-    /* One half should be positive */
-    return (mean + offset);
+    std::normal_distribution<> d(mean, stand);
+    auto result = std::round(d(w_ptr->rng));
+    return static_cast<int16_t>(result);
 }
 
 /*

--- a/src/term/z-rand.cpp
+++ b/src/term/z-rand.cpp
@@ -293,8 +293,3 @@ int32_t Rand_external(int32_t m)
     std::uniform_int_distribution<> d(0, m - 1);
     return d(urbg_external.value());
 }
-
-bool next_bool()
-{
-    return randint0(2) == 0;
-}

--- a/src/term/z-rand.h
+++ b/src/term/z-rand.h
@@ -68,4 +68,3 @@ int16_t damroll(DICE_NUMBER num, DICE_SID sides);
 int16_t maxroll(DICE_NUMBER num, DICE_SID sides);
 int32_t div_round(int32_t n, int32_t d);
 int32_t Rand_external(int32_t m);
-bool next_bool();

--- a/src/term/z-rand.h
+++ b/src/term/z-rand.h
@@ -8,8 +8,7 @@
  * are included in all such copies.  Other copyrights may also apply.
  */
 
-#ifndef INCLUDED_Z_RAND_H
-#define INCLUDED_Z_RAND_H
+#pragma once
 
 #include "system/h-basic.h"
 
@@ -21,21 +20,19 @@
  */
 #define RAND_DEG 63
 
-/**** Available macros ****/
+/*
+ * Generates a random long integer X where A<=X<=B
+ * The integer X falls along a uniform distribution.
+ * Note: rand_range(0,N-1) == randint0(N)
+ */
+int rand_range(int a, int b);
 
 /*
  * Generates a random long integer X where O<=X<M.
  * The integer X falls along a uniform distribution.
  * For example, if M is 100, you get "percentile dice"
  */
-#define randint0(M) ((int32_t)Rand_div(M))
-
-/*
- * Generates a random long integer X where A<=X<=B
- * The integer X falls along a uniform distribution.
- * Note: rand_range(0,N-1) == randint0(N)
- */
-#define rand_range(A, B) ((A) + (randint0(1 + (B) - (A))))
+#define randint0(M) (rand_range(0, (M) - 1))
 
 /*
  * Generate a random long integer X where A-D<=X<=A+D
@@ -55,6 +52,9 @@
  */
 #define magik(P) (randint0(100) < (P))
 
+/*
+ * Evaluate to TRUE with probability 1/x
+ */
 #define one_in_(X) (randint0(X) == 0)
 
 /*
@@ -62,19 +62,10 @@
  */
 #define saving_throw(S) (randint0(100) < (S))
 
-extern uint16_t Rand_place;
-extern uint32_t Rand_state[RAND_DEG];
-
 void Rand_state_init(void);
-void Rand_state_set(uint32_t seed);
-void Rand_state_backup(uint32_t *backup_state);
-void Rand_state_restore(uint32_t *backup_state);
-int32_t Rand_div(int32_t m);
 int16_t randnor(int mean, int stand);
 int16_t damroll(DICE_NUMBER num, DICE_SID sides);
 int16_t maxroll(DICE_NUMBER num, DICE_SID sides);
 int32_t div_round(int32_t n, int32_t d);
 int32_t Rand_external(int32_t m);
 bool next_bool();
-
-#endif

--- a/src/util/rng-xoshiro.cpp
+++ b/src/util/rng-xoshiro.cpp
@@ -1,0 +1,101 @@
+﻿#include "util/rng-xoshiro.h"
+
+namespace {
+
+/*!
+ * @brief 32ビットデータを右ローテートする
+ *
+ * @param x 右ローテートする32ビットデータ
+ * @param k 右ローテートするビット数
+ * @return xを右にkビットローテートした32ビットデータを返す
+ */
+uint32_t u32b_rotl(uint32_t x, int k)
+{
+    return (x << k) | (x >> (32 - k));
+}
+
+}
+
+/*!
+ * @brief デフォルトシードで乱数の内部状態を初期化したXoshiro128StarStarクラスのオブジェクトを生成する
+ */
+Xoshiro128StarStar::Xoshiro128StarStar()
+    : rng_state{
+        // default seeds
+        123456789,
+        362436069,
+        521288629,
+        88675123,
+    }
+{
+}
+
+/*!
+ * @brief 引数で与えたシードを元に乱数の内部状態を初期化したXoshiro128StarStarクラスのオブジェクトを生成する
+ *
+ * @param seed 乱数の内部状態を初期化する元となるシード
+ */
+Xoshiro128StarStar::Xoshiro128StarStar(uint32_t seed)
+{
+    this->set_state(seed);
+}
+
+/*!
+ * @brief 次の乱数を生成し、内部状態を更新する
+ *
+ * @return 生成した乱数を返す
+ */
+Xoshiro128StarStar::result_type Xoshiro128StarStar::operator()()
+{
+    auto &s = this->rng_state;
+
+    const uint32_t result = u32b_rotl(s[1] * 5, 7) * 9;
+
+    const uint32_t t = s[1] << 9;
+
+    s[2] ^= s[0];
+    s[3] ^= s[1];
+    s[1] ^= s[2];
+    s[0] ^= s[3];
+
+    s[2] ^= t;
+
+    s[3] = u32b_rotl(s[3], 11);
+
+    return result;
+}
+
+/*!
+ * @brief 乱数の内部状態をセットする
+ *
+ * @param state 乱数の内部状態
+ */
+void Xoshiro128StarStar::set_state(const state_type &state)
+{
+    this->rng_state = state;
+}
+
+/*!
+ * @brief シードを元に乱数の内部状態をセットする
+ *
+ * @param seed 乱数の内部状態の元とするシード
+ */
+void Xoshiro128StarStar::set_state(uint32_t seed)
+{
+    auto i = 1;
+    for (auto &s : this->rng_state) {
+        seed = 1812433253UL * (seed ^ (seed >> 30)) + i;
+        s = seed;
+        ++i;
+    }
+}
+
+/**
+ * @brief 乱数の内部状態を取得する
+ *
+ * @return 乱数の内部状態への参照
+ */
+const Xoshiro128StarStar::state_type &Xoshiro128StarStar::get_state() const
+{
+    return this->rng_state;
+}

--- a/src/util/rng-xoshiro.h
+++ b/src/util/rng-xoshiro.h
@@ -1,0 +1,44 @@
+﻿#pragma once
+
+#include <array>
+#include <cstdint>
+
+#ifdef WINDOWS
+// windows.h をインクルードすると min と max マクロが勝手に定義されるという迷惑な仕様があるため、
+// undef しておかないと Xoshiro128StarStar::min/max の宣言がエラーになる
+#undef min
+#undef max
+#endif
+
+/*!
+ * @brief 乱数生成器 xoshiro128** クラス
+ * @details 乱数生成器 xoshiro128** (https://prng.di.unimi.it/) を STL の <random> ヘッダで提供される
+ * 各種アルゴリズムが使用できる Uniform Random Bit Generator として実装したクラス
+ */
+class Xoshiro128StarStar {
+public:
+    using result_type = uint32_t;
+    using state_type = std::array<uint32_t, 4>;
+
+    Xoshiro128StarStar();
+    explicit Xoshiro128StarStar(uint32_t seed);
+
+    static constexpr result_type min()
+    {
+        return 0;
+    }
+    static constexpr result_type max()
+    {
+        return ~min();
+    }
+
+    result_type operator()();
+
+    void set_state(uint32_t seed);
+
+    void set_state(const state_type &state);
+    const state_type &get_state() const;
+
+private:
+    state_type rng_state; //!< RNG state
+};

--- a/src/world/world.h
+++ b/src/world/world.h
@@ -3,6 +3,7 @@
 #include "player-info/class-types.h"
 #include "system/angband.h"
 #include "util/flag-group.h"
+#include "util/rng-xoshiro.h"
 
 #define MAX_BOUNTY 20
 
@@ -28,6 +29,8 @@ struct world_type {
     MONSTER_IDX today_mon{}; //!< 実際の日替わり賞金首
 
     uint32_t play_time{}; /*!< 実プレイ時間 */
+
+    Xoshiro128StarStar rng; //!< Uniform random bit generator for <random>
 
     uint32_t seed_flavor{}; /* Hack -- consistent object colors */
     uint32_t seed_town{}; /* Hack -- consistent town layout */


### PR DESCRIPTION
C++化の一環として乱数生成関連で以下のリファクタリングを行いました。

- <random> ヘッダを使えるように現在の xoshiro128** を実装する Uniform Random Bit Generator 要件を満たすクラス Xoshiro128StarStar の作成
- 上記のオブジェクトをRNGとして world_type 構造体のメンバに持たせる
- 一様整数分布乱数に std::uniform_int_distribution を使用する
- 正規分布乱数に std::normal_distribution を使用する

また、next_bool() という半々の確率でtrue/falseのいずれかを返す関数がありますが、one_in_(2)で十分で存在意義が見いだせない（むしろ1/2という情報が無くなって曖昧になってしまっている）ので削除しました。