### PR TITLE
[Fix] 地震による落盤で死ぬと死因が0feetになる #1883

### DIFF
--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -163,7 +163,7 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
 
         map[16 + player_ptr->y - cy][16 + player_ptr->x - cx] = false;
         if (damage) {
-            concptr killer;
+            std::string killer;
 
             if (m_idx) {
                 GAME_TEXT m_name[MAX_NLEN];
@@ -174,7 +174,7 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
                 killer = _("地震", "an earthquake");
             }
 
-            take_hit(player_ptr, DAMAGE_ATTACK, damage, killer);
+            take_hit(player_ptr, DAMAGE_ATTACK, damage, killer.c_str());
         }
     }
 


### PR DESCRIPTION
earthquake()内でkillerにformatを直接渡しているため、後にtake_hit()内で上書きされていることが原因。
killerをstd::stringにして文字列のコピーとして保持するよう修正する。