### PR TITLE
Linux/Unix: tighten regexp gcc-wrap uses to set the object file name …

### DIFF
--- a/src/gcc-wrap
+++ b/src/gcc-wrap
@@ -5,7 +5,7 @@ jp=$(grep "#define JP" autoconf.h | wc -l)
 if test $jp -eq 1; then
     # Prepare the various file paths.
     eval SRC_FILE=\${$#}
-    OBJ_FILE=$(echo $SRC_FILE | sed -E 's/\..+$/\.o/')
+    OBJ_FILE=$(echo $SRC_FILE | sed -E 's/\.[^./]+$/\.o/')
     SRC_DIR=$(
         cd $(dirname $0)
         pwd


### PR DESCRIPTION
…so it works properly if the path has more than one '.' or has only one '.' but that '.' is not in the base part of the file's name.

That's not an issue with the current version of Hengband but ran into problems adopting the gcc-wrap script to work for a Hengband variant, https://github.com/Cryomaniac13/hengband-touhou-katteban-en .