### PR TITLE
ベースアイテムのtval/sval を一意に特定できるクラスを作った

### DIFF
--- a/src/market/building-initializer.cpp
+++ b/src/market/building-initializer.cpp
@@ -34,13 +34,13 @@ void init_towns(void)
                 continue;
             }
 
-            for (const auto &kind : store_regular_sale_table.at(sst)) {
-                auto k_idx = lookup_kind(kind.type_value, kind.subtype_value);
+            for (const auto &baseitem : store_regular_sale_table.at(sst)) {
+                auto k_idx = lookup_kind(baseitem);
                 store_ptr->regular.push_back(k_idx);
             }
 
-            for (const auto &kind : store_sale_table.at(sst)) {
-                auto k_idx = lookup_kind(kind.type_value, kind.subtype_value);
+            for (const auto &baseitem : store_sale_table.at(sst)) {
+                auto k_idx = lookup_kind(baseitem);
                 store_ptr->table.push_back(k_idx);
             }
         }

--- a/src/market/building-initializer.cpp
+++ b/src/market/building-initializer.cpp
@@ -35,12 +35,12 @@ void init_towns(void)
             }
 
             for (const auto &kind : store_regular_sale_table.at(sst)) {
-                auto k_idx = lookup_kind(kind.tval, kind.sval);
+                auto k_idx = lookup_kind(kind.type_value, kind.subtype_value);
                 store_ptr->regular.push_back(k_idx);
             }
 
             for (const auto &kind : store_sale_table.at(sst)) {
-                auto k_idx = lookup_kind(kind.tval, kind.sval);
+                auto k_idx = lookup_kind(kind.type_value, kind.subtype_value);
                 store_ptr->table.push_back(k_idx);
             }
         }

--- a/src/object/object-kind-hook.cpp
+++ b/src/object/object-kind-hook.cpp
@@ -218,6 +218,11 @@ static const std::vector<const BaseItemInfo *> &get_sorted_baseitems()
     return sorted_cache;
 }
 
+short lookup_kind(const BaseitemKey &key)
+{
+    return lookup_kind(key.tval(), key.sval());
+}
+
 /*!
  * @brief tvalとsvalに対応するベースアイテムのIDを検索する
  * Find the index of the BaseItemInfo with the given tval and sval

--- a/src/object/object-kind-hook.h
+++ b/src/object/object-kind-hook.h
@@ -15,4 +15,6 @@ bool kind_is_boots(KIND_OBJECT_IDX k_idx);
 bool kind_is_amulet(KIND_OBJECT_IDX k_idx);
 bool kind_is_good(KIND_OBJECT_IDX k_idx);
 
+class BaseitemKey;
+short lookup_kind(const BaseitemKey &key); // @details 作業用ラッパーメソッド、今後は下のメソッドではなくこちらに寄せる.
 KIND_OBJECT_IDX lookup_kind(ItemKindType tval, OBJECT_SUBTYPE_VALUE sval);

--- a/src/store/articles-on-sale.cpp
+++ b/src/store/articles-on-sale.cpp
@@ -23,7 +23,7 @@
  * 17エントリーまで設定可能。(最後はTV_NONE で止める)
  * 種類が多すぎる場合、店舗を埋めつくすので注意。
  */
