### PR TITLE
[Feature] モンスターのHP表示部に出す情報追加

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -623,6 +623,7 @@
     <ClCompile Include="..\..\src\window\display-sub-window-spells.cpp" />
     <ClCompile Include="..\..\src\window\display-sub-windows.cpp" />
     <ClCompile Include="..\..\src\window\main-window-left-frame.cpp" />
+    <ClCompile Include="..\..\src\window\main-window-row-column.cpp" />
     <ClCompile Include="..\..\src\window\main-window-stat-poster.cpp" />
     <ClCompile Include="..\..\src\window\main-window-util.cpp" />
     <ClCompile Include="..\..\src\mspell\monster-power-table.cpp" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2466,6 +2466,9 @@
     <ClCompile Include="..\..\src\system\terrain-type-definition.cpp">
       <Filter>system</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\window\main-window-row-column.cpp">
+      <Filter>window</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\monster-race\race-brightness-mask.cpp">
       <Filter>monster-race</Filter>
     </ClCompile>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -996,7 +996,7 @@ hengband_SOURCES = \
 	window/display-sub-window-spells.cpp window/display-sub-window-spells.h \
 	window/display-sub-windows.cpp window/display-sub-windows.h \
 	window/main-window-left-frame.cpp window/main-window-left-frame.h \
-	window/main-window-row-column.h \
+	window/main-window-row-column.cpp window/main-window-row-column.h \
 	window/main-window-stat-poster.cpp window/main-window-stat-poster.h \
 	window/main-window-util.cpp window/main-window-util.h \
 	window/main-window-equipments.cpp window/main-window-equipments.h \

--- a/src/core/window-redrawer.cpp
+++ b/src/core/window-redrawer.cpp
@@ -165,14 +165,14 @@ void redraw_stuff(PlayerType *player_ptr)
         print_depth(player_ptr);
     }
 
-    if (player_ptr->redraw & (PR_HEALTH)) {
-        player_ptr->redraw &= ~(PR_HEALTH);
-        health_redraw(player_ptr, false);
-    }
-
     if (player_ptr->redraw & (PR_UHEALTH)) {
         player_ptr->redraw &= ~(PR_UHEALTH);
-        health_redraw(player_ptr, true);
+        print_health(player_ptr, true);
+    }
+
+    if (player_ptr->redraw & (PR_HEALTH)) {
+        player_ptr->redraw &= ~(PR_HEALTH);
+        print_health(player_ptr, false);
     }
 
     if (player_ptr->redraw & (PR_EXTRA)) {

--- a/src/system/monster-entity.cpp
+++ b/src/system/monster-entity.cpp
@@ -86,6 +86,11 @@ short MonsterEntity::get_remaining_sleep() const
     return this->mtimed[MTIMED_CSLEEP];
 }
 
