### PR TITLE
[Fix] GCU版で画面描画中にカーソルがちらつく

### DIFF
--- a/src/main-gcu.cpp
+++ b/src/main-gcu.cpp
@@ -895,14 +895,10 @@ static errr Term_xtra_gcu(int n, int v)
         (void)wrefresh(td->win);
         return (0);
 
-#ifdef USE_CURS_SET
-
     /* Change the cursor visibility */
     case TERM_XTRA_SHAPE:
         curs_set(v);
         return (0);
-
-#endif
 
     /* Suspend/Resume curses */
     case TERM_XTRA_ALIVE:

--- a/src/term/z-term.cpp
+++ b/src/term/z-term.cpp
@@ -1106,13 +1106,9 @@ errr term_fresh(void)
         }
     }
 
-    /* Cursor Update -- Erase old Cursor */
+    /* Hide the hardware cursor while drawing */
     else {
-        /* Cursor will be invisible */
-        if (scr->cu || !scr->cv) {
-            /* Make the cursor invisible */
-            term_xtra(TERM_XTRA_SHAPE, 0);
-        }
+        term_xtra(TERM_XTRA_SHAPE, 0);
     }
 
     /* Something to update */
@@ -1192,31 +1188,12 @@ errr term_fresh(void)
 
     /* Cursor Update -- Show new Cursor */
     else {
-        /* The cursor is useless, hide it */
         if (scr->cu) {
             /* Paranoia -- Put the cursor NEAR where it belongs */
             (void)((*Term->curs_hook)(w - 1, scr->cy));
-
-            /* Make the cursor invisible */
-            /* term_xtra(TERM_XTRA_SHAPE, 0); */
-        }
-
-        /* The cursor is invisible, hide it */
-        else if (!scr->cv) {
-            /* Paranoia -- Put the cursor where it belongs */
-            (void)((*Term->curs_hook)(scr->cx, scr->cy));
-
-            /* Make the cursor invisible */
-            /* term_xtra(TERM_XTRA_SHAPE, 0); */
-        }
-
-        /* The cursor is visible, display it correctly */
-        else {
+        } else {
             /* Put the cursor where it belongs */
             (void)((*Term->curs_hook)(scr->cx, scr->cy));
-
-            /* Make the cursor visible */
-            term_xtra(TERM_XTRA_SHAPE, 1);
         }
     }
 
@@ -1228,6 +1205,12 @@ errr term_fresh(void)
 
     /* Actually flush the output */
     term_xtra(TERM_XTRA_FRESH, 0);
+
+    if (!Term->soft_cursor && !scr->cu && scr->cv) {
+        /* The cursor is visible, display it correctly */
+        term_xtra(TERM_XTRA_SHAPE, 1);
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
z-term.cpp で端末のハードウェアカーソルの描画のON/OFFを切り替える TERM_XTRA_SHAPE
を引数とした term_xtra() 関数の呼び出しがあるが、main-gcu.cpp でその対応部分が
#ifdef USE_CURS_SET ～ #endif で囲まれており、USE_CURS_SET は ./configure 等
でも #define される事は無いため、現状有効になることはない。そのため描画中の箇所にカー
ソルがちらついて見えることがある。
試しにこの部分を有効にしたところ想定どおり描画中のカーソル表示は消え、ちらつきがおこら
なくなった。
cursesの curs_set() 関数が使えない環境は無いと思うのでプリプロセッサを削除し常にカー
ソルの描画の切り替えが有効になるようにする。