### PR TITLE
誰得の巻物を使うとINSTA_ART指定のベースアイテムが生成される場合がある事象を修正した

### DIFF
--- a/src/object-use/read/scroll-read-executor.cpp
+++ b/src/object-use/read/scroll-read-executor.cpp
@@ -410,11 +410,11 @@ bool ScrollReadExecutor::read()
         break;
     case SV_SCROLL_AMUSEMENT:
         this->ident = true;
-        amusement(this->player_ptr, 1, false);
+        generate_amusement(this->player_ptr, 1, false);
         break;
     case SV_SCROLL_STAR_AMUSEMENT:
         this->ident = true;
-        amusement(this->player_ptr, randint1(2) + 1, false);
+        generate_amusement(this->player_ptr, randint1(2) + 1, false);
         break;
     default:
         break;

--- a/src/object-use/read/scroll-read-executor.cpp
+++ b/src/object-use/read/scroll-read-executor.cpp
@@ -410,11 +410,11 @@ bool ScrollReadExecutor::read()
         break;
     case SV_SCROLL_AMUSEMENT:
         this->ident = true;
-        amusement(this->player_ptr, this->player_ptr->y, this->player_ptr->x, 1, false);
+        amusement(this->player_ptr, 1, false);
         break;
     case SV_SCROLL_STAR_AMUSEMENT:
         this->ident = true;
