### PR TITLE
[Refactor] セーブファイルから整数値を読み込む関数のインターフェース

### DIFF
--- a/src/load/birth-loader.cpp
+++ b/src/load/birth-loader.cpp
@@ -16,46 +16,36 @@ void load_quick_start(void)
         return;
     }
 
-    byte tmp8u;
-    rd_byte(&tmp8u);
-    previous_char.psex = i2enum<player_sex>(tmp8u);
-    rd_byte(&tmp8u);
-    previous_char.prace = (PlayerRaceType)tmp8u;
-    rd_byte(&tmp8u);
-    previous_char.pclass = (PlayerClassType)tmp8u;
-    rd_byte(&tmp8u);
-    previous_char.ppersonality = (player_personality_type)tmp8u;
-    rd_byte(&tmp8u);
-    previous_char.realm1 = (int16_t)tmp8u;
-    rd_byte(&tmp8u);
-    previous_char.realm2 = (int16_t)tmp8u;
+    previous_char.psex = i2enum<player_sex>(rd_byte());
+    previous_char.prace = i2enum<PlayerRaceType>(rd_byte());
+    previous_char.pclass = i2enum<PlayerClassType>(rd_byte());
+    previous_char.ppersonality = i2enum<player_personality_type>(rd_byte());
+    previous_char.realm1 = rd_byte();
+    previous_char.realm2 = rd_byte();
 
-    rd_s16b(&previous_char.age);
-    rd_s16b(&previous_char.ht);
-    rd_s16b(&previous_char.wt);
-    rd_s16b(&previous_char.sc);
-    rd_s32b(&previous_char.au);
+    previous_char.age = rd_s16b();
+    previous_char.ht = rd_s16b();
+    previous_char.wt = rd_s16b();
+    previous_char.sc = rd_s16b();
+    previous_char.au = rd_s32b();
 
     for (int i = 0; i < A_MAX; i++)
-        rd_s16b(&previous_char.stat_max[i]);
+        previous_char.stat_max[i] = rd_s16b();
     for (int i = 0; i < A_MAX; i++)
-        rd_s16b(&previous_char.stat_max_max[i]);
+        previous_char.stat_max_max[i] = rd_s16b();
 
     for (int i = 0; i < PY_MAX_LEVEL; i++) {
-        int16_t tmp16s;
-        rd_s16b(&tmp16s);
-        previous_char.player_hp[i] = (HIT_POINT)tmp16s;
+        previous_char.player_hp[i] = rd_s16b();
     }
 
-    rd_s16b(&previous_char.chaos_patron);
+    previous_char.chaos_patron = rd_s16b();
 
     for (int i = 0; i < 8; i++)
-        rd_s16b(&previous_char.vir_types[i]);
+        previous_char.vir_types[i] = rd_s16b();
 
     for (int i = 0; i < 4; i++)
         rd_string(previous_char.history[i], sizeof(previous_char.history[i]));
 
-    rd_byte(&tmp8u);
-    rd_byte(&tmp8u);
-    previous_char.quick_ok = (bool)tmp8u;
+    strip_bytes(1);
+    previous_char.quick_ok = rd_byte() != 0;
 }

--- a/src/load/dummy-loader.cpp
+++ b/src/load/dummy-loader.cpp
@@ -13,12 +13,8 @@
  */
 void rd_dummy1(void)
 {
-    int16_t tmp16s;
-    rd_s16b(&tmp16s);
-    for (int i = 0; i < tmp16s; i++) {
-        int16_t tmp16s2;
-        rd_s16b(&tmp16s2);
-    }
+    auto tmp16s = rd_s16b();
+    strip_bytes(2 * tmp16s);
 }
 
 /*!
@@ -28,10 +24,7 @@ void rd_dummy1(void)
  */
 void rd_dummy2(void)
 {
-    byte tmp8u;
-    for (int i = 0; i < 48; i++)
-        rd_byte(&tmp8u);
-
+    strip_bytes(48);
     strip_bytes(12);
 }
 
@@ -45,8 +38,7 @@ void rd_dummy_monsters(player_type *player_ptr)
     if (h_older_than(1, 5, 0, 2))
         return;
 
-    int16_t tmp16s;
-    rd_s16b(&tmp16s);
+    auto tmp16s = rd_s16b();
     for (int i = 0; i < tmp16s; i++) {
         monster_type dummy_mon;
         rd_monster(player_ptr, &dummy_mon);
@@ -67,9 +59,6 @@ void rd_ghost(void)
 
 void rd_dummy3(void)
 {
-    uint16_t tmp16u;
-    rd_u16b(&tmp16u);
-
-    byte tmp8u;
-    rd_byte(&tmp8u);
+    strip_bytes(2);
+    strip_bytes(1);
 }

--- a/src/load/dungeon-loader.cpp
+++ b/src/load/dungeon-loader.cpp
@@ -37,38 +37,31 @@ static errr rd_dungeon(player_type *player_ptr)
         return err;
     }
 
-    rd_s16b(&max_floor_id);
-    byte tmp8u;
-    rd_byte(&tmp8u);
-    player_ptr->dungeon_idx = (DUNGEON_IDX)tmp8u; // @todo セーブデータの方を16ビットにするかdungeon_idxの定義を8ビットにした方が良い.
-    byte num;
-    rd_byte(&num);
+    max_floor_id = rd_s16b();
+    player_ptr->dungeon_idx = rd_byte(); // @todo セーブデータの方を16ビットにするかdungeon_idxの定義を8ビットにした方が良い.
+    auto num = rd_byte();
     if (num == 0) {
         err = rd_saved_floor(player_ptr, nullptr);
     } else {
         for (int i = 0; i < num; i++) {
             saved_floor_type *sf_ptr = &saved_floors[i];
 
-            rd_s16b(&sf_ptr->floor_id);
-            rd_byte(&tmp8u);
-            sf_ptr->savefile_id = (int16_t)tmp8u;
+            sf_ptr->floor_id = rd_s16b();
+            sf_ptr->savefile_id = rd_byte();
 
-            int16_t tmp16s;
-            rd_s16b(&tmp16s);
-            sf_ptr->dun_level = (DEPTH)tmp16s;
+            sf_ptr->dun_level = rd_s16b();
 
-            rd_s32b(&sf_ptr->last_visit);
-            rd_u32b(&sf_ptr->visit_mark);
-            rd_s16b(&sf_ptr->upper_floor_id);
-            rd_s16b(&sf_ptr->lower_floor_id);
+            sf_ptr->last_visit = rd_s32b();
+            sf_ptr->visit_mark = rd_u32b();
+            sf_ptr->upper_floor_id = rd_s16b();
+            sf_ptr->lower_floor_id = rd_s16b();
         }
 
         for (int i = 0; i < num; i++) {
             saved_floor_type *sf_ptr = &saved_floors[i];
             if (!sf_ptr->floor_id)
                 continue;
-            rd_byte(&tmp8u);
-            if (tmp8u)
+            if (rd_byte() != 0)
                 continue;
 
             err = rd_saved_floor(player_ptr, sf_ptr);
@@ -146,8 +139,7 @@ errr restore_dungeon(player_type *player_ptr)
     }
 
     rd_ghost();
-    int32_t tmp32s;
-    rd_s32b(&tmp32s);
+    auto tmp32s = rd_s32b();
     strip_bytes(tmp32s);
     return 0;
 }

--- a/src/load/extra-loader.cpp
+++ b/src/load/extra-loader.cpp
@@ -22,20 +22,20 @@ void rd_extra(player_type *player_ptr)
     if (h_older_than(0, 0, 7))
         player_ptr->riding = 0;
     else
-        rd_s16b(&player_ptr->riding);
+        player_ptr->riding = rd_s16b();
 
     if (h_older_than(1, 5, 0, 0))
         player_ptr->floor_id = 0;
     else
-        rd_s16b(&player_ptr->floor_id);
+        player_ptr->floor_id = rd_s16b();
 
     rd_dummy_monsters(player_ptr);
     if (h_older_than(0, 1, 2))
         w_ptr->play_time = 0;
     else
-        rd_u32b(&w_ptr->play_time);
+        w_ptr->play_time = rd_u32b();
 
     rd_visited_towns(player_ptr);
     if (!h_older_than(1, 0, 5))
-        rd_u32b(&player_ptr->count);
+        player_ptr->count = rd_u32b();
 }

