### PR TITLE
[Feature] 継続自傷ダメージ装備の導入

### DIFF
--- a/lib/edit/a_info.txt
+++ b/lib/edit/a_info.txt
@@ -3698,13 +3698,12 @@ D:モリアの入口に向かって突進していった。」
 
 N:212:バルログの長ゴスモグの
 E:of Gothmog
-I:21:2:-2
-W:60:35:90:66666
-P:0:3d6:13:15:0
-F:INT | WIS | DEX | STEALTH | HIDE_TYPE | SLAY_HUMAN |
+I:21:2:3
+W:80:100:300:66666
+P:0:6d12:15:25:0
+F:STR | DEX | CON | HIDE_TYPE | 
 F:HEAVY_CURSE | CURSED | AGGRAVATE | 
-F:BRAND_FIRE | IM_FIRE | RES_ELEC | RES_DARK | LITE
-F:SLAY_ANIMAL | SLAY_ORC | SLAY_TROLL | SLAY_GIANT | 
+F:BRAND_FIRE | RES_FIRE | RES_ELEC | SH_FIRE | SELF_FIRE | RES_DARK | LITE_3 | 
 F:ACTIVATE | SHOW_MODS
 U:BA_FIRE_2
 D:$With this unbearably bright whip of flame, the Balrog Gothmog has become

--- a/src/flavor/flag-inscriptions-table.cpp
+++ b/src/flavor/flag-inscriptions-table.cpp
@@ -60,6 +60,7 @@ std::vector<flag_insc_table> flag_insc_misc = {
     { N("闇", "Dl"), TR_LITE_M2, -1 }, { N("闇", "Dl"), TR_LITE_M3, -1 }, { N("警", "Wr"), TR_WARNING, -1 }, { N("倍", "Xm"), TR_XTRA_MIGHT, -1 },
     { N("射", "Xs"), TR_XTRA_SHOTS, -1 }, { N("瞬", "Te"), TR_TELEPORT, -1 }, { N("怒", "Ag"), TR_AGGRAVATE, -1 }, { N("祝", "Bs"), TR_BLESSED, -1 },
     { N("忌", "Ty"), TR_TY_CURSE, -1 }, { N("呪", "C-"), TR_ADD_L_CURSE, -1 }, { N("詛", "C+"), TR_ADD_H_CURSE, -1 },
+    { N("焼", "F"), TR_SELF_FIRE, -1 }, { N("凍", "Co"), TR_SELF_COLD, -1 }, { N("電", "E"), TR_SELF_ELEC, -1 },
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(オーラ) */

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -118,7 +118,7 @@ void process_player_hp_mp(player_type *player_ptr)
             sound(SOUND_DAMAGE_OVER_TIME);
         }
     }
-    
+
     auto player_cut = player_ptr->effects()->cut();
     if (player_cut->is_cut() && !is_invuln(player_ptr)) {
         auto dam = player_cut->get_damage();
@@ -208,6 +208,51 @@ void process_player_hp_mp(player_type *player_ptr)
         }
     }
 
+    if (get_player_flags(player_ptr, TR_SELF_FIRE) && !has_immune_fire(player_ptr)) {
+        HIT_POINT damage;
+        damage = player_ptr->lev;
+        if (race.tr_flags().has(TR_VUL_FIRE))
+            damage += damage / 3;
+        if (has_resist_fire(player_ptr))
+            damage = damage / 3;
+        if (is_oppose_fire(player_ptr))
+            damage = damage / 3;
+
+        damage = std::max(damage, 1);
+        msg_print(_("熱い！", "It's hot!"));
+        take_hit(player_ptr, DAMAGE_NOESCAPE, damage, _("炎のオーラ", "Fire aura"));
+    }
+
+    if (get_player_flags(player_ptr, TR_SELF_ELEC) && !has_immune_elec(player_ptr)) {
+        HIT_POINT damage;
+        damage = player_ptr->lev;
+        if (race.tr_flags().has(TR_VUL_ELEC))
+            damage += damage / 3;
+        if (has_resist_elec(player_ptr))
+            damage = damage / 3;
+        if (is_oppose_elec(player_ptr))
+            damage = damage / 3;
+
+        damage = std::max(damage, 1);
+        msg_print(_("痛い！", "It hurts!"));
+        take_hit(player_ptr, DAMAGE_NOESCAPE, damage, _("電気のオーラ", "Elec aura"));
+    }
+
+    if (get_player_flags(player_ptr, TR_SELF_COLD) && !has_immune_cold(player_ptr)) {
+        HIT_POINT damage;
+        damage = player_ptr->lev;
+        if (race.tr_flags().has(TR_VUL_COLD))
+            damage += damage / 3;
+        if (has_resist_cold(player_ptr))
+            damage = damage / 3;
+        if (is_oppose_cold(player_ptr))
+            damage = damage / 3;
+
+        damage = std::max(damage, 1);
+        msg_print(_("冷たい！", "It's cold!"));
+        take_hit(player_ptr, DAMAGE_NOESCAPE, damage, _("冷気のオーラ", "Cold aura"));
+    }
+
     if (player_ptr->riding) {
         HIT_POINT damage;
         auto auras = r_info[player_ptr->current_floor_ptr->m_list[player_ptr->riding].r_idx].aura_flags;
@@ -219,6 +264,8 @@ void process_player_hp_mp(player_type *player_ptr)
                 damage = damage / 3;
             if (is_oppose_fire(player_ptr))
                 damage = damage / 3;
+
+            damage = std::max(damage, 1);
             msg_print(_("熱い！", "It's hot!"));
             take_hit(player_ptr, DAMAGE_NOESCAPE, damage, _("炎のオーラ", "Fire aura"));
         }
