### PR TITLE
[Fix] 意図したフォールスルーに [[fallthrough]] 属性を使用する

### DIFF
--- a/src/autopick/autopick-finder.cpp
+++ b/src/autopick/autopick-finder.cpp
@@ -174,7 +174,7 @@ byte get_string_for_search(PlayerType *player_ptr, ObjectType **o_handle, concpt
 
         case KTRL('r'):
             back = true;
-            /* Fall through */
+            [[fallthrough]];
 
         case '\n':
         case '\r':
@@ -221,7 +221,7 @@ byte get_string_for_search(PlayerType *player_ptr, ObjectType **o_handle, concpt
 
             pos = i;
         }
-            /* Fall through */
+            [[fallthrough]];
 
         case 0x7F:
         case KTRL('d'): {

--- a/src/birth/birth-body-spec.cpp
+++ b/src/birth/birth-body-spec.cpp
@@ -23,6 +23,7 @@ void get_height_weight(PlayerType *player_ptr)
         player_ptr->ht = randnor(rp_ptr->f_b_ht, rp_ptr->f_m_ht);
         deviation = (int)(player_ptr->ht) * 100 / (int)(rp_ptr->f_b_ht);
         player_ptr->wt = randnor((int)(rp_ptr->f_b_wt) * deviation / 100, (int)(rp_ptr->f_m_wt) * deviation / 300);
+        return;
     default:
         return;
     }

--- a/src/cmd-item/cmd-magiceat.cpp
+++ b/src/cmd-item/cmd-magiceat.cpp
@@ -524,6 +524,7 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
         break;
     case ItemKindType::ROD:
         base = EATER_ROD_BASE;
+        break;
     default:
         break;
     }

--- a/src/core/asking-player.cpp
+++ b/src/core/asking-player.cpp
@@ -140,7 +140,7 @@ bool askfor(char *buf, int len, bool numpad_cursor)
 
             pos = i;
         }
-            /* Fall through */
+            [[fallthrough]];
         case 0x7F:
         case KTRL('d'): {
             color = TERM_WHITE;

--- a/src/flavor/flavor-util.cpp
+++ b/src/flavor/flavor-util.cpp
@@ -473,7 +473,7 @@ char *object_desc_count_japanese(char *t, ObjectType *o_ptr)
             break;
         }
     }
