### PR TITLE
[Refactor] describe_flavor (5/5)

### DIFF
--- a/src/flavor/flavor-util.cpp
+++ b/src/flavor/flavor-util.cpp
@@ -1,5 +1,6 @@
 ﻿#include "flavor/flavor-util.h"
 #include "flavor/flag-inscriptions-table.h"
+#include "object-enchant/tr-flags.h"
 #include "object-enchant/tr-types.h"
 #include "object/object-flags.h"
 #include "object/tval-types.h"
@@ -9,6 +10,16 @@
 #include "util/quarks.h"
 #include "util/string-processor.h"
 #include <sstream>
+
+static bool has_lite_flag(const TrFlags &flags)
+{
+    return flags.has(TR_LITE_1) || flags.has(TR_LITE_2) || flags.has(TR_LITE_3);
+}
+
+static bool has_dark_flag(const TrFlags &flags)
+{
+    return flags.has(TR_LITE_M1) || flags.has(TR_LITE_M2) || flags.has(TR_LITE_M3);
+}
 
 /*!
  * @brief オブジェクトフラグを追加する
@@ -371,13 +382,3 @@ std::string describe_count_with_counter_suffix(const ItemEntity &item)
     return ss.str();
 }
 #endif
-
-bool has_lite_flag(const TrFlags &flags)
-{
-    return flags.has(TR_LITE_1) || flags.has(TR_LITE_2) || flags.has(TR_LITE_3);
-}
-
-bool has_dark_flag(const TrFlags &flags)
-{
-    return flags.has(TR_LITE_M1) || flags.has(TR_LITE_M2) || flags.has(TR_LITE_M3);
-}

--- a/src/flavor/flavor-util.cpp
+++ b/src/flavor/flavor-util.cpp
@@ -12,6 +12,7 @@
 #include "util/bit-flags-calculator.h"
 #include "util/enum-converter.h"
 #include "util/quarks.h"
+#include <sstream>
 
 flavor_type *initialize_flavor_type(flavor_type *flavor_ptr, char *buf, ItemEntity *o_ptr, BIT_FLAGS mode)
 {
@@ -397,34 +398,31 @@ void get_inscription(char *buff, const ItemEntity *o_ptr)
 
 #ifdef JP
 /*!
- * @brief 日本語の個数表示ルーチン
- * @param t 保管先文字列ポインタ
- * @param o_ptr 記述したいオブジェクトの構造体参照ポインタ
- * @details
- * cmd1.c で流用するために object_desc_japanese から移動した。
+ * @brief アイテムにふさわしい助数詞をつけて数を記述する
+ * @param item 数を記述したいアイテムの参照
+ * @return 記述した文字列
  */
