### PR TITLE
ArmorEnchanter を鎧種別ごとに分離した

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -277,6 +277,7 @@
     <ClCompile Include="..\..\src\monster-race\monster-kind-mask.cpp" />
     <ClCompile Include="..\..\src\monster-race\race-resistance-mask.cpp" />
     <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-dragon-armor.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-hard-armor.cpp" />
     <ClCompile Include="..\..\src\object-enchant\weapon\abstract-weapon-enchanter.cpp" />
     <ClCompile Include="..\..\src\object-use\quaff\quaff-effects.cpp" />
     <ClCompile Include="..\..\src\object-use\read\gbh-shirt-read-executor.cpp" />
@@ -960,6 +961,7 @@
     <ClInclude Include="..\..\src\mspell\mspell-result.h" />
     <ClInclude Include="..\..\src\object-enchant\others\apply-magic-lite.h" />
     <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-dragon-armor.h" />
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-hard-armor.h" />
     <ClInclude Include="..\..\src\object-enchant\weapon\abstract-weapon-enchanter.h" />
     <ClInclude Include="..\..\src\object-use\quaff\quaff-effects.h" />
     <ClInclude Include="..\..\src\object-use\read\gbh-shirt-read-executor.h" />

--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -276,6 +276,7 @@
     <ClCompile Include="..\..\src\object-enchant\others\apply-magic-lite.cpp" />
     <ClCompile Include="..\..\src\monster-race\monster-kind-mask.cpp" />
     <ClCompile Include="..\..\src\monster-race\race-resistance-mask.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-dragon-armor.cpp" />
     <ClCompile Include="..\..\src\object-enchant\weapon\abstract-weapon-enchanter.cpp" />
     <ClCompile Include="..\..\src\object-use\quaff\quaff-effects.cpp" />
     <ClCompile Include="..\..\src\object-use\read\gbh-shirt-read-executor.cpp" />
@@ -958,6 +959,7 @@
     <ClInclude Include="..\..\src\monster-race\race-visual-flags.h" />
     <ClInclude Include="..\..\src\mspell\mspell-result.h" />
     <ClInclude Include="..\..\src\object-enchant\others\apply-magic-lite.h" />
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-dragon-armor.h" />
     <ClInclude Include="..\..\src\object-enchant\weapon\abstract-weapon-enchanter.h" />
     <ClInclude Include="..\..\src\object-use\quaff\quaff-effects.h" />
     <ClInclude Include="..\..\src\object-use\read\gbh-shirt-read-executor.h" />

--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -273,6 +273,7 @@
     <ClCompile Include="..\..\src\load\item\item-loader-factory.cpp" />
     <ClCompile Include="..\..\src\load\monster\monster-loader-factory.cpp" />
     <ClCompile Include="..\..\src\load\player-class-specific-data-loader.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-soft-armor.cpp" />
     <ClCompile Include="..\..\src\object-enchant\others\apply-magic-lite.cpp" />
     <ClCompile Include="..\..\src\monster-race\monster-kind-mask.cpp" />
     <ClCompile Include="..\..\src\monster-race\race-resistance-mask.cpp" />
@@ -959,6 +960,7 @@
     <ClInclude Include="..\..\src\monster-race\race-resistance-mask.h" />
     <ClInclude Include="..\..\src\monster-race\race-visual-flags.h" />
     <ClInclude Include="..\..\src\mspell\mspell-result.h" />
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-soft-armor.h" />
     <ClInclude Include="..\..\src\object-enchant\others\apply-magic-lite.h" />
     <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-dragon-armor.h" />
     <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-hard-armor.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2418,6 +2418,9 @@
     <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-dragon-armor.cpp">
       <Filter>object-enchant\protector</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-hard-armor.cpp">
+      <Filter>object-enchant\protector</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5254,6 +5257,9 @@
       <Filter>monster-race</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-dragon-armor.h">
+      <Filter>object-enchant\protector</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-hard-armor.h">
       <Filter>object-enchant\protector</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2421,6 +2421,9 @@
     <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-hard-armor.cpp">
       <Filter>object-enchant\protector</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-soft-armor.cpp">
+      <Filter>object-enchant\protector</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5260,6 +5263,9 @@
       <Filter>object-enchant\protector</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-hard-armor.h">
