### PR TITLE
強化も弱化もしない装備品 (毒針・ダイヤモンドエッジ・死の大鎌)が判定をすり抜けて強化/弱化する不具合を解消した

### DIFF
--- a/src/object-enchant/weapon/abstract-weapon-enchanter.cpp
+++ b/src/object-enchant/weapon/abstract-weapon-enchanter.cpp
@@ -18,17 +18,15 @@ void AbstractWeaponEnchanter::decide_skip()
     }
 }
 
-void AbstractWeaponEnchanter::apply_magic()
+/*!
+ * @brief 武器に殺戮修正を付与する
+ */
+void AbstractWeaponEnchanter::give_killing_bonus()
 {
     if (this->should_skip) {
         return;
     }
 
-    this->prepare_application();
-}
-
-void AbstractWeaponEnchanter::prepare_application()
-{
     auto tohit1 = static_cast<short>(randint1(5) + m_bonus(5, this->level));
     auto todam1 = static_cast<short>(randint1(5) + m_bonus(5, this->level));
     auto tohit2 = static_cast<short>(m_bonus(10, this->level));

--- a/src/object-enchant/weapon/abstract-weapon-enchanter.cpp
+++ b/src/object-enchant/weapon/abstract-weapon-enchanter.cpp
@@ -9,11 +9,26 @@ AbstractWeaponEnchanter::AbstractWeaponEnchanter(ObjectType *o_ptr, DEPTH level,
     , level(level)
     , power(power)
 {
-    this->decide_skip();
+}
+
+void AbstractWeaponEnchanter::decide_skip()
+{
+    if (this->power == 0) {
+        this->should_skip = true;
+    }
+}
+
+void AbstractWeaponEnchanter::apply_magic()
+{
     if (this->should_skip) {
         return;
     }
 
+    this->prepare_application();
+}
+
+void AbstractWeaponEnchanter::prepare_application()
+{
     auto tohit1 = static_cast<short>(randint1(5) + m_bonus(5, this->level));
     auto todam1 = static_cast<short>(randint1(5) + m_bonus(5, this->level));
     auto tohit2 = static_cast<short>(m_bonus(10, this->level));
@@ -46,12 +61,5 @@ AbstractWeaponEnchanter::AbstractWeaponEnchanter(ObjectType *o_ptr, DEPTH level,
         if (this->o_ptr->to_h + this->o_ptr->to_d < 0) {
             this->o_ptr->curse_flags.set(CurseTraitType::CURSED);
         }
-    }
-}
-
-void AbstractWeaponEnchanter::decide_skip()
-{
-    if (this->power == 0) {
-        this->should_skip = true;
     }
 }

--- a/src/object-enchant/weapon/abstract-weapon-enchanter.h
+++ b/src/object-enchant/weapon/abstract-weapon-enchanter.h
@@ -15,9 +15,6 @@ protected:
     int power;
     bool should_skip = false;
 
-    virtual void apply_magic();
+    void give_killing_bonus();
     virtual void decide_skip();
-
-private:
-    void prepare_application();
 };

--- a/src/object-enchant/weapon/abstract-weapon-enchanter.h
+++ b/src/object-enchant/weapon/abstract-weapon-enchanter.h
@@ -15,5 +15,9 @@ protected:
     int power;
     bool should_skip = false;
 
+    virtual void apply_magic();
     virtual void decide_skip();
+
+private:
+    void prepare_application();
 };

--- a/src/object-enchant/weapon/apply-magic-arrow.cpp
+++ b/src/object-enchant/weapon/apply-magic-arrow.cpp
@@ -35,6 +35,7 @@ void ArrowEnchanter::apply_magic()
         return;
     }
 
