### PR TITLE
object_type::xtra1を消した

### DIFF
--- a/src/load/old/item-loader-savefile50.cpp
+++ b/src/load/old/item-loader-savefile50.cpp
@@ -98,7 +98,10 @@ void ItemLoader50::rd_item(object_type *o_ptr)
     }
 
     o_ptr->held_m_idx = any_bits(flags, SaveDataItemFlagType::HELD_M_IDX) ? rd_s16b() : 0;
-    o_ptr->xtra1 = any_bits(flags, SaveDataItemFlagType::XTRA1) ? rd_byte() : 0;
+    if (any_bits(flags, SaveDataItemFlagType::XTRA1)) {
+        strip_bytes(1);
+    }
+
     if (any_bits(flags, SaveDataItemFlagType::ACTIVATION_ID)) {
         if (h_older_than(3, 0, 0, 2)) {
             o_ptr->activation_id = i2enum<RandomArtActType>(rd_byte());

--- a/src/load/old/load-v1-5-0.cpp
+++ b/src/load/old/load-v1-5-0.cpp
@@ -144,11 +144,11 @@ void rd_item_old(object_type *o_ptr)
     }
 
     o_ptr->held_m_idx = rd_s16b();
-    o_ptr->xtra1 = rd_byte();
+    auto xtra1 = rd_byte(); // かつてエゴアイテムの情報を格納していた名残.
     o_ptr->activation_id = i2enum<RandomArtActType>(rd_byte());
 
     if (h_older_than(1, 0, 10)) {
-        if (o_ptr->xtra1 == EGO_XTRA_SUSTAIN) {
+        if (xtra1 == EGO_XTRA_SUSTAIN) {
             switch (enum2i(o_ptr->activation_id) % 6) {
             case 0:
                 o_ptr->art_flags.set(TR_SUST_STR);
@@ -170,7 +170,7 @@ void rd_item_old(object_type *o_ptr)
                 break;
             }
             o_ptr->activation_id = i2enum<RandomArtActType>(0);
-        } else if (o_ptr->xtra1 == EGO_XTRA_POWER) {
+        } else if (xtra1 == EGO_XTRA_POWER) {
             switch (enum2i(o_ptr->activation_id) % 11) {
             case 0:
                 o_ptr->art_flags.set(TR_RES_BLIND);
@@ -207,7 +207,7 @@ void rd_item_old(object_type *o_ptr)
                 break;
             }
             o_ptr->activation_id = i2enum<RandomArtActType>(0);
-        } else if (o_ptr->xtra1 == EGO_XTRA_ABILITY) {
+        } else if (xtra1 == EGO_XTRA_ABILITY) {
             switch (enum2i(o_ptr->activation_id) % 8) {
             case 0:
                 o_ptr->art_flags.set(TR_LEVITATION);
@@ -236,7 +236,8 @@ void rd_item_old(object_type *o_ptr)
             }
             o_ptr->activation_id = i2enum<RandomArtActType>(0);
         }
-        o_ptr->xtra1 = 0;
+        
+        xtra1 = 0;
     }
 
     if (h_older_than(0, 2, 3)) {
@@ -244,9 +245,10 @@ void rd_item_old(object_type *o_ptr)
         o_ptr->xtra4 = 0;
         o_ptr->xtra5 = 0;
         if ((o_ptr->tval == ItemKindType::CHEST) || (o_ptr->tval == ItemKindType::CAPTURE)) {
-            o_ptr->xtra3 = o_ptr->xtra1;
-            o_ptr->xtra1 = 0;
+            o_ptr->xtra3 = xtra1;
+            xtra1 = 0;
         }
+
         if (o_ptr->tval == ItemKindType::CAPTURE) {
             if (r_info[o_ptr->pval].flags1 & RF1_FORCE_MAXHP)
                 o_ptr->xtra5 = maxroll(r_info[o_ptr->pval].hdice, r_info[o_ptr->pval].hside);

--- a/src/object/object-stack.cpp
+++ b/src/object/object-stack.cpp
@@ -168,8 +168,6 @@ int object_similar_part(const object_type *o_ptr, const object_type *j_ptr)
             return 0;
         if (o_ptr->xtra4 != j_ptr->xtra4)
             return 0;
-        if (o_ptr->xtra1 || j_ptr->xtra1)
-            return 0;
         if (o_ptr->timeout || j_ptr->timeout)
             return 0;
         if (o_ptr->ac != j_ptr->ac)

--- a/src/save/item-writer.cpp
+++ b/src/save/item-writer.cpp
@@ -61,9 +61,6 @@ static void write_item_flags(object_type *o_ptr, BIT_FLAGS *flags)
     if (o_ptr->held_m_idx)
         set_bits(*flags, SaveDataItemFlagType::HELD_M_IDX);
 
-    if (o_ptr->xtra1)
-        set_bits(*flags, SaveDataItemFlagType::XTRA1);
-
     if (o_ptr->activation_id > RandomArtActType::NONE)
         set_bits(*flags, SaveDataItemFlagType::ACTIVATION_ID);
 
@@ -139,9 +136,6 @@ static void write_item_info(object_type *o_ptr, const BIT_FLAGS flags)
 
     if (any_bits(flags, SaveDataItemFlagType::HELD_M_IDX))
         wr_s16b(o_ptr->held_m_idx);
-
-    if (any_bits(flags, SaveDataItemFlagType::XTRA1))
-        wr_byte(o_ptr->xtra1);
 
     if (any_bits(flags, SaveDataItemFlagType::ACTIVATION_ID))
         wr_s16b(enum2i(o_ptr->activation_id));

--- a/src/store/store-util.cpp
+++ b/src/store/store-util.cpp
@@ -232,9 +232,6 @@ bool store_object_similar(object_type *o_ptr, object_type *j_ptr)
     if (o_ptr->art_flags != j_ptr->art_flags)
         return false;
 
-    if (o_ptr->xtra1 || j_ptr->xtra1)
-        return false;
-
     if (o_ptr->timeout || j_ptr->timeout)
         return false;
 

--- a/src/system/object-type-definition.h
+++ b/src/system/object-type-definition.h
@@ -36,7 +36,6 @@ typedef struct object_type {
     ARTIFACT_IDX name1{}; /*!< Artifact type, if any */
     EGO_IDX name2{}; /*!< Ego-Item type, if any */
 
-    XTRA8 xtra1{}; /*!< Extra info type (now unused) */
     RandomArtActType activation_id{}; /*!< エゴ/アーティファクトの発動ID / Extra info activation index */
     XTRA8 xtra3{}; /*!< 複数の使用用途 捕らえたモンスターの速度 / Extra info */
     XTRA16 xtra4{}; /*!< 複数の使用用途 光源の残り寿命、あるいは捕らえたモンスターの現HP / Extra info fuel or captured monster's current HP */

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -344,7 +344,7 @@ static void wiz_display_item(PlayerType *player_ptr, object_type *o_ptr)
     prt(format("number = %-3d  wgt = %-6d  ac = %-5d    damage = %dd%d", o_ptr->number, o_ptr->weight, o_ptr->ac, o_ptr->dd, o_ptr->ds), 5, j);
     prt(format("pval = %-5d  toac = %-5d  tohit = %-4d  todam = %-4d", o_ptr->pval, o_ptr->to_a, o_ptr->to_h, o_ptr->to_d), 6, j);
     prt(format("name1 = %-4d  name2 = %-4d  cost = %ld", o_ptr->name1, o_ptr->name2, (long)object_value_real(o_ptr)), 7, j);
-    prt(format("ident = %04x  xtra1 = %-4d  activation_id = %-4d  timeout = %-d", o_ptr->ident, o_ptr->xtra1, o_ptr->activation_id, o_ptr->timeout), 8, j);
+    prt(format("ident = %04x  activation_id = %-4d  timeout = %-d", o_ptr->ident, o_ptr->activation_id, o_ptr->timeout), 8, j);
     prt(format("xtra3 = %-4d  xtra4 = %-4d  xtra5 = %-4d  cursed  = %-d", o_ptr->xtra3, o_ptr->xtra4, o_ptr->xtra5, o_ptr->curse_flags), 9, j);
 
     prt("+------------FLAGS1------------+", 10, j);


### PR DESCRIPTION
掲題の通りです
もう使われていないフィールドにつき、ほとんど読み捨てる形で\*抹殺\*しました
ご確認下さい

なおxtra1で全文grepするとまだ何箇所か引っかかりますが、これは昔耐性を被ダメ時と画面表示時で別々に計算していた頃の名残っぽいです
本件とは無関係なので暫定で残してあります