### PR TITLE
[Refactor] shape_buffer のシグネチャ変更に伴うリファクタリング

### DIFF
--- a/src/autopick/autopick-drawer.cpp
+++ b/src/autopick/autopick-drawer.cpp
@@ -13,7 +13,7 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
-#include "util/buffer-shaper.h"
+#include "view/display-util.h"
 
 #define DESCRIPT_HGT 3
 
@@ -268,8 +268,6 @@ void draw_text_editor(PlayerType *player_ptr, text_body_type *tb)
         }
     } else if (autopick_new_entry(entry, tb->lines_list[tb->cy], false)) {
         char buf[MAX_LINELEN];
-        char temp[MAX_LINELEN];
-        concptr t;
 
         describe_autopick(buf, entry);
 
@@ -281,16 +279,7 @@ void draw_text_editor(PlayerType *player_ptr, text_body_type *tb)
             strcat(buf, _("この行は現在は無効な状態です。", "  This line is bypassed currently."));
         }
 
-        shape_buffer(buf, 81, temp, sizeof(temp));
-        t = temp;
-        for (int j = 0; j < 3; j++) {
-            if (t[0] == 0) {
-                break;
-            } else {
-                prt(t, tb->hgt + 1 + 1 + j, 0);
-                t += strlen(t) + 1;
-            }
-        }
+        display_wrap_around(buf, 81, tb->hgt + 2, 0);
     }
 
     if (!str1.empty()) {

--- a/src/birth/birth-select-realm.cpp
+++ b/src/birth/birth-select-realm.cpp
@@ -11,8 +11,8 @@
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 #include "term/z-form.h"
-#include "util/buffer-shaper.h"
 #include "util/int-char-converter.h"
+#include "view/display-util.h"
 
 static const byte REALM_SELECT_CANCEL = 255;
 
@@ -351,7 +351,6 @@ bool get_player_realms(PlayerType *player_ptr)
     }
 
     while (true) {
-        char temp[80 * 10];
         int count = 0;
         player_ptr->realm1 = select_realm(player_ptr, realm_choices1[enum2i(player_ptr->pclass)], &count);
         if (player_ptr->realm1 == REALM_SELECT_CANCEL) {
@@ -362,16 +361,7 @@ bool get_player_realms(PlayerType *player_ptr)
         }
 
         cleanup_realm_selection_window();
-        shape_buffer(realm_explanations[technic2magic(player_ptr->realm1) - 1].data(), 74, temp, sizeof(temp));
-        concptr t = temp;
-        for (int i = 0; i < 10; i++) {
-            if (t[0] == 0) {
-                break;
-            } else {
-                prt(t, 12 + i, 3);
-                t += strlen(t) + 1;
-            }
-        }
+        display_wrap_around(realm_explanations[technic2magic(player_ptr->realm1) - 1], 74, 12, 3);
 
         if (check_realm_selection(player_ptr, count)) {
             break;
@@ -390,7 +380,6 @@ bool get_player_realms(PlayerType *player_ptr)
 
     /* Select the second realm */
     while (true) {
-        char temp[80 * 8];
         int count = 0;
         player_ptr->realm2 = select_realm(player_ptr, realm_choices2[enum2i(player_ptr->pclass)], &count);
 
@@ -402,16 +391,7 @@ bool get_player_realms(PlayerType *player_ptr)
         }
 
         cleanup_realm_selection_window();
-        shape_buffer(realm_explanations[technic2magic(player_ptr->realm2) - 1].data(), 74, temp, sizeof(temp));
-        concptr t = temp;
-        for (int i = 0; i < A_MAX; i++) {
-            if (t[0] == 0) {
-                break;
-            } else {
-                prt(t, 12 + i, 3);
-                t += strlen(t) + 1;
-            }
-        }
+        display_wrap_around(realm_explanations[technic2magic(player_ptr->realm2) - 1], 74, 12, 3);
 
         if (check_realm_selection(player_ptr, count)) {
             break;

--- a/src/birth/birth-wizard.cpp
+++ b/src/birth/birth-wizard.cpp
@@ -35,12 +35,12 @@
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 #include "term/z-form.h"
-#include "util/buffer-shaper.h"
 #include "util/enum-converter.h"
 #include "util/int-char-converter.h"
 #include "util/string-processor.h"
 #include "view/display-birth.h" // 暫定。後で消す予定。
 #include "view/display-player.h" // 暫定。後で消す.
+#include "view/display-util.h"
 #include "world/world.h"
 #include <sstream>
 
@@ -182,22 +182,12 @@ static bool let_player_select_race(PlayerType *player_ptr)
     clear_from(10);
     player_ptr->prace = PlayerRaceType::HUMAN;
     while (true) {
-        char temp[80 * 10];
         if (!get_player_race(player_ptr)) {
             return false;
         }
 
         clear_from(10);
-        shape_buffer(race_explanations[enum2i(player_ptr->prace)].data(), 74, temp, sizeof(temp));
-        concptr t = temp;
-        for (int i = 0; i < 10; i++) {
-            if (t[0] == 0) {
-                break;
-            } else {
-                prt(t, 12 + i, 3);
-                t += strlen(t) + 1;
-            }
-        }
+        display_wrap_around(race_explanations[enum2i(player_ptr->prace)], 74, 12, 3);
         if (get_check_strict(player_ptr, _("よろしいですか？", "Are you sure? "), CHECK_DEFAULT_Y)) {
             break;
         }
@@ -214,22 +204,12 @@ static bool let_player_select_class(PlayerType *player_ptr)
     clear_from(10);
     player_ptr->pclass = PlayerClassType::WARRIOR;
     while (true) {
-        char temp[80 * 9];
         if (!get_player_class(player_ptr)) {
             return false;
         }
 
         clear_from(10);
-        shape_buffer(class_explanations[enum2i(player_ptr->pclass)].data(), 74, temp, sizeof(temp));
-        concptr t = temp;
-        for (int i = 0; i < 9; i++) {
-            if (t[0] == 0) {
-                break;
-            } else {
-                prt(t, 12 + i, 3);
-                t += strlen(t) + 1;
-            }
-        }
+        display_wrap_around(class_explanations[enum2i(player_ptr->pclass)], 74, 12, 3);
 
         if (get_check_strict(player_ptr, _("よろしいですか？", "Are you sure? "), CHECK_DEFAULT_Y)) {
             break;
@@ -245,22 +225,12 @@ static bool let_player_select_personality(PlayerType *player_ptr)
 {
     player_ptr->ppersonality = PERSONALITY_ORDINARY;
     while (true) {
-        char temp[80 * 8];
         if (!get_player_personality(player_ptr)) {
             return false;
         }
 
         clear_from(10);
-        shape_buffer(personality_explanations[player_ptr->ppersonality].data(), 74, temp, sizeof(temp));
-        concptr t = temp;
-        for (int i = 0; i < A_MAX; i++) {
-            if (t[0] == 0) {
-                break;
-            } else {
-                prt(t, 12 + i, 3);
-                t += strlen(t) + 1;
-            }
-        }
+        display_wrap_around(personality_explanations[player_ptr->ppersonality], 74, 12, 3);
 
         if (get_check_strict(player_ptr, _("よろしいですか？", "Are you sure? "), CHECK_DEFAULT_Y)) {
             break;

--- a/src/birth/history-generator.cpp
+++ b/src/birth/history-generator.cpp
@@ -3,6 +3,8 @@
 #include "player-info/race-types.h"
 #include "system/player-type-definition.h"
 #include "util/buffer-shaper.h"
+#include "util/string-processor.h"
+#include <algorithm>
 #include <sstream>
 #include <string>
 
@@ -130,15 +132,10 @@ void get_history(PlayerType *player_ptr)
     }
 
     auto social_class = decide_social_class(player_ptr);
-    char tmp_history[64 * lines];
-    shape_buffer(social_class.data(), 60, tmp_history, sizeof(tmp_history));
-    auto *history = tmp_history;
-    for (auto i = 0; i < lines; i++) {
-        if (history[0] == 0) {
-            return;
-        }
-
-        strcpy(player_ptr->history[i], history);
-        history += strlen(history) + 1;
+    constexpr auto max_line_len = sizeof(player_ptr->history[0]);
+    const auto history_lines = shape_buffer(social_class.data(), max_line_len);
+    const auto max_lines = std::min<int>(lines, history_lines.size());
+    for (auto i = 0; i < max_lines; ++i) {
+        angband_strcpy(player_ptr->history[i], history_lines[i].data(), max_line_len);
     }
 }

--- a/src/cmd-action/cmd-mind.cpp
+++ b/src/cmd-action/cmd-mind.cpp
@@ -50,9 +50,9 @@
 #include "term/screen-processor.h"
 #include "timed-effect/player-stun.h"
 #include "timed-effect/timed-effects.h"
-#include "util/buffer-shaper.h"
 #include "util/enum-converter.h"
 #include "view/display-messages.h"
+#include "view/display-util.h"
 
 /*!
  * @brief 職業別特殊技能の処理用構造体
@@ -454,7 +454,6 @@ static MindKindType decide_use_mind_browse(PlayerType *player_ptr)
 void do_cmd_mind_browse(PlayerType *player_ptr)
 {
     SPELL_IDX n = 0;
-    char temp[62 * 5];
     MindKindType use_mind = decide_use_mind_browse(player_ptr);
     screen_save();
     while (true) {
@@ -469,11 +468,7 @@ void do_cmd_mind_browse(PlayerType *player_ptr)
         term_erase(12, 18, 255);
         term_erase(12, 17, 255);
         term_erase(12, 16, 255);
-        shape_buffer(mind_tips[(int)use_mind][n], 62, temp, sizeof(temp));
-        for (int j = 0, line = 17; temp[j]; j += (1 + strlen(&temp[j]))) {
-            prt(&temp[j], line, 15);
-            line++;
-        }
+        display_wrap_around(mind_tips[enum2i(use_mind)][n], 62, 17, 15);
 
         switch (use_mind) {
         case MindKindType::MIRROR_MASTER:

--- a/src/cmd-action/cmd-racial.cpp
+++ b/src/cmd-action/cmd-racial.cpp
@@ -34,9 +34,9 @@
 #include "term/screen-processor.h"
 #include "term/z-form.h"
 #include "util/bit-flags-calculator.h"
-#include "util/buffer-shaper.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
+#include "view/display-util.h"
 #include <string>
 
 #define RC_PAGE_SIZE 18
@@ -305,7 +305,6 @@ static bool ask_invoke_racial_power(rc_type *rc_ptr)
 static void racial_power_display_explanation(PlayerType *player_ptr, rc_type *rc_ptr)
 {
     auto &rpi = rc_ptr->power_desc[rc_ptr->command_code];
-    char temp[62 * 5];
 
     term_erase(12, 21, 255);
     term_erase(12, 20, 255);
@@ -313,11 +312,7 @@ static void racial_power_display_explanation(PlayerType *player_ptr, rc_type *rc
     term_erase(12, 18, 255);
     term_erase(12, 17, 255);
     term_erase(12, 16, 255);
-    shape_buffer(rpi.text.data(), 62, temp, sizeof(temp));
-    for (int j = 0, line = 17; temp[j]; j += (1 + strlen(&temp[j]))) {
-        prt(&temp[j], line, 15);
-        line++;
-    }
+    display_wrap_around(rpi.text, 62, 17, 15);
 
     prt(_("何かキーを押して下さい。", "Hit any key."), 0, 0);
     (void)inkey();

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -67,9 +67,9 @@
 #include "timed-effect/player-blindness.h"
 #include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
-#include "util/buffer-shaper.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
+#include "view/display-util.h"
 
 static const int extra_magic_gain_exp = 4;
 
@@ -580,12 +580,10 @@ static FuncItemTester get_learnable_spellbook_tester(PlayerType *player_ptr)
 void do_cmd_browse(PlayerType *player_ptr)
 {
     OBJECT_IDX item;
-    int j, line;
     SPELL_IDX spell = -1;
     int num = 0;
 
     SPELL_IDX spells[64];
-    char temp[62 * 4];
 
     /* Warriors are illiterate */
     PlayerClass pc(player_ptr);
@@ -671,12 +669,7 @@ void do_cmd_browse(PlayerType *player_ptr)
         term_erase(14, 11, 255);
 
         const auto spell_desc = exe_spell(player_ptr, use_realm, spell, SpellProcessType::DESCRIPTION);
-        shape_buffer(spell_desc->data(), 62, temp, sizeof(temp));
-
-        for (j = 0, line = 11; temp[j]; j += 1 + strlen(&temp[j])) {
-            prt(&temp[j], line, 15);
-            line++;
-        }
+        display_wrap_around(spell_desc.value(), 62, 11, 15);
     }
     screen_load();
 }

--- a/src/cmd-item/cmd-magiceat.cpp
+++ b/src/cmd-item/cmd-magiceat.cpp
@@ -80,9 +80,9 @@
 #include "term/z-form.h"
 #include "timed-effect/player-stun.h"
 #include "timed-effect/timed-effects.h"
-#include "util/buffer-shaper.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
+#include "view/display-util.h"
 #include <algorithm>
 #include <optional>
 
@@ -485,21 +485,13 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
 
         /* Browse */
         else {
-            int line, j;
-            char temp[70 * 20];
-
             /* Clear lines, position cursor  (really should use strlen here) */
             term_erase(7, 23, 255);
             term_erase(7, 22, 255);
             term_erase(7, 21, 255);
             term_erase(7, 20, 255);
 
-            shape_buffer(baseitems_info[lookup_baseitem_id({ tval, i })].text.data(), 62, temp, sizeof(temp));
-            for (j = 0, line = 21; temp[j]; j += 1 + strlen(&temp[j])) {
-                prt(&temp[j], line, 10);
-                line++;
-            }
-
+            display_wrap_around(baseitems_info[lookup_baseitem_id({ tval, i })].text, 62, 21, 10);
             continue;
         }
 

--- a/src/io/read-pref-file.cpp
+++ b/src/io/read-pref-file.cpp
@@ -28,9 +28,10 @@
 #include "term/z-form.h"
 #include "util/angband-files.h"
 #include "util/buffer-shaper.h"
+#include "util/string-processor.h"
 #include "view/display-messages.h"
 #include "world/world.h"
-
+#include <algorithm>
 #include <string>
 
 //!< @todo コールバック関数に変更するので、いずれ消す.
@@ -314,8 +315,7 @@ bool read_histpref(PlayerType *player_ptr)
 {
     errr err;
     int i, j, n;
-    char *s, *t;
-    char temp[64 * 4];
+    char *s;
     char histbuf[HISTPREF_LIMIT];
 
     if (!get_check(_("生い立ち設定ファイルをロードしますか? ", "Load background history preference file? "))) {
@@ -357,15 +357,11 @@ bool read_histpref(PlayerType *player_ptr)
         s[--n] = '\0';
     }
 
-    shape_buffer(s, 60, temp, sizeof(temp));
-    t = temp;
-    for (i = 0; i < 4; i++) {
-        if (t[0] == 0) {
-            break;
-        } else {
-            strcpy(player_ptr->history[i], t);
-            t += strlen(t) + 1;
-        }
+    constexpr auto max_line_len = sizeof(player_ptr->history[0]);
+    const auto history_lines = shape_buffer(s, max_line_len);
+    const auto max_lines = std::min<int>(4, history_lines.size());
+    for (auto l = 0; l < max_lines; ++l) {
+        angband_strcpy(player_ptr->history[l], history_lines[l].data(), max_line_len);
     }
 
     for (i = 0; i < 4; i++) {

--- a/src/knowledge/knowledge-self.cpp
+++ b/src/knowledge/knowledge-self.cpp
@@ -48,6 +48,14 @@ void do_cmd_knowledge_virtues(PlayerType *player_ptr)
     fd_kill(file_name);
 }
 
+static void dump_explanation(std::string_view explanation, FILE *fff)
+{
+    for (const auto &line : shape_buffer(explanation, 78)) {
+        fputs(line.data(), fff);
+        fputc('\n', fff);
+    }
+}
+
 /*!
  * @brief 自分に関する情報を画面に表示する
  * @param player_ptr プレイヤーへの参照ポインタ
@@ -59,77 +67,29 @@ static void dump_yourself(PlayerType *player_ptr, FILE *fff)
         return;
     }
 
-    char temp[80 * 10];
-    shape_buffer(race_explanations[enum2i(player_ptr->prace)].data(), 78, temp, sizeof(temp));
     fprintf(fff, "\n\n");
     fprintf(fff, _("種族: %s\n", "Race: %s\n"), race_info[enum2i(player_ptr->prace)].title);
-    concptr t = temp;
-
-    for (int i = 0; i < 10; i++) {
-        if (t[0] == 0) {
-            break;
-        }
-        fprintf(fff, "%s\n", t);
-        t += strlen(t) + 1;
-    }
+    dump_explanation(race_explanations[enum2i(player_ptr->prace)], fff);
 
     auto short_pclass = enum2i(player_ptr->pclass);
-    shape_buffer(class_explanations[short_pclass].data(), 78, temp, sizeof(temp));
     fprintf(fff, "\n");
     fprintf(fff, _("職業: %s\n", "Class: %s\n"), class_info[short_pclass].title);
+    dump_explanation(class_explanations[short_pclass].data(), fff);
 
-    t = temp;
-    for (int i = 0; i < 10; i++) {
-        if (t[0] == 0) {
-            break;
-        }
-        fprintf(fff, "%s\n", t);
-        t += strlen(t) + 1;
-    }
-
-    shape_buffer(personality_explanations[player_ptr->ppersonality].data(), 78, temp, sizeof(temp));
     fprintf(fff, "\n");
     fprintf(fff, _("性格: %s\n", "Pesonality: %s\n"), personality_info[player_ptr->ppersonality].title);
-
-    t = temp;
-    for (int i = 0; i < A_MAX; i++) {
-        if (t[0] == 0) {
-            break;
-        }
-        fprintf(fff, "%s\n", t);
-        t += strlen(t) + 1;
-    }
+    dump_explanation(personality_explanations[player_ptr->ppersonality], fff);
 
     fprintf(fff, "\n");
     if (player_ptr->realm1) {
-        shape_buffer(realm_explanations[technic2magic(player_ptr->realm1) - 1].data(), 78, temp, sizeof(temp));
         fprintf(fff, _("魔法: %s\n", "Realm: %s\n"), realm_names[player_ptr->realm1]);
-
-        t = temp;
-        for (int i = 0; i < A_MAX; i++) {
-            if (t[0] == 0) {
-                break;
-            }
-
-            fprintf(fff, "%s\n", t);
-            t += strlen(t) + 1;
-        }
+        dump_explanation(realm_explanations[technic2magic(player_ptr->realm1) - 1], fff);
     }
 
     fprintf(fff, "\n");
     if (player_ptr->realm2) {
-        shape_buffer(realm_explanations[technic2magic(player_ptr->realm2) - 1].data(), 78, temp, sizeof(temp));
         fprintf(fff, _("魔法: %s\n", "Realm: %s\n"), realm_names[player_ptr->realm2]);
-
-        t = temp;
-        for (int i = 0; i < A_MAX; i++) {
-            if (t[0] == 0) {
-                break;
-            }
-
-            fprintf(fff, "%s\n", t);
-            t += strlen(t) + 1;
-        }
+        dump_explanation(realm_explanations[technic2magic(player_ptr->realm2) - 1], fff);
     }
 }
 

--- a/src/market/building-craft-armor.cpp
+++ b/src/market/building-craft-armor.cpp
@@ -2,7 +2,7 @@
 #include "io/input-key-acceptor.h"
 #include "market/building-util.h"
 #include "term/screen-processor.h"
-#include "util/buffer-shaper.h"
+#include "view/display-util.h"
 
 /*!
  * @brief ACから回避率、ダメージ減少率を計算し表示する。 / Evaluate AC
@@ -36,7 +36,6 @@ bool eval_ac(ARMOUR_CLASS iAC)
     int protection;
     TERM_LEN col, row = 2;
     DEPTH lvl;
-    char buf[80 * 20], *t;
 
     if (iAC < 0) {
         iAC = 0;
@@ -70,10 +69,7 @@ bool eval_ac(ARMOUR_CLASS iAC)
         put_str(format("%3d", average), row + 2, col);
     }
 
-    shape_buffer(memo, 70, buf, sizeof(buf));
-    for (t = buf; t[0]; t += strlen(t) + 1) {
-        put_str(t, (row++) + 4, 4);
-    }
+    display_wrap_around(memo, 70, row + 4, 4);
 
     prt(_("現在のあなたの装備からすると、あなたの防御力はこれくらいです:", "Defense abilities from your current Armor Class are evaluated below."), 0, 0);
 

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -71,10 +71,10 @@
 #include "timed-effect/player-stun.h"
 #include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
-#include "util/buffer-shaper.h"
 #include "util/enum-converter.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
+#include "view/display-util.h"
 #include <array>
 #include <string>
 #include <unordered_map>
@@ -947,7 +947,6 @@ void do_cmd_element(PlayerType *player_ptr)
 void do_cmd_element_browse(PlayerType *player_ptr)
 {
     SPELL_IDX n = 0;
-    char temp[62 * 5];
 
     screen_save();
     while (true) {
@@ -962,11 +961,7 @@ void do_cmd_element_browse(PlayerType *player_ptr)
         term_erase(12, 18, 255);
         term_erase(12, 17, 255);
         term_erase(12, 16, 255);
-        shape_buffer(get_element_tip(player_ptr, n).data(), 62, temp, sizeof(temp));
-        for (int j = 0, line = 17; temp[j]; j += (1 + strlen(&temp[j]))) {
-            prt(&temp[j], line, 15);
-            line++;
-        }
+        display_wrap_around(get_element_tip(player_ptr, n), 62, 17, 15);
 
         prt(_("何かキーを押して下さい。", "Hit any key."), 0, 0);
         (void)inkey();
@@ -1245,16 +1240,7 @@ byte select_element_realm(PlayerType *player_ptr)
         }
 
         auto realm = i2enum<ElementRealmType>(realm_idx);
-        char temp[80 * 5];
-        shape_buffer(element_texts.at(realm).data(), 74, temp, sizeof(temp));
-        concptr t = temp;
-        for (int i = 0; i < 5; i++) {
-            if (t[0] == 0) {
-                break;
-            }
-            prt(t, row + i, 3);
-            t += strlen(t) + 1;
-        }
+        display_wrap_around(element_texts.at(realm), 74, row, 3);
 
         if (get_check_strict(player_ptr, _("よろしいですか？", "Are you sure? "), CHECK_DEFAULT_Y)) {
             break;

--- a/src/mind/mind-sniper.cpp
+++ b/src/mind/mind-sniper.cpp
@@ -36,9 +36,9 @@
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 #include "term/z-form.h"
-#include "util/buffer-shaper.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
+#include "view/display-util.h"
 
 #define MAX_SNIPE_POWERS 16
 
@@ -630,8 +630,6 @@ void do_cmd_snipe(PlayerType *player_ptr)
 void do_cmd_snipe_browse(PlayerType *player_ptr)
 {
     COMMAND_CODE n = 0;
-    int j, line;
-    char temp[62 * 4];
 
     screen_save();
 
@@ -648,10 +646,6 @@ void do_cmd_snipe_browse(PlayerType *player_ptr)
         term_erase(12, 19, 255);
         term_erase(12, 18, 255);
 
-        shape_buffer(snipe_tips[n], 62, temp, sizeof(temp));
-        for (j = 0, line = 19; temp[j]; j += (1 + strlen(&temp[j]))) {
-            prt(&temp[j], line, 15);
-            line++;
-        }
+        display_wrap_around(snipe_tips[n], 62, 19, 15);
     }
 }

--- a/src/mind/mind-weaponsmith.cpp
+++ b/src/mind/mind-weaponsmith.cpp
@@ -25,9 +25,9 @@
 #include "term/term-color-types.h"
 #include "term/z-form.h"
 #include "util/bit-flags-calculator.h"
-#include "util/buffer-shaper.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
+#include "view/display-util.h"
 #include <algorithm>
 #include <sstream>
 
@@ -664,9 +664,6 @@ void do_cmd_kaji(PlayerType *player_ptr, bool only_browse)
             }
 
             if (only_browse) {
-                char temp[62 * 5];
-                int line, j;
-
                 /* Clear lines, position cursor  (really should use strlen here) */
                 term_erase(14, 21, 255);
                 term_erase(14, 20, 255);
@@ -675,11 +672,7 @@ void do_cmd_kaji(PlayerType *player_ptr, bool only_browse)
                 term_erase(14, 17, 255);
                 term_erase(14, 16, 255);
 
-                shape_buffer(kaji_tips[mode - 1], 62, temp, sizeof(temp));
-                for (j = 0, line = 17; temp[j]; j += (1 + strlen(&temp[j]))) {
-                    prt(&temp[j], line, 15);
-                    line++;
-                }
+                display_wrap_around(kaji_tips[mode - 1], 62, 17, 15);
                 mode = 0;
             }
             if (!only_browse) {

--- a/src/perception/identification.cpp
+++ b/src/perception/identification.cpp
@@ -25,6 +25,7 @@
 #include "util/bit-flags-calculator.h"
 #include "util/buffer-shaper.h"
 #include "util/enum-converter.h"
+#include <algorithm>
 
 /*!
  * @brief オブジェクトの*鑑定*内容を詳述して表示する /
@@ -36,7 +37,6 @@
  */
 bool screen_object(PlayerType *player_ptr, ItemEntity *o_ptr, BIT_FLAGS mode)
 {
-    char temp[70 * 20];
     concptr info[128];
     GAME_TEXT o_name[MAX_NLEN];
 
@@ -44,13 +44,11 @@ bool screen_object(PlayerType *player_ptr, ItemEntity *o_ptr, BIT_FLAGS mode)
     auto flgs = object_flags(o_ptr);
 
     const auto item_text = o_ptr->is_fixed_artifact() ? artifacts_info.at(o_ptr->fixed_artifact_idx).text.data() : baseitems_info[o_ptr->bi_id].text.data();
-    shape_buffer(item_text, 77 - 15, temp, sizeof(temp));
+    const auto item_text_lines = shape_buffer(item_text, 77 - 15);
 
     int i = 0;
-    for (int j = 0; temp[j]; j += 1 + strlen(&temp[j])) {
-        info[i] = &temp[j];
-        i++;
-    }
+    std::ranges::transform(item_text_lines, &info[i], [](const auto &line) { return line.data(); });
+    i += item_text_lines.size();
 
     if (o_ptr->is_equipment()) {
         trivial_info = i;

--- a/src/player/process-death.cpp
+++ b/src/player/process-death.cpp
@@ -69,42 +69,38 @@ static void show_basic_params(PlayerType *player_ptr)
  */
 static std::pair<std::string, int> show_killing_monster(PlayerType *player_ptr)
 {
-    char buf[160];
-    shape_buffer(player_ptr->died_from.data(), GRAVE_LINE_WIDTH + 1, buf, sizeof(buf));
-    char *t = buf + strlen(buf) + 1;
-    if (!*t) {
-        return std::make_pair(buf, 0);
+    auto lines = shape_buffer(player_ptr->died_from.data(), GRAVE_LINE_WIDTH + 1);
+    if (lines.size() == 1) {
+        return std::make_pair(std::move(lines[0]), 0);
     }
 
-    std::string killer = t; /* 2nd line */
-    if (*(t + strlen(t) + 1)) /* Does 3rd line exist? */
-    {
-        auto i = (killer.length() > 2) ? 0 : killer.length() - 2;
-        while (i > 0 && iskanji(killer[i - 1])) {
+    if (lines.size() >= 3) {
+        auto i = (lines[1].length() > 2) ? 0 : lines[1].length() - 2;
+        while (i > 0 && iskanji(lines[1][i - 1])) {
             --i;
         }
-        killer.erase(i);
-        killer.append("…");
-    } else if (angband_strstr(buf, "『") && suffix(killer.data(), "』")) {
-        char *name_head = angband_strstr(buf, "『");
+        lines[1].erase(i);
+        lines[1].append("…");
+    } else if (angband_strstr(lines[0].data(), "『") && suffix(lines[1], "』")) {
+        char *name_head = angband_strstr(lines[0].data(), "『");
         std::string killer2 = name_head;
-        killer2.append(killer);
+        killer2.append(lines[1]);
         if (killer2.length() <= GRAVE_LINE_WIDTH) {
-            killer = killer2;
-            *name_head = '\0';
+            lines[1] = killer2;
+            lines[0].erase(name_head - lines[0].data());
         }
-    } else if (angband_strstr(buf, "「") && suffix(killer.data(), "」")) {
-        char *name_head = angband_strstr(buf, "「");
+    } else if (angband_strstr(lines[0].data(), "「") && suffix(lines[1], "」")) {
+        char *name_head = angband_strstr(lines[0].data(), "「");
         std::string killer2 = name_head;
-        killer2.append(killer);
+        killer2.append(lines[1]);
         if (killer2.length() <= GRAVE_LINE_WIDTH) {
-            killer = killer2;
-            *name_head = '\0';
+            lines[1] = killer2;
+            lines[0].erase(name_head - lines[0].data());
         }
     }
 
-    put_str(center_string(killer), 15, 11);
-    return std::make_pair(buf, 1);
+    put_str(center_string(lines[1]), 15, 11);
+    return std::make_pair(std::move(lines[0]), 1);
 }
 
 /*!
@@ -167,24 +163,20 @@ static void show_tomb_detail(PlayerType *player_ptr)
 {
     put_str(center_string(format("Killed on Level %d", player_ptr->current_floor_ptr->dun_level)), 14, 11);
 
-    char buf[160];
-    shape_buffer(format("by %s.", player_ptr->died_from.data()).data(), GRAVE_LINE_WIDTH + 1, buf, sizeof(buf));
-    put_str(center_string(buf), 15, 11);
-    char *t = buf + strlen(buf) + 1;
-    if (!*t) {
+    auto lines = shape_buffer(format("by %s.", player_ptr->died_from.data()).data(), GRAVE_LINE_WIDTH + 1);
+    put_str(center_string(lines[0]), 15, 11);
+    if (lines.size() == 1) {
         return;
     }
 
-    std::string killer = t; /* 2nd line */
-    if (*(t + strlen(t) + 1)) /* Does 3rd line exist? */
-    {
-        if (killer.length() > GRAVE_LINE_WIDTH - 3) {
-            killer.erase(GRAVE_LINE_WIDTH - 3);
+    if (lines.size() >= 3) {
+        if (lines[1].length() > GRAVE_LINE_WIDTH - 3) {
+            lines[1].erase(GRAVE_LINE_WIDTH - 3);
         }
-        killer.append("...");
+        lines[1].append("...");
     }
 
-    put_str(center_string(killer), 16, 11);
+    put_str(center_string(lines[1]), 16, 11);
 }
 #endif
 

--- a/src/util/buffer-shaper.cpp
+++ b/src/util/buffer-shaper.cpp
@@ -1,90 +1,83 @@
 ﻿#include "util/buffer-shaper.h"
+#include <algorithm>
+#include <set>
 
-void shape_buffer(concptr str, int maxlen, char *tbuf, size_t bufsize)
+static const std::set<std::string_view> kinsoku_list{
+    // clang-format off
+    "、", "。", "，", "．", "？", "！",
+    "ァ", "ィ", "ゥ", "ェ", "ォ", "ャ", "ュ", "ョ", "ッ",
+    "ぁ", "ぃ", "ぅ", "ぇ", "ぉ", "ゃ", "ゅ", "ょ", "っ",
+    "ー", "～",
+    "」", "』", "）", "｝", "］", "》", "】",
+    // clang-format on
+};
+
+static bool is_kinsoku(std::string_view ch)
 {
-    int read_pt = 0;
-    int write_pt = 0;
-    int line_len = 0;
-    int word_punct = 0;
-    char ch[3];
-    ch[2] = '\0';
+    return (ch.length() >= 2) && kinsoku_list.contains(ch);
+}
 
-    while (str[read_pt]) {
-#ifdef JP
-        bool kinsoku = false;
-        bool kanji;
-#endif
-        int ch_len = 1;
-        ch[0] = str[read_pt];
-        ch[1] = '\0';
-#ifdef JP
-        kanji = iskanji(ch[0]);
+/*!
+ * @brief 文字列を指定した最大長を目安として分割する
+ *
+ * 与えられた文字列 sv を指定した最大長 maxlen ごとに分割する。
+ * 分割する際には以下の配慮を行う。
+ *
+ * - なるべく空白(' ')の部分で分割しようとする。具体的には表示可能なASCII文字が連続している途中で
+ *   最大長に達した場合、最後に空白が出現した位置で分割する。
+ *   但し、最大長に達した時点で連続している部分の長さが maxlen の約 1/3 以上になる場合は連続の途中でも分割する。
+ * - 分割後の先頭の文字が空白である場合は残さず削除する。
+ * - 改行文字('\\n')が検出された場合はその位置で強制的に分割する。
+ * - 日本語（全角文字）の場合は基本的にどこでも分割するが、分割後の先頭の文字が kinsoku_list
+ *   に含まれる場合はその1文字前で分割する。（いわゆる行頭禁則処理）
+ * - 終端文字('\\0')の領域を残すため、分割後の文字列の長さは最大 maxlen - 1 バイトになるように分割する。
+ *
+ * @param sv 分割する文字列
+ * @param maxlen 分割する最大長
+ * @return std::vector<std::string> 分割後の文字列を要素とする配列
+ */
+std::vector<std::string> shape_buffer(std::string_view sv, size_t maxlen)
+{
+    std::vector<std::string> result;
+    std::string line;
+    auto separate_pos = 0U;
 
-        if (kanji) {
-            ch[1] = str[read_pt + 1];
-            ch_len = 2;
+    while (line.length() < sv.length()) {
+        const auto is_kanji = _(iskanji(sv[line.length()]), false);
+        auto ch = sv.substr(line.length(), is_kanji ? 2 : 1);
+        const auto is_newline = ch[0] == '\n';
 
-            if (strcmp(ch, "。") == 0 || strcmp(ch, "、") == 0 || strcmp(ch, "ィ") == 0 || strcmp(ch, "ー") == 0) {
-                kinsoku = true;
-            }
-        } else if (!isprint(ch[0])) {
-            ch[0] = ' ';
+        if ((ch.length() == 1) && !isprint(ch[0])) {
+            ch = " ";
         }
-#else
-        if (!isprint(ch[0])) {
-            ch[0] = ' ';
-        }
-#endif
 
-        if (line_len + ch_len > maxlen - 1 || str[read_pt] == '\n') {
-            int word_len = read_pt - word_punct;
-#ifdef JP
-            if (kanji && !kinsoku) {
-                /* nothing */;
-            } else
-#endif
-                if (ch[0] == ' ' || word_len >= line_len / 2) {
-                read_pt++;
+        if ((line.length() + ch.length() >= maxlen) || is_newline) {
+            if ((ch[0] == ' ') || (line.length() >= separate_pos * 2) || (is_kanji && !is_kinsoku(ch))) {
+                sv.remove_prefix(line.length());
             } else {
-                read_pt = word_punct;
-                if (str[word_punct] == ' ') {
-                    read_pt++;
-                }
-                write_pt -= word_len;
+                line.erase(separate_pos);
+                sv.remove_prefix(separate_pos);
+            }
+            if ((sv.front() == ' ') || is_newline) {
+                sv.remove_prefix(1);
             }
 
-            tbuf[write_pt++] = '\0';
-            line_len = 0;
-            word_punct = read_pt;
+            result.push_back(std::move(line));
+            line.clear();
+            separate_pos = 0;
             continue;
         }
 
-        if (ch[0] == ' ') {
-            word_punct = read_pt;
+        if ((ch[0] == ' ') || is_kanji) {
+            separate_pos = line.length();
         }
 
-#ifdef JP
-        if (!kinsoku) {
-            word_punct = read_pt;
-        }
-#endif
-
-        if ((size_t)(write_pt + 3) >= bufsize) {
-            break;
-        }
-
-        tbuf[write_pt++] = ch[0];
-        line_len++;
-        read_pt++;
-#ifdef JP
-        if (kanji) {
-            tbuf[write_pt++] = ch[1];
-            line_len++;
-            read_pt++;
-        }
-#endif
+        line.append(ch);
     }
 
-    tbuf[write_pt] = '\0';
-    tbuf[write_pt + 1] = '\0';
+    if (!line.empty()) {
+        result.push_back(std::move(line));
+    }
+
+    return result;
 }

--- a/src/util/buffer-shaper.h
+++ b/src/util/buffer-shaper.h
@@ -1,5 +1,8 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include <string>
+#include <string_view>
+#include <vector>
 
-void shape_buffer(concptr str, int wlen, char *tbuf, size_t bufsize);
+std::vector<std::string> shape_buffer(std::string_view sv, size_t maxlen);

--- a/src/view/display-util.cpp
+++ b/src/view/display-util.cpp
@@ -1,5 +1,7 @@
 ﻿#include "view/display-util.h"
+#include "term/screen-processor.h"
 #include "term/term-color-types.h"
+#include "util/buffer-shaper.h"
 #include <string>
 #include <vector>
 
@@ -88,4 +90,23 @@ void display_player_one_line(int entry, std::string_view val, TERM_COLOR attr)
     }
     str.append(val);
     term_putstr(col + head_len, row, -1, attr, str);
+}
+
+/*!
+ * @brief 文字列を折り返しながら画面に表示する
+ *
+ * @param sv 表示する文字列
+ * @param width 折り返しをする幅
+ * @param start_row 表示開始行
+ * @param col 表示開始桁
+ * @return 表示した行数
+ */
+int display_wrap_around(std::string_view sv, size_t width, int start_row, int col)
+{
+    auto line_count = 0;
+    for (const auto &line : shape_buffer(sv, width)) {
+        prt(line, start_row + line_count, col);
+        ++line_count;
+    }
+    return line_count;
 }

--- a/src/view/display-util.h
+++ b/src/view/display-util.h
@@ -4,3 +4,4 @@
 #include <string_view>
 
 void display_player_one_line(int entry, std::string_view val, TERM_COLOR attr);
+int display_wrap_around(std::string_view sv, size_t width, int start_row, int col);


### PR DESCRIPTION
shape_buffer のシグネチャを結果を格納するバッファ領域を指すポインタを受け取る方式から
std::string 型文字列の配列を返す方式に変更する。

# 変更点のポイント

以下に変更のポイントを記載するので、それを念頭にレビューいただきたいです。

## shape_buffer

シグネチャ変更に伴い、だいぶ読みづらい元のコードから仕様を整理し C++ 風に書き直しました。仕様の詳細は doxygen コメントにまとめています。また、禁則処理したほうがよいと思われる文字を複数追加しました。
なお、日本語独特の処理であるため、ネットを検索してもふさわしい英語がぱっと出て来ないのでローマ字名称の kinsoku のままにしています。

## shape_buffer の結果を画面に出力する処理

この処理を行う似たようなループが大量にあったので、display_wrap_around 関数にまとめそれを呼ぶようにしました。一部元のコードでは prt ではなく put_str を使っているものがありますが、この2者の違いは行末まで一旦消すかどうか（prtは消す、put_strは消さない）だけで、 put_str を使用している箇所も prt で問題ないと判断しました。これについてもチェックいただきたく。

## show_killing_monster について

ごちゃごちゃしていますが、#2955 で改めてリファクタリングを予定しているので、今回の PR では現在のコードを極力維持する形で修正しています。
