### PR TITLE
[Feature] 英語版のフレーバーテキストを良い感じに連結する

### DIFF
--- a/src/info-reader/artifact-reader.cpp
+++ b/src/info-reader/artifact-reader.cpp
@@ -86,7 +86,7 @@ errr parse_a_info(std::string_view buf, angband_header *)
 #else
         if (tokens[1][0] != '$')
             return PARSE_ERROR_NONE;
-        a_ptr->text.append(buf.substr(3));
+        append_english_text(a_ptr->text, buf.substr(3));
 #endif
     } else if (tokens[0] == "I") {
         // I:tval:sval:pval

--- a/src/info-reader/dungeon-reader.cpp
+++ b/src/info-reader/dungeon-reader.cpp
@@ -128,7 +128,7 @@ errr parse_d_info(std::string_view buf, angband_header *)
 #else
         if (tokens[1][0] != '$')
             return PARSE_ERROR_NONE;
-        d_ptr->text.append(buf.substr(3));
+        append_english_text(d_ptr->text, buf.substr(3));
 #endif
     } else if (tokens[0] == "W") {
         // W:min_level:max_level:(1):mode:(2):(3):(4):(5):prob_pit:prob_nest

--- a/src/info-reader/info-reader-util.cpp
+++ b/src/info-reader/info-reader-util.cpp
@@ -2,8 +2,9 @@
 #include "artifact/random-art-effects.h"
 #include "main/angband-headers.h"
 #include "object-enchant/activation-info-table.h"
-#include "view/display-messages.h"
 #include "util/enum-converter.h"
+#include "util/string-processor.h"
+#include "view/display-messages.h"
 
 /* Help give useful error messages */
 int error_idx; /*!< データ読み込み/初期化時に汎用的にエラーコードを保存するグローバル変数 */
@@ -35,3 +36,28 @@ RandomArtActType grab_one_activation_flag(concptr what)
     msg_format(_("未知の発動・フラグ '%s'。", "Unknown activation flag '%s'."), what);
     return RandomArtActType::NONE;
 }
+
+#ifndef JP
+/*!
+ * @brief 英語のフレーバーテキストを連結する
+ * @details add は両端のスペースを削除し、text が空でなく連結する場合は text の末尾が
+ * ".!?" のいずれかならスペースを2つ、それ以外ならスペースを1つ挟んで連結する。
+ *
+ * @param text 現在までに作成されたフレーバーテキスト
+ * @param add 連結するテキスト
+ */
+void append_english_text(std::string &text, std::string_view add)
+{
+    const auto add_trimmed = str_trim(add);
+    if (add_trimmed.empty()) {
+        return;
+    }
+
+    if (!text.empty()) {
+        constexpr std::string_view eos_symbols = ".!?";
+        auto is_eos = eos_symbols.find(text.back()) != std::string_view::npos;
+        text.append(is_eos ? "  " : " ");
+    }
+    text.append(add_trimmed);
+}
+#endif

--- a/src/info-reader/info-reader-util.h
+++ b/src/info-reader/info-reader-util.h
@@ -15,6 +15,10 @@ extern int error_line; //!< エラーが発生した行
 enum class RandomArtActType : short;
 RandomArtActType grab_one_activation_flag(concptr what);
 
+#ifndef JP
+void append_english_text(std::string &text, std::string_view add);
+#endif
+
 /*!
  * @brief infoフラグ文字列をフラグビットに変換する
  * @param flags ビットフラグ変数

--- a/src/info-reader/kind-reader.cpp
+++ b/src/info-reader/kind-reader.cpp
@@ -87,7 +87,7 @@ errr parse_k_info(std::string_view buf, angband_header *)
 #else
         if (tokens[1][0] != '$')
             return PARSE_ERROR_NONE;
-        k_ptr->text.append(buf.substr(3));
+        append_english_text(k_ptr->text, buf.substr(3));
 #endif
     } else if (tokens[0] == "G") {
         // G:color:symbol

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -113,7 +113,7 @@ errr parse_r_info(std::string_view buf, angband_header *)
 #else
         if (tokens[1][0] != '$')
             return PARSE_ERROR_NONE;
-        r_ptr->text.append(buf.substr(3));
+        append_english_text(r_ptr->text, buf.substr(3));
 #endif
     } else if (tokens[0] == "G") {
         // G:color:symbol


### PR DESCRIPTION
現在*_info.txtに記述される英語版のフレーバーテキストは、2行以上にわたる
場合スペースを挟んで連結されるように行末か行頭にスペースを入れている。
しかし、行末にスペースを入れると視認しづらいし、どちらに入れるにしても
メンテナンスが面倒になるので、パーサの処理時に自動的にスペースを挟んで
連結するようにする。
既存のフレーバーテキストのスペースは削除しなくて済むように、パーサ側で
両端のスペースは削除しながら連結する。


ちなみに現時点でも、第○の乗り手のユニークなどスペースが挿入されておらず思い出を表示すると行の前後が繋がってしまっているものがいくつかあるようです。