### PR TITLE
[Fix] モンスターの色/文字を正常にprfファイルに保存できない

### DIFF
--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -123,7 +123,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
                     continue;
 
                 auto_dump_printf(auto_dump_stream, "# %s\n", r_ref.name.c_str());
-                auto_dump_printf(auto_dump_stream, "R:%d:0x%02X/0x%02X\n\n", i, (byte)(r_ref.x_attr), (byte)(r_ref.x_char));
+                auto_dump_printf(auto_dump_stream, "R:%d:0x%02X/0x%02X\n\n", r_ref.idx, (byte)(r_ref.x_attr), (byte)(r_ref.x_char));
             }
 
             close_auto_dump(&auto_dump_stream, mark);


### PR DESCRIPTION
Issue #1909 の件。
該当の出力箇所でループ形式を変更した際、ループカウンタを使用していた箇所が正常動作しなくなっていた。
そもそもループカウンタではなくモンスターの種族IDを使用するべきなので、そのように修正。