### PR TITLE
[Refactor] std::string をC言語の文字列表現に変換するメソッドを統一

### DIFF
--- a/src/action/movement-execution.cpp
+++ b/src/action/movement-execution.cpp
@@ -229,17 +229,17 @@ void exe_movement(PlayerType *player_ptr, DIRECTION dir, bool do_pickup, bool br
         } else if (f_ptr->flags.has(TerrainCharacteristics::CAN_SWIM) && (riding_r_ptr->feature_flags.has(MonsterFeatureType::CAN_SWIM))) {
             /* Allow moving */
         } else if (f_ptr->flags.has(TerrainCharacteristics::WATER) && riding_r_ptr->feature_flags.has_not(MonsterFeatureType::AQUATIC) && (f_ptr->flags.has(TerrainCharacteristics::DEEP) || riding_r_ptr->aura_flags.has(MonsterAuraType::FIRE))) {
-            msg_format(_("%sの上に行けない。", "Can't swim."), terrains_info[g_ptr->get_feat_mimic()].name.c_str());
+            msg_format(_("%sの上に行けない。", "Can't swim."), terrains_info[g_ptr->get_feat_mimic()].name.data());
             energy.reset_player_turn();
             can_move = false;
             disturb(player_ptr, false, true);
         } else if (f_ptr->flags.has_not(TerrainCharacteristics::WATER) && riding_r_ptr->feature_flags.has(MonsterFeatureType::AQUATIC)) {
-            msg_format(_("%sから上がれない。", "Can't land."), terrains_info[floor_ptr->grid_array[player_ptr->y][player_ptr->x].get_feat_mimic()].name.c_str());
+            msg_format(_("%sから上がれない。", "Can't land."), terrains_info[floor_ptr->grid_array[player_ptr->y][player_ptr->x].get_feat_mimic()].name.data());
             energy.reset_player_turn();
             can_move = false;
             disturb(player_ptr, false, true);
         } else if (f_ptr->flags.has(TerrainCharacteristics::LAVA) && riding_r_ptr->resistance_flags.has_none_of(RFR_EFF_IM_FIRE_MASK)) {
-            msg_format(_("%sの上に行けない。", "Too hot to go through."), terrains_info[g_ptr->get_feat_mimic()].name.c_str());
+            msg_format(_("%sの上に行けない。", "Too hot to go through."), terrains_info[g_ptr->get_feat_mimic()].name.data());
             energy.reset_player_turn();
             can_move = false;
             disturb(player_ptr, false, true);
@@ -256,7 +256,7 @@ void exe_movement(PlayerType *player_ptr, DIRECTION dir, bool do_pickup, bool br
 
     if (!can_move) {
     } else if (f_ptr->flags.has_not(TerrainCharacteristics::MOVE) && f_ptr->flags.has(TerrainCharacteristics::CAN_FLY) && !player_ptr->levitation) {
-        msg_format(_("空を飛ばないと%sの上には行けない。", "You need to fly to go through the %s."), terrains_info[g_ptr->get_feat_mimic()].name.c_str());
+        msg_format(_("空を飛ばないと%sの上には行けない。", "You need to fly to go through the %s."), terrains_info[g_ptr->get_feat_mimic()].name.data());
         energy.reset_player_turn();
         player_ptr->running = 0;
         can_move = false;
@@ -273,7 +273,7 @@ void exe_movement(PlayerType *player_ptr, DIRECTION dir, bool do_pickup, bool br
     } else if (!p_can_enter && !p_can_kill_walls) {
         FEAT_IDX feat = g_ptr->get_feat_mimic();
         TerrainType *mimic_f_ptr = &terrains_info[feat];
-        concptr name = mimic_f_ptr->name.c_str();
+        concptr name = mimic_f_ptr->name.data();
         can_move = false;
         if (!g_ptr->is_mark() && !player_can_see_bold(player_ptr, y, x)) {
             if (boundary_floor(g_ptr, f_ptr, mimic_f_ptr)) {

--- a/src/action/open-close-execution.cpp
+++ b/src/action/open-close-execution.cpp
@@ -48,7 +48,7 @@ bool exe_open(PlayerType *player_ptr, POSITION y, POSITION x)
     auto *f_ptr = &terrains_info[g_ptr->feat];
     PlayerEnergy(player_ptr).set_player_turn_energy(100);
     if (f_ptr->flags.has_not(TerrainCharacteristics::OPEN)) {
-        msg_format(_("%sはがっちりと閉じられているようだ。", "The %s appears to be stuck."), terrains_info[g_ptr->get_feat_mimic()].name.c_str());
+        msg_format(_("%sはがっちりと閉じられているようだ。", "The %s appears to be stuck."), terrains_info[g_ptr->get_feat_mimic()].name.data());
         return false;
     }
 
@@ -152,7 +152,7 @@ bool easy_open_door(PlayerType *player_ptr, POSITION y, POSITION x)
     }
 
     if (f_ptr->flags.has_not(TerrainCharacteristics::OPEN)) {
-        msg_format(_("%sはがっちりと閉じられているようだ。", "The %s appears to be stuck."), terrains_info[g_ptr->get_feat_mimic()].name.c_str());
+        msg_format(_("%sはがっちりと閉じられているようだ。", "The %s appears to be stuck."), terrains_info[g_ptr->get_feat_mimic()].name.data());
     } else if (f_ptr->power) {
         i = player_ptr->skill_dis;
         const auto effects = player_ptr->effects();
@@ -269,7 +269,7 @@ bool exe_disarm(PlayerType *player_ptr, POSITION y, POSITION x, DIRECTION dir)
 {
     auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
     auto *f_ptr = &terrains_info[g_ptr->feat];
-    concptr name = f_ptr->name.c_str();
+    concptr name = f_ptr->name.data();
     int power = f_ptr->power;
     bool more = false;
     int i = player_ptr->skill_dis;
@@ -329,7 +329,7 @@ bool exe_bash(PlayerType *player_ptr, POSITION y, POSITION x, DIRECTION dir)
     int bash = adj_str_blow[player_ptr->stat_index[A_STR]];
     int temp = f_ptr->power;
     bool more = false;
-    concptr name = terrains_info[g_ptr->get_feat_mimic()].name.c_str();
+    concptr name = terrains_info[g_ptr->get_feat_mimic()].name.data();
     PlayerEnergy(player_ptr).set_player_turn_energy(100);
     msg_format(_("%sに体当たりをした！", "You smash into the %s!"), name);
     temp = (bash - (temp * 10));

--- a/src/action/tunnel-execution.cpp
+++ b/src/action/tunnel-execution.cpp
@@ -69,7 +69,7 @@ bool exe_tunnel(PlayerType *player_ptr, POSITION y, POSITION x)
     f_ptr = &terrains_info[g_ptr->feat];
     power = f_ptr->power;
     mimic_f_ptr = &terrains_info[g_ptr->get_feat_mimic()];
-    name = mimic_f_ptr->name.c_str();
+    name = mimic_f_ptr->name.data();
     sound(SOUND_DIG);
     if (f_ptr->flags.has(TerrainCharacteristics::PERMANENT)) {
         if (mimic_f_ptr->flags.has(TerrainCharacteristics::PERMANENT)) {

--- a/src/artifact/random-art-characteristics.cpp
+++ b/src/artifact/random-art-characteristics.cpp
@@ -152,7 +152,7 @@ void get_random_name(ObjectType *o_ptr, char *return_name, bool armour, int powe
     }
 
     auto filename = get_random_art_filename(armour, power);
-    (void)get_rnd_line(filename.c_str(), o_ptr->artifact_bias, return_name);
+    (void)get_rnd_line(filename.data(), o_ptr->artifact_bias, return_name);
 #ifdef JP
     if (return_name[0] == 0) {
         get_table_name(return_name);

--- a/src/autopick/autopick-describer.cpp
+++ b/src/autopick/autopick-describer.cpp
@@ -569,9 +569,9 @@ void describe_autopick(char *buff, autopick_type *entry)
 {
     //! @note autopick_describer::str は non-nullable、autopick_describer::insc は nullable という制約がある
     autopick_describer describer;
-    describer.str = entry->name.c_str();
+    describer.str = entry->name.data();
     describer.act = entry->action;
-    describer.insc = entry->insc.empty() ? nullptr : entry->insc.c_str();
+    describer.insc = entry->insc.empty() ? nullptr : entry->insc.data();
     describer.top = false;
     describer.before_n = 0;
     describer.body_str = _("アイテム", "items");

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -388,10 +388,10 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, Ob
                 auto *e_ptr = &egos_info[o_ptr->ego_idx];
 #ifdef JP
                 /* エゴ銘には「^」マークが使える */
-                sprintf(name_str, "^%s", e_ptr->name.c_str());
+                sprintf(name_str, "^%s", e_ptr->name.data());
 #else
                 /* We ommit the basename and cannot use the ^ mark */
-                strcpy(name_str, e_ptr->name.c_str());
+                strcpy(name_str, e_ptr->name.data());
 #endif
                 name = false;
                 if (!o_ptr->is_rare()) {

--- a/src/autopick/autopick-matcher.cpp
+++ b/src/autopick/autopick-matcher.cpp
@@ -35,7 +35,7 @@
  */
 bool is_autopick_match(PlayerType *player_ptr, ObjectType *o_ptr, autopick_type *entry, concptr o_name)
 {
-    concptr ptr = entry->name.c_str();
+    concptr ptr = entry->name.data();
     if (IS_FLG(FLG_UNAWARE) && o_ptr->is_aware()) {
         return false;
     }

--- a/src/autopick/autopick-util.cpp
+++ b/src/autopick/autopick-util.cpp
@@ -59,7 +59,7 @@ void auto_inscribe_item(PlayerType *player_ptr, ObjectType *o_ptr, int idx)
     }
 
     if (!o_ptr->inscription) {
-        o_ptr->inscription = quark_add(autopick_list[idx].insc.c_str());
+        o_ptr->inscription = quark_add(autopick_list[idx].insc.data());
     }
 
     player_ptr->window_flags |= (PW_EQUIP | PW_INVEN);

--- a/src/birth/character-builder.cpp
+++ b/src/birth/character-builder.cpp
@@ -76,7 +76,7 @@ static void write_birth_diary(PlayerType *player_ptr)
     sprintf(buf, _("%s性格に%sを選択した。", "%schose %s personality."), indent, personality_info[player_ptr->ppersonality].title);
     exe_write_diary(player_ptr, DIARY_DESCRIPTION, 1, buf);
     if (PlayerClass(player_ptr).equals(PlayerClassType::CHAOS_WARRIOR)) {
-        sprintf(buf, _("%s守護神%sと契約を交わした。", "%smade a contract with patron %s."), indent, patron_list[player_ptr->chaos_patron].name.c_str());
+        sprintf(buf, _("%s守護神%sと契約を交わした。", "%smade a contract with patron %s."), indent, patron_list[player_ptr->chaos_patron].name.data());
         exe_write_diary(player_ptr, DIARY_DESCRIPTION, 1, buf);
     }
 }

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -272,7 +272,7 @@ void do_cmd_go_down(PlayerType *player_ptr)
         if (!max_dlv[target_dungeon]) {
             const auto mes = _("ここには%sの入り口(%d階相当)があります", "There is the entrance of %s (Danger level: %d)");
             const auto &dungeon = dungeons_info[target_dungeon];
-            msg_format(mes, dungeon.name.c_str(), dungeon.mindepth);
+            msg_format(mes, dungeon.name.data(), dungeon.mindepth);
             if (!get_check(_("本当にこのダンジョンに入りますか？", "Do you really get in this dungeon? "))) {
                 return;
             }
@@ -312,7 +312,7 @@ void do_cmd_go_down(PlayerType *player_ptr)
         msg_print(_("わざと落とし戸に落ちた。", "You deliberately jump through the trap door."));
     } else {
         if (target_dungeon) {
-            msg_format(_("%sへ入った。", "You entered %s."), dungeons_info[player_ptr->dungeon_idx].text.c_str());
+            msg_format(_("%sへ入った。", "You entered %s."), dungeons_info[player_ptr->dungeon_idx].text.data());
         } else {
             if (is_echizen(player_ptr)) {
                 msg_print(_("なんだこの階段は！", "What's this STAIRWAY!"));

--- a/src/cmd-action/cmd-open-close.cpp
+++ b/src/cmd-action/cmd-open-close.cpp
@@ -382,7 +382,7 @@ void do_cmd_spike(PlayerType *player_ptr)
         do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
     } else {
         PlayerEnergy(player_ptr).set_player_turn_energy(100);
-        msg_format(_("%sにくさびを打ち込んだ。", "You jam the %s with a spike."), terrains_info[feat].name.c_str());
+        msg_format(_("%sにくさびを打ち込んだ。", "You jam the %s with a spike."), terrains_info[feat].name.data());
         cave_alter_feat(player_ptr, y, x, TerrainCharacteristics::SPIKE);
         vary_item(player_ptr, item, -1);
     }

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -268,11 +268,11 @@ bool do_cmd_riding(PlayerType *player_ptr, bool force)
             /* Feature code (applying "mimic" field) */
             auto *f_ptr = &terrains_info[g_ptr->get_feat_mimic()];
 #ifdef JP
-            msg_format("そのモンスターは%sの%sにいる。", f_ptr->name.c_str(),
+            msg_format("そのモンスターは%sの%sにいる。", f_ptr->name.data(),
                 (f_ptr->flags.has_none_of({ TerrainCharacteristics::MOVE, TerrainCharacteristics::CAN_FLY }) || f_ptr->flags.has_none_of({ TerrainCharacteristics::LOS, TerrainCharacteristics::TREE })) ? "中" : "上");
 #else
             msg_format("This monster is %s the %s.",
-                (f_ptr->flags.has_none_of({ TerrainCharacteristics::MOVE, TerrainCharacteristics::CAN_FLY }) || f_ptr->flags.has_none_of({ TerrainCharacteristics::LOS, TerrainCharacteristics::TREE })) ? "in" : "on", f_ptr->name.c_str());
+                (f_ptr->flags.has_none_of({ TerrainCharacteristics::MOVE, TerrainCharacteristics::CAN_FLY }) || f_ptr->flags.has_none_of({ TerrainCharacteristics::LOS, TerrainCharacteristics::TREE })) ? "in" : "on", f_ptr->name.data());
 #endif
 
             return false;
@@ -404,7 +404,7 @@ void do_cmd_pet(PlayerType *player_ptr)
     powers[num++] = PET_DISMISS;
 
     auto is_hallucinated = player_ptr->effects()->hallucination()->is_hallucinated();
-    auto taget_of_pet = monraces_info[player_ptr->current_floor_ptr->m_list[player_ptr->pet_t_m_idx].ap_r_idx].name.c_str();
+    auto taget_of_pet = monraces_info[player_ptr->current_floor_ptr->m_list[player_ptr->pet_t_m_idx].ap_r_idx].name.data();
     auto target_of_pet_appearance = is_hallucinated ? _("何か奇妙な物", "something strange") : taget_of_pet;
     auto mes = _("ペットのターゲットを指定 (現在：%s)", "specify a target of pet (now:%s)");
     auto target_name = player_ptr->pet_t_m_idx > 0 ? target_of_pet_appearance : _("指定なし", "nothing");
@@ -559,7 +559,7 @@ void do_cmd_pet(PlayerType *player_ptr)
         while (!flag) {
             if (choice == ESCAPE) {
                 choice = ' ';
-            } else if (!get_com(prompt.c_str(), &choice, true)) {
+            } else if (!get_com(prompt.data(), &choice, true)) {
                 break;
             }
 
@@ -631,7 +631,7 @@ void do_cmd_pet(PlayerType *player_ptr)
                         }
 
                         ss << power_desc[control];
-                        prt(ss.str().c_str(), y + control, x);
+                        prt(ss.str().data(), y + control, x);
                     }
 
                     prt("", y + std::min(control, 17), x);

--- a/src/cmd-action/cmd-racial.cpp
+++ b/src/cmd-action/cmd-racial.cpp
@@ -91,8 +91,8 @@ static void racial_power_display_list(PlayerType *player_ptr, rc_type *rc_ptr)
 
         auto &rpi = rc_ptr->power_desc[ctr];
         strcat(dummy,
-            format("%-30.30s %2d %4d %3d%% %s", rpi.racial_name.c_str(), rpi.min_level, rpi.cost, 100 - racial_chance(player_ptr, &rc_ptr->power_desc[ctr]),
-                rpi.info.c_str()));
+            format("%-30.30s %2d %4d %3d%% %s", rpi.racial_name.data(), rpi.min_level, rpi.cost, 100 - racial_chance(player_ptr, &rc_ptr->power_desc[ctr]),
+                rpi.info.data()));
 
         prt(dummy, 2 + y, x);
     }
@@ -297,7 +297,7 @@ static bool ask_invoke_racial_power(rc_type *rc_ptr)
     }
 
     char tmp_val[160];
-    (void)strnfmt(tmp_val, 78, _("%sを使いますか？ ", "Use %s? "), rc_ptr->power_desc[rc_ptr->command_code].racial_name.c_str());
+    (void)strnfmt(tmp_val, 78, _("%sを使いますか？ ", "Use %s? "), rc_ptr->power_desc[rc_ptr->command_code].racial_name.data());
     return get_check(tmp_val);
 }
 
@@ -312,7 +312,7 @@ static void racial_power_display_explanation(PlayerType *player_ptr, rc_type *rc
     term_erase(12, 18, 255);
     term_erase(12, 17, 255);
     term_erase(12, 16, 255);
-    shape_buffer(rpi.text.c_str(), 62, temp, sizeof(temp));
+    shape_buffer(rpi.text.data(), 62, temp, sizeof(temp));
     for (int j = 0, line = 17; temp[j]; j += (1 + strlen(&temp[j]))) {
         prt(&temp[j], line, 15);
         line++;

--- a/src/cmd-io/cmd-lore.cpp
+++ b/src/cmd-io/cmd-lore.cpp
@@ -123,9 +123,9 @@ void do_cmd_query_symbol(PlayerType *player_ptr)
             }
 
 #ifdef JP
-            strcpy(temp2, r_ref.E_name.c_str());
+            strcpy(temp2, r_ref.E_name.data());
 #else
-            strcpy(temp2, r_ref.name.c_str());
+            strcpy(temp2, r_ref.name.data());
 #endif
             for (xx = 0; temp2[xx] && xx < MAX_MONSTER_NAME; xx++) {
                 if (isupper(temp2[xx])) {
@@ -134,7 +134,7 @@ void do_cmd_query_symbol(PlayerType *player_ptr)
             }
 
 #ifdef JP
-            if (angband_strstr(temp2, temp) || angband_strstr(r_ref.name.c_str(), temp))
+            if (angband_strstr(temp2, temp) || angband_strstr(r_ref.name.data(), temp))
 #else
             if (angband_strstr(temp2, temp))
 #endif

--- a/src/cmd-io/cmd-macro.cpp
+++ b/src/cmd-io/cmd-macro.cpp
@@ -219,7 +219,7 @@ void do_cmd_macros(PlayerType *player_ptr)
                 msg_print(_("そのキーにはマクロは定義されていません。", "Found no macro."));
             } else {
                 // マクロの作成時に参照するためmacro_bufにコピーする
-                strncpy(macro_buf, macro__act[k].c_str(), sizeof(macro_buf) - 1);
+                strncpy(macro_buf, macro__act[k].data(), sizeof(macro_buf) - 1);
                 // too long macro must die
                 strncpy(tmp, macro_buf, 80);
                 tmp[80] = '\0';

--- a/src/cmd-item/cmd-magiceat.cpp
+++ b/src/cmd-item/cmd-magiceat.cpp
@@ -335,7 +335,7 @@ static std::optional<std::tuple<ItemKindType, OBJECT_SUBTYPE_VALUE>> select_magi
                 if (k_idx) {
                     if (tval == ItemKindType::ROD) {
                         strcat(dummy,
-                            format(_(" %-22.22s 充填:%2d/%2d%3d%%", " %-22.22s   (%2d/%2d) %3d%%"), baseitems_info[k_idx].name.c_str(),
+                            format(_(" %-22.22s 充填:%2d/%2d%3d%%", " %-22.22s   (%2d/%2d) %3d%%"), baseitems_info[k_idx].name.data(),
                                 item.charge ? (item.charge - 1) / (EATER_ROD_CHARGE * baseitems_info[k_idx].pval) + 1 : 0,
                                 item.count, chance));
                         if (item.charge > baseitems_info[k_idx].pval * (item.count - 1) * EATER_ROD_CHARGE) {
@@ -343,7 +343,7 @@ static std::optional<std::tuple<ItemKindType, OBJECT_SUBTYPE_VALUE>> select_magi
                         }
                     } else {
                         strcat(dummy,
-                            format(" %-22.22s    %2d/%2d %3d%%", baseitems_info[k_idx].name.c_str(), (int16_t)(item.charge / EATER_CHARGE),
+                            format(" %-22.22s    %2d/%2d %3d%%", baseitems_info[k_idx].name.data(), (int16_t)(item.charge / EATER_CHARGE),
                                 item.count, chance));
                         if (item.charge < EATER_CHARGE) {
                             col = TERM_RED;
@@ -497,7 +497,7 @@ static std::optional<std::tuple<ItemKindType, OBJECT_SUBTYPE_VALUE>> select_magi
             term_erase(7, 21, 255);
             term_erase(7, 20, 255);
 
-            shape_buffer(baseitems_info[lookup_kind(tval, i)].text.c_str(), 62, temp, sizeof(temp));
+            shape_buffer(baseitems_info[lookup_kind(tval, i)].text.data(), 62, temp, sizeof(temp));
             for (j = 0, line = 21; temp[j]; j += 1 + strlen(&temp[j])) {
                 prt(&temp[j], line, 10);
                 line++;

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -133,7 +133,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
                     continue;
                 }
 
-                auto_dump_printf(auto_dump_stream, "# %s\n", r_ref.name.c_str());
+                auto_dump_printf(auto_dump_stream, "# %s\n", r_ref.name.data());
                 auto_dump_printf(auto_dump_stream, "R:%d:0x%02X/0x%02X\n\n", r_ref.idx, (byte)(r_ref.x_attr), (byte)(r_ref.x_char));
             }
 
@@ -206,7 +206,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
                     continue;
                 }
 
-                auto_dump_printf(auto_dump_stream, "# %s\n", (f_ref.name.c_str()));
+                auto_dump_printf(auto_dump_stream, "# %s\n", (f_ref.name.data()));
                 auto_dump_printf(auto_dump_stream, "F:%d:0x%02X/0x%02X:0x%02X/0x%02X:0x%02X/0x%02X\n\n", f_ref.idx, (byte)(f_ref.x_attr[F_LIT_STANDARD]),
                     (byte)(f_ref.x_char[F_LIT_STANDARD]), (byte)(f_ref.x_attr[F_LIT_LITE]), (byte)(f_ref.x_char[F_LIT_LITE]),
                     (byte)(f_ref.x_attr[F_LIT_DARK]), (byte)(f_ref.x_char[F_LIT_DARK]));
@@ -231,7 +231,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
                 TERM_COLOR ca = r_ptr->x_attr;
                 byte cc = r_ptr->x_char;
 
-                term_putstr(5, 17, -1, TERM_WHITE, format(_("モンスター = %d, 名前 = %-40.40s", "Monster = %d, Name = %-40.40s"), r, r_ptr->name.c_str()));
+                term_putstr(5, 17, -1, TERM_WHITE, format(_("モンスター = %d, 名前 = %-40.40s", "Monster = %d, Name = %-40.40s"), r, r_ptr->name.data()));
                 term_putstr(10, 19, -1, TERM_WHITE, format(_("初期値  色 / 文字 = %3u / %3u", "Default attr/char = %3u / %3u"), da, dc));
                 term_putstr(40, 19, -1, TERM_WHITE, empty_symbol);
                 term_queue_bigchar(43, 19, da, dc, 0, 0);
@@ -303,7 +303,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
 
                 term_putstr(5, 17, -1, TERM_WHITE,
                     format(
-                        _("アイテム = %d, 名前 = %-40.40s", "Object = %d, Name = %-40.40s"), k, (!k_ptr->flavor ? k_ptr->name : k_ptr->flavor_name).c_str()));
+                        _("アイテム = %d, 名前 = %-40.40s", "Object = %d, Name = %-40.40s"), k, (!k_ptr->flavor ? k_ptr->name : k_ptr->flavor_name).data()));
                 term_putstr(10, 19, -1, TERM_WHITE, format(_("初期値  色 / 文字 = %3d / %3d", "Default attr/char = %3d / %3d"), da, dc));
                 term_putstr(40, 19, -1, TERM_WHITE, empty_symbol);
                 term_queue_bigchar(43, 19, da, dc, 0, 0);
@@ -376,7 +376,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
 
                 prt("", 17, 5);
                 term_putstr(5, 17, -1, TERM_WHITE,
-                    format(_("地形 = %d, 名前 = %s, 明度 = %s", "Terrain = %d, Name = %s, Lighting = %s"), f, (f_ptr->name.c_str()),
+                    format(_("地形 = %d, 名前 = %s, 明度 = %s", "Terrain = %d, Name = %s, Lighting = %s"), f, (f_ptr->name.data()),
                         lighting_level_str[lighting_level]));
                 term_putstr(10, 19, -1, TERM_WHITE, format(_("初期値  色 / 文字 = %3d / %3d", "Default attr/char = %3d / %3d"), da, dc));
                 term_putstr(40, 19, -1, TERM_WHITE, empty_symbol);

--- a/src/core/asking-player.cpp
+++ b/src/core/asking-player.cpp
@@ -439,7 +439,7 @@ bool get_value(const char *text, int min, int max, int *value)
     st << text << "(" << min << "-" << max << "): ";
     int digit = std::max(std::to_string(min).length(), std::to_string(max).length());
     while (true) {
-        if (!get_string(st.str().c_str(), tmp_val, digit)) {
+        if (!get_string(st.str().data(), tmp_val, digit)) {
             return false;
         }
 

--- a/src/core/scores.cpp
+++ b/src/core/scores.cpp
@@ -233,14 +233,14 @@ errr top_twenty(PlayerType *player_ptr)
     /* Save the cause of death (31 chars) */
     if (player_ptr->died_from.size() >= sizeof(the_score.how)) {
 #ifdef JP
-        angband_strcpy(the_score.how, player_ptr->died_from.c_str(), sizeof(the_score.how) - 2);
+        angband_strcpy(the_score.how, player_ptr->died_from.data(), sizeof(the_score.how) - 2);
         strcat(the_score.how, "…");
 #else
-        angband_strcpy(the_score.how, player_ptr->died_from.c_str(), sizeof(the_score.how) - 3);
+        angband_strcpy(the_score.how, player_ptr->died_from.data(), sizeof(the_score.how) - 3);
         strcat(the_score.how, "...");
 #endif
     } else {
-        angband_strcpy(the_score.how, player_ptr->died_from.c_str(), sizeof(the_score.how));
+        angband_strcpy(the_score.how, player_ptr->died_from.data(), sizeof(the_score.how));
     }
 
     /* Grab permissions */

--- a/src/dungeon/dungeon-processor.cpp
+++ b/src/dungeon/dungeon-processor.cpp
@@ -147,9 +147,9 @@ void process_dungeon(PlayerType *player_ptr, bool load_game)
         const auto &guardian_ref = monraces_info[guardian];
         if (guardian_ref.max_num) {
 #ifdef JP
-            msg_format("この階には%sの主である%sが棲んでいる。", dungeon.name.c_str(), guardian_ref.name.c_str());
+            msg_format("この階には%sの主である%sが棲んでいる。", dungeon.name.data(), guardian_ref.name.data());
 #else
-            msg_format("%^s lives in this level as the keeper of %s.", guardian_ref.name.c_str(), dungeon.name.c_str());
+            msg_format("%^s lives in this level as the keeper of %s.", guardian_ref.name.data(), dungeon.name.data());
 #endif
         }
     }

--- a/src/dungeon/quest.cpp
+++ b/src/dungeon/quest.cpp
@@ -301,7 +301,7 @@ void quest_discovery(QuestId q_idx)
     }
 
     GAME_TEXT name[MAX_NLEN];
-    strcpy(name, (r_ptr->name.c_str()));
+    strcpy(name, (r_ptr->name.data()));
 
     msg_print(find_quest_map[rand_range(0, 4)]);
     msg_print(nullptr);

--- a/src/effect/effect-feature.cpp
+++ b/src/effect/effect-feature.cpp
@@ -240,7 +240,7 @@ bool affect_feature(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITIO
             break;
         }
 
-        msg_format(_("%sに何かがつっかえて開かなくなった。", "The %s seems stuck."), mimic_f_ptr->name.c_str());
+        msg_format(_("%sに何かがつっかえて開かなくなった。", "The %s seems stuck."), mimic_f_ptr->name.data());
         obvious = true;
         break;
     }
@@ -250,7 +250,7 @@ bool affect_feature(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITIO
         }
 
         if (known && g_ptr->is_mark()) {
-            msg_format(_("%sが溶けて泥になった！", "The %s turns into mud!"), terrains_info[g_ptr->get_feat_mimic()].name.c_str());
+            msg_format(_("%sが溶けて泥になった！", "The %s turns into mud!"), terrains_info[g_ptr->get_feat_mimic()].name.data());
             obvious = true;
         }
 
@@ -428,7 +428,7 @@ bool affect_feature(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITIO
         }
 
         if (known && (g_ptr->is_mark())) {
-            msg_format(_("%sが割れた！", "The %s crumbled!"), terrains_info[g_ptr->get_feat_mimic()].name.c_str());
+            msg_format(_("%sが割れた！", "The %s crumbled!"), terrains_info[g_ptr->get_feat_mimic()].name.data());
             sound(SOUND_GLASS);
         }
 
@@ -450,7 +450,7 @@ bool affect_feature(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITIO
         }
 
         if (known && (g_ptr->is_mark())) {
-            msg_format(_("%sが割れた！", "The %s crumbled!"), terrains_info[g_ptr->get_feat_mimic()].name.c_str());
+            msg_format(_("%sが割れた！", "The %s crumbled!"), terrains_info[g_ptr->get_feat_mimic()].name.data());
             sound(SOUND_GLASS);
         }
 

--- a/src/flavor/flavor-util.cpp
+++ b/src/flavor/flavor-util.cpp
@@ -18,7 +18,7 @@ flavor_type *initialize_flavor_type(flavor_type *flavor_ptr, char *buf, ObjectTy
     flavor_ptr->buf = buf;
     flavor_ptr->o_ptr = o_ptr;
     flavor_ptr->mode = mode;
-    flavor_ptr->kindname = baseitems_info[o_ptr->k_idx].name.c_str();
+    flavor_ptr->kindname = baseitems_info[o_ptr->k_idx].name.data();
     flavor_ptr->basenm = flavor_ptr->kindname;
     flavor_ptr->modstr = "";
     flavor_ptr->aware = false;

--- a/src/flavor/named-item-describer.cpp
+++ b/src/flavor/named-item-describer.cpp
@@ -61,7 +61,7 @@ static void set_base_name(flavor_type *flavor_ptr)
 
     const auto fixed_art_id = flavor_ptr->o_ptr->fixed_artifact_idx;
     const auto is_known_artifact = flavor_ptr->known && flavor_ptr->o_ptr->is_fixed_artifact() && none_bits(flavor_ptr->mode, OD_BASE_NAME);
-    flavor_ptr->basenm = is_known_artifact ? artifacts_info.at(fixed_art_id).name.c_str() : flavor_ptr->kindname;
+    flavor_ptr->basenm = is_known_artifact ? artifacts_info.at(fixed_art_id).name.data() : flavor_ptr->kindname;
 }
 
 #ifdef JP
@@ -126,7 +126,7 @@ static void describe_artifact_ja(flavor_type *flavor_ptr)
         const auto &a_ref = artifacts_info.at(flavor_ptr->o_ptr->fixed_artifact_idx);
         /* '『' から始まらない伝説のアイテムの名前は最初に付加する */
         if (a_ref.name.find("『", 0, 2) != 0) {
-            flavor_ptr->t = object_desc_str(flavor_ptr->t, a_ref.name.c_str());
+            flavor_ptr->t = object_desc_str(flavor_ptr->t, a_ref.name.data());
         }
 
         return;
@@ -134,7 +134,7 @@ static void describe_artifact_ja(flavor_type *flavor_ptr)
 
     if (flavor_ptr->o_ptr->is_ego()) {
         auto *e_ptr = &egos_info[flavor_ptr->o_ptr->ego_idx];
-        flavor_ptr->t = object_desc_str(flavor_ptr->t, e_ptr->name.c_str());
+        flavor_ptr->t = object_desc_str(flavor_ptr->t, e_ptr->name.data());
     }
 }
 
@@ -218,7 +218,7 @@ static void describe_artifact_body_ja(flavor_type *flavor_ptr)
     if (flavor_ptr->o_ptr->is_fixed_artifact()) {
         const auto &a_ref = artifacts_info.at(flavor_ptr->o_ptr->fixed_artifact_idx);
         if (a_ref.name.find("『", 0, 2) == 0) {
-            flavor_ptr->t = object_desc_str(flavor_ptr->t, a_ref.name.c_str());
+            flavor_ptr->t = object_desc_str(flavor_ptr->t, a_ref.name.data());
         }
 
         return;
@@ -325,14 +325,14 @@ static void describe_artifact_body_en(flavor_type *flavor_ptr)
     if (flavor_ptr->o_ptr->is_fixed_artifact()) {
         const auto &a_ref = artifacts_info.at(flavor_ptr->o_ptr->fixed_artifact_idx);
         flavor_ptr->t = object_desc_chr(flavor_ptr->t, ' ');
-        flavor_ptr->t = object_desc_str(flavor_ptr->t, a_ref.name.c_str());
+        flavor_ptr->t = object_desc_str(flavor_ptr->t, a_ref.name.data());
         return;
     }
 
     if (flavor_ptr->o_ptr->is_ego()) {
         auto *e_ptr = &egos_info[flavor_ptr->o_ptr->ego_idx];
         flavor_ptr->t = object_desc_chr(flavor_ptr->t, ' ');
-        flavor_ptr->t = object_desc_str(flavor_ptr->t, e_ptr->name.c_str());
+        flavor_ptr->t = object_desc_str(flavor_ptr->t, e_ptr->name.data());
     }
 
     if (flavor_ptr->o_ptr->inscription && angband_strchr(quark_str(flavor_ptr->o_ptr->inscription), '#')) {

--- a/src/flavor/tval-description-switcher.cpp
+++ b/src/flavor/tval-description-switcher.cpp
@@ -34,10 +34,10 @@ static void describe_monster_ball(flavor_type *flavor_ptr)
     }
 
 #ifdef JP
-    sprintf(flavor_ptr->tmp_val2, " (%s)", r_ptr->name.c_str());
+    sprintf(flavor_ptr->tmp_val2, " (%s)", r_ptr->name.data());
     flavor_ptr->modstr = flavor_ptr->tmp_val2;
 #else
-    flavor_ptr->t = format("%s", r_ptr->name.c_str());
+    flavor_ptr->t = format("%s", r_ptr->name.data());
     if (r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE)) {
         sprintf(flavor_ptr->tmp_val2, " (%s%s)", (is_a_vowel(*flavor_ptr->t) ? "an " : "a "), flavor_ptr->t);
         flavor_ptr->modstr = flavor_ptr->tmp_val2;
@@ -53,9 +53,9 @@ static void describe_statue(flavor_type *flavor_ptr)
     const auto r_idx = i2enum<MonsterRaceId>(flavor_ptr->o_ptr->pval);
     auto *r_ptr = &monraces_info[r_idx];
 #ifdef JP
-    flavor_ptr->modstr = r_ptr->name.c_str();
+    flavor_ptr->modstr = r_ptr->name.data();
 #else
-    flavor_ptr->t = format("%s", r_ptr->name.c_str());
+    flavor_ptr->t = format("%s", r_ptr->name.data());
     if (r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE)) {
         sprintf(flavor_ptr->tmp_val2, "%s%s", (is_a_vowel(*flavor_ptr->t) ? "an " : "a "), flavor_ptr->t);
         flavor_ptr->modstr = flavor_ptr->tmp_val2;
@@ -69,7 +69,7 @@ static void describe_corpse(flavor_type *flavor_ptr)
 {
     const auto r_idx = i2enum<MonsterRaceId>(flavor_ptr->o_ptr->pval);
     auto *r_ptr = &monraces_info[r_idx];
-    flavor_ptr->modstr = r_ptr->name.c_str();
+    flavor_ptr->modstr = r_ptr->name.data();
 #ifdef JP
     flavor_ptr->basenm = "#%";
 #else
@@ -87,7 +87,7 @@ static void describe_amulet(flavor_type *flavor_ptr)
         return;
     }
 
-    flavor_ptr->modstr = flavor_ptr->flavor_k_ptr->flavor_name.c_str();
+    flavor_ptr->modstr = flavor_ptr->flavor_k_ptr->flavor_name.data();
     if (!flavor_ptr->flavor) {
         flavor_ptr->basenm = _("%のアミュレット", "& Amulet~ of %");
     } else if (flavor_ptr->aware) {
@@ -103,7 +103,7 @@ static void describe_ring(flavor_type *flavor_ptr)
         return;
     }
 
-    flavor_ptr->modstr = flavor_ptr->flavor_k_ptr->flavor_name.c_str();
+    flavor_ptr->modstr = flavor_ptr->flavor_k_ptr->flavor_name.data();
     if (!flavor_ptr->flavor) {
         flavor_ptr->basenm = _("%の指輪", "& Ring~ of %");
     } else if (flavor_ptr->aware) {
@@ -119,7 +119,7 @@ static void describe_ring(flavor_type *flavor_ptr)
 
 static void describe_staff(flavor_type *flavor_ptr)
 {
-    flavor_ptr->modstr = flavor_ptr->flavor_k_ptr->flavor_name.c_str();
+    flavor_ptr->modstr = flavor_ptr->flavor_k_ptr->flavor_name.data();
     if (!flavor_ptr->flavor) {
         flavor_ptr->basenm = _("%の杖", "& Staff~ of %");
     } else if (flavor_ptr->aware) {
@@ -131,7 +131,7 @@ static void describe_staff(flavor_type *flavor_ptr)
 
 static void describe_wand(flavor_type *flavor_ptr)
 {
-    flavor_ptr->modstr = flavor_ptr->flavor_k_ptr->flavor_name.c_str();
+    flavor_ptr->modstr = flavor_ptr->flavor_k_ptr->flavor_name.data();
     if (!flavor_ptr->flavor) {
         flavor_ptr->basenm = _("%の魔法棒", "& Wand~ of %");
     } else if (flavor_ptr->aware) {
@@ -143,7 +143,7 @@ static void describe_wand(flavor_type *flavor_ptr)
 
 static void describe_rod(flavor_type *flavor_ptr)
 {
-    flavor_ptr->modstr = flavor_ptr->flavor_k_ptr->flavor_name.c_str();
+    flavor_ptr->modstr = flavor_ptr->flavor_k_ptr->flavor_name.data();
     if (!flavor_ptr->flavor) {
         flavor_ptr->basenm = _("%のロッド", "& Rod~ of %");
     } else if (flavor_ptr->aware) {
@@ -155,7 +155,7 @@ static void describe_rod(flavor_type *flavor_ptr)
 
 static void describe_scroll(flavor_type *flavor_ptr)
 {
-    flavor_ptr->modstr = flavor_ptr->flavor_k_ptr->flavor_name.c_str();
+    flavor_ptr->modstr = flavor_ptr->flavor_k_ptr->flavor_name.data();
     if (!flavor_ptr->flavor) {
         flavor_ptr->basenm = _("%の巻物", "& Scroll~ of %");
     } else if (flavor_ptr->aware) {
@@ -167,7 +167,7 @@ static void describe_scroll(flavor_type *flavor_ptr)
 
 static void describe_potion(flavor_type *flavor_ptr)
 {
-    flavor_ptr->modstr = flavor_ptr->flavor_k_ptr->flavor_name.c_str();
+    flavor_ptr->modstr = flavor_ptr->flavor_k_ptr->flavor_name.data();
     if (!flavor_ptr->flavor) {
         flavor_ptr->basenm = _("%の薬", "& Potion~ of %");
     } else if (flavor_ptr->aware) {
@@ -183,7 +183,7 @@ static void describe_food(flavor_type *flavor_ptr)
         return;
     }
 
-    flavor_ptr->modstr = flavor_ptr->flavor_k_ptr->flavor_name.c_str();
+    flavor_ptr->modstr = flavor_ptr->flavor_k_ptr->flavor_name.data();
     if (!flavor_ptr->flavor) {
         flavor_ptr->basenm = _("%のキノコ", "& Mushroom~ of %");
     } else if (flavor_ptr->aware) {

--- a/src/floor/floor-util.cpp
+++ b/src/floor/floor-util.cpp
@@ -209,6 +209,6 @@ concptr map_name(PlayerType *player_ptr)
     } else if (!floor_ptr->dun_level && player_ptr->town_num) {
         return town_info[player_ptr->town_num].name;
     } else {
-        return dungeons_info[player_ptr->dungeon_idx].name.c_str();
+        return dungeons_info[player_ptr->dungeon_idx].name.data();
     }
 }

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -90,13 +90,13 @@ static bool deal_damege_by_feat(PlayerType *player_ptr, grid_type *g_ptr, concpt
     if (player_ptr->levitation) {
         msg_print(msg_levitation);
 
-        take_hit(player_ptr, DAMAGE_NOESCAPE, damage, format(_("%sの上に浮遊したダメージ", "flying over %s"), terrains_info[g_ptr->get_feat_mimic()].name.c_str()));
+        take_hit(player_ptr, DAMAGE_NOESCAPE, damage, format(_("%sの上に浮遊したダメージ", "flying over %s"), terrains_info[g_ptr->get_feat_mimic()].name.data()));
 
         if (additional_effect != nullptr) {
             additional_effect(player_ptr, damage);
         }
     } else {
-        concptr name = terrains_info[player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x].get_feat_mimic()].name.c_str();
+        concptr name = terrains_info[player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x].get_feat_mimic()].name.data();
         msg_format(_("%s%s！", "The %s %s!"), name, msg_normal);
         take_hit(player_ptr, DAMAGE_NOESCAPE, damage, name);
 

--- a/src/info-reader/artifact-reader.cpp
+++ b/src/info-reader/artifact-reader.cpp
@@ -166,7 +166,7 @@ errr parse_artifacts_info(std::string_view buf, angband_header *)
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
 
-        auto n = grab_one_activation_flag(tokens[1].c_str());
+        auto n = grab_one_activation_flag(tokens[1].data());
         if (n <= RandomArtActType::NONE) {
             return PARSE_ERROR_INVALID_FLAG;
         }

--- a/src/info-reader/baseitem-reader.cpp
+++ b/src/info-reader/baseitem-reader.cpp
@@ -174,7 +174,7 @@ errr parse_baseitems_info(std::string_view buf, angband_header *head)
         if (tokens.size() < 2 || tokens[1].size() == 0) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
-        auto n = grab_one_activation_flag(tokens[1].c_str());
+        auto n = grab_one_activation_flag(tokens[1].data());
         if (n <= RandomArtActType::NONE) {
             return PARSE_ERROR_INVALID_FLAG;
         }

--- a/src/info-reader/ego-reader.cpp
+++ b/src/info-reader/ego-reader.cpp
@@ -139,7 +139,7 @@ errr parse_egos_info(std::string_view buf, angband_header *)
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
 
-        auto n = grab_one_activation_flag(tokens[1].c_str());
+        auto n = grab_one_activation_flag(tokens[1].data());
         if (n <= RandomArtActType::NONE) {
             return PARSE_ERROR_INVALID_FLAG;
         }

--- a/src/info-reader/feature-reader.cpp
+++ b/src/info-reader/feature-reader.cpp
@@ -455,7 +455,7 @@ static FEAT_IDX search_real_feat(std::string feat)
         }
     }
 
-    msg_format(_("未定義のタグ '%s'。", "%s is undefined."), feat.c_str());
+    msg_format(_("未定義のタグ '%s'。", "%s is undefined."), feat.data());
     return -1;
 }
 

--- a/src/info-reader/fixed-map-parser.cpp
+++ b/src/info-reader/fixed-map-parser.cpp
@@ -305,7 +305,7 @@ parse_error_type parse_fixed_map(PlayerType *player_ptr, concptr name, int ymin,
 
 static QuestId parse_quest_number_n(const std::vector<std::string> &token)
 {
-    auto number = i2enum<QuestId>(atoi(token[1].substr(_(0, 1)).c_str()));
+    auto number = i2enum<QuestId>(atoi(token[1].substr(_(0, 1)).data()));
     return number;
 }
 
@@ -368,7 +368,7 @@ static void parse_quest_info_aux(const char *file_name, std::set<QuestId> &key_l
             break;
         }
         case '%': {
-            parse_quest_info_aux(token[1].c_str(), key_list_ref);
+            parse_quest_info_aux(token[1].data(), key_list_ref);
             break;
         }
         default:

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -185,7 +185,7 @@ static void dump_aux_recall(FILE *fff)
             seiha = true;
         }
 
-        fprintf(fff, _("   %c%-12s: %3d 階\n", "   %c%-16s: level %3d\n"), seiha ? '!' : ' ', d_ref.name.c_str(), (int)max_dlv[d_ref.idx]);
+        fprintf(fff, _("   %c%-12s: %3d 階\n", "   %c%-16s: level %3d\n"), seiha ? '!' : ' ', d_ref.name.data(), (int)max_dlv[d_ref.idx]);
     }
 }
 
@@ -268,9 +268,9 @@ static void dump_aux_arena(PlayerType *player_ptr, FILE *fff)
         } else {
 #ifdef JP
             fprintf(
-                fff, "\n 闘技場: %d回戦で%sの前に敗北\n", -player_ptr->arena_number, monraces_info[arena_info[-1 - player_ptr->arena_number].r_idx].name.c_str());
+                fff, "\n 闘技場: %d回戦で%sの前に敗北\n", -player_ptr->arena_number, monraces_info[arena_info[-1 - player_ptr->arena_number].r_idx].name.data());
 #else
-            fprintf(fff, "\n Arena: Defeated by %s in the %d%s fight\n", monraces_info[arena_info[-1 - player_ptr->arena_number].r_idx].name.c_str(),
+            fprintf(fff, "\n Arena: Defeated by %s in the %d%s fight\n", monraces_info[arena_info[-1 - player_ptr->arena_number].r_idx].name.data(),
                 -player_ptr->arena_number, get_ordinal_number_suffix(-player_ptr->arena_number));
 #endif
         }
@@ -377,9 +377,9 @@ static void dump_aux_monsters(PlayerType *player_ptr, FILE *fff)
         }
 
         auto name = str_separate(r_ptr->name, 40);
-        fprintf(fff, _("  %-40s (レベル%3d)%s\n", "  %-40s (level %3d)%s\n"), name.front().c_str(), (int)r_ptr->level, buf);
+        fprintf(fff, _("  %-40s (レベル%3d)%s\n", "  %-40s (level %3d)%s\n"), name.front().data(), (int)r_ptr->level, buf);
         for (auto i = 1U; i < name.size(); ++i) {
-            fprintf(fff, "  %s\n", name[i].c_str());
+            fprintf(fff, "  %s\n", name[i].data());
         }
     }
 }
@@ -473,7 +473,7 @@ static void dump_aux_virtues(PlayerType *player_ptr, FILE *fff)
     }
 
     std::string alg = PlayerAlignment(player_ptr).get_alignment_description();
-    fprintf(fff, _("\n属性 : %s\n", "\nYour alignment : %s\n"), alg.c_str());
+    fprintf(fff, _("\n属性 : %s\n", "\nYour alignment : %s\n"), alg.data());
     fprintf(fff, "\n");
     dump_virtues(player_ptr, fff);
 }

--- a/src/io-dump/special-class-dump.cpp
+++ b/src/io-dump/special-class-dump.cpp
@@ -72,7 +72,7 @@ static void dump_magic_eater(PlayerType *player_ptr, FILE *fff)
             }
 
             char buf[128];
-            snprintf(buf, sizeof(buf), "%23s (%2d)", baseitems_info[k_idx].name.c_str(), item.count);
+            snprintf(buf, sizeof(buf), "%23s (%2d)", baseitems_info[k_idx].name.data(), item.count);
             desc_list.emplace_back(buf);
         }
 
@@ -83,7 +83,7 @@ static void dump_magic_eater(PlayerType *player_ptr, FILE *fff)
 
         uint i;
         for (i = 0; i < desc_list.size(); i++) {
-            fputs(desc_list[i].c_str(), fff);
+            fputs(desc_list[i].data(), fff);
             if (i % 3 < 2) {
                 fputs("    ", fff);
             } else {

--- a/src/io/input-key-acceptor.cpp
+++ b/src/io/input-key-acceptor.cpp
@@ -169,7 +169,7 @@ static char inkey_aux(void)
         return ch;
     }
 
-    concptr pat = macro__pat[k].c_str();
+    concptr pat = macro__pat[k].data();
     n = strlen(pat);
     while (p > n) {
         if (term_key_push(buf[--p])) {
@@ -182,7 +182,7 @@ static char inkey_aux(void)
         return 0;
     }
 
-    concptr act = macro__act[k].c_str();
+    concptr act = macro__act[k].data();
 
     n = strlen(act);
     while (n > 0) {

--- a/src/io/read-pref-file.cpp
+++ b/src/io/read-pref-file.cpp
@@ -138,7 +138,7 @@ static errr process_pref_file_aux(PlayerType *player_ptr, concptr name, int pref
         /* Print error message */
         /* ToDo: Add better error messages */
         msg_format(_("ファイル'%s'の%d行でエラー番号%dのエラー。", "Error %d in line %d of file '%s'."), _(name, err), line, _(err, name));
-        msg_format(_("('%s'を解析中)", "Parsing '%s'"), error_line.c_str());
+        msg_format(_("('%s'を解析中)", "Parsing '%s'"), error_line.data());
         msg_print(nullptr);
     }
 

--- a/src/io/report.cpp
+++ b/src/io/report.cpp
@@ -441,7 +441,7 @@ bool report_score(PlayerType *player_ptr)
     buf_sprintf(score, "seikaku: %s\n", personality_desc);
     buf_sprintf(score, "realm1: %s\n", realm1_name);
     buf_sprintf(score, "realm2: %s\n", realm_names[player_ptr->realm2]);
-    buf_sprintf(score, "killer: %s\n", player_ptr->died_from.c_str());
+    buf_sprintf(score, "killer: %s\n", player_ptr->died_from.data());
     buf_sprintf(score, "-----charcter dump-----\n");
 
     make_dump(player_ptr, score);

--- a/src/io/write-diary.cpp
+++ b/src/io/write-diary.cpp
@@ -90,9 +90,9 @@ static QuestId write_floor(PlayerType *player_ptr, concptr *note_level, char *no
         *note_level = _("クエスト:", "Quest:");
     } else {
 #ifdef JP
-        sprintf(note_level_buf, "%d階(%s):", (int)floor_ptr->dun_level, dungeons_info[player_ptr->dungeon_idx].name.c_str());
+        sprintf(note_level_buf, "%d階(%s):", (int)floor_ptr->dun_level, dungeons_info[player_ptr->dungeon_idx].name.data());
 #else
-        sprintf(note_level_buf, "%s L%d:", dungeons_info[player_ptr->dungeon_idx].name.c_str(), (int)floor_ptr->dun_level);
+        sprintf(note_level_buf, "%s L%d:", dungeons_info[player_ptr->dungeon_idx].name.data(), (int)floor_ptr->dun_level);
 #endif
         *note_level = note_level_buf;
     }
@@ -216,13 +216,13 @@ int exe_write_diary_quest(PlayerType *player_ptr, int type, QuestId num)
     }
     case DIARY_RAND_QUEST_C: {
         GAME_TEXT name[MAX_NLEN];
-        strcpy(name, monraces_info[q_ref.r_idx].name.c_str());
+        strcpy(name, monraces_info[q_ref.r_idx].name.data());
         fprintf(fff, _(" %2d:%02d %20s ランダムクエスト(%s)を達成した。\n", " %2d:%02d %20s completed random quest '%s'\n"), hour, min, note_level, name);
         break;
     }
     case DIARY_RAND_QUEST_F: {
         GAME_TEXT name[MAX_NLEN];
-        strcpy(name, monraces_info[q_ref.r_idx].name.c_str());
+        strcpy(name, monraces_info[q_ref.r_idx].name.data());
         fprintf(fff, _(" %2d:%02d %20s ランダムクエスト(%s)から逃げ出した。\n", " %2d:%02d %20s ran away from quest '%s'.\n"), hour, min, note_level, name);
         break;
     }
@@ -311,14 +311,14 @@ errr exe_write_diary(PlayerType *player_ptr, int type, int num, concptr note)
     }
     case DIARY_MAXDEAPTH: {
         fprintf(fff, _(" %2d:%02d %20s %sの最深階%d階に到達した。\n", " %2d:%02d %20s reached level %d of %s for the first time.\n"), hour, min, note_level,
-            _(dungeons_info[player_ptr->dungeon_idx].name.c_str(), num),
-            _(num, dungeons_info[player_ptr->dungeon_idx].name.c_str()));
+            _(dungeons_info[player_ptr->dungeon_idx].name.data(), num),
+            _(num, dungeons_info[player_ptr->dungeon_idx].name.data()));
         break;
     }
     case DIARY_TRUMP: {
         fprintf(fff, _(" %2d:%02d %20s %s%sの最深階を%d階にセットした。\n", " %2d:%02d %20s reset recall level of %s to %d %s.\n"), hour, min, note_level, note,
-            _(dungeons_info[num].name.c_str(), (int)max_dlv[num]),
-            _((int)max_dlv[num], dungeons_info[num].name.c_str()));
+            _(dungeons_info[num].name.data(), (int)max_dlv[num]),
+            _((int)max_dlv[num], dungeons_info[num].name.data()));
         break;
     }
     case DIARY_STAIR: {
@@ -333,8 +333,8 @@ errr exe_write_diary(PlayerType *player_ptr, int type, int num, concptr note)
     case DIARY_RECALL: {
         if (!num) {
             fprintf(fff, _(" %2d:%02d %20s 帰還を使って%sの%d階へ下りた。\n", " %2d:%02d %20s recalled to dungeon level %d of %s.\n"),
-                hour, min, note_level, _(dungeons_info[player_ptr->dungeon_idx].name.c_str(), (int)max_dlv[player_ptr->dungeon_idx]),
-                _((int)max_dlv[player_ptr->dungeon_idx], dungeons_info[player_ptr->dungeon_idx].name.c_str()));
+                hour, min, note_level, _(dungeons_info[player_ptr->dungeon_idx].name.data(), (int)max_dlv[player_ptr->dungeon_idx]),
+                _((int)max_dlv[player_ptr->dungeon_idx], dungeons_info[player_ptr->dungeon_idx].name.data()));
         } else {
             fprintf(fff, _(" %2d:%02d %20s 帰還を使って地上へと戻った。\n", " %2d:%02d %20s recalled from dungeon to surface.\n"), hour, min, note_level);
         }
@@ -381,7 +381,7 @@ errr exe_write_diary(PlayerType *player_ptr, int type, int num, concptr note)
         const auto &floor_ref = *player_ptr->current_floor_ptr;
         concptr to = !floor_ref.is_in_dungeon()
                          ? _("地上", "the surface")
-                         : format(_("%d階(%s)", "level %d of %s"), floor_ref.dun_level, dungeons_info[player_ptr->dungeon_idx].name.c_str());
+                         : format(_("%d階(%s)", "level %d of %s"), floor_ref.dun_level, dungeons_info[player_ptr->dungeon_idx].name.data());
         fprintf(fff, _(" %2d:%02d %20s %sへとウィザード・テレポートで移動した。\n", " %2d:%02d %20s wizard-teleported to %s.\n"), hour, min, note_level, to);
         break;
     }
@@ -389,7 +389,7 @@ errr exe_write_diary(PlayerType *player_ptr, int type, int num, concptr note)
         const auto &floor_ref = *player_ptr->current_floor_ptr;
         concptr to = !floor_ref.is_in_dungeon()
                          ? _("地上", "the surface")
-                         : format(_("%d階(%s)", "level %d of %s"), floor_ref.dun_level, dungeons_info[player_ptr->dungeon_idx].name.c_str());
+                         : format(_("%d階(%s)", "level %d of %s"), floor_ref.dun_level, dungeons_info[player_ptr->dungeon_idx].name.data());
         fprintf(fff, _(" %2d:%02d %20s %sへとパターンの力で移動した。\n", " %2d:%02d %20s used Pattern to teleport to %s.\n"), hour, min, note_level, to);
         break;
     }

--- a/src/knowledge/knowledge-features.cpp
+++ b/src/knowledge/knowledge-features.cpp
@@ -68,7 +68,7 @@ static void display_feature_list(int col, int row, int per_page, FEAT_IDX *feat_
         auto *f_ptr = &terrains_info[f_idx];
         int row_i = row + i;
         attr = ((i + feat_top == feat_cur) ? TERM_L_BLUE : TERM_WHITE);
-        c_prt(attr, f_ptr->name.c_str(), row_i, col);
+        c_prt(attr, f_ptr->name.data(), row_i, col);
         if (per_page == 1) {
             c_prt(attr, format("(%s)", lighting_level_str[lighting_level]), row_i, col + 1 + f_ptr->name.size());
             c_prt(attr, format("%02x/%02x", f_ptr->x_attr[lighting_level], (unsigned char)f_ptr->x_char[lighting_level]), row_i,
@@ -385,7 +385,7 @@ void do_cmd_knowledge_dungeon(PlayerType *player_ptr)
             seiha = true;
         }
 
-        fprintf(fff, _("%c%-12s :  %3d 階\n", "%c%-16s :  level %3d\n"), seiha ? '!' : ' ', d_ref.name.c_str(), (int)max_dlv[d_ref.idx]);
+        fprintf(fff, _("%c%-12s :  %3d 階\n", "%c%-16s :  level %3d\n"), seiha ? '!' : ' ', d_ref.name.data(), (int)max_dlv[d_ref.idx]);
     }
 
     angband_fclose(fff);

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -207,7 +207,7 @@ void do_cmd_knowledge_kill_count(PlayerType *player_ptr)
                     buf[0] = '\0';
                 }
 
-                fprintf(fff, "     %s%s\n", r_ptr->name.c_str(), buf);
+                fprintf(fff, "     %s%s\n", r_ptr->name.data(), buf);
                 total++;
             }
 
@@ -221,17 +221,17 @@ void do_cmd_knowledge_kill_count(PlayerType *player_ptr)
 
 #ifdef JP
         concptr number_of_kills = angband_strchr("pt", r_ptr->d_char) ? "人" : "体";
-        fprintf(fff, "     %3d %sの %s\n", (int)this_monster, number_of_kills, r_ptr->name.c_str());
+        fprintf(fff, "     %3d %sの %s\n", (int)this_monster, number_of_kills, r_ptr->name.data());
 #else
         if (this_monster < 2) {
-            if (angband_strstr(r_ptr->name.c_str(), "coins")) {
-                fprintf(fff, "     1 pile of %s\n", r_ptr->name.c_str());
+            if (angband_strstr(r_ptr->name.data(), "coins")) {
+                fprintf(fff, "     1 pile of %s\n", r_ptr->name.data());
             } else {
-                fprintf(fff, "     1 %s\n", r_ptr->name.c_str());
+                fprintf(fff, "     1 %s\n", r_ptr->name.data());
             }
         } else {
             char ToPlural[80];
-            strcpy(ToPlural, r_ptr->name.c_str());
+            strcpy(ToPlural, r_ptr->name.data());
             plural_aux(ToPlural);
             fprintf(fff, "     %d %s\n", this_monster, ToPlural);
         }
@@ -262,7 +262,7 @@ static void display_monster_list(int col, int row, int per_page, const std::vect
         MonsterRaceId r_idx = mon_idx[mon_top + i];
         auto *r_ptr = &monraces_info[r_idx];
         attr = ((i + mon_top == mon_cur) ? TERM_L_BLUE : TERM_WHITE);
-        c_prt(attr, (r_ptr->name.c_str()), row + i, col);
+        c_prt(attr, (r_ptr->name.data()), row + i, col);
         if (per_page == 1) {
             c_prt(attr, format("%02x/%02x", r_ptr->x_attr, r_ptr->x_char), row + i, (w_ptr->wizard || visual_only) ? 56 : 61);
         }
@@ -484,7 +484,7 @@ void do_cmd_knowledge_bounty(PlayerType *player_ptr)
     }
 
     fprintf(fff, _("今日のターゲット : %s\n", "Today's target : %s\n"),
-        player_ptr->knows_daily_bounty ? monraces_info[w_ptr->today_mon].name.c_str() : _("不明", "unknown"));
+        player_ptr->knows_daily_bounty ? monraces_info[w_ptr->today_mon].name.data() : _("不明", "unknown"));
     fprintf(fff, "\n");
     fprintf(fff, _("賞金首リスト\n", "List of wanted monsters\n"));
     fprintf(fff, "----------------------------------------------\n");
@@ -492,7 +492,7 @@ void do_cmd_knowledge_bounty(PlayerType *player_ptr)
     bool listed = false;
     for (const auto &[r_idx, is_achieved] : w_ptr->bounties) {
         if (!is_achieved) {
-            fprintf(fff, "%s\n", monraces_info[r_idx].name.c_str());
+            fprintf(fff, "%s\n", monraces_info[r_idx].name.data());
             listed = true;
         }
     }

--- a/src/knowledge/knowledge-quests.cpp
+++ b/src/knowledge/knowledge-quests.cpp
@@ -87,7 +87,7 @@ static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
                 switch (q_ref.type) {
                 case QuestKindType::KILL_LEVEL:
                     r_ptr = &monraces_info[q_ref.r_idx];
-                    strcpy(name, r_ptr->name.c_str());
+                    strcpy(name, r_ptr->name.data());
                     if (q_ref.max_num > 1) {
 #ifdef JP
                         sprintf(note, " - %d 体の%sを倒す。(あと %d 体)", (int)q_ref.max_num, name, (int)(q_ref.max_num - q_ref.cur_num));
@@ -160,7 +160,7 @@ static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
         }
 
         r_ptr = &monraces_info[q_ref.r_idx];
-        strcpy(name, r_ptr->name.c_str());
+        strcpy(name, r_ptr->name.data());
         if (q_ref.max_num <= 1) {
             sprintf(rand_tmp_str, _("  %s (%d 階) - %sを倒す。\n", "  %s (Dungeon level: %d)\n  Kill %s.\n"), q_ref.name, (int)q_ref.level, name);
             continue;
@@ -210,13 +210,13 @@ static bool do_cmd_knowledge_quests_aux(PlayerType *player_ptr, FILE *fff, Quest
 
     auto fputs_name_remain = [fff](const auto &name) {
         for (auto i = 1U; i < name.size(); ++i) {
-            fprintf(fff, "  %s\n", name[i].c_str());
+            fprintf(fff, "  %s\n", name[i].data());
         }
     };
 
     if (is_fixed_quest || !MonsterRace(q_ref.r_idx).is_valid()) {
         auto name = str_separate(q_ref.name, 35);
-        sprintf(tmp_str, _("  %-35s (危険度:%3d階相当) - レベル%2d - %s\n", "  %-35s (Danger  level: %3d) - level %2d - %s\n"), name.front().c_str(), (int)q_ref.level,
+        sprintf(tmp_str, _("  %-35s (危険度:%3d階相当) - レベル%2d - %s\n", "  %-35s (Danger  level: %3d) - level %2d - %s\n"), name.front().data(), (int)q_ref.level,
             q_ref.complev, playtime_str);
         fputs(tmp_str, fff);
         fputs_name_remain(name);
@@ -226,13 +226,13 @@ static bool do_cmd_knowledge_quests_aux(PlayerType *player_ptr, FILE *fff, Quest
     auto name = str_separate(monraces_info[q_ref.r_idx].name, 35);
     if (q_ref.complev == 0) {
         sprintf(tmp_str, _("  %-35s (%3d階)            -   不戦勝 - %s\n", "  %-35s (Dungeon level: %3d) - Unearned - %s\n"),
-            name.front().c_str(), (int)q_ref.level, playtime_str);
+            name.front().data(), (int)q_ref.level, playtime_str);
         fputs(tmp_str, fff);
         fputs_name_remain(name);
         return true;
     }
 
-    sprintf(tmp_str, _("  %-35s (%3d階)            - レベル%2d - %s\n", "  %-35s (Dungeon level: %3d) - level %2d - %s\n"), name.front().c_str(),
+    sprintf(tmp_str, _("  %-35s (%3d階)            - レベル%2d - %s\n", "  %-35s (Dungeon level: %3d) - level %2d - %s\n"), name.front().data(),
         (int)q_ref.level, q_ref.complev, playtime_str);
     fputs(tmp_str, fff);
     fputs_name_remain(name);
@@ -303,7 +303,7 @@ static void do_cmd_knowledge_quests_wiz_random(FILE *fff)
 
         if ((q_ref.type == QuestKindType::RANDOM) && (q_ref.status == QuestStatusType::TAKEN)) {
             total++;
-            sprintf(tmp_str, _("  %s (%d階, %s)\n", "  %s (%d, %s)\n"), q_ref.name, (int)q_ref.level, monraces_info[q_ref.r_idx].name.c_str());
+            sprintf(tmp_str, _("  %s (%d階, %s)\n", "  %s (%d, %s)\n"), q_ref.name, (int)q_ref.level, monraces_info[q_ref.r_idx].name.data());
             fputs(tmp_str, fff);
         }
     }

--- a/src/knowledge/knowledge-self.cpp
+++ b/src/knowledge/knowledge-self.cpp
@@ -41,7 +41,7 @@ void do_cmd_knowledge_virtues(PlayerType *player_ptr)
     }
 
     std::string alg = PlayerAlignment(player_ptr).get_alignment_description();
-    fprintf(fff, _("現在の属性 : %s\n\n", "Your alignment : %s\n\n"), alg.c_str());
+    fprintf(fff, _("現在の属性 : %s\n\n", "Your alignment : %s\n\n"), alg.data());
     dump_virtues(player_ptr, fff);
     angband_fclose(fff);
     (void)show_file(player_ptr, true, file_name, _("八つの徳", "Virtues"), 0, 0);
@@ -162,7 +162,7 @@ static void dump_winner_classes(FILE *fff)
         }
 
         if (l.size() + t.size() + 2 > max_len) {
-            fprintf(fff, " %s\n", str_rtrim(l).c_str());
+            fprintf(fff, " %s\n", str_rtrim(l).data());
             l = "";
         }
         if (l.size() > 0) {
@@ -172,7 +172,7 @@ static void dump_winner_classes(FILE *fff)
     }
 
     if (l.size() > 0) {
-        fprintf(fff, " %s\n", str_rtrim(l).c_str());
+        fprintf(fff, " %s\n", str_rtrim(l).data());
     }
 }
 

--- a/src/knowledge/knowledge-uniques.cpp
+++ b/src/knowledge/knowledge-uniques.cpp
@@ -128,9 +128,9 @@ static void display_uniques(unique_list_type *unique_list_ptr, FILE *fff)
         }
 
         const auto name = str_separate(r_ptr->name, 40);
-        fprintf(fff, _("     %-40s (レベル%3d)%s\n", "     %-40s (level %3d)%s\n"), name.front().c_str(), (int)r_ptr->level, buf);
+        fprintf(fff, _("     %-40s (レベル%3d)%s\n", "     %-40s (level %3d)%s\n"), name.front().data(), (int)r_ptr->level, buf);
         for (auto i = 1U; i < name.size(); ++i) {
-            fprintf(fff, "     %s\n", name[i].c_str());
+            fprintf(fff, "     %s\n", name[i].data());
         }
     }
 }

--- a/src/lore/monster-lore.cpp
+++ b/src/lore/monster-lore.cpp
@@ -169,7 +169,7 @@ void process_monster_lore(PlayerType *player_ptr, MonsterRaceId r_idx, monster_l
     set_flags1(lore_ptr);
     set_race_flags(lore_ptr);
     display_kill_numbers(lore_ptr);
-    concptr tmp = lore_ptr->r_ptr->text.c_str();
+    concptr tmp = lore_ptr->r_ptr->text.data();
     if (tmp[0]) {
         hooked_roff(tmp);
         hooked_roff("\n");

--- a/src/main-gcu.cpp
+++ b/src/main-gcu.cpp
@@ -1293,7 +1293,7 @@ errr init_gcu(int argc, char *argv[])
     /* Hack -- Require large screen, or Quit with message */
     i = ((LINES < 24) || (COLS < 80));
     if (i) {
-        quit_fmt("%s needs an 80x24 'curses' screen", std::string(VARIANT_NAME).c_str());
+        quit_fmt("%s needs an 80x24 'curses' screen", std::string(VARIANT_NAME).data());
     }
 
 #ifdef A_COLOR
@@ -1599,7 +1599,7 @@ errr init_gcu(int argc, char *argv[])
 
         /* Map Terminal */
         if (remaining.cx < MIN_TERM0_COLS || remaining.cy < MIN_TERM0_LINES) {
-            quit_fmt("Failed: %s needs an %dx%d map screen, not %dx%d", std::string(VARIANT_NAME).c_str(), MIN_TERM0_COLS, MIN_TERM0_LINES, remaining.cx, remaining.cy);
+            quit_fmt("Failed: %s needs an %dx%d map screen, not %dx%d", std::string(VARIANT_NAME).data(), MIN_TERM0_COLS, MIN_TERM0_LINES, remaining.cx, remaining.cy);
         }
         data[0].r = remaining;
         term_data_init(&data[0]);

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -338,7 +338,7 @@ static void save_prefs_aux(int i)
     }
 
     auto pwchar = td->lf.lfFaceName[0] != '\0' ? td->lf.lfFaceName : _(L"ＭＳ ゴシック", L"Courier");
-    WritePrivateProfileStringA(sec_name, "Font", to_multibyte(pwchar).c_str(), ini_file);
+    WritePrivateProfileStringA(sec_name, "Font", to_multibyte(pwchar).data(), ini_file);
 
     wsprintfA(buf, "%d", td->lf.lfWidth);
     WritePrivateProfileStringA(sec_name, "FontWid", buf, ini_file);
@@ -1545,7 +1545,7 @@ static void check_for_save_file(const std::string &savefile_option)
         return;
     }
 
-    strcpy(savefile, savefile_option.c_str());
+    strcpy(savefile, savefile_option.data());
     validate_file(savefile);
     game_in_progress = true;
 }
@@ -2245,7 +2245,7 @@ LRESULT PASCAL angband_window_procedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
             term_no_press = false;
         } else {
             WCHAR wc[2] = { (WCHAR)wParam, '\0' };
-            term_keypress(to_multibyte(wc).c_str());
+            term_keypress(to_multibyte(wc).data());
         }
         return 0;
     }
