### PR TITLE
get_rnd_line() の引数からchar *を削除し、返り値をstd::optional<std::string> に変えた

### DIFF
--- a/src/artifact/random-art-characteristics.cpp
+++ b/src/artifact/random-art-characteristics.cpp
@@ -154,7 +154,7 @@ std::string get_random_name(const ItemEntity &item, bool armour, int power)
 
     auto filename = get_random_art_filename(armour, power);
     char random_artifact_name[80]{};
-    (void)get_rnd_line(filename.data(), item.artifact_bias, random_artifact_name);
+    (void)get_random_line(filename.data(), item.artifact_bias, random_artifact_name);
 #ifdef JP
     if (random_artifact_name[0] == 0) {
         return get_table_name();

--- a/src/artifact/random-art-characteristics.cpp
+++ b/src/artifact/random-art-characteristics.cpp
@@ -153,14 +153,16 @@ std::string get_random_name(const ItemEntity &item, bool armour, int power)
     }
 
     auto filename = get_random_art_filename(armour, power);
-    char random_artifact_name[80]{};
-    (void)get_random_line(filename.data(), item.artifact_bias, random_artifact_name);
+    auto random_artifact_name = get_random_line(filename.data(), item.artifact_bias);
 #ifdef JP
-    if (random_artifact_name[0] == 0) {
-        return get_table_name();
+    if (random_artifact_name.has_value()) {
+        return random_artifact_name.value();
     }
+
+    return get_table_name();
+#else
+    return random_artifact_name.value();
 #endif
-    return random_artifact_name;
 }
 
 /*対邪平均ダメージの計算処理*/

--- a/src/flavor/object-flavor.cpp
+++ b/src/flavor/object-flavor.cpp
@@ -104,7 +104,7 @@ std::string get_table_name_aux()
     ss << get_random_line("aname_j.txt", 2).value();
     return ss.str();
 #else
