### PR TITLE
[Implement] 呪力弱点の導入

### DIFF
--- a/src/flavor/flag-inscriptions-table.cpp
+++ b/src/flavor/flag-inscriptions-table.cpp
@@ -39,7 +39,7 @@ std::vector<flag_insc_table> flag_insc_immune = {
 /*! オブジェクトの特性表示記号テーブルの定義(弱点) */
 std::vector<flag_insc_table> flag_insc_vuln = {
     { N("酸", "Ac"), TR_VUL_ACID, TR_IM_ACID }, { N("電", "El"), TR_VUL_ELEC, TR_IM_ELEC }, { N("火", "Fi"), TR_VUL_FIRE, TR_IM_FIRE }, { N("冷", "Co"), TR_VUL_COLD, TR_IM_COLD },
-    { N("閃", "Li"), TR_VUL_LITE, -1 }
+    { N("閃", "Li"), TR_VUL_LITE, -1 }, { N("呪", "Cu"), TR_VUL_CURSE, -1 }
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(耐性) */

--- a/src/info-reader/kind-info-tokens-table.cpp
+++ b/src/info-reader/kind-info-tokens-table.cpp
@@ -174,6 +174,7 @@ const std::unordered_map<std::string_view, tr_type> k_info_flags = {
     { "SELF_COLD", TR_SELF_COLD },
     { "SELF_ELEC", TR_SELF_ELEC },
     { "PERSITENT_CURSE", TR_PERSITENT_CURSE },
+    { "VUL_CURSE", TR_VUL_CURSE },
 };
 
 /*!

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -121,6 +121,9 @@ static void choise_cursed_item(CurseTraitType flag, object_type *o_ptr, int *cho
     case CurseTraitType::PERSISTENT_CURSE:
         cf = TR_PERSITENT_CURSE;
         break;
+    case CurseTraitType::VUL_CURSE:
+        cf = TR_VUL_CURSE;
+        break;
     default:
         break;
     }

--- a/src/object-enchant/smith-tables.cpp
+++ b/src/object-enchant/smith-tables.cpp
@@ -353,6 +353,7 @@ const std::vector<essence_drain_type> Smith::essence_drain_info_table = {
     { TR_SELF_ELEC, { SmithEssenceType::BRAND_ELEC, SmithEssenceType::RES_ELEC }, 10 },
     { TR_SELF_COLD, { SmithEssenceType::BRAND_COLD, SmithEssenceType::RES_COLD }, 10 },
     { TR_PERSITENT_CURSE, {}, -1 },
+    { TR_VUL_CURSE, {}, -1 },
 };
 
 namespace {

--- a/src/object-enchant/tr-types.h
+++ b/src/object-enchant/tr-types.h
@@ -176,8 +176,9 @@ enum tr_type : int32_t {
     TR_SELF_COLD = 160, //!< マイナスフラグ - 持続冷気ダメージ
 
     TR_PERSITENT_CURSE = 161, //!< 頻繁に自身を呪いなおすフラグ
+    TR_VUL_CURSE = 162, //!< 呪力弱点
 
-    TR_FLAG_MAX = 162,
+    TR_FLAG_MAX = 163,
 };
 
 /** 能力値(STR,INT,WIS,DEX,CON,CHR)のpvalを増減させるフラグのリスト */

--- a/src/object-enchant/trc-types.h
+++ b/src/object-enchant/trc-types.h
@@ -26,6 +26,7 @@ enum class CurseTraitType {
     CALL_UNDEAD = 21,
     BERS_RAGE = 22,
     PERSISTENT_CURSE = 23,
+    VUL_CURSE = 24,
     MAX,
 };
 

--- a/src/object/object-value-calc.cpp
+++ b/src/object/object-value-calc.cpp
@@ -424,6 +424,8 @@ PRICE flag_cost(const object_type *o_ptr, int plusses)
         else
             total += 250;
     }
+    if (flgs.has(TR_VUL_CURSE))
+        total -= 7500;
 
     if (flgs.has(TR_AGGRAVATE))
         total -= 10000;

--- a/src/perception/identification.cpp
+++ b/src/perception/identification.cpp
@@ -101,10 +101,6 @@ bool screen_object(PlayerType *player_ptr, object_type *o_ptr, BIT_FLAGS mode)
         info[i++] = _("それは物を強く投げることを可能にする。", "It provides great strength when you throw an item.");
     }
 