+      <Filter>object-enchant\protector</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-soft-armor.h">
       <Filter>object-enchant\protector</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2415,6 +2415,9 @@
     <ClCompile Include="..\..\src\object-use\quaff\quaff-effects.cpp">
       <Filter>object-use\quaff</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-dragon-armor.cpp">
+      <Filter>object-enchant\protector</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5249,6 +5252,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\monster-race\race-drop-flags.h">
       <Filter>monster-race</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-dragon-armor.h">
+      <Filter>object-enchant\protector</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -611,6 +611,7 @@ hengband_SOURCES = \
 	object-enchant/protector/apply-magic-boots.cpp object-enchant/protector/apply-magic-boots.h \
 	object-enchant/protector/apply-magic-cloak.cpp object-enchant/protector/apply-magic-cloak.h \
 	object-enchant/protector/apply-magic-crown.cpp object-enchant/protector/apply-magic-crown.h \
+	object-enchant/protector/apply-magic-dragon-armor.cpp object-enchant/protector/apply-magic-dragon-armor.h \
 	object-enchant/protector/apply-magic-gloves.cpp object-enchant/protector/apply-magic-gloves.h \
 	object-enchant/protector/apply-magic-helm.cpp object-enchant/protector/apply-magic-helm.h \
 	object-enchant/protector/apply-magic-shield.cpp object-enchant/protector/apply-magic-shield.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -616,6 +616,7 @@ hengband_SOURCES = \
 	object-enchant/protector/apply-magic-hard-armor.cpp object-enchant/protector/apply-magic-hard-armor.h \
 	object-enchant/protector/apply-magic-helm.cpp object-enchant/protector/apply-magic-helm.h \
 	object-enchant/protector/apply-magic-shield.cpp object-enchant/protector/apply-magic-shield.h \
+	object-enchant/protector/apply-magic-soft-armor.cpp object-enchant/protector/apply-magic-soft-armor.h \
 	\
 	object-enchant/weapon/abstract-weapon-enchanter.cpp object-enchant/weapon/abstract-weapon-enchanter.h \
 	object-enchant/weapon/apply-magic-weapon.cpp object-enchant/weapon/apply-magic-weapon.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -613,6 +613,7 @@ hengband_SOURCES = \
 	object-enchant/protector/apply-magic-crown.cpp object-enchant/protector/apply-magic-crown.h \
 	object-enchant/protector/apply-magic-dragon-armor.cpp object-enchant/protector/apply-magic-dragon-armor.h \
 	object-enchant/protector/apply-magic-gloves.cpp object-enchant/protector/apply-magic-gloves.h \
+	object-enchant/protector/apply-magic-hard-armor.cpp object-enchant/protector/apply-magic-hard-armor.h \
 	object-enchant/protector/apply-magic-helm.cpp object-enchant/protector/apply-magic-helm.h \
 	object-enchant/protector/apply-magic-shield.cpp object-enchant/protector/apply-magic-shield.h \
 	\

--- a/src/object-enchant/apply-magic.cpp
+++ b/src/object-enchant/apply-magic.cpp
@@ -21,6 +21,7 @@
 #include "object-enchant/protector/apply-magic-boots.h"
 #include "object-enchant/protector/apply-magic-cloak.h"
 #include "object-enchant/protector/apply-magic-crown.h"
+#include "object-enchant/protector/apply-magic-dragon-armor.h"
 #include "object-enchant/protector/apply-magic-gloves.h"
 #include "object-enchant/protector/apply-magic-helm.h"
 #include "object-enchant/protector/apply-magic-shield.h"
