### PR TITLE
clang: include <unordered_map> in mspell/mspell-data.h to avoid …

### DIFF
--- a/src/mspell/mspell-data.h
+++ b/src/mspell/mspell-data.h
@@ -4,6 +4,7 @@
 #include "system/angband.h"
 #include <functional>
 #include <type_traits>
+#include <unordered_map>
 
 enum class AttributeType;
 struct mspell_cast_msg_blind;


### PR DESCRIPTION
…compiler errors when compiled without precompiled headers.  Resolves https://github.com/hengband/hengband/issues/2465 .