### PR TITLE
[Feature] クエスト「塔」のバランス調整

### DIFF
--- a/lib/edit/q0000005.txt
+++ b/lib/edit/q0000005.txt
@@ -54,25 +54,25 @@ F:<:QUEST_UP:8:0:0:0:0:NONE:6
 # Quest down
 F:>:QUEST_DOWN:8
 
-# Random Monsters
-F:1:FLOOR:8:*
-
 # Nexious fume
-F:2:FLOOR:8:884
+F:#:FLOOR:8:884
 
-# Young green dragon
-F:d:FLOOR:8:461
+# Young green dragon with Object 10 levels out of depth
+F:d:FLOOR:8:461:*10
+
+# Shrieker
+F:@:FLOOR:8:40
 
 # Dungeon
 D:XXXXXXXXXXX
-D:X>.....1..X
-D:XXXXXXXXX.X
+D:X>.....d..X
+D:XXXXXXXXX@X
 D:X.....d.X.X
 D:X.XXXXX.X.X
-D:X1X<XXX.X2X
+D:XdX<XXX.X#X
 D:X.X.....X.X
 D:X.XXXXXXX.X
-D:X.....1...X
+D:X..#....@.X
 D:XXXXXXXXXXX
 
 # Starting position when coming from town

--- a/lib/edit/q0000006.txt
+++ b/lib/edit/q0000006.txt
@@ -8,14 +8,14 @@ Q:6:N:塔
 Q:$6:Q:8:0:0:0:40:0:0:0:11
 Q:6:Q:8:0:0:0:40:0:0:0:11
 
-# Random Monsters Levels +10
-F:1:FLOOR:8:*10
-
 # Nexious fume
-F:2:FLOOR:8:884
+F:#:FLOOR:8:884
 
-# Mature green dragon
-F:d:FLOOR:8:561
+# Mature green dragon with Object 10 levels out of depth
+F:d:FLOOR:8:561:*10
+
+# Shrieker
+F:@:FLOOR:8:40
 
 
 # Quest down to Town
@@ -26,13 +26,13 @@ F:<:QUEST_UP:8:0:0:0:0:NONE:7
 
 # Dungeon
 D:XXXXXXXXX
-D:X.1.....X
+D:X..@.#..X
 D:X.XXXXX.X
-D:X.X..1XdX
+D:X.X..dX@X
 D:X.X.X.X.X
-D:X1X>X.X.X
+D:XdX>X.XdX
 D:X.XXX.X.X
-D:X.2...X<X
+D:X.#.@.X<X
 D:XXXXXXXXX
 
 # Starting position when coming from level 1 of the tower (quest 5)

--- a/lib/edit/q0000007.txt
+++ b/lib/edit/q0000007.txt
@@ -12,13 +12,13 @@ Q:7:Q:8:0:0:0:40:0:0:0:11
 F:@:FLOOR:8:40
 
 # Nexious fume
-F:2:FLOOR:8:884
+F:#:FLOOR:8:884
 
-# Mature green dragon
-F:d:FLOOR:8:561
+# Mature green dragon with Object 10 levels out of depth
+F:d:FLOOR:8:561:*10
 
-# Ancient green dragon
-F:D:FLOOR:8:618
+# Ancient green dragon with Object 10 levels out of depth
+F:D:FLOOR:8:618:*10
 
 
 # Quest stairs down to Town
@@ -26,9 +26,9 @@ F:>:QUEST_DOWN:8
 
 # Dungeon
 D:XXXXXXXXX
-D:XD.2...@X
+D:XD.#...@X
 D:X.......X
-D:X.2...d.X
+D:X.#...d.X
 D:X@...d.@X
 D:X...d...X
 D:X..d....X


### PR DESCRIPTION
Issue #2006 の件。3.0alpha以降の調整で機能不全となっている旧来のクエストを修正する。

クエスト「塔」のランダム配置モンスターを撤去し、固定モンスターを配置する。
また、若干のアイテムを配置して追加の報酬とする。

3.0alpha以降のモンスターの追加・再配置によりランダム配置で実装当初よりも強力なモンスターが出現するようになったことへの対応。
また、全体的にアイテム生成が良くなったことでクエスト報酬の耐毒の指輪の価値が相対的に下がっている。アイテム生成を増やすことでクエストを受注する価値を高める。