### PR TITLE
Replace sprintf() simply.  Does part of the work to resolve …

### DIFF
--- a/src/autopick/autopick-editor-command.cpp
+++ b/src/autopick/autopick-editor-command.cpp
@@ -25,6 +25,7 @@
 #include "player-info/race-info.h"
 #include "system/player-type-definition.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 
 /*!
  * @brief
@@ -566,7 +567,7 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
             break;
         }
         char expression[80];
-        sprintf(expression, "?:[AND [EQU $RACE %s] [EQU $CLASS %s] [GEQ $LEVEL %02d]]",
+        strnfmt(expression, sizeof(expression), "?:[AND [EQU $RACE %s] [EQU $CLASS %s] [GEQ $LEVEL %02d]]",
 #ifdef JP
             rp_ptr->E_title, cp_ptr->E_title,
 #else

--- a/src/birth/birth-select-realm.cpp
+++ b/src/birth/birth-select-realm.cpp
@@ -10,6 +10,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/buffer-shaper.h"
 #include "util/int-char-converter.h"
 
@@ -149,7 +150,7 @@ static void analyze_realms(const PlayerType *player_ptr, const uint32_t choices,
 
         birth_realm_ptr->sym[birth_realm_ptr->n] = I2A(birth_realm_ptr->n);
 
-        sprintf(birth_realm_ptr->buf, "%c%c %s", birth_realm_ptr->sym[birth_realm_ptr->n], birth_realm_ptr->p2, realm_names[i + 1]);
+        strnfmt(birth_realm_ptr->buf, sizeof(birth_realm_ptr->buf), "%c%c %s", birth_realm_ptr->sym[birth_realm_ptr->n], birth_realm_ptr->p2, realm_names[i + 1]);
         put_str(birth_realm_ptr->buf, 12 + (birth_realm_ptr->n / 5), 2 + 15 * (birth_realm_ptr->n % 5));
         birth_realm_ptr->picks[birth_realm_ptr->n++] = i + 1;
     }
@@ -164,11 +165,11 @@ static void move_birth_realm_cursor(birth_realm_type *birth_realm_ptr)
     c_put_str(TERM_WHITE, birth_realm_ptr->cur, 12 + (birth_realm_ptr->os / 5), 2 + 15 * (birth_realm_ptr->os % 5));
 
     if (birth_realm_ptr->cs == birth_realm_ptr->n) {
-        sprintf(birth_realm_ptr->cur, "%c%c %s", '*', birth_realm_ptr->p2, _("ランダム", "Random"));
+        strnfmt(birth_realm_ptr->cur, sizeof(birth_realm_ptr->cur), "%c%c %s", '*', birth_realm_ptr->p2, _("ランダム", "Random"));
     } else {
-        sprintf(birth_realm_ptr->cur, "%c%c %s", birth_realm_ptr->sym[birth_realm_ptr->cs], birth_realm_ptr->p2,
+        strnfmt(birth_realm_ptr->cur, sizeof(birth_realm_ptr->cur), "%c%c %s", birth_realm_ptr->sym[birth_realm_ptr->cs], birth_realm_ptr->p2,
             realm_names[birth_realm_ptr->picks[birth_realm_ptr->cs]]);
-        sprintf(birth_realm_ptr->buf, "%s", realm_names[birth_realm_ptr->picks[birth_realm_ptr->cs]]);
+        strnfmt(birth_realm_ptr->buf, sizeof(birth_realm_ptr->buf), "%s", realm_names[birth_realm_ptr->picks[birth_realm_ptr->cs]]);
         c_put_str(TERM_L_BLUE, birth_realm_ptr->buf, 3, 40);
         prt(_("の特徴", ": Characteristic"), 3, 40 + strlen(birth_realm_ptr->buf));
         prt(realm_subinfo[technic2magic(birth_realm_ptr->picks[birth_realm_ptr->cs]) - 1].data(), 4, 40);
@@ -218,7 +219,7 @@ static bool get_a_realm(PlayerType *player_ptr, birth_realm_type *birth_realm_pt
             break;
         }
 
-        sprintf(birth_realm_ptr->buf, _("領域を選んで下さい(%c-%c) ('='初期オプション設定): ", "Choose a realm (%c-%c) ('=' for options): "),
+        strnfmt(birth_realm_ptr->buf, sizeof(birth_realm_ptr->buf), _("領域を選んで下さい(%c-%c) ('='初期オプション設定): ", "Choose a realm (%c-%c) ('=' for options): "),
             birth_realm_ptr->sym[0], birth_realm_ptr->sym[birth_realm_ptr->n - 1]);
 
         put_str(birth_realm_ptr->buf, 10, 10);
@@ -285,7 +286,7 @@ static byte select_realm(PlayerType *player_ptr, uint32_t choices, int *count)
     birth_realm_type tmp_birth_realm;
     birth_realm_type *birth_realm_ptr = initialize_birth_realm_type(&tmp_birth_realm);
     analyze_realms(player_ptr, choices, birth_realm_ptr);
-    sprintf(birth_realm_ptr->cur, "%c%c %s", '*', birth_realm_ptr->p2, _("ランダム", "Random"));
+    strnfmt(birth_realm_ptr->cur, sizeof(birth_realm_ptr->cur), "%c%c %s", '*', birth_realm_ptr->p2, _("ランダム", "Random"));
     if (get_a_realm(player_ptr, birth_realm_ptr)) {
         return REALM_SELECT_CANCEL;
     }

--- a/src/birth/character-builder.cpp
+++ b/src/birth/character-builder.cpp
@@ -37,6 +37,7 @@
 #include "store/store-owners.h"
 #include "store/store.h"
 #include "system/player-type-definition.h"
+#include "term/z-form.h"
 #include "util/enum-converter.h"
 #include "view/display-messages.h"
 #include "world/world.h"
@@ -58,25 +59,25 @@ static void write_birth_diary(PlayerType *player_ptr)
     exe_write_diary(player_ptr, DIARY_GAMESTART, 1, _("-------- 新規ゲーム開始 --------", "------- Started New Game -------"));
     exe_write_diary(player_ptr, DIARY_DIALY, 0, nullptr);
     char buf[80];
-    sprintf(buf, _("%s性別に%sを選択した。", "%schose %s gender."), indent, sex_info[player_ptr->psex].title);
+    strnfmt(buf, sizeof(buf), _("%s性別に%sを選択した。", "%schose %s gender."), indent, sex_info[player_ptr->psex].title);
     exe_write_diary(player_ptr, DIARY_DESCRIPTION, 1, buf);
-    sprintf(buf, _("%s種族に%sを選択した。", "%schose %s race."), indent, race_info[enum2i(player_ptr->prace)].title);
+    strnfmt(buf, sizeof(buf), _("%s種族に%sを選択した。", "%schose %s race."), indent, race_info[enum2i(player_ptr->prace)].title);
     exe_write_diary(player_ptr, DIARY_DESCRIPTION, 1, buf);
-    sprintf(buf, _("%s職業に%sを選択した。", "%schose %s class."), indent, class_info[enum2i(player_ptr->pclass)].title);
+    strnfmt(buf, sizeof(buf), _("%s職業に%sを選択した。", "%schose %s class."), indent, class_info[enum2i(player_ptr->pclass)].title);
     exe_write_diary(player_ptr, DIARY_DESCRIPTION, 1, buf);
     if (player_ptr->realm1) {
-        sprintf(buf, _("%s魔法の領域に%s%sを選択した。", "%schose %s%s."), indent, realm_names[player_ptr->realm1],
+        strnfmt(buf, sizeof(buf), _("%s魔法の領域に%s%sを選択した。", "%schose %s%s."), indent, realm_names[player_ptr->realm1],
             player_ptr->realm2 ? format(_("と%s", " and %s realms"), realm_names[player_ptr->realm2]) : _("", " realm"));
         exe_write_diary(player_ptr, DIARY_DESCRIPTION, 1, buf);
     }
     if (player_ptr->element) {
-        sprintf(buf, _("%s元素系統に%sを選択した。", "%schose %s system."), indent, get_element_title(player_ptr->element));
+        strnfmt(buf, sizeof(buf), _("%s元素系統に%sを選択した。", "%schose %s system."), indent, get_element_title(player_ptr->element));
         exe_write_diary(player_ptr, DIARY_DESCRIPTION, 1, buf);
     }
-    sprintf(buf, _("%s性格に%sを選択した。", "%schose %s personality."), indent, personality_info[player_ptr->ppersonality].title);
+    strnfmt(buf, sizeof(buf), _("%s性格に%sを選択した。", "%schose %s personality."), indent, personality_info[player_ptr->ppersonality].title);
     exe_write_diary(player_ptr, DIARY_DESCRIPTION, 1, buf);
     if (PlayerClass(player_ptr).equals(PlayerClassType::CHAOS_WARRIOR)) {
-        sprintf(buf, _("%s守護神%sと契約を交わした。", "%smade a contract with patron %s."), indent, patron_list[player_ptr->chaos_patron].name.data());
+        strnfmt(buf, sizeof(buf), _("%s守護神%sと契約を交わした。", "%smade a contract with patron %s."), indent, patron_list[player_ptr->chaos_patron].name.data());
         exe_write_diary(player_ptr, DIARY_DESCRIPTION, 1, buf);
     }
 }

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -63,6 +63,7 @@
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "timed-effect/player-blindness.h"
 #include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
@@ -706,7 +707,7 @@ static void change_realm2(PlayerType *player_ptr, int16_t next_realm)
     player_ptr->spell_worked2 = 0L;
     player_ptr->spell_forgotten2 = 0L;
 
-    sprintf(tmp, _("魔法の領域を%sから%sに変更した。", "changed magic realm from %s to %s."), realm_names[player_ptr->realm2], realm_names[next_realm]);
+    strnfmt(tmp, sizeof(tmp), _("魔法の領域を%sから%sに変更した。", "changed magic realm from %s to %s."), realm_names[player_ptr->realm2], realm_names[next_realm]);
     exe_write_diary(player_ptr, DIARY_DESCRIPTION, 0, tmp);
     player_ptr->old_realm |= 1U << (player_ptr->realm2 - 1);
     player_ptr->realm2 = next_realm;

--- a/src/cmd-io/cmd-macro.cpp
+++ b/src/cmd-io/cmd-macro.cpp
@@ -11,6 +11,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/int-char-converter.h"
 #include "util/string-processor.h"
@@ -186,7 +187,7 @@ void do_cmd_macros(PlayerType *player_ptr)
         if (key == '1') {
             prt(_("コマンド: ユーザー設定ファイルのロード", "Command: Load a user pref file"), 16, 0);
             prt(_("ファイル: ", "File: "), 18, 0);
-            sprintf(tmp, "%s.prf", player_ptr->base_name);
+            strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
             if (!askfor(tmp, 80)) {
                 continue;
             }
@@ -202,7 +203,7 @@ void do_cmd_macros(PlayerType *player_ptr)
         } else if (key == '2') {
             prt(_("コマンド: マクロをファイルに追加する", "Command: Append macros to a file"), 16, 0);
             prt(_("ファイル: ", "File: "), 18, 0);
-            sprintf(tmp, "%s.prf", player_ptr->base_name);
+            strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
             if (!askfor(tmp, 80)) {
                 continue;
             }
@@ -253,7 +254,7 @@ void do_cmd_macros(PlayerType *player_ptr)
         } else if (key == '6') {
             prt(_("コマンド: キー配置をファイルに追加する", "Command: Append keymaps to a file"), 16, 0);
             prt(_("ファイル: ", "File: "), 18, 0);
-            sprintf(tmp, "%s.prf", player_ptr->base_name);
+            strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
             if (!askfor(tmp, 80)) {
                 continue;
             }

--- a/src/cmd-item/cmd-destroy.cpp
+++ b/src/cmd-item/cmd-destroy.cpp
@@ -34,6 +34,7 @@
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 
@@ -63,7 +64,7 @@ static bool check_destory_item(PlayerType *player_ptr, destroy_type *destroy_ptr
     }
 
     describe_flavor(player_ptr, destroy_ptr->o_name, destroy_ptr->o_ptr, OD_OMIT_PREFIX);
-    sprintf(destroy_ptr->out_val, _("本当に%sを壊しますか? [y/n/Auto]", "Really destroy %s? [y/n/Auto]"), destroy_ptr->o_name);
+    strnfmt(destroy_ptr->out_val, sizeof(destroy_ptr->out_val), _("本当に%sを壊しますか? [y/n/Auto]", "Really destroy %s? [y/n/Auto]"), destroy_ptr->o_name);
     msg_print(nullptr);
     message_add(destroy_ptr->out_val);
     player_ptr->window_flags |= PW_MESSAGE;

--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -15,6 +15,7 @@
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
 #include "util/string-processor.h"
 #include "view/display-messages.h"
@@ -99,7 +100,7 @@ void do_cmd_player_status(PlayerType *player_ptr)
             get_name(player_ptr);
             process_player_name(player_ptr);
         } else if (c == 'f') {
-            sprintf(tmp, "%s.txt", player_ptr->base_name);
+            strnfmt(tmp, sizeof(tmp), "%s.txt", player_ptr->base_name);
             if (get_string(_("ファイル名: ", "File name: "), tmp, 80)) {
                 if (tmp[0] && (tmp[0] != ' ')) {
                     update_playtime();

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -23,6 +23,7 @@
 #include "system/terrain-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
@@ -38,7 +39,7 @@ static bool cmd_visuals_aux(int i, IDX *num, IDX max)
 {
     if (iscntrl(i)) {
         char str[10] = "";
-        sprintf(str, "%d", *num);
+        strnfmt(str, sizeof(str), "%d", *num);
         if (!get_string(format("Input new number(0-%d): ", max - 1), str, 4)) {
             return false;
         }
@@ -104,7 +105,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
         case '0': {
             prt(_("コマンド: ユーザー設定ファイルのロード", "Command: Load a user pref file"), 15, 0);
             prt(_("ファイル: ", "File: "), 17, 0);
-            sprintf(tmp, "%s.prf", player_ptr->base_name);
+            strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
             if (!askfor(tmp, 70)) {
                 continue;
             }
@@ -117,7 +118,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
             static concptr mark = "Monster attr/chars";
             prt(_("コマンド: モンスターの[色/文字]をファイルに書き出します", "Command: Dump monster attr/chars"), 15, 0);
             prt(_("ファイル: ", "File: "), 17, 0);
-            sprintf(tmp, "%s.prf", player_ptr->base_name);
+            strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
             if (!askfor(tmp, 70)) {
                 continue;
             }
@@ -145,7 +146,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
             static concptr mark = "Object attr/chars";
             prt(_("コマンド: アイテムの[色/文字]をファイルに書き出します", "Command: Dump object attr/chars"), 15, 0);
             prt(_("ファイル: ", "File: "), 17, 0);
-            sprintf(tmp, "%s.prf", player_ptr->base_name);
+            strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
             if (!askfor(tmp, 70)) {
                 continue;
             }
@@ -187,7 +188,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
             static concptr mark = "Feature attr/chars";
             prt(_("コマンド: 地形の[色/文字]をファイルに書き出します", "Command: Dump feature attr/chars"), 15, 0);
             prt(_("ファイル: ", "File: "), 17, 0);
-            sprintf(tmp, "%s.prf", player_ptr->base_name);
+            strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
             if (!askfor(tmp, 70)) {
                 continue;
             }

--- a/src/core/asking-player.cpp
+++ b/src/core/asking-player.cpp
@@ -10,6 +10,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
 #include "util/string-processor.h"
 #include "view/display-messages.h"
@@ -385,14 +386,14 @@ QUANTITY get_quantity(concptr prompt, QUANTITY max)
     }
 
     if (!prompt) {
-        sprintf(tmp, _("いくつですか (1-%d): ", "Quantity (1-%d): "), max);
+        strnfmt(tmp, sizeof(tmp), _("いくつですか (1-%d): ", "Quantity (1-%d): "), max);
         prompt = tmp;
     }
 
     msg_print(nullptr);
     prt(prompt, 0, 0);
     amt = 1;
-    sprintf(buf, "%d", amt);
+    strnfmt(buf, sizeof(buf), "%d", amt);
 
     /*
      * Ask for a quantity

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -90,6 +90,7 @@
 #include "target/target-checker.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "view/display-messages.h"
 #include "view/display-player.h"
@@ -284,7 +285,7 @@ static void generate_world(PlayerType *player_ptr, bool new_game)
     }
 
     char buf[80];
-    sprintf(buf, _("%sに降り立った。", "arrived in %s."), map_name(player_ptr));
+    strnfmt(buf, sizeof(buf), _("%sに降り立った。", "arrived in %s."), map_name(player_ptr));
     exe_write_diary(player_ptr, DIARY_DESCRIPTION, 0, buf);
 }
 

--- a/src/floor/object-scanner.cpp
+++ b/src/floor/object-scanner.cpp
@@ -13,6 +13,8 @@
 #include "system/player-type-definition.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
+#include "util/string-processor.h"
 
 /*!
  * @brief 床に落ちているオブジェクトの数を返す / scan floor items
@@ -154,20 +156,20 @@ COMMAND_CODE show_floor_items(PlayerType *player_ptr, int target_item, POSITION 
         prt("", j + 1, col ? col - 2 : col);
         if (use_menu && target_item) {
             if (j == (target_item - 1)) {
-                strcpy(tmp_val, _("》", "> "));
+                angband_strcpy(tmp_val, _("》", "> "), sizeof(tmp_val));
                 target_item_label = m;
             } else {
-                strcpy(tmp_val, "   ");
+                angband_strcpy(tmp_val, "   ", sizeof(tmp_val));
             }
         } else {
-            sprintf(tmp_val, "%c)", floor_label[j]);
+            strnfmt(tmp_val, sizeof(tmp_val), "%c)", floor_label[j]);
         }
 
         put_str(tmp_val, j + 1, col);
         c_put_str(out_color[j], out_desc[j], j + 1, col + 3);
         if (show_weights && (o_ptr->bi_key.tval() != ItemKindType::GOLD)) {
             int wgt = o_ptr->weight * o_ptr->number;
-            sprintf(tmp_val, _("%3d.%1d kg", "%3d.%1d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
+            strnfmt(tmp_val, sizeof(tmp_val), _("%3d.%1d kg", "%3d.%1d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
             prt(tmp_val, j + 1, wid - 9);
         }
     }

--- a/src/floor/pattern-walk.cpp
+++ b/src/floor/pattern-walk.cpp
@@ -24,6 +24,7 @@
 #include "system/grid-type-definition.h"
 #include "system/player-type-definition.h"
 #include "system/terrain-type-definition.h"
+#include "term/z-form.h"
 #include "timed-effect/player-confusion.h"
 #include "timed-effect/player-cut.h"
 #include "timed-effect/player-hallucination.h"
@@ -62,8 +63,8 @@ void pattern_teleport(PlayerType *player_ptr)
             min_level = dungeons_info[player_ptr->dungeon_idx].mindepth;
         }
 
-        sprintf(ppp, _("テレポート先:(%d-%d)", "Teleport to level (%d-%d): "), (int)min_level, (int)max_level);
-        sprintf(tmp_val, "%d", (int)player_ptr->current_floor_ptr->dun_level);
+        strnfmt(ppp, sizeof(ppp), _("テレポート先:(%d-%d)", "Teleport to level (%d-%d): "), (int)min_level, (int)max_level);
+        strnfmt(tmp_val, sizeof(tmp_val), "%d", (int)player_ptr->current_floor_ptr->dun_level);
         if (!get_string(ppp, tmp_val, 10)) {
             return;
         }

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -29,7 +29,9 @@
 #include "system/player-type-definition.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
+#include "util/string-processor.h"
 #include "view/display-inventory.h"
 #include "view/display-messages.h"
 #include "window/display-sub-windows.h"
@@ -349,104 +351,104 @@ bool get_item_floor(PlayerType *player_ptr, COMMAND_CODE *cp, concptr pmt, concp
         }
 
         if (command_wrk == USE_INVEN) {
-            sprintf(fis_ptr->out_val, _("持ち物:", "Inven:"));
+            angband_strcpy(fis_ptr->out_val, _("持ち物:", "Inven:"), sizeof(fis_ptr->out_val));
             if (!use_menu) {
                 char tmp_val[80];
-                sprintf(tmp_val, _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(fis_ptr->i1), index_to_label(fis_ptr->i2));
-                strcat(fis_ptr->out_val, tmp_val);
+                strnfmt(tmp_val, sizeof(tmp_val), _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(fis_ptr->i1), index_to_label(fis_ptr->i2));
+                angband_strcat(fis_ptr->out_val, tmp_val, sizeof(fis_ptr->out_val));
             }
 
             if (!command_see && !use_menu) {
-                strcat(fis_ptr->out_val, _(" '*'一覧,", " * to see,"));
+                angband_strcat(fis_ptr->out_val, _(" '*'一覧,", " * to see,"), sizeof(fis_ptr->out_val));
             }
 
             if (fis_ptr->allow_equip) {
                 if (!use_menu) {
-                    strcat(fis_ptr->out_val, _(" '/' 装備品,", " / for Equip,"));
+                    angband_strcat(fis_ptr->out_val, _(" '/' 装備品,", " / for Equip,"), sizeof(fis_ptr->out_val));
                 } else if (fis_ptr->allow_floor) {
-                    strcat(fis_ptr->out_val, _(" '6' 装備品,", " 6 for Equip,"));
+                    angband_strcat(fis_ptr->out_val, _(" '6' 装備品,", " 6 for Equip,"), sizeof(fis_ptr->out_val));
                 } else {
-                    strcat(fis_ptr->out_val, _(" '4'or'6' 装備品,", " 4 or 6 for Equip,"));
+                    angband_strcat(fis_ptr->out_val, _(" '4'or'6' 装備品,", " 4 or 6 for Equip,"), sizeof(fis_ptr->out_val));
                 }
             }
 
             if (fis_ptr->allow_floor) {
                 if (!use_menu) {
-                    strcat(fis_ptr->out_val, _(" '-'床上,", " - for floor,"));
+                    angband_strcat(fis_ptr->out_val, _(" '-'床上,", " - for floor,"), sizeof(fis_ptr->out_val));
                 } else if (fis_ptr->allow_equip) {
-                    strcat(fis_ptr->out_val, _(" '4' 床上,", " 4 for floor,"));
+                    angband_strcat(fis_ptr->out_val, _(" '4' 床上,", " 4 for floor,"), sizeof(fis_ptr->out_val));
                 } else {
-                    strcat(fis_ptr->out_val, _(" '4'or'6' 床上,", " 4 or 6 for floor,"));
+                    angband_strcat(fis_ptr->out_val, _(" '4'or'6' 床上,", " 4 or 6 for floor,"), sizeof(fis_ptr->out_val));
                 }
             }
         } else if (command_wrk == (USE_EQUIP)) {
-            sprintf(fis_ptr->out_val, _("装備品:", "Equip:"));
+            angband_strcpy(fis_ptr->out_val, _("装備品:", "Equip:"), sizeof(fis_ptr->out_val));
             if (!use_menu) {
                 char tmp_val[80];
-                sprintf(tmp_val, _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(fis_ptr->e1), index_to_label(fis_ptr->e2));
-                strcat(fis_ptr->out_val, tmp_val);
+                strnfmt(tmp_val, sizeof(tmp_val), _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(fis_ptr->e1), index_to_label(fis_ptr->e2));
+                angband_strcat(fis_ptr->out_val, tmp_val, sizeof(fis_ptr->out_val));
             }
 
             if (!command_see && !use_menu) {
-                strcat(fis_ptr->out_val, _(" '*'一覧,", " * to see,"));
+                angband_strcat(fis_ptr->out_val, _(" '*'一覧,", " * to see,"), sizeof(fis_ptr->out_val));
             }
 
             if (fis_ptr->allow_inven) {
                 if (!use_menu) {
-                    strcat(fis_ptr->out_val, _(" '/' 持ち物,", " / for Inven,"));
+                    angband_strcat(fis_ptr->out_val, _(" '/' 持ち物,", " / for Inven,"), sizeof(fis_ptr->out_val));
                 } else if (fis_ptr->allow_floor) {
-                    strcat(fis_ptr->out_val, _(" '4' 持ち物,", " 4 for Inven,"));
+                    angband_strcat(fis_ptr->out_val, _(" '4' 持ち物,", " 4 for Inven,"), sizeof(fis_ptr->out_val));
                 } else {
-                    strcat(fis_ptr->out_val, _(" '4'or'6' 持ち物,", " 4 or 6 for Inven,"));
+                    angband_strcat(fis_ptr->out_val, _(" '4'or'6' 持ち物,", " 4 or 6 for Inven,"), sizeof(fis_ptr->out_val));
                 }
             }
 
             if (fis_ptr->allow_floor) {
                 if (!use_menu) {
-                    strcat(fis_ptr->out_val, _(" '-'床上,", " - for floor,"));
+                    angband_strcat(fis_ptr->out_val, _(" '-'床上,", " - for floor,"), sizeof(fis_ptr->out_val));
                 } else if (fis_ptr->allow_inven) {
-                    strcat(fis_ptr->out_val, _(" '6' 床上,", " 6 for floor,"));
+                    angband_strcat(fis_ptr->out_val, _(" '6' 床上,", " 6 for floor,"), sizeof(fis_ptr->out_val));
                 } else {
-                    strcat(fis_ptr->out_val, _(" '4'or'6' 床上,", " 4 or 6 for floor,"));
+                    angband_strcat(fis_ptr->out_val, _(" '4'or'6' 床上,", " 4 or 6 for floor,"), sizeof(fis_ptr->out_val));
                 }
             }
         } else if (command_wrk == USE_FLOOR) {
-            sprintf(fis_ptr->out_val, _("床上:", "Floor:"));
+            angband_strcpy(fis_ptr->out_val, _("床上:", "Floor:"), sizeof(fis_ptr->out_val));
             if (!use_menu) {
                 char tmp_val[80];
-                sprintf(tmp_val, _("%c-%c,'(',')',", " %c-%c,'(',')',"), fis_ptr->n1, fis_ptr->n2);
-                strcat(fis_ptr->out_val, tmp_val);
+                strnfmt(tmp_val, sizeof(tmp_val), _("%c-%c,'(',')',", " %c-%c,'(',')',"), fis_ptr->n1, fis_ptr->n2);
+                angband_strcat(fis_ptr->out_val, tmp_val, sizeof(fis_ptr->out_val));
             }
 
             if (!command_see && !use_menu) {
-                strcat(fis_ptr->out_val, _(" '*'一覧,", " * to see,"));
+                angband_strcat(fis_ptr->out_val, _(" '*'一覧,", " * to see,"), sizeof(fis_ptr->out_val));
             }
 
             if (use_menu) {
                 if (fis_ptr->allow_inven && fis_ptr->allow_equip) {
-                    strcat(fis_ptr->out_val, _(" '4' 装備品, '6' 持ち物,", " 4 for Equip, 6 for Inven,"));
+                    angband_strcat(fis_ptr->out_val, _(" '4' 装備品, '6' 持ち物,", " 4 for Equip, 6 for Inven,"), sizeof(fis_ptr->out_val));
                 } else if (fis_ptr->allow_inven) {
-                    strcat(fis_ptr->out_val, _(" '4'or'6' 持ち物,", " 4 or 6 for Inven,"));
+                    angband_strcat(fis_ptr->out_val, _(" '4'or'6' 持ち物,", " 4 or 6 for Inven,"), sizeof(fis_ptr->out_val));
                 } else if (fis_ptr->allow_equip) {
-                    strcat(fis_ptr->out_val, _(" '4'or'6' 装備品,", " 4 or 6 for Equip,"));
+                    angband_strcat(fis_ptr->out_val, _(" '4'or'6' 装備品,", " 4 or 6 for Equip,"), sizeof(fis_ptr->out_val));
                 }
             } else if (fis_ptr->allow_inven) {
-                strcat(fis_ptr->out_val, _(" '/' 持ち物,", " / for Inven,"));
+                angband_strcat(fis_ptr->out_val, _(" '/' 持ち物,", " / for Inven,"), sizeof(fis_ptr->out_val));
             } else if (fis_ptr->allow_equip) {
-                strcat(fis_ptr->out_val, _(" '/'装備品,", " / for Equip,"));
+                angband_strcat(fis_ptr->out_val, _(" '/'装備品,", " / for Equip,"), sizeof(fis_ptr->out_val));
             }
 
             if (command_see && !use_menu) {
-                strcat(fis_ptr->out_val, _(" Enter 次,", " Enter for scroll down,"));
+                angband_strcat(fis_ptr->out_val, _(" Enter 次,", " Enter for scroll down,"), sizeof(fis_ptr->out_val));
             }
         }
 
         if (fis_ptr->force) {
-            strcat(fis_ptr->out_val, _(" 'w'練気術,", " w for the Force,"));
+            angband_strcat(fis_ptr->out_val, _(" 'w'練気術,", " w for the Force,"), sizeof(fis_ptr->out_val));
         }
 
-        strcat(fis_ptr->out_val, " ESC");
-        sprintf(fis_ptr->tmp_val, "(%s) %s", fis_ptr->out_val, pmt);
+        angband_strcat(fis_ptr->out_val, " ESC", sizeof(fis_ptr->out_val));
+        strnfmt(fis_ptr->tmp_val, sizeof(fis_ptr->tmp_val), "(%s) %s", fis_ptr->out_val, pmt);
         prt(fis_ptr->tmp_val, 0, 0);
         fis_ptr->which = inkey();
         if (use_menu) {

--- a/src/inventory/item-getter.cpp
+++ b/src/inventory/item-getter.cpp
@@ -23,7 +23,9 @@
 #include "system/player-type-definition.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
+#include "util/string-processor.h"
 #include "view/display-inventory.h"
 #include "view/display-messages.h"
 #include "window/display-sub-windows.h"
@@ -329,49 +331,51 @@ bool get_item(PlayerType *player_ptr, OBJECT_IDX *cp, concptr pmt, concptr str, 
         }
 
         if (!command_wrk) {
-            sprintf(item_selection_ptr->out_val, _("持ち物:", "Inven:"));
+            angband_strcpy(item_selection_ptr->out_val, _("持ち物:", "Inven:"), sizeof(item_selection_ptr->out_val));
             if ((item_selection_ptr->i1 <= item_selection_ptr->i2) && !use_menu) {
                 char tmp_val[80];
-                sprintf(tmp_val, _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(item_selection_ptr->i1),
-                    index_to_label(item_selection_ptr->i2));
-                strcat(item_selection_ptr->out_val, tmp_val);
+                strnfmt(tmp_val, sizeof(tmp_val), _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(item_selection_ptr->i1), index_to_label(item_selection_ptr->i2));
+                angband_strcat(item_selection_ptr->out_val, tmp_val, sizeof(item_selection_ptr->out_val));
             }
 
             if (!command_see && !use_menu) {
-                strcat(item_selection_ptr->out_val, _(" '*'一覧,", " * to see,"));
+                angband_strcat(item_selection_ptr->out_val, _(" '*'一覧,", " * to see,"), sizeof(item_selection_ptr->out_val));
             }
 
             if (item_selection_ptr->equip) {
-                strcat(item_selection_ptr->out_val, format(_(" %s 装備品,", " %s for Equip,"), use_menu ? _("'4'or'6'", "4 or 6") : _("'/'", "/")));
+                char tmp_val[80];
+                strnfmt(tmp_val, sizeof(tmp_val), _(" %s 装備品,", " %s for Equip,"), use_menu ? _("'4'or'6'", "4 or 6") : _("'/'", "/"));
+                angband_strcat(item_selection_ptr->out_val, tmp_val, sizeof(item_selection_ptr->out_val));
             }
         } else {
-            sprintf(item_selection_ptr->out_val, _("装備品:", "Equip:"));
+            angband_strcpy(item_selection_ptr->out_val, _("装備品:", "Equip:"), sizeof(item_selection_ptr->out_val));
             if ((item_selection_ptr->e1 <= item_selection_ptr->e2) && !use_menu) {
                 char tmp_val[80];
-                sprintf(tmp_val, _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(item_selection_ptr->e1),
-                    index_to_label(item_selection_ptr->e2));
-                strcat(item_selection_ptr->out_val, tmp_val);
+                strnfmt(tmp_val, sizeof(tmp_val), _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(item_selection_ptr->e1), index_to_label(item_selection_ptr->e2));
+                angband_strcat(item_selection_ptr->out_val, tmp_val, sizeof(item_selection_ptr->out_val));
             }
 
             if (!command_see && !use_menu) {
-                strcat(item_selection_ptr->out_val, _(" '*'一覧,", " * to see,"));
+                angband_strcat(item_selection_ptr->out_val, _(" '*'一覧,", " * to see,"), sizeof(item_selection_ptr->out_val));
             }
 
             if (item_selection_ptr->inven) {
-                strcat(item_selection_ptr->out_val, format(_(" %s 持ち物,", " %s for Inven,"), use_menu ? _("'4'or'6'", "4 or 6") : _("'/'", "'/'")));
+                char tmp_val[80];
+                strnfmt(tmp_val, sizeof(tmp_val), _(" %s 持ち物,", " %s for Inven,"), use_menu ? _("'4'or'6'", "4 or 6") : _("'/'", "'/'"));
+                angband_strcat(item_selection_ptr->out_val, tmp_val, sizeof(item_selection_ptr->out_val));
             }
         }
 
         if (item_selection_ptr->allow_floor) {
-            strcat(item_selection_ptr->out_val, _(" '-'床上,", " - for floor,"));
+            angband_strcat(item_selection_ptr->out_val, _(" '-'床上,", " - for floor,"), sizeof(item_selection_ptr->out_val));
         }
 
         if (item_selection_ptr->mode & USE_FORCE) {
-            strcat(item_selection_ptr->out_val, _(" 'w'練気術,", " w for the Force,"));
+            angband_strcat(item_selection_ptr->out_val, _(" 'w'練気術,", " w for the Force,"), sizeof(item_selection_ptr->out_val));
         }
 
-        strcat(item_selection_ptr->out_val, " ESC");
-        sprintf(item_selection_ptr->tmp_val, "(%s) %s", item_selection_ptr->out_val, pmt);
+        angband_strcat(item_selection_ptr->out_val, " ESC", sizeof(item_selection_ptr->out_val));
+        strnfmt(item_selection_ptr->tmp_val, sizeof(item_selection_ptr->tmp_val), "(%s) %s", item_selection_ptr->out_val, pmt);
         prt(item_selection_ptr->tmp_val, 0, 0);
         item_selection_ptr->which = inkey();
         if (use_menu) {

--- a/src/inventory/player-inventory.cpp
+++ b/src/inventory/player-inventory.cpp
@@ -31,6 +31,7 @@
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "target/target-checker.h"
+#include "term/z-form.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 #ifdef JP
@@ -159,7 +160,7 @@ void py_pickup_floor(PlayerType *player_ptr, bool pickup)
         char out_val[MAX_NLEN + 20];
         o_ptr = &player_ptr->current_floor_ptr->o_list[floor_o_idx];
         describe_flavor(player_ptr, o_name, o_ptr, 0);
-        (void)sprintf(out_val, _("%sを拾いますか? ", "Pick up %s? "), o_name);
+        strnfmt(out_val, sizeof(out_val), _("%sを拾いますか? ", "Pick up %s? "), o_name);
         if (!get_check(out_val)) {
             return;
         }
@@ -294,7 +295,7 @@ void carry(PlayerType *player_ptr, bool pickup)
         int is_pickup_successful = true;
         if (carry_query_flag) {
             char out_val[MAX_NLEN + 20];
-            sprintf(out_val, _("%sを拾いますか? ", "Pick up %s? "), o_name);
+            strnfmt(out_val, sizeof(out_val), _("%sを拾いますか? ", "Pick up %s? "), o_name);
             is_pickup_successful = get_check(out_val);
         }
 

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -39,6 +39,7 @@
 #include "system/monster-entity.h"
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
+#include "term/z-form.h"
 #include "util/enum-converter.h"
 #include "util/int-char-converter.h"
 #include "util/sort.h"
@@ -368,7 +369,7 @@ static void dump_aux_monsters(PlayerType *player_ptr, FILE *fff)
     for (auto it = who.rbegin(); it != who.rend() && std::distance(who.rbegin(), it) < 10; it++) {
         auto *r_ptr = &monraces_info[*it];
         if (r_ptr->defeat_level && r_ptr->defeat_time) {
-            sprintf(buf, _(" - レベル%2d - %d:%02d:%02d", " - level %2d - %d:%02d:%02d"), r_ptr->defeat_level, r_ptr->defeat_time / (60 * 60),
+            strnfmt(buf, sizeof(buf), _(" - レベル%2d - %d:%02d:%02d", " - level %2d - %d:%02d:%02d"), r_ptr->defeat_level, r_ptr->defeat_time / (60 * 60),
                 (r_ptr->defeat_time / 60) % 60, r_ptr->defeat_time % 60);
         } else {
             buf[0] = '\0';

--- a/src/io-dump/dump-remover.cpp
+++ b/src/io-dump/dump-remover.cpp
@@ -1,6 +1,7 @@
 ﻿#include "io-dump/dump-remover.h"
 #include "io-dump/dump-util.h"
 #include "io/read-pref-file.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 
 /*!
@@ -9,6 +10,7 @@
  * @brief prf出力内容を消去する /
  * Remove old lines automatically generated before.
  * @param orig_file 消去を行うファイル名
+ * @param auto_dump_mark 出力するヘッダマーク
  */
 void remove_auto_dump(concptr orig_file, concptr auto_dump_mark)
 {
@@ -20,8 +22,8 @@ void remove_auto_dump(concptr orig_file, concptr auto_dump_mark)
     char header_mark_str[80];
     char footer_mark_str[80];
 
-    sprintf(header_mark_str, auto_dump_header, auto_dump_mark);
-    sprintf(footer_mark_str, auto_dump_footer, auto_dump_mark);
+    strnfmt(header_mark_str, sizeof(header_mark_str), auto_dump_header, auto_dump_mark);
+    strnfmt(footer_mark_str, sizeof(footer_mark_str), auto_dump_footer, auto_dump_mark);
     size_t mark_len = strlen(footer_mark_str);
 
     FILE *orig_fff;

--- a/src/io/pref-file-expressor.cpp
+++ b/src/io/pref-file-expressor.cpp
@@ -5,6 +5,7 @@
 #include "realm/realm-names-table.h"
 #include "system/player-type-definition.h"
 #include "system/system-variables.h"
+#include "term/z-form.h"
 #include "util/string-processor.h"
 
 /*!
@@ -208,7 +209,7 @@ concptr process_pref_file_expr(PlayerType *player_ptr, char **sp, char *fp)
         v = realm_names[player_ptr->realm2];
 #endif
     } else if (streq(b + 1, "LEVEL")) {
-        sprintf(tmp, "%02d", player_ptr->lev);
+        strnfmt(tmp, sizeof(tmp), "%02d", player_ptr->lev);
         v = tmp;
     } else if (streq(b + 1, "AUTOREGISTER")) {
         if (player_ptr->autopick_autoregister) {
@@ -217,7 +218,7 @@ concptr process_pref_file_expr(PlayerType *player_ptr, char **sp, char *fp)
             v = "0";
         }
     } else if (streq(b + 1, "MONEY")) {
-        sprintf(tmp, "%09ld", (long int)player_ptr->au);
+        strnfmt(tmp, sizeof(tmp), "%09ld", (long int)player_ptr->au);
         v = tmp;
     }
 

--- a/src/lore/lore-calculator.cpp
+++ b/src/lore/lore-calculator.cpp
@@ -7,6 +7,7 @@
 #include "mspell/mspell-damage-calculator.h"
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
+#include "util/string-processor.h"
 
 /*!
  * @brief ダイス目を文字列に変換する
@@ -27,20 +28,20 @@ void dice_to_string(int base_damage, int dice_num, int dice_side, int dice_mult,
     }
 
     if (base_damage != 0) {
-        sprintf(base, "%d+", base_damage);
+        strnfmt(base, sizeof(base), "%d+", base_damage);
     }
 
     if (dice_num == 1) {
-        sprintf(dice, "d%d", dice_side);
+        strnfmt(dice, sizeof(dice), "d%d", dice_side);
     } else {
-        sprintf(dice, "%dd%d", dice_num, dice_side);
+        strnfmt(dice, sizeof(dice), "%dd%d", dice_num, dice_side);
     }
 
     if (dice_mult != 1 || dice_div != 1) {
         if (dice_div == 1) {
-            sprintf(mult, "*%d", dice_mult);
+            strnfmt(mult, sizeof(mult), "*%d", dice_mult);
         } else {
-            sprintf(mult, "*(%d/%d)", dice_mult, dice_div);
+            strnfmt(mult, sizeof(mult), "*(%d/%d)", dice_mult, dice_div);
         }
     }
 
@@ -125,21 +126,23 @@ bool know_damage(MonsterRaceId r_idx, int i)
 void set_damage(PlayerType *player_ptr, lore_type *lore_ptr, MonsterAbilityType ms_type, concptr msg)
 {
     MonsterRaceId r_idx = lore_ptr->r_idx;
+    char *tmp = lore_ptr->tmp_msg[lore_ptr->vn];
+    size_t tmpsz = sizeof(lore_ptr->tmp_msg[lore_ptr->vn]);
+
+    if (!know_armour(r_idx, lore_ptr->know_everything)) {
+        strnfmt(tmp, tmpsz, msg, "");
+        return;
+    }
+
     int base_damage = monspell_race_damage(player_ptr, ms_type, r_idx, BASE_DAM);
     int dice_num = monspell_race_damage(player_ptr, ms_type, r_idx, DICE_NUM);
     int dice_side = monspell_race_damage(player_ptr, ms_type, r_idx, DICE_SIDE);
     int dice_mult = monspell_race_damage(player_ptr, ms_type, r_idx, DICE_MULT);
     int dice_div = monspell_race_damage(player_ptr, ms_type, r_idx, DICE_DIV);
-    char dmg_str[80], dice_str[sizeof(dmg_str) + 10];
-    char *tmp = lore_ptr->tmp_msg[lore_ptr->vn];
-    dice_to_string(base_damage, dice_num, dice_side, dice_mult, dice_div, dmg_str);
-    sprintf(dice_str, "(%s)", dmg_str);
-
-    if (know_armour(r_idx, lore_ptr->know_everything)) {
-        sprintf(tmp, msg, dice_str);
-    } else {
-        sprintf(tmp, msg, "");
-    }
+    char dmg_str[80] = "(";
+    dice_to_string(base_damage, dice_num, dice_side, dice_mult, dice_div, dmg_str + 1);
+    angband_strcat(dmg_str, ")", sizeof(dmg_str));
+    strnfmt(tmp, tmpsz, msg, dmg_str);
 }
 
 void set_drop_flags(lore_type *lore_ptr)

--- a/src/main-cap.cpp
+++ b/src/main-cap.cpp
@@ -4,6 +4,7 @@
 
 #include "io/exit-panic.h"
 #include "system/angband.h"
+#include "term/z-form.h"
 
 #ifdef USE_CAP
 
@@ -255,7 +256,7 @@ static void do_cs(int y1, int y2)
 
 #ifdef USE_HARDCODE
     char temp[64];
-    sprintf(temp, cs, y1, y2);
+    strnfmt(temp, sizeof(temp), cs, y1, y2);
     tp(temp);
 #endif
 }
@@ -274,7 +275,7 @@ static void do_cm(int x, int y)
 
 #ifdef USE_HARDCODE
     char temp[64];
-    sprintf(temp, cm, y + 1, x + 1);
+    strnfmt(temp, sizeof(temp), cm, y + 1, x + 1);
     tp(temp);
 #endif
 }

--- a/src/mind/mind-monk.cpp
+++ b/src/mind/mind-monk.cpp
@@ -11,6 +11,7 @@
 #include "status/action-setter.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 
@@ -44,7 +45,7 @@ bool choose_monk_stance(PlayerType *player_ptr)
     for (auto i = 0U; i < monk_stances.size(); i++) {
         if (player_ptr->lev >= monk_stances[i].min_level) {
             char buf[80];
-            sprintf(buf, " %c) %-12s  %s", I2A(i + 1), monk_stances[i].desc, monk_stances[i].info);
+            strnfmt(buf, sizeof(buf), " %c) %-12s  %s", I2A(i + 1), monk_stances[i].desc, monk_stances[i].info);
             prt(buf, 3 + i, 20);
         }
     }

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -36,6 +36,7 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "timed-effect/player-cut.h"
 #include "timed-effect/player-fear.h"
 #include "timed-effect/player-stun.h"
@@ -396,7 +397,7 @@ bool choose_samurai_stance(PlayerType *player_ptr)
     prt(_(" a) 型を崩す", " a) No Form"), 2, 20);
     for (auto i = 0U; i < samurai_stances.size(); i++) {
         if (player_ptr->lev >= samurai_stances[i].min_level) {
-            sprintf(buf, _(" %c) %sの型    %s", " %c) Stance of %-12s  %s"), I2A(i + 1), samurai_stances[i].desc, samurai_stances[i].info);
+            strnfmt(buf, sizeof(buf), _(" %c) %sの型    %s", " %c) Stance of %-12s  %s"), I2A(i + 1), samurai_stances[i].desc, samurai_stances[i].info);
             prt(buf, 3 + i, 20);
         }
     }

--- a/src/player-info/race-ability-info.cpp
+++ b/src/player-info/race-ability-info.cpp
@@ -1,6 +1,7 @@
 ﻿#include "player-info/race-ability-info.h"
 #include "player-info/self-info-util.h"
 #include "system/player-type-definition.h"
+#include "term/z-form.h"
 
 /*!
  * @brief レイシャルパワーの説明文を表示する
@@ -84,7 +85,7 @@ void set_race_ability_info(PlayerType *player_ptr, self_info_type *self_ptr)
         break;
     case PlayerRaceType::CYCLOPS:
         if (player_ptr->lev >= 20) {
-            sprintf(self_ptr->plev_buf, _("あなたは %d ダメージの岩石を投げることができる。(15 MP)", "You can throw a boulder, dam. %d (cost 15)."),
+            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージの岩石を投げることができる。(15 MP)", "You can throw a boulder, dam. %d (cost 15)."),
                 (3 * player_ptr->lev) / 2);
             self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
         }
@@ -98,15 +99,15 @@ void set_race_ability_info(PlayerType *player_ptr, self_info_type *self_ptr)
         break;
     case PlayerRaceType::KLACKON:
         if (player_ptr->lev >= 9) {
-            sprintf(
-                self_ptr->plev_buf, _("あなたは %d ダメージの酸を吹きかけることができる。(9 MP)", "You can spit acid, dam. %d (cost 9)."), player_ptr->lev);
+            strnfmt(
+                self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージの酸を吹きかけることができる。(9 MP)", "You can spit acid, dam. %d (cost 9)."), player_ptr->lev);
             self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
         }
 
         break;
     case PlayerRaceType::KOBOLD:
         if (player_ptr->lev >= 12) {
-            sprintf(self_ptr->plev_buf, _("あなたは %d ダメージの毒矢を投げることができる。(8 MP)", "You can throw a dart of poison, dam. %d (cost 8)."),
+            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージの毒矢を投げることができる。(8 MP)", "You can throw a dart of poison, dam. %d (cost 8)."),
                 player_ptr->lev);
             self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
         }
@@ -114,20 +115,20 @@ void set_race_ability_info(PlayerType *player_ptr, self_info_type *self_ptr)
         break;
     case PlayerRaceType::DARK_ELF:
         if (player_ptr->lev >= 2) {
-            sprintf(self_ptr->plev_buf, _("あなたは %d ダメージのマジック・ミサイルの呪文を使える。(2 MP)", "You can cast a Magic Missile, dam %d (cost 2)."),
+            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージのマジック・ミサイルの呪文を使える。(2 MP)", "You can cast a Magic Missile, dam %d (cost 2)."),
                 (3 + ((player_ptr->lev - 1) / 5)));
             self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
         }
 
         break;
     case PlayerRaceType::DRACONIAN:
-        sprintf(self_ptr->plev_buf, _("あなたは %d ダメージのブレスを吐くことができる。(%d MP)", "You can breathe, dam. %d (cost %d)."), 2 * player_ptr->lev,
+        strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージのブレスを吐くことができる。(%d MP)", "You can breathe, dam. %d (cost %d)."), 2 * player_ptr->lev,
             player_ptr->lev);
         self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
         break;
     case PlayerRaceType::MIND_FLAYER:
         if (player_ptr->lev >= 15) {
-            sprintf(self_ptr->plev_buf, _("あなたは %d ダメージの精神攻撃をすることができる。(12 MP)", "You can mind blast your enemies, dam %d (cost 12)."),
+            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージの精神攻撃をすることができる。(12 MP)", "You can mind blast your enemies, dam %d (cost 12)."),
                 player_ptr->lev);
         }
 
@@ -135,14 +136,14 @@ void set_race_ability_info(PlayerType *player_ptr, self_info_type *self_ptr)
         break;
     case PlayerRaceType::IMP:
         if (player_ptr->lev >= 30) {
-            sprintf(self_ptr->plev_buf, _("あなたは %d ダメージのファイア・ボールの呪文を使える。(15 MP)", "You can cast a Fire Ball, dam. %d (cost 15)."),
+            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージのファイア・ボールの呪文を使える。(15 MP)", "You can cast a Fire Ball, dam. %d (cost 15)."),
                 player_ptr->lev);
             self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
             break;
         }
 
         if (player_ptr->lev >= 9) {
-            sprintf(self_ptr->plev_buf, _("あなたは %d ダメージのファイア・ボルトの呪文を使える。(15 MP)", "You can cast a Fire Bolt, dam. %d (cost 15)."),
+            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージのファイア・ボルトの呪文を使える。(15 MP)", "You can cast a Fire Bolt, dam. %d (cost 15)."),
                 player_ptr->lev);
             self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
         }
@@ -166,7 +167,7 @@ void set_race_ability_info(PlayerType *player_ptr, self_info_type *self_ptr)
             break;
         }
 
-        sprintf(self_ptr->plev_buf, _("あなたは敵から %d HP の生命力を吸収できる。(%d MP)", "You can steal life from a foe, dam. %d (cost %d)."),
+        strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは敵から %d HP の生命力を吸収できる。(%d MP)", "You can steal life from a foe, dam. %d (cost %d)."),
             player_ptr->lev * 2, 1 + (player_ptr->lev / 3));
         self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
         break;
@@ -183,7 +184,7 @@ void set_race_ability_info(PlayerType *player_ptr, self_info_type *self_ptr)
 
         break;
     case PlayerRaceType::BALROG:
-        sprintf(self_ptr->plev_buf, _("あなたは %d ダメージの地獄か火炎のブレスを吐くことができる。(%d MP)", "You can breathe nether, dam. %d (cost %d)."),
+        strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージの地獄か火炎のブレスを吐くことができる。(%d MP)", "You can breathe nether, dam. %d (cost %d)."),
             3 * player_ptr->lev, 10 + player_ptr->lev / 3);
         self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
         break;
@@ -195,20 +196,20 @@ void set_race_ability_info(PlayerType *player_ptr, self_info_type *self_ptr)
         break;
     case PlayerRaceType::ANDROID:
         if (player_ptr->lev < 10) {
-            sprintf(self_ptr->plev_buf, _("あなたは %d ダメージのレイガンを撃つことができる。(7 MP)", "You can fire a ray gun with damage %d (cost 7)."),
+            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージのレイガンを撃つことができる。(7 MP)", "You can fire a ray gun with damage %d (cost 7)."),
                 (player_ptr->lev + 1) / 2);
         } else if (player_ptr->lev < 25) {
-            sprintf(self_ptr->plev_buf, _("あなたは %d ダメージのブラスターを撃つことができる。(13 MP)", "You can fire a blaster with damage %d (cost 13)."),
+            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージのブラスターを撃つことができる。(13 MP)", "You can fire a blaster with damage %d (cost 13)."),
                 player_ptr->lev);
         } else if (player_ptr->lev < 35) {
-            sprintf(self_ptr->plev_buf, _("あなたは %d ダメージのバズーカを撃つことができる。(26 MP)", "You can fire a bazooka with damage %d (cost 26)."),
+            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージのバズーカを撃つことができる。(26 MP)", "You can fire a bazooka with damage %d (cost 26)."),
                 player_ptr->lev * 2);
         } else if (player_ptr->lev < 45) {
-            sprintf(self_ptr->plev_buf,
+            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf),
                 _("あなたは %d ダメージのビームキャノンを撃つことができる。(40 MP)", "You can fire a beam cannon with damage %d (cost 40)."),
                 player_ptr->lev * 2);
         } else {
-            sprintf(self_ptr->plev_buf, _("あなたは %d ダメージのロケットを撃つことができる。(60 MP)", "You can fire a rocket with damage %d (cost 60)."),
+            strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージのロケットを撃つことができる。(60 MP)", "You can fire a rocket with damage %d (cost 60)."),
                 player_ptr->lev * 5);
         }
 

--- a/src/player-info/self-info.cpp
+++ b/src/player-info/self-info.cpp
@@ -28,6 +28,7 @@
 #include "player/player-status.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "timed-effect/player-blindness.h"
 #include "timed-effect/player-confusion.h"
 #include "timed-effect/player-cut.h"
@@ -436,7 +437,7 @@ void report_magics(PlayerType *player_ptr)
     int k = 2;
     char buf[80];
     for (int j = 0; j < i; j++) {
-        sprintf(buf, _("%-28s : 期間 - %s ", "%s %s."), info[j], report_magic_durations[info2[j]]);
+        strnfmt(buf, sizeof(buf), _("%-28s : 期間 - %s ", "%s %s."), info[j], report_magic_durations[info2[j]]);
         prt(buf, k++, 15);
 
         /* Every 20 entries (lines 2 to 21), start over */

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -38,6 +38,7 @@
 #include "target/target-setter.h"
 #include "target/target-types.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 #include "world/world.h"
@@ -297,7 +298,7 @@ bool tele_town(PlayerType *player_ptr)
             continue;
         }
 