-        /* Fall through */
+        [[fallthrough]];
     default: {
         if (o_ptr->number < 10) {
             t = object_desc_str(t, "つ");

--- a/src/info-reader/general-parser.cpp
+++ b/src/info-reader/general-parser.cpp
@@ -100,7 +100,7 @@ parse_error_type parse_line_feature(FloorType *floor_ptr, char *buf)
     switch (num) {
     case 9:
         letter[index].special = (int16_t)atoi(zz[8]);
-        /* Fall through */
+        [[fallthrough]];
     case 8:
         if ((zz[7][0] == '*') && !zz[7][1]) {
             letter[index].random |= RANDOM_TRAP;
@@ -110,7 +110,7 @@ parse_error_type parse_line_feature(FloorType *floor_ptr, char *buf)
                 return PARSE_ERROR_UNDEFINED_TERRAIN_TAG;
             }
         }
-        /* Fall through */
+        [[fallthrough]];
     case 7:
         if (zz[6][0] == '*') {
             letter[index].random |= RANDOM_ARTIFACT;
@@ -125,7 +125,7 @@ parse_error_type parse_line_feature(FloorType *floor_ptr, char *buf)
         } else {
             letter[index].artifact = i2enum<FixedArtifactId>(atoi(zz[6]));
         }
-        /* Fall through */
+        [[fallthrough]];
     case 6:
         if (zz[5][0] == '*') {
             letter[index].random |= RANDOM_EGO;
@@ -135,7 +135,7 @@ parse_error_type parse_line_feature(FloorType *floor_ptr, char *buf)
         } else {
             letter[index].ego = i2enum<EgoType>(atoi(zz[5]));
         }
-        /* Fall through */
+        [[fallthrough]];
     case 5:
         if (zz[4][0] == '*') {
             letter[index].random |= RANDOM_OBJECT;
@@ -156,7 +156,7 @@ parse_error_type parse_line_feature(FloorType *floor_ptr, char *buf)
         } else {
             letter[index].object = (OBJECT_IDX)atoi(zz[4]);
         }
-        /* Fall through */
+        [[fallthrough]];
     case 4:
         if (zz[3][0] == '*') {
             letter[index].random |= RANDOM_MONSTER;
@@ -171,10 +171,10 @@ parse_error_type parse_line_feature(FloorType *floor_ptr, char *buf)
         } else {
             letter[index].monster = (MONSTER_IDX)atoi(zz[3]);
         }
-        /* Fall through */
+        [[fallthrough]];
     case 3:
         letter[index].cave_info = atoi(zz[2]);
-        /* Fall through */
+        [[fallthrough]];
     case 2:
         if ((zz[1][0] == '*') && !zz[1][1]) {
             letter[index].random |= RANDOM_FEATURE;

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -786,7 +786,7 @@ bool get_item_floor(PlayerType *player_ptr, COMMAND_CODE *cp, concptr pmt, concp
                 break;
             }
         }
-            /* Fall through */
+            [[fallthrough]];
         default: {
             bool tag_not_found = false;
 

--- a/src/inventory/item-getter.cpp
+++ b/src/inventory/item-getter.cpp
@@ -569,7 +569,7 @@ bool get_item(PlayerType *player_ptr, OBJECT_IDX *cp, concptr pmt, concptr str, 
                 break;
             }
         }
-            /* Fall through */
+            [[fallthrough]];
         default: {
             bool tag_not_found = false;
 

--- a/src/knowledge/knowledge-features.cpp
+++ b/src/knowledge/knowledge-features.cpp
@@ -298,7 +298,7 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
                     f_ptr->x_char[i] = char_old[i];
                 }
 
-                /* Fall through */
+                [[fallthrough]];
             case '\n':
             case '\r':
                 if (direct_f_idx >= 0) {

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -1943,7 +1943,7 @@ static void process_menus(PlayerType *player_ptr, WORD wCmd)
         }
         // 壁紙の設定に失敗した（ファイルが存在しない等）場合、壁紙に使うファイルを選択させる
     }
-        [[fallthrough]]; /* Fall through */
+        [[fallthrough]];
     case IDM_OPTIONS_OPEN_BG: {
         memset(&ofn, 0, sizeof(ofn));
         ofn.lStructSize = sizeof(ofn);
@@ -2035,7 +2035,7 @@ static bool process_keydown(WPARAM wParam, LPARAM lParam)
         switch (wParam) {
         case VK_DIVIDE:
             term_no_press = true;
-            [[fallthrough]]; /* Fall through */
+            [[fallthrough]];
         case VK_RETURN:
             numpad = ext_key;
             break;
@@ -2055,7 +2055,7 @@ static bool process_keydown(WPARAM wParam, LPARAM lParam)
         case VK_SEPARATOR:
         case VK_DECIMAL:
             term_no_press = true;
-            [[fallthrough]]; /* Fall through */
+            [[fallthrough]];
         case VK_CLEAR:
         case VK_HOME:
         case VK_END:
@@ -2479,7 +2479,7 @@ LRESULT PASCAL angband_window_procedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
             }
         }
     }
