### PR TITLE
[Fix] #2667 自身をターゲットにスーパーレイを打つとクラッシュする

### DIFF
--- a/src/spell-class/spells-mirror-master.cpp
+++ b/src/spell-class/spells-mirror-master.cpp
@@ -471,6 +471,10 @@ void SpellsMirrorMaster::project_super_ray(int target_x, int target_y, int dam)
     std::vector<projection_path> second_path_g_list;
     handle_stuff(this->player_ptr);
 
+    if (path_g.path_num() == 0) {
+        return;
+    }
+
     project_m_n = 0;
     project_m_x = 0;
     project_m_y = 0;


### PR DESCRIPTION
自身をターゲットにしてスーパーレイを打つと魔法軌道の長さが 0 になるが、この時内部で保持
するサイズ 0 のコンテナに対し back() を取ってしまいクラッシュする。
長さが 0 の時はその後の処理を行わずリターンするようにする。
なお、この時何も起きずMPだけ消費することになるが、エンバグ前も同じ仕様である。