### PR TITLE
ItemEntity::tval/sval をBaseitemKey に差し替えるための準備をした その3

### DIFF
--- a/src/artifact/random-art-generator.cpp
+++ b/src/artifact/random-art-generator.cpp
@@ -275,7 +275,7 @@ static void strengthen_pval(ItemEntity *o_ptr)
  */
 static void invest_positive_modified_value(ItemEntity *o_ptr)
 {
-    if (o_ptr->is_armour()) {
+    if (o_ptr->is_protector()) {
         o_ptr->to_a += randint1(o_ptr->to_a > 19 ? 1 : 20 - o_ptr->to_a);
         return;
     }
@@ -298,7 +298,7 @@ static void invest_positive_modified_value(ItemEntity *o_ptr)
  */
 static void invest_negative_modified_value(ItemEntity *o_ptr)
 {
-    if (!o_ptr->is_armour()) {
+    if (!o_ptr->is_protector()) {
         return;
     }
 
@@ -385,7 +385,7 @@ static int decide_random_art_power_level(ItemEntity *o_ptr, const bool a_cursed,
 static void name_unnatural_random_artifact(PlayerType *player_ptr, ItemEntity *o_ptr, const bool a_scroll, const int power_level, GAME_TEXT *new_name)
 {
     if (!a_scroll) {
-        get_random_name(o_ptr, new_name, o_ptr->is_armour(), power_level);
+        get_random_name(o_ptr, new_name, o_ptr->is_protector(), power_level);
         return;
     }
 
@@ -460,7 +460,7 @@ bool become_random_artifact(PlayerType *player_ptr, ItemEntity *o_ptr, bool a_sc
     }
 
     constexpr auto activation_chance = 3;
-    if (!a_cursed && one_in_(o_ptr->is_armour() ? activation_chance * 2 : activation_chance)) {
+    if (!a_cursed && one_in_(o_ptr->is_protector() ? activation_chance * 2 : activation_chance)) {
         o_ptr->activation_id = RandomArtActType::NONE;
         give_activation_power(o_ptr);
     }

--- a/src/artifact/random-art-misc.cpp
+++ b/src/artifact/random-art-misc.cpp
@@ -358,7 +358,7 @@ void random_misc(PlayerType *player_ptr, ItemEntity *o_ptr)
     case 24:
     case 25:
     case 26:
-        if (o_ptr->is_armour()) {
+        if (o_ptr->is_protector()) {
             random_misc(player_ptr, o_ptr);
         } else {
             o_ptr->to_a = 4 + randint1(11);

--- a/src/artifact/random-art-resistance.cpp
+++ b/src/artifact/random-art-resistance.cpp
@@ -12,14 +12,13 @@
 
 /*!
  * @brief オーラフラグを付与する
- *
  * @param o_ptr フラグを付与するオブジェクト構造体へのポインタ
  * @param tr_sh_flag 付与するフラグ (TR_SH_*)
  * @return 続くフラグ付与の処理を打ち切る場合 true を返す
  */
 static bool random_art_aura(ItemEntity *o_ptr, tr_type tr_sh_flag)
 {
-    if ((o_ptr->tval < ItemKindType::CLOAK) || (o_ptr->tval > ItemKindType::HARD_ARMOR) || o_ptr->art_flags.has(tr_sh_flag)) {
+    if (!o_ptr->can_be_aura_protector() || o_ptr->art_flags.has(tr_sh_flag)) {
         return false;
     }
 

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -469,7 +469,7 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, It
 
     if (o_ptr->is_ammo()) {
         ADD_FLG(FLG_MISSILES);
-    } else if (o_ptr->tval == ItemKindType::SCROLL || o_ptr->tval == ItemKindType::STAFF || o_ptr->tval == ItemKindType::WAND || o_ptr->tval == ItemKindType::ROD) {
+    } else if (o_ptr->tval == ItemKindType::SCROLL || o_ptr->tval == ItemKindType::STAFF || o_ptr->is_wand_rod()) {
         ADD_FLG(FLG_DEVICES);
     } else if (o_ptr->tval == ItemKindType::LITE) {
         ADD_FLG(FLG_LIGHTS);

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -469,7 +469,7 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, It
 
     if (o_ptr->is_ammo()) {
         ADD_FLG(FLG_MISSILES);
-    } else if (o_ptr->tval == ItemKindType::SCROLL || o_ptr->tval == ItemKindType::STAFF || o_ptr->is_wand_rod()) {
+    } else if (o_ptr->tval == ItemKindType::SCROLL || o_ptr->is_wand_staff() || o_ptr->is_wand_rod()) {
         ADD_FLG(FLG_DEVICES);
     } else if (o_ptr->tval == ItemKindType::LITE) {
         ADD_FLG(FLG_LIGHTS);

--- a/src/autopick/autopick-matcher.cpp
+++ b/src/autopick/autopick-matcher.cpp
@@ -248,7 +248,7 @@ bool is_autopick_match(PlayerType *player_ptr, ItemEntity *o_ptr, autopick_type 
             return false;
         }
     } else if (IS_FLG(FLG_ARMORS)) {
-        if (!o_ptr->is_armour()) {
+        if (!o_ptr->is_protector()) {
             return false;
         }
     } else if (IS_FLG(FLG_MISSILES)) {

--- a/src/cmd-building/cmd-building.cpp
+++ b/src/cmd-building/cmd-building.cpp
@@ -168,7 +168,7 @@ static void bldg_process_command(PlayerType *player_ptr, building_type *bldg, in
         enchant_item(player_ptr, bcost, 1, 1, 0, FuncItemTester(&ItemEntity::allow_enchant_melee_weapon));
         break;
     case BACT_ENCHANT_ARMOR:
-        enchant_item(player_ptr, bcost, 0, 0, 1, FuncItemTester(&ItemEntity::is_armour));
+        enchant_item(player_ptr, bcost, 0, 0, 1, FuncItemTester(&ItemEntity::is_protector));
         break;
     case BACT_RECHARGE:
         building_recharge(player_ptr);

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -153,7 +153,7 @@ bool exe_eat_food_type_object(PlayerType *player_ptr, ItemEntity *o_ptr)
  */
 bool exe_eat_charge_of_magic_device(PlayerType *player_ptr, ItemEntity *o_ptr, INVENTORY_IDX item)
 {
-    if (o_ptr->tval != ItemKindType::STAFF && o_ptr->tval != ItemKindType::WAND) {
+    if (!o_ptr->is_wand_staff()) {
         return false;
     }
 

--- a/src/combat/aura-counterattack.cpp
+++ b/src/combat/aura-counterattack.cpp
@@ -243,7 +243,7 @@ static void aura_shadow_by_monster_attack(PlayerType *player_ptr, MonsterAttackP
     /* Some cursed armours gives an extra effect */
     for (int j = 0; j < TABLE_SIZE; j++) {
         o_armed_ptr = &player_ptr->inventory_list[table[j].slot];
-        if ((o_armed_ptr->bi_id) && o_armed_ptr->is_cursed() && o_armed_ptr->is_armour()) {
+        if ((o_armed_ptr->bi_id) && o_armed_ptr->is_cursed() && o_armed_ptr->is_protector()) {
             project(player_ptr, 0, 0, monap_ptr->m_ptr->fy, monap_ptr->m_ptr->fx, (player_ptr->lev * 2), table[j].type, flg);
         }
     }

--- a/src/flavor/flavor-describer.cpp
+++ b/src/flavor/flavor-describer.cpp
@@ -483,7 +483,7 @@ static void describe_remaining(flavor_type *flavor_ptr)
         return;
     }
 
-    if (((flavor_ptr->o_ptr->tval == ItemKindType::STAFF) || (flavor_ptr->o_ptr->tval == ItemKindType::WAND))) {
+    if (flavor_ptr->o_ptr->is_wand_staff()) {
         describe_charges_staff_wand(flavor_ptr);
     } else if (flavor_ptr->o_ptr->tval == ItemKindType::ROD) {
         describe_charges_rod(flavor_ptr);

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -578,10 +578,7 @@ OBJECT_IDX drop_near(PlayerType *player_ptr, ItemEntity *j_ptr, PERCENTAGE chanc
 void floor_item_charges(FloorType *floor_ptr, INVENTORY_IDX item)
 {
     auto *o_ptr = &floor_ptr->o_list[item];
-    if ((o_ptr->tval != ItemKindType::STAFF) && (o_ptr->tval != ItemKindType::WAND)) {
-        return;
-    }
-    if (!o_ptr->is_known()) {
+    if (!o_ptr->is_wand_staff() || !o_ptr->is_known()) {
         return;
     }
 

--- a/src/knowledge/knowledge-inventory.cpp
+++ b/src/knowledge/knowledge-inventory.cpp
@@ -289,11 +289,11 @@ void do_cmd_knowledge_inventory(PlayerType *player_ptr)
 
     fprintf(fff, "%s\n", inven_res_label);
     int label_number = 0;
-    for (auto tval = enum2i(TV_WEARABLE_BEGIN); tval <= enum2i(TV_WEARABLE_END); tval++) {
+    for (auto tval : TV_WEARABLE_RANGE) {
         reset_label_number(&label_number, fff);
-        show_wearing_equipment_resistances(player_ptr, i2enum<ItemKindType>(tval), &label_number, fff);
-        show_holding_equipment_resistances(player_ptr, i2enum<ItemKindType>(tval), &label_number, fff);
-        show_home_equipment_resistances(player_ptr, i2enum<ItemKindType>(tval), &label_number, fff);
+        show_wearing_equipment_resistances(player_ptr, tval, &label_number, fff);
+        show_holding_equipment_resistances(player_ptr, tval, &label_number, fff);
+        show_home_equipment_resistances(player_ptr, tval, &label_number, fff);
     }
 
     angband_fclose(fff);

--- a/src/market/building-recharger.cpp
+++ b/src/market/building-recharger.cpp
@@ -36,25 +36,18 @@ void building_recharge(PlayerType *player_ptr)
     msg_flag = false;
     clear_bldg(4, 18);
     prt(_("  再充填の費用はアイテムの種類によります。", "  The prices of recharge depend on the type."), 6, 0);
-
-    concptr q = _("どのアイテムに魔力を充填しますか? ", "Recharge which item? ");
-    concptr s = _("魔力を充填すべきアイテムがない。", "You have nothing to recharge.");
-
+    const auto q = _("どのアイテムに魔力を充填しますか? ", "Recharge which item? ");
+    const auto s = _("魔力を充填すべきアイテムがない。", "You have nothing to recharge.");
     OBJECT_IDX item;
-    ItemEntity *o_ptr;
-    o_ptr = choose_object(player_ptr, &item, q, s, (USE_INVEN | USE_FLOOR), FuncItemTester(&ItemEntity::is_rechargeable));
-    if (!o_ptr) {
+    auto *o_ptr = choose_object(player_ptr, &item, q, s, (USE_INVEN | USE_FLOOR), FuncItemTester(&ItemEntity::can_recharge));
+    if (o_ptr == nullptr) {
         return;
     }
-
-    BaseitemInfo *k_ptr;
-    k_ptr = &baseitems_info[o_ptr->bi_id];
 
     /*
      * We don't want to give the player free info about
      * the level of the item or the number of charges.
      */
-    /* The item must be "known" */
     char tmp_str[MAX_NLEN];
     if (!o_ptr->is_known()) {
         msg_format(_("充填する前に鑑定されている必要があります！", "The item must be identified first!"));
@@ -75,25 +68,26 @@ void building_recharge(PlayerType *player_ptr)
         return;
     }
 
-    DEPTH lev = baseitems_info[o_ptr->bi_id].level;
-    PRICE price;
+    const auto &baseitem = baseitems_info[o_ptr->bi_id];
+    const auto lev = baseitem.level;
+    int price;
     if (o_ptr->tval == ItemKindType::ROD) {
         if (o_ptr->timeout > 0) {
-            price = (lev * 50 * o_ptr->timeout) / k_ptr->pval;
+            price = (lev * 50 * o_ptr->timeout) / baseitem.pval;
         } else {
             price = 0;
             msg_format(_("それは再充填する必要はありません。", "That doesn't need to be recharged."));
             return;
         }
     } else if (o_ptr->tval == ItemKindType::STAFF) {
-        price = (baseitems_info[o_ptr->bi_id].cost / 10) * o_ptr->number;
+        price = (baseitem.cost / 10) * o_ptr->number;
         price = std::max(10, price);
     } else {
-        price = (baseitems_info[o_ptr->bi_id].cost / 10);
+        price = baseitem.cost / 10;
         price = std::max(10, price);
     }
 
-    if (o_ptr->tval == ItemKindType::WAND && (o_ptr->pval / o_ptr->number >= k_ptr->pval)) {
+    if ((o_ptr->tval == ItemKindType::WAND) && (o_ptr->pval / o_ptr->number >= baseitem.pval)) {
         if (o_ptr->number > 1) {
             msg_print(_("この魔法棒はもう充分に充填されています。", "These wands are already fully charged."));
         } else {
@@ -101,7 +95,7 @@ void building_recharge(PlayerType *player_ptr)
         }
 
         return;
-    } else if (o_ptr->tval == ItemKindType::STAFF && o_ptr->pval >= k_ptr->pval) {
+    } else if ((o_ptr->tval == ItemKindType::STAFF) && o_ptr->pval >= baseitem.pval) {
         if (o_ptr->number > 1) {
             msg_print(_("この杖はもう充分に充填されています。", "These staffs are already fully charged."));
         } else {
@@ -121,7 +115,6 @@ void building_recharge(PlayerType *player_ptr)
         return;
     }
 
-    PARAMETER_VALUE charges;
     if (o_ptr->tval == ItemKindType::ROD) {
 #ifdef JP
         if (get_check(format("そのロッドを＄%d で再充填しますか？", price)))
@@ -137,20 +130,19 @@ void building_recharge(PlayerType *player_ptr)
     } else {
         int max_charges;
         if (o_ptr->tval == ItemKindType::STAFF) {
-            max_charges = k_ptr->pval - o_ptr->pval;
+            max_charges = baseitem.pval - o_ptr->pval;
         } else {
-            max_charges = o_ptr->number * k_ptr->pval - o_ptr->pval;
+            max_charges = o_ptr->number * baseitem.pval - o_ptr->pval;
         }
 
-        charges = (PARAMETER_VALUE)get_quantity(
-            format(_("一回分＄%d で何回分充填しますか？", "Add how many charges for %d gold apiece? "), price), std::min(player_ptr->au / price, max_charges));
-
+        const auto mes = _("一回分＄%d で何回分充填しますか？", "Add how many charges for %d gold apiece? ");
+        const auto charges = get_quantity(format(mes, price), std::min(player_ptr->au / price, max_charges));
         if (charges < 1) {
             return;
         }
 
         price *= charges;
-        o_ptr->pval += charges;
+        o_ptr->pval += static_cast<short>(charges);
         o_ptr->ident &= ~(IDENT_EMPTY);
     }
 
@@ -186,7 +178,7 @@ void building_recharge_all(PlayerType *player_ptr)
     auto total_cost = 0;
     for (short i = 0; i < INVEN_PACK; i++) {
         const auto &item = player_ptr->inventory_list[i];
-        if (!item.is_rechargeable()) {
+        if (!item.can_recharge()) {
             continue;
         }
 
@@ -238,7 +230,7 @@ void building_recharge_all(PlayerType *player_ptr)
     for (short i = 0; i < INVEN_PACK; i++) {
         auto *o_ptr = &player_ptr->inventory_list[i];
         const auto &baseitem = baseitems_info[o_ptr->bi_id];
-        if (!o_ptr->is_rechargeable()) {
+        if (!o_ptr->can_recharge()) {
             continue;
         }
 

--- a/src/mind/mind-mage.cpp
+++ b/src/mind/mind-mage.cpp
@@ -103,7 +103,7 @@ bool eat_magic(PlayerType *player_ptr, int power)
         msg_format(_("魔力が逆流した！%sは完全に魔力を失った。", "The recharging backfires - %s is completely drained!"), o_name);
         if (o_ptr->tval == ItemKindType::ROD) {
             o_ptr->timeout = k_ptr->pval * o_ptr->number;
-        } else if ((o_ptr->tval == ItemKindType::WAND) || (o_ptr->tval == ItemKindType::STAFF)) {
+        } else if (o_ptr->is_wand_staff()) {
             o_ptr->pval = 0;
         }
 

--- a/src/mind/mind-mage.cpp
+++ b/src/mind/mind-mage.cpp
@@ -34,10 +34,9 @@ bool eat_magic(PlayerType *player_ptr, int power)
     concptr q = _("どのアイテムから魔力を吸収しますか？", "Drain which item? ");
     concptr s = _("魔力を吸収できるアイテムがありません。", "You have nothing to drain.");
 
-    ItemEntity *o_ptr;
     OBJECT_IDX item;
-    o_ptr = choose_object(player_ptr, &item, q, s, (USE_INVEN | USE_FLOOR), FuncItemTester(&ItemEntity::is_rechargeable));
-    if (!o_ptr) {
+    auto *o_ptr = choose_object(player_ptr, &item, q, s, (USE_INVEN | USE_FLOOR), FuncItemTester(&ItemEntity::can_recharge));
+    if (o_ptr == nullptr) {
         return false;
     }
 

--- a/src/mind/mind-magic-eater.cpp
+++ b/src/mind/mind-magic-eater.cpp
@@ -21,11 +21,11 @@
  */
 bool import_magic_device(PlayerType *player_ptr)
 {
-    concptr q = _("どのアイテムの魔力を取り込みますか? ", "Gain power of which item? ");
-    concptr s = _("魔力を取り込めるアイテムがない。", "There's nothing with power to absorb.");
+    const auto q = _("どのアイテムの魔力を取り込みますか? ", "Gain power of which item? ");
+    const auto s = _("魔力を取り込めるアイテムがない。", "There's nothing with power to absorb.");
     OBJECT_IDX item;
-    auto *o_ptr = choose_object(player_ptr, &item, q, s, USE_INVEN | USE_FLOOR, FuncItemTester(&ItemEntity::is_rechargeable));
-    if (!o_ptr) {
+    auto *o_ptr = choose_object(player_ptr, &item, q, s, USE_INVEN | USE_FLOOR, FuncItemTester(&ItemEntity::can_recharge));
+    if (o_ptr == nullptr) {
         return false;
     }
 

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -454,7 +454,7 @@ void MonsterAttackPlayer::gain_armor_exp()
 {
     const auto o_ptr_mh = &this->player_ptr->inventory_list[INVEN_MAIN_HAND];
     const auto o_ptr_sh = &this->player_ptr->inventory_list[INVEN_SUB_HAND];
-    if (!o_ptr_mh->is_armour() && !o_ptr_sh->is_armour()) {
+    if (!o_ptr_mh->is_protector() && !o_ptr_sh->is_protector()) {
         return;
     }
 

--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -121,7 +121,7 @@ static void move_item_to_monster(PlayerType *player_ptr, MonsterAttackPlayer *mo
     j_ptr = &player_ptr->current_floor_ptr->o_list[o_idx];
     j_ptr->copy_from(monap_ptr->o_ptr);
     j_ptr->number = 1;
-    if ((monap_ptr->o_ptr->tval == ItemKindType::ROD) || (monap_ptr->o_ptr->tval == ItemKindType::WAND)) {
+    if (monap_ptr->o_ptr->is_wand_rod()) {
         j_ptr->pval = monap_ptr->o_ptr->pval / monap_ptr->o_ptr->number;
         monap_ptr->o_ptr->pval -= j_ptr->pval;
     }

--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -223,7 +223,7 @@ void process_eat_lite(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
  */
 bool process_un_power(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
 {
-    if (((monap_ptr->o_ptr->tval != ItemKindType::STAFF) && (monap_ptr->o_ptr->tval != ItemKindType::WAND)) || (monap_ptr->o_ptr->pval == 0)) {
+    if (!monap_ptr->o_ptr->is_wand_staff() || (monap_ptr->o_ptr->pval == 0)) {
         return false;
     }
 

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -324,29 +324,7 @@ static bool make_equipment(PlayerType *player_ptr, ItemEntity *q_ptr, const BIT_
         return true;
     }
 
-    auto tval = q_ptr->tval;
-    switch (tval) {
-    case ItemKindType::BOW:
-    case ItemKindType::DIGGING:
-    case ItemKindType::HAFTED:
-    case ItemKindType::POLEARM:
-    case ItemKindType::SWORD:
-    case ItemKindType::BOOTS:
-    case ItemKindType::GLOVES:
-    case ItemKindType::HELM:
-    case ItemKindType::CROWN:
-    case ItemKindType::SHIELD:
-    case ItemKindType::CLOAK:
-    case ItemKindType::SOFT_ARMOR:
-    case ItemKindType::HARD_ARMOR:
-    case ItemKindType::DRAG_ARMOR:
-    case ItemKindType::LITE:
-    case ItemKindType::AMULET:
-    case ItemKindType::RING:
-        return true;
-    default:
-        return false;
-    }
+    return q_ptr->is_wearable() && (q_ptr->tval != ItemKindType::CARD);
 }
 
 /*

--- a/src/object-enchant/object-curse.cpp
+++ b/src/object-enchant/object-curse.cpp
@@ -49,7 +49,7 @@ CurseTraitType get_curse(int power, ItemEntity *o_ptr)
         if (new_curse == CurseTraitType::LOW_MELEE && !o_ptr->is_weapon()) {
             continue;
         }
-        if (new_curse == CurseTraitType::LOW_AC && !o_ptr->is_armour()) {
+        if (new_curse == CurseTraitType::LOW_AC && !o_ptr->is_protector()) {
             continue;
         }
         break;

--- a/src/object-hook/hook-expendable.cpp
+++ b/src/object-hook/hook-expendable.cpp
@@ -31,7 +31,7 @@ bool item_tester_hook_eatable(PlayerType *player_ptr, const ItemEntity *o_ptr)
 
     auto food_type = PlayerRace(player_ptr).food();
     if (food_type == PlayerRaceFoodType::MANA) {
-        if (o_ptr->tval == ItemKindType::STAFF || o_ptr->tval == ItemKindType::WAND) {
+        if (o_ptr->is_wand_staff()) {
             return true;
         }
     } else if (food_type == PlayerRaceFoodType::CORPSE) {

--- a/src/object/object-stack.cpp
+++ b/src/object/object-stack.cpp
@@ -31,7 +31,7 @@
  */
 void distribute_charges(ItemEntity *o_ptr, ItemEntity *q_ptr, int amt)
 {
-    if ((o_ptr->tval != ItemKindType::WAND) && (o_ptr->tval != ItemKindType::ROD)) {
+    if (!o_ptr->is_wand_rod()) {
         return;
     }
 
@@ -66,7 +66,7 @@ void distribute_charges(ItemEntity *o_ptr, ItemEntity *q_ptr, int amt)
  */
 void reduce_charges(ItemEntity *o_ptr, int amt)
 {
-    if (((o_ptr->tval == ItemKindType::WAND) || (o_ptr->tval == ItemKindType::ROD)) && (amt < o_ptr->number)) {
+    if (o_ptr->is_wand_rod() && (amt < o_ptr->number)) {
         o_ptr->pval -= o_ptr->pval * amt / o_ptr->number;
     }
 }

--- a/src/object/tval-types.h
+++ b/src/object/tval-types.h
@@ -76,9 +76,8 @@ enum class ItemKindType : short {
 
 #define TV_EQUIP_BEGIN ItemKindType::SHOT
 #define TV_EQUIP_END ItemKindType::CARD
-#define TV_WEARABLE_BEGIN ItemKindType::BOW
-#define TV_WEARABLE_END ItemKindType::CARD
 #define TV_WEAPON_BEGIN ItemKindType::BOW
 #define TV_WEAPON_END ItemKindType::SWORD
 
-constexpr auto TV_WEAPON_RANGE = EnumRange(TV_WEAPON_BEGIN, TV_WEAPON_END);
+constexpr auto TV_WEARABLE_RANGE = EnumRange(ItemKindType::BOW, ItemKindType::CARD);
+constexpr auto TV_WEAPON_RANGE = EnumRange(ItemKindType::BOW, ItemKindType::SWORD);

--- a/src/object/tval-types.h
+++ b/src/object/tval-types.h
@@ -80,7 +80,5 @@ enum class ItemKindType : short {
 #define TV_WEARABLE_END ItemKindType::CARD
 #define TV_WEAPON_BEGIN ItemKindType::BOW
 #define TV_WEAPON_END ItemKindType::SWORD
-#define TV_ARMOR_BEGIN ItemKindType::BOOTS
-#define TV_ARMOR_END ItemKindType::DRAG_ARMOR
 
 constexpr auto TV_WEAPON_RANGE = EnumRange(TV_WEAPON_BEGIN, TV_WEAPON_END);

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -113,7 +113,7 @@ static bool acid_minus_ac(PlayerType *player_ptr)
         break;
     }
 
-    if ((o_ptr == nullptr) || (o_ptr->bi_id == 0) || !o_ptr->is_armour()) {
+    if ((o_ptr == nullptr) || (o_ptr->bi_id == 0) || !o_ptr->is_protector()) {
         return false;
     }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -1713,7 +1713,7 @@ static ARMOUR_CLASS calc_base_ac(PlayerType *player_ptr)
 
     const auto o_ptr_mh = &player_ptr->inventory_list[INVEN_MAIN_HAND];
     const auto o_ptr_sh = &player_ptr->inventory_list[INVEN_SUB_HAND];
-    if (o_ptr_mh->is_armour() || o_ptr_sh->is_armour()) {
+    if (o_ptr_mh->is_protector() || o_ptr_sh->is_protector()) {
         ac += player_ptr->skill_exp[PlayerSkillKindType::SHIELD] * (1 + player_ptr->lev / 22) / 2000;
     }
 
@@ -1840,7 +1840,7 @@ static ARMOUR_CLASS calc_to_ac(PlayerType *player_ptr, bool is_real_value)
             if (!o_ptr->bi_id) {
                 continue;
             }
-            if (!o_ptr->is_armour()) {
+            if (!o_ptr->is_protector()) {
                 continue;
             }
             if (!o_ptr->is_cursed()) {

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -549,7 +549,7 @@ concptr do_hex_spell(PlayerType *player_ptr, spell_hex_type spell, SpellProcessT
             q = _("どれを呪いますか？", "Which piece of armour do you curse?");
             s = _("防具を装備していない。", "You're not wearing any armor.");
 
-            o_ptr = choose_object(player_ptr, &item, q, s, (USE_EQUIP), FuncItemTester(&ItemEntity::is_armour));
+            o_ptr = choose_object(player_ptr, &item, q, s, (USE_EQUIP), FuncItemTester(&ItemEntity::is_protector));
             if (!o_ptr) {
                 return "";
             }

--- a/src/smith/smith-info.cpp
+++ b/src/smith/smith-info.cpp
@@ -156,7 +156,7 @@ bool EnchantArmourSmithInfo::add_essence(PlayerType *player_ptr, ItemEntity *o_p
 
 bool EnchantArmourSmithInfo::can_give_smith_effect(const ItemEntity *o_ptr) const
 {
-    return o_ptr->is_armour();
+    return o_ptr->is_protector();
 }
 
 SustainSmithInfo::SustainSmithInfo(SmithEffectType effect, concptr name, SmithCategoryType category, std::vector<SmithEssenceType> need_essences, int consumption)

--- a/src/spell-kind/magic-item-recharger.cpp
+++ b/src/spell-kind/magic-item-recharger.cpp
@@ -125,7 +125,7 @@ bool recharge(PlayerType *player_ptr, int power)
         msg_format(_("魔力が逆流した！%sは完全に魔力を失った。", "The recharging backfires - %s is completely drained!"), o_name);
         if ((o_ptr->tval == ItemKindType::ROD) && (o_ptr->timeout < 10000)) {
             o_ptr->timeout = (o_ptr->timeout + 100) * 2;
-        } else if ((o_ptr->tval == ItemKindType::WAND) || (o_ptr->tval == ItemKindType::STAFF)) {
+        } else if (o_ptr->is_wand_staff()) {
             o_ptr->pval = 0;
         }
         return update_player(player_ptr);

--- a/src/spell-kind/magic-item-recharger.cpp
+++ b/src/spell-kind/magic-item-recharger.cpp
@@ -53,15 +53,13 @@ bool recharge(PlayerType *player_ptr, int power)
     concptr s = _("魔力を充填すべきアイテムがない。", "You have nothing to recharge.");
 
     OBJECT_IDX item;
-    ItemEntity *o_ptr;
-    o_ptr = choose_object(player_ptr, &item, q, s, (USE_INVEN | USE_FLOOR), FuncItemTester(&ItemEntity::is_rechargeable));
-    if (!o_ptr) {
+    auto *o_ptr = choose_object(player_ptr, &item, q, s, (USE_INVEN | USE_FLOOR), FuncItemTester(&ItemEntity::can_recharge));
+    if (o_ptr == nullptr) {
         return false;
     }
 
-    BaseitemInfo *k_ptr;
-    k_ptr = &baseitems_info[o_ptr->bi_id];
-    DEPTH lev = baseitems_info[o_ptr->bi_id].level;
+    const auto &baseitem = baseitems_info[o_ptr->bi_id];
+    const auto lev = baseitem.level;
 
     TIME_EFFECT recharge_amount;
     int recharge_strength;
@@ -92,7 +90,7 @@ bool recharge(PlayerType *player_ptr, int power)
         if (one_in_(recharge_strength)) {
             is_recharge_successful = false;
         } else {
-            recharge_amount = randint1(1 + k_ptr->pval / 2);
+            recharge_amount = randint1(1 + baseitem.pval / 2);
             if ((o_ptr->tval == ItemKindType::WAND) && (o_ptr->number > 1)) {
                 recharge_amount += (randint1(recharge_amount * (o_ptr->number - 1))) / 2;
                 if (recharge_amount < 1) {
@@ -204,7 +202,7 @@ bool recharge(PlayerType *player_ptr, int power)
         }
 
         if (o_ptr->tval == ItemKindType::ROD) {
-            o_ptr->timeout = (o_ptr->number - 1) * k_ptr->pval;
+            o_ptr->timeout = (o_ptr->number - 1) * baseitem.pval;
         }
         if (o_ptr->tval == ItemKindType::WAND) {
             o_ptr->pval = 0;

--- a/src/spell-realm/spells-nature.cpp
+++ b/src/spell-realm/spells-nature.cpp
@@ -19,10 +19,11 @@
  */
 bool rustproof(PlayerType *player_ptr)
 {
-    concptr q = _("どの防具に錆止めをしますか？", "Rustproof which piece of armour? ");
-    concptr s = _("錆止めできるものがありません。", "You have nothing to rustproof.");
+    const auto q = _("どの防具に錆止めをしますか？", "Rustproof which piece of armour? ");
+    const auto s = _("錆止めできるものがありません。", "You have nothing to rustproof.");
     OBJECT_IDX item;
-    auto *o_ptr = choose_object(player_ptr, &item, q, s, USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT, FuncItemTester(&ItemEntity::is_armour));
+    const auto options = USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT;
+    auto *o_ptr = choose_object(player_ptr, &item, q, s, options, FuncItemTester(&ItemEntity::is_protector));
     if (o_ptr == nullptr) {
         return false;
     }

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -534,15 +534,15 @@ bool enchant_spell(PlayerType *player_ptr, HIT_PROB num_hit, int num_dam, ARMOUR
 
     /* Enchant armor if requested */
     if (num_ac) {
-        item_tester = FuncItemTester(&ItemEntity::is_armour);
+        item_tester = FuncItemTester(&ItemEntity::is_protector);
     }
 
-    concptr q = _("どのアイテムを強化しますか? ", "Enchant which item? ");
-    concptr s = _("強化できるアイテムがない。", "You have nothing to enchant.");
+    const auto q = _("どのアイテムを強化しますか? ", "Enchant which item? ");
+    const auto s = _("強化できるアイテムがない。", "You have nothing to enchant.");
 
     OBJECT_IDX item;
-    ItemEntity *o_ptr;
-    o_ptr = choose_object(player_ptr, &item, q, s, (USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT), item_tester);
+    const auto options = USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT;
+    auto *o_ptr = choose_object(player_ptr, &item, q, s, options, item_tester);
     if (!o_ptr) {
         return false;
     }

--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -319,7 +319,7 @@ void store_purchase(PlayerType *player_ptr, StoreSaleType store_num)
     describe_flavor(player_ptr, o_name, &player_ptr->inventory_list[item_new], 0);
     msg_format(_("%s(%c)を手に入れた。", "You have %s (%c)."), o_name, index_to_label(item_new));
 
-    if ((o_ptr->tval == ItemKindType::ROD) || (o_ptr->tval == ItemKindType::WAND)) {
+    if (o_ptr->is_wand_rod()) {
         o_ptr->pval -= j_ptr->pval;
     }
 

--- a/src/store/sell-order.cpp
+++ b/src/store/sell-order.cpp
@@ -115,7 +115,7 @@ void store_sell(PlayerType *player_ptr, StoreSaleType store_num)
     q_ptr->copy_from(o_ptr);
     q_ptr->number = amt;
 
-    if ((o_ptr->tval == ItemKindType::ROD) || (o_ptr->tval == ItemKindType::WAND)) {
+    if (o_ptr->is_wand_rod()) {
         q_ptr->pval = o_ptr->pval * amt / o_ptr->number;
     }
 
@@ -161,7 +161,7 @@ void store_sell(PlayerType *player_ptr, StoreSaleType store_num)
             q_ptr->number = amt;
             q_ptr->ident |= IDENT_STORE;
 
-            if ((o_ptr->tval == ItemKindType::ROD) || (o_ptr->tval == ItemKindType::WAND)) {
+            if (o_ptr->is_wand_rod()) {
                 q_ptr->pval = o_ptr->pval * amt / o_ptr->number;
             }
 

--- a/src/store/service-checker.cpp
+++ b/src/store/service-checker.cpp
@@ -451,7 +451,7 @@ void mass_produce(PlayerType *, ItemEntity *o_ptr, StoreSaleType store_num)
 
     o_ptr->discount = discount;
     o_ptr->number = size - (size * discount / 100);
-    if ((o_ptr->tval == ItemKindType::ROD) || (o_ptr->tval == ItemKindType::WAND)) {
+    if (o_ptr->is_wand_rod()) {
         o_ptr->pval *= (PARAMETER_VALUE)o_ptr->number;
     }
 }

--- a/src/store/store-util.cpp
+++ b/src/store/store-util.cpp
@@ -101,17 +101,13 @@ std::vector<PARAMETER_VALUE> store_same_magic_device_pvals(ItemEntity *j_ptr)
     auto list = std::vector<PARAMETER_VALUE>();
     for (INVENTORY_IDX i = 0; i < st_ptr->stock_num; i++) {
         auto *o_ptr = &st_ptr->stock[i];
-        if (o_ptr == j_ptr) {
+        if ((o_ptr == j_ptr) || (o_ptr->bi_id != j_ptr->bi_id) || !o_ptr->is_wand_staff()) {
             continue;
         }
-        if (o_ptr->bi_id != j_ptr->bi_id) {
-            continue;
-        }
-        if (o_ptr->tval != ItemKindType::STAFF && o_ptr->tval != ItemKindType::WAND) {
-            continue;
-        }
+
         list.push_back(o_ptr->pval);
     }
+
     return list;
 }
 

--- a/src/store/store-util.cpp
+++ b/src/store/store-util.cpp
@@ -81,7 +81,7 @@ void store_delete(void)
         num = 1;
     }
 
-    if ((st_ptr->stock[what].tval == ItemKindType::ROD) || (st_ptr->stock[what].tval == ItemKindType::WAND)) {
+    if (st_ptr->stock[what].is_wand_rod()) {
         st_ptr->stock[what].pval -= num * st_ptr->stock[what].pval / st_ptr->stock[what].number;
     }
 
@@ -136,7 +136,7 @@ bool store_object_similar(ItemEntity *o_ptr, ItemEntity *j_ptr)
         return false;
     }
 
-    if ((o_ptr->pval != j_ptr->pval) && (o_ptr->tval != ItemKindType::WAND) && (o_ptr->tval != ItemKindType::ROD)) {
+    if ((o_ptr->pval != j_ptr->pval) && !o_ptr->is_wand_rod()) {
         return false;
     }
 
@@ -216,7 +216,7 @@ static void store_object_absorb(ItemEntity *o_ptr, ItemEntity *j_ptr)
     int total = o_ptr->number + j_ptr->number;
     int diff = (total > max_num) ? total - max_num : 0;
     o_ptr->number = (total > max_num) ? max_num : total;
-    if ((o_ptr->tval == ItemKindType::ROD) || (o_ptr->tval == ItemKindType::WAND)) {
+    if (o_ptr->is_wand_rod()) {
         o_ptr->pval += j_ptr->pval * (j_ptr->number - diff) / j_ptr->number;
     }
 }

--- a/src/system/baseitem-info.cpp
+++ b/src/system/baseitem-info.cpp
@@ -161,6 +161,18 @@ bool BaseitemKey::has_unidentified_name() const
     }
 }
 
+bool BaseitemKey::can_recharge() const
+{
+    switch (this->type_value) {
+    case ItemKindType::STAFF:
+    case ItemKindType::WAND:
+    case ItemKindType::ROD:
+        return true;
+    default:
+        return false;
+    }
+}
+
 bool BaseitemKey::is_mushrooms() const
 {
     if (!this->subtype_value.has_value()) {

--- a/src/system/baseitem-info.cpp
+++ b/src/system/baseitem-info.cpp
@@ -173,6 +173,17 @@ bool BaseitemKey::can_recharge() const
     }
 }
 
+bool BaseitemKey::is_wand_rod() const
+{
+    switch (this->type_value) {
+    case ItemKindType::WAND:
+    case ItemKindType::ROD:
+        return true;
+    default:
+        return false;
+    }
+}
+
 bool BaseitemKey::is_mushrooms() const
 {
     if (!this->subtype_value.has_value()) {

--- a/src/system/baseitem-info.cpp
+++ b/src/system/baseitem-info.cpp
@@ -184,6 +184,17 @@ bool BaseitemKey::is_wand_rod() const
     }
 }
 
+bool BaseitemKey::is_wand_staff() const
+{
+    switch (this->type_value) {
+    case ItemKindType::WAND:
+    case ItemKindType::STAFF:
+        return true;
+    default:
+        return false;
+    }
+}
+
 bool BaseitemKey::is_mushrooms() const
 {
     if (!this->subtype_value.has_value()) {

--- a/src/system/baseitem-info.cpp
+++ b/src/system/baseitem-info.cpp
@@ -225,6 +225,33 @@ bool BaseitemKey::can_be_aura_protector() const
     }
 }
 
+bool BaseitemKey::is_wearable() const
+{
+    switch (this->type_value) {
+    case ItemKindType::BOW:
+    case ItemKindType::DIGGING:
+    case ItemKindType::HAFTED:
+    case ItemKindType::POLEARM:
+    case ItemKindType::SWORD:
+    case ItemKindType::BOOTS:
+    case ItemKindType::GLOVES:
+    case ItemKindType::HELM:
+    case ItemKindType::CROWN:
+    case ItemKindType::SHIELD:
+    case ItemKindType::CLOAK:
+    case ItemKindType::SOFT_ARMOR:
+    case ItemKindType::HARD_ARMOR:
+    case ItemKindType::DRAG_ARMOR:
+    case ItemKindType::LITE:
+    case ItemKindType::AMULET:
+    case ItemKindType::RING:
+    case ItemKindType::CARD:
+        return true;
+    default:
+        return false;
+    }
+}
+
 bool BaseitemKey::is_mushrooms() const
 {
     if (!this->subtype_value.has_value()) {

--- a/src/system/baseitem-info.cpp
+++ b/src/system/baseitem-info.cpp
@@ -195,6 +195,36 @@ bool BaseitemKey::is_wand_staff() const
     }
 }
 
+bool BaseitemKey::is_protector() const
+{
+    switch (this->type_value) {
+    case ItemKindType::BOOTS:
+    case ItemKindType::GLOVES:
+    case ItemKindType::HELM:
+    case ItemKindType::CROWN:
+    case ItemKindType::SHIELD:
+    case ItemKindType::CLOAK:
+    case ItemKindType::SOFT_ARMOR:
+    case ItemKindType::HARD_ARMOR:
+    case ItemKindType::DRAG_ARMOR:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool BaseitemKey::can_be_aura_protector() const
+{
+    switch (this->type_value) {
+    case ItemKindType::CLOAK:
+    case ItemKindType::SOFT_ARMOR:
+    case ItemKindType::HARD_ARMOR:
+        return true;
+    default:
+        return false;
+    }
+}
+
 bool BaseitemKey::is_mushrooms() const
 {
     if (!this->subtype_value.has_value()) {

--- a/src/system/baseitem-info.h
+++ b/src/system/baseitem-info.h
@@ -48,6 +48,7 @@ public:
     bool is_wand_staff() const;
     bool is_protector() const;
     bool can_be_aura_protector() const;
+    bool is_wearable() const;
 
 private:
     ItemKindType type_value;

--- a/src/system/baseitem-info.h
+++ b/src/system/baseitem-info.h
@@ -44,6 +44,7 @@ public:
     bool is_ammo() const;
     bool has_unidentified_name() const;
     bool can_recharge() const;
+    bool is_wand_rod() const;
 
 private:
     ItemKindType type_value;

--- a/src/system/baseitem-info.h
+++ b/src/system/baseitem-info.h
@@ -45,6 +45,7 @@ public:
     bool has_unidentified_name() const;
     bool can_recharge() const;
     bool is_wand_rod() const;
+    bool is_wand_staff() const;
 
 private:
     ItemKindType type_value;

--- a/src/system/baseitem-info.h
+++ b/src/system/baseitem-info.h
@@ -46,6 +46,8 @@ public:
     bool can_recharge() const;
     bool is_wand_rod() const;
     bool is_wand_staff() const;
+    bool is_protector() const;
+    bool can_be_aura_protector() const;
 
 private:
     ItemKindType type_value;

--- a/src/system/baseitem-info.h
+++ b/src/system/baseitem-info.h
@@ -43,6 +43,7 @@ public:
     bool is_melee_weapon() const;
     bool is_ammo() const;
     bool has_unidentified_name() const;
+    bool can_recharge() const;
 
 private:
     ItemKindType type_value;

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -519,7 +519,7 @@ bool ItemEntity::can_refill_torch() const
  * @brief 魔力充填が可能なアイテムかどうか判定する
  * @return 魔力充填が可能ならばTRUEを返す
  */
-bool ItemEntity::is_rechargeable() const
+bool ItemEntity::can_recharge() const
 {
     return BaseitemKey(this->tval).can_recharge();
 }

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -516,20 +516,12 @@ bool ItemEntity::can_refill_torch() const
 }
 
 /*!
- * @brief 魔力充填が可能なアイテムかどうか判定する /
- * Hook for "get_item()".  Determine if something is rechargable.
+ * @brief 魔力充填が可能なアイテムかどうか判定する
  * @return 魔力充填が可能ならばTRUEを返す
  */
 bool ItemEntity::is_rechargeable() const
 {
-    switch (this->tval) {
-    case ItemKindType::STAFF:
-    case ItemKindType::WAND:
-    case ItemKindType::ROD:
-        return true;
-    default:
-        return false;
-    }
+    return BaseitemKey(this->tval).can_recharge();
 }
 
 /*!

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -131,7 +131,7 @@ bool ItemEntity::is_weapon_ammo() const
  */
 bool ItemEntity::is_weapon_armour_ammo() const
 {
-    return this->is_weapon_ammo() || this->is_armour();
+    return this->is_weapon_ammo() || this->is_protector();
 }
 
 /*!
@@ -324,12 +324,21 @@ bool ItemEntity::is_lance() const
 }
 
 /*!
- * @brief アイテムが防具として装備できるかどうかを返す / Check if an object is armour
+ * @brief アイテムが防具として装備できるかどうかを返す
  * @return 防具として装備できるならばtrueを返す
  */
-bool ItemEntity::is_armour() const
+bool ItemEntity::is_protector() const
 {
-    return (TV_ARMOR_BEGIN <= this->tval) && (this->tval <= TV_ARMOR_END);
+    return BaseitemKey(this->tval).is_protector();
+}
+
+/*!
+ * @brief アイテムがオーラを纏える防具かどうかを返す
+ * @return オーラを纏えるならばtrueを返す
+ */
+bool ItemEntity::can_be_aura_protector() const
+{
+    return BaseitemKey(this->tval).can_be_aura_protector();
 }
 
 /*!

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -814,3 +814,8 @@ bool ItemEntity::is_wand_rod() const
 {
     return BaseitemKey(this->tval).is_wand_rod();
 }
+
+bool ItemEntity::is_wand_staff() const
+{
+    return BaseitemKey(this->tval).is_wand_staff();
+}

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -170,7 +170,7 @@ bool ItemEntity::is_melee_ammo() const
  */
 bool ItemEntity::is_wearable() const
 {
-    return (TV_WEARABLE_BEGIN <= this->tval) && (this->tval <= TV_WEARABLE_END);
+    return BaseitemKey(this->tval).is_wearable();
 }
 
 /*!

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -809,3 +809,8 @@ ItemKindType ItemEntity::get_arrow_kind() const
 {
     return BaseitemKey(this->tval, this->sval).get_arrow_kind();
 }
+
+bool ItemEntity::is_wand_rod() const
+{
+    return BaseitemKey(this->tval).is_wand_rod();
+}

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -123,6 +123,7 @@ public:
     bool is_specific_artifact(FixedArtifactId id) const;
     bool has_unidentified_name() const;
     ItemKindType get_arrow_kind() const;
+    bool is_wand_rod() const;
 
 private:
     int get_baseitem_price() const;

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -110,7 +110,7 @@ public:
     bool is_readable() const;
     bool can_refill_lantern() const;
     bool can_refill_torch() const;
-    bool is_rechargeable() const;
+    bool can_recharge() const;
     bool is_offerable() const;
     bool is_activatable() const;
     bool is_fuel() const;

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -124,6 +124,7 @@ public:
     bool has_unidentified_name() const;
     ItemKindType get_arrow_kind() const;
     bool is_wand_rod() const;
+    bool is_wand_staff() const;
 
 private:
     int get_baseitem_price() const;

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -90,7 +90,8 @@ public:
     bool is_ammo() const;
     bool is_convertible() const;
     bool is_lance() const;
-    bool is_armour() const;
+    bool is_protector() const;
+    bool can_be_aura_protector() const;
     bool is_rare() const;
     bool is_ego() const;
     bool is_smith() const;

--- a/src/view/object-describer.cpp
+++ b/src/view/object-describer.cpp
@@ -19,12 +19,7 @@
  */
 void inven_item_charges(const ItemEntity &item)
 {
-    const auto tval = item.tval;
-    if ((tval != ItemKindType::STAFF) && (tval != ItemKindType::WAND)) {
-        return;
-    }
-
-    if (!item.is_known()) {
+    if (!item.is_wand_staff() || !item.is_known()) {
         return;
     }
 


### PR DESCRIPTION
掲題の通りです
ItemEntity のオブジェクトメソッドをBaseitemKey のオブジェクトメソッドにリダイレクトした他、本体作業のための最適化を複数図りました (主にポインタ→参照 差し替え)
ロジック変更も複数あります
ご確認下さい