### PR TITLE
[Feature] MonsterDamageProseccorに複合属性渡しを許可する

### DIFF
--- a/src/combat/slaying.cpp
+++ b/src/combat/slaying.cpp
@@ -208,12 +208,15 @@ HIT_POINT calc_attack_damage_with_slay(player_type *player_ptr, object_type *o_p
     return (tdam * mult / 10);
 }
 
-EFFECT_ID melee_effect_type(player_type *player_ptr, object_type *o_ptr, combat_options mode)
+EffectFlags melee_effect_type(player_type *player_ptr, object_type *o_ptr, combat_options mode)
 {
+    EffectFlags effect_flags{};
+    effect_flags.set(GF_PLAYER_MELEE);
+
     if (player_ptr->pclass == PlayerClassType::SAMURAI) {
         static const struct samurai_convert_table_t {
             combat_options hissatsu_type;
-            EFFECT_ID effect_type;
+            spells_type effect_type;
         } samurai_convert_table[] = {
             { HISSATSU_FIRE,    GF_FIRE },
             { HISSATSU_COLD,    GF_COLD },
@@ -226,7 +229,7 @@ EFFECT_ID melee_effect_type(player_type *player_ptr, object_type *o_ptr, combat_
             const struct samurai_convert_table_t *p = &samurai_convert_table[i];
 
             if (mode == p->hissatsu_type)
-                return p->effect_type;
+                effect_flags.set(p->effect_type);
         }
     }
 
@@ -248,7 +251,7 @@ EFFECT_ID melee_effect_type(player_type *player_ptr, object_type *o_ptr, combat_
     
     static const struct brand_convert_table_t {
         tr_type brand_type;
-        EFFECT_ID effect_type;
+        spells_type effect_type;
     } brand_convert_table[] = {
         { TR_BRAND_ACID, GF_ACID },
         { TR_BRAND_FIRE, GF_FIRE },
@@ -265,13 +268,13 @@ EFFECT_ID melee_effect_type(player_type *player_ptr, object_type *o_ptr, combat_
         const struct brand_convert_table_t *p = &brand_convert_table[i];
 
         if (flgs.has(p->brand_type))
-            return p->effect_type;
+            effect_flags.set(p->effect_type);
     }
 
     
     if ((flgs.has(TR_FORCE_WEAPON)) && (player_ptr->csp > (o_ptr->dd * o_ptr->ds / 5))) {
-        return GF_MANA;
+        effect_flags.set(GF_MANA);
     }
 
-    return GF_ATTACK;
+    return effect_flags;
 }

--- a/src/combat/slaying.h
+++ b/src/combat/slaying.h
@@ -4,6 +4,7 @@
 
 #include "combat/combat-options-type.h"
 #include "object-enchant/tr-flags.h"
+#include "spell/spell-types.h"
 
 struct monster_type;
 struct object_type;
@@ -11,4 +12,4 @@ struct player_type;
 MULTIPLY mult_slaying(player_type *player_ptr, MULTIPLY mult, const TrFlags &flgs, monster_type *m_ptr);
 MULTIPLY mult_brand(player_type *player_ptr, MULTIPLY mult, const TrFlags &flgs, monster_type *m_ptr);
 HIT_POINT calc_attack_damage_with_slay(player_type *player_ptr, object_type *o_ptr, HIT_POINT tdam, monster_type *m_ptr, combat_options mode, bool thrown);
-EFFECT_ID melee_effect_type(player_type *player_ptr, object_type *o_ptr, combat_options mode);
+EffectFlags melee_effect_type(player_type *player_ptr, object_type *o_ptr, combat_options mode);

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -337,12 +337,28 @@ static void on_defeat_last_boss(player_type *player_ptr)
     msg_print(_("準備が整ったら引退(自殺コマンド)しても結構です。", "You may retire (commit suicide) when you are ready."));
 }
 
+
 /*!
  * @brief モンスターが死亡した時の処理 /
  * Handle the "death" of a monster.
  * @param m_idx 死亡したモンスターのID
  * @param drop_item TRUEならばモンスターのドロップ処理を行う
- * @return 撃破されたモンスターの述語
+ * @param effect_type ラストアタックの属性 (単一属性)
+ */
+void monster_death(player_type *player_ptr, MONSTER_IDX m_idx, bool drop_item, EFFECT_ID effect_type)
+{
+    EffectFlags flags;
+    flags.clear();
+    flags.set((spells_type)effect_type);
+    monster_death(player_ptr, m_idx, drop_item, flags);
+}
+
+/*!
+ * @brief モンスターが死亡した時の処理 /
+ * Handle the "death" of a monster.
+ * @param m_idx 死亡したモンスターのID
+ * @param drop_item TRUEならばモンスターのドロップ処理を行う
+ * @param effect_flags ラストアタックの属性 (複数属性)
  * @details
  * <pre>
  * Disperse treasures centered at the monster location based on the
@@ -354,7 +370,7 @@ static void on_defeat_last_boss(player_type *player_ptr)
  * it drops all of its objects, which may disappear in crowded rooms.
  * </pre>
  */
-void monster_death(player_type *player_ptr, MONSTER_IDX m_idx, bool drop_item, EFFECT_ID effect_type)
+void monster_death(player_type *player_ptr, MONSTER_IDX m_idx, bool drop_item, EffectFlags effect_flags)
 {
     monster_death_type tmp_md;
     monster_death_type *md_ptr = initialize_monster_death_type(player_ptr, &tmp_md, m_idx, drop_item);
@@ -386,7 +402,7 @@ void monster_death(player_type *player_ptr, MONSTER_IDX m_idx, bool drop_item, E
     drop_corpse(player_ptr, md_ptr);
     monster_drop_carried_objects(player_ptr, md_ptr->m_ptr);
     decide_drop_quality(md_ptr);
-    switch_special_death(player_ptr, md_ptr, effect_type);
+    switch_special_death(player_ptr, md_ptr, effect_flags);
     drop_artifact(player_ptr, md_ptr);
     int drop_numbers = decide_drop_numbers(player_ptr, md_ptr, drop_item);
     coin_type = md_ptr->force_coin;

--- a/src/monster-floor/monster-death.h
+++ b/src/monster-floor/monster-death.h
@@ -2,8 +2,10 @@
 
 #include "system/angband.h"
 #include "monster-floor/monster-death-util.h"
+#include "spell/spell-types.h"
 
 struct player_type;
+void monster_death(player_type *player_ptr, MONSTER_IDX m_idx, bool drop_item, EffectFlags effect_flags);
 void monster_death(player_type *player_ptr, MONSTER_IDX m_idx, bool drop_item, EFFECT_ID effect_type);
 bool drop_single_artifact(player_type *player_ptr, monster_death_type *md_ptr, ARTIFACT_IDX a_idx);
 concptr extract_note_dies(MONRACE_IDX r_idx);

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -533,15 +533,15 @@ static void on_dead_mimics(player_type *player_ptr, monster_death_type *md_ptr)
     }
 }
 
-static void on_dead_swordfish(player_type *player_ptr, monster_death_type *md_ptr, EFFECT_ID effect_type)
+static void on_dead_swordfish(player_type *player_ptr, monster_death_type *md_ptr, EffectFlags effect_flags)
 {
-    if ((effect_type != GF_COLD) || (randint1(100) >= 10))
+    if (effect_flags.has_not(GF_COLD) || !md_ptr->drop_chosen_item || (randint1(100) >= 10))
         return;
 
     drop_single_artifact(player_ptr, md_ptr, ART_FROZEN_SWORDFISH);
 }
 
-void switch_special_death(player_type *player_ptr, monster_death_type *md_ptr, EFFECT_ID effect_type)
+void switch_special_death(player_type *player_ptr, monster_death_type *md_ptr, EffectFlags effect_flags)
 {
     switch (md_ptr->m_ptr->r_idx) {
     case MON_PINK_HORROR:
@@ -622,7 +622,7 @@ void switch_special_death(player_type *player_ptr, monster_death_type *md_ptr, E
         on_dead_chest_mimic(player_ptr, md_ptr);
         break;
     case MON_SWORDFISH:
-        on_dead_swordfish(player_ptr, md_ptr, effect_type);
+        on_dead_swordfish(player_ptr, md_ptr, effect_flags);
         break;
     default:
         on_dead_mimics(player_ptr, md_ptr);

--- a/src/monster-floor/special-death-switcher.h
+++ b/src/monster-floor/special-death-switcher.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 #include "system/angband.h"
+#include "spell/spell-types.h"
 
 typedef struct monster_death_type monster_death_type;
 struct player_type;
-void switch_special_death(player_type *player_ptr, monster_death_type *md_ptr, EFFECT_ID effect_type);
+void switch_special_death(player_type *player_ptr, monster_death_type *md_ptr, EffectFlags effect_flags);

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -55,7 +55,7 @@
  * @param m_idx ダメージを与えたモンスターのID
  * @param dam 与えたダメージ量
  * @param fear ダメージによってモンスターが恐慌状態に陥ったならばtrue
- * @param type 与えたダメージの種類
+ * @param effect_type 与えたダメージの種類 (単一属性)
  * @param note モンスターが倒された際の特別なメッセージ述語
  */
 MonsterDamageProcessor::MonsterDamageProcessor(player_type *player_ptr, MONSTER_IDX m_idx, HIT_POINT dam, bool *fear, EFFECT_ID effect_type)
@@ -63,7 +63,26 @@ MonsterDamageProcessor::MonsterDamageProcessor(player_type *player_ptr, MONSTER_
     , m_idx(m_idx)
     , dam(dam)
     , fear(fear)
-    , effect_type(effect_type)
+{
+    this->effect_flags.clear();
+    this->effect_flags.set((spells_type)effect_type);
+}
+
+/*
+ * @brief コンストラクタ
+ * @param player_ptr プレイヤーへの参照ポインタ
+ * @param m_idx ダメージを与えたモンスターのID
+ * @param dam 与えたダメージ量
+ * @param fear ダメージによってモンスターが恐慌状態に陥ったならばtrue
+ * @param effect_flags 与えたダメージの種類 (複数属性)
+ * @param note モンスターが倒された際の特別なメッセージ述語
+ */
+MonsterDamageProcessor::MonsterDamageProcessor(player_type *player_ptr, MONSTER_IDX m_idx, HIT_POINT dam, bool *fear, EffectFlags effect_flags)
+    : player_ptr(player_ptr)
+    , m_idx(m_idx)
+    , dam(dam)
+    , fear(fear)
+    , effect_flags(effect_flags)
 {
 }
 
@@ -90,7 +109,7 @@ bool MonsterDamageProcessor::mon_take_hit(concptr note)
     }
 
     if (allow_debug_options) {
-        msg_format(_("合計%d/%dのダメージを与えた。(EffectID: %d)", "You do %d (out of %d) damage. (EffectID: %d)"), m_ptr->dealt_damage, m_ptr->maxhp, this->effect_type);
+        msg_format(_("合計%d/%dのダメージを与えた。", "You do %d (out of %d) damage."), m_ptr->dealt_damage, m_ptr->maxhp);
     }
 
     if (this->process_dead_exp_virtue(note, &exp_mon)) {
@@ -144,7 +163,7 @@ bool MonsterDamageProcessor::process_dead_exp_virtue(concptr note, monster_type 
     sound(SOUND_KILL);
     this->show_kill_message(note, m_name);
     this->show_bounty_message(m_name);
-    monster_death(this->player_ptr, this->m_idx, true, this->effect_type);
+    monster_death(this->player_ptr, this->m_idx, true, this->effect_flags);
     this->summon_special_unique();
     this->get_exp_from_mon(exp_mon, exp_mon->max_maxhp * 2);
     *this->fear = false;

--- a/src/monster/monster-damage.h
+++ b/src/monster/monster-damage.h
@@ -3,6 +3,7 @@
 #include "monster-race/race-indice-types.h"
 #include "system/angband.h"
 #include "spell/spell-types.h"
+#include "util/flag-group.h"
 #include <tuple>
 #include <vector>
 
@@ -13,6 +14,7 @@ typedef std::vector<std::tuple<monster_race_type, monster_race_type, monster_rac
 class MonsterDamageProcessor {
 public:
     MonsterDamageProcessor(player_type *player_ptr, MONSTER_IDX m_idx, HIT_POINT dam, bool *fear, EFFECT_ID effect_type);
+    MonsterDamageProcessor(player_type *player_ptr, MONSTER_IDX m_idx, HIT_POINT dam, bool *fear, EffectFlags effect_flags);
     virtual ~MonsterDamageProcessor() = default;
     bool mon_take_hit(concptr note);
 
@@ -21,7 +23,7 @@ private:
     MONSTER_IDX m_idx;
     HIT_POINT dam;
     bool *fear;
-    EFFECT_ID effect_type;
+    EffectFlags effect_flags{};
     void get_exp_from_mon(monster_type *m_ptr, HIT_POINT exp_dam);
     bool genocide_chaos_patron();
     bool process_dead_exp_virtue(concptr note, monster_type *exp_mon);

--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -435,11 +435,12 @@ void ObjectThrowEntity::attack_racial_power()
         this->m_ptr->hp - this->tdam, this->m_ptr->maxhp, this->m_ptr->max_maxhp);
 
     auto fear = false;
-    EFFECT_ID effect_type = GF_PLAYER_SHOOT;
+    EffectFlags effect_flags{};
+    effect_flags.set(GF_PLAYER_SHOOT);
     if (is_active_torch(this->o_ptr))
-        effect_type = GF_FIRE;
+        effect_flags.set(GF_FIRE);
 
-    MonsterDamageProcessor mdp(this->player_ptr, this->g_ptr->m_idx, this->tdam, &fear, effect_type);
+    MonsterDamageProcessor mdp(this->player_ptr, this->g_ptr->m_idx, this->tdam, &fear, effect_flags);
     if (mdp.mon_take_hit(extract_note_dies(real_r_idx(this->m_ptr)))) {
         return;
     }

--- a/src/player-attack/player-attack-util.h
+++ b/src/player-attack/player-attack-util.h
@@ -5,6 +5,7 @@
 #include "object-enchant/tr-flags.h"
 #include "system/angband.h"
 #include "system/system-variables.h"
+#include "spell/spell-types.h"
 
 /*!
  * @brief カオス効果種別
@@ -54,5 +55,5 @@ typedef struct player_attack_type {
     int drain_result{}; //!< 吸血した累積量
     int drain_left{}; //!< 吸血できる残量(最大MAX_VAMPIRIC_DRAIN)
     bool weak{}; //!< 打撃効果でモンスターが弱くなったかどうか
-    EFFECT_ID effect_type{}; //!< 与えたダメージの種類 
+    EffectFlags effect_flags{}; //!< 与えたダメージの種類 
 } player_attack_type;

--- a/src/player-attack/player-attack.cpp
+++ b/src/player-attack/player-attack.cpp
@@ -414,7 +414,7 @@ static void apply_damage_negative_effect(player_attack_type *pa_ptr, bool is_zan
  */
 static bool check_fear_death(player_type *player_ptr, player_attack_type *pa_ptr, const int num, const bool is_lowlevel)
 {
-    MonsterDamageProcessor mdp(player_ptr, pa_ptr->m_idx, pa_ptr->attack_damage, pa_ptr->fear, pa_ptr->effect_type);
+    MonsterDamageProcessor mdp(player_ptr, pa_ptr->m_idx, pa_ptr->attack_damage, pa_ptr->fear, pa_ptr->effect_flags);
     if (!mdp.mon_take_hit(nullptr))
         return false;
 
@@ -539,7 +539,7 @@ void exe_player_attack_to_monster(player_type *player_ptr, POSITION y, POSITION 
         if (!process_attack_hit(player_ptr, pa_ptr, chance))
             continue;
 
-        pa_ptr->effect_type = melee_effect_type(player_ptr, o_ptr, pa_ptr->mode);
+        pa_ptr->effect_flags = melee_effect_type(player_ptr, o_ptr, pa_ptr->mode);
         apply_actual_attack(player_ptr, pa_ptr, &do_quake, is_zantetsu_nullified, is_ej_nullified);
         calc_drain(pa_ptr);
         if (check_fear_death(player_ptr, pa_ptr, num, is_lowlevel))

--- a/src/spell/spell-types.h
+++ b/src/spell/spell-types.h
@@ -1,4 +1,5 @@
 ﻿#pragma once
+#include "util/flag-group.h"
 
 enum spells_type
 {
@@ -106,6 +107,11 @@ enum spells_type
 	GF_VOID = 118,              /*!< 魔法効果: 虚無 */
 	GF_ABYSS = 119,             /*!< 魔法効果: 深淵 */
     GF_HUNGRY = 120,            /*!< 魔法効果: 空腹>*/
-    GF_PLAYER_SHOOT = 121,		/*!< 属性取得用: プレイヤーの射撃/投擲>*/
-	MAX_GF = 122,		        /*!< 欠番を無視した最大サイズ (直上の値+1) */
+	GF_PLAYER_SHOOT = 121,		 /*!< 属性取得用: プレイヤーの射撃/投擲>*/
+	GF_PLAYER_MELEE = 122,		 /*!< 属性取得用: プレイヤーの近接攻撃>*/
+	MAX_GF = 123,		        /*!< 欠番を無視した最大サイズ (直上の値+1) */
 };
+
+
+/*! 属性フラグspell_typesの集合を表すクラス */
+using EffectFlags = FlagGroup<spells_type, MAX_GF>;


### PR DESCRIPTION
複数属性を持つ武器/射撃によるアタックを評価するためMDPを拡張した。
例示として実装しているメカジキだが、適当な棒など複数属性武器で攻撃した際に
該当武器に冷気ブランドが含まれていればドロップする実装となった。