### PR TITLE
[Fix] __attribute__((format)) による警告に対応

### DIFF
--- a/src/action/activation-execution.cpp
+++ b/src/action/activation-execution.cpp
@@ -190,7 +190,7 @@ static bool activate_artifact(PlayerType *player_ptr, ItemEntity *o_ptr)
     case RandomArtActType::MURAMASA:
         return true;
     default:
-        msg_format("Special timeout is not implemented: %d.", act_ptr->index);
+        msg_format("Special timeout is not implemented: %d.", enum2i(act_ptr->index));
         return false;
     }
 }

--- a/src/action/movement-execution.cpp
+++ b/src/action/movement-execution.cpp
@@ -228,17 +228,17 @@ void exe_movement(PlayerType *player_ptr, DIRECTION dir, bool do_pickup, bool br
         } else if (f_ptr->flags.has(TerrainCharacteristics::CAN_SWIM) && (riding_r_ptr->feature_flags.has(MonsterFeatureType::CAN_SWIM))) {
             /* Allow moving */
         } else if (f_ptr->flags.has(TerrainCharacteristics::WATER) && riding_r_ptr->feature_flags.has_not(MonsterFeatureType::AQUATIC) && (f_ptr->flags.has(TerrainCharacteristics::DEEP) || riding_r_ptr->aura_flags.has(MonsterAuraType::FIRE))) {
-            msg_format(_("%sの上に行けない。", "Can't swim."), terrains_info[g_ptr->get_feat_mimic()].name.data());
+            msg_print(_(format("%sの上に行けない。", terrains_info[g_ptr->get_feat_mimic()].name.data()), "Can't swim."));
             energy.reset_player_turn();
             can_move = false;
             disturb(player_ptr, false, true);
         } else if (f_ptr->flags.has_not(TerrainCharacteristics::WATER) && riding_r_ptr->feature_flags.has(MonsterFeatureType::AQUATIC)) {
-            msg_format(_("%sから上がれない。", "Can't land."), terrains_info[floor_ptr->grid_array[player_ptr->y][player_ptr->x].get_feat_mimic()].name.data());
+            msg_print(_(format("%sから上がれない。", terrains_info[floor_ptr->grid_array[player_ptr->y][player_ptr->x].get_feat_mimic()].name.data()), "Can't land."));
             energy.reset_player_turn();
             can_move = false;
             disturb(player_ptr, false, true);
         } else if (f_ptr->flags.has(TerrainCharacteristics::LAVA) && riding_r_ptr->resistance_flags.has_none_of(RFR_EFF_IM_FIRE_MASK)) {
-            msg_format(_("%sの上に行けない。", "Too hot to go through."), terrains_info[g_ptr->get_feat_mimic()].name.data());
+            msg_print(_(format("%sの上に行けない。", terrains_info[g_ptr->get_feat_mimic()].name.data()), "Too hot to go through."));
             energy.reset_player_turn();
             can_move = false;
             disturb(player_ptr, false, true);

--- a/src/action/mutation-execution.cpp
+++ b/src/action/mutation-execution.cpp
@@ -298,7 +298,7 @@ bool exe_mutation_power(PlayerType *player_ptr, PlayerMutationType power)
     }
     default:
         PlayerEnergy(player_ptr).reset_player_turn();
-        msg_format(_("能力 %s は実装されていません。", "Power %s not implemented. Oops."), power);
+        msg_format(_("能力 PlayerMutationType::%d は実装されていません。", "Power PlayerMutationType::%d not implemented. Oops."), enum2i(power));
         return true;
     }
 }

--- a/src/artifact/random-art-generator.cpp
+++ b/src/artifact/random-art-generator.cpp
@@ -412,7 +412,7 @@ static void generate_unnatural_random_artifact(
 {
     o_ptr->randart_name = name_unnatural_random_artifact(player_ptr, o_ptr, a_scroll, power_level);
     msg_format_wizard(player_ptr, CHEAT_OBJECT,
-        _("パワー %d で 価値%ld のランダムアーティファクト生成 バイアスは「%s」", "Random artifact generated - Power:%d Value:%d Bias:%s."), max_powers,
+        _("パワー %d で 価値 %d のランダムアーティファクト生成 バイアスは「%s」", "Random artifact generated - Power:%d Value:%d Bias:%s."), max_powers,
         total_flags, artifact_bias_name[o_ptr->artifact_bias]);
     set_bits(player_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_FLOOR_ITEM_LIST | PW_FOUND_ITEM_LIST);
 }

--- a/src/birth/birth-wizard.cpp
+++ b/src/birth/birth-wizard.cpp
@@ -403,9 +403,9 @@ static bool display_auto_roller_count(PlayerType *player_ptr, const int col)
 
     birth_put_stats(player_ptr);
     if (auto_upper_round) {
-        put_str(format("%ld%09ld", auto_upper_round, auto_round), 10, col + 20);
+        put_str(format("%d%09d", auto_upper_round, auto_round), 10, col + 20);
     } else {
-        put_str(format("%10ld", auto_round), 10, col + 20);
+        put_str(format("%10d", auto_round), 10, col + 20);
     }
     term_fresh();
     inkey_scan = true;

--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -183,7 +183,7 @@ bool do_cmd_attack(PlayerType *player_ptr, POSITION y, POSITION x, combat_option
 
     if (!can_attack_with_main_hand(player_ptr) && !can_attack_with_sub_hand(player_ptr) && player_ptr->muta.has_none_of(mutation_attack_methods)) {
         sound(SOUND_ATTACK_FAILED);
-        msg_format(_("%s攻撃できない。", "You cannot attack."), (empty_hands(player_ptr, false) == EMPTY_HAND_NONE) ? _("両手がふさがって", "") : "");
+        msg_print(_(format("%s攻撃できない。", (empty_hands(player_ptr, false) == EMPTY_HAND_NONE) ? "両手がふさがって" : ""), "You cannot attack."));
         return false;
     }
 

--- a/src/cmd-action/cmd-mind.cpp
+++ b/src/cmd-action/cmd-mind.cpp
@@ -239,7 +239,7 @@ static void check_mind_mindcrafter(PlayerType *player_ptr, cm_type *cm_ptr)
         return;
     }
 
-    msg_format(_("%sの力が制御できない氾流となって解放された！", "Your mind unleashes its power in an uncontrollable storm!"), cm_ptr->mind_explanation);
+    msg_print(_(format("%sの力が制御できない氾流となって解放された！", cm_ptr->mind_explanation), "Your mind unleashes its power in an uncontrollable storm!"));
     project(player_ptr, PROJECT_WHO_UNCTRL_POWER, 2 + cm_ptr->plev / 10, player_ptr->y, player_ptr->x, cm_ptr->plev * 2, AttributeType::MANA,
         PROJECT_JUMP | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM);
     player_ptr->csp = std::max(0, player_ptr->csp - cm_ptr->plev * std::max(1, cm_ptr->plev / 10));
@@ -267,7 +267,7 @@ static void check_mind_mirror_master(PlayerType *player_ptr, cm_type *cm_ptr)
         return;
     }
 
