### PR TITLE
[Fix] 修行僧が記憶喪失処理に陥らない例外判定が真偽反転していたのを修正。

### DIFF
--- a/src/object-use/quaff/quaff-effects.cpp
+++ b/src/object-use/quaff/quaff-effects.cpp
@@ -274,7 +274,7 @@ bool QuaffEffects::booze()
         ident = true;
     }
 
-    if (!is_monk || !one_in_(13)) {
+    if (is_monk || !one_in_(13)) {
         return ident;
     }
 


### PR DESCRIPTION
単純なフラグ判定逆転なので、１箇所修正させてもらいました。