### PR TITLE
[Feature] ★『レイトウメカジキ』の追加

### DIFF
--- a/lib/edit/a_info.txt
+++ b/lib/edit/a_info.txt
@@ -4493,3 +4493,12 @@ D:$ blends easily into any shadows and never finds his or her movements
 D:$ hindered.
 D:遥か東の国の盗賊が身につける仕事着だ。
 D:その漆黒の装いは闇に溶け込み、いかなる体の動きをも邪魔しない。
+
+N:269:『レイトウメカジキ』
+E:Frozen Swordfish
+I:23:24:2
+W:30:5:200:48000
+P:0:3d11:10:10:0
+F:STR | CHR | HIDE_TYPE | BRAND_COLD | RES_COLD | SHOW_MODS |
+D:$A frozen Swordfish wielded as a great sword. Proof of the owner's angling mastery.
+D:メカジキを凍らせたもの。最強釣り師の証でもある。分類は大剣。

--- a/src/artifact/fixed-art-types.h
+++ b/src/artifact/fixed-art-types.h
@@ -43,5 +43,6 @@ enum fixed_artifact_type {
     ART_MILIM = 246,
     ART_ROBINTON = 251,
     ART_ICINGDEATH = 259,
-    ART_TWINKLE = 260
+    ART_TWINKLE = 260,
+    ART_FROZEN_SWORDFISH = 269
 };

--- a/src/effect/effect-monster.cpp
+++ b/src/effect/effect-monster.cpp
@@ -161,7 +161,7 @@ static void effect_damage_killed_pet(player_type *player_ptr, effect_monster_typ
     if (em_ptr->who > 0)
         monster_gain_exp(player_ptr, em_ptr->who, em_ptr->m_ptr->r_idx);
 
-    monster_death(player_ptr, em_ptr->g_ptr->m_idx, false);
+    monster_death(player_ptr, em_ptr->g_ptr->m_idx, false, em_ptr->effect_type);
     delete_monster_idx(player_ptr, em_ptr->g_ptr->m_idx);
     if (sad)
         msg_print(_("少し悲しい気分がした。", "You feel sad for a moment."));

--- a/src/melee/melee-postprocess.cpp
+++ b/src/melee/melee-postprocess.cpp
@@ -37,6 +37,7 @@
 #include "player-info/class-info.h"
 #include "player-info/race-types.h"
 #include "player/player-personality-types.h"
+#include "spell/spell-types.h"
 #include "system/floor-type-definition.h"
 #include "system/monster-race-definition.h"
 #include "system/monster-type-definition.h"
@@ -182,7 +183,7 @@ static bool check_monster_hp(player_type *player_ptr, mam_pp_type *mam_pp_ptr)
     *(mam_pp_ptr->dead) = true;
     print_monster_dead_by_monster(player_ptr, mam_pp_ptr);
     monster_gain_exp(player_ptr, mam_pp_ptr->who, mam_pp_ptr->m_ptr->r_idx);
-    monster_death(player_ptr, mam_pp_ptr->m_idx, false);
+    monster_death(player_ptr, mam_pp_ptr->m_idx, false, GF_NONE);
     delete_monster_idx(player_ptr, mam_pp_ptr->m_idx);
     *(mam_pp_ptr->fear) = false;
     return true;

--- a/src/monster-floor/monster-death.h
+++ b/src/monster-floor/monster-death.h
@@ -1,7 +1,9 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include "monster-floor/monster-death-util.h"
 
 struct player_type;
-void monster_death(player_type *player_ptr, MONSTER_IDX m_idx, bool drop_item);
+void monster_death(player_type *player_ptr, MONSTER_IDX m_idx, bool drop_item, EFFECT_ID effect_type);
+bool drop_single_artifact(player_type *player_ptr, monster_death_type *md_ptr, ARTIFACT_IDX a_idx);
 concptr extract_note_dies(MONRACE_IDX r_idx);

--- a/src/monster-floor/quantum-effect.cpp
+++ b/src/monster-floor/quantum-effect.cpp
@@ -11,6 +11,7 @@
 #include "monster/smart-learn-types.h"
 #include "mspell/assign-monster-spell.h"
 #include "mspell/mspell.h"
+#include "spell/spell-types.h"
 #include "spell-kind/spells-teleport.h"
 #include "system/floor-type-definition.h"
 #include "system/monster-race-definition.h"
@@ -33,7 +34,7 @@ static void vanish_nonunique(player_type *player_ptr, MONSTER_IDX m_idx, bool se
         msg_format(_("%sは消え去った！", "%^s disappears!"), m_name);
     }
 
-    monster_death(player_ptr, m_idx, false);
+    monster_death(player_ptr, m_idx, false, GF_NONE);
     delete_monster_idx(player_ptr, m_idx);
     if (is_pet(m_ptr) && !(m_ptr->ml))
         msg_print(_("少しの間悲しい気分になった。", "You feel sad for a moment."));

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -18,6 +18,7 @@
 #include "grid/grid.h"
 #include "main/sound-definitions-table.h"
 #include "main/sound-of-music.h"
+#include "monster-floor/monster-death.h"
 #include "monster-floor/monster-death-util.h"
 #include "monster-floor/monster-summon.h"
 #include "monster-floor/place-monster-types.h"
@@ -532,7 +533,15 @@ static void on_dead_mimics(player_type *player_ptr, monster_death_type *md_ptr)
     }
 }
 
