### PR TITLE
[Refactor] 熟練度レベルの定数を enum class にする

### DIFF
--- a/src/birth/birth-stat.cpp
+++ b/src/birth/birth-stat.cpp
@@ -116,11 +116,11 @@ void get_extra(player_type *player_ptr, bool roll_hitdie)
 
     for (int i = 0; i < 64; i++) {
         if (player_ptr->pclass == PlayerClassType::SORCERER)
-            player_ptr->spell_exp[i] = PlayerSkill::spell_exp_at(EXP_LEVEL_MASTER);
+            player_ptr->spell_exp[i] = PlayerSkill::spell_exp_at(PlayerSkillRank::MASTER);
         else if (player_ptr->pclass == PlayerClassType::RED_MAGE)
-            player_ptr->spell_exp[i] = PlayerSkill::spell_exp_at(EXP_LEVEL_SKILLED);
+            player_ptr->spell_exp[i] = PlayerSkill::spell_exp_at(PlayerSkillRank::SKILLED);
         else
-            player_ptr->spell_exp[i] = PlayerSkill::spell_exp_at(EXP_LEVEL_UNSKILLED);
+            player_ptr->spell_exp[i] = PlayerSkill::spell_exp_at(PlayerSkillRank::UNSKILLED);
     }
 
     auto pclass = enum2i(player_ptr->pclass);
@@ -128,7 +128,7 @@ void get_extra(player_type *player_ptr, bool roll_hitdie)
 
     if (player_ptr->ppersonality == PERSONALITY_SEXY) {
         auto &whip_exp = player_ptr->weapon_exp[ItemKindType::HAFTED][SV_WHIP];
-        whip_exp = std::max(whip_exp, PlayerSkill::weapon_exp_at(EXP_LEVEL_BEGINNER));
+        whip_exp = std::max(whip_exp, PlayerSkill::weapon_exp_at(PlayerSkillRank::BEGINNER));
     }
 
     for (auto i : PLAYER_SKILL_KIND_TYPE_RANGE)

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -728,7 +728,7 @@ static void change_realm2(player_type *player_ptr, int16_t next_realm)
         player_ptr->spell_order[j] = 99;
 
     for (i = 32; i < 64; i++) {
-        player_ptr->spell_exp[i] = PlayerSkill::spell_exp_at(EXP_LEVEL_UNSKILLED);
+        player_ptr->spell_exp[i] = PlayerSkill::spell_exp_at(PlayerSkillRank::UNSKILLED);
     }
     player_ptr->spell_learned2 = 0L;
     player_ptr->spell_worked2 = 0L;
@@ -879,7 +879,7 @@ void do_cmd_study(player_type *player_ptr)
     }
 
     if (learned) {
-        auto max_exp = PlayerSkill::spell_exp_at((spell < 32) ? EXP_LEVEL_MASTER : EXP_LEVEL_EXPERT);
+        auto max_exp = PlayerSkill::spell_exp_at((spell < 32) ? PlayerSkillRank::MASTER : PlayerSkillRank::EXPERT);
         int old_exp = player_ptr->spell_exp[spell];
         concptr name = exe_spell(player_ptr, increment ? player_ptr->realm2 : player_ptr->realm1, spell % 32, SPELL_NAME);
 
@@ -897,7 +897,8 @@ void do_cmd_study(player_type *player_ptr)
         }
 
         auto new_rank = PlayerSkill(player_ptr).gain_spell_skill_exp_over_learning(spell);