@@ -2503,7 +2503,7 @@ LRESULT PASCAL AngbandListProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPara
             term_no_press = false;
         } else {
             WCHAR wc[2] = { (WCHAR)wParam, '\0' };
-            term_keypress(to_multibyte(wc).c_str());
+            term_keypress(to_multibyte(wc).data());
         }
         return 0;
     }

--- a/src/main-win/commandline-win.cpp
+++ b/src/main-win/commandline-win.cpp
@@ -48,7 +48,7 @@ void CommandLine::handle(void)
                 if (argv[i][0] != L'-') {
                     // "-"で始まらない最初のオプションをセーブファイル名とみなす
                     if (savefile_option.empty()) {
-                        savefile_option = to_multibyte(argv[i]).c_str();
+                        savefile_option = to_multibyte(argv[i]).data();
                     }
                 }
             }

--- a/src/main-win/main-win-cfg-reader.cpp
+++ b/src/main-win/main-win-cfg-reader.cpp
@@ -91,7 +91,7 @@ CfgData *CfgReader::read_sections(std::initializer_list<cfg_section> sections)
 {
     CfgData *result = new CfgData();
 
-    if (!check_file(this->cfg_path.c_str())) {
+    if (!check_file(this->cfg_path.data())) {
         return result;
     }
 
@@ -106,7 +106,7 @@ CfgData *CfgReader::read_sections(std::initializer_list<cfg_section> sections)
         int index = 0;
         concptr read_key;
         while ((read_key = section.key_at(index, key_buf)) != nullptr) {
-            GetPrivateProfileStringA(section.section_name, read_key, "", buf, MAIN_WIN_MAX_PATH, this->cfg_path.c_str());
+            GetPrivateProfileStringA(section.section_name, read_key, "", buf, MAIN_WIN_MAX_PATH, this->cfg_path.data());
             if (*buf != '\0') {
                 cfg_values *filenames = new cfg_values();
 #ifdef JP

--- a/src/main-win/main-win-cfg-reader.h
+++ b/src/main-win/main-win-cfg-reader.h
@@ -59,7 +59,7 @@ public:
     CfgData *read_sections(std::initializer_list<cfg_section> sections);
     concptr get_cfg_path()
     {
-        return cfg_path.c_str();
+        return cfg_path.data();
     }
 
 protected:

--- a/src/main-win/main-win-music.cpp
+++ b/src/main-win/main-win-music.cpp
@@ -201,7 +201,7 @@ errr play_music(int type, int val)
     strcpy(current_music_path, buf);
 
     to_wchar path(buf);
-    mci_open_parms.lpstrDeviceType = mci_device_type.c_str();
+    mci_open_parms.lpstrDeviceType = mci_device_type.data();
     mci_open_parms.lpstrElementName = path.wc_str();
     mciSendCommandW(mci_open_parms.wDeviceID, MCI_STOP, MCI_WAIT, 0);
     mciSendCommandW(mci_open_parms.wDeviceID, MCI_CLOSE, MCI_WAIT, 0);

--- a/src/main-win/main-win-utils.cpp
+++ b/src/main-win/main-win-utils.cpp
@@ -51,7 +51,7 @@ void save_screen_as_html(HWND hWnd)
     ofnw.Flags = OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT;
 
     if (GetSaveFileNameW(&ofnw)) {
-        do_cmd_save_screen_html_aux(to_multibyte(&buf[0]).c_str(), 0);
+        do_cmd_save_screen_html_aux(to_multibyte(&buf[0]).data(), 0);
     }
 }
 
@@ -62,7 +62,7 @@ void save_screen_as_html(HWND hWnd)
 void open_dir_in_explorer(char *filename)
 {
     std::string str = "/select," + std::string(filename);
-    ShellExecuteW(NULL, NULL, L"explorer.exe", to_wchar(str.c_str()).wc_str(), NULL, SW_SHOWNORMAL);
+    ShellExecuteW(NULL, NULL, L"explorer.exe", to_wchar(str.data()).wc_str(), NULL, SW_SHOWNORMAL);
 }
 
 /*!
@@ -92,7 +92,7 @@ bool get_open_filename(OPENFILENAMEW *ofn, concptr dirname, char *filename, DWOR
     // call API
     if (GetOpenFileNameW(ofn)) {
         // to multibyte
-        strncpy_s(filename, max_name_size, to_multibyte(&buf[0]).c_str(), _TRUNCATE);
+        strncpy_s(filename, max_name_size, to_multibyte(&buf[0]).data(), _TRUNCATE);
         return true;
     }
 

--- a/src/market/arena.cpp
+++ b/src/market/arena.cpp
@@ -134,7 +134,7 @@ static void see_arena_poster(PlayerType *player_ptr)
 
     monster_race *r_ptr;
     r_ptr = &monraces_info[arena_info[player_ptr->arena_number].r_idx];
-    concptr name = r_ptr->name.c_str();
+    concptr name = r_ptr->name.data();
     msg_format(_("%s に挑戦するものはいないか？", "Do I hear any challenges against: %s"), name);
 
     player_ptr->monster_race_idx = arena_info[player_ptr->arena_number].r_idx;
@@ -293,8 +293,8 @@ bool monster_arena_comm(PlayerType *player_ptr)
         auto *r_ptr = &monraces_info[battle_mon_list[i]];
 
         sprintf(buf, _("%d) %-58s  %4ld.%02ld倍", "%d) %-58s  %4ld.%02ld"), i + 1,
-            _(format("%s%s", r_ptr->name.c_str(), r_ptr->kind_flags.has(MonsterKindType::UNIQUE) ? "もどき" : "      "),
-                format("%s%s", r_ptr->kind_flags.has(MonsterKindType::UNIQUE) ? "Fake " : "", r_ptr->name.c_str())),
+            _(format("%s%s", r_ptr->name.data(), r_ptr->kind_flags.has(MonsterKindType::UNIQUE) ? "もどき" : "      "),
+                format("%s%s", r_ptr->kind_flags.has(MonsterKindType::UNIQUE) ? "Fake " : "", r_ptr->name.data())),
             (long int)mon_odds[i] / 100, (long int)mon_odds[i] % 100);
         prt(buf, 5 + i, 1);
     }

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -110,7 +110,7 @@ bool exchange_cash(PlayerType *player_ptr)
         o_ptr = &player_ptr->inventory_list[i];
         const auto r_idx_of_item = static_cast<MonsterRaceId>(o_ptr->pval);
 
-        if ((o_ptr->tval == ItemKindType::CORPSE) && (o_ptr->sval == SV_CORPSE) && (streq(monraces_info[r_idx_of_item].name.c_str(), monraces_info[w_ptr->today_mon].name.c_str()))) {
+        if ((o_ptr->tval == ItemKindType::CORPSE) && (o_ptr->sval == SV_CORPSE) && (streq(monraces_info[r_idx_of_item].name.data(), monraces_info[w_ptr->today_mon].name.data()))) {
             char buf[MAX_NLEN + 32];
             describe_flavor(player_ptr, o_name, o_ptr, 0);
             sprintf(buf, _("%s を換金しますか？", "Convert %s into money? "), o_name);
@@ -130,7 +130,7 @@ bool exchange_cash(PlayerType *player_ptr)
         o_ptr = &player_ptr->inventory_list[i];
         const auto r_idx_of_item = static_cast<MonsterRaceId>(o_ptr->pval);
 
-        if ((o_ptr->tval == ItemKindType::CORPSE) && (o_ptr->sval == SV_SKELETON) && (streq(monraces_info[r_idx_of_item].name.c_str(), monraces_info[w_ptr->today_mon].name.c_str()))) {
+        if ((o_ptr->tval == ItemKindType::CORPSE) && (o_ptr->sval == SV_SKELETON) && (streq(monraces_info[r_idx_of_item].name.data(), monraces_info[w_ptr->today_mon].name.data()))) {
             char buf[MAX_NLEN + 32];
             describe_flavor(player_ptr, o_name, o_ptr, 0);
             sprintf(buf, _("%s を換金しますか？", "Convert %s into money? "), o_name);
@@ -218,7 +218,7 @@ void today_target(PlayerType *player_ptr)
 
     clear_bldg(4, 18);
     c_put_str(TERM_YELLOW, _("本日の賞金首", "Wanted monster that changes from day to day"), 5, 10);
-    sprintf(buf, _("ターゲット： %s", "target: %s"), r_ptr->name.c_str());
+    sprintf(buf, _("ターゲット： %s", "target: %s"), r_ptr->name.data());
     c_put_str(TERM_YELLOW, buf, 6, 10);
     sprintf(buf, _("死体 ---- $%d", "corpse   ---- $%d"), (int)r_ptr->level * 50 + 100);
     prt(buf, 8, 10);
@@ -258,7 +258,7 @@ void show_bounty(void)
         auto color = is_achieved ? TERM_RED : TERM_WHITE;
         auto done_mark = is_achieved ? _("(済)", "(done)") : "";
 
-        c_prt(color, format("%s %s", r_ptr->name.c_str(), done_mark), y + 7, 10);
+        c_prt(color, format("%s %s", r_ptr->name.data(), done_mark), y + 7, 10);
 
         y = (y + 1) % 10;
         if (!y && (i < std::size(w_ptr->bounties) - 1)) {
@@ -299,7 +299,7 @@ void determine_daily_bounty(PlayerType *player_ptr, bool conv_old)
         r_ptr = &monraces_info[w_ptr->today_mon];
 
         if (cheat_hear) {
-            msg_format("日替わり候補: %s ", r_ptr->name.c_str());
+            msg_format("日替わり候補: %s ", r_ptr->name.data());
         }
 
         if (r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {

--- a/src/market/building-monster.cpp
+++ b/src/market/building-monster.cpp
@@ -119,9 +119,9 @@ bool research_mon(PlayerType *player_ptr)
 
             char temp2[MAX_MONSTER_NAME];
 #ifdef JP
-            strcpy(temp2, r_ref.E_name.c_str());
+            strcpy(temp2, r_ref.E_name.data());
 #else
-            strcpy(temp2, r_ref.name.c_str());
+            strcpy(temp2, r_ref.name.data());
 #endif
             for (int xx = 0; temp2[xx] && xx < 80; xx++) {
                 if (isupper(temp2[xx])) {
@@ -130,7 +130,7 @@ bool research_mon(PlayerType *player_ptr)
             }
 
 #ifdef JP
-            if (angband_strstr(temp2, temp) || angband_strstr(r_ref.name.c_str(), temp))
+            if (angband_strstr(temp2, temp) || angband_strstr(r_ref.name.data(), temp))
 #else
             if (angband_strstr(temp2, temp))
 #endif

--- a/src/mind/mind-weaponsmith.cpp
+++ b/src/mind/mind-weaponsmith.cpp
@@ -288,9 +288,9 @@ static void display_smith_effect_list(const Smith &smith, const std::vector<Smit
         if (need_essences.size() == 1) {
             auto essence = need_essences.front();
             auto amount = smith.get_essence_num_of_posessions(essence);
-            snprintf(str, sizeof(str), "%-49s %5d/%d", title.str().c_str(), amount, consumption);
+            snprintf(str, sizeof(str), "%-49s %5d/%d", title.str().data(), amount, consumption);
         } else {
-            snprintf(str, sizeof(str), "%-49s  (\?\?)/%d", title.str().c_str(), consumption);
+            snprintf(str, sizeof(str), "%-49s  (\?\?)/%d", title.str().data(), consumption);
         }
 
         auto col = (smith.get_addable_count(effect) > 0) ? TERM_WHITE : TERM_RED;
@@ -332,7 +332,7 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
         while (!flag) {
             if (page_max > 1) {
                 std::string page_str = format("%d/%d", page + 1, page_max);
-                strnfmt(out_val, 78, _("(SPACEで次ページ, ESCで中断) どの能力を付加しますか？ %s", "(SPACE=next, ESC=exit) Add which ability? %s"), page_str.c_str());
+                strnfmt(out_val, 78, _("(SPACEで次ページ, ESCで中断) どの能力を付加しますか？ %s", "(SPACE=next, ESC=exit) Add which ability? %s"), page_str.data());
             } else {
                 strnfmt(out_val, 78, _("(ESCで中断) どの能力を付加しますか？", "(ESC=exit) Add which ability? "));
             }

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -236,7 +236,7 @@ static void drop_artifacts(PlayerType *player_ptr, monster_death_type *md_ptr)
         (void)drop_near(player_ptr, q_ptr, -1, md_ptr->md_y, md_ptr->md_x);
     }
 
-    msg_format(_("あなたは%sを制覇した！", "You have conquered %s!"), dungeons_info[player_ptr->dungeon_idx].name.c_str());
+    msg_format(_("あなたは%sを制覇した！", "You have conquered %s!"), dungeons_info[player_ptr->dungeon_idx].name.data());
 }
 
 static void decide_drop_quality(monster_death_type *md_ptr)

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -274,7 +274,7 @@ bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSI
     auto *floor_ptr = player_ptr->current_floor_ptr;
     auto *g_ptr = &floor_ptr->grid_array[y][x];
     auto *r_ptr = &monraces_info[r_idx];
-    concptr name = r_ptr->name.c_str();
+    concptr name = r_ptr->name.data();
 
     if (player_ptr->wild_mode || !in_bounds(floor_ptr, y, x) || !MonsterRace(r_idx).is_valid() || r_ptr->name.empty()) {
         return false;

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -157,7 +157,7 @@ bool MonsterDamageProcessor::process_dead_exp_virtue(concptr note, monster_type 
     ac.change_virtue();
     if (r_ref.kind_flags.has(MonsterKindType::UNIQUE) && record_destroy_uniq) {
         char note_buf[160];
-        sprintf(note_buf, "%s%s", r_ref.name.c_str(), m_ptr->mflag2.has(MonsterConstantFlagType::CLONED) ? _("(クローン)", "(Clone)") : "");
+        sprintf(note_buf, "%s%s", r_ref.name.data(), m_ptr->mflag2.has(MonsterConstantFlagType::CLONED) ? _("(クローン)", "(Clone)") : "");
         exe_write_diary(this->player_ptr, DIARY_UNIQUE, 0, note_buf);
     }
 

--- a/src/monster/monster-describer.cpp
+++ b/src/monster/monster-describer.cpp
@@ -26,7 +26,7 @@ void monster_desc(PlayerType *player_ptr, char *desc, monster_type *m_ptr, BIT_F
 {
     monster_race *r_ptr;
     r_ptr = &monraces_info[m_ptr->ap_r_idx];
-    concptr name = (mode & MD_TRUE_NAME) ? m_ptr->get_real_r_ref().name.c_str() : r_ptr->name.c_str();
+    concptr name = (mode & MD_TRUE_NAME) ? m_ptr->get_real_r_ref().name.data() : r_ptr->name.data();
     GAME_TEXT silly_name[1024];
     bool named = false;
     auto is_hallucinated = player_ptr->effects()->hallucination()->is_hallucinated();
@@ -45,7 +45,7 @@ void monster_desc(PlayerType *player_ptr, char *desc, monster_type *m_ptr, BIT_F
                 hallu_race = &monraces_info[r_idx];
             } while (hallu_race->name.empty() || hallu_race->kind_flags.has(MonsterKindType::UNIQUE));
 
-            strcpy(silly_name, (hallu_race->name.c_str()));
+            strcpy(silly_name, (hallu_race->name.data()));
         }
 
         name = silly_name;
@@ -243,7 +243,7 @@ void monster_desc(PlayerType *player_ptr, char *desc, monster_type *m_ptr, BIT_F
     }
 
     if ((mode & MD_IGNORE_HALLU) && !m_ptr->is_original_ap()) {
-        strcat(desc, format("(%s)", monraces_info[m_ptr->r_idx].name.c_str()));
+        strcat(desc, format("(%s)", monraces_info[m_ptr->r_idx].name.data()));
     }
 
     /* Handle the Possessive as a special afterthought */

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -501,9 +501,9 @@ void monster_gain_exp(PlayerType *player_ptr, MONSTER_IDX m_idx, MonsterRaceId s
                 auto mes_evolution = _("%sは%sに進化した。", "%^s evolved into %s.");
                 auto mes_degeneration = _("%sは%sに退化した。", "%^s degenerated into %s.");
                 auto mes = randint0(2) == 0 ? mes_evolution : mes_degeneration;
-                msg_format(mes, m_name, hallucinated_race->name.c_str());
+                msg_format(mes, m_name, hallucinated_race->name.data());
             } else {
-                msg_format(_("%sは%sに進化した。", "%^s evolved into %s."), m_name, r_ptr->name.c_str());
+                msg_format(_("%sは%sに進化した。", "%^s evolved into %s."), m_name, r_ptr->name.data());
             }
         }
 

--- a/src/mutation/mutation-techniques.cpp
+++ b/src/mutation/mutation-techniques.cpp
@@ -45,7 +45,7 @@ bool eat_rock(PlayerType *player_ptr)
     if (mimic_f_ptr->flags.has_not(TerrainCharacteristics::HURT_ROCK)) {
         msg_print(_("この地形は食べられない。", "You cannot eat this feature."));
     } else if (f_ptr->flags.has(TerrainCharacteristics::PERMANENT)) {
-        msg_format(_("いてっ！この%sはあなたの歯より硬い！", "Ouch!  This %s is harder than your teeth!"), mimic_f_ptr->name.c_str());
+        msg_format(_("いてっ！この%sはあなたの歯より硬い！", "Ouch!  This %s is harder than your teeth!"), mimic_f_ptr->name.data());
     } else if (g_ptr->m_idx) {
         auto *m_ptr = &player_ptr->current_floor_ptr->m_list[g_ptr->m_idx];
         msg_print(_("何かが邪魔しています！", "There's something in the way!"));
@@ -62,7 +62,7 @@ bool eat_rock(PlayerType *player_ptr)
     } else if (f_ptr->flags.has(TerrainCharacteristics::MAY_HAVE_GOLD) || f_ptr->flags.has(TerrainCharacteristics::HAS_GOLD)) {
         (void)set_food(player_ptr, player_ptr->food + 5000);
     } else {
-        msg_format(_("この%sはとてもおいしい！", "This %s is very filling!"), mimic_f_ptr->name.c_str());
+        msg_format(_("この%sはとてもおいしい！", "This %s is very filling!"), mimic_f_ptr->name.data());
         (void)set_food(player_ptr, player_ptr->food + 10000);
     }
 

--- a/src/object-activation/activation-others.cpp
+++ b/src/object-activation/activation-others.cpp
@@ -179,7 +179,7 @@ bool activate_unique_detection(PlayerType *player_ptr)
 
         r_ptr = &monraces_info[m_ptr->r_idx];
         if (r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
-            msg_format(_("%s． ", "%s. "), r_ptr->name.c_str());
+            msg_format(_("%s． ", "%s. "), r_ptr->name.data());
         }
 
         if (m_ptr->r_idx == MonsterRaceId::DIO) {

--- a/src/object-enchant/others/apply-magic-others.cpp
+++ b/src/object-enchant/others/apply-magic-others.cpp
@@ -180,7 +180,7 @@ void OtherItemsEnchanter::generate_statue()
 
     this->o_ptr->pval = enum2i(r_idx);
     if (cheat_peek) {
-        msg_format(_("%sの像", "Statue of %s"), r_ptr->name.c_str());
+        msg_format(_("%sの像", "Statue of %s"), r_ptr->name.data());
     }
 
     object_aware(this->player_ptr, this->o_ptr);

--- a/src/object-hook/hook-quest.cpp
+++ b/src/object-hook/hook-quest.cpp
@@ -30,7 +30,7 @@ bool object_is_bounty(PlayerType *player_ptr, ObjectType *o_ptr)
     }
 
     auto corpse_r_idx = i2enum<MonsterRaceId>(o_ptr->pval);
-    if (player_ptr->knows_daily_bounty && (streq(monraces_info[corpse_r_idx].name.c_str(), monraces_info[w_ptr->today_mon].name.c_str()))) {
+    if (player_ptr->knows_daily_bounty && (streq(monraces_info[corpse_r_idx].name.data(), monraces_info[w_ptr->today_mon].name.data()))) {
         return true;
     }
 

--- a/src/perception/identification.cpp
+++ b/src/perception/identification.cpp
@@ -43,7 +43,7 @@ bool screen_object(PlayerType *player_ptr, ObjectType *o_ptr, BIT_FLAGS mode)
     int trivial_info = 0;
     auto flgs = object_flags(o_ptr);
 
-    const auto item_text = o_ptr->is_fixed_artifact() ? artifacts_info.at(o_ptr->fixed_artifact_idx).text.c_str() : baseitems_info[o_ptr->k_idx].text.c_str();
+    const auto item_text = o_ptr->is_fixed_artifact() ? artifacts_info.at(o_ptr->fixed_artifact_idx).text.data() : baseitems_info[o_ptr->k_idx].text.data();
     shape_buffer(item_text, 77 - 15, temp, sizeof(temp));
 
     int i = 0;
@@ -803,8 +803,8 @@ bool screen_object(PlayerType *player_ptr, ObjectType *o_ptr, BIT_FLAGS mode)
     if ((o_ptr->tval == ItemKindType::STATUE) && (o_ptr->sval == SV_PHOTO)) {
         auto statue_r_idx = i2enum<MonsterRaceId>(o_ptr->pval);
         auto *r_ptr = &monraces_info[statue_r_idx];
-        int namelen = strlen(r_ptr->name.c_str());
-        prt(format("%s: '", r_ptr->name.c_str()), 1, 15);
+        int namelen = strlen(r_ptr->name.data());
+        prt(format("%s: '", r_ptr->name.data()), 1, 15);
         term_queue_bigchar(18 + namelen, 1, r_ptr->x_attr, r_ptr->x_char, 0, 0);
         prt("'", 1, (use_bigtile ? 20 : 19) + namelen);
     } else {

--- a/src/player/eldritch-horror.cpp
+++ b/src/player/eldritch-horror.cpp
@@ -157,7 +157,7 @@ void sanity_blast(PlayerType *player_ptr, monster_type *m_ptr, bool necro)
         get_mon_num_prep(player_ptr, get_nightmare, nullptr);
         r_ptr = &monraces_info[get_mon_num(player_ptr, 0, MAX_DEPTH, 0)];
         power = r_ptr->level + 10;
-        desc = r_ptr->name.c_str();
+        desc = r_ptr->name.data();
         get_mon_num_prep(player_ptr, nullptr, nullptr);
 #ifdef JP
 #else

--- a/src/player/patron.cpp
+++ b/src/player/patron.cpp
@@ -183,12 +183,12 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
     }
     type--;
 
-    sprintf(wrath_reason, _("%sの怒り", "the Wrath of %s"), this->name.c_str());
+    sprintf(wrath_reason, _("%sの怒り", "the Wrath of %s"), this->name.data());
 
     effect = this->reward_table[type];
 
     if (one_in_(6) && !chosen_reward) {
-        msg_format(_("%^sは褒美としてあなたを突然変異させた。", "%^s rewards you with a mutation!"), this->name.c_str());
+        msg_format(_("%^sは褒美としてあなたを突然変異させた。", "%^s rewards you with a mutation!"), this->name.data());
         (void)gain_mutation(player_ptr, 0);
         reward = _("変異した。", "mutation");
     } else {
@@ -196,7 +196,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
 
         case REW_POLY_SLF:
 
-            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.c_str());
+            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「汝、新たなる姿を必要とせり！」", "'Thou needst a new form, mortal!'"));
 
             do_poly_self(player_ptr);
@@ -205,7 +205,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
 
         case REW_GAIN_EXP:
 
-            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.c_str());
+            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「汝は良く行いたり！続けよ！」", "'Well done, mortal! Lead on!'"));
 
             if (PlayerRace(this->player_ptr).equals(PlayerRaceType::ANDROID)) {
@@ -224,7 +224,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
 
         case REW_LOSE_EXP:
 
-            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.c_str());
+            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「下僕よ、汝それに値せず。」", "'Thou didst not deserve that, slave.'"));
 
             if (PlayerRace(this->player_ptr).equals(PlayerRaceType::ANDROID)) {
@@ -236,7 +236,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             break;
 
         case REW_GOOD_OBJ:
-            msg_format(_("%sの声がささやいた:", "The voice of %s whispers:"), this->name.c_str());
+            msg_format(_("%sの声がささやいた:", "The voice of %s whispers:"), this->name.data());
             msg_print(_("「我が与えし物を賢明に使うべし。」", "'Use my gift wisely.'"));
 
             acquirement(player_ptr, this->player_ptr->y, this->player_ptr->x, 1, false, false, false);
@@ -245,7 +245,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
 
         case REW_GREA_OBJ:
 
-            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.c_str());
+            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「我が与えし物を賢明に使うべし。」", "'Use my gift wisely.'"));
 
             acquirement(player_ptr, this->player_ptr->y, this->player_ptr->x, 1, true, false, false);
@@ -253,7 +253,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             break;
 
         case REW_CHAOS_WP:
-            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.c_str());
+            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「汝の行いは貴き剣に値せり。」", "'Thy deed hath earned thee a worthy blade.'"));
             acquire_chaos_weapon(player_ptr);
             reward = _("(混沌)の武器を手に入れた。", "chaos weapon");
@@ -261,7 +261,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
 
         case REW_GOOD_OBS:
 
-            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.c_str());
+            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「汝の行いは貴き報いに値せり。」", "'Thy deed hath earned thee a worthy reward.'"));
 
             acquirement(player_ptr, this->player_ptr->y, this->player_ptr->x, randint1(2) + 1, false, false, false);
