### PR TITLE
[Fix] モンスターの死体や骨が正しく表示されない

### DIFF
--- a/src/flavor/tval-description-switcher.cpp
+++ b/src/flavor/tval-description-switcher.cpp
@@ -79,7 +79,7 @@ static std::pair<std::string, std::string> describe_corpse(const ItemEntity &ite
             ? "& % of #"
             : "& # %";
 #endif
-    return { modstr, basename };
+    return { basename, modstr };
 }
 
 /*!


### PR DESCRIPTION
describe_flavor をリファクタリングした時に basename と modstr の順序が誤って逆に なっていた。正しい順序に修正する。

Resolves #3014 
なんというポカ。