### PR TITLE
[Fix] #2430 光源の残ターン数が負のオーバーフローを起こす

### DIFF
--- a/src/load/old/item-loader-savefile50.cpp
+++ b/src/load/old/item-loader-savefile50.cpp
@@ -131,7 +131,7 @@ void ItemLoader50::rd_item(ObjectType *o_ptr)
     if (loading_savefile_version_is_older_than(13)) {
         int16_t xtra4 = any_bits(flags, SavedataItemOlderThan13FlagType::XTRA4) ? rd_s16b() : 0;
         if (o_ptr->is_fuel()) {
-            o_ptr->fuel = static_cast<ushort>(xtra4);
+            o_ptr->fuel = static_cast<short>(xtra4);
         } else if (o_ptr->tval == ItemKindType::CAPTURE) {
             o_ptr->captured_monster_current_hp = xtra4;
         } else {
@@ -139,7 +139,7 @@ void ItemLoader50::rd_item(ObjectType *o_ptr)
             o_ptr->smith_damage = static_cast<byte>(xtra4 & 0x000f);
         }
     } else {
-        o_ptr->fuel = any_bits(flags, SaveDataItemFlagType::FUEL) ? rd_u16b() : 0;
+        o_ptr->fuel = any_bits(flags, SaveDataItemFlagType::FUEL) ? rd_s16b() : 0;
         o_ptr->captured_monster_current_hp = any_bits(flags, SaveDataItemFlagType::CAPTURED_MONSTER_CURRENT_HP) ? rd_s16b() : 0;
     }
 

--- a/src/load/old/item-loader-savefile50.cpp
+++ b/src/load/old/item-loader-savefile50.cpp
@@ -143,6 +143,13 @@ void ItemLoader50::rd_item(ObjectType *o_ptr)
         o_ptr->captured_monster_current_hp = any_bits(flags, SaveDataItemFlagType::CAPTURED_MONSTER_CURRENT_HP) ? rd_s16b() : 0;
     }
 
+    if (o_ptr->is_fuel()) {
+        const auto fuel_max = o_ptr->sval == SV_LITE_TORCH ? FUEL_TORCH : FUEL_LAMP;
+        if (o_ptr->fuel < 0 || o_ptr->fuel > fuel_max) {
+            o_ptr->fuel = 0;
+        }
+    }
+
     o_ptr->captured_monster_max_hp = any_bits(flags, SaveDataItemFlagType::XTRA5) ? rd_s16b() : 0;
     o_ptr->feeling = any_bits(flags, SaveDataItemFlagType::FEELING) ? rd_byte() : 0;
     o_ptr->stack_idx = any_bits(flags, SaveDataItemFlagType::STACK_IDX) ? rd_s16b() : 0;

--- a/src/save/item-writer.cpp
+++ b/src/save/item-writer.cpp
@@ -197,7 +197,7 @@ static void write_item_info(ObjectType *o_ptr, const BIT_FLAGS flags)
     }
 
     if (any_bits(flags, SaveDataItemFlagType::FUEL)) {
-        wr_u16b(o_ptr->fuel);
+        wr_s16b(o_ptr->fuel);
     }
 
     if (any_bits(flags, SaveDataItemFlagType::CAPTURED_MONSTER_CURRENT_HP)) {

--- a/src/system/object-type-definition.h
+++ b/src/system/object-type-definition.h
@@ -41,7 +41,7 @@ public:
     uint8_t captured_monster_speed = 0; /*!< 捕らえたモンスターの速度 */
     short captured_monster_current_hp = 0; /*!< 捕らえたモンスターの現HP */
     short captured_monster_max_hp = 0; /*!< 捕らえたモンスターの最大HP */
-    ushort fuel = 0; /*!< 光源の残り寿命 / Extra info fuel or captured monster's current HP */
+    short fuel = 0; /*!< 光源の残り寿命 / Remaining fuel */
 
     byte smith_hit = 0; /*!< 鍛冶をした結果上昇した命中値 */
     byte smith_damage = 0; /*!< 鍛冶をした結果上昇したダメージ */


### PR DESCRIPTION
モンスターの攻撃により光源の残ターン数が一時的に負の値になる事があるが、変数が符号なし
のため負のオーバーフローを起こす。
符号付きに修正する。