### PR TITLE
Facilitate building on OpenBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -132,6 +132,14 @@ if test "$use_japanese" != no; then
   fi
 fi
 
+if test "$enable_pch" != no; then
+  dnl md5sum, sha224sum, sha256sum, sha384sum, sha512sum and b2sum are
+  dnl frequently available on Linux.  md5 is available on macOS and OpenBSD.
+  dnl sha1, sha256, and sha512 are available on OpenBSD.
+  AC_PATH_PROGS(PCH_CHECKSUMMER, [md5sum md5 sha1sum sha1 sha224sum sha256sum sha256 sha384sum sha512sum sha512 b2sum], [none])
+  AC_ARG_VAR([PCH_CHECKSUMMER], [full path to a utility to compute the checksum for the precompiled header; checksum is for ccache's pch_external_checksum])
+fi
+
 AC_CHECK_HEADERS(fcntl.h sys/file.h sys/ioctl.h sys/time.h termio.h unistd.h stdint.h)
 
 dnl Checks for typedefs, structures, and compiler characteristics.

--- a/configure.ac
+++ b/configure.ac
@@ -95,7 +95,7 @@ AC_PATH_XTRA
 if test "$have_x" = yes; then
   LIBS="$LIBS -lX11"
   AC_DEFINE(USE_X11, 1, [Allow -mX11 environment])
-  CFLAGS="$X_CFLAGS $CFLAGS"
+  CXXFLAGS="$X_CFLAGS $CXXFLAGS"
   LDFLAGS="$X_LIBS $LDFLAGS"
 
   if test "$use_fontset" = yes; then

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1063,8 +1063,10 @@ CXXCOMPILE = $(srcdir)/gcc-wrap $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) \
 if PCH
 stdafx.h.gch: stdafx.h stdafx.cpp Makefile
 	$(CXX) -x c++-header $(CXXFLAGS) $(srcdir)/stdafx.cpp -o $@
-	rm -f stdafx.h.gch.sum
-	md5sum $@ > stdafx.h.gch.sum
+	if test none != "$(PCH_CHECKSUMMER)" ; then \
+		rm -f "$@".sum ; \
+		$(PCH_CHECKSUMMER) $@ > "$@".sum ; \
+	fi
 
 $(hengband_SOURCES:.cpp=.$(OBJEXT)): stdafx.h.gch
 endif

--- a/src/system/h-system.h
+++ b/src/system/h-system.h
@@ -31,7 +31,6 @@
     #include <sys/file.h>
     #include <sys/param.h>
     #include <sys/stat.h>
-    #include <sys/timeb.h>
     #include <sys/types.h>
     #include <unistd.h>
   #endif


### PR DESCRIPTION
- Avoid compiler error about missing sys/timeb.h.
- Pick up path to X11 headers which are not in the standard include path.
- Make it so using precompiled headers doesn't end with an error when trying to run md5sum.