### PR TITLE
[Fix] #2509 未鑑定の篭手がまとまってしまう事がある

### DIFF
--- a/src/object/object-stack.cpp
+++ b/src/object/object-stack.cpp
@@ -140,6 +140,10 @@ int object_similar_part(const ObjectType *o_ptr, const ObjectType *j_ptr)
             return 0;
         }
 
+        if (!o_ptr->is_known() || !j_ptr->is_known()) {
+            return 0;
+        }
+
         if (!o_ptr->can_pile(j_ptr)) {
             return 0;
         }


### PR DESCRIPTION
Resolve #2509 

2.2.1r のソースと見比べたところ、リファクタリングの過程で篭手の処理が分離された際に
どちらか一方でも未鑑定であればまとまらないようにする判定が失われてしまっていた。
他の装備品と同様にどちらか一方でも未鑑定であればまとまらないようにする処理を追加する。