### PR TITLE
[Fix] ダンジョンのモンスターシンボル制限の指定数の上限をなくす

### DIFF
--- a/src/dungeon/dungeon.h
+++ b/src/dungeon/dungeon.h
@@ -87,7 +87,7 @@ struct dungeon_type {
     EnumClassFlagGroup<MonsterResistanceType> mon_resistance_flags;
     EnumClassFlagGroup<MonsterDropType> mon_drop_flags;
 
-    char r_char[5]{}; /* Monster race allowed */
+    std::vector<char> r_chars; /* Monster symbols allowed */
     KIND_OBJECT_IDX final_object{}; /* The object you'll find at the bottom */
     ARTIFACT_IDX final_artifact{}; /* The artifact you'll find at the bottom */
     MonsterRaceId final_guardian{}; /* The artifact's guardian. If an artifact is specified, then it's NEEDED */

--- a/src/info-reader/dungeon-reader.cpp
+++ b/src/info-reader/dungeon-reader.cpp
@@ -296,11 +296,7 @@ errr parse_d_info(std::string_view buf, angband_header *)
 
             const auto &m_tokens = str_split(f, '_');
             if (m_tokens[0] == "R" && m_tokens[1] == "CHAR") {
-                if (m_tokens[2].size() > 4) {
-                    return PARSE_ERROR_GENERIC;
-                }
-
-                strcpy(d_ptr->r_char, m_tokens[2].c_str());
+                d_ptr->r_chars.insert(d_ptr->r_chars.end(), m_tokens[2].begin(), m_tokens[2].end());
                 continue;
             }
 

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -139,7 +139,7 @@ static bool restrict_monster_to_dungeon(PlayerType *player_ptr, MonsterRaceId r_
         };
 
         auto result = std::all_of(is_possible.begin(), is_possible.end(), [](const auto &v) { return v; });
-        result &= std::all_of(std::begin(d_ptr->r_char), std::end(d_ptr->r_char), [r_ptr](const auto &v) { return !v || (v == r_ptr->d_char); });
+        result &= std::all_of(d_ptr->r_chars.begin(), d_ptr->r_chars.end(), [r_ptr](const auto &v) { return v == r_ptr->d_char; });
 
         return d_ptr->mode == DUNGEON_MODE_AND ? result : !result;
     }
@@ -160,7 +160,7 @@ static bool restrict_monster_to_dungeon(PlayerType *player_ptr, MonsterRaceId r_
         };
 
         auto result = std::any_of(is_possible.begin(), is_possible.end(), [](const auto &v) { return v; });
-        result |= std::any_of(std::begin(d_ptr->r_char), std::end(d_ptr->r_char), [r_ptr](const auto &v) { return v == r_ptr->d_char; });
+        result |= std::any_of(d_ptr->r_chars.begin(), d_ptr->r_chars.end(), [r_ptr](const auto &v) { return v == r_ptr->d_char; });
 
         return d_ptr->mode == DUNGEON_MODE_OR ? result : !result;
     }


### PR DESCRIPTION
ダンジョンで生成されるモンスターのシンボル制限のデータを std::vector にし、現在4つ
までとなっている指定数の上限を撤廃する。