--- a/src/load/info-loader.cpp
+++ b/src/load/info-loader.cpp
@@ -16,8 +16,7 @@
  */
 void rd_version_info(void)
 {
-    byte fake_major;
-    rd_byte(&fake_major);
+    byte fake_major = rd_byte();
 
     strip_bytes(3);
     load_xor_byte = w_ptr->sf_extra;
@@ -25,17 +24,17 @@ void rd_version_info(void)
     x_check = 0L;
 
     /* Old savefile will be version 0.0.0.3 */
-    rd_byte(&w_ptr->h_ver_extra);
-    rd_byte(&w_ptr->h_ver_patch);
-    rd_byte(&w_ptr->h_ver_minor);
-    rd_byte(&w_ptr->h_ver_major);
+    w_ptr->h_ver_extra = rd_byte();
+    w_ptr->h_ver_patch = rd_byte();
+    w_ptr->h_ver_minor = rd_byte();
+    w_ptr->h_ver_major = rd_byte();
 
-    rd_u32b(&w_ptr->sf_system);
-    rd_u32b(&w_ptr->sf_when);
-    rd_u16b(&w_ptr->sf_lives);
-    rd_u16b(&w_ptr->sf_saves);
+    w_ptr->sf_system = rd_u32b();
+    w_ptr->sf_when = rd_u32b();
+    w_ptr->sf_lives = rd_u16b();
+    w_ptr->sf_saves = rd_u16b();
 
-    rd_u32b(&loading_savefile_version);
+    loading_savefile_version = rd_u32b();
 
     /* h_ver_majorがfake_ver_majorと同じだったころへの対策 */
     if (fake_major - w_ptr->h_ver_major < FAKE_VER_PLUS)
@@ -51,20 +50,15 @@ void rd_version_info(void)
  */
 void rd_randomizer(void)
 {
-    uint16_t tmp16u;
-    rd_u16b(&tmp16u);
-    rd_u16b(&tmp16u);
+    strip_bytes(4);
 
     Xoshiro128StarStar::state_type state;
     for (auto &s : state) {
-        rd_u32b(&s);
+        s = rd_u32b();
     }
     w_ptr->rng.set_state(state);
 
-    uint32_t tmp32u;
-    for (int i = state.size(); i < RAND_DEG; i++) {
-        rd_u32b(&tmp32u);
-    }
+    strip_bytes(4 * (RAND_DEG - state.size()));
 }
 
 /*!
@@ -73,8 +67,7 @@ void rd_randomizer(void)
 void rd_messages(void)
 {
     if (h_older_than(2, 2, 0, 75)) {
-        uint16_t num;
-        rd_u16b(&num);
+        auto num = rd_u16b();
         int message_max;
         message_max = (int)num;
 
@@ -85,8 +78,7 @@ void rd_messages(void)
         }
     }
 
-    uint32_t num;
-    rd_u32b(&num);
+    auto num = rd_u32b();
     int message_max = (int)num;
     for (int i = 0; i < message_max; i++) {
         char buf[128];
@@ -97,7 +89,7 @@ void rd_messages(void)
 
 void rd_system_info(void)
 {
-    rd_byte(&kanji_code);
+    kanji_code = rd_byte();
     rd_randomizer();
     load_note(_("乱数情報をロードしました", "Loaded Randomizer Info"));
     rd_options();

--- a/src/load/inventory-loader.cpp
+++ b/src/load/inventory-loader.cpp
@@ -28,8 +28,7 @@ static errr rd_inventory(player_type *player_ptr)
 
     int slot = 0;
     while (true) {
-        uint16_t n;
-        rd_u16b(&n);
+        auto n = rd_u16b();
 
         if (n == 0xFFFF)
             break;
@@ -65,10 +64,8 @@ static errr rd_inventory(player_type *player_ptr)
 
 errr load_inventory(player_type *player_ptr)
 {
-    byte tmp8u;
     for (int i = 0; i < 64; i++) {
-        rd_byte(&tmp8u);
-        player_ptr->spell_order[i] = (SPELL_IDX)tmp8u;
+        player_ptr->spell_order[i] = rd_byte();
     }
 
     if (!rd_inventory(player_ptr))

--- a/src/load/item-loader.cpp
+++ b/src/load/item-loader.cpp
@@ -29,15 +29,11 @@ void rd_item(object_type *o_ptr)
         return;
     }
 
-    BIT_FLAGS flags;
-    rd_u32b(&flags);
-    rd_s16b(&o_ptr->k_idx);
+    auto flags = rd_u32b();
+    o_ptr->k_idx = rd_s16b();
 
-    byte tmp8u;
-    rd_byte(&tmp8u);
-    o_ptr->iy = (POSITION)tmp8u;
-    rd_byte(&tmp8u);
-    o_ptr->ix = (POSITION)tmp8u;
+    o_ptr->iy = rd_byte();
+    o_ptr->ix = rd_byte();
 
     object_kind *k_ptr;
     k_ptr = &k_info[o_ptr->k_idx];
@@ -45,86 +41,77 @@ void rd_item(object_type *o_ptr)
     o_ptr->sval = k_ptr->sval;
 
     if (any_bits(flags, SaveDataItemFlagType::PVAL))
-        rd_s16b(&o_ptr->pval);
+        o_ptr->pval = rd_s16b();
     else
         o_ptr->pval = 0;
 
     if (any_bits(flags, SaveDataItemFlagType::DISCOUNT))
-        rd_byte(&o_ptr->discount);
+        o_ptr->discount = rd_byte();
     else
         o_ptr->discount = 0;
     if (any_bits(flags, SaveDataItemFlagType::NUMBER)) {
-        rd_byte(&tmp8u);
-        o_ptr->number = tmp8u;
+        o_ptr->number = rd_byte();
     } else
         o_ptr->number = 1;
 
-    int16_t tmp16s;
-    rd_s16b(&tmp16s);
-    o_ptr->weight = tmp16s;
+    o_ptr->weight = rd_s16b();
 
     if (any_bits(flags, SaveDataItemFlagType::NAME1)) {
         if (h_older_than(3, 0, 0, 2)) {
-            rd_byte(&tmp8u);
-            o_ptr->name1 = tmp8u;
+            o_ptr->name1 = rd_byte();
         } else {
-            rd_s16b(&tmp16s);
-            o_ptr->name1 = tmp16s;
+            o_ptr->name1 = rd_s16b();
         }
     } else
         o_ptr->name1 = 0;
 
     if (any_bits(flags, SaveDataItemFlagType::NAME2)) {
-        rd_byte(&tmp8u);
-        o_ptr->name2 = tmp8u;
+        o_ptr->name2 = rd_byte();
     } else
         o_ptr->name2 = 0;
 
     if (any_bits(flags, SaveDataItemFlagType::TIMEOUT))
-        rd_s16b(&o_ptr->timeout);
+        o_ptr->timeout = rd_s16b();
     else
         o_ptr->timeout = 0;
 
     if (any_bits(flags, SaveDataItemFlagType::TO_H))
-        rd_s16b(&o_ptr->to_h);
+        o_ptr->to_h = rd_s16b();
     else
         o_ptr->to_h = 0;
 
     if (any_bits(flags, SaveDataItemFlagType::TO_D)) {
-        rd_s16b(&tmp16s);
-        o_ptr->to_d = tmp16s;
+        o_ptr->to_d = rd_s16b();
     } else
         o_ptr->to_d = 0;
 
     if (any_bits(flags, SaveDataItemFlagType::TO_A))
-        rd_s16b(&o_ptr->to_a);
+        o_ptr->to_a = rd_s16b();
     else
         o_ptr->to_a = 0;
 
     if (any_bits(flags, SaveDataItemFlagType::AC))
-        rd_s16b(&o_ptr->ac);
+        o_ptr->ac = rd_s16b();
     else
         o_ptr->ac = 0;
 
     if (any_bits(flags, SaveDataItemFlagType::DD)) {
-        rd_byte(&tmp8u);
-        o_ptr->dd = tmp8u;
+        o_ptr->dd = rd_byte();
     } else
         o_ptr->dd = 0;
 
     if (any_bits(flags, SaveDataItemFlagType::DS)) {
-        rd_byte(&tmp8u);
-        o_ptr->ds = tmp8u;
+        o_ptr->ds = rd_byte();
     } else
         o_ptr->ds = 0;
 
     if (any_bits(flags, SaveDataItemFlagType::IDENT))
-        rd_byte(&o_ptr->ident);
+        o_ptr->ident = rd_byte();
     else
         o_ptr->ident = 0;
 
     if (any_bits(flags, SaveDataItemFlagType::MARKED))
-        rd_byte(&o_ptr->marked);
+        o_ptr->marked = rd_byte();
     else
         o_ptr->marked = 0;
 
@@ -140,8 +127,7 @@ void rd_item(object_type *o_ptr)
         auto start = 0;
         for (auto f : old_savefile_art_flags) {
             if (any_bits(flags, f)) {
-                uint32_t tmp32u;
-                rd_u32b(&tmp32u);
+                auto tmp32u = rd_u32b();
                 migrate_bitflag_to_flaggroup(o_ptr->art_flags, tmp32u, start);
             }
             start += 32;
@@ -156,8 +142,7 @@ void rd_item(object_type *o_ptr)
 
     if (any_bits(flags, SaveDataItemFlagType::CURSE_FLAGS)) {
         if (loading_savefile_version_is_older_than(5)) {
-            uint32_t tmp32u;
-            rd_u32b(&tmp32u);
+            auto tmp32u = rd_u32b();
             migrate_bitflag_to_flaggroup(o_ptr->curse_flags, tmp32u);
         } else {
             rd_FlagGroup(o_ptr->curse_flags, rd_byte);
@@ -168,61 +153,57 @@ void rd_item(object_type *o_ptr)
 
     /* Monster holding object */
     if (any_bits(flags, SaveDataItemFlagType::HELD_M_IDX))
-        rd_s16b(&o_ptr->held_m_idx);
+        o_ptr->held_m_idx = rd_s16b();
     else
         o_ptr->held_m_idx = 0;
 
     /* Special powers */
     if (any_bits(flags, SaveDataItemFlagType::XTRA1))
-        rd_byte(&o_ptr->xtra1);
+        o_ptr->xtra1 = rd_byte();
     else
         o_ptr->xtra1 = 0;
 
     if (any_bits(flags, SaveDataItemFlagType::ACTIVATION_ID)) {
         if (h_older_than(3, 0, 0, 2)) {
-            rd_byte(&tmp8u);
-            o_ptr->activation_id = i2enum<RandomArtActType>(tmp8u);
+            o_ptr->activation_id = i2enum<RandomArtActType>(rd_byte());
         } else {
-            rd_s16b(&tmp16s);
-            o_ptr->activation_id = i2enum<RandomArtActType>(tmp16s);
+            o_ptr->activation_id = i2enum<RandomArtActType>(rd_s16b());
         }
     } else {
         o_ptr->activation_id = i2enum<RandomArtActType>(0);
     }
 
     if (any_bits(flags, SaveDataItemFlagType::XTRA3))
-        rd_byte(&o_ptr->xtra3);
+        o_ptr->xtra3 = rd_byte();
     else
         o_ptr->xtra3 = 0;
 
     if (any_bits(flags, SaveDataItemFlagType::XTRA4))
-        rd_s16b(&o_ptr->xtra4);
+        o_ptr->xtra4 = rd_s16b();
     else
         o_ptr->xtra4 = 0;
 
     if (any_bits(flags, SaveDataItemFlagType::XTRA5))
-        rd_s16b(&o_ptr->xtra5);
+        o_ptr->xtra5 = rd_s16b();
     else
         o_ptr->xtra5 = 0;
 
     if (any_bits(flags, SaveDataItemFlagType::FEELING))
-        rd_byte(&o_ptr->feeling);
+        o_ptr->feeling = rd_byte();
     else
         o_ptr->feeling = 0;
 
     if (any_bits(flags, SaveDataItemFlagType::STACK_IDX))
-        rd_s16b(&o_ptr->stack_idx);
+        o_ptr->stack_idx = rd_s16b();
     else
         o_ptr->stack_idx = 0;
 
     if (any_bits(flags, SaveDataItemFlagType::SMITH) && !loading_savefile_version_is_older_than(7)) {
-        rd_s16b(&tmp16s);
-        if (tmp16s > 0) {
+        if (auto tmp16s = rd_s16b(); tmp16s > 0) {
             o_ptr->smith_effect = static_cast<SmithEffect>(tmp16s);
         }
 
-        rd_s16b(&tmp16s);
-        if (tmp16s > 0) {
+        if (auto tmp16s = rd_s16b(); tmp16s > 0) {
             o_ptr->smith_act_idx = static_cast<RandomArtActType>(tmp16s);
         }
     }
@@ -301,19 +282,17 @@ void rd_item(object_type *o_ptr)
  */
 errr load_item(void)
 {
-    uint16_t loading_max_k_idx;
-    rd_u16b(&loading_max_k_idx);
+    auto loading_max_k_idx = rd_u16b();
 
     object_kind *k_ptr;
     object_kind dummy;
-    byte tmp8u;
     for (auto i = 0U; i < loading_max_k_idx; i++) {
         if (i < k_info.size())
             k_ptr = &k_info[i];
         else
             k_ptr = &dummy;
 
-        rd_byte(&tmp8u);
+        auto tmp8u = rd_byte();
         k_ptr->aware = any_bits(tmp8u, 0x01);
         k_ptr->tried = any_bits(tmp8u, 0x02);
     }
@@ -328,27 +307,22 @@ errr load_item(void)
  */
 errr load_artifact(void)
 {
-    uint16_t loading_max_a_idx;
-    rd_u16b(&loading_max_a_idx);
+    auto loading_max_a_idx = rd_u16b();
 
     artifact_type *a_ptr;
     artifact_type dummy;
-    byte tmp8u;
     for (auto i = 0U; i < loading_max_a_idx; i++) {
         if (i < a_info.size())
             a_ptr = &a_info[i];
         else
             a_ptr = &dummy;
 
-        rd_byte(&tmp8u);
-        a_ptr->cur_num = tmp8u;
+        a_ptr->cur_num = rd_byte();
         if (h_older_than(1, 5, 0, 0)) {
             a_ptr->floor_id = 0;
-            rd_byte(&tmp8u);
-            rd_byte(&tmp8u);
-            rd_byte(&tmp8u);
+            strip_bytes(3);
         } else {
-            rd_s16b(&a_ptr->floor_id);
+            a_ptr->floor_id = rd_s16b();
         }
     }
 

--- a/src/load/load-util.cpp
+++ b/src/load/load-util.cpp
@@ -54,44 +54,52 @@ byte sf_get(void)
 }
 
 /*!
- * @brief ロードファイルポインタから1バイトを読み込んでポインタに渡す
- * @param ip 読み込みポインタ
+ * @brief ロードファイルポインタから1バイトを読み込む
  */
-void rd_byte(byte *ip) { *ip = sf_get(); }
-
-/*!
- * @brief ロードファイルポインタから符号なし16bit値を読み込んでポインタに渡す
- * @param ip 読み込みポインタ
- */
-void rd_u16b(uint16_t *ip)
+byte rd_byte()
 {
-    (*ip) = sf_get();
-    (*ip) |= ((uint16_t)(sf_get()) << 8);
+    return sf_get();
 }
 
 /*!
- * @brief ロードファイルポインタから符号つき16bit値を読み込んでポインタに渡す
- * @param ip 読み込みポインタ
+ * @brief ロードファイルポインタから符号なし16bit値を読み込む
  */
-void rd_s16b(int16_t *ip) { rd_u16b((uint16_t *)ip); }
-
-/*!
- * @brief ロードファイルポインタから符号なし32bit値を読み込んでポインタに渡す
- * @param ip 読み込みポインタ
- */
-void rd_u32b(uint32_t *ip)
+uint16_t rd_u16b()
 {
-    (*ip) = sf_get();
-    (*ip) |= ((uint32_t)(sf_get()) << 8);
-    (*ip) |= ((uint32_t)(sf_get()) << 16);
-    (*ip) |= ((uint32_t)(sf_get()) << 24);
+    uint16_t val = sf_get();
+    val |= (static_cast<uint16_t>(sf_get()) << 8);
+
+    return val;
 }
 
 /*!
- * @brief ロードファイルポインタから符号つき32bit値を読み込んでポインタに渡す
- * @param ip 読み込みポインタ
+ * @brief ロードファイルポインタから符号つき16bit値を読み込む
  */
-void rd_s32b(int32_t *ip) { rd_u32b((uint32_t *)ip); }
+int16_t rd_s16b()
+{
+    return static_cast<int16_t>(rd_u16b());
+}
+
+/*!
+ * @brief ロードファイルポインタから符号なし32bit値を読み込む
+ */
+uint32_t rd_u32b()
+{
+    uint32_t val = sf_get();
+    val |= (static_cast<uint32_t>(sf_get()) << 8);
+    val |= (static_cast<uint32_t>(sf_get()) << 16);
+    val |= (static_cast<uint32_t>(sf_get()) << 24);
+
+    return val;
+}
+
+/*!
+ * @brief ロードファイルポインタから符号つき32bit値を読み込む
+ */
+int32_t rd_s32b()
+{
+    return static_cast<int32_t>(rd_u32b());
+}
 
 /*!
  * @brief ロードファイルポインタから文字列を読み込んでポインタに渡す / Hack -- read a string
@@ -101,8 +109,7 @@ void rd_s32b(int32_t *ip) { rd_u32b((uint32_t *)ip); }
 void rd_string(char *str, int max)
 {
     for (int i = 0; true; i++) {
-        byte tmp8u;
-        rd_byte(&tmp8u);
+        auto tmp8u = rd_byte();
         if (i < max)
             str[i] = tmp8u;
 
@@ -146,9 +153,9 @@ void rd_string(char *str, int max)
  */
 void strip_bytes(int n)
 {
-    byte tmp8u;
-    while (n--)
-        rd_byte(&tmp8u);
+    while (n-- > 0) {
+        (void)rd_byte();
+    }
 }
 
 /**

--- a/src/load/load-util.h
+++ b/src/load/load-util.h
@@ -14,11 +14,11 @@ extern byte kanji_code;
 
 void load_note(concptr msg);
 byte sf_get(void);
-void rd_byte(byte *ip);
-void rd_u16b(uint16_t *ip);
-void rd_s16b(int16_t *ip);
-void rd_u32b(uint32_t *ip);
-void rd_s32b(int32_t *ip);
+byte rd_byte();
+uint16_t rd_u16b();
+int16_t rd_s16b();
+uint32_t rd_u32b();
+int32_t rd_s32b();
 void rd_string(char *str, int max);
 void strip_bytes(int n);
 bool loading_savefile_version_is_older_than(uint32_t version);

--- a/src/load/load-v1-5-0.cpp
+++ b/src/load/load-v1-5-0.cpp
@@ -60,19 +60,14 @@ const int QUEST_ROYAL_CRYPT = 28; // 王家の墓.
  */
 void rd_item_old(object_type *o_ptr)
 {
-    rd_s16b(&o_ptr->k_idx);
+    o_ptr->k_idx = rd_s16b();
 
-    byte tmp8u;
-    rd_byte(&tmp8u);
-    o_ptr->iy = (POSITION)tmp8u;
-    rd_byte(&tmp8u);
-    o_ptr->ix = (POSITION)tmp8u;
+    o_ptr->iy = rd_byte();
+    o_ptr->ix = rd_byte();
 
     /* Type/Subtype */
-    rd_byte(&tmp8u);
-    o_ptr->tval = i2enum<ItemKindType>(tmp8u);
-    rd_byte(&tmp8u);
-    o_ptr->sval = tmp8u;
+    o_ptr->tval = i2enum<ItemKindType>(rd_byte());
+    o_ptr->sval = rd_byte();
 
     if (h_older_than(0, 4, 4)) {
         if (o_ptr->tval == i2enum <ItemKindType>(100))
@@ -83,40 +78,31 @@ void rd_item_old(object_type *o_ptr)
             o_ptr->tval = ItemKindType::HISSATSU_BOOK;
     }
 
-    rd_s16b(&o_ptr->pval);
-    rd_byte(&o_ptr->discount);
-    rd_byte(&tmp8u);
-    o_ptr->number = (ITEM_NUMBER)tmp8u;
+    o_ptr->pval = rd_s16b();
+    o_ptr->discount = rd_byte();
+    o_ptr->number = rd_byte();
 
-    int16_t tmp16s;
-    rd_s16b(&tmp16s);
-    o_ptr->weight = tmp16s;
+    o_ptr->weight = rd_s16b();
 
-    rd_byte(&tmp8u);
-    o_ptr->name1 = tmp8u;
+    o_ptr->name1 = rd_byte();
 
-    rd_byte(&tmp8u);
-    o_ptr->name2 = tmp8u;
+    o_ptr->name2 = rd_byte();
 
-    rd_s16b(&o_ptr->timeout);
-    rd_s16b(&o_ptr->to_h);
-    rd_s16b(&tmp16s);
-    o_ptr->to_d = tmp16s;
+    o_ptr->timeout = rd_s16b();
+    o_ptr->to_h = rd_s16b();
+    o_ptr->to_d = rd_s16b();
 
-    rd_s16b(&o_ptr->to_a);
-    rd_s16b(&o_ptr->ac);
-    rd_byte(&tmp8u);
-    o_ptr->dd = tmp8u;
+    o_ptr->to_a = rd_s16b();
+    o_ptr->ac = rd_s16b();
+    o_ptr->dd = rd_byte();
 
-    rd_byte(&tmp8u);
-    o_ptr->ds = tmp8u;
+    o_ptr->ds = rd_byte();
 
-    rd_byte(&o_ptr->ident);
-    rd_byte(&o_ptr->marked);
+    o_ptr->ident = rd_byte();
+    o_ptr->marked = rd_byte();
 
     for (int i = 0, count = (h_older_than(1, 3, 0, 0) ? 3 : 4); i < count; i++) {
-        uint32_t tmp32u;
-        rd_u32b(&tmp32u);
+        auto tmp32u = rd_u32b();
         migrate_bitflag_to_flaggroup(o_ptr->art_flags, tmp32u, i * 32);
     }
 
@@ -150,15 +136,13 @@ void rd_item_old(object_type *o_ptr)
         }
         o_ptr->art_flags.reset({ i2enum<tr_type>(93), i2enum<tr_type>(94), i2enum<tr_type>(95) });
     } else {
-        uint32_t tmp32u;
-        rd_u32b(&tmp32u);
+        auto tmp32u = rd_u32b();
         migrate_bitflag_to_flaggroup(o_ptr->curse_flags, tmp32u);
     }
 
-    rd_s16b(&o_ptr->held_m_idx);
-    rd_byte(&o_ptr->xtra1);
-    rd_byte(&tmp8u);
-    o_ptr->activation_id = i2enum<RandomArtActType>(tmp8u);
+    o_ptr->held_m_idx = rd_s16b();
+    o_ptr->xtra1 = rd_byte();
+    o_ptr->activation_id = i2enum<RandomArtActType>(rd_byte());
 
     if (h_older_than(1, 0, 10)) {
         if (o_ptr->xtra1 == EGO_XTRA_SUSTAIN) {
@@ -271,14 +255,14 @@ void rd_item_old(object_type *o_ptr)
             o_ptr->xtra4 = o_ptr->xtra5;
         }
     } else {
-        rd_byte(&o_ptr->xtra3);
+        o_ptr->xtra3 = rd_byte();
         if (h_older_than(1, 3, 0, 1)) {
             if (o_ptr->is_smith() && o_ptr->xtra3 >= 1 + 96)
                 o_ptr->xtra3 += -96 + MIN_SPECIAL_ESSENCE;
         }
 
-        rd_s16b(&o_ptr->xtra4);
-        rd_s16b(&o_ptr->xtra5);
+        o_ptr->xtra4 = rd_s16b();
+        o_ptr->xtra5 = rd_s16b();
     }
 
     if (h_older_than(1, 0, 5)
@@ -287,7 +271,7 @@ void rd_item_old(object_type *o_ptr)
         o_ptr->pval = 0;
     }
 
-    rd_byte(&o_ptr->feeling);
+    o_ptr->feeling = rd_byte();
 
     char buf[128];
     rd_string(buf, sizeof(buf));
@@ -300,9 +284,7 @@ void rd_item_old(object_type *o_ptr)
     if (buf[0])
         o_ptr->art_name = quark_add(buf);
     {
-        int32_t tmp32s;
-
-        rd_s32b(&tmp32s);
+        auto tmp32s = rd_s32b();
         strip_bytes(tmp32s);
     }
 
@@ -341,12 +323,12 @@ void rd_item_old(object_type *o_ptr)
  */
 void rd_monster_old(player_type *player_ptr, monster_type *m_ptr)
 {
-    rd_s16b(&m_ptr->r_idx);
+    m_ptr->r_idx = rd_s16b();
 
     if (h_older_than(1, 0, 12))
         m_ptr->ap_r_idx = m_ptr->r_idx;
     else
-        rd_s16b(&m_ptr->ap_r_idx);
+        m_ptr->ap_r_idx = rd_s16b();
 
     if (h_older_than(1, 0, 14)) {
         monster_race *r_ptr = &r_info[m_ptr->r_idx];
@@ -357,42 +339,33 @@ void rd_monster_old(player_type *player_ptr, monster_type *m_ptr)
         if (r_ptr->flags3 & RF3_GOOD)
             m_ptr->sub_align |= SUB_ALIGN_GOOD;
     } else
-        rd_byte(&m_ptr->sub_align);
+        m_ptr->sub_align = rd_byte();
 
-    byte tmp8u;
-    rd_byte(&tmp8u);
-    m_ptr->fy = (POSITION)tmp8u;
-    rd_byte(&tmp8u);
-    m_ptr->fx = (POSITION)tmp8u;
+    m_ptr->fy = rd_byte();
+    m_ptr->fx = rd_byte();
     m_ptr->current_floor_ptr = player_ptr->current_floor_ptr;
 
-    int16_t tmp16s;
-    rd_s16b(&tmp16s);
-    m_ptr->hp = tmp16s;
-    rd_s16b(&tmp16s);
-    m_ptr->maxhp = tmp16s;
+    m_ptr->hp = rd_s16b();
+    m_ptr->maxhp = rd_s16b();
 
     if (h_older_than(1, 0, 5)) {
         m_ptr->max_maxhp = m_ptr->maxhp;
     } else {
-        rd_s16b(&tmp16s);
-        m_ptr->max_maxhp = (HIT_POINT)tmp16s;
+        m_ptr->max_maxhp = rd_s16b();
     }
     if (h_older_than(2, 1, 2, 1)) {
         m_ptr->dealt_damage = 0;
     } else {
-        rd_s32b(&m_ptr->dealt_damage);
+        m_ptr->dealt_damage = rd_s32b();
     }
 
-    rd_s16b(&m_ptr->mtimed[MTIMED_CSLEEP]);
-    rd_byte(&tmp8u);
-    m_ptr->mspeed = tmp8u;
+    m_ptr->mtimed[MTIMED_CSLEEP] = rd_s16b();
+    m_ptr->mspeed = rd_byte();
 
     if (h_older_than(0, 4, 2)) {
-        rd_byte(&tmp8u);
-        m_ptr->energy_need = (int16_t)tmp8u;
+        m_ptr->energy_need = rd_byte();
     } else
-        rd_s16b(&m_ptr->energy_need);
+        m_ptr->energy_need = rd_s16b();
 
     if (h_older_than(1, 0, 13))
         m_ptr->energy_need = 100 - m_ptr->energy_need;
@@ -401,36 +374,27 @@ void rd_monster_old(player_type *player_ptr, monster_type *m_ptr)
         m_ptr->mtimed[MTIMED_FAST] = 0;
         m_ptr->mtimed[MTIMED_SLOW] = 0;
     } else {
-        rd_byte(&tmp8u);
-        m_ptr->mtimed[MTIMED_FAST] = (int16_t)tmp8u;
-        rd_byte(&tmp8u);
-        m_ptr->mtimed[MTIMED_SLOW] = (int16_t)tmp8u;
+        m_ptr->mtimed[MTIMED_FAST] = rd_byte();
+        m_ptr->mtimed[MTIMED_SLOW] = rd_byte();
     }
 
-    rd_byte(&tmp8u);
-    m_ptr->mtimed[MTIMED_STUNNED] = (int16_t)tmp8u;
-    rd_byte(&tmp8u);
-    m_ptr->mtimed[MTIMED_CONFUSED] = (int16_t)tmp8u;
-    rd_byte(&tmp8u);
-    m_ptr->mtimed[MTIMED_MONFEAR] = (int16_t)tmp8u;
+    m_ptr->mtimed[MTIMED_STUNNED] = rd_byte();
+    m_ptr->mtimed[MTIMED_CONFUSED] = rd_byte();
+    m_ptr->mtimed[MTIMED_MONFEAR] = rd_byte();
 
     if (h_older_than(0, 0, 10)) {
         reset_target(m_ptr);
     } else if (h_older_than(0, 0, 11)) {
-        rd_s16b(&tmp16s);
+        strip_bytes(2);
         reset_target(m_ptr);
     } else {
-        rd_s16b(&tmp16s);
-        m_ptr->target_y = (POSITION)tmp16s;
-        rd_s16b(&tmp16s);
-        m_ptr->target_x = (POSITION)tmp16s;
+        m_ptr->target_y = rd_s16b();
+        m_ptr->target_x = rd_s16b();
     }
 
-    rd_byte(&tmp8u);
-    m_ptr->mtimed[MTIMED_INVULNER] = (int16_t)tmp8u;
+    m_ptr->mtimed[MTIMED_INVULNER] = rd_byte();
 
-    uint32_t tmp32u;
-    rd_u32b(&tmp32u);
+    auto tmp32u = rd_u32b();
     migrate_bitflag_to_flaggroup(m_ptr->smart, tmp32u);
 
     // 3.0.0Alpha10以前のSM_CLONED(ビット位置22)、SM_PET(23)、SM_FRIEDLY(28)をMFLAG2に移行する
@@ -444,8 +408,7 @@ void rd_monster_old(player_type *player_ptr, monster_type *m_ptr)
     if (h_older_than(0, 4, 5)) {
         m_ptr->exp = 0;
     } else {
-        rd_u32b(&tmp32u);
-        m_ptr->exp = tmp32u;
+        m_ptr->exp = rd_u32b();
     }
 
     if (h_older_than(0, 2, 2)) {
@@ -454,7 +417,7 @@ void rd_monster_old(player_type *player_ptr, monster_type *m_ptr)
             m_ptr->mflag2.set(MFLAG2::KAGE);
         }
     } else {
-        rd_byte(&tmp8u);
+        auto tmp8u = rd_byte();
         constexpr auto base = enum2i(MFLAG2::KAGE);
         migrate_bitflag_to_flaggroup(m_ptr->mflag2, tmp8u, base, 7);
     }
@@ -473,7 +436,7 @@ void rd_monster_old(player_type *player_ptr, monster_type *m_ptr)
             m_ptr->nickname = quark_add(buf);
     }
 
-    rd_byte(&tmp8u);
+    strip_bytes(1);
 }
 
 static void move_RF3_to_RFR(monster_race *r_ptr, const BIT_FLAGS rf3, const BIT_FLAGS rfr)
