### PR TITLE
[Fix] 鍛冶師でマイナスのpvalのアイテムからエッセンスが抽出できてしまう

### DIFF
--- a/src/smith/object-smith.cpp
+++ b/src/smith/object-smith.cpp
@@ -368,7 +368,8 @@ Smith::DrainEssenceResult Smith::drain_essence(object_type *o_ptr)
 
         if ((new_flgs.has_not(info.tr_flag) || pval) && old_flgs.has(info.tr_flag)) {
             for (auto &&essence : info.essences) {
-                drain_values[essence] += info.amount * std::max(pval, 1);
+                auto mult = TR_PVAL_FLAG_MASK.has(info.tr_flag) ? pval : 1;
+                drain_values[essence] += info.amount * mult;
             }
         }
     }


### PR DESCRIPTION
Fix #2130
鍛冶師のリファクタリング時に pval の対象で無い特性フラグのエッセンスを pval 倍しない
既定値分吸えるように std::max(pval, 1) としたが、pval がマイナスの時（該当部分の
変数 pval の値は0になる）が考慮できていなかった。
pval の対象のフラグかどうかで分岐して特性フラグが pval の対象の場合にはpvalをそのま
ま掛けるようにする。