### PR TITLE
[Feature] ビルドテストの Workflow に BOM チェックを追加

### DIFF
--- a/.github/scripts/check-bom.sh
+++ b/.github/scripts/check-bom.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+SRC_FILES=$(find src/ -name \*.cpp -or -name \*.h)
+
+STATUS=0
+
+for file in $SRC_FILES; do
+    file $file | grep "BOM" >/dev/null
+    if [ $? != 0 ]; then
+        echo "$file: BOM does not exists."
+        STATUS=1
+    fi
+done
+
+exit $STATUS

--- a/.github/workflows/buildtest-on-linux.yml
+++ b/.github/workflows/buildtest-on-linux.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Check the BOM of the source files
+        run: sh .github/scripts/check-bom.sh
+
       - name: Install required packages
         run: |
           sudo apt-get update


### PR DESCRIPTION
新しく追加したソースファイルへの BOM 付け忘れや修正したソースファイルからの BOM 消失
防止のため、GitHub Actions のビルドテストでビルド実行前にすべてのソースフィアルに
BOM が付いているかどうかのチェックを行うようにする。