-        msg_format(_("%sの熟練度が%sに上がった。", "Your proficiency of %s is now %s rank."), name, exp_level_str[new_rank]);
+        auto new_rank_str = PlayerSkill::skill_rank_str(new_rank);
+        msg_format(_("%sの熟練度が%sに上がった。", "Your proficiency of %s is now %s rank."), name, new_rank_str);
     } else {
         /* Find the next open entry in "player_ptr->spell_order[]" */
         for (i = 0; i < 64; i++) {

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -431,7 +431,7 @@ void exe_fire(player_type *player_ptr, INVENTORY_IDX item, object_type *j_ptr, S
     if ((j_ptr->sval == SV_LIGHT_XBOW) || (j_ptr->sval == SV_HEAVY_XBOW))
         chance = (player_ptr->skill_thb + (player_ptr->weapon_exp[j_ptr->tval][j_ptr->sval] / 400 + bonus) * BTH_PLUS_ADJ);
     else
-        chance = (player_ptr->skill_thb + ((player_ptr->weapon_exp[j_ptr->tval][j_ptr->sval] - (PlayerSkill::weapon_exp_at(EXP_LEVEL_MASTER) / 2)) / 200 + bonus) * BTH_PLUS_ADJ);
+        chance = (player_ptr->skill_thb + ((player_ptr->weapon_exp[j_ptr->tval][j_ptr->sval] - (PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER) / 2)) / 200 + bonus) * BTH_PLUS_ADJ);
 
     PlayerEnergy(player_ptr).set_player_turn_energy(bow_energy(j_ptr->sval));
     tmul = bow_tmul(j_ptr->sval);
@@ -946,7 +946,7 @@ HIT_POINT critical_shot(player_type *player_ptr, WEIGHT weight, int plus_ammo, i
     if (player_ptr->tval_ammo == ItemKindType::BOLT)
         i = (player_ptr->skill_thb + (player_ptr->weapon_exp[j_ptr->tval][j_ptr->sval] / 400 + i) * BTH_PLUS_ADJ);
     else
-        i = (player_ptr->skill_thb + ((player_ptr->weapon_exp[j_ptr->tval][j_ptr->sval] - (PlayerSkill::weapon_exp_at(EXP_LEVEL_MASTER) / 2)) / 200 + i) * BTH_PLUS_ADJ);
+        i = (player_ptr->skill_thb + ((player_ptr->weapon_exp[j_ptr->tval][j_ptr->sval] - (PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER) / 2)) / 200 + i) * BTH_PLUS_ADJ);
 
     auto sniper_data = PlayerClass(player_ptr).get_specific_data<sniper_data_type>();
     auto sniper_concent = sniper_data ? sniper_data->concent : 0;
@@ -1097,7 +1097,7 @@ HIT_POINT calc_crit_ratio_shot(player_type *player_ptr, HIT_POINT plus_ammo, HIT
     if (player_ptr->tval_ammo == ItemKindType::BOLT)
         i = (player_ptr->skill_thb + (player_ptr->weapon_exp[j_ptr->tval][j_ptr->sval] / 400 + i) * BTH_PLUS_ADJ);
     else
-        i = (player_ptr->skill_thb + ((player_ptr->weapon_exp[j_ptr->tval][j_ptr->sval] - (PlayerSkill::weapon_exp_at(EXP_LEVEL_MASTER) / 2)) / 200 + i) * BTH_PLUS_ADJ);
+        i = (player_ptr->skill_thb + ((player_ptr->weapon_exp[j_ptr->tval][j_ptr->sval] - (PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER) / 2)) / 200 + i) * BTH_PLUS_ADJ);
 
     auto sniper_data = PlayerClass(player_ptr).get_specific_data<sniper_data_type>();
     auto sniper_concent = sniper_data ? sniper_data->concent : 0;

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -260,10 +260,10 @@ static void generate_world(player_type *player_ptr, bool new_game)
     if (player_ptr->pclass != PlayerClassType::SORCERER) {
         auto pclass = enum2i(player_ptr->pclass);
         if (player_ptr->ppersonality == PERSONALITY_SEXY)
-            s_info[pclass].w_max[ItemKindType::HAFTED][SV_WHIP] = PlayerSkill::weapon_exp_at(EXP_LEVEL_MASTER);
+            s_info[pclass].w_max[ItemKindType::HAFTED][SV_WHIP] = PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER);
         if (player_ptr->prace == PlayerRaceType::MERFOLK) {
-            s_info[pclass].w_max[ItemKindType::POLEARM][SV_TRIDENT] = PlayerSkill::weapon_exp_at(EXP_LEVEL_MASTER);
-            s_info[pclass].w_max[ItemKindType::POLEARM][SV_TRIFURCATE_SPEAR] = PlayerSkill::weapon_exp_at(EXP_LEVEL_MASTER);
+            s_info[pclass].w_max[ItemKindType::POLEARM][SV_TRIDENT] = PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER);
+            s_info[pclass].w_max[ItemKindType::POLEARM][SV_TRIFURCATE_SPEAR] = PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER);
         }
     }
 