-    msg_format(_("%sの力が制御できない氾流となって解放された！", "Your mind unleashes its power in an uncontrollable storm!"), cm_ptr->mind_explanation);
+    msg_print(_(format("%sの力が制御できない氾流となって解放された！", cm_ptr->mind_explanation), "Your mind unleashes its power in an uncontrollable storm!"));
     project(player_ptr, PROJECT_WHO_UNCTRL_POWER, 2 + cm_ptr->plev / 10, player_ptr->y, player_ptr->x, cm_ptr->plev * 2, AttributeType::MANA,
         PROJECT_JUMP | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM);
     player_ptr->csp = std::max(0, player_ptr->csp - cm_ptr->plev * std::max(1, cm_ptr->plev / 10));
@@ -316,7 +316,7 @@ static bool switch_mind_class(PlayerType *player_ptr, cm_type *cm_ptr)
         cm_ptr->cast = cast_ninja_spell(player_ptr, i2enum<MindNinjaType>(cm_ptr->n));
         return true;
     default:
-        msg_format(_("謎の能力:%d, %d", "Mystery power:%d, %d"), cm_ptr->use_mind, cm_ptr->n);
+        msg_format(_("謎の能力:%d, %d", "Mystery power:%d, %d"), enum2i(cm_ptr->use_mind), cm_ptr->n);
         return false;
     }
 }
@@ -359,7 +359,7 @@ static void mind_reflection(PlayerType *player_ptr, cm_type *cm_ptr)
     }
 
     player_ptr->csp = std::max(0, player_ptr->csp - cm_ptr->mana_cost);
-    msg_format(_("%sを集中しすぎて気を失ってしまった！", "You faint from the effort!"), cm_ptr->mind_explanation);
+    msg_print(_(format("%sを集中しすぎて気を失ってしまった！", cm_ptr->mind_explanation), "You faint from the effort!"));
     (void)BadStatusSetter(player_ptr).mod_paralysis(randint1(5 * oops + 1));
     if (randint0(100) >= 50) {
         return;

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -115,7 +115,7 @@ void do_cmd_pet_dismiss(PlayerType *player_ptr)
             health_track(player_ptr, pet_ctr);
             handle_stuff(player_ptr);
 
-            msg_format(_("%sを放しますか？ [Yes/No/Unnamed (%d体)]", "Dismiss %s? [Yes/No/Unnamed (%d remain)]"), friend_name.data(), who.size() - i);
+            msg_format(_("%sを放しますか？ [Yes/No/Unnamed (%lu体)]", "Dismiss %s? [Yes/No/Unnamed (%lu remain)]"), friend_name.data(), who.size() - i);
 
             if (m_ptr->ml) {
                 move_cursor_relative(m_ptr->fy, m_ptr->fx);

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -135,7 +135,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
                 }
 
                 auto_dump_printf(auto_dump_stream, "# %s\n", r_ref.name.data());
-                auto_dump_printf(auto_dump_stream, "R:%d:0x%02X/0x%02X\n\n", r_ref.idx, (byte)(r_ref.x_attr), (byte)(r_ref.x_char));
+                auto_dump_printf(auto_dump_stream, "R:%d:0x%02X/0x%02X\n\n", enum2i(r_ref.idx), (byte)(r_ref.x_attr), (byte)(r_ref.x_char));
             }
 
             close_auto_dump(&auto_dump_stream, mark);
@@ -232,7 +232,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
                 TERM_COLOR ca = r_ptr->x_attr;
                 byte cc = r_ptr->x_char;
 
-                term_putstr(5, 17, -1, TERM_WHITE, format(_("モンスター = %d, 名前 = %-40.40s", "Monster = %d, Name = %-40.40s"), r, r_ptr->name.data()));
+                term_putstr(5, 17, -1, TERM_WHITE, format(_("モンスター = %d, 名前 = %-40.40s", "Monster = %d, Name = %-40.40s"), enum2i(r), r_ptr->name.data()));
                 term_putstr(10, 19, -1, TERM_WHITE, format(_("初期値  色 / 文字 = %3u / %3u", "Default attr/char = %3u / %3u"), da, dc));
                 term_putstr(40, 19, -1, TERM_WHITE, empty_symbol);
                 term_queue_bigchar(43, 19, da, dc, 0, 0);

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -88,7 +88,7 @@ static void process_fishing(PlayerType *player_ptr)
             x = player_ptr->x + ddx[player_ptr->fishing_dir];
             if (place_monster_aux(player_ptr, 0, y, x, r_idx, PM_NO_KAGE)) {
                 const auto m_name = monster_desc(player_ptr, &floor_ptr->m_list[floor_ptr->grid_array[y][x].m_idx], 0);
-                msg_format(_("%sが釣れた！", "You have a good catch!"), m_name.data());
+                msg_print(_(format("%sが釣れた！", m_name.data()), "You have a good catch!"));
                 success = true;
             }
         }

