### PR TITLE
[Feature] モンスターの特殊な行動、回復について連続行動阻害の要件を整理

### DIFF
--- a/src/mspell/mspell-special.cpp
+++ b/src/mspell/mspell-special.cpp
@@ -51,6 +51,9 @@ static MonsterSpellResult spell_RF6_SPECIAL_BANORLUPART(PlayerType *player_ptr, 
     POSITION dummy_x = m_ptr->fx;
     BIT_FLAGS mode = 0L;
 
+    if (see_monster(player_ptr, m_idx) && monster_near_player(floor_ptr, m_idx, 0))
+        disturb(player_ptr, true, true);
+
     switch (m_ptr->r_idx) {
     case MON_BANORLUPART:
         dummy_hp = (m_ptr->hp + 1) / 2;
@@ -114,10 +117,18 @@ static MonsterSpellResult spell_RF6_SPECIAL_ROLENTO(PlayerType *player_ptr, POSI
     int count = 0, k;
     int num = 1 + randint1(3);
     BIT_FLAGS mode = 0L;
+    floor_type *floor_ptr = player_ptr->current_floor_ptr;
+    bool see_either = see_monster(player_ptr, m_idx) || see_monster(player_ptr, t_idx);
+    bool mon_to_mon = TARGET_TYPE == MONSTER_TO_MONSTER;
+    bool mon_to_player = TARGET_TYPE == MONSTER_TO_PLAYER;
+    bool known = monster_near_player(floor_ptr, m_idx, t_idx);
+
     mspell_cast_msg_blind msg(_("%^sが何か大量に投げた。", "%^s spreads something."),
         _("%^sは手榴弾をばらまいた。", "%^s throws some hand grenades."), _("%^sは手榴弾をばらまいた。", "%^s throws some hand grenades."));
 
     monspell_message(player_ptr, m_idx, t_idx, msg, TARGET_TYPE);
+    if (mon_to_player || (mon_to_mon && known && see_either))
+        disturb(player_ptr, true, true);
 
     for (k = 0; k < num; k++) {
         count += summon_named_creature(player_ptr, m_idx, y, x, MON_GRENADE, mode);
@@ -228,7 +239,6 @@ MonsterSpellResult spell_RF6_SPECIAL(PlayerType *player_ptr, POSITION y, POSITIO
     monster_type *m_ptr = &floor_ptr->m_list[m_idx];
     monster_race *r_ptr = &r_info[m_ptr->r_idx];
 
-    disturb(player_ptr, true, true);
     switch (m_ptr->r_idx) {
     case MON_OHMU:
         return MonsterSpellResult::make_invalid();

--- a/src/mspell/mspell-status.cpp
+++ b/src/mspell/mspell-status.cpp
@@ -587,8 +587,6 @@ MonsterSpellResult spell_RF6_HEAL(PlayerType *player_ptr, MONSTER_IDX m_idx, MON
     char m_poss[10];
     monster_desc(player_ptr, m_poss, m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE);
 
-    disturb(player_ptr, true, true);
-
     msg.to_player_true = _("%^sが何かをつぶやいた。", "%^s mumbles.");
     msg.to_mons_true = _("%^sは自分の傷に念を集中した。", format("%%^s concentrates on %s wounds.", m_poss));
     msg.to_player_false = _("%^sが自分の傷に集中した。", format("%%^s concentrates on %s wounds.", m_poss));


### PR DESCRIPTION
距離無制限で連続行動を阻害していたものについて修正を入れ、プレイヤー周辺の事象のみを阻害の対象にする。
「時を止める」をどうするか判断に迷うところだが、能力の危険性も加味して暫定的に距離無限で気づけるものとしている。