@@ -270,7 +270,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
 
         case REW_GREA_OBS:
 
-            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.c_str());
+            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「下僕よ、汝の献身への我が惜しみ無き報いを見るがよい。」", "'Behold, mortal, how generously I reward thy loyalty.'"));
 
             acquirement(player_ptr, this->player_ptr->y, this->player_ptr->x, randint1(2) + 1, true, false, false);
@@ -278,7 +278,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             break;
 
         case REW_TY_CURSE:
-            msg_format(_("%sの声が轟き渡った:", "The voice of %s thunders:"), this->name.c_str());
+            msg_format(_("%sの声が轟き渡った:", "The voice of %s thunders:"), this->name.data());
             msg_print(_("「下僕よ、汝傲慢なり。」", "'Thou art growing arrogant, mortal.'"));
 
             (void)activate_ty_curse(player_ptr, false, &count);
@@ -287,7 +287,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
 
         case REW_SUMMON_M:
 
-            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.c_str());
+            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「我が下僕たちよ、かの傲慢なる者を倒すべし！」", "'My pets, destroy the arrogant mortal!'"));
 
             for (int i = 0, summon_num = randint1(5) + 1; i < summon_num; i++) {
@@ -299,7 +299,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
 
         case REW_H_SUMMON:
 
-            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.c_str());
+            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「汝、より強き敵を必要とせり！」", "'Thou needst worthier opponents!'"));
 
             activate_hi_summon(player_ptr, this->player_ptr->y, this->player_ptr->x, false);
