### PR TITLE
イテレータ範囲の要素をシャッフルする関数 rand_shuffle を実装

### DIFF
--- a/src/flavor/object-flavor.cpp
+++ b/src/flavor/object-flavor.cpp
@@ -41,6 +41,7 @@
 #include "util/quarks.h"
 #include "util/string-processor.h"
 #include "world/world.h"
+#include <functional>
 #include <utility>
 
 /*!
@@ -188,7 +189,7 @@ void get_table_sindarin(char *out_string)
  */
 static void shuffle_flavors(ItemKindType tval)
 {
-    std::vector<KIND_OBJECT_IDX> k_idx_list;
+    std::vector<std::reference_wrapper<IDX>> flavor_idx_ref_list;
     for (const auto &k_ref : k_info) {
         if (k_ref.tval != tval) {
             continue;
@@ -202,14 +203,10 @@ static void shuffle_flavors(ItemKindType tval)
             continue;
         }
 
-        k_idx_list.push_back(k_ref.idx);
+        flavor_idx_ref_list.push_back(k_info[k_ref.idx].flavor);
     }
 
-    for (auto i = k_idx_list.size() - 1; i > 0; --i) {
-        object_kind *k1_ptr = &k_info[k_idx_list[i]];
-        object_kind *k2_ptr = &k_info[k_idx_list[randint0(i + 1)]];
-        std::swap(k1_ptr->flavor, k2_ptr->flavor);
-    }
+    rand_shuffle(flavor_idx_ref_list.begin(), flavor_idx_ref_list.end());
 }
 
 /*!

--- a/src/market/poker.cpp
+++ b/src/market/poker.cpp
@@ -4,6 +4,8 @@
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 #include "util/int-char-converter.h"
+#include <iterator>
+#include <numeric>
 
 /*!
  * ポーカーの現在の手札ID
@@ -45,18 +47,10 @@ static int cards[5];
  * @brief ポーカーの山札を切る
  * @param deck デッキの配列
  */
-static void reset_deck(int deck[])
+static void reset_deck(int (&deck)[53])
 {
-    for (int i = 0; i < 53; i++) {
-        deck[i] = i;
-    }
-
-    for (int i = 0; i < 53; i++) {
-        int tmp1 = randint0(53 - i) + i;
-        int tmp2 = deck[i];
-        deck[i] = deck[tmp1];
-        deck[tmp1] = tmp2;
-    }
+    std::iota(std::begin(deck), std::end(deck), 0);
+    rand_shuffle(std::begin(deck), std::end(deck));
 }
 
 /*!


### PR DESCRIPTION
Resolves #2439
詳細はコミットログをご参照ください。