### PR TITLE
[Refactor] 必要以上のMonsterRaceIdのキャストとMonsterRaceId::PLAYERの使用を避ける

### DIFF
--- a/src/action/movement-execution.cpp
+++ b/src/action/movement-execution.cpp
@@ -201,9 +201,9 @@ void exe_movement(PlayerType *player_ptr, DIRECTION dir, bool do_pickup, bool br
     }
 
     monster_type *riding_m_ptr = &floor_ptr->m_list[player_ptr->riding];
-    monster_race *riding_r_ptr = &r_info[player_ptr->riding ? riding_m_ptr->r_idx : MonsterRaceId::PLAYER];
     PlayerEnergy energy(player_ptr);
     if (can_move && player_ptr->riding) {
+        const auto *riding_r_ptr = &r_info[riding_m_ptr->r_idx];
         if (riding_r_ptr->behavior_flags.has(MonsterBehaviorType::NEVER_MOVE)) {
             msg_print(_("動けない！", "Can't move!"));
             energy.reset_player_turn();
@@ -255,7 +255,8 @@ void exe_movement(PlayerType *player_ptr, DIRECTION dir, bool do_pickup, bool br
         player_ptr->running = 0;
         can_move = false;
     } else if (f_ptr->flags.has(FloorFeatureType::TREE) && !p_can_kill_walls) {
-        if (!PlayerClass(player_ptr).equals(PlayerClassType::RANGER) && !player_ptr->levitation && (!player_ptr->riding || !(riding_r_ptr->flags8 & RF8_WILD_WOOD))) {
+        auto riding_wild_wood = player_ptr->riding && any_bits(r_info[riding_m_ptr->r_idx].flags8, RF8_WILD_WOOD);
+        if (!PlayerClass(player_ptr).equals(PlayerClassType::RANGER) && !player_ptr->levitation && !riding_wild_wood) {
             energy.mul_player_turn_energy(2);
         }
     } else if ((do_pickup != easy_disarm) && f_ptr->flags.has(FloorFeatureType::DISARM) && !g_ptr->mimic) {

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -10,7 +10,6 @@
 #include "monster-race/monster-race.h"
 #include "monster-race/race-flags1.h"
 #include "monster-race/race-flags7.h"
-#include "monster-race/race-indice-types.h"
 #include "object/object-kind.h"
 #include "pet/pet-util.h"
 #include "player-base/player-class.h"
@@ -65,7 +64,7 @@ void player_wipe_without_name(PlayerType *player_ptr)
         q_ref.max_num = 0;
         q_ref.type = QuestKindType::NONE;
         q_ref.level = 0;
-        q_ref.r_idx = MonsterRaceId::PLAYER;
+        q_ref.r_idx = MonsterRace::empty_id();
         q_ref.complev = 0;
         q_ref.comptime = 0;
     }

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -22,7 +22,6 @@
 #include "monster-race/monster-race.h"
 #include "monster-race/race-flags1.h"
 #include "monster-race/race-flags7.h"
-#include "monster-race/race-indice-types.h"
 #include "monster/monster-describer.h"
 #include "monster/monster-description-types.h"
 #include "monster/monster-info.h"
@@ -124,8 +123,8 @@ static void record_pet_diary(PlayerType *player_ptr)
  */
 static void preserve_pet(PlayerType *player_ptr)
 {
-    for (MONSTER_IDX party_monster_num = 0; party_monster_num < MAX_PARTY_MON; party_monster_num++) {
-        party_mon[party_monster_num].r_idx = MonsterRaceId::PLAYER;
+    for (auto &mon : party_mon) {
+        mon.r_idx = MonsterRace::empty_id();
     }
 
     check_riding_preservation(player_ptr);
@@ -261,7 +260,7 @@ static void get_out_monster(PlayerType *player_ptr)
  */
 static void preserve_info(PlayerType *player_ptr)
 {
-    auto quest_r_idx = MonsterRaceId::PLAYER;
+    auto quest_r_idx = MonsterRace::empty_id();
     for (auto &[q_idx, q_ref] : quest_map) {
         auto quest_relating_monster = (q_ref.status == QuestStatusType::TAKEN);
         quest_relating_monster &= ((q_ref.type == QuestKindType::KILL_LEVEL) || (q_ref.type == QuestKindType::RANDOM));

--- a/src/market/arena-info-table.cpp
+++ b/src/market/arena-info-table.cpp
@@ -1,4 +1,5 @@
 ﻿#include "market/arena-info-table.h"
+#include "monster-race/monster-race.h"
 #include "monster-race/race-indice-types.h"
 #include "object/tval-types.h"
 #include "sv-definition/sv-amulet-types.h"
@@ -56,7 +57,7 @@ const std::vector<arena_type> arena_info = {
     { MonsterRaceId::BLACK_REAVER, ItemKindType::RING, SV_RING_LORDLY },
     { MonsterRaceId::FENGHUANG, ItemKindType::STAFF, SV_STAFF_THE_MAGI },
     { MonsterRaceId::WYRM_POWER, ItemKindType::SCROLL, SV_SCROLL_ARTIFACT },
-    { MonsterRaceId::PLAYER, ItemKindType::NONE, 0 }, /* Victory prizing */
+    { MonsterRace::empty_id(), ItemKindType::NONE, 0 }, /* Victory prizing */
     { MonsterRaceId::HAGURE, ItemKindType::SCROLL, SV_SCROLL_ARTIFACT },
 };
 

--- a/src/monster-floor/monster-summon.cpp
+++ b/src/monster-floor/monster-summon.cpp
@@ -133,7 +133,7 @@ bool summon_specific(PlayerType *player_ptr, MONSTER_IDX who, POSITION y1, POSIT
     }
 
     POSITION x, y;
-    if (!mon_scatter(player_ptr, MonsterRaceId::PLAYER, &y, &x, y1, x1, 2)) {
+    if (!mon_scatter(player_ptr, MonsterRace::empty_id(), &y, &x, y1, x1, 2)) {
         return false;
     }
 

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -338,7 +338,7 @@ bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSI
     }
 
     if (any_bits(r_ptr->flags7, RF7_CHAMELEON)) {
-        choose_new_monster(player_ptr, g_ptr->m_idx, true, MonsterRaceId::PLAYER);
+        choose_new_monster(player_ptr, g_ptr->m_idx, true, MonsterRace::empty_id());
         r_ptr = &r_info[m_ptr->r_idx];
         m_ptr->mflag2.set(MonsterConstantFlagType::CHAMELEON);
         if (r_ptr->kind_flags.has(MonsterKindType::UNIQUE) && (who <= 0)) {

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -488,8 +488,8 @@ static void on_dead_chest_mimic(PlayerType *player_ptr, monster_death_type *md_p
     }
 
     bool notice = false;
-    MonsterRaceId mimic_inside;
-    int num_summons;
+    auto mimic_inside = MonsterRace::empty_id();
+    auto num_summons = 0;
     auto r_idx = md_ptr->m_ptr->r_idx;
     switch (r_idx) {
     case MonsterRaceId::CHEST_MIMIC_03:
@@ -505,8 +505,6 @@ static void on_dead_chest_mimic(PlayerType *player_ptr, monster_death_type *md_p
         num_summons = one_in_(2) ? 3 : 2;
         break;
     default:
-        mimic_inside = i2enum<MonsterRaceId>(-1);
-        num_summons = 0;
         return;
     }
 

--- a/src/monster-race/monster-race-hook.cpp
+++ b/src/monster-race/monster-race-hook.cpp
@@ -19,6 +19,7 @@
 #include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "util/string-processor.h"
+#include <set>
 
 /*! 通常pit生成時のモンスターの構成条件ID / Race index for "monster pit (clone)" */
 MonsterRaceId vault_aux_race;
@@ -454,8 +455,21 @@ bool vault_aux_undead(PlayerType *player_ptr, MonsterRaceId r_idx)
  */
 bool vault_aux_chapel_g(PlayerType *player_ptr, MonsterRaceId r_idx)
 {
-    static MonsterRaceId chapel_list[] = { MonsterRaceId::NOV_PRIEST, MonsterRaceId::NOV_PALADIN, MonsterRaceId::NOV_PRIEST_G, MonsterRaceId::NOV_PALADIN_G, MonsterRaceId::PRIEST, MonsterRaceId::JADE_MONK, MonsterRaceId::IVORY_MONK,
-        MonsterRaceId::ULTRA_PALADIN, MonsterRaceId::EBONY_MONK, MonsterRaceId::W_KNIGHT, MonsterRaceId::KNI_TEMPLAR, MonsterRaceId::PALADIN, MonsterRaceId::TOPAZ_MONK, MonsterRaceId::PLAYER };
+    static const std::set<MonsterRaceId> chapel_list = {
+        MonsterRaceId::NOV_PRIEST,
+        MonsterRaceId::NOV_PALADIN,
+        MonsterRaceId::NOV_PRIEST_G,
+        MonsterRaceId::NOV_PALADIN_G,
+        MonsterRaceId::PRIEST,
+        MonsterRaceId::JADE_MONK,
+        MonsterRaceId::IVORY_MONK,
+        MonsterRaceId::ULTRA_PALADIN,
+        MonsterRaceId::EBONY_MONK,
+        MonsterRaceId::W_KNIGHT,
+        MonsterRaceId::KNI_TEMPLAR,
+        MonsterRaceId::PALADIN,
+        MonsterRaceId::TOPAZ_MONK,
+    };
 
     auto *r_ptr = &r_info[r_idx];
     if (!vault_monster_okay(player_ptr, r_idx)) {
@@ -474,13 +488,7 @@ bool vault_aux_chapel_g(PlayerType *player_ptr, MonsterRaceId r_idx)
         return true;
     }
 
-    for (int i = 0; MonsterRace(chapel_list[i]).is_valid(); i++) {
-        if (r_idx == chapel_list[i]) {
-            return true;
-        }
-    }
-
-    return false;
+    return chapel_list.find(r_idx) != chapel_list.end();
 }
 
 /*!
@@ -757,7 +765,7 @@ bool vault_aux_cthulhu(PlayerType *player_ptr, MonsterRaceId r_idx)
  */
 bool vault_aux_dark_elf(PlayerType *player_ptr, MonsterRaceId r_idx)
 {
-    static MonsterRaceId dark_elf_list[] = {
+    static const std::set<MonsterRaceId> dark_elf_list = {
         MonsterRaceId::D_ELF,
         MonsterRaceId::D_ELF_MAGE,
         MonsterRaceId::D_ELF_WARRIOR,
@@ -768,20 +776,13 @@ bool vault_aux_dark_elf(PlayerType *player_ptr, MonsterRaceId r_idx)
         MonsterRaceId::NIGHTBLADE,
         MonsterRaceId::D_ELF_SORC,
         MonsterRaceId::D_ELF_SHADE,
-        MonsterRaceId::PLAYER,
     };
 
     if (!vault_monster_okay(player_ptr, r_idx)) {
         return false;
     }
 
-    for (int i = 0; MonsterRace(dark_elf_list[i]).is_valid(); i++) {
-        if (r_idx == dark_elf_list[i]) {
-            return true;
-        }
-    }
-
-    return false;
+    return dark_elf_list.find(r_idx) != dark_elf_list.end();
 }
 
 /*!

--- a/src/monster-race/monster-race.cpp
+++ b/src/monster-race/monster-race.cpp
@@ -18,6 +18,19 @@ MonsterRace::MonsterRace(MonsterRaceId r_idx)
 }
 
 /*!
+ * @brief どのモンスター種族でもない事を意味する MonsterRaceId を返す
+ * @details 実態は MonsterRaceId::PLAYER だが、この値は実際にプレイヤーとしての意味として使われる場合
+ * （召喚主がプレイヤーの場合やマップ上の表示属性情報等）とどのモンスターでもない意味として使われる場合があるので、
+ * 後者ではこれを使用することでコード上の意図をわかりやすくする。
+ *
+ * @return (どのモンスター種族でもないという意味での) MonsterRaceId::PLAYER を返す
+ */
+MonsterRaceId MonsterRace::empty_id()
+{
+    return MonsterRaceId::PLAYER;
+}
+
+/*!
  * @brief (MonsterRaceId::PLAYERを除く)実在するすべてのモンスター種族IDから等確率で1つ選択する
  *
  * @return 選択したモンスター種族ID

--- a/src/monster-race/monster-race.h
+++ b/src/monster-race/monster-race.h
@@ -12,6 +12,7 @@ class MonsterRace {
 public:
     MonsterRace(MonsterRaceId r_idx);
 
+    static MonsterRaceId empty_id();
     static MonsterRaceId pick_one_at_random();
 
     bool is_valid() const;

--- a/src/monster-race/race-indice-types.h
+++ b/src/monster-race/race-indice-types.h
@@ -1,7 +1,7 @@
 ﻿#pragma once
 
 enum class MonsterRaceId : int16_t {
-    PLAYER = 0, // Dummy.
+    PLAYER = 0,
     BEGGAR = 12,
     LEPER = 13,
     LION_HEART = 19,

--- a/src/monster/monster-damage.h
+++ b/src/monster/monster-damage.h
@@ -31,7 +31,7 @@ private:
     void death_special_flag_monster();
     void death_unique_monster(MonsterRaceId r_idx);
     bool check_combined_unique(const MonsterRaceId r_idx, std::vector<MonsterRaceId> *combined_uniques);
-    void death_combined_uniques(const MonsterRaceId r_idx, combined_uniques *combined_uniques);
+    void death_combined_uniques(const MonsterRaceId r_idx, const combined_uniques &combined_uniques);
     void increase_kill_numbers();
     void death_amberites(GAME_TEXT *m_name);
     void dying_scream(GAME_TEXT *m_name);

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -177,7 +177,7 @@ MonsterRaceId get_mon_num(PlayerType *player_ptr, DEPTH min_level, DEPTH max_lev
     }
 
     if (prob_table.empty()) {
-        return MonsterRaceId::PLAYER;
+        return MonsterRace::empty_id();
     }
 
     // 40%で1回、50%で2回、10%で3回抽選し、その中で一番レベルが高いモンスターを選択する

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -122,7 +122,7 @@ void process_monster(PlayerType *player_ptr, MONSTER_IDX m_idx)
 
     decide_drop_from_monster(player_ptr, m_idx, turn_flags_ptr->is_riding_mon);
     if (m_ptr->mflag2.has(MonsterConstantFlagType::CHAMELEON) && one_in_(13) && !monster_csleep_remaining(m_ptr)) {
-        choose_new_monster(player_ptr, m_idx, false, MonsterRaceId::PLAYER);
+        choose_new_monster(player_ptr, m_idx, false, MonsterRace::empty_id());
         r_ptr = &r_info[m_ptr->r_idx];
     }
 

--- a/src/object-enchant/others/apply-magic-others.cpp
+++ b/src/object-enchant/others/apply-magic-others.cpp
@@ -168,17 +168,16 @@ void OtherItemsEnchanter::generate_corpse()
  */
 void OtherItemsEnchanter::generate_statue()
 {
-    MonsterRaceId r_idx;
-    const auto *r_ptr = &r_info[MonsterRaceId::PLAYER];
-    while (true) {
-        r_idx = MonsterRace::pick_one_at_random();
-        r_ptr = &r_info[r_idx];
-        if (r_ptr->rarity == 0) {
-            continue;
+    auto pick_r_idx_for_statue = [] {
+        while (true) {
+            auto r_idx = MonsterRace::pick_one_at_random();
+            if (r_info[r_idx].rarity > 0) {
+                return r_idx;
+            }
         }
-
-        break;
-    }
+    };
+    auto r_idx = pick_r_idx_for_statue();
+    auto *r_ptr = &r_info[r_idx];
 
     this->o_ptr->pval = enum2i(r_idx);
     if (cheat_peek) {


### PR DESCRIPTION
MonsterRaceId への不要なキャストを減らせるようにリファクタリングする。
ObjectType::pval を MonsterRaceId にキャストするコードは数が多いので別途対応する。

MonsterRaceId::PLAYER という値はほとんどの場合、どのモンスターでもないという意味で
使用されているので、その場合 MonsterRaceId::empty_id() の戻り値を使用する。
（念の為、実際の値は MonsterRaceId::PLAYER のままとしてある。）
真にプレイヤーを意味する場合のみに MonsterRaceId::PLAYER を使用する。

関連して MSVC の警告をなくすためのリファクタリングも含まれます。