### PR TITLE
GCU版の機能拡張: bigscreen / color / layout customize / cursor flicker fix

### DIFF
--- a/src/main-gcu.cpp
+++ b/src/main-gcu.cpp
@@ -887,9 +887,8 @@ static errr Term_xtra_gcu_react(void)
         * Both also have the basic 16 ANSI colors, plus some extra grayscale
         * colors which we do not use.
         */
-        int i;
         int scale = COLORS == 256 ? 6 : 4;
-        for (i = 0; i < 16; i++)
+        for (int i = 0; i < 16; i++)
         {
             int fg = create_color(i, scale);
             init_pair(i + 1, fg, bg_color);

--- a/src/main-gcu.cpp
+++ b/src/main-gcu.cpp
@@ -905,23 +905,31 @@ static errr Term_xtra_gcu_react(void)
 
 #ifdef A_COLOR
 
-    if (COLORS == 256 || COLORS == 88) {
-        /* If we have more than 16 colors, find the best matches. These numbers
-        * correspond to xterm/rxvt's builtin color numbers--they do not
-        * correspond to curses' constants OR with curses' color pairs.
-        *
-        * XTerm has 216 (6*6*6) RGB colors, with each RGB setting 0-5.
-        * RXVT has 64 (4*4*4) RGB colors, with each RGB setting 0-3.
-        *
-        * Both also have the basic 16 ANSI colors, plus some extra grayscale
-        * colors which we do not use.
-        */
-        int scale = COLORS == 256 ? 6 : 4;
-        for (int i = 0; i < 16; i++) {
-            int fg = create_color(i, scale);
-            init_pair(i + 1, fg, bg_color);
-            colortable[i] = COLOR_PAIR(i + 1) | A_NORMAL;
-        }
+    if (!can_change_color()) {
+		if (COLORS == 256 || COLORS == 88) {
+		    /* If we have more than 16 colors, find the best matches. These numbers
+		    * correspond to xterm/rxvt's builtin color numbers--they do not
+		    * correspond to curses' constants OR with curses' color pairs.
+		    *
+		    * XTerm has 216 (6*6*6) RGB colors, with each RGB setting 0-5.
+		    * RXVT has 64 (4*4*4) RGB colors, with each RGB setting 0-3.
+		    *
+		    * Both also have the basic 16 ANSI colors, plus some extra grayscale
+		    * colors which we do not use.
+		    */
+		    int scale = COLORS == 256 ? 6 : 4;
+		    for (int i = 0; i < 16; i++) {
+		        int fg = create_color(i, scale);
+		        init_pair(i + 1, fg, bg_color);
+		        colortable[i] = COLOR_PAIR(i + 1) | A_NORMAL;
+		    }
+		}
+    } else {
+    	for (int i = 0; i < 16; ++i) {
+        	init_color(i, (angband_color_table[i][1] * 1000) / 255,
+            (angband_color_table[i][2] * 1000) / 255,
+            (angband_color_table[i][3] * 1000) / 255);
+    	}
     }
 
 #endif
@@ -1238,8 +1246,6 @@ errr init_gcu(int argc, char *argv[])
         if (prefix(argv[i], "-o")) {
             nobigscreen = TRUE;
         }
-
-        plog_fmt("Ignoring option: %s", argv[i]);
     }
 
     /* Initialize for others systems */
@@ -1441,7 +1447,7 @@ errr init_gcu(int argc, char *argv[])
         EDIT: Added support for -left and -top.
     */
     {
-        rect_t remaining = rect(0, 0, COLS - 1, LINES - 1);
+        rect_t remaining = rect(0, 0, COLS, LINES);
         int spacer_cx = 1;
         int spacer_cy = 1;
         int next_term = 1;

--- a/src/main-gcu.cpp
+++ b/src/main-gcu.cpp
@@ -338,6 +338,12 @@ static int can_fix_color = false;
  * Simple Angband to Curses color conversion table
  */
 static int colortable[16];
+
+/**
+ * Background color we should draw with; either BLACK or DEFAULT
+ */
+static int bg_color = COLOR_BLACK;
+
 #endif
 
 /*
@@ -841,6 +847,26 @@ static errr Term_xtra_gcu_sound(int v)
     return (0);
 }
 
+static int scale_color(int i, int j, int scale)
+{
+    return (angband_color_table[i][j] * (scale - 1) + 127) / 255;
+}
+
+static int create_color(int i, int scale)
+{
+    int r = scale_color(i, 1, scale);
+    int g = scale_color(i, 2, scale);
+    int b = scale_color(i, 3, scale);
+    int rgb = 16 + scale * scale * r + scale * g + b;
+    /* In the case of white and black we need to use the ANSI colors */
+    if (r == g && g == b)
+    {
+        if (b == 0) rgb = 0;
+        if (b == scale) rgb = 15;
+    }
+    return rgb;
+}
+
 /*
  * React to changes
  */
@@ -849,16 +875,26 @@ static errr Term_xtra_gcu_react(void)
 
 #ifdef A_COLOR
 
-    int i;
-
-    /* Cannot handle color redefinition */
-    if (!can_fix_color)
-        return (0);
-
-    /* Set the colors */
-    for (i = 0; i < 16; i++) {
-        /* Set one color (note scaling) */
-        init_color(i, angband_color_table[i][1] * 1000 / 255, angband_color_table[i][2] * 1000 / 255, angband_color_table[i][3] * 1000 / 255);
+    if (COLORS == 256 || COLORS == 88)
+    {
+        /* If we have more than 16 colors, find the best matches. These numbers
+        * correspond to xterm/rxvt's builtin color numbers--they do not
+        * correspond to curses' constants OR with curses' color pairs.
+        *
+        * XTerm has 216 (6*6*6) RGB colors, with each RGB setting 0-5.
+        * RXVT has 64 (4*4*4) RGB colors, with each RGB setting 0-3.
+        *
+        * Both also have the basic 16 ANSI colors, plus some extra grayscale
+        * colors which we do not use.
+        */
+        int i;
+        int scale = COLORS == 256 ? 6 : 4;
+        for (i = 0; i < 16; i++)
+        {
+            int fg = create_color(i, scale);
+            init_pair(i + 1, fg, bg_color);
+            colortable[i] = COLOR_PAIR(i + 1) | A_NORMAL;
+        }
     }
 
 #endif

--- a/src/main-gcu.cpp
+++ b/src/main-gcu.cpp
@@ -930,14 +930,10 @@ static errr Term_xtra_gcu(int n, int v)
         (void)wrefresh(td->win);
         return (0);
 
-#ifdef USE_CURS_SET
-
     /* Change the cursor visibility */
     case TERM_XTRA_SHAPE:
         curs_set(v);
         return (0);
-
-#endif
 
     /* Suspend/Resume curses */
     case TERM_XTRA_ALIVE:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -272,6 +272,8 @@ static void display_usage(const char *program)
 
 #ifdef USE_GCU
     puts("  -mgcu    To use GCU (GNU Curses)");
+    puts("  --       Sub options");
+    puts("  -- -o    old subwindow layout (no bigscreen)");
 #endif /* USE_GCU */
 
 #ifdef USE_CAP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -274,6 +274,7 @@ static void display_usage(const char *program)
     puts("  -mgcu    To use GCU (GNU Curses)");
     puts("  --       Sub options");
     puts("  -- -o    old subwindow layout (no bigscreen)");
+    puts("  -- -K    Keep terminal's color table when changing colors");
 #endif /* USE_GCU */
 
 #ifdef USE_CAP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -274,7 +274,6 @@ static void display_usage(const char *program)
     puts("  -mgcu    To use GCU (GNU Curses)");
     puts("  --       Sub options");
     puts("  -- -o    old subwindow layout (no bigscreen)");
-    puts("  -- -K    Keep terminal's color table when changing colors");
 #endif /* USE_GCU */
 
 #ifdef USE_CAP

--- a/src/term/z-term.cpp
+++ b/src/term/z-term.cpp
@@ -1106,13 +1106,10 @@ errr term_fresh(void)
         }
     }
 
