### PR TITLE
ItemEntity::tval/sval をBaseitemKey に差し替えるための準備をした その4

### DIFF
--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -488,14 +488,7 @@ static MULTIPLY calc_shot_damage_with_slay(
  */
 void exe_fire(PlayerType *player_ptr, INVENTORY_IDX item, ItemEntity *j_ptr, SPELL_IDX snipe_type)
 {
-    DIRECTION dir;
-    int i;
     POSITION y, x, ny, nx, ty, tx, prev_y, prev_x;
-    int tdam_base, tdis, thits, tmul;
-    int bonus, chance;
-    int cur_dis, visible;
-    PERCENTAGE j;
-
     ItemEntity forge;
     ItemEntity *q_ptr;
     ItemEntity *o_ptr;
@@ -503,12 +496,8 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX item, ItemEntity *j_ptr, SPE
     AttributeFlags attribute_flags{};
     attribute_flags.set(AttributeType::PLAYER_SHOOT);
 
-    bool hit_body = false;
-
-    GAME_TEXT o_name[MAX_NLEN];
-
-    /* STICK TO */
-    bool stick_to = false;
+    auto hit_body = false;
+    auto stick_to = false;
 
     /* Access the item (if in the pack) */
     if (item >= 0) {
@@ -522,27 +511,30 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX item, ItemEntity *j_ptr, SPE
         snipe_type = SP_NONE;
     }
 
+    GAME_TEXT o_name[MAX_NLEN];
     describe_flavor(player_ptr, o_name, o_ptr, OD_OMIT_PREFIX);
 
     /* Use the proper number of shots */
-    thits = player_ptr->num_fire;
+    auto thits = player_ptr->num_fire;
 
     /* Use a base distance */
-    tdis = 10;
+    auto tdis = 10;
 
     /* Base damage from thrown object plus launcher bonus */
-    tdam_base = damroll(o_ptr->dd, o_ptr->ds) + o_ptr->to_d + j_ptr->to_d;
+    auto tdam_base = damroll(o_ptr->dd, o_ptr->ds) + o_ptr->to_d + j_ptr->to_d;
 
     /* Actually "fire" the object */
-    bonus = (player_ptr->to_h_b + o_ptr->to_h + j_ptr->to_h);
+    auto bonus = (player_ptr->to_h_b + o_ptr->to_h + j_ptr->to_h);
+    int chance;
+    auto weapon_exp = player_ptr->weapon_exp[j_ptr->tval][j_ptr->sval];
     if ((j_ptr->sval == SV_LIGHT_XBOW) || (j_ptr->sval == SV_HEAVY_XBOW)) {
-        chance = (player_ptr->skill_thb + (player_ptr->weapon_exp[j_ptr->tval][j_ptr->sval] / 400 + bonus) * BTH_PLUS_ADJ);
+        chance = (player_ptr->skill_thb + (weapon_exp / 400 + bonus) * BTH_PLUS_ADJ);
     } else {
-        chance = (player_ptr->skill_thb + ((player_ptr->weapon_exp[j_ptr->tval][j_ptr->sval] - (PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER) / 2)) / 200 + bonus) * BTH_PLUS_ADJ);
+        chance = (player_ptr->skill_thb + ((weapon_exp - (PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER) / 2)) / 200 + bonus) * BTH_PLUS_ADJ);
     }
 
     PlayerEnergy(player_ptr).set_player_turn_energy(j_ptr->get_bow_energy());
-    tmul = bow_tmul(j_ptr->sval);
+    auto tmul = j_ptr->get_arrow_magnification();
 
     /* Get extra "power" from "extra might" */
     if (player_ptr->xtra_might) {
@@ -567,6 +559,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX item, ItemEntity *j_ptr, SPE
     project_length = tdis + 1;
 
     /* Get a direction (or cancel) */
+    DIRECTION dir;
     if (!get_aim_dir(player_ptr, &dir)) {
         PlayerEnergy(player_ptr).reset_player_turn();
 
@@ -609,7 +602,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX item, ItemEntity *j_ptr, SPE
     }
 
     /* Take a (partial) turn */
-    PlayerEnergy(player_ptr).div_player_turn_energy((ENERGY)thits);
+    PlayerEnergy(player_ptr).div_player_turn_energy(thits);
     player_ptr->is_fired = true;
 
     /* Sniper - Difficult to shot twice at 1 turn */
@@ -618,7 +611,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX item, ItemEntity *j_ptr, SPE
     }
 
     /* Sniper - Repeat shooting when double shots */
