### PR TITLE
SwordEnchanter を分離してPolearmEnchanter とHaftedEnchanter を定義した

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -280,6 +280,7 @@
     <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-dragon-armor.cpp" />
     <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-hard-armor.cpp" />
     <ClCompile Include="..\..\src\object-enchant\weapon\abstract-weapon-enchanter.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\weapon\apply-magic-hafted.cpp" />
     <ClCompile Include="..\..\src\object-enchant\weapon\melee-weapon-enchanter.cpp" />
     <ClCompile Include="..\..\src\object-use\quaff\quaff-effects.cpp" />
     <ClCompile Include="..\..\src\object-enchant\weapon\apply-magic-arrow.cpp" />
@@ -970,6 +971,7 @@
     <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-dragon-armor.h" />
     <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-hard-armor.h" />
     <ClInclude Include="..\..\src\object-enchant\weapon\abstract-weapon-enchanter.h" />
+    <ClInclude Include="..\..\src\object-enchant\weapon\apply-magic-hafted.h" />
     <ClInclude Include="..\..\src\object-enchant\weapon\melee-weapon-enchanter.h" />
     <ClInclude Include="..\..\src\object-use\quaff\quaff-effects.h" />
     <ClInclude Include="..\..\src\object-enchant\weapon\apply-magic-arrow.h" />

--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -280,6 +280,7 @@
     <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-dragon-armor.cpp" />
     <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-hard-armor.cpp" />
     <ClCompile Include="..\..\src\object-enchant\weapon\abstract-weapon-enchanter.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\weapon\melee-weapon-enchanter.cpp" />
     <ClCompile Include="..\..\src\object-use\quaff\quaff-effects.cpp" />
     <ClCompile Include="..\..\src\object-enchant\weapon\apply-magic-arrow.cpp" />
     <ClCompile Include="..\..\src\object-enchant\weapon\apply-magic-digging.cpp" />
@@ -969,6 +970,7 @@
     <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-dragon-armor.h" />
     <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-hard-armor.h" />
     <ClInclude Include="..\..\src\object-enchant\weapon\abstract-weapon-enchanter.h" />
+    <ClInclude Include="..\..\src\object-enchant\weapon\melee-weapon-enchanter.h" />
     <ClInclude Include="..\..\src\object-use\quaff\quaff-effects.h" />
     <ClInclude Include="..\..\src\object-enchant\weapon\apply-magic-arrow.h" />
     <ClInclude Include="..\..\src\object-enchant\weapon\apply-magic-digging.h" />

--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -281,6 +281,7 @@
     <ClCompile Include="..\..\src\object-enchant\protector\apply-magic-hard-armor.cpp" />
     <ClCompile Include="..\..\src\object-enchant\weapon\abstract-weapon-enchanter.cpp" />
     <ClCompile Include="..\..\src\object-enchant\weapon\apply-magic-hafted.cpp" />
+    <ClCompile Include="..\..\src\object-enchant\weapon\apply-magic-polearm.cpp" />
     <ClCompile Include="..\..\src\object-enchant\weapon\melee-weapon-enchanter.cpp" />
     <ClCompile Include="..\..\src\object-use\quaff\quaff-effects.cpp" />
     <ClCompile Include="..\..\src\object-enchant\weapon\apply-magic-arrow.cpp" />
@@ -972,6 +973,7 @@
     <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-hard-armor.h" />
     <ClInclude Include="..\..\src\object-enchant\weapon\abstract-weapon-enchanter.h" />
     <ClInclude Include="..\..\src\object-enchant\weapon\apply-magic-hafted.h" />
+    <ClInclude Include="..\..\src\object-enchant\weapon\apply-magic-polearm.h" />
     <ClInclude Include="..\..\src\object-enchant\weapon\melee-weapon-enchanter.h" />
     <ClInclude Include="..\..\src\object-use\quaff\quaff-effects.h" />
     <ClInclude Include="..\..\src\object-enchant\weapon\apply-magic-arrow.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2439,6 +2439,9 @@
     <ClCompile Include="..\..\src\object-enchant\weapon\apply-magic-hafted.cpp">
       <Filter>object-enchant\weapon</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\weapon\apply-magic-polearm.cpp">
