### PR TITLE
[Refactor] いくつかの関数の文字列引数の型を std::string_view に変更

### DIFF
--- a/src/load/load-util.cpp
+++ b/src/load/load-util.cpp
@@ -23,7 +23,7 @@ byte kanji_code = 0;
  * @details
  * Avoid the top two lines, to avoid interference with "msg_print()".
  */
-void load_note(concptr msg)
+void load_note(std::string_view msg)
 {
     static TERM_LEN y = 2;
     prt(msg, y, 0);

--- a/src/load/load-util.h
+++ b/src/load/load-util.h
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <bitset>
 #include <string>
+#include <string_view>
 
 extern FILE *loading_savefile;
 extern uint32_t loading_savefile_version;
@@ -13,7 +14,7 @@ extern uint32_t v_check;
 extern uint32_t x_check;
 extern byte kanji_code;
 
-void load_note(concptr msg);
+void load_note(std::string_view msg);
 byte sf_get(void);
 bool rd_bool();
 byte rd_byte();

--- a/src/lore/lore-util.cpp
+++ b/src/lore/lore-util.cpp
@@ -64,7 +64,7 @@ lore_type *initialize_lore_type(lore_type *lore_ptr, MonsterRaceId r_idx, monste
  * @brief モンスターの思い出メッセージをあらかじめ指定された関数ポインタに基づき出力する
  * @param str 出力文字列
  */
-void hooked_roff(concptr str)
+void hooked_roff(std::string_view str)
 {
     hook_c_roff(TERM_WHITE, str);
 }

--- a/src/lore/lore-util.h
+++ b/src/lore/lore-util.h
@@ -13,6 +13,7 @@
 #include "system/angband.h"
 #include "util/flag-group.h"
 #include <string>
+#include <string_view>
 #include <unordered_map>
 
 enum class MonsterRaceId : int16_t;
@@ -80,11 +81,11 @@ enum monster_lore_mode {
     MONSTER_LORE_DEBUG
 };
 
-typedef void (*hook_c_roff_pf)(TERM_COLOR attr, concptr str);
+using hook_c_roff_pf = void (*)(TERM_COLOR attr, std::string_view str);
 extern hook_c_roff_pf hook_c_roff;
 
 lore_type *initialize_lore_type(lore_type *lore_ptr, MonsterRaceId r_idx, monster_lore_mode mode);
-void hooked_roff(concptr str);
+void hooked_roff(std::string_view str);
 
 enum WHO_WORD_TYPE { WHO = 0,
     WHOSE = 1,

--- a/src/term/screen-processor.cpp
+++ b/src/term/screen-processor.cpp
@@ -123,7 +123,7 @@ void prt(std::string_view sv, TERM_LEN row, TERM_LEN col)
  * This function will correctly handle any width up to the maximum legal
  * value of 256, though it works best for a standard 80 character width.
  */
-void c_roff(TERM_COLOR a, concptr str)
+void c_roff(TERM_COLOR a, std::string_view str)
 {
     int w, h;
     (void)term_get_size(&w, &h);
@@ -135,7 +135,7 @@ void c_roff(TERM_COLOR a, concptr str)
         return;
     }
 
-    for (concptr s = str; *s; s++) {
+    for (auto s = str.begin(); s != str.end(); s++) {
         char ch;
 #ifdef JP
         int k_flag = iskanji(*s);
@@ -250,7 +250,7 @@ void c_roff(TERM_COLOR a, concptr str)
 /*
  * As above, but in "white"
  */
-void roff(concptr str)
+void roff(std::string_view str)
 {
     /* Spawn */
     c_roff(TERM_WHITE, str);

--- a/src/term/screen-processor.h
+++ b/src/term/screen-processor.h
@@ -17,6 +17,6 @@ void c_put_str(TERM_COLOR attr, std::string_view sv, TERM_LEN row, TERM_LEN col)
 void put_str(std::string_view sv, TERM_LEN row, TERM_LEN col);
 void c_prt(TERM_COLOR attr, std::string_view sv, TERM_LEN row, TERM_LEN col);
 void prt(std::string_view sv, TERM_LEN row, TERM_LEN col);
-void c_roff(TERM_COLOR attr, concptr str);
-void roff(concptr str);
+void c_roff(TERM_COLOR attr, std::string_view str);
+void roff(std::string_view str);
 void clear_from(int row);

--- a/src/view/display-lore.cpp
+++ b/src/view/display-lore.cpp
@@ -116,7 +116,7 @@ void display_roff(PlayerType *player_ptr)
  * @param roff_func 出力処理を行う関数ポインタ
  * @todo ここのroff_funcの引数にFILE* を追加しないとspoiler_file をローカル関数化することができないと判明した、保留.
  */
-void output_monster_spoiler(MonsterRaceId r_idx, void (*roff_func)(TERM_COLOR attr, concptr str))
+void output_monster_spoiler(MonsterRaceId r_idx, hook_c_roff_pf roff_func)
 {
     hook_c_roff = roff_func;
     PlayerType dummy;

--- a/src/view/display-lore.h
+++ b/src/view/display-lore.h
@@ -8,7 +8,7 @@ class PlayerType;
 void roff_top(MonsterRaceId r_idx);
 void screen_roff(PlayerType *player_ptr, MonsterRaceId r_idx, monster_lore_mode mode);
 void display_roff(PlayerType *player_ptr);
-void output_monster_spoiler(MonsterRaceId r_idx, void (*roff_func)(TERM_COLOR attr, concptr str));
+void output_monster_spoiler(MonsterRaceId r_idx, hook_c_roff_pf roff_func);
 void display_kill_numbers(lore_type *lore_ptr);
 bool display_where_to_appear(lore_type *lore_ptr);
 void display_random_move(lore_type *lore_ptr);

--- a/src/wizard/monster-info-spoiler.cpp
+++ b/src/wizard/monster-info-spoiler.cpp
@@ -159,10 +159,10 @@ SpoilerOutputResultType spoil_mon_desc(concptr fname, std::function<bool(const M
  * @param attr 未使用
  * @param str 文字列参照ポインタ
  */
-static void roff_func(TERM_COLOR attr, concptr str)
+static void roff_func(TERM_COLOR attr, std::string_view str)
 {
     (void)attr;
-    spoil_out(str);
+    spoil_out(str.data());
 }
 
 /*!


### PR DESCRIPTION
format 関数の戻り値を std::string にするにあたり、事前のリサーチで format の戻り 値を直接渡している関数のうち使用箇所が多く std::string_view に変更しておいたほうが 良いと思われる以下のものを先に変更しておく。

- load_note
- roff 系関数