-    for (i = 0; i < ((snipe_type == SP_DOUBLE) ? 2 : 1); i++) {
+    for (auto i = 0; i < ((snipe_type == SP_DOUBLE) ? 2 : 1); i++) {
         /* Start at the player */
         y = player_ptr->y;
         x = player_ptr->x;
@@ -640,7 +633,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX item, ItemEntity *j_ptr, SPE
         hit_body = false;
 
         /* Travel until stopped */
-        for (cur_dis = 0; cur_dis <= tdis;) {
+        for (auto cur_dis = 0; cur_dis <= tdis;) {
             grid_type *g_ptr;
 
             /* Hack -- Stop at the target */
@@ -740,7 +733,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX item, ItemEntity *j_ptr, SPE
                 auto *r_ptr = &monraces_info[m_ptr->r_idx];
 
                 /* Check the visibility */
-                visible = m_ptr->ml;
+                auto visible = m_ptr->ml;
 
                 /* Note the collision */
                 hit_body = true;
@@ -946,7 +939,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX item, ItemEntity *j_ptr, SPE
         }
 
         /* Chance of breakage (during attacks) */
-        j = (hit_body ? breakage_chance(player_ptr, q_ptr, PlayerClass(player_ptr).equals(PlayerClassType::ARCHER), snipe_type) : 0);
+        auto j = (hit_body ? breakage_chance(player_ptr, q_ptr, PlayerClass(player_ptr).equals(PlayerClassType::ARCHER), snipe_type) : 0);
 
         if (stick_to) {
             MONSTER_IDX m_idx = player_ptr->current_floor_ptr->grid_array[y][x].m_idx;
@@ -1113,55 +1106,6 @@ int critical_shot(PlayerType *player_ptr, WEIGHT weight, int plus_ammo, int plus
     }
 
     return dam;
-}
-
-/*
- * Return bow tmul
- */
-int bow_tmul(OBJECT_SUBTYPE_VALUE sval)
-{
-    int tmul = 0;
-
-    /* Analyze the launcher */
-    switch (sval) {
-        /* Sling and ammo */
-    case SV_SLING: {
-        tmul = 2;
-        break;
-    }
-
-    /* Short Bow and Arrow */
-    case SV_SHORT_BOW: {
-        tmul = 2;
-        break;
-    }
-
-    /* Long Bow and Arrow */
-    case SV_LONG_BOW: {
-        tmul = 3;
-        break;
-    }
-
-    /* Bow of irresponsiblity and Arrow */
-    case SV_NAMAKE_BOW: {
-        tmul = 3;
-        break;
-    }
-
-    /* Light Crossbow and Bolt */
-    case SV_LIGHT_XBOW: {
-        tmul = 3;
-        break;
-    }
-
-    /* Heavy Crossbow and Bolt */
-    case SV_HEAVY_XBOW: {
-        tmul = 4;
-        break;
-    }
-    }
-
-    return tmul;
 }
 
 /*!

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -541,7 +541,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX item, ItemEntity *j_ptr, SPE
         chance = (player_ptr->skill_thb + ((player_ptr->weapon_exp[j_ptr->tval][j_ptr->sval] - (PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER) / 2)) / 200 + bonus) * BTH_PLUS_ADJ);
     }
 
-    PlayerEnergy(player_ptr).set_player_turn_energy(bow_energy(j_ptr->sval));
+    PlayerEnergy(player_ptr).set_player_turn_energy(j_ptr->get_bow_energy());
     tmul = bow_tmul(j_ptr->sval);
 
     /* Get extra "power" from "extra might" */
@@ -1113,57 +1113,6 @@ int critical_shot(PlayerType *player_ptr, WEIGHT weight, int plus_ammo, int plus
     }
 
     return dam;
-}
-
-/*!
- * @brief 射撃武器の攻撃に必要な基本消費エネルギーを返す/Return bow energy
- * @param sval 射撃武器のアイテム副分類ID
- * @return 消費する基本エネルギー
- */
-ENERGY bow_energy(OBJECT_SUBTYPE_VALUE sval)
-{
-    ENERGY energy = 10000;
-
-    /* Analyze the launcher */
-    switch (sval) {
-        /* Sling and ammo */
-    case SV_SLING: {
-        energy = 8000;
-        break;
-    }
-
-    /* Short Bow and Arrow */
-    case SV_SHORT_BOW: {
-        energy = 10000;
-        break;
-    }
-
-    /* Long Bow and Arrow */
-    case SV_LONG_BOW: {
-        energy = 10000;
-        break;
-    }
-
-    /* Bow of irresponsiblity and Arrow */
-    case SV_NAMAKE_BOW: {
-        energy = 7777;
-        break;
-    }
-
-    /* Light Crossbow and Bolt */
-    case SV_LIGHT_XBOW: {
-        energy = 12000;
-        break;
-    }
-
-    /* Heavy Crossbow and Bolt */
-    case SV_HEAVY_XBOW: {
-        energy = 13333;
-        break;
-    }
-    }
-
-    return energy;
 }
 
 /*

--- a/src/combat/shoot.h
+++ b/src/combat/shoot.h
@@ -7,7 +7,6 @@ class ItemEntity;
 class PlayerType;
 bool test_hit_fire(PlayerType *player_ptr, int chance, MonsterEntity *m_ptr, int vis, char *o_name);
 int critical_shot(PlayerType *player_ptr, WEIGHT weight, int plus_ammo, int plus_bow, int dam);
-int bow_tmul(OBJECT_SUBTYPE_VALUE sval);
 int calc_crit_ratio_shot(PlayerType *player_ptr, int plus_ammo, int plus_bow);
 int calc_expect_crit_shot(PlayerType *player_ptr, WEIGHT weight, int plus_ammo, int plus_bow, int dam);
 int calc_expect_crit(PlayerType *player_ptr, WEIGHT weight, int plus, int dam, int16_t meichuu, bool dokubari, bool impact);

--- a/src/combat/shoot.h
+++ b/src/combat/shoot.h
@@ -7,7 +7,6 @@ class ItemEntity;
 class PlayerType;
 bool test_hit_fire(PlayerType *player_ptr, int chance, MonsterEntity *m_ptr, int vis, char *o_name);
 int critical_shot(PlayerType *player_ptr, WEIGHT weight, int plus_ammo, int plus_bow, int dam);
-ENERGY bow_energy(OBJECT_SUBTYPE_VALUE sval);
 int bow_tmul(OBJECT_SUBTYPE_VALUE sval);
 int calc_crit_ratio_shot(PlayerType *player_ptr, int plus_ammo, int plus_bow);
 int calc_expect_crit_shot(PlayerType *player_ptr, WEIGHT weight, int plus_ammo, int plus_bow, int dam);

--- a/src/flavor/flavor-describer.cpp
+++ b/src/flavor/flavor-describer.cpp
@@ -177,7 +177,7 @@ static void describe_bow(PlayerType *player_ptr, flavor_type *flavor_ptr)
         return;
     }
 
-    flavor_ptr->fire_rate = bow_energy(flavor_ptr->o_ptr->sval) / num_fire;
+    flavor_ptr->fire_rate = flavor_ptr->o_ptr->get_bow_energy() / num_fire;
     flavor_ptr->t = object_desc_chr(flavor_ptr->t, ' ');
     flavor_ptr->t = object_desc_chr(flavor_ptr->t, flavor_ptr->p1);
     flavor_ptr->t = object_desc_num(flavor_ptr->t, flavor_ptr->fire_rate / 100);
@@ -242,7 +242,7 @@ static void describe_named_item_tval(flavor_type *flavor_ptr)
 
 static void describe_fire_energy(PlayerType *player_ptr, flavor_type *flavor_ptr)
 {
-    ENERGY energy_fire = bow_energy(flavor_ptr->bow_ptr->sval);
+    const auto energy_fire = flavor_ptr->bow_ptr->get_bow_energy();
     if (player_ptr->num_fire == 0) {
         flavor_ptr->t = object_desc_chr(flavor_ptr->t, '0');
         return;
@@ -256,7 +256,9 @@ static void describe_fire_energy(PlayerType *player_ptr, flavor_type *flavor_ptr
         return;
     }
 
-    int percent = calc_crit_ratio_shot(player_ptr, flavor_ptr->known ? flavor_ptr->o_ptr->to_h : 0, flavor_ptr->known ? flavor_ptr->bow_ptr->to_h : 0);
+    const auto o_bonus = flavor_ptr->known ? flavor_ptr->o_ptr->to_h : 0;
+    const auto bow_bonus = flavor_ptr->known ? flavor_ptr->bow_ptr->to_h : 0;
+    const auto percent = calc_crit_ratio_shot(player_ptr, o_bonus, bow_bonus);
     flavor_ptr->t = object_desc_chr(flavor_ptr->t, '/');
     flavor_ptr->t = object_desc_num(flavor_ptr->t, percent / 100);
     flavor_ptr->t = object_desc_chr(flavor_ptr->t, '.');

--- a/src/flavor/flavor-describer.cpp
+++ b/src/flavor/flavor-describer.cpp
@@ -153,7 +153,7 @@ static void describe_weapon_dice(PlayerType *player_ptr, flavor_type *flavor_ptr
 
 static void describe_bow(PlayerType *player_ptr, flavor_type *flavor_ptr)
 {
-    flavor_ptr->power = bow_tmul(flavor_ptr->o_ptr->sval);
+    flavor_ptr->power = flavor_ptr->o_ptr->get_arrow_magnification();
     if (flavor_ptr->tr_flags.has(TR_XTRA_MIGHT)) {
         flavor_ptr->power++;
     }
@@ -275,7 +275,7 @@ static void describe_bow_power(PlayerType *player_ptr, flavor_type *flavor_ptr)
     const auto *o_ptr = flavor_ptr->o_ptr;
     const auto *bow_ptr = flavor_ptr->bow_ptr;
     flavor_ptr->avgdam = o_ptr->dd * (o_ptr->ds + 1) * 10 / 2;
-    auto tmul = bow_tmul(bow_ptr->sval);
+    auto tmul = bow_ptr->get_arrow_magnification();
     if (bow_ptr->is_known()) {
         flavor_ptr->avgdam += (bow_ptr->to_d * 10);
     }

--- a/src/object/tval-types.h
+++ b/src/object/tval-types.h
@@ -76,8 +76,6 @@ enum class ItemKindType : short {
 
 #define TV_EQUIP_BEGIN ItemKindType::SHOT
 #define TV_EQUIP_END ItemKindType::CARD
-#define TV_WEAPON_BEGIN ItemKindType::BOW
-#define TV_WEAPON_END ItemKindType::SWORD
 
 constexpr auto TV_WEARABLE_RANGE = EnumRange(ItemKindType::BOW, ItemKindType::CARD);
 constexpr auto TV_WEAPON_RANGE = EnumRange(ItemKindType::BOW, ItemKindType::SWORD);

--- a/src/object/tval-types.h
+++ b/src/object/tval-types.h
@@ -74,8 +74,5 @@ enum class ItemKindType : short {
     GOLD = 127, /* Gold can only be picked up by players */
 };
 
-#define TV_EQUIP_BEGIN ItemKindType::SHOT
-#define TV_EQUIP_END ItemKindType::CARD
-
 constexpr auto TV_WEARABLE_RANGE = EnumRange(ItemKindType::BOW, ItemKindType::CARD);
 constexpr auto TV_WEAPON_RANGE = EnumRange(ItemKindType::BOW, ItemKindType::SWORD);

--- a/src/system/baseitem-info.cpp
+++ b/src/system/baseitem-info.cpp
@@ -9,8 +9,13 @@
 
 #include "system/baseitem-info.h"
 #include "object/tval-types.h"
+#include "sv-definition/sv-armor-types.h"
 #include "sv-definition/sv-bow-types.h"
 #include "sv-definition/sv-food-types.h"
+#include "sv-definition/sv-protector-types.h"
+#include "sv-definition/sv-weapon-types.h"
+#include <set>
+#include <unordered_map>
 
 BaseitemKey::BaseitemKey(const ItemKindType type_value, const std::optional<int> &subtype_value)
     : type_value(type_value)
@@ -294,6 +299,113 @@ bool BaseitemKey::is_equipement() const
     default:
         return false;
     }
