### PR TITLE
[Fix] 画面左下部の情報が正しく表示されない 

### DIFF
--- a/src/core/window-redrawer.cpp
+++ b/src/core/window-redrawer.cpp
@@ -49,14 +49,17 @@ void redraw_window(void)
  */
 static void print_dungeon(PlayerType *player_ptr)
 {
-    c_put_str(TERM_WHITE, "             ", ROW_DUNGEON, COL_DUNGEON);
+    TERM_LEN width, height;
+    term_get_size(&width, &height);
+
+    c_put_str(TERM_WHITE, "             ", height + ROW_DUNGEON, COL_DUNGEON);
     concptr dungeon_name = map_name(player_ptr);
     TERM_LEN col = COL_DUNGEON + 6 - strlen(dungeon_name) / 2;
     if (col < 0) {
         col = 0;
     }
 
-    c_put_str(TERM_L_UMBER, format("%s", dungeon_name), ROW_DUNGEON, col);
+    c_put_str(TERM_L_UMBER, format("%s", dungeon_name), height + ROW_DUNGEON, col);
 }
 
 /*!

--- a/src/locale/language-switcher.h
+++ b/src/locale/language-switcher.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "system/h-basic.h"
+
 #ifdef JP
 #define _(JAPANESE, ENGLISH) (JAPANESE)
 #else

--- a/src/window/main-window-row-column.h
+++ b/src/window/main-window-row-column.h
@@ -43,28 +43,28 @@
 #define ROW_CURSP 15
 #define COL_CURSP 0 /* "Cur SP xxxxx" */
 
-#define ROW_CUT 16
-#define COL_CUT 0 /* <cut> */
-
-#define ROW_STUN 17
-#define COL_STUN 0 /* <stun> */
-
-#define ROW_HUNGRY 18
-#define COL_HUNGRY 0 /* "Weak" / "Hungry" / "Full" / "Gorged" */
-
-#define ROW_STATE 19
-#define COL_STATE 7 /* <state> */
-
-#define ROW_RIDING_INFO 21
+#define ROW_RIDING_INFO 16
 #define COL_RIDING_INFO 0 /* "xxxxxxxxxxxx" */
 
-#define ROW_INFO 24
+#define ROW_INFO 17
 #define COL_INFO 0 /* "xxxxxxxxxxxx" */
 
-#define ROW_DAY 32
+#define ROW_CUT (-6)
+#define COL_CUT 0 /* <cut> */
+
+#define ROW_STUN (-5)
+#define COL_STUN 0 /* <stun> */
+
+#define ROW_HUNGRY (-4)
+#define COL_HUNGRY 0 /* "Weak" / "Hungry" / "Full" / "Gorged" */
+
+#define ROW_STATE (-4)
+#define COL_STATE 7 /* <state> */
+
+#define ROW_DAY (-3)
 #define COL_DAY 0 /* day */
 
