### PR TITLE
バリアント名をセーブデータに含めた

### DIFF
--- a/src/core/scores.cpp
+++ b/src/core/scores.cpp
@@ -181,7 +181,7 @@ errr top_twenty(PlayerType *current_player_ptr)
     char buf[32];
 
     /* Save the version */
-    sprintf(the_score.what, "%u.%u.%u", FAKE_VER_MAJOR, FAKE_VER_MINOR, FAKE_VER_PATCH);
+    sprintf(the_score.what, "%u.%u.%u", H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH);
 
     /* Calculate and save the points */
     sprintf(the_score.pts, "%9ld", (long)calc_score(current_player_ptr));
@@ -289,7 +289,7 @@ errr predict_score(PlayerType *current_player_ptr)
     }
 
     /* Save the version */
-    sprintf(the_score.what, "%u.%u.%u", FAKE_VER_MAJOR, FAKE_VER_MINOR, FAKE_VER_PATCH);
+    sprintf(the_score.what, "%u.%u.%u", H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH);
 
     /* Calculate and save the points */
     sprintf(the_score.pts, "%9ld", (long)calc_score(current_player_ptr));

--- a/src/core/show-file.cpp
+++ b/src/core/show-file.cpp
@@ -301,7 +301,7 @@ bool show_file(PlayerType *player_ptr, bool show_version, concptr name, concptr 
             continue;
         }
 
-        prt(format(_("[変愚蛮怒 %d.%d.%d, %s, %d/%d]", "[Hengband %d.%d.%d, %s, Line %d/%d]"), FAKE_VER_MAJOR - 10, FAKE_VER_MINOR, FAKE_VER_PATCH, caption,
+        prt(format(_("[変愚蛮怒 %d.%d.%d, %s, %d/%d]", "[Hengband %d.%d.%d, %s, Line %d/%d]"), H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH, caption,
                 line, size),
             0, 0);
 

--- a/src/io/report.cpp
+++ b/src/io/report.cpp
@@ -194,7 +194,7 @@ static bool http_post(concptr url, BUF *buf)
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, slist);
 
     char user_agent[64];
-    snprintf(user_agent, sizeof(user_agent), "Hengband %d.%d.%d", FAKE_VER_MAJOR - 10, FAKE_VER_MINOR, FAKE_VER_PATCH);
+    snprintf(user_agent, sizeof(user_agent), "Hengband %d.%d.%d", H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, user_agent);
 
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);

