### PR TITLE
[Fix] object_type宣言の余計なセミコロンを機械的に削除。

### DIFF
--- a/src/artifact/artifact-info.h
+++ b/src/artifact/artifact-info.h
@@ -9,6 +9,6 @@
 
 enum class RandomArtActType : short;
 struct activation_type;
-struct object_type;;
+struct object_type;
 RandomArtActType activation_index(const object_type *o_ptr);
 std::optional<const activation_type *> find_activation_info(const object_type *o_ptr);

--- a/src/artifact/fixed-art-generator.h
+++ b/src/artifact/fixed-art-generator.h
@@ -7,7 +7,7 @@
 #include "system/angband.h"
 
 typedef struct artifact_type artifact_type;
-struct object_type;;
+struct object_type;
 struct player_type;
 bool create_named_art(player_type *player_ptr, ARTIFACT_IDX a_idx, POSITION y, POSITION x);
 bool make_artifact(player_type *player_ptr, object_type *o_ptr);

--- a/src/artifact/random-art-activation.h
+++ b/src/artifact/random-art-activation.h
@@ -4,5 +4,5 @@
  * @brief ランダムアーティファクトの発動実装ヘッダ
  */
 
-struct object_type;;
+struct object_type;
 void give_activation_power(object_type *o_ptr);

--- a/src/artifact/random-art-characteristics.h
+++ b/src/artifact/random-art-characteristics.h
@@ -4,7 +4,7 @@
  * @brief ランダムアーティファクトのバイアス付加処理ヘッダ
  */
 
-struct object_type;;
+struct object_type;
 struct player_type;
 void curse_artifact(player_type *player_ptr, object_type *o_ptr);
 void get_random_name(object_type *o_ptr, char *return_name, bool armour, int power);

--- a/src/artifact/random-art-generator.h
+++ b/src/artifact/random-art-generator.h
@@ -4,6 +4,6 @@
  * @brief ランダムアーティファクトの生成メインヘッダ / Artifact code
  */
 
-struct object_type;;
+struct object_type;
 struct player_type;
 bool become_random_artifact(player_type *player_ptr, object_type *o_ptr, bool a_scroll);

--- a/src/artifact/random-art-misc.h
+++ b/src/artifact/random-art-misc.h
@@ -4,6 +4,6 @@
  * @brief ランダムアーティファクト生成のその他特性バイアス付けヘッダ / Artifact code
  */
 
-struct object_type;;
+struct object_type;
 struct player_type;
 void random_misc(player_type *player_ptr, object_type *o_ptr);

--- a/src/artifact/random-art-pval-investor.h
+++ b/src/artifact/random-art-pval-investor.h
@@ -4,5 +4,5 @@
  * @brief ランダムアーティファクトのpval付加処理ヘッダ
  */
 
-struct object_type;;
+struct object_type;
 void random_plus(object_type *o_ptr);

--- a/src/artifact/random-art-resistance.h
+++ b/src/artifact/random-art-resistance.h
@@ -4,5 +4,5 @@
  * @brief ランダムアーティファクトの耐性付加処理ヘッダ
  */
 
-struct object_type;;
+struct object_type;
 void random_resistance(object_type *o_ptr);

--- a/src/artifact/random-art-slay.h
+++ b/src/artifact/random-art-slay.h
@@ -4,5 +4,5 @@
  * @brief ランダムアーティファクトのスレイ付加処理ヘッダ
  */
 
-struct object_type;;
+struct object_type;
 void random_slay(object_type *o_ptr);

--- a/src/autopick/autopick-destroyer.h
+++ b/src/autopick/autopick-destroyer.h
@@ -1,5 +1,5 @@
 ﻿#pragma once
 
-struct object_type;;
+struct object_type;
 struct player_type;
 void auto_destroy_item(player_type *player_ptr, object_type *o_ptr, int autopick_idx);

--- a/src/autopick/autopick-entry.h
+++ b/src/autopick/autopick-entry.h
@@ -3,7 +3,7 @@
 #include "system/angband.h"
 
 typedef struct autopick_type autopick_type;
-struct object_type;;
+struct object_type;
 struct player_type;
 bool autopick_new_entry(autopick_type *entry, concptr str, bool allow_default);
 void autopick_entry_from_object(player_type *player_ptr, autopick_type *entry, object_type *o_ptr);

