### PR TITLE
[Fix] PlayerType クラスのメンバに武器スキルの最大値を持たせる

### DIFF
--- a/src/birth/birth-stat.cpp
+++ b/src/birth/birth-stat.cpp
@@ -125,6 +125,7 @@ void get_extra(PlayerType *player_ptr, bool roll_hitdie)
 
     auto pclass = enum2i(player_ptr->pclass);
     player_ptr->weapon_exp = s_info[pclass].w_start;
+    player_ptr->weapon_exp_max = s_info[pclass].w_max;
 
     if (player_ptr->ppersonality == PERSONALITY_SEXY) {
         auto &whip_exp = player_ptr->weapon_exp[ItemKindType::HAFTED][SV_WHIP];

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -257,16 +257,6 @@ static void generate_world(PlayerType *player_ptr, bool new_game)
     panel_row_min = floor_ptr->height;
     panel_col_min = floor_ptr->width;
 
-    if (player_ptr->pclass != PlayerClassType::SORCERER) {
-        auto pclass = enum2i(player_ptr->pclass);
-        if (player_ptr->ppersonality == PERSONALITY_SEXY)
-            s_info[pclass].w_max[ItemKindType::HAFTED][SV_WHIP] = PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER);
-        if (player_ptr->prace == PlayerRaceType::MERFOLK) {
-            s_info[pclass].w_max[ItemKindType::POLEARM][SV_TRIDENT] = PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER);
-            s_info[pclass].w_max[ItemKindType::POLEARM][SV_TRIFURCATE_SPEAR] = PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER);
-        }
-    }
-
     set_floor_and_wall(player_ptr->dungeon_idx);
     flavor_init();
     prt(_("お待ち下さい...", "Please wait..."), 0, 0);

--- a/src/knowledge/knowledge-experiences.cpp
+++ b/src/knowledge/knowledge-experiences.cpp
@@ -41,11 +41,11 @@ void do_cmd_knowledge_weapon_exp(PlayerType *player_ptr)
                     continue;
 
                 SUB_EXP weapon_exp = player_ptr->weapon_exp[tval][num];
-                SUB_EXP weapon_max = s_info[enum2i(player_ptr->pclass)].w_max[tval][num];
+                SUB_EXP weapon_max = player_ptr->weapon_exp_max[tval][num];
                 strip_name(tmp, k_ref.idx);
                 fprintf(fff, "%-25s ", tmp);
                 if (show_actual_value)
-                    fprintf(fff, "%4d/%4d ", std::min(weapon_exp, weapon_max), weapon_max);
+                    fprintf(fff, "%4d/%4d ", weapon_exp, weapon_max);
                 if (weapon_exp >= weapon_max)
                     fprintf(fff, "!");
                 else

--- a/src/object-hook/hook-weapon.cpp
+++ b/src/object-hook/hook-weapon.cpp
@@ -21,7 +21,6 @@ bool object_is_favorite(PlayerType *player_ptr, const object_type *o_ptr)
     }
 
     /* Favorite weapons are varied depend on the class */
-    auto short_pclass = enum2i(player_ptr->pclass);
     switch (player_ptr->pclass) {
     case PlayerClassType::PRIEST: {
         auto flgs = object_flags_known(o_ptr);
@@ -34,7 +33,7 @@ bool object_is_favorite(PlayerType *player_ptr, const object_type *o_ptr)
     case PlayerClassType::MONK:
     case PlayerClassType::FORCETRAINER:
         /* Icky to wield? */
-        if (!(s_info[short_pclass].w_max[o_ptr->tval][o_ptr->sval]))
+        if (player_ptr->weapon_exp_max[o_ptr->tval][o_ptr->sval] == PlayerSkill::weapon_exp_at(PlayerSkillRank::UNSKILLED))
             return false;
         break;
 
@@ -50,13 +49,13 @@ bool object_is_favorite(PlayerType *player_ptr, const object_type *o_ptr)
     }
 
     case PlayerClassType::SORCERER:
-        if (s_info[short_pclass].w_max[o_ptr->tval][o_ptr->sval] < PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER))
+        if (player_ptr->weapon_exp_max[o_ptr->tval][o_ptr->sval] < PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER))
             return false;
         break;
 
     case PlayerClassType::NINJA:
         /* Icky to wield? */
-        if (s_info[short_pclass].w_max[o_ptr->tval][o_ptr->sval] <= PlayerSkill::weapon_exp_at(PlayerSkillRank::BEGINNER))
+        if (player_ptr->weapon_exp_max[o_ptr->tval][o_ptr->sval] <= PlayerSkill::weapon_exp_at(PlayerSkillRank::BEGINNER))
             return false;
         break;
 