--- a/src/effect/effect-monster-charm.cpp
+++ b/src/effect/effect-monster-charm.cpp
@@ -426,7 +426,7 @@ static void effect_monster_captured(PlayerType *player_ptr, effect_monster_type 
     cap_mon_ptr->max_hp = static_cast<short>(em_ptr->m_ptr->max_maxhp);
     cap_mon_ptr->nickname = em_ptr->m_ptr->nickname;
     if ((em_ptr->g_ptr->m_idx == player_ptr->riding) && process_fall_off_horse(player_ptr, -1, false)) {
-        msg_format(_("地面に落とされた。", "You have fallen from %s."), em_ptr->m_name);
+        msg_print(_("地面に落とされた。", format("You have fallen from %s.", em_ptr->m_name)));
     }
 
     delete_monster_idx(player_ptr, em_ptr->g_ptr->m_idx);
@@ -465,7 +465,7 @@ ProcessResult effect_monster_capture(PlayerType *player_ptr, effect_monster_type
     auto capturable_hp = std::max(2, calcutate_capturable_hp(player_ptr, em_ptr->m_ptr, em_ptr->m_ptr->max_maxhp));
 
     if (threshold_hp < 2 || em_ptr->m_ptr->hp >= capturable_hp) {
-        msg_format(_("もっと弱らせないと。", "You need to weaken %s more."), em_ptr->m_name);
+        msg_print(_("もっと弱らせないと。", format("You need to weaken %s more.", em_ptr->m_name)));
         em_ptr->skipped = true;
         return ProcessResult::PROCESS_CONTINUE;
     }
@@ -475,7 +475,7 @@ ProcessResult effect_monster_capture(PlayerType *player_ptr, effect_monster_type
         return ProcessResult::PROCESS_TRUE;
     }
 
-    msg_format(_("うまく捕まえられなかった。", "You failed to capture %s."), em_ptr->m_name);
+    msg_print(_("うまく捕まえられなかった。", format("You failed to capture %s.", em_ptr->m_name)));
     em_ptr->skipped = true;
     return ProcessResult::PROCESS_CONTINUE;
 }

--- a/src/effect/effect-monster-oldies.cpp
+++ b/src/effect/effect-monster-oldies.cpp
@@ -79,7 +79,7 @@ ProcessResult effect_monster_star_heal(PlayerType *player_ptr, effect_monster_ty
 
     if (em_ptr->m_ptr->maxhp < em_ptr->m_ptr->max_maxhp) {
         if (em_ptr->seen_msg) {
-            msg_format(_("%s^の強さが戻った。", "%s^ recovers %s vitality."), em_ptr->m_name, em_ptr->m_poss);
+            msg_print(_(format("%s^の強さが戻った。", em_ptr->m_name), format("%s^ recovers %s vitality.", em_ptr->m_name, em_ptr->m_poss)));
         }
         em_ptr->m_ptr->maxhp = em_ptr->m_ptr->max_maxhp;
     }
@@ -146,7 +146,7 @@ static void effect_monster_old_heal_recovery(PlayerType *player_ptr, effect_mons
 
     if (em_ptr->m_ptr->is_fearful()) {
         if (em_ptr->seen_msg) {
-            msg_format(_("%s^は勇気を取り戻した。", "%s^ recovers %s courage."), em_ptr->m_name, em_ptr->m_poss);
+            msg_print(_(format("%s^は勇気を取り戻した。", em_ptr->m_name), format("%s^ recovers %s courage.", em_ptr->m_name, em_ptr->m_poss)));
         }
 
         (void)set_monster_monfear(player_ptr, em_ptr->g_ptr->m_idx, 0);

--- a/src/effect/effect-player.cpp
+++ b/src/effect/effect-player.cpp
@@ -213,7 +213,7 @@ bool affect_player(MONSTER_IDX who, PlayerType *player_ptr, concptr who_name, in
     SpellHex(player_ptr).store_vengeful_damage(ep_ptr->get_damage);
     if ((player_ptr->tim_eyeeye || SpellHex(player_ptr).is_spelling_specific(HEX_EYE_FOR_EYE)) && (ep_ptr->get_damage > 0) && !player_ptr->is_dead && (ep_ptr->who > 0)) {
         const auto m_name_self = monster_desc(player_ptr, ep_ptr->m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE | MD_OBJECTIVE);
-        msg_format(_("攻撃が%s自身を傷つけた！", "The attack of %s has wounded %s!"), ep_ptr->m_name, m_name_self.data());
+        msg_print(_(format("攻撃が%s自身を傷つけた！", ep_ptr->m_name), format("The attack of %s has wounded %s!", ep_ptr->m_name, m_name_self.data())));
         (*project)(player_ptr, 0, 0, ep_ptr->m_ptr->fy, ep_ptr->m_ptr->fx, ep_ptr->get_damage, AttributeType::MISSILE, PROJECT_KILL, std::nullopt);
         if (player_ptr->tim_eyeeye) {
             set_tim_eyeeye(player_ptr, player_ptr->tim_eyeeye - 5, true);

--- a/src/flavor/named-item-describer.cpp
+++ b/src/flavor/named-item-describer.cpp
@@ -143,7 +143,7 @@ static std::optional<std::string> describe_random_artifact_name_after_body_ja(co
 
     // "'foobar'" の foobar の部分を取り出し『foobar』と表記する
     // (英語版のセーブファイルのランダムアーティファクトを考慮)
-    return format("『%s』", name_sv.substr(1, name_sv.length() - 2));
+    return format("『%s』", name_sv.substr(1, name_sv.length() - 2).data());
 }
 
 static std::string describe_fake_artifact_name_after_body_ja(const ItemEntity &item)

--- a/src/io/read-pref-file.h
+++ b/src/io/read-pref-file.h
@@ -11,7 +11,7 @@ errr process_autopick_file(PlayerType *player_ptr, concptr name);
 errr process_histpref_file(PlayerType *player_ptr, concptr name);
 bool read_histpref(PlayerType *player_ptr);
 
-void auto_dump_printf(FILE *auto_dump_stream, concptr fmt, ...);
+void auto_dump_printf(FILE *auto_dump_stream, concptr fmt, ...) __attribute__((format(printf, 2, 3)));
 bool open_auto_dump(FILE **fpp, concptr buf, concptr mark);
 void close_auto_dump(FILE **fpp, concptr auto_dump_mark);
 

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -266,7 +266,7 @@ static void display_monster_list(int col, int row, int per_page, const std::vect
         }
 
         if (w_ptr->wizard || visual_only) {
-            c_prt(attr, format("%d", r_idx), row + i, 62);
+            c_prt(attr, format("%d", enum2i(r_idx)), row + i, 62);
         }
 
         term_erase(69, row + i, 255);
@@ -397,7 +397,7 @@ void do_cmd_knowledge_monsters(PlayerType *player_ptr, bool *need_redraw, bool v
             display_visual_list(max + 3, 7, browser_rows - 1, wid - (max + 3), attr_top, char_left);
         }
 
-        prt(format(_("%d 種", "%d Races"), r_idx_list.size()), 3, 26);
+        prt(format(_("%lu 種", "%lu Races"), r_idx_list.size()), 3, 26);
         prt(format(_("<方向>%s%s%s, ESC", "<dir>%s%s%s, ESC"), (!visual_list && !visual_only) ? _(", 'r'で思い出を見る", ", 'r' to recall") : "",
                 visual_list ? _(", ENTERで決定", ", ENTER to accept") : _(", 'v'でシンボル変更", ", 'v' for visuals"),
                 (attr_idx || char_idx) ? _(", 'c', 'p'でペースト", ", 'c', 'p' to paste") : _(", 'c'でコピー", ", 'c' to copy")),

--- a/src/load/info-loader.cpp
+++ b/src/load/info-loader.cpp
@@ -60,7 +60,7 @@ void rd_version_info(void)
         }
     }
 
-    load_note(format(_("バージョン %d.%d.%d のセーブデータ(SAVE%lu形式)をロード中...", "Loading a version %d.%d.%d savefile (SAVE%lu format)..."),
+    load_note(format(_("バージョン %d.%d.%d のセーブデータ(SAVE%u形式)をロード中...", "Loading a version %d.%d.%d savefile (SAVE%u format)..."),
         w_ptr->h_ver_major, w_ptr->h_ver_minor, w_ptr->h_ver_patch,
         loading_savefile_version));
 }

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -440,7 +440,7 @@ bool load_savedata(PlayerType *player_ptr, bool *new_game)
     }
 
     if (err) {
-        msg_format(_("エラー(%s)がバージョン%d.%d.%d.%d 用セーブファイル読み込み中に発生。", "Error (%s) reading %d.%d.%d.% savefile."), what,
+        msg_format(_("エラー(%s)がバージョン %d.%d.%d.%d 用セーブファイル読み込み中に発生。", "Error (%s) reading %d.%d.%d.%d savefile."), what,
             w_ptr->h_ver_major, w_ptr->h_ver_minor, w_ptr->h_ver_patch, w_ptr->h_ver_extra);
         msg_print(nullptr);
         return false;

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -97,7 +97,7 @@ static errr init_info(std::string_view filename, angband_header &head, InfoType 
 
     auto *fp = angband_fopen(buf, "r");
     if (!fp) {
-        quit_fmt(_("'%s'ファイルをオープンできません。", "Cannot open '%s' file."), filename);
+        quit_fmt(_("'%s'ファイルをオープンできません。", "Cannot open '%s' file."), filename.data());
     }
 
     constexpr auto info_is_vector = is_vector_v<InfoType>;
@@ -111,14 +111,14 @@ static errr init_info(std::string_view filename, angband_header &head, InfoType 
     if (err) {
         const auto oops = (((err > 0) && (err < PARSE_ERROR_MAX)) ? err_str[err] : _("未知の", "unknown"));
 #ifdef JP
-        msg_format("'%s'ファイルの %d 行目にエラー。", filename, error_line);
+        msg_format("'%s'ファイルの %d 行目にエラー。", filename.data(), error_line);
 #else
-        msg_format("Error %d at line %d of '%s'.", err, error_line, filename);
+        msg_format("Error %d at line %d of '%s'.", err, error_line, filename.data());
 #endif
         msg_format(_("レコード %d は '%s' エラーがあります。", "Record %d contains a '%s' error."), error_idx, oops);
         msg_format(_("構文 '%s'。", "Parsing '%s'."), buf);
         msg_print(nullptr);
-        quit_fmt(_("'%s'ファイルにエラー", "Error in '%s' file."), filename);
+        quit_fmt(_("'%s'ファイルにエラー", "Error in '%s' file."), filename.data());
     }
 
     if constexpr (info_is_vector) {

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -162,10 +162,10 @@ bool exchange_cash(PlayerType *player_ptr)
             chg_virtue(player_ptr, V_JUSTICE, 5);
             is_achieved = true;
 
-            auto num = std::count_if(std::begin(w_ptr->bounties), std::end(w_ptr->bounties),
-                [](const auto &b_ref) { return b_ref.is_achieved; });
+            auto num = static_cast<int>(std::count_if(std::begin(w_ptr->bounties), std::end(w_ptr->bounties),
+                [](const auto &b_ref) { return b_ref.is_achieved; }));
 
-            msg_format(_("これで合計 %d ポイント獲得しました。", "You earned %d point%s total."), num, (num > 1 ? "s" : ""));
+            msg_print(_(format("これで合計 %d ポイント獲得しました。", num), format("You earned %d point%s total.", num, (num > 1 ? "s" : ""))));
 
             (&forge)->prep(lookup_baseitem_id(prize_list[num - 1]));
             ItemMagicApplier(player_ptr, &forge, player_ptr->current_floor_ptr->object_level, AM_NO_FIXED_ART).execute();

--- a/src/mind/mind-archer.cpp
+++ b/src/mind/mind-archer.cpp
@@ -134,7 +134,7 @@ bool create_ammo(PlayerType *player_ptr)
         int16_t slot = store_item_to_inventory(player_ptr, q_ptr);
         GAME_TEXT o_name[MAX_NLEN];
         describe_flavor(player_ptr, o_name, q_ptr, 0);
-        msg_format(_("%sを作った。", "You make some ammo."), o_name);
+        msg_print(_(format("%sを作った。", o_name), "You make some ammo."));
         if (slot >= 0) {
             autopick_alter_item(player_ptr, slot, false);
         }
@@ -162,7 +162,7 @@ bool create_ammo(PlayerType *player_ptr)
         q_ptr->discount = 99;
         GAME_TEXT o_name[MAX_NLEN];
         describe_flavor(player_ptr, o_name, q_ptr, 0);
-        msg_format(_("%sを作った。", "You make some ammo."), o_name);
+        msg_print(_(format("%sを作った。", o_name), "You make some ammo."));
         vary_item(player_ptr, item, -1);
         int16_t slot = store_item_to_inventory(player_ptr, q_ptr);
         if (slot >= 0) {
@@ -190,7 +190,7 @@ bool create_ammo(PlayerType *player_ptr)
         q_ptr->discount = 99;
         GAME_TEXT o_name[MAX_NLEN];
         describe_flavor(player_ptr, o_name, q_ptr, 0);
-        msg_format(_("%sを作った。", "You make some ammo."), o_name);
+        msg_print(_(format("%sを作った。", o_name), "You make some ammo."));
         vary_item(player_ptr, item, -1);
         int16_t slot = store_item_to_inventory(player_ptr, q_ptr);
         if (slot >= 0) {

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -1303,7 +1303,7 @@ void switch_element_racial(PlayerType *player_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_CLASS_1);
         break;
     case ElementRealmType::DARKNESS:
-        rpi = rpi_type(format(_("闇の扉", "Door to darkness"), 15 + plev / 2));
+        rpi = rpi_type(_("闇の扉", "Door to darkness"));
         rpi.info = format("%s%d", KWD_SPHERE, 15 + plev / 2);
         rpi.min_level = 5;
         rpi.cost = 5 + plev / 7;

--- a/src/mind/mind-mage.cpp
+++ b/src/mind/mind-mage.cpp
@@ -164,7 +164,7 @@ bool eat_magic(PlayerType *player_ptr, int power)
 
     if (fail_type == 1) {
         if (tval == ItemKindType::ROD) {
-            msg_format(_("ロッドは破損を免れたが、魔力は全て失なわれた。", "You save your rod from destruction, but all charges are lost."), o_name);
+            msg_print(_("ロッドは破損を免れたが、魔力は全て失なわれた。", "You save your rod from destruction, but all charges are lost."));
             o_ptr->timeout = baseitem.pval * o_ptr->number;
         } else if (tval == ItemKindType::WAND) {
             msg_format(_("%sは破損を免れたが、魔力が全て失われた。", "You save your %s from destruction, but all charges are lost."), o_name);

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -90,7 +90,7 @@ void MonsterAttackPlayer::make_attack_normal()
     angband_strcpy(this->m_name, monster_desc(this->player_ptr, this->m_ptr, 0).data(), sizeof(this->m_name));
     angband_strcpy(this->ddesc, monster_desc(this->player_ptr, this->m_ptr, MD_WRONGDOER_NAME).data(), sizeof(this->ddesc));
     if (PlayerClass(this->player_ptr).samurai_stance_is(SamuraiStanceType::IAI)) {
-        msg_format(_("相手が襲いかかる前に素早く武器を振るった。", "You took sen, drew and cut in one motion before %s moved."), this->m_name);
+        msg_print(_("相手が襲いかかる前に素早く武器を振るった。", format("You took sen, drew and cut in one motion before %s moved.", this->m_name)));
         if (do_cmd_attack(this->player_ptr, this->m_ptr->fy, this->m_ptr->fx, HISSATSU_IAI)) {
             return;
         }

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -175,7 +175,7 @@ MonsterRaceId get_mon_num(PlayerType *player_ptr, DEPTH min_level, DEPTH max_lev
     }
 
     if (cheat_hear) {
-        msg_format(_("モンスター第3次候補数:%d(%d-%dF)%d ", "monster third selection:%d(%d-%dF)%d "), prob_table.item_count(), min_level, max_level,
+        msg_format(_("モンスター第3次候補数:%lu(%d-%dF)%d ", "monster third selection:%lu(%d-%dF)%d "), prob_table.item_count(), min_level, max_level,
             prob_table.total_prob());
     }
 
@@ -382,7 +382,7 @@ void choose_new_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, bool born, Mo
         if (!(r_ptr->flags7 & RF7_RIDING)) {
             if (process_fall_off_horse(player_ptr, 0, true)) {
                 const auto m_name = monster_desc(player_ptr, m_ptr, 0);
-                msg_format(_("地面に落とされた。", "You have fallen from %s."), m_name.data());
+                msg_print(_("地面に落とされた。", format("You have fallen from %s.", m_name.data())));
             }
         }
     }

--- a/src/mspell/mspell-special.cpp
+++ b/src/mspell/mspell-special.cpp
@@ -215,7 +215,7 @@ static MonsterSpellResult spell_RF6_SPECIAL_B(PlayerType *player_ptr, POSITION y
         int get_damage = take_hit(player_ptr, DAMAGE_NOESCAPE, dam, m_name.data());
         if (player_ptr->tim_eyeeye && get_damage > 0 && !player_ptr->is_dead) {
             const auto m_name_self = monster_desc(player_ptr, m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE | MD_OBJECTIVE);
-            msg_format(_("攻撃が%s自身を傷つけた！", "The attack of %s has wounded %s!"), m_name.data(), m_name_self.data());
+            msg_print(_(format("攻撃が%s自身を傷つけた！", m_name.data()), format("The attack of %s has wounded %s!", m_name.data(), m_name_self.data())));
             project(player_ptr, 0, 0, m_ptr->fy, m_ptr->fx, get_damage, AttributeType::MISSILE, PROJECT_KILL);
             set_tim_eyeeye(player_ptr, player_ptr->tim_eyeeye - 5, true);
         }

--- a/src/mspell/mspell-status.cpp
+++ b/src/mspell/mspell-status.cpp
@@ -633,7 +633,7 @@ MonsterSpellResult spell_RF6_HEAL(PlayerType *player_ptr, MONSTER_IDX m_idx, MON
 
     if (see_monster(player_ptr, m_idx)) {
         const auto m_name = monster_name(player_ptr, m_idx);
-        msg_format(_("%s^は勇気を取り戻した。", format("%%s^ recovers %s courage.", m_poss.data())), m_name.data());
+        msg_print(_(format("%s^は勇気を取り戻した。", m_name.data()), format("%s^ recovers %s courage.", m_name.data(), m_poss.data())));
     }
 
     return res;

--- a/src/object-activation/activation-switcher.cpp
+++ b/src/object-activation/activation-switcher.cpp
@@ -385,7 +385,7 @@ bool switch_activation(PlayerType *player_ptr, ItemEntity **o_ptr_ptr, const act
     case RandomArtActType::DISPEL_MAGIC:
         return activate_dispel_magic(player_ptr);
     default:
-        msg_format(_("Unknown activation effect: %d.", "Unknown activation effect: %d."), act_ptr->index);
+        msg_format(_("Unknown activation effect: %d.", "Unknown activation effect: %d."), enum2i(act_ptr->index));
         return false;
     }
 }

--- a/src/object-use/read/parchment-read-executor.cpp
+++ b/src/object-use/read/parchment-read-executor.cpp
@@ -31,7 +31,7 @@ bool ParchmentReadExecutor::read()
     GAME_TEXT o_name[MAX_NLEN]{};
     char buf[1024]{};
     screen_save();
-    auto q = format("book-%d_jp.txt", this->o_ptr->bi_key.sval());
+    auto q = format("book-%d_jp.txt", this->o_ptr->bi_key.sval().value());
     describe_flavor(this->player_ptr, o_name, this->o_ptr, OD_NAME_ONLY);
     (void)path_build(buf, sizeof(buf), ANGBAND_DIR_FILE, q.data());
     (void)show_file(this->player_ptr, true, buf, o_name, 0, 0);

--- a/src/racial/mutation-racial-selector.cpp
+++ b/src/racial/mutation-racial-selector.cpp
@@ -70,7 +70,7 @@ void select_mutation_racial(PlayerType *player_ptr, rc_type *rc_ptr)
 
     if (player_ptr->muta.has(PlayerMutationType::MIND_BLST)) {
         rpi = rpi_type(_("精神攻撃", "Mind Blast"));
-        rpi.info = format("%s%dd%", KWD_DAM, 3 + (rc_ptr->lvl - 1) / 5, 3);
+        rpi.info = format("%s%dd%d", KWD_DAM, 3 + (rc_ptr->lvl - 1) / 5, 3);
         rpi.text = _("モンスター1体に精神攻撃を行う。", "Deals a PSI damage to a monster.");
         rpi.min_level = 5;
         rpi.cost = 3;

--- a/src/room/room-generator.cpp
+++ b/src/room/room-generator.cpp
@@ -225,7 +225,7 @@ bool generate_rooms(PlayerType *player_ptr, dun_data_type *dd_ptr)
 
     /*! @details 部屋生成数が2未満の場合生成失敗を返す */
     if (rooms_built < 2) {
-        msg_format_wizard(player_ptr, CHEAT_DUNGEON, _("部屋数が2未満でした。生成を再試行します。", "Number of rooms was under 2. Retry."), rooms_built);
+        msg_print_wizard(player_ptr, CHEAT_DUNGEON, _("部屋数が2未満でした。生成を再試行します。", "Number of rooms was under 2. Retry."));
         return false;
     }
 

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -258,7 +258,7 @@ bool teleport_level_other(PlayerType *player_ptr)
     auto has_immune = r_ptr->resistance_flags.has_any_of(RFR_EFF_RESIST_NEXUS_MASK) || r_ptr->resistance_flags.has(MonsterResistanceType::RESIST_TELEPORT);
 
     if (has_immune || (r_ptr->flags1 & RF1_QUESTOR) || (r_ptr->level + randint1(50) > player_ptr->lev + randint1(60))) {
-        msg_format(_("しかし効果がなかった！", "%s^ is unaffected!"), m_name.data());
+        msg_print(_("しかし効果がなかった！", format("%s^ is unaffected!", m_name.data())));
     } else {
         teleport_level(player_ptr, target_m_idx);
     }
@@ -565,7 +565,7 @@ bool reset_recall(PlayerType *player_ptr)
         exe_write_diary(player_ptr, DIARY_TRUMP, select_dungeon, _("フロア・リセットで", "using a scroll of reset recall"));
     }
 #ifdef JP
-    msg_format("%sの帰還レベルを %d 階にセット。", dungeons_info[select_dungeon].name.data(), dummy, dummy * 50);
+    msg_format("%sの帰還レベルを %d 階にセット。", dungeons_info[select_dungeon].name.data(), dummy);
 #else
     msg_format("Recall depth set to level %d (%d').", dummy, dummy * 50);
 #endif

--- a/src/spell-realm/spells-sorcery.cpp
+++ b/src/spell-realm/spells-sorcery.cpp
@@ -82,7 +82,7 @@ bool alchemy(PlayerType *player_ptr)
     if (price > 30000) {
         price = 30000;
     }
-    msg_format(_("%sを＄%d の金に変えた。", "You turn %s to %ld coins worth of gold."), o_name, price);
+    msg_format(_("%sを＄%d の金に変えた。", "You turn %s to %d coins worth of gold."), o_name, price);
 
     player_ptr->au += price;
     player_ptr->redraw |= PR_GOLD;

--- a/src/spell/spells-summon.cpp
+++ b/src/spell/spells-summon.cpp
@@ -294,7 +294,7 @@ int summon_cyber(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSITION x
 void mitokohmon(PlayerType *player_ptr)
 {
     int count = 0;
-    concptr sukekakusan = "";
+    [[maybe_unused]] concptr sukekakusan = "";
     if (summon_named_creature(player_ptr, 0, player_ptr->y, player_ptr->x, MonsterRaceId::SUKE, PM_FORCE_PET)) {
         msg_print(_("『助さん』が現れた。", "Suke-san apperars."));
         sukekakusan = "Suke-san";
@@ -333,9 +333,9 @@ void mitokohmon(PlayerType *player_ptr)
         return;
     }
 
-    msg_format(
-        _("「者ども、ひかえおろう！！！このお方をどなたとこころえる。」", "%s^ says 'WHO do you think this person is! Bow your head, down to your knees!'"),
-        sukekakusan);
+    msg_print(_(
+        "「者ども、ひかえおろう！！！このお方をどなたとこころえる。」",
+        format("%s^ says 'WHO do you think this person is! Bow your head, down to your knees!'", sukekakusan)));
     sukekaku = true;
     stun_monsters(player_ptr, 120);
     confuse_monsters(player_ptr, 120);

--- a/src/status/shape-changer.cpp
+++ b/src/status/shape-changer.cpp
@@ -172,7 +172,7 @@ void do_poly_self(PlayerType *player_ptr)
     if ((power > randint0(30)) && one_in_(6)) {
         int tmp = 0;
         power -= 20;
-        msg_format(_("%sの構成が変化した！", "Your internal organs are rearranged!"), pr.equals(PlayerRaceType::ANDROID) ? "機械" : "内臓");
+        msg_print(_(format("%sの構成が変化した！", pr.equals(PlayerRaceType::ANDROID) ? "機械" : "内臓"), "Your internal organs are rearranged!"));
 
         while (tmp < A_MAX) {
             (void)dec_stat(player_ptr, tmp, randint1(6) + 6, one_in_(3));

--- a/src/system/h-config.h
+++ b/src/system/h-config.h
@@ -113,3 +113,7 @@ constexpr auto MAINTAINER = "echizen@users.sourceforge.jp";
 #endif
 
 // clang-format on
+
+#if !defined(__GNUC__)
+#define __attribute__(x)
+#endif

--- a/src/term/z-form.h
+++ b/src/term/z-form.h
@@ -31,21 +31,21 @@
 extern uint vstrnfmt(char *buf, uint max, concptr fmt, va_list vp);
 
 /* Simple interface to "vstrnfmt()" */
-extern uint strnfmt(char *buf, uint max, concptr fmt, ...);
+extern uint strnfmt(char *buf, uint max, concptr fmt, ...) __attribute__((format(printf, 3, 4)));
 
 /* Format arguments into a static resizing buffer */
 extern std::string vformat(concptr fmt, va_list vp);
 
 /* Simple interface to "vformat()" */
-extern std::string format(concptr fmt, ...);
+extern std::string format(concptr fmt, ...) __attribute__((format(printf, 1, 2)));
 
 /* Vararg interface to "plog()", using "format()" */
-extern void plog_fmt(concptr fmt, ...);
+extern void plog_fmt(concptr fmt, ...) __attribute__((format(printf, 1, 2)));
 
 /* Vararg interface to "quit()", using "format()" */
-extern void quit_fmt(concptr fmt, ...);
+extern void quit_fmt(concptr fmt, ...) __attribute__((format(printf, 1, 2)));
 
 /* Vararg interface to "core()", using "format()" */
-extern void core_fmt(concptr fmt, ...);
+extern void core_fmt(concptr fmt, ...) __attribute__((format(printf, 1, 2)));
 
 #endif

--- a/src/util/flag-group.h
+++ b/src/util/flag-group.h
@@ -375,6 +375,26 @@ public:
         return bs_.to_string();
     }
 
+    /*!
+     * @brief フラグ集合の状態を表したビット列を unsigned long 型にして返す
+     *
+     * @return フラグ集合の状態を表したビット列
+     */
+    [[nodiscard]] unsigned long to_ulong() const
+    {
+        return bs_.to_ulong();
+    }
+
+    /*!
+     * @brief フラグ集合の状態を表したビット列を unsigned long long 型にして返す
+     *
+     * @return フラグ集合の状態を表したビット列
+     */
+    [[nodiscard]] unsigned long long to_ullong() const
+    {
+        return bs_.to_ullong();
+    }
+
     /**
      * @brief フラグ集合 *this と rhs が等値かどうかを調べる
      *

--- a/src/view/display-lore.cpp
+++ b/src/view/display-lore.cpp
@@ -61,7 +61,7 @@ void roff_top(MonsterRaceId r_idx)
 
     if (w_ptr->wizard || cheat_know) {
         term_addstr(-1, TERM_WHITE, "[");
-        term_addstr(-1, TERM_L_BLUE, format("%d", r_idx));
+        term_addstr(-1, TERM_L_BLUE, format("%d", enum2i(r_idx)));
         term_addstr(-1, TERM_WHITE, "] ");
     }
 
@@ -207,16 +207,16 @@ static void display_number_of_nazguls(lore_type *lore_ptr)
     int killed = lore_ptr->r_ptr->r_akills;
     if (remain == 0) {
 #ifdef JP
-        hooked_roff(format("%sはかつて %ld 体存在した。", Who::who(lore_ptr->msex, (killed > 1)), killed));
+        hooked_roff(format("%sはかつて %d 体存在した。", Who::who(lore_ptr->msex, (killed > 1)), killed));
 #else
-        hooked_roff(format("You already killed all %ld of %s.  ", killed, Who::whom(lore_ptr->msex, (killed > 1))));
+        hooked_roff(format("You already killed all %d of %s.  ", killed, Who::whom(lore_ptr->msex, (killed > 1))));
 #endif
     } else {
 #ifdef JP
-        hooked_roff(format("%sはまだ %ld 体生きている。", Who::who(lore_ptr->msex, (remain + killed > 1)), remain));
+        hooked_roff(format("%sはまだ %d 体生きている。", Who::who(lore_ptr->msex, (remain + killed > 1)), remain));
 #else
         concptr be = (remain > 1) ? "are" : "is";
-        hooked_roff(format("%ld of %s %s still alive.  ", remain, Who::whom(lore_ptr->msex, (remain + killed > 1)), be));
+        hooked_roff(format("%d of %s %s still alive.  ", remain, Who::whom(lore_ptr->msex, (remain + killed > 1)), be));
 #endif
     }
 }
@@ -435,16 +435,17 @@ void display_monster_exp(PlayerType *player_ptr, lore_type *lore_ptr)
     hooked_roff("を倒すことは");
 #endif
 
-    int64_t base_exp = lore_ptr->r_ptr->mexp * lore_ptr->r_ptr->level * 3 / 2;
-    int64_t player_factor = (int64_t)player_ptr->max_plv + 2;
+    // 最も経験値の多い金無垢の指輪(level 110、mexp 5000000)でも符号付き32bit整数に収まる
+    const auto base_exp = lore_ptr->r_ptr->mexp * lore_ptr->r_ptr->level * 3 / 2;
+    const auto player_factor = player_ptr->max_plv + 2;
 
-    int64_t exp_integer = base_exp / player_factor;
-    int64_t exp_decimal = ((base_exp % player_factor * 1000 / player_factor) + 5) / 10;
+    const auto exp_integer = base_exp / player_factor;
+    const auto exp_decimal = ((base_exp % player_factor * 1000 / player_factor) + 5) / 10;
 
 #ifdef JP
-    hooked_roff(format(" %d レベルのキャラクタにとって 約%lld.%02lld ポイントの経験となる。", player_ptr->lev, exp_integer, exp_decimal));
+    hooked_roff(format(" %d レベルのキャラクタにとって 約%d.%02d ポイントの経験となる。", player_ptr->lev, exp_integer, exp_decimal));
 #else
-    hooked_roff(format(" is worth about %lld.%02lld point%s", exp_integer, exp_decimal, ((exp_integer == 1) && (exp_decimal == 0)) ? "" : "s"));
+    hooked_roff(format(" is worth about %d.%02d point%s", exp_integer, exp_decimal, ((exp_integer == 1) && (exp_decimal == 0)) ? "" : "s"));
 
     concptr ordinal;
     switch (player_ptr->lev % 10) {

--- a/src/view/display-messages.cpp
+++ b/src/view/display-messages.cpp
@@ -403,3 +403,13 @@ void msg_format(std::string_view fmt, ...)
     va_end(vp);
     msg_print(buf);
 }
+
+void msg_format(const char *fmt, ...)
+{
+    va_list vp;
+    char buf[1024];
+    va_start(vp, fmt);
+    (void)vstrnfmt(buf, sizeof(buf), fmt, vp);
+    va_end(vp);
+    msg_print(buf);
+}

--- a/src/view/display-messages.h
+++ b/src/view/display-messages.h
@@ -20,3 +20,4 @@ void msg_erase(void);
 void msg_print(std::string_view msg);
 void msg_print(std::nullptr_t);
 void msg_format(std::string_view fmt, ...);
+void msg_format(const char *fmt, ...) __attribute__((format(printf, 1, 2)));

--- a/src/view/display-player-middle.cpp
+++ b/src/view/display-player-middle.cpp
@@ -257,13 +257,13 @@ static void display_player_exp(PlayerType *player_ptr)
     PlayerRace pr(player_ptr);
     int e = pr.equals(PlayerRaceType::ANDROID) ? ENTRY_EXP_ANDR : ENTRY_CUR_EXP;
     if (player_ptr->exp >= player_ptr->max_exp) {
-        display_player_one_line(e, format("%ld", player_ptr->exp), TERM_L_GREEN);
+        display_player_one_line(e, format("%d", player_ptr->exp), TERM_L_GREEN);
     } else {
-        display_player_one_line(e, format("%ld", player_ptr->exp), TERM_YELLOW);
+        display_player_one_line(e, format("%d", player_ptr->exp), TERM_YELLOW);
     }
 
     if (!pr.equals(PlayerRaceType::ANDROID)) {
-        display_player_one_line(ENTRY_MAX_EXP, format("%ld", player_ptr->max_exp), TERM_L_GREEN);
+        display_player_one_line(ENTRY_MAX_EXP, format("%d", player_ptr->max_exp), TERM_L_GREEN);
     }
 
     e = pr.equals(PlayerRaceType::ANDROID) ? ENTRY_EXP_TO_ADV_ANDR : ENTRY_EXP_TO_ADV;
@@ -271,9 +271,9 @@ static void display_player_exp(PlayerType *player_ptr)
     if (player_ptr->lev >= PY_MAX_LEVEL) {
         display_player_one_line(e, "*****", TERM_L_GREEN);
     } else if (pr.equals(PlayerRaceType::ANDROID)) {
-        display_player_one_line(e, format("%ld", (int32_t)(player_exp_a[player_ptr->lev - 1] * player_ptr->expfact / 100L)), TERM_L_GREEN);
+        display_player_one_line(e, format("%d", player_exp_a[player_ptr->lev - 1] * player_ptr->expfact / 100), TERM_L_GREEN);
     } else {
-        display_player_one_line(e, format("%ld", (int32_t)(player_exp[player_ptr->lev - 1] * player_ptr->expfact / 100L)), TERM_L_GREEN);
+        display_player_one_line(e, format("%d", player_exp[player_ptr->lev - 1] * player_ptr->expfact / 100), TERM_L_GREEN);
     }
 }
 
@@ -322,7 +322,7 @@ static void display_real_playtime(void)
     uint32_t play_hour = w_ptr->play_time / (60 * 60);
     uint32_t play_min = (w_ptr->play_time / 60) % 60;
     uint32_t play_sec = w_ptr->play_time % 60;
-    display_player_one_line(ENTRY_PLAY_TIME, format("%.2lu:%.2lu:%.2lu", play_hour, play_min, play_sec), TERM_L_GREEN);
+    display_player_one_line(ENTRY_PLAY_TIME, format("%.2u:%.2u:%.2u", play_hour, play_min, play_sec), TERM_L_GREEN);
 }
 
 /*!
@@ -350,7 +350,7 @@ void display_player_middle(PlayerType *player_ptr)
     int tmp_speed = calc_temporary_speed(player_ptr);
     display_player_speed(player_ptr, attr, base_speed, tmp_speed);
     display_player_exp(player_ptr);
-    display_player_one_line(ENTRY_GOLD, format("%ld", player_ptr->au), TERM_L_GREEN);
+    display_player_one_line(ENTRY_GOLD, format("%d", player_ptr->au), TERM_L_GREEN);
     display_playtime_in_game(player_ptr);
     display_real_playtime();
 }

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -346,14 +346,14 @@ static void wiz_display_item(PlayerType *player_ptr, ItemEntity *o_ptr)
     auto line = 4;
     const auto &bi_key = o_ptr->bi_key;
     const auto item_level = baseitems_info[o_ptr->bi_id].level;
-    prt(format("kind = %-5d  level = %-4d  tval = %-5d  sval = %-5d", o_ptr->bi_id, item_level, bi_key.tval(), bi_key.sval().value()), line, j);
+    prt(format("kind = %-5d  level = %-4d  tval = %-5d  sval = %-5d", o_ptr->bi_id, item_level, enum2i(bi_key.tval()), bi_key.sval().value()), line, j);
     prt(format("number = %-3d  wgt = %-6d  ac = %-5d    damage = %dd%d", o_ptr->number, o_ptr->weight, o_ptr->ac, o_ptr->dd, o_ptr->ds), ++line, j);
     prt(format("pval = %-5d  toac = %-5d  tohit = %-4d  todam = %-4d", o_ptr->pval, o_ptr->to_a, o_ptr->to_h, o_ptr->to_d), ++line, j);
-    prt(format("fixed_artifact_idx = %-4d  ego_idx = %-4d  cost = %ld", o_ptr->fixed_artifact_idx, o_ptr->ego_idx, object_value_real(o_ptr)), ++line, j);
-    prt(format("ident = %04x  activation_id = %-4d  timeout = %-d", o_ptr->ident, o_ptr->activation_id, o_ptr->timeout), ++line, j);
+    prt(format("fixed_artifact_idx = %-4d  ego_idx = %-4d  cost = %d", enum2i(o_ptr->fixed_artifact_idx), enum2i(o_ptr->ego_idx), object_value_real(o_ptr)), ++line, j);
+    prt(format("ident = %04x  activation_id = %-4d  timeout = %-d", o_ptr->ident, enum2i(o_ptr->activation_id), o_ptr->timeout), ++line, j);
     prt(format("chest_level = %-4d  fuel = %-d", o_ptr->chest_level, o_ptr->fuel), ++line, j);
     prt(format("smith_hit = %-4d  smith_damage = %-4d", o_ptr->smith_hit, o_ptr->smith_damage), ++line, j);
-    prt(format("cursed  = %-d  captured_monster_speed = %-4d", o_ptr->curse_flags, o_ptr->captured_monster_speed), ++line, j);
+    prt(format("cursed  = %-4lX  captured_monster_speed = %-4d", o_ptr->curse_flags.to_ulong(), o_ptr->captured_monster_speed), ++line, j);
     prt(format("captured_monster_max_hp = %-4d  captured_monster_max_hp = %-4d", o_ptr->captured_monster_current_hp, o_ptr->captured_monster_max_hp), ++line, j);
 
     prt("+------------FLAGS1------------+", ++line, j);
@@ -919,7 +919,7 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
                 str_tolower(o_name);
 #endif
                 if (cheat_xtra) {
-                    msg_format("matching ego no.%d %s...", e_ref.idx, o_name);
+                    msg_format("matching ego no.%d %s...", enum2i(e_ref.idx), o_name);
                 }
 
                 if (_(!strncmp(str, o_name, strlen(o_name)), !strrncmp(str, o_name, strlen(o_name)))) {
@@ -994,7 +994,7 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
 #endif
 
             if (cheat_xtra) {
-                msg_format("Matching artifact No.%d %s(%s)", a_idx, a_desc, _(&o_name[2], o_name));
+                msg_format("Matching artifact No.%d %s(%s)", enum2i(a_idx), a_desc, _(&o_name[2], o_name));
             }
 
             std::vector<const char *> l = { a_str, a_ref.name.data(), _(&o_name[2], o_name) };

--- a/src/wizard/wizard-messages.h
+++ b/src/wizard/wizard-messages.h
@@ -4,4 +4,4 @@
 
 class PlayerType;
 void msg_print_wizard(PlayerType *player_ptr, int cheat_type, concptr msg);
-void msg_format_wizard(PlayerType *player_ptr, int cheat_type, concptr fmt, ...);
+void msg_format_wizard(PlayerType *player_ptr, int cheat_type, concptr fmt, ...) __attribute__((format(printf, 3, 4)));

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -304,7 +304,7 @@ static std::optional<FixedArtifactId> wiz_select_named_artifact(PlayerType *play
             put_str(ss.str().data(), i + 1, 15);
         }
         if (page_max > 1) {
-            put_str(format("-- more (%d/%d) --", current_page + 1, page_max), page_item_count + 1, 15);
+            put_str(format("-- more (%lu/%lu) --", current_page + 1, page_max), page_item_count + 1, 15);
         }
 
         char cmd = ESCAPE;

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -259,7 +259,7 @@ void wiz_kill_target(PlayerType *player_ptr, int dam, AttributeType effect_idx, 
         for (auto i = 0U; i < std::size(gf_descriptions); ++i) {
             auto name = std::string_view(gf_descriptions[i].name).substr(3); // 先頭の"GF_"を取り除く
             auto num = enum2i(gf_descriptions[i].num);
-            put_str(format("%03d:%^-.10s", num, name.data()), 1 + i / 5, 1 + (i % 5) * 16);
+            put_str(format("%03d:%-.10s^", num, name.data()), 1 + i / 5, 1 + (i % 5) * 16);
         }
         if (!get_value("EffectID", 1, max - 1, &idx)) {
             screen_load();


### PR DESCRIPTION
printf ライクな書式と引数を受け付ける主要な関数に `__attribute__((format))` を付け、出力された警告に対応する。

#2990 関連作業です。