### PR TITLE
噂を聞く時に欠番の固定アーティファクトIDを指定されるとクラッシュする不具合を修正した

### DIFF
--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -69,7 +69,11 @@ void display_rumor(PlayerType *player_ptr, bool ex)
         ArtifactType *a_ptr;
         while (true) {
             a_idx = i2enum<FixedArtifactId>(rumor_num(zz[1], enum2i(artifacts_info.rbegin()->first)));
-            a_ptr = &artifacts_info.at(a_idx);
+            a_ptr = ArtifactsInfo::get_instance().get_artifact(a_idx);
+            if (a_ptr == nullptr) {
+                continue;
+            }
+
             if (!a_ptr->name.empty()) {
                 break;
             }

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -16,11 +16,7 @@
 #include "view/display-messages.h"
 #include "world/world.h"
 
-/*
- * Display a rumor and apply its effects
- */
-
-IDX rumor_num(char *zz, IDX max_idx)
+static IDX get_rumor_num(char *zz, IDX max_idx)
 {
     if (strcmp(zz, "*") == 0) {
         return randint1(max_idx - 1);
@@ -28,7 +24,7 @@ IDX rumor_num(char *zz, IDX max_idx)
     return (IDX)atoi(zz);
 }
 
-concptr rumor_bind_name(char *base, concptr fullname)
+static concptr bind_rumor_name(char *base, concptr fullname)
 {
     char *s, *v;
     s = strstr(base, "{Name}");
@@ -68,7 +64,7 @@ void display_rumor(PlayerType *player_ptr, bool ex)
         FixedArtifactId a_idx;
         ArtifactType *a_ptr;
         while (true) {
-            a_idx = i2enum<FixedArtifactId>(rumor_num(zz[1], enum2i(artifacts_info.rbegin()->first)));
+            a_idx = i2enum<FixedArtifactId>(get_rumor_num(zz[1], enum2i(artifacts_info.rbegin()->first)));
             a_ptr = ArtifactsInfo::get_instance().get_artifact(a_idx);
             if (a_ptr == nullptr) {
                 continue;
@@ -89,7 +85,7 @@ void display_rumor(PlayerType *player_ptr, bool ex)
     } else if (strcmp(zz[0], "MONSTER") == 0) {
         monster_race *r_ptr;
         while (true) {
-            auto r_idx = i2enum<MonsterRaceId>(rumor_num(zz[1], static_cast<IDX>(monraces_info.size())));
+            auto r_idx = i2enum<MonsterRaceId>(get_rumor_num(zz[1], static_cast<IDX>(monraces_info.size())));
             r_ptr = &monraces_info[r_idx];
             if (!r_ptr->name.empty()) {
                 break;
@@ -105,7 +101,7 @@ void display_rumor(PlayerType *player_ptr, bool ex)
         DUNGEON_IDX d_idx;
         dungeon_type *d_ptr;
         while (true) {
-            d_idx = rumor_num(zz[1], static_cast<IDX>(dungeons_info.size()));
+            d_idx = get_rumor_num(zz[1], static_cast<IDX>(dungeons_info.size()));
             d_ptr = &dungeons_info[d_idx];
             if (!d_ptr->name.empty()) {
                 break;
@@ -121,7 +117,7 @@ void display_rumor(PlayerType *player_ptr, bool ex)
     } else if (strcmp(zz[0], "TOWN") == 0) {
         IDX t_idx;
         while (true) {
-            t_idx = rumor_num(zz[1], NO_TOWN);
+            t_idx = get_rumor_num(zz[1], NO_TOWN);
             if (town_info[t_idx].name[0] != '\0') {
                 break;
             }
@@ -136,7 +132,7 @@ void display_rumor(PlayerType *player_ptr, bool ex)
         }
     }
 
-    concptr rumor_msg = rumor_bind_name(zz[2], fullname);
+    concptr rumor_msg = bind_rumor_name(zz[2], fullname);
     msg_print(rumor_msg);
     if (rumor_eff_format) {
         msg_print(nullptr);

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -29,7 +29,7 @@
 static short get_rumor_num(std::string_view zz, short max_idx)
 {
     if (zz == "*") {
-        return randint1(max_idx - 1);
+        return randint1(max_idx);
     }
 
     return static_cast<short>(atoi(zz.data()));
@@ -121,7 +121,9 @@ void display_rumor(PlayerType *player_ptr, bool ex)
     } else if (category == "MONSTER") {
         monster_race *r_ptr;
         const auto &monster_name = tokens[1];
-        const auto monraces_size = static_cast<short>(monraces_info.size());
+
+        // @details プレイヤーもダミーで入っているので、1つ引いておかないと数が合わなくなる.
+        const auto monraces_size = static_cast<short>(monraces_info.size() - 1);
         while (true) {
             auto r_idx = i2enum<MonsterRaceId>(get_rumor_num(monster_name, monraces_size));
             r_ptr = &monraces_info[r_idx];

--- a/src/system/artifact-type-definition.cpp
+++ b/src/system/artifact-type-definition.cpp
@@ -1,6 +1,21 @@
 ﻿#include "system/artifact-type-definition.h"
+#include "artifact/fixed-art-types.h"
 
-/*
- * The artifact arrays
- */
 std::map<FixedArtifactId, ArtifactType> artifacts_info;
+
+ArtifactsInfo ArtifactsInfo::instance{};
+
+ArtifactsInfo &ArtifactsInfo::get_instance()
+{
+    return instance;
+}
+
+ArtifactType *ArtifactsInfo::get_artifact(const FixedArtifactId id) const
+{
+    auto itr = artifacts_info.find(id);
+    if (itr == artifacts_info.end()) {
+        return nullptr;
+    }
+
+    return &itr->second;
+}

--- a/src/system/artifact-type-definition.h
+++ b/src/system/artifact-type-definition.h
@@ -43,3 +43,19 @@ public:
 };
 
 extern std::map<FixedArtifactId, ArtifactType> artifacts_info;
+
+class ArtifactsInfo {
+public:
+    ArtifactsInfo(const ArtifactsInfo &) = delete;
+    ArtifactsInfo(ArtifactsInfo &&) = delete;
+    ArtifactsInfo &operator=(const ArtifactsInfo &) = delete;
+    ArtifactsInfo &operator=(ArtifactsInfo &&) = delete;
+    ~ArtifactsInfo() = default;
+
+    static ArtifactsInfo &get_instance();
+    ArtifactType *get_artifact(const FixedArtifactId id) const;
+
+private:
+    ArtifactsInfo() = default;
+    static ArtifactsInfo instance;
+};


### PR DESCRIPTION
掲題の通りです
具体的にはartifact-type-definition.cpp/h に、固定アーティファクトIDから固定アーティファクトへのポインタを返すシングルトンなメソッドを実装しました
optionalなのでhas\_value() で存在確認が可能です

ついでにC言語時代の配列だらけでイミフだったので所見でも理解度が上がるように改造しました
ついでにしてはちょっと規模が大きい気もしますし、リファクタリングとしては中途半端な気もしますが、デバッグで動かしたところ、固定アーティファクト・町・ダンジョン・モンスター全て問題なく動いたのでこのままPRに出します
ご確認下さい
(続きは別チケットで行う予定)