### PR TITLE
[Fix] 油つぼからランタンの燃料補給ができなくなる

### DIFF
--- a/src/load/old/item-loader-savefile50.cpp
+++ b/src/load/old/item-loader-savefile50.cpp
@@ -143,7 +143,7 @@ void ItemLoader50::rd_item(ObjectType *o_ptr)
         o_ptr->captured_monster_current_hp = any_bits(flags, SaveDataItemFlagType::CAPTURED_MONSTER_CURRENT_HP) ? rd_s16b() : 0;
     }
 
-    if (o_ptr->is_fuel()) {
+    if (o_ptr->is_fuel() && (o_ptr->tval == ItemKindType::LITE)) {
         const auto fuel_max = o_ptr->sval == SV_LITE_TORCH ? FUEL_TORCH : FUEL_LAMP;
         if (o_ptr->fuel < 0 || o_ptr->fuel > fuel_max) {
             o_ptr->fuel = 0;


### PR DESCRIPTION
Resolves #2468 

#2431 で負のオーバーフローにより残りターン数が異常になった光源をセーブファイルからロ
ードした時に強制的に残りターン数0にするようにしたが、ObjectType::is_fuel() のみを
見ているため油つぼも対象になっており、油つぼの補給ターン数も0になってしまっている。
ObjectType::is_fuel() に加えて ItemKindType::LITE であるかどうかもチェックする
ようにする。