--- a/src/player/player-skill.h
+++ b/src/player/player-skill.h
@@ -71,6 +71,9 @@ public:
 
     EXP exp_of_spell(int realm, int spell_idx) const;
 
+    void apply_special_weapon_skill_max_values();
+    void limit_weapon_skills_by_max_value();
+
 private:
     PlayerType *player_ptr;
 };

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -1695,7 +1695,7 @@ bool has_not_ninja_weapon(PlayerType *player_ptr, int i)
     auto tval = player_ptr->inventory_list[INVEN_MAIN_HAND + i].tval;
     auto sval = player_ptr->inventory_list[INVEN_MAIN_HAND + i].sval;
     return player_ptr->pclass == PlayerClassType::NINJA &&
-           !((s_info[enum2i(PlayerClassType::NINJA)].w_max[tval][sval] > PlayerSkill::weapon_exp_at(PlayerSkillRank::BEGINNER)) &&
+           !((player_ptr->weapon_exp_max[tval][sval] > PlayerSkill::weapon_exp_at(PlayerSkillRank::BEGINNER)) &&
                (player_ptr->inventory_list[INVEN_SUB_HAND - i].tval != ItemKindType::SHIELD));
 }
 
@@ -1707,7 +1707,7 @@ bool has_not_monk_weapon(PlayerType *player_ptr, int i)
     
     auto tval = player_ptr->inventory_list[INVEN_MAIN_HAND + i].tval;
     auto sval = player_ptr->inventory_list[INVEN_MAIN_HAND + i].sval;
-    return ((player_ptr->pclass == PlayerClassType::MONK) || (player_ptr->pclass == PlayerClassType::FORCETRAINER)) && !(s_info[enum2i(player_ptr->pclass)].w_max[tval][sval]);
+    return ((player_ptr->pclass == PlayerClassType::MONK) || (player_ptr->pclass == PlayerClassType::FORCETRAINER)) && (player_ptr->weapon_exp_max[tval][sval] == PlayerSkill::weapon_exp_at(PlayerSkillRank::UNSKILLED));
 }
 
 bool has_good_luck(PlayerType *player_ptr)

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -2457,6 +2457,9 @@ void update_creature(PlayerType *player_ptr)
     if (any_bits(player_ptr->update, (PU_BONUS))) {
         reset_bits(player_ptr->update, PU_BONUS);
         PlayerAlignment(player_ptr).update_alignment();
+        PlayerSkill ps(player_ptr);
+        ps.apply_special_weapon_skill_max_values();
+        ps.limit_weapon_skills_by_max_value();
         update_bonuses(player_ptr);
     }
 

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -189,6 +189,7 @@ public:
 
     SUB_EXP spell_exp[64]{}; /* Proficiency of spells */
     std::map<ItemKindType, std::array<SUB_EXP, 64>> weapon_exp{}; /* Proficiency of weapons */
+    std::map<ItemKindType, std::array<SUB_EXP, 64>> weapon_exp_max{}; /* Maximum proficiency of weapons */
     std::map<PlayerSkillKindType, SUB_EXP> skill_exp{}; /* Proficiency of misc. skill */
 
     ClassSpecificData class_specific_data;

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -420,9 +420,10 @@ void wiz_change_status(PlayerType *player_ptr)
 
     for (auto tval : TV_WEAPON_RANGE) {
         for (int i = 0; i < 64; i++) {
-            player_ptr->weapon_exp[tval][i] = std::min(tmp_s16b, s_info[enum2i(player_ptr->pclass)].w_max[tval][i]);
+            player_ptr->weapon_exp[tval][i] = tmp_s16b;
         }
     }
+    PlayerSkill(player_ptr).limit_weapon_skills_by_max_value();
 
     for (auto j : PLAYER_SKILL_KIND_TYPE_RANGE) {
         player_ptr->skill_exp[j] = tmp_s16b;


### PR DESCRIPTION
特別に武器スキルの最大値を変化させる時、スキル情報テーブル s_info の保持している最大
値を変化させているが、これが原因でマーフォークから別の種族に変化した時に三叉槍やトライ
デントのスキル最大値がゲームを再起動するまで達人のままになるという現象が発生している。

そもそもの設計として read-only であるべきテーブルの値をいじっているのがよくないので
最大値の定義を必要に応じて PlayerType クラスのメンバにコピーし、最大値の変更や参照は
そちらを使うようにする。