-        sprintf(buf, "%c) %-20s", I2A(i - 1), town_info[i].name);
+        strnfmt(buf, sizeof(buf), "%c) %-20s", I2A(i - 1), town_info[i].name);
         prt(buf, 5 + i, 5);
         num++;
     }
@@ -406,8 +407,7 @@ static DUNGEON_IDX choose_dungeon(concptr note, POSITION y, POSITION x)
             seiha = true;
         }
 
-        sprintf(buf, _("      %c) %c%-12s : 最大 %d 階", "      %c) %c%-16s : Max level %d"),
-            static_cast<char>('a' + dun.size()), seiha ? '!' : ' ', d_ref.name.data(), (int)max_dlv[d_ref.idx]);
+        strnfmt(buf, sizeof(buf), _("      %c) %c%-12s : 最大 %d 階", "      %c) %c%-16s : Max level %d"), static_cast<char>('a' + dun.size()), seiha ? '!' : ' ', d_ref.name.data(), (int)max_dlv[d_ref.idx]);
         prt(buf, y + dun.size(), x);
         dun.push_back(d_ref.idx);
     }
@@ -532,8 +532,6 @@ bool free_level_recall(PlayerType *player_ptr)
 bool reset_recall(PlayerType *player_ptr)
 {
     int select_dungeon, dummy = 0;
-    char ppp[80];
-    char tmp_val[160];
 
     select_dungeon = choose_dungeon(_("をセット", "reset"), 2, 14);
     if (ironman_downward) {
@@ -544,8 +542,10 @@ bool reset_recall(PlayerType *player_ptr)
     if (!select_dungeon) {
         return false;
     }
-    sprintf(ppp, _("何階にセットしますか (%d-%d):", "Reset to which level (%d-%d): "), (int)dungeons_info[select_dungeon].mindepth, (int)max_dlv[select_dungeon]);
-    sprintf(tmp_val, "%d", (int)std::max(player_ptr->current_floor_ptr->dun_level, 1));
+    char ppp[80];
+    strnfmt(ppp, sizeof(ppp), _("何階にセットしますか (%d-%d):", "Reset to which level (%d-%d): "), (int)dungeons_info[select_dungeon].mindepth, (int)max_dlv[select_dungeon]);
+    char tmp_val[160];
+    strnfmt(tmp_val, sizeof(tmp_val), "%d", (int)std::max(player_ptr->current_floor_ptr->dun_level, 1));
 
     if (!get_string(ppp, tmp_val, 10)) {
         return false;

--- a/src/spell-realm/spells-sorcery.cpp
+++ b/src/spell-realm/spells-sorcery.cpp
@@ -12,6 +12,7 @@
 #include "object/object-value.h"
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
+#include "term/z-form.h"
 #include "view/display-messages.h"
 
 /*!
@@ -53,7 +54,7 @@ bool alchemy(PlayerType *player_ptr)
     if (!force) {
         if (confirm_destroy || (o_ptr->get_price() > 0)) {
             char out_val[MAX_NLEN + 40];
-            sprintf(out_val, _("本当に%sを金に変えますか？", "Really turn %s to gold? "), o_name);
+            strnfmt(out_val, sizeof(out_val), _("本当に%sを金に変えますか？", "Really turn %s to gold? "), o_name);
             if (!get_check(out_val)) {
                 return false;
             }

--- a/src/store/museum.cpp
+++ b/src/store/museum.cpp
@@ -25,11 +25,8 @@ void museum_remove_object(PlayerType *player_ptr)
         i = store_bottom;
     }
 
-    char out_val[160];
-    sprintf(out_val, _("どのアイテムの展示をやめさせますか？", "Which item do you want to order to remove? "));
-
     COMMAND_CODE item;
-    if (!get_stock(&item, out_val, 0, i - 1, StoreSaleType::MUSEUM)) {
+    if (!get_stock(&item, _("どのアイテムの展示をやめさせますか？", "Which item do you want to order to remove? "), 0, i - 1, StoreSaleType::MUSEUM)) {
         return;
     }
 

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -30,6 +30,7 @@
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
 #include "util/quarks.h"
 #include "view/display-messages.h"
@@ -164,9 +165,9 @@ int get_stock(COMMAND_CODE *com_val, concptr pmt, int i, int j, [[maybe_unused]]
     char hi = (j > 25) ? toupper(I2A(j - 26)) : I2A(j);
     char out_val[160];
 #ifdef JP
-    (void)sprintf(out_val, "(%s:%c-%c, ESCで中断) %s", (((store_num == StoreSaleType::HOME) || (store_num == StoreSaleType::MUSEUM)) ? "アイテム" : "商品"), lo, hi, pmt);
+    strnfmt(out_val, sizeof(out_val), "(%s:%c-%c, ESCで中断) %s", (((store_num == StoreSaleType::HOME) || (store_num == StoreSaleType::MUSEUM)) ? "アイテム" : "商品"), lo, hi, pmt);
 #else
-    (void)sprintf(out_val, "(Items %c-%c, ESC to exit) %s", lo, hi, pmt);
+    strnfmt(out_val, sizeof(out_val), "(Items %c-%c, ESC to exit) %s", lo, hi, pmt);
 #endif
 
     char command;
@@ -223,11 +224,8 @@ void store_examine(PlayerType *player_ptr, StoreSaleType store_num)
         i = store_bottom;
     }
 
-    char out_val[160];
-    sprintf(out_val, _("どれを調べますか？", "Which item do you want to examine? "));
-
     COMMAND_CODE item;
-    if (!get_stock(&item, out_val, 0, i - 1, store_num)) {
+    if (!get_stock(&item, _("どれを調べますか？", "Which item do you want to examine? "), 0, i - 1, store_num)) {
         return;
     }
     item = item + store_top;

--- a/src/target/target-setter.cpp
+++ b/src/target/target-setter.cpp
@@ -21,8 +21,10 @@
 #include "target/target-preparation.h"
 #include "target/target-types.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
+#include "util/string-processor.h"
 #include "window/display-sub-windows.h"
 #include "window/main-window-util.h"
 #include <vector>
@@ -175,9 +177,9 @@ static void describe_projectablity(PlayerType *player_ptr, ts_type *ts_ptr)
 
     ts_ptr->g_ptr = &player_ptr->current_floor_ptr->grid_array[ts_ptr->y][ts_ptr->x];
     if (target_able(player_ptr, ts_ptr->g_ptr->m_idx)) {
-        strcpy(ts_ptr->info, _("q止 t決 p自 o現 +次 -前", "q,t,p,o,+,-,<dir>"));
+        angband_strcpy(ts_ptr->info, _("q止 t決 p自 o現 +次 -前", "q,t,p,o,+,-,<dir>"), sizeof(ts_ptr->info));
     } else {
-        strcpy(ts_ptr->info, _("q止 p自 o現 +次 -前", "q,p,o,+,-,<dir>"));
+        angband_strcpy(ts_ptr->info, _("q止 p自 o現 +次 -前", "q,p,o,+,-,<dir>"), sizeof(ts_ptr->info));
     }
 
     if (!cheat_sight) {
@@ -185,9 +187,11 @@ static void describe_projectablity(PlayerType *player_ptr, ts_type *ts_ptr)
     }
 
     char cheatinfo[30];
-    sprintf(cheatinfo, " X:%d Y:%d LOS:%d LOP:%d", ts_ptr->x, ts_ptr->y, los(player_ptr, player_ptr->y, player_ptr->x, ts_ptr->y, ts_ptr->x),
+    strnfmt(cheatinfo, sizeof(cheatinfo), " X:%d Y:%d LOS:%d LOP:%d", ts_ptr->x,
+        ts_ptr->y,
+        los(player_ptr, player_ptr->y, player_ptr->x, ts_ptr->y, ts_ptr->x),
         projectable(player_ptr, player_ptr->y, player_ptr->x, ts_ptr->y, ts_ptr->x));
-    strcat(ts_ptr->info, cheatinfo);
+    angband_strcat(ts_ptr->info, cheatinfo, sizeof(ts_ptr->info));
 }
 
 static void menu_target(ts_type *ts_ptr)
@@ -424,9 +428,9 @@ static void describe_grid_wizard(PlayerType *player_ptr, ts_type *ts_ptr)
     }
 
     char cheatinfo[100];
-    sprintf(cheatinfo, " X:%d Y:%d LOS:%d LOP:%d SPECIAL:%d", ts_ptr->x, ts_ptr->y, los(player_ptr, player_ptr->y, player_ptr->x, ts_ptr->y, ts_ptr->x),
+    strnfmt(cheatinfo, sizeof(cheatinfo), " X:%d Y:%d LOS:%d LOP:%d SPECIAL:%d", ts_ptr->x, ts_ptr->y, los(player_ptr, player_ptr->y, player_ptr->x, ts_ptr->y, ts_ptr->x),
         projectable(player_ptr, player_ptr->y, player_ptr->x, ts_ptr->y, ts_ptr->x), ts_ptr->g_ptr->special);
-    strcat(ts_ptr->info, cheatinfo);
+    angband_strcat(ts_ptr->info, cheatinfo, sizeof(ts_ptr->info));
 }
 
 static void switch_next_grid_command(PlayerType *player_ptr, ts_type *ts_ptr)

--- a/src/term/z-form.cpp
+++ b/src/term/z-form.cpp
@@ -167,7 +167,7 @@ static uint vstrnfmt_aux_dflt(char *buf, uint max, concptr fmt, vptr arg)
     fmt = fmt ? fmt : 0;
 
     /* Pointer display */
-    sprintf(tmp, "<<%p>>", arg);
+    snprintf(tmp, sizeof(tmp), "<<%p>>", arg);
     len = strlen(tmp);
     if (len >= max) {
         len = max - 1;
@@ -413,7 +413,7 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
                     arg = va_arg(vp, int);
 
                     /* Hack -- append the "length" */
-                    sprintf(aux + q, "%d", arg);
+                    snprintf(aux + q, sizeof(aux) - q, "%d", arg);
 
                     /* Hack -- accept the "length" */
                     while (aux[q]) {
@@ -457,7 +457,7 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
             arg = va_arg(vp, int);
 
             /* Format the argument */
-            sprintf(tmp, "%c", arg);
+            snprintf(tmp, sizeof(tmp), "%c", arg);
 
             break;
         }
@@ -472,7 +472,7 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
                 arg = va_arg(vp, long);
 
                 /* Format the argument */
-                sprintf(tmp, aux, arg);
+                snprintf(tmp, sizeof(tmp), aux, arg);
             } else if (do_long_long) {
                 long long arg;
 
@@ -480,7 +480,7 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
                 arg = va_arg(vp, long long);
 
                 /* Format the argument */
-                sprintf(tmp, aux, arg);
+                snprintf(tmp, sizeof(tmp), aux, arg);
             } else {
                 int arg;
 
@@ -488,7 +488,7 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
                 arg = va_arg(vp, int);
 
                 /* Format the argument */
-                sprintf(tmp, aux, arg);
+                snprintf(tmp, sizeof(tmp), aux, arg);
             }
 
             break;
@@ -505,20 +505,20 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
                 /* Access next argument */
                 arg = va_arg(vp, ulong);
 
-                sprintf(tmp, aux, arg);
+                snprintf(tmp, sizeof(tmp), aux, arg);
             } else if (do_long_long) {
                 unsigned long long arg;
 
                 /* Access next argument */
                 arg = va_arg(vp, unsigned long long);
 
-                sprintf(tmp, aux, arg);
+                snprintf(tmp, sizeof(tmp), aux, arg);
             } else {
                 uint arg;
 
                 /* Access next argument */
                 arg = va_arg(vp, uint);
-                sprintf(tmp, aux, arg);
+                snprintf(tmp, sizeof(tmp), aux, arg);
             }
 
             break;
@@ -536,7 +536,7 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
             arg = va_arg(vp, double);
 
             /* Format the argument */
-            sprintf(tmp, aux, arg);
+            snprintf(tmp, sizeof(tmp), aux, arg);
 
             break;
         }
@@ -549,7 +549,7 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
             arg = va_arg(vp, vptr);
 
             /* Format the argument */
-            sprintf(tmp, aux, arg);
+            snprintf(tmp, sizeof(tmp), aux, arg);
 
             break;
         }
