### PR TITLE
SpellsMirrorMaster クラスを作成して鏡魔法の効果処理を大部分移した

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -294,6 +294,7 @@
     <ClCompile Include="..\..\src\player-info\magic-eater-data-type.cpp" />
     <ClCompile Include="..\..\src\save\player-class-specific-data-writer.cpp" />
     <ClCompile Include="..\..\src\specific-object\stone-of-lore.cpp" />
+    <ClCompile Include="..\..\src\spell-class\spells-mirror-master.cpp" />
     <ClCompile Include="..\..\src\system\grid-type-definition.cpp" />
     <ClCompile Include="..\..\src\grid\feature-action-flags.cpp" />
     <ClCompile Include="..\..\src\main-win\commandline-win.cpp" />
@@ -1057,6 +1058,7 @@
     <ClInclude Include="..\..\src\main-win\main-win-utils.h" />
     <ClInclude Include="..\..\src\save\player-class-specific-data-writer.h" />
     <ClInclude Include="..\..\src\specific-object\stone-of-lore.h" />
+    <ClInclude Include="..\..\src\spell-class\spells-mirror-master.h" />
     <ClInclude Include="..\..\src\store\cmd-store.h" />
     <ClInclude Include="..\..\src\cmd-io\cmd-floor.h" />
     <ClInclude Include="..\..\src\cmd-io\cmd-lore.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2409,6 +2409,9 @@
     <ClCompile Include="..\..\src\object-use\read\parchment-read-executor.cpp">
       <Filter>object-use\read</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\spell-class\spells-mirror-master.cpp">
+      <Filter>spell-class</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5235,6 +5238,9 @@
     <ClInclude Include="..\..\src\object-use\read\read-executor-base.h">
       <Filter>object-use\read</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\spell-class\spells-mirror-master.h">
