### PR TITLE
[Implement] get_value()が参照代入値ポインタの入力前値をデフォルト値にするよう仕様追加。

### DIFF
--- a/src/core/asking-player.cpp
+++ b/src/core/asking-player.cpp
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <string>
 #include <sstream>
+#include <charconv>
 
 /*
  * Get some string input at the cursor location.
@@ -422,7 +423,8 @@ bool get_value(const char *text, int min, int max, int *value)
 {
     std::stringstream st;
     int val;
-    char tmp_val[10] = "";
+    char tmp_val[12] = "";
+    std::to_chars(std::begin(tmp_val), std::end(tmp_val) - 1, *value);
     st << text << "(" << min << "-" << max << "): ";
     int digit = std::max(std::to_string(min).length(), std::to_string(max).length());
     while (true) {

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -192,7 +192,7 @@ void wiz_summon_random_enemy(player_type *player_ptr, int num)
 void wiz_summon_specific_enemy(player_type *player_ptr, MONRACE_IDX r_idx)
 {
     if (r_idx <= 0) {
-        int val;
+        int val = 1;
         if(!get_value("MonsterID", 1, r_info.size() - 1, &val)) {
             return;
         }
@@ -211,7 +211,7 @@ void wiz_summon_specific_enemy(player_type *player_ptr, MONRACE_IDX r_idx)
 void wiz_summon_pet(player_type *player_ptr, MONRACE_IDX r_idx)
 {
     if (r_idx <= 0) {
-        int val;
+        int val = 1;
         if (!get_value("MonsterID", 1, r_info.size() - 1, &val)) {
             return;
         }


### PR DESCRIPTION
現在ウェイト処理のms指定とデバッグモードのモンスターID指定にだけ用いています。
レビューお願いします。
