### PR TITLE
アイテムから発動IDを取ろうとする処理で落ちることがある

### DIFF
--- a/src/artifact/artifact-info.cpp
+++ b/src/artifact/artifact-info.cpp
@@ -28,9 +28,11 @@ RandomArtActType activation_index(const ObjectType *o_ptr)
         return act_idx.value();
     }
 
-    const auto &fixed_artifact = a_info.at(o_ptr->fixed_artifact_idx);
-    if (o_ptr->is_fixed_artifact() && fixed_artifact.flags.has(TR_ACTIVATE)) {
-        return fixed_artifact.act_idx;
+    if (o_ptr->is_fixed_artifact()) {
+        const auto &fixed_artifact = a_info.at(o_ptr->fixed_artifact_idx);
+        if (fixed_artifact.flags.has(TR_ACTIVATE)) {
+            return fixed_artifact.act_idx;
+        }
     }
 
     if (o_ptr->is_ego() && e_info[o_ptr->ego_idx].flags.has(TR_ACTIVATE)) {

--- a/src/system/angband-version.h
+++ b/src/system/angband-version.h
@@ -23,7 +23,7 @@ constexpr std::string_view ROOT_VARIANT_NAME("Hengband");
 #define H_VER_MAJOR 3 //!< ゲームのバージョン定義(メジャー番号)
 #define H_VER_MINOR 0 //!< ゲームのバージョン定義(マイナー番号)
 #define H_VER_PATCH 0 //!< ゲームのバージョン定義(パッチ番号)
-#define H_VER_EXTRA 66 //!< ゲームのバージョン定義(エクストラ番号)
+#define H_VER_EXTRA 67 //!< ゲームのバージョン定義(エクストラ番号)
 
 /*!
  * @brief セーブファイルのバージョン(3.0.0から導入)


### PR DESCRIPTION
Hotfix (クラッシュバグ)につきmaster ブランチにも反映させます
ご確認下さい