### PR TITLE
monster-loader.cpp/h をクラス化し、ファクトリクラスで処理を分割した

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -271,6 +271,7 @@
     <ClCompile Include="..\..\src\core\score-util.cpp" />
     <ClCompile Include="..\..\src\load\item\item-loader-base.cpp" />
     <ClCompile Include="..\..\src\load\item\item-loader-factory.cpp" />
+    <ClCompile Include="..\..\src\load\monster\monster-loader-factory.cpp" />
     <ClCompile Include="..\..\src\load\player-class-specific-data-loader.cpp" />
     <ClCompile Include="..\..\src\object-enchant\object-smith.cpp" />
     <ClCompile Include="..\..\src\object-enchant\smith-info.cpp" />
@@ -927,6 +928,9 @@
     <ClInclude Include="..\..\src\load\item\item-loader-version-types.h" />
     <ClInclude Include="..\..\src\load\item\item-loader-base.h" />
     <ClInclude Include="..\..\src\load\item\item-loader-factory.h" />
+    <ClInclude Include="..\..\src\load\monster\monster-loader-base.h" />
+    <ClInclude Include="..\..\src\load\monster\monster-loader-factory.h" />
+    <ClInclude Include="..\..\src\load\monster\monster-loader-version-types.h" />
     <ClInclude Include="..\..\src\load\old\monster-flag-types-savefile10.h" />
     <ClInclude Include="..\..\src\load\player-class-specific-data-loader.h" />
     <ClInclude Include="..\..\src\load\savedata-old-flag-types.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2370,6 +2370,9 @@
     <ClCompile Include="..\..\src\load\item\item-loader-factory.cpp">
       <Filter>load\item</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\load\monster\monster-loader-factory.cpp">
+      <Filter>load\monster</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5139,6 +5142,15 @@
     <ClInclude Include="..\..\src\load\item\item-loader-version-types.h">
       <Filter>load\item</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\load\monster\monster-loader-base.h">
+      <Filter>load\monster</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\monster\monster-loader-factory.h">
+      <Filter>load\monster</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\monster\monster-loader-version-types.h">
+      <Filter>load\monster</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\src\wall.bmp" />
@@ -5366,6 +5378,9 @@
     </Filter>
     <Filter Include="load\item">
       <UniqueIdentifier>{346bc9ba-a477-404f-bc72-2ad9c1ec6daf}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="load\monster">
+      <UniqueIdentifier>{ad11aaea-5034-4df2-9a9b-d63457fdad55}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -361,6 +361,10 @@ hengband_SOURCES = \
 	load/item/item-loader-factory.cpp load/item/item-loader-factory.h \
 	load/item/item-loader-version-types.h \
 	\
+	load/monster/monster-loader-base.h \
+	load/monster/monster-loader-factory.cpp load/monster/monster-loader-factory.h \
+	load/monster/monster-loader-version-types.h \
+	\
 	load/old/item-flag-types-savefile10.h \
 	load/old/item-loader-savefile10.cpp load/old/item-loader-savefile10.h \
 	load/old/load-v1-5-0.cpp load/old/load-v1-5-0.h \

--- a/src/load/dummy-loader.cpp
+++ b/src/load/dummy-loader.cpp
@@ -1,6 +1,7 @@
 ﻿#include "load/dummy-loader.h"
 #include "load/angband-version-comparer.h"
 #include "load/load-util.h"
+#include "load/monster/monster-loader-factory.h"
 #include "load/old/monster-loader-savefile10.h"
 #include "system/floor-type-definition.h"
 #include "system/monster-type-definition.h"
@@ -39,9 +40,10 @@ void rd_dummy_monsters(player_type *player_ptr)
         return;
 
     auto tmp16s = rd_s16b();
+    monster_type dummy_mon;
+    auto monster_loader = MonsterLoaderFactory::create_loader(player_ptr);
     for (int i = 0; i < tmp16s; i++) {
-        monster_type dummy_mon;
-        rd_monster(player_ptr, &dummy_mon);
+        monster_loader->rd_monster(&dummy_mon);
     }
 }
 