--- a/src/info-reader/skill-reader.cpp
+++ b/src/info-reader/skill-reader.cpp
@@ -45,8 +45,8 @@ errr parse_s_info(std::string_view buf, angband_header *head)
         info_set_value(max, tokens[4]);
 
         auto tval = ItemKindType::BOW + tval_offset;
-        s_ptr->w_start[tval][sval] = PlayerSkill::weapon_exp_at(start);
-        s_ptr->w_max[tval][sval] = PlayerSkill::weapon_exp_at(max);
+        s_ptr->w_start[tval][sval] = PlayerSkill::weapon_exp_at(i2enum<PlayerSkillRank>(start));
+        s_ptr->w_max[tval][sval] = PlayerSkill::weapon_exp_at(i2enum<PlayerSkillRank>(max));
     } else if (tokens[0] == "S") {
         if (tokens.size() < 4)
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;

--- a/src/knowledge/knowledge-experiences.cpp
+++ b/src/knowledge/knowledge-experiences.cpp
@@ -50,7 +50,8 @@ void do_cmd_knowledge_weapon_exp(player_type *player_ptr)
                     fprintf(fff, "!");
                 else
                     fprintf(fff, " ");
-                fprintf(fff, "%s", exp_level_str[PlayerSkill::weapon_exp_level(weapon_exp)]);
+                auto skill_rank = PlayerSkill::weapon_skill_rank(weapon_exp);
+                fprintf(fff, "%s", PlayerSkill::skill_rank_str(skill_rank));
                 if (cheat_xtra)
                     fprintf(fff, " %d", weapon_exp);
                 fprintf(fff, "\n");
@@ -88,7 +89,7 @@ void do_cmd_knowledge_spell_exp(player_type *player_ptr)
             if (s_ptr->slevel >= 99)
                 continue;
             SUB_EXP spell_exp = player_ptr->spell_exp[i];
-            auto exp_level = PlayerSkill::spell_exp_level(spell_exp);
+            auto skill_rank = PlayerSkill::spell_skill_rank(spell_exp);
             fprintf(fff, "%-25s ", exe_spell(player_ptr, player_ptr->realm1, i, SPELL_NAME));
             if (player_ptr->realm1 == REALM_HISSATSU) {
                 if (show_actual_value)
@@ -96,12 +97,12 @@ void do_cmd_knowledge_spell_exp(player_type *player_ptr)
                 fprintf(fff, "[--]");
             } else {
                 if (show_actual_value)
-                    fprintf(fff, "%4d/%4d ", spell_exp, PlayerSkill::spell_exp_at(EXP_LEVEL_MASTER));
-                if (exp_level >= EXP_LEVEL_MASTER)
+                    fprintf(fff, "%4d/%4d ", spell_exp, PlayerSkill::spell_exp_at(PlayerSkillRank::MASTER));
+                if (skill_rank >= PlayerSkillRank::MASTER)
                     fprintf(fff, "!");
                 else
                     fprintf(fff, " ");
-                fprintf(fff, "%s", exp_level_str[exp_level]);
+                fprintf(fff, "%s", PlayerSkill::skill_rank_str(skill_rank));
             }
 
             if (cheat_xtra)
@@ -124,15 +125,15 @@ void do_cmd_knowledge_spell_exp(player_type *player_ptr)
                 continue;
 
             SUB_EXP spell_exp = player_ptr->spell_exp[i + 32];
-            auto exp_level = PlayerSkill::spell_exp_level(spell_exp);
+            auto skill_rank = PlayerSkill::spell_skill_rank(spell_exp);
             fprintf(fff, "%-25s ", exe_spell(player_ptr, player_ptr->realm2, i, SPELL_NAME));
             if (show_actual_value)
-                fprintf(fff, "%4d/%4d ", spell_exp, PlayerSkill::spell_exp_at(EXP_LEVEL_MASTER));
-            if (exp_level >= EXP_LEVEL_EXPERT)
+                fprintf(fff, "%4d/%4d ", spell_exp, PlayerSkill::spell_exp_at(PlayerSkillRank::MASTER));
+            if (skill_rank >= PlayerSkillRank::EXPERT)
                 fprintf(fff, "!");
             else
                 fprintf(fff, " ");
-            fprintf(fff, "%s", exp_level_str[exp_level]);
+            fprintf(fff, "%s", PlayerSkill::skill_rank_str(skill_rank));
             if (cheat_xtra)
                 fprintf(fff, " %d", spell_exp);
             fprintf(fff, "\n");
@@ -165,7 +166,8 @@ void do_cmd_knowledge_skill_exp(player_type *player_ptr)
             fprintf(fff, "!");
         else
             fprintf(fff, " ");
-        fprintf(fff, "%s", exp_level_str[(i == PlayerSkillKindType::RIDING) ? PlayerSkill::riding_exp_level(skill_exp) : PlayerSkill::weapon_exp_level(skill_exp)]);
+        auto skill_rank = (i == PlayerSkillKindType::RIDING) ? PlayerSkill::riding_skill_rank(skill_exp) : PlayerSkill::weapon_skill_rank(skill_exp);
+        fprintf(fff, "%s", PlayerSkill::skill_rank_str(skill_rank));
         if (cheat_xtra)
             fprintf(fff, " %d", skill_exp);
         fprintf(fff, "\n");

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -101,7 +101,7 @@ void rd_experience(player_type *player_ptr)
 
     if ((player_ptr->pclass == PlayerClassType::SORCERER) && h_older_than(0, 4, 2))
         for (int i = 0; i < 64; i++)
-            player_ptr->spell_exp[i] = PlayerSkill::spell_exp_at(EXP_LEVEL_MASTER);
+            player_ptr->spell_exp[i] = PlayerSkill::spell_exp_at(PlayerSkillRank::MASTER);
 
     const int max_weapon_exp_size = h_older_than(0, 3, 6) ? 60 : 64;
     for (auto tval : TV_WEAPON_RANGE)

--- a/src/object-hook/hook-weapon.cpp
+++ b/src/object-hook/hook-weapon.cpp
@@ -50,13 +50,13 @@ bool object_is_favorite(player_type *player_ptr, const object_type *o_ptr)
     }
 
     case PlayerClassType::SORCERER:
