### PR TITLE
特性表示記号テーブル定義のリファクタリング

### DIFF
--- a/src/flavor/flag-inscriptions-table.cpp
+++ b/src/flavor/flag-inscriptions-table.cpp
@@ -23,28 +23,28 @@ const concptr game_inscriptions[MAX_GAME_INSCRIPTIONS] = {
 
 /*! オブジェクトの特性表示記号テーブルの定義(pval要素) */
 std::vector<flag_insc_table> flag_insc_plus = {
-    { N("攻", "At"), TR_BLOWS, -1 },
-    { N("速", "Sp"), TR_SPEED, -1 },
-    { N("腕", "St"), TR_STR, -1 },
-    { N("知", "In"), TR_INT, -1 },
-    { N("賢", "Wi"), TR_WIS, -1 },
-    { N("器", "Dx"), TR_DEX, -1 },
-    { N("耐", "Cn"), TR_CON, -1 },
-    { N("魅", "Ch"), TR_CHR, -1 },
-    { N("道", "Md"), TR_MAGIC_MASTERY, -1 },
-    { N("隠", "Sl"), TR_STEALTH, -1 },
-    { N("探", "Sr"), TR_SEARCH, -1 },
-    { N("赤", "If"), TR_INFRA, -1 },
-    { N("掘", "Dg"), TR_TUNNEL, -1 },
+    { N("攻", "At"), TR_BLOWS },
+    { N("速", "Sp"), TR_SPEED },
+    { N("腕", "St"), TR_STR },
+    { N("知", "In"), TR_INT },
+    { N("賢", "Wi"), TR_WIS },
+    { N("器", "Dx"), TR_DEX },
+    { N("耐", "Cn"), TR_CON },
+    { N("魅", "Ch"), TR_CHR },
+    { N("道", "Md"), TR_MAGIC_MASTERY },
+    { N("隠", "Sl"), TR_STEALTH },
+    { N("探", "Sr"), TR_SEARCH },
+    { N("赤", "If"), TR_INFRA },
+    { N("掘", "Dg"), TR_TUNNEL },
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(免疫) */
 std::vector<flag_insc_table> flag_insc_immune = {
-    { N("酸", "Ac"), TR_IM_ACID, -1 },
-    { N("電", "El"), TR_IM_ELEC, -1 },
-    { N("火", "Fi"), TR_IM_FIRE, -1 },
-    { N("冷", "Co"), TR_IM_COLD, -1 },
-    { N("暗", "Dk"), TR_IM_DARK, -1 }
+    { N("酸", "Ac"), TR_IM_ACID },
+    { N("電", "El"), TR_IM_ELEC },
+    { N("火", "Fi"), TR_IM_FIRE },
+    { N("冷", "Co"), TR_IM_COLD },
+    { N("暗", "Dk"), TR_IM_DARK }
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(弱点) */
@@ -53,8 +53,8 @@ std::vector<flag_insc_table> flag_insc_vuln = {
     { N("電", "El"), TR_VUL_ELEC, TR_IM_ELEC },
     { N("火", "Fi"), TR_VUL_FIRE, TR_IM_FIRE },
     { N("冷", "Co"), TR_VUL_COLD, TR_IM_COLD },
-    { N("閃", "Li"), TR_VUL_LITE, -1 },
-    { N("呪", "Cu"), TR_VUL_CURSE, -1 }
+    { N("閃", "Li"), TR_VUL_LITE },
+    { N("呪", "Cu"), TR_VUL_CURSE }
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(耐性) */
@@ -63,92 +63,92 @@ std::vector<flag_insc_table> flag_insc_resistance = {
     { N("電", "El"), TR_RES_ELEC, TR_IM_ELEC },
     { N("火", "Fi"), TR_RES_FIRE, TR_IM_FIRE },
     { N("冷", "Co"), TR_RES_COLD, TR_IM_COLD },
-    { N("毒", "Po"), TR_RES_POIS, -1 },
-    { N("閃", "Li"), TR_RES_LITE, -1 },
-    { N("暗", "Dk"), TR_RES_DARK, -1 },
-    { N("破", "Sh"), TR_RES_SHARDS, -1 },
-    { N("盲", "Bl"), TR_RES_BLIND, -1 },
-    { N("乱", "Cf"), TR_RES_CONF, -1 },
-    { N("轟", "So"), TR_RES_SOUND, -1 },
-    { N("獄", "Nt"), TR_RES_NETHER, -1 },
-    { N("因", "Nx"), TR_RES_NEXUS, -1 },
-    { N("沌", "Ca"), TR_RES_CHAOS, -1 },
-    { N("劣", "Di"), TR_RES_DISEN, -1 },
-    { N("時", "Tm"), TR_RES_TIME, -1 },
-    { N("水", "Wt"), TR_RES_WATER, -1 },
-    { N("恐", "Fe"), TR_RES_FEAR, -1 },
-    { N("呪", "Cu"), TR_RES_CURSE, -1 },
+    { N("毒", "Po"), TR_RES_POIS },
+    { N("閃", "Li"), TR_RES_LITE },
+    { N("暗", "Dk"), TR_RES_DARK },
+    { N("破", "Sh"), TR_RES_SHARDS },
+    { N("盲", "Bl"), TR_RES_BLIND },
+    { N("乱", "Cf"), TR_RES_CONF },
+    { N("轟", "So"), TR_RES_SOUND },
+    { N("獄", "Nt"), TR_RES_NETHER },
+    { N("因", "Nx"), TR_RES_NEXUS },
+    { N("沌", "Ca"), TR_RES_CHAOS },
+    { N("劣", "Di"), TR_RES_DISEN },
+    { N("時", "Tm"), TR_RES_TIME },
+    { N("水", "Wt"), TR_RES_WATER },
+    { N("恐", "Fe"), TR_RES_FEAR },
+    { N("呪", "Cu"), TR_RES_CURSE },
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(その他特性) */
 std::vector<flag_insc_table> flag_insc_misc = {
-    { N("易", "Es"), TR_EASY_SPELL, -1 },
-    { N("減", "Dm"), TR_DEC_MANA, -1 },
-    { N("投", "Th"), TR_THROW, -1 },
-    { N("反", "Rf"), TR_REFLECT, -1 },
-    { N("麻", "Fa"), TR_FREE_ACT, -1 },
-    { N("視", "Si"), TR_SEE_INVIS, -1 },
-    { N("経", "Hl"), TR_HOLD_EXP, -1 },
-    { N("遅", "Sd"), TR_SLOW_DIGEST, -1 },
-    { N("活", "Rg"), TR_REGEN, -1 },
-    { N("浮", "Lv"), TR_LEVITATION, -1 },
-    { N("明", "Lu"), TR_LITE_1, -1 },
-    { N("明", "Lu"), TR_LITE_2, -1 },
-    { N("明", "Lu"), TR_LITE_3, -1 },
-    { N("闇", "Dl"), TR_LITE_M1, -1 },
-    { N("闇", "Dl"), TR_LITE_M2, -1 },
-    { N("闇", "Dl"), TR_LITE_M3, -1 },
-    { N("警", "Wr"), TR_WARNING, -1 },
-    { N("倍", "Xm"), TR_XTRA_MIGHT, -1 },
-    { N("射", "Xs"), TR_XTRA_SHOTS, -1 },
-    { N("瞬", "Te"), TR_TELEPORT, -1 },
-    { N("怒", "Ag"), TR_AGGRAVATE, -1 },
-    { N("祝", "Bs"), TR_BLESSED, -1 },
-    { N("忌", "Ty"), TR_TY_CURSE, -1 },
-    { N("呪", "C-"), TR_ADD_L_CURSE, -1 },
-    { N("詛", "C+"), TR_ADD_H_CURSE, -1 },
-    { N("焼", "F"), TR_SELF_FIRE, -1 },
-    { N("凍", "Co"), TR_SELF_COLD, -1 },
-    { N("電", "E"), TR_SELF_ELEC, -1 },
+    { N("易", "Es"), TR_EASY_SPELL },
+    { N("減", "Dm"), TR_DEC_MANA },
+    { N("投", "Th"), TR_THROW },
+    { N("反", "Rf"), TR_REFLECT },
+    { N("麻", "Fa"), TR_FREE_ACT },
+    { N("視", "Si"), TR_SEE_INVIS },
+    { N("経", "Hl"), TR_HOLD_EXP },
+    { N("遅", "Sd"), TR_SLOW_DIGEST },
+    { N("活", "Rg"), TR_REGEN },
+    { N("浮", "Lv"), TR_LEVITATION },
+    { N("明", "Lu"), TR_LITE_1 },
+    { N("明", "Lu"), TR_LITE_2 },
+    { N("明", "Lu"), TR_LITE_3 },
+    { N("闇", "Dl"), TR_LITE_M1 },
+    { N("闇", "Dl"), TR_LITE_M2 },
+    { N("闇", "Dl"), TR_LITE_M3 },
+    { N("警", "Wr"), TR_WARNING },
+    { N("倍", "Xm"), TR_XTRA_MIGHT },
+    { N("射", "Xs"), TR_XTRA_SHOTS },
+    { N("瞬", "Te"), TR_TELEPORT },
+    { N("怒", "Ag"), TR_AGGRAVATE },
+    { N("祝", "Bs"), TR_BLESSED },
+    { N("忌", "Ty"), TR_TY_CURSE },
+    { N("呪", "C-"), TR_ADD_L_CURSE },
+    { N("詛", "C+"), TR_ADD_H_CURSE },
+    { N("焼", "F"), TR_SELF_FIRE },
+    { N("凍", "Co"), TR_SELF_COLD },
+    { N("電", "E"), TR_SELF_ELEC },
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(オーラ) */
 std::vector<flag_insc_table> flag_insc_aura = {
-    { N("炎", "F"), TR_SH_FIRE, -1 },
-    { N("電", "E"), TR_SH_ELEC, -1 },
-    { N("冷", "C"), TR_SH_COLD, -1 },
-    { N("魔", "M"), TR_NO_MAGIC, -1 },
-    { N("瞬", "T"), TR_NO_TELE, -1 },
+    { N("炎", "F"), TR_SH_FIRE },
+    { N("電", "E"), TR_SH_ELEC },
+    { N("冷", "C"), TR_SH_COLD },
+    { N("魔", "M"), TR_NO_MAGIC },
+    { N("瞬", "T"), TR_NO_TELE },
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(属性スレイ) */
 std::vector<flag_insc_table> flag_insc_brand = {
-    { N("酸", "A"), TR_BRAND_ACID, -1 },
-    { N("電", "E"), TR_BRAND_ELEC, -1 },
-    { N("焼", "F"), TR_BRAND_FIRE, -1 },
-    { N("凍", "Co"), TR_BRAND_COLD, -1 },
-    { N("毒", "P"), TR_BRAND_POIS, -1 },
-    { N("沌", "Ca"), TR_CHAOTIC, -1 },
-    { N("魔", "Ma"), TR_BRAND_MAGIC, -1 },
-    { N("吸", "V"), TR_VAMPIRIC, -1 },
-    { N("震", "Q"), TR_EARTHQUAKE, -1 },
-    { N("切", "Sl"), TR_VORPAL, -1 },
-    { N("強", "Sm"), TR_IMPACT, -1 },
-    { N("理", "Mf"), TR_FORCE_WEAPON, -1 }
+    { N("酸", "A"), TR_BRAND_ACID },
+    { N("電", "E"), TR_BRAND_ELEC },
+    { N("焼", "F"), TR_BRAND_FIRE },
+    { N("凍", "Co"), TR_BRAND_COLD },
+    { N("毒", "P"), TR_BRAND_POIS },
+    { N("沌", "Ca"), TR_CHAOTIC },
+    { N("魔", "Ma"), TR_BRAND_MAGIC },
+    { N("吸", "V"), TR_VAMPIRIC },
+    { N("震", "Q"), TR_EARTHQUAKE },
+    { N("切", "Sl"), TR_VORPAL },
+    { N("強", "Sm"), TR_IMPACT },
+    { N("理", "Mf"), TR_FORCE_WEAPON }
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(種族スレイ) */
 std::vector<flag_insc_table> flag_insc_kill = {
-    { N("邪", "*"), TR_KILL_EVIL, -1 },
-    { N("善", "A"), TR_KILL_GOOD, -1 },
-    { N("人", "p"), TR_KILL_HUMAN, -1 },
-    { N("龍", "D"), TR_KILL_DRAGON, -1 },
-    { N("オ", "o"), TR_KILL_ORC, -1 },
-    { N("ト", "T"), TR_KILL_TROLL, -1 },
-    { N("巨", "P"), TR_KILL_GIANT, -1 },
-    { N("デ", "U"), TR_KILL_DEMON, -1 },
-    { N("死", "L"), TR_KILL_UNDEAD, -1 },
-    { N("動", "Z"), TR_KILL_ANIMAL, -1 },
+    { N("邪", "*"), TR_KILL_EVIL },
+    { N("善", "A"), TR_KILL_GOOD },
+    { N("人", "p"), TR_KILL_HUMAN },
+    { N("龍", "D"), TR_KILL_DRAGON },
+    { N("オ", "o"), TR_KILL_ORC },
+    { N("ト", "T"), TR_KILL_TROLL },
+    { N("巨", "P"), TR_KILL_GIANT },
+    { N("デ", "U"), TR_KILL_DEMON },
+    { N("死", "L"), TR_KILL_UNDEAD },
+    { N("動", "Z"), TR_KILL_ANIMAL },
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(種族*スレイ*) */
@@ -167,31 +167,31 @@ std::vector<flag_insc_table> flag_insc_slay = {
 
 /*! オブジェクトの特性表示記号テーブルの定義(ESP1) */
 std::vector<flag_insc_table> flag_insc_esp1 = {
-    { N("感", "Tele"), TR_TELEPATHY, -1 },
-    { N("邪", "Evil"), TR_ESP_EVIL, -1 },
-    { N("善", "Good"), TR_ESP_GOOD, -1 },
-    { N("無", "Nolv"), TR_ESP_NONLIVING, -1 },
-    { N("個", "Uniq"), TR_ESP_UNIQUE, -1 },
+    { N("感", "Tele"), TR_TELEPATHY },
+    { N("邪", "Evil"), TR_ESP_EVIL },
+    { N("善", "Good"), TR_ESP_GOOD },
+    { N("無", "Nolv"), TR_ESP_NONLIVING },
+    { N("個", "Uniq"), TR_ESP_UNIQUE },
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(ESP2) */
 std::vector<flag_insc_table> flag_insc_esp2 = {
-    { N("人", "p"), TR_ESP_HUMAN, -1 },
-    { N("竜", "D"), TR_ESP_DRAGON, -1 },
-    { N("オ", "o"), TR_ESP_ORC, -1 },
-    { N("ト", "T"), TR_ESP_TROLL, -1 },
-    { N("巨", "P"), TR_ESP_GIANT, -1 },
-    { N("デ", "U"), TR_ESP_DEMON, -1 },
-    { N("死", "L"), TR_ESP_UNDEAD, -1 },
-    { N("動", "Z"), TR_ESP_ANIMAL, -1 },
+    { N("人", "p"), TR_ESP_HUMAN },
+    { N("竜", "D"), TR_ESP_DRAGON },
+    { N("オ", "o"), TR_ESP_ORC },
+    { N("ト", "T"), TR_ESP_TROLL },
+    { N("巨", "P"), TR_ESP_GIANT },
+    { N("デ", "U"), TR_ESP_DEMON },
+    { N("死", "L"), TR_ESP_UNDEAD },
+    { N("動", "Z"), TR_ESP_ANIMAL },
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(能力維持) */
 std::vector<flag_insc_table> flag_insc_sust = {
-    { N("腕", "St"), TR_SUST_STR, -1 },
-    { N("知", "In"), TR_SUST_INT, -1 },
-    { N("賢", "Wi"), TR_SUST_WIS, -1 },
-    { N("器", "Dx"), TR_SUST_DEX, -1 },
-    { N("耐", "Cn"), TR_SUST_CON, -1 },
-    { N("魅", "Ch"), TR_SUST_CHR, -1 },
+    { N("腕", "St"), TR_SUST_STR },
+    { N("知", "In"), TR_SUST_INT },
+    { N("賢", "Wi"), TR_SUST_WIS },
+    { N("器", "Dx"), TR_SUST_DEX },
+    { N("耐", "Cn"), TR_SUST_CON },
+    { N("魅", "Ch"), TR_SUST_CHR },
 };

--- a/src/flavor/flag-inscriptions-table.cpp
+++ b/src/flavor/flag-inscriptions-table.cpp
@@ -22,7 +22,7 @@ const concptr game_inscriptions[MAX_GAME_INSCRIPTIONS] = {
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(pval要素) */
-std::vector<flag_insc_table> flag_insc_plus = {
+const std::vector<flag_insc_table> flag_insc_plus = {
     { N("攻", "At"), TR_BLOWS },
     { N("速", "Sp"), TR_SPEED },
     { N("腕", "St"), TR_STR },
@@ -39,7 +39,7 @@ std::vector<flag_insc_table> flag_insc_plus = {
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(免疫) */
-std::vector<flag_insc_table> flag_insc_immune = {
+const std::vector<flag_insc_table> flag_insc_immune = {
     { N("酸", "Ac"), TR_IM_ACID },
     { N("電", "El"), TR_IM_ELEC },
     { N("火", "Fi"), TR_IM_FIRE },
@@ -48,7 +48,7 @@ std::vector<flag_insc_table> flag_insc_immune = {
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(弱点) */
-std::vector<flag_insc_table> flag_insc_vuln = {
+const std::vector<flag_insc_table> flag_insc_vuln = {
     { N("酸", "Ac"), TR_VUL_ACID, TR_IM_ACID },
     { N("電", "El"), TR_VUL_ELEC, TR_IM_ELEC },
     { N("火", "Fi"), TR_VUL_FIRE, TR_IM_FIRE },
@@ -58,7 +58,7 @@ std::vector<flag_insc_table> flag_insc_vuln = {
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(耐性) */
-std::vector<flag_insc_table> flag_insc_resistance = {
+const std::vector<flag_insc_table> flag_insc_resistance = {
     { N("酸", "Ac"), TR_RES_ACID, TR_IM_ACID },
     { N("電", "El"), TR_RES_ELEC, TR_IM_ELEC },
     { N("火", "Fi"), TR_RES_FIRE, TR_IM_FIRE },
@@ -81,7 +81,7 @@ std::vector<flag_insc_table> flag_insc_resistance = {
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(その他特性) */
-std::vector<flag_insc_table> flag_insc_misc = {
+const std::vector<flag_insc_table> flag_insc_misc = {
     { N("易", "Es"), TR_EASY_SPELL },
     { N("減", "Dm"), TR_DEC_MANA },
     { N("投", "Th"), TR_THROW },
@@ -113,7 +113,7 @@ std::vector<flag_insc_table> flag_insc_misc = {
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(オーラ) */
-std::vector<flag_insc_table> flag_insc_aura = {
+const std::vector<flag_insc_table> flag_insc_aura = {
     { N("炎", "F"), TR_SH_FIRE },
     { N("電", "E"), TR_SH_ELEC },
     { N("冷", "C"), TR_SH_COLD },
@@ -122,7 +122,7 @@ std::vector<flag_insc_table> flag_insc_aura = {
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(属性スレイ) */
-std::vector<flag_insc_table> flag_insc_brand = {
+const std::vector<flag_insc_table> flag_insc_brand = {
     { N("酸", "A"), TR_BRAND_ACID },
     { N("電", "E"), TR_BRAND_ELEC },
     { N("焼", "F"), TR_BRAND_FIRE },
@@ -138,7 +138,7 @@ std::vector<flag_insc_table> flag_insc_brand = {
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(種族スレイ) */
-std::vector<flag_insc_table> flag_insc_kill = {
+const std::vector<flag_insc_table> flag_insc_kill = {
     { N("邪", "*"), TR_KILL_EVIL },
     { N("善", "A"), TR_KILL_GOOD },
     { N("人", "p"), TR_KILL_HUMAN },
@@ -152,7 +152,7 @@ std::vector<flag_insc_table> flag_insc_kill = {
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(種族*スレイ*) */
-std::vector<flag_insc_table> flag_insc_slay = {
+const std::vector<flag_insc_table> flag_insc_slay = {
     { N("邪", "*"), TR_SLAY_EVIL, TR_KILL_EVIL },
     { N("善", "A"), TR_SLAY_GOOD, TR_KILL_GOOD },
     { N("人", "p"), TR_SLAY_HUMAN, TR_KILL_HUMAN },
@@ -166,7 +166,7 @@ std::vector<flag_insc_table> flag_insc_slay = {
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(ESP1) */
-std::vector<flag_insc_table> flag_insc_esp1 = {
+const std::vector<flag_insc_table> flag_insc_esp1 = {
     { N("感", "Tele"), TR_TELEPATHY },
     { N("邪", "Evil"), TR_ESP_EVIL },
     { N("善", "Good"), TR_ESP_GOOD },
@@ -175,7 +175,7 @@ std::vector<flag_insc_table> flag_insc_esp1 = {
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(ESP2) */
-std::vector<flag_insc_table> flag_insc_esp2 = {
+const std::vector<flag_insc_table> flag_insc_esp2 = {
     { N("人", "p"), TR_ESP_HUMAN },
     { N("竜", "D"), TR_ESP_DRAGON },
     { N("オ", "o"), TR_ESP_ORC },
@@ -187,7 +187,7 @@ std::vector<flag_insc_table> flag_insc_esp2 = {
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(能力維持) */
-std::vector<flag_insc_table> flag_insc_sust = {
+const std::vector<flag_insc_table> flag_insc_sust = {
     { N("腕", "St"), TR_SUST_STR },
     { N("知", "In"), TR_SUST_INT },
     { N("賢", "Wi"), TR_SUST_WIS },

--- a/src/flavor/flag-inscriptions-table.cpp
+++ b/src/flavor/flag-inscriptions-table.cpp
@@ -21,91 +21,177 @@ const concptr game_inscriptions[MAX_GAME_INSCRIPTIONS] = {
     _("特別製", "special"), /* FEEL_SPECIAL */
 };
 
-// clang-format off
 /*! オブジェクトの特性表示記号テーブルの定義(pval要素) */
 std::vector<flag_insc_table> flag_insc_plus = {
-    { N("攻", "At"), TR_BLOWS, -1 }, { N("速", "Sp"), TR_SPEED, -1 },
-    { N("腕", "St"), TR_STR, -1 }, { N("知", "In"), TR_INT, -1 }, { N("賢", "Wi"), TR_WIS, -1 },
-    { N("器", "Dx"), TR_DEX, -1 }, { N("耐", "Cn"), TR_CON, -1 }, { N("魅", "Ch"), TR_CHR, -1 }, { N("道", "Md"), TR_MAGIC_MASTERY, -1 },
-    { N("隠", "Sl"), TR_STEALTH, -1 }, { N("探", "Sr"), TR_SEARCH, -1 }, { N("赤", "If"), TR_INFRA, -1 }, { N("掘", "Dg"), TR_TUNNEL, -1 },
+    { N("攻", "At"), TR_BLOWS, -1 },
+    { N("速", "Sp"), TR_SPEED, -1 },
+    { N("腕", "St"), TR_STR, -1 },
+    { N("知", "In"), TR_INT, -1 },
+    { N("賢", "Wi"), TR_WIS, -1 },
+    { N("器", "Dx"), TR_DEX, -1 },
+    { N("耐", "Cn"), TR_CON, -1 },
+    { N("魅", "Ch"), TR_CHR, -1 },
+    { N("道", "Md"), TR_MAGIC_MASTERY, -1 },
+    { N("隠", "Sl"), TR_STEALTH, -1 },
+    { N("探", "Sr"), TR_SEARCH, -1 },
+    { N("赤", "If"), TR_INFRA, -1 },
+    { N("掘", "Dg"), TR_TUNNEL, -1 },
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(免疫) */
 std::vector<flag_insc_table> flag_insc_immune = {
-    { N("酸", "Ac"), TR_IM_ACID, -1 }, { N("電", "El"), TR_IM_ELEC, -1 }, { N("火", "Fi"), TR_IM_FIRE, -1 }, { N("冷", "Co"), TR_IM_COLD, -1 },
+    { N("酸", "Ac"), TR_IM_ACID, -1 },
+    { N("電", "El"), TR_IM_ELEC, -1 },
+    { N("火", "Fi"), TR_IM_FIRE, -1 },
+    { N("冷", "Co"), TR_IM_COLD, -1 },
     { N("暗", "Dk"), TR_IM_DARK, -1 }
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(弱点) */
 std::vector<flag_insc_table> flag_insc_vuln = {
-    { N("酸", "Ac"), TR_VUL_ACID, TR_IM_ACID }, { N("電", "El"), TR_VUL_ELEC, TR_IM_ELEC }, { N("火", "Fi"), TR_VUL_FIRE, TR_IM_FIRE }, { N("冷", "Co"), TR_VUL_COLD, TR_IM_COLD },
-    { N("閃", "Li"), TR_VUL_LITE, -1 }, { N("呪", "Cu"), TR_VUL_CURSE, -1 }
+    { N("酸", "Ac"), TR_VUL_ACID, TR_IM_ACID },
+    { N("電", "El"), TR_VUL_ELEC, TR_IM_ELEC },
+    { N("火", "Fi"), TR_VUL_FIRE, TR_IM_FIRE },
+    { N("冷", "Co"), TR_VUL_COLD, TR_IM_COLD },
+    { N("閃", "Li"), TR_VUL_LITE, -1 },
+    { N("呪", "Cu"), TR_VUL_CURSE, -1 }
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(耐性) */
 std::vector<flag_insc_table> flag_insc_resistance = {
-    { N("酸", "Ac"), TR_RES_ACID, TR_IM_ACID }, { N("電", "El"), TR_RES_ELEC, TR_IM_ELEC }, { N("火", "Fi"), TR_RES_FIRE, TR_IM_FIRE }, { N("冷", "Co"), TR_RES_COLD, TR_IM_COLD },
-    { N("毒", "Po"), TR_RES_POIS, -1 }, { N("閃", "Li"), TR_RES_LITE, -1 }, { N("暗", "Dk"), TR_RES_DARK, -1 }, { N("破", "Sh"), TR_RES_SHARDS, -1 },
-    { N("盲", "Bl"), TR_RES_BLIND, -1 }, { N("乱", "Cf"), TR_RES_CONF, -1 }, { N("轟", "So"), TR_RES_SOUND, -1 }, { N("獄", "Nt"), TR_RES_NETHER, -1 },
-    { N("因", "Nx"), TR_RES_NEXUS, -1 }, { N("沌", "Ca"), TR_RES_CHAOS, -1 }, { N("劣", "Di"), TR_RES_DISEN, -1 }, { N("時", "Tm"), TR_RES_TIME, -1 },
-    { N("水", "Wt"), TR_RES_WATER, -1 }, { N("恐", "Fe"), TR_RES_FEAR, -1 }, { N("呪", "Cu"), TR_RES_CURSE, -1 },
+    { N("酸", "Ac"), TR_RES_ACID, TR_IM_ACID },
+    { N("電", "El"), TR_RES_ELEC, TR_IM_ELEC },
+    { N("火", "Fi"), TR_RES_FIRE, TR_IM_FIRE },
+    { N("冷", "Co"), TR_RES_COLD, TR_IM_COLD },
+    { N("毒", "Po"), TR_RES_POIS, -1 },
+    { N("閃", "Li"), TR_RES_LITE, -1 },
+    { N("暗", "Dk"), TR_RES_DARK, -1 },
+    { N("破", "Sh"), TR_RES_SHARDS, -1 },
+    { N("盲", "Bl"), TR_RES_BLIND, -1 },
+    { N("乱", "Cf"), TR_RES_CONF, -1 },
+    { N("轟", "So"), TR_RES_SOUND, -1 },
+    { N("獄", "Nt"), TR_RES_NETHER, -1 },
+    { N("因", "Nx"), TR_RES_NEXUS, -1 },
+    { N("沌", "Ca"), TR_RES_CHAOS, -1 },
+    { N("劣", "Di"), TR_RES_DISEN, -1 },
+    { N("時", "Tm"), TR_RES_TIME, -1 },
+    { N("水", "Wt"), TR_RES_WATER, -1 },
+    { N("恐", "Fe"), TR_RES_FEAR, -1 },
+    { N("呪", "Cu"), TR_RES_CURSE, -1 },
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(その他特性) */
 std::vector<flag_insc_table> flag_insc_misc = {
-    { N("易", "Es"), TR_EASY_SPELL, -1 }, { N("減", "Dm"), TR_DEC_MANA, -1 },
-    { N("投", "Th"), TR_THROW, -1 }, { N("反", "Rf"), TR_REFLECT, -1 }, { N("麻", "Fa"), TR_FREE_ACT, -1 }, { N("視", "Si"), TR_SEE_INVIS, -1 },
-    { N("経", "Hl"), TR_HOLD_EXP, -1 }, { N("遅", "Sd"), TR_SLOW_DIGEST, -1 }, { N("活", "Rg"), TR_REGEN, -1 }, { N("浮", "Lv"), TR_LEVITATION, -1 },
-    { N("明", "Lu"), TR_LITE_1, -1 }, { N("明", "Lu"), TR_LITE_2, -1 }, { N("明", "Lu"), TR_LITE_3, -1 }, { N("闇", "Dl"), TR_LITE_M1, -1 },
-    { N("闇", "Dl"), TR_LITE_M2, -1 }, { N("闇", "Dl"), TR_LITE_M3, -1 }, { N("警", "Wr"), TR_WARNING, -1 }, { N("倍", "Xm"), TR_XTRA_MIGHT, -1 },
-    { N("射", "Xs"), TR_XTRA_SHOTS, -1 }, { N("瞬", "Te"), TR_TELEPORT, -1 }, { N("怒", "Ag"), TR_AGGRAVATE, -1 }, { N("祝", "Bs"), TR_BLESSED, -1 },
-    { N("忌", "Ty"), TR_TY_CURSE, -1 }, { N("呪", "C-"), TR_ADD_L_CURSE, -1 }, { N("詛", "C+"), TR_ADD_H_CURSE, -1 },
-    { N("焼", "F"), TR_SELF_FIRE, -1 }, { N("凍", "Co"), TR_SELF_COLD, -1 }, { N("電", "E"), TR_SELF_ELEC, -1 },
+    { N("易", "Es"), TR_EASY_SPELL, -1 },
+    { N("減", "Dm"), TR_DEC_MANA, -1 },
+    { N("投", "Th"), TR_THROW, -1 },
+    { N("反", "Rf"), TR_REFLECT, -1 },
+    { N("麻", "Fa"), TR_FREE_ACT, -1 },
+    { N("視", "Si"), TR_SEE_INVIS, -1 },
+    { N("経", "Hl"), TR_HOLD_EXP, -1 },
+    { N("遅", "Sd"), TR_SLOW_DIGEST, -1 },
+    { N("活", "Rg"), TR_REGEN, -1 },
+    { N("浮", "Lv"), TR_LEVITATION, -1 },
+    { N("明", "Lu"), TR_LITE_1, -1 },
+    { N("明", "Lu"), TR_LITE_2, -1 },
+    { N("明", "Lu"), TR_LITE_3, -1 },
+    { N("闇", "Dl"), TR_LITE_M1, -1 },
+    { N("闇", "Dl"), TR_LITE_M2, -1 },
+    { N("闇", "Dl"), TR_LITE_M3, -1 },
+    { N("警", "Wr"), TR_WARNING, -1 },
+    { N("倍", "Xm"), TR_XTRA_MIGHT, -1 },
+    { N("射", "Xs"), TR_XTRA_SHOTS, -1 },
+    { N("瞬", "Te"), TR_TELEPORT, -1 },
+    { N("怒", "Ag"), TR_AGGRAVATE, -1 },
+    { N("祝", "Bs"), TR_BLESSED, -1 },
+    { N("忌", "Ty"), TR_TY_CURSE, -1 },
+    { N("呪", "C-"), TR_ADD_L_CURSE, -1 },
+    { N("詛", "C+"), TR_ADD_H_CURSE, -1 },
+    { N("焼", "F"), TR_SELF_FIRE, -1 },
+    { N("凍", "Co"), TR_SELF_COLD, -1 },
+    { N("電", "E"), TR_SELF_ELEC, -1 },
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(オーラ) */
 std::vector<flag_insc_table> flag_insc_aura = {
-    { N("炎", "F"), TR_SH_FIRE, -1 }, { N("電", "E"), TR_SH_ELEC, -1 }, { N("冷", "C"), TR_SH_COLD, -1 },
-    { N("魔", "M"), TR_NO_MAGIC, -1 }, { N("瞬", "T"), TR_NO_TELE, -1 },
+    { N("炎", "F"), TR_SH_FIRE, -1 },
+    { N("電", "E"), TR_SH_ELEC, -1 },
+    { N("冷", "C"), TR_SH_COLD, -1 },
+    { N("魔", "M"), TR_NO_MAGIC, -1 },
+    { N("瞬", "T"), TR_NO_TELE, -1 },
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(属性スレイ) */
 std::vector<flag_insc_table> flag_insc_brand = {
-    { N("酸", "A"), TR_BRAND_ACID, -1 }, { N("電", "E"), TR_BRAND_ELEC, -1 }, { N("焼", "F"), TR_BRAND_FIRE, -1 }, { N("凍", "Co"), TR_BRAND_COLD, -1 },
-    { N("毒", "P"), TR_BRAND_POIS, -1 }, { N("沌", "Ca"), TR_CHAOTIC, -1 }, { N("魔", "Ma"), TR_BRAND_MAGIC, -1 },
-    { N("吸", "V"), TR_VAMPIRIC, -1 }, { N("震", "Q"), TR_EARTHQUAKE, -1 }, { N("切", "Sl"), TR_VORPAL, -1 }, { N("強", "Sm"), TR_IMPACT, -1 },
+    { N("酸", "A"), TR_BRAND_ACID, -1 },
+    { N("電", "E"), TR_BRAND_ELEC, -1 },
+    { N("焼", "F"), TR_BRAND_FIRE, -1 },
+    { N("凍", "Co"), TR_BRAND_COLD, -1 },
+    { N("毒", "P"), TR_BRAND_POIS, -1 },
+    { N("沌", "Ca"), TR_CHAOTIC, -1 },
+    { N("魔", "Ma"), TR_BRAND_MAGIC, -1 },
+    { N("吸", "V"), TR_VAMPIRIC, -1 },
+    { N("震", "Q"), TR_EARTHQUAKE, -1 },
+    { N("切", "Sl"), TR_VORPAL, -1 },
+    { N("強", "Sm"), TR_IMPACT, -1 },
     { N("理", "Mf"), TR_FORCE_WEAPON, -1 }
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(種族スレイ) */
 std::vector<flag_insc_table> flag_insc_kill = {
-    { N("邪", "*"), TR_KILL_EVIL, -1 }, { N("善", "A"), TR_KILL_GOOD, -1 }, { N("人", "p"), TR_KILL_HUMAN, -1 }, { N("龍", "D"), TR_KILL_DRAGON, -1 },
-    { N("オ", "o"), TR_KILL_ORC, -1 }, { N("ト", "T"), TR_KILL_TROLL, -1 }, { N("巨", "P"), TR_KILL_GIANT, -1 },
-    { N("デ", "U"), TR_KILL_DEMON, -1 }, { N("死", "L"), TR_KILL_UNDEAD, -1 }, { N("動", "Z"), TR_KILL_ANIMAL, -1 },
+    { N("邪", "*"), TR_KILL_EVIL, -1 },
+    { N("善", "A"), TR_KILL_GOOD, -1 },
+    { N("人", "p"), TR_KILL_HUMAN, -1 },
+    { N("龍", "D"), TR_KILL_DRAGON, -1 },
+    { N("オ", "o"), TR_KILL_ORC, -1 },
+    { N("ト", "T"), TR_KILL_TROLL, -1 },
+    { N("巨", "P"), TR_KILL_GIANT, -1 },
+    { N("デ", "U"), TR_KILL_DEMON, -1 },
+    { N("死", "L"), TR_KILL_UNDEAD, -1 },
+    { N("動", "Z"), TR_KILL_ANIMAL, -1 },
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(種族*スレイ*) */
 std::vector<flag_insc_table> flag_insc_slay = {
-    { N("邪", "*"), TR_SLAY_EVIL, TR_KILL_EVIL }, { N("善", "A"), TR_SLAY_GOOD, TR_KILL_GOOD }, { N("人", "p"), TR_SLAY_HUMAN, TR_KILL_HUMAN }, { N("竜", "D"), TR_SLAY_DRAGON, TR_KILL_DRAGON },
-    { N("オ", "o"), TR_SLAY_ORC, TR_KILL_ORC }, { N("ト", "T"), TR_SLAY_TROLL, TR_KILL_TROLL }, { N("巨", "P"), TR_SLAY_GIANT, TR_KILL_GIANT },
-    { N("デ", "U"), TR_SLAY_DEMON, TR_KILL_DEMON }, { N("死", "L"), TR_SLAY_UNDEAD, TR_KILL_UNDEAD }, { N("動", "Z"), TR_SLAY_ANIMAL, TR_KILL_ANIMAL },
+    { N("邪", "*"), TR_SLAY_EVIL, TR_KILL_EVIL },
+    { N("善", "A"), TR_SLAY_GOOD, TR_KILL_GOOD },
+    { N("人", "p"), TR_SLAY_HUMAN, TR_KILL_HUMAN },
+    { N("竜", "D"), TR_SLAY_DRAGON, TR_KILL_DRAGON },
+    { N("オ", "o"), TR_SLAY_ORC, TR_KILL_ORC },
+    { N("ト", "T"), TR_SLAY_TROLL, TR_KILL_TROLL },
+    { N("巨", "P"), TR_SLAY_GIANT, TR_KILL_GIANT },
+    { N("デ", "U"), TR_SLAY_DEMON, TR_KILL_DEMON },
+    { N("死", "L"), TR_SLAY_UNDEAD, TR_KILL_UNDEAD },
+    { N("動", "Z"), TR_SLAY_ANIMAL, TR_KILL_ANIMAL },
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(ESP1) */
 std::vector<flag_insc_table> flag_insc_esp1 = {
-    { N("感", "Tele"), TR_TELEPATHY, -1 }, { N("邪", "Evil"), TR_ESP_EVIL, -1 }, { N("善", "Good"), TR_ESP_GOOD, -1 },
-    { N("無", "Nolv"), TR_ESP_NONLIVING, -1 }, { N("個", "Uniq"), TR_ESP_UNIQUE, -1 },
+    { N("感", "Tele"), TR_TELEPATHY, -1 },
+    { N("邪", "Evil"), TR_ESP_EVIL, -1 },
+    { N("善", "Good"), TR_ESP_GOOD, -1 },
+    { N("無", "Nolv"), TR_ESP_NONLIVING, -1 },
+    { N("個", "Uniq"), TR_ESP_UNIQUE, -1 },
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(ESP2) */
 std::vector<flag_insc_table> flag_insc_esp2 = {
-    { N("人", "p"), TR_ESP_HUMAN, -1 }, { N("竜", "D"), TR_ESP_DRAGON, -1 }, { N("オ", "o"), TR_ESP_ORC, -1 }, { N("ト", "T"), TR_ESP_TROLL, -1 },
-    { N("巨", "P"), TR_ESP_GIANT, -1 }, { N("デ", "U"), TR_ESP_DEMON, -1 }, { N("死", "L"), TR_ESP_UNDEAD, -1 }, { N("動", "Z"), TR_ESP_ANIMAL, -1 },
+    { N("人", "p"), TR_ESP_HUMAN, -1 },
+    { N("竜", "D"), TR_ESP_DRAGON, -1 },
+    { N("オ", "o"), TR_ESP_ORC, -1 },
+    { N("ト", "T"), TR_ESP_TROLL, -1 },
+    { N("巨", "P"), TR_ESP_GIANT, -1 },
+    { N("デ", "U"), TR_ESP_DEMON, -1 },
+    { N("死", "L"), TR_ESP_UNDEAD, -1 },
+    { N("動", "Z"), TR_ESP_ANIMAL, -1 },
 };
 
 /*! オブジェクトの特性表示記号テーブルの定義(能力維持) */
 std::vector<flag_insc_table> flag_insc_sust = {
-    { N("腕", "St"), TR_SUST_STR, -1 }, { N("知", "In"), TR_SUST_INT, -1 }, { N("賢", "Wi"), TR_SUST_WIS, -1 },
-    { N("器", "Dx"), TR_SUST_DEX, -1 }, { N("耐", "Cn"), TR_SUST_CON, -1 }, { N("魅", "Ch"), TR_SUST_CHR, -1 },
+    { N("腕", "St"), TR_SUST_STR, -1 },
+    { N("知", "In"), TR_SUST_INT, -1 },
+    { N("賢", "Wi"), TR_SUST_WIS, -1 },
+    { N("器", "Dx"), TR_SUST_DEX, -1 },
+    { N("耐", "Cn"), TR_SUST_CON, -1 },
+    { N("魅", "Ch"), TR_SUST_CHR, -1 },
 };
-// clang format on

--- a/src/flavor/flag-inscriptions-table.h
+++ b/src/flavor/flag-inscriptions-table.h
@@ -38,15 +38,15 @@ struct flag_insc_table {
 
 extern const concptr game_inscriptions[MAX_GAME_INSCRIPTIONS];
 
-extern std::vector<flag_insc_table> flag_insc_plus;
-extern std::vector<flag_insc_table> flag_insc_immune;
-extern std::vector<flag_insc_table> flag_insc_vuln;
-extern std::vector<flag_insc_table> flag_insc_resistance;
-extern std::vector<flag_insc_table> flag_insc_misc;
-extern std::vector<flag_insc_table> flag_insc_aura;
-extern std::vector<flag_insc_table> flag_insc_brand;
-extern std::vector<flag_insc_table> flag_insc_kill;
-extern std::vector<flag_insc_table> flag_insc_slay;
-extern std::vector<flag_insc_table> flag_insc_esp1;
-extern std::vector<flag_insc_table> flag_insc_esp2;
-extern std::vector<flag_insc_table> flag_insc_sust;
+extern const std::vector<flag_insc_table> flag_insc_plus;
+extern const std::vector<flag_insc_table> flag_insc_immune;
+extern const std::vector<flag_insc_table> flag_insc_vuln;
+extern const std::vector<flag_insc_table> flag_insc_resistance;
+extern const std::vector<flag_insc_table> flag_insc_misc;
+extern const std::vector<flag_insc_table> flag_insc_aura;
+extern const std::vector<flag_insc_table> flag_insc_brand;
+extern const std::vector<flag_insc_table> flag_insc_kill;
+extern const std::vector<flag_insc_table> flag_insc_slay;
+extern const std::vector<flag_insc_table> flag_insc_esp1;
+extern const std::vector<flag_insc_table> flag_insc_esp2;
+extern const std::vector<flag_insc_table> flag_insc_sust;

--- a/src/flavor/flag-inscriptions-table.h
+++ b/src/flavor/flag-inscriptions-table.h
@@ -1,5 +1,6 @@
 ﻿#pragma once
 
+#include <optional>
 #include <vector>
 
 #include "system/angband.h"
@@ -11,11 +12,28 @@ enum tr_type : int32_t;
 /*! オブジェクトの特性表示記号テーブルの構造体 / Structs and tables for Auto Inscription for flags */
 struct flag_insc_table {
 #ifdef JP
+    flag_insc_table(concptr japanese, concptr english, tr_type flag, std::optional<tr_type> except_flag = std::nullopt)
+        : japanese(japanese)
+        , english(english)
+        , flag(flag)
+        , except_flag(except_flag)
+    {
+    }
+#else
+    flag_insc_table(concptr english, tr_type flag, std::optional<tr_type> except_flag = std::nullopt)
+        : english(english)
+        , flag(flag)
+        , except_flag(except_flag)
+    {
+    }
+#endif
+
+#ifdef JP
     concptr japanese;
 #endif
     concptr english;
     tr_type flag;
-    int except_flag;
+    std::optional<tr_type> except_flag;
 };
 
 extern const concptr game_inscriptions[MAX_GAME_INSCRIPTIONS];

--- a/src/flavor/flavor-util.cpp
+++ b/src/flavor/flavor-util.cpp
@@ -146,14 +146,14 @@ static void add_inscription(char **short_flavor, concptr str)
  * sprintf(t, "%+d", n), and return a pointer to the terminator.
  * Note that we always print a sign, either "+" or "-".
  */
-static char *inscribe_flags_aux(std::vector<flag_insc_table> &fi_vec, const TrFlags &flgs, bool kanji, char *ptr)
+static char *inscribe_flags_aux(const std::vector<flag_insc_table> &fi_vec, const TrFlags &flgs, bool kanji, char *ptr)
 {
 #ifdef JP
 #else
     (void)kanji;
 #endif
 
-    for (flag_insc_table &fi : fi_vec) {
+    for (const auto &fi : fi_vec) {
         if (flgs.has(fi.flag) && (!fi.except_flag.has_value() || flgs.has_not(fi.except_flag.value()))) {
             add_inscription(&ptr, _(kanji ? fi.japanese : fi.english, fi.english));
         }
@@ -169,9 +169,9 @@ static char *inscribe_flags_aux(std::vector<flag_insc_table> &fi_vec, const TrFl
  * @param flgs 対応するオブジェクトのフラグ文字列
  * @return 1つでも該当の特性があったらTRUEを返す。
  */
-static bool has_flag_of(std::vector<flag_insc_table> &fi_vec, const TrFlags &flgs)
+static bool has_flag_of(const std::vector<flag_insc_table> &fi_vec, const TrFlags &flgs)
 {
-    for (flag_insc_table &fi : fi_vec) {
+    for (const auto &fi : fi_vec) {
         if (flgs.has(fi.flag) && (!fi.except_flag.has_value() || flgs.has_not(fi.except_flag.value()))) {
             return true;
         }

--- a/src/flavor/flavor-util.cpp
+++ b/src/flavor/flavor-util.cpp
@@ -154,7 +154,7 @@ static char *inscribe_flags_aux(std::vector<flag_insc_table> &fi_vec, const TrFl
 #endif
 
     for (flag_insc_table &fi : fi_vec) {
-        if (flgs.has(fi.flag) && (fi.except_flag == -1 || flgs.has_not(i2enum<tr_type>(fi.except_flag)))) {
+        if (flgs.has(fi.flag) && (!fi.except_flag.has_value() || flgs.has_not(fi.except_flag.value()))) {
             add_inscription(&ptr, _(kanji ? fi.japanese : fi.english, fi.english));
         }
     }
@@ -172,7 +172,7 @@ static char *inscribe_flags_aux(std::vector<flag_insc_table> &fi_vec, const TrFl
 static bool has_flag_of(std::vector<flag_insc_table> &fi_vec, const TrFlags &flgs)
 {
     for (flag_insc_table &fi : fi_vec) {
-        if (flgs.has(fi.flag) && (fi.except_flag == -1 || flgs.has_not(i2enum<tr_type>(fi.except_flag)))) {
+        if (flgs.has(fi.flag) && (!fi.except_flag.has_value() || flgs.has_not(fi.except_flag.value()))) {
             return true;
         }
     }


### PR DESCRIPTION
特性表示記号テーブルの定義について以下のリファクタリングを行いました。

- テーブルの初期化リストの整列
- except_flag を int から std::optional<tr_type> に変更
- constを付与