### PR TITLE
変愚蛮怒以外ではh_older_thanによる互換性確保は作動しないように

### DIFF
--- a/src/load/angband-version-comparer.cpp
+++ b/src/load/angband-version-comparer.cpp
@@ -1,4 +1,5 @@
-﻿#include "load/angband-version-comparer.h"
+#include "load/angband-version-comparer.h"
+#include "system/angband-version.h"
 #include "world/world.h"
 
 /*!
@@ -12,6 +13,9 @@
  */
 bool h_older_than(byte major, byte minor, byte patch, byte extra)
 {
+    if (VARIANT_NAME != ROOT_VARIANT_NAME)
+        return false;
+
     if (w_ptr->h_ver_major < major)
         return true;
     if (w_ptr->h_ver_major > major)
@@ -46,6 +50,9 @@ bool h_older_than(byte major, byte minor, byte patch, byte extra)
  */
 bool h_older_than(byte major, byte minor, byte patch)
 {
+    if (VARIANT_NAME != ROOT_VARIANT_NAME)
+        return false;
+
     if (w_ptr->h_ver_major < major)
         return true;
     if (w_ptr->h_ver_major > major)

--- a/src/load/angband-version-comparer.cpp
+++ b/src/load/angband-version-comparer.cpp
@@ -1,4 +1,4 @@
-#include "load/angband-version-comparer.h"
+﻿#include "load/angband-version-comparer.h"
 #include "system/angband-version.h"
 #include "world/world.h"
 
@@ -13,28 +13,37 @@
  */
 bool h_older_than(byte major, byte minor, byte patch, byte extra)
 {
-    if (VARIANT_NAME != ROOT_VARIANT_NAME)
+    if (VARIANT_NAME != ROOT_VARIANT_NAME) {
         return false;
+    }
 
-    if (w_ptr->h_ver_major < major)
+    if (w_ptr->h_ver_major < major) {
         return true;
-    if (w_ptr->h_ver_major > major)
+    }
+    if (w_ptr->h_ver_major > major) {
         return false;
+    }
 
-    if (w_ptr->h_ver_minor < minor)
+    if (w_ptr->h_ver_minor < minor) {
         return true;
-    if (w_ptr->h_ver_minor > minor)
+    }
+    if (w_ptr->h_ver_minor > minor) {
         return false;
+    }
 
-    if (w_ptr->h_ver_patch < patch)
+    if (w_ptr->h_ver_patch < patch) {
         return true;
-    if (w_ptr->h_ver_patch > patch)
+    }
+    if (w_ptr->h_ver_patch > patch) {
         return false;
+    }
 
-    if (w_ptr->h_ver_extra < extra)
+    if (w_ptr->h_ver_extra < extra) {
         return true;
-    if (w_ptr->h_ver_extra > extra)
+    }
+    if (w_ptr->h_ver_extra > extra) {
         return false;
+    }
 
     return false;
 }
@@ -50,23 +59,30 @@ bool h_older_than(byte major, byte minor, byte patch, byte extra)
  */
 bool h_older_than(byte major, byte minor, byte patch)
 {
-    if (VARIANT_NAME != ROOT_VARIANT_NAME)
+    if (VARIANT_NAME != ROOT_VARIANT_NAME) {
         return false;
+    }
 
-    if (w_ptr->h_ver_major < major)
+    if (w_ptr->h_ver_major < major) {
         return true;
-    if (w_ptr->h_ver_major > major)
+    }
+    if (w_ptr->h_ver_major > major) {
         return false;
+    }
 
-    if (w_ptr->h_ver_minor < minor)
+    if (w_ptr->h_ver_minor < minor) {
         return true;
-    if (w_ptr->h_ver_minor > minor)
+    }
+    if (w_ptr->h_ver_minor > minor) {
         return false;
+    }
 
-    if (w_ptr->h_ver_patch < patch)
+    if (w_ptr->h_ver_patch < patch) {
         return true;
-    if (w_ptr->h_ver_patch > patch)
+    }
+    if (w_ptr->h_ver_patch > patch) {
         return false;
+    }
 
     return false;
 }

--- a/src/system/angband-version.h
+++ b/src/system/angband-version.h
@@ -5,13 +5,15 @@
 
 constexpr std::string_view VARIANT_NAME("Hengband");
 
+constexpr std::string_view ROOT_VARIANT_NAME("Hengband");
+
 /*!
  * @brief セーブファイル上のバージョン定義 / "Savefile Version Number" for Hengband
  * @details v1.1.1以上にのみ適用
  */
-#define H_VER_MAJOR  3 //!< ゲームのバージョン定義(メジャー番号)
-#define H_VER_MINOR  0 //!< ゲームのバージョン定義(マイナー番号)
-#define H_VER_PATCH  0 //!< ゲームのバージョン定義(パッチ番号)
+#define H_VER_MAJOR 3 //!< ゲームのバージョン定義(メジャー番号)
+#define H_VER_MINOR 0 //!< ゲームのバージョン定義(マイナー番号)
+#define H_VER_PATCH 0 //!< ゲームのバージョン定義(パッチ番号)
 #define H_VER_EXTRA 51 //!< ゲームのバージョン定義(エクストラ番号)
 
 /*!
@@ -25,10 +27,10 @@ constexpr uint32_t SAVEFILE_VERSION = 10;
 constexpr bool IS_STABLE_VERSION = (H_VER_MINOR % 2 == 0 && H_VER_EXTRA == 0);
 
 enum class VersionStatusType {
-	ALPHA,
-	BETA,
-	RELEASE_CANDIDATE,
-	RELEASE,
+    ALPHA,
+    BETA,
+    RELEASE_CANDIDATE,
+    RELEASE,
 };
 
 /*!


### PR DESCRIPTION
現状だとバリアントを切ってバージョンの数字を書き換えるとセーブファイルを読み込む際にバグるが、そのためにバリアントを切る度この関数による条件分岐全てを消すのは面倒なので、姑息な対処だがとりあえずバリアント名を書き換えたらh_older_thanは常にfalseを返すようにした

バージョンによる互換性の確保を全て別ファイルに分けるなどして処理自体を消しやすくした方がいいため、それについては別途Issueを作成する