@@ -165,6 +166,8 @@ void apply_magic_to_object(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH lev,
         BootsEnchanter(player_ptr, o_ptr, lev, power).apply_magic();
         break;
     case ItemKindType::DRAG_ARMOR:
+        DragonArmorEnchanter(player_ptr, o_ptr, lev, power).apply_magic();
+        break;
     case ItemKindType::HARD_ARMOR:
     case ItemKindType::SOFT_ARMOR:
         // @todo いずれSoftArmorEnchanter等作って分離する.

--- a/src/object-enchant/apply-magic.cpp
+++ b/src/object-enchant/apply-magic.cpp
@@ -26,6 +26,7 @@
 #include "object-enchant/protector/apply-magic-hard-armor.h"
 #include "object-enchant/protector/apply-magic-helm.h"
 #include "object-enchant/protector/apply-magic-shield.h"
+#include "object-enchant/protector/apply-magic-soft-armor.h"
 #include "object-enchant/special-object-flags.h"
 #include "object-enchant/tr-types.h"
 #include "object-enchant/trc-types.h"
@@ -173,8 +174,7 @@ void apply_magic_to_object(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH lev,
         HardArmorEnchanter(player_ptr, o_ptr, lev, power).apply_magic();
         break;
     case ItemKindType::SOFT_ARMOR:
-        // @todo いずれSoftArmorEnchanter等作って分離する.
-        ArmorEnchanter(player_ptr, o_ptr, lev, power).apply_magic();
+        SoftArmorEnchanter(player_ptr, o_ptr, lev, power).apply_magic();
         break;
     case ItemKindType::GLOVES:
         GlovesEnchanter(player_ptr, o_ptr, lev, power).apply_magic();

--- a/src/object-enchant/apply-magic.cpp
+++ b/src/object-enchant/apply-magic.cpp
@@ -23,6 +23,7 @@
 #include "object-enchant/protector/apply-magic-crown.h"
 #include "object-enchant/protector/apply-magic-dragon-armor.h"
 #include "object-enchant/protector/apply-magic-gloves.h"
+#include "object-enchant/protector/apply-magic-hard-armor.h"
 #include "object-enchant/protector/apply-magic-helm.h"
 #include "object-enchant/protector/apply-magic-shield.h"
 #include "object-enchant/special-object-flags.h"
@@ -169,6 +170,8 @@ void apply_magic_to_object(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH lev,
         DragonArmorEnchanter(player_ptr, o_ptr, lev, power).apply_magic();
         break;
     case ItemKindType::HARD_ARMOR:
+        HardArmorEnchanter(player_ptr, o_ptr, lev, power).apply_magic();
+        break;
     case ItemKindType::SOFT_ARMOR:
         // @todo いずれSoftArmorEnchanter等作って分離する.
         ArmorEnchanter(player_ptr, o_ptr, lev, power).apply_magic();

--- a/src/object-enchant/protector/apply-magic-armor.cpp
+++ b/src/object-enchant/protector/apply-magic-armor.cpp
@@ -28,59 +28,6 @@ ArmorEnchanter::ArmorEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH 
 {
 }
 
-/*!
- * @brief power > 2 はデバッグ専用.
- */
-void ArmorEnchanter::apply_magic()
-{
-    if (this->power == 0) {
-        return;
-    }
-
-    switch (this->o_ptr->tval) {
-    case ItemKindType::SOFT_ARMOR:
-        // @todo 後ほどSoftArmorEnchanterへ分離した時、このswitch文はsval_enchant() へ移動させる.
-        switch (this->o_ptr->sval) {
-        case SV_KUROSHOUZOKU:
-            this->o_ptr->pval = randint1(4);
-            break;
-        case SV_ABUNAI_MIZUGI:
-            if (this->player_ptr->ppersonality != PERSONALITY_SEXY) {
-                break;
-            }
-
-            this->o_ptr->pval = 3;
-            this->o_ptr->art_flags.set(TR_STR);
-            this->o_ptr->art_flags.set(TR_INT);
-            this->o_ptr->art_flags.set(TR_WIS);
-            this->o_ptr->art_flags.set(TR_DEX);
-            this->o_ptr->art_flags.set(TR_CON);
-            this->o_ptr->art_flags.set(TR_CHR);
-            break;
-        default:
-            break;
-        }
-
-        if (this->power > 1) {
-            this->give_high_ego_index();
-            if (this->is_high_ego_generated) {
-                return;
-            }
-
-            this->give_ego_index();
-            return;
-        }
-
-        if (this->power < -1) {
-            this->give_cursed();
-        }
-
-        return;
-    default:
-        return;
-    }
-}
-
 /*
  * @details power > 2はデバッグ専用.
  */

--- a/src/object-enchant/protector/apply-magic-armor.cpp
+++ b/src/object-enchant/protector/apply-magic-armor.cpp
@@ -64,31 +64,6 @@ void ArmorEnchanter::give_ego_index()
     }
 }
 
-/*
- * @brief ベースアイテムがローブの時、確率で永続か宵闇のローブを生成する.
- * @return 生成条件を満たしたらtrue、満たさなかったらfalse
- * @details 永続：12%、宵闇：3%
- */
-void ArmorEnchanter::give_high_ego_index()
-{
-    if ((this->o_ptr->sval != SV_ROBE) || (randint0(100) >= 15)) {
-        return;
-    }
-
-    this->is_high_ego_generated = true;
-    auto ego_robe = one_in_(5);
-    this->o_ptr->ego_idx = ego_robe ? EgoType::TWILIGHT : EgoType::PERMANENCE;
-    if (!ego_robe) {
-        return;
-    }
-
-    this->o_ptr->k_idx = lookup_kind(ItemKindType::SOFT_ARMOR, SV_TWILIGHT_ROBE);
-    this->o_ptr->sval = SV_TWILIGHT_ROBE;
-    this->o_ptr->ac = 0;
-    this->o_ptr->to_a = 0;
-    return;
-}
-
 void ArmorEnchanter::give_cursed()
 {
     this->o_ptr->ego_idx = get_random_ego(INVEN_BODY, false);

--- a/src/object-enchant/protector/apply-magic-armor.cpp
+++ b/src/object-enchant/protector/apply-magic-armor.cpp
@@ -1,18 +1,15 @@
 ﻿/*
- * @brief 鎧類に耐性等の追加効果を付与する処理
- * @date 2021/08/01
+ * @brief 鎧類に耐性等の追加効果を付与する基底処理
+ * @date 2022/03/12
  * @author Hourier
+ * @details 重鎧と軽鎧に適用. ドラゴン・スケイルメイルは対象外.
  */
 
 #include "object-enchant/protector/apply-magic-armor.h"
 #include "artifact/random-art-generator.h"
 #include "inventory/inventory-slot-types.h"
-#include "object-enchant/object-ego.h"
 #include "object/object-kind-hook.h"
-#include "player/player-personality-types.h"
-#include "sv-definition/sv-armor-types.h"
 #include "system/object-type-definition.h"
-#include "system/player-type-definition.h"
 #include "view/display-messages.h"
 
 /*
@@ -29,6 +26,7 @@ ArmorEnchanter::ArmorEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH 
 }
 
 /*
+ * @brief 重鎧/軽鎧共通のエゴ付与処理
  * @details power > 2はデバッグ専用.
  */
 void ArmorEnchanter::give_ego_index()
@@ -64,6 +62,9 @@ void ArmorEnchanter::give_ego_index()
     }
 }
 
