### PR TITLE
[Feature] ccache のためにキャッシュを生成するワークフロー

### DIFF
--- a/.github/workflows/create-cache-for-ccache.yml
+++ b/.github/workflows/create-cache-for-ccache.yml
@@ -1,0 +1,38 @@
+name: Create Cache for ccache
+
+on:
+  push:
+    branches:
+      - develop
+
+  # 手動トリガーを許可
+  workflow_dispatch:
+
+jobs:
+  clang_without_pch_japanese:
+    name: Japanese version with clang (without using pre-compiled headers)
+    uses: ./.github/workflows/build-with-autotools.yml
+    with:
+      cxx: clang++-11
+      cxx-flags: "-pipe -O3 -Werror -Wall -Wextra -Wno-unused-const-variable -Wno-invalid-source-encoding"
+      configure-opts: "--disable-pch"
+      use-ccache: true
+
+  gcc_japanese:
+    name: Japanese version with gcc
+    needs: clang_without_pch_japanese
+    uses: ./.github/workflows/build-with-autotools.yml
+    with:
+      cxx: g++
+      cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
+      use-ccache: true
+
+  gcc_english:
+    name: English version with gcc
+    needs: gcc_japanese
+    uses: ./.github/workflows/build-with-autotools.yml
+    with:
+      cxx: g++
+      cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
+      configure-opts: "--disable-japanese"
+      use-ccache: true


### PR DESCRIPTION
Pull Request Status Check で行われるビルドテスト時に ccache によるコンパイル
キャッシュが初めから利用できるようにしやすくするため、develop ブランチにマージされた
時にビルドテストと同じビルドを実行してキャッシュを予め生成しておくようにする。