@@ -541,52 +504,39 @@ void set_old_lore(monster_race *r_ptr, BIT_FLAGS f4, const MONRACE_IDX r_idx)
  */
 errr rd_dungeon_old(player_type *player_ptr)
 {
-    int16_t tmp16s;
-    rd_s16b(&tmp16s);
     floor_type *floor_ptr = player_ptr->current_floor_ptr;
-    floor_ptr->dun_level = (DEPTH)tmp16s;
+    floor_ptr->dun_level = rd_s16b();
     if (h_older_than(0, 3, 8))
         player_ptr->dungeon_idx = DUNGEON_ANGBAND;
     else {
-        byte tmp8u;
-        rd_byte(&tmp8u);
-        player_ptr->dungeon_idx = (IDX)tmp8u;
+        player_ptr->dungeon_idx = rd_byte();
     }
 
     floor_ptr->base_level = floor_ptr->dun_level;
-    rd_s16b(&tmp16s);
-    floor_ptr->base_level = (DEPTH)tmp16s;
+    floor_ptr->base_level = rd_s16b();
 
-    rd_s16b(&tmp16s);
-    floor_ptr->num_repro = (MONSTER_NUMBER)tmp16s;
-    rd_s16b(&tmp16s);
-    player_ptr->y = (POSITION)tmp16s;
-    rd_s16b(&tmp16s);
-    player_ptr->x = (POSITION)tmp16s;
+    floor_ptr->num_repro = rd_s16b();
+    player_ptr->y = rd_s16b();
+    player_ptr->x = rd_s16b();
     if (h_older_than(0, 3, 13) && !floor_ptr->dun_level && !floor_ptr->inside_arena) {
         player_ptr->y = 33;
         player_ptr->x = 131;
     }
-    rd_s16b(&tmp16s);
-    floor_ptr->height = (POSITION)tmp16s;
-    rd_s16b(&tmp16s);
-    floor_ptr->width = (POSITION)tmp16s;
-    rd_s16b(&tmp16s); /* max_panel_rows */
-    rd_s16b(&tmp16s); /* max_panel_cols */
+    floor_ptr->height = rd_s16b();
+    floor_ptr->width = rd_s16b();
+    strip_bytes(2); /* max_panel_rows */
+    strip_bytes(2); /* max_panel_cols */
 
     int ymax = floor_ptr->height;
     int xmax = floor_ptr->width;
 
     for (int x = 0, y = 0; y < ymax;) {
         uint16_t info;
-        byte count;
-        rd_byte(&count);
+        auto count = rd_byte();
         if (h_older_than(0, 3, 6)) {
-            byte tmp8u;
-            rd_byte(&tmp8u);
-            info = (uint16_t)tmp8u;
+            info = rd_byte();
         } else {
-            rd_u16b(&info);
+            info = rd_u16b();
             info &= ~(CAVE_LITE | CAVE_VIEW | CAVE_MNLT | CAVE_MNDK);
         }
 
@@ -603,10 +553,8 @@ errr rd_dungeon_old(player_type *player_ptr)
     }
 
     for (int x = 0, y = 0; y < ymax;) {
-        byte count;
-        rd_byte(&count);
-        byte tmp8u;
-        rd_byte(&tmp8u);
+        auto count = rd_byte();
+        auto tmp8u = rd_byte();
         for (int i = count; i > 0; i--) {
             grid_type *g_ptr;
             g_ptr = &floor_ptr->grid_array[y][x];
@@ -620,10 +568,8 @@ errr rd_dungeon_old(player_type *player_ptr)
     }
 
     for (int x = 0, y = 0; y < ymax;) {
-        byte count;
-        rd_byte(&count);
-        byte tmp8u;
-        rd_byte(&tmp8u);
+        auto count = rd_byte();
+        auto tmp8u = rd_byte();
         for (int i = count; i > 0; i--) {
             grid_type *g_ptr;
             g_ptr = &floor_ptr->grid_array[y][x];
@@ -637,9 +583,8 @@ errr rd_dungeon_old(player_type *player_ptr)
     }
 
     for (int x = 0, y = 0; y < ymax;) {
-        byte count;
-        rd_byte(&count);
-        rd_s16b(&tmp16s);
+        auto count =  rd_byte();
+        auto tmp16s = rd_s16b();
         for (int i = count; i > 0; i--) {
             grid_type *g_ptr;
             g_ptr = &floor_ptr->grid_array[y][x];
@@ -729,7 +674,7 @@ errr rd_dungeon_old(player_type *player_ptr)
     }
 
     uint16_t limit;
-    rd_u16b(&limit);
+    limit = rd_u16b();
     if (limit > w_ptr->max_o_idx) {
         load_note(format(_("アイテムの配列が大きすぎる(%d)！", "Too many (%d) object entries!"), limit));
         return (151);
@@ -750,7 +695,7 @@ errr rd_dungeon_old(player_type *player_ptr)
         list.add(floor_ptr, o_idx);
     }
 
-    rd_u16b(&limit);
+    limit = rd_u16b();
     if (limit > w_ptr->max_m_idx) {
         load_note(format(_("モンスターの配列が大きすぎる(%d)！", "Too many (%d) monster entries!"), limit));
         return (161);

--- a/src/load/load-v1-7-0.cpp
+++ b/src/load/load-v1-7-0.cpp
@@ -8,37 +8,23 @@
 
 void set_hp_old(player_type *player_ptr)
 {
-    int16_t tmp16s;
-    rd_s16b(&tmp16s);
-    player_ptr->mhp = tmp16s;
+    player_ptr->mhp = rd_s16b();
 
-    rd_s16b(&tmp16s);
-    player_ptr->chp = tmp16s;
-
-    uint16_t tmp16u;
-    rd_u16b(&tmp16u);
-    player_ptr->chp_frac = (uint32_t)tmp16u;
+    player_ptr->chp = rd_s16b();
+    player_ptr->chp_frac = rd_u16b();
 }
 
 void set_mana_old(player_type *player_ptr)
 {
-    int16_t tmp16s;
-    rd_s16b(&tmp16s);
-    player_ptr->msp = tmp16s;
+    player_ptr->msp = rd_s16b();
 
-    rd_s16b(&tmp16s);
-    player_ptr->csp = tmp16s;
-
-    uint16_t tmp16u;
-    rd_u16b(&tmp16u);
-    player_ptr->csp_frac = (uint32_t)tmp16u;
+    player_ptr->csp = rd_s16b();
+    player_ptr->csp_frac = rd_u16b();
 }
 
 void set_exp_frac_old(player_type *player_ptr)
 {
-    uint16_t tmp16u;
-    rd_u16b(&tmp16u);
-    player_ptr->exp_frac = (uint32_t)tmp16u;
+    player_ptr->exp_frac = rd_u16b();
 }
 
 void remove_water_cave(player_type* player_ptr)

--- a/src/load/load-zangband.cpp
+++ b/src/load/load-zangband.cpp
@@ -136,9 +136,7 @@ void set_zangband_reflection(player_type *player_ptr)
 
 void rd_zangband_dungeon()
 {
-    int16_t tmp16s;
-    rd_s16b(&tmp16s);
-    max_dlv[DUNGEON_ANGBAND] = tmp16s;
+    max_dlv[DUNGEON_ANGBAND] = rd_s16b();
 }
 
 void set_zangband_game_turns(player_type *player_ptr)
@@ -151,16 +149,12 @@ void set_zangband_game_turns(player_type *player_ptr)
 
 void set_zangband_gambling_monsters(int i)
 {
-    int16_t tmp16s;
-    rd_s16b(&tmp16s);
-    mon_odds[i] = tmp16s;
+    mon_odds[i] = rd_s16b();
 }
 
 void set_zangband_special_attack(player_type *player_ptr)
 {
-    byte tmp8u;
-    rd_byte(&tmp8u);
-    if (tmp8u)
+    if (rd_byte() != 0)
         player_ptr->special_attack = ATTACK_CONFUSE;
 
     player_ptr->ele_attack = 0;
@@ -174,16 +168,13 @@ void set_zangband_special_defense(player_type *player_ptr)
 
 void set_zangband_action(player_type *player_ptr)
 {
-    byte tmp8u;
-    rd_byte(&tmp8u);
-    if (tmp8u)
+    if (rd_byte() != 0)
         player_ptr->action = ACTION_LEARN;
 }
 
 void set_zangband_visited_towns(player_type *player_ptr)
 {
-    int32_t tmp32s;
-    rd_s32b(&tmp32s);
+    strip_bytes(4);
     player_ptr->visit = 1L;
 }
 
@@ -234,43 +225,36 @@ void set_zangband_learnt_spells(player_type *player_ptr)
 void set_zangband_pet(player_type *player_ptr)
 {
     player_ptr->pet_extra_flags = 0;
-    byte tmp8u;
-    rd_byte(&tmp8u);
-    if (tmp8u)
+    if (rd_byte() != 0)
         player_ptr->pet_extra_flags |= PF_OPEN_DOORS;
 
-    rd_byte(&tmp8u);
-    if (tmp8u)
+    if (rd_byte() != 0)
         player_ptr->pet_extra_flags |= PF_PICKUP_ITEMS;
 
     if (h_older_than(0, 0, 4))
         player_ptr->pet_extra_flags |= PF_TELEPORT;
     else {
-        rd_byte(&tmp8u);
-        if (tmp8u)
+        if (rd_byte() != 0)
             player_ptr->pet_extra_flags |= PF_TELEPORT;
     }
 
     if (h_older_than(0, 0, 7))
         player_ptr->pet_extra_flags |= PF_ATTACK_SPELL;
     else {
-        rd_byte(&tmp8u);
-        if (tmp8u)
+        if (rd_byte() != 0)
             player_ptr->pet_extra_flags |= PF_ATTACK_SPELL;
     }
 
     if (h_older_than(0, 0, 8))
         player_ptr->pet_extra_flags |= PF_SUMMON_SPELL;
     else {
-        rd_byte(&tmp8u);
-        if (tmp8u)
+        if (rd_byte() != 0)
             player_ptr->pet_extra_flags |= PF_SUMMON_SPELL;
     }
 
     if (h_older_than(0, 0, 8))
         return;
 
-    rd_byte(&tmp8u);
-    if (tmp8u)
+    if (rd_byte() != 0)
         player_ptr->pet_extra_flags |= PF_BALL_SPELL;
 }

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -86,7 +86,7 @@ static void rd_total_play_time()
     if (loading_savefile_version_is_older_than(4))
         return;
 
-    rd_u32b(&w_ptr->sf_play_time);
+    w_ptr->sf_play_time = rd_u32b();
 }
 
 /*!
@@ -107,8 +107,8 @@ static void load_player_world(player_type *player_ptr)
     rd_winner_class();
     rd_base_info(player_ptr);
     rd_player_info(player_ptr);
-    rd_byte((byte *)&preserve_mode);
-    rd_byte((byte *)&player_ptr->wait_report_score);
+    preserve_mode = rd_byte() != 0;
+    player_ptr->wait_report_score = rd_byte() != 0;
     rd_dummy2();
     rd_global_configurations(player_ptr);
     rd_extra(player_ptr);
@@ -121,17 +121,14 @@ static void load_player_world(player_type *player_ptr)
 
 static errr load_hp(player_type *player_ptr)
 {
-    uint16_t tmp16u;
-    rd_u16b(&tmp16u);
+    auto tmp16u = rd_u16b();
     if (tmp16u > PY_MAX_LEVEL) {
         load_note(format(_("ヒットポイント配列が大きすぎる(%u)！", "Too many (%u) hitpoint entries!"), tmp16u));
         return 25;
     }
 
     for (int i = 0; i < tmp16u; i++) {
-        int16_t tmp16s;
-        rd_s16b(&tmp16s);
-        player_ptr->player_hp[i] = (HIT_POINT)tmp16s;
+        player_ptr->player_hp[i] = rd_s16b();
     }
 
     return 0;
@@ -139,30 +136,28 @@ static errr load_hp(player_type *player_ptr)
 
 static void load_spells(player_type *player_ptr)
 {
-    rd_u32b(&player_ptr->spell_learned1);
-    rd_u32b(&player_ptr->spell_learned2);
-    rd_u32b(&player_ptr->spell_worked1);
-    rd_u32b(&player_ptr->spell_worked2);
-    rd_u32b(&player_ptr->spell_forgotten1);
-    rd_u32b(&player_ptr->spell_forgotten2);
+    player_ptr->spell_learned1 = rd_u32b();
+    player_ptr->spell_learned2 = rd_u32b();
+    player_ptr->spell_worked1 = rd_u32b();
+    player_ptr->spell_worked2 = rd_u32b();
+    player_ptr->spell_forgotten1 = rd_u32b();
+    player_ptr->spell_forgotten2 = rd_u32b();
 
     if (h_older_than(0, 0, 5))
         set_zangband_learnt_spells(player_ptr);
     else
-        rd_s16b(&player_ptr->learned_spells);
+        player_ptr->learned_spells = rd_s16b();
 
     if (h_older_than(0, 0, 6))
         player_ptr->add_spells = 0;
     else
-        rd_s16b(&player_ptr->add_spells);
+        player_ptr->add_spells = rd_s16b();
 }
 
 static errr verify_checksum()
 {
-    uint32_t n_v_check = v_check;
-    uint32_t o_v_check;
-    rd_u32b(&o_v_check);
-    if (o_v_check == n_v_check)
+    auto n_v_check = v_check;
+    if (rd_u32b() == n_v_check)
         return 0;
 
     load_note(_("チェックサムがおかしい", "Invalid checksum"));
@@ -171,10 +166,8 @@ static errr verify_checksum()
 
 static errr verify_encoded_checksum()
 {
-    uint32_t n_x_check = x_check;
-    uint32_t o_x_check;
-    rd_u32b(&o_x_check);
-    if (o_x_check == n_x_check)
+    auto n_x_check = x_check;
+    if (rd_u32b() == n_x_check)
         return 0;
 
     load_note(_("エンコードされたチェックサムがおかしい", "Invalid encoded checksum"));
@@ -233,11 +226,11 @@ static errr exe_reading_savefile(player_type *player_ptr)
     if (load_store_result != 0)
         return load_store_result;
 
-    rd_s16b(&player_ptr->pet_follow_distance);
+    player_ptr->pet_follow_distance = rd_s16b();
     if (h_older_than(0, 4, 10))
         set_zangband_pet(player_ptr);
     else
-        rd_u16b(&player_ptr->pet_extra_flags);
+        player_ptr->pet_extra_flags = rd_u16b();
 
     if (!h_older_than(1, 0, 9)) {
         std::vector<char> buf(SCREEN_BUF_MAX_SIZE);

--- a/src/load/lore-loader.cpp
+++ b/src/load/lore-loader.cpp
@@ -13,82 +13,69 @@
  */
 void rd_lore(monster_race *r_ptr, MONRACE_IDX r_idx)
 {
-    int16_t tmp16s;
-    rd_s16b(&tmp16s);
-    r_ptr->r_sights = (MONSTER_NUMBER)tmp16s;
-
-    rd_s16b(&tmp16s);
-    r_ptr->r_deaths = (MONSTER_NUMBER)tmp16s;
-
-    rd_s16b(&tmp16s);
-    r_ptr->r_pkills = (MONSTER_NUMBER)tmp16s;
+    r_ptr->r_sights = rd_s16b();
+    r_ptr->r_deaths = rd_s16b();
+    r_ptr->r_pkills = rd_s16b();
 
     if (h_older_than(1, 7, 0, 5)) {
         r_ptr->r_akills = r_ptr->r_pkills;
     } else {
-        rd_s16b(&tmp16s);
-        r_ptr->r_akills = (MONSTER_NUMBER)tmp16s;
+        r_ptr->r_akills = rd_s16b();
     }
 
-    rd_s16b(&tmp16s);
-    r_ptr->r_tkills = (MONSTER_NUMBER)tmp16s;
+    r_ptr->r_tkills = rd_s16b();
 
-    rd_byte(&r_ptr->r_wake);
-    rd_byte(&r_ptr->r_ignore);
+    r_ptr->r_wake = rd_byte();
+    r_ptr->r_ignore = rd_byte();
 
-    byte tmp8u;
-    rd_byte(&tmp8u);
-    r_ptr->r_can_evolve = tmp8u > 0;
+    r_ptr->r_can_evolve = rd_byte() > 0;
     if (loading_savefile_version_is_older_than(6)) {
         // かつては未使用フラグr_ptr->r_xtra2だった.
-        rd_byte(&tmp8u);
+        strip_bytes(1);
     }
 
-    rd_byte(&tmp8u);
-    r_ptr->r_drop_gold = (ITEM_NUMBER)tmp8u;
-    rd_byte(&tmp8u);
-    r_ptr->r_drop_item = (ITEM_NUMBER)tmp8u;
+    r_ptr->r_drop_gold = rd_byte();
+    r_ptr->r_drop_item = rd_byte();
 
-    rd_byte(&tmp8u);
-    rd_byte(&r_ptr->r_cast_spell);
+    strip_bytes(1);
+    r_ptr->r_cast_spell = rd_byte();
 
-    rd_byte(&r_ptr->r_blows[0]);
-    rd_byte(&r_ptr->r_blows[1]);
-    rd_byte(&r_ptr->r_blows[2]);
-    rd_byte(&r_ptr->r_blows[3]);
+    r_ptr->r_blows[0] = rd_byte();
+    r_ptr->r_blows[1] = rd_byte();
+    r_ptr->r_blows[2] = rd_byte();
+    r_ptr->r_blows[3] = rd_byte();
 
-    rd_u32b(&r_ptr->r_flags1);
-    rd_u32b(&r_ptr->r_flags2);
-    rd_u32b(&r_ptr->r_flags3);
+    r_ptr->r_flags1 = rd_u32b();
+    r_ptr->r_flags2 = rd_u32b();
+    r_ptr->r_flags3 = rd_u32b();
     if (loading_savefile_version_is_older_than(3)) {
         uint32_t f4, f5, f6;
-        rd_u32b(&f4);
-        rd_u32b(&f5);
-        rd_u32b(&f6);
+        f4 = rd_u32b();
+        f5 = rd_u32b();
+        f6 = rd_u32b();
         if (h_older_than(1, 5, 0, 3))
             set_old_lore(r_ptr, f4, r_idx);
         else
-            rd_u32b(&r_ptr->r_flagsr);
+            r_ptr->r_flagsr = rd_u32b();
 
         migrate_bitflag_to_flaggroup(r_ptr->r_ability_flags, f4, sizeof(uint32_t) * 8 * 0);
         migrate_bitflag_to_flaggroup(r_ptr->r_ability_flags, f5, sizeof(uint32_t) * 8 * 1);
         migrate_bitflag_to_flaggroup(r_ptr->r_ability_flags, f6, sizeof(uint32_t) * 8 * 2);
     } else {
-        rd_u32b(&r_ptr->r_flagsr);
+        r_ptr->r_flagsr = rd_u32b();
         rd_FlagGroup(r_ptr->r_ability_flags, rd_byte);
     }
 
-    rd_byte(&tmp8u);
-    r_ptr->max_num = (MONSTER_NUMBER)tmp8u;
+    r_ptr->max_num = rd_byte();
 
-    rd_s16b(&r_ptr->floor_id);
+    r_ptr->floor_id = rd_s16b();
 
     if (!loading_savefile_version_is_older_than(4)) {
-        rd_s16b(&r_ptr->defeat_level);
-        rd_u32b(&r_ptr->defeat_time);
+        r_ptr->defeat_level = rd_s16b();
+        r_ptr->defeat_time = rd_u32b();
     }
 
-    rd_byte(&tmp8u);
+    strip_bytes(1);
 
     r_ptr->r_flags1 &= r_ptr->flags1;
     r_ptr->r_flags2 &= r_ptr->flags2;
@@ -99,8 +86,7 @@ void rd_lore(monster_race *r_ptr, MONRACE_IDX r_idx)
 
 errr load_lore(void)
 {
-    uint16_t loading_max_r_idx;
-    rd_u16b(&loading_max_r_idx);
+    auto loading_max_r_idx = rd_u16b();
 
     monster_race *r_ptr;
     monster_race dummy;

--- a/src/load/monster-loader.cpp
+++ b/src/load/monster-loader.cpp
@@ -21,94 +21,77 @@ void rd_monster(player_type *player_ptr, monster_type *m_ptr)
         return;
     }
 
-    BIT_FLAGS flags;
-    rd_u32b(&flags);
-    rd_s16b(&m_ptr->r_idx);
-    byte tmp8u;
-    rd_byte(&tmp8u);
-    m_ptr->fy = (POSITION)tmp8u;
-    rd_byte(&tmp8u);
-    m_ptr->fx = (POSITION)tmp8u;
+    auto flags = rd_u32b();
+    m_ptr->r_idx = rd_s16b();
+    m_ptr->fy = rd_byte();
+    m_ptr->fx = rd_byte();
 
-    int16_t tmp16s;
-    rd_s16b(&tmp16s);
-    m_ptr->hp = (HIT_POINT)tmp16s;
-    rd_s16b(&tmp16s);
-    m_ptr->maxhp = (HIT_POINT)tmp16s;
-    rd_s16b(&tmp16s);
-    m_ptr->max_maxhp = (HIT_POINT)tmp16s;
+    m_ptr->hp = rd_s16b();
+    m_ptr->maxhp = rd_s16b();
+    m_ptr->max_maxhp = rd_s16b();
 
     if (h_older_than(2, 1, 2, 1)) {
         m_ptr->dealt_damage = 0;
     } else {
-        rd_s32b(&m_ptr->dealt_damage);
+        m_ptr->dealt_damage = rd_s32b();
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::AP_R_IDX))
-        rd_s16b(&m_ptr->ap_r_idx);
+        m_ptr->ap_r_idx = rd_s16b();
     else
         m_ptr->ap_r_idx = m_ptr->r_idx;
 
     if (any_bits(flags, SaveDataMonsterFlagType::SUB_ALIGN))
-        rd_byte(&m_ptr->sub_align);
+        m_ptr->sub_align = rd_byte();
     else
         m_ptr->sub_align = 0;
 
     if (any_bits(flags, SaveDataMonsterFlagType::CSLEEP))
-        rd_s16b(&m_ptr->mtimed[MTIMED_CSLEEP]);
+        m_ptr->mtimed[MTIMED_CSLEEP] = rd_s16b();
     else
         m_ptr->mtimed[MTIMED_CSLEEP] = 0;
 
-    rd_byte(&tmp8u);
-    m_ptr->mspeed = tmp8u;
+    m_ptr->mspeed = rd_byte();
 
-    rd_s16b(&m_ptr->energy_need);
+    m_ptr->energy_need = rd_s16b();
 
     if (any_bits(flags, SaveDataMonsterFlagType::FAST)) {
-        rd_byte(&tmp8u);
-        m_ptr->mtimed[MTIMED_FAST] = (int16_t)tmp8u;
+        m_ptr->mtimed[MTIMED_FAST] = rd_byte();
     } else
         m_ptr->mtimed[MTIMED_FAST] = 0;
 
     if (any_bits(flags, SaveDataMonsterFlagType::SLOW)) {
-        rd_byte(&tmp8u);
-        m_ptr->mtimed[MTIMED_SLOW] = (int16_t)tmp8u;
+        m_ptr->mtimed[MTIMED_SLOW] = rd_byte();
     } else
         m_ptr->mtimed[MTIMED_SLOW] = 0;
 
     if (any_bits(flags, SaveDataMonsterFlagType::STUNNED)) {
-        rd_byte(&tmp8u);
-        m_ptr->mtimed[MTIMED_STUNNED] = (int16_t)tmp8u;
+        m_ptr->mtimed[MTIMED_STUNNED] = rd_byte();
     } else
         m_ptr->mtimed[MTIMED_STUNNED] = 0;
 
     if (any_bits(flags, SaveDataMonsterFlagType::CONFUSED)) {
-        rd_byte(&tmp8u);
-        m_ptr->mtimed[MTIMED_CONFUSED] = (int16_t)tmp8u;
+        m_ptr->mtimed[MTIMED_CONFUSED] = rd_byte();
     } else
         m_ptr->mtimed[MTIMED_CONFUSED] = 0;
 
     if (any_bits(flags, SaveDataMonsterFlagType::MONFEAR)) {
-        rd_byte(&tmp8u);
-        m_ptr->mtimed[MTIMED_MONFEAR] = (int16_t)tmp8u;
+        m_ptr->mtimed[MTIMED_MONFEAR] = rd_byte();
     } else
         m_ptr->mtimed[MTIMED_MONFEAR] = 0;
 
     if (any_bits(flags, SaveDataMonsterFlagType::TARGET_Y)) {
-        rd_s16b(&tmp16s);
-        m_ptr->target_y = (POSITION)tmp16s;
+        m_ptr->target_y = rd_s16b();
     } else
         m_ptr->target_y = 0;
 
     if (any_bits(flags, SaveDataMonsterFlagType::TARGET_X)) {
-        rd_s16b(&tmp16s);
-        m_ptr->target_x = (POSITION)tmp16s;
+        m_ptr->target_x = rd_s16b();
     } else
         m_ptr->target_x = 0;
 
     if (any_bits(flags, SaveDataMonsterFlagType::INVULNER)) {
-        rd_byte(&tmp8u);
-        m_ptr->mtimed[MTIMED_INVULNER] = (int16_t)tmp8u;
+        m_ptr->mtimed[MTIMED_INVULNER] = rd_byte();
     } else
         m_ptr->mtimed[MTIMED_INVULNER] = 0;
 
@@ -117,8 +100,7 @@ void rd_monster(player_type *player_ptr, monster_type *m_ptr)
 
     if (any_bits(flags, SaveDataMonsterFlagType::SMART)) {
         if (loading_savefile_version_is_older_than(2)) {
-            uint32_t tmp32u;
-            rd_u32b(&tmp32u);
+            auto tmp32u = rd_u32b();
             migrate_bitflag_to_flaggroup(m_ptr->smart, tmp32u);
 
             // 3.0.0Alpha10以前のSM_CLONED(ビット位置22)、SM_PET(23)、SM_FRIEDLY(28)をMFLAG2に移行する
@@ -136,15 +118,13 @@ void rd_monster(player_type *player_ptr, monster_type *m_ptr)
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::EXP)) {
-        uint32_t tmp32u;
-        rd_u32b(&tmp32u);
-        m_ptr->exp = (EXP)tmp32u;
+        m_ptr->exp = rd_u32b();
     } else
         m_ptr->exp = 0;
 
     if (any_bits(flags, SaveDataMonsterFlagType::MFLAG2)) {
         if (loading_savefile_version_is_older_than(2)) {
-            rd_byte(&tmp8u);
+            auto tmp8u = rd_byte();
             constexpr auto base = enum2i(MFLAG2::KAGE);
             migrate_bitflag_to_flaggroup(m_ptr->mflag2, tmp8u, base, 7);
         } else {
@@ -160,7 +140,7 @@ void rd_monster(player_type *player_ptr, monster_type *m_ptr)
         m_ptr->nickname = 0;
 
     if (any_bits(flags, SaveDataMonsterFlagType::PARENT))
-        rd_s16b(&m_ptr->parent_m_idx);
+        m_ptr->parent_m_idx = rd_s16b();
     else
         m_ptr->parent_m_idx = 0;
 }

--- a/src/load/option-loader.cpp
+++ b/src/load/option-loader.cpp
@@ -26,27 +26,22 @@ void rd_options(void)
 {
     strip_bytes(16);
 
-    byte b;
-
     if (loading_savefile_version_is_older_than(9)) {
-        rd_byte(&b);
+        auto b = rd_byte();
         delay_factor = b * b * b;
     } else {
-        rd_s32b(&delay_factor);
+        delay_factor = rd_s32b();
     }
 
-    rd_byte(&b);
-    hitpoint_warn = b;
+    hitpoint_warn = rd_byte();
 
     if (h_older_than(1, 7, 0, 0)) {
         mana_warn = 2;
     } else {
-        rd_byte(&b);
-        mana_warn = b;
+        mana_warn = rd_byte();
     }
 
-    uint16_t c;
-    rd_u16b(&c);
+    auto c = rd_u16b();
 
     cheat_peek = any_bits(c, 0x0100);
     cheat_hear = any_bits(c, 0x0200);
@@ -60,17 +55,17 @@ void rd_options(void)
     cheat_sight = any_bits(c, 0x0040);
     cheat_immortal = any_bits(c, 0x0020);
 
-    rd_byte((byte *)&autosave_l);
-    rd_byte((byte *)&autosave_t);
-    rd_s16b(&autosave_freq);
+    autosave_l = rd_byte() != 0;
+    autosave_t = rd_byte() != 0;
+    autosave_freq = rd_s16b();
 
     BIT_FLAGS flag[8];
     for (int n = 0; n < 8; n++)
-        rd_u32b(&flag[n]);
+        flag[n] = rd_u32b();
 
     BIT_FLAGS mask[8];
     for (int n = 0; n < 8; n++)
-        rd_u32b(&mask[n]);
+        mask[n] = rd_u32b();
 
     for (auto n = 0; n < 8; n++) {
         for (auto i = 0; i < 32; i++) {
@@ -91,10 +86,10 @@ void rd_options(void)
 
     extract_option_vars();
     for (int n = 0; n < 8; n++)
-        rd_u32b(&flag[n]);
+        flag[n] = rd_u32b();
 
     for (int n = 0; n < 8; n++)
-        rd_u32b(&mask[n]);
+        mask[n] = rd_u32b();
 
     for (int n = 0; n < 8; n++) {
         for (int i = 0; i < 32; i++) {

--- a/src/load/player-attack-loader.cpp
+++ b/src/load/player-attack-loader.cpp
@@ -16,8 +16,8 @@ void rd_special_attack(player_type *player_ptr)
         return;
     }
 
-    rd_s16b(&player_ptr->ele_attack);
-    rd_u32b(&player_ptr->special_attack);
+    player_ptr->ele_attack = rd_s16b();
+    player_ptr->special_attack = rd_u32b();
 }
 
 void rd_special_action(player_type *player_ptr)
@@ -39,16 +39,14 @@ void rd_special_defense(player_type *player_ptr)
         return;
     }
 
-    rd_s16b(&player_ptr->ele_immune);
-    rd_u32b(&player_ptr->special_defense);
+    player_ptr->ele_immune = rd_s16b();
+    player_ptr->special_defense = rd_u32b();
 }
 
 void rd_action(player_type *player_ptr)
 {
-    byte tmp8u;
-    rd_byte(&tmp8u);
-    rd_byte(&tmp8u);
-    player_ptr->action = tmp8u;
+    strip_bytes(1);
+    player_ptr->action = rd_byte();
     if (!h_older_than(0, 4, 3)) {
         set_zangband_action(player_ptr);
     }

--- a/src/load/player-class-specific-data-loader.cpp
+++ b/src/load/player-class-specific-data-loader.cpp
@@ -28,10 +28,10 @@ std::tuple<std::vector<int32_t>, std::vector<byte>> load_old_savfile_magic_num()
 
     if (loading_savefile_version_is_older_than(9)) {
         for (auto &item : magic_num1) {
-            rd_s32b(&item);
+            item = rd_s32b();
         }
         for (auto &item : magic_num2) {
-            rd_byte(&item);
+            item = rd_byte();
         }
     }
 
@@ -59,9 +59,8 @@ void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<smith_data_type> 
         }
     } else {
         while (true) {
-            int16_t essence, amount;
-            rd_s16b(&essence);
-            rd_s16b(&amount);
+            auto essence = rd_s16b();
+            auto amount = rd_s16b();
             if (essence < 0 && amount < 0) {
                 break;
             }
@@ -76,7 +75,7 @@ void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<force_trainer_dat
         auto [magic_num1, magic_num2] = load_old_savfile_magic_num();
         force_trainer_data->ki = magic_num1[0];
     } else {
-        rd_s32b(&force_trainer_data->ki);
+        force_trainer_data->ki = rd_s32b();
     }
 }
 
@@ -109,13 +108,10 @@ void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<magic_eater_data_
         load_old_item_group(magic_eater_data->rods, 2);
     } else {
         auto load_item_group = [](auto &item_group) {
-            uint16_t item_count;
-            rd_u16b(&item_count);
+            auto item_count = rd_u16b();
             for (auto i = 0U; i < item_count; ++i) {
-                int32_t charge;
-                byte count;
-                rd_s32b(&charge);
-                rd_byte(&count);
+                auto charge = rd_s32b();
+                auto count = rd_byte();
                 if (i < item_group.size()) {
                     item_group[i].charge = charge;
                     item_group[i].count = count;
@@ -137,13 +133,10 @@ void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<bard_data_type> &
         bird_data->singing_duration = magic_num1[2];
         bird_data->singing_song_spell_idx = magic_num2[0];
     } else {
-        int32_t tmp32s;
-        rd_s32b(&tmp32s);
-        bird_data->singing_song = i2enum<realm_song_type>(tmp32s);
-        rd_s32b(&tmp32s);
-        bird_data->interrputing_song = i2enum<realm_song_type>(tmp32s);
-        rd_s32b(&bird_data->singing_duration);
-        rd_byte(&bird_data->singing_song_spell_idx);
+        bird_data->singing_song = i2enum<realm_song_type>(rd_s32b());
+        bird_data->interrputing_song = i2enum<realm_song_type>(rd_s32b());
+        bird_data->singing_duration = rd_s32b();
+        bird_data->singing_song_spell_idx = rd_byte();
     }
 }
 
@@ -153,12 +146,10 @@ void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<mane_data_type> &
         // 古いセーブファイルのものまね師のデータは magic_num には保存されていないので読み捨てる
         load_old_savfile_magic_num();
     } else {
-        int16_t count;
-        rd_s16b(&count);
+        auto count = rd_s16b();
         for (; count > 0; --count) {
-            int16_t spell, damage;
-            rd_s16b(&spell);
-            rd_s16b(&damage);
+            auto spell = rd_s16b();
+            auto damage = rd_s16b();
             mane_data->mane_list.push_back({ i2enum<RF_ABILITY>(spell), damage });
         }
     }
@@ -170,7 +161,7 @@ void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<sniper_data_type>
         // 古いセーブファイルのスナイパーのデータは magic_num には保存されていないので読み捨てる
         load_old_savfile_magic_num();
     } else {
-        rd_s16b(&sniper_data->concent);
+        sniper_data->concent = rd_s16b();
     }
 }
 
@@ -180,9 +171,7 @@ void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<samurai_data_type
         // 古いセーブファイルの剣術家のデータは magic_num には保存されていないので読み捨てる
         load_old_savfile_magic_num();
     } else {
-        byte tmp8u;
-        rd_byte(&tmp8u);
-        samurai_data->stance = i2enum<SamuraiStance>(tmp8u);
+        samurai_data->stance = i2enum<SamuraiStance>(rd_byte());
     }
 }
 
@@ -192,9 +181,7 @@ void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<monk_data_type> &
         // 古いセーブファイルの修行僧のデータは magic_num には保存されていないので読み捨てる
         load_old_savfile_magic_num();
     } else {
-        byte tmp8u;
-        rd_byte(&tmp8u);
-        monk_data->stance = i2enum<MonkStance>(tmp8u);
+        monk_data->stance = i2enum<MonkStance>(rd_byte());
     }
 }
 
