### PR TITLE
[Fix] メイン画面のサイズ変更時に自動で再描画されない

### DIFF
--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -104,7 +104,7 @@ static void restore_windows(PlayerType *player_ptr)
     w_ptr->character_icky_depth = 1;
     term_activate(angband_terms[0]);
     angband_terms[0]->resize_hook = resize_map;
-    for (auto i = 0U; i < angband_terms.size(); ++i) {
+    for (auto i = 1U; i < angband_terms.size(); ++i) {
         if (angband_terms[i]) {
             angband_terms[i]->resize_hook = redraw_window;
         }


### PR DESCRIPTION
Resolves #3060

メイン画面の resize_hook に resize_map を設定した後、誤って redraw_window を 上書きしてしまっている。
redraw_window はサブ画面にのみ設定するように修正する。