### PR TITLE
[Refactor] ItemEntity::art_name の型/名称を変更

### DIFF
--- a/src/artifact/random-art-generator.cpp
+++ b/src/artifact/random-art-generator.cpp
@@ -393,7 +393,7 @@ static std::string name_unnatural_random_artifact(PlayerType *player_ptr, ItemEn
     object_aware(player_ptr, o_ptr);
     object_known(o_ptr);
     o_ptr->ident |= IDENT_FULL_KNOWN;
-    o_ptr->art_name = quark_add("");
+    o_ptr->randart_name.reset();
     (void)screen_object(player_ptr, o_ptr, 0L);
     char new_name[160] = "";
     if (!get_string(ask_msg, new_name, sizeof new_name) || !new_name[0]) {
@@ -410,8 +410,7 @@ static std::string name_unnatural_random_artifact(PlayerType *player_ptr, ItemEn
 static void generate_unnatural_random_artifact(
     PlayerType *player_ptr, ItemEntity *o_ptr, const bool a_scroll, const int power_level, const int max_powers, const int total_flags)
 {
-    auto new_name = name_unnatural_random_artifact(player_ptr, o_ptr, a_scroll, power_level);
-    o_ptr->art_name = quark_add(new_name.data());
+    o_ptr->randart_name = name_unnatural_random_artifact(player_ptr, o_ptr, a_scroll, power_level);
     msg_format_wizard(player_ptr, CHEAT_OBJECT,
         _("パワー %d で 価値%ld のランダムアーティファクト生成 バイアスは「%s」", "Random artifact generated - Power:%d Value:%d Bias:%s."), max_powers,
         total_flags, artifact_bias_name[o_ptr->artifact_bias]);

--- a/src/flavor/named-item-describer.cpp
+++ b/src/flavor/named-item-describer.cpp
@@ -96,16 +96,16 @@ static std::string describe_unique_name_before_body_ja(const ItemEntity &item, c
     }
 
     if (item.is_random_artifact()) {
-        concptr temp = quark_str(item.art_name);
+        const std::string_view name_sv = item.randart_name.value();
 
         /* '『' から始まらない伝説のアイテムの名前は最初に付加する */
         /* 英語版のセーブファイルから来た 'of XXX' は,「XXXの」と表示する */
-        if (strncmp(temp, "of ", 3) == 0) {
+        if (name_sv.starts_with("of ")) {
             std::stringstream ss;
-            ss << &temp[3] << "の";
+            ss << name_sv.substr(3) << "の";
             return ss.str();
-        } else if ((strncmp(temp, "『", 2) != 0) && (strncmp(temp, "《", 2) != 0) && (temp[0] != '\'')) {
-            return temp;
+        } else if (!name_sv.starts_with("『") && !name_sv.starts_with("《") && !name_sv.starts_with('\'')) {
+            return item.randart_name.value();
         }
     }
 
@@ -132,20 +132,18 @@ static std::optional<std::string> describe_random_artifact_name_after_body_ja(co
         return std::nullopt;
     }
 
-    char temp[256];
-    int itemp;
-    strcpy(temp, quark_str(item.art_name));
-    if (strncmp(temp, "『", 2) == 0 || strncmp(temp, "《", 2) == 0) {
-        return temp;
+    const std::string_view name_sv = item.randart_name.value();
+    if (name_sv.starts_with("『") || name_sv.starts_with("《")) {
+        return item.randart_name;
     }
 
-    if (temp[0] != '\'') {
+    if (!name_sv.starts_with('\'')) {
         return "";
     }
 
-    itemp = strlen(temp);
-    temp[itemp - 1] = 0;
-    return format("『%s』", &temp[1]);
+    // "'foobar'" の foobar の部分を取り出し『foobar』と表記する
+    // (英語版のセーブファイルのランダムアーティファクトを考慮)
+    return format("『%s』", name_sv.substr(1, name_sv.length() - 2));
 }
 
 static std::string describe_fake_artifact_name_after_body_ja(const ItemEntity &item)
@@ -291,7 +289,7 @@ static std::string describe_unique_name_after_body_en(const ItemEntity &item, co
     std::stringstream ss;
 
     if (item.is_random_artifact()) {
-        ss << ' ' << quark_str(item.art_name);
+        ss << ' ' << item.randart_name.value();
         return ss.str();
     }
 

--- a/src/load/old/item-loader-savefile50.cpp
+++ b/src/load/old/item-loader-savefile50.cpp
@@ -183,9 +183,9 @@ void ItemLoader50::rd_item(ItemEntity *o_ptr)
     if (any_bits(flags, SaveDataItemFlagType::ART_NAME)) {
         char buf[128];
         rd_string(buf, sizeof(buf));
-        o_ptr->art_name = quark_add(buf);
+        o_ptr->randart_name.emplace(buf);
     } else {
-        o_ptr->art_name = 0;
+        o_ptr->randart_name.reset();
     }
 
     if (!h_older_than(2, 1, 2, 4)) {

--- a/src/load/old/load-v1-5-0.cpp
+++ b/src/load/old/load-v1-5-0.cpp
@@ -317,7 +317,7 @@ void rd_item_old(ItemEntity *o_ptr)
 
     /*!< @todo 元々このif文には末尾に";"が付いていた、バグかもしれない */
     if (buf[0]) {
-        o_ptr->art_name = quark_add(buf);
+        o_ptr->randart_name.emplace(buf);
     }
     {
         auto tmp32s = rd_s32b();

--- a/src/object-activation/activation-others.cpp
+++ b/src/object-activation/activation-others.cpp
@@ -401,7 +401,8 @@ bool activate_recall(PlayerType *player_ptr)
 
 bool activate_tree_creation(PlayerType *player_ptr, ItemEntity *o_ptr, concptr name)
 {
-    msg_format(_("%s%sから明るい緑の光があふれ出た...", "The %s%s wells with clear light..."), name, quark_str(o_ptr->art_name));
+    const auto randart_name = o_ptr->is_random_artifact() ? o_ptr->randart_name->data() : "";
+    msg_format(_("%s%sから明るい緑の光があふれ出た...", "The %s%s wells with clear light..."), name, randart_name);
     return tree_creation(player_ptr, player_ptr->y, player_ptr->x);
 }
 

--- a/src/save/item-writer.cpp
+++ b/src/save/item-writer.cpp
@@ -264,7 +264,7 @@ void wr_item(ItemEntity *o_ptr)
     }
 
     if (any_bits(flags, SaveDataItemFlagType::ART_NAME)) {
-        wr_string(quark_str(o_ptr->art_name));
+        wr_string(o_ptr->randart_name.value());
     }
 }
 

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -328,7 +328,7 @@ bool ItemEntity::is_smith() const
  */
 bool ItemEntity::is_artifact() const
 {
-    return this->is_fixed_artifact() || (this->art_name != 0);
+    return this->is_fixed_artifact() || this->randart_name.has_value();
 }
 
 /*!

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -60,7 +60,7 @@ public:
     byte ident{}; /*!< Special flags  */
     EnumClassFlagGroup<OmType> marked{}; /*!< Object is marked */
     uint16_t inscription{}; /*!< Inscription index */
-    uint16_t art_name{}; /*!< Artifact name (random artifacts) */
+    std::optional<std::string> randart_name{}; /*!< Artifact name (random artifacts) */
     byte feeling{}; /*!< Game generated inscription number (eg, pseudo-id) */
 
     TrFlags art_flags{}; /*!< Extra Flags for ego and artifacts */


### PR DESCRIPTION
Resolves #2911 

quark_add/quark_str のインデクスを持たせるのではなく直接文字列を持たせるようにする。 既存のインデクスが0以外ならランダムアーティファクト、0なら非ランダムアーティファクト
という仕様を維持するため std::optional<std::string> 型にし、非ランダムアーティファ クトの場合は std::nullopt とする。
また明確にランダムアーティファクトの名称である事がわかるようにするためメンバの名称を
randart_name に変更する。