+      <Filter>object-enchant\weapon</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5296,6 +5299,9 @@
       <Filter>object-enchant\weapon</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\object-enchant\weapon\apply-magic-hafted.h">
+      <Filter>object-enchant\weapon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\weapon\apply-magic-polearm.h">
       <Filter>object-enchant\weapon</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2436,6 +2436,9 @@
     <ClCompile Include="..\..\src\object-enchant\weapon\melee-weapon-enchanter.cpp">
       <Filter>object-enchant\weapon</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\weapon\apply-magic-hafted.cpp">
+      <Filter>object-enchant\weapon</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5290,6 +5293,9 @@
       <Filter>monster-race</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\object-enchant\weapon\melee-weapon-enchanter.h">
+      <Filter>object-enchant\weapon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\weapon\apply-magic-hafted.h">
       <Filter>object-enchant\weapon</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2433,6 +2433,9 @@
     <ClCompile Include="..\..\src\object-enchant\weapon\apply-magic-arrow.cpp">
       <Filter>object-enchant\weapon</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\object-enchant\weapon\melee-weapon-enchanter.cpp">
+      <Filter>object-enchant\weapon</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5285,6 +5288,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\monster-race\race-wilderness-flags.h">
       <Filter>monster-race</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\object-enchant\weapon\melee-weapon-enchanter.h">
+      <Filter>object-enchant\weapon</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -623,6 +623,7 @@ hengband_SOURCES = \
 	object-enchant/weapon/apply-magic-bow.cpp object-enchant/weapon/apply-magic-bow.h \
 	object-enchant/weapon/apply-magic-digging.cpp object-enchant/weapon/apply-magic-digging.h \
 	object-enchant/weapon/apply-magic-hafted.cpp object-enchant/weapon/apply-magic-hafted.h \
+	object-enchant/weapon/apply-magic-polearm.cpp object-enchant/weapon/apply-magic-polearm.h \
 	object-enchant/weapon/apply-magic-sword.cpp object-enchant/weapon/apply-magic-sword.h \
 	object-enchant/weapon/melee-weapon-enchanter.cpp object-enchant/weapon/melee-weapon-enchanter.h \
 	\

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -622,6 +622,7 @@ hengband_SOURCES = \
 	object-enchant/weapon/apply-magic-arrow.cpp object-enchant/weapon/apply-magic-arrow.h \
 	object-enchant/weapon/apply-magic-bow.cpp object-enchant/weapon/apply-magic-bow.h \
 	object-enchant/weapon/apply-magic-digging.cpp object-enchant/weapon/apply-magic-digging.h \
+	object-enchant/weapon/apply-magic-hafted.cpp object-enchant/weapon/apply-magic-hafted.h \
 	object-enchant/weapon/apply-magic-sword.cpp object-enchant/weapon/apply-magic-sword.h \
 	object-enchant/weapon/melee-weapon-enchanter.cpp object-enchant/weapon/melee-weapon-enchanter.h \
 	\

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -623,6 +623,7 @@ hengband_SOURCES = \
 	object-enchant/weapon/apply-magic-bow.cpp object-enchant/weapon/apply-magic-bow.h \
 	object-enchant/weapon/apply-magic-digging.cpp object-enchant/weapon/apply-magic-digging.h \
 	object-enchant/weapon/apply-magic-sword.cpp object-enchant/weapon/apply-magic-sword.h \
+	object-enchant/weapon/melee-weapon-enchanter.cpp object-enchant/weapon/melee-weapon-enchanter.h \
 	\
 	object-hook/hook-armor.cpp object-hook/hook-armor.h \
 	object-hook/hook-expendable.cpp object-hook/hook-expendable.h \

