### PR TITLE
project() 内の一部変数のスコープを処理内容に合わせた + ブレスのエンバグ修正

### DIFF
--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -96,7 +96,6 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
     POSITION x1;
     POSITION y2;
     POSITION x2;
-    bool visual = false;
     bool breath = false;
     bool blind = player_ptr->blind != 0;
     bool old_hide = false;
@@ -188,6 +187,7 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
         auto oy = y1;
         auto ox = x1;
         auto jump = any_bits(flag, PROJECT_JUMP);
+        auto visual = false;
         for (int i = 0; i < path_n; ++i) {
             POSITION ny = get_grid_y(path_g[i]);
             POSITION nx = get_grid_x(path_g[i]);
@@ -295,6 +295,7 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
         project_m_y = 0;
         auto oy = y1;
         auto ox = x1;
+        auto visual = false;
         for (int i = 0; i < path_n; ++i) {
             POSITION ny = get_grid_y(path_g[i]);
             POSITION nx = get_grid_x(path_g[i]);
@@ -399,6 +400,7 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
     int k;
     auto oy = y1;
     auto ox = x1;
+    auto visual = false;
     for (k = 0; k < path_n; ++k) {
         POSITION ny = get_grid_y(path_g[k]);
         POSITION nx = get_grid_x(path_g[k]);

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -106,9 +106,7 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
     POSITION gy[1024];
     POSITION gm[32];
     POSITION gm_rad = rad;
-    GAME_TEXT who_name[MAX_NLEN];
     bool see_s_msg = true;
-    who_name[0] = '\0';
     rakubadam_p = 0;
     rakubadam_m = 0;
     monster_target_y = player_ptr->y;
@@ -125,7 +123,6 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
     } else if (who > 0) {
         x1 = player_ptr->current_floor_ptr->m_list[who].fx;
         y1 = player_ptr->current_floor_ptr->m_list[who].fy;
-        monster_desc(player_ptr, who_name, &player_ptr->current_floor_ptr->m_list[who], MD_WRONGDOER_NAME);
     } else {
         x1 = target_x;
         y1 = target_y;
@@ -814,6 +811,12 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
                      */
                     effective_dist++;
                 }
+            }
+
+            GAME_TEXT who_name[MAX_NLEN];
+            who_name[0] = '\0';
+            if (who > 0) {
+                monster_desc(player_ptr, who_name, &player_ptr->current_floor_ptr->m_list[who], MD_WRONGDOER_NAME);
             }
 
             if (affect_player(who, player_ptr, who_name, effective_dist, y, x, dam, typ, flag, project)) {

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -99,7 +99,6 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
     POSITION y_saver;
     POSITION x_saver;
     bool visual = false;
-    bool drawn = false;
     bool breath = false;
     bool blind = player_ptr->blind != 0;
     bool old_hide = false;
@@ -540,6 +539,7 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
     }
 
     if (!blind && !(flag & (PROJECT_HIDE)) && (delay_factor > 0)) {
+        auto drawn = false;
         for (int t = 0; t <= gm_rad; t++) {
             for (int i = gm[t]; i < gm[t + 1]; i++) {
                 auto y = gy[i];

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -109,7 +109,6 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
     POSITION gy[1024];
     POSITION gm[32];
     POSITION gm_rad = rad;
-    bool jump = false;
     GAME_TEXT who_name[MAX_NLEN];
     bool see_s_msg = true;
     who_name[0] = '\0';
@@ -120,11 +119,9 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
 
     ProjectResult res;
 
-    if (flag & (PROJECT_JUMP)) {
+    if (any_bits(flag, PROJECT_JUMP)) {
         x1 = target_x;
         y1 = target_y;
-        flag &= ~(PROJECT_JUMP);
-        jump = true;
     } else if (who <= 0) {
         x1 = player_ptr->x;
         y1 = player_ptr->y;
@@ -195,6 +192,7 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
         project_m_y = 0;
         auto oy = y1;
         auto ox = x1;
+        auto jump = any_bits(flag, PROJECT_JUMP);
         for (int i = 0; i < path_n; ++i) {
             POSITION ny = get_grid_y(path_g[i]);
             POSITION nx = get_grid_x(path_g[i]);
@@ -385,7 +383,7 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
             POSITION py = get_grid_y(path_g[i]);
             POSITION px = get_grid_x(path_g[i]);
             (void)affect_monster(player_ptr, 0, 0, py, px, dam, AttributeType::SUPER_RAY, flag, true, cap_mon_ptr);
-            if (!who && (project_m_n == 1) && !jump) {
+            if (!who && (project_m_n == 1) && none_bits(flag, PROJECT_JUMP)) {
                 if (player_ptr->current_floor_ptr->grid_array[project_m_y][project_m_x].m_idx > 0) {
                     auto *m_ptr = &player_ptr->current_floor_ptr->m_list[player_ptr->current_floor_ptr->grid_array[project_m_y][project_m_x].m_idx];
                     if (m_ptr->ml) {
@@ -751,9 +749,8 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
                 res.notice = true;
             }
         }
-
         /* Player affected one monster (without "jumping") */
-        if (!who && (project_m_n == 1) && !jump) {
+        if (!who && (project_m_n == 1) && none_bits(flag, PROJECT_JUMP)) {
             auto x = project_m_x;
             auto y = project_m_y;
             if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx > 0) {

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -96,8 +96,6 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
     POSITION x1;
     POSITION y2;
     POSITION x2;
-    POSITION y_saver;
-    POSITION x_saver;
     bool visual = false;
     bool breath = false;
     bool blind = player_ptr->blind != 0;
@@ -133,9 +131,6 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
         x1 = target_x;
         y1 = target_y;
     }
-
-    y_saver = y1;
-    x_saver = x1;
     y2 = target_y;
     x2 = target_x;
 
@@ -645,14 +640,14 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
                     POSITION t_y, t_x;
                     int max_attempts = 10;
                     do {
-                        t_y = y_saver - 1 + randint1(3);
-                        t_x = x_saver - 1 + randint1(3);
+                        t_y = y1 - 1 + randint1(3);
+                        t_x = x1 - 1 + randint1(3);
                         max_attempts--;
                     } while (max_attempts && in_bounds2u(player_ptr->current_floor_ptr, t_y, t_x) && !projectable(player_ptr, y, x, t_y, t_x));
 
                     if (max_attempts < 1) {
-                        t_y = y_saver;
-                        t_x = x_saver;
+                        t_y = y1;
+                        t_x = x1;
                     }
 
                     if (is_seen(player_ptr, m_ptr)) {

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -105,8 +105,6 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
     POSITION gx[1024];
     POSITION gy[1024];
     POSITION gm[32];
-    POSITION gm_rad = rad;
-    bool see_s_msg = true;
     rakubadam_p = 0;
     rakubadam_m = 0;
     monster_target_y = player_ptr->y;
@@ -398,6 +396,8 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
     auto oy = y1;
     auto ox = x1;
     auto visual = false;
+    POSITION gm_rad = rad;
+    bool see_s_msg = true;
     for (k = 0; k < path_n; ++k) {
         POSITION ny = get_grid_y(path_g[k]);
         POSITION nx = get_grid_x(path_g[k]);

--- a/src/spell-kind/spells-launcher.cpp
+++ b/src/spell-kind/spells-launcher.cpp
@@ -4,6 +4,7 @@
 #include "floor/geometry.h"
 #include "system/player-type-definition.h"
 #include "target/target-checker.h"
+#include "util/bit-flags-calculator.h"
 
 /*!
  * @brief ボール系スペルの発動 / Cast a ball spell
@@ -56,7 +57,18 @@ bool fire_ball(PlayerType *player_ptr, AttributeType typ, DIRECTION dir, int dam
  */
 bool fire_breath(PlayerType *player_ptr, AttributeType typ, DIRECTION dir, int dam, POSITION rad)
 {
-    return fire_ball(player_ptr, typ, dir, dam, -rad);
+    BIT_FLAGS flg = PROJECT_STOP | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_BREATH;
+
+    auto tx = player_ptr->x + 99 * ddx[dir];
+    auto ty = player_ptr->y + 99 * ddy[dir];
+
+    if ((dir == 5) && target_okay(player_ptr)) {
+        reset_bits(flg, PROJECT_STOP);
+        tx = target_col;
+        ty = target_row;
+    }
+
+    return project(player_ptr, 0, rad, ty, tx, dam, typ, flg).notice;
 }
 
 /*!


### PR DESCRIPTION
Resolve #2345 
一つ一つの変更は小さいが、かなり大幅にスコープを狭めているものもあるため注意してご確認いただきたい

ちなみにビット計算の件だが、pythonスクリプトで置き換えれば可能であるため使っても問題ないと判断し、今回からnone_bits()などに置き換える