### PR TITLE
[Refactor] 賞金首関連のコードの整理

### DIFF
--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -150,7 +150,7 @@ void player_wipe_without_name(PlayerType *player_ptr)
     player_ptr->current_floor_ptr->quest_number = QuestId::NONE;
 
     player_ptr->exit_bldg = true;
-    player_ptr->today_mon = MonsterRaceId::PLAYER;
+    player_ptr->knows_daily_bounty = false;
     update_gambling_monsters(player_ptr);
     player_ptr->muta.clear();
 

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -16,7 +16,6 @@
 #include "knowledge/monster-group-table.h"
 #include "locale/english.h"
 #include "lore/lore-util.h"
-#include "market/bounty.h"
 #include "monster-race/monster-race.h"
 #include "monster-race/race-flags1.h"
 #include "monster-race/race-flags3.h"
@@ -77,8 +76,8 @@ static IDX collect_monsters(PlayerType *player_ptr, IDX grp_cur, MonsterRaceId m
                 continue;
             }
         } else if (grp_wanted) {
-            auto wanted = MonsterRace(player_ptr->today_mon).is_valid() && (player_ptr->today_mon == r_ref.idx);
-            wanted |= is_bounty(r_ref.idx, false);
+            auto wanted = player_ptr->knows_daily_bounty && (w_ptr->today_mon == r_ref.idx);
+            wanted |= MonsterRace(r_ref.idx).is_bounty(false);
 
             if (!wanted) {
                 continue;
@@ -494,7 +493,7 @@ void do_cmd_knowledge_bounty(PlayerType *player_ptr)
     }
 
     fprintf(fff, _("今日のターゲット : %s\n", "Today's target : %s\n"),
-        MonsterRace(player_ptr->today_mon).is_valid() ? r_info[player_ptr->today_mon].name.c_str() : _("不明", "unknown"));
+        player_ptr->knows_daily_bounty ? r_info[w_ptr->today_mon].name.c_str() : _("不明", "unknown"));
     fprintf(fff, "\n");
     fprintf(fff, _("賞金首リスト\n", "List of wanted monsters\n"));
     fprintf(fff, "----------------------------------------------\n");

--- a/src/load/world-loader.cpp
+++ b/src/load/world-loader.cpp
@@ -127,7 +127,7 @@ static void rd_world_info(PlayerType *player_ptr)
         determine_daily_bounty(player_ptr, true);
     } else {
         w_ptr->today_mon = i2enum<MonsterRaceId>(rd_s16b());
-        player_ptr->today_mon = i2enum<MonsterRaceId>(rd_s16b());
+        player_ptr->knows_daily_bounty = rd_s16b() != 0; // 現在bool型だが、かつてモンスター種族IDを保存していた仕様に合わせる
     }
 }
 

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -225,7 +225,7 @@ void today_target(PlayerType *player_ptr)
     prt(buf, 8, 10);
     sprintf(buf, _("骨   ---- $%d", "skeleton ---- $%d"), (int)r_ptr->level * 30 + 60);
     prt(buf, 9, 10);
