### PR TITLE
[Fix] ビルドテストでの ccache が効いていない

### DIFF
--- a/.github/workflows/buildtest-on-linux.yml
+++ b/.github/workflows/buildtest-on-linux.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: hendrikmuhs/ccache-action@v1
         with:
-          max-size: 8.0G
+          max-size: 8000M
 
       - name: Configuring ccache to use precompiled headers
         run: |


### PR DESCRIPTION
ccache のほうの設定では 8.0G のような GB 単位の指定が可能だが、使用している Action
の設定では MB での表記しか認識できない模様。
8000M と MB 単位での表記に修正する。