### PR TITLE
[Refactor/Feature] format/strnfmt の機能整理/コード整形

### DIFF
--- a/src/term/z-form.cpp
+++ b/src/term/z-form.cpp
@@ -66,10 +66,18 @@
  * Format("%g", double r)
  *   Append the double "r", in various formats.
  *
+ * Format("%LE", long double r)
+ * Format("%LF", long double r)
+ * Format("%LG", long double r)
+ * Format("%Le", long double r)
+ * Format("%Lf", long double r)
+ * Format("%Lg", long double r)
+ *   Append the long double "r", in various formats.
+ *
  * Format("%ld", long int i)
  *   Append the long integer "i".
  *
- * Format("%Ld", long long int i)
+ * Format("%lld", long long int i)
  *   Append the long long integer "i".
  *
  * Format("%d", int i)
@@ -78,7 +86,7 @@
  * Format("%lu", unsigned long int i)
  *   Append the unsigned long integer "i".
  *
- * Format("%Lu", unsigned long long int i)
+ * Format("%llu", unsigned long long int i)
  *   Append the unsigned long long integer "i".
  *
  * Format("%u", unsigned int i)
@@ -230,6 +238,7 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
 
         auto do_long = false;
         auto do_long_long = false;
+        auto do_long_double = false;
         auto do_capitalize = false;
 
         /* Format sequence */
@@ -252,17 +261,21 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
             }
 
             if (isalpha(*s)) {
-                /* handle "long" request */
+                /* handle "long" or "long long" request */
                 if (*s == 'l') {
                     aux.push_back(*s++);
-                    do_long = true;
+                    if (*s == 'l') {
+                        aux.push_back(*s++);
+                        do_long_long = true;
+                    } else {
+                        do_long = true;
+                    }
                 }
 
-                /* handle "extra-long" request */
+                /* handle "long double" request */
                 else if (*s == 'L') {
-                    aux.append("ll");
-                    do_long_long = true;
-                    s++;
+                    aux.push_back(*s++);
+                    do_long_double = true;
                 }
 
                 /* Handle normal end of format sequence */
@@ -344,8 +357,13 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
         case 'E':
         case 'g':
         case 'G': {
-            auto arg = va_arg(vp, double);
-            snprintf(tmp, sizeof(tmp), aux.data(), arg);
+            if (do_long_double) {
+                auto arg = va_arg(vp, long double);
+                snprintf(tmp, sizeof(tmp), aux.data(), arg);
+            } else {
+                auto arg = va_arg(vp, double);
+                snprintf(tmp, sizeof(tmp), aux.data(), arg);
+            }
             break;
         }
 

--- a/src/term/z-form.cpp
+++ b/src/term/z-form.cpp
@@ -25,9 +25,7 @@
  * of the resulting string, not including the (mandatory) terminator.
  *
  * The format strings allow the basic "sprintf()" format sequences, though
- * some of them are processed slightly more carefully or portably, as well
- * as a few "special" sequences, including the "%r" and "%v" sequences, and
- * the "capilitization" sequences of "%C", "%S", and "%V".
+ * some of them are processed slightly more carefully or portably.
  *
  * Note that some "limitations" are enforced by the current implementation,
  * for example, no "format sequence" can exceed 100 characters, including any
@@ -45,7 +43,7 @@
  * removed from the "format sequence", and replaced by the textual form
  * of the next argument in the argument list.  See examples below.
  *
- * Legal format characters: %,n,p,c,s,d,i,o,u,X,x,E,e,F,f,G,g,r,v.
+ * Legal format characters: %,n,p,c,s,d,i,o,u,X,x,E,e,F,f,G,g.
  *
  * Format("%%")
  *   Append the literal "%".
@@ -110,16 +108,6 @@
  *   Do not use the "+" or "0" flags.
  *   Note that a "nullptr" value of "s" is converted to the empty string.
  *
- * Format("%V", vptr v)
- *   Note -- possibly significant mode flag
- * Format("%v", vptr v)
- *   Append the object "v", using the current "user defined print routine".
- *   User specified modifiers, often ignored.
- *
- * Format("%r", vstrnfmt_aux_func *fp)
- *   Set the "user defined print routine" (vstrnfmt_aux) to "fp".
- *   No legal modifiers.
- *
  *
  * For examples below, assume "int n = 0; int m = 100; char buf[100];",
  * plus "char *s = nullptr;", and unknown values "char *txt; int i;".
@@ -139,49 +127,10 @@
  * For example: "s = buf; n = vstrnfmt(s+n, 100-n, ...); ..." will allow
  * multiple bounded "appends" to "buf", with constant access to "strlen(buf)".
  *
- * For example: "format("The %r%v was destroyed!", obj_desc, obj);"
- * (where "obj_desc(buf, max, fmt, obj)" will "append" a "description"
- * of the given object to the given buffer, and return the total length)
- * will return a "useful message" about the object "obj", for example,
- * "The Large Shield was destroyed!".
- *
  * For example: "format("%^-.*s", i, txt)" will produce a string containing
  * the first "i" characters of "txt", left justified, with the first non-space
  * character capitilized, if reasonable.
  */
-
-/*
- * The "type" of the "user defined print routine" pointer
- */
-typedef uint (*vstrnfmt_aux_func)(char *buf, uint max, concptr fmt, vptr arg);
-
-/*
- * The "default" user defined print routine.  Ignore the "fmt" string.
- */
-static uint vstrnfmt_aux_dflt(char *buf, uint max, concptr fmt, vptr arg)
-{
-    uint len;
-    char tmp[32];
-
-    /* XXX XXX */
-    fmt = fmt ? fmt : 0;
-
-    /* Pointer display */
-    snprintf(tmp, sizeof(tmp), "<<%p>>", arg);
-    len = strlen(tmp);
-    if (len >= max) {
-        len = max - 1;
-    }
-    tmp[len] = '\0';
-    strcpy(buf, tmp);
-    return len;
-}
-
-/*
- * The "current" user defined print routine.  It can be changed
- * dynamically by sending the proper "%r" sequence to "vstrnfmt()"
- */
-static vstrnfmt_aux_func vstrnfmt_aux = vstrnfmt_aux_dflt;
 
 /*
  * Basic "vararg" format function.
@@ -322,16 +271,6 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
             (*arg) = n;
 
             /* Skip the "n" */
-            s++;
-            continue;
-        }
-
-        /* Hack -- Pre-process "%r" */
-        if (*s == 'r') {
-            /* Extract the next argument, and save it (globally) */
-            vstrnfmt_aux = va_arg(vp, vstrnfmt_aux_func);
-
-            /* Skip the "r" */
             s++;
             continue;
         }