@@ -307,7 +307,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             break;
 
         case REW_DO_HAVOC:
-            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.c_str());
+            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「死と破壊こそ我が喜びなり！」", "'Death and destruction! This pleaseth me!'"));
 
             call_chaos(player_ptr);
@@ -315,7 +315,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             break;
 
         case REW_GAIN_ABL:
-            msg_format(_("%sの声が鳴り響いた:", "The voice of %s rings out:"), this->name.c_str());
+            msg_format(_("%sの声が鳴り響いた:", "The voice of %s rings out:"), this->name.data());
             msg_print(_("「留まるのだ、下僕よ。余が汝の肉体を鍛えん。」", "'Stay, mortal, and let me mold thee.'"));
 
             if (one_in_(3) && !(this->boost_stat != A_RANDOM)) {
@@ -327,7 +327,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             break;
 
         case REW_LOSE_ABL:
-            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.c_str());
+            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「下僕よ、余は汝に飽みたり。」", "'I grow tired of thee, mortal.'"));
 
             if (one_in_(3) && !(this->boost_stat != A_RANDOM)) {
@@ -340,7 +340,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
 
         case REW_RUIN_ABL:
 
-            msg_format(_("%sの声が轟き渡った:", "The voice of %s thunders:"), this->name.c_str());
+            msg_format(_("%sの声が轟き渡った:", "The voice of %s thunders:"), this->name.data());
             msg_print(_("「汝、謙虚たることを学ぶべし！」", "'Thou needst a lesson in humility, mortal!'"));
             msg_print(_("あなたは以前より弱くなった！", "You feel less powerful!"));
 
@@ -352,14 +352,14 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
 
         case REW_POLY_WND:
 
-            msg_format(_("%sの力が触れるのを感じた。", "You feel the power of %s touch you."), this->name.c_str());
+            msg_format(_("%sの力が触れるのを感じた。", "You feel the power of %s touch you."), this->name.data());
             do_poly_wounds(player_ptr);
             reward = _("傷が変化した。", "polymorphing wounds");
             break;
 
         case REW_AUGM_ABL:
 
-            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.c_str());
+            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
 
             msg_print(_("「我がささやかなる賜物を受けとるがよい！」", "'Receive this modest gift from me!'"));
 