-    player_ptr->today_mon = w_ptr->today_mon;
+    player_ptr->knows_daily_bounty = true;
 }
 
 /*!
@@ -269,31 +269,6 @@ void show_bounty(void)
             clear_bldg(7, 18);
         }
     }
-}
-
-/*!
- * @brief モンスターが賞金首の対象かどうかを調べる。達成済みの賞金首と日替わり賞金首は対象外。
- *
- * @param r_idx 対象のモンスター種族ID
- * @param unachieved_only true の場合未達成の賞金首のみを対象とする。false の場合達成未達成に関わらずすべての賞金首を対象とする。
- * @return 引数で指定したモンスター種族IDが賞金首の対象ならば true、そうでなければ false
- */
-bool is_bounty(MonsterRaceId r_idx, bool unachieved_only)
-{
-    auto it = std::find_if(std::begin(w_ptr->bounties), std::end(w_ptr->bounties),
-        [r_idx](const auto &b_ref) {
-            return b_ref.r_idx == r_idx;
-        });
-
-    if (it == std::end(w_ptr->bounties)) {
-        return false;
-    }
-
-    if (unachieved_only && (*it).is_achieved) {
-        return false;
-    }
-
-    return true;
 }
 
 /*!
@@ -346,8 +321,7 @@ void determine_daily_bounty(PlayerType *player_ptr, bool conv_old)
         break;
     }
 
-    // プレイヤーは日替わり賞金首に関する知識を失う。
-    player_ptr->today_mon = MonsterRaceId::PLAYER;
+    player_ptr->knows_daily_bounty = false;
 }
 
 /*!

--- a/src/market/bounty.h
+++ b/src/market/bounty.h
@@ -8,6 +8,5 @@ bool exchange_cash(PlayerType *player_ptr);
 void today_target(PlayerType *player_ptr);
 void tsuchinoko(void);
 void show_bounty(void);
-bool is_bounty(MonsterRaceId r_idx, bool unachieved_only);
 void determine_daily_bounty(PlayerType *player_ptr, bool conv_old);
 void determine_bounty_uniques(PlayerType *player_ptr);

--- a/src/monster-race/monster-race.cpp
+++ b/src/monster-race/monster-race.cpp
@@ -5,6 +5,7 @@
 #include "monster-race/race-resistance-mask.h"
 #include "system/monster-race-definition.h"
 #include "util/probability-table.h"
+#include "world/world.h"
 #include <algorithm>
 #include <vector>
 
@@ -45,6 +46,30 @@ MonsterRaceId MonsterRace::pick_one_at_random()
 bool MonsterRace::is_valid() const
 {
     return this->r_idx != MonsterRaceId::PLAYER;
+}
+
+/*!
+ * @brief モンスター種族が賞金首の対象かどうかを調べる。日替わり賞金首は対象外。
+ *
+ * @param unachieved_only true の場合未達成の賞金首のみを対象とする。false の場合達成未達成に関わらずすべての賞金首を対象とする。
+ * @return モンスター種族が賞金首の対象ならば true、そうでなければ false
+ */
+bool MonsterRace::is_bounty(bool unachieved_only) const
+{
+    auto it = std::find_if(std::begin(w_ptr->bounties), std::end(w_ptr->bounties),
+        [r_idx = this->r_idx](const auto &b_ref) {
+            return b_ref.r_idx == r_idx;
+        });
+
+    if (it == std::end(w_ptr->bounties)) {
+        return false;
+    }
+
+    if (unachieved_only && (*it).is_achieved) {
+        return false;
+    }
+
+    return true;
 }
 
 /*!

--- a/src/monster-race/monster-race.h
+++ b/src/monster-race/monster-race.h
@@ -15,6 +15,7 @@ public:
     static MonsterRaceId pick_one_at_random();
 
     bool is_valid() const;
+    bool is_bounty(bool unachieved_only) const;
     int calc_power() const;
 
 private:

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -17,7 +17,6 @@
 #include "io/write-diary.h"
 #include "main/sound-definitions-table.h"
 #include "main/sound-of-music.h"
-#include "market/bounty.h"
 #include "mind/mind-ninja.h"
 #include "monster-floor/monster-death.h"
 #include "monster-floor/monster-remover.h"
@@ -415,7 +414,7 @@ void MonsterDamageProcessor::show_bounty_message(GAME_TEXT *m_name)
         return;
     }
 
-    if (is_bounty(m_ptr->r_idx, true)) {
+    if (MonsterRace(m_ptr->r_idx).is_bounty(true)) {
         msg_format(_("%sの首には賞金がかかっている。", "There is a price on %s's head."), m_name);
     }
 }

--- a/src/object-hook/hook-quest.cpp
+++ b/src/object-hook/hook-quest.cpp
@@ -2,7 +2,6 @@
 #include "cmd-building/cmd-building.h"
 #include "dungeon/quest.h"
 #include "game-option/birth-options.h"
-#include "market/bounty.h"
 #include "monster-race/monster-race.h"
 #include "monster-race/race-indice-types.h"
 #include "object-enchant/trg-types.h"
@@ -29,7 +28,7 @@ bool object_is_bounty(PlayerType *player_ptr, ObjectType *o_ptr)
     }
 
     auto corpse_r_idx = i2enum<MonsterRaceId>(o_ptr->pval);
-    if (MonsterRace(player_ptr->today_mon).is_valid() && (streq(r_info[corpse_r_idx].name.c_str(), r_info[w_ptr->today_mon].name.c_str()))) {
+    if (player_ptr->knows_daily_bounty && (streq(r_info[corpse_r_idx].name.c_str(), r_info[w_ptr->today_mon].name.c_str()))) {
         return true;
     }
 
@@ -37,7 +36,7 @@ bool object_is_bounty(PlayerType *player_ptr, ObjectType *o_ptr)
         return true;
     }
 
-    return is_bounty(corpse_r_idx, true);
+    return MonsterRace(corpse_r_idx).is_bounty(true);
 }
 
 /*!

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -258,7 +258,7 @@ void wr_player(PlayerType *player_ptr)
     wr_s32b(w_ptr->dungeon_turn);
     wr_s32b(w_ptr->arena_start_turn);
     wr_s16b(enum2i(w_ptr->today_mon));
-    wr_s16b(enum2i(player_ptr->today_mon));
+    wr_s16b(player_ptr->knows_daily_bounty ? 1 : 0); // 現在bool型だが、かつてモンスター種族IDを保存していた仕様に合わせる
     wr_s16b(player_ptr->riding);
     wr_s16b(player_ptr->floor_id);
 

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -220,7 +220,7 @@ public:
     int16_t pet_follow_distance{}; /* Length of the imaginary "leash" for pets */
     BIT_FLAGS16 pet_extra_flags{}; /* Various flags for controling pets */
 
