### PR TITLE
Refactor monster_desc() to avoid sprintf().  To work with the …

### DIFF
--- a/src/action/movement-execution.cpp
+++ b/src/action/movement-execution.cpp
@@ -166,7 +166,7 @@ void exe_movement(PlayerType *player_ptr, DIRECTION dir, bool do_pickup, bool br
     p_can_kill_walls &= f_ptr->flags.has(TerrainCharacteristics::HURT_DISI);
     p_can_kill_walls &= !p_can_enter || f_ptr->flags.has_not(TerrainCharacteristics::LOS);
     p_can_kill_walls &= f_ptr->flags.has_not(TerrainCharacteristics::PERMANENT);
-    GAME_TEXT m_name[MAX_NLEN];
+    std::string m_name;
     bool can_move = true;
     bool do_past = false;
     if (g_ptr->m_idx && (m_ptr->ml || p_can_enter || p_can_kill_walls)) {
@@ -181,7 +181,7 @@ void exe_movement(PlayerType *player_ptr, DIRECTION dir, bool do_pickup, bool br
         can_cast &= player_ptr->muta.has_not(PlayerMutationType::BERS_RAGE) || !is_shero(player_ptr);
         if (!m_ptr->is_hostile() && can_cast && pattern_seq(player_ptr, player_ptr->y, player_ptr->x, y, x) && (p_can_enter || p_can_kill_walls)) {
             (void)set_monster_csleep(player_ptr, g_ptr->m_idx, 0);
-            monster_desc(player_ptr, m_name, m_ptr, 0);
+            m_name = monster_desc(player_ptr, m_ptr, 0);
             if (m_ptr->ml) {
                 if (!is_hallucinated) {
                     monster_race_track(player_ptr, m_ptr->ap_r_idx);
@@ -196,7 +196,7 @@ void exe_movement(PlayerType *player_ptr, DIRECTION dir, bool do_pickup, bool br
             } else if (monster_can_cross_terrain(player_ptr, floor_ptr->grid_array[player_ptr->y][player_ptr->x].feat, r_ptr, 0)) {
                 do_past = true;
             } else {
-                msg_format(_("%^sが邪魔だ！", "%^s is in your way!"), m_name);
+                msg_format(_("%^sが邪魔だ！", "%^s is in your way!"), m_name.data());
                 PlayerEnergy(player_ptr).reset_player_turn();
                 can_move = false;
             }
@@ -216,9 +216,8 @@ void exe_movement(PlayerType *player_ptr, DIRECTION dir, bool do_pickup, bool br
             can_move = false;
             disturb(player_ptr, false, true);
         } else if (riding_m_ptr->is_fearful()) {
-            GAME_TEXT steed_name[MAX_NLEN];
-            monster_desc(player_ptr, steed_name, riding_m_ptr, 0);
-            msg_format(_("%sが恐怖していて制御できない。", "%^s is too scared to control."), steed_name);
+            const auto steed_name = monster_desc(player_ptr, riding_m_ptr, 0);
+            msg_format(_("%sが恐怖していて制御できない。", "%^s is too scared to control."), steed_name.data());
             can_move = false;
             disturb(player_ptr, false, true);
         } else if (player_ptr->riding_ryoute) {
@@ -246,9 +245,8 @@ void exe_movement(PlayerType *player_ptr, DIRECTION dir, bool do_pickup, bool br
         }
 
         if (can_move && riding_m_ptr->is_stunned() && one_in_(2)) {
-            GAME_TEXT steed_name[MAX_NLEN];
-            monster_desc(player_ptr, steed_name, riding_m_ptr, 0);
-            msg_format(_("%sが朦朧としていてうまく動けない！", "You cannot control stunned %s!"), steed_name);
+            const auto steed_name = monster_desc(player_ptr, riding_m_ptr, 0);
+            msg_format(_("%sが朦朧としていてうまく動けない！", "You cannot control stunned %s!"), steed_name.data());
             can_move = false;
             disturb(player_ptr, false, true);
         }
@@ -342,7 +340,7 @@ void exe_movement(PlayerType *player_ptr, DIRECTION dir, bool do_pickup, bool br
     }
 
     if (do_past) {
-        msg_format(_("%sを押し退けた。", "You push past %s."), m_name);
+        msg_format(_("%sを押し退けた。", "You push past %s."), m_name.data());
     }
 
     if (player_ptr->wild_mode) {

--- a/src/action/mutation-execution.cpp
+++ b/src/action/mutation-execution.cpp
@@ -260,9 +260,8 @@ bool exe_mutation_power(PlayerType *player_ptr, PlayerMutationType power)
         r_ptr = &monraces_info[m_ptr->r_idx];
         if (r_ptr->kind_flags.has(MonsterKindType::EVIL) && none_bits(r_ptr->flags1, RF1_QUESTOR) && r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE) && !player_ptr->current_floor_ptr->inside_arena && !inside_quest(player_ptr->current_floor_ptr->quest_number) && (r_ptr->level < randint1(player_ptr->lev + 50)) && m_ptr->mflag2.has_not(MonsterConstantFlagType::NOGENO)) {
             if (record_named_pet && m_ptr->is_pet() && m_ptr->nickname) {
-                GAME_TEXT m_name[MAX_NLEN];
-                monster_desc(player_ptr, m_name, m_ptr, MD_INDEF_VISIBLE);
-                exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_GENOCIDE, m_name);
+                const auto m_name = monster_desc(player_ptr, m_ptr, MD_INDEF_VISIBLE);
+                exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_GENOCIDE, m_name.data());
             }
 
             delete_monster_idx(player_ptr, g_ptr->m_idx);

--- a/src/blue-magic/blue-magic-caster.cpp
+++ b/src/blue-magic/blue-magic-caster.cpp
@@ -93,20 +93,20 @@ static bool cast_blue_hand_doom(PlayerType *player_ptr, bmc_type *bmc_ptr)
     return true;
 }
 
-static bool exe_blue_teleport_back(PlayerType *player_ptr, GAME_TEXT *m_name)
+static std::pair<bool, std::string> exe_blue_teleport_back(PlayerType *player_ptr)
 {
     MonsterEntity *m_ptr;
     MonsterRaceInfo *r_ptr;
     auto *floor_ptr = player_ptr->current_floor_ptr;
     if ((floor_ptr->grid_array[target_row][target_col].m_idx == 0) || !player_has_los_bold(player_ptr, target_row, target_col) || !projectable(player_ptr, player_ptr->y, player_ptr->x, target_row, target_col)) {
-        return true;
+        return std::make_pair(true, std::string());
     }
 
     m_ptr = &floor_ptr->m_list[floor_ptr->grid_array[target_row][target_col].m_idx];
     r_ptr = &monraces_info[m_ptr->r_idx];
-    monster_desc(player_ptr, m_name, m_ptr, 0);
+    auto m_name = monster_desc(player_ptr, m_ptr, 0);
     if (r_ptr->resistance_flags.has_not(MonsterResistanceType::RESIST_TELEPORT)) {
-        return false;
+        return std::make_pair(false, m_name);
     }
 
     if (r_ptr->kind_flags.has(MonsterKindType::UNIQUE) || r_ptr->resistance_flags.has(MonsterResistanceType::RESIST_ALL)) {
@@ -114,20 +114,20 @@ static bool exe_blue_teleport_back(PlayerType *player_ptr, GAME_TEXT *m_name)
             r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_TELEPORT);
         }
 
-        msg_format(_("%sには効果がなかった！", "%s is unaffected!"), m_name);
-        return true;
+        msg_format(_("%sには効果がなかった！", "%s is unaffected!"), m_name.data());
+        return std::make_pair(true, m_name);
     }
 
     if (r_ptr->level <= randint1(100)) {
-        return false;
+        return std::make_pair(false, m_name);
     }
 
     if (is_original_ap_and_seen(player_ptr, m_ptr)) {
         r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_TELEPORT);
     }
 
-    msg_format(_("%sには耐性がある！", "%s resists!"), m_name);
-    return true;
+    msg_format(_("%sには耐性がある！", "%s resists!"), m_name.data());
+    return std::make_pair(true, m_name);
 }
 
 static bool cast_blue_teleport_back(PlayerType *player_ptr)
@@ -136,12 +136,12 @@ static bool cast_blue_teleport_back(PlayerType *player_ptr)
         return false;
     }
 
-    GAME_TEXT m_name[MAX_NLEN];
-    if (exe_blue_teleport_back(player_ptr, m_name)) {
+    const auto [resisted, m_name] = exe_blue_teleport_back(player_ptr);
+    if (resisted) {
         return true;
     }
 
-    msg_format(_("%sを引き戻した。", "You command %s to return."), m_name);
+    msg_format(_("%sを引き戻した。", "You command %s to return."), m_name.data());
     teleport_monster_to(
         player_ptr, player_ptr->current_floor_ptr->grid_array[target_row][target_col].m_idx, player_ptr->y, player_ptr->x, 100, TELEPORT_PASSIVE);
     return true;

--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -112,9 +112,7 @@ static void natural_attack(PlayerType *player_ptr, MONSTER_IDX m_idx, PlayerMuta
         atk_desc = _("未定義の部位", "undefined body part");
     }
 
-    GAME_TEXT m_name[MAX_NLEN];
-    monster_desc(player_ptr, m_name, m_ptr, 0);
-
+    const auto m_name = monster_desc(player_ptr, m_ptr, 0);
     int bonus = player_ptr->to_h_m + (player_ptr->lev * 6 / 5);
     int chance = (player_ptr->skill_thn + (bonus * BTH_PLUS_ADJ));
 
@@ -122,12 +120,12 @@ static void natural_attack(PlayerType *player_ptr, MONSTER_IDX m_idx, PlayerMuta
     is_hit &= test_hit_norm(player_ptr, chance, r_ptr->ac, m_ptr->ml);
     if (!is_hit) {
         sound(SOUND_MISS);
-        msg_format(_("ミス！ %sにかわされた。", "You miss %s."), m_name);
+        msg_format(_("ミス！ %sにかわされた。", "You miss %s."), m_name.data());
         return;
     }
 
     sound(SOUND_HIT);
-    msg_format(_("%sを%sで攻撃した。", "You hit %s with your %s."), m_name, atk_desc);
+    msg_format(_("%sを%sで攻撃した。", "You hit %s with your %s."), m_name.data(), atk_desc);
 
     int k = damroll(dice_num, dice_side);
     k = critical_norm(player_ptr, n_weight, bonus, k, (int16_t)bonus, HISSATSU_NONE);
@@ -176,7 +174,6 @@ bool do_cmd_attack(PlayerType *player_ptr, POSITION y, POSITION x, combat_option
     auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
     auto *m_ptr = &player_ptr->current_floor_ptr->m_list[g_ptr->m_idx];
     auto *r_ptr = &monraces_info[m_ptr->r_idx];
-    GAME_TEXT m_name[MAX_NLEN];
 
     const std::initializer_list<PlayerMutationType> mutation_attack_methods = { PlayerMutationType::HORNS, PlayerMutationType::BEAK, PlayerMutationType::SCOR_TAIL, PlayerMutationType::TRUNK, PlayerMutationType::TENTACLES };
 
@@ -190,8 +187,7 @@ bool do_cmd_attack(PlayerType *player_ptr, POSITION y, POSITION x, combat_option
         return false;
     }
 
-    monster_desc(player_ptr, m_name, m_ptr, 0);
-
+    const auto m_name = monster_desc(player_ptr, m_ptr, 0);
     auto effects = player_ptr->effects();
     auto is_hallucinated = effects->hallucination()->is_hallucinated();
     if (m_ptr->ml) {
@@ -234,7 +230,7 @@ bool do_cmd_attack(PlayerType *player_ptr, POSITION y, POSITION x, combat_option
         }
 
         if (is_stormbringer) {
-            msg_format(_("黒い刃は強欲に%sを攻撃した！", "Your black blade greedily attacks %s!"), m_name);
+            msg_format(_("黒い刃は強欲に%sを攻撃した！", "Your black blade greedily attacks %s!"), m_name.data());
             chg_virtue(player_ptr, V_INDIVIDUALISM, 1);
             chg_virtue(player_ptr, V_HONOUR, -1);
             chg_virtue(player_ptr, V_JUSTICE, -1);
@@ -246,7 +242,7 @@ bool do_cmd_attack(PlayerType *player_ptr, POSITION y, POSITION x, combat_option
                 chg_virtue(player_ptr, V_JUSTICE, -1);
                 chg_virtue(player_ptr, V_COMPASSION, -1);
             } else {
-                msg_format(_("%sを攻撃するのを止めた。", "You stop to avoid hitting %s."), m_name);
+                msg_format(_("%sを攻撃するのを止めた。", "You stop to avoid hitting %s."), m_name.data());
                 return false;
             }
         }
@@ -255,7 +251,7 @@ bool do_cmd_attack(PlayerType *player_ptr, POSITION y, POSITION x, combat_option
     if (effects->fear()->is_fearful()) {
         if (m_ptr->ml) {
             sound(SOUND_ATTACK_FAILED);
-            msg_format(_("恐くて%sを攻撃できない！", "You are too fearful to attack %s!"), m_name);
+            msg_format(_("恐くて%sを攻撃できない！", "You are too fearful to attack %s!"), m_name.data());
         } else {
             sound(SOUND_ATTACK_FAILED);
             msg_format(_("そっちには何か恐いものがいる！", "There is something scary in your way!"));
@@ -304,7 +300,7 @@ bool do_cmd_attack(PlayerType *player_ptr, POSITION y, POSITION x, combat_option
 
     if (fear && m_ptr->ml && !mdeath) {
         sound(SOUND_FLEE);
-        msg_format(_("%^sは恐怖して逃げ出した！", "%^s flees in terror!"), m_name);
+        msg_format(_("%^sは恐怖して逃げ出した！", "%^s flees in terror!"), m_name.data());
     }
 
     if (PlayerClass(player_ptr).samurai_stance_is(SamuraiStanceType::IAI) && ((mode != HISSATSU_IAI) || mdeath)) {

--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -919,10 +919,6 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
     case MonsterAbilityType::SPECIAL:
         break;
     case MonsterAbilityType::TELE_TO: {
-        MonsterEntity *m_ptr;
-        MonsterRaceInfo *r_ptr;
-        GAME_TEXT m_name[MAX_NLEN];
-
         if (!target_set(player_ptr, TARGET_KILL)) {
             return false;
         }
@@ -935,27 +931,27 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
         if (!projectable(player_ptr, player_ptr->y, player_ptr->x, target_row, target_col)) {
             break;
         }
-        m_ptr = &player_ptr->current_floor_ptr->m_list[player_ptr->current_floor_ptr->grid_array[target_row][target_col].m_idx];
-        r_ptr = &monraces_info[m_ptr->r_idx];
-        monster_desc(player_ptr, m_name, m_ptr, 0);
+        auto *m_ptr = &player_ptr->current_floor_ptr->m_list[player_ptr->current_floor_ptr->grid_array[target_row][target_col].m_idx];
+        auto *r_ptr = &monraces_info[m_ptr->r_idx];
+        const auto m_name = monster_desc(player_ptr, m_ptr, 0);
         if (r_ptr->resistance_flags.has(MonsterResistanceType::RESIST_TELEPORT)) {
             if (r_ptr->kind_flags.has(MonsterKindType::UNIQUE) || r_ptr->resistance_flags.has(MonsterResistanceType::RESIST_ALL)) {
                 if (is_original_ap_and_seen(player_ptr, m_ptr)) {
                     r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_TELEPORT);
                 }
-                msg_format(_("%sには効果がなかった！", "%s is unaffected!"), m_name);
+                msg_format(_("%sには効果がなかった！", "%s is unaffected!"), m_name.data());
 
                 break;
             } else if (r_ptr->level > randint1(100)) {
                 if (is_original_ap_and_seen(player_ptr, m_ptr)) {
                     r_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_TELEPORT);
                 }
-                msg_format(_("%sには耐性がある！", "%s resists!"), m_name);
+                msg_format(_("%sには耐性がある！", "%s resists!"), m_name.data());
 
                 break;
             }
         }
-        msg_format(_("%sを引き戻した。", "You command %s to return."), m_name);
+        msg_format(_("%sを引き戻した。", "You command %s to return."), m_name.data());
 
         teleport_monster_to(
             player_ptr, player_ptr->current_floor_ptr->grid_array[target_row][target_col].m_idx, player_ptr->y, player_ptr->x, 100, TELEPORT_PASSIVE);

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -102,23 +102,19 @@ void do_cmd_pet_dismiss(PlayerType *player_ptr)
 
     /* Process the monsters (backwards) */
     for (auto i = 0U; i < who.size(); i++) {
-        bool delete_this;
-        GAME_TEXT friend_name[MAX_NLEN];
-        bool kakunin;
-
         auto pet_ctr = who[i];
         m_ptr = &player_ptr->current_floor_ptr->m_list[pet_ctr];
 
-        delete_this = false;
-        kakunin = ((pet_ctr == player_ptr->riding) || (m_ptr->nickname));
-        monster_desc(player_ptr, friend_name, m_ptr, MD_ASSUME_VISIBLE);
+        bool delete_this = false;
+        bool kakunin = ((pet_ctr == player_ptr->riding) || (m_ptr->nickname));
+        const auto friend_name = monster_desc(player_ptr, m_ptr, MD_ASSUME_VISIBLE);
 
         if (!all_pets) {
             /* Hack -- health bar for this monster */
             health_track(player_ptr, pet_ctr);
             handle_stuff(player_ptr);
 
-            msg_format(_("%sを放しますか？ [Yes/No/Unnamed (%d体)]", "Dismiss %s? [Yes/No/Unnamed (%d remain)]"), friend_name, who.size() - i);
+            msg_format(_("%sを放しますか？ [Yes/No/Unnamed (%d体)]", "Dismiss %s? [Yes/No/Unnamed (%d remain)]"), friend_name.data(), who.size() - i);
 
             if (m_ptr->ml) {
                 move_cursor_relative(m_ptr->fy, m_ptr->fx);
@@ -131,7 +127,7 @@ void do_cmd_pet_dismiss(PlayerType *player_ptr)
                     delete_this = true;
 
                     if (kakunin) {
-                        msg_format(_("本当によろしいですか？ (%s) ", "Are you sure? (%s) "), friend_name);
+                        msg_format(_("本当によろしいですか？ (%s) ", "Are you sure? (%s) "), friend_name.data());
                         ch = inkey();
                         if (ch != 'Y' && ch != 'y') {
                             delete_this = false;
@@ -155,14 +151,12 @@ void do_cmd_pet_dismiss(PlayerType *player_ptr)
 
         if ((all_pets && !kakunin) || (!all_pets && delete_this)) {
             if (record_named_pet && m_ptr->nickname) {
-                GAME_TEXT m_name[MAX_NLEN];
-
-                monster_desc(player_ptr, m_name, m_ptr, MD_INDEF_VISIBLE);
-                exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_DISMISS, m_name);
+                const auto m_name = monster_desc(player_ptr, m_ptr, MD_INDEF_VISIBLE);
+                exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_DISMISS, m_name.data());
             }
 
             if (pet_ctr == player_ptr->riding) {
-                msg_format(_("%sから降りた。", "You dismount from %s. "), friend_name);
+                msg_format(_("%sから降りた。", "You dismount from %s. "), friend_name.data());
 
                 player_ptr->riding = 0;
 
@@ -171,7 +165,7 @@ void do_cmd_pet_dismiss(PlayerType *player_ptr)
             }
 
             /* HACK : Add the line to message buffer */
-            msg_format(_("%s を放した。", "Dismissed %s."), friend_name);
+            msg_format(_("%s を放した。", "Dismissed %s."), friend_name.data());
             player_ptr->update |= (PU_BONUS);
             player_ptr->window_flags |= (PW_MESSAGE);
 
@@ -284,10 +278,9 @@ bool do_cmd_riding(PlayerType *player_ptr, bool force)
         }
 
         if (m_ptr->is_asleep()) {
-            GAME_TEXT m_name[MAX_NLEN];
-            monster_desc(player_ptr, m_name, m_ptr, 0);
+            const auto m_name = monster_desc(player_ptr, m_ptr, 0);
             (void)set_monster_csleep(player_ptr, g_ptr->m_idx, 0);
-            msg_format(_("%sを起こした。", "You have woken %s up."), m_name);
+            msg_format(_("%sを起こした。", "You have woken %s up."), m_name.data());
         }
 
         if (player_ptr->action == ACTION_MONK_STANCE) {
@@ -322,7 +315,6 @@ static void do_name_pet(PlayerType *player_ptr)
 {
     MonsterEntity *m_ptr;
     char out_val[20];
-    GAME_TEXT m_name[MAX_NLEN];
     bool old_name = false;
     bool old_target_pet = target_pet;
 
@@ -345,9 +337,8 @@ static void do_name_pet(PlayerType *player_ptr)
             msg_print(_("そのモンスターの名前は変えられない！", "You cannot change the name of this monster!"));
             return;
         }
-        monster_desc(player_ptr, m_name, m_ptr, 0);
 
-        msg_format(_("%sに名前をつける。", "Name %s."), m_name);
+        msg_format(_("%sに名前をつける。", "Name %s."), monster_desc(player_ptr, m_ptr, 0).data());
         msg_print(nullptr);
 
         /* Start with nothing */
@@ -366,13 +357,11 @@ static void do_name_pet(PlayerType *player_ptr)
                 /* Save the inscription */
                 m_ptr->nickname = quark_add(out_val);
                 if (record_named_pet) {
-                    monster_desc(player_ptr, m_name, m_ptr, MD_INDEF_VISIBLE);
-                    exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_NAME, m_name);
+                    exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_NAME, monster_desc(player_ptr, m_ptr, MD_INDEF_VISIBLE).data());
                 }
             } else {
                 if (record_named_pet && old_name) {
-                    monster_desc(player_ptr, m_name, m_ptr, MD_INDEF_VISIBLE);
-                    exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_UNNAME, m_name);
+                    exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_UNNAME, monster_desc(player_ptr, m_ptr, MD_INDEF_VISIBLE).data());
                 }
                 m_ptr->nickname = 0;
             }

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -781,12 +781,10 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX item, ItemEntity *j_ptr, SPE
 
                     /* Handle visible monster */
                     else {
-                        GAME_TEXT m_name[MAX_NLEN];
-
                         /* Get "the monster" or "it" */
-                        monster_desc(player_ptr, m_name, m_ptr, 0);
+                        const auto m_name = monster_desc(player_ptr, m_ptr, 0);
 
-                        msg_format(_("%sが%sに命中した。", "The %s hits %s."), o_name, m_name);
+                        msg_format(_("%sが%sに命中した。", "The %s hits %s."), o_name, m_name.data());
 
                         if (m_ptr->ml) {
                             if (!player_ptr->effects()->hallucination()->is_hallucinated()) {
@@ -801,14 +799,12 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX item, ItemEntity *j_ptr, SPE
                         const auto is_unique = r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
                         const auto fatality = randint1(r_ptr->level / (3 + sniper_concent)) + (8 - sniper_concent);
                         if ((randint1(fatality) == 1) && !is_unique && none_bits(r_ptr->flags7, RF7_UNIQUE2)) {
-                            GAME_TEXT m_name[MAX_NLEN];
-
                             /* Get "the monster" or "it" */
-                            monster_desc(player_ptr, m_name, m_ptr, 0);
+                            const auto m_name = monster_desc(player_ptr, m_ptr, 0);
 
                             tdam = m_ptr->hp + 1;
                             base_dam = tdam;
-                            msg_format(_("%sの急所に突き刺さった！", "Your shot hit a fatal spot of %s!"), m_name);
+                            msg_format(_("%sの急所に突き刺さった！", "Your shot hit a fatal spot of %s!"), m_name.data());
                         } else {
                             tdam = 1;
                             base_dam = tdam;
@@ -859,12 +855,10 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX item, ItemEntity *j_ptr, SPE
                     else {
                         /* STICK TO */
                         if (q_ptr->is_fixed_artifact() && (sniper_concent == 0)) {
-                            GAME_TEXT m_name[MAX_NLEN];
-
-                            monster_desc(player_ptr, m_name, m_ptr, 0);
+                            const auto m_name = monster_desc(player_ptr, m_ptr, 0);
 
                             stick_to = true;
-                            msg_format(_("%sは%sに突き刺さった！", "%^s is stuck in %s!"), o_name, m_name);
+                            msg_format(_("%sは%sに突き刺さった！", "%^s is stuck in %s!"), o_name, m_name.data());
                         }
 
                         message_pain(player_ptr, c_mon_ptr->m_idx, tdam);
@@ -875,10 +869,9 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX item, ItemEntity *j_ptr, SPE
                         }
 
                         if (fear && m_ptr->ml) {
-                            GAME_TEXT m_name[MAX_NLEN];
+                            const auto m_name = monster_desc(player_ptr, m_ptr, 0);
                             sound(SOUND_FLEE);
-                            monster_desc(player_ptr, m_name, m_ptr, 0);
-                            msg_format(_("%^sは恐怖して逃げ出した！", "%^s flees in terror!"), m_name);
+                            msg_format(_("%^sは恐怖して逃げ出した！", "%^s flees in terror!"), m_name.data());
                         }
 
                         set_target(m_ptr, player_ptr->y, player_ptr->x);
@@ -1053,9 +1046,8 @@ bool test_hit_fire(PlayerType *player_ptr, int chance, MonsterEntity *m_ptr, int
     /* Power competes against armor */
     if (randint0(chance) < (ac * 3 / 4)) {
         if (m_ptr->r_idx == MonsterRaceId::GOEMON && !m_ptr->is_asleep()) {
-            GAME_TEXT m_name[MAX_NLEN];
-            monster_desc(player_ptr, m_name, m_ptr, 0);
-            msg_format(_("%sは%sを斬り捨てた！", "%s cuts down %s!"), m_name, o_name);
+            const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+            msg_format(_("%sは%sを斬り捨てた！", "%s cuts down %s!"), m_name.data(), o_name);
         }
         return false;
     }

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -87,9 +87,8 @@ static void process_fishing(PlayerType *player_ptr)
             y = player_ptr->y + ddy[player_ptr->fishing_dir];
             x = player_ptr->x + ddx[player_ptr->fishing_dir];
             if (place_monster_aux(player_ptr, 0, y, x, r_idx, PM_NO_KAGE)) {
-                GAME_TEXT m_name[MAX_NLEN];
-                monster_desc(player_ptr, m_name, &floor_ptr->m_list[floor_ptr->grid_array[y][x].m_idx], 0);
-                msg_format(_("%sが釣れた！", "You have a good catch!"), m_name);
+                const auto m_name = monster_desc(player_ptr, &floor_ptr->m_list[floor_ptr->grid_array[y][x].m_idx], 0);
+                msg_format(_("%sが釣れた！", "You have a good catch!"), m_name.data());
                 success = true;
             }
         }
@@ -187,36 +186,32 @@ void process_player(PlayerType *player_ptr)
         auto *m_ptr = &player_ptr->current_floor_ptr->m_list[player_ptr->riding];
         auto *r_ptr = &monraces_info[m_ptr->r_idx];
         if (m_ptr->is_asleep()) {
-            GAME_TEXT m_name[MAX_NLEN];
+            const auto m_name = monster_desc(player_ptr, m_ptr, 0);
             (void)set_monster_csleep(player_ptr, player_ptr->riding, 0);
-            monster_desc(player_ptr, m_name, m_ptr, 0);
-            msg_format(_("%^sを起こした。", "You have woken %s up."), m_name);
+            msg_format(_("%^sを起こした。", "You have woken %s up."), m_name.data());
         }
 
         if (m_ptr->is_stunned()) {
             if (set_monster_stunned(player_ptr, player_ptr->riding,
                     (randint0(r_ptr->level) < player_ptr->skill_exp[PlayerSkillKindType::RIDING]) ? 0 : (m_ptr->get_remaining_stun() - 1))) {
-                GAME_TEXT m_name[MAX_NLEN];
-                monster_desc(player_ptr, m_name, m_ptr, 0);
-                msg_format(_("%^sを朦朧状態から立ち直らせた。", "%^s is no longer stunned."), m_name);
+                const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+                msg_format(_("%^sを朦朧状態から立ち直らせた。", "%^s is no longer stunned."), m_name.data());
             }
         }
 
         if (m_ptr->is_confused()) {
             if (set_monster_confused(player_ptr, player_ptr->riding,
                     (randint0(r_ptr->level) < player_ptr->skill_exp[PlayerSkillKindType::RIDING]) ? 0 : (m_ptr->get_remaining_confusion() - 1))) {
-                GAME_TEXT m_name[MAX_NLEN];
-                monster_desc(player_ptr, m_name, m_ptr, 0);
-                msg_format(_("%^sを混乱状態から立ち直らせた。", "%^s is no longer confused."), m_name);
+                const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+                msg_format(_("%^sを混乱状態から立ち直らせた。", "%^s is no longer confused."), m_name.data());
             }
         }
 
         if (m_ptr->is_fearful()) {
             if (set_monster_monfear(player_ptr, player_ptr->riding,
                     (randint0(r_ptr->level) < player_ptr->skill_exp[PlayerSkillKindType::RIDING]) ? 0 : (m_ptr->get_remaining_fear() - 1))) {
-                GAME_TEXT m_name[MAX_NLEN];
-                monster_desc(player_ptr, m_name, m_ptr, 0);
-                msg_format(_("%^sを恐怖から立ち直らせた。", "%^s is no longer fearful."), m_name);
+                const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+                msg_format(_("%^sを恐怖から立ち直らせた。", "%^s is no longer fearful."), m_name.data());
             }
         }
 

--- a/src/effect/effect-monster-psi.cpp
+++ b/src/effect/effect-monster-psi.cpp
@@ -20,6 +20,7 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
+#include "util/string-processor.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 
@@ -161,7 +162,7 @@ static void effect_monster_psi_resist(PlayerType *player_ptr, effect_monster_typ
     }
 
     /* Injure +/- confusion */
-    monster_desc(player_ptr, em_ptr->killer, em_ptr->m_ptr, MD_WRONGDOER_NAME);
+    angband_strcpy(em_ptr->killer, monster_desc(player_ptr, em_ptr->m_ptr, MD_WRONGDOER_NAME).data(), sizeof(em_ptr->killer));
     take_hit(player_ptr, DAMAGE_ATTACK, em_ptr->dam, em_ptr->killer);
     effect_monster_psi_reflect_extra_effect(player_ptr, em_ptr);
     em_ptr->dam = 0;
@@ -253,7 +254,7 @@ static void effect_monster_psi_drain_resist(PlayerType *player_ptr, effect_monst
         return;
     }
 
-    monster_desc(player_ptr, em_ptr->killer, em_ptr->m_ptr, MD_WRONGDOER_NAME);
+    angband_strcpy(em_ptr->killer, monster_desc(player_ptr, em_ptr->m_ptr, MD_WRONGDOER_NAME).data(), sizeof(em_ptr->killer));
     if (check_multishadow(player_ptr)) {
         take_hit(player_ptr, DAMAGE_ATTACK, em_ptr->dam, em_ptr->killer);
         em_ptr->dam = 0;

--- a/src/effect/effect-monster-spirit.cpp
+++ b/src/effect/effect-monster-spirit.cpp
@@ -16,6 +16,7 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
+#include "util/string-processor.h"
 #include "view/display-messages.h"
 
 ProcessResult effect_monster_drain_mana(PlayerType *player_ptr, effect_monster_type *em_ptr)
@@ -60,7 +61,7 @@ ProcessResult effect_monster_drain_mana(PlayerType *player_ptr, effect_monster_t
     }
 
     if (em_ptr->see_s_msg) {
-        monster_desc(player_ptr, em_ptr->killer, em_ptr->m_caster_ptr, 0);
+        angband_strcpy(em_ptr->killer, monster_desc(player_ptr, em_ptr->m_caster_ptr, 0).data(), sizeof(em_ptr->killer));
         msg_format(_("%^sは気分が良さそうだ。", "%^s appears healthier."), em_ptr->killer);
     }
 

--- a/src/effect/effect-monster.cpp
+++ b/src/effect/effect-monster.cpp
@@ -53,6 +53,7 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
+#include "util/string-processor.h"
 #include "view/display-messages.h"
 #include <algorithm>
 
@@ -108,8 +109,8 @@ static ProcessResult is_affective(PlayerType *player_ptr, effect_monster_type *e
 static void make_description_of_affecred_monster(PlayerType *player_ptr, effect_monster_type *em_ptr)
 {
     em_ptr->dam = (em_ptr->dam + em_ptr->r) / (em_ptr->r + 1);
-    monster_desc(player_ptr, em_ptr->m_name, em_ptr->m_ptr, 0);
-    monster_desc(player_ptr, em_ptr->m_poss, em_ptr->m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE);
+    angband_strcpy(em_ptr->m_name, monster_desc(player_ptr, em_ptr->m_ptr, 0).data(), sizeof(em_ptr->m_name));
+    angband_strcpy(em_ptr->m_poss, monster_desc(player_ptr, em_ptr->m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE).data(), sizeof(em_ptr->m_poss));
 }
 
 /*!
@@ -181,7 +182,7 @@ static void effect_damage_killed_pet(PlayerType *player_ptr, effect_monster_type
 {
     bool sad = em_ptr->m_ptr->is_pet() && !(em_ptr->m_ptr->ml);
     if (em_ptr->known && em_ptr->note) {
-        monster_desc(player_ptr, em_ptr->m_name, em_ptr->m_ptr, MD_TRUE_NAME);
+        angband_strcpy(em_ptr->m_name, monster_desc(player_ptr, em_ptr->m_ptr, MD_TRUE_NAME).data(), sizeof(em_ptr->m_name));
         if (em_ptr->see_s_msg) {
             msg_format("%^s%s", em_ptr->m_name, em_ptr->note);
         } else {
@@ -269,9 +270,8 @@ static bool heal_leaper(PlayerType *player_ptr, effect_monster_type *em_ptr)
     }
 
     if (record_named_pet && em_ptr->m_ptr->is_pet() && em_ptr->m_ptr->nickname) {
-        char m2_name[MAX_NLEN];
-        monster_desc(player_ptr, m2_name, em_ptr->m_ptr, MD_INDEF_VISIBLE);
-        exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_HEAL_LEPER, m2_name);
+        const auto m2_name = monster_desc(player_ptr, em_ptr->m_ptr, MD_INDEF_VISIBLE);
+        exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_HEAL_LEPER, m2_name.data());
     }
 
     delete_monster_idx(player_ptr, em_ptr->g_ptr->m_idx);

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -547,13 +547,12 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
                 }
             }
 
-            GAME_TEXT who_name[MAX_NLEN];
-            who_name[0] = '\0';
+            std::string who_name;
             if (who > 0) {
-                monster_desc(player_ptr, who_name, &player_ptr->current_floor_ptr->m_list[who], MD_WRONGDOER_NAME);
+                who_name = monster_desc(player_ptr, &player_ptr->current_floor_ptr->m_list[who], MD_WRONGDOER_NAME);
             }
 
-            if (affect_player(who, player_ptr, who_name, effective_dist, y, x, dam, typ, flag, project)) {
+            if (affect_player(who, player_ptr, who_name.data(), effective_dist, y, x, dam, typ, flag, project)) {
                 res.notice = true;
                 res.affected_player = true;
             }
@@ -561,17 +560,16 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX who, POSITION ra
     }
 
     if (player_ptr->riding) {
-        GAME_TEXT m_name[MAX_NLEN];
-        monster_desc(player_ptr, m_name, &player_ptr->current_floor_ptr->m_list[player_ptr->riding], 0);
+        const auto m_name = monster_desc(player_ptr, &player_ptr->current_floor_ptr->m_list[player_ptr->riding], 0);
         if (rakubadam_m > 0) {
             if (process_fall_off_horse(player_ptr, rakubadam_m, false)) {
-                msg_format(_("%^sに振り落とされた！", "%^s has thrown you off!"), m_name);
+                msg_format(_("%^sに振り落とされた！", "%^s has thrown you off!"), m_name.data());
             }
         }
 
         if (player_ptr->riding && rakubadam_p > 0) {
             if (process_fall_off_horse(player_ptr, rakubadam_p, false)) {
-                msg_format(_("%^sから落ちてしまった！", "You have fallen from %s."), m_name);
+                msg_format(_("%^sから落ちてしまった！", "You have fallen from %s."), m_name.data());
             }
         }
     }

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -151,12 +151,9 @@ static void place_pet(PlayerType *player_ptr)
         } else {
             auto *m_ptr = &party_mon[current_monster];
             auto &r_ref = m_ptr->get_real_r_ref();
-            GAME_TEXT m_name[MAX_NLEN];
-            monster_desc(player_ptr, m_name, m_ptr, 0);
-            msg_format(_("%sとはぐれてしまった。", "You have lost sight of %s."), m_name);
+            msg_format(_("%sとはぐれてしまった。", "You have lost sight of %s."), monster_desc(player_ptr, m_ptr, 0).data());
             if (record_named_pet && m_ptr->nickname) {
-                monster_desc(player_ptr, m_name, m_ptr, MD_INDEF_VISIBLE);
-                exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_LOST_SIGHT, m_name);
+                exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_LOST_SIGHT, monster_desc(player_ptr, m_ptr, MD_INDEF_VISIBLE).data());
             }
 
             if (r_ref.cur_num) {

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -99,13 +99,11 @@ static void record_pet_diary(PlayerType *player_ptr)
 
     for (MONSTER_IDX i = player_ptr->current_floor_ptr->m_max - 1; i >= 1; i--) {
         auto *m_ptr = &player_ptr->current_floor_ptr->m_list[i];
-        GAME_TEXT m_name[MAX_NLEN];
         if (!m_ptr->is_valid() || !m_ptr->is_pet() || !m_ptr->nickname || (player_ptr->riding == i)) {
             continue;
         }
 
-        monster_desc(player_ptr, m_name, m_ptr, MD_ASSUME_VISIBLE | MD_INDEF_VISIBLE);
-        exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_MOVED, m_name);
+        exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_MOVED, monster_desc(player_ptr, m_ptr, MD_ASSUME_VISIBLE | MD_INDEF_VISIBLE).data());
     }
 }
 
@@ -130,9 +128,8 @@ static void preserve_pet(PlayerType *player_ptr)
         }
 
         if (is_seen(player_ptr, m_ptr)) {
-            GAME_TEXT m_name[MAX_NLEN];
-            monster_desc(player_ptr, m_name, m_ptr, 0);
-            msg_format(_("%sは消え去った！", "%^s disappears!"), m_name);
+            const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+            msg_format(_("%sは消え去った！", "%^s disappears!"), m_name.data());
         }
 
         delete_monster_idx(player_ptr, i);

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -76,9 +76,8 @@ static void dump_aux_pet(PlayerType *player_ptr, FILE *fff)
             pet = true;
         }
 
-        GAME_TEXT pet_name[MAX_NLEN];
-        monster_desc(player_ptr, pet_name, m_ptr, MD_ASSUME_VISIBLE | MD_INDEF_VISIBLE);
-        fprintf(fff, "%s\n", pet_name);
+        const auto pet_name = monster_desc(player_ptr, m_ptr, MD_ASSUME_VISIBLE | MD_INDEF_VISIBLE);
+        fprintf(fff, "%s\n", pet_name.data());
     }
 
     if (!pet_settings) {

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -119,7 +119,6 @@ void do_cmd_knowledge_pets(PlayerType *player_ptr)
     }
 
     MonsterEntity *m_ptr;
-    GAME_TEXT pet_name[MAX_NLEN];
     int t_friends = 0;
     for (int i = player_ptr->current_floor_ptr->m_max - 1; i >= 1; i--) {
         m_ptr = &player_ptr->current_floor_ptr->m_list[i];
@@ -128,8 +127,8 @@ void do_cmd_knowledge_pets(PlayerType *player_ptr)
         }
 
         t_friends++;
-        monster_desc(player_ptr, pet_name, m_ptr, MD_ASSUME_VISIBLE | MD_INDEF_VISIBLE);
-        fprintf(fff, "%s (%s)\n", pet_name, look_mon_desc(m_ptr, 0x00).data());
+        const auto pet_name = monster_desc(player_ptr, m_ptr, MD_ASSUME_VISIBLE | MD_INDEF_VISIBLE);
+        fprintf(fff, "%s (%s)\n", pet_name.data(), look_mon_desc(m_ptr, 0x00).data());
     }
 
     int show_upkeep = calculate_upkeep(player_ptr);

--- a/src/melee/melee-postprocess.cpp
+++ b/src/melee/melee-postprocess.cpp
@@ -43,6 +43,7 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
+#include "util/string-processor.h"
 #include "view/display-messages.h"
 
 // Melee-post-process-type
@@ -151,7 +152,7 @@ static void print_monster_dead_by_monster(PlayerType *player_ptr, mam_pp_type *m
         return;
     }
 
-    monster_desc(player_ptr, mam_pp_ptr->m_name, mam_pp_ptr->m_ptr, MD_TRUE_NAME);
+    angband_strcpy(mam_pp_ptr->m_name, monster_desc(player_ptr, mam_pp_ptr->m_ptr, MD_TRUE_NAME).data(), sizeof(mam_pp_ptr->m_name));
     if (!mam_pp_ptr->seen) {
         player_ptr->current_floor_ptr->monster_noise = true;
         return;
@@ -251,7 +252,7 @@ static void fall_off_horse_by_melee(PlayerType *player_ptr, mam_pp_type *mam_pp_
         return;
     }
 
-    monster_desc(player_ptr, mam_pp_ptr->m_name, mam_pp_ptr->m_ptr, 0);
+    angband_strcpy(mam_pp_ptr->m_name, monster_desc(player_ptr, mam_pp_ptr->m_ptr, 0).data(), sizeof(mam_pp_ptr->m_name));
     if (mam_pp_ptr->m_ptr->hp > mam_pp_ptr->m_ptr->maxhp / 3) {
         mam_pp_ptr->dam = (mam_pp_ptr->dam + 1) / 2;
     }
@@ -278,7 +279,7 @@ void mon_take_hit_mon(PlayerType *player_ptr, MONSTER_IDX m_idx, int dam, bool *
     auto *m_ptr = &floor_ptr->m_list[m_idx];
     mam_pp_type tmp_mam_pp;
     mam_pp_type *mam_pp_ptr = initialize_mam_pp_type(player_ptr, &tmp_mam_pp, m_idx, dam, dead, fear, note, who);
-    monster_desc(player_ptr, mam_pp_ptr->m_name, m_ptr, 0);
+    angband_strcpy(mam_pp_ptr->m_name, monster_desc(player_ptr, m_ptr, 0).data(), sizeof(mam_pp_ptr->m_name));
     prepare_redraw(player_ptr, mam_pp_ptr);
     (void)set_monster_csleep(player_ptr, m_idx, 0);
 

--- a/src/melee/melee-spell.cpp
+++ b/src/melee/melee-spell.cpp
@@ -20,6 +20,7 @@
 #include "system/player-type-definition.h"
 #include "timed-effect/player-blindness.h"
 #include "timed-effect/timed-effects.h"
+#include "util/string-processor.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 #ifdef JP
@@ -99,16 +100,12 @@ static void process_rememberance(melee_spell_type *ms_ptr)
 static void describe_melee_spell(PlayerType *player_ptr, melee_spell_type *ms_ptr)
 {
     /* Get the monster name (or "it") */
-    monster_desc(player_ptr, ms_ptr->m_name, ms_ptr->m_ptr, 0x00);
+    angband_strcpy(ms_ptr->m_name, monster_desc(player_ptr, ms_ptr->m_ptr, 0x00).data(), sizeof(ms_ptr->m_name));
 #ifdef JP
 #else
     /* Get the monster possessive ("his"/"her"/"its") */
-    monster_desc(player_ptr, ms_ptr->m_poss, ms_ptr->m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE);
+    angband_strcpy(ms_ptr->m_poss, monster_desc(player_ptr, ms_ptr->m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE).data(), sizeof(ms_ptr->m_poss));
 #endif
-
-    /* Get the target's name (or "it") */
-    GAME_TEXT t_name[160];
-    monster_desc(player_ptr, t_name, ms_ptr->t_ptr, 0x00);
 }
 
 /*!

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -36,6 +36,7 @@
 #include "system/monster-entity.h"
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
+#include "util/string-processor.h"
 #include "view/display-messages.h"
 
 static void heal_monster_by_melee(PlayerType *player_ptr, mam_type *mam_ptr)
@@ -343,8 +344,8 @@ bool monst_attack_monst(PlayerType *player_ptr, MONSTER_IDX m_idx, MONSTER_IDX t
         return false;
     }
 
-    monster_desc(player_ptr, mam_ptr->m_name, mam_ptr->m_ptr, 0);
-    monster_desc(player_ptr, mam_ptr->t_name, mam_ptr->t_ptr, 0);
+    angband_strcpy(mam_ptr->m_name, monster_desc(player_ptr, mam_ptr->m_ptr, 0).data(), sizeof(mam_ptr->m_name));
+    angband_strcpy(mam_ptr->t_name, monster_desc(player_ptr, mam_ptr->t_ptr, 0).data(), sizeof(mam_ptr->t_name));
     if (!mam_ptr->see_either && mam_ptr->known) {
         player_ptr->current_floor_ptr->monster_noise = true;
     }

--- a/src/mind/mind-cavalry.cpp
+++ b/src/mind/mind-cavalry.cpp
@@ -28,11 +28,6 @@
  */
 bool rodeo(PlayerType *player_ptr)
 {
-    GAME_TEXT m_name[MAX_NLEN];
-    MonsterEntity *m_ptr;
-    MonsterRaceInfo *r_ptr;
-    int rlev;
-
     if (player_ptr->riding) {
         msg_print(_("今は乗馬中だ。", "You ARE riding."));
         return false;
@@ -42,16 +37,16 @@ bool rodeo(PlayerType *player_ptr)
         return true;
     }
 
-    m_ptr = &player_ptr->current_floor_ptr->m_list[player_ptr->riding];
-    r_ptr = &monraces_info[m_ptr->r_idx];
-    monster_desc(player_ptr, m_name, m_ptr, 0);
-    msg_format(_("%sに乗った。", "You ride on %s."), m_name);
+    auto *m_ptr = &player_ptr->current_floor_ptr->m_list[player_ptr->riding];
+    auto *r_ptr = &monraces_info[m_ptr->r_idx];
+    const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+    msg_format(_("%sに乗った。", "You ride on %s."), m_name.data());
 
     if (m_ptr->is_pet()) {
         return true;
     }
 
-    rlev = r_ptr->level;
+    auto rlev = r_ptr->level;
 
     if (r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
         rlev = rlev * 3 / 2;
@@ -62,10 +57,10 @@ bool rodeo(PlayerType *player_ptr)
     if ((randint1(player_ptr->skill_exp[PlayerSkillKindType::RIDING] / 120 + player_ptr->lev * 2 / 3) > rlev) && one_in_(2) &&
         !player_ptr->current_floor_ptr->inside_arena && !player_ptr->phase_out && !(r_ptr->flags7 & (RF7_GUARDIAN)) && !(r_ptr->flags1 & (RF1_QUESTOR)) &&
         (rlev < player_ptr->lev * 3 / 2 + randint0(player_ptr->lev / 5))) {
-        msg_format(_("%sを手なずけた。", "You tame %s."), m_name);
+        msg_format(_("%sを手なずけた。", "You tame %s."), m_name.data());
         set_pet(player_ptr, m_ptr);
     } else {
-        msg_format(_("%sに振り落とされた！", "You have been thrown off by %s."), m_name);
+        msg_format(_("%sに振り落とされた！", "You have been thrown off by %s."), m_name.data());
         process_fall_off_horse(player_ptr, 1, true);
 
         /* 落馬処理に失敗してもとにかく乗馬解除 */

--- a/src/mind/mind-force-trainer.cpp
+++ b/src/mind/mind-force-trainer.cpp
@@ -221,11 +221,10 @@ bool shock_power(PlayerType *player_ptr)
     MONSTER_IDX m_idx = player_ptr->current_floor_ptr->grid_array[y][x].m_idx;
     auto *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
     auto *r_ptr = &monraces_info[m_ptr->r_idx];
-    GAME_TEXT m_name[MAX_NLEN];
-    monster_desc(player_ptr, m_name, m_ptr, 0);
+    const auto m_name = monster_desc(player_ptr, m_ptr, 0);
 
     if (randint1(r_ptr->level * 3 / 2) > randint0(dam / 2) + dam / 2) {
-        msg_format(_("%sは飛ばされなかった。", "%^s was not blown away."), m_name);
+        msg_format(_("%sは飛ばされなかった。", "%^s was not blown away."), m_name.data());
         return true;
     }
 
@@ -246,7 +245,7 @@ bool shock_power(PlayerType *player_ptr)
         return true;
     }
 
-    msg_format(_("%sを吹き飛ばした！", "You blow %s away!"), m_name);
+    msg_format(_("%sを吹き飛ばした！", "You blow %s away!"), m_name.data());
     player_ptr->current_floor_ptr->grid_array[oy][ox].m_idx = 0;
     player_ptr->current_floor_ptr->grid_array[ty][tx].m_idx = m_idx;
     m_ptr->fy = ty;

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -202,9 +202,8 @@ bool rush_attack(PlayerType *player_ptr, bool *mdeath)
             msg_format("There is %s in the way!", m_ptr->ml ? (tm_idx ? "another monster" : "a monster") : "someone");
 #endif
         } else if (!player_bold(player_ptr, ty, tx)) {
-            GAME_TEXT m_name[MAX_NLEN];
-            monster_desc(player_ptr, m_name, m_ptr, 0);
-            msg_format(_("素早く%sの懐に入り込んだ！", "You quickly jump in and attack %s!"), m_name);
+            const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+            msg_format(_("素早く%sの懐に入り込んだ！", "You quickly jump in and attack %s!"), m_name.data());
         }
 
         if (!player_bold(player_ptr, ty, tx)) {

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -522,10 +522,9 @@ void musou_counterattack(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
         return;
     }
 
-    char m_target_name[MAX_NLEN];
-    monster_desc(player_ptr, m_target_name, monap_ptr->m_ptr, 0);
+    const auto m_target_name = monster_desc(player_ptr, monap_ptr->m_ptr, 0);
     player_ptr->csp -= 7;
-    msg_format(_("%^sに反撃した！", "You counterattacked %s!"), m_target_name);
+    msg_format(_("%^sに反撃した！", "You counterattacked %s!"), m_target_name.data());
     do_cmd_attack(player_ptr, monap_ptr->m_ptr->fy, monap_ptr->m_ptr->fx, HISSATSU_COUNTER);
     monap_ptr->fear = false;
     player_ptr->redraw |= (PR_MANA);

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -58,6 +58,7 @@
 #include "timed-effect/player-stun.h"
 #include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
+#include "util/string-processor.h"
 #include "view/display-messages.h"
 
 /*!
@@ -86,8 +87,8 @@ void MonsterAttackPlayer::make_attack_normal()
 
     auto *r_ptr = &monraces_info[this->m_ptr->r_idx];
     this->rlev = ((r_ptr->level >= 1) ? r_ptr->level : 1);
-    monster_desc(this->player_ptr, this->m_name, this->m_ptr, 0);
-    monster_desc(this->player_ptr, this->ddesc, this->m_ptr, MD_WRONGDOER_NAME);
+    angband_strcpy(this->m_name, monster_desc(this->player_ptr, this->m_ptr, 0).data(), sizeof(this->m_name));
+    angband_strcpy(this->ddesc, monster_desc(this->player_ptr, this->m_ptr, MD_WRONGDOER_NAME).data(), sizeof(this->ddesc));
     if (PlayerClass(this->player_ptr).samurai_stance_is(SamuraiStanceType::IAI)) {
         msg_format(_("相手が襲いかかる前に素早く武器を振るった。", "You took sen, drew and cut in one motion before %s moved."), this->m_name);
         if (do_cmd_attack(this->player_ptr, this->m_ptr->fy, this->m_ptr->fx, HISSATSU_IAI)) {

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -57,9 +57,8 @@ static void write_pet_death(PlayerType *player_ptr, monster_death_type *md_ptr)
     md_ptr->md_y = md_ptr->m_ptr->fy;
     md_ptr->md_x = md_ptr->m_ptr->fx;
     if (record_named_pet && md_ptr->m_ptr->is_pet() && md_ptr->m_ptr->nickname) {
-        GAME_TEXT m_name[MAX_NLEN];
-        monster_desc(player_ptr, m_name, md_ptr->m_ptr, MD_INDEF_VISIBLE);
-        exe_write_diary(player_ptr, DIARY_NAMED_PET, 3, m_name);
+        const auto m_name = monster_desc(player_ptr, md_ptr->m_ptr, MD_INDEF_VISIBLE);
+        exe_write_diary(player_ptr, DIARY_NAMED_PET, 3, m_name.data());
     }
 }
 
@@ -113,9 +112,8 @@ static void on_defeat_arena_monster(PlayerType *player_ptr, monster_death_type *
         return;
     }
 
-    GAME_TEXT m_name[MAX_NLEN];
-    monster_desc(player_ptr, m_name, md_ptr->m_ptr, MD_WRONGDOER_NAME);
-    exe_write_diary(player_ptr, DIARY_ARENA, player_ptr->arena_number, m_name);
+    const auto m_name = monster_desc(player_ptr, md_ptr->m_ptr, MD_WRONGDOER_NAME);
+    exe_write_diary(player_ptr, DIARY_ARENA, player_ptr->arena_number, m_name.data());
 }
 
 static void drop_corpse(PlayerType *player_ptr, monster_death_type *md_ptr)

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -535,13 +535,8 @@ void process_speak_sound(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION oy,
         return;
     }
 
-    GAME_TEXT m_name[MAX_NLEN];
+    const auto m_name = m_ptr->ml ? monster_desc(player_ptr, m_ptr, 0) : std::string(_("それ", "It"));
     char monmessage[1024];
-    if (m_ptr->ml) {
-        monster_desc(player_ptr, m_name, m_ptr, 0);
-    } else {
-        strcpy(m_name, _("それ", "It"));
-    }
 
     auto filename = get_speak_filename(m_ptr);
     if (filename.empty()) {
@@ -549,7 +544,7 @@ void process_speak_sound(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION oy,
     }
 
     if (get_rnd_line(filename.data(), enum2i(m_ptr->ap_r_idx), monmessage) == 0) {
-        msg_format(_("%^s%s", "%^s %s"), m_name, monmessage);
+        msg_format(_("%^s%s", "%^s %s"), m_name.data(), monmessage);
     }
 }
 

--- a/src/monster-floor/monster-object.cpp
+++ b/src/monster-floor/monster-object.cpp
@@ -190,7 +190,7 @@ void update_object_by_monster_movement(PlayerType *player_ptr, turn_flags *turn_
     for (auto it = g_ptr->o_idx_list.begin(); it != g_ptr->o_idx_list.end();) {
         EnumClassFlagGroup<MonsterKindType> flg_monster_kind;
         EnumClassFlagGroup<MonsterResistanceType> flgr;
-        GAME_TEXT m_name[MAX_NLEN], o_name[MAX_NLEN];
+        GAME_TEXT o_name[MAX_NLEN];
         OBJECT_IDX this_o_idx = *it++;
         auto *o_ptr = &player_ptr->current_floor_ptr->o_list[this_o_idx];
 
@@ -203,13 +203,13 @@ void update_object_by_monster_movement(PlayerType *player_ptr, turn_flags *turn_
 
         auto flgs = object_flags(o_ptr);
         describe_flavor(player_ptr, o_name, o_ptr, 0);
-        monster_desc(player_ptr, m_name, m_ptr, MD_INDEF_HIDDEN);
+        const auto m_name = monster_desc(player_ptr, m_ptr, MD_INDEF_HIDDEN);
         update_object_flags(flgs, flg_monster_kind, flgr);
 
         auto is_unpickable_object = o_ptr->is_artifact();
         is_unpickable_object |= r_ptr->kind_flags.has_any_of(flg_monster_kind);
         is_unpickable_object |= !r_ptr->resistance_flags.has_all_of(flgr) && r_ptr->resistance_flags.has_not(MonsterResistanceType::RESIST_ALL);
-        monster_pickup_object(player_ptr, turn_flags_ptr, m_idx, o_ptr, is_unpickable_object, ny, nx, m_name, o_name, this_o_idx);
+        monster_pickup_object(player_ptr, turn_flags_ptr, m_idx, o_ptr, is_unpickable_object, ny, nx, m_name.data(), o_name, this_o_idx);
     }
 }
 

--- a/src/monster-floor/monster-runaway.cpp
+++ b/src/monster-floor/monster-runaway.cpp
@@ -46,7 +46,7 @@ static bool is_acting_monster(const MonsterRaceId r_idx)
  * @param m_ptr モンスターへの参照ポインタ
  * @param m_name モンスター名称
  */
-static void escape_monster(PlayerType *player_ptr, turn_flags *turn_flags_ptr, MonsterEntity *m_ptr, GAME_TEXT *m_name)
+static void escape_monster(PlayerType *player_ptr, turn_flags *turn_flags_ptr, MonsterEntity *m_ptr, concptr m_name)
 {
     if (turn_flags_ptr->is_riding_mon) {
         msg_format(_("%sはあなたの束縛から脱出した。", "%^s succeeded to escape from your restriction!"), m_name);
@@ -109,17 +109,16 @@ bool runaway_monster(PlayerType *player_ptr, turn_flags *turn_flags_ptr, MONSTER
         return false;
     }
 
-    GAME_TEXT m_name[MAX_NLEN];
-    monster_desc(player_ptr, m_name, m_ptr, 0);
+    const auto m_name = monster_desc(player_ptr, m_ptr, 0);
     if (turn_flags_ptr->is_riding_mon && riding_pinch < 2) {
         msg_format(
-            _("%sは傷の痛さの余りあなたの束縛から逃れようとしている。", "%^s seems to be in so much pain and tries to escape from your restriction."), m_name);
+            _("%sは傷の痛さの余りあなたの束縛から逃れようとしている。", "%^s seems to be in so much pain and tries to escape from your restriction."), m_name.data());
         riding_pinch++;
         disturb(player_ptr, true, true);
         return false;
     }
 
-    escape_monster(player_ptr, turn_flags_ptr, m_ptr, m_name);
+    escape_monster(player_ptr, turn_flags_ptr, m_ptr, m_name.data());
     QuestCompletionChecker(player_ptr, m_ptr).complete();
     delete_monster_idx(player_ptr, m_idx);
     return true;

--- a/src/monster-floor/quantum-effect.cpp
+++ b/src/monster-floor/quantum-effect.cpp
@@ -29,9 +29,8 @@ static void vanish_nonunique(PlayerType *player_ptr, MONSTER_IDX m_idx, bool see
 {
     auto *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
     if (see_m) {
-        GAME_TEXT m_name[MAX_NLEN];
-        monster_desc(player_ptr, m_name, m_ptr, 0);
-        msg_format(_("%sは消え去った！", "%^s disappears!"), m_name);
+        const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+        msg_format(_("%sは消え去った！", "%^s disappears!"), m_name.data());
     }
 
     monster_death(player_ptr, m_idx, false, AttributeType::NONE);
@@ -62,9 +61,8 @@ static void produce_quantum_effect(PlayerType *player_ptr, MONSTER_IDX m_idx, bo
     }
 
     if (see_m) {
-        GAME_TEXT m_name[MAX_NLEN];
-        monster_desc(player_ptr, m_name, m_ptr, MD_NONE);
-        msg_format(_("%sは量子的効果を起こした！", "%^s produced a decoherence!"), m_name);
+        const auto m_name = monster_desc(player_ptr, m_ptr, MD_NONE);
+        msg_format(_("%sは量子的効果を起こした！", "%^s produced a decoherence!"), m_name.data());
     } else {
         msg_print(_("量子的効果が起こった！", "A decoherence was produced!"));
     }

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -299,10 +299,9 @@ static void on_dead_dragon_centipede(PlayerType *player_ptr, monster_death_type 
         }
     }
 
-    GAME_TEXT m_name[MAX_NLEN];
-    monster_desc(player_ptr, m_name, md_ptr->m_ptr, MD_NONE);
     if (notice) {
-        msg_format(_("%sが再生した！", "The %s reproduced!"), m_name);
+        const auto m_name = monster_desc(player_ptr, md_ptr->m_ptr, MD_NONE);
+        msg_format(_("%sが再生した！", "The %s reproduced!"), m_name.data());
         sound(SOUND_SUMMON);
     }
 }

--- a/src/monster/monster-compaction.cpp
+++ b/src/monster/monster-compaction.cpp
@@ -141,9 +141,8 @@ void compact_monsters(PlayerType *player_ptr, int size)
             }
 
             if (record_named_pet && m_ptr->is_pet() && m_ptr->nickname) {
-                GAME_TEXT m_name[MAX_NLEN];
-                monster_desc(player_ptr, m_name, m_ptr, MD_INDEF_VISIBLE);
-                exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_COMPACT, m_name);
+                const auto m_name = monster_desc(player_ptr, m_ptr, MD_INDEF_VISIBLE);
+                exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_COMPACT, m_name.data());
             }
 
             delete_monster_idx(player_ptr, i);

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -148,10 +148,9 @@ bool MonsterDamageProcessor::process_dead_exp_virtue(concptr note, MonsterEntity
     }
 
     this->increase_kill_numbers();
-    GAME_TEXT m_name[MAX_NLEN];
-    monster_desc(this->player_ptr, m_name, m_ptr, MD_TRUE_NAME);
-    this->death_amberites(m_name);
-    this->dying_scream(m_name);
+    const auto m_name = monster_desc(this->player_ptr, m_ptr, MD_TRUE_NAME);
+    this->death_amberites(m_name.data());
+    this->dying_scream(m_name.data());
     AvatarChanger ac(player_ptr, m_ptr);
     ac.change_virtue();
     if (r_ref.kind_flags.has(MonsterKindType::UNIQUE) && record_destroy_uniq) {
@@ -159,8 +158,8 @@ bool MonsterDamageProcessor::process_dead_exp_virtue(concptr note, MonsterEntity
     }
 
     sound(SOUND_KILL);
-    this->show_kill_message(note, m_name);
-    this->show_bounty_message(m_name);
+    this->show_kill_message(note, m_name.data());
+    this->show_bounty_message(m_name.data());
     monster_death(this->player_ptr, this->m_idx, true, this->attribute_flags);
     this->summon_special_unique();
     this->get_exp_from_mon(exp_mon, exp_mon->max_maxhp * 2);
@@ -310,7 +309,7 @@ void MonsterDamageProcessor::increase_kill_numbers()
     monster_race_track(this->player_ptr, m_ptr->ap_r_idx);
 }
 
-void MonsterDamageProcessor::death_amberites(GAME_TEXT *m_name)
+void MonsterDamageProcessor::death_amberites(concptr m_name)
 {
     auto *m_ptr = &this->player_ptr->current_floor_ptr->m_list[this->m_idx];
     const auto &r_ref = m_ptr->get_real_r_ref();
@@ -328,7 +327,7 @@ void MonsterDamageProcessor::death_amberites(GAME_TEXT *m_name)
     } while (--curses);
 }
 
-void MonsterDamageProcessor::dying_scream(GAME_TEXT *m_name)
+void MonsterDamageProcessor::dying_scream(concptr m_name)
 {
     auto *m_ptr = &this->player_ptr->current_floor_ptr->m_list[this->m_idx];
     const auto &r_ref = m_ptr->get_real_r_ref();
@@ -348,7 +347,7 @@ void MonsterDamageProcessor::dying_scream(GAME_TEXT *m_name)
 #endif
 }
 
-void MonsterDamageProcessor::show_kill_message(concptr note, GAME_TEXT *m_name)
+void MonsterDamageProcessor::show_kill_message(concptr note, concptr m_name)
 {
     auto *floor_ptr = this->player_ptr->current_floor_ptr;
     auto *m_ptr = &floor_ptr->m_list[this->m_idx];
@@ -389,7 +388,7 @@ void MonsterDamageProcessor::show_kill_message(concptr note, GAME_TEXT *m_name)
     msg_format(mes, m_name);
 }
 
-void MonsterDamageProcessor::show_bounty_message(GAME_TEXT *m_name)
+void MonsterDamageProcessor::show_bounty_message(concptr m_name)
 {
     auto *floor_ptr = this->player_ptr->current_floor_ptr;
     auto *m_ptr = &floor_ptr->m_list[this->m_idx];

--- a/src/monster/monster-damage.h
+++ b/src/monster/monster-damage.h
@@ -33,10 +33,10 @@ private:
     bool check_combined_unique(const MonsterRaceId r_idx, std::vector<MonsterRaceId> *combined_uniques);
     void death_combined_uniques(const MonsterRaceId r_idx, const combined_uniques &combined_uniques);
     void increase_kill_numbers();
-    void death_amberites(GAME_TEXT *m_name);
-    void dying_scream(GAME_TEXT *m_name);
-    void show_kill_message(concptr note, GAME_TEXT *m_name);
-    void show_bounty_message(GAME_TEXT *m_name);
+    void death_amberites(concptr m_name);
+    void dying_scream(concptr m_name);
+    void show_kill_message(concptr note, concptr m_name);
+    void show_bounty_message(concptr m_name);
     void set_redraw();
     void summon_special_unique();
     void add_monster_fear();

--- a/src/monster/monster-describer.h
+++ b/src/monster/monster-describer.h
@@ -1,8 +1,9 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include <string>
 
 class MonsterEntity;
 class PlayerType;
-void monster_desc(PlayerType *player_ptr, char *desc, MonsterEntity *m_ptr, BIT_FLAGS mode);
+std::string monster_desc(PlayerType *player_ptr, MonsterEntity *m_ptr, BIT_FLAGS mode);
 void message_pain(PlayerType *player_ptr, MONSTER_IDX m_idx, int dam);

--- a/src/monster/monster-info.cpp
+++ b/src/monster/monster-info.cpp
@@ -270,10 +270,10 @@ bool is_original_ap_and_seen(PlayerType *player_ptr, const MonsterEntity *m_ptr)
  * @brief モンスターIDを取り、モンスター名をm_nameに代入する /
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param m_idx モンスターID
- * @param m_name モンスター名を入力する配列
+ * @return std::string モンスター名
  */
-void monster_name(PlayerType *player_ptr, MONSTER_IDX m_idx, char *m_name)
+std::string monster_name(PlayerType *player_ptr, MONSTER_IDX m_idx)
 {
     auto *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
-    monster_desc(player_ptr, m_name, m_ptr, 0x00);
+    return monster_desc(player_ptr, m_ptr, 0x00);
 }

--- a/src/monster/monster-info.h
+++ b/src/monster/monster-info.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include <string>
 
 /*
  * Bit flags for the *_can_enter() and monster_can_cross_terrain()
@@ -16,4 +17,4 @@ bool monster_can_enter(PlayerType *player_ptr, POSITION y, POSITION x, MonsterRa
 bool are_enemies(PlayerType *player_ptr, const MonsterEntity &m1_ref, const MonsterEntity &m2_ref);
 bool monster_has_hostile_align(PlayerType *player_ptr, MonsterEntity *m_ptr, int pa_good, int pa_evil, MonsterRaceInfo *r_ptr);
 bool is_original_ap_and_seen(PlayerType *player_ptr, const MonsterEntity *m_ptr);
-void monster_name(PlayerType *player_ptr, MONSTER_IDX m_idx, char *m_name);
+std::string monster_name(PlayerType *player_ptr, MONSTER_IDX m_idx);

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -320,8 +320,7 @@ void choose_new_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, bool born, Mo
     }
     r_ptr = &monraces_info[r_idx];
 
-    char old_m_name[MAX_NLEN];
-    monster_desc(player_ptr, old_m_name, m_ptr, 0);
+    const auto old_m_name = monster_desc(player_ptr, m_ptr, 0);
 
     if (!MonsterRace(r_idx).is_valid()) {
         DEPTH level;
@@ -379,12 +378,11 @@ void choose_new_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, bool born, Mo
     }
 
     if (m_idx == player_ptr->riding) {
-        GAME_TEXT m_name[MAX_NLEN];
-        monster_desc(player_ptr, m_name, m_ptr, 0);
-        msg_format(_("突然%sが変身した。", "Suddenly, %s transforms!"), old_m_name);
+        msg_format(_("突然%sが変身した。", "Suddenly, %s transforms!"), old_m_name.data());
         if (!(r_ptr->flags7 & RF7_RIDING)) {
             if (process_fall_off_horse(player_ptr, 0, true)) {
-                msg_format(_("地面に落とされた。", "You have fallen from %s."), m_name);
+                const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+                msg_format(_("地面に落とされた。", "You have fallen from %s."), m_name.data());
             }
         }
     }

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -243,9 +243,8 @@ void decide_drop_from_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, bool is
 #ifdef JP
         msg_print("地面に落とされた。");
 #else
-        GAME_TEXT m_name[MAX_NLEN];
-        monster_desc(player_ptr, m_name, &player_ptr->current_floor_ptr->m_list[player_ptr->riding], 0);
-        msg_format("You have fallen from %s.", m_name);
+        const auto m_name = monster_desc(player_ptr, &player_ptr->current_floor_ptr->m_list[player_ptr->riding], 0);
+        msg_format("You have fallen from %s.", m_name.data());
 #endif
     }
 }
@@ -271,15 +270,13 @@ bool vanish_summoned_children(PlayerType *player_ptr, MONSTER_IDX m_idx, bool se
     }
 
     if (see_m) {
-        GAME_TEXT m_name[MAX_NLEN];
-        monster_desc(player_ptr, m_name, m_ptr, 0);
-        msg_format(_("%sは消え去った！", "%^s disappears!"), m_name);
+        const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+        msg_format(_("%sは消え去った！", "%^s disappears!"), m_name.data());
     }
 
     if (record_named_pet && m_ptr->is_pet() && m_ptr->nickname) {
-        GAME_TEXT m_name[MAX_NLEN];
-        monster_desc(player_ptr, m_name, m_ptr, MD_INDEF_VISIBLE);
-        exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_LOSE_PARENT, m_name);
+        const auto m_name = monster_desc(player_ptr, m_ptr, MD_INDEF_VISIBLE);
+        exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_LOSE_PARENT, m_name.data());
     }
 
     delete_monster_idx(player_ptr, m_idx);
@@ -306,9 +303,8 @@ bool awake_monster(PlayerType *player_ptr, MONSTER_IDX m_idx)
 
     (void)set_monster_csleep(player_ptr, m_idx, 0);
     if (m_ptr->ml) {
-        GAME_TEXT m_name[MAX_NLEN];
-        monster_desc(player_ptr, m_name, m_ptr, 0);
-        msg_format(_("%^sが目を覚ました。", "%^s wakes up."), m_name);
+        const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+        msg_format(_("%^sが目を覚ました。", "%^s wakes up."), m_name.data());
     }
 
     if (is_original_ap_and_seen(player_ptr, m_ptr) && (r_ptr->r_wake < MAX_UCHAR)) {
@@ -341,8 +337,7 @@ void process_angar(PlayerType *player_ptr, MONSTER_IDX m_idx, bool see_m)
         return;
     }
 
-    GAME_TEXT m_name[MAX_NLEN];
-    monster_desc(player_ptr, m_name, m_ptr, m_ptr->is_pet() ? MD_ASSUME_VISIBLE : 0);
+    const auto m_name = monster_desc(player_ptr, m_ptr, m_ptr->is_pet() ? MD_ASSUME_VISIBLE : 0);
 
     /* When riding a hostile alignment pet */
     if (player_ptr->riding == m_idx) {
@@ -350,7 +345,7 @@ void process_angar(PlayerType *player_ptr, MONSTER_IDX m_idx, bool see_m)
             return;
         }
 
-        msg_format(_("%^sが突然暴れだした！", "%^s suddenly begins unruly!"), m_name);
+        msg_format(_("%^sが突然暴れだした！", "%^s suddenly begins unruly!"), m_name.data());
         if (!process_fall_off_horse(player_ptr, 1, true)) {
             return;
         }
@@ -359,7 +354,7 @@ void process_angar(PlayerType *player_ptr, MONSTER_IDX m_idx, bool see_m)
     }
 
     if (m_ptr->is_pet() || see_m) {
-        msg_format(_("%^sは突然敵にまわった！", "%^s suddenly becomes hostile!"), m_name);
+        msg_format(_("%^sは突然敵にまわった！", "%^s suddenly becomes hostile!"), m_name.data());
     }
 
     set_hostile(player_ptr, m_ptr);
@@ -519,9 +514,8 @@ bool process_monster_fear(PlayerType *player_ptr, turn_flags *turn_flags_ptr, MO
         return true;
     }
 
-    GAME_TEXT m_name[MAX_NLEN];
-    monster_desc(player_ptr, m_name, m_ptr, 0);
-    msg_format(_("%^sは戦いを決意した！", "%^s turns to fight!"), m_name);
+    const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+    msg_format(_("%^sは戦いを決意した！", "%^s turns to fight!"), m_name.data());
     return true;
 }
 

--- a/src/monster/monster-status-setter.cpp
+++ b/src/monster/monster-status-setter.cpp
@@ -68,9 +68,8 @@ void anger_monster(PlayerType *player_ptr, MonsterEntity *m_ptr)
         return;
     }
 
-    GAME_TEXT m_name[MAX_NLEN];
-    monster_desc(player_ptr, m_name, m_ptr, 0);
-    msg_format(_("%^sは怒った！", "%^s gets angry!"), m_name);
+    const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+    msg_format(_("%^sは怒った！", "%^s gets angry!"), m_name.data());
     set_hostile(player_ptr, m_ptr);
     chg_virtue(player_ptr, V_INDIVIDUALISM, 1);
     chg_virtue(player_ptr, V_HONOUR, -1);
@@ -387,8 +386,7 @@ bool set_monster_timewalk(PlayerType *player_ptr, int num, MonsterRaceId who, bo
     }
 
     if (vs_player) {
-        GAME_TEXT m_name[MAX_NLEN];
-        monster_desc(player_ptr, m_name, m_ptr, 0);
+        const auto m_name = monster_desc(player_ptr, m_ptr, 0);
 
         concptr mes;
         switch (who) {
@@ -406,7 +404,7 @@ bool set_monster_timewalk(PlayerType *player_ptr, int num, MonsterRaceId who, bo
             break;
         }
 
-        msg_format(mes, m_name);
+        msg_format(mes, m_name.data());
         msg_print(nullptr);
     }
 

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -224,9 +224,8 @@ static void process_monsters_mtimed_aux(PlayerType *player_ptr, MONSTER_IDX m_id
 
         /* Notice the "waking up" */
         if (m_ptr->ml) {
-            GAME_TEXT m_name[MAX_NLEN];
-            monster_desc(player_ptr, m_name, m_ptr, 0);
-            msg_format(_("%^sが目を覚ました。", "%^s wakes up."), m_name);
+            const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+            msg_format(_("%^sが目を覚ました。", "%^s wakes up."), m_name.data());
         }
 
         if (is_original_ap_and_seen(player_ptr, m_ptr)) {
@@ -243,9 +242,8 @@ static void process_monsters_mtimed_aux(PlayerType *player_ptr, MONSTER_IDX m_id
         /* Reduce by one, note if expires */
         if (set_monster_fast(player_ptr, m_idx, m_ptr->get_remaining_acceleration() - 1)) {
             if (is_seen(player_ptr, m_ptr)) {
-                GAME_TEXT m_name[MAX_NLEN];
-                monster_desc(player_ptr, m_name, m_ptr, 0);
-                msg_format(_("%^sはもう加速されていない。", "%^s is no longer fast."), m_name);
+                const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+                msg_format(_("%^sはもう加速されていない。", "%^s is no longer fast."), m_name.data());
             }
         }
 
@@ -255,9 +253,8 @@ static void process_monsters_mtimed_aux(PlayerType *player_ptr, MONSTER_IDX m_id
         /* Reduce by one, note if expires */
         if (set_monster_slow(player_ptr, m_idx, m_ptr->get_remaining_deceleration() - 1)) {
             if (is_seen(player_ptr, m_ptr)) {
-                GAME_TEXT m_name[MAX_NLEN];
-                monster_desc(player_ptr, m_name, m_ptr, 0);
-                msg_format(_("%^sはもう減速されていない。", "%^s is no longer slow."), m_name);
+                const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+                msg_format(_("%^sはもう減速されていない。", "%^s is no longer slow."), m_name.data());
             }
         }
 
@@ -270,9 +267,8 @@ static void process_monsters_mtimed_aux(PlayerType *player_ptr, MONSTER_IDX m_id
         if (set_monster_stunned(player_ptr, m_idx, (randint0(10000) <= rlev * rlev) ? 0 : (m_ptr->get_remaining_stun() - 1))) {
             /* Message if visible */
             if (is_seen(player_ptr, m_ptr)) {
-                GAME_TEXT m_name[MAX_NLEN];
-                monster_desc(player_ptr, m_name, m_ptr, 0);
-                msg_format(_("%^sは朦朧状態から立ち直った。", "%^s is no longer stunned."), m_name);
+                const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+                msg_format(_("%^sは朦朧状態から立ち直った。", "%^s is no longer stunned."), m_name.data());
             }
         }
 
@@ -287,9 +283,8 @@ static void process_monsters_mtimed_aux(PlayerType *player_ptr, MONSTER_IDX m_id
 
         /* Message if visible */
         if (is_seen(player_ptr, m_ptr)) {
-            GAME_TEXT m_name[MAX_NLEN];
-            monster_desc(player_ptr, m_name, m_ptr, 0);
-            msg_format(_("%^sは混乱から立ち直った。", "%^s is no longer confused."), m_name);
+            const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+            msg_format(_("%^sは混乱から立ち直った。", "%^s is no longer confused."), m_name.data());
         }
 
         break;
@@ -303,19 +298,16 @@ static void process_monsters_mtimed_aux(PlayerType *player_ptr, MONSTER_IDX m_id
 
         /* Visual note */
         if (is_seen(player_ptr, m_ptr)) {
-            GAME_TEXT m_name[MAX_NLEN];
+            const auto m_name = monster_desc(player_ptr, m_ptr, 0);
 #ifdef JP
 #else
-            char m_poss[80];
-
             /* Acquire the monster possessive */
-            monster_desc(player_ptr, m_poss, m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE);
+            const auto m_poss = monster_desc(player_ptr, m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE);
 #endif
-            monster_desc(player_ptr, m_name, m_ptr, 0);
 #ifdef JP
-            msg_format("%^sは勇気を取り戻した。", m_name);
+            msg_format("%^sは勇気を取り戻した。", m_name.data());
 #else
-            msg_format("%^s recovers %s courage.", m_name, m_poss);
+            msg_format("%^s recovers %s courage.", m_name.data(), m_poss.data());
 #endif
         }
 
@@ -329,9 +321,8 @@ static void process_monsters_mtimed_aux(PlayerType *player_ptr, MONSTER_IDX m_id
         }
 
         if (is_seen(player_ptr, m_ptr)) {
-            GAME_TEXT m_name[MAX_NLEN];
-            monster_desc(player_ptr, m_name, m_ptr, 0);
-            msg_format(_("%^sはもう無敵でない。", "%^s is no longer invulnerable."), m_name);
+            const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+            msg_format(_("%^sはもう無敵でない。", "%^s is no longer invulnerable."), m_name.data());
         }
 
         break;
@@ -371,24 +362,22 @@ void process_monsters_mtimed(PlayerType *player_ptr, int mtimed_idx)
 void dispel_monster_status(PlayerType *player_ptr, MONSTER_IDX m_idx)
 {
     auto *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
-    GAME_TEXT m_name[MAX_NLEN];
-
-    monster_desc(player_ptr, m_name, m_ptr, 0);
+    const auto m_name = monster_desc(player_ptr, m_ptr, 0);
     if (set_monster_invulner(player_ptr, m_idx, 0, true)) {
         if (m_ptr->ml) {
-            msg_format(_("%sはもう無敵ではない。", "%^s is no longer invulnerable."), m_name);
+            msg_format(_("%sはもう無敵ではない。", "%^s is no longer invulnerable."), m_name.data());
         }
     }
 
     if (set_monster_fast(player_ptr, m_idx, 0)) {
         if (m_ptr->ml) {
-            msg_format(_("%sはもう加速されていない。", "%^s is no longer fast."), m_name);
+            msg_format(_("%sはもう加速されていない。", "%^s is no longer fast."), m_name.data());
         }
     }
 
     if (set_monster_slow(player_ptr, m_idx, 0)) {
         if (m_ptr->ml) {
-            msg_format(_("%sはもう減速されていない。", "%^s is no longer slow."), m_name);
+            msg_format(_("%sはもう減速されていない。", "%^s is no longer slow."), m_name.data());
         }
     }
 }
@@ -441,7 +430,6 @@ void monster_gain_exp(PlayerType *player_ptr, MONSTER_IDX m_idx, MonsterRaceId s
         return;
     }
 
-    GAME_TEXT m_name[MAX_NLEN];
     auto old_hp = m_ptr->hp;
     auto old_maxhp = m_ptr->max_maxhp;
     auto old_r_idx = m_ptr->r_idx;
@@ -450,7 +438,7 @@ void monster_gain_exp(PlayerType *player_ptr, MONSTER_IDX m_idx, MonsterRaceId s
     /* Hack -- Reduce the racial counter of previous monster */
     m_ptr->get_real_r_ref().cur_num--;
 
-    monster_desc(player_ptr, m_name, m_ptr, 0);
+    const auto m_name = monster_desc(player_ptr, m_ptr, 0);
     m_ptr->r_idx = r_ptr->next_r_idx;
 
     /* Count the monsters on the level */
@@ -501,9 +489,9 @@ void monster_gain_exp(PlayerType *player_ptr, MONSTER_IDX m_idx, MonsterRaceId s
                 auto mes_evolution = _("%sは%sに進化した。", "%^s evolved into %s.");
                 auto mes_degeneration = _("%sは%sに退化した。", "%^s degenerated into %s.");
                 auto mes = randint0(2) == 0 ? mes_evolution : mes_degeneration;
-                msg_format(mes, m_name, hallucinated_race->name.data());
+                msg_format(mes, m_name.data(), hallucinated_race->name.data());
             } else {
-                msg_format(_("%sは%sに進化した。", "%^s evolved into %s."), m_name, r_ptr->name.data());
+                msg_format(_("%sは%sに進化した。", "%^s evolved into %s."), m_name.data(), r_ptr->name.data());
             }
         }
 

--- a/src/mspell/mspell-attack.cpp
+++ b/src/mspell/mspell-attack.cpp
@@ -36,6 +36,7 @@
 #include "target/projection-path-calculator.h"
 #include "timed-effect/player-blindness.h"
 #include "timed-effect/timed-effects.h"
+#include "util/string-processor.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 #ifdef JP
@@ -129,14 +130,7 @@ static void set_mspell_list(msa_type *msa_ptr)
 
 static void describe_mspell_monster(PlayerType *player_ptr, msa_type *msa_ptr)
 {
-    monster_desc(player_ptr, msa_ptr->m_name, msa_ptr->m_ptr, 0x00);
-
-#ifdef JP
-#else
-    /* Get the monster possessive ("his"/"her"/"its") */
-    char m_poss[80];
-    monster_desc(player_ptr, m_poss, msa_ptr->m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE);
-#endif
+    angband_strcpy(msa_ptr->m_name, monster_desc(player_ptr, msa_ptr->m_ptr, 0x00).data(), sizeof(msa_ptr->m_name));
 }
 
 static bool switch_do_spell(PlayerType *player_ptr, msa_type *msa_ptr)

--- a/src/mspell/mspell-attack/mspell-ball.cpp
+++ b/src/mspell/mspell-attack/mspell-ball.cpp
@@ -45,8 +45,7 @@ static bool message_water_ball(PlayerType *player_ptr, MONSTER_IDX m_idx, MONSTE
     auto see_either = see_monster(player_ptr, m_idx) || see_monster(player_ptr, t_idx);
     auto mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     auto mon_to_player = (target_type == MONSTER_TO_PLAYER);
-    GAME_TEXT t_name[MAX_NLEN];
-    monster_name(player_ptr, t_idx, t_name);
+    const auto t_name = monster_name(player_ptr, t_idx);
 
     mspell_cast_msg_blind msg(_("%^sが何かをつぶやいた。", "%^s mumbles."), _("%^sが流れるような身振りをした。", "%^s gestures fluidly."),
         _("%^sが%sに対して流れるような身振りをした。", "%^s gestures fluidly at %s."));
@@ -56,7 +55,7 @@ static bool message_water_ball(PlayerType *player_ptr, MONSTER_IDX m_idx, MONSTE
     if (mon_to_player) {
         msg_format(_("あなたは渦巻きに飲み込まれた。", "You are engulfed in a whirlpool."));
     } else if (mon_to_mon && known && see_either && !player_ptr->effects()->blindness()->is_blind()) {
-        msg_format(_("%^sは渦巻に飲み込まれた。", "%^s is engulfed in a whirlpool."), t_name);
+        msg_format(_("%^sは渦巻に飲み込まれた。", "%^s is engulfed in a whirlpool."), t_name.data());
     }
     return result;
 }

--- a/src/mspell/mspell-attack/mspell-breath.cpp
+++ b/src/mspell/mspell-attack/mspell-breath.cpp
@@ -56,20 +56,19 @@ static void message_breath(PlayerType *player_ptr, MONSTER_IDX m_idx, MONSTER_ID
     auto known = monster_near_player(floor_ptr, m_idx, t_idx);
     auto mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     auto mon_to_player = (target_type == MONSTER_TO_PLAYER);
-    GAME_TEXT m_name[MAX_NLEN], t_name[MAX_NLEN];
-    monster_name(player_ptr, m_idx, m_name);
-    monster_name(player_ptr, t_idx, t_name);
+    const auto m_name = monster_name(player_ptr, m_idx);
+    const auto t_name = monster_name(player_ptr, t_idx);
 
-    if (!spell_RF4_BREATH_special_message(m_ptr->r_idx, GF_TYPE, m_name)) {
+    if (!spell_RF4_BREATH_special_message(m_ptr->r_idx, GF_TYPE, m_name.data())) {
         if (player_ptr->effects()->blindness()->is_blind()) {
             if (mon_to_player || (mon_to_mon && known && see_either)) {
-                msg_format(_("%^sが何かのブレスを吐いた。", "%^s breathes."), m_name);
+                msg_format(_("%^sが何かのブレスを吐いた。", "%^s breathes."), m_name.data());
             }
         } else {
             if (mon_to_player) {
-                msg_format(_("%^sが%^sのブレスを吐いた。", "%^s breathes %^s."), m_name, type_s.data());
+                msg_format(_("%^sが%^sのブレスを吐いた。", "%^s breathes %^s."), m_name.data(), type_s.data());
             } else if (mon_to_mon && known && see_either) {
-                _(msg_format("%^sが%^sに%^sのブレスを吐いた。", m_name, t_name, type_s.data()), msg_format("%^s breathes %^s at %^s.", m_name, type_s.data(), t_name));
+                _(msg_format("%^sが%^sに%^sのブレスを吐いた。", m_name.data(), t_name.data(), type_s.data()), msg_format("%^s breathes %^s at %^s.", m_name.data(), type_s.data(), t_name.data()));
             }
         }
     }

--- a/src/mspell/mspell-attack/mspell-curse.cpp
+++ b/src/mspell/mspell-attack/mspell-curse.cpp
@@ -16,20 +16,19 @@
 
 static bool message_curse(PlayerType *player_ptr, MONSTER_IDX m_idx, MONSTER_IDX t_idx, std::string_view msg1, std::string_view msg2, std::string_view msg3, int target_type)
 {
-    GAME_TEXT m_name[MAX_NLEN], t_name[MAX_NLEN];
-    monster_name(player_ptr, m_idx, m_name);
-    monster_name(player_ptr, t_idx, t_name);
+    const auto m_name = monster_name(player_ptr, m_idx);
+    const auto t_name = monster_name(player_ptr, t_idx);
 
     if (target_type == MONSTER_TO_PLAYER) {
         disturb(player_ptr, true, true);
         if (player_ptr->effects()->blindness()->is_blind()) {
-            msg_format(msg1.data(), m_name);
+            msg_format(msg1.data(), m_name.data());
         } else {
-            msg_format(msg2.data(), m_name);
+            msg_format(msg2.data(), m_name.data());
         }
     } else if (target_type == MONSTER_TO_MONSTER) {
         if (see_monster(player_ptr, m_idx)) {
-            msg_format(msg3.data(), m_name, t_name);
+            msg_format(msg3.data(), m_name.data(), t_name.data());
         } else {
             player_ptr->current_floor_ptr->monster_noise = true;
         }

--- a/src/mspell/mspell-dispel.cpp
+++ b/src/mspell/mspell-dispel.cpp
@@ -117,10 +117,6 @@ MonsterSpellResult spell_RF4_DISPEL(MONSTER_IDX m_idx, PlayerType *player_ptr, M
     auto res = MonsterSpellResult::make_valid();
     res.learnable = target_type == MONSTER_TO_PLAYER;
 
-    GAME_TEXT m_name[MAX_NLEN], t_name[MAX_NLEN];
-    monster_name(player_ptr, m_idx, m_name);
-    monster_name(player_ptr, t_idx, t_name);
-
     mspell_cast_msg_blind msg(_("%^sが何かを力強くつぶやいた。", "%^s mumbles powerfully."),
         _("%^sが魔力消去の呪文を念じた。", "%^s invokes a dispel magic."), _("%^sが%sに対して魔力消去の呪文を念じた。", "%^s invokes a dispel magic at %s."));
 

--- a/src/mspell/mspell-floor.cpp
+++ b/src/mspell/mspell-floor.cpp
@@ -89,8 +89,6 @@ MonsterSpellResult spell_RF4_SHRIEK(MONSTER_IDX m_idx, PlayerType *player_ptr, M
 MonsterSpellResult spell_RF6_WORLD(PlayerType *player_ptr, MONSTER_IDX m_idx)
 {
     auto *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
-    GAME_TEXT m_name[MAX_NLEN];
-    monster_name(player_ptr, m_idx, m_name);
     disturb(player_ptr, true, true);
     (void)set_monster_timewalk(player_ptr, randint1(2) + 2, m_ptr->r_idx, true);
 
@@ -109,9 +107,7 @@ MonsterSpellResult spell_RF6_WORLD(PlayerType *player_ptr, MONSTER_IDX m_idx)
 MonsterSpellResult spell_RF6_BLINK(PlayerType *player_ptr, MONSTER_IDX m_idx, int target_type, bool is_quantum_effect)
 {
     const auto res = MonsterSpellResult::make_valid();
-
-    GAME_TEXT m_name[MAX_NLEN];
-    monster_name(player_ptr, m_idx, m_name);
+    const auto m_name = monster_name(player_ptr, m_idx);
 
     if (target_type == MONSTER_TO_PLAYER) {
         disturb(player_ptr, true, true);
@@ -119,13 +115,13 @@ MonsterSpellResult spell_RF6_BLINK(PlayerType *player_ptr, MONSTER_IDX m_idx, in
 
     if (!is_quantum_effect && SpellHex(player_ptr).check_hex_barrier(m_idx, HEX_ANTI_TELE)) {
         if (see_monster(player_ptr, m_idx)) {
-            msg_format(_("魔法のバリアが%^sのテレポートを邪魔した。", "Magic barrier obstructs teleporting of %^s."), m_name);
+            msg_format(_("魔法のバリアが%^sのテレポートを邪魔した。", "Magic barrier obstructs teleporting of %^s."), m_name.data());
         }
         return res;
     }
 
     if (see_monster(player_ptr, m_idx)) {
-        msg_format(_("%^sが瞬時に消えた。", "%^s blinks away."), m_name);
+        msg_format(_("%^sが瞬時に消えた。", "%^s blinks away."), m_name.data());
     }
 
     teleport_away(player_ptr, m_idx, 10, TELEPORT_SPONTANEOUS);
@@ -148,22 +144,20 @@ MonsterSpellResult spell_RF6_BLINK(PlayerType *player_ptr, MONSTER_IDX m_idx, in
 MonsterSpellResult spell_RF6_TPORT(PlayerType *player_ptr, MONSTER_IDX m_idx, int target_type)
 {
     const auto res = MonsterSpellResult::make_valid();
-
-    GAME_TEXT m_name[MAX_NLEN];
-    monster_name(player_ptr, m_idx, m_name);
+    const auto m_name = monster_name(player_ptr, m_idx);
 
     if (target_type == MONSTER_TO_PLAYER) {
         disturb(player_ptr, true, true);
     }
     if (SpellHex(player_ptr).check_hex_barrier(m_idx, HEX_ANTI_TELE)) {
         if (see_monster(player_ptr, m_idx)) {
-            msg_format(_("魔法のバリアが%^sのテレポートを邪魔した。", "Magic barrier obstructs teleporting of %^s."), m_name);
+            msg_format(_("魔法のバリアが%^sのテレポートを邪魔した。", "Magic barrier obstructs teleporting of %^s."), m_name.data());
         }
         return res;
     }
 
     if (see_monster(player_ptr, m_idx)) {
-        msg_format(_("%^sがテレポートした。", "%^s teleports away."), m_name);
+        msg_format(_("%^sがテレポートした。", "%^s teleports away."), m_name.data());
     }
 
     teleport_away_followable(player_ptr, m_idx);
@@ -205,8 +199,7 @@ MonsterSpellResult spell_RF6_TELE_TO(PlayerType *player_ptr, MONSTER_IDX m_idx, 
     }
 
     bool resists_tele = false;
-    GAME_TEXT t_name[MAX_NLEN];
-    monster_name(player_ptr, t_idx, t_name);
+    const auto t_name = monster_name(player_ptr, t_idx);
 
     if (tr_ptr->resistance_flags.has(MonsterResistanceType::RESIST_TELEPORT)) {
         if (tr_ptr->kind_flags.has(MonsterKindType::UNIQUE) || tr_ptr->resistance_flags.has(MonsterResistanceType::RESIST_ALL)) {
@@ -214,7 +207,7 @@ MonsterSpellResult spell_RF6_TELE_TO(PlayerType *player_ptr, MONSTER_IDX m_idx, 
                 tr_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_TELEPORT);
             }
             if (see_monster(player_ptr, t_idx)) {
-                msg_format(_("%^sには効果がなかった。", "%^s is unaffected!"), t_name);
+                msg_format(_("%^sには効果がなかった。", "%^s is unaffected!"), t_name.data());
             }
             resists_tele = true;
         } else if (tr_ptr->level > randint1(100)) {
@@ -222,7 +215,7 @@ MonsterSpellResult spell_RF6_TELE_TO(PlayerType *player_ptr, MONSTER_IDX m_idx, 
                 tr_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_TELEPORT);
             }
             if (see_monster(player_ptr, t_idx)) {
-                msg_format(_("%^sは耐性を持っている！", "%^s resists!"), t_name);
+                msg_format(_("%^sは耐性を持っている！", "%^s resists!"), t_name.data());
             }
             resists_tele = true;
         }
@@ -286,8 +279,7 @@ MonsterSpellResult spell_RF6_TELE_AWAY(PlayerType *player_ptr, MONSTER_IDX m_idx
     }
 
     bool resists_tele = false;
-    GAME_TEXT t_name[MAX_NLEN];
-    monster_name(player_ptr, t_idx, t_name);
+    const auto t_name = monster_name(player_ptr, t_idx);
 
     if (tr_ptr->resistance_flags.has(MonsterResistanceType::RESIST_TELEPORT)) {
         if (tr_ptr->kind_flags.has(MonsterKindType::UNIQUE) || tr_ptr->resistance_flags.has(MonsterResistanceType::RESIST_ALL)) {
@@ -295,7 +287,7 @@ MonsterSpellResult spell_RF6_TELE_AWAY(PlayerType *player_ptr, MONSTER_IDX m_idx
                 tr_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_TELEPORT);
             }
             if (see_monster(player_ptr, t_idx)) {
-                msg_format(_("%^sには効果がなかった。", "%^s is unaffected!"), t_name);
+                msg_format(_("%^sには効果がなかった。", "%^s is unaffected!"), t_name.data());
             }
             resists_tele = true;
         } else if (tr_ptr->level > randint1(100)) {
@@ -303,7 +295,7 @@ MonsterSpellResult spell_RF6_TELE_AWAY(PlayerType *player_ptr, MONSTER_IDX m_idx
                 tr_ptr->r_resistance_flags.set(MonsterResistanceType::RESIST_TELEPORT);
             }
             if (see_monster(player_ptr, t_idx)) {
-                msg_format(_("%^sは耐性を持っている！", "%^s resists!"), t_name);
+                msg_format(_("%^sは耐性を持っている！", "%^s resists!"), t_name.data());
             }
             resists_tele = true;
         }
@@ -401,8 +393,7 @@ MonsterSpellResult spell_RF6_DARKNESS(PlayerType *player_ptr, POSITION y, POSITI
     bool can_use_lite_area = false;
     bool monster_to_monster = target_type == MONSTER_TO_MONSTER;
     bool monster_to_player = target_type == MONSTER_TO_PLAYER;
-    GAME_TEXT t_name[MAX_NLEN];
-    monster_name(player_ptr, t_idx, t_name);
+    const auto t_name = monster_name(player_ptr, t_idx);
 
     const auto is_ninja = PlayerClass(player_ptr).equals(PlayerClassType::NINJA);
     const auto is_living_monster = r_ptr->kind_flags.has_not(MonsterKindType::UNDEAD);
@@ -436,7 +427,7 @@ MonsterSpellResult spell_RF6_DARKNESS(PlayerType *player_ptr, POSITION y, POSITI
     monspell_message(player_ptr, m_idx, t_idx, msg, target_type);
 
     if (see_monster(player_ptr, t_idx) && monster_to_monster) {
-        msg_format(msg_done, t_name);
+        msg_format(msg_done, t_name.data());
     }
 
     if (monster_to_player) {
@@ -469,14 +460,13 @@ MonsterSpellResult spell_RF6_DARKNESS(PlayerType *player_ptr, POSITION y, POSITI
  */
 MonsterSpellResult spell_RF6_TRAPS(PlayerType *player_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx)
 {
-    GAME_TEXT m_name[MAX_NLEN];
-    monster_name(player_ptr, m_idx, m_name);
+    const auto m_name = monster_name(player_ptr, m_idx);
     disturb(player_ptr, true, true);
 
     if (player_ptr->effects()->blindness()->is_blind()) {
-        msg_format(_("%^sが何かをつぶやいて邪悪に微笑んだ。", "%^s mumbles, and then cackles evilly."), m_name);
+        msg_format(_("%^sが何かをつぶやいて邪悪に微笑んだ。", "%^s mumbles, and then cackles evilly."), m_name.data());
     } else {
-        msg_format(_("%^sが呪文を唱えて邪悪に微笑んだ。", "%^s casts a spell and cackles evilly."), m_name);
+        msg_format(_("%^sが呪文を唱えて邪悪に微笑んだ。", "%^s casts a spell and cackles evilly."), m_name.data());
     }
 
     (void)trap_creation(player_ptr, y, x);

--- a/src/mspell/mspell-special.cpp
+++ b/src/mspell/mspell-special.cpp
@@ -168,8 +168,7 @@ static MonsterSpellResult spell_RF6_SPECIAL_B(PlayerType *player_ptr, POSITION y
     bool monster_to_player = (target_type == MONSTER_TO_PLAYER);
     bool monster_to_monster = (target_type == MONSTER_TO_MONSTER);
     bool direct = player_bold(player_ptr, y, x);
-    GAME_TEXT m_name[MAX_NLEN];
-    monster_name(player_ptr, m_idx, m_name);
+    const auto m_name = monster_name(player_ptr, m_idx);
 
     disturb(player_ptr, true, true);
     if (one_in_(3) || !direct) {
@@ -213,11 +212,10 @@ static MonsterSpellResult spell_RF6_SPECIAL_B(PlayerType *player_ptr, POSITION y
     dam += damroll(6, 8);
 
     if (monster_to_player || (monster_to_monster && player_ptr->riding == t_idx)) {
-        int get_damage = take_hit(player_ptr, DAMAGE_NOESCAPE, dam, m_name);
+        int get_damage = take_hit(player_ptr, DAMAGE_NOESCAPE, dam, m_name.data());
         if (player_ptr->tim_eyeeye && get_damage > 0 && !player_ptr->is_dead) {
-            GAME_TEXT m_name_self[MAX_MONSTER_NAME];
-            monster_desc(player_ptr, m_name_self, m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE | MD_OBJECTIVE);
-            msg_format(_("攻撃が%s自身を傷つけた！", "The attack of %s has wounded %s!"), m_name, m_name_self);
+            const auto m_name_self = monster_desc(player_ptr, m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE | MD_OBJECTIVE);
+            msg_format(_("攻撃が%s自身を傷つけた！", "The attack of %s has wounded %s!"), m_name.data(), m_name_self.data());
             project(player_ptr, 0, 0, m_ptr->fy, m_ptr->fx, get_damage, AttributeType::MISSILE, PROJECT_KILL);
             set_tim_eyeeye(player_ptr, player_ptr->tim_eyeeye - 5, true);
         }

--- a/src/mspell/mspell-status.cpp
+++ b/src/mspell/mspell-status.cpp
@@ -66,14 +66,13 @@ mspell_cast_msg_bad_status_to_monster::mspell_cast_msg_bad_status_to_monster(con
 void spell_badstatus_message_to_player(PlayerType *player_ptr, MONSTER_IDX m_idx, const mspell_cast_msg_bad_status_to_player &msgs, bool resist,
     bool saved_throw)
 {
-    GAME_TEXT m_name[MAX_NLEN];
-    monster_name(player_ptr, m_idx, m_name);
+    const auto m_name = monster_name(player_ptr, m_idx);
 
     disturb(player_ptr, true, true);
     if (player_ptr->effects()->blindness()->is_blind()) {
-        msg_format(msgs.blind, m_name);
+        msg_format(msgs.blind, m_name.data());
     } else {
-        msg_format(msgs.not_blind, m_name);
+        msg_format(msgs.not_blind, m_name.data());
     }
 
     if (resist) {
@@ -101,13 +100,12 @@ void spell_badstatus_message_to_mons(PlayerType *player_ptr, MONSTER_IDX m_idx, 
     bool see_either = see_monster(player_ptr, m_idx) || see_monster(player_ptr, t_idx);
     bool see_t = see_monster(player_ptr, t_idx);
     bool known = monster_near_player(floor_ptr, m_idx, t_idx);
-    GAME_TEXT m_name[MAX_NLEN], t_name[MAX_NLEN];
-    monster_name(player_ptr, m_idx, m_name);
-    monster_name(player_ptr, t_idx, t_name);
+    const auto m_name = monster_name(player_ptr, m_idx);
+    const auto t_name = monster_name(player_ptr, t_idx);
 
     if (known) {
         if (see_either) {
-            msg_format(msgs.default_msg, m_name, t_name);
+            msg_format(msgs.default_msg, m_name.data(), t_name.data());
         } else {
             floor_ptr->monster_noise = true;
         }
@@ -115,15 +113,15 @@ void spell_badstatus_message_to_mons(PlayerType *player_ptr, MONSTER_IDX m_idx, 
 
     if (resist) {
         if (see_t) {
-            msg_format(msgs.resist, t_name);
+            msg_format(msgs.resist, t_name.data());
         }
     } else if (saved_throw) {
         if (see_t) {
-            msg_format(msgs.saved_throw, t_name);
+            msg_format(msgs.saved_throw, t_name.data());
         }
     } else {
         if (see_t) {
-            msg_format(msgs.success, t_name);
+            msg_format(msgs.success, t_name.data());
         }
     }
 
@@ -143,15 +141,14 @@ void spell_badstatus_message_to_mons(PlayerType *player_ptr, MONSTER_IDX m_idx, 
  */
 MonsterSpellResult spell_RF5_DRAIN_MANA(PlayerType *player_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    GAME_TEXT m_name[MAX_NLEN], t_name[MAX_NLEN];
-    monster_name(player_ptr, m_idx, m_name);
-    monster_name(player_ptr, t_idx, t_name);
+    const auto m_name = monster_name(player_ptr, m_idx);
+    const auto t_name = monster_name(player_ptr, t_idx);
 
     if (target_type == MONSTER_TO_PLAYER) {
         disturb(player_ptr, true, true);
     } else if (target_type == MONSTER_TO_MONSTER && see_monster(player_ptr, m_idx)) {
         /* Basic message */
-        msg_format(_("%^sは精神エネルギーを%sから吸いとった。", "%^s draws psychic energy from %s."), m_name, t_name);
+        msg_format(_("%^sは精神エネルギーを%sから吸いとった。", "%^s draws psychic energy from %s."), m_name.data(), t_name.data());
     }
 
     const auto dam = monspell_damage(player_ptr, MonsterAbilityType::DRAIN_MANA, m_idx, DAM_ROLL);
@@ -181,19 +178,18 @@ MonsterSpellResult spell_RF5_MIND_BLAST(PlayerType *player_ptr, POSITION y, POSI
 {
     auto *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
     bool seen = (!player_ptr->effects()->blindness()->is_blind() && m_ptr->ml);
-    GAME_TEXT m_name[MAX_NLEN], t_name[MAX_NLEN];
-    monster_name(player_ptr, m_idx, m_name);
-    monster_name(player_ptr, t_idx, t_name);
+    const auto m_name = monster_name(player_ptr, m_idx);
+    const auto t_name = monster_name(player_ptr, t_idx);
 
     if (target_type == MONSTER_TO_PLAYER) {
         disturb(player_ptr, true, true);
         if (!seen) {
             msg_print(_("何かがあなたの精神に念を放っているようだ。", "You feel something focusing on your mind."));
         } else {
-            msg_format(_("%^sがあなたの瞳をじっとにらんでいる。", "%^s gazes deep into your eyes."), m_name);
+            msg_format(_("%^sがあなたの瞳をじっとにらんでいる。", "%^s gazes deep into your eyes."), m_name.data());
         }
     } else if (target_type == MONSTER_TO_MONSTER && see_monster(player_ptr, m_idx)) {
-        msg_format(_("%^sは%sをじっと睨んだ。", "%^s gazes intently at %s."), m_name, t_name);
+        msg_format(_("%^sは%sをじっと睨んだ。", "%^s gazes intently at %s."), m_name.data(), t_name.data());
     }
 
     const auto dam = monspell_damage(player_ptr, MonsterAbilityType::MIND_BLAST, m_idx, DAM_ROLL);
@@ -220,19 +216,18 @@ MonsterSpellResult spell_RF5_BRAIN_SMASH(PlayerType *player_ptr, POSITION y, POS
 {
     auto *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
     bool seen = (!player_ptr->effects()->blindness()->is_blind() && m_ptr->ml);
-    GAME_TEXT m_name[MAX_NLEN], t_name[MAX_NLEN];
-    monster_name(player_ptr, m_idx, m_name);
-    monster_name(player_ptr, t_idx, t_name);
+    const auto m_name = monster_name(player_ptr, m_idx);
+    const auto t_name = monster_name(player_ptr, t_idx);
 
     if (target_type == MONSTER_TO_PLAYER) {
         disturb(player_ptr, true, true);
         if (!seen) {
             msg_print(_("何かがあなたの精神に念を放っているようだ。", "You feel something focusing on your mind."));
         } else {
-            msg_format(_("%^sがあなたの瞳をじっとにらんでいる。", "%^s gazes deep into your eyes."), m_name);
+            msg_format(_("%^sがあなたの瞳をじっとにらんでいる。", "%^s gazes deep into your eyes."), m_name.data());
         }
     } else if (target_type == MONSTER_TO_MONSTER && see_monster(player_ptr, m_idx)) {
-        msg_format(_("%^sは%sをじっと睨んだ。", "%^s gazes intently at %s."), m_name, t_name);
+        msg_format(_("%^sは%sをじっと睨んだ。", "%^s gazes intently at %s."), m_name.data(), t_name.data());
     }
 
     const auto dam = monspell_damage(player_ptr, MonsterAbilityType::BRAIN_SMASH, m_idx, DAM_ROLL);
@@ -343,10 +338,9 @@ MonsterSpellResult spell_RF5_BLIND(MONSTER_IDX m_idx, PlayerType *player_ptr, MO
     }
 
     concptr msg_default;
-    GAME_TEXT t_name[MAX_NLEN];
-    monster_name(player_ptr, t_idx, t_name);
+    const auto t_name = monster_name(player_ptr, t_idx);
 
-    if (streq(t_name, "it")) {
+    if (streq(t_name.data(), "it")) {
         msg_default = _("%sは呪文を唱えて%sの目を焼き付かせた。", "%^s casts a spell, burning %ss eyes.");
     } else {
         msg_default = _("%sは呪文を唱えて%sの目を焼き付かせた。", "%^s casts a spell, burning %s's eyes.");
@@ -494,21 +488,19 @@ MonsterSpellResult spell_RF6_HASTE(PlayerType *player_ptr, MONSTER_IDX m_idx, MO
 {
     bool see_m = see_monster(player_ptr, m_idx);
     auto *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
-    GAME_TEXT m_name[MAX_NLEN];
-    monster_name(player_ptr, m_idx, m_name);
-    char m_poss[10];
-    monster_desc(player_ptr, m_poss, m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE);
+    const auto m_name = monster_name(player_ptr, m_idx);
+    const auto m_poss = monster_desc(player_ptr, m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE);
 
     mspell_cast_msg msg(_("%^sが何かをつぶやいた。", "%^s mumbles."),
-        _("%^sが自分の体に念を送った。", format("%%^s concentrates on %s body.", m_poss)),
-        _("%^sが自分の体に念を送った。", format("%%^s concentrates on %s body.", m_poss)),
-        _("%^sが自分の体に念を送った。", format("%%^s concentrates on %s body.", m_poss)));
+        _("%^sが自分の体に念を送った。", format("%%^s concentrates on %s body.", m_poss.data())),
+        _("%^sが自分の体に念を送った。", format("%%^s concentrates on %s body.", m_poss.data())),
+        _("%^sが自分の体に念を送った。", format("%%^s concentrates on %s body.", m_poss.data())));
 
     monspell_message_base(player_ptr, m_idx, t_idx, msg, player_ptr->effects()->blindness()->is_blind(), target_type);
 
     if (set_monster_fast(player_ptr, m_idx, m_ptr->get_remaining_acceleration() + 100)) {
         if (target_type == MONSTER_TO_PLAYER || (target_type == MONSTER_TO_MONSTER && see_m)) {
-            msg_format(_("%^sの動きが速くなった。", "%^s starts moving faster."), m_name);
+            msg_format(_("%^sの動きが速くなった。", "%^s starts moving faster."), m_name.data());
         }
     }
 
@@ -557,10 +549,9 @@ MonsterSpellResult spell_RF5_SLOW(MONSTER_IDX m_idx, PlayerType *player_ptr, MON
     }
 
     concptr msg_default;
-    GAME_TEXT t_name[MAX_NLEN];
-    monster_name(player_ptr, t_idx, t_name);
+    const auto t_name = monster_name(player_ptr, t_idx);
 
-    if (streq(t_name, "it")) {
+    if (streq(t_name.data(), "it")) {
         msg_default = _("%sが%sの筋肉から力を吸いとった。", "%^s drains power from %ss muscles.");
     } else {
         msg_default = _("%sが%sの筋肉から力を吸いとった。", "%^s drains power from %s's muscles.");
@@ -600,15 +591,12 @@ MonsterSpellResult spell_RF6_HEAL(PlayerType *player_ptr, MONSTER_IDX m_idx, MON
     DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
     const auto is_blind = player_ptr->effects()->blindness()->is_blind();
     const auto seen = (!is_blind && m_ptr->ml);
-    GAME_TEXT m_name[MAX_NLEN];
-    monster_name(player_ptr, m_idx, m_name);
-    char m_poss[10];
-    monster_desc(player_ptr, m_poss, m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE);
+    const auto m_poss = monster_desc(player_ptr, m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE);
 
     msg.to_player_true = _("%^sが何かをつぶやいた。", "%^s mumbles.");
-    msg.to_mons_true = _("%^sは自分の傷に念を集中した。", format("%%^s concentrates on %s wounds.", m_poss));
-    msg.to_player_false = _("%^sが自分の傷に集中した。", format("%%^s concentrates on %s wounds.", m_poss));
-    msg.to_mons_false = _("%^sは自分の傷に念を集中した。", format("%%^s concentrates on %s wounds.", m_poss));
+    msg.to_mons_true = _("%^sは自分の傷に念を集中した。", format("%%^s concentrates on %s wounds.", m_poss.data()));
+    msg.to_player_false = _("%^sが自分の傷に集中した。", format("%%^s concentrates on %s wounds.", m_poss.data()));
+    msg.to_mons_false = _("%^sは自分の傷に念を集中した。", format("%%^s concentrates on %s wounds.", m_poss.data()));
 
     monspell_message_base(player_ptr, m_idx, t_idx, msg, is_blind, target_type);
 
@@ -644,7 +632,8 @@ MonsterSpellResult spell_RF6_HEAL(PlayerType *player_ptr, MONSTER_IDX m_idx, MON
     (void)set_monster_monfear(player_ptr, m_idx, 0);
 
     if (see_monster(player_ptr, m_idx)) {
-        msg_format(_("%^sは勇気を取り戻した。", format("%%^s recovers %s courage.", m_poss)), m_name);
+        const auto m_name = monster_name(player_ptr, m_idx);
+        msg_format(_("%^sは勇気を取り戻した。", format("%%^s recovers %s courage.", m_poss.data())), m_name.data());
     }
 
     return res;
@@ -671,18 +660,17 @@ MonsterSpellResult spell_RF6_INVULNER(PlayerType *player_ptr, MONSTER_IDX m_idx,
 
     if (m_ptr->ml) {
         MonsterRaceId r_idx = m_ptr->r_idx;
-        GAME_TEXT m_name[MAX_NLEN];
-        monster_desc(player_ptr, m_name, m_ptr, MD_NONE);
+        const auto m_name = monster_desc(player_ptr, m_ptr, MD_NONE);
         switch (r_idx) {
         case MonsterRaceId::MARIO:
         case MonsterRaceId::LUIGI:
-            msg_format(_("%sはスターを取った！", "%^s got a star!"), m_name);
+            msg_format(_("%sはスターを取った！", "%^s got a star!"), m_name.data());
             break;
         case MonsterRaceId::DIAVOLO:
             msg_print(_("『読める』………動きの『軌跡』が読める……", "'Read'......... I can read the 'trajectory' of movement..."));
             break;
         default:
-            msg_format(_("%sの身体がまばゆく輝き始めた！", "The body of %^s began to shine dazzlingly!"), m_name);
+            msg_format(_("%sの身体がまばゆく輝き始めた！", "The body of %^s began to shine dazzlingly!"), m_name.data());
             break;
         }
     }
@@ -704,12 +692,11 @@ MonsterSpellResult spell_RF6_INVULNER(PlayerType *player_ptr, MONSTER_IDX m_idx,
 MonsterSpellResult spell_RF6_FORGET(PlayerType *player_ptr, MONSTER_IDX m_idx)
 {
     DEPTH rlev = monster_level_idx(player_ptr->current_floor_ptr, m_idx);
-    GAME_TEXT m_name[MAX_NLEN];
-    monster_name(player_ptr, m_idx, m_name);
+    const auto m_name = monster_name(player_ptr, m_idx);
 
     disturb(player_ptr, true, true);
 
-    msg_format(_("%^sがあなたの記憶を消去しようとしている。", "%^s tries to blank your mind."), m_name);
+    msg_format(_("%^sがあなたの記憶を消去しようとしている。", "%^s tries to blank your mind."), m_name.data());
 
     if (randint0(100 + rlev / 2) < player_ptr->skill_sav) {
         msg_print(_("しかし効力を跳ね返した！", "You resist the effects!"));

--- a/src/mspell/mspell-summon.cpp
+++ b/src/mspell/mspell-summon.cpp
@@ -139,17 +139,15 @@ MonsterSpellResult spell_RF6_S_KIN(PlayerType *player_ptr, POSITION y, POSITION 
     auto *floor_ptr = player_ptr->current_floor_ptr;
     auto *m_ptr = &floor_ptr->m_list[m_idx];
     DEPTH rlev = monster_level_idx(floor_ptr, m_idx);
-    GAME_TEXT m_name[MAX_NLEN], t_name[MAX_NLEN], m_poss[80];
-    monster_name(player_ptr, m_idx, m_name);
-    monster_name(player_ptr, t_idx, t_name);
-    monster_desc(player_ptr, m_poss, m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE);
+    const auto m_name = monster_name(player_ptr, m_idx);
+    const auto m_poss = monster_desc(player_ptr, m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE);
 
     bool see_either = see_monster(player_ptr, m_idx) || see_monster(player_ptr, t_idx);
     bool known = monster_near_player(floor_ptr, m_idx, t_idx);
 
     summon_disturb(player_ptr, target_type, known, see_either);
 
-    decide_summon_kin_caster(player_ptr, m_idx, t_idx, target_type, m_name, m_poss, known);
+    decide_summon_kin_caster(player_ptr, m_idx, t_idx, target_type, m_name.data(), m_poss.data(), known);
     int count = 0;
     switch (m_ptr->r_idx) {
     case MonsterRaceId::MENELDOR:
@@ -773,8 +771,6 @@ MonsterSpellResult spell_RF6_S_HI_UNDEAD(PlayerType *player_ptr, POSITION y, POS
     bool see_either = see_monster(player_ptr, m_idx) || see_monster(player_ptr, t_idx);
     bool known = monster_near_player(floor_ptr, m_idx, t_idx);
 
-    GAME_TEXT m_name[MAX_NLEN];
-    monster_name(player_ptr, m_idx, m_name);
     summon_disturb(player_ptr, target_type, known, see_either);
 
     int count = 0;

--- a/src/mspell/mspell-util.cpp
+++ b/src/mspell/mspell-util.cpp
@@ -67,9 +67,8 @@ bool monspell_message_base(PlayerType *player_ptr, MONSTER_IDX m_idx, MONSTER_ID
     bool see_either = see_monster(player_ptr, m_idx) || see_monster(player_ptr, t_idx);
     bool mon_to_mon = (target_type == MONSTER_TO_MONSTER);
     bool mon_to_player = (target_type == MONSTER_TO_PLAYER);
-    GAME_TEXT m_name[MAX_NLEN], t_name[MAX_NLEN];
-    monster_name(player_ptr, m_idx, m_name);
-    monster_name(player_ptr, t_idx, t_name);
+    const auto m_name = monster_name(player_ptr, m_idx);
+    const auto t_name = monster_name(player_ptr, t_idx);
 
     if (mon_to_player || (mon_to_mon && known && see_either)) {
         disturb(player_ptr, true, true);
@@ -77,18 +76,18 @@ bool monspell_message_base(PlayerType *player_ptr, MONSTER_IDX m_idx, MONSTER_ID
 
     if (msg_flag_aux) {
         if (mon_to_player) {
-            msg_format(msgs.to_player_true, m_name);
+            msg_format(msgs.to_player_true, m_name.data());
             notice = true;
         } else if (mon_to_mon && known && see_either) {
-            msg_format(msgs.to_mons_true, m_name);
+            msg_format(msgs.to_mons_true, m_name.data());
             notice = true;
         }
     } else {
         if (mon_to_player) {
-            msg_format(msgs.to_player_false, m_name);
+            msg_format(msgs.to_player_false, m_name.data());
             notice = true;
         } else if (mon_to_mon && known && see_either) {
-            msg_format(msgs.to_mons_false, m_name, t_name);
+            msg_format(msgs.to_mons_false, m_name.data(), t_name.data());
             notice = true;
         }
     }

--- a/src/mspell/specified-summon.cpp
+++ b/src/mspell/specified-summon.cpp
@@ -179,13 +179,12 @@ MONSTER_NUMBER summon_NAZGUL(PlayerType *player_ptr, POSITION y, POSITION x, MON
     BIT_FLAGS mode = 0L;
     POSITION cy = y;
     POSITION cx = x;
-    GAME_TEXT m_name[MAX_NLEN];
-    monster_name(player_ptr, m_idx, m_name);
+    const auto m_name = monster_name(player_ptr, m_idx);
 
     if (player_ptr->effects()->blindness()->is_blind()) {
-        msg_format(_("%^sが何かをつぶやいた。", "%^s mumbles."), m_name);
+        msg_format(_("%^sが何かをつぶやいた。", "%^s mumbles."), m_name.data());
     } else {
-        msg_format(_("%^sが魔法で幽鬼戦隊を召喚した！", "%^s magically summons rangers of Nazgul!"), m_name);
+        msg_format(_("%^sが魔法で幽鬼戦隊を召喚した！", "%^s magically summons rangers of Nazgul!"), m_name.data());
     }
 
     msg_print(nullptr);

--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -66,6 +66,7 @@
 #include "timed-effect/player-hallucination.h"
 #include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
+#include "util/string-processor.h"
 #include "view/display-messages.h"
 #include "view/object-describer.h"
 #include "wizard/wizard-messages.h"
@@ -217,7 +218,7 @@ void ObjectThrowEntity::exe_throw()
         auto *floor_ptr = this->player_ptr->current_floor_ptr;
         this->g_ptr = &floor_ptr->grid_array[this->y][this->x];
         this->m_ptr = &floor_ptr->m_list[this->g_ptr->m_idx];
-        monster_name(this->player_ptr, this->g_ptr->m_idx, this->m_name);
+        angband_strcpy(this->m_name, monster_name(this->player_ptr, this->g_ptr->m_idx).data(), sizeof(this->m_name));
         this->visible = this->m_ptr->ml;
         this->hit_body = true;
         this->attack_racial_power();
@@ -267,9 +268,8 @@ void ObjectThrowEntity::display_potion_throw()
         return;
     }
 
-    GAME_TEXT angry_m_name[MAX_NLEN];
-    monster_desc(this->player_ptr, angry_m_name, angry_m_ptr, 0);
-    msg_format(_("%sは怒った！", "%^s gets angry!"), angry_m_name);
+    const auto angry_m_name = monster_desc(this->player_ptr, angry_m_ptr, 0);
+    msg_format(_("%sは怒った！", "%^s gets angry!"), angry_m_name.data());
     set_hostile(this->player_ptr, &floor_ptr->m_list[floor_ptr->grid_array[this->y][this->x].m_idx]);
     this->do_drop = false;
 }

--- a/src/pet/pet-fall-off.cpp
+++ b/src/pet/pet-fall-off.cpp
@@ -40,10 +40,9 @@ void check_fall_off_horse(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr
         return;
     }
 
-    char m_steed_name[MAX_NLEN];
-    monster_desc(player_ptr, m_steed_name, &player_ptr->current_floor_ptr->m_list[player_ptr->riding], 0);
+    const auto m_steed_name = monster_desc(player_ptr, &player_ptr->current_floor_ptr->m_list[player_ptr->riding], 0);
     if (process_fall_off_horse(player_ptr, (monap_ptr->damage > 200) ? 200 : monap_ptr->damage, false)) {
-        msg_format(_("%^sから落ちてしまった！", "You have fallen from %s."), m_steed_name);
+        msg_format(_("%^sから落ちてしまった！", "You have fallen from %s."), m_steed_name.data());
     }
 }
 
@@ -93,7 +92,6 @@ bool process_fall_off_horse(PlayerType *player_ptr, int dam, bool force)
     POSITION sy = 0;
     POSITION sx = 0;
     int sn = 0;
-    GAME_TEXT m_name[MAX_NLEN];
     auto *m_ptr = &player_ptr->current_floor_ptr->m_list[player_ptr->riding];
     auto *r_ptr = &monraces_info[m_ptr->r_idx];
 
@@ -143,8 +141,8 @@ bool process_fall_off_horse(PlayerType *player_ptr, int dam, bool force)
         }
 
         if (!sn) {
-            monster_desc(player_ptr, m_name, m_ptr, 0);
-            msg_format(_("%sから振り落とされそうになって、壁にぶつかった。", "You have nearly fallen from %s but bumped into a wall."), m_name);
+            const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+            msg_format(_("%sから振り落とされそうになって、壁にぶつかった。", "You have nearly fallen from %s but bumped into a wall."), m_name.data());
             take_hit(player_ptr, DAMAGE_NOESCAPE, r_ptr->level + 3, _("壁への衝突", "bumping into a wall"));
             return false;
         }
@@ -173,8 +171,8 @@ bool process_fall_off_horse(PlayerType *player_ptr, int dam, bool force)
 
     bool fall_dam = false;
     if (player_ptr->levitation && !force) {
-        monster_desc(player_ptr, m_name, m_ptr, 0);
-        msg_format(_("%sから落ちたが、空中でうまく体勢を立て直して着地した。", "You are thrown from %s but make a good landing."), m_name);
+        const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+        msg_format(_("%sから落ちたが、空中でうまく体勢を立て直して着地した。", "You are thrown from %s but make a good landing."), m_name.data());
     } else {
         take_hit(player_ptr, DAMAGE_NOESCAPE, r_ptr->level + 3, _("落馬", "Falling from riding"));
         fall_dam = true;

--- a/src/player-attack/attack-chaos-effect.cpp
+++ b/src/player-attack/attack-chaos-effect.cpp
@@ -38,6 +38,7 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
+#include "util/string-processor.h"
 #include "view/display-messages.h"
 
 /*!
@@ -242,7 +243,7 @@ static void attack_polymorph(PlayerType *player_ptr, player_attack_type *pa_ptr,
     }
 
     pa_ptr->m_ptr = &player_ptr->current_floor_ptr->m_list[pa_ptr->m_idx];
-    monster_desc(player_ptr, pa_ptr->m_name, pa_ptr->m_ptr, 0);
+    angband_strcpy(pa_ptr->m_name, monster_desc(player_ptr, pa_ptr->m_ptr, 0).data(), sizeof(pa_ptr->m_name));
 }
 
 /*!

--- a/src/player-attack/player-attack.cpp
+++ b/src/player-attack/player-attack.cpp
@@ -58,6 +58,7 @@
 #include "timed-effect/player-cut.h"
 #include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
+#include "util/string-processor.h"
 #include "view/display-messages.h"
 #include "wizard/wizard-messages.h"
 #include "world/world.h"
@@ -559,7 +560,7 @@ void exe_player_attack_to_monster(PlayerType *player_ptr, POSITION y, POSITION x
 
     /* Disturb the monster */
     (void)set_monster_csleep(player_ptr, pa_ptr->m_idx, 0);
-    monster_desc(player_ptr, pa_ptr->m_name, pa_ptr->m_ptr, 0);
+    angband_strcpy(pa_ptr->m_name, monster_desc(player_ptr, pa_ptr->m_ptr, 0).data(), sizeof(pa_ptr->m_name));
 
     int chance = calc_attack_quality(player_ptr, pa_ptr);
     auto *o_ptr = &player_ptr->inventory_list[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];

--- a/src/player/eldritch-horror.cpp
+++ b/src/player/eldritch-horror.cpp
@@ -60,7 +60,7 @@ static concptr decide_horror_message(MonsterRaceInfo *r_ptr)
  * @param r_ptr モンスター情報への参照ポインタ
  * @todo m_nameとdescで何が違うのかは良く分からない
  */
-static void see_eldritch_horror(GAME_TEXT *m_name, MonsterRaceInfo *r_ptr)
+static void see_eldritch_horror(concptr m_name, MonsterRaceInfo *r_ptr)
 {
     concptr horror_message = decide_horror_message(r_ptr);
     msg_format(_("%s%sの顔を見てしまった！", "You behold the %s visage of %s!"), horror_message, m_name);
@@ -92,10 +92,9 @@ void sanity_blast(PlayerType *player_ptr, MonsterEntity *m_ptr, bool necro)
 
     int power = 100;
     if (!necro && m_ptr) {
-        GAME_TEXT m_name[MAX_NLEN];
         auto *r_ptr = &monraces_info[m_ptr->ap_r_idx];
+        const auto m_name = monster_desc(player_ptr, m_ptr, 0);
         power = r_ptr->level / 2;
-        monster_desc(player_ptr, m_name, m_ptr, 0);
         if (r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE)) {
             if (r_ptr->flags1 & RF1_FRIENDS) {
                 power /= 2;
@@ -129,7 +128,7 @@ void sanity_blast(PlayerType *player_ptr, MonsterEntity *m_ptr, bool necro)
         }
 
         if (player_ptr->effects()->hallucination()->is_hallucinated()) {
-            msg_format(_("%s%sの顔を見てしまった！", "You behold the %s visage of %s!"), funny_desc[randint0(MAX_SAN_FUNNY)], m_name);
+            msg_format(_("%s%sの顔を見てしまった！", "You behold the %s visage of %s!"), funny_desc[randint0(MAX_SAN_FUNNY)], m_name.data());
             if (one_in_(3)) {
                 msg_print(funny_comments[randint0(MAX_SAN_COMMENT)]);
                 BadStatusSetter(player_ptr).mod_hallucination(randint1(r_ptr->level));
@@ -138,7 +137,7 @@ void sanity_blast(PlayerType *player_ptr, MonsterEntity *m_ptr, bool necro)
             return;
         }
 
-        see_eldritch_horror(m_name, r_ptr);
+        see_eldritch_horror(m_name.data(), r_ptr);
         switch (PlayerRace(player_ptr).life()) {
         case PlayerRaceLifeType::DEMON:
             return;

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -615,11 +615,9 @@ static void process_aura_damage(MonsterEntity *m_ptr, PlayerType *player_ptr, bo
         return;
     }
 
-    GAME_TEXT mon_name[MAX_NLEN];
     int aura_damage = damroll(1 + (r_ptr->level / 26), 1 + (r_ptr->level / 17));
-    monster_desc(player_ptr, mon_name, m_ptr, MD_WRONGDOER_NAME);
     msg_print(message);
-    (*dam_func)(player_ptr, aura_damage, mon_name, true);
+    (*dam_func)(player_ptr, aura_damage, monster_desc(player_ptr, m_ptr, MD_WRONGDOER_NAME).data(), true);
     if (is_original_ap_and_seen(player_ptr, m_ptr)) {
         r_ptr->r_aura_flags.set(aura_flag);
     }

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -402,9 +402,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 POSITION oy = y, ox = x;
                 MONSTER_IDX m_idx = player_ptr->current_floor_ptr->grid_array[y][x].m_idx;
                 auto *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
-                GAME_TEXT m_name[MAX_NLEN];
-
-                monster_desc(player_ptr, m_name, m_ptr, 0);
+                const auto m_name = monster_desc(player_ptr, m_ptr, 0);
 
                 for (i = 0; i < 5; i++) {
                     y += ddy[dir];
@@ -417,7 +415,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                     }
                 }
                 if ((ty != oy) || (tx != ox)) {
-                    msg_format(_("%sを吹き飛ばした！", "You blow %s away!"), m_name);
+                    msg_format(_("%sを吹き飛ばした！", "You blow %s away!"), m_name.data());
                     player_ptr->current_floor_ptr->grid_array[oy][ox].m_idx = 0;
                     player_ptr->current_floor_ptr->grid_array[ty][tx].m_idx = m_idx;
                     m_ptr->fy = ty;
@@ -690,9 +688,8 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                     continue;
                 }
 
-                GAME_TEXT m_name[MAX_NLEN];
-                monster_desc(player_ptr, m_name, m_ptr, 0);
-                msg_format(_("%sには効果がない！", "%s is unharmed!"), m_name);
+                const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+                msg_format(_("%sには効果がない！", "%s is unharmed!"), m_name.data());
             }
         }
 

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -177,10 +177,9 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
             std::string killer;
 
             if (m_idx) {
-                GAME_TEXT m_name[MAX_NLEN];
                 auto *m_ptr = &floor_ptr->m_list[m_idx];
-                monster_desc(player_ptr, m_name, m_ptr, MD_WRONGDOER_NAME);
-                killer = format(_("%sの起こした地震", "an earthquake caused by %s"), m_name);
+                const auto m_name = monster_desc(player_ptr, m_ptr, MD_WRONGDOER_NAME);
+                killer = format(_("%sの起こした地震", "an earthquake caused by %s"), m_name.data());
             } else {
                 killer = _("地震", "an earthquake");
             }
@@ -218,7 +217,6 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
                 continue;
             }
 
-            GAME_TEXT m_name[MAX_NLEN];
             sn = 0;
             if (r_ptr->behavior_flags.has_not(MonsterBehaviorType::NEVER_MOVE)) {
                 for (DIRECTION i = 0; i < 8; i++) {
@@ -264,9 +262,9 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
                 }
             }
 
-            monster_desc(player_ptr, m_name, m_ptr, 0);
+            const auto m_name = monster_desc(player_ptr, m_ptr, 0);
             if (!ignore_unview || is_seen(player_ptr, m_ptr)) {
-                msg_format(_("%^sは苦痛で泣きわめいた！", "%^s wails out in pain!"), m_name);
+                msg_format(_("%^sは苦痛で泣きわめいた！", "%^s wails out in pain!"), m_name.data());
             }
 
             damage = (sn ? damroll(4, 8) : (m_ptr->hp + 1));
@@ -274,16 +272,14 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
             m_ptr->hp -= damage;
             if (m_ptr->hp < 0) {
                 if (!ignore_unview || is_seen(player_ptr, m_ptr)) {
-                    msg_format(_("%^sは岩石に埋もれてしまった！", "%^s is embedded in the rock!"), m_name);
+                    msg_format(_("%^sは岩石に埋もれてしまった！", "%^s is embedded in the rock!"), m_name.data());
                 }
 
                 if (gg_ptr->m_idx) {
                     const auto &m_ref = floor_ptr->m_list[gg_ptr->m_idx];
                     if (record_named_pet && m_ref.is_pet() && m_ref.nickname) {
-                        char m2_name[MAX_NLEN];
-
-                        monster_desc(player_ptr, m2_name, m_ptr, MD_INDEF_VISIBLE);
-                        exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_EARTHQUAKE, m2_name);
+                        const auto m2_name = monster_desc(player_ptr, m_ptr, MD_INDEF_VISIBLE);
+                        exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_EARTHQUAKE, m2_name.data());
                     }
                 }
 

--- a/src/spell-kind/spells-fetcher.cpp
+++ b/src/spell-kind/spells-fetcher.cpp
@@ -117,16 +117,11 @@ void fetch_item(PlayerType *player_ptr, DIRECTION dir, WEIGHT wgt, bool require_
 
 bool fetch_monster(PlayerType *player_ptr)
 {
-    MonsterEntity *m_ptr;
-    MONSTER_IDX m_idx;
-    GAME_TEXT m_name[MAX_NLEN];
-    POSITION ty, tx;
-
     if (!target_set(player_ptr, TARGET_KILL)) {
         return false;
     }
 
-    m_idx = player_ptr->current_floor_ptr->grid_array[target_row][target_col].m_idx;
+    auto m_idx = player_ptr->current_floor_ptr->grid_array[target_row][target_col].m_idx;
     if (!m_idx) {
         return false;
     }
@@ -140,11 +135,11 @@ bool fetch_monster(PlayerType *player_ptr)
         return false;
     }
 
-    m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
-    monster_desc(player_ptr, m_name, m_ptr, 0);
-    msg_format(_("%sを引き戻した。", "You pull back %s."), m_name);
+    auto *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
+    const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+    msg_format(_("%sを引き戻した。", "You pull back %s."), m_name.data());
     projection_path path_g(player_ptr, get_max_range(player_ptr), target_row, target_col, player_ptr->y, player_ptr->x, 0);
-    ty = target_row, tx = target_col;
+    auto ty = target_row, tx = target_col;
     for (const auto &[ny, nx] : path_g) {
         auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[ny][nx];
 

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -328,10 +328,8 @@ bool destroy_area(PlayerType *player_ptr, POSITION y1, POSITION x1, POSITION r, 
                     }
                 } else {
                     if (record_named_pet && m_ptr->is_pet() && m_ptr->nickname) {
-                        GAME_TEXT m_name[MAX_NLEN];
-
-                        monster_desc(player_ptr, m_name, m_ptr, MD_INDEF_VISIBLE);
-                        exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_DESTROY, m_name);
+                        const auto m_name = monster_desc(player_ptr, m_ptr, MD_INDEF_VISIBLE);
+                        exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_DESTROY, m_name.data());
                     }
 
                     /* Delete the monster (if any) */

--- a/src/spell-kind/spells-genocide.cpp
+++ b/src/spell-kind/spells-genocide.cpp
@@ -63,9 +63,8 @@ bool genocide_aux(PlayerType *player_ptr, MONSTER_IDX m_idx, int power, bool pla
         resist = true;
     } else {
         if (record_named_pet && m_ptr->is_pet() && m_ptr->nickname) {
-            GAME_TEXT m_name[MAX_NLEN];
-            monster_desc(player_ptr, m_name, m_ptr, MD_INDEF_VISIBLE);
-            exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_GENOCIDE, m_name);
+            const auto m_name = monster_desc(player_ptr, m_ptr, MD_INDEF_VISIBLE);
+            exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_GENOCIDE, m_name.data());
         }
 
         delete_monster_idx(player_ptr, m_idx);
@@ -73,22 +72,21 @@ bool genocide_aux(PlayerType *player_ptr, MONSTER_IDX m_idx, int power, bool pla
 
     if (resist && player_cast) {
         bool see_m = is_seen(player_ptr, m_ptr);
-        GAME_TEXT m_name[MAX_NLEN];
-        monster_desc(player_ptr, m_name, m_ptr, 0);
+        const auto m_name = monster_desc(player_ptr, m_ptr, 0);
         if (see_m) {
-            msg_format(_("%^sには効果がなかった。", "%^s is unaffected."), m_name);
+            msg_format(_("%^sには効果がなかった。", "%^s is unaffected."), m_name.data());
         }
 
         if (m_ptr->is_asleep()) {
             (void)set_monster_csleep(player_ptr, m_idx, 0);
             if (m_ptr->ml) {
-                msg_format(_("%^sが目を覚ました。", "%^s wakes up."), m_name);
+                msg_format(_("%^sが目を覚ました。", "%^s wakes up."), m_name.data());
             }
         }
 
         if (m_ptr->is_friendly() && !m_ptr->is_pet()) {
             if (see_m) {
-                msg_format(_("%sは怒った！", "%^s gets angry!"), m_name);
+                msg_format(_("%sは怒った！", "%^s gets angry!"), m_name.data());
             }
 
             set_hostile(player_ptr, m_ptr);

--- a/src/spell-kind/spells-lite.cpp
+++ b/src/spell-kind/spells-lite.cpp
@@ -77,9 +77,8 @@ static void cave_temp_room_lite(PlayerType *player_ptr, const std::vector<Pos2D>
             if (m_ptr->is_asleep() && (randint0(100) < chance)) {
                 (void)set_monster_csleep(player_ptr, g_ptr->m_idx, 0);
                 if (m_ptr->ml) {
-                    GAME_TEXT m_name[MAX_NLEN];
-                    monster_desc(player_ptr, m_name, m_ptr, 0);
-                    msg_format(_("%^sが目を覚ました。", "%^s wakes up."), m_name);
+                    const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+                    msg_format(_("%^sが目を覚ました。", "%^s wakes up."), m_name.data());
                 }
             }
         }

--- a/src/spell-kind/spells-pet.cpp
+++ b/src/spell-kind/spells-pet.cpp
@@ -49,9 +49,8 @@ void discharge_minion(PlayerType *player_ptr)
         MonsterRaceInfo *r_ptr;
         r_ptr = &monraces_info[m_ptr->r_idx];
         if (r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
-            GAME_TEXT m_name[MAX_NLEN];
-            monster_desc(player_ptr, m_name, m_ptr, 0x00);
-            msg_format(_("%sは爆破されるのを嫌がり、勝手に自分の世界へと帰った。", "%^s resists being blasted and runs away."), m_name);
+            const auto m_name = monster_desc(player_ptr, m_ptr, 0x00);
+            msg_format(_("%sは爆破されるのを嫌がり、勝手に自分の世界へと帰った。", "%^s resists being blasted and runs away."), m_name.data());
             delete_monster_idx(player_ptr, i);
             continue;
         }
@@ -69,10 +68,8 @@ void discharge_minion(PlayerType *player_ptr)
         project(player_ptr, i, 2 + (r_ptr->level / 20), m_ptr->fy, m_ptr->fx, dam, AttributeType::PLASMA, PROJECT_STOP | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL);
 
         if (record_named_pet && m_ptr->nickname) {
-            GAME_TEXT m_name[MAX_NLEN];
-
-            monster_desc(player_ptr, m_name, m_ptr, MD_INDEF_VISIBLE);
-            exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_BLAST, m_name);
+            const auto m_name = monster_desc(player_ptr, m_ptr, MD_INDEF_VISIBLE);
+            exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_BLAST, m_name.data());
         }
 
         delete_monster_idx(player_ptr, i);

--- a/src/spell-kind/spells-sight.cpp
+++ b/src/spell-kind/spells-sight.cpp
@@ -383,8 +383,7 @@ std::string probed_monster_info(PlayerType *player_ptr, MonsterEntity *m_ptr, Mo
         lite_spot(player_ptr, m_ptr->fy, m_ptr->fx);
     }
 
-    GAME_TEXT m_name[MAX_NLEN];
-    monster_desc(player_ptr, m_name, m_ptr, MD_IGNORE_HALLU | MD_INDEF_HIDDEN);
+    const auto m_name = monster_desc(player_ptr, m_ptr, MD_IGNORE_HALLU | MD_INDEF_HIDDEN);
 
     concptr align;
     if (r_ptr->kind_flags.has_all_of(alignment_mask)) {
@@ -404,7 +403,7 @@ std::string probed_monster_info(PlayerType *player_ptr, MonsterEntity *m_ptr, Mo
     }
 
     const auto speed = m_ptr->get_temporary_speed() - STANDARD_SPEED;
-    std::string result = format(_("%s ... 属性:%s HP:%d/%d AC:%d 速度:%s%d 経験:", "%s ... align:%s HP:%d/%d AC:%d speed:%s%d exp:"), m_name, align, (int)m_ptr->hp,
+    std::string result = format(_("%s ... 属性:%s HP:%d/%d AC:%d 速度:%s%d 経験:", "%s ... align:%s HP:%d/%d AC:%d speed:%s%d exp:"), m_name.data(), align, (int)m_ptr->hp,
         (int)m_ptr->maxhp, r_ptr->ac, (speed > 0) ? "+" : "", speed);
 
     if (MonsterRace(r_ptr->next_r_idx).is_valid()) {

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -69,14 +69,14 @@ bool is_teleport_level_ineffective(PlayerType *player_ptr, MONSTER_IDX idx)
  */
 void teleport_level(PlayerType *player_ptr, MONSTER_IDX m_idx)
 {
-    GAME_TEXT m_name[160];
+    std::string m_name;
     auto see_m = true;
     auto &floor_ref = *player_ptr->current_floor_ptr;
     if (m_idx <= 0) {
-        strcpy(m_name, _("あなた", "you"));
+        m_name = _("あなた", "you");
     } else {
         auto *m_ptr = &floor_ref.m_list[m_idx];
-        monster_desc(player_ptr, m_name, m_ptr, 0);
+        m_name = monster_desc(player_ptr, m_ptr, 0);
         see_m = is_seen(player_ptr, m_ptr);
     }
 
@@ -110,11 +110,11 @@ void teleport_level(PlayerType *player_ptr, MONSTER_IDX m_idx)
     if ((ironman_downward && (m_idx <= 0)) || (floor_ref.dun_level <= dungeons_info[player_ptr->dungeon_idx].mindepth)) {
 #ifdef JP
         if (see_m) {
-            msg_format("%^sは床を突き破って沈んでいく。", m_name);
+            msg_format("%^sは床を突き破って沈んでいく。", m_name.data());
         }
 #else
         if (see_m) {
-            msg_format("%^s sink%s through the floor.", m_name, (m_idx <= 0) ? "" : "s");
+            msg_format("%^s sink%s through the floor.", m_name.data(), (m_idx <= 0) ? "" : "s");
         }
 #endif
         if (m_idx <= 0) {
@@ -144,11 +144,11 @@ void teleport_level(PlayerType *player_ptr, MONSTER_IDX m_idx)
     } else if (inside_quest(quest_number(player_ptr, floor_ref.dun_level)) || (floor_ref.dun_level >= dungeons_info[player_ptr->dungeon_idx].maxdepth)) {
 #ifdef JP
         if (see_m) {
-            msg_format("%^sは天井を突き破って宙へ浮いていく。", m_name);
+            msg_format("%^sは天井を突き破って宙へ浮いていく。", m_name.data());
         }
 #else
         if (see_m) {
-            msg_format("%^s rise%s up through the ceiling.", m_name, (m_idx <= 0) ? "" : "s");
+            msg_format("%^s rise%s up through the ceiling.", m_name.data(), (m_idx <= 0) ? "" : "s");
         }
 #endif
 
@@ -170,11 +170,11 @@ void teleport_level(PlayerType *player_ptr, MONSTER_IDX m_idx)
     } else if (go_up) {
 #ifdef JP
         if (see_m) {
-            msg_format("%^sは天井を突き破って宙へ浮いていく。", m_name);
+            msg_format("%^sは天井を突き破って宙へ浮いていく。", m_name.data());
         }
 #else
         if (see_m) {
-            msg_format("%^s rise%s up through the ceiling.", m_name, (m_idx <= 0) ? "" : "s");
+            msg_format("%^s rise%s up through the ceiling.", m_name.data(), (m_idx <= 0) ? "" : "s");
         }
 #endif
 
@@ -193,11 +193,11 @@ void teleport_level(PlayerType *player_ptr, MONSTER_IDX m_idx)
     } else {
 #ifdef JP
         if (see_m) {
-            msg_format("%^sは床を突き破って沈んでいく。", m_name);
+            msg_format("%^sは床を突き破って沈んでいく。", m_name.data());
         }
 #else
         if (see_m) {
-            msg_format("%^s sink%s through the floor.", m_name, (m_idx <= 0) ? "" : "s");
+            msg_format("%^s sink%s through the floor.", m_name.data(), (m_idx <= 0) ? "" : "s");
         }
 #endif
 
@@ -222,10 +222,8 @@ void teleport_level(PlayerType *player_ptr, MONSTER_IDX m_idx)
     auto *m_ptr = &floor_ref.m_list[m_idx];
     QuestCompletionChecker(player_ptr, m_ptr).complete();
     if (record_named_pet && m_ptr->is_pet() && m_ptr->nickname) {
-        char m2_name[MAX_NLEN];
-
-        monster_desc(player_ptr, m2_name, m_ptr, MD_INDEF_VISIBLE);
-        exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_TELE_LEVEL, m2_name);
+        const auto m2_name = monster_desc(player_ptr, m_ptr, MD_INDEF_VISIBLE);
+        exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_TELE_LEVEL, m2_name.data());
     }
 
     delete_monster_idx(player_ptr, m_idx);
@@ -254,14 +252,13 @@ bool teleport_level_other(PlayerType *player_ptr)
     MonsterRaceInfo *r_ptr;
     m_ptr = &player_ptr->current_floor_ptr->m_list[target_m_idx];
     r_ptr = &monraces_info[m_ptr->r_idx];
-    GAME_TEXT m_name[MAX_NLEN];
-    monster_desc(player_ptr, m_name, m_ptr, 0);
-    msg_format(_("%^sの足を指さした。", "You gesture at %^s's feet."), m_name);
+    const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+    msg_format(_("%^sの足を指さした。", "You gesture at %^s's feet."), m_name.data());
 
     auto has_immune = r_ptr->resistance_flags.has_any_of(RFR_EFF_RESIST_NEXUS_MASK) || r_ptr->resistance_flags.has(MonsterResistanceType::RESIST_TELEPORT);
 
     if (has_immune || (r_ptr->flags1 & RF1_QUESTOR) || (r_ptr->level + randint1(50) > player_ptr->lev + randint1(60))) {
-        msg_format(_("しかし効果がなかった！", "%^s is unaffected!"), m_name);
+        msg_format(_("しかし効果がなかった！", "%^s is unaffected!"), m_name.data());
     } else {
         teleport_level(player_ptr, target_m_idx);
     }

--- a/src/spell-realm/spells-chaos.cpp
+++ b/src/spell-realm/spells-chaos.cpp
@@ -116,7 +116,6 @@ bool vanish_dungeon(PlayerType *player_ptr)
         return false;
     }
 
-    GAME_TEXT m_name[MAX_NLEN];
     for (POSITION y = 1; y < floor_ptr->height - 1; y++) {
         for (POSITION x = 1; x < floor_ptr->width - 1; x++) {
             auto *g_ptr = &floor_ptr->grid_array[y][x];
@@ -127,8 +126,8 @@ bool vanish_dungeon(PlayerType *player_ptr)
             if (g_ptr->m_idx && m_ptr->is_asleep()) {
                 (void)set_monster_csleep(player_ptr, g_ptr->m_idx, 0);
                 if (m_ptr->ml) {
-                    monster_desc(player_ptr, m_name, m_ptr, 0);
-                    msg_format(_("%^sが目を覚ました。", "%^s wakes up."), m_name);
+                    const auto m_name = monster_desc(player_ptr, m_ptr, 0);
+                    msg_format(_("%^sが目を覚ました。", "%^s wakes up."), m_name.data());
                 }
             }
 

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -356,9 +356,8 @@ void SpellHex::eyes_on_eyes()
 #ifdef JP
     msg_format("攻撃が%s自身を傷つけた！", this->monap_ptr->m_name);
 #else
-    GAME_TEXT m_name_self[MAX_MONSTER_NAME];
-    monster_desc(this->player_ptr, m_name_self, this->monap_ptr->m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE | MD_OBJECTIVE);
-    msg_format("The attack of %s has wounded %s!", this->monap_ptr->m_name, m_name_self);
+    const auto m_name_self = monster_desc(this->player_ptr, this->monap_ptr->m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE | MD_OBJECTIVE);
+    msg_format("The attack of %s has wounded %s!", this->monap_ptr->m_name, m_name_self.data());
 #endif
     const auto y = this->monap_ptr->m_ptr->fy;
     const auto x = this->monap_ptr->m_ptr->fx;

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -540,9 +540,8 @@ bool fishing(PlayerType *player_ptr)
     }
 
     if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
-        GAME_TEXT m_name[MAX_NLEN];
-        monster_desc(player_ptr, m_name, &player_ptr->current_floor_ptr->m_list[player_ptr->current_floor_ptr->grid_array[y][x].m_idx], 0);
-        msg_format(_("%sが邪魔だ！", "%^s is standing in your way."), m_name);
+        const auto m_name = monster_desc(player_ptr, &player_ptr->current_floor_ptr->m_list[player_ptr->current_floor_ptr->grid_array[y][x].m_idx], 0);
+        msg_format(_("%sが邪魔だ！", "%^s is standing in your way."), m_name.data());
         PlayerEnergy(player_ptr).reset_player_turn();
         return false;
     }

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -195,8 +195,7 @@ static bool describe_grid_lore(PlayerType *player_ptr, eg_type *eg_ptr)
 static void describe_grid_monster(PlayerType *player_ptr, eg_type *eg_ptr)
 {
     bool recall = false;
-    GAME_TEXT m_name[MAX_NLEN];
-    monster_desc(player_ptr, m_name, eg_ptr->m_ptr, MD_INDEF_VISIBLE);
+    const auto m_name = monster_desc(player_ptr, eg_ptr->m_ptr, MD_INDEF_VISIBLE);
     while (true) {
         if (recall) {
             if (describe_grid_lore(player_ptr, eg_ptr)) {
@@ -210,10 +209,10 @@ static void describe_grid_monster(PlayerType *player_ptr, eg_type *eg_ptr)
         std::string acount = evaluate_monster_exp(player_ptr, eg_ptr->m_ptr);
         const auto mon_desc = look_mon_desc(eg_ptr->m_ptr, 0x01);
 #ifdef JP
-        strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "[%s]%s%s(%s)%s%s [r思 %s%s]", acount.data(), eg_ptr->s1, m_name, mon_desc.data(), eg_ptr->s2, eg_ptr->s3,
+        strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "[%s]%s%s(%s)%s%s [r思 %s%s]", acount.data(), eg_ptr->s1, m_name.data(), mon_desc.data(), eg_ptr->s2, eg_ptr->s3,
             eg_ptr->x_info, eg_ptr->info);
 #else
-        strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "[%s]%s%s%s%s(%s) [r, %s%s]", acount.data(), eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, m_name, mon_desc.data(),
+        strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "[%s]%s%s%s%s(%s) [r, %s%s]", acount.data(), eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, m_name.data(), mon_desc.data(),
             eg_ptr->x_info, eg_ptr->info);
 #endif
         prt(eg_ptr->out_val, 0, 0);

--- a/src/target/target-getter.cpp
+++ b/src/target/target-getter.cpp
@@ -174,14 +174,12 @@ bool get_direction(PlayerType *player_ptr, DIRECTION *dp, bool allow_under, bool
         if (is_confused) {
             msg_print(_("あなたは混乱している。", "You are confused."));
         } else {
-            GAME_TEXT m_name[MAX_NLEN];
             auto *m_ptr = &player_ptr->current_floor_ptr->m_list[player_ptr->riding];
-
-            monster_desc(player_ptr, m_name, m_ptr, 0);
+            const auto m_name = monster_desc(player_ptr, m_ptr, 0);
             if (m_ptr->is_confused()) {
-                msg_format(_("%sは混乱している。", "%^s is confused."), m_name);
+                msg_format(_("%sは混乱している。", "%^s is confused."), m_name.data());
             } else {
-                msg_format(_("%sは思い通りに動いてくれない。", "You cannot control %s."), m_name);
+                msg_format(_("%sは思い通りに動いてくれない。", "You cannot control %s."), m_name.data());
             }
         }
     }
@@ -266,13 +264,12 @@ bool get_rep_dir(PlayerType *player_ptr, DIRECTION *dp, bool under)
         if (is_confused) {
             msg_print(_("あなたは混乱している。", "You are confused."));
         } else {
-            GAME_TEXT m_name[MAX_NLEN];
             auto *m_ptr = &player_ptr->current_floor_ptr->m_list[player_ptr->riding];
-            monster_desc(player_ptr, m_name, m_ptr, 0);
+            const auto m_name = monster_desc(player_ptr, m_ptr, 0);
             if (m_ptr->is_confused()) {
-                msg_format(_("%sは混乱している。", "%^s is confused."), m_name);
+                msg_format(_("%sは混乱している。", "%^s is confused."), m_name.data());
             } else {
-                msg_format(_("%sは思い通りに動いてくれない。", "You cannot control %s."), m_name);
+                msg_format(_("%sは思い通りに動いてくれない。", "You cannot control %s."), m_name.data());
             }
         }
     }

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -825,10 +825,8 @@ void wiz_zap_surrounding_monsters(PlayerType *player_ptr)
         }
 
         if (record_named_pet && m_ptr->is_pet() && m_ptr->nickname) {
-            GAME_TEXT m_name[MAX_NLEN];
-
-            monster_desc(player_ptr, m_name, m_ptr, MD_INDEF_VISIBLE);
-            exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_WIZ_ZAP, m_name);
+            const auto m_name = monster_desc(player_ptr, m_ptr, MD_INDEF_VISIBLE);
+            exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_WIZ_ZAP, m_name.data());
         }
 
         delete_monster_idx(player_ptr, i);
@@ -848,9 +846,8 @@ void wiz_zap_floor_monsters(PlayerType *player_ptr)
         }
 
         if (record_named_pet && m_ptr->is_pet() && m_ptr->nickname) {
-            GAME_TEXT m_name[MAX_NLEN];
-            monster_desc(player_ptr, m_name, m_ptr, MD_INDEF_VISIBLE);
-            exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_WIZ_ZAP, m_name);
+            const auto m_name = monster_desc(player_ptr, m_ptr, MD_INDEF_VISIBLE);
+            exe_write_diary(player_ptr, DIARY_NAMED_PET, RECORD_NAMED_PET_WIZ_ZAP, m_name.data());
         }
 
         delete_monster_idx(player_ptr, i);

--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -168,10 +168,9 @@ void WorldTurnProcessor::process_monster_arena()
 
 void WorldTurnProcessor::process_monster_arena_winner(int win_m_idx)
 {
-    GAME_TEXT m_name[MAX_NLEN];
     auto *wm_ptr = &this->player_ptr->current_floor_ptr->m_list[win_m_idx];
-    monster_desc(this->player_ptr, m_name, wm_ptr, 0);
-    msg_format(_("%sが勝利した！", "%s won!"), m_name);
+    const auto m_name = monster_desc(this->player_ptr, wm_ptr, 0);
+    msg_format(_("%sが勝利した！", "%s won!"), m_name.data());
     msg_print(nullptr);
 
     if (win_m_idx == (sel_monster + 1)) {


### PR DESCRIPTION
…refactored monster_desc(), refactor monster_name() and change the prototypes for MonsterDamageProcessor's death_amberites(), dying_scream(), show_bounty_message(), and show_kill_message().  Does part of the work of resolving https://github.com/hengband/hengband/issues/2858 and https://github.com/hengband/hengband/issues/2859 .