### PR TITLE
クラスまたは荒野に依存する判定の設計を修正した

### DIFF
--- a/src/cmd-io/cmd-menu-content-table.cpp
+++ b/src/cmd-io/cmd-menu-content-table.cpp
@@ -3,11 +3,11 @@
 #include "util/enum-converter.h"
 #include "util/int-char-converter.h"
 
-SpecialMenuContent::SpecialMenuContent(concptr name, byte window, byte number, SpecialMenuType jouken, PlayerClassType jouken_naiyou)
+SpecialMenuContent::SpecialMenuContent(concptr name, byte window, byte number, SpecialMenuType menu_condition, PlayerClassType jouken_naiyou)
     : name(name)
     , window(window)
     , number(number)
-    , jouken(jouken)
+    , menu_condition(menu_condition)
     , jouken_naiyou(jouken_naiyou)
 {
 }

--- a/src/cmd-io/cmd-menu-content-table.cpp
+++ b/src/cmd-io/cmd-menu-content-table.cpp
@@ -3,24 +3,33 @@
 #include "util/enum-converter.h"
 #include "util/int-char-converter.h"
 
+SpecialMenuContent::SpecialMenuContent(concptr name, byte window, byte number, byte jouken, PlayerClassType jouken_naiyou)
+    : name(name)
+    , window(window)
+    , number(number)
+    , jouken(jouken)
+    , jouken_naiyou(jouken_naiyou)
+{
+}
+
 /*
  * @todo 遅くともv2.2.1の頃には職業enumとboolとintが混じっているゴミ配列であった
  * jouken_naiyou (フィールド名もゴミ)が複数目的に利用されているようである
  * 後で何とかする
  */
