### PR TITLE
[Fix] X11版で起動直後の初期化中にキーを押すとクラッシュする

### DIFF
--- a/src/main-x11.cpp
+++ b/src/main-x11.cpp
@@ -1173,7 +1173,7 @@ static void react_keypress(XKeyEvent *xev)
 
     send_keys(msg);
 
-    if (n && (macro_find_exact(msg) < 0)) {
+    if (n && !macro__pat.empty() && (macro_find_exact(msg) < 0)) {
         macro_add(msg, buf);
     }
 }


### PR DESCRIPTION
Resolves #2435 

X11版は入力したキーが Modifier キーで修飾されている場合は自動的にその組み合わせを
マクロに登録するという処理がなされている（そのような実装になっている詳細な理由は不明）。
Modifier キーとは Mod1 が Altキー、 Mod2 が NumLock キーにあたる。
したがって、NumLockがオンの状態では普通にキーを押しただけでマクロが自動的に登録される。
一方、起動直後はまだマクロ情報の配列変数(std::vector)の領域確保が完了しておらず、
マクロを登録しようとすると配列外アクセスを起こす。
結果として、起動直後の初期化中に NumLock がオンになった状態でなんらかのキーを入力する
とクラッシュを引き起こす。

該当のマクロ登録部でマクロの配列の領域が確保済みかどうかをチェックし、確保されていない
場合はマクロの登録をスキップするようにする。