### PR TITLE
[Fix] #2416 魔力食いを失敗した時のメッセージがおかしい

### DIFF
--- a/src/mind/mind-mage.cpp
+++ b/src/mind/mind-mage.cpp
@@ -185,7 +185,7 @@ bool eat_magic(PlayerType *player_ptr, int power)
                 o_ptr->pval = o_ptr->pval * (o_ptr->number - 1) / o_ptr->number;
             }
         } else {
-            msg_format(_("乱暴な魔法のために%sが何本か壊れた！", "Wild magic consumes your %s!"), o_name);
+            msg_format(_("乱暴な魔法のために%sが壊れた！", "Wild magic consumes your %s!"), o_name);
         }
 
         vary_item(player_ptr, item, -1);


### PR DESCRIPTION
1本だけのスタックしていないアイテムから魔力食いをして失敗してアイテムが破壊された時、
「○○が何本壊れた！」と実態に合っていないメッセージが表示される事がある。
「○○が壊れた！」と正しいメッセージに修正する。