### PR TITLE
[Fix] 変愚蛮怒設計ルールに則り、char* への変換メソッドをc_str() からdata() に差し替えた

### DIFF
--- a/src/main-win/main-win-utils.h
+++ b/src/main-win/main-win-utils.h
@@ -72,7 +72,7 @@ public:
     to_multibyte(const to_multibyte &) = delete;
     char *&operator=(const char *&) = delete;
 
-    char *c_str()
+    char *data()
     {
         return buf.has_value() ? (*buf).data() : NULL;
     }


### PR DESCRIPTION
掲題の通りです
一箇所Windows専用のメソッドがあり、Linux用のコンパイルスクリプトではすり抜けたようです
ご確認下さい