+/*!
+ * @brief 重鎧/軽鎧共通の呪い付与処理
+ */
 void ArmorEnchanter::give_cursed()
 {
     this->o_ptr->ego_idx = get_random_ego(INVEN_BODY, false);

--- a/src/object-enchant/protector/apply-magic-armor.cpp
+++ b/src/object-enchant/protector/apply-magic-armor.cpp
@@ -38,17 +38,6 @@ void ArmorEnchanter::apply_magic()
     }
 
     switch (this->o_ptr->tval) {
-    case ItemKindType::HARD_ARMOR:
-        if (this->power > 1) {
-            this->give_ego_index();
-            return;
-        }
-
-        if (this->power < -1) {
-            this->give_cursed();
-        }
-
-        return;
     case ItemKindType::SOFT_ARMOR:
         // @todo 後ほどSoftArmorEnchanterへ分離した時、このswitch文はsval_enchant() へ移動させる.
         switch (this->o_ptr->sval) {

--- a/src/object-enchant/protector/apply-magic-armor.cpp
+++ b/src/object-enchant/protector/apply-magic-armor.cpp
@@ -38,12 +38,6 @@ void ArmorEnchanter::apply_magic()
     }
 
     switch (this->o_ptr->tval) {
-    case ItemKindType::DRAG_ARMOR:
-        if ((this->power > 2) || one_in_(50)) {
-            become_random_artifact(this->player_ptr, this->o_ptr, false);
-        }
-
-        break;
     case ItemKindType::HARD_ARMOR:
         if (this->power > 1) {
             this->give_ego_index();

--- a/src/object-enchant/protector/apply-magic-armor.h
+++ b/src/object-enchant/protector/apply-magic-armor.h
@@ -1,6 +1,5 @@
 ﻿#pragma once
 
-#include "object-enchant/enchanter-base.h"
 #include "object-enchant/protector/abstract-protector-enchanter.h"
 #include "system/angband.h"
 

--- a/src/object-enchant/protector/apply-magic-armor.h
+++ b/src/object-enchant/protector/apply-magic-armor.h
@@ -15,7 +15,6 @@ protected:
     PlayerType *player_ptr;
     bool is_high_ego_generated = false;
 
-    void sval_enchant() override{};
     void give_ego_index() override;
     void give_high_ego_index() override;
     void give_cursed() override;

--- a/src/object-enchant/protector/apply-magic-armor.h
+++ b/src/object-enchant/protector/apply-magic-armor.h
@@ -5,7 +5,7 @@
 
 class ObjectType;
 class PlayerType;
-class ArmorEnchanter : AbstractProtectorEnchanter {
+class ArmorEnchanter : public AbstractProtectorEnchanter {
 public:
     ArmorEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power);
     virtual ~ArmorEnchanter() = default;

--- a/src/object-enchant/protector/apply-magic-armor.h
+++ b/src/object-enchant/protector/apply-magic-armor.h
@@ -13,9 +13,7 @@ protected:
     ArmorEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power);
 
     PlayerType *player_ptr;
-    bool is_high_ego_generated = false;
 
     void give_ego_index() override;
-    void give_high_ego_index() override;
     void give_cursed() override;
 };

--- a/src/object-enchant/protector/apply-magic-armor.h
+++ b/src/object-enchant/protector/apply-magic-armor.h
@@ -7,17 +7,16 @@ class ObjectType;
 class PlayerType;
 class ArmorEnchanter : public AbstractProtectorEnchanter {
 public:
-    ArmorEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power);
     virtual ~ArmorEnchanter() = default;
-    void apply_magic() override;
 
 protected:
+    ArmorEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power);
+
+    PlayerType *player_ptr;
+    bool is_high_ego_generated = false;
+
     void sval_enchant() override{};
     void give_ego_index() override;
     void give_high_ego_index() override;
     void give_cursed() override;
-
-private:
-    PlayerType *player_ptr;
-    bool is_high_ego_generated = false;
 };