-        if (s_info[short_pclass].w_max[o_ptr->tval][o_ptr->sval] < PlayerSkill::weapon_exp_at(EXP_LEVEL_MASTER))
+        if (s_info[short_pclass].w_max[o_ptr->tval][o_ptr->sval] < PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER))
             return false;
         break;
 
     case PlayerClassType::NINJA:
         /* Icky to wield? */
-        if (s_info[short_pclass].w_max[o_ptr->tval][o_ptr->sval] <= PlayerSkill::weapon_exp_at(EXP_LEVEL_BEGINNER))
+        if (s_info[short_pclass].w_max[o_ptr->tval][o_ptr->sval] <= PlayerSkill::weapon_exp_at(PlayerSkillRank::BEGINNER))
             return false;
         break;
 

--- a/src/player/player-skill.h
+++ b/src/player/player-skill.h
@@ -17,28 +17,27 @@ enum class PlayerSkillKindType {
     MAX,
 };
 
+enum class PlayerSkillRank {
+    UNSKILLED = 0,
+    BEGINNER = 1,
+    SKILLED = 2,
+    EXPERT = 3,
+    MASTER = 4,
+};
+
 constexpr auto PLAYER_SKILL_KIND_TYPE_RANGE = EnumRange(PlayerSkillKindType::MARTIAL_ARTS, PlayerSkillKindType::SHIELD);
