### PR TITLE
Include <string> to avoid compiler error on MacOS/clang when not …

### DIFF
--- a/src/view/display-util.cpp
+++ b/src/view/display-util.cpp
@@ -1,5 +1,6 @@
 ﻿#include "view/display-util.h"
 #include "term/term-color-types.h"
+#include <string>
 #include <vector>
 
 namespace {


### PR DESCRIPTION
…using precompiled headers.  Resolves https://github.com/hengband/hengband/issues/2963 .