### PR TITLE
[Fix] モンスターが暗黒免疫を学習しない

### DIFF
--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -699,7 +699,7 @@ void update_smart_learn(PlayerType *player_ptr, MONSTER_IDX m_idx, int what)
 
         break;
     case DRS_DARK:
-        if (has_resist_dark(player_ptr)) {
+        if (has_resist_dark(player_ptr) || has_immune_dark(player_ptr)) {
             m_ptr->smart.set(MonsterSmartLearnType::RES_DARK);
         }
 

--- a/src/mspell/high-resistance-checker.cpp
+++ b/src/mspell/high-resistance-checker.cpp
@@ -113,7 +113,7 @@ static void check_dark_resistance(PlayerType *player_ptr, msr_type *msr_ptr)
         return;
     }
 
-    if (PlayerRace(player_ptr).tr_flags().has(TR_IM_DARK)) {
+    if (has_immune_dark(player_ptr)) {
         msr_ptr->ability_flags.reset(MonsterAbilityType::BR_DARK);
         msr_ptr->ability_flags.reset(MonsterAbilityType::BA_DARK);
         return;


### PR DESCRIPTION
Resolves #2371

そもそも既存のコードで暗黒免疫が学習対象になっていない。全く学習しないのはおかしいので、
とりあえず暗黒耐性と同様の学習を行うようにする。
また、免疫持ちの場合100%暗黒ブレス・ボールの使用がキャンセルされるが、この時種族の特性
フラグしか対象としていない。現状装備では暗黒免疫が付与される事はないが、幽体化による一
時的な暗黒免疫が存在するので、has_immune_dark() に置き換えて全ての暗黒免疫を対象に
する。