### PR TITLE
ItemEntity::tval/sval をBaseitemKey に差し替えるための準備をした その2

### DIFF
--- a/src/artifact/random-art-pval-investor.cpp
+++ b/src/artifact/random-art-pval-investor.cpp
@@ -156,7 +156,7 @@ void random_plus(ItemEntity *o_ptr)
         return;
     }
 
-    int this_type = o_ptr->is_weapon_ammo() ? 23 : 19;
+    const auto this_type = o_ptr->is_weapon_ammo() ? 23 : 19;
     switch (randint1(this_type)) {
     case 1:
     case 2:

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -204,7 +204,7 @@ bool exe_eat_charge_of_magic_device(PlayerType *player_ptr, ItemEntity *o_ptr, I
         }
 
         if (item >= 0) {
-            inven_item_charges(player_ptr, item);
+            inven_item_charges(player_ptr->inventory_list[item]);
         } else {
             floor_item_charges(player_ptr->current_floor_ptr, 0 - item);
         }

--- a/src/object-enchant/weapon/abstract-weapon-enchanter.cpp
+++ b/src/object-enchant/weapon/abstract-weapon-enchanter.cpp
@@ -32,7 +32,7 @@ void AbstractWeaponEnchanter::give_killing_bonus()
     auto tohit2 = static_cast<short>(m_bonus(10, this->level));
     auto todam2 = static_cast<short>(m_bonus(10, this->level));
 
-    if ((this->o_ptr->tval == ItemKindType::BOLT) || (this->o_ptr->tval == ItemKindType::ARROW) || (this->o_ptr->tval == ItemKindType::SHOT)) {
+    if (this->o_ptr->is_ammo()) {
         tohit2 = (tohit2 + 1) / 2;
         todam2 = (todam2 + 1) / 2;
     }

--- a/src/object-hook/hook-weapon.cpp
+++ b/src/object-hook/hook-weapon.cpp
@@ -16,8 +16,7 @@
  */
 bool object_is_favorite(PlayerType *player_ptr, const ItemEntity *o_ptr)
 {
-    /* Only melee weapons match */
-    if (!(o_ptr->tval == ItemKindType::POLEARM || o_ptr->tval == ItemKindType::SWORD || o_ptr->tval == ItemKindType::DIGGING || o_ptr->tval == ItemKindType::HAFTED)) {
+    if (!o_ptr->is_melee_weapon()) {
         return false;
     }
 

--- a/src/object-use/use-execution.cpp
+++ b/src/object-use/use-execution.cpp
@@ -136,7 +136,7 @@ void ObjectUseEntity::execute()
     }
 
     if (this->item >= 0) {
-        inven_item_charges(this->player_ptr, this->item);
+        inven_item_charges(this->player_ptr->inventory_list[this->item]);
     } else {
         floor_item_charges(this->player_ptr->current_floor_ptr, 0 - this->item);
     }

--- a/src/object-use/zapwand-execution.cpp
+++ b/src/object-use/zapwand-execution.cpp
@@ -125,7 +125,7 @@ void ObjectZapWandEntity::execute(INVENTORY_IDX item)
     set_bits(this->player_ptr->update, inventory_flags);
     o_ptr->pval--;
     if (item >= 0) {
-        inven_item_charges(this->player_ptr, item);
+        inven_item_charges(this->player_ptr->inventory_list[item]);
         return;
     }
 

--- a/src/object/tval-types.h
+++ b/src/object/tval-types.h
@@ -76,8 +76,6 @@ enum class ItemKindType : short {
 
 #define TV_EQUIP_BEGIN ItemKindType::SHOT
 #define TV_EQUIP_END ItemKindType::CARD
-#define TV_MISSILE_BEGIN ItemKindType::SHOT
-#define TV_MISSILE_END ItemKindType::BOLT
 #define TV_WEARABLE_BEGIN ItemKindType::BOW
 #define TV_WEARABLE_END ItemKindType::CARD
 #define TV_WEAPON_BEGIN ItemKindType::BOW

--- a/src/perception/object-perception.cpp
+++ b/src/perception/object-perception.cpp
@@ -62,8 +62,7 @@ void object_aware(PlayerType *player_ptr, const ItemEntity *o_ptr)
         return;
     }
 
-    // 未鑑定名の無いアイテムは記録しない
-    if (!((o_ptr->tval >= ItemKindType::AMULET && o_ptr->tval <= ItemKindType::POTION) || o_ptr->tval == ItemKindType::FOOD)) {
+    if (!o_ptr->has_unidentified_name()) {
         return;
     }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -333,8 +333,7 @@ static void update_bonuses(PlayerType *player_ptr)
     update_ability_scores(player_ptr);
     o_ptr = &player_ptr->inventory_list[INVEN_BOW];
     if (o_ptr->bi_id) {
-        const BaseitemKey key(o_ptr->tval, o_ptr->sval);
-        player_ptr->tval_ammo = key.get_arrow_kind();
+        player_ptr->tval_ammo = o_ptr->get_arrow_kind();
         player_ptr->num_fire = calc_num_fire(player_ptr, o_ptr);
     }
 
@@ -1048,8 +1047,7 @@ int16_t calc_num_fire(PlayerType *player_ptr, ItemEntity *o_ptr)
         return (int16_t)num;
     }
 
-    const BaseitemKey key(o_ptr->tval, o_ptr->sval);
-    const auto tval_ammo = key.get_arrow_kind();
+    const auto tval_ammo = o_ptr->get_arrow_kind();
     PlayerClass pc(player_ptr);
     if (pc.equals(PlayerClassType::RANGER) && (tval_ammo == ItemKindType::ARROW)) {
         num += (player_ptr->lev * 4);

--- a/src/smith/object-smith.cpp
+++ b/src/smith/object-smith.cpp
@@ -167,7 +167,7 @@ int Smith::get_essence_consumption(SmithEffectType effect, const ItemEntity *o_p
         return consumption;
     }
 
-    if ((o_ptr->tval >= ItemKindType::SHOT) && (o_ptr->tval <= ItemKindType::BOLT)) {
+    if (o_ptr->is_ammo()) {
         consumption = (consumption + 9) / 10;
     }
 

--- a/src/system/baseitem-info.cpp
+++ b/src/system/baseitem-info.cpp
@@ -126,6 +126,18 @@ bool BaseitemKey::is_melee_weapon() const
     }
 }
 
+bool BaseitemKey::is_ammo() const
+{
+    switch (this->type_value) {
+    case ItemKindType::SHOT:
+    case ItemKindType::ARROW:
+    case ItemKindType::BOLT:
+        return true;
+    default:
+        return false;
+    }
+}
+
 BaseitemInfo::BaseitemInfo()
     : bi_key(ItemKindType::NONE)
 {

--- a/src/system/baseitem-info.cpp
+++ b/src/system/baseitem-info.cpp
@@ -113,6 +113,19 @@ bool BaseitemKey::is_high_level_book() const
     return this->subtype_value >= 2;
 }
 
+bool BaseitemKey::is_melee_weapon() const
+{
+    switch (this->type_value) {
+    case ItemKindType::POLEARM:
+    case ItemKindType::SWORD:
+    case ItemKindType::DIGGING:
+    case ItemKindType::HAFTED:
+        return true;
+    default:
+        return false;
+    }
+}
+
 BaseitemInfo::BaseitemInfo()
     : bi_key(ItemKindType::NONE)
 {

--- a/src/system/baseitem-info.cpp
+++ b/src/system/baseitem-info.cpp
@@ -10,6 +10,7 @@
 #include "system/baseitem-info.h"
 #include "object/tval-types.h"
 #include "sv-definition/sv-bow-types.h"
+#include "sv-definition/sv-food-types.h"
 
 BaseitemKey::BaseitemKey(const ItemKindType type_value, const std::optional<int> &subtype_value)
     : type_value(type_value)
@@ -132,6 +133,61 @@ bool BaseitemKey::is_ammo() const
     case ItemKindType::SHOT:
     case ItemKindType::ARROW:
     case ItemKindType::BOLT:
+        return true;
+    default:
+        return false;
+    }
+}
+
+/*
+ * @brief 未鑑定名を持つか否かの判定
+ * @details FOODはキノコが該当する
+ */
+bool BaseitemKey::has_unidentified_name() const
+{
+    switch (this->type_value) {
+    case ItemKindType::AMULET:
+    case ItemKindType::RING:
+    case ItemKindType::STAFF:
+    case ItemKindType::WAND:
+    case ItemKindType::ROD:
+    case ItemKindType::SCROLL:
+    case ItemKindType::POTION:
+        return true;
+    case ItemKindType::FOOD:
+        return this->is_mushrooms();
+    default:
+        return false;
+    }
+}
+
+bool BaseitemKey::is_mushrooms() const
+{
+    if (!this->subtype_value.has_value()) {
+        return false;
+    }
+
+    switch (this->subtype_value.value()) {
+    case SV_FOOD_POISON:
+    case SV_FOOD_BLINDNESS:
+    case SV_FOOD_PARANOIA:
+    case SV_FOOD_CONFUSION:
+    case SV_FOOD_HALLUCINATION:
+    case SV_FOOD_PARALYSIS:
+    case SV_FOOD_WEAKNESS:
+    case SV_FOOD_SICKNESS:
+    case SV_FOOD_STUPIDITY:
+    case SV_FOOD_NAIVETY:
+    case SV_FOOD_UNHEALTH:
+    case SV_FOOD_DISEASE:
+    case SV_FOOD_CURE_POISON:
+    case SV_FOOD_CURE_BLINDNESS:
+    case SV_FOOD_CURE_PARANOIA:
+    case SV_FOOD_CURE_CONFUSION:
+    case SV_FOOD_CURE_SERIOUS:
+    case SV_FOOD_RESTORE_STR:
+    case SV_FOOD_RESTORE_CON:
+    case SV_FOOD_RESTORING:
         return true;
     default:
         return false;

--- a/src/system/baseitem-info.h
+++ b/src/system/baseitem-info.h
@@ -40,6 +40,7 @@ public:
     ItemKindType get_arrow_kind() const;
     bool is_spell_book() const;
     bool is_high_level_book() const;
+    bool is_melee_weapon() const;
 
 private:
     ItemKindType type_value;

--- a/src/system/baseitem-info.h
+++ b/src/system/baseitem-info.h
@@ -41,6 +41,7 @@ public:
     bool is_spell_book() const;
     bool is_high_level_book() const;
     bool is_melee_weapon() const;
+    bool is_ammo() const;
 
 private:
     ItemKindType type_value;

--- a/src/system/baseitem-info.h
+++ b/src/system/baseitem-info.h
@@ -42,10 +42,13 @@ public:
     bool is_high_level_book() const;
     bool is_melee_weapon() const;
     bool is_ammo() const;
+    bool has_unidentified_name() const;
 
 private:
     ItemKindType type_value;
     std::optional<int> subtype_value;
+
+    bool is_mushrooms() const;
 };
 
 enum class ItemKindType : short;

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -812,3 +812,8 @@ bool ItemEntity::has_unidentified_name() const
 {
     return BaseitemKey(this->tval).has_unidentified_name();
 }
+
+ItemKindType ItemEntity::get_arrow_kind() const
+{
+    return BaseitemKey(this->tval, this->sval).get_arrow_kind();
+}

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -141,7 +141,7 @@ bool ItemEntity::is_weapon_armour_ammo() const
  */
 bool ItemEntity::is_melee_weapon() const
 {
-    return (ItemKindType::DIGGING <= this->tval) && (this->tval <= ItemKindType::SWORD);
+    return BaseitemKey(this->tval).is_melee_weapon();
 }
 
 /*!

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -807,3 +807,8 @@ bool ItemEntity::is_specific_artifact(FixedArtifactId id) const
 {
     return this->fixed_artifact_idx == id;
 }
+
+bool ItemEntity::has_unidentified_name() const
+{
+    return BaseitemKey(this->tval).has_unidentified_name();
+}

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -117,13 +117,12 @@ bool ItemEntity::is_weapon() const
 }
 
 /*!
- * @brief アイテムが武器や矢弾として使用できるかを返す / Check if an object is weapon (including bows and ammo)
- * Rare weapons/aromors including Blade of Chaos, Dragon armors, etc.
+ * @brief アイテムが武器や矢弾として使用できるかを返す
  * @return 武器や矢弾として使えるならばtrueを返す
  */
 bool ItemEntity::is_weapon_ammo() const
 {
-    return (TV_MISSILE_BEGIN <= this->tval) && (this->tval <= TV_WEAPON_END);
+    return this->is_weapon() || this->is_ammo();
 }
 
 /*!
@@ -302,7 +301,7 @@ bool ItemEntity::allow_two_hands_wielding() const
  */
 bool ItemEntity::is_ammo() const
 {
-    return (TV_MISSILE_BEGIN <= this->tval) && (this->tval <= TV_MISSILE_END);
+    return BaseitemKey(this->tval).is_ammo();
 }
 
 /*!

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -122,6 +122,7 @@ public:
     int get_price() const;
     bool is_specific_artifact(FixedArtifactId id) const;
     bool has_unidentified_name() const;
+    ItemKindType get_arrow_kind() const;
 
 private:
     int get_baseitem_price() const;

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -121,6 +121,7 @@ public:
     char get_symbol() const;
     int get_price() const;
     bool is_specific_artifact(FixedArtifactId id) const;
+    bool has_unidentified_name() const;
 
 private:
     int get_baseitem_price() const;

--- a/src/util/object-sort.cpp
+++ b/src/util/object-sort.cpp
@@ -14,6 +14,23 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 
+static int get_item_sort_rank(const ItemEntity &item)
+{
+    if (item.is_fixed_artifact()) {
+        return 3;
+    }
+
+    if (item.art_name) {
+        return 2;
+    }
+
+    if (item.is_ego()) {
+        return 1;
+    }
+
+    return 0;
+}
+
 /*!
  * @brief オブジェクトを定義された基準に従いソートするための関数 /
  * Check if we have space for an item in the pack without overflow
@@ -24,7 +41,6 @@
  */
 bool object_sort_comp(PlayerType *player_ptr, ItemEntity *o_ptr, int32_t o_value, ItemEntity *j_ptr)
 {
-    int o_type, j_type;
     if (!j_ptr->bi_id) {
         return true;
     }
@@ -71,30 +87,12 @@ bool object_sort_comp(PlayerType *player_ptr, ItemEntity *o_ptr, int32_t o_value
         return true;
     }
 
-    if (o_ptr->is_fixed_artifact()) {
-        o_type = 3;
-    } else if (o_ptr->art_name) {
-        o_type = 2;
-    } else if (o_ptr->is_ego()) {
-        o_type = 1;
-    } else {
-        o_type = 0;
-    }
-
-    if (j_ptr->is_fixed_artifact()) {
-        j_type = 3;
-    } else if (j_ptr->art_name) {
-        j_type = 2;
-    } else if (j_ptr->is_ego()) {
-        j_type = 1;
-    } else {
-        j_type = 0;
-    }
-
-    if (o_type < j_type) {
+    const auto o_rank = get_item_sort_rank(*o_ptr);
+    const auto j_rank = get_item_sort_rank(*j_ptr);
+    if (o_rank < j_rank) {
         return true;
     }
-    if (o_type > j_type) {
+    if (o_rank > j_rank) {
         return false;
     }
 

--- a/src/util/object-sort.cpp
+++ b/src/util/object-sort.cpp
@@ -41,48 +41,58 @@ static int get_item_sort_rank(const ItemEntity &item)
  */
 bool object_sort_comp(PlayerType *player_ptr, ItemEntity *o_ptr, int32_t o_value, ItemEntity *j_ptr)
 {
-    if (!j_ptr->bi_id) {
+    if (j_ptr->bi_id == 0) {
         return true;
     }
 
-    if ((o_ptr->tval == get_realm1_book(player_ptr)) && (j_ptr->tval != get_realm1_book(player_ptr))) {
+    const auto o_tval = o_ptr->tval;
+    const auto j_tval = j_ptr->tval;
+    if ((o_tval == get_realm1_book(player_ptr)) && (j_tval != get_realm1_book(player_ptr))) {
         return true;
     }
-    if ((j_ptr->tval == get_realm1_book(player_ptr)) && (o_ptr->tval != get_realm1_book(player_ptr))) {
+
+    if ((j_tval == get_realm1_book(player_ptr)) && (o_tval != get_realm1_book(player_ptr))) {
         return false;
     }
 
-    if ((o_ptr->tval == get_realm2_book(player_ptr)) && (j_ptr->tval != get_realm2_book(player_ptr))) {
+    if ((o_tval == get_realm2_book(player_ptr)) && (j_tval != get_realm2_book(player_ptr))) {
         return true;
     }
-    if ((j_ptr->tval == get_realm2_book(player_ptr)) && (o_ptr->tval != get_realm2_book(player_ptr))) {
+
+    if ((j_tval == get_realm2_book(player_ptr)) && (o_tval != get_realm2_book(player_ptr))) {
         return false;
     }
 
-    if (o_ptr->tval > j_ptr->tval) {
+    if (o_tval > j_tval) {
         return true;
     }
-    if (o_ptr->tval < j_ptr->tval) {
+
+    if (o_tval < j_tval) {
         return false;
     }
 
     if (!o_ptr->is_aware()) {
         return false;
     }
+
     if (!j_ptr->is_aware()) {
         return true;
     }
 
-    if (o_ptr->sval < j_ptr->sval) {
+    const auto o_sval = o_ptr->sval;
+    const auto j_sval = j_ptr->sval;
+    if (o_sval < j_sval) {
         return true;
     }
-    if (o_ptr->sval > j_ptr->sval) {
+
+    if (o_sval > j_sval) {
         return false;
     }
 
     if (!o_ptr->is_known()) {
         return false;
     }
+
     if (!j_ptr->is_known()) {
         return true;
     }
@@ -92,11 +102,12 @@ bool object_sort_comp(PlayerType *player_ptr, ItemEntity *o_ptr, int32_t o_value
     if (o_rank < j_rank) {
         return true;
     }
+
     if (o_rank > j_rank) {
         return false;
     }
 
-    switch (o_ptr->tval) {
+    switch (o_tval) {
     case ItemKindType::FIGURINE:
     case ItemKindType::STATUE:
     case ItemKindType::CORPSE:
@@ -106,32 +117,35 @@ bool object_sort_comp(PlayerType *player_ptr, ItemEntity *o_ptr, int32_t o_value
         if (monraces_info[o_r_idx].level < monraces_info[j_r_idx].level) {
             return true;
         }
+
         if ((monraces_info[o_r_idx].level == monraces_info[j_r_idx].level) && (o_ptr->pval < j_ptr->pval)) {
             return true;
         }
+
         return false;
     }
-
     case ItemKindType::SHOT:
     case ItemKindType::ARROW:
     case ItemKindType::BOLT:
         if (o_ptr->to_h + o_ptr->to_d < j_ptr->to_h + j_ptr->to_d) {
             return true;
         }
+
         if (o_ptr->to_h + o_ptr->to_d > j_ptr->to_h + j_ptr->to_d) {
             return false;
         }
-        break;
 
+        break;
     case ItemKindType::ROD:
         if (o_ptr->pval < j_ptr->pval) {
             return true;
         }
+
         if (o_ptr->pval > j_ptr->pval) {
             return false;
         }
-        break;
 
+        break;
     default:
         break;
     }

--- a/src/view/object-describer.cpp
+++ b/src/view/object-describer.cpp
@@ -14,34 +14,31 @@
 #include "view/display-messages.h"
 
 /*!
- * @brief 魔道具の使用回数の残量を示すメッセージを表示する /
- * Describe the charges on an item in the inventory.
- * @param player_ptr プレイヤーへの参照ポインタ
- * @param item 残量を表示したいプレイヤーのアイテム所持スロット
+ * @brief 魔道具の使用回数の残量を示すメッセージを表示する
+ * @param item 残量を表示したいインベントリ内のアイテム
  */
-void inven_item_charges(PlayerType *player_ptr, INVENTORY_IDX item)
+void inven_item_charges(const ItemEntity &item)
 {
-    auto *o_ptr = &player_ptr->inventory_list[item];
-    if ((o_ptr->tval != ItemKindType::STAFF) && (o_ptr->tval != ItemKindType::WAND)) {
+    const auto tval = item.tval;
+    if ((tval != ItemKindType::STAFF) && (tval != ItemKindType::WAND)) {
         return;
     }
-    if (!o_ptr->is_known()) {
+
+    if (!item.is_known()) {
         return;
     }
 
 #ifdef JP
-    if (o_ptr->pval <= 0) {
+    if (item.pval <= 0) {
         msg_print("もう魔力が残っていない。");
     } else {
-        msg_format("あと %d 回分の魔力が残っている。", o_ptr->pval);
+        msg_format("あと %d 回分の魔力が残っている。", item.pval);
     }
 #else
-    if (o_ptr->pval != 1) {
-        msg_format("You have %d charges remaining.", o_ptr->pval);
-    }
-
-    else {
-        msg_format("You have %d charge remaining.", o_ptr->pval);
+    if (item.pval != 1) {
+        msg_format("You have %d charges remaining.", item.pval);
+    } else {
+        msg_format("You have %d charge remaining.", item.pval);
     }
 #endif
 }
@@ -52,7 +49,7 @@ void inven_item_charges(PlayerType *player_ptr, INVENTORY_IDX item)
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param item 残量を表示したいプレイヤーのアイテム所持スロット
  */
-void inven_item_describe(PlayerType *player_ptr, INVENTORY_IDX item)
+void inven_item_describe(PlayerType *player_ptr, short item)
 {
     auto *o_ptr = &player_ptr->inventory_list[item];
     GAME_TEXT o_name[MAX_NLEN];

--- a/src/view/object-describer.h
+++ b/src/view/object-describer.h
@@ -1,8 +1,7 @@
 ﻿#pragma once
 
-#include "system/angband.h"
-
+class ItemEntity;
 class PlayerType;
-void inven_item_charges(PlayerType *player_ptr, INVENTORY_IDX item);
-void inven_item_describe(PlayerType *player_ptr, INVENTORY_IDX item);
+void inven_item_charges(const ItemEntity &item);
+void inven_item_describe(PlayerType *player_ptr, short item);
 void display_koff(PlayerType *player_ptr, short bi_id);


### PR DESCRIPTION
掲題の通りです
ItemEntity のオブジェクトメソッドをBaseitemKey のオブジェクトメソッドにリダイレクトした他、本体作業のための最適化を複数図りました
ロジック変更も複数あります
ご確認下さい