--- a/src/load/floor-loader.cpp
+++ b/src/load/floor-loader.cpp
@@ -11,6 +11,7 @@
 #include "load/item/item-loader-factory.h"
 #include "load/load-util.h"
 #include "load/old-feature-types.h"
+#include "load/monster/monster-loader-factory.h"
 #include "load/old/item-loader-savefile10.h"
 #include "load/old/load-v1-5-0.h"
 #include "load/old/monster-loader-savefile10.h"
@@ -173,17 +174,16 @@ errr rd_saved_floor(player_type *player_ptr, saved_floor_type *sf_ptr)
     if (limit > w_ptr->max_m_idx)
         return 161;
 
-    for (int i = 1; i < limit; i++) {
-        grid_type *g_ptr;
-        MONSTER_IDX m_idx;
-        monster_type *m_ptr;
-        m_idx = m_pop(floor_ptr);
-        if (i != m_idx)
+    auto monster_loader = MonsterLoaderFactory::create_loader(player_ptr);
+    for (auto i = 1; i < limit; i++) {
+        auto m_idx = m_pop(floor_ptr);
+        if (i != m_idx) {
             return 162;
+        }
 
-        m_ptr = &floor_ptr->m_list[m_idx];
-        rd_monster(player_ptr, m_ptr);
-        g_ptr = &floor_ptr->grid_array[m_ptr->fy][m_ptr->fx];
+        auto *m_ptr = &floor_ptr->m_list[m_idx];
+        monster_loader->rd_monster(m_ptr);
+        auto *g_ptr = &floor_ptr->grid_array[m_ptr->fy][m_ptr->fx];
         g_ptr->m_idx = m_idx;
         real_r_ptr(m_ptr)->cur_num++;
     }

--- a/src/load/monster/monster-loader-base.h
+++ b/src/load/monster/monster-loader-base.h
@@ -1,0 +1,12 @@
+﻿#pragma once
+
+struct monster_type;
+struct player_type;
+class MonsterLoaderBase {
+public:
+    virtual ~MonsterLoaderBase() = default;
+    virtual void rd_monster(monster_type *m_ptr) = 0;
+
+protected:
+    MonsterLoaderBase() = default;
+};

--- a/src/load/monster/monster-loader-factory.cpp
+++ b/src/load/monster/monster-loader-factory.cpp
@@ -1,0 +1,52 @@
+﻿/*!
+ * @brief モンスター情報をセーブデータから読み込むクラスを選択するファクトリクラス
+ * @date 2021/10/16
+ * @author Hourier
+ */
+
+#include "load/monster/monster-loader-base.h"
+#include "load/monster/monster-loader-factory.h"
+#include "load/monster/monster-loader-version-types.h"
+#include "load/load-util.h"
+#include "load/old/monster-loader-savefile10.h"
+
+/*!
+ * @brief アイテム読み込みクラスを返却する.
+ * @return アイテム読み込みクラスへの参照ポインタ.
+ * @details MonsterLoaderBaseは純粋仮想関数を含むので参照を返す必要がある.
+ * (値を返す設計はコンパイルエラー)
+ */
+std::shared_ptr<MonsterLoaderBase> MonsterLoaderFactory::create_loader(player_type *player_ptr)
+{
+    auto version = get_version();
+    switch (version) {
+    case MonsterLoaderVersionType::LOAD10:
+        return std::make_shared<MonsterLoader10>(player_ptr);
+    case MonsterLoaderVersionType::LOAD11:
+        // dummy yet.
+    default:
+        throw("Invalid loader version was specified!");
+    }
+}
+
+/*!
+ * @brief MonsterLoaderのバージョン切り替え.
+ * @return セーブファイルバージョン群の中で互換性のある最古のバージョン.
+ * @details (備忘録)例えばバージョン15で更に変更された場合、以下のように書き換えること.
+ * 
+ * if (loading_savefile_version_is_older_than(15)) {
+ *   return MonsterLoaderVersionType::LOAD11;
+ * } else if (loading_savefile_version_is_older_than(11)) {
+ *   return MonsterLoaderVersionType::LOAD10;
+ * } else {
+ *   return MonsterLoaderVersionType::LOAD15;
+ * }
+ */
+MonsterLoaderVersionType MonsterLoaderFactory::get_version()
+{
+    if (loading_savefile_version_is_older_than(11)) {
+        return MonsterLoaderVersionType::LOAD10;
+    } else {
+        return MonsterLoaderVersionType::LOAD11;
+    }
+}

--- a/src/load/monster/monster-loader-factory.h
+++ b/src/load/monster/monster-loader-factory.h
@@ -1,0 +1,16 @@
+﻿#pragma once
+
+#include <memory>
+
+enum class MonsterLoaderVersionType;
+struct player_type;
+struct monster_type;
+class MonsterLoaderBase;
+class MonsterLoaderFactory {
+public:
+    static std::shared_ptr<MonsterLoaderBase> create_loader(player_type *player_ptr);
+
+private:
+    MonsterLoaderFactory() = delete;
+    static MonsterLoaderVersionType get_version();
+};

--- a/src/load/monster/monster-loader-version-types.h
+++ b/src/load/monster/monster-loader-version-types.h
@@ -1,0 +1,6 @@
+﻿#pragma once
+
+enum class MonsterLoaderVersionType {
+    LOAD10,
+    LOAD11,
+};

--- a/src/load/old/load-v1-5-0.cpp
+++ b/src/load/old/load-v1-5-0.cpp
@@ -16,6 +16,7 @@
 #include "load/item/item-loader-factory.h"
 #include "load/item/item-loader-version-types.h"
 #include "load/load-util.h"
+#include "load/monster/monster-loader-factory.h"
 #include "load/old-feature-types.h"
 #include "load/old/item-loader-savefile10.h"
 #include "load/old/monster-loader-savefile10.h"
@@ -701,19 +702,17 @@ errr rd_dungeon_old(player_type *player_ptr)
         return (161);
     }
 
