### PR TITLE
[Implement] 強力に呪われているとき、恐怖/狂戦士化の呪いを強化する

### DIFF
--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -309,7 +309,20 @@ static void curse_call_monster(PlayerType *player_ptr)
 
 static void curse_cowardice(PlayerType *player_ptr)
 {
-    if ((player_ptr->cursed.has_not(CurseTraitType::COWARDICE)) || !one_in_(1500))
+    if (player_ptr->cursed.has_not(CurseTraitType::COWARDICE))
+        return;
+
+    object_type *o_ptr;
+    o_ptr = choose_cursed_obj_name(player_ptr, CurseTraitType::COWARDICE);
+    int chance = 1500;
+    int duration = 13 + randint1(26);
+
+    if (o_ptr->curse_flags.has(CurseTraitType::HEAVY_CURSE)) {
+        chance = 150;
+        duration *= 2;
+    }
+    
+    if (!one_in_(chance))
         return;
 
     if (has_resist_fear(player_ptr))
@@ -317,7 +330,7 @@ static void curse_cowardice(PlayerType *player_ptr)
 
     disturb(player_ptr, false, true);
     msg_print(_("とても暗い... とても恐い！", "It's so dark... so scary!"));
-    (void)BadStatusSetter(player_ptr).mod_afraidness(13 + randint1(26));
+    (void)BadStatusSetter(player_ptr).mod_afraidness(duration);
 }
 
 /*!
@@ -326,13 +339,26 @@ static void curse_cowardice(PlayerType *player_ptr)
  */
 static void curse_berserk_rage(PlayerType *player_ptr)
 {
-    if ((player_ptr->cursed.has_not(CurseTraitType::BERS_RAGE)) || !one_in_(1500))
+    if (player_ptr->cursed.has_not(CurseTraitType::BERS_RAGE))
+        return;
+
+    object_type *o_ptr;
+    o_ptr = choose_cursed_obj_name(player_ptr, CurseTraitType::BERS_RAGE);
+    int chance = 1500;
+    int duration = 10 + randint1(player_ptr->lev);
+
+    if (o_ptr->curse_flags.has(CurseTraitType::HEAVY_CURSE)) {
+        chance = 150;
+        duration *= 2;
+    }
+    
+    if (!one_in_(chance))
         return;
 
     disturb(player_ptr, false, true);
     msg_print(_("ウガァァア！", "RAAAAGHH!"));
     msg_print(_("激怒の発作に襲われた！", "You feel a fit of rage coming over you!"));
-    (void)set_shero(player_ptr, 10 + randint1(player_ptr->lev), false);
+    (void)set_shero(player_ptr, duration, false);
     (void)BadStatusSetter(player_ptr).afraidness(0);
 }
 


### PR DESCRIPTION
AC低下等の呪いで既に実現しているギミックを恐怖/狂戦士化に拡張する。
該当のアイテムにかけられた呪いが強力であるとき、頻度と持続時間を強化する。
具体的には10ゲームターン毎1/1500から1/150に、持続時間は倍にする。