### PR TITLE
ItemEntity::tval/sval をBaseitemKey に差し替えるための準備 その6

### DIFF
--- a/src/cmd-action/cmd-shoot.cpp
+++ b/src/cmd-action/cmd-shoot.cpp
@@ -26,14 +26,12 @@
  */
 void do_cmd_fire(PlayerType *player_ptr, SPELL_IDX snipe_type)
 {
-    OBJECT_IDX item;
-    ItemEntity *j_ptr, *ammo_ptr;
     if (player_ptr->wild_mode) {
         return;
     }
 
     player_ptr->is_fired = false;
-    j_ptr = &player_ptr->inventory_list[INVEN_BOW];
+    auto *j_ptr = &player_ptr->inventory_list[INVEN_BOW];
     if (j_ptr->tval == ItemKindType::NONE) {
         msg_print(_("射撃用の武器を持っていない。", "You have nothing to fire with."));
         flush();
@@ -53,10 +51,10 @@ void do_cmd_fire(PlayerType *player_ptr, SPELL_IDX snipe_type)
     }
 
     PlayerClass(player_ptr).break_samurai_stance({ SamuraiStanceType::MUSOU });
-
-    concptr q = _("どれを撃ちますか? ", "Fire which item? ");
-    concptr s = _("発射されるアイテムがありません。", "You have nothing to fire.");
-    ammo_ptr = choose_object(player_ptr, &item, q, s, USE_INVEN | USE_FLOOR, TvalItemTester(player_ptr->tval_ammo));
+    const auto q = _("どれを撃ちますか? ", "Fire which item? ");
+    const auto s = _("発射されるアイテムがありません。", "You have nothing to fire.");
+    short item;
+    const auto *ammo_ptr = choose_object(player_ptr, &item, q, s, USE_INVEN | USE_FLOOR, TvalItemTester(player_ptr->tval_ammo));
     if (!ammo_ptr) {
         flush();
         return;

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -580,17 +580,12 @@ void do_cmd_browse(PlayerType *player_ptr)
 {
     OBJECT_IDX item;
     OBJECT_SUBTYPE_VALUE sval;
-    int16_t use_realm = 0;
     int j, line;
     SPELL_IDX spell = -1;
     int num = 0;
 
     SPELL_IDX spells[64];
     char temp[62 * 4];
-
-    ItemEntity *o_ptr;
-
-    concptr q, s;
 
     /* Warriors are illiterate */
     PlayerClass pc(player_ptr);
@@ -611,12 +606,10 @@ void do_cmd_browse(PlayerType *player_ptr)
     /* Restrict choices to "useful" books */
     auto item_tester = get_learnable_spellbook_tester(player_ptr);
 
-    q = _("どの本を読みますか? ", "Browse which book? ");
-    s = _("読める本がない。", "You have no books that you can read.");
-
-    o_ptr = choose_object(player_ptr, &item, q, s, USE_INVEN | USE_FLOOR | (pc.equals(PlayerClassType::FORCETRAINER) ? USE_FORCE : 0), item_tester);
-
-    if (!o_ptr) {
+    const auto q = _("どの本を読みますか? ", "Browse which book? ");
+    const auto s = _("読める本がない。", "You have no books that you can read.");
+    const auto *o_ptr = choose_object(player_ptr, &item, q, s, USE_INVEN | USE_FLOOR | (pc.equals(PlayerClassType::FORCETRAINER) ? USE_FORCE : 0), item_tester);
+    if (o_ptr == nullptr) {
         if (item == INVEN_FORCE) /* the_force */
         {
             do_cmd_mind_browse(player_ptr);
@@ -628,7 +621,7 @@ void do_cmd_browse(PlayerType *player_ptr)
     /* Access the item's sval */
     sval = o_ptr->sval;
 
-    use_realm = tval2realm(o_ptr->tval);
+    short use_realm = tval2realm(o_ptr->tval);
 
     /* Track the object kind */
     object_kind_track(player_ptr, o_ptr->bi_id);
@@ -733,31 +726,22 @@ static void change_realm2(PlayerType *player_ptr, int16_t next_realm)
  */
 void do_cmd_study(PlayerType *player_ptr)
 {
-    int i;
-    OBJECT_IDX item;
-    OBJECT_SUBTYPE_VALUE sval;
-    int increment = 0;
-    bool learned = false;
+    auto increment = 0;
+    auto learned = false;
 
     /* Spells of realm2 will have an increment of +32 */
     SPELL_IDX spell = -1;
-    concptr p = spell_category_name(mp_ptr->spell_book);
-    ItemEntity *o_ptr;
-    concptr q, s;
-
+    const auto p = spell_category_name(mp_ptr->spell_book);
     if (!player_ptr->realm1) {
         msg_print(_("本を読むことができない！", "You cannot read books!"));
         return;
     }
 
-    if (cmd_limit_blind(player_ptr)) {
-        return;
-    }
-    if (cmd_limit_confused(player_ptr)) {
+    if (cmd_limit_blind(player_ptr) || cmd_limit_confused(player_ptr)) {
         return;
     }
 
-    if (!(player_ptr->new_spells)) {
+    if (player_ptr->new_spells == 0) {
         msg_format(_("新しい%sを覚えることはできない！", "You cannot learn any new %ss!"), p);
         return;
     }
@@ -779,18 +763,16 @@ void do_cmd_study(PlayerType *player_ptr)
     /* Restrict choices to "useful" books */
     auto item_tester = get_learnable_spellbook_tester(player_ptr);
 
-    q = _("どの本から学びますか? ", "Study which book? ");
-    s = _("読める本がない。", "You have no books that you can read.");
+    const auto q = _("どの本から学びますか? ", "Study which book? ");
+    const auto s = _("読める本がない。", "You have no books that you can read.");
 
-    o_ptr = choose_object(player_ptr, &item, q, s, (USE_INVEN | USE_FLOOR), item_tester);
-
-    if (!o_ptr) {
+    short item;
+    const auto *o_ptr = choose_object(player_ptr, &item, q, s, (USE_INVEN | USE_FLOOR), item_tester);
+    if (o_ptr == nullptr) {
         return;
     }
 
-    /* Access the item's sval */
-    sval = o_ptr->sval;
-
+    const auto sval = o_ptr->sval;
     if (o_ptr->tval == get_realm2_book(player_ptr)) {
         increment = 32;
     } else if (o_ptr->tval != get_realm1_book(player_ptr)) {
@@ -891,6 +873,7 @@ void do_cmd_study(PlayerType *player_ptr)
         msg_format(_("%sの熟練度が%sに上がった。", "Your proficiency of %s is now %s rank."), name, new_rank_str);
     } else {
         /* Find the next open entry in "player_ptr->spell_order[]" */
+        int i;
         for (i = 0; i < 64; i++) {
             /* Stop at the first empty space */
             if (player_ptr->spell_order[i] == 99) {
@@ -952,21 +935,15 @@ void do_cmd_study(PlayerType *player_ptr)
  */
 bool do_cmd_cast(PlayerType *player_ptr)
 {
-    OBJECT_IDX item;
-    OBJECT_SUBTYPE_VALUE sval;
     SPELL_IDX spell;
     int16_t realm;
     int chance;
-    int increment = 0;
+    auto increment = 0;
     int16_t use_realm;
     MANA_POINT need_mana;
 
-    concptr prayer;
-    ItemEntity *o_ptr;
     const magic_type *s_ptr;
-    concptr q, s;
-
-    bool over_exerted = false;
+    auto over_exerted = false;
 
     /* Require spell ability */
     PlayerClass pc(player_ptr);
@@ -983,6 +960,7 @@ bool do_cmd_cast(PlayerType *player_ptr)
             msg_print(_("目が見えない！", "You cannot see!"));
             flush();
         }
+
         return false;
     }
 
@@ -1012,26 +990,23 @@ bool do_cmd_cast(PlayerType *player_ptr)
         }
     }
 
-    prayer = spell_category_name(mp_ptr->spell_book);
-
-    q = _("どの呪文書を使いますか? ", "Use which book? ");
-    s = _("呪文書がない！", "You have no spell books!");
-
+    const auto prayer = spell_category_name(mp_ptr->spell_book);
+    const auto q = _("どの呪文書を使いますか? ", "Use which book? ");
+    const auto s = _("呪文書がない！", "You have no spell books!");
     auto item_tester = get_castable_spellbook_tester(player_ptr);
-
-    o_ptr = choose_object(player_ptr, &item, q, s, USE_INVEN | USE_FLOOR | (pc.equals(PlayerClassType::FORCETRAINER) ? USE_FORCE : 0), item_tester);
-    if (!o_ptr) {
-        if (item == INVEN_FORCE) /* the_force */
-        {
+    const auto options = USE_INVEN | USE_FLOOR | (pc.equals(PlayerClassType::FORCETRAINER) ? USE_FORCE : 0);
+    short item;
+    const auto *o_ptr = choose_object(player_ptr, &item, q, s, options, item_tester);
+    if (o_ptr == nullptr) {
+        if (item == INVEN_FORCE) {
             do_cmd_mind(player_ptr);
             return true; //!< 錬気キャンセル時の処理がない
         }
+
         return false;
     }
 
-    /* Access the item's sval */
-    sval = o_ptr->sval;
-
+    const auto sval = o_ptr->sval;
     if (!is_every_magic && (o_ptr->tval == get_realm2_book(player_ptr))) {
         increment = 32;
     }

--- a/src/cmd-item/cmd-item.cpp
+++ b/src/cmd-item/cmd-item.cpp
@@ -240,19 +240,17 @@ void do_cmd_inscribe(PlayerType *player_ptr)
  */
 void do_cmd_use(PlayerType *player_ptr)
 {
-    OBJECT_IDX item;
-    ItemEntity *o_ptr;
     if (player_ptr->wild_mode || cmd_limit_arena(player_ptr)) {
         return;
     }
 
     PlayerClass(player_ptr).break_samurai_stance({ SamuraiStanceType::MUSOU, SamuraiStanceType::KOUKIJIN });
-
-    concptr q = _("どれを使いますか？", "Use which item? ");
-    concptr s = _("使えるものがありません。", "You have nothing to use.");
-    o_ptr = choose_object(
-        player_ptr, &item, q, s, (USE_INVEN | USE_EQUIP | USE_FLOOR | IGNORE_BOTHHAND_SLOT), FuncItemTester(item_tester_hook_use, player_ptr));
-    if (!o_ptr) {
+    const auto q = _("どれを使いますか？", "Use which item? ");
+    const auto s = _("使えるものがありません。", "You have nothing to use.");
+    const auto options = USE_INVEN | USE_EQUIP | USE_FLOOR | IGNORE_BOTHHAND_SLOT;
+    short item;
+    const auto *o_ptr = choose_object(player_ptr, &item, q, s, options, FuncItemTester(item_tester_hook_use, player_ptr));
+    if (o_ptr == nullptr) {
         return;
     }
 

--- a/src/mind/mind-mage.cpp
+++ b/src/mind/mind-mage.cpp
@@ -31,31 +31,28 @@ bool eat_magic(PlayerType *player_ptr, int power)
     byte fail_type = 1;
     GAME_TEXT o_name[MAX_NLEN];
 
-    concptr q = _("どのアイテムから魔力を吸収しますか？", "Drain which item? ");
-    concptr s = _("魔力を吸収できるアイテムがありません。", "You have nothing to drain.");
-
-    OBJECT_IDX item;
+    const auto q = _("どのアイテムから魔力を吸収しますか？", "Drain which item? ");
+    const auto s = _("魔力を吸収できるアイテムがありません。", "You have nothing to drain.");
+    short item;
     auto *o_ptr = choose_object(player_ptr, &item, q, s, (USE_INVEN | USE_FLOOR), FuncItemTester(&ItemEntity::can_recharge));
     if (o_ptr == nullptr) {
         return false;
     }
 
-    BaseitemInfo *k_ptr;
-    k_ptr = &baseitems_info[o_ptr->bi_id];
-    DEPTH lev = baseitems_info[o_ptr->bi_id].level;
-
-    int recharge_strength = 0;
-    bool is_eating_successful = true;
+    const auto &baseitem = baseitems_info[o_ptr->bi_id];
+    const auto lev = baseitem.level;
+    auto recharge_strength = 0;
+    auto is_eating_successful = true;
     if (o_ptr->tval == ItemKindType::ROD) {
         recharge_strength = ((power > lev / 2) ? (power - lev / 2) : 0) / 5;
         if (one_in_(recharge_strength)) {
             is_eating_successful = false;
         } else {
-            if (o_ptr->timeout > (o_ptr->number - 1) * k_ptr->pval) {
+            if (o_ptr->timeout > (o_ptr->number - 1) * baseitem.pval) {
                 msg_print(_("充填中のロッドから魔力を吸収することはできません。", "You can't absorb energy from a discharged rod."));
             } else {
                 player_ptr->csp += lev;
-                o_ptr->timeout += k_ptr->pval;
+                o_ptr->timeout += baseitem.pval;
             }
         }
     } else {
@@ -102,7 +99,7 @@ bool eat_magic(PlayerType *player_ptr, int power)
         describe_flavor(player_ptr, o_name, o_ptr, OD_NAME_ONLY);
         msg_format(_("魔力が逆流した！%sは完全に魔力を失った。", "The recharging backfires - %s is completely drained!"), o_name);
         if (o_ptr->tval == ItemKindType::ROD) {
-            o_ptr->timeout = k_ptr->pval * o_ptr->number;
+            o_ptr->timeout = baseitem.pval * o_ptr->number;
         } else if (o_ptr->is_wand_staff()) {
             o_ptr->pval = 0;
         }
@@ -167,7 +164,7 @@ bool eat_magic(PlayerType *player_ptr, int power)
     if (fail_type == 1) {
         if (o_ptr->tval == ItemKindType::ROD) {
             msg_format(_("ロッドは破損を免れたが、魔力は全て失なわれた。", "You save your rod from destruction, but all charges are lost."), o_name);
-            o_ptr->timeout = k_ptr->pval * o_ptr->number;
+            o_ptr->timeout = baseitem.pval * o_ptr->number;
         } else if (o_ptr->tval == ItemKindType::WAND) {
             msg_format(_("%sは破損を免れたが、魔力が全て失われた。", "You save your %s from destruction, but all charges are lost."), o_name);
             o_ptr->pval = 0;
@@ -179,7 +176,7 @@ bool eat_magic(PlayerType *player_ptr, int power)
             msg_format(_("乱暴な魔法のために%sが一本壊れた！", "Wild magic consumes one of your %s!"), o_name);
             /* Reduce rod stack maximum timeout, drain wands. */
             if (o_ptr->tval == ItemKindType::ROD) {
-                o_ptr->timeout = std::min<short>(o_ptr->timeout, k_ptr->pval * (o_ptr->number - 1));
+                o_ptr->timeout = std::min<short>(o_ptr->timeout, baseitem.pval * (o_ptr->number - 1));
             } else if (o_ptr->tval == ItemKindType::WAND) {
                 o_ptr->pval = o_ptr->pval * (o_ptr->number - 1) / o_ptr->number;
             }

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -160,23 +160,21 @@ concptr do_hex_spell(PlayerType *player_ptr, spell_hex_type spell, SpellProcessT
         if (name) {
             return _("武器呪縛", "Curse weapon");
         }
+
         if (description) {
             return _("装備している武器を呪う。", "Curses your weapon.");
         }
+
         if (cast) {
-            OBJECT_IDX item;
-            concptr q, s;
-            GAME_TEXT o_name[MAX_NLEN];
-            ItemEntity *o_ptr;
-
-            q = _("どれを呪いますか？", "Which weapon do you curse?");
-            s = _("武器を装備していない。", "You're not wielding a weapon.");
-
-            o_ptr = choose_object(player_ptr, &item, q, s, (USE_EQUIP), FuncItemTester(&ItemEntity::is_melee_weapon));
-            if (!o_ptr) {
+            const auto q = _("どれを呪いますか？", "Which weapon do you curse?");
+            const auto s = _("武器を装備していない。", "You're not wielding a weapon.");
+            short item;
+            auto *o_ptr = choose_object(player_ptr, &item, q, s, (USE_EQUIP), FuncItemTester(&ItemEntity::is_melee_weapon));
+            if (o_ptr == nullptr) {
                 return "";
             }
 
+            GAME_TEXT o_name[MAX_NLEN];
             describe_flavor(player_ptr, o_name, o_ptr, OD_NAME_ONLY);
             auto f = object_flags(o_ptr);
 

--- a/src/spell-realm/spells-craft.cpp
+++ b/src/spell-realm/spells-craft.cpp
@@ -269,11 +269,11 @@ bool choose_ele_immune(PlayerType *player_ptr, TIME_EFFECT immune_turn)
  */
 bool pulish_shield(PlayerType *player_ptr)
 {
-    concptr q = _("どの盾を磨きますか？", "Polish which shield? ");
-    concptr s = _("磨く盾がありません。", "You have no shield to polish.");
-
-    OBJECT_IDX item;
-    auto *o_ptr = choose_object(player_ptr, &item, q, s, USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT, TvalItemTester(ItemKindType::SHIELD));
+    const auto q = _("どの盾を磨きますか？", "Polish which shield? ");
+    const auto s = _("磨く盾がありません。", "You have no shield to polish.");
+    const auto options = USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT;
+    short item;
+    auto *o_ptr = choose_object(player_ptr, &item, q, s, options, TvalItemTester(ItemKindType::SHIELD));
     if (o_ptr == nullptr) {
         return false;
     }
@@ -281,7 +281,7 @@ bool pulish_shield(PlayerType *player_ptr)
     GAME_TEXT o_name[MAX_NLEN];
     describe_flavor(player_ptr, o_name, o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
 
-    bool is_pulish_successful = o_ptr->bi_id && !o_ptr->is_artifact() && !o_ptr->is_ego();
+    auto is_pulish_successful = (o_ptr->bi_id > 0) && !o_ptr->is_artifact() && !o_ptr->is_ego();
     is_pulish_successful &= !o_ptr->is_cursed();
     is_pulish_successful &= (o_ptr->sval != SV_MIRROR_SHIELD);
     if (is_pulish_successful) {


### PR DESCRIPTION
掲題の処理をする過程で、「ついで」で実施したような諸作業 (明示的な型宣言 → 型推論)を別PRに分離しました
ご確認下さい
(注：一部このPRから漏れて本体コミットに紛れ込んでいるかもしれませんがもはやご容赦下さい)

(その5がマージされるまではドラフト)