### PR TITLE
小文字しか入力範囲のないコマンドで大文字を入力した際の確認機能を削除した

### DIFF
--- a/src/cmd-action/cmd-hissatsu.cpp
+++ b/src/cmd-action/cmd-hissatsu.cpp
@@ -69,7 +69,6 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
     POSITION y = 1;
     POSITION x = 15;
     PLAYER_LEVEL plev = player_ptr->lev;
-    int ask = true;
     char choice;
     char out_val[160];
     SPELL_IDX sentaku[32];
@@ -118,6 +117,7 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
             break;
         }
 
+        auto should_redraw_cursor = true;
         if (use_menu && choice != ' ') {
             switch (choice) {
             case '0': {
@@ -186,13 +186,13 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
             case '\r':
             case '\n': {
                 i = menu_line - 1;
-                ask = false;
+                should_redraw_cursor = false;
                 break;
             }
             }
         }
         /* Request redraw */
-        if ((choice == ' ') || (choice == '*') || (choice == '?') || (use_menu && ask)) {
+        if ((choice == ' ') || (choice == '*') || (choice == '?') || (use_menu && should_redraw_cursor)) {
             /* Show the list */
             if (!redraw || use_menu) {
                 char psi_desc[80];
@@ -262,19 +262,8 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
 
         if (!use_menu) {
             if (isalpha(choice)) {
-                /* Note verify */
-                ask = (isupper(choice));
-
-                /* Lowercase */
-                if (ask) {
-                    choice = (char)tolower(choice);
-                }
-
-                /* Extract request */
-                i = (islower(choice) ? A2I(choice) : -1);
+                i = A2I(choice);
             } else {
-                ask = false; /* Can't uppercase digits */
-
                 i = choice - '0' + 26;
             }
         }
@@ -286,19 +275,6 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
         }
 
         j = sentaku[i];
-
-        /* Verify it */
-        if (ask) {
-            char tmp_val[160];
-
-            /* Prompt */
-            (void)strnfmt(tmp_val, 78, _("%sを使いますか？", "Use %s? "), exe_spell(player_ptr, REALM_HISSATSU, j, SpellProcessType::NAME));
-
-            /* Belay that order */
-            if (!get_check(tmp_val)) {
-                continue;
-            }
-        }
 
         /* Stop the loop */
         flag = true;

--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -147,7 +147,6 @@ static int get_mane_power(PlayerType *player_ptr, int *sn, bool baigaesi)
     PERCENTAGE minfail = 0;
     PLAYER_LEVEL plev = player_ptr->lev;
     PERCENTAGE chance = 0;
-    int ask;
     char choice;
     char out_val[MAX_MONSTER_NAME];
     char comment[80];
@@ -253,16 +252,8 @@ static int get_mane_power(PlayerType *player_ptr, int *sn, bool baigaesi)
             continue;
         }
 
-        /* Note verify */
-        ask = isupper(choice);
-
-        /* Lowercase */
-        if (ask) {
-            choice = (char)tolower(choice);
-        }
-
         /* Extract request */
-        i = (islower(choice) ? A2I(choice) : -1);
+        i = A2I(choice);
 
         /* Totally Illegal */
         if ((i < 0) || (i >= num)) {
@@ -272,19 +263,6 @@ static int get_mane_power(PlayerType *player_ptr, int *sn, bool baigaesi)
 
         /* Save the spell index */
         spell = monster_powers.at(mane_data->mane_list[i].spell);
-
-        /* Verify it */
-        if (ask) {
-            char tmp_val[160];
-
-            /* Prompt */
-            (void)strnfmt(tmp_val, 78, _("%sをまねますか？", "Use %s? "), spell.name);
-
-            /* Belay that order */
-            if (!get_check(tmp_val)) {
-                continue;
-            }
-        }
 
         /* Stop the loop */
         flag = true;

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -556,14 +556,13 @@ void do_cmd_pet(PlayerType *player_ptr)
 
         /* Get a command from the user */
         while (!flag) {
-            int ask = true;
-
             if (choice == ESCAPE) {
                 choice = ' ';
             } else if (!get_com(prompt.c_str(), &choice, true)) {
                 break;
             }
 
+            auto should_redraw_cursor = true;
             if (use_menu && (choice != ' ')) {
                 switch (choice) {
                 case '0':
@@ -599,7 +598,7 @@ void do_cmd_pet(PlayerType *player_ptr)
                 case '\r':
                 case '\n':
                     i = menu_line - 1;
-                    ask = false;
+                    should_redraw_cursor = false;
                     break;
                 }
                 if (menu_line > num) {
@@ -608,7 +607,7 @@ void do_cmd_pet(PlayerType *player_ptr)
             }
 
             /* Request redraw */
-            if ((choice == ' ') || (choice == '*') || (choice == '?') || (use_menu && ask)) {
+            if ((choice == ' ') || (choice == '*') || (choice == '?') || (use_menu && should_redraw_cursor)) {
                 /* Show the list */
                 if (!redraw || use_menu) {
                     byte y = 1, x = 0;
@@ -649,29 +648,13 @@ void do_cmd_pet(PlayerType *player_ptr)
             }
 
             if (!use_menu) {
-                /* Note verify */
-                ask = (isupper(choice));
-
-                /* Lowercase */
-                if (ask) {
-                    choice = (char)tolower(choice);
-                }
-
-                /* Extract request */
-                i = (islower(choice) ? A2I(choice) : -1);
+                i = A2I(choice);
             }
 
             /* Totally Illegal */
             if ((i < 0) || (i >= num)) {
                 bell();
                 continue;
-            }
-
-            /* Verify it */
-            if (ask) {
-                if (!get_check(format(_("%sを使いますか？ ", "Use %s? "), power_desc[i].c_str()))) {
-                    continue;
-                }
             }
 
             /* Stop the loop */

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -698,7 +698,6 @@ bool get_element_power(PlayerType *player_ptr, SPELL_IDX *sn, bool only_browse)
     TERM_LEN y = 1;
     TERM_LEN x = 10;
     PLAYER_LEVEL plev = player_ptr->lev;
-    int ask = true;
     char choice;
     char out_val[160];
     char comment[80];
@@ -746,6 +745,7 @@ bool get_element_power(PlayerType *player_ptr, SPELL_IDX *sn, bool only_browse)
             break;
         }
 
+        auto should_redraw_cursor = true;
         if (use_menu && choice != ' ') {
             switch (choice) {
             case '0':
@@ -768,7 +768,7 @@ bool get_element_power(PlayerType *player_ptr, SPELL_IDX *sn, bool only_browse)
             case '\r':
             case '\n':
                 i = menu_line - 1;
-                ask = false;
+                should_redraw_cursor = false;
                 break;
             }
 
@@ -778,7 +778,7 @@ bool get_element_power(PlayerType *player_ptr, SPELL_IDX *sn, bool only_browse)
         }
 
         int spell_max = enum2i(ElementSpells::MAX);
-        if ((choice == ' ') || (choice == '*') || (choice == '?') || (use_menu && ask)) {
+        if ((choice == ' ') || (choice == '*') || (choice == '?') || (use_menu && should_redraw_cursor)) {
             if (!redraw || use_menu) {
                 char desc[80];
                 char name[80];
@@ -828,29 +828,12 @@ bool get_element_power(PlayerType *player_ptr, SPELL_IDX *sn, bool only_browse)
         }
 
         if (!use_menu) {
-            ask = isupper(choice);
-            if (ask) {
-                choice = (char)tolower(choice);
-            }
-
-            i = (islower(choice) ? A2I(choice) : -1);
+            i = A2I(choice);
         }
 
         if ((i < 0) || (i >= num)) {
             bell();
             continue;
-        }
-
-        if (ask) {
-            char name[80];
-            char tmp_val[160];
-            elem = get_elemental_elem(player_ptr, i);
-            spell = get_elemental_info(player_ptr, i);
-            (void)sprintf(name, spell.name, get_element_name(player_ptr->element, elem));
-            (void)strnfmt(tmp_val, 78, _("%sを使いますか？", "Use %s? "), name);
-            if (!get_check(tmp_val)) {
-                continue;
-            }
         }
 
         flag = true;

--- a/src/mind/mind-power-getter.cpp
+++ b/src/mind/mind-power-getter.cpp
@@ -163,14 +163,6 @@ bool MindPowerGetter::decide_mind_choice(char *out_val, const bool only_browse)
         }
 
         this->spell = &mind_ptr->info[this->index];
-        if (this->ask) {
-            char tmp_val[160];
-            (void)strnfmt(tmp_val, 78, _("%sを使いますか？", "Use %s? "), this->spell->name);
-            if (!get_check(tmp_val)) {
-                continue;
-            }
-        }
-
         this->flag = true;
     }
 
@@ -183,6 +175,7 @@ bool MindPowerGetter::interpret_mind_key_input(const bool only_browse)
         return true;
     }
 
+    this->should_redraw_cursor = true;
     switch (this->choice) {
     case '0':
         if (!only_browse) {
@@ -205,7 +198,7 @@ bool MindPowerGetter::interpret_mind_key_input(const bool only_browse)
     case '\r':
     case '\n':
         this->index = this->menu_line - 1;
-        this->ask = false;
+        this->should_redraw_cursor = false;
         break;
     default:
         break;
@@ -220,7 +213,7 @@ bool MindPowerGetter::interpret_mind_key_input(const bool only_browse)
 
 bool MindPowerGetter::display_minds_chance(const bool only_browse)
 {
-    if ((this->choice != ' ') && (this->choice != '*') && (this->choice != '?') && (!use_menu || !this->ask)) {
+    if ((this->choice != ' ') && (this->choice != '*') && (this->choice != '?') && (!use_menu || !this->should_redraw_cursor)) {
         return false;
     }
 
@@ -364,10 +357,5 @@ void MindPowerGetter::make_choice_lower()
         return;
     }
 
-    this->ask = (bool)isupper(this->choice);
-    if (this->ask) {
-        this->choice = (char)tolower(this->choice);
-    }
-
-    this->index = (islower(this->choice) ? A2I(this->choice) : -1);
+    this->index = A2I(this->choice);
 }

--- a/src/mind/mind-power-getter.h
+++ b/src/mind/mind-power-getter.h
@@ -18,7 +18,7 @@ private:
     int num = 0;
     TERM_LEN y = 1;
     TERM_LEN x = 10;
-    bool ask = true;
+    bool should_redraw_cursor = true;
     char choice = 0;
     concptr mind_description = "";
     const mind_type *spell = nullptr;

--- a/src/mind/mind-sniper.cpp
+++ b/src/mind/mind-sniper.cpp
@@ -249,7 +249,6 @@ static int get_snipe_power(PlayerType *player_ptr, COMMAND_CODE *sn, bool only_b
     TERM_LEN y = 1;
     TERM_LEN x = 20;
     PLAYER_LEVEL plev = player_ptr->lev;
-    int ask;
     char choice;
     char out_val[160];
     concptr p = _("射撃術", "power");
@@ -359,16 +358,7 @@ static int get_snipe_power(PlayerType *player_ptr, COMMAND_CODE *sn, bool only_b
             continue;
         }
 
-        /* Note verify */
-        ask = isupper(choice);
-
-        /* Lowercase */
-        if (ask) {
-            choice = (char)tolower(choice);
-        }
-
-        /* Extract request */
-        i = (islower(choice) ? A2I(choice) : -1);
+        i = A2I(choice);
 
         /* Totally Illegal */
         if ((i < 0) || (i > num) || (!only_browse && (snipe_powers[i].mana_cost > sniper_data->concent))) {
@@ -378,19 +368,6 @@ static int get_snipe_power(PlayerType *player_ptr, COMMAND_CODE *sn, bool only_b
 
         /* Save the spell index */
         spell = snipe_powers[i];
-
-        /* Verify it */
-        if (ask) {
-            char tmp_val[160];
-
-            /* Prompt */
-            (void)strnfmt(tmp_val, 78, _("%sを使いますか？", "Use %s? "), snipe_powers[i].name);
-
-            /* Belay that order */
-            if (!get_check(tmp_val)) {
-                continue;
-            }
-        }
 
         /* Stop the loop */
         flag = true;

--- a/src/mind/mind-weaponsmith.cpp
+++ b/src/mind/mind-weaponsmith.cpp
@@ -309,7 +309,6 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
     char choice;
     concptr q, s;
     ObjectType *o_ptr;
-    int ask = true;
     char out_val[160];
     GAME_TEXT o_name[MAX_NLEN];
     int menu_line = (use_menu ? 1 : 0);
@@ -346,6 +345,7 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
                 break;
             }
 
+            auto should_redraw_cursor = true;
             if (use_menu) {
                 switch (choice) {
                 case '0': {
@@ -388,7 +388,7 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
                 case '\r':
                 case '\n': {
                     i = menu_line - 1;
-                    ask = false;
+                    should_redraw_cursor = false;
                     break;
                 }
                 }
@@ -399,7 +399,7 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
             }
 
             /* Request redraw */
-            if ((choice == ' ') || (use_menu && ask)) {
+            if ((choice == ' ') || (use_menu && should_redraw_cursor)) {
                 if (!use_menu) {
                     page++;
                 }
@@ -412,16 +412,7 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
             }
 
             if (!use_menu) {
-                /* Note verify */
-                ask = (isupper(choice));
-
-                /* Lowercase */
-                if (ask) {
-                    choice = (char)tolower(choice);
-                }
-
-                /* Extract request */
-                i = (islower(choice) ? A2I(choice) : -1);
+                i = A2I(choice);
             }
 
             effect_idx = page * effect_num_per_page + i;
@@ -429,19 +420,6 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
             if ((effect_idx < 0) || (effect_idx >= smith_effect_list_max) || smith.get_addable_count(smith_effect_list[effect_idx]) <= 0) {
                 bell();
                 continue;
-            }
-
-            /* Verify it */
-            if (ask) {
-                char tmp_val[160];
-
-                /* Prompt */
-                (void)strnfmt(tmp_val, 78, _("%sを付加しますか？ ", "Add the ability of %s? "), Smith::get_effect_name(smith_effect_list[i]));
-
-                /* Belay that order */
-                if (!get_check(tmp_val)) {
-                    continue;
-                }
             }
 
             /* Stop the loop */


### PR DESCRIPTION
掲題の通りです
これらのUI操作は似たりよったりのコピペなので、ひとまず剣術家で動いてヨシ！ したのでPRとして提出します
ご確認下さい

なお、元々以下のようなメッセージが出ていました
冷静に考えるとa～hの範囲しか取り得ないので数値が正常値扱いされるのは違和感があります
> (必殺剣 a-5, '*'で一覧, ESC) どの必殺剣を使いますか？

メニューを使ってカーソルを選んでも、取りうる値の範囲が2、4、6、8及びそれらのローグキー配置なのと、カーソル移動のためのキー入力を敢えて正常値としてユーザに示すのは変なので、全体として整合性が取れていません
本件は別途対応します