### PR TITLE
MSVCにおけるコンパイルエラー/警告を解消した

### DIFF
--- a/src/main-win/main-win-music.cpp
+++ b/src/main-win/main-win-music.cpp
@@ -56,11 +56,6 @@ static concptr basic_key_at(int index, char *buf)
     return angband_music_basic_name[index];
 }
 
-static inline DUNGEON_IDX get_dungeon_count()
-{
-    return static_cast<DUNGEON_IDX>(d_info.size());
-}
-
 /*!
  * @brief action-valに対応する[Dungeon]セクションのキー名を取得する
  * @param index "term_xtra()"の第2引数action-valに対応する値
@@ -69,17 +64,12 @@ static inline DUNGEON_IDX get_dungeon_count()
  */
 static concptr dungeon_key_at(int index, char *buf)
 {
-    if (index >= get_dungeon_count()) {
+    if (index >= static_cast<int>(d_info.size())) {
         return nullptr;
     }
 
     sprintf(buf, "dungeon%03d", index);
     return buf;
-}
-
-static inline int16_t get_quest_count()
-{
-    return max_q_idx;
 }
 
 /*!
@@ -90,17 +80,12 @@ static inline int16_t get_quest_count()
  */
 static concptr quest_key_at(int index, char *buf)
 {
-    if (index >= get_quest_count()) {
+    if (index >= static_cast<int>(max_q_idx)) {
         return nullptr;
     }
 
     sprintf(buf, "quest%03d", index);
     return buf;
-}
-
-static inline int16_t get_town_count()
-{
-    return max_towns;
 }
 
 /*!
@@ -111,17 +96,12 @@ static inline int16_t get_town_count()
  */
 static concptr town_key_at(int index, char *buf)
 {
-    if (index >= get_town_count()) {
+    if (index >= static_cast<int>(max_towns)) {
         return nullptr;
     }
 
     sprintf(buf, "town%03d", index);
     return buf;
-}
-
-static inline MonsterRaceId get_monster_count()
-{
-    return static_cast<MonsterRaceId>(r_info.size());
 }
 
 /*!
@@ -132,7 +112,7 @@ static inline MonsterRaceId get_monster_count()
  */
 static concptr monster_key_at(int index, char *buf)
 {
-    if (index >= get_monster_count()) {
+    if (index >= static_cast<int>(r_info.size())) {
         return nullptr;
     }
 

--- a/src/monster-race/monster-race.h
+++ b/src/monster-race/monster-race.h
@@ -18,5 +18,5 @@ public:
     bool is_valid() const;
 
 private:
-    const MonsterRaceId r_idx;
+    MonsterRaceId r_idx;
 };


### PR DESCRIPTION
monster_key_at() がintとenum classの比較をしていたため

なお当該関数はコールバックとして使われており引数の型を変えられなかったので、MonsterRaceIdを返り値とする関数の方にenum2i() を噛ませた。本質的にはもう型がintとenum classで異なるのでコールバックせず素直に関数を分離した方が良さそうである

以上、ご確認下さい