@@ -231,6 +278,8 @@ void process_player_hp_mp(player_type *player_ptr)
                 damage = damage / 3;
             if (is_oppose_elec(player_ptr))
                 damage = damage / 3;
+
+            damage = std::max(damage, 1);
             msg_print(_("痛い！", "It hurts!"));
             take_hit(player_ptr, DAMAGE_NOESCAPE, damage, _("電気のオーラ", "Elec aura"));
         }
@@ -243,6 +292,8 @@ void process_player_hp_mp(player_type *player_ptr)
                 damage = damage / 3;
             if (is_oppose_cold(player_ptr))
                 damage = damage / 3;
+
+            damage = std::max(damage, 1);
             msg_print(_("冷たい！", "It's cold!"));
             take_hit(player_ptr, DAMAGE_NOESCAPE, damage, _("冷気のオーラ", "Cold aura"));
         }
@@ -256,8 +307,7 @@ void process_player_hp_mp(player_type *player_ptr)
      * WILL BE!
      */
     if (f_ptr->flags.has_none_of({ FF::MOVE, FF::CAN_FLY })) {
-        if (!is_invuln(player_ptr) && !player_ptr->wraith_form && !player_ptr->tim_pass_wall
-            && ((player_ptr->chp > (player_ptr->lev / 5)) || !has_pass_wall(player_ptr))) {
+        if (!is_invuln(player_ptr) && !player_ptr->wraith_form && !player_ptr->tim_pass_wall && ((player_ptr->chp > (player_ptr->lev / 5)) || !has_pass_wall(player_ptr))) {
             concptr dam_desc;
             cave_no_regen = true;
 

--- a/src/info-reader/kind-info-tokens-table.cpp
+++ b/src/info-reader/kind-info-tokens-table.cpp
@@ -170,6 +170,9 @@ const std::unordered_map<std::string_view, tr_type> k_info_flags = {
     { "VUL_FIRE", TR_VUL_FIRE },
     { "VUL_LITE", TR_VUL_LITE },
     { "IM_DARK", TR_IM_DARK },
+    { "SELF_FIRE", TR_SELF_FIRE },
+    { "SELF_COLD", TR_SELF_COLD },
+    { "SELF_ELEC", TR_SELF_ELEC },
 };
 
 /*!

--- a/src/object-enchant/smith-tables.cpp
+++ b/src/object-enchant/smith-tables.cpp
@@ -348,6 +348,10 @@ const std::vector<essence_drain_type> Smith::essence_drain_info_table = {
     { TR_VUL_FIRE, {}, -1 },
     { TR_VUL_LITE, {}, -1 },
     { TR_IM_DARK, {}, 0 },
+
+    { TR_SELF_FIRE, { SmithEssence::BRAND_FIRE, SmithEssence::RES_FIRE }, 10 },
+    { TR_SELF_ELEC, { SmithEssence::BRAND_ELEC, SmithEssence::RES_ELEC }, 10 },
+    { TR_SELF_COLD, { SmithEssence::BRAND_COLD, SmithEssence::RES_COLD }, 10 },
 };
 
 namespace {

--- a/src/object-enchant/tr-types.h
+++ b/src/object-enchant/tr-types.h
@@ -171,7 +171,11 @@ enum tr_type : int32_t {
     TR_VUL_LITE = 156, //!< 閃光弱点
     TR_IM_DARK = 157, //!< 暗黒免疫
 
-    TR_FLAG_MAX = 158,
+    TR_SELF_FIRE = 158, //!< マイナスフラグ - 持続火炎ダメージ
+    TR_SELF_ELEC = 159, //!< マイナスフラグ - 持続電撃ダメージ
+    TR_SELF_COLD = 160, //!< マイナスフラグ - 持続冷気ダメージ
+
+    TR_FLAG_MAX = 161,
 };
 
 /** 能力値(STR,INT,WIS,DEX,CON,CHR)のpvalを増減させるフラグのリスト */

--- a/src/perception/identification.cpp
+++ b/src/perception/identification.cpp
@@ -572,6 +572,18 @@ bool screen_object(player_type *player_ptr, object_type *o_ptr, BIT_FLAGS mode)
         info[i++] = _("それは冷気のバリアを張る。", "It produces a sheath of coldness.");
     }
 
+    if (flgs.has(TR_SELF_FIRE)) {
+        info[i++] = _("それはあなたを燃やす。", "It burns you.");
+    }
+
+    if (flgs.has(TR_SELF_ELEC)) {
+        info[i++] = _("それはあなたを電撃で包む。", "It electrocutes you.");
+    }
+
+    if (flgs.has(TR_SELF_COLD)) {
+        info[i++] = _("それはあなたを凍らせる。", "It freezes you.");
+    }
+
     if (flgs.has(TR_NO_MAGIC)) {
         info[i++] = _("それは反魔法バリアを張る。", "It produces an anti-magic shell.");
     }

--- a/src/player-info/body-improvement-info.cpp
+++ b/src/player-info/body-improvement-info.cpp
@@ -75,11 +75,20 @@ void set_body_improvement_info_3(player_type *player_ptr, self_info_type *self_p
     if (has_sh_fire(player_ptr))
         self_ptr->info[self_ptr->line++] = _("あなたは炎のオーラに包まれている。", "You are surrounded with a fiery aura.");
 
+    if (get_player_flags(player_ptr, TR_SELF_FIRE))
+        self_ptr->info[self_ptr->line++] = _("あなたは身を焼く炎に包まれている。", "You are beging damaged with fire.");
+
     if (has_sh_elec(player_ptr))
-        self_ptr->info[self_ptr->line++] = _("あなたは電気に包まれている。", "You are surrounded with electricity.");
+        self_ptr->info[self_ptr->line++] = _("あなたは電気のオーラに包まれている。", "You are surrounded with an electricity aura.");
+
+    if (get_player_flags(player_ptr, TR_SELF_ELEC))
+        self_ptr->info[self_ptr->line++] = _("あなたは身を焦がす電撃に包まれている。", "You are beging damaged with electricity.");
 
     if (has_sh_cold(player_ptr))
         self_ptr->info[self_ptr->line++] = _("あなたは冷気のオーラに包まれている。", "You are surrounded with an aura of coldness.");
+
+    if (get_player_flags(player_ptr, TR_SELF_COLD))
+        self_ptr->info[self_ptr->line++] = _("あなたは身も凍る冷気に包まれている。", "You are beging damaged with coldness.");
 
     if (player_ptr->tim_sh_holy)
         self_ptr->info[self_ptr->line++] = _("あなたは聖なるオーラに包まれている。", "You are surrounded with a holy aura.");

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -450,6 +450,10 @@ BIT_FLAGS get_player_flags(player_type *player_ptr, tr_type tr_flag)
         return has_vuln_lite(player_ptr);
     case TR_IM_DARK:
         return has_immune_dark(player_ptr);
+    case TR_SELF_FIRE:
+    case TR_SELF_COLD:
+    case TR_SELF_ELEC:
+        return check_equipment_flags(player_ptr, tr_flag);
 
     case TR_FLAG_MAX:
         break;

--- a/src/view/display-characteristic.cpp
+++ b/src/view/display-characteristic.cpp
@@ -558,6 +558,10 @@ static void display_stustain_aura_info(
     process_one_characteristic(player_ptr, row++, col, _("電気オーラ:", "Aura Elec :"), TR_SH_ELEC, f, 0);
     process_one_characteristic(player_ptr, row++, col, _("冷気オーラ:", "Aura Cold :"), TR_SH_COLD, f, 0);
     process_one_characteristic(player_ptr, row++, col, _("射撃無効  :", "Invl Arrow:"), TR_INVULN_ARROW, f, 0);
+    row++;
+    process_one_characteristic(player_ptr, row++, col, _("自傷火炎  :", "Self Fire :"), TR_SELF_FIRE, f, 0);
+    process_one_characteristic(player_ptr, row++, col, _("自傷電気  :", "Self Elec :"), TR_SELF_ELEC, f, 0);
+    process_one_characteristic(player_ptr, row++, col, _("自傷冷気  :", "Self Cold :"), TR_SELF_COLD, f, 0);
 }
 
 /*!


### PR DESCRIPTION
新パターンのデメリット装備として装備中ダメージを受け続けるものを導入する。
10ゲームターン毎にレベルと同値のダメージを受けるという重いデメリットを課す。
二重耐性+急回復で相殺でき、免疫があればデメリットを踏み倒すことが可能。
常用不可、短期決戦用の強力な装備を選択肢として提示することを期待する。
試験枠として★バルログの長ゴスモグのムチを強化してみた。要調整。