-    if (flgs.has(TR_DOWN_SAVING)) {
-        info[i++] = _("それは魔法抵抗力を下げる。", "It decreases your magic resistance.");
-    }
-
     if (o_ptr->tval == ItemKindType::STATUE) {
         monster_race *r_ptr = &r_info[o_ptr->pval];
         if (o_ptr->pval == MON_BULLGATES)
@@ -681,6 +677,14 @@ bool screen_object(PlayerType *player_ptr, object_type *o_ptr, BIT_FLAGS mode)
 
     if ((flgs.has(TR_LOW_AC)) || o_ptr->curse_flags.has(CurseTraitType::LOW_AC)) {
         info[i++] = _("それは攻撃を受けやすい。", "It helps your enemies' blows.");
+    }
+
+    if (o_ptr->curse_flags.has(CurseTraitType::VUL_CURSE) || flgs.has(TR_VUL_CURSE)) {
+        info[i++] = _("それは呪いへの抵抗力を下げる。", "It decreases your resistance to curses.");
+    }
+
+    if (flgs.has(TR_DOWN_SAVING)) {
+        info[i++] = _("それは魔法抵抗力を半減させる。", "It halves your magic resistance.");
     }
 
     if ((flgs.has(TR_HARD_SPELL)) || o_ptr->curse_flags.has(CurseTraitType::HARD_SPELL)) {

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -455,6 +455,8 @@ BIT_FLAGS get_player_flags(PlayerType *player_ptr, tr_type tr_flag)
     case TR_SELF_ELEC:
     case TR_PERSITENT_CURSE:
         return check_equipment_flags(player_ptr, tr_flag);
+    case TR_VUL_CURSE:
+        return has_vuln_curse(player_ptr);
 
     case TR_FLAG_MAX:
         break;
@@ -1072,6 +1074,8 @@ void update_curses(PlayerType *player_ptr)
             player_ptr->cursed.set(CurseTraitType::BERS_RAGE);
         if (flgs.has(TR_PERSITENT_CURSE))
             player_ptr->cursed.set(CurseTraitType::PERSISTENT_CURSE);
+        if (flgs.has(TR_VUL_CURSE))
+            player_ptr->cursed.set(CurseTraitType::VUL_CURSE);
 
         auto obj_curse_flags = o_ptr->curse_flags;
         obj_curse_flags.reset({ CurseTraitType::CURSED, CurseTraitType::HEAVY_CURSE, CurseTraitType::PERMA_CURSE });
@@ -1405,6 +1409,52 @@ BIT_FLAGS has_resist_curse(PlayerType *player_ptr)
 
     if (player_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
+    }
+
+    return result;
+}
+
+/*!
+ * @brief 呪力弱点を所持しているかどうか
+ * @param プレイヤー情報への参照ポインタ
+ * @return 呪力弱点を所持していればTRUE、なければFALSE
+ */
+BIT_FLAGS has_vuln_curse(PlayerType *player_ptr)
+{
+    object_type *o_ptr;
+    BIT_FLAGS result = 0L;
+    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+        o_ptr = &player_ptr->inventory_list[i];
+        if (!o_ptr->k_idx)
+            continue;
+
+        auto flgs = object_flags(o_ptr);
+
+        if (flgs.has(TR_VUL_CURSE) || o_ptr->curse_flags.has(CurseTraitType::VUL_CURSE))
+            set_bits(result, convert_inventory_slot_type_to_flag_cause(i2enum<inventory_slot_type>(i)));
+    }
+
+    return result;
+}
+
+/*!
+ * @brief 呪力弱点かつ重く呪われている装備の有無
+ * @param プレイヤー情報への参照ポインタ
+ * @return 呪力弱点かつ重く呪われている装備があればTRUE、なければFALSE
+ */
+BIT_FLAGS has_heavy_vuln_curse(PlayerType *player_ptr)
+{
+    object_type *o_ptr;
+    BIT_FLAGS result = 0L;
+    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+        o_ptr = &player_ptr->inventory_list[i];
+        if (!o_ptr->k_idx)
+            continue;
+
+        auto flgs = object_flags(o_ptr);
+
+        if ((flgs.has(TR_VUL_CURSE) || o_ptr->curse_flags.has(CurseTraitType::VUL_CURSE)) && o_ptr->curse_flags.has(CurseTraitType::HEAVY_CURSE))
+            set_bits(result, convert_inventory_slot_type_to_flag_cause(i2enum<inventory_slot_type>(i)));
     }
 
     return result;

--- a/src/player/player-status-flags.h
+++ b/src/player/player-status-flags.h
@@ -126,6 +126,8 @@ BIT_FLAGS has_resist_neth(PlayerType *player_ptr);
 BIT_FLAGS has_resist_time(PlayerType *player_ptr);
 BIT_FLAGS has_resist_water(PlayerType *player_ptr);
 BIT_FLAGS has_resist_curse(PlayerType *player_ptr);
