### PR TITLE
[Fix/Refactor] 乱数のシード初期化にSTLを使用する

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,8 +84,6 @@ fi
 
 AC_CHECK_LIB(iconv, iconv_open)
 
-AC_CHECK_FILE(/dev/urandom, AC_DEFINE(RNG_DEVICE, "/dev/urandom", [Random Number Generation device file]))
-
 if test "$worldscore" != no; then
   PKG_CHECK_MODULES(libcurl, [libcurl])
 fi


### PR DESCRIPTION
乱数の初期化を行う関数 Rand_state_init において、プラットフォーム毎に
固有の方法で非決定論的乱数を生成して疑似乱数生成器のシードとしていたが、
これをやめて代わりに STL の std::random_device を使用するようにする。
また Issue #1805 の原因として、Windows での非決定論的乱数生成に使用して
いた Crypt 系APIの呼び出しが失敗した結果、無限ループに陥ってる事が推察
される。
std::random_device を使用するように変更したことによりこれも合わせて解消
される見込み。

元々特定の環境でWindowsの Crypt 系APIの呼び出しが失敗することがあったが、Rand_state に 0 以外の初期値が設定されていたのでループの継続条件にひっかからず抜けることができていたようです。 #1759 でローカルでシードを生成して引数に渡すように変更した結果、 0 で初期化されたシードが API 呼び出し失敗で延々と 0 のままとなり、無限ループになってフリーズが発生したものと思われます。
