### PR TITLE
parse_artifacts_info() からbuf へ直接依存している読み込みルーチンを排除した

### DIFF
--- a/src/info-reader/artifact-reader.cpp
+++ b/src/info-reader/artifact-reader.cpp
@@ -96,7 +96,7 @@ errr parse_artifacts_info(std::string_view buf, angband_header *)
 
         const auto it = artifacts_info.rbegin();
         auto &a_ref = it->second;
-        a_ref.text.append(buf.substr(2));
+        a_ref.text.append(tokens[1]);
 #else
         if (tokens[1][0] != '$') {
             return PARSE_ERROR_NONE;
@@ -104,7 +104,7 @@ errr parse_artifacts_info(std::string_view buf, angband_header *)
 
         const auto it = artifacts_info.rbegin();
         auto &a_ref = it->second;
-        append_english_text(a_ref.text, buf.substr(3));
+        append_english_text(a_ref.text, tokens[1].substr(1));
 #endif
         return PARSE_ERROR_NONE;
     }


### PR DESCRIPTION
偶然、buf をtokens に分解しているのに使っていない箇所を見つけたので差し替えました
2箇所だけサクッと差し替えたのでチケットはありません
ご確認下さい