### PR TITLE
[Fix] 光源のスタックの挙動がおかしい

### DIFF
--- a/src/object-enchant/others/apply-magic-lite.cpp
+++ b/src/object-enchant/others/apply-magic-lite.cpp
@@ -21,15 +21,11 @@ LiteEnchanter::LiteEnchanter(PlayerType *player_ptr, ItemEntity *o_ptr, int powe
         if (o_ptr->pval > 0) {
             o_ptr->fuel = randint1(o_ptr->pval);
         }
-
-        o_ptr->pval = 0;
         return;
     case SV_LITE_LANTERN:
         if (o_ptr->pval > 0) {
             o_ptr->fuel = randint1(o_ptr->pval);
         }
-
-        o_ptr->pval = 0;
         return;
     default:
         return;

--- a/src/store/store-util.cpp
+++ b/src/store/store-util.cpp
@@ -189,6 +189,10 @@ bool store_object_similar(ItemEntity *o_ptr, ItemEntity *j_ptr)
         return false;
     }
 
+    if ((tval == ItemKindType::LITE) && (o_ptr->fuel != j_ptr->fuel)) {
+        return false;
+    }
+
     if (o_ptr->discount != j_ptr->discount) {
         return false;
     }


### PR DESCRIPTION
光源のスタックの挙動において、重なるべきものが重ならなかったり、逆に重ならないはずのものが重なったりする。
おかしな挙動の原因は2つ。

- 初期所持の光源は pval が初期値のままだが、店売りアイテムは LiteEnchanter により pval が 0 になる。したがって pval が異なることにより重ならない。
- 店のアイテムのスタック判定 store_object_similar で fuel の値が考慮されていない ため、残りターン数が異なっても重なってしまう。

LiteEnchanter で pval を 0 にせずそのままの値とし、store_object_similar には fuel の比較を追加することで修正する。