-        [[fallthrough]]; /* Fall through */
+        [[fallthrough]];
     case WM_ENABLE: {
         if (wParam == FALSE && keep_subwindows) {
             for (int i = 1; i < MAX_TERM_DATA; i++) {

--- a/src/melee/melee-switcher.cpp
+++ b/src/melee/melee-switcher.cpp
@@ -164,7 +164,7 @@ void decide_monster_attack_effect(PlayerType *player_ptr, mam_type *mam_ptr)
             break;
         }
 
-        /* Fall through */
+        [[fallthrough]];
     case RaceBlowEffectType::HURT:
         mam_ptr->damage -= (mam_ptr->damage * ((mam_ptr->ac < 150) ? mam_ptr->ac : 150) / 250);
         break;

--- a/src/monster-attack/monster-attack-switcher.cpp
+++ b/src/monster-attack/monster-attack-switcher.cpp
@@ -349,7 +349,7 @@ void switch_monster_blow_to_player(PlayerType *player_ptr, MonsterAttackPlayer *
             break;
         }
     }
-        /* Fall through */
+        [[fallthrough]];
     case RaceBlowEffectType::HURT: { /* AC軽減あり / Player armor reduces total damage */
         monap_ptr->obvious = true;
         monap_ptr->damage -= (monap_ptr->damage * ((monap_ptr->ac < 150) ? monap_ptr->ac : 150) / 250);

--- a/src/player-info/class-ability-info.cpp
+++ b/src/player-info/class-ability-info.cpp
@@ -17,7 +17,7 @@ void set_class_ability_info(PlayerType *player_ptr, self_info_type *self_ptr)
         if (player_ptr->realm1 == REALM_HEX) {
             break;
         }
-        /* Fall through */
+        [[fallthrough]];
     case PlayerClassType::MAGE:
     case PlayerClassType::SORCERER:
         if (player_ptr->lev > 24) {

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -2159,21 +2159,21 @@ static short calc_to_damage(PlayerType *player_ptr, INVENTORY_IDX slot, bool is_
         }
 
         switch (player_melee_type(player_ptr)) {
-        case MELEE_TYPE_BAREHAND_TWO: /* fall through */
+        case MELEE_TYPE_BAREHAND_TWO:
         case MELEE_TYPE_WEAPON_TWOHAND:
             if (calc_hand == main_attack_hand(player_ptr)) {
                 damage += (int16_t)bonus_to_d;
             }
             break;
 
-        case MELEE_TYPE_BAREHAND_MAIN: /* fall through */
+        case MELEE_TYPE_BAREHAND_MAIN:
         case MELEE_TYPE_WEAPON_MAIN:
             if ((calc_hand == PLAYER_HAND_MAIN) && (i != INVEN_SUB_RING)) {
                 damage += (int16_t)bonus_to_d;
             }
             break;
 
-        case MELEE_TYPE_BAREHAND_SUB: /* fall through */
+        case MELEE_TYPE_BAREHAND_SUB:
         case MELEE_TYPE_WEAPON_SUB:
             if ((calc_hand == PLAYER_HAND_SUB) && (i != INVEN_MAIN_RING)) {
                 damage += (int16_t)bonus_to_d;
@@ -2270,12 +2270,12 @@ static short calc_to_hit(PlayerType *player_ptr, INVENTORY_IDX slot, bool is_rea
             if (player_ptr->riding) {
                 break;
             }
-            /* fall through */
+            [[fallthrough]];
         case MELEE_TYPE_BAREHAND_SUB:
             if (player_ptr->riding) {
                 break;
             }
-            /* fall through */
+            [[fallthrough]];
         case MELEE_TYPE_BAREHAND_TWO:
             hit += (player_ptr->skill_exp[PlayerSkillKindType::MARTIAL_ARTS] - PlayerSkill::weapon_exp_at(PlayerSkillRank::BEGINNER)) / 200;
             break;
@@ -2395,21 +2395,21 @@ static short calc_to_hit(PlayerType *player_ptr, INVENTORY_IDX slot, bool is_rea
         }
 
         switch (player_melee_type(player_ptr)) {
-        case MELEE_TYPE_BAREHAND_TWO: /* fall through */
+        case MELEE_TYPE_BAREHAND_TWO:
         case MELEE_TYPE_WEAPON_TWOHAND:
             if (calc_hand == main_attack_hand(player_ptr)) {
                 hit += (int16_t)bonus_to_h;
             }
             break;
 
-        case MELEE_TYPE_BAREHAND_MAIN: /* fall through */
+        case MELEE_TYPE_BAREHAND_MAIN:
         case MELEE_TYPE_WEAPON_MAIN:
             if ((calc_hand == PLAYER_HAND_MAIN) && (i != INVEN_SUB_RING)) {
                 hit += (int16_t)bonus_to_h;
             }
             break;
 
-        case MELEE_TYPE_BAREHAND_SUB: /* fall through */
+        case MELEE_TYPE_BAREHAND_SUB:
         case MELEE_TYPE_WEAPON_SUB:
             if ((calc_hand == PLAYER_HAND_SUB) && (i != INVEN_MAIN_RING)) {
                 hit += (int16_t)bonus_to_h;

--- a/src/racial/class-racial-switcher.cpp
+++ b/src/racial/class-racial-switcher.cpp
@@ -30,7 +30,7 @@ void switch_class_racial(PlayerType *player_ptr, rc_type *rc_ptr)
             rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
             break;
         }
-        /* Fall through */
+        [[fallthrough]];
     case PlayerClassType::MAGE:
     case PlayerClassType::SORCERER:
         rpi = rpi_type(_("魔力食い", "Eat Magic"));

--- a/src/racial/racial-switcher.cpp
+++ b/src/racial/racial-switcher.cpp
@@ -102,7 +102,7 @@ bool switch_class_racial_execution(PlayerType *player_ptr, const int32_t command
             return retval;
         }
 
-        /* Fall through */
+        [[fallthrough]];
     case PlayerClassType::MAGE:
     case PlayerClassType::SORCERER:
         return eat_magic(player_ptr, player_ptr->lev * 2);

--- a/src/room/rooms-builder.cpp
+++ b/src/room/rooms-builder.cpp
@@ -278,7 +278,7 @@ void build_recursive_room(PlayerType *player_ptr, POSITION x1, POSITION y1, POSI
         ysize = y2 - y1;
         power += 2;
     }
-        /* Fall through */
+        [[fallthrough]];
     case 4: {
         /* Try to build a room */
         if ((xsize < 3) || (ysize < 3)) {

--- a/src/spell-kind/blood-curse.cpp
+++ b/src/spell-kind/blood-curse.cpp
@@ -37,7 +37,7 @@ void blood_curse_to_enemy(PlayerType *player_ptr, MONSTER_IDX m_idx)
                     break;
                 }
             }
-            /* Fall through */
+            [[fallthrough]];
         case 3:
         case 4:
         case 5:
@@ -50,7 +50,7 @@ void blood_curse_to_enemy(PlayerType *player_ptr, MONSTER_IDX m_idx)
                     break;
                 }
             }
-            /* Fall through */
+            [[fallthrough]];
         case 7:
         case 8:
             if (!count) {
@@ -65,7 +65,7 @@ void blood_curse_to_enemy(PlayerType *player_ptr, MONSTER_IDX m_idx)
                     break;
                 }
             }
-            /* Fall through */
+            [[fallthrough]];
         case 9:
         case 10:
         case 11:
@@ -74,7 +74,7 @@ void blood_curse_to_enemy(PlayerType *player_ptr, MONSTER_IDX m_idx)
             if (!one_in_(6)) {
                 break;
             }
-            /* Fall through */
+            [[fallthrough]];
         case 12:
         case 13:
         case 14:
@@ -84,14 +84,14 @@ void blood_curse_to_enemy(PlayerType *player_ptr, MONSTER_IDX m_idx)
             if (!one_in_(6)) {
                 break;
             }
-            /* Fall through */
+            [[fallthrough]];
         case 17:
         case 18:
             count += activate_hi_summon(player_ptr, m_ptr->fy, m_ptr->fx, true);
             if (!one_in_(6)) {
                 break;
             }
-            /* Fall through */
+            [[fallthrough]];
         case 19:
         case 20:
         case 21:
@@ -111,7 +111,7 @@ void blood_curse_to_enemy(PlayerType *player_ptr, MONSTER_IDX m_idx)
                 break;
             }
         }
-            /* Fall through */
+            [[fallthrough]];
         case 23:
         case 24:
         case 25:
@@ -128,7 +128,7 @@ void blood_curse_to_enemy(PlayerType *player_ptr, MONSTER_IDX m_idx)
             if (!one_in_(6)) {
                 break;
             }
-            /* Fall through */
+            [[fallthrough]];
         case 26:
         case 27:
         case 28:

--- a/src/spell-kind/spells-random.cpp
+++ b/src/spell-kind/spells-random.cpp
@@ -115,7 +115,7 @@ bool activate_ty_curse(PlayerType *player_ptr, bool stop_ty, int *count)
                     break;
                 }
             }