@@ -371,7 +371,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
 
         case REW_HURT_LOT:
 
-            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.c_str());
+            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「苦しむがよい、無能な愚か者よ！」", "'Suffer, pathetic fool!'"));
 
             fire_ball(player_ptr, AttributeType::DISINTEGRATE, 0, this->player_ptr->lev * 4, 4);
@@ -381,7 +381,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
 
         case REW_HEAL_FUL:
 
-            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.c_str());
+            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             (void)restore_level(player_ptr);
             (void)restore_all_status(player_ptr);
             (void)true_healing(player_ptr, 5000);
@@ -394,7 +394,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             if (!has_melee_weapon(player_ptr, INVEN_MAIN_HAND) && !has_melee_weapon(player_ptr, INVEN_SUB_HAND)) {
                 break;
             }
-            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.c_str());
+            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「汝、武器に頼ることなかれ。」", "'Thou reliest too much on thy weapon.'"));
 
             slot = INVEN_MAIN_HAND;
@@ -415,7 +415,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             if (!this->player_ptr->inventory_list[INVEN_BODY].k_idx) {
                 break;
             }
-            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.c_str());
+            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「汝、防具に頼ることなかれ。」", "'Thou reliest too much on thine equipment.'"));
 
             describe_flavor(player_ptr, o_name, &this->player_ptr->inventory_list[INVEN_BODY], OD_NAME_ONLY);