--- a/src/object-enchant/protector/apply-magic-boots.h
+++ b/src/object-enchant/protector/apply-magic-boots.h
@@ -1,6 +1,5 @@
 ﻿#pragma once
 
-#include "object-enchant/enchanter-base.h"
 #include "object-enchant/protector/abstract-protector-enchanter.h"
 #include "system/angband.h"
 

--- a/src/object-enchant/protector/apply-magic-cloak.h
+++ b/src/object-enchant/protector/apply-magic-cloak.h
@@ -1,6 +1,5 @@
 ﻿#pragma once
 
-#include "object-enchant/enchanter-base.h"
 #include "object-enchant/protector/abstract-protector-enchanter.h"
 #include "system/angband.h"
 

--- a/src/object-enchant/protector/apply-magic-crown.h
+++ b/src/object-enchant/protector/apply-magic-crown.h
@@ -1,6 +1,5 @@
 ﻿#pragma once
 
-#include "object-enchant/enchanter-base.h"
 #include "object-enchant/protector/abstract-protector-enchanter.h"
 #include "system/angband.h"
 

--- a/src/object-enchant/protector/apply-magic-dragon-armor.cpp
+++ b/src/object-enchant/protector/apply-magic-dragon-armor.cpp
@@ -1,0 +1,34 @@
+﻿/*
+ * @brief ドラゴン・スケイルメイルに耐性等の追加効果を付与する処理
+ * @date 2022/03/12
+ * @author Hourier
+ */
+
+#include "object-enchant/protector/apply-magic-dragon-armor.h"
+#include "artifact/random-art-generator.h"
+#include "object-enchant/protector/abstract-protector-enchanter.h"
+#include "system/object-type-definition.h"
+#include "system/player-type-definition.h"
+
+/*
+ * @brief コンストラクタ
+ * @param player_ptr プレイヤーへの参照ポインタ
+ * @param o_ptr 強化を与えたいオブジェクトの構造体参照ポインタ
+ * @param level 生成基準階
+ * @param power 生成ランク
+ */
+DragonArmorEnchanter::DragonArmorEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power)
+    : AbstractProtectorEnchanter{ o_ptr, level, power }
+    , player_ptr(player_ptr)
+{
+}
+
+/*!
+ * @brief power > 2 はデバッグ専用.
+ */
+void DragonArmorEnchanter::apply_magic()
+{
+    if ((this->power > 2) || one_in_(50)) {
+        become_random_artifact(this->player_ptr, this->o_ptr, false);
+    }
+}

