### PR TITLE
[Fix] ascii_to_textのバッファオーバーランを修正

### DIFF
--- a/src/autopick/autopick-inserter-killer.cpp
+++ b/src/autopick/autopick-inserter-killer.cpp
@@ -97,7 +97,7 @@ bool insert_macro_line(text_body_type *tb)
     flush();
 
     char tmp[1024];
-    ascii_to_text(tmp, buf);
+    ascii_to_text(tmp, buf, sizeof(tmp));
     if (!tmp[0]) {
         return false;
     }
@@ -111,7 +111,7 @@ bool insert_macro_line(text_body_type *tb)
     if (i == -1) {
         tmp[0] = '\0';
     } else {
-        ascii_to_text(tmp, macro__act[i]);
+        ascii_to_text(tmp, macro__act[i], sizeof(tmp));
     }
 
     insert_return_code(tb);
@@ -143,7 +143,7 @@ bool insert_keymap_line(text_body_type *tb)
 
     flush();
     char tmp[1024];
-    ascii_to_text(tmp, buf);
+    ascii_to_text(tmp, buf, sizeof(tmp));
     if (!tmp[0]) {
         return false;
     }
@@ -155,7 +155,7 @@ bool insert_keymap_line(text_body_type *tb)
 
     concptr act = keymap_act[mode][(byte)(buf[0])];
     if (act) {
-        ascii_to_text(tmp, act);
+        ascii_to_text(tmp, act, sizeof(tmp));
     }
 
     insert_return_code(tb);

--- a/src/cmd-io/cmd-macro.cpp
+++ b/src/cmd-io/cmd-macro.cpp
@@ -32,9 +32,9 @@ static void macro_dump(FILE **fpp, concptr fname)
     auto_dump_printf(*fpp, _("\n# 自動マクロセーブ\n\n", "\n# Automatic macro dump\n\n"));
 
     for (int i = 0; i < macro__num; i++) {
-        ascii_to_text(buf, macro__act[i]);
+        ascii_to_text(buf, macro__act[i], sizeof(buf));
         auto_dump_printf(*fpp, "A:%s\n", buf);
-        ascii_to_text(buf, macro__pat[i]);
+        ascii_to_text(buf, macro__pat[i], sizeof(buf));
         auto_dump_printf(*fpp, "P:%s\n", buf);
         auto_dump_printf(*fpp, "\n");
     }
@@ -69,7 +69,7 @@ static void do_cmd_macro_aux(char *buf)
     buf[n] = '\0';
     flush();
     char tmp[1024];
-    ascii_to_text(tmp, buf);
+    ascii_to_text(tmp, buf, sizeof(tmp));
     term_addstr(-1, TERM_WHITE, tmp);
 }
 
@@ -89,7 +89,7 @@ static void do_cmd_macro_aux_keymap(char *buf)
     flush();
     buf[0] = inkey();
     buf[1] = '\0';
-    ascii_to_text(tmp, buf);
+    ascii_to_text(tmp, buf, sizeof(tmp));
     term_addstr(-1, TERM_WHITE, tmp);
     flush();
 }
@@ -129,8 +129,8 @@ static errr keymap_dump(concptr fname)
 
         buf[0] = (char)i;
         buf[1] = '\0';
-        ascii_to_text(key, buf);
-        ascii_to_text(buf, act);
+        ascii_to_text(key, buf, sizeof(key));
+        ascii_to_text(buf, act, sizeof(buf));
         auto_dump_printf(auto_dump_stream, "A:%s\n", buf);
         auto_dump_printf(auto_dump_stream, "C:%d:%s\n", mode, key);
     }
@@ -223,7 +223,7 @@ void do_cmd_macros(PlayerType *player_ptr)
                 // too long macro must die
                 strncpy(tmp, macro_buf, 80);
                 tmp[80] = '\0';
-                ascii_to_text(buf, tmp);
+                ascii_to_text(buf, tmp, sizeof(buf));
                 prt(buf, 22, 0);
                 msg_print(_("マクロを確認しました。", "Found a macro."));
             }