@@ -572,7 +572,7 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
             arg2[1023] = '\0';
 
             /* Format the argument */
-            sprintf(tmp, aux, arg);
+            snprintf(tmp, sizeof(tmp), aux, arg);
 
             break;
         }
@@ -586,7 +586,7 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
             arg = va_arg(vp, vptr);
 
             /* Format the "user data" */
-            sprintf(tmp, aux, arg);
+            snprintf(tmp, sizeof(tmp), aux, arg);
 
             break;
         }

--- a/src/view/display-inventory.cpp
+++ b/src/view/display-inventory.cpp
@@ -15,6 +15,8 @@
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
+#include "util/string-processor.h"
 
 /*!
  * @brief 所持アイテムの表示を行う /
@@ -93,15 +95,15 @@ COMMAND_CODE show_inventory(PlayerType *player_ptr, int target_item, BIT_FLAGS m
         prt("", j + 1, col ? col - 2 : col);
         if (use_menu && target_item) {
             if (j == (target_item - 1)) {
-                strcpy(tmp_val, _("》", "> "));
+                angband_strcpy(tmp_val, _("》", "> "), sizeof(tmp_val));
                 target_item_label = i;
             } else {
-                strcpy(tmp_val, "  ");
+                angband_strcpy(tmp_val, "  ", sizeof(tmp_val));
             }
         } else if (i <= INVEN_PACK) {
-            sprintf(tmp_val, "%c)", inven_label[i]);
+            strnfmt(tmp_val, sizeof(tmp_val), "%c)", inven_label[i]);
         } else {
-            sprintf(tmp_val, "%c)", index_to_label(i));
+            strnfmt(tmp_val, sizeof(tmp_val), "%c)", index_to_label(i));
         }
 
         put_str(tmp_val, j + 1, col);
@@ -120,7 +122,7 @@ COMMAND_CODE show_inventory(PlayerType *player_ptr, int target_item, BIT_FLAGS m
         c_put_str(out_color[j], out_desc[j], j + 1, cur_col);
         if (show_weights) {
             int wgt = o_ptr->weight * o_ptr->number;
-            (void)sprintf(tmp_val, _("%3d.%1d kg", "%3d.%1d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
+            strnfmt(tmp_val, sizeof(tmp_val), _("%3d.%1d kg", "%3d.%1d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
             prt(tmp_val, j + 1, wid - 9);
         }
     }
@@ -166,7 +168,7 @@ void display_inventory(PlayerType *player_ptr, const ItemTester &item_tester)
 
         auto o_ptr = &player_ptr->inventory_list[i];
         auto do_disp = item_tester.okay(o_ptr);
-        strcpy(tmp_val, "   ");
+        angband_strcpy(tmp_val, "   ", sizeof(tmp_val));
         if (do_disp) {
             tmp_val[0] = index_to_label(i);
             tmp_val[1] = ')';
@@ -197,7 +199,9 @@ void display_inventory(PlayerType *player_ptr, const ItemTester &item_tester)
 
         if (show_weights) {
             int wgt = o_ptr->weight * o_ptr->number;
-            sprintf(tmp_val, _("%3d.%1d kg", "%3d.%1d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
+            strnfmt(tmp_val, sizeof(tmp_val), _("%3d.%1d kg", "%3d.%1d lb"),
+                _(lb_to_kg_integer(wgt), wgt / 10),
+                _(lb_to_kg_fraction(wgt), wgt % 10));
             prt(tmp_val, i, wid - 9);
         }
     }

--- a/src/view/display-lore.cpp
+++ b/src/view/display-lore.cpp
@@ -24,7 +24,9 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/bit-flags-calculator.h"
+#include "util/string-processor.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 
@@ -623,10 +625,10 @@ void display_monster_launching(PlayerType *player_ptr, lore_type *lore_ptr)
     }
 
     if (know_armour(lore_ptr->r_idx, lore_ptr->know_everything)) {
-        sprintf(lore_ptr->tmp_msg[lore_ptr->vn], _("威力 %dd%d の射撃をする", "fire an arrow (Power:%dd%d)"), lore_ptr->r_ptr->blow[p].d_dice,
+        strnfmt(lore_ptr->tmp_msg[lore_ptr->vn], sizeof(lore_ptr->tmp_msg[lore_ptr->vn]), _("威力 %dd%d の射撃をする", "fire an arrow (Power:%dd%d)"), lore_ptr->r_ptr->blow[p].d_dice,
             lore_ptr->r_ptr->blow[p].d_side);
     } else {
-        sprintf(lore_ptr->tmp_msg[lore_ptr->vn], _("射撃をする", "fire an arrow"));
+        angband_strcpy(lore_ptr->tmp_msg[lore_ptr->vn], _("射撃をする", "fire an arrow"), sizeof(lore_ptr->tmp_msg[lore_ptr->vn]));
     }
 
     lore_ptr->vp[lore_ptr->vn] = lore_ptr->tmp_msg[lore_ptr->vn];

--- a/src/window/main-window-equipments.cpp
+++ b/src/window/main-window-equipments.cpp
@@ -17,6 +17,8 @@
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
+#include "util/string-processor.h"
 
 /*!
  * @brief メインウィンドウの右上に装備アイテムの表示させる
@@ -88,15 +90,15 @@ COMMAND_CODE show_equipment(PlayerType *player_ptr, int target_item, BIT_FLAGS m
         prt("", j + 1, col ? col - 2 : col);
         if (use_menu && target_item) {
             if (j == (target_item - 1)) {
-                strcpy(tmp_val, _("》", "> "));
+                angband_strcpy(tmp_val, _("》", "> "), sizeof(tmp_val));
                 target_item_label = i;
             } else {
-                strcpy(tmp_val, "  ");
+                angband_strcpy(tmp_val, "  ", sizeof(tmp_val));
             }
         } else if (i >= INVEN_MAIN_HAND) {
-            sprintf(tmp_val, "%c)", equip_label[i - INVEN_MAIN_HAND]);
+            strnfmt(tmp_val, sizeof(tmp_val), "%c)", equip_label[i - INVEN_MAIN_HAND]);
         } else {
-            sprintf(tmp_val, "%c)", index_to_label(i));
+            strnfmt(tmp_val, sizeof(tmp_val), "%c)", index_to_label(i));
         }
 
         put_str(tmp_val, j + 1, col);
@@ -113,7 +115,7 @@ COMMAND_CODE show_equipment(PlayerType *player_ptr, int target_item, BIT_FLAGS m
         }
 
         if (show_labels) {
-            (void)sprintf(tmp_val, _("%-7s: ", "%-14s: "), mention_use(player_ptr, i));
+            strnfmt(tmp_val, sizeof(tmp_val), _("%-7s: ", "%-14s: "), mention_use(player_ptr, i));
             put_str(tmp_val, j + 1, cur_col);
             c_put_str(out_color[j], out_desc[j], j + 1, _(cur_col + 9, cur_col + 16));
         } else {
@@ -125,7 +127,7 @@ COMMAND_CODE show_equipment(PlayerType *player_ptr, int target_item, BIT_FLAGS m
         }
 
         int wgt = o_ptr->weight * o_ptr->number;
-        (void)sprintf(tmp_val, _("%3d.%1d kg", "%3d.%d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
+        strnfmt(tmp_val, sizeof(tmp_val), _("%3d.%1d kg", "%3d.%d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
         prt(tmp_val, j + 1, wid - 9);
     }
 

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -37,6 +37,7 @@
 #include "system/system-variables.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
 #include "util/string-processor.h"
@@ -435,7 +436,7 @@ static void wiz_statistics(PlayerType *player_ptr, ItemEntity *o_ptr)
             break;
         }
 
-        sprintf(tmp_val, "%ld", (long int)test_roll);
+        strnfmt(tmp_val, sizeof(tmp_val), "%ld", (long int)test_roll);
         if (get_string(p, tmp_val, 10)) {
             test_roll = atol(tmp_val);
         }
@@ -596,7 +597,7 @@ static void wiz_tweak_item(PlayerType *player_ptr, ItemEntity *o_ptr)
 
     concptr p = "Enter new 'pval' setting: ";
     char tmp_val[80];
-    sprintf(tmp_val, "%d", o_ptr->pval);
+    strnfmt(tmp_val, sizeof(tmp_val), "%d", o_ptr->pval);
     if (!get_string(p, tmp_val, 5)) {
         return;
     }
@@ -604,7 +605,7 @@ static void wiz_tweak_item(PlayerType *player_ptr, ItemEntity *o_ptr)
     o_ptr->pval = clamp_cast<int16_t>(atoi(tmp_val));
     wiz_display_item(player_ptr, o_ptr);
     p = "Enter new 'to_a' setting: ";
-    sprintf(tmp_val, "%d", o_ptr->to_a);
+    strnfmt(tmp_val, sizeof(tmp_val), "%d", o_ptr->to_a);
     if (!get_string(p, tmp_val, 5)) {
         return;
     }
@@ -612,7 +613,7 @@ static void wiz_tweak_item(PlayerType *player_ptr, ItemEntity *o_ptr)
     o_ptr->to_a = clamp_cast<int16_t>(atoi(tmp_val));
     wiz_display_item(player_ptr, o_ptr);
     p = "Enter new 'to_h' setting: ";
-    sprintf(tmp_val, "%d", o_ptr->to_h);
+    strnfmt(tmp_val, sizeof(tmp_val), "%d", o_ptr->to_h);
     if (!get_string(p, tmp_val, 5)) {
         return;
     }
@@ -620,7 +621,7 @@ static void wiz_tweak_item(PlayerType *player_ptr, ItemEntity *o_ptr)
     o_ptr->to_h = clamp_cast<int16_t>(atoi(tmp_val));
     wiz_display_item(player_ptr, o_ptr);
     p = "Enter new 'to_d' setting: ";
-    sprintf(tmp_val, "%d", (int)o_ptr->to_d);
+    strnfmt(tmp_val, sizeof(tmp_val), "%d", (int)o_ptr->to_d);
     if (!get_string(p, tmp_val, 5)) {
         return;
     }
@@ -643,7 +644,7 @@ static void wiz_quantity_item(ItemEntity *o_ptr)
 
     int tmp_qnt = o_ptr->number;
     char tmp_val[100];
-    sprintf(tmp_val, "%d", (int)o_ptr->number);
+    strnfmt(tmp_val, sizeof(tmp_val), "%d", (int)o_ptr->number);
     if (get_string("Quantity: ", tmp_val, 2)) {
         int tmp_int = atoi(tmp_val);
         if (tmp_int < 1) {

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -90,6 +90,7 @@
 #include "system/terrain-type-definition.h"
 #include "target/grid-selector.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/bit-flags-calculator.h"
 #include "util/enum-converter.h"
@@ -413,8 +414,8 @@ void wiz_change_status(PlayerType *player_ptr)
     char tmp_val[160];
     char ppp[80];
     for (int i = 0; i < A_MAX; i++) {
-        sprintf(ppp, "%s (3-%d): ", stat_names[i], player_ptr->stat_max_max[i]);
-        sprintf(tmp_val, "%d", player_ptr->stat_max[i]);
+        strnfmt(ppp, sizeof(ppp), "%s (3-%d): ", stat_names[i], player_ptr->stat_max_max[i]);
+        strnfmt(tmp_val, sizeof(tmp_val), "%d", player_ptr->stat_max[i]);
         if (!get_string(ppp, tmp_val, 3)) {
             return;
         }
@@ -429,7 +430,7 @@ void wiz_change_status(PlayerType *player_ptr)
         player_ptr->stat_cur[i] = player_ptr->stat_max[i] = (BASE_STATUS)tmp_int;
     }
 
-    sprintf(tmp_val, "%d", PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER));
+    strnfmt(tmp_val, sizeof(tmp_val), "%d", PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER));
     if (!get_string(_("熟練度: ", "Proficiency: "), tmp_val, 4)) {
         return;
     }
@@ -462,7 +463,7 @@ void wiz_change_status(PlayerType *player_ptr)
         player_ptr->spell_exp[k] = std::min(PlayerSkill::spell_exp_at(PlayerSkillRank::EXPERT), tmp_s16b);
     }
 
-    sprintf(tmp_val, "%ld", (long)(player_ptr->au));
+    strnfmt(tmp_val, sizeof(tmp_val), "%ld", (long)(player_ptr->au));
     if (!get_string("Gold: ", tmp_val, 9)) {
         return;
     }
@@ -473,7 +474,7 @@ void wiz_change_status(PlayerType *player_ptr)
     }
 
     player_ptr->au = tmp_long;
-    sprintf(tmp_val, "%ld", (long)(player_ptr->max_exp));
+    strnfmt(tmp_val, sizeof(tmp_val), "%ld", (long)(player_ptr->max_exp));
     if (!get_string("Experience: ", tmp_val, 9)) {
         return;
     }
@@ -547,11 +548,9 @@ static bool select_debugging_dungeon(PlayerType *player_ptr, DUNGEON_IDX *dungeo
     }
 
     while (true) {
-        char ppp[80];
         char tmp_val[160];
-        sprintf(ppp, "Jump which dungeon : ");
-        sprintf(tmp_val, "%d", player_ptr->dungeon_idx);
-        if (!get_string(ppp, tmp_val, 2)) {
+        strnfmt(tmp_val, sizeof(tmp_val), "%d", player_ptr->dungeon_idx);
+        if (!get_string("Jump which dungeon : ", tmp_val, 2)) {
             return false;
         }
 
@@ -584,8 +583,8 @@ static bool select_debugging_floor(PlayerType *player_ptr, int dungeon_type)
     while (true) {
         char ppp[80];
         char tmp_val[160];
-        sprintf(ppp, "Jump to level (0, %d-%d): ", min_depth, max_depth);
-        sprintf(tmp_val, "%d", (int)player_ptr->current_floor_ptr->dun_level);
+        strnfmt(ppp, sizeof(ppp), "Jump to level (0, %d-%d): ", min_depth, max_depth);
+        strnfmt(tmp_val, sizeof(tmp_val), "%d", (int)player_ptr->current_floor_ptr->dun_level);
         if (!get_string(ppp, tmp_val, 10)) {
             return false;
         }


### PR DESCRIPTION
… https://github.com/hengband/hengband/issues/2858 and https://github.com/hengband/hengband/issues/2859 .
Either use a direct replacement (strnfmt() or snprintf()) or, if it was just copying a string, use angband_strcpy() or omit the copy entirely when possible.  Some instances of strcat() and strcpy() adjacent to the changes are changed to angband_strcat() and angband_strcpy() in the spirit of checking buffer lengths.

This is subset of https://github.com/hengband/hengband/pull/2861 as requested in the feedback there.