### PR TITLE
[Refactor] ItemEntity::inscription の型を変更 

### DIFF
--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -328,9 +328,8 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, It
 {
     /* Assume that object name is to be added */
     bool name = true;
-    auto insc = quark_str(o_ptr->inscription);
     entry->name.clear();
-    entry->insc = insc != nullptr ? insc : "";
+    entry->insc = o_ptr->inscription.value_or("");
     entry->action = DO_AUTOPICK | DO_DISPLAY;
     entry->flag[0] = entry->flag[1] = 0L;
     entry->dice = 0;

--- a/src/autopick/autopick-util.cpp
+++ b/src/autopick/autopick-util.cpp
@@ -59,7 +59,7 @@ void auto_inscribe_item(PlayerType *player_ptr, ItemEntity *o_ptr, int idx)
     }
 
     if (!o_ptr->is_inscribed()) {
-        o_ptr->inscription = quark_add(autopick_list[idx].insc.data());
+        o_ptr->inscription = autopick_list[idx].insc;
     }
 
     player_ptr->window_flags |= (PW_EQUIP | PW_INVEN);

--- a/src/autopick/autopick-util.cpp
+++ b/src/autopick/autopick-util.cpp
@@ -58,7 +58,7 @@ void auto_inscribe_item(PlayerType *player_ptr, ItemEntity *o_ptr, int idx)
         return;
     }
 
-    if (!o_ptr->inscription) {
+    if (!o_ptr->is_inscribed()) {
         o_ptr->inscription = quark_add(autopick_list[idx].insc.data());
     }
 

--- a/src/cmd-item/cmd-item.cpp
+++ b/src/cmd-item/cmd-item.cpp
@@ -194,7 +194,7 @@ void do_cmd_uninscribe(PlayerType *player_ptr)
     }
 
     msg_print(_("銘を消した。", "Inscription removed."));
-    o_ptr->inscription = 0;
+    o_ptr->inscription.reset();
     set_bits(player_ptr->update, PU_COMBINE);
     set_bits(player_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_FLOOR_ITEM_LIST | PW_FOUND_ITEM_LIST);
     set_bits(player_ptr->update, PU_BONUS);
@@ -222,11 +222,11 @@ void do_cmd_inscribe(PlayerType *player_ptr)
     msg_print(nullptr);
     strcpy(out_val, "");
     if (o_ptr->is_inscribed()) {
-        angband_strcpy(out_val, quark_str(o_ptr->inscription), MAX_INSCRIPTION);
+        angband_strcpy(out_val, o_ptr->inscription->data(), MAX_INSCRIPTION);
     }
 
     if (get_string(_("銘: ", "Inscription: "), out_val, MAX_INSCRIPTION)) {
-        o_ptr->inscription = quark_add(out_val);
+        o_ptr->inscription.emplace(out_val);
         set_bits(player_ptr->update, PU_COMBINE);
         set_bits(player_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_FLOOR_ITEM_LIST | PW_FOUND_ITEM_LIST);
         set_bits(player_ptr->update, PU_BONUS);

--- a/src/cmd-item/cmd-item.cpp
+++ b/src/cmd-item/cmd-item.cpp
@@ -188,7 +188,7 @@ void do_cmd_uninscribe(PlayerType *player_ptr)
         return;
     }
 
