### PR TITLE
[Feature] FlagGroup を固定バイト長でセーブファイルに読み書きする関数 

### DIFF
--- a/src/action/run-execution.cpp
+++ b/src/action/run-execution.cpp
@@ -240,7 +240,7 @@ static bool run_test(PlayerType *player_ptr)
         for (const auto this_o_idx : g_ptr->o_idx_list) {
             ItemEntity *o_ptr;
             o_ptr = &floor_ptr->o_list[this_o_idx];
-            if (o_ptr->marked & OM_FOUND) {
+            if (o_ptr->marked.has(OmType::FOUND)) {
                 return true;
             }
         }

--- a/src/autopick/autopick-destroyer.cpp
+++ b/src/autopick/autopick-destroyer.cpp
@@ -154,6 +154,6 @@ void auto_destroy_item(PlayerType *player_ptr, ItemEntity *o_ptr, int autopick_i
     }
 
     autopick_last_destroyed_object = *o_ptr;
-    o_ptr->marked |= OM_AUTODESTROY;
+    o_ptr->marked.set(OmType::AUTODESTROY);
     player_ptr->update |= PU_AUTODESTROY;
 }

--- a/src/autopick/autopick.cpp
+++ b/src/autopick/autopick.cpp
@@ -42,7 +42,7 @@ static void autopick_delayed_alter_aux(PlayerType *player_ptr, INVENTORY_IDX ite
     ItemEntity *o_ptr;
     o_ptr = ref_item(player_ptr, item);
 
-    if (o_ptr->bi_id == 0 || !(o_ptr->marked & OM_AUTODESTROY)) {
+    if (o_ptr->bi_id == 0 || o_ptr->marked.has_not(OmType::AUTODESTROY)) {
         return;
     }
 
@@ -117,7 +117,7 @@ void autopick_pickup_items(PlayerType *player_ptr, grid_type *g_ptr)
             GAME_TEXT o_name[MAX_NLEN];
             describe_flavor(player_ptr, o_name, o_ptr, 0);
             msg_format(_("ザックには%sを入れる隙間がない。", "You have no room for %s."), o_name);
-            o_ptr->marked |= OM_NOMSG;
+            o_ptr->marked.set(OmType::SUPRESS_MESSAGE);
             continue;
         }
 
@@ -128,14 +128,14 @@ void autopick_pickup_items(PlayerType *player_ptr, grid_type *g_ptr)
 
         char out_val[MAX_NLEN + 20];
         GAME_TEXT o_name[MAX_NLEN];
-        if (o_ptr->marked & OM_NO_QUERY) {
+        if (o_ptr->marked.has(OmType::NO_QUERY)) {
             continue;
         }
 
         describe_flavor(player_ptr, o_name, o_ptr, 0);
         sprintf(out_val, _("%sを拾いますか? ", "Pick up %s? "), o_name);
         if (!get_check(out_val)) {
-            o_ptr->marked |= OM_NOMSG | OM_NO_QUERY;
+            o_ptr->marked.set({ OmType::SUPRESS_MESSAGE, OmType::NO_QUERY });
             continue;
         }
 

--- a/src/cmd-item/cmd-equipment.cpp
+++ b/src/cmd-item/cmd-equipment.cpp
@@ -293,7 +293,7 @@ void do_cmd_wield(PlayerType *player_ptr)
     }
 
     o_ptr->copy_from(q_ptr);
-    o_ptr->marked |= OM_TOUCHED;
+    o_ptr->marked.set(OmType::TOUCHED);
     player_ptr->equip_cnt++;
 
 #define STR_WIELD_HAND_RIGHT _("%s(%c)を右手に装備した。", "You are wielding %s (%c) in your right hand.")

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -965,7 +965,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX item, ItemEntity *j_ptr, SPE
             o_ptr->copy_from(q_ptr);
 
             /* Forget mark */
-            reset_bits(o_ptr->marked, OM_TOUCHED);
+            o_ptr->marked.reset(OmType::TOUCHED);
 
             /* Forget location */
             o_ptr->iy = o_ptr->ix = 0;

--- a/src/effect/effect-item.cpp
+++ b/src/effect/effect-item.cpp
@@ -214,7 +214,7 @@ bool affect_item(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITION y
 
             o_ptr->pval = (0 - o_ptr->pval);
             object_known(o_ptr);
-            if (known && (o_ptr->marked & OM_FOUND)) {
+            if (known && o_ptr->marked.has(OmType::FOUND)) {
                 msg_print(_("カチッと音がした！", "Click!"));
                 is_item_affected = true;
             }
@@ -259,20 +259,20 @@ bool affect_item(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITION y
         }
 
         GAME_TEXT o_name[MAX_NLEN];
-        if (known && (o_ptr->marked & OM_FOUND)) {
+        if (known && o_ptr->marked.has(OmType::FOUND)) {
             is_item_affected = true;
             describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
         }
 
         if ((is_artifact || ignore)) {
-            if (known && (o_ptr->marked & OM_FOUND)) {
+            if (known && o_ptr->marked.has(OmType::FOUND)) {
                 msg_format(_("%sは影響を受けない！", (plural ? "The %s are unaffected!" : "The %s is unaffected!")), o_name);
             }
 
             continue;
         }
 
-        if (known && (o_ptr->marked & OM_FOUND) && note_kill) {
+        if (known && o_ptr->marked.has(OmType::FOUND) && note_kill) {
             msg_format(_("%sは%s", "The %s%s"), o_name, note_kill);
         }
 

--- a/src/floor/floor-events.cpp
+++ b/src/floor/floor-events.cpp
@@ -157,7 +157,7 @@ static byte get_dungeon_feeling(PlayerType *player_ptr)
         auto *o_ptr = &floor_ptr->o_list[i];
         auto *k_ptr = &baseitems_info[o_ptr->bi_id];
         int delta = 0;
-        if (!o_ptr->is_valid() || (o_ptr->is_known() && ((o_ptr->marked & OM_TOUCHED) != 0)) || ((o_ptr->ident & IDENT_SENSE) != 0)) {
+        if (!o_ptr->is_valid() || (o_ptr->is_known() && o_ptr->marked.has(OmType::TOUCHED)) || ((o_ptr->ident & IDENT_SENSE) != 0)) {
             continue;
         }
 

--- a/src/floor/object-scanner.cpp
+++ b/src/floor/object-scanner.cpp
@@ -44,7 +44,7 @@ ITEM_NUMBER scan_floor_items(PlayerType *player_ptr, OBJECT_IDX *items, POSITION
             continue;
         }
 
-        if ((mode & SCAN_FLOOR_ONLY_MARKED) && !(o_ptr->marked & OM_FOUND)) {
+        if ((mode & SCAN_FLOOR_ONLY_MARKED) && o_ptr->marked.has_not(OmType::FOUND)) {
             continue;
         }
 

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -358,7 +358,7 @@ void note_spot(PlayerType *player_ptr, POSITION y, POSITION x)
         auto *o_ptr = &player_ptr->current_floor_ptr->o_list[this_o_idx];
 
         /* Memorize objects */
-        o_ptr->marked |= OM_FOUND;
+        o_ptr->marked.set(OmType::FOUND);
     }
 
     /* Hack -- memorize grids */

--- a/src/inventory/inventory-object.cpp
+++ b/src/inventory/inventory-object.cpp
@@ -354,7 +354,7 @@ int16_t store_item_to_inventory(PlayerType *player_ptr, ItemEntity *o_ptr)
     j_ptr = &player_ptr->inventory_list[i];
     j_ptr->held_m_idx = 0;
     j_ptr->iy = j_ptr->ix = 0;
-    j_ptr->marked = OM_TOUCHED;
+    j_ptr->marked.clear().set(OmType::TOUCHED);
 
     player_ptr->inven_cnt++;
     player_ptr->update |= (PU_BONUS | PU_COMBINE | PU_REORDER);

--- a/src/inventory/item-getter.cpp
+++ b/src/inventory/item-getter.cpp
@@ -256,7 +256,7 @@ bool get_item(PlayerType *player_ptr, OBJECT_IDX *cp, concptr pmt, concptr str, 
         for (const auto this_o_idx : player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x].o_idx_list) {
             ItemEntity *o_ptr;
             o_ptr = &player_ptr->current_floor_ptr->o_list[this_o_idx];
-            if ((item_tester.okay(o_ptr) || (item_selection_ptr->mode & USE_FULL)) && (o_ptr->marked & OM_FOUND)) {
+            if ((item_tester.okay(o_ptr) || (item_selection_ptr->mode & USE_FULL)) && o_ptr->marked.has(OmType::FOUND)) {
                 item_selection_ptr->allow_floor = true;
             }
         }

--- a/src/inventory/player-inventory.cpp
+++ b/src/inventory/player-inventory.cpp
@@ -104,8 +104,8 @@ void py_pickup_floor(PlayerType *player_ptr, bool pickup)
             player_ptr->window_flags |= (PW_PLAYER);
             delete_object_idx(player_ptr, this_o_idx);
             continue;
-        } else if (o_ptr->marked & OM_NOMSG) {
-            o_ptr->marked &= ~(OM_NOMSG);
+        } else if (o_ptr->marked.has(OmType::SUPRESS_MESSAGE)) {
+            o_ptr->marked.reset(OmType::SUPRESS_MESSAGE);
             continue;
         }
 
@@ -208,7 +208,7 @@ void describe_pickup_item(PlayerType *player_ptr, OBJECT_IDX o_idx)
     if (player_ptr->ppersonality == PERSONALITY_MUNCHKIN) {
         bool old_known = identify_item(player_ptr, o_ptr);
         autopick_alter_item(player_ptr, slot, (bool)(destroy_identify && !old_known));
-        if (o_ptr->marked & OM_AUTODESTROY) {
+        if (o_ptr->marked.has(OmType::AUTODESTROY)) {
             return;
         }
     }
@@ -278,8 +278,8 @@ void carry(PlayerType *player_ptr, bool pickup)
             continue;
         }
 
-        if (o_ptr->marked & OM_NOMSG) {
-            o_ptr->marked &= ~OM_NOMSG;
+        if (o_ptr->marked.has(OmType::SUPRESS_MESSAGE)) {
+            o_ptr->marked.reset(OmType::SUPRESS_MESSAGE);
             continue;
         }
 

--- a/src/load/inventory-loader.cpp
+++ b/src/load/inventory-loader.cpp
@@ -43,7 +43,7 @@ static errr rd_inventory(PlayerType *player_ptr)
         }
 
         if (n >= INVEN_MAIN_HAND) {
-            item.marked |= OM_TOUCHED;
+            item.marked.set(OmType::TOUCHED);
             player_ptr->inventory_list[n].copy_from(&item);
             player_ptr->equip_cnt++;
             continue;
@@ -55,7 +55,7 @@ static errr rd_inventory(PlayerType *player_ptr)
         }
 
         n = slot++;
-        item.marked |= OM_TOUCHED;
+        item.marked.set(OmType::TOUCHED);
         player_ptr->inventory_list[n].copy_from(&item);
         player_ptr->inven_cnt++;
     }

--- a/src/load/old/item-loader-savefile50.cpp
+++ b/src/load/old/item-loader-savefile50.cpp
@@ -60,7 +60,10 @@ void ItemLoader50::rd_item(ItemEntity *o_ptr)
     o_ptr->dd = any_bits(flags, SaveDataItemFlagType::DD) ? rd_byte() : 0;
     o_ptr->ds = any_bits(flags, SaveDataItemFlagType::DS) ? rd_byte() : 0;
     o_ptr->ident = any_bits(flags, SaveDataItemFlagType::IDENT) ? rd_byte() : 0;
-    o_ptr->marked = any_bits(flags, SaveDataItemFlagType::MARKED) ? rd_byte() : 0;
+    o_ptr->marked.clear();
+    if (any_bits(flags, SaveDataItemFlagType::MARKED)) {
+        rd_FlagGroup_bytes(o_ptr->marked, rd_byte, 1);
+    }
 
     /* Object flags */
     if (loading_savefile_version_is_older_than(7)) {

--- a/src/load/old/load-v1-5-0.cpp
+++ b/src/load/old/load-v1-5-0.cpp
@@ -108,7 +108,7 @@ void rd_item_old(ItemEntity *o_ptr)
     o_ptr->ds = rd_byte();
 
     o_ptr->ident = rd_byte();
-    o_ptr->marked = rd_byte();
+    rd_FlagGroup_bytes(o_ptr->marked, rd_byte, 1);
 
     for (int i = 0, count = (h_older_than(1, 3, 0, 0) ? 3 : 4); i < count; i++) {
         auto tmp32u = rd_u32b();

--- a/src/mind/mind-mindcrafter.cpp
+++ b/src/mind/mind-mindcrafter.cpp
@@ -84,7 +84,7 @@ bool psychometry(PlayerType *player_ptr)
 
     set_bits(o_ptr->ident, IDENT_SENSE);
     o_ptr->feeling = feel;
-    set_bits(o_ptr->marked, OM_TOUCHED);
+    o_ptr->marked.set(OmType::TOUCHED);
 
     set_bits(player_ptr->update, PU_COMBINE | PU_REORDER);
     set_bits(player_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_PLAYER | PW_FLOOR_ITEM_LIST);

--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -126,7 +126,7 @@ static void move_item_to_monster(PlayerType *player_ptr, MonsterAttackPlayer *mo
         monap_ptr->o_ptr->pval -= j_ptr->pval;
     }
 
-    j_ptr->marked = OM_TOUCHED;
+    j_ptr->marked.clear().set(OmType::TOUCHED);
     j_ptr->held_m_idx = monap_ptr->m_idx;
     monap_ptr->m_ptr->hold_o_idx_list.add(player_ptr->current_floor_ptr, o_idx);
 }

--- a/src/monster-floor/monster-object.cpp
+++ b/src/monster-floor/monster-object.cpp
@@ -149,7 +149,8 @@ static void monster_pickup_object(PlayerType *player_ptr, turn_flags *turn_flags
         }
 
         excise_object_idx(player_ptr->current_floor_ptr, this_o_idx);
-        o_ptr->marked &= OM_TOUCHED;
+        // 意図としては OmType::TOUCHED を維持しつつ OmType::FOUND を消す事と思われるが一応元のロジックを維持しておく
+        o_ptr->marked &= { OmType::TOUCHED };
         o_ptr->iy = o_ptr->ix = 0;
         o_ptr->held_m_idx = m_idx;
         m_ptr->hold_o_idx_list.add(player_ptr->current_floor_ptr, this_o_idx);

--- a/src/object/object-mark-types.h
+++ b/src/object/object-mark-types.h
@@ -10,10 +10,11 @@
 
 #pragma once
 
-enum om_type {
-    OM_FOUND = 0x01, /*!< アイテムを一度でも視界に収めたことがあるか */
-    OM_NOMSG = 0x02, /* temporary flag to suppress messages */
-    OM_NO_QUERY = 0x04, /* Query for auto-pick was already answered as 'No' */
-    OM_AUTODESTROY = 0x08, /* Destroy later to avoid illegal inventry shift */
-    OM_TOUCHED = 0x10, /* Object was touched by player */
+enum class OmType {
+    FOUND = 0, /*!< アイテムを一度でも視界に収めたことがあるか */
+    SUPRESS_MESSAGE = 1, /* temporary flag to suppress messages */
+    NO_QUERY = 2, /* Query for auto-pick was already answered as 'No' */
+    AUTODESTROY = 3, /* Destroy later to avoid illegal inventry shift */
+    TOUCHED = 4, /* Object was touched by player */
+    MAX,
 };

--- a/src/player-attack/attack-chaos-effect.cpp
+++ b/src/player-attack/attack-chaos-effect.cpp
@@ -264,7 +264,7 @@ static void attack_golden_hammer(PlayerType *player_ptr, player_attack_type *pa_
     GAME_TEXT o_name[MAX_NLEN];
     describe_flavor(player_ptr, o_name, q_ptr, OD_NAME_ONLY);
     q_ptr->held_m_idx = 0;
-    q_ptr->marked = OM_TOUCHED;
+    q_ptr->marked.clear().set(OmType::TOUCHED);
     m_ptr->hold_o_idx_list.pop_front();
     msg_format(_("%sを奪った。", "You snatched %s."), o_name);
     store_item_to_inventory(player_ptr, q_ptr);

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -2752,7 +2752,7 @@ bool player_has_no_spellbooks(PlayerType *player_ptr)
     auto *floor_ptr = player_ptr->current_floor_ptr;
     for (const auto this_o_idx : floor_ptr->grid_array[player_ptr->y][player_ptr->x].o_idx_list) {
         o_ptr = &floor_ptr->o_list[this_o_idx];
-        if (o_ptr->bi_id && any_bits(o_ptr->marked, OM_FOUND) && check_book_realm(player_ptr, { o_ptr->tval, o_ptr->sval })) {
+        if (o_ptr->bi_id && o_ptr->marked.has(OmType::FOUND) && check_book_realm(player_ptr, { o_ptr->tval, o_ptr->sval })) {
             return false;
         }
     }

--- a/src/save/item-writer.cpp
+++ b/src/save/item-writer.cpp
@@ -62,7 +62,7 @@ static void write_item_flags(ItemEntity *o_ptr, BIT_FLAGS *flags)
         set_bits(*flags, SaveDataItemFlagType::IDENT);
     }
 
-    if (o_ptr->marked) {
+    if (o_ptr->marked.any()) {
         set_bits(*flags, SaveDataItemFlagType::MARKED);
     }
 
@@ -169,7 +169,7 @@ static void write_item_info(ItemEntity *o_ptr, const BIT_FLAGS flags)
     }
 
     if (any_bits(flags, SaveDataItemFlagType::MARKED)) {
-        wr_byte(o_ptr->marked);
+        wr_FlagGroup_bytes(o_ptr->marked, wr_byte, 1);
     }
 
     if (any_bits(flags, SaveDataItemFlagType::ART_FLAGS)) {

--- a/src/spell-kind/spells-detection.cpp
+++ b/src/spell-kind/spells-detection.cpp
@@ -200,7 +200,7 @@ bool detect_objects_gold(PlayerType *player_ptr, POSITION range)
         }
 
         if (o_ptr->tval == ItemKindType::GOLD) {
-            o_ptr->marked |= OM_FOUND;
+            o_ptr->marked.set(OmType::FOUND);
             lite_spot(player_ptr, y, x);
             detect = true;
         }
@@ -252,7 +252,7 @@ bool detect_objects_normal(PlayerType *player_ptr, POSITION range)
         }
 
         if (o_ptr->tval != ItemKindType::GOLD) {
-            o_ptr->marked |= OM_FOUND;
+            o_ptr->marked.set(OmType::FOUND);
             lite_spot(player_ptr, y, x);
             detect = true;
         }
@@ -313,7 +313,7 @@ bool detect_objects_magic(PlayerType *player_ptr, POSITION range)
 
         tv = o_ptr->tval;
         if (o_ptr->is_artifact() || o_ptr->is_ego() || (tv == ItemKindType::WHISTLE) || (tv == ItemKindType::AMULET) || (tv == ItemKindType::RING) || (tv == ItemKindType::STAFF) || (tv == ItemKindType::WAND) || (tv == ItemKindType::ROD) || (tv == ItemKindType::SCROLL) || (tv == ItemKindType::POTION) || (tv == ItemKindType::LIFE_BOOK) || (tv == ItemKindType::SORCERY_BOOK) || (tv == ItemKindType::NATURE_BOOK) || (tv == ItemKindType::CHAOS_BOOK) || (tv == ItemKindType::DEATH_BOOK) || (tv == ItemKindType::TRUMP_BOOK) || (tv == ItemKindType::ARCANE_BOOK) || (tv == ItemKindType::CRAFT_BOOK) || (tv == ItemKindType::DEMON_BOOK) || (tv == ItemKindType::CRUSADE_BOOK) || (tv == ItemKindType::MUSIC_BOOK) || (tv == ItemKindType::HISSATSU_BOOK) || (tv == ItemKindType::HEX_BOOK) || ((o_ptr->to_a > 0) || (o_ptr->to_h + o_ptr->to_d > 0))) {
-            o_ptr->marked |= OM_FOUND;
+            o_ptr->marked.set(OmType::FOUND);
             lite_spot(player_ptr, y, x);
             detect = true;
         }

--- a/src/spell-kind/spells-enchant.cpp
+++ b/src/spell-kind/spells-enchant.cpp
@@ -141,7 +141,7 @@ bool mundane_spell(PlayerType *player_ptr, bool only_equip)
     msg_print(_("まばゆい閃光が走った！", "There is a bright flash of light!"));
     POSITION iy = o_ptr->iy;
     POSITION ix = o_ptr->ix;
-    byte marked = o_ptr->marked;
+    auto marked = o_ptr->marked;
     uint16_t inscription = o_ptr->inscription;
 
     o_ptr->prep(o_ptr->bi_id);

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -72,7 +72,7 @@ void wiz_lite(PlayerType *player_ptr, bool ninja)
         if (o_ptr->is_held_by_monster()) {
             continue;
         }
-        o_ptr->marked |= OM_FOUND;
+        o_ptr->marked.set(OmType::FOUND);
     }
 
     /* Scan all normal grids */
@@ -170,7 +170,8 @@ void wiz_dark(PlayerType *player_ptr)
         }
 
         /* Forget the object */
-        o_ptr->marked &= OM_TOUCHED;
+        // 意図としては OmType::TOUCHED を維持しつつ OmType::FOUND を消す事と思われるが一応元のロジックを維持しておく
+        o_ptr->marked &= { OmType::TOUCHED };
     }
 
     /* Forget travel route when we have forgotten map */

--- a/src/spell-kind/spells-perception.cpp
+++ b/src/spell-kind/spells-perception.cpp
@@ -73,7 +73,7 @@ bool identify_item(PlayerType *player_ptr, ItemEntity *o_ptr)
 
     object_aware(player_ptr, o_ptr);
     object_known(o_ptr);
-    set_bits(o_ptr->marked, OM_TOUCHED);
+    o_ptr->marked.set(OmType::TOUCHED);
 
     set_bits(player_ptr->update, PU_BONUS | PU_COMBINE | PU_REORDER);
     set_bits(player_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_PLAYER | PW_FLOOR_ITEM_LIST);

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -10,6 +10,7 @@
 #include "object-enchant/object-ego.h"
 #include "object-enchant/tr-flags.h"
 #include "object-enchant/trc-types.h"
+#include "object/object-mark-types.h"
 #include "system/angband.h"
 #include "system/system-variables.h"
 #include "util/flag-group.h"
@@ -58,7 +59,7 @@ public:
     DICE_SID ds{}; /*!< Damage dice/sides */
     TIME_EFFECT timeout{}; /*!< Timeout Counter */
     byte ident{}; /*!< Special flags  */
-    byte marked{}; /*!< Object is marked */
+    EnumClassFlagGroup<OmType> marked{}; /*!< Object is marked */
     uint16_t inscription{}; /*!< Inscription index */
     uint16_t art_name{}; /*!< Artifact name (random artifacts) */
     byte feeling{}; /*!< Game generated inscription number (eg, pseudo-id) */

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -410,7 +410,7 @@ static int16_t loop_describing_grid(PlayerType *player_ptr, eg_type *eg_ptr)
 
 static int16_t describe_footing_sight(PlayerType *player_ptr, eg_type *eg_ptr, ItemEntity *o_ptr)
 {
-    if ((o_ptr->marked & OM_FOUND) == 0) {
+    if (o_ptr->marked.has_not(OmType::FOUND)) {
         return CONTINUOUS_DESCRIPTION;
     }
 

--- a/src/target/target-preparation.cpp
+++ b/src/target/target-preparation.cpp
@@ -97,7 +97,7 @@ static bool target_set_accept(PlayerType *player_ptr, POSITION y, POSITION x)
     for (const auto this_o_idx : g_ptr->o_idx_list) {
         ItemEntity *o_ptr;
         o_ptr = &floor_ptr->o_list[this_o_idx];
-        if (o_ptr->marked & OM_FOUND) {
+        if (o_ptr->marked.has(OmType::FOUND)) {
             return true;
         }
     }

--- a/src/view/display-map.cpp
+++ b/src/view/display-map.cpp
@@ -263,7 +263,7 @@ void map_info(PlayerType *player_ptr, POSITION y, POSITION x, TERM_COLOR *ap, ch
     for (const auto this_o_idx : g_ptr->o_idx_list) {
         ItemEntity *o_ptr;
         o_ptr = &floor_ptr->o_list[this_o_idx];
-        if (!(o_ptr->marked & OM_FOUND)) {
+        if (o_ptr->marked.has_not(OmType::FOUND)) {
             continue;
         }
 

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -619,7 +619,7 @@ static void display_floor_item_list(PlayerType *player_ptr, const int y, const i
         ItemEntity *const o_ptr = &floor_ptr->o_list[o_idx];
 
         // 未発見アイテムおよび金は対象外。
-        if (none_bits(o_ptr->marked, OM_FOUND) || o_ptr->tval == ItemKindType::GOLD) {
+        if (o_ptr->marked.has_not(OmType::FOUND) || o_ptr->tval == ItemKindType::GOLD) {
             continue;
         }
 

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -228,7 +228,7 @@ void wiz_identify_full_inventory(PlayerType *player_ptr)
         auto k_ptr = &baseitems_info[o_ptr->bi_id];
         k_ptr->aware = true; //!< @note 記録には残さないためTRUEを立てるのみ
         set_bits(o_ptr->ident, IDENT_KNOWN | IDENT_FULL_KNOWN);
-        set_bits(o_ptr->marked, OM_TOUCHED);
+        o_ptr->marked.set(OmType::TOUCHED);
     }
 
     /* Refrect item informaiton onto subwindows without updating inventory */


### PR DESCRIPTION
FlagGroup を固定バイト長でセーブファイルに読み書きする関数 rd_FlagGroup_bytes と wr_FlagGroup_bytes を追加する。
既存のビット集合型の読み書きをこれらの関数に置き換えることでセーブファイルの互換性を維持しつつビット集合変数を FlagGroup に置き換えることが可能となる。

移行の実例として、https://github.com/hengband/hengband/issues/2802#issuecomment-1315018222 であった ItemEntity::marked を FlagGroup にするコミットも追加しています。

ところで、marked を FlagGroup に移行する際に2箇所ほど
```c++
o_ptr->marked &= OM_TOUCHED
```
としている箇所があったのですが、コードの流れ的にどうみても
```c++
o_ptr->marked &= ~OM_TOUCHED
```
と OM_TOUCHED のビットを落とす処理と誤っているのではないかと思えたので、修正前のロジックと変わりますが FlagGroup::reset を呼ぶようにしています。開発者諸氏の意見を伺いたく。