+BIT_FLAGS has_vuln_curse(PlayerType *player_ptr);
+BIT_FLAGS has_heavy_vuln_curse(PlayerType *player_ptr);
 BIT_FLAGS has_resist_fear(PlayerType *player_ptr);
 BIT_FLAGS has_immune_acid(PlayerType *player_ptr);
 BIT_FLAGS has_immune_elec(PlayerType *player_ptr);

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -1078,6 +1078,8 @@ static ACTION_SKILL_POWER calc_device_ability(PlayerType *player_ptr)
  * * 呪力耐性の装備による加算(30)
  * * 祝福された装備による加算(5 + レベル / 10)
  * * 賢さによるadj_wis_savテーブル加算
+ * * 呪力弱点の装備による減算(-10)
+ * * 呪力弱点の装備が強力に呪われているときさらに減算(-20)
  * * 狂戦士化による減算(-30)
  * * 反魔法持ちで大なり上書き(90+レベル未満ならその値に上書き)
  * * クターのつぶれ状態なら(10に上書き)
@@ -1109,6 +1111,12 @@ static ACTION_SKILL_POWER calc_saving_throw(PlayerType *player_ptr)
         pow += 6 + (player_ptr->lev - 1) / 10;
 
     pow += adj_wis_sav[player_ptr->stat_index[A_WIS]];
+
+    if (has_vuln_curse(player_ptr))
+        pow -= 10;
+
+    if (has_heavy_vuln_curse(player_ptr))
+        pow -= 20;
 
     if (is_shero(player_ptr))
         pow -= 30;

