### PR TITLE
[Refactor] 武器熟練度のテーブルを std::map にする

### DIFF
--- a/src/birth/birth-stat.cpp
+++ b/src/birth/birth-stat.cpp
@@ -124,13 +124,11 @@ void get_extra(player_type *player_ptr, bool roll_hitdie)
     }
 
     auto pclass = enum2i(player_ptr->pclass);
-    for (int i = 0; i < 5; i++)
-        for (int j = 0; j < 64; j++)
-            player_ptr->weapon_exp[i][j] = s_info[pclass].w_start[i][j];
+    player_ptr->weapon_exp = s_info[pclass].w_start;
 
-    auto sexy_tval = ItemKindType::HAFTED - TV_WEAPON_BEGIN;
-    if ((player_ptr->ppersonality == PERSONALITY_SEXY) && (player_ptr->weapon_exp[sexy_tval][SV_WHIP] < WEAPON_EXP_BEGINNER)) {
-        player_ptr->weapon_exp[sexy_tval][SV_WHIP] = WEAPON_EXP_BEGINNER;
+    auto &whip_exp = player_ptr->weapon_exp[ItemKindType::HAFTED][SV_WHIP];
+    if ((player_ptr->ppersonality == PERSONALITY_SEXY) && (whip_exp < WEAPON_EXP_BEGINNER)) {
+        whip_exp = WEAPON_EXP_BEGINNER;
     }
 
     for (int i = 0; i < MAX_SKILLS; i++)

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -429,9 +429,9 @@ void exe_fire(player_type *player_ptr, INVENTORY_IDX item, object_type *j_ptr, S
     /* Actually "fire" the object */
     bonus = (player_ptr->to_h_b + o_ptr->to_h + j_ptr->to_h);
     if ((j_ptr->sval == SV_LIGHT_XBOW) || (j_ptr->sval == SV_HEAVY_XBOW))
-        chance = (player_ptr->skill_thb + (player_ptr->weapon_exp[0][j_ptr->sval] / 400 + bonus) * BTH_PLUS_ADJ);
+        chance = (player_ptr->skill_thb + (player_ptr->weapon_exp[j_ptr->tval][j_ptr->sval] / 400 + bonus) * BTH_PLUS_ADJ);
     else
-        chance = (player_ptr->skill_thb + ((player_ptr->weapon_exp[0][j_ptr->sval] - (WEAPON_EXP_MASTER / 2)) / 200 + bonus) * BTH_PLUS_ADJ);
+        chance = (player_ptr->skill_thb + ((player_ptr->weapon_exp[j_ptr->tval][j_ptr->sval] - (WEAPON_EXP_MASTER / 2)) / 200 + bonus) * BTH_PLUS_ADJ);
 
     PlayerEnergy(player_ptr).set_player_turn_energy(bow_energy(j_ptr->sval));
     tmul = bow_tmul(j_ptr->sval);
@@ -637,8 +637,8 @@ void exe_fire(player_type *player_ptr, INVENTORY_IDX item, object_type *j_ptr, S
                 }
 
                 if ((r_ptr->level + 10) > player_ptr->lev) {
-                    int now_exp = player_ptr->weapon_exp[0][j_ptr->sval];
-                    if (now_exp < s_info[enum2i(player_ptr->pclass)].w_max[0][j_ptr->sval]) {
+                    auto &now_exp = player_ptr->weapon_exp[j_ptr->tval][j_ptr->sval];
+                    if (now_exp < s_info[enum2i(player_ptr->pclass)].w_max[j_ptr->tval][j_ptr->sval]) {
                         SUB_EXP amount = 0;
                         if (now_exp < WEAPON_EXP_BEGINNER)
                             amount = 80;
@@ -648,7 +648,7 @@ void exe_fire(player_type *player_ptr, INVENTORY_IDX item, object_type *j_ptr, S
                             amount = 10;
                         else if (player_ptr->lev > 34)
                             amount = 2;
-                        player_ptr->weapon_exp[0][j_ptr->sval] += amount;
+                        now_exp += amount;
                         set_bits(player_ptr->update, PU_BONUS);
                     }
                 }
@@ -963,9 +963,9 @@ HIT_POINT critical_shot(player_type *player_ptr, WEIGHT weight, int plus_ammo, i
     i = player_ptr->to_h_b + plus_ammo;
 
     if (player_ptr->tval_ammo == ItemKindType::BOLT)
-        i = (player_ptr->skill_thb + (player_ptr->weapon_exp[0][j_ptr->sval] / 400 + i) * BTH_PLUS_ADJ);
+        i = (player_ptr->skill_thb + (player_ptr->weapon_exp[j_ptr->tval][j_ptr->sval] / 400 + i) * BTH_PLUS_ADJ);
     else
-        i = (player_ptr->skill_thb + ((player_ptr->weapon_exp[0][j_ptr->sval] - (WEAPON_EXP_MASTER / 2)) / 200 + i) * BTH_PLUS_ADJ);
+        i = (player_ptr->skill_thb + ((player_ptr->weapon_exp[j_ptr->tval][j_ptr->sval] - (WEAPON_EXP_MASTER / 2)) / 200 + i) * BTH_PLUS_ADJ);
 
     auto sniper_data = PlayerClass(player_ptr).get_specific_data<sniper_data_type>();
     auto sniper_concent = sniper_data ? sniper_data->concent : 0;
@@ -1114,9 +1114,9 @@ HIT_POINT calc_crit_ratio_shot(player_type *player_ptr, HIT_POINT plus_ammo, HIT
     i = player_ptr->to_h_b + plus_ammo;
 
     if (player_ptr->tval_ammo == ItemKindType::BOLT)
-        i = (player_ptr->skill_thb + (player_ptr->weapon_exp[0][j_ptr->sval] / 400 + i) * BTH_PLUS_ADJ);
+        i = (player_ptr->skill_thb + (player_ptr->weapon_exp[j_ptr->tval][j_ptr->sval] / 400 + i) * BTH_PLUS_ADJ);
     else
-        i = (player_ptr->skill_thb + ((player_ptr->weapon_exp[0][j_ptr->sval] - (WEAPON_EXP_MASTER / 2)) / 200 + i) * BTH_PLUS_ADJ);
+        i = (player_ptr->skill_thb + ((player_ptr->weapon_exp[j_ptr->tval][j_ptr->sval] - (WEAPON_EXP_MASTER / 2)) / 200 + i) * BTH_PLUS_ADJ);
 
     auto sniper_data = PlayerClass(player_ptr).get_specific_data<sniper_data_type>();
     auto sniper_concent = sniper_data ? sniper_data->concent : 0;

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -258,12 +258,12 @@ static void generate_world(player_type *player_ptr, bool new_game)
     panel_col_min = floor_ptr->width;
 
     if (player_ptr->pclass != PlayerClassType::SORCERER) {
-        auto begin = enum2i(TV_WEAPON_BEGIN);
+        auto pclass = enum2i(player_ptr->pclass);
         if (player_ptr->ppersonality == PERSONALITY_SEXY)
-            s_info[enum2i(player_ptr->pclass)].w_max[enum2i(ItemKindType::HAFTED) - begin][SV_WHIP] = WEAPON_EXP_MASTER;
+            s_info[pclass].w_max[ItemKindType::HAFTED][SV_WHIP] = WEAPON_EXP_MASTER;
         if (player_ptr->prace == PlayerRaceType::MERFOLK) {
-            s_info[enum2i(player_ptr->pclass)].w_max[enum2i(ItemKindType::POLEARM) - begin][SV_TRIDENT] = WEAPON_EXP_MASTER;
-            s_info[enum2i(player_ptr->pclass)].w_max[enum2i(ItemKindType::POLEARM) - begin][SV_TRIFURCATE_SPEAR] = WEAPON_EXP_MASTER;
+            s_info[pclass].w_max[ItemKindType::POLEARM][SV_TRIDENT] = WEAPON_EXP_MASTER;
+            s_info[pclass].w_max[ItemKindType::POLEARM][SV_TRIFURCATE_SPEAR] = WEAPON_EXP_MASTER;
         }
     }
 

--- a/src/info-reader/skill-reader.cpp
+++ b/src/info-reader/skill-reader.cpp
@@ -4,6 +4,7 @@
 #include "main/angband-headers.h"
 #include "object/tval-types.h"
 #include "player/player-skill.h"
+#include "util/enum-converter.h"
 #include "util/string-processor.h"
 
 namespace {
@@ -47,8 +48,8 @@ errr parse_s_info(std::string_view buf, angband_header *head)
         if (tokens.size() < 5)
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
 
-        int tval, sval, start, max;
-        info_set_value(tval, tokens[1]);
+        int tval_offset, sval, start, max;
+        info_set_value(tval_offset, tokens[1]);
         info_set_value(sval, tokens[2]);
         info_set_value(start, tokens[3]);
         info_set_value(max, tokens[4]);
@@ -61,6 +62,7 @@ errr parse_s_info(std::string_view buf, angband_header *head)
         if (max_exp == level_to_exp.end())
             return PARSE_ERROR_INVALID_FLAG;
 
+        auto tval = ItemKindType::BOW + tval_offset;
         s_ptr->w_start[tval][sval] = (SUB_EXP)start_exp->second;
         s_ptr->w_max[tval][sval] = (SUB_EXP)max_exp->second;
     } else if (tokens[0] == "S") {

--- a/src/knowledge/knowledge-experiences.cpp
+++ b/src/knowledge/knowledge-experiences.cpp
@@ -31,17 +31,17 @@ void do_cmd_knowledge_weapon_exp(player_type *player_ptr)
     if (!open_temporary_file(&fff, file_name))
         return;
 
-    for (int i = 0; i < 5; i++) {
+    for (auto tval : {ItemKindType::SWORD, ItemKindType::POLEARM, ItemKindType::HAFTED, ItemKindType::DIGGING, ItemKindType::BOW}) {
         for (int num = 0; num < 64; num++) {
             char tmp[30];
             for (const auto &k_ref : k_info) {
-                if ((enum2i(k_ref.tval) != enum2i(ItemKindType::SWORD) - i) || (k_ref.sval != num))
+                if ((k_ref.tval != tval) || (k_ref.sval != num))
                     continue;
                 if ((k_ref.tval == ItemKindType::BOW) && (k_ref.sval == SV_CRIMSON || k_ref.sval == SV_HARP))
                     continue;
 
-                SUB_EXP weapon_exp = player_ptr->weapon_exp[4 - i][num];
-                SUB_EXP weapon_max = s_info[enum2i(player_ptr->pclass)].w_max[4 - i][num];
+                SUB_EXP weapon_exp = player_ptr->weapon_exp[tval][num];
+                SUB_EXP weapon_max = s_info[enum2i(player_ptr->pclass)].w_max[tval][num];
                 strip_name(tmp, k_ref.idx);
                 fprintf(fff, "%-25s ", tmp);
                 if (show_actual_value)

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -117,9 +117,9 @@ void rd_experience(player_type *player_ptr)
             player_ptr->spell_exp[i] = SPELL_EXP_MASTER;
 
     const int max_weapon_exp_size = h_older_than(0, 3, 6) ? 60 : 64;
-    for (int i = 0; i < 5; i++)
+    for (auto tval : TV_WEAPON_RANGE)
         for (int j = 0; j < max_weapon_exp_size; j++)
-            rd_s16b(&player_ptr->weapon_exp[i][j]);
+            rd_s16b(&player_ptr->weapon_exp[tval][j]);
 
     for (int i = 0; i < MAX_SKILLS; i++)
         rd_s16b(&player_ptr->skill_exp[i]);

--- a/src/object-hook/hook-weapon.cpp
+++ b/src/object-hook/hook-weapon.cpp
@@ -34,7 +34,7 @@ bool object_is_favorite(player_type *player_ptr, const object_type *o_ptr)
     case PlayerClassType::MONK:
     case PlayerClassType::FORCETRAINER:
         /* Icky to wield? */
-        if (!(s_info[short_pclass].w_max[o_ptr->tval - TV_WEAPON_BEGIN][o_ptr->sval]))
+        if (!(s_info[short_pclass].w_max[o_ptr->tval][o_ptr->sval]))
             return false;
         break;
 
@@ -50,13 +50,13 @@ bool object_is_favorite(player_type *player_ptr, const object_type *o_ptr)
     }
 
     case PlayerClassType::SORCERER:
-        if (s_info[short_pclass].w_max[o_ptr->tval - TV_WEAPON_BEGIN][o_ptr->sval] < WEAPON_EXP_MASTER)
+        if (s_info[short_pclass].w_max[o_ptr->tval][o_ptr->sval] < WEAPON_EXP_MASTER)
             return false;
         break;
 
     case PlayerClassType::NINJA:
         /* Icky to wield? */
-        if (s_info[short_pclass].w_max[o_ptr->tval - TV_WEAPON_BEGIN][o_ptr->sval] <= WEAPON_EXP_BEGINNER)
+        if (s_info[short_pclass].w_max[o_ptr->tval][o_ptr->sval] <= WEAPON_EXP_BEGINNER)
             return false;
         break;
 

--- a/src/object/tval-types.h
+++ b/src/object/tval-types.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include "util/enum-converter.h"
+#include "util/enum-range.h"
 
 enum class ItemKindType : short {
     NONE = 0,
@@ -84,3 +84,5 @@ enum class ItemKindType : short {
 #define TV_WEAPON_END ItemKindType::SWORD
 #define TV_ARMOR_BEGIN ItemKindType::BOOTS
 #define TV_ARMOR_END ItemKindType::DRAG_ARMOR
+
+constexpr auto TV_WEAPON_RANGE = EnumRange(TV_WEAPON_BEGIN, TV_WEAPON_END);

--- a/src/player-attack/player-attack.cpp
+++ b/src/player-attack/player-attack.cpp
@@ -139,8 +139,8 @@ static void get_bare_knuckle_exp(player_type *player_ptr, player_attack_type *pa
  */
 static void get_weapon_exp(player_type *player_ptr, player_attack_type *pa_ptr)
 {
-    int tval = player_ptr->inventory_list[INVEN_MAIN_HAND + pa_ptr->hand].tval - TV_WEAPON_BEGIN;
-    OBJECT_SUBTYPE_VALUE sval = player_ptr->inventory_list[INVEN_MAIN_HAND + pa_ptr->hand].sval;
+    auto tval = player_ptr->inventory_list[INVEN_MAIN_HAND + pa_ptr->hand].tval;
+    auto sval = player_ptr->inventory_list[INVEN_MAIN_HAND + pa_ptr->hand].sval;
     int now_exp = player_ptr->weapon_exp[tval][sval];
     if (now_exp >= s_info[enum2i(player_ptr->pclass)].w_max[tval][sval])
         return;

--- a/src/player/player-skill.h
+++ b/src/player/player-skill.h
@@ -1,6 +1,9 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+
+#include <array>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -42,14 +45,16 @@ enum skill_idx {
 
 extern const concptr exp_level_str[5];
 
+enum class ItemKindType : short;
+
 /*
  * Information about "skill"
  */
 typedef struct skill_table {
-    SUB_EXP w_start[5][64]{}; /* start weapon exp */
-    SUB_EXP w_max[5][64]{}; /* max weapon exp */
-    SUB_EXP s_start[10]{}; /* start skill */
-    SUB_EXP s_max[10]{}; /* max skill */
+    std::map<ItemKindType, std::array<SUB_EXP, 64>> w_start{}; /* start weapon exp */
+    std::map<ItemKindType, std::array<SUB_EXP, 64>> w_max{}; /* max weapon exp */
+    SUB_EXP s_start[MAX_SKILLS]{}; /* start skill */
+    SUB_EXP s_max[MAX_SKILLS]{}; /* max skill */
 } skill_table;
 
 extern std::vector<skill_table> s_info;

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -1635,8 +1635,8 @@ bool has_not_ninja_weapon(player_type *player_ptr, int i)
         return false;
     }
 
-    auto tval = player_ptr->inventory_list[INVEN_MAIN_HAND + i].tval - TV_WEAPON_BEGIN;
-    OBJECT_SUBTYPE_VALUE sval = player_ptr->inventory_list[INVEN_MAIN_HAND + i].sval;
+    auto tval = player_ptr->inventory_list[INVEN_MAIN_HAND + i].tval;
+    auto sval = player_ptr->inventory_list[INVEN_MAIN_HAND + i].sval;
     return player_ptr->pclass == PlayerClassType::NINJA
         && !((s_info[enum2i(PlayerClassType::NINJA)].w_max[tval][sval] > WEAPON_EXP_BEGINNER) && (player_ptr->inventory_list[INVEN_SUB_HAND - i].tval != ItemKindType::SHIELD));
 }
@@ -1647,8 +1647,8 @@ bool has_not_monk_weapon(player_type *player_ptr, int i)
         return false;
     }
     
-    auto tval = player_ptr->inventory_list[INVEN_MAIN_HAND + i].tval - TV_WEAPON_BEGIN;
-    OBJECT_SUBTYPE_VALUE sval = player_ptr->inventory_list[INVEN_MAIN_HAND + i].sval;
+    auto tval = player_ptr->inventory_list[INVEN_MAIN_HAND + i].tval;
+    auto sval = player_ptr->inventory_list[INVEN_MAIN_HAND + i].sval;
     return ((player_ptr->pclass == PlayerClassType::MONK) || (player_ptr->pclass == PlayerClassType::FORCETRAINER)) && !(s_info[enum2i(player_ptr->pclass)].w_max[tval][sval]);
 }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -2162,11 +2162,8 @@ static int16_t calc_to_hit(player_type *player_ptr, INVENTORY_IDX slot, bool is_
         object_type *o_ptr = &player_ptr->inventory_list[slot];
         auto flgs = object_flags(o_ptr);
 
-        auto tval = o_ptr->tval - TV_WEAPON_BEGIN;
-        OBJECT_SUBTYPE_VALUE sval = o_ptr->sval;
-
         /* Traind bonuses */
-        hit += (player_ptr->weapon_exp[tval][sval] - WEAPON_EXP_BEGINNER) / 200;
+        hit += (player_ptr->weapon_exp[o_ptr->tval][o_ptr->sval] - WEAPON_EXP_BEGINNER) / 200;
 
         /* Weight penalty */
         if (calc_weapon_weight_limit(player_ptr) < o_ptr->weight / 10) {

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -78,9 +78,9 @@ void wr_player(player_type *player_ptr)
     for (int i = 0; i < 64; i++)
         wr_s16b(player_ptr->spell_exp[i]);
 
-    for (int i = 0; i < 5; i++)
+    for (auto tval : TV_WEAPON_RANGE)
         for (int j = 0; j < 64; j++)
-            wr_s16b(player_ptr->weapon_exp[i][j]);
+            wr_s16b(player_ptr->weapon_exp[tval][j]);
 
     for (int i = 0; i < MAX_SKILLS; i++)
         wr_s16b(player_ptr->skill_exp[i]);

--- a/src/system/gamevalue.h
+++ b/src/system/gamevalue.h
@@ -39,6 +39,8 @@
 #define MIN_M_ALLOC_TD          4 /*!< 街(昼間)の最低住人配置数 / The town starts out with 4 residents during the day */
 #define MIN_M_ALLOC_TN          8 /*!< 街(夜間)の最低住人配置数 / The town starts out with 8 residents during the night */
 
+#define MAX_SKILLS 10
+
 /*!
 * @brief モンスター増殖の最大数
 * @details

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -2,7 +2,6 @@
 
 #include "mutation/mutation-flag-types.h"
 #include "object-enchant/trc-types.h"
-#include "object/tval-types.h"
 #include "player-ability/player-ability-types.h"
 #include "player-info/class-specific-data.h"
 #include "player-info/class-types.h"
@@ -13,8 +12,10 @@
 #include "system/system-variables.h"
 #include "util/flag-group.h"
 
-#define MAX_SKILLS 10
+#include <array>
+#include <map>
 
+enum class ItemKindType : short;
 enum class RF_ABILITY;
 
 struct floor_type;
@@ -38,7 +39,7 @@ public:
     int16_t realm1{}; /* First magic realm */
     int16_t realm2{}; /* Second magic realm */
     int16_t element{}; //!< 元素使い領域番号 / Elementalist system index
-    
+
     DICE_SID hitdie{}; /* Hit dice (sides) */
     uint16_t expfact{}; /* Experience factor
                          * Note: was byte, causing overflow for Amberite
@@ -184,7 +185,7 @@ public:
     SPELL_IDX spell_order[64]{}; /* order spells learned/remembered/forgotten */
 
     SUB_EXP spell_exp[64]{}; /* Proficiency of spells */
-    SUB_EXP weapon_exp[5][64]{}; /* Proficiency of weapons */
+    std::map<ItemKindType, std::array<SUB_EXP, 64>> weapon_exp{}; /* Proficiency of weapons */
     SUB_EXP skill_exp[MAX_SKILLS]{}; /* Proficiency of misc. skill */
 
     ClassSpecificData class_specific_data;

--- a/src/view/display-player-middle.cpp
+++ b/src/view/display-player-middle.cpp
@@ -99,9 +99,9 @@ static void display_hit_damage(player_type *player_ptr)
         show_todam += o_ptr->to_d;
 
     if ((o_ptr->sval == SV_LIGHT_XBOW) || (o_ptr->sval == SV_HEAVY_XBOW))
-        show_tohit += player_ptr->weapon_exp[0][o_ptr->sval] / 400;
+        show_tohit += player_ptr->weapon_exp[o_ptr->tval][o_ptr->sval] / 400;
     else
-        show_tohit += (player_ptr->weapon_exp[0][o_ptr->sval] - (WEAPON_EXP_MASTER / 2)) / 200;
+        show_tohit += (player_ptr->weapon_exp[o_ptr->tval][o_ptr->sval] - (WEAPON_EXP_MASTER / 2)) / 200;
 
     show_tohit += player_ptr->skill_thb / BTH_PLUS_ADJ;
 

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -97,6 +97,7 @@
 #include "wizard/wizard-spoiler.h"
 #include "world/world.h"
 
+#include <algorithm>
 #include <optional>
 #include <sstream>
 #include <tuple>
@@ -420,12 +421,9 @@ void wiz_change_status(player_type *player_ptr)
     if (tmp_s16b > WEAPON_EXP_MASTER)
         tmp_s16b = WEAPON_EXP_MASTER;
 
-    for (auto j = 0; j <= TV_WEAPON_END - TV_WEAPON_BEGIN; j++) {
+    for (auto tval : TV_WEAPON_RANGE) {
         for (int i = 0; i < 64; i++) {
-            player_ptr->weapon_exp[j][i] = tmp_s16b;
-            auto short_pclass = enum2i(player_ptr->pclass);
-            if (player_ptr->weapon_exp[j][i] > s_info[short_pclass].w_max[j][i])
-                player_ptr->weapon_exp[j][i] = s_info[short_pclass].w_max[j][i];
+            player_ptr->weapon_exp[tval][i] = std::min(tmp_s16b, s_info[enum2i(player_ptr->pclass)].w_max[tval][i]);
         }
     }
 


### PR DESCRIPTION
既存の武器熟練度のテーブルは弓のtvalをベースにした武器のtvalのオフセットを
要素にした配列で持っているためアクセスするのに余計な引き算や列挙型と基底型
の変換が必要になってしまう。
列挙型で直接アクセスでき、データの意味合い的にも連想コンテナのほうがふさわ
しいので std::map を使用するようにする。

なお、 #1754 とコンフリクトするはずなので、後で直す予定。