### PR TITLE
スレイの対象が逆転してしまっているバグを修正した

### DIFF
--- a/src/combat/slaying.cpp
+++ b/src/combat/slaying.cpp
@@ -65,7 +65,7 @@ MULTIPLY mult_slaying(PlayerType *player_ptr, MULTIPLY mult, const TrFlags &flgs
     for (size_t i = 0; i < sizeof(slay_table) / sizeof(slay_table[0]); ++i) {
         const struct slay_table_t *p = &slay_table[i];
 
-        if (flgs.has_not(p->slay_flag) || r_ptr->kind_flags.has(p->affect_race_flag)) {
+        if (flgs.has_not(p->slay_flag) || r_ptr->kind_flags.has_not(p->affect_race_flag)) {
             continue;
         }
 


### PR DESCRIPTION
Resolve #2323 
ゲームバランス面で致命的なので優先度は緊急にしておきます

参考(置き換える前のコード):
```cpp
if (flgs.has_not(p->slay_flag) || !(atoffset(BIT_FLAGS, r_ptr, p->flag_offset) & p->affect_race_flag))
            continue;
```