+    auto monster_loader = MonsterLoaderFactory::create_loader(player_ptr);
     for (int i = 1; i < limit; i++) {
-        MONSTER_IDX m_idx;
-        monster_type *m_ptr;
-        m_idx = m_pop(floor_ptr);
+        auto m_idx = m_pop(floor_ptr);
         if (i != m_idx) {
             load_note(format(_("モンスター配置エラー (%d <> %d)", "Monster allocation error (%d <> %d)"), i, m_idx));
             return (162);
         }
 
-        m_ptr = &floor_ptr->m_list[m_idx];
-        rd_monster(player_ptr, m_ptr);
-        grid_type *g_ptr;
-        g_ptr = &floor_ptr->grid_array[m_ptr->fy][m_ptr->fx];
+        auto m_ptr = &floor_ptr->m_list[m_idx];
+        monster_loader->rd_monster(m_ptr);
+        auto *g_ptr = &floor_ptr->grid_array[m_ptr->fy][m_ptr->fx];
         g_ptr->m_idx = m_idx;
         real_r_ptr(m_ptr)->cur_num++;
     }

--- a/src/load/old/monster-loader-savefile10.cpp
+++ b/src/load/old/monster-loader-savefile10.cpp
@@ -9,138 +9,142 @@
 #include "util/enum-converter.h"
 #include "util/quarks.h"
 
