### PR TITLE
カコデーモンとアラクノトロンの説明文を修正

### DIFF
--- a/lib/edit/r_info.txt
+++ b/lib/edit/r_info.txt
@@ -26663,9 +26663,9 @@ F:WILD_VOLCANO | WILD_MOUNTAIN | WILD_TOWN | WILD_ALL
 S:1_IN_8
 S:BO_FIRE
 D:$It is a floating and one-eyed demon.
-D:$  It is very round, with six spines on the top and two on the bottom.
+D:$  It is spherical, with eight horns on the top and four on the bottom.
 D:$  It breathes a plasma ball from its wide mouth.
-D:それはとても丸っこくて体の上部に6本、下部に2本のトゲがあり、浮遊する一つ目の悪魔だ。
+D:それはとても丸っこくて体の上部に8本、下部に4本の角があり、浮遊する一つ目の悪魔だ。
 D:その裂けたような口からプラズマの弾を発射してくる。
 
 N:1349:マンキュバス
@@ -26691,5 +26691,5 @@ F:DROP_1D2 | DROP_60 | DROP_90 | ONLY_ITEM | DROP_GOOD | DROP_CORPSE | EVIL | DE
 F:FORCE_MAXHP | NO_FEAR | RES_PLAS | BASH_DOOR | KILL_BODY
 S:1_IN_1
 S:BO_PLAS
-D:$It has spider-like machine legs and carries a monster that looks brain-like.
-D:蜘蛛のような機械の脚を持っている敵で、脳みそのような生き物を載せている。
+D:$It is a brain-like monster on a machine with four spider-like legs.
+D:それは脳みそのような生き物で、蜘蛛のような脚を4つ持つ機械に乗っている。


### PR DESCRIPTION
* カコデーモンのトゲ（角）の本数を間違っていたのと"spike"(トゲ)ではなく"horn"(角)だったため日英双方そちらに合わせて修正しました。また、とても丸っこいは"very round"よりも"spherical"の方が直接的なのでそっちに修正いたしました
* アラクノトロンは脳みそのようなやつが本体なのでそう捉えられるように訂正しました