### PR TITLE
[Refactor] エゴアイテムの情報を格納する e_info を std::map にする

### DIFF
--- a/src/action/activation-execution.cpp
+++ b/src/action/activation-execution.cpp
@@ -65,7 +65,7 @@ static void decide_activation_level(ae_type *ae_ptr)
     }
 
     if (((ae_ptr->o_ptr->tval == ItemKindType::RING) || (ae_ptr->o_ptr->tval == ItemKindType::AMULET)) && ae_ptr->o_ptr->is_ego())
-        ae_ptr->lev = e_info[enum2i<EgoType>(ae_ptr->o_ptr->name2)].level;
+        ae_ptr->lev = e_info[ae_ptr->o_ptr->name2].level;
 }
 
 static void decide_chance_fail(PlayerType *player_ptr, ae_type *ae_ptr)

--- a/src/artifact/artifact-info.cpp
+++ b/src/artifact/artifact-info.cpp
@@ -31,8 +31,8 @@ RandomArtActType activation_index(const ObjectType *o_ptr)
     if (o_ptr->is_fixed_artifact() && a_info[o_ptr->name1].flags.has(TR_ACTIVATE))
         return a_info[o_ptr->name1].act_idx;
 
-    if (o_ptr->is_ego() && e_info[enum2i<EgoType>(o_ptr->name2)].flags.has(TR_ACTIVATE))
-        return e_info[enum2i<EgoType>(o_ptr->name2)].act_idx;
+    if (o_ptr->is_ego() && e_info[o_ptr->name2].flags.has(TR_ACTIVATE))
+        return e_info[o_ptr->name2].act_idx;
 
     if (!o_ptr->is_random_artifact() && k_info[o_ptr->k_idx].flags.has(TR_ACTIVATE))
         return k_info[o_ptr->k_idx].act_idx;

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -347,7 +347,7 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, Ob
                  * are almost meaningless.
                  * Register the ego type only.
                  */
-                ego_item_type *e_ptr = &e_info[enum2i<EgoType>(o_ptr->name2)];
+                auto *e_ptr = &e_info[o_ptr->name2];
 #ifdef JP
                 /* エゴ銘には「^」マークが使える */
                 sprintf(name_str, "^%s", e_ptr->name.c_str());

--- a/src/flavor/flavor-util.cpp
+++ b/src/flavor/flavor-util.cpp
@@ -193,7 +193,7 @@ char *get_ability_abbreviation(char *short_flavor, ObjectType *o_ptr, bool kanji
         }
 
         if (o_ptr->is_ego()) {
-            ego_item_type *e_ptr = &e_info[enum2i<EgoType>(o_ptr->name2)];
+            auto *e_ptr = &e_info[o_ptr->name2];
             flgs.reset(e_ptr->flags);
         }
     }

--- a/src/flavor/named-item-describer.cpp
+++ b/src/flavor/named-item-describer.cpp
@@ -120,7 +120,7 @@ static void describe_artifact_ja(flavor_type *flavor_ptr)
     }
 
     if (flavor_ptr->o_ptr->is_ego()) {
-        ego_item_type *e_ptr = &e_info[enum2i<EgoType>(flavor_ptr->o_ptr->name2)];
+        auto *e_ptr = &e_info[flavor_ptr->o_ptr->name2];
         flavor_ptr->t = object_desc_str(flavor_ptr->t, e_ptr->name.c_str());
     }
 }
@@ -298,7 +298,7 @@ static void describe_artifact_body_en(flavor_type *flavor_ptr)
     }
 
     if (flavor_ptr->o_ptr->is_ego()) {
-        ego_item_type *e_ptr = &e_info[enum2i<EgoType>(flavor_ptr->o_ptr->name2)];
+        auto *e_ptr = &e_info[flavor_ptr->o_ptr->name2];
         flavor_ptr->t = object_desc_chr(flavor_ptr->t, ' ');
         flavor_ptr->t = object_desc_str(flavor_ptr->t, e_ptr->name.c_str());
     }

--- a/src/floor/floor-events.cpp
+++ b/src/floor/floor-events.cpp
@@ -150,7 +150,7 @@ static byte get_dungeon_feeling(PlayerType *player_ptr)
             continue;
 
         if (o_ptr->is_ego()) {
-            ego_item_type *e_ptr = &e_info[enum2i<EgoType>(o_ptr->name2)];
+            auto *e_ptr = &e_info[o_ptr->name2];
             delta += e_ptr->rating * base;
         }
 

--- a/src/info-reader/ego-reader.cpp
+++ b/src/info-reader/ego-reader.cpp
@@ -74,12 +74,9 @@ errr parse_e_info(std::string_view buf, angband_header *)
         auto i = std::stoi(tokens[1]);
         if (i < error_idx)
             return PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
-        if (i >= static_cast<int>(e_info.size())) {
-            e_info.resize(i + 1);
-        }
 
         error_idx = i;