+      <Filter>spell-class</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\src\wall.bmp" />
@@ -5480,6 +5486,9 @@
     </Filter>
     <Filter Include="object-use\read">
       <UniqueIdentifier>{b0af4dd7-335a-466f-adb9-cd217597e87b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="spell-class">
+      <UniqueIdentifier>{b03873b1-e021-4bfe-84e4-0fa1e0bc87a2}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -810,6 +810,8 @@ hengband_SOURCES = \
 	spell/summon-types.h \
 	spell/technic-info-table.cpp spell/technic-info-table.h \
 	\
+	spell-class/spells-mirror-master.cpp spell-class/spells-mirror-master.h \
+	\
 	spell-kind/blood-curse.cpp spell-kind/blood-curse.h \
 	spell-kind/earthquake.cpp spell-kind/earthquake.h \
 	spell-kind/magic-item-recharger.cpp spell-kind/magic-item-recharger.h \

--- a/src/effect/effect-feature.cpp
+++ b/src/effect/effect-feature.cpp
@@ -16,6 +16,7 @@
 #include "monster/monster-update.h"
 #include "player/special-defense-types.h"
 #include "room/door-definition.h"
+#include "spell-class/spells-mirror-master.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
 #include "system/player-type-definition.h"
@@ -414,7 +415,7 @@ bool affect_feature(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITIO
         if (g_ptr->is_mirror()) {
             msg_print(_("鏡が割れた！", "The mirror was shattered!"));
             sound(SOUND_GLASS);
-            remove_mirror(player_ptr, y, x);
+            SpellsMirrorMaster(player_ptr).remove_mirror(y, x);
             project(player_ptr, 0, 2, y, x, player_ptr->lev / 2 + 5, AttributeType::SHARDS,
                 (PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_JUMP | PROJECT_NO_HANGEKI));
         }
@@ -436,7 +437,7 @@ bool affect_feature(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITIO
         if (g_ptr->is_mirror() && player_ptr->lev < 40) {
             msg_print(_("鏡が割れた！", "The mirror was shattered!"));
             sound(SOUND_GLASS);
-            remove_mirror(player_ptr, y, x);
+            SpellsMirrorMaster(player_ptr).remove_mirror(y, x);
             project(player_ptr, 0, 2, y, x, player_ptr->lev / 2 + 5, AttributeType::SHARDS,
                 (PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_JUMP | PROJECT_NO_HANGEKI));
         }
@@ -456,7 +457,7 @@ bool affect_feature(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITIO
     }
     case AttributeType::DISINTEGRATE: {
         if (g_ptr->is_mirror() || g_ptr->is_rune_protection() || g_ptr->is_rune_explosion()) {
-            remove_mirror(player_ptr, y, x);
+            SpellsMirrorMaster(player_ptr).remove_mirror(y, x);
         }
 
         if (f_ptr->flags.has_not(FloorFeatureType::HURT_DISI) || f_ptr->flags.has(FloorFeatureType::PERMANENT)) {

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -26,6 +26,7 @@
 #include "monster/monster-info.h"
 #include "pet/pet-fall-off.h"
 #include "player/player-status.h"
+#include "spell-class/spells-mirror-master.h"
 #include "spell/range-calc.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
@@ -228,7 +229,7 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
 
             monster_target_y = ny;
             monster_target_x = nx;
-            remove_mirror(player_ptr, ny, nx);
+            SpellsMirrorMaster(player_ptr).remove_mirror(ny, nx);
             next_mirror(player_ptr, &oy, &ox, ny, nx);
             path_n = i + projection_path(player_ptr, &(path_g[i + 1]), (project_length ? project_length : get_max_range(player_ptr)), ny, nx, oy, ox, flag);
             auto y = ny;
@@ -338,7 +339,7 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
             if (player_ptr->current_floor_ptr->grid_array[ny][nx].is_mirror() && !second_step) {
                 monster_target_y = ny;
                 monster_target_x = nx;
-                remove_mirror(player_ptr, ny, nx);
+                SpellsMirrorMaster(player_ptr).remove_mirror(ny, nx);
                 auto y = ny;
                 auto x = nx;
                 for (j = 0; j <= i; j++) {

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -31,6 +31,7 @@
 #include "player/player-status.h"
 #include "player/special-defense-types.h"
 #include "save/floor-writer.h"
+#include "spell-class/spells-mirror-master.h"
 #include "system/artifact-type-definition.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
@@ -442,7 +443,7 @@ static void exe_leave_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr)
 void leave_floor(PlayerType *player_ptr)
 {
     preserve_pet(player_ptr);
-    remove_all_mirrors(player_ptr, false);
+    SpellsMirrorMaster(player_ptr).remove_all_mirrors(false);
     set_superstealth(player_ptr, false);
 
     new_floor_id = 0;

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -831,32 +831,6 @@ void cave_alter_feat(PlayerType *player_ptr, POSITION y, POSITION x, FloorFeatur
     }
 }
 
-/* Remove a mirror */
-void remove_mirror(PlayerType *player_ptr, POSITION y, POSITION x)
-{
-    auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
-
-    /* Remove the mirror */
-    g_ptr->info &= ~(CAVE_OBJECT);
-    g_ptr->mimic = 0;
-
-    if (d_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
-        g_ptr->info &= ~(CAVE_GLOW);
-        if (!view_torch_grids) {
-            g_ptr->info &= ~(CAVE_MARK);
-        }
-        if (g_ptr->m_idx) {
-            update_monster(player_ptr, g_ptr->m_idx, false);
-        }
-
-        update_local_illumination(player_ptr, y, x);
-    }
-
-    note_spot(player_ptr, y, x);
-
-    lite_spot(player_ptr, y, x);
-}
-
 /*!
  * @brief 指定されたマスがモンスターのテレポート可能先かどうかを判定する。
  * @param player_ptr プレイヤーへの参照ポインタ

--- a/src/grid/grid.h
+++ b/src/grid/grid.h
@@ -57,7 +57,6 @@ void lite_spot(PlayerType *player_ptr, POSITION y, POSITION x);
 void update_flow(PlayerType *player_ptr);
 FEAT_IDX feat_state(floor_type *floor_ptr, FEAT_IDX feat, FloorFeatureType action);
 void cave_alter_feat(PlayerType *player_ptr, POSITION y, POSITION x, FloorFeatureType action);
-void remove_mirror(PlayerType *player_ptr, POSITION y, POSITION x);
 bool is_open(PlayerType *player_ptr, FEAT_IDX feat);
 bool check_local_illumination(PlayerType *player_ptr, POSITION y, POSITION x);
 bool cave_monster_teleportable_bold(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION y, POSITION x, teleport_flags mode);

--- a/src/mind/mind-mirror-master.cpp
+++ b/src/mind/mind-mirror-master.cpp
@@ -262,26 +262,6 @@ bool place_mirror(PlayerType *player_ptr)
     return true;
 }
 
-/*!
- * @brief 鏡抜け処理のメインルーチン /
- * Mirror Master's Dimension Door
- * @param player_ptr プレイヤーへの参照ポインタ
- * @return ターンを消費した場合TRUEを返す
- */
-bool mirror_tunnel(PlayerType *player_ptr)
-{
-    POSITION x = 0, y = 0;
-    if (!tgt_pt(player_ptr, &x, &y)) {
-        return false;
-    }
-    if (exe_dimension_door(player_ptr, x, y)) {
-        return true;
-    }
-
-    msg_print(_("鏡の世界をうまく通れなかった！", "You could not enter the mirror!"));
-    return true;
-}
-
 /*
  * Set "multishadow", notice observable changes
  */
@@ -528,7 +508,7 @@ bool cast_mirror_spell(PlayerType *player_ptr, mind_mirror_master_type spell)
         break;
     case MIRROR_TUNNEL:
         msg_print(_("鏡の世界を通り抜け…  ", "You try to enter the mirror..."));
-        return mirror_tunnel(player_ptr);
+        return SpellsMirrorMaster(player_ptr).mirror_tunnel();
     case RECALL_MIRROR:
         return recall_player(player_ptr, randint0(21) + 15);
     case MULTI_SHADOW:

--- a/src/mind/mind-mirror-master.cpp
+++ b/src/mind/mind-mirror-master.cpp
@@ -22,6 +22,7 @@
 #include "mind/mind-magic-resistance.h"
 #include "mind/mind-numbers.h"
 #include "pet/pet-util.h"
+#include "spell-class/spells-mirror-master.h"
 #include "spell-kind/spells-detection.h"
 #include "spell-kind/spells-floor.h"
 #include "spell-kind/spells-launcher.h"
@@ -78,30 +79,6 @@ bool mirror_concentration(PlayerType *player_ptr)
 
     player_ptr->redraw |= PR_MANA;
     return true;
-}
-
-/*!
- * @brief 全鏡の消去 / Remove all mirrors in this floor
- * @param player_ptr プレイヤーへの参照ポインタ
- * @param explode 爆発処理を伴うならばTRUE
- */
-void remove_all_mirrors(PlayerType *player_ptr, bool explode)
-{
-    for (POSITION x = 0; x < player_ptr->current_floor_ptr->width; x++) {
-        for (POSITION y = 0; y < player_ptr->current_floor_ptr->height; y++) {
-            if (!player_ptr->current_floor_ptr->grid_array[y][x].is_mirror()) {
-                continue;
-            }
-
-            remove_mirror(player_ptr, y, x);
-            if (!explode) {
-                continue;
-            }
-
-            project(player_ptr, 0, 2, y, x, player_ptr->lev / 2 + 5, AttributeType::SHARDS,
-                (PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_JUMP | PROJECT_NO_HANGEKI));
-        }
-    }
 }
 
 /*!
@@ -214,7 +191,7 @@ bool binding_field(PlayerType *player_ptr, int dam)
 
     if (one_in_(7)) {
         msg_print(_("鏡が結界に耐えきれず、壊れてしまった。", "The field broke a mirror"));
-        remove_mirror(player_ptr, point_y[0], point_x[0]);
+        SpellsMirrorMaster(player_ptr).remove_mirror(point_y[0], point_x[0]);
     }
 
     return true;
@@ -238,7 +215,7 @@ void seal_of_mirror(PlayerType *player_ptr, int dam)
             }
 
             if (!player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
-                remove_mirror(player_ptr, y, x);
+                SpellsMirrorMaster(player_ptr).remove_mirror(y, x);
             }
         }
     }

--- a/src/mind/mind-mirror-master.cpp
+++ b/src/mind/mind-mirror-master.cpp
@@ -53,35 +53,6 @@ bool check_multishadow(PlayerType *player_ptr)
 }
 
 /*!
- * 静水
- * @param player_ptr プレイヤーへの参照ポインタ
- * @return ペットを操っている場合を除きTRUE
- */
-bool mirror_concentration(PlayerType *player_ptr)
-{
-    if (total_friends) {
-        msg_print(_("今はペットを操ることに集中していないと。", "Your pets demand all of your attention."));
-        return false;
-    }
-
-    if (!player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x].is_mirror()) {
-        msg_print(_("鏡の上でないと集中できない！", "There's no mirror here!"));
-        return true;
-    }
-
-    msg_print(_("少し頭がハッキリした。", "You feel your head clear a little."));
-
-    player_ptr->csp += (5 + player_ptr->lev * player_ptr->lev / 100);
-    if (player_ptr->csp >= player_ptr->msp) {
-        player_ptr->csp = player_ptr->msp;
-        player_ptr->csp_frac = 0;
-    }
-
-    player_ptr->redraw |= PR_MANA;
-    return true;
-}
-
-/*!
  * @brief 鏡魔法「封魔結界」の効果処理
  * @param dam ダメージ量
  * @return 効果があったらTRUEを返す

--- a/src/mind/mind-mirror-master.cpp
+++ b/src/mind/mind-mirror-master.cpp
@@ -169,30 +169,6 @@ bool binding_field(PlayerType *player_ptr, int dam)
 }
 
 /*!
- * @brief 鏡魔法「鏡の封印」の効果処理
- * @param dam ダメージ量
- * @return 効果があったらTRUEを返す
- */
-void seal_of_mirror(PlayerType *player_ptr, int dam)
-{
-    for (POSITION x = 0; x < player_ptr->current_floor_ptr->width; x++) {
-        for (POSITION y = 0; y < player_ptr->current_floor_ptr->height; y++) {
-            if (!player_ptr->current_floor_ptr->grid_array[y][x].is_mirror()) {
-                continue;
-            }
-
-            if (!affect_monster(player_ptr, 0, 0, y, x, dam, AttributeType::GENOCIDE, (PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_JUMP), true)) {
-                continue;
-            }
-
-            if (!player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
-                SpellsMirrorMaster(player_ptr).remove_mirror(y, x);
-            }
-        }
-    }
-}
-
-/*!
  * 幻惑の光 @ 鏡使いだけでなく混沌の戦士も使える
  * @param player_ptr プレイヤーへの参照ポインタ
  * @return 常にTRUE
@@ -415,7 +391,7 @@ bool cast_mirror_spell(PlayerType *player_ptr, mind_mirror_master_type spell)
         fire_beam(player_ptr, AttributeType::SEEKER, dir, damroll(11 + (plev - 5) / 4, 8));
         break;
     case SEALING_MIRROR:
-        seal_of_mirror(player_ptr, plev * 4 + 100);
+        SpellsMirrorMaster(player_ptr).seal_of_mirror(plev * 4 + 100);
         break;
     case WATER_SHIELD:
         t = 20 + randint1(20);

--- a/src/mind/mind-mirror-master.cpp
+++ b/src/mind/mind-mirror-master.cpp
@@ -237,31 +237,6 @@ bool confusing_light(PlayerType *player_ptr)
     return true;
 }
 
-/*!
- * @brief 鏡設置処理
- * @return 実際に設置が行われた場合TRUEを返す
- */
-bool place_mirror(PlayerType *player_ptr)
-{
-    if (!cave_clean_bold(player_ptr->current_floor_ptr, player_ptr->y, player_ptr->x)) {
-        msg_print(_("床上のアイテムが呪文を跳ね返した。", "The object resists the spell."));
-        return false;
-    }
-
-    /* Create a mirror */
-    player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x].info |= CAVE_OBJECT;
-    player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x].mimic = feat_mirror;
-
-    /* Turn on the light */
-    player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x].info |= CAVE_GLOW;
-
-    note_spot(player_ptr, player_ptr->y, player_ptr->x);
-    lite_spot(player_ptr, player_ptr->y, player_ptr->x);
-    update_local_illumination(player_ptr, player_ptr->y, player_ptr->x);
-
-    return true;
-}
-
 /*
  * Set "multishadow", notice observable changes
  */
@@ -406,7 +381,7 @@ bool cast_mirror_spell(PlayerType *player_ptr, mind_mirror_master_type spell)
         break;
     case MAKE_MIRROR:
         if (number_of_mirrors(player_ptr->current_floor_ptr) < 4 + plev / 10) {
-            place_mirror(player_ptr);
+            SpellsMirrorMaster(player_ptr).place_mirror();
         } else {
             msg_format(_("これ以上鏡は制御できない！", "There are too many mirrors to control!"));
         }

--- a/src/mind/mind-mirror-master.cpp
+++ b/src/mind/mind-mirror-master.cpp
@@ -1,4 +1,11 @@
-﻿#include "mind/mind-mirror-master.h"
+﻿/*!
+ * @brief 鏡使いの鏡魔法コマンド処理
+ * @date 2022/03/07
+ * @author Hourier
+ * @todo 作りかけの部分複数あり
+ */
+
+#include "mind/mind-mirror-master.h"
 #include "core/disturbance.h"
 #include "core/player-redraw-types.h"
 #include "core/player-update-types.h"

--- a/src/mind/mind-mirror-master.h
+++ b/src/mind/mind-mirror-master.h
@@ -4,7 +4,6 @@
 
 class PlayerType;
 bool check_multishadow(PlayerType *player_ptr);
-bool mirror_concentration(PlayerType *player_ptr);
 bool binding_field(PlayerType *player_ptr, int dam);
 void seal_of_mirror(PlayerType *player_ptr, int dam);
 bool confusing_light(PlayerType *player_ptr);

--- a/src/mind/mind-mirror-master.h
+++ b/src/mind/mind-mirror-master.h
@@ -5,7 +5,6 @@
 class PlayerType;
 bool check_multishadow(PlayerType *player_ptr);
 bool mirror_concentration(PlayerType *player_ptr);
-void remove_all_mirrors(PlayerType *player_ptr, bool explode);
 bool binding_field(PlayerType *player_ptr, int dam);
 void seal_of_mirror(PlayerType *player_ptr, int dam);
 bool confusing_light(PlayerType *player_ptr);

--- a/src/mind/mind-mirror-master.h
+++ b/src/mind/mind-mirror-master.h
@@ -9,7 +9,6 @@ bool binding_field(PlayerType *player_ptr, int dam);
 void seal_of_mirror(PlayerType *player_ptr, int dam);
 bool confusing_light(PlayerType *player_ptr);
 bool place_mirror(PlayerType *player_ptr);
-bool mirror_tunnel(PlayerType *player_ptr);
 bool set_multishadow(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec);
 bool set_dustrobe(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec);
 

--- a/src/mind/mind-mirror-master.h
+++ b/src/mind/mind-mirror-master.h
@@ -5,7 +5,6 @@
 class PlayerType;
 bool check_multishadow(PlayerType *player_ptr);
 bool binding_field(PlayerType *player_ptr, int dam);
-void seal_of_mirror(PlayerType *player_ptr, int dam);
 bool confusing_light(PlayerType *player_ptr);
 bool set_multishadow(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec);
 bool set_dustrobe(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec);

--- a/src/mind/mind-mirror-master.h
+++ b/src/mind/mind-mirror-master.h
@@ -8,7 +8,6 @@ bool mirror_concentration(PlayerType *player_ptr);
 bool binding_field(PlayerType *player_ptr, int dam);
 void seal_of_mirror(PlayerType *player_ptr, int dam);
 bool confusing_light(PlayerType *player_ptr);
-bool place_mirror(PlayerType *player_ptr);
 bool set_multishadow(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec);
 bool set_dustrobe(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec);
 

--- a/src/racial/racial-switcher.cpp
+++ b/src/racial/racial-switcher.cpp
@@ -61,6 +61,7 @@
 #include "racial/racial-kutar.h"
 #include "racial/racial-vampire.h"
 #include "realm/realm-names-table.h"
+#include "spell-class/spells-mirror-master.h"
 #include "spell-kind/spells-beam.h"
 #include "spell-kind/spells-detection.h"
 #include "spell-kind/spells-grid.h"
@@ -265,7 +266,7 @@ bool switch_class_racial_execution(PlayerType *player_ptr, const int32_t command
         return identify_fully(player_ptr, true);
     case PlayerClassType::MIRROR_MASTER:
         if (command == -3) {
-            remove_all_mirrors(player_ptr, true);
+            SpellsMirrorMaster(player_ptr).remove_all_mirrors(true);
             return true;
         }
 

--- a/src/racial/racial-switcher.cpp
+++ b/src/racial/racial-switcher.cpp
@@ -264,17 +264,19 @@ bool switch_class_racial_execution(PlayerType *player_ptr, const int32_t command
         }
 
         return identify_fully(player_ptr, true);
-    case PlayerClassType::MIRROR_MASTER:
+    case PlayerClassType::MIRROR_MASTER: {
+        SpellsMirrorMaster smm(player_ptr);
         if (command == -3) {
-            SpellsMirrorMaster(player_ptr).remove_all_mirrors(true);
+            smm.remove_all_mirrors(true);
             return true;
         }
 
         if (command == -4) {
-            return mirror_concentration(player_ptr);
+            return smm.mirror_concentration();
         }
 
         return true;
+    }
     case PlayerClassType::NINJA:
         return hayagake(player_ptr);
     case PlayerClassType::ELEMENTALIST:

--- a/src/spell-class/spells-mirror-master.cpp
+++ b/src/spell-class/spells-mirror-master.cpp
@@ -1,7 +1,64 @@
 ﻿#include "spell-class/spells-mirror-master.h"
+#include "dungeon/dungeon-flag-types.h"
+#include "dungeon/dungeon.h"
+#include "effect/attribute-types.h"
+#include "effect/effect-characteristics.h"
+#include "effect/effect-processor.h"
+#include "game-option/map-screen-options.h"
+#include "grid/grid.h"
+#include "monster/monster-update.h"
+#include "system/floor-type-definition.h"
+#include "system/grid-type-definition.h"
 #include "system/player-type-definition.h"
+#include "util/bit-flags-calculator.h"
 
 SpellsMirrorMaster::SpellsMirrorMaster(PlayerType *player_ptr)
     : player_ptr(player_ptr)
 {
+}
+
+void SpellsMirrorMaster::remove_mirror(int y, int x)
+{
+    auto *g_ptr = &this->player_ptr->current_floor_ptr->grid_array[y][x];
+    reset_bits(g_ptr->info, CAVE_OBJECT);
+    g_ptr->mimic = 0;
+    if (d_info[this->player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+        g_ptr->info &= ~(CAVE_GLOW);
+        if (!view_torch_grids) {
+            g_ptr->info &= ~(CAVE_MARK);
+        }
+
+        if (g_ptr->m_idx) {
+            update_monster(this->player_ptr, g_ptr->m_idx, false);
+        }
+
+        update_local_illumination(this->player_ptr, y, x);
+    }
+
+    note_spot(this->player_ptr, y, x);
+    lite_spot(this->player_ptr, y, x);
+}
+
+/*!
+ * @brief 全鏡の消去 / Remove all mirrors in this floor
+ * @param player_ptr プレイヤーへの参照ポインタ
+ * @param explode 爆発処理を伴うならばTRUE
+ */
+void SpellsMirrorMaster::remove_all_mirrors(bool explode)
+{
+    for (auto x = 0; x < this->player_ptr->current_floor_ptr->width; x++) {
+        for (auto y = 0; y < this->player_ptr->current_floor_ptr->height; y++) {
+            if (!this->player_ptr->current_floor_ptr->grid_array[y][x].is_mirror()) {
+                continue;
+            }
+
+            this->remove_mirror(y, x);
+            if (!explode) {
+                continue;
+            }
+
+            constexpr BIT_FLAGS projection = PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_JUMP | PROJECT_NO_HANGEKI;
+            project(this->player_ptr, 0, 2, y, x, this->player_ptr->lev / 2 + 5, AttributeType::SHARDS, projection);
+        }
+    }
 }

--- a/src/spell-class/spells-mirror-master.cpp
+++ b/src/spell-class/spells-mirror-master.cpp
@@ -1,0 +1,7 @@
+﻿#include "spell-class/spells-mirror-master.h"
+#include "system/player-type-definition.h"
+
+SpellsMirrorMaster::SpellsMirrorMaster(PlayerType *player_ptr)
+    : player_ptr(player_ptr)
+{
+}

--- a/src/spell-class/spells-mirror-master.cpp
+++ b/src/spell-class/spells-mirror-master.cpp
@@ -1,4 +1,5 @@
 ﻿#include "spell-class/spells-mirror-master.h"
+#include "core/player-redraw-types.h"
 #include "dungeon/dungeon-flag-types.h"
 #include "dungeon/dungeon.h"
 #include "effect/attribute-types.h"
@@ -9,6 +10,7 @@
 #include "grid/feature.h"
 #include "grid/grid.h"
 #include "monster/monster-update.h"
+#include "pet/pet-util.h"
 #include "spell-kind/spells-teleport.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
@@ -113,5 +115,33 @@ bool SpellsMirrorMaster::place_mirror()
     note_spot(this->player_ptr, y, x);
     lite_spot(this->player_ptr, y, x);
     update_local_illumination(this->player_ptr, y, x);
+    return true;
+}
+
+/*!
+ * @brief 静水
+ * @param player_ptr プレイヤーへの参照ポインタ
+ * @return ペットを操っている場合を除きTRUE
+ */
+bool SpellsMirrorMaster::mirror_concentration()
+{
+    if (total_friends) {
+        msg_print(_("今はペットを操ることに集中していないと。", "Your pets demand all of your attention."));
+        return false;
+    }
+
+    if (!this->player_ptr->current_floor_ptr->grid_array[this->player_ptr->y][this->player_ptr->x].is_mirror()) {
+        msg_print(_("鏡の上でないと集中できない！", "There's no mirror here!"));
+        return true;
+    }
+
+    msg_print(_("少し頭がハッキリした。", "You feel your head clear a little."));
+    this->player_ptr->csp += (5 + this->player_ptr->lev * this->player_ptr->lev / 100);
+    if (this->player_ptr->csp >= this->player_ptr->msp) {
+        this->player_ptr->csp = this->player_ptr->msp;
+        this->player_ptr->csp_frac = 0;
+    }
+
+    this->player_ptr->redraw |= PR_MANA;
     return true;
 }

--- a/src/spell-class/spells-mirror-master.cpp
+++ b/src/spell-class/spells-mirror-master.cpp
@@ -4,7 +4,9 @@
 #include "effect/attribute-types.h"
 #include "effect/effect-characteristics.h"
 #include "effect/effect-processor.h"
+#include "floor/cave.h"
 #include "game-option/map-screen-options.h"
+#include "grid/feature.h"
 #include "grid/grid.h"
 #include "monster/monster-update.h"
 #include "spell-kind/spells-teleport.h"
@@ -85,5 +87,31 @@ bool SpellsMirrorMaster::mirror_tunnel()
     }
 
     msg_print(_("鏡の世界をうまく通れなかった！", "You could not enter the mirror!"));
+    return true;
+}
+
+/*!
+ * @brief 鏡設置処理
+ * @return 実際に設置が行われた場合TRUEを返す
+ */
+bool SpellsMirrorMaster::place_mirror()
+{
+    auto y = this->player_ptr->y;
+    auto x = this->player_ptr->x;
+    if (!cave_clean_bold(this->player_ptr->current_floor_ptr, y, x)) {
+        msg_print(_("床上のアイテムが呪文を跳ね返した。", "The object resists the spell."));
+        return false;
+    }
+
+    /* Create a mirror */
+    this->player_ptr->current_floor_ptr->grid_array[y][x].info |= CAVE_OBJECT;
+    this->player_ptr->current_floor_ptr->grid_array[y][x].mimic = feat_mirror;
+
+    /* Turn on the light */
+    this->player_ptr->current_floor_ptr->grid_array[y][x].info |= CAVE_GLOW;
+
+    note_spot(this->player_ptr, y, x);
+    lite_spot(this->player_ptr, y, x);
+    update_local_illumination(this->player_ptr, y, x);
     return true;
 }