-    MonsterRaceId today_mon{}; //!< 日替わり賞金首を知っていればそのモンスターID、知らなければ MonsterRaceId::PLAYER
+    bool knows_daily_bounty{}; //!< 日替わり賞金首を知っているか否か
 
     bool dtrap{}; /* Whether you are on trap-safe grids */
     FLOOR_IDX floor_id{}; /* Current floor location */

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -11,7 +11,6 @@
 #include "inventory/inventory-util.h"
 #include "locale/japanese.h"
 #include "main/sound-of-music.h"
-#include "market/bounty.h"
 #include "monster-race/monster-race.h"
 #include "monster-race/race-flags1.h"
 #include "monster/monster-flag-types.h"
@@ -115,7 +114,7 @@ static void print_monster_line(TERM_LEN x, TERM_LEN y, monster_type *m_ptr, int 
         return;
     }
     if (r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
-        term_addstr(-1, TERM_WHITE, is_bounty(r_idx, true) ? "  W" : "  U");
+        term_addstr(-1, TERM_WHITE, MonsterRace(r_idx).is_bounty(true) ? "  W" : "  U");
     } else {
         sprintf(buf, "%3d", n_same);
         term_addstr(-1, TERM_WHITE, buf);


### PR DESCRIPTION
is_bounty() を MonsterRace のメンバにする。
また、 PlayerType::today_mon は日替わり賞金首を確認済みかだけの情報があればよい
（実際のモンスター種族IDは world_type::today_mon を見ればわかる）ので、bool 型に
変更し、メンバ名を knows_daily_bounty に変更する。

同じ MonsterRace クラスを変更する関係上、 #2377 のブランチから分岐しているため #2377 の差分も含まれます。後でリベースしますが、このPR単体の修正範囲を確認するには、 9f4a6e8b976d23f5b9b3539bd5ad40746541e4df を見てもらえば良いです。