### PR TITLE
[Feature] キャラクタ情報を画面中央に表示する

### DIFF
--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -77,10 +77,14 @@ void do_cmd_redraw(PlayerType *player_ptr)
  */
 void do_cmd_player_status(PlayerType *player_ptr)
 {
+    constexpr auto display_width = 80;
+    constexpr auto display_height = 24;
     int mode = 0;
     char tmp[160];
     screen_save();
     while (true) {
+        TermCenteredOffsetSetter tcos(display_width, display_height);
+
         update_playtime();
         (void)display_player(player_ptr, mode);
 

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -589,6 +589,8 @@ static std::string get_check_sum(void)
  */
 void make_character_dump(PlayerType *player_ptr, FILE *fff)
 {
+    TermOffsetSetter tos(0, 0);
+
     fprintf(fff, _("  [%s キャラクタ情報]\n\n", "  [%s Character Dump]\n\n"), get_version().data());
 
     dump_aux_player_status(player_ptr, fff);

--- a/src/io/files-util.cpp
+++ b/src/io/files-util.cpp
@@ -84,7 +84,10 @@ errr file_character(PlayerType *player_ptr, concptr name)
         return -1;
     }
 
+    screen_save();
     make_character_dump(player_ptr, fff);
+    screen_load();
+
     angband_fclose(fff);
     msg_print(_("キャラクタ情報のファイルへの書き出しに成功しました。", "Character dump successful."));
     msg_print(nullptr);

--- a/src/term/screen-processor.cpp
+++ b/src/term/screen-processor.cpp
@@ -263,6 +263,7 @@ void roff(std::string_view str)
 void clear_from(int row)
 {
     for (int y = row; y < game_term->hgt; y++) {
+        TermOffsetSetter tos(0, std::nullopt);
         term_erase(0, y, 255);
     }
 }

--- a/src/term/z-term.cpp
+++ b/src/term/z-term.cpp
@@ -35,6 +35,64 @@ term_type *game_term = nullptr;
 
 /*** Local routines ***/
 
+/*!
+ * @brief オブジェクトが生存している間、画面表示関数の座標をずらす。
+ *
+ * 引数でずらすX座標オフセット、Y座標オフセットをそれぞれ指定する。
+ * 正方向のオフセットのみ有効。負の値が指定された場合、オフセット位置は 0 とする。
+ * 指定された座標が std::nullopt の場合、現在のオフセットを維持する。
+ *
+ * @param x X座標オフセット
+ * @param y Y座標オフセット
+ */
+TermOffsetSetter::TermOffsetSetter(std::optional<TERM_LEN> x, std::optional<TERM_LEN> y)
+    : term(game_term)
+    , orig_offset_x(game_term != nullptr ? game_term->offset_x : 0)
+    , orig_offset_y(game_term != nullptr ? game_term->offset_y : 0)
+{
+    if (this->term == nullptr) {
+        return;
+    }
+
+    if (x.has_value()) {
+        this->term->offset_x = (x.value() > 0) ? x.value() : 0;
+    }
+    if (y.has_value()) {
+        this->term->offset_y = (y.value() > 0) ? y.value() : 0;
+    }
+}
+
+TermOffsetSetter::~TermOffsetSetter()
+{
+    if (this->term == nullptr) {
+        return;
+    }
+
+    this->term->offset_x = this->orig_offset_x;
+    this->term->offset_y = this->orig_offset_y;
+}
+
+/*!
+ * @brief オブジェクトが生存している間、画面表示関数の座標をずらす。
+ *
+ * 表示に使用する領域の大きさを指定し、その領域が画面中央に表示されるように座標をずらす。
+ * 引数で領域の横幅、縦幅をそれぞれ指定する。
+ * 画面の幅より大きな値が指定された場合はオフセット 0 になる。
+ * 指定された幅が std::nullopt の場合、画面の幅全体を使用する（オフセット 0 になる）。
+ *
+ * @param width 表示に使用する領域の横幅
+ * @param height 表示に使用する領域の縦幅
+ */
+TermCenteredOffsetSetter::TermCenteredOffsetSetter(std::optional<TERM_LEN> width, std::optional<TERM_LEN> height)
+{
+    TERM_LEN term_width, term_height;
+    term_get_size(&term_width, &term_height);
+
+    const auto offset_x = width.has_value() ? (term_width - width.value()) / 2 : 0;
+    const auto offset_y = height.has_value() ? (term_height - height.value()) / 2 : 0;
+    this->tos.emplace(offset_x, offset_y);
+}
+
 /*
  * Initialize a "term_win" (using the given window size)
  */
@@ -194,7 +252,7 @@ static errr term_pict_hack(TERM_LEN x, TERM_LEN y, int n, const TERM_COLOR *ap, 
  * Mentally draw an attr/char at a given location
  * Assumes given location and values are valid.
  */
-void term_queue_char(TERM_LEN x, TERM_LEN y, TERM_COLOR a, char c, TERM_COLOR ta, char tc)
+static void term_queue_char_aux(TERM_LEN x, TERM_LEN y, TERM_COLOR a, char c, TERM_COLOR ta, char tc)
 {
     const auto &scrn = game_term->scr;
 
@@ -242,6 +300,15 @@ void term_queue_char(TERM_LEN x, TERM_LEN y, TERM_COLOR a, char c, TERM_COLOR ta
         }
 }
 
+void term_queue_char(TERM_LEN x, TERM_LEN y, TERM_COLOR a, char c, TERM_COLOR ta, char tc)
+{
+    if (auto res = term_gotoxy(x, y); res != 0) {
+        return;
+    }
+
+    term_queue_char_aux(game_term->scr->cx, game_term->scr->cy, a, c, ta, tc);
+}
+
 /*
  * Bigtile version of term_queue_char().
  * If use_bigtile is FALSE, simply call term_queue_char().
@@ -268,9 +335,13 @@ void term_queue_bigchar(TERM_LEN x, TERM_LEN y, TERM_COLOR a, char c, TERM_COLOR
     byte a2;
     char c2;
 
+    if (auto res = term_gotoxy(x, y); res != 0) {
+        return;
+    }
+
     /* If non bigtile mode, call orginal function */
     if (!use_bigtile) {
-        term_queue_char(x, y, a, c, ta, tc);
+        term_queue_char_aux(game_term->scr->cx, game_term->scr->cy, a, c, ta, tc);
         return;
     }
 
@@ -311,8 +382,8 @@ void term_queue_bigchar(TERM_LEN x, TERM_LEN y, TERM_COLOR a, char c, TERM_COLOR
     }
 
     /* Display pair of attr/char */
-    term_queue_char(x, y, a, c, ta, tc);
-    term_queue_char(x + 1, y, a2, c2, 0, 0);
+    term_queue_char_aux(game_term->scr->cx, game_term->scr->cy, a, c, ta, tc);
+    term_queue_char_aux(game_term->scr->cx + 1, game_term->scr->cy, a2, c2, 0, 0);
 }
 
 /*
@@ -1288,6 +1359,9 @@ errr term_gotoxy(TERM_LEN x, TERM_LEN y)
     int w = game_term->wid;
     int h = game_term->hgt;
 
+    x += game_term->offset_x;
+    y += game_term->offset_y;
+
     /* Verify */
     if ((x < 0) || (x >= w)) {
         return -1;
@@ -1312,13 +1386,7 @@ errr term_gotoxy(TERM_LEN x, TERM_LEN y)
  */
 errr term_draw(TERM_LEN x, TERM_LEN y, TERM_COLOR a, char c)
 {
-    int w = game_term->wid;
-    int h = game_term->hgt;
-
-    if ((x < 0) || (x >= w)) {
-        return -1;
-    }
-    if ((y < 0) || (y >= h)) {
+    if (auto res = term_gotoxy(x, y); res != 0) {
         return -1;
     }
 
@@ -1328,7 +1396,7 @@ errr term_draw(TERM_LEN x, TERM_LEN y, TERM_COLOR a, char c)
     }
 
     /* Queue it for later */
-    term_queue_char(x, y, a, c, 0, 0);
+    term_queue_char_aux(game_term->scr->cx, game_term->scr->cy, a, c, 0, 0);
     return 0;
 }
 
@@ -1363,7 +1431,7 @@ errr term_addch(TERM_COLOR a, char c)
     }
 
     /* Queue the given character for display */
-    term_queue_char(game_term->scr->cx, game_term->scr->cy, a, c, 0, 0);
+    term_queue_char_aux(game_term->scr->cx, game_term->scr->cy, a, c, 0, 0);
 
     /* Advance the cursor */
     game_term->scr->cx++;
@@ -1534,6 +1602,9 @@ errr term_erase(TERM_LEN x, TERM_LEN y, int n)
     if (term_gotoxy(x, y)) {
         return -1;
     }
+
+    x = game_term->scr->cx;
+    y = game_term->scr->cy;
 
     /* Force legal size */
     if (x + n > w) {
@@ -1780,8 +1851,8 @@ errr term_get_size(TERM_LEN *w, TERM_LEN *h)
 errr term_locate(TERM_LEN *x, TERM_LEN *y)
 {
     /* Access the cursor */
-    (*x) = game_term->scr->cx;
-    (*y) = game_term->scr->cy;
+    *x = game_term->scr->cx - game_term->offset_x;
+    *y = game_term->scr->cy - game_term->offset_y;
 
     /* Warn about "useless" cursor */
     if (game_term->scr->cu) {

--- a/src/term/z-term.h
+++ b/src/term/z-term.h
@@ -13,8 +13,8 @@
 
 #include "system/angband.h"
 #include "system/h-basic.h"
-
 #include <memory>
+#include <optional>
 #include <stack>
 #include <string_view>
 #include <vector>
@@ -77,6 +77,9 @@ struct term_type {
     TERM_LEN wid{}; //!< Window Width(max 255)
     TERM_LEN hgt{}; //!< Window Height(max 255)
 
+    TERM_LEN offset_x{};
+    TERM_LEN offset_y{};
+
     TERM_LEN y1{}; //!< Minimum modified row
     TERM_LEN y2{}; //!< Maximum modified row
 
@@ -111,6 +114,34 @@ struct term_type {
     term_type &operator=(const term_type &) = delete;
     term_type(term_type &&) = default;
     term_type &operator=(term_type &&) = default;
+};
+
+class TermOffsetSetter {
+public:
+    TermOffsetSetter(std::optional<TERM_LEN> x, std::optional<TERM_LEN> y);
+    ~TermOffsetSetter();
+    TermOffsetSetter(const TermOffsetSetter &) = delete;
+    TermOffsetSetter &operator=(const TermOffsetSetter &) = delete;
+    TermOffsetSetter(TermOffsetSetter &&) = delete;
+    TermOffsetSetter &operator=(TermOffsetSetter &&) = delete;
+
+private:
+    term_type *term;
+    TERM_LEN orig_offset_x;
+    TERM_LEN orig_offset_y;
+};
+
+class TermCenteredOffsetSetter {
+public:
+    TermCenteredOffsetSetter(std::optional<TERM_LEN> width, std::optional<TERM_LEN> height);
+    ~TermCenteredOffsetSetter() = default;
+    TermCenteredOffsetSetter(const TermCenteredOffsetSetter &) = delete;
+    TermCenteredOffsetSetter &operator=(const TermCenteredOffsetSetter &) = delete;
+    TermCenteredOffsetSetter(TermCenteredOffsetSetter &&) = delete;
+    TermCenteredOffsetSetter &operator=(TermCenteredOffsetSetter &&) = delete;
+
+private:
+    std::optional<TermOffsetSetter> tos;
 };
 
 /**** Available Constants ****/

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -68,6 +68,8 @@ static bool display_player_info(PlayerType *player_ptr, int mode)
     }
 
     if (mode == 5) {
+        constexpr auto display_width = 80;
+        TermCenteredOffsetSetter tcos(display_width, std::nullopt);
         do_cmd_knowledge_mutations(player_ptr);
         return true;
     }
@@ -280,7 +282,10 @@ std::optional<int> display_player(PlayerType *player_ptr, const int tmp_mode)
 {
     auto has_any_mutation = (player_ptr->muta.any() || has_good_luck(player_ptr)) && display_mutations;
     auto mode = has_any_mutation ? tmp_mode % 6 : tmp_mode % 5;
-    clear_from(0);
+    {
+        TermOffsetSetter tos(0, 0);
+        clear_from(0);
+    }
     if (display_player_info(player_ptr, mode)) {
         return std::nullopt;
     }


### PR DESCRIPTION
Resolves #3026 

画面表示オフセットを設定するクラスを導入し、ひとまずキャラクタ情報画面の中央表示にのみ対応しました。
画面ごとの修正量自体は比較的少なく済みそうなので、この PR で方針が固まれば他の画面を１つずつ対応していきたいと思っています。