@@ -526,6 +465,7 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
 
         /* Floating Point -- various formats */
         case 'f':
+        case 'F':
         case 'e':
         case 'E':
         case 'g':
@@ -572,20 +512,6 @@ uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp)
             arg2[1023] = '\0';
 
             /* Format the argument */
-            snprintf(tmp, sizeof(tmp), aux, arg);
-
-            break;
-        }
-
-        /* User defined data */
-        case 'V':
-        case 'v': {
-            vptr arg;
-
-            /* Access next argument */
-            arg = va_arg(vp, vptr);
-
-            /* Format the "user data" */
             snprintf(tmp, sizeof(tmp), aux, arg);
 
             break;

--- a/src/view/display-lore.cpp
+++ b/src/view/display-lore.cpp
@@ -442,9 +442,9 @@ void display_monster_exp(PlayerType *player_ptr, lore_type *lore_ptr)
     int64_t exp_decimal = ((base_exp % player_factor * 1000 / player_factor) + 5) / 10;
 
 #ifdef JP
-    hooked_roff(format(" %d レベルのキャラクタにとって 約%Ld.%02Ld ポイントの経験となる。", player_ptr->lev, exp_integer, exp_decimal));
+    hooked_roff(format(" %d レベルのキャラクタにとって 約%lld.%02lld ポイントの経験となる。", player_ptr->lev, exp_integer, exp_decimal));
 #else
-    hooked_roff(format(" is worth about %Ld.%02Ld point%s", exp_integer, exp_decimal, ((exp_integer == 1) && (exp_decimal == 0)) ? "" : "s"));
+    hooked_roff(format(" is worth about %lld.%02lld point%s", exp_integer, exp_decimal, ((exp_integer == 1) && (exp_decimal == 0)) ? "" : "s"));
 
     concptr ordinal;
     switch (player_ptr->lev % 10) {


### PR DESCRIPTION
#2990 に関して、ひとまず使える書式の整理と vstrnfmt 関数がだいぶ読みづらかったのでコードの整形を行いました。
内容についてはコミットログを参照してください。

`__attribute__ format` でチェックを行う件と `%^s` の書式の件については別 PR にて処理したいと思います。