### PR TITLE
[Feature] ゲームオーバー時の画面をウィンドウの中央に表示する

### DIFF
--- a/src/core/game-closer.cpp
+++ b/src/core/game-closer.cpp
@@ -96,34 +96,30 @@ static void kingly(PlayerType *player_ptr)
 
     player_ptr->exp = player_ptr->max_exp;
     player_ptr->lev = player_ptr->max_plv;
-    TERM_LEN wid, hgt;
-    term_get_size(&wid, &hgt);
-    auto cy = hgt / 2;
-    auto cx = wid / 2;
     player_ptr->au += 10000000L;
     term_clear();
 
-    put_str("#", cy - 11, cx - 1);
-    put_str("#####", cy - 10, cx - 3);
-    put_str("#", cy - 9, cx - 1);
-    put_str(",,,  $$$  ,,,", cy - 8, cx - 7);
-    put_str(",,=$   \"$$$$$\"   $=,,", cy - 7, cx - 11);
-    put_str(",$$        $$$        $$,", cy - 6, cx - 13);
-    put_str("*>         <*>         <*", cy - 5, cx - 13);
-    put_str("$$         $$$         $$", cy - 4, cx - 13);
-    put_str("\"$$        $$$        $$\"", cy - 3, cx - 13);
-    put_str("\"$$       $$$       $$\"", cy - 2, cx - 12);
-    put_str("*#########*#########*", cy - 1, cx - 11);
-    put_str("*#########*#########*", cy, cx - 11);
+    put_str("#", 1, 39);
+    put_str("#####", 2, 37);
+    put_str("#", 3, 39);
+    put_str(",,,  $$$  ,,,", 4, 33);
+    put_str(",,=$   \"$$$$$\"   $=,,", 5, 29);
+    put_str(",$$        $$$        $$,", 6, 27);
+    put_str("*>         <*>         <*", 7, 27);
+    put_str("$$         $$$         $$", 8, 27);
+    put_str("\"$$        $$$        $$\"", 9, 27);
+    put_str("\"$$       $$$       $$\"", 10, 28);
+    put_str("*#########*#########*", 11, 29);
+    put_str("*#########*#########*", 12, 29);
 
 #ifdef JP
-    put_str("Veni, Vidi, Vici!", cy + 3, cx - 9);
-    put_str("来た、見た、勝った！", cy + 4, cx - 10);
-    put_str(format("偉大なる%s万歳！", sp_ptr->winner), cy + 5, cx - 11);
+    put_str("Veni, Vidi, Vici!", 15, 31);
+    put_str("来た、見た、勝った！", 16, 30);
+    put_str(format("偉大なる%s万歳！", sp_ptr->winner), 17, 29);
 #else
-    put_str("Veni, Vidi, Vici!", cy + 3, cx - 9);
-    put_str("I came, I saw, I conquered!", cy + 4, cx - 14);
-    put_str(format("All Hail the Mighty %s!", sp_ptr->winner), cy + 5, cx - 13);
+    put_str("Veni, Vidi, Vici!", 15, 31);
+    put_str("I came, I saw, I conquered!", 16, 26);
+    put_str(format("All Hail the Mighty %s!", sp_ptr->winner), 17, 27);
 #endif
 
     if (!seppuku) {
@@ -133,7 +129,7 @@ static void kingly(PlayerType *player_ptr)
     }
 
     flush();
-    pause_line(hgt - 1);
+    pause_line(23);
 }
 
 /*!
@@ -164,6 +160,7 @@ void close_game(PlayerType *player_ptr)
         return;
     }
 
+    TermCenteredOffsetSetter tcos(80, 24);
     if (w_ptr->total_winner) {
         kingly(player_ptr);
     }

--- a/src/floor/object-scanner.cpp
+++ b/src/floor/object-scanner.cpp
@@ -102,6 +102,8 @@ static void prepare_label_string_floor(FloorType *floor_ptr, char *label, FLOOR_
  */
 COMMAND_CODE show_floor_items(PlayerType *player_ptr, int target_item, POSITION y, POSITION x, TERM_LEN *min_width, const ItemTester &item_tester)
 {
+    TermOffsetSetter tos(0, std::nullopt);
+
     COMMAND_CODE i, m;
     int j, k, l;
     ItemEntity *o_ptr;

--- a/src/view/display-inventory.cpp
+++ b/src/view/display-inventory.cpp
@@ -28,6 +28,8 @@
  */
 COMMAND_CODE show_inventory(PlayerType *player_ptr, int target_item, BIT_FLAGS mode, const ItemTester &item_tester)
 {
+    TermOffsetSetter tos(0, std::nullopt);
+
     COMMAND_CODE i;
     int k, l, z = 0;
     ItemEntity *o_ptr;

--- a/src/window/main-window-equipments.cpp
+++ b/src/window/main-window-equipments.cpp
@@ -28,6 +28,8 @@
  */
 COMMAND_CODE show_equipment(PlayerType *player_ptr, int target_item, BIT_FLAGS mode, const ItemTester &item_tester)
 {
+    TermOffsetSetter tos(0, std::nullopt);
+
     COMMAND_CODE i;
     int j, k, l;
     ItemEntity *o_ptr;


### PR DESCRIPTION
ゲームオーバー（勝利後に引退・死亡）時の画面をウィンドウの中央に表示する。
勝利後の引退時の王冠表示は元々中央に表示するように計算されていたが、今回のオフセットに
よる中央表示を一貫して適用するため 80x24 の画面に表示するときの座標に変更する。

#3040 の作業の一部です。