--- a/src/object-enchant/apply-magic.cpp
+++ b/src/object-enchant/apply-magic.cpp
@@ -34,6 +34,7 @@
 #include "object-enchant/weapon/apply-magic-arrow.h"
 #include "object-enchant/weapon/apply-magic-bow.h"
 #include "object-enchant/weapon/apply-magic-digging.h"
+#include "object-enchant/weapon/apply-magic-hafted.h"
 #include "object-enchant/weapon/apply-magic-sword.h"
 #include "object/object-kind.h"
 #include "player/player-status-flags.h"
@@ -152,6 +153,8 @@ void apply_magic_to_object(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH lev,
         ArrowEnchanter(player_ptr, o_ptr, lev, power).apply_magic();
         break;
     case ItemKindType::HAFTED:
+        HaftedEnchanter(player_ptr, o_ptr, lev, power).apply_magic();
+        break;
     case ItemKindType::POLEARM:
     case ItemKindType::SWORD:
         SwordEnchanter(player_ptr, o_ptr, lev, power).apply_magic();

--- a/src/object-enchant/apply-magic.cpp
+++ b/src/object-enchant/apply-magic.cpp
@@ -35,6 +35,7 @@
 #include "object-enchant/weapon/apply-magic-bow.h"
 #include "object-enchant/weapon/apply-magic-digging.h"
 #include "object-enchant/weapon/apply-magic-hafted.h"
+#include "object-enchant/weapon/apply-magic-polearm.h"
 #include "object-enchant/weapon/apply-magic-sword.h"
 #include "object/object-kind.h"
 #include "player/player-status-flags.h"
@@ -156,6 +157,8 @@ void apply_magic_to_object(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH lev,
         HaftedEnchanter(player_ptr, o_ptr, lev, power).apply_magic();
         break;
     case ItemKindType::POLEARM:
+        PolearmEnchanter(player_ptr, o_ptr, lev, power).apply_magic();
+        break;
     case ItemKindType::SWORD:
         SwordEnchanter(player_ptr, o_ptr, lev, power).apply_magic();
         break;

--- a/src/object-enchant/weapon/abstract-weapon-enchanter.cpp
+++ b/src/object-enchant/weapon/abstract-weapon-enchanter.cpp
@@ -53,10 +53,5 @@ void AbstractWeaponEnchanter::decide_skip()
 {
     if (this->power == 0) {
         this->should_skip = true;
-        return;
     }
-
-    this->should_skip |= (this->o_ptr->tval == ItemKindType::SWORD) && (this->o_ptr->sval == SV_DIAMOND_EDGE);
-    this->should_skip |= (this->o_ptr->tval == ItemKindType::SWORD) && (this->o_ptr->sval == SV_POISON_NEEDLE);
-    this->should_skip |= (this->o_ptr->tval == ItemKindType::POLEARM) && (this->o_ptr->sval == SV_DEATH_SCYTHE);
 }

--- a/src/object-enchant/weapon/abstract-weapon-enchanter.h
+++ b/src/object-enchant/weapon/abstract-weapon-enchanter.h
@@ -15,6 +15,5 @@ protected:
     int power;
     bool should_skip = false;
 
-private:
-    void decide_skip();
+    virtual void decide_skip();
 };

--- a/src/object-enchant/weapon/abstract-weapon-enchanter.h
+++ b/src/object-enchant/weapon/abstract-weapon-enchanter.h
@@ -4,7 +4,7 @@
 #include "system/angband.h"
 
 class ObjectType;
-class AbstractWeaponEnchanter : EnchanterBase {
+class AbstractWeaponEnchanter : public EnchanterBase {
 public:
     virtual ~AbstractWeaponEnchanter() = default;
 

--- a/src/object-enchant/weapon/apply-magic-hafted.cpp
+++ b/src/object-enchant/weapon/apply-magic-hafted.cpp
@@ -1,0 +1,64 @@
+﻿/*!
+ * @brief 鈍器に耐性等の追加効果を付与する処理
+ * @date 2022/03/22
+ * @author Hourier
+ */
+
+#include "object-enchant/weapon/apply-magic-hafted.h"
+#include "floor/floor-base-definitions.h"
+#include "inventory/inventory-slot-types.h"
+#include "object-enchant/object-boost.h"
+#include "system/object-type-definition.h"
+
+/*!
+ * @brief 鈍器強化クラスのコンストラクタ
+ * @param player_ptr プレイヤーへの参照ポインタ
+ * @param o_ptr 強化を与えたいオブジェクトの構造体参照ポインタ
+ * @param level 生成基準階
+ * @param power 生成ランク
+ */
+HaftedEnchanter::HaftedEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power)
+    : MeleeWeaponEnchanter(player_ptr, o_ptr, level, power)
+{
+}
+
+void HaftedEnchanter::give_ego_index()
+{
+    while (true) {
+        this->o_ptr->ego_idx = get_random_ego(INVEN_MAIN_HAND, true);
+        if (this->o_ptr->ego_idx == EgoType::SHARPNESS) {
+            continue;
+        }
+
+        break;
+    }
+
+    switch (this->o_ptr->ego_idx) {
+    case EgoType::EARTHQUAKES:
+        if (one_in_(3) && (this->level > 60)) {
+            this->o_ptr->art_flags.set(TR_BLOWS);
+        } else {
+            this->o_ptr->pval = static_cast<short>(m_bonus(3, this->level));
+        }
+
+        break;
+    default:
+        break;
+    }
+}
+
+void HaftedEnchanter::give_cursed()
+{
+    if (randint0(MAX_DEPTH) >= this->level) {
+        return;
+    }
+
+    while (true) {
+        this->o_ptr->ego_idx = get_random_ego(INVEN_MAIN_HAND, false);
+        if (this->o_ptr->ego_idx == EgoType::WEIRD) {
+            continue;
+        }
+
+        return;
+    }
+}

--- a/src/object-enchant/weapon/apply-magic-hafted.cpp
+++ b/src/object-enchant/weapon/apply-magic-hafted.cpp
@@ -8,6 +8,7 @@
 #include "floor/floor-base-definitions.h"
 #include "inventory/inventory-slot-types.h"
 #include "object-enchant/object-boost.h"
+#include "sv-definition/sv-weapon-types.h"
 #include "system/object-type-definition.h"
 
 /*!
@@ -20,6 +21,12 @@
 HaftedEnchanter::HaftedEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power)
     : MeleeWeaponEnchanter(player_ptr, o_ptr, level, power)
 {
+}
+
+void HaftedEnchanter::decide_skip()
+{
+    AbstractWeaponEnchanter::decide_skip();
+    this->should_skip |= this->o_ptr->sval == SV_DEATH_SCYTHE;
 }
 
 void HaftedEnchanter::give_ego_index()

--- a/src/object-enchant/weapon/apply-magic-hafted.h
+++ b/src/object-enchant/weapon/apply-magic-hafted.h
@@ -1,0 +1,17 @@
+﻿#pragma once
+
+#include "object-enchant/weapon/melee-weapon-enchanter.h"
+#include "system/angband.h"
+
+class ObjectType;
+class PlayerType;
+class HaftedEnchanter : public MeleeWeaponEnchanter {
+public:
+    HaftedEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power);
+
+protected:
+    void sval_enchant() override{};
+    void give_ego_index() override;
+    void give_high_ego_index() override{};
+    void give_cursed() override;
+};

--- a/src/object-enchant/weapon/apply-magic-hafted.h
+++ b/src/object-enchant/weapon/apply-magic-hafted.h
@@ -10,6 +10,7 @@ public:
     HaftedEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power);
 
 protected:
+    void decide_skip() override;
     void sval_enchant() override{};
     void give_ego_index() override;
     void give_high_ego_index() override{};

--- a/src/object-enchant/weapon/apply-magic-polearm.cpp
+++ b/src/object-enchant/weapon/apply-magic-polearm.cpp
@@ -7,6 +7,7 @@
 #include "object-enchant/weapon/apply-magic-polearm.h"
 #include "floor/floor-base-definitions.h"
 #include "inventory/inventory-slot-types.h"
+#include "sv-definition/sv-weapon-types.h"
 #include "system/object-type-definition.h"
 
 /*!
@@ -19,6 +20,12 @@
 PolearmEnchanter::PolearmEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power)
     : MeleeWeaponEnchanter(player_ptr, o_ptr, level, power)
 {
+}
+
+void PolearmEnchanter::decide_skip()
+{
+    AbstractWeaponEnchanter::decide_skip();
+    this->should_skip |= this->o_ptr->sval == SV_DEATH_SCYTHE;
 }
 
 void PolearmEnchanter::give_ego_index()

--- a/src/object-enchant/weapon/apply-magic-polearm.cpp
+++ b/src/object-enchant/weapon/apply-magic-polearm.cpp
@@ -1,0 +1,50 @@
+﻿/*!
+ * @brief 長柄/斧に耐性等の追加効果を付与する処理
+ * @date 2022/03/22
+ * @author Hourier
+ */
+
+#include "object-enchant/weapon/apply-magic-polearm.h"
+#include "floor/floor-base-definitions.h"
+#include "inventory/inventory-slot-types.h"
+#include "system/object-type-definition.h"
+
+/*!
+ * @brief 長柄/斧強化クラスのコンストラクタ
+ * @param player_ptr プレイヤーへの参照ポインタ
+ * @param o_ptr 強化を与えたいオブジェクトの構造体参照ポインタ
+ * @param level 生成基準階
+ * @param power 生成ランク
+ */
+PolearmEnchanter::PolearmEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power)
+    : MeleeWeaponEnchanter(player_ptr, o_ptr, level, power)
+{
+}
+
+void PolearmEnchanter::give_ego_index()
+{
+    while (true) {
+        this->o_ptr->ego_idx = get_random_ego(INVEN_MAIN_HAND, true);
+        if ((this->o_ptr->ego_idx == EgoType::SHARPNESS) || (this->o_ptr->ego_idx == EgoType::EARTHQUAKES)) {
+            continue;
+        }
+
+        break;
+    }
+}
+
+void PolearmEnchanter::give_cursed()
+{
+    if (randint0(MAX_DEPTH) >= this->level) {
+        return;
+    }
+
+    while (true) {
+        this->o_ptr->ego_idx = get_random_ego(INVEN_MAIN_HAND, false);
+        if (this->o_ptr->ego_idx == EgoType::WEIRD) {
+            continue;
+        }
+
+        return;
+    }
+}

--- a/src/object-enchant/weapon/apply-magic-polearm.h
+++ b/src/object-enchant/weapon/apply-magic-polearm.h
@@ -10,6 +10,7 @@ public:
     PolearmEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power);
 
 protected:
