### PR TITLE
[Refactor] get_obj_num関数をget_obj_indexにrenameした

### DIFF
--- a/src/artifact/fixed-art-generator.cpp
+++ b/src/artifact/fixed-art-generator.cpp
@@ -364,8 +364,8 @@ bool make_artifact_special(PlayerType *player_ptr, ObjectType *o_ptr)
         return false;
     }
 
-    /*! @note get_obj_num_hookによる指定がある場合は生成をキャンセルする / Themed object */
-    if (get_obj_num_hook) {
+    /*! @note get_obj_index_hookによる指定がある場合は生成をキャンセルする / Themed object */
+    if (get_obj_index_hook) {
         return false;
     }
 

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -50,12 +50,12 @@
  * @brief オブジェクト生成テーブルに生成制約を加える /
  * Apply a "object restriction function" to the "object allocation table"
  * @return 常に0を返す。
- * @details 生成の制約はグローバルのget_obj_num_hook関数ポインタで加える
+ * @details 生成の制約はグローバルのget_obj_index_hook関数ポインタで加える
  */
-static errr get_obj_num_prep(void)
+static errr get_obj_index_prep(void)
 {
     for (auto &entry : alloc_kind_table) {
-        if (!get_obj_num_hook || (*get_obj_num_hook)(entry.index)) {
+        if (!get_obj_index_hook || (*get_obj_index_hook)(entry.index)) {
             entry.prob2 = entry.prob1;
         } else {
             entry.prob2 = 0;
@@ -124,18 +124,18 @@ bool make_object(PlayerType *player_ptr, ObjectType *j_ptr, BIT_FLAGS mode, std:
     auto prob = any_bits(mode, AM_GOOD) ? 10 : 1000;
     auto base = get_base_floor(floor_ptr, mode, rq_mon_level);
     if (!one_in_(prob) || !make_artifact_special(player_ptr, j_ptr)) {
-        if (any_bits(mode, AM_GOOD) && !get_obj_num_hook) {
-            get_obj_num_hook = kind_is_good;
+        if (any_bits(mode, AM_GOOD) && !get_obj_index_hook) {
+            get_obj_index_hook = kind_is_good;
         }
 
-        if (get_obj_num_hook) {
-            get_obj_num_prep();
+        if (get_obj_index_hook) {
+            get_obj_index_prep();
         }
 
-        auto k_idx = get_obj_num(player_ptr, base, mode);
-        if (get_obj_num_hook) {
-            get_obj_num_hook = nullptr;
-            get_obj_num_prep();
+        auto k_idx = get_obj_index(player_ptr, base, mode);
+        if (get_obj_index_hook) {
+            get_obj_index_hook = nullptr;
+            get_obj_index_prep();
         }
 
         if (k_idx == 0) {

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -143,9 +143,9 @@ static void on_dead_raal(PlayerType *player_ptr, monster_death_type *md_ptr)
     auto *q_ptr = &forge;
     q_ptr->wipe();
     if ((floor_ptr->dun_level > 49) && one_in_(5)) {
-        get_obj_num_hook = kind_is_good_book;
+        get_obj_index_hook = kind_is_good_book;
     } else {
-        get_obj_num_hook = kind_is_book;
+        get_obj_index_hook = kind_is_book;
     }
 
     (void)make_object(player_ptr, q_ptr, md_ptr->mo_mode);
@@ -367,7 +367,7 @@ static void on_dead_random_artifact(PlayerType *player_ptr, monster_death_type *
     while (true) {
         // make_object() の中でアイテム種別をキャンセルしている
         // よってこのwhileループ中へ入れないと、引数で指定していない種別のアイテムが選ばれる可能性がある
-        get_obj_num_hook = object_hook_pf;
+        get_obj_index_hook = object_hook_pf;
         if (!make_equipment(player_ptr, q_ptr, drop_mode, is_object_hook_null)) {
             continue;
         }
@@ -412,7 +412,7 @@ static void drop_specific_item_on_dead(PlayerType *player_ptr, monster_death_typ
     ObjectType forge;
     auto *q_ptr = &forge;
     q_ptr->wipe();
-    get_obj_num_hook = object_hook_pf;
+    get_obj_index_hook = object_hook_pf;
     (void)make_object(player_ptr, q_ptr, md_ptr->mo_mode);
     (void)drop_near(player_ptr, q_ptr, -1, md_ptr->md_y, md_ptr->md_x);
 }

--- a/src/room/rooms-special.cpp
+++ b/src/room/rooms-special.cpp
@@ -132,7 +132,7 @@ bool build_type15(PlayerType *player_ptr, dun_data_type *dd_ptr)
         }
 
         /* Place a potion */
-        get_obj_num_hook = kind_is_potion;
+        get_obj_index_hook = kind_is_potion;
         place_object(player_ptr, yval, xval, AM_NO_FIXED_ART);
         floor_ptr->grid_array[yval][xval].info |= (CAVE_ICKY);
     } break;
@@ -232,14 +232,14 @@ bool build_type15(PlayerType *player_ptr, dun_data_type *dd_ptr)
 
         /* Place two potions */
         if (one_in_(2)) {
-            get_obj_num_hook = kind_is_potion;
+            get_obj_index_hook = kind_is_potion;
             place_object(player_ptr, yval, xval - 1, AM_NO_FIXED_ART);
-            get_obj_num_hook = kind_is_potion;
+            get_obj_index_hook = kind_is_potion;
             place_object(player_ptr, yval, xval + 1, AM_NO_FIXED_ART);
         } else {
-            get_obj_num_hook = kind_is_potion;
+            get_obj_index_hook = kind_is_potion;
             place_object(player_ptr, yval - 1, xval, AM_NO_FIXED_ART);
-            get_obj_num_hook = kind_is_potion;
+            get_obj_index_hook = kind_is_potion;
             place_object(player_ptr, yval + 1, xval, AM_NO_FIXED_ART);
         }
 

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -328,7 +328,7 @@ static void store_create(PlayerType *player_ptr, KIND_OBJECT_IDX fix_k_idx, Stor
         DEPTH level;
         if (store_num == StoreSaleType::BLACK) {
             level = 25 + randint0(25);
-            k_idx = get_obj_num(player_ptr, level, 0x00000000);
+            k_idx = get_obj_index(player_ptr, level, 0x00000000);
             if (k_idx == 0) {
                 continue;
             }

--- a/src/system/system-variables.cpp
+++ b/src/system/system-variables.cpp
@@ -27,8 +27,8 @@ concptr ANGBAND_GRAF = "ascii";
 init_flags_type init_flags; //!< @todo このグローバル変数何とかしたい
 
 /*!
- * Function hook to restrict "get_obj_num_prep()" function
+ * Function hook to restrict "get_obj_index_prep()" function
  */
-bool (*get_obj_num_hook)(KIND_OBJECT_IDX k_idx);
+bool (*get_obj_index_hook)(KIND_OBJECT_IDX k_idx);
 
 OBJECT_SUBTYPE_VALUE coin_type;

--- a/src/system/system-variables.h
+++ b/src/system/system-variables.h
@@ -28,4 +28,4 @@ extern concptr ANGBAND_KEYBOARD;
 extern concptr ANGBAND_GRAF;
 
 extern OBJECT_SUBTYPE_VALUE coin_type;
-extern bool (*get_obj_num_hook)(KIND_OBJECT_IDX k_idx);
+extern bool (*get_obj_index_hook)(KIND_OBJECT_IDX k_idx);

--- a/src/world/world-object.cpp
+++ b/src/world/world-object.cpp
@@ -68,7 +68,7 @@ OBJECT_IDX o_pop(FloorType *floor_ptr)
  * Note that if no objects are "appropriate", then this function will\n
  * fail, and return zero, but this should *almost* never happen.\n
  */
-OBJECT_IDX get_obj_num(PlayerType *player_ptr, DEPTH level, BIT_FLAGS mode)
+OBJECT_IDX get_obj_index(PlayerType *player_ptr, DEPTH level, BIT_FLAGS mode)
 {
     if (level > MAX_DEPTH - 1) {
         level = MAX_DEPTH - 1;

--- a/src/world/world-object.h
+++ b/src/world/world-object.h
@@ -5,4 +5,4 @@
 class FloorType;
 class PlayerType;
 OBJECT_IDX o_pop(FloorType *floor_ptr);
-OBJECT_IDX get_obj_num(PlayerType *player_ptr, DEPTH level, BIT_FLAGS mode);
+OBJECT_IDX get_obj_index(PlayerType *player_ptr, DEPTH level, BIT_FLAGS mode);


### PR DESCRIPTION
`get_obj_num` という名称だとオブジェクトの個数を取得するように読めてしまうので
indexを取得することが明確になる名前にrenameしました。

合わせてコメント修正や `get_object_num_hook` -> `get_object_index_hook` へのrenameも行っています