### PR TITLE
Refactor get_table_{name,name_aux,sindarin,sindarin_aux}() to avoid …

### DIFF
--- a/src/artifact/random-art-characteristics.cpp
+++ b/src/artifact/random-art-characteristics.cpp
@@ -143,23 +143,21 @@ std::string get_random_name(const ItemEntity &item, bool armour, int power)
 {
     const auto prob = randint1(100);
     constexpr auto chance_sindarin = 10;
-    char random_artifact_name[1024]{};
     if (prob <= chance_sindarin) {
-        get_table_sindarin(random_artifact_name);
-        return random_artifact_name;
+        return get_table_sindarin();
     }
 
     constexpr auto chance_table = 20;
     if (prob <= chance_table) {
-        get_table_name(random_artifact_name);
-        return random_artifact_name;
+        return get_table_name();
     }
 
     auto filename = get_random_art_filename(armour, power);
+    char random_artifact_name[80]{};
     (void)get_rnd_line(filename.data(), item.artifact_bias, random_artifact_name);
 #ifdef JP
     if (random_artifact_name[0] == 0) {
-        get_table_name(random_artifact_name);
+        return get_table_name();
     }
 #endif
     return random_artifact_name;

--- a/src/artifact/random-art-generator.cpp
+++ b/src/artifact/random-art-generator.cpp
@@ -395,12 +395,12 @@ static std::string name_unnatural_random_artifact(PlayerType *player_ptr, ItemEn
     o_ptr->ident |= IDENT_FULL_KNOWN;
     o_ptr->art_name = quark_add("");
     (void)screen_object(player_ptr, o_ptr, 0L);
-    char new_name[1024] = "";
+    char new_name[160] = "";
     if (!get_string(ask_msg, new_name, sizeof new_name) || !new_name[0]) {
         if (one_in_(2)) {
-            get_table_sindarin_aux(new_name);
+            return get_table_sindarin_aux();
         } else {
-            get_table_name_aux(new_name);
+            return get_table_name_aux();
         }
     }
 

--- a/src/flavor/object-flavor.cpp
+++ b/src/flavor/object-flavor.cpp
@@ -92,18 +92,20 @@ static bool object_easy_know(int i)
 
 /*!
  * @brief 各種語彙からランダムな名前を作成する / Create a name from random parts.
- * @param out_string 作成した名を保管する参照ポインタ
+ * @return std::string 作成した名前
  * @details 日本語の場合 aname_j.txt 英語の場合確率に応じて
  * syllables 配列と elvish.txt を組み合わせる。\n
  */
-void get_table_name_aux(char *out_string)
+std::string get_table_name_aux()
 {
+    std::string name;
 #ifdef JP
     char syllable[80];
     get_rnd_line("aname_j.txt", 1, syllable);
-    strcpy(out_string, syllable);
+    name = syllable;
     get_rnd_line("aname_j.txt", 2, syllable);
-    strcat(out_string, syllable);
+    name.append(syllable);
+    return name;
 #else
 #define MAX_SYLLABLES 164 /* Used with scrolls (see below) */
 
@@ -117,70 +119,59 @@ void get_table_name_aux(char *out_string)
         "wed", "werg", "wex", "whon", "wun", "x", "yerg", "yp", "zun", "tri", "blaa", "jah", "bul", "on", "foo", "ju", "xuxu" };
 
     int testcounter = randint1(3) + 1;
-    strcpy(out_string, "");
     if (randint1(3) == 2) {
         while (testcounter--) {
-            strcat(out_string, syllables[randint0(MAX_SYLLABLES)]);
+            name.append(syllables[randint0(MAX_SYLLABLES)]);
         }
     } else {
         char syllable[80];
         testcounter = randint1(2) + 1;
         while (testcounter--) {
             (void)get_rnd_line("elvish.txt", 0, syllable);
-            strcat(out_string, syllable);
+            name.append(syllable);
         }
     }
 
-    out_string[0] = toupper(out_string[1]);
-    out_string[16] = '\0';
+    name[0] = toupper(name[0]);
+    return name;
 #endif
 }
 
 /*!
  * @brief ランダムな名前をアーティファクト銘として整形する。 / Create a name from random parts with quotes.
- * @param out_string 作成した名を保管する参照ポインタ
+ * @return std::string 作成した名前
  * @details get_table_name_aux()ほぼ完全に実装を依存している。
  */
-void get_table_name(char *out_string)
+std::string get_table_name()
 {
-    char buff[80];
-    get_table_name_aux(buff);
-    sprintf(out_string, _("『%s』", "'%s'"), buff);
+    return std::string(_("『", "'")).append(get_table_name_aux()).append(_("』", "'"));
 }
 
 /*!
  * @brief ランダムなシンダリン銘を作成する / Make random Sindarin name
- * @param out_string 作成した名を保管する参照ポインタ
+ * @return std::string 作成した名前
  * @details sname.txtが語幹の辞書となっている。
  */
-void get_table_sindarin_aux(char *out_string)
+std::string get_table_sindarin_aux()
 {
     char syllable[80];
-#ifdef JP
-    char tmp[80];
-#endif
 
     get_rnd_line("sname.txt", 1, syllable);
-    strcpy(_(tmp, out_string), syllable);
+    std::string name = syllable;
     get_rnd_line("sname.txt", 2, syllable);
-#ifdef JP
-    strcat(tmp, syllable);
-    sindarin_to_kana(out_string, tmp);
-#else
-    strcat(out_string, syllable);
-#endif
+    name.append(syllable);
+    return _(sindarin_to_kana(name), name);
 }
 
 /*!
  * @brief シンダリン銘をアーティファクト用に整形する。 / Make random Sindarin name with quotes
  * @param out_string 作成した名を保管する参照ポインタ
+ * @return std::string 作成した名前
  * @details get_table_sindarin_aux()ほぼ完全に実装を依存している。
  */
-void get_table_sindarin(char *out_string)
+std::string get_table_sindarin()
 {
-    char buff[80];
-    get_table_sindarin_aux(buff);
-    sprintf(out_string, _("『%s』", "'%s'"), buff);
+    return std::string(_("『", "'")).append(get_table_sindarin_aux()).append(_("』", "'"));
 }
 
 /*!

--- a/src/flavor/object-flavor.h
+++ b/src/flavor/object-flavor.h
@@ -2,9 +2,9 @@
 
 #include <string>
 
-void get_table_name_aux(char *out_string);
-void get_table_name(char *out_string);
-void get_table_sindarin_aux(char *out_string);
-void get_table_sindarin(char *out_string);
+std::string get_table_name_aux();
+std::string get_table_name();
+std::string get_table_sindarin_aux();
+std::string get_table_sindarin();
 void flavor_init(void);
 std::string strip_name(short bi_id);

--- a/src/locale/japanese.h
+++ b/src/locale/japanese.h
@@ -3,12 +3,15 @@
 #include "system/angband.h"
 
 #ifdef JP
+#include <string>
+#include <string_view>
+
 constexpr int JVERB_AND = 1;
 constexpr int JVERB_TO = 2;
 constexpr int JVERB_OR = 3;
 void jverb(concptr in, char *out, int flag);
 
-void sindarin_to_kana(char *kana, concptr sindarin);
+std::string sindarin_to_kana(std::string_view sindarin);
 void sjis2euc(char *str);
 void euc2sjis(char *str);
 byte codeconv(char *str);


### PR DESCRIPTION
…sprintf().  Does part of the work of resolving https://github.com/hengband/hengband/issues/2858 and https://github.com/hengband/hengband/issues/2859 .

Fixes a minor issue with get_table_name_aux() for English:  second letter was copied to the first letter and capitalized.