-/*!
- * @brief モンスターを読み込む(現版) / Read a monster (New method)
- * @param player_ptr プレイヤーへの参照ポインタ
- * @param m_ptr モンスター保存先ポインタ
- */
-void rd_monster(player_type *player_ptr, monster_type *m_ptr)
+MonsterLoader10::MonsterLoader10(player_type *player_ptr)
+    : player_ptr(player_ptr)
 {
+}
+
+/*!
+ * @brief モンスターを読み込む(v3.0.0 Savefile ver10まで)
+ */
+void MonsterLoader10::rd_monster(monster_type *m_ptr_)
+{
+    this->m_ptr = m_ptr_;
     if (h_older_than(1, 5, 0, 0)) {
-        rd_monster_old(player_ptr, m_ptr);
+        rd_monster_old(this->player_ptr, this->m_ptr);
         return;
     }
 
     auto flags = rd_u32b();
-    m_ptr->r_idx = rd_s16b();
-    m_ptr->fy = rd_byte();
-    m_ptr->fx = rd_byte();
+    this->m_ptr->r_idx = rd_s16b();
+    this->m_ptr->fy = rd_byte();
+    this->m_ptr->fx = rd_byte();
 
-    m_ptr->hp = rd_s16b();
-    m_ptr->maxhp = rd_s16b();
-    m_ptr->max_maxhp = rd_s16b();
+    this->m_ptr->hp = rd_s16b();
+    this->m_ptr->maxhp = rd_s16b();
+    this->m_ptr->max_maxhp = rd_s16b();
 
     if (h_older_than(2, 1, 2, 1)) {
-        m_ptr->dealt_damage = 0;
+        this->m_ptr->dealt_damage = 0;
     } else {
-        m_ptr->dealt_damage = rd_s32b();
+        this->m_ptr->dealt_damage = rd_s32b();
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::AP_R_IDX))
-        m_ptr->ap_r_idx = rd_s16b();
+        this->m_ptr->ap_r_idx = rd_s16b();
     else
-        m_ptr->ap_r_idx = m_ptr->r_idx;
+        this->m_ptr->ap_r_idx = this->m_ptr->r_idx;
 
     if (any_bits(flags, SaveDataMonsterFlagType::SUB_ALIGN))
-        m_ptr->sub_align = rd_byte();
+        this->m_ptr->sub_align = rd_byte();
     else
-        m_ptr->sub_align = 0;
+        this->m_ptr->sub_align = 0;
 
     if (any_bits(flags, SaveDataMonsterFlagType::CSLEEP))
-        m_ptr->mtimed[MTIMED_CSLEEP] = rd_s16b();
+        this->m_ptr->mtimed[MTIMED_CSLEEP] = rd_s16b();
     else
-        m_ptr->mtimed[MTIMED_CSLEEP] = 0;
+        this->m_ptr->mtimed[MTIMED_CSLEEP] = 0;
 
-    m_ptr->mspeed = rd_byte();
+    this->m_ptr->mspeed = rd_byte();
 
-    m_ptr->energy_need = rd_s16b();
+    this->m_ptr->energy_need = rd_s16b();
 
     if (any_bits(flags, SaveDataMonsterFlagType::FAST)) {
-        m_ptr->mtimed[MTIMED_FAST] = rd_byte();
+        this->m_ptr->mtimed[MTIMED_FAST] = rd_byte();
     } else
-        m_ptr->mtimed[MTIMED_FAST] = 0;
+        this->m_ptr->mtimed[MTIMED_FAST] = 0;
 
     if (any_bits(flags, SaveDataMonsterFlagType::SLOW)) {
-        m_ptr->mtimed[MTIMED_SLOW] = rd_byte();
+        this->m_ptr->mtimed[MTIMED_SLOW] = rd_byte();
     } else
-        m_ptr->mtimed[MTIMED_SLOW] = 0;
+        this->m_ptr->mtimed[MTIMED_SLOW] = 0;
 
     if (any_bits(flags, SaveDataMonsterFlagType::STUNNED)) {
-        m_ptr->mtimed[MTIMED_STUNNED] = rd_byte();
+        this->m_ptr->mtimed[MTIMED_STUNNED] = rd_byte();
     } else
-        m_ptr->mtimed[MTIMED_STUNNED] = 0;
+        this->m_ptr->mtimed[MTIMED_STUNNED] = 0;
 
     if (any_bits(flags, SaveDataMonsterFlagType::CONFUSED)) {
-        m_ptr->mtimed[MTIMED_CONFUSED] = rd_byte();
+        this->m_ptr->mtimed[MTIMED_CONFUSED] = rd_byte();
     } else
-        m_ptr->mtimed[MTIMED_CONFUSED] = 0;
+        this->m_ptr->mtimed[MTIMED_CONFUSED] = 0;
 
     if (any_bits(flags, SaveDataMonsterFlagType::MONFEAR)) {
-        m_ptr->mtimed[MTIMED_MONFEAR] = rd_byte();
+        this->m_ptr->mtimed[MTIMED_MONFEAR] = rd_byte();
     } else
