### PR TITLE
Replace many instances of sprintf().  Does part of the work of …

### DIFF
--- a/src/autopick/autopick-editor-command.cpp
+++ b/src/autopick/autopick-editor-command.cpp
@@ -25,6 +25,7 @@
 #include "player-info/race-info.h"
 #include "system/player-type-definition.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 
 /*!
  * @brief
@@ -566,7 +567,7 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
             break;
         }
         char expression[80];
-        sprintf(expression, "?:[AND [EQU $RACE %s] [EQU $CLASS %s] [GEQ $LEVEL %02d]]",
+        strnfmt(expression, sizeof(expression), "?:[AND [EQU $RACE %s] [EQU $CLASS %s] [GEQ $LEVEL %02]]",
 #ifdef JP
             rp_ptr->E_title, cp_ptr->E_title,
 #else

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -328,9 +328,8 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, It
 {
     /* Assume that object name is to be added */
     bool name = true;
-    GAME_TEXT name_str[MAX_NLEN + 32];
-    name_str[0] = '\0';
     auto insc = quark_str(o_ptr->inscription);
+    entry->name.clear();
     entry->insc = insc != nullptr ? insc : "";
     entry->action = DO_AUTOPICK | DO_DISPLAY;
     entry->flag[0] = entry->flag[1] = 0L;
@@ -388,10 +387,11 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, It
                 auto *e_ptr = &egos_info[o_ptr->ego_idx];
 #ifdef JP
                 /* エゴ銘には「^」マークが使える */
-                sprintf(name_str, "^%s", e_ptr->name.data());
+                entry->name = "^";
+                entry->name.append(e_ptr->name);
 #else
-                /* We ommit the basename and cannot use the ^ mark */
-                strcpy(name_str, e_ptr->name.data());
+                /* We omit the basename and cannot use the ^ mark */
+                entry->name = e_ptr->name;
 #endif
                 name = false;
                 if (!o_ptr->is_rare()) {
@@ -503,8 +503,7 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, It
     }
 
     if (!name) {
-        str_tolower(name_str);
-        entry->name = name_str;
+        str_tolower(entry->name.data());
         return;
     }
 
@@ -515,9 +514,8 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, It
      * If necessary, add a '^' which indicates the
      * beginning of line.
      */
-    sprintf(name_str, "%s%s", is_hat_added ? "^" : "", o_name);
-    str_tolower(name_str);
-    entry->name = name_str;
+    entry->name = std::string(is_hat_added ? "^" : "").append(o_name);
+    str_tolower(entry->name.data());
 }
 
 /*!

--- a/src/autopick/autopick.cpp
+++ b/src/autopick/autopick.cpp
@@ -126,15 +126,14 @@ void autopick_pickup_items(PlayerType *player_ptr, grid_type *g_ptr)
             continue;
         }
 
-        char out_val[MAX_NLEN + 20];
-        GAME_TEXT o_name[MAX_NLEN];
         if (o_ptr->marked.has(OmType::NO_QUERY)) {
             continue;
         }
 
+        GAME_TEXT o_name[MAX_NLEN];
         describe_flavor(player_ptr, o_name, o_ptr, 0);
-        sprintf(out_val, _("%sを拾いますか? ", "Pick up %s? "), o_name);
-        if (!get_check(out_val)) {
+        auto prompt = std::string(_(o_name, "Pick up ")).append(_("を拾いますか", o_name)).append("? ");
+        if (!get_check(prompt.data())) {
             o_ptr->marked.set({ OmType::SUPRESS_MESSAGE, OmType::NO_QUERY });
             continue;
         }

--- a/src/birth/auto-roller.cpp
+++ b/src/birth/auto-roller.cpp
@@ -13,6 +13,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
 
 /*! オートローラの能力値的要求水準 / Autoroll limit */
@@ -161,29 +162,32 @@ static void decide_initial_stat(PlayerType *player_ptr, int *cval)
 
 /*!
  * @brief オートローラの設定能力値行を作成する
- * @param cur カーソル文字列を入れるバッファ
  * @param cval 設定能力値配列
  * @param cs カーソル位置(能力値番号)
+ * @return カーソル文字列
  */
-static void cursor_of_adjusted_stat(char *cur, int *cval, int cs)
+static std::string cursor_of_adjusted_stat(const int *cval, int cs)
 {
-    char inp[80], maxv[80];
     auto j = rp_ptr->r_adj[cs] + cp_ptr->c_adj[cs] + ap_ptr->a_adj[cs];
     auto m = adjust_stat(17, j);
+    char maxv[20];
     if (m > 18) {
-        sprintf(maxv, "18/%02d", (m - 18));
+        strnfmt(maxv, sizeof(maxv), "18/%02d", (m - 18));
     } else {
-        sprintf(maxv, "%2d", m);
+        strnfmt(maxv, sizeof(maxv), "%2d", m);
     }
 
     m = adjust_stat(cval[cs], j);
+    char inp[20];
     if (m > 18) {
-        sprintf(inp, "18/%02d", (m - 18));
+        strnfmt(inp, sizeof(inp), "18/%02d", (m - 18));
     } else {
-        sprintf(inp, "%2d", m);
+        strnfmt(inp, sizeof(inp), "%2d", m);
     }
 
-    sprintf(cur, "%6s       %2d   %+3d  %+3d  %+3d  =  %6s  %6s", stat_names[cs], cval[cs], rp_ptr->r_adj[cs], cp_ptr->c_adj[cs], ap_ptr->a_adj[cs], inp, maxv);
+    char cur[60];
+    strnfmt(cur, sizeof(cur), "%6s       %2d   %+3d  %+3d  %+3d  =  %6s  %6s", stat_names[cs], cval[cs], rp_ptr->r_adj[cs], cp_ptr->c_adj[cs], ap_ptr->a_adj[cs], inp, maxv);
+    return cur;
 }
 
 /*!
@@ -192,14 +196,16 @@ static void cursor_of_adjusted_stat(char *cur, int *cval, int cs)
  */
 static void display_autoroller_chance(int *cval)
 {
-    char buf[320];
+    concptr buf;
+    char work[60];
     autoroll_chance = get_autoroller_prob(cval);
     if (autoroll_chance == -999) {
-        sprintf(buf, _("確率: 不可能(合計86超)       ", "Prob: Impossible(>86 tot stats)"));
+        buf = _("確率: 不可能(合計86超)       ", "Prob: Impossible(>86 tot stats)");
     } else if (autoroll_chance < 1) {
-        sprintf(buf, _("確率: 非常に容易(1/10000以上)", "Prob: Quite Easy(>1/10000)     "));
+        buf = _("確率: 非常に容易(1/10000以上)", "Prob: Quite Easy(>1/10000)     ");
     } else {
-        sprintf(buf, _("確率: 約 1/%8d00             ", "Prob: ~ 1/%8d00                "), autoroll_chance);
+        strnfmt(work, sizeof(work), _("確率: 約 1/%8d00             ", "Prob: ~ 1/%8d00                "), autoroll_chance);
+        buf = work;
     }
     put_str(buf, 23, 25);
 }
@@ -218,15 +224,13 @@ bool get_stat_limits(PlayerType *player_ptr)
     int cval[A_MAX]{};
     decide_initial_stat(player_ptr, cval);
 
-    char buf[320];
-    char cur[160];
     for (int i = 0; i < A_MAX; i++) {
-        cursor_of_adjusted_stat(buf, cval, i);
-        put_str(buf, 14 + i, 10);
+        put_str(cursor_of_adjusted_stat(cval, i).data(), 14 + i, 10);
     }
 
     display_autoroller_chance(cval);
 
+    std::string cur;
     int cs = 0;
     int os = A_MAX;
     while (true) {
@@ -236,14 +240,14 @@ bool get_stat_limits(PlayerType *player_ptr)
             } else if (os == A_MAX) {
                 c_put_str(TERM_WHITE, _("決定する", "Accept"), 21, 35);
             } else if (os < A_MAX) {
-                c_put_str(TERM_WHITE, cur, 14 + os, 10);
+                c_put_str(TERM_WHITE, cur.data(), 14 + os, 10);
             }
 
             if (cs == A_MAX) {
                 c_put_str(TERM_YELLOW, _("決定する", "Accept"), 21, 35);
             } else {
-                cursor_of_adjusted_stat(cur, cval, cs);
-                c_put_str(TERM_YELLOW, cur, 14 + cs, 10);
+                cur = cursor_of_adjusted_stat(cval, cs);
+                c_put_str(TERM_YELLOW, cur.data(), 14 + cs, 10);
             }
 
             os = cs;
@@ -367,7 +371,6 @@ bool get_chara_limits(PlayerType *player_ptr, chara_limit_type *chara_limit_ptr)
 {
 #define MAXITEMS 8
 
-    char buf[80], cur[80];
     concptr itemname[] = { _("年齢", "age"), _("身長(インチ)", "height"), _("体重(ポンド)", "weight"), _("社会的地位", "social class") };
 
     clear_from(10);
@@ -442,14 +445,16 @@ bool get_chara_limits(PlayerType *player_ptr, chara_limit_type *chara_limit_ptr)
     }
 
     for (int i = 0; i < 4; i++) {
-        sprintf(buf, "%-12s (%3d - %3d)", itemname[i], mval[i * 2], mval[i * 2 + 1]);
+        char buf[40];
+        strnfmt(buf, sizeof(buf), "%-12s (%3d - %3d)", itemname[i], mval[i * 2], mval[i * 2 + 1]);
         put_str(buf, 14 + i, 20);
         for (int j = 0; j < 2; j++) {
-            sprintf(buf, "     %3d", cval[i * 2 + j]);
+            strnfmt(buf, sizeof(buf), "     %3d", cval[i * 2 + j]);
             put_str(buf, 14 + i, 45 + 8 * j);
         }
     }
 
+    char cur[40] = "";
     int cs = 0;
     int os = MAXITEMS;
     while (true) {
@@ -464,7 +469,7 @@ bool get_chara_limits(PlayerType *player_ptr, chara_limit_type *chara_limit_ptr)
             if (cs == MAXITEMS) {
                 c_put_str(TERM_YELLOW, accept, 19, 35);
             } else {
-                sprintf(cur, "     %3d", cval[cs]);
+                strnfmt(cur, sizeof(cur), "     %3d", cval[cs]);
                 c_put_str(TERM_YELLOW, cur, 14 + cs / 2, 45 + 8 * (cs % 2));
             }
 

--- a/src/birth/birth-select-class.cpp
+++ b/src/birth/birth-select-class.cpp
@@ -6,10 +6,10 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
+#include "util/string-processor.h"
 #include "world/world.h"
-
-static const char p2 = ')';
 
 static TERM_COLOR birth_class_color(PlayerClassType cs)
 {
@@ -24,77 +24,81 @@ static TERM_COLOR birth_class_color(PlayerClassType cs)
     return TERM_WHITE;
 }
 
+static std::string birth_class_label(int cs, concptr sym)
+{
+    const char p2 = ')';
+    std::string result;
+
+    if (cs < 0 || cs >= PLAYER_CLASS_TYPE_MAX) {
+        result.append(1, '*').append(1, p2).append(_("ランダム", "Random"));
+    } else {
+        result.append(1, sym[cs]).append(1, p2);
+        if (!(rp_ptr->choice & (1UL << cs))) {
+            result.append(1, '(').append(class_info[cs].title).append(1, ')');
+        } else {
+            result.append(class_info[cs].title);
+        }
+    }
+    return result;
+}
+
 static void enumerate_class_list(char *sym)
 {
     for (auto n = 0; n < PLAYER_CLASS_TYPE_MAX; n++) {
         cp_ptr = &class_info[n];
         mp_ptr = &class_magics_info[n];
-        concptr str = cp_ptr->title;
         if (n < 26) {
             sym[n] = I2A(n);
         } else {
             sym[n] = ('A' + n - 26);
         }
 
-        char buf[80];
-        if (!(rp_ptr->choice & (1UL << n))) {
-            sprintf(buf, "%c%c(%s)", sym[n], p2, str);
-        } else {
-            sprintf(buf, "%c%c%s", sym[n], p2, str);
-        }
-
         auto cs = i2enum<PlayerClassType>(n);
-        c_put_str(birth_class_color(cs), buf, 13 + (n / 4), 2 + 19 * (n % 4));
+        c_put_str(birth_class_color(cs), birth_class_label(n, sym).data(), 13 + (n / 4), 2 + 19 * (n % 4));
     }
 }
 
-static void display_class_stat(int cs, int *os, char *cur, char *sym)
+static std::string display_class_stat(int cs, int *os, const std::string &cur, concptr sym)
 {
     if (cs == *os) {
-        return;
+        return cur;
     }
 
     auto pclass = i2enum<PlayerClassType>(*os);
-    c_put_str(birth_class_color(pclass), cur, 13 + (*os / 4), 2 + 19 * (*os % 4));
+    c_put_str(birth_class_color(pclass), cur.data(), 13 + (*os / 4), 2 + 19 * (*os % 4));
     put_str("                                   ", 3, 40);
+    auto result = birth_class_label(cs, sym);
     if (cs == PLAYER_CLASS_TYPE_MAX) {
-        sprintf(cur, "%c%c%s", '*', p2, _("ランダム", "Random"));
         put_str("                                   ", 4, 40);
         put_str("                                   ", 5, 40);
         put_str("                                   ", 6, 40);
     } else {
         cp_ptr = &class_info[cs];
         mp_ptr = &class_magics_info[cs];
-        concptr str = cp_ptr->title;
-        if (!(rp_ptr->choice & (1UL << cs))) {
-            sprintf(cur, "%c%c(%s)", sym[cs], p2, str);
-        } else {
-            sprintf(cur, "%c%c%s", sym[cs], p2, str);
-        }
 
         c_put_str(TERM_L_BLUE, cp_ptr->title, 3, 40);
         put_str(_("の職業修正", ": Class modification"), 3, 40 + strlen(cp_ptr->title));
         put_str(_("腕力 知能 賢さ 器用 耐久 魅力 経験 ", "Str  Int  Wis  Dex  Con  Chr   EXP "), 4, 40);
         char buf[80];
-        sprintf(buf, "%+3d  %+3d  %+3d  %+3d  %+3d  %+3d %+4d%% ", cp_ptr->c_adj[0], cp_ptr->c_adj[1], cp_ptr->c_adj[2], cp_ptr->c_adj[3], cp_ptr->c_adj[4],
-            cp_ptr->c_adj[5], cp_ptr->c_exp);
+        strnfmt(buf, sizeof(buf), "%+3d  %+3d  %+3d  %+3d  %+3d  %+3d %+4d%% ", cp_ptr->c_adj[0], cp_ptr->c_adj[1], cp_ptr->c_adj[2], cp_ptr->c_adj[3], cp_ptr->c_adj[4], cp_ptr->c_adj[5], cp_ptr->c_exp);
         c_put_str(TERM_L_BLUE, buf, 5, 40);
 
         put_str("HD", 6, 40);
-        sprintf(buf, "%+3d", cp_ptr->c_mhp);
+        strnfmt(buf, sizeof(buf), "%+3d", cp_ptr->c_mhp);
         c_put_str(TERM_L_BLUE, buf, 6, 42);
 
         put_str(_("隠密", "Stealth"), 6, 47);
         if (i2enum<PlayerClassType>(cs) == PlayerClassType::BERSERKER) {
-            strcpy(buf, " xx");
+            angband_strcpy(buf, " xx", sizeof(buf));
         } else {
-            sprintf(buf, " %+2d", cp_ptr->c_stl);
+            strnfmt(buf, sizeof(buf), " %+2d", cp_ptr->c_stl);
         }
         c_put_str(TERM_L_BLUE, buf, 6, _(51, 54));
     }
 
-    c_put_str(TERM_YELLOW, cur, 13 + (cs / 4), 2 + 19 * (cs % 4));
+    c_put_str(TERM_YELLOW, result.data(), 13 + (cs / 4), 2 + 19 * (cs % 4));
     *os = cs;
+    return result;
 }
 
 static void interpret_class_select_key_move(char c, int *cs)
@@ -124,21 +128,21 @@ static void interpret_class_select_key_move(char c, int *cs)
     }
 }
 
-static bool select_class(PlayerType *player_ptr, char *cur, char *sym, int *k)
+static bool select_class(PlayerType *player_ptr, concptr sym, int *k)
 {
     auto cs = player_ptr->pclass;
     auto os = PlayerClassType::MAX;
     int int_os = enum2i(os);
     int int_cs = enum2i(cs);
+    auto cur = birth_class_label(int_os, sym);
     while (true) {
-        display_class_stat(int_cs, &int_os, cur, sym);
+        cur = display_class_stat(int_cs, &int_os, cur, sym);
         if (*k >= 0) {
             break;
         }
 
         char buf[80];
-        sprintf(buf, _("職業を選んで下さい (%c-%c) ('='初期オプション設定, 灰色:勝利済): ", "Choose a class (%c-%c) ('=' for options, Gray is winner): "),
-            sym[0], sym[PLAYER_CLASS_TYPE_MAX - 1]);
+        strnfmt(buf, sizeof(buf), _("職業を選んで下さい (%c-%c) ('='初期オプション設定, 灰色:勝利済): ", "Choose a class (%c-%c) ('=' for options, Gray is winner): "), sym[0], sym[PLAYER_CLASS_TYPE_MAX - 1]);
 
         put_str(buf, 10, 6);
         char c = inkey();
@@ -203,10 +207,8 @@ bool get_player_class(PlayerType *player_ptr)
     char sym[PLAYER_CLASS_TYPE_MAX];
     enumerate_class_list(sym);
 
-    char cur[80];
-    sprintf(cur, "%c%c%s", '*', p2, _("ランダム", "Random"));
     int k = -1;
-    if (!select_class(player_ptr, cur, sym, &k)) {
+    if (!select_class(player_ptr, sym, &k)) {
         return false;
     }
 

--- a/src/birth/birth-select-personality.cpp
+++ b/src/birth/birth-select-personality.cpp
@@ -5,67 +5,74 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
 
-static const char p2 = ')';
-
-static void enumerate_personality_list(PlayerType *player_ptr, concptr *str, char *sym)
+static std::string birth_personality_label(int cs, concptr sym)
 {
-    char buf[80];
+    const char p2 = ')';
+    std::string result;
+
+    if (cs < 0 || cs >= MAX_PERSONALITIES) {
+        result.append(1, '*').append(1, p2).append(_("ランダム", "Random"));
+    } else {
+        result.append(1, sym[cs]).append(1, p2).append(personality_info[cs].title);
+    }
+    return result;
+}
+
+static void enumerate_personality_list(PlayerType *player_ptr, char *sym)
+{
     for (int n = 0; n < MAX_PERSONALITIES; n++) {
         if (personality_info[n].sex && (personality_info[n].sex != (player_ptr->psex + 1))) {
             continue;
         }
 
         ap_ptr = &personality_info[n];
-        *str = ap_ptr->title;
         if (n < 26) {
             sym[n] = I2A(n);
         } else {
             sym[n] = ('A' + n - 26);
         }
 
-        sprintf(buf, "%c%c%s", I2A(n), p2, *str);
-        put_str(buf, 12 + (n / 4), 2 + 18 * (n % 4));
+        put_str(birth_personality_label(n, sym).data(), 12 + (n / 4), 2 + 18 * (n % 4));
     }
 }
 
-static void display_personality_stat(int cs, int *os, concptr *str, char *cur, char *sym)
+static std::string display_personality_stat(int cs, int *os, const std::string &cur, concptr sym)
 {
-    char buf[80];
     if (cs == *os) {
-        return;
+        return cur;
     }
 
-    c_put_str(TERM_WHITE, cur, 12 + (*os / 4), 2 + 18 * (*os % 4));
+    c_put_str(TERM_WHITE, cur.data(), 12 + (*os / 4), 2 + 18 * (*os % 4));
     put_str("                                   ", 3, 40);
+    auto result = birth_personality_label(cs, sym);
     if (cs == MAX_PERSONALITIES) {
-        sprintf(cur, "%c%c%s", '*', p2, _("ランダム", "Random"));
         put_str("                                   ", 4, 40);
         put_str("                                   ", 5, 40);
         put_str("                                   ", 6, 40);
     } else {
         ap_ptr = &personality_info[cs];
-        *str = ap_ptr->title;
-        sprintf(cur, "%c%c%s", sym[cs], p2, *str);
         c_put_str(TERM_L_BLUE, ap_ptr->title, 3, 40);
         put_str(_("の性格修正", ": Personality modification"), 3, 40 + strlen(ap_ptr->title));
         put_str(_("腕力 知能 賢さ 器用 耐久 魅力      ", "Str  Int  Wis  Dex  Con  Chr       "), 4, 40);
-        sprintf(buf, "%+3d  %+3d  %+3d  %+3d  %+3d  %+3d       ", ap_ptr->a_adj[0], ap_ptr->a_adj[1], ap_ptr->a_adj[2], ap_ptr->a_adj[3], ap_ptr->a_adj[4],
-            ap_ptr->a_adj[5]);
+        char buf[80];
+        strnfmt(buf, sizeof(buf), "%+3d  %+3d  %+3d  %+3d  %+3d  %+3d       ", ap_ptr->a_adj[0], ap_ptr->a_adj[1], ap_ptr->a_adj[2], ap_ptr->a_adj[3], ap_ptr->a_adj[4], ap_ptr->a_adj[5]);
         c_put_str(TERM_L_BLUE, buf, 5, 40);
 
         put_str("HD", 6, 40);
-        sprintf(buf, "%+3d", ap_ptr->a_mhp);
+        strnfmt(buf, sizeof(buf), "%+3d", ap_ptr->a_mhp);
         c_put_str(TERM_L_BLUE, buf, 6, 42);
 
         put_str(_("隠密", "Stealth"), 6, 47);
-        sprintf(buf, "%+3d", ap_ptr->a_stl);
+        strnfmt(buf, sizeof(buf), "%+3d", ap_ptr->a_stl);
         c_put_str(TERM_L_BLUE, buf, 6, _(51, 54));
     }
 
-    c_put_str(TERM_YELLOW, cur, 12 + (cs / 4), 2 + 18 * (cs % 4));
+    c_put_str(TERM_YELLOW, result.data(), 12 + (cs / 4), 2 + 18 * (cs % 4));
     *os = cs;
+    return result;
 }
 
 static void interpret_personality_select_key_move(PlayerType *player_ptr, char c, int *cs)
@@ -123,21 +130,19 @@ static void interpret_personality_select_key_move(PlayerType *player_ptr, char c
     }
 }
 
-static bool select_personality(PlayerType *player_ptr, int *k, concptr *str, char *sym)
+static bool select_personality(PlayerType *player_ptr, int *k, concptr sym)
 {
-    char cur[80];
-    sprintf(cur, "%c%c%s", '*', p2, _("ランダム", "Random"));
     int cs = player_ptr->ppersonality;
     int os = MAX_PERSONALITIES;
+    std::string cur = birth_personality_label(os, sym);
     while (true) {
-        display_personality_stat(cs, &os, str, cur, sym);
+        cur = display_personality_stat(cs, &os, cur, sym);
         if (*k >= 0) {
             break;
         }
 
         char buf[80];
-        sprintf(
-            buf, _("性格を選んで下さい (%c-%c) ('='初期オプション設定): ", "Choose a personality (%c-%c) ('=' for options): "), sym[0], sym[MAX_PERSONALITIES - 1]);
+        strnfmt(buf, sizeof(buf), _("性格を選んで下さい (%c-%c) ('='初期オプション設定): ", "Choose a personality (%c-%c) ('=' for options): "), sym[0], sym[MAX_PERSONALITIES - 1]);
         put_str(buf, 10, 10);
         char c = inkey();
         if (c == 'Q') {
@@ -206,11 +211,10 @@ bool get_player_personality(PlayerType *player_ptr)
         23, 5);
     put_str("                                   ", 6, 40);
 
-    concptr str;
     char sym[MAX_PERSONALITIES];
-    enumerate_personality_list(player_ptr, &str, sym);
+    enumerate_personality_list(player_ptr, sym);
     int k = -1;
-    if (!select_personality(player_ptr, &k, &str, sym)) {
+    if (!select_personality(player_ptr, &k, sym)) {
         return false;
     }
 

--- a/src/birth/birth-select-race.cpp
+++ b/src/birth/birth-select-race.cpp
@@ -6,69 +6,76 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/enum-converter.h"
 #include "util/int-char-converter.h"
 
-static const char p2 = ')';
+static std::string birth_race_label(int cs, concptr sym)
+{
+    const char p2 = ')';
+    std::string result;
+
+    if (cs < 0 || cs >= MAX_RACES) {
+        result.append(1, '*').append(1, p2).append(_("ランダム", "Random"));
+    } else {
+        result.append(1, sym[cs]).append(1, p2).append(race_info[cs].title);
+    }
+    return result;
+}
 
 static void enumerate_race_list(char *sym)
 {
-    char buf[80];
     for (int n = 0; n < MAX_RACES; n++) {
         rp_ptr = &race_info[n];
-        concptr str = rp_ptr->title;
         if (n < 26) {
             sym[n] = I2A(n);
         } else {
             sym[n] = ('A' + n - 26);
         }
 
-        sprintf(buf, "%c%c%s", sym[n], p2, str);
-        put_str(buf, 12 + (n / 5), 1 + 16 * (n % 5));
+        put_str(birth_race_label(n, sym).data(), 12 + (n / 5), 1 + 16 * (n % 5));
     }
 }
 
-static void display_race_stat(int cs, int *os, char *cur, char *sym)
+static std::string display_race_stat(int cs, int *os, const std::string &cur, concptr sym)
 {
-    char buf[80];
     if (cs == *os) {
-        return;
+        return cur;
     }
 
-    c_put_str(TERM_WHITE, cur, 12 + (*os / 5), 1 + 16 * (*os % 5));
+    c_put_str(TERM_WHITE, cur.data(), 12 + (*os / 5), 1 + 16 * (*os % 5));
     put_str("                                   ", 3, 40);
+    auto result = birth_race_label(cs, sym);
     if (cs == MAX_RACES) {
-        sprintf(cur, "%c%c%s", '*', p2, _("ランダム", "Random"));
         put_str("                                   ", 4, 40);
         put_str("                                   ", 5, 40);
         put_str("                                   ", 6, 40);
     } else {
         rp_ptr = &race_info[cs];
-        concptr str = rp_ptr->title;
-        sprintf(cur, "%c%c%s", sym[cs], p2, str);
         c_put_str(TERM_L_BLUE, rp_ptr->title, 3, 40);
         put_str(_("腕力 知能 賢さ 器用 耐久 魅力 経験 ", "Str  Int  Wis  Dex  Con  Chr   EXP "), 4, 40);
         put_str(_("の種族修正", ": Race modification"), 3, 40 + strlen(rp_ptr->title));
 
-        sprintf(buf, "%+3d  %+3d  %+3d  %+3d  %+3d  %+3d %+4d%% ", rp_ptr->r_adj[0], rp_ptr->r_adj[1], rp_ptr->r_adj[2], rp_ptr->r_adj[3], rp_ptr->r_adj[4],
-            rp_ptr->r_adj[5], (rp_ptr->r_exp - 100));
+        char buf[80];
+        strnfmt(buf, sizeof(buf), "%+3d  %+3d  %+3d  %+3d  %+3d  %+3d %+4d%% ", rp_ptr->r_adj[0], rp_ptr->r_adj[1], rp_ptr->r_adj[2], rp_ptr->r_adj[3], rp_ptr->r_adj[4], rp_ptr->r_adj[5], (rp_ptr->r_exp - 100));
         c_put_str(TERM_L_BLUE, buf, 5, 40);
 
         put_str("HD ", 6, 40);
-        sprintf(buf, "%2d", rp_ptr->r_mhp);
+        strnfmt(buf, sizeof(buf), "%2d", rp_ptr->r_mhp);
         c_put_str(TERM_L_BLUE, buf, 6, 43);
 
         put_str(_("隠密", "Stealth"), 6, 47);
-        sprintf(buf, "%+2d", rp_ptr->r_stl);
+        strnfmt(buf, sizeof(buf), "%+2d", rp_ptr->r_stl);
         c_put_str(TERM_L_BLUE, buf, 6, _(52, 55));
 
         put_str(_("赤外線視力", "Infra"), 6, _(56, 59));
-        sprintf(buf, _("%2dft", "%2dft"), 10 * rp_ptr->infra);
+        strnfmt(buf, sizeof(buf), _("%2dft", "%2dft"), 10 * rp_ptr->infra);
         c_put_str(TERM_L_BLUE, buf, 6, _(67, 65));
     }
 
-    c_put_str(TERM_YELLOW, cur, 12 + (cs / 5), 1 + 16 * (cs % 5));
+    c_put_str(TERM_YELLOW, result.data(), 12 + (cs / 5), 1 + 16 * (cs % 5));
     *os = cs;
+    return result;
 }
 
 static void interpret_race_select_key_move(char c, int *cs)
@@ -100,18 +107,17 @@ static void interpret_race_select_key_move(char c, int *cs)
 
 static bool select_race(PlayerType *player_ptr, char *sym, int *k)
 {
-    char cur[80];
-    sprintf(cur, "%c%c%s", '*', p2, _("ランダム", "Random"));
     auto cs = enum2i(player_ptr->prace);
     int os = MAX_RACES;
+    std::string cur = birth_race_label(os, sym);
     while (true) {
-        display_race_stat(cs, &os, cur, sym);
+        cur = display_race_stat(cs, &os, cur, sym);
         if (*k >= 0) {
             break;
         }
 
         char buf[80];
-        sprintf(buf, _("種族を選んで下さい (%c-%c) ('='初期オプション設定): ", "Choose a race (%c-%c) ('=' for options): "), sym[0], sym[MAX_RACES - 1]);
+        strnfmt(buf, sizeof(buf), _("種族を選んで下さい (%c-%c) ('='初期オプション設定): ", "Choose a race (%c-%c) ('=' for options): "), sym[0], sym[MAX_RACES - 1]);
         put_str(buf, 10, 10);
         char c = inkey();
         if (c == 'Q') {

--- a/src/birth/birth-select-realm.cpp
+++ b/src/birth/birth-select-realm.cpp
@@ -10,6 +10,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/buffer-shaper.h"
 #include "util/int-char-converter.h"
 
@@ -149,7 +150,7 @@ static void analyze_realms(const PlayerType *player_ptr, const uint32_t choices,
 
         birth_realm_ptr->sym[birth_realm_ptr->n] = I2A(birth_realm_ptr->n);
 
-        sprintf(birth_realm_ptr->buf, "%c%c %s", birth_realm_ptr->sym[birth_realm_ptr->n], birth_realm_ptr->p2, realm_names[i + 1]);
+        strnfmt(birth_realm_ptr->buf, sizeof(birth_realm_ptr->buf), "%c%c %s", birth_realm_ptr->sym[birth_realm_ptr->n], birth_realm_ptr->p2, realm_names[i + 1]);
         put_str(birth_realm_ptr->buf, 12 + (birth_realm_ptr->n / 5), 2 + 15 * (birth_realm_ptr->n % 5));
         birth_realm_ptr->picks[birth_realm_ptr->n++] = i + 1;
     }
@@ -164,11 +165,11 @@ static void move_birth_realm_cursor(birth_realm_type *birth_realm_ptr)
     c_put_str(TERM_WHITE, birth_realm_ptr->cur, 12 + (birth_realm_ptr->os / 5), 2 + 15 * (birth_realm_ptr->os % 5));
 
     if (birth_realm_ptr->cs == birth_realm_ptr->n) {
-        sprintf(birth_realm_ptr->cur, "%c%c %s", '*', birth_realm_ptr->p2, _("ランダム", "Random"));
+        strnfmt(birth_realm_ptr->cur, sizeof(birth_realm_ptr->cur), "%c%c %s", '*', birth_realm_ptr->p2, _("ランダム", "Random"));
     } else {
-        sprintf(birth_realm_ptr->cur, "%c%c %s", birth_realm_ptr->sym[birth_realm_ptr->cs], birth_realm_ptr->p2,
+        strnfmt(birth_realm_ptr->cur, sizeof(birth_realm_ptr->cur), "%c%c %s", birth_realm_ptr->sym[birth_realm_ptr->cs], birth_realm_ptr->p2,
             realm_names[birth_realm_ptr->picks[birth_realm_ptr->cs]]);
-        sprintf(birth_realm_ptr->buf, "%s", realm_names[birth_realm_ptr->picks[birth_realm_ptr->cs]]);
+        strnfmt(birth_realm_ptr->buf, sizeof(birth_realm_ptr->buf), "%s", realm_names[birth_realm_ptr->picks[birth_realm_ptr->cs]]);
         c_put_str(TERM_L_BLUE, birth_realm_ptr->buf, 3, 40);
         prt(_("の特徴", ": Characteristic"), 3, 40 + strlen(birth_realm_ptr->buf));
         prt(realm_subinfo[technic2magic(birth_realm_ptr->picks[birth_realm_ptr->cs]) - 1].data(), 4, 40);
@@ -218,7 +219,7 @@ static bool get_a_realm(PlayerType *player_ptr, birth_realm_type *birth_realm_pt
             break;
         }
 
-        sprintf(birth_realm_ptr->buf, _("領域を選んで下さい(%c-%c) ('='初期オプション設定): ", "Choose a realm (%c-%c) ('=' for options): "),
+        strnfmt(birth_realm_ptr->buf, sizeof(birth_realm_ptr->buf), _("領域を選んで下さい(%c-%c) ('='初期オプション設定): ", "Choose a realm (%c-%c) ('=' for options): "),
             birth_realm_ptr->sym[0], birth_realm_ptr->sym[birth_realm_ptr->n - 1]);
 
         put_str(birth_realm_ptr->buf, 10, 10);
@@ -285,7 +286,7 @@ static byte select_realm(PlayerType *player_ptr, uint32_t choices, int *count)
     birth_realm_type tmp_birth_realm;
     birth_realm_type *birth_realm_ptr = initialize_birth_realm_type(&tmp_birth_realm);
     analyze_realms(player_ptr, choices, birth_realm_ptr);
-    sprintf(birth_realm_ptr->cur, "%c%c %s", '*', birth_realm_ptr->p2, _("ランダム", "Random"));
+    strnfmt(birth_realm_ptr->cur, sizeof(birth_realm_ptr->cur), "%c%c %s", '*', birth_realm_ptr->p2, _("ランダム", "Random"));
     if (get_a_realm(player_ptr, birth_realm_ptr)) {
         return REALM_SELECT_CANCEL;
     }

--- a/src/birth/birth-wizard.cpp
+++ b/src/birth/birth-wizard.cpp
@@ -34,9 +34,11 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/buffer-shaper.h"
 #include "util/enum-converter.h"
 #include "util/int-char-converter.h"
+#include "util/string-processor.h"
 #include "view/display-birth.h" // 暫定。後で消す予定。
 #include "view/display-player.h" // 暫定。後で消す.
 #include "world/world.h"
@@ -83,31 +85,39 @@ static void display_help_on_sex_select(PlayerType *player_ptr, char c)
 }
 
 /*!
- * @brief プレイヤーの性別選択を行う / Player sex
- * @param player_ptr プレイヤーへの参照ポインタ
- * @buf 表示用バッファ
- * @return やり直すならFALSE、それ以外はTRUE
+ * @brief 表示されている性別のラベルを取得する
+ * @param cs 性別の指標
+ * @return std::string 表示するラベルを保持
  */
-static bool get_player_sex(PlayerType *player_ptr, char *buf)
+static std::string birth_sex_label(int cs)
 {
     const char p2 = ')';
-    char cur[80];
-    sprintf(cur, _("%c%c%s", "%c%c %s"), '*', p2, _("ランダム", "Random"));
+    std::string result;
+
+    if (cs < 0 || cs >= MAX_SEXES) {
+        result.append(1, '*').append(1, p2).append(_("ランダム", "Random"));
+    } else {
+        result.append(1, I2A(cs)).append(1, p2).append(sex_info[cs].title);
+    }
+    return result;
+}
+
+/*!
+ * @brief プレイヤーの性別選択を行う / Player sex
+ * @param player_ptr プレイヤーへの参照ポインタ
+ * @return やり直すならFALSE、それ以外はTRUE
+ */
+static bool get_player_sex(PlayerType *player_ptr)
+{
     int k = -1;
     int cs = 0;
     int os = MAX_SEXES;
+    auto cur = birth_sex_label(os);
     while (true) {
         if (cs != os) {
-            put_str(cur, 12 + (os / 5), 2 + 15 * (os % 5));
-            if (cs == MAX_SEXES) {
-                sprintf(cur, _("%c%c%s", "%c%c %s"), '*', p2, _("ランダム", "Random"));
-            } else {
-                sp_ptr = &sex_info[cs];
-                concptr str = sp_ptr->title;
-                sprintf(cur, _("%c%c%s", "%c%c %s"), I2A(cs), p2, str);
-            }
-
-            c_put_str(TERM_YELLOW, cur, 12 + (cs / 5), 2 + 15 * (cs % 5));
+            put_str(cur.data(), 12 + (os / 5), 2 + 15 * (os % 5));
+            cur = birth_sex_label(cs);
+            c_put_str(TERM_YELLOW, cur.data(), 12 + (cs / 5), 2 + 15 * (cs % 5));
             os = cs;
         }
 
@@ -115,7 +125,8 @@ static bool get_player_sex(PlayerType *player_ptr, char *buf)
             break;
         }
 
-        sprintf(buf, _("性別を選んで下さい (%c-%c) ('='初期オプション設定): ", "Choose a sex (%c-%c) ('=' for options): "), I2A(0), I2A(1));
+        char buf[80];
+        strnfmt(buf, sizeof(buf), _("性別を選んで下さい (%c-%c) ('='初期オプション設定): ", "Choose a sex (%c-%c) ('=' for options): "), I2A(0), I2A(1));
         put_str(buf, 10, 10);
         char c = inkey();
         if (c == 'Q') {
@@ -263,8 +274,7 @@ static bool let_player_select_personality(PlayerType *player_ptr)
 
 static bool let_player_build_character(PlayerType *player_ptr)
 {
-    char buf[80];
-    if (!get_player_sex(player_ptr, buf)) {
+    if (!get_player_sex(player_ptr)) {
         return false;
     }
 
@@ -301,23 +311,23 @@ static void display_initial_options(PlayerType *player_ptr)
     put_str("                                   ", 3, 40);
     put_str(_("修正の合計値", "Your total modification"), 3, 40);
     put_str(_("腕力 知能 賢さ 器用 耐久 魅力 経験 ", "Str  Int  Wis  Dex  Con  Chr   EXP "), 4, 40);
-    sprintf(buf, "%+3d  %+3d  %+3d  %+3d  %+3d  %+3d %+4d%% ", adj[0], adj[1], adj[2], adj[3], adj[4], adj[5], expfact);
+    strnfmt(buf, sizeof(buf), "%+3d  %+3d  %+3d  %+3d  %+3d  %+3d %+4d%% ", adj[0], adj[1], adj[2], adj[3], adj[4], adj[5], expfact);
     c_put_str(TERM_L_BLUE, buf, 5, 40);
 
     put_str("HD ", 6, 40);
-    sprintf(buf, "%2d", rp_ptr->r_mhp + cp_ptr->c_mhp + ap_ptr->a_mhp);
+    strnfmt(buf, sizeof(buf), "%2d", rp_ptr->r_mhp + cp_ptr->c_mhp + ap_ptr->a_mhp);
     c_put_str(TERM_L_BLUE, buf, 6, 43);
 
     put_str(_("隠密", "Stealth"), 6, 47);
     if (PlayerClass(player_ptr).equals(PlayerClassType::BERSERKER)) {
-        strcpy(buf, "xx");
+        angband_strcpy(buf, "xx", sizeof(buf));
     } else {
-        sprintf(buf, "%+2d", rp_ptr->r_stl + cp_ptr->c_stl + ap_ptr->a_stl);
+        strnfmt(buf, sizeof(buf), "%+2d", rp_ptr->r_stl + cp_ptr->c_stl + ap_ptr->a_stl);
     }
     c_put_str(TERM_L_BLUE, buf, 6, _(52, 55));
 
     put_str(_("赤外線視力", "Infra"), 6, _(56, 59));
-    sprintf(buf, _("%2dft", "%2dft"), 10 * rp_ptr->infra);
+    strnfmt(buf, sizeof(buf), _("%2dft", "%2dft"), 10 * rp_ptr->infra);
     c_put_str(TERM_L_BLUE, buf, 6, _(67, 65));
 
     clear_from(10);
@@ -338,11 +348,11 @@ static void display_auto_roller_success_rate(const int col)
     char buf[32];
 
     if (autoroll_chance >= 1) {
-        sprintf(buf, _("確率 :  1/%8d00", "Prob :  1/%8d00"), autoroll_chance);
+        strnfmt(buf, sizeof(buf), _("確率 :  1/%8d00", "Prob :  1/%8d00"), autoroll_chance);
     } else if (autoroll_chance == -999) {
-        sprintf(buf, _("確率 :     不可能", "Prob :     Impossible"));
+        angband_strcpy(buf, _("確率 :     不可能", "Prob :     Impossible"), sizeof(buf));
     } else {
-        sprintf(buf, _("確率 :     1/10000以上", "Prob :     >1/10000"));
+        angband_strcpy(buf, _("確率 :     1/10000以上", "Prob :     >1/10000"), sizeof(buf));
     }
     put_str(buf, 11, col + 10);
 
@@ -592,12 +602,8 @@ static void set_name_history(PlayerType *player_ptr)
 bool player_birth_wizard(PlayerType *player_ptr)
 {
     display_initial_birth_message(player_ptr);
-    const char p2 = ')';
-    char buf[80];
     for (int n = 0; n < MAX_SEXES; n++) {
-        sp_ptr = &sex_info[n];
-        sprintf(buf, _("%c%c%s", "%c%c %s"), I2A(n), p2, sp_ptr->title);
-        put_str(buf, 12 + (n / 5), 2 + 15 * (n % 5));
+        put_str(birth_sex_label(n).data(), 12 + (n / 5), 2 + 15 * (n % 5));
     }
 
     if (!let_player_build_character(player_ptr)) {

--- a/src/birth/character-builder.cpp
+++ b/src/birth/character-builder.cpp
@@ -37,6 +37,7 @@
 #include "store/store-owners.h"
 #include "store/store.h"
 #include "system/player-type-definition.h"
+#include "term/z-form.h"
 #include "util/enum-converter.h"
 #include "view/display-messages.h"
 #include "world/world.h"
@@ -58,25 +59,25 @@ static void write_birth_diary(PlayerType *player_ptr)
     exe_write_diary(player_ptr, DIARY_GAMESTART, 1, _("-------- 新規ゲーム開始 --------", "------- Started New Game -------"));
     exe_write_diary(player_ptr, DIARY_DIALY, 0, nullptr);
     char buf[80];
-    sprintf(buf, _("%s性別に%sを選択した。", "%schose %s gender."), indent, sex_info[player_ptr->psex].title);
+    strnfmt(buf, sizeof(buf), _("%s性別に%sを選択した。", "%schose %s gender."), indent, sex_info[player_ptr->psex].title);
     exe_write_diary(player_ptr, DIARY_DESCRIPTION, 1, buf);
-    sprintf(buf, _("%s種族に%sを選択した。", "%schose %s race."), indent, race_info[enum2i(player_ptr->prace)].title);
+    strnfmt(buf, sizeof(buf), _("%s種族に%sを選択した。", "%schose %s race."), indent, race_info[enum2i(player_ptr->prace)].title);
     exe_write_diary(player_ptr, DIARY_DESCRIPTION, 1, buf);
-    sprintf(buf, _("%s職業に%sを選択した。", "%schose %s class."), indent, class_info[enum2i(player_ptr->pclass)].title);
+    strnfmt(buf, sizeof(buf), _("%s職業に%sを選択した。", "%schose %s class."), indent, class_info[enum2i(player_ptr->pclass)].title);
     exe_write_diary(player_ptr, DIARY_DESCRIPTION, 1, buf);
     if (player_ptr->realm1) {
-        sprintf(buf, _("%s魔法の領域に%s%sを選択した。", "%schose %s%s."), indent, realm_names[player_ptr->realm1],
+        strnfmt(buf, sizeof(buf), _("%s魔法の領域に%s%sを選択した。", "%schose %s%s."), indent, realm_names[player_ptr->realm1],
             player_ptr->realm2 ? format(_("と%s", " and %s realms"), realm_names[player_ptr->realm2]) : _("", " realm"));
         exe_write_diary(player_ptr, DIARY_DESCRIPTION, 1, buf);
     }
     if (player_ptr->element) {
-        sprintf(buf, _("%s元素系統に%sを選択した。", "%schose %s system."), indent, get_element_title(player_ptr->element));
+        strnfmt(buf, sizeof(buf), _("%s元素系統に%sを選択した。", "%schose %s system."), indent, get_element_title(player_ptr->element));
         exe_write_diary(player_ptr, DIARY_DESCRIPTION, 1, buf);
     }
-    sprintf(buf, _("%s性格に%sを選択した。", "%schose %s personality."), indent, personality_info[player_ptr->ppersonality].title);
+    strnfmt(buf, sizeof(buf), _("%s性格に%sを選択した。", "%schose %s personality."), indent, personality_info[player_ptr->ppersonality].title);
     exe_write_diary(player_ptr, DIARY_DESCRIPTION, 1, buf);
     if (PlayerClass(player_ptr).equals(PlayerClassType::CHAOS_WARRIOR)) {
-        sprintf(buf, _("%s守護神%sと契約を交わした。", "%smade a contract with patron %s."), indent, patron_list[player_ptr->chaos_patron].name.data());
+        strnfmt(buf, sizeof(buf), _("%s守護神%sと契約を交わした。", "%smade a contract with patron %s."), indent, patron_list[player_ptr->chaos_patron].name.data());
         exe_write_diary(player_ptr, DIARY_DESCRIPTION, 1, buf);
     }
 }

--- a/src/birth/history-editor.cpp
+++ b/src/birth/history-editor.cpp
@@ -6,6 +6,7 @@
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 #include "util/int-char-converter.h"
+#include "util/string-processor.h"
 #include "view/display-player.h" // 暫定。後で消す.
 
 /*!
@@ -14,9 +15,9 @@
  */
 void edit_history(PlayerType *player_ptr)
 {
-    char old_history[4][60];
+    std::string old_history[4];
     for (int i = 0; i < 4; i++) {
-        sprintf(old_history[i], "%s", player_ptr->history[i]);
+        old_history[i] = player_ptr->history[i];
     }
 
     for (int i = 0; i < 4; i++) {
@@ -117,7 +118,7 @@ void edit_history(PlayerType *player_ptr)
             clear_from(11);
             put_str(_("(キャラクターの生い立ち)", "(Character Background)"), 11, 25);
             for (int i = 0; i < 4; i++) {
-                sprintf(player_ptr->history[i], "%s", old_history[i]);
+                angband_strcpy(player_ptr->history[i], old_history[i].data(), sizeof(player_ptr->history[i]));
                 put_str(player_ptr->history[i], i + 12, 10);
             }
 

--- a/src/cmd-action/cmd-hissatsu.cpp
+++ b/src/cmd-action/cmd-hissatsu.cpp
@@ -39,6 +39,7 @@
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 
@@ -195,7 +196,6 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
         if ((choice == ' ') || (choice == '*') || (choice == '?') || (use_menu && should_redraw_cursor)) {
             /* Show the list */
             if (!redraw || use_menu) {
-                char psi_desc[80];
                 int line;
                 redraw = true;
                 if (!use_menu) {
@@ -225,11 +225,12 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
                     if (!(player_ptr->spell_learned1 & (1UL << i))) {
                         continue;
                     }
+                    std::string psi_desc;
                     if (use_menu) {
                         if (i == (menu_line - 1)) {
-                            strcpy(psi_desc, _("  》", "  > "));
+                            psi_desc = _("  》", "  > ");
                         } else {
-                            strcpy(psi_desc, "    ");
+                            psi_desc = "    ";
                         }
 
                     } else {
@@ -239,12 +240,12 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
                         } else {
                             letter = '0' + line - 27;
                         }
-                        sprintf(psi_desc, "  %c)", letter);
+                        psi_desc = format("  %c)", letter);
                     }
 
                     /* Dump the spell --(-- */
-                    strcat(psi_desc, format(" %-18s%2d %3d", exe_spell(player_ptr, REALM_HISSATSU, i, SpellProcessType::NAME), spell.slevel, spell.smana));
-                    prt(psi_desc, y + (line % 17) + (line >= 17), x + (line / 17) * 30);
+                    psi_desc.append(format(" %-18s%2d %3d", exe_spell(player_ptr, REALM_HISSATSU, i, SpellProcessType::NAME), spell.slevel, spell.smana));
+                    prt(psi_desc.data(), y + (line % 17) + (line >= 17), x + (line / 17) * 30);
                     prt("", y + (line % 17) + (line >= 17) + 1, x + (line / 17) * 30);
                 }
             }

--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -65,6 +65,7 @@
 #include "target/target-setter.h"
 #include "target/target-types.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "timed-effect/player-stun.h"
 #include "timed-effect/timed-effects.h"
 #include "util/enum-converter.h"
@@ -180,7 +181,6 @@ static int get_mane_power(PlayerType *player_ptr, int *sn, bool baigaesi)
         if ((choice == ' ') || (choice == '*') || (choice == '?')) {
             /* Show the list */
             if (!redraw) {
-                char psi_desc[160];
                 redraw = true;
                 screen_save();
 
@@ -233,8 +233,7 @@ static int get_mane_power(PlayerType *player_ptr, int *sn, bool baigaesi)
                     mane_info(player_ptr, comment, mane.spell, (baigaesi ? mane.damage * 2 : mane.damage));
 
                     /* Dump the spell --(-- */
-                    sprintf(psi_desc, "  %c) %-30s %3d%%%s", I2A(i), spell.name, chance, comment);
-                    prt(psi_desc, y + i + 1, x);
+                    prt(format("  %c) %-30s %3d%%%s", I2A(i), spell.name, chance, comment), y + i + 1, x);
                 }
 
                 /* Clear the bottom line */

--- a/src/cmd-action/cmd-racial.cpp
+++ b/src/cmd-action/cmd-racial.cpp
@@ -32,6 +32,7 @@
 #include "status/action-setter.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/bit-flags-calculator.h"
 #include "util/buffer-shaper.h"
 #include "util/int-char-converter.h"
@@ -64,8 +65,6 @@ static void racial_power_erase_cursor(rc_type *rc_ptr)
 static void racial_power_display_list(PlayerType *player_ptr, rc_type *rc_ptr)
 {
     TERM_LEN x = 11;
-    char dummy[256];
-    strcpy(dummy, "");
 
     prt(_("                                   Lv   MP 失率 効果", "                                   Lv   MP Fail Effect"), 1, x);
 
@@ -76,8 +75,9 @@ static void racial_power_display_list(PlayerType *player_ptr, rc_type *rc_ptr)
             break;
         }
 
+        std::string dummy;
         if (use_menu) {
-            strcpy(dummy, "    ");
+            dummy = "    ";
         } else {
             char letter;
             if (ctr < 26) {
@@ -86,15 +86,15 @@ static void racial_power_display_list(PlayerType *player_ptr, rc_type *rc_ptr)
                 letter = '0' + ctr - 26;
             }
 
-            sprintf(dummy, " %c) ", letter);
+            dummy = format(" %c) ", letter);
         }
 
         auto &rpi = rc_ptr->power_desc[ctr];
-        strcat(dummy,
+        dummy.append(
             format("%-30.30s %2d %4d %3d%% %s", rpi.racial_name.data(), rpi.min_level, rpi.cost, 100 - racial_chance(player_ptr, &rc_ptr->power_desc[ctr]),
                 rpi.info.data()));
 
-        prt(dummy, 2 + y, x);
+        prt(dummy.data(), 2 + y, x);
     }
 
     prt("", 2 + y, x);

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -63,6 +63,7 @@
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "timed-effect/player-blindness.h"
 #include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
@@ -706,7 +707,7 @@ static void change_realm2(PlayerType *player_ptr, int16_t next_realm)
     player_ptr->spell_worked2 = 0L;
     player_ptr->spell_forgotten2 = 0L;
 
-    sprintf(tmp, _("魔法の領域を%sから%sに変更した。", "changed magic realm from %s to %s."), realm_names[player_ptr->realm2], realm_names[next_realm]);
+    strnfmt(tmp, sizeof(tmp), _("魔法の領域を%sから%sに変更した。", "changed magic realm from %s to %s."), realm_names[player_ptr->realm2], realm_names[next_realm]);
     exe_write_diary(player_ptr, DIARY_DESCRIPTION, 0, tmp);
     player_ptr->old_realm |= 1U << (player_ptr->realm2 - 1);
     player_ptr->realm2 = next_realm;

--- a/src/cmd-building/cmd-inn.cpp
+++ b/src/cmd-building/cmd-inn.cpp
@@ -169,9 +169,7 @@ static void display_stay_result(PlayerType *player_ptr, int prev_hour)
 {
     if ((prev_hour >= 6) && (prev_hour < 18)) {
 #if JP
-        char refresh_message_jp[50];
-        sprintf(refresh_message_jp, "%s%s%s", "あなたはリフレッシュして目覚め、", is_player_undead(player_ptr) ? "夜" : "夕方", "を迎えた。");
-        msg_print(refresh_message_jp);
+        msg_print(std::string("あな>たはリフレッシュして目覚め、").append(is_player_undead(player_ptr) ? "夜" : "夕方").append("を迎えた。"));
 #else
         msg_print("You awake refreshed for the evening.");
 #endif

--- a/src/cmd-io/cmd-diary.cpp
+++ b/src/cmd-io/cmd-diary.cpp
@@ -12,6 +12,7 @@
 #include "player/player-personality.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
@@ -23,26 +24,26 @@
  */
 static void display_diary(PlayerType *player_ptr)
 {
-    char diary_title[256];
-    GAME_TEXT file_name[MAX_NLEN];
+    std::string file_name = _("playrecord-", "playrec-");
+    file_name.append(savefile_base).append(".txt");
     char buf[1024];
-    char tmp[80];
-    sprintf(file_name, _("playrecord-%s.txt", "playrec-%s.txt"), savefile_base);
-    path_build(buf, sizeof(buf), ANGBAND_DIR_USER, file_name);
+    path_build(buf, sizeof(buf), ANGBAND_DIR_USER, file_name.data());
 
     PlayerClass pc(player_ptr);
+    concptr tmp;
     if (pc.is_tough()) {
-        strcpy(tmp, subtitle[randint0(MAX_SUBTITLE - 1)]);
+        tmp = subtitle[randint0(MAX_SUBTITLE - 1)];
     } else if (pc.is_wizard()) {
-        strcpy(tmp, subtitle[randint0(MAX_SUBTITLE - 1) + 1]);
+        tmp = subtitle[randint0(MAX_SUBTITLE - 1) + 1];
     } else {
-        strcpy(tmp, subtitle[randint0(MAX_SUBTITLE - 2) + 1]);
+        tmp = subtitle[randint0(MAX_SUBTITLE - 2) + 1];
     }
 
+    char diary_title[256];
 #ifdef JP
-    sprintf(diary_title, "「%s%s%sの伝説 -%s-」", ap_ptr->title, ap_ptr->no ? "の" : "", player_ptr->name, tmp);
+    strnfmt(diary_title, sizeof(diary_title), "「%s%s%sの伝説 -%s-」", ap_ptr->title, ap_ptr->no ? "の" : "", player_ptr->name, tmp);
 #else
-    sprintf(diary_title, "Legend of %s %s '%s'", ap_ptr->title, player_ptr->name, tmp);
+    strnfmt(diary_title, sizeof(diary_title), "Legend of %s %s '%s'", ap_ptr->title, player_ptr->name, tmp);
 #endif
 
     (void)show_file(player_ptr, false, buf, diary_title, -1, 0);
@@ -71,14 +72,14 @@ static void do_cmd_last_get(PlayerType *player_ptr)
     }
 
     char buf[256];
-    sprintf(buf, _("%sの入手を記録します。", "Do you really want to record getting %s? "), record_o_name);
+    strnfmt(buf, sizeof(buf), _("%sの入手を記録します。", "Do you really want to record getting %s? "), record_o_name);
     if (!get_check(buf)) {
         return;
     }
 
     GAME_TURN turn_tmp = w_ptr->game_turn;
     w_ptr->game_turn = record_turn;
-    sprintf(buf, _("%sを手に入れた。", "discover %s."), record_o_name);
+    strnfmt(buf, sizeof(buf), _("%sを手に入れた。", "discover %s."), record_o_name);
     exe_write_diary(player_ptr, DIARY_DESCRIPTION, 0, buf);
     w_ptr->game_turn = turn_tmp;
 }
@@ -88,15 +89,15 @@ static void do_cmd_last_get(PlayerType *player_ptr)
  */
 static void do_cmd_erase_diary(void)
 {
-    GAME_TEXT file_name[MAX_NLEN];
     char buf[256];
     FILE *fff = nullptr;
 
     if (!get_check(_("本当に記録を消去しますか？", "Do you really want to delete all your records? "))) {
         return;
     }
-    sprintf(file_name, _("playrecord-%s.txt", "playrec-%s.txt"), savefile_base);
-    path_build(buf, sizeof(buf), ANGBAND_DIR_USER, file_name);
+    std::string file_name = _("playrecord-", "playrec-");
+    file_name.append(savefile_base).append(".txt");
+    path_build(buf, sizeof(buf), ANGBAND_DIR_USER, file_name.data());
     fd_kill(buf);
 
     fff = angband_fopen(buf, "w");

--- a/src/cmd-io/cmd-dump.cpp
+++ b/src/cmd-io/cmd-dump.cpp
@@ -84,7 +84,7 @@ void do_cmd_colors(PlayerType *player_ptr)
         if (i == '1') {
             prt(_("コマンド: ユーザー設定ファイルをロードします", "Command: Load a user pref file"), 8, 0);
             prt(_("ファイル: ", "File: "), 10, 0);
-            sprintf(tmp, "%s.prf", player_ptr->base_name);
+            strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
             if (!askfor(tmp, 70)) {
                 continue;
             }
@@ -96,7 +96,7 @@ void do_cmd_colors(PlayerType *player_ptr)
             static concptr mark = "Colors";
             prt(_("コマンド: カラーの設定をファイルに書き出します", "Command: Dump colors"), 8, 0);
             prt(_("ファイル: ", "File: "), 10, 0);
-            sprintf(tmp, "%s.prf", player_ptr->base_name);
+            strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
             if (!askfor(tmp, 70)) {
                 continue;
             }
@@ -270,17 +270,11 @@ void do_cmd_time(PlayerType *player_ptr)
     int day, hour, min;
     extract_day_hour_min(player_ptr, &day, &hour, &min);
 
-    char desc[1024];
-    strcpy(desc, _("変な時刻だ。", "It is a strange time."));
+    std::string desc = _("変な時刻だ。", "It is a strange time.");
 
-    char day_buf[20];
-    if (day < MAX_DAYS) {
-        sprintf(day_buf, "%d", day);
-    } else {
-        strcpy(day_buf, "*****");
-    }
+    std::string day_buf = (day < MAX_DAYS) ? std::to_string(day) : "*****";
 
-    msg_format(_("%s日目, 時刻は%d:%02d %sです。", "This is day %s. The time is %d:%02d %s."), day_buf, (hour % 12 == 0) ? 12 : (hour % 12), min,
+    msg_format(_("%s日目, 時刻は%d:%02d %sです。", "This is day %s. The time is %d:%02d %s."), day_buf.data(), (hour % 12 == 0) ? 12 : (hour % 12), min,
         (hour < 12) ? "AM" : "PM");
 
     char buf[1024];
@@ -327,7 +321,7 @@ void do_cmd_time(PlayerType *player_ptr)
         if (buf[0] == 'D') {
             num++;
             if (!randint0(num)) {
-                strcpy(desc, buf + 2);
+                desc = buf + 2;
             }
 
             continue;

--- a/src/cmd-io/cmd-floor.cpp
+++ b/src/cmd-io/cmd-floor.cpp
@@ -13,6 +13,7 @@
 #include "target/target-checker.h"
 #include "target/target-setter.h"
 #include "target/target-types.h"
+#include "term/z-form.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "window/main-window-util.h"
@@ -55,29 +56,28 @@ void do_cmd_locate(PlayerType *player_ptr)
 {
     DIRECTION dir;
     POSITION y1, x1;
-    GAME_TEXT tmp_val[80];
-    GAME_TEXT out_val[MAX_MONSTER_NAME];
     TERM_LEN wid, hgt;
     get_screen_size(&wid, &hgt);
     POSITION y2 = y1 = panel_row_min;
     POSITION x2 = x1 = panel_col_min;
     while (true) {
+        std::string tmp_val;
         if ((y2 == y1) && (x2 == x1)) {
-            strcpy(tmp_val, _("真上", "\0"));
+            tmp_val = _("真上", "");
         } else {
-            sprintf(tmp_val, "%s%s", ((y2 < y1) ? _("北", " North") : (y2 > y1) ? _("南", " South")
-                                                                                : ""),
-                ((x2 < x1) ? _("西", " West") : (x2 > x1) ? _("東", " East")
-                                                          : ""));
+            tmp_val.append((y2 < y1) ? _("北", " North") : (y2 > y1) ? _("南", " South")
+                                                                     : "");
+            tmp_val.append((x2 < x1) ? _("西", " West") : (x2 > x1) ? _("東", " East")
+                                                                    : "");
         }
 
-        sprintf(out_val, _("マップ位置 [%d(%02d),%d(%02d)] (プレイヤーの%s)  方向?", "Map sector [%d(%02d),%d(%02d)], which is%s your sector.  Direction?"),
-            y2 / (hgt / 2), y2 % (hgt / 2), x2 / (wid / 2), x2 % (wid / 2), tmp_val);
+        std::string out_val = format(_("マップ位置 [%d(%02d),%d(%02d)] (プレイヤーの%s)  方向?", "Map sector [%d(%02d),%d(%02d)], which is%s your sector.  Direction?"),
+            y2 / (hgt / 2), y2 % (hgt / 2), x2 / (wid / 2), x2 % (wid / 2), tmp_val.data());
 
         dir = 0;
         while (!dir) {
             char command;
-            if (!get_com(out_val, &command, true)) {
+            if (!get_com(out_val.data(), &command, true)) {
                 break;
             }
 

--- a/src/cmd-io/cmd-gameoption.cpp
+++ b/src/cmd-io/cmd-gameoption.cpp
@@ -20,6 +20,7 @@
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
 #include "util/string-processor.h"
@@ -93,21 +94,16 @@ static void do_cmd_options_autosave(PlayerType *player_ptr, concptr info)
 {
     char ch;
     int i, k = 0, n = 2;
-    char buf[80];
     term_clear();
     while (true) {
-        sprintf(buf,
-            _("%s ( リターンで次へ, y/n でセット, F で頻度を入力, ESC で決定 ) ", "%s (RET to advance, y/n to set, 'F' for frequency, ESC to accept) "), info);
-        prt(buf, 0, 0);
+        prt(format(_("%s ( リターンで次へ, y/n でセット, F で頻度を入力, ESC で決定 ) ", "%s (RET to advance, y/n to set, 'F' for frequency, ESC to accept) "), info), 0, 0);
         for (i = 0; i < n; i++) {
             byte a = TERM_WHITE;
             if (i == k) {
                 a = TERM_L_BLUE;
             }
 
-            sprintf(
-                buf, "%-48s: %s (%s)", autosave_info[i].o_desc, (*autosave_info[i].o_var ? _("はい  ", "yes") : _("いいえ", "no ")), autosave_info[i].o_text);
-            c_prt(a, buf, i + 2, 0);
+            c_prt(a, format("%-48s: %s (%s)", autosave_info[i].o_desc, (*autosave_info[i].o_var ? _("はい  ", "yes") : _("いいえ", "no ")), autosave_info[i].o_text), i + 2, 0);
         }
 
         prt(format(_("自動セーブの頻度： %d ターン毎", "Timed autosave frequency: every %d turns"), autosave_freq), 5, 0);
@@ -336,9 +332,7 @@ static void do_cmd_options_cheat(PlayerType *player_ptr, concptr info)
     auto k = 0U;
     const auto n = cheat_info.size();
     while (true) {
-        char buf[80];
-        sprintf(buf, _("%s ( リターンで次へ, y/n でセット, ESC で決定 )", "%s (RET to advance, y/n to set, ESC to accept) "), info);
-        prt(buf, 0, 0);
+        prt(format(_("%s ( リターンで次へ, y/n でセット, ESC で決定 )", "%s (RET to advance, y/n to set, ESC to accept) "), info), 0, 0);
 
 #ifdef JP
         /* 詐欺オプションをうっかりいじってしまう人がいるようなので注意 */
@@ -353,8 +347,7 @@ static void do_cmd_options_cheat(PlayerType *player_ptr, concptr info)
                 a = TERM_L_BLUE;
             }
 
-            sprintf(buf, "%-48s: %s (%s)", cheat_info[i].o_desc, (*cheat_info[i].o_var ? _("はい  ", "yes") : _("いいえ", "no ")), cheat_info[i].o_text);
-            c_prt(enum2i(a), buf, i + 2, 0);
+            c_prt(enum2i(a), format("%-48s: %s (%s)", cheat_info[i].o_desc, (*cheat_info[i].o_var ? _("はい  ", "yes") : _("いいえ", "no ")), cheat_info[i].o_text), i + 2, 0);
         }
 
         move_cursor(k + 2, 50);
@@ -396,8 +389,7 @@ static void do_cmd_options_cheat(PlayerType *player_ptr, concptr info)
             k = (k + 1) % n;
             break;
         case '?':
-            strnfmt(buf, sizeof(buf), _("joption.txt#%s", "option.txt#%s"), cheat_info[k].o_text);
-            (void)show_file(player_ptr, true, buf, nullptr, 0, 0);
+            (void)show_file(player_ptr, true, std::string(_("joption.txt#", "option.txt#")).append(cheat_info[k].o_text).data(), nullptr, 0, 0);
             term_clear();
             break;
         default:
@@ -648,7 +640,6 @@ void do_cmd_options_aux(PlayerType *player_ptr, game_option_types page, concptr 
     char ch;
     int i, k = 0, n = 0, l;
     int opt[24];
-    char buf[80];
     bool browse_only = (page == OPT_PAGE_BIRTH) && w_ptr->character_generated && (!w_ptr->wizard || !allow_debug_opts);
 
     for (i = 0; i < 24; i++) {
@@ -664,9 +655,7 @@ void do_cmd_options_aux(PlayerType *player_ptr, game_option_types page, concptr 
     term_clear();
     while (true) {
         DIRECTION dir;
-        sprintf(buf, _("%s (リターン:次, %sESC:終了, ?:ヘルプ) ", "%s (RET:next, %s, ?:help) "), info,
-            browse_only ? _("", "ESC:exit") : _("y/n:変更, ", "y/n:change, ESC:accept"));
-        prt(buf, 0, 0);
+        prt(format(_("%s (リターン:次, %sESC:終了, ?:ヘルプ) ", "%s (RET:next, %s, ?:help) "), info, browse_only ? _("", "ESC:exit") : _("y/n:変更, ", "y/n:change, ESC:accept")), 0, 0);
         if (page == OPT_PAGE_AUTODESTROY) {
             c_prt(TERM_YELLOW, _("以下のオプションは、簡易自動破壊を使用するときのみ有効", "Following options will protect items from easy auto-destroyer."), 6,
                 _(6, 3));
@@ -678,12 +667,12 @@ void do_cmd_options_aux(PlayerType *player_ptr, game_option_types page, concptr 
                 a = TERM_L_BLUE;
             }
 
-            sprintf(buf, "%-48s: %s (%.19s)", option_info[opt[i]].o_desc, (*option_info[opt[i]].o_var ? _("はい  ", "yes") : _("いいえ", "no ")),
+            std::string label = format("%-48s: %s (%.19s)", option_info[opt[i]].o_desc, (*option_info[opt[i]].o_var ? _("はい  ", "yes") : _("いいえ", "no ")),
                 option_info[opt[i]].o_text);
             if ((page == OPT_PAGE_AUTODESTROY) && i > 2) {
-                c_prt(a, buf, i + 5, 0);
+                c_prt(a, label.data(), i + 5, 0);
             } else {
-                c_prt(a, buf, i + 2, 0);
+                c_prt(a, label.data(), i + 2, 0);
             }
         }
 
@@ -744,8 +733,7 @@ void do_cmd_options_aux(PlayerType *player_ptr, game_option_types page, concptr 
             break;
         }
         case '?': {
-            strnfmt(buf, sizeof(buf), _("joption.txt#%s", "option.txt#%s"), option_info[opt[k]].o_text);
-            (void)show_file(player_ptr, true, buf, nullptr, 0, 0);
+            (void)show_file(player_ptr, true, std::string(_("joption.txt#", "option.txt#")).append(option_info[opt[k]].o_text).data(), nullptr, 0, 0);
             term_clear();
             break;
         }

--- a/src/cmd-io/cmd-lore.cpp
+++ b/src/cmd-io/cmd-lore.cpp
@@ -13,6 +13,7 @@
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
 #include "util/sort.h"
 #include "util/string-processor.h"
@@ -37,7 +38,6 @@
 void do_cmd_query_symbol(PlayerType *player_ptr)
 {
     char sym, query;
-    char buf[256];
 
     bool all = false;
     bool uniq = false;
@@ -62,32 +62,33 @@ void do_cmd_query_symbol(PlayerType *player_ptr)
         }
     }
 
+    std::string buf;
     if (sym == KTRL('A')) {
         all = true;
-        strcpy(buf, _("全モンスターのリスト", "Full monster list."));
+        buf = _("全モンスターのリスト", "Full monster list.");
     } else if (sym == KTRL('U')) {
         all = uniq = true;
-        strcpy(buf, _("ユニーク・モンスターのリスト", "Unique monster list."));
+        buf = _("ユニーク・モンスターのリスト", "Unique monster list.");
     } else if (sym == KTRL('N')) {
         all = norm = true;
-        strcpy(buf, _("ユニーク外モンスターのリスト", "Non-unique monster list."));
+        buf = _("ユニーク外モンスターのリスト", "Non-unique monster list.");
     } else if (sym == KTRL('R')) {
         all = ride = true;
-        strcpy(buf, _("乗馬可能モンスターのリスト", "Ridable monster list."));
+        buf = _("乗馬可能モンスターのリスト", "Ridable monster list.");
     } else if (sym == KTRL('M')) {
         all = true;
         if (!get_string(_("名前(英語の場合小文字で可)", "Enter name:"), temp, 70)) {
             temp[0] = 0;
             return;
         }
-        sprintf(buf, _("名前:%sにマッチ", "Monsters' names with \"%s\""), temp);
+        buf = format(_("名前:%sにマッチ", "Monsters' names with \"%s\""), temp);
     } else if (ident_info[ident_i]) {
-        sprintf(buf, "%c - %s.", sym, ident_info[ident_i] + 2);
+        buf = format("%c - %s.", sym, ident_info[ident_i] + 2);
     } else {
-        sprintf(buf, "%c - %s", sym, _("無効な文字", "Unknown Symbol"));
+        buf = format("%c - %s", sym, _("無効な文字", "Unknown Symbol"));
     }
 
-    prt(buf, 0, 0);
+    prt(buf.data(), 0, 0);
     std::vector<MonsterRaceId> who;
     for (const auto &[r_idx, r_ref] : monraces_info) {
         if (!cheat_know && !r_ref.r_sights) {
@@ -152,7 +153,7 @@ void do_cmd_query_symbol(PlayerType *player_ptr)
 
     put_str(_("思い出を見ますか? (k:殺害順/y/n): ", "Recall details? (k/y/n): "), 0, _(36, 40));
     query = inkey();
-    prt(buf, 0, 0);
+    prt(buf.data(), 0, 0);
     why = 2;
     ang_sort(player_ptr, who.data(), &why, who.size(), ang_sort_comp_hook, ang_sort_swap_hook);
     if (query == 'k') {
@@ -213,5 +214,5 @@ void do_cmd_query_symbol(PlayerType *player_ptr)
         }
     }
 
-    prt(buf, 0, 0);
+    prt(buf.data(), 0, 0);
 }

--- a/src/cmd-io/cmd-macro.cpp
+++ b/src/cmd-io/cmd-macro.cpp
@@ -11,6 +11,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/int-char-converter.h"
 #include "util/string-processor.h"
@@ -186,7 +187,7 @@ void do_cmd_macros(PlayerType *player_ptr)
         if (key == '1') {
             prt(_("コマンド: ユーザー設定ファイルのロード", "Command: Load a user pref file"), 16, 0);
             prt(_("ファイル: ", "File: "), 18, 0);
-            sprintf(tmp, "%s.prf", player_ptr->base_name);
+            strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
             if (!askfor(tmp, 80)) {
                 continue;
             }
@@ -202,7 +203,7 @@ void do_cmd_macros(PlayerType *player_ptr)
         } else if (key == '2') {
             prt(_("コマンド: マクロをファイルに追加する", "Command: Append macros to a file"), 16, 0);
             prt(_("ファイル: ", "File: "), 18, 0);
-            sprintf(tmp, "%s.prf", player_ptr->base_name);
+            strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
             if (!askfor(tmp, 80)) {
                 continue;
             }
@@ -253,7 +254,7 @@ void do_cmd_macros(PlayerType *player_ptr)
         } else if (key == '6') {
             prt(_("コマンド: キー配置をファイルに追加する", "Command: Append keymaps to a file"), 16, 0);
             prt(_("ファイル: ", "File: "), 18, 0);
-            sprintf(tmp, "%s.prf", player_ptr->base_name);
+            strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
             if (!askfor(tmp, 80)) {
                 continue;
             }

--- a/src/cmd-item/cmd-destroy.cpp
+++ b/src/cmd-item/cmd-destroy.cpp
@@ -34,6 +34,7 @@
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 
@@ -63,7 +64,7 @@ static bool check_destory_item(PlayerType *player_ptr, destroy_type *destroy_ptr
     }
 
     describe_flavor(player_ptr, destroy_ptr->o_name, destroy_ptr->o_ptr, OD_OMIT_PREFIX);
-    sprintf(destroy_ptr->out_val, _("本当に%sを壊しますか? [y/n/Auto]", "Really destroy %s? [y/n/Auto]"), destroy_ptr->o_name);
+    strnfmt(destroy_ptr->out_val, sizeof(destroy_ptr->out_val), _("本当に%sを壊しますか? [y/n/Auto]", "Really destroy %s? [y/n/Auto]"), destroy_ptr->o_name);
     msg_print(nullptr);
     message_add(destroy_ptr->out_val);
     player_ptr->window_flags |= PW_MESSAGE;

--- a/src/cmd-item/cmd-equipment.cpp
+++ b/src/cmd-item/cmd-equipment.cpp
@@ -48,6 +48,7 @@
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
 #include "view/display-inventory.h"
 #include "view/display-messages.h"
@@ -90,7 +91,6 @@ static void do_curse_on_equip(OBJECT_IDX slot, ItemEntity *o_ptr, PlayerType *pl
  */
 void do_cmd_equip(PlayerType *player_ptr)
 {
-    char out_val[160];
     command_wrk = true;
     if (easy_floor) {
         command_wrk = USE_EQUIP;
@@ -100,13 +100,14 @@ void do_cmd_equip(PlayerType *player_ptr)
     (void)show_equipment(player_ptr, 0, USE_FULL, AllMatchItemTester());
     auto weight = calc_inventory_weight(player_ptr);
     auto weight_lim = calc_weight_limit(player_ptr);
+    std::string out_val;
 #ifdef JP
-    sprintf(out_val, "装備： 合計 %3d.%1d kg (限界の%d%%) コマンド: ", lb_to_kg_integer(weight), lb_to_kg_fraction(weight), weight * 100 / weight_lim);
+    out_val = format("装備： 合計 %3d.%1d kg (限界の%d%%) コマンド: ", lb_to_kg_integer(weight), lb_to_kg_fraction(weight), weight * 100 / weight_lim);
 #else
-    sprintf(out_val, "Equipment: carrying %d.%d pounds (%d%% of capacity). Command: ", weight / 10, weight % 10, weight * 100 / weight_lim);
+    out_val = format("Equipment: carrying %d.%d pounds (%d%% of capacity). Command: ", weight / 10, weight % 10, weight * 100 / weight_lim);
 #endif
 
-    prt(out_val, 0, 0);
+    prt(out_val.data(), 0, 0);
     command_new = inkey();
     screen_load();
 
@@ -231,24 +232,16 @@ void do_cmd_wield(PlayerType *player_ptr)
     }
 
     if (confirm_wear && ((o_ptr->is_cursed() && o_ptr->is_known()) || ((o_ptr->ident & IDENT_SENSE) && (FEEL_BROKEN <= o_ptr->feeling) && (o_ptr->feeling <= FEEL_CURSED)))) {
-        char dummy[MAX_NLEN + 80];
         describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
-        sprintf(dummy, _("本当に%s{呪われている}を使いますか？", "Really use the %s {cursed}? "), o_name);
-
-        if (!get_check(dummy)) {
+        if (!get_check(format(_("本当に%s{呪われている}を使いますか？", "Really use the %s {cursed}? "), o_name))) {
             return;
         }
     }
 
     PlayerRace pr(player_ptr);
     if (o_ptr->is_specific_artifact(FixedArtifactId::STONEMASK) && o_ptr->is_known() && !pr.equals(PlayerRaceType::VAMPIRE) && !pr.equals(PlayerRaceType::ANDROID)) {
-        char dummy[MAX_NLEN + 100];
         describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
-        sprintf(dummy,
-            _("%sを装備すると吸血鬼になります。よろしいですか？", "%s will transform you into a vampire permanently when equipped. Do you become a vampire? "),
-            o_name);
-
-        if (!get_check(dummy)) {
+        if (!get_check(format(_("%sを装備すると吸血鬼になります。よろしいですか？", "%s will transform you into a vampire permanently when equipped. Do you become a vampire? "), o_name))) {
             return;
         }
     }

--- a/src/cmd-item/cmd-item.cpp
+++ b/src/cmd-item/cmd-item.cpp
@@ -63,6 +63,7 @@
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
 #include "util/quarks.h"
@@ -75,7 +76,6 @@
  */
 void do_cmd_inven(PlayerType *player_ptr)
 {
-    char out_val[160];
     command_wrk = false;
     if (easy_floor) {
         command_wrk = USE_INVEN;
@@ -85,14 +85,15 @@ void do_cmd_inven(PlayerType *player_ptr)
     (void)show_inventory(player_ptr, 0, USE_FULL, AllMatchItemTester());
     WEIGHT weight = calc_inventory_weight(player_ptr);
     WEIGHT weight_lim = calc_weight_limit(player_ptr);
+    std::string out_val;
 #ifdef JP
-    sprintf(out_val, "持ち物： 合計 %3d.%1d kg (限界の%ld%%) コマンド: ", lb_to_kg_integer(weight), lb_to_kg_fraction(weight),
+    out_val = format("持ち物： 合計 %3d.%1d kg (限界の%ld%%) コマンド: ", lb_to_kg_integer(weight), lb_to_kg_fraction(weight),
 #else
-    sprintf(out_val, "Inventory: carrying %d.%d pounds (%ld%% of capacity). Command: ", weight / 10, weight % 10,
+    out_val = format("Inventory: carrying %d.%d pounds (%ld%% of capacity). Command: ", weight / 10, weight % 10,
 #endif
         (long int)(weight * 100) / weight_lim);
 
-    prt(out_val, 0, 0);
+    prt(out_val.data(), 0, 0);
     command_new = inkey();
     screen_load();
     if (command_new != ESCAPE) {

--- a/src/cmd-item/cmd-magiceat.cpp
+++ b/src/cmd-item/cmd-magiceat.cpp
@@ -77,6 +77,7 @@
 #include "target/target-getter.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "timed-effect/player-stun.h"
 #include "timed-effect/timed-effects.h"
 #include "util/buffer-shaper.h"
@@ -257,12 +258,9 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
             OBJECT_SUBTYPE_VALUE ctr;
             PERCENTAGE chance;
             short bi_id;
-            char dummy[80];
             POSITION x1, y1;
             DEPTH level;
             byte col;
-
-            strcpy(dummy, "");
 
             for (y = 1; y < 20; y++) {
                 prt("", y, x);
@@ -290,11 +288,12 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
 
                 bi_id = lookup_baseitem_id({ tval, ctr });
 
+                std::string dummy;
                 if (use_menu) {
                     if (ctr == (menu_line - 1)) {
-                        strcpy(dummy, _("》", "> "));
+                        dummy = _("》", "> ");
                     } else {
-                        strcpy(dummy, "  ");
+                        dummy = "  ";
                     }
                 }
                 /* letter/number for power selection */
@@ -305,7 +304,7 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
                     } else {
                         letter = '0' + ctr - 26;
                     }
-                    sprintf(dummy, "%c)", letter);
+                    dummy = format("%c)", letter);
                 }
                 x1 = ((ctr < ITEM_GROUP_SIZE / 2) ? x : x + 40);
                 y1 = ((ctr < ITEM_GROUP_SIZE / 2) ? y + ctr : y + ctr - ITEM_GROUP_SIZE / 2);
@@ -330,7 +329,7 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
 
                 if (bi_id) {
                     if (tval == ItemKindType::ROD) {
-                        strcat(dummy,
+                        dummy.append(
                             format(_(" %-22.22s 充填:%2d/%2d%3d%%", " %-22.22s   (%2d/%2d) %3d%%"), baseitems_info[bi_id].name.data(),
                                 item.charge ? (item.charge - 1) / (EATER_ROD_CHARGE * baseitems_info[bi_id].pval) + 1 : 0,
                                 item.count, chance));
@@ -338,7 +337,7 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
                             col = TERM_RED;
                         }
                     } else {
-                        strcat(dummy,
+                        dummy.append(
                             format(" %-22.22s    %2d/%2d %3d%%", baseitems_info[bi_id].name.data(), (int16_t)(item.charge / EATER_CHARGE),
                                 item.count, chance));
                         if (item.charge < EATER_CHARGE) {
@@ -346,9 +345,9 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
                         }
                     }
                 } else {
-                    strcpy(dummy, "");
+                    dummy.clear();
                 }
-                c_prt(col, dummy, y1, x1);
+                c_prt(col, dummy.data(), y1, x1);
             }
         }
 

--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -15,6 +15,7 @@
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
 #include "util/string-processor.h"
 #include "view/display-messages.h"
@@ -99,7 +100,7 @@ void do_cmd_player_status(PlayerType *player_ptr)
             get_name(player_ptr);
             process_player_name(player_ptr);
         } else if (c == 'f') {
-            sprintf(tmp, "%s.txt", player_ptr->base_name);
+            strnfmt(tmp, sizeof(tmp), "%s.txt", player_ptr->base_name);
             if (get_string(_("ファイル名: ", "File name: "), tmp, 80)) {
                 if (tmp[0] && (tmp[0] != ' ')) {
                     update_playtime();

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -23,6 +23,7 @@
 #include "system/terrain-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
@@ -38,7 +39,7 @@ static bool cmd_visuals_aux(int i, IDX *num, IDX max)
 {
     if (iscntrl(i)) {
         char str[10] = "";
-        sprintf(str, "%d", *num);
+        strnfmt(str, sizeof(str), "%d", *num);
         if (!get_string(format("Input new number(0-%d): ", max - 1), str, 4)) {
             return false;
         }
@@ -104,7 +105,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
         case '0': {
             prt(_("コマンド: ユーザー設定ファイルのロード", "Command: Load a user pref file"), 15, 0);
             prt(_("ファイル: ", "File: "), 17, 0);
-            sprintf(tmp, "%s.prf", player_ptr->base_name);
+            strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
             if (!askfor(tmp, 70)) {
                 continue;
             }
@@ -117,7 +118,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
             static concptr mark = "Monster attr/chars";
             prt(_("コマンド: モンスターの[色/文字]をファイルに書き出します", "Command: Dump monster attr/chars"), 15, 0);
             prt(_("ファイル: ", "File: "), 17, 0);
-            sprintf(tmp, "%s.prf", player_ptr->base_name);
+            strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
             if (!askfor(tmp, 70)) {
                 continue;
             }
@@ -145,7 +146,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
             static concptr mark = "Object attr/chars";
             prt(_("コマンド: アイテムの[色/文字]をファイルに書き出します", "Command: Dump object attr/chars"), 15, 0);
             prt(_("ファイル: ", "File: "), 17, 0);
-            sprintf(tmp, "%s.prf", player_ptr->base_name);
+            strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
             if (!askfor(tmp, 70)) {
                 continue;
             }
@@ -187,7 +188,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
             static concptr mark = "Feature attr/chars";
             prt(_("コマンド: 地形の[色/文字]をファイルに書き出します", "Command: Dump feature attr/chars"), 15, 0);
             prt(_("ファイル: ", "File: "), 17, 0);
-            sprintf(tmp, "%s.prf", player_ptr->base_name);
+            strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
             if (!askfor(tmp, 70)) {
                 continue;
             }

--- a/src/core/asking-player.cpp
+++ b/src/core/asking-player.cpp
@@ -10,6 +10,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
 #include "util/string-processor.h"
 #include "view/display-messages.h"
@@ -385,14 +386,14 @@ QUANTITY get_quantity(concptr prompt, QUANTITY max)
     }
 
     if (!prompt) {
-        sprintf(tmp, _("いくつですか (1-%d): ", "Quantity (1-%d): "), max);
+        strnfmt(tmp, sizeof(tmp), _("いくつですか (1-%d): ", "Quantity (1-%d): "), max);
         prompt = tmp;
     }
 
     msg_print(nullptr);
     prt(prompt, 0, 0);
     amt = 1;
-    sprintf(buf, "%d", amt);
+    strnfmt(buf, sizeof(buf), "%d", amt);
 
     /*
      * Ask for a quantity

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -90,6 +90,7 @@
 #include "target/target-checker.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "view/display-messages.h"
 #include "view/display-player.h"
@@ -284,7 +285,7 @@ static void generate_world(PlayerType *player_ptr, bool new_game)
     }
 
     char buf[80];
-    sprintf(buf, _("%sに降り立った。", "arrived in %s."), map_name(player_ptr));
+    strnfmt(buf, sizeof(buf), _("%sに降り立った。", "arrived in %s."), map_name(player_ptr));
     exe_write_diary(player_ptr, DIARY_DESCRIPTION, 0, buf);
 }
 

--- a/src/core/scores.cpp
+++ b/src/core/scores.cpp
@@ -34,6 +34,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/enum-converter.h"
 #include "util/int-char-converter.h"
@@ -192,18 +193,18 @@ errr top_twenty(PlayerType *player_ptr)
     char buf[32];
 
     /* Save the version */
-    sprintf(the_score.what, "%u.%u.%u", H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH);
+    snprintf(the_score.what, sizeof(the_score.what), "%u.%u.%u", H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH);
 
     /* Calculate and save the points */
-    sprintf(the_score.pts, "%9ld", (long)calc_score(player_ptr));
+    snprintf(the_score.pts, sizeof(the_score.pts), "%9ld", (long)calc_score(player_ptr));
     the_score.pts[9] = '\0';
 
     /* Save the current gold */
-    sprintf(the_score.gold, "%9lu", (long)player_ptr->au);
+    snprintf(the_score.gold, sizeof(the_score.gold), "%9lu", (long)player_ptr->au);
     the_score.gold[9] = '\0';
 
     /* Save the current turn */
-    sprintf(the_score.turns, "%9lu", (long)turn_real(player_ptr, w_ptr->game_turn));
+    snprintf(the_score.turns, sizeof(the_score.turns), "%9lu", (long)turn_real(player_ptr, w_ptr->game_turn));
     the_score.turns[9] = '\0';
 
     time_t ct = time((time_t *)0);
@@ -212,11 +213,11 @@ errr top_twenty(PlayerType *player_ptr)
     strftime(the_score.day, 10, "@%Y%m%d", localtime(&ct));
 
     /* Save the player name (15 chars) */
-    sprintf(the_score.who, "%-.15s", player_ptr->name);
+    snprintf(the_score.who, sizeof(the_score.who), "%-.15s", player_ptr->name);
 
     /* Save the player info */
-    sprintf(the_score.uid, "%7u", player_ptr->player_uid);
-    sprintf(the_score.sex, "%c", (player_ptr->psex ? 'm' : 'f'));
+    snprintf(the_score.uid, sizeof(the_score.uid), "%7u", player_ptr->player_uid);
+    snprintf(the_score.sex, sizeof(the_score.sex), "%c", (player_ptr->psex ? 'm' : 'f'));
     snprintf(buf, sizeof(buf), "%2d", std::min(enum2i(player_ptr->prace), MAX_RACES));
     memcpy(the_score.p_r, buf, 3);
     snprintf(buf, sizeof(buf), "%2d", enum2i(std::min(player_ptr->pclass, PlayerClassType::MAX)));
@@ -225,19 +226,19 @@ errr top_twenty(PlayerType *player_ptr)
     memcpy(the_score.p_a, buf, 3);
 
     /* Save the level and such */
-    sprintf(the_score.cur_lev, "%3d", std::min<ushort>(player_ptr->lev, 999));
-    sprintf(the_score.cur_dun, "%3d", (int)player_ptr->current_floor_ptr->dun_level);
-    sprintf(the_score.max_lev, "%3d", std::min<ushort>(player_ptr->max_plv, 999));
-    sprintf(the_score.max_dun, "%3d", (int)max_dlv[player_ptr->dungeon_idx]);
+    snprintf(the_score.cur_lev, sizeof(the_score.cur_lev), "%3d", std::min<ushort>(player_ptr->lev, 999));
+    snprintf(the_score.cur_dun, sizeof(the_score.cur_dun), "%3d", (int)player_ptr->current_floor_ptr->dun_level);
+    snprintf(the_score.max_lev, sizeof(the_score.max_lev), "%3d", std::min<ushort>(player_ptr->max_plv, 999));
+    snprintf(the_score.max_dun, sizeof(the_score.max_dun), "%3d", (int)max_dlv[player_ptr->dungeon_idx]);
 
     /* Save the cause of death (31 chars) */
     if (player_ptr->died_from.size() >= sizeof(the_score.how)) {
 #ifdef JP
         angband_strcpy(the_score.how, player_ptr->died_from.data(), sizeof(the_score.how) - 2);
-        strcat(the_score.how, "…");
+        angband_strcat(the_score.how, "…", sizeof(the_score.how));
 #else
         angband_strcpy(the_score.how, player_ptr->died_from.data(), sizeof(the_score.how) - 3);
-        strcat(the_score.how, "...");
+        angband_strcat(the_score.how, "...", sizeof(the_score.how));
 #endif
     } else {
         angband_strcpy(the_score.how, player_ptr->died_from.data(), sizeof(the_score.how));
@@ -302,26 +303,26 @@ errr predict_score(PlayerType *player_ptr)
     }
 
     /* Save the version */
-    sprintf(the_score.what, "%u.%u.%u", H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH);
+    snprintf(the_score.what, sizeof(the_score.what), "%u.%u.%u", H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH);
 
     /* Calculate and save the points */
-    sprintf(the_score.pts, "%9ld", (long)calc_score(player_ptr));
+    snprintf(the_score.pts, sizeof(the_score.pts), "%9ld", (long)calc_score(player_ptr));
 
     /* Save the current gold */
-    sprintf(the_score.gold, "%9lu", (long)player_ptr->au);
+    snprintf(the_score.gold, sizeof(the_score.gold), "%9lu", (long)player_ptr->au);
 
     /* Save the current turn */
-    sprintf(the_score.turns, "%9lu", (long)turn_real(player_ptr, w_ptr->game_turn));
+    snprintf(the_score.turns, sizeof(the_score.turns), "%9lu", (long)turn_real(player_ptr, w_ptr->game_turn));
 
     /* Hack -- no time needed */
-    strcpy(the_score.day, _("今日", "TODAY"));
+    angband_strcpy(the_score.day, _("今日", "TODAY"), sizeof(the_score.day));
 
     /* Save the player name (15 chars) */
-    sprintf(the_score.who, "%-.15s", player_ptr->name);
+    snprintf(the_score.who, sizeof(the_score.who), "%-.15s", player_ptr->name);
 
     /* Save the player info */
-    sprintf(the_score.uid, "%7u", player_ptr->player_uid);
-    sprintf(the_score.sex, "%c", (player_ptr->psex ? 'm' : 'f'));
+    snprintf(the_score.uid, sizeof(the_score.uid), "%7u", player_ptr->player_uid);
+    snprintf(the_score.sex, sizeof(the_score.sex), "%c", (player_ptr->psex ? 'm' : 'f'));
     snprintf(buf, sizeof(buf), "%2d", std::min(enum2i(player_ptr->prace), MAX_RACES));
     memcpy(the_score.p_r, buf, 3);
     snprintf(buf, sizeof(buf), "%2d", enum2i(std::min(player_ptr->pclass, PlayerClassType::MAX)));
@@ -330,10 +331,10 @@ errr predict_score(PlayerType *player_ptr)
     memcpy(the_score.p_a, buf, 3);
 
     /* Save the level and such */
-    sprintf(the_score.cur_lev, "%3d", std::min<ushort>(player_ptr->lev, 999));
-    sprintf(the_score.cur_dun, "%3d", (int)player_ptr->current_floor_ptr->dun_level);
-    sprintf(the_score.max_lev, "%3d", std::min<ushort>(player_ptr->max_plv, 999));
-    sprintf(the_score.max_dun, "%3d", (int)max_dlv[player_ptr->dungeon_idx]);
+    snprintf(the_score.cur_lev, sizeof(the_score.cur_lev), "%3d", std::min<ushort>(player_ptr->lev, 999));
+    snprintf(the_score.cur_dun, sizeof(the_score.cur_dun), "%3d", (int)player_ptr->current_floor_ptr->dun_level);
+    snprintf(the_score.max_lev, sizeof(the_score.max_lev), "%3d", std::min<ushort>(player_ptr->max_plv, 999));
+    snprintf(the_score.max_dun, sizeof(the_score.max_dun), "%3d", (int)max_dlv[player_ptr->dungeon_idx]);
 
     /* まだ死んでいないときの識別文字 */
     strcpy(the_score.how, _("yet", "nobody (yet!)"));
@@ -396,9 +397,9 @@ void show_highclass(PlayerType *player_ptr)
         clev = (PLAYER_LEVEL)atoi(the_score.cur_lev);
 
 #ifdef JP
-        sprintf(out_val, "   %3d) %sの%s (レベル %2d)", (m + 1), race_info[pr].title, the_score.who, clev);
+        strnfmt(out_val, sizeof(out_val), "   %3d) %sの%s (レベル %2d)", (m + 1), race_info[pr].title, the_score.who, clev);
 #else
-        sprintf(out_val, "%3d) %s the %s (Level %2d)", (m + 1), the_score.who, race_info[pr].title, clev);
+        strnfmt(out_val, sizeof(out_val), "%3d) %s the %s (Level %2d)", (m + 1), the_score.who, race_info[pr].title, clev);
 #endif
 
         prt(out_val, (m + 7), 0);
@@ -407,9 +408,9 @@ void show_highclass(PlayerType *player_ptr)
     }
 
 #ifdef JP
-    sprintf(out_val, "あなた) %sの%s (レベル %2d)", race_info[enum2i(player_ptr->prace)].title, player_ptr->name, player_ptr->lev);
+    strnfmt(out_val, sizeof(out_val), "あなた) %sの%s (レベル %2d)", race_info[enum2i(player_ptr->prace)].title, player_ptr->name, player_ptr->lev);
 #else
-    sprintf(out_val, "You) %s the %s (Level %2d)", player_ptr->name, race_info[enum2i(player_ptr->prace)].title, player_ptr->lev);
+    strnfmt(out_val, sizeof(out_val), "You) %s the %s (Level %2d)", player_ptr->name, race_info[enum2i(player_ptr->prace)].title, player_ptr->lev);
 #endif
 
     prt(out_val, (m + 8), 0);
@@ -436,14 +437,12 @@ void race_score(PlayerType *player_ptr, int race_num)
     int i = 0, j, m = 0;
     int pr, clev, lastlev;
     high_score the_score;
-    char buf[1024], out_val[256], tmp_str[80];
+    char buf[1024], out_val[256];
 
     lastlev = 0;
 
     /* rr9: TODO - pluralize the race */
-    sprintf(tmp_str, _("最高の%s", "The Greatest of all the %s"), race_info[race_num].title);
-
-    prt(tmp_str, 5, 15);
+    prt(std::string(_("最高の", "The Greatest of all the ")).append(race_info[race_num].title).data(), 5, 15);
     path_build(buf, sizeof(buf), ANGBAND_DIR_APEX, "scores.raw");
 
     highscore_fd = fd_open(buf, O_RDONLY);
@@ -479,9 +478,9 @@ void race_score(PlayerType *player_ptr, int race_num)
 
         if (pr == race_num) {
 #ifdef JP
-            sprintf(out_val, "   %3d) %sの%s (レベル %2d)", (m + 1), race_info[pr].title, the_score.who, clev);
+            strnfmt(out_val, sizeof(out_val), "   %3d) %sの%s (レベル %2d)", (m + 1), race_info[pr].title, the_score.who, clev);
 #else
-            sprintf(out_val, "%3d) %s the %s (Level %3d)", (m + 1), the_score.who, race_info[pr].title, clev);
+            strnfmt(out_val, sizeof(out_val), "%3d) %s the %s (Level %3d)", (m + 1), the_score.who, race_info[pr].title, clev);
 #endif
 
             prt(out_val, (m + 7), 0);
@@ -494,9 +493,9 @@ void race_score(PlayerType *player_ptr, int race_num)
     /* add player if qualified */
     if ((enum2i(player_ptr->prace) == race_num) && (player_ptr->lev >= lastlev)) {
 #ifdef JP
-        sprintf(out_val, "あなた) %sの%s (レベル %2d)", race_info[enum2i(player_ptr->prace)].title, player_ptr->name, player_ptr->lev);
+        strnfmt(out_val, sizeof(out_val), "あなた) %sの%s (レベル %2d)", race_info[enum2i(player_ptr->prace)].title, player_ptr->name, player_ptr->lev);
 #else
-        sprintf(out_val, "You) %s the %s (Level %3d)", player_ptr->name, race_info[enum2i(player_ptr->prace)].title, player_ptr->lev);
+        strnfmt(out_val, sizeof(out_val), "You) %s the %s (Level %3d)", player_ptr->name, race_info[enum2i(player_ptr->prace)].title, player_ptr->lev);
 #endif
 
         prt(out_val, (m + 8), 0);

--- a/src/core/show-file.cpp
+++ b/src/core/show-file.cpp
@@ -8,6 +8,7 @@
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/int-char-converter.h"
 #include "util/string-processor.h"
@@ -135,50 +136,45 @@ bool show_file(PlayerType *player_ptr, bool show_version, concptr name, concptr 
     int wid, hgt;
     term_get_size(&wid, &hgt);
 
-    char finder_str[81];
-    strcpy(finder_str, "");
+    char finder_str[81] = "";
 
-    char shower_str[81];
-    strcpy(shower_str, "");
+    char shower_str[81] = "";
 
-    char caption[1024 + 256];
-    strcpy(caption, "");
+    std::string caption;
 
     char hook[68][32];
     for (int i = 0; i < 68; i++) {
         hook[i][0] = '\0';
     }
 
-    char filename[1024];
-    strcpy(filename, name);
-    int n = strlen(filename);
-
-    concptr tag = nullptr;
-    for (int i = 0; i < n; i++) {
-        if (filename[i] == '#') {
-            filename[i] = '\0';
-            tag = filename + i + 1;
-            break;
-        }
+    std::string stripped_name;
+    concptr tag = angband_strstr(name, "#");
+    if (tag) {
+        stripped_name.append(name, tag - name);
+        name = stripped_name.data();
+        ++tag;
     }
 
-    name = filename;
     FILE *fff = nullptr;
     char path[1024];
     if (what) {
-        strcpy(caption, what);
-        strcpy(path, name);
+        caption = what;
+        angband_strcpy(path, name, sizeof(path));
         fff = angband_fopen(path, "r");
     }
 
     if (!fff) {
-        sprintf(caption, _("ヘルプ・ファイル'%s'", "Help file '%s'"), name);
+        caption = _("ヘルプ・ファイル'", "Help file '");
+        caption.append(name);
+        caption.append("'");
         path_build(path, sizeof(path), ANGBAND_DIR_HELP, name);
         fff = angband_fopen(path, "r");
     }
 
     if (!fff) {
-        sprintf(caption, _("スポイラー・ファイル'%s'", "Info file '%s'"), name);
+        caption = _("スポイラー・ファイル'", "Info file '");
+        caption.append(name);
+        caption.append("'");
         path_build(path, sizeof(path), ANGBAND_DIR_INFO, name);
         fff = angband_fopen(path, "r");
     }
@@ -192,7 +188,9 @@ bool show_file(PlayerType *player_ptr, bool show_version, concptr name, concptr 
             }
         }
 
-        sprintf(caption, _("スポイラー・ファイル'%s'", "Info file '%s'"), name);
+        caption = _("スポイラー・ファイル'", "Info file '");
+        caption.append(name);
+        caption.append("'");
         fff = angband_fopen(path, "r");
     }
 
@@ -321,7 +319,7 @@ bool show_file(PlayerType *player_ptr, bool show_version, concptr name, concptr 
             continue;
         }
 
-        prt(format(_("[変愚蛮怒 %d.%d.%d, %s, %d/%d]", "[Hengband %d.%d.%d, %s, Line %d/%d]"), H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH, caption,
+        prt(format(_("[変愚蛮怒 %d.%d.%d, %s, %d/%d]", "[Hengband %d.%d.%d, %s, Line %d/%d]"), H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH, caption.data(),
                 line, size),
             0, 0);
 
@@ -330,7 +328,7 @@ bool show_file(PlayerType *player_ptr, bool show_version, concptr name, concptr 
             put_version(title);
             prt(format("[%s]", title), 0, 0);
         } else {
-            prt(format(_("[%s, %d/%d]", "[%s, Line %d/%d]"), caption, line, size), 0, 0);
+            prt(format(_("[%s, %d/%d]", "[%s, Line %d/%d]"), caption.data(), line, size), 0, 0);
         }
 
         if (size <= rows) {
@@ -487,9 +485,7 @@ bool show_file(PlayerType *player_ptr, bool show_version, concptr name, concptr 
         if (skey == '|') {
             FILE *ffp;
             char buff[1024];
-            char xtmp[sizeof(caption) + 128];
-
-            strcpy(xtmp, "");
+            char xtmp[81] = "";
 
             if (!get_string(_("ファイル名: ", "File name: "), xtmp, 80)) {
                 continue;
@@ -508,8 +504,7 @@ bool show_file(PlayerType *player_ptr, bool show_version, concptr name, concptr 
                 break;
             }
 
-            sprintf(xtmp, "%s: %s", player_ptr->name, what ? what : caption);
-            angband_fputs(ffp, xtmp, 80);
+            angband_fputs(ffp, format("%s: %s", player_ptr->name, what ? what : caption.data()), 80);
             angband_fputs(ffp, "\n", 80);
 
             while (!angband_fgets(fff, buff, sizeof(buff))) {

--- a/src/core/visuals-reseter.cpp
+++ b/src/core/visuals-reseter.cpp
@@ -31,9 +31,6 @@ void reset_visuals(PlayerType *player_ptr)
     }
 
     concptr pref_file = use_graphics ? "graf.prf" : "font.prf";
-    concptr base_name = use_graphics ? "graf-%s.prf" : "font-%s.prf";
-    char buf[1024];
     process_pref_file(player_ptr, pref_file);
-    sprintf(buf, base_name, player_ptr->base_name);
-    process_pref_file(player_ptr, buf);
+    process_pref_file(player_ptr, std::string(use_graphics ? "graf-" : "font-").append(player_ptr->base_name).append(".prf").data());
 }

--- a/src/floor/object-scanner.cpp
+++ b/src/floor/object-scanner.cpp
@@ -13,6 +13,8 @@
 #include "system/player-type-definition.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
+#include "util/string-processor.h"
 
 /*!
  * @brief 床に落ちているオブジェクトの数を返す / scan floor items
@@ -154,20 +156,20 @@ COMMAND_CODE show_floor_items(PlayerType *player_ptr, int target_item, POSITION 
         prt("", j + 1, col ? col - 2 : col);
         if (use_menu && target_item) {
             if (j == (target_item - 1)) {
-                strcpy(tmp_val, _("》", "> "));
+                angband_strcpy(tmp_val, _("》", "> "), sizeof(tmp_val));
                 target_item_label = m;
             } else {
-                strcpy(tmp_val, "   ");
+                angband_strcpy(tmp_val, "   ", sizeof(tmp_val));
             }
         } else {
-            sprintf(tmp_val, "%c)", floor_label[j]);
+            strnfmt(tmp_val, sizeof(tmp_val), "%c)", floor_label[j]);
         }
 
         put_str(tmp_val, j + 1, col);
         c_put_str(out_color[j], out_desc[j], j + 1, col + 3);
         if (show_weights && (o_ptr->bi_key.tval() != ItemKindType::GOLD)) {
             int wgt = o_ptr->weight * o_ptr->number;
-            sprintf(tmp_val, _("%3d.%1d kg", "%3d.%1d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
+            strnfmt(tmp_val, sizeof(tmp_val), _("%3d.%1d kg", "%3d.%1d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
             prt(tmp_val, j + 1, wid - 9);
         }
     }

--- a/src/floor/pattern-walk.cpp
+++ b/src/floor/pattern-walk.cpp
@@ -24,6 +24,7 @@
 #include "system/grid-type-definition.h"
 #include "system/player-type-definition.h"
 #include "system/terrain-type-definition.h"
+#include "term/z-form.h"
 #include "timed-effect/player-confusion.h"
 #include "timed-effect/player-cut.h"
 #include "timed-effect/player-hallucination.h"
@@ -62,8 +63,8 @@ void pattern_teleport(PlayerType *player_ptr)
             min_level = dungeons_info[player_ptr->dungeon_idx].mindepth;
         }
 
-        sprintf(ppp, _("テレポート先:(%d-%d)", "Teleport to level (%d-%d): "), (int)min_level, (int)max_level);
-        sprintf(tmp_val, "%d", (int)player_ptr->current_floor_ptr->dun_level);
+        strnfmt(ppp, sizeof(ppp), _("テレポート先:(%d-%d)", "Teleport to level (%d-%d): "), (int)min_level, (int)max_level);
+        strnfmt(tmp_val, sizeof(tmp_val), "%d", (int)player_ptr->current_floor_ptr->dun_level);
         if (!get_string(ppp, tmp_val, 10)) {
             return;
         }

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -152,16 +152,14 @@ void process_player_hp_mp(PlayerType *player_ptr)
 
         if ((player_ptr->inventory_list[INVEN_LITE].bi_key.tval() != ItemKindType::NONE) && flgs.has_not(TR_DARK_SOURCE) && !has_resist_lite(player_ptr)) {
             GAME_TEXT o_name[MAX_NLEN];
-            char ouch[MAX_NLEN + 40];
             describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
             msg_format(_("%sがあなたのアンデッドの肉体を焼き焦がした！", "The %s scorches your undead flesh!"), o_name);
 
             cave_no_regen = true;
-            describe_flavor(player_ptr, o_name, o_ptr, OD_NAME_ONLY);
-            sprintf(ouch, _("%sを装備したダメージ", "wielding %s"), o_name);
 
             if (!is_invuln(player_ptr)) {
-                take_hit(player_ptr, DAMAGE_NOESCAPE, 1, ouch);
+                describe_flavor(player_ptr, o_name, o_ptr, OD_NAME_ONLY);
+                take_hit(player_ptr, DAMAGE_NOESCAPE, 1, std::string(_(o_name, "wielding ")).append(_("%sを装備したダメージ", o_name)).data());
             }
         }
     }

--- a/src/info-reader/fixed-map-parser.cpp
+++ b/src/info-reader/fixed-map-parser.cpp
@@ -26,7 +26,6 @@
 #include <sstream>
 #include <stdexcept>
 
-static char tmp[8];
 static concptr variant = "ZANGBAND";
 
 /*!
@@ -39,6 +38,7 @@ static concptr variant = "ZANGBAND";
  */
 static concptr parse_fixed_map_expression(PlayerType *player_ptr, char **sp, char *fp)
 {
+    static std::string tmp;
     char b1 = '[';
     char b2 = ']';
 
@@ -199,39 +199,38 @@ static concptr parse_fixed_map_expression(PlayerType *player_ptr, char **sp, cha
         *tpn = '\0';
         v = tmp_player_name;
     } else if (streq(b + 1, "TOWN")) {
-        sprintf(tmp, "%d", player_ptr->town_num);
-        v = tmp;
+        tmp = std::to_string(player_ptr->town_num);
+        v = tmp.data();
     } else if (streq(b + 1, "LEVEL")) {
-        sprintf(tmp, "%d", player_ptr->lev);
-        v = tmp;
+        tmp = std::to_string(player_ptr->lev);
+        v = tmp.data();
     } else if (streq(b + 1, "QUEST_NUMBER")) {
-        sprintf(tmp, "%d", enum2i(player_ptr->current_floor_ptr->quest_number));
-        v = tmp;
+        tmp = std::to_string(enum2i(player_ptr->current_floor_ptr->quest_number));
+        v = tmp.data();
     } else if (streq(b + 1, "LEAVING_QUEST")) {
-        sprintf(tmp, "%d", enum2i(leaving_quest));
-        v = tmp;
+        tmp = std::to_string(enum2i(leaving_quest));
+        v = tmp.data();
     } else if (prefix(b + 1, "QUEST_TYPE")) {
         const auto &quest_list = QuestList::get_instance();
-        sprintf(tmp, "%d", enum2i(quest_list[i2enum<QuestId>(atoi(b + 11))].type));
-        v = tmp;
+        tmp = std::to_string(enum2i(quest_list[i2enum<QuestId>(atoi(b + 11))].type));
+        v = tmp.data();
     } else if (prefix(b + 1, "QUEST")) {
         const auto &quest_list = QuestList::get_instance();
-        sprintf(tmp, "%d", enum2i(quest_list[i2enum<QuestId>(atoi(b + 6))].status));
-        v = tmp;
+        tmp = std::to_string(enum2i(quest_list[i2enum<QuestId>(atoi(b + 6))].status));
+        v = tmp.data();
     } else if (prefix(b + 1, "RANDOM")) {
-        sprintf(tmp, "%d", (int)(w_ptr->seed_town % atoi(b + 7)));
-        v = tmp;
+        tmp = std::to_string((int)(w_ptr->seed_town % atoi(b + 7)));
+        v = tmp.data();
     } else if (streq(b + 1, "VARIANT")) {
         v = variant;
     } else if (streq(b + 1, "WILDERNESS")) {
         if (vanilla_town) {
-            sprintf(tmp, "NONE");
+            v = "NONE";
         } else if (lite_town) {
-            sprintf(tmp, "LITE");
+            v = "LITE";
         } else {
-            sprintf(tmp, "NORMAL");
+            v = "NORMAL";
         }
-        v = tmp;
     } else if (streq(b + 1, "IRONMAN_DOWNWARD")) {
         v = (ironman_downward ? "1" : "0");
     }

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -29,7 +29,9 @@
 #include "system/player-type-definition.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
+#include "util/string-processor.h"
 #include "view/display-inventory.h"
 #include "view/display-messages.h"
 #include "window/display-sub-windows.h"
@@ -349,104 +351,104 @@ bool get_item_floor(PlayerType *player_ptr, COMMAND_CODE *cp, concptr pmt, concp
         }
 
         if (command_wrk == USE_INVEN) {
-            sprintf(fis_ptr->out_val, _("持ち物:", "Inven:"));
+            angband_strcpy(fis_ptr->out_val, _("持ち物:", "Inven:"), sizeof(fis_ptr->out_val));
             if (!use_menu) {
                 char tmp_val[80];
-                sprintf(tmp_val, _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(fis_ptr->i1), index_to_label(fis_ptr->i2));
-                strcat(fis_ptr->out_val, tmp_val);
+                strnfmt(tmp_val, sizeof(tmp_val), _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(fis_ptr->i1), index_to_label(fis_ptr->i2));
+                angband_strcat(fis_ptr->out_val, tmp_val, sizeof(fis_ptr->out_val));
             }
 
             if (!command_see && !use_menu) {
-                strcat(fis_ptr->out_val, _(" '*'一覧,", " * to see,"));
+                angband_strcat(fis_ptr->out_val, _(" '*'一覧,", " * to see,"), sizeof(fis_ptr->out_val));
             }
 
             if (fis_ptr->allow_equip) {
                 if (!use_menu) {
-                    strcat(fis_ptr->out_val, _(" '/' 装備品,", " / for Equip,"));
+                    angband_strcat(fis_ptr->out_val, _(" '/' 装備品,", " / for Equip,"), sizeof(fis_ptr->out_val));
                 } else if (fis_ptr->allow_floor) {
-                    strcat(fis_ptr->out_val, _(" '6' 装備品,", " 6 for Equip,"));
+                    angband_strcat(fis_ptr->out_val, _(" '6' 装備品,", " 6 for Equip,"), sizeof(fis_ptr->out_val));
                 } else {
-                    strcat(fis_ptr->out_val, _(" '4'or'6' 装備品,", " 4 or 6 for Equip,"));
+                    angband_strcat(fis_ptr->out_val, _(" '4'or'6' 装備品,", " 4 or 6 for Equip,"), sizeof(fis_ptr->out_val));
                 }
             }
 
             if (fis_ptr->allow_floor) {
                 if (!use_menu) {
-                    strcat(fis_ptr->out_val, _(" '-'床上,", " - for floor,"));
+                    angband_strcat(fis_ptr->out_val, _(" '-'床上,", " - for floor,"), sizeof(fis_ptr->out_val));
                 } else if (fis_ptr->allow_equip) {
-                    strcat(fis_ptr->out_val, _(" '4' 床上,", " 4 for floor,"));
+                    angband_strcat(fis_ptr->out_val, _(" '4' 床上,", " 4 for floor,"), sizeof(fis_ptr->out_val));
                 } else {
-                    strcat(fis_ptr->out_val, _(" '4'or'6' 床上,", " 4 or 6 for floor,"));
+                    angband_strcat(fis_ptr->out_val, _(" '4'or'6' 床上,", " 4 or 6 for floor,"), sizeof(fis_ptr->out_val));
                 }
             }
         } else if (command_wrk == (USE_EQUIP)) {
-            sprintf(fis_ptr->out_val, _("装備品:", "Equip:"));
+            angband_strcpy(fis_ptr->out_val, _("装備品:", "Equip:"), sizeof(fis_ptr->out_val));
             if (!use_menu) {
                 char tmp_val[80];
-                sprintf(tmp_val, _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(fis_ptr->e1), index_to_label(fis_ptr->e2));
-                strcat(fis_ptr->out_val, tmp_val);
+                strnfmt(tmp_val, sizeof(tmp_val), _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(fis_ptr->e1), index_to_label(fis_ptr->e2));
+                angband_strcat(fis_ptr->out_val, tmp_val, sizeof(fis_ptr->out_val));
             }
 
             if (!command_see && !use_menu) {
-                strcat(fis_ptr->out_val, _(" '*'一覧,", " * to see,"));
+                angband_strcat(fis_ptr->out_val, _(" '*'一覧,", " * to see,"), sizeof(fis_ptr->out_val));
             }
 
             if (fis_ptr->allow_inven) {
                 if (!use_menu) {
-                    strcat(fis_ptr->out_val, _(" '/' 持ち物,", " / for Inven,"));
+                    angband_strcat(fis_ptr->out_val, _(" '/' 持ち物,", " / for Inven,"), sizeof(fis_ptr->out_val));
                 } else if (fis_ptr->allow_floor) {
-                    strcat(fis_ptr->out_val, _(" '4' 持ち物,", " 4 for Inven,"));
+                    angband_strcat(fis_ptr->out_val, _(" '4' 持ち物,", " 4 for Inven,"), sizeof(fis_ptr->out_val));
                 } else {
-                    strcat(fis_ptr->out_val, _(" '4'or'6' 持ち物,", " 4 or 6 for Inven,"));
+                    angband_strcat(fis_ptr->out_val, _(" '4'or'6' 持ち物,", " 4 or 6 for Inven,"), sizeof(fis_ptr->out_val));
                 }
             }
 
             if (fis_ptr->allow_floor) {
                 if (!use_menu) {
-                    strcat(fis_ptr->out_val, _(" '-'床上,", " - for floor,"));
+                    angband_strcat(fis_ptr->out_val, _(" '-'床上,", " - for floor,"), sizeof(fis_ptr->out_val));
                 } else if (fis_ptr->allow_inven) {
-                    strcat(fis_ptr->out_val, _(" '6' 床上,", " 6 for floor,"));
+                    angband_strcat(fis_ptr->out_val, _(" '6' 床上,", " 6 for floor,"), sizeof(fis_ptr->out_val));
                 } else {
-                    strcat(fis_ptr->out_val, _(" '4'or'6' 床上,", " 4 or 6 for floor,"));
+                    angband_strcat(fis_ptr->out_val, _(" '4'or'6' 床上,", " 4 or 6 for floor,"), sizeof(fis_ptr->out_val));
                 }
             }
         } else if (command_wrk == USE_FLOOR) {
-            sprintf(fis_ptr->out_val, _("床上:", "Floor:"));
+            angband_strcpy(fis_ptr->out_val, _("床上:", "Floor:"), sizeof(fis_ptr->out_val));
             if (!use_menu) {
                 char tmp_val[80];
-                sprintf(tmp_val, _("%c-%c,'(',')',", " %c-%c,'(',')',"), fis_ptr->n1, fis_ptr->n2);
-                strcat(fis_ptr->out_val, tmp_val);
+                strnfmt(tmp_val, sizeof(tmp_val), _("%c-%c,'(',')',", " %c-%c,'(',')',"), fis_ptr->n1, fis_ptr->n2);
+                angband_strcat(fis_ptr->out_val, tmp_val, sizeof(fis_ptr->out_val));
             }
 
             if (!command_see && !use_menu) {
-                strcat(fis_ptr->out_val, _(" '*'一覧,", " * to see,"));
+                angband_strcat(fis_ptr->out_val, _(" '*'一覧,", " * to see,"), sizeof(fis_ptr->out_val));
             }
 
             if (use_menu) {
                 if (fis_ptr->allow_inven && fis_ptr->allow_equip) {
-                    strcat(fis_ptr->out_val, _(" '4' 装備品, '6' 持ち物,", " 4 for Equip, 6 for Inven,"));
+                    angband_strcat(fis_ptr->out_val, _(" '4' 装備品, '6' 持ち物,", " 4 for Equip, 6 for Inven,"), sizeof(fis_ptr->out_val));
                 } else if (fis_ptr->allow_inven) {
-                    strcat(fis_ptr->out_val, _(" '4'or'6' 持ち物,", " 4 or 6 for Inven,"));
+                    angband_strcat(fis_ptr->out_val, _(" '4'or'6' 持ち物,", " 4 or 6 for Inven,"), sizeof(fis_ptr->out_val));
                 } else if (fis_ptr->allow_equip) {
-                    strcat(fis_ptr->out_val, _(" '4'or'6' 装備品,", " 4 or 6 for Equip,"));
+                    angband_strcat(fis_ptr->out_val, _(" '4'or'6' 装備品,", " 4 or 6 for Equip,"), sizeof(fis_ptr->out_val));
                 }
             } else if (fis_ptr->allow_inven) {
-                strcat(fis_ptr->out_val, _(" '/' 持ち物,", " / for Inven,"));
+                angband_strcat(fis_ptr->out_val, _(" '/' 持ち物,", " / for Inven,"), sizeof(fis_ptr->out_val));
             } else if (fis_ptr->allow_equip) {
-                strcat(fis_ptr->out_val, _(" '/'装備品,", " / for Equip,"));
+                angband_strcat(fis_ptr->out_val, _(" '/'装備品,", " / for Equip,"), sizeof(fis_ptr->out_val));
             }
 
             if (command_see && !use_menu) {
-                strcat(fis_ptr->out_val, _(" Enter 次,", " Enter for scroll down,"));
+                angband_strcat(fis_ptr->out_val, _(" Enter 次,", " Enter for scroll down,"), sizeof(fis_ptr->out_val));
             }
         }
 
         if (fis_ptr->force) {
-            strcat(fis_ptr->out_val, _(" 'w'練気術,", " w for the Force,"));
+            angband_strcat(fis_ptr->out_val, _(" 'w'練気術,", " w for the Force,"), sizeof(fis_ptr->out_val));
         }
 
-        strcat(fis_ptr->out_val, " ESC");
-        sprintf(fis_ptr->tmp_val, "(%s) %s", fis_ptr->out_val, pmt);
+        angband_strcat(fis_ptr->out_val, " ESC", sizeof(fis_ptr->out_val));
+        strnfmt(fis_ptr->tmp_val, sizeof(fis_ptr->tmp_val), "(%s) %s", fis_ptr->out_val, pmt);
         prt(fis_ptr->tmp_val, 0, 0);
         fis_ptr->which = inkey();
         if (use_menu) {

--- a/src/inventory/inventory-util.cpp
+++ b/src/inventory/inventory-util.cpp
@@ -285,7 +285,6 @@ INVENTORY_IDX label_to_inventory(PlayerType *player_ptr, int c)
 bool verify(PlayerType *player_ptr, concptr prompt, INVENTORY_IDX item)
 {
     GAME_TEXT o_name[MAX_NLEN];
-    char out_val[MAX_NLEN + 20];
     ItemEntity *o_ptr;
     if (item >= 0) {
         o_ptr = &player_ptr->inventory_list[item];
@@ -294,8 +293,13 @@ bool verify(PlayerType *player_ptr, concptr prompt, INVENTORY_IDX item)
     }
 
     describe_flavor(player_ptr, o_name, o_ptr, 0);
-    (void)sprintf(out_val, _("%s%sですか? ", "%s %s? "), prompt, o_name);
-    return get_check(out_val);
+    std::string out_val = prompt;
+#ifndef JP
+    out_val.append(" ");
+#endif
+    out_val.append(o_name);
+    out_val.append(_("ですか? ", "? "));
+    return get_check(out_val.data());
 }
 
 /*!

--- a/src/inventory/item-getter.cpp
+++ b/src/inventory/item-getter.cpp
@@ -23,7 +23,9 @@
 #include "system/player-type-definition.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
+#include "util/string-processor.h"
 #include "view/display-inventory.h"
 #include "view/display-messages.h"
 #include "window/display-sub-windows.h"
@@ -329,49 +331,51 @@ bool get_item(PlayerType *player_ptr, OBJECT_IDX *cp, concptr pmt, concptr str, 
         }
 
         if (!command_wrk) {
-            sprintf(item_selection_ptr->out_val, _("持ち物:", "Inven:"));
+            angband_strcpy(item_selection_ptr->out_val, _("持ち物:", "Inven:"), sizeof(item_selection_ptr->out_val));
             if ((item_selection_ptr->i1 <= item_selection_ptr->i2) && !use_menu) {
                 char tmp_val[80];
-                sprintf(tmp_val, _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(item_selection_ptr->i1),
-                    index_to_label(item_selection_ptr->i2));
-                strcat(item_selection_ptr->out_val, tmp_val);
+                strnfmt(tmp_val, sizeof(tmp_val), _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(item_selection_ptr->i1), index_to_label(item_selection_ptr->i2));
+                angband_strcat(item_selection_ptr->out_val, tmp_val, sizeof(item_selection_ptr->out_val));
             }
 
             if (!command_see && !use_menu) {
-                strcat(item_selection_ptr->out_val, _(" '*'一覧,", " * to see,"));
+                angband_strcat(item_selection_ptr->out_val, _(" '*'一覧,", " * to see,"), sizeof(item_selection_ptr->out_val));
             }
 
             if (item_selection_ptr->equip) {
-                strcat(item_selection_ptr->out_val, format(_(" %s 装備品,", " %s for Equip,"), use_menu ? _("'4'or'6'", "4 or 6") : _("'/'", "/")));
+                char tmp_val[80];
+                strnfmt(tmp_val, sizeof(tmp_val), _(" %s 装備品,", " %s for Equip,"), use_menu ? _("'4'or'6'", "4 or 6") : _("'/'", "/"));
+                angband_strcat(item_selection_ptr->out_val, tmp_val, sizeof(item_selection_ptr->out_val));
             }
         } else {
-            sprintf(item_selection_ptr->out_val, _("装備品:", "Equip:"));
+            angband_strcpy(item_selection_ptr->out_val, _("装備品:", "Equip:"), sizeof(item_selection_ptr->out_val));
             if ((item_selection_ptr->e1 <= item_selection_ptr->e2) && !use_menu) {
                 char tmp_val[80];
-                sprintf(tmp_val, _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(item_selection_ptr->e1),
-                    index_to_label(item_selection_ptr->e2));
-                strcat(item_selection_ptr->out_val, tmp_val);
+                strnfmt(tmp_val, sizeof(tmp_val), _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(item_selection_ptr->e1), index_to_label(item_selection_ptr->e2));
+                angband_strcat(item_selection_ptr->out_val, tmp_val, sizeof(item_selection_ptr->out_val));
             }
 
             if (!command_see && !use_menu) {
-                strcat(item_selection_ptr->out_val, _(" '*'一覧,", " * to see,"));
+                angband_strcat(item_selection_ptr->out_val, _(" '*'一覧,", " * to see,"), sizeof(item_selection_ptr->out_val));
             }
 
             if (item_selection_ptr->inven) {
-                strcat(item_selection_ptr->out_val, format(_(" %s 持ち物,", " %s for Inven,"), use_menu ? _("'4'or'6'", "4 or 6") : _("'/'", "'/'")));
+                char tmp_val[80];
+                strnfmt(tmp_val, sizeof(tmp_val), _(" %s 持ち物,", " %s for Inven,"), use_menu ? _("'4'or'6'", "4 or 6") : _("'/'", "'/'"));
+                angband_strcat(item_selection_ptr->out_val, tmp_val, sizeof(item_selection_ptr->out_val));
             }
         }
 
         if (item_selection_ptr->allow_floor) {
-            strcat(item_selection_ptr->out_val, _(" '-'床上,", " - for floor,"));
+            angband_strcat(item_selection_ptr->out_val, _(" '-'床上,", " - for floor,"), sizeof(item_selection_ptr->out_val));
         }
 
         if (item_selection_ptr->mode & USE_FORCE) {
-            strcat(item_selection_ptr->out_val, _(" 'w'練気術,", " w for the Force,"));
+            angband_strcat(item_selection_ptr->out_val, _(" 'w'練気術,", " w for the Force,"), sizeof(item_selection_ptr->out_val));
         }
 
-        strcat(item_selection_ptr->out_val, " ESC");
-        sprintf(item_selection_ptr->tmp_val, "(%s) %s", item_selection_ptr->out_val, pmt);
+        angband_strcat(item_selection_ptr->out_val, " ESC", sizeof(item_selection_ptr->out_val));
+        strnfmt(item_selection_ptr->tmp_val, sizeof(item_selection_ptr->tmp_val), "(%s) %s", item_selection_ptr->out_val, pmt);
         prt(item_selection_ptr->tmp_val, 0, 0);
         item_selection_ptr->which = inkey();
         if (use_menu) {

--- a/src/inventory/player-inventory.cpp
+++ b/src/inventory/player-inventory.cpp
@@ -31,6 +31,7 @@
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "target/target-checker.h"
+#include "term/z-form.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 #ifdef JP
@@ -159,7 +160,7 @@ void py_pickup_floor(PlayerType *player_ptr, bool pickup)
         char out_val[MAX_NLEN + 20];
         o_ptr = &player_ptr->current_floor_ptr->o_list[floor_o_idx];
         describe_flavor(player_ptr, o_name, o_ptr, 0);
-        (void)sprintf(out_val, _("%sを拾いますか? ", "Pick up %s? "), o_name);
+        strnfmt(out_val, sizeof(out_val), _("%sを拾いますか? ", "Pick up %s? "), o_name);
         if (!get_check(out_val)) {
             return;
         }
@@ -294,7 +295,7 @@ void carry(PlayerType *player_ptr, bool pickup)
         int is_pickup_successful = true;
         if (carry_query_flag) {
             char out_val[MAX_NLEN + 20];
-            sprintf(out_val, _("%sを拾いますか? ", "Pick up %s? "), o_name);
+            strnfmt(out_val, sizeof(out_val), _("%sを拾いますか? ", "Pick up %s? "), o_name);
             is_pickup_successful = get_check(out_val);
         }
 

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -39,6 +39,7 @@
 #include "system/monster-entity.h"
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
+#include "term/z-form.h"
 #include "util/enum-converter.h"
 #include "util/int-char-converter.h"
 #include "util/sort.h"
@@ -367,8 +368,9 @@ static void dump_aux_monsters(PlayerType *player_ptr, FILE *fff)
     char buf[80];
     for (auto it = who.rbegin(); it != who.rend() && std::distance(who.rbegin(), it) < 10; it++) {
         auto *r_ptr = &monraces_info[*it];
+        std::string details;
         if (r_ptr->defeat_level && r_ptr->defeat_time) {
-            sprintf(buf, _(" - レベル%2d - %d:%02d:%02d", " - level %2d - %d:%02d:%02d"), r_ptr->defeat_level, r_ptr->defeat_time / (60 * 60),
+            strnfmt(buf, sizeof(buf), _(" - レベル%2d - %d:%02d:%02d", " - level %2d - %d:%02d:%02d"), r_ptr->defeat_level, r_ptr->defeat_time / (60 * 60),
                 (r_ptr->defeat_time / 60) % 60, r_ptr->defeat_time % 60);
         } else {
             buf[0] = '\0';

--- a/src/io-dump/dump-remover.cpp
+++ b/src/io-dump/dump-remover.cpp
@@ -1,6 +1,7 @@
 ﻿#include "io-dump/dump-remover.h"
 #include "io-dump/dump-util.h"
 #include "io/read-pref-file.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 
 /*!
@@ -9,6 +10,7 @@
  * @brief prf出力内容を消去する /
  * Remove old lines automatically generated before.
  * @param orig_file 消去を行うファイル名
+ * @param auto_dump_mark 出力するヘッダマーク
  */
 void remove_auto_dump(concptr orig_file, concptr auto_dump_mark)
 {
@@ -20,8 +22,8 @@ void remove_auto_dump(concptr orig_file, concptr auto_dump_mark)
     char header_mark_str[80];
     char footer_mark_str[80];
 
-    sprintf(header_mark_str, auto_dump_header, auto_dump_mark);
-    sprintf(footer_mark_str, auto_dump_footer, auto_dump_mark);
+    strnfmt(header_mark_str, sizeof(header_mark_str), auto_dump_header, auto_dump_mark);
+    strnfmt(footer_mark_str, sizeof(footer_mark_str), auto_dump_footer, auto_dump_mark);
     size_t mark_len = strlen(footer_mark_str);
 
     FILE *orig_fff;

--- a/src/io-dump/random-art-info-dumper.cpp
+++ b/src/io-dump/random-art-info-dumper.cpp
@@ -22,14 +22,12 @@
 static void spoiler_print_randart(ItemEntity *o_ptr, obj_desc_list *art_ptr)
 {
     pval_info_type *pval_ptr = &art_ptr->pval_info;
-    char buf[80];
     fprintf(spoiler_file, "%s\n", art_ptr->description);
     if (!o_ptr->is_fully_known()) {
         fprintf(spoiler_file, _("%s不明\n", "%sUnknown\n"), spoiler_indent);
     } else {
         if (pval_ptr->pval_desc[0]) {
-            sprintf(buf, _("%sの修正:", "%s to"), pval_ptr->pval_desc);
-            spoiler_outlist(buf, pval_ptr->pval_affects, item_separator);
+            spoiler_outlist(std::string(pval_ptr->pval_desc).append(_("の修正:", " to")).data(), pval_ptr->pval_affects, item_separator);
         }
 
         spoiler_outlist(_("対:", "Slay"), art_ptr->slays, item_separator);
@@ -80,8 +78,7 @@ void spoil_random_artifact(PlayerType *player_ptr, concptr fname)
         return;
     }
 
-    sprintf(buf, "Random artifacts list.\r");
-    spoiler_underline(buf);
+    spoiler_underline("Random artifacts list.\r");
     for (const auto &[tval_list, name] : group_artifact_list) {
         for (auto tval : tval_list) {
             for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {

--- a/src/io/files-util.cpp
+++ b/src/io/files-util.cpp
@@ -21,6 +21,7 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "view/display-messages.h"
 
@@ -63,10 +64,11 @@ errr file_character(PlayerType *player_ptr, concptr name)
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, name);
     int fd = fd_open(buf, O_RDONLY);
     if (fd >= 0) {
-        char out_val[sizeof(buf) + 128];
+        std::string query = _("現存するファイル ", "Replace existing file ");
+        query.append(buf);
+        query.append(_(" に上書き>しますか? ", "? "));
         (void)fd_close(fd);
-        (void)sprintf(out_val, _("現存するファイル %s に上書きしますか? ", "Replace existing file %s? "), buf);
-        if (get_check_strict(player_ptr, out_val, CHECK_NO_HISTORY)) {
+        if (get_check_strict(player_ptr, query.data(), CHECK_NO_HISTORY)) {
             fd = -1;
         }
     }
@@ -221,9 +223,9 @@ static errr counts_seek(PlayerType *player_ptr, int fd, uint32_t where, bool fla
     char temp1[128], temp2[128];
     auto short_pclass = enum2i(player_ptr->pclass);
 #ifdef SAVEFILE_USE_UID
-    (void)sprintf(temp1, "%d.%s.%d%d%d", player_ptr->player_uid, savefile_base, short_pclass, player_ptr->ppersonality, player_ptr->age);
+    strnfmt(temp1, sizeof(temp1), "%d.%s.%d%d%d", player_ptr->player_uid, savefile_base, short_pclass, player_ptr->ppersonality, player_ptr->age);
 #else
-    (void)sprintf(temp1, "%s.%d%d%d", savefile_base, short_pclass, player_ptr->ppersonality, player_ptr->age);
+    strnfmt(temp1, sizeof(temp1), "%s.%d%d%d", savefile_base, short_pclass, player_ptr->ppersonality, player_ptr->age);
 #endif
     for (int i = 0; temp1[i]; i++) {
         temp1[i] ^= (i + 1) * 63;

--- a/src/io/pref-file-expressor.cpp
+++ b/src/io/pref-file-expressor.cpp
@@ -5,6 +5,7 @@
 #include "realm/realm-names-table.h"
 #include "system/player-type-definition.h"
 #include "system/system-variables.h"
+#include "term/z-form.h"
 #include "util/string-processor.h"
 
 /*!
@@ -208,7 +209,7 @@ concptr process_pref_file_expr(PlayerType *player_ptr, char **sp, char *fp)
         v = realm_names[player_ptr->realm2];
 #endif
     } else if (streq(b + 1, "LEVEL")) {
-        sprintf(tmp, "%02d", player_ptr->lev);
+        strnfmt(tmp, sizeof(tmp), "%02d", player_ptr->lev);
         v = tmp;
     } else if (streq(b + 1, "AUTOREGISTER")) {
         if (player_ptr->autopick_autoregister) {
@@ -217,7 +218,7 @@ concptr process_pref_file_expr(PlayerType *player_ptr, char **sp, char *fp)
             v = "0";
         }
     } else if (streq(b + 1, "MONEY")) {
-        sprintf(tmp, "%09ld", (long int)player_ptr->au);
+        strnfmt(tmp, sizeof(tmp), "%09ld", (long int)player_ptr->au);
         v = tmp;
     }
 

--- a/src/io/read-pref-file.cpp
+++ b/src/io/read-pref-file.cpp
@@ -25,6 +25,7 @@
 #include "player-info/race-info.h"
 #include "realm/realm-names-table.h"
 #include "system/player-type-definition.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/buffer-shaper.h"
 #include "view/display-messages.h"
@@ -248,8 +249,7 @@ void auto_dump_printf(FILE *auto_dump_stream, concptr fmt, ...)
 bool open_auto_dump(FILE **fpp, concptr buf, concptr mark)
 {
     char header_mark_str[80];
-    concptr auto_dump_mark = mark;
-    sprintf(header_mark_str, auto_dump_header, auto_dump_mark);
+    strnfmt(header_mark_str, sizeof(header_mark_str), auto_dump_header, mark);
     remove_auto_dump(buf, mark);
     *fpp = angband_fopen(buf, "a");
     if (!fpp) {
@@ -269,11 +269,12 @@ bool open_auto_dump(FILE **fpp, concptr buf, concptr mark)
 /*!
  * @brief prfファイルをファイルクローズする /
  * Append foot part and close auto dump.
+ * @param auto_dump_mark 出力するヘッダマーク
  */
 void close_auto_dump(FILE **fpp, concptr auto_dump_mark)
 {
     char footer_mark_str[80];
-    sprintf(footer_mark_str, auto_dump_footer, auto_dump_mark);
+    strnfmt(footer_mark_str, sizeof(footer_mark_str), auto_dump_footer, auto_dump_mark);
     auto_dump_printf(*fpp, _("# *警告!!* 以降の行は自動生成されたものです。\n", "# *Warning!*  The lines below are an automatic dump.\n"));
     auto_dump_printf(
         *fpp, _("# *警告!!* 後で自動的に削除されるので編集しないでください。\n", "# Don't edit them; changes will be deleted and replaced automatically.\n"));
@@ -290,25 +291,17 @@ void close_auto_dump(FILE **fpp, concptr auto_dump_mark)
  */
 void load_all_pref_files(PlayerType *player_ptr)
 {
-    char buf[1024];
-    sprintf(buf, "user.prf");
-    process_pref_file(player_ptr, buf);
-    sprintf(buf, "user-%s.prf", ANGBAND_SYS);
-    process_pref_file(player_ptr, buf);
-    sprintf(buf, "%s.prf", rp_ptr->title);
-    process_pref_file(player_ptr, buf);
-    sprintf(buf, "%s.prf", cp_ptr->title);
-    process_pref_file(player_ptr, buf);
-    sprintf(buf, "%s.prf", player_ptr->base_name);
-    process_pref_file(player_ptr, buf);
+    process_pref_file(player_ptr, "user.prf");
+    process_pref_file(player_ptr, std::string("user-").append(ANGBAND_SYS).append(".prf").data());
+    process_pref_file(player_ptr, std::string(rp_ptr->title).append(".prf").data());
+    process_pref_file(player_ptr, std::string(cp_ptr->title).append(".prf").data());
+    process_pref_file(player_ptr, std::string(player_ptr->base_name).append(".prf").data());
     if (player_ptr->realm1 != REALM_NONE) {
-        sprintf(buf, "%s.prf", realm_names[player_ptr->realm1]);
-        process_pref_file(player_ptr, buf);
+        process_pref_file(player_ptr, std::string(realm_names[player_ptr->realm1]).append(".prf").data());
     }
 
     if (player_ptr->realm2 != REALM_NONE) {
-        sprintf(buf, "%s.prf", realm_names[player_ptr->realm2]);
-        process_pref_file(player_ptr, buf);
+        process_pref_file(player_ptr, std::string(realm_names[player_ptr->realm2]).append(".prf").data());
     }
 
     autopick_load_pref(player_ptr, false);
@@ -319,7 +312,6 @@ void load_all_pref_files(PlayerType *player_ptr)
  */
 bool read_histpref(PlayerType *player_ptr)
 {
-    char buf[80];
     errr err;
     int i, j, n;
     char *s, *t;
@@ -333,12 +325,10 @@ bool read_histpref(PlayerType *player_ptr)
     histbuf[0] = '\0';
     histpref_buf = histbuf;
 
-    sprintf(buf, _("histedit-%s.prf", "histpref-%s.prf"), player_ptr->base_name);
-    err = process_histpref_file(player_ptr, buf);
+    err = process_histpref_file(player_ptr, std::string(_("histedit-", "histpref-")).append(player_ptr->base_name).append(".prf").data());
 
     if (0 > err) {
-        strcpy(buf, _("histedit.prf", "histpref.prf"));
-        err = process_histpref_file(player_ptr, buf);
+        err = process_histpref_file(player_ptr, _("histedit.prf", "histpref.prf"));
     }
 
     if (err) {

--- a/src/io/report.cpp
+++ b/src/io/report.cpp
@@ -416,14 +416,10 @@ concptr make_screen_dump(PlayerType *player_ptr)
 bool report_score(PlayerType *player_ptr)
 {
     auto *score = buf_new();
-    char personality_desc[128];
+    std::string personality_desc = ap_ptr->title;
+    personality_desc.append(_(ap_ptr->no ? "の" : "", " "));
     char title[128];
     put_version(title);
-#ifdef JP
-    sprintf(personality_desc, "%s%s", ap_ptr->title, (ap_ptr->no ? "の" : ""));
-#else
-    sprintf(personality_desc, "%s ", ap_ptr->title);
-#endif
 
     auto realm1_name = PlayerClass(player_ptr).equals(PlayerClassType::ELEMENTALIST) ? get_element_title(player_ptr->element) : realm_names[player_ptr->realm1];
     buf_sprintf(score, "name: %s\n", player_ptr->name);
@@ -438,7 +434,7 @@ bool report_score(PlayerType *player_ptr)
     buf_sprintf(score, "sex: %d\n", player_ptr->psex);
     buf_sprintf(score, "race: %s\n", rp_ptr->title);
     buf_sprintf(score, "class: %s\n", cp_ptr->title);
-    buf_sprintf(score, "seikaku: %s\n", personality_desc);
+    buf_sprintf(score, "seikaku: %s\n", personality_desc.data());
     buf_sprintf(score, "realm1: %s\n", realm1_name);
     buf_sprintf(score, "realm2: %s\n", realm_names[player_ptr->realm2]);
     buf_sprintf(score, "killer: %s\n", player_ptr->died_from.data());

--- a/src/io/write-diary.cpp
+++ b/src/io/write-diary.cpp
@@ -15,6 +15,7 @@
 #include "system/floor-type-definition.h"
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
@@ -54,10 +55,10 @@ concptr get_ordinal_number_suffix(int num)
  */
 static bool open_diary_file(FILE **fff, bool *disable_diary)
 {
-    GAME_TEXT file_name[MAX_NLEN];
-    sprintf(file_name, _("playrecord-%s.txt", "playrec-%s.txt"), savefile_base);
+    std::string file_name = _("playrecord-", "playrec-");
+    file_name.append(savefile_base).append(".txt");
     char buf[1024];
-    path_build(buf, sizeof(buf), ANGBAND_DIR_USER, file_name);
+    path_build(buf, sizeof(buf), ANGBAND_DIR_USER, file_name.data());
     *fff = angband_fopen(buf, "a");
     if (*fff) {
         return true;
@@ -72,32 +73,34 @@ static bool open_diary_file(FILE **fff, bool *disable_diary)
 /*!
  * @brief フロア情報を日記に追加する
  * @param player_ptr プレイヤーへの参照ポインタ
- * @return クエストID
+ * @return クエストIDとレベルノートのペア
  */
-static QuestId write_floor(PlayerType *player_ptr, concptr *note_level, char *note_level_buf)
+static std::pair<QuestId, std::string> write_floor(PlayerType *player_ptr)
 {
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    auto q_idx = quest_number(player_ptr, floor_ptr->dun_level);
+    std::pair<QuestId, std::string> result;
+    result.first = quest_number(player_ptr, floor_ptr->dun_level);
     if (!write_level) {
-        return q_idx;
+        return result;
     }
 
     if (floor_ptr->inside_arena) {
-        *note_level = _("アリーナ:", "Arena:");
+        result.second = _("アリーナ:", "Arena:");
     } else if (!floor_ptr->dun_level) {
-        *note_level = _("地上:", "Surface:");
-    } else if (inside_quest(q_idx) && quest_type::is_fixed(q_idx) && !((q_idx == QuestId::OBERON) || (q_idx == QuestId::SERPENT))) {
-        *note_level = _("クエスト:", "Quest:");
+        result.second = _("地上:", "Surface:");
+    } else if (inside_quest(result.first) && quest_type::is_fixed(result.first) && !((result.first == QuestId::OBERON) || (result.first == QuestId::SERPENT))) {
+        result.second = _("クエスト:", "Quest:");
     } else {
 #ifdef JP
-        sprintf(note_level_buf, "%d階(%s):", (int)floor_ptr->dun_level, dungeons_info[player_ptr->dungeon_idx].name.data());
+        result.second = std::to_string((int)floor_ptr->dun_level);
+        result.second.append("階(").append(dungeons_info[player_ptr->dungeon_idx].name).append("):");
 #else
-        sprintf(note_level_buf, "%s L%d:", dungeons_info[player_ptr->dungeon_idx].name.data(), (int)floor_ptr->dun_level);
+        result.second = dungeons_info[player_ptr->dungeon_idx].name;
+        result.second.append(" L").append(std::to_string((int)floor_ptr->dun_level)).append(":");
 #endif
-        *note_level = note_level_buf;
     }
 
-    return q_idx;
+    return result;
 }
 
 /*!
@@ -186,9 +189,7 @@ int exe_write_diary_quest(PlayerType *player_ptr, int type, QuestId num)
     parse_fixed_map(player_ptr, QUEST_DEFINITION_LIST, 0, 0, 0, 0);
     player_ptr->current_floor_ptr->quest_number = old_quest;
 
-    concptr note_level = "";
-    char note_level_buf[40];
-    write_floor(player_ptr, &note_level, note_level_buf);
+    std::pair<QuestId, std::string> floor_result = write_floor(player_ptr);
 
     FILE *fff = nullptr;
     if (!open_diary_file(&fff, &disable_diary)) {
@@ -203,7 +204,7 @@ int exe_write_diary_quest(PlayerType *player_ptr, int type, QuestId num)
             break;
         }
 
-        fprintf(fff, _(" %2d:%02d %20s クエスト「%s」を達成した。\n", " %2d:%02d %20s completed quest '%s'.\n"), hour, min, note_level, q_ref.name);
+        fprintf(fff, _(" %2d:%02d %20s クエスト「%s」を達成した。\n", " %2d:%02d %20s completed quest '%s'.\n"), hour, min, floor_result.second.data(), q_ref.name);
         break;
     }
     case DIARY_FIX_QUEST_F: {
@@ -211,19 +212,15 @@ int exe_write_diary_quest(PlayerType *player_ptr, int type, QuestId num)
             break;
         }
 
-        fprintf(fff, _(" %2d:%02d %20s クエスト「%s」から命からがら逃げ帰った。\n", " %2d:%02d %20s ran away from quest '%s'.\n"), hour, min, note_level, q_ref.name);
+        fprintf(fff, _(" %2d:%02d %20s クエスト「%s」から命からがら逃げ帰った。\n", " %2d:%02d %20s ran away from quest '%s'.\n"), hour, min, floor_result.second.data(), q_ref.name);
         break;
     }
     case DIARY_RAND_QUEST_C: {
-        GAME_TEXT name[MAX_NLEN];
-        strcpy(name, monraces_info[q_ref.r_idx].name.data());
-        fprintf(fff, _(" %2d:%02d %20s ランダムクエスト(%s)を達成した。\n", " %2d:%02d %20s completed random quest '%s'\n"), hour, min, note_level, name);
+        fprintf(fff, _(" %2d:%02d %20s ランダムクエスト(%s)を達成した。\n", " %2d:%02d %20s completed random quest '%s'\n"), hour, min, floor_result.second.data(), monraces_info[q_ref.r_idx].name.data());
         break;
     }
     case DIARY_RAND_QUEST_F: {
-        GAME_TEXT name[MAX_NLEN];
-        strcpy(name, monraces_info[q_ref.r_idx].name.data());
-        fprintf(fff, _(" %2d:%02d %20s ランダムクエスト(%s)から逃げ出した。\n", " %2d:%02d %20s ran away from quest '%s'.\n"), hour, min, note_level, name);
+        fprintf(fff, _(" %2d:%02d %20s ランダムクエスト(%s)から逃げ出した。\n", " %2d:%02d %20s ran away from quest '%s'.\n"), hour, min, floor_result.second.data(), monraces_info[q_ref.r_idx].name.data());
         break;
     }
     case DIARY_TO_QUEST: {
@@ -232,7 +229,7 @@ int exe_write_diary_quest(PlayerType *player_ptr, int type, QuestId num)
         }
 
         fprintf(fff, _(" %2d:%02d %20s クエスト「%s」へと突入した。\n", " %2d:%02d %20s entered the quest '%s'.\n"),
-            hour, min, note_level, q_ref.name);
+            hour, min, floor_result.second.data(), q_ref.name);
         break;
     }
     default:
@@ -271,9 +268,7 @@ errr exe_write_diary(PlayerType *player_ptr, int type, int num, concptr note)
         return -1;
     }
 
-    concptr note_level = "";
-    char note_level_buf[40];
-    auto q_idx = write_floor(player_ptr, &note_level, note_level_buf);
+    std::pair<QuestId, std::string> floor_result = write_floor(player_ptr);
 
     bool do_level = true;
     switch (type) {
@@ -292,78 +287,78 @@ errr exe_write_diary(PlayerType *player_ptr, int type, int num, concptr note)
             fprintf(fff, "%s\n", note);
             do_level = false;
         } else {
-            fprintf(fff, " %2d:%02d %20s %s\n", hour, min, note_level, note);
+            fprintf(fff, " %2d:%02d %20s %s\n", hour, min, floor_result.second.data(), note);
         }
 
         break;
     }
     case DIARY_ART: {
-        fprintf(fff, _(" %2d:%02d %20s %sを発見した。\n", " %2d:%02d %20s discovered %s.\n"), hour, min, note_level, note);
+        fprintf(fff, _(" %2d:%02d %20s %sを発見した。\n", " %2d:%02d %20s discovered %s.\n"), hour, min, floor_result.second.data(), note);
         break;
     }
     case DIARY_ART_SCROLL: {
-        fprintf(fff, _(" %2d:%02d %20s 巻物によって%sを生成した。\n", " %2d:%02d %20s created %s by scroll.\n"), hour, min, note_level, note);
+        fprintf(fff, _(" %2d:%02d %20s 巻物によって%sを生成した。\n", " %2d:%02d %20s created %s by scroll.\n"), hour, min, floor_result.second.data(), note);
         break;
     }
     case DIARY_UNIQUE: {
-        fprintf(fff, _(" %2d:%02d %20s %sを倒した。\n", " %2d:%02d %20s defeated %s.\n"), hour, min, note_level, note);
+        fprintf(fff, _(" %2d:%02d %20s %sを倒した。\n", " %2d:%02d %20s defeated %s.\n"), hour, min, floor_result.second.data(), note);
         break;
     }
     case DIARY_MAXDEAPTH: {
-        fprintf(fff, _(" %2d:%02d %20s %sの最深階%d階に到達した。\n", " %2d:%02d %20s reached level %d of %s for the first time.\n"), hour, min, note_level,
+        fprintf(fff, _(" %2d:%02d %20s %sの最深階%d階に到達した。\n", " %2d:%02d %20s reached level %d of %s for the first time.\n"), hour, min, floor_result.second.data(),
             _(dungeons_info[player_ptr->dungeon_idx].name.data(), num),
             _(num, dungeons_info[player_ptr->dungeon_idx].name.data()));
         break;
     }
     case DIARY_TRUMP: {
-        fprintf(fff, _(" %2d:%02d %20s %s%sの最深階を%d階にセットした。\n", " %2d:%02d %20s reset recall level of %s to %d %s.\n"), hour, min, note_level, note,
+        fprintf(fff, _(" %2d:%02d %20s %s%sの最深階を%d階にセットした。\n", " %2d:%02d %20s reset recall level of %s to %d %s.\n"), hour, min, floor_result.second.data(), note,
             _(dungeons_info[num].name.data(), (int)max_dlv[num]),
             _((int)max_dlv[num], dungeons_info[num].name.data()));
         break;
     }
     case DIARY_STAIR: {
-        concptr to = inside_quest(q_idx) && (quest_type::is_fixed(q_idx) && !((q_idx == QuestId::OBERON) || (q_idx == QuestId::SERPENT)))
+        concptr to = inside_quest(floor_result.first) && (quest_type::is_fixed(floor_result.first) && !((floor_result.first == QuestId::OBERON) || (floor_result.first == QuestId::SERPENT)))
                          ? _("地上", "the surface")
                      : !(player_ptr->current_floor_ptr->dun_level + num)
                          ? _("地上", "the surface")
                          : format(_("%d階", "level %d"), player_ptr->current_floor_ptr->dun_level + num);
-        fprintf(fff, _(" %2d:%02d %20s %sへ%s。\n", " %2d:%02d %20s %s %s.\n"), hour, min, note_level, _(to, note), _(note, to));
+        fprintf(fff, _(" %2d:%02d %20s %sへ%s。\n", " %2d:%02d %20s %s %s.\n"), hour, min, floor_result.second.data(), _(to, note), _(note, to));
         break;
     }
     case DIARY_RECALL: {
         if (!num) {
             fprintf(fff, _(" %2d:%02d %20s 帰還を使って%sの%d階へ下りた。\n", " %2d:%02d %20s recalled to dungeon level %d of %s.\n"),
-                hour, min, note_level, _(dungeons_info[player_ptr->dungeon_idx].name.data(), (int)max_dlv[player_ptr->dungeon_idx]),
+                hour, min, floor_result.second.data(), _(dungeons_info[player_ptr->dungeon_idx].name.data(), (int)max_dlv[player_ptr->dungeon_idx]),
                 _((int)max_dlv[player_ptr->dungeon_idx], dungeons_info[player_ptr->dungeon_idx].name.data()));
         } else {
-            fprintf(fff, _(" %2d:%02d %20s 帰還を使って地上へと戻った。\n", " %2d:%02d %20s recalled from dungeon to surface.\n"), hour, min, note_level);
+            fprintf(fff, _(" %2d:%02d %20s 帰還を使って地上へと戻った。\n", " %2d:%02d %20s recalled from dungeon to surface.\n"), hour, min, floor_result.second.data());
         }
 
         break;
     }
     case DIARY_TELEPORT_LEVEL: {
         fprintf(fff, _(" %2d:%02d %20s レベル・テレポートで脱出した。\n", " %2d:%02d %20s got out using teleport level.\n"),
-            hour, min, note_level);
+            hour, min, floor_result.second.data());
         break;
     }
     case DIARY_BUY: {
-        fprintf(fff, _(" %2d:%02d %20s %sを購入した。\n", " %2d:%02d %20s bought %s.\n"), hour, min, note_level, note);
+        fprintf(fff, _(" %2d:%02d %20s %sを購入した。\n", " %2d:%02d %20s bought %s.\n"), hour, min, floor_result.second.data(), note);
         break;
     }
     case DIARY_SELL: {
-        fprintf(fff, _(" %2d:%02d %20s %sを売却した。\n", " %2d:%02d %20s sold %s.\n"), hour, min, note_level, note);
+        fprintf(fff, _(" %2d:%02d %20s %sを売却した。\n", " %2d:%02d %20s sold %s.\n"), hour, min, floor_result.second.data(), note);
         break;
     }
     case DIARY_ARENA: {
         if (num < 0) {
             int n = -num;
             fprintf(fff, _(" %2d:%02d %20s 闘技場の%d%s回戦で、%sの前に敗れ去った。\n", " %2d:%02d %20s beaten by %s in the %d%s fight.\n"),
-                hour, min, note_level, _(n, note), _("", n), _(note, get_ordinal_number_suffix(n)));
+                hour, min, floor_result.second.data(), _(n, note), _("", n), _(note, get_ordinal_number_suffix(n)));
             break;
         }
 
         fprintf(fff, _(" %2d:%02d %20s 闘技場の%d%s回戦(%s)に勝利した。\n", " %2d:%02d %20s won the %d%s fight (%s).\n"),
-            hour, min, note_level, num, _("", get_ordinal_number_suffix(num)), note);
+            hour, min, floor_result.second.data(), num, _("", get_ordinal_number_suffix(num)), note);
 
         if (num == MAX_ARENA_MONS) {
             fprintf(fff, _("                 闘技場のすべての敵に勝利し、チャンピオンとなった。\n",
@@ -374,7 +369,7 @@ errr exe_write_diary(PlayerType *player_ptr, int type, int num, concptr note)
         break;
     }
     case DIARY_FOUND: {
-        fprintf(fff, _(" %2d:%02d %20s %sを識別した。\n", " %2d:%02d %20s identified %s.\n"), hour, min, note_level, note);
+        fprintf(fff, _(" %2d:%02d %20s %sを識別した。\n", " %2d:%02d %20s identified %s.\n"), hour, min, floor_result.second.data(), note);
         break;
     }
     case DIARY_WIZ_TELE: {
@@ -382,7 +377,7 @@ errr exe_write_diary(PlayerType *player_ptr, int type, int num, concptr note)
         concptr to = !floor_ref.is_in_dungeon()
                          ? _("地上", "the surface")
                          : format(_("%d階(%s)", "level %d of %s"), floor_ref.dun_level, dungeons_info[player_ptr->dungeon_idx].name.data());
-        fprintf(fff, _(" %2d:%02d %20s %sへとウィザード・テレポートで移動した。\n", " %2d:%02d %20s wizard-teleported to %s.\n"), hour, min, note_level, to);
+        fprintf(fff, _(" %2d:%02d %20s %sへとウィザード・テレポートで移動した。\n", " %2d:%02d %20s wizard-teleported to %s.\n"), hour, min, floor_result.second.data(), to);
         break;
     }
     case DIARY_PAT_TELE: {
@@ -390,11 +385,11 @@ errr exe_write_diary(PlayerType *player_ptr, int type, int num, concptr note)
         concptr to = !floor_ref.is_in_dungeon()
                          ? _("地上", "the surface")
                          : format(_("%d階(%s)", "level %d of %s"), floor_ref.dun_level, dungeons_info[player_ptr->dungeon_idx].name.data());
-        fprintf(fff, _(" %2d:%02d %20s %sへとパターンの力で移動した。\n", " %2d:%02d %20s used Pattern to teleport to %s.\n"), hour, min, note_level, to);
+        fprintf(fff, _(" %2d:%02d %20s %sへとパターンの力で移動した。\n", " %2d:%02d %20s used Pattern to teleport to %s.\n"), hour, min, floor_result.second.data(), to);
         break;
     }
     case DIARY_LEVELUP: {
-        fprintf(fff, _(" %2d:%02d %20s レベルが%dに上がった。\n", " %2d:%02d %20s reached player level %d.\n"), hour, min, note_level, num);
+        fprintf(fff, _(" %2d:%02d %20s レベルが%dに上がった。\n", " %2d:%02d %20s reached player level %d.\n"), hour, min, floor_result.second.data(), num);
         break;
     }
     case DIARY_GAMESTART: {
@@ -403,13 +398,13 @@ errr exe_write_diary(PlayerType *player_ptr, int type, int num, concptr note)
         if (num) {
             fprintf(fff, "%s %s", note, ctime(&ct));
         } else {
-            fprintf(fff, " %2d:%02d %20s %s %s", hour, min, note_level, note, ctime(&ct));
+            fprintf(fff, " %2d:%02d %20s %s %s", hour, min, floor_result.second.data(), note, ctime(&ct));
         }
 
         break;
     }
     case DIARY_NAMED_PET: {
-        fprintf(fff, " %2d:%02d %20s ", hour, min, note_level);
+        fprintf(fff, " %2d:%02d %20s ", hour, min, floor_result.second.data());
         write_diary_pet(fff, num, note);
         break;
     }

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -32,6 +32,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
@@ -193,21 +194,19 @@ void do_cmd_knowledge_kill_count(PlayerType *player_ptr)
     }
 
     uint16_t why = 2;
-    char buf[80];
     ang_sort(player_ptr, who.data(), &why, who.size(), ang_sort_comp_hook, ang_sort_swap_hook);
     for (auto r_idx : who) {
         auto *r_ptr = &monraces_info[r_idx];
         if (r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
             bool dead = (r_ptr->max_num == 0);
             if (dead) {
+                std::string details;
                 if (r_ptr->defeat_level && r_ptr->defeat_time) {
-                    sprintf(buf, _(" - レベル%2d - %d:%02d:%02d", " - level %2d - %d:%02d:%02d"), r_ptr->defeat_level, r_ptr->defeat_time / (60 * 60),
+                    details = format(_(" - レベル%2d - %d:%02d:%02d", " - level %2d - %d:%02d:%02d"), r_ptr->defeat_level, r_ptr->defeat_time / (60 * 60),
                         (r_ptr->defeat_time / 60) % 60, r_ptr->defeat_time % 60);
-                } else {
-                    buf[0] = '\0';
                 }
 
-                fprintf(fff, "     %s%s\n", r_ptr->name.data(), buf);
+                fprintf(fff, "     %s%s\n", r_ptr->name.data(), details.data());
                 total++;
             }
 

--- a/src/knowledge/knowledge-quests.cpp
+++ b/src/knowledge/knowledge-quests.cpp
@@ -24,6 +24,7 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/enum-converter.h"
 #include "util/sort.h"
@@ -50,8 +51,7 @@ void do_cmd_checkquest(PlayerType *player_ptr)
 static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
 {
     const auto &quest_list = QuestList::get_instance();
-    char tmp_str[1024];
-    char rand_tmp_str[512] = "\0";
+    std::string rand_tmp_str;
     GAME_TEXT name[MAX_NLEN];
     MonsterRaceInfo *r_ptr;
     int rand_level = 100;
@@ -82,21 +82,21 @@ static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
         }
         total++;
         if (q_ref.type != QuestKindType::RANDOM) {
-            char note[512] = "\0";
+            std::string note;
             if (q_ref.status == QuestStatusType::TAKEN || q_ref.status == QuestStatusType::STAGE_COMPLETED) {
                 switch (q_ref.type) {
                 case QuestKindType::KILL_LEVEL:
                     r_ptr = &monraces_info[q_ref.r_idx];
-                    strcpy(name, r_ptr->name.data());
                     if (q_ref.max_num > 1) {
 #ifdef JP
-                        sprintf(note, " - %d 体の%sを倒す。(あと %d 体)", (int)q_ref.max_num, name, (int)(q_ref.max_num - q_ref.cur_num));
+                        note = format(" - %d 体の%sを倒す。(あと %d 体)", (int)q_ref.max_num, r_ptr->name.data(), (int)(q_ref.max_num - q_ref.cur_num));
 #else
+                        angband_strcpy(name, r_ptr->name.data(), sizeof(name));
                         plural_aux(name);
-                        sprintf(note, " - kill %d %s, have killed %d.", (int)q_ref.max_num, name, (int)q_ref.cur_num);
+                        note = format(" - kill %d %s, have killed %d.", (int)q_ref.max_num, name, (int)q_ref.cur_num);
 #endif
                     } else {
-                        sprintf(note, _(" - %sを倒す。", " - kill %s."), name);
+                        note = format(_(" - %sを倒す。", " - kill %s."), r_ptr->name.data());
                     }
 
                     break;
@@ -111,33 +111,31 @@ static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
                         describe_flavor(player_ptr, name, &item, OD_NAME_ONLY);
                     }
 
-                    sprintf(note, _("\n   - %sを見つけ出す。", "\n   - Find %s."), name);
+                    note = format(_("\n   - %sを見つけ出す。", "\n   - Find %s."), name);
                     break;
                 case QuestKindType::FIND_EXIT:
-                    sprintf(note, _(" - 出口に到達する。", " - Reach exit."));
+                    note = _(" - 出口に到達する。", " - Reach exit.");
                     break;
                 case QuestKindType::KILL_NUMBER:
 #ifdef JP
-                    sprintf(note, " - %d 体のモンスターを倒す。(あと %d 体)", (int)q_ref.max_num, (int)(q_ref.max_num - q_ref.cur_num));
+                    note = format(" - %d 体のモンスターを倒す。(あと %d 体)", (int)q_ref.max_num, (int)(q_ref.max_num - q_ref.cur_num));
 #else
-                    sprintf(note, " - Kill %d monsters, have killed %d.", (int)q_ref.max_num, (int)q_ref.cur_num);
+                    note = format(" - Kill %d monsters, have killed %d.", (int)q_ref.max_num, (int)q_ref.cur_num);
 #endif
                     break;
 
                 case QuestKindType::KILL_ALL:
                 case QuestKindType::TOWER:
-                    sprintf(note, _(" - 全てのモンスターを倒す。", " - Kill all monsters."));
+                    note = _(" - 全てのモンスターを倒す。", " - Kill all monsters.");
                     break;
                 default:
                     break;
                 }
             }
 
-            sprintf(tmp_str, _("  %s (危険度:%d階相当)%s\n", "  %s (Danger level: %d)%s\n"), q_ref.name, (int)q_ref.level, note);
-            fputs(tmp_str, fff);
+            fprintf(fff, _("  %s (危険度:%d階相当)%s\n", "  %s (Danger level: %d)%s\n"), q_ref.name, (int)q_ref.level, note.data());
             if (q_ref.status == QuestStatusType::COMPLETED) {
-                sprintf(tmp_str, _("    クエスト達成 - まだ報酬を受けとってない。\n", "    Quest Completed - Unrewarded\n"));
-                fputs(tmp_str, fff);
+                fputs(_("    クエスト達成 - まだ報酬を受けとってない。\n", "    Quest Completed - Unrewarded\n"), fff);
                 continue;
             }
 
@@ -159,25 +157,25 @@ static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
         }
 
         r_ptr = &monraces_info[q_ref.r_idx];
-        strcpy(name, r_ptr->name.data());
         if (q_ref.max_num <= 1) {
-            sprintf(rand_tmp_str, _("  %s (%d 階) - %sを倒す。\n", "  %s (Dungeon level: %d)\n  Kill %s.\n"), q_ref.name, (int)q_ref.level, name);
+            rand_tmp_str = format(_("  %s (%d 階) - %sを倒す。\n", "  %s (Dungeon level: %d)\n  Kill %s.\n"), q_ref.name, (int)q_ref.level, r_ptr->name.data());
             continue;
         }
 
 #ifdef JP
-        sprintf(rand_tmp_str, "  %s (%d 階) - %d 体の%sを倒す。(あと %d 体)\n", q_ref.name, (int)q_ref.level, (int)q_ref.max_num, name,
+        rand_tmp_str = format("  %s (%d 階) - %d 体の%sを倒す。(あと %d 体)\n", q_ref.name, (int)q_ref.level, (int)q_ref.max_num, r_ptr->name.data(),
             (int)(q_ref.max_num - q_ref.cur_num));
 #else
+        angband_strcpy(name, r_ptr->name.data(), sizeof(name));
         plural_aux(name);
 
-        sprintf(rand_tmp_str, "  %s (Dungeon level: %d)\n  Kill %d %s, have killed %d.\n", q_ref.name, (int)q_ref.level, (int)q_ref.max_num, name,
+        rand_tmp_str = format("  %s (Dungeon level: %d)\n  Kill %d %s, have killed %d.\n", q_ref.name, (int)q_ref.level, (int)q_ref.max_num, name,
             (int)q_ref.cur_num);
 #endif
     }
 
-    if (rand_tmp_str[0]) {
-        fputs(rand_tmp_str, fff);
+    if (rand_tmp_str.length()) {
+        fputs(rand_tmp_str.data(), fff);
     }
 
     if (!total) {
@@ -187,8 +185,6 @@ static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
 
 static bool do_cmd_knowledge_quests_aux(PlayerType *player_ptr, FILE *fff, QuestId q_idx)
 {
-    char tmp_str[120];
-    char playtime_str[16];
     const auto &quest_list = QuestList::get_instance();
     const auto &q_ref = quest_list[q_idx];
 
@@ -205,7 +201,7 @@ static bool do_cmd_knowledge_quests_aux(PlayerType *player_ptr, FILE *fff, Quest
         }
     }
 
-    strnfmt(playtime_str, sizeof(playtime_str), "%02d:%02d:%02d", q_ref.comptime / (60 * 60), (q_ref.comptime / 60) % 60, q_ref.comptime % 60);
+    std::string playtime_str = format("%02d:%02d:%02d", q_ref.comptime / (60 * 60), (q_ref.comptime / 60) % 60, q_ref.comptime % 60);
 
     auto fputs_name_remain = [fff](const auto &name) {
         for (auto i = 1U; i < name.size(); ++i) {
@@ -213,27 +209,28 @@ static bool do_cmd_knowledge_quests_aux(PlayerType *player_ptr, FILE *fff, Quest
         }
     };
 
+    std::string tmp_str;
     if (is_fixed_quest || !MonsterRace(q_ref.r_idx).is_valid()) {
         auto name = str_separate(q_ref.name, 35);
-        sprintf(tmp_str, _("  %-35s (危険度:%3d階相当) - レベル%2d - %s\n", "  %-35s (Danger  level: %3d) - level %2d - %s\n"), name.front().data(), (int)q_ref.level,
-            q_ref.complev, playtime_str);
-        fputs(tmp_str, fff);
+        tmp_str = format(_("  %-35s (危険度:%3d階相当) - レベル%2d - %s\n", "  %-35s (Danger  level: %3d) - level %2d - %s\n"), name.front().data(), (int)q_ref.level,
+            q_ref.complev, playtime_str.data());
+        fputs(tmp_str.data(), fff);
         fputs_name_remain(name);
         return true;
     }
 
     auto name = str_separate(monraces_info[q_ref.r_idx].name, 35);
     if (q_ref.complev == 0) {
-        sprintf(tmp_str, _("  %-35s (%3d階)            -   不戦勝 - %s\n", "  %-35s (Dungeon level: %3d) - Unearned - %s\n"),
-            name.front().data(), (int)q_ref.level, playtime_str);
-        fputs(tmp_str, fff);
+        tmp_str = format(_("  %-35s (%3d階)            -   不戦勝 - %s\n", "  %-35s (Dungeon level: %3d) - Unearned - %s\n"),
+            name.front().data(), (int)q_ref.level, playtime_str.data());
+        fputs(tmp_str.data(), fff);
         fputs_name_remain(name);
         return true;
     }
 
-    sprintf(tmp_str, _("  %-35s (%3d階)            - レベル%2d - %s\n", "  %-35s (Dungeon level: %3d) - level %2d - %s\n"), name.front().data(),
-        (int)q_ref.level, q_ref.complev, playtime_str);
-    fputs(tmp_str, fff);
+    tmp_str = format(_("  %-35s (%3d階)            - レベル%2d - %s\n", "  %-35s (Dungeon level: %3d) - level %2d - %s\n"), name.front().data(),
+        (int)q_ref.level, q_ref.complev, playtime_str.data());
+    fputs(tmp_str.data(), fff);
     fputs_name_remain(name);
     return true;
 }
@@ -293,7 +290,6 @@ static void do_cmd_knowledge_quests_wiz_random(FILE *fff)
 {
     fprintf(fff, _("《残りのランダムクエスト》\n", "< Remaining Random Quest >\n"));
     const auto &quest_list = QuestList::get_instance();
-    GAME_TEXT tmp_str[120];
     int16_t total = 0;
     for (const auto &[q_idx, q_ref] : quest_list) {
         if (q_ref.flags & QUEST_FLAG_SILENT) {
@@ -302,8 +298,7 @@ static void do_cmd_knowledge_quests_wiz_random(FILE *fff)
 
         if ((q_ref.type == QuestKindType::RANDOM) && (q_ref.status == QuestStatusType::TAKEN)) {
             total++;
-            sprintf(tmp_str, _("  %s (%d階, %s)\n", "  %s (%d, %s)\n"), q_ref.name, (int)q_ref.level, monraces_info[q_ref.r_idx].name.data());
-            fputs(tmp_str, fff);
+            fputs(format(_("  %s (%d階, %s)\n", "  %s (%d, %s)\n"), q_ref.name, (int)q_ref.level, monraces_info[q_ref.r_idx].name.data()), fff);
         }
     }
 

--- a/src/knowledge/knowledge-uniques.cpp
+++ b/src/knowledge/knowledge-uniques.cpp
@@ -12,6 +12,7 @@
 #include "monster-race/race-flags1.h"
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/sort.h"
 #include "util/string-processor.h"
@@ -116,19 +117,17 @@ static void display_uniques(unique_list_type *unique_list_ptr, FILE *fff)
         fputs(no_unique_desc, fff);
     }
 
-    char buf[80];
     for (auto r_idx : unique_list_ptr->who) {
         auto *r_ptr = &monraces_info[r_idx];
+        std::string details;
 
         if (r_ptr->defeat_level && r_ptr->defeat_time) {
-            sprintf(buf, _(" - レベル%2d - %d:%02d:%02d", " - level %2d - %d:%02d:%02d"), r_ptr->defeat_level, r_ptr->defeat_time / (60 * 60),
+            details = format(_(" - レベル%2d - %d:%02d:%02d", " - level %2d - %d:%02d:%02d"), r_ptr->defeat_level, r_ptr->defeat_time / (60 * 60),
                 (r_ptr->defeat_time / 60) % 60, r_ptr->defeat_time % 60);
-        } else {
-            buf[0] = '\0';
         }
 
         const auto name = str_separate(r_ptr->name, 40);
-        fprintf(fff, _("     %-40s (レベル%3d)%s\n", "     %-40s (level %3d)%s\n"), name.front().data(), (int)r_ptr->level, buf);
+        fprintf(fff, _("     %-40s (レベル%3d)%s\n", "     %-40s (level %3d)%s\n"), name.front().data(), (int)r_ptr->level, details.data());
         for (auto i = 1U; i < name.size(); ++i) {
             fprintf(fff, "     %s\n", name[i].data());
         }

--- a/src/load/floor-loader.cpp
+++ b/src/load/floor-loader.cpp
@@ -25,6 +25,7 @@
 #include "system/item-entity.h"
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "world/world-object.h"
 #include "world/world.h"
@@ -286,11 +287,13 @@ bool load_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr, BIT_FLAGS mode
         old_loading_savefile_version = loading_savefile_version;
     }
 
-    char floor_savefile[sizeof(savefile) + 32];
-    sprintf(floor_savefile, "%s.F%02d", savefile, (int)sf_ptr->savefile_id);
+    std::string floor_savefile = savefile;
+    char ext[32];
+    strnfmt(ext, sizeof(ext), ".F%02d", (int)sf_ptr->savefile_id);
+    floor_savefile.append(ext);
 
     safe_setuid_grab(player_ptr);
-    loading_savefile = angband_fopen(floor_savefile, "rb");
+    loading_savefile = angband_fopen(floor_savefile.data(), "rb");
     safe_setuid_drop();
 
     bool is_save_successful = true;
@@ -307,7 +310,7 @@ bool load_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr, BIT_FLAGS mode
         angband_fclose(loading_savefile);
         safe_setuid_grab(player_ptr);
         if (!(mode & SLF_NO_KILL)) {
-            (void)fd_kill(floor_savefile);
+            (void)fd_kill(floor_savefile.data());
         }
 
         safe_setuid_drop();

--- a/src/lore/lore-calculator.cpp
+++ b/src/lore/lore-calculator.cpp
@@ -7,6 +7,7 @@
 #include "mspell/mspell-damage-calculator.h"
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
+#include "util/string-processor.h"
 
 /*!
  * @brief ダイス目を文字列に変換する
@@ -27,20 +28,20 @@ void dice_to_string(int base_damage, int dice_num, int dice_side, int dice_mult,
     }
 
     if (base_damage != 0) {
-        sprintf(base, "%d+", base_damage);
+        strnfmt(base, sizeof(base), "%d+", base_damage);
     }
 
     if (dice_num == 1) {
-        sprintf(dice, "d%d", dice_side);
+        strnfmt(dice, sizeof(dice), "d%d", dice_side);
     } else {
-        sprintf(dice, "%dd%d", dice_num, dice_side);
+        strnfmt(dice, sizeof(dice), "%dd%d", dice_num, dice_side);
     }
 
     if (dice_mult != 1 || dice_div != 1) {
         if (dice_div == 1) {
-            sprintf(mult, "*%d", dice_mult);
+            strnfmt(mult, sizeof(mult), "*%d", dice_mult);
         } else {
-            sprintf(mult, "*(%d/%d)", dice_mult, dice_div);
+            strnfmt(mult, sizeof(mult), "*(%d/%d)", dice_mult, dice_div);
         }
     }
 
@@ -125,20 +126,21 @@ bool know_damage(MonsterRaceId r_idx, int i)
 void set_damage(PlayerType *player_ptr, lore_type *lore_ptr, MonsterAbilityType ms_type, concptr msg)
 {
     MonsterRaceId r_idx = lore_ptr->r_idx;
-    int base_damage = monspell_race_damage(player_ptr, ms_type, r_idx, BASE_DAM);
-    int dice_num = monspell_race_damage(player_ptr, ms_type, r_idx, DICE_NUM);
-    int dice_side = monspell_race_damage(player_ptr, ms_type, r_idx, DICE_SIDE);
-    int dice_mult = monspell_race_damage(player_ptr, ms_type, r_idx, DICE_MULT);
-    int dice_div = monspell_race_damage(player_ptr, ms_type, r_idx, DICE_DIV);
-    char dmg_str[80], dice_str[sizeof(dmg_str) + 10];
     char *tmp = lore_ptr->tmp_msg[lore_ptr->vn];
-    dice_to_string(base_damage, dice_num, dice_side, dice_mult, dice_div, dmg_str);
-    sprintf(dice_str, "(%s)", dmg_str);
+    size_t tmpsz = sizeof(lore_ptr->tmp_msg[lore_ptr->vn]);
 
     if (know_armour(r_idx, lore_ptr->know_everything)) {
-        sprintf(tmp, msg, dice_str);
+        int base_damage = monspell_race_damage(player_ptr, ms_type, r_idx, BASE_DAM);
+        int dice_num = monspell_race_damage(player_ptr, ms_type, r_idx, DICE_NUM);
+        int dice_side = monspell_race_damage(player_ptr, ms_type, r_idx, DICE_SIDE);
+        int dice_mult = monspell_race_damage(player_ptr, ms_type, r_idx, DICE_MULT);
+        int dice_div = monspell_race_damage(player_ptr, ms_type, r_idx, DICE_DIV);
+        char dmg_str[80] = "(";
+        dice_to_string(base_damage, dice_num, dice_side, dice_mult, dice_div, dmg_str + 1);
+        angband_strcat(dmg_str, ")", sizeof(dmg_str));
+        strnfmt(tmp, tmpsz, msg, dmg_str);
     } else {
-        sprintf(tmp, msg, "");
+        tmp[0] = '\0';
     }
 }
 

--- a/src/main-cap.cpp
+++ b/src/main-cap.cpp
@@ -4,6 +4,7 @@
 
 #include "io/exit-panic.h"
 #include "system/angband.h"
+#include "term/z-form.h"
 
 #ifdef USE_CAP
 
@@ -255,7 +256,7 @@ static void do_cs(int y1, int y2)
 
 #ifdef USE_HARDCODE
     char temp[64];
-    sprintf(temp, cs, y1, y2);
+    strnfmt(temp, sizeof(temp), cs, y1, y2);
     tp(temp);
 #endif
 }
@@ -274,7 +275,7 @@ static void do_cm(int x, int y)
 
 #ifdef USE_HARDCODE
     char temp[64];
-    sprintf(temp, cm, y + 1, x + 1);
+    strnfmt(temp, sizeof(temp), cm, y + 1, x + 1);
     tp(temp);
 #endif
 }

--- a/src/main-gcu.cpp
+++ b/src/main-gcu.cpp
@@ -597,16 +597,16 @@ static bool init_sound(void)
     }
 
     int i;
-    char wav[128];
     char buf[1024];
 
     /* Prepare the sounds */
     for (i = 1; i < SOUND_MAX; i++) {
         /* Extract name of sound file */
-        sprintf(wav, "%s.wav", angband_sound_name[i]);
+        std::string wav = angband_sound_name[i];
+        wav.append(".wav");
 
         /* Access the sound */
-        path_build(buf, sizeof(buf), ANGBAND_DIR_XTRA_SOUND, wav);
+        path_build(buf, sizeof(buf), ANGBAND_DIR_XTRA_SOUND, wav.data());
 
         /* Save the sound filename, if it exists */
         if (check_file(buf)) {
@@ -875,8 +875,6 @@ static errr game_term_xtra_gcu_event(int v)
  */
 static errr game_term_xtra_gcu_sound(int v)
 {
-    char buf[1024];
-
     /* Sound disabled */
     if (!use_sound) {
         return 1;
@@ -892,11 +890,9 @@ static errr game_term_xtra_gcu_sound(int v)
         return 1;
     }
 
-    sprintf(buf, "./gcusound.sh %s\n", sound_file[v]);
-
-    return system(buf) < 0;
-
-    return 0;
+    std::string buf = "./gcusound.sh ";
+    buf.append(sound_file[v]).append("\n");
+    return system(buf.data()) < 0;
 }
 
 static int scale_color(int i, int j, int scale)

--- a/src/main-x11.cpp
+++ b/src/main-x11.cpp
@@ -102,6 +102,7 @@
 #include "system/system-variables.h"
 #include "term/gameterm.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
@@ -1166,9 +1167,9 @@ static void react_keypress(XKeyEvent *xev)
     }
 
     if (ks) {
-        sprintf(msg, "%c%s%s%s%s_%lX%c", 31, mc ? "N" : "", ms ? "S" : "", mo ? "O" : "", mx ? "M" : "", (unsigned long)(ks), 13);
+        strnfmt(msg, sizeof(msg), "%c%s%s%s%s_%lX%c", 31, mc ? "N" : "", ms ? "S" : "", mo ? "O" : "", mx ? "M" : "", (unsigned long)(ks), 13);
     } else {
-        sprintf(msg, "%c%s%s%s%sK_%X%c", 31, mc ? "N" : "", ms ? "S" : "", mo ? "O" : "", mx ? "M" : "", ev->keycode, 13);
+        strnfmt(msg, sizeof(msg), "%c%s%s%s%sK_%X%c", 31, mc ? "N" : "", ms ? "S" : "", mo ? "O" : "", mx ? "M" : "", ev->keycode, 13);
     }
 
     send_keys(msg);
@@ -1799,13 +1800,13 @@ static bool check_file(concptr s)
 static void init_sound(void)
 {
     int i;
-    char wav[128];
     char buf[1024];
     char dir_xtra_sound[1024];
     path_build(dir_xtra_sound, sizeof(dir_xtra_sound), ANGBAND_DIR_XTRA, "sound");
     for (i = 1; i < SOUND_MAX; i++) {
-        sprintf(wav, "%s.wav", angband_sound_name[i]);
-        path_build(buf, sizeof(buf), dir_xtra_sound, wav);
+        std::string wav = angband_sound_name[i];
+        wav.append(".wav");
+        path_build(buf, sizeof(buf), dir_xtra_sound, wav.data());
         if (check_file(buf)) {
             sound_file[i] = string_make(buf);
         }
@@ -1820,7 +1821,6 @@ static void init_sound(void)
  */
 static errr game_term_xtra_x11_sound(int v)
 {
-    char buf[1024];
     if (!use_sound) {
         return 1;
     }
@@ -1831,8 +1831,9 @@ static errr game_term_xtra_x11_sound(int v)
         return 1;
     }
 
-    sprintf(buf, "./playwave.sh %s\n", sound_file[v]);
-    return system(buf) < 0;
+    std::string buf = "./playwave.sh ";
+    buf.append(sound_file[v]).append("\n");
+    return system(buf.data()) < 0;
 }
 
 /*
@@ -2193,8 +2194,6 @@ static errr term_data_init(term_data *td, int i)
 
     int wid, hgt, num;
 
-    char buf[80];
-
     concptr str;
 
     int val;
@@ -2209,8 +2208,7 @@ static errr term_data_init(term_data *td, int i)
     XWMHints *wh;
 #endif
 
-    sprintf(buf, "ANGBAND_X11_FONT_%d", i);
-    font = getenv(buf);
+    font = getenv(format("ANGBAND_X11_FONT_%d", i));
     if (!font) {
         font = getenv("ANGBAND_X11_FONT");
     }
@@ -2247,23 +2245,19 @@ static errr term_data_init(term_data *td, int i)
         }
     }
 
-    sprintf(buf, "ANGBAND_X11_AT_X_%d", i);
-    str = getenv(buf);
+    str = getenv(format("ANGBAND_X11_AT_X_%d", i));
     x = (str != nullptr) ? atoi(str) : -1;
 
-    sprintf(buf, "ANGBAND_X11_AT_Y_%d", i);
-    str = getenv(buf);
+    str = getenv(format("ANGBAND_X11_AT_Y_%d", i));
     y = (str != nullptr) ? atoi(str) : -1;
 
-    sprintf(buf, "ANGBAND_X11_COLS_%d", i);
-    str = getenv(buf);
+    str = getenv(format("ANGBAND_X11_COLS_%d", i));
     val = (str != nullptr) ? atoi(str) : -1;
     if (val > 0) {
         cols = val;
     }
 
-    sprintf(buf, "ANGBAND_X11_ROWS_%d", i);
-    str = getenv(buf);
+    str = getenv(format("ANGBAND_X11_ROWS_%d", i));
     val = (str != nullptr) ? atoi(str) : -1;
     if (val > 0) {
         rows = val;
@@ -2278,15 +2272,13 @@ static errr term_data_init(term_data *td, int i)
         }
     }
 
-    sprintf(buf, "ANGBAND_X11_IBOX_%d", i);
-    str = getenv(buf);
+    str = getenv(format("ANGBAND_X11_IBOX_%d", i));
     val = (str != nullptr) ? atoi(str) : -1;
     if (val > 0) {
         ox = val;
     }
 
-    sprintf(buf, "ANGBAND_X11_IBOY_%d", i);
-    str = getenv(buf);
+    str = getenv(format("ANGBAND_X11_IBOY_%d", i));
     val = (str != nullptr) ? atoi(str) : -1;
     if (val > 0) {
         oy = val;

--- a/src/main/angband-initializer.cpp
+++ b/src/main/angband-initializer.cpp
@@ -182,9 +182,9 @@ static void init_note_no_term(concptr str)
  * functions are "supposed" to work under any conditions.
  * </pre>
  */
-static void init_angband_aux(concptr why)
+static void init_angband_aux(const std::string &why)
 {
-    plog(why);
+    plog(why.data());
     plog(_("'lib'ディレクトリが存在しないか壊れているようです。", "The 'lib' directory is probably missing or broken."));
     plog(_("ひょっとするとアーカイブが正しく解凍されていないのかもしれません。", "The 'lib' directory is probably missing or broken."));
     plog(_("該当する'README'ファイルを読んで確認してみて下さい。", "See the 'README' file for more information."));
@@ -218,8 +218,9 @@ void init_angband(PlayerType *player_ptr, bool no_term)
     path_build(buf, sizeof(buf), ANGBAND_DIR_FILE, _("news_j.txt", "news.txt"));
     int fd = fd_open(buf, O_RDONLY);
     if (fd < 0) {
-        char why[sizeof(buf) + 128];
-        sprintf(why, _("'%s'ファイルにアクセスできません!", "Cannot access the '%s' file!"), buf);
+        std::string why = _("'", "Cannot access the '");
+        why.append(buf);
+        why.append(_("'ファイルにアクセスできません!", "' file!"));
         init_angband_aux(why);
     }
 
@@ -251,8 +252,9 @@ void init_angband(PlayerType *player_ptr, bool no_term)
         fd = fd_make(buf, file_permission);
         safe_setuid_drop();
         if (fd < 0) {
-            char why[sizeof(buf) + 128];
-            sprintf(why, _("'%s'ファイルを作成できません!", "Cannot create the '%s' file!"), buf);
+            std::string why = _("'", "Cannot create the '");
+            why.append(buf);
+            why.append(_("'ファイルを作成できません!", "' file!"));
             init_angband_aux(why);
         }
     }
@@ -341,9 +343,7 @@ void init_angband(PlayerType *player_ptr, bool no_term)
     init_note(_("[データの初期化中... (アロケーション)]", "[Initializing arrays... (alloc)]"));
     init_alloc();
     init_note(_("[ユーザー設定ファイルを初期化しています...]", "[Initializing user pref files...]"));
-    strcpy(buf, "pref.prf");
-    process_pref_file(player_ptr, buf);
-    sprintf(buf, "pref-%s.prf", ANGBAND_SYS);
-    process_pref_file(player_ptr, buf);
+    process_pref_file(player_ptr, "pref.prf");
+    process_pref_file(player_ptr, std::string("pref-").append(ANGBAND_SYS).append(".prf").data());
     init_note(_("[初期化終了]", "[Initialization complete]"));
 }

--- a/src/market/arena.cpp
+++ b/src/market/arena.cpp
@@ -25,6 +25,7 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 #include "world/world.h"
@@ -267,7 +268,7 @@ bool monster_arena_comm(PlayerType *player_ptr)
 {
     PRICE maxbet;
     PRICE wager;
-    char out_val[MAX_MONSTER_NAME], tmp_str[80];
+    char out_val[MAX_MONSTER_NAME];
     concptr p;
 
     if ((w_ptr->game_turn - w_ptr->arena_start_turn) > TURNS_PER_TICK * 250) {
@@ -289,14 +290,10 @@ bool monster_arena_comm(PlayerType *player_ptr)
 
     prt(_("モンスター                                                     倍率", "Monsters                                                       Odds"), 4, 4);
     for (int i = 0; i < 4; i++) {
-        char buf[MAX_MONSTER_NAME];
         auto *r_ptr = &monraces_info[battle_mon_list[i]];
-
-        sprintf(buf, _("%d) %-58s  %4ld.%02ld倍", "%d) %-58s  %4ld.%02ld"), i + 1,
-            _(format("%s%s", r_ptr->name.data(), r_ptr->kind_flags.has(MonsterKindType::UNIQUE) ? "もどき" : "      "),
-                format("%s%s", r_ptr->kind_flags.has(MonsterKindType::UNIQUE) ? "Fake " : "", r_ptr->name.data())),
-            (long int)mon_odds[i] / 100, (long int)mon_odds[i] % 100);
-        prt(buf, 5 + i, 1);
+        std::string name = _(r_ptr->name, r_ptr->kind_flags.has(MonsterKindType::UNIQUE) ? "Fake " : "");
+        name.append(_(r_ptr->kind_flags.has(MonsterKindType::UNIQUE) ? "もどき" : "      ", r_ptr->name));
+        prt(format(_("%d) %-58s  %4ld.%02ld倍", "%d) %-58s  %4ld.%02ld"), i + 1, name.data(), (long int)mon_odds[i] / 100, (long int)mon_odds[i] % 100), 5 + i, 1);
     }
 
     prt(_("どれに賭けますか:", "Which monster: "), 0, 0);
@@ -331,15 +328,13 @@ bool monster_arena_comm(PlayerType *player_ptr)
     /* We can't bet more than we have */
     maxbet = std::min(maxbet, player_ptr->au);
 
-    /* Get the wager */
-    strcpy(out_val, "");
-    sprintf(tmp_str, _("賭け金 (1-%ld)？", "Your wager (1-%ld) ? "), (long int)maxbet);
-
     /*
+     * Get the wager
      * Use get_string() because we may need more than
      * the int16_t value returned by get_quantity().
      */
-    if (!get_string(tmp_str, out_val, 32)) {
+    out_val[0] = '\0';
+    if (!get_string(format(_("賭け金 (1-%ld)？", "Your wager (1-%ld) ? "), (long int)maxbet), out_val, 32)) {
         screen_load();
         return false;
     }

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -34,6 +34,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "world/world.h"
@@ -55,10 +56,8 @@ bool exchange_cash(PlayerType *player_ptr)
         const auto r_idx_of_item = static_cast<MonsterRaceId>(o_ptr->pval);
 
         if ((o_ptr->bi_key.tval() == ItemKindType::CAPTURE) && (r_idx_of_item == MonsterRaceId::TSUCHINOKO)) {
-            char buf[MAX_NLEN + 32];
             describe_flavor(player_ptr, o_name, o_ptr, 0);
-            sprintf(buf, _("%s を換金しますか？", "Convert %s into money? "), o_name);
-            if (get_check(buf)) {
+            if (get_check(format(_("%s を換金しますか？", "Convert %s into money? "), o_name))) {
                 msg_format(_("賞金 %ld＄を手に入れた。", "You get %ldgp."), (long int)(1000000L * o_ptr->number));
                 player_ptr->au += 1000000L * o_ptr->number;
                 player_ptr->redraw |= (PR_GOLD);
@@ -74,10 +73,8 @@ bool exchange_cash(PlayerType *player_ptr)
         const auto r_idx_of_item = static_cast<MonsterRaceId>(o_ptr->pval);
 
         if (o_ptr->bi_key == BaseitemKey(ItemKindType::CORPSE, SV_CORPSE) && (r_idx_of_item == MonsterRaceId::TSUCHINOKO)) {
-            char buf[MAX_NLEN + 32];
             describe_flavor(player_ptr, o_name, o_ptr, 0);
-            sprintf(buf, _("%s を換金しますか？", "Convert %s into money? "), o_name);
-            if (get_check(buf)) {
+            if (get_check(format(_("%s を換金しますか？", "Convert %s into money? "), o_name))) {
                 msg_format(_("賞金 %ld＄を手に入れた。", "You get %ldgp."), (long int)(200000L * o_ptr->number));
                 player_ptr->au += 200000L * o_ptr->number;
                 player_ptr->redraw |= (PR_GOLD);
@@ -93,10 +90,8 @@ bool exchange_cash(PlayerType *player_ptr)
         const auto r_idx_of_item = static_cast<MonsterRaceId>(o_ptr->pval);
 
         if (o_ptr->bi_key == BaseitemKey(ItemKindType::CORPSE, SV_SKELETON) && (r_idx_of_item == MonsterRaceId::TSUCHINOKO)) {
-            char buf[MAX_NLEN + 32];
             describe_flavor(player_ptr, o_name, o_ptr, 0);
-            sprintf(buf, _("%s を換金しますか？", "Convert %s into money? "), o_name);
-            if (get_check(buf)) {
+            if (get_check(format(_("%s を換金しますか？", "Convert %s into money? "), o_name))) {
                 msg_format(_("賞金 %ld＄を手に入れた。", "You get %ldgp."), (long int)(100000L * o_ptr->number));
                 player_ptr->au += 100000L * o_ptr->number;
                 player_ptr->redraw |= (PR_GOLD);
@@ -112,10 +107,8 @@ bool exchange_cash(PlayerType *player_ptr)
         const auto r_idx_of_item = static_cast<MonsterRaceId>(o_ptr->pval);
 
         if (o_ptr->bi_key == BaseitemKey(ItemKindType::CORPSE, SV_CORPSE) && (streq(monraces_info[r_idx_of_item].name.data(), monraces_info[w_ptr->today_mon].name.data()))) {
-            char buf[MAX_NLEN + 32];
             describe_flavor(player_ptr, o_name, o_ptr, 0);
-            sprintf(buf, _("%s を換金しますか？", "Convert %s into money? "), o_name);
-            if (get_check(buf)) {
+            if (get_check(format(_("%s を換金しますか？", "Convert %s into money? "), o_name))) {
                 msg_format(
                     _("賞金 %ld＄を手に入れた。", "You get %ldgp."), (long int)((monraces_info[w_ptr->today_mon].level * 50 + 100) * o_ptr->number));
                 player_ptr->au += (monraces_info[w_ptr->today_mon].level * 50 + 100) * o_ptr->number;
@@ -132,10 +125,8 @@ bool exchange_cash(PlayerType *player_ptr)
         const auto r_idx_of_item = static_cast<MonsterRaceId>(o_ptr->pval);
 
         if (o_ptr->bi_key == BaseitemKey(ItemKindType::CORPSE, SV_SKELETON) && (streq(monraces_info[r_idx_of_item].name.data(), monraces_info[w_ptr->today_mon].name.data()))) {
-            char buf[MAX_NLEN + 32];
             describe_flavor(player_ptr, o_name, o_ptr, 0);
-            sprintf(buf, _("%s を換金しますか？", "Convert %s into money? "), o_name);
-            if (get_check(buf)) {
+            if (get_check(format(_("%s を換金しますか？", "Convert %s into money? "), o_name))) {
                 msg_format(_("賞金 %ld＄を手に入れた。", "You get %ldgp."), (long int)((monraces_info[w_ptr->today_mon].level * 30 + 60) * o_ptr->number));
                 player_ptr->au += (monraces_info[w_ptr->today_mon].level * 30 + 60) * o_ptr->number;
                 player_ptr->redraw |= (PR_GOLD);
@@ -159,13 +150,11 @@ bool exchange_cash(PlayerType *player_ptr)
                 continue;
             }
 
-            char buf[MAX_NLEN + 20];
             INVENTORY_IDX item_new;
             ItemEntity forge;
 
             describe_flavor(player_ptr, o_name, o_ptr, 0);
-            sprintf(buf, _("%sを渡しますか？", "Hand %s over? "), o_name);
-            if (!get_check(buf)) {
+            if (!get_check(format(_("%sを渡しますか？", "Hand %s over? "), o_name))) {
                 continue;
             }
 
@@ -214,17 +203,13 @@ bool exchange_cash(PlayerType *player_ptr)
  */
 void today_target(PlayerType *player_ptr)
 {
-    char buf[160];
     auto *r_ptr = &monraces_info[w_ptr->today_mon];
 
     clear_bldg(4, 18);
     c_put_str(TERM_YELLOW, _("本日の賞金首", "Wanted monster that changes from day to day"), 5, 10);
-    sprintf(buf, _("ターゲット： %s", "target: %s"), r_ptr->name.data());
-    c_put_str(TERM_YELLOW, buf, 6, 10);
-    sprintf(buf, _("死体 ---- $%d", "corpse   ---- $%d"), (int)r_ptr->level * 50 + 100);
-    prt(buf, 8, 10);
-    sprintf(buf, _("骨   ---- $%d", "skeleton ---- $%d"), (int)r_ptr->level * 30 + 60);
-    prt(buf, 9, 10);
+    c_put_str(TERM_YELLOW, format(_("ターゲット： %s", "target: %s"), r_ptr->name.data()), 6, 10);
+    prt(format(_("死体 ---- $%d", "corpse   ---- $%d"), (int)r_ptr->level * 50 + 100), 8, 10);
+    prt(format(_("骨   ---- $%d", "skeleton ---- $%d"), (int)r_ptr->level * 30 + 60), 9, 10);
     player_ptr->knows_daily_bounty = true;
 }
 

--- a/src/market/building-craft-weapon.cpp
+++ b/src/market/building-craft-weapon.cpp
@@ -23,6 +23,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "world/world.h"
@@ -99,11 +100,9 @@ static uint32_t calc_expect_dice(
 static void show_weapon_dmg(int r, int c, int mindice, int maxdice, int blows, int dam_bonus, concptr attr, byte color)
 {
     c_put_str(color, attr, r, c);
-    GAME_TEXT tmp_str[80];
     int mindam = blows * (mindice + dam_bonus);
     int maxdam = blows * (maxdice + dam_bonus);
-    sprintf(tmp_str, _("１ターン: %d-%d ダメージ", "Attack: %d-%d damage"), mindam, maxdam);
-    put_str(tmp_str, r, c + 8);
+    put_str(format(_("１ターン: %d-%d ダメージ", "Attack: %d-%d damage"), mindam, maxdam), r, c + 8);
 }
 
 /*!
@@ -312,7 +311,6 @@ static void compare_weapon_aux(PlayerType *player_ptr, ItemEntity *o_ptr, int co
 static void list_weapon(PlayerType *player_ptr, ItemEntity *o_ptr, TERM_LEN row, TERM_LEN col)
 {
     GAME_TEXT o_name[MAX_NLEN];
-    GAME_TEXT tmp_str[80];
 
     DICE_NUMBER eff_dd = o_ptr->dd + player_ptr->to_dd[0];
     DICE_SID eff_ds = o_ptr->ds + player_ptr->to_ds[0];
@@ -320,23 +318,27 @@ static void list_weapon(PlayerType *player_ptr, ItemEntity *o_ptr, TERM_LEN row,
 
     describe_flavor(player_ptr, o_name, o_ptr, OD_NAME_ONLY);
     c_put_str(TERM_YELLOW, o_name, row, col);
-    sprintf(tmp_str, _("攻撃回数: %d", "Number of Blows: %d"), player_ptr->num_blow[0]);
-    put_str(tmp_str, row + 1, col);
+    put_str(format(_("攻撃回数: %d", "Number of Blows: %d"), player_ptr->num_blow[0]), row + 1, col);
 
-    sprintf(tmp_str, _("命中率:  0  50 100 150 200 (敵のAC)", "To Hit:  0  50 100 150 200 (AC)"));
-    put_str(tmp_str, row + 2, col);
-    sprintf(tmp_str, "        %2d  %2d  %2d  %2d  %2d (%%)", (int)hit_chance(player_ptr, hit_reliability, 0), (int)hit_chance(player_ptr, hit_reliability, 50),
-        (int)hit_chance(player_ptr, hit_reliability, 100), (int)hit_chance(player_ptr, hit_reliability, 150), (int)hit_chance(player_ptr, hit_reliability, 200));
-    put_str(tmp_str, row + 3, col);
+    put_str(_("命中率:  0  50 100 150 200 (敵のAC)", "To Hit:  0  50 100 150 200 (AC)"), row + 2, col);
+    put_str(format("        %2d  %2d  %2d  %2d  %2d (%%)",
+                (int)hit_chance(player_ptr, hit_reliability, 0),
+                (int)hit_chance(player_ptr, hit_reliability, 50),
+                (int)hit_chance(player_ptr, hit_reliability, 100),
+                (int)hit_chance(player_ptr, hit_reliability, 150),
+                (int)hit_chance(player_ptr, hit_reliability, 200)),
+        row + 3, col);
     c_put_str(TERM_YELLOW, _("可能なダメージ:", "Possible Damage:"), row + 5, col);
 
-    sprintf(tmp_str, _("攻撃一回につき %d-%d", "One Strike: %d-%d damage"), (int)(eff_dd + o_ptr->to_d + player_ptr->to_d[0]),
-        (int)(eff_ds * eff_dd + o_ptr->to_d + player_ptr->to_d[0]));
-    put_str(tmp_str, row + 6, col + 1);
+    put_str(format(_("攻撃一回につき %d-%d", "One Strike: %d-%d damage"),
+                (int)(eff_dd + o_ptr->to_d + player_ptr->to_d[0]),
+                (int)(eff_ds * eff_dd + o_ptr->to_d + player_ptr->to_d[0])),
+        row + 6, col + 1);
 
-    sprintf(tmp_str, _("１ターンにつき %d-%d", "One Attack: %d-%d damage"), (int)(player_ptr->num_blow[0] * (eff_dd + o_ptr->to_d + player_ptr->to_d[0])),
-        (int)(player_ptr->num_blow[0] * (eff_ds * eff_dd + o_ptr->to_d + player_ptr->to_d[0])));
-    put_str(tmp_str, row + 7, col + 1);
+    put_str(format(_("１ターンにつき %d-%d", "One Attack: %d-%d damage"),
+                (int)(player_ptr->num_blow[0] * (eff_dd + o_ptr->to_d + player_ptr->to_d[0])),
+                (int)(player_ptr->num_blow[0] * (eff_ds * eff_dd + o_ptr->to_d + player_ptr->to_d[0]))),
+        row + 7, col + 1);
 }
 
 /*!

--- a/src/market/building-monster.cpp
+++ b/src/market/building-monster.cpp
@@ -11,6 +11,7 @@
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
 #include "util/sort.h"
 #include "util/string-processor.h"
@@ -24,7 +25,6 @@
  */
 bool research_mon(PlayerType *player_ptr)
 {
-    char buf[256];
     bool notpicked;
     bool recall = false;
     uint16_t why = 0;
@@ -54,15 +54,16 @@ bool research_mon(PlayerType *player_ptr)
     }
 
     /* XTRA HACK WHATSEARCH */
+    std::string buf;
     if (sym == KTRL('A')) {
         all = true;
-        strcpy(buf, _("全モンスターのリスト", "Full monster list."));
+        buf = _("全モンスターのリスト", "Full monster list.");
     } else if (sym == KTRL('U')) {
         all = uniq = true;
-        strcpy(buf, _("ユニーク・モンスターのリスト", "Unique monster list."));
+        buf = _("ユニーク・モンスターのリスト", "Unique monster list.");
     } else if (sym == KTRL('N')) {
         all = norm = true;
-        strcpy(buf, _("ユニーク外モンスターのリスト", "Non-unique monster list."));
+        buf = _("ユニーク外モンスターのリスト", "Non-unique monster list.");
     } else if (sym == KTRL('M')) {
         all = true;
         if (!get_string(_("名前(英語の場合小文字で可)", "Enter name:"), temp, 70)) {
@@ -72,15 +73,15 @@ bool research_mon(PlayerType *player_ptr)
             return false;
         }
 
-        sprintf(buf, _("名前:%sにマッチ", "Monsters' names with \"%s\""), temp);
+        buf = format(_("名前:%sにマッチ", "Monsters' names with \"%s\""), temp);
     } else if (ident_info[ident_i]) {
-        sprintf(buf, "%c - %s.", sym, ident_info[ident_i] + 2);
+        buf = format("%c - %s.", sym, ident_info[ident_i] + 2);
     } else {
-        sprintf(buf, "%c - %s", sym, _("無効な文字", "Unknown Symbol"));
+        buf = format("%c - %s", sym, _("無効な文字", "Unknown Symbol"));
     }
 
     /* Display the result */
-    prt(buf, 16, 10);
+    prt(buf.data(), 16, 10);
 
     /* Allocate the "who" array */
     std::vector<MonsterRaceId> who;
@@ -117,22 +118,17 @@ bool research_mon(PlayerType *player_ptr)
                 }
             }
 
-            char temp2[MAX_MONSTER_NAME];
-#ifdef JP
-            strcpy(temp2, r_ref.E_name.data());
-#else
-            strcpy(temp2, r_ref.name.data());
-#endif
-            for (int xx = 0; temp2[xx] && xx < 80; xx++) {
+            std::string temp2 = _(r_ref.E_name, r_ref.name);
+            for (std::string::size_type xx = 0; xx < temp2.length(); xx++) {
                 if (isupper(temp2[xx])) {
                     temp2[xx] = (char)tolower(temp2[xx]);
                 }
             }
 
 #ifdef JP
-            if (angband_strstr(temp2, temp) || angband_strstr(r_ref.name.data(), temp))
+            if (angband_strstr(temp2.data(), temp) || angband_strstr(r_ref.name.data(), temp))
 #else
-            if (angband_strstr(temp2, temp))
+            if (angband_strstr(temp2.data(), temp))
 #endif
                 who.push_back(r_ref.idx);
         } else if (all || (r_ref.d_char == sym)) {

--- a/src/market/building-quest.cpp
+++ b/src/market/building-quest.cpp
@@ -13,6 +13,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "view/display-messages.h"
 
 /*!
@@ -48,15 +49,13 @@ static void get_questinfo(PlayerType *player_ptr, QuestId questnum, bool do_init
  * @param questnum クエストのID
  * @param do_init クエストの開始処理か(true)、結果処理か(FALSE)
  */
-void print_questinfo(PlayerType *player_ptr, QuestId questnum, bool do_init)
+static void print_questinfo(PlayerType *player_ptr, QuestId questnum, bool do_init)
 {
     get_questinfo(player_ptr, questnum, do_init);
 
     const auto &quest_list = QuestList::get_instance();
     const auto *q_ptr = &quest_list[questnum];
-    GAME_TEXT tmp_str[80];
-    sprintf(tmp_str, _("クエスト情報 (危険度: %d 階相当)", "Quest Information (Danger level: %d)"), (int)q_ptr->level);
-    prt(tmp_str, 5, 0);
+    prt(format(_("クエスト情報 (危険度: %d 階相当)", "Quest Information (Danger level: %d)"), (int)q_ptr->level), 5, 0);
     prt(q_ptr->name, 7, 0);
 
     for (int i = 0; i < 10; i++) {

--- a/src/market/building-service.cpp
+++ b/src/market/building-service.cpp
@@ -6,6 +6,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/enum-converter.h"
 
 /*!
@@ -81,69 +82,61 @@ bool is_member(PlayerType *player_ptr, building_type *bldg)
  */
 void display_buikding_service(PlayerType *player_ptr, building_type *bldg)
 {
-    char buff[20];
     byte action_color;
-    char tmp_str[80];
 
     term_clear();
-    sprintf(tmp_str, "%s (%s) %35s", bldg->owner_name, bldg->owner_race, bldg->name);
-    prt(tmp_str, 2, 1);
+    prt(format("%s (%s) %35s", bldg->owner_name, bldg->owner_race, bldg->name), 2, 1);
 
     for (int i = 0; i < 8; i++) {
         if (!bldg->letters[i]) {
             continue;
         }
 
+        std::string buff;
         if (bldg->action_restr[i] == 0) {
             if ((is_owner(player_ptr, bldg) && (bldg->member_costs[i] == 0)) || (!is_owner(player_ptr, bldg) && (bldg->other_costs[i] == 0))) {
                 action_color = TERM_WHITE;
-                buff[0] = '\0';
             } else if (is_owner(player_ptr, bldg)) {
                 action_color = TERM_YELLOW;
-                sprintf(buff, _("($%ld)", "(%ldgp)"), (long int)bldg->member_costs[i]);
+                buff = format(_("($%ld)", "(%ldgp)"), (long int)bldg->member_costs[i]);
             } else {
                 action_color = TERM_YELLOW;
-                sprintf(buff, _("($%ld)", "(%ldgp)"), (long int)bldg->other_costs[i]);
+                buff = format(_("($%ld)", "(%ldgp)"), (long int)bldg->other_costs[i]);
             }
 
-            sprintf(tmp_str, " %c) %s %s", bldg->letters[i], bldg->act_names[i], buff);
-            c_put_str(action_color, tmp_str, 19 + (i / 2), 35 * (i % 2));
+            c_put_str(action_color, format(" %c) %s %s", bldg->letters[i], bldg->act_names[i], buff.data()), 19 + (i / 2), 35 * (i % 2));
             continue;
         }
 
         if (bldg->action_restr[i] == 1) {
             if (!is_member(player_ptr, bldg)) {
                 action_color = TERM_L_DARK;
-                strcpy(buff, _("(閉店)", "(closed)"));
+                buff = _("(閉店)", "(closed)");
             } else if ((is_owner(player_ptr, bldg) && (bldg->member_costs[i] == 0)) || (is_member(player_ptr, bldg) && (bldg->other_costs[i] == 0))) {
                 action_color = TERM_WHITE;
-                buff[0] = '\0';
             } else if (is_owner(player_ptr, bldg)) {
                 action_color = TERM_YELLOW;
-                sprintf(buff, _("($%ld)", "(%ldgp)"), (long int)bldg->member_costs[i]);
+                buff = format(_("($%ld)", "(%ldgp)"), (long int)bldg->member_costs[i]);
             } else {
                 action_color = TERM_YELLOW;
-                sprintf(buff, _("($%ld)", "(%ldgp)"), (long int)bldg->other_costs[i]);
+                buff = format(_("($%ld)", "(%ldgp)"), (long int)bldg->other_costs[i]);
             }
 
-            sprintf(tmp_str, " %c) %s %s", bldg->letters[i], bldg->act_names[i], buff);
-            c_put_str(action_color, tmp_str, 19 + (i / 2), 35 * (i % 2));
+            c_put_str(action_color, format(" %c) %s %s", bldg->letters[i], bldg->act_names[i], buff.data()), 19 + (i / 2), 35 * (i % 2));
             continue;
         }
 
         if (!is_owner(player_ptr, bldg)) {
             action_color = TERM_L_DARK;
-            strcpy(buff, _("(閉店)", "(closed)"));
+            buff = _("(閉店)", "(closed)");
         } else if (bldg->member_costs[i] != 0) {
             action_color = TERM_YELLOW;
-            sprintf(buff, _("($%ld)", "(%ldgp)"), (long int)bldg->member_costs[i]);
+            buff = format(_("($%ld)", "(%ldgp)"), (long int)bldg->member_costs[i]);
         } else {
             action_color = TERM_WHITE;
-            buff[0] = '\0';
         }
 
-        sprintf(tmp_str, " %c) %s %s", bldg->letters[i], bldg->act_names[i], buff);
-        c_put_str(action_color, tmp_str, 19 + (i / 2), 35 * (i % 2));
+        c_put_str(action_color, format(" %c) %s %s", bldg->letters[i], bldg->act_names[i], buff.data()), 19 + (i / 2), 35 * (i % 2));
     }
 
     prt(_(" ESC) 建物を出る", " ESC) Exit building"), 23, 0);

--- a/src/market/building-util.cpp
+++ b/src/market/building-util.cpp
@@ -1,6 +1,7 @@
 ﻿#include "market/building-util.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 
 /*!
  * @brief コンソールに表示された施設に関する情報を消去する / Clear the building information
@@ -21,8 +22,6 @@ void clear_bldg(int min_row, int max_row)
  */
 void building_prt_gold(PlayerType *player_ptr)
 {
-    char tmp_str[80];
     prt(_("手持ちのお金: ", "Gold Remaining: "), 23, 53);
-    sprintf(tmp_str, "%9ld", (long)player_ptr->au);
-    prt(tmp_str, 23, 68);
+    prt(format("%9ld", (long)player_ptr->au), 23, 68);
 }

--- a/src/market/play-gamble.cpp
+++ b/src/market/play-gamble.cpp
@@ -9,6 +9,8 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
+#include "util/string-processor.h"
 #include "view/display-fruit.h"
 #include "view/display-messages.h"
 
@@ -26,7 +28,7 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
     int32_t maxbet;
     int32_t oldgold;
 
-    char out_val[160], tmp_str[80], again;
+    char out_val[160] = "", again;
     concptr p;
 
     screen_save();
@@ -48,14 +50,11 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
     maxbet = player_ptr->lev * 200;
     maxbet = std::min(maxbet, player_ptr->au);
 
-    strcpy(out_val, "");
-    sprintf(tmp_str, _("賭け金 (1-%ld)？", "Your wager (1-%ld) ? "), (long int)maxbet);
-
     /*
      * Use get_string() because we may need more than
      * the int16_t value returned by get_quantity().
      */
-    if (!get_string(tmp_str, out_val, 32)) {
+    if (!get_string(format(_("賭け金 (1-%ld)？", "Your wager (1-%ld) ? "), (long int)maxbet), out_val, 32)) {
         msg_print(nullptr);
         screen_load();
         return true;
@@ -83,10 +82,8 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
     odds = 0;
     oldgold = player_ptr->au;
 
-    sprintf(tmp_str, _("ゲーム前の所持金: %9ld", "Gold before game: %9ld"), (long int)oldgold);
-    prt(tmp_str, 20, 2);
-    sprintf(tmp_str, _("現在の掛け金:     %9ld", "Current Wager:    %9ld"), (long int)wager);
-    prt(tmp_str, 21, 2);
+    prt(format(_("ゲーム前の所持金: %9ld", "Gold before game: %9ld"), (long int)oldgold), 20, 2);
+    prt(format(_("現在の掛け金:     %9ld", "Current Wager:    %9ld"), (long int)wager), 21, 2);
 
     do {
         player_ptr->au -= wager;
@@ -99,12 +96,10 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
             roll1 = randint1(10);
             roll2 = randint1(10);
             choice = randint1(10);
-            sprintf(tmp_str, _("黒ダイス: %d        黒ダイス: %d", "Black die: %d       Black Die: %d"), roll1, roll2);
 
-            prt(tmp_str, 8, 3);
-            sprintf(tmp_str, _("赤ダイス: %d", "Red die: %d"), choice);
+            prt(format(_("黒ダイス: %d        黒ダイス: %d", "Black die: %d       Black Die: %d"), roll1, roll2), 8, 3);
 
-            prt(tmp_str, 11, 14);
+            prt(format(_("赤ダイス: %d", "Red die: %d"), choice), 11, 14);
             if (((choice > roll1) && (choice < roll2)) || ((choice < roll1) && (choice > roll2))) {
                 win = 1;
             }
@@ -118,8 +113,7 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
             roll2 = randint1(6);
             roll3 = roll1 + roll2;
             choice = roll3;
-            sprintf(tmp_str, _("１振りめ: %d %d      Total: %d", "First roll: %d %d    Total: %d"), roll1, roll2, roll3);
-            prt(tmp_str, 7, 5);
+            prt(format(_("１振りめ: %d %d      Total: %d", "First roll: %d %d    Total: %d"), roll1, roll2, roll3), 7, 5);
             if ((roll3 == 7) || (roll3 == 11)) {
                 win = 1;
             } else if ((roll3 == 2) || (roll3 == 3) || (roll3 == 12)) {
@@ -132,8 +126,7 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
                     roll1 = randint1(6);
                     roll2 = randint1(6);
                     roll3 = roll1 + roll2;
-                    sprintf(tmp_str, _("出目: %d %d          合計:      %d", "Roll result: %d %d   Total:     %d"), roll1, roll2, roll3);
-                    prt(tmp_str, 8, 5);
+                    prt(format(_("出目: %d %d          合計:      %d", "Roll result: %d %d   Total:     %d"), roll1, roll2, roll3), 8, 5);
                     if (roll3 == choice) {
                         win = 1;
                     } else if (roll3 == 7) {
@@ -167,8 +160,7 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
             }
             msg_print(nullptr);
             roll1 = randint0(10);
-            sprintf(tmp_str, _("ルーレットは回り、止まった。勝者は %d番だ。", "The wheel spins to a stop and the winner is %d"), roll1);
-            prt(tmp_str, 13, 3);
+            prt(format(_("ルーレットは回り、止まった。勝>者は %d番だ。", "The wheel spins to a stop and the winner is %d"), roll1), 13, 3);
             prt("", 9, 0);
             prt("*", 9, (3 * roll1 + 5));
             if (roll1 == choice) {
@@ -256,17 +248,14 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
             prt(_("あなたの勝ち", "YOU WON"), 16, 37);
 
             player_ptr->au += odds * wager;
-            sprintf(tmp_str, _("倍率: %d", "Payoff: %d"), odds);
 
-            prt(tmp_str, 17, 37);
+            prt(format(_("倍率: %d", "Payoff: %d"), odds), 17, 37);
         } else {
             prt(_("あなたの負け", "You Lost"), 16, 37);
             prt("", 17, 37);
         }
 
-        sprintf(tmp_str, _("現在の所持金:     %9ld", "Current Gold:     %9ld"), (long int)player_ptr->au);
-
-        prt(tmp_str, 22, 2);
+        prt(format(_("現在の所持金:     %9ld", "Current Gold:     %9ld"), (long int)player_ptr->au), 22, 2);
         prt(_("もう一度(Y/N)？", "Again(Y/N)?"), 18, 37);
 
         move_cursor(18, 52);

--- a/src/mind/mind-monk.cpp
+++ b/src/mind/mind-monk.cpp
@@ -11,6 +11,7 @@
 #include "status/action-setter.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 
@@ -44,7 +45,7 @@ bool choose_monk_stance(PlayerType *player_ptr)
     for (auto i = 0U; i < monk_stances.size(); i++) {
         if (player_ptr->lev >= monk_stances[i].min_level) {
             char buf[80];
-            sprintf(buf, " %c) %-12s  %s", I2A(i + 1), monk_stances[i].desc, monk_stances[i].info);
+            strnfmt(buf, sizeof(buf), " %c) %-12s  %s", I2A(i + 1), monk_stances[i].desc, monk_stances[i].info);
             prt(buf, 3 + i, 20);
         }
     }

--- a/src/mind/mind-power-getter.cpp
+++ b/src/mind/mind-power-getter.cpp
@@ -16,6 +16,7 @@
 #include "player/player-status-table.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "timed-effect/player-stun.h"
 #include "timed-effect/timed-effects.h"
 #include "util/enum-converter.h"
@@ -256,21 +257,20 @@ void MindPowerGetter::display_each_mind_chance()
         calculate_mind_chance(has_weapon);
         char comment[80];
         mindcraft_info(this->player_ptr, comment, this->use_mind, this->index);
-        char psi_desc[80];
+        std::string psi_desc;
         if (use_menu) {
             if (this->index == (this->menu_line - 1)) {
-                strcpy(psi_desc, _("  》 ", "  >  "));
+                psi_desc = _("  》 ", "  >  ");
             } else {
-                strcpy(psi_desc, "     ");
+                psi_desc = "     ";
             }
         } else {
-            sprintf(psi_desc, "  %c) ", I2A(this->index));
+            psi_desc = format("  %c) ", I2A(this->index));
         }
 
-        strcat(psi_desc,
-            format("%-30s%2d %4d%s %3d%%%s", this->spell->name, this->spell->min_lev, mana_cost,
-                (((this->use_mind == MindKindType::MINDCRAFTER) && (this->index == 13)) ? _("～", "~ ") : "  "), chance, comment));
-        prt(psi_desc, y + this->index + 1, x);
+        psi_desc.append(format("%-30s%2d %4d%s %3d%%%s", this->spell->name, this->spell->min_lev, mana_cost,
+            (((this->use_mind == MindKindType::MINDCRAFTER) && (this->index == 13)) ? _("～", "~ ") : "  "), chance, comment));
+        prt(psi_desc.data(), y + this->index + 1, x);
     }
 }
 

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -36,6 +36,7 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "timed-effect/player-cut.h"
 #include "timed-effect/player-fear.h"
 #include "timed-effect/player-stun.h"
@@ -396,7 +397,7 @@ bool choose_samurai_stance(PlayerType *player_ptr)
     prt(_(" a) 型を崩す", " a) No Form"), 2, 20);
     for (auto i = 0U; i < samurai_stances.size(); i++) {
         if (player_ptr->lev >= samurai_stances[i].min_level) {
-            sprintf(buf, _(" %c) %sの型    %s", " %c) Stance of %-12s  %s"), I2A(i + 1), samurai_stances[i].desc, samurai_stances[i].info);
+            strnfmt(buf, sizeof(buf), _(" %c) %sの型    %s", " %c) Stance of %-12s  %s"), I2A(i + 1), samurai_stances[i].desc, samurai_stances[i].info);
             prt(buf, 3 + i, 20);
         }
     }

--- a/src/mind/mind-sniper.cpp
+++ b/src/mind/mind-sniper.cpp
@@ -35,6 +35,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/buffer-shaper.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
@@ -214,13 +215,10 @@ void display_snipe_list(PlayerType *player_ptr)
             continue;
         }
 
-        sprintf(psi_desc, "  %c) %-30s%2d %4d", I2A(i), spell.name, spell.min_lev, spell.mana_cost);
+        strnfmt(psi_desc, sizeof(psi_desc), "  %c) %-30s%2d %4d", I2A(i), spell.name, spell.min_lev, spell.mana_cost);
 
-        if (spell.mana_cost > sniper_data->concent) {
-            term_putstr(x, y + i + 1, -1, TERM_SLATE, psi_desc);
-        } else {
-            term_putstr(x, y + i + 1, -1, TERM_WHITE, psi_desc);
-        }
+        TERM_COLOR tcol = (spell.mana_cost > sniper_data->concent) ? TERM_SLATE : TERM_WHITE;
+        term_putstr(x, y + i + 1, -1, tcol, psi_desc);
     }
 }
 
@@ -302,8 +300,6 @@ static int get_snipe_power(PlayerType *player_ptr, COMMAND_CODE *sn, bool only_b
         if ((choice == ' ') || (choice == '*') || (choice == '?')) {
             /* Show the list */
             if (!redraw) {
-                char psi_index[6];
-                char psi_desc[75];
                 redraw = true;
                 if (!only_browse) {
                     screen_save();
@@ -324,21 +320,12 @@ static int get_snipe_power(PlayerType *player_ptr, COMMAND_CODE *sn, bool only_b
 
                     /* Dump the spell --(-- */
                     if (spell.min_lev > plev) {
-                        sprintf(psi_index, "   ) ");
-                    } else {
-                        sprintf(psi_index, "  %c) ", I2A(i));
-                    }
-
-                    sprintf(psi_desc, "%-30s%2d %4d", spell.name, spell.min_lev, spell.mana_cost);
-
-                    if (spell.min_lev > plev) {
                         tcol = TERM_SLATE;
                     } else if (spell.mana_cost > sniper_data->concent) {
                         tcol = TERM_L_BLUE;
                     }
-
-                    term_putstr(x, y + i + 1, -1, tcol, psi_index);
-                    term_putstr(x + 5, y + i + 1, -1, tcol, psi_desc);
+                    term_putstr(x, y + i + 1, -1, tcol, (spell.min_lev > plev) ? "   ) " : format("  %c) ", I2A(i)));
+                    term_putstr(x + 5, y + i + 1, -1, tcol, format("%-30s%2d %4d", spell.name, spell.min_lev, spell.mana_cost));
                 }
 
                 /* Clear the bottom line */

--- a/src/mind/mind-weaponsmith.cpp
+++ b/src/mind/mind-weaponsmith.cpp
@@ -23,9 +23,11 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/bit-flags-calculator.h"
 #include "util/buffer-shaper.h"
 #include "util/int-char-converter.h"
+#include "util/string-processor.h"
 #include "view/display-messages.h"
 #include <algorithm>
 #include <sstream>
@@ -471,14 +473,12 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
             }
             o_ptr->pval = 1;
         } else if (o_ptr->pval == 0) {
-            char tmp[80];
             char tmp_val[8];
             auto limit = std::min(5, smith.get_addable_count(effect, o_ptr));
 
-            sprintf(tmp, _("いくつ付加しますか？ (1-%d): ", "Enchant how many? (1-%d): "), limit);
-            strcpy(tmp_val, "1");
+            angband_strcpy(tmp_val, "1", sizeof(tmp_val));
 
-            if (!get_string(tmp, tmp_val, 1)) {
+            if (!get_string(format(_("いくつ付加しますか？ (1-%d): ", "Enchant how many? (1-%d): "), limit), tmp_val, 1)) {
                 return;
             }
             o_ptr->pval = static_cast<PARAMETER_VALUE>(std::clamp(atoi(tmp_val), 1, limit));

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -155,9 +155,7 @@ bool MonsterDamageProcessor::process_dead_exp_virtue(concptr note, MonsterEntity
     AvatarChanger ac(player_ptr, m_ptr);
     ac.change_virtue();
     if (r_ref.kind_flags.has(MonsterKindType::UNIQUE) && record_destroy_uniq) {
-        char note_buf[160];
-        sprintf(note_buf, "%s%s", r_ref.name.data(), m_ptr->mflag2.has(MonsterConstantFlagType::CLONED) ? _("(クローン)", "(Clone)") : "");
-        exe_write_diary(this->player_ptr, DIARY_UNIQUE, 0, note_buf);
+        exe_write_diary(this->player_ptr, DIARY_UNIQUE, 0, std::string(r_ref.name).append(m_ptr->mflag2.has(MonsterConstantFlagType::CLONED) ? _("(クローン)", "(Clone)") : "").data());
     }
 
     sound(SOUND_KILL);

--- a/src/monster/monster-describer.cpp
+++ b/src/monster/monster-describer.cpp
@@ -225,9 +225,9 @@ void monster_desc(PlayerType *player_ptr, char *desc, MonsterEntity *m_ptr, BIT_
     }
 
     if (m_ptr->nickname) {
-        char buf[128];
-        sprintf(buf, _("「%s」", " called %s"), quark_str(m_ptr->nickname));
-        strcat(desc, buf);
+        std::string buf = _("「", " called ");
+        buf.append(quark_str(m_ptr->nickname)).append(_("」", ""));
+        strcat(desc, buf.data());
     }
 
     if (player_ptr->riding && (&floor_ptr->m_list[player_ptr->riding] == m_ptr)) {

--- a/src/object/object-info.cpp
+++ b/src/object/object-info.cpp
@@ -37,28 +37,27 @@
 /*!
  * @brief オブジェクトの発動効果名称を返す（サブルーチン/ブレス）
  * @param o_ptr 名称を取得する元のオブジェクト構造体参照ポインタ
- * @return concptr 発動名称を返す文字列ポインタ
+ * @return std::string 発動名称を返す文字列ポインタ
  */
-static concptr item_activation_dragon_breath(ItemEntity *o_ptr)
+static std::string item_activation_dragon_breath(ItemEntity *o_ptr)
 {
-    static char desc[256];
+    std::string desc = _("", "breathe ");
     int n = 0;
 
     auto flgs = object_flags(o_ptr);
-    strcpy(desc, _("", "breathe "));
 
     for (int i = 0; dragonbreath_info[i].flag != 0; i++) {
         if (flgs.has(dragonbreath_info[i].flag)) {
             if (n > 0) {
-                strcat(desc, _("、", ", "));
+                desc.append(_("、", ", "));
             }
 
-            strcat(desc, dragonbreath_info[i].name);
+            desc.append(dragonbreath_info[i].name);
             n++;
         }
     }
 
-    strcat(desc, _("のブレス(250)", " (250)"));
+    desc.append(_("のブレス(250)", " (250)"));
     return desc;
 }
 
@@ -69,8 +68,7 @@ static concptr item_activation_dragon_breath(ItemEntity *o_ptr)
  */
 static concptr item_activation_aux(ItemEntity *o_ptr)
 {
-    static char activation_detail[512];
-    char timeout[64];
+    static std::string activation_detail;
     auto tmp_act_ptr = find_activation_info(o_ptr);
     if (!tmp_act_ptr.has_value()) {
         return _("未定義", "something undefined");
@@ -78,6 +76,7 @@ static concptr item_activation_aux(ItemEntity *o_ptr)
 
     auto *act_ptr = tmp_act_ptr.value();
     concptr desc = act_ptr->desc;
+    std::string dragon_breath;
     switch (act_ptr->index) {
     case RandomArtActType::NONE:
         break;
@@ -92,7 +91,8 @@ static concptr item_activation_aux(ItemEntity *o_ptr)
         }
         break;
     case RandomArtActType::BR_DRAGON:
-        desc = item_activation_dragon_breath(o_ptr);
+        dragon_breath = item_activation_dragon_breath(o_ptr);
+        desc = dragon_breath.data();
         break;
     case RandomArtActType::AGGRAVATE:
         if (o_ptr->is_specific_artifact(FixedArtifactId::HYOUSIGI)) {
@@ -134,40 +134,48 @@ static concptr item_activation_aux(ItemEntity *o_ptr)
     }
 
     /* Timeout description */
+    std::string timeout;
     int constant = act_ptr->timeout.constant;
     int dice = act_ptr->timeout.dice;
     if (constant == 0 && dice == 0) {
         /* We can activate it every turn */
-        strcpy(timeout, _("いつでも", "every turn"));
+        timeout = _("いつでも", "every turn");
     } else if (constant < 0) {
         /* Activations that have special timeout */
         switch (act_ptr->index) {
         case RandomArtActType::BR_FIRE:
-            sprintf(timeout, _("%d ターン毎", "every %d turns"), o_ptr->bi_key == BaseitemKey(ItemKindType::RING, SV_RING_FLAMES) ? 200 : 250);
+            timeout.append(_("", "every ")).append(std::to_string(o_ptr->bi_key == BaseitemKey(ItemKindType::RING, SV_RING_FLAMES) ? 200 : 250)).append(_(" ターン毎", " turns"));
             break;
         case RandomArtActType::BR_COLD:
-            sprintf(timeout, _("%d ターン毎", "every %d turns"), o_ptr->bi_key == BaseitemKey(ItemKindType::RING, SV_RING_ICE) ? 200 : 250);
+            timeout.append(_("", "every ")).append(std::to_string(o_ptr->bi_key == BaseitemKey(ItemKindType::RING, SV_RING_ICE) ? 200 : 250)).append(_(" ターン毎", " turns"));
             break;
         case RandomArtActType::TERROR:
-            strcpy(timeout, _("3*(レベル+10) ターン毎", "every 3 * (level+10) turns"));
+            timeout = _("3*(レベル+10) ターン毎", "every 3 * (level+10) turns");
             break;
         case RandomArtActType::MURAMASA:
-            strcpy(timeout, _("確率50%で壊れる", "(destroyed 50%)"));
+            timeout = _("確率50%で壊れる", "(destroyed 50%)");
             break;
         default:
-            strcpy(timeout, "undefined");
+            timeout = "undefined";
             break;
         }
     } else {
-        char constant_str[16], dice_str[16];
-        sprintf(constant_str, "%d", constant);
-        sprintf(dice_str, "d%d", dice);
-        sprintf(timeout, _("%s%s%s ターン毎", "every %s%s%s turns"), (constant > 0) ? constant_str : "", (constant > 0 && dice > 0) ? "+" : "",
-            (dice > 0) ? dice_str : "");
+        timeout.append(_("", "every "));
+        if (constant > 0) {
+            timeout.append(std::to_string(constant));
+            if (dice > 0) {
+                timeout.append("+");
+            }
+        }
+        if (dice > 0) {
+            timeout.append("d").append(std::to_string(dice));
+        }
+        timeout.append(_(" ターン毎", " turns"));
     }
 
-    sprintf(activation_detail, _("%s : %s", "%s %s"), desc, timeout);
-    return activation_detail;
+    activation_detail = desc;
+    activation_detail.append(_(" : ", " ")).append(timeout);
+    return activation_detail.data();
 }
 
 /*!

--- a/src/perception/identification.cpp
+++ b/src/perception/identification.cpp
@@ -39,7 +39,6 @@ bool screen_object(PlayerType *player_ptr, ItemEntity *o_ptr, BIT_FLAGS mode)
     char temp[70 * 20];
     concptr info[128];
     GAME_TEXT o_name[MAX_NLEN];
-    char desc[256];
 
     int trivial_info = 0;
     auto flgs = object_flags(o_ptr);
@@ -145,21 +144,25 @@ bool screen_object(PlayerType *player_ptr, ItemEntity *o_ptr, BIT_FLAGS mode)
         rad++;
     }
 
+    std::string desc;
     if (flgs.has(TR_LITE_FUEL) && flgs.has_not(TR_DARK_SOURCE)) {
         if (rad > 0) {
-            sprintf(desc, _("それは燃料補給によって明かり(半径 %d)を授ける。", "It provides light (radius %d) when fueled."), (int)rad);
+            desc = _("それは燃料補給によって明かり(半径 ", "It provides light (radius ");
+            desc.append(std::to_string((int)rad)).append(_(")を授ける。", ") when fueled."));
         }
     } else {
         if (rad > 0) {
-            sprintf(desc, _("それは永遠なる明かり(半径 %d)を授ける。", "It provides light (radius %d) forever."), (int)rad);
+            desc = _("それは永遠なる明かり(半径 ", "It provides light (radius ");
+            desc.append(std::to_string((int)rad)).append(_(")を授ける。", ") forever."));
         }
         if (rad < 0) {
-            sprintf(desc, _("それは明かりの半径を狭める(半径に-%d)。", "It decreases the radius of your light by %d."), (int)-rad);
+            desc = _("それは明かりの半径を狭める(半径に-", "It decreases the radius of your light by");
+            desc.append(std::to_string((int)-rad)).append(_(")。", "."));
         }
     }
 
     if (rad != 0) {
-        info[i++] = desc;
+        info[i++] = desc.data();
     }
 
     if (o_ptr->ego_idx == EgoType::LITE_LONG) {

--- a/src/player-info/race-ability-info.cpp
+++ b/src/player-info/race-ability-info.cpp
@@ -1,6 +1,7 @@
 ﻿#include "player-info/race-ability-info.h"
 #include "player-info/self-info-util.h"
 #include "system/player-type-definition.h"
+#include "term/z-form.h"
 
 /*!
  * @brief レイシャルパワーの説明文を表示する
@@ -84,7 +85,7 @@ void set_race_ability_info(PlayerType *player_ptr, self_info_type *self_ptr)
         break;
     case PlayerRaceType::CYCLOPS:
         if (player_ptr->lev >= 20) {
-            sprintf(self_ptr->plev_buf, _("あなたは %d ダメージの岩石を投げることができる。(15 MP)", "You can throw a boulder, dam. %d (cost 15)."),
+            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージの岩石を投げることができる。(15 MP)", "You can throw a boulder, dam. %d (cost 15)."),
                 (3 * player_ptr->lev) / 2);
             self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
         }
@@ -98,15 +99,15 @@ void set_race_ability_info(PlayerType *player_ptr, self_info_type *self_ptr)
         break;
     case PlayerRaceType::KLACKON:
         if (player_ptr->lev >= 9) {
-            sprintf(
-                self_ptr->plev_buf, _("あなたは %d ダメージの酸を吹きかけることができる。(9 MP)", "You can spit acid, dam. %d (cost 9)."), player_ptr->lev);
+            strnfmt(
+                self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージの酸を吹きかけることができる。(9 MP)", "You can spit acid, dam. %d (cost 9)."), player_ptr->lev);
             self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
         }
 
         break;
     case PlayerRaceType::KOBOLD:
         if (player_ptr->lev >= 12) {
-            sprintf(self_ptr->plev_buf, _("あなたは %d ダメージの毒矢を投げることができる。(8 MP)", "You can throw a dart of poison, dam. %d (cost 8)."),
+            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージの毒矢を投げることができる。(8 MP)", "You can throw a dart of poison, dam. %d (cost 8)."),
                 player_ptr->lev);
             self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
         }
@@ -114,20 +115,20 @@ void set_race_ability_info(PlayerType *player_ptr, self_info_type *self_ptr)
         break;
     case PlayerRaceType::DARK_ELF:
         if (player_ptr->lev >= 2) {
-            sprintf(self_ptr->plev_buf, _("あなたは %d ダメージのマジック・ミサイルの呪文を使える。(2 MP)", "You can cast a Magic Missile, dam %d (cost 2)."),
+            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージのマジック・ミサイルの呪文を使える。(2 MP)", "You can cast a Magic Missile, dam %d (cost 2)."),
                 (3 + ((player_ptr->lev - 1) / 5)));
             self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
         }
 
         break;
     case PlayerRaceType::DRACONIAN:
-        sprintf(self_ptr->plev_buf, _("あなたは %d ダメージのブレスを吐くことができる。(%d MP)", "You can breathe, dam. %d (cost %d)."), 2 * player_ptr->lev,
+        strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージのブレスを吐くことができる。(%d MP)", "You can breathe, dam. %d (cost %d)."), 2 * player_ptr->lev,
             player_ptr->lev);
         self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
         break;
     case PlayerRaceType::MIND_FLAYER:
         if (player_ptr->lev >= 15) {
-            sprintf(self_ptr->plev_buf, _("あなたは %d ダメージの精神攻撃をすることができる。(12 MP)", "You can mind blast your enemies, dam %d (cost 12)."),
+            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージの精神攻撃をすることができる。(12 MP)", "You can mind blast your enemies, dam %d (cost 12)."),
                 player_ptr->lev);
         }
 
@@ -135,14 +136,14 @@ void set_race_ability_info(PlayerType *player_ptr, self_info_type *self_ptr)
         break;
     case PlayerRaceType::IMP:
         if (player_ptr->lev >= 30) {
-            sprintf(self_ptr->plev_buf, _("あなたは %d ダメージのファイア・ボールの呪文を使える。(15 MP)", "You can cast a Fire Ball, dam. %d (cost 15)."),
+            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージのファイア・ボールの呪文を使える。(15 MP)", "You can cast a Fire Ball, dam. %d (cost 15)."),
                 player_ptr->lev);
             self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
             break;
         }
 
         if (player_ptr->lev >= 9) {
-            sprintf(self_ptr->plev_buf, _("あなたは %d ダメージのファイア・ボルトの呪文を使える。(15 MP)", "You can cast a Fire Bolt, dam. %d (cost 15)."),
+            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージのファイア・ボルトの呪文を使える。(15 MP)", "You can cast a Fire Bolt, dam. %d (cost 15)."),
                 player_ptr->lev);
             self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
         }
@@ -166,7 +167,7 @@ void set_race_ability_info(PlayerType *player_ptr, self_info_type *self_ptr)
             break;
         }
 
-        sprintf(self_ptr->plev_buf, _("あなたは敵から %d HP の生命力を吸収できる。(%d MP)", "You can steal life from a foe, dam. %d (cost %d)."),
+        strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは敵から %d HP の生命力を吸収できる。(%d MP)", "You can steal life from a foe, dam. %d (cost %d)."),
             player_ptr->lev * 2, 1 + (player_ptr->lev / 3));
         self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
         break;
@@ -183,7 +184,7 @@ void set_race_ability_info(PlayerType *player_ptr, self_info_type *self_ptr)
 
         break;
     case PlayerRaceType::BALROG:
-        sprintf(self_ptr->plev_buf, _("あなたは %d ダメージの地獄か火炎のブレスを吐くことができる。(%d MP)", "You can breathe nether, dam. %d (cost %d)."),
+        strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージの地獄か火炎のブレスを吐くことができる。(%d MP)", "You can breathe nether, dam. %d (cost %d)."),
             3 * player_ptr->lev, 10 + player_ptr->lev / 3);
         self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
         break;
@@ -195,20 +196,20 @@ void set_race_ability_info(PlayerType *player_ptr, self_info_type *self_ptr)
         break;
     case PlayerRaceType::ANDROID:
         if (player_ptr->lev < 10) {
-            sprintf(self_ptr->plev_buf, _("あなたは %d ダメージのレイガンを撃つことができる。(7 MP)", "You can fire a ray gun with damage %d (cost 7)."),
+            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージのレイガンを撃つことができる。(7 MP)", "You can fire a ray gun with damage %d (cost 7)."),
                 (player_ptr->lev + 1) / 2);
         } else if (player_ptr->lev < 25) {
-            sprintf(self_ptr->plev_buf, _("あなたは %d ダメージのブラスターを撃つことができる。(13 MP)", "You can fire a blaster with damage %d (cost 13)."),
+            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージのブラスターを撃つことができる。(13 MP)", "You can fire a blaster with damage %d (cost 13)."),
                 player_ptr->lev);
         } else if (player_ptr->lev < 35) {
-            sprintf(self_ptr->plev_buf, _("あなたは %d ダメージのバズーカを撃つことができる。(26 MP)", "You can fire a bazooka with damage %d (cost 26)."),
+            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージのバズーカを撃つことができる。(26 MP)", "You can fire a bazooka with damage %d (cost 26)."),
                 player_ptr->lev * 2);
         } else if (player_ptr->lev < 45) {
-            sprintf(self_ptr->plev_buf,
+            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf),
                 _("あなたは %d ダメージのビームキャノンを撃つことができる。(40 MP)", "You can fire a beam cannon with damage %d (cost 40)."),
                 player_ptr->lev * 2);
         } else {
-            sprintf(self_ptr->plev_buf, _("あなたは %d ダメージのロケットを撃つことができる。(60 MP)", "You can fire a rocket with damage %d (cost 60)."),
+            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージのロケットを撃つことができる。(60 MP)", "You can fire a rocket with damage %d (cost 60)."),
                 player_ptr->lev * 5);
         }
 

--- a/src/player-info/self-info.cpp
+++ b/src/player-info/self-info.cpp
@@ -28,6 +28,7 @@
 #include "player/player-status.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "timed-effect/player-blindness.h"
 #include "timed-effect/player-confusion.h"
 #include "timed-effect/player-cut.h"
@@ -436,7 +437,7 @@ void report_magics(PlayerType *player_ptr)
     int k = 2;
     char buf[80];
     for (int j = 0; j < i; j++) {
-        sprintf(buf, _("%-28s : 期間 - %s ", "%s %s."), info[j], report_magic_durations[info2[j]]);
+        strnfmt(buf, sizeof(buf), _("%-28s : 期間 - %s ", "%s %s."), info[j], report_magic_durations[info2[j]]);
         prt(buf, k++, 15);
 
         /* Every 20 entries (lines 2 to 21), start over */

--- a/src/player/eldritch-horror.cpp
+++ b/src/player/eldritch-horror.cpp
@@ -152,7 +152,7 @@ void sanity_blast(PlayerType *player_ptr, MonsterEntity *m_ptr, bool necro)
         }
     } else if (!necro) {
         MonsterRaceInfo *r_ptr;
-        GAME_TEXT m_name[MAX_NLEN];
+        std::string m_name;
         concptr desc;
         get_mon_num_prep(player_ptr, get_nightmare, nullptr);
         r_ptr = &monraces_info[get_mon_num(player_ptr, 0, MAX_DEPTH, 0)];
@@ -163,10 +163,10 @@ void sanity_blast(PlayerType *player_ptr, MonsterEntity *m_ptr, bool necro)
 #else
 
         if (r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE)) {
-            sprintf(m_name, "%s %s", (is_a_vowel(desc[0]) ? "an" : "a"), desc);
-        } else
+            m_name = (is_a_vowel(desc[0])) ? "an " : "a ";
+        }
 #endif
-        sprintf(m_name, "%s", desc);
+        m_name.append(desc);
 
         if (r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE)) {
             if (r_ptr->flags1 & RF1_FRIENDS) {
@@ -177,12 +177,12 @@ void sanity_blast(PlayerType *player_ptr, MonsterEntity *m_ptr, bool necro)
         }
 
         if (saving_throw(player_ptr->skill_sav * 100 / power)) {
-            msg_format(_("夢の中で%sに追いかけられた。", "%^s chases you through your dreams."), m_name);
+            msg_format(_("夢の中で%sに追いかけられた。", "%^s chases you through your dreams."), m_name.data());
             return;
         }
 
         if (player_ptr->effects()->hallucination()->is_hallucinated()) {
-            msg_format(_("%s%sの顔を見てしまった！", "You behold the %s visage of %s!"), funny_desc[randint0(MAX_SAN_FUNNY)], m_name);
+            msg_format(_("%s%sの顔を見てしまった！", "You behold the %s visage of %s!"), funny_desc[randint0(MAX_SAN_FUNNY)], m_name.data());
             if (one_in_(3)) {
                 msg_print(funny_comments[randint0(MAX_SAN_COMMENT)]);
                 BadStatusSetter(player_ptr).mod_hallucination(randint1(r_ptr->level));

--- a/src/player/patron.cpp
+++ b/src/player/patron.cpp
@@ -143,7 +143,6 @@ Patron::Patron(const char *name, std::vector<patron_reward> reward_table, player
 void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
 {
     this->player_ptr = player_ptr_;
-    char wrath_reason[32] = "";
     int nasty_chance = 6;
     int type;
     patron_reward effect;
@@ -183,7 +182,8 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
     }
     type--;
 
-    sprintf(wrath_reason, _("%sの怒り", "the Wrath of %s"), this->name.data());
+    std::string wrath_reason = _(this->name, "the Wrath of ");
+    wrath_reason.append(_("%sの怒り", ""));
 
     effect = this->reward_table[type];
 
@@ -375,7 +375,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             msg_print(_("「苦しむがよい、無能な愚か者よ！」", "'Suffer, pathetic fool!'"));
 
             fire_ball(player_ptr, AttributeType::DISINTEGRATE, 0, this->player_ptr->lev * 4, 4);
-            take_hit(player_ptr, DAMAGE_NOESCAPE, this->player_ptr->lev * 4, wrath_reason);
+            take_hit(player_ptr, DAMAGE_NOESCAPE, this->player_ptr->lev * 4, wrath_reason.data());
             reward = _("分解の球が発生した。", "generating disintegration ball");
             break;
 
@@ -476,7 +476,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             msg_format(_("%sの声が轟き渡った:", "The voice of %s thunders:"), this->name.data());
             msg_print(_("「死ぬがよい、下僕よ！」", "'Die, mortal!'"));
 
-            take_hit(player_ptr, DAMAGE_LOSELIFE, this->player_ptr->lev * 4, wrath_reason);
+            take_hit(player_ptr, DAMAGE_LOSELIFE, this->player_ptr->lev * 4, wrath_reason.data());
             for (int stat = 0; stat < A_MAX; stat++) {
                 (void)dec_stat(player_ptr, stat, 10 + randint1(15), false);
             }

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -297,7 +297,6 @@ int take_hit(PlayerType *player_ptr, int damage_type, int damage, concptr hit_fr
     int old_chp = player_ptr->chp;
 
     char death_message[1024];
-    char tmp[1024];
 
     int warning = (player_ptr->mhp * hitpoint_warn / 10);
     if (player_ptr->is_dead) {
@@ -580,8 +579,7 @@ int take_hit(PlayerType *player_ptr, int damage_type, int damage, concptr hit_fr
                 hit_from = _("何か", "something");
             }
 
-            sprintf(tmp, _("%sによってピンチに陥った。", "was in a critical situation because of %s."), hit_from);
-            exe_write_diary(player_ptr, DIARY_DESCRIPTION, 0, tmp);
+            exe_write_diary(player_ptr, DIARY_DESCRIPTION, 0, std::string(_(hit_from, "was in a critical situation because of ")).append(_("によってピンチに陥った。", ".")).data());
         }
 
         if (auto_more) {

--- a/src/player/process-death.cpp
+++ b/src/player/process-death.cpp
@@ -42,172 +42,155 @@
  * Centers a string within a GRAVE_LINE_WIDTH character string		-JWT-
  * @details
  */
-static void center_string(char *buf, concptr str)
+static std::string center_string(const std::string &str)
 {
-    int i = strlen(str);
-    int j = GRAVE_LINE_WIDTH / 2 - i / 2;
-    (void)sprintf(buf, "%*s%s%*s", j, "", str, GRAVE_LINE_WIDTH - i - j, "");
+    int j = GRAVE_LINE_WIDTH / 2 - str.length() / 2;
+    return std::string().append(j, ' ').append(str).append(GRAVE_LINE_WIDTH - str.length() - j, ' ');
 }
 
 /*!
  * @brief 墓に基本情報を表示
  * @param player_ptr プレイヤーへの参照ポインタ
- * @param buf 墓テンプレ
  */
-static void show_basic_params(PlayerType *player_ptr, char *buf)
+static void show_basic_params(PlayerType *player_ptr)
 {
-    char tomb_message[160];
-    (void)sprintf(tomb_message, _("レベル: %d", "Level: %d"), (int)player_ptr->lev);
-    center_string(buf, tomb_message);
-    put_str(buf, 11, 11);
+    put_str(center_string(format(_("レベル: %d", "Level: %d"), (int)player_ptr->lev)).data(), 11, 11);
 
-    (void)sprintf(tomb_message, _("経験値: %ld", "Exp: %ld"), (long)player_ptr->exp);
-    center_string(buf, tomb_message);
-    put_str(buf, 12, 11);
+    put_str(center_string(format(_("経験値: %ld", "Exp: %ld"), (long)player_ptr->exp)).data(), 12, 11);
 
-    (void)sprintf(tomb_message, _("所持金: %ld", "AU: %ld"), (long)player_ptr->au);
-    center_string(buf, tomb_message);
-    put_str(buf, 13, 11);
+    put_str(center_string(format(_("所持金: %ld", "AU: %ld"), (long)player_ptr->au)).data(), 13, 11);
 }
 
 #ifdef JP
 /*!
  * @brief プレイヤーを殺したモンスターを表示する (日本語版専用)
  * @param player_ptr プレイヤーへの参照ポインタ
- * @param buf 墓テンプレ
- * @param tomb_message 墓碑に刻む言葉
- * @return 追加の行数
+ * @return メッセージと余分な行数のペア
  */
-static int show_killing_monster(PlayerType *player_ptr, char *buf, char *tomb_message, size_t tomb_message_size)
+static std::pair<std::string, int> show_killing_monster(PlayerType *player_ptr)
 {
-    shape_buffer(player_ptr->died_from.data(), GRAVE_LINE_WIDTH + 1, tomb_message, tomb_message_size);
-    char *t;
-    t = tomb_message + strlen(tomb_message) + 1;
+    char buf[160];
+    shape_buffer(player_ptr->died_from.data(), GRAVE_LINE_WIDTH + 1, buf, sizeof(buf));
+    char *t = buf + strlen(buf) + 1;
     if (!*t) {
-        return 0;
+        return std::pair<std::string, int>(buf, 0);
     }
 
-    char killer[MAX_MONSTER_NAME];
-    strcpy(killer, t); /* 2nd line */
+    std::string killer = t; /* 2nd line */
     if (*(t + strlen(t) + 1)) /* Does 3rd line exist? */
     {
-        for (t = killer + strlen(killer) - 2; iskanji(*(t - 1)); t--) { /* Loop */
-            ;
+        auto i = killer.length() - 2;
+        while (iskanji(killer[i - 1])) {
+            --i;
         }
-        strcpy(t, "…");
-    } else if (angband_strstr(tomb_message, "『") && suffix(killer, "』")) {
-        char killer2[MAX_MONSTER_NAME];
-        char *name_head = angband_strstr(tomb_message, "『");
-        sprintf(killer2, "%s%s", name_head, killer);
-        if (strlen(killer2) <= GRAVE_LINE_WIDTH) {
-            strcpy(killer, killer2);
-            *name_head = '\0';
-        }
-    } else if (angband_strstr(tomb_message, "「") && suffix(killer, "」")) {
-        char killer2[MAX_MONSTER_NAME];
-        char *name_head = angband_strstr(tomb_message, "「");
-        sprintf(killer2, "%s%s", name_head, killer);
-        if (strlen(killer2) <= GRAVE_LINE_WIDTH) {
-            strcpy(killer, killer2);
-            *name_head = '\0';
+        killer.erase(i);
+        killer.append("…");
+    } else {
+        char *name_head = angband_strstr(buf, "『");
+
+        if (name_head && suffix(killer.data(), "』")) {
+            std::string killer2 = name_head;
+            killer2.append(killer);
+            if (killer2.length() <= GRAVE_LINE_WIDTH) {
+                killer = killer2;
+                *name_head = '\0';
+            }
+        } else {
+            name_head = angband_strstr(buf, "「");
+            if (name_head && suffix(killer, "」")) {
+                std::string killer2 = name_head;
+                killer2.append(killer);
+                if (killer2.length() <= GRAVE_LINE_WIDTH) {
+                    killer = killer2;
+                    *name_head = '\0';
+                }
+            }
         }
     }
 
-    center_string(buf, killer);
-    put_str(buf, 15, 11);
-    return 1;
+    put_str(center_string(killer).data(), 15, 11);
+    return std::pair<std::string, int>(buf, 1);
 }
 
 /*!
  * @brief どこで死んだかを表示する (日本語版専用)
  * @param player_ptr プレイヤーへの参照ポインタ
- * @param buf 墓テンプレ
- * @param tomb_message 表示する文字列
  * @param extra_line 追加の行数
  */
-static void show_dead_place(PlayerType *player_ptr, char *buf, char *tomb_message, int extra_line)
+static void show_dead_place(PlayerType *player_ptr, int extra_line)
 {
     if (streq(player_ptr->died_from, "ripe") || streq(player_ptr->died_from, "Seppuku")) {
         return;
     }
 
+    std::string place;
     if (player_ptr->current_floor_ptr->dun_level == 0) {
         concptr field_name = player_ptr->town_num ? "街" : "荒野";
         if (streq(player_ptr->died_from, "途中終了")) {
-            sprintf(tomb_message, "%sで死んだ", field_name);
+            place = format("%sで死んだ", field_name);
         } else {
-            sprintf(tomb_message, "に%sで殺された", field_name);
+            place = format("に%sで殺された", field_name);
         }
+    } else if (streq(player_ptr->died_from, "途中終了")) {
+        place = format("地下 %d 階で死んだ", (int)player_ptr->current_floor_ptr->dun_level);
     } else {
-        if (streq(player_ptr->died_from, "途中終了")) {
-            sprintf(tomb_message, "地下 %d 階で死んだ", (int)player_ptr->current_floor_ptr->dun_level);
-        } else {
-            sprintf(tomb_message, "に地下 %d 階で殺された", (int)player_ptr->current_floor_ptr->dun_level);
-        }
+        place = format("に地下 %d 階で殺された", (int)player_ptr->current_floor_ptr->dun_level);
     }
 
-    center_string(buf, tomb_message);
-    put_str(buf, 15 + extra_line, 11);
+    put_str(center_string(place).data(), 15 + extra_line, 11);
 }
 
 /*!
  * @brief 墓に刻む言葉を細かく表示 (日本語版専用)
  * @param player_ptr プレイヤーへの参照ポインタ
- * @param buf 墓テンプレ
  */
-static void show_tomb_detail(PlayerType *player_ptr, char *buf)
+static void show_tomb_detail(PlayerType *player_ptr)
 {
-    char tomb_message[160];
-    int extra_line = 0;
+    std::pair<std::string, int> tomb_message;
+    tomb_message.second = 0;
     if (streq(player_ptr->died_from, "途中終了")) {
-        strcpy(tomb_message, "<自殺>");
+        tomb_message.first = "<自殺>";
     } else if (streq(player_ptr->died_from, "ripe")) {
-        strcpy(tomb_message, "引退後に天寿を全う");
+        tomb_message.first = "引退後に天寿を全う";
     } else if (streq(player_ptr->died_from, "Seppuku")) {
-        strcpy(tomb_message, "勝利の後、切腹");
+        tomb_message.first = "勝利の後、切腹";
     } else {
-        extra_line = show_killing_monster(player_ptr, buf, tomb_message, sizeof(tomb_message));
+        tomb_message = show_killing_monster(player_ptr);
     }
 
-    center_string(buf, tomb_message);
-    put_str(buf, 14, 11);
+    put_str(center_string(tomb_message.first).data(), 14, 11);
 
-    show_dead_place(player_ptr, buf, tomb_message, extra_line);
+    show_dead_place(player_ptr, tomb_message.second);
 }
 #else
 
 /*!
  * @brief Detailed display of words engraved on the tomb (English version only)
  * @param player_ptr reference pointer to the player
- * @param buf template of the tomb
  * @return nothing
  */
-static void show_tomb_detail(PlayerType *player_ptr, char *buf)
+static void show_tomb_detail(PlayerType *player_ptr)
 {
-    char tomb_message[160];
-    (void)sprintf(tomb_message, "Killed on Level %d", player_ptr->current_floor_ptr->dun_level);
-    center_string(buf, tomb_message);
-    put_str(buf, 14, 11);
+    put_str(center_string(format("Killed on Level %d", player_ptr->current_floor_ptr->dun_level)).data(), 14, 11);
 
-    shape_buffer(format("by %s.", player_ptr->died_from.data()), GRAVE_LINE_WIDTH + 1, tomb_message, sizeof(tomb_message));
-    center_string(buf, tomb_message);
-    char *t;
-    put_str(buf, 15, 11);
-    t = tomb_message + strlen(tomb_message) + 1;
+    char buf[160];
+    shape_buffer(format("by %s.", player_ptr->died_from.data()), GRAVE_LINE_WIDTH + 1, buf, sizeof(buf));
+    put_str(center_string(buf).data(), 15, 11);
+    char *t = buf + strlen(buf) + 1;
     if (!*t) {
         return;
     }
 
-    char killer[MAX_MONSTER_NAME];
-    strcpy(killer, t); /* 2nd line */
+    std::string killer = t; /* 2nd line */
     if (*(t + strlen(t) + 1)) /* Does 3rd line exist? */
     {
-        int dummy_len = strlen(killer);
-        strcpy(killer + std::min(dummy_len, GRAVE_LINE_WIDTH - 3), "...");
+        if (killer.length() > GRAVE_LINE_WIDTH - 3) {
+            killer.erase(GRAVE_LINE_WIDTH - 3);
+        }
+        killer.append("...");
     }
 
-    center_string(buf, killer);
-    put_str(buf, 16, 11);
+    put_str(center_string(killer).data(), 16, 11);
 }
 #endif
 
@@ -223,29 +206,22 @@ void print_tomb(PlayerType *player_ptr)
     read_dead_file(buf, sizeof(buf));
     concptr p = w_ptr->total_winner ? _("偉大なる者", "Magnificent") : player_titles[enum2i(player_ptr->pclass)][(player_ptr->lev - 1) / 5].data();
 
-    center_string(buf, player_ptr->name);
-    put_str(buf, 6, 11);
+    put_str(center_string(player_ptr->name).data(), 6, 11);
 
 #ifdef JP
 #else
-    center_string(buf, "the");
-    put_str(buf, 7, 11);
+    put_str(center_string("the").data(), 7, 11);
 #endif
 
-    center_string(buf, p);
-    put_str(buf, 8, 11);
+    put_str(center_string(p).data(), 8, 11);
 
-    center_string(buf, cp_ptr->title);
-    put_str(buf, 10, 11);
+    put_str(center_string(cp_ptr->title).data(), 10, 11);
 
-    show_basic_params(player_ptr, buf);
-    show_tomb_detail(player_ptr, buf);
+    show_basic_params(player_ptr);
+    show_tomb_detail(player_ptr);
 
-    char current_time[80];
     time_t ct = time((time_t *)0);
-    (void)sprintf(current_time, "%-.24s", ctime(&ct));
-    center_string(buf, current_time);
-    put_str(buf, 17, 11);
+    put_str(center_string(format("%-.24s", ctime(&ct))).data(), 17, 11);
     msg_format(_("さようなら、%s!", "Goodbye, %s!"), player_ptr->name);
 }
 
@@ -335,11 +311,9 @@ static void show_dead_home_items(PlayerType *player_ptr)
             term_clear();
             for (int j = 0; (j < 12) && (i < store_ptr->stock_num); j++, i++) {
                 GAME_TEXT o_name[MAX_NLEN];
-                char tmp_val[80];
                 ItemEntity *o_ptr;
                 o_ptr = &store_ptr->stock[i];
-                sprintf(tmp_val, "%c) ", I2A(j));
-                prt(tmp_val, j + 2, 4);
+                prt(format("%c) ", I2A(j)), j + 2, 4);
                 describe_flavor(player_ptr, o_name, o_ptr, 0);
                 c_put_str(tval_to_attr[enum2i(o_ptr->bi_key.tval())], o_name, j + 2, 7);
             }
@@ -362,9 +336,8 @@ static void export_player_info(PlayerType *player_ptr)
     prt(_("キャラクターの記録をファイルに書き出すことができます。", "You may now dump a character record to one or more files."), 21, 0);
     prt(_("リターンキーでキャラクターを見ます。ESCで中断します。", "Then, hit RETURN to see the character, or ESC to abort."), 22, 0);
     while (true) {
-        char out_val[160];
+        char out_val[160] = "";
         put_str(_("ファイルネーム: ", "Filename: "), 23, 0);
-        strcpy(out_val, "");
         if (!askfor(out_val, 60)) {
             return;
         }

--- a/src/player/process-name.cpp
+++ b/src/player/process-name.cpp
@@ -87,16 +87,17 @@ void process_player_name(PlayerType *player_ptr, bool is_new_savefile)
 
     auto is_modified = false;
     if (is_new_savefile && (!savefile[0] || !keep_savefile)) {
-        char temp[128];
+        std::string temp;
 
 #ifdef SAVEFILE_USE_UID
         /* Rename the savefile, using the player_ptr->player_uid and player_ptr->base_name */
-        (void)sprintf(temp, "%d.%s", player_ptr->player_uid, player_ptr->base_name);
+        temp = std::to_string(player_ptr->player_uid);
+        temp.append(".").append(player_ptr->base_name);
 #else
         /* Rename the savefile, using the player_ptr->base_name */
-        (void)sprintf(temp, "%s", player_ptr->base_name);
+        temp = player_ptr->base_name;
 #endif
-        path_build(savefile, sizeof(savefile), ANGBAND_DIR_SAVE, temp);
+        path_build(savefile, sizeof(savefile), ANGBAND_DIR_SAVE, temp.data());
         is_modified = true;
     }
 

--- a/src/room/rooms-pit-nest.cpp
+++ b/src/room/rooms-pit-nest.cpp
@@ -67,50 +67,46 @@ static int pick_vault_type(FloorType *floor_ptr, std::vector<nest_pit_type> &l_p
  * Hack -- Get the string describing subtype of pit/nest
  * Determined in prepare function (some pit/nest only)
  */
-static concptr pit_subtype_string(int type, bool nest)
+static std::string pit_subtype_string(int type, bool nest)
 {
-    static char inner_buf[256] = "";
-    inner_buf[0] = '\0';
     if (nest) {
         switch (type) {
         case NEST_TYPE_CLONE:
-            sprintf(inner_buf, "(%s)", monraces_info[vault_aux_race].name.data());
-            break;
+            return std::string("(").append(monraces_info[vault_aux_race].name).append(1, ')');
         case NEST_TYPE_SYMBOL_GOOD:
         case NEST_TYPE_SYMBOL_EVIL:
-            sprintf(inner_buf, "(%c)", vault_aux_char);
-            break;
+            return std::string("(").append(1, vault_aux_char).append(1, ')');
         }
 
-        return inner_buf;
+        return std::string();
     }
 
     /* Pits */
     switch (type) {
     case PIT_TYPE_SYMBOL_GOOD:
     case PIT_TYPE_SYMBOL_EVIL:
-        sprintf(inner_buf, "(%c)", vault_aux_char);
+        return std::string("(").append(1, vault_aux_char).append(1, ')');
         break;
     case PIT_TYPE_DRAGON:
         if (vault_aux_dragon_mask4.has_all_of({ MonsterAbilityType::BR_ACID, MonsterAbilityType::BR_ELEC, MonsterAbilityType::BR_FIRE, MonsterAbilityType::BR_COLD, MonsterAbilityType::BR_POIS })) {
-            strcpy(inner_buf, _("(万色)", "(multi-hued)"));
+            return _("(万色)", "(multi-hued)");
         } else if (vault_aux_dragon_mask4.has(MonsterAbilityType::BR_ACID)) {
-            strcpy(inner_buf, _("(酸)", "(acid)"));
+            return _("(酸)", "(acid)");
         } else if (vault_aux_dragon_mask4.has(MonsterAbilityType::BR_ELEC)) {
-            strcpy(inner_buf, _("(稲妻)", "(lightning)"));
+            return _("(稲妻)", "(lightning)");
         } else if (vault_aux_dragon_mask4.has(MonsterAbilityType::BR_FIRE)) {
-            strcpy(inner_buf, _("(火炎)", "(fire)"));
+            return _("(火炎)", "(fire)");
         } else if (vault_aux_dragon_mask4.has(MonsterAbilityType::BR_COLD)) {
-            strcpy(inner_buf, _("(冷気)", "(frost)"));
+            return _("(冷気)", "(frost)");
         } else if (vault_aux_dragon_mask4.has(MonsterAbilityType::BR_POIS)) {
-            strcpy(inner_buf, _("(毒)", "(poison)"));
+            return _("(毒)", "(poison)");
         } else {
-            strcpy(inner_buf, _("(未定義)", "(undefined)"));
+            return _("(未定義)", "(undefined)");
         }
         break;
     }
 
-    return inner_buf;
+    return std::string();
 }
 
 /*
@@ -374,7 +370,7 @@ bool build_type5(PlayerType *player_ptr, dun_data_type *dd_ptr)
     }
 
     msg_format_wizard(
-        player_ptr, CHEAT_DUNGEON, _("モンスター部屋(nest)(%s%s)を生成します。", "Monster nest (%s%s)"), n_ptr->name, pit_subtype_string(cur_nest_type, true));
+        player_ptr, CHEAT_DUNGEON, _("モンスター部屋(nest)(%s%s)を生成します。", "Monster nest (%s%s)"), n_ptr->name, pit_subtype_string(cur_nest_type, true).data());
 
     /* Place some monsters */
     for (y = yval - 2; y <= yval + 2; y++) {
@@ -628,7 +624,7 @@ bool build_type6(PlayerType *player_ptr, dun_data_type *dd_ptr)
     }
 
     msg_format_wizard(
-        player_ptr, CHEAT_DUNGEON, _("モンスター部屋(pit)(%s%s)を生成します。", "Monster pit (%s%s)"), n_ptr->name, pit_subtype_string(cur_pit_type, false));
+        player_ptr, CHEAT_DUNGEON, _("モンスター部屋(pit)(%s%s)を生成します。", "Monster pit (%s%s)"), n_ptr->name, pit_subtype_string(cur_pit_type, false).data());
 
     /* Select the entries */
     for (i = 0; i < 8; i++) {
@@ -959,7 +955,7 @@ bool build_type13(PlayerType *player_ptr, dun_data_type *dd_ptr)
     }
 
     msg_format_wizard(
-        player_ptr, CHEAT_DUNGEON, _("%s%sの罠ピットが生成されました。", "Trapped monster pit (%s%s)"), n_ptr->name, pit_subtype_string(cur_pit_type, false));
+        player_ptr, CHEAT_DUNGEON, _("%s%sの罠ピットが生成されました。", "Trapped monster pit (%s%s)"), n_ptr->name, pit_subtype_string(cur_pit_type, false).data());
 
     /* Select the entries */
     for (i = 0; i < 8; i++) {

--- a/src/save/floor-writer.cpp
+++ b/src/save/floor-writer.cpp
@@ -16,6 +16,7 @@
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/sort.h"
 
@@ -239,7 +240,6 @@ bool save_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr, BIT_FLAGS mode
     uint32_t old_v_stamp = 0;
     uint32_t old_x_stamp = 0;
 
-    char floor_savefile[sizeof(savefile) + 32];
     if ((mode & SLF_SECOND) != 0) {
         old_fff = saving_savefile;
         old_xor_byte = save_xor_byte;
@@ -247,20 +247,23 @@ bool save_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr, BIT_FLAGS mode
         old_x_stamp = x_stamp;
     }
 
-    sprintf(floor_savefile, "%s.F%02d", savefile, (int)sf_ptr->savefile_id);
+    std::string floor_savefile = savefile;
+    char ext[32];
+    strnfmt(ext, sizeof(ext), ".F%02d", (int)sf_ptr->savefile_id);
+    floor_savefile.append(ext);
     safe_setuid_grab(player_ptr);
-    fd_kill(floor_savefile);
+    fd_kill(floor_savefile.data());
     safe_setuid_drop();
     saving_savefile = nullptr;
     safe_setuid_grab(player_ptr);
 
-    int fd = fd_make(floor_savefile, 0644);
+    int fd = fd_make(floor_savefile.data(), 0644);
     safe_setuid_drop();
     bool is_save_successful = false;
     if (fd >= 0) {
         (void)fd_close(fd);
         safe_setuid_grab(player_ptr);
-        saving_savefile = angband_fopen(floor_savefile, "wb");
+        saving_savefile = angband_fopen(floor_savefile.data(), "wb");
         safe_setuid_drop();
         if (saving_savefile) {
             if (save_floor_aux(player_ptr, sf_ptr)) {
@@ -274,7 +277,7 @@ bool save_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr, BIT_FLAGS mode
 
         if (!is_save_successful) {
             safe_setuid_grab(player_ptr);
-            (void)fd_kill(floor_savefile);
+            (void)fd_kill(floor_savefile.data());
             safe_setuid_drop();
         }
     }

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -38,6 +38,7 @@
 #include "target/target-setter.h"
 #include "target/target-types.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 #include "world/world.h"
@@ -297,7 +298,7 @@ bool tele_town(PlayerType *player_ptr)
             continue;
         }
 
-        sprintf(buf, "%c) %-20s", I2A(i - 1), town_info[i].name);
+        strnfmt(buf, sizeof(buf), "%c) %-20s", I2A(i - 1), town_info[i].name);
         prt(buf, 5 + i, 5);
         num++;
     }
@@ -406,8 +407,7 @@ static DUNGEON_IDX choose_dungeon(concptr note, POSITION y, POSITION x)
             seiha = true;
         }
 
-        sprintf(buf, _("      %c) %c%-12s : 最大 %d 階", "      %c) %c%-16s : Max level %d"),
-            static_cast<char>('a' + dun.size()), seiha ? '!' : ' ', d_ref.name.data(), (int)max_dlv[d_ref.idx]);
+        strnfmt(buf, sizeof(buf), _("      %c) %c%-12s : 最大 %d 階", "      %c) %c%-16s : Max level %d"), static_cast<char>('a' + dun.size()), seiha ? '!' : ' ', d_ref.name.data(), (int)max_dlv[d_ref.idx]);
         prt(buf, y + dun.size(), x);
         dun.push_back(d_ref.idx);
     }
@@ -532,8 +532,6 @@ bool free_level_recall(PlayerType *player_ptr)
 bool reset_recall(PlayerType *player_ptr)
 {
     int select_dungeon, dummy = 0;
-    char ppp[80];
-    char tmp_val[160];
 
     select_dungeon = choose_dungeon(_("をセット", "reset"), 2, 14);
     if (ironman_downward) {
@@ -544,8 +542,10 @@ bool reset_recall(PlayerType *player_ptr)
     if (!select_dungeon) {
         return false;
     }
-    sprintf(ppp, _("何階にセットしますか (%d-%d):", "Reset to which level (%d-%d): "), (int)dungeons_info[select_dungeon].mindepth, (int)max_dlv[select_dungeon]);
-    sprintf(tmp_val, "%d", (int)std::max(player_ptr->current_floor_ptr->dun_level, 1));
+    char ppp[80];
+    strnfmt(ppp, sizeof(ppp), _("何階にセットしますか (%d-%d):", "Reset to which level (%d-%d): "), (int)dungeons_info[select_dungeon].mindepth, (int)max_dlv[select_dungeon]);
+    char tmp_val[160];
+    strnfmt(tmp_val, sizeof(tmp_val), "%d", (int)std::max(player_ptr->current_floor_ptr->dun_level, 1));
 
     if (!get_string(ppp, tmp_val, 10)) {
         return false;

--- a/src/spell-realm/spells-sorcery.cpp
+++ b/src/spell-realm/spells-sorcery.cpp
@@ -12,6 +12,7 @@
 #include "object/object-value.h"
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
+#include "term/z-form.h"
 #include "view/display-messages.h"
 
 /*!
@@ -53,7 +54,7 @@ bool alchemy(PlayerType *player_ptr)
     if (!force) {
         if (confirm_destroy || (o_ptr->get_price() > 0)) {
             char out_val[MAX_NLEN + 40];
-            sprintf(out_val, _("本当に%sを金に変えますか？", "Really turn %s to gold? "), o_name);
+            strnfmt(out_val, sizeof(out_val), _("本当に%sを金に変えますか？", "Really turn %s to gold? "), o_name);
             if (!get_check(out_val)) {
                 return false;
             }

--- a/src/spell/spell-info.cpp
+++ b/src/spell/spell-info.cpp
@@ -15,6 +15,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "timed-effect/player-stun.h"
 #include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
@@ -254,8 +255,6 @@ void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell, SPELL_IDX *spe
 
     int i;
     const magic_type *s_ptr;
-    char info[80];
-    char out_val[160];
     char ryakuji[5];
     bool max = false;
     for (i = 0; i < num; i++) {
@@ -296,24 +295,25 @@ void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell, SPELL_IDX *spe
             ryakuji[4] = '\0';
         }
 
+        std::string out_val;
         if (use_menu && target_spell) {
             if (i == (target_spell - 1)) {
-                strcpy(out_val, _("  》 ", "  >  "));
+                out_val = _("  》 ", "  >  ");
             } else {
-                strcpy(out_val, "     ");
+                out_val = "     ";
             }
         } else {
-            sprintf(out_val, "  %c) ", I2A(i));
+            out_val = format("  %c) ", I2A(i));
         }
 
         if (s_ptr->slevel >= 99) {
-            strcat(out_val, format("%-30s", _("(判読不能)", "(illegible)")));
-            c_prt(TERM_L_DARK, out_val, y + i + 1, x);
+            out_val.append(format("%-30s", _("(判読不能)", "(illegible)")));
+            c_prt(TERM_L_DARK, out_val.data(), y + i + 1, x);
             continue;
         }
 
-        strcpy(info, exe_spell(player_ptr, use_realm, spell, SpellProcessType::INFO));
-        concptr comment = info;
+        std::string info = exe_spell(player_ptr, use_realm, spell, SpellProcessType::INFO);
+        concptr comment = info.data();
         byte line_attr = TERM_WHITE;
         if (pc.is_every_magic()) {
             if (s_ptr->slevel > player_ptr->max_plv) {
@@ -338,14 +338,13 @@ void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell, SPELL_IDX *spe
         }
 
         if (use_realm == REALM_HISSATSU) {
-            strcat(out_val, format("%-25s %2d %4d", exe_spell(player_ptr, use_realm, spell, SpellProcessType::NAME), s_ptr->slevel, need_mana));
+            out_val.append(format("%-25s %2d %4d", exe_spell(player_ptr, use_realm, spell, SpellProcessType::NAME), s_ptr->slevel, need_mana));
         } else {
-            strcat(out_val,
-                format("%-25s%c%-4s %2d %4d %3d%% %s", exe_spell(player_ptr, use_realm, spell, SpellProcessType::NAME), (max ? '!' : ' '), ryakuji, s_ptr->slevel,
-                    need_mana, spell_chance(player_ptr, spell, use_realm), comment));
+            out_val.append(format("%-25s%c%-4s %2d %4d %3d%% %s", exe_spell(player_ptr, use_realm, spell, SpellProcessType::NAME), (max ? '!' : ' '), ryakuji, s_ptr->slevel,
+                need_mana, spell_chance(player_ptr, spell, use_realm), comment));
         }
 
-        c_prt(line_attr, out_val, y + i + 1, x);
+        c_prt(line_attr, out_val.data(), y + i + 1, x);
     }
 
     prt("", y + i + 1, x);

--- a/src/status/shape-changer.cpp
+++ b/src/status/shape-changer.cpp
@@ -117,8 +117,7 @@ void do_poly_self(PlayerType *player_ptr)
 
     PlayerRace pr(player_ptr);
     if ((power > randint0(20)) && one_in_(3) && !pr.equals(PlayerRaceType::ANDROID)) {
-        char effect_msg[80] = "";
-        char sex_msg[32] = "";
+        std::string effect_msg, sex_msg;
         PlayerRaceType new_race;
 
         power -= 10;
@@ -127,11 +126,11 @@ void do_poly_self(PlayerType *player_ptr)
             if (player_ptr->psex == SEX_MALE) {
                 player_ptr->psex = SEX_FEMALE;
                 sp_ptr = &sex_info[player_ptr->psex];
-                sprintf(sex_msg, _("女性の", "female"));
+                sex_msg = _("女性の", "female");
             } else {
                 player_ptr->psex = SEX_MALE;
                 sp_ptr = &sex_info[player_ptr->psex];
-                sprintf(sex_msg, _("男性の", "male"));
+                sex_msg = _("男性の", "male");
             }
         }
 
@@ -148,10 +147,11 @@ void do_poly_self(PlayerType *player_ptr)
 
             (void)dec_stat(player_ptr, A_CHR, randint1(6), true);
 
-            if (sex_msg[0]) {
-                sprintf(effect_msg, _("奇形の%s", "deformed %s "), sex_msg);
+            if (sex_msg.length()) {
+                effect_msg = _("奇形の", "deformed ");
+                effect_msg.append(sex_msg).append(_("", " "));
             } else {
-                sprintf(effect_msg, _("奇形の", "deformed "));
+                effect_msg = _("奇形の", "deformed ");
             }
         }
 
@@ -167,7 +167,7 @@ void do_poly_self(PlayerType *player_ptr)
             new_race = (PlayerRaceType)randint0(MAX_RACES);
         } while (pr.equals(new_race) || (new_race == PlayerRaceType::ANDROID));
 
-        change_race(player_ptr, new_race, effect_msg);
+        change_race(player_ptr, new_race, effect_msg.data());
     }
 
     if ((power > randint0(30)) && one_in_(6)) {

--- a/src/store/museum.cpp
+++ b/src/store/museum.cpp
@@ -25,11 +25,8 @@ void museum_remove_object(PlayerType *player_ptr)
         i = store_bottom;
     }
 
-    char out_val[160];
-    sprintf(out_val, _("どのアイテムの展示をやめさせますか？", "Which item do you want to order to remove? "));
-
     COMMAND_CODE item;
-    if (!get_stock(&item, out_val, 0, i - 1, StoreSaleType::MUSEUM)) {
+    if (!get_stock(&item, _("どのアイテムの展示をやめさせますか？", "Which item do you want to order to remove? "), 0, i - 1, StoreSaleType::MUSEUM)) {
         return;
     }
 

--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -70,21 +70,21 @@ static std::optional<PRICE> prompt_to_buy(PlayerType *player_ptr, ItemEntity *o_
  */
 static bool show_store_select_item(COMMAND_CODE *item, const int i, StoreSaleType store_num)
 {
-    char out_val[160];
+    concptr prompt;
 
     switch (store_num) {
     case StoreSaleType::HOME:
-        sprintf(out_val, _("どのアイテムを取りますか? ", "Which item do you want to take? "));
+        prompt = _("どのアイテムを取りますか? ", "Which item do you want to take? ");
         break;
     case StoreSaleType::BLACK:
-        sprintf(out_val, _("どれ? ", "Which item, huh? "));
+        prompt = _("どれ? ", "Which item, huh? ");
         break;
     default:
-        sprintf(out_val, _("どの品物が欲しいんだい? ", "Which item are you interested in? "));
+        prompt = _("どの品物が欲しいんだい? ", "Which item are you interested in? ");
         break;
     }
 
-    return get_stock(item, out_val, 0, i - 1, store_num) != 0;
+    return get_stock(item, prompt, 0, i - 1, store_num) != 0;
 }
 
 /*!
@@ -140,15 +140,11 @@ static void shuffle_store(PlayerType *player_ptr, StoreSaleType store_num)
         return;
     }
 
-    char buf[80];
-
     msg_print(_("店主は引退した。", "The shopkeeper retires."));
     store_shuffle(player_ptr, store_num);
     prt("", 3, 0);
-    sprintf(buf, "%s (%s)", ot_ptr->owner_name, race_info[enum2i(ot_ptr->owner_race)].title);
-    put_str(buf, 3, 10);
-    sprintf(buf, "%s (%ld)", terrains_info[cur_store_feat].name.data(), (long)(ot_ptr->max_cost));
-    prt(buf, 3, 50);
+    put_str(format("%s (%s)", ot_ptr->owner_name, race_info[enum2i(ot_ptr->owner_race)].title), 3, 10);
+    prt(format("%s (%ld)", terrains_info[cur_store_feat].name.data(), (long)(ot_ptr->max_cost)), 3, 50);
 }
 
 static void switch_store_stock(PlayerType *player_ptr, const int i, const COMMAND_CODE item, StoreSaleType store_num)

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -30,6 +30,7 @@
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
 #include "util/quarks.h"
 #include "view/display-messages.h"
@@ -164,9 +165,9 @@ int get_stock(COMMAND_CODE *com_val, concptr pmt, int i, int j, [[maybe_unused]]
     char hi = (j > 25) ? toupper(I2A(j - 26)) : I2A(j);
     char out_val[160];
 #ifdef JP
-    (void)sprintf(out_val, "(%s:%c-%c, ESCで中断) %s", (((store_num == StoreSaleType::HOME) || (store_num == StoreSaleType::MUSEUM)) ? "アイテム" : "商品"), lo, hi, pmt);
+    strnfmt(out_val, sizeof(out_val), "(%s:%c-%c, ESCで中断) %s", (((store_num == StoreSaleType::HOME) || (store_num == StoreSaleType::MUSEUM)) ? "アイテム" : "商品"), lo, hi, pmt);
 #else
-    (void)sprintf(out_val, "(Items %c-%c, ESC to exit) %s", lo, hi, pmt);
+    strnfmt(out_val, sizeof(out_val), "(Items %c-%c, ESC to exit) %s", lo, hi, pmt);
 #endif
 
     char command;
@@ -223,11 +224,8 @@ void store_examine(PlayerType *player_ptr, StoreSaleType store_num)
         i = store_bottom;
     }
 
-    char out_val[160];
-    sprintf(out_val, _("どれを調べますか？", "Which item do you want to examine? "));
-
     COMMAND_CODE item;
-    if (!get_stock(&item, out_val, 0, i - 1, store_num)) {
+    if (!get_stock(&item, _("どれを調べますか？", "Which item do you want to examine? "), 0, i - 1, store_num)) {
         return;
     }
     item = item + store_top;

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -38,6 +38,7 @@
 #include "target/target-types.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "timed-effect/player-hallucination.h"
 #include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
@@ -98,18 +99,16 @@ static eg_type *initialize_eg_type(PlayerType *player_ptr, eg_type *eg_ptr, POSI
 /*
  * Evaluate number of kill needed to gain level
  */
-static void evaluate_monster_exp(PlayerType *player_ptr, char *buf, MonsterEntity *m_ptr)
+static std::string evaluate_monster_exp(PlayerType *player_ptr, MonsterEntity *m_ptr)
 {
     MonsterRaceInfo *ap_r_ptr = &monraces_info[m_ptr->ap_r_idx];
     if ((player_ptr->lev >= PY_MAX_LEVEL) || PlayerRace(player_ptr).equals(PlayerRaceType::ANDROID)) {
-        sprintf(buf, "**");
-        return;
+        return std::string("**");
     }
 
     if (!ap_r_ptr->r_tkills || m_ptr->mflag2.has(MonsterConstantFlagType::KAGE)) {
         if (!w_ptr->wizard) {
-            sprintf(buf, "??");
-            return;
+            return std::string("??");
         }
     }
 
@@ -129,7 +128,7 @@ static void evaluate_monster_exp(PlayerType *player_ptr, char *buf, MonsterEntit
     s64b_div(&exp_adv, &exp_adv_frac, exp_mon, exp_mon_frac);
 
     auto num = std::min<uint>(999, exp_adv_frac);
-    sprintf(buf, "%03ld", (long int)num);
+    return format("%03ld", (long int)num);
 }
 
 static void describe_scan_result(PlayerType *player_ptr, eg_type *eg_ptr)
@@ -169,9 +168,9 @@ static ProcessResult describe_hallucinated_target(PlayerType *player_ptr, eg_typ
 
     concptr name = _("何か奇妙な物", "something strange");
 #ifdef JP
-    sprintf(eg_ptr->out_val, "%s%s%s%s [%s]", eg_ptr->s1, name, eg_ptr->s2, eg_ptr->s3, eg_ptr->info);
+    strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s [%s]", eg_ptr->s1, name, eg_ptr->s2, eg_ptr->s3, eg_ptr->info);
 #else
-    sprintf(eg_ptr->out_val, "%s%s%s%s [%s]", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, name, eg_ptr->info);
+    strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s [%s]", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, name, eg_ptr->info);
 #endif
     prt(eg_ptr->out_val, 0, 0);
     move_cursor_relative(eg_ptr->y, eg_ptr->x);
@@ -199,7 +198,6 @@ static void describe_grid_monster(PlayerType *player_ptr, eg_type *eg_ptr)
     GAME_TEXT m_name[MAX_NLEN];
     monster_desc(player_ptr, m_name, eg_ptr->m_ptr, MD_INDEF_VISIBLE);
     while (true) {
-        char acount[10];
         if (recall) {
             if (describe_grid_lore(player_ptr, eg_ptr)) {
                 return;
@@ -209,12 +207,12 @@ static void describe_grid_monster(PlayerType *player_ptr, eg_type *eg_ptr)
             continue;
         }
 
-        evaluate_monster_exp(player_ptr, acount, eg_ptr->m_ptr);
+        std::string acount = evaluate_monster_exp(player_ptr, eg_ptr->m_ptr);
 #ifdef JP
-        sprintf(eg_ptr->out_val, "[%s]%s%s(%s)%s%s [r思 %s%s]", acount, eg_ptr->s1, m_name, look_mon_desc(eg_ptr->m_ptr, 0x01), eg_ptr->s2, eg_ptr->s3,
+        strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "[%s]%s%s(%s)%s%s [r思 %s%s]", acount.data(), eg_ptr->s1, m_name, look_mon_desc(eg_ptr->m_ptr, 0x01), eg_ptr->s2, eg_ptr->s3,
             eg_ptr->x_info, eg_ptr->info);
 #else
-        sprintf(eg_ptr->out_val, "[%s]%s%s%s%s(%s) [r, %s%s]", acount, eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, m_name, look_mon_desc(eg_ptr->m_ptr, 0x01),
+        strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "[%s]%s%s%s%s(%s) [r, %s%s]", acount.data(), eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, m_name, look_mon_desc(eg_ptr->m_ptr, 0x01),
             eg_ptr->x_info, eg_ptr->info);
 #endif
         prt(eg_ptr->out_val, 0, 0);
@@ -254,9 +252,9 @@ static uint16_t describe_monster_item(PlayerType *player_ptr, eg_type *eg_ptr)
         o_ptr = &player_ptr->current_floor_ptr->o_list[this_o_idx];
         describe_flavor(player_ptr, o_name, o_ptr, 0);
 #ifdef JP
-        sprintf(eg_ptr->out_val, "%s%s%s%s[%s]", eg_ptr->s1, o_name, eg_ptr->s2, eg_ptr->s3, eg_ptr->info);
+        strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s[%s]", eg_ptr->s1, o_name, eg_ptr->s2, eg_ptr->s3, eg_ptr->info);
 #else
-        sprintf(eg_ptr->out_val, "%s%s%s%s [%s]", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, o_name, eg_ptr->info);
+        strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s [%s]", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, o_name, eg_ptr->info);
 #endif
         prt(eg_ptr->out_val, 0, 0);
         move_cursor_relative(eg_ptr->y, eg_ptr->x);
@@ -325,9 +323,9 @@ static int16_t describe_footing(PlayerType *player_ptr, eg_type *eg_ptr)
     o_ptr = &player_ptr->current_floor_ptr->o_list[eg_ptr->floor_list[0]];
     describe_flavor(player_ptr, o_name, o_ptr, 0);
 #ifdef JP
-    sprintf(eg_ptr->out_val, "%s%s%s%s[%s]", eg_ptr->s1, o_name, eg_ptr->s2, eg_ptr->s3, eg_ptr->info);
+    strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s[%s]", eg_ptr->s1, o_name, eg_ptr->s2, eg_ptr->s3, eg_ptr->info);
 #else
-    sprintf(eg_ptr->out_val, "%s%s%s%s [%s]", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, o_name, eg_ptr->info);
+    strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s [%s]", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, o_name, eg_ptr->info);
 #endif
     prt(eg_ptr->out_val, 0, 0);
     move_cursor_relative(eg_ptr->y, eg_ptr->x);
@@ -342,9 +340,9 @@ static int16_t describe_footing_items(eg_type *eg_ptr)
     }
 
 #ifdef JP
-    sprintf(eg_ptr->out_val, "%s %d個のアイテム%s%s ['x'で一覧, %s]", eg_ptr->s1, (int)eg_ptr->floor_num, eg_ptr->s2, eg_ptr->s3, eg_ptr->info);
+    strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s %d個のアイテム%s%s ['x'で一覧, %s]", eg_ptr->s1, (int)eg_ptr->floor_num, eg_ptr->s2, eg_ptr->s3, eg_ptr->info);
 #else
-    sprintf(eg_ptr->out_val, "%s%s%sa pile of %d items [x,%s]", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, (int)eg_ptr->floor_num, eg_ptr->info);
+    strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%sa pile of %d items [x,%s]", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, (int)eg_ptr->floor_num, eg_ptr->info);
 #endif
     prt(eg_ptr->out_val, 0, 0);
     move_cursor_relative(eg_ptr->y, eg_ptr->x);
@@ -364,9 +362,9 @@ static char describe_footing_many_items(PlayerType *player_ptr, eg_type *eg_ptr,
         (void)show_floor_items(player_ptr, 0, eg_ptr->y, eg_ptr->x, min_width, AllMatchItemTester());
         show_gold_on_floor = false;
 #ifdef JP
-        sprintf(eg_ptr->out_val, "%s %d個のアイテム%s%s [Enterで次へ, %s]", eg_ptr->s1, (int)eg_ptr->floor_num, eg_ptr->s2, eg_ptr->s3, eg_ptr->info);
+        strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s %d個のアイテム%s%s [Enterで次へ, %s]", eg_ptr->s1, (int)eg_ptr->floor_num, eg_ptr->s2, eg_ptr->s3, eg_ptr->info);
 #else
-        sprintf(eg_ptr->out_val, "%s%s%sa pile of %d items [Enter,%s]", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, (int)eg_ptr->floor_num, eg_ptr->info);
+        strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%sa pile of %d items [Enter,%s]", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, (int)eg_ptr->floor_num, eg_ptr->info);
 #endif
         prt(eg_ptr->out_val, 0, 0);
         eg_ptr->query = inkey();
@@ -418,9 +416,9 @@ static int16_t describe_footing_sight(PlayerType *player_ptr, eg_type *eg_ptr, I
     eg_ptr->boring = false;
     describe_flavor(player_ptr, o_name, o_ptr, 0);
 #ifdef JP
-    sprintf(eg_ptr->out_val, "%s%s%s%s[%s]", eg_ptr->s1, o_name, eg_ptr->s2, eg_ptr->s3, eg_ptr->info);
+    strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s[%s]", eg_ptr->s1, o_name, eg_ptr->s2, eg_ptr->s3, eg_ptr->info);
 #else
-    sprintf(eg_ptr->out_val, "%s%s%s%s [%s]", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, o_name, eg_ptr->info);
+    strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s [%s]", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, o_name, eg_ptr->info);
 #endif
     prt(eg_ptr->out_val, 0, 0);
     move_cursor_relative(eg_ptr->y, eg_ptr->x);
@@ -504,27 +502,27 @@ static void describe_grid_monster_all(eg_type *eg_ptr)
 {
     if (!w_ptr->wizard) {
 #ifdef JP
-        sprintf(eg_ptr->out_val, "%s%s%s%s[%s]", eg_ptr->s1, eg_ptr->name, eg_ptr->s2, eg_ptr->s3, eg_ptr->info);
+        strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s[%s]", eg_ptr->s1, eg_ptr->name, eg_ptr->s2, eg_ptr->s3, eg_ptr->info);
 #else
-        sprintf(eg_ptr->out_val, "%s%s%s%s [%s]", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, eg_ptr->name, eg_ptr->info);
+        strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s [%s]", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, eg_ptr->name, eg_ptr->info);
 #endif
         return;
     }
 
-    char f_idx_str[32];
+    std::string f_idx_str;
     if (eg_ptr->g_ptr->mimic) {
-        sprintf(f_idx_str, "%d/%d", eg_ptr->g_ptr->feat, eg_ptr->g_ptr->mimic);
+        f_idx_str = format("%d/%d", eg_ptr->g_ptr->feat, eg_ptr->g_ptr->mimic);
     } else {
-        sprintf(f_idx_str, "%d", eg_ptr->g_ptr->feat);
+        f_idx_str = std::to_string(eg_ptr->g_ptr->feat);
     }
 
 #ifdef JP
-    sprintf(eg_ptr->out_val, "%s%s%s%s[%s] %x %s %d %d %d (%d,%d) %d", eg_ptr->s1, eg_ptr->name, eg_ptr->s2, eg_ptr->s3, eg_ptr->info,
-        (uint)eg_ptr->g_ptr->info, f_idx_str, eg_ptr->g_ptr->dists[FLOW_NORMAL], eg_ptr->g_ptr->costs[FLOW_NORMAL], eg_ptr->g_ptr->when, (int)eg_ptr->y,
+    strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s[%s] %x %s %d %d %d (%d,%d) %d", eg_ptr->s1, eg_ptr->name, eg_ptr->s2, eg_ptr->s3, eg_ptr->info,
+        (uint)eg_ptr->g_ptr->info, f_idx_str.data(), eg_ptr->g_ptr->dists[FLOW_NORMAL], eg_ptr->g_ptr->costs[FLOW_NORMAL], eg_ptr->g_ptr->when, (int)eg_ptr->y,
         (int)eg_ptr->x, travel.cost[eg_ptr->y][eg_ptr->x]);
 #else
-    sprintf(eg_ptr->out_val, "%s%s%s%s [%s] %x %s %d %d %d (%d,%d)", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, eg_ptr->name, eg_ptr->info, eg_ptr->g_ptr->info,
-        f_idx_str, eg_ptr->g_ptr->dists[FLOW_NORMAL], eg_ptr->g_ptr->costs[FLOW_NORMAL], eg_ptr->g_ptr->when, (int)eg_ptr->y, (int)eg_ptr->x);
+    strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s [%s] %x %s %d %d %d (%d,%d)", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, eg_ptr->name, eg_ptr->info, eg_ptr->g_ptr->info,
+        f_idx_str.data(), eg_ptr->g_ptr->dists[FLOW_NORMAL], eg_ptr->g_ptr->costs[FLOW_NORMAL], eg_ptr->g_ptr->when, (int)eg_ptr->y, (int)eg_ptr->x);
 #endif
 }
 

--- a/src/target/target-setter.cpp
+++ b/src/target/target-setter.cpp
@@ -21,8 +21,10 @@
 #include "target/target-preparation.h"
 #include "target/target-types.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
+#include "util/string-processor.h"
 #include "window/display-sub-windows.h"
 #include "window/main-window-util.h"
 #include <vector>
@@ -175,9 +177,9 @@ static void describe_projectablity(PlayerType *player_ptr, ts_type *ts_ptr)
 
     ts_ptr->g_ptr = &player_ptr->current_floor_ptr->grid_array[ts_ptr->y][ts_ptr->x];
     if (target_able(player_ptr, ts_ptr->g_ptr->m_idx)) {
-        strcpy(ts_ptr->info, _("q止 t決 p自 o現 +次 -前", "q,t,p,o,+,-,<dir>"));
+        angband_strcpy(ts_ptr->info, _("q止 t決 p自 o現 +次 -前", "q,t,p,o,+,-,<dir>"), sizeof(ts_ptr->info));
     } else {
-        strcpy(ts_ptr->info, _("q止 p自 o現 +次 -前", "q,p,o,+,-,<dir>"));
+        angband_strcpy(ts_ptr->info, _("q止 p自 o現 +次 -前", "q,p,o,+,-,<dir>"), sizeof(ts_ptr->info));
     }
 
     if (!cheat_sight) {
@@ -185,9 +187,11 @@ static void describe_projectablity(PlayerType *player_ptr, ts_type *ts_ptr)
     }
 
     char cheatinfo[30];
-    sprintf(cheatinfo, " X:%d Y:%d LOS:%d LOP:%d", ts_ptr->x, ts_ptr->y, los(player_ptr, player_ptr->y, player_ptr->x, ts_ptr->y, ts_ptr->x),
+    strnfmt(cheatinfo, sizeof(cheatinfo), " X:%d Y:%d LOS:%d LOP:%d", ts_ptr->x,
+        ts_ptr->y,
+        los(player_ptr, player_ptr->y, player_ptr->x, ts_ptr->y, ts_ptr->x),
         projectable(player_ptr, player_ptr->y, player_ptr->x, ts_ptr->y, ts_ptr->x));
-    strcat(ts_ptr->info, cheatinfo);
+    angband_strcat(ts_ptr->info, cheatinfo, sizeof(ts_ptr->info));
 }
 
 static void menu_target(ts_type *ts_ptr)
@@ -423,10 +427,10 @@ static void describe_grid_wizard(PlayerType *player_ptr, ts_type *ts_ptr)
         return;
     }
 
-    char cheatinfo[100];
-    sprintf(cheatinfo, " X:%d Y:%d LOS:%d LOP:%d SPECIAL:%d", ts_ptr->x, ts_ptr->y, los(player_ptr, player_ptr->y, player_ptr->x, ts_ptr->y, ts_ptr->x),
+    char cheatinfo[30];
+    strnfmt(cheatinfo, sizeof(cheatinfo), " X:%d Y:%d LOS:%d LOP:%d SPECIAL:%d", ts_ptr->x, ts_ptr->y, los(player_ptr, player_ptr->y, player_ptr->x, ts_ptr->y, ts_ptr->x),
         projectable(player_ptr, player_ptr->y, player_ptr->x, ts_ptr->y, ts_ptr->x), ts_ptr->g_ptr->special);
-    strcat(ts_ptr->info, cheatinfo);
+    angband_strcat(ts_ptr->info, cheatinfo, sizeof(ts_ptr->info));
 }
 
 static void switch_next_grid_command(PlayerType *player_ptr, ts_type *ts_ptr)

--- a/src/term/z-form.cpp
+++ b/src/term/z-form.cpp
@@ -167,7 +167,7 @@ static uint vstrnfmt_aux_dflt(char *buf, uint max, concptr fmt, vptr arg)
     fmt = fmt ? fmt : 0;
 
     /* Pointer display */
-    sprintf(tmp, "<<%p>>", arg);
+    snprintf(tmp, sizeof(tmp), "<<%p>>", arg);
     len = strlen(tmp);
     if (len >= max) {
         len = max - 1;
@@ -413,7 +413,7 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
                     arg = va_arg(vp, int);
 
                     /* Hack -- append the "length" */
-                    sprintf(aux + q, "%d", arg);
+                    snprintf(aux + q, sizeof(aux) - q, "%d", arg);
 
                     /* Hack -- accept the "length" */
                     while (aux[q]) {
@@ -457,7 +457,7 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
             arg = va_arg(vp, int);
 
             /* Format the argument */
-            sprintf(tmp, "%c", arg);
+            snprintf(tmp, sizeof(tmp), "%c", arg);
 
             break;
         }
@@ -472,7 +472,7 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
                 arg = va_arg(vp, long);
 
                 /* Format the argument */
-                sprintf(tmp, aux, arg);
+                snprintf(tmp, sizeof(tmp), aux, arg);
             } else if (do_long_long) {
                 long long arg;
 
@@ -480,7 +480,7 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
                 arg = va_arg(vp, long long);
 
                 /* Format the argument */
-                sprintf(tmp, aux, arg);
+                snprintf(tmp, sizeof(tmp), aux, arg);
             } else {
                 int arg;
 
@@ -488,7 +488,7 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
                 arg = va_arg(vp, int);
 
                 /* Format the argument */
-                sprintf(tmp, aux, arg);
+                snprintf(tmp, sizeof(tmp), aux, arg);
             }
 
             break;
@@ -505,20 +505,20 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
                 /* Access next argument */
                 arg = va_arg(vp, ulong);
 
-                sprintf(tmp, aux, arg);
+                snprintf(tmp, sizeof(tmp), aux, arg);
             } else if (do_long_long) {
                 unsigned long long arg;
 
                 /* Access next argument */
                 arg = va_arg(vp, unsigned long long);
 
-                sprintf(tmp, aux, arg);
+                snprintf(tmp, sizeof(tmp), aux, arg);
             } else {
                 uint arg;
 
                 /* Access next argument */
                 arg = va_arg(vp, uint);
-                sprintf(tmp, aux, arg);
+                snprintf(tmp, sizeof(tmp), aux, arg);
             }
 
             break;
@@ -536,7 +536,7 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
             arg = va_arg(vp, double);
 
             /* Format the argument */
-            sprintf(tmp, aux, arg);
+            snprintf(tmp, sizeof(tmp), aux, arg);
 
             break;
         }
@@ -549,7 +549,7 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
             arg = va_arg(vp, vptr);
 
             /* Format the argument */
-            sprintf(tmp, aux, arg);
+            snprintf(tmp, sizeof(tmp), aux, arg);
 
             break;
         }
@@ -572,7 +572,7 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
             arg2[1023] = '\0';
 
             /* Format the argument */
-            sprintf(tmp, aux, arg);
+            snprintf(tmp, sizeof(tmp), aux, arg);
 
             break;
         }
@@ -586,7 +586,7 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
             arg = va_arg(vp, vptr);
 
             /* Format the "user data" */
-            sprintf(tmp, aux, arg);
+            snprintf(tmp, sizeof(tmp), aux, arg);
 
             break;
         }

--- a/src/view/display-inventory.cpp
+++ b/src/view/display-inventory.cpp
@@ -15,6 +15,8 @@
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
+#include "util/string-processor.h"
 
 /*!
  * @brief 所持アイテムの表示を行う /
@@ -93,15 +95,15 @@ COMMAND_CODE show_inventory(PlayerType *player_ptr, int target_item, BIT_FLAGS m
         prt("", j + 1, col ? col - 2 : col);
         if (use_menu && target_item) {
             if (j == (target_item - 1)) {
-                strcpy(tmp_val, _("》", "> "));
+                angband_strcpy(tmp_val, _("》", "> "), sizeof(tmp_val));
                 target_item_label = i;
             } else {
-                strcpy(tmp_val, "  ");
+                angband_strcpy(tmp_val, "  ", sizeof(tmp_val));
             }
         } else if (i <= INVEN_PACK) {
-            sprintf(tmp_val, "%c)", inven_label[i]);
+            strnfmt(tmp_val, sizeof(tmp_val), "%c)", inven_label[i]);
         } else {
-            sprintf(tmp_val, "%c)", index_to_label(i));
+            strnfmt(tmp_val, sizeof(tmp_val), "%c)", index_to_label(i));
         }
 
         put_str(tmp_val, j + 1, col);
@@ -120,7 +122,7 @@ COMMAND_CODE show_inventory(PlayerType *player_ptr, int target_item, BIT_FLAGS m
         c_put_str(out_color[j], out_desc[j], j + 1, cur_col);
         if (show_weights) {
             int wgt = o_ptr->weight * o_ptr->number;
-            (void)sprintf(tmp_val, _("%3d.%1d kg", "%3d.%1d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
+            strnfmt(tmp_val, sizeof(tmp_val), _("%3d.%1d kg", "%3d.%1d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
             prt(tmp_val, j + 1, wid - 9);
         }
     }
@@ -166,7 +168,7 @@ void display_inventory(PlayerType *player_ptr, const ItemTester &item_tester)
 
         auto o_ptr = &player_ptr->inventory_list[i];
         auto do_disp = item_tester.okay(o_ptr);
-        strcpy(tmp_val, "   ");
+        angband_strcpy(tmp_val, "   ", sizeof(tmp_val));
         if (do_disp) {
             tmp_val[0] = index_to_label(i);
             tmp_val[1] = ')';
@@ -197,7 +199,9 @@ void display_inventory(PlayerType *player_ptr, const ItemTester &item_tester)
 
         if (show_weights) {
             int wgt = o_ptr->weight * o_ptr->number;
-            sprintf(tmp_val, _("%3d.%1d kg", "%3d.%1d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
+            strnfmt(tmp_val, sizeof(tmp_val), _("%3d.%1d kg", "%3d.%1d lb"),
+                _(lb_to_kg_integer(wgt), wgt / 10),
+                _(lb_to_kg_fraction(wgt), wgt % 10));
             prt(tmp_val, i, wid - 9);
         }
     }

--- a/src/view/display-lore.cpp
+++ b/src/view/display-lore.cpp
@@ -24,7 +24,9 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/bit-flags-calculator.h"
+#include "util/string-processor.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 
@@ -623,10 +625,10 @@ void display_monster_launching(PlayerType *player_ptr, lore_type *lore_ptr)
     }
 
     if (know_armour(lore_ptr->r_idx, lore_ptr->know_everything)) {
-        sprintf(lore_ptr->tmp_msg[lore_ptr->vn], _("威力 %dd%d の射撃をする", "fire an arrow (Power:%dd%d)"), lore_ptr->r_ptr->blow[p].d_dice,
+        strnfmt(lore_ptr->tmp_msg[lore_ptr->vn], sizeof(lore_ptr->tmp_msg[lore_ptr->vn]), _("威力 %dd%d の射撃をする", "fire an arrow (Power:%dd%d)"), lore_ptr->r_ptr->blow[p].d_dice,
             lore_ptr->r_ptr->blow[p].d_side);
     } else {
-        sprintf(lore_ptr->tmp_msg[lore_ptr->vn], _("射撃をする", "fire an arrow"));
+        angband_strcpy(lore_ptr->tmp_msg[lore_ptr->vn], _("射撃をする", "fire an arrow"), sizeof(lore_ptr->tmp_msg[lore_ptr->vn]));
     }
 
     lore_ptr->vp[lore_ptr->vn] = lore_ptr->tmp_msg[lore_ptr->vn];

--- a/src/view/display-player-middle.cpp
+++ b/src/view/display-player-middle.cpp
@@ -25,6 +25,7 @@
 #include "system/monster-entity.h"
 #include "system/player-type-definition.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "timed-effect/player-deceleration.h"
 #include "timed-effect/timed-effects.h"
 #include "view/display-util.h"
@@ -52,15 +53,13 @@ static void display_player_melee_bonus(PlayerType *player_ptr, int hand, int han
 
     show_tohit += player_ptr->skill_thn / BTH_PLUS_ADJ;
 
-    char buf[160];
-    sprintf(buf, "(%+d,%+d)", (int)show_tohit, (int)show_todam);
-
+    std::string buf = format("(%+d,%+d)", (int)show_tohit, (int)show_todam);
     if (!has_melee_weapon(player_ptr, INVEN_MAIN_HAND) && !has_melee_weapon(player_ptr, INVEN_SUB_HAND)) {
-        display_player_one_line(ENTRY_BARE_HAND, buf, TERM_L_BLUE);
+        display_player_one_line(ENTRY_BARE_HAND, buf.data(), TERM_L_BLUE);
     } else if (has_two_handed_weapons(player_ptr)) {
-        display_player_one_line(ENTRY_TWO_HANDS, buf, TERM_L_BLUE);
+        display_player_one_line(ENTRY_TWO_HANDS, buf.data(), TERM_L_BLUE);
     } else {
-        display_player_one_line(hand_entry, buf, TERM_L_BLUE);
+        display_player_one_line(hand_entry, buf.data(), TERM_L_BLUE);
     }
 }
 
@@ -220,16 +219,16 @@ static int calc_temporary_speed(PlayerType *player_ptr)
  */
 static void display_player_speed(PlayerType *player_ptr, TERM_COLOR attr, int base_speed, int tmp_speed)
 {
-    char buf[160];
+    std::string buf;
     if (tmp_speed) {
         if (!player_ptr->riding) {
             if (player_ptr->lightspeed) {
-                sprintf(buf, _("光速化 (+99)", "Lightspeed (+99)"));
+                buf = _("光速化 (+99)", "Lightspeed (+99)");
             } else {
-                sprintf(buf, "(%+d%+d)", base_speed - tmp_speed, tmp_speed);
+                buf = format("(%+d%+d)", base_speed - tmp_speed, tmp_speed);
             }
         } else {
-            sprintf(buf, _("乗馬中 (%+d%+d)", "Riding (%+d%+d)"), base_speed - tmp_speed, tmp_speed);
+            buf = format(_("乗馬中 (%+d%+d)", "Riding (%+d%+d)"), base_speed - tmp_speed, tmp_speed);
         }
 
         if (tmp_speed > 0) {
@@ -239,13 +238,13 @@ static void display_player_speed(PlayerType *player_ptr, TERM_COLOR attr, int ba
         }
     } else {
         if (!player_ptr->riding) {
-            sprintf(buf, "(%+d)", base_speed);
+            buf = format("(%+d)", base_speed);
         } else {
-            sprintf(buf, _("乗馬中 (%+d)", "Riding (%+d)"), base_speed);
+            buf = format(_("乗馬中 (%+d)", "Riding (%+d)"), base_speed);
         }
     }
 
-    display_player_one_line(ENTRY_SPEED, buf, attr);
+    display_player_one_line(ENTRY_SPEED, buf.data(), attr);
     display_player_one_line(ENTRY_LEVEL, format("%d", player_ptr->lev), TERM_L_GREEN);
 }
 
@@ -287,14 +286,14 @@ static void display_playtime_in_game(PlayerType *player_ptr)
     int day, hour, min;
     extract_day_hour_min(player_ptr, &day, &hour, &min);
 
-    char buf[160];
+    std::string buf;
     if (day < MAX_DAYS) {
-        sprintf(buf, _("%d日目 %2d:%02d", "Day %d %2d:%02d"), day, hour, min);
+        buf = format(_("%d日目 %2d:%02d", "Day %d %2d:%02d"), day, hour, min);
     } else {
-        sprintf(buf, _("*****日目 %2d:%02d", "Day ***** %2d:%02d"), hour, min);
+        buf = format(_("*****日目 %2d:%02d", "Day ***** %2d:%02d"), hour, min);
     }
 
-    display_player_one_line(ENTRY_DAY, buf, TERM_L_GREEN);
+    display_player_one_line(ENTRY_DAY, buf.data(), TERM_L_GREEN);
 
     if (player_ptr->chp >= player_ptr->mhp) {
         display_player_one_line(ENTRY_HP, format("%4d/%4d", player_ptr->chp, player_ptr->mhp), TERM_L_GREEN);

--- a/src/view/display-player-misc-info.cpp
+++ b/src/view/display-player-misc-info.cpp
@@ -5,6 +5,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "view/display-player-stat-info.h"
 
 /*!
@@ -19,19 +20,17 @@ void display_player_misc_info(PlayerType *player_ptr)
     put_str(_("種族  :", "Race  :"), 4, 1);
     put_str(_("職業  :", "Class :"), 5, 1);
 
-    char buf[80];
-    char tmp[80];
-    strcpy(tmp, ap_ptr->title);
+    std::string tmp = ap_ptr->title;
 #ifdef JP
     if (ap_ptr->no == 1) {
-        strcat(tmp, "の");
+        tmp.append("の");
     }
 #else
-    strcat(tmp, " ");
+    tmp.append(" ");
 #endif
-    strcat(tmp, player_ptr->name);
+    tmp.append(player_ptr->name);
 
-    c_put_str(TERM_L_BLUE, tmp, 1, 34);
+    c_put_str(TERM_L_BLUE, tmp.data(), 1, 34);
     c_put_str(TERM_L_BLUE, sp_ptr->title, 3, 9);
     c_put_str(TERM_L_BLUE, (player_ptr->mimic_form != MimicKindType::NONE ? mimic_info.at(player_ptr->mimic_form).title : rp_ptr->title), 4, 9);
     c_put_str(TERM_L_BLUE, cp_ptr->title, 5, 9);
@@ -40,10 +39,7 @@ void display_player_misc_info(PlayerType *player_ptr)
     put_str(_("ＨＰ  :", "Hits  :"), 7, 1);
     put_str(_("ＭＰ  :", "Mana  :"), 8, 1);
 
-    (void)sprintf(buf, "%d", (int)player_ptr->lev);
-    c_put_str(TERM_L_BLUE, buf, 6, 9);
-    (void)sprintf(buf, "%d/%d", (int)player_ptr->chp, (int)player_ptr->mhp);
-    c_put_str(TERM_L_BLUE, buf, 7, 9);
-    (void)sprintf(buf, "%d/%d", (int)player_ptr->csp, (int)player_ptr->msp);
-    c_put_str(TERM_L_BLUE, buf, 8, 9);
+    c_put_str(TERM_L_BLUE, format("%d", (int)player_ptr->lev), 6, 9);
+    c_put_str(TERM_L_BLUE, format("%d/%d", (int)player_ptr->chp, (int)player_ptr->mhp), 7, 9);
+    c_put_str(TERM_L_BLUE, format("%d/%d", (int)player_ptr->csp, (int)player_ptr->msp), 8, 9);
 }

--- a/src/view/display-player-stat-info.cpp
+++ b/src/view/display-player-stat-info.cpp
@@ -22,6 +22,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/bit-flags-calculator.h"
 
 /*!
@@ -123,17 +124,13 @@ static void display_basic_stat_name(PlayerType *player_ptr, int stat_num, int ro
  */
 static void display_basic_stat_value(PlayerType *player_ptr, int stat_num, int r_adj, int e_adj, int row, int stat_col, char *buf)
 {
-    (void)sprintf(buf, "%3d", r_adj);
-    c_put_str(TERM_L_BLUE, buf, row + stat_num + 1, stat_col + 13);
+    c_put_str(TERM_L_BLUE, format("%3d", r_adj), row + stat_num + 1, stat_col + 13);
 
-    (void)sprintf(buf, "%3d", (int)cp_ptr->c_adj[stat_num]);
-    c_put_str(TERM_L_BLUE, buf, row + stat_num + 1, stat_col + 16);
+    c_put_str(TERM_L_BLUE, format("%3d", (int)cp_ptr->c_adj[stat_num]), row + stat_num + 1, stat_col + 16);
 
-    (void)sprintf(buf, "%3d", (int)ap_ptr->a_adj[stat_num]);
-    c_put_str(TERM_L_BLUE, buf, row + stat_num + 1, stat_col + 19);
+    c_put_str(TERM_L_BLUE, format("%3d", (int)ap_ptr->a_adj[stat_num]), row + stat_num + 1, stat_col + 19);
 
-    (void)sprintf(buf, "%3d", (int)e_adj);
-    c_put_str(TERM_L_BLUE, buf, row + stat_num + 1, stat_col + 22);
+    c_put_str(TERM_L_BLUE, format("%3d", (int)e_adj), row + stat_num + 1, stat_col + 22);
 
     cnv_stat(player_ptr->stat_top[stat_num], buf);
     c_put_str(TERM_L_GREEN, buf, row + stat_num + 1, stat_col + 26);

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -82,14 +82,10 @@ static bool display_player_info(PlayerType *player_ptr, int mode)
  */
 static void display_player_basic_info(PlayerType *player_ptr)
 {
-    char tmp[64];
-#ifdef JP
-    sprintf(tmp, "%s%s%s", ap_ptr->title, ap_ptr->no == 1 ? "の" : "", player_ptr->name);
-#else
-    sprintf(tmp, "%s %s", ap_ptr->title, player_ptr->name);
-#endif
+    std::string tmp = ap_ptr->title;
+    tmp.append(_(ap_ptr->no == 1 ? "の" : "", " ")).append(player_ptr->name);
 
-    display_player_one_line(ENTRY_NAME, tmp, TERM_L_BLUE);
+    display_player_one_line(ENTRY_NAME, tmp.data(), TERM_L_BLUE);
     display_player_one_line(ENTRY_SEX, sp_ptr->title, TERM_L_BLUE);
     display_player_one_line(ENTRY_RACE, (player_ptr->mimic_form != MimicKindType::NONE ? mimic_info.at(player_ptr->mimic_form).title : rp_ptr->title), TERM_L_BLUE);
     display_player_one_line(ENTRY_CLASS, cp_ptr->title, TERM_L_BLUE);
@@ -105,16 +101,17 @@ static void display_magic_realms(PlayerType *player_ptr)
         return;
     }
 
-    char tmp[64];
+    std::string tmp;
     if (PlayerClass(player_ptr).equals(PlayerClassType::ELEMENTALIST)) {
-        sprintf(tmp, "%s", get_element_title(player_ptr->element));
+        tmp = get_element_title(player_ptr->element);
     } else if (player_ptr->realm2) {
-        sprintf(tmp, "%s, %s", realm_names[player_ptr->realm1], realm_names[player_ptr->realm2]);
+        tmp = realm_names[player_ptr->realm1];
+        tmp.append(", ").append(realm_names[player_ptr->realm2]);
     } else {
-        strcpy(tmp, realm_names[player_ptr->realm1]);
+        tmp = realm_names[player_ptr->realm1];
     }
 
-    display_player_one_line(ENTRY_REALM, tmp, TERM_L_BLUE);
+    display_player_one_line(ENTRY_REALM, tmp.data(), TERM_L_BLUE);
 }
 
 /*!

--- a/src/view/display-scores.cpp
+++ b/src/view/display-scores.cpp
@@ -9,6 +9,7 @@
 #include "system/angband.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/int-char-converter.h"
 
@@ -70,10 +71,8 @@ void display_scores(int from, int to, int note, high_score *score)
     for (auto k = from, place = k + 1; k < num_scores; k += per_screen) {
         term_clear();
         put_str(_("                変愚蛮怒: 勇者の殿堂", "                Hengband Hall of Fame"), 0, 0);
-        GAME_TEXT tmp_val[160];
         if (k > 0) {
-            sprintf(tmp_val, _("( %d 位以下 )", "(from position %d)"), k + 1);
-            put_str(tmp_val, 0, 40);
+            put_str(format(_("( %d 位以下 )", "(from position %d)"), k + 1), 0, 40);
         }
 
         for (auto n = 0, j = k; (j < num_scores) && (n < per_screen); place++, j++, n++) {
@@ -117,75 +116,74 @@ void display_scores(int from, int to, int note, high_score *score)
                 ;
             }
 
+            std::string alt_when;
             if ((*when == '@') && strlen(when) == 9) {
-                sprintf(tmp_val, "%.4s-%.2s-%.2s", when + 1, when + 5, when + 7);
-                when = tmp_val;
+                alt_when = format("%.4s-%.2s-%.2s", when + 1, when + 5, when + 7);
+                when = alt_when.data();
             }
 
-            GAME_TEXT out_val[256];
+            std::string out_val;
 #ifdef JP
-            /*sprintf(out_val, "%3d.%9s  %s%s%sという名の%sの%s (レベル %d)", */
-            sprintf(out_val, "%3d.%9s  %s%s%s - %s%s (レベル %d)", place, the_score.pts, personality_info[pa].title, (personality_info[pa].no ? "の" : ""),
+            /* out_val = format("%3d.%9s  %s%s%sという名の%sの%s (レベル %d)", */
+            out_val = format("%3d.%9s  %s%s%s - %s%s (レベル %d)", place, the_score.pts, personality_info[pa].title, (personality_info[pa].no ? "の" : ""),
                 the_score.who, race_info[pr].title, class_info[pc].title, clev);
 
 #else
-            sprintf(out_val, "%3d.%9s  %s %s the %s %s, Level %d", place, the_score.pts, personality_info[pa].title, the_score.who, race_info[pr].title,
+            out_val = format("%3d.%9s  %s %s the %s %s, Level %d", place, the_score.pts, personality_info[pa].title, the_score.who, race_info[pr].title,
                 class_info[pc].title, clev);
 #endif
             if (mlev > clev) {
-                strcat(out_val, format(_(" (最高%d)", " (Max %d)"), mlev));
+                out_val.append(format(_(" (最高%d)", " (Max %d)"), mlev));
             }
 
-            c_put_str(attr, out_val, n * 4 + 2, 0);
+            c_put_str(attr, out_val.data(), n * 4 + 2, 0);
 #ifdef JP
             if (mdun != 0) {
-                sprintf(out_val, "    最高%3d階", mdun);
+                out_val = format("    最高%3d階", mdun);
             } else {
-                sprintf(out_val, "             ");
+                out_val = "             ";
             }
 
             /* 死亡原因をオリジナルより細かく表示 */
             if (streq(the_score.how, "yet")) {
-                sprintf(out_val + 13, "  まだ生きている (%d%s)", cdun, "階");
+                out_val.append(format("  まだ生きている (%d%s)", cdun, "階"));
             } else if (streq(the_score.how, "ripe")) {
-                sprintf(out_val + 13, "  勝利の後に引退 (%d%s)", cdun, "階");
+                out_val.append(format("  勝利の後に引退 (%d%s)", cdun, "階"));
             } else if (streq(the_score.how, "Seppuku")) {
-                sprintf(out_val + 13, "  勝利の後に切腹 (%d%s)", cdun, "階");
+                out_val.append(format("  勝利の後に切腹 (%d%s)", cdun, "階"));
             } else {
                 codeconv(the_score.how);
                 if (!cdun) {
-                    sprintf(out_val + 13, "  地上で%sに殺された", the_score.how);
+                    out_val.append(format("  地上で%sに殺された", the_score.how));
                 } else {
-                    sprintf(out_val + 13, "  %d階で%sに殺された", cdun, the_score.how);
+                    out_val.append(format("  %d階で%sに殺された", cdun, the_score.how));
                 }
             }
 #else
             if (!cdun) {
-                sprintf(out_val, "               Killed by %s on the surface", the_score.how);
+                out_val = format("               Killed by %s on the surface", the_score.how);
             } else {
-                sprintf(out_val, "               Killed by %s on %s %d", the_score.how, "Dungeon Level", cdun);
+                out_val = format("               Killed by %s on %s %d", the_score.how, "Dungeon Level", cdun);
             }
 
             if (mdun > cdun) {
-                strcat(out_val, format(" (Max %d)", mdun));
+                out_val.append(format(" (Max %d)", mdun));
             }
 #endif
-            c_put_str(attr, out_val, n * 4 + 3, 0);
+            c_put_str(attr, out_val.data(), n * 4 + 3, 0);
 #ifdef JP
-            char buf[11];
-
             /* 日付を 19yy/mm/dd の形式に変更する */
             if (strlen(when) == 8 && when[2] == '/' && when[5] == '/') {
-                sprintf(buf, "%d%s/%.5s", 19 + (when[6] < '8'), when + 6, when);
-                when = buf;
+                alt_when = format("%d%s/%.5s", 19 + (when[6] < '8'), when + 6, when);
+                when = alt_when.data();
             }
 
-            sprintf(out_val, "        (ユーザー:%s, 日付:%s, 所持金:%s, ターン:%s)", user, when, gold, aged);
+            out_val = format("        (ユーザー:%s, 日付:%s, 所持金:%s, ターン:%s)", user, when, gold, aged);
 #else
-            sprintf(out_val, "               (User %s, Date %s, Gold %s, Turn %s).", user, when, gold, aged);
+            out_val = format("               (User %s, Date %s, Gold %s, Turn %s).", user, when, gold, aged);
 #endif
 
-            c_put_str(attr, out_val, n * 4 + 4, 0);
+            c_put_str(attr, out_val.data(), n * 4 + 4, 0);
         }
 
         prt(_("[ ESCで中断, その他のキーで続けます ]", "[Press ESC to quit, any other key to continue.]"), hgt - 1, _(21, 17));

--- a/src/view/display-self-info.cpp
+++ b/src/view/display-self-info.cpp
@@ -7,15 +7,17 @@
 #include "player/player-status-table.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
+#include "util/string-processor.h"
 #include <string>
 
 void display_life_rating(PlayerType *player_ptr, self_info_type *self_ptr)
 {
     player_ptr->knowledge |= KNOW_STAT | KNOW_HPRATE;
-    strcpy(self_ptr->plev_buf, "");
+    angband_strcpy(self_ptr->plev_buf, "", sizeof(self_ptr->plev_buf));
     int percent = (int)(((long)player_ptr->player_hp[PY_MAX_LEVEL - 1] * 200L) / (2 * player_ptr->hitdie + ((PY_MAX_LEVEL - 1 + 3) * (player_ptr->hitdie + 1))));
-    sprintf(self_ptr->plev_buf, _("現在の体力ランク : %d/100", "Your current Life Rating is %d/100."), percent);
-    strcpy(self_ptr->buf[0], self_ptr->plev_buf);
+    strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("現在の体力ランク : %d/100", "Your current Life Rating is %d/100."), percent);
+    angband_strcpy(self_ptr->buf[0], self_ptr->plev_buf, sizeof(self_ptr->buf[0]));
     self_ptr->info[self_ptr->line++] = self_ptr->buf[0];
     self_ptr->info[self_ptr->line++] = "";
 }
@@ -24,9 +26,7 @@ void display_max_base_status(PlayerType *player_ptr, self_info_type *self_ptr)
 {
     self_ptr->info[self_ptr->line++] = _("能力の最大値", "Limits of maximum stats");
     for (int v_nr = 0; v_nr < A_MAX; v_nr++) {
-        char stat_desc[80];
-        sprintf(stat_desc, "%s 18/%d", stat_names[v_nr], player_ptr->stat_max_max[v_nr] - 18);
-        strcpy(self_ptr->s_string[v_nr], stat_desc);
+        angband_strcpy(self_ptr->s_string[v_nr], format("%s 18/%d", stat_names[v_nr], player_ptr->stat_max_max[v_nr] - 18), sizeof(self_ptr->s_string[v_nr]));
         self_ptr->info[self_ptr->line++] = self_ptr->s_string[v_nr];
     }
 }
@@ -35,44 +35,42 @@ void display_virtue(PlayerType *player_ptr, self_info_type *self_ptr)
 {
     self_ptr->info[self_ptr->line++] = "";
     std::string alg = PlayerAlignment(player_ptr).get_alignment_description(true);
-    sprintf(self_ptr->plev_buf, _("現在の属性 : %s", "Your alignment : %s"), alg.data());
-    strcpy(self_ptr->buf[1], self_ptr->plev_buf);
+    strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("現在の属性 : %s", "Your alignment : %s"), alg.data());
+    angband_strcpy(self_ptr->buf[1], self_ptr->plev_buf, sizeof(self_ptr->buf[1]));
     self_ptr->info[self_ptr->line++] = self_ptr->buf[1];
     for (int v_nr = 0; v_nr < 8; v_nr++) {
-        GAME_TEXT vir_name[20];
-        char vir_desc[80];
+        std::string vir_name = virtue[(player_ptr->vir_types[v_nr]) - 1];
+        std::string vir_desc = format(_("おっと。%sの情報なし。", "Oops. No info about %s."), vir_name.data());
         int tester = player_ptr->virtues[v_nr];
-        strcpy(vir_name, virtue[(player_ptr->vir_types[v_nr]) - 1]);
-        sprintf(vir_desc, _("おっと。%sの情報なし。", "Oops. No info about %s."), vir_name);
         if (tester < -100) {
-            sprintf(vir_desc, _("[%s]の対極 (%d)", "You are the polar opposite of %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の対極 (%d)", "You are the polar opposite of %s (%d)."), vir_name.data(), tester);
         } else if (tester < -80) {
-            sprintf(vir_desc, _("[%s]の大敵 (%d)", "You are an arch-enemy of %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の大敵 (%d)", "You are an arch-enemy of %s (%d)."), vir_name.data(), tester);
         } else if (tester < -60) {
-            sprintf(vir_desc, _("[%s]の強敵 (%d)", "You are a bitter enemy of %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の強敵 (%d)", "You are a bitter enemy of %s (%d)."), vir_name.data(), tester);
         } else if (tester < -40) {
-            sprintf(vir_desc, _("[%s]の敵 (%d)", "You are an enemy of %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の敵 (%d)", "You are an enemy of %s (%d)."), vir_name.data(), tester);
         } else if (tester < -20) {
-            sprintf(vir_desc, _("[%s]の罪者 (%d)", "You have sinned against %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の罪者 (%d)", "You have sinned against %s (%d)."), vir_name.data(), tester);
         } else if (tester < 0) {
-            sprintf(vir_desc, _("[%s]の迷道者 (%d)", "You have strayed from the path of %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の迷道者 (%d)", "You have strayed from the path of %s (%d)."), vir_name.data(), tester);
         } else if (tester == 0) {
-            sprintf(vir_desc, _("[%s]の中立者 (%d)", "You are neutral to %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の中立者 (%d)", "You are neutral to %s (%d)."), vir_name.data(), tester);
         } else if (tester < 20) {
-            sprintf(vir_desc, _("[%s]の小徳者 (%d)", "You are somewhat virtuous in %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の小徳者 (%d)", "You are somewhat virtuous in %s (%d)."), vir_name.data(), tester);
         } else if (tester < 40) {
-            sprintf(vir_desc, _("[%s]の中徳者 (%d)", "You are virtuous in %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の中徳者 (%d)", "You are virtuous in %s (%d)."), vir_name.data(), tester);
         } else if (tester < 60) {
-            sprintf(vir_desc, _("[%s]の高徳者 (%d)", "You are very virtuous in %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の高徳者 (%d)", "You are very virtuous in %s (%d)."), vir_name.data(), tester);
         } else if (tester < 80) {
-            sprintf(vir_desc, _("[%s]の覇者 (%d)", "You are a champion of %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の覇者 (%d)", "You are a champion of %s (%d)."), vir_name.data(), tester);
         } else if (tester < 100) {
-            sprintf(vir_desc, _("[%s]の偉大な覇者 (%d)", "You are a great champion of %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の偉大な覇者 (%d)", "You are a great champion of %s (%d)."), vir_name.data(), tester);
         } else {
-            sprintf(vir_desc, _("[%s]の具現者 (%d)", "You are the living embodiment of %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の具現者 (%d)", "You are the living embodiment of %s (%d)."), vir_name.data(), tester);
         }
 
-        strcpy(self_ptr->v_string[v_nr], vir_desc);
+        angband_strcpy(self_ptr->v_string[v_nr], vir_desc.data(), sizeof(self_ptr->v_string[v_nr]));
         self_ptr->info[self_ptr->line++] = self_ptr->v_string[v_nr];
     }
 }
@@ -84,7 +82,7 @@ void display_mimic_race_ability(PlayerType *player_ptr, self_info_type *self_ptr
         return;
     case MimicKindType::DEMON:
     case MimicKindType::DEMON_LORD:
-        sprintf(self_ptr->plev_buf, _("あなたは %d ダメージの地獄か火炎のブレスを吐くことができる。(%d MP)", "You can breathe nether, dam. %d (cost %d)."),
+        strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージの地獄か火炎のブレスを吐くことができる。(%d MP)", "You can breathe nether, dam. %d (cost %d)."),
             3 * player_ptr->lev, 10 + player_ptr->lev / 3);
 
         self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
@@ -94,7 +92,7 @@ void display_mimic_race_ability(PlayerType *player_ptr, self_info_type *self_ptr
             break;
         }
 
-        sprintf(self_ptr->plev_buf, _("あなたは敵から %d-%d HP の生命力を吸収できる。(%d MP)", "You can steal life from a foe, dam. %d-%d (cost %d)."),
+        strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは敵から %d-%d HP の生命力を吸収できる。(%d MP)", "You can steal life from a foe, dam. %d-%d (cost %d)."),
             player_ptr->lev + std::max(1, player_ptr->lev / 10), player_ptr->lev + player_ptr->lev * std::max(1, player_ptr->lev / 10),
             1 + (player_ptr->lev / 3));
         self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;

--- a/src/view/display-store.cpp
+++ b/src/view/display-store.cpp
@@ -17,6 +17,7 @@
 #include "system/terrain-type-definition.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/enum-converter.h"
 #include "util/int-char-converter.h"
 
@@ -29,9 +30,7 @@
 void store_prt_gold(PlayerType *player_ptr)
 {
     prt(_("手持ちのお金: ", "Gold Remaining: "), 19 + xtra_stock, 53);
-    char out_val[64];
-    sprintf(out_val, "%9ld", (long)player_ptr->au);
-    prt(out_val, 19 + xtra_stock, 68);
+    prt(format("%9ld", (long)player_ptr->au), 19 + xtra_stock, 68);
 }
 
 /*!
@@ -47,9 +46,7 @@ void display_entry(PlayerType *player_ptr, int pos, StoreSaleType store_num)
     int i = (pos % store_bottom);
 
     /* Label it, clear the line --(-- */
-    char out_val[160];
-    (void)sprintf(out_val, "%c) ", ((i > 25) ? toupper(I2A(i - 26)) : I2A(i)));
-    prt(out_val, i + 6, 0);
+    prt(format("%c) ", ((i > 25) ? toupper(I2A(i - 26)) : I2A(i))), i + 6, 0);
 
     int cur_col = 3;
     if (show_item_graph) {
@@ -78,8 +75,7 @@ void display_entry(PlayerType *player_ptr, int pos, StoreSaleType store_num)
         c_put_str(tval_to_attr[enum2i(o_ptr->bi_key.tval())], o_name, i + 6, cur_col);
         if (show_weights) {
             WEIGHT wgt = o_ptr->weight;
-            sprintf(out_val, _("%3d.%1d kg", "%3d.%d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
-            put_str(out_val, i + 6, _(67, 68));
+            put_str(format(_("%3d.%1d kg", "%3d.%d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10)), i + 6, _(67, 68));
         }
 
         return;
@@ -97,14 +93,12 @@ void display_entry(PlayerType *player_ptr, int pos, StoreSaleType store_num)
 
     if (show_weights) {
         int wgt = o_ptr->weight;
-        sprintf(out_val, "%3d.%1d", _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
-        put_str(out_val, i + 6, _(60, 61));
+        put_str(format("%3d.%1d", _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10)), i + 6, _(60, 61));
     }
 
     const auto price = price_item(player_ptr, o_ptr, ot_ptr->inflate, false, store_num);
 
-    (void)sprintf(out_val, "%9ld  ", (long)price);
-    put_str(out_val, i + 6, 68);
+    put_str(format("%9ld  ", (long)price), i + 6, 68);
 }
 
 /*!
@@ -181,12 +175,9 @@ void display_store(PlayerType *player_ptr, StoreSaleType store_num)
     concptr store_name = terrains_info[cur_store_feat].name.data();
     concptr owner_name = (ot_ptr->owner_name);
     concptr race_name = race_info[enum2i(ot_ptr->owner_race)].title;
-    char buf[80];
-    sprintf(buf, "%s (%s)", owner_name, race_name);
-    put_str(buf, 3, 10);
+    put_str(format("%s (%s)", owner_name, race_name), 3, 10);
 
-    sprintf(buf, "%s (%ld)", store_name, (long)(ot_ptr->max_cost));
-    prt(buf, 3, 50);
+    prt(format("%s (%ld)", store_name, (long)(ot_ptr->max_cost)), 3, 50);
 
     put_str(_("商品の一覧", "Item Description"), 5, 5);
     if (show_weights) {

--- a/src/view/display-util.cpp
+++ b/src/view/display-util.cpp
@@ -1,5 +1,6 @@
 ﻿#include "view/display-util.h"
 #include "term/term-color-types.h"
+#include <string>
 #include <vector>
 
 namespace {
@@ -85,7 +86,11 @@ void display_player_one_line(int entry, concptr val, TERM_COLOR attr)
     }
 
     int val_len = len - head_len;
-    char buf[40];
-    sprintf(buf, "%*.*s", val_len, val_len, val);
-    term_putstr(col + head_len, row, -1, attr, buf);
+    int ncopy = (int)std::min<size_t>((size_t)val_len, strlen(val));
+    std::string buf;
+    if (ncopy < val_len) {
+        buf.append(val_len - ncopy, ' ');
+    }
+    buf.append(val, ncopy);
+    term_putstr(col + head_len, row, -1, attr, buf.data());
 }

--- a/src/view/status-first-page.cpp
+++ b/src/view/status-first-page.cpp
@@ -27,6 +27,7 @@
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-util.h"
 
@@ -178,57 +179,55 @@ static int strengthen_basedam(PlayerType *player_ptr, ItemEntity *o_ptr, int bas
  * @param x 技能値
  * @param y 技能値に対するランク基準比
  */
-static concptr likert(int x, int y)
+static std::string likert(int x, int y)
 {
-    static char dummy[20] = "", dummy2[20] = "";
-    memset(dummy, 0, strlen(dummy));
-    memset(dummy2, 0, strlen(dummy2));
+    std::string result;
     if (y <= 0) {
         y = 1;
     }
 
     if (show_actual_value) {
-        sprintf(dummy, "%3d-", x);
+        result = format("%3d-", x);
     }
 
     if (x < 0) {
         likert_color = TERM_L_DARK;
-        strcat(dummy, _("最低", "Very Bad"));
-        return dummy;
+        result.append(_("最低", "Very Bad"));
+        return result;
     }
 
     switch ((x / y)) {
     case 0:
     case 1: {
         likert_color = TERM_RED;
-        strcat(dummy, _("悪い", "Bad"));
+        result.append(_("悪い", "Bad"));
         break;
     }
     case 2: {
         likert_color = TERM_L_RED;
-        strcat(dummy, _("劣る", "Poor"));
+        result.append(_("劣る", "Poor"));
         break;
     }
     case 3:
     case 4: {
         likert_color = TERM_ORANGE;
-        strcat(dummy, _("普通", "Fair"));
+        result.append(_("普通", "Fair"));
         break;
     }
     case 5: {
         likert_color = TERM_YELLOW;
-        strcat(dummy, _("良い", "Good"));
+        result.append(_("良い", "Good"));
         break;
     }
     case 6: {
         likert_color = TERM_YELLOW;
-        strcat(dummy, _("大変良い", "Very Good"));
+        result.append(_("大変良い", "Very Good"));
         break;
     }
     case 7:
     case 8: {
         likert_color = TERM_L_GREEN;
-        strcat(dummy, _("卓越", "Excellent"));
+        result.append(_("卓越", "Excellent"));
         break;
     }
     case 9:
@@ -237,7 +236,7 @@ static concptr likert(int x, int y)
     case 12:
     case 13: {
         likert_color = TERM_GREEN;
-        strcat(dummy, _("超越", "Superb"));
+        result.append(_("超越", "Superb"));
         break;
     }
     case 14:
@@ -245,18 +244,17 @@ static concptr likert(int x, int y)
     case 16:
     case 17: {
         likert_color = TERM_BLUE;
-        strcat(dummy, _("英雄的", "Heroic"));
+        result.append(_("英雄的", "Heroic"));
         break;
     }
     default: {
         likert_color = TERM_VIOLET;
-        sprintf(dummy2, _("伝説的[%d]", "Legendary[%d]"), (int)((((x / y) - 17) * 5) / 2));
-        strcat(dummy, dummy2);
+        result.append(format(_("伝説的[%d]", "Legendary[%d]"), (int)((((x / y) - 17) * 5) / 2)));
         break;
     }
     }
 
-    return dummy;
+    return result;
 }
 
 /*!
@@ -354,35 +352,23 @@ static void display_first_page(PlayerType *player_ptr, int xthb, int *damage, in
     int xfos = player_ptr->skill_fos;
     int xdig = player_ptr->skill_dig;
 
-    concptr desc = likert(xthn, 12);
-    display_player_one_line(ENTRY_SKILL_FIGHT, desc, likert_color);
+    display_player_one_line(ENTRY_SKILL_FIGHT, likert(xthn, 12).data(), likert_color);
 
-    desc = likert(xthb, 12);
-    display_player_one_line(ENTRY_SKILL_SHOOT, desc, likert_color);
+    display_player_one_line(ENTRY_SKILL_SHOOT, likert(xthb, 12).data(), likert_color);
 
-    desc = likert(xsav, 7);
-    display_player_one_line(ENTRY_SKILL_SAVING, desc, likert_color);
+    display_player_one_line(ENTRY_SKILL_SAVING, likert(xsav, 7).data(), likert_color);
 
-    desc = likert((xstl > 0) ? xstl : -1, 1);
-    display_player_one_line(ENTRY_SKILL_STEALTH, desc, likert_color);
+    display_player_one_line(ENTRY_SKILL_STEALTH, likert((xstl > 0) ? xstl : -1, 1).data(), likert_color);
 
-    desc = likert(xfos, 6);
-    display_player_one_line(ENTRY_SKILL_PERCEP, desc, likert_color);
+    display_player_one_line(ENTRY_SKILL_PERCEP, likert(xfos, 6).data(), likert_color);
 
-    desc = likert(xsrh, 6);
-    display_player_one_line(ENTRY_SKILL_SEARCH, desc, likert_color);
+    display_player_one_line(ENTRY_SKILL_SEARCH, likert(xsrh, 6).data(), likert_color);
 
-    desc = likert(xdis, 8);
-    display_player_one_line(ENTRY_SKILL_DISARM, desc, likert_color);
+    display_player_one_line(ENTRY_SKILL_DISARM, likert(xdis, 8).data(), likert_color);
 
-    desc = likert(xdev, 6);
-    display_player_one_line(ENTRY_SKILL_DEVICE, desc, likert_color);
+    display_player_one_line(ENTRY_SKILL_DEVICE, likert(xdev, 6).data(), likert_color);
 
-    desc = likert(xdev, 6);
-    display_player_one_line(ENTRY_SKILL_DEVICE, desc, likert_color);
-
-    desc = likert(xdig, 4);
-    display_player_one_line(ENTRY_SKILL_DIG, desc, likert_color);
+    display_player_one_line(ENTRY_SKILL_DIG, likert(xdig, 4).data(), likert_color);
 
     if (!muta_att) {
         display_player_one_line(ENTRY_BLOWS, format("%d+%d", blows1, blows2), TERM_L_BLUE);
@@ -392,6 +378,7 @@ static void display_first_page(PlayerType *player_ptr, int xthb, int *damage, in
 
     display_player_one_line(ENTRY_SHOTS, format("%d.%02d", shots, shot_frac), TERM_L_BLUE);
 
+    concptr desc;
     if ((damage[0] + damage[1]) == 0) {
         desc = "nil!";
     } else {

--- a/src/window/display-sub-window-spells.cpp
+++ b/src/window/display-sub-window-spells.cpp
@@ -15,6 +15,7 @@
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "timed-effect/player-stun.h"
 #include "timed-effect/timed-effects.h"
 #include "util/int-char-converter.h"
@@ -33,7 +34,6 @@ static void display_spell_list(PlayerType *player_ptr)
     int m[9];
     const magic_type *s_ptr;
     GAME_TEXT name[MAX_NLEN];
-    char out_val[160];
 
     clear_from(0);
 
@@ -53,7 +53,6 @@ static void display_spell_list(PlayerType *player_ptr)
         PERCENTAGE chance = 0;
         mind_type spell;
         char comment[80];
-        char psi_desc[160];
         MindKindType use_mind;
         bool use_hp = false;
 
@@ -124,9 +123,8 @@ static void display_spell_list(PlayerType *player_ptr)
             }
 
             mindcraft_info(player_ptr, comment, use_mind, i);
-            sprintf(psi_desc, "  %c) %-30s%2d %4d %3d%%%s", I2A(i), spell.name, spell.min_lev, spell.mana_cost, chance, comment);
 
-            term_putstr(x, y + i + 1, -1, a, psi_desc);
+            term_putstr(x, y + i + 1, -1, a, format("  %c) %-30s%2d %4d %3d%%%s", I2A(i), spell.name, spell.min_lev, spell.mana_cost, chance, comment));
         }
 
         return;
@@ -163,10 +161,8 @@ static void display_spell_list(PlayerType *player_ptr)
                 a = TERM_YELLOW;
             }
 
-            sprintf(out_val, "%c/%c) %-20.20s", I2A(n / 8), I2A(n % 8), name);
-
             m[j] = y + n;
-            term_putstr(x, m[j], -1, a, out_val);
+            term_putstr(x, m[j], -1, a, format("%c/%c) %-20.20s", I2A(n / 8), I2A(n % 8), name));
             n++;
         }
     }

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -37,6 +37,7 @@
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "timed-effect/player-hallucination.h"
 #include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
@@ -108,7 +109,7 @@ void fix_inventory(PlayerType *player_ptr)
  */
 static void print_monster_line(TERM_LEN x, TERM_LEN y, MonsterEntity *m_ptr, int n_same, int n_awake)
 {
-    char buf[256];
+    std::string buf;
     MonsterRaceId r_idx = m_ptr->ap_r_idx;
     auto *r_ptr = &monraces_info[r_idx];
 
@@ -118,26 +119,25 @@ static void print_monster_line(TERM_LEN x, TERM_LEN y, MonsterEntity *m_ptr, int
         return;
     }
     if (r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
-        sprintf(buf, _("%3s(覚%2d)", "%3s(%2d)"), MonsterRace(r_idx).is_bounty(true) ? "  W" : "  U", n_awake);
-        term_addstr(-1, TERM_WHITE, buf);
+        buf = format(_("%3s(覚%2d)", "%3s(%2d)"), MonsterRace(r_idx).is_bounty(true) ? "  W" : "  U", n_awake);
     } else {
-        sprintf(buf, _("%3d(覚%2d)", "%3d(%2d)"), n_same, n_awake);
-        term_addstr(-1, TERM_WHITE, buf);
+        buf = format(_("%3d(覚%2d)", "%3d(%2d)"), n_same, n_awake);
     }
+    term_addstr(-1, TERM_WHITE, buf.data());
 
     term_addstr(-1, TERM_WHITE, " ");
     term_add_bigch(r_ptr->x_attr, r_ptr->x_char);
 
     if (r_ptr->r_tkills && m_ptr->mflag2.has_not(MonsterConstantFlagType::KAGE)) {
-        sprintf(buf, " %2d", (int)r_ptr->level);
+        buf = format(" %2d", (int)r_ptr->level);
     } else {
-        strcpy(buf, " ??");
+        buf = " ??";
     }
 
-    term_addstr(-1, TERM_WHITE, buf);
+    term_addstr(-1, TERM_WHITE, buf.data());
 
-    sprintf(buf, " %s ", r_ptr->name.data());
-    term_addstr(-1, TERM_WHITE, buf);
+    buf = format(" %s ", r_ptr->name.data());
+    term_addstr(-1, TERM_WHITE, buf.data());
 }
 
 /*!
@@ -250,7 +250,6 @@ static void display_equipment(PlayerType *player_ptr, const ItemTester &item_tes
     term_get_size(&wid, &hgt);
 
     TERM_COLOR attr = TERM_WHITE;
-    char tmp_val[80];
     GAME_TEXT o_name[MAX_NLEN];
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         int cur_row = i - INVEN_MAIN_HAND;
@@ -260,7 +259,7 @@ static void display_equipment(PlayerType *player_ptr, const ItemTester &item_tes
 
         auto o_ptr = &player_ptr->inventory_list[i];
         auto do_disp = player_ptr->select_ring_slot ? is_ring_slot(i) : item_tester.okay(o_ptr);
-        strcpy(tmp_val, "   ");
+        std::string tmp_val = "   ";
 
         if (do_disp) {
             tmp_val[0] = index_to_label(i);
@@ -269,7 +268,7 @@ static void display_equipment(PlayerType *player_ptr, const ItemTester &item_tes
 
         int cur_col = 3;
         term_erase(cur_col, cur_row, 255);
-        term_putstr(0, cur_row, cur_col, TERM_WHITE, tmp_val);
+        term_putstr(0, cur_row, cur_col, TERM_WHITE, tmp_val.data());
 
         if ((((i == INVEN_MAIN_HAND) && can_attack_with_sub_hand(player_ptr)) || ((i == INVEN_SUB_HAND) && can_attack_with_main_hand(player_ptr))) && has_two_handed_weapons(player_ptr)) {
             strcpy(o_name, _("(武器を両手持ち)", "(wielding with two-hands)"));
@@ -298,8 +297,8 @@ static void display_equipment(PlayerType *player_ptr, const ItemTester &item_tes
         term_putstr(cur_col, cur_row, n, attr, o_name);
         if (show_weights) {
             int wgt = o_ptr->weight * o_ptr->number;
-            sprintf(tmp_val, _("%3d.%1d kg", "%3d.%1d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
-            prt(tmp_val, cur_row, wid - (show_labels ? 28 : 9));
+            tmp_val = format(_("%3d.%1d kg", "%3d.%1d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
+            prt(tmp_val.data(), cur_row, wid - (show_labels ? 28 : 9));
         }
 
         if (show_labels) {
@@ -583,34 +582,34 @@ static void display_floor_item_list(PlayerType *player_ptr, const int y, const i
 
     auto *floor_ptr = player_ptr->current_floor_ptr;
     const auto *g_ptr = &floor_ptr->grid_array[y][x];
-    char line[1024];
+    std::string line;
 
     // 先頭行を書く。
     auto is_hallucinated = player_ptr->effects()->hallucination()->is_hallucinated();
     if (player_bold(player_ptr, y, x)) {
-        sprintf(line, _("(X:%03d Y:%03d) あなたの足元のアイテム一覧", "Items at (%03d,%03d) under you"), x, y);
+        line = format(_("(X:%03d Y:%03d) あなたの足元のアイテム一覧", "Items at (%03d,%03d) under you"), x, y);
     } else if (const auto *m_ptr = monster_on_floor_items(floor_ptr, g_ptr); m_ptr != nullptr) {
         if (is_hallucinated) {
-            sprintf(line, _("(X:%03d Y:%03d) 何か奇妙な物の足元の発見済みアイテム一覧", "Found items at (%03d,%03d) under something strange"), x, y);
+            line = format(_("(X:%03d Y:%03d) 何か奇妙な物の足元の発見済みアイテム一覧", "Found items at (%03d,%03d) under something strange"), x, y);
         } else {
             const MonsterRaceInfo *const r_ptr = &monraces_info[m_ptr->ap_r_idx];
-            sprintf(line, _("(X:%03d Y:%03d) %sの足元の発見済みアイテム一覧", "Found items at (%03d,%03d) under %s"), x, y, r_ptr->name.data());
+            line = format(_("(X:%03d Y:%03d) %sの足元の発見済みアイテム一覧", "Found items at (%03d,%03d) under %s"), x, y, r_ptr->name.data());
         }
     } else {
         const TerrainType *const f_ptr = &terrains_info[g_ptr->feat];
         concptr fn = f_ptr->name.data();
-        char buf[512];
+        std::string buf;
 
         if (f_ptr->flags.has(TerrainCharacteristics::STORE) || (f_ptr->flags.has(TerrainCharacteristics::BLDG) && !floor_ptr->inside_arena)) {
-            sprintf(buf, _("%sの入口", "on the entrance of %s"), fn);
+            buf = format(_("%sの入口", "on the entrance of %s"), fn);
         } else if (f_ptr->flags.has(TerrainCharacteristics::WALL)) {
-            sprintf(buf, _("%sの中", "in %s"), fn);
+            buf = format(_("%sの中", "in %s"), fn);
         } else {
-            sprintf(buf, _("%s", "on %s"), fn);
+            buf = format(_("%s", "on %s"), fn);
         }
-        sprintf(line, _("(X:%03d Y:%03d) %sの上の発見済みアイテム一覧", "Found items at (X:%03d Y:%03d) %s"), x, y, buf);
+        line = format(_("(X:%03d Y:%03d) %sの上の発見済みアイテム一覧", "Found items at (X:%03d Y:%03d) %s"), x, y, buf.data());
     }
-    term_addstr(-1, TERM_WHITE, line);
+    term_addstr(-1, TERM_WHITE, line.data());
 
     // (y,x) のアイテムを1行に1個ずつ書く。
     TERM_LEN term_y = 1;
@@ -632,9 +631,10 @@ static void display_floor_item_list(PlayerType *player_ptr, const int y, const i
         if (is_hallucinated) {
             term_addstr(-1, TERM_WHITE, _("何か奇妙な物", "something strange"));
         } else {
-            describe_flavor(player_ptr, line, o_ptr, 0);
+            char buf[1024];
+            describe_flavor(player_ptr, buf, o_ptr, 0);
             TERM_COLOR attr = tval_to_attr[enum2i(tval) % 128];
-            term_addstr(-1, attr, line);
+            term_addstr(-1, attr, buf);
         }
 
         ++term_y;

--- a/src/window/main-window-equipments.cpp
+++ b/src/window/main-window-equipments.cpp
@@ -17,6 +17,8 @@
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
+#include "util/string-processor.h"
 
 /*!
  * @brief メインウィンドウの右上に装備アイテムの表示させる
@@ -88,15 +90,15 @@ COMMAND_CODE show_equipment(PlayerType *player_ptr, int target_item, BIT_FLAGS m
         prt("", j + 1, col ? col - 2 : col);
         if (use_menu && target_item) {
             if (j == (target_item - 1)) {
-                strcpy(tmp_val, _("》", "> "));
+                angband_strcpy(tmp_val, _("》", "> "), sizeof(tmp_val));
                 target_item_label = i;
             } else {
-                strcpy(tmp_val, "  ");
+                angband_strcpy(tmp_val, "  ", sizeof(tmp_val));
             }
         } else if (i >= INVEN_MAIN_HAND) {
-            sprintf(tmp_val, "%c)", equip_label[i - INVEN_MAIN_HAND]);
+            strnfmt(tmp_val, sizeof(tmp_val), "%c)", equip_label[i - INVEN_MAIN_HAND]);
         } else {
-            sprintf(tmp_val, "%c)", index_to_label(i));
+            strnfmt(tmp_val, sizeof(tmp_val), "%c)", index_to_label(i));
         }
 
         put_str(tmp_val, j + 1, col);
@@ -113,7 +115,7 @@ COMMAND_CODE show_equipment(PlayerType *player_ptr, int target_item, BIT_FLAGS m
         }
 
         if (show_labels) {
-            (void)sprintf(tmp_val, _("%-7s: ", "%-14s: "), mention_use(player_ptr, i));
+            strnfmt(tmp_val, sizeof(tmp_val), _("%-7s: ", "%-14s: "), mention_use(player_ptr, i));
             put_str(tmp_val, j + 1, cur_col);
             c_put_str(out_color[j], out_desc[j], j + 1, _(cur_col + 9, cur_col + 16));
         } else {
@@ -125,7 +127,7 @@ COMMAND_CODE show_equipment(PlayerType *player_ptr, int target_item, BIT_FLAGS m
         }
 
         int wgt = o_ptr->weight * o_ptr->number;
-        (void)sprintf(tmp_val, _("%3d.%1d kg", "%3d.%d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
+        strnfmt(tmp_val, sizeof(tmp_val), _("%3d.%1d kg", "%3d.%d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
         prt(tmp_val, j + 1, wid - 9);
     }
 

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -14,6 +14,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "timed-effect/player-hallucination.h"
 #include "timed-effect/timed-effects.h"
 #include "util/string-processor.h"
@@ -50,14 +51,13 @@ void print_title(PlayerType *player_ptr)
  */
 void print_level(PlayerType *player_ptr)
 {
-    char tmp[32];
-    sprintf(tmp, "%5d", player_ptr->lev);
+    std::string tmp = format("%5d", player_ptr->lev);
     if (player_ptr->lev >= player_ptr->max_plv) {
         put_str(_("レベル ", "LEVEL "), ROW_LEVEL, 0);
-        c_put_str(TERM_L_GREEN, tmp, ROW_LEVEL, COL_LEVEL + 7);
+        c_put_str(TERM_L_GREEN, tmp.data(), ROW_LEVEL, COL_LEVEL + 7);
     } else {
         put_str(_("xレベル", "Level "), ROW_LEVEL, 0);
-        c_put_str(TERM_YELLOW, tmp, ROW_LEVEL, COL_LEVEL + 7);
+        c_put_str(TERM_YELLOW, tmp.data(), ROW_LEVEL, COL_LEVEL + 7);
     }
 }
 
@@ -66,16 +66,16 @@ void print_level(PlayerType *player_ptr)
  */
 void print_exp(PlayerType *player_ptr)
 {
-    char out_val[32];
+    std::string out_val;
 
     PlayerRace pr(player_ptr);
     if ((!exp_need) || pr.equals(PlayerRaceType::ANDROID)) {
-        (void)sprintf(out_val, "%8ld", (long)player_ptr->exp);
+        out_val = format("%8ld", (long)player_ptr->exp);
     } else {
         if (player_ptr->lev >= PY_MAX_LEVEL) {
-            (void)sprintf(out_val, "********");
+            out_val = "********";
         } else {
-            (void)sprintf(out_val, "%8ld", (long)(player_exp[player_ptr->lev - 1] * player_ptr->expfact / 100L) - player_ptr->exp);
+            out_val = format("%8ld", (long)(player_exp[player_ptr->lev - 1] * player_ptr->expfact / 100L) - player_ptr->exp);
         }
     }
 
@@ -85,10 +85,10 @@ void print_exp(PlayerType *player_ptr)
         } else {
             put_str(_("経験 ", "EXP "), ROW_EXP, 0);
         }
-        c_put_str(TERM_L_GREEN, out_val, ROW_EXP, COL_EXP + 4);
+        c_put_str(TERM_L_GREEN, out_val.data(), ROW_EXP, COL_EXP + 4);
     } else {
         put_str(_("x経験", "Exp "), ROW_EXP, 0);
-        c_put_str(TERM_YELLOW, out_val, ROW_EXP, COL_EXP + 4);
+        c_put_str(TERM_YELLOW, out_val.data(), ROW_EXP, COL_EXP + 4);
     }
 }
 
@@ -97,17 +97,15 @@ void print_exp(PlayerType *player_ptr)
  */
 void print_ac(PlayerType *player_ptr)
 {
-    char tmp[32];
+    std::string tmp = format("%5d", player_ptr->dis_ac + player_ptr->dis_to_a);
 
 #ifdef JP
     /* AC の表示方式を変更している */
     put_str(" ＡＣ(     )", ROW_AC, COL_AC);
-    sprintf(tmp, "%5d", player_ptr->dis_ac + player_ptr->dis_to_a);
-    c_put_str(TERM_L_GREEN, tmp, ROW_AC, COL_AC + 6);
+    c_put_str(TERM_L_GREEN, tmp.data(), ROW_AC, COL_AC + 6);
 #else
     put_str("Cur AC ", ROW_AC, COL_AC);
-    sprintf(tmp, "%5d", player_ptr->dis_ac + player_ptr->dis_to_a);
-    c_put_str(TERM_L_GREEN, tmp, ROW_AC, COL_AC + 7);
+    c_put_str(TERM_L_GREEN, tmp.data(), ROW_AC, COL_AC + 7);
 #endif
 }
 
@@ -116,9 +114,7 @@ void print_ac(PlayerType *player_ptr)
  */
 void print_hp(PlayerType *player_ptr)
 {
-    char tmp[32];
     put_str("HP", ROW_CURHP, COL_CURHP);
-    sprintf(tmp, "%4ld", (long int)player_ptr->chp);
     TERM_COLOR color;
     if (player_ptr->chp >= player_ptr->mhp) {
         color = TERM_L_GREEN;
@@ -128,11 +124,10 @@ void print_hp(PlayerType *player_ptr)
         color = TERM_RED;
     }
 
-    c_put_str(color, tmp, ROW_CURHP, COL_CURHP + 3);
+    c_put_str(color, format("%4ld", (long int)player_ptr->chp), ROW_CURHP, COL_CURHP + 3);
     put_str("/", ROW_CURHP, COL_CURHP + 7);
-    sprintf(tmp, "%4ld", (long int)player_ptr->mhp);
     color = TERM_L_GREEN;
-    c_put_str(color, tmp, ROW_CURHP, COL_CURHP + 8);
+    c_put_str(color, format("%4ld", (long int)player_ptr->mhp), ROW_CURHP, COL_CURHP + 8);
 }
 
 /*!
@@ -140,14 +135,12 @@ void print_hp(PlayerType *player_ptr)
  */
 void print_sp(PlayerType *player_ptr)
 {
-    char tmp[32];
-    byte color;
     if ((mp_ptr->spell_book == ItemKindType::NONE) && mp_ptr->spell_first == SPELL_FIRST_NO_SPELL) {
         return;
     }
 
     put_str(_("MP", "SP"), ROW_CURSP, COL_CURSP);
-    sprintf(tmp, "%4ld", (long int)player_ptr->csp);
+    byte color;
     if (player_ptr->csp >= player_ptr->msp) {
         color = TERM_L_GREEN;
     } else if (player_ptr->csp > (player_ptr->msp * mana_warn) / 10) {
@@ -156,11 +149,10 @@ void print_sp(PlayerType *player_ptr)
         color = TERM_RED;
     }
 
-    c_put_str(color, tmp, ROW_CURSP, COL_CURSP + 3);
+    c_put_str(color, format("%4ld", (long int)player_ptr->csp), ROW_CURSP, COL_CURSP + 3);
     put_str("/", ROW_CURSP, COL_CURSP + 7);
-    sprintf(tmp, "%4ld", (long int)player_ptr->msp);
     color = TERM_L_GREEN;
-    c_put_str(color, tmp, ROW_CURSP, COL_CURSP + 8);
+    c_put_str(color, format("%4ld", (long int)player_ptr->msp), ROW_CURSP, COL_CURSP + 8);
 }
 
 /*!
@@ -169,10 +161,8 @@ void print_sp(PlayerType *player_ptr)
  */
 void print_gold(PlayerType *player_ptr)
 {
-    char tmp[32];
     put_str(_("＄ ", "AU "), ROW_GOLD, COL_GOLD);
-    sprintf(tmp, "%9ld", (long)player_ptr->au);
-    c_put_str(TERM_L_GREEN, tmp, ROW_GOLD, COL_GOLD + 3);
+    c_put_str(TERM_L_GREEN, format("%9ld", (long)player_ptr->au), ROW_GOLD, COL_GOLD + 3);
 }
 
 /*!
@@ -181,7 +171,6 @@ void print_gold(PlayerType *player_ptr)
  */
 void print_depth(PlayerType *player_ptr)
 {
-    char depths[32];
     TERM_COLOR attr = TERM_WHITE;
 
     TERM_LEN wid, hgt;
@@ -191,21 +180,20 @@ void print_depth(PlayerType *player_ptr)
 
     auto *floor_ptr = player_ptr->current_floor_ptr;
     if (!floor_ptr->dun_level) {
-        strcpy(depths, _("地上", "Surf."));
-        c_prt(attr, format("%7s", depths), row_depth, col_depth);
+        c_prt(attr, format("%7s", _("地上", "Surf.")), row_depth, col_depth);
         return;
     }
 
     if (inside_quest(floor_ptr->quest_number) && !player_ptr->dungeon_idx) {
-        strcpy(depths, _("地上", "Quest"));
-        c_prt(attr, format("%7s", depths), row_depth, col_depth);
+        c_prt(attr, format("%7s", _("地上", "Quest")), row_depth, col_depth);
         return;
     }
 
+    std::string depths;
     if (depth_in_feet) {
-        (void)sprintf(depths, _("%d ft", "%d ft"), (int)floor_ptr->dun_level * 50);
+        depths = format(_("%d ft", "%d ft"), (int)floor_ptr->dun_level * 50);
     } else {
-        (void)sprintf(depths, _("%d 階", "Lev %d"), (int)floor_ptr->dun_level);
+        depths = format(_("%d 階", "Lev %d"), (int)floor_ptr->dun_level);
     }
 
     switch (player_ptr->feeling) {
@@ -244,7 +232,7 @@ void print_depth(PlayerType *player_ptr)
         break; /* Boring place */
     }
 
-    c_prt(attr, format("%7s", depths), row_depth, col_depth);
+    c_prt(attr, format("%7s", depths.data()), row_depth, col_depth);
 }
 
 /*!

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -22,6 +22,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "timed-effect/player-blindness.h"
 #include "timed-effect/player-confusion.h"
 #include "timed-effect/player-cut.h"
@@ -158,37 +159,38 @@ void print_hunger(PlayerType *player_ptr)
 void print_state(PlayerType *player_ptr)
 {
     TERM_COLOR attr = TERM_WHITE;
-    GAME_TEXT text[16];
+    std::string text;
     if (command_rep) {
         if (command_rep > 999) {
-            (void)sprintf(text, "%2d00", command_rep / 100);
+            text = format("%2d00", command_rep / 100);
         } else {
-            (void)sprintf(text, "  %2d", command_rep);
+            text = format("  %2d", command_rep);
         }
 
-        c_put_str(attr, format("%5.5s", text), ROW_STATE, COL_STATE);
+        c_put_str(attr, format("%5.5s", text.data()), ROW_STATE, COL_STATE);
         return;
     }
 
     switch (player_ptr->action) {
     case ACTION_SEARCH: {
-        strcpy(text, _("探索", "Sear"));
+        text = _("探索", "Sear");
         break;
     }
     case ACTION_REST:
-        strcpy(text, _("    ", "    "));
         if (player_ptr->resting > 0) {
-            sprintf(text, "%4d", player_ptr->resting);
+            text = format("%4d", player_ptr->resting);
         } else if (player_ptr->resting == COMMAND_ARG_REST_FULL_HEALING) {
-            text[0] = text[1] = text[2] = text[3] = '*';
+            text = "****";
         } else if (player_ptr->resting == COMMAND_ARG_REST_UNTIL_DONE) {
-            text[0] = text[1] = text[2] = text[3] = '&';
+            text = "&&&&";
+        } else {
+            text = "    ";
         }
 
         break;
 
     case ACTION_LEARN: {
-        strcpy(text, _("学習", "lear"));
+        text = _("学習", "lear");
         auto bluemage_data = PlayerClass(player_ptr).get_specific_data<bluemage_data_type>();
         if (bluemage_data->new_magic_learned) {
             attr = TERM_L_RED;
@@ -196,7 +198,7 @@ void print_state(PlayerType *player_ptr)
         break;
     }
     case ACTION_FISH: {
-        strcpy(text, _("釣り", "fish"));
+        text = _("釣り", "fish");
         break;
     }
     case ACTION_MONK_STANCE: {
@@ -218,36 +220,36 @@ void print_state(PlayerType *player_ptr)
             default:
                 break;
             }
-            strcpy(text, monk_stances[enum2i(stance) - 1].desc);
+            text = monk_stances[enum2i(stance) - 1].desc;
         }
         break;
     }
     case ACTION_SAMURAI_STANCE: {
         if (auto stance = PlayerClass(player_ptr).get_samurai_stance();
             stance != SamuraiStanceType::NONE) {
-            strcpy(text, samurai_stances[enum2i(stance) - 1].desc);
+            text = samurai_stances[enum2i(stance) - 1].desc;
         }
         break;
     }
     case ACTION_SING: {
-        strcpy(text, _("歌  ", "Sing"));
+        text = _("歌  ", "Sing");
         break;
     }
     case ACTION_HAYAGAKE: {
-        strcpy(text, _("速駆", "Fast"));
+        text = _("速駆", "Fast");
         break;
     }
     case ACTION_SPELL: {
-        strcpy(text, _("詠唱", "Spel"));
+        text = _("詠唱", "Spel");
         break;
     }
     default: {
-        strcpy(text, "    ");
+        text = "    ";
         break;
     }
     }
 
-    c_put_str(attr, format("%5.5s", text), ROW_STATE, COL_STATE);
+    c_put_str(attr, format("%5.5s", text.data()), ROW_STATE, COL_STATE);
 }
 
 /*!
@@ -264,7 +266,7 @@ void print_speed(PlayerType *player_ptr)
     const auto speed = player_ptr->pspeed - STANDARD_SPEED;
     auto *floor_ptr = player_ptr->current_floor_ptr;
     bool is_player_fast = is_fast(player_ptr);
-    char buf[32] = "";
+    std::string buf;
     TERM_COLOR attr = TERM_WHITE;
     if (speed > 0) {
         auto is_slow = player_ptr->effects()->deceleration()->is_slow();
@@ -284,7 +286,7 @@ void print_speed(PlayerType *player_ptr)
         } else {
             attr = TERM_L_GREEN;
         }
-        sprintf(buf, "%s(+%d)", (player_ptr->riding ? _("乗馬", "Ride") : _("加速", "Fast")), speed);
+        buf = format("%s(+%d)", (player_ptr->riding ? _("乗馬", "Ride") : _("加速", "Fast")), speed);
     } else if (speed < 0) {
         auto is_slow = player_ptr->effects()->deceleration()->is_slow();
         if (player_ptr->riding) {
@@ -303,13 +305,13 @@ void print_speed(PlayerType *player_ptr)
         } else {
             attr = TERM_L_UMBER;
         }
-        sprintf(buf, "%s(%d)", (player_ptr->riding ? _("乗馬", "Ride") : _("減速", "Slow")), speed);
+        buf = format("%s(%d)", (player_ptr->riding ? _("乗馬", "Ride") : _("減速", "Slow")), speed);
     } else if (player_ptr->riding) {
         attr = TERM_GREEN;
-        strcpy(buf, _("乗馬中", "Riding"));
+        buf = _("乗馬中", "Riding");
     }
 
-    c_put_str(attr, format("%-9s", buf), row_speed, col_speed);
+    c_put_str(attr, format("%-9s", buf.data()), row_speed, col_speed);
 }
 
 /*!

--- a/src/wizard/fixed-artifacts-spoiler.cpp
+++ b/src/wizard/fixed-artifacts-spoiler.cpp
@@ -20,42 +20,36 @@
  */
 void spoiler_outlist(concptr header, concptr *list, char separator)
 {
-    char line[MAX_LINE_LEN + 20], buf[80];
     if (*list == nullptr) {
         return;
     }
 
-    strcpy(line, spoiler_indent);
+    std::string line = spoiler_indent;
     if (header && (header[0])) {
-        strcat(line, header);
-        strcat(line, " ");
+        line.append(header);
+        line.append(" ");
     }
 
-    int buf_len;
-    int line_len = strlen(line);
     while (true) {
-        strcpy(buf, *list);
-        buf_len = strlen(buf);
+        std::string elem = *list;
         if (list[1]) {
-            sprintf(buf + buf_len, "%c ", separator);
-            buf_len += 2;
+            elem.push_back(separator);
+            elem.push_back(' ');
         }
 
-        if (line_len + buf_len <= MAX_LINE_LEN) {
-            strcat(line, buf);
-            line_len += buf_len;
+        if (line.length() + elem.length() <= MAX_LINE_LEN) {
+            line.append(elem);
         } else {
-            if (line_len > 1 && line[line_len - 1] == ' ' && line[line_len - 2] == list_separator) {
-                line[line_len - 2] = '\0';
-                fprintf(spoiler_file, "%s\n", line);
-                sprintf(line, "%s%s", spoiler_indent, buf);
+            if (line.length() > 1 && line[line.length() - 1] == ' ' && line[line.length() - 2] == list_separator) {
+                line[line.length() - 2] = '\0';
+                fprintf(spoiler_file, "%s\n", line.data());
+                line = spoiler_indent;
+                line.append(elem);
             } else {
-                fprintf(spoiler_file, "%s\n", line);
-                concptr ident2 = "      ";
-                sprintf(line, "%s%s", ident2, buf);
+                fprintf(spoiler_file, "%s\n", line.data());
+                line = "      ";
+                line.append(elem);
             }
-
-            line_len = strlen(line);
         }
 
         if (!*++list) {
@@ -63,7 +57,7 @@ void spoiler_outlist(concptr header, concptr *list, char separator)
         }
     }
 
-    fprintf(spoiler_file, "%s\n", line);
+    fprintf(spoiler_file, "%s\n", line.data());
 }
 
 /*!
@@ -71,11 +65,9 @@ void spoiler_outlist(concptr header, concptr *list, char separator)
  */
 static void print_header(void)
 {
-    char buf[360];
     char title[180];
     put_version(title);
-    sprintf(buf, "Artifact Spoilers for Hengband Version %s", title);
-    spoiler_underline(buf);
+    spoiler_underline(std::string("Artifact Spoilers for Hengband Version ").append(title).data());
 }
 
 /*!
@@ -118,11 +110,9 @@ static bool make_fake_artifact(ItemEntity *o_ptr, FixedArtifactId fixed_artifact
 static void spoiler_print_art(obj_desc_list *art_ptr)
 {
     pval_info_type *pval_ptr = &art_ptr->pval_info;
-    char buf[80];
     fprintf(spoiler_file, "%s\n", art_ptr->description);
     if (pval_ptr->pval_desc[0]) {
-        sprintf(buf, _("%sの修正:", "%s to"), pval_ptr->pval_desc);
-        spoiler_outlist(buf, pval_ptr->pval_affects, item_separator);
+        spoiler_outlist(std::string(pval_ptr->pval_desc).append(_("の修正:", " to")).data(), pval_ptr->pval_affects, item_separator);
     }
 
     spoiler_outlist(_("対:", "Slay"), art_ptr->slays, item_separator);

--- a/src/wizard/items-spoiler.cpp
+++ b/src/wizard/items-spoiler.cpp
@@ -9,6 +9,7 @@
 #include "system/baseitem-info.h"
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "view/display-messages.h"
 #include "wizard/spoiler-util.h"
@@ -26,7 +27,7 @@
  * @param value 価値を返すバッファ参照ポインタ
  * @param bi_id ベースアイテムID
  */
-static void describe_baseitem_info(PlayerType *player_ptr, char *name, char *damage_desc, char *weight_desc, char *chance_desc, DEPTH *level, PRICE *value, short bi_id)
+static void describe_baseitem_info(PlayerType *player_ptr, char *name, std::string *damage_desc, std::string *weight_desc, std::string *chance_desc, DEPTH *level, PRICE *value, short bi_id)
 {
     ItemEntity forge;
     auto *q_ptr = &forge;
@@ -43,18 +44,17 @@ static void describe_baseitem_info(PlayerType *player_ptr, char *name, char *dam
     }
 
     describe_flavor(player_ptr, name, q_ptr, OD_NAME_ONLY | OD_STORE);
-    strcpy(damage_desc, "");
     switch (q_ptr->bi_key.tval()) {
     case ItemKindType::SHOT:
     case ItemKindType::BOLT:
     case ItemKindType::ARROW:
-        sprintf(damage_desc, "%dd%d", q_ptr->dd, q_ptr->ds);
+        *damage_desc = format("%dd%d", q_ptr->dd, q_ptr->ds);
         break;
     case ItemKindType::HAFTED:
     case ItemKindType::POLEARM:
     case ItemKindType::SWORD:
     case ItemKindType::DIGGING:
-        sprintf(damage_desc, "%dd%d", q_ptr->dd, q_ptr->ds);
+        *damage_desc = format("%dd%d", q_ptr->dd, q_ptr->ds);
         break;
     case ItemKindType::BOOTS:
     case ItemKindType::GLOVES:
@@ -65,24 +65,23 @@ static void describe_baseitem_info(PlayerType *player_ptr, char *name, char *dam
     case ItemKindType::SOFT_ARMOR:
     case ItemKindType::HARD_ARMOR:
     case ItemKindType::DRAG_ARMOR:
-        sprintf(damage_desc, "%d", q_ptr->ac);
+        *damage_desc = format("%d", q_ptr->ac);
         break;
     default:
+        damage_desc->clear();
         break;
     }
 
-    strcpy(chance_desc, "");
+    chance_desc->clear();
     const auto &baseitem = baseitems_info[q_ptr->bi_id];
     for (auto i = 0U; i < baseitem.alloc_tables.size(); i++) {
         const auto &[level, chance] = baseitem.alloc_tables[i];
-        char chance_aux[20] = "";
         if (chance > 0) {
-            sprintf(chance_aux, "%s%3dF:%+4d", (i != 0 ? "/" : ""), level, 100 / chance);
-            strcat(chance_desc, chance_aux);
+            chance_desc->append(format("%s%3dF:%+4d", (i != 0 ? "/" : ""), level, 100 / chance));
         }
     }
 
-    sprintf(weight_desc, "%3d.%d", (int)(q_ptr->weight / 10), (int)(q_ptr->weight % 10));
+    *weight_desc = format("%3d.%d", (int)(q_ptr->weight / 10), (int)(q_ptr->weight % 10));
 }
 
 /*!
@@ -131,12 +130,12 @@ SpoilerOutputResultType spoil_obj_desc(concptr fname)
         for (const auto &bi_id : whats) {
             DEPTH e;
             PRICE v;
-            char wgt[80];
-            char chance[80];
-            char dam[80];
+            std::string wgt, chance, dam;
             PlayerType dummy;
-            describe_baseitem_info(&dummy, buf, dam, wgt, chance, &e, &v, bi_id);
-            fprintf(spoiler_file, "  %-35s%8s%7s%5d %-40s%9ld\n", buf, dam, wgt, static_cast<int>(e), chance, static_cast<long>(v));
+            describe_baseitem_info(&dummy, buf, &dam, &wgt, &chance, &e, &v, bi_id);
+            fprintf(spoiler_file, "  %-35s%8s%7s%5d %-40s%9ld\n", buf,
+                dam.data(), wgt.data(), static_cast<int>(e), chance.data(),
+                static_cast<long>(v));
         }
     }
 

--- a/src/wizard/monster-info-spoiler.cpp
+++ b/src/wizard/monster-info-spoiler.cpp
@@ -7,6 +7,7 @@
 #include "system/angband-version.h"
 #include "system/monster-race-info.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/bit-flags-calculator.h"
 #include "util/sort.h"
@@ -77,13 +78,6 @@ SpoilerOutputResultType spoil_mon_desc(concptr fname, std::function<bool(const M
     PlayerType dummy;
     uint16_t why = 2;
     char buf[1024];
-    char nam[MAX_MONSTER_NAME + 10]; // ユニークには[U] が付くので少し伸ばす
-    char lev[80];
-    char rar[80];
-    char spd[80];
-    char ac[80];
-    char hp[80];
-    char symbol[80];
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, fname);
     spoiler_file = angband_fopen(buf, "w");
     if (!spoiler_file) {
@@ -121,27 +115,31 @@ SpoilerOutputResultType spoil_mon_desc(concptr fname, std::function<bool(const M
         }
 
         const auto name = str_separate(r_ptr->name, 40);
+        std::string nam;
         if (r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
-            sprintf(nam, "[U] %s", name.front().data());
+            nam = "[U] ";
         } else if (r_ptr->population_flags.has(MonsterPopulationType::NAZGUL)) {
-            sprintf(nam, "[N] %s", name.front().data());
+            nam = "[N] ";
         } else {
-            sprintf(nam, _("    %s", "The %s"), name.front().data());
+            nam = _("    ", "The ");
         }
+        nam.append(name.front());
 
-        sprintf(lev, "%d", (int)r_ptr->level);
-        sprintf(rar, "%d", (int)r_ptr->rarity);
-        sprintf(spd, "%+d", r_ptr->speed - STANDARD_SPEED);
-        sprintf(ac, "%d", r_ptr->ac);
+        std::string lev = format("%d", (int)r_ptr->level);
+        std::string rar = format("%d", (int)r_ptr->rarity);
+        std::string spd = format("%+d", r_ptr->speed - STANDARD_SPEED);
+        std::string ac = format("%d", r_ptr->ac);
+        std::string hp;
         if (any_bits(r_ptr->flags1, RF1_FORCE_MAXHP) || (r_ptr->hside == 1)) {
-            sprintf(hp, "%d", r_ptr->hdice * r_ptr->hside);
+            hp = format("%d", r_ptr->hdice * r_ptr->hside);
         } else {
-            sprintf(hp, "%dd%d", r_ptr->hdice, r_ptr->hside);
+            hp = format("%dd%d", r_ptr->hdice, r_ptr->hside);
         }
 
-        sprintf(symbol, "%ld", (long)(r_ptr->mexp));
-        sprintf(symbol, "%s '%c'", attr_to_text(r_ptr), r_ptr->d_char);
-        fprintf(spoiler_file, "%-45.45s%4s %4s %4s %7s %7s  %19.19s\n", nam, lev, rar, spd, hp, ac, symbol);
+        std::string symbol = format("%s '%c'", attr_to_text(r_ptr), r_ptr->d_char);
+        fprintf(spoiler_file, "%-45.45s%4s %4s %4s %7s %7s  %19.19s\n",
+            nam.data(), lev.data(), rar.data(), spd.data(), hp.data(),
+            ac.data(), symbol.data());
 
         for (auto i = 1U; i < name.size(); ++i) {
             fprintf(spoiler_file, "    %s\n", name[i].data());
@@ -182,8 +180,7 @@ SpoilerOutputResultType spoil_mon_info(concptr fname)
 
     char title[200];
     put_version(title);
-    sprintf(buf, "Monster Spoilers for %s\n", title);
-    spoil_out(buf);
+    spoil_out(std::string("Monster Spoilers for ").append(title).append("\n").data());
     spoil_out("------------------------------------------\n\n");
 
     std::vector<MonsterRaceId> who;
@@ -203,32 +200,22 @@ SpoilerOutputResultType spoil_mon_info(concptr fname)
             spoil_out("[N] ");
         }
 
-        sprintf(buf, _("%s/%s  (", "%s%s ("), r_ptr->name.data(), _(r_ptr->E_name.data(), "")); /* ---)--- */
-        spoil_out(buf);
+        spoil_out(std::string(format(_("%s/%s  (", "%s%s ("), r_ptr->name.data(), _(r_ptr->E_name.data(), ""))).data()); /* ---)--- */
         spoil_out(attr_to_text(r_ptr));
-        sprintf(buf, " '%c')\n", r_ptr->d_char);
-        spoil_out(buf);
-        sprintf(buf, "=== ");
-        spoil_out(buf);
-        sprintf(buf, "Num:%d  ", enum2i(r_idx));
-        spoil_out(buf);
-        sprintf(buf, "Lev:%d  ", (int)r_ptr->level);
-        spoil_out(buf);
-        sprintf(buf, "Rar:%d  ", r_ptr->rarity);
-        spoil_out(buf);
-        sprintf(buf, "Spd:%+d  ", r_ptr->speed - STANDARD_SPEED);
-        spoil_out(buf);
+        spoil_out(std::string(format(" '%c'\n)", r_ptr->d_char)).data());
+        spoil_out("=== ");
+        spoil_out(std::string(format("Num:%d  ", enum2i(r_idx))).data());
+        spoil_out(std::string(format("Lev:%d  ", (int)r_ptr->level)).data());
+        spoil_out(std::string(format("Rar:%d  ", r_ptr->rarity)).data());
+        spoil_out(std::string(format("Spd:+d  ", r_ptr->speed - STANDARD_SPEED)).data());
         if (any_bits(r_ptr->flags1, RF1_FORCE_MAXHP) || (r_ptr->hside == 1)) {
-            sprintf(buf, "Hp:%d  ", r_ptr->hdice * r_ptr->hside);
+            spoil_out(std::string(format("Hp:%d  ", r_ptr->hdice * r_ptr->hside)).data());
         } else {
-            sprintf(buf, "Hp:%dd%d  ", r_ptr->hdice, r_ptr->hside);
+            spoil_out(std::string(format("Hp:%dd%d  ", r_ptr->hdice, r_ptr->hside)).data());
         }
 
-        spoil_out(buf);
-        sprintf(buf, "Ac:%d  ", r_ptr->ac);
-        spoil_out(buf);
-        sprintf(buf, "Exp:%ld\n", (long)(r_ptr->mexp));
-        spoil_out(buf);
+        spoil_out(std::string(format("Ac:%d  ", r_ptr->ac)).data());
+        spoil_out(std::string(format("Exp:%ld\n", (long)(r_ptr->mexp))).data());
         output_monster_spoiler(r_idx, roff_func);
         spoil_out(nullptr);
     }

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -37,6 +37,7 @@
 #include "system/system-variables.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
 #include "util/string-processor.h"
@@ -435,7 +436,7 @@ static void wiz_statistics(PlayerType *player_ptr, ItemEntity *o_ptr)
             break;
         }
 
-        sprintf(tmp_val, "%ld", (long int)test_roll);
+        strnfmt(tmp_val, sizeof(tmp_val), "%ld", (long int)test_roll);
         if (get_string(p, tmp_val, 10)) {
             test_roll = atol(tmp_val);
         }
@@ -596,7 +597,7 @@ static void wiz_tweak_item(PlayerType *player_ptr, ItemEntity *o_ptr)
 
     concptr p = "Enter new 'pval' setting: ";
     char tmp_val[80];
-    sprintf(tmp_val, "%d", o_ptr->pval);
+    strnfmt(tmp_val, sizeof(tmp_val), "%d", o_ptr->pval);
     if (!get_string(p, tmp_val, 5)) {
         return;
     }
@@ -604,7 +605,7 @@ static void wiz_tweak_item(PlayerType *player_ptr, ItemEntity *o_ptr)
     o_ptr->pval = clamp_cast<int16_t>(atoi(tmp_val));
     wiz_display_item(player_ptr, o_ptr);
     p = "Enter new 'to_a' setting: ";
-    sprintf(tmp_val, "%d", o_ptr->to_a);
+    strnfmt(tmp_val, sizeof(tmp_val), "%d", o_ptr->to_a);
     if (!get_string(p, tmp_val, 5)) {
         return;
     }
@@ -612,7 +613,7 @@ static void wiz_tweak_item(PlayerType *player_ptr, ItemEntity *o_ptr)
     o_ptr->to_a = clamp_cast<int16_t>(atoi(tmp_val));
     wiz_display_item(player_ptr, o_ptr);
     p = "Enter new 'to_h' setting: ";
-    sprintf(tmp_val, "%d", o_ptr->to_h);
+    strnfmt(tmp_val, sizeof(tmp_val), "%d", o_ptr->to_h);
     if (!get_string(p, tmp_val, 5)) {
         return;
     }
@@ -620,7 +621,7 @@ static void wiz_tweak_item(PlayerType *player_ptr, ItemEntity *o_ptr)
     o_ptr->to_h = clamp_cast<int16_t>(atoi(tmp_val));
     wiz_display_item(player_ptr, o_ptr);
     p = "Enter new 'to_d' setting: ";
-    sprintf(tmp_val, "%d", (int)o_ptr->to_d);
+    strnfmt(tmp_val, sizeof(tmp_val), "%d", (int)o_ptr->to_d);
     if (!get_string(p, tmp_val, 5)) {
         return;
     }
@@ -643,7 +644,7 @@ static void wiz_quantity_item(ItemEntity *o_ptr)
 
     int tmp_qnt = o_ptr->number;
     char tmp_val[100];
-    sprintf(tmp_val, "%d", (int)o_ptr->number);
+    strnfmt(tmp_val, sizeof(tmp_val), "%d", (int)o_ptr->number);
     if (get_string("Quantity: ", tmp_val, 2)) {
         int tmp_int = atoi(tmp_val);
         if (tmp_int < 1) {

--- a/src/wizard/wizard-messages.cpp
+++ b/src/wizard/wizard-messages.cpp
@@ -3,6 +3,7 @@
 #include "game-option/cheat-types.h"
 #include "io/write-diary.h"
 #include "view/display-messages.h"
+#include <string>
 
 void msg_print_wizard(PlayerType *player_ptr, int cheat_type, concptr msg)
 {
@@ -19,13 +20,14 @@ void msg_print_wizard(PlayerType *player_ptr, int cheat_type, concptr msg)
         return;
     }
 
-    concptr cheat_mes[] = { "ITEM", "MONS", "DUNG", "MISC" };
-    char buf[1024 + 32];
-    sprintf(buf, "WIZ-%s:%s", cheat_mes[cheat_type], msg);
+    concptr cheat_mes[] = { "ITEM:", "MONS:", "DUNG:", "MISC:" };
+    std::string buf = "WIZ-";
+    buf.append(cheat_mes[cheat_type]);
+    buf.append(msg);
     msg_print(buf);
 
     if (cheat_diary_output) {
-        exe_write_diary(player_ptr, DIARY_WIZARD_LOG, 0, buf);
+        exe_write_diary(player_ptr, DIARY_WIZARD_LOG, 0, buf.data());
     }
 }
 

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -90,6 +90,7 @@
 #include "system/terrain-type-definition.h"
 #include "target/grid-selector.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/bit-flags-calculator.h"
 #include "util/enum-converter.h"
@@ -413,8 +414,8 @@ void wiz_change_status(PlayerType *player_ptr)
     char tmp_val[160];
     char ppp[80];
     for (int i = 0; i < A_MAX; i++) {
-        sprintf(ppp, "%s (3-%d): ", stat_names[i], player_ptr->stat_max_max[i]);
-        sprintf(tmp_val, "%d", player_ptr->stat_max[i]);
+        strnfmt(ppp, sizeof(ppp), "%s (3-%d): ", stat_names[i], player_ptr->stat_max_max[i]);
+        strnfmt(tmp_val, sizeof(tmp_val), "%d", player_ptr->stat_max[i]);
         if (!get_string(ppp, tmp_val, 3)) {
             return;
         }
@@ -429,7 +430,7 @@ void wiz_change_status(PlayerType *player_ptr)
         player_ptr->stat_cur[i] = player_ptr->stat_max[i] = (BASE_STATUS)tmp_int;
     }
 
-    sprintf(tmp_val, "%d", PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER));
+    strnfmt(tmp_val, sizeof(tmp_val), "%d", PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER));
     if (!get_string(_("熟練度: ", "Proficiency: "), tmp_val, 4)) {
         return;
     }
@@ -462,7 +463,7 @@ void wiz_change_status(PlayerType *player_ptr)
         player_ptr->spell_exp[k] = std::min(PlayerSkill::spell_exp_at(PlayerSkillRank::EXPERT), tmp_s16b);
     }
 
-    sprintf(tmp_val, "%ld", (long)(player_ptr->au));
+    strnfmt(tmp_val, sizeof(tmp_val), "%ld", (long)(player_ptr->au));
     if (!get_string("Gold: ", tmp_val, 9)) {
         return;
     }
@@ -473,7 +474,7 @@ void wiz_change_status(PlayerType *player_ptr)
     }
 
     player_ptr->au = tmp_long;
-    sprintf(tmp_val, "%ld", (long)(player_ptr->max_exp));
+    strnfmt(tmp_val, sizeof(tmp_val), "%ld", (long)(player_ptr->max_exp));
     if (!get_string("Experience: ", tmp_val, 9)) {
         return;
     }
@@ -547,11 +548,9 @@ static bool select_debugging_dungeon(PlayerType *player_ptr, DUNGEON_IDX *dungeo
     }
 
     while (true) {
-        char ppp[80];
         char tmp_val[160];
-        sprintf(ppp, "Jump which dungeon : ");
-        sprintf(tmp_val, "%d", player_ptr->dungeon_idx);
-        if (!get_string(ppp, tmp_val, 2)) {
+        strnfmt(tmp_val, sizeof(tmp_val), "%d", player_ptr->dungeon_idx);
+        if (!get_string("Jump which dungeon : ", tmp_val, 2)) {
             return false;
         }
 
@@ -584,8 +583,8 @@ static bool select_debugging_floor(PlayerType *player_ptr, int dungeon_type)
     while (true) {
         char ppp[80];
         char tmp_val[160];
-        sprintf(ppp, "Jump to level (0, %d-%d): ", min_depth, max_depth);
-        sprintf(tmp_val, "%d", (int)player_ptr->current_floor_ptr->dun_level);
+        strnfmt(ppp, sizeof(ppp), "Jump to level (0, %d-%d): ", min_depth, max_depth);
+        strnfmt(tmp_val, sizeof(tmp_val), "%d", (int)player_ptr->current_floor_ptr->dun_level);
         if (!get_string(ppp, tmp_val, 10)) {
             return false;
         }

--- a/src/wizard/wizard-spoiler.cpp
+++ b/src/wizard/wizard-spoiler.cpp
@@ -30,6 +30,7 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
@@ -106,8 +107,7 @@ static SpoilerOutputResultType spoil_mon_evol(concptr fname)
 
     char title[200];
     put_version(title);
-    sprintf(buf, "Monster Spoilers for %s\n", title);
-    spoil_out(buf);
+    spoil_out(std::string("Monster Spoilers for ").append(title).append("\n").data());
 
     spoil_out("------------------------------------------\n\n");
 
@@ -188,8 +188,7 @@ static SpoilerOutputResultType spoil_player_spell(concptr fname)
 
     char title[200];
     put_version(title);
-    sprintf(buf, "Player Spells for %s\n", title);
-    spoil_out(buf);
+    spoil_out(std::string("Player spells for ").append(title).append("\n").data());
     spoil_out("------------------------------------------\n\n");
 
     PlayerType dummy_p;
@@ -197,8 +196,7 @@ static SpoilerOutputResultType spoil_player_spell(concptr fname)
 
     for (int c = 0; c < PLAYER_CLASS_TYPE_MAX; c++) {
         auto class_ptr = &class_info[c];
-        sprintf(buf, "[[Class: %s]]\n", class_ptr->title);
-        spoil_out(buf);
+        spoil_out(std::string("[[Class: ").append(class_ptr->title).append("]]\n").data());
 
         auto magic_ptr = &class_magics_info[c];
         concptr book_name = "なし";
@@ -212,23 +210,19 @@ static SpoilerOutputResultType spoil_player_spell(concptr fname)
             *s = '\0';
         }
 
-        sprintf(buf, "BookType:%s Stat:%s Xtra:%x Type:%d Weight:%d\n", book_name, wiz_spell_stat[magic_ptr->spell_stat].data(), magic_ptr->spell_xtra,
-            magic_ptr->spell_type, magic_ptr->spell_weight);
-        spoil_out(buf);
+        spoil_out(std::string(format("BookType:%s Stat:%s Xtra:%x Type:%d Weight:%d\n", book_name, wiz_spell_stat[magic_ptr->spell_stat].data(), magic_ptr->spell_xtra, magic_ptr->spell_type, magic_ptr->spell_weight)).data());
         if (magic_ptr->spell_book == ItemKindType::NONE) {
             spoil_out(_("呪文なし\n\n", "No spells.\n\n"));
             continue;
         }
 
         for (int16_t r = 1; r < MAX_MAGIC; r++) {
-            sprintf(buf, "[Realm: %s]\n", realm_names[r]);
-            spoil_out(buf);
+            spoil_out(std::string("[Realm: ").append(realm_names[r]).append("\n").data());
             spoil_out("Name                     Lv Cst Dif Exp\n");
             for (SPELL_IDX i = 0; i < 32; i++) {
                 auto spell_ptr = &magic_ptr->info[r][i];
                 auto spell_name = exe_spell(&dummy_p, r, i, SpellProcessType::NAME);
-                sprintf(buf, "%-24s %2d %3d %3d %3d\n", spell_name, spell_ptr->slevel, spell_ptr->smana, spell_ptr->sfail, spell_ptr->sexp);
-                spoil_out(buf);
+                spoil_out(std::string(format("%-24s %2d %3d %3d %3d\n", spell_name, spell_ptr->slevel, spell_ptr->smana, spell_ptr->sfail, spell_ptr->sexp)).data());
             }
             spoil_out("\n");
         }


### PR DESCRIPTION
…resolving https://github.com/hengband/hengband/issues/2858 and https://github.com/hengband/hengband/issues/2859.

Typically used strnfmt() (from term/z-form.h) as the replacement.  In core/scores.cpp and term/z-form.cpp used snprintf() (the former was already using snprintf(); the latter is too avoid recursion in the implementation of vstrnfmt()).  In some cases where sprintf() was used without any arguments to the format string, it was replaced with angband_strcpy().  In the spirit of checking buffer limits, some instances of strcpy() and strcat() that were near replaced instances of sprintf() were replaced with angband_strcpy() and angband_strcat().

Did not replace sprintf() in globally visible functions where the buffer was passed in without a length.  Those are:  learnt_info() (and the file-level static, set_bluemage_damage(), it calls) in blue-magic/learnt-info.cpp, mane_info() in cmd-action/cmd-mane.cpp, object_desc_num() in flavor/flavor-util.cpp, get_table_name() and get_table_sindarin() in flavor/object-flavor.cpp, sindarin_to_kana() in locale/japanese.cpp, dice_to_string() in lore/lore-calculator.cpp, get_element_effect_info() in mind/mind-elementalist.cpp, mindcraft_info() (and the file-level static functions it calls) in mind/mind-info.cpp, and monster_desc() in monster/monster-describer.cpp.