### PR TITLE
[Fix] std::ranges::transform -> std::transform

### DIFF
--- a/src/perception/identification.cpp
+++ b/src/perception/identification.cpp
@@ -47,7 +47,7 @@ bool screen_object(PlayerType *player_ptr, ItemEntity *o_ptr, BIT_FLAGS mode)
     const auto item_text_lines = shape_buffer(item_text, 77 - 15);
 
     int i = 0;
-    std::ranges::transform(item_text_lines, &info[i], [](const auto &line) { return line.data(); });
+    std::transform(item_text_lines.begin(), item_text_lines.end(), &info[i], [](const auto &line) { return line.data(); });
     i += item_text_lines.size();
 
     if (o_ptr->is_equipment()) {


### PR DESCRIPTION
Resolves #2982 

Apple Clang 14 ではまだ The One Ranges Proposal がサポートされていないので、 C++20 で追加された std::ranges::* のSTLアルゴリズムが使用できない。
したがって従来の通りイテレータペアを受け取る std::transform を使用する。