### PR TITLE
[Fix] モンスター間の生命力吸収攻撃の挙動がおかしい

### DIFF
--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -40,7 +40,7 @@
 
 static void heal_monster_by_melee(PlayerType *player_ptr, mam_type *mam_ptr)
 {
-    if (!monster_living(mam_ptr->m_idx) || (mam_ptr->damage <= 2)) {
+    if (!monster_living(mam_ptr->t_ptr->r_idx) || (mam_ptr->damage <= 2)) {
         return;
     }
 


### PR DESCRIPTION
Resolves #2348 
HP回復効果が有効かどうかのチェックで monster_living() 関数を呼んでいるが、この時本
来は「攻撃目標のモンスターの種族ID」を渡すべきところ、誤って「攻撃主のモンスターの現マ
ップに存在するモンスターリスト上の要素番号」を渡しておりダブルで間違っている。
正しいものを渡すように修正する。