--- a/src/object-enchant/protector/apply-magic-dragon-armor.h
+++ b/src/object-enchant/protector/apply-magic-dragon-armor.h
@@ -1,0 +1,21 @@
+﻿#pragma once
+
+#include "object-enchant/protector/abstract-protector-enchanter.h"
+#include "system/angband.h"
+
+class ObjectType;
+class PlayerType;
+class DragonArmorEnchanter : AbstractProtectorEnchanter {
+public:
+    DragonArmorEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power);
+    void apply_magic() override;
+
+protected:
+    void sval_enchant() override{};
+    void give_ego_index() override{};
+    void give_high_ego_index() override{};
+    void give_cursed() override{};
+
+private:
+    PlayerType *player_ptr;
+};

--- a/src/object-enchant/protector/apply-magic-gloves.h
+++ b/src/object-enchant/protector/apply-magic-gloves.h
@@ -1,6 +1,5 @@
 ﻿#pragma once
 
-#include "object-enchant/enchanter-base.h"
 #include "object-enchant/protector/abstract-protector-enchanter.h"
 #include "system/angband.h"
 

--- a/src/object-enchant/protector/apply-magic-hard-armor.cpp
+++ b/src/object-enchant/protector/apply-magic-hard-armor.cpp
@@ -1,0 +1,34 @@
+﻿/*
+ * @brief 重鎧に耐性等の追加効果を付与する処理
+ * @date 2022/03/12
+ * @author Hourier
+ */
+
+#include "object-enchant/protector/apply-magic-hard-armor.h"
+
+/*
+ * @brief コンストラクタ
+ * @param player_ptr プレイヤーへの参照ポインタ
+ * @param o_ptr 強化を与えたいオブジェクトの構造体参照ポインタ
+ * @param level 生成基準階
+ * @param power 生成ランク
+ */
+HardArmorEnchanter::HardArmorEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power)
+    : ArmorEnchanter{ player_ptr, o_ptr, level, power }
+{
+}
+
+/*!
+ * @brief power > 2 はデバッグ専用.
+ */
+void HardArmorEnchanter::apply_magic()
+{
+    if (this->power > 1) {
+        this->give_ego_index();
+        return;
+    }
+
+    if (this->power < -1) {
+        this->give_cursed();
+    }
+}

--- a/src/object-enchant/protector/apply-magic-hard-armor.h
+++ b/src/object-enchant/protector/apply-magic-hard-armor.h
@@ -1,0 +1,12 @@
+﻿#pragma once
+
+#include "object-enchant/protector/apply-magic-armor.h"
+#include "system/angband.h"
+
+class ObjectType;
+class PlayerType;
+class HardArmorEnchanter : ArmorEnchanter {
+public:
+    HardArmorEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power);
+    void apply_magic() override;
+};

--- a/src/object-enchant/protector/apply-magic-hard-armor.h
+++ b/src/object-enchant/protector/apply-magic-hard-armor.h
@@ -12,4 +12,5 @@ public:
 
 protected:
     void sval_enchant() override{};
+    void give_high_ego_index() override{};
 };

--- a/src/object-enchant/protector/apply-magic-hard-armor.h
+++ b/src/object-enchant/protector/apply-magic-hard-armor.h
@@ -9,4 +9,7 @@ class HardArmorEnchanter : ArmorEnchanter {
 public:
     HardArmorEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power);
     void apply_magic() override;
+
+protected:
+    void sval_enchant() override{};
 };