+    void decide_skip() override;
     void sval_enchant() override{};
     void give_ego_index() override;
     void give_high_ego_index() override{};

--- a/src/object-enchant/weapon/apply-magic-polearm.h
+++ b/src/object-enchant/weapon/apply-magic-polearm.h
@@ -1,0 +1,17 @@
+﻿#pragma once
+
+#include "object-enchant/weapon/melee-weapon-enchanter.h"
+#include "system/angband.h"
+
+class ObjectType;
+class PlayerType;
+class PolearmEnchanter : public MeleeWeaponEnchanter {
+public:
+    PolearmEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power);
+
+protected:
+    void sval_enchant() override{};
+    void give_ego_index() override;
+    void give_high_ego_index() override{};
+    void give_cursed() override;
+};

--- a/src/object-enchant/weapon/apply-magic-sword.cpp
+++ b/src/object-enchant/weapon/apply-magic-sword.cpp
@@ -24,6 +24,13 @@ SwordEnchanter::SwordEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH 
 {
 }
 
+void SwordEnchanter::decide_skip()
+{
+    AbstractWeaponEnchanter::decide_skip();
+    this->should_skip |= this->o_ptr->sval == SV_DIAMOND_EDGE;
+    this->should_skip |= this->o_ptr->sval == SV_POISON_NEEDLE;
+}
+
 void SwordEnchanter::give_ego_index()
 {
     while (true) {

--- a/src/object-enchant/weapon/apply-magic-sword.cpp
+++ b/src/object-enchant/weapon/apply-magic-sword.cpp
@@ -24,29 +24,8 @@
  * @param power 生成ランク
  */
 SwordEnchanter::SwordEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power)
-    : AbstractWeaponEnchanter(o_ptr, level, power)
-    , player_ptr(player_ptr)
+    : MeleeWeaponEnchanter(player_ptr, o_ptr, level, power)
 {
-}
-
-/*!
- * @brief 剣・鈍器・戦斧系オブジェクトに生成ランクごとの強化を与えるサブルーチン
- * @details power > 2はデバッグ専用.
- */
-void SwordEnchanter::apply_magic()
-{
-    if (this->should_skip) {
-        return;
-    }
-
-    if (this->power > 1) {
-        this->strengthen();
-        return;
-    }
-
-    if (this->power < -1) {
-        this->give_cursed();
-    }
 }
 
 void SwordEnchanter::give_ego_index()
@@ -105,26 +84,5 @@ void SwordEnchanter::give_cursed()
         }
 
         continue;