-#define ROW_DUNGEON 33
+#define ROW_DUNGEON (-2)
 #define COL_DUNGEON 0 /* dungeon */
 
 #define ROW_SPEED (-1)

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -81,14 +81,16 @@ void print_stat(PlayerType *player_ptr, int stat)
  */
 void print_cut(PlayerType *player_ptr)
 {
+    TERM_LEN width, height;
+    term_get_size(&width, &height);
     auto player_cut = player_ptr->effects()->cut();
     if (!player_cut->is_cut()) {
-        put_str("            ", ROW_CUT, COL_CUT);
+        put_str("            ", height + ROW_CUT, COL_CUT);
         return;
     }
 
     auto [color, stat] = player_cut->get_expr();
-    c_put_str(color, stat.data(), ROW_CUT, COL_CUT);
+    c_put_str(color, stat.data(), height + ROW_CUT, COL_CUT);
 }
 
 /*!
@@ -97,14 +99,16 @@ void print_cut(PlayerType *player_ptr)
  */
 void print_stun(PlayerType *player_ptr)
 {
+    TERM_LEN width, height;
+    term_get_size(&width, &height);
     auto player_stun = player_ptr->effects()->stun();
     if (!player_stun->is_stunned()) {
-        put_str("            ", ROW_STUN, COL_STUN);
+        put_str("            ", height + ROW_STUN, COL_STUN);
         return;
     }
 
     auto [color, stat] = player_stun->get_expr();
-    c_put_str(color, stat.data(), ROW_STUN, COL_STUN);
+    c_put_str(color, stat.data(), height + ROW_STUN, COL_STUN);
 }
 
 /*!
@@ -117,32 +121,36 @@ void print_hunger(PlayerType *player_ptr)
         return;
     }
 
+    TERM_LEN width, height;
+    term_get_size(&width, &height);
+    const auto row = height + ROW_HUNGRY;
+
     if (player_ptr->food < PY_FOOD_FAINT) {
-        c_put_str(TERM_RED, _("衰弱  ", "Weak  "), ROW_HUNGRY, COL_HUNGRY);
+        c_put_str(TERM_RED, _("衰弱  ", "Weak  "), row, COL_HUNGRY);
         return;
     }
 
     if (player_ptr->food < PY_FOOD_WEAK) {
-        c_put_str(TERM_ORANGE, _("衰弱  ", "Weak  "), ROW_HUNGRY, COL_HUNGRY);
+        c_put_str(TERM_ORANGE, _("衰弱  ", "Weak  "), row, COL_HUNGRY);
         return;
     }
 
     if (player_ptr->food < PY_FOOD_ALERT) {
-        c_put_str(TERM_YELLOW, _("空腹  ", "Hungry"), ROW_HUNGRY, COL_HUNGRY);
+        c_put_str(TERM_YELLOW, _("空腹  ", "Hungry"), row, COL_HUNGRY);
         return;
     }
 
     if (player_ptr->food < PY_FOOD_FULL) {
-        c_put_str(TERM_L_GREEN, "      ", ROW_HUNGRY, COL_HUNGRY);
+        c_put_str(TERM_L_GREEN, "      ", row, COL_HUNGRY);
         return;
     }
 
     if (player_ptr->food < PY_FOOD_MAX) {
-        c_put_str(TERM_L_GREEN, _("満腹  ", "Full  "), ROW_HUNGRY, COL_HUNGRY);
+        c_put_str(TERM_L_GREEN, _("満腹  ", "Full  "), row, COL_HUNGRY);
         return;
     }
 
-    c_put_str(TERM_GREEN, _("食過ぎ", "Gorged"), ROW_HUNGRY, COL_HUNGRY);
+    c_put_str(TERM_GREEN, _("食過ぎ", "Gorged"), row, COL_HUNGRY);
 }
 
 /*!
@@ -155,6 +163,9 @@ void print_hunger(PlayerType *player_ptr)
  */
 void print_state(PlayerType *player_ptr)
 {
+    TERM_LEN width, height;
+    term_get_size(&width, &height);
+
     TERM_COLOR attr = TERM_WHITE;
     std::string text;
     if (command_rep) {
@@ -164,7 +175,7 @@ void print_state(PlayerType *player_ptr)
             text = format("  %2d", command_rep);
         }
 
-        c_put_str(attr, format("%5.5s", text.data()), ROW_STATE, COL_STATE);
+        c_put_str(attr, format("%5.5s", text.data()), height + ROW_STATE, COL_STATE);
         return;
     }
 
@@ -246,7 +257,7 @@ void print_state(PlayerType *player_ptr)
     }
     }
 
-    c_put_str(attr, format("%5.5s", text.data()), ROW_STATE, COL_STATE);
+    c_put_str(attr, format("%5.5s", text.data()), height + ROW_STATE, COL_STATE);
 }
 
 /*!

--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -103,16 +103,20 @@ void WorldTurnProcessor::process_world()
  */
 void WorldTurnProcessor::print_time()
 {
+    TERM_LEN width, height;
+    term_get_size(&width, &height);
+    const auto row = height + ROW_DAY;
+
     int day;
-    c_put_str(TERM_WHITE, "             ", ROW_DAY, COL_DAY);
+    c_put_str(TERM_WHITE, "             ", row, COL_DAY);
     extract_day_hour_min(this->player_ptr, &day, &this->hour, &this->min);
     if (day < 1000) {
-        c_put_str(TERM_WHITE, format(_("%2d日目", "Day%3d"), day), ROW_DAY, COL_DAY);
+        c_put_str(TERM_WHITE, format(_("%2d日目", "Day%3d"), day), row, COL_DAY);
     } else {
-        c_put_str(TERM_WHITE, _("***日目", "Day***"), ROW_DAY, COL_DAY);
+        c_put_str(TERM_WHITE, _("***日目", "Day***"), row, COL_DAY);
     }
 
-    c_put_str(TERM_WHITE, format("%2d:%02d", this->hour, this->min), ROW_DAY, COL_DAY + 7);
+    c_put_str(TERM_WHITE, format("%2d:%02d", this->hour, this->min), row, COL_DAY + 7);
 }
 
 void WorldTurnProcessor::process_downward()


### PR DESCRIPTION
Resolves #3021 

PR #2852 で追加されたモンスターのHP表示部に追加情報を表示する機能において、画面サイズを考慮していないため小さな画面では情報がすべて表示されない。
表示内容を一旦機能追加前を基準としたものに戻したうえで、プレイヤーの切り傷・朦朧・空腹の状態やダンジョン名・経過日数はウィンドウの縦幅にあわせて下に移動させるようにし、空いたスペースにモンスターの状態を表示するようにする。
なお、縦サイズが最小の24行の場合は空きスペースは無いためモンスターの状態表示はされない。