-char *object_desc_count_japanese(char *t, const ItemEntity *o_ptr)
+std::string describe_count_with_counter_suffix(const ItemEntity &item)
 {
-    t = object_desc_num(t, o_ptr->number);
-    switch (o_ptr->bi_key.tval()) {
+    std::stringstream ss;
+    ss << item.number;
+
+    switch (item.bi_key.tval()) {
     case ItemKindType::BOLT:
     case ItemKindType::ARROW:
     case ItemKindType::POLEARM:
     case ItemKindType::STAFF:
     case ItemKindType::WAND:
     case ItemKindType::ROD:
-    case ItemKindType::DIGGING: {
-        t = object_desc_str(t, "本");
+    case ItemKindType::DIGGING:
+        ss << "本";
         break;
-    }
-    case ItemKindType::SCROLL: {
-        t = object_desc_str(t, "巻");
+    case ItemKindType::SCROLL:
+        ss << "巻";
         break;
-    }
-    case ItemKindType::POTION: {
-        t = object_desc_str(t, "服");
+    case ItemKindType::POTION:
+        ss << "服";
         break;
-    }
     case ItemKindType::LIFE_BOOK:
     case ItemKindType::SORCERY_BOOK:
     case ItemKindType::NATURE_BOOK:
@@ -437,48 +435,44 @@ char *object_desc_count_japanese(char *t, const ItemEntity *o_ptr)
     case ItemKindType::CRUSADE_BOOK:
     case ItemKindType::MUSIC_BOOK:
     case ItemKindType::HISSATSU_BOOK:
-    case ItemKindType::HEX_BOOK: {
-        t = object_desc_str(t, "冊");
+    case ItemKindType::HEX_BOOK:
+        ss << "冊";
         break;
-    }
     case ItemKindType::SOFT_ARMOR:
     case ItemKindType::HARD_ARMOR:
     case ItemKindType::DRAG_ARMOR:
-    case ItemKindType::CLOAK: {
-        t = object_desc_str(t, "着");
+    case ItemKindType::CLOAK:
+        ss << "着";
         break;
-    }
     case ItemKindType::SWORD:
     case ItemKindType::HAFTED:
-    case ItemKindType::BOW: {
-        t = object_desc_str(t, "振");
+    case ItemKindType::BOW:
+        ss << "振";
         break;
-    }
-    case ItemKindType::BOOTS: {
-        t = object_desc_str(t, "足");
+    case ItemKindType::BOOTS:
+        ss << "足";
         break;
-    }
-    case ItemKindType::CARD: {
-        t = object_desc_str(t, "枚");
+
+    case ItemKindType::CARD:
+        ss << "枚";
         break;
-    }
-    case ItemKindType::FOOD: {
-        if (o_ptr->bi_key.sval().value() == SV_FOOD_JERKY) {
-            t = object_desc_str(t, "切れ");
+
+    case ItemKindType::FOOD:
+        if (item.bi_key.sval().value() == SV_FOOD_JERKY) {
+            ss << "切れ";
             break;
         }
-    }
         [[fallthrough]];
-    default: {
-        if (o_ptr->number < 10) {
-            t = object_desc_str(t, "つ");
+    default:
+        if (item.number < 10) {
+            ss << "つ";
         } else {
-            t = object_desc_str(t, "個");
+            ss << "個";
         }
         break;
     }
-    }
-    return t;
+
+    return ss.str();
 }
 #endif
 

--- a/src/flavor/flavor-util.h
+++ b/src/flavor/flavor-util.h
@@ -2,8 +2,6 @@
 
 #include "system/angband.h"
 
-#include "object-enchant/tr-flags.h"
-
 struct describe_option_type {
     BIT_FLAGS mode;
     bool aware;
@@ -14,8 +12,6 @@ struct describe_option_type {
 class ItemEntity;
 char *get_ability_abbreviation(char *ptr, const ItemEntity *o_ptr, bool kanji, bool all);
 void get_inscription(char *buff, const ItemEntity *o_ptr);
-bool has_lite_flag(const TrFlags &flags);
-bool has_dark_flag(const TrFlags &flags);
 
 #ifdef JP
 std::string describe_count_with_counter_suffix(const ItemEntity &item);

--- a/src/flavor/flavor-util.h
+++ b/src/flavor/flavor-util.h
@@ -51,5 +51,5 @@ bool has_lite_flag(const TrFlags &flags);
 bool has_dark_flag(const TrFlags &flags);
 
 #ifdef JP
-char *object_desc_count_japanese(char *t, const ItemEntity *o_ptr);
+std::string describe_count_with_counter_suffix(const ItemEntity &item);
 #endif

--- a/src/flavor/flavor-util.h
+++ b/src/flavor/flavor-util.h
@@ -1,36 +1,8 @@
 ﻿#pragma once
 
 #include "system/angband.h"
-#include "system/system-variables.h"
 
 #include "object-enchant/tr-flags.h"
-
-class BaseitemInfo;
-class ItemEntity;
-struct flavor_type {
-    char *buf;
-    ItemEntity *o_ptr;
-    BIT_FLAGS mode;
-    int power;
-    bool aware;
-    bool known; // 鑑定 or *鑑定* 済.
-    bool flavor;
-    char *t;
-    char p1; // const.
-    char p2; // const.
-    char b1; // const.
-    char b2; // const.
-    char c1; // const.
-    char c2; // const.
-    char tmp_val[MAX_NLEN + 160];
-    char tmp_val2[MAX_NLEN + 10];
-    char fake_insc_buf[30];
-    TrFlags tr_flags;
-    ItemEntity *bow_ptr;
-    BaseitemInfo *bii_ptr;
-    BaseitemInfo *flavor_bii_ptr;
-    int avgdam;
-};
 
 struct describe_option_type {
     BIT_FLAGS mode;
@@ -39,12 +11,7 @@ struct describe_option_type {
     bool flavor;
 };
 
-class PlayerType;
-flavor_type *initialize_flavor_type(flavor_type *flavor_ptr, char *buf, ItemEntity *o_ptr, BIT_FLAGS mode);
-char *object_desc_chr(char *t, char c);
-char *object_desc_str(char *t, concptr s);
-char *object_desc_num(char *t, uint n);
-char *object_desc_int(char *t, int v);
+class ItemEntity;
 char *get_ability_abbreviation(char *ptr, const ItemEntity *o_ptr, bool kanji, bool all);
 void get_inscription(char *buff, const ItemEntity *o_ptr);
 bool has_lite_flag(const TrFlags &flags);

--- a/src/flavor/named-item-describer.cpp
+++ b/src/flavor/named-item-describer.cpp
@@ -51,10 +51,7 @@ static std::string describe_item_count_ja(const ItemEntity &item, const describe
         return "";
     }
 
-    // TODO: object_desc_count_japanese の std::string へのインターフェース変更は別途行う
-    char num_buf[16]{};
-    object_desc_count_japanese(num_buf, &item);
-    return std::string(num_buf) + "の ";
+    return describe_count_with_counter_suffix(item) + "の ";
 }
 
 /*!

--- a/src/inventory/player-inventory.cpp
+++ b/src/inventory/player-inventory.cpp
@@ -187,8 +187,6 @@ void describe_pickup_item(PlayerType *player_ptr, OBJECT_IDX o_idx)
 #ifdef JP
     GAME_TEXT o_name[MAX_NLEN];
     GAME_TEXT old_name[MAX_NLEN];
-    char kazu_str[80];
-    int hirottakazu;
 #else
     GAME_TEXT o_name[MAX_NLEN];
 #endif
@@ -198,8 +196,8 @@ void describe_pickup_item(PlayerType *player_ptr, OBJECT_IDX o_idx)
 
 #ifdef JP
     describe_flavor(player_ptr, old_name, o_ptr, OD_NAME_ONLY);
-    object_desc_count_japanese(kazu_str, o_ptr);
-    hirottakazu = o_ptr->number;
+    const auto picked_count_str = describe_count_with_counter_suffix(*o_ptr);
+    const auto picked_count = o_ptr->number;
 #endif
 
     INVENTORY_IDX slot = store_item_to_inventory(player_ptr, o_ptr);
@@ -224,8 +222,8 @@ void describe_pickup_item(PlayerType *player_ptr, OBJECT_IDX o_idx)
         if (plain_pickup) {
             msg_format("%s(%c)を持っている。", o_name, index_to_label(slot));
         } else {
-            if (o_ptr->number > hirottakazu) {
-                msg_format("%s拾って、%s(%c)を持っている。", kazu_str, o_name, index_to_label(slot));
+            if (o_ptr->number > picked_count) {
+                msg_format("%s拾って、%s(%c)を持っている。", picked_count_str.data(), o_name, index_to_label(slot));
             } else {
                 msg_format("%s(%c)を拾った。", o_name, index_to_label(slot));
             }


### PR DESCRIPTION
#2865 に関して行ってきた一連のリファクタリングの仕上げ。

describe_flavor がかつて使用していた神構造体の flavor_type とバッファ非安全な関数群 object_desc_\* をごっそり削除。