### PR TITLE
[Fix] デバッグモードoコマンドの表示が崩れていたので行指定変数を正しく修正。

### DIFF
--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -378,7 +378,7 @@ static void wiz_display_item(PlayerType *player_ptr, ObjectType *o_ptr)
     prt("rtsxnaeydcedwlatdcedsrekdfddrxss", ++line, j);
     prt_binary(get_seq_32bits(flgs, 32 * 1), ++line, j);
 
-    line = 10;
+    line = 13;
     prt("+------------FLAGS3------------+", line, j + 32);
     prt("fe cnn t      stdrmsiiii d ab   ", ++line, j + 32);
     prt("aa aoomywhs lleeieihgggg rtgl   ", ++line, j + 32);


### PR DESCRIPTION
タイトル通り行が狂っているだけなので、すぐ修正つきました。確認お願いします。