### PR TITLE
[Refactor] 魔法の熟練度処理を PlayerSkill クラスに移設

### DIFF
--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -881,7 +881,6 @@ void do_cmd_study(player_type *player_ptr)
     if (learned) {
         int max_exp = (spell < 32) ? SPELL_EXP_MASTER : SPELL_EXP_EXPERT;
         int old_exp = player_ptr->spell_exp[spell];
-        int new_rank = EXP_LEVEL_UNSKILLED;
         concptr name = exe_spell(player_ptr, increment ? player_ptr->realm2 : player_ptr->realm1, spell % 32, SPELL_NAME);
 
         if (old_exp >= max_exp) {
@@ -895,22 +894,9 @@ void do_cmd_study(player_type *player_ptr)
 #endif
         {
             return;
-        } else if (old_exp >= SPELL_EXP_EXPERT) {
-            player_ptr->spell_exp[spell] = SPELL_EXP_MASTER;
-            new_rank = EXP_LEVEL_MASTER;
-        } else if (old_exp >= SPELL_EXP_SKILLED) {
-            if (spell >= 32)
-                player_ptr->spell_exp[spell] = SPELL_EXP_EXPERT;
-            else
-                player_ptr->spell_exp[spell] += SPELL_EXP_EXPERT - SPELL_EXP_SKILLED;
-            new_rank = EXP_LEVEL_EXPERT;
-        } else if (old_exp >= SPELL_EXP_BEGINNER) {
-            player_ptr->spell_exp[spell] = SPELL_EXP_SKILLED + (old_exp - SPELL_EXP_BEGINNER) * 2 / 3;
-            new_rank = EXP_LEVEL_SKILLED;
-        } else {
-            player_ptr->spell_exp[spell] = SPELL_EXP_BEGINNER + old_exp / 3;
-            new_rank = EXP_LEVEL_BEGINNER;
         }
+
+        auto new_rank = PlayerSkill(player_ptr).gain_spell_skill_exp_over_learning(spell);
         msg_format(_("%sの熟練度が%sに上がった。", "Your proficiency of %s is now %s rank."), name, exp_level_str[new_rank]);
     } else {
         /* Find the next open entry in "player_ptr->spell_order[]" */
@@ -1312,22 +1298,7 @@ bool do_cmd_cast(player_type *player_ptr)
             break;
         }
         if (any_bits(mp_ptr->spell_xtra, extra_magic_gain_exp)) {
-            int16_t cur_exp = player_ptr->spell_exp[(increment ? 32 : 0) + spell];
-            int16_t exp_gain = 0;
-
-            if (cur_exp < SPELL_EXP_BEGINNER)
-                exp_gain += 60;
-            else if (cur_exp < SPELL_EXP_SKILLED) {
-                if ((player_ptr->current_floor_ptr->dun_level > 4) && ((player_ptr->current_floor_ptr->dun_level + 10) > player_ptr->lev))
-                    exp_gain = 8;
-            } else if (cur_exp < SPELL_EXP_EXPERT) {
-                if (((player_ptr->current_floor_ptr->dun_level + 5) > player_ptr->lev) && ((player_ptr->current_floor_ptr->dun_level + 5) > s_ptr->slevel))
-                    exp_gain = 2;
-            } else if ((cur_exp < SPELL_EXP_MASTER) && !increment) {
-                if (((player_ptr->current_floor_ptr->dun_level + 5) > player_ptr->lev) && (player_ptr->current_floor_ptr->dun_level > s_ptr->slevel))
-                    exp_gain = 1;
-            }
-            player_ptr->spell_exp[(increment ? 32 : 0) + spell] += exp_gain;
+            PlayerSkill(player_ptr).gain_spell_skill_exp(realm, spell);
         }
     }
 

--- a/src/knowledge/knowledge-experiences.cpp
+++ b/src/knowledge/knowledge-experiences.cpp
@@ -88,7 +88,7 @@ void do_cmd_knowledge_spell_exp(player_type *player_ptr)
             if (s_ptr->slevel >= 99)
                 continue;
             SUB_EXP spell_exp = player_ptr->spell_exp[i];
