### PR TITLE
[Fix] GCC 12 でビルドすると info-initializer.cpp でコンパイルエラーが発生する

### DIFF
--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -102,7 +102,8 @@ static errr init_info(std::string_view filename, angband_header &head, InfoType 
 
     constexpr auto info_is_vector = is_vector_v<InfoType>;
     if constexpr (info_is_vector) {
-        info.assign(head.info_num, {});
+        using value_type = typename InfoType::value_type;
+        info.assign(head.info_num, value_type{});
     }
 
     const auto err = init_info_txt(fp, buf, &head, parser);


### PR DESCRIPTION
Resolves #2854 

GCC 11 までは問題なかったが、GCC 12 で std::vector::assign に渡す第2引数に対し {} だけを指定すると、コンテナの要素の型のデフォルトコンストラクタ呼び出しだと推論されなくなったようでコンパイルエラーが発生する。
エラーを回避するため、型名を明示的に与えるようにする。

sprintf の警告については他PR（#2861）で対応しそうなので、このPRでではコンパイルエラーにのみ対処。 