@@ -204,11 +191,8 @@ void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<ninja_data_type> 
         // 古いセーブファイルの忍者のデータは magic_num には保存されていないので読み捨てる
         load_old_savfile_magic_num();
     } else {
-        byte tmp8u;
-        rd_byte(&tmp8u);
-        ninja_data->kawarimi = tmp8u != 0;
-        rd_byte(&tmp8u);
-        ninja_data->s_stealth = tmp8u != 0;
+        ninja_data->kawarimi = rd_byte() != 0;
+        ninja_data->s_stealth = rd_byte() != 0;
     }
 }
 
@@ -222,10 +206,8 @@ void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<spell_hex_data_ty
         spell_hex_data->revenge_turn = magic_num2[2];
     } else {
         rd_FlagGroup(spell_hex_data->casting_spells, rd_byte);
-        rd_s32b(&spell_hex_data->revenge_power);
-        byte tmp8u;
-        rd_byte(&tmp8u);
-        spell_hex_data->revenge_type = i2enum<SpellHexRevengeType>(tmp8u);
-        rd_byte(&spell_hex_data->revenge_turn);
+        spell_hex_data->revenge_power = rd_s32b();
+        spell_hex_data->revenge_type = i2enum<SpellHexRevengeType>(rd_byte());
+        spell_hex_data->revenge_turn = rd_byte();
     }
 }

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -32,16 +32,12 @@
  */
 static void rd_realms(player_type *player_ptr)
 {
-    byte tmp8u;
-
-    rd_byte(&tmp8u);
     if (player_ptr->pclass == PlayerClassType::ELEMENTALIST)
-        player_ptr->element = (int16_t)tmp8u;
+        player_ptr->element = rd_byte();
     else
-        player_ptr->realm1 = (int16_t)tmp8u;
+        player_ptr->realm1 = rd_byte();
 
-    rd_byte(&tmp8u);
-    player_ptr->realm2 = (int16_t)tmp8u;
+    player_ptr->realm2 = rd_byte();
     if (player_ptr->realm2 == 255)
         player_ptr->realm2 = 0;
 }