-        amusement(this->player_ptr, this->player_ptr->y, this->player_ptr->x, randint1(2) + 1, false);
+        amusement(this->player_ptr, randint1(2) + 1, false);
         break;
     default:
         break;

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -76,6 +76,35 @@ static amuse_type amuse_info[] = { { ItemKindType::BOTTLE, SV_ANY, 5, AMS_NOTHIN
 
     { ItemKindType::NONE, 0, 0, 0 } };
 
+static short sweep_amusement_artifact(const bool insta_art, const short k_idx)
+{
+    for (const auto &a_ref : a_info) {
+        if (a_ref.idx == 0) {
+            continue;
+        }
+
+        if (insta_art && !a_ref.gen_flags.has(ItemGenerationTraitType::INSTA_ART)) {
+            continue;
+        }
+
+        if (a_ref.tval != k_info[k_idx].tval) {
+            continue;
+        }
+
+        if (a_ref.sval != k_info[k_idx].sval) {
+            continue;
+        }
+
+        if (a_ref.cur_num > 0) {
+            continue;
+        }
+
+        return a_ref.idx;
+    }
+
+    return 0;
+}
+
 /*!
  * @brief 誰得ドロップを行う。
  * @param player_ptr プレイヤーへの参照ポインタ
@@ -110,31 +139,7 @@ void amusement(PlayerType *player_ptr, POSITION y1, POSITION x1, int num, bool k
         const auto fixed_art = any_bits(amuse_info[i].flag, AMS_FIXED_ART);
         short a_idx = 0;
         if (insta_art || fixed_art) {
-            for (const auto &a_ref : a_info) {
-                if (a_ref.idx == 0) {
-                    continue;
-                }
-
-                if (insta_art && !a_ref.gen_flags.has(ItemGenerationTraitType::INSTA_ART)) {
-                    continue;
-                }
-
-                if (a_ref.tval != k_info[k_idx].tval) {
-                    continue;
-                }
-
-                if (a_ref.sval != k_info[k_idx].sval) {
-                    continue;
-                }
-
-                if (a_ref.cur_num > 0) {
-                    continue;
-                }
-
-                a_idx = a_ref.idx;
-                break;
-            }
-
+            a_idx = sweep_amusement_artifact(insta_art, k_idx);
             if (a_idx >= static_cast<short>(a_info.size())) {
                 continue;
             }

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -55,11 +55,11 @@ static constexpr std::array<int, 16> enchant_table = { { 0, 10, 50, 100, 200, 30
  * Scatter some "amusing" objects near the player
  */
 enum class AmusementFlagType : byte {
-    NOTHING = 0x00, /* No restriction */
-    NO_UNIQUE = 0x01, /* Don't make the amusing object of uniques */
-    FIXED_ART = 0x02, /* Make a fixed artifact based on the amusing object */
-    MULTIPLE = 0x04, /* Drop 1-3 objects for one type */
-    PILE = 0x08, /* Drop 1-99 pile objects for one type */
+    NOTHING, /* No restriction */
+    NO_UNIQUE, /* Don't make the amusing object of uniques */
+    FIXED_ART, /* Make a fixed artifact based on the amusing object */
+    MULTIPLE, /* Drop 1-3 objects for one type */
+    PILE, /* Drop 1-99 pile objects for one type */
 };
 
 struct amuse_type {
@@ -144,8 +144,8 @@ void generate_amusement(PlayerType *player_ptr, int num, bool known)
         }
 
         const auto insta_art = k_info[k_idx].gen_flags.has(ItemGenerationTraitType::INSTA_ART);
-        const auto flag = enum2i(amuse_info[i].flag);
-        const auto fixed_art = any_bits(flag, enum2i(AmusementFlagType::FIXED_ART));
+        const auto flag = amuse_info[i].flag;
+        const auto fixed_art = flag == AmusementFlagType::FIXED_ART;
         std::optional<short> opt_a_idx(std::nullopt);
         if (insta_art || fixed_art) {
             opt_a_idx = sweep_amusement_artifact(insta_art, k_idx);
@@ -161,17 +161,17 @@ void generate_amusement(PlayerType *player_ptr, int num, bool known)
         }
 
         ItemMagicApplier(player_ptr, &item, 1, AM_NO_FIXED_ART).execute();
-        if (any_bits(flag, enum2i(AmusementFlagType::NO_UNIQUE))) {
+        if (flag == AmusementFlagType::NO_UNIQUE) {
             if (r_info[i2enum<MonsterRaceId>(item.pval)].kind_flags.has(MonsterKindType::UNIQUE)) {
                 continue;
             }
         }
 
-        if (any_bits(flag, enum2i(AmusementFlagType::MULTIPLE))) {
+        if (flag == AmusementFlagType::MULTIPLE) {
             item.number = randint1(3);
         }
 
-        if (any_bits(flag, enum2i(AmusementFlagType::PILE))) {
+        if (flag == AmusementFlagType::PILE) {
             item.number = randint1(99);
         }
 

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -147,6 +147,10 @@ void amusement(PlayerType *player_ptr, POSITION y1, POSITION x1, int num, bool k
             }
         }
 
+        if (insta_art && (a_idx == 0)) {
+            continue;
+        }
+
         /* Make an object (if possible) */
         i_ptr->prep(k_idx);
         if (a_idx) {

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -116,12 +116,10 @@ static short sweep_amusement_artifact(const bool insta_art, const short k_idx)
 /*!
  * @brief 誰得ドロップを行う。
  * @param player_ptr プレイヤーへの参照ポインタ
- * @param y1 配置したいフロアのY座標
- * @param x1 配置したいフロアのX座標
  * @param num 誰得の処理回数
  * @param known TRUEならばオブジェクトが必ず＊鑑定＊済になる
  */
-void amusement(PlayerType *player_ptr, POSITION y1, POSITION x1, int num, bool known)
+void amusement(PlayerType *player_ptr, int num, bool known)
 {
     auto t = 0;
     for (auto n = 0; amuse_info[n].tval != ItemKindType::NONE; n++) {
@@ -183,7 +181,7 @@ void amusement(PlayerType *player_ptr, POSITION y1, POSITION x1, int num, bool k
             object_known(&item);
         }
 
-        (void)drop_near(player_ptr, &item, -1, y1, x1);
+        (void)drop_near(player_ptr, &item, -1, player_ptr->y, player_ptr->x);
         num--;
     }
 }

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -52,28 +52,36 @@ struct amuse_type {
 };
 
 /*!
- * @brief 装備強化処理の失敗率定数（千分率） /
- * Used by the "enchant" function (chance of failure)
- * (modified for Zangband, we need better stuff there...) -- TY
+ * @brief 装備強化処理の失敗率定数 (千分率)
+ * @details 強化値が負値から0までは必ず成功する
+ * 正値は+15までしか鍛えることができず、+16以上への強化を試みると確実に失敗する
  */
-static int enchant_table[16] = { 0, 10, 50, 100, 200, 300, 400, 500, 650, 800, 950, 987, 993, 995, 998, 1000 };
+static constexpr std::array<int, 16> enchant_table = { { 0, 10, 50, 100, 200, 300, 400, 500, 650, 800, 950, 987, 993, 995, 998, 1000 } };
 
 /*
  * Scatter some "amusing" objects near the player
  */
 
-#define AMS_NOTHING 0x00 /* No restriction */
-#define AMS_NO_UNIQUE 0x01 /* Don't make the amusing object of uniques */
-#define AMS_FIXED_ART 0x02 /* Make a fixed artifact based on the amusing object */
-#define AMS_MULTIPLE 0x04 /* Drop 1-3 objects for one type */
-#define AMS_PILE 0x08 /* Drop 1-99 pile objects for one type */
+constexpr byte AMS_NOTHING = 0x00; /* No restriction */
+constexpr byte AMS_NO_UNIQUE = 0x01; /* Don't make the amusing object of uniques */
+constexpr byte AMS_FIXED_ART = 0x02; /* Make a fixed artifact based on the amusing object */
+constexpr byte AMS_MULTIPLE = 0x04; /* Drop 1-3 objects for one type */
+constexpr byte AMS_PILE = 0x08; /* Drop 1-99 pile objects for one type */
 
-static amuse_type amuse_info[] = { { ItemKindType::BOTTLE, SV_ANY, 5, AMS_NOTHING }, { ItemKindType::JUNK, SV_ANY, 3, AMS_MULTIPLE }, { ItemKindType::SPIKE, SV_ANY, 10, AMS_PILE }, { ItemKindType::STATUE, SV_ANY, 15, AMS_NOTHING },
-    { ItemKindType::CORPSE, SV_ANY, 15, AMS_NO_UNIQUE }, { ItemKindType::SKELETON, SV_ANY, 10, AMS_NO_UNIQUE }, { ItemKindType::FIGURINE, SV_ANY, 10, AMS_NO_UNIQUE },
-    { ItemKindType::PARCHMENT, SV_ANY, 1, AMS_NOTHING }, { ItemKindType::POLEARM, SV_TSURIZAO, 3, AMS_NOTHING }, // Fishing Pole of Taikobo
+static const std::vector<amuse_type> amuse_info = {
+    { ItemKindType::BOTTLE, SV_ANY, 5, AMS_NOTHING },
+    { ItemKindType::JUNK, SV_ANY, 3, AMS_MULTIPLE },
+    { ItemKindType::SPIKE, SV_ANY, 10, AMS_PILE },
+    { ItemKindType::STATUE, SV_ANY, 15, AMS_NOTHING },
+    { ItemKindType::CORPSE, SV_ANY, 15, AMS_NO_UNIQUE },
+    { ItemKindType::SKELETON, SV_ANY, 10, AMS_NO_UNIQUE },
+    { ItemKindType::FIGURINE, SV_ANY, 10, AMS_NO_UNIQUE },
+    { ItemKindType::PARCHMENT, SV_ANY, 1, AMS_NOTHING },
+    { ItemKindType::POLEARM, SV_TSURIZAO, 3, AMS_NOTHING }, // Fishing Pole of Taikobo
     { ItemKindType::SWORD, SV_BROKEN_DAGGER, 3, AMS_FIXED_ART }, // Broken Dagger of Magician
-    { ItemKindType::SWORD, SV_BROKEN_DAGGER, 10, AMS_NOTHING }, { ItemKindType::SWORD, SV_BROKEN_SWORD, 5, AMS_NOTHING }, { ItemKindType::SCROLL, SV_SCROLL_AMUSEMENT, 10, AMS_NOTHING },
-
+    { ItemKindType::SWORD, SV_BROKEN_DAGGER, 10, AMS_NOTHING },
+    { ItemKindType::SWORD, SV_BROKEN_SWORD, 5, AMS_NOTHING },
+    { ItemKindType::SCROLL, SV_SCROLL_AMUSEMENT, 10, AMS_NOTHING },
     { ItemKindType::NONE, 0, 0, 0 } };
 
 static short sweep_amusement_artifact(const bool insta_art, const short k_idx)

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -119,7 +119,7 @@ static short sweep_amusement_artifact(const bool insta_art, const short k_idx)
  * @param num 誰得の処理回数
  * @param known TRUEならばオブジェクトが必ず＊鑑定＊済になる
  */
-void amusement(PlayerType *player_ptr, int num, bool known)
+void generate_amusement(PlayerType *player_ptr, int num, bool known)
 {
     auto t = 0;
     for (auto n = 0; amuse_info[n].tval != ItemKindType::NONE; n++) {

--- a/src/spell/spells-object.h
+++ b/src/spell/spells-object.h
@@ -4,7 +4,7 @@
 
 class ObjectType;
 class PlayerType;
-void amusement(PlayerType *player_ptr, POSITION y1, POSITION x1, int num, bool known);
+void amusement(PlayerType *player_ptr, int num, bool known);
 void acquirement(PlayerType *player_ptr, POSITION y1, POSITION x1, int num, bool great, bool special, bool known);
 bool curse_armor(PlayerType *player_ptr);
 bool curse_weapon_object(PlayerType *player_ptr, bool force, ObjectType *o_ptr);

--- a/src/spell/spells-object.h
+++ b/src/spell/spells-object.h
@@ -4,7 +4,7 @@
 
 class ObjectType;
 class PlayerType;
-void amusement(PlayerType *player_ptr, int num, bool known);
+void generate_amusement(PlayerType *player_ptr, int num, bool known);
 void acquirement(PlayerType *player_ptr, POSITION y1, POSITION x1, int num, bool great, bool special, bool known);
 bool curse_armor(PlayerType *player_ptr);
 bool curse_weapon_object(PlayerType *player_ptr, bool force, ObjectType *o_ptr);


### PR DESCRIPTION
掲題の通りです
それはそれとしてamusement() 自体読みづらかったのであちこち修正しました
★太公望の釣り竿 がドロップした後は通常の釣り竿ドロップ処理に進まなくなることをステップ実行で確認しました
ご確認下さい