### PR TITLE
[Fix] モンスターを倒した時のメッセージがおかしい

### DIFF
--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -51,6 +51,7 @@
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "world/world.h"
+#include <algorithm>
 
 static void write_pet_death(PlayerType *player_ptr, monster_death_type *md_ptr)
 {
@@ -442,15 +443,19 @@ void monster_death(PlayerType *player_ptr, MONSTER_IDX m_idx, bool drop_item, At
  */
 concptr extract_note_dies(MonsterRaceId r_idx)
 {
-    auto *r_ptr = &monraces_info[r_idx];
+    const auto &r_ref = monraces_info[r_idx];
+    const auto explode = std::any_of(std::begin(r_ref.blow), std::end(r_ref.blow), [](const auto &blow) { return blow.method == RaceBlowMethodType::EXPLODE; });
+
     if (monster_living(r_idx)) {
+        if (explode) {
+            return _("は爆発して死んだ。", " explodes and dies.");
+        }
+
         return _("は死んだ。", " dies.");
     }
 
-    for (int i = 0; i < 4; i++) {
-        if (r_ptr->blow[i].method == RaceBlowMethodType::EXPLODE) {
-            return _("は爆発して粉々になった。", " explodes into tiny shreds.");
-        }
+    if (explode) {
+        return _("は爆発して粉々になった。", " explodes into tiny shreds.");
     }
 
     return _("を倒した。", " is destroyed.");

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -365,18 +365,18 @@ void MonsterDamageProcessor::show_kill_message(concptr note, GAME_TEXT *m_name)
         return;
     }
 
+    const auto explode = std::any_of(std::begin(r_ref.blow), std::end(r_ref.blow), [](const auto &blow) { return blow.method == RaceBlowMethodType::EXPLODE; });
+
     if (monster_living(m_ptr->r_idx)) {
+        if (explode) {
+            msg_format(_("%sは爆発して死んだ。", "%^s explodes and dies."), m_name);
+            return;
+        }
+
         auto mes = is_echizen(this->player_ptr) ? _("せっかくだから%sを葬り去った。", "Because it's time, you have slain %s.")
                                                 : _("%sを葬り去った。", "You have slain %s.");
         msg_format(mes, m_name);
         return;
-    }
-
-    auto explode = false;
-    for (auto i = 0; i < 4; i++) {
-        if (r_ref.blow[i].method == RaceBlowMethodType::EXPLODE) {
-            explode = true;
-        }
     }
 
     if (explode) {

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -366,8 +366,8 @@ void MonsterDamageProcessor::show_kill_message(concptr note, GAME_TEXT *m_name)
     }
 
     if (monster_living(m_ptr->r_idx)) {
-        auto mes = is_echizen(this->player_ptr) ? _("せっかくだから%sを殺した。", "Because it's time, you have slain %s.")
-                                                : _("%sを殺した。", "You have slain %s.");
+        auto mes = is_echizen(this->player_ptr) ? _("せっかくだから%sを葬り去った。", "Because it's time, you have slain %s.")
+                                                : _("%sを葬り去った。", "You have slain %s.");
         msg_format(mes, m_name);
         return;
     }
@@ -384,8 +384,8 @@ void MonsterDamageProcessor::show_kill_message(concptr note, GAME_TEXT *m_name)
         return;
     }
 
-    auto mes = is_echizen(this->player_ptr) ? _("せっかくだから%sを殺した。", "Because it's time, you have destroyed %s.")
-                                            : _("%sを殺した。", "You have destroyed %s.");
+    auto mes = is_echizen(this->player_ptr) ? _("せっかくだから%sを倒した。", "Because it's time, you have destroyed %s.")
+                                            : _("%sを倒した。", "You have destroyed %s.");
     msg_format(mes, m_name);
 }
 


### PR DESCRIPTION
以前行われていた、モンスターを倒した時の状況に合わせた「殺した・葬り去った・倒した」の
メッセージ切り替えが、リファクタリング時にすべて「殺した」になってしまっていたので元の
仕様に戻す。

微修正なのでIssueなし。
該当コミット: 97eb4ef031f5cefe86abfcb6ef3e8896fa144c3e