-    /* Cursor Update -- Erase old Cursor */
+    /* Hide the hardware cursor while drawing */
     else {
         /* Cursor will be invisible */
-        if (scr->cu || !scr->cv) {
-            /* Make the cursor invisible */
-            term_xtra(TERM_XTRA_SHAPE, 0);
-        }
+        term_xtra(TERM_XTRA_SHAPE, 0);
     }
 
     /* Something to update */
@@ -1192,31 +1189,12 @@ errr term_fresh(void)
 
     /* Cursor Update -- Show new Cursor */
     else {
-        /* The cursor is useless, hide it */
         if (scr->cu) {
             /* Paranoia -- Put the cursor NEAR where it belongs */
             (void)((*Term->curs_hook)(w - 1, scr->cy));
-
-            /* Make the cursor invisible */
-            /* term_xtra(TERM_XTRA_SHAPE, 0); */
-        }
-
-        /* The cursor is invisible, hide it */
-        else if (!scr->cv) {
-            /* Paranoia -- Put the cursor where it belongs */
-            (void)((*Term->curs_hook)(scr->cx, scr->cy));
-
-            /* Make the cursor invisible */
-            /* term_xtra(TERM_XTRA_SHAPE, 0); */
-        }
-
-        /* The cursor is visible, display it correctly */
-        else {
+        } else {
             /* Put the cursor where it belongs */
             (void)((*Term->curs_hook)(scr->cx, scr->cy));
-
-            /* Make the cursor visible */
-            term_xtra(TERM_XTRA_SHAPE, 1);
         }
     }
 
@@ -1229,6 +1207,12 @@ errr term_fresh(void)
     /* Actually flush the output */
     term_xtra(TERM_XTRA_FRESH, 0);
     return 0;
+        
+    if (!Term->soft_cursor && !scr->cu && scr->cv) {
+        /* The cursor is visible, display it correctly */
+        term_xtra(TERM_XTRA_SHAPE, 1);
+    }
+
 }
 
 /*


### PR DESCRIPTION
Implement bigscreen for curses and use it as the default behaviour. The old behaviour is still avilable using -o as a subopt for -mgcu. Also implements a new syntax for user-controlled subwindow layouts (from poschengband), documented within code comments.