### PR TITLE
マクロ関数update_local_illumination_aux() を普通の関数に展開した

### DIFF
--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -180,19 +180,26 @@ bool check_local_illumination(PlayerType *player_ptr, POSITION y, POSITION x)
     }
 }
 
-/*! 対象座標のマスの照明状態を更新する際の補助処理マクロ */
-#define update_local_illumination_aux(C, Y, X)                                                  \
-    {                                                                                           \
-        if (player_has_los_bold((C), (Y), (X))) {                                               \
-            /* Update the monster */                                                            \
-            if ((C)->current_floor_ptr->grid_array[(Y)][(X)].m_idx)                             \
-                update_monster((C), (C)->current_floor_ptr->grid_array[(Y)][(X)].m_idx, false); \
-                                                                                                \
-            /* Notice and redraw */                                                             \
-            note_spot((C), (Y), (X));                                                           \
-            lite_spot((C), (Y), (X));                                                           \
-        }                                                                                       \
+/*!
+ * @brief 対象座標のマスの照明状態を更新する
+ * @param player_ptr プレイヤーへの参照ポインタ
+ * @param y 更新したいマスのY座標
+ * @param x 更新したいマスのX座標
+ */
+static void update_local_illumination_aux(PlayerType *player_ptr, int y, int x)
+{
+    if (!player_has_los_bold(player_ptr, y, x)) {
+        return;
     }
+
+    const auto &grid = player_ptr->current_floor_ptr->grid_array[y][x];
+    if (grid.m_idx > 0) {
+        update_monster(player_ptr, grid.m_idx, false);
+    }
+
+    note_spot(player_ptr, y, x);
+    lite_spot(player_ptr, y, x);
+}
 
 /*!
  * @brief 指定された座標の照明状態を更新する / Update "local" illumination

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -66,9 +66,6 @@
 #include "world/world.h"
 #include <queue>
 
-#define MONSTER_FLOW_DEPTH \
-    32 /*!< 敵のプレイヤーに対する移動道のりの最大値(この値以上は処理を打ち切る) / OPTION: Maximum flow depth when using "MONSTER_FLOW" */
-
 /*!
  * @brief 新規フロアに入りたてのプレイヤーをランダムな場所に配置する / Returns random co-ordinates for player/monster/object
  * @param player_ptr プレイヤーへの参照ポインタ
@@ -752,8 +749,9 @@ void update_flow(PlayerType *player_ptr)
                     g_ptr->dists[i] = n;
                 }
 
-                /* Hack -- limit flow depth */
-                if (n == MONSTER_FLOW_DEPTH) {
+                // 敵のプレイヤーに対する移動道のりの最大値(この値以上は処理を打ち切る).
+                constexpr auto monster_flow_depth = 32;
+                if (n == monster_flow_depth) {
                     continue;
                 }
 


### PR DESCRIPTION
掲題の通りです (ついでに見つけたdefine定数もconstexprにした)
ご確認下さい

ちなみに、これで2行以上のマクロ関数は絶滅したと思います
(末尾がバックスラッシュされているdefineは他になし)