### PR TITLE
[Fix] クロークの灼熱エゴアイテムでクラッシュする

### DIFF
--- a/src/object/object-flags.cpp
+++ b/src/object/object-flags.cpp
@@ -12,30 +12,36 @@
 #include "util/bit-flags-calculator.h"
 
 /*!
- * @brief 光源用のフラグを付与する
+ * @brief エゴ光源のフラグを修正する
+ *
+ * 寿命のある光源で寿命が0ターンの時、光源エゴアイテムに起因するフラグは
+ * 灼熱エゴの火炎耐性を除き付与されないようにする。
+ *
  * @param o_ptr フラグ取得元のオブジェクト構造体ポインタ
  * @param flags フラグ情報を受け取る配列
  */
-static void object_flags_lite(const ItemEntity *o_ptr, TrFlags &flags)
+static void modify_ego_lite_flags(const ItemEntity *o_ptr, TrFlags &flags)
 {
     if (o_ptr->bi_key.tval() != ItemKindType::LITE) {
         return;
     }
 
-    const auto is_out_of_fuel = o_ptr->fuel == 0;
-    if ((o_ptr->ego_idx == EgoType::LITE_AURA_FIRE) && is_out_of_fuel && o_ptr->is_lite_requiring_fuel()) {
+    if (!o_ptr->is_lite_requiring_fuel() || o_ptr->fuel != 0) {
+        return;
+    }
+
+    switch (o_ptr->ego_idx) {
+    case EgoType::LITE_AURA_FIRE:
         flags.reset(TR_SH_FIRE);
         return;
-    }
-
-    if ((o_ptr->ego_idx == EgoType::LITE_INFRA) && is_out_of_fuel && o_ptr->is_lite_requiring_fuel()) {
+    case EgoType::LITE_INFRA:
         flags.reset(TR_INFRA);
         return;
-    }
-
-    if ((o_ptr->ego_idx == EgoType::LITE_EYE) && is_out_of_fuel && o_ptr->is_lite_requiring_fuel()) {
-        flags.reset(TR_RES_BLIND);
-        flags.reset(TR_SEE_INVIS);
+    case EgoType::LITE_EYE:
+        flags.reset({ TR_RES_BLIND, TR_SEE_INVIS });
+        return;
+    default:
+        return;
     }
 }
 
@@ -56,7 +62,7 @@ TrFlags object_flags(const ItemEntity *o_ptr)
     if (o_ptr->is_ego()) {
         const auto &ego = egos_info[o_ptr->ego_idx];
         flags.set(ego.flags);
-        object_flags_lite(o_ptr, flags);
+        modify_ego_lite_flags(o_ptr, flags);
     }
 
     flags.set(o_ptr->art_flags);
@@ -94,7 +100,7 @@ TrFlags object_flags_known(const ItemEntity *o_ptr)
     if (o_ptr->is_ego()) {
         const auto &ego = egos_info[o_ptr->ego_idx];
         flags.set(ego.flags);
-        object_flags_lite(o_ptr, flags);
+        modify_ego_lite_flags(o_ptr, flags);
     }
 
     if (o_ptr->is_fully_known()) {


### PR DESCRIPTION
Resolves #3069

object_flags_lite 関数内の光源の灼熱エゴに関する処理で、光源の灼熱エゴ (LITE_AURA_FIRE) ではなく、クロークの灼熱エゴ (AURA_FIRE) のフラグを誤ってチェックしており、クロークに対して is_lite_requiring_fuel() を呼び出してしまうことで
例外が発生しクラッシュする。
正しいフラグに修正し、また念のため光源以外のアイテムでは early return するようにしておく。