### PR TITLE
[Feature] 候補を表示して選択するクラス

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -624,6 +624,7 @@
     <ClCompile Include="..\..\src\timed-effect\player-poison.cpp" />
     <ClCompile Include="..\..\src\timed-effect\player-stun.cpp" />
     <ClCompile Include="..\..\src\timed-effect\timed-effects.cpp" />
+    <ClCompile Include="..\..\src\util\candidate-selector.cpp" />
     <ClCompile Include="..\..\src\util\rng-xoshiro.cpp" />
     <ClCompile Include="..\..\src\util\sha256.cpp" />
     <ClCompile Include="..\..\src\view\display-inventory.cpp" />
@@ -1432,6 +1433,7 @@
     <ClInclude Include="..\..\src\timed-effect\timed-effects.h" />
     <ClInclude Include="..\..\src\util\bit-flags-calculator.h" />
     <ClInclude Include="..\..\src\util\buffer-shaper.h" />
+    <ClInclude Include="..\..\src\util\candidate-selector.h" />
     <ClInclude Include="..\..\src\util\enum-converter.h" />
     <ClInclude Include="..\..\src\util\enum-range.h" />
     <ClInclude Include="..\..\src\util\finalizer.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2493,6 +2493,9 @@
     <ClCompile Include="..\..\src\main-win\main-win-exception.cpp">
       <Filter>main-win</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\util\candidate-selector.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5402,6 +5405,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\main-win\main-win-exception.h">
       <Filter>main-win</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\candidate-selector.h">
+      <Filter>util</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -967,6 +967,7 @@ hengband_SOURCES = \
 	util/angband-files.cpp util/angband-files.h \
 	util/buffer-shaper.cpp util/buffer-shaper.h \
 	util/bit-flags-calculator.h \
+	util/candidate-selector.cpp util/candidate-selector.h \
 	util/enum-converter.h \
 	util/enum-range.h \
 	util/finalizer.h \

--- a/src/util/candidate-selector.cpp
+++ b/src/util/candidate-selector.cpp
@@ -13,9 +13,15 @@ const std::array<char, 62> CandidateSelector::i2sym = {
     // clang-format on
 };
 
-CandidateSelector::CandidateSelector()
-    : prompt(_("選択: ", "Choose: "))
-    , start_col(0)
+/*!
+ * @brief CandidateSelectorクラスのコンストラクタ
+ *
+ * @param prompt 画面最上部に表示する文字列
+ * @param start_col 候補の表示を開始する列
+ */
+CandidateSelector::CandidateSelector(const std::string &prompt, int start_col)
+    : prompt(prompt)
+    , start_col(start_col)
 {
     this->set_max_per_page();
 }

--- a/src/util/candidate-selector.cpp
+++ b/src/util/candidate-selector.cpp
@@ -1,0 +1,61 @@
+#include "util/candidate-selector.h"
+#include <algorithm>
+#include <iterator>
+
+/*!
+ * @brief 候補の選択に使用するシンボルのリスト
+ */
+const std::array<char, 62> CandidateSelector::i2sym = {
+    // clang-format off
+    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+    // clang-format on
+};
+
+CandidateSelector::CandidateSelector()
+    : prompt(_("選択: ", "Choose: "))
+    , start_col(0)
+{
+    this->set_max_per_page();
+}
+
+std::pair<size_t, std::optional<size_t>> CandidateSelector::process_input(char cmd, size_t current_page, size_t page_max)
+{
+    switch (cmd) {
+    case ' ':
+        current_page++;
+        break;
+    case '-':
+        current_page += (page_max - 1);
+        break;
+    default:
+        if (auto select_sym_it = std::find(i2sym.begin(), i2sym.end(), cmd);
+            select_sym_it != i2sym.end()) {
+            const auto idx = static_cast<size_t>(std::distance(i2sym.begin(), select_sym_it));
+            return { current_page, idx };
+        }
+        break;
+    }
+
+    if (current_page >= page_max) {
+        current_page %= page_max;
+    }
+
+    return { current_page, std::nullopt };
+}
+
+/*!
+ * @brief 1ページに表示する候補の最大数を設定する
+ *
+ * 引数を省略した場合もしくは設定数が端末の高さより大きい場合は、端末の高さに合わせる
+ *
+ * @param max 1ページに表示する候補の最大数
+ */
+void CandidateSelector::set_max_per_page(size_t max)
+{
+    TERM_LEN term_w, term_h;
+    term_get_size(&term_w, &term_h);
+
+    this->max_per_page = std::min<size_t>(max, term_h - 2);
+}

--- a/src/util/candidate-selector.h
+++ b/src/util/candidate-selector.h
@@ -37,7 +37,7 @@ concept SizedContainer = requires(T t) {
  */
 class CandidateSelector {
 public:
-    CandidateSelector();
+    CandidateSelector(const std::string &prompt, int start_col = 0);
 
     void set_max_per_page(size_t max_per_page = std::numeric_limits<size_t>::max());
 
@@ -95,9 +95,6 @@ public:
         }
     }
 
