### PR TITLE
[Fix] #1931 職業選択時、ランダムをカーソル＋Enterで選択すると強制終了する

### DIFF
--- a/src/birth/birth-select-class.cpp
+++ b/src/birth/birth-select-class.cpp
@@ -137,7 +137,7 @@ static bool select_class(PlayerType *player_ptr, char *cur, char *sym, int *k)
             return false;
 
         if (c == ' ' || c == '\r' || c == '\n') {
-            if (cs == PlayerClassType::MAX) {
+            if (int_cs == enum2i(PlayerClassType::MAX)) {
                 *k = randint0(PLAYER_CLASS_TYPE_MAX);
                 cs = i2enum<PlayerClassType>(*k);
                 continue;


### PR DESCRIPTION
カーソルでランダムが選択されているかを判定する部分で比較する変数が誤っている。
正しいものに修正する。