+bool MonsterEntity::is_dead() const
+{
+    return this->hp < 0;
+}
+
 bool MonsterEntity::is_asleep() const
 {
     return this->get_remaining_sleep() > 0;

--- a/src/system/monster-entity.h
+++ b/src/system/monster-entity.h
@@ -69,6 +69,7 @@ public:
     short get_remaining_confusion() const;
     short get_remaining_fear() const;
     short get_remaining_invulnerability() const;
+    bool is_dead() const;
     bool is_asleep() const;
     bool is_accelerated() const;
     bool is_decelerated() const;

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -294,20 +294,20 @@ static void print_health_monster_in_arena_for_wizard(PlayerType *player_ptr)
     int row = ROW_INFO - 1;
     int col = COL_INFO + 2;
 
-    const int MAX_NUM_OF_MONSTER_IN_ARENA = 4;
+    const int max_num_of_monster_in_arena = 4;
 
-    for (int i = 0; i < MAX_NUM_OF_MONSTER_IN_ARENA; i++) {
-        auto rowOffset = i;
-        auto monsterListIndex = i + 1; // m_listの1-4に闘技場のモンスターデータが入っている
+    for (int i = 0; i < max_num_of_monster_in_arena; i++) {
+        auto row_offset = i;
+        auto monster_list_index = i + 1; // m_listの1-4に闘技場のモンスターデータが入っている
 
-        term_putstr(col - 2, row + rowOffset, 12, TERM_WHITE, "      /     ");
+        term_putstr(col - 2, row + row_offset, 12, TERM_WHITE, "      /     ");
 
-        auto &monster = player_ptr->current_floor_ptr->m_list[monsterListIndex];
+        auto &monster = player_ptr->current_floor_ptr->m_list[monster_list_index];
         if (MonsterRace(monster.r_idx).is_valid()) {
-            term_putstr(col - 2, row + rowOffset, 2, monraces_info[monster.r_idx].x_attr,
+            term_putstr(col - 2, row + row_offset, 2, monraces_info[monster.r_idx].x_attr,
                 format("%c", monraces_info[monster.r_idx].x_char));
-            term_putstr(col - 1, row + rowOffset, 5, TERM_WHITE, format("%5d", monster.hp));
-            term_putstr(col + 5, row + rowOffset, 6, TERM_WHITE, format("%5d", monster.max_maxhp));
+            term_putstr(col - 1, row + row_offset, 5, TERM_WHITE, format("%5d", monster.hp));
+            term_putstr(col + 5, row + row_offset, 6, TERM_WHITE, format("%5d", monster.max_maxhp));
         }
     }
 }
@@ -419,28 +419,28 @@ void print_health(PlayerType *player_ptr, bool riding)
         col = COL_INFO;
     }
 
-    const int MAX_HEIGHT_RIDING = 3; // 騎乗時に描画する高さの最大範囲
-    const int MAX_HEIGHT = 6; // 通常時に描画する高さの最大範囲
-    const int MAX_WIDTH = 12; // 表示幅
+    const int max_height_riding = 3; // 騎乗時に描画する高さの最大範囲
+    const int max_height = 6; // 通常時に描画する高さの最大範囲
+    const int max_width = 12; // 表示幅
 
     // 表示範囲を一旦全部消す
-    int range = riding ? MAX_HEIGHT_RIDING : MAX_HEIGHT;
+    int range = riding ? max_height_riding : max_height;
     for (int y = row; y < row + range; y++) {
-        term_erase(col, y, MAX_WIDTH);
+        term_erase(col, y, max_width);
     }
 
     if (!monster_idx.has_value()) {
         return;
     }
 
-    const int ROW_OFFSET_NAME = 0; // 名前
-    const int ROW_OFFSET_HEALTH = 1; // HP
-    const int ROW_OFFSET_CONDITION = 2; // 状態異常
+    const int row_offset_name = 0; // 名前
+    const int row_offset_health = 1; // HP
+    const int row_offset_condition = 2; // 状態異常
 
     const auto &monster = player_ptr->current_floor_ptr->m_list[monster_idx.value()];
 
     if ((!monster.ml) || (player_ptr->effects()->hallucination()->is_hallucinated()) || monster.is_dead()) {
-        term_putstr(col, row + ROW_OFFSET_HEALTH, MAX_WIDTH, TERM_WHITE, "[----------]");
+        term_putstr(col, row + row_offset_health, max_width, TERM_WHITE, "[----------]");
         return;
     }
 
@@ -448,15 +448,15 @@ void print_health(PlayerType *player_ptr, bool riding)
     int pct2 = monster.maxhp > 0 ? 100L * monster.hp / monster.max_maxhp : 0;
     int len = (pct2 < 10) ? 1 : (pct2 < 90) ? (pct2 / 10 + 1)
                                             : 10;
-    auto hit_point_bar_clor = get_monster_hp_point_bar_color(monster);
+    auto hit_point_bar_color = get_monster_hp_point_bar_color(monster);
     const auto &ap_r_ref = monraces_info[monster.ap_r_idx];
 
     // 名前
     // 表示枠に収まらない場合は途中で切る
-    term_putstr(col, row + ROW_OFFSET_NAME, MAX_WIDTH, TERM_WHITE, str_separate(ap_r_ref.name, MAX_WIDTH)[0].data());
+    term_putstr(col, row + row_offset_name, max_width, TERM_WHITE, str_separate(ap_r_ref.name, max_width)[0].data());
     // HPの割合
-    term_putstr(col, row + ROW_OFFSET_HEALTH, MAX_WIDTH, TERM_WHITE, "[----------]");
-    term_putstr(col + 1, row + ROW_OFFSET_HEALTH, len, hit_point_bar_clor, "**********");
+    term_putstr(col, row + row_offset_health, max_width, TERM_WHITE, "[----------]");
+    term_putstr(col + 1, row + row_offset_health, len, hit_point_bar_color, "**********");
 
     // 騎乗中のモンスターの状態異常は表示しない
     if (riding) {
@@ -469,11 +469,11 @@ void print_health(PlayerType *player_ptr, bool riding)
     // 一時的状態異常
     // MAX_WIDTHを超えたら次の行に移動する
     for (const auto &info : get_condition_layout_info(monster)) {
-        if (col_offset + info.label.length() - 1 > MAX_WIDTH) { // 改行が必要かどうかチェック。length() - 1してるのは\0の分を文字数から取り除くため
+        if (col_offset + info.label.length() - 1 > max_width) { // 改行が必要かどうかチェック。length() - 1してるのは\0の分を文字数から取り除くため
             col_offset = 0;
             row_offset++;
         }
-        term_putstr(col + col_offset, row + ROW_OFFSET_CONDITION + row_offset, MAX_WIDTH, info.color, info.label.data());
+        term_putstr(col + col_offset, row + row_offset_condition + row_offset, max_width, info.color, info.label.data());
         col_offset += info.label.length() + 1; // 文字数と空白の分だけoffsetを加算
     }
 }

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -433,10 +433,7 @@ void print_health(PlayerType *player_ptr, bool riding)
 
     const auto &monster = player_ptr->current_floor_ptr->m_list[monster_idx.value()];
 
-    // 視認できない
-    // プレイヤーが幻覚を見ている
-    // 死亡している
-    if ((!monster.ml) || (player_ptr->effects()->hallucination()->is_hallucinated()) || (monster.hp < 0)) {
+    if ((!monster.ml) || (player_ptr->effects()->hallucination()->is_hallucinated()) || (monster.is_dead())) {
         term_putstr(col, row + ROW_OFFSET_HEALTH, MAX_WIDTH, TERM_WHITE, "[----------]");
         return;
     }

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -1,4 +1,4 @@
-#include "window/main-window-left-frame.h"
+﻿#include "window/main-window-left-frame.h"
 #include "game-option/special-options.h"
 #include "game-option/text-display-options.h"
 #include "market/arena-info-table.h"
@@ -346,6 +346,31 @@ static std::vector<condition_layout_info> get_condition_layout_info(const Monste
 }
 
 /*!
+ * @brief 対象のモンスターからHPバーの色を算出する
+ * @param monster 対象のモンスター
+ */
+static TERM_COLOR get_monster_hp_point_bar_color(const MonsterEntity &monster)
+{
+    int pct = monster.maxhp > 0 ? 100L * monster.hp / monster.maxhp : 0;
+
+    // HPの割合に応じてHPバーの色を設定
+    if (monster.is_invulnerable()) {
+        return TERM_WHITE;
+    } else if (monster.is_asleep()) {
+        return TERM_BLUE;
+    } else if (pct >= 100) {
+        return TERM_L_GREEN;
+    } else if (pct >= 60) {
+        return TERM_YELLOW;
+    } else if (pct >= 25) {
+        return TERM_ORANGE;
+    } else if (pct >= 10) {
+        return TERM_L_RED;
+    }
+    return TERM_RED;
+}
+
+/*!
  * @brief モンスターの体力ゲージを表示する
  * @param riding TRUEならば騎乗中のモンスターの体力、FALSEならターゲットモンスターの体力を表示する。表示位置は固定。
  * @details
@@ -417,29 +442,10 @@ void print_health(PlayerType *player_ptr, bool riding)
     }
 
     // HPの割合計算
-    int pct = monster.maxhp > 0 ? 100L * monster.hp / monster.maxhp : 0;
     int pct2 = monster.maxhp > 0 ? 100L * monster.hp / monster.max_maxhp : 0;
     int len = (pct2 < 10) ? 1 : (pct2 < 90) ? (pct2 / 10 + 1)
                                             : 10;
-
-    // HPの割合に応じてHPバーの色を設定
-    TERM_COLOR hit_point_bar_clor = TERM_L_GREEN;
-    if (monster.is_invulnerable()) {
-        hit_point_bar_clor = TERM_WHITE;
-    } else if (monster.is_asleep()) {
-        hit_point_bar_clor = TERM_BLUE;
-    } else if (pct >= 100) {
-        hit_point_bar_clor = TERM_L_GREEN;
-    } else if (pct >= 60) {
-        hit_point_bar_clor = TERM_YELLOW;
-    } else if (pct >= 25) {
-        hit_point_bar_clor = TERM_ORANGE;
-    } else if (pct >= 10) {
-        hit_point_bar_clor = TERM_L_RED;
-    } else {
-        hit_point_bar_clor = TERM_RED;
-    }
-
+    auto hit_point_bar_clor = get_monster_hp_point_bar_color(monster);
     const auto &ap_r_ref = monraces_info[monster.ap_r_idx];
 
     // 名前

--- a/src/window/main-window-left-frame.h
+++ b/src/window/main-window-left-frame.h
@@ -10,4 +10,4 @@ void print_sp(PlayerType *player_ptr);
 void print_gold(PlayerType *player_ptr);
 void print_depth(PlayerType *player_ptr);
 void print_frame_basic(PlayerType *player_ptr);
-void health_redraw(PlayerType *player_ptr, bool riding);
+void print_health(PlayerType *player_ptr, bool riding);

--- a/src/window/main-window-row-column.cpp
+++ b/src/window/main-window-row-column.cpp
@@ -1,5 +1,5 @@
 ﻿#include "window/main-window-row-column.h"
-#include <locale/language-switcher.h>
+#include "locale/language-switcher.h"
 
 const std::map<monster_timed_effect_type, std::string> effect_type_to_label = {
     { MTIMED_CSLEEP, _("睡眠", "sleep") },

--- a/src/window/main-window-row-column.cpp
+++ b/src/window/main-window-row-column.cpp
@@ -1,0 +1,12 @@
+﻿#include "window/main-window-row-column.h"
+#include <locale/language-switcher.h>
+
+const std::map<monster_timed_effect_type, std::string> effect_type_to_label = {
+    { MTIMED_CSLEEP, _("睡眠", "sleep") },
+    { MTIMED_FAST, _("加速", "haste") },
+    { MTIMED_SLOW, _("減速", "slow") },
+    { MTIMED_STUNNED, _("朦朧", "stun") },
+    { MTIMED_CONFUSED, _("混乱", "confuse") },
+    { MTIMED_MONFEAR, _("恐怖", "scare") },
+    { MTIMED_INVULNER, _("無敵", "invulnerable") }
+};

--- a/src/window/main-window-row-column.h
+++ b/src/window/main-window-row-column.h
@@ -1,5 +1,9 @@
 ﻿#pragma once
 
+#include "monster/monster-timed-effect-types.h"
+#include <map>
+#include <string>
+
 /*
  * Some screen locations for various display routines
  * Currently, row 8 and 15 are the only "blank" rows.
@@ -11,12 +15,6 @@
 
 #define ROW_TITLE 2
 #define COL_TITLE 0 /* <title> or <mode> */
-
-#define ROW_DAY 21
-#define COL_DAY 0 /* day */
-
-#define ROW_DUNGEON 22
-#define COL_DUNGEON 0 /* dungeon */
 
 #define ROW_LEVEL 3
 #define COL_LEVEL 0 /* "LEVEL xxxxxx" */
@@ -45,23 +43,29 @@
 #define ROW_CURSP 15
 #define COL_CURSP 0 /* "Cur SP xxxxx" */
 
-#define ROW_RIDING_INFO 16
-#define COL_RIDING_INFO 0 /* "xxxxxxxxxxxx" */
-
-#define ROW_INFO 17
-#define COL_INFO 0 /* "xxxxxxxxxxxx" */
-
-#define ROW_CUT 18
+#define ROW_CUT 16
 #define COL_CUT 0 /* <cut> */
 
-#define ROW_STUN 19
+#define ROW_STUN 17
 #define COL_STUN 0 /* <stun> */
 
-#define ROW_HUNGRY 20
+#define ROW_HUNGRY 18
 #define COL_HUNGRY 0 /* "Weak" / "Hungry" / "Full" / "Gorged" */
 
-#define ROW_STATE 20
+#define ROW_STATE 19
 #define COL_STATE 7 /* <state> */
+
+#define ROW_RIDING_INFO 21
+#define COL_RIDING_INFO 0 /* "xxxxxxxxxxxx" */
+
+#define ROW_INFO 24
+#define COL_INFO 0 /* "xxxxxxxxxxxx" */
+
+#define ROW_DAY 32
+#define COL_DAY 0 /* day */
+
+#define ROW_DUNGEON 33
+#define COL_DUNGEON 0 /* dungeon */
 
 #define ROW_SPEED (-1)
 #define COL_SPEED (-24) /* "Slow (-NN)" or "Fast (+NN)" */
@@ -75,3 +79,5 @@
 #define ROW_STATBAR (-1)
 #define COL_STATBAR 0
 #define MAX_COL_STATBAR (-26)
+
+extern const std::map<monster_timed_effect_type, std::string> effect_type_to_label;


### PR DESCRIPTION
[【QoL向上】ターゲットしているモンスターの画面に出す情報を追加](https://github.com/hengband/hengband/issues/2825)
↑issueで挙げた対応のpull reqになります。

# 情報を追加する以外に、従来の処理から変えているところ
- 従来の処理では恐怖状態の時にHPバーの色を紫にしていましたが、下記理由によりゲージの色を変えないようにしました
  - 恐怖状態のときにテキストで表示するようにした
  - 他の状態異常の時に特に色を変えてなくて一貫性がない
    - 無敵と睡眠時のゲージ色は迷いましたが、恐怖よりもプレイに影響がありそうなのでそのままにしています
- 従来の処理では 
```
キャラのステータス
ターゲット情報
キャラ情報（切り傷、朦朧、空腹、探索、学習など）
``` 
といった順で表示していましたが、これだと
```
ユーザー情報
敵情報
ユーザー情報
``` 
という並び順で違和感があったので
```
キャラのステータス
キャラ情報（切り傷、朦朧、空腹、探索、学習など）
ターゲット情報
``` 
の順で表示するようにしました　 

# マージタイミング
https://github.com/hengband/hengband/issues/2825#issuecomment-1325774643
↑とのことなので、マージはそれが片付いてから

# 実装してて思ったこと
- 画面に出す文字列は定数ファイルにまとめたいと思った
- 状態異常と色の対応もまとめられると良いと思った
- defineも見つけたところからconstexpr|constに変えたいと思った