### PR TITLE
Replace sprintf() with std::string and/or format().  Does part of the…

### DIFF
--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -328,9 +328,8 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, It
 {
     /* Assume that object name is to be added */
     bool name = true;
-    GAME_TEXT name_str[MAX_NLEN + 32];
-    name_str[0] = '\0';
     auto insc = quark_str(o_ptr->inscription);
+    entry->name.clear();
     entry->insc = insc != nullptr ? insc : "";
     entry->action = DO_AUTOPICK | DO_DISPLAY;
     entry->flag[0] = entry->flag[1] = 0L;
@@ -388,10 +387,11 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, It
                 auto *e_ptr = &egos_info[o_ptr->ego_idx];
 #ifdef JP
                 /* エゴ銘には「^」マークが使える */
-                sprintf(name_str, "^%s", e_ptr->name.data());
+                entry->name = "^";
+                entry->name.append(e_ptr->name);
 #else
-                /* We ommit the basename and cannot use the ^ mark */
-                strcpy(name_str, e_ptr->name.data());
+                /* We omit the basename and cannot use the ^ mark */
+                entry->name = e_ptr->name;
 #endif
                 name = false;
                 if (!o_ptr->is_rare()) {
@@ -503,8 +503,7 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, It
     }
 
     if (!name) {
-        str_tolower(name_str);
-        entry->name = name_str;
+        str_tolower(entry->name.data());
         return;
     }
 
@@ -515,9 +514,8 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, It
      * If necessary, add a '^' which indicates the
      * beginning of line.
      */
-    sprintf(name_str, "%s%s", is_hat_added ? "^" : "", o_name);
-    str_tolower(name_str);
-    entry->name = name_str;
+    entry->name = std::string(is_hat_added ? "^" : "").append(o_name);
+    str_tolower(entry->name.data());
 }
 
 /*!

--- a/src/autopick/autopick.cpp
+++ b/src/autopick/autopick.cpp
@@ -126,15 +126,14 @@ void autopick_pickup_items(PlayerType *player_ptr, grid_type *g_ptr)
             continue;
         }
 
-        char out_val[MAX_NLEN + 20];
-        GAME_TEXT o_name[MAX_NLEN];
         if (o_ptr->marked.has(OmType::NO_QUERY)) {
             continue;
         }
 
+        GAME_TEXT o_name[MAX_NLEN];
         describe_flavor(player_ptr, o_name, o_ptr, 0);
-        sprintf(out_val, _("%sを拾いますか? ", "Pick up %s? "), o_name);
-        if (!get_check(out_val)) {
+        auto prompt = std::string(_(o_name, "Pick up ")).append(_("を拾いますか", o_name)).append("? ");
+        if (!get_check(prompt)) {
             o_ptr->marked.set({ OmType::SUPRESS_MESSAGE, OmType::NO_QUERY });
             continue;
         }

--- a/src/birth/history-editor.cpp
+++ b/src/birth/history-editor.cpp
@@ -6,6 +6,7 @@
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 #include "util/int-char-converter.h"
+#include "util/string-processor.h"
 #include "view/display-player.h" // 暫定。後で消す.
 
 /*!
@@ -14,9 +15,9 @@
  */
 void edit_history(PlayerType *player_ptr)
 {
-    char old_history[4][60];
+    std::string old_history[4];
     for (int i = 0; i < 4; i++) {
-        sprintf(old_history[i], "%s", player_ptr->history[i]);
+        old_history[i] = player_ptr->history[i];
     }
 
     for (int i = 0; i < 4; i++) {
@@ -117,7 +118,7 @@ void edit_history(PlayerType *player_ptr)
             clear_from(11);
             put_str(_("(キャラクターの生い立ち)", "(Character Background)"), 11, 25);
             for (int i = 0; i < 4; i++) {
-                sprintf(player_ptr->history[i], "%s", old_history[i]);
+                angband_strcpy(player_ptr->history[i], old_history[i].data(), sizeof(player_ptr->history[i]));
                 put_str(player_ptr->history[i], i + 12, 10);
             }
 

--- a/src/cmd-action/cmd-hissatsu.cpp
+++ b/src/cmd-action/cmd-hissatsu.cpp
@@ -39,6 +39,7 @@
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 
@@ -195,7 +196,6 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
         if ((choice == ' ') || (choice == '*') || (choice == '?') || (use_menu && should_redraw_cursor)) {
             /* Show the list */
             if (!redraw || use_menu) {
-                char psi_desc[80];
                 int line;
                 redraw = true;
                 if (!use_menu) {
@@ -225,11 +225,12 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
                     if (!(player_ptr->spell_learned1 & (1UL << i))) {
                         continue;
                     }
+                    std::string psi_desc;
                     if (use_menu) {
                         if (i == (menu_line - 1)) {
-                            strcpy(psi_desc, _("  》", "  > "));
+                            psi_desc = _("  》", "  > ");
                         } else {
-                            strcpy(psi_desc, "    ");
+                            psi_desc = "    ";
                         }
 
                     } else {
@@ -239,12 +240,12 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
                         } else {
                             letter = '0' + line - 27;
                         }
-                        sprintf(psi_desc, "  %c)", letter);
+                        psi_desc = format("  %c)", letter);
                     }
 
                     /* Dump the spell --(-- */
                     const auto spell_name = exe_spell(player_ptr, REALM_HISSATSU, i, SpellProcessType::NAME);
-                    strcat(psi_desc, format(" %-18s%2d %3d", spell_name->data(), spell.slevel, spell.smana));
+                    psi_desc.append(format(" %-18s%2d %3d", spell_name->data(), spell.slevel, spell.smana));
                     prt(psi_desc, y + (line % 17) + (line >= 17), x + (line / 17) * 30);
                     prt("", y + (line % 17) + (line >= 17) + 1, x + (line / 17) * 30);
                 }

--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -65,6 +65,7 @@
 #include "target/target-setter.h"
 #include "target/target-types.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "timed-effect/player-stun.h"
 #include "timed-effect/timed-effects.h"
 #include "util/enum-converter.h"
@@ -180,7 +181,6 @@ static int get_mane_power(PlayerType *player_ptr, int *sn, bool baigaesi)
         if ((choice == ' ') || (choice == '*') || (choice == '?')) {
             /* Show the list */
             if (!redraw) {
-                char psi_desc[160];
                 redraw = true;
                 screen_save();
 
@@ -233,8 +233,7 @@ static int get_mane_power(PlayerType *player_ptr, int *sn, bool baigaesi)
                     mane_info(player_ptr, comment, mane.spell, (baigaesi ? mane.damage * 2 : mane.damage));
 
                     /* Dump the spell --(-- */
-                    sprintf(psi_desc, "  %c) %-30s %3d%%%s", I2A(i), spell.name, chance, comment);
-                    prt(psi_desc, y + i + 1, x);
+                    prt(format("  %c) %-30s %3d%%%s", I2A(i), spell.name, chance, comment), y + i + 1, x);
                 }
 
                 /* Clear the bottom line */

--- a/src/cmd-action/cmd-racial.cpp
+++ b/src/cmd-action/cmd-racial.cpp
@@ -32,6 +32,7 @@
 #include "status/action-setter.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/bit-flags-calculator.h"
 #include "util/buffer-shaper.h"
 #include "util/int-char-converter.h"
@@ -64,8 +65,6 @@ static void racial_power_erase_cursor(rc_type *rc_ptr)
 static void racial_power_display_list(PlayerType *player_ptr, rc_type *rc_ptr)
 {
     TERM_LEN x = 11;
-    char dummy[256];
-    strcpy(dummy, "");
 
     prt(_("                                   Lv   MP 失率 効果", "                                   Lv   MP Fail Effect"), 1, x);
 
@@ -76,8 +75,9 @@ static void racial_power_display_list(PlayerType *player_ptr, rc_type *rc_ptr)
             break;
         }
 
+        std::string dummy;
         if (use_menu) {
-            strcpy(dummy, "    ");
+            dummy = "    ";
         } else {
             char letter;
             if (ctr < 26) {
@@ -86,11 +86,11 @@ static void racial_power_display_list(PlayerType *player_ptr, rc_type *rc_ptr)
                 letter = '0' + ctr - 26;
             }
 
-            sprintf(dummy, " %c) ", letter);
+            dummy = format(" %c) ", letter);
         }
 
         auto &rpi = rc_ptr->power_desc[ctr];
-        strcat(dummy,
+        dummy.append(
             format("%-30.30s %2d %4d %3d%% %s", rpi.racial_name.data(), rpi.min_level, rpi.cost, 100 - racial_chance(player_ptr, &rc_ptr->power_desc[ctr]),
                 rpi.info.data()));
 

--- a/src/cmd-building/cmd-inn.cpp
+++ b/src/cmd-building/cmd-inn.cpp
@@ -169,9 +169,7 @@ static void display_stay_result(PlayerType *player_ptr, int prev_hour)
 {
     if ((prev_hour >= 6) && (prev_hour < 18)) {
 #if JP
-        char refresh_message_jp[50];
-        sprintf(refresh_message_jp, "%s%s%s", "あなたはリフレッシュして目覚め、", is_player_undead(player_ptr) ? "夜" : "夕方", "を迎えた。");
-        msg_print(refresh_message_jp);
+        msg_format("あなたはリフレッシュして目覚め、%sを迎えた。", is_player_undead(player_ptr) ? "夜" : "夕方");
 #else
         msg_print("You awake refreshed for the evening.");
 #endif

--- a/src/cmd-io/cmd-diary.cpp
+++ b/src/cmd-io/cmd-diary.cpp
@@ -12,6 +12,7 @@
 #include "player/player-personality.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
@@ -23,26 +24,26 @@
  */
 static void display_diary(PlayerType *player_ptr)
 {
-    char diary_title[256];
-    GAME_TEXT file_name[MAX_NLEN];
+    std::string file_name = _("playrecord-", "playrec-");
+    file_name.append(savefile_base).append(".txt");
     char buf[1024];
-    char tmp[80];
-    sprintf(file_name, _("playrecord-%s.txt", "playrec-%s.txt"), savefile_base);
-    path_build(buf, sizeof(buf), ANGBAND_DIR_USER, file_name);
+    path_build(buf, sizeof(buf), ANGBAND_DIR_USER, file_name.data());
 
     PlayerClass pc(player_ptr);
+    concptr tmp;
     if (pc.is_tough()) {
-        strcpy(tmp, subtitle[randint0(MAX_SUBTITLE - 1)]);
+        tmp = subtitle[randint0(MAX_SUBTITLE - 1)];
     } else if (pc.is_wizard()) {
-        strcpy(tmp, subtitle[randint0(MAX_SUBTITLE - 1) + 1]);
+        tmp = subtitle[randint0(MAX_SUBTITLE - 1) + 1];
     } else {
-        strcpy(tmp, subtitle[randint0(MAX_SUBTITLE - 2) + 1]);
+        tmp = subtitle[randint0(MAX_SUBTITLE - 2) + 1];
     }
 
+    char diary_title[256];
 #ifdef JP
-    sprintf(diary_title, "「%s%s%sの伝説 -%s-」", ap_ptr->title, ap_ptr->no ? "の" : "", player_ptr->name, tmp);
+    strnfmt(diary_title, sizeof(diary_title), "「%s%s%sの伝説 -%s-」", ap_ptr->title, ap_ptr->no ? "の" : "", player_ptr->name, tmp);
 #else
-    sprintf(diary_title, "Legend of %s %s '%s'", ap_ptr->title, player_ptr->name, tmp);
+    strnfmt(diary_title, sizeof(diary_title), "Legend of %s %s '%s'", ap_ptr->title, player_ptr->name, tmp);
 #endif
 
     (void)show_file(player_ptr, false, buf, diary_title, -1, 0);
@@ -71,14 +72,14 @@ static void do_cmd_last_get(PlayerType *player_ptr)
     }
 
     char buf[256];
-    sprintf(buf, _("%sの入手を記録します。", "Do you really want to record getting %s? "), record_o_name);
+    strnfmt(buf, sizeof(buf), _("%sの入手を記録します。", "Do you really want to record getting %s? "), record_o_name);
     if (!get_check(buf)) {
         return;
     }
 
     GAME_TURN turn_tmp = w_ptr->game_turn;
     w_ptr->game_turn = record_turn;
-    sprintf(buf, _("%sを手に入れた。", "discover %s."), record_o_name);
+    strnfmt(buf, sizeof(buf), _("%sを手に入れた。", "discover %s."), record_o_name);
     exe_write_diary(player_ptr, DIARY_DESCRIPTION, 0, buf);
     w_ptr->game_turn = turn_tmp;
 }
@@ -88,15 +89,15 @@ static void do_cmd_last_get(PlayerType *player_ptr)
  */
 static void do_cmd_erase_diary(void)
 {
-    GAME_TEXT file_name[MAX_NLEN];
     char buf[256];
     FILE *fff = nullptr;
 
     if (!get_check(_("本当に記録を消去しますか？", "Do you really want to delete all your records? "))) {
         return;
     }
-    sprintf(file_name, _("playrecord-%s.txt", "playrec-%s.txt"), savefile_base);
-    path_build(buf, sizeof(buf), ANGBAND_DIR_USER, file_name);
+    std::string file_name = _("playrecord-", "playrec-");
+    file_name.append(savefile_base).append(".txt");
+    path_build(buf, sizeof(buf), ANGBAND_DIR_USER, file_name.data());
     fd_kill(buf);
 
     fff = angband_fopen(buf, "w");

--- a/src/cmd-io/cmd-dump.cpp
+++ b/src/cmd-io/cmd-dump.cpp
@@ -84,7 +84,7 @@ void do_cmd_colors(PlayerType *player_ptr)
         if (i == '1') {
             prt(_("コマンド: ユーザー設定ファイルをロードします", "Command: Load a user pref file"), 8, 0);
             prt(_("ファイル: ", "File: "), 10, 0);
-            sprintf(tmp, "%s.prf", player_ptr->base_name);
+            strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
             if (!askfor(tmp, 70)) {
                 continue;
             }
@@ -96,7 +96,7 @@ void do_cmd_colors(PlayerType *player_ptr)
             static concptr mark = "Colors";
             prt(_("コマンド: カラーの設定をファイルに書き出します", "Command: Dump colors"), 8, 0);
             prt(_("ファイル: ", "File: "), 10, 0);
-            sprintf(tmp, "%s.prf", player_ptr->base_name);
+            strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
             if (!askfor(tmp, 70)) {
                 continue;
             }
@@ -270,17 +270,11 @@ void do_cmd_time(PlayerType *player_ptr)
     int day, hour, min;
     extract_day_hour_min(player_ptr, &day, &hour, &min);
 
-    char desc[1024];
-    strcpy(desc, _("変な時刻だ。", "It is a strange time."));
+    std::string desc = _("変な時刻だ。", "It is a strange time.");
 
-    char day_buf[20];
-    if (day < MAX_DAYS) {
-        sprintf(day_buf, "%d", day);
-    } else {
-        strcpy(day_buf, "*****");
-    }
+    std::string day_buf = (day < MAX_DAYS) ? std::to_string(day) : "*****";
 
-    msg_format(_("%s日目, 時刻は%d:%02d %sです。", "This is day %s. The time is %d:%02d %s."), day_buf, (hour % 12 == 0) ? 12 : (hour % 12), min,
+    msg_format(_("%s日目, 時刻は%d:%02d %sです。", "This is day %s. The time is %d:%02d %s."), day_buf.data(), (hour % 12 == 0) ? 12 : (hour % 12), min,
         (hour < 12) ? "AM" : "PM");
 
     char buf[1024];
@@ -327,7 +321,7 @@ void do_cmd_time(PlayerType *player_ptr)
         if (buf[0] == 'D') {
             num++;
             if (!randint0(num)) {
-                strcpy(desc, buf + 2);
+                desc = buf + 2;
             }
 
             continue;

--- a/src/cmd-io/cmd-floor.cpp
+++ b/src/cmd-io/cmd-floor.cpp
@@ -13,6 +13,7 @@
 #include "target/target-checker.h"
 #include "target/target-setter.h"
 #include "target/target-types.h"
+#include "term/z-form.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "window/main-window-util.h"
@@ -53,26 +54,21 @@ void do_cmd_look(PlayerType *player_ptr)
  */
 void do_cmd_locate(PlayerType *player_ptr)
 {
+    const char *dirstrings[3][3] = {
+        { _("北西", " northwest of"), _("北", " north of"), _("北東", " northeast of") },
+        { _("西", " west of"), _("真上", ""), _("東", " east of") },
+        { _("南西", " southwest of"), _("南", " south of"), _("南東", " southeast of") },
+    };
     DIRECTION dir;
     POSITION y1, x1;
-    GAME_TEXT tmp_val[80];
-    GAME_TEXT out_val[MAX_MONSTER_NAME];
     TERM_LEN wid, hgt;
     get_screen_size(&wid, &hgt);
     POSITION y2 = y1 = panel_row_min;
     POSITION x2 = x1 = panel_col_min;
     while (true) {
-        if ((y2 == y1) && (x2 == x1)) {
-            strcpy(tmp_val, _("真上", "\0"));
-        } else {
-            sprintf(tmp_val, "%s%s", ((y2 < y1) ? _("北", " North") : (y2 > y1) ? _("南", " South")
-                                                                                : ""),
-                ((x2 < x1) ? _("西", " West") : (x2 > x1) ? _("東", " East")
-                                                          : ""));
-        }
-
-        sprintf(out_val, _("マップ位置 [%d(%02d),%d(%02d)] (プレイヤーの%s)  方向?", "Map sector [%d(%02d),%d(%02d)], which is%s your sector.  Direction?"),
-            y2 / (hgt / 2), y2 % (hgt / 2), x2 / (wid / 2), x2 % (wid / 2), tmp_val);
+        std::string_view dirstring = dirstrings[(y2 < y1) ? 0 : ((y2 > y1) ? 2 : 1)][(x2 < x1) ? 0 : ((x2 > x1) ? 2 : 1)];
+        std::string out_val = format(_("マップ位置 [%d(%02d),%d(%02d)] (プレイヤーの%s)  方向?", "Map sector [%d(%02d),%d(%02d)], which is%s your sector.  Direction?"),
+            y2 / (hgt / 2), y2 % (hgt / 2), x2 / (wid / 2), x2 % (wid / 2), dirstring.data());
 
         dir = 0;
         while (!dir) {

--- a/src/cmd-io/cmd-gameoption.cpp
+++ b/src/cmd-io/cmd-gameoption.cpp
@@ -20,6 +20,7 @@
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
 #include "util/string-processor.h"
@@ -93,21 +94,16 @@ static void do_cmd_options_autosave(PlayerType *player_ptr, concptr info)
 {
     char ch;
     int i, k = 0, n = 2;
-    char buf[80];
     term_clear();
     while (true) {
-        sprintf(buf,
-            _("%s ( リターンで次へ, y/n でセット, F で頻度を入力, ESC で決定 ) ", "%s (RET to advance, y/n to set, 'F' for frequency, ESC to accept) "), info);
-        prt(buf, 0, 0);
+        prt(format(_("%s ( リターンで次へ, y/n でセット, F で頻度を入力, ESC で決定 ) ", "%s (RET to advance, y/n to set, 'F' for frequency, ESC to accept) "), info), 0, 0);
         for (i = 0; i < n; i++) {
             byte a = TERM_WHITE;
             if (i == k) {
                 a = TERM_L_BLUE;
             }
 
-            sprintf(
-                buf, "%-48s: %s (%s)", autosave_info[i].o_desc, (*autosave_info[i].o_var ? _("はい  ", "yes") : _("いいえ", "no ")), autosave_info[i].o_text);
-            c_prt(a, buf, i + 2, 0);
+            c_prt(a, format("%-48s: %s (%s)", autosave_info[i].o_desc, (*autosave_info[i].o_var ? _("はい  ", "yes") : _("いいえ", "no ")), autosave_info[i].o_text), i + 2, 0);
         }
 
         prt(format(_("自動セーブの頻度： %d ターン毎", "Timed autosave frequency: every %d turns"), autosave_freq), 5, 0);
@@ -336,9 +332,7 @@ static void do_cmd_options_cheat(PlayerType *player_ptr, concptr info)
     auto k = 0U;
     const auto n = cheat_info.size();
     while (true) {
-        char buf[80];
-        sprintf(buf, _("%s ( リターンで次へ, y/n でセット, ESC で決定 )", "%s (RET to advance, y/n to set, ESC to accept) "), info);
-        prt(buf, 0, 0);
+        prt(format(_("%s ( リターンで次へ, y/n でセット, ESC で決定 )", "%s (RET to advance, y/n to set, ESC to accept) "), info), 0, 0);
 
 #ifdef JP
         /* 詐欺オプションをうっかりいじってしまう人がいるようなので注意 */
@@ -353,8 +347,7 @@ static void do_cmd_options_cheat(PlayerType *player_ptr, concptr info)
                 a = TERM_L_BLUE;
             }
 
-            sprintf(buf, "%-48s: %s (%s)", cheat_info[i].o_desc, (*cheat_info[i].o_var ? _("はい  ", "yes") : _("いいえ", "no ")), cheat_info[i].o_text);
-            c_prt(enum2i(a), buf, i + 2, 0);
+            c_prt(enum2i(a), format("%-48s: %s (%s)", cheat_info[i].o_desc, (*cheat_info[i].o_var ? _("はい  ", "yes") : _("いいえ", "no ")), cheat_info[i].o_text), i + 2, 0);
         }
 
         move_cursor(k + 2, 50);
@@ -396,8 +389,7 @@ static void do_cmd_options_cheat(PlayerType *player_ptr, concptr info)
             k = (k + 1) % n;
             break;
         case '?':
-            strnfmt(buf, sizeof(buf), _("joption.txt#%s", "option.txt#%s"), cheat_info[k].o_text);
-            (void)show_file(player_ptr, true, buf, nullptr, 0, 0);
+            (void)show_file(player_ptr, true, std::string(_("joption.txt#", "option.txt#")).append(cheat_info[k].o_text).data(), nullptr, 0, 0);
             term_clear();
             break;
         default:
@@ -648,7 +640,6 @@ void do_cmd_options_aux(PlayerType *player_ptr, game_option_types page, concptr 
     char ch;
     int i, k = 0, n = 0, l;
     int opt[24];
-    char buf[80];
     bool browse_only = (page == OPT_PAGE_BIRTH) && w_ptr->character_generated && (!w_ptr->wizard || !allow_debug_opts);
 
     for (i = 0; i < 24; i++) {
@@ -664,9 +655,7 @@ void do_cmd_options_aux(PlayerType *player_ptr, game_option_types page, concptr 
     term_clear();
     while (true) {
         DIRECTION dir;
-        sprintf(buf, _("%s (リターン:次, %sESC:終了, ?:ヘルプ) ", "%s (RET:next, %s, ?:help) "), info,
-            browse_only ? _("", "ESC:exit") : _("y/n:変更, ", "y/n:change, ESC:accept"));
-        prt(buf, 0, 0);
+        prt(format(_("%s (リターン:次, %sESC:終了, ?:ヘルプ) ", "%s (RET:next, %s, ?:help) "), info, browse_only ? _("", "ESC:exit") : _("y/n:変更, ", "y/n:change, ESC:accept")), 0, 0);
         if (page == OPT_PAGE_AUTODESTROY) {
             c_prt(TERM_YELLOW, _("以下のオプションは、簡易自動破壊を使用するときのみ有効", "Following options will protect items from easy auto-destroyer."), 6,
                 _(6, 3));
@@ -678,12 +667,12 @@ void do_cmd_options_aux(PlayerType *player_ptr, game_option_types page, concptr 
                 a = TERM_L_BLUE;
             }
 
-            sprintf(buf, "%-48s: %s (%.19s)", option_info[opt[i]].o_desc, (*option_info[opt[i]].o_var ? _("はい  ", "yes") : _("いいえ", "no ")),
+            std::string label = format("%-48s: %s (%.19s)", option_info[opt[i]].o_desc, (*option_info[opt[i]].o_var ? _("はい  ", "yes") : _("いいえ", "no ")),
                 option_info[opt[i]].o_text);
             if ((page == OPT_PAGE_AUTODESTROY) && i > 2) {
-                c_prt(a, buf, i + 5, 0);
+                c_prt(a, label, i + 5, 0);
             } else {
-                c_prt(a, buf, i + 2, 0);
+                c_prt(a, label, i + 2, 0);
             }
         }
 
@@ -744,8 +733,7 @@ void do_cmd_options_aux(PlayerType *player_ptr, game_option_types page, concptr 
             break;
         }
         case '?': {
-            strnfmt(buf, sizeof(buf), _("joption.txt#%s", "option.txt#%s"), option_info[opt[k]].o_text);
-            (void)show_file(player_ptr, true, buf, nullptr, 0, 0);
+            (void)show_file(player_ptr, true, std::string(_("joption.txt#", "option.txt#")).append(option_info[opt[k]].o_text).data(), nullptr, 0, 0);
             term_clear();
             break;
         }

--- a/src/cmd-io/cmd-lore.cpp
+++ b/src/cmd-io/cmd-lore.cpp
@@ -13,6 +13,7 @@
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
 #include "util/sort.h"
 #include "util/string-processor.h"
@@ -37,7 +38,6 @@
 void do_cmd_query_symbol(PlayerType *player_ptr)
 {
     char sym, query;
-    char buf[256];
 
     bool all = false;
     bool uniq = false;
@@ -62,29 +62,30 @@ void do_cmd_query_symbol(PlayerType *player_ptr)
         }
     }
 
+    std::string buf;
     if (sym == KTRL('A')) {
         all = true;
-        strcpy(buf, _("全モンスターのリスト", "Full monster list."));
+        buf = _("全モンスターのリスト", "Full monster list.");
     } else if (sym == KTRL('U')) {
         all = uniq = true;
-        strcpy(buf, _("ユニーク・モンスターのリスト", "Unique monster list."));
+        buf = _("ユニーク・モンスターのリスト", "Unique monster list.");
     } else if (sym == KTRL('N')) {
         all = norm = true;
-        strcpy(buf, _("ユニーク外モンスターのリスト", "Non-unique monster list."));
+        buf = _("ユニーク外モンスターのリスト", "Non-unique monster list.");
     } else if (sym == KTRL('R')) {
         all = ride = true;
-        strcpy(buf, _("乗馬可能モンスターのリスト", "Ridable monster list."));
+        buf = _("乗馬可能モンスターのリスト", "Ridable monster list.");
     } else if (sym == KTRL('M')) {
         all = true;
         if (!get_string(_("名前(英語の場合小文字で可)", "Enter name:"), temp, 70)) {
             temp[0] = 0;
             return;
         }
-        sprintf(buf, _("名前:%sにマッチ", "Monsters' names with \"%s\""), temp);
+        buf = format(_("名前:%sにマッチ", "Monsters' names with \"%s\""), temp);
     } else if (ident_info[ident_i]) {
-        sprintf(buf, "%c - %s.", sym, ident_info[ident_i] + 2);
+        buf = format("%c - %s.", sym, ident_info[ident_i] + 2);
     } else {
-        sprintf(buf, "%c - %s", sym, _("無効な文字", "Unknown Symbol"));
+        buf = format("%c - %s", sym, _("無効な文字", "Unknown Symbol"));
     }
 
     prt(buf, 0, 0);

--- a/src/cmd-item/cmd-equipment.cpp
+++ b/src/cmd-item/cmd-equipment.cpp
@@ -48,6 +48,7 @@
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
 #include "view/display-inventory.h"
 #include "view/display-messages.h"
@@ -90,7 +91,6 @@ static void do_curse_on_equip(OBJECT_IDX slot, ItemEntity *o_ptr, PlayerType *pl
  */
 void do_cmd_equip(PlayerType *player_ptr)
 {
-    char out_val[160];
     command_wrk = true;
     if (easy_floor) {
         command_wrk = USE_EQUIP;
@@ -100,10 +100,11 @@ void do_cmd_equip(PlayerType *player_ptr)
     (void)show_equipment(player_ptr, 0, USE_FULL, AllMatchItemTester());
     auto weight = calc_inventory_weight(player_ptr);
     auto weight_lim = calc_weight_limit(player_ptr);
+    std::string out_val;
 #ifdef JP
-    sprintf(out_val, "装備： 合計 %3d.%1d kg (限界の%d%%) コマンド: ", lb_to_kg_integer(weight), lb_to_kg_fraction(weight), weight * 100 / weight_lim);
+    out_val = format("装備： 合計 %3d.%1d kg (限界の%d%%) コマンド: ", lb_to_kg_integer(weight), lb_to_kg_fraction(weight), weight * 100 / weight_lim);
 #else
-    sprintf(out_val, "Equipment: carrying %d.%d pounds (%d%% of capacity). Command: ", weight / 10, weight % 10, weight * 100 / weight_lim);
+    out_val = format("Equipment: carrying %d.%d pounds (%d%% of capacity). Command: ", weight / 10, weight % 10, weight * 100 / weight_lim);
 #endif
 
     prt(out_val, 0, 0);
@@ -231,24 +232,16 @@ void do_cmd_wield(PlayerType *player_ptr)
     }
 
     if (confirm_wear && ((o_ptr->is_cursed() && o_ptr->is_known()) || ((o_ptr->ident & IDENT_SENSE) && (FEEL_BROKEN <= o_ptr->feeling) && (o_ptr->feeling <= FEEL_CURSED)))) {
-        char dummy[MAX_NLEN + 80];
         describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
-        sprintf(dummy, _("本当に%s{呪われている}を使いますか？", "Really use the %s {cursed}? "), o_name);
-
-        if (!get_check(dummy)) {
+        if (!get_check(format(_("本当に%s{呪われている}を使いますか？", "Really use the %s {cursed}? "), o_name))) {
             return;
         }
     }
 
     PlayerRace pr(player_ptr);
     if (o_ptr->is_specific_artifact(FixedArtifactId::STONEMASK) && o_ptr->is_known() && !pr.equals(PlayerRaceType::VAMPIRE) && !pr.equals(PlayerRaceType::ANDROID)) {
-        char dummy[MAX_NLEN + 100];
         describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
-        sprintf(dummy,
-            _("%sを装備すると吸血鬼になります。よろしいですか？", "%s will transform you into a vampire permanently when equipped. Do you become a vampire? "),
-            o_name);
-
-        if (!get_check(dummy)) {
+        if (!get_check(format(_("%sを装備すると吸血鬼になります。よろしいですか？", "%s will transform you into a vampire permanently when equipped. Do you become a vampire? "), o_name))) {
             return;
         }
     }

--- a/src/cmd-item/cmd-item.cpp
+++ b/src/cmd-item/cmd-item.cpp
@@ -63,6 +63,7 @@
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
 #include "util/quarks.h"
@@ -75,7 +76,6 @@
  */
 void do_cmd_inven(PlayerType *player_ptr)
 {
-    char out_val[160];
     command_wrk = false;
     if (easy_floor) {
         command_wrk = USE_INVEN;
@@ -85,10 +85,11 @@ void do_cmd_inven(PlayerType *player_ptr)
     (void)show_inventory(player_ptr, 0, USE_FULL, AllMatchItemTester());
     WEIGHT weight = calc_inventory_weight(player_ptr);
     WEIGHT weight_lim = calc_weight_limit(player_ptr);
+    std::string out_val;
 #ifdef JP
-    sprintf(out_val, "持ち物： 合計 %3d.%1d kg (限界の%ld%%) コマンド: ", lb_to_kg_integer(weight), lb_to_kg_fraction(weight),
+    out_val = format("持ち物： 合計 %3d.%1d kg (限界の%ld%%) コマンド: ", lb_to_kg_integer(weight), lb_to_kg_fraction(weight),
 #else
-    sprintf(out_val, "Inventory: carrying %d.%d pounds (%ld%% of capacity). Command: ", weight / 10, weight % 10,
+    out_val = format("Inventory: carrying %d.%d pounds (%ld%% of capacity). Command: ", weight / 10, weight % 10,
 #endif
         (long int)(weight * 100) / weight_lim);
 

--- a/src/cmd-item/cmd-magiceat.cpp
+++ b/src/cmd-item/cmd-magiceat.cpp
@@ -77,6 +77,7 @@
 #include "target/target-getter.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "timed-effect/player-stun.h"
 #include "timed-effect/timed-effects.h"
 #include "util/buffer-shaper.h"
@@ -257,12 +258,9 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
             OBJECT_SUBTYPE_VALUE ctr;
             PERCENTAGE chance;
             short bi_id;
-            char dummy[80];
             POSITION x1, y1;
             DEPTH level;
             byte col;
-
-            strcpy(dummy, "");
 
             for (y = 1; y < 20; y++) {
                 prt("", y, x);
@@ -290,11 +288,12 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
 
                 bi_id = lookup_baseitem_id({ tval, ctr });
 
+                std::string dummy;
                 if (use_menu) {
                     if (ctr == (menu_line - 1)) {
-                        strcpy(dummy, _("》", "> "));
+                        dummy = _("》", "> ");
                     } else {
-                        strcpy(dummy, "  ");
+                        dummy = "  ";
                     }
                 }
                 /* letter/number for power selection */
@@ -305,7 +304,7 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
                     } else {
                         letter = '0' + ctr - 26;
                     }
-                    sprintf(dummy, "%c)", letter);
+                    dummy = format("%c)", letter);
                 }
                 x1 = ((ctr < ITEM_GROUP_SIZE / 2) ? x : x + 40);
                 y1 = ((ctr < ITEM_GROUP_SIZE / 2) ? y + ctr : y + ctr - ITEM_GROUP_SIZE / 2);
@@ -330,7 +329,7 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
 
                 if (bi_id) {
                     if (tval == ItemKindType::ROD) {
-                        strcat(dummy,
+                        dummy.append(
                             format(_(" %-22.22s 充填:%2d/%2d%3d%%", " %-22.22s   (%2d/%2d) %3d%%"), baseitems_info[bi_id].name.data(),
                                 item.charge ? (item.charge - 1) / (EATER_ROD_CHARGE * baseitems_info[bi_id].pval) + 1 : 0,
                                 item.count, chance));
@@ -338,7 +337,7 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
                             col = TERM_RED;
                         }
                     } else {
-                        strcat(dummy,
+                        dummy.append(
                             format(" %-22.22s    %2d/%2d %3d%%", baseitems_info[bi_id].name.data(), (int16_t)(item.charge / EATER_CHARGE),
                                 item.count, chance));
                         if (item.charge < EATER_CHARGE) {
@@ -346,7 +345,7 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
                         }
                     }
                 } else {
-                    strcpy(dummy, "");
+                    dummy.clear();
                 }
                 c_prt(col, dummy, y1, x1);
             }

--- a/src/core/scores.cpp
+++ b/src/core/scores.cpp
@@ -192,18 +192,18 @@ errr top_twenty(PlayerType *player_ptr)
     char buf[32];
 
     /* Save the version */
-    sprintf(the_score.what, "%u.%u.%u", H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH);
+    snprintf(the_score.what, sizeof(the_score.what), "%u.%u.%u", H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH);
 
     /* Calculate and save the points */
-    sprintf(the_score.pts, "%9ld", (long)calc_score(player_ptr));
+    snprintf(the_score.pts, sizeof(the_score.pts), "%9ld", (long)calc_score(player_ptr));
     the_score.pts[9] = '\0';
 
     /* Save the current gold */
-    sprintf(the_score.gold, "%9lu", (long)player_ptr->au);
+    snprintf(the_score.gold, sizeof(the_score.gold), "%9lu", (long)player_ptr->au);
     the_score.gold[9] = '\0';
 
     /* Save the current turn */
-    sprintf(the_score.turns, "%9lu", (long)turn_real(player_ptr, w_ptr->game_turn));
+    snprintf(the_score.turns, sizeof(the_score.turns), "%9lu", (long)turn_real(player_ptr, w_ptr->game_turn));
     the_score.turns[9] = '\0';
 
     time_t ct = time((time_t *)0);
@@ -212,11 +212,11 @@ errr top_twenty(PlayerType *player_ptr)
     strftime(the_score.day, 10, "@%Y%m%d", localtime(&ct));
 
     /* Save the player name (15 chars) */
-    sprintf(the_score.who, "%-.15s", player_ptr->name);
+    snprintf(the_score.who, sizeof(the_score.who), "%-.15s", player_ptr->name);
 
     /* Save the player info */
-    sprintf(the_score.uid, "%7u", player_ptr->player_uid);
-    sprintf(the_score.sex, "%c", (player_ptr->psex ? 'm' : 'f'));
+    snprintf(the_score.uid, sizeof(the_score.uid), "%7u", player_ptr->player_uid);
+    snprintf(the_score.sex, sizeof(the_score.sex), "%c", (player_ptr->psex ? 'm' : 'f'));
     snprintf(buf, sizeof(buf), "%2d", std::min(enum2i(player_ptr->prace), MAX_RACES));
     memcpy(the_score.p_r, buf, 3);
     snprintf(buf, sizeof(buf), "%2d", enum2i(std::min(player_ptr->pclass, PlayerClassType::MAX)));
@@ -225,19 +225,19 @@ errr top_twenty(PlayerType *player_ptr)
     memcpy(the_score.p_a, buf, 3);
 
     /* Save the level and such */
-    sprintf(the_score.cur_lev, "%3d", std::min<ushort>(player_ptr->lev, 999));
-    sprintf(the_score.cur_dun, "%3d", (int)player_ptr->current_floor_ptr->dun_level);
-    sprintf(the_score.max_lev, "%3d", std::min<ushort>(player_ptr->max_plv, 999));
-    sprintf(the_score.max_dun, "%3d", (int)max_dlv[player_ptr->dungeon_idx]);
+    snprintf(the_score.cur_lev, sizeof(the_score.cur_lev), "%3d", std::min<ushort>(player_ptr->lev, 999));
+    snprintf(the_score.cur_dun, sizeof(the_score.cur_dun), "%3d", (int)player_ptr->current_floor_ptr->dun_level);
+    snprintf(the_score.max_lev, sizeof(the_score.max_lev), "%3d", std::min<ushort>(player_ptr->max_plv, 999));
+    snprintf(the_score.max_dun, sizeof(the_score.max_dun), "%3d", (int)max_dlv[player_ptr->dungeon_idx]);
 
     /* Save the cause of death (31 chars) */
     if (player_ptr->died_from.size() >= sizeof(the_score.how)) {
 #ifdef JP
         angband_strcpy(the_score.how, player_ptr->died_from.data(), sizeof(the_score.how) - 2);
-        strcat(the_score.how, "…");
+        angband_strcat(the_score.how, "…", sizeof(the_score.how));
 #else
         angband_strcpy(the_score.how, player_ptr->died_from.data(), sizeof(the_score.how) - 3);
-        strcat(the_score.how, "...");
+        angband_strcat(the_score.how, "...", sizeof(the_score.how));
 #endif
     } else {
         angband_strcpy(the_score.how, player_ptr->died_from.data(), sizeof(the_score.how));
@@ -302,26 +302,26 @@ errr predict_score(PlayerType *player_ptr)
     }
 
     /* Save the version */
-    sprintf(the_score.what, "%u.%u.%u", H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH);
+    snprintf(the_score.what, sizeof(the_score.what), "%u.%u.%u", H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH);
 
     /* Calculate and save the points */
-    sprintf(the_score.pts, "%9ld", (long)calc_score(player_ptr));
+    snprintf(the_score.pts, sizeof(the_score.pts), "%9ld", (long)calc_score(player_ptr));
 
     /* Save the current gold */
-    sprintf(the_score.gold, "%9lu", (long)player_ptr->au);
+    snprintf(the_score.gold, sizeof(the_score.gold), "%9lu", (long)player_ptr->au);
 
     /* Save the current turn */
-    sprintf(the_score.turns, "%9lu", (long)turn_real(player_ptr, w_ptr->game_turn));
+    snprintf(the_score.turns, sizeof(the_score.turns), "%9lu", (long)turn_real(player_ptr, w_ptr->game_turn));
 
     /* Hack -- no time needed */
-    strcpy(the_score.day, _("今日", "TODAY"));
+    angband_strcpy(the_score.day, _("今日", "TODAY"), sizeof(the_score.day));
 
     /* Save the player name (15 chars) */
-    sprintf(the_score.who, "%-.15s", player_ptr->name);
+    snprintf(the_score.who, sizeof(the_score.who), "%-.15s", player_ptr->name);
 
     /* Save the player info */
-    sprintf(the_score.uid, "%7u", player_ptr->player_uid);
-    sprintf(the_score.sex, "%c", (player_ptr->psex ? 'm' : 'f'));
+    snprintf(the_score.uid, sizeof(the_score.uid), "%7u", player_ptr->player_uid);
+    snprintf(the_score.sex, sizeof(the_score.sex), "%c", (player_ptr->psex ? 'm' : 'f'));
     snprintf(buf, sizeof(buf), "%2d", std::min(enum2i(player_ptr->prace), MAX_RACES));
     memcpy(the_score.p_r, buf, 3);
     snprintf(buf, sizeof(buf), "%2d", enum2i(std::min(player_ptr->pclass, PlayerClassType::MAX)));
@@ -330,10 +330,10 @@ errr predict_score(PlayerType *player_ptr)
     memcpy(the_score.p_a, buf, 3);
 
     /* Save the level and such */
-    sprintf(the_score.cur_lev, "%3d", std::min<ushort>(player_ptr->lev, 999));
-    sprintf(the_score.cur_dun, "%3d", (int)player_ptr->current_floor_ptr->dun_level);
-    sprintf(the_score.max_lev, "%3d", std::min<ushort>(player_ptr->max_plv, 999));
-    sprintf(the_score.max_dun, "%3d", (int)max_dlv[player_ptr->dungeon_idx]);
+    snprintf(the_score.cur_lev, sizeof(the_score.cur_lev), "%3d", std::min<ushort>(player_ptr->lev, 999));
+    snprintf(the_score.cur_dun, sizeof(the_score.cur_dun), "%3d", (int)player_ptr->current_floor_ptr->dun_level);
+    snprintf(the_score.max_lev, sizeof(the_score.max_lev), "%3d", std::min<ushort>(player_ptr->max_plv, 999));
+    snprintf(the_score.max_dun, sizeof(the_score.max_dun), "%3d", (int)max_dlv[player_ptr->dungeon_idx]);
 
     /* まだ死んでいないときの識別文字 */
     strcpy(the_score.how, _("yet", "nobody (yet!)"));
@@ -396,9 +396,9 @@ void show_highclass(PlayerType *player_ptr)
         clev = (PLAYER_LEVEL)atoi(the_score.cur_lev);
 
 #ifdef JP
-        sprintf(out_val, "   %3d) %sの%s (レベル %2d)", (m + 1), race_info[pr].title, the_score.who, clev);
+        snprintf(out_val, sizeof(out_val), "   %3d) %sの%s (レベル %2d)", (m + 1), race_info[pr].title, the_score.who, clev);
 #else
-        sprintf(out_val, "%3d) %s the %s (Level %2d)", (m + 1), the_score.who, race_info[pr].title, clev);
+        snprintf(out_val, sizeof(out_val), "%3d) %s the %s (Level %2d)", (m + 1), the_score.who, race_info[pr].title, clev);
 #endif
 
         prt(out_val, (m + 7), 0);
@@ -407,9 +407,9 @@ void show_highclass(PlayerType *player_ptr)
     }
 
 #ifdef JP
-    sprintf(out_val, "あなた) %sの%s (レベル %2d)", race_info[enum2i(player_ptr->prace)].title, player_ptr->name, player_ptr->lev);
+    snprintf(out_val, sizeof(out_val), "あなた) %sの%s (レベル %2d)", race_info[enum2i(player_ptr->prace)].title, player_ptr->name, player_ptr->lev);
 #else
-    sprintf(out_val, "You) %s the %s (Level %2d)", player_ptr->name, race_info[enum2i(player_ptr->prace)].title, player_ptr->lev);
+    snprintf(out_val, sizeof(out_val), "You) %s the %s (Level %2d)", player_ptr->name, race_info[enum2i(player_ptr->prace)].title, player_ptr->lev);
 #endif
 
     prt(out_val, (m + 8), 0);
@@ -436,14 +436,12 @@ void race_score(PlayerType *player_ptr, int race_num)
     int i = 0, j, m = 0;
     int pr, clev, lastlev;
     high_score the_score;
-    char buf[1024], out_val[256], tmp_str[80];
+    char buf[1024], out_val[256];
 
     lastlev = 0;
 
     /* rr9: TODO - pluralize the race */
-    sprintf(tmp_str, _("最高の%s", "The Greatest of all the %s"), race_info[race_num].title);
-
-    prt(tmp_str, 5, 15);
+    prt(std::string(_("最高の", "The Greatest of all the ")).append(race_info[race_num].title), 5, 15);
     path_build(buf, sizeof(buf), ANGBAND_DIR_APEX, "scores.raw");
 
     highscore_fd = fd_open(buf, O_RDONLY);
@@ -479,9 +477,9 @@ void race_score(PlayerType *player_ptr, int race_num)
 
         if (pr == race_num) {
 #ifdef JP
-            sprintf(out_val, "   %3d) %sの%s (レベル %2d)", (m + 1), race_info[pr].title, the_score.who, clev);
+            snprintf(out_val, sizeof(out_val), "   %3d) %sの%s (レベル %2d)", (m + 1), race_info[pr].title, the_score.who, clev);
 #else
-            sprintf(out_val, "%3d) %s the %s (Level %3d)", (m + 1), the_score.who, race_info[pr].title, clev);
+            snprintf(out_val, sizeof(out_val), "%3d) %s the %s (Level %3d)", (m + 1), the_score.who, race_info[pr].title, clev);
 #endif
 
             prt(out_val, (m + 7), 0);
@@ -494,9 +492,9 @@ void race_score(PlayerType *player_ptr, int race_num)
     /* add player if qualified */
     if ((enum2i(player_ptr->prace) == race_num) && (player_ptr->lev >= lastlev)) {
 #ifdef JP
-        sprintf(out_val, "あなた) %sの%s (レベル %2d)", race_info[enum2i(player_ptr->prace)].title, player_ptr->name, player_ptr->lev);
+        snprintf(out_val, sizeof(out_val), "あなた) %sの%s (レベル %2d)", race_info[enum2i(player_ptr->prace)].title, player_ptr->name, player_ptr->lev);
 #else
-        sprintf(out_val, "You) %s the %s (Level %3d)", player_ptr->name, race_info[enum2i(player_ptr->prace)].title, player_ptr->lev);
+        snprintf(out_val, sizeof(out_val), "You) %s the %s (Level %3d)", player_ptr->name, race_info[enum2i(player_ptr->prace)].title, player_ptr->lev);
 #endif
 
         prt(out_val, (m + 8), 0);

--- a/src/core/show-file.cpp
+++ b/src/core/show-file.cpp
@@ -8,6 +8,7 @@
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/int-char-converter.h"
 #include "util/string-processor.h"
@@ -135,50 +136,43 @@ bool show_file(PlayerType *player_ptr, bool show_version, concptr name, concptr 
     int wid, hgt;
     term_get_size(&wid, &hgt);
 
-    char finder_str[81];
-    strcpy(finder_str, "");
+    char finder_str[81] = "";
 
-    char shower_str[81];
-    strcpy(shower_str, "");
+    char shower_str[81] = "";
 
-    char caption[1024 + 256];
-    strcpy(caption, "");
+    std::string caption;
 
     char hook[68][32];
     for (int i = 0; i < 68; i++) {
         hook[i][0] = '\0';
     }
 
-    char filename[1024];
-    strcpy(filename, name);
-    int n = strlen(filename);
-
-    concptr tag = nullptr;
-    for (int i = 0; i < n; i++) {
-        if (filename[i] == '#') {
-            filename[i] = '\0';
-            tag = filename + i + 1;
-            break;
-        }
+    std::string stripped_name;
+    concptr tag = angband_strstr(name, "#");
+    if (tag) {
+        stripped_name.append(name, tag - name);
+        name = stripped_name.data();
+        ++tag;
     }
 
-    name = filename;
     FILE *fff = nullptr;
     char path[1024];
     if (what) {
-        strcpy(caption, what);
-        strcpy(path, name);
+        caption = what;
+        angband_strcpy(path, name, sizeof(path));
         fff = angband_fopen(path, "r");
     }
 
     if (!fff) {
-        sprintf(caption, _("ヘルプ・ファイル'%s'", "Help file '%s'"), name);
+        caption = _("ヘルプ・ファイル'", "Help file '");
+        caption.append(name).append("'");
         path_build(path, sizeof(path), ANGBAND_DIR_HELP, name);
         fff = angband_fopen(path, "r");
     }
 
     if (!fff) {
-        sprintf(caption, _("スポイラー・ファイル'%s'", "Info file '%s'"), name);
+        caption = _("スポイラー・ファイル'", "Info file '");
+        caption.append(name).append("'");
         path_build(path, sizeof(path), ANGBAND_DIR_INFO, name);
         fff = angband_fopen(path, "r");
     }
@@ -192,7 +186,8 @@ bool show_file(PlayerType *player_ptr, bool show_version, concptr name, concptr 
             }
         }
 
-        sprintf(caption, _("スポイラー・ファイル'%s'", "Info file '%s'"), name);
+        caption = _("スポイラー・ファイル'", "Info file '");
+        caption.append(name).append("'");
         fff = angband_fopen(path, "r");
     }
 
@@ -321,7 +316,7 @@ bool show_file(PlayerType *player_ptr, bool show_version, concptr name, concptr 
             continue;
         }
 
-        prt(format(_("[変愚蛮怒 %d.%d.%d, %s, %d/%d]", "[Hengband %d.%d.%d, %s, Line %d/%d]"), H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH, caption,
+        prt(format(_("[変愚蛮怒 %d.%d.%d, %s, %d/%d]", "[Hengband %d.%d.%d, %s, Line %d/%d]"), H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH, caption.data(),
                 line, size),
             0, 0);
 
@@ -330,7 +325,7 @@ bool show_file(PlayerType *player_ptr, bool show_version, concptr name, concptr 
             put_version(title);
             prt(format("[%s]", title), 0, 0);
         } else {
-            prt(format(_("[%s, %d/%d]", "[%s, Line %d/%d]"), caption, line, size), 0, 0);
+            prt(format(_("[%s, %d/%d]", "[%s, Line %d/%d]"), caption.data(), line, size), 0, 0);
         }
 
         if (size <= rows) {
@@ -487,9 +482,7 @@ bool show_file(PlayerType *player_ptr, bool show_version, concptr name, concptr 
         if (skey == '|') {
             FILE *ffp;
             char buff[1024];
-            char xtmp[sizeof(caption) + 128];
-
-            strcpy(xtmp, "");
+            char xtmp[81] = "";
 
             if (!get_string(_("ファイル名: ", "File name: "), xtmp, 80)) {
                 continue;
@@ -508,9 +501,7 @@ bool show_file(PlayerType *player_ptr, bool show_version, concptr name, concptr 
                 break;
             }
 
-            sprintf(xtmp, "%s: %s", player_ptr->name, what ? what : caption);
-            angband_fputs(ffp, xtmp, 80);
-            angband_fputs(ffp, "\n", 80);
+            fprintf(ffp, "%s: %s\n", player_ptr->name, what ? what : caption.data());
 
             while (!angband_fgets(fff, buff, sizeof(buff))) {
                 angband_fputs(ffp, buff, 80);

--- a/src/core/visuals-reseter.cpp
+++ b/src/core/visuals-reseter.cpp
@@ -31,9 +31,6 @@ void reset_visuals(PlayerType *player_ptr)
     }
 
     concptr pref_file = use_graphics ? "graf.prf" : "font.prf";
-    concptr base_name = use_graphics ? "graf-%s.prf" : "font-%s.prf";
-    char buf[1024];
     process_pref_file(player_ptr, pref_file);
-    sprintf(buf, base_name, player_ptr->base_name);
-    process_pref_file(player_ptr, buf);
+    process_pref_file(player_ptr, std::string(use_graphics ? "graf-" : "font-").append(player_ptr->base_name).append(".prf").data());
 }

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -152,16 +152,14 @@ void process_player_hp_mp(PlayerType *player_ptr)
 
         if ((player_ptr->inventory_list[INVEN_LITE].bi_key.tval() != ItemKindType::NONE) && flgs.has_not(TR_DARK_SOURCE) && !has_resist_lite(player_ptr)) {
             GAME_TEXT o_name[MAX_NLEN];
-            char ouch[MAX_NLEN + 40];
             describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
             msg_format(_("%sがあなたのアンデッドの肉体を焼き焦がした！", "The %s scorches your undead flesh!"), o_name);
 
             cave_no_regen = true;
-            describe_flavor(player_ptr, o_name, o_ptr, OD_NAME_ONLY);
-            sprintf(ouch, _("%sを装備したダメージ", "wielding %s"), o_name);
 
             if (!is_invuln(player_ptr)) {
-                take_hit(player_ptr, DAMAGE_NOESCAPE, 1, ouch);
+                describe_flavor(player_ptr, o_name, o_ptr, OD_NAME_ONLY);
+                take_hit(player_ptr, DAMAGE_NOESCAPE, 1, std::string(_(o_name, "wielding ")).append(_("を装備したダメージ", o_name)).data());
             }
         }
     }

--- a/src/info-reader/fixed-map-parser.cpp
+++ b/src/info-reader/fixed-map-parser.cpp
@@ -26,7 +26,6 @@
 #include <sstream>
 #include <stdexcept>
 
-static char tmp[8];
 static concptr variant = "ZANGBAND";
 
 /*!
@@ -39,6 +38,7 @@ static concptr variant = "ZANGBAND";
  */
 static concptr parse_fixed_map_expression(PlayerType *player_ptr, char **sp, char *fp)
 {
+    static std::string tmp;
     char b1 = '[';
     char b2 = ']';
 
@@ -199,39 +199,38 @@ static concptr parse_fixed_map_expression(PlayerType *player_ptr, char **sp, cha
         *tpn = '\0';
         v = tmp_player_name;
     } else if (streq(b + 1, "TOWN")) {
-        sprintf(tmp, "%d", player_ptr->town_num);
-        v = tmp;
+        tmp = std::to_string(player_ptr->town_num);
+        v = tmp.data();
     } else if (streq(b + 1, "LEVEL")) {
-        sprintf(tmp, "%d", player_ptr->lev);
-        v = tmp;
+        tmp = std::to_string(player_ptr->lev);
+        v = tmp.data();
     } else if (streq(b + 1, "QUEST_NUMBER")) {
-        sprintf(tmp, "%d", enum2i(player_ptr->current_floor_ptr->quest_number));
-        v = tmp;
+        tmp = std::to_string(enum2i(player_ptr->current_floor_ptr->quest_number));
+        v = tmp.data();
     } else if (streq(b + 1, "LEAVING_QUEST")) {
-        sprintf(tmp, "%d", enum2i(leaving_quest));
-        v = tmp;
+        tmp = std::to_string(enum2i(leaving_quest));
+        v = tmp.data();
     } else if (prefix(b + 1, "QUEST_TYPE")) {
         const auto &quest_list = QuestList::get_instance();
-        sprintf(tmp, "%d", enum2i(quest_list[i2enum<QuestId>(atoi(b + 11))].type));
-        v = tmp;
+        tmp = std::to_string(enum2i(quest_list[i2enum<QuestId>(atoi(b + 11))].type));
+        v = tmp.data();
     } else if (prefix(b + 1, "QUEST")) {
         const auto &quest_list = QuestList::get_instance();
-        sprintf(tmp, "%d", enum2i(quest_list[i2enum<QuestId>(atoi(b + 6))].status));
-        v = tmp;
+        tmp = std::to_string(enum2i(quest_list[i2enum<QuestId>(atoi(b + 6))].status));
+        v = tmp.data();
     } else if (prefix(b + 1, "RANDOM")) {
-        sprintf(tmp, "%d", (int)(w_ptr->seed_town % atoi(b + 7)));
-        v = tmp;
+        tmp = std::to_string((int)(w_ptr->seed_town % atoi(b + 7)));
+        v = tmp.data();
     } else if (streq(b + 1, "VARIANT")) {
         v = variant;
     } else if (streq(b + 1, "WILDERNESS")) {
         if (vanilla_town) {
-            sprintf(tmp, "NONE");
+            v = "NONE";
         } else if (lite_town) {
-            sprintf(tmp, "LITE");
+            v = "LITE";
         } else {
-            sprintf(tmp, "NORMAL");
+            v = "NORMAL";
         }
-        v = tmp;
     } else if (streq(b + 1, "IRONMAN_DOWNWARD")) {
         v = (ironman_downward ? "1" : "0");
     }

--- a/src/inventory/inventory-util.cpp
+++ b/src/inventory/inventory-util.cpp
@@ -285,7 +285,6 @@ INVENTORY_IDX label_to_inventory(PlayerType *player_ptr, int c)
 bool verify(PlayerType *player_ptr, concptr prompt, INVENTORY_IDX item)
 {
     GAME_TEXT o_name[MAX_NLEN];
-    char out_val[MAX_NLEN + 20];
     ItemEntity *o_ptr;
     if (item >= 0) {
         o_ptr = &player_ptr->inventory_list[item];
@@ -294,7 +293,11 @@ bool verify(PlayerType *player_ptr, concptr prompt, INVENTORY_IDX item)
     }
 
     describe_flavor(player_ptr, o_name, o_ptr, 0);
-    (void)sprintf(out_val, _("%s%sですか? ", "%s %s? "), prompt, o_name);
+    std::string out_val = prompt;
+#ifndef JP
+    out_val.append(" ");
+#endif
+    out_val.append(o_name).append(_("ですか? ", "? "));
     return get_check(out_val);
 }
 

--- a/src/io-dump/random-art-info-dumper.cpp
+++ b/src/io-dump/random-art-info-dumper.cpp
@@ -22,14 +22,12 @@
 static void spoiler_print_randart(ItemEntity *o_ptr, obj_desc_list *art_ptr)
 {
     pval_info_type *pval_ptr = &art_ptr->pval_info;
-    char buf[80];
     fprintf(spoiler_file, "%s\n", art_ptr->description);
     if (!o_ptr->is_fully_known()) {
         fprintf(spoiler_file, _("%s不明\n", "%sUnknown\n"), spoiler_indent);
     } else {
         if (pval_ptr->pval_desc[0]) {
-            sprintf(buf, _("%sの修正:", "%s to"), pval_ptr->pval_desc);
-            spoiler_outlist(buf, pval_ptr->pval_affects, item_separator);
+            spoiler_outlist(std::string(pval_ptr->pval_desc).append(_("の修正:", " to")).data(), pval_ptr->pval_affects, item_separator);
         }
 
         spoiler_outlist(_("対:", "Slay"), art_ptr->slays, item_separator);
@@ -80,8 +78,7 @@ void spoil_random_artifact(PlayerType *player_ptr, concptr fname)
         return;
     }
 
-    sprintf(buf, "Random artifacts list.\r");
-    spoiler_underline(buf);
+    spoiler_underline("Random artifacts list.\r");
     for (const auto &[tval_list, name] : group_artifact_list) {
         for (auto tval : tval_list) {
             for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {

--- a/src/io/files-util.cpp
+++ b/src/io/files-util.cpp
@@ -21,6 +21,7 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "view/display-messages.h"
 
@@ -63,10 +64,10 @@ errr file_character(PlayerType *player_ptr, concptr name)
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, name);
     int fd = fd_open(buf, O_RDONLY);
     if (fd >= 0) {
-        char out_val[sizeof(buf) + 128];
+        std::string query = _("現存するファイル ", "Replace existing file ");
+        query.append(buf).append(_(" に上書きしますか? ", "? "));
         (void)fd_close(fd);
-        (void)sprintf(out_val, _("現存するファイル %s に上書きしますか? ", "Replace existing file %s? "), buf);
-        if (get_check_strict(player_ptr, out_val, CHECK_NO_HISTORY)) {
+        if (get_check_strict(player_ptr, query, CHECK_NO_HISTORY)) {
             fd = -1;
         }
     }
@@ -221,9 +222,9 @@ static errr counts_seek(PlayerType *player_ptr, int fd, uint32_t where, bool fla
     char temp1[128], temp2[128];
     auto short_pclass = enum2i(player_ptr->pclass);
 #ifdef SAVEFILE_USE_UID
-    (void)sprintf(temp1, "%d.%s.%d%d%d", player_ptr->player_uid, savefile_base, short_pclass, player_ptr->ppersonality, player_ptr->age);
+    strnfmt(temp1, sizeof(temp1), "%d.%s.%d%d%d", player_ptr->player_uid, savefile_base, short_pclass, player_ptr->ppersonality, player_ptr->age);
 #else
-    (void)sprintf(temp1, "%s.%d%d%d", savefile_base, short_pclass, player_ptr->ppersonality, player_ptr->age);
+    strnfmt(temp1, sizeof(temp1), "%s.%d%d%d", savefile_base, short_pclass, player_ptr->ppersonality, player_ptr->age);
 #endif
     for (int i = 0; temp1[i]; i++) {
         temp1[i] ^= (i + 1) * 63;

--- a/src/io/read-pref-file.cpp
+++ b/src/io/read-pref-file.cpp
@@ -25,6 +25,7 @@
 #include "player-info/race-info.h"
 #include "realm/realm-names-table.h"
 #include "system/player-type-definition.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/buffer-shaper.h"
 #include "view/display-messages.h"
@@ -248,8 +249,7 @@ void auto_dump_printf(FILE *auto_dump_stream, concptr fmt, ...)
 bool open_auto_dump(FILE **fpp, concptr buf, concptr mark)
 {
     char header_mark_str[80];
-    concptr auto_dump_mark = mark;
-    sprintf(header_mark_str, auto_dump_header, auto_dump_mark);
+    strnfmt(header_mark_str, sizeof(header_mark_str), auto_dump_header, mark);
     remove_auto_dump(buf, mark);
     *fpp = angband_fopen(buf, "a");
     if (!fpp) {
@@ -269,11 +269,12 @@ bool open_auto_dump(FILE **fpp, concptr buf, concptr mark)
 /*!
  * @brief prfファイルをファイルクローズする /
  * Append foot part and close auto dump.
+ * @param auto_dump_mark 出力するヘッダマーク
  */
 void close_auto_dump(FILE **fpp, concptr auto_dump_mark)
 {
     char footer_mark_str[80];
-    sprintf(footer_mark_str, auto_dump_footer, auto_dump_mark);
+    strnfmt(footer_mark_str, sizeof(footer_mark_str), auto_dump_footer, auto_dump_mark);
     auto_dump_printf(*fpp, _("# *警告!!* 以降の行は自動生成されたものです。\n", "# *Warning!*  The lines below are an automatic dump.\n"));
     auto_dump_printf(
         *fpp, _("# *警告!!* 後で自動的に削除されるので編集しないでください。\n", "# Don't edit them; changes will be deleted and replaced automatically.\n"));
@@ -290,25 +291,17 @@ void close_auto_dump(FILE **fpp, concptr auto_dump_mark)
  */
 void load_all_pref_files(PlayerType *player_ptr)
 {
-    char buf[1024];
-    sprintf(buf, "user.prf");
-    process_pref_file(player_ptr, buf);
-    sprintf(buf, "user-%s.prf", ANGBAND_SYS);
-    process_pref_file(player_ptr, buf);
-    sprintf(buf, "%s.prf", rp_ptr->title);
-    process_pref_file(player_ptr, buf);
-    sprintf(buf, "%s.prf", cp_ptr->title);
-    process_pref_file(player_ptr, buf);
-    sprintf(buf, "%s.prf", player_ptr->base_name);
-    process_pref_file(player_ptr, buf);
+    process_pref_file(player_ptr, "user.prf");
+    process_pref_file(player_ptr, std::string("user-").append(ANGBAND_SYS).append(".prf").data());
+    process_pref_file(player_ptr, std::string(rp_ptr->title).append(".prf").data());
+    process_pref_file(player_ptr, std::string(cp_ptr->title).append(".prf").data());
+    process_pref_file(player_ptr, std::string(player_ptr->base_name).append(".prf").data());
     if (player_ptr->realm1 != REALM_NONE) {
-        sprintf(buf, "%s.prf", realm_names[player_ptr->realm1]);
-        process_pref_file(player_ptr, buf);
+        process_pref_file(player_ptr, std::string(realm_names[player_ptr->realm1]).append(".prf").data());
     }
 
     if (player_ptr->realm2 != REALM_NONE) {
-        sprintf(buf, "%s.prf", realm_names[player_ptr->realm2]);
-        process_pref_file(player_ptr, buf);
+        process_pref_file(player_ptr, std::string(realm_names[player_ptr->realm2]).append(".prf").data());
     }
 
     autopick_load_pref(player_ptr, false);
@@ -319,7 +312,6 @@ void load_all_pref_files(PlayerType *player_ptr)
  */
 bool read_histpref(PlayerType *player_ptr)
 {
-    char buf[80];
     errr err;
     int i, j, n;
     char *s, *t;
@@ -333,12 +325,10 @@ bool read_histpref(PlayerType *player_ptr)
     histbuf[0] = '\0';
     histpref_buf = histbuf;
 
-    sprintf(buf, _("histedit-%s.prf", "histpref-%s.prf"), player_ptr->base_name);
-    err = process_histpref_file(player_ptr, buf);
+    err = process_histpref_file(player_ptr, std::string(_("histedit-", "histpref-")).append(player_ptr->base_name).append(".prf").data());
 
     if (0 > err) {
-        strcpy(buf, _("histedit.prf", "histpref.prf"));
-        err = process_histpref_file(player_ptr, buf);
+        err = process_histpref_file(player_ptr, _("histedit.prf", "histpref.prf"));
     }
 
     if (err) {

--- a/src/io/report.cpp
+++ b/src/io/report.cpp
@@ -416,14 +416,10 @@ concptr make_screen_dump(PlayerType *player_ptr)
 bool report_score(PlayerType *player_ptr)
 {
     auto *score = buf_new();
-    char personality_desc[128];
+    std::string personality_desc = ap_ptr->title;
+    personality_desc.append(_(ap_ptr->no ? "の" : "", " "));
     char title[128];
     put_version(title);
-#ifdef JP
-    sprintf(personality_desc, "%s%s", ap_ptr->title, (ap_ptr->no ? "の" : ""));
-#else
-    sprintf(personality_desc, "%s ", ap_ptr->title);
-#endif
 
     auto realm1_name = PlayerClass(player_ptr).equals(PlayerClassType::ELEMENTALIST) ? get_element_title(player_ptr->element) : realm_names[player_ptr->realm1];
     buf_sprintf(score, "name: %s\n", player_ptr->name);
@@ -438,7 +434,7 @@ bool report_score(PlayerType *player_ptr)
     buf_sprintf(score, "sex: %d\n", player_ptr->psex);
     buf_sprintf(score, "race: %s\n", rp_ptr->title);
     buf_sprintf(score, "class: %s\n", cp_ptr->title);
-    buf_sprintf(score, "seikaku: %s\n", personality_desc);
+    buf_sprintf(score, "seikaku: %s\n", personality_desc.data());
     buf_sprintf(score, "realm1: %s\n", realm1_name);
     buf_sprintf(score, "realm2: %s\n", realm_names[player_ptr->realm2]);
     buf_sprintf(score, "killer: %s\n", player_ptr->died_from.data());

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -32,6 +32,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
@@ -193,21 +194,19 @@ void do_cmd_knowledge_kill_count(PlayerType *player_ptr)
     }
 
     uint16_t why = 2;
-    char buf[80];
     ang_sort(player_ptr, who.data(), &why, who.size(), ang_sort_comp_hook, ang_sort_swap_hook);
     for (auto r_idx : who) {
         auto *r_ptr = &monraces_info[r_idx];
         if (r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
             bool dead = (r_ptr->max_num == 0);
             if (dead) {
+                std::string details;
                 if (r_ptr->defeat_level && r_ptr->defeat_time) {
-                    sprintf(buf, _(" - レベル%2d - %d:%02d:%02d", " - level %2d - %d:%02d:%02d"), r_ptr->defeat_level, r_ptr->defeat_time / (60 * 60),
+                    details = format(_(" - レベル%2d - %d:%02d:%02d", " - level %2d - %d:%02d:%02d"), r_ptr->defeat_level, r_ptr->defeat_time / (60 * 60),
                         (r_ptr->defeat_time / 60) % 60, r_ptr->defeat_time % 60);
-                } else {
-                    buf[0] = '\0';
                 }
 
-                fprintf(fff, "     %s%s\n", r_ptr->name.data(), buf);
+                fprintf(fff, "     %s%s\n", r_ptr->name.data(), details.data());
                 total++;
             }
 

--- a/src/knowledge/knowledge-uniques.cpp
+++ b/src/knowledge/knowledge-uniques.cpp
@@ -12,6 +12,7 @@
 #include "monster-race/race-flags1.h"
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/sort.h"
 #include "util/string-processor.h"
@@ -116,19 +117,17 @@ static void display_uniques(unique_list_type *unique_list_ptr, FILE *fff)
         fputs(no_unique_desc, fff);
     }
 
-    char buf[80];
     for (auto r_idx : unique_list_ptr->who) {
         auto *r_ptr = &monraces_info[r_idx];
+        std::string details;
 
         if (r_ptr->defeat_level && r_ptr->defeat_time) {
-            sprintf(buf, _(" - レベル%2d - %d:%02d:%02d", " - level %2d - %d:%02d:%02d"), r_ptr->defeat_level, r_ptr->defeat_time / (60 * 60),
+            details = format(_(" - レベル%2d - %d:%02d:%02d", " - level %2d - %d:%02d:%02d"), r_ptr->defeat_level, r_ptr->defeat_time / (60 * 60),
                 (r_ptr->defeat_time / 60) % 60, r_ptr->defeat_time % 60);
-        } else {
-            buf[0] = '\0';
         }
 
         const auto name = str_separate(r_ptr->name, 40);
-        fprintf(fff, _("     %-40s (レベル%3d)%s\n", "     %-40s (level %3d)%s\n"), name.front().data(), (int)r_ptr->level, buf);
+        fprintf(fff, _("     %-40s (レベル%3d)%s\n", "     %-40s (level %3d)%s\n"), name.front().data(), (int)r_ptr->level, details.data());
         for (auto i = 1U; i < name.size(); ++i) {
             fprintf(fff, "     %s\n", name[i].data());
         }

--- a/src/load/floor-loader.cpp
+++ b/src/load/floor-loader.cpp
@@ -25,6 +25,7 @@
 #include "system/item-entity.h"
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "world/world-object.h"
 #include "world/world.h"
@@ -286,11 +287,13 @@ bool load_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr, BIT_FLAGS mode
         old_loading_savefile_version = loading_savefile_version;
     }
 
-    char floor_savefile[sizeof(savefile) + 32];
-    sprintf(floor_savefile, "%s.F%02d", savefile, (int)sf_ptr->savefile_id);
+    std::string floor_savefile = savefile;
+    char ext[32];
+    strnfmt(ext, sizeof(ext), ".F%02d", (int)sf_ptr->savefile_id);
+    floor_savefile.append(ext);
 
     safe_setuid_grab(player_ptr);
-    loading_savefile = angband_fopen(floor_savefile, "rb");
+    loading_savefile = angband_fopen(floor_savefile.data(), "rb");
     safe_setuid_drop();
 
     bool is_save_successful = true;
@@ -307,7 +310,7 @@ bool load_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr, BIT_FLAGS mode
         angband_fclose(loading_savefile);
         safe_setuid_grab(player_ptr);
         if (!(mode & SLF_NO_KILL)) {
-            (void)fd_kill(floor_savefile);
+            (void)fd_kill(floor_savefile.data());
         }
 
         safe_setuid_drop();

--- a/src/main-gcu.cpp
+++ b/src/main-gcu.cpp
@@ -597,16 +597,16 @@ static bool init_sound(void)
     }
 
     int i;
-    char wav[128];
     char buf[1024];
 
     /* Prepare the sounds */
     for (i = 1; i < SOUND_MAX; i++) {
         /* Extract name of sound file */
-        sprintf(wav, "%s.wav", angband_sound_name[i]);
+        std::string wav = angband_sound_name[i];
+        wav.append(".wav");
 
         /* Access the sound */
-        path_build(buf, sizeof(buf), ANGBAND_DIR_XTRA_SOUND, wav);
+        path_build(buf, sizeof(buf), ANGBAND_DIR_XTRA_SOUND, wav.data());
 
         /* Save the sound filename, if it exists */
         if (check_file(buf)) {
@@ -875,8 +875,6 @@ static errr game_term_xtra_gcu_event(int v)
  */
 static errr game_term_xtra_gcu_sound(int v)
 {
-    char buf[1024];
-
     /* Sound disabled */
     if (!use_sound) {
         return 1;
@@ -892,11 +890,9 @@ static errr game_term_xtra_gcu_sound(int v)
         return 1;
     }
 
-    sprintf(buf, "./gcusound.sh %s\n", sound_file[v]);
-
-    return system(buf) < 0;
-
-    return 0;
+    std::string buf = "./gcusound.sh ";
+    buf.append(sound_file[v]).append("\n");
+    return system(buf.data()) < 0;
 }
 
 static int scale_color(int i, int j, int scale)

--- a/src/main-x11.cpp
+++ b/src/main-x11.cpp
@@ -102,6 +102,7 @@
 #include "system/system-variables.h"
 #include "term/gameterm.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
@@ -1166,9 +1167,9 @@ static void react_keypress(XKeyEvent *xev)
     }
 
     if (ks) {
-        sprintf(msg, "%c%s%s%s%s_%lX%c", 31, mc ? "N" : "", ms ? "S" : "", mo ? "O" : "", mx ? "M" : "", (unsigned long)(ks), 13);
+        strnfmt(msg, sizeof(msg), "%c%s%s%s%s_%lX%c", 31, mc ? "N" : "", ms ? "S" : "", mo ? "O" : "", mx ? "M" : "", (unsigned long)(ks), 13);
     } else {
-        sprintf(msg, "%c%s%s%s%sK_%X%c", 31, mc ? "N" : "", ms ? "S" : "", mo ? "O" : "", mx ? "M" : "", ev->keycode, 13);
+        strnfmt(msg, sizeof(msg), "%c%s%s%s%sK_%X%c", 31, mc ? "N" : "", ms ? "S" : "", mo ? "O" : "", mx ? "M" : "", ev->keycode, 13);
     }
 
     send_keys(msg);
@@ -1799,13 +1800,13 @@ static bool check_file(concptr s)
 static void init_sound(void)
 {
     int i;
-    char wav[128];
     char buf[1024];
     char dir_xtra_sound[1024];
     path_build(dir_xtra_sound, sizeof(dir_xtra_sound), ANGBAND_DIR_XTRA, "sound");
     for (i = 1; i < SOUND_MAX; i++) {
-        sprintf(wav, "%s.wav", angband_sound_name[i]);
-        path_build(buf, sizeof(buf), dir_xtra_sound, wav);
+        std::string wav = angband_sound_name[i];
+        wav.append(".wav");
+        path_build(buf, sizeof(buf), dir_xtra_sound, wav.data());
         if (check_file(buf)) {
             sound_file[i] = string_make(buf);
         }
@@ -1820,7 +1821,6 @@ static void init_sound(void)
  */
 static errr game_term_xtra_x11_sound(int v)
 {
-    char buf[1024];
     if (!use_sound) {
         return 1;
     }
@@ -1831,8 +1831,9 @@ static errr game_term_xtra_x11_sound(int v)
         return 1;
     }
 
-    sprintf(buf, "./playwave.sh %s\n", sound_file[v]);
-    return system(buf) < 0;
+    std::string buf = "./playwave.sh ";
+    buf.append(sound_file[v]).append("\n");
+    return system(buf.data()) < 0;
 }
 
 /*
@@ -2193,8 +2194,6 @@ static errr term_data_init(term_data *td, int i)
 
     int wid, hgt, num;
 
-    char buf[80];
-
     concptr str;
 
     int val;
@@ -2209,8 +2208,7 @@ static errr term_data_init(term_data *td, int i)
     XWMHints *wh;
 #endif
 
-    sprintf(buf, "ANGBAND_X11_FONT_%d", i);
-    font = getenv(buf);
+    font = getenv(format("ANGBAND_X11_FONT_%d", i));
     if (!font) {
         font = getenv("ANGBAND_X11_FONT");
     }
@@ -2247,23 +2245,19 @@ static errr term_data_init(term_data *td, int i)
         }
     }
 
-    sprintf(buf, "ANGBAND_X11_AT_X_%d", i);
-    str = getenv(buf);
+    str = getenv(format("ANGBAND_X11_AT_X_%d", i));
     x = (str != nullptr) ? atoi(str) : -1;
 
-    sprintf(buf, "ANGBAND_X11_AT_Y_%d", i);
-    str = getenv(buf);
+    str = getenv(format("ANGBAND_X11_AT_Y_%d", i));
     y = (str != nullptr) ? atoi(str) : -1;
 
-    sprintf(buf, "ANGBAND_X11_COLS_%d", i);
-    str = getenv(buf);
+    str = getenv(format("ANGBAND_X11_COLS_%d", i));
     val = (str != nullptr) ? atoi(str) : -1;
     if (val > 0) {
         cols = val;
     }
 
-    sprintf(buf, "ANGBAND_X11_ROWS_%d", i);
-    str = getenv(buf);
+    str = getenv(format("ANGBAND_X11_ROWS_%d", i));
     val = (str != nullptr) ? atoi(str) : -1;
     if (val > 0) {
         rows = val;
@@ -2278,15 +2272,13 @@ static errr term_data_init(term_data *td, int i)
         }
     }
 
-    sprintf(buf, "ANGBAND_X11_IBOX_%d", i);
-    str = getenv(buf);
+    str = getenv(format("ANGBAND_X11_IBOX_%d", i));
     val = (str != nullptr) ? atoi(str) : -1;
     if (val > 0) {
         ox = val;
     }
 
-    sprintf(buf, "ANGBAND_X11_IBOY_%d", i);
-    str = getenv(buf);
+    str = getenv(format("ANGBAND_X11_IBOY_%d", i));
     val = (str != nullptr) ? atoi(str) : -1;
     if (val > 0) {
         oy = val;

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -34,6 +34,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "world/world.h"
@@ -55,10 +56,8 @@ bool exchange_cash(PlayerType *player_ptr)
         const auto r_idx_of_item = static_cast<MonsterRaceId>(o_ptr->pval);
 
         if ((o_ptr->bi_key.tval() == ItemKindType::CAPTURE) && (r_idx_of_item == MonsterRaceId::TSUCHINOKO)) {
-            char buf[MAX_NLEN + 32];
             describe_flavor(player_ptr, o_name, o_ptr, 0);
-            sprintf(buf, _("%s を換金しますか？", "Convert %s into money? "), o_name);
-            if (get_check(buf)) {
+            if (get_check(format(_("%s を換金しますか？", "Convert %s into money? "), o_name))) {
                 msg_format(_("賞金 %ld＄を手に入れた。", "You get %ldgp."), (long int)(1000000L * o_ptr->number));
                 player_ptr->au += 1000000L * o_ptr->number;
                 player_ptr->redraw |= (PR_GOLD);
@@ -74,10 +73,8 @@ bool exchange_cash(PlayerType *player_ptr)
         const auto r_idx_of_item = static_cast<MonsterRaceId>(o_ptr->pval);
 
         if (o_ptr->bi_key == BaseitemKey(ItemKindType::CORPSE, SV_CORPSE) && (r_idx_of_item == MonsterRaceId::TSUCHINOKO)) {
-            char buf[MAX_NLEN + 32];
             describe_flavor(player_ptr, o_name, o_ptr, 0);
-            sprintf(buf, _("%s を換金しますか？", "Convert %s into money? "), o_name);
-            if (get_check(buf)) {
+            if (get_check(format(_("%s を換金しますか？", "Convert %s into money? "), o_name))) {
                 msg_format(_("賞金 %ld＄を手に入れた。", "You get %ldgp."), (long int)(200000L * o_ptr->number));
                 player_ptr->au += 200000L * o_ptr->number;
                 player_ptr->redraw |= (PR_GOLD);
@@ -93,10 +90,8 @@ bool exchange_cash(PlayerType *player_ptr)
         const auto r_idx_of_item = static_cast<MonsterRaceId>(o_ptr->pval);
 
         if (o_ptr->bi_key == BaseitemKey(ItemKindType::CORPSE, SV_SKELETON) && (r_idx_of_item == MonsterRaceId::TSUCHINOKO)) {
-            char buf[MAX_NLEN + 32];
             describe_flavor(player_ptr, o_name, o_ptr, 0);
-            sprintf(buf, _("%s を換金しますか？", "Convert %s into money? "), o_name);
-            if (get_check(buf)) {
+            if (get_check(format(_("%s を換金しますか？", "Convert %s into money? "), o_name))) {
                 msg_format(_("賞金 %ld＄を手に入れた。", "You get %ldgp."), (long int)(100000L * o_ptr->number));
                 player_ptr->au += 100000L * o_ptr->number;
                 player_ptr->redraw |= (PR_GOLD);
@@ -112,10 +107,8 @@ bool exchange_cash(PlayerType *player_ptr)
         const auto r_idx_of_item = static_cast<MonsterRaceId>(o_ptr->pval);
 
         if (o_ptr->bi_key == BaseitemKey(ItemKindType::CORPSE, SV_CORPSE) && (streq(monraces_info[r_idx_of_item].name.data(), monraces_info[w_ptr->today_mon].name.data()))) {
-            char buf[MAX_NLEN + 32];
             describe_flavor(player_ptr, o_name, o_ptr, 0);
-            sprintf(buf, _("%s を換金しますか？", "Convert %s into money? "), o_name);
-            if (get_check(buf)) {
+            if (get_check(format(_("%s を換金しますか？", "Convert %s into money? "), o_name))) {
                 msg_format(
                     _("賞金 %ld＄を手に入れた。", "You get %ldgp."), (long int)((monraces_info[w_ptr->today_mon].level * 50 + 100) * o_ptr->number));
                 player_ptr->au += (monraces_info[w_ptr->today_mon].level * 50 + 100) * o_ptr->number;
@@ -132,10 +125,8 @@ bool exchange_cash(PlayerType *player_ptr)
         const auto r_idx_of_item = static_cast<MonsterRaceId>(o_ptr->pval);
 
         if (o_ptr->bi_key == BaseitemKey(ItemKindType::CORPSE, SV_SKELETON) && (streq(monraces_info[r_idx_of_item].name.data(), monraces_info[w_ptr->today_mon].name.data()))) {
-            char buf[MAX_NLEN + 32];
             describe_flavor(player_ptr, o_name, o_ptr, 0);
-            sprintf(buf, _("%s を換金しますか？", "Convert %s into money? "), o_name);
-            if (get_check(buf)) {
+            if (get_check(format(_("%s を換金しますか？", "Convert %s into money? "), o_name))) {
                 msg_format(_("賞金 %ld＄を手に入れた。", "You get %ldgp."), (long int)((monraces_info[w_ptr->today_mon].level * 30 + 60) * o_ptr->number));
                 player_ptr->au += (monraces_info[w_ptr->today_mon].level * 30 + 60) * o_ptr->number;
                 player_ptr->redraw |= (PR_GOLD);
@@ -159,13 +150,11 @@ bool exchange_cash(PlayerType *player_ptr)
                 continue;
             }
 
-            char buf[MAX_NLEN + 20];
             INVENTORY_IDX item_new;
             ItemEntity forge;
 
             describe_flavor(player_ptr, o_name, o_ptr, 0);
-            sprintf(buf, _("%sを渡しますか？", "Hand %s over? "), o_name);
-            if (!get_check(buf)) {
+            if (!get_check(format(_("%sを渡しますか？", "Hand %s over? "), o_name))) {
                 continue;
             }
 
@@ -214,17 +203,13 @@ bool exchange_cash(PlayerType *player_ptr)
  */
 void today_target(PlayerType *player_ptr)
 {
-    char buf[160];
     auto *r_ptr = &monraces_info[w_ptr->today_mon];
 
     clear_bldg(4, 18);
     c_put_str(TERM_YELLOW, _("本日の賞金首", "Wanted monster that changes from day to day"), 5, 10);
-    sprintf(buf, _("ターゲット： %s", "target: %s"), r_ptr->name.data());
-    c_put_str(TERM_YELLOW, buf, 6, 10);
-    sprintf(buf, _("死体 ---- $%d", "corpse   ---- $%d"), (int)r_ptr->level * 50 + 100);
-    prt(buf, 8, 10);
-    sprintf(buf, _("骨   ---- $%d", "skeleton ---- $%d"), (int)r_ptr->level * 30 + 60);
-    prt(buf, 9, 10);
+    c_put_str(TERM_YELLOW, format(_("ターゲット： %s", "target: %s"), r_ptr->name.data()), 6, 10);
+    prt(format(_("死体 ---- $%d", "corpse   ---- $%d"), (int)r_ptr->level * 50 + 100), 8, 10);
+    prt(format(_("骨   ---- $%d", "skeleton ---- $%d"), (int)r_ptr->level * 30 + 60), 9, 10);
     player_ptr->knows_daily_bounty = true;
 }
 

--- a/src/market/building-craft-weapon.cpp
+++ b/src/market/building-craft-weapon.cpp
@@ -23,6 +23,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "world/world.h"
@@ -99,11 +100,9 @@ static uint32_t calc_expect_dice(
 static void show_weapon_dmg(int r, int c, int mindice, int maxdice, int blows, int dam_bonus, concptr attr, byte color)
 {
     c_put_str(color, attr, r, c);
-    GAME_TEXT tmp_str[80];
     int mindam = blows * (mindice + dam_bonus);
     int maxdam = blows * (maxdice + dam_bonus);
-    sprintf(tmp_str, _("１ターン: %d-%d ダメージ", "Attack: %d-%d damage"), mindam, maxdam);
-    put_str(tmp_str, r, c + 8);
+    put_str(format(_("１ターン: %d-%d ダメージ", "Attack: %d-%d damage"), mindam, maxdam), r, c + 8);
 }
 
 /*!
@@ -312,7 +311,6 @@ static void compare_weapon_aux(PlayerType *player_ptr, ItemEntity *o_ptr, int co
 static void list_weapon(PlayerType *player_ptr, ItemEntity *o_ptr, TERM_LEN row, TERM_LEN col)
 {
     GAME_TEXT o_name[MAX_NLEN];
-    GAME_TEXT tmp_str[80];
 
     DICE_NUMBER eff_dd = o_ptr->dd + player_ptr->to_dd[0];
     DICE_SID eff_ds = o_ptr->ds + player_ptr->to_ds[0];
@@ -320,23 +318,27 @@ static void list_weapon(PlayerType *player_ptr, ItemEntity *o_ptr, TERM_LEN row,
 
     describe_flavor(player_ptr, o_name, o_ptr, OD_NAME_ONLY);
     c_put_str(TERM_YELLOW, o_name, row, col);
-    sprintf(tmp_str, _("攻撃回数: %d", "Number of Blows: %d"), player_ptr->num_blow[0]);
-    put_str(tmp_str, row + 1, col);
+    put_str(format(_("攻撃回数: %d", "Number of Blows: %d"), player_ptr->num_blow[0]), row + 1, col);
 
-    sprintf(tmp_str, _("命中率:  0  50 100 150 200 (敵のAC)", "To Hit:  0  50 100 150 200 (AC)"));
-    put_str(tmp_str, row + 2, col);
-    sprintf(tmp_str, "        %2d  %2d  %2d  %2d  %2d (%%)", (int)hit_chance(player_ptr, hit_reliability, 0), (int)hit_chance(player_ptr, hit_reliability, 50),
-        (int)hit_chance(player_ptr, hit_reliability, 100), (int)hit_chance(player_ptr, hit_reliability, 150), (int)hit_chance(player_ptr, hit_reliability, 200));
-    put_str(tmp_str, row + 3, col);
+    put_str(_("命中率:  0  50 100 150 200 (敵のAC)", "To Hit:  0  50 100 150 200 (AC)"), row + 2, col);
+    put_str(format("        %2d  %2d  %2d  %2d  %2d (%%)",
+                (int)hit_chance(player_ptr, hit_reliability, 0),
+                (int)hit_chance(player_ptr, hit_reliability, 50),
+                (int)hit_chance(player_ptr, hit_reliability, 100),
+                (int)hit_chance(player_ptr, hit_reliability, 150),
+                (int)hit_chance(player_ptr, hit_reliability, 200)),
+        row + 3, col);
     c_put_str(TERM_YELLOW, _("可能なダメージ:", "Possible Damage:"), row + 5, col);
 
-    sprintf(tmp_str, _("攻撃一回につき %d-%d", "One Strike: %d-%d damage"), (int)(eff_dd + o_ptr->to_d + player_ptr->to_d[0]),
-        (int)(eff_ds * eff_dd + o_ptr->to_d + player_ptr->to_d[0]));
-    put_str(tmp_str, row + 6, col + 1);
+    put_str(format(_("攻撃一回につき %d-%d", "One Strike: %d-%d damage"),
+                (int)(eff_dd + o_ptr->to_d + player_ptr->to_d[0]),
+                (int)(eff_ds * eff_dd + o_ptr->to_d + player_ptr->to_d[0])),
+        row + 6, col + 1);
 
-    sprintf(tmp_str, _("１ターンにつき %d-%d", "One Attack: %d-%d damage"), (int)(player_ptr->num_blow[0] * (eff_dd + o_ptr->to_d + player_ptr->to_d[0])),
-        (int)(player_ptr->num_blow[0] * (eff_ds * eff_dd + o_ptr->to_d + player_ptr->to_d[0])));
-    put_str(tmp_str, row + 7, col + 1);
+    put_str(format(_("１ターンにつき %d-%d", "One Attack: %d-%d damage"),
+                (int)(player_ptr->num_blow[0] * (eff_dd + o_ptr->to_d + player_ptr->to_d[0])),
+                (int)(player_ptr->num_blow[0] * (eff_ds * eff_dd + o_ptr->to_d + player_ptr->to_d[0]))),
+        row + 7, col + 1);
 }
 
 /*!

--- a/src/market/building-monster.cpp
+++ b/src/market/building-monster.cpp
@@ -11,6 +11,7 @@
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/int-char-converter.h"
 #include "util/sort.h"
 #include "util/string-processor.h"
@@ -24,7 +25,6 @@
  */
 bool research_mon(PlayerType *player_ptr)
 {
-    char buf[256];
     bool notpicked;
     bool recall = false;
     uint16_t why = 0;
@@ -54,15 +54,16 @@ bool research_mon(PlayerType *player_ptr)
     }
 
     /* XTRA HACK WHATSEARCH */
+    std::string buf;
     if (sym == KTRL('A')) {
         all = true;
-        strcpy(buf, _("全モンスターのリスト", "Full monster list."));
+        buf = _("全モンスターのリスト", "Full monster list.");
     } else if (sym == KTRL('U')) {
         all = uniq = true;
-        strcpy(buf, _("ユニーク・モンスターのリスト", "Unique monster list."));
+        buf = _("ユニーク・モンスターのリスト", "Unique monster list.");
     } else if (sym == KTRL('N')) {
         all = norm = true;
-        strcpy(buf, _("ユニーク外モンスターのリスト", "Non-unique monster list."));
+        buf = _("ユニーク外モンスターのリスト", "Non-unique monster list.");
     } else if (sym == KTRL('M')) {
         all = true;
         if (!get_string(_("名前(英語の場合小文字で可)", "Enter name:"), temp, 70)) {
@@ -72,11 +73,11 @@ bool research_mon(PlayerType *player_ptr)
             return false;
         }
 
-        sprintf(buf, _("名前:%sにマッチ", "Monsters' names with \"%s\""), temp);
+        buf = format(_("名前:%sにマッチ", "Monsters' names with \"%s\""), temp);
     } else if (ident_info[ident_i]) {
-        sprintf(buf, "%c - %s.", sym, ident_info[ident_i] + 2);
+        buf = format("%c - %s.", sym, ident_info[ident_i] + 2);
     } else {
-        sprintf(buf, "%c - %s", sym, _("無効な文字", "Unknown Symbol"));
+        buf = format("%c - %s", sym, _("無効な文字", "Unknown Symbol"));
     }
 
     /* Display the result */
@@ -117,22 +118,17 @@ bool research_mon(PlayerType *player_ptr)
                 }
             }
 
-            char temp2[MAX_MONSTER_NAME];
-#ifdef JP
-            strcpy(temp2, r_ref.E_name.data());
-#else
-            strcpy(temp2, r_ref.name.data());
-#endif
-            for (int xx = 0; temp2[xx] && xx < 80; xx++) {
-                if (isupper(temp2[xx])) {
-                    temp2[xx] = (char)tolower(temp2[xx]);
+            std::string temp2 = _(r_ref.E_name, r_ref.name);
+            for (auto &ch : temp2) {
+                if (isupper(ch)) {
+                    ch = static_cast<char>(tolower(ch));
                 }
             }
 
 #ifdef JP
-            if (angband_strstr(temp2, temp) || angband_strstr(r_ref.name.data(), temp))
+            if (angband_strstr(temp2.data(), temp) || angband_strstr(r_ref.name.data(), temp))
 #else
-            if (angband_strstr(temp2, temp))
+            if (angband_strstr(temp2.data(), temp))
 #endif
                 who.push_back(r_ref.idx);
         } else if (all || (r_ref.d_char == sym)) {

--- a/src/market/building-quest.cpp
+++ b/src/market/building-quest.cpp
@@ -13,6 +13,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "view/display-messages.h"
 
 /*!
@@ -48,15 +49,13 @@ static void get_questinfo(PlayerType *player_ptr, QuestId questnum, bool do_init
  * @param questnum クエストのID
  * @param do_init クエストの開始処理か(true)、結果処理か(FALSE)
  */
-void print_questinfo(PlayerType *player_ptr, QuestId questnum, bool do_init)
+static void print_questinfo(PlayerType *player_ptr, QuestId questnum, bool do_init)
 {
     get_questinfo(player_ptr, questnum, do_init);
 
     const auto &quest_list = QuestList::get_instance();
     const auto *q_ptr = &quest_list[questnum];
-    GAME_TEXT tmp_str[80];
-    sprintf(tmp_str, _("クエスト情報 (危険度: %d 階相当)", "Quest Information (Danger level: %d)"), (int)q_ptr->level);
-    prt(tmp_str, 5, 0);
+    prt(format(_("クエスト情報 (危険度: %d 階相当)", "Quest Information (Danger level: %d)"), (int)q_ptr->level), 5, 0);
     prt(q_ptr->name, 7, 0);
 
     for (int i = 0; i < 10; i++) {

--- a/src/market/building-service.cpp
+++ b/src/market/building-service.cpp
@@ -6,6 +6,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/enum-converter.h"
 
 /*!
@@ -81,69 +82,61 @@ bool is_member(PlayerType *player_ptr, building_type *bldg)
  */
 void display_buikding_service(PlayerType *player_ptr, building_type *bldg)
 {
-    char buff[20];
     byte action_color;
-    char tmp_str[80];
 
     term_clear();
-    sprintf(tmp_str, "%s (%s) %35s", bldg->owner_name, bldg->owner_race, bldg->name);
-    prt(tmp_str, 2, 1);
+    prt(format("%s (%s) %35s", bldg->owner_name, bldg->owner_race, bldg->name), 2, 1);
 
     for (int i = 0; i < 8; i++) {
         if (!bldg->letters[i]) {
             continue;
         }
 
+        std::string buff;
         if (bldg->action_restr[i] == 0) {
             if ((is_owner(player_ptr, bldg) && (bldg->member_costs[i] == 0)) || (!is_owner(player_ptr, bldg) && (bldg->other_costs[i] == 0))) {
                 action_color = TERM_WHITE;
-                buff[0] = '\0';
             } else if (is_owner(player_ptr, bldg)) {
                 action_color = TERM_YELLOW;
-                sprintf(buff, _("($%ld)", "(%ldgp)"), (long int)bldg->member_costs[i]);
+                buff = format(_("($%ld)", "(%ldgp)"), (long int)bldg->member_costs[i]);
             } else {
                 action_color = TERM_YELLOW;
-                sprintf(buff, _("($%ld)", "(%ldgp)"), (long int)bldg->other_costs[i]);
+                buff = format(_("($%ld)", "(%ldgp)"), (long int)bldg->other_costs[i]);
             }
 
-            sprintf(tmp_str, " %c) %s %s", bldg->letters[i], bldg->act_names[i], buff);
-            c_put_str(action_color, tmp_str, 19 + (i / 2), 35 * (i % 2));
+            c_put_str(action_color, format(" %c) %s %s", bldg->letters[i], bldg->act_names[i], buff.data()), 19 + (i / 2), 35 * (i % 2));
             continue;
         }
 
         if (bldg->action_restr[i] == 1) {
             if (!is_member(player_ptr, bldg)) {
                 action_color = TERM_L_DARK;
-                strcpy(buff, _("(閉店)", "(closed)"));
+                buff = _("(閉店)", "(closed)");
             } else if ((is_owner(player_ptr, bldg) && (bldg->member_costs[i] == 0)) || (is_member(player_ptr, bldg) && (bldg->other_costs[i] == 0))) {
                 action_color = TERM_WHITE;
-                buff[0] = '\0';
             } else if (is_owner(player_ptr, bldg)) {
                 action_color = TERM_YELLOW;
-                sprintf(buff, _("($%ld)", "(%ldgp)"), (long int)bldg->member_costs[i]);
+                buff = format(_("($%ld)", "(%ldgp)"), (long int)bldg->member_costs[i]);
             } else {
                 action_color = TERM_YELLOW;
-                sprintf(buff, _("($%ld)", "(%ldgp)"), (long int)bldg->other_costs[i]);
+                buff = format(_("($%ld)", "(%ldgp)"), (long int)bldg->other_costs[i]);
             }
 
-            sprintf(tmp_str, " %c) %s %s", bldg->letters[i], bldg->act_names[i], buff);
-            c_put_str(action_color, tmp_str, 19 + (i / 2), 35 * (i % 2));
+            c_put_str(action_color, format(" %c) %s %s", bldg->letters[i], bldg->act_names[i], buff.data()), 19 + (i / 2), 35 * (i % 2));
             continue;
         }
 
         if (!is_owner(player_ptr, bldg)) {
             action_color = TERM_L_DARK;
-            strcpy(buff, _("(閉店)", "(closed)"));
+            buff = _("(閉店)", "(closed)");
         } else if (bldg->member_costs[i] != 0) {
             action_color = TERM_YELLOW;
-            sprintf(buff, _("($%ld)", "(%ldgp)"), (long int)bldg->member_costs[i]);
+            buff = format(_("($%ld)", "(%ldgp)"), (long int)bldg->member_costs[i]);
         } else {
             action_color = TERM_WHITE;
-            buff[0] = '\0';
         }
 
-        sprintf(tmp_str, " %c) %s %s", bldg->letters[i], bldg->act_names[i], buff);
-        c_put_str(action_color, tmp_str, 19 + (i / 2), 35 * (i % 2));
+        c_put_str(action_color, format(" %c) %s %s", bldg->letters[i], bldg->act_names[i], buff.data()), 19 + (i / 2), 35 * (i % 2));
     }
 
     prt(_(" ESC) 建物を出る", " ESC) Exit building"), 23, 0);

--- a/src/market/building-util.cpp
+++ b/src/market/building-util.cpp
@@ -1,6 +1,7 @@
 ﻿#include "market/building-util.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 
 /*!
  * @brief コンソールに表示された施設に関する情報を消去する / Clear the building information
@@ -21,8 +22,6 @@ void clear_bldg(int min_row, int max_row)
  */
 void building_prt_gold(PlayerType *player_ptr)
 {
-    char tmp_str[80];
     prt(_("手持ちのお金: ", "Gold Remaining: "), 23, 53);
-    sprintf(tmp_str, "%9ld", (long)player_ptr->au);
-    prt(tmp_str, 23, 68);
+    prt(format("%9ld", (long)player_ptr->au), 23, 68);
 }

--- a/src/market/play-gamble.cpp
+++ b/src/market/play-gamble.cpp
@@ -9,6 +9,8 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
+#include "util/string-processor.h"
 #include "view/display-fruit.h"
 #include "view/display-messages.h"
 
@@ -26,7 +28,7 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
     int32_t maxbet;
     int32_t oldgold;
 
-    char out_val[160], tmp_str[80], again;
+    char out_val[160] = "", again;
     concptr p;
 
     screen_save();
@@ -48,14 +50,11 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
     maxbet = player_ptr->lev * 200;
     maxbet = std::min(maxbet, player_ptr->au);
 
-    strcpy(out_val, "");
-    sprintf(tmp_str, _("賭け金 (1-%ld)？", "Your wager (1-%ld) ? "), (long int)maxbet);
-
     /*
      * Use get_string() because we may need more than
      * the int16_t value returned by get_quantity().
      */
-    if (!get_string(tmp_str, out_val, 32)) {
+    if (!get_string(format(_("賭け金 (1-%ld)？", "Your wager (1-%ld) ? "), (long int)maxbet), out_val, 32)) {
         msg_print(nullptr);
         screen_load();
         return true;
@@ -83,10 +82,8 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
     odds = 0;
     oldgold = player_ptr->au;
 
-    sprintf(tmp_str, _("ゲーム前の所持金: %9ld", "Gold before game: %9ld"), (long int)oldgold);
-    prt(tmp_str, 20, 2);
-    sprintf(tmp_str, _("現在の掛け金:     %9ld", "Current Wager:    %9ld"), (long int)wager);
-    prt(tmp_str, 21, 2);
+    prt(format(_("ゲーム前の所持金: %9ld", "Gold before game: %9ld"), (long int)oldgold), 20, 2);
+    prt(format(_("現在の掛け金:     %9ld", "Current Wager:    %9ld"), (long int)wager), 21, 2);
 
     do {
         player_ptr->au -= wager;
@@ -99,12 +96,10 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
             roll1 = randint1(10);
             roll2 = randint1(10);
             choice = randint1(10);
-            sprintf(tmp_str, _("黒ダイス: %d        黒ダイス: %d", "Black die: %d       Black Die: %d"), roll1, roll2);
 
-            prt(tmp_str, 8, 3);
-            sprintf(tmp_str, _("赤ダイス: %d", "Red die: %d"), choice);
+            prt(format(_("黒ダイス: %d        黒ダイス: %d", "Black die: %d       Black Die: %d"), roll1, roll2), 8, 3);
 
-            prt(tmp_str, 11, 14);
+            prt(format(_("赤ダイス: %d", "Red die: %d"), choice), 11, 14);
             if (((choice > roll1) && (choice < roll2)) || ((choice < roll1) && (choice > roll2))) {
                 win = 1;
             }
@@ -118,8 +113,7 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
             roll2 = randint1(6);
             roll3 = roll1 + roll2;
             choice = roll3;
-            sprintf(tmp_str, _("１振りめ: %d %d      Total: %d", "First roll: %d %d    Total: %d"), roll1, roll2, roll3);
-            prt(tmp_str, 7, 5);
+            prt(format(_("１振りめ: %d %d      Total: %d", "First roll: %d %d    Total: %d"), roll1, roll2, roll3), 7, 5);
             if ((roll3 == 7) || (roll3 == 11)) {
                 win = 1;
             } else if ((roll3 == 2) || (roll3 == 3) || (roll3 == 12)) {
@@ -132,8 +126,7 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
                     roll1 = randint1(6);
                     roll2 = randint1(6);
                     roll3 = roll1 + roll2;
-                    sprintf(tmp_str, _("出目: %d %d          合計:      %d", "Roll result: %d %d   Total:     %d"), roll1, roll2, roll3);
-                    prt(tmp_str, 8, 5);
+                    prt(format(_("出目: %d %d          合計:      %d", "Roll result: %d %d   Total:     %d"), roll1, roll2, roll3), 8, 5);
                     if (roll3 == choice) {
                         win = 1;
                     } else if (roll3 == 7) {
@@ -167,8 +160,7 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
             }
             msg_print(nullptr);
             roll1 = randint0(10);
-            sprintf(tmp_str, _("ルーレットは回り、止まった。勝者は %d番だ。", "The wheel spins to a stop and the winner is %d"), roll1);
-            prt(tmp_str, 13, 3);
+            prt(format(_("ルーレットは回り、止まった。勝者は %d番だ。", "The wheel spins to a stop and the winner is %d"), roll1), 13, 3);
             prt("", 9, 0);
             prt("*", 9, (3 * roll1 + 5));
             if (roll1 == choice) {
@@ -256,17 +248,14 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
             prt(_("あなたの勝ち", "YOU WON"), 16, 37);
 
             player_ptr->au += odds * wager;
-            sprintf(tmp_str, _("倍率: %d", "Payoff: %d"), odds);
 
-            prt(tmp_str, 17, 37);
+            prt(format(_("倍率: %d", "Payoff: %d"), odds), 17, 37);
         } else {
             prt(_("あなたの負け", "You Lost"), 16, 37);
             prt("", 17, 37);
         }
 
-        sprintf(tmp_str, _("現在の所持金:     %9ld", "Current Gold:     %9ld"), (long int)player_ptr->au);
-
-        prt(tmp_str, 22, 2);
+        prt(format(_("現在の所持金:     %9ld", "Current Gold:     %9ld"), (long int)player_ptr->au), 22, 2);
         prt(_("もう一度(Y/N)？", "Again(Y/N)?"), 18, 37);
 
         move_cursor(18, 52);

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -67,6 +67,7 @@
 #include "target/target-getter.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "timed-effect/player-stun.h"
 #include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
@@ -692,7 +693,7 @@ static MANA_POINT decide_element_mana_cost(PlayerType *player_ptr, mind_type spe
  * @param only_browse 閲覧モードかどうか
  * @return 選んだらTRUE、選ばなかったらFALSE
  */
-bool get_element_power(PlayerType *player_ptr, SPELL_IDX *sn, bool only_browse)
+static bool get_element_power(PlayerType *player_ptr, SPELL_IDX *sn, bool only_browse)
 {
     SPELL_IDX i;
     int num = 0;
@@ -781,8 +782,6 @@ bool get_element_power(PlayerType *player_ptr, SPELL_IDX *sn, bool only_browse)
         int spell_max = enum2i(ElementSpells::MAX);
         if ((choice == ' ') || (choice == '*') || (choice == '?') || (use_menu && should_redraw_cursor)) {
             if (!redraw || use_menu) {
-                char desc[80];
-                char name[80];
                 redraw = true;
                 if (!only_browse && !use_menu) {
                     screen_save();
@@ -803,19 +802,20 @@ bool get_element_power(PlayerType *player_ptr, SPELL_IDX *sn, bool only_browse)
                     int mana_cost = decide_element_mana_cost(player_ptr, spell);
                     get_element_effect_info(player_ptr, i, comment);
 
+                    std::string desc;
                     if (use_menu) {
                         if (i == (menu_line - 1)) {
-                            strcpy(desc, _("  》 ", "  >  "));
+                            desc = _("  》 ", "  >  ");
                         } else {
-                            strcpy(desc, "     ");
+                            desc = "     ";
                         }
                     } else {
-                        sprintf(desc, "  %c) ", I2A(i));
+                        desc = format("  %c) ", I2A(i));
                     }
 
                     concptr s = get_element_name(player_ptr->element, elem);
-                    sprintf(name, spell.name, s);
-                    strcat(desc, format("%-30s%2d %4d %3d%%%s", name, spell.min_lev, mana_cost, chance, comment));
+                    std::string name = format(spell.name, s);
+                    desc.append(format("%-30s%2d %4d %3d%%%s", name.data(), spell.min_lev, mana_cost, chance, comment));
                     prt(desc, y + i + 1, x);
                 }
 
@@ -1114,7 +1114,6 @@ bool has_element_resist(PlayerType *player_ptr, ElementRealmType realm, PLAYER_L
  */
 static void display_realm_cursor(int i, int n, term_color_type color)
 {
-    char cur[80];
     char sym;
     concptr name;
     if (i == n) {
@@ -1124,9 +1123,8 @@ static void display_realm_cursor(int i, int n, term_color_type color)
         sym = I2A(i);
         name = element_types.at(i2enum<ElementRealmType>(i + 1)).title.data();
     }
-    sprintf(cur, "%c) %s", sym, name);
 
-    c_put_str(color, cur, 12 + (i / 5), 2 + 15 * (i % 5));
+    c_put_str(color, format("%c) %s", sym, name), 12 + (i / 5), 2 + 15 * (i % 5));
 }
 
 /*!
@@ -1181,8 +1179,7 @@ static int get_element_realm(PlayerType *player_ptr, int is, int n)
     int os = cs;
     int k;
 
-    char buf[80];
-    sprintf(buf, _("領域を選んで下さい(%c-%c) ('='初期オプション設定): ", "Choose a realm (%c-%c) ('=' for options): "), I2A(0), I2A(n - 1));
+    std::string buf = format(_("領域を選んで下さい(%c-%c) ('='初期オプション設定): ", "Choose a realm (%c-%c) ('=' for options): "), I2A(0), I2A(n - 1));
 
     while (true) {
         display_realm_cursor(os, n, TERM_WHITE);

--- a/src/mind/mind-power-getter.cpp
+++ b/src/mind/mind-power-getter.cpp
@@ -16,6 +16,7 @@
 #include "player/player-status-table.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "timed-effect/player-stun.h"
 #include "timed-effect/timed-effects.h"
 #include "util/enum-converter.h"
@@ -256,20 +257,19 @@ void MindPowerGetter::display_each_mind_chance()
         calculate_mind_chance(has_weapon);
         char comment[80];
         mindcraft_info(this->player_ptr, comment, this->use_mind, this->index);
-        char psi_desc[80];
+        std::string psi_desc;
         if (use_menu) {
             if (this->index == (this->menu_line - 1)) {
-                strcpy(psi_desc, _("  》 ", "  >  "));
+                psi_desc = _("  》 ", "  >  ");
             } else {
-                strcpy(psi_desc, "     ");
+                psi_desc = "     ";
             }
         } else {
-            sprintf(psi_desc, "  %c) ", I2A(this->index));
+            psi_desc = format("  %c) ", I2A(this->index));
         }
 
-        strcat(psi_desc,
-            format("%-30s%2d %4d%s %3d%%%s", this->spell->name, this->spell->min_lev, mana_cost,
-                (((this->use_mind == MindKindType::MINDCRAFTER) && (this->index == 13)) ? _("～", "~ ") : "  "), chance, comment));
+        psi_desc.append(format("%-30s%2d %4d%s %3d%%%s", this->spell->name, this->spell->min_lev, mana_cost,
+            (((this->use_mind == MindKindType::MINDCRAFTER) && (this->index == 13)) ? _("～", "~ ") : "  "), chance, comment));
         prt(psi_desc, y + this->index + 1, x);
     }
 }

--- a/src/mind/mind-sniper.cpp
+++ b/src/mind/mind-sniper.cpp
@@ -35,6 +35,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/buffer-shaper.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
@@ -214,13 +215,10 @@ void display_snipe_list(PlayerType *player_ptr)
             continue;
         }
 
-        sprintf(psi_desc, "  %c) %-30s%2d %4d", I2A(i), spell.name, spell.min_lev, spell.mana_cost);
+        strnfmt(psi_desc, sizeof(psi_desc), "  %c) %-30s%2d %4d", I2A(i), spell.name, spell.min_lev, spell.mana_cost);
 
-        if (spell.mana_cost > sniper_data->concent) {
-            term_putstr(x, y + i + 1, -1, TERM_SLATE, psi_desc);
-        } else {
-            term_putstr(x, y + i + 1, -1, TERM_WHITE, psi_desc);
-        }
+        TERM_COLOR tcol = (spell.mana_cost > sniper_data->concent) ? TERM_SLATE : TERM_WHITE;
+        term_putstr(x, y + i + 1, -1, tcol, psi_desc);
     }
 }
 
@@ -302,8 +300,6 @@ static int get_snipe_power(PlayerType *player_ptr, COMMAND_CODE *sn, bool only_b
         if ((choice == ' ') || (choice == '*') || (choice == '?')) {
             /* Show the list */
             if (!redraw) {
-                char psi_index[6];
-                char psi_desc[75];
                 redraw = true;
                 if (!only_browse) {
                     screen_save();
@@ -324,21 +320,12 @@ static int get_snipe_power(PlayerType *player_ptr, COMMAND_CODE *sn, bool only_b
 
                     /* Dump the spell --(-- */
                     if (spell.min_lev > plev) {
-                        sprintf(psi_index, "   ) ");
-                    } else {
-                        sprintf(psi_index, "  %c) ", I2A(i));
-                    }
-
-                    sprintf(psi_desc, "%-30s%2d %4d", spell.name, spell.min_lev, spell.mana_cost);
-
-                    if (spell.min_lev > plev) {
                         tcol = TERM_SLATE;
                     } else if (spell.mana_cost > sniper_data->concent) {
                         tcol = TERM_L_BLUE;
                     }
-
-                    term_putstr(x, y + i + 1, -1, tcol, psi_index);
-                    term_putstr(x + 5, y + i + 1, -1, tcol, psi_desc);
+                    term_putstr(x, y + i + 1, -1, tcol, (spell.min_lev > plev) ? "   ) " : format("  %c) ", I2A(i)));
+                    term_putstr(x + 5, y + i + 1, -1, tcol, format("%-30s%2d %4d", spell.name, spell.min_lev, spell.mana_cost));
                 }
 
                 /* Clear the bottom line */

--- a/src/mind/mind-weaponsmith.cpp
+++ b/src/mind/mind-weaponsmith.cpp
@@ -23,6 +23,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/bit-flags-calculator.h"
 #include "util/buffer-shaper.h"
 #include "util/int-char-converter.h"
@@ -471,14 +472,10 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
             }
             o_ptr->pval = 1;
         } else if (o_ptr->pval == 0) {
-            char tmp[80];
-            char tmp_val[8];
+            char tmp_val[8] = "1";
             auto limit = std::min(5, smith.get_addable_count(effect, o_ptr));
 
-            sprintf(tmp, _("いくつ付加しますか？ (1-%d): ", "Enchant how many? (1-%d): "), limit);
-            strcpy(tmp_val, "1");
-
-            if (!get_string(tmp, tmp_val, 1)) {
+            if (!get_string(format(_("いくつ付加しますか？ (1-%d): ", "Enchant how many? (1-%d): "), limit), tmp_val, 1)) {
                 return;
             }
             o_ptr->pval = static_cast<PARAMETER_VALUE>(std::clamp(atoi(tmp_val), 1, limit));

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -155,9 +155,7 @@ bool MonsterDamageProcessor::process_dead_exp_virtue(concptr note, MonsterEntity
     AvatarChanger ac(player_ptr, m_ptr);
     ac.change_virtue();
     if (r_ref.kind_flags.has(MonsterKindType::UNIQUE) && record_destroy_uniq) {
-        char note_buf[160];
-        sprintf(note_buf, "%s%s", r_ref.name.data(), m_ptr->mflag2.has(MonsterConstantFlagType::CLONED) ? _("(クローン)", "(Clone)") : "");
-        exe_write_diary(this->player_ptr, DIARY_UNIQUE, 0, note_buf);
+        exe_write_diary(this->player_ptr, DIARY_UNIQUE, 0, std::string(r_ref.name).append(m_ptr->mflag2.has(MonsterConstantFlagType::CLONED) ? _("(クローン)", "(Clone)") : "").data());
     }
 
     sound(SOUND_KILL);

--- a/src/monster/monster-describer.cpp
+++ b/src/monster/monster-describer.cpp
@@ -225,9 +225,9 @@ void monster_desc(PlayerType *player_ptr, char *desc, MonsterEntity *m_ptr, BIT_
     }
 
     if (m_ptr->nickname) {
-        char buf[128];
-        sprintf(buf, _("「%s」", " called %s"), quark_str(m_ptr->nickname));
-        strcat(desc, buf);
+        std::string buf = _("「", " called ");
+        buf.append(quark_str(m_ptr->nickname)).append(_("」", ""));
+        strcat(desc, buf.data());
     }
 
     if (player_ptr->riding && (&floor_ptr->m_list[player_ptr->riding] == m_ptr)) {

--- a/src/perception/identification.cpp
+++ b/src/perception/identification.cpp
@@ -39,7 +39,6 @@ bool screen_object(PlayerType *player_ptr, ItemEntity *o_ptr, BIT_FLAGS mode)
     char temp[70 * 20];
     concptr info[128];
     GAME_TEXT o_name[MAX_NLEN];
-    char desc[256];
 
     int trivial_info = 0;
     auto flgs = object_flags(o_ptr);
@@ -145,21 +144,25 @@ bool screen_object(PlayerType *player_ptr, ItemEntity *o_ptr, BIT_FLAGS mode)
         rad++;
     }
 
+    std::string desc;
     if (flgs.has(TR_LITE_FUEL) && flgs.has_not(TR_DARK_SOURCE)) {
         if (rad > 0) {
-            sprintf(desc, _("それは燃料補給によって明かり(半径 %d)を授ける。", "It provides light (radius %d) when fueled."), (int)rad);
+            desc = _("それは燃料補給によって明かり(半径 ", "It provides light (radius ");
+            desc.append(std::to_string((int)rad)).append(_(")を授ける。", ") when fueled."));
         }
     } else {
         if (rad > 0) {
-            sprintf(desc, _("それは永遠なる明かり(半径 %d)を授ける。", "It provides light (radius %d) forever."), (int)rad);
+            desc = _("それは永遠なる明かり(半径 ", "It provides light (radius ");
+            desc.append(std::to_string((int)rad)).append(_(")を授ける。", ") forever."));
         }
         if (rad < 0) {
-            sprintf(desc, _("それは明かりの半径を狭める(半径に-%d)。", "It decreases the radius of your light by %d."), (int)-rad);
+            desc = _("それは明かりの半径を狭める(半径に-", "It decreases the radius of your light by");
+            desc.append(std::to_string((int)-rad)).append(_(")。", "."));
         }
     }
 
     if (rad != 0) {
-        info[i++] = desc;
+        info[i++] = desc.data();
     }
 
     if (o_ptr->ego_idx == EgoType::LITE_LONG) {

--- a/src/player/eldritch-horror.cpp
+++ b/src/player/eldritch-horror.cpp
@@ -152,7 +152,7 @@ void sanity_blast(PlayerType *player_ptr, MonsterEntity *m_ptr, bool necro)
         }
     } else if (!necro) {
         MonsterRaceInfo *r_ptr;
-        GAME_TEXT m_name[MAX_NLEN];
+        std::string m_name;
         concptr desc;
         get_mon_num_prep(player_ptr, get_nightmare, nullptr);
         r_ptr = &monraces_info[get_mon_num(player_ptr, 0, MAX_DEPTH, 0)];
@@ -163,10 +163,10 @@ void sanity_blast(PlayerType *player_ptr, MonsterEntity *m_ptr, bool necro)
 #else
 
         if (r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE)) {
-            sprintf(m_name, "%s %s", (is_a_vowel(desc[0]) ? "an" : "a"), desc);
-        } else
+            m_name = (is_a_vowel(desc[0])) ? "an " : "a ";
+        }
 #endif
-        sprintf(m_name, "%s", desc);
+        m_name.append(desc);
 
         if (r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE)) {
             if (r_ptr->flags1 & RF1_FRIENDS) {
@@ -177,12 +177,12 @@ void sanity_blast(PlayerType *player_ptr, MonsterEntity *m_ptr, bool necro)
         }
 
         if (saving_throw(player_ptr->skill_sav * 100 / power)) {
-            msg_format(_("夢の中で%sに追いかけられた。", "%^s chases you through your dreams."), m_name);
+            msg_format(_("夢の中で%sに追いかけられた。", "%^s chases you through your dreams."), m_name.data());
             return;
         }
 
         if (player_ptr->effects()->hallucination()->is_hallucinated()) {
-            msg_format(_("%s%sの顔を見てしまった！", "You behold the %s visage of %s!"), funny_desc[randint0(MAX_SAN_FUNNY)], m_name);
+            msg_format(_("%s%sの顔を見てしまった！", "You behold the %s visage of %s!"), funny_desc[randint0(MAX_SAN_FUNNY)], m_name.data());
             if (one_in_(3)) {
                 msg_print(funny_comments[randint0(MAX_SAN_COMMENT)]);
                 BadStatusSetter(player_ptr).mod_hallucination(randint1(r_ptr->level));

--- a/src/player/patron.cpp
+++ b/src/player/patron.cpp
@@ -143,7 +143,6 @@ Patron::Patron(const char *name, std::vector<patron_reward> reward_table, player
 void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
 {
     this->player_ptr = player_ptr_;
-    char wrath_reason[32] = "";
     int nasty_chance = 6;
     int type;
     patron_reward effect;
@@ -183,7 +182,8 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
     }
     type--;
 
-    sprintf(wrath_reason, _("%sの怒り", "the Wrath of %s"), this->name.data());
+    std::string wrath_reason = _(this->name, "the Wrath of ");
+    wrath_reason.append(_("の怒り", this->name));
 
     effect = this->reward_table[type];
 
@@ -375,7 +375,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             msg_print(_("「苦しむがよい、無能な愚か者よ！」", "'Suffer, pathetic fool!'"));
 
             fire_ball(player_ptr, AttributeType::DISINTEGRATE, 0, this->player_ptr->lev * 4, 4);
-            take_hit(player_ptr, DAMAGE_NOESCAPE, this->player_ptr->lev * 4, wrath_reason);
+            take_hit(player_ptr, DAMAGE_NOESCAPE, this->player_ptr->lev * 4, wrath_reason.data());
             reward = _("分解の球が発生した。", "generating disintegration ball");
             break;
 
@@ -476,7 +476,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             msg_format(_("%sの声が轟き渡った:", "The voice of %s thunders:"), this->name.data());
             msg_print(_("「死ぬがよい、下僕よ！」", "'Die, mortal!'"));
 
-            take_hit(player_ptr, DAMAGE_LOSELIFE, this->player_ptr->lev * 4, wrath_reason);
+            take_hit(player_ptr, DAMAGE_LOSELIFE, this->player_ptr->lev * 4, wrath_reason.data());
             for (int stat = 0; stat < A_MAX; stat++) {
                 (void)dec_stat(player_ptr, stat, 10 + randint1(15), false);
             }

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -297,7 +297,6 @@ int take_hit(PlayerType *player_ptr, int damage_type, int damage, concptr hit_fr
     int old_chp = player_ptr->chp;
 
     char death_message[1024];
-    char tmp[1024];
 
     int warning = (player_ptr->mhp * hitpoint_warn / 10);
     if (player_ptr->is_dead) {
@@ -580,8 +579,7 @@ int take_hit(PlayerType *player_ptr, int damage_type, int damage, concptr hit_fr
                 hit_from = _("何か", "something");
             }
 
-            sprintf(tmp, _("%sによってピンチに陥った。", "was in a critical situation because of %s."), hit_from);
-            exe_write_diary(player_ptr, DIARY_DESCRIPTION, 0, tmp);
+            exe_write_diary(player_ptr, DIARY_DESCRIPTION, 0, std::string(_(hit_from, "was in a critical situation because of ")).append(_("によってピンチに陥った。", hit_from)).append(_("", ".")).data());
         }
 
         if (auto_more) {

--- a/src/player/process-name.cpp
+++ b/src/player/process-name.cpp
@@ -87,16 +87,17 @@ void process_player_name(PlayerType *player_ptr, bool is_new_savefile)
 
     auto is_modified = false;
     if (is_new_savefile && (!savefile[0] || !keep_savefile)) {
-        char temp[128];
+        std::string temp;
 
 #ifdef SAVEFILE_USE_UID
         /* Rename the savefile, using the player_ptr->player_uid and player_ptr->base_name */
-        (void)sprintf(temp, "%d.%s", player_ptr->player_uid, player_ptr->base_name);
+        temp = std::to_string(player_ptr->player_uid);
+        temp.append(".").append(player_ptr->base_name);
 #else
         /* Rename the savefile, using the player_ptr->base_name */
-        (void)sprintf(temp, "%s", player_ptr->base_name);
+        temp = player_ptr->base_name;
 #endif
-        path_build(savefile, sizeof(savefile), ANGBAND_DIR_SAVE, temp);
+        path_build(savefile, sizeof(savefile), ANGBAND_DIR_SAVE, temp.data());
         is_modified = true;
     }
 

--- a/src/save/floor-writer.cpp
+++ b/src/save/floor-writer.cpp
@@ -16,6 +16,7 @@
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/sort.h"
 
@@ -239,7 +240,6 @@ bool save_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr, BIT_FLAGS mode
     uint32_t old_v_stamp = 0;
     uint32_t old_x_stamp = 0;
 
-    char floor_savefile[sizeof(savefile) + 32];
     if ((mode & SLF_SECOND) != 0) {
         old_fff = saving_savefile;
         old_xor_byte = save_xor_byte;
@@ -247,20 +247,23 @@ bool save_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr, BIT_FLAGS mode
         old_x_stamp = x_stamp;
     }
 
-    sprintf(floor_savefile, "%s.F%02d", savefile, (int)sf_ptr->savefile_id);
+    std::string floor_savefile = savefile;
+    char ext[32];
+    strnfmt(ext, sizeof(ext), ".F%02d", (int)sf_ptr->savefile_id);
+    floor_savefile.append(ext);
     safe_setuid_grab(player_ptr);
-    fd_kill(floor_savefile);
+    fd_kill(floor_savefile.data());
     safe_setuid_drop();
     saving_savefile = nullptr;
     safe_setuid_grab(player_ptr);
 
-    int fd = fd_make(floor_savefile, 0644);
+    int fd = fd_make(floor_savefile.data(), 0644);
     safe_setuid_drop();
     bool is_save_successful = false;
     if (fd >= 0) {
         (void)fd_close(fd);
         safe_setuid_grab(player_ptr);
-        saving_savefile = angband_fopen(floor_savefile, "wb");
+        saving_savefile = angband_fopen(floor_savefile.data(), "wb");
         safe_setuid_drop();
         if (saving_savefile) {
             if (save_floor_aux(player_ptr, sf_ptr)) {
@@ -274,7 +277,7 @@ bool save_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr, BIT_FLAGS mode
 
         if (!is_save_successful) {
             safe_setuid_grab(player_ptr);
-            (void)fd_kill(floor_savefile);
+            (void)fd_kill(floor_savefile.data());
             safe_setuid_drop();
         }
     }

--- a/src/spell/spell-info.cpp
+++ b/src/spell/spell-info.cpp
@@ -15,6 +15,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "timed-effect/player-stun.h"
 #include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
@@ -254,8 +255,6 @@ void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell, SPELL_IDX *spe
 
     int i;
     const magic_type *s_ptr;
-    char info[80];
-    char out_val[160];
     char ryakuji[5];
     bool max = false;
     for (i = 0; i < num; i++) {
@@ -296,25 +295,25 @@ void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell, SPELL_IDX *spe
             ryakuji[4] = '\0';
         }
 
+        std::string out_val;
         if (use_menu && target_spell) {
             if (i == (target_spell - 1)) {
-                strcpy(out_val, _("  》 ", "  >  "));
+                out_val = _("  》 ", "  >  ");
             } else {
-                strcpy(out_val, "     ");
+                out_val = "     ";
             }
         } else {
-            sprintf(out_val, "  %c) ", I2A(i));
+            out_val = format("  %c) ", I2A(i));
         }
 
         if (s_ptr->slevel >= 99) {
-            strcat(out_val, format("%-30s", _("(判読不能)", "(illegible)")));
+            out_val.append(format("%-30s", _("(判読不能)", "(illegible)")));
             c_prt(TERM_L_DARK, out_val, y + i + 1, x);
             continue;
         }
 
-        const auto spell_info = exe_spell(player_ptr, use_realm, spell, SpellProcessType::INFO);
-        strcpy(info, spell_info->data());
-        concptr comment = info;
+        const auto info = exe_spell(player_ptr, use_realm, spell, SpellProcessType::INFO);
+        concptr comment = info->data();
         byte line_attr = TERM_WHITE;
         if (pc.is_every_magic()) {
             if (s_ptr->slevel > player_ptr->max_plv) {
@@ -340,11 +339,10 @@ void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell, SPELL_IDX *spe
 
         const auto spell_name = exe_spell(player_ptr, use_realm, spell, SpellProcessType::NAME);
         if (use_realm == REALM_HISSATSU) {
-            strcat(out_val, format("%-25s %2d %4d", spell_name->data(), s_ptr->slevel, need_mana));
+            out_val.append(format("%-25s %2d %4d", spell_name->data(), s_ptr->slevel, need_mana));
         } else {
-            strcat(out_val,
-                format("%-25s%c%-4s %2d %4d %3d%% %s", spell_name->data(), (max ? '!' : ' '), ryakuji, s_ptr->slevel,
-                    need_mana, spell_chance(player_ptr, spell, use_realm), comment));
+            out_val.append(format("%-25s%c%-4s %2d %4d %3d%% %s", spell_name->data(), (max ? '!' : ' '), ryakuji, s_ptr->slevel,
+                need_mana, spell_chance(player_ptr, spell, use_realm), comment));
         }
 
         c_prt(line_attr, out_val, y + i + 1, x);

--- a/src/status/shape-changer.cpp
+++ b/src/status/shape-changer.cpp
@@ -117,8 +117,8 @@ void do_poly_self(PlayerType *player_ptr)
 
     PlayerRace pr(player_ptr);
     if ((power > randint0(20)) && one_in_(3) && !pr.equals(PlayerRaceType::ANDROID)) {
-        char effect_msg[80] = "";
-        char sex_msg[32] = "";
+        std::string effect_msg;
+        std::string_view sex_msg;
         PlayerRaceType new_race;
 
         power -= 10;
@@ -127,11 +127,11 @@ void do_poly_self(PlayerType *player_ptr)
             if (player_ptr->psex == SEX_MALE) {
                 player_ptr->psex = SEX_FEMALE;
                 sp_ptr = &sex_info[player_ptr->psex];
-                sprintf(sex_msg, _("女性の", "female"));
+                sex_msg = _("女性の", "female");
             } else {
                 player_ptr->psex = SEX_MALE;
                 sp_ptr = &sex_info[player_ptr->psex];
-                sprintf(sex_msg, _("男性の", "male"));
+                sex_msg = _("男性の", "male");
             }
         }
 
@@ -148,10 +148,9 @@ void do_poly_self(PlayerType *player_ptr)
 
             (void)dec_stat(player_ptr, A_CHR, randint1(6), true);
 
-            if (sex_msg[0]) {
-                sprintf(effect_msg, _("奇形の%s", "deformed %s "), sex_msg);
-            } else {
-                sprintf(effect_msg, _("奇形の", "deformed "));
+            effect_msg = _("奇形の", "deformed ");
+            if (!sex_msg.empty()) {
+                effect_msg.append(sex_msg).append(_("", " "));
             }
         }
 
@@ -167,7 +166,7 @@ void do_poly_self(PlayerType *player_ptr)
             new_race = (PlayerRaceType)randint0(MAX_RACES);
         } while (pr.equals(new_race) || (new_race == PlayerRaceType::ANDROID));
 
-        change_race(player_ptr, new_race, effect_msg);
+        change_race(player_ptr, new_race, effect_msg.data());
     }
 
     if ((power > randint0(30)) && one_in_(6)) {

--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -70,21 +70,21 @@ static std::optional<PRICE> prompt_to_buy(PlayerType *player_ptr, ItemEntity *o_
  */
 static bool show_store_select_item(COMMAND_CODE *item, const int i, StoreSaleType store_num)
 {
-    char out_val[160];
+    concptr prompt;
 
     switch (store_num) {
     case StoreSaleType::HOME:
-        sprintf(out_val, _("どのアイテムを取りますか? ", "Which item do you want to take? "));
+        prompt = _("どのアイテムを取りますか? ", "Which item do you want to take? ");
         break;
     case StoreSaleType::BLACK:
-        sprintf(out_val, _("どれ? ", "Which item, huh? "));
+        prompt = _("どれ? ", "Which item, huh? ");
         break;
     default:
-        sprintf(out_val, _("どの品物が欲しいんだい? ", "Which item are you interested in? "));
+        prompt = _("どの品物が欲しいんだい? ", "Which item are you interested in? ");
         break;
     }
 
-    return get_stock(item, out_val, 0, i - 1, store_num) != 0;
+    return get_stock(item, prompt, 0, i - 1, store_num) != 0;
 }
 
 /*!
@@ -140,15 +140,11 @@ static void shuffle_store(PlayerType *player_ptr, StoreSaleType store_num)
         return;
     }
 
-    char buf[80];
-
     msg_print(_("店主は引退した。", "The shopkeeper retires."));
     store_shuffle(player_ptr, store_num);
     prt("", 3, 0);
-    sprintf(buf, "%s (%s)", ot_ptr->owner_name, race_info[enum2i(ot_ptr->owner_race)].title);
-    put_str(buf, 3, 10);
-    sprintf(buf, "%s (%ld)", terrains_info[cur_store_feat].name.data(), (long)(ot_ptr->max_cost));
-    prt(buf, 3, 50);
+    put_str(format("%s (%s)", ot_ptr->owner_name, race_info[enum2i(ot_ptr->owner_race)].title), 3, 10);
+    prt(format("%s (%ld)", terrains_info[cur_store_feat].name.data(), (long)(ot_ptr->max_cost)), 3, 50);
 }
 
 static void switch_store_stock(PlayerType *player_ptr, const int i, const COMMAND_CODE item, StoreSaleType store_num)

--- a/src/view/display-player-middle.cpp
+++ b/src/view/display-player-middle.cpp
@@ -25,6 +25,7 @@
 #include "system/monster-entity.h"
 #include "system/player-type-definition.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "timed-effect/player-deceleration.h"
 #include "timed-effect/timed-effects.h"
 #include "view/display-util.h"
@@ -52,9 +53,7 @@ static void display_player_melee_bonus(PlayerType *player_ptr, int hand, int han
 
     show_tohit += player_ptr->skill_thn / BTH_PLUS_ADJ;
 
-    char buf[160];
-    sprintf(buf, "(%+d,%+d)", (int)show_tohit, (int)show_todam);
-
+    std::string buf = format("(%+d,%+d)", (int)show_tohit, (int)show_todam);
     if (!has_melee_weapon(player_ptr, INVEN_MAIN_HAND) && !has_melee_weapon(player_ptr, INVEN_SUB_HAND)) {
         display_player_one_line(ENTRY_BARE_HAND, buf, TERM_L_BLUE);
     } else if (has_two_handed_weapons(player_ptr)) {
@@ -220,16 +219,16 @@ static int calc_temporary_speed(PlayerType *player_ptr)
  */
 static void display_player_speed(PlayerType *player_ptr, TERM_COLOR attr, int base_speed, int tmp_speed)
 {
-    char buf[160];
+    std::string buf;
     if (tmp_speed) {
         if (!player_ptr->riding) {
             if (player_ptr->lightspeed) {
-                sprintf(buf, _("光速化 (+99)", "Lightspeed (+99)"));
+                buf = _("光速化 (+99)", "Lightspeed (+99)");
             } else {
-                sprintf(buf, "(%+d%+d)", base_speed - tmp_speed, tmp_speed);
+                buf = format("(%+d%+d)", base_speed - tmp_speed, tmp_speed);
             }
         } else {
-            sprintf(buf, _("乗馬中 (%+d%+d)", "Riding (%+d%+d)"), base_speed - tmp_speed, tmp_speed);
+            buf = format(_("乗馬中 (%+d%+d)", "Riding (%+d%+d)"), base_speed - tmp_speed, tmp_speed);
         }
 
         if (tmp_speed > 0) {
@@ -239,9 +238,9 @@ static void display_player_speed(PlayerType *player_ptr, TERM_COLOR attr, int ba
         }
     } else {
         if (!player_ptr->riding) {
-            sprintf(buf, "(%+d)", base_speed);
+            buf = format("(%+d)", base_speed);
         } else {
-            sprintf(buf, _("乗馬中 (%+d)", "Riding (%+d)"), base_speed);
+            buf = format(_("乗馬中 (%+d)", "Riding (%+d)"), base_speed);
         }
     }
 
@@ -287,11 +286,11 @@ static void display_playtime_in_game(PlayerType *player_ptr)
     int day, hour, min;
     extract_day_hour_min(player_ptr, &day, &hour, &min);
 
-    char buf[160];
+    std::string buf;
     if (day < MAX_DAYS) {
-        sprintf(buf, _("%d日目 %2d:%02d", "Day %d %2d:%02d"), day, hour, min);
+        buf = format(_("%d日目 %2d:%02d", "Day %d %2d:%02d"), day, hour, min);
     } else {
-        sprintf(buf, _("*****日目 %2d:%02d", "Day ***** %2d:%02d"), hour, min);
+        buf = format(_("*****日目 %2d:%02d", "Day ***** %2d:%02d"), hour, min);
     }
 
     display_player_one_line(ENTRY_DAY, buf, TERM_L_GREEN);

--- a/src/view/display-player-misc-info.cpp
+++ b/src/view/display-player-misc-info.cpp
@@ -5,6 +5,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "view/display-player-stat-info.h"
 
 /*!
@@ -19,17 +20,8 @@ void display_player_misc_info(PlayerType *player_ptr)
     put_str(_("種族  :", "Race  :"), 4, 1);
     put_str(_("職業  :", "Class :"), 5, 1);
 
-    char buf[80];
-    char tmp[80];
-    strcpy(tmp, ap_ptr->title);
-#ifdef JP
-    if (ap_ptr->no == 1) {
-        strcat(tmp, "の");
-    }
-#else
-    strcat(tmp, " ");
-#endif
-    strcat(tmp, player_ptr->name);
+    std::string tmp = ap_ptr->title;
+    tmp.append(_(ap_ptr->no == 1 ? "の" : "", " ")).append(player_ptr->name);
 
     c_put_str(TERM_L_BLUE, tmp, 1, 34);
     c_put_str(TERM_L_BLUE, sp_ptr->title, 3, 9);
@@ -40,10 +32,7 @@ void display_player_misc_info(PlayerType *player_ptr)
     put_str(_("ＨＰ  :", "Hits  :"), 7, 1);
     put_str(_("ＭＰ  :", "Mana  :"), 8, 1);
 
-    (void)sprintf(buf, "%d", (int)player_ptr->lev);
-    c_put_str(TERM_L_BLUE, buf, 6, 9);
-    (void)sprintf(buf, "%d/%d", (int)player_ptr->chp, (int)player_ptr->mhp);
-    c_put_str(TERM_L_BLUE, buf, 7, 9);
-    (void)sprintf(buf, "%d/%d", (int)player_ptr->csp, (int)player_ptr->msp);
-    c_put_str(TERM_L_BLUE, buf, 8, 9);
+    c_put_str(TERM_L_BLUE, format("%d", (int)player_ptr->lev), 6, 9);
+    c_put_str(TERM_L_BLUE, format("%d/%d", (int)player_ptr->chp, (int)player_ptr->mhp), 7, 9);
+    c_put_str(TERM_L_BLUE, format("%d/%d", (int)player_ptr->csp, (int)player_ptr->msp), 8, 9);
 }

--- a/src/view/display-player-stat-info.cpp
+++ b/src/view/display-player-stat-info.cpp
@@ -22,6 +22,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "util/bit-flags-calculator.h"
 
 /*!
@@ -123,17 +124,13 @@ static void display_basic_stat_name(PlayerType *player_ptr, int stat_num, int ro
  */
 static void display_basic_stat_value(PlayerType *player_ptr, int stat_num, int r_adj, int e_adj, int row, int stat_col, char *buf)
 {
-    (void)sprintf(buf, "%3d", r_adj);
-    c_put_str(TERM_L_BLUE, buf, row + stat_num + 1, stat_col + 13);
+    c_put_str(TERM_L_BLUE, format("%3d", r_adj), row + stat_num + 1, stat_col + 13);
 
-    (void)sprintf(buf, "%3d", (int)cp_ptr->c_adj[stat_num]);
-    c_put_str(TERM_L_BLUE, buf, row + stat_num + 1, stat_col + 16);
+    c_put_str(TERM_L_BLUE, format("%3d", (int)cp_ptr->c_adj[stat_num]), row + stat_num + 1, stat_col + 16);
 
-    (void)sprintf(buf, "%3d", (int)ap_ptr->a_adj[stat_num]);
-    c_put_str(TERM_L_BLUE, buf, row + stat_num + 1, stat_col + 19);
+    c_put_str(TERM_L_BLUE, format("%3d", (int)ap_ptr->a_adj[stat_num]), row + stat_num + 1, stat_col + 19);
 
-    (void)sprintf(buf, "%3d", (int)e_adj);
-    c_put_str(TERM_L_BLUE, buf, row + stat_num + 1, stat_col + 22);
+    c_put_str(TERM_L_BLUE, format("%3d", (int)e_adj), row + stat_num + 1, stat_col + 22);
 
     cnv_stat(player_ptr->stat_top[stat_num], buf);
     c_put_str(TERM_L_GREEN, buf, row + stat_num + 1, stat_col + 26);

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -82,12 +82,8 @@ static bool display_player_info(PlayerType *player_ptr, int mode)
  */
 static void display_player_basic_info(PlayerType *player_ptr)
 {
-    char tmp[64];
-#ifdef JP
-    sprintf(tmp, "%s%s%s", ap_ptr->title, ap_ptr->no == 1 ? "の" : "", player_ptr->name);
-#else
-    sprintf(tmp, "%s %s", ap_ptr->title, player_ptr->name);
-#endif
+    std::string tmp = ap_ptr->title;
+    tmp.append(_(ap_ptr->no == 1 ? "の" : "", " ")).append(player_ptr->name);
 
     display_player_one_line(ENTRY_NAME, tmp, TERM_L_BLUE);
     display_player_one_line(ENTRY_SEX, sp_ptr->title, TERM_L_BLUE);
@@ -105,13 +101,14 @@ static void display_magic_realms(PlayerType *player_ptr)
         return;
     }
 
-    char tmp[64];
+    std::string tmp;
     if (PlayerClass(player_ptr).equals(PlayerClassType::ELEMENTALIST)) {
-        sprintf(tmp, "%s", get_element_title(player_ptr->element));
+        tmp = get_element_title(player_ptr->element);
     } else if (player_ptr->realm2) {
-        sprintf(tmp, "%s, %s", realm_names[player_ptr->realm1], realm_names[player_ptr->realm2]);
+        tmp = realm_names[player_ptr->realm1];
+        tmp.append(", ").append(realm_names[player_ptr->realm2]);
     } else {
-        strcpy(tmp, realm_names[player_ptr->realm1]);
+        tmp = realm_names[player_ptr->realm1];
     }
 
     display_player_one_line(ENTRY_REALM, tmp, TERM_L_BLUE);

--- a/src/view/display-self-info.cpp
+++ b/src/view/display-self-info.cpp
@@ -7,15 +7,17 @@
 #include "player/player-status-table.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
+#include "util/string-processor.h"
 #include <string>
 
 void display_life_rating(PlayerType *player_ptr, self_info_type *self_ptr)
 {
     player_ptr->knowledge |= KNOW_STAT | KNOW_HPRATE;
-    strcpy(self_ptr->plev_buf, "");
+    angband_strcpy(self_ptr->plev_buf, "", sizeof(self_ptr->plev_buf));
     int percent = (int)(((long)player_ptr->player_hp[PY_MAX_LEVEL - 1] * 200L) / (2 * player_ptr->hitdie + ((PY_MAX_LEVEL - 1 + 3) * (player_ptr->hitdie + 1))));
-    sprintf(self_ptr->plev_buf, _("現在の体力ランク : %d/100", "Your current Life Rating is %d/100."), percent);
-    strcpy(self_ptr->buf[0], self_ptr->plev_buf);
+    strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("現在の体力ランク : %d/100", "Your current Life Rating is %d/100."), percent);
+    angband_strcpy(self_ptr->buf[0], self_ptr->plev_buf, sizeof(self_ptr->buf[0]));
     self_ptr->info[self_ptr->line++] = self_ptr->buf[0];
     self_ptr->info[self_ptr->line++] = "";
 }
@@ -24,9 +26,7 @@ void display_max_base_status(PlayerType *player_ptr, self_info_type *self_ptr)
 {
     self_ptr->info[self_ptr->line++] = _("能力の最大値", "Limits of maximum stats");
     for (int v_nr = 0; v_nr < A_MAX; v_nr++) {
-        char stat_desc[80];
-        sprintf(stat_desc, "%s 18/%d", stat_names[v_nr], player_ptr->stat_max_max[v_nr] - 18);
-        strcpy(self_ptr->s_string[v_nr], stat_desc);
+        strnfmt(self_ptr->s_string[v_nr], sizeof(self_ptr->s_string[v_nr]), "%s 18/%d", stat_names[v_nr], player_ptr->stat_max_max[v_nr] - 18);
         self_ptr->info[self_ptr->line++] = self_ptr->s_string[v_nr];
     }
 }
@@ -35,44 +35,42 @@ void display_virtue(PlayerType *player_ptr, self_info_type *self_ptr)
 {
     self_ptr->info[self_ptr->line++] = "";
     std::string alg = PlayerAlignment(player_ptr).get_alignment_description(true);
-    sprintf(self_ptr->plev_buf, _("現在の属性 : %s", "Your alignment : %s"), alg.data());
-    strcpy(self_ptr->buf[1], self_ptr->plev_buf);
+    strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("現在の属性 : %s", "Your alignment : %s"), alg.data());
+    angband_strcpy(self_ptr->buf[1], self_ptr->plev_buf, sizeof(self_ptr->buf[1]));
     self_ptr->info[self_ptr->line++] = self_ptr->buf[1];
     for (int v_nr = 0; v_nr < 8; v_nr++) {
-        GAME_TEXT vir_name[20];
-        char vir_desc[80];
+        concptr vir_name = virtue[(player_ptr->vir_types[v_nr]) - 1];
+        std::string vir_desc = format(_("おっと。%sの情報なし。", "Oops. No info about %s."), vir_name);
         int tester = player_ptr->virtues[v_nr];
-        strcpy(vir_name, virtue[(player_ptr->vir_types[v_nr]) - 1]);
-        sprintf(vir_desc, _("おっと。%sの情報なし。", "Oops. No info about %s."), vir_name);
         if (tester < -100) {
-            sprintf(vir_desc, _("[%s]の対極 (%d)", "You are the polar opposite of %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の対極 (%d)", "You are the polar opposite of %s (%d)."), vir_name, tester);
         } else if (tester < -80) {
-            sprintf(vir_desc, _("[%s]の大敵 (%d)", "You are an arch-enemy of %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の大敵 (%d)", "You are an arch-enemy of %s (%d)."), vir_name, tester);
         } else if (tester < -60) {
-            sprintf(vir_desc, _("[%s]の強敵 (%d)", "You are a bitter enemy of %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の強敵 (%d)", "You are a bitter enemy of %s (%d)."), vir_name, tester);
         } else if (tester < -40) {
-            sprintf(vir_desc, _("[%s]の敵 (%d)", "You are an enemy of %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の敵 (%d)", "You are an enemy of %s (%d)."), vir_name, tester);
         } else if (tester < -20) {
-            sprintf(vir_desc, _("[%s]の罪者 (%d)", "You have sinned against %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の罪者 (%d)", "You have sinned against %s (%d)."), vir_name, tester);
         } else if (tester < 0) {
-            sprintf(vir_desc, _("[%s]の迷道者 (%d)", "You have strayed from the path of %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の迷道者 (%d)", "You have strayed from the path of %s (%d)."), vir_name, tester);
         } else if (tester == 0) {
-            sprintf(vir_desc, _("[%s]の中立者 (%d)", "You are neutral to %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の中立者 (%d)", "You are neutral to %s (%d)."), vir_name, tester);
         } else if (tester < 20) {
-            sprintf(vir_desc, _("[%s]の小徳者 (%d)", "You are somewhat virtuous in %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の小徳者 (%d)", "You are somewhat virtuous in %s (%d)."), vir_name, tester);
         } else if (tester < 40) {
-            sprintf(vir_desc, _("[%s]の中徳者 (%d)", "You are virtuous in %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の中徳者 (%d)", "You are virtuous in %s (%d)."), vir_name, tester);
         } else if (tester < 60) {
-            sprintf(vir_desc, _("[%s]の高徳者 (%d)", "You are very virtuous in %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の高徳者 (%d)", "You are very virtuous in %s (%d)."), vir_name, tester);
         } else if (tester < 80) {
-            sprintf(vir_desc, _("[%s]の覇者 (%d)", "You are a champion of %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の覇者 (%d)", "You are a champion of %s (%d)."), vir_name, tester);
         } else if (tester < 100) {
-            sprintf(vir_desc, _("[%s]の偉大な覇者 (%d)", "You are a great champion of %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の偉大な覇者 (%d)", "You are a great champion of %s (%d)."), vir_name, tester);
         } else {
-            sprintf(vir_desc, _("[%s]の具現者 (%d)", "You are the living embodiment of %s (%d)."), vir_name, tester);
+            vir_desc = format(_("[%s]の具現者 (%d)", "You are the living embodiment of %s (%d)."), vir_name, tester);
         }
 
-        strcpy(self_ptr->v_string[v_nr], vir_desc);
+        angband_strcpy(self_ptr->v_string[v_nr], vir_desc.data(), sizeof(self_ptr->v_string[v_nr]));
         self_ptr->info[self_ptr->line++] = self_ptr->v_string[v_nr];
     }
 }
@@ -84,7 +82,7 @@ void display_mimic_race_ability(PlayerType *player_ptr, self_info_type *self_ptr
         return;
     case MimicKindType::DEMON:
     case MimicKindType::DEMON_LORD:
-        sprintf(self_ptr->plev_buf, _("あなたは %d ダメージの地獄か火炎のブレスを吐くことができる。(%d MP)", "You can breathe nether, dam. %d (cost %d)."),
+        strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは %d ダメージの地獄か火炎のブレスを吐くことができる。(%d MP)", "You can breathe nether, dam. %d (cost %d)."),
             3 * player_ptr->lev, 10 + player_ptr->lev / 3);
 
         self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;
@@ -94,7 +92,7 @@ void display_mimic_race_ability(PlayerType *player_ptr, self_info_type *self_ptr
             break;
         }
 
-        sprintf(self_ptr->plev_buf, _("あなたは敵から %d-%d HP の生命力を吸収できる。(%d MP)", "You can steal life from a foe, dam. %d-%d (cost %d)."),
+        strnfmt(self_ptr->plev_buf, sizeof(self_ptr->plev_buf), _("あなたは敵から %d-%d HP の生命力を吸収できる。(%d MP)", "You can steal life from a foe, dam. %d-%d (cost %d)."),
             player_ptr->lev + std::max(1, player_ptr->lev / 10), player_ptr->lev + player_ptr->lev * std::max(1, player_ptr->lev / 10),
             1 + (player_ptr->lev / 3));
         self_ptr->info[self_ptr->line++] = self_ptr->plev_buf;

--- a/src/view/display-store.cpp
+++ b/src/view/display-store.cpp
@@ -17,6 +17,7 @@
 #include "system/terrain-type-definition.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/enum-converter.h"
 #include "util/int-char-converter.h"
 
@@ -29,9 +30,7 @@
 void store_prt_gold(PlayerType *player_ptr)
 {
     prt(_("手持ちのお金: ", "Gold Remaining: "), 19 + xtra_stock, 53);
-    char out_val[64];
-    sprintf(out_val, "%9ld", (long)player_ptr->au);
-    prt(out_val, 19 + xtra_stock, 68);
+    prt(format("%9ld", (long)player_ptr->au), 19 + xtra_stock, 68);
 }
 
 /*!
@@ -47,9 +46,7 @@ void display_entry(PlayerType *player_ptr, int pos, StoreSaleType store_num)
     int i = (pos % store_bottom);
 
     /* Label it, clear the line --(-- */
-    char out_val[160];
-    (void)sprintf(out_val, "%c) ", ((i > 25) ? toupper(I2A(i - 26)) : I2A(i)));
-    prt(out_val, i + 6, 0);
+    prt(format("%c) ", ((i > 25) ? toupper(I2A(i - 26)) : I2A(i))), i + 6, 0);
 
     int cur_col = 3;
     if (show_item_graph) {
@@ -78,8 +75,7 @@ void display_entry(PlayerType *player_ptr, int pos, StoreSaleType store_num)
         c_put_str(tval_to_attr[enum2i(o_ptr->bi_key.tval())], o_name, i + 6, cur_col);
         if (show_weights) {
             WEIGHT wgt = o_ptr->weight;
-            sprintf(out_val, _("%3d.%1d kg", "%3d.%d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
-            put_str(out_val, i + 6, _(67, 68));
+            put_str(format(_("%3d.%1d kg", "%3d.%d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10)), i + 6, _(67, 68));
         }
 
         return;
@@ -97,14 +93,12 @@ void display_entry(PlayerType *player_ptr, int pos, StoreSaleType store_num)
 
     if (show_weights) {
         int wgt = o_ptr->weight;
-        sprintf(out_val, "%3d.%1d", _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
-        put_str(out_val, i + 6, _(60, 61));
+        put_str(format("%3d.%1d", _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10)), i + 6, _(60, 61));
     }
 
     const auto price = price_item(player_ptr, o_ptr, ot_ptr->inflate, false, store_num);
 
-    (void)sprintf(out_val, "%9ld  ", (long)price);
-    put_str(out_val, i + 6, 68);
+    put_str(format("%9ld  ", (long)price), i + 6, 68);
 }
 
 /*!
@@ -181,12 +175,9 @@ void display_store(PlayerType *player_ptr, StoreSaleType store_num)
     concptr store_name = terrains_info[cur_store_feat].name.data();
     concptr owner_name = (ot_ptr->owner_name);
     concptr race_name = race_info[enum2i(ot_ptr->owner_race)].title;
-    char buf[80];
-    sprintf(buf, "%s (%s)", owner_name, race_name);
-    put_str(buf, 3, 10);
+    put_str(format("%s (%s)", owner_name, race_name), 3, 10);
 
-    sprintf(buf, "%s (%ld)", store_name, (long)(ot_ptr->max_cost));
-    prt(buf, 3, 50);
+    prt(format("%s (%ld)", store_name, (long)(ot_ptr->max_cost)), 3, 50);
 
     put_str(_("商品の一覧", "Item Description"), 5, 5);
     if (show_weights) {

--- a/src/window/display-sub-window-spells.cpp
+++ b/src/window/display-sub-window-spells.cpp
@@ -15,6 +15,7 @@
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "timed-effect/player-stun.h"
 #include "timed-effect/timed-effects.h"
 #include "util/int-char-converter.h"
@@ -33,7 +34,6 @@ static void display_spell_list(PlayerType *player_ptr)
     int m[9];
     const magic_type *s_ptr;
     GAME_TEXT name[MAX_NLEN];
-    char out_val[160];
 
     clear_from(0);
 
@@ -53,7 +53,6 @@ static void display_spell_list(PlayerType *player_ptr)
         PERCENTAGE chance = 0;
         mind_type spell;
         char comment[80];
-        char psi_desc[160];
         MindKindType use_mind;
         bool use_hp = false;
 
@@ -124,9 +123,8 @@ static void display_spell_list(PlayerType *player_ptr)
             }
 
             mindcraft_info(player_ptr, comment, use_mind, i);
-            sprintf(psi_desc, "  %c) %-30s%2d %4d %3d%%%s", I2A(i), spell.name, spell.min_lev, spell.mana_cost, chance, comment);
 
-            term_putstr(x, y + i + 1, -1, a, psi_desc);
+            term_putstr(x, y + i + 1, -1, a, format("  %c) %-30s%2d %4d %3d%%%s", I2A(i), spell.name, spell.min_lev, spell.mana_cost, chance, comment));
         }
 
         return;
@@ -164,10 +162,8 @@ static void display_spell_list(PlayerType *player_ptr)
                 a = TERM_YELLOW;
             }
 
-            sprintf(out_val, "%c/%c) %-20.20s", I2A(n / 8), I2A(n % 8), name);
-
             m[j] = y + n;
-            term_putstr(x, m[j], -1, a, out_val);
+            term_putstr(x, m[j], -1, a, format("%c/%c) %-20.20s", I2A(n / 8), I2A(n % 8), name));
             n++;
         }
     }

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -14,6 +14,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "timed-effect/player-hallucination.h"
 #include "timed-effect/timed-effects.h"
 #include "util/string-processor.h"
@@ -58,8 +59,7 @@ void print_title(PlayerType *player_ptr)
  */
 void print_level(PlayerType *player_ptr)
 {
-    char tmp[32];
-    sprintf(tmp, "%5d", player_ptr->lev);
+    std::string tmp = format("%5d", player_ptr->lev);
     if (player_ptr->lev >= player_ptr->max_plv) {
         put_str(_("レベル ", "LEVEL "), ROW_LEVEL, 0);
         c_put_str(TERM_L_GREEN, tmp, ROW_LEVEL, COL_LEVEL + 7);
@@ -74,16 +74,16 @@ void print_level(PlayerType *player_ptr)
  */
 void print_exp(PlayerType *player_ptr)
 {
-    char out_val[32];
+    std::string out_val;
 
     PlayerRace pr(player_ptr);
     if ((!exp_need) || pr.equals(PlayerRaceType::ANDROID)) {
-        (void)sprintf(out_val, "%8ld", (long)player_ptr->exp);
+        out_val = format("%8ld", (long)player_ptr->exp);
     } else {
         if (player_ptr->lev >= PY_MAX_LEVEL) {
-            (void)sprintf(out_val, "********");
+            out_val = "********";
         } else {
-            (void)sprintf(out_val, "%8ld", (long)(player_exp[player_ptr->lev - 1] * player_ptr->expfact / 100L) - player_ptr->exp);
+            out_val = format("%8ld", (long)(player_exp[player_ptr->lev - 1] * player_ptr->expfact / 100L) - player_ptr->exp);
         }
     }
 
@@ -105,18 +105,9 @@ void print_exp(PlayerType *player_ptr)
  */
 void print_ac(PlayerType *player_ptr)
 {
-    char tmp[32];
-
-#ifdef JP
     /* AC の表示方式を変更している */
-    put_str(" ＡＣ(     )", ROW_AC, COL_AC);
-    sprintf(tmp, "%5d", player_ptr->dis_ac + player_ptr->dis_to_a);
-    c_put_str(TERM_L_GREEN, tmp, ROW_AC, COL_AC + 6);
-#else
-    put_str("Cur AC ", ROW_AC, COL_AC);
-    sprintf(tmp, "%5d", player_ptr->dis_ac + player_ptr->dis_to_a);
-    c_put_str(TERM_L_GREEN, tmp, ROW_AC, COL_AC + 7);
-#endif
+    put_str(_(" ＡＣ(     )", "Cur AC "), ROW_AC, COL_AC);
+    c_put_str(TERM_L_GREEN, format("%5d", player_ptr->dis_ac + player_ptr->dis_to_a), ROW_AC, COL_AC + _(6, 7));
 }
 
 /*!
@@ -124,9 +115,7 @@ void print_ac(PlayerType *player_ptr)
  */
 void print_hp(PlayerType *player_ptr)
 {
-    char tmp[32];
     put_str("HP", ROW_CURHP, COL_CURHP);
-    sprintf(tmp, "%4ld", (long int)player_ptr->chp);
     TERM_COLOR color;
     if (player_ptr->chp >= player_ptr->mhp) {
         color = TERM_L_GREEN;
@@ -136,11 +125,10 @@ void print_hp(PlayerType *player_ptr)
         color = TERM_RED;
     }
 
-    c_put_str(color, tmp, ROW_CURHP, COL_CURHP + 3);
+    c_put_str(color, format("%4ld", (long int)player_ptr->chp), ROW_CURHP, COL_CURHP + 3);
     put_str("/", ROW_CURHP, COL_CURHP + 7);
-    sprintf(tmp, "%4ld", (long int)player_ptr->mhp);
     color = TERM_L_GREEN;
-    c_put_str(color, tmp, ROW_CURHP, COL_CURHP + 8);
+    c_put_str(color, format("%4ld", (long int)player_ptr->mhp), ROW_CURHP, COL_CURHP + 8);
 }
 
 /*!
@@ -148,14 +136,12 @@ void print_hp(PlayerType *player_ptr)
  */
 void print_sp(PlayerType *player_ptr)
 {
-    char tmp[32];
-    byte color;
     if ((mp_ptr->spell_book == ItemKindType::NONE) && mp_ptr->spell_first == SPELL_FIRST_NO_SPELL) {
         return;
     }
 
     put_str(_("MP", "SP"), ROW_CURSP, COL_CURSP);
-    sprintf(tmp, "%4ld", (long int)player_ptr->csp);
+    byte color;
     if (player_ptr->csp >= player_ptr->msp) {
         color = TERM_L_GREEN;
     } else if (player_ptr->csp > (player_ptr->msp * mana_warn) / 10) {
@@ -164,11 +150,10 @@ void print_sp(PlayerType *player_ptr)
         color = TERM_RED;
     }
 
-    c_put_str(color, tmp, ROW_CURSP, COL_CURSP + 3);
+    c_put_str(color, format("%4ld", (long int)player_ptr->csp), ROW_CURSP, COL_CURSP + 3);
     put_str("/", ROW_CURSP, COL_CURSP + 7);
-    sprintf(tmp, "%4ld", (long int)player_ptr->msp);
     color = TERM_L_GREEN;
-    c_put_str(color, tmp, ROW_CURSP, COL_CURSP + 8);
+    c_put_str(color, format("%4ld", (long int)player_ptr->msp), ROW_CURSP, COL_CURSP + 8);
 }
 
 /*!
@@ -177,10 +162,8 @@ void print_sp(PlayerType *player_ptr)
  */
 void print_gold(PlayerType *player_ptr)
 {
-    char tmp[32];
     put_str(_("＄ ", "AU "), ROW_GOLD, COL_GOLD);
-    sprintf(tmp, "%9ld", (long)player_ptr->au);
-    c_put_str(TERM_L_GREEN, tmp, ROW_GOLD, COL_GOLD + 3);
+    c_put_str(TERM_L_GREEN, format("%9ld", (long)player_ptr->au), ROW_GOLD, COL_GOLD + 3);
 }
 
 /*!
@@ -189,7 +172,6 @@ void print_gold(PlayerType *player_ptr)
  */
 void print_depth(PlayerType *player_ptr)
 {
-    char depths[32];
     TERM_COLOR attr = TERM_WHITE;
 
     TERM_LEN wid, hgt;
@@ -199,21 +181,20 @@ void print_depth(PlayerType *player_ptr)
 
     auto *floor_ptr = player_ptr->current_floor_ptr;
     if (!floor_ptr->dun_level) {
-        strcpy(depths, _("地上", "Surf."));
-        c_prt(attr, format("%7s", depths), row_depth, col_depth);
+        c_prt(attr, format("%7s", _("地上", "Surf.")), row_depth, col_depth);
         return;
     }
 
     if (inside_quest(floor_ptr->quest_number) && !player_ptr->dungeon_idx) {
-        strcpy(depths, _("地上", "Quest"));
-        c_prt(attr, format("%7s", depths), row_depth, col_depth);
+        c_prt(attr, format("%7s", _("地上", "Quest")), row_depth, col_depth);
         return;
     }
 
+    std::string depths;
     if (depth_in_feet) {
-        (void)sprintf(depths, _("%d ft", "%d ft"), (int)floor_ptr->dun_level * 50);
+        depths = format(_("%d ft", "%d ft"), (int)floor_ptr->dun_level * 50);
     } else {
-        (void)sprintf(depths, _("%d 階", "Lev %d"), (int)floor_ptr->dun_level);
+        depths = format(_("%d 階", "Lev %d"), (int)floor_ptr->dun_level);
     }
 
     switch (player_ptr->feeling) {
@@ -252,7 +233,7 @@ void print_depth(PlayerType *player_ptr)
         break; /* Boring place */
     }
 
-    c_prt(attr, format("%7s", depths), row_depth, col_depth);
+    c_prt(attr, format("%7s", depths.data()), row_depth, col_depth);
 }
 
 /*!

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -22,6 +22,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "term/z-form.h"
 #include "timed-effect/player-blindness.h"
 #include "timed-effect/player-confusion.h"
 #include "timed-effect/player-cut.h"
@@ -158,37 +159,38 @@ void print_hunger(PlayerType *player_ptr)
 void print_state(PlayerType *player_ptr)
 {
     TERM_COLOR attr = TERM_WHITE;
-    GAME_TEXT text[16];
+    std::string text;
     if (command_rep) {
         if (command_rep > 999) {
-            (void)sprintf(text, "%2d00", command_rep / 100);
+            text = format("%2d00", command_rep / 100);
         } else {
-            (void)sprintf(text, "  %2d", command_rep);
+            text = format("  %2d", command_rep);
         }
 
-        c_put_str(attr, format("%5.5s", text), ROW_STATE, COL_STATE);
+        c_put_str(attr, format("%5.5s", text.data()), ROW_STATE, COL_STATE);
         return;
     }
 
     switch (player_ptr->action) {
     case ACTION_SEARCH: {
-        strcpy(text, _("探索", "Sear"));
+        text = _("探索", "Sear");
         break;
     }
     case ACTION_REST:
-        strcpy(text, _("    ", "    "));
         if (player_ptr->resting > 0) {
-            sprintf(text, "%4d", player_ptr->resting);
+            text = format("%4d", player_ptr->resting);
         } else if (player_ptr->resting == COMMAND_ARG_REST_FULL_HEALING) {
-            text[0] = text[1] = text[2] = text[3] = '*';
+            text = "****";
         } else if (player_ptr->resting == COMMAND_ARG_REST_UNTIL_DONE) {
-            text[0] = text[1] = text[2] = text[3] = '&';
+            text = "&&&&";
+        } else {
+            text = "    ";
         }
 
         break;
 
     case ACTION_LEARN: {
-        strcpy(text, _("学習", "lear"));
+        text = _("学習", "lear");
         auto bluemage_data = PlayerClass(player_ptr).get_specific_data<bluemage_data_type>();
         if (bluemage_data->new_magic_learned) {
             attr = TERM_L_RED;
@@ -196,7 +198,7 @@ void print_state(PlayerType *player_ptr)
         break;
     }
     case ACTION_FISH: {
-        strcpy(text, _("釣り", "fish"));
+        text = _("釣り", "fish");
         break;
     }
     case ACTION_MONK_STANCE: {
@@ -218,36 +220,36 @@ void print_state(PlayerType *player_ptr)
             default:
                 break;
             }
-            strcpy(text, monk_stances[enum2i(stance) - 1].desc);
+            text = monk_stances[enum2i(stance) - 1].desc;
         }
         break;
     }
     case ACTION_SAMURAI_STANCE: {
         if (auto stance = PlayerClass(player_ptr).get_samurai_stance();
             stance != SamuraiStanceType::NONE) {
-            strcpy(text, samurai_stances[enum2i(stance) - 1].desc);
+            text = samurai_stances[enum2i(stance) - 1].desc;
         }
         break;
     }
     case ACTION_SING: {
-        strcpy(text, _("歌  ", "Sing"));
+        text = _("歌  ", "Sing");
         break;
     }
     case ACTION_HAYAGAKE: {
-        strcpy(text, _("速駆", "Fast"));
+        text = _("速駆", "Fast");
         break;
     }
     case ACTION_SPELL: {
-        strcpy(text, _("詠唱", "Spel"));
+        text = _("詠唱", "Spel");
         break;
     }
     default: {
-        strcpy(text, "    ");
+        text = "    ";
         break;
     }
     }
 
-    c_put_str(attr, format("%5.5s", text), ROW_STATE, COL_STATE);
+    c_put_str(attr, format("%5.5s", text.data()), ROW_STATE, COL_STATE);
 }
 
 /*!
@@ -264,7 +266,7 @@ void print_speed(PlayerType *player_ptr)
     const auto speed = player_ptr->pspeed - STANDARD_SPEED;
     auto *floor_ptr = player_ptr->current_floor_ptr;
     bool is_player_fast = is_fast(player_ptr);
-    char buf[32] = "";
+    std::string buf;
     TERM_COLOR attr = TERM_WHITE;
     if (speed > 0) {
         auto is_slow = player_ptr->effects()->deceleration()->is_slow();
@@ -284,7 +286,7 @@ void print_speed(PlayerType *player_ptr)
         } else {
             attr = TERM_L_GREEN;
         }
-        sprintf(buf, "%s(+%d)", (player_ptr->riding ? _("乗馬", "Ride") : _("加速", "Fast")), speed);
+        buf = format("%s(+%d)", (player_ptr->riding ? _("乗馬", "Ride") : _("加速", "Fast")), speed);
     } else if (speed < 0) {
         auto is_slow = player_ptr->effects()->deceleration()->is_slow();
         if (player_ptr->riding) {
@@ -303,13 +305,13 @@ void print_speed(PlayerType *player_ptr)
         } else {
             attr = TERM_L_UMBER;
         }
-        sprintf(buf, "%s(%d)", (player_ptr->riding ? _("乗馬", "Ride") : _("減速", "Slow")), speed);
+        buf = format("%s(%d)", (player_ptr->riding ? _("乗馬", "Ride") : _("減速", "Slow")), speed);
     } else if (player_ptr->riding) {
         attr = TERM_GREEN;
-        strcpy(buf, _("乗馬中", "Riding"));
+        buf = _("乗馬中", "Riding");
     }
 
-    c_put_str(attr, format("%-9s", buf), row_speed, col_speed);
+    c_put_str(attr, format("%-9s", buf.data()), row_speed, col_speed);
 }
 
 /*!

--- a/src/wizard/fixed-artifacts-spoiler.cpp
+++ b/src/wizard/fixed-artifacts-spoiler.cpp
@@ -20,42 +20,35 @@
  */
 void spoiler_outlist(concptr header, concptr *list, char separator)
 {
-    char line[MAX_LINE_LEN + 20], buf[80];
     if (*list == nullptr) {
         return;
     }
 
-    strcpy(line, spoiler_indent);
+    std::string line = spoiler_indent;
     if (header && (header[0])) {
-        strcat(line, header);
-        strcat(line, " ");
+        line.append(header).append(" ");
     }
 
-    int buf_len;
-    int line_len = strlen(line);
     while (true) {
-        strcpy(buf, *list);
-        buf_len = strlen(buf);
+        std::string elem = *list;
         if (list[1]) {
-            sprintf(buf + buf_len, "%c ", separator);
-            buf_len += 2;
+            elem.push_back(separator);
+            elem.push_back(' ');
         }
 
-        if (line_len + buf_len <= MAX_LINE_LEN) {
-            strcat(line, buf);
-            line_len += buf_len;
+        if (line.length() + elem.length() <= MAX_LINE_LEN) {
+            line.append(elem);
         } else {
-            if (line_len > 1 && line[line_len - 1] == ' ' && line[line_len - 2] == list_separator) {
-                line[line_len - 2] = '\0';
-                fprintf(spoiler_file, "%s\n", line);
-                sprintf(line, "%s%s", spoiler_indent, buf);
+            if (line.length() > 1 && line[line.length() - 1] == ' ' && line[line.length() - 2] == list_separator) {
+                line[line.length() - 2] = '\0';
+                fprintf(spoiler_file, "%s\n", line.data());
+                line = spoiler_indent;
+                line.append(elem);
             } else {
-                fprintf(spoiler_file, "%s\n", line);
-                concptr ident2 = "      ";
-                sprintf(line, "%s%s", ident2, buf);
+                fprintf(spoiler_file, "%s\n", line.data());
+                line = "      ";
+                line.append(elem);
             }
-
-            line_len = strlen(line);
         }
 
         if (!*++list) {
@@ -63,7 +56,7 @@ void spoiler_outlist(concptr header, concptr *list, char separator)
         }
     }
 
-    fprintf(spoiler_file, "%s\n", line);
+    fprintf(spoiler_file, "%s\n", line.data());
 }
 
 /*!
@@ -71,11 +64,9 @@ void spoiler_outlist(concptr header, concptr *list, char separator)
  */
 static void print_header(void)
 {
-    char buf[360];
     char title[180];
     put_version(title);
-    sprintf(buf, "Artifact Spoilers for Hengband Version %s", title);
-    spoiler_underline(buf);
+    spoiler_underline(std::string("Artifact Spoilers for Hengband Version ").append(title).data());
 }
 
 /*!
@@ -118,11 +109,9 @@ static bool make_fake_artifact(ItemEntity *o_ptr, FixedArtifactId fixed_artifact
 static void spoiler_print_art(obj_desc_list *art_ptr)
 {
     pval_info_type *pval_ptr = &art_ptr->pval_info;
-    char buf[80];
     fprintf(spoiler_file, "%s\n", art_ptr->description);
     if (pval_ptr->pval_desc[0]) {
-        sprintf(buf, _("%sの修正:", "%s to"), pval_ptr->pval_desc);
-        spoiler_outlist(buf, pval_ptr->pval_affects, item_separator);
+        spoiler_outlist(std::string(pval_ptr->pval_desc).append(_("の修正:", " to")).data(), pval_ptr->pval_affects, item_separator);
     }
 
     spoiler_outlist(_("対:", "Slay"), art_ptr->slays, item_separator);

--- a/src/wizard/wizard-messages.cpp
+++ b/src/wizard/wizard-messages.cpp
@@ -3,6 +3,7 @@
 #include "game-option/cheat-types.h"
 #include "io/write-diary.h"
 #include "view/display-messages.h"
+#include <string>
 
 void msg_print_wizard(PlayerType *player_ptr, int cheat_type, concptr msg)
 {
@@ -19,13 +20,13 @@ void msg_print_wizard(PlayerType *player_ptr, int cheat_type, concptr msg)
         return;
     }
 
-    concptr cheat_mes[] = { "ITEM", "MONS", "DUNG", "MISC" };
-    char buf[1024 + 32];
-    sprintf(buf, "WIZ-%s:%s", cheat_mes[cheat_type], msg);
+    concptr cheat_mes[] = { "ITEM:", "MONS:", "DUNG:", "MISC:" };
+    std::string buf = "WIZ-";
+    buf.append(cheat_mes[cheat_type]).append(msg);
     msg_print(buf);
 
     if (cheat_diary_output) {
-        exe_write_diary(player_ptr, DIARY_WIZARD_LOG, 0, buf);
+        exe_write_diary(player_ptr, DIARY_WIZARD_LOG, 0, buf.data());
     }
 }
 

--- a/src/wizard/wizard-spoiler.cpp
+++ b/src/wizard/wizard-spoiler.cpp
@@ -30,6 +30,7 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
+#include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
@@ -106,8 +107,7 @@ static SpoilerOutputResultType spoil_mon_evol(concptr fname)
 
     char title[200];
     put_version(title);
-    sprintf(buf, "Monster Spoilers for %s\n", title);
-    spoil_out(buf);
+    spoil_out(std::string("Monster Spoilers for ").append(title).append("\n").data());
 
     spoil_out("------------------------------------------\n\n");
 
@@ -188,8 +188,7 @@ static SpoilerOutputResultType spoil_player_spell(concptr fname)
 
     char title[200];
     put_version(title);
-    sprintf(buf, "Player Spells for %s\n", title);
-    spoil_out(buf);
+    spoil_out(format("Player spells for %s\n", title));
     spoil_out("------------------------------------------\n\n");
 
     PlayerType dummy_p;
@@ -197,8 +196,7 @@ static SpoilerOutputResultType spoil_player_spell(concptr fname)
 
     for (int c = 0; c < PLAYER_CLASS_TYPE_MAX; c++) {
         auto class_ptr = &class_info[c];
-        sprintf(buf, "[[Class: %s]]\n", class_ptr->title);
-        spoil_out(buf);
+        spoil_out(format("[[Class: %s]]\n", class_ptr->title));
 
         auto magic_ptr = &class_magics_info[c];
         concptr book_name = "なし";
@@ -212,23 +210,19 @@ static SpoilerOutputResultType spoil_player_spell(concptr fname)
             *s = '\0';
         }
 
-        sprintf(buf, "BookType:%s Stat:%s Xtra:%x Type:%d Weight:%d\n", book_name, wiz_spell_stat[magic_ptr->spell_stat].data(), magic_ptr->spell_xtra,
-            magic_ptr->spell_type, magic_ptr->spell_weight);
-        spoil_out(buf);
+        spoil_out(format("BookType:%s Stat:%s Xtra:%x Type:%d Weight:%d\n", book_name, wiz_spell_stat[magic_ptr->spell_stat].data(), magic_ptr->spell_xtra, magic_ptr->spell_type, magic_ptr->spell_weight));
         if (magic_ptr->spell_book == ItemKindType::NONE) {
             spoil_out(_("呪文なし\n\n", "No spells.\n\n"));
             continue;
         }
 
         for (int16_t r = 1; r < MAX_MAGIC; r++) {
-            sprintf(buf, "[Realm: %s]\n", realm_names[r]);
-            spoil_out(buf);
+            spoil_out(format("[Realm: %s]\n", realm_names[r]));
             spoil_out("Name                     Lv Cst Dif Exp\n");
             for (SPELL_IDX i = 0; i < 32; i++) {
                 auto spell_ptr = &magic_ptr->info[r][i];
                 const auto spell_name = exe_spell(&dummy_p, r, i, SpellProcessType::NAME);
-                sprintf(buf, "%-24s %2d %3d %3d %3d\n", spell_name->data(), spell_ptr->slevel, spell_ptr->smana, spell_ptr->sfail, spell_ptr->sexp);
-                spoil_out(buf);
+                spoil_out(format("%-24s %2d %3d %3d %3d\n", spell_name->data(), spell_ptr->slevel, spell_ptr->smana, spell_ptr->sfail, spell_ptr->sexp));
             }
             spoil_out("\n");
         }


### PR DESCRIPTION
… work of resolving https://github.com/hengband/hengband/issues/2858 and https://github.com/hengband/hengband/issues/2859 .

This is a subset of the changes in #2861 as requested by feedback there.  It does include some simpler replacements for sprintf() (strnfmt(), angband_strcpy(), or avoiding copying altogether) where those replacements are used in the same file as replacements that use std::string/format().  In general, these changes don't change the return value or declared arguments for functions.  There's two exceptions to that in wizard/artifact-analyzer.cpp where two local functions pick up an additional size_t argument to specify the length of a buffer.