### PR TITLE
[Fix] カメレオンを倒した時に変身先のモンスターを倒した扱いになってしまう

### DIFF
--- a/src/avatar/avatar-changer.cpp
+++ b/src/avatar/avatar-changer.cpp
@@ -13,6 +13,7 @@
 #include "monster-race/race-flags2.h"
 #include "monster-race/race-flags3.h"
 #include "monster-race/race-indice-types.h"
+#include "monster/monster-info.h"
 #include "system/floor-type-definition.h"
 #include "system/monster-race-definition.h"
 #include "system/monster-type-definition.h"
@@ -35,7 +36,7 @@ void AvatarChanger::change_virtue()
 {
     this->change_virtue_non_beginner();
     this->change_virtue_unique();
-    auto *r_ptr = &r_info[m_ptr->r_idx];
+    auto *r_ptr = real_r_ptr(this->m_ptr);
     if (m_ptr->r_idx == MON_BEGGAR || m_ptr->r_idx == MON_LEPER) {
         chg_virtue(this->player_ptr, V_COMPASSION, -1);
     }

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -116,7 +116,7 @@ bool MonsterDamageProcessor::genocide_chaos_patron()
 bool MonsterDamageProcessor::process_dead_exp_virtue(concptr note, monster_type *exp_mon)
 {
     auto *m_ptr = &this->player_ptr->current_floor_ptr->m_list[this->m_idx];
-    auto *r_ptr = &r_info[m_ptr->r_idx];
+    auto *r_ptr = real_r_ptr(m_ptr);
     if (m_ptr->hp >= 0) {
         return false;
     }
@@ -168,6 +168,7 @@ void MonsterDamageProcessor::death_special_flag_monster()
 
     if (m_ptr->mflag2.has(MFLAG2::CHAMELEON)) {
         r_ptr = real_r_ptr(m_ptr);
+        r_idx = real_r_idx(m_ptr);
         if (r_ptr->r_sights < MAX_SHORT) {
             r_ptr->r_sights++;
         }
@@ -278,7 +279,7 @@ void MonsterDamageProcessor::death_combined_uniques(const monster_race_type r_id
 void MonsterDamageProcessor::increase_kill_numbers()
 {
     auto *m_ptr = &this->player_ptr->current_floor_ptr->m_list[this->m_idx];
-    auto *r_ptr = &r_info[m_ptr->r_idx];
+    auto *r_ptr = real_r_ptr(m_ptr);
     if (((m_ptr->ml == 0) || this->player_ptr->hallucinated) && none_bits(r_ptr->flags1, RF1_UNIQUE)) {
         return;
     }
@@ -301,7 +302,7 @@ void MonsterDamageProcessor::increase_kill_numbers()
 void MonsterDamageProcessor::death_amberites(GAME_TEXT *m_name)
 {
     auto *m_ptr = &this->player_ptr->current_floor_ptr->m_list[this->m_idx];
-    auto *r_ptr = &r_info[m_ptr->r_idx];
+    auto *r_ptr = real_r_ptr(m_ptr);
     if (none_bits(r_ptr->flags3, RF3_AMBERITE) || one_in_(2)) {
         return;
     }
@@ -319,7 +320,7 @@ void MonsterDamageProcessor::death_amberites(GAME_TEXT *m_name)
 void MonsterDamageProcessor::dying_scream(GAME_TEXT *m_name)
 {
     auto *m_ptr = &this->player_ptr->current_floor_ptr->m_list[this->m_idx];
-    auto *r_ptr = &r_info[m_ptr->r_idx];
+    auto *r_ptr = real_r_ptr(m_ptr);
     if (none_bits(r_ptr->flags2, RF2_CAN_SPEAK)) {
         return;
     }
@@ -340,7 +341,7 @@ void MonsterDamageProcessor::show_kill_message(concptr note, GAME_TEXT *m_name)
 {
     auto *floor_ptr = this->player_ptr->current_floor_ptr;
     auto *m_ptr = &floor_ptr->m_list[this->m_idx];
-    auto *r_ptr = &r_info[m_ptr->r_idx];
+    auto *r_ptr = real_r_ptr(m_ptr);
     if (note != nullptr) {
         msg_format("%^s%s", m_name, note);
         return;
@@ -381,7 +382,7 @@ void MonsterDamageProcessor::show_bounty_message(GAME_TEXT *m_name)
 {
     auto *floor_ptr = this->player_ptr->current_floor_ptr;
     auto *m_ptr = &floor_ptr->m_list[this->m_idx];
-    auto *r_ptr = &r_info[m_ptr->r_idx];
+    auto *r_ptr = real_r_ptr(m_ptr);
     if (none_bits(r_ptr->flags1, RF1_UNIQUE) || m_ptr->mflag2.has(MFLAG2::CLONED) || vanilla_town) {
         return;
     }


### PR DESCRIPTION
リファクタリングによるエンバグが原因。
リファクタリング以前のコードでは倒したモンスターがカメレオンもしくはカメレオンの王だった
場合、r_ptr を real_r_ptr の戻り値で書き換えてから死亡後の一連の処理を行っていたが、
リファクタリングにより複数の関数に分割した時に r_ptr をそれぞれの関数で取得しなおす
ようにしており、その時に real_r_ptr を使用していないためカメレオンであることが考慮
されていない。
モンスター死亡時の一連の処理では real_r_ptr により r_ptr を取得するようにして、
リファクタリングによるエンバグ前の動作と同等になるように修正する。