### PR TITLE
速度補正が正しく機能していない不具合を解消した

### DIFF
--- a/src/player-status/player-speed.cpp
+++ b/src/player-status/player-speed.cpp
@@ -71,7 +71,7 @@ int16_t PlayerSpeed::race_value()
  */
 int16_t PlayerSpeed::class_value()
 {
-    byte result = 0;
+    int16_t result = 0;
     PlayerClass pc(this->player_ptr);
     if (pc.equals(PlayerClassType::NINJA)) {
         if (heavy_armor(this->player_ptr)) {


### PR DESCRIPTION
改めてメソッド名、変数名、ブランチ名をbonusに変えてみました
ご確認下さい