-
-/* Proficiency level */
-#define EXP_LEVEL_UNSKILLED 0
-#define EXP_LEVEL_BEGINNER 1
-#define EXP_LEVEL_SKILLED 2
-#define EXP_LEVEL_EXPERT 3
-#define EXP_LEVEL_MASTER 4
-
-extern const concptr exp_level_str[5];
 
 enum class ItemKindType : short;
 
 /*
  * Information about "skill"
  */
-typedef struct skill_table {
+struct skill_table {
     std::map<ItemKindType, std::array<SUB_EXP, 64>> w_start{}; /* start weapon exp */
     std::map<ItemKindType, std::array<SUB_EXP, 64>> w_max{}; /* max weapon exp */
     std::map<PlayerSkillKindType, SUB_EXP> s_start{}; /* start skill */
     std::map<PlayerSkillKindType, SUB_EXP> s_max{}; /* max skill */
-} skill_table;
+};
 
 extern std::vector<skill_table> s_info;
 
@@ -50,13 +49,14 @@ class PlayerSkill {
 public:
     PlayerSkill(player_type *player_ptr);
 
-    static SUB_EXP weapon_exp_at(int level);
-    static SUB_EXP spell_exp_at(int level);
+    static SUB_EXP weapon_exp_at(PlayerSkillRank rank);
+    static SUB_EXP spell_exp_at(PlayerSkillRank rank);
     static bool valid_weapon_exp(int weapon_exp);
-    static int weapon_exp_level(int weapon_exp);
-    static int riding_exp_level(int riding_exp);
-    static int spell_exp_level(int spell_exp);
+    static PlayerSkillRank weapon_skill_rank(int weapon_exp);
+    static PlayerSkillRank riding_skill_rank(int riding_exp);
+    static PlayerSkillRank spell_skill_rank(int spell_exp);
     static concptr skill_name(PlayerSkillKindType skill);
+    static concptr skill_rank_str(PlayerSkillRank rank);
 
     void gain_melee_weapon_exp(const object_type *o_ptr);
     void gain_range_weapon_exp(const object_type *o_ptr);
@@ -67,7 +67,7 @@ public:
     void gain_riding_skill_exp_on_fall_off_check(HIT_POINT dam);
     void gain_spell_skill_exp(int realm, int spell_idx);
     void gain_continuous_spell_skill_exp(int realm, int spell_idx);
-    int gain_spell_skill_exp_over_learning(int spell_idx);
+    PlayerSkillRank gain_spell_skill_exp_over_learning(int spell_idx);
 
     EXP exp_of_spell(int realm, int spell_idx) const;
 

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -1638,7 +1638,7 @@ bool has_not_ninja_weapon(player_type *player_ptr, int i)
     auto tval = player_ptr->inventory_list[INVEN_MAIN_HAND + i].tval;
     auto sval = player_ptr->inventory_list[INVEN_MAIN_HAND + i].sval;
     return player_ptr->pclass == PlayerClassType::NINJA &&
-           !((s_info[enum2i(PlayerClassType::NINJA)].w_max[tval][sval] > PlayerSkill::weapon_exp_at(EXP_LEVEL_BEGINNER)) &&
+           !((s_info[enum2i(PlayerClassType::NINJA)].w_max[tval][sval] > PlayerSkill::weapon_exp_at(PlayerSkillRank::BEGINNER)) &&
                (player_ptr->inventory_list[INVEN_SUB_HAND - i].tval != ItemKindType::SHIELD));
 }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -2088,7 +2088,7 @@ static short calc_to_hit(player_type *player_ptr, INVENTORY_IDX slot, bool is_re
                 break;
             /* fall through */
         case MELEE_TYPE_BAREHAND_TWO:
-            hit += (player_ptr->skill_exp[PlayerSkillKindType::MARTIAL_ARTS] - PlayerSkill::weapon_exp_at(EXP_LEVEL_BEGINNER)) / 200;
+            hit += (player_ptr->skill_exp[PlayerSkillKindType::MARTIAL_ARTS] - PlayerSkill::weapon_exp_at(PlayerSkillRank::BEGINNER)) / 200;
             break;
 
         default:
@@ -2109,7 +2109,7 @@ static short calc_to_hit(player_type *player_ptr, INVENTORY_IDX slot, bool is_re
         auto flgs = object_flags(o_ptr);
 
         /* Traind bonuses */
-        hit += (player_ptr->weapon_exp[o_ptr->tval][o_ptr->sval] - PlayerSkill::weapon_exp_at(EXP_LEVEL_BEGINNER)) / 200;
+        hit += (player_ptr->weapon_exp[o_ptr->tval][o_ptr->sval] - PlayerSkill::weapon_exp_at(PlayerSkillRank::BEGINNER)) / 200;
 
         /* Weight penalty */
         if (calc_weapon_weight_limit(player_ptr) < o_ptr->weight / 10) {

--- a/src/spell/spell-info.cpp
+++ b/src/spell/spell-info.cpp
@@ -39,7 +39,7 @@ MANA_POINT mod_need_mana(player_type *player_ptr, MANA_POINT need_mana, SPELL_ID
 #define MANA_DIV 4
 #define DEC_MANA_DIV 3
     if ((realm > REALM_NONE) && (realm <= MAX_REALM)) {
-        need_mana = need_mana * (MANA_CONST + PlayerSkill::spell_exp_at(EXP_LEVEL_EXPERT) - PlayerSkill(player_ptr).exp_of_spell(realm, spell)) + (MANA_CONST - 1);
+        need_mana = need_mana * (MANA_CONST + PlayerSkill::spell_exp_at(PlayerSkillRank::EXPERT) - PlayerSkill(player_ptr).exp_of_spell(realm, spell)) + (MANA_CONST - 1);
         need_mana *= player_ptr->dec_mana ? DEC_MANA_DIV : MANA_DIV;
         need_mana /= MANA_CONST * MANA_DIV;
         if (need_mana < 1)
@@ -182,9 +182,9 @@ PERCENTAGE spell_chance(player_type *player_ptr, SPELL_IDX spell, int16_t use_re
     if ((use_realm == player_ptr->realm1) || (use_realm == player_ptr->realm2) || (player_ptr->pclass == PlayerClassType::SORCERER)
         || (player_ptr->pclass == PlayerClassType::RED_MAGE)) {
         auto exp = PlayerSkill(player_ptr).exp_of_spell(use_realm, spell);
-        if (exp >= PlayerSkill::spell_exp_at(EXP_LEVEL_EXPERT))
+        if (exp >= PlayerSkill::spell_exp_at(PlayerSkillRank::EXPERT))
             chance--;
-        if (exp >= PlayerSkill::spell_exp_at(EXP_LEVEL_MASTER))
+        if (exp >= PlayerSkill::spell_exp_at(PlayerSkillRank::MASTER))
             chance--;
     }
 
@@ -226,7 +226,6 @@ void print_spells(player_type *player_ptr, SPELL_IDX target_spell, SPELL_IDX *sp
         increment = 32;
 
     int i;
-    int exp_level;
     const magic_type *s_ptr;
     char info[80];
     char out_val[160];
@@ -247,22 +246,23 @@ void print_spells(player_type *player_ptr, SPELL_IDX target_spell, SPELL_IDX *sp
         else {
             auto exp = PlayerSkill(player_ptr).exp_of_spell(use_realm, spell);
             need_mana = mod_need_mana(player_ptr, s_ptr->smana, spell, use_realm);
+            PlayerSkillRank skill_rank;
             if ((increment == 64) || (s_ptr->slevel >= 99))
-                exp_level = EXP_LEVEL_UNSKILLED;
+                skill_rank = PlayerSkillRank::UNSKILLED;
             else
-                exp_level = PlayerSkill::spell_exp_level(exp);
+                skill_rank = PlayerSkill::spell_skill_rank(exp);
 
             max = false;
-            if (!increment && (exp_level == EXP_LEVEL_MASTER))
+            if (!increment && (skill_rank == PlayerSkillRank::MASTER))
                 max = true;
-            else if ((increment == 32) && (exp_level >= EXP_LEVEL_EXPERT))
+            else if ((increment == 32) && (skill_rank >= PlayerSkillRank::EXPERT))
                 max = true;
             else if (s_ptr->slevel >= 99)
                 max = true;
-            else if ((player_ptr->pclass == PlayerClassType::RED_MAGE) && (exp_level >= EXP_LEVEL_SKILLED))
+            else if ((player_ptr->pclass == PlayerClassType::RED_MAGE) && (skill_rank >= PlayerSkillRank::SKILLED))
                 max = true;
 
-            strncpy(ryakuji, exp_level_str[exp_level], 4);
+            strncpy(ryakuji, PlayerSkill::skill_rank_str(skill_rank), 4);
             ryakuji[3] = ']';
             ryakuji[4] = '\0';
         }

--- a/src/view/display-player-middle.cpp
+++ b/src/view/display-player-middle.cpp
@@ -101,7 +101,7 @@ static void display_hit_damage(player_type *player_ptr)
     if ((o_ptr->sval == SV_LIGHT_XBOW) || (o_ptr->sval == SV_HEAVY_XBOW))
         show_tohit += player_ptr->weapon_exp[o_ptr->tval][o_ptr->sval] / 400;
     else
-        show_tohit += (player_ptr->weapon_exp[o_ptr->tval][o_ptr->sval] - (PlayerSkill::weapon_exp_at(EXP_LEVEL_MASTER) / 2)) / 200;
+        show_tohit += (player_ptr->weapon_exp[o_ptr->tval][o_ptr->sval] - (PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER) / 2)) / 200;
 
     show_tohit += player_ptr->skill_thb / BTH_PLUS_ADJ;
 

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -410,13 +410,13 @@ void wiz_change_status(player_type *player_ptr)
         player_ptr->stat_cur[i] = player_ptr->stat_max[i] = (BASE_STATUS)tmp_int;
     }
 
-    sprintf(tmp_val, "%d", PlayerSkill::weapon_exp_at(EXP_LEVEL_MASTER));
+    sprintf(tmp_val, "%d", PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER));
     if (!get_string(_("熟練度: ", "Proficiency: "), tmp_val, 4))
         return;
 
     auto tmp_s16b = std::clamp(static_cast<SUB_EXP>(atoi(tmp_val)),
-        PlayerSkill::weapon_exp_at(EXP_LEVEL_UNSKILLED),
-        PlayerSkill::weapon_exp_at(EXP_LEVEL_MASTER));
+        PlayerSkill::weapon_exp_at(PlayerSkillRank::UNSKILLED),
+        PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER));
 
     for (auto tval : TV_WEAPON_RANGE) {
         for (int i = 0; i < 64; i++) {
@@ -433,10 +433,10 @@ void wiz_change_status(player_type *player_ptr)
 
     int k;
     for (k = 0; k < 32; k++)
-        player_ptr->spell_exp[k] = std::min(PlayerSkill::spell_exp_at(EXP_LEVEL_MASTER), tmp_s16b);
+        player_ptr->spell_exp[k] = std::min(PlayerSkill::spell_exp_at(PlayerSkillRank::MASTER), tmp_s16b);
 
     for (; k < 64; k++)
-        player_ptr->spell_exp[k] = std::min(PlayerSkill::spell_exp_at(EXP_LEVEL_EXPERT), tmp_s16b);
+        player_ptr->spell_exp[k] = std::min(PlayerSkill::spell_exp_at(PlayerSkillRank::EXPERT), tmp_s16b);
 
     sprintf(tmp_val, "%ld", (long)(player_ptr->au));
     if (!get_string("Gold: ", tmp_val, 9))


### PR DESCRIPTION
リファクタリングの一環として既存の熟練度レベルを表す定数 EXP_LEVEL_* を
enum class にする。型名は PlayerSkillRank とし、関連する関数名も合わせて
変更する。
またこれに伴い、熟練度レベルを表す文字列をもつグローバルな配列変数を削除し、
PlayerSkill クラスの静的メンバ関数 skill_rank_name() を使用して取得する
ようにする。

#1833 を前提としているので draft PR にしています。