-    }
-}
-
-void SwordEnchanter::strengthen()
-{
-    if ((this->power > 2) || one_in_(40)) {
-        become_random_artifact(this->player_ptr, this->o_ptr, false);
-        return;
-    }
-
-    this->give_ego_index();
-    if (this->o_ptr->art_name > 0) {
-        return;
-    }
-
-    while (one_in_(10 * this->o_ptr->dd * this->o_ptr->ds)) {
-        this->o_ptr->dd++;
-    }
-
-    if (this->o_ptr->dd > 9) {
-        this->o_ptr->dd = 9;
     }
 }

--- a/src/object-enchant/weapon/apply-magic-sword.cpp
+++ b/src/object-enchant/weapon/apply-magic-sword.cpp
@@ -1,23 +1,19 @@
 ﻿/*!
- * @brief 剣・鈍器・戦斧に耐性等の追加効果を付与する処理
- * @date 2022/03/11
+ * @brief 剣に耐性等の追加効果を付与する処理
+ * @date 2022/03/22
  * @author Hourier
- * @details give_ego_index() を中心に、剣と鈍器はまだ分ける余地はあるが、これ以上分割しても煩雑なだけになりそうなので保留.
  */
 
 #include "object-enchant/weapon/apply-magic-sword.h"
-#include "artifact/random-art-generator.h"
 #include "floor/floor-base-definitions.h"
 #include "inventory/inventory-slot-types.h"
 #include "object-enchant/object-boost.h"