-        e_ptr = &e_info[i];
+        e_ptr = &(e_info.emplace_hint(e_info.end(), i2enum<EgoType>(i), ego_item_type{})->second);
         e_ptr->idx = i2enum<EgoType>(i);
 #ifdef JP
         e_ptr->name = tokens[2];

--- a/src/load/old/load-v1-5-0.cpp
+++ b/src/load/old/load-v1-5-0.cpp
@@ -131,7 +131,7 @@ void rd_item_old(ObjectType *o_ptr)
                 if (a_ptr->gen_flags.has(ItemGenerationTraitType::PERMA_CURSE))
                     o_ptr->curse_flags.set(CurseTraitType::PERMA_CURSE);
             } else if (o_ptr->is_ego()) {
-                ego_item_type *e_ptr = &e_info[enum2i<EgoType>(o_ptr->name2)];
+                auto *e_ptr = &e_info[o_ptr->name2];
                 if (e_ptr->gen_flags.has(ItemGenerationTraitType::HEAVY_CURSE))
                     o_ptr->curse_flags.set(CurseTraitType::HEAVY_CURSE);
                 if (e_ptr->gen_flags.has(ItemGenerationTraitType::PERMA_CURSE))
@@ -329,8 +329,7 @@ void rd_item_old(ObjectType *o_ptr)
     }
 
     if (o_ptr->is_ego()) {
-        ego_item_type *e_ptr;
-        e_ptr = &e_info[enum2i<EgoType>(o_ptr->name2)];
+        auto *e_ptr = &e_info[o_ptr->name2];
         if (e_ptr->name.empty())
             o_ptr->name2 = EgoType::NONE;
     }

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -51,6 +51,12 @@ template <typename T, typename Alloc>
 struct is_vector<std::vector<T, Alloc>> : std::true_type {
 };
 
+/*!
+ * @brief 与えられた型 T が std::vector 型かどうか調べる
+ * T の型が std::vector<SomeType> に一致する時、is_vector_v<T> == true
+ * 一致しない時、is_vector_v<T> == false となる
+ * @tparam T 調べる型
+ */
 template <typename T>
 constexpr bool is_vector_v = is_vector<T>::value;
 

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -41,6 +41,21 @@
 #endif
 #include <string_view>
 
+namespace {
+
+template <typename>
+struct is_vector : std::false_type {
+};
+
+template <typename T, typename Alloc>
+struct is_vector<std::vector<T, Alloc>> : std::true_type {
+};
+
+template <typename T>
+constexpr bool is_vector_v = is_vector<T>::value;
+
+}
+
 /*!
  * @brief 基本情報読み込みのメインルーチン /
  * Initialize misc. values
@@ -78,7 +93,7 @@ static void init_header(angband_header *head, IDX num = 0)
  * even if the string happens to be empty (everyone has a unique '\0').
  */
 template <typename InfoType>
