### PR TITLE
[Fix] 充填魔力吸収打撃でpvalが負値になる

### DIFF
--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -231,12 +231,13 @@ bool process_un_power(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
     PARAMETER_VALUE pval = kind_ptr->pval;
     DEPTH level = monap_ptr->rlev;
     int drain = is_magic_mastery ? std::min<short>(pval, pval * level / 400 + pval * randint1(level) / 400) : pval;
+    drain = std::min<short>(drain, monap_ptr->o_ptr->pval);
     if (drain <= 0) {
         return false;
     }
 
     msg_print(_("ザックからエネルギーが吸い取られた！", "Energy was drained from your pack!"));
-    if (is_magic_mastery) {
+    if (is_magic_mastery && (drain != monap_ptr->o_ptr->pval)) {
         msg_print(_("しかし、あなたの魔法を操る力がその一部を取り返した！", "However, your skill of magic mastery got back the part of energy!"));
     }
 


### PR DESCRIPTION
Issue #2454の原因。has_magic_mastery()がtrueのケースで吸収量が対象魔法道具の現在値を越えることがある。
現在値を越えないように修正。
ついでに魔法道具を空にされたとき「あなたの魔法を操る力がその一部を取り返した」メッセージが出るのは不自然なので修正。