### PR TITLE
[Fix] Workflow ファイルの actions/checkout のバージョン更新

### DIFF
--- a/.github/workflows/build-with-autotools.yml
+++ b/.github/workflows/build-with-autotools.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
 

--- a/.github/workflows/publish-spoiler-page.yml
+++ b/.github/workflows/publish-spoiler-page.yml
@@ -11,7 +11,7 @@ jobs:
     name: Create auto generate spoiler files
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
 
@@ -52,7 +52,7 @@ jobs:
     env:
       GITHUB_PAGES_REPOSITORY: hengband/spoiler
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: ${{ env.GITHUB_PAGES_REPOSITORY }}
 

--- a/.github/workflows/pull-request-status-check.yml
+++ b/.github/workflows/pull-request-status-check.yml
@@ -12,14 +12,14 @@ jobs:
     name: Check the BOM of the source files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: sh ./.github/scripts/check-bom.sh
 
   check_format:
     name: Check the format of the source files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: sh ./.github/scripts/check-format.sh
 
   build_test_clang_without_pch:


### PR DESCRIPTION
GitHub Actions の Node.js 12 のサポート終了に伴い、 actions/checkout@v2 が 使用できなくなるので、actions/checkout@v3 に更新する。