@@ -66,51 +62,42 @@ void rd_base_info(player_type *player_ptr)
     for (int i = 0; i < max_history_lines; i++)
         rd_string(player_ptr->history[i], sizeof(player_ptr->history[i]));
 
-    byte tmp8u;
-    rd_byte(&tmp8u);
-    player_ptr->prace = (PlayerRaceType)tmp8u;
-
-    rd_byte(&tmp8u);
-    player_ptr->pclass = (PlayerClassType)tmp8u;
-
-    rd_byte(&tmp8u);
-    player_ptr->ppersonality = (player_personality_type)tmp8u;
-
-    rd_byte(&tmp8u);
-    player_ptr->psex = i2enum<player_sex>(tmp8u);
+    player_ptr->prace = i2enum<PlayerRaceType>(rd_byte());
+    player_ptr->pclass = i2enum<PlayerClassType>(rd_byte());
+    player_ptr->ppersonality = i2enum<player_personality_type>(rd_byte());
+    player_ptr->psex = i2enum<player_sex>(rd_byte());
 
     rd_realms(player_ptr);
 
-    rd_byte(&tmp8u);
+    strip_bytes(1);
     if (h_older_than(0, 4, 4))
         set_zangband_realm(player_ptr);
 
-    rd_byte(&tmp8u);
-    player_ptr->hitdie = (DICE_SID)tmp8u;
-    rd_u16b(&player_ptr->expfact);
+    player_ptr->hitdie = rd_byte();
+    player_ptr->expfact = rd_u16b();
 
