### PR TITLE
[Fix] SIGKILL にシグナルハンドラを設定している

### DIFF
--- a/src/io/signal-handlers.cpp
+++ b/src/io/signal-handlers.cpp
@@ -216,10 +216,6 @@ void signals_init(void)
     (void)signal(SIGIOT, handle_signal_abort);
 #endif
 
-#ifdef SIGKILL
-    (void)signal(SIGKILL, handle_signal_abort);
-#endif
-
 #ifdef SIGBUS
     (void)signal(SIGBUS, handle_signal_abort);
 #endif


### PR DESCRIPTION
SIGKILL はいかなる手段を用いても捕捉不可能なシグナルであり、シグナルハンドラを設定する事自体間違いなので削除する。

#2983 の補足事項で言及されている件についての対処です。