--- a/src/load/info-loader.cpp
+++ b/src/load/info-loader.cpp
@@ -16,18 +16,37 @@
  */
 void rd_version_info(void)
 {
-    byte fake_major = rd_byte();
+    auto tmp_major = rd_byte();
+    auto is_old_ver = (10 <= tmp_major) && (tmp_major <= 13);
+    if (tmp_major == 8) {
+        // strip_byte() だと自動ローテーションされるので手動スキップ.
+        for (auto i = 0; i < 8; i++) {
+            load_xor_byte = 0;
+            (void)rd_byte();
+        }
 
-    strip_bytes(3);
+        load_xor_byte = 0;
+        w_ptr->h_ver_major = rd_byte();
+        w_ptr->h_ver_minor = rd_byte();
+        w_ptr->h_ver_patch = rd_byte();
+        w_ptr->h_ver_extra = rd_byte();
+    } else if (is_old_ver) {
+        strip_bytes(3);
+    } else {
+        throw("Invalid version is detected!");
+    }
+
     load_xor_byte = w_ptr->sf_extra;
     v_check = 0L;
     x_check = 0L;
 
-    /* Old savefile will be version 0.0.0.3 */
-    w_ptr->h_ver_extra = rd_byte();
-    w_ptr->h_ver_patch = rd_byte();
-    w_ptr->h_ver_minor = rd_byte();
-    w_ptr->h_ver_major = rd_byte();
+    if (is_old_ver) {
+        /* Old savefile will be version 0.0.0.3 */
+        w_ptr->h_ver_extra = rd_byte();
+        w_ptr->h_ver_patch = rd_byte();
+        w_ptr->h_ver_minor = rd_byte();
+        w_ptr->h_ver_major = rd_byte();
+    }
 
     w_ptr->sf_system = rd_u32b();
     w_ptr->sf_when = rd_u32b();
@@ -37,8 +56,12 @@ void rd_version_info(void)
     loading_savefile_version = rd_u32b();
 
     /* h_ver_majorがfake_ver_majorと同じだったころへの対策 */
-    if (fake_major - w_ptr->h_ver_major < FAKE_VER_PLUS)
-        w_ptr->h_ver_major -= FAKE_VER_PLUS;
+    if (loading_savefile_version_is_older_than(10)) {
+        constexpr auto fake_ver_plus = 10;
+        if (tmp_major - w_ptr->h_ver_major < fake_ver_plus) {
+            w_ptr->h_ver_major -= fake_ver_plus;
+        }
+    }
 
     load_note(format(_("バージョン %d.%d.%d のセーブデータ(SAVE%lu形式)をロード中...", "Loading a Verison %d.%d.%d savefile (SAVE%lu format)..."),
         w_ptr->h_ver_major, w_ptr->h_ver_minor, w_ptr->h_ver_patch,

--- a/src/load/info-loader.cpp
+++ b/src/load/info-loader.cpp
@@ -19,17 +19,13 @@ void rd_version_info(void)
     auto tmp_major = rd_byte();
     auto is_old_ver = (10 <= tmp_major) && (tmp_major <= 13);
     if (tmp_major == 8) {
-        // strip_byte() だと自動ローテーションされるので手動スキップ.
-        for (auto i = 0; i < 8; i++) {
-            load_xor_byte = 0;
-            (void)rd_byte();
-        }
-
+        strip_bytes(8);
         load_xor_byte = 0;
         w_ptr->h_ver_major = rd_byte();
         w_ptr->h_ver_minor = rd_byte();
         w_ptr->h_ver_patch = rd_byte();
         w_ptr->h_ver_extra = rd_byte();
+        strip_bytes(1);
     } else if (is_old_ver) {
         strip_bytes(3);
     } else {

--- a/src/load/info-loader.cpp
+++ b/src/load/info-loader.cpp
@@ -18,8 +18,9 @@ void rd_version_info(void)
 {
     auto tmp_major = rd_byte();
     auto is_old_ver = (10 <= tmp_major) && (tmp_major <= 13);
-    if (tmp_major == 8) {
-        strip_bytes(8);
+    auto variant_length = VARIANT_NAME.length();
+    if (tmp_major == variant_length) {
+        strip_bytes(variant_length);
         load_xor_byte = 0;
         w_ptr->h_ver_major = rd_byte();
         w_ptr->h_ver_minor = rd_byte();

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -46,6 +46,8 @@
 #include "util/enum-converter.h"
 #include "view/display-messages.h"
 #include "world/world.h"
+#include <sstream>
+#include <string>
 
 /*!
  * @brief 変愚蛮怒 v2.1.3で追加された街とクエストについて読み込む
@@ -305,7 +307,7 @@ bool load_savedata(PlayerType *player_ptr, bool *new_game)
 
     bool err = false;
     int fd = -1;
-    char tmp_ver[13]{};
+    char tmp_ver[14]{};
     if (!err) {
         fd = fd_open(savefile, O_RDONLY);
         if (fd < 0)
@@ -316,7 +318,7 @@ bool load_savedata(PlayerType *player_ptr, bool *new_game)
     }
 
     if (!err) {
-        if (fd_read(fd, (char *)(tmp_ver), 13)) {
+        if (fd_read(fd, (char *)(tmp_ver), 14)) {
             err = true;
         }
 

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -341,7 +341,7 @@ bool load_savedata(PlayerType *player_ptr, bool *new_game)
     }
 
     if (!err) {
-        if (fd_read(fd, (char *)(tmp_ver), 14)) {
+        if (fd_read(fd, tmp_ver, 14)) {
             err = true;
         }
 
@@ -354,13 +354,7 @@ bool load_savedata(PlayerType *player_ptr, bool *new_game)
         auto tmp_major = tmp_ver[0];
         auto is_old_ver = (10 <= tmp_major) && (tmp_major <= 13);
         if (tmp_major == 8) {
-            std::string variant_name(VERSION_NAME);
-            std::stringstream current_variant;
-            for (auto i = 1; i < 9; i++) {
-                current_variant << tmp_ver[i];
-            }
-
-            if (current_variant.str() != variant_name) {
+            if (std::string_view(&tmp_ver[1], 8) != VARIANT_NAME) {
                 throw(_("セーブデータのバリアントは変愚蛮怒以外です", "The variant of save data is other than Hengband!"));
             }
 

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -56,18 +56,21 @@
  */
 static errr load_town_quest(PlayerType *player_ptr)
 {
-    if (h_older_than(2, 1, 3))
+    if (h_older_than(2, 1, 3)) {
         return 0;
+    }
 
-    errr load_town_result = load_town();
-    if (load_town_result != 0)
+    auto load_town_result = load_town();
+    if (load_town_result != 0) {
         return load_town_result;
-
+    }
+    
     uint16_t max_quests_load;
     byte max_rquests_load;
-    errr load_quest_result = load_quest_info(&max_quests_load, &max_rquests_load);
-    if (load_quest_result != 0)
+    auto load_quest_result = load_quest_info(&max_quests_load, &max_rquests_load);
+    if (load_quest_result != 0) {
         return load_quest_result;
+    }
 
     analyze_quests(player_ptr, max_quests_load, max_rquests_load);
 
@@ -86,9 +89,10 @@ static errr load_town_quest(PlayerType *player_ptr)
  */
 static void rd_total_play_time()
 {
-    if (loading_savefile_version_is_older_than(4))
+    if (loading_savefile_version_is_older_than(4)) {
         return;
-
+    }
+    
     w_ptr->sf_play_time = rd_u32b();
 }
 
@@ -97,8 +101,9 @@ static void rd_total_play_time()
  */
 static void rd_winner_class()
 {
-    if (loading_savefile_version_is_older_than(4))
+    if (loading_savefile_version_is_older_than(4)) {
         return;
+    }
 
     rd_FlagGroup(w_ptr->sf_winner, rd_byte);
     rd_FlagGroup(w_ptr->sf_retired, rd_byte);
@@ -116,8 +121,9 @@ static void load_player_world(PlayerType *player_ptr)
     rd_global_configurations(player_ptr);
     rd_extra(player_ptr);
 
-    if (player_ptr->energy_need < -999)
+    if (player_ptr->energy_need < -999) {
         player_ptr->timewalk = true;
+    }
 
     load_note(_("特別情報をロードしました", "Loaded extra information"));
 }
@@ -130,7 +136,7 @@ static errr load_hp(PlayerType *player_ptr)
         return 25;
     }
 
-    for (int i = 0; i < tmp16u; i++) {
+    for (auto i = 0; i < tmp16u; i++) {
         player_ptr->player_hp[i] = rd_s16b();
     }
 
@@ -145,23 +151,25 @@ static void load_spells(PlayerType *player_ptr)
     player_ptr->spell_worked2 = rd_u32b();
     player_ptr->spell_forgotten1 = rd_u32b();
     player_ptr->spell_forgotten2 = rd_u32b();
-
-    if (h_older_than(0, 0, 5))
+    if (h_older_than(0, 0, 5)) {
         set_zangband_learnt_spells(player_ptr);
-    else
+    } else {
         player_ptr->learned_spells = rd_s16b();
+    }
 
-    if (h_older_than(0, 0, 6))
+    if (h_older_than(0, 0, 6)) {
         player_ptr->add_spells = 0;
-    else
+    } else {
         player_ptr->add_spells = rd_s16b();
+    }
 }
 
 static errr verify_checksum()
 {
     auto n_v_check = v_check;
-    if (rd_u32b() == n_v_check)
+    if (rd_u32b() == n_v_check) {
         return 0;
+    }
 
     load_note(_("チェックサムがおかしい", "Invalid checksum"));
     return 11;
@@ -170,8 +178,9 @@ static errr verify_checksum()
 static errr verify_encoded_checksum()
 {
     auto n_x_check = x_check;
-    if (rd_u32b() == n_x_check)
+    if (rd_u32b() == n_x_check) {
         return 0;
+    }
 
     load_note(_("エンコードされたチェックサムがおかしい", "Invalid encoded checksum"));
     return 11;
@@ -189,16 +198,18 @@ static errr exe_reading_savefile(PlayerType *player_ptr)
     load_lore();
     auto item_loader = ItemLoaderFactory::create_loader();
     item_loader->load_item();
-    errr load_town_quest_result = load_town_quest(player_ptr);
-    if (load_town_quest_result != 0)
+    auto load_town_quest_result = load_town_quest(player_ptr);
+    if (load_town_quest_result != 0) {
         return load_town_quest_result;
+    }
 
     load_note(_("クエスト情報をロードしました", "Loaded Quests"));
     item_loader->load_artifact();
     load_player_world(player_ptr);
-    errr load_hp_result = load_hp(player_ptr);
-    if (load_hp_result != 0)
+    auto load_hp_result = load_hp(player_ptr);
+    if (load_hp_result != 0) {
         return load_hp_result;
+    }
 
     auto short_pclass = enum2i(player_ptr->pclass);
     sp_ptr = &sex_info[player_ptr->psex];
@@ -210,37 +221,44 @@ static errr exe_reading_savefile(PlayerType *player_ptr)
     mp_ptr = &m_info[short_pclass];
 
     load_spells(player_ptr);
-    if (player_ptr->pclass == PlayerClassType::MINDCRAFTER)
+    if (player_ptr->pclass == PlayerClassType::MINDCRAFTER) {
         player_ptr->add_spells = 0;
+    }
 
-    errr load_inventory_result = load_inventory(player_ptr);
-    if (load_inventory_result != 0)
+    auto load_inventory_result = load_inventory(player_ptr);
+    if (load_inventory_result != 0) {
         return load_inventory_result;
+    }
 
     load_store(player_ptr);
     player_ptr->pet_follow_distance = rd_s16b();
-    if (h_older_than(0, 4, 10))
+    if (h_older_than(0, 4, 10)) {
         set_zangband_pet(player_ptr);
-    else
+    } else {
         player_ptr->pet_extra_flags = rd_u16b();
+    }
 
     if (!h_older_than(1, 0, 9)) {
         std::vector<char> buf(SCREEN_BUF_MAX_SIZE);
         rd_string(buf.data(), SCREEN_BUF_MAX_SIZE);
-        if (buf[0])
+        if (buf[0]) {
             screen_dump = string_make(buf.data());
+        }
     }
 
-    errr restore_dungeon_result = restore_dungeon(player_ptr);
-    if (restore_dungeon_result != 0)
+    auto restore_dungeon_result = restore_dungeon(player_ptr);
+    if (restore_dungeon_result != 0) {
         return restore_dungeon_result;
+    }
 
-    if (h_older_than(1, 7, 0, 6))
+    if (h_older_than(1, 7, 0, 6)) {
         remove_water_cave(player_ptr);
+    }
 
-    errr checksum_result = verify_checksum();
-    if (checksum_result != 0)
+    auto checksum_result = verify_checksum();
+    if (checksum_result != 0) {
         return checksum_result;
+    }
 
     return verify_encoded_checksum();
 }
@@ -255,12 +273,14 @@ static errr rd_savefile(PlayerType *player_ptr)
     safe_setuid_grab(player_ptr);
     loading_savefile = angband_fopen(savefile, "rb");
     safe_setuid_drop();
-    if (!loading_savefile)
+    if (!loading_savefile) {
         return -1;
+    }
 
     errr err = exe_reading_savefile(player_ptr);
-    if (ferror(loading_savefile))
+    if (ferror(loading_savefile)) {
         err = -1;
+    }
 
     angband_fclose(loading_savefile);
     return err;
@@ -290,11 +310,12 @@ static bool can_takeover_savefile(const PlayerType *player_ptr)
  */
 bool load_savedata(PlayerType *player_ptr, bool *new_game)
 {
-    concptr what = "generic";
+    auto what = "generic";
     w_ptr->game_turn = 0;
     player_ptr->is_dead = false;
-    if (!savefile[0])
+    if (!savefile[0]) {
         return true;
+    }
 
 #ifndef WINDOWS
     if (access(savefile, 0) < 0) {
@@ -305,16 +326,18 @@ bool load_savedata(PlayerType *player_ptr, bool *new_game)
     }
 #endif
 
-    bool err = false;
-    int fd = -1;
+    auto err = false;
+    auto fd = -1;
     char tmp_ver[14]{};
     if (!err) {
         fd = fd_open(savefile, O_RDONLY);
-        if (fd < 0)
+        if (fd < 0) {
             err = true;
+        }
 
-        if (err)
+        if (err) {
             what = _("セーブファイルを開けません", "Cannot open savefile");
+        }
     }
 
     if (!err) {
@@ -360,24 +383,28 @@ bool load_savedata(PlayerType *player_ptr, bool *new_game)
 
     if (!err) {
         term_clear();
-        if (rd_savefile(player_ptr))
+        if (rd_savefile(player_ptr)) {
             err = true;
-        if (err)
+        }
+
+        if (err) {
             what = _("セーブファイルを解析出来ません。", "Cannot parse savefile");
+        }
     }
 
     if (!err) {
-        if (!w_ptr->game_turn)
+        if (!w_ptr->game_turn) {
             err = true;
+        }
 
-        if (err)
+        if (err) {
             what = _("セーブファイルが壊れています", "Broken savefile");
+        }
     }
 
     if (err) {
         msg_format(_("エラー(%s)がバージョン%d.%d.%d.%d 用セーブファイル読み込み中に発生。", "Error (%s) reading %d.%d.%d.% savefile."), what,
             w_ptr->h_ver_major, w_ptr->h_ver_minor, w_ptr->h_ver_patch, w_ptr->h_ver_extra);
-
         msg_print(nullptr);
         return false;
     }
@@ -391,6 +418,7 @@ bool load_savedata(PlayerType *player_ptr, bool *new_game)
             msg_print(nullptr);
             return false;
         }
+
         player_ptr->is_dead = true;
         player_ptr->wait_report_score = false;
     }
@@ -403,12 +431,13 @@ bool load_savedata(PlayerType *player_ptr, bool *new_game)
     }
 
     w_ptr->character_loaded = true;
-    uint32_t tmp = counts_read(player_ptr, 2);
+    auto tmp = counts_read(player_ptr, 2);
     if (tmp > player_ptr->count)
         player_ptr->count = tmp;
 
-    if (counts_read(player_ptr, 0) > w_ptr->play_time || counts_read(player_ptr, 1) == w_ptr->play_time)
+    if (counts_read(player_ptr, 0) > w_ptr->play_time || counts_read(player_ptr, 1) == w_ptr->play_time) {
         counts_write(player_ptr, 2, ++player_ptr->count);
+    }
 
     counts_write(player_ptr, 1, w_ptr->play_time);
     return true;

--- a/src/main-win/main-win-utils.cpp
+++ b/src/main-win/main-win-utils.cpp
@@ -17,17 +17,14 @@
  * 特定の名前のミューテックスオブジェクトの所有権取得を試みる。
  * 取得できない場合は他に変愚蛮怒のプロセスが起動しているとみなす。
  * 取得したミューテックスのハンドルは明示的な解放は行わず、プロセス終了時にOSが解放する。
- * @retval true 他に変愚蛮怒のプロセスが起動している
- * @retval false 他に変愚蛮怒のプロセスは起動していない
+ * @return 起動済の変愚蛮怒プロセス有無
  */
 bool is_already_running(void)
 {
-    [[maybe_unused]] HANDLE hMutex = CreateMutexW(NULL, TRUE, L"" VERSION_NAME);
-    if (GetLastError() == ERROR_ALREADY_EXISTS) {
-        return true;
-    }
-
-    return false;
+    wchar_t wtext[32];
+    mbstowcs(wtext, VERSION_NAME.data(), VERSION_NAME.length());
+    [[maybe_unused]] HANDLE hMutex = CreateMutexW(NULL, TRUE, wtext);
+    return GetLastError() == ERROR_ALREADY_EXISTS;
 }
 
 /*!

--- a/src/main-win/main-win-utils.cpp
+++ b/src/main-win/main-win-utils.cpp
@@ -22,7 +22,7 @@
 bool is_already_running(void)
 {
     wchar_t wtext[32];
-    mbstowcs(wtext, VERSION_NAME.data(), VERSION_NAME.length());
+    mbstowcs(wtext, VARIANT_NAME.data(), VARIANT_NAME.length());
     [[maybe_unused]] HANDLE hMutex = CreateMutexW(NULL, TRUE, wtext);
     return GetLastError() == ERROR_ALREADY_EXISTS;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,7 +89,7 @@ static void create_user_dir(void)
     mkdir(dirpath, 0700);
 
     /* Build the path to the variant-specific sub-directory */
-    path_build(subdirpath, sizeof(subdirpath), dirpath, VERSION_NAME.data());
+    path_build(subdirpath, sizeof(subdirpath), dirpath, VARIANT_NAME.data());
 
     /* Create the directory */
     mkdir(subdirpath, 0700);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,7 @@
 #include "util/string-processor.h"
 #include "view/display-scores.h"
 #include "wizard/wizard-spoiler.h"
+#include <string>
 
 /*
  * Available graphic modes
@@ -88,7 +89,7 @@ static void create_user_dir(void)
     mkdir(dirpath, 0700);
 
     /* Build the path to the variant-specific sub-directory */
-    path_build(subdirpath, sizeof(subdirpath), dirpath, VERSION_NAME);
+    path_build(subdirpath, sizeof(subdirpath), dirpath, VERSION_NAME.data());
 
     /* Create the directory */
     mkdir(subdirpath, 0700);

--- a/src/main/angband-initializer.cpp
+++ b/src/main/angband-initializer.cpp
@@ -90,7 +90,7 @@ void init_file_paths(char *libpath, char *varpath)
     path_build(buf, sizeof(buf), ANGBAND_DIR_SAVE, "log");
     ANGBAND_DIR_DEBUG_SAVE = string_make(buf);
 #ifdef PRIVATE_USER_PATH
-    path_build(buf, sizeof(buf), PRIVATE_USER_PATH, VERSION_NAME.data());
+    path_build(buf, sizeof(buf), PRIVATE_USER_PATH, VARIANT_NAME.data());
     ANGBAND_DIR_USER = string_make(buf);
 #else
     strcpy(vartail, "user");

--- a/src/main/angband-initializer.cpp
+++ b/src/main/angband-initializer.cpp
@@ -36,6 +36,9 @@
 #include <dirent.h>
 #include "util/string-processor.h"
 #endif
+#ifdef PRIVATE_USER_PATH
+#include <string>
+#endif
 
 /*!
  * @brief 各データファイルを読み取るためのパスを取得する
@@ -87,7 +90,7 @@ void init_file_paths(char *libpath, char *varpath)
     path_build(buf, sizeof(buf), ANGBAND_DIR_SAVE, "log");
     ANGBAND_DIR_DEBUG_SAVE = string_make(buf);
 #ifdef PRIVATE_USER_PATH
-    path_build(buf, sizeof(buf), PRIVATE_USER_PATH, VERSION_NAME);
+    path_build(buf, sizeof(buf), PRIVATE_USER_PATH, VERSION_NAME.data());
     ANGBAND_DIR_USER = string_make(buf);
 #else
     strcpy(vartail, "user");

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -57,23 +57,27 @@ static bool wr_savefile_new(PlayerType *player_ptr, save_type type)
     w_ptr->sf_system = 0L;
     w_ptr->sf_when = now;
     w_ptr->sf_saves++;
+
+    std::string tmp_variant(VERSION_NAME);
     save_xor_byte = 0;
-    wr_byte(FAKE_VER_MAJOR);
+    wr_byte(static_cast<byte>(tmp_variant.length()));
+    for (auto i = 0; i < 8; i++) {
+        auto variant_name = tmp_variant.c_str();
+        save_xor_byte = 0;
+        wr_byte(variant_name[i]);
+    }
+
     save_xor_byte = 0;
-    wr_byte(FAKE_VER_MINOR);
-    save_xor_byte = 0;
-    wr_byte(FAKE_VER_PATCH);
-    save_xor_byte = 0;
+    wr_byte(H_VER_MAJOR);
+    wr_byte(H_VER_MINOR);
+    wr_byte(H_VER_PATCH);
+    wr_byte(H_VER_EXTRA);
 
     byte tmp8u = (byte)Rand_external(256);
     wr_byte(tmp8u);
     v_stamp = 0L;
     x_stamp = 0L;
-
-    wr_byte(H_VER_EXTRA);
-    wr_byte(H_VER_PATCH);
-    wr_byte(H_VER_MINOR);
-    wr_byte(H_VER_MAJOR);
+ 
     wr_u32b(w_ptr->sf_system);
     wr_u32b(w_ptr->sf_when);
     wr_u16b(w_ptr->sf_lives);

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -58,13 +58,12 @@ static bool wr_savefile_new(PlayerType *player_ptr, save_type type)
     w_ptr->sf_when = now;
     w_ptr->sf_saves++;
 
-    std::string tmp_variant(VERSION_NAME);
     save_xor_byte = 0;
-    wr_byte(static_cast<byte>(tmp_variant.length()));
-    for (auto i = 0; i < 8; i++) {
-        auto variant_name = tmp_variant.c_str();
+    auto variant_length = VARIANT_NAME.length();
+    wr_byte(static_cast<byte>(variant_length));
+    for (auto i = 0U; i < variant_length; i++) {
         save_xor_byte = 0;
-        wr_byte(variant_name[i]);
+        wr_byte(VARIANT_NAME[i]);
     }
 
     save_xor_byte = 0;

--- a/src/system/angband-version.cpp
+++ b/src/system/angband-version.cpp
@@ -3,8 +3,26 @@
 
 void put_version(char *buf)
 {
-    if (IS_ALPHA_VERSION) {
-        sprintf(buf, _("変愚蛮怒 %d.%d.%dAlpha%d", "Hengband %d.%d.%dAlpha%d"), H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH, H_VER_EXTRA);
+    std::string_view expr;
+    switch (VERSION_STATUS) {
+    case VersionStatusType::ALPHA:
+        expr = "Alpha";
+        break;
+    case VersionStatusType::BETA:
+        expr = "Beta";
+        break;
+    case VersionStatusType::RELEASE_CANDIDATE:
+        expr = "RC";
+        break;
+    case VersionStatusType::RELEASE:
+        expr = "";
+        break;
+    default:
+        throw("Invalid version status was specified!");
+    }
+
+    if (VERSION_STATUS != VersionStatusType::RELEASE) {
+        sprintf(buf, _("変愚蛮怒 %d.%d.%d%s%d", "Hengband %d.%d.%d%s%d"), H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH, expr.data(), H_VER_EXTRA);
     } else {
         concptr mode = IS_STABLE_VERSION ? _("安定版", "Stable") : _("開発版", "Developing");
         sprintf(buf, _("変愚蛮怒 %d.%d.%d.%d(%s)", "Hengband %d.%d.%d.%d(%s)"), H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH, H_VER_EXTRA, mode);

--- a/src/system/angband-version.h
+++ b/src/system/angband-version.h
@@ -1,18 +1,13 @@
 ﻿#pragma once
 
 #include <stdint.h>
+#include <string>
 
-#define VERSION_NAME "Hengband" /*!< バリアント名称 / Name of the version/variant */
+constexpr std::string_view VERSION_NAME("Hengband"); /*!< バリアント名称 / Name of the version/variant */
 
 /*!
- * @brief セーブファイル上のバージョン定義(メジャー番号) / "Savefile Version Number" for Hengband 1.1.1 and later
- * @details
- * 当面FAKE_VER_*を参照しておく。
- * <pre>
- * Program Version of Hengband version is
- *   "(H_VER_MAJOR).(H_VER_MINOR).(H_VER_PATCH).(H_VER_EXTRA)".
- * Upper compatibility is always guaranteed when it is more than 1.0.0 .
- * </pre>
+ * @brief セーブファイル上のバージョン定義 / "Savefile Version Number" for Hengband
+ * @details v1.1.1以上にのみ適用
  */
 #define H_VER_MAJOR  3 //!< ゲームのバージョン定義(メジャー番号)
 #define H_VER_MINOR  0 //!< ゲームのバージョン定義(マイナー番号)
@@ -27,12 +22,18 @@ constexpr uint32_t SAVEFILE_VERSION = 10;
 /*!
  * @brief バージョンが開発版が安定版かを返す(廃止予定)
  */
-#define IS_STABLE_VERSION (H_VER_MINOR % 2 == 0 && H_VER_EXTRA == 0)
+constexpr bool IS_STABLE_VERSION = (H_VER_MINOR % 2 == 0 && H_VER_EXTRA == 0);
+
+enum class VersionStatusType {
+	ALPHA,
+	BETA,
+	RELEASE_CANDIDATE,
+	RELEASE,
+};
 
 /*!
- * @brief 状態がアルファ版かどうかを返す
- * @note アルファ版はエクストラ番号一定値までをアルファとし、一定まで進めて安定次第ベータ版、さらにそれも解除して無印版とする。
+ * @brief バージョンの立ち位置
  */
-#define IS_ALPHA_VERSION 1
+constexpr VersionStatusType VERSION_STATUS = VersionStatusType::ALPHA;
 
 void put_version(char *buf);

--- a/src/system/angband-version.h
+++ b/src/system/angband-version.h
@@ -35,18 +35,4 @@ constexpr uint32_t SAVEFILE_VERSION = 10;
  */
 #define IS_ALPHA_VERSION 1
 
-/*!
- * @brief ゲームのバージョン番号定義 / "Program Version Number" of the game
- * @details
- * 本FAKE_VERSIONそのものは未使用である。Zangと整合性を合わせるための疑似的処理のためFAKE_VER_MAJORは実値-10が該当のバージョン番号となる。
- * <pre>
- * FAKE_VER_MAJOR=1,2 were reserved for ZAngband version 1.x.x/2.x.x .
- * </pre>
- */
-#define FAKE_VER_PLUS 10 //!< 偽バージョン番号としていくつ足すか
-#define FAKE_VER_MAJOR (H_VER_MAJOR + FAKE_VER_PLUS) //!< 偽バージョン番号定義(メジャー番号) */
-#define FAKE_VER_MINOR H_VER_MINOR //!< 偽バージョン番号定義(マイナー番号) */
-#define FAKE_VER_PATCH H_VER_PATCH //!< 偽バージョン番号定義(パッチ番号) */
-#define FAKE_VER_EXTRA H_VER_EXTRA //!< 偽バージョン番号定義(エクストラ番号) */
-
 void put_version(char *buf);

--- a/src/system/angband-version.h
+++ b/src/system/angband-version.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <string>
 
-constexpr std::string_view VERSION_NAME("Hengband"); /*!< バリアント名称 / Name of the version/variant */
+constexpr std::string_view VARIANT_NAME("Hengband");
 
 /*!
  * @brief セーブファイル上のバージョン定義 / "Savefile Version Number" for Hengband


### PR DESCRIPTION
#1743 の実装案ですが、これを実行するとセーブデータが破損します
具体的には以下の流れを踏みます：

1. セーブデータの書き込みは正常に完了するように見える (save.cpp)
2. セーブデータの読み込みに関して、バリアント部は正常に読み込めている (load.cpp)
3. しかし、rd\_version\_info() でw\_ptr->sf\_systemを読み込む辺りでXORのローテーションが壊れている (sf\_savesはセーブした回数なので、デバッグ用のセーブデータだと精々数回のはずだが、1000を超えた値で読み込まれる)
4. その手前、load\_xor\_byte = w\_ptr->sf\_extra; は、developブランチだと右辺と左辺が同値なので行が存在している意味がないのだが、このfeatureブランチだと異なる値になっている

どこがおかしそうか、お手数ですが確認頂けると助かります