### PR TITLE
ItemEntity::tval/sval をBaseitemKey に差し替えるための準備をした その5

### DIFF
--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -58,14 +58,14 @@
  * @param o_ptr 食べるオブジェクト
  * @return 鑑定されるならTRUE、されないならFALSE
  */
-static bool exe_eat_food_type_object(PlayerType *player_ptr, ItemEntity *o_ptr)
+static bool exe_eat_food_type_object(PlayerType *player_ptr, const BaseitemKey &bi_key)
 {
-    if (o_ptr->tval != ItemKindType::FOOD) {
+    if (bi_key.tval() != ItemKindType::FOOD) {
         return false;
     }
 
     BadStatusSetter bss(player_ptr);
-    switch (o_ptr->sval) {
+    switch (bi_key.sval().value()) {
     case SV_FOOD_POISON:
         return (!(has_resist_pois(player_ptr) || is_oppose_pois(player_ptr))) && bss.mod_poison(randint0(10) + 10);
     case SV_FOOD_BLINDNESS:
@@ -232,7 +232,7 @@ void exe_eat_food(PlayerType *player_ptr, INVENTORY_IDX item)
     int lev = baseitems_info[o_ptr->bi_id].level;
 
     /* Identity not known yet */
-    int ident = exe_eat_food_type_object(player_ptr, o_ptr);
+    int ident = exe_eat_food_type_object(player_ptr, { o_ptr->tval, o_ptr->sval });
 
     /*
      * Store what may have to be updated for the inventory (including

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -58,7 +58,7 @@
  * @param o_ptr 食べるオブジェクト
  * @return 鑑定されるならTRUE、されないならFALSE
  */
-bool exe_eat_food_type_object(PlayerType *player_ptr, ItemEntity *o_ptr)
+static bool exe_eat_food_type_object(PlayerType *player_ptr, ItemEntity *o_ptr)
 {
     if (o_ptr->tval != ItemKindType::FOOD) {
         return false;
@@ -148,72 +148,63 @@ bool exe_eat_food_type_object(PlayerType *player_ptr, ItemEntity *o_ptr)
  * @brief 魔法道具のチャージをの食料として食べたときの効果を発動
  * @param player_ptr プレイヤー情報への参照ポインタ
  * @param o_ptr 食べるオブジェクト
- * @param item オブジェクトのインベントリ番号
+ * @param inventory オブジェクトのインベントリ番号
  * @return 食べようとしたらTRUE、しなかったらFALSE
  */
-bool exe_eat_charge_of_magic_device(PlayerType *player_ptr, ItemEntity *o_ptr, INVENTORY_IDX item)
+static bool exe_eat_charge_of_magic_device(PlayerType *player_ptr, ItemEntity *o_ptr, short inventory)
 {
-    if (!o_ptr->is_wand_staff()) {
+    if (!o_ptr->is_wand_staff() || (PlayerRace(player_ptr).food() != PlayerRaceFoodType::MANA)) {
         return false;
     }
 
-    if (PlayerRace(player_ptr).food() == PlayerRaceFoodType::MANA) {
-        concptr staff;
-
-        if (o_ptr->tval == ItemKindType::STAFF && (item < 0) && (o_ptr->number > 1)) {
-            msg_print(_("まずは杖を拾わなければ。", "You must first pick up the staffs."));
-            return true;
-        }
-
-        staff = (o_ptr->tval == ItemKindType::STAFF) ? _("杖", "staff") : _("魔法棒", "wand");
-
-        /* "Eat" charges */
-        if (o_ptr->pval == 0) {
-            msg_format(_("この%sにはもう魔力が残っていない。", "The %s has no charges left."), staff);
-            o_ptr->ident |= (IDENT_EMPTY);
-            player_ptr->window_flags |= (PW_INVEN);
-            return true;
-        }
-
-        msg_format(_("あなたは%sの魔力をエネルギー源として吸収した。", "You absorb mana of the %s as your energy."), staff);
-
-        /* Use a single charge */
-        o_ptr->pval--;
-
-        /* Eat a charge */
-        set_food(player_ptr, player_ptr->food + 5000);
-
-        /* XXX Hack -- unstack if necessary */
-        if (o_ptr->tval == ItemKindType::STAFF && (item >= 0) && (o_ptr->number > 1)) {
-            ItemEntity forge;
-            ItemEntity *q_ptr;
-            q_ptr = &forge;
-            q_ptr->copy_from(o_ptr);
-
-            /* Modify quantity */
-            q_ptr->number = 1;
-
-            /* Restore the charges */
-            o_ptr->pval++;
-
-            /* Unstack the used item */
-            o_ptr->number--;
-            item = store_item_to_inventory(player_ptr, q_ptr);
-
-            msg_format(_("杖をまとめなおした。", "You unstack your staff."));
-        }
-
-        if (item >= 0) {
-            inven_item_charges(player_ptr->inventory_list[item]);
-        } else {
-            floor_item_charges(player_ptr->current_floor_ptr, 0 - item);
-        }
-
-        player_ptr->window_flags |= (PW_INVEN | PW_EQUIP);
+    const auto is_staff = o_ptr->tval == ItemKindType::STAFF;
+    if (is_staff && (inventory < 0) && (o_ptr->number > 1)) {
+        msg_print(_("まずは杖を拾わなければ。", "You must first pick up the staffs."));
         return true;
     }
 
-    return false;
+    const auto staff = is_staff ? _("杖", "staff") : _("魔法棒", "wand");
+
+    /* "Eat" charges */
+    if (o_ptr->pval == 0) {
+        msg_format(_("この%sにはもう魔力が残っていない。", "The %s has no charges left."), staff);
+        o_ptr->ident |= IDENT_EMPTY;
+        player_ptr->window_flags |= PW_INVEN;
+        return true;
+    }
+
+    msg_format(_("あなたは%sの魔力をエネルギー源として吸収した。", "You absorb mana of the %s as your energy."), staff);
+
+    /* Use a single charge */
+    o_ptr->pval--;
+
+    /* Eat a charge */
+    set_food(player_ptr, player_ptr->food + 5000);
+
+    /* XXX Hack -- unstack if necessary */
+    if (is_staff && (inventory >= 0) && (o_ptr->number > 1)) {
+        auto item = *o_ptr;
+
+        /* Modify quantity */
+        item.number = 1;
+
+        /* Restore the charges */
+        o_ptr->pval++;
+
+        /* Unstack the used item */
+        o_ptr->number--;
+        inventory = store_item_to_inventory(player_ptr, &item);
+        msg_format(_("杖をまとめなおした。", "You unstack your staff."));
+    }
+
+    if (inventory >= 0) {
+        inven_item_charges(player_ptr->inventory_list[inventory]);
+    } else {
+        floor_item_charges(player_ptr->current_floor_ptr, 0 - inventory);
+    }
+
+    player_ptr->window_flags |= PW_INVEN | PW_EQUIP;
+    return true;
 }
 
 /*!

--- a/src/cmd-item/cmd-magiceat.cpp
+++ b/src/cmd-item/cmd-magiceat.cpp
@@ -72,8 +72,6 @@
 #include "player-status/player-energy.h"
 #include "player/player-status-table.h"
 #include "spell/spell-info.h"
-#include "sv-definition/sv-other-types.h"
-#include "sv-definition/sv-rod-types.h"
 #include "system/baseitem-info.h"
 #include "system/player-type-definition.h"
 #include "target/target-getter.h"
@@ -598,14 +596,11 @@ bool do_cmd_magic_eater(PlayerType *player_ptr, bool only_browse, bool powerful)
                 return false;
             }
 
-            const auto sval = opt_sval.value();
-            if ((sval >= SV_ROD_MIN_DIRECTION) && (sval != SV_ROD_HAVOC) && (sval != SV_ROD_AGGRAVATE) && (sval != SV_ROD_PESTICIDE)) {
-                if (!get_aim_dir(player_ptr, &dir)) {
-                    return false;
-                }
+            if (baseitem.is_aiming_rod() && !get_aim_dir(player_ptr, &dir)) {
+                return false;
             }
 
-            (void)rod_effect(player_ptr, sval, dir, &use_charge, powerful);
+            (void)rod_effect(player_ptr, opt_sval.value(), dir, &use_charge, powerful);
             if (!use_charge) {
                 return false;
             }

--- a/src/cmd-item/cmd-magiceat.cpp
+++ b/src/cmd-item/cmd-magiceat.cpp
@@ -132,7 +132,7 @@ static std::optional<BaseitemKey> check_magic_eater_spell_repeat(magic_eater_dat
 /*!
  * @brief 魔道具術師の取り込んだ魔力一覧から選択/閲覧する /
  * @param only_browse 閲覧するだけならばTRUE
- * @return 選択した魔力のID、キャンセルならば-1を返す
+ * @return 選択したアイテムのベースアイテムキー、キャンセルならばnullopt
  */
 static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, bool only_browse)
 {
@@ -591,8 +591,8 @@ bool do_cmd_magic_eater(PlayerType *player_ptr, bool only_browse, bool powerful)
 
         switch (baseitem.tval()) {
         case ItemKindType::ROD: {
-            const auto opt_sval = baseitem.sval();
-            if (!opt_sval.has_value()) {
+            const auto sval = baseitem.sval();
+            if (!sval.has_value()) {
                 return false;
             }
 
@@ -600,7 +600,7 @@ bool do_cmd_magic_eater(PlayerType *player_ptr, bool only_browse, bool powerful)
                 return false;
             }
 
-            (void)rod_effect(player_ptr, opt_sval.value(), dir, &use_charge, powerful);
+            (void)rod_effect(player_ptr, sval.value(), dir, &use_charge, powerful);
             if (!use_charge) {
                 return false;
             }
@@ -608,8 +608,8 @@ bool do_cmd_magic_eater(PlayerType *player_ptr, bool only_browse, bool powerful)
             break;
         }
         case ItemKindType::WAND: {
-            const auto opt_sval = baseitem.sval();
-            if (!opt_sval.has_value()) {
+            const auto sval = baseitem.sval();
+            if (!sval.has_value()) {
                 return false;
             }
 
@@ -617,18 +617,16 @@ bool do_cmd_magic_eater(PlayerType *player_ptr, bool only_browse, bool powerful)
                 return false;
             }
 
-            const auto sval = opt_sval.value();
-            wand_effect(player_ptr, sval, dir, powerful, true);
+            (void)wand_effect(player_ptr, sval.value(), dir, powerful, true);
             break;
         }
         default:
-            const auto opt_sval = baseitem.sval();
-            if (!opt_sval.has_value()) {
+            const auto sval = baseitem.sval();
+            if (!sval.has_value()) {
                 return false;
             }
 
-            const auto sval = opt_sval.value();
-            staff_effect(player_ptr, sval, &use_charge, powerful, true, true);
+            (void)staff_effect(player_ptr, sval.value(), &use_charge, powerful, true, true);
             if (!use_charge) {
                 return false;
             }

--- a/src/object-use/zaprod-execution.cpp
+++ b/src/object-use/zaprod-execution.cpp
@@ -53,7 +53,7 @@ void ObjectZapRodEntity::execute(INVENTORY_IDX item)
         return;
     }
 
-    if (((o_ptr->sval >= SV_ROD_MIN_DIRECTION) && (o_ptr->sval != SV_ROD_HAVOC) && (o_ptr->sval != SV_ROD_AGGRAVATE) && (o_ptr->sval != SV_ROD_PESTICIDE)) || !o_ptr->is_aware()) {
+    if (o_ptr->is_aiming_rod() || !o_ptr->is_aware()) {
         if (!get_aim_dir(this->player_ptr, &dir)) {
             return;
         }

--- a/src/object/object-flags.cpp
+++ b/src/object/object-flags.cpp
@@ -4,23 +4,11 @@
 #include "object-enchant/tr-types.h"
 #include "perception/object-perception.h"
 #include "smith/object-smith.h"
-#include "sv-definition/sv-lite-types.h"
 #include "system/artifact-type-definition.h"
 #include "system/baseitem-info.h"
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
-
-static bool has_fuel(int sval)
-{
-    switch (sval) {
-    case SV_LITE_TORCH:
-    case SV_LITE_LANTERN:
-        return true;
-    default:
-        return false;
-    }
-}
 
 /*!
  * @brief 光源用のフラグを付与する
@@ -37,18 +25,17 @@ static void object_flags_lite(const ItemEntity *o_ptr, TrFlags &flgs)
     flgs.set(ego.flags);
 
     const auto is_out_of_fuel = o_ptr->fuel == 0;
-    const auto sval = o_ptr->sval;
-    if ((o_ptr->ego_idx == EgoType::AURA_FIRE) && is_out_of_fuel && has_fuel(sval)) {
+    if ((o_ptr->ego_idx == EgoType::AURA_FIRE) && is_out_of_fuel && o_ptr->is_lite_requiring_fuel()) {
         flgs.reset(TR_SH_FIRE);
         return;
     }
 
-    if ((o_ptr->ego_idx == EgoType::LITE_INFRA) && is_out_of_fuel && has_fuel(sval)) {
+    if ((o_ptr->ego_idx == EgoType::LITE_INFRA) && is_out_of_fuel && o_ptr->is_lite_requiring_fuel()) {
         flgs.reset(TR_INFRA);
         return;
     }
 
-    if ((o_ptr->ego_idx == EgoType::LITE_EYE) && is_out_of_fuel && has_fuel(sval)) {
+    if ((o_ptr->ego_idx == EgoType::LITE_EYE) && is_out_of_fuel && o_ptr->is_lite_requiring_fuel()) {
         flgs.reset(TR_RES_BLIND);
         flgs.reset(TR_SEE_INVIS);
     }

--- a/src/object/object-flags.cpp
+++ b/src/object/object-flags.cpp
@@ -11,6 +11,17 @@
 #include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 
+static bool has_fuel(int sval)
+{
+    switch (sval) {
+    case SV_LITE_TORCH:
+    case SV_LITE_LANTERN:
+        return true;
+    default:
+        return false;
+    }
+}
+
 /*!
  * @brief 光源用のフラグを付与する
  * @param o_ptr フラグ取得元のオブジェクト構造体ポインタ
@@ -22,21 +33,22 @@ static void object_flags_lite(const ItemEntity *o_ptr, TrFlags &flgs)
         return;
     }
 
-    auto *e_ptr = &egos_info[o_ptr->ego_idx];
-    flgs.set(e_ptr->flags);
+    const auto &ego = egos_info[o_ptr->ego_idx];
+    flgs.set(ego.flags);
 
-    auto is_out_of_fuel = o_ptr->fuel == 0;
-    if ((o_ptr->ego_idx == EgoType::AURA_FIRE) && is_out_of_fuel && (o_ptr->sval <= SV_LITE_LANTERN)) {
+    const auto is_out_of_fuel = o_ptr->fuel == 0;
+    const auto sval = o_ptr->sval;
+    if ((o_ptr->ego_idx == EgoType::AURA_FIRE) && is_out_of_fuel && has_fuel(sval)) {
         flgs.reset(TR_SH_FIRE);
         return;
     }
 
-    if ((o_ptr->ego_idx == EgoType::LITE_INFRA) && is_out_of_fuel && (o_ptr->sval <= SV_LITE_LANTERN)) {
+    if ((o_ptr->ego_idx == EgoType::LITE_INFRA) && is_out_of_fuel && has_fuel(sval)) {
         flgs.reset(TR_INFRA);
         return;
     }
 
-    if ((o_ptr->ego_idx == EgoType::LITE_EYE) && is_out_of_fuel && (o_ptr->sval <= SV_LITE_LANTERN)) {
+    if ((o_ptr->ego_idx == EgoType::LITE_EYE) && is_out_of_fuel && has_fuel(sval)) {
         flgs.reset(TR_RES_BLIND);
         flgs.reset(TR_SEE_INVIS);
     }

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -59,24 +59,6 @@
 #endif
 
 /*!
- * @brief 呪術領域の武器呪縛の対象にできる武器かどうかを返す。 / An "item_tester_hook" for offer
- * @param o_ptr オブジェクト構造体の参照ポインタ
- * @return 呪縛可能な武器ならばTRUEを返す
- */
-static bool item_tester_hook_weapon_except_bow(const ItemEntity *o_ptr)
-{
-    switch (o_ptr->tval) {
-    case ItemKindType::SWORD:
-    case ItemKindType::HAFTED:
-    case ItemKindType::POLEARM:
-    case ItemKindType::DIGGING:
-        return true;
-    default:
-        return false;
-    }
-}
-
-/*!
  * @brief 呪術領域魔法の各処理を行う
  * @param spell 魔法ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO / SpellProcessType::CAST / SPELL_CONT / SpellProcessType::STOP)
@@ -190,7 +172,7 @@ concptr do_hex_spell(PlayerType *player_ptr, spell_hex_type spell, SpellProcessT
             q = _("どれを呪いますか？", "Which weapon do you curse?");
             s = _("武器を装備していない。", "You're not wielding a weapon.");
 
-            o_ptr = choose_object(player_ptr, &item, q, s, (USE_EQUIP), FuncItemTester(item_tester_hook_weapon_except_bow));
+            o_ptr = choose_object(player_ptr, &item, q, s, (USE_EQUIP), FuncItemTester(&ItemEntity::is_melee_weapon));
             if (!o_ptr) {
                 return "";
             }

--- a/src/system/baseitem-info.cpp
+++ b/src/system/baseitem-info.cpp
@@ -13,12 +13,14 @@
 #include "sv-definition/sv-bow-types.h"
 #include "sv-definition/sv-food-types.h"
 #include "sv-definition/sv-protector-types.h"
+#include "sv-definition/sv-rod-types.h"
 #include "sv-definition/sv-weapon-types.h"
 #include <set>
 #include <unordered_map>
 
 namespace {
 constexpr auto ITEM_NOT_BOW = "This item is not a bow!";
+constexpr auto ITEM_NOT_ROD = "This item is not a rod!";
 }
 
 BaseitemKey::BaseitemKey(const ItemKindType type_value, const std::optional<int> &subtype_value)
@@ -450,6 +452,35 @@ int BaseitemKey::get_arrow_magnification() const
         return 4;
     default:
         return 0;
+    }
+}
+
+bool BaseitemKey::is_aiming_rod() const
+{
+    if ((this->type_value != ItemKindType::ROD) || !this->subtype_value.has_value()) {
+        throw std::logic_error(ITEM_NOT_ROD);
+    }
+
+    switch (this->subtype_value.value()) {
+    case SV_ROD_TELEPORT_AWAY:
+    case SV_ROD_DISARMING:
+    case SV_ROD_LITE:
+    case SV_ROD_SLEEP_MONSTER:
+    case SV_ROD_SLOW_MONSTER:
+    case SV_ROD_HYPODYNAMIA:
+    case SV_ROD_POLYMORPH:
+    case SV_ROD_ACID_BOLT:
+    case SV_ROD_ELEC_BOLT:
+    case SV_ROD_FIRE_BOLT:
+    case SV_ROD_COLD_BOLT:
+    case SV_ROD_ACID_BALL:
+    case SV_ROD_ELEC_BALL:
+    case SV_ROD_FIRE_BALL:
+    case SV_ROD_COLD_BALL:
+    case SV_ROD_STONE_TO_MUD:
+        return true;
+    default:
+        return false;
     }
 }
 

--- a/src/system/baseitem-info.cpp
+++ b/src/system/baseitem-info.cpp
@@ -12,6 +12,7 @@
 #include "sv-definition/sv-armor-types.h"
 #include "sv-definition/sv-bow-types.h"
 #include "sv-definition/sv-food-types.h"
+#include "sv-definition/sv-lite-types.h"
 #include "sv-definition/sv-protector-types.h"
 #include "sv-definition/sv-rod-types.h"
 #include "sv-definition/sv-weapon-types.h"
@@ -21,6 +22,7 @@
 namespace {
 constexpr auto ITEM_NOT_BOW = "This item is not a bow!";
 constexpr auto ITEM_NOT_ROD = "This item is not a rod!";
+constexpr auto ITEM_NOT_LITE = "This item is not a lite!";
 }
 
 BaseitemKey::BaseitemKey(const ItemKindType type_value, const std::optional<int> &subtype_value)
@@ -478,6 +480,21 @@ bool BaseitemKey::is_aiming_rod() const
     case SV_ROD_FIRE_BALL:
     case SV_ROD_COLD_BALL:
     case SV_ROD_STONE_TO_MUD:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool BaseitemKey::is_lite_requiring_fuel() const
+{
+    if ((this->type_value != ItemKindType::LITE) || !this->subtype_value.has_value()) {
+        throw std::logic_error(ITEM_NOT_LITE);
+    }
+
+    switch (this->subtype_value.value()) {
+    case SV_LITE_TORCH:
+    case SV_LITE_LANTERN:
         return true;
     default:
         return false;

--- a/src/system/baseitem-info.h
+++ b/src/system/baseitem-info.h
@@ -59,6 +59,7 @@ public:
     bool is_rare() const;
     short get_bow_energy() const;
     int get_arrow_magnification() const;
+    bool is_aiming_rod() const;
 
 private:
     ItemKindType type_value;

--- a/src/system/baseitem-info.h
+++ b/src/system/baseitem-info.h
@@ -60,6 +60,7 @@ public:
     short get_bow_energy() const;
     int get_arrow_magnification() const;
     bool is_aiming_rod() const;
+    bool is_lite_requiring_fuel() const;
 
 private:
     ItemKindType type_value;

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -773,3 +773,8 @@ int ItemEntity::get_arrow_magnification() const
 {
     return BaseitemKey(this->tval, this->sval).get_arrow_magnification();
 }
+
+bool ItemEntity::is_aiming_rod() const
+{
+    return BaseitemKey(this->tval, this->sval).is_aiming_rod();
+}

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -778,3 +778,8 @@ bool ItemEntity::is_aiming_rod() const
 {
     return BaseitemKey(this->tval, this->sval).is_aiming_rod();
 }
+
+bool ItemEntity::is_lite_requiring_fuel() const
+{
+    return BaseitemKey(this->tval, this->sval).is_lite_requiring_fuel();
+}

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -128,6 +128,7 @@ public:
     bool is_wand_staff() const;
     short get_bow_energy() const;
     int get_arrow_magnification() const;
+    bool is_aiming_rod() const;
 
 private:
     int get_baseitem_price() const;

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -129,6 +129,7 @@ public:
     short get_bow_energy() const;
     int get_arrow_magnification() const;
     bool is_aiming_rod() const;
+    bool is_lite_requiring_fuel() const;
 
 private:
     int get_baseitem_price() const;


### PR DESCRIPTION
掲題の通りです
ItemEntity のオブジェクトメソッドをBaseitemKey のオブジェクトメソッドにリダイレクトした他、本体作業のための最適化を複数図りました
(tval/svalに依存する関数の、BaseitemKey のオブジェクトメソッドへの繰り込み 他)
ロジック変更も複数あります
ご確認下さい