-    rd_s16b(&player_ptr->age);
-    rd_s16b(&player_ptr->ht);
-    rd_s16b(&player_ptr->wt);
+    player_ptr->age = rd_s16b();
+    player_ptr->ht = rd_s16b();
+    player_ptr->wt = rd_s16b();
 }
 
 void rd_experience(player_type *player_ptr)
 {
-    rd_s32b(&player_ptr->max_exp);
+    player_ptr->max_exp = rd_s32b();
     if (h_older_than(1, 5, 4, 1))
         player_ptr->max_max_exp = player_ptr->max_exp;
     else
-        rd_s32b(&player_ptr->max_max_exp);
+        player_ptr->max_max_exp = rd_s32b();
 
-    rd_s32b(&player_ptr->exp);
+    player_ptr->exp = rd_s32b();
     if (h_older_than(1, 7, 0, 3))
         set_exp_frac_old(player_ptr);
     else
-        rd_u32b(&player_ptr->exp_frac);
+        player_ptr->exp_frac = rd_u32b();
 
-    rd_s16b(&player_ptr->lev);
+    player_ptr->lev = rd_s16b();
     for (int i = 0; i < 64; i++)
-        rd_s16b(&player_ptr->spell_exp[i]);
+        player_ptr->spell_exp[i] = rd_s16b();
 
     if ((player_ptr->pclass == PlayerClassType::SORCERER) && h_older_than(0, 4, 2))
         for (int i = 0; i < 64; i++)
@@ -119,10 +106,10 @@ void rd_experience(player_type *player_ptr)
     const int max_weapon_exp_size = h_older_than(0, 3, 6) ? 60 : 64;
     for (auto tval : TV_WEAPON_RANGE)
         for (int j = 0; j < max_weapon_exp_size; j++)
-            rd_s16b(&player_ptr->weapon_exp[tval][j]);
+            player_ptr->weapon_exp[tval][j] = rd_s16b();
 
     for (int i = 0; i < MAX_SKILLS; i++)
-        rd_s16b(&player_ptr->skill_exp[i]);
+        player_ptr->skill_exp[i] = rd_s16b();
 }
 
 void rd_skills(player_type *player_ptr)
@@ -139,15 +126,10 @@ void rd_skills(player_type *player_ptr)
 
 static void set_race(player_type *player_ptr)
 {
-    byte tmp8u;
-    rd_byte(&tmp8u);
-    player_ptr->start_race = (PlayerRaceType)tmp8u;
-    int32_t tmp32s;
-    rd_s32b(&tmp32s);
-    player_ptr->old_race1 = (BIT_FLAGS)tmp32s;
-    rd_s32b(&tmp32s);
-    player_ptr->old_race2 = (BIT_FLAGS)tmp32s;
-    rd_s16b(&player_ptr->old_realm);
+    player_ptr->start_race = i2enum<PlayerRaceType>(rd_byte());
+    player_ptr->old_race1 = rd_u32b();
+    player_ptr->old_race2 = rd_u32b();
+    player_ptr->old_realm = rd_s16b();
 }
 
 void rd_race(player_type *player_ptr)
@@ -168,7 +150,7 @@ void rd_bounty_uniques(player_type *player_ptr)
     }
 
     for (int i = 0; i < MAX_BOUNTY; i++)