+}
+
+bool BaseitemKey::is_melee_ammo() const
+{
+    switch (this->type_value) {
+    case ItemKindType::HAFTED:
+    case ItemKindType::POLEARM:
+    case ItemKindType::DIGGING:
+    case ItemKindType::BOLT:
+    case ItemKindType::ARROW:
+    case ItemKindType::SHOT:
+        return true;
+    case ItemKindType::SWORD:
+        return this->subtype_value != SV_POISON_NEEDLE;
+    default:
+        return false;
+    }
+}
+
+bool BaseitemKey::is_orthodox_melee_weapon() const
+{
+    switch (this->type_value) {
+    case ItemKindType::HAFTED:
+    case ItemKindType::POLEARM:
+    case ItemKindType::DIGGING:
+        return true;
+    case ItemKindType::SWORD:
+        return this->subtype_value != SV_POISON_NEEDLE;
+    default:
+        return false;
+    }
+}
+
+bool BaseitemKey::is_broken_weapon() const
+{
+    if (this->type_value != ItemKindType::SWORD) {
+        return false;
+    }
+
+    if (!this->subtype_value.has_value()) {
+        return false;
+    }
+
+    switch (this->subtype_value.value()) {
+    case SV_BROKEN_DAGGER:
+    case SV_BROKEN_SWORD:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool BaseitemKey::is_throwable() const
+{
+    switch (this->type_value) {
+    case ItemKindType::DIGGING:
+    case ItemKindType::HAFTED:
+    case ItemKindType::POLEARM:
+    case ItemKindType::SWORD:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool BaseitemKey::is_wieldable_in_etheir_hand() const
+{
+    switch (this->type_value) {
+    case ItemKindType::DIGGING:
+    case ItemKindType::HAFTED:
+    case ItemKindType::POLEARM:
+    case ItemKindType::SWORD:
+    case ItemKindType::SHIELD:
+    case ItemKindType::CAPTURE:
+    case ItemKindType::CARD:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool BaseitemKey::is_rare() const
+{
+    static const std::unordered_map<ItemKindType, const std::set<int>> rare_table = {
+        { ItemKindType::HAFTED, { SV_MACE_OF_DISRUPTION, SV_WIZSTAFF } },
+        { ItemKindType::POLEARM, { SV_SCYTHE_OF_SLICING, SV_DEATH_SCYTHE } },
+        { ItemKindType::SWORD, { SV_BLADE_OF_CHAOS, SV_DIAMOND_EDGE, SV_POISON_NEEDLE, SV_HAYABUSA } },
+        { ItemKindType::SHIELD, { SV_DRAGON_SHIELD, SV_MIRROR_SHIELD } },
+        { ItemKindType::HELM, { SV_DRAGON_HELM } },
+        { ItemKindType::BOOTS, { SV_PAIR_OF_DRAGON_GREAVE } },
+        { ItemKindType::CLOAK, { SV_ELVEN_CLOAK, SV_ETHEREAL_CLOAK, SV_SHADOW_CLOAK, SV_MAGIC_RESISTANCE_CLOAK } },
+        { ItemKindType::GLOVES, { SV_SET_OF_DRAGON_GLOVES } },
+        { ItemKindType::SOFT_ARMOR, { SV_KUROSHOUZOKU, SV_ABUNAI_MIZUGI } },
+        { ItemKindType::HARD_ARMOR, { SV_MITHRIL_CHAIN_MAIL, SV_MITHRIL_PLATE_MAIL, SV_ADAMANTITE_PLATE_MAIL } },
+        { ItemKindType::DRAG_ARMOR, { /* Any */ } },
+    };
+
+    if (!this->subtype_value.has_value()) {
+        return false;
+    }
+
+    if (auto it = rare_table.find(this->type_value); it != rare_table.end()) {
+        const auto &svals = it->second;
+        return svals.empty() || (svals.find(this->subtype_value.value()) != svals.end());
+    }
+
+    return false;
 }
 
 bool BaseitemKey::is_mushrooms() const

--- a/src/system/baseitem-info.cpp
+++ b/src/system/baseitem-info.cpp
@@ -17,6 +17,10 @@
 #include <set>
 #include <unordered_map>
 
+namespace {
+constexpr auto ITEM_NOT_BOW = "This item is not a bow!";
+}
+
 BaseitemKey::BaseitemKey(const ItemKindType type_value, const std::optional<int> &subtype_value)
     : type_value(type_value)
     , subtype_value(subtype_value)
@@ -411,7 +415,7 @@ bool BaseitemKey::is_rare() const
 short BaseitemKey::get_bow_energy() const
 {
     if ((this->type_value != ItemKindType::BOW) || !this->subtype_value.has_value()) {
-        throw std::logic_error("This item is not a bow!");
+        throw std::logic_error(ITEM_NOT_BOW);
     }
 
     switch (this->subtype_value.value()) {
@@ -425,6 +429,27 @@ short BaseitemKey::get_bow_energy() const
         return 13333;
     default:
         return 10000;
+    }
+}
+
+int BaseitemKey::get_arrow_magnification() const
+{
+    if ((this->type_value != ItemKindType::BOW) || !this->subtype_value.has_value()) {
+        throw std::logic_error(ITEM_NOT_BOW);
+    }
+
+    switch (this->subtype_value.value()) {
+    case SV_SLING:
+    case SV_SHORT_BOW:
+        return 2;
+    case SV_LONG_BOW:
+    case SV_NAMAKE_BOW:
+    case SV_LIGHT_XBOW:
+        return 3;
+    case SV_HEAVY_XBOW:
+        return 4;
+    default:
+        return 0;
     }
 }
 

--- a/src/system/baseitem-info.cpp
+++ b/src/system/baseitem-info.cpp
@@ -266,6 +266,36 @@ bool BaseitemKey::is_weapon() const
     }
 }
 
+bool BaseitemKey::is_equipement() const
+{
+    switch (this->type_value) {
+    case ItemKindType::SHOT:
+    case ItemKindType::ARROW:
+    case ItemKindType::BOLT:
+    case ItemKindType::BOW:
+    case ItemKindType::DIGGING:
+    case ItemKindType::HAFTED:
+    case ItemKindType::POLEARM:
+    case ItemKindType::SWORD:
+    case ItemKindType::BOOTS:
+    case ItemKindType::GLOVES:
+    case ItemKindType::HELM:
+    case ItemKindType::CROWN:
+    case ItemKindType::SHIELD:
+    case ItemKindType::CLOAK:
+    case ItemKindType::SOFT_ARMOR:
+    case ItemKindType::HARD_ARMOR:
+    case ItemKindType::DRAG_ARMOR:
+    case ItemKindType::LITE:
+    case ItemKindType::AMULET:
+    case ItemKindType::RING:
+    case ItemKindType::CARD:
+        return true;
+    default:
+        return false;
+    }
+}
+
 bool BaseitemKey::is_mushrooms() const
 {
     if (!this->subtype_value.has_value()) {

--- a/src/system/baseitem-info.cpp
+++ b/src/system/baseitem-info.cpp
@@ -408,6 +408,26 @@ bool BaseitemKey::is_rare() const
     return false;
 }
 
+short BaseitemKey::get_bow_energy() const
+{
+    if ((this->type_value != ItemKindType::BOW) || !this->subtype_value.has_value()) {
+        throw std::logic_error("This item is not a bow!");
+    }
+
+    switch (this->subtype_value.value()) {
+    case SV_SLING:
+        return 8000;
+    case SV_NAMAKE_BOW:
+        return 7777;
+    case SV_LIGHT_XBOW:
+        return 12000;
+    case SV_HEAVY_XBOW:
+        return 13333;
+    default:
+        return 10000;
+    }
+}
+
 bool BaseitemKey::is_mushrooms() const
 {
     if (!this->subtype_value.has_value()) {

--- a/src/system/baseitem-info.cpp
+++ b/src/system/baseitem-info.cpp
@@ -252,6 +252,20 @@ bool BaseitemKey::is_wearable() const
     }
 }
 
+bool BaseitemKey::is_weapon() const
+{
+    switch (this->type_value) {
+    case ItemKindType::BOW:
+    case ItemKindType::DIGGING:
+    case ItemKindType::HAFTED:
+    case ItemKindType::POLEARM:
+    case ItemKindType::SWORD:
+        return true;
+    default:
+        return false;
+    }
+}
+
 bool BaseitemKey::is_mushrooms() const
 {
     if (!this->subtype_value.has_value()) {

--- a/src/system/baseitem-info.h
+++ b/src/system/baseitem-info.h
@@ -58,6 +58,7 @@ public:
     bool is_wieldable_in_etheir_hand() const;
     bool is_rare() const;
     short get_bow_energy() const;
+    int get_arrow_magnification() const;
 
 private:
     ItemKindType type_value;

--- a/src/system/baseitem-info.h
+++ b/src/system/baseitem-info.h
@@ -49,6 +49,7 @@ public:
     bool is_protector() const;
     bool can_be_aura_protector() const;
     bool is_wearable() const;
+    bool is_weapon() const;
 
 private:
     ItemKindType type_value;

--- a/src/system/baseitem-info.h
+++ b/src/system/baseitem-info.h
@@ -51,6 +51,12 @@ public:
     bool is_wearable() const;
     bool is_weapon() const;
     bool is_equipement() const;
+    bool is_melee_ammo() const;
+    bool is_orthodox_melee_weapon() const;
+    bool is_broken_weapon() const;
+    bool is_throwable() const;
+    bool is_wieldable_in_etheir_hand() const;
+    bool is_rare() const;
 
 private:
     ItemKindType type_value;

--- a/src/system/baseitem-info.h
+++ b/src/system/baseitem-info.h
@@ -57,6 +57,7 @@ public:
     bool is_throwable() const;
     bool is_wieldable_in_etheir_hand() const;
     bool is_rare() const;
+    short get_bow_energy() const;
 
 private:
     ItemKindType type_value;

--- a/src/system/baseitem-info.h
+++ b/src/system/baseitem-info.h
@@ -50,6 +50,7 @@ public:
     bool can_be_aura_protector() const;
     bool is_wearable() const;
     bool is_weapon() const;
+    bool is_equipement() const;
 
 private:
     ItemKindType type_value;

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -179,7 +179,7 @@ bool ItemEntity::is_wearable() const
  */
 bool ItemEntity::is_equipment() const
 {
-    return (TV_EQUIP_BEGIN <= this->tval) && (this->tval <= TV_EQUIP_END);
+    return BaseitemKey(this->tval).is_equipement();
 }
 
 /*!

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -768,3 +768,8 @@ short ItemEntity::get_bow_energy() const
 {
     return BaseitemKey(this->tval, this->sval).get_bow_energy();
 }
+
+int ItemEntity::get_arrow_magnification() const
+{
+    return BaseitemKey(this->tval, this->sval).get_arrow_magnification();
+}

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -1,8 +1,9 @@
 ﻿/*
  * @file item-entity.cpp
- * @brief アイテム定義の構造体とエンティティ処理実装
+ * @brief アイテム実体とそれにまつわる判定処理群
  * @author Hourier
- * @date 2022/10/09
+ * @date 2022/11/25
+ * @details オブジェクトの状態を変更するメソッドは道半ば
  */
 
 #include "system/item-entity.h"
@@ -11,23 +12,18 @@
 #include "monster-race/monster-race.h"
 #include "object-enchant/object-curse.h"
 #include "object-enchant/special-object-flags.h"
-#include "object-enchant/tr-types.h"
-#include "object-enchant/trc-types.h"
-#include "object-enchant/trg-types.h"
 #include "object/object-flags.h"
 #include "object/object-value.h"
 #include "object/tval-types.h"
 #include "smith/object-smith.h"
-#include "sv-definition/sv-armor-types.h"
 #include "sv-definition/sv-lite-types.h"
 #include "sv-definition/sv-other-types.h"
-#include "sv-definition/sv-protector-types.h"
 #include "sv-definition/sv-weapon-types.h"
 #include "system/baseitem-info.h"
 #include "system/monster-race-info.h"
-#include "system/player-type-definition.h"
 #include "term/term-color-types.h"
 #include "util/bit-flags-calculator.h"
+#include "util/enum-converter.h"
 #include "util/string-processor.h"
 
 ItemEntity::ItemEntity()
@@ -63,7 +59,7 @@ void ItemEntity::prep(short new_bi_id)
 {
     auto *k_ptr = &baseitems_info[new_bi_id];
     auto old_stack_idx = this->stack_idx;
-    wipe();
+    this->wipe();
     this->stack_idx = old_stack_idx;
     this->bi_id = new_bi_id;
     this->tval = k_ptr->bi_key.tval();
@@ -500,7 +496,7 @@ bool ItemEntity::is_fuel() const
 {
     const BaseitemKey bi_key(this->tval, this->sval);
     auto is_fuel = bi_key == BaseitemKey(ItemKindType::LITE, SV_LITE_TORCH);
-    is_fuel |= bi_key == BaseitemKey(ItemKindType::LITE,  SV_LITE_LANTERN);
+    is_fuel |= bi_key == BaseitemKey(ItemKindType::LITE, SV_LITE_LANTERN);
     is_fuel |= bi_key == BaseitemKey(ItemKindType::FLASK, SV_FLASK_OIL);
     return is_fuel;
 }

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -113,7 +113,7 @@ void ItemEntity::prep(short new_bi_id)
  */
 bool ItemEntity::is_weapon() const
 {
-    return (TV_WEAPON_BEGIN <= this->tval) && (this->tval <= TV_WEAPON_END);
+    return BaseitemKey(this->tval).is_weapon();
 }
 
 /*!

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -57,46 +57,52 @@ void ItemEntity::copy_from(const ItemEntity *j_ptr)
  */
 void ItemEntity::prep(short new_bi_id)
 {
-    auto *k_ptr = &baseitems_info[new_bi_id];
+    const auto &baseitem = baseitems_info[new_bi_id];
     auto old_stack_idx = this->stack_idx;
     this->wipe();
     this->stack_idx = old_stack_idx;
     this->bi_id = new_bi_id;
-    this->tval = k_ptr->bi_key.tval();
-    this->sval = k_ptr->bi_key.sval().value();
-    this->pval = k_ptr->pval;
+    this->tval = baseitem.bi_key.tval();
+    this->sval = baseitem.bi_key.sval().value();
+    this->pval = baseitem.pval;
     this->number = 1;
-    this->weight = k_ptr->weight;
-    this->to_h = k_ptr->to_h;
-    this->to_d = k_ptr->to_d;
-    this->to_a = k_ptr->to_a;
-    this->ac = k_ptr->ac;
-    this->dd = k_ptr->dd;
-    this->ds = k_ptr->ds;
+    this->weight = baseitem.weight;
+    this->to_h = baseitem.to_h;
+    this->to_d = baseitem.to_d;
+    this->to_a = baseitem.to_a;
+    this->ac = baseitem.ac;
+    this->dd = baseitem.dd;
+    this->ds = baseitem.ds;
 
-    if (k_ptr->act_idx > RandomArtActType::NONE) {
-        this->activation_id = k_ptr->act_idx;
+    if (baseitem.act_idx > RandomArtActType::NONE) {
+        this->activation_id = baseitem.act_idx;
     }
+
     if (baseitems_info[this->bi_id].cost <= 0) {
         this->ident |= (IDENT_BROKEN);
     }
 
-    if (k_ptr->gen_flags.has(ItemGenerationTraitType::CURSED)) {
+    if (baseitem.gen_flags.has(ItemGenerationTraitType::CURSED)) {
         this->curse_flags.set(CurseTraitType::CURSED);
     }
-    if (k_ptr->gen_flags.has(ItemGenerationTraitType::HEAVY_CURSE)) {
+
+    if (baseitem.gen_flags.has(ItemGenerationTraitType::HEAVY_CURSE)) {
         this->curse_flags.set(CurseTraitType::HEAVY_CURSE);
     }
-    if (k_ptr->gen_flags.has(ItemGenerationTraitType::PERMA_CURSE)) {
+
+    if (baseitem.gen_flags.has(ItemGenerationTraitType::PERMA_CURSE)) {
         this->curse_flags.set(CurseTraitType::PERMA_CURSE);
     }
-    if (k_ptr->gen_flags.has(ItemGenerationTraitType::RANDOM_CURSE0)) {
+
+    if (baseitem.gen_flags.has(ItemGenerationTraitType::RANDOM_CURSE0)) {
         this->curse_flags.set(get_curse(0, this));
     }
-    if (k_ptr->gen_flags.has(ItemGenerationTraitType::RANDOM_CURSE1)) {
+
+    if (baseitem.gen_flags.has(ItemGenerationTraitType::RANDOM_CURSE1)) {
         this->curse_flags.set(get_curse(1, this));
     }
-    if (k_ptr->gen_flags.has(ItemGenerationTraitType::RANDOM_CURSE2)) {
+
+    if (baseitem.gen_flags.has(ItemGenerationTraitType::RANDOM_CURSE2)) {
         this->curse_flags.set(get_curse(2, this));
     }
 }

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -763,3 +763,8 @@ bool ItemEntity::is_wand_staff() const
 {
     return BaseitemKey(this->tval).is_wand_staff();
 }
+
+short ItemEntity::get_bow_energy() const
+{
+    return BaseitemKey(this->tval, this->sval).get_bow_energy();
+}

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -126,6 +126,7 @@ public:
     ItemKindType get_arrow_kind() const;
     bool is_wand_rod() const;
     bool is_wand_staff() const;
+    short get_bow_energy() const;
 
 private:
     int get_baseitem_price() const;

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -127,6 +127,7 @@ public:
     bool is_wand_rod() const;
     bool is_wand_staff() const;
     short get_bow_energy() const;
+    int get_arrow_magnification() const;
 
 private:
     int get_baseitem_price() const;

--- a/src/view/display-player-middle.cpp
+++ b/src/view/display-player-middle.cpp
@@ -126,7 +126,7 @@ static void display_shoot_magnification(PlayerType *player_ptr)
 {
     int tmul = 0;
     if (player_ptr->inventory_list[INVEN_BOW].bi_id) {
-        tmul = bow_tmul(player_ptr->inventory_list[INVEN_BOW].sval);
+        tmul = player_ptr->inventory_list[INVEN_BOW].get_arrow_magnification();
         if (player_ptr->xtra_might) {
             tmul++;
         }

--- a/src/view/status-first-page.cpp
+++ b/src/view/status-first-page.cpp
@@ -45,7 +45,7 @@ static void calc_shot_params(PlayerType *player_ptr, ItemEntity *o_ptr, int *sho
         return;
     }
 
-    ENERGY energy_fire = bow_energy(o_ptr->sval);
+    const auto energy_fire = o_ptr->get_bow_energy();
     *shots = player_ptr->num_fire * 100;
     *shot_frac = ((*shots) * 100 / energy_fire) % 100;
     *shots = (*shots) / energy_fire;


### PR DESCRIPTION
掲題の通りです
ItemEntity のオブジェクトメソッドをBaseitemKey のオブジェクトメソッドにリダイレクトした他、本体作業のための最適化を複数図りました
(tval/svalに依存する関数の、BaseitemKey のオブジェクトメソッドへの繰り込み 他)
ロジック変更も複数あります
ご確認下さい