### PR TITLE
[Fix] 暗黒・盲目耐性なしで暗黒属性攻撃を受けても盲目にならない

### DIFF
--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -446,7 +446,7 @@ void effect_player_dark(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
     ep_ptr->dam = ep_ptr->dam * calc_dark_damage_rate(player_ptr, CALC_RAND) / 100;
 
-    auto go_blind = is_blind;
+    auto go_blind = !is_blind;
     go_blind &= !has_resist_blind(player_ptr);
     go_blind &= !(has_resist_dark(player_ptr) || has_immune_dark(player_ptr));
     go_blind &= !check_multishadow(player_ptr);


### PR DESCRIPTION
Resolves #2668

リファクタリング時の真偽反転によるエンバグ。正しい真偽値に修正する。