-        m_ptr->mtimed[MTIMED_MONFEAR] = 0;
+        this->m_ptr->mtimed[MTIMED_MONFEAR] = 0;
 
     if (any_bits(flags, SaveDataMonsterFlagType::TARGET_Y)) {
-        m_ptr->target_y = rd_s16b();
+        this->m_ptr->target_y = rd_s16b();
     } else
-        m_ptr->target_y = 0;
+        this->m_ptr->target_y = 0;
 
     if (any_bits(flags, SaveDataMonsterFlagType::TARGET_X)) {
-        m_ptr->target_x = rd_s16b();
+        this->m_ptr->target_x = rd_s16b();
     } else
-        m_ptr->target_x = 0;
+        this->m_ptr->target_x = 0;
 
     if (any_bits(flags, SaveDataMonsterFlagType::INVULNER)) {
-        m_ptr->mtimed[MTIMED_INVULNER] = rd_byte();
+        this->m_ptr->mtimed[MTIMED_INVULNER] = rd_byte();
     } else
-        m_ptr->mtimed[MTIMED_INVULNER] = 0;
+        this->m_ptr->mtimed[MTIMED_INVULNER] = 0;
 
-    m_ptr->mflag.clear();
-    m_ptr->mflag2.clear();
+    this->m_ptr->mflag.clear();
+    this->m_ptr->mflag2.clear();
 
     if (any_bits(flags, SaveDataMonsterFlagType::SMART)) {
         if (loading_savefile_version_is_older_than(2)) {
             auto tmp32u = rd_u32b();
-            migrate_bitflag_to_flaggroup(m_ptr->smart, tmp32u);
+            migrate_bitflag_to_flaggroup(this->m_ptr->smart, tmp32u);
 
             // 3.0.0Alpha10以前のSM_CLONED(ビット位置22)、SM_PET(23)、SM_FRIEDLY(28)をMFLAG2に移行する
             // ビット位置の定義はなくなるので、ビット位置の値をハードコードする。
             std::bitset<32> rd_bits(tmp32u);
-            m_ptr->mflag2[MFLAG2::CLONED] = rd_bits[22];
-            m_ptr->mflag2[MFLAG2::PET] = rd_bits[23];
-            m_ptr->mflag2[MFLAG2::FRIENDLY] = rd_bits[28];
-            m_ptr->smart.reset(i2enum<SM>(22)).reset(i2enum<SM>(23)).reset(i2enum<SM>(28));
+            this->m_ptr->mflag2[MFLAG2::CLONED] = rd_bits[22];
+            this->m_ptr->mflag2[MFLAG2::PET] = rd_bits[23];
+            this->m_ptr->mflag2[MFLAG2::FRIENDLY] = rd_bits[28];
+            this->m_ptr->smart.reset(i2enum<SM>(22)).reset(i2enum<SM>(23)).reset(i2enum<SM>(28));
         } else {
-            rd_FlagGroup(m_ptr->smart, rd_byte);
+            rd_FlagGroup(this->m_ptr->smart, rd_byte);
         }
     } else {
-        m_ptr->smart.clear();
+        this->m_ptr->smart.clear();
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::EXP)) {
-        m_ptr->exp = rd_u32b();
+        this->m_ptr->exp = rd_u32b();
     } else
-        m_ptr->exp = 0;
+        this->m_ptr->exp = 0;
 
     if (any_bits(flags, SaveDataMonsterFlagType::MFLAG2)) {
         if (loading_savefile_version_is_older_than(2)) {
             auto tmp8u = rd_byte();
             constexpr auto base = enum2i(MFLAG2::KAGE);
-            migrate_bitflag_to_flaggroup(m_ptr->mflag2, tmp8u, base, 7);
+            migrate_bitflag_to_flaggroup(this->m_ptr->mflag2, tmp8u, base, 7);
         } else {
-            rd_FlagGroup(m_ptr->mflag2, rd_byte);
+            rd_FlagGroup(this->m_ptr->mflag2, rd_byte);
         }
     }
 
     if (any_bits(flags, SaveDataMonsterFlagType::NICKNAME)) {
         char buf[128];
         rd_string(buf, sizeof(buf));
-        m_ptr->nickname = quark_add(buf);
+        this->m_ptr->nickname = quark_add(buf);
     } else