-    std::string prompt;
-    int start_col;
-
 private:
     static std::pair<size_t, std::optional<size_t>> process_input(char cmd, size_t current_page, size_t page_max);
 
@@ -126,5 +123,8 @@ private:
     }
 
     static const std::array<char, 62> i2sym;
+
+    std::string prompt;
+    int start_col;
     size_t max_per_page;
 };

--- a/src/util/candidate-selector.h
+++ b/src/util/candidate-selector.h
@@ -1,0 +1,130 @@
+#pragma once
+
+#include "core/asking-player.h"
+#include "term/screen-processor.h"
+#include "util/finalizer.h"
+#include <array>
+#include <concepts>
+#include <limits>
+#include <optional>
+#include <sstream>
+#include <string>
+
+/// @note clang-formatによるconceptの整形が安定していないので抑制しておく
+// clang-format off
+/*!
+ * @brief 型Argのオブジェクトの説明を生成する関数の型Funcを表すコンセプト
+ */
+template <typename Func, typename Arg>
+concept Describer = requires(Func f, Arg a) {
+    { std::invoke(f, a) } -> std::convertible_to<std::string>;
+};
+
+/*!
+ * @brief サイズが既知のコンテナの型を表すコンセプト
+ */
+template <typename T>
+concept SizedContainer = requires(T t) {
+    { std::begin(t) } -> std::convertible_to<typename T::iterator>;
+    { std::end(t) } -> std::convertible_to<typename T::iterator>;
+    std::size(t);
+    typename T::value_type;
+};
+// clang-format on
+
+/*!
+ * @brief 候補を選択するためのクラス
+ */
+class CandidateSelector {
+public:
+    CandidateSelector();
+
+    void set_max_per_page(size_t max_per_page = std::numeric_limits<size_t>::max());
+
+    /*!
+     * @brief 引数で与えられた候補リストを画面に表示し選択する
+     *
+     * 最上行に prompt を表示し、次の行から候補を
+     *
+     * <pre>
+     * a) 候補1
+     * b) 候補2
+     *    ︙
+     * </pre>
+     *
+     * のように表示する。
+     * 候補名は関数 describe_candidate によって生成する。
+     *
+     * 先頭の記号をキーボードで入力することによって選択する。
+     * 与えられた要素の数が max_per_page を超える場合はページ分けを行い、
+     * ' ' によって次ページ、'-' によって前ページへの切り替えを行う。
+     * ESCキーを押すと選択をキャンセルする。
+     *
+     * @param candidates 選択する候補
+     * @param describe_candidates 候補名を生成する関数
+     * @return 選択した要素を指すイテレータ
+     *         キャンセルした場合はstd::end(candidates)
+     */
+    template <SizedContainer Candidates, Describer<typename Candidates::value_type> F>
+    typename Candidates::const_iterator select(const Candidates &candidates, F &&describe_candidate)
+    {
+        const auto candidates_count = std::size(candidates);
+        const auto page_max = (candidates_count - 1) / this->max_per_page + 1;
+        auto current_page = 0U;
+
+        screen_save();
+        const auto finalizer = util::make_finalizer([] { screen_load(); });
+
+        while (true) {
+            this->display_page(current_page, candidates, describe_candidate);
+
+            const auto cmd = input_command(this->prompt);
+            if (!cmd) {
+                return std::end(candidates);
+            }
+
+            const auto page_base_idx = current_page * this->max_per_page;
+            const auto page_item_count = std::min(this->max_per_page, candidates_count - page_base_idx);
+
+            const auto [new_page, idx] = process_input(*cmd, current_page, page_max);
+            if (idx && *idx < page_item_count) {
+                return std::next(std::begin(candidates), page_base_idx + *idx);
+            }
+
+            current_page = new_page;
+        }
+    }
+
+    std::string prompt;
+    int start_col;
+
+private:
+    static std::pair<size_t, std::optional<size_t>> process_input(char cmd, size_t current_page, size_t page_max);
+
+    template <SizedContainer Candidates, Describer<typename Candidates::value_type> F>
+    void display_page(size_t page, const Candidates &candidates, F &&describe_candidate)
+    {
+        const auto candidates_count = std::size(candidates);
+        const auto page_max = (candidates_count - 1) / this->max_per_page + 1;
+        const auto page_base_idx = page * this->max_per_page;
+        const auto page_item_count = std::min(this->max_per_page, candidates_count - page_base_idx);
+
+        for (auto i = 0U; i < this->max_per_page + 1; ++i) {
+            term_erase(this->start_col, i + 1, 255);
+        }
+
+        auto it = std::next(std::begin(candidates), page_base_idx);
+        for (auto i = 0U; i < page_item_count; ++i, ++it) {
+            std::stringstream ss;
+            ss << i2sym[i] << ") " << std::invoke(describe_candidate, *it);
+            put_str(ss.str(), i + 1, this->start_col);
+        }
+        if (page_max > 1) {
+            const auto page_info = format("-- more (%lu/%lu) --", page + 1, page_max);
+            put_str(page_info, page_item_count + 1, this->start_col);
+        }
+    }
+
+    static const std::array<char, 62> i2sym;
+    size_t max_per_page;
+};

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -286,9 +286,7 @@ static std::string wiz_make_named_artifact_desc(PlayerType *player_ptr, FixedArt
  */
 static std::optional<FixedArtifactId> wiz_select_named_artifact(PlayerType *player_ptr, const std::vector<FixedArtifactId> &a_idx_list)
 {
-    CandidateSelector cs;
-    cs.prompt = "Which artifact: ";
-    cs.start_col = 15;
+    CandidateSelector cs("Which artifact: ", 15);
 
     auto describe_artifact = [player_ptr](FixedArtifactId a_idx) { return wiz_make_named_artifact_desc(player_ptr, a_idx); };
     const auto it = cs.select(a_idx_list, describe_artifact);

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -92,6 +92,7 @@
 #include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/bit-flags-calculator.h"
+#include "util/candidate-selector.h"
 #include "util/enum-converter.h"
 #include "util/finalizer.h"
 #include "util/int-char-converter.h"
@@ -285,53 +286,13 @@ static std::string wiz_make_named_artifact_desc(PlayerType *player_ptr, FixedArt
  */
 static std::optional<FixedArtifactId> wiz_select_named_artifact(PlayerType *player_ptr, const std::vector<FixedArtifactId> &a_idx_list)
 {
-    constexpr auto MAX_PER_PAGE = 20UL;
-    const auto page_max = (a_idx_list.size() - 1) / MAX_PER_PAGE + 1;
-    auto current_page = 0UL;
+    CandidateSelector cs;
+    cs.prompt = "Which artifact: ";
+    cs.start_col = 15;
 
-    screen_save();
-
-    std::optional<FixedArtifactId> selected_a_idx;
-
-    while (!selected_a_idx.has_value()) {
-        const auto page_base_idx = current_page * MAX_PER_PAGE;
-        for (auto i = 0U; i < MAX_PER_PAGE + 1; ++i) {
-            term_erase(14, i + 1, 255);
-        }
-        const auto page_item_count = std::min(MAX_PER_PAGE, a_idx_list.size() - page_base_idx);
-        for (auto i = 0U; i < page_item_count; ++i) {
-            std::stringstream ss;
-            ss << I2A(i) << ") " << wiz_make_named_artifact_desc(player_ptr, a_idx_list[page_base_idx + i]);
-            put_str(ss.str(), i + 1, 15);
-        }
-        if (page_max > 1) {
-            put_str(format("-- more (%lu/%lu) --", current_page + 1, page_max), page_item_count + 1, 15);
-        }
-
-        const auto command = input_command("Which artifact: ");
-        const auto cmd = command.value_or(ESCAPE);
-        switch (cmd) {
-        case ESCAPE:
-            screen_load();
-            return selected_a_idx;
-        case ' ':
-            current_page++;
-            if (current_page >= page_max) {
-                current_page = 0;
-            }
-            break;
-        default:
-            const auto select_idx = A2I(cmd) + page_base_idx;
-            if (select_idx < a_idx_list.size()) {
-                selected_a_idx = a_idx_list[select_idx];
-            }
-            break;
-        }
-    }
-
-    screen_load();
-
-    return selected_a_idx;
+    auto describe_artifact = [player_ptr](FixedArtifactId a_idx) { return wiz_make_named_artifact_desc(player_ptr, a_idx); };
+    const auto it = cs.select(a_idx_list, describe_artifact);
+    return (it != a_idx_list.end()) ? std::make_optional(*it) : std::nullopt;
 }
 
 /**
@@ -370,21 +331,20 @@ void wiz_create_named_art(PlayerType *player_ptr)
     }
 
     std::optional<FixedArtifactId> create_a_idx;
-    while (!create_a_idx.has_value()) {
+    while (!create_a_idx) {
         const auto command = input_command("Kind of artifact: ");
-        const auto cmd = command.value_or(ESCAPE);
-        switch (cmd) {
-        case ESCAPE:
+        if (!command) {
             screen_load();
             return;
-        default:
-            if (auto idx = A2I(cmd); idx < group_artifact_list.size()) {
-                const auto &a_idx_list = wiz_collect_group_a_idx(group_artifact_list[idx]);
-                create_a_idx = wiz_select_named_artifact(player_ptr, a_idx_list);
-            }
-
-            break;
         }
+
+        const auto idx = A2I(*command);
+        if (idx >= group_artifact_list.size()) {
+            continue;
+        }
+
+        const auto a_idx_list = wiz_collect_group_a_idx(group_artifact_list[idx]);
+        create_a_idx = wiz_select_named_artifact(player_ptr, a_idx_list);
     }
 
     screen_load();


### PR DESCRIPTION
引数で与えられた候補を画面に表示して選択する関数テンプレート select_from_candidates を追加する。
使用例として、デバッグコマンドの固定アーティファクト生成の選択ルーチンをこの関数で置き換える。

#2779 の件について、ちょっと作ってみました。暫定として util/candidates-selector.h に置いていますが、もっとふさわしい場所があるかもしれず。(暫定なのでVSのファイルリストへの追加はしていない。ヘッダの追加だけならソリューションに追加しなくてもビルド自体はできるっぽい？)
ご意見募集。