--- a/src/autopick/autopick-finder.h
+++ b/src/autopick/autopick-finder.h
@@ -2,7 +2,7 @@
 
 #include "system/angband.h"
 
-struct object_type;;
+struct object_type;
 struct player_type;
 struct text_body_type;
 int find_autopick_list(player_type *player_ptr, object_type *o_ptr);

--- a/src/autopick/autopick-matcher.h
+++ b/src/autopick/autopick-matcher.h
@@ -3,6 +3,6 @@
 #include "system/angband.h"
 
 typedef struct autopick_type autopick_type;
-struct object_type;;
+struct object_type;
 struct player_type;
 bool is_autopick_match(player_type *player_ptr, object_type *o_ptr, autopick_type *entry, concptr o_name);

--- a/src/autopick/autopick-registry.h
+++ b/src/autopick/autopick-registry.h
@@ -1,5 +1,5 @@
 ﻿#pragma once
 
-struct object_type;;
+struct object_type;
 struct player_type;
 bool autopick_autoregister(player_type *player_ptr, object_type *o_ptr);

--- a/src/birth/inventory-initializer.h
+++ b/src/birth/inventory-initializer.h
@@ -1,6 +1,6 @@
 ﻿#pragma once
 
-struct object_type;;
+struct object_type;
 struct player_type;
 void wield_all(player_type *player_ptr);
 void add_outfit(player_type *player_ptr, object_type *o_ptr);

--- a/src/combat/shoot.h
+++ b/src/combat/shoot.h
@@ -3,7 +3,7 @@
 #include "system/angband.h"
 
 struct monster_type;
-struct object_type;;
+struct object_type;
 struct player_type;
 bool test_hit_fire(player_type *player_ptr, int chance, monster_type *m_ptr, int vis, char *o_name);
 HIT_POINT critical_shot(player_type *player_ptr, WEIGHT weight, int plus_ammo, int plus_bow, HIT_POINT dam);

--- a/src/combat/slaying.h
+++ b/src/combat/slaying.h
@@ -6,7 +6,7 @@
 #include "object-enchant/tr-flags.h"
 
 struct monster_type;
-struct object_type;;
+struct object_type;
 struct player_type;
 MULTIPLY mult_slaying(player_type *player_ptr, MULTIPLY mult, const TrFlags &flgs, monster_type *m_ptr);
 MULTIPLY mult_brand(player_type *player_ptr, MULTIPLY mult, const TrFlags &flgs, monster_type *m_ptr);

--- a/src/flavor/flavor-describer.h
+++ b/src/flavor/flavor-describer.h
@@ -2,6 +2,6 @@
 
 #include "system/angband.h"
 
-struct object_type;;
+struct object_type;
 struct player_type;
 void describe_flavor(player_type *player_ptr, char *buf, object_type *o_ptr, BIT_FLAGS mode);

--- a/src/flavor/flavor-util.h
+++ b/src/flavor/flavor-util.h
@@ -6,7 +6,7 @@
 #include "object-enchant/tr-flags.h"
 
 typedef struct object_kind object_kind;