@@ -238,7 +238,7 @@ void do_cmd_macros(PlayerType *player_ptr)
             prt(_("マクロ行動: ", "Action: "), 20, 0);
             // 最後に参照したマクロデータを元に作成する（コピーを行えるように）
             macro_buf[80] = '\0';
-            ascii_to_text(tmp, macro_buf);
+            ascii_to_text(tmp, macro_buf, sizeof(tmp));
             if (askfor(tmp, 80)) {
                 text_to_ascii(macro_buf, tmp);
                 macro_add(buf, macro_buf);
@@ -274,7 +274,7 @@ void do_cmd_macros(PlayerType *player_ptr)
                 // too long macro must die
                 strncpy(tmp, macro_buf, 80);
                 tmp[80] = '\0';
-                ascii_to_text(buf, tmp);
+                ascii_to_text(buf, tmp, sizeof(buf));
                 prt(buf, 22, 0);
                 msg_print(_("キー配置を確認しました。", "Found a keymap."));
             }
@@ -289,7 +289,7 @@ void do_cmd_macros(PlayerType *player_ptr)
             prt(_("行動: ", "Action: "), 20, 0);
             // 最後に参照したマクロデータを元に作成する（コピーを行えるように）
             macro_buf[80] = '\0';
-            ascii_to_text(tmp, macro_buf);
+            ascii_to_text(tmp, macro_buf, sizeof(tmp));
             if (askfor(tmp, 80)) {
                 text_to_ascii(macro_buf, tmp);
                 string_free(keymap_act[mode][(byte)(buf[0])]);

--- a/src/cmd-io/cmd-macro.cpp
+++ b/src/cmd-io/cmd-macro.cpp
@@ -240,7 +240,7 @@ void do_cmd_macros(PlayerType *player_ptr)
             macro_buf[80] = '\0';
             ascii_to_text(tmp, macro_buf, sizeof(tmp));
             if (askfor(tmp, 80)) {
-                text_to_ascii(macro_buf, tmp);
+                text_to_ascii(macro_buf, tmp, sizeof(macro_buf));
                 macro_add(buf, macro_buf);
                 msg_print(_("マクロを追加しました。", "Added a macro."));
             }
@@ -291,7 +291,7 @@ void do_cmd_macros(PlayerType *player_ptr)
             macro_buf[80] = '\0';
             ascii_to_text(tmp, macro_buf, sizeof(tmp));
             if (askfor(tmp, 80)) {
-                text_to_ascii(macro_buf, tmp);
+                text_to_ascii(macro_buf, tmp, sizeof(macro_buf));
                 string_free(keymap_act[mode][(byte)(buf[0])]);
                 keymap_act[mode][(byte)(buf[0])] = string_make(macro_buf);
                 msg_print(_("キー配置を追加しました。", "Added a keymap."));
@@ -315,7 +315,7 @@ void do_cmd_macros(PlayerType *player_ptr)
                 continue;
             }
 
-            text_to_ascii(macro_buf, buf);
+            text_to_ascii(macro_buf, buf, sizeof(macro_buf));
         } else {
             bell();
         }

--- a/src/io/input-key-acceptor.cpp
+++ b/src/io/input-key-acceptor.cpp
@@ -391,7 +391,7 @@ int inkey_special(bool numpad_cursor)
         return (int)((unsigned char)c);
     }
 