-            /* Fall through */
+            [[fallthrough]];
         case 30:
         case 31:
             if (!(*count)) {
@@ -127,7 +127,7 @@ bool activate_ty_curse(PlayerType *player_ptr, bool stop_ty, int *count)
                     break;
                 }
             }
-            /* Fall through */
+            [[fallthrough]];
         case 32:
         case 33:
             if (!(*count)) {
@@ -140,7 +140,7 @@ bool activate_ty_curse(PlayerType *player_ptr, bool stop_ty, int *count)
                     break;
                 }
             }
-            /* Fall through */
+            [[fallthrough]];
         case 34:
             msg_print(_("エネルギーのうねりを感じた！", "You feel a surge of energy!"));
             wall_breaker(player_ptr);
@@ -152,7 +152,7 @@ bool activate_ty_curse(PlayerType *player_ptr, bool stop_ty, int *count)
             if (!one_in_(6)) {
                 break;
             }
-            /* Fall through */
+            [[fallthrough]];
         case 1:
         case 2:
         case 3:
@@ -162,7 +162,7 @@ bool activate_ty_curse(PlayerType *player_ptr, bool stop_ty, int *count)
             if (!one_in_(6)) {
                 break;
             }
-            /* Fall through */
+            [[fallthrough]];
         case 4:
         case 5:
         case 6:
