### PR TITLE
[Feature] モンスターの召喚魔法によるプレイヤー連続行動阻害の条件を統一

### DIFF
--- a/src/mspell/mspell-summon.cpp
+++ b/src/mspell/mspell-summon.cpp
@@ -32,6 +32,23 @@ constexpr int S_NUM_6 = 6;
 constexpr int S_NUM_4 = 4;
 
 /*!
+ * @brief モンスターが召喚呪文を使った際にプレイヤーの連続行動を止める処理 /
+ * @param player_ptr プレイヤーへの参照ポインタ
+ * @param target_type プレイヤーを対象とする場合MONSTER_TO_PLAYER、モンスターを対象とする場合MONSTER_TO_MONSTER
+ * @param known モンスターが近くにいる場合TRUE
+ * @param see_either モンスターを視認可能な場合TRUE
+ */
+static void summon_disturb(PlayerType *player_ptr, int target_type, bool known, bool see_either)
+{
+    bool mon_to_mon = target_type == MONSTER_TO_MONSTER;
+    bool mon_to_player = target_type == MONSTER_TO_PLAYER;
+    if (mon_to_player || (mon_to_mon && known && see_either)) {
+        disturb(player_ptr, true, true);
+    }
+}
+
+
+/*!
  * @brief 特定条件のモンスター召喚のみPM_ALLOW_UNIQUEを許可する /
  * @param floor_ptr 現在フロアへの参照ポインタ
  * @param m_idx モンスターID
@@ -84,8 +101,7 @@ static void decide_summon_kin_caster(
         return;
     }
 
-    if (mon_to_player || (mon_to_mon && known && see_either))
-        disturb(player_ptr, true, true);
+    summon_disturb(player_ptr, target_type, known, see_either);
 
     if (player_ptr->blind) {
         if (mon_to_player)
@@ -123,9 +139,12 @@ MonsterSpellResult spell_RF6_S_KIN(PlayerType *player_ptr, POSITION y, POSITION 
     monster_name(player_ptr, m_idx, m_name);
     monster_name(player_ptr, t_idx, t_name);
     monster_desc(player_ptr, m_poss, m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE);
-
-    disturb(player_ptr, true, true);
+    
+    bool see_either = see_monster(player_ptr, m_idx) || see_monster(player_ptr, t_idx);
     bool known = monster_near_player(floor_ptr, m_idx, t_idx);
+
+    summon_disturb(player_ptr, target_type, known, see_either);
+
     decide_summon_kin_caster(player_ptr, m_idx, t_idx, target_type, m_name, m_poss, known);
     int count = 0;
     switch (m_ptr->r_idx) {
@@ -213,18 +232,21 @@ MonsterSpellResult spell_RF6_S_KIN(PlayerType *player_ptr, POSITION y, POSITION 
  */
 MonsterSpellResult spell_RF6_S_CYBER(PlayerType *player_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int TARGET_TYPE)
 {
-    int count = 0;
     floor_type *floor_ptr = player_ptr->current_floor_ptr;
     monster_type *m_ptr = &floor_ptr->m_list[m_idx];
     DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
     bool mon_to_mon = (TARGET_TYPE == MONSTER_TO_MONSTER);
     bool mon_to_player = (TARGET_TYPE == MONSTER_TO_PLAYER);
+    bool see_either = see_monster(player_ptr, m_idx) || see_monster(player_ptr, t_idx);
+    bool known = monster_near_player(floor_ptr, m_idx, t_idx);
     mspell_cast_msg_blind msg(_("%^sが何かをつぶやいた。", "%^s mumbles."),
         _("%^sがサイバーデーモンを召喚した！", "%^s magically summons Cyberdemons!"),
         _("%^sがサイバーデーモンを召喚した！", "%^s magically summons Cyberdemons!"));
 
     monspell_message(player_ptr, m_idx, t_idx, msg, TARGET_TYPE);
+    summon_disturb(player_ptr, TARGET_TYPE, known, see_either);
 
+    int count = 0;
     if (is_friendly(m_ptr) && mon_to_mon) {
         count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_CYBER, (PM_ALLOW_GROUP));
     } else {
@@ -256,16 +278,20 @@ MonsterSpellResult spell_RF6_S_CYBER(PlayerType *player_ptr, POSITION y, POSITIO
  */
 MonsterSpellResult spell_RF6_S_MONSTER(PlayerType *player_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int TARGET_TYPE)
 {
+    floor_type *floor_ptr = player_ptr->current_floor_ptr;
+    DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
+    bool mon_to_mon = (TARGET_TYPE == MONSTER_TO_MONSTER);
+    bool mon_to_player = (TARGET_TYPE == MONSTER_TO_PLAYER);
+    bool see_either = see_monster(player_ptr, m_idx) || see_monster(player_ptr, t_idx);
+    bool known = monster_near_player(floor_ptr, m_idx, t_idx);
+
     mspell_cast_msg_blind msg(_("%^sが何かをつぶやいた。", "%^s mumbles."), _("%^sが魔法で仲間を召喚した！", "%^s magically summons help!"),
         _("%^sが魔法で仲間を召喚した！", "%^s magically summons help!"));
 
     monspell_message(player_ptr, m_idx, t_idx, msg, TARGET_TYPE);
+    summon_disturb(player_ptr, TARGET_TYPE, known, see_either);
 
-    floor_type *floor_ptr = player_ptr->current_floor_ptr;
     int count = 0;
-    DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
-    bool mon_to_mon = (TARGET_TYPE == MONSTER_TO_MONSTER);
-    bool mon_to_player = (TARGET_TYPE == MONSTER_TO_PLAYER);
     for (int k = 0; k < 1; k++) {
         if (mon_to_player)
             count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_NONE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE));
@@ -299,16 +325,20 @@ MonsterSpellResult spell_RF6_S_MONSTER(PlayerType *player_ptr, POSITION y, POSIT
  */
 MonsterSpellResult spell_RF6_S_MONSTERS(PlayerType *player_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int TARGET_TYPE)
 {
+    floor_type *floor_ptr = player_ptr->current_floor_ptr;
+    DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
+    bool mon_to_mon = (TARGET_TYPE == MONSTER_TO_MONSTER);
+    bool mon_to_player = (TARGET_TYPE == MONSTER_TO_PLAYER);
+    bool see_either = see_monster(player_ptr, m_idx) || see_monster(player_ptr, t_idx);
+    bool known = monster_near_player(floor_ptr, m_idx, t_idx);
+
     mspell_cast_msg_blind msg(_("%^sが何かをつぶやいた。", "%^s mumbles."),
         _("%^sが魔法でモンスターを召喚した！", "%^s magically summons monsters!"), _("%^sが魔法でモンスターを召喚した！", "%^s magically summons monsters!"));
 
     monspell_message(player_ptr, m_idx, t_idx, msg, TARGET_TYPE);
+    summon_disturb(player_ptr, TARGET_TYPE, known, see_either);
 
-    floor_type *floor_ptr = player_ptr->current_floor_ptr;
     int count = 0;
-    DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
-    bool mon_to_mon = (TARGET_TYPE == MONSTER_TO_MONSTER);
-    bool mon_to_player = (TARGET_TYPE == MONSTER_TO_PLAYER);
     for (auto k = 0; k < S_NUM_6; k++) {
         if (mon_to_player)
             count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_NONE, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE));
@@ -342,16 +372,20 @@ MonsterSpellResult spell_RF6_S_MONSTERS(PlayerType *player_ptr, POSITION y, POSI
  */
 MonsterSpellResult spell_RF6_S_ANT(PlayerType *player_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int TARGET_TYPE)
 {
-    mspell_cast_msg_blind msg(_("%^sが何かをつぶやいた。", "%^s mumbles."), _("%^sが魔法でアリを召喚した。", "%^s magically summons ants."),
-        _("%^sが魔法でアリを召喚した。", "%^s magically summons ants."));
-
-    monspell_message(player_ptr, m_idx, t_idx, msg, TARGET_TYPE);
-
-    int count = 0;
     floor_type *floor_ptr = player_ptr->current_floor_ptr;
     DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
     bool mon_to_mon = (TARGET_TYPE == MONSTER_TO_MONSTER);
     bool mon_to_player = (TARGET_TYPE == MONSTER_TO_PLAYER);
+    bool see_either = see_monster(player_ptr, m_idx) || see_monster(player_ptr, t_idx);
+    bool known = monster_near_player(floor_ptr, m_idx, t_idx);
+
+    mspell_cast_msg_blind msg(_("%^sが何かをつぶやいた。", "%^s mumbles."), _("%^sが魔法でアリを召喚した。", "%^s magically summons ants."),
+        _("%^sが魔法でアリを召喚した。", "%^s magically summons ants."));
+
+    monspell_message(player_ptr, m_idx, t_idx, msg, TARGET_TYPE);
+    summon_disturb(player_ptr, TARGET_TYPE, known, see_either);
+
+    int count = 0;
     for (auto k = 0; k < S_NUM_6; k++) {
         count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_ANT, PM_ALLOW_GROUP);
     }
@@ -381,16 +415,20 @@ MonsterSpellResult spell_RF6_S_ANT(PlayerType *player_ptr, POSITION y, POSITION 
  */
 MonsterSpellResult spell_RF6_S_SPIDER(PlayerType *player_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int TARGET_TYPE)
 {
+    floor_type *floor_ptr = player_ptr->current_floor_ptr;
+    DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
+    bool mon_to_mon = (TARGET_TYPE == MONSTER_TO_MONSTER);
+    bool mon_to_player = (TARGET_TYPE == MONSTER_TO_PLAYER);
+    bool see_either = see_monster(player_ptr, m_idx) || see_monster(player_ptr, t_idx);
+    bool known = monster_near_player(floor_ptr, m_idx, t_idx);
+
     mspell_cast_msg_blind msg(_("%^sが何かをつぶやいた。", "%^s mumbles."), _("%^sが魔法でクモを召喚した。", "%^s magically summons spiders."),
         _("%^sが魔法でクモを召喚した。", "%^s magically summons spiders."));
 
     monspell_message(player_ptr, m_idx, t_idx, msg, TARGET_TYPE);
+    summon_disturb(player_ptr, TARGET_TYPE, known, see_either);
 
     int count = 0;
-    bool mon_to_mon = (TARGET_TYPE == MONSTER_TO_MONSTER);
-    bool mon_to_player = (TARGET_TYPE == MONSTER_TO_PLAYER);
-    floor_type *floor_ptr = player_ptr->current_floor_ptr;
-    DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
     for (auto k = 0; k < S_NUM_6; k++) {
         count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_SPIDER, PM_ALLOW_GROUP);
     }
@@ -420,16 +458,20 @@ MonsterSpellResult spell_RF6_S_SPIDER(PlayerType *player_ptr, POSITION y, POSITI
  */
 MonsterSpellResult spell_RF6_S_HOUND(PlayerType *player_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int TARGET_TYPE)
 {
-    mspell_cast_msg_blind msg(_("%^sが何かをつぶやいた。", "%^s mumbles."),
-        _("%^sが魔法でハウンドを召喚した。", "%^s magically summons hounds."), _("%^sが魔法でハウンドを召喚した。", "%^s magically summons hounds."));
-
-    monspell_message(player_ptr, m_idx, t_idx, msg, TARGET_TYPE);
-
-    int count = 0;
     floor_type *floor_ptr = player_ptr->current_floor_ptr;
     DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
     bool mon_to_mon = (TARGET_TYPE == MONSTER_TO_MONSTER);
     bool mon_to_player = (TARGET_TYPE == MONSTER_TO_PLAYER);
+    bool see_either = see_monster(player_ptr, m_idx) || see_monster(player_ptr, t_idx);
+    bool known = monster_near_player(floor_ptr, m_idx, t_idx);
+
+    mspell_cast_msg_blind msg(_("%^sが何かをつぶやいた。", "%^s mumbles."),
+        _("%^sが魔法でハウンドを召喚した。", "%^s magically summons hounds."), _("%^sが魔法でハウンドを召喚した。", "%^s magically summons hounds."));
+
+    monspell_message(player_ptr, m_idx, t_idx, msg, TARGET_TYPE);
+    summon_disturb(player_ptr, TARGET_TYPE, known, see_either);
+
+    int count = 0;
     for (auto k = 0; k < S_NUM_4; k++) {
         count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_HOUND, PM_ALLOW_GROUP);
     }
@@ -459,16 +501,20 @@ MonsterSpellResult spell_RF6_S_HOUND(PlayerType *player_ptr, POSITION y, POSITIO
  */
 MonsterSpellResult spell_RF6_S_HYDRA(PlayerType *player_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int TARGET_TYPE)
 {
-    mspell_cast_msg_blind msg(_("%^sが何かをつぶやいた。", "%^s mumbles."),
-        _("%^sが魔法でヒドラを召喚した。", "%^s magically summons hydras."), _("%^sが魔法でヒドラを召喚した。", "%^s magically summons hydras."));
-
-    monspell_message(player_ptr, m_idx, t_idx, msg, TARGET_TYPE);
-
-    int count = 0;
     floor_type *floor_ptr = player_ptr->current_floor_ptr;
     DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
     bool mon_to_mon = (TARGET_TYPE == MONSTER_TO_MONSTER);
     bool mon_to_player = (TARGET_TYPE == MONSTER_TO_PLAYER);
+    bool see_either = see_monster(player_ptr, m_idx) || see_monster(player_ptr, t_idx);
+    bool known = monster_near_player(floor_ptr, m_idx, t_idx);
+
+    mspell_cast_msg_blind msg(_("%^sが何かをつぶやいた。", "%^s mumbles."),
+        _("%^sが魔法でヒドラを召喚した。", "%^s magically summons hydras."), _("%^sが魔法でヒドラを召喚した。", "%^s magically summons hydras."));
+
+    monspell_message(player_ptr, m_idx, t_idx, msg, TARGET_TYPE);
+    summon_disturb(player_ptr, TARGET_TYPE, known, see_either);
+
+    int count = 0;
     for (auto k = 0; k < S_NUM_4; k++) {
         count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_HYDRA, PM_ALLOW_GROUP);
     }
@@ -498,12 +544,18 @@ MonsterSpellResult spell_RF6_S_HYDRA(PlayerType *player_ptr, POSITION y, POSITIO
  */
 MonsterSpellResult spell_RF6_S_ANGEL(PlayerType *player_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int TARGET_TYPE)
 {
+    floor_type *floor_ptr = player_ptr->current_floor_ptr;
+    DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
+    bool mon_to_mon = (TARGET_TYPE == MONSTER_TO_MONSTER);
+    bool see_either = see_monster(player_ptr, m_idx) || see_monster(player_ptr, t_idx);
+    bool known = monster_near_player(floor_ptr, m_idx, t_idx);
+
     mspell_cast_msg_blind msg(_("%^sが何かをつぶやいた。", "%^s mumbles."),
         _("%^sが魔法で天使を召喚した！", "%^s magically summons an angel!"), _("%^sが魔法で天使を召喚した！", "%^s magically summons an angel!"));
 
     monspell_message(player_ptr, m_idx, t_idx, msg, TARGET_TYPE);
+    summon_disturb(player_ptr, TARGET_TYPE, known, see_either);
 
-    floor_type *floor_ptr = player_ptr->current_floor_ptr;
     monster_type *m_ptr = &floor_ptr->m_list[m_idx];
     monster_race *r_ptr = &r_info[m_ptr->r_idx];
     int num = 1;
@@ -511,7 +563,6 @@ MonsterSpellResult spell_RF6_S_ANGEL(PlayerType *player_ptr, POSITION y, POSITIO
         num += r_ptr->level / 40;
     }
 
-    DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
     int count = 0;
     for (int k = 0; k < num; k++) {
         count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_ANGEL, PM_ALLOW_GROUP);
@@ -525,7 +576,6 @@ MonsterSpellResult spell_RF6_S_ANGEL(PlayerType *player_ptr, POSITION y, POSITIO
             msg_print(_("多くのものが間近に現れた音がする。", "You hear many things appear nearby."));
     }
 
-    bool mon_to_mon = (TARGET_TYPE == MONSTER_TO_MONSTER);
     if (monster_near_player(floor_ptr, m_idx, t_idx) && !see_monster(player_ptr, t_idx) && count && mon_to_mon)
         floor_ptr->monster_noise = true;
 
@@ -548,14 +598,19 @@ MonsterSpellResult spell_RF6_S_ANGEL(PlayerType *player_ptr, POSITION y, POSITIO
  */
 MonsterSpellResult spell_RF6_S_DEMON(PlayerType *player_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int TARGET_TYPE)
 {
+    floor_type *floor_ptr = player_ptr->current_floor_ptr;
+    DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
+    bool mon_to_mon = (TARGET_TYPE == MONSTER_TO_MONSTER);
+    bool see_either = see_monster(player_ptr, m_idx) || see_monster(player_ptr, t_idx);
+    bool known = monster_near_player(floor_ptr, m_idx, t_idx);
+
     mspell_cast_msg_blind msg(_("%^sが何かをつぶやいた。", "%^s mumbles."),
         _("%^sは魔法で混沌の宮廷から悪魔を召喚した！", "%^s magically summons a demon from the Courts of Chaos!"),
         _("%^sは魔法で混沌の宮廷から悪魔を召喚した！", "%^s magically summons a demon from the Courts of Chaos!"));
 
     monspell_message(player_ptr, m_idx, t_idx, msg, TARGET_TYPE);
+    summon_disturb(player_ptr, TARGET_TYPE, known, see_either);
 
-    floor_type *floor_ptr = player_ptr->current_floor_ptr;
-    DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
     int count = 0;
     for (int k = 0; k < 1; k++) {
         count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_DEMON, PM_ALLOW_GROUP);
@@ -564,7 +619,6 @@ MonsterSpellResult spell_RF6_S_DEMON(PlayerType *player_ptr, POSITION y, POSITIO
     if (player_ptr->blind && count)
         msg_print(_("何かが間近に現れた音がする。", "You hear something appear nearby."));
 
-    bool mon_to_mon = (TARGET_TYPE == MONSTER_TO_MONSTER);
     if (monster_near_player(floor_ptr, m_idx, t_idx) && !see_monster(player_ptr, t_idx) && count && mon_to_mon)
         floor_ptr->monster_noise = true;
 
@@ -587,14 +641,19 @@ MonsterSpellResult spell_RF6_S_DEMON(PlayerType *player_ptr, POSITION y, POSITIO
  */
 MonsterSpellResult spell_RF6_S_UNDEAD(PlayerType *player_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int TARGET_TYPE)
 {
+    floor_type *floor_ptr = player_ptr->current_floor_ptr;
+    DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
+    bool mon_to_mon = (TARGET_TYPE == MONSTER_TO_MONSTER);
+    bool see_either = see_monster(player_ptr, m_idx) || see_monster(player_ptr, t_idx);
+    bool known = monster_near_player(floor_ptr, m_idx, t_idx);
+
     mspell_cast_msg_blind msg(_("%^sが何かをつぶやいた。", "%^s mumbles."),
         _("%^sが魔法でアンデッドの強敵を召喚した！", "%^s magically summons an undead adversary!"),
         _("%sが魔法でアンデッドを召喚した。", "%^s magically summons undead."));
 
     monspell_message(player_ptr, m_idx, t_idx, msg, TARGET_TYPE);
+    summon_disturb(player_ptr, TARGET_TYPE, known, see_either);
 
-    floor_type *floor_ptr = player_ptr->current_floor_ptr;
-    DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
     int count = 0;
     for (int k = 0; k < 1; k++) {
         count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_UNDEAD, PM_ALLOW_GROUP);
@@ -603,7 +662,6 @@ MonsterSpellResult spell_RF6_S_UNDEAD(PlayerType *player_ptr, POSITION y, POSITI
     if (player_ptr->blind && count)
         msg_print(_("何かが間近に現れた音がする。", "You hear something appear nearby."));
 
-    bool mon_to_mon = (TARGET_TYPE == MONSTER_TO_MONSTER);
     if (monster_near_player(floor_ptr, m_idx, t_idx) && !see_monster(player_ptr, t_idx) && count && mon_to_mon)
         floor_ptr->monster_noise = true;
 
@@ -626,15 +684,19 @@ MonsterSpellResult spell_RF6_S_UNDEAD(PlayerType *player_ptr, POSITION y, POSITI
  */
 MonsterSpellResult spell_RF6_S_DRAGON(PlayerType *player_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int TARGET_TYPE)
 {
-    mspell_cast_msg_blind msg(_("%^sが何かをつぶやいた。", "%^s mumbles."),
-        _("%^sが魔法でドラゴンを召喚した！", "%^s magically summons a dragon!"), _("%^sが魔法でドラゴンを召喚した！", "%^s magically summons a dragon!"));
-
-    monspell_message(player_ptr, m_idx, t_idx, msg, TARGET_TYPE);
-
     floor_type *floor_ptr = player_ptr->current_floor_ptr;
     DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
     bool mon_to_mon = (TARGET_TYPE == MONSTER_TO_MONSTER);
     bool mon_to_player = (TARGET_TYPE == MONSTER_TO_PLAYER);
+    bool see_either = see_monster(player_ptr, m_idx) || see_monster(player_ptr, t_idx);
+    bool known = monster_near_player(floor_ptr, m_idx, t_idx);
+
+    mspell_cast_msg_blind msg(_("%^sが何かをつぶやいた。", "%^s mumbles."),
+        _("%^sが魔法でドラゴンを召喚した！", "%^s magically summons a dragon!"), _("%^sが魔法でドラゴンを召喚した！", "%^s magically summons a dragon!"));
+
+    monspell_message(player_ptr, m_idx, t_idx, msg, TARGET_TYPE);
+    summon_disturb(player_ptr, TARGET_TYPE, known, see_either);
+
     int count = 0;
     if (mon_to_player)
         count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_DRAGON, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE));
@@ -667,15 +729,18 @@ MonsterSpellResult spell_RF6_S_DRAGON(PlayerType *player_ptr, POSITION y, POSITI
  */
 MonsterSpellResult spell_RF6_S_HI_UNDEAD(PlayerType *player_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int TARGET_TYPE)
 {
-    GAME_TEXT m_name[MAX_NLEN];
-    monster_name(player_ptr, m_idx, m_name);
-
-    disturb(player_ptr, true, true);
-
     floor_type *floor_ptr = player_ptr->current_floor_ptr;
     monster_type *m_ptr = &floor_ptr->m_list[m_idx];
-    bool mon_to_player = (TARGET_TYPE == MONSTER_TO_PLAYER);
+    DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
     bool mon_to_mon = (TARGET_TYPE == MONSTER_TO_MONSTER);
+    bool mon_to_player = (TARGET_TYPE == MONSTER_TO_PLAYER);
+    bool see_either = see_monster(player_ptr, m_idx) || see_monster(player_ptr, t_idx);
+    bool known = monster_near_player(floor_ptr, m_idx, t_idx);
+
+    GAME_TEXT m_name[MAX_NLEN];
+    monster_name(player_ptr, m_idx, m_name);
+    summon_disturb(player_ptr, TARGET_TYPE, known, see_either);
+
     int count = 0;
     if (((m_ptr->r_idx == MON_MORGOTH) || (m_ptr->r_idx == MON_SAURON) || (m_ptr->r_idx == MON_ANGMAR)) && ((r_info[MON_NAZGUL].cur_num + 2) < r_info[MON_NAZGUL].max_num) && mon_to_player) {
         count += summon_NAZGUL(player_ptr, y, x, m_idx);
@@ -686,7 +751,6 @@ MonsterSpellResult spell_RF6_S_HI_UNDEAD(PlayerType *player_ptr, POSITION y, POS
 
         monspell_message(player_ptr, m_idx, t_idx, msg, TARGET_TYPE);
 
-        DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
         for (auto k = 0; k < S_NUM_6; k++) {
             if (mon_to_player)
                 count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_HI_UNDEAD, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE));
@@ -722,16 +786,20 @@ MonsterSpellResult spell_RF6_S_HI_UNDEAD(PlayerType *player_ptr, POSITION y, POS
  */
 MonsterSpellResult spell_RF6_S_HI_DRAGON(PlayerType *player_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int TARGET_TYPE)
 {
+    floor_type *floor_ptr = player_ptr->current_floor_ptr;
+    DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
+    bool mon_to_mon = (TARGET_TYPE == MONSTER_TO_MONSTER);
+    bool mon_to_player = (TARGET_TYPE == MONSTER_TO_PLAYER);
+    bool see_either = see_monster(player_ptr, m_idx) || see_monster(player_ptr, t_idx);
+    bool known = monster_near_player(floor_ptr, m_idx, t_idx);
+
     mspell_cast_msg_blind msg(_("%^sが何かをつぶやいた。", "%^s mumbles."),
         _("%^sが魔法で古代ドラゴンを召喚した！", "%^s magically summons ancient dragons!"),
         _("%^sが魔法で古代ドラゴンを召喚した！", "%^s magically summons ancient dragons!"));
 
     monspell_message(player_ptr, m_idx, t_idx, msg, TARGET_TYPE);
+    summon_disturb(player_ptr, TARGET_TYPE, known, see_either);
 
-    floor_type *floor_ptr = player_ptr->current_floor_ptr;
-    DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
-    bool mon_to_mon = (TARGET_TYPE == MONSTER_TO_MONSTER);
-    bool mon_to_player = (TARGET_TYPE == MONSTER_TO_PLAYER);
     int count = 0;
     for (auto k = 0; k < S_NUM_4; k++) {
         if (mon_to_player)
@@ -767,17 +835,21 @@ MonsterSpellResult spell_RF6_S_HI_DRAGON(PlayerType *player_ptr, POSITION y, POS
  */
 MonsterSpellResult spell_RF6_S_AMBERITES(PlayerType *player_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int TARGET_TYPE)
 {
+    floor_type *floor_ptr = player_ptr->current_floor_ptr;
+    DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
+    bool mon_to_mon = (TARGET_TYPE == MONSTER_TO_MONSTER);
+    bool mon_to_player = (TARGET_TYPE == MONSTER_TO_PLAYER);
+    bool see_either = see_monster(player_ptr, m_idx) || see_monster(player_ptr, t_idx);
+    bool known = monster_near_player(floor_ptr, m_idx, t_idx);
+
     mspell_cast_msg_blind msg(_("%^sが何かをつぶやいた。", "%^s mumbles."),
         _("%^sがアンバーの王族を召喚した！", "%^s magically summons Lords of Amber!"),
         _("%^sがアンバーの王族を召喚した！", "%^s magically summons Lords of Amber!"));
 
     monspell_message(player_ptr, m_idx, t_idx, msg, TARGET_TYPE);
+    summon_disturb(player_ptr, TARGET_TYPE, known, see_either);
 
     int count = 0;
-    floor_type *floor_ptr = player_ptr->current_floor_ptr;
-    DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
-    bool mon_to_mon = (TARGET_TYPE == MONSTER_TO_MONSTER);
-    bool mon_to_player = (TARGET_TYPE == MONSTER_TO_PLAYER);
     for (auto k = 0; k < S_NUM_4; k++) {
         count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_AMBERITES, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE));
     }
@@ -808,17 +880,21 @@ MonsterSpellResult spell_RF6_S_AMBERITES(PlayerType *player_ptr, POSITION y, POS
  */
 MonsterSpellResult spell_RF6_S_UNIQUE(PlayerType *player_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int TARGET_TYPE)
 {
+    floor_type *floor_ptr = player_ptr->current_floor_ptr;
+    DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
+    bool mon_to_mon = (TARGET_TYPE == MONSTER_TO_MONSTER);
+    bool mon_to_player = (TARGET_TYPE == MONSTER_TO_PLAYER);
+    bool see_either = see_monster(player_ptr, m_idx) || see_monster(player_ptr, t_idx);
+    bool known = monster_near_player(floor_ptr, m_idx, t_idx);
+
     mspell_cast_msg_blind msg(_("%^sが何かをつぶやいた。", "%^s mumbles."),
         _("%^sが魔法で特別な強敵を召喚した！", "%^s magically summons special opponents!"),
         _("%^sが魔法で特別な強敵を召喚した！", "%^s magically summons special opponents!"));
 
     monspell_message(player_ptr, m_idx, t_idx, msg, TARGET_TYPE);
+    summon_disturb(player_ptr, TARGET_TYPE, known, see_either);
 
-    floor_type *floor_ptr = player_ptr->current_floor_ptr;
     monster_type *m_ptr = &floor_ptr->m_list[m_idx];
-    DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
-    bool mon_to_mon = (TARGET_TYPE == MONSTER_TO_MONSTER);
-    bool mon_to_player = (TARGET_TYPE == MONSTER_TO_PLAYER);
     bool uniques_are_summoned = false;
     int count = 0;
     for (auto k = 0; k < S_NUM_4; k++) {


### PR DESCRIPTION
モンスターの召喚魔法は種類によってプレイヤーの連続行動を阻害する条件が異なっていた。
これを統一して「プレイヤーが召喚魔法を受けた場合」「感知範囲内に召喚者または被召喚者がいる場合」のみ連続行動を阻害するように変更する。