### PR TITLE
Resolve _POSIX_SAVED_IDS issues on Debian

### DIFF
--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -42,9 +42,6 @@ static void k_info_reset(void)
  */
 void player_wipe_without_name(PlayerType *player_ptr)
 {
-#ifdef SET_UID
-    int uid = player_ptr->player_uid;
-#endif
     auto tmp = *player_ptr;
     if (player_ptr->last_message)
         string_free(player_ptr->last_message);
@@ -163,7 +160,13 @@ void player_wipe_without_name(PlayerType *player_ptr)
     memcpy(player_ptr->name, tmp.name, sizeof(tmp.name));
 
 #ifdef SET_UID
-    player_ptr->player_uid = uid;
+    player_ptr->player_uid = tmp.player_uid;
+#ifdef SAFE_SETUID
+#ifdef SAFE_SETUID_POSIX
+    player_ptr->player_euid = tmp.player_euid;
+    player_ptr->player_egid = tmp.player_egid;
+#endif
+#endif
 #endif
 }
 

--- a/src/io/uid-checker.cpp
+++ b/src/io/uid-checker.cpp
@@ -1,12 +1,5 @@
 ﻿#include "io/uid-checker.h"
 #include "system/player-type-definition.h"
-#ifdef SET_UID
-#ifdef SAFE_SETUID
-#ifdef SAFE_SETUID_POSIX
-#include "util.h"
-#endif
-#endif
-#endif
 
 /*!
  * @brief ファイルのドロップパーミッションチェック / Hack -- drop permissions
@@ -44,7 +37,7 @@ void safe_setuid_grab(PlayerType *player_ptr)
 #ifdef SAFE_SETUID
 #ifdef SAFE_SETUID_POSIX
 
-    if (setuid(player_ptr->player_egid) != 0) {
+    if (setuid(player_ptr->player_euid) != 0) {
         quit(_("setuid(): 正しく許可が取れません！", "setuid(): cannot set permissions correctly!"));
     }
     if (setgid(player_ptr->player_egid) != 0) {

--- a/src/system/h-config.h
+++ b/src/system/h-config.h
@@ -48,6 +48,8 @@ constexpr auto MAINTAINER = "echizen@users.sourceforge.jp";
   #endif
   
   #define SAFE_SETUID
+  /* Pick up system's definition of _POSIX_SAVED_IDS. */
+  #include <unistd.h>
   #ifdef _POSIX_SAVED_IDS
     #define SAFE_SETUID_POSIX
   #endif


### PR DESCRIPTION
In my hands, these changes resolve the issues I saw with escalating and dropping privileges on Debian (mentioned in #1974 ).  I don't know if they'll resolve the issues when running in Cygwin.