--- a/src/object-enchant/protector/apply-magic-helm.h
+++ b/src/object-enchant/protector/apply-magic-helm.h
@@ -1,6 +1,5 @@
 ﻿#pragma once
 
-#include "object-enchant/enchanter-base.h"
 #include "object-enchant/protector/abstract-protector-enchanter.h"
 #include "system/angband.h"
 

--- a/src/object-enchant/protector/apply-magic-shield.h
+++ b/src/object-enchant/protector/apply-magic-shield.h
@@ -1,6 +1,5 @@
 ﻿#pragma once
 
-#include "object-enchant/enchanter-base.h"
 #include "object-enchant/protector/abstract-protector-enchanter.h"
 #include "system/angband.h"
 

--- a/src/object-enchant/protector/apply-magic-soft-armor.cpp
+++ b/src/object-enchant/protector/apply-magic-soft-armor.cpp
@@ -1,0 +1,63 @@
+﻿/*
+ * @brief 軽鎧に耐性等の追加効果を付与する処理
+ * @date 2022/03/12
+ * @author Hourier
+ */
+
+#include "object-enchant/protector/apply-magic-soft-armor.h"
+#include "system/object-type-definition.h"
+#include "system/player-type-definition.h"
+#include "sv-definition/sv-armor-types.h"
+
+/*
+ * @brief コンストラクタ
+ * @param player_ptr プレイヤーへの参照ポインタ
+ * @param o_ptr 強化を与えたいオブジェクトの構造体参照ポインタ
+ * @param level 生成基準階
+ * @param power 生成ランク
+ */
+SoftArmorEnchanter::SoftArmorEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power)
+    : ArmorEnchanter{ player_ptr, o_ptr, level, power }
+{
+}
+
+/*!
+ * @brief power > 2 はデバッグ専用.
+ */
+void SoftArmorEnchanter::apply_magic()
+{
+    switch (this->o_ptr->sval) {
+    case SV_KUROSHOUZOKU:
+        this->o_ptr->pval = randint1(4);
+        break;
+    case SV_ABUNAI_MIZUGI:
+        if (this->player_ptr->ppersonality != PERSONALITY_SEXY) {
+            break;
+        }
+
+        this->o_ptr->pval = 3;
+        this->o_ptr->art_flags.set(TR_STR);
+        this->o_ptr->art_flags.set(TR_INT);
+        this->o_ptr->art_flags.set(TR_WIS);
+        this->o_ptr->art_flags.set(TR_DEX);
+        this->o_ptr->art_flags.set(TR_CON);
+        this->o_ptr->art_flags.set(TR_CHR);
+        break;
+    default:
+        break;
+    }
+
+    if (this->power > 1) {
+        this->give_high_ego_index();
+        if (this->is_high_ego_generated) {
+            return;
+        }
+
+        this->give_ego_index();
+        return;
+    }
+
+    if (this->power < -1) {
+        this->give_cursed();
+    }
+}

--- a/src/object-enchant/protector/apply-magic-soft-armor.cpp
+++ b/src/object-enchant/protector/apply-magic-soft-armor.cpp
@@ -5,9 +5,9 @@
  */
 
 #include "object-enchant/protector/apply-magic-soft-armor.h"
