### PR TITLE
English:  change some messages, mostly related to the elementalists

### DIFF
--- a/src/birth/history.cpp
+++ b/src/birth/history.cpp
@@ -1517,8 +1517,8 @@ hist_type bg[MAX_BACKGROUNDS] = {
     { "あなたの下半身は二股の尾で、", 60, 172, 173, 50 },
     { "あなたの下半身は陸上の種族とあまり変わりなく、", 100, 172, 173, 50 },
 #else
-    { "Your lower body is a tail, ", 50, 172, 173, 50 },
-    { "Your lower body are two tails, ", 60, 172, 173, 50 },
+    { "Your lower body ends in a tail, ", 50, 172, 173, 50 },
+    { "Your lower body ends in two tails, ", 60, 172, 173, 50 },
     { "Your lower body is not much different from a land race, ", 100, 172, 173, 50 },
 #endif
 

--- a/src/cmd-action/cmd-racial.cpp
+++ b/src/cmd-action/cmd-racial.cpp
@@ -67,7 +67,7 @@ static void racial_power_display_list(PlayerType *player_ptr, rc_type *rc_ptr)
     char dummy[256];
     strcpy(dummy, "");
 
-    prt(_("                                   Lv   MP 失率 効果", "                               Lv   MP Fail Effect"), 1, x);
+    prt(_("                                   Lv   MP 失率 効果", "                                   Lv   MP Fail Effect"), 1, x);
 
     auto y = 0;
     for (; y < RC_PAGE_SIZE; y++) {

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -713,7 +713,7 @@ bool get_element_power(PlayerType *player_ptr, SPELL_IDX *sn, bool only_browse)
         }
     }
 
-    concptr p = _("元素魔法", "magic");
+    concptr p = _("元素魔法", "power");
     flag = false;
     redraw = false;
 

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -892,7 +892,7 @@ static bool try_cast_element_spell(PlayerType *player_ptr, SPELL_IDX spell_idx, 
         flush();
     }
 
-    msg_format(_("魔力の集中に失敗した！", "You failed to concentrate hard enough for Mana!"));
+    msg_format(_("魔力の集中に失敗した！", "You failed to focus the elemental power!"));
     sound(SOUND_FAIL);
 
     if (randint1(100) < chance / 2) {

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -789,7 +789,7 @@ bool get_element_power(PlayerType *player_ptr, SPELL_IDX *sn, bool only_browse)
 
                 prt("", y, x);
                 put_str(_("名前", "Name"), y, x + 5);
-                put_str(_("Lv   MP   失率 効果", "Lv   MP   Fail Info"), y, x + 35);
+                put_str(_("Lv   MP   失率 効果", "Lv   MP Fail Info"), y, x + 35);
                 for (i = 0; i < spell_max; i++) {
                     elem = get_elemental_elem(player_ptr, i);
                     spell = get_elemental_info(player_ptr, i);


### PR DESCRIPTION
- Align labels to the columns in the racial and elementalist power menus.
- Reword some entries for a merfolk's background - avoids a subject-verb disagreement.
- Change failure message when invoking an elementalist's power.
- Use "power" rather than "magic" in the elementalist's power menu.