### PR TITLE
PlayerType::blind フィールド変数をPlayerBlindness クラスでカプセル化した

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -601,6 +601,7 @@
     <ClCompile Include="..\..\src\target\target-preparation.cpp" />
     <ClCompile Include="..\..\src\target\target-setter.cpp" />
     <ClCompile Include="..\..\src\timed-effect\player-acceleration.cpp" />
+    <ClCompile Include="..\..\src\timed-effect\player-blindness.cpp" />
     <ClCompile Include="..\..\src\timed-effect\player-confusion.cpp" />
     <ClCompile Include="..\..\src\timed-effect\player-cut.cpp" />
     <ClCompile Include="..\..\src\timed-effect\player-deceleration.cpp" />
@@ -1397,6 +1398,7 @@
     <ClInclude Include="..\..\src\target\target-setter.h" />
     <ClInclude Include="..\..\src\target\target-types.h" />
     <ClInclude Include="..\..\src\term\screen-processor.h" />
+    <ClInclude Include="..\..\src\timed-effect\player-blindness.h" />
     <ClInclude Include="..\..\src\timed-effect\player-confusion.h" />
     <ClInclude Include="..\..\src\timed-effect\player-cut.h" />
     <ClInclude Include="..\..\src\timed-effect\player-acceleration.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2463,6 +2463,9 @@
     <ClCompile Include="..\..\src\timed-effect\player-poison.cpp">
       <Filter>timed-effect</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\timed-effect\player-blindness.cpp">
+      <Filter>timed-effect</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5353,6 +5356,9 @@
       <Filter>timed-effect</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\timed-effect\player-poison.h">
+      <Filter>timed-effect</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\timed-effect\player-blindness.h">
       <Filter>timed-effect</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -942,6 +942,7 @@ hengband_SOURCES = \
 	term/z-virt.cpp term/z-virt.h \
 	\
 	timed-effect/player-acceleration.cpp timed-effect/player-acceleration.h \
+	timed-effect/player-blindness.cpp timed-effect/player-blindness.h \
 	timed-effect/player-confusion.cpp timed-effect/player-confusion.h \
 	timed-effect/player-cut.cpp timed-effect/player-cut.h \
 	timed-effect/player-deceleration.cpp timed-effect/player-deceleration.h \

--- a/src/action/action-limited.cpp
+++ b/src/action/action-limited.cpp
@@ -15,6 +15,7 @@
 #include "system/floor-type-definition.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "timed-effect/player-blindness.h"
 #include "timed-effect/player-confusion.h"
 #include "timed-effect/player-hallucination.h"
 #include "timed-effect/player-stun.h"
@@ -89,7 +90,7 @@ bool cmd_limit_arena(PlayerType *player_ptr)
 
 bool cmd_limit_blind(PlayerType *player_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("目が見えない。", "You can't see anything."));
         return true;
     }

--- a/src/action/open-close-execution.cpp
+++ b/src/action/open-close-execution.cpp
@@ -27,6 +27,7 @@
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "timed-effect/player-blindness.h"
 #include "timed-effect/player-confusion.h"
 #include "timed-effect/player-hallucination.h"
 #include "timed-effect/timed-effects.h"
@@ -57,11 +58,11 @@ bool exe_open(PlayerType *player_ptr, POSITION y, POSITION x)
     }
 
     int i = player_ptr->skill_dis;
