### PR TITLE
ItemEntity::tval/sval をBaseitemKey に差し替えるための準備をした

### DIFF
--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -433,7 +433,7 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, It
         ADD_FLG(FLG_HUMAN);
     }
 
-    if (o_ptr->tval >= ItemKindType::LIFE_BOOK && !check_book_realm(player_ptr, o_ptr->tval, o_ptr->sval)) {
+    if (o_ptr->tval >= ItemKindType::LIFE_BOOK && !check_book_realm(player_ptr, BaseitemKey(o_ptr->tval, o_ptr->sval))) {
         ADD_FLG(FLG_UNREADABLE);
         if (o_ptr->tval != ItemKindType::ARCANE_BOOK) {
             name = false;

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -433,7 +433,8 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, It
         ADD_FLG(FLG_HUMAN);
     }
 
-    if (o_ptr->tval >= ItemKindType::LIFE_BOOK && !check_book_realm(player_ptr, BaseitemKey(o_ptr->tval, o_ptr->sval))) {
+    const BaseitemKey bi_key(o_ptr->tval, o_ptr->sval);
+    if (o_ptr->is_spell_book() && !check_book_realm(player_ptr, bi_key)) {
         ADD_FLG(FLG_UNREADABLE);
         if (o_ptr->tval != ItemKindType::ARCANE_BOOK) {
             name = false;
@@ -453,16 +454,16 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, It
         name = false;
     }
 
-    if (o_ptr->tval >= ItemKindType::LIFE_BOOK && 0 == o_ptr->sval) {
+    if (o_ptr->is_spell_book() && (o_ptr->sval == 0)) {
         ADD_FLG(FLG_FIRST);
     }
-    if (o_ptr->tval >= ItemKindType::LIFE_BOOK && 1 == o_ptr->sval) {
+    if (o_ptr->is_spell_book() && (o_ptr->sval == 1)) {
         ADD_FLG(FLG_SECOND);
     }
-    if (o_ptr->tval >= ItemKindType::LIFE_BOOK && 2 == o_ptr->sval) {
+    if (o_ptr->is_spell_book() && (o_ptr->sval == 2)) {
         ADD_FLG(FLG_THIRD);
     }
-    if (o_ptr->tval >= ItemKindType::LIFE_BOOK && 3 == o_ptr->sval) {
+    if (o_ptr->is_spell_book() && (o_ptr->sval == 3)) {
         ADD_FLG(FLG_FOURTH);
     }
 
@@ -476,7 +477,7 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, It
         ADD_FLG(FLG_JUNKS);
     } else if (o_ptr->tval == ItemKindType::CORPSE) {
         ADD_FLG(FLG_CORPSES);
-    } else if (o_ptr->tval >= ItemKindType::LIFE_BOOK) {
+    } else if (o_ptr->is_spell_book()) {
         ADD_FLG(FLG_SPELLBOOKS);
     } else if (o_ptr->tval == ItemKindType::POLEARM || o_ptr->tval == ItemKindType::SWORD || o_ptr->tval == ItemKindType::DIGGING || o_ptr->tval == ItemKindType::HAFTED) {
         ADD_FLG(FLG_WEAPONS);

--- a/src/autopick/autopick-matcher.cpp
+++ b/src/autopick/autopick-matcher.cpp
@@ -207,7 +207,8 @@ bool is_autopick_match(PlayerType *player_ptr, ItemEntity *o_ptr, autopick_type 
         return false;
     }
 
-    if (IS_FLG(FLG_UNREADABLE) && (o_ptr->tval < ItemKindType::LIFE_BOOK || check_book_realm(player_ptr, { o_ptr->tval, o_ptr->sval }))) {
+    const BaseitemKey bi_key(o_ptr->tval, o_ptr->sval);
+    if (IS_FLG(FLG_UNREADABLE) && check_book_realm(player_ptr, bi_key)) {
         return false;
     }
 
@@ -222,19 +223,19 @@ bool is_autopick_match(PlayerType *player_ptr, ItemEntity *o_ptr, autopick_type 
         return false;
     }
 
-    if (IS_FLG(FLG_FIRST) && ((o_ptr->tval < ItemKindType::LIFE_BOOK) || (o_ptr->sval) != 0)) {
+    if (IS_FLG(FLG_FIRST) && (!o_ptr->is_spell_book() || (o_ptr->sval != 0))) {
         return false;
     }
 
-    if (IS_FLG(FLG_SECOND) && ((o_ptr->tval < ItemKindType::LIFE_BOOK) || (o_ptr->sval) != 1)) {
+    if (IS_FLG(FLG_SECOND) && (!o_ptr->is_spell_book() || (o_ptr->sval != 1))) {
         return false;
     }
 
-    if (IS_FLG(FLG_THIRD) && ((o_ptr->tval < ItemKindType::LIFE_BOOK) || (o_ptr->sval) != 2)) {
+    if (IS_FLG(FLG_THIRD) && (!o_ptr->is_spell_book() || (o_ptr->sval != 2))) {
         return false;
     }
 
-    if (IS_FLG(FLG_FOURTH) && ((o_ptr->tval < ItemKindType::LIFE_BOOK) || (o_ptr->sval) != 3)) {
+    if (IS_FLG(FLG_FOURTH) && (!o_ptr->is_spell_book() || (o_ptr->sval != 3))) {
         return false;
     }
 
@@ -283,7 +284,7 @@ bool is_autopick_match(PlayerType *player_ptr, ItemEntity *o_ptr, autopick_type 
             return false;
         }
     } else if (IS_FLG(FLG_SPELLBOOKS)) {
-        if (!(o_ptr->tval >= ItemKindType::LIFE_BOOK)) {
+        if (!o_ptr->is_spell_book()) {
             return false;
         }
     } else if (IS_FLG(FLG_HAFTED)) {

--- a/src/autopick/autopick-matcher.cpp
+++ b/src/autopick/autopick-matcher.cpp
@@ -207,7 +207,7 @@ bool is_autopick_match(PlayerType *player_ptr, ItemEntity *o_ptr, autopick_type 
         return false;
     }
 
-    if (IS_FLG(FLG_UNREADABLE) && (o_ptr->tval < ItemKindType::LIFE_BOOK || check_book_realm(player_ptr, o_ptr->tval, o_ptr->sval))) {
+    if (IS_FLG(FLG_UNREADABLE) && (o_ptr->tval < ItemKindType::LIFE_BOOK || check_book_realm(player_ptr, { o_ptr->tval, o_ptr->sval }))) {
         return false;
     }
 

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -58,6 +58,7 @@
 #include "status/bad-status-setter.h"
 #include "status/base-status.h"
 #include "status/experience.h"
+#include "system/baseitem-info.h"
 #include "system/floor-type-definition.h"
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
@@ -552,7 +553,7 @@ static void confirm_use_force(PlayerType *player_ptr, bool browse_only)
 
 static FuncItemTester get_castable_spellbook_tester(PlayerType *player_ptr)
 {
-    return FuncItemTester([](auto p_ptr, auto o_ptr) { return check_book_realm(p_ptr, o_ptr->tval, o_ptr->sval); }, player_ptr);
+    return FuncItemTester([](auto p_ptr, auto o_ptr) { return check_book_realm(p_ptr, { o_ptr->tval, o_ptr->sval }); }, player_ptr);
 }
 
 static FuncItemTester get_learnable_spellbook_tester(PlayerType *player_ptr)

--- a/src/cmd-item/cmd-destroy.cpp
+++ b/src/cmd-item/cmd-destroy.cpp
@@ -133,13 +133,15 @@ static bool decide_magic_book_exp(PlayerType *player_ptr, destroy_type *destroy_
         return false;
     }
 
-    bool gain_expr = false;
+    auto gain_expr = false;
+    const auto tval = destroy_ptr->o_ptr->tval;
+    auto is_good_magic_realm = (tval == ItemKindType::LIFE_BOOK) || (tval == ItemKindType::CRUSADE_BOOK);
     if (is_good_realm(player_ptr->realm1)) {
-        if (!is_good_realm(tval2realm(destroy_ptr->q_ptr->tval))) {
+        if (!is_good_magic_realm) {
             gain_expr = true;
         }
     } else {
-        if (is_good_realm(tval2realm(destroy_ptr->q_ptr->tval))) {
+        if (is_good_magic_realm) {
             gain_expr = true;
         }
     }

--- a/src/cmd-item/cmd-destroy.cpp
+++ b/src/cmd-item/cmd-destroy.cpp
@@ -30,6 +30,7 @@
 #include "realm/realm-names-table.h"
 #include "status/action-setter.h"
 #include "status/experience.h"
+#include "system/baseitem-info.h"
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
@@ -126,37 +127,30 @@ static bool decide_magic_book_exp(PlayerType *player_ptr, destroy_type *destroy_
 
     PlayerClass pc(player_ptr);
     if (pc.equals(PlayerClassType::WARRIOR) || pc.equals(PlayerClassType::BERSERKER)) {
-        return true;
+        return destroy_ptr->q_ptr->tval != ItemKindType::HISSATSU_BOOK;
     }
 
     if (!pc.equals(PlayerClassType::PALADIN)) {
         return false;
     }
 
-    auto gain_expr = false;
     const auto tval = destroy_ptr->o_ptr->tval;
     auto is_good_magic_realm = (tval == ItemKindType::LIFE_BOOK) || (tval == ItemKindType::CRUSADE_BOOK);
     if (is_good_realm(player_ptr->realm1)) {
-        if (!is_good_magic_realm) {
-            gain_expr = true;
-        }
+        return !is_good_magic_realm;
     } else {
-        if (is_good_magic_realm) {
-            gain_expr = true;
-        }
+        return is_good_magic_realm;
     }
-
-    return gain_expr;
 }
 
 static void gain_exp_by_destroying_magic_book(PlayerType *player_ptr, destroy_type *destroy_ptr)
 {
-    bool gain_expr = decide_magic_book_exp(player_ptr, destroy_ptr);
+    const auto gain_expr = decide_magic_book_exp(player_ptr, destroy_ptr);
     if (!gain_expr || (player_ptr->exp >= PY_MAX_EXP)) {
         return;
     }
 
-    int32_t tester_exp = player_ptr->max_exp / 20;
+    auto tester_exp = player_ptr->max_exp / 20;
     if (tester_exp > 10000) {
         tester_exp = 10000;
     }
@@ -175,15 +169,18 @@ static void gain_exp_by_destroying_magic_book(PlayerType *player_ptr, destroy_ty
 
 static void process_destroy_magic_book(PlayerType *player_ptr, destroy_type *destroy_ptr)
 {
-    if (!item_tester_high_level_book(destroy_ptr->q_ptr)) {
+    const auto *q_ptr = destroy_ptr->q_ptr;
+    const BaseitemKey bi_key(q_ptr->tval, q_ptr->sval);
+    if (!bi_key.is_high_level_book()) {
         return;
     }
 
+    const auto tval = bi_key.tval();
     gain_exp_by_destroying_magic_book(player_ptr, destroy_ptr);
-    if (item_tester_high_level_book(destroy_ptr->q_ptr) && destroy_ptr->q_ptr->tval == ItemKindType::LIFE_BOOK) {
+    if (tval == ItemKindType::LIFE_BOOK) {
         chg_virtue(player_ptr, V_UNLIFE, 1);
         chg_virtue(player_ptr, V_VITALITY, -1);
-    } else if (item_tester_high_level_book(destroy_ptr->q_ptr) && destroy_ptr->q_ptr->tval == ItemKindType::DEATH_BOOK) {
+    } else if (tval == ItemKindType::DEATH_BOOK) {
         chg_virtue(player_ptr, V_UNLIFE, -1);
         chg_virtue(player_ptr, V_VITALITY, 1);
     }

--- a/src/flavor/named-item-describer.cpp
+++ b/src/flavor/named-item-describer.cpp
@@ -410,7 +410,7 @@ void describe_named_item(PlayerType *player_ptr, flavor_type *flavor_ptr)
 
     describe_artifact_ja(flavor_ptr);
 #endif
-    if (flavor_ptr->o_ptr->is_book()) {
+    if (flavor_ptr->o_ptr->is_spell_book()) {
         // svalは0から数えているので表示用に+1している
         flavor_ptr->t = object_desc_str(flavor_ptr->t, format("Lv%d ", flavor_ptr->o_ptr->sval + 1));
     }

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -156,7 +156,7 @@ static short collect_objects(int grp_cur, short object_idx[], BIT_FLAGS8 mode)
 
         const auto tval = k_ref.bi_key.tval();
         if (group_tval == ItemKindType::LIFE_BOOK) {
-            if (ItemKindType::LIFE_BOOK <= tval && tval <= ItemKindType::HEX_BOOK) {
+            if (k_ref.bi_key.is_spell_book()) {
                 object_idx[object_cnt++] = k_ref.idx;
             } else {
                 continue;

--- a/src/object-hook/hook-magic.cpp
+++ b/src/object-hook/hook-magic.cpp
@@ -7,6 +7,7 @@
 #include "player-info/class-info.h"
 #include "player/player-realm.h"
 #include "realm/realm-names-table.h"
+#include "system/baseitem-info.h"
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
@@ -58,6 +59,10 @@ bool item_tester_hook_use(PlayerType *player_ptr, const ItemEntity *o_ptr)
  */
 bool item_tester_learn_spell(PlayerType *player_ptr, const ItemEntity *o_ptr)
 {
+    if (!o_ptr->is_spell_book()) {
+        return false;
+    }
+
     int32_t choices = realm_choices2[enum2i(player_ptr->pclass)];
     PlayerClass pc(player_ptr);
     if (pc.equals(PlayerClassType::PRIEST)) {
@@ -68,33 +73,13 @@ bool item_tester_learn_spell(PlayerType *player_ptr, const ItemEntity *o_ptr)
         }
     }
 
-    if ((o_ptr->tval < ItemKindType::LIFE_BOOK) || (o_ptr->tval > ItemKindType::HEX_BOOK)) {
-        return false;
-    }
-
     if ((o_ptr->tval == ItemKindType::MUSIC_BOOK) && pc.equals(PlayerClassType::BARD)) {
         return true;
-    } else if (!is_magic(tval2realm(o_ptr->tval))) {
+    }
+
+    if (!is_magic(tval2realm(o_ptr->tval))) {
         return false;
     }
 
     return (get_realm1_book(player_ptr) == o_ptr->tval) || (get_realm2_book(player_ptr) == o_ptr->tval) || (choices & (0x0001U << (tval2realm(o_ptr->tval) - 1)));
-}
-
-/*!
- * @brief オブジェクトが高位の魔法書かどうかを判定する
- * @param o_ptr 判定したいオブジェクトの構造体参照ポインタ
- * @return オブジェクトが高位の魔法書ならばTRUEを返す
- */
-bool item_tester_high_level_book(const ItemEntity *o_ptr)
-{
-    if ((o_ptr->tval == ItemKindType::LIFE_BOOK) || (o_ptr->tval == ItemKindType::SORCERY_BOOK) || (o_ptr->tval == ItemKindType::NATURE_BOOK) || (o_ptr->tval == ItemKindType::CHAOS_BOOK) || (o_ptr->tval == ItemKindType::DEATH_BOOK) || (o_ptr->tval == ItemKindType::TRUMP_BOOK) || (o_ptr->tval == ItemKindType::CRAFT_BOOK) || (o_ptr->tval == ItemKindType::DEMON_BOOK) || (o_ptr->tval == ItemKindType::CRUSADE_BOOK) || (o_ptr->tval == ItemKindType::MUSIC_BOOK) || (o_ptr->tval == ItemKindType::HEX_BOOK)) {
-        if (o_ptr->sval > 1) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    return false;
 }

--- a/src/object-hook/hook-magic.h
+++ b/src/object-hook/hook-magic.h
@@ -4,4 +4,3 @@ class ItemEntity;
 class PlayerType;
 bool item_tester_hook_use(PlayerType *player_ptr, const ItemEntity *o_ptr);
 bool item_tester_learn_spell(PlayerType *player_ptr, const ItemEntity *o_ptr);
-bool item_tester_high_level_book(const ItemEntity *o_ptr);

--- a/src/object/object-info.cpp
+++ b/src/object/object-info.cpp
@@ -293,11 +293,11 @@ int16_t wield_slot(PlayerType *player_ptr, const ItemEntity *o_ptr)
  */
 bool check_book_realm(PlayerType *player_ptr, const BaseitemKey &bi_key)
 {
-    const auto tval = bi_key.tval();
-    if (tval < ItemKindType::LIFE_BOOK) {
+    if (!bi_key.is_spell_book()) {
         return false;
     }
 
+    const auto tval = bi_key.tval();
     PlayerClass pc(player_ptr);
     if (pc.equals(PlayerClassType::SORCERER)) {
         return is_magic(tval2realm(tval));

--- a/src/object/object-info.cpp
+++ b/src/object/object-info.cpp
@@ -286,28 +286,28 @@ int16_t wield_slot(PlayerType *player_ptr, const ItemEntity *o_ptr)
 }
 
 /*!
- * @brief tval/sval指定のベースアイテムがプレイヤーの使用可能な魔法書かどうかを返す /
- * Hack: Check if a spellbook is one of the realms we can use. -- TY
- * @param book_tval ベースアイテムのtval
- * @param book_sval ベースアイテムのsval
+ * @brief tval/sval指定のベースアイテムがプレイヤーの使用可能な魔法書かどうかを返す
+ * @param player_ptr プレイヤーへの参照ポインタ
+ * @param bi_key ベースアイテム特定キー
  * @return 使用可能な魔法書ならばTRUEを返す。
  */
-bool check_book_realm(PlayerType *player_ptr, const ItemKindType book_tval, const OBJECT_SUBTYPE_VALUE book_sval)
+bool check_book_realm(PlayerType *player_ptr, const BaseitemKey &bi_key)
 {
-    if (book_tval < ItemKindType::LIFE_BOOK) {
+    const auto tval = bi_key.tval();
+    if (tval < ItemKindType::LIFE_BOOK) {
         return false;
     }
 
     PlayerClass pc(player_ptr);
     if (pc.equals(PlayerClassType::SORCERER)) {
-        return is_magic(tval2realm(book_tval));
+        return is_magic(tval2realm(tval));
     } else if (pc.equals(PlayerClassType::RED_MAGE)) {
-        if (is_magic(tval2realm(book_tval))) {
-            return ((book_tval == ItemKindType::ARCANE_BOOK) || (book_sval < 2));
+        if (is_magic(tval2realm(tval))) {
+            return ((tval == ItemKindType::ARCANE_BOOK) || (bi_key.sval() < 2));
         }
     }
 
-    return (get_realm1_book(player_ptr) == book_tval) || (get_realm2_book(player_ptr) == book_tval);
+    return (get_realm1_book(player_ptr) == tval) || (get_realm2_book(player_ptr) == tval);
 }
 
 ItemEntity *ref_item(PlayerType *player_ptr, INVENTORY_IDX item)

--- a/src/object/object-info.h
+++ b/src/object/object-info.h
@@ -5,10 +5,11 @@
 
 #define OBJ_GOLD_LIST 480 /* First "gold" entry */
 
+class BaseitemKey;
 class ItemEntity;
 class PlayerType;
 concptr activation_explanation(ItemEntity *o_ptr);
 char index_to_label(int i);
 int16_t wield_slot(PlayerType *player_ptr, const ItemEntity *o_ptr);
-bool check_book_realm(PlayerType *player_ptr, const ItemKindType book_tval, const OBJECT_SUBTYPE_VALUE book_sval);
+bool check_book_realm(PlayerType *player_ptr, const BaseitemKey &bi_key);
 ItemEntity *ref_item(PlayerType *player_ptr, INVENTORY_IDX item);

--- a/src/object/object-kind-hook.cpp
+++ b/src/object/object-kind-hook.cpp
@@ -50,25 +50,25 @@ bool kind_is_sword(short bi_id)
 }
 
 /*!
- * @brief オブジェクトが魔法書かどうかを判定する /
+ * @brief オブジェクトが魔法書かどうかを判定する
  * @param bi_id 判定したいオブジェクトのベースアイテムID
  * @return オブジェクトが魔法書ならばTRUEを返す
  */
 bool kind_is_book(short bi_id)
 {
     const auto &k_ref = baseitems_info[bi_id];
-    return (k_ref.bi_key.tval() >= ItemKindType::LIFE_BOOK) && (k_ref.bi_key.tval() <= ItemKindType::CRUSADE_BOOK);
+    return k_ref.bi_key.is_spell_book();
 }
 
 /*!
- * @brief オブジェクトがベースアイテム時点でGOODかどうかを判定する /
+ * @brief オブジェクトがベースアイテム時点でGOODかどうかを判定する
  * @param bi_id 判定したいオブジェクトのベースアイテムID
  * @return オブジェクトがベースアイテム時点でGOODなアイテムならばTRUEを返す
  */
 bool kind_is_good_book(short bi_id)
 {
     const auto &k_ref = baseitems_info[bi_id];
-    return (k_ref.bi_key.tval() >= ItemKindType::LIFE_BOOK) && (k_ref.bi_key.tval() <= ItemKindType::CRUSADE_BOOK) && (k_ref.bi_key.tval() != ItemKindType::ARCANE_BOOK) && (k_ref.bi_key.sval() > 1);
+    return k_ref.bi_key.is_high_level_book();
 }
 
 /*!

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -2744,7 +2744,7 @@ bool player_has_no_spellbooks(PlayerType *player_ptr)
     ItemEntity *o_ptr;
     for (int i = 0; i < INVEN_PACK; i++) {
         o_ptr = &player_ptr->inventory_list[i];
-        if (o_ptr->bi_id && check_book_realm(player_ptr, o_ptr->tval, o_ptr->sval)) {
+        if (o_ptr->bi_id && check_book_realm(player_ptr, { o_ptr->tval, o_ptr->sval })) {
             return false;
         }
     }
@@ -2752,7 +2752,7 @@ bool player_has_no_spellbooks(PlayerType *player_ptr)
     auto *floor_ptr = player_ptr->current_floor_ptr;
     for (const auto this_o_idx : floor_ptr->grid_array[player_ptr->y][player_ptr->x].o_idx_list) {
         o_ptr = &floor_ptr->o_list[this_o_idx];
-        if (o_ptr->bi_id && any_bits(o_ptr->marked, OM_FOUND) && check_book_realm(player_ptr, o_ptr->tval, o_ptr->sval)) {
+        if (o_ptr->bi_id && any_bits(o_ptr->marked, OM_FOUND) && check_book_realm(player_ptr, { o_ptr->tval, o_ptr->sval })) {
             return false;
         }
     }

--- a/src/system/baseitem-info.cpp
+++ b/src/system/baseitem-info.cpp
@@ -78,6 +78,41 @@ ItemKindType BaseitemKey::get_arrow_kind() const
     }
 }
 
+bool BaseitemKey::is_spell_book() const
+{
+    switch (this->type_value) {
+    case ItemKindType::LIFE_BOOK:
+    case ItemKindType::SORCERY_BOOK:
+    case ItemKindType::NATURE_BOOK:
+    case ItemKindType::CHAOS_BOOK:
+    case ItemKindType::DEATH_BOOK:
+    case ItemKindType::TRUMP_BOOK:
+    case ItemKindType::ARCANE_BOOK:
+    case ItemKindType::CRAFT_BOOK:
+    case ItemKindType::DEMON_BOOK:
+    case ItemKindType::CRUSADE_BOOK:
+    case ItemKindType::MUSIC_BOOK:
+    case ItemKindType::HISSATSU_BOOK:
+    case ItemKindType::HEX_BOOK:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool BaseitemKey::is_high_level_book() const
+{
+    if (!this->is_spell_book()) {
+        return false;
+    }
+
+    if (this->type_value == ItemKindType::ARCANE_BOOK) {
+        return false;
+    }
+
+    return this->subtype_value >= 2;
+}
+
 BaseitemInfo::BaseitemInfo()
     : bi_key(ItemKindType::NONE)
 {

--- a/src/system/baseitem-info.h
+++ b/src/system/baseitem-info.h
@@ -38,6 +38,8 @@ public:
     std::optional<int> sval() const;
 
     ItemKindType get_arrow_kind() const;
+    bool is_spell_book() const;
+    bool is_high_level_book() const;
 
 private:
     ItemKindType type_value;

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -38,7 +38,7 @@ ItemEntity::ItemEntity()
 }
 
 /*!
- * @brief オブジェクトを初期化する
+ * @brief アイテムを初期化する
  * Wipe an object clean.
  */
 void ItemEntity::wipe()
@@ -47,7 +47,7 @@ void ItemEntity::wipe()
 }
 
 /*!
- * @brief オブジェクトを複製する
+ * @brief アイテムを複製する
  * Wipe an object clean.
  * @param j_ptr 複製元のオブジェクトの構造体参照ポインタ
  */
@@ -57,7 +57,7 @@ void ItemEntity::copy_from(const ItemEntity *j_ptr)
 }
 
 /*!
- * @brief オブジェクト構造体にベースアイテムを作成する
+ * @brief アイテム構造体にベースアイテムを作成する
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param bi_id 新たに作成したいベースアイテム情報のID
  */
@@ -108,7 +108,7 @@ void ItemEntity::prep(short new_bi_id)
 }
 
 /*!
- * @brief オブジェクトが武器として装備できるかどうかを返す / Check if an object is weapon (including bows)
+ * @brief アイテムが武器として装備できるかどうかを返す / Check if an object is weapon (including bows)
  * @return 武器として使えるならばtrueを返す
  */
 bool ItemEntity::is_weapon() const
@@ -117,7 +117,7 @@ bool ItemEntity::is_weapon() const
 }
 
 /*!
- * @brief オブジェクトが武器や矢弾として使用できるかを返す / Check if an object is weapon (including bows and ammo)
+ * @brief アイテムが武器や矢弾として使用できるかを返す / Check if an object is weapon (including bows and ammo)
  * Rare weapons/aromors including Blade of Chaos, Dragon armors, etc.
  * @return 武器や矢弾として使えるならばtrueを返す
  */
@@ -127,7 +127,7 @@ bool ItemEntity::is_weapon_ammo() const
 }
 
 /*!
- * @brief オブジェクトが武器、防具、矢弾として使用できるかを返す / Check if an object is weapon, armour or ammo
+ * @brief アイテムが武器、防具、矢弾として使用できるかを返す / Check if an object is weapon, armour or ammo
  * @return 武器、防具、矢弾として使えるならばtrueを返す
  */
 bool ItemEntity::is_weapon_armour_ammo() const
@@ -136,7 +136,7 @@ bool ItemEntity::is_weapon_armour_ammo() const
 }
 
 /*!
- * @brief オブジェクトが近接武器として装備できるかを返す / Melee weapons
+ * @brief アイテムが近接武器として装備できるかを返す / Melee weapons
  * @return 近接武器として使えるならばtrueを返す
  */
 bool ItemEntity::is_melee_weapon() const
@@ -166,7 +166,7 @@ bool ItemEntity::is_melee_ammo() const
 }
 
 /*!
- * @brief オブジェクトが装備可能であるかを返す / Wearable including all weapon, all armour, bow, light source, amulet, and ring
+ * @brief アイテムが装備可能であるかを返す / Wearable including all weapon, all armour, bow, light source, amulet, and ring
  * @return 装備可能ならばTRUEを返す
  */
 bool ItemEntity::is_wearable() const
@@ -175,7 +175,7 @@ bool ItemEntity::is_wearable() const
 }
 
 /*!
- * @brief オブジェクトが装備品であるかを返す(ItemEntity::is_wearableに矢弾を含む) / Equipment including all wearable objects and ammo
+ * @brief アイテムが装備品であるかを返す(ItemEntity::is_wearableに矢弾を含む) / Equipment including all wearable objects and ammo
  * @return 装備品ならばtrueを返す
  */
 bool ItemEntity::is_equipment() const
@@ -221,7 +221,7 @@ bool ItemEntity::is_broken_weapon() const
 }
 
 /*!
- * @brief オブジェクトが投射可能な武器かどうかを返す。
+ * @brief アイテムが投射可能な武器かどうかを返す。
  * @return 投射可能な武器ならばtrue
  */
 bool ItemEntity::is_throwable() const
@@ -238,7 +238,7 @@ bool ItemEntity::is_throwable() const
 }
 
 /*!
- * @brief オブジェクトがどちらの手にも装備できる武器かどうかの判定
+ * @brief アイテムがどちらの手にも装備できる武器かどうかの判定
  * @return 左右両方の手で装備できるならばtrueを返す。
  */
 bool ItemEntity::is_wieldable_in_etheir_hand() const
@@ -258,7 +258,7 @@ bool ItemEntity::is_wieldable_in_etheir_hand() const
 }
 
 /*!
- * @brief オブジェクトが強化不能武器であるかを返す / Poison needle can not be enchanted
+ * @brief アイテムが強化不能武器であるかを返す / Poison needle can not be enchanted
  * @return 強化不能ならばtrueを返す
  */
 bool ItemEntity::refuse_enchant_weapon() const
@@ -267,7 +267,7 @@ bool ItemEntity::refuse_enchant_weapon() const
 }
 
 /*!
- * @brief オブジェクトが強化可能武器であるかを返す /
+ * @brief アイテムが強化可能武器であるかを返す /
  * Check if an object is weapon (including bows and ammo) and allows enchantment
  * @return 強化可能ならばtrueを返す
  */
@@ -277,7 +277,7 @@ bool ItemEntity::allow_enchant_weapon() const
 }
 
 /*!
- * @brief オブジェクトが強化可能な近接武器であるかを返す /
+ * @brief アイテムが強化可能な近接武器であるかを返す /
  * Check if an object is melee weapon and allows enchantment
  * @return 強化可能な近接武器ならばtrueを返す
  */
@@ -287,7 +287,7 @@ bool ItemEntity::allow_enchant_melee_weapon() const
 }
 
 /*!
- * @brief オブジェクトが両手持ち可能な武器かを返す /
+ * @brief アイテムが両手持ち可能な武器かを返す /
  * Check if an object is melee weapon and allows wielding with two-hands
  * @return 両手持ち可能ならばTRUEを返す
  */
@@ -297,7 +297,7 @@ bool ItemEntity::allow_two_hands_wielding() const
 }
 
 /*!
- * @brief オブジェクトが矢弾として使用できるかどうかを返す / Check if an object is ammo
+ * @brief アイテムが矢弾として使用できるかどうかを返す / Check if an object is ammo
  * @return 矢弾として使えるならばtrueを返す
  */
 bool ItemEntity::is_ammo() const
@@ -325,7 +325,7 @@ bool ItemEntity::is_lance() const
 }
 
 /*!
- * @brief オブジェクトが防具として装備できるかどうかを返す / Check if an object is armour
+ * @brief アイテムが防具として装備できるかどうかを返す / Check if an object is armour
  * @return 防具として装備できるならばtrueを返す
  */
 bool ItemEntity::is_armour() const
@@ -334,7 +334,7 @@ bool ItemEntity::is_armour() const
 }
 
 /*!
- * @brief オブジェクトがレアアイテムかどうかを返す /
+ * @brief アイテムがレアアイテムかどうかを返す /
  * Rare weapons/aromors including Blade of Chaos, Dragon armors, etc.
  * @return レアアイテムならばTRUEを返す
  */
@@ -363,7 +363,7 @@ bool ItemEntity::is_rare() const
 }
 
 /*!
- * @brief オブジェクトがエゴアイテムかどうかを返す
+ * @brief アイテムがエゴアイテムかどうかを返す
  * @return エゴアイテムならばtrueを返す
  */
 bool ItemEntity::is_ego() const
@@ -372,7 +372,7 @@ bool ItemEntity::is_ego() const
 }
 
 /*!
- * @brief オブジェクトが鍛冶師のエッセンス付加済みかを返す /
+ * @brief アイテムが鍛冶師のエッセンス付加済みかを返す /
  * Check if an object is made by a smith's special ability
  * @return エッセンス付加済みならばTRUEを返す
  */
@@ -382,7 +382,7 @@ bool ItemEntity::is_smith() const
 }
 
 /*!
- * @brief オブジェクトがアーティファクトかを返す /
+ * @brief アイテムがアーティファクトかを返す /
  * Check if an object is artifact
  * @return アーティファクトならばtrueを返す
  */
@@ -392,7 +392,7 @@ bool ItemEntity::is_artifact() const
 }
 
 /*!
- * @brief オブジェクトが固定アーティファクトかを返す /
+ * @brief アイテムが固定アーティファクトかを返す /
  * Check if an object is fixed artifact
  * @return 固定アーティファクトならばtrueを返す
  */
@@ -402,7 +402,7 @@ bool ItemEntity::is_fixed_artifact() const
 }
 
 /*!
- * @brief オブジェクトがランダムアーティファクトかを返す /
+ * @brief アイテムがランダムアーティファクトかを返す /
  * Check if an object is random artifact
  * @return ランダムアーティファクトならばtrueを返す
  */
@@ -412,7 +412,7 @@ bool ItemEntity::is_random_artifact() const
 }
 
 /*!
- * @brief オブジェクトが通常のアイテム(アーティファクト、エゴ、鍛冶師エッセンス付加いずれでもない)かを返す /
+ * @brief アイテムが通常のアイテム(アーティファクト、エゴ、鍛冶師エッセンス付加いずれでもない)かを返す /
  * Check if an object is neither artifact, ego, nor 'smith' object
  * @return 通常のアイテムならばtrueを返す
  */
@@ -474,7 +474,7 @@ bool ItemEntity::is_tried() const
 }
 
 /*!
- * @brief オブジェクトが薬であるかを返す
+ * @brief アイテムが薬であるかを返す
  * @return オブジェクトが薬ならばtrueを返す
  */
 bool ItemEntity::is_potion() const
@@ -483,7 +483,7 @@ bool ItemEntity::is_potion() const
 }
 
 /*!
- * @brief オブジェクトをプレイヤーが読むことができるかを判定する /
+ * @brief アイテムをプレイヤーが読むことができるかを判定する /
  * Hook to determine if an object is readable
  * @return 読むことが可能ならばtrueを返す
  */
@@ -497,7 +497,7 @@ bool ItemEntity::is_readable() const
 }
 
 /*!
- * @brief オブジェクトがランタンの燃料になるかどうかを判定する
+ * @brief アイテムがランタンの燃料になるかどうかを判定する
  * An "item_tester_hook" for refilling lanterns
  * @return オブジェクトがランタンの燃料になるならばTRUEを返す
  */
@@ -507,7 +507,7 @@ bool ItemEntity::can_refill_lantern() const
 }
 
 /*!
- * @brief オブジェクトが松明に束ねられるかどうかを判定する
+ * @brief アイテムが松明に束ねられるかどうかを判定する
  * An "item_tester_hook" for refilling torches
  * @return オブジェクトが松明に束ねられるならばTRUEを返す
  */
@@ -547,7 +547,7 @@ bool ItemEntity::is_offerable() const
 }
 
 /*!
- * @brief オブジェクトをプレイヤーが魔道具として発動できるかを判定する /
+ * @brief アイテムをプレイヤーが魔道具として発動できるかを判定する /
  * Hook to determine if an object is activatable
  * @return 魔道具として発動可能ならばTRUEを返す
  */
@@ -562,7 +562,7 @@ bool ItemEntity::is_activatable() const
 }
 
 /*!
- * @brief オブジェクトが燃料として使えるかを判定する
+ * @brief アイテムが燃料として使えるかを判定する
  * @return 燃料か否か
  */
 bool ItemEntity::is_fuel() const