-static errr init_info(concptr filename, angband_header &head, std::vector<InfoType> &info, std::function<errr(std::string_view, angband_header *)> parser,
+static errr init_info(concptr filename, angband_header &head, InfoType &info, std::function<errr(std::string_view, angband_header *)> parser,
     void (*retouch)(angband_header *head))
 {
     char buf[1024];
@@ -89,7 +104,10 @@ static errr init_info(concptr filename, angband_header &head, std::vector<InfoTy
     if (!fp)
         quit(format(_("'%s.txt'ファイルをオープンできません。", "Cannot open '%s.txt' file."), filename));
 
-    info = std::vector<InfoType>(head.info_num);
+    constexpr auto info_is_vector = is_vector_v<InfoType>;
+    if constexpr (info_is_vector) {
+        info.assign(head.info_num, {});
+    }
 
     errr err = init_info_txt(fp, buf, &head, parser);
     angband_fclose(fp);
@@ -107,7 +125,9 @@ static errr init_info(concptr filename, angband_header &head, std::vector<InfoTy
         quit(format(_("'%s.txt'ファイルにエラー", "Error in '%s.txt' file."), filename));
     }
 
-    info.shrink_to_fit();
+    if constexpr (info_is_vector) {
+        info.shrink_to_fit();
+    }
     head.info_num = static_cast<uint16_t>(info.size());
 
     if (retouch)

--- a/src/object-enchant/object-ego.cpp
+++ b/src/object-enchant/object-ego.cpp
@@ -23,7 +23,7 @@
 /*
  * The ego-item arrays
  */
-std::vector<ego_item_type> e_info;
+std::map<EgoType, ego_item_type> e_info;
 
 /*!
  * @brief アイテムのエゴをレア度の重みに合わせてランダムに選択する
@@ -35,7 +35,7 @@ std::vector<ego_item_type> e_info;
 EgoType get_random_ego(byte slot, bool good)
 {
     ProbabilityTable<EgoType> prob_table;
-    for (const auto &e_ref : e_info) {
+    for (const auto &[e_idx, e_ref] : e_info) {
         if (e_ref.idx == EgoType::NONE || e_ref.slot != slot || e_ref.rarity <= 0)
             continue;
 
@@ -236,7 +236,7 @@ void ego_invest_extra_attack(ObjectType *o_ptr, ego_item_type *e_ptr, DEPTH lev)
  */
 void apply_ego(ObjectType *o_ptr, DEPTH lev)
 {
-    auto e_ptr = &e_info[enum2i<EgoType>(o_ptr->name2)];
+    auto e_ptr = &e_info[o_ptr->name2];
     auto gen_flags = e_ptr->gen_flags;
 
     ego_interpret_extra_abilities(o_ptr, e_ptr, gen_flags);

--- a/src/object-enchant/object-ego.h
+++ b/src/object-enchant/object-ego.h
@@ -1,5 +1,6 @@
 ﻿#pragma once
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -270,7 +271,7 @@ struct ego_item_type {
     RandomArtActType act_idx{}; //!< 発動番号 / Activative ability index
 };
 
-extern std::vector<ego_item_type> e_info;
+extern std::map<EgoType, ego_item_type> e_info;
 
 class ObjectType;
 class PlayerType;

--- a/src/object-enchant/weapon/apply-magic-weapon.cpp
+++ b/src/object-enchant/weapon/apply-magic-weapon.cpp
@@ -104,7 +104,7 @@ void WeaponEnchanter::apply_magic()
                         continue;
                     }
 
-                    ego_item_type *e_ptr = &e_info[enum2i<EgoType>(this->o_ptr->name2)];
+                    auto *e_ptr = &e_info[this->o_ptr->name2];
                     if (this->o_ptr->tval == ItemKindType::SWORD && this->o_ptr->sval == SV_HAYABUSA && e_ptr->max_pval < 0) {
                         if (++n > 1000) {
                             msg_print(_("エラー:隼の剣に割り当てるエゴ無し", "Error: Cannot find for Hayabusa."));

--- a/src/object/object-flags.cpp
+++ b/src/object/object-flags.cpp
@@ -22,7 +22,7 @@ static void object_flags_lite(const ObjectType *o_ptr, TrFlags &flgs)
         return;
     }
 
-    auto *e_ptr = &e_info[enum2i<EgoType>(o_ptr->name2)];
+    auto *e_ptr = &e_info[o_ptr->name2];
     flgs.set(e_ptr->flags);
 
     auto is_out_of_fuel = o_ptr->fuel == 0;

--- a/src/object/object-value-calc.cpp
+++ b/src/object/object-value-calc.cpp
@@ -34,7 +34,7 @@ PRICE flag_cost(const ObjectType *o_ptr, int plusses)
         auto *a_ptr = &a_info[o_ptr->name1];
         flgs.reset(a_ptr->flags);
     } else if (o_ptr->is_ego()) {
-        ego_item_type *e_ptr = &e_info[enum2i<EgoType>(o_ptr->name2)];
+        auto *e_ptr = &e_info[o_ptr->name2];
         flgs.reset(e_ptr->flags);
     }
 

--- a/src/object/object-value.cpp
+++ b/src/object/object-value.cpp
@@ -153,7 +153,7 @@ PRICE object_value_real(const ObjectType *o_ptr)
         value += flag_cost(o_ptr, o_ptr->pval);
         return value;
     } else if (o_ptr->is_ego()) {
-        ego_item_type *e_ptr = &e_info[enum2i<EgoType>(o_ptr->name2)];
+        auto *e_ptr = &e_info[o_ptr->name2];
         if (!e_ptr->cost)
             return 0;
 

--- a/src/racial/racial-android.cpp
+++ b/src/racial/racial-android.cpp
@@ -82,7 +82,7 @@ void calc_android_exp(PlayerType *player_ptr)
             level = (level + std::max(a_info[o_ptr->name1].level - 8, 5)) / 2;
             level += std::min(20, a_info[o_ptr->name1].rarity / (a_info[o_ptr->name1].gen_flags.has(ItemGenerationTraitType::INSTA_ART) ? 10 : 3));
         } else if (o_ptr->is_ego()) {
-            level += std::max(3, (e_info[enum2i<EgoType>(o_ptr->name2)].rating - 5) / 2);
+            level += std::max(3, (e_info[o_ptr->name2].rating - 5) / 2);
         } else if (o_ptr->art_name) {
             int32_t total_flags = flag_cost(o_ptr, o_ptr->pval);
             int fake_level;

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -878,7 +878,7 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
             KIND_OBJECT_IDX k_idx = k_ids.back();
             o_ptr->prep(k_idx);
 
-            for (const auto &e_ref : e_info) {
+            for (const auto &[e_idx, e_ref] : e_info) {
                 if (e_ref.idx == EgoType::NONE || e_ref.name.empty())
                     continue;
 


### PR DESCRIPTION
Resolve #2250 
本質は parse_e_info をちょこっと修正しただけなので、他の *_info を map にする必要がでてきた場合も参考にできるかと思います。