-special_menu_content special_menu_info[MAX_SPECIAL_MENU_NUM] = {
-    { _("超能力/特殊能力", "MindCraft/Special"), 0, 0, MENU_CLASS, PlayerClassType::MINDCRAFTER },
-    { _("ものまね/特殊能力", "Imitation/Special"), 0, 0, MENU_CLASS, PlayerClassType::IMITATOR },
-    { _("歌/特殊能力", "Song/Special"), 0, 0, MENU_CLASS, PlayerClassType::BARD },
-    { _("必殺技/特殊能力", "Technique/Special"), 0, 0, MENU_CLASS, PlayerClassType::SAMURAI },
-    { _("練気術/魔法/特殊能力", "Mind/Magic/Special"), 0, 0, MENU_CLASS, PlayerClassType::FORCETRAINER },
-    { _("技/特殊能力", "BrutalPower/Special"), 0, 0, MENU_CLASS, PlayerClassType::BERSERKER },
-    { _("技術/特殊能力", "Technique/Special"), 0, 0, MENU_CLASS, PlayerClassType::SMITH },
-    { _("鏡魔法/特殊能力", "MirrorMagic/Special"), 0, 0, MENU_CLASS, PlayerClassType::MIRROR_MASTER },
-    { _("忍術/特殊能力", "Ninjutsu/Special"), 0, 0, MENU_CLASS, PlayerClassType::NINJA },
-    { _("広域マップ(<)", "Enter global map(<)"), 2, 6, MENU_WILD, i2enum<PlayerClassType>(0) },
-    { _("通常マップ(>)", "Enter local map(>)"), 2, 7, MENU_WILD, i2enum<PlayerClassType>(1) },
-    { "", 0, 0, 0, i2enum<PlayerClassType>(0) },
+const std::vector<SpecialMenuContent> special_menu_info = {
+    SpecialMenuContent(_("超能力/特殊能力", "MindCraft/Special"), 0, 0, MENU_CLASS, PlayerClassType::MINDCRAFTER),
+    SpecialMenuContent(_("ものまね/特殊能力", "Imitation/Special"), 0, 0, MENU_CLASS, PlayerClassType::IMITATOR),
+    SpecialMenuContent(_("歌/特殊能力", "Song/Special"), 0, 0, MENU_CLASS, PlayerClassType::BARD),
+    SpecialMenuContent(_("必殺技/特殊能力", "Technique/Special"), 0, 0, MENU_CLASS, PlayerClassType::SAMURAI),
+    SpecialMenuContent(_("練気術/魔法/特殊能力", "Mind/Magic/Special"), 0, 0, MENU_CLASS, PlayerClassType::FORCETRAINER),
+    SpecialMenuContent(_("技/特殊能力", "BrutalPower/Special"), 0, 0, MENU_CLASS, PlayerClassType::BERSERKER),
+    SpecialMenuContent(_("技術/特殊能力", "Technique/Special"), 0, 0, MENU_CLASS, PlayerClassType::SMITH),
+    SpecialMenuContent(_("鏡魔法/特殊能力", "MirrorMagic/Special"), 0, 0, MENU_CLASS, PlayerClassType::MIRROR_MASTER),
+    SpecialMenuContent(_("忍術/特殊能力", "Ninjutsu/Special"), 0, 0, MENU_CLASS, PlayerClassType::NINJA),
+    SpecialMenuContent(_("広域マップ(<)", "Enter global map(<)"), 2, 6, MENU_WILD, i2enum<PlayerClassType>(0)),
+    SpecialMenuContent(_("通常マップ(>)", "Enter local map(>)"), 2, 7, MENU_WILD, i2enum<PlayerClassType>(1)),
+    SpecialMenuContent("", 0, 0, 0, i2enum<PlayerClassType>(0)),
 };
 
 menu_content menu_info[MAX_COMMAND_MENU_NUM][MAX_COMMAND_PER_SCREEN] = {

--- a/src/cmd-io/cmd-menu-content-table.cpp
+++ b/src/cmd-io/cmd-menu-content-table.cpp
@@ -3,7 +3,7 @@
 #include "util/enum-converter.h"
 #include "util/int-char-converter.h"
 
-SpecialMenuContent::SpecialMenuContent(concptr name, byte window, byte number, byte jouken, PlayerClassType jouken_naiyou)
+SpecialMenuContent::SpecialMenuContent(concptr name, byte window, byte number, SpecialMenuType jouken, PlayerClassType jouken_naiyou)
     : name(name)
     , window(window)
     , number(number)
@@ -18,18 +18,18 @@ SpecialMenuContent::SpecialMenuContent(concptr name, byte window, byte number, b
  * 後で何とかする
  */
 const std::vector<SpecialMenuContent> special_menu_info = {
-    SpecialMenuContent(_("超能力/特殊能力", "MindCraft/Special"), 0, 0, MENU_CLASS, PlayerClassType::MINDCRAFTER),
-    SpecialMenuContent(_("ものまね/特殊能力", "Imitation/Special"), 0, 0, MENU_CLASS, PlayerClassType::IMITATOR),
-    SpecialMenuContent(_("歌/特殊能力", "Song/Special"), 0, 0, MENU_CLASS, PlayerClassType::BARD),
-    SpecialMenuContent(_("必殺技/特殊能力", "Technique/Special"), 0, 0, MENU_CLASS, PlayerClassType::SAMURAI),
-    SpecialMenuContent(_("練気術/魔法/特殊能力", "Mind/Magic/Special"), 0, 0, MENU_CLASS, PlayerClassType::FORCETRAINER),
-    SpecialMenuContent(_("技/特殊能力", "BrutalPower/Special"), 0, 0, MENU_CLASS, PlayerClassType::BERSERKER),
-    SpecialMenuContent(_("技術/特殊能力", "Technique/Special"), 0, 0, MENU_CLASS, PlayerClassType::SMITH),
-    SpecialMenuContent(_("鏡魔法/特殊能力", "MirrorMagic/Special"), 0, 0, MENU_CLASS, PlayerClassType::MIRROR_MASTER),
-    SpecialMenuContent(_("忍術/特殊能力", "Ninjutsu/Special"), 0, 0, MENU_CLASS, PlayerClassType::NINJA),
-    SpecialMenuContent(_("広域マップ(<)", "Enter global map(<)"), 2, 6, MENU_WILD, i2enum<PlayerClassType>(0)),
-    SpecialMenuContent(_("通常マップ(>)", "Enter local map(>)"), 2, 7, MENU_WILD, i2enum<PlayerClassType>(1)),
-    SpecialMenuContent("", 0, 0, 0, i2enum<PlayerClassType>(0)),
+    SpecialMenuContent(_("超能力/特殊能力", "MindCraft/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::MINDCRAFTER),
+    SpecialMenuContent(_("ものまね/特殊能力", "Imitation/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::IMITATOR),
+    SpecialMenuContent(_("歌/特殊能力", "Song/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::BARD),
+    SpecialMenuContent(_("必殺技/特殊能力", "Technique/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::SAMURAI),
+    SpecialMenuContent(_("練気術/魔法/特殊能力", "Mind/Magic/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::FORCETRAINER),
+    SpecialMenuContent(_("技/特殊能力", "BrutalPower/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::BERSERKER),
+    SpecialMenuContent(_("技術/特殊能力", "Technique/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::SMITH),
+    SpecialMenuContent(_("鏡魔法/特殊能力", "MirrorMagic/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::MIRROR_MASTER),
+    SpecialMenuContent(_("忍術/特殊能力", "Ninjutsu/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::NINJA),
+    SpecialMenuContent(_("広域マップ(<)", "Enter global map(<)"), 2, 6, SpecialMenuType::WILD, i2enum<PlayerClassType>(0)),
+    SpecialMenuContent(_("通常マップ(>)", "Enter local map(>)"), 2, 7, SpecialMenuType::WILD, i2enum<PlayerClassType>(1)),
+    SpecialMenuContent("", 0, 0, SpecialMenuType::NONE, i2enum<PlayerClassType>(0)),
 };
 
 menu_content menu_info[MAX_COMMAND_MENU_NUM][MAX_COMMAND_PER_SCREEN] = {

--- a/src/cmd-io/cmd-menu-content-table.cpp
+++ b/src/cmd-io/cmd-menu-content-table.cpp
@@ -3,33 +3,29 @@
 #include "util/enum-converter.h"
 #include "util/int-char-converter.h"
 
-SpecialMenuContent::SpecialMenuContent(concptr name, byte window, byte number, SpecialMenuType menu_condition, PlayerClassType class_condition)
+SpecialMenuContent::SpecialMenuContent(concptr name, byte window, byte number, SpecialMenuType menu_condition, std::optional<PlayerClassType> class_condition, std::optional<bool> wild_mode)
     : name(name)
     , window(window)
     , number(number)
     , menu_condition(menu_condition)
     , class_condition(class_condition)
+    , wild_mode(wild_mode)
 {
 }
 
-/*
- * @todo 遅くともv2.2.1の頃には職業enumとboolとintが混じっているゴミ配列であった
- * jouken_naiyou (フィールド名もゴミ)が複数目的に利用されているようである
- * 後で何とかする
- */
 const std::vector<SpecialMenuContent> special_menu_info = {
-    SpecialMenuContent(_("超能力/特殊能力", "MindCraft/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::MINDCRAFTER),
-    SpecialMenuContent(_("ものまね/特殊能力", "Imitation/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::IMITATOR),
-    SpecialMenuContent(_("歌/特殊能力", "Song/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::BARD),
-    SpecialMenuContent(_("必殺技/特殊能力", "Technique/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::SAMURAI),
-    SpecialMenuContent(_("練気術/魔法/特殊能力", "Mind/Magic/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::FORCETRAINER),
-    SpecialMenuContent(_("技/特殊能力", "BrutalPower/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::BERSERKER),
-    SpecialMenuContent(_("技術/特殊能力", "Technique/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::SMITH),
-    SpecialMenuContent(_("鏡魔法/特殊能力", "MirrorMagic/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::MIRROR_MASTER),
-    SpecialMenuContent(_("忍術/特殊能力", "Ninjutsu/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::NINJA),
-    SpecialMenuContent(_("広域マップ(<)", "Enter global map(<)"), 2, 6, SpecialMenuType::WILD, i2enum<PlayerClassType>(0)),
-    SpecialMenuContent(_("通常マップ(>)", "Enter local map(>)"), 2, 7, SpecialMenuType::WILD, i2enum<PlayerClassType>(1)),
-    SpecialMenuContent("", 0, 0, SpecialMenuType::NONE, i2enum<PlayerClassType>(0)),
+    SpecialMenuContent(_("超能力/特殊能力", "MindCraft/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::MINDCRAFTER, std::nullopt),
+    SpecialMenuContent(_("ものまね/特殊能力", "Imitation/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::IMITATOR, std::nullopt),
+    SpecialMenuContent(_("歌/特殊能力", "Song/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::BARD, std::nullopt),
+    SpecialMenuContent(_("必殺技/特殊能力", "Technique/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::SAMURAI, std::nullopt),
+    SpecialMenuContent(_("練気術/魔法/特殊能力", "Mind/Magic/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::FORCETRAINER, std::nullopt),
+    SpecialMenuContent(_("技/特殊能力", "BrutalPower/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::BERSERKER, std::nullopt),
+    SpecialMenuContent(_("技術/特殊能力", "Technique/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::SMITH, std::nullopt),
+    SpecialMenuContent(_("鏡魔法/特殊能力", "MirrorMagic/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::MIRROR_MASTER, std::nullopt),
+    SpecialMenuContent(_("忍術/特殊能力", "Ninjutsu/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::NINJA, std::nullopt),
+    SpecialMenuContent(_("広域マップ(<)", "Enter global map(<)"), 2, 6, SpecialMenuType::WILD, std::nullopt, false),
+    SpecialMenuContent(_("通常マップ(>)", "Enter local map(>)"), 2, 7, SpecialMenuType::WILD, std::nullopt, true),
+    SpecialMenuContent("", 0, 0, SpecialMenuType::NONE, std::nullopt, std::nullopt),
 };
 
 menu_content menu_info[MAX_COMMAND_MENU_NUM][MAX_COMMAND_PER_SCREEN] = {

--- a/src/cmd-io/cmd-menu-content-table.cpp
+++ b/src/cmd-io/cmd-menu-content-table.cpp
@@ -3,12 +3,12 @@
 #include "util/enum-converter.h"
 #include "util/int-char-converter.h"
 
-SpecialMenuContent::SpecialMenuContent(concptr name, byte window, byte number, SpecialMenuType menu_condition, PlayerClassType jouken_naiyou)
+SpecialMenuContent::SpecialMenuContent(concptr name, byte window, byte number, SpecialMenuType menu_condition, PlayerClassType class_condition)
     : name(name)
     , window(window)
     , number(number)
     , menu_condition(menu_condition)
-    , jouken_naiyou(jouken_naiyou)
+    , class_condition(class_condition)
 {
 }
 

--- a/src/cmd-io/cmd-menu-content-table.h
+++ b/src/cmd-io/cmd-menu-content-table.h
@@ -18,11 +18,11 @@ enum class SpecialMenuType {
 enum class PlayerClassType : short;
 class SpecialMenuContent {
 public:
-    SpecialMenuContent(concptr name, byte window, byte number, SpecialMenuType jouken, PlayerClassType jouken_naiyou);
+    SpecialMenuContent(concptr name, byte window, byte number, SpecialMenuType menu_condition, PlayerClassType jouken_naiyou);
     concptr name;
     byte window;
     byte number;
-    SpecialMenuType jouken;
+    SpecialMenuType menu_condition;
     PlayerClassType jouken_naiyou;
 };
 

--- a/src/cmd-io/cmd-menu-content-table.h
+++ b/src/cmd-io/cmd-menu-content-table.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include <vector>
 
 struct menu_content {
     concptr name;
@@ -9,7 +10,9 @@ struct menu_content {
 };
 
 enum class PlayerClassType : short;
-struct special_menu_content {
+class SpecialMenuContent {
+public:
+    SpecialMenuContent(concptr name, byte window, byte number, byte jouken, PlayerClassType jouken_naiyou);
     concptr name;
     byte window;
     byte number;
@@ -22,7 +25,6 @@ struct special_menu_content {
 
 #define MENU_CLASS 1
 #define MENU_WILD 2
-#define MAX_SPECIAL_MENU_NUM 12
 
 extern menu_content menu_info[MAX_COMMAND_MENU_NUM][MAX_COMMAND_PER_SCREEN];
-extern special_menu_content special_menu_info[MAX_SPECIAL_MENU_NUM];
+extern const std::vector<SpecialMenuContent> special_menu_info;

--- a/src/cmd-io/cmd-menu-content-table.h
+++ b/src/cmd-io/cmd-menu-content-table.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include <optional>
 #include <vector>
 
 struct menu_content {
@@ -18,12 +19,13 @@ enum class SpecialMenuType {
 enum class PlayerClassType : short;
 class SpecialMenuContent {
 public:
-    SpecialMenuContent(concptr name, byte window, byte number, SpecialMenuType menu_condition, PlayerClassType class_condition);
+    SpecialMenuContent(concptr name, byte window, byte number, SpecialMenuType menu_condition, std::optional<PlayerClassType> class_condition, std::optional<bool> in_wilderness);
     concptr name;
     byte window;
     byte number;
     SpecialMenuType menu_condition;
-    PlayerClassType class_condition;
+    std::optional<PlayerClassType> class_condition;
+    std::optional<bool> wild_mode;
 };
 
 #define MAX_COMMAND_PER_SCREEN 10

--- a/src/cmd-io/cmd-menu-content-table.h
+++ b/src/cmd-io/cmd-menu-content-table.h
@@ -28,8 +28,8 @@ public:
     std::optional<bool> wild_mode;
 };
 
-#define MAX_COMMAND_PER_SCREEN 10
-#define MAX_COMMAND_MENU_NUM 10
+constexpr int MAX_COMMAND_PER_SCREEN = 10;
+constexpr int MAX_COMMAND_MENU_NUM = 10;
 
 extern menu_content menu_info[MAX_COMMAND_MENU_NUM][MAX_COMMAND_PER_SCREEN];
 extern const std::vector<SpecialMenuContent> special_menu_info;

--- a/src/cmd-io/cmd-menu-content-table.h
+++ b/src/cmd-io/cmd-menu-content-table.h
@@ -18,12 +18,12 @@ enum class SpecialMenuType {
 enum class PlayerClassType : short;
 class SpecialMenuContent {
 public:
-    SpecialMenuContent(concptr name, byte window, byte number, SpecialMenuType menu_condition, PlayerClassType jouken_naiyou);
+    SpecialMenuContent(concptr name, byte window, byte number, SpecialMenuType menu_condition, PlayerClassType class_condition);
     concptr name;
     byte window;
     byte number;
     SpecialMenuType menu_condition;
-    PlayerClassType jouken_naiyou;
+    PlayerClassType class_condition;
 };
 
 #define MAX_COMMAND_PER_SCREEN 10

--- a/src/cmd-io/cmd-menu-content-table.h
+++ b/src/cmd-io/cmd-menu-content-table.h
@@ -9,22 +9,25 @@ struct menu_content {
     bool fin;
 };
 
+enum class SpecialMenuType {
+    NONE = 0,
+    CLASS = 1,
+    WILD = 2,
+};
+
 enum class PlayerClassType : short;
 class SpecialMenuContent {
 public:
-    SpecialMenuContent(concptr name, byte window, byte number, byte jouken, PlayerClassType jouken_naiyou);
+    SpecialMenuContent(concptr name, byte window, byte number, SpecialMenuType jouken, PlayerClassType jouken_naiyou);
     concptr name;
     byte window;
     byte number;
-    byte jouken;
+    SpecialMenuType jouken;
     PlayerClassType jouken_naiyou;
 };
 
 #define MAX_COMMAND_PER_SCREEN 10
 #define MAX_COMMAND_MENU_NUM 10
-
-#define MENU_CLASS 1
-#define MENU_WILD 2
 
 extern menu_content menu_info[MAX_COMMAND_MENU_NUM][MAX_COMMAND_PER_SCREEN];
 extern const std::vector<SpecialMenuContent> special_menu_info;

--- a/src/io/input-key-requester.cpp
+++ b/src/io/input-key-requester.cpp
@@ -367,7 +367,7 @@ std::string InputKeyRequestor::switch_special_menu_condition(SpecialMenuContent 
     case SpecialMenuType::NONE:
         return "";
     case SpecialMenuType::CLASS:
-        if (PlayerClass(this->player_ptr).equals(special_menu.class_condition)) {
+        if (PlayerClass(this->player_ptr).equals(special_menu.class_condition.value())) {
             return std::string(special_menu.name);
         }
 
@@ -378,8 +378,7 @@ std::string InputKeyRequestor::switch_special_menu_condition(SpecialMenuContent 
             return "";
         }
 
-        auto can_do_in_wilderness = enum2i(special_menu.class_condition) > 0;
-        if (this->player_ptr->wild_mode == can_do_in_wilderness) {
+        if (this->player_ptr->wild_mode == special_menu.wild_mode) {
             return std::string(special_menu.name);
         }
 

--- a/src/io/input-key-requester.cpp
+++ b/src/io/input-key-requester.cpp
@@ -361,7 +361,7 @@ void InputKeyRequestor::make_commands_frame()
     put_str("+----------------------------------------------------+", this->base_y + line++, this->base_x);
 }
 
-std::string InputKeyRequestor::switch_special_menu_condition(SpecialMenuContent &special_menu)
+std::string InputKeyRequestor::switch_special_menu_condition(const SpecialMenuContent &special_menu)
 {
     switch (special_menu.menu_condition) {
     case SpecialMenuType::NONE:
@@ -392,14 +392,13 @@ std::string InputKeyRequestor::switch_special_menu_condition(SpecialMenuContent 
 int InputKeyRequestor::get_command_per_menu_num()
 {
     int command_per_menu_num;
-    for (command_per_menu_num = 0; command_per_menu_num < 10; command_per_menu_num++) {
+    for (command_per_menu_num = 0; command_per_menu_num < MAX_COMMAND_PER_SCREEN; command_per_menu_num++) {
         if (menu_info[this->menu_num][command_per_menu_num].cmd == 0) {
             break;
         }
 
         std::string menu_name(menu_info[this->menu_num][command_per_menu_num].name);
-        for (auto special_menu_num = 0;; special_menu_num++) {
-            auto special_menu = special_menu_info[special_menu_num];
+        for (const auto &special_menu : special_menu_info) {
             if (special_menu.name[0] == '\0') {
                 break;
             }

--- a/src/io/input-key-requester.cpp
+++ b/src/io/input-key-requester.cpp
@@ -367,7 +367,7 @@ std::string InputKeyRequestor::switch_special_menu_condition(SpecialMenuContent 
     case SpecialMenuType::NONE:
         return "";
     case SpecialMenuType::CLASS:
-        if (PlayerClass(this->player_ptr).equals(special_menu.jouken_naiyou)) {
+        if (PlayerClass(this->player_ptr).equals(special_menu.class_condition)) {
             return std::string(special_menu.name);
         }
 
@@ -378,7 +378,7 @@ std::string InputKeyRequestor::switch_special_menu_condition(SpecialMenuContent 
             return "";
         }
 
-        auto can_do_in_wilderness = enum2i(special_menu.jouken_naiyou) > 0;
+        auto can_do_in_wilderness = enum2i(special_menu.class_condition) > 0;
         if (this->player_ptr->wild_mode == can_do_in_wilderness) {
             return std::string(special_menu.name);
         }

--- a/src/io/input-key-requester.cpp
+++ b/src/io/input-key-requester.cpp
@@ -364,13 +364,15 @@ void InputKeyRequestor::make_commands_frame()
 std::string InputKeyRequestor::switch_special_menu_condition(SpecialMenuContent &special_menu)
 {
     switch (special_menu.jouken) {
-    case MENU_CLASS:
+    case SpecialMenuType::NONE:
+        return "";
+    case SpecialMenuType::CLASS:
         if (PlayerClass(this->player_ptr).equals(special_menu.jouken_naiyou)) {
             return std::string(special_menu.name);
         }
 
         return "";
-    case MENU_WILD: {
+    case SpecialMenuType::WILD: {
         auto floor_ptr = this->player_ptr->current_floor_ptr;
         if ((floor_ptr->dun_level > 0) || floor_ptr->inside_arena || inside_quest(floor_ptr->quest_number)) {
             return "";
@@ -384,7 +386,7 @@ std::string InputKeyRequestor::switch_special_menu_condition(SpecialMenuContent 
         return "";
     }
     default:
-        return "";
+        throw("Invalid SpecialMenuType is specified!");
     }
 }
 

--- a/src/io/input-key-requester.cpp
+++ b/src/io/input-key-requester.cpp
@@ -361,7 +361,7 @@ void InputKeyRequestor::make_commands_frame()
     put_str("+----------------------------------------------------+", this->base_y + line++, this->base_x);
 }
 
-std::string InputKeyRequestor::switch_special_menu_condition(special_menu_content &special_menu)
+std::string InputKeyRequestor::switch_special_menu_condition(SpecialMenuContent &special_menu)
 {
     switch (special_menu.jouken) {
     case MENU_CLASS:

--- a/src/io/input-key-requester.cpp
+++ b/src/io/input-key-requester.cpp
@@ -363,7 +363,7 @@ void InputKeyRequestor::make_commands_frame()
 
 std::string InputKeyRequestor::switch_special_menu_condition(SpecialMenuContent &special_menu)
 {
-    switch (special_menu.jouken) {
+    switch (special_menu.menu_condition) {
     case SpecialMenuType::NONE:
         return "";
     case SpecialMenuType::CLASS:

--- a/src/io/input-key-requester.h
+++ b/src/io/input-key-requester.h
@@ -19,7 +19,7 @@ extern int16_t command_new;
 
 class ObjectType;
 class PlayerType;
-struct special_menu_content;
+class SpecialMenuContent;
 class InputKeyRequestor {
 public:
     InputKeyRequestor(PlayerType *player_ptr, bool shopping);
@@ -51,7 +51,7 @@ private:
     void confirm_command(ObjectType &o_ref, const int caret_command);
 
     void make_commands_frame();
-    std::string switch_special_menu_condition(special_menu_content &special_menu);
+    std::string switch_special_menu_condition(SpecialMenuContent &special_menu);
     int get_command_per_menu_num();
     bool check_continuous_command();
     bool check_escape_key(const int old_num);

--- a/src/io/input-key-requester.h
+++ b/src/io/input-key-requester.h
@@ -51,7 +51,7 @@ private:
     void confirm_command(ObjectType &o_ref, const int caret_command);
 
     void make_commands_frame();
-    std::string switch_special_menu_condition(SpecialMenuContent &special_menu);
+    std::string switch_special_menu_condition(const SpecialMenuContent &special_menu);
     int get_command_per_menu_num();
     bool check_continuous_command();
     bool check_escape_key(const int old_num);


### PR DESCRIPTION
special\_menu\_contentという構造体がありました
optionalが無かったことを差し引いても「プレイヤーのクラス (enum)」と「荒野にいるかフィールドにいるか (bool)」を同一の変数で扱うというxtra4もびっくりのマルキ設計があったので修正しました
変数名もローマ字で本物のゴミだったのでそれも修正しました
ご確認下さい