+    this->give_killing_bonus();
     if (this->power > 1) {
         if (this->power > 2) {
             become_random_artifact(this->player_ptr, this->o_ptr, false);

--- a/src/object-enchant/weapon/apply-magic-arrow.cpp
+++ b/src/object-enchant/weapon/apply-magic-arrow.cpp
@@ -30,6 +30,7 @@ ArrowEnchanter::ArrowEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH 
  */
 void ArrowEnchanter::apply_magic()
 {
+    this->decide_skip();
     if (this->should_skip) {
         return;
     }

--- a/src/object-enchant/weapon/apply-magic-bow.cpp
+++ b/src/object-enchant/weapon/apply-magic-bow.cpp
@@ -29,6 +29,7 @@ BowEnchanter::BowEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH leve
  */
 void BowEnchanter::apply_magic()
 {
+    this->decide_skip();
     if (this->should_skip) {
         return;
     }

--- a/src/object-enchant/weapon/apply-magic-bow.cpp
+++ b/src/object-enchant/weapon/apply-magic-bow.cpp
@@ -34,6 +34,7 @@ void BowEnchanter::apply_magic()
         return;
     }
 
+    this->give_killing_bonus();
     if (this->power > 1) {
         if ((this->power > 2) || one_in_(20)) {
             become_random_artifact(this->player_ptr, this->o_ptr, false);

--- a/src/object-enchant/weapon/apply-magic-digging.cpp
+++ b/src/object-enchant/weapon/apply-magic-digging.cpp
@@ -28,6 +28,7 @@ DiggingEnchanter::DiggingEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DE
  */
 void DiggingEnchanter::apply_magic()
 {
+    this->decide_skip();
     if (this->should_skip) {
         return;
     }

--- a/src/object-enchant/weapon/apply-magic-digging.cpp
+++ b/src/object-enchant/weapon/apply-magic-digging.cpp
@@ -33,6 +33,7 @@ void DiggingEnchanter::apply_magic()
         return;
     }
 
+    this->give_killing_bonus();
     if (this->power > 1) {
         if ((this->power > 2) || one_in_(30)) {
             become_random_artifact(this->player_ptr, this->o_ptr, false);

--- a/src/object-enchant/weapon/apply-magic-hafted.cpp
+++ b/src/object-enchant/weapon/apply-magic-hafted.cpp
@@ -23,12 +23,6 @@ HaftedEnchanter::HaftedEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPT
 {
 }
 
-void HaftedEnchanter::decide_skip()
-{
-    AbstractWeaponEnchanter::decide_skip();
-    this->should_skip |= this->o_ptr->sval == SV_DEATH_SCYTHE;
-}
-
 void HaftedEnchanter::give_ego_index()
 {
     while (true) {

--- a/src/object-enchant/weapon/apply-magic-hafted.cpp
+++ b/src/object-enchant/weapon/apply-magic-hafted.cpp
@@ -23,6 +23,12 @@ HaftedEnchanter::HaftedEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPT
 {
 }
 
+void HaftedEnchanter::apply_magic()
+{
+    this->decide_skip();
+    MeleeWeaponEnchanter::apply_magic();
+}
+
 void HaftedEnchanter::give_ego_index()
 {
     while (true) {

--- a/src/object-enchant/weapon/apply-magic-hafted.h
+++ b/src/object-enchant/weapon/apply-magic-hafted.h
@@ -10,7 +10,6 @@ public:
     HaftedEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power);
 
 protected:
-    void decide_skip() override;
     void sval_enchant() override{};
     void give_ego_index() override;
     void give_high_ego_index() override{};

--- a/src/object-enchant/weapon/apply-magic-hafted.h
+++ b/src/object-enchant/weapon/apply-magic-hafted.h
@@ -9,6 +9,8 @@ class HaftedEnchanter : public MeleeWeaponEnchanter {
 public:
     HaftedEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power);
 
+    void apply_magic() override;
+
 protected:
     void sval_enchant() override{};
     void give_ego_index() override;

--- a/src/object-enchant/weapon/apply-magic-polearm.cpp
+++ b/src/object-enchant/weapon/apply-magic-polearm.cpp
@@ -22,6 +22,12 @@ PolearmEnchanter::PolearmEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DE
 {
 }
 
+void PolearmEnchanter::apply_magic()
+{
+    this->decide_skip();
+    MeleeWeaponEnchanter::apply_magic();
+}
+
 void PolearmEnchanter::decide_skip()
 {
     AbstractWeaponEnchanter::decide_skip();

--- a/src/object-enchant/weapon/apply-magic-polearm.h
+++ b/src/object-enchant/weapon/apply-magic-polearm.h
@@ -9,6 +9,8 @@ class PolearmEnchanter : public MeleeWeaponEnchanter {
 public:
     PolearmEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power);
 
+    void apply_magic() override;
+
 protected:
     void decide_skip() override;
     void sval_enchant() override{};

--- a/src/object-enchant/weapon/apply-magic-sword.cpp
+++ b/src/object-enchant/weapon/apply-magic-sword.cpp
@@ -27,8 +27,22 @@ SwordEnchanter::SwordEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH 
 void SwordEnchanter::decide_skip()
 {
     AbstractWeaponEnchanter::decide_skip();
-    this->should_skip |= this->o_ptr->sval == SV_DIAMOND_EDGE;
     this->should_skip |= this->o_ptr->sval == SV_POISON_NEEDLE;
+}
+
+void SwordEnchanter::apply_magic()
+{
+    this->decide_skip();
+    if (this->should_skip) {
+        return;
+    }
+
+    this->give_killing_bonus();
+    if (this->o_ptr->sval == SV_DIAMOND_EDGE) {
+        return;
+    }
+
+    MeleeWeaponEnchanter::apply_magic();
 }
 
 void SwordEnchanter::give_ego_index()

--- a/src/object-enchant/weapon/apply-magic-sword.h
+++ b/src/object-enchant/weapon/apply-magic-sword.h
@@ -9,6 +9,8 @@ class SwordEnchanter : public MeleeWeaponEnchanter {
 public:
     SwordEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPTH level, int power);
 
+    void apply_magic() override;
+
 protected:
     void decide_skip() override;
     void sval_enchant() override{};

--- a/src/object-enchant/weapon/melee-weapon-enchanter.cpp
+++ b/src/object-enchant/weapon/melee-weapon-enchanter.cpp
@@ -20,6 +20,8 @@ MeleeWeaponEnchanter::MeleeWeaponEnchanter(PlayerType *player_ptr, ObjectType *o
  */
 void MeleeWeaponEnchanter::apply_magic()
 {
+    this->decide_skip();
+    AbstractWeaponEnchanter::apply_magic();
     if (this->should_skip) {
         return;
     }

--- a/src/object-enchant/weapon/melee-weapon-enchanter.cpp
+++ b/src/object-enchant/weapon/melee-weapon-enchanter.cpp
@@ -20,8 +20,6 @@ MeleeWeaponEnchanter::MeleeWeaponEnchanter(PlayerType *player_ptr, ObjectType *o
  */
 void MeleeWeaponEnchanter::apply_magic()
 {
-    this->decide_skip();
-    AbstractWeaponEnchanter::apply_magic();
     if (this->should_skip) {
         return;
     }

--- a/src/object-enchant/weapon/melee-weapon-enchanter.h
+++ b/src/object-enchant/weapon/melee-weapon-enchanter.h
@@ -16,6 +16,8 @@ protected:
 
     PlayerType *player_ptr;
 
+    void prepare_magic_application();
+
 private:
     void strengthen();
 };


### PR DESCRIPTION
掲題の通りです
詳細は以下の通りです
ご確認下さい

* C++では派生クラスのコンストラクタで初期化する最中に基底クラスのメソッドを呼ばれた場合、基底クラスのメソッドが呼ばれるが、派生クラスのオーバーライドメソッドが呼ばれると勘違いしていた
* 上記を解消するため、以下の対策を行った
  * AbstractWeaponEnchanterのコンストラクタではフィールド変数への代入以外は何もしないようにした
  * AbstractWeaponEnchanter::apply\_magic() を新たに定義し、必ずdecide\_skip() より後に呼ぶことにした
  * decide\_skip() を基底クラス、派生クラス双方で正しく協調動作するように設計を見直した