-    static std::vector<std::string_view> syllables = {
+    static const std::vector<std::string_view> syllables = {
         "a", "ab", "ag", "aks", "ala", "an", "ankh", "app", "arg", "arze", "ash", "aus", "ban", "bar", "bat", "bek",
         "bie", "bin", "bit", "bjor", "blu", "bot", "bu", "byt", "comp", "con", "cos", "cre", "dalf", "dan", "den", "der", "doe", "dok", "eep", "el", "eng",
         "er", "ere", "erk", "esh", "evs", "fa", "fid", "flit", "for", "fri", "fu", "gan", "gar", "glen", "gop", "gre", "ha", "he", "hyd", "i", "ing", "ion",

--- a/src/flavor/object-flavor.cpp
+++ b/src/flavor/object-flavor.cpp
@@ -91,52 +91,43 @@ static bool object_easy_know(int i)
 }
 
 /*!
- * @brief 各種語彙からランダムな名前を作成する / Create a name from random parts.
+ * @brief 各種語彙からランダムな名前を作成する
  * @return std::string 作成した名前
  * @details 日本語の場合 aname_j.txt 英語の場合確率に応じて
- * syllables 配列と elvish.txt を組み合わせる。\n
+ * syllables 配列と elvish.txt を組み合わせる
  */
 std::string get_table_name_aux()
 {
-    std::string name;
+    std::stringstream ss;
 #ifdef JP
-    char syllable[80];
-    get_random_line("aname_j.txt", 1, syllable);
-    name = syllable;
-    get_random_line("aname_j.txt", 2, syllable);
-    name.append(syllable);
-    return name;
+    ss << get_random_line("aname_j.txt", 1).value();
+    ss << get_random_line("aname_j.txt", 2).value();
+    return ss.str();
 #else
-#define MAX_SYLLABLES 164 /* Used with scrolls (see below) */
-
-    static concptr syllables[MAX_SYLLABLES] = { "a", "ab", "ag", "aks", "ala", "an", "ankh", "app", "arg", "arze", "ash", "aus", "ban", "bar", "bat", "bek",
+    static std::vector<std::string_view> syllables = {
+        "a", "ab", "ag", "aks", "ala", "an", "ankh", "app", "arg", "arze", "ash", "aus", "ban", "bar", "bat", "bek",
         "bie", "bin", "bit", "bjor", "blu", "bot", "bu", "byt", "comp", "con", "cos", "cre", "dalf", "dan", "den", "der", "doe", "dok", "eep", "el", "eng",
         "er", "ere", "erk", "esh", "evs", "fa", "fid", "flit", "for", "fri", "fu", "gan", "gar", "glen", "gop", "gre", "ha", "he", "hyd", "i", "ing", "ion",
         "ip", "ish", "it", "ite", "iv", "jo", "kho", "kli", "klis", "la", "lech", "man", "mar", "me", "mi", "mic", "mik", "mon", "mung", "mur", "nag", "nej",
         "nelg", "nep", "ner", "nes", "nis", "nih", "nin", "o", "od", "ood", "org", "orn", "ox", "oxy", "pay", "pet", "ple", "plu", "po", "pot", "prok", "re",
         "rea", "rhov", "ri", "ro", "rog", "rok", "rol", "sa", "san", "sat", "see", "sef", "seh", "shu", "ski", "sna", "sne", "snik", "sno", "so", "sol", "sri",
         "sta", "sun", "ta", "tab", "tem", "ther", "ti", "tox", "trol", "tue", "turs", "u", "ulk", "um", "un", "uni", "ur", "val", "viv", "vly", "vom", "wah",
-        "wed", "werg", "wex", "whon", "wun", "x", "yerg", "yp", "zun", "tri", "blaa", "jah", "bul", "on", "foo", "ju", "xuxu" };
+        "wed", "werg", "wex", "whon", "wun", "x", "yerg", "yp", "zun", "tri", "blaa", "jah", "bul", "on", "foo", "ju", "xuxu"
+    };
 
     int testcounter = randint1(3) + 1;
     if (randint1(3) == 2) {
         while (testcounter--) {
-            name.append(syllables[randint0(MAX_SYLLABLES)]);
+            ss << syllables[randint0(syllables.size())];
         }
     } else {
-        char syllable[80];
         testcounter = randint1(2) + 1;
         while (testcounter--) {
-<<<<<<< HEAD
-            (void)get_rnd_line("elvish.txt", 0, syllable);
-            name.append(syllable);
-=======
-            (void)get_random_line("elvish.txt", 0, syllable);
-            strcat(out_string, syllable);
->>>>>>> dd39ec10b ([Refactor] #2651 Renamed get_rnd_line() to get_random_line())
+            ss << get_random_line("elvish.txt", 0).value();
         }
     }
 
+    auto name = ss.str();
     name[0] = toupper(name[0]);
     return name;
 #endif
@@ -159,11 +150,10 @@ std::string get_table_name()
  */
 std::string get_table_sindarin_aux()
 {
-    char syllable[80];
-    get_random_line("sname.txt", 1, syllable);
-    std::string name = syllable;
-    get_random_line("sname.txt", 2, syllable);
-    name.append(syllable);
+    std::stringstream ss;
+    ss << get_random_line("sname.txt", 1).value();
+    ss << get_random_line("sname.txt", 2).value();
+    auto name = ss.str();
     return _(sindarin_to_kana(name), name);
 }
 

--- a/src/flavor/object-flavor.cpp
+++ b/src/flavor/object-flavor.cpp
@@ -101,9 +101,9 @@ std::string get_table_name_aux()
     std::string name;
 #ifdef JP
     char syllable[80];
-    get_rnd_line("aname_j.txt", 1, syllable);
+    get_random_line("aname_j.txt", 1, syllable);
     name = syllable;
-    get_rnd_line("aname_j.txt", 2, syllable);
+    get_random_line("aname_j.txt", 2, syllable);
     name.append(syllable);
     return name;
 #else
@@ -127,8 +127,13 @@ std::string get_table_name_aux()
         char syllable[80];
         testcounter = randint1(2) + 1;
         while (testcounter--) {
+<<<<<<< HEAD
             (void)get_rnd_line("elvish.txt", 0, syllable);
             name.append(syllable);
+=======
+            (void)get_random_line("elvish.txt", 0, syllable);
+            strcat(out_string, syllable);
+>>>>>>> dd39ec10b ([Refactor] #2651 Renamed get_rnd_line() to get_random_line())
         }
     }
 
@@ -155,10 +160,9 @@ std::string get_table_name()
 std::string get_table_sindarin_aux()
 {
     char syllable[80];
-
-    get_rnd_line("sname.txt", 1, syllable);
+    get_random_line("sname.txt", 1, syllable);
     std::string name = syllable;
-    get_rnd_line("sname.txt", 2, syllable);
+    get_random_line("sname.txt", 2, syllable);
     name.append(syllable);
     return _(sindarin_to_kana(name), name);
 }

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -34,6 +34,8 @@
 #include "util/quarks.h"
 #include "util/string-processor.h"
 #include "view/display-messages.h"
+#include <optional>
+#include <string>
 
 namespace {
 const EnumClassFlagGroup<CurseTraitType> TRC_P_FLAG_MASK({ CurseTraitType::TY_CURSE, CurseTraitType::DRAIN_EXP, CurseTraitType::ADD_L_CURSE, CurseTraitType::ADD_H_CURSE, CurseTraitType::CALL_ANIMAL, CurseTraitType::CALL_DEMON,
@@ -223,10 +225,11 @@ static void occur_chainsword_effect(PlayerType *player_ptr)
         return;
     }
 
-    char noise[1024];
-    if (!get_random_line(_("chainswd_j.txt", "chainswd.txt"), 0, noise)) {
-        msg_print(noise);
+    const auto noise = get_random_line(_("chainswd_j.txt", "chainswd.txt"), 0);
+    if (noise.has_value()) {
+        msg_print(noise.value());
     }
+
     disturb(player_ptr, false, false);
 }
 

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -224,7 +224,7 @@ static void occur_chainsword_effect(PlayerType *player_ptr)
     }
 
     char noise[1024];
-    if (!get_rnd_line(_("chainswd_j.txt", "chainswd.txt"), 0, noise)) {
+    if (!get_random_line(_("chainswd_j.txt", "chainswd.txt"), 0, noise)) {
         msg_print(noise);
     }
     disturb(player_ptr, false, false);

--- a/src/io/files-util.cpp
+++ b/src/io/files-util.cpp
@@ -24,6 +24,7 @@
 #include "term/z-form.h"
 #include "util/angband-files.h"
 #include "view/display-messages.h"
+#include <algorithm>
 
 concptr ANGBAND_DIR; //!< Path name: The main "lib" directory This variable is not actually used anywhere in the code
 concptr ANGBAND_DIR_APEX; //!< High score files (binary) These files may be portable between platforms
@@ -143,7 +144,7 @@ std::optional<std::string> get_random_line(concptr file_name, int entry)
     }
 
     auto counter = 0;
-    std::string line{};
+    std::optional<std::string> line{};
     while (true) {
         char buf[1024];
         while (true) {
@@ -172,11 +173,7 @@ std::optional<std::string> get_random_line(concptr file_name, int entry)
     }
 
     angband_fclose(fp);
-    if (counter > 0) {
-        return line;
-    }
-
-    return std::nullopt;
+    return line;
 }
 
 #ifdef JP
@@ -198,8 +195,8 @@ std::optional<std::string> get_random_line_ja_only(concptr file_name, int entry,
         }
 
         auto is_kanji = false;
-        for (auto c = line.value().data(); *c != '\0'; c++) {
-            is_kanji |= iskanji(*c);
+        for (const auto c : line.value()) {
+            is_kanji |= iskanji(c);
         }
 
         if (is_kanji) {

--- a/src/io/files-util.cpp
+++ b/src/io/files-util.cpp
@@ -102,7 +102,7 @@ errr file_character(PlayerType *player_ptr, concptr name)
  * Based on the monster speech patch by Matt Graham,
  * </pre>
  */
-errr get_rnd_line(concptr file_name, int entry, char *output)
+errr get_random_line(concptr file_name, int entry, char *output)
 {
     char buf[1024];
     path_build(buf, sizeof(buf), ANGBAND_DIR_FILE, file_name);
@@ -191,7 +191,7 @@ errr get_rnd_line_jonly(concptr file_name, int entry, char *output, int count)
 {
     errr result = 1;
     for (int i = 0; i < count; i++) {
-        result = get_rnd_line(file_name, entry, output);
+        result = get_random_line(file_name, entry, output);
         if (result) {
             break;
         }

--- a/src/io/files-util.cpp
+++ b/src/io/files-util.cpp
@@ -182,32 +182,33 @@ errr get_random_line(concptr file_name, int entry, char *output)
 
 #ifdef JP
 /*!
- * @brief ファイルからランダムに行を一つ取得する(日本語文字列のみ) /
+ * @brief ファイルからランダムに行を一つ取得する(日本語文字列のみ)
  * @param file_name ファイル名
  * @param entry 特定条件時のN:タグヘッダID
- * @param output 出力先の文字列参照ポインタ
  * @param count 試行回数
- * @return エラーコード
+ * @return ファイルから取得した行 (但しファイルがなかったり異常値ならばnullopt)
  * @details
  */
-errr get_random_line_ja_only(concptr file_name, int entry, char *output, int count)
+std::optional<std::string> get_random_line_ja_only(concptr file_name, int entry, int count)
 {
-    errr result = 1;
-    for (int i = 0; i < count; i++) {
-        result = get_random_line(file_name, entry, output);
-        if (result) {
-            break;
+    char line[1024]{};
+    for (auto i = 0; i < count; i++) {
+        auto error = get_random_line(file_name, entry, line);
+        if (error) {
+            return std::nullopt;
         }
-        bool kanji = false;
-        for (int j = 0; output[j]; j++) {
-            kanji |= iskanji(output[j]);
+
+        auto is_kanji = false;
+        for (auto j = 0; line[j]; j++) {
+            is_kanji |= iskanji(line[j]);
         }
-        if (kanji) {
-            break;
+
+        if (is_kanji) {
+            return line;
         }
     }
 
-    return result;
+    return line;
 }
 #endif
 

--- a/src/io/files-util.cpp
+++ b/src/io/files-util.cpp
@@ -190,7 +190,7 @@ errr get_random_line(concptr file_name, int entry, char *output)
  * @return エラーコード
  * @details
  */
-errr get_rnd_line_jonly(concptr file_name, int entry, char *output, int count)
+errr get_random_line_ja_only(concptr file_name, int entry, char *output, int count)
 {
     errr result = 1;
     for (int i = 0; i < count; i++) {

--- a/src/io/files-util.cpp
+++ b/src/io/files-util.cpp
@@ -104,17 +104,17 @@ errr file_character(PlayerType *player_ptr, concptr name)
  */
 errr get_random_line(concptr file_name, int entry, char *output)
 {
-    char buf[1024];
-    path_build(buf, sizeof(buf), ANGBAND_DIR_FILE, file_name);
-    FILE *fp;
-    fp = angband_fopen(buf, "r");
+    char filename[1024];
+    path_build(filename, sizeof(filename), ANGBAND_DIR_FILE, file_name);
+    auto *fp = angband_fopen(filename, "r");
     if (!fp) {
         return -1;
     }
 
     int test;
-    int line_num = 0;
+    auto line_num = 0;
     while (true) {
+        char buf[1024];
         if (angband_fgets(fp, buf, sizeof(buf)) != 0) {
             angband_fclose(fp);
             return -1;
@@ -127,7 +127,9 @@ errr get_random_line(concptr file_name, int entry, char *output)
 
         if (buf[2] == '*') {
             break;
-        } else if (buf[2] == 'M') {
+        }
+        
+        if (buf[2] == 'M') {
             if (monraces_info[i2enum<MonsterRaceId>(entry)].flags1 & RF1_MALE) {
                 break;
             }
@@ -146,20 +148,19 @@ errr get_random_line(concptr file_name, int entry, char *output)
         }
     }
 
-    int counter;
-    for (counter = 0;; counter++) {
+    auto counter = 0;
+    while (true) {
+        char buf[1024];
         while (true) {
-            test = angband_fgets(fp, buf, sizeof(buf));
-            if (!test) {
-                /* Ignore lines starting with 'N:' */
-                if ((buf[0] == 'N') && (buf[1] == ':')) {
-                    continue;
-                }
+            if (angband_fgets(fp, buf, sizeof(buf))) {
+                break;
+            }
 
-                if (buf[0] != '#') {
-                    break;
-                }
-            } else {
+            if ((buf[0] == 'N') && (buf[1] == ':')) {
+                continue;
+            }
+
+            if (buf[0] != '#') {
                 break;
             }
         }
@@ -171,6 +172,8 @@ errr get_random_line(concptr file_name, int entry, char *output)
         if (one_in_(counter + 1)) {
             strcpy(output, buf);
         }
+
+        counter++;
     }
 
     angband_fclose(fp);

--- a/src/io/files-util.h
+++ b/src/io/files-util.h
@@ -1,6 +1,8 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include <optional>
+#include <string>
 
 extern char savefile[1024];
 extern char savefile_base[40];
@@ -29,7 +31,7 @@ errr get_random_line(concptr file_name, int entry, char *output);
 void read_dead_file(char *buf, size_t buf_size);
 
 #ifdef JP
-errr get_random_line_ja_only(concptr file_name, int entry, char *output, int count);
+std::optional<std::string> get_random_line_ja_only(concptr file_name, int entry, int count);
 #endif
 errr counts_write(PlayerType *player_ptr, int where, uint32_t count);
 uint32_t counts_read(PlayerType *player_ptr, int where);

--- a/src/io/files-util.h
+++ b/src/io/files-util.h
@@ -24,12 +24,12 @@ extern concptr ANGBAND_DIR_XTRA;
 class PlayerType;
 typedef void (*update_playtime_pf)(void);
 
-extern errr file_character(PlayerType *player_ptr, concptr name);
-extern errr get_random_line(concptr file_name, int entry, char *output);
+errr file_character(PlayerType *player_ptr, concptr name);
+errr get_random_line(concptr file_name, int entry, char *output);
 void read_dead_file(char *buf, size_t buf_size);
 
 #ifdef JP
-extern errr get_rnd_line_jonly(concptr file_name, int entry, char *output, int count);
+errr get_random_line_ja_only(concptr file_name, int entry, char *output, int count);
 #endif
-extern errr counts_write(PlayerType *player_ptr, int where, uint32_t count);
-extern uint32_t counts_read(PlayerType *player_ptr, int where);
+errr counts_write(PlayerType *player_ptr, int where, uint32_t count);
+uint32_t counts_read(PlayerType *player_ptr, int where);

--- a/src/io/files-util.h
+++ b/src/io/files-util.h
@@ -25,7 +25,7 @@ class PlayerType;
 typedef void (*update_playtime_pf)(void);
 
 extern errr file_character(PlayerType *player_ptr, concptr name);
-extern errr get_rnd_line(concptr file_name, int entry, char *output);
+extern errr get_random_line(concptr file_name, int entry, char *output);
 void read_dead_file(char *buf, size_t buf_size);
 
 #ifdef JP

--- a/src/io/files-util.h
+++ b/src/io/files-util.h
@@ -27,7 +27,7 @@ class PlayerType;
 typedef void (*update_playtime_pf)(void);
 
 errr file_character(PlayerType *player_ptr, concptr name);
-errr get_random_line(concptr file_name, int entry, char *output);
+std::optional<std::string> get_random_line(concptr file_name, int entry);
 void read_dead_file(char *buf, size_t buf_size);
 
 #ifdef JP

--- a/src/io/input-key-processor.cpp
+++ b/src/io/input-key-processor.cpp
@@ -683,7 +683,7 @@ void process_command(PlayerType *player_ptr)
         if (one_in_(2)) {
             char error_m[1024];
             sound(SOUND_ILLEGAL);
-            if (!get_rnd_line(_("error_j.txt", "error.txt"), 0, error_m)) {
+            if (!get_random_line(_("error_j.txt", "error.txt"), 0, error_m)) {
                 msg_print(error_m);
             }
         } else {

--- a/src/io/input-key-processor.cpp
+++ b/src/io/input-key-processor.cpp
@@ -95,6 +95,8 @@
 #include "window/display-sub-windows.h"
 #include "wizard/cmd-wizard.h"
 #include "world/world.h"
+#include <optional>
+#include <string>
 
 /*!
  * @brief ウィザードモードへの導入処理
@@ -681,10 +683,10 @@ void process_command(PlayerType *player_ptr)
             flush();
         }
         if (one_in_(2)) {
-            char error_m[1024];
             sound(SOUND_ILLEGAL);
-            if (!get_random_line(_("error_j.txt", "error.txt"), 0, error_m)) {
-                msg_print(error_m);
+            const auto error_mes = get_random_line(_("error_j.txt", "error.txt"), 0);
+            if (error_mes.has_value()) {
+                msg_print(error_mes.value());
             }
         } else {
             prt(_(" '?' でヘルプが表示されます。", "Type '?' for help."), 0, 0);

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -536,15 +536,14 @@ void process_speak_sound(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION oy,
     }
 
     const auto m_name = m_ptr->ml ? monster_desc(player_ptr, m_ptr, 0) : std::string(_("それ", "It"));
-    char monmessage[1024];
-
     auto filename = get_speak_filename(m_ptr);
     if (filename.empty()) {
         return;
     }
 
-    if (get_random_line(filename.data(), enum2i(m_ptr->ap_r_idx), monmessage) == 0) {
-        msg_format(_("%^s%s", "%^s %s"), m_name.data(), monmessage);
+    const auto monmessage = get_random_line(filename.data(), enum2i(m_ptr->ap_r_idx));
+    if (monmessage.has_value()) {
+        msg_format(_("%^s%s", "%^s %s"), m_name.data(), monmessage->data());
     }
 }
 

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -543,7 +543,7 @@ void process_speak_sound(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION oy,
         return;
     }
 
-    if (get_rnd_line(filename.data(), enum2i(m_ptr->ap_r_idx), monmessage) == 0) {
+    if (get_random_line(filename.data(), enum2i(m_ptr->ap_r_idx), monmessage) == 0) {
         msg_format(_("%^s%s", "%^s %s"), m_name.data(), monmessage);
     }
 }

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -336,8 +336,8 @@ void MonsterDamageProcessor::dying_scream(std::string_view m_name)
     }
 
     char line_got[1024];
-    if (!get_rnd_line(_("mondeath_j.txt", "mondeath.txt"), enum2i(m_ptr->r_idx), line_got)) {
-        msg_format("%^s %s", m_name.data(), line_got);
+    if (!get_random_line(_("mondeath_j.txt", "mondeath.txt"), enum2i(m_ptr->r_idx), line_got)) {
+        msg_format("%^s %s", m_name, line_got);
     }
 
 #ifdef WORLD_SCORE

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -339,7 +339,7 @@ void MonsterDamageProcessor::dying_scream(std::string_view m_name)
 
     const auto death_mes = get_random_line(_("mondeath_j.txt", "mondeath.txt"), enum2i(m_ptr->r_idx));
     if (death_mes.has_value()) {
-        msg_format("%^s %s", m_name, death_mes->data());
+        msg_format("%^s %s", m_name.data(), death_mes->data());
     }
 
 #ifdef WORLD_SCORE

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -48,6 +48,8 @@
 #include "view/display-messages.h"
 #include "world/world.h"
 #include <algorithm>
+#include <optional>
+#include <string>
 
 /*
  * @brief コンストラクタ
@@ -335,9 +337,9 @@ void MonsterDamageProcessor::dying_scream(std::string_view m_name)
         return;
     }
 
-    char line_got[1024];
-    if (!get_random_line(_("mondeath_j.txt", "mondeath.txt"), enum2i(m_ptr->r_idx), line_got)) {
-        msg_format("%^s %s", m_name, line_got);
+    const auto death_mes = get_random_line(_("mondeath_j.txt", "mondeath.txt"), enum2i(m_ptr->r_idx));
+    if (death_mes.has_value()) {
+        msg_format("%^s %s", m_name, death_mes->data());
     }
 
 #ifdef WORLD_SCORE

--- a/src/monster/monster-describer.cpp
+++ b/src/monster/monster-describer.cpp
@@ -32,7 +32,7 @@ std::string monster_desc(PlayerType *player_ptr, MonsterEntity *m_ptr, BIT_FLAGS
     auto is_hallucinated = player_ptr->effects()->hallucination()->is_hallucinated();
     if (is_hallucinated && !(mode & MD_IGNORE_HALLU)) {
         if (one_in_(2)) {
-            if (!get_rnd_line(_("silly_j.txt", "silly.txt"), enum2i(m_ptr->r_idx), silly_name)) {
+            if (!get_random_line(_("silly_j.txt", "silly.txt"), enum2i(m_ptr->r_idx), silly_name)) {
                 named = true;
             }
         }

--- a/src/object-enchant/vorpal-weapon.cpp
+++ b/src/object-enchant/vorpal-weapon.cpp
@@ -63,7 +63,7 @@ static void print_chainsword_noise(ItemEntity *o_ptr)
     }
 
     char chainsword_noise[1024];
-    if (!get_rnd_line(_("chainswd_j.txt", "chainswd.txt"), 0, chainsword_noise)) {
+    if (!get_random_line(_("chainswd_j.txt", "chainswd.txt"), 0, chainsword_noise)) {
         msg_print(chainsword_noise);
     }
 }

--- a/src/object-enchant/vorpal-weapon.cpp
+++ b/src/object-enchant/vorpal-weapon.cpp
@@ -62,9 +62,9 @@ static void print_chainsword_noise(ItemEntity *o_ptr)
         return;
     }
 
-    char chainsword_noise[1024];
-    if (!get_random_line(_("chainswd_j.txt", "chainswd.txt"), 0, chainsword_noise)) {
-        msg_print(chainsword_noise);
+    const auto chainsword_noise = get_random_line(_("chainswd_j.txt", "chainswd.txt"), 0);
+    if (chainsword_noise.has_value()) {
+        msg_print(chainsword_noise.value());
     }
 }
 

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -482,19 +482,23 @@ int take_hit(PlayerType *player_ptr, int damage_type, int damage, concptr hit_fr
                 }
 
                 auto &death_message = opt_death_message.value();
+                constexpr auto max_last_words = 1024;
+                char player_last_words[max_last_words]{};
+                angband_strcpy(player_last_words, death_message.data(), max_last_words);
                 do {
 #ifdef JP
-                    while (!get_string(winning_seppuku ? "辞世の句: " : "断末魔の叫び: ", death_message.data(), death_message.length())) {
+                    while (!get_string(winning_seppuku ? "辞世の句: " : "断末魔の叫び: ", player_last_words, max_last_words)) {
                         ;
                     }
 #else
-                    while (!get_string("Last words: ", death_message.data(), 1024)) {
+                    while (!get_string("Last words: ", player_last_words, max_last_words)) {
                         ;
                     }
 #endif
                 } while (winning_seppuku && !get_check_strict(player_ptr, _("よろしいですか？", "Are you sure? "), CHECK_NO_HISTORY));
 
-                if (death_message[0] == '\0') {
+                death_message = player_last_words;
+                if (death_message.empty()) {
 #ifdef JP
                     death_message = format("あなたは%sました。", android ? "壊れ" : "死に");
 #else

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -476,9 +476,9 @@ int take_hit(PlayerType *player_ptr, int damage_type, int damage, concptr hit_fr
                 msg_print(nullptr);
             } else {
                 if (winning_seppuku) {
-                    get_rnd_line(_("seppuku_j.txt", "seppuku.txt"), 0, death_message);
+                    get_random_line(_("seppuku_j.txt", "seppuku.txt"), 0, death_message);
                 } else {
-                    get_rnd_line(_("death_j.txt", "death.txt"), 0, death_message);
+                    get_random_line(_("death_j.txt", "death.txt"), 0, death_message);
                 }
 
                 do {

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -73,6 +73,8 @@
 #include "util/string-processor.h"
 #include "view/display-messages.h"
 #include "world/world.h"
+#include <sstream>
+#include <string>
 
 using dam_func = int (*)(PlayerType *player_ptr, int dam, concptr kb_str, bool aura);
 
@@ -295,9 +297,6 @@ int cold_dam(PlayerType *player_ptr, int dam, concptr kb_str, bool aura)
 int take_hit(PlayerType *player_ptr, int damage_type, int damage, concptr hit_from)
 {
     int old_chp = player_ptr->chp;
-
-    char death_message[1024];
-
     int warning = (player_ptr->mhp * hitpoint_warn / 10);
     if (player_ptr->is_dead) {
         return 0;
@@ -475,19 +474,21 @@ int take_hit(PlayerType *player_ptr, int damage_type, int damage, concptr hit_fr
 
                 msg_print(nullptr);
             } else {
+                std::optional<std::string> opt_death_message;
                 if (winning_seppuku) {
-                    get_random_line(_("seppuku_j.txt", "seppuku.txt"), 0, death_message);
+                    opt_death_message = get_random_line(_("seppuku_j.txt", "seppuku.txt"), 0);
                 } else {
-                    get_random_line(_("death_j.txt", "death.txt"), 0, death_message);
+                    opt_death_message = get_random_line(_("death_j.txt", "death.txt"), 0);
                 }
 
+                auto &death_message = opt_death_message.value();
                 do {
 #ifdef JP
-                    while (!get_string(winning_seppuku ? "辞世の句: " : "断末魔の叫び: ", death_message, sizeof(death_message))) {
+                    while (!get_string(winning_seppuku ? "辞世の句: " : "断末魔の叫び: ", death_message.data(), death_message.length())) {
                         ;
                     }
 #else
-                    while (!get_string("Last words: ", death_message, 1024)) {
+                    while (!get_string("Last words: ", death_message.data(), 1024)) {
                         ;
                     }
 #endif
@@ -495,12 +496,12 @@ int take_hit(PlayerType *player_ptr, int damage_type, int damage, concptr hit_fr
 
                 if (death_message[0] == '\0') {
 #ifdef JP
-                    strcpy(death_message, format("あなたは%sました。", android ? "壊れ" : "死に").data());
+                    death_message = format("あなたは%sました。", android ? "壊れ" : "死に");
 #else
-                    strcpy(death_message, android ? "You are broken." : "You die.");
+                    death_message = android ? "You are broken." : "You die.";
 #endif
                 } else {
-                    player_ptr->last_message = string_make(death_message);
+                    player_ptr->last_message = string_make(death_message.data());
                 }
 
 #ifdef JP
@@ -510,9 +511,6 @@ int take_hit(PlayerType *player_ptr, int damage_type, int damage, concptr hit_fr
                     int h = game_term->hgt;
                     int msg_pos_x[9] = { 5, 7, 9, 12, 14, 17, 19, 21, 23 };
                     int msg_pos_y[9] = { 3, 4, 5, 4, 5, 4, 5, 6, 4 };
-                    concptr str;
-                    char *str2;
-
                     term_clear();
 
                     /* 桜散る */
@@ -520,12 +518,12 @@ int take_hit(PlayerType *player_ptr, int damage_type, int damage, concptr hit_fr
                         term_putstr(randint0(w / 2) * 2, randint0(h), 2, TERM_VIOLET, "υ");
                     }
 
-                    str = death_message;
+                    auto str = death_message.data();
                     if (strncmp(str, "「", 2) == 0) {
                         str += 2;
                     }
 
-                    str2 = angband_strstr(str, "」");
+                    auto *str2 = angband_strstr(str, "」");
                     if (str2 != nullptr) {
                         *str2 = '\0';
                     }
@@ -579,7 +577,11 @@ int take_hit(PlayerType *player_ptr, int damage_type, int damage, concptr hit_fr
                 hit_from = _("何か", "something");
             }
 
-            exe_write_diary(player_ptr, DIARY_DESCRIPTION, 0, std::string(_(hit_from, "was in a critical situation because of ")).append(_("によってピンチに陥った。", hit_from)).append(_("", ".")).data());
+            std::stringstream ss;
+            ss << _(hit_from, "was in a critical situation because of ");
+            ss << _("によってピンチに陥った。", hit_from);
+            ss << _("", ".");
+            exe_write_diary(player_ptr, DIARY_DESCRIPTION, 0, ss.str().data());
         }
 
         if (auto_more) {
@@ -632,7 +634,10 @@ static void process_aura_damage(MonsterEntity *m_ptr, PlayerType *player_ptr, bo
  */
 void touch_zap_player(MonsterEntity *m_ptr, PlayerType *player_ptr)
 {
-    process_aura_damage(m_ptr, player_ptr, has_immune_fire(player_ptr) != 0, MonsterAuraType::FIRE, fire_dam, _("突然とても熱くなった！", "You are suddenly very hot!"));
-    process_aura_damage(m_ptr, player_ptr, has_immune_cold(player_ptr) != 0, MonsterAuraType::COLD, cold_dam, _("突然とても寒くなった！", "You are suddenly very cold!"));
-    process_aura_damage(m_ptr, player_ptr, has_immune_elec(player_ptr) != 0, MonsterAuraType::ELEC, elec_dam, _("電撃をくらった！", "You get zapped!"));
+    constexpr auto fire_mes = _("突然とても熱くなった！", "You are suddenly very hot!");
+    constexpr auto cold_mes = _("突然とても寒くなった！", "You are suddenly very cold!");
+    constexpr auto elec_mes = _("電撃をくらった！", "You get zapped!");
+    process_aura_damage(m_ptr, player_ptr, has_immune_fire(player_ptr) != 0, MonsterAuraType::FIRE, fire_dam, fire_mes);
+    process_aura_damage(m_ptr, player_ptr, has_immune_cold(player_ptr) != 0, MonsterAuraType::COLD, cold_dam, cold_mes);
+    process_aura_damage(m_ptr, player_ptr, has_immune_elec(player_ptr) != 0, MonsterAuraType::ELEC, elec_dam, elec_mes);
 }

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -95,7 +95,7 @@ void display_rumor(PlayerType *player_ptr, bool ex)
 {
     char rumor[1024];
     int section = (ex && (randint0(3) == 0)) ? 1 : 0;
-    errr err = _(get_rnd_line_jonly("rumors_j.txt", section, rumor, 10), get_random_line("rumors.txt", section, rumor));
+    errr err = _(get_random_line_ja_only("rumors_j.txt", section, rumor, 10), get_random_line("rumors.txt", section, rumor));
     if (err) {
         strcpy(rumor, _("嘘の噂もある。", "Some rumors are wrong."));
     }

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -93,12 +93,23 @@ static std::pair<FixedArtifactId, const ArtifactType *> get_artifact_definition(
 
 void display_rumor(PlayerType *player_ptr, bool ex)
 {
-    char rumor[1024];
     int section = (ex && (randint0(3) == 0)) ? 1 : 0;
-    errr err = _(get_random_line_ja_only("rumors_j.txt", section, rumor, 10), get_random_line("rumors.txt", section, rumor));
+    char rumor[1024]{};
+
+    // @todo「嘘の噂もある。」は後で統合するため日英分離しない.
+#ifdef JP
+    auto tmp_rumor = get_random_line_ja_only("rumors_j.txt", section, 10);
+    if (tmp_rumor.has_value()) {
+        strcpy(rumor, tmp_rumor.value().data());
+    } else {
+        strcpy(rumor, _("嘘の噂もある。", "Some rumors are wrong."));
+    }
+#else
+    errr err = get_random_line("rumors.txt", section, rumor);
     if (err) {
         strcpy(rumor, _("嘘の噂もある。", "Some rumors are wrong."));
     }
+#endif
 
     if (strncmp(rumor, "R:", 2) != 0) {
         msg_format("%s", rumor);

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -101,12 +101,12 @@ void display_rumor(PlayerType *player_ptr, bool ex)
 #endif
     std::string rumor;
     if (opt_rumor.has_value()) {
-        rumor = opt_rumor.value().data();
+        rumor = std::move(opt_rumor.value());
     } else {
         rumor = _("嘘の噂もある。", "Some rumors are wrong.");
     }
 
-    if (strncmp(rumor.data(), "R:", 2) != 0) {
+    if (!rumor.starts_with("R:")) {
         msg_print(rumor);
         return;
     }

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -95,7 +95,7 @@ void display_rumor(PlayerType *player_ptr, bool ex)
 {
     char rumor[1024];
     int section = (ex && (randint0(3) == 0)) ? 1 : 0;
-    errr err = _(get_rnd_line_jonly("rumors_j.txt", section, rumor, 10), get_rnd_line("rumors.txt", section, rumor));
+    errr err = _(get_rnd_line_jonly("rumors_j.txt", section, rumor, 10), get_random_line("rumors.txt", section, rumor));
     if (err) {
         strcpy(rumor, _("嘘の噂もある。", "Some rumors are wrong."));
     }

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -94,25 +94,20 @@ static std::pair<FixedArtifactId, const ArtifactType *> get_artifact_definition(
 void display_rumor(PlayerType *player_ptr, bool ex)
 {
     int section = (ex && (randint0(3) == 0)) ? 1 : 0;
-    char rumor[1024]{};
-
-    // @todo「嘘の噂もある。」は後で統合するため日英分離しない.
 #ifdef JP
-    auto tmp_rumor = get_random_line_ja_only("rumors_j.txt", section, 10);
-    if (tmp_rumor.has_value()) {
-        strcpy(rumor, tmp_rumor.value().data());
-    } else {
-        strcpy(rumor, _("嘘の噂もある。", "Some rumors are wrong."));
-    }
+    auto opt_rumor = get_random_line_ja_only("rumors_j.txt", section, 10);
 #else
-    errr err = get_random_line("rumors.txt", section, rumor);
-    if (err) {
-        strcpy(rumor, _("嘘の噂もある。", "Some rumors are wrong."));
-    }
+    auto opt_rumor = get_random_line("rumors.txt", section);
 #endif
+    std::string rumor;
+    if (opt_rumor.has_value()) {
+        rumor = opt_rumor.value().data();
+    } else {
+        rumor = _("嘘の噂もある。", "Some rumors are wrong.");
+    }
 
-    if (strncmp(rumor, "R:", 2) != 0) {
-        msg_format("%s", rumor);
+    if (strncmp(rumor.data(), "R:", 2) != 0) {
+        msg_print(rumor);
         return;
     }
 


### PR DESCRIPTION
掲題の通りです
一部「行が見つからない」というエラーパターンもあるようなので、その時はnulloptを返すように調整しました
ご確認下さい