### PR TITLE
サブディレクトリとデフォルトmp3の追加に合わせたWindows用ビルドスクリプトを修正。

### DIFF
--- a/Build-Windows-Release-Package.ps1
+++ b/Build-Windows-Release-Package.ps1
@@ -37,7 +37,7 @@ function BuildPackage ($package_name, $package_unique_files, $build_conf) {
     Get-ChildItem -Path $tempDir | Compress-Archive -Force -Verbose -DestinationPath $package_path
 
     # 作業用テンポラリフォルダ削除
-    $tempDir | Where-Object { Test-Path $_ } | ForEach-Object { Get-ChildItem $_ -File -Recurse | Remove-Item; $_ } | Remove-Item -Recurse
+    $tempDir | Where-Object { Test-Path $_ } | ForEach-Object { Get-ChildItem $_ -File -Recurse | Remove-Item; $_ } | Remove-Item -Recurse -Force
 }
 
 # 日本語版

--- a/Build-Windows-Release-Package.ps1
+++ b/Build-Windows-Release-Package.ps1
@@ -30,7 +30,7 @@ function BuildPackage ($package_name, $package_unique_files, $build_conf) {
     Copy-Item -Verbose -Recurse -Path .\lib -Destination $hengbandDir -Exclude Makefile.am, *.raw, .gitattributes
     Copy-Item -Verbose -Path .\lib\apex\h_scores.raw -Destination $hengbandDir\lib\apex
     Remove-Item -Verbose -Exclude delete.me -Recurse -Path $hengbandDir\lib\save\*, $hengbandDir\lib\user\*
-    Remove-Item -Verbose -Exclude music.cfg -Path $hengbandDir\lib\xtra\music\*
+    Remove-Item -Verbose -Exclude music.cfg, readme.txt, *.mp3 -Path $hengbandDir\lib\xtra\music\*
 
     # zipアーカイブ作成
     $package_path = Join-Path $(Get-Location) "${package_name}.zip"

--- a/Build-Windows-Release-Package.ps1
+++ b/Build-Windows-Release-Package.ps1
@@ -43,4 +43,4 @@ function BuildPackage ($package_name, $package_unique_files, $build_conf) {
 # 日本語版
 BuildPackage -package_name Hengband-$Version-jp -package_unique_files .\readme.md, .\autopick.txt -build_conf Release
 # 英語版
-BuildPackage -package_name Hengband-$Version-en -package_unique_files .\readme_eng.md, .\autopick_eng.txt -build_conf English-Release
+BuildPackage -package_name Hengband-$Version-en -package_unique_files .\readme-eng.md, .\autopick_eng.txt -build_conf English-Release


### PR DESCRIPTION
テンポラリ削除エラーに -Force を付けて対処。削除してしまっていた、mp3とreadme.txtを削除除外から外して正しくアーカイブされることを確認しました。チェックお願いします。