### PR TITLE
[Fix] アイテム未確定名のシャッフルに偏りがある

### DIFF
--- a/src/flavor/object-flavor.cpp
+++ b/src/flavor/object-flavor.cpp
@@ -205,9 +205,9 @@ static void shuffle_flavors(ItemKindType tval)
         k_idx_list.push_back(k_ref.idx);
     }
 
-    for (auto k_idx : k_idx_list) {
-        object_kind *k1_ptr = &k_info[k_idx];
-        object_kind *k2_ptr = &k_info[k_idx_list[randint0(k_idx_list.size())]];
+    for (auto i = k_idx_list.size() - 1; i > 0; --i) {
+        object_kind *k1_ptr = &k_info[k_idx_list[i]];
+        object_kind *k2_ptr = &k_info[k_idx_list[randint0(i + 1)]];
         std::swap(k1_ptr->flavor, k2_ptr->flavor);
     }
 }


### PR DESCRIPTION
Resolve #2289 
適当に作ったと思われるアルゴリズムでシャッフルしているため、シャッフルの結果未確定名の
割り当てが等確率にならず偏りが発生している。
フィッシャー-イェーツのシャッフルを実装することで、きちんと等確率に未確定名が割り当て
られるようにする。