-#include "object/tval-types.h"
 #include "sv-definition/sv-weapon-types.h"
 #include "system/object-type-definition.h"
-#include "system/player-type-definition.h"
 #include "view/display-messages.h"
 
 /*!
- * @brief 剣・鈍器・戦斧強化クラスのコンストラクタ
+ * @brief 剣強化クラスのコンストラクタ
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param o_ptr 強化を与えたいオブジェクトの構造体参照ポインタ
  * @param level 生成基準階
@@ -32,11 +28,7 @@ void SwordEnchanter::give_ego_index()
 {
     while (true) {
         this->o_ptr->ego_idx = get_random_ego(INVEN_MAIN_HAND, true);
-        if (this->o_ptr->ego_idx == EgoType::SHARPNESS && this->o_ptr->tval != ItemKindType::SWORD) {
-            continue;
-        }
-
-        if (this->o_ptr->ego_idx == EgoType::EARTHQUAKES && this->o_ptr->tval != ItemKindType::HAFTED) {
+        if (this->o_ptr->ego_idx == EgoType::EARTHQUAKES) {
             continue;
         }
 
@@ -46,14 +38,6 @@ void SwordEnchanter::give_ego_index()
     switch (this->o_ptr->ego_idx) {
     case EgoType::SHARPNESS:
         this->o_ptr->pval = static_cast<short>(m_bonus(5, this->level) + 1);
-        break;
-    case EgoType::EARTHQUAKES:
-        if (one_in_(3) && (this->level > 60)) {
-            this->o_ptr->art_flags.set(TR_BLOWS);
-        } else {
-            this->o_ptr->pval = static_cast<short>(m_bonus(3, this->level));
-        }
-
         break;
     default:
         break;
@@ -69,12 +53,8 @@ void SwordEnchanter::give_cursed()
     auto n = 0;
     while (true) {
         this->o_ptr->ego_idx = get_random_ego(INVEN_MAIN_HAND, false);
-        if ((this->o_ptr->ego_idx == EgoType::WEIRD) && (this->o_ptr->tval != ItemKindType::SWORD)) {
-            continue;
-        }
-
         const auto *e_ptr = &e_info[this->o_ptr->ego_idx];
-        if ((this->o_ptr->tval != ItemKindType::SWORD) || (this->o_ptr->sval != SV_HAYABUSA) || (e_ptr->max_pval >= 0)) {
+        if ((this->o_ptr->sval != SV_HAYABUSA) || (e_ptr->max_pval >= 0)) {
             return;
         }
 

--- a/src/object-enchant/weapon/apply-magic-sword.h
+++ b/src/object-enchant/weapon/apply-magic-sword.h
@@ -1,23 +1,17 @@
 ﻿#pragma once
 
-#include "object-enchant/weapon/abstract-weapon-enchanter.h"
+#include "object-enchant/weapon/melee-weapon-enchanter.h"
 #include "system/angband.h"
 
 class ObjectType;
 class PlayerType;
-class SwordEnchanter : AbstractWeaponEnchanter {
+class SwordEnchanter : public MeleeWeaponEnchanter {
 public:
     SwordEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power);
-    void apply_magic() override;
 
 protected:
     void sval_enchant() override{};
     void give_ego_index() override;
     void give_high_ego_index() override{};
     void give_cursed() override;
-
-private:
-    PlayerType *player_ptr;
-
-    void strengthen();
 };

--- a/src/object-enchant/weapon/apply-magic-sword.h
+++ b/src/object-enchant/weapon/apply-magic-sword.h
@@ -10,6 +10,7 @@ public:
     SwordEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power);
 
 protected:
+    void decide_skip() override;
     void sval_enchant() override{};
     void give_ego_index() override;
     void give_high_ego_index() override{};

--- a/src/object-enchant/weapon/melee-weapon-enchanter.cpp
+++ b/src/object-enchant/weapon/melee-weapon-enchanter.cpp
@@ -1,0 +1,13 @@
+﻿/*!
+ * @brief 剣・鈍器・戦斧武器に耐性等の追加効果を付与する処理
+ * @date 2022/03/22
+ * @author Hourier
+ */
+
+#include "object-enchant/weapon/melee-weapon-enchanter.h"
+
+MeleeWeaponEnchanter::MeleeWeaponEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power)
+    : AbstractWeaponEnchanter(o_ptr, level, power)
+    , player_ptr(player_ptr)
+{
+}

