### PR TITLE
[Fix] クエスト、モンサルヴァト城への侵攻にて町への帰還後の位置が永久岩の壁になっていたので修正。

### DIFF
--- a/lib/edit/t0000002.txt
+++ b/lib/edit/t0000002.txt
@@ -496,7 +496,7 @@ P:7:99
 
 # Starting position when coming from quest 16
 ?:[EQU $LEAVING_QUEST 16]
-P:58:157
+P:57:157
 
 # Starting position when coming from quest 26
 ?:[EQU $LEAVING_QUEST 26]


### PR DESCRIPTION
テルモラの町のクエスト条件に伴う初期座標を修正。