### PR TITLE
元素使いで切り傷を直すと却って傷が深くなる不具合を修正した

### DIFF
--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -497,7 +497,7 @@ static bool cast_element_spell(player_type *player_ptr, SPELL_IDX spell_idx)
         return psychometry(player_ptr);
     case ElementSpells::CURE:
         (void)hp_player(player_ptr, damroll(2, 8));
-        (void)BadStatusSetter(player_ptr).mod_cut(10);
+        (void)BadStatusSetter(player_ptr).mod_cut(-10);
         break;
     case ElementSpells::BOLT_2ND:
         if (!get_aim_dir(player_ptr, &dir))


### PR DESCRIPTION
掲題の通りです
ピンポイントで切り傷蓄積の正負が逆でした (リファクタリング時のエンバグ)
ご確認下さい