@@ -425,7 +425,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
 
         case REW_PISS_OFF:
 
-            msg_format(_("%sの声がささやいた:", "The voice of %s whispers:"), this->name.c_str());
+            msg_format(_("%sの声がささやいた:", "The voice of %s whispers:"), this->name.data());
             msg_print(_("「我を怒りしめた罪を償うべし。」", "'Now thou shalt pay for annoying me.'"));
 
             switch (randint1(4)) {
@@ -473,7 +473,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
 
         case REW_WRATH:
 
-            msg_format(_("%sの声が轟き渡った:", "The voice of %s thunders:"), this->name.c_str());
+            msg_format(_("%sの声が轟き渡った:", "The voice of %s thunders:"), this->name.data());
             msg_print(_("「死ぬがよい、下僕よ！」", "'Die, mortal!'"));
 
             take_hit(player_ptr, DAMAGE_LOSELIFE, this->player_ptr->lev * 4, wrath_reason);
@@ -505,7 +505,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
 
         case REW_DESTRUCT:
 
-            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.c_str());
+            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「死と破壊こそ我が喜びなり！」", "'Death and destruction! This pleaseth me!'"));
 
             (void)destroy_area(player_ptr, this->player_ptr->y, this->player_ptr->x, 25, false);
@@ -514,7 +514,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
 
         case REW_GENOCIDE:
 
-            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.c_str());
+            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「我、汝の敵を抹殺せん！」", "'Let me relieve thee of thine oppressors!'"));
             (void)symbol_genocide(player_ptr, 0, false);
             reward = _("モンスターが抹殺された。", "genociding monsters");
@@ -522,7 +522,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
 
         case REW_MASS_GEN:
 
-            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.c_str());
+            msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「我、汝の敵を抹殺せん！」", "'Let me relieve thee of thine oppressors!'"));
 
             (void)mass_genocide(player_ptr, 0, false);
@@ -531,18 +531,18 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
 
         case REW_DISPEL_C:
 