-    ascii_to_text(buf, inkey_macro_trigger_string);
+    ascii_to_text(buf, inkey_macro_trigger_string, sizeof(buf));
     if (prefix(str, "\\[")) {
         str += 2;
         while (true) {

--- a/src/io/interpret-pref-file.cpp
+++ b/src/io/interpret-pref-file.cpp
@@ -252,7 +252,7 @@ static errr interpret_e_token(char *buf)
 static errr interpret_p_token(char *buf)
 {
     char tmp[1024];
-    text_to_ascii(tmp, buf + 2);
+    text_to_ascii(tmp, buf + 2, sizeof(tmp));
     return macro_add(tmp, macro__buf.data());
 }
 
@@ -274,7 +274,7 @@ static errr interpret_c_token(char *buf)
     }
 
     char tmp[1024];
-    text_to_ascii(tmp, zz[1]);
+    text_to_ascii(tmp, zz[1], sizeof(tmp));
     if (!tmp[0] || tmp[1]) {
         return 1;
     }
@@ -527,7 +527,7 @@ errr interpret_pref_file(PlayerType *player_ptr, char *buf)
         return interpret_e_token(buf);
     case 'A': {
         /* Process "A:<str>" -- save an "action" for later */
-        text_to_ascii(macro__buf.data(), buf + 2);
+        text_to_ascii(macro__buf.data(), buf + 2, macro__buf.size());
         return 0;
     }
     case 'P':

--- a/src/util/string-processor.cpp
+++ b/src/util/string-processor.cpp
@@ -331,11 +331,13 @@ static bool trigger_ascii_to_text(char **bufptr, concptr *strptr)
 /*
  * Hack -- convert a string into a printable form
  */
-void ascii_to_text(char *buf, std::string_view sv)
+void ascii_to_text(char *buf, std::string_view sv, size_t bufsize)
 {
     char *s = buf;
+    auto buffer_end = s + bufsize;
     auto str = sv.data();
-    while (*str) {
+    constexpr auto step_size = 4;
+    while (*str && (s + step_size < buffer_end)) {
         byte i = (byte)(*str++);
         if (i == 31) {
             if (!trigger_ascii_to_text(&s, &str)) {

--- a/src/util/string-processor.cpp
+++ b/src/util/string-processor.cpp
@@ -197,11 +197,13 @@ static void trigger_text_to_ascii(char **bufptr, concptr *strptr)
  * parsing "\xFF" into a (signed) char.  Whoever thought of making
  * the "sign" of a "char" undefined is a complete moron.  Oh well.
  */
-void text_to_ascii(char *buf, std::string_view sv)
+void text_to_ascii(char *buf, std::string_view sv, size_t bufsize)
 {
     char *s = buf;
+    auto buffer_end = s + bufsize;
     auto str = sv.data();
-    while (*str) {
+    constexpr auto step_size = 1;
+    while (*str && (s + step_size < buffer_end)) {
         if (*str == '\\') {
             str++;
             if (!(*str)) {

--- a/src/util/string-processor.h
+++ b/src/util/string-processor.h
@@ -22,7 +22,7 @@ extern concptr macro_trigger_name[MAX_MACRO_TRIG];
 extern concptr macro_trigger_keycode[2][MAX_MACRO_TRIG];
 
 void text_to_ascii(char *buf, std::string_view sv);
-void ascii_to_text(char *buf, std::string_view sv);
+void ascii_to_text(char *buf, std::string_view sv, size_t bufsize);
 size_t angband_strcpy(char *buf, concptr src, size_t bufsize);
 size_t angband_strcat(char *buf, concptr src, size_t bufsize);
 char *angband_strstr(concptr haystack, concptr needle);

--- a/src/util/string-processor.h
+++ b/src/util/string-processor.h
@@ -21,7 +21,7 @@ extern concptr macro_modifier_name[MAX_MACRO_MOD];
 extern concptr macro_trigger_name[MAX_MACRO_TRIG];
 extern concptr macro_trigger_keycode[2][MAX_MACRO_TRIG];
 
-void text_to_ascii(char *buf, std::string_view sv);
+void text_to_ascii(char *buf, std::string_view sv, size_t bufsize);
 void ascii_to_text(char *buf, std::string_view sv, size_t bufsize);
 size_t angband_strcpy(char *buf, concptr src, size_t bufsize);
 size_t angband_strcat(char *buf, concptr src, size_t bufsize);


### PR DESCRIPTION
【バグ】 マクロを保存しようとするとゲームが落ちる https://github.com/hengband/hengband/issues/2337 の原因。
ascii_to_text()がバッファサイズを越える書き込みを禁止していないため範囲外アクセスが発生している。
バッファ長を引数に取り、範囲外アクセスを禁止する。
また、対になるtext_to_ascii()も同様に修正する。