-    if (player_ptr->blind || no_lite(player_ptr)) {
+    const auto effects = player_ptr->effects();
+    if (effects->blindness()->is_blind() || no_lite(player_ptr)) {
         i = i / 10;
     }
 
-    auto effects = player_ptr->effects();
     if (effects->confusion()->is_confused() || effects->hallucination()->is_hallucinated()) {
         i = i / 10;
     }
@@ -153,11 +154,11 @@ bool easy_open_door(PlayerType *player_ptr, POSITION y, POSITION x)
         msg_format(_("%sはがっちりと閉じられているようだ。", "The %s appears to be stuck."), f_info[g_ptr->get_feat_mimic()].name.c_str());
     } else if (f_ptr->power) {
         i = player_ptr->skill_dis;
-        if (player_ptr->blind || no_lite(player_ptr)) {
+        const auto effects = player_ptr->effects();
+        if (effects->blindness()->is_blind() || no_lite(player_ptr)) {
             i = i / 10;
         }
 
-        auto effects = player_ptr->effects();
         if (effects->confusion()->is_confused() || effects->hallucination()->is_hallucinated()) {
             i = i / 10;
         }
@@ -208,11 +209,11 @@ bool exe_disarm_chest(PlayerType *player_ptr, POSITION y, POSITION x, OBJECT_IDX
     auto *o_ptr = &player_ptr->current_floor_ptr->o_list[o_idx];
     PlayerEnergy(player_ptr).set_player_turn_energy(100);
     int i = player_ptr->skill_dis;
-    if (player_ptr->blind || no_lite(player_ptr)) {
+    const auto effects = player_ptr->effects();
+    if (effects->blindness()->is_blind() || no_lite(player_ptr)) {
         i = i / 10;
     }
 
-    auto effects = player_ptr->effects();
     if (effects->confusion()->is_confused() || effects->hallucination()->is_hallucinated()) {
         i = i / 10;
     }
@@ -272,11 +273,11 @@ bool exe_disarm(PlayerType *player_ptr, POSITION y, POSITION x, DIRECTION dir)
     bool more = false;
     int i = player_ptr->skill_dis;
     PlayerEnergy(player_ptr).set_player_turn_energy(100);
-    if (player_ptr->blind || no_lite(player_ptr)) {
+    auto effects = player_ptr->effects();
+    if (effects->blindness()->is_blind() || no_lite(player_ptr)) {
         i = i / 10;
     }
 
-    auto effects = player_ptr->effects();
     if (effects->confusion()->is_confused() || effects->hallucination()->is_hallucinated()) {
         i = i / 10;
     }

--- a/src/action/travel-execution.cpp
+++ b/src/action/travel-execution.cpp
@@ -19,6 +19,8 @@
 #include "system/grid-type-definition.h"
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
 travel_type travel;
@@ -32,7 +34,8 @@ travel_type travel;
  */
 static DIRECTION travel_test(PlayerType *player_ptr, DIRECTION prev_dir)
 {
-    if (player_ptr->blind || no_lite(player_ptr)) {
+    const auto blindness = player_ptr->effects()->blindness();
+    if (blindness->is_blind() || no_lite(player_ptr)) {
         msg_print(_("目が見えない！", "You cannot see!"));
         return 0;
     }

--- a/src/blue-magic/blue-magic-checker.cpp
+++ b/src/blue-magic/blue-magic-checker.cpp
@@ -22,6 +22,7 @@
 #include "status/experience.h"
 #include "system/angband.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-blindness.h"
 #include "timed-effect/player-confusion.h"
 #include "timed-effect/player-hallucination.h"
 #include "timed-effect/player-paralysis.h"
@@ -44,12 +45,13 @@ void learn_spell(PlayerType *player_ptr, MonsterAbilityType monspell)
         return;
     }
 
-    auto effects = player_ptr->effects();
-    auto is_confused = effects->confusion()->is_confused();
-    auto is_stunned = effects->stun()->is_stunned();
-    auto is_hallucinated = effects->hallucination()->is_hallucinated();
-    auto is_paralyzed = effects->paralysis()->is_paralyzed();
-    if (is_confused || player_ptr->blind || is_hallucinated || is_stunned || is_paralyzed) {
+    const auto effects = player_ptr->effects();
+    const auto is_confused = effects->confusion()->is_confused();
+    const auto is_blind = effects->blindness()->is_blind();
+    const auto is_stunned = effects->stun()->is_stunned();
+    const auto is_hallucinated = effects->hallucination()->is_hallucinated();
+    const auto is_paralyzed = effects->paralysis()->is_paralyzed();
+    if (is_confused || is_blind || is_hallucinated || is_stunned || is_paralyzed) {
         return;
     }
 

--- a/src/cmd-action/cmd-open-close.cpp
+++ b/src/cmd-action/cmd-open-close.cpp
@@ -27,6 +27,7 @@
 #include "system/player-type-definition.h"
 #include "target/target-getter.h"
 #include "term/screen-processor.h"
+#include "timed-effect/player-blindness.h"
 #include "timed-effect/player-confusion.h"
 #include "timed-effect/player-hallucination.h"
 #include "timed-effect/timed-effects.h"
@@ -52,11 +53,11 @@ static bool exe_open_chest(PlayerType *player_ptr, POSITION y, POSITION x, OBJEC
     if (o_ptr->pval > 0) {
         flag = false;
         int i = player_ptr->skill_dis;
-        if (player_ptr->blind || no_lite(player_ptr)) {
+        const auto effects = player_ptr->effects();
+        if (effects->blindness()->is_blind() || no_lite(player_ptr)) {
             i = i / 10;
         }
 
-        auto effects = player_ptr->effects();
         if (effects->confusion()->is_confused() || effects->hallucination()->is_hallucinated()) {
             i = i / 10;
         }

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -62,6 +62,8 @@
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "util/buffer-shaper.h"
 #include "util/int-char-converter.h"
@@ -973,7 +975,7 @@ bool do_cmd_cast(PlayerType *player_ptr)
         return false;
     }
 
-    if (player_ptr->blind || no_lite(player_ptr)) {
+    if (player_ptr->effects()->blindness()->is_blind() || no_lite(player_ptr)) {
         if (pc.equals(PlayerClassType::FORCETRAINER)) {
             confirm_use_force(player_ptr, false);
         } else {

--- a/src/cmd-building/cmd-inn.cpp
+++ b/src/cmd-building/cmd-inn.cpp
@@ -132,7 +132,7 @@ static void back_to_health(PlayerType *player_ptr)
 {
     BadStatusSetter bss(player_ptr);
     (void)bss.set_blindness(0);
-    (void)bss.confusion(0);
+    (void)bss.set_confusion(0);
     player_ptr->effects()->stun()->reset();
     player_ptr->chp = player_ptr->mhp;
     player_ptr->csp = player_ptr->msp;

--- a/src/cmd-building/cmd-inn.cpp
+++ b/src/cmd-building/cmd-inn.cpp
@@ -131,7 +131,7 @@ static bool has_a_nightmare(PlayerType *player_ptr)
 static void back_to_health(PlayerType *player_ptr)
 {
     BadStatusSetter bss(player_ptr);
-    (void)bss.blindness(0);
+    (void)bss.set_blindness(0);
     (void)bss.confusion(0);
     player_ptr->effects()->stun()->reset();
     player_ptr->chp = player_ptr->mhp;

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -105,7 +105,7 @@ bool exe_eat_food_type_object(PlayerType *player_ptr, ObjectType *o_ptr)
     case SV_FOOD_CURE_POISON:
         return bss.set_poison(0);
     case SV_FOOD_CURE_BLINDNESS:
-        return bss.blindness(0);
+        return bss.set_blindness(0);
     case SV_FOOD_CURE_PARANOIA:
         return bss.fear(0);
     case SV_FOOD_CURE_CONFUSION:

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -109,7 +109,7 @@ bool exe_eat_food_type_object(PlayerType *player_ptr, ObjectType *o_ptr)
     case SV_FOOD_CURE_PARANOIA:
         return bss.fear(0);
     case SV_FOOD_CURE_CONFUSION:
-        return bss.confusion(0);
+        return bss.set_confusion(0);
     case SV_FOOD_CURE_SERIOUS:
         return cure_serious_wounds(player_ptr, 4, 8);
     case SV_FOOD_RESTORE_STR:

--- a/src/core/magic-effects-timeout-reducer.cpp
+++ b/src/core/magic-effects-timeout-reducer.cpp
@@ -18,6 +18,7 @@
 #include "status/temporary-resistance.h"
 #include "system/player-type-definition.h"
 #include "timed-effect/player-acceleration.h"
+#include "timed-effect/player-blindness.h"
 #include "timed-effect/player-confusion.h"
 #include "timed-effect/player-cut.h"
 #include "timed-effect/player-deceleration.h"
@@ -39,12 +40,12 @@ void reduce_magic_effects_timeout(PlayerType *player_ptr)
     }
 
     BadStatusSetter bss(player_ptr);
-    auto effects = player_ptr->effects();
+    const auto effects = player_ptr->effects();
     if (effects->hallucination()->is_hallucinated()) {
         (void)bss.mod_hallucination(-1);
     }
 
-    if (player_ptr->blind) {
+    if (effects->blindness()->is_blind()) {
         (void)bss.mod_blindness(-1);
     }
 

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -56,6 +56,7 @@
 #include "system/monster-race-definition.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "timed-effect/player-blindness.h"
 #include "timed-effect/player-confusion.h"
 #include "timed-effect/player-cut.h"
 #include "timed-effect/player-hallucination.h"
@@ -182,7 +183,8 @@ void process_player(PlayerType *player_ptr)
         }
     }
 
-    if (player_ptr->riding && !player_ptr->effects()->confusion()->is_confused() && !player_ptr->blind) {
+    const auto effects = player_ptr->effects();
+    if (player_ptr->riding && !effects->confusion()->is_confused() && !effects->blindness()->is_blind()) {
         auto *m_ptr = &player_ptr->current_floor_ptr->m_list[player_ptr->riding];
         auto *r_ptr = &r_info[m_ptr->r_idx];
         if (monster_csleep_remaining(m_ptr)) {
@@ -281,7 +283,6 @@ void process_player(PlayerType *player_ptr)
 
         PlayerEnergy energy(player_ptr);
         energy.reset_player_turn();
-        auto effects = player_ptr->effects();
         auto is_knocked_out = effects->stun()->is_knocked_out();
         auto is_paralyzed = effects->paralysis()->is_paralyzed();
         if (player_ptr->phase_out) {

--- a/src/effect/effect-feature.cpp
+++ b/src/effect/effect-feature.cpp
@@ -20,6 +20,8 @@
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "world/world.h"
@@ -191,7 +193,7 @@ bool affect_feature(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITIO
             }
         }
 
-        if (player_ptr->blind || !player_has_los_bold(player_ptr, y, x)) {
+        if (player_ptr->effects()->blindness()->is_blind() || !player_has_los_bold(player_ptr, y, x)) {
             break;
         }
 
@@ -210,7 +212,7 @@ bool affect_feature(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITIO
             cave_alter_feat(player_ptr, y, x, FloorFeatureType::TUNNEL);
         }
 
-        if (player_ptr->blind || !player_has_los_bold(player_ptr, y, x)) {
+        if (player_ptr->effects()->blindness()->is_blind() || !player_has_los_bold(player_ptr, y, x)) {
             break;
         }
 

--- a/src/effect/effect-player-oldies.cpp
+++ b/src/effect/effect-player-oldies.cpp
@@ -8,11 +8,13 @@
 #include "status/buff-setter.h"
 #include "system/player-type-definition.h"
 #include "timed-effect/player-acceleration.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
 void effect_player_old_heal(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("何らかの攻撃によって気分がよくなった。", "You are hit by something invigorating!"));
     }
 
@@ -22,7 +24,7 @@ void effect_player_old_heal(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_old_speed(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("何かで攻撃された！", "You are hit by something!"));
     }
 
@@ -32,7 +34,7 @@ void effect_player_old_speed(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_old_slow(PlayerType *player_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("何か遅いもので攻撃された！", "You are hit by something slow!"));
     }
 
@@ -45,7 +47,7 @@ void effect_player_old_sleep(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
         return;
     }
 
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("眠ってしまった！", "You fall asleep!"));
     }
 

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -30,6 +30,8 @@
 #include "status/shape-changer.h"
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 
@@ -37,7 +39,7 @@
 void effect_player_elements(
     PlayerType *player_ptr, EffectPlayerType *ep_ptr, concptr attack_message, int (*damage_func)(PlayerType *, int, concptr, bool))
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(attack_message);
     }
 
@@ -47,7 +49,7 @@ void effect_player_elements(
 void effect_player_poison(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
     bool double_resist = is_oppose_pois(player_ptr);
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("毒で攻撃された！", "You are hit by poison!"));
     }
 
@@ -67,7 +69,7 @@ void effect_player_poison(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 void effect_player_nuke(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
     bool double_resist = is_oppose_pois(player_ptr);
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("放射能で攻撃された！", "You are hit by radiation!"));
     }
 
@@ -96,7 +98,7 @@ void effect_player_nuke(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_missile(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("何かで攻撃された！", "You are hit by something!"));
     }
 
@@ -105,7 +107,7 @@ void effect_player_missile(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_holy_fire(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("何かで攻撃された！", "You are hit by something!"));
     }
 
@@ -116,7 +118,7 @@ void effect_player_holy_fire(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_hell_fire(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("何かで攻撃された！", "You are hit by something!"));
     }
 
@@ -127,7 +129,7 @@ void effect_player_hell_fire(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_arrow(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         sound(SOUND_SHOOT_HIT);
         msg_print(_("何か鋭いもので攻撃された！", "You are hit by something sharp!"));
         ep_ptr->get_damage = take_hit(player_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
@@ -145,7 +147,7 @@ void effect_player_arrow(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_plasma(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("何かとても熱いもので攻撃された！", "You are hit by something *HOT*!"));
     }
 
@@ -171,7 +173,7 @@ void effect_player_plasma(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_nether(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("地獄の力で攻撃された！", "You are hit by nether forces!"));
     }
 
@@ -203,7 +205,7 @@ void effect_player_nether(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
  */
 void effect_player_water(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("何か湿ったもので攻撃された！", "You are hit by something wet!"));
     }
 
@@ -235,7 +237,7 @@ void effect_player_water(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_chaos(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("無秩序の波動で攻撃された！", "You are hit by a wave of anarchy!"));
     }
 
@@ -271,7 +273,7 @@ void effect_player_chaos(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_shards(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("何か鋭いもので攻撃された！", "You are hit by something sharp!"));
     }
 
@@ -290,7 +292,7 @@ void effect_player_shards(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_sound(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("轟音で攻撃された！", "You are hit by a loud noise!"));
     }
 
@@ -310,7 +312,7 @@ void effect_player_sound(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_confusion(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("何か混乱するもので攻撃された！", "You are hit by something puzzling!"));
     }
 
@@ -325,7 +327,7 @@ void effect_player_confusion(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_disenchant(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("何かさえないもので攻撃された！", "You are hit by something static!"));
     }
 
@@ -340,7 +342,7 @@ void effect_player_disenchant(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_nexus(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("何か奇妙なもので攻撃された！", "You are hit by something strange!"));
     }
 
@@ -355,7 +357,7 @@ void effect_player_nexus(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_force(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("運動エネルギーで攻撃された！", "You are hit by kinetic force!"));
     }
     if (!has_resist_sound(player_ptr) && !check_multishadow(player_ptr)) {
@@ -367,7 +369,7 @@ void effect_player_force(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_rocket(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("爆発があった！", "There is an explosion!"));
     }
 
@@ -390,7 +392,7 @@ void effect_player_rocket(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_inertial(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("何か遅いもので攻撃された！", "You are hit by something slow!"));
     }
 
@@ -403,10 +405,12 @@ void effect_player_inertial(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_lite(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    const auto is_blind = player_ptr->effects()->blindness()->is_blind();
+    if (is_blind) {
         msg_print(_("何かで攻撃された！", "You are hit by something!"));
     }
-    if (!player_ptr->blind && !has_resist_lite(player_ptr) && !has_resist_blind(player_ptr) && !check_multishadow(player_ptr)) {
+
+    if (!is_blind && !has_resist_lite(player_ptr) && !has_resist_blind(player_ptr) && !check_multishadow(player_ptr)) {
         (void)BadStatusSetter(player_ptr).mod_blindness(randint1(5) + 2);
     }
 
@@ -435,13 +439,14 @@ void effect_player_lite(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_dark(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    const auto is_blind = player_ptr->effects()->blindness()->is_blind();
+    if (is_blind) {
         msg_print(_("何かで攻撃された！", "You are hit by something!"));
     }
 
     ep_ptr->dam = ep_ptr->dam * calc_dark_damage_rate(player_ptr, CALC_RAND) / 100;
 
-    auto go_blind = player_ptr->blind == 0;
+    auto go_blind = is_blind;
     go_blind &= !has_resist_blind(player_ptr);
     go_blind &= !(has_resist_dark(player_ptr) || has_immune_dark(player_ptr));
     go_blind &= !check_multishadow(player_ptr);
@@ -541,7 +546,7 @@ static void effect_player_time_addition(PlayerType *player_ptr)
  */
 void effect_player_time(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("過去からの衝撃に攻撃された！", "You are hit by a blast from the past!"));
     }
 
@@ -562,7 +567,7 @@ void effect_player_time(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_gravity(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("何か重いもので攻撃された！", "You are hit by something heavy!"));
     }
 
@@ -591,7 +596,7 @@ void effect_player_gravity(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_disintegration(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("純粋なエネルギーで攻撃された！", "You are hit by pure energy!"));
     }
 
@@ -600,7 +605,7 @@ void effect_player_disintegration(PlayerType *player_ptr, EffectPlayerType *ep_p
 
 void effect_player_death_ray(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("何か非常に冷たいもので攻撃された！", "You are hit by something extremely cold!"));
     }
 
@@ -610,7 +615,7 @@ void effect_player_death_ray(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_mana(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("魔法のオーラで攻撃された！", "You are hit by an aura of magic!"));
     }
 
@@ -619,7 +624,7 @@ void effect_player_mana(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_psy_spear(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("エネルギーの塊で攻撃された！", "You are hit by an energy!"));
     }
 
@@ -628,7 +633,7 @@ void effect_player_psy_spear(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_meteor(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("何かが空からあなたの頭上に落ちてきた！", "Something falls from the sky on you!"));
     }
 
@@ -643,7 +648,7 @@ void effect_player_meteor(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_icee(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("何か鋭く冷たいもので攻撃された！", "You are hit by something sharp and cold!"));
     }
 
@@ -688,8 +693,8 @@ void effect_player_hand_doom(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_void(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    auto effect_mes = player_ptr->blind ? _("何かに身体が引っ張りこまれる！", "Something absorbs you!")
-                                        : _("周辺の空間が歪んだ。", "Sight warps around you.");
+    auto effect_mes = player_ptr->effects()->blindness()->is_blind() ? _("何かに身体が引っ張りこまれる！", "Something absorbs you!")
+                                                                     : _("周辺の空間が歪んだ。", "Sight warps around you.");
     msg_print(effect_mes);
     if (!check_multishadow(player_ptr) && !player_ptr->levitation && !player_ptr->anti_tele) {
         (void)BadStatusSetter(player_ptr).mod_deceleration(randint0(4) + 4, false);
@@ -704,8 +709,9 @@ void effect_player_void(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
 void effect_player_abyss(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 {
-    auto effect_mes = player_ptr->blind ? _("身体が沈み込む気がする！", "You feel you are sinking into something!")
-                                        : _("深淵があなたを誘い込んでいる！", "You are falling into the abyss!");
+    const auto is_blind = player_ptr->effects()->blindness()->is_blind();
+    const auto effect_mes = is_blind ? _("身体が沈み込む気がする！", "You feel you are sinking into something!")
+                                     : _("深淵があなたを誘い込んでいる！", "You are falling into the abyss!");
     msg_print(effect_mes);
     ep_ptr->dam = ep_ptr->dam * calc_abyss_damage_rate(player_ptr, CALC_RAND) / 100;
     BadStatusSetter bss(player_ptr);
@@ -717,7 +723,7 @@ void effect_player_abyss(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
         (void)bss.mod_deceleration(randint0(4) + 4, false);
     }
 
-    if (player_ptr->blind) {
+    if (is_blind) {
         return;
     }
 

--- a/src/effect/effect-player.cpp
+++ b/src/effect/effect-player.cpp
@@ -32,6 +32,8 @@
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
 #include "target/projection-path-calculator.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include <string>
@@ -78,7 +80,7 @@ static bool process_bolt_reflection(PlayerType *player_ptr, EffectPlayerType *ep
     sound(SOUND_REFLECT);
 
     std::string mes;
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         mes = _("何かが跳ね返った！", "Something bounces!");
     } else if (PlayerClass(player_ptr).samurai_stance_is(SamuraiStanceType::FUUJIN)) {
         mes = _("風の如く武器を振るって弾き返した！", "The attack bounces!");

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -34,6 +34,7 @@
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
 #include "target/projection-path-calculator.h"
+#include "timed-effect/player-blindness.h"
 #include "timed-effect/player-hallucination.h"
 #include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
@@ -64,7 +65,6 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
     POSITION y2;
     POSITION x2;
     bool breath = false;
-    bool blind = player_ptr->blind != 0;
     bool old_hide = false;
     int path_n = 0;
     int grids = 0;
@@ -145,6 +145,7 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
     auto visual = false;
     POSITION gm_rad = rad;
     bool see_s_msg = true;
+    const auto is_blind = player_ptr->effects()->blindness()->is_blind();
     for (const auto &[ny, nx] : path_g) {
         if (flag & PROJECT_DISI) {
             if (cave_stop_disintegration(player_ptr->current_floor_ptr, ny, nx) && (rad > 0)) {
@@ -166,7 +167,7 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
         }
 
         if (delay_factor > 0) {
-            if (!blind && !(flag & (PROJECT_HIDE | PROJECT_FAST))) {
+            if (!is_blind && !(flag & (PROJECT_HIDE | PROJECT_FAST))) {
                 if (panel_contains(ny, nx) && player_has_los_bold(player_ptr, ny, nx)) {
                     print_bolt_pict(player_ptr, oy, ox, ny, nx, typ);
                     move_cursor_relative(ny, nx);
@@ -268,7 +269,7 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
         return res;
     }
 
-    if (!blind && !(flag & (PROJECT_HIDE)) && (delay_factor > 0)) {
+    if (!is_blind && !(flag & (PROJECT_HIDE)) && (delay_factor > 0)) {
         auto drawn = false;
         for (int t = 0; t <= gm_rad; t++) {
             for (int i = gm[t]; i < gm[t + 1]; i++) {

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -41,6 +41,8 @@
 #include "system/monster-race-definition.h"
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 #include "window/main-window-util.h"
 #include "world/world.h"
@@ -364,7 +366,7 @@ static void cut_off_the_upstair(PlayerType *player_ptr)
         return;
     }
 
-    if (!player_ptr->blind) {
+    if (!player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("突然階段が塞がれてしまった。", "Suddenly the stairs is blocked!"));
     } else {
         msg_print(_("ゴトゴトと何か音がした。", "You hear some noises."));

--- a/src/floor/geometry.cpp
+++ b/src/floor/geometry.cpp
@@ -8,6 +8,8 @@
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
 #include "target/projection-path-calculator.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 
 /*!
@@ -153,7 +155,7 @@ bool player_can_see_bold(PlayerType *player_ptr, POSITION y, POSITION x)
     grid_type *g_ptr;
 
     /* Blind players see nothing */
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         return false;
     }
 

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -54,6 +54,8 @@
 #include "system/player-type-definition.h"
 #include "term/gameterm.h"
 #include "term/term-color-types.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "util/enum-converter.h"
 #include "util/point-2d.h"
@@ -286,7 +288,6 @@ void print_bolt_pict(PlayerType *player_ptr, POSITION y, POSITION x, POSITION ny
 }
 
 /*!
- * @todo ここにPlayerType を追加した時のコンパイルエラーに対処できなかったので保留
  * Memorize interesting viewable object/features in the given grid
  *
  * This function should only be called on "legal" grids.
@@ -330,7 +331,7 @@ void note_spot(PlayerType *player_ptr, POSITION y, POSITION x)
     auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
 
     /* Blind players see nothing */
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         return;
     }
 

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -24,6 +24,7 @@
 #include "system/floor-type-definition.h"
 #include "system/player-type-definition.h"
 #include "timed-effect/player-acceleration.h"
+#include "timed-effect/player-blindness.h"
 #include "timed-effect/player-confusion.h"
 #include "timed-effect/player-cut.h"
 #include "timed-effect/player-deceleration.h"
@@ -334,7 +335,7 @@ static void rd_bad_status(PlayerType *player_ptr)
 {
     auto effects = player_ptr->effects();
     strip_bytes(2); /* Old "rest" */
-    player_ptr->blind = rd_s16b();
+    effects->blindness()->set(rd_s16b());
     effects->paralysis()->set(rd_s16b());
     effects->confusion()->set(rd_s16b());
     player_ptr->food = rd_s16b();

--- a/src/melee/melee-spell.cpp
+++ b/src/melee/melee-spell.cpp
@@ -18,6 +18,8 @@
 #include "system/monster-race-definition.h"
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 #ifdef JP
@@ -62,7 +64,7 @@ static void process_special_melee_spell(PlayerType *player_ptr, melee_spell_type
     bool is_special_magic = ms_ptr->m_ptr->ml;
     is_special_magic &= ms_ptr->maneable;
     is_special_magic &= w_ptr->timewalk_m_idx == 0;
-    is_special_magic &= !player_ptr->blind;
+    is_special_magic &= !player_ptr->effects()->blindness()->is_blind();
     is_special_magic &= pc.equals(PlayerClassType::IMITATOR);
     is_special_magic &= ms_ptr->thrown_spell != MonsterAbilityType::SPECIAL;
     if (!is_special_magic) {

--- a/src/mind/mind-mirror-master.cpp
+++ b/src/mind/mind-mirror-master.cpp
@@ -46,6 +46,8 @@
 #include "target/grid-selector.h"
 #include "target/projection-path-calculator.h"
 #include "target/target-getter.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "world/world.h"
@@ -124,7 +126,7 @@ bool binding_field(PlayerType *player_ptr, int dam)
         for (x = x1; x <= x2; x++) {
             if (centersign * ((point_x[0] - x) * (point_y[1] - y) - (point_y[0] - y) * (point_x[1] - x)) >= 0 && centersign * ((point_x[1] - x) * (point_y[2] - y) - (point_y[1] - y) * (point_x[2] - x)) >= 0 && centersign * ((point_x[2] - x) * (point_y[0] - y) - (point_y[2] - y) * (point_x[0] - x)) >= 0) {
                 if (player_has_los_bold(player_ptr, y, x) && projectable(player_ptr, player_ptr->y, player_ptr->x, y, x)) {
-                    if (!(player_ptr->blind) && panel_contains(y, x)) {
+                    if (!(player_ptr->effects()->blindness()->is_blind()) && panel_contains(y, x)) {
                         print_bolt_pict(player_ptr, y, x, y, x, AttributeType::MANA);
                         move_cursor_relative(y, x);
                         term_fresh();

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -57,6 +57,7 @@
 #include "target/projection-path-calculator.h"
 #include "target/target-checker.h"
 #include "target/target-getter.h"
+#include "timed-effect/player-blindness.h"
 #include "timed-effect/player-confusion.h"
 #include "timed-effect/player-hallucination.h"
 #include "timed-effect/player-paralysis.h"
@@ -84,11 +85,12 @@ bool kawarimi(PlayerType *player_ptr, bool success)
         return false;
     }
 
-    auto effects = player_ptr->effects();
-    auto is_confused = effects->confusion()->is_confused();
-    auto is_hallucinated = effects->hallucination()->is_hallucinated();
-    auto is_paralyzed = effects->paralysis()->is_paralyzed();
-    if (is_confused || player_ptr->blind || is_paralyzed || is_hallucinated) {
+    const auto effects = player_ptr->effects();
+    const auto is_confused = effects->confusion()->is_confused();
+    const auto is_blind = effects->blindness()->is_blind();
+    const auto is_hallucinated = effects->hallucination()->is_hallucinated();
+    const auto is_paralyzed = effects->paralysis()->is_paralyzed();
+    if (is_confused || is_blind || is_paralyzed || is_hallucinated) {
         return false;
     }
 
@@ -231,7 +233,7 @@ bool rush_attack(PlayerType *player_ptr, bool *mdeath)
 void process_surprise_attack(PlayerType *player_ptr, player_attack_type *pa_ptr)
 {
     auto *r_ptr = &r_info[pa_ptr->m_ptr->r_idx];
-    if (!has_melee_weapon(player_ptr, INVEN_MAIN_HAND + pa_ptr->hand) || player_ptr->is_icky_wield[pa_ptr->hand]) {
+    if (!has_melee_weapon(player_ptr, enum2i(INVEN_MAIN_HAND) + pa_ptr->hand) || player_ptr->is_icky_wield[pa_ptr->hand]) {
         return;
     }
 

--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -29,6 +29,7 @@
 #include "system/monster-type-definition.h"
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-blindness.h"
 #include "timed-effect/player-paralysis.h"
 #include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
@@ -204,7 +205,7 @@ void process_eat_lite(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
         monap_ptr->o_ptr->fuel = 1;
     }
 
-    if (!player_ptr->blind) {
+    if (!player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("明かりが暗くなってしまった。", "Your light dims."));
         monap_ptr->obvious = true;
     }

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -22,6 +22,7 @@
 #include "system/monster-race-definition.h"
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-blindness.h"
 #include "timed-effect/player-hallucination.h"
 #include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
@@ -85,7 +86,7 @@ int mon_damage_mod(PlayerType *player_ptr, monster_type *m_ptr, int dam, bool is
     }
 
     if (is_psy_spear) {
-        if (!player_ptr->blind && is_seen(player_ptr, m_ptr)) {
+        if (!player_ptr->effects()->blindness()->is_blind() && is_seen(player_ptr, m_ptr)) {
             msg_print(_("バリアを切り裂いた！", "The barrier is penetrated!"));
         }
 

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -41,6 +41,7 @@
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
 #include "target/projection-path-calculator.h"
+#include "timed-effect/player-blindness.h"
 #include "timed-effect/player-hallucination.h"
 #include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
@@ -443,7 +444,7 @@ static void decide_sight_invisible_monster(PlayerType *player_ptr, um_type *um_p
         update_specific_race_telepathy(player_ptr, um_ptr);
     }
 
-    if (!player_has_los_bold(player_ptr, um_ptr->fy, um_ptr->fx) || player_ptr->blind) {
+    if (!player_has_los_bold(player_ptr, um_ptr->fy, um_ptr->fx) || player_ptr->effects()->blindness()->is_blind()) {
         return;
     }
 

--- a/src/mspell/mspell-attack.cpp
+++ b/src/mspell/mspell-attack.cpp
@@ -34,6 +34,8 @@
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
 #include "target/projection-path-calculator.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 #ifdef JP
@@ -272,8 +274,8 @@ static bool check_thrown_mspell(PlayerType *player_ptr, msa_type *msa_ptr)
 
 static void check_mspell_imitation(PlayerType *player_ptr, msa_type *msa_ptr)
 {
-    bool seen = (!player_ptr->blind && msa_ptr->m_ptr->ml);
-    bool can_imitate = player_has_los_bold(player_ptr, msa_ptr->m_ptr->fy, msa_ptr->m_ptr->fx);
+    const auto seen = (!player_ptr->effects()->blindness()->is_blind() && msa_ptr->m_ptr->ml);
+    const auto can_imitate = player_has_los_bold(player_ptr, msa_ptr->m_ptr->fy, msa_ptr->m_ptr->fx);
     PlayerClass pc(player_ptr);
     if (!seen || !can_imitate || (w_ptr->timewalk_m_idx != 0) || !pc.equals(PlayerClassType::IMITATOR)) {
         return;

--- a/src/mspell/mspell-attack/mspell-ball.cpp
+++ b/src/mspell/mspell-attack/mspell-ball.cpp
@@ -17,6 +17,8 @@
 #include "system/floor-type-definition.h"
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
 static bool message_fire_ball(PlayerType *player_ptr, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
@@ -53,7 +55,7 @@ static bool message_water_ball(PlayerType *player_ptr, MONSTER_IDX m_idx, MONSTE
 
     if (mon_to_player) {
         msg_format(_("あなたは渦巻きに飲み込まれた。", "You are engulfed in a whirlpool."));
-    } else if (mon_to_mon && known && see_either && !player_ptr->blind) {
+    } else if (mon_to_mon && known && see_either && !player_ptr->effects()->blindness()->is_blind()) {
         msg_format(_("%^sは渦巻に飲み込まれた。", "%^s is engulfed in a whirlpool."), t_name);
     }
     return result;

--- a/src/mspell/mspell-attack/mspell-breath.cpp
+++ b/src/mspell/mspell-attack/mspell-breath.cpp
@@ -17,6 +17,8 @@
 #include "system/floor-type-definition.h"
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
 /*!
@@ -59,7 +61,7 @@ static void message_breath(PlayerType *player_ptr, MONSTER_IDX m_idx, MONSTER_ID
     monster_name(player_ptr, t_idx, t_name);
 
     if (!spell_RF4_BREATH_special_message(m_ptr->r_idx, GF_TYPE, m_name)) {
-        if (player_ptr->blind) {
+        if (player_ptr->effects()->blindness()->is_blind()) {
             if (mon_to_player || (mon_to_mon && known && see_either)) {
                 msg_format(_("%^sが何かのブレスを吐いた。", "%^s breathes."), m_name);
             }

--- a/src/mspell/mspell-attack/mspell-curse.cpp
+++ b/src/mspell/mspell-attack/mspell-curse.cpp
@@ -10,6 +10,8 @@
 #include "mspell/mspell-result.h"
 #include "mspell/mspell-util.h"
 #include "system/floor-type-definition.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
 static bool message_curse(PlayerType *player_ptr, MONSTER_IDX m_idx, MONSTER_IDX t_idx, std::string_view msg1, std::string_view msg2, std::string_view msg3, int target_type)
@@ -20,7 +22,7 @@ static bool message_curse(PlayerType *player_ptr, MONSTER_IDX m_idx, MONSTER_IDX
 
     if (target_type == MONSTER_TO_PLAYER) {
         disturb(player_ptr, true, true);
-        if (player_ptr->blind) {
+        if (player_ptr->effects()->blindness()->is_blind()) {
             msg_format(msg1.data(), m_name);
         } else {
             msg_format(msg2.data(), m_name);

--- a/src/mspell/mspell-floor.cpp
+++ b/src/mspell/mspell-floor.cpp
@@ -41,6 +41,8 @@
 #include "system/monster-race-definition.h"
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 
@@ -467,7 +469,7 @@ MonsterSpellResult spell_RF6_TRAPS(PlayerType *player_ptr, POSITION y, POSITION 
     monster_name(player_ptr, m_idx, m_name);
     disturb(player_ptr, true, true);
 
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_format(_("%^sが何かをつぶやいて邪悪に微笑んだ。", "%^s mumbles, and then cackles evilly."), m_name);
     } else {
         msg_format(_("%^sが呪文を唱えて邪悪に微笑んだ。", "%^s casts a spell and cackles evilly."), m_name);

--- a/src/mspell/mspell-learn-checker.cpp
+++ b/src/mspell/mspell-learn-checker.cpp
@@ -4,6 +4,8 @@
 #include "system/floor-type-definition.h"
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "world/world.h"
 
 /*!
@@ -16,9 +18,8 @@
  */
 bool spell_learnable(PlayerType *player_ptr, MONSTER_IDX m_idx)
 {
-    auto *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
-    bool seen = (!player_ptr->blind && m_ptr->ml);
-
-    bool maneable = player_has_los_bold(player_ptr, m_ptr->fy, m_ptr->fx);
+    const auto *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
+    const auto seen = (!player_ptr->effects()->blindness()->is_blind() && m_ptr->ml);
+    const auto maneable = player_has_los_bold(player_ptr, m_ptr->fy, m_ptr->fx);
     return seen && maneable && (w_ptr->timewalk_m_idx == 0);
 }

--- a/src/mspell/mspell-special.cpp
+++ b/src/mspell/mspell-special.cpp
@@ -35,6 +35,8 @@
 #include "system/monster-race-definition.h"
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
 /*!
@@ -140,7 +142,7 @@ static MonsterSpellResult spell_RF6_SPECIAL_ROLENTO(PlayerType *player_ptr, POSI
     for (k = 0; k < num; k++) {
         count += summon_named_creature(player_ptr, m_idx, y, x, MonsterRaceId::GRENADE, mode);
     }
-    if (player_ptr->blind && count) {
+    if (player_ptr->effects()->blindness()->is_blind() && count) {
         msg_print(_("多くのものが間近にばらまかれる音がする。", "You hear many things scattered nearby."));
     }
 

--- a/src/mspell/mspell-status.cpp
+++ b/src/mspell/mspell-status.cpp
@@ -331,7 +331,7 @@ MonsterSpellResult spell_RF5_BLIND(MONSTER_IDX m_idx, PlayerType *player_ptr, MO
         spell_badstatus_message_to_player(player_ptr, m_idx, msg, resist, saving_throw);
 
         if (!resist && !saving_throw) {
-            (void)BadStatusSetter(player_ptr).blindness(12 + randint0(4));
+            (void)BadStatusSetter(player_ptr).set_blindness(12 + randint0(4));
         }
 
         update_smart_learn(player_ptr, m_idx, DRS_BLIND);

--- a/src/mspell/mspell-status.cpp
+++ b/src/mspell/mspell-status.cpp
@@ -35,6 +35,8 @@
 #include "system/monster-race-definition.h"
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
 mspell_cast_msg_bad_status_to_player::mspell_cast_msg_bad_status_to_player(concptr blind, concptr not_blind, concptr resist, concptr saved_throw)
@@ -68,7 +70,7 @@ void spell_badstatus_message_to_player(PlayerType *player_ptr, MONSTER_IDX m_idx
     monster_name(player_ptr, m_idx, m_name);
 
     disturb(player_ptr, true, true);
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_format(msgs.blind, m_name);
     } else {
         msg_format(msgs.not_blind, m_name);
@@ -178,7 +180,7 @@ MonsterSpellResult spell_RF5_DRAIN_MANA(PlayerType *player_ptr, POSITION y, POSI
 MonsterSpellResult spell_RF5_MIND_BLAST(PlayerType *player_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
     auto *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
-    bool seen = (!player_ptr->blind && m_ptr->ml);
+    bool seen = (!player_ptr->effects()->blindness()->is_blind() && m_ptr->ml);
     GAME_TEXT m_name[MAX_NLEN], t_name[MAX_NLEN];
     monster_name(player_ptr, m_idx, m_name);
     monster_name(player_ptr, t_idx, t_name);
@@ -217,7 +219,7 @@ MonsterSpellResult spell_RF5_MIND_BLAST(PlayerType *player_ptr, POSITION y, POSI
 MonsterSpellResult spell_RF5_BRAIN_SMASH(PlayerType *player_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
     auto *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
-    bool seen = (!player_ptr->blind && m_ptr->ml);
+    bool seen = (!player_ptr->effects()->blindness()->is_blind() && m_ptr->ml);
     GAME_TEXT m_name[MAX_NLEN], t_name[MAX_NLEN];
     monster_name(player_ptr, m_idx, m_name);
     monster_name(player_ptr, t_idx, t_name);
@@ -502,7 +504,7 @@ MonsterSpellResult spell_RF6_HASTE(PlayerType *player_ptr, MONSTER_IDX m_idx, MO
         _("%^sが自分の体に念を送った。", format("%%^s concentrates on %s body.", m_poss)),
         _("%^sが自分の体に念を送った。", format("%%^s concentrates on %s body.", m_poss)));
 
-    monspell_message_base(player_ptr, m_idx, t_idx, msg, player_ptr->blind > 0, target_type);
+    monspell_message_base(player_ptr, m_idx, t_idx, msg, player_ptr->effects()->blindness()->is_blind(), target_type);
 
     if (set_monster_fast(player_ptr, m_idx, monster_fast_remaining(m_ptr) + 100)) {
         if (target_type == MONSTER_TO_PLAYER || (target_type == MONSTER_TO_MONSTER && see_m)) {
@@ -596,7 +598,8 @@ MonsterSpellResult spell_RF6_HEAL(PlayerType *player_ptr, MONSTER_IDX m_idx, MON
     auto *floor_ptr = player_ptr->current_floor_ptr;
     auto *m_ptr = &floor_ptr->m_list[m_idx];
     DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
-    bool seen = (!player_ptr->blind && m_ptr->ml);
+    const auto is_blind = player_ptr->effects()->blindness()->is_blind();
+    const auto seen = (!is_blind && m_ptr->ml);
     GAME_TEXT m_name[MAX_NLEN];
     monster_name(player_ptr, m_idx, m_name);
     char m_poss[10];
@@ -607,7 +610,7 @@ MonsterSpellResult spell_RF6_HEAL(PlayerType *player_ptr, MONSTER_IDX m_idx, MON
     msg.to_player_false = _("%^sが自分の傷に集中した。", format("%%^s concentrates on %s wounds.", m_poss));
     msg.to_mons_false = _("%^sは自分の傷に念を集中した。", format("%%^s concentrates on %s wounds.", m_poss));
 
-    monspell_message_base(player_ptr, m_idx, t_idx, msg, player_ptr->blind > 0, target_type);
+    monspell_message_base(player_ptr, m_idx, t_idx, msg, is_blind, target_type);
 
     m_ptr->hp += (rlev * 6);
     if (m_ptr->hp >= m_ptr->maxhp) {
@@ -659,7 +662,7 @@ MonsterSpellResult spell_RF6_HEAL(PlayerType *player_ptr, MONSTER_IDX m_idx, MON
 MonsterSpellResult spell_RF6_INVULNER(PlayerType *player_ptr, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
     auto *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
-    bool seen = (!player_ptr->blind && m_ptr->ml);
+    bool seen = (!player_ptr->effects()->blindness()->is_blind() && m_ptr->ml);
     mspell_cast_msg msg(_("%^sが何かを力強くつぶやいた。", "%^s mumbles powerfully."),
         _("%^sが何かを力強くつぶやいた。", "%^s mumbles powerfully."), _("%sは無傷の球の呪文を唱えた。", "%^s casts a Globe of Invulnerability."),
         _("%sは無傷の球の呪文を唱えた。", "%^s casts a Globe of Invulnerability."));

--- a/src/mspell/mspell-summon.cpp
+++ b/src/mspell/mspell-summon.cpp
@@ -24,6 +24,8 @@
 #include "system/monster-race-definition.h"
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 
@@ -103,7 +105,7 @@ static void decide_summon_kin_caster(
 
     summon_disturb(player_ptr, target_type, known, see_either);
 
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         if (mon_to_player) {
             msg_format(_("%^sが何かをつぶやいた。", "%^s mumbles."), m_name);
         }
@@ -209,7 +211,7 @@ MonsterSpellResult spell_RF6_S_KIN(PlayerType *player_ptr, POSITION y, POSITION 
         break;
     }
 
-    if (player_ptr->blind && count && (target_type == MONSTER_TO_PLAYER)) {
+    if (player_ptr->effects()->blindness()->is_blind() && count && (target_type == MONSTER_TO_PLAYER)) {
         msg_print(_("多くのものが間近に現れた音がする。", "You hear many things appear nearby."));
     }
 
@@ -257,7 +259,7 @@ MonsterSpellResult spell_RF6_S_CYBER(PlayerType *player_ptr, POSITION y, POSITIO
         count += summon_cyber(player_ptr, m_idx, y, x);
     }
 
-    if (player_ptr->blind && count && mon_to_player) {
+    if (player_ptr->effects()->blindness()->is_blind() && count && mon_to_player) {
         msg_print(_("重厚な足音が近くで聞こえる。", "You hear heavy steps nearby."));
     }
 
@@ -308,7 +310,7 @@ MonsterSpellResult spell_RF6_S_MONSTER(PlayerType *player_ptr, POSITION y, POSIT
         }
     }
 
-    if (player_ptr->blind && count && mon_to_player) {
+    if (player_ptr->effects()->blindness()->is_blind() && count && mon_to_player) {
         msg_print(_("何かが間近に現れた音がする。", "You hear something appear nearby."));
     }
 
@@ -359,7 +361,7 @@ MonsterSpellResult spell_RF6_S_MONSTERS(PlayerType *player_ptr, POSITION y, POSI
         }
     }
 
-    if (player_ptr->blind && count && mon_to_player) {
+    if (player_ptr->effects()->blindness()->is_blind() && count && mon_to_player) {
         msg_print(_("多くのものが間近に現れた音がする。", "You hear many things appear nearby."));
     }
 
@@ -404,7 +406,7 @@ MonsterSpellResult spell_RF6_S_ANT(PlayerType *player_ptr, POSITION y, POSITION 
         count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_ANT, PM_ALLOW_GROUP);
     }
 
-    if (player_ptr->blind && count && mon_to_player) {
+    if (player_ptr->effects()->blindness()->is_blind() && count && mon_to_player) {
         msg_print(_("多くのものが間近に現れた音がする。", "You hear many things appear nearby."));
     }
 
@@ -449,7 +451,7 @@ MonsterSpellResult spell_RF6_S_SPIDER(PlayerType *player_ptr, POSITION y, POSITI
         count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_SPIDER, PM_ALLOW_GROUP);
     }
 
-    if (player_ptr->blind && count && mon_to_player) {
+    if (player_ptr->effects()->blindness()->is_blind() && count && mon_to_player) {
         msg_print(_("多くのものが間近に現れた音がする。", "You hear many things appear nearby."));
     }
 
@@ -494,7 +496,7 @@ MonsterSpellResult spell_RF6_S_HOUND(PlayerType *player_ptr, POSITION y, POSITIO
         count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_HOUND, PM_ALLOW_GROUP);
     }
 
-    if (player_ptr->blind && count && mon_to_player) {
+    if (player_ptr->effects()->blindness()->is_blind() && count && mon_to_player) {
         msg_print(_("多くのものが間近に現れた音がする。", "You hear many things appear nearby."));
     }
 
@@ -539,7 +541,7 @@ MonsterSpellResult spell_RF6_S_HYDRA(PlayerType *player_ptr, POSITION y, POSITIO
         count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_HYDRA, PM_ALLOW_GROUP);
     }
 
-    if (player_ptr->blind && count && mon_to_player) {
+    if (player_ptr->effects()->blindness()->is_blind() && count && mon_to_player) {
         msg_print(_("多くのものが間近に現れた音がする。", "You hear many things appear nearby."));
     }
 
@@ -590,12 +592,13 @@ MonsterSpellResult spell_RF6_S_ANGEL(PlayerType *player_ptr, POSITION y, POSITIO
         count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_ANGEL, PM_ALLOW_GROUP);
     }
 
+    const auto is_blind = player_ptr->effects()->blindness()->is_blind();
     if (count < 2) {
-        if (player_ptr->blind && count) {
+        if (is_blind && count) {
             msg_print(_("何かが間近に現れた音がする。", "You hear something appear nearby."));
         }
     } else {
-        if (player_ptr->blind) {
+        if (is_blind) {
             msg_print(_("多くのものが間近に現れた音がする。", "You hear many things appear nearby."));
         }
     }
@@ -641,7 +644,7 @@ MonsterSpellResult spell_RF6_S_DEMON(PlayerType *player_ptr, POSITION y, POSITIO
         count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_DEMON, PM_ALLOW_GROUP);
     }
 
-    if (player_ptr->blind && count) {
+    if (player_ptr->effects()->blindness()->is_blind() && count) {
         msg_print(_("何かが間近に現れた音がする。", "You hear something appear nearby."));
     }
 
@@ -686,7 +689,7 @@ MonsterSpellResult spell_RF6_S_UNDEAD(PlayerType *player_ptr, POSITION y, POSITI
         count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_UNDEAD, PM_ALLOW_GROUP);
     }
 
-    if (player_ptr->blind && count) {
+    if (player_ptr->effects()->blindness()->is_blind() && count) {
         msg_print(_("何かが間近に現れた音がする。", "You hear something appear nearby."));
     }
 
@@ -735,7 +738,7 @@ MonsterSpellResult spell_RF6_S_DRAGON(PlayerType *player_ptr, POSITION y, POSITI
         count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_DRAGON, (PM_ALLOW_GROUP | monster_u_mode(floor_ptr, m_idx)));
     }
 
-    if (player_ptr->blind && count) {
+    if (player_ptr->effects()->blindness()->is_blind() && count) {
         msg_print(_("何かが間近に現れた音がする。", "You hear something appear nearby."));
     }
 
@@ -795,7 +798,7 @@ MonsterSpellResult spell_RF6_S_HI_UNDEAD(PlayerType *player_ptr, POSITION y, POS
         }
     }
 
-    if (player_ptr->blind && count && mon_to_player) {
+    if (player_ptr->effects()->blindness()->is_blind() && count && mon_to_player) {
         msg_print(_("間近で何か多くのものが這い回る音が聞こえる。", "You hear many creepy things appear nearby."));
     }
 
@@ -847,7 +850,7 @@ MonsterSpellResult spell_RF6_S_HI_DRAGON(PlayerType *player_ptr, POSITION y, POS
         }
     }
 
-    if (player_ptr->blind && count && mon_to_player) {
+    if (player_ptr->effects()->blindness()->is_blind() && count && mon_to_player) {
         msg_print(_("多くの力強いものが間近に現れた音が聞こえる。", "You hear many powerful things appear nearby."));
     }
 
@@ -893,7 +896,7 @@ MonsterSpellResult spell_RF6_S_AMBERITES(PlayerType *player_ptr, POSITION y, POS
         count += summon_specific(player_ptr, m_idx, y, x, rlev, SUMMON_AMBERITES, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE));
     }
 
-    if (player_ptr->blind && count && mon_to_player) {
+    if (player_ptr->effects()->blindness()->is_blind() && count && mon_to_player) {
         msg_print(_("何者かが次元を超えて現れた気配がした。", "You feel shadow shifting by immortal beings."));
     }
 
@@ -956,7 +959,7 @@ MonsterSpellResult spell_RF6_S_UNIQUE(PlayerType *player_ptr, POSITION y, POSITI
         count += summon_specific(player_ptr, m_idx, y, x, rlev, non_unique_type, (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE));
     }
 
-    if (player_ptr->blind && count && mon_to_player) {
+    if (player_ptr->effects()->blindness()->is_blind() && count && mon_to_player) {
         msg_format(_("多くの%sが間近に現れた音が聞こえる。", "You hear many %s appear nearby."),
             uniques_are_summoned ? _("力強いもの", "powerful things") : _("もの", "things"));
     }

--- a/src/mspell/mspell-util.cpp
+++ b/src/mspell/mspell-util.cpp
@@ -6,6 +6,8 @@
 #include "system/floor-type-definition.h"
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
 mspell_cast_msg::mspell_cast_msg(concptr to_player_true, concptr to_mons_true, concptr to_player_false, concptr to_mons_false)
@@ -117,7 +119,9 @@ bool monspell_message_base(PlayerType *player_ptr, MONSTER_IDX m_idx, MONSTER_ID
  */
 bool monspell_message(PlayerType *player_ptr, MONSTER_IDX m_idx, MONSTER_IDX t_idx, const mspell_cast_msg_blind &msgs, int target_type)
 {
-    return monspell_message_base(player_ptr, m_idx, t_idx, mspell_cast_msg(msgs.blind, msgs.blind, msgs.to_player, msgs.to_mons), player_ptr->blind > 0, target_type);
+    mspell_cast_msg mcm(msgs.blind, msgs.blind, msgs.to_player, msgs.to_mons);
+    const auto is_blind = player_ptr->effects()->blindness()->is_blind();
+    return monspell_message_base(player_ptr, m_idx, t_idx, mcm, is_blind, target_type);
 }
 
 /*!
@@ -130,5 +134,7 @@ bool monspell_message(PlayerType *player_ptr, MONSTER_IDX m_idx, MONSTER_IDX t_i
  */
 void simple_monspell_message(PlayerType *player_ptr, MONSTER_IDX m_idx, MONSTER_IDX t_idx, const mspell_cast_msg_simple &msgs, int target_type)
 {
-    monspell_message_base(player_ptr, m_idx, t_idx, mspell_cast_msg(msgs.to_player, msgs.to_mons, msgs.to_player, msgs.to_mons), player_ptr->blind > 0, target_type);
+    mspell_cast_msg mcm(msgs.to_player, msgs.to_mons, msgs.to_player, msgs.to_mons);
+    const auto is_blind = player_ptr->effects()->blindness()->is_blind();
+    monspell_message_base(player_ptr, m_idx, t_idx, mcm, is_blind, target_type);
 }

--- a/src/mspell/specified-summon.cpp
+++ b/src/mspell/specified-summon.cpp
@@ -14,6 +14,8 @@
 #include "spell/summon-types.h"
 #include "system/monster-race-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
 /*!
@@ -180,7 +182,7 @@ MONSTER_NUMBER summon_NAZGUL(PlayerType *player_ptr, POSITION y, POSITION x, MON
     GAME_TEXT m_name[MAX_NLEN];
     monster_name(player_ptr, m_idx, m_name);
 
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         msg_format(_("%^sが何かをつぶやいた。", "%^s mumbles."), m_name);
     } else {
         msg_format(_("%^sが魔法で幽鬼戦隊を召喚した！", "%^s magically summons rangers of Nazgul!"), m_name);

--- a/src/object-activation/activation-others.cpp
+++ b/src/object-activation/activation-others.cpp
@@ -379,7 +379,7 @@ bool activate_protection_elbereth(PlayerType *player_ptr)
     msg_print(_("エルベレスよ、我を護り給え！", "A Elbereth gilthoniel!"));
     create_rune_protection_one(player_ptr);
     (void)bss.fear(0);
-    (void)bss.blindness(0);
+    (void)bss.set_blindness(0);
     (void)bss.hallucination(0);
     set_blessed(player_ptr, randint0(25) + 25, true);
     set_bits(player_ptr->redraw, PR_STATS);

--- a/src/object-use/quaff/quaff-effects.cpp
+++ b/src/object-use/quaff/quaff-effects.cpp
@@ -262,7 +262,7 @@ bool QuaffEffects::booze()
     }
 
     BadStatusSetter bss(this->player_ptr);
-    if (!has_resist_conf(this->player_ptr) && bss.confusion(randint0(20) + 15)) {
+    if (!has_resist_conf(this->player_ptr) && bss.set_confusion(randint0(20) + 15)) {
         ident = true;
     }
 

--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -62,6 +62,7 @@
 #include "target/target-checker.h"
 #include "target/target-getter.h"
 #include "term/screen-processor.h"
+#include "timed-effect/player-blindness.h"
 #include "timed-effect/player-hallucination.h"
 #include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
@@ -539,7 +540,8 @@ void ObjectThrowEntity::process_boomerang_throw()
 
 void ObjectThrowEntity::display_boomerang_throw()
 {
-    if ((this->back_chance > 37) && !this->player_ptr->blind && (this->item >= 0)) {
+    const auto is_blind = this->player_ptr->effects()->blindness()->is_blind();
+    if ((this->back_chance > 37) && !is_blind && (this->item >= 0)) {
         msg_format(_("%sが手元に返ってきた。", "%s comes back to you."), this->o2_name);
         this->come_back = true;
         return;

--- a/src/object/lite-processor.cpp
+++ b/src/object/lite-processor.cpp
@@ -9,6 +9,8 @@
 #include "sv-definition/sv-lite-types.h"
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 
@@ -49,7 +51,7 @@ void notice_lite_change(PlayerType *player_ptr, ObjectType *o_ptr)
         player_ptr->window_flags |= (PW_EQUIP);
     }
 
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         if (o_ptr->fuel == 0) {
             o_ptr->fuel++;
         }

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -35,6 +35,8 @@
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
 #include "target/projection-path-calculator.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 
@@ -123,7 +125,7 @@ static void spell_damcalc(PlayerType *player_ptr, monster_type *m_ptr, Attribute
         break;
 
     case AttributeType::MONSTER_SHOOT:
-        if (!player_ptr->blind && (has_invuln_arrow(player_ptr))) {
+        if (!player_ptr->effects()->blindness()->is_blind() && (has_invuln_arrow(player_ptr))) {
             dam = 0;
             ignore_wraith_form = true;
         }

--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -28,6 +28,8 @@
 #include "status/action-setter.h"
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 
 PlayerClass::PlayerClass(PlayerType *player_ptr)
@@ -223,7 +225,7 @@ TrFlags PlayerClass::stance_tr_flags() const
 
     switch (this->get_samurai_stance()) {
     case SamuraiStanceType::FUUJIN:
-        if (!this->player_ptr->blind) {
+        if (!this->player_ptr->effects()->blindness()->is_blind()) {
             flags.set(TR_REFLECT);
         }
         break;

--- a/src/player-info/self-info.cpp
+++ b/src/player-info/self-info.cpp
@@ -28,6 +28,7 @@
 #include "player/player-status.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "timed-effect/player-blindness.h"
 #include "timed-effect/player-confusion.h"
 #include "timed-effect/player-cut.h"
 #include "timed-effect/player-fear.h"
@@ -40,7 +41,7 @@
 static void set_bad_status_info(PlayerType *player_ptr, self_info_type *self_ptr)
 {
     auto effects = player_ptr->effects();
-    if (player_ptr->blind) {
+    if (effects->blindness()->is_blind()) {
         self_ptr->info[self_ptr->line++] = _("あなたは目が見えない。", "You cannot see.");
     }
 
@@ -319,13 +320,14 @@ void report_magics(PlayerType *player_ptr)
     int i = 0;
     concptr info[128];
     int info2[128];
-    auto effects = player_ptr->effects();
-    if (player_ptr->blind) {
-        info2[i] = report_magics_aux(player_ptr->blind);
+    const auto effects = player_ptr->effects();
+    const auto blindness = effects->blindness();
+    if (blindness->is_blind()) {
+        info2[i] = report_magics_aux(blindness->current());
         info[i++] = _("あなたは目が見えない", "You cannot see");
     }
 
-    auto confusion = effects->confusion();
+    const auto confusion = effects->confusion();
     if (confusion->is_confused()) {
         info2[i] = report_magics_aux(confusion->current());
         info[i++] = _("あなたは混乱している", "You are confused");

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -46,6 +46,7 @@
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
 #include "target/target-checker.h"
+#include "timed-effect/player-blindness.h"
 #include "timed-effect/player-confusion.h"
 #include "timed-effect/player-hallucination.h"
 #include "timed-effect/timed-effects.h"
@@ -108,11 +109,11 @@ static void discover_hidden_things(PlayerType *player_ptr, POSITION y, POSITION 
 void search(PlayerType *player_ptr)
 {
     PERCENTAGE chance = player_ptr->skill_srh;
-    if (player_ptr->blind || no_lite(player_ptr)) {
+    const auto effects = player_ptr->effects();
+    if (effects->blindness()->is_blind() || no_lite(player_ptr)) {
         chance = chance / 10;
     }
 
-    auto effects = player_ptr->effects();
     if (effects->confusion()->is_confused() || effects->hallucination()->is_hallucinated()) {
         chance = chance / 10;
     }
@@ -176,7 +177,7 @@ bool move_player_effect(PlayerType *player_ptr, POSITION ny, POSITION nx, BIT_FL
 
         player_ptr->update |= PU_VIEW | PU_LITE | PU_FLOW | PU_MON_LITE | PU_DISTANCE;
         player_ptr->window_flags |= PW_OVERHEAD | PW_DUNGEON;
-        if ((!player_ptr->blind && !no_lite(player_ptr)) || !is_trap(player_ptr, g_ptr->feat)) {
+        if ((!player_ptr->effects()->blindness()->is_blind() && !no_lite(player_ptr)) || !is_trap(player_ptr, g_ptr->feat)) {
             g_ptr->info &= ~(CAVE_UNSAFE);
         }
 

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -45,6 +45,8 @@
 #include "system/monster-type-definition.h"
 #include "system/object-type-definition.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "util/quarks.h"
 #include "util/string-processor.h"
@@ -702,7 +704,7 @@ BIT_FLAGS has_no_ac(PlayerType *player_ptr)
 
 BIT_FLAGS has_invuln_arrow(PlayerType *player_ptr)
 {
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         return 0;
     }
 

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -11,6 +11,7 @@
 #include "system/floor-type-definition.h"
 #include "system/player-type-definition.h"
 #include "timed-effect/player-acceleration.h"
+#include "timed-effect/player-blindness.h"
 #include "timed-effect/player-confusion.h"
 #include "timed-effect/player-cut.h"
 #include "timed-effect/player-deceleration.h"
@@ -159,7 +160,7 @@ void wr_player(PlayerType *player_ptr)
 
     auto effects = player_ptr->effects();
     wr_s16b(0); /* old "rest" */
-    wr_s16b(player_ptr->blind);
+    wr_s16b(effects->blindness()->current());
     wr_s16b(effects->paralysis()->current());
     wr_s16b(effects->confusion()->current());
     wr_s16b(player_ptr->food);

--- a/src/spell-class/spells-mirror-master.cpp
+++ b/src/spell-class/spells-mirror-master.cpp
@@ -35,6 +35,7 @@
 #include "target/grid-selector.h"
 #include "target/projection-path-calculator.h"
 #include "target/target-checker.h"
+#include "timed-effect/player-blindness.h"
 #include "timed-effect/player-hallucination.h"
 #include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
@@ -267,7 +268,6 @@ void SpellsMirrorMaster::project_seeker_ray(int target_x, int target_y, int dam)
     POSITION x1;
     POSITION y2;
     POSITION x2;
-    bool blind = this->player_ptr->blind != 0;
     constexpr auto typ = AttributeType::SEEKER;
     BIT_FLAGS flag = PROJECT_BEAM | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM | PROJECT_THRU | PROJECT_MIRROR;
     rakubadam_p = 0;
@@ -307,7 +307,7 @@ void SpellsMirrorMaster::project_seeker_ray(int target_x, int target_y, int dam)
             const auto [oy, ox] = *(path_g_ite == path_g.begin() ? path_g.begin() : path_g_ite - 1);
             const auto [ny, nx] = *path_g_ite;
 
-            if (delay_factor > 0 && !blind) {
+            if (delay_factor > 0 && !this->player_ptr->effects()->blindness()->is_blind()) {
                 if (panel_contains(ny, nx) && player_has_los_bold(this->player_ptr, ny, nx)) {
                     print_bolt_pict(this->player_ptr, oy, ox, ny, nx, typ);
                     move_cursor_relative(ny, nx);

--- a/src/spell-kind/spells-lite.cpp
+++ b/src/spell-kind/spells-lite.cpp
@@ -25,6 +25,8 @@
 #include "system/monster-type-definition.h"
 #include "system/player-type-definition.h"
 #include "target/projection-path-calculator.h"
+#include "timed-effect/player-blindness.h"
+#include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
 #include "util/point-2d.h"
 #include "view/display-messages.h"
@@ -385,7 +387,7 @@ void unlite_room(PlayerType *player_ptr, const POSITION y1, const POSITION x1)
  */
 bool starlight(PlayerType *player_ptr, bool magic)
 {
-    if (!player_ptr->blind && !magic) {
+    if (!player_ptr->effects()->blindness()->is_blind() && !magic) {
         msg_print(_("杖の先が明るく輝いた...", "The end of the staff glows brightly..."));
     }
 
@@ -426,7 +428,7 @@ bool lite_area(PlayerType *player_ptr, int dam, POSITION rad)
         return false;
     }
 
-    if (!player_ptr->blind) {
+    if (!player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("白い光が辺りを覆った。", "You are surrounded by a white light."));
     }
 
@@ -447,7 +449,7 @@ bool lite_area(PlayerType *player_ptr, int dam, POSITION rad)
  */
 bool unlite_area(PlayerType *player_ptr, int dam, POSITION rad)
 {
-    if (!player_ptr->blind) {
+    if (!player_ptr->effects()->blindness()->is_blind()) {
         msg_print(_("暗闇が辺りを覆った。", "Darkness surrounds you."));
     }
 

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -291,7 +291,7 @@ bool life_stream(PlayerType *player_ptr, bool message, bool virtue_change)
     restore_level(player_ptr);
     BadStatusSetter bss(player_ptr);
     (void)bss.set_poison(0);
-    (void)bss.blindness(0);
+    (void)bss.set_blindness(0);
     (void)bss.confusion(0);
     (void)bss.hallucination(0);
     (void)bss.stun(0);
@@ -349,7 +349,7 @@ bool cure_light_wounds(PlayerType *player_ptr, DICE_NUMBER dice, DICE_SID sides)
     }
 
     BadStatusSetter bss(player_ptr);
-    if (bss.blindness(0)) {
+    if (bss.set_blindness(0)) {
         ident = true;
     }
 
@@ -372,7 +372,7 @@ bool cure_serious_wounds(PlayerType *player_ptr, DICE_NUMBER dice, DICE_SID side
     }
 
     BadStatusSetter bss(player_ptr);
-    if (bss.blindness(0)) {
+    if (bss.set_blindness(0)) {
         ident = true;
     }
 
@@ -399,7 +399,7 @@ bool cure_critical_wounds(PlayerType *player_ptr, int pow)
     }
 
     BadStatusSetter bss(player_ptr);
-    if (bss.blindness(0)) {
+    if (bss.set_blindness(0)) {
         ident = true;
     }
 
@@ -434,7 +434,7 @@ bool true_healing(PlayerType *player_ptr, int pow)
     }
 
     BadStatusSetter bss(player_ptr);
-    if (bss.blindness(0)) {
+    if (bss.set_blindness(0)) {
         ident = true;
     }
 

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -292,7 +292,7 @@ bool life_stream(PlayerType *player_ptr, bool message, bool virtue_change)
     BadStatusSetter bss(player_ptr);
     (void)bss.set_poison(0);
     (void)bss.set_blindness(0);
-    (void)bss.confusion(0);
+    (void)bss.set_confusion(0);
     (void)bss.hallucination(0);
     (void)bss.stun(0);
     (void)bss.cut(0);
@@ -376,7 +376,7 @@ bool cure_serious_wounds(PlayerType *player_ptr, DICE_NUMBER dice, DICE_SID side
         ident = true;
     }
 
-    if (bss.confusion(0)) {
+    if (bss.set_confusion(0)) {
         ident = true;
     }
 
@@ -403,7 +403,7 @@ bool cure_critical_wounds(PlayerType *player_ptr, int pow)
         ident = true;
     }
 
-    if (bss.confusion(0)) {
+    if (bss.set_confusion(0)) {
         ident = true;
     }
 
@@ -438,7 +438,7 @@ bool true_healing(PlayerType *player_ptr, int pow)
         ident = true;
     }
 
-    if (bss.confusion(0)) {
+    if (bss.set_confusion(0)) {
         ident = true;
     }
 

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -48,7 +48,7 @@ BadStatusSetter::BadStatusSetter(PlayerType *player_ptr)
  * Note that blindness is currently the only thing which can affect\n
  * "player_can_see_bold()".\n
  */
-bool BadStatusSetter::blindness(const TIME_EFFECT tmp_v)
+bool BadStatusSetter::set_blindness(const TIME_EFFECT tmp_v)
 {
     auto notice = false;
     auto v = std::clamp<short>(tmp_v, 0, 10000);
@@ -101,7 +101,7 @@ bool BadStatusSetter::blindness(const TIME_EFFECT tmp_v)
 
 bool BadStatusSetter::mod_blindness(const TIME_EFFECT tmp_v)
 {
-    return this->blindness(this->player_ptr->effects()->blindness()->current() + tmp_v);
+    return this->set_blindness(this->player_ptr->effects()->blindness()->current() + tmp_v);
 }
 
 /*!

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -109,7 +109,7 @@ bool BadStatusSetter::mod_blindness(const TIME_EFFECT tmp_v)
  * @param v 継続時間
  * @return ステータスに影響を及ぼす変化があった場合TRUEを返す。
  */
-bool BadStatusSetter::confusion(const TIME_EFFECT tmp_v)
+bool BadStatusSetter::set_confusion(const TIME_EFFECT tmp_v)
 {
     auto notice = false;
     auto v = std::clamp<short>(tmp_v, 0, 10000);
@@ -177,7 +177,7 @@ bool BadStatusSetter::confusion(const TIME_EFFECT tmp_v)
 
 bool BadStatusSetter::mod_confusion(const TIME_EFFECT tmp_v)
 {
-    return this->confusion(this->player_confusion->current() + tmp_v);
+    return this->set_confusion(this->player_confusion->current() + tmp_v);
 }
 
 /*!

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -19,6 +19,7 @@
 #include "status/base-status.h"
 #include "status/buff-setter.h"
 #include "system/player-type-definition.h"
+#include "timed-effect/player-blindness.h"
 #include "timed-effect/player-confusion.h"
 #include "timed-effect/player-cut.h"
 #include "timed-effect/player-deceleration.h"
@@ -55,9 +56,11 @@ bool BadStatusSetter::blindness(const TIME_EFFECT tmp_v)
         return false;
     }
 
-    PlayerRace pr(player_ptr);
+    PlayerRace pr(this->player_ptr);
+    const auto blindness = this->player_ptr->effects()->blindness();
+    const auto is_blind = blindness->is_blind();
     if (v > 0) {
-        if (!this->player_ptr->blind) {
+        if (!is_blind) {
             if (pr.equals(PlayerRaceType::ANDROID)) {
                 msg_print(_("センサーをやられた！", "The sensor broke!"));
             } else {
@@ -68,7 +71,7 @@ bool BadStatusSetter::blindness(const TIME_EFFECT tmp_v)
             chg_virtue(this->player_ptr, V_ENLIGHTEN, -1);
         }
     } else {
-        if (this->player_ptr->blind) {
+        if (is_blind) {
             if (pr.equals(PlayerRaceType::ANDROID)) {
                 msg_print(_("センサーが復旧した。", "The sensor has been restored."));
             } else {
@@ -79,7 +82,7 @@ bool BadStatusSetter::blindness(const TIME_EFFECT tmp_v)
         }
     }
 
-    this->player_ptr->blind = v;
+    blindness->set(v);
     this->player_ptr->redraw |= PR_STATUS;
     if (!notice) {
         return false;
@@ -98,7 +101,7 @@ bool BadStatusSetter::blindness(const TIME_EFFECT tmp_v)
 
 bool BadStatusSetter::mod_blindness(const TIME_EFFECT tmp_v)
 {
-    return this->blindness(this->player_ptr->blind + tmp_v);
+    return this->blindness(this->player_ptr->effects()->blindness()->current() + tmp_v);
 }
 
 /*!

--- a/src/status/bad-status-setter.h
+++ b/src/status/bad-status-setter.h
@@ -18,7 +18,7 @@ public:
 
     bool set_blindness(const TIME_EFFECT tmp_v);
     bool mod_blindness(const TIME_EFFECT tmp_v);
-    bool confusion(const TIME_EFFECT tmp_v);
+    bool set_confusion(const TIME_EFFECT tmp_v);
     bool mod_confusion(const TIME_EFFECT tmp_v);
     bool set_poison(const TIME_EFFECT tmp_v);
     bool mod_poison(const TIME_EFFECT tmp_v);

--- a/src/status/bad-status-setter.h
+++ b/src/status/bad-status-setter.h
@@ -16,7 +16,7 @@ public:
     BadStatusSetter(PlayerType *player_ptr);
     virtual ~BadStatusSetter() = default;
 
-    bool blindness(const TIME_EFFECT tmp_v);
+    bool set_blindness(const TIME_EFFECT tmp_v);
     bool mod_blindness(const TIME_EFFECT tmp_v);
     bool confusion(const TIME_EFFECT tmp_v);
     bool mod_confusion(const TIME_EFFECT tmp_v);

--- a/src/status/buff-setter.cpp
+++ b/src/status/buff-setter.cpp
@@ -20,6 +20,7 @@
 #include "status/element-resistance.h"
 #include "system/player-type-definition.h"
 #include "timed-effect/player-acceleration.h"
+#include "timed-effect/player-blindness.h"
 #include "timed-effect/player-confusion.h"
 #include "timed-effect/player-cut.h"
 #include "timed-effect/player-deceleration.h"
@@ -40,7 +41,7 @@ void reset_tim_flags(PlayerType *player_ptr)
     effects->acceleration()->reset();
     player_ptr->lightspeed = 0;
     effects->deceleration()->reset();
-    player_ptr->blind = 0; /* Timed -- Blindness */
+    effects->blindness()->reset();
     effects->paralysis()->reset();
     effects->confusion()->reset();
     effects->fear()->reset();

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -1,5 +1,6 @@
 ﻿#include "system/player-type-definition.h"
 #include "market/arena-info-table.h"
+#include "timed-effect/player-blindness.h"
 #include "timed-effect/player-confusion.h"
 #include "timed-effect/player-cut.h"
 #include "timed-effect/player-deceleration.h"
@@ -46,7 +47,7 @@ bool PlayerType::is_fully_healthy() const
     auto effects = this->effects();
     auto is_fully_healthy = this->chp == this->mhp;
     is_fully_healthy &= this->csp >= this->msp;
-    is_fully_healthy &= !this->blind;
+    is_fully_healthy &= !effects->blindness()->is_blind();
     is_fully_healthy &= !effects->confusion()->is_confused();
     is_fully_healthy &= !effects->poison()->is_poisoned();
     is_fully_healthy &= !effects->fear()->is_fearful();

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -94,8 +94,6 @@ public:
 
     uint32_t count{};
 
-    TIME_EFFECT blind{}; /* Timed -- Blindness */
-
     TIME_EFFECT protevil{}; /* Timed -- Protection */
     TIME_EFFECT invuln{}; /* Timed -- Invulnerable */
     TIME_EFFECT ult_res{}; /* Timed -- Ultimate Resistance */

--- a/src/timed-effect/player-blindness.cpp
+++ b/src/timed-effect/player-blindness.cpp
@@ -1,0 +1,32 @@
+﻿/*!
+ * @brief プレイヤーの盲目ステータス変更と判定
+ * @date 2022/08/30
+ * @author Hourier
+ */
+
+#include "timed-effect/player-blindness.h"
+#include <stdexcept>
+
+short PlayerBlindness::current() const
+{
+    return this->blindness;
+}
+
+bool PlayerBlindness::is_blind() const
+{
+    return this->blindness > 0;
+}
+
+void PlayerBlindness::set(short value)
+{
+    if (value < 0) {
+        throw std::invalid_argument("Negative value can't be set in the player's blindness parameter!");
+    }
+
+    this->blindness = value;
+}
+
+void PlayerBlindness::reset()
+{
+    this->set(0);
+}

--- a/src/timed-effect/player-blindness.h
+++ b/src/timed-effect/player-blindness.h
@@ -1,0 +1,14 @@
+﻿#pragma once
+
+class PlayerBlindness {
+public:
+    PlayerBlindness() = default;
+
+    short current() const;
+    bool is_blind() const;
+    void set(short value);
+    void reset();
+
+private:
+    short blindness = 0;
+};

--- a/src/timed-effect/timed-effects.cpp
+++ b/src/timed-effect/timed-effects.cpp
@@ -6,6 +6,7 @@
 
 #include "timed-effect/timed-effects.h"
 #include "timed-effect/player-acceleration.h"
+#include "timed-effect/player-blindness.h"
 #include "timed-effect/player-confusion.h"
 #include "timed-effect/player-cut.h"
 #include "timed-effect/player-deceleration.h"
@@ -16,7 +17,8 @@
 #include "timed-effect/player-stun.h"
 
 TimedEffects::TimedEffects()
-    : player_confusion(std::make_shared<PlayerConfusion>())
+    : player_blindness(std::make_shared<PlayerBlindness>())
+    , player_confusion(std::make_shared<PlayerConfusion>())
     , player_cut(std::make_shared<PlayerCut>())
     , player_fear(std::make_shared<PlayerFear>())
     , player_hallucination(std::make_shared<PlayerHallucination>())
@@ -26,6 +28,11 @@ TimedEffects::TimedEffects()
     , player_deceleration(std::make_shared<PlayerDeceleration>())
     , player_poison(std::make_shared<PlayerPoison>())
 {
+}
+
+std::shared_ptr<PlayerBlindness> TimedEffects::blindness() const
+{
+    return this->player_blindness;
 }
 
 std::shared_ptr<PlayerConfusion> TimedEffects::confusion() const

--- a/src/timed-effect/timed-effects.h
+++ b/src/timed-effect/timed-effects.h
@@ -3,6 +3,7 @@
 #include <memory>
 
 class PlayerAcceleration;
+class PlayerBlindness;
 class PlayerConfusion;
 class PlayerDeceleration;
 class PlayerFear;
@@ -16,6 +17,7 @@ public:
     TimedEffects();
     virtual ~TimedEffects() = default;
 
+    std::shared_ptr<PlayerBlindness> blindness() const;
     std::shared_ptr<PlayerConfusion> confusion() const;
     std::shared_ptr<PlayerCut> cut() const;
     std::shared_ptr<PlayerFear> fear() const;
@@ -27,6 +29,7 @@ public:
     std::shared_ptr<PlayerPoison> poison() const;
 
 private:
+    std::shared_ptr<PlayerBlindness> player_blindness;
     std::shared_ptr<PlayerConfusion> player_confusion;
     std::shared_ptr<PlayerCut> player_cut;
     std::shared_ptr<PlayerFear> player_fear;

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -22,6 +22,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "timed-effect/player-blindness.h"
 #include "timed-effect/player-confusion.h"
 #include "timed-effect/player-cut.h"
 #include "timed-effect/player-deceleration.h"
@@ -470,7 +471,7 @@ void print_status(PlayerType *player_ptr)
         ADD_BAR_FLAG(BAR_HALLUCINATION);
     }
 
-    if (player_ptr->blind) {
+    if (player_ptr->effects()->blindness()->is_blind()) {
         ADD_BAR_FLAG(BAR_BLINDNESS);
     }
 


### PR DESCRIPTION
掲題の通りです
形容詞だとクラス名として扱いにくかったので名詞化しました
設計は、今までに実装してきたTimedEffect 系統と同じです
以下のことを確認しました

- 盲目打撃で盲目になる
- 盲目状態で巻物・魔法書が読めない
- 盲目状態でも超能力は使える (鏡魔法・元素魔法も同様のはずなのでスキップ)
- 盲目耐性があれば盲目打撃を受けても盲目にならない
- 盲目耐性があれば閃光魔法を浴びても盲目にならない
- 盲目耐性があれば暗黒魔法を浴びても盲目にならない

……が、参照されている箇所がかなり多く、上に書いた以上のあれやこれやが盲目だと不可能になったりするので、目視確認は厚めにお願いします
今までは引数がintとboolで無区別だったとかいう地獄設計なので、current() とすべきところをis\_blind() にしている可能性があります
(逆は多分ない)