--- a/src/spell-class/spells-mirror-master.cpp
+++ b/src/spell-class/spells-mirror-master.cpp
@@ -1,4 +1,11 @@
-﻿#include "spell-class/spells-mirror-master.h"
+﻿/*!
+ * @brief 鏡使いの鏡魔法効果処理
+ * @date 2022/03/07
+ * @author Hourier
+ * @todo 作りかけの部分複数あり
+ */
+
+#include "spell-class/spells-mirror-master.h"
 #include "core/player-redraw-types.h"
 #include "dungeon/dungeon-flag-types.h"
 #include "dungeon/dungeon.h"

--- a/src/spell-class/spells-mirror-master.cpp
+++ b/src/spell-class/spells-mirror-master.cpp
@@ -4,6 +4,7 @@
 #include "dungeon/dungeon.h"
 #include "effect/attribute-types.h"
 #include "effect/effect-characteristics.h"
+#include "effect/effect-monster.h"
 #include "effect/effect-processor.h"
 #include "floor/cave.h"
 #include "game-option/map-screen-options.h"
@@ -144,4 +145,30 @@ bool SpellsMirrorMaster::mirror_concentration()
 
     this->player_ptr->redraw |= PR_MANA;
     return true;
+}
+
+/*!
+ * @brief 鏡魔法「鏡の封印」の効果処理
+ * @param dam ダメージ量
+ * @return 効果があったらTRUEを返す
+ */
+void SpellsMirrorMaster::seal_of_mirror(const int dam)
+{
+    const auto *floor_ptr = this->player_ptr->current_floor_ptr;
+    for (auto x = 0; x < floor_ptr->width; x++) {
+        for (auto y = 0; y < floor_ptr->height; y++) {
+            if (!floor_ptr->grid_array[y][x].is_mirror()) {
+                continue;
+            }
+
+            constexpr BIT_FLAGS flags = PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_JUMP;
+            if (!affect_monster(this->player_ptr, 0, 0, y, x, dam, AttributeType::GENOCIDE, flags, true)) {
+                continue;
+            }
+
+            if (!floor_ptr->grid_array[y][x].m_idx) {
+                this->remove_mirror(y, x);
+            }
+        }
+    }
 }

