### PR TITLE
種族や職業に依存する割引が動作していない事象を修正した

### DIFF
--- a/src/info-reader/general-parser.cpp
+++ b/src/info-reader/general-parser.cpp
@@ -232,8 +232,8 @@ parse_error_type parse_line_building(char *buf)
     case 'C': {
         auto pct_max = PLAYER_CLASS_TYPE_MAX;
         auto n = tokenize(s + 2, pct_max, zz, 0);
-        for (int i = 0; i < pct_max; i++) {
-            building[index].member_class.push_back((i < n) ? atoi(zz[i]) : 1);
+        for (auto i = 0; i < pct_max; i++) {
+            building[index].member_class[i] = (i < n) ? atoi(zz[i]) : 1;
         }
 
         break;


### PR DESCRIPTION
掲題の通りです
assign済のvectorに対しては代入だけしていれば良かったのですが間違ってpush\_backしていました
アーチャーでの修正を確認済です
ご確認下さい