### PR TITLE
[Fix] chest_traps 配列外アクセス

### DIFF
--- a/src/action/open-util.cpp
+++ b/src/action/open-util.cpp
@@ -62,7 +62,7 @@ int count_chests(PlayerType *player_ptr, POSITION *y, POSITION *x, bool trapped)
             continue;
         }
 
-        if (trapped && (!o_ptr->is_known() || chest_traps[o_ptr->pval].none())) {
+        if (trapped && (!o_ptr->is_known() || ((o_ptr->pval > 0) && chest_traps[o_ptr->pval].none()))) {
             continue;
         }
 

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -89,7 +89,7 @@ static void discover_hidden_things(PlayerType *player_ptr, POSITION y, POSITION 
             continue;
         }
 
-        if (chest_traps[o_ptr->pval].none()) {
+        if (o_ptr->pval <= 0 || chest_traps[o_ptr->pval].none()) {
             continue;
         }
 


### PR DESCRIPTION
Resolves #2538 

箱にしかけられたトラップの種類は chest_traps 配列に定義されており、どのトラップが仕
掛けられているかは ObjectType::pval にこの配列の要素番号を格納することで決定している。
しかし、トラップを解除した時解除済みのマークとしてこの pval の符号を逆転して負にする
仕様となっている。
これを考慮せずそのまま配列にアクセスしてしまい、結果として負の値の要素にアクセスして
しまっている。
chest_traps 配列にアクセスする時は pval が確実に正の値であることをチェックするように
修正する。