-            msg_format(_("%sの力が敵を攻撃するのを感じた！", "You can feel the power of %s assault your enemies!"), this->name.c_str());
+            msg_format(_("%sの力が敵を攻撃するのを感じた！", "You can feel the power of %s assault your enemies!"), this->name.data());
             (void)dispel_monsters(player_ptr, this->player_ptr->lev * 4);
             break;
 
         case REW_IGNORE:
 
-            msg_format(_("%sはあなたを無視した。", "%s ignores you."), this->name.c_str());
+            msg_format(_("%sはあなたを無視した。", "%s ignores you."), this->name.data());
             break;
 
         case REW_SER_DEMO:
 
-            msg_format(_("%sは褒美として悪魔の使いをよこした！", "%s rewards you with a demonic servant!"), this->name.c_str());
+            msg_format(_("%sは褒美として悪魔の使いをよこした！", "%s rewards you with a demonic servant!"), this->name.data());
 
             if (!summon_specific(player_ptr, -1, this->player_ptr->y, this->player_ptr->x, this->player_ptr->current_floor_ptr->dun_level, SUMMON_DEMON, PM_FORCE_PET)) {
                 msg_print(_("何も現れなかった...", "Nobody ever turns up..."));
@@ -553,7 +553,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             break;
 
         case REW_SER_MONS:
-            msg_format(_("%sは褒美として使いをよこした！", "%s rewards you with a servant!"), this->name.c_str());
+            msg_format(_("%sは褒美として使いをよこした！", "%s rewards you with a servant!"), this->name.data());
 
             if (!summon_specific(player_ptr, -1, this->player_ptr->y, this->player_ptr->x, this->player_ptr->current_floor_ptr->dun_level, SUMMON_NONE, PM_FORCE_PET)) {
                 msg_print(_("何も現れなかった...", "Nobody ever turns up..."));
@@ -564,7 +564,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             break;
 
         case REW_SER_UNDE:
-            msg_format(_("%sは褒美としてアンデッドの使いをよこした。", "%s rewards you with an undead servant!"), this->name.c_str());
+            msg_format(_("%sは褒美としてアンデッドの使いをよこした。", "%s rewards you with an undead servant!"), this->name.data());
 
             if (!summon_specific(player_ptr, -1, this->player_ptr->y, this->player_ptr->x, this->player_ptr->current_floor_ptr->dun_level, SUMMON_UNDEAD, PM_FORCE_PET)) {
                 msg_print(_("何も現れなかった...", "Nobody ever turns up..."));
@@ -575,7 +575,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             break;
 
         default:
-            msg_format(_("%sの声がどもった:", "The voice of %s stammers:"), this->name.c_str());
+            msg_format(_("%sの声がどもった:", "The voice of %s stammers:"), this->name.data());
             msg_format(_("「あー、あー、答えは %d/%d。質問は何？」", "'Uh... uh... the answer's %d/%d, what's the question?'"), type, effect);
         }
     }
@@ -588,7 +588,7 @@ void Patron::admire(PlayerType *player_ptr_)
 {
     this->player_ptr = player_ptr_;
     if (PlayerClass(this->player_ptr).equals(PlayerClassType::CHAOS_WARRIOR) || this->player_ptr->muta.has(PlayerMutationType::CHAOS_GIFT)) {
-        msg_format(_("%sからの声が響いた。", "The voice of %s booms out:"), this->name.c_str());
+        msg_format(_("%sからの声が響いた。", "The voice of %s booms out:"), this->name.data());
         msg_print(_("『よくやった、定命の者よ！』", "'Thou art donst well, mortal!'"));
     }
 }

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -392,7 +392,7 @@ int take_hit(PlayerType *player_ptr, int damage_type, int damage, concptr hit_fr
 
         const auto &floor_ref = *player_ptr->current_floor_ptr;
         if (floor_ref.inside_arena) {
-            concptr m_name = monraces_info[arena_info[player_ptr->arena_number].r_idx].name.c_str();
+            concptr m_name = monraces_info[arena_info[player_ptr->arena_number].r_idx].name.data();
             msg_format(_("あなたは%sの前に敗れ去った。", "You are beaten by %s."), m_name);
             msg_print(nullptr);
             if (record_arena) {
@@ -447,11 +447,11 @@ int take_hit(PlayerType *player_ptr, int damage_type, int damage, concptr hit_fr
                 }
 
 #ifdef JP
-                std::string note = format("%sで%sに殺された。", place.c_str(), player_ptr->died_from.c_str());
+                std::string note = format("%sで%sに殺された。", place.data(), player_ptr->died_from.data());
 #else
-                std::string note = format("killed by %s %s.", player_ptr->died_from.c_str(), place.c_str());
+                std::string note = format("killed by %s %s.", player_ptr->died_from.data(), place.data());
 #endif
-                exe_write_diary(player_ptr, DIARY_DESCRIPTION, 0, note.c_str());
+                exe_write_diary(player_ptr, DIARY_DESCRIPTION, 0, note.data());
             }
 
             exe_write_diary(player_ptr, DIARY_GAMESTART, 1, _("-------- ゲームオーバー --------", "--------   Game  Over   --------"));

--- a/src/player/process-death.cpp
+++ b/src/player/process-death.cpp
@@ -80,7 +80,7 @@ static void show_basic_params(PlayerType *player_ptr, char *buf)
  */
 static int show_killing_monster(PlayerType *player_ptr, char *buf, char *tomb_message, size_t tomb_message_size)
 {
-    shape_buffer(player_ptr->died_from.c_str(), GRAVE_LINE_WIDTH + 1, tomb_message, tomb_message_size);
+    shape_buffer(player_ptr->died_from.data(), GRAVE_LINE_WIDTH + 1, tomb_message, tomb_message_size);
     char *t;
     t = tomb_message + strlen(tomb_message) + 1;
     if (!*t) {
@@ -189,7 +189,7 @@ static void show_tomb_detail(PlayerType *player_ptr, char *buf)
     center_string(buf, tomb_message);
     put_str(buf, 14, 11);
 
-    shape_buffer(format("by %s.", player_ptr->died_from.c_str()), GRAVE_LINE_WIDTH + 1, tomb_message, sizeof(tomb_message));
+    shape_buffer(format("by %s.", player_ptr->died_from.data()), GRAVE_LINE_WIDTH + 1, tomb_message, sizeof(tomb_message));
     center_string(buf, tomb_message);
     char *t;
     put_str(buf, 15, 11);

--- a/src/room/rooms-pit-nest.cpp
+++ b/src/room/rooms-pit-nest.cpp
@@ -74,7 +74,7 @@ static concptr pit_subtype_string(int type, bool nest)
     if (nest) {
         switch (type) {
         case NEST_TYPE_CLONE:
-            sprintf(inner_buf, "(%s)", monraces_info[vault_aux_race].name.c_str());
+            sprintf(inner_buf, "(%s)", monraces_info[vault_aux_race].name.data());
             break;
         case NEST_TYPE_SYMBOL_GOOD:
         case NEST_TYPE_SYMBOL_EVIL:
@@ -408,7 +408,7 @@ bool build_type5(PlayerType *player_ptr, dun_data_type *dd_ptr)
                 }
             }
 
-            msg_format_wizard(player_ptr, CHEAT_DUNGEON, "Nest構成モンスターNo.%d:%s", i, monraces_info[nest_mon_info[i].r_idx].name.c_str());
+            msg_format_wizard(player_ptr, CHEAT_DUNGEON, "Nest構成モンスターNo.%d:%s", i, monraces_info[nest_mon_info[i].r_idx].name.data());
         }
     }
 
@@ -634,7 +634,7 @@ bool build_type6(PlayerType *player_ptr, dun_data_type *dd_ptr)
     for (i = 0; i < 8; i++) {
         /* Every other entry */
         what[i] = what[i * 2];
-        msg_format_wizard(player_ptr, CHEAT_DUNGEON, _("Nest構成モンスター選択No.%d:%s", "Nest Monster Select No.%d:%s"), i, monraces_info[what[i]].name.c_str());
+        msg_format_wizard(player_ptr, CHEAT_DUNGEON, _("Nest構成モンスター選択No.%d:%s", "Nest Monster Select No.%d:%s"), i, monraces_info[what[i]].name.data());
     }
 
     /* Top and bottom rows */

--- a/src/room/rooms-trap.cpp
+++ b/src/room/rooms-trap.cpp
@@ -90,6 +90,6 @@ bool build_type14(PlayerType *player_ptr, dun_data_type *dd_ptr)
     g_ptr->mimic = g_ptr->feat;
     g_ptr->feat = trap;
 
-    msg_format_wizard(player_ptr, CHEAT_DUNGEON, _("%sの部屋が生成されました。", "Room of %s was generated."), terrains_info[trap].name.c_str());
+    msg_format_wizard(player_ptr, CHEAT_DUNGEON, _("%sの部屋が生成されました。", "Room of %s was generated."), terrains_info[trap].name.data());
     return true;
 }

--- a/src/room/rooms-vault.cpp
+++ b/src/room/rooms-vault.cpp
@@ -1069,10 +1069,10 @@ bool build_fixed_room(PlayerType *player_ptr, dun_data_type *dd_ptr, int typ, bo
         return false;
     }
 
-    msg_format_wizard(player_ptr, CHEAT_DUNGEON, _("固定部屋(%s)を生成しました。", "Fixed room (%s)."), v_ptr->name.c_str());
+    msg_format_wizard(player_ptr, CHEAT_DUNGEON, _("固定部屋(%s)を生成しました。", "Fixed room (%s)."), v_ptr->name.data());
 
     /* Hack -- Build the vault */
-    build_vault(player_ptr, yval, xval, v_ptr->hgt, v_ptr->wid, v_ptr->text.c_str(), xoffset, yoffset, transno);
+    build_vault(player_ptr, yval, xval, v_ptr->hgt, v_ptr->wid, v_ptr->text.data(), xoffset, yoffset, transno);
 
     return true;
 }

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -185,7 +185,7 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
                 killer = _("地震", "an earthquake");
             }
 
-            take_hit(player_ptr, DAMAGE_ATTACK, damage, killer.c_str());
+            take_hit(player_ptr, DAMAGE_ATTACK, damage, killer.data());
         }
     }
 

--- a/src/spell-kind/spells-sight.cpp
+++ b/src/spell-kind/spells-sight.cpp
@@ -471,7 +471,7 @@ bool probing(PlayerType *player_ptr)
         inkey();
         term_erase(0, 0, 255);
         if (lore_do_probe(player_ptr, m_ptr->r_idx)) {
-            strcpy(buf, (r_ptr->name.c_str()));
+            strcpy(buf, (r_ptr->name.data()));
 #ifdef JP
             msg_format("%sについてさらに詳しくなった気がする。", buf);
 #else

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -379,7 +379,7 @@ static DUNGEON_IDX choose_dungeon(concptr note, POSITION y, POSITION x)
         if (max_dlv[DUNGEON_ANGBAND]) {
             return DUNGEON_ANGBAND;
         } else {
-            msg_format(_("まだ%sに入ったことはない。", "You haven't entered %s yet."), dungeons_info[DUNGEON_ANGBAND].name.c_str());
+            msg_format(_("まだ%sに入ったことはない。", "You haven't entered %s yet."), dungeons_info[DUNGEON_ANGBAND].name.data());
             msg_print(nullptr);
             return 0;
         }
@@ -407,7 +407,7 @@ static DUNGEON_IDX choose_dungeon(concptr note, POSITION y, POSITION x)
         }
 
         sprintf(buf, _("      %c) %c%-12s : 最大 %d 階", "      %c) %c%-16s : Max level %d"),
-            static_cast<char>('a' + dun.size()), seiha ? '!' : ' ', d_ref.name.c_str(), (int)max_dlv[d_ref.idx]);
+            static_cast<char>('a' + dun.size()), seiha ? '!' : ' ', d_ref.name.data(), (int)max_dlv[d_ref.idx]);
         prt(buf, y + dun.size(), x);
         dun.push_back(d_ref.idx);
     }
@@ -505,7 +505,7 @@ bool free_level_recall(PlayerType *player_ptr)
     }
 
     const auto mes = _("%sの何階にテレポートしますか？", "Teleport to which level of %s? ");
-    QUANTITY amt = get_quantity(format(mes, dungeon.name.c_str()), (QUANTITY)max_depth);
+    QUANTITY amt = get_quantity(format(mes, dungeon.name.data()), (QUANTITY)max_depth);
     if (amt <= 0) {
         return false;
     }
@@ -568,7 +568,7 @@ bool reset_recall(PlayerType *player_ptr)
         exe_write_diary(player_ptr, DIARY_TRUMP, select_dungeon, _("フロア・リセットで", "using a scroll of reset recall"));
     }
 #ifdef JP
-    msg_format("%sの帰還レベルを %d 階にセット。", dungeons_info[select_dungeon].name.c_str(), dummy, dummy * 50);
+    msg_format("%sの帰還レベルを %d 階にセット。", dungeons_info[select_dungeon].name.data(), dummy, dummy * 50);
 #else
     msg_format("Recall depth set to level %d (%d').", dummy, dummy * 50);
 #endif

--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -147,7 +147,7 @@ static void shuffle_store(PlayerType *player_ptr, StoreSaleType store_num)
     prt("", 3, 0);
     sprintf(buf, "%s (%s)", ot_ptr->owner_name, race_info[enum2i(ot_ptr->owner_race)].title);
     put_str(buf, 3, 10);
-    sprintf(buf, "%s (%ld)", terrains_info[cur_store_feat].name.c_str(), (long)(ot_ptr->max_cost));
+    sprintf(buf, "%s (%ld)", terrains_info[cur_store_feat].name.data(), (long)(ot_ptr->max_cost));
     prt(buf, 3, 50);
 }
 

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -132,7 +132,7 @@ void display_rumor(PlayerType *player_ptr, bool ex)
             }
         }
 
-        strcpy(fullname, r_ptr->name.c_str());
+        strcpy(fullname, r_ptr->name.data());
 
         if (!r_ptr->r_sights) {
             r_ptr->r_sights++;
@@ -150,7 +150,7 @@ void display_rumor(PlayerType *player_ptr, bool ex)
             }
         }
 
-        strcpy(fullname, d_ptr->name.c_str());
+        strcpy(fullname, d_ptr->name.data());
         if (!max_dlv[d_idx]) {
             max_dlv[d_idx] = d_ptr->mindepth;
             rumor_eff_format = _("%sに帰還できるようになった。", "You can recall to %s.");

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -486,7 +486,7 @@ static concptr decide_target_floor(PlayerType *player_ptr, eg_type *eg_ptr)
     }
 
     if (eg_ptr->f_ptr->flags.has(TerrainCharacteristics::ENTRANCE)) {
-        return format(_("%s(%d階相当)", "%s(level %d)"), dungeons_info[eg_ptr->g_ptr->special].text.c_str(), dungeons_info[eg_ptr->g_ptr->special].mindepth);
+        return format(_("%s(%d階相当)", "%s(level %d)"), dungeons_info[eg_ptr->g_ptr->special].text.data(), dungeons_info[eg_ptr->g_ptr->special].mindepth);
     }
 
     if (eg_ptr->f_ptr->flags.has(TerrainCharacteristics::TOWN)) {
@@ -497,7 +497,7 @@ static concptr decide_target_floor(PlayerType *player_ptr, eg_type *eg_ptr)
         return _("道", "road");
     }
 
-    return eg_ptr->f_ptr->name.c_str();
+    return eg_ptr->f_ptr->name.data();
 }
 
 static void describe_grid_monster_all(eg_type *eg_ptr)

--- a/src/view/display-characteristic.cpp
+++ b/src/view/display-characteristic.cpp
@@ -316,7 +316,7 @@ static void process_one_characteristic(PlayerType *player_ptr, TERM_LEN row, TER
         if (s == "." && (!char_stat.has_imm && !char_stat.has_vul)) {
             clr = TERM_L_DARK;
         }
-        c_put_str(clr, s.c_str(), row, col++);
+        c_put_str(clr, s.data(), row, col++);
     }
 }
 

--- a/src/view/display-lore-status.cpp
+++ b/src/view/display-lore-status.cpp
@@ -357,7 +357,7 @@ void display_monster_evolution(lore_type *lore_ptr)
 
     if (MonsterRace(lore_ptr->r_ptr->next_r_idx).is_valid()) {
         hooked_roff(format(_("%^sは経験を積むと、", "%^s will evolve into "), Who::who(lore_ptr->msex)));
-        hook_c_roff(TERM_YELLOW, format("%s", monraces_info[lore_ptr->r_ptr->next_r_idx].name.c_str()));
+        hook_c_roff(TERM_YELLOW, format("%s", monraces_info[lore_ptr->r_ptr->next_r_idx].name.data()));
 
         hooked_roff(_(format("に進化する。"), format(" when %s gets enough experience.  ", Who::who(lore_ptr->msex))));
     } else if (lore_ptr->r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE)) {

--- a/src/view/display-lore.cpp
+++ b/src/view/display-lore.cpp
@@ -63,7 +63,7 @@ void roff_top(MonsterRaceId r_idx)
         term_addstr(-1, TERM_WHITE, "] ");
     }
 
-    term_addstr(-1, TERM_WHITE, (r_ptr->name.c_str()));
+    term_addstr(-1, TERM_WHITE, (r_ptr->name.data()));
 
     term_addstr(-1, TERM_WHITE, " ('");
     term_add_bigch(a1, c1);
