### PR TITLE
[Refactor] get_inscription 関数のシグネチャを変更

### DIFF
--- a/src/flavor/flavor-describer.cpp
+++ b/src/flavor/flavor-describer.cpp
@@ -486,9 +486,7 @@ static std::string describe_player_inscription(const ItemEntity &item)
         return "";
     }
 
-    char insc[1024]{};
-    get_inscription(insc, &item);
-    return insc;
+    return get_inscription(item);
 }
 
 static std::string describe_item_discount(const ItemEntity &item, bool hide_discount)

--- a/src/flavor/flavor-util.h
+++ b/src/flavor/flavor-util.h
@@ -11,7 +11,7 @@ struct describe_option_type {
 
 class ItemEntity;
 std::string get_ability_abbreviation(const ItemEntity &o_ptr, bool is_kanji, bool all);
-void get_inscription(char *buff, const ItemEntity *o_ptr);
+std::string get_inscription(const ItemEntity &item);
 
 #ifdef JP
 std::string describe_count_with_counter_suffix(const ItemEntity &item);


### PR DESCRIPTION
get_inscription 関数のシグネチャを、文字列を格納するバッファを指すポインタ引数を受け取る方式から std::string 型の戻り値で文字列を返す方式に変更する。