### PR TITLE
#2497 長柄/斧と鈍器に殺戮修正が付与されない事象を暫定的に修正した

### DIFF
--- a/src/object-enchant/weapon/apply-magic-hafted.cpp
+++ b/src/object-enchant/weapon/apply-magic-hafted.cpp
@@ -26,6 +26,7 @@ HaftedEnchanter::HaftedEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DEPT
 void HaftedEnchanter::apply_magic()
 {
     this->decide_skip();
+    this->give_killing_bonus();
     MeleeWeaponEnchanter::apply_magic();
 }
 

--- a/src/object-enchant/weapon/apply-magic-polearm.cpp
+++ b/src/object-enchant/weapon/apply-magic-polearm.cpp
@@ -25,6 +25,7 @@ PolearmEnchanter::PolearmEnchanter(PlayerType *player_ptr, ObjectType *o_ptr, DE
 void PolearmEnchanter::apply_magic()
 {
     this->decide_skip();
+    this->give_killing_bonus();
     MeleeWeaponEnchanter::apply_magic();
 }
 


### PR DESCRIPTION
掲題の通りです
過去に議論があった通り、暫定でgive\_killing\_bonus() を長柄/斧と鈍器の強化/弱化処理に追加しました
手元の環境では問題なく殺戮修正が付いているように見えます
ご確認下さい

注意：最終的には設計の見直しが必要
#2490 を参照のこと