-const std::map<StoreSaleType, std::vector<store_stock_item_type>> store_regular_sale_table = {
+const std::map<StoreSaleType, std::vector<BaseitemKey>> store_regular_sale_table = {
     { StoreSaleType::GENERAL,
         {
             { ItemKindType::FOOD, SV_FOOD_RATION },
@@ -98,7 +98,7 @@ const std::map<StoreSaleType, std::vector<store_stock_item_type>> store_regular_
  * @brief 店舗でランダム販売するオブジェクトを定義する
  * @details tval/svalのペア
  */
-const std::map<StoreSaleType, std::vector<store_stock_item_type>> store_sale_table = {
+const std::map<StoreSaleType, std::vector<BaseitemKey>> store_sale_table = {
     { StoreSaleType::GENERAL,
         {
             /* General Store */

--- a/src/store/articles-on-sale.cpp
+++ b/src/store/articles-on-sale.cpp
@@ -1,4 +1,6 @@
 ﻿#include "store/articles-on-sale.h"
+#include "object/tval-types.h"
+#include "store/store-owners.h"
 #include "sv-definition/sv-amulet-types.h"
 #include "sv-definition/sv-armor-types.h"
 #include "sv-definition/sv-bow-types.h"
@@ -14,6 +16,7 @@
 #include "sv-definition/sv-staff-types.h"
 #include "sv-definition/sv-wand-types.h"
 #include "sv-definition/sv-weapon-types.h"
+#include "system/baseitem-info-definition.h"
 
 /*!
  * @brief 店舗で常時販売するオブジェクトを定義する

--- a/src/store/articles-on-sale.h
+++ b/src/store/articles-on-sale.h
@@ -1,15 +1,9 @@
 ﻿#pragma once
 
-#include "object/tval-types.h"
-#include "store/store-owners.h"
-#include "store/store.h"
-#include "system/angband.h"
 #include <map>
+#include <vector>
 
-struct BaseitemKey {
-    ItemKindType tval;
-    OBJECT_SUBTYPE_VALUE sval;
-};
-
+enum class StoreSaleType;
+class BaseitemKey;
 extern const std::map<StoreSaleType, std::vector<BaseitemKey>> store_regular_sale_table;
 extern const std::map<StoreSaleType, std::vector<BaseitemKey>> store_sale_table;

--- a/src/store/articles-on-sale.h
+++ b/src/store/articles-on-sale.h
@@ -6,10 +6,10 @@
 #include "system/angband.h"
 #include <map>
 
-struct store_stock_item_type {
+struct BaseitemKey {
     ItemKindType tval;
     OBJECT_SUBTYPE_VALUE sval;
 };
 
-extern const std::map<StoreSaleType, std::vector<store_stock_item_type>> store_regular_sale_table;
-extern const std::map<StoreSaleType, std::vector<store_stock_item_type>> store_sale_table;
+extern const std::map<StoreSaleType, std::vector<BaseitemKey>> store_regular_sale_table;
+extern const std::map<StoreSaleType, std::vector<BaseitemKey>> store_sale_table;

--- a/src/system/baseitem-info-definition.cpp
+++ b/src/system/baseitem-info-definition.cpp
@@ -8,9 +8,41 @@
  */
 
 #include "system/baseitem-info-definition.h"
-#include "system/object-type-definition.h"
+#include "object/tval-types.h"
 
-/*
- * The object kind arrays
- */
+BaseitemKey::BaseitemKey(ItemKindType type_value, int subtype_value)
+    : type_value(type_value)
+    , subtype_value(subtype_value)
+{
+}
+
+bool BaseitemKey::operator==(const BaseitemKey &other) const
+{
+    return (this->type_value == other.type_value) && (this->subtype_value == other.subtype_value);
+}
+
+// @details type_valueに大小があればそれを判定し、同一ならばsubtype_valueの大小を判定する.
+bool BaseitemKey::operator<(const BaseitemKey &other) const
+{
+    if (this->type_value < other.type_value) {
+        return true;
+    }
+
+    if (this->type_value > other.type_value) {
+        return false;
+    }
+
+    return this->subtype_value < other.subtype_value;
+}
+
+ItemKindType BaseitemKey::tval() const
+{
+    return this->type_value;
+}
+
+int BaseitemKey::sval() const
+{
+    return this->subtype_value;
+}
+
 std::vector<BaseItemInfo> baseitems_info;

--- a/src/system/baseitem-info-definition.h
+++ b/src/system/baseitem-info-definition.h
@@ -37,14 +37,9 @@ public:
     ItemKindType tval() const;
     int sval() const;
 
-    /*
-     * @todo アクセシビリティによるコンパイルエラーを避けるための一時的措置.
-     * @details svalは後でoptionalにする.
-     */
-    ItemKindType type_value;
-    int subtype_value;
-
 private:
+    ItemKindType type_value;
+    int subtype_value; // @todo optionalにする.
 };
 
 enum class ItemKindType : short;

--- a/src/system/baseitem-info-definition.h
+++ b/src/system/baseitem-info-definition.h
@@ -4,8 +4,48 @@
 #include "object-enchant/trg-types.h"
 #include "system/angband.h"
 #include "util/flag-group.h"
+#include <optional>
 #include <string>
 #include <vector>
+
+enum class ItemKindType : short;
+class BaseitemKey {
+public:
+    BaseitemKey(ItemKindType type_value, int subtype_value);
+    bool operator==(const BaseitemKey &other) const;
+    bool operator!=(const BaseitemKey &other) const
+    {
+        return !(*this == other);
+    }
+
+    bool operator<(const BaseitemKey &other) const;
+    bool operator>(const BaseitemKey &other) const
+    {
+        return other < *this;
+    }
+
+    bool operator<=(const BaseitemKey &other) const
+    {
+        return !(*this > other);
+    }
+
+    bool operator>=(const BaseitemKey &other) const
+    {
+        return !(*this < other);
+    }
+
+    ItemKindType tval() const;
+    int sval() const;
+
+    /*
+     * @todo アクセシビリティによるコンパイルエラーを避けるための一時的措置.
+     * @details svalは後でoptionalにする.
+     */
+    ItemKindType type_value;
+    int subtype_value;
+
+private:
+};
 
 enum class ItemKindType : short;
 enum class RandomArtActType : short;


### PR DESCRIPTION
掲題の通りです
コンストラクタ通過後は変更できないイミュータブルクラスにしました
ご確認下さい
他の諸クラスにあるtval/sval の組み合わせは、次のチケットで順次置換する予定です
(tval/svalのアップデートはまだしない想定、するなら返り値をBaseitemKeyにしてイミュータブルを保つ)