### PR TITLE
[Refactor] 賞金首情報の処理コードのリファクタリング

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -941,6 +941,7 @@
     <ClInclude Include="..\..\src\load\old\monster-flag-types-savefile50.h" />
     <ClInclude Include="..\..\src\load\player-class-specific-data-loader.h" />
     <ClInclude Include="..\..\src\load\savedata-old-flag-types.h" />
+    <ClInclude Include="..\..\src\market\bounty-type-definition.h" />
     <ClInclude Include="..\..\src\monster-race\monster-aura-types.h" />
     <ClInclude Include="..\..\src\monster-race\monster-kind-mask.h" />
     <ClInclude Include="..\..\src\monster-race\race-behavior-flags.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -5199,6 +5199,9 @@
     <ClInclude Include="..\..\src\timed-effect\player-fear.h">
       <Filter>timed-effect</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\market\bounty-type-definition.h">
+      <Filter>market</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\src\wall.bmp" />

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -407,6 +407,7 @@ hengband_SOURCES = \
 	market/poker.cpp market/poker.h \
 	market/arena.cpp market/arena.h \
 	market/bounty-prize-table.cpp market/bounty-prize-table.h \
+	market/bounty-type-definition.h \
 	market/bounty.cpp market/bounty.h \
 	market/building-recharger.cpp market/building-recharger.h \
 	market/building-quest.cpp market/building-quest.h \

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -16,6 +16,7 @@
 #include "knowledge/monster-group-table.h"
 #include "locale/english.h"
 #include "lore/lore-util.h"
+#include "market/bounty.h"
 #include "monster-race/monster-race.h"
 #include "monster-race/race-flags1.h"
 #include "monster-race/race-flags3.h"