--- a/src/view/display-characteristic.cpp
+++ b/src/view/display-characteristic.cpp
@@ -79,6 +79,7 @@ static std::unordered_map<tr_type, tr_type> flag_to_lesser_flag = {
     { TR_RES_ELEC, TR_VUL_ELEC },
     { TR_RES_FIRE, TR_VUL_FIRE },
     { TR_RES_LITE, TR_VUL_LITE },
+    { TR_RES_CURSE, TR_VUL_CURSE },
 };
 
 /*!

--- a/src/wizard/artifact-analyzer.cpp
+++ b/src/wizard/artifact-analyzer.cpp
@@ -134,6 +134,19 @@ static void analyze_immune(object_type *o_ptr, concptr *immune_list)
 }
 
 /*!
+ * @brief アーティファクトの弱点付与を構造体に収める /
+ * Note the immunities granted by an object
+ * @param o_ptr オブジェクト構造体の参照ポインタ
+ * @param immune_list 弱点構造体の参照ポインタ
+ */
+static void analyze_vulnerable(object_type *o_ptr, concptr *vulnerable_list)
+{
+    auto flgs = object_flags(o_ptr);
+    vulnerable_list = spoiler_flag_aux(flgs, vulnerable_flags_desc, vulnerable_list, N_ELEMENTS(vulnerable_flags_desc));
+    *vulnerable_list = nullptr;
+}
+
+/*!
  * @brief アーティファクトの維持特性を構造体に収める /
  * Note which stats an object sustains
  * @param o_ptr オブジェクト構造体の参照ポインタ
@@ -281,6 +294,7 @@ void object_analyze(PlayerType *player_ptr, object_type *o_ptr, obj_desc_list *d
     analyze_slay(o_ptr, desc_ptr->slays);
     analyze_immune(o_ptr, desc_ptr->immunities);
     analyze_resist(o_ptr, desc_ptr->resistances);
+    analyze_vulnerable(o_ptr, desc_ptr->vulnerables);
     analyze_sustains(o_ptr, desc_ptr->sustains);
     analyze_misc_magic(o_ptr, desc_ptr->misc_magic);
     analyze_addition(o_ptr, desc_ptr->addition);
@@ -303,6 +317,7 @@ void random_artifact_analyze(PlayerType *player_ptr, object_type *o_ptr, obj_des
     analyze_slay(o_ptr, desc_ptr->slays);
     analyze_immune(o_ptr, desc_ptr->immunities);
     analyze_resist(o_ptr, desc_ptr->resistances);
+    analyze_vulnerable(o_ptr, desc_ptr->vulnerables);
     analyze_sustains(o_ptr, desc_ptr->sustains);
     analyze_misc_magic(o_ptr, desc_ptr->misc_magic);
     desc_ptr->activation = activation_explanation(o_ptr);

--- a/src/wizard/fixed-artifacts-spoiler.cpp
+++ b/src/wizard/fixed-artifacts-spoiler.cpp
@@ -124,6 +124,7 @@ static void spoiler_print_art(obj_desc_list *art_ptr)
     spoiler_outlist(_("武器属性:", ""), art_ptr->brands, list_separator);
     spoiler_outlist(_("免疫:", "Immunity to"), art_ptr->immunities, item_separator);
     spoiler_outlist(_("耐性:", "Resist"), art_ptr->resistances, item_separator);
+    spoiler_outlist(_("弱点:", "Vulnerable"), art_ptr->vulnerables, item_separator);
     spoiler_outlist(_("維持:", "Sustain"), art_ptr->sustains, item_separator);
     spoiler_outlist("", art_ptr->misc_magic, list_separator);
 

--- a/src/wizard/spoiler-table.cpp
+++ b/src/wizard/spoiler-table.cpp
@@ -136,6 +136,15 @@ const flag_desc resist_flags_desc[MAX_RESISTANCE_FLAGS_DESCRIPTION] = {
     { TR_RES_CURSE, _("呪力", "Curse") },
 };
 
+const flag_desc vulnerable_flags_desc[MAX_VULNERABLE_FLAGS_DESCRIPTION] = {
+    { TR_VUL_ACID, _("酸", "Acid") },
+    { TR_VUL_ELEC, _("電撃", "Lightning") },
+    { TR_VUL_FIRE, _("火炎", "Fire") },
+    { TR_VUL_COLD, _("冷気", "Cold") },
+    { TR_VUL_LITE, _("閃光", "Light") },
+    { TR_VUL_CURSE, _("呪力", "Curse") },
+};
+
 /* Elemental immunities (along with poison) */
 const flag_desc immune_flags_desc[MAX_IMMUNITY_FLAGS_DESCRIPTION] = {
     { TR_IM_ACID, _("酸", "Acid") },

--- a/src/wizard/spoiler-table.h
+++ b/src/wizard/spoiler-table.h
@@ -11,6 +11,7 @@
 #define MAX_SLAY_FLAGS_DESCRIPTION 20
 #define MAX_BRAND_FLAGS_DESCRIPTION 12
 #define MAX_RESISTANCE_FLAGS_DESCRIPTION 19
+#define MAX_VULNERABLE_FLAGS_DESCRIPTION 6
 #define MAX_IMMUNITY_FLAGS_DESCRIPTION 4
 #define MAX_SUSTAINER_FLAGS_DESCRIPTION 6
 #define MAX_MISC2_FLAGS_DESCRIPTION 4
@@ -40,6 +41,7 @@ extern flag_desc pval_flags1_desc[MAX_PVAL_FLAGS_DESCRIPTION];
 extern flag_desc slay_flags_desc[MAX_SLAY_FLAGS_DESCRIPTION];
 extern flag_desc brand_flags_desc[MAX_BRAND_FLAGS_DESCRIPTION];
 extern const flag_desc resist_flags_desc[MAX_RESISTANCE_FLAGS_DESCRIPTION];
+extern const flag_desc vulnerable_flags_desc[MAX_VULNERABLE_FLAGS_DESCRIPTION];
 extern const flag_desc immune_flags_desc[MAX_IMMUNITY_FLAGS_DESCRIPTION];
 extern const flag_desc sustain_flags_desc[MAX_SUSTAINER_FLAGS_DESCRIPTION];
 extern const flag_desc misc_flags2_desc[MAX_MISC2_FLAGS_DESCRIPTION];

--- a/src/wizard/spoiler-util.h
+++ b/src/wizard/spoiler-util.h
@@ -31,6 +31,7 @@ typedef struct obj_desc_list {
     concptr brands[N_ELEMENTS(brand_flags_desc) + 1]; /* A list if an object's elemental brands */
     concptr immunities[N_ELEMENTS(immune_flags_desc) + 1]; /* A list of immunities granted by an object */
     concptr resistances[N_ELEMENTS(resist_flags_desc) + 1]; /* A list of resistances granted by an object */
+    concptr vulnerables[N_ELEMENTS(vulnerable_flags_desc) + 1]; /* A list of resistances granted by an object */
     concptr sustains[N_ELEMENTS(sustain_flags_desc) - 1 + 1]; /* A list of stats sustained by an object */
 
     /* A list of various magical qualities an object may have */


### PR DESCRIPTION
魔法防御半減はペナルティとして強力すぎて使いにくいので、気軽に導入できるペナルティとして呪力弱点を導入する。
呪力耐性と関連させて耐性-弱点の関係とする。
平常時MR-10、強力に呪われているときMR-30とした。複数装備しても重複しない。