### PR TITLE
[Feature] C++ 言語の標準バージョンを C++20 にする

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -113,7 +113,7 @@
       <ConformanceMode>true</ConformanceMode>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AdditionalIncludeDirectories>..\..\src;curl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <ExceptionHandling>SyncCThrow</ExceptionHandling>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>

--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ AC_SUBST(DEFAULT_VAR_PATH)
 dnl Checks for programs.
 AC_LANG(C++)
 AC_PROG_CXX
-AX_CXX_COMPILE_STDCXX(17, [ext], [mandatory])
+AX_CXX_COMPILE_STDCXX(20, [ext], [mandatory])
 PKG_PROG_PKG_CONFIG
 
 AC_ARG_ENABLE(japanese,

--- a/m4/ax_cxx_compile_stdcxx.m4
+++ b/m4/ax_cxx_compile_stdcxx.m4
@@ -279,11 +279,11 @@ namespace cxx11
     }
 
     int
-    test(const int c, volatile int v)
+    test(const int c, int v)
     {
       static_assert(is_same<int, decltype(0)>::value == true, "");
       static_assert(is_same<int, decltype(c)>::value == false, "");
-      static_assert(is_same<int, decltype(v)>::value == false, "");
+      static_assert(is_same<int, decltype(v)>::value == true, "");
       auto ac = c;
       auto av = v;
       auto sumi = ac + av + 'x';
@@ -914,7 +914,7 @@ namespace cxx17
     struct S
     {
       int x1 : 2;
-      volatile double y1;
+      double y1;
     };
 
     S f3()

--- a/src/maid-x11.cpp
+++ b/src/maid-x11.cpp
@@ -690,9 +690,8 @@ static XImage *ResizeImage(Display *dpy, XImage *Im, int ix, int iy, int ox, int
     Visual *visual = DefaultVisual(dpy, DefaultScreen(dpy));
 
     int width1, height1, width2, height2;
-    volatile int x1, x2, y1, y2, Tx, Ty;
-    volatile int *px1, *px2, *dx1, *dx2;
-    volatile int *py1, *py2, *dy1, *dy2;
+    int x1, x2, y1, y2, Tx, Ty;
+    int dx1, dx2, dy1, dy2;
 
     XImage *Tmp;
 
@@ -713,52 +712,60 @@ static XImage *ResizeImage(Display *dpy, XImage *Im, int ix, int iy, int ox, int
     Tmp = XCreateImage(dpy, visual, Im->depth, ZPixmap, 0, Data, width2, height2, 32, 0);
 
     if (ix > ox) {
-        px1 = &x1;
-        px2 = &x2;
-        dx1 = &ix;
-        dx2 = &ox;
+        dx1 = ix;
+        dx2 = ox;
     } else {
-        px1 = &x2;
-        px2 = &x1;
-        dx1 = &ox;
-        dx2 = &ix;
+        dx1 = ox;
+        dx2 = ix;
     }
 
     if (iy > oy) {
-        py1 = &y1;
-        py2 = &y2;
-        dy1 = &iy;
-        dy2 = &oy;
+        dy1 = iy;
+        dy2 = oy;
     } else {
-        py1 = &y2;
-        py2 = &y1;
-        dy1 = &oy;
-        dy2 = &iy;
+        dy1 = oy;
+        dy2 = iy;
     }
 
-    Ty = *dy1 / 2;
+    Ty = dy1 / 2;
 
     for (y1 = 0, y2 = 0; (y1 < height1) && (y2 < height2);) {
-        Tx = *dx1 / 2;
+        Tx = dx1 / 2;
 
         for (x1 = 0, x2 = 0; (x1 < width1) && (x2 < width2);) {
             XPutPixel(Tmp, x2, y2, XGetPixel(Im, x1, y1));
 
-            (*px1)++;
+            if (ix > ox) {
+                ++x1;
+            } else {
+                ++x2;
+            }
 
-            Tx -= *dx2;
+            Tx -= dx2;
             if (Tx < 0) {
-                Tx += *dx1;
-                (*px2)++;
+                Tx += dx1;
+                if (ix > ox) {
+                    ++x2;
+                } else {
+                    ++x1;
+                }
             }
         }
 
-        (*py1)++;
+        if (iy > oy) {
+            ++y1;
+        } else {
+            ++y2;
+        }
 
-        Ty -= *dy2;
+        Ty -= dy2;
         if (Ty < 0) {
-            Ty += *dy1;
-            (*py2)++;
+            Ty += dy1;
+            if (iy > oy) {
+                ++y2;
+            } else {
+                ++y1;
+            }
         }
     }
 


### PR DESCRIPTION
Resolves #2894 

各プラットフォームで対応の準備が整ったので、C++ 言語の標準バージョンを C++20 にする。
なお、Visual Studio 用プロジェクトの設定は latest （C++23 の機能を含むプレビュー バージョン）が指定されていたが、こちらも C++20 を指定することとする。