### PR TITLE
libcurl4のインストールに失敗し、GitHub Actionsが正常に動作しない事象を修正した

### DIFF
--- a/.github/workflows/build-with-autotools.yml
+++ b/.github/workflows/build-with-autotools.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 
@@ -35,6 +35,7 @@ jobs:
 
       - name: Install required packages
         run: |
+          sudo apt-get update
           sudo apt-get install \
             autoconf-archive \
             libncursesw5-dev \


### PR DESCRIPTION
掲題の通りです
詳細はチケットとコミットログをご参照下さい