### PR TITLE
[Fix] configure の --with-setgid オプションが正しく機能しない

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,7 @@ AM_CONDITIONAL(SET_GID, test "$GAMEGROUP" != "")
 
 dnl generate the installation path for the ./lib/ folder
 if test "$GAMEGROUP" != ""; then
-  MY_EXPAND_DIR(game_libpath, "$datadir/games/$PACKAGE/lib/")
+  MY_EXPAND_DIR(game_libpath, "$datarootdir/games/$PACKAGE/lib/")
 else
   MY_EXPAND_DIR(game_libpath, "./lib/")
   bindir=".."


### PR DESCRIPTION
configure の --with-setgid オプションででグループを指定してコンパイルし、make install を行うと指定された prefix ディレクトリ以下に実行バイナリとゲームのデータがインストールされるが、このときゲームのデータがインストールされるパス DEFAULT_LIB_PATH の定義が "${prefix}/share/games/hengband/lib/" と ${prefix} の部分が正しく展開されずそのまま残ってしまうためゲームのデータが読み込めず、ゲームを起動することができない。
configure.ac 内の `$datadir` を `$datarootdir` にすると ${prefix} の部分が正しく 展開されるようになるようなので、そのように修正する。