### PR TITLE
[Fix] モンスターの復元数変数が初期化されていなかった不具合を修正。

### DIFF
--- a/src/wizard/wizard-game-modifier.cpp
+++ b/src/wizard/wizard-game-modifier.cpp
@@ -153,7 +153,7 @@ void wiz_complete_quest(PlayerType *player_ptr)
 void wiz_restore_monster_max_num(MonsterRaceId r_idx)
 {
     if (!MonsterRace(r_idx).is_valid()) {
-        int val;
+        int val = 1;
         if (!get_value("MonsterID", 1, r_info.size() - 1, &val)) {
             return;
         }


### PR DESCRIPTION
１か所直すのみ。