--- a/src/spell-class/spells-mirror-master.cpp
+++ b/src/spell-class/spells-mirror-master.cpp
@@ -7,10 +7,13 @@
 #include "game-option/map-screen-options.h"
 #include "grid/grid.h"
 #include "monster/monster-update.h"
+#include "spell-kind/spells-teleport.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
 #include "system/player-type-definition.h"
+#include "target/grid-selector.h"
 #include "util/bit-flags-calculator.h"
+#include "view/display-messages.h"
 
 SpellsMirrorMaster::SpellsMirrorMaster(PlayerType *player_ptr)
     : player_ptr(player_ptr)
@@ -61,4 +64,26 @@ void SpellsMirrorMaster::remove_all_mirrors(bool explode)
             project(this->player_ptr, 0, 2, y, x, this->player_ptr->lev / 2 + 5, AttributeType::SHARDS, projection);
         }
     }
+}
+
+/*!
+ * @brief 鏡抜け処理のメインルーチン /
+ * Mirror Master's Dimension Door
+ * @param player_ptr プレイヤーへの参照ポインタ
+ * @return ターンを消費した場合TRUEを返す
+ */
+bool SpellsMirrorMaster::mirror_tunnel()
+{
+    int x;
+    int y;
+    if (!tgt_pt(this->player_ptr, &x, &y)) {
+        return false;
+    }
+
+    if (exe_dimension_door(this->player_ptr, x, y)) {
+        return true;
+    }
+
+    msg_print(_("鏡の世界をうまく通れなかった！", "You could not enter the mirror!"));
+    return true;
 }

