### PR TITLE
[Refactor] メッセージ表示関連関数の引数の型を std::string_view にする 

### DIFF
--- a/src/effect/effect-player.cpp
+++ b/src/effect/effect-player.cpp
@@ -86,7 +86,7 @@ static bool process_bolt_reflection(PlayerType *player_ptr, EffectPlayerType *ep
         mes = _("攻撃が跳ね返った！", "The attack bounces!");
     }
 
-    msg_print(mes.data());
+    msg_print(mes);
     POSITION t_y;
     POSITION t_x;
     if (ep_ptr->who > 0) {

--- a/src/io/write-diary.cpp
+++ b/src/io/write-diary.cpp
@@ -63,7 +63,7 @@ static bool open_diary_file(FILE **fff, bool *disable_diary)
     }
 
     msg_format(_("%s を開くことができませんでした。プレイ記録を一時停止します。", "Failed to open %s. Play-Record is disabled temporarily."), buf);
-    msg_format(nullptr);
+    msg_print(nullptr);
     *disable_diary = true;
     return false;
 }

--- a/src/main/game-data-initializer.cpp
+++ b/src/main/game-data-initializer.cpp
@@ -53,7 +53,7 @@ void init_quests(void)
         std::stringstream ss;
         ss << _("ファイル読み込みエラー: ", "File loading error: ") << r.what();
 
-        msg_print(ss.str().c_str());
+        msg_print(ss.str());
         msg_print(nullptr);
         quit(_("クエスト初期化エラー", "Error of quests initializing"));
     }

--- a/src/object-use/item-use-checker.cpp
+++ b/src/object-use/item-use-checker.cpp
@@ -13,7 +13,7 @@ bool ItemUseChecker::check_stun(std::string_view mes) const
 {
     auto penalty = this->player_ptr->effects()->stun()->get_item_chance_penalty();
     if (penalty >= randint1(100)) {
-        msg_print(mes.data());
+        msg_print(mes);
         return false;
     }
 

--- a/src/room/rooms-pit-nest.cpp
+++ b/src/room/rooms-pit-nest.cpp
@@ -967,7 +967,7 @@ bool build_type13(PlayerType *player_ptr, dun_data_type *dd_ptr)
         what[i] = what[i * 2];
 
         if (cheat_hear) {
-            msg_print(r_info[what[i]].name.c_str());
+            msg_print(r_info[what[i]].name);
         }
     }
 

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -528,7 +528,7 @@ bool BadStatusSetter::process_stun_effect(const short v)
 void BadStatusSetter::process_stun_status(const PlayerStunRank new_rank, const short v)
 {
     auto stun_mes = PlayerStun::get_stun_mes(new_rank);
-    msg_print(stun_mes.data());
+    msg_print(stun_mes);
     this->decrease_int_wis(v);
     if (PlayerClass(this->player_ptr).lose_balance()) {
         msg_print(_("型が崩れた。", "You lose your stance."));
@@ -617,7 +617,7 @@ void BadStatusSetter::decrease_charisma(const PlayerCutRank new_rank, const shor
 {
     auto player_cut = this->player_ptr->effects()->cut();
     auto cut_mes = player_cut->get_cut_mes(new_rank);
-    msg_print(cut_mes.data());
+    msg_print(cut_mes);
     if (v <= randint1(1000) && !one_in_(16)) {
         return;
     }

--- a/src/view/display-messages.h
+++ b/src/view/display-messages.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include <string_view>
 
 /*
  * OPTION: Maximum number of messages to remember (see "io.c")
@@ -13,7 +14,8 @@ extern COMMAND_CODE now_message;
 
 int32_t message_num(void);
 concptr message_str(int age);
-void message_add(concptr msg);
+void message_add(std::string_view msg);
 void msg_erase(void);
-void msg_print(concptr msg);
-void msg_format(concptr fmt, ...);
+void msg_print(std::string_view msg);
+void msg_print(std::nullptr_t);
+void msg_format(std::string_view fmt, ...);

--- a/src/wizard/wizard-game-modifier.cpp
+++ b/src/wizard/wizard-game-modifier.cpp
@@ -184,6 +184,6 @@ void wiz_restore_monster_max_num(MonsterRaceId r_idx)
 
     std::stringstream ss;
     ss << r_ptr->name << _("の出現数を復元しました。", " can appear again now.");
-    msg_print(ss.str().c_str());
+    msg_print(ss.str());
     msg_print(nullptr);
 }


### PR DESCRIPTION
Resolves #2417 

表題の通り、msg_print 等の引数を concptr から std::string_view に変更し、呼び出し側は concptr、std::string、std::string_view のどれでも渡せるようにしました。
また現状のコードで c_str() や data() などの呼び出しが不要になるものについて、メンバ関数の呼び出しを削除しました。
ついでに既存の msg_print がかなり見通しの悪いコードなので、多少読みやすくなるように改善しました。