### PR TITLE
[Fix] 同一のセーブファイルでゲームを開始するオプションに不要なアスタリスク

### DIFF
--- a/src/game-option/option-types-table.cpp
+++ b/src/game-option/option-types-table.cpp
@@ -239,7 +239,7 @@ const std::vector<option_type> option_info = {
 
     { &powerup_home, true, OPT_PAGE_BIRTH, 4, 3, "powerup_home", _("我が家を拡張する(*)", "Increase capacity of your home (*)") },
 
-    { &keep_savefile, true, OPT_PAGE_BIRTH, 4, 4, "keep_savefile", _("同一のセーブファイルでゲームを開始する(*)", "Start game with same savefile thet is loaded (*)") },
+    { &keep_savefile, true, OPT_PAGE_BIRTH, 4, 4, "keep_savefile", _("同一のセーブファイルでゲームを開始する", "Start game with same savefile thet is loaded") },
 
     /*** Easy Object Auto-Destroyer ***/
     { &destroy_items, false, OPT_PAGE_AUTODESTROY, 7, 0, "destroy_items", _("アイテムの簡易自動破壊を使用する", "Use easy auto-destroyer") },


### PR DESCRIPTION
Issue #1903 の件。
スコアへの影響はないので表記を修正する。