--- a/src/spell-class/spells-mirror-master.h
+++ b/src/spell-class/spells-mirror-master.h
@@ -8,6 +8,7 @@ public:
     void remove_mirror(int y, int x);
     bool mirror_tunnel();
     bool place_mirror();
+    bool mirror_concentration();
 
 private:
     PlayerType *player_ptr;

--- a/src/spell-class/spells-mirror-master.h
+++ b/src/spell-class/spells-mirror-master.h
@@ -1,0 +1,10 @@
+﻿#pragma once
+
+class PlayerType;
+class SpellsMirrorMaster {
+public:
+    SpellsMirrorMaster(PlayerType *player_ptr);
+
+private:
+    PlayerType *player_ptr;
+};

--- a/src/spell-class/spells-mirror-master.h
+++ b/src/spell-class/spells-mirror-master.h
@@ -6,6 +6,7 @@ public:
     SpellsMirrorMaster(PlayerType *player_ptr);
     void remove_all_mirrors(bool explode);
     void remove_mirror(int y, int x);
+    bool mirror_tunnel();
 
 private:
     PlayerType *player_ptr;

--- a/src/spell-class/spells-mirror-master.h
+++ b/src/spell-class/spells-mirror-master.h
@@ -4,6 +4,8 @@ class PlayerType;
 class SpellsMirrorMaster {
 public:
     SpellsMirrorMaster(PlayerType *player_ptr);
+    void remove_all_mirrors(bool explode);
+    void remove_mirror(int y, int x);
 
 private:
     PlayerType *player_ptr;

--- a/src/spell-class/spells-mirror-master.h
+++ b/src/spell-class/spells-mirror-master.h
@@ -9,6 +9,7 @@ public:
     bool mirror_tunnel();
     bool place_mirror();
     bool mirror_concentration();
+    void seal_of_mirror(const int dam);
 
 private:
     PlayerType *player_ptr;

--- a/src/spell-class/spells-mirror-master.h
+++ b/src/spell-class/spells-mirror-master.h
@@ -7,6 +7,7 @@ public:
     void remove_all_mirrors(bool explode);
     void remove_mirror(int y, int x);
     bool mirror_tunnel();
+    bool place_mirror();
 
 private:
     PlayerType *player_ptr;


### PR DESCRIPTION
掲題の通りです
以下の4つは移していません
* シーカーレイ：project() に繰り込まれていて分離困難 (飛竜さん作業予定)
* スーパーレイ：同上
* 封魔結界：長過ぎるので保留
* 幻惑の光：混沌の戦士も使えるので現時点では混ぜたくない

現時点では、シーカーレイ/スーパーレイ の処理を移植させる準備としてクラスを作るのが目的なので特に大きな変更はありません
ご確認下さい