### PR TITLE
[Fix] ヘッダ整形の結果、MSVCでコンパイルできなくなった事象を解消した

### DIFF
--- a/src/main-win/main-win-mci.h
+++ b/src/main-win/main-win-mci.h
@@ -1,8 +1,8 @@
 ﻿#pragma once
 
-#include <mciapi.h>
 #include <windows.h>
 
+#include <mciapi.h>
 #include <string>
 
 extern MCI_OPEN_PARMSW mci_open_parms;

--- a/src/main-win/main-win-utils.h
+++ b/src/main-win/main-win-utils.h
@@ -6,9 +6,10 @@
 
 #include "term/z-virt.h"
 
+#include <windows.h>
+
 #include <optional>
 #include <vector>
-#include <windows.h>
 
 /*!
  * @brief マルチバイト文字列(CP932)をワイド文字列へ変換するクラス

--- a/src/main-win/wav-reader.h
+++ b/src/main-win/wav-reader.h
@@ -4,10 +4,10 @@
  * @brief Windows版固有実装(WAVファイル読込)ヘッダ
  */
 
-#include <memory>
-
-#include <mmsystem.h>
 #include <windows.h>
+
+#include <memory>
+#include <mmsystem.h>
 
 /*!
  * WAVファイルの読み込み


### PR DESCRIPTION
<windows.h> は、他のヘッダより優先して読み込まないとコンパイルが通らないようです
順番を修正し、clang-formatで整形されないように空行を置きました
ご確認下さい