### PR TITLE
[Feature] 魔法書の先頭にLv値を表示するようにした

### DIFF
--- a/src/flavor/named-item-describer.cpp
+++ b/src/flavor/named-item-describer.cpp
@@ -409,6 +409,10 @@ void describe_named_item(PlayerType *player_ptr, flavor_type *flavor_ptr)
 
     describe_artifact_ja(flavor_ptr);
 #endif
+    if (flavor_ptr->o_ptr->is_book()) {
+        // svalは0から数えているので表示用に+1している
+        flavor_ptr->t = object_desc_str(flavor_ptr->t, format("Lv%d ", flavor_ptr->o_ptr->sval + 1));
+    }
 
     describe_inscription(flavor_ptr);
     *flavor_ptr->t = '\0';

--- a/src/system/object-type-definition.cpp
+++ b/src/system/object-type-definition.cpp
@@ -574,6 +574,32 @@ bool ObjectType::is_fuel() const
 }
 
 /*!
+ * @brief オブジェクトが魔法書かどうかを判定する
+ * @return 魔法書か否か
+ */
+bool ObjectType::is_book() const
+{
+    switch (this->tval) {
+    case ItemKindType::LIFE_BOOK:
+    case ItemKindType::SORCERY_BOOK:
+    case ItemKindType::NATURE_BOOK:
+    case ItemKindType::CHAOS_BOOK:
+    case ItemKindType::DEATH_BOOK:
+    case ItemKindType::TRUMP_BOOK:
+    case ItemKindType::ARCANE_BOOK:
+    case ItemKindType::CRAFT_BOOK:
+    case ItemKindType::DEMON_BOOK:
+    case ItemKindType::CRUSADE_BOOK:
+    case ItemKindType::MUSIC_BOOK:
+    case ItemKindType::HISSATSU_BOOK:
+    case ItemKindType::HEX_BOOK:
+        return true;
+    default:
+        return false;
+    }
+}
+
+/*!
  * @brief オブジェクトが同一の命中値上昇及びダメージ上昇があるかを判定する
  * @return 同一修正か
  * @details 鍛冶師が篭手に殺戮エッセンスを付加した場合のみこの判定に意味がある

--- a/src/system/object-type-definition.h
+++ b/src/system/object-type-definition.h
@@ -113,6 +113,7 @@ public:
     bool is_offerable() const;
     bool is_activatable() const;
     bool is_fuel() const;
+    bool is_book() const;
     bool is_glove_same_temper(const ObjectType *j_ptr) const;
     bool can_pile(const ObjectType *j_ptr) const;
     TERM_COLOR get_color() const;


### PR DESCRIPTION
[【QoL向上】魔法書のアイテム名先頭にLv値を表示する](https://github.com/hengband/hengband/issues/2785)
↑issueで挙げた対応のpull reqになります。

# 相談したいポイント
- ロジックをいじる形で実装しましたが、`BaseItemDefinitions.txt` を下のように編集するのでも実装はできそうです（この場合Lvの表示はアイテム名の先頭ではなくなりますが）
  - 例: `N:334:[入門書]` → `N:334:[Lv1 入門書]`
- 最初は魔法書かどうかの判定&Lv値追加ロジックを `describe_named_item` の下位関数である `switch_tval_description` から呼び出される各 `describe_book_*` 関数あたりに記述しようと思ったのですが、↓の理由により一旦見送りました
  - describe_book_* で参照してるのが文字列ポインタの `basenm` だけなので可変する文字列を扱おうとすると変更量が多くなりそう（C/C++の文字列に対する経験値があまりないので。。）
  - 言語がnot JPのときに `if (mp_ptr->spell_book == ItemKindType::LIFE_BOOK) ` で分岐している意図がわからなかった