--- a/src/object-enchant/weapon/melee-weapon-enchanter.cpp
+++ b/src/object-enchant/weapon/melee-weapon-enchanter.cpp
@@ -1,13 +1,60 @@
 ﻿/*!
- * @brief 剣・鈍器・戦斧武器に耐性等の追加効果を付与する処理
+ * @brief 剣・鈍器・長柄/斧武器に耐性等の追加効果を付与する処理
  * @date 2022/03/22
  * @author Hourier
  */
 
 #include "object-enchant/weapon/melee-weapon-enchanter.h"
+#include "artifact/random-art-generator.h"
+#include "system/object-type-definition.h"
 
 MeleeWeaponEnchanter::MeleeWeaponEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power)
     : AbstractWeaponEnchanter(o_ptr, level, power)
     , player_ptr(player_ptr)
 {
+}
+
+/*!
+ * @brief 打撃系オブジェクトに生成ランクごとの強化を与えるサブルーチン
+ * @details power > 2はデバッグ専用.
+ */
+void MeleeWeaponEnchanter::apply_magic()
+{
+    if (this->should_skip) {
+        return;
+    }
+
+    if (this->power > 1) {
+        this->strengthen();
+        return;
+    }
+
+    if (this->power < -1) {
+        this->give_cursed();
+    }
+}
+
+/*!
+ * @brief アーティファクト生成・ダイス強化処理
+ * @details power > 2はデバッグ専用.
+ */
+void MeleeWeaponEnchanter::strengthen()
+{
+    if ((this->power > 2) || one_in_(40)) {
+        become_random_artifact(this->player_ptr, this->o_ptr, false);
+        return;
+    }
+
+    this->give_ego_index();
+    if (this->o_ptr->art_name > 0) {
+        return;
+    }
+
+    while (one_in_(10 * this->o_ptr->dd * this->o_ptr->ds)) {
+        this->o_ptr->dd++;
+    }
+
+    if (this->o_ptr->dd > 9) {
+        this->o_ptr->dd = 9;
+    }
 }