@@ -75,13 +76,8 @@ static IDX collect_monsters(PlayerType *player_ptr, IDX grp_cur, IDX mon_idx[], 
                 continue;
             }
         } else if (grp_wanted) {
-            bool wanted = false;
-            for (int j = 0; j < MAX_BOUNTY; j++) {
-                if ((w_ptr->bounties[j].r_idx == r_ref.idx) || (player_ptr->today_mon && player_ptr->today_mon == r_ref.idx)) {
-                    wanted = true;
-                    break;
-                }
-            }
+            auto wanted = (player_ptr->today_mon > 0) && (player_ptr->today_mon == r_ref.idx);
+            wanted |= is_bounty(r_ref.idx, false);
 
             if (!wanted) {
                 continue;

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -499,9 +499,9 @@ void do_cmd_knowledge_bounty(PlayerType *player_ptr)
     fprintf(fff, "----------------------------------------------\n");
 
     bool listed = false;
-    for (int i = 0; i < MAX_BOUNTY; i++) {
-        if (!w_ptr->bounties[i].is_achieved) {
-            fprintf(fff, "%s\n", r_info[w_ptr->bounties[i].r_idx].name.c_str());
+    for (const auto &[r_idx, is_achieved] : w_ptr->bounties) {
+        if (!is_achieved) {
+            fprintf(fff, "%s\n", r_info[r_idx].name.c_str());
             listed = true;
         }
     }

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -77,7 +77,7 @@ static IDX collect_monsters(PlayerType *player_ptr, IDX grp_cur, IDX mon_idx[], 
         } else if (grp_wanted) {
             bool wanted = false;
             for (int j = 0; j < MAX_BOUNTY; j++) {
-                if (w_ptr->bounty_r_idx[j] == r_ref.idx || w_ptr->bounty_r_idx[j] - 10000 == r_ref.idx || (player_ptr->today_mon && player_ptr->today_mon == r_ref.idx)) {
+                if ((w_ptr->bounties[j].r_idx == r_ref.idx) || (player_ptr->today_mon && player_ptr->today_mon == r_ref.idx)) {
                     wanted = true;
                     break;
                 }
@@ -504,8 +504,8 @@ void do_cmd_knowledge_bounty(PlayerType *player_ptr)
 
     bool listed = false;
     for (int i = 0; i < MAX_BOUNTY; i++) {
-        if (w_ptr->bounty_r_idx[i] <= 10000) {
-            fprintf(fff, "%s\n", r_info[w_ptr->bounty_r_idx[i]].name.c_str());
+        if (!w_ptr->bounties[i].is_achieved) {
+            fprintf(fff, "%s\n", r_info[w_ptr->bounties[i].r_idx].name.c_str());
             listed = true;
         }
     }

--- a/src/load/load-zangband.cpp
+++ b/src/load/load-zangband.cpp
@@ -121,10 +121,10 @@ void set_zangband_race(PlayerType *player_ptr)
 void set_zangband_bounty_uniques(PlayerType *player_ptr)
 {
     determine_bounty_uniques(player_ptr);
-    for (int i = 0; i < MAX_BOUNTY; i++) {
+    for (auto &[r_idx, is_achieved] : w_ptr->bounties) {
         /* Is this bounty unique already dead? */
-        if (r_info[w_ptr->bounties[i].r_idx].max_num == 0) {
-            w_ptr->bounties[i].is_achieved = true;
+        if (r_info[r_idx].max_num == 0) {
+            is_achieved = true;
         }
     }
 }

--- a/src/load/load-zangband.cpp
+++ b/src/load/load-zangband.cpp
@@ -123,8 +123,8 @@ void set_zangband_bounty_uniques(PlayerType *player_ptr)
     determine_bounty_uniques(player_ptr);
     for (int i = 0; i < MAX_BOUNTY; i++) {
         /* Is this bounty unique already dead? */
-        if (!r_info[w_ptr->bounty_r_idx[i]].max_num) {
-            w_ptr->bounty_r_idx[i] += 10000;
+        if (r_info[w_ptr->bounties[i].r_idx].max_num == 0) {
+            w_ptr->bounties[i].is_achieved = true;
         }
     }
 }

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -174,7 +174,19 @@ void rd_bounty_uniques(PlayerType *player_ptr)
     }
 
     for (int i = 0; i < MAX_BOUNTY; i++) {
-        w_ptr->bounty_r_idx[i] = rd_s16b();
+        auto &b_ref = w_ptr->bounties[i];
+        b_ref.r_idx = rd_s16b();
+
+        if (loading_savefile_version_is_older_than(16)) {
+            constexpr auto old_achieved_flag = 10000; // かつて賞金首達成フラグとしてモンスター種族番号を10000増やしていた
+            b_ref.is_achieved = false;
+            if (b_ref.r_idx >= old_achieved_flag) {
+                b_ref.r_idx -= old_achieved_flag;
+                b_ref.is_achieved = true;
+            }
+        } else {
+            b_ref.is_achieved = rd_byte() != 0;
+        }
     }
 }
 

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -173,19 +173,18 @@ void rd_bounty_uniques(PlayerType *player_ptr)
         return;
     }
 
-    for (int i = 0; i < MAX_BOUNTY; i++) {
-        auto &b_ref = w_ptr->bounties[i];
-        b_ref.r_idx = rd_s16b();
+    for (auto &[r_idx, is_achieved] : w_ptr->bounties) {
+        r_idx = rd_s16b();
 
         if (loading_savefile_version_is_older_than(16)) {
             constexpr auto old_achieved_flag = 10000; // かつて賞金首達成フラグとしてモンスター種族番号を10000増やしていた
-            b_ref.is_achieved = false;
-            if (b_ref.r_idx >= old_achieved_flag) {
-                b_ref.r_idx -= old_achieved_flag;
-                b_ref.is_achieved = true;
+            is_achieved = false;
+            if (r_idx >= old_achieved_flag) {
+                r_idx -= old_achieved_flag;
+                is_achieved = true;
             }
         } else {
-            b_ref.is_achieved = rd_byte() != 0;
+            is_achieved = rd_byte() != 0;
         }
     }
 }

--- a/src/market/bounty-type-definition.h
+++ b/src/market/bounty-type-definition.h
@@ -1,0 +1,8 @@
+﻿#pragma once
+
+#include "system/angband.h"
+
+struct bounty_type {
+    MONRACE_IDX r_idx; //!< 賞金首の対象のモンスター種族ID
+    bool is_achieved; //!< 死体を渡して報酬を獲得したかどうか
+};

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -36,6 +36,7 @@
 #include "term/term-color-types.h"
 #include "view/display-messages.h"
 #include "world/world.h"
+#include <algorithm>
 
 /*!
  * @brief 賞金首の引き換え処理 / Get prize
@@ -266,6 +267,31 @@ void show_bounty(void)
             clear_bldg(7, 18);
         }
     }
+}
+
+/*!
+ * @brief モンスターが賞金首の対象かどうかを調べる。達成済みの賞金首と日替わり賞金首は対象外。
+ *
+ * @param r_idx 対象のモンスター種族ID
+ * @param unachieved_only true の場合未達成の賞金首のみを対象とする。false の場合達成未達成に関わらずすべての賞金首を対象とする。
+ * @return 引数で指定したモンスター種族IDが賞金首の対象ならば true、そうでなければ false
+ */
+bool is_bounty(MONRACE_IDX r_idx, bool unachieved_only)
+{
+    auto it = std::find_if(std::begin(w_ptr->bounties), std::end(w_ptr->bounties),
+        [r_idx](const auto &b_ref) {
+            return b_ref.r_idx == r_idx;
+        });
+
+    if (it == std::end(w_ptr->bounties)) {
+        return false;
+    }
+
+    if (unachieved_only && (*it).is_achieved) {
+        return false;
+    }
+
+    return true;
 }
 
 /*!

--- a/src/market/bounty.h
+++ b/src/market/bounty.h
@@ -1,9 +1,12 @@
 ﻿#pragma once
 
+#include "system/angband.h"
+
 class PlayerType;
 bool exchange_cash(PlayerType *player_ptr);
 void today_target(PlayerType *player_ptr);
 void tsuchinoko(void);
 void show_bounty(void);
+bool is_bounty(MONRACE_IDX r_idx, bool unachieved_only);
 void determine_daily_bounty(PlayerType *player_ptr, bool conv_old);
 void determine_bounty_uniques(PlayerType *player_ptr);

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -410,8 +410,12 @@ void MonsterDamageProcessor::show_bounty_message(GAME_TEXT *m_name)
         return;
     }
 
+    if (m_ptr->mflag2.has(MonsterConstantFlagType::CHAMELEON)) {
+        return;
+    }
+
     for (auto i = 0; i < MAX_BOUNTY; i++) {
-        if ((w_ptr->bounty_r_idx[i] == m_ptr->r_idx) && m_ptr->mflag2.has_not(MonsterConstantFlagType::CHAMELEON)) {
+        if (!w_ptr->bounties[i].is_achieved && (w_ptr->bounties[i].r_idx == m_ptr->r_idx)) {
             msg_format(_("%sの首には賞金がかかっている。", "There is a price on %s's head."), m_name);
             break;
         }

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -17,6 +17,7 @@
 #include "io/write-diary.h"
 #include "main/sound-definitions-table.h"
 #include "main/sound-of-music.h"
+#include "market/bounty.h"
 #include "mind/mind-ninja.h"
 #include "monster-floor/monster-death.h"
 #include "monster-floor/monster-remover.h"
@@ -414,11 +415,8 @@ void MonsterDamageProcessor::show_bounty_message(GAME_TEXT *m_name)
         return;
     }
 
-    for (auto i = 0; i < MAX_BOUNTY; i++) {
-        if (!w_ptr->bounties[i].is_achieved && (w_ptr->bounties[i].r_idx == m_ptr->r_idx)) {
-            msg_format(_("%sの首には賞金がかかっている。", "There is a price on %s's head."), m_name);
-            break;
-        }
+    if (is_bounty(m_ptr->r_idx, true)) {
+        msg_format(_("%sの首には賞金がかかっている。", "There is a price on %s's head."), m_name);
     }
 }
 

--- a/src/object-hook/hook-quest.cpp
+++ b/src/object-hook/hook-quest.cpp
@@ -38,7 +38,7 @@ bool object_is_bounty(PlayerType *player_ptr, ObjectType *o_ptr)
     }
 
     for (i = 0; i < MAX_BOUNTY; i++) {
-        if (o_ptr->pval == w_ptr->bounty_r_idx[i]) {
+        if (!w_ptr->bounties[i].is_achieved && (o_ptr->pval == w_ptr->bounties[i].r_idx)) {
             break;
         }
     }

--- a/src/object-hook/hook-quest.cpp
+++ b/src/object-hook/hook-quest.cpp
@@ -2,6 +2,7 @@
 #include "cmd-building/cmd-building.h"
 #include "dungeon/quest.h"
 #include "game-option/birth-options.h"
+#include "market/bounty.h"
 #include "monster-race/monster-race.h"
 #include "monster-race/race-indice-types.h"
 #include "object-enchant/trg-types.h"
@@ -19,8 +20,6 @@
  */
 bool object_is_bounty(PlayerType *player_ptr, ObjectType *o_ptr)
 {
-    int i;
-
     if (o_ptr->tval != ItemKindType::CORPSE) {
         return false;
     }
@@ -37,16 +36,8 @@ bool object_is_bounty(PlayerType *player_ptr, ObjectType *o_ptr)
         return true;
     }
 
-    for (i = 0; i < MAX_BOUNTY; i++) {
-        if (!w_ptr->bounties[i].is_achieved && (o_ptr->pval == w_ptr->bounties[i].r_idx)) {
-            break;
-        }
-    }
-    if (i < MAX_BOUNTY) {
-        return true;
-    }
-
-    return false;
+    auto corpse_r_idx = o_ptr->pval;
+    return is_bounty(corpse_r_idx, true);
 }
 
 /*!

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -112,7 +112,8 @@ void wr_player(PlayerType *player_ptr)
     wr_s16b(player_ptr->old_realm);
 
     for (int i = 0; i < MAX_BOUNTY; i++) {
-        wr_s16b(w_ptr->bounty_r_idx[i]);
+        wr_s16b(w_ptr->bounties[i].r_idx);
+        wr_byte(w_ptr->bounties[i].is_achieved);
     }
 
     for (int i = 0; i < 4; i++) {

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -111,9 +111,9 @@ void wr_player(PlayerType *player_ptr)
     wr_s32b(player_ptr->old_race2);
     wr_s16b(player_ptr->old_realm);
 
-    for (int i = 0; i < MAX_BOUNTY; i++) {
-        wr_s16b(w_ptr->bounties[i].r_idx);
-        wr_byte(w_ptr->bounties[i].is_achieved);
+    for (const auto &[r_idx, is_achieved] : w_ptr->bounties) {
+        wr_s16b(r_idx);
+        wr_byte(is_achieved);
     }
 
     for (int i = 0; i < 4; i++) {

--- a/src/system/angband-version.h
+++ b/src/system/angband-version.h
@@ -28,7 +28,7 @@ constexpr std::string_view ROOT_VARIANT_NAME("Hengband");
 /*!
  * @brief セーブファイルのバージョン(3.0.0から導入)
  */
-constexpr uint32_t SAVEFILE_VERSION = 15;
+constexpr uint32_t SAVEFILE_VERSION = 16;
 
 /*!
  * @brief バージョンが開発版が安定版かを返す(廃止予定)

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -116,7 +116,7 @@ static void print_monster_line(TERM_LEN x, TERM_LEN y, monster_type *m_ptr, int 
     if (r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
         bool is_bounty = false;
         for (int i = 0; i < MAX_BOUNTY; i++) {
-            if (w_ptr->bounty_r_idx[i] == r_idx) {
+            if (!w_ptr->bounties[i].is_achieved && (w_ptr->bounties[i].r_idx == r_idx)) {
                 is_bounty = true;
                 break;
             }

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -11,6 +11,7 @@
 #include "inventory/inventory-util.h"
 #include "locale/japanese.h"
 #include "main/sound-of-music.h"
+#include "market/bounty.h"
 #include "monster-race/monster-race.h"
 #include "monster-race/race-flags1.h"
 #include "monster/monster-flag-types.h"
@@ -114,15 +115,7 @@ static void print_monster_line(TERM_LEN x, TERM_LEN y, monster_type *m_ptr, int 
         return;
     }
     if (r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
-        bool is_bounty = false;
-        for (int i = 0; i < MAX_BOUNTY; i++) {
-            if (!w_ptr->bounties[i].is_achieved && (w_ptr->bounties[i].r_idx == r_idx)) {
-                is_bounty = true;
-                break;
-            }
-        }
-
-        term_addstr(-1, TERM_WHITE, is_bounty ? "  W" : "  U");
+        term_addstr(-1, TERM_WHITE, is_bounty(r_idx, true) ? "  W" : "  U");
     } else {
         sprintf(buf, "%3d", n_same);
         term_addstr(-1, TERM_WHITE, buf);

--- a/src/world/world.h
+++ b/src/world/world.h
@@ -1,11 +1,12 @@
 ﻿#pragma once
 
+#include "market/bounty-type-definition.h"
 #include "player-info/class-types.h"
 #include "system/angband.h"
 #include "util/flag-group.h"
 #include "util/rng-xoshiro.h"
 
-#define MAX_BOUNTY 20
+constexpr auto MAX_BOUNTY = 20;
 
 /*!
  * @brief 世界情報構造体
@@ -25,7 +26,7 @@ struct world_type {
 
     MONSTER_IDX timewalk_m_idx{}; /*!< 現在時間停止を行っているモンスターのID */
 
-    MONRACE_IDX bounty_r_idx[MAX_BOUNTY]{};
+    bounty_type bounties[MAX_BOUNTY]{};
     MONSTER_IDX today_mon{}; //!< 実際の日替わり賞金首
 
     uint32_t play_time{}; /*!< 実プレイ時間 */


### PR DESCRIPTION
Resolve #2338 
賞金首周りの奇っ怪なコードをリファクタリングしました。
内容についてはコミットログをご参照ください。

⚠️ セーブデータバージョンが15→16に上がります。