### PR TITLE
prace == HOGEの判定をPlayerRace::equals(HOGE) で置換した

### DIFF
--- a/src/autopick/autopick-destroyer.cpp
+++ b/src/autopick/autopick-destroyer.cpp
@@ -23,6 +23,7 @@
 #include "object/tval-types.h"
 #include "perception/object-perception.h"
 #include "player-base/player-class.h"
+#include "player-base/player-race.h"
 #include "player-info/race-types.h"
 #include "sv-definition/sv-other-types.h"
 #include "sv-definition/sv-wand-types.h"
@@ -44,7 +45,7 @@ static bool is_leave_special_item(PlayerType *player_ptr, ObjectType *o_ptr)
         return true;
 
     PlayerClass pc(player_ptr);
-    if (player_ptr->prace == PlayerRaceType::BALROG) {
+    if (PlayerRace(player_ptr).equals(PlayerRaceType::BALROG)) {
         if (o_ptr->tval == ItemKindType::CORPSE && o_ptr->sval == SV_CORPSE && angband_strchr("pht", r_info[o_ptr->pval].d_char))
             return false;
     } else if (pc.equals(PlayerClassType::ARCHER)) {

--- a/src/birth/birth-body-spec.cpp
+++ b/src/birth/birth-body-spec.cpp
@@ -1,5 +1,6 @@
 ﻿#include "birth/birth-body-spec.h"
 #include "player-base/player-class.h"
+#include "player-base/player-race.h"
 #include "player-info/race-info.h"
 #include "player-info/race-types.h"
 #include "player/player-personality-types.h"
@@ -66,7 +67,7 @@ void get_money(PlayerType *player_ptr)
         gold /= 2;
     else if (player_ptr->ppersonality == PERSONALITY_MUNCHKIN)
         gold = 10000000;
-    if (player_ptr->prace == PlayerRaceType::ANDROID)
+    if (PlayerRace(player_ptr).equals(PlayerRaceType::ANDROID))
         gold /= 5;
 
     player_ptr->au = gold;

--- a/src/birth/birth-stat.cpp
+++ b/src/birth/birth-stat.cpp
@@ -2,6 +2,7 @@
 #include "birth/auto-roller.h"
 #include "core/player-redraw-types.h"
 #include "player-base/player-class.h"
+#include "player-base/player-race.h"
 #include "player-info/class-info.h"
 #include "player-info/race-info.h"
 #include "player-info/race-types.h"
@@ -93,10 +94,11 @@ uint16_t get_expfact(PlayerType *player_ptr)
 {
     uint16_t expfact = rp_ptr->r_exp;
 
-    if (player_ptr->prace != PlayerRaceType::ANDROID)
+    PlayerRace pr(player_ptr);
+    if (!pr.equals(PlayerRaceType::ANDROID))
         expfact += cp_ptr->c_exp;
 
-    auto is_race_gaining_additional_speed = (player_ptr->prace == PlayerRaceType::KLACKON) || (player_ptr->prace == PlayerRaceType::SPRITE);
+    auto is_race_gaining_additional_speed = pr.equals(PlayerRaceType::KLACKON) || pr.equals(PlayerRaceType::SPRITE);
     auto is_class_gaining_additional_speed = PlayerClass(player_ptr).has_additional_speed();
     if (is_race_gaining_additional_speed && is_class_gaining_additional_speed)
         expfact -= 15;

--- a/src/birth/character-builder.cpp
+++ b/src/birth/character-builder.cpp
@@ -26,6 +26,7 @@
 #include "mind/mind-elementalist.h"
 #include "monster-floor/monster-remover.h"
 #include "player-base/player-class.h"
+#include "player-base/player-race.h"
 #include "player-info/class-info.h"
 #include "player-info/race-types.h"
 #include "player/patron.h"
@@ -109,7 +110,7 @@ void player_birth(PlayerType *player_ptr)
     }
 
     seed_wilderness();
-    if (player_ptr->prace == PlayerRaceType::BEASTMAN)
+    if (PlayerRace(player_ptr).equals(PlayerRaceType::BEASTMAN))
         player_ptr->hack_mutation = true;
     else
         player_ptr->hack_mutation = false;

--- a/src/birth/inventory-initializer.cpp
+++ b/src/birth/inventory-initializer.cpp
@@ -15,6 +15,7 @@
 #include "object/object-kind.h"
 #include "perception/object-perception.h"
 #include "player-base/player-class.h"
+#include "player-base/player-race.h"
 #include "player-info/race-types.h"
 #include "player/player-personality-types.h"
 #include "realm/realm-types.h"
@@ -150,7 +151,8 @@ void player_outfit(PlayerType *player_ptr)
     q_ptr = &forge;
 
     PlayerClass pc(player_ptr);
-    if ((player_ptr->prace == PlayerRaceType::VAMPIRE) && !pc.equals(PlayerClassType::NINJA)) {
+    PlayerRace pr(player_ptr);
+    if (pr.equals(PlayerRaceType::VAMPIRE) && !pc.equals(PlayerClassType::NINJA)) {
         q_ptr->prep(lookup_kind(ItemKindType::SCROLL, SV_SCROLL_DARKNESS));
         q_ptr->number = (ITEM_NUMBER)rand_range(2, 5);
         add_outfit(player_ptr, q_ptr);
@@ -163,7 +165,7 @@ void player_outfit(PlayerType *player_ptr)
     }
 
     q_ptr = &forge;
-    if (player_ptr->prace == PlayerRaceType::MERFOLK) {
+    if (pr.equals(PlayerRaceType::MERFOLK)) {
         q_ptr->prep(lookup_kind(ItemKindType::RING, SV_RING_LEVITATION_FALL));
         q_ptr->number = 1;
         add_outfit(player_ptr, q_ptr);
@@ -240,23 +242,23 @@ void player_outfit(PlayerType *player_ptr)
         auto short_pclass = enum2i(player_ptr->pclass);
         if (player_ptr->ppersonality == PERSONALITY_SEXY) {
             player_init[short_pclass][2] = std::make_tuple(ItemKindType::HAFTED, SV_WHIP);            
-        } else if (player_ptr->prace == PlayerRaceType::MERFOLK) {
+        } else if (pr.equals(PlayerRaceType::MERFOLK)) {
             player_init[short_pclass][2] = std::make_tuple(ItemKindType::POLEARM, SV_TRIDENT);
         }
     }
 
     for (auto i = 0; i < 3; i++) {
         auto &[tv, sv] = player_init[enum2i(player_ptr->pclass)][i];
-        if ((player_ptr->prace == PlayerRaceType::ANDROID) && ((tv == ItemKindType::SOFT_ARMOR) || (tv == ItemKindType::HARD_ARMOR)))
+        if (pr.equals(PlayerRaceType::ANDROID) && ((tv == ItemKindType::SOFT_ARMOR) || (tv == ItemKindType::HARD_ARMOR)))
             continue;
 
         if (tv == ItemKindType::SORCERY_BOOK)
             tv = i2enum<ItemKindType>(enum2i(ItemKindType::LIFE_BOOK) + player_ptr->realm1 - 1);
         else if (tv == ItemKindType::DEATH_BOOK)
             tv = i2enum<ItemKindType>(enum2i(ItemKindType::LIFE_BOOK) + player_ptr->realm2 - 1);
-        else if (tv == ItemKindType::RING && sv == SV_RING_RES_FEAR && player_ptr->prace == PlayerRaceType::BARBARIAN)
+        else if (tv == ItemKindType::RING && sv == SV_RING_RES_FEAR && pr.equals(PlayerRaceType::BARBARIAN))
             sv = SV_RING_SUSTAIN_STR;
-        else if (tv == ItemKindType::RING && sv == SV_RING_SUSTAIN_INT && player_ptr->prace == PlayerRaceType::MIND_FLAYER) {
+        else if (tv == ItemKindType::RING && sv == SV_RING_SUSTAIN_INT && pr.equals(PlayerRaceType::MIND_FLAYER)) {
             tv = ItemKindType::POTION;
             sv = SV_POTION_RESTORE_MANA;
         }

--- a/src/cmd-item/cmd-destroy.cpp
+++ b/src/cmd-item/cmd-destroy.cpp
@@ -21,6 +21,7 @@
 #include "object/object-stack.h"
 #include "object/object-value.h"
 #include "player-base/player-class.h"
+#include "player-base/player-race.h"
 #include "player-info/samurai-data-type.h"
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
@@ -111,7 +112,7 @@ static bool select_destroying_item(PlayerType *player_ptr, destroy_type *destroy
  */
 static bool decide_magic_book_exp(PlayerType *player_ptr, destroy_type *destroy_ptr)
 {
-    if (player_ptr->prace == PlayerRaceType::ANDROID)
+    if (PlayerRace(player_ptr).equals(PlayerRaceType::ANDROID))
         return false;
 
     PlayerClass pc(player_ptr);

--- a/src/cmd-item/cmd-equipment.cpp
+++ b/src/cmd-item/cmd-equipment.cpp
@@ -33,6 +33,7 @@
 #include "object/object-mark-types.h"
 #include "perception/object-perception.h"
 #include "player-base/player-class.h"
+#include "player-base/player-race.h"
 #include "player-info/equipment-info.h"
 #include "player-info/samurai-data-type.h"
 #include "player-status/player-energy.h"
@@ -229,7 +230,8 @@ void do_cmd_wield(PlayerType *player_ptr)
             return;
     }
 
-    if ((o_ptr->name1 == ART_STONEMASK) && o_ptr->is_known() && (player_ptr->prace != PlayerRaceType::VAMPIRE) && (player_ptr->prace != PlayerRaceType::ANDROID)) {
+    PlayerRace pr(player_ptr);
+    if ((o_ptr->name1 == ART_STONEMASK) && o_ptr->is_known() && !pr.equals(PlayerRaceType::VAMPIRE) && !pr.equals(PlayerRaceType::ANDROID)) {
         char dummy[MAX_NLEN + 100];
         describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
         sprintf(dummy,
@@ -322,7 +324,7 @@ void do_cmd_wield(PlayerType *player_ptr)
 
     do_curse_on_equip(slot, o_ptr, player_ptr);
 
-    if ((o_ptr->name1 == ART_STONEMASK) && (player_ptr->prace != PlayerRaceType::VAMPIRE) && (player_ptr->prace != PlayerRaceType::ANDROID))
+    if ((o_ptr->name1 == ART_STONEMASK) && !pr.equals(PlayerRaceType::VAMPIRE) && !pr.equals(PlayerRaceType::ANDROID))
         change_race(player_ptr, PlayerRaceType::VAMPIRE, "");
 
     calc_android_exp(player_ptr);

--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -7,6 +7,7 @@
 #include "io/files-util.h"
 #include "io/input-key-acceptor.h"
 #include "main/sound-of-music.h"
+#include "player-base/player-race.h"
 #include "player-info/race-types.h"
 #include "player/process-name.h"
 #include "racial/racial-android.h"
@@ -53,7 +54,7 @@ void do_cmd_redraw(PlayerType *player_ptr)
 
     update_playtime();
     handle_stuff(player_ptr);
-    if (player_ptr->prace == PlayerRaceType::ANDROID)
+    if (PlayerRace(player_ptr).equals(PlayerRaceType::ANDROID))
         calc_android_exp(player_ptr);
 
     term_type *old = Term;

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -64,6 +64,7 @@
 #include "monster-race/race-indice-types.h"
 #include "monster/monster-util.h"
 #include "player-base/player-class.h"
+#include "player-base/player-race.h"
 #include "player-info/class-info.h"
 #include "player-info/race-types.h"
 #include "player/player-personality-types.h"
@@ -406,7 +407,7 @@ void play_game(PlayerType *player_ptr, bool new_game, bool browsing_movie)
     if (player_ptr->chp < 0 && !cheat_immortal)
         player_ptr->is_dead = true;
 
-    if (player_ptr->prace == PlayerRaceType::ANDROID)
+    if (PlayerRace(player_ptr).equals(PlayerRaceType::ANDROID))
         calc_android_exp(player_ptr);
 
     init_riding_pet(player_ptr, new_game);

--- a/src/core/scores.cpp
+++ b/src/core/scores.cpp
@@ -25,6 +25,7 @@
 #include "io/uid-checker.h"
 #include "locale/japanese.h"
 #include "player-info/class-info.h"
+#include "player-base/player-race.h"
 #include "player/player-personality.h"
 #include "player/player-status.h"
 #include "player/race-info-table.h"

--- a/src/core/scores.cpp
+++ b/src/core/scores.cpp
@@ -130,11 +130,11 @@ static int highscore_add(high_score *score)
 
 /*!
  * @brief スコアサーバへの転送処理
- * @param current_player_ptr プレイヤーへの参照ポインタ
+ * @param player_ptr プレイヤーへの参照ポインタ
  * @param do_send 実際に転送ア処置を行うか否か
  * @return 転送が成功したらTRUEを返す
  */
-bool send_world_score(PlayerType *current_player_ptr, bool do_send)
+bool send_world_score(PlayerType *player_ptr, bool do_send)
 {
 #ifdef WORLD_SCORE
     if (!send_score || !do_send) {
@@ -142,7 +142,7 @@ bool send_world_score(PlayerType *current_player_ptr, bool do_send)
     }
 
     auto is_registration = get_check_strict(
-        current_player_ptr, _("スコアをスコア・サーバに登録しますか? ", "Do you send score to the world score server? "), (CHECK_NO_ESCAPE | CHECK_NO_HISTORY));
+        player_ptr, _("スコアをスコア・サーバに登録しますか? ", "Do you send score to the world score server? "), (CHECK_NO_ESCAPE | CHECK_NO_HISTORY));
     if (!is_registration) {
         return true;
     }
@@ -151,7 +151,7 @@ bool send_world_score(PlayerType *current_player_ptr, bool do_send)
     prt(_("送信中．．", "Sending..."), 0, 0);
     term_fresh();
     screen_save();
-    auto successful_send = report_score(current_player_ptr);
+    auto successful_send = report_score(player_ptr);
     screen_load();
     if (!successful_send) {
         return false;
@@ -160,7 +160,7 @@ bool send_world_score(PlayerType *current_player_ptr, bool do_send)
     prt(_("完了。何かキーを押してください。", "Completed.  Hit any key."), 0, 0);
     (void)inkey();
 #else
-    (void)current_player_ptr;
+    (void)player_ptr;
     (void)do_send;
 #endif
     return true;
@@ -170,12 +170,12 @@ bool send_world_score(PlayerType *current_player_ptr, bool do_send)
  * @brief スコアの過去二十位内ランキングを表示する
  * Enters a players name on a hi-score table, if "legal", and in any
  * case, displays some relevant portion of the high score list.
- * @param current_player_ptr プレイヤーへの参照ポインタ
+ * @param player_ptr プレイヤーへの参照ポインタ
  * @return エラーコード
  * @details
  * Assumes "signals_ignore_tstp()" has been called.
  */
-errr top_twenty(PlayerType *current_player_ptr)
+errr top_twenty(PlayerType *player_ptr)
 {
     high_score the_score = {};
     char buf[32];
@@ -184,15 +184,15 @@ errr top_twenty(PlayerType *current_player_ptr)
     sprintf(the_score.what, "%u.%u.%u", H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH);
 
     /* Calculate and save the points */
-    sprintf(the_score.pts, "%9ld", (long)calc_score(current_player_ptr));
+    sprintf(the_score.pts, "%9ld", (long)calc_score(player_ptr));
     the_score.pts[9] = '\0';
 
     /* Save the current gold */
-    sprintf(the_score.gold, "%9lu", (long)current_player_ptr->au);
+    sprintf(the_score.gold, "%9lu", (long)player_ptr->au);
     the_score.gold[9] = '\0';
 
     /* Save the current turn */
-    sprintf(the_score.turns, "%9lu", (long)turn_real(current_player_ptr, w_ptr->game_turn));
+    sprintf(the_score.turns, "%9lu", (long)turn_real(player_ptr, w_ptr->game_turn));
     the_score.turns[9] = '\0';
 
     time_t ct = time((time_t *)0);
@@ -201,39 +201,39 @@ errr top_twenty(PlayerType *current_player_ptr)
     strftime(the_score.day, 10, "@%Y%m%d", localtime(&ct));
 
     /* Save the player name (15 chars) */
-    sprintf(the_score.who, "%-.15s", current_player_ptr->name);
+    sprintf(the_score.who, "%-.15s", player_ptr->name);
 
     /* Save the player info */
-    sprintf(the_score.uid, "%7u", current_player_ptr->player_uid);
-    sprintf(the_score.sex, "%c", (current_player_ptr->psex ? 'm' : 'f'));
-    snprintf(buf, sizeof(buf), "%2d", std::min(enum2i(current_player_ptr->prace), MAX_RACES));
+    sprintf(the_score.uid, "%7u", player_ptr->player_uid);
+    sprintf(the_score.sex, "%c", (player_ptr->psex ? 'm' : 'f'));
+    snprintf(buf, sizeof(buf), "%2d", std::min(enum2i(player_ptr->prace), MAX_RACES));
     memcpy(the_score.p_r, buf, 3);
-    snprintf(buf, sizeof(buf), "%2d", enum2i(std::min(current_player_ptr->pclass, PlayerClassType::MAX)));
+    snprintf(buf, sizeof(buf), "%2d", enum2i(std::min(player_ptr->pclass, PlayerClassType::MAX)));
     memcpy(the_score.p_c, buf, 3);
-    snprintf(buf, sizeof(buf), "%2d", std::min(current_player_ptr->ppersonality, MAX_PERSONALITIES));
+    snprintf(buf, sizeof(buf), "%2d", std::min(player_ptr->ppersonality, MAX_PERSONALITIES));
     memcpy(the_score.p_a, buf, 3);
 
     /* Save the level and such */
-    sprintf(the_score.cur_lev, "%3d", std::min<ushort>(current_player_ptr->lev, 999));
-    sprintf(the_score.cur_dun, "%3d", (int)current_player_ptr->current_floor_ptr->dun_level);
-    sprintf(the_score.max_lev, "%3d", std::min<ushort>(current_player_ptr->max_plv, 999));
-    sprintf(the_score.max_dun, "%3d", (int)max_dlv[current_player_ptr->dungeon_idx]);
+    sprintf(the_score.cur_lev, "%3d", std::min<ushort>(player_ptr->lev, 999));
+    sprintf(the_score.cur_dun, "%3d", (int)player_ptr->current_floor_ptr->dun_level);
+    sprintf(the_score.max_lev, "%3d", std::min<ushort>(player_ptr->max_plv, 999));
+    sprintf(the_score.max_dun, "%3d", (int)max_dlv[player_ptr->dungeon_idx]);
 
     /* Save the cause of death (31 chars) */
-    if (strlen(current_player_ptr->died_from) >= sizeof(the_score.how)) {
+    if (strlen(player_ptr->died_from) >= sizeof(the_score.how)) {
 #ifdef JP
-        angband_strcpy(the_score.how, current_player_ptr->died_from, sizeof(the_score.how) - 2);
+        angband_strcpy(the_score.how, player_ptr->died_from, sizeof(the_score.how) - 2);
         strcat(the_score.how, "…");
 #else
-        angband_strcpy(the_score.how, current_player_ptr->died_from, sizeof(the_score.how) - 3);
+        angband_strcpy(the_score.how, player_ptr->died_from, sizeof(the_score.how) - 3);
         strcat(the_score.how, "...");
 #endif
     } else {
-        strcpy(the_score.how, current_player_ptr->died_from);
+        strcpy(the_score.how, player_ptr->died_from);
     }
 
     /* Grab permissions */
-    safe_setuid_grab(current_player_ptr);
+    safe_setuid_grab(player_ptr);
 
     /* Lock (for writing) the highscore file, or fail */
     errr err = fd_lock(highscore_fd, F_WRLCK);
@@ -248,7 +248,7 @@ errr top_twenty(PlayerType *current_player_ptr)
     int j = highscore_add(&the_score);
 
     /* Grab permissions */
-    safe_setuid_grab(current_player_ptr);
+    safe_setuid_grab(player_ptr);
 
     /* Unlock the highscore file, or fail */
     err = fd_lock(highscore_fd, F_UNLCK);
@@ -276,7 +276,7 @@ errr top_twenty(PlayerType *current_player_ptr)
  * Predict the players location, and display it.
  * @return エラーコード
  */
-errr predict_score(PlayerType *current_player_ptr)
+errr predict_score(PlayerType *player_ptr)
 {
     high_score the_score;
     char buf[32];
@@ -292,35 +292,35 @@ errr predict_score(PlayerType *current_player_ptr)
     sprintf(the_score.what, "%u.%u.%u", H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH);
 
     /* Calculate and save the points */
-    sprintf(the_score.pts, "%9ld", (long)calc_score(current_player_ptr));
+    sprintf(the_score.pts, "%9ld", (long)calc_score(player_ptr));
 
     /* Save the current gold */
-    sprintf(the_score.gold, "%9lu", (long)current_player_ptr->au);
+    sprintf(the_score.gold, "%9lu", (long)player_ptr->au);
 
     /* Save the current turn */
-    sprintf(the_score.turns, "%9lu", (long)turn_real(current_player_ptr, w_ptr->game_turn));
+    sprintf(the_score.turns, "%9lu", (long)turn_real(player_ptr, w_ptr->game_turn));
 
     /* Hack -- no time needed */
     strcpy(the_score.day, _("今日", "TODAY"));
 
     /* Save the player name (15 chars) */
-    sprintf(the_score.who, "%-.15s", current_player_ptr->name);
+    sprintf(the_score.who, "%-.15s", player_ptr->name);
 
     /* Save the player info */
-    sprintf(the_score.uid, "%7u", current_player_ptr->player_uid);
-    sprintf(the_score.sex, "%c", (current_player_ptr->psex ? 'm' : 'f'));
-    snprintf(buf, sizeof(buf), "%2d", std::min(enum2i(current_player_ptr->prace), MAX_RACES));
+    sprintf(the_score.uid, "%7u", player_ptr->player_uid);
+    sprintf(the_score.sex, "%c", (player_ptr->psex ? 'm' : 'f'));
+    snprintf(buf, sizeof(buf), "%2d", std::min(enum2i(player_ptr->prace), MAX_RACES));
     memcpy(the_score.p_r, buf, 3);
-    snprintf(buf, sizeof(buf), "%2d", enum2i(std::min(current_player_ptr->pclass, PlayerClassType::MAX)));
+    snprintf(buf, sizeof(buf), "%2d", enum2i(std::min(player_ptr->pclass, PlayerClassType::MAX)));
     memcpy(the_score.p_c, buf, 3);
-    snprintf(buf, sizeof(buf), "%2d", std::min(current_player_ptr->ppersonality, MAX_PERSONALITIES));
+    snprintf(buf, sizeof(buf), "%2d", std::min(player_ptr->ppersonality, MAX_PERSONALITIES));
     memcpy(the_score.p_a, buf, 3);
 
     /* Save the level and such */
-    sprintf(the_score.cur_lev, "%3d", std::min<ushort>(current_player_ptr->lev, 999));
-    sprintf(the_score.cur_dun, "%3d", (int)current_player_ptr->current_floor_ptr->dun_level);
-    sprintf(the_score.max_lev, "%3d", std::min<ushort>(current_player_ptr->max_plv, 999));
-    sprintf(the_score.max_dun, "%3d", (int)max_dlv[current_player_ptr->dungeon_idx]);
+    sprintf(the_score.cur_lev, "%3d", std::min<ushort>(player_ptr->lev, 999));
+    sprintf(the_score.cur_dun, "%3d", (int)player_ptr->current_floor_ptr->dun_level);
+    sprintf(the_score.max_lev, "%3d", std::min<ushort>(player_ptr->max_plv, 999));
+    sprintf(the_score.max_dun, "%3d", (int)max_dlv[player_ptr->dungeon_idx]);
 
     /* まだ死んでいないときの識別文字 */
     strcpy(the_score.how, _("yet", "nobody (yet!)"));
@@ -343,7 +343,7 @@ errr predict_score(PlayerType *current_player_ptr)
  * @brief スコアランキングの簡易表示 /
  * show_highclass - selectively list highscores based on class -KMW-
  */
-void show_highclass(PlayerType *current_player_ptr)
+void show_highclass(PlayerType *player_ptr)
 {
     screen_save();
     char buf[1024], out_val[256];
@@ -389,9 +389,9 @@ void show_highclass(PlayerType *current_player_ptr)
     }
 
 #ifdef JP
-    sprintf(out_val, "あなた) %sの%s (レベル %2d)", race_info[enum2i(current_player_ptr->prace)].title, current_player_ptr->name, current_player_ptr->lev);
+    sprintf(out_val, "あなた) %sの%s (レベル %2d)", race_info[enum2i(player_ptr->prace)].title, player_ptr->name, player_ptr->lev);
 #else
-    sprintf(out_val, "You) %s the %s (Level %2d)", current_player_ptr->name, race_info[enum2i(current_player_ptr->prace)].title, current_player_ptr->lev);
+    sprintf(out_val, "You) %s the %s (Level %2d)", player_ptr->name, race_info[enum2i(player_ptr->prace)].title, player_ptr->lev);
 #endif
 
     prt(out_val, (m + 8), 0);
@@ -412,7 +412,7 @@ void show_highclass(PlayerType *current_player_ptr)
  * Race Legends -KMW-
  * @param race_num 種族ID
  */
-void race_score(PlayerType *current_player_ptr, int race_num)
+void race_score(PlayerType *player_ptr, int race_num)
 {
     int i = 0, j, m = 0;
     int pr, clev, lastlev;
@@ -469,11 +469,11 @@ void race_score(PlayerType *current_player_ptr, int race_num)
     }
 
     /* add player if qualified */
-    if ((enum2i(current_player_ptr->prace) == race_num) && (current_player_ptr->lev >= lastlev)) {
+    if ((enum2i(player_ptr->prace) == race_num) && (player_ptr->lev >= lastlev)) {
 #ifdef JP
-        sprintf(out_val, "あなた) %sの%s (レベル %2d)", race_info[enum2i(current_player_ptr->prace)].title, current_player_ptr->name, current_player_ptr->lev);
+        sprintf(out_val, "あなた) %sの%s (レベル %2d)", race_info[enum2i(player_ptr->prace)].title, player_ptr->name, player_ptr->lev);
 #else
-        sprintf(out_val, "You) %s the %s (Level %3d)", current_player_ptr->name, race_info[enum2i(current_player_ptr->prace)].title, current_player_ptr->lev);
+        sprintf(out_val, "You) %s the %s (Level %3d)", player_ptr->name, race_info[enum2i(player_ptr->prace)].title, player_ptr->lev);
 #endif
 
         prt(out_val, (m + 8), 0);
@@ -487,10 +487,10 @@ void race_score(PlayerType *current_player_ptr, int race_num)
  * @brief スコアランキングの簡易表示(種族毎)メインルーチン /
  * Race Legends -KMW-
  */
-void race_legends(PlayerType *current_player_ptr)
+void race_legends(PlayerType *player_ptr)
 {
     for (int i = 0; i < MAX_RACES; i++) {
-        race_score(current_player_ptr, i);
+        race_score(player_ptr, i);
         msg_print(_("何かキーを押すとゲームに戻ります", "Hit any key to continue"));
         msg_print(nullptr);
         for (int j = 5; j < 19; j++)
@@ -502,7 +502,7 @@ void race_legends(PlayerType *current_player_ptr)
  * @brief スコアファイル出力
  * Display some character info
  */
-bool check_score(PlayerType *current_player_ptr)
+bool check_score(PlayerType *player_ptr)
 {
     term_clear();
 
@@ -528,14 +528,14 @@ bool check_score(PlayerType *current_player_ptr)
     }
 
     /* Interupted */
-    if (!w_ptr->total_winner && streq(current_player_ptr->died_from, _("強制終了", "Interrupting"))) {
+    if (!w_ptr->total_winner && streq(player_ptr->died_from, _("強制終了", "Interrupting"))) {
         msg_print(_("強制終了のためスコアが記録されません。", "Score not registered due to interruption."));
         msg_print(nullptr);
         return false;
     }
 
     /* Quitter */
-    if (!w_ptr->total_winner && streq(current_player_ptr->died_from, _("途中終了", "Quitting"))) {
+    if (!w_ptr->total_winner && streq(player_ptr->died_from, _("途中終了", "Quitting"))) {
         msg_print(_("途中終了のためスコアが記録されません。", "Score not registered due to quitting."));
         msg_print(nullptr);
         return false;

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -484,7 +484,7 @@ static void effect_player_time_addition(PlayerType *player_ptr)
     case 3:
     case 4:
     case 5: {
-        if (player_ptr->prace == PlayerRaceType::ANDROID)
+        if (PlayerRace(player_ptr).equals(PlayerRaceType::ANDROID))
             break;
 
         msg_print(_("人生が逆戻りした気がする。", "You feel like a chunk of the past has been ripped away."));

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -17,6 +17,7 @@
 #include "object-enchant/trc-types.h"
 #include "object/object-flags.h"
 #include "perception/object-perception.h"
+#include "player-base/player-race.h"
 #include "player-info/race-types.h"
 #include "player/player-damage.h"
 #include "player/player-status-flags.h"
@@ -220,7 +221,7 @@ static void occur_chainsword_effect(PlayerType *player_ptr)
 
 static void curse_drain_exp(PlayerType *player_ptr)
 {
-    if ((player_ptr->prace == PlayerRaceType::ANDROID) || (player_ptr->cursed.has_not(CurseTraitType::DRAIN_EXP)) || !one_in_(4))
+    if (PlayerRace(player_ptr).equals(PlayerRaceType::ANDROID) || (player_ptr->cursed.has_not(CurseTraitType::DRAIN_EXP)) || !one_in_(4))
         return;
 
     player_ptr->exp -= (player_ptr->lev + 1) / 2;

--- a/src/monster-attack/monster-attack-lose.cpp
+++ b/src/monster-attack/monster-attack-lose.cpp
@@ -2,6 +2,7 @@
 #include "mind/mind-mirror-master.h"
 #include "monster-attack/monster-attack-player.h"
 #include "monster-attack/monster-attack-status.h"
+#include "player-base/player-race.h"
 #include "player/player-damage.h"
 #include "player/player-status-flags.h"
 #include "player/player-status-resist.h"
@@ -33,7 +34,7 @@ void calc_blow_disease(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
         monap_ptr->obvious = true;
 
     bool disease_possibility = randint1(100) > calc_nuke_damage_rate(player_ptr);
-    if (disease_possibility || (randint1(100) > 10) || (player_ptr->prace == PlayerRaceType::ANDROID))
+    if (disease_possibility || (randint1(100) > 10) || PlayerRace(player_ptr).equals(PlayerRaceType::ANDROID))
         return;
 
     bool perm = one_in_(10);

--- a/src/monster-attack/monster-attack-status.cpp
+++ b/src/monster-attack/monster-attack-status.cpp
@@ -10,6 +10,7 @@
 #include "monster-attack/monster-attack-player.h"
 #include "monster-race/monster-race.h"
 #include "monster-race/race-indice-types.h"
+#include "player-base/player-race.h"
 #include "player/player-status-flags.h"
 #include "status/bad-status-setter.h"
 #include "status/base-status.h"
@@ -28,7 +29,7 @@ void process_blind_attack(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr
 
     auto is_dio = monap_ptr->m_ptr->r_idx == MON_DIO;
     auto dio_msg = _("どうだッ！この血の目潰しはッ！", "How is it! This blood-blinding!");
-    if (is_dio && player_ptr->prace == PlayerRaceType::SKELETON) {
+    if (is_dio && PlayerRace(player_ptr).equals(PlayerRaceType::SKELETON)) {
         msg_print(dio_msg);
         msg_print(_("しかし、あなたには元々目はなかった！", "However, you don't have eyes!"));
         return;
@@ -180,7 +181,7 @@ void process_monster_attack_time(PlayerType *player_ptr, MonsterAttackPlayer *mo
     case 3:
     case 4:
     case 5:
-        if (player_ptr->prace == PlayerRaceType::ANDROID) {
+        if (PlayerRace(player_ptr).equals(PlayerRaceType::ANDROID)) {
             break;
         }
 

--- a/src/mspell/mspell-judgement.cpp
+++ b/src/mspell/mspell-judgement.cpp
@@ -23,6 +23,7 @@
 #include "monster/monster-info.h"
 #include "monster/monster-status.h"
 #include "player-base/player-class.h"
+#include "player-base/player-race.h"
 #include "player-info/race-info.h"
 #include "player/attack-defense-types.h"
 #include "player/player-status-flags.h"
@@ -269,7 +270,7 @@ bool dispel_check(PlayerType *player_ptr, MONSTER_IDX m_idx)
     }
 
     if (r_ptr->ability_flags.has(MonsterAbilityType::BR_FIRE)) {
-        if (!((player_ptr->prace == PlayerRaceType::BALROG) && player_ptr->lev > 44)) {
+        if (!(PlayerRace(player_ptr).equals(PlayerRaceType::BALROG) && player_ptr->lev > 44)) {
             if (!has_immune_fire(player_ptr) && (player_ptr->oppose_fire || music_singing(player_ptr, MUSIC_RESIST)))
                 return true;
 

--- a/src/mutation/mutation-calculator.cpp
+++ b/src/mutation/mutation-calculator.cpp
@@ -13,6 +13,7 @@
 
 #include "mutation/mutation-calculator.h"
 #include "mutation/mutation-flag-types.h"
+#include "player-base/player-race.h"
 #include "system/player-type-definition.h"
 
  /*!
@@ -40,7 +41,7 @@ int calc_mutant_regenerate_mod(PlayerType *player_ptr)
     if (player_ptr->ppersonality == PERSONALITY_LUCKY)
         count--;
 
-    if (player_ptr->prace == PlayerRaceType::BEASTMAN) {
+    if (PlayerRace(player_ptr).equals(PlayerRaceType::BEASTMAN)) {
         count -= 10;
         mod = 5;
     }

--- a/src/mutation/mutation-investor-remover.cpp
+++ b/src/mutation/mutation-investor-remover.cpp
@@ -7,6 +7,7 @@
 #include "mutation/mutation-calculator.h" //!< @todo calc_mutant_regenerate_mod() が相互依存している、後で消す.
 #include "mutation/mutation-flag-types.h"
 #include "mutation/mutation-util.h"
+#include "player-base/player-race.h"
 #include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
@@ -32,31 +33,32 @@ static void race_dependent_mutation(PlayerType *player_ptr, glm_type *gm_ptr)
     if (gm_ptr->choose_mut != 0)
         return;
 
-    if (player_ptr->prace == PlayerRaceType::VAMPIRE && player_ptr->muta.has_not(PlayerMutationType::HYPN_GAZE) && (randint1(10) < 7)) {
+    PlayerRace pr(player_ptr);
+    if (pr.equals(PlayerRaceType::VAMPIRE) && player_ptr->muta.has_not(PlayerMutationType::HYPN_GAZE) && (randint1(10) < 7)) {
         gm_ptr->muta_which = PlayerMutationType::HYPN_GAZE;
         gm_ptr->muta_desc = _("眼が幻惑的になった...", "Your eyes look mesmerizing...");
         return;
     }
 
-    if (player_ptr->prace == PlayerRaceType::IMP && player_ptr->muta.has_not(PlayerMutationType::HORNS) && (randint1(10) < 7)) {
+    if (pr.equals(PlayerRaceType::IMP) && player_ptr->muta.has_not(PlayerMutationType::HORNS) && (randint1(10) < 7)) {
         gm_ptr->muta_which = PlayerMutationType::HORNS;
         gm_ptr->muta_desc = _("角が額から生えてきた！", "Horns pop forth into your forehead!");
         return;
     }
 
-    if (player_ptr->prace == PlayerRaceType::YEEK && player_ptr->muta.has_not(PlayerMutationType::SHRIEK) && (randint1(10) < 7)) {
+    if (pr.equals(PlayerRaceType::YEEK) && player_ptr->muta.has_not(PlayerMutationType::SHRIEK) && (randint1(10) < 7)) {
         gm_ptr->muta_which = PlayerMutationType::SHRIEK;
         gm_ptr->muta_desc = _("声質がかなり強くなった。", "Your vocal cords get much tougher.");
         return;
     }
 
-    if (player_ptr->prace == PlayerRaceType::BEASTMAN && player_ptr->muta.has_not(PlayerMutationType::POLYMORPH) && (randint1(10) < 2)) {
+    if (pr.equals(PlayerRaceType::BEASTMAN) && player_ptr->muta.has_not(PlayerMutationType::POLYMORPH) && (randint1(10) < 2)) {
         gm_ptr->muta_which = PlayerMutationType::POLYMORPH;
         gm_ptr->muta_desc = _("あなたの肉体は変化できるようになった、", "Your body seems mutable.");
         return;
     }
 
-    if (player_ptr->prace == PlayerRaceType::MIND_FLAYER && player_ptr->muta.has_not(PlayerMutationType::TENTACLES) && (randint1(10) < 7)) {
+    if (pr.equals(PlayerRaceType::MIND_FLAYER) && player_ptr->muta.has_not(PlayerMutationType::TENTACLES) && (randint1(10) < 7)) {
         gm_ptr->muta_which = PlayerMutationType::TENTACLES;
         gm_ptr->muta_desc = _("邪悪な触手が口の周りに生えた。", "Evil-looking tentacles sprout from your mouth.");
     }

--- a/src/object-use/quaff-execution.cpp
+++ b/src/object-use/quaff-execution.cpp
@@ -439,7 +439,7 @@ void ObjectQuaffEntity::execute(INVENTORY_IDX item)
             break;
 
         case SV_POTION_EXPERIENCE:
-            if (this->player_ptr->prace == PlayerRaceType::ANDROID)
+            if (PlayerRace(this->player_ptr).equals(PlayerRaceType::ANDROID))
                 break;
             chg_virtue(this->player_ptr, V_ENLIGHTEN, 1);
             if (this->player_ptr->exp < PY_MAX_EXP) {

--- a/src/player-base/player-race.cpp
+++ b/src/player-base/player-race.cpp
@@ -40,10 +40,10 @@ TrFlags PlayerRace::tr_flags() const
         flags.set(TR_INFRA);
 
     for (auto &cond : race_ptr->extra_flags) {
-        if (player_ptr->lev < cond.level)
+        if (this->player_ptr->lev < cond.level)
             continue;
         if (cond.pclass.has_value()) {
-            auto is_class_equal = PlayerClass(player_ptr).equals(cond.pclass.value());
+            auto is_class_equal = PlayerClass(this->player_ptr).equals(cond.pclass.value());
             if (cond.not_class && is_class_equal)
                 continue;
             if (!cond.not_class && !is_class_equal)
@@ -106,17 +106,16 @@ bool PlayerRace::is_mimic_nonliving() const
 
 bool PlayerRace::has_cut_immunity() const
 {
-    auto cut_immunity = PlayerRace(this->player_ptr).equals(PlayerRaceType::GOLEM);
-    cut_immunity |= PlayerRace(this->player_ptr).equals(PlayerRaceType::SKELETON);
-    cut_immunity |= PlayerRace(this->player_ptr).equals(PlayerRaceType::SPECTRE);
-    cut_immunity |= PlayerRace(this->player_ptr).equals(PlayerRaceType::ZOMBIE) && (this->player_ptr->lev > 11);
+    auto cut_immunity = this->equals(PlayerRaceType::GOLEM);
+    cut_immunity |= this->equals(PlayerRaceType::SKELETON);
+    cut_immunity |= this->equals(PlayerRaceType::SPECTRE);
+    cut_immunity |= this->equals(PlayerRaceType::ZOMBIE) && (this->player_ptr->lev > 11);
     return cut_immunity;
 }
 
-
 bool PlayerRace::has_stun_immunity() const
 {
-    return PlayerRace(this->player_ptr).equals(PlayerRaceType::GOLEM);
+    return this->equals(PlayerRaceType::GOLEM);
 }
 
 bool PlayerRace::equals(PlayerRaceType prace) const
@@ -138,10 +137,10 @@ int16_t PlayerRace::speed() const
 {
     int16_t result = 0;
 
-    if (PlayerRace(this->player_ptr).equals(PlayerRaceType::KLACKON) || PlayerRace(this->player_ptr).equals(PlayerRaceType::SPRITE))
+    if (this->equals(PlayerRaceType::KLACKON) || this->equals(PlayerRaceType::SPRITE))
         result += (this->player_ptr->lev) / 10;
 
-    if (PlayerRace(this->player_ptr).equals(PlayerRaceType::MERFOLK)) {
+    if (this->equals(PlayerRaceType::MERFOLK)) {
         auto *floor_ptr = this->player_ptr->current_floor_ptr;
         auto *f_ptr = &f_info[floor_ptr->grid_array[this->player_ptr->y][this->player_ptr->x].feat];
         if (f_ptr->flags.has(FloorFeatureType::WATER)) {
@@ -178,7 +177,7 @@ int16_t PlayerRace::additional_strength() const
 {
     int16_t result = 0;
 
-    if (PlayerRace(this->player_ptr).equals(PlayerRaceType::ENT)) {
+    if (this->equals(PlayerRaceType::ENT)) {
         if (this->player_ptr->lev > 25)
             result++;
         if (this->player_ptr->lev > 40)
@@ -201,7 +200,7 @@ int16_t PlayerRace::additional_dexterity() const
 {
     int16_t result = 0;
 
-    if (PlayerRace(this->player_ptr).equals(PlayerRaceType::ENT)) {
+    if (this->equals(PlayerRaceType::ENT)) {
         if (this->player_ptr->lev > 25)
             result--;
         if (this->player_ptr->lev > 40)

--- a/src/player-status/player-speed.cpp
+++ b/src/player-status/player-speed.cpp
@@ -111,7 +111,8 @@ int16_t PlayerSpeed::class_value()
 int16_t PlayerSpeed::personality_value()
 {
     int16_t result = 0;
-    if (this->player_ptr->ppersonality == PERSONALITY_MUNCHKIN && this->player_ptr->prace != PlayerRaceType::KLACKON && this->player_ptr->prace != PlayerRaceType::SPRITE) {
+    PlayerRace pr(this->player_ptr);
+    if (this->player_ptr->ppersonality == PERSONALITY_MUNCHKIN && !pr.equals(PlayerRaceType::KLACKON) && !pr.equals(PlayerRaceType::SPRITE)) {
         result += (this->player_ptr->lev) / 10 + 5;
     }
     return result;

--- a/src/player/patron.cpp
+++ b/src/player/patron.cpp
@@ -14,6 +14,7 @@
 #include "object-enchant/object-curse.h"
 #include "object/object-kind-hook.h"
 #include "player-base/player-class.h"
+#include "player-base/player-race.h"
 #include "player-info/class-info.h"
 #include "player-info/equipment-info.h"
 #include "player-info/race-types.h"
@@ -201,7 +202,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.c_str());
             msg_print(_("「汝は良く行いたり！続けよ！」", "'Well done, mortal! Lead on!'"));
 
-            if (this->player_ptr->prace == PlayerRaceType::ANDROID) {
+            if (PlayerRace(this->player_ptr).equals(PlayerRaceType::ANDROID)) {
                 msg_print(_("しかし何も起こらなかった。", "But, nothing happens."));
             } else if (this->player_ptr->exp < PY_MAX_EXP) {
                 int32_t ee = (this->player_ptr->exp / 2) + 10;
@@ -219,7 +220,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.c_str());
             msg_print(_("「下僕よ、汝それに値せず。」", "'Thou didst not deserve that, slave.'"));
 
-            if (this->player_ptr->prace == PlayerRaceType::ANDROID) {
+            if (PlayerRace(this->player_ptr).equals(PlayerRaceType::ANDROID)) {
                 msg_print(_("しかし何も起こらなかった。", "But, nothing happens."));
             } else {
                 lose_exp(player_ptr, this->player_ptr->exp / 6);

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -44,6 +44,7 @@
 #include "object/object-broken.h"
 #include "object/object-flags.h"
 #include "player-base/player-class.h"
+#include "player-base/player-race.h"
 #include "player-info/class-info.h"
 #include "player-info/race-types.h"
 #include "player-info/samurai-data-type.h"
@@ -351,7 +352,7 @@ int take_hit(PlayerType *player_ptr, int damage_type, int damage, concptr hit_fr
     }
 
     if (player_ptr->chp < 0 && !cheat_immortal) {
-        bool android = player_ptr->prace == PlayerRaceType::ANDROID;
+        bool android = PlayerRace(player_ptr).equals(PlayerRaceType::ANDROID);
 
         /* 死んだ時に強制終了して死を回避できなくしてみた by Habu */
         if (!cheat_save && !save_player(player_ptr, SAVE_TYPE_CLOSE_GAME))

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -31,6 +31,7 @@
 #include "monster/monster-update.h"
 #include "perception/object-perception.h"
 #include "player-base/player-class.h"
+#include "player-base/player-race.h"
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
 #include "player/player-status-flags.h"
@@ -184,7 +185,7 @@ bool move_player_effect(PlayerType *player_ptr, POSITION ny, POSITION nx, BIT_FL
             set_action(player_ptr, ACTION_NONE);
         }
 
-        if (player_ptr->prace == PlayerRaceType::MERFOLK) {
+        if (PlayerRace(player_ptr).equals(PlayerRaceType::MERFOLK)) {
             if (f_ptr->flags.has(FloorFeatureType::WATER) ^ of_ptr->flags.has(FloorFeatureType::WATER)) {
                 player_ptr->update |= PU_BONUS;
                 update_creature(player_ptr);

--- a/src/player/player-skill.cpp
+++ b/src/player/player-skill.cpp
@@ -2,6 +2,7 @@
 #include "core/player-update-types.h"
 #include "monster-race/monster-race.h"
 #include "player-base/player-class.h"
+#include "player-base/player-race.h"
 #include "player-info/class-info.h"
 #include "player/player-realm.h"
 #include "sv-definition/sv-weapon-types.h"
@@ -438,7 +439,7 @@ void PlayerSkill::apply_special_weapon_skill_max_values()
         w_exp_max[ItemKindType::HAFTED][SV_WHIP] = PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER);
     }
 
-    if (this->player_ptr->prace == PlayerRaceType::MERFOLK) {
+    if (PlayerRace(player_ptr).equals(PlayerRaceType::MERFOLK)) {
         w_exp_max[ItemKindType::POLEARM][SV_TRIDENT] = PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER);
         w_exp_max[ItemKindType::POLEARM][SV_TRIFURCATE_SPEAR] = PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER);
     }

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -495,7 +495,7 @@ bool has_pass_wall(PlayerType *player_ptr)
 {
     bool pow = false;
 
-    if (player_ptr->wraith_form || player_ptr->tim_pass_wall || (!player_ptr->mimic_form && player_ptr->prace == PlayerRaceType::SPECTRE)) {
+    if (player_ptr->wraith_form || player_ptr->tim_pass_wall || PlayerRace(player_ptr).equals(PlayerRaceType::SPECTRE)) {
         pow = true;
     }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -1335,7 +1335,7 @@ static ACTION_SKILL_POWER calc_skill_dig(PlayerType *player_ptr)
 
     pow = 0;
 
-    if (!player_ptr->mimic_form && player_ptr->prace == PlayerRaceType::ENT && !player_ptr->inventory_list[INVEN_MAIN_HAND].k_idx) {
+    if (PlayerRace(player_ptr).equals(PlayerRaceType::ENT) && !player_ptr->inventory_list[INVEN_MAIN_HAND].k_idx) {
         pow += player_ptr->lev * 10;
     }
 
@@ -1632,7 +1632,8 @@ static ARMOUR_CLASS calc_to_ac(PlayerType *player_ptr, bool is_real_value)
         }
     }
 
-    if (PlayerRace(player_ptr).equals(PlayerRaceType::GOLEM) || PlayerRace(player_ptr).equals(PlayerRaceType::ANDROID)) {
+    PlayerRace pr(player_ptr);
+    if (pr.equals(PlayerRaceType::GOLEM) || pr.equals(PlayerRaceType::ANDROID)) {
         ac += 10 + (player_ptr->lev * 2 / 5);
     }
 
@@ -2643,7 +2644,8 @@ void check_experience(PlayerType *player_ptr)
     set_bits(player_ptr->redraw, PR_EXP);
     handle_stuff(player_ptr);
 
-    bool android = player_ptr->prace == PlayerRaceType::ANDROID;
+    PlayerRace pr(player_ptr);
+    bool android = pr.equals(PlayerRaceType::ANDROID);
     PLAYER_LEVEL old_lev = player_ptr->lev;
     while ((player_ptr->lev > 1) && (player_ptr->exp < ((android ? player_exp_a : player_exp)[player_ptr->lev - 2] * player_ptr->expfact / 100L))) {
         player_ptr->lev--;
@@ -2665,7 +2667,7 @@ void check_experience(PlayerType *player_ptr)
             if (PlayerClass(player_ptr).equals(PlayerClassType::CHAOS_WARRIOR) || player_ptr->muta.has(PlayerMutationType::CHAOS_GIFT)) {
                 level_reward = true;
             }
-            if (player_ptr->prace == PlayerRaceType::BEASTMAN) {
+            if (pr.equals(PlayerRaceType::BEASTMAN)) {
                 if (one_in_(5))
                     level_mutation = true;
             }
@@ -2866,7 +2868,7 @@ long calc_score(PlayerType *player_ptr)
     if (ironman_downward)
         point *= 2;
     if (PlayerClass(player_ptr).equals(PlayerClassType::BERSERKER)) {
-        if (player_ptr->prace == PlayerRaceType::SPECTRE)
+        if (PlayerRace(player_ptr).equals(PlayerRaceType::SPECTRE))
             point = point / 5;
     }
 

--- a/src/racial/racial-android.cpp
+++ b/src/racial/racial-android.cpp
@@ -6,6 +6,7 @@
 #include "object/object-kind.h"
 #include "object/object-value-calc.h"
 #include "object/object-value.h"
+#include "player-base/player-race.h"
 #include "player-info/equipment-info.h"
 #include "player/player-status.h"
 #include "spell-kind/spells-launcher.h"
@@ -57,7 +58,7 @@ bool android_inside_weapon(PlayerType *player_ptr)
 void calc_android_exp(PlayerType *player_ptr)
 {
     uint32_t total_exp = 0;
-    if (player_ptr->is_dead || (player_ptr->prace != PlayerRaceType::ANDROID))
+    if (player_ptr->is_dead || !PlayerRace(player_ptr).equals(PlayerRaceType::ANDROID))
         return;
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {

--- a/src/specific-object/bloody-moon.cpp
+++ b/src/specific-object/bloody-moon.cpp
@@ -3,6 +3,7 @@
 #include "core/player-update-types.h"
 #include "object-enchant/object-boost.h"
 #include "object-enchant/tr-types.h"
+#include "player-base/player-race.h"
 #include "racial/racial-android.h"
 #include "system/artifact-type-definition.h"
 #include "system/object-type-definition.h"
@@ -58,7 +59,7 @@ bool activate_bloody_moon(PlayerType *player_ptr, ObjectType *o_ptr)
 
     msg_print(_("鎌が明るく輝いた...", "Your scythe glows brightly!"));
     get_bloody_moon_flags(o_ptr);
-    if (player_ptr->prace == PlayerRaceType::ANDROID)
+    if (PlayerRace(player_ptr).equals(PlayerRaceType::ANDROID))
         calc_android_exp(player_ptr);
 
     player_ptr->update |= PU_BONUS | PU_HP;

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -47,10 +47,11 @@ bool BadStatusSetter::blindness(const TIME_EFFECT tmp_v)
     if (this->player_ptr->is_dead) {
         return false;
     }
-
+    
+    PlayerRace pr(player_ptr);    
     if (v > 0) {
         if (!this->player_ptr->blind) {
-            if (this->player_ptr->prace == PlayerRaceType::ANDROID) {
+            if (pr.equals(PlayerRaceType::ANDROID)) {
                 msg_print(_("センサーをやられた！", "The sensor broke!"));
             } else {
                 msg_print(_("目が見えなくなってしまった！", "You are blind!"));
@@ -61,7 +62,7 @@ bool BadStatusSetter::blindness(const TIME_EFFECT tmp_v)
         }
     } else {
         if (this->player_ptr->blind) {
-            if (this->player_ptr->prace == PlayerRaceType::ANDROID) {
+            if (pr.equals(PlayerRaceType::ANDROID)) {
                 msg_print(_("センサーが復旧した。", "The sensor has been restored."));
             } else {
                 msg_print(_("やっと目が見えるようになった。", "You can see again."));

--- a/src/status/experience.cpp
+++ b/src/status/experience.cpp
@@ -1,4 +1,5 @@
 ﻿#include "status/experience.h"
+#include "player-base/player-race.h"
 #include "player/player-status.h"
 #include "system/player-type-definition.h"
 #include "view/display-messages.h"
@@ -10,7 +11,7 @@ void gain_exp_64(PlayerType *player_ptr, int32_t amount, uint32_t amount_frac)
 {
     if (player_ptr->is_dead)
         return;
-    if (player_ptr->prace == PlayerRaceType::ANDROID)
+    if (PlayerRace(player_ptr).equals(PlayerRaceType::ANDROID))
         return;
 
     s64b_add(&(player_ptr->exp), &(player_ptr->exp_frac), amount, amount_frac);
@@ -32,7 +33,7 @@ void gain_exp(PlayerType *player_ptr, int32_t amount) { gain_exp_64(player_ptr, 
  */
 void lose_exp(PlayerType *player_ptr, int32_t amount)
 {
-    if (player_ptr->prace == PlayerRaceType::ANDROID)
+    if (PlayerRace(player_ptr).equals(PlayerRaceType::ANDROID))
         return;
     if (amount > player_ptr->exp)
         amount = player_ptr->exp;
@@ -63,7 +64,7 @@ bool restore_level(PlayerType *player_ptr)
  */
 bool drain_exp(PlayerType *player_ptr, int32_t drain, int32_t slip, int hold_exp_prob)
 {
-    if (player_ptr->prace == PlayerRaceType::ANDROID)
+    if (PlayerRace(player_ptr).equals(PlayerRaceType::ANDROID))
         return false;
 
     if (player_ptr->hold_exp && (randint0(100) < hold_exp_prob)) {

--- a/src/status/shape-changer.cpp
+++ b/src/status/shape-changer.cpp
@@ -13,6 +13,7 @@
 #include "locale/english.h"
 #include "mutation/mutation-investor-remover.h"
 #include "player-base/player-class.h"
+#include "player-base/player-race.h"
 #include "player-info/class-info.h"
 #include "player/player-damage.h"
 #include "player/player-personality.h"
@@ -78,8 +79,9 @@ void change_race(PlayerType *player_ptr, PlayerRaceType new_race, concptr effect
     bool is_special_class = pc.equals(PlayerClassType::MONK);
     is_special_class |= pc.equals(PlayerClassType::FORCETRAINER);
     is_special_class |= pc.equals(PlayerClassType::NINJA);
-    bool is_special_race = player_ptr->prace == PlayerRaceType::KLACKON;
-    is_special_race |= player_ptr->prace == PlayerRaceType::SPRITE;
+    PlayerRace pr(player_ptr);
+    bool is_special_race = pr.equals(PlayerRaceType::KLACKON);
+    is_special_race |= pr.equals(PlayerRaceType::SPRITE);
     if (is_special_class && is_special_race)
         player_ptr->expfact -= 15;
 
@@ -109,7 +111,8 @@ void do_poly_self(PlayerType *player_ptr)
     msg_print(_("あなたは変化の訪れを感じた...", "You feel a change coming over you..."));
     chg_virtue(player_ptr, V_CHANCE, 1);
 
-    if ((power > randint0(20)) && one_in_(3) && (player_ptr->prace != PlayerRaceType::ANDROID)) {
+    PlayerRace pr(player_ptr);
+    if ((power > randint0(20)) && one_in_(3) && !pr.equals(PlayerRaceType::ANDROID)) {
         char effect_msg[80] = "";
         char sex_msg[32] = "";
         PlayerRaceType new_race;
@@ -157,7 +160,7 @@ void do_poly_self(PlayerType *player_ptr)
 
         do {
             new_race = (PlayerRaceType)randint0(MAX_RACES);
-        } while ((new_race == player_ptr->prace) || (new_race == PlayerRaceType::ANDROID));
+        } while (pr.equals(new_race) || (new_race == PlayerRaceType::ANDROID));
 
         change_race(player_ptr, new_race, effect_msg);
     }
@@ -165,7 +168,7 @@ void do_poly_self(PlayerType *player_ptr)
     if ((power > randint0(30)) && one_in_(6)) {
         int tmp = 0;
         power -= 20;
-        msg_format(_("%sの構成が変化した！", "Your internal organs are rearranged!"), player_ptr->prace == PlayerRaceType::ANDROID ? "機械" : "内臓");
+        msg_format(_("%sの構成が変化した！", "Your internal organs are rearranged!"), pr.equals(PlayerRaceType::ANDROID) ? "機械" : "内臓");
 
         while (tmp < A_MAX) {
             (void)dec_stat(player_ptr, tmp, randint1(6) + 6, one_in_(3));

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -24,6 +24,7 @@
 #include "monster/monster-flag-types.h"
 #include "object/item-tester-hooker.h"
 #include "object/object-mark-types.h"
+#include "player-base/player-race.h"
 #include "player/player-status-table.h"
 #include "system/building-type-definition.h"
 #include "system/floor-type-definition.h"
@@ -97,7 +98,7 @@ static eg_type *initialize_eg_type(PlayerType *player_ptr, eg_type *eg_ptr, POSI
 static void evaluate_monster_exp(PlayerType *player_ptr, char *buf, monster_type *m_ptr)
 {
     monster_race *ap_r_ptr = &r_info[m_ptr->ap_r_idx];
-    if ((player_ptr->lev >= PY_MAX_LEVEL) || (player_ptr->prace == PlayerRaceType::ANDROID)) {
+    if ((player_ptr->lev >= PY_MAX_LEVEL) || PlayerRace(player_ptr).equals(PlayerRaceType::ANDROID)) {
         sprintf(buf, "**");
         return;
     }

--- a/src/view/display-player-middle.cpp
+++ b/src/view/display-player-middle.cpp
@@ -8,6 +8,7 @@
 #include "object-enchant/special-object-flags.h"
 #include "perception/object-perception.h"
 #include "player-base/player-class.h"
+#include "player-base/player-race.h"
 #include "player-info/equipment-info.h"
 #include "player-info/monk-data-type.h"
 #include "player-info/race-types.h"
@@ -220,20 +221,21 @@ static void display_player_speed(PlayerType *player_ptr, TERM_COLOR attr, int ba
  */
 static void display_player_exp(PlayerType *player_ptr)
 {
-    int e = (player_ptr->prace == PlayerRaceType::ANDROID) ? ENTRY_EXP_ANDR : ENTRY_CUR_EXP;
+    PlayerRace pr(player_ptr);
+    int e = pr.equals(PlayerRaceType::ANDROID) ? ENTRY_EXP_ANDR : ENTRY_CUR_EXP;
     if (player_ptr->exp >= player_ptr->max_exp)
         display_player_one_line(e, format("%ld", player_ptr->exp), TERM_L_GREEN);
     else
         display_player_one_line(e, format("%ld", player_ptr->exp), TERM_YELLOW);
 
-    if (player_ptr->prace != PlayerRaceType::ANDROID)
+    if (!pr.equals(PlayerRaceType::ANDROID))
         display_player_one_line(ENTRY_MAX_EXP, format("%ld", player_ptr->max_exp), TERM_L_GREEN);
 
-    e = (player_ptr->prace == PlayerRaceType::ANDROID) ? ENTRY_EXP_TO_ADV_ANDR : ENTRY_EXP_TO_ADV;
+    e = pr.equals(PlayerRaceType::ANDROID) ? ENTRY_EXP_TO_ADV_ANDR : ENTRY_EXP_TO_ADV;
 
     if (player_ptr->lev >= PY_MAX_LEVEL)
         display_player_one_line(e, "*****", TERM_L_GREEN);
-    else if (player_ptr->prace == PlayerRaceType::ANDROID)
+    else if (pr.equals(PlayerRaceType::ANDROID))
         display_player_one_line(e, format("%ld", (int32_t)(player_exp_a[player_ptr->lev - 1] * player_ptr->expfact / 100L)), TERM_L_GREEN);
     else
         display_player_one_line(e, format("%ld", (int32_t)(player_exp[player_ptr->lev - 1] * player_ptr->expfact / 100L)), TERM_L_GREEN);

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -4,6 +4,7 @@
 #include "market/arena-info-table.h"
 #include "monster-race/monster-race.h"
 #include "monster/monster-status.h"
+#include "player-base/player-race.h"
 #include "player-info/class-info.h"
 #include "player-info/mimic-info-table.h"
 #include "player/player-status-table.h"
@@ -65,7 +66,8 @@ void print_exp(PlayerType *player_ptr)
 {
     char out_val[32];
 
-    if ((!exp_need) || (player_ptr->prace == PlayerRaceType::ANDROID)) {
+    PlayerRace pr(player_ptr);
+    if ((!exp_need) || pr.equals(PlayerRaceType::ANDROID)) {
         (void)sprintf(out_val, "%8ld", (long)player_ptr->exp);
     } else {
         if (player_ptr->lev >= PY_MAX_LEVEL) {
@@ -76,7 +78,7 @@ void print_exp(PlayerType *player_ptr)
     }
 
     if (player_ptr->exp >= player_ptr->max_exp) {
-        if (player_ptr->prace == PlayerRaceType::ANDROID)
+        if (pr.equals(PlayerRaceType::ANDROID))
             put_str(_("強化 ", "Cst "), ROW_EXP, 0);
         else
             put_str(_("経験 ", "EXP "), ROW_EXP, 0);

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -58,6 +58,7 @@
 #include "object/object-kind.h"
 #include "perception/object-perception.h"
 #include "player-base/player-class.h"
+#include "player-base/player-race.h"
 #include "player-info/class-info.h"
 #include "player-info/race-info.h"
 #include "player-info/race-types.h"
@@ -456,7 +457,7 @@ void wiz_change_status(PlayerType *player_ptr)
     if (tmp_long < 0)
         tmp_long = 0L;
 
-    if (player_ptr->prace == PlayerRaceType::ANDROID)
+    if (PlayerRace(player_ptr).equals(PlayerRaceType::ANDROID))
         return;
 
     player_ptr->max_exp = tmp_long;


### PR DESCRIPTION
掲題の通りです
元々あった(？) equals() の定義だと、変身していない (mimic\_form == MIMIC\_NONE)判定を同時にやっています
恐らくこれといって害はないと思われますが、併せてご確認下さい
(見た感じでは、変身の判定自体ほとんど＠自身の種族とは別枠な気がする？)