-    if (!o_ptr->inscription) {
+    if (!o_ptr->is_inscribed()) {
         msg_print(_("このアイテムには消すべき銘がない。", "That item had no inscription to remove."));
         return;
     }
@@ -221,7 +221,7 @@ void do_cmd_inscribe(PlayerType *player_ptr)
     msg_format(_("%sに銘を刻む。", "Inscribing %s."), o_name);
     msg_print(nullptr);
     strcpy(out_val, "");
-    if (o_ptr->inscription) {
+    if (o_ptr->is_inscribed()) {
         angband_strcpy(out_val, quark_str(o_ptr->inscription), MAX_INSCRIPTION);
     }
 

--- a/src/flavor/flavor-describer.cpp
+++ b/src/flavor/flavor-describer.cpp
@@ -471,7 +471,7 @@ static std::string describe_ability_abbrev(const ItemEntity &item)
 {
     auto should_describe = abbrev_extra || abbrev_all;
     should_describe &= item.is_fully_known();
-    should_describe &= (item.inscription == 0) || !angband_strchr(quark_str(item.inscription), '%');
+    should_describe &= !item.is_inscribed() || !angband_strchr(quark_str(item.inscription), '%');
     if (!should_describe) {
         return "";
     }
@@ -482,7 +482,7 @@ static std::string describe_ability_abbrev(const ItemEntity &item)
 
 static std::string describe_player_inscription(const ItemEntity &item)
 {
-    if (item.inscription == 0) {
+    if (!item.is_inscribed()) {
         return "";
     }
 

--- a/src/flavor/flavor-describer.cpp
+++ b/src/flavor/flavor-describer.cpp
@@ -471,7 +471,7 @@ static std::string describe_ability_abbrev(const ItemEntity &item)
 {
     auto should_describe = abbrev_extra || abbrev_all;
     should_describe &= item.is_fully_known();
-    should_describe &= !item.is_inscribed() || !angband_strchr(quark_str(item.inscription), '%');
+    should_describe &= !item.is_inscribed() || !angband_strchr(item.inscription->data(), '%');
     if (!should_describe) {
         return "";
     }

--- a/src/flavor/flavor-util.cpp
+++ b/src/flavor/flavor-util.cpp
@@ -218,11 +218,14 @@ std::string get_ability_abbreviation(const ItemEntity &item, bool is_kanji, bool
  */
 std::string get_inscription(const ItemEntity &item)
 {
-    const auto insc = quark_str(item.inscription);
+    if (!item.is_inscribed()) {
+        return {};
+    }
+
     std::stringstream ss;
 
     if (!item.is_fully_known()) {
-        for (std::string_view sv = insc; !sv.empty(); sv.remove_prefix(1)) {
+        for (std::string_view sv = item.inscription.value(); !sv.empty(); sv.remove_prefix(1)) {
             if (sv.front() == '#') {
                 break;
             }
@@ -241,7 +244,7 @@ std::string get_inscription(const ItemEntity &item)
         return ss.str();
     }
 
-    for (std::string_view sv = insc; !sv.empty(); sv.remove_prefix(1)) {
+    for (std::string_view sv = item.inscription.value(); !sv.empty(); sv.remove_prefix(1)) {
         switch (sv.front()) {
         case '#':
             return ss.str();

--- a/src/flavor/named-item-describer.cpp
+++ b/src/flavor/named-item-describer.cpp
@@ -148,7 +148,7 @@ static std::optional<std::string> describe_random_artifact_name_after_body_ja(co
 
 static std::string describe_fake_artifact_name_after_body_ja(const ItemEntity &item)
 {
-    if (!item.inscription) {
+    if (!item.is_inscribed()) {
         return "";
     }
 
@@ -303,7 +303,7 @@ static std::string describe_unique_name_after_body_en(const ItemEntity &item, co
         ss << ' ' << egos_info[item.ego_idx].name;
     }
 
-    if (item.inscription) {
+    if (item.is_inscribed()) {
         if (auto str = angband_strchr(quark_str(item.inscription), '#'); str != nullptr) {
             ss << ' ' << str + 1;
         }

--- a/src/flavor/named-item-describer.cpp
+++ b/src/flavor/named-item-describer.cpp
@@ -152,7 +152,7 @@ static std::string describe_fake_artifact_name_after_body_ja(const ItemEntity &i
         return "";
     }
 
-    concptr str = quark_str(item.inscription);
+    auto str = item.inscription->data();
     while (*str) {
         if (iskanji(*str)) {
             str += 2;
@@ -170,7 +170,7 @@ static std::string describe_fake_artifact_name_after_body_ja(const ItemEntity &i
         return "";
     }
 
-    concptr str_aux = angband_strchr(quark_str(item.inscription), '#');
+    auto str_aux = angband_strchr(item.inscription->data(), '#');
     return format("『%s』", str_aux + 1);
 }
 
@@ -304,7 +304,7 @@ static std::string describe_unique_name_after_body_en(const ItemEntity &item, co
     }
 
     if (item.is_inscribed()) {
-        if (auto str = angband_strchr(quark_str(item.inscription), '#'); str != nullptr) {
+        if (auto str = angband_strchr(item.inscription->data(), '#'); str != nullptr) {
             ss << ' ' << str + 1;
         }
     }

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -191,7 +191,7 @@ static void curse_teleport(PlayerType *player_ptr)
             continue;
         }
 
-        if (o_ptr->inscription && angband_strchr(quark_str(o_ptr->inscription), '.')) {
+        if (o_ptr->is_inscribed() && angband_strchr(quark_str(o_ptr->inscription), '.')) {
             continue;
         }
 

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -191,7 +191,7 @@ static void curse_teleport(PlayerType *player_ptr)
             continue;
         }
 
-        if (o_ptr->is_inscribed() && angband_strchr(quark_str(o_ptr->inscription), '.')) {
+        if (o_ptr->is_inscribed() && angband_strchr(o_ptr->inscription->data(), '.')) {
             continue;
         }
 

--- a/src/inventory/inventory-util.cpp
+++ b/src/inventory/inventory-util.cpp
@@ -53,7 +53,7 @@ bool get_tag_floor(FloorType *floor_ptr, COMMAND_CODE *cp, char tag, FLOOR_IDX f
             continue;
         }
 
-        concptr s = angband_strchr(quark_str(o_ptr->inscription), '@');
+        auto s = angband_strchr(o_ptr->inscription->data(), '@');
         while (s) {
             if ((s[1] == command_cmd) && (s[2] == tag)) {
                 *cp = i;
@@ -74,7 +74,7 @@ bool get_tag_floor(FloorType *floor_ptr, COMMAND_CODE *cp, char tag, FLOOR_IDX f
             continue;
         }
 
-        concptr s = angband_strchr(quark_str(o_ptr->inscription), '@');
+        auto s = angband_strchr(o_ptr->inscription->data(), '@');
         while (s) {
             if (s[1] == tag) {
                 *cp = i;
@@ -132,7 +132,7 @@ bool get_tag(PlayerType *player_ptr, COMMAND_CODE *cp, char tag, BIT_FLAGS mode,
             continue;
         }
 
-        concptr s = angband_strchr(quark_str(o_ptr->inscription), '@');
+        auto s = angband_strchr(o_ptr->inscription->data(), '@');
         while (s) {
             if ((s[1] == command_cmd) && (s[2] == tag)) {
                 *cp = i;
@@ -157,7 +157,7 @@ bool get_tag(PlayerType *player_ptr, COMMAND_CODE *cp, char tag, BIT_FLAGS mode,
             continue;
         }
 
-        concptr s = angband_strchr(quark_str(o_ptr->inscription), '@');
+        auto s = angband_strchr(o_ptr->inscription->data(), '@');
         while (s) {
             if (s[1] == tag) {
                 *cp = i;
@@ -215,7 +215,7 @@ bool get_item_allow(PlayerType *player_ptr, INVENTORY_IDX item)
         return true;
     }
 
-    concptr s = angband_strchr(quark_str(o_ptr->inscription), '!');
+    auto s = angband_strchr(o_ptr->inscription->data(), '!');
     while (s) {
         if ((s[1] == command_cmd) || (s[1] == '*')) {
             if (!verify(player_ptr, _("本当に", "Really try"), item)) {

--- a/src/inventory/inventory-util.cpp
+++ b/src/inventory/inventory-util.cpp
@@ -49,7 +49,7 @@ bool get_tag_floor(FloorType *floor_ptr, COMMAND_CODE *cp, char tag, FLOOR_IDX f
 {
     for (COMMAND_CODE i = 0; i < floor_num && i < 23; i++) {
         auto *o_ptr = &floor_ptr->o_list[floor_list[i]];
-        if (!o_ptr->inscription) {
+        if (!o_ptr->is_inscribed()) {
             continue;
         }
 
@@ -70,7 +70,7 @@ bool get_tag_floor(FloorType *floor_ptr, COMMAND_CODE *cp, char tag, FLOOR_IDX f
 
     for (COMMAND_CODE i = 0; i < floor_num && i < 23; i++) {
         auto *o_ptr = &floor_ptr->o_list[floor_list[i]];
-        if (!o_ptr->inscription) {
+        if (!o_ptr->is_inscribed()) {
             continue;
         }
 
@@ -124,7 +124,7 @@ bool get_tag(PlayerType *player_ptr, COMMAND_CODE *cp, char tag, BIT_FLAGS mode,
 
     for (COMMAND_CODE i = start; i <= end; i++) {
         auto *o_ptr = &player_ptr->inventory_list[i];
-        if ((o_ptr->bi_id == 0) || (o_ptr->inscription == 0)) {
+        if ((o_ptr->bi_id == 0) || !o_ptr->is_inscribed()) {
             continue;
         }
 
@@ -149,7 +149,7 @@ bool get_tag(PlayerType *player_ptr, COMMAND_CODE *cp, char tag, BIT_FLAGS mode,
 
     for (COMMAND_CODE i = start; i <= end; i++) {
         auto *o_ptr = &player_ptr->inventory_list[i];
-        if ((o_ptr->bi_id == 0) || (o_ptr->inscription == 0)) {
+        if ((o_ptr->bi_id == 0) || !o_ptr->is_inscribed()) {
             continue;
         }
 
@@ -211,7 +211,7 @@ bool get_item_allow(PlayerType *player_ptr, INVENTORY_IDX item)
         o_ptr = &player_ptr->current_floor_ptr->o_list[0 - item];
     }
 
-    if (!o_ptr->inscription) {
+    if (!o_ptr->is_inscribed()) {
         return true;
     }
 

--- a/src/inventory/recharge-processor.cpp
+++ b/src/inventory/recharge-processor.cpp
@@ -22,7 +22,7 @@
  */
 static void recharged_notice(PlayerType *player_ptr, ItemEntity *o_ptr)
 {
-    if (!o_ptr->inscription) {
+    if (!o_ptr->is_inscribed()) {
         return;
     }
 

--- a/src/inventory/recharge-processor.cpp
+++ b/src/inventory/recharge-processor.cpp
@@ -26,7 +26,7 @@ static void recharged_notice(PlayerType *player_ptr, ItemEntity *o_ptr)
         return;
     }
 
-    concptr s = angband_strchr(quark_str(o_ptr->inscription), '!');
+    auto s = angband_strchr(o_ptr->inscription->data(), '!');
     while (s) {
         if (s[1] == '!') {
             GAME_TEXT o_name[MAX_NLEN];

--- a/src/io/input-key-requester.cpp
+++ b/src/io/input-key-requester.cpp
@@ -320,7 +320,7 @@ void InputKeyRequestor::sweep_confirmation_equipments()
     auto caret_command = this->get_caret_command();
     for (auto i = enum2i(INVEN_MAIN_HAND); i < INVEN_TOTAL; i++) {
         auto &o_ref = this->player_ptr->inventory_list[i];
-        if ((o_ref.bi_id == 0) || (o_ref.inscription == 0)) {
+        if ((o_ref.bi_id == 0) || !o_ref.is_inscribed()) {
             continue;
         }
 

--- a/src/io/input-key-requester.cpp
+++ b/src/io/input-key-requester.cpp
@@ -330,7 +330,7 @@ void InputKeyRequestor::sweep_confirmation_equipments()
 
 void InputKeyRequestor::confirm_command(ItemEntity &o_ref, const int caret_command)
 {
-    auto s = quark_str(o_ref.inscription);
+    auto s = o_ref.inscription->data();
     s = angband_strchr(s, '^');
     while (s) {
 #ifdef JP

--- a/src/load/old/item-loader-savefile50.cpp
+++ b/src/load/old/item-loader-savefile50.cpp
@@ -175,9 +175,9 @@ void ItemLoader50::rd_item(ItemEntity *o_ptr)
     if (any_bits(flags, SaveDataItemFlagType::INSCRIPTION)) {
         char buf[128];
         rd_string(buf, sizeof(buf));
-        o_ptr->inscription = quark_add(buf);
+        o_ptr->inscription.emplace(buf);
     } else {
-        o_ptr->inscription = 0;
+        o_ptr->inscription.reset();
     }
 
     if (any_bits(flags, SaveDataItemFlagType::ART_NAME)) {

--- a/src/load/old/load-v1-5-0.cpp
+++ b/src/load/old/load-v1-5-0.cpp
@@ -310,7 +310,7 @@ void rd_item_old(ItemEntity *o_ptr)
     char buf[128];
     rd_string(buf, sizeof(buf));
     if (buf[0]) {
-        o_ptr->inscription = quark_add(buf);
+        o_ptr->inscription.emplace(buf);
     }
 
     rd_string(buf, sizeof(buf));

--- a/src/object/object-stack.cpp
+++ b/src/object/object-stack.cpp
@@ -213,7 +213,7 @@ int object_similar_part(const ItemEntity *o_ptr, const ItemEntity *j_ptr)
         return 0;
     }
 
-    if (o_ptr->inscription && j_ptr->inscription && (o_ptr->inscription != j_ptr->inscription)) {
+    if (o_ptr->is_inscribed() && j_ptr->is_inscribed() && (o_ptr->inscription != j_ptr->inscription)) {
         return 0;
     }
 
@@ -277,7 +277,7 @@ void object_absorb(ItemEntity *o_ptr, ItemEntity *j_ptr)
     if (j_ptr->is_fully_known()) {
         o_ptr->ident |= (IDENT_FULL_KNOWN);
     }
-    if (j_ptr->inscription) {
+    if (j_ptr->is_inscribed()) {
         o_ptr->inscription = j_ptr->inscription;
     }
     if (j_ptr->feeling) {

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -806,7 +806,7 @@ BIT_FLAGS has_warning(PlayerType *player_ptr)
         auto flgs = object_flags(o_ptr);
 
         if (flgs.has(TR_WARNING)) {
-            if (!o_ptr->inscription || !(angband_strchr(quark_str(o_ptr->inscription), '$'))) {
+            if (!o_ptr->is_inscribed() || !(angband_strchr(quark_str(o_ptr->inscription), '$'))) {
                 set_bits(result, convert_inventory_slot_type_to_flag_cause(i2enum<inventory_slot_type>(i)));
             }
         }
@@ -1148,7 +1148,7 @@ void update_curses(PlayerType *player_ptr)
                 concptr insc = quark_str(o_ptr->inscription);
 
                 /* {.} will stop random teleportation. */
-                if (o_ptr->inscription && angband_strchr(insc, '.')) {
+                if (o_ptr->is_inscribed() && angband_strchr(insc, '.')) {
                 } else {
                     player_ptr->cursed_special.set(CurseSpecialTraitType::TELEPORT_SELF);
                 }

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -806,7 +806,7 @@ BIT_FLAGS has_warning(PlayerType *player_ptr)
         auto flgs = object_flags(o_ptr);
 
         if (flgs.has(TR_WARNING)) {
-            if (!o_ptr->is_inscribed() || !(angband_strchr(quark_str(o_ptr->inscription), '$'))) {
+            if (!o_ptr->is_inscribed() || !angband_strchr(o_ptr->inscription->data(), '$')) {
                 set_bits(result, convert_inventory_slot_type_to_flag_cause(i2enum<inventory_slot_type>(i)));
             }
         }
@@ -1145,10 +1145,8 @@ void update_curses(PlayerType *player_ptr)
             if (o_ptr->is_cursed()) {
                 player_ptr->cursed.set(CurseTraitType::TELEPORT);
             } else {
-                concptr insc = quark_str(o_ptr->inscription);
-
                 /* {.} will stop random teleportation. */
-                if (o_ptr->is_inscribed() && angband_strchr(insc, '.')) {
+                if (o_ptr->is_inscribed() && angband_strchr(o_ptr->inscription->data(), '.')) {
                 } else {
                     player_ptr->cursed_special.set(CurseSpecialTraitType::TELEPORT_SELF);
                 }

--- a/src/save/item-writer.cpp
+++ b/src/save/item-writer.cpp
@@ -106,7 +106,7 @@ static void write_item_flags(ItemEntity *o_ptr, BIT_FLAGS *flags)
         set_bits(*flags, SaveDataItemFlagType::FEELING);
     }
 
-    if (o_ptr->inscription) {
+    if (o_ptr->is_inscribed()) {
         set_bits(*flags, SaveDataItemFlagType::INSCRIPTION);
     }
 

--- a/src/save/item-writer.cpp
+++ b/src/save/item-writer.cpp
@@ -260,7 +260,7 @@ void wr_item(ItemEntity *o_ptr)
 
     write_item_info(o_ptr, flags);
     if (any_bits(flags, SaveDataItemFlagType::INSCRIPTION)) {
-        wr_string(quark_str(o_ptr->inscription));
+        wr_string(o_ptr->inscription.value());
     }
 
     if (any_bits(flags, SaveDataItemFlagType::ART_NAME)) {

--- a/src/specific-object/monster-ball.cpp
+++ b/src/specific-object/monster-ball.cpp
@@ -32,7 +32,7 @@ static void inscribe_nickname(ae_type *ae_ptr, CapturedMonsterType *cap_mon_ptr)
     concptr t;
     char *s;
     char buf[80] = "";
-    if (ae_ptr->o_ptr->inscription) {
+    if (ae_ptr->o_ptr->is_inscribed()) {
         strcpy(buf, quark_str(ae_ptr->o_ptr->inscription));
     }
 
@@ -134,7 +134,7 @@ static void add_quark_to_inscription(PlayerType *player_ptr, ae_type *ae_ptr, co
 
 static void check_inscription_value(PlayerType *player_ptr, ae_type *ae_ptr)
 {
-    if (ae_ptr->o_ptr->inscription == 0) {
+    if (!ae_ptr->o_ptr->is_inscribed()) {
         return;
     }
 

--- a/src/specific-object/monster-ball.cpp
+++ b/src/specific-object/monster-ball.cpp
@@ -21,6 +21,7 @@
 #include "target/target-getter.h"
 #include "util/flag-group.h"
 #include "util/quarks.h"
+#include "util/string-processor.h"
 #include "view/display-messages.h"
 
 static void inscribe_nickname(ae_type *ae_ptr, CapturedMonsterType *cap_mon_ptr)
@@ -33,7 +34,7 @@ static void inscribe_nickname(ae_type *ae_ptr, CapturedMonsterType *cap_mon_ptr)
     char *s;
     char buf[80] = "";
     if (ae_ptr->o_ptr->is_inscribed()) {
-        strcpy(buf, quark_str(ae_ptr->o_ptr->inscription));
+        angband_strcpy(buf, ae_ptr->o_ptr->inscription->data(), sizeof(buf));
     }
 
     s = buf;
@@ -62,7 +63,7 @@ static void inscribe_nickname(ae_type *ae_ptr, CapturedMonsterType *cap_mon_ptr)
     *s++ = '\'';
 #endif
     *s = '\0';
-    ae_ptr->o_ptr->inscription = quark_add(buf);
+    ae_ptr->o_ptr->inscription.emplace(buf);
 }
 
 static bool set_activation_target(PlayerType *player_ptr, ae_type *ae_ptr)
@@ -120,7 +121,7 @@ static void add_quark_to_inscription(PlayerType *player_ptr, ae_type *ae_ptr, co
 
     *s = '\0';
     player_ptr->current_floor_ptr->m_list[hack_m_idx_ii].nickname = quark_add(buf);
-    t = quark_str(ae_ptr->o_ptr->inscription);
+    t = ae_ptr->o_ptr->inscription->data();
     s = buf;
     while (*t && (*t != '#')) {
         *s = *t;
@@ -129,7 +130,7 @@ static void add_quark_to_inscription(PlayerType *player_ptr, ae_type *ae_ptr, co
     }
 
     *s = '\0';
-    ae_ptr->o_ptr->inscription = quark_add(buf);
+    ae_ptr->o_ptr->inscription.emplace(buf);
 }
 
 static void check_inscription_value(PlayerType *player_ptr, ae_type *ae_ptr)
@@ -139,8 +140,8 @@ static void check_inscription_value(PlayerType *player_ptr, ae_type *ae_ptr)
     }
 
     char buf[80];
-    concptr t = quark_str(ae_ptr->o_ptr->inscription);
-    for (t = quark_str(ae_ptr->o_ptr->inscription); *t && (*t != '#'); t++) {
+    concptr t;
+    for (t = ae_ptr->o_ptr->inscription->data(); *t && (*t != '#'); t++) {
 #ifdef JP
         if (iskanji(*t)) {
             t++;

--- a/src/spell-kind/spells-enchant.cpp
+++ b/src/spell-kind/spells-enchant.cpp
@@ -142,14 +142,14 @@ bool mundane_spell(PlayerType *player_ptr, bool only_equip)
     POSITION iy = o_ptr->iy;
     POSITION ix = o_ptr->ix;
     auto marked = o_ptr->marked;
-    uint16_t inscription = o_ptr->inscription;
+    auto inscription = std::move(o_ptr->inscription);
 
     o_ptr->prep(o_ptr->bi_id);
 
     o_ptr->iy = iy;
     o_ptr->ix = ix;
     o_ptr->marked = marked;
-    o_ptr->inscription = inscription;
+    o_ptr->inscription = std::move(inscription);
 
     calc_android_exp(player_ptr);
     return true;

--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -302,7 +302,7 @@ void store_purchase(PlayerType *player_ptr, StoreSaleType store_num)
         exe_write_diary(player_ptr, DIARY_ART, 0, o_name);
     }
 
-    j_ptr->inscription = 0;
+    j_ptr->inscription.reset();
     j_ptr->feeling = FEEL_NONE;
     j_ptr->ident &= ~(IDENT_STORE);
 

--- a/src/store/sell-order.cpp
+++ b/src/store/sell-order.cpp
@@ -122,7 +122,7 @@ void store_sell(PlayerType *player_ptr, StoreSaleType store_num)
     GAME_TEXT o_name[MAX_NLEN];
     describe_flavor(player_ptr, o_name, q_ptr, 0);
     if ((store_num != StoreSaleType::HOME) && (store_num != StoreSaleType::MUSEUM)) {
-        q_ptr->inscription = 0;
+        q_ptr->inscription.reset();
         q_ptr->feeling = FEEL_NONE;
     }
 

--- a/src/store/store-util.cpp
+++ b/src/store/store-util.cpp
@@ -239,7 +239,7 @@ int store_carry(ItemEntity *o_ptr)
     }
 
     o_ptr->ident |= IDENT_FULL_KNOWN;
-    o_ptr->inscription = 0;
+    o_ptr->inscription.reset();
     o_ptr->feeling = FEEL_NONE;
     int slot;
     for (slot = 0; slot < st_ptr->stock_num; slot++) {

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -295,7 +295,7 @@ void store_shuffle(PlayerType *player_ptr, StoreSaleType store_num)
         }
 
         o_ptr->discount = 50;
-        o_ptr->inscription = quark_add(_("売出中", "on sale"));
+        o_ptr->inscription.emplace(_("売出中", "on sale"));
     }
 }
 

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -802,5 +802,5 @@ bool ItemEntity::is_cross_bow() const
 
 bool ItemEntity::is_inscribed() const
 {
-    return this->inscription != 0;
+    return this->inscription != std::nullopt;
 }

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -799,3 +799,8 @@ bool ItemEntity::is_cross_bow() const
 {
     return this->bi_key.is_cross_bow();
 }
+
+bool ItemEntity::is_inscribed() const
+{
+    return this->inscription != 0;
+}

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -59,7 +59,7 @@ public:
     TIME_EFFECT timeout{}; /*!< Timeout Counter */
     byte ident{}; /*!< Special flags  */
     EnumClassFlagGroup<OmType> marked{}; /*!< Object is marked */
-    uint16_t inscription{}; /*!< Inscription index */
+    std::optional<std::string> inscription{}; /*!< Inscription */
     std::optional<std::string> randart_name{}; /*!< Artifact name (random artifacts) */
     byte feeling{}; /*!< Game generated inscription number (eg, pseudo-id) */
 

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -132,6 +132,7 @@ public:
     bool is_junk() const;
     bool is_armour() const;
     bool is_cross_bow() const;
+    bool is_inscribed() const;
 
 private:
     int get_baseitem_price() const;


### PR DESCRIPTION
Resolves #2910 

既存の quark_str のインデクスを持たせる方式から文字列を直接持たせる方式に変更する。
空文字列を銘を刻んでいない状態とするのはやや紛らわしくなるので、std::optional<std::string> 型とし、銘を刻んでいない場合は値を std::nullopt とする。