### PR TITLE
[Fix] モンスターの爆発でプレイヤーがダメージを受けない

### DIFF
--- a/src/effect/effect-player-switcher.cpp
+++ b/src/effect/effect-player-switcher.cpp
@@ -36,6 +36,7 @@ void switch_effects_player(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
         effect_player_nuke(player_ptr, ep_ptr);
         return;
     case AttributeType::MISSILE:
+    case AttributeType::MONSTER_MELEE:
         effect_player_missile(player_ptr, ep_ptr);
         return;
     case AttributeType::HOLY_FIRE:


### PR DESCRIPTION
Resolves #2993 

過去に HURT に対応する AttributeType が MONSTER_MELEE に変更されたが、その時 switch_effects_player に MONSTER_MELEE が追加されなかったため、爆発のダメージが 入らなくなっている。
ひとまず元の MISSILE と同じく MONSTER_MELEE でも effect_player_missile を呼ぶ ようにしておく。