@@ -573,7 +573,7 @@ bool ItemEntity::is_fuel() const
 }
 
 /*!
- * @brief オブジェクトが魔法書かどうかを判定する
+ * @brief アイテムが魔法書かどうかを判定する
  * @return 魔法書か否か
  */
 bool ItemEntity::is_spell_book() const
@@ -582,7 +582,7 @@ bool ItemEntity::is_spell_book() const
 }
 
 /*!
- * @brief オブジェクトが同一の命中値上昇及びダメージ上昇があるかを判定する
+ * @brief アイテムが同一の命中値上昇及びダメージ上昇があるかを判定する
  * @return 同一修正か
  * @details 鍛冶師が篭手に殺戮エッセンスを付加した場合のみこの判定に意味がある
  */
@@ -604,7 +604,7 @@ bool ItemEntity::is_glove_same_temper(const ItemEntity *j_ptr) const
 }
 
 /*!
- * @brief オブジェクトが「2つの～～」と重ねられるかを一般的に判定する
+ * @brief アイテムが「2つの～～」と重ねられるかを一般的に判定する
  * @return 重ねられるか
  * @details 個別のアイテムによっては別途条件があるが、それはこの関数では判定しない
  */
@@ -709,7 +709,7 @@ char ItemEntity::get_symbol() const
 }
 
 /*!
- * @brief オブジェクト価格算出のメインルーチン
+ * @brief アイテム価格算出のメインルーチン
  * @return オブジェクトの判明している現価格
  */
 int ItemEntity::get_price() const

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -568,7 +568,7 @@ bool ItemEntity::is_activatable() const
 bool ItemEntity::is_fuel() const
 {
     auto is_fuel = (this->tval == ItemKindType::LITE) && ((this->sval == SV_LITE_TORCH) || (this->sval == SV_LITE_LANTERN));
-    is_fuel |= (this->tval == ItemKindType::FLASK) && (this->sval == SV_FLASK_OIL);
+    is_fuel |= BaseitemKey(this->tval, this->sval) == BaseitemKey(ItemKindType::FLASK, SV_FLASK_OIL);
     return is_fuel;
 }
 
