### PR TITLE
Visual Studio 2022 v17.3 からコンパイルエラーが出るようになったのを修正した

### DIFF
--- a/src/store/store-util.h
+++ b/src/store/store-util.h
@@ -46,7 +46,7 @@ struct store_type {
     store_k_idx table{}; //!< Table -- Legal item kinds
     int16_t stock_num{}; //!< Stock -- Number of entries
     int16_t stock_size{}; //!< Stock -- Total Size of Array
-    std::unique_ptr<ObjectType[]> stock{}; //!< Stock -- Actual stock items
+    std::unique_ptr<ObjectType[]> stock; //!< Stock -- Actual stock items
 
     store_type() = default;
     store_type(const store_type &) = delete;


### PR DESCRIPTION
クラス定義内でunique_ptrを初期化した結果、std::unique_ptr\<ObjectType\[\]\> がインライン展開される
しかしObjectType型は不完全型なのでコンパイルエラーになる

Habu 氏のコメントに基づいて修正し、VS2022 v17.3 にてコンパイルが通ることを確認しました
ご確認下さい