### PR TITLE
[Refactor] ボルトの軌道の描画を関数化する

### DIFF
--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -34,7 +34,6 @@
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
 #include "target/projection-path-calculator.h"
-#include "term/gameterm.h"
 #include "timed-effect/player-hallucination.h"
 #include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
@@ -169,22 +168,14 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
         if (delay_factor > 0) {
             if (!blind && !(flag & (PROJECT_HIDE | PROJECT_FAST))) {
                 if (panel_contains(ny, nx) && player_has_los_bold(player_ptr, ny, nx)) {
-                    uint16_t p;
-                    TERM_COLOR a;
-                    p = bolt_pict(oy, ox, ny, nx, typ);
-                    a = PICT_A(p);
-                    auto c = PICT_C(p);
-                    print_rel(player_ptr, c, a, ny, nx);
+                    print_bolt_pict(player_ptr, oy, ox, ny, nx, typ);
                     move_cursor_relative(ny, nx);
                     term_fresh();
                     term_xtra(TERM_XTRA_DELAY, delay_factor);
                     lite_spot(player_ptr, ny, nx);
                     term_fresh();
                     if (flag & (PROJECT_BEAM)) {
-                        p = bolt_pict(ny, nx, ny, nx, typ);
-                        a = PICT_A(p);
-                        c = PICT_C(p);
-                        print_rel(player_ptr, c, a, ny, nx);
+                        print_bolt_pict(player_ptr, ny, nx, ny, nx, typ);
                     }
 
                     visual = true;
@@ -284,13 +275,8 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
                 auto y = gy[i];
                 auto x = gx[i];
                 if (panel_contains(y, x) && player_has_los_bold(player_ptr, y, x)) {
-                    uint16_t p;
-                    TERM_COLOR a;
                     drawn = true;
-                    p = bolt_pict(y, x, y, x, typ);
-                    a = PICT_A(p);
-                    auto c = PICT_C(p);
-                    print_rel(player_ptr, c, a, y, x);
+                    print_bolt_pict(player_ptr, y, x, y, x, typ);
                 }
             }
 

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -52,6 +52,7 @@
 #include "system/monster-type-definition.h"
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
+#include "term/gameterm.h"
 #include "term/term-color-types.h"
 #include "util/bit-flags-calculator.h"
 #include "util/enum-converter.h"
@@ -276,6 +277,12 @@ void print_rel(PlayerType *player_ptr, char c, TERM_COLOR a, POSITION y, POSITIO
         /* Draw the char using the attr */
         term_queue_bigchar(panel_col_of(x), y - panel_row_prt, a, c, 0, 0);
     }
+}
+
+void print_bolt_pict(PlayerType *player_ptr, POSITION y, POSITION x, POSITION ny, POSITION nx, AttributeType typ)
+{
+    const auto [a, c] = bolt_pict(y, x, ny, nx, typ);
+    print_rel(player_ptr, c, a, ny, nx);
 }
 
 /*!

--- a/src/grid/grid.h
+++ b/src/grid/grid.h
@@ -18,6 +18,8 @@
 #include "spell/spells-util.h"
 #include "system/angband.h"
 
+enum class AttributeType;
+
 /*  A structure type for terrain template of saving dungeon floor */
 struct grid_template_type {
     BIT_FLAGS info;
@@ -52,6 +54,7 @@ bool feat_uses_special(FEAT_IDX f_idx);
 void update_local_illumination(PlayerType *player_ptr, POSITION y, POSITION x);
 bool no_lite(PlayerType *player_ptr);
 void print_rel(PlayerType *player_ptr, char c, TERM_COLOR a, POSITION y, POSITION x);
+void print_bolt_pict(PlayerType *player_ptr, POSITION y, POSITION x, POSITION ny, POSITION nx, AttributeType typ);
 void note_spot(PlayerType *player_ptr, POSITION y, POSITION x);
 void lite_spot(PlayerType *player_ptr, POSITION y, POSITION x);
 void update_flow(PlayerType *player_ptr);

--- a/src/mind/mind-mirror-master.cpp
+++ b/src/mind/mind-mirror-master.cpp
@@ -46,7 +46,6 @@
 #include "target/grid-selector.h"
 #include "target/projection-path-calculator.h"
 #include "target/target-getter.h"
-#include "term/gameterm.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "world/world.h"
@@ -126,8 +125,7 @@ bool binding_field(PlayerType *player_ptr, int dam)
             if (centersign * ((point_x[0] - x) * (point_y[1] - y) - (point_y[0] - y) * (point_x[1] - x)) >= 0 && centersign * ((point_x[1] - x) * (point_y[2] - y) - (point_y[1] - y) * (point_x[2] - x)) >= 0 && centersign * ((point_x[2] - x) * (point_y[0] - y) - (point_y[2] - y) * (point_x[0] - x)) >= 0) {
                 if (player_has_los_bold(player_ptr, y, x) && projectable(player_ptr, player_ptr->y, player_ptr->x, y, x)) {
                     if (!(player_ptr->blind) && panel_contains(y, x)) {
-                        uint16_t p = bolt_pict(y, x, y, x, AttributeType::MANA);
-                        print_rel(player_ptr, PICT_C(p), PICT_A(p), y, x);
+                        print_bolt_pict(player_ptr, y, x, y, x, AttributeType::MANA);
                         move_cursor_relative(y, x);
                         term_fresh();
                         term_xtra(TERM_XTRA_DELAY, delay_factor);

--- a/src/spell-class/spells-mirror-master.cpp
+++ b/src/spell-class/spells-mirror-master.cpp
@@ -35,7 +35,6 @@
 #include "target/grid-selector.h"
 #include "target/projection-path-calculator.h"
 #include "target/target-checker.h"
-#include "term/gameterm.h"
 #include "timed-effect/player-hallucination.h"
 #include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
@@ -306,20 +305,14 @@ void SpellsMirrorMaster::project_seeker_ray(int target_x, int target_y, int dam)
 
             if (delay_factor > 0 && !blind) {
                 if (panel_contains(ny, nx) && player_has_los_bold(this->player_ptr, ny, nx)) {
-                    auto p = bolt_pict(oy, ox, ny, nx, typ);
-                    auto a = PICT_A(p);
-                    auto c = PICT_C(p);
-                    print_rel(this->player_ptr, c, a, ny, nx);
+                    print_bolt_pict(this->player_ptr, oy, ox, ny, nx, typ);
                     move_cursor_relative(ny, nx);
                     term_fresh();
                     term_xtra(TERM_XTRA_DELAY, delay_factor);
                     lite_spot(this->player_ptr, ny, nx);
                     term_fresh();
 
-                    p = bolt_pict(ny, nx, ny, nx, typ);
-                    a = PICT_A(p);
-                    c = PICT_C(p);
-                    print_rel(this->player_ptr, c, a, ny, nx);
+                    print_bolt_pict(this->player_ptr, ny, nx, ny, nx, typ);
 
                     visual = true;
                 } else if (visual) {
@@ -403,20 +396,14 @@ void SpellsMirrorMaster::project_super_ray(int target_x, int target_y, int dam)
     for (const auto &[ny, nx] : path_g) {
         if (delay_factor > 0) {
             if (panel_contains(ny, nx) && player_has_los_bold(this->player_ptr, ny, nx)) {
-                auto p = bolt_pict(oy, ox, ny, nx, typ);
-                auto a = PICT_A(p);
-                auto c = PICT_C(p);
-                print_rel(this->player_ptr, c, a, ny, nx);
+                print_bolt_pict(this->player_ptr, oy, ox, ny, nx, typ);
                 move_cursor_relative(ny, nx);
                 term_fresh();
                 term_xtra(TERM_XTRA_DELAY, delay_factor);
                 lite_spot(this->player_ptr, ny, nx);
                 term_fresh();
 
-                p = bolt_pict(ny, nx, ny, nx, typ);
-                a = PICT_A(p);
-                c = PICT_C(p);
-                print_rel(this->player_ptr, c, a, ny, nx);
+                print_bolt_pict(this->player_ptr, ny, nx, ny, nx, typ);
 
                 visual = true;
             } else if (visual) {
@@ -467,20 +454,14 @@ void SpellsMirrorMaster::project_super_ray(int target_x, int target_y, int dam)
         for (const auto &[ny, nx] : second_path_g) {
             if (delay_factor > 0) {
                 if (panel_contains(ny, nx) && player_has_los_bold(this->player_ptr, ny, nx)) {
-                    auto p = bolt_pict(oy, ox, ny, nx, typ);
-                    auto a = PICT_A(p);
-                    auto c = PICT_C(p);
-                    print_rel(this->player_ptr, c, a, ny, nx);
+                    print_bolt_pict(this->player_ptr, oy, ox, ny, nx, typ);
                     move_cursor_relative(ny, nx);
                     term_fresh();
                     term_xtra(TERM_XTRA_DELAY, delay_factor);
                     lite_spot(this->player_ptr, ny, nx);
                     term_fresh();
 
-                    p = bolt_pict(ny, nx, ny, nx, typ);
-                    a = PICT_A(p);
-                    c = PICT_C(p);
-                    print_rel(this->player_ptr, c, a, ny, nx);
+                    print_bolt_pict(this->player_ptr, ny, nx, ny, nx, typ);
 
                     visual = true;
                 } else if (visual) {

--- a/src/term/gameterm.cpp
+++ b/src/term/gameterm.cpp
@@ -574,7 +574,7 @@ static TERM_COLOR spell_color(AttributeType type)
  * If the distance is not "one", we (may) return "*".
  * </pre>
  */
-uint16_t bolt_pict(POSITION y, POSITION x, POSITION ny, POSITION nx, AttributeType typ)
+std::pair<TERM_COLOR, char> bolt_pict(POSITION y, POSITION x, POSITION ny, POSITION nx, AttributeType typ)
 {
     int base;
 
@@ -620,7 +620,7 @@ uint16_t bolt_pict(POSITION y, POSITION x, POSITION ny, POSITION nx, AttributeTy
     auto c = misc_to_char[base + k];
 
     /* Create pict */
-    return PICT(a, c);
+    return { a, c };
 }
 
 /*!

--- a/src/term/gameterm.h
+++ b/src/term/gameterm.h
@@ -2,18 +2,7 @@
 
 #include "system/angband.h"
 #include <map>
-
-/*
- * Convert a "pict" (P) into an "attr" (A)
- */
-#define PICT_A(P) \
-    ((byte)((P) >> 8))
-
-/*
- * Convert a "pict" (P) into an "char" (C)
- */
-#define PICT_C(P) \
-    ((char)((byte)(P)))
+#include <utility>
 
 extern const concptr color_names[16];
 extern const concptr window_flag_desc[32];
@@ -32,4 +21,4 @@ enum class AttributeType : int;
 extern std::map<AttributeType, ushort> gf_colors;
 extern TERM_COLOR color_char_to_attr(char c);
 
-uint16_t bolt_pict(POSITION y, POSITION x, POSITION ny, POSITION nx, AttributeType typ);
+std::pair<TERM_COLOR, char> bolt_pict(POSITION y, POSITION x, POSITION ny, POSITION nx, AttributeType typ);


### PR DESCRIPTION
bolt_pict() で色と文字を選んで print_rel() で描画するという一連の処理を
print_bolt_pict() 関数にまとめる。
bolt_pict() は色と文字を uint16_t で返してマクロで分解するのをやめ、
std::pair<TERM_COLOR, char> を返すようにする。

先程レビューしていて目についたので。ちょっとしたリファクタリングなので Issue は無しです。