@@ -576,26 +576,9 @@ bool ItemEntity::is_fuel() const
  * @brief オブジェクトが魔法書かどうかを判定する
  * @return 魔法書か否か
  */
-bool ItemEntity::is_book() const
+bool ItemEntity::is_spell_book() const
 {
-    switch (this->tval) {
-    case ItemKindType::LIFE_BOOK:
-    case ItemKindType::SORCERY_BOOK:
-    case ItemKindType::NATURE_BOOK:
-    case ItemKindType::CHAOS_BOOK:
-    case ItemKindType::DEATH_BOOK:
-    case ItemKindType::TRUMP_BOOK:
-    case ItemKindType::ARCANE_BOOK:
-    case ItemKindType::CRAFT_BOOK:
-    case ItemKindType::DEMON_BOOK:
-    case ItemKindType::CRUSADE_BOOK:
-    case ItemKindType::MUSIC_BOOK:
-    case ItemKindType::HISSATSU_BOOK:
-    case ItemKindType::HEX_BOOK:
-        return true;
-    default:
-        return false;
-    }
+    return BaseitemKey(this->tval).is_spell_book();
 }
 
 /*!

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -113,7 +113,7 @@ public:
     bool is_offerable() const;
     bool is_activatable() const;
     bool is_fuel() const;
-    bool is_book() const;
+    bool is_spell_book() const;
     bool is_glove_same_temper(const ItemEntity *j_ptr) const;
     bool can_pile(const ItemEntity *j_ptr) const;
     TERM_COLOR get_color() const;


### PR DESCRIPTION
作業中に出てきた、「これは置換作業と別にやるべきだろう」という整理系コミットをまとめました
特に、is\_spell\_book() の扱いは、#2815 に絡んで不具合修正に近い仕様変更があります
併せてご確認下さい
(何故か呪術は魔法書でない扱いになっている等)