--- a/src/object-enchant/weapon/melee-weapon-enchanter.h
+++ b/src/object-enchant/weapon/melee-weapon-enchanter.h
@@ -5,21 +5,17 @@
 
 class ObjectType;
 class PlayerType;
-class MeleeWeaponEnchanter : AbstractWeaponEnchanter {
+class MeleeWeaponEnchanter : public AbstractWeaponEnchanter {
 public:
     virtual ~MeleeWeaponEnchanter() = default;
 
-    void apply_magic() override{};
+    void apply_magic() override;
 
 protected:
     MeleeWeaponEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power);
 
-    void sval_enchant() override{};
-    void give_ego_index() override{};
-    void give_high_ego_index() override{};
-    void give_cursed() override{};
-    void strengthen(){};
+    PlayerType *player_ptr;
 
 private:
-    PlayerType *player_ptr;
+    void strengthen();
 };

--- a/src/object-enchant/weapon/melee-weapon-enchanter.h
+++ b/src/object-enchant/weapon/melee-weapon-enchanter.h
@@ -1,0 +1,25 @@
+﻿#pragma once
+
+#include "object-enchant/weapon/abstract-weapon-enchanter.h"
+#include "system/angband.h"
+
+class ObjectType;
+class PlayerType;
+class MeleeWeaponEnchanter : AbstractWeaponEnchanter {
+public:
+    virtual ~MeleeWeaponEnchanter() = default;
+
+    void apply_magic() override{};
+
+protected:
+    MeleeWeaponEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power);
+
+    void sval_enchant() override{};
+    void give_ego_index() override{};
+    void give_high_ego_index() override{};
+    void give_cursed() override{};
+    void strengthen(){};
+
+private:
+    PlayerType *player_ptr;
+};


### PR DESCRIPTION
SwordEnchanter は名ばかりで、実態は鈍器と戦斧への強化/弱化処理も含まれていました
これを各武器に分離しました
剣・鈍器・戦斧の全てで狙った種類のエゴが生成されることは確認済です
なお基底メソッドを呼んでいてちょっと設計が悪い部分もありますが、これは長期的な課題として後日対応するかもしれません
ご確認下さい