### PR TITLE
[Fix] トランプ魔術の塔の選択肢が消えてしまう

### DIFF
--- a/src/cmd-building/cmd-building.cpp
+++ b/src/cmd-building/cmd-building.cpp
@@ -210,8 +210,10 @@ static void bldg_process_command(PlayerType *player_ptr, building_type *bldg, in
         break;
 
     case BACT_TELEPORT_LEVEL:
+        screen_save();
         clear_bldg(4, 20);
         paid = free_level_recall(player_ptr);
+        screen_load();
         break;
 
     case BACT_LOSE_MUTATION: {


### PR DESCRIPTION
Resolves #3045 

ダンジョンの候補を表示するときに一旦選択肢を消しているが、キャンセルされたときに戻す処
理を行っていない。画面を screen_save / screen_load する事で選択肢の表示を戻すよう にする。