### PR TITLE
地獄免疫の回復メッセージがひらがなと漢字で２度表示されるバグを修正

### DIFF
--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -179,7 +179,6 @@ void effect_player_nether(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
     if (PlayerRace(player_ptr).equals(PlayerRaceType::SPECTRE)) {
         if (!evaded) {
-            msg_print(_("気分がよくなった。", "You feel invigorated!"));
             hp_player(player_ptr, ep_ptr->dam / 4);
         }
         ep_ptr->get_damage = 0;


### PR DESCRIPTION
「気分がよくなった」と「気分が良くなった」が両方表示されてたので後者に合わせた