### PR TITLE
[Refactor] ウィンドウのデフォルトサイズを定数にする

### DIFF
--- a/src/birth/character-builder.cpp
+++ b/src/birth/character-builder.cpp
@@ -37,6 +37,7 @@
 #include "store/store-owners.h"
 #include "store/store.h"
 #include "system/player-type-definition.h"
+#include "term/gameterm.h"
 #include "term/z-form.h"
 #include "util/enum-converter.h"
 #include "view/display-messages.h"
@@ -90,9 +91,7 @@ static void write_birth_diary(PlayerType *player_ptr)
  */
 void player_birth(PlayerType *player_ptr)
 {
-    constexpr auto display_width = 80;
-    constexpr auto display_height = 24;
-    TermCenteredOffsetSetter tcos(display_width, display_height);
+    TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, MAIN_TERM_MIN_ROWS);
 
     w_ptr->play_time = 0;
     wipe_monsters_list(player_ptr);

--- a/src/cmd-io/cmd-gameoption.cpp
+++ b/src/cmd-io/cmd-gameoption.cpp
@@ -639,10 +639,10 @@ void do_cmd_options_aux(PlayerType *player_ptr, game_option_types page, concptr 
 {
     char ch;
     int i, k = 0, n = 0, l;
-    int opt[24];
+    int opt[MAIN_TERM_MIN_ROWS];
     bool browse_only = (page == OPT_PAGE_BIRTH) && w_ptr->character_generated && (!w_ptr->wizard || !allow_debug_opts);
 
-    for (i = 0; i < 24; i++) {
+    for (i = 0; i < MAIN_TERM_MIN_ROWS; i++) {
         opt[i] = 0;
     }
 

--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -77,13 +77,11 @@ void do_cmd_redraw(PlayerType *player_ptr)
  */
 void do_cmd_player_status(PlayerType *player_ptr)
 {
-    constexpr auto display_width = 80;
-    constexpr auto display_height = 24;
     int mode = 0;
     char tmp[160];
     screen_save();
     while (true) {
-        TermCenteredOffsetSetter tcos(display_width, display_height);
+        TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, MAIN_TERM_MIN_ROWS);
 
         update_playtime();
         (void)display_player(player_ptr, mode);

--- a/src/core/asking-player.cpp
+++ b/src/core/asking-player.cpp
@@ -8,6 +8,7 @@
 #include "io/input-key-requester.h" //!< @todo 相互依存している、後で何とかする.
 #include "main/sound-of-music.h"
 #include "system/player-type-definition.h"
+#include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 #include "term/z-form.h"
@@ -54,12 +55,12 @@ bool askfor(char *buf, int len, bool numpad_cursor)
         len = 1;
     }
 
-    if ((x < 0) || (x >= 80)) {
+    if ((x < 0) || (x >= MAIN_TERM_MIN_COLS)) {
         x = 0;
     }
 
-    if (x + len > 80) {
-        len = 80 - x;
+    if (x + len > MAIN_TERM_MIN_COLS) {
+        len = MAIN_TERM_MIN_COLS - x;
     }
 
     buf[len] = '\0';

--- a/src/core/game-closer.cpp
+++ b/src/core/game-closer.cpp
@@ -25,6 +25,7 @@
 #include "save/save.h"
 #include "system/floor-type-definition.h"
 #include "system/player-type-definition.h"
+#include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "util/angband-files.h"
 #include "util/int-char-converter.h"
@@ -129,7 +130,7 @@ static void kingly(PlayerType *player_ptr)
     }
 
     flush();
-    pause_line(23);
+    pause_line(MAIN_TERM_MIN_ROWS - 1);
 }
 
 /*!
@@ -160,7 +161,7 @@ void close_game(PlayerType *player_ptr)
         return;
     }
 
-    TermCenteredOffsetSetter tcos(80, 24);
+    TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, MAIN_TERM_MIN_ROWS);
     if (w_ptr->total_winner) {
         kingly(player_ptr);
     }

--- a/src/load/load-util.cpp
+++ b/src/load/load-util.cpp
@@ -1,5 +1,6 @@
 ﻿#include "load/load-util.h"
 #include "locale/japanese.h"
+#include "term/gameterm.h"
 #include "term/screen-processor.h"
 
 FILE *loading_savefile;
@@ -27,7 +28,7 @@ void load_note(std::string_view msg)
 {
     static TERM_LEN y = 2;
     prt(msg, y, 0);
-    if (++y >= 24) {
+    if (++y >= MAIN_TERM_MIN_ROWS) {
         y = 2;
     }
 

--- a/src/main-cap.cpp
+++ b/src/main-cap.cpp
@@ -4,6 +4,7 @@
 
 #include "io/exit-panic.h"
 #include "system/angband.h"
+#include "term/gameterm.h"
 #include "term/z-form.h"
 
 #ifdef USE_CAP
@@ -332,10 +333,10 @@ errr init_cap_aux(void)
 
     /* Get the (initial) columns and rows, or default */
     if ((cols = tgetnum("co")) == -1) {
-        cols = 80;
+        cols = TERM_DEFAULT_COLS;
     }
     if ((rows = tgetnum("li")) == -1) {
-        rows = 24;
+        rows = TERM_DEFAULT_ROWS;
     }
 
     /* Find out how to move the cursor to a given location */
@@ -399,8 +400,8 @@ errr init_cap_aux(void)
 #ifdef USE_HARDCODE
 
     /* Assume some defualt information */
-    rows = 24;
-    cols = 80;
+    rows = TERM_DEFAULT_ROWS;
+    cols = TERM_DEFAULT_COLS;
 
     /* Clear screen */
     cl = "\033[2J\033[H"; /* --]--]-- */
@@ -801,7 +802,7 @@ static errr game_term_wipe_cap(int x, int y, int n)
     game_term_curs_cap(x, y);
 
     /* Wipe to end of line */
-    if (x + n >= 80) {
+    if (x + n >= MAIN_TERM_MIN_COLS) {
         do_ce();
     }
 
@@ -960,7 +961,7 @@ errr init_cap(void)
     }
 
     /* Hack -- Require large screen, or Quit with message */
-    if ((rows < 24) || (cols < 80)) {
+    if ((rows < MAIN_TERM_MIN_ROWS) || (cols < MAIN_TERM_MIN_COLS)) {
         quit("Screen too small!");
     }
 
@@ -981,7 +982,7 @@ errr init_cap(void)
     /*** Now prepare the term ***/
 
     /* Initialize the term */
-    term_init(t, 80, 24, 256);
+    term_init(t, TERM_DEFAULT_COLS, TERM_DEFAULT_ROWS, 256);
 
     /* Avoid the bottom right corner */
     t->icky_corner = true;

--- a/src/main-gcu.cpp
+++ b/src/main-gcu.cpp
@@ -218,10 +218,6 @@ struct term_data {
 /* Max number of windows on screen */
 #define MAX_TERM_DATA 8
 
-/* Minimum main term size */
-#define MIN_TERM0_LINES 24
-#define MIN_TERM0_COLS 80
-
 /* Information about our windows */
 static term_data data[MAX_TERM_DATA];
 
@@ -1287,9 +1283,9 @@ errr init_gcu(int argc, char *argv[])
     core_aux = hook_quit;
 
     /* Hack -- Require large screen, or Quit with message */
-    i = ((LINES < 24) || (COLS < 80));
+    i = ((LINES < MAIN_TERM_MIN_ROWS) || (COLS < MAIN_TERM_MIN_COLS));
     if (i) {
-        quit_fmt("%s needs an 80x24 'curses' screen", std::string(VARIANT_NAME).data());
+        quit_fmt("%s needs an %dx%d 'curses' screen", std::string(VARIANT_NAME).data(), MAIN_TERM_MIN_COLS, MAIN_TERM_MIN_ROWS);
     }
 
 #ifdef A_COLOR
@@ -1402,36 +1398,36 @@ errr init_gcu(int argc, char *argv[])
             switch (i) {
             /* Upper left */
             case 0: {
-                rows = 24;
-                cols = 80;
+                rows = TERM_DEFAULT_ROWS;
+                cols = TERM_DEFAULT_COLS;
                 y = x = 0;
                 break;
             }
 
             /* Lower left */
             case 1: {
-                rows = LINES - 25;
-                cols = 80;
-                y = 25;
+                rows = LINES - TERM_DEFAULT_ROWS - 1;
+                cols = TERM_DEFAULT_COLS;
+                y = TERM_DEFAULT_ROWS + 1;
                 x = 0;
                 break;
             }
 
             /* Upper right */
             case 2: {
-                rows = 24;
-                cols = COLS - 81;
+                rows = TERM_DEFAULT_ROWS;
+                cols = COLS - TERM_DEFAULT_COLS - 1;
                 y = 0;
-                x = 81;
+                x = TERM_DEFAULT_COLS + 1;
                 break;
             }
 
             /* Lower right */
             case 3: {
-                rows = LINES - 25;
-                cols = COLS - 81;
-                y = 25;
-                x = 81;
+                rows = LINES - TERM_DEFAULT_ROWS - 1;
+                cols = COLS - TERM_DEFAULT_COLS - 1;
+                y = TERM_DEFAULT_ROWS + 1;
+                x = TERM_DEFAULT_COLS + 1;
                 break;
             }
 
@@ -1594,8 +1590,8 @@ errr init_gcu(int argc, char *argv[])
         }
 
         /* Map Terminal */
-        if (remaining.cx < MIN_TERM0_COLS || remaining.cy < MIN_TERM0_LINES) {
-            quit_fmt("Failed: %s needs an %dx%d map screen, not %dx%d", std::string(VARIANT_NAME).data(), MIN_TERM0_COLS, MIN_TERM0_LINES, remaining.cx, remaining.cy);
+        if (remaining.cx < MAIN_TERM_MIN_COLS || remaining.cy < MAIN_TERM_MIN_ROWS) {
+            quit_fmt("Failed: %s needs an %dx%d map screen, not %dx%d", std::string(VARIANT_NAME).data(), MAIN_TERM_MIN_COLS, MAIN_TERM_MIN_ROWS, remaining.cx, remaining.cy);
         }
         data[0].r = remaining;
         term_data_init(&data[0]);

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -1323,8 +1323,8 @@ static void init_windows(void)
     *td = {};
     td->name = win_term_name[0];
 
-    td->rows = 24;
-    td->cols = 80;
+    td->rows = MAIN_TERM_MIN_ROWS;
+    td->cols = MAIN_TERM_MIN_COLS;
     td->visible = true;
     td->size_ow1 = 2;
     td->size_ow2 = 2;
@@ -1338,8 +1338,8 @@ static void init_windows(void)
         td = &data[i];
         *td = {};
         td->name = win_term_name[i];
-        td->rows = 24;
-        td->cols = 80;
+        td->rows = TERM_DEFAULT_ROWS;
+        td->cols = TERM_DEFAULT_COLS;
         td->visible = false;
         td->size_ow1 = 1;
         td->size_ow2 = 1;
@@ -2161,8 +2161,8 @@ static bool handle_window_resize(term_data *td, UINT uMsg, WPARAM wParam, LPARAM
     switch (uMsg) {
     case WM_GETMINMAXINFO: {
         const bool is_main = is_main_term(td);
-        const int min_cols = (is_main) ? 80 : 20;
-        const int min_rows = (is_main) ? 24 : 3;
+        const int min_cols = (is_main) ? MAIN_TERM_MIN_COLS : 20;
+        const int min_rows = (is_main) ? MAIN_TERM_MIN_ROWS : 3;
         const LONG w = min_cols * td->tile_wid + td->size_ow1 + td->size_ow2;
         const LONG h = min_rows * td->tile_hgt + td->size_oh1 + td->size_oh2 + 1;
         RECT rc{ 0, 0, w, h };
@@ -2805,9 +2805,7 @@ int WINAPI WinMain(
     signals_init();
     term_activate(term_screen);
     {
-        constexpr auto display_width = 80;
-        constexpr auto display_height = 24;
-        TermCenteredOffsetSetter tcos(display_width, display_height);
+        TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, MAIN_TERM_MIN_ROWS);
 
         init_angband(p_ptr, false);
         initialized = true;

--- a/src/main-x11.cpp
+++ b/src/main-x11.cpp
@@ -1732,11 +1732,11 @@ static errr CheckEvent(bool wait)
         }
 
         if (td == &data[0]) {
-            if (cols < 80) {
-                cols = 80;
+            if (cols < MAIN_TERM_MIN_COLS) {
+                cols = MAIN_TERM_MIN_COLS;
             }
-            if (rows < 24) {
-                rows = 24;
+            if (rows < MAIN_TERM_MIN_ROWS) {
+                rows = MAIN_TERM_MIN_ROWS;
             }
         }
 
@@ -2186,8 +2186,8 @@ static errr term_data_init(term_data *td, int i)
     int x = 0;
     int y = 0;
 
-    int cols = 80;
-    int rows = 24;
+    int cols = TERM_DEFAULT_COLS;
+    int rows = TERM_DEFAULT_ROWS;
 
     int ox = 1;
     int oy = 1;
@@ -2264,11 +2264,11 @@ static errr term_data_init(term_data *td, int i)
     }
 
     if (!i) {
-        if (cols < 80) {
-            cols = 80;
+        if (cols < MAIN_TERM_MIN_COLS) {
+            cols = MAIN_TERM_MIN_COLS;
         }
-        if (rows < 24) {
-            rows = 24;
+        if (rows < MAIN_TERM_MIN_ROWS) {
+            rows = MAIN_TERM_MIN_ROWS;
         }
     }
 
@@ -2326,8 +2326,8 @@ static errr term_data_init(term_data *td, int i)
 
     if (i == 0) {
         sh->flags = PMinSize | PMaxSize;
-        sh->min_width = 80 * td->fnt->wid + (ox + ox);
-        sh->min_height = 24 * td->fnt->hgt + (oy + oy);
+        sh->min_width = MAIN_TERM_MIN_COLS * td->fnt->wid + (ox + ox);
+        sh->min_height = MAIN_TERM_MIN_ROWS * td->fnt->hgt + (oy + oy);
         sh->max_width = 255 * td->fnt->wid + (ox + ox);
         sh->max_height = 255 * td->fnt->hgt + (oy + oy);
     } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -564,15 +564,13 @@ int main(int argc, char *argv[])
     signals_init();
 
     {
-        constexpr auto display_width = 80;
-        constexpr auto display_height = 24;
-        TermCenteredOffsetSetter tcos(display_width, display_height);
+        TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, MAIN_TERM_MIN_ROWS);
 
         /* Initialize */
         init_angband(p_ptr, false);
 
         /* Wait for response */
-        pause_line(23);
+        pause_line(MAIN_TERM_MIN_ROWS - 1);
     }
 
     /* Play the game */

--- a/src/main/angband-initializer.cpp
+++ b/src/main/angband-initializer.cpp
@@ -28,6 +28,7 @@
 #include "system/dungeon-info.h"
 #include "system/monster-race-info.h"
 #include "system/system-variables.h"
+#include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 #include "time.h"
@@ -199,7 +200,7 @@ static void put_title()
 {
     const auto title = get_version();
 
-    auto col = (title.length() <= 80) ? (80 - title.length()) / 2 : 0;
+    auto col = (title.length() <= MAIN_TERM_MIN_COLS) ? (MAIN_TERM_MIN_COLS - title.length()) / 2 : 0;
     constexpr auto VER_INFO_ROW = 3; //!< タイトル表記(行)
     prt(title, VER_INFO_ROW, col);
 }

--- a/src/player-info/self-info.cpp
+++ b/src/player-info/self-info.cpp
@@ -27,6 +27,7 @@
 #include "player/player-status-flags.h"
 #include "player/player-status.h"
 #include "system/player-type-definition.h"
+#include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/z-form.h"
 #include "timed-effect/player-blindness.h"
@@ -429,7 +430,7 @@ void report_magics(PlayerType *player_ptr)
     screen_save();
 
     /* Erase the screen */
-    for (int k = 1; k < 24; k++) {
+    for (int k = 1; k < MAIN_TERM_MIN_ROWS; k++) {
         prt("", k, 13);
     }
 

--- a/src/store/cmd-store.cpp
+++ b/src/store/cmd-store.cpp
@@ -28,6 +28,7 @@
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "system/terrain-type-definition.h"
+#include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
@@ -58,7 +59,7 @@ void do_cmd_store(PlayerType *player_ptr)
     TERM_LEN w, h;
     term_get_size(&w, &h);
 
-    xtra_stock = std::min(14 + 26, ((h > 24) ? (h - 24) : 0));
+    xtra_stock = std::min(14 + 26, ((h > MAIN_TERM_MIN_ROWS) ? (h - MAIN_TERM_MIN_ROWS) : 0));
     store_bottom = MIN_STOCK + xtra_stock;
 
     auto *floor_ptr = player_ptr->current_floor_ptr;

--- a/src/term/gameterm.h
+++ b/src/term/gameterm.h
@@ -6,6 +6,11 @@
 #include <string>
 #include <utility>
 
+constexpr auto TERM_DEFAULT_COLS = 80;
+constexpr auto TERM_DEFAULT_ROWS = 24;
+constexpr auto MAIN_TERM_MIN_COLS = TERM_DEFAULT_COLS;
+constexpr auto MAIN_TERM_MIN_ROWS = TERM_DEFAULT_ROWS;
+
 extern const concptr color_names[16];
 extern const concptr window_flag_desc[32];
 extern const concptr ident_info[];

--- a/src/view/display-messages.cpp
+++ b/src/view/display-messages.cpp
@@ -97,28 +97,28 @@ static void message_add_aux(std::string str)
         return;
     }
 
-    // 80桁を超えるメッセージは80桁ずつ分割する
-    if (str.length() > 80) {
+    // MAIN_TERM_MIN_COLS桁を超えるメッセージはMAIN_TERM_MIN_COLS桁ずつ分割する
+    if (str.length() > MAIN_TERM_MIN_COLS) {
         int n;
 #ifdef JP
-        for (n = 0; n < 80; n++) {
+        for (n = 0; n < MAIN_TERM_MIN_COLS; n++) {
             if (iskanji(str[n])) {
                 n++;
             }
         }
 
         /* 最後の文字が漢字半分 */
-        if (n == 81) {
-            n = 79;
+        if (n == MAIN_TERM_MIN_COLS + 1) {
+            n = MAIN_TERM_MIN_COLS - 1;
         }
 #else
-        for (n = 80; n > 60; n--) {
+        for (n = MAIN_TERM_MIN_COLS; n > MAIN_TERM_MIN_COLS - 20; n--) {
             if (str[n] == ' ') {
                 break;
             }
         }
-        if (n == 60) {
-            n = 80;
+        if (n == MAIN_TERM_MIN_COLS - 20) {
+            n = MAIN_TERM_MIN_COLS;
         }
 #endif
         splitted = str.substr(n);

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -31,6 +31,7 @@
 #include "system/floor-type-definition.h"
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
+#include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 #include "view/display-characteristic.h"
@@ -68,8 +69,7 @@ static bool display_player_info(PlayerType *player_ptr, int mode)
     }
 
     if (mode == 5) {
-        constexpr auto display_width = 80;
-        TermCenteredOffsetSetter tcos(display_width, std::nullopt);
+        TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, std::nullopt);
         do_cmd_knowledge_mutations(player_ptr);
         return true;
     }

--- a/src/view/display-scores.cpp
+++ b/src/view/display-scores.cpp
@@ -7,6 +7,7 @@
 #include "player/player-personality.h"
 #include "player/race-info-table.h"
 #include "system/angband.h"
+#include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 #include "term/z-form.h"
@@ -65,11 +66,9 @@ void display_scores(int from, int to, int note, high_score *score)
         num_scores = to;
     }
 
-    constexpr auto display_width = 80;
-    constexpr auto display_height = 24;
-    constexpr auto per_screen = (display_height - 4) / 4;
+    constexpr auto per_screen = (MAIN_TERM_MIN_ROWS - 4) / 4;
     for (auto k = from, place = k + 1; k < num_scores; k += per_screen) {
-        TermCenteredOffsetSetter tcos(display_width, display_height);
+        TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, MAIN_TERM_MIN_ROWS);
 
         term_clear();
         put_str(_("                変愚蛮怒: 勇者の殿堂", "                Hengband Hall of Fame"), 0, 0);
@@ -188,9 +187,9 @@ void display_scores(int from, int to, int note, high_score *score)
             c_put_str(attr, out_val, n * 4 + 4, 0);
         }
 
-        prt(_("[ ESCで中断, その他のキーで続けます ]", "[Press ESC to quit, any other key to continue.]"), display_height - 1, _(21, 17));
+        prt(_("[ ESCで中断, その他のキーで続けます ]", "[Press ESC to quit, any other key to continue.]"), MAIN_TERM_MIN_ROWS - 1, _(21, 17));
         auto key = inkey();
-        prt("", display_height - 1, 0);
+        prt("", MAIN_TERM_MIN_ROWS - 1, 0);
         if (key == ESCAPE) {
             break;
         }

--- a/src/view/display-self-info.cpp
+++ b/src/view/display-self-info.cpp
@@ -6,6 +6,7 @@
 #include "player-info/self-info-util.h"
 #include "player/player-status-table.h"
 #include "system/player-type-definition.h"
+#include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/z-form.h"
 #include "util/string-processor.h"
@@ -103,7 +104,7 @@ void display_mimic_race_ability(PlayerType *player_ptr, self_info_type *self_ptr
 void display_self_info(self_info_type *self_ptr)
 {
     screen_save();
-    for (int k = 1; k < 24; k++) {
+    for (int k = 1; k < MAIN_TERM_MIN_ROWS; k++) {
         prt("", k, 13);
     }
 

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -12,6 +12,7 @@
 #include "system/monster-entity.h"
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
+#include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 #include "term/z-form.h"
@@ -434,7 +435,7 @@ void print_health(PlayerType *player_ptr, bool riding)
 
     TERM_LEN width, height;
     term_get_size(&width, &height);
-    const auto extra_line_count = height - 24;
+    const auto extra_line_count = height - MAIN_TERM_MIN_ROWS;
 
     // 一時的状態異常
     // MAX_WIDTHを超えたら次の行に移動する


### PR DESCRIPTION
Resolves #3075 

ウィンドウのデフォルトサイズ関連の値が即値で記述されている箇所が多数あるので、下記定数
を定義してそれを使用するようにする。

- TERM_DEFAULT_COLS: ウィンドウのデフォルト横サイズ
- TERM_DEFAULT_ROWS: ウィンドウのデフォルト縦サイズ
- MAIN_TERM_MIN_COLS: メインウィンドウの最小横サイズ
- MAIN_TERM_MIN_ROWS: メインウィンドウの最小縦サイズ

とりあえず 80 と 24 で検索してウィンドウのサイズに関係していそうな所は定数で置き換えました。
また、 80 と 24 そのものではなくこれらの数値からの差分として表すべき即値があると思われますが、さすがにすべてチェックはしきれないのでとりあえず目についたものだけに対応しています。