-            int exp_level = spell_exp_level(spell_exp);
+            auto exp_level = PlayerSkill::spell_exp_level(spell_exp);
             fprintf(fff, "%-25s ", exe_spell(player_ptr, player_ptr->realm1, i, SPELL_NAME));
             if (player_ptr->realm1 == REALM_HISSATSU) {
                 if (show_actual_value)
@@ -124,7 +124,7 @@ void do_cmd_knowledge_spell_exp(player_type *player_ptr)
                 continue;
 
             SUB_EXP spell_exp = player_ptr->spell_exp[i + 32];
-            int exp_level = spell_exp_level(spell_exp);
+            auto exp_level = PlayerSkill::spell_exp_level(spell_exp);
             fprintf(fff, "%-25s ", exe_spell(player_ptr, player_ptr->realm2, i, SPELL_NAME));
             if (show_actual_value)
                 fprintf(fff, "%4d/%4d ", std::min<short>(spell_exp, SPELL_EXP_MASTER), SPELL_EXP_MASTER);

--- a/src/player/player-skill.h
+++ b/src/player/player-skill.h
@@ -57,6 +57,7 @@ public:
     static bool valid_weapon_exp(int weapon_exp);
     static int weapon_exp_level(int weapon_exp);
     static int riding_exp_level(int riding_exp);
+    static int spell_exp_level(int spell_exp);
 
     void gain_melee_weapon_exp(const object_type *o_ptr);
     void gain_range_weapon_exp(const object_type *o_ptr);
@@ -65,6 +66,11 @@ public:
     void gain_riding_skill_exp_on_melee_attack(const monster_race *r_ptr);
     void gain_riding_skill_exp_on_range_attack();
     void gain_riding_skill_exp_on_fall_off_check(HIT_POINT dam);
+    void gain_spell_skill_exp(int realm, int spell_idx);
+    void gain_continuous_spell_skill_exp(int realm, int spell_idx);
+    int gain_spell_skill_exp_over_learning(int spell_idx);
+
+    EXP exp_of_spell(int realm, int spell_idx) const;
 
 private:
     player_type *player_ptr;

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -150,25 +150,6 @@ static player_hand main_attack_hand(player_type *player_ptr);
 /*** Player information ***/
 
 /*!
- * @brief プレイヤーの呪文レベルの抽象的ランクを返す。 / Return proficiency level of spells
- * @param spell_exp 経験値
- * @return ランク値
- */
-int spell_exp_level(int spell_exp)
-{
-    if (spell_exp < SPELL_EXP_BEGINNER)
-        return EXP_LEVEL_UNSKILLED;
-    else if (spell_exp < SPELL_EXP_SKILLED)
-        return EXP_LEVEL_BEGINNER;
-    else if (spell_exp < SPELL_EXP_EXPERT)
-        return EXP_LEVEL_SKILLED;
-    else if (spell_exp < SPELL_EXP_MASTER)
-        return EXP_LEVEL_EXPERT;
-    else
-        return EXP_LEVEL_MASTER;
-}
-
-/*!
  * @brief 遅延描画更新 / Delayed visual update
  * @details update_view(), update_lite(), update_mon_lite() においてのみ更新すること / Only used if update_view(), update_lite() or update_mon_lite() was called
  * @param player_ptr 主観となるプレイヤー構造体参照ポインタ

--- a/src/player/player-status.h
+++ b/src/player/player-status.h
@@ -9,7 +9,6 @@
 
 struct object_type;;
 struct player_type;
-int spell_exp_level(int spell_exp);
 
 WEIGHT calc_weapon_weight_limit(player_type *player_ptr);
 WEIGHT calc_bow_weight_limit(player_type *player_ptr);

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -254,76 +254,13 @@ int SpellHex::calc_need_mana()
 
 void SpellHex::gain_exp()
 {
+    PlayerSkill ps(player_ptr);
     for (auto spell : this->casting_spells) {
         if (!this->is_spelling_specific(spell)) {
             continue;
         }
 
-        if (this->player_ptr->spell_exp[spell] < SPELL_EXP_BEGINNER) {
-            this->player_ptr->spell_exp[spell] += 5;
-            continue;
-        }
-
-        if (this->gain_exp_skilled(spell)) {
-            continue;
-        }
-
-        if (this->gain_exp_expert(spell)) {
-            continue;
-        }
-
-        this->gain_exp_master(spell);
-    }
-}
-
-bool SpellHex::gain_exp_skilled(const int spell)
-{
-    if (this->player_ptr->spell_exp[spell] >= SPELL_EXP_SKILLED) {
-        return false;
-    }
-
-    auto *floor_ptr = this->player_ptr->current_floor_ptr;
-    auto gain_condition = one_in_(2);
-    gain_condition &= floor_ptr->dun_level > 4;
-    gain_condition &= (floor_ptr->dun_level + 10) > this->player_ptr->lev;
-    if (gain_condition) {
-        this->player_ptr->spell_exp[spell]++;
-    }
-
-    return true;
-}
-
-bool SpellHex::gain_exp_expert(const int spell)
-{
-    if (this->player_ptr->spell_exp[spell] >= SPELL_EXP_EXPERT) {
-        return false;
-    }
-
-    const auto *s_ptr = &technic_info[REALM_HEX - MIN_TECHNIC][spell];
-    auto *floor_ptr = this->player_ptr->current_floor_ptr;
-    auto gain_condition = one_in_(5);
-    gain_condition &= (floor_ptr->dun_level + 5) > this->player_ptr->lev;
-    gain_condition &= (floor_ptr->dun_level + 5) > s_ptr->slevel;
-    if (gain_condition) {
-        this->player_ptr->spell_exp[spell]++;
-    }
-
-    return true;
-}
-
-void SpellHex::gain_exp_master(const int spell)
-{
-    if (this->player_ptr->spell_exp[spell] >= SPELL_EXP_MASTER) {
-        return;
-    }
-
-    const auto *s_ptr = &technic_info[REALM_HEX - MIN_TECHNIC][spell];
-    auto *floor_ptr = this->player_ptr->current_floor_ptr;
-    auto gain_condition = one_in_(5);
-    gain_condition &= (floor_ptr->dun_level + 5) > this->player_ptr->lev;
-    gain_condition &= floor_ptr->dun_level > s_ptr->slevel;
-    if (gain_condition) {
-        this->player_ptr->spell_exp[spell]++;
+        ps.gain_continuous_spell_skill_exp(REALM_HEX, spell);
     }
 }
 

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -53,7 +53,4 @@ private:
     bool check_restart();
     int calc_need_mana();
     void gain_exp();
-    bool gain_exp_skilled(const int spell);
-    bool gain_exp_expert(const int spell);
-    void gain_exp_master(const int spell);
 };

--- a/src/spell-realm/spells-song.cpp
+++ b/src/spell-realm/spells-song.cpp
@@ -63,19 +63,7 @@ void check_music(player_type *player_ptr)
         }
     }
 
-    if (player_ptr->spell_exp[spell] < SPELL_EXP_BEGINNER)
-        player_ptr->spell_exp[spell] += 5;
-    else if (player_ptr->spell_exp[spell] < SPELL_EXP_SKILLED) {
-        if (one_in_(2) && (player_ptr->current_floor_ptr->dun_level > 4) && ((player_ptr->current_floor_ptr->dun_level + 10) > player_ptr->lev))
-            player_ptr->spell_exp[spell] += 1;
-    } else if (player_ptr->spell_exp[spell] < SPELL_EXP_EXPERT) {
-        if (one_in_(5) && ((player_ptr->current_floor_ptr->dun_level + 5) > player_ptr->lev)
-            && ((player_ptr->current_floor_ptr->dun_level + 5) > s_ptr->slevel))
-            player_ptr->spell_exp[spell] += 1;
-    } else if (player_ptr->spell_exp[spell] < SPELL_EXP_MASTER) {
-        if (one_in_(5) && ((player_ptr->current_floor_ptr->dun_level + 5) > player_ptr->lev) && (player_ptr->current_floor_ptr->dun_level > s_ptr->slevel))
-            player_ptr->spell_exp[spell] += 1;
-    }
+    PlayerSkill(player_ptr).gain_continuous_spell_skill_exp(REALM_MUSIC, spell);
 
     exe_spell(player_ptr, REALM_MUSIC, spell, SPELL_CONTNUATION);
 }

--- a/src/spell/spell-info.h
+++ b/src/spell/spell-info.h
@@ -3,7 +3,6 @@
 #include "system/angband.h"
 
 struct player_type;
-EXP experience_of_spell(player_type *player_ptr, SPELL_IDX spell, int16_t use_realm);
 MANA_POINT mod_need_mana(player_type *player_ptr, MANA_POINT need_mana, SPELL_IDX spell, int16_t realm);
 PERCENTAGE mod_spell_chance_1(player_type *player_ptr, PERCENTAGE chance);
 PERCENTAGE mod_spell_chance_2(player_type *player_ptr, PERCENTAGE chance);


### PR DESCRIPTION
魔法の熟練度経験値上昇処理を PlayerSkill クラスのメンバ関数へ移設

- gain_spell_skill_exp():
  魔法を詠唱した時の熟練度経験値上昇処理
- gain_continuous_spell_skill_exp():
  継続して詠唱する魔法(歌・呪術)の熟練度経験値上昇処理
- gain_spell_skill_exp_over_learning():
  学習済みの魔法をさらに学習した時の熟練度経験値上昇処理

現在の熟練度経験値を得る関数 experience_of_spell を PlayerSkill::
exp_of_spell に移設
熟練度経験値から熟練度レベルを得る関数 spell_exp_level を PlayerSkill
クラスの静的メンバ関数にする