### PR TITLE
Avoid use of sprintf() in probed_monster_info().  That's part of …

### DIFF
--- a/src/player-attack/attack-chaos-effect.cpp
+++ b/src/player-attack/attack-chaos-effect.cpp
@@ -162,9 +162,7 @@ static void attack_probe(PlayerType *player_ptr, player_attack_type *pa_ptr)
 {
     msg_print(_("刃が敵を調査した...", "The blade probed your enemy..."));
     msg_print(nullptr);
-    char buf[256];
-    probed_monster_info(buf, player_ptr, pa_ptr->m_ptr, pa_ptr->r_ptr);
-    msg_print(buf);
+    msg_print(probed_monster_info(player_ptr, pa_ptr->m_ptr, pa_ptr->r_ptr));
     msg_print(nullptr);
     (void)lore_do_probe(player_ptr, pa_ptr->r_idx);
 }

--- a/src/spell-kind/spells-sight.h
+++ b/src/spell-kind/spells-sight.h
@@ -2,6 +2,7 @@
 
 #include "effect/attribute-types.h"
 #include "system/angband.h"
+#include <string>
 
 class MonsterRaceInfo;
 class MonsterEntity;
@@ -30,5 +31,5 @@ bool banish_monsters(PlayerType *player_ptr, int dist);
 bool turn_evil(PlayerType *player_ptr, int dam);
 bool turn_monsters(PlayerType *player_ptr, int dam);
 bool deathray_monsters(PlayerType *player_ptr);
-void probed_monster_info(char *buf, PlayerType *player_ptr, MonsterEntity *m_ptr, MonsterRaceInfo *r_ptr);
+std::string probed_monster_info(PlayerType *player_ptr, MonsterEntity *m_ptr, MonsterRaceInfo *r_ptr);
 bool probing(PlayerType *player_ptr);


### PR DESCRIPTION
…resolving https://github.com/hengband/hengband/issues/2858 and https://github.com/hengband/hengband/issues/2859 .

This is a reopening of https://github.com/hengband/hengband/pull/2877 which I closed by an errant forced push.  The changes here should address Hourier's concerns:  no calls to data() when passing the string to message_add() or msg_print(), change the description of the return value from probed_monster_info(), use "const auto" when receiving the result of probed_monster_info() in probing(), and rename some local variables to avoid shadowing names.