-        rd_s16b(&w_ptr->bounty_r_idx[i]);
+        w_ptr->bounty_r_idx[i] = rd_s16b();
 }
 
 /*!
@@ -178,13 +160,13 @@ void rd_bounty_uniques(player_type *player_ptr)
 static void rd_base_status(player_type *player_ptr)
 {
     for (int i = 0; i < A_MAX; i++)
-        rd_s16b(&player_ptr->stat_max[i]);
+        player_ptr->stat_max[i] = rd_s16b();
 
     for (int i = 0; i < A_MAX; i++)
-        rd_s16b(&player_ptr->stat_max_max[i]);
+        player_ptr->stat_max_max[i] = rd_s16b();
 
     for (int i = 0; i < A_MAX; i++)
-        rd_s16b(&player_ptr->stat_cur[i]);
+        player_ptr->stat_cur[i] = rd_s16b();
 }
 
 static void set_imitation(player_type *player_ptr)
@@ -194,14 +176,13 @@ static void set_imitation(player_type *player_ptr)
     }
 
     if (h_older_than(0, 2, 3)) {
-        int16_t tmp16s;
         const int OLD_MAX_MANE = 22;
         for (int i = 0; i < OLD_MAX_MANE; i++) {
-            rd_s16b(&tmp16s);
-            rd_s16b(&tmp16s);
+            strip_bytes(2);
+            strip_bytes(2);
         }
 
-        rd_s16b(&tmp16s);
+        strip_bytes(2);
         return;
     }
 
@@ -213,28 +194,23 @@ static void set_imitation(player_type *player_ptr)
         }
 
         for (int i = 0; i < MAX_MANE; ++i) {
-            int16_t spell, damage;
-            rd_s16b(&spell);
-            rd_s16b(&damage);
+            auto spell = rd_s16b();
+            auto damage = rd_s16b();
             mane_data->mane_list.push_back({ i2enum<RF_ABILITY>(spell), damage });
         }
-        int16_t count;
-        rd_s16b(&count);
+        auto count = rd_s16b();
         mane_data->mane_list.resize(count);
     }
 }
 
 static void rd_phase_out(player_type *player_ptr)
 {
-    int16_t tmp16s;
-    rd_s16b(&tmp16s);
-    player_ptr->current_floor_ptr->inside_arena = (bool)tmp16s;
-    rd_s16b(&player_ptr->current_floor_ptr->inside_quest);
+    player_ptr->current_floor_ptr->inside_arena = rd_s16b() != 0;
+    player_ptr->current_floor_ptr->inside_quest = rd_s16b();
     if (h_older_than(0, 3, 5))
         player_ptr->phase_out = false;
     else {
-        rd_s16b(&tmp16s);
-        player_ptr->phase_out = (bool)tmp16s;
+        player_ptr->phase_out = rd_s16b() != 0;
     }
 }
 
@@ -245,22 +221,18 @@ static void rd_arena(player_type *player_ptr)
     else
         set_gambling_monsters();
 
-    rd_s16b(&player_ptr->town_num);
-    rd_s16b(&player_ptr->arena_number);
+    player_ptr->town_num = rd_s16b();
+    player_ptr->arena_number = rd_s16b();
     if (h_older_than(1, 5, 0, 1))
         if (player_ptr->arena_number >= 99)
             player_ptr->arena_number = ARENA_DEFEATED_OLD_VER;
 
     rd_phase_out(player_ptr);
-    byte tmp8u;
-    rd_byte(&player_ptr->exit_bldg);
-    rd_byte(&tmp8u);
+    player_ptr->exit_bldg = rd_byte();
+    strip_bytes(1);
 
-    int16_t tmp16s;
-    rd_s16b(&tmp16s);
-    player_ptr->oldpx = (POSITION)tmp16s;
-    rd_s16b(&tmp16s);
-    player_ptr->oldpy = (POSITION)tmp16s;
+    player_ptr->oldpx = rd_s16b();
+    player_ptr->oldpy = rd_s16b();
     if (h_older_than(0, 3, 13) && !is_in_dungeon(player_ptr) && !player_ptr->current_floor_ptr->inside_arena) {
         player_ptr->oldpy = 33;
         player_ptr->oldpx = 131;
@@ -278,9 +250,9 @@ static void rd_hp(player_type *player_ptr)
         return;
     }
 
-    rd_s32b(&player_ptr->mhp);
-    rd_s32b(&player_ptr->chp);
-    rd_u32b(&player_ptr->chp_frac);
+    player_ptr->mhp = rd_s32b();
+    player_ptr->chp = rd_s32b();
+    player_ptr->chp_frac = rd_u32b();
 }
 
 /*!
@@ -294,9 +266,9 @@ static void rd_mana(player_type *player_ptr)
         return;
     }
 
-    rd_s32b(&player_ptr->msp);
-    rd_s32b(&player_ptr->csp);
-    rd_u32b(&player_ptr->csp_frac);
+    player_ptr->msp = rd_s32b();
+    player_ptr->csp = rd_s32b();
+    player_ptr->csp_frac = rd_u32b();
 }
 
 /*!
@@ -306,23 +278,23 @@ static void rd_mana(player_type *player_ptr)
 static void rd_bad_status(player_type *player_ptr)
 {
     strip_bytes(2); /* Old "rest" */
-    rd_s16b(&player_ptr->blind);
-    rd_s16b(&player_ptr->paralyzed);
-    rd_s16b(&player_ptr->confused);
-    rd_s16b(&player_ptr->food);
+    player_ptr->blind = rd_s16b();
+    player_ptr->paralyzed = rd_s16b();
+    player_ptr->confused = rd_s16b();
+    player_ptr->food = rd_s16b();
     strip_bytes(4); /* Old "food_digested" / "protection" */
 }
 
 static void rd_energy(player_type *player_ptr)
 {
-    rd_s16b(&player_ptr->energy_need);
+    player_ptr->energy_need = rd_s16b();
     if (h_older_than(1, 0, 13))
         player_ptr->energy_need = 100 - player_ptr->energy_need;
 
     if (h_older_than(2, 1, 2, 0))
         player_ptr->enchant_energy_need = 0;
     else
-        rd_s16b(&player_ptr->enchant_energy_need);
+        player_ptr->enchant_energy_need = rd_s16b();
 }
 
 /*!
@@ -332,22 +304,19 @@ static void rd_energy(player_type *player_ptr)
  */
 static void rd_status(player_type *player_ptr)
 {
-    int16_t tmp16s;
-    rd_s16b(&player_ptr->fast);
-    rd_s16b(&player_ptr->slow);
-    rd_s16b(&player_ptr->afraid);
-    rd_s16b(&tmp16s);
-    player_ptr->effects()->cut()->set(tmp16s);
-    rd_s16b(&tmp16s);
-    player_ptr->effects()->stun()->set(tmp16s);
-    rd_s16b(&player_ptr->poisoned);
-    rd_s16b(&player_ptr->hallucinated);
-    rd_s16b(&player_ptr->protevil);
-    rd_s16b(&player_ptr->invuln);
+    player_ptr->fast = rd_s16b();
+    player_ptr->slow = rd_s16b();
+    player_ptr->afraid = rd_s16b();
+    player_ptr->effects()->cut()->set(rd_s16b());
+    player_ptr->effects()->stun()->set(rd_s16b());
+    player_ptr->poisoned = rd_s16b();
+    player_ptr->hallucinated = rd_s16b();
+    player_ptr->protevil = rd_s16b();
+    player_ptr->invuln = rd_s16b();
     if (h_older_than(0, 0, 0))
         player_ptr->ult_res = 0;
     else
-        rd_s16b(&player_ptr->ult_res);
+        player_ptr->ult_res = rd_s16b();
 }
 
 static void rd_tsuyoshi(player_type *player_ptr)
@@ -355,52 +324,50 @@ static void rd_tsuyoshi(player_type *player_ptr)
     if (h_older_than(0, 0, 2))
         player_ptr->tsuyoshi = 0;
     else
-        rd_s16b(&player_ptr->tsuyoshi);
+        player_ptr->tsuyoshi = rd_s16b();
 }
 
 static void set_timed_effects(player_type *player_ptr)
 {
-    rd_s16b(&player_ptr->tim_esp);
-    rd_s16b(&player_ptr->wraith_form);
-    rd_s16b(&player_ptr->resist_magic);
-    rd_s16b(&player_ptr->tim_regen);
-    rd_s16b(&player_ptr->tim_pass_wall);
-    rd_s16b(&player_ptr->tim_stealth);
-    rd_s16b(&player_ptr->tim_levitation);
-    rd_s16b(&player_ptr->tim_sh_touki);
-    rd_s16b(&player_ptr->lightspeed);
-    rd_s16b(&player_ptr->tsubureru);
+    player_ptr->tim_esp = rd_s16b();
+    player_ptr->wraith_form = rd_s16b();
+    player_ptr->resist_magic = rd_s16b();
+    player_ptr->tim_regen = rd_s16b();
+    player_ptr->tim_pass_wall = rd_s16b();
+    player_ptr->tim_stealth = rd_s16b();
+    player_ptr->tim_levitation = rd_s16b();
+    player_ptr->tim_sh_touki = rd_s16b();
+    player_ptr->lightspeed = rd_s16b();
+    player_ptr->tsubureru = rd_s16b();
     if (h_older_than(0, 4, 7))
         player_ptr->magicdef = 0;
     else
-        rd_s16b(&player_ptr->magicdef);
+        player_ptr->magicdef = rd_s16b();
 
-    rd_s16b(&player_ptr->tim_res_nether);
+    player_ptr->tim_res_nether = rd_s16b();
     if (h_older_than(0, 4, 11))
         set_zangband_mimic(player_ptr);
     else {
-        rd_s16b(&player_ptr->tim_res_time);
+        player_ptr->tim_res_time = rd_s16b();
 
-        byte tmp8u;
-        rd_byte(&tmp8u);
-        player_ptr->mimic_form = (IDX)tmp8u;
-        rd_s16b(&player_ptr->tim_mimic);
-        rd_s16b(&player_ptr->tim_sh_fire);
+        player_ptr->mimic_form = rd_byte();
+        player_ptr->tim_mimic = rd_s16b();
+        player_ptr->tim_sh_fire = rd_s16b();
     }
 
     if (h_older_than(1, 0, 99))
         set_zangband_holy_aura(player_ptr);
     else {
-        rd_s16b(&player_ptr->tim_sh_holy);
-        rd_s16b(&player_ptr->tim_eyeeye);
+        player_ptr->tim_sh_holy = rd_s16b();
+        player_ptr->tim_eyeeye = rd_s16b();
     }
 
     if (h_older_than(1, 0, 3))
         set_zangband_reflection(player_ptr);
     else {
-        rd_s16b(&player_ptr->tim_reflect);
-        rd_s16b(&player_ptr->multishadow);
-        rd_s16b(&player_ptr->dustrobe);
+        player_ptr->tim_reflect = rd_s16b();
+        player_ptr->multishadow = rd_s16b();
+        player_ptr->dustrobe = rd_s16b();
     }
 }
 
