### PR TITLE
[Fix] #1938 モンスターの思い出にオーラの情報が表示されない

### DIFF
--- a/src/lore/lore-util.cpp
+++ b/src/lore/lore-util.cpp
@@ -45,6 +45,7 @@ lore_type *initialize_lore_type(lore_type *lore_ptr, MONRACE_IDX r_idx, monster_
     lore_ptr->flags2 = (lore_ptr->r_ptr->flags2 & lore_ptr->r_ptr->r_flags2);
     lore_ptr->flags3 = (lore_ptr->r_ptr->flags3 & lore_ptr->r_ptr->r_flags3);
     lore_ptr->ability_flags = (lore_ptr->r_ptr->ability_flags & lore_ptr->r_ptr->r_ability_flags);
+    lore_ptr->aura_flags = (lore_ptr->r_ptr->aura_flags & lore_ptr->r_ptr->r_aura_flags);
     lore_ptr->flags7 = (lore_ptr->r_ptr->flags7 & lore_ptr->r_ptr->flags7);
     lore_ptr->flagsr = (lore_ptr->r_ptr->flagsr & lore_ptr->r_ptr->r_flagsr);
     lore_ptr->reinforce = false;


### PR DESCRIPTION
モンスターのオーラフラグを monster_race::aura_flags に分離した際、それに伴い
lore_type::aura_flags も追加したが、これを初期化する処理を追加し忘れているのが原因。
initialize_lore_type() で lore_type::aura_flags も他と同様に初期化するように
する。