### PR TITLE
[Refactor] gf_colors に直接 std::string を持たせる

### DIFF
--- a/src/io/interpret-pref-file.cpp
+++ b/src/io/interpret-pref-file.cpp
@@ -369,7 +369,7 @@ static int interpret_z_token(char *buf)
             continue;
         }
 
-        gf_colors[description.num] = quark_add(t);
+        gf_colors[description.num] = t;
         return 0;
     }
 

--- a/src/main/game-data-initializer.cpp
+++ b/src/main/game-data-initializer.cpp
@@ -35,9 +35,8 @@ constexpr int MACRO_MAX = 256;
 
 static void init_gf_colors()
 {
-    constexpr ushort default_gf_color = 0;
     for (auto i = 0; i < enum2i(AttributeType::MAX); i++) {
-        gf_colors.emplace(i2enum<AttributeType>(i), default_gf_color);
+        gf_colors.emplace(i2enum<AttributeType>(i), "");
     }
 }
 

--- a/src/term/gameterm.cpp
+++ b/src/term/gameterm.cpp
@@ -367,9 +367,9 @@ char misc_to_char[256];
 TERM_COLOR tval_to_attr[128];
 
 /*
- * Default spell color table (quark index)
+ * Default spell color table
  */
-std::map<AttributeType, ushort> gf_colors;
+std::map<AttributeType, std::string> gf_colors;
 
 /*!
  * @brief 万色表現用にランダムな色を選択する関数 /
@@ -533,14 +533,14 @@ static TERM_COLOR spell_color(AttributeType type)
         TERM_COLOR a;
 
         /* Lookup the default colors for this type */
-        concptr s = quark_str(gf_colors[type]);
+        const auto &color = gf_colors[type];
 
-        if (!s) {
+        if (color.empty()) {
             return TERM_WHITE;
         }
 
         /* Pick a random color */
-        auto c = s[randint0(strlen(s))];
+        auto c = color[randint0(color.size())];
 
         /* Lookup this color */
         a = angband_strchr(color_char, c) - color_char;

--- a/src/term/gameterm.h
+++ b/src/term/gameterm.h
@@ -3,6 +3,7 @@
 #include "system/angband.h"
 #include <array>
 #include <map>
+#include <string>
 #include <utility>
 
 extern const concptr color_names[16];
@@ -19,7 +20,7 @@ extern const char angband_term_name[8][16];
 extern byte angband_color_table[256][4];
 
 enum class AttributeType : int;
-extern std::map<AttributeType, ushort> gf_colors;
+extern std::map<AttributeType, std::string> gf_colors;
 extern TERM_COLOR color_char_to_attr(char c);
 
 std::pair<TERM_COLOR, char> bolt_pict(POSITION y, POSITION x, POSITION ny, POSITION nx, AttributeType typ);


### PR DESCRIPTION
既存の gf_colors (魔法やブレスなどの属性毎の描画色定義) は quark_str のインデック スを保持している。これを std::string を直接持つように変更する。

一連の quark_str 使用の削除に含まれ単体の変更量が少ないので Issue は作っていません。