### PR TITLE
[Fix]暗黒耐性判定フラグに暗黒免疫の論理和を付加し、暗闇の巻物で吸血鬼が盲目になるエンバグを修正。

### DIFF
--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -1352,7 +1352,7 @@ BIT_FLAGS has_vuln_lite(PlayerType *player_ptr)
 
 BIT_FLAGS has_resist_dark(PlayerType *player_ptr)
 {
-    BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_DARK);
+    BIT_FLAGS result = common_cause_flags(player_ptr, TR_RES_DARK) | common_cause_flags(player_ptr, TR_IM_DARK);
 
     if (player_ptr->ult_res) {
         result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;


### PR DESCRIPTION
これで、他に不具合がないかチェックする必要はあると思うが基本大丈夫だとは思う。少なくともデバッグで、これの修正後、暗黒の100万ダメージを＠さんに与えても0であることは確認した。