### PR TITLE
[Fix] to_multibyte クラスの存在しないメソッド data() を呼んでいる

### DIFF
--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -338,7 +338,7 @@ static void save_prefs_aux(int i)
     }
 
     auto pwchar = td->lf.lfFaceName[0] != '\0' ? td->lf.lfFaceName : _(L"ＭＳ ゴシック", L"Courier");
-    WritePrivateProfileStringA(sec_name, "Font", to_multibyte(pwchar).data(), ini_file);
+    WritePrivateProfileStringA(sec_name, "Font", to_multibyte(pwchar).c_str(), ini_file);
 
     wsprintfA(buf, "%d", td->lf.lfWidth);
     WritePrivateProfileStringA(sec_name, "FontWid", buf, ini_file);
@@ -2245,7 +2245,7 @@ LRESULT PASCAL angband_window_procedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
             term_no_press = false;
         } else {
             WCHAR wc[2] = { (WCHAR)wParam, '\0' };
-            term_keypress(to_multibyte(wc).data());
+            term_keypress(to_multibyte(wc).c_str());
         }
         return 0;
     }
@@ -2503,7 +2503,7 @@ LRESULT PASCAL AngbandListProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPara
             term_no_press = false;
         } else {
             WCHAR wc[2] = { (WCHAR)wParam, '\0' };
-            term_keypress(to_multibyte(wc).data());
+            term_keypress(to_multibyte(wc).c_str());
         }
         return 0;
     }

--- a/src/main-win/commandline-win.cpp
+++ b/src/main-win/commandline-win.cpp
@@ -48,7 +48,7 @@ void CommandLine::handle(void)
                 if (argv[i][0] != L'-') {
                     // "-"で始まらない最初のオプションをセーブファイル名とみなす
                     if (savefile_option.empty()) {
-                        savefile_option = to_multibyte(argv[i]).data();
+                        savefile_option = to_multibyte(argv[i]).c_str();
                     }
                 }
             }

--- a/src/main-win/main-win-utils.cpp
+++ b/src/main-win/main-win-utils.cpp
@@ -51,7 +51,7 @@ void save_screen_as_html(HWND hWnd)
     ofnw.Flags = OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT;
 
     if (GetSaveFileNameW(&ofnw)) {
-        do_cmd_save_screen_html_aux(to_multibyte(&buf[0]).data(), 0);
+        do_cmd_save_screen_html_aux(to_multibyte(&buf[0]).c_str(), 0);
     }
 }
 
@@ -92,7 +92,7 @@ bool get_open_filename(OPENFILENAMEW *ofn, concptr dirname, char *filename, DWOR
     // call API
     if (GetOpenFileNameW(ofn)) {
         // to multibyte
-        strncpy_s(filename, max_name_size, to_multibyte(&buf[0]).data(), _TRUNCATE);
+        strncpy_s(filename, max_name_size, to_multibyte(&buf[0]).c_str(), _TRUNCATE);
         return true;
     }
 


### PR DESCRIPTION
先の std::string クラスの c_str() メソッド呼び出しを data() 呼び出しに統一する修正を行った時に to_multibyte クラスの c_str() メソッド呼び出しまで巻き込んでしまっていた。
to_multibyte は独自に作成したクラスであり、対となるクラス to_wchar に wc_str() というメソッドもあるため、とりあえずこのクラスでは c_str() を呼び出すことにする。