### PR TITLE
[Fix] mon-info.txt に出力される情報がおかしい

### DIFF
--- a/src/wizard/monster-info-spoiler.cpp
+++ b/src/wizard/monster-info-spoiler.cpp
@@ -216,7 +216,7 @@ SpoilerOutputResultType spoil_mon_info(concptr fname)
         spoil_out(buf);
         sprintf(buf, "Rar:%d  ", r_ptr->rarity);
         spoil_out(buf);
-        sprintf(buf, "%+d", r_ptr->speed - STANDARD_SPEED);
+        sprintf(buf, "Spd:%+d  ", r_ptr->speed - STANDARD_SPEED);
         spoil_out(buf);
         if (any_bits(r_ptr->flags1, RF1_FORCE_MAXHP) || (r_ptr->hside == 1)) {
             sprintf(buf, "Hp:%d  ", r_ptr->hdice * r_ptr->hside);


### PR DESCRIPTION
コミット 23d1bbe において「Spd:」の表示部分が誤って消されてしまっているので復活させる。