-struct object_type;;
+struct object_type;
 typedef struct flavor_type {
     char *buf;
     object_type *o_ptr;

--- a/src/floor/floor-object.h
+++ b/src/floor/floor-object.h
@@ -7,7 +7,7 @@
 class ObjectIndexList;
 
 struct floor_type;
-struct object_type;;
+struct object_type;
 struct player_type;
 class ItemTester;
 bool make_object(player_type *player_ptr, object_type *j_ptr, BIT_FLAGS mode, std::optional<int> rq_mon_level = std::nullopt);

--- a/src/inventory/inventory-curse.h
+++ b/src/inventory/inventory-curse.h
@@ -2,7 +2,7 @@
 
 #include "system/angband.h"
 
-struct object_type;;
+struct object_type;
 struct player_type;
 object_type *choose_cursed_obj_name(player_type *player_ptr, BIT_FLAGS flag);
 void execute_cursed_items_effect(player_type *player_ptr);

--- a/src/inventory/inventory-damage.h
+++ b/src/inventory/inventory-damage.h
@@ -5,7 +5,7 @@
 /*
  * This seems like a pretty standard "typedef"
  */
-struct object_type;;
+struct object_type;
 struct player_type;
 
 void inventory_damage(player_type *player_ptr, const ObjectBreaker& breaker, int perc);

--- a/src/inventory/inventory-object.h
+++ b/src/inventory/inventory-object.h
@@ -2,7 +2,7 @@
 
 #include "system/angband.h"
 
-struct object_type;;
+struct object_type;
 struct player_type;
 void vary_item(player_type *player_ptr, INVENTORY_IDX item, ITEM_NUMBER num);
 void inven_item_increase(player_type *player_ptr, INVENTORY_IDX item, ITEM_NUMBER num);

--- a/src/load/old/load-v1-5-0.h
+++ b/src/load/old/load-v1-5-0.h
@@ -36,7 +36,7 @@ extern const int OLD_QUEST_WATER_CAVE;
 extern const int QUEST_OLD_CASTLE;
 extern const int QUEST_ROYAL_CRYPT;
 
-struct object_type;;
+struct object_type;
 struct player_type;
 void rd_item_old(object_type *o_ptr);
 void rd_monster_old(player_type *player_ptr, monster_type *m_ptr);

--- a/src/monster-attack/monster-attack-util.h
+++ b/src/monster-attack/monster-attack-util.h
@@ -6,7 +6,7 @@
 
 /* MONster-Attack-Player、地図のMAPと紛らわしいのでmonapとした */
 struct monster_type;
-struct object_type;;
+struct object_type;
 typedef struct monap_type {
 #ifdef JP
     int abbreviate; // 2回目以降の省略表現フラグ.

--- a/src/object-activation/activation-breath.h
+++ b/src/object-activation/activation-breath.h
@@ -1,6 +1,6 @@
 ﻿#pragma once
 
-struct object_type;;
+struct object_type;
 struct player_type;
 bool activate_dragon_breath(player_type *player_ptr, object_type *o_ptr);
 bool activate_breath_fire(player_type *player_ptr, object_type *o_ptr);

--- a/src/object-activation/activation-others.h
+++ b/src/object-activation/activation-others.h
@@ -2,7 +2,7 @@
 
 #include "system/angband.h"
 
-struct object_type;;
+struct object_type;
 struct player_type;
 bool activate_sunlight(player_type *player_ptr);
 bool activate_confusion(player_type *player_ptr);

--- a/src/object-activation/activation-switcher.h
+++ b/src/object-activation/activation-switcher.h
@@ -3,6 +3,6 @@
 #include "system/angband.h"
 
 struct activation_type;
-struct object_type;;
+struct object_type;
 struct player_type;
 bool switch_activation(player_type *player_ptr, object_type **o_ptr_ptr, const activation_type *const act_ptr, concptr name);

--- a/src/object-activation/activation-util.h
+++ b/src/object-activation/activation-util.h
@@ -3,7 +3,7 @@
 #include "system/angband.h"
 
 // Activation Execution.
-struct object_type;;
+struct object_type;
 typedef struct ae_type {
     DIRECTION dir;
     bool success;

--- a/src/object-enchant/apply-magic-others.h
+++ b/src/object-enchant/apply-magic-others.h
@@ -1,5 +1,5 @@
 ﻿#pragma once
 
-struct object_type;;
+struct object_type;
 struct player_type;
 void apply_magic_others(player_type *player_ptr, object_type *o_ptr, int power);

--- a/src/object-enchant/apply-magic-weapon.h
+++ b/src/object-enchant/apply-magic-weapon.h
@@ -2,6 +2,6 @@
 
 #include "system/angband.h"
 
-struct object_type;;
+struct object_type;
 struct player_type;
 void apply_magic_weapon(player_type *player_ptr, object_type *o_ptr, DEPTH level, int power);

--- a/src/object-enchant/enchanter-base.h
+++ b/src/object-enchant/enchanter-base.h
@@ -10,7 +10,7 @@
 
 #include "system/angband.h"
 
-struct object_type;;
+struct object_type;
 struct player_type;
 class EnchanterBase {
 public:

--- a/src/object-enchant/object-boost.h
+++ b/src/object-enchant/object-boost.h
@@ -2,7 +2,7 @@
 
 #include "system/angband.h"
 
-struct object_type;;
+struct object_type;
 int m_bonus(int max, DEPTH level);
 void one_sustain(object_type *o_ptr);
 bool add_esp_strong(object_type *o_ptr);

--- a/src/object-enchant/object-curse.h
+++ b/src/object-enchant/object-curse.h
@@ -2,7 +2,7 @@
 
 #include "system/angband.h"
 
-struct object_type;;
+struct object_type;
 struct player_type;
 enum class TRC;
 TRC get_curse(int power, object_type *o_ptr);

--- a/src/object-enchant/object-ego.h
+++ b/src/object-enchant/object-ego.h
@@ -266,7 +266,7 @@ struct ego_item_type {
 
 extern std::vector<ego_item_type> e_info;
 
-struct object_type;;
+struct object_type;
 struct player_type;
 byte get_random_ego(byte slot, bool good);
 void apply_ego(object_type *o_ptr, DEPTH lev);

--- a/src/object-hook/hook-armor.h
+++ b/src/object-hook/hook-armor.h
@@ -1,5 +1,5 @@
 ﻿#pragma once
 
-struct object_type;;
+struct object_type;
 struct player_type;
 bool item_tester_hook_wear(player_type *player_ptr, const object_type *o_ptr);

--- a/src/object-hook/hook-expendable.h
+++ b/src/object-hook/hook-expendable.h
@@ -1,6 +1,6 @@
 ﻿#pragma once
 
-struct object_type;;
+struct object_type;
 struct player_type;
 bool item_tester_hook_eatable(player_type *player_ptr, const object_type *o_ptr);
 bool item_tester_hook_quaff(player_type *player_ptr, const object_type *o_ptr);

--- a/src/object-hook/hook-magic.h
+++ b/src/object-hook/hook-magic.h
@@ -1,6 +1,6 @@
 ﻿#pragma once
 
-struct object_type;;
+struct object_type;
 struct player_type;
 bool item_tester_hook_use(player_type *player_ptr, const object_type *o_ptr);
 bool item_tester_learn_spell(player_type *player_ptr, const object_type *o_ptr);

--- a/src/object-hook/hook-perception.h
+++ b/src/object-hook/hook-perception.h
@@ -1,6 +1,6 @@
 ﻿#pragma once
 
-struct object_type;;
+struct object_type;
 bool object_is_nameless_weapon_armour(const object_type *o_ptr);
 bool object_is_not_identified(const object_type *o_ptr);
 bool object_is_not_identified_weapon_armor(const object_type *o_ptr);

--- a/src/object-hook/hook-quest.h
+++ b/src/object-hook/hook-quest.h
@@ -2,7 +2,7 @@
 
 #include "system/angband.h"
 
-struct object_type;;
+struct object_type;
 struct player_type;
 bool object_is_bounty(player_type *player_ptr, object_type *o_ptr);
 bool object_is_quest_target(QUEST_IDX quest_idx, object_type *o_ptr);

--- a/src/object-hook/hook-weapon.h
+++ b/src/object-hook/hook-weapon.h
@@ -1,5 +1,5 @@
 ﻿#pragma once
 
-struct object_type;;
+struct object_type;
 struct player_type;
 bool object_is_favorite(player_type *player_ptr, const object_type *o_ptr);

--- a/src/object/lite-processor.h
+++ b/src/object/lite-processor.h
@@ -1,6 +1,6 @@
 ﻿#pragma once
 
-struct object_type;;
+struct object_type;
 struct player_type;
 void reduce_lite_life(player_type *player_ptr);
 void notice_lite_change(player_type* player_ptr, object_type* o_ptr);

--- a/src/object/object-broken.h
+++ b/src/object/object-broken.h
@@ -3,7 +3,7 @@
 #include "system/angband.h"
 #include "object-enchant/tr-types.h"
 
-struct object_type;;
+struct object_type;
 struct player_type;
 
 bool potion_smash_effect(player_type *player_ptr, MONSTER_IDX who, POSITION y, POSITION x, KIND_OBJECT_IDX k_idx);

--- a/src/object/object-info.h
+++ b/src/object/object-info.h
@@ -5,7 +5,7 @@
 
 #define OBJ_GOLD_LIST 480 /* First "gold" entry */
 
-struct object_type;;
+struct object_type;
 struct player_type;
 concptr activation_explanation(object_type *o_ptr);
 char index_to_label(int i);

--- a/src/object/object-stack.h
+++ b/src/object/object-stack.h
@@ -1,6 +1,6 @@
 ﻿#pragma once
 
-struct object_type;;
+struct object_type;
 void distribute_charges(object_type *o_ptr, object_type *q_ptr, int amt);
 void reduce_charges(object_type *o_ptr, int amt);
 int object_similar_part(const object_type *o_ptr, const object_type *j_ptr);

--- a/src/object/object-value-calc.h
+++ b/src/object/object-value-calc.h
@@ -2,6 +2,6 @@
 
 #include "system/angband.h"
 
-struct object_type;;
+struct object_type;
 struct player_type;
 int32_t flag_cost(const object_type *o_ptr, int plusses);

--- a/src/object/object-value.h
+++ b/src/object/object-value.h
@@ -2,7 +2,7 @@
 
 #include "system/angband.h"
 
-struct object_type;;
+struct object_type;
 struct player_type;
 PRICE object_value(const object_type *o_ptr);
 PRICE object_value_real(const object_type *o_ptr);

--- a/src/object/warning.h
+++ b/src/object/warning.h
@@ -2,7 +2,7 @@
 
 #include "system/angband.h"
 
-struct object_type;;
+struct object_type;
 struct player_type;
 object_type *choose_warning_item(player_type *player_ptr);
 bool process_warning(player_type *player_ptr, POSITION xx, POSITION yy);

--- a/src/perception/identification.h
+++ b/src/perception/identification.h
@@ -4,6 +4,6 @@
 
 #define SCROBJ_FAKE_OBJECT 0x00000001
 #define SCROBJ_FORCE_DETAIL 0x00000002
-struct object_type;;
+struct object_type;
 struct player_type;
 bool screen_object(player_type *player_ptr, object_type *o_ptr, BIT_FLAGS mode);

--- a/src/perception/object-perception.h
+++ b/src/perception/object-perception.h
@@ -1,6 +1,6 @@
 ﻿#pragma once
 
-struct object_type;;
+struct object_type;
 struct player_type;
 void object_known(object_type *o_ptr);
 void object_aware(player_type *player_ptr, object_type *o_ptr);

--- a/src/perception/simple-perception.h
+++ b/src/perception/simple-perception.h
@@ -2,7 +2,7 @@
 
 #include "object-enchant/item-feeling.h"
 
-struct object_type;;
+struct object_type;
 struct player_type;
 void sense_inventory1(player_type *player_ptr);
 void sense_inventory2(player_type* player_ptr);

--- a/src/player/player-status.h
+++ b/src/player/player-status.h
@@ -7,7 +7,7 @@
 
 #include "system/angband.h"
 
-struct object_type;;
+struct object_type;
 struct player_type;
 int spell_exp_level(int spell_exp);
 

--- a/src/save/item-writer.h
+++ b/src/save/item-writer.h
@@ -2,6 +2,6 @@
 
 #include "system/angband.h"
 
-struct object_type;;
+struct object_type;
 void wr_item(object_type *o_ptr);
 void wr_perception(KIND_OBJECT_IDX k_idx);

--- a/src/specific-object/bloody-moon.h
+++ b/src/specific-object/bloody-moon.h
@@ -1,6 +1,6 @@
 ﻿#pragma once
 
-struct object_type;;
+struct object_type;
 struct player_type;
 void get_bloody_moon_flags(object_type *o_ptr);
 bool activate_bloody_moon(player_type *player_ptr, object_type *o_ptr);

--- a/src/specific-object/death-crimson.h
+++ b/src/specific-object/death-crimson.h
@@ -1,5 +1,5 @@
 ﻿#pragma once
 
-struct object_type;;
+struct object_type;
 struct player_type;
 bool activate_crimson(player_type *player_ptr, object_type *o_ptr);

--- a/src/specific-object/muramasa.h
+++ b/src/specific-object/muramasa.h
@@ -1,5 +1,5 @@
 ﻿#pragma once
 
-struct object_type;;
+struct object_type;
 struct player_type;
 bool activate_muramasa(player_type *player_ptr, object_type *o_ptr);

--- a/src/specific-object/torch.h
+++ b/src/specific-object/torch.h
@@ -4,7 +4,7 @@
 
 #include "object-enchant/tr-flags.h"
 
-struct object_type;;
+struct object_type;
 struct player_type;
 void torch_flags(object_type *o_ptr, TrFlags &flgs);
 void torch_dice(object_type *o_ptr, DICE_NUMBER *dd, DICE_SID *ds);

--- a/src/spell-kind/spells-perception.h
+++ b/src/spell-kind/spells-perception.h
@@ -2,7 +2,7 @@
 
 #include "system/angband.h"
 
-struct object_type;;
+struct object_type;
 struct player_type;
 void identify_pack(player_type *player_ptr);
 bool identify_item(player_type *player_ptr, object_type *o_ptr);

--- a/src/spell/spells-object.h
+++ b/src/spell/spells-object.h
@@ -2,7 +2,7 @@
 
 #include "system/angband.h"
 
-struct object_type;;
+struct object_type;
 struct player_type;
 void amusement(player_type *player_ptr, POSITION y1, POSITION x1, int num, bool known);
 void acquirement(player_type *player_ptr, POSITION y1, POSITION x1, int num, bool great, bool special, bool known);

--- a/src/spell/spells-status.h
+++ b/src/spell/spells-status.h
@@ -3,7 +3,7 @@
 #include "system/angband.h"
 #include "spell/spells-util.h"
 
-struct object_type;;
+struct object_type;
 struct player_type;
 struct monster_type;
 bool heal_monster(player_type *player_ptr, DIRECTION dir, HIT_POINT dam);

--- a/src/spell/spells-summon.h
+++ b/src/spell/spells-summon.h
@@ -4,7 +4,7 @@
 
 enum summon_type : int;
 
-struct object_type;;
+struct object_type;
 struct player_type;
 bool trump_summoning(player_type *player_ptr, int num, bool pet, POSITION y, POSITION x, DEPTH lev, summon_type type, BIT_FLAGS mode);
 bool cast_summon_demon(player_type *player_ptr, int power);

--- a/src/store/black-market.h
+++ b/src/store/black-market.h
@@ -1,5 +1,5 @@
 ﻿#pragma once
 
-struct object_type;;
+struct object_type;
 struct player_type;
 bool black_market_crap(player_type *player_ptr, object_type *o_ptr);

--- a/src/store/pricing.h
+++ b/src/store/pricing.h
@@ -4,6 +4,6 @@
 
 #define LOW_PRICE_THRESHOLD 10L
 
-struct object_type;;
+struct object_type;
 struct player_type;
 PRICE price_item(player_type *player_ptr, object_type *o_ptr, int greed, bool flip);

--- a/src/store/service-checker.h
+++ b/src/store/service-checker.h
@@ -1,6 +1,6 @@
 ﻿#pragma once
 
-struct object_type;;
+struct object_type;
 struct player_type;
 bool store_will_buy(player_type *player_ptr, const object_type *o_ptr);
 void mass_produce(player_type *player_ptr, object_type *o_ptr);

--- a/src/store/store-util.h
+++ b/src/store/store-util.h
@@ -30,7 +30,7 @@ using store_k_idx = std::vector<KIND_OBJECT_IDX>;
 /*!
  * @brief 店舗の情報構造体
  */
-struct object_type;;
+struct object_type;
 struct store_type {
     byte type{};           //!< Store type
     byte owner{};          //!< Owner index

--- a/src/system/floor-type-definition.h
+++ b/src/system/floor-type-definition.h
@@ -8,7 +8,7 @@
 #include <vector>
 
 struct grid_type;;
-struct object_type;;
+struct object_type;
 struct monster_type;
 typedef struct floor_type {
     DUNGEON_IDX dungeon_idx;

--- a/src/util/object-sort.h
+++ b/src/util/object-sort.h
@@ -2,6 +2,6 @@
 
 #include "system/angband.h"
 
-struct object_type;;
+struct object_type;
 struct player_type;
 bool object_sort_comp(player_type *player_ptr, object_type *o_ptr, int32_t o_value, object_type *j_ptr);

--- a/src/window/main-window-util.h
+++ b/src/window/main-window-util.h
@@ -5,7 +5,7 @@
 #define ROW_MAP 0
 #define COL_MAP 12
 
-struct object_type;;
+struct object_type;
 extern object_type *autopick_obj;
 extern POSITION panel_row_min;
 extern POSITION panel_row_max;

--- a/src/wizard/artifact-analyzer.h
+++ b/src/wizard/artifact-analyzer.h
@@ -1,6 +1,6 @@
 ﻿#pragma once
 
-struct object_type;;
+struct object_type;
 typedef struct obj_desc_list obj_desc_list;
 struct player_type;
 void object_analyze(player_type *player_ptr, object_type *o_ptr, obj_desc_list *desc_ptr);


### PR DESCRIPTION
Issueなし。単純に置換上のミスに思えたので。