@@ -170,7 +170,7 @@ bool activate_ty_curse(PlayerType *player_ptr, bool stop_ty, int *count)
             if (!one_in_(6)) {
                 break;
             }
-            /* Fall through */
+            [[fallthrough]];
         case 7:
         case 8:
         case 9:
@@ -180,7 +180,7 @@ bool activate_ty_curse(PlayerType *player_ptr, bool stop_ty, int *count)
             if (!one_in_(6)) {
                 break;
             }
-            /* Fall through */
+            [[fallthrough]];
         case 10:
         case 11:
         case 12:
@@ -189,7 +189,7 @@ bool activate_ty_curse(PlayerType *player_ptr, bool stop_ty, int *count)
             if (!one_in_(6)) {
                 break;
             }
-            /* Fall through */
+            [[fallthrough]];
         case 13:
         case 14:
         case 15:
@@ -209,7 +209,7 @@ bool activate_ty_curse(PlayerType *player_ptr, bool stop_ty, int *count)
                 break;
             }
         }
-            /* Fall through */
+            [[fallthrough]];
         case 21:
         case 22:
         case 23:
@@ -217,14 +217,14 @@ bool activate_ty_curse(PlayerType *player_ptr, bool stop_ty, int *count)
             if (!one_in_(6)) {
                 break;
             }
-            /* Fall through */
+            [[fallthrough]];
         case 24:
             msg_print(_("ほえ？私は誰？ここで何してる？", "Huh? Who am I? What am I doing here?"));
             lose_all_info(player_ptr);
             if (!one_in_(6)) {
                 break;
             }
