### PR TITLE
[Refactor] flavor_type 構造体の show_weapon/show_armour メンバを削除

### DIFF
--- a/src/flavor/flavor-describer.cpp
+++ b/src/flavor/flavor-describer.cpp
@@ -38,6 +38,35 @@
 #include "util/string-processor.h"
 #include "window/display-sub-window-items.h"
 
+static void check_object_known_aware(flavor_type *flavor_ptr)
+{
+    flavor_ptr->tr_flags = object_flags(flavor_ptr->o_ptr);
+    if (flavor_ptr->o_ptr->is_aware()) {
+        flavor_ptr->aware = true;
+    }
+
+    if (flavor_ptr->o_ptr->is_known()) {
+        flavor_ptr->known = true;
+    }
+
+    if (flavor_ptr->aware && ((flavor_ptr->mode & OD_NO_FLAVOR) || plain_descriptions)) {
+        flavor_ptr->flavor = false;
+    }
+
+    if ((flavor_ptr->mode & OD_STORE) || (flavor_ptr->o_ptr->ident & IDENT_STORE)) {
+        flavor_ptr->flavor = false;
+        flavor_ptr->aware = true;
+        flavor_ptr->known = true;
+    }
+
+    if (flavor_ptr->mode & OD_FORCE_FLAVOR) {
+        flavor_ptr->aware = false;
+        flavor_ptr->flavor = true;
+        flavor_ptr->known = false;
+        flavor_ptr->flavor_k_ptr = flavor_ptr->k_ptr;
+    }
+}
+
 static void describe_chest_trap(flavor_type *flavor_ptr)
 {
     auto trap_kinds = chest_traps[flavor_ptr->o_ptr->pval];
@@ -559,6 +588,7 @@ void describe_flavor(PlayerType *player_ptr, char *buf, ItemEntity *o_ptr, BIT_F
 {
     flavor_type tmp_flavor;
     flavor_type *flavor_ptr = initialize_flavor_type(&tmp_flavor, buf, o_ptr, mode);
+    check_object_known_aware(flavor_ptr);
     describe_named_item(player_ptr, flavor_ptr);
     if (flavor_ptr->mode & OD_NAME_ONLY || o_ptr->bi_id == 0) {
         angband_strcpy(flavor_ptr->buf, flavor_ptr->tmp_val, MAX_NLEN);

--- a/src/flavor/flavor-describer.cpp
+++ b/src/flavor/flavor-describer.cpp
@@ -116,11 +116,9 @@ static void describe_chest(flavor_type *flavor_ptr)
     describe_chest_trap(flavor_ptr);
 }
 
-static void decide_tval_show(flavor_type *flavor_ptr)
+static bool should_show_ac_bonus(const ItemEntity &item)
 {
-    if (flavor_ptr->o_ptr->ac) {
-        flavor_ptr->show_armour = true;
-    }
+    return (item.ac != 0) || item.is_protector();
 }
 
 static bool should_show_slaying_bonus(const ItemEntity &item)
@@ -346,7 +344,7 @@ static void describe_spike_power(PlayerType *player_ptr, flavor_type *flavor_ptr
 
 static void describe_known_item_ac(flavor_type *flavor_ptr)
 {
-    if (flavor_ptr->show_armour) {
+    if (should_show_ac_bonus(*flavor_ptr->o_ptr)) {
         flavor_ptr->t = object_desc_chr(flavor_ptr->t, ' ');
         flavor_ptr->t = object_desc_chr(flavor_ptr->t, flavor_ptr->b1);
         flavor_ptr->t = object_desc_num(flavor_ptr->t, flavor_ptr->o_ptr->ac);
@@ -373,7 +371,7 @@ static void describe_ac(flavor_type *flavor_ptr)
         return;
     }
 
-    if (!flavor_ptr->show_armour) {
+    if (!should_show_ac_bonus(*flavor_ptr->o_ptr)) {
         return;
     }
 
@@ -568,7 +566,6 @@ void describe_flavor(PlayerType *player_ptr, char *buf, ItemEntity *o_ptr, BIT_F
     }
 
     describe_chest(flavor_ptr);
-    decide_tval_show(flavor_ptr);
     describe_tval(player_ptr, flavor_ptr);
     describe_named_item_tval(flavor_ptr);
     if (!(mode & OD_DEBUG)) {

--- a/src/flavor/flavor-util.cpp
+++ b/src/flavor/flavor-util.cpp
@@ -24,7 +24,6 @@ flavor_type *initialize_flavor_type(flavor_type *flavor_ptr, char *buf, ItemEnti
     flavor_ptr->aware = false;
     flavor_ptr->known = false;
     flavor_ptr->flavor = true;
-    flavor_ptr->show_weapon = false;
     flavor_ptr->show_armour = false;
     flavor_ptr->p1 = '(';
     flavor_ptr->p2 = ')';

--- a/src/flavor/flavor-util.cpp
+++ b/src/flavor/flavor-util.cpp
@@ -24,7 +24,6 @@ flavor_type *initialize_flavor_type(flavor_type *flavor_ptr, char *buf, ItemEnti
     flavor_ptr->aware = false;
     flavor_ptr->known = false;
     flavor_ptr->flavor = true;
-    flavor_ptr->show_armour = false;
     flavor_ptr->p1 = '(';
     flavor_ptr->p2 = ')';
     flavor_ptr->b1 = '[';

--- a/src/flavor/flavor-util.h
+++ b/src/flavor/flavor-util.h
@@ -19,7 +19,6 @@ struct flavor_type {
     bool aware;
     bool known; // 鑑定 or *鑑定* 済.
     bool flavor;
-    bool show_weapon;
     bool show_armour;
     concptr s;
     concptr s0;

--- a/src/flavor/flavor-util.h
+++ b/src/flavor/flavor-util.h
@@ -19,7 +19,6 @@ struct flavor_type {
     bool aware;
     bool known; // 鑑定 or *鑑定* 済.
     bool flavor;
-    bool show_armour;
     concptr s;
     concptr s0;
     char *t;

--- a/src/flavor/named-item-describer.cpp
+++ b/src/flavor/named-item-describer.cpp
@@ -25,35 +25,6 @@
 #include "system/monster-race-info.h"
 #endif
 
-static void check_object_known_aware(flavor_type *flavor_ptr)
-{
-    flavor_ptr->tr_flags = object_flags(flavor_ptr->o_ptr);
-    if (flavor_ptr->o_ptr->is_aware()) {
-        flavor_ptr->aware = true;
-    }
-
-    if (flavor_ptr->o_ptr->is_known()) {
-        flavor_ptr->known = true;
-    }
-
-    if (flavor_ptr->aware && ((flavor_ptr->mode & OD_NO_FLAVOR) || plain_descriptions)) {
-        flavor_ptr->flavor = false;
-    }
-
-    if ((flavor_ptr->mode & OD_STORE) || (flavor_ptr->o_ptr->ident & IDENT_STORE)) {
-        flavor_ptr->flavor = false;
-        flavor_ptr->aware = true;
-        flavor_ptr->known = true;
-    }
-
-    if (flavor_ptr->mode & OD_FORCE_FLAVOR) {
-        flavor_ptr->aware = false;
-        flavor_ptr->flavor = true;
-        flavor_ptr->known = false;
-        flavor_ptr->flavor_k_ptr = flavor_ptr->k_ptr;
-    }
-}
-
 static void set_base_name(flavor_type *flavor_ptr)
 {
     if (!flavor_ptr->aware || flavor_ptr->tr_flags.has_not(TR_FULL_NAME)) {
@@ -387,7 +358,6 @@ static void describe_inscription(flavor_type *flavor_ptr)
 
 void describe_named_item(PlayerType *player_ptr, flavor_type *flavor_ptr)
 {
-    check_object_known_aware(flavor_ptr);
     switch_tval_description(flavor_ptr);
     set_base_name(flavor_ptr);
     flavor_ptr->t = flavor_ptr->tmp_val;

--- a/src/flavor/tval-description-switcher.cpp
+++ b/src/flavor/tval-description-switcher.cpp
@@ -374,7 +374,6 @@ void switch_tval_description(flavor_type *flavor_ptr)
     case ItemKindType::SOFT_ARMOR:
     case ItemKindType::HARD_ARMOR:
     case ItemKindType::DRAG_ARMOR:
-        flavor_ptr->show_armour = true;
         break;
     case ItemKindType::LITE:
         break;

--- a/src/flavor/tval-description-switcher.cpp
+++ b/src/flavor/tval-description-switcher.cpp
@@ -111,10 +111,6 @@ static void describe_ring(flavor_type *flavor_ptr)
     } else {
         flavor_ptr->basenm = _("#指輪", "& # Ring~");
     }
-
-    if (!flavor_ptr->k_ptr->to_h && !flavor_ptr->k_ptr->to_d && (flavor_ptr->o_ptr->to_h || flavor_ptr->o_ptr->to_d)) {
-        flavor_ptr->show_weapon = true;
-    }
 }
 
 static void describe_staff(flavor_type *flavor_ptr)
@@ -368,7 +364,6 @@ void switch_tval_description(flavor_type *flavor_ptr)
     case ItemKindType::POLEARM:
     case ItemKindType::SWORD:
     case ItemKindType::DIGGING:
-        flavor_ptr->show_weapon = true;
         break;
     case ItemKindType::BOOTS:
     case ItemKindType::GLOVES:


### PR DESCRIPTION
まず #2865 のとっかかりとして、これらのメンバが実際に表示するときと全く異なる場所でセットされているため flavor_type 引数を削除しながらリファクタリングするうえで邪魔になるので先に削除しておく。