@@ -408,8 +375,7 @@ static void set_mutations(player_type *player_ptr)
 {
     if (loading_savefile_version_is_older_than(2)) {
         for (int i = 0; i < 3; i++) {
-            uint32_t tmp32u;
-            rd_u32b(&tmp32u);
+            auto tmp32u = rd_u32b();
             migrate_bitflag_to_flaggroup(player_ptr->muta, tmp32u, i * 32);
         }
     } else {
@@ -420,10 +386,10 @@ static void set_mutations(player_type *player_ptr)
 static void set_virtues(player_type *player_ptr)
 {
     for (int i = 0; i < 8; i++)
-        rd_s16b(&player_ptr->virtues[i]);
+        player_ptr->virtues[i] = rd_s16b();
 
     for (int i = 0; i < 8; i++)
-        rd_s16b(&player_ptr->vir_types[i]);
+        player_ptr->vir_types[i] = rd_s16b();
 }
 
 /*!
@@ -433,7 +399,7 @@ static void set_virtues(player_type *player_ptr)
 static void rd_timed_effects(player_type *player_ptr)
 {
     set_timed_effects(player_ptr);
-    rd_s16b(&player_ptr->chaos_patron);
+    player_ptr->chaos_patron = rd_s16b();
     set_mutations(player_ptr);
     set_virtues(player_ptr);
 }
@@ -442,7 +408,7 @@ static void rd_player_status(player_type *player_ptr)
 {
     rd_base_status(player_ptr);
     strip_bytes(24);
-    rd_s32b(&player_ptr->au);
+    player_ptr->au = rd_s32b();
     rd_experience(player_ptr);
     rd_skills(player_ptr);
     rd_race(player_ptr);
@@ -452,37 +418,36 @@ static void rd_player_status(player_type *player_ptr)
     rd_dummy1();
     rd_hp(player_ptr);
     rd_mana(player_ptr);
-    rd_s16b(&player_ptr->max_plv);
+    player_ptr->max_plv = rd_s16b();
     rd_dungeons(player_ptr);
     strip_bytes(8);
-    rd_s16b(&player_ptr->sc);
+    player_ptr->sc = rd_s16b();
     if (loading_savefile_version_is_older_than(9)) {
         auto sniper_data = PlayerClass(player_ptr).get_specific_data<sniper_data_type>();
         if (sniper_data) {
-            rd_s16b(&sniper_data->concent);
+            sniper_data->concent = rd_s16b();
         } else {
             // 職業がスナイパーではないので読み捨てる
-            int16_t tmp16s;
-            rd_s16b(&tmp16s);
+            strip_bytes(2);
         }
     }
     rd_bad_status(player_ptr);
     rd_energy(player_ptr);
     rd_status(player_ptr);
-    rd_s16b(&player_ptr->hero);
-    rd_s16b(&player_ptr->shero);
-    rd_s16b(&player_ptr->shield);
-    rd_s16b(&player_ptr->blessed);
-    rd_s16b(&player_ptr->tim_invis);
-    rd_s16b(&player_ptr->word_recall);
+    player_ptr->hero = rd_s16b();
+    player_ptr->shero = rd_s16b();
+    player_ptr->shield = rd_s16b();
+    player_ptr->blessed = rd_s16b();
+    player_ptr->tim_invis = rd_s16b();
+    player_ptr->word_recall = rd_s16b();
     rd_alter_reality(player_ptr);
-    rd_s16b(&player_ptr->see_infra);
-    rd_s16b(&player_ptr->tim_infra);
-    rd_s16b(&player_ptr->oppose_fire);
-    rd_s16b(&player_ptr->oppose_cold);
-    rd_s16b(&player_ptr->oppose_acid);
-    rd_s16b(&player_ptr->oppose_elec);
-    rd_s16b(&player_ptr->oppose_pois);
+    player_ptr->see_infra = rd_s16b();
+    player_ptr->tim_infra = rd_s16b();
+    player_ptr->oppose_fire = rd_s16b();
+    player_ptr->oppose_cold = rd_s16b();
+    player_ptr->oppose_acid = rd_s16b();
+    player_ptr->oppose_elec = rd_s16b();
+    player_ptr->oppose_pois = rd_s16b();
     rd_tsuyoshi(player_ptr);
     rd_timed_effects(player_ptr);
     player_ptr->mutant_regenerate_mod = calc_mutant_regenerate_mod(player_ptr);
@@ -494,7 +459,7 @@ void rd_player_info(player_type *player_ptr)
     rd_special_attack(player_ptr);
     rd_special_action(player_ptr);
     rd_special_defense(player_ptr);
-    rd_byte(&player_ptr->knowledge);
+    player_ptr->knowledge = rd_byte();
     rd_autopick(player_ptr);
     rd_action(player_ptr);
 }

--- a/src/load/quest-loader.cpp
+++ b/src/load/quest-loader.cpp
@@ -16,8 +16,7 @@
 
 errr load_town(void)
 {
-    uint16_t max_towns_load;
-    rd_u16b(&max_towns_load);
+    auto max_towns_load = rd_u16b();
     if (max_towns_load <= max_towns)
         return 0;
 
@@ -27,11 +26,11 @@ errr load_town(void)
 
 errr load_quest_info(uint16_t *max_quests_load, byte *max_rquests_load)
 {
-    rd_u16b(max_quests_load);
+    *max_quests_load = rd_u16b();
     if (h_older_than(1, 0, 7))
         *max_rquests_load = 10;
     else
-        rd_byte(max_rquests_load);
+        *max_rquests_load = rd_byte();
 
     if (*max_quests_load <= max_q_idx)
         return 0;
@@ -52,47 +51,36 @@ static bool check_quest_index(int loading_quest_index)
 
 static void load_quest_completion(quest_type *q_ptr)
 {
-    int16_t tmp16s;
-    rd_s16b(&tmp16s);
-    q_ptr->status = i2enum<QuestStatusType>(tmp16s);
-    rd_s16b(&tmp16s);
-    q_ptr->level = tmp16s;
+    q_ptr->status = i2enum<QuestStatusType>(rd_s16b());
+    q_ptr->level = rd_s16b();
 
     if (h_older_than(1, 0, 6))
         q_ptr->complev = 0;
     else {
-        byte tmp8u;
-        rd_byte(&tmp8u);
-        q_ptr->complev = tmp8u;
+        q_ptr->complev = rd_byte();
     }
 
     if (h_older_than(2, 1, 2, 2))
         q_ptr->comptime = 0;
     else
-        rd_u32b(&q_ptr->comptime);
+        q_ptr->comptime = rd_u32b();
 }
 
 static void load_quest_details(player_type *player_ptr, quest_type *q_ptr, int loading_quest_index)
 {
-    int16_t tmp16s;
-    rd_s16b(&tmp16s);
-    q_ptr->cur_num = (MONSTER_NUMBER)tmp16s;
-    rd_s16b(&tmp16s);
-    q_ptr->max_num = (MONSTER_NUMBER)tmp16s;
-    rd_s16b(&tmp16s);
-    q_ptr->type = i2enum<QuestKindType>(tmp16s);
+    q_ptr->cur_num = rd_s16b();
+    q_ptr->max_num = rd_s16b();
+    q_ptr->type = i2enum<QuestKindType>(rd_s16b());
 
-    rd_s16b(&q_ptr->r_idx);
+    q_ptr->r_idx = rd_s16b();
     if ((q_ptr->type == QuestKindType::RANDOM) && (!q_ptr->r_idx))
         determine_random_questor(player_ptr, &quest[loading_quest_index]);
 
-    rd_s16b(&q_ptr->k_idx);
+    q_ptr->k_idx = rd_s16b();
     if (q_ptr->k_idx)
         a_info[q_ptr->k_idx].gen_flags.set(TRG::QUESTITEM);
 
-    byte tmp8u;
-    rd_byte(&tmp8u);
-    q_ptr->flags = tmp8u;
+    q_ptr->flags = rd_byte();
 }
 
 void analyze_quests(player_type *player_ptr, const uint16_t max_quests_load, const byte max_rquests_load)
@@ -114,9 +102,7 @@ void analyze_quests(player_type *player_ptr, const uint16_t max_quests_load, con
         if (h_older_than(0, 3, 11))
             set_zangband_quest(player_ptr, q_ptr, i, old_inside_quest);
         else {
-            byte tmp8u;
-            rd_byte(&tmp8u);
-            q_ptr->dungeon = tmp8u;
+            q_ptr->dungeon = rd_byte();
         }
 
         if (q_ptr->status == QuestStatusType::TAKEN || q_ptr->status == QuestStatusType::UNTAKEN)

--- a/src/load/store-loader.cpp
+++ b/src/load/store-loader.cpp
@@ -74,24 +74,20 @@ static errr rd_store(player_type *player_ptr, int town_number, int store_number)
         store_ptr = &town_info[town_number].store[store_number];
     }
 
-    byte owner_idx;
-    byte tmp8u;
     int16_t inven_num;
-    rd_s32b(&store_ptr->store_open);
-    rd_s16b(&store_ptr->insult_cur);
-    rd_byte(&owner_idx);
+    store_ptr->store_open = rd_s32b();
+    store_ptr->insult_cur = rd_s16b();
+    store_ptr->owner = rd_byte();
     if (h_older_than(1, 0, 4)) {
-        rd_byte(&tmp8u);
-        inven_num = tmp8u;
+        inven_num = rd_byte();
     } else {
-        rd_s16b(&inven_num);
+        inven_num = rd_s16b();
     }
 
-    rd_s16b(&store_ptr->good_buy);
-    rd_s16b(&store_ptr->bad_buy);
+    store_ptr->good_buy = rd_s16b();
+    store_ptr->bad_buy = rd_s16b();
 
-    rd_s32b(&store_ptr->last_visit);
-    store_ptr->owner = owner_idx;
+    store_ptr->last_visit = rd_s32b();
 
     for (int j = 0; j < inven_num; j++) {
         object_type forge;
@@ -125,12 +121,8 @@ errr load_store(player_type *player_ptr)
 {
     (void)player_ptr;
 
-    uint16_t tmp16u;
-    rd_u16b(&tmp16u);
-    auto town_count = (int)tmp16u;
-
-    rd_u16b(&tmp16u);
-    auto store_count = (int)tmp16u;
+    int town_count = rd_u16b();
+    int store_count = rd_u16b();
 
     for (int town_idx = 1; town_idx < town_count; town_idx++)
         for (int store_idx = 0; store_idx < store_count; store_idx++)

--- a/src/load/world-loader.cpp
+++ b/src/load/world-loader.cpp
@@ -13,11 +13,9 @@
 
 static void rd_hengband_dungeons(void)
 {
-    byte max;
-    rd_byte(&max);
-    int16_t tmp16s;
+    auto max = rd_byte();
     for (auto i = 0U; i < max; i++) {
-        rd_s16b(&tmp16s);
+        auto tmp16s = rd_s16b();
         if (i >= d_info.size()){
             continue;
         }
@@ -45,29 +43,27 @@ void rd_dungeons(player_type *player_ptr)
  */
 void rd_alter_reality(player_type *player_ptr)
 {
-    int16_t tmp16s;
     if (h_older_than(0, 3, 8))
         player_ptr->recall_dungeon = DUNGEON_ANGBAND;
     else {
-        rd_s16b(&tmp16s);
-        player_ptr->recall_dungeon = (byte)tmp16s;
+        player_ptr->recall_dungeon = rd_s16b();
     }
 
     if (h_older_than(1, 5, 0, 0))
         player_ptr->alter_reality = 0;
     else
-        rd_s16b(&player_ptr->alter_reality);
+        player_ptr->alter_reality = rd_s16b();
 }
 
 void set_gambling_monsters(void)
 {
     const int max_gambling_monsters = 4;
     for (int i = 0; i < max_gambling_monsters; i++) {
-        rd_s16b(&battle_mon[i]);
+        battle_mon[i] = rd_s16b();
         if (h_older_than(0, 3, 4))
             set_zangband_gambling_monsters(i);
         else
-            rd_u32b(&mon_odds[i]);
+            mon_odds[i] = rd_u32b();
     }
 }
 
@@ -76,9 +72,7 @@ void set_gambling_monsters(void)
  */
 void rd_autopick(player_type *player_ptr)
 {
-    byte tmp8u;
-    rd_byte(&tmp8u);
-    player_ptr->autopick_autoregister = tmp8u != 0;
+    player_ptr->autopick_autoregister = rd_byte() != 0;
 }
 
 static void set_undead_turn_limit(player_type *player_ptr)
@@ -100,17 +94,17 @@ static void rd_world_info(player_type *player_ptr)
 {
     set_undead_turn_limit(player_ptr);
     w_ptr->dungeon_turn_limit = TURNS_PER_TICK * TOWN_DAWN * (MAX_DAYS - 1) + TURNS_PER_TICK * TOWN_DAWN * 3 / 4;
-    rd_s32b(&player_ptr->current_floor_ptr->generated_turn);
+    player_ptr->current_floor_ptr->generated_turn = rd_s32b();
     if (h_older_than(1, 7, 0, 4))
         player_ptr->feeling_turn = player_ptr->current_floor_ptr->generated_turn;
     else
-        rd_s32b(&player_ptr->feeling_turn);
+        player_ptr->feeling_turn = rd_s32b();
 
-    rd_s32b(&w_ptr->game_turn);
+    w_ptr->game_turn = rd_s32b();
     if (h_older_than(0, 3, 12))
         w_ptr->dungeon_turn = w_ptr->game_turn;
     else
-        rd_s32b(&w_ptr->dungeon_turn);
+        w_ptr->dungeon_turn = rd_s32b();
 
     if (h_older_than(1, 0, 13))
         set_zangband_game_turns(player_ptr);
@@ -118,13 +112,13 @@ static void rd_world_info(player_type *player_ptr)
     if (h_older_than(0, 3, 13))
         w_ptr->arena_start_turn = w_ptr->game_turn;
     else
-        rd_s32b(&w_ptr->arena_start_turn);
+        w_ptr->arena_start_turn = rd_s32b();
 
     if (h_older_than(0, 0, 3))
         determine_daily_bounty(player_ptr, true);
     else {
-        rd_s16b(&w_ptr->today_mon);
-        rd_s16b(&player_ptr->today_mon);
+        w_ptr->today_mon = rd_s16b();
+        player_ptr->today_mon = rd_s16b();
     }
 }
 
@@ -140,32 +134,28 @@ void rd_visited_towns(player_type *player_ptr)
         return;
     }
 
-    int32_t tmp32s;
-    rd_s32b(&tmp32s);
-    player_ptr->visit = (BIT_FLAGS)tmp32s;
+    player_ptr->visit = rd_u32b();
 }
 
 void rd_global_configurations(player_type *player_ptr)
 {
-    rd_u32b(&w_ptr->seed_flavor);
-    rd_u32b(&w_ptr->seed_town);
+    w_ptr->seed_flavor = rd_u32b();
+    w_ptr->seed_town = rd_u32b();
 
-    rd_u16b(&player_ptr->panic_save);
-    rd_u16b(&w_ptr->total_winner);
-    rd_u16b(&w_ptr->noscore);
+    player_ptr->panic_save = rd_u16b();
+    w_ptr->total_winner = rd_u16b();
+    w_ptr->noscore = rd_u16b();
 
-    byte tmp8u;
-    rd_byte(&tmp8u);
-    player_ptr->is_dead = (bool)tmp8u;
+    player_ptr->is_dead = rd_byte() != 0;
 
-    rd_byte(&player_ptr->feeling);
+    player_ptr->feeling = rd_byte();
     rd_world_info(player_ptr);
 }
 
 void load_wilderness_info(player_type *player_ptr)
 {
-    rd_s32b(&player_ptr->wilderness_x);
-    rd_s32b(&player_ptr->wilderness_y);
+    player_ptr->wilderness_x = rd_s32b();
+    player_ptr->wilderness_y = rd_s32b();
     if (h_older_than(0, 3, 13)) {
         player_ptr->wilderness_x = 5;
         player_ptr->wilderness_y = 48;
@@ -174,20 +164,18 @@ void load_wilderness_info(player_type *player_ptr)
     if (h_older_than(0, 3, 7))
         player_ptr->wild_mode = false;
     else
-        rd_byte((byte *)&player_ptr->wild_mode);
+        player_ptr->wild_mode = rd_byte() != 0;
 
     if (h_older_than(0, 3, 7))
         player_ptr->ambush_flag = false;
     else
-        rd_byte((byte *)&player_ptr->ambush_flag);
+        player_ptr->ambush_flag = rd_byte() != 0;
 }
 
 errr analyze_wilderness(void)
 {
-    int32_t wild_x_size;
-    int32_t wild_y_size;
-    rd_s32b(&wild_x_size);
-    rd_s32b(&wild_y_size);
+    auto wild_x_size = rd_s32b();
+    auto wild_y_size = rd_s32b();
 
     if ((wild_x_size > w_ptr->max_wild_x) || (wild_y_size > w_ptr->max_wild_y)) {
         load_note(format(_("荒野が大きすぎる(%u/%u)！", "Wilderness is too big (%u/%u)!"), wild_x_size, wild_y_size));
@@ -196,7 +184,7 @@ errr analyze_wilderness(void)
 
     for (int i = 0; i < wild_x_size; i++)
         for (int j = 0; j < wild_y_size; j++)
-            rd_u32b(&wilderness[j][i].seed);
+            wilderness[j][i].seed = rd_u32b();
 
     return 0;
 }

--- a/src/util/flag-group.h
+++ b/src/util/flag-group.h
@@ -476,14 +476,12 @@ public:
     template <typename Func>
     friend void rd_FlagGroup(FlagGroup<FlagType, MAX> &fg, Func rd_byte_func)
     {
-        uint8_t tmp_l, tmp_h;
-        rd_byte_func(&tmp_l);
-        rd_byte_func(&tmp_h);
+        auto tmp_l = rd_byte_func();
+        auto tmp_h = rd_byte_func();
         const auto fg_size = static_cast<uint16_t>((tmp_h << 8) | tmp_l);
 
         for (int i = 0; i < fg_size; i++) {
-            uint8_t flag_byte;
-            rd_byte_func(&flag_byte);
+            auto flag_byte = rd_byte_func();
             std::bitset<8> flag_bits(flag_byte);
             for (int j = 0; j < 8; j++) {
                 const size_t pos = i * 8 + j;


### PR DESCRIPTION
tmp8u などの一時変数を頻繁に使用する事になっている主な原因として、セーブ
ファイルから整数を読み込む関数群 rd_byte/s16b/u16b/s32b/u32b のインター
フェースが引数にポインタを受け取りそのポインタが指す領域にセーブファイル
から読み込んだ値を書き込むようになっている事が挙げられる。
そもそも読み込んだデータを戻り値として返すのが自然であるし、コードの冗長
性が大幅に減らせるのでそのようにインターフェースを変更する。

#1729 に対応しようとしていて、そもそもコードが煩雑になっている原因は rd_\* のインターフェースにあるという事に気づいたのでそちらのほうをまず修正することにしました。 これで #1729 はひとまず現状のままでもいいかなという感じもします。