-            /* Fall through */
+            [[fallthrough]];
         case 25:
             if ((floor_ptr->dun_level > 65) && !stop_ty) {
                 (*count) += summon_cyber(player_ptr, -1, player_ptr->y, player_ptr->x);
@@ -235,7 +235,7 @@ bool activate_ty_curse(PlayerType *player_ptr, bool stop_ty, int *count)
             if (!one_in_(6)) {
                 break;
             }
-            /* Fall through */
+            [[fallthrough]];
         default:
             for (int i = 0; i < A_MAX; i++) {
                 do {

--- a/src/store/service-checker.cpp
+++ b/src/store/service-checker.cpp
@@ -110,14 +110,14 @@ static bool check_store_temple(const ObjectType *o_ptr)
             }
         }
     }
-        /* Fall through */
+        [[fallthrough]];
     case ItemKindType::POLEARM:
     case ItemKindType::SWORD:
         if (is_blessed_item(o_ptr)) {
             return true;
         }
 
-        /* Fall through */
+        [[fallthrough]];
     default:
         return false;
     }

--- a/src/target/target-setter.cpp
+++ b/src/target/target-setter.cpp
@@ -258,7 +258,7 @@ static void switch_target_input(PlayerType *player_ptr, ts_type *ts_ptr)
         ts_ptr->y = player_ptr->y;
         ts_ptr->x = player_ptr->x;
     }
-        /* Fall through */
+        [[fallthrough]];
     case 'o':
         ts_ptr->flag = false;
         return;

--- a/src/target/target-setter.cpp
+++ b/src/target/target-setter.cpp
@@ -454,8 +454,10 @@ static void switch_next_grid_command(PlayerType *player_ptr, ts_type *ts_ptr)
         target_set_prepare(player_ptr, ys_interest, xs_interest, ts_ptr->mode);
         ts_ptr->y = player_ptr->y;
         ts_ptr->x = player_ptr->x;
+        break;
     case 'o':
-        //!< @todo ↑元からbreakしていないがFall Throughを付けてよいか不明なので保留
+        // ターゲット時の「m近」「o現」の切り替え
+        // すでに「o現」の時にoを押してもなにも起きない
         break;
     case ' ':
     case '*':

--- a/src/term/gameterm.cpp
+++ b/src/term/gameterm.cpp
@@ -501,17 +501,17 @@ static TERM_COLOR spell_color(AttributeType type)
             return mh_attr(2);
         case AttributeType::DISINTEGRATE:
             return 0x05;
-        case AttributeType::PSI: /* fall through */
-        case AttributeType::PSI_DRAIN: /* fall through */
-        case AttributeType::TELEKINESIS: /* fall through */
-        case AttributeType::DOMINATION: /* fall through */
-        case AttributeType::DRAIN_MANA: /* fall through */
-        case AttributeType::MIND_BLAST: /* fall through */
+        case AttributeType::PSI:
+        case AttributeType::PSI_DRAIN:
+        case AttributeType::TELEKINESIS:
+        case AttributeType::DOMINATION:
+        case AttributeType::DRAIN_MANA:
+        case AttributeType::MIND_BLAST:
         case AttributeType::BRAIN_SMASH:
             return 0x09;
-        case AttributeType::CAUSE_1: /* fall through */
-        case AttributeType::CAUSE_2: /* fall through */
-        case AttributeType::CAUSE_3: /* fall through */
+        case AttributeType::CAUSE_1:
+        case AttributeType::CAUSE_2:
+        case AttributeType::CAUSE_3:
         case AttributeType::CAUSE_4:
             return 0x0E;
         case AttributeType::HAND_DOOM:


### PR DESCRIPTION
switch-case 文において意図したフォールスルーを行っている箇所について、コメントの代わりに C++17 から追加された [[fallthrough]] 属性を使用する。
また、もともとフォールスルーコメント不要な箇所についてはコメントを削除する。

変愚蛮怒のソースコードに起因する C5262 の警告についてはすべて [[fallthrough]] で回避するようにしましたが、STLのヘッダ内に該当の警告がひっかかる箇所があり、その部分についての警告は依然として出力されます。これはMicrosoftの対応待ちになるのでしょうか？