@@ -546,16 +546,16 @@ static void display_monster_escort_contents(lore_type *lore_ptr)
 
         const auto *rf_ptr = &monraces_info[r_idx];
         if (rf_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
-            hooked_roff(format(_("、%s", ", %s"), rf_ptr->name.c_str()));
+            hooked_roff(format(_("、%s", ", %s"), rf_ptr->name.data()));
             continue;
         }
 
 #ifdef JP
-        hooked_roff(format("、 %dd%d 体の%s", dd, ds, rf_ptr->name.c_str()));
+        hooked_roff(format("、 %dd%d 体の%s", dd, ds, rf_ptr->name.data()));
 #else
         auto plural = (dd * ds > 1);
         GAME_TEXT name[MAX_NLEN];
-        strcpy(name, rf_ptr->name.c_str());
+        strcpy(name, rf_ptr->name.data());
         if (plural) {
             plural_aux(name);
         }

--- a/src/view/display-messages.cpp
+++ b/src/view/display-messages.cpp
@@ -86,7 +86,7 @@ concptr message_str(int age)
         return "";
     }
 
-    return message_history[age]->c_str();
+    return message_history[age]->data();
 }
 
 static void message_add_aux(std::string str)
@@ -149,7 +149,7 @@ static void message_add_aux(std::string str)
         }
 
         if (str == last_message && (j < 1000)) {
-            str = format("%s <x%d>", str.c_str(), j + 1);
+            str = format("%s <x%d>", str.data(), j + 1);
             message_history.pop_front();
             if (!now_message) {
                 now_message++;

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -137,7 +137,7 @@ static void display_phisique(PlayerType *player_ptr)
     display_player_one_line(ENTRY_SOCIAL, format("%d", (int)player_ptr->sc), TERM_L_BLUE);
 #endif
     std::string alg = PlayerAlignment(player_ptr).get_alignment_description();
-    display_player_one_line(ENTRY_ALIGN, format("%s", alg.c_str()), TERM_L_BLUE);
+    display_player_one_line(ENTRY_ALIGN, format("%s", alg.data()), TERM_L_BLUE);
 }
 
 /*!
@@ -188,9 +188,9 @@ static std::optional<std::string> search_death_cause(PlayerType *player_ptr)
 
     if (!floor_ptr->dun_level) {
 #ifdef JP
-        return std::string(format("…あなたは%sで%sに殺された。", map_name(player_ptr), player_ptr->died_from.c_str()));
+        return std::string(format("…あなたは%sで%sに殺された。", map_name(player_ptr), player_ptr->died_from.data()));
 #else
-        return std::string(format("...You were killed by %s in %s.", player_ptr->died_from.c_str(), map_name(player_ptr)));
+        return std::string(format("...You were killed by %s in %s.", player_ptr->died_from.data(), map_name(player_ptr)));
 #endif
     }
 
@@ -204,16 +204,16 @@ static std::optional<std::string> search_death_cause(PlayerType *player_ptr)
 
         const auto *q_ptr = &quest_list[floor_ptr->quest_number];
 #ifdef JP
-        return std::string(format("…あなたは、クエスト「%s」で%sに殺された。", q_ptr->name, player_ptr->died_from.c_str()));
+        return std::string(format("…あなたは、クエスト「%s」で%sに殺された。", q_ptr->name, player_ptr->died_from.data()));
 #else
-        return std::string(format("...You were killed by %s in the quest '%s'.", player_ptr->died_from.c_str(), q_ptr->name));
+        return std::string(format("...You were killed by %s in the quest '%s'.", player_ptr->died_from.data(), q_ptr->name));
 #endif
     }
 
 #ifdef JP
-    return std::string(format("…あなたは、%sの%d階で%sに殺された。", map_name(player_ptr), (int)floor_ptr->dun_level, player_ptr->died_from.c_str()));
+    return std::string(format("…あなたは、%sの%d階で%sに殺された。", map_name(player_ptr), (int)floor_ptr->dun_level, player_ptr->died_from.data()));
 #else
-    return std::string(format("...You were killed by %s on level %d of %s.", player_ptr->died_from.c_str(), floor_ptr->dun_level, map_name(player_ptr)));
+    return std::string(format("...You were killed by %s on level %d of %s.", player_ptr->died_from.data(), floor_ptr->dun_level, map_name(player_ptr)));
 #endif
 }
 
@@ -280,7 +280,7 @@ static int display_current_floor(const std::string &statmsg)
 {
     char temp[1000];
     constexpr auto chars_per_line = 60;
-    shape_buffer(statmsg.c_str(), chars_per_line, temp, sizeof(temp));
+    shape_buffer(statmsg.data(), chars_per_line, temp, sizeof(temp));
     auto t = temp;
     auto statmsg_size = statmsg.size();
     auto fraction = statmsg_size % (chars_per_line - 1);
@@ -321,7 +321,7 @@ std::optional<int> display_player(PlayerType *player_ptr, const int tmp_mode)
     display_player_basic_info(player_ptr);
     display_magic_realms(player_ptr);
     if (PlayerClass(player_ptr).equals(PlayerClassType::CHAOS_WARRIOR) || (player_ptr->muta.has(PlayerMutationType::CHAOS_GIFT))) {
-        display_player_one_line(ENTRY_PATRON, patron_list[player_ptr->chaos_patron].name.c_str(), TERM_L_BLUE);
+        display_player_one_line(ENTRY_PATRON, patron_list[player_ptr->chaos_patron].name.data(), TERM_L_BLUE);
     }
 
     display_phisique(player_ptr);

--- a/src/view/display-self-info.cpp
+++ b/src/view/display-self-info.cpp
@@ -35,7 +35,7 @@ void display_virtue(PlayerType *player_ptr, self_info_type *self_ptr)
 {
     self_ptr->info[self_ptr->line++] = "";
     std::string alg = PlayerAlignment(player_ptr).get_alignment_description(true);
-    sprintf(self_ptr->plev_buf, _("現在の属性 : %s", "Your alignment : %s"), alg.c_str());
+    sprintf(self_ptr->plev_buf, _("現在の属性 : %s", "Your alignment : %s"), alg.data());
     strcpy(self_ptr->buf[1], self_ptr->plev_buf);
     self_ptr->info[self_ptr->line++] = self_ptr->buf[1];
     for (int v_nr = 0; v_nr < 8; v_nr++) {

--- a/src/view/display-store.cpp
+++ b/src/view/display-store.cpp
@@ -178,7 +178,7 @@ void display_store(PlayerType *player_ptr, StoreSaleType store_num)
         return;
     }
 
-    concptr store_name = terrains_info[cur_store_feat].name.c_str();
+    concptr store_name = terrains_info[cur_store_feat].name.data();
     concptr owner_name = (ot_ptr->owner_name);
     concptr race_name = race_info[enum2i(ot_ptr->owner_race)].title;
     char buf[80];

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -132,7 +132,7 @@ static void print_monster_line(TERM_LEN x, TERM_LEN y, monster_type *m_ptr, int 
 
     term_addstr(-1, TERM_WHITE, buf);
 
-    sprintf(buf, " %s ", r_ptr->name.c_str());
+    sprintf(buf, " %s ", r_ptr->name.data());
     term_addstr(-1, TERM_WHITE, buf);
 }
 
@@ -594,11 +594,11 @@ static void display_floor_item_list(PlayerType *player_ptr, const int y, const i
             sprintf(line, _("(X:%03d Y:%03d) 何か奇妙な物の足元の発見済みアイテム一覧", "Found items at (%03d,%03d) under something strange"), x, y);
         } else {
             const monster_race *const r_ptr = &monraces_info[m_ptr->ap_r_idx];
-            sprintf(line, _("(X:%03d Y:%03d) %sの足元の発見済みアイテム一覧", "Found items at (%03d,%03d) under %s"), x, y, r_ptr->name.c_str());
+            sprintf(line, _("(X:%03d Y:%03d) %sの足元の発見済みアイテム一覧", "Found items at (%03d,%03d) under %s"), x, y, r_ptr->name.data());
         }
     } else {
         const TerrainType *const f_ptr = &terrains_info[g_ptr->feat];
-        concptr fn = f_ptr->name.c_str();
+        concptr fn = f_ptr->name.data();
         char buf[512];
 
         if (f_ptr->flags.has(TerrainCharacteristics::STORE) || (f_ptr->flags.has(TerrainCharacteristics::BLDG) && !floor_ptr->inside_arena)) {

--- a/src/wizard/cmd-wizard.cpp
+++ b/src/wizard/cmd-wizard.cpp
@@ -109,7 +109,7 @@ void display_debug_menu(int page, int max_page, int page_size, int max_line)
         std::stringstream ss;
         const auto &[symbol, desc] = debug_menu_table[pos];
         ss << symbol << ") " << desc;
-        put_str(ss.str().c_str(), r++, c);
+        put_str(ss.str().data(), r++, c);
     }
     if (max_page > 1) {
         put_str("-- more --", r++, c);

--- a/src/wizard/monster-info-spoiler.cpp
+++ b/src/wizard/monster-info-spoiler.cpp
@@ -122,11 +122,11 @@ SpoilerOutputResultType spoil_mon_desc(concptr fname, std::function<bool(const m
 
         const auto name = str_separate(r_ptr->name, 40);
         if (r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
-            sprintf(nam, "[U] %s", name.front().c_str());
+            sprintf(nam, "[U] %s", name.front().data());
         } else if (r_ptr->population_flags.has(MonsterPopulationType::NAZGUL)) {
-            sprintf(nam, "[N] %s", name.front().c_str());
+            sprintf(nam, "[N] %s", name.front().data());
         } else {
-            sprintf(nam, _("    %s", "The %s"), name.front().c_str());
+            sprintf(nam, _("    %s", "The %s"), name.front().data());
         }
 
         sprintf(lev, "%d", (int)r_ptr->level);
@@ -144,7 +144,7 @@ SpoilerOutputResultType spoil_mon_desc(concptr fname, std::function<bool(const m
         fprintf(spoiler_file, "%-45.45s%4s %4s %4s %7s %7s  %19.19s\n", nam, lev, rar, spd, hp, ac, symbol);
 
         for (auto i = 1U; i < name.size(); ++i) {
-            fprintf(spoiler_file, "    %s\n", name[i].c_str());
+            fprintf(spoiler_file, "    %s\n", name[i].data());
         }
     }
 
@@ -203,7 +203,7 @@ SpoilerOutputResultType spoil_mon_info(concptr fname)
             spoil_out("[N] ");
         }
 
-        sprintf(buf, _("%s/%s  (", "%s%s ("), r_ptr->name.c_str(), _(r_ptr->E_name.c_str(), "")); /* ---)--- */
+        sprintf(buf, _("%s/%s  (", "%s%s ("), r_ptr->name.data(), _(r_ptr->E_name.data(), "")); /* ---)--- */
         spoil_out(buf);
         spoil_out(attr_to_text(r_ptr));
         sprintf(buf, " '%c')\n", r_ptr->d_char);

--- a/src/wizard/wizard-game-modifier.cpp
+++ b/src/wizard/wizard-game-modifier.cpp
@@ -57,7 +57,7 @@ void display_wizard_game_modifier_menu()
     for (const auto &[symbol, desc] : wizard_game_modifier_menu_table) {
         std::stringstream ss;
         ss << symbol << ") " << desc;
-        put_str(ss.str().c_str(), r++, c);
+        put_str(ss.str().data(), r++, c);
     }
 }
 

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -83,7 +83,7 @@ void display_wizard_sub_menu()
     for (const auto &[symbol, desc] : wizard_sub_menu_table) {
         std::stringstream ss;
         ss << symbol << ") " << desc;
-        put_str(ss.str().c_str(), r++, c);
+        put_str(ss.str().data(), r++, c);
     }
 }
 }
@@ -913,7 +913,7 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
                     continue;
                 }
 
-                strcpy(o_name, e_ref.name.c_str());
+                strcpy(o_name, e_ref.name.data());
 #ifndef JP
                 str_tolower(o_name);
 #endif
@@ -958,7 +958,7 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
             str_tolower(o_name);
 #endif
             a_str = a_desc;
-            strcpy(a_desc, a_ref.name.c_str());
+            strcpy(a_desc, a_ref.name.data());
 
             if (*a_str == '$') {
                 a_str++;
@@ -996,7 +996,7 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
                 msg_format("Matching artifact No.%d %s(%s)", a_idx, a_desc, _(&o_name[2], o_name));
             }
 
-            std::vector<const char *> l = { a_str, a_ref.name.c_str(), _(&o_name[2], o_name) };
+            std::vector<const char *> l = { a_str, a_ref.name.data(), _(&o_name[2], o_name) };
             for (size_t c = 0; c < l.size(); c++) {
                 if (!strcmp(str, l.at(c))) {
                     len = strlen(l.at(c));

--- a/src/wizard/wizard-player-modifier.cpp
+++ b/src/wizard/wizard-player-modifier.cpp
@@ -48,7 +48,7 @@ void display_wizard_player_modifier_menu()
     for (const auto &[symbol, desc] : wizard_player_modifier_menu_table) {
         std::stringstream ss;
         ss << symbol << ") " << desc;
-        put_str(ss.str().c_str(), r++, c);
+        put_str(ss.str().data(), r++, c);
     }
 }
 

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -171,7 +171,7 @@ static KIND_OBJECT_IDX wiz_select_sval(const ItemKindType tval, concptr tval_des
         auto col = _(30, 32) * (num / 20);
         ch = listsym[num];
         const auto buf = strip_name(k_ref.idx);
-        prt(format("[%c] %s", ch, buf.c_str()), row, col);
+        prt(format("[%c] %s", ch, buf.data()), row, col);
         choice[num++] = k_ref.idx;
     }
 
@@ -302,7 +302,7 @@ static std::optional<FixedArtifactId> wiz_select_named_artifact(PlayerType *play
         for (auto i = 0U; i < page_item_count; ++i) {
             std::stringstream ss;
             ss << I2A(i) << ") " << wiz_make_named_artifact_desc(player_ptr, a_idx_list[page_base_idx + i]);
-            put_str(ss.str().c_str(), i + 1, 15);
+            put_str(ss.str().data(), i + 1, 15);
         }
         if (page_max > 1) {
             put_str(format("-- more (%d/%d) --", current_page + 1, page_max), page_item_count + 1, 15);
@@ -365,7 +365,7 @@ void wiz_create_named_art(PlayerType *player_ptr)
         std::stringstream ss;
         ss << I2A(i) << ") " << name;
         term_erase(14, i + 1, 255);
-        put_str(ss.str().c_str(), i + 1, 15);
+        put_str(ss.str().data(), i + 1, 15);
     }
 
     std::optional<FixedArtifactId> create_a_idx;

--- a/src/wizard/wizard-spoiler.cpp
+++ b/src/wizard/wizard-spoiler.cpp
@@ -113,14 +113,14 @@ static SpoilerOutputResultType spoil_mon_evol(concptr fname)
 
     for (auto r_idx : get_mon_evol_roots()) {
         auto r_ptr = &monraces_info[r_idx];
-        fprintf(spoiler_file, _("[%d]: %s (レベル%d, '%c')\n", "[%d]: %s (Level %d, '%c')\n"), enum2i(r_idx), r_ptr->name.c_str(), (int)r_ptr->level, r_ptr->d_char);
+        fprintf(spoiler_file, _("[%d]: %s (レベル%d, '%c')\n", "[%d]: %s (Level %d, '%c')\n"), enum2i(r_idx), r_ptr->name.data(), (int)r_ptr->level, r_ptr->d_char);
 
         for (auto n = 1; MonsterRace(r_ptr->next_r_idx).is_valid(); n++) {
             fprintf(spoiler_file, "%*s-(%d)-> ", n * 2, "", r_ptr->next_exp);
             fprintf(spoiler_file, "[%d]: ", enum2i(r_ptr->next_r_idx));
             r_ptr = &monraces_info[r_ptr->next_r_idx];
 
-            fprintf(spoiler_file, _("%s (レベル%d, '%c')\n", "%s (Level %d, '%c')\n"), r_ptr->name.c_str(), (int)r_ptr->level, r_ptr->d_char);
+            fprintf(spoiler_file, _("%s (レベル%d, '%c')\n", "%s (Level %d, '%c')\n"), r_ptr->name.data(), (int)r_ptr->level, r_ptr->d_char);
         }
 
         fputc('\n', spoiler_file);

--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -291,7 +291,7 @@ void WorldTurnProcessor::shuffle_shopkeeper()
         }
 
         if (cheat_xtra) {
-            msg_format(_("%sの店主をシャッフルします。", "Shuffle a Shopkeeper of %s."), f_ref.name.c_str());
+            msg_format(_("%sの店主をシャッフルします。", "Shuffle a Shopkeeper of %s."), f_ref.name.data());
         }
 
         store_shuffle(this->player_ptr, i2enum<StoreSaleType>(n));


### PR DESCRIPTION
Resolve #2760 

現在 std::string オブジェクトをC言語の文字列表現に変換するメソッドとして
c_str() と data() が混在して使用されているので、data() に統一する。

.c_str() を .data() に、 ->c_str() を ->data() に機械的変換しました。おそらく取りこぼしは無いはず。
今後の修正でも data() を使用するようにし、 c_str() が使用されている場合はレビューで指摘していく方針に従っていただければと思います。