### PR TITLE
[Fix} 誰得の巻物で固定アーティファクトが生成されない

### DIFF
--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -131,6 +131,8 @@ void amusement(PlayerType *player_ptr, POSITION y1, POSITION x1, int num, bool k
                     continue;
                 if (a_ref.cur_num > 0)
                     continue;
+
+                a_idx = a_ref.idx;
                 break;
             }
 


### PR DESCRIPTION
アーティファクトID取得ループでID取得ができなくなっていた。
IDを取得するように修正。