### PR TITLE
[Fix] #2765 OSに渡すミューテックス文字列が正しく初期化されず毎回異なる値となってアプリの多重起動を許してしまう事象を修正した

### DIFF
--- a/src/main-win/main-win-utils.cpp
+++ b/src/main-win/main-win-utils.cpp
@@ -17,12 +17,14 @@
  * 特定の名前のミューテックスオブジェクトの所有権取得を試みる。
  * 取得できない場合は他に変愚蛮怒のプロセスが起動しているとみなす。
  * 取得したミューテックスのハンドルは明示的な解放は行わず、プロセス終了時にOSが解放する。
+ * バリアント名の先頭から63文字が一致していたらそれらを同時起動できない (が、そのようなことは起きない想定)。
  * @return 起動済の変愚蛮怒プロセス有無
  */
 bool is_already_running(void)
 {
-    wchar_t wtext[32];
-    mbstowcs(wtext, VARIANT_NAME.data(), VARIANT_NAME.length());
+    constexpr auto max_mutex_length = 64;
+    wchar_t wtext[max_mutex_length]{};
+    mbstowcs(wtext, VARIANT_NAME.data(), max_mutex_length - 1);
     [[maybe_unused]] HANDLE hMutex = CreateMutexW(NULL, TRUE, wtext);
     return GetLastError() == ERROR_ALREADY_EXISTS;
 }


### PR DESCRIPTION
掲題の通りです
長い名前のバリアントにも対応できるように、最大63文字までのミューテックスとしました
ご確認下さい