### PR TITLE
[Refactor] termの配列に対してループ処理をする際にマジックナンバーを使っているのをやめる

### DIFF
--- a/src/cmd-io/cmd-gameoption.cpp
+++ b/src/cmd-io/cmd-gameoption.cpp
@@ -308,17 +308,17 @@ static void do_cmd_options_win(PlayerType *player_ptr)
         }
     }
 
-    for (j = 0; j < 8; j++) {
+    for (auto term_index = 0U; term_index < angband_terms.size(); ++term_index) {
         term_type *old = game_term;
-        if (!angband_term[j]) {
+        if (!angband_terms[term_index]) {
             continue;
         }
 
-        if (window_flag[j] == old_flag[j]) {
+        if (window_flag[term_index] == old_flag[term_index]) {
             continue;
         }
 
-        term_activate(angband_term[j]);
+        term_activate(angband_terms[term_index]);
         term_clear();
         term_fresh();
         term_activate(old);

--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -59,12 +59,12 @@ void do_cmd_redraw(PlayerType *player_ptr)
     }
 
     term_type *old = game_term;
-    for (int j = 0; j < 8; j++) {
-        if (!angband_term[j]) {
+    for (auto i = 0U; i < angband_terms.size(); ++i) {
+        if (!angband_terms[i]) {
             continue;
         }
 
-        term_activate(angband_term[j]);
+        term_activate(angband_terms[i]);
         term_redraw();
         term_fresh();
         term_activate(old);

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -101,11 +101,11 @@ static void restore_windows(PlayerType *player_ptr)
 {
     player_ptr->hack_mutation = false;
     w_ptr->character_icky_depth = 1;
-    term_activate(angband_term[0]);
-    angband_term[0]->resize_hook = resize_map;
-    for (MONSTER_IDX i = 1; i < 8; i++) {
-        if (angband_term[i]) {
-            angband_term[i]->resize_hook = redraw_window;
+    term_activate(angband_terms[0]);
+    angband_terms[0]->resize_hook = resize_map;
+    for (auto i = 0U; i < angband_terms.size(); ++i) {
+        if (angband_terms[i]) {
+            angband_terms[i]->resize_hook = redraw_window;
         }
     }
 

--- a/src/core/window-redrawer.cpp
+++ b/src/core/window-redrawer.cpp
@@ -235,9 +235,9 @@ void window_stuff(PlayerType *player_ptr)
     }
 
     BIT_FLAGS mask = 0L;
-    for (int j = 0; j < 8; j++) {
-        if (angband_term[j] && !angband_term[j]->never_fresh) {
-            mask |= window_flag[j];
+    for (auto i = 0U; i < angband_terms.size(); ++i) {
+        if (angband_terms[i] && !angband_terms[i]->never_fresh) {
+            mask |= window_flag[i];
         }
     }
     BIT_FLAGS window_flags = player_ptr->window_flags & mask;

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -304,8 +304,8 @@ bool get_item_floor(PlayerType *player_ptr, COMMAND_CODE *cp, concptr pmt, concp
     while (!fis_ptr->done) {
         int ni = 0;
         int ne = 0;
-        for (int i = 0; i < 8; i++) {
-            if (!angband_term[i]) {
+        for (auto i = 0U; i < angband_terms.size(); ++i) {
+            if (!angband_terms[i]) {
                 continue;
             }
 

--- a/src/inventory/item-getter.cpp
+++ b/src/inventory/item-getter.cpp
@@ -296,16 +296,16 @@ bool get_item(PlayerType *player_ptr, OBJECT_IDX *cp, concptr pmt, concptr str, 
         COMMAND_CODE get_item_label = 0;
         int ni = 0;
         int ne = 0;
-        for (int j = 0; j < 8; j++) {
-            if (!angband_term[j]) {
+        for (auto i = 0U; i < angband_terms.size(); ++i) {
+            if (!angband_terms[i]) {
                 continue;
             }
 
-            if (window_flag[j] & (PW_INVEN)) {
+            if (window_flag[i] & (PW_INVEN)) {
                 ni++;
             }
 
-            if (window_flag[j] & (PW_EQUIP)) {
+            if (window_flag[i] & (PW_EQUIP)) {
                 ne++;
             }
         }

--- a/src/io/input-key-acceptor.cpp
+++ b/src/io/input-key-acceptor.cpp
@@ -443,9 +443,9 @@ int inkey_special(bool numpad_cursor)
  */
 void stop_term_fresh(void)
 {
-    for (int j = 0; j < 8; j++) {
-        if (angband_terms[j]) {
-            angband_terms[j]->never_fresh = true;
+    for (auto &angband_term : angband_terms) {
+        if (angband_term != nullptr) {
+            angband_term->never_fresh = true;
         }
     }
 }
@@ -455,9 +455,9 @@ void stop_term_fresh(void)
  */
 void start_term_fresh(void)
 {
-    for (int j = 0; j < 8; j++) {
-        if (angband_terms[j]) {
-            angband_terms[j]->never_fresh = false;
+    for (auto &angband_term : angband_terms) {
+        if (angband_term != nullptr) {
+            angband_term->never_fresh = false;
         }
     }
 }

--- a/src/io/input-key-acceptor.cpp
+++ b/src/io/input-key-acceptor.cpp
@@ -52,7 +52,7 @@ static void all_term_fresh(int x, int y)
     p_ptr->window_flags |= PW_ALL;
     handle_stuff(p_ptr);
 
-    term_activate(angband_term[0]);
+    term_activate(angband_terms[0]);
     term_gotoxy(x, y);
     term_fresh();
 }
@@ -226,9 +226,9 @@ char inkey(bool do_all_term_refresh)
         (void)term_set_cursor(1);
     }
 
-    term_activate(angband_term[0]);
-    auto y = angband_term[0]->scr->cy;
-    auto x = angband_term[0]->scr->cx;
+    term_activate(angband_terms[0]);
+    auto y = angband_terms[0]->scr->cy;
+    auto x = angband_terms[0]->scr->cx;
     char kk;
     while (!ch) {
         if (!inkey_base && inkey_scan && (0 != term_inkey(&kk, false, false))) {
@@ -444,8 +444,8 @@ int inkey_special(bool numpad_cursor)
 void stop_term_fresh(void)
 {
     for (int j = 0; j < 8; j++) {
-        if (angband_term[j]) {
-            angband_term[j]->never_fresh = true;
+        if (angband_terms[j]) {
+            angband_terms[j]->never_fresh = true;
         }
     }
 }
@@ -456,8 +456,8 @@ void stop_term_fresh(void)
 void start_term_fresh(void)
 {
     for (int j = 0; j < 8; j++) {
-        if (angband_term[j]) {
-            angband_term[j]->never_fresh = false;
+        if (angband_terms[j]) {
+            angband_terms[j]->never_fresh = false;
         }
     }
 }
@@ -470,7 +470,7 @@ bool macro_running(void)
 {
     /* マクロ展開中のみ詳細に判定する */
     if (parse_macro) {
-        int diff = angband_term[0]->key_head - angband_term[0]->key_tail;
+        int diff = angband_terms[0]->key_head - angband_terms[0]->key_tail;
 
         /* 最終入力を展開した直後はdiff==1となる */
         if (diff != 1) {

--- a/src/io/record-play-movie.cpp
+++ b/src/io/record-play-movie.cpp
@@ -65,7 +65,7 @@ static errr (*old_text_hook)(int x, int y, int n, TERM_COLOR a, concptr s);
 
 static void disable_chuukei_server(void)
 {
-    term_type *t = angband_term[0];
+    term_type *t = angband_terms[0];
     t->xtra_hook = old_xtra_hook;
     t->curs_hook = old_curs_hook;
     t->bigcurs_hook = old_bigcurs_hook;
@@ -255,7 +255,7 @@ static errr send_bigcurs_to_chuukei_server(int x, int y)
  */
 void prepare_chuukei_hooks(void)
 {
-    term_type *t0 = angband_term[0];
+    term_type *t0 = angband_terms[0];
 
     /* Save original z-term hooks */
     old_xtra_hook = t0->xtra_hook;
@@ -507,7 +507,7 @@ static bool flush_ringbuf_client(void)
             euc2sjis(mesg);
 #endif
             update_term_size(x, y, len);
-            (void)((*angband_term[0]->text_hook)(x, y, len, (byte)col, mesg));
+            (void)((*angband_terms[0]->text_hook)(x, y, len, (byte)col, mesg));
             memcpy(&game_term->scr->c[y][x], mesg, len);
             for (i = x; i < x + len; i++) {
                 game_term->scr->a[y][i] = col;
@@ -520,7 +520,7 @@ static bool flush_ringbuf_client(void)
             }
             mesg[i] = '\0';
             update_term_size(x, y, len);
-            (void)((*angband_term[0]->text_hook)(x, y, len, (byte)col, mesg));
+            (void)((*angband_terms[0]->text_hook)(x, y, len, (byte)col, mesg));
             memcpy(&game_term->scr->c[y][x], mesg, len);
             for (i = x; i < x + len; i++) {
                 game_term->scr->a[y][i] = col;
@@ -529,30 +529,30 @@ static bool flush_ringbuf_client(void)
 
         case 's': /* 一文字 */
             update_term_size(x, y, 1);
-            (void)((*angband_term[0]->text_hook)(x, y, 1, (byte)col, mesg));
+            (void)((*angband_terms[0]->text_hook)(x, y, 1, (byte)col, mesg));
             memcpy(&game_term->scr->c[y][x], mesg, 1);
             game_term->scr->a[y][x] = col;
             break;
 
         case 'w':
             update_term_size(x, y, len);
-            (void)((*angband_term[0]->wipe_hook)(x, y, len));
+            (void)((*angband_terms[0]->wipe_hook)(x, y, len));
             break;
 
         case 'x':
             if (x == TERM_XTRA_CLEAR) {
                 term_clear();
             }
-            (void)((*angband_term[0]->xtra_hook)(x, 0));
+            (void)((*angband_terms[0]->xtra_hook)(x, 0));
             break;
 
         case 'c':
             update_term_size(x, y, 1);
-            (void)((*angband_term[0]->curs_hook)(x, y));
+            (void)((*angband_terms[0]->curs_hook)(x, y));
             break;
         case 'C':
             update_term_size(x, y, 1);
-            (void)((*angband_term[0]->bigcurs_hook)(x, y));
+            (void)((*angband_terms[0]->bigcurs_hook)(x, y));
             break;
         }
     }

--- a/src/main-gcu.cpp
+++ b/src/main-gcu.cpp
@@ -1455,7 +1455,7 @@ errr init_gcu(int argc, char *argv[])
             term_data_init_gcu(&data[next_win], rows, cols, y, x);
 
             /* Remember the term */
-            angband_term[next_win] = &data[next_win].t;
+            angband_terms[next_win] = &data[next_win].t;
 
             /* One more window */
             next_win++;
@@ -1603,12 +1603,12 @@ errr init_gcu(int argc, char *argv[])
         }
         data[0].r = remaining;
         term_data_init(&data[0]);
-        angband_term[0] = game_term;
+        angband_terms[0] = game_term;
 
         /* Child Terminals */
         for (next_term = 1; next_term < term_ct; next_term++) {
             term_data_init(&data[next_term]);
-            angband_term[next_term] = game_term;
+            angband_terms[next_term] = game_term;
         }
     }
 

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -1405,7 +1405,7 @@ static void init_windows(void)
         td->size_hack = false;
 
         term_data_link(td);
-        angband_term[i] = &td->t;
+        angband_terms[i] = &td->t;
 
         if (td->visible) {
             /* Activate the window */
@@ -1437,7 +1437,7 @@ static void init_windows(void)
     td->size_hack = false;
 
     term_data_link(td);
-    angband_term[0] = &td->t;
+    angband_terms[0] = &td->t;
     normsize.x = td->cols;
     normsize.y = td->rows;
 

--- a/src/main-x11.cpp
+++ b/src/main-x11.cpp
@@ -2162,7 +2162,7 @@ static void game_term_nuke_x11(term_type *)
             XftDrawDestroy(iwin->draw);
         }
 #endif
-        angband_term[i] = nullptr;
+        angband_terms[i] = nullptr;
     }
 
     if (Metadpy->xim) {
@@ -2502,7 +2502,7 @@ errr init_x11(int argc, char *argv[])
     for (i = 0; i < num_term; i++) {
         term_data *td = &data[i];
         term_data_init(td, i);
-        angband_term[i] = game_term;
+        angband_terms[i] = game_term;
     }
 
     Infowin_set(data[0].win.get());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,20 +51,18 @@
  */
 static void quit_hook(concptr s)
 {
-    int j;
-
     /* Unused */
     (void)s;
 
     /* Scan windows */
-    for (j = 8 - 1; j >= 0; j--) {
+    for (int i = static_cast<int>(angband_terms.size()); i >= 0; i--) {
         /* Unused */
-        if (!angband_term[j]) {
+        if (!angband_terms[i]) {
             continue;
         }
 
         /* Nuke it */
-        term_nuke(angband_term[j]);
+        term_nuke(angband_terms[i]);
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,7 +55,7 @@ static void quit_hook(concptr s)
     (void)s;
 
     /* Scan windows */
-    for (int i = static_cast<int>(angband_terms.size()); i >= 0; i--) {
+    for (auto i = static_cast<int>(angband_terms.size()); i >= 0; i--) {
         /* Unused */
         if (!angband_terms[i]) {
             continue;

--- a/src/term/gameterm.cpp
+++ b/src/term/gameterm.cpp
@@ -345,7 +345,7 @@ const concptr ident_info[] = {
 /*
  * The array of window pointers
  */
-term_type *angband_term[8];
+std::array<term_type *, 8> angband_terms;
 
 /*!
  * スクリーン表示色キャラクタ /

--- a/src/term/gameterm.h
+++ b/src/term/gameterm.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include <array>
 #include <map>
 #include <utility>
 
@@ -8,8 +9,8 @@ extern const concptr color_names[16];
 extern const concptr window_flag_desc[32];
 extern const concptr ident_info[];
 
-extern term_type *angband_term[8];
-#define term_screen (angband_term[0])
+extern std::array<term_type *, 8> angband_terms;
+#define term_screen (angband_terms[0])
 
 extern TERM_COLOR misc_to_attr[256];
 extern char misc_to_char[256];

--- a/src/view/display-messages.cpp
+++ b/src/view/display-messages.cpp
@@ -195,14 +195,14 @@ void message_add(std::string_view msg)
 
 bool is_msg_window_flowed(void)
 {
-    int i;
-    for (i = 0; i < 8; i++) {
-        if (angband_term[i] && (window_flag[i] & PW_MESSAGE)) {
+    auto i = 0U;
+    for (; i < angband_terms.size(); ++i) {
+        if (angband_terms[i] && (window_flag[i] & PW_MESSAGE)) {
             break;
         }
     }
     if (i < 8) {
-        if (num_more < angband_term[i]->hgt) {
+        if (num_more < angband_terms[i]->hgt) {
             return false;
         }
 

--- a/src/window/display-sub-window-spells.cpp
+++ b/src/window/display-sub-window-spells.cpp
@@ -179,17 +179,17 @@ static void display_spell_list(PlayerType *player_ptr)
  */
 void fix_spell(PlayerType *player_ptr)
 {
-    for (int j = 0; j < 8; j++) {
+    for (auto i = 0U; i < angband_terms.size(); ++i) {
         term_type *old = game_term;
-        if (!angband_term[j]) {
+        if (!angband_terms[i]) {
             continue;
         }
 
-        if (!(window_flag[j] & (PW_SPELL))) {
+        if (!(window_flag[i] & (PW_SPELL))) {
             continue;
         }
 
-        term_activate(angband_term[j]);
+        term_activate(angband_terms[i]);
         display_spell_list(player_ptr);
         term_fresh();
         player_ptr->window_flags &= ~(PW_SPELL);

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -75,7 +75,7 @@ void fix_inventory(PlayerType *player_ptr)
 {
     for (int j = 0; j < 8; j++) {
         term_type *old = game_term;
-        if (!angband_term[j]) {
+        if (!angband_terms[j]) {
             continue;
         }
 
@@ -83,7 +83,7 @@ void fix_inventory(PlayerType *player_ptr)
             continue;
         }
 
-        term_activate(angband_term[j]);
+        term_activate(angband_terms[j]);
         display_inventory(player_ptr, *fix_item_tester);
         term_fresh();
         term_activate(old);
@@ -211,17 +211,17 @@ void fix_monster_list(PlayerType *player_ptr)
 
     for (int j = 0; j < 8; j++) {
         term_type *old = game_term;
-        if (!angband_term[j]) {
+        if (!angband_terms[j]) {
             continue;
         }
         if (!(window_flag[j] & PW_MONSTER_LIST)) {
             continue;
         }
-        if (angband_term[j]->never_fresh) {
+        if (angband_terms[j]->never_fresh) {
             continue;
         }
 
-        term_activate(angband_term[j]);
+        term_activate(angband_terms[j]);
         int w, h;
         term_get_size(&w, &h);
         std::call_once(once, target_sensing_monsters_prepare, player_ptr, monster_list);
@@ -322,14 +322,14 @@ void fix_equip(PlayerType *player_ptr)
 {
     for (int j = 0; j < 8; j++) {
         term_type *old = game_term;
-        if (!angband_term[j]) {
+        if (!angband_terms[j]) {
             continue;
         }
         if (!(window_flag[j] & (PW_EQUIP))) {
             continue;
         }
 
-        term_activate(angband_term[j]);
+        term_activate(angband_terms[j]);
         display_equipment(player_ptr, *fix_item_tester);
         term_fresh();
         term_activate(old);
@@ -345,7 +345,7 @@ void fix_player(PlayerType *player_ptr)
 {
     for (int j = 0; j < 8; j++) {
         term_type *old = game_term;
-        if (!angband_term[j]) {
+        if (!angband_terms[j]) {
             continue;
         }
 
@@ -353,7 +353,7 @@ void fix_player(PlayerType *player_ptr)
             continue;
         }
 
-        term_activate(angband_term[j]);
+        term_activate(angband_terms[j]);
         update_playtime();
         (void)display_player(player_ptr, 0);
         term_fresh();
@@ -370,7 +370,7 @@ void fix_message(void)
 {
     for (int j = 0; j < 8; j++) {
         term_type *old = game_term;
-        if (!angband_term[j]) {
+        if (!angband_terms[j]) {
             continue;
         }
 
@@ -378,7 +378,7 @@ void fix_message(void)
             continue;
         }
 
-        term_activate(angband_term[j]);
+        term_activate(angband_terms[j]);
         TERM_LEN w, h;
         term_get_size(&w, &h);
         for (int i = 0; i < h; i++) {
@@ -406,7 +406,7 @@ void fix_overhead(PlayerType *player_ptr)
     for (int j = 0; j < 8; j++) {
         term_type *old = game_term;
         TERM_LEN wid, hgt;
-        if (!angband_term[j]) {
+        if (!angband_terms[j]) {
             continue;
         }
 
@@ -414,7 +414,7 @@ void fix_overhead(PlayerType *player_ptr)
             continue;
         }
 
-        term_activate(angband_term[j]);
+        term_activate(angband_terms[j]);
         term_get_size(&wid, &hgt);
         if (wid > COL_MAP + 2 && hgt > ROW_MAP + 2) {
             int cy, cx;
@@ -472,7 +472,7 @@ void fix_dungeon(PlayerType *player_ptr)
 {
     for (int j = 0; j < 8; j++) {
         term_type *old = game_term;
-        if (!angband_term[j]) {
+        if (!angband_terms[j]) {
             continue;
         }
 
@@ -480,7 +480,7 @@ void fix_dungeon(PlayerType *player_ptr)
             continue;
         }
 
-        term_activate(angband_term[j]);
+        term_activate(angband_terms[j]);
         display_dungeon(player_ptr);
         term_fresh();
         term_activate(old);
@@ -496,7 +496,7 @@ void fix_monster(PlayerType *player_ptr)
 {
     for (int j = 0; j < 8; j++) {
         term_type *old = game_term;
-        if (!angband_term[j]) {
+        if (!angband_terms[j]) {
             continue;
         }
 
@@ -504,7 +504,7 @@ void fix_monster(PlayerType *player_ptr)
             continue;
         }
 
-        term_activate(angband_term[j]);
+        term_activate(angband_terms[j]);
         if (MonsterRace(player_ptr->monster_race_idx).is_valid()) {
             display_roff(player_ptr);
         }
@@ -523,7 +523,7 @@ void fix_object(PlayerType *player_ptr)
 {
     for (auto i = 0; i < 8; i++) {
         auto *old = game_term;
-        if (angband_term[i] == nullptr) {
+        if (angband_terms[i] == nullptr) {
             continue;
         }
 
@@ -531,7 +531,7 @@ void fix_object(PlayerType *player_ptr)
             continue;
         }
 
-        term_activate(angband_term[i]);
+        term_activate(angband_terms[i]);
         display_koff(player_ptr);
         term_fresh();
         term_activate(old);
@@ -647,10 +647,10 @@ static void display_floor_item_list(PlayerType *player_ptr, const int y, const i
 void fix_floor_item_list(PlayerType *player_ptr, const int y, const int x)
 {
     for (int j = 0; j < 8; j++) {
-        if (!angband_term[j]) {
+        if (!angband_terms[j]) {
             continue;
         }
-        if (angband_term[j]->never_fresh) {
+        if (angband_terms[j]->never_fresh) {
             continue;
         }
         if (!(window_flag[j] & PW_FLOOR_ITEM_LIST)) {
@@ -658,7 +658,7 @@ void fix_floor_item_list(PlayerType *player_ptr, const int y, const int x)
         }
 
         term_type *old = game_term;
-        term_activate(angband_term[j]);
+        term_activate(angband_terms[j]);
 
         display_floor_item_list(player_ptr, y, x);
         term_fresh();
@@ -746,10 +746,10 @@ static void display_found_item_list(PlayerType *player_ptr)
 void fix_found_item_list(PlayerType *player_ptr)
 {
     for (int j = 0; j < 8; j++) {
-        if (!angband_term[j]) {
+        if (!angband_terms[j]) {
             continue;
         }
-        if (angband_term[j]->never_fresh) {
+        if (angband_terms[j]->never_fresh) {
             continue;
         }
         if (none_bits(window_flag[j], PW_FOUND_ITEM_LIST)) {
@@ -757,7 +757,7 @@ void fix_found_item_list(PlayerType *player_ptr)
         }
 
         term_type *old = game_term;
-        term_activate(angband_term[j]);
+        term_activate(angband_terms[j]);
 
         display_found_item_list(player_ptr);
         term_fresh();
@@ -772,21 +772,21 @@ void fix_found_item_list(PlayerType *player_ptr)
  */
 void toggle_inventory_equipment(PlayerType *player_ptr)
 {
-    for (int j = 0; j < 8; j++) {
-        if (!angband_term[j]) {
+    for (auto i = 0U; i < angband_terms.size(); ++i) {
+        if (!angband_terms[i]) {
             continue;
         }
 
-        if (window_flag[j] & (PW_INVEN)) {
-            window_flag[j] &= ~(PW_INVEN);
-            window_flag[j] |= (PW_EQUIP);
+        if (window_flag[i] & (PW_INVEN)) {
+            window_flag[i] &= ~(PW_INVEN);
+            window_flag[i] |= (PW_EQUIP);
             player_ptr->window_flags |= (PW_EQUIP);
             continue;
         }
 
-        if (window_flag[j] & PW_EQUIP) {
-            window_flag[j] &= ~(PW_EQUIP);
-            window_flag[j] |= PW_INVEN;
+        if (window_flag[i] & PW_EQUIP) {
+            window_flag[i] &= ~(PW_EQUIP);
+            window_flag[i] |= PW_INVEN;
             player_ptr->window_flags |= PW_INVEN;
         }
     }


### PR DESCRIPTION
[【リファクタリング】angband_term配列に対してループ処理を記述する際、'8'というマジックナンバーを使っているのをやめる](https://github.com/hengband/hengband/issues/2860)
↑issueで挙げた対応のpull reqになります。

# やったこと

- angband_term → angband_termsにrename
- angband_termsの型を配列からstd::array<term_type *, 8> に変更
- angband_termsに対するループ処理を angband_terms.size()を使って行うようにした