-void switch_special_death(player_type *player_ptr, monster_death_type *md_ptr)
+static void on_dead_swordfish(player_type *player_ptr, monster_death_type *md_ptr, EFFECT_ID effect_type)
+{
+    if ((effect_type != GF_COLD) || (randint1(100) >= 10))
+        return;
+
+    drop_single_artifact(player_ptr, md_ptr, ART_FROZEN_SWORDFISH);
+}
+
+void switch_special_death(player_type *player_ptr, monster_death_type *md_ptr, EFFECT_ID effect_type)
 {
     switch (md_ptr->m_ptr->r_idx) {
     case MON_PINK_HORROR:
@@ -611,6 +620,9 @@ void switch_special_death(player_type *player_ptr, monster_death_type *md_ptr)
     case MON_CHEST_MIMIC_04:
     case MON_CHEST_MIMIC_11:
         on_dead_chest_mimic(player_ptr, md_ptr);
+        break;
+    case MON_SWORDFISH:
+        on_dead_swordfish(player_ptr, md_ptr, effect_type);
         break;
     default:
         on_dead_mimics(player_ptr, md_ptr);

--- a/src/monster-floor/special-death-switcher.h
+++ b/src/monster-floor/special-death-switcher.h
@@ -1,5 +1,6 @@
 ﻿#pragma once
+#include "system/angband.h"
 
 typedef struct monster_death_type monster_death_type;
 struct player_type;
-void switch_special_death(player_type *player_ptr, monster_death_type *md_ptr);
+void switch_special_death(player_type *player_ptr, monster_death_type *md_ptr, EFFECT_ID effect_type);

--- a/src/monster-race/race-indice-types.h
+++ b/src/monster-race/race-indice-types.h
@@ -12,6 +12,7 @@ enum monster_race_type {
     MON_LOUSE = 69,
     MON_PIRANHA = 70,
     MON_COPPER_COINS = 85,
+    MON_SWORDFISH = 88,
     MON_NOV_PALADIN = 97,
     MON_NOV_PRIEST_G = 109,
     MON_SILVER_COINS = 117,

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -144,7 +144,7 @@ bool MonsterDamageProcessor::process_dead_exp_virtue(concptr note, monster_type 
     sound(SOUND_KILL);
     this->show_kill_message(note, m_name);
     this->show_bounty_message(m_name);
-    monster_death(this->player_ptr, this->m_idx, true);
+    monster_death(this->player_ptr, this->m_idx, true, this->effect_type);
     this->summon_special_unique();
     this->get_exp_from_mon(exp_mon, exp_mon->max_maxhp * 2);
     *this->fear = false;


### PR DESCRIPTION
要望のあった★の追加。
加えて、メカジキを冷気属性で倒したときに10%の確率でドロップするようにした。
条件ドロップの実装テストも兼ねて。