### PR TITLE
SPEED の型エイリアスを廃止した

### DIFF
--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -137,7 +137,7 @@ void process_player(PlayerType *player_ptr)
 
         WorldTurnProcessor(player_ptr).print_time();
     } else if (!(load && player_ptr->energy_need <= 0)) {
-        player_ptr->energy_need -= SPEED_TO_ENERGY(player_ptr->pspeed);
+        player_ptr->energy_need -= speed_to_energy(player_ptr->pspeed);
     }
 
     if (player_ptr->energy_need > 0)
@@ -423,7 +423,7 @@ void process_player(PlayerType *player_ptr)
 void process_upkeep_with_speed(PlayerType *player_ptr)
 {
     if (!load && player_ptr->enchant_energy_need > 0 && !player_ptr->leaving) {
-        player_ptr->enchant_energy_need -= SPEED_TO_ENERGY(player_ptr->pspeed);
+        player_ptr->enchant_energy_need -= speed_to_energy(player_ptr->pspeed);
     }
 
     if (player_ptr->enchant_energy_need > 0)

--- a/src/core/speed-table.cpp
+++ b/src/core/speed-table.cpp
@@ -49,3 +49,9 @@ const byte extract_energy[NUM_SPEED] = {
 	/* F+70 */    49, 49, 49, 49, 49, 49, 49, 49, 49, 49,
 	/* Fast */    49, 49, 49, 49, 49, 49, 49, 49, 49, 49,
 };
+
+/*! @brief 加速値に応じた基本行動エネルギー消費量を返す / Extract energy from speed (Assumes that SPEED is unsigned) */
+byte speed_to_energy(byte speed)
+{
+    return speed > 199 ? 49 : extract_energy[speed];
+}

--- a/src/core/speed-table.cpp
+++ b/src/core/speed-table.cpp
@@ -1,4 +1,5 @@
 ﻿#include "core/speed-table.h"
+#include <vector>
 
 /*!
  * @brief 加速値による実質速度修正倍率テーブル /
@@ -27,7 +28,7 @@
  * the (compiled out) small random energy boost code.  It may
  * also tend to cause more "clumping" at high speeds.
  */
-const byte extract_energy[NUM_SPEED] = {
+static const std::vector<byte> extract_energy = {
 	/* Slow */     1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
 	/* Slow */     1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
 	/* Slow */     1,  1,  1,  1,  1,  1,  1,  1,  1,  1,

--- a/src/core/speed-table.h
+++ b/src/core/speed-table.h
@@ -2,11 +2,7 @@
 
 #include "system/angband.h"
 
-#define NUM_SPEED 200
-
 /*! @brief 消費する行動エネルギー値を正規乱数で返す(中央100/分散25) / Random energy */
 #define ENERGY_NEED() (randnor(100, 25))
-
-extern const byte extract_energy[NUM_SPEED];
 
 byte speed_to_energy(byte speed);

--- a/src/core/speed-table.h
+++ b/src/core/speed-table.h
@@ -7,7 +7,6 @@
 /*! @brief 消費する行動エネルギー値を正規乱数で返す(中央100/分散25) / Random energy */
 #define ENERGY_NEED() (randnor(100, 25))
 
-/*! @brief 加速値に応じた基本行動エネルギー消費量を返す / Extract energy from speed (Assumes that SPEED is unsigned) */
-#define SPEED_TO_ENERGY(SPEED) (((SPEED) > 199) ? 49 : extract_energy[(SPEED)])
-
 extern const byte extract_energy[NUM_SPEED];
+
+byte speed_to_energy(byte speed);

--- a/src/lore/lore-util.h
+++ b/src/lore/lore-util.h
@@ -26,7 +26,7 @@ struct lore_type {
 #endif
     bool nightmare;
     monster_race *r_ptr;
-    SPEED speed;
+    byte speed;
     ITEM_NUMBER drop_gold;
     ITEM_NUMBER drop_item;
     BIT_FLAGS flags1;

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -439,10 +439,10 @@ void MonsterDamageProcessor::get_exp_from_mon(monster_type *m_ptr, HIT_POINT exp
      * - Varying speed effects
      * - Get a fraction in proportion of damage point
      */
-    auto new_exp = r_ptr->level * SPEED_TO_ENERGY(m_ptr->mspeed) * exp_dam;
+    auto new_exp = r_ptr->level * speed_to_energy(m_ptr->mspeed) * exp_dam;
     auto new_exp_frac = 0U;
     auto div_h = 0;
-    auto div_l = (uint)((this->player_ptr->max_plv + 2) * SPEED_TO_ENERGY(r_ptr->speed));
+    auto div_l = (uint)((this->player_ptr->max_plv + 2) * speed_to_energy(r_ptr->speed));
 
     /* Use (average maxhp * 2) as a denominator */
     auto compensation = any_bits(r_ptr->flags1, RF1_FORCE_MAXHP) ? r_ptr->hside * 2 : r_ptr->hside + 1;

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -376,9 +376,9 @@ void choose_new_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, bool born, MO
  * @param r_ptr モンスター種族の参照ポインタ
  * @return 加速値
  */
-SPEED get_mspeed(floor_type *floor_ptr, monster_race *r_ptr)
+byte get_mspeed(floor_type *floor_ptr, monster_race *r_ptr)
 {
-    SPEED mspeed = r_ptr->speed;
+    auto mspeed = r_ptr->speed;
     if (r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE) && !floor_ptr->inside_arena) {
         /* Allow some small variation per monster */
         int i = speed_to_energy(r_ptr->speed) / (one_in_(4) ? 3 : 10);

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -381,7 +381,7 @@ SPEED get_mspeed(floor_type *floor_ptr, monster_race *r_ptr)
     SPEED mspeed = r_ptr->speed;
     if (r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE) && !floor_ptr->inside_arena) {
         /* Allow some small variation per monster */
-        int i = SPEED_TO_ENERGY(r_ptr->speed) / (one_in_(4) ? 3 : 10);
+        int i = speed_to_energy(r_ptr->speed) / (one_in_(4) ? 3 : 10);
         if (i)
             mspeed += rand_spread(0, i);
     }

--- a/src/monster/monster-list.h
+++ b/src/monster/monster-list.h
@@ -11,5 +11,5 @@ MONSTER_IDX m_pop(floor_type *floor_ptr);
 
 MONRACE_IDX get_mon_num(PlayerType *player_ptr, DEPTH min_level, DEPTH max_level, BIT_FLAGS option);
 void choose_new_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, bool born, MONRACE_IDX r_idx);
-SPEED get_mspeed(floor_type *player_ptr, monster_race *r_ptr);
+byte get_mspeed(floor_type *player_ptr, monster_race *r_ptr);
 int get_monster_crowd_number(floor_type *floor_ptr, MONSTER_IDX m_idx);

--- a/src/monster/monster-processor-util.cpp
+++ b/src/monster/monster-processor-util.cpp
@@ -305,9 +305,9 @@ void save_old_race_flags(MONRACE_IDX monster_race_idx, old_race_flags *old_race_
  * @param m_ptr モンスターへの参照ポインタ
  * return モンスターの加速値
  */
-SPEED decide_monster_speed(monster_type *m_ptr)
+byte decide_monster_speed(monster_type *m_ptr)
 {
-    SPEED speed = m_ptr->mspeed;
+    auto speed = m_ptr->mspeed;
     if (ironman_nightmare)
         speed += 5;
 

--- a/src/monster/monster-processor-util.h
+++ b/src/monster/monster-processor-util.h
@@ -60,4 +60,4 @@ coordinate_candidate init_coordinate_candidate(void);
 void store_enemy_approch_direction(int *mm, POSITION y, POSITION x);
 void store_moves_val(int *mm, int y, int x);
 void save_old_race_flags(MONRACE_IDX monster_race_idx, old_race_flags *old_race_flags_ptr);
-SPEED decide_monster_speed(monster_type *m_ptr);
+byte decide_monster_speed(monster_type *m_ptr);

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -555,7 +555,7 @@ void sweep_monster_process(PlayerType *player_ptr)
         if ((m_ptr->cdis >= AAF_LIMIT) || !decide_process_continue(player_ptr, m_ptr))
             continue;
 
-        SPEED speed = (player_ptr->riding == i) ? player_ptr->pspeed : decide_monster_speed(m_ptr);
+        byte speed = (player_ptr->riding == i) ? player_ptr->pspeed : decide_monster_speed(m_ptr);
         m_ptr->energy_need -= speed_to_energy(speed);
         if (m_ptr->energy_need > 0)
             continue;

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -556,7 +556,7 @@ void sweep_monster_process(PlayerType *player_ptr)
             continue;
 
         SPEED speed = (player_ptr->riding == i) ? player_ptr->pspeed : decide_monster_speed(m_ptr);
-        m_ptr->energy_need -= SPEED_TO_ENERGY(speed);
+        m_ptr->energy_need -= speed_to_energy(speed);
         if (m_ptr->energy_need > 0)
             continue;
 

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -199,7 +199,7 @@ static void process_monsters_mtimed_aux(PlayerType *player_ptr, MONSTER_IDX m_id
         auto d = (m_ptr->cdis < AAF_LIMIT / 2) ? (AAF_LIMIT / m_ptr->cdis) : 1;
 
         /* Hack -- amount of "waking" is affected by speed of player */
-        d = (d * SPEED_TO_ENERGY(player_ptr->pspeed)) / 10;
+        d = (d * speed_to_energy(player_ptr->pspeed)) / 10;
         if (d < 0) {
             d = 1;
         }

--- a/src/player-status/player-speed.cpp
+++ b/src/player-status/player-speed.cpp
@@ -71,7 +71,7 @@ int16_t PlayerSpeed::race_value()
  */
 int16_t PlayerSpeed::class_value()
 {
-    SPEED result = 0;
+    byte result = 0;
     PlayerClass pc(this->player_ptr);
     if (pc.equals(PlayerClassType::NINJA)) {
         if (heavy_armor(this->player_ptr)) {
@@ -221,7 +221,7 @@ int16_t PlayerSpeed::stance_value()
  */
 int16_t PlayerSpeed::mutation_value()
 {
-    SPEED result = 0;
+    int16_t result = 0;
 
     const auto &muta = this->player_ptr->muta;
     if (muta.has(PlayerMutationType::XTRA_FAT)) {
@@ -248,8 +248,8 @@ int16_t PlayerSpeed::mutation_value()
 int16_t PlayerSpeed::riding_value()
 {
     monster_type *riding_m_ptr = &(this->player_ptr)->current_floor_ptr->m_list[this->player_ptr->riding];
-    SPEED speed = riding_m_ptr->mspeed;
-    SPEED result = 0;
+    int16_t speed = riding_m_ptr->mspeed;
+    int16_t result = 0;
 
     if (!this->player_ptr->riding) {
         return 0;
@@ -308,7 +308,7 @@ int16_t PlayerSpeed::inventory_weight_value()
  */
 int16_t PlayerSpeed::action_value()
 {
-    SPEED result = 0;
+    int16_t result = 0;
     if (this->player_ptr->action == ACTION_SEARCH)
         result -= 10;
     return result;

--- a/src/player/digestion-processor.cpp
+++ b/src/player/digestion-processor.cpp
@@ -33,7 +33,7 @@ void starve_player(PlayerType *player_ptr)
     if (player_ptr->food >= PY_FOOD_MAX) {
         (void)set_food(player_ptr, player_ptr->food - 100);
     } else if (!(w_ptr->game_turn % (TURNS_PER_TICK * 5))) {
-        int digestion = SPEED_TO_ENERGY(player_ptr->pspeed);
+        int digestion = speed_to_energy(player_ptr->pspeed);
         if (player_ptr->regenerate)
             digestion += 20;
         PlayerClass pc(player_ptr);

--- a/src/spell-kind/spells-sight.cpp
+++ b/src/spell-kind/spells-sight.cpp
@@ -373,7 +373,7 @@ void probed_monster_info(char *buf, PlayerType *player_ptr, monster_type *m_ptr,
     GAME_TEXT m_name[MAX_NLEN];
     monster_desc(player_ptr, m_name, m_ptr, MD_IGNORE_HALLU | MD_INDEF_HIDDEN);
 
-    SPEED speed = m_ptr->mspeed - 110;
+    auto speed = m_ptr->mspeed - 110;
     if (monster_fast_remaining(m_ptr))
         speed += 10;
     if (monster_slow_remaining(m_ptr))

--- a/src/system/h-type.h
+++ b/src/system/h-type.h
@@ -123,7 +123,6 @@ typedef int32_t ITEM_NUMBER; /*!< ゲーム中のアイテム数型を定義 */
 typedef int16_t ACTION_ENERGY; /*!< ゲーム中の行動エネルギー型を定義 */
 typedef int16_t ARMOUR_CLASS; /*!< ゲーム中の行動アーマークラス型を定義 */
 typedef int16_t TIME_EFFECT; /*!< ゲーム中の時限期間の型を定義 */
-typedef int16_t SPEED; /*!< ゲーム中の加速値の型定義 */
 
 /*!
  * @var typedef int16_t ENEGRY

--- a/src/system/monster-race-definition.h
+++ b/src/system/monster-race-definition.h
@@ -54,7 +54,7 @@ struct monster_race {
     ARMOUR_CLASS ac{}; //!< アーマークラス / Armour Class
     SLEEP_DEGREE sleep{}; //!< 睡眠値 / Inactive counter (base)
     POSITION aaf{}; //!< 感知範囲(1-100スクエア) / Area affect radius (1-100)
-    SPEED speed{}; //!< 加速(110で+0) / Speed (normally 110)
+    byte speed{}; //!< 加速(110で+0) / Speed (normally 110)
     EXP mexp{}; //!< 殺害時基本経験値 / Exp value for kill
     BIT_FLAGS16 extra{}; //!< 未使用 /  Unused (for now)
     RARITY freq_spell{}; //!< 魔法＆特殊能力仕様頻度(1/n) /  Spell frequency

--- a/src/system/monster-type-definition.h
+++ b/src/system/monster-type-definition.h
@@ -35,7 +35,7 @@ struct monster_type {
 	HIT_POINT max_maxhp{};		/*!< 生成時の初期最大HP / Max Max Hit points */
 	HIT_POINT dealt_damage{};		/*!< これまでに蓄積して与えてきたダメージ / Sum of damages dealt by player */
 	TIME_EFFECT mtimed[MAX_MTIMED]{};	/*!< 与えられた時限効果の残りターン / Timed status counter */
-	SPEED mspeed{};	        /*!< モンスターの個体加速値 / Monster "speed" */
+	byte mspeed{};	        /*!< モンスターの個体加速値 / Monster "speed" */
 	ACTION_ENERGY energy_need{};	/*!< モンスター次ターンまでに必要な行動エネルギー / Monster "energy" */
 	POSITION cdis{};		/*!< 現在のプレイヤーから距離(逐一計算を避けるためのテンポラリ変数) Current dis from player */
 	EnumClassFlagGroup<MonsterTemporaryFlagType> mflag{};	/*!< モンスター個体に与えられた特殊フラグ1 (セーブ不要) / Extra monster flags */


### PR DESCRIPTION
掲題の通りです
速度定義がbyteなのでそれに統一しています
一部、PlayerSpeedがint16\_tを返していますがインターフェースを噛ましていて他との兼ね合いがありそうだったのでそこは手つかずとしました
ご確認下さい