### PR TITLE
[Refactor] 変身中の切り傷無効処理の可読性向上

### DIFF
--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -221,7 +221,7 @@ TrFlags PlayerClass::form_tr_flags() const
     return flags;
 }
 
-bool PlayerClass::can_resist_stun() const
+bool PlayerClass::has_stun_immunity() const
 {
     return (this->player_ptr->pclass == PlayerClassType::BERSERKER) && (this->player_ptr->lev > 34);
 }

--- a/src/player-base/player-class.h
+++ b/src/player-base/player-class.h
@@ -20,7 +20,7 @@ public:
     TrFlags tr_flags() const;
     TrFlags form_tr_flags() const;
 
-    bool can_resist_stun() const;
+    bool has_stun_immunity() const;
     bool is_wizard() const;
 
     bool lose_balance();

--- a/src/player-base/player-race.cpp
+++ b/src/player-base/player-race.cpp
@@ -102,13 +102,19 @@ bool PlayerRace::is_mimic_nonliving() const
     return any_bits(mimic_info[this->player_ptr->mimic_form].choice, nonliving_flag);
 }
 
-bool PlayerRace::can_resist_cut() const
+bool PlayerRace::has_cut_immunity() const
 {
-    auto can_resist_cut = this->player_ptr->prace == PlayerRaceType::GOLEM;
-    can_resist_cut |= this->player_ptr->prace == PlayerRaceType::SKELETON;
-    can_resist_cut |= this->player_ptr->prace == PlayerRaceType::SPECTRE;
-    can_resist_cut |= (this->player_ptr->prace == PlayerRaceType::ZOMBIE) && (this->player_ptr->lev > 11);
-    return can_resist_cut;
+    auto cut_immunity = PlayerRace(this->player_ptr).equals(PlayerRaceType::GOLEM);
+    cut_immunity |= PlayerRace(this->player_ptr).equals(PlayerRaceType::SKELETON);
+    cut_immunity |= PlayerRace(this->player_ptr).equals(PlayerRaceType::SPECTRE);
+    cut_immunity |= PlayerRace(this->player_ptr).equals(PlayerRaceType::ZOMBIE) && (this->player_ptr->lev > 11);
+    return cut_immunity;
+}
+
+
+bool PlayerRace::has_stun_immunity() const
+{
+    return PlayerRace(this->player_ptr).equals(PlayerRaceType::GOLEM);
 }
 
 bool PlayerRace::equals(PlayerRaceType prace) const

--- a/src/player-base/player-race.h
+++ b/src/player-base/player-race.h
@@ -18,7 +18,8 @@ public:
     PlayerRaceFood food() const;
 
     bool is_mimic_nonliving() const;
-    bool can_resist_cut() const;
+    bool has_cut_immunity() const;
+    bool has_stun_immunity() const;
     bool equals(PlayerRaceType prace) const;
 
     int16_t speed() const;

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -434,7 +434,7 @@ bool BadStatusSetter::stun(const TIME_EFFECT tmp_v)
         return false;
     }
 
-    if (PlayerRace(this->player_ptr).equals(PlayerRaceType::GOLEM) || PlayerClass(this->player_ptr).can_resist_stun()) {
+    if (PlayerRace(this->player_ptr).has_stun_immunity() || PlayerClass(this->player_ptr).has_stun_immunity()) {
         v = 0;
     }
 
@@ -473,7 +473,7 @@ bool BadStatusSetter::cut(const TIME_EFFECT tmp_v)
         return false;
     }
 
-    if (PlayerRace(this->player_ptr).can_resist_cut() && !this->player_ptr->mimic_form) {
+    if (PlayerRace(this->player_ptr).has_cut_immunity()) {
         v = 0;
     }
 


### PR DESCRIPTION
PlayerRaceの内外に処理が散っていたのでPlayerRace内に処理を集約した。
また、関数名を実態に即したものに変更した。
ついでに類似のネーミングであったPlayerClass.can_resist_stun()もhas_stun_immunity()に変更。
いずれも動作変更は行わない。