-        m_ptr->nickname = 0;
+        this->m_ptr->nickname = 0;
 
     if (any_bits(flags, SaveDataMonsterFlagType::PARENT))
-        m_ptr->parent_m_idx = rd_s16b();
+        this->m_ptr->parent_m_idx = rd_s16b();
     else
-        m_ptr->parent_m_idx = 0;
+        this->m_ptr->parent_m_idx = 0;
 }

--- a/src/load/old/monster-loader-savefile10.cpp
+++ b/src/load/old/monster-loader-savefile10.cpp
@@ -40,68 +40,21 @@ void MonsterLoader10::rd_monster(monster_type *m_ptr_)
         this->m_ptr->dealt_damage = rd_s32b();
     }
 
-    if (any_bits(flags, SaveDataMonsterFlagType::AP_R_IDX))
-        this->m_ptr->ap_r_idx = rd_s16b();
-    else
-        this->m_ptr->ap_r_idx = this->m_ptr->r_idx;
-
-    if (any_bits(flags, SaveDataMonsterFlagType::SUB_ALIGN))
-        this->m_ptr->sub_align = rd_byte();
-    else
-        this->m_ptr->sub_align = 0;
-
-    if (any_bits(flags, SaveDataMonsterFlagType::CSLEEP))
-        this->m_ptr->mtimed[MTIMED_CSLEEP] = rd_s16b();
-    else
-        this->m_ptr->mtimed[MTIMED_CSLEEP] = 0;
-
+    this->m_ptr->ap_r_idx = any_bits(flags, SaveDataMonsterFlagType::AP_R_IDX) ? rd_s16b() : this->m_ptr->r_idx;
+    this->m_ptr->sub_align = any_bits(flags, SaveDataMonsterFlagType::SUB_ALIGN) ? rd_byte() : 0;
+    this->m_ptr->mtimed[MTIMED_CSLEEP] = any_bits(flags, SaveDataMonsterFlagType::CSLEEP) ? rd_s16b() : 0;
     this->m_ptr->mspeed = rd_byte();
-
     this->m_ptr->energy_need = rd_s16b();
-
-    if (any_bits(flags, SaveDataMonsterFlagType::FAST)) {
-        this->m_ptr->mtimed[MTIMED_FAST] = rd_byte();
-    } else
-        this->m_ptr->mtimed[MTIMED_FAST] = 0;
-
-    if (any_bits(flags, SaveDataMonsterFlagType::SLOW)) {
-        this->m_ptr->mtimed[MTIMED_SLOW] = rd_byte();
-    } else
-        this->m_ptr->mtimed[MTIMED_SLOW] = 0;
-
-    if (any_bits(flags, SaveDataMonsterFlagType::STUNNED)) {
-        this->m_ptr->mtimed[MTIMED_STUNNED] = rd_byte();
-    } else
-        this->m_ptr->mtimed[MTIMED_STUNNED] = 0;
-
-    if (any_bits(flags, SaveDataMonsterFlagType::CONFUSED)) {
-        this->m_ptr->mtimed[MTIMED_CONFUSED] = rd_byte();
-    } else
-        this->m_ptr->mtimed[MTIMED_CONFUSED] = 0;
-
-    if (any_bits(flags, SaveDataMonsterFlagType::MONFEAR)) {
-        this->m_ptr->mtimed[MTIMED_MONFEAR] = rd_byte();
-    } else
-        this->m_ptr->mtimed[MTIMED_MONFEAR] = 0;
-
-    if (any_bits(flags, SaveDataMonsterFlagType::TARGET_Y)) {
-        this->m_ptr->target_y = rd_s16b();
-    } else
-        this->m_ptr->target_y = 0;
-
-    if (any_bits(flags, SaveDataMonsterFlagType::TARGET_X)) {
-        this->m_ptr->target_x = rd_s16b();
-    } else
-        this->m_ptr->target_x = 0;
-
-    if (any_bits(flags, SaveDataMonsterFlagType::INVULNER)) {
-        this->m_ptr->mtimed[MTIMED_INVULNER] = rd_byte();
-    } else
-        this->m_ptr->mtimed[MTIMED_INVULNER] = 0;
-
+    this->m_ptr->mtimed[MTIMED_FAST] = any_bits(flags, SaveDataMonsterFlagType::FAST) ? rd_byte() : 0;
+    this->m_ptr->mtimed[MTIMED_SLOW] = any_bits(flags, SaveDataMonsterFlagType::SLOW) ? rd_byte() : 0;
+    this->m_ptr->mtimed[MTIMED_STUNNED] = any_bits(flags, SaveDataMonsterFlagType::STUNNED) ? rd_byte() : 0;
+    this->m_ptr->mtimed[MTIMED_CONFUSED] = any_bits(flags, SaveDataMonsterFlagType::CONFUSED) ? rd_byte() : 0;
+    this->m_ptr->mtimed[MTIMED_MONFEAR] = any_bits(flags, SaveDataMonsterFlagType::MONFEAR) ? rd_byte() : 0;
+    this->m_ptr->target_y = any_bits(flags, SaveDataMonsterFlagType::TARGET_Y) ? rd_s16b() : 0;
+    this->m_ptr->target_x = any_bits(flags, SaveDataMonsterFlagType::TARGET_X) ? rd_s16b() : 0;
+    this->m_ptr->mtimed[MTIMED_INVULNER] = any_bits(flags, SaveDataMonsterFlagType::INVULNER) ? rd_byte() : 0;
     this->m_ptr->mflag.clear();
     this->m_ptr->mflag2.clear();
