### PR TITLE
clang-format によるソースコード整形チェックが機能していない問題を修正

### DIFF
--- a/.github/scripts/check-format.sh
+++ b/.github/scripts/check-format.sh
@@ -23,6 +23,12 @@ sudo apt-get install clang-format-15 >/dev/null
 SRC_FILES=$(find src/ -name \*.cpp -or -name \*.h)
 
 clang-format-15 -style=file:.github/scripts/check-clang-format-style -i $SRC_FILES
+clang_format_result=$?
+
+if [ $clang_format_result -ne 0 ]; then
+    echo "Could not execute clang-format properly."
+    exit $clang_format_result
+fi
 
 DIFF_FILE=$(mktemp)
 git diff >$DIFF_FILE

--- a/.github/scripts/check-format.sh
+++ b/.github/scripts/check-format.sh
@@ -8,12 +8,12 @@ wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key 2>/dev/null | sudo apt-key 
 cat <<EOF | sudo tee /etc/apt/sources.list.d/llvm.list >/dev/null
 deb http://apt.llvm.org/focal/ llvm-toolchain-focal main
 deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal main
-# 13
-deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main
-deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main
 # 14
 deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main
 deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main
+# 15
+deb http://apt.llvm.org/focal/ llvm-toolchain-focal-15 main
+deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-15 main
 
 EOF
 

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -52,8 +52,8 @@
 #include "target/target-types.h"
 #include "term/screen-processor.h"
 #include "timed-effect/player-acceleration.h"
-#include "timed-effect/player-deceleration.h"
 #include "timed-effect/player-confusion.h"
+#include "timed-effect/player-deceleration.h"
 #include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -398,7 +398,7 @@ bool BadStatusSetter::set_deceleration(const TIME_EFFECT tmp_v, bool do_dec)
     if (this->player_ptr->is_dead) {
         return false;
     }
-    
+
     auto deceleration = this->player_ptr->effects()->deceleration();
     auto is_slow = deceleration->is_slow();
     if (v > 0) {


### PR DESCRIPTION
Resolve #2599

以下の修正を行いました。

- 正しく clang-format-15 をインストールできるバージョン15用のAPTリポジトリを追加
- 今後の同様の事態に備えて clang-format を正しく実行できなかったときはソースコード整形チェック失敗となるようにする
- ソースコード整形チェックが正しく機能していなかった間に混入した未整形のソースコードを整形