+#include "sv-definition/sv-armor-types.h"
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
-#include "sv-definition/sv-armor-types.h"
 
 /*
  * @brief コンストラクタ
@@ -26,27 +26,7 @@ SoftArmorEnchanter::SoftArmorEnchanter(PlayerType *player_ptr, ObjectType *o_ptr
  */
 void SoftArmorEnchanter::apply_magic()
 {
-    switch (this->o_ptr->sval) {
-    case SV_KUROSHOUZOKU:
-        this->o_ptr->pval = randint1(4);
-        break;
-    case SV_ABUNAI_MIZUGI:
-        if (this->player_ptr->ppersonality != PERSONALITY_SEXY) {
-            break;
-        }
-
-        this->o_ptr->pval = 3;
-        this->o_ptr->art_flags.set(TR_STR);
-        this->o_ptr->art_flags.set(TR_INT);
-        this->o_ptr->art_flags.set(TR_WIS);
-        this->o_ptr->art_flags.set(TR_DEX);
-        this->o_ptr->art_flags.set(TR_CON);
-        this->o_ptr->art_flags.set(TR_CHR);
-        break;
-    default:
-        break;
-    }
-
+    this->sval_enchant();
     if (this->power > 1) {
         this->give_high_ego_index();
         if (this->is_high_ego_generated) {
@@ -59,5 +39,29 @@ void SoftArmorEnchanter::apply_magic()
 
     if (this->power < -1) {
         this->give_cursed();
+    }
+}
+
+void SoftArmorEnchanter::sval_enchant()
+{
+    switch (this->o_ptr->sval) {
+    case SV_KUROSHOUZOKU:
+        this->o_ptr->pval = randint1(4);
+        return;
+    case SV_ABUNAI_MIZUGI:
+        if (this->player_ptr->ppersonality != PERSONALITY_SEXY) {
+            return;
+        }
+
+        this->o_ptr->pval = 3;
+        this->o_ptr->art_flags.set(TR_STR);
+        this->o_ptr->art_flags.set(TR_INT);
+        this->o_ptr->art_flags.set(TR_WIS);
+        this->o_ptr->art_flags.set(TR_DEX);
+        this->o_ptr->art_flags.set(TR_CON);
+        this->o_ptr->art_flags.set(TR_CHR);
+        return;
+    default:
+        return;
     }
 }

--- a/src/object-enchant/protector/apply-magic-soft-armor.cpp
+++ b/src/object-enchant/protector/apply-magic-soft-armor.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "object-enchant/protector/apply-magic-soft-armor.h"
+#include "object/object-kind-hook.h"
 #include "sv-definition/sv-armor-types.h"
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
@@ -64,4 +65,29 @@ void SoftArmorEnchanter::sval_enchant()
     default:
         return;
     }
+}
+
+/*
+ * @brief ベースアイテムがローブの時、確率で永続か宵闇のローブを生成する.
+ * @return 生成条件を満たしたらtrue、満たさなかったらfalse
+ * @details 永続：12%、宵闇：3%
+ */
+void SoftArmorEnchanter::give_high_ego_index()
+{
+    if ((this->o_ptr->sval != SV_ROBE) || (randint0(100) >= 15)) {
+        return;
+    }
+
+    this->is_high_ego_generated = true;
+    auto ego_robe = one_in_(5);
+    this->o_ptr->ego_idx = ego_robe ? EgoType::TWILIGHT : EgoType::PERMANENCE;
+    if (!ego_robe) {
+        return;
+    }
+
+    this->o_ptr->k_idx = lookup_kind(ItemKindType::SOFT_ARMOR, SV_TWILIGHT_ROBE);
+    this->o_ptr->sval = SV_TWILIGHT_ROBE;
+    this->o_ptr->ac = 0;
+    this->o_ptr->to_a = 0;
+    return;
 }

--- a/src/object-enchant/protector/apply-magic-soft-armor.h
+++ b/src/object-enchant/protector/apply-magic-soft-armor.h
@@ -1,0 +1,12 @@
+﻿#pragma once
+
+#include "object-enchant/protector/apply-magic-armor.h"
+#include "system/angband.h"
+
+class ObjectType;
+class PlayerType;
+class SoftArmorEnchanter : ArmorEnchanter {
+public:
+    SoftArmorEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power);
+    void apply_magic() override;
+};

--- a/src/object-enchant/protector/apply-magic-soft-armor.h
+++ b/src/object-enchant/protector/apply-magic-soft-armor.h
@@ -12,4 +12,8 @@ public:
 
 protected:
     void sval_enchant() override;
+    void give_high_ego_index() override;
+
+private:
+    bool is_high_ego_generated = false;
 };

--- a/src/object-enchant/protector/apply-magic-soft-armor.h
+++ b/src/object-enchant/protector/apply-magic-soft-armor.h
@@ -9,4 +9,7 @@ class SoftArmorEnchanter : ArmorEnchanter {
 public:
     SoftArmorEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power);
     void apply_magic() override;
+
+protected:
+    void sval_enchant() override;
 };


### PR DESCRIPTION
#2404 の後続作業です
ドラゴン・スケイルメイルは行数的にかなり寂しいですが、分岐はファクトリに閉じ込めた方が分かりやすくなるのでこのままとします
ご確認下さい