### PR TITLE
[Refactor] セーブファイルにbool値を読み書きする関数を追加する

### DIFF
--- a/src/load/load-util.cpp
+++ b/src/load/load-util.cpp
@@ -53,6 +53,14 @@ byte sf_get(void)
 }
 
 /*!
+ * @brief ロードファイルポインタからbool値を読み込む
+ */
+bool rd_bool()
+{
+    return rd_byte() != 0;
+}
+
+/*!
  * @brief ロードファイルポインタから1バイトを読み込む
  */
 byte rd_byte()

--- a/src/load/load-util.h
+++ b/src/load/load-util.h
@@ -15,6 +15,7 @@ extern byte kanji_code;
 
 void load_note(concptr msg);
 byte sf_get(void);
+bool rd_bool();
 byte rd_byte();
 uint16_t rd_u16b();
 int16_t rd_s16b();

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -118,8 +118,8 @@ static void load_player_world(PlayerType *player_ptr)
     rd_winner_class();
     rd_base_info(player_ptr);
     rd_player_info(player_ptr);
-    preserve_mode = rd_byte() != 0;
-    player_ptr->wait_report_score = rd_byte() != 0;
+    preserve_mode = rd_bool();
+    player_ptr->wait_report_score = rd_bool();
     rd_dummy2();
     rd_global_configurations(player_ptr);
     rd_extra(player_ptr);

--- a/src/load/option-loader.cpp
+++ b/src/load/option-loader.cpp
@@ -59,8 +59,8 @@ void rd_options(void)
     cheat_sight = any_bits(c, 0x0040);
     cheat_immortal = any_bits(c, 0x0020);
 
-    autosave_l = rd_byte() != 0;
-    autosave_t = rd_byte() != 0;
+    autosave_l = rd_bool();
+    autosave_t = rd_bool();
     autosave_freq = rd_s16b();
 
     BIT_FLAGS flag[8];

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -184,7 +184,7 @@ void rd_bounty_uniques(PlayerType *player_ptr)
                 is_achieved = true;
             }
         } else {
-            is_achieved = rd_byte() != 0;
+            is_achieved = rd_bool();
         }
     }
 }

--- a/src/load/world-loader.cpp
+++ b/src/load/world-loader.cpp
@@ -77,7 +77,7 @@ void set_gambling_monsters(void)
  */
 void rd_autopick(PlayerType *player_ptr)
 {
-    player_ptr->autopick_autoregister = rd_byte() != 0;
+    player_ptr->autopick_autoregister = rd_bool();
 }
 
 static void set_undead_turn_limit(PlayerType *player_ptr)
@@ -155,7 +155,7 @@ void rd_global_configurations(PlayerType *player_ptr)
     w_ptr->total_winner = rd_u16b();
     w_ptr->noscore = rd_u16b();
 
-    player_ptr->is_dead = rd_byte() != 0;
+    player_ptr->is_dead = rd_bool();
 
     player_ptr->feeling = rd_byte();
     rd_world_info(player_ptr);
@@ -173,13 +173,13 @@ void load_wilderness_info(PlayerType *player_ptr)
     if (h_older_than(0, 3, 7)) {
         player_ptr->wild_mode = false;
     } else {
-        player_ptr->wild_mode = rd_byte() != 0;
+        player_ptr->wild_mode = rd_bool();
     }
 
     if (h_older_than(0, 3, 7)) {
         player_ptr->ambush_flag = false;
     } else {
-        player_ptr->ambush_flag = rd_byte() != 0;
+        player_ptr->ambush_flag = rd_bool();
     }
 }
 

--- a/src/save/info-writer.cpp
+++ b/src/save/info-writer.cpp
@@ -117,8 +117,8 @@ void wr_options(save_type type)
 
     wr_u16b(c);
 
-    wr_byte(autosave_l);
-    wr_byte(autosave_t);
+    wr_bool(autosave_l);
+    wr_bool(autosave_t);
     wr_s16b(autosave_freq);
 
     for (int i = 0; option_info[i].o_desc; i++) {

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -113,7 +113,7 @@ void wr_player(PlayerType *player_ptr)
 
     for (const auto &[r_idx, is_achieved] : w_ptr->bounties) {
         wr_s16b(r_idx);
-        wr_byte(is_achieved);
+        wr_bool(is_achieved);
     }
 
     for (int i = 0; i < 4; i++) {
@@ -229,12 +229,12 @@ void wr_player(PlayerType *player_ptr)
     wr_s16b(player_ptr->ele_immune);
     wr_u32b(player_ptr->special_defense);
     wr_byte(player_ptr->knowledge);
-    wr_byte(player_ptr->autopick_autoregister);
+    wr_bool(player_ptr->autopick_autoregister);
     wr_byte(0);
     wr_byte((byte)player_ptr->action);
     wr_byte(0);
-    wr_byte(preserve_mode);
-    wr_byte(player_ptr->wait_report_score);
+    wr_bool(preserve_mode);
+    wr_bool(player_ptr->wait_report_score);
 
     for (int i = 0; i < 12; i++) {
         wr_u32b(0L);
@@ -250,7 +250,7 @@ void wr_player(PlayerType *player_ptr)
     wr_u16b(player_ptr->panic_save);
     wr_u16b(w_ptr->total_winner);
     wr_u16b(w_ptr->noscore);
-    wr_byte(player_ptr->is_dead);
+    wr_bool(player_ptr->is_dead);
     wr_byte(player_ptr->feeling);
     wr_s32b(player_ptr->current_floor_ptr->generated_turn);
     wr_s32b(player_ptr->feeling_turn);

--- a/src/save/save-util.cpp
+++ b/src/save/save-util.cpp
@@ -21,6 +21,15 @@ static void sf_put(byte v)
 }
 
 /*!
+ * @brief bool値をファイルに書き込む(wr_byte()の糖衣)
+ * @param v 書き込むbool値
+ */
+void wr_bool(bool v)
+{
+    wr_byte(v ? 1 : 0);
+}
+
+/*!
  * @brief 1バイトをファイルに書き込む(sf_put()の糖衣)
  * @param v 書き込むバイト
  */

--- a/src/save/save-util.h
+++ b/src/save/save-util.h
@@ -8,6 +8,7 @@ extern byte save_xor_byte;
 extern uint32_t v_stamp;
 extern uint32_t x_stamp;
 
+void wr_bool(bool v);
 void wr_byte(byte v);
 void wr_u16b(uint16_t v);
 void wr_s16b(int16_t v);

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -155,8 +155,8 @@ static bool wr_savefile_new(PlayerType *player_ptr, save_type type)
 
     wr_s32b(player_ptr->wilderness_x);
     wr_s32b(player_ptr->wilderness_y);
-    wr_byte(player_ptr->wild_mode);
-    wr_byte(player_ptr->ambush_flag);
+    wr_bool(player_ptr->wild_mode);
+    wr_bool(player_ptr->ambush_flag);
     wr_s32b(w_ptr->max_wild_x);
     wr_s32b(w_ptr->max_wild_y);
     for (int i = 0; i < w_ptr->max_wild_x; i++) {


### PR DESCRIPTION
Resolve #2344 

セーブファイルにbool値を読み書きする関数 rd_bool / wr_bool を追加する。
現状bool値を rd_byte / wr_byte で読み書きしているものについてはすべて書き換えたが
旧式の方法が使えなくなったわけではないで今後bool値をセーブファイルに記録する時は各自
注意されたし。