-
     if (any_bits(flags, SaveDataMonsterFlagType::SMART)) {
         if (loading_savefile_version_is_older_than(2)) {
             auto tmp32u = rd_u32b();
@@ -121,11 +74,7 @@ void MonsterLoader10::rd_monster(monster_type *m_ptr_)
         this->m_ptr->smart.clear();
     }
 
-    if (any_bits(flags, SaveDataMonsterFlagType::EXP)) {
-        this->m_ptr->exp = rd_u32b();
-    } else
-        this->m_ptr->exp = 0;
-
+    this->m_ptr->exp = any_bits(flags, SaveDataMonsterFlagType::EXP) ? rd_u32b() : 0;
     if (any_bits(flags, SaveDataMonsterFlagType::MFLAG2)) {
         if (loading_savefile_version_is_older_than(2)) {
             auto tmp8u = rd_byte();
@@ -140,11 +89,9 @@ void MonsterLoader10::rd_monster(monster_type *m_ptr_)
         char buf[128];
         rd_string(buf, sizeof(buf));
         this->m_ptr->nickname = quark_add(buf);
-    } else
+    } else {
         this->m_ptr->nickname = 0;
+    }
 
-    if (any_bits(flags, SaveDataMonsterFlagType::PARENT))
-        this->m_ptr->parent_m_idx = rd_s16b();
-    else
-        this->m_ptr->parent_m_idx = 0;
+    this->m_ptr->parent_m_idx = any_bits(flags, SaveDataMonsterFlagType::PARENT) ? rd_s16b() : 0;
 }

--- a/src/load/old/monster-loader-savefile10.h
+++ b/src/load/old/monster-loader-savefile10.h
@@ -1,5 +1,15 @@
 ﻿#pragma once
 
+#include "load/monster/monster-loader-base.h"
+
 struct monster_type;
 struct player_type;
-void rd_monster(player_type *player_ptr, monster_type *m_ptr);
+class MonsterLoader10 : public MonsterLoaderBase {
+public:
+    MonsterLoader10(player_type *player_ptr);
+    void rd_monster(monster_type *m_ptr) override;
+
+private:
+    player_type *player_ptr;
+    monster_type *m_ptr = nullptr;
+};


### PR DESCRIPTION
#1724 の前段作業で、#1798 の亜種です
このチケットによるセーブデータのバージョン変更はありません
Alpha42を目処に、読み込み処理を切り替える予定なので、その準備です
設計はitem-loaderと同様です
ご確認下さい
(注：#1724 がマージされるのを前提としたブランチなので、それまではドラフトにしておきます)