### PR TITLE
[Refactor] get_quantity 関数のシグネチャ変更

### DIFF
--- a/src/cmd-item/cmd-destroy.cpp
+++ b/src/cmd-item/cmd-destroy.cpp
@@ -110,7 +110,7 @@ static bool select_destroying_item(PlayerType *player_ptr, destroy_type *destroy
         return true;
     }
 
-    destroy_ptr->amt = get_quantity(nullptr, destroy_ptr->o_ptr->number);
+    destroy_ptr->amt = get_quantity(std::nullopt, destroy_ptr->o_ptr->number);
     return destroy_ptr->amt > 0;
 }
 

--- a/src/cmd-item/cmd-item.cpp
+++ b/src/cmd-item/cmd-item.cpp
@@ -129,7 +129,7 @@ void do_cmd_drop(PlayerType *player_ptr)
     }
 
     if (o_ptr->number > 1) {
-        amt = get_quantity(nullptr, o_ptr->number);
+        amt = get_quantity(std::nullopt, o_ptr->number);
         if (amt <= 0) {
             return;
         }

--- a/src/core/asking-player.cpp
+++ b/src/core/asking-player.cpp
@@ -350,7 +350,7 @@ bool get_com(std::string_view prompt, char *command, bool z_escape)
  *
  * Hack -- allow "command_arg" to specify a quantity
  */
-QUANTITY get_quantity(concptr prompt, QUANTITY max)
+QUANTITY get_quantity(std::optional<std::string_view> prompt_opt, QUANTITY max)
 {
     // FIXME : QUANTITY、COMMAND_CODE、その他の型サイズがまちまちな変数とのやり取りが多数ある。この処理での数の入力を0からSHRT_MAXに制限することで不整合の発生を回避する。
     max = std::clamp<QUANTITY>(max, 0, SHRT_MAX);
@@ -384,7 +384,10 @@ QUANTITY get_quantity(concptr prompt, QUANTITY max)
         return amt;
     }
 
-    if (!prompt) {
+    std::string_view prompt;
+    if (prompt_opt.has_value()) {
+        prompt = prompt_opt.value();
+    } else {
         strnfmt(tmp, sizeof(tmp), _("いくつですか (1-%d): ", "Quantity (1-%d): "), max);
         prompt = tmp;
     }

--- a/src/core/asking-player.h
+++ b/src/core/asking-player.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include <optional>
 #include <string_view>
 
 /*
@@ -17,6 +18,6 @@ bool get_string(std::string_view prompt, char *buf, int len);
 bool get_check(std::string_view prompt);
 bool get_check_strict(PlayerType *player_ptr, std::string_view prompt, BIT_FLAGS mode);
 bool get_com(std::string_view prompt, char *command, bool z_escape);
-QUANTITY get_quantity(concptr prompt, QUANTITY max);
+QUANTITY get_quantity(std::optional<std::string_view> prompt_opt, QUANTITY max);
 void pause_line(int row);
 bool get_value(std::string_view prompt, int min, int max, int *value);

--- a/src/spell-realm/spells-sorcery.cpp
+++ b/src/spell-realm/spells-sorcery.cpp
@@ -39,7 +39,7 @@ bool alchemy(PlayerType *player_ptr)
 
     int amt = 1;
     if (o_ptr->number > 1) {
-        amt = get_quantity(nullptr, o_ptr->number);
+        amt = get_quantity(std::nullopt, o_ptr->number);
         if (amt <= 0) {
             return false;
         }

--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -231,7 +231,7 @@ void store_purchase(PlayerType *player_ptr, StoreSaleType store_num)
             msg_format(_("一つにつき $%ldです。", "That costs %ld gold per item."), (long)(best));
         }
 
-        amt = get_quantity(nullptr, o_ptr->number);
+        amt = get_quantity(std::nullopt, o_ptr->number);
         if (amt <= 0) {
             return;
         }

--- a/src/store/sell-order.cpp
+++ b/src/store/sell-order.cpp
@@ -104,7 +104,7 @@ void store_sell(PlayerType *player_ptr, StoreSaleType store_num)
 
     int amt = 1;
     if (o_ptr->number > 1) {
-        amt = get_quantity(nullptr, o_ptr->number);
+        amt = get_quantity(std::nullopt, o_ptr->number);
         if (amt <= 0) {
             return;
         }


### PR DESCRIPTION
他の get_* シリーズと違い、既存の仕様で nullptr が渡された時にデフォルトメッセージを表示するという仕様があるので単純に std::string_view にできない。
したがって std::optional<std::string_view> にし、std::nullopt で対応する。