### PR TITLE
[Feature] 店舗・建物内の画面をウィンドウ中央に表示する

### DIFF
--- a/src/cmd-building/cmd-building.cpp
+++ b/src/cmd-building/cmd-building.cpp
@@ -63,6 +63,7 @@
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "system/terrain-type-definition.h"
+#include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
@@ -315,6 +316,8 @@ void do_cmd_building(PlayerType *player_ptr)
         msg_print(_("ここには建物はない。", "You see no building here."));
         return;
     }
+
+    TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, MAIN_TERM_MIN_ROWS);
 
     int which = terrains_info[player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x].feat].subtype;
 

--- a/src/core/show-file.cpp
+++ b/src/core/show-file.cpp
@@ -133,6 +133,8 @@ static void show_file_aux_line(concptr str, int cy, concptr shower)
  */
 bool show_file(PlayerType *player_ptr, bool show_version, concptr name, concptr what, int line, BIT_FLAGS mode)
 {
+    TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, std::nullopt);
+
     int wid, hgt;
     term_get_size(&wid, &hgt);
 

--- a/src/floor/object-scanner.cpp
+++ b/src/floor/object-scanner.cpp
@@ -102,8 +102,6 @@ static void prepare_label_string_floor(FloorType *floor_ptr, char *label, FLOOR_
  */
 COMMAND_CODE show_floor_items(PlayerType *player_ptr, int target_item, POSITION y, POSITION x, TERM_LEN *min_width, const ItemTester &item_tester)
 {
-    TermOffsetSetter tos(0, std::nullopt);
-
     COMMAND_CODE i, m;
     int j, k, l;
     ItemEntity *o_ptr;

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -589,7 +589,7 @@ static std::string get_check_sum(void)
  */
 void make_character_dump(PlayerType *player_ptr, FILE *fff)
 {
-    TermOffsetSetter tos(0, 0);
+    TermCenteredOffsetSetter tos(std::nullopt, std::nullopt);
 
     fprintf(fff, _("  [%s キャラクタ情報]\n\n", "  [%s Character Dump]\n\n"), get_version().data());
 

--- a/src/store/cmd-store.cpp
+++ b/src/store/cmd-store.cpp
@@ -56,6 +56,7 @@ void do_cmd_store(PlayerType *player_ptr)
     if (player_ptr->wild_mode) {
         return;
     }
+    TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, std::nullopt);
     TERM_LEN w, h;
     term_get_size(&w, &h);
 

--- a/src/term/z-term.cpp
+++ b/src/term/z-term.cpp
@@ -1874,6 +1874,9 @@ errr term_what(TERM_LEN x, TERM_LEN y, TERM_COLOR *a, char *c)
     TERM_LEN w = game_term->wid;
     TERM_LEN h = game_term->hgt;
 
+    x += game_term->offset_x;
+    y += game_term->offset_y;
+
     if ((x < 0) || (x >= w)) {
         return -1;
     }

--- a/src/term/z-term.cpp
+++ b/src/term/z-term.cpp
@@ -84,13 +84,26 @@ TermOffsetSetter::~TermOffsetSetter()
  * @param height 表示に使用する領域の縦幅
  */
 TermCenteredOffsetSetter::TermCenteredOffsetSetter(std::optional<TERM_LEN> width, std::optional<TERM_LEN> height)
+    : term(game_term)
+    , orig_centered_wid(game_term != nullptr ? game_term->centered_wid : std::nullopt)
+    , orig_centered_hgt(game_term != nullptr ? game_term->centered_hgt : std::nullopt)
 {
-    TERM_LEN term_width, term_height;
-    term_get_size(&term_width, &term_height);
-
-    const auto offset_x = width.has_value() ? (term_width - width.value()) / 2 : 0;
-    const auto offset_y = height.has_value() ? (term_height - height.value()) / 2 : 0;
+    const auto offset_x = width.has_value() ? (game_term->wid - width.value()) / 2 : 0;
+    const auto offset_y = height.has_value() ? (game_term->hgt - height.value()) / 2 : 0;
     this->tos.emplace(offset_x, offset_y);
+
+    game_term->centered_wid = (width < game_term->wid) ? width : std::nullopt;
+    game_term->centered_hgt = (height < game_term->hgt) ? height : std::nullopt;
+}
+
+TermCenteredOffsetSetter::~TermCenteredOffsetSetter()
+{
+    if (this->term == nullptr) {
+        return;
+    }
+
+    this->term->centered_wid = this->orig_centered_wid;
+    this->term->centered_hgt = this->orig_centered_hgt;
 }
 
 /*
@@ -1841,9 +1854,8 @@ errr term_get_cursor(int *v)
  */
 errr term_get_size(TERM_LEN *w, TERM_LEN *h)
 {
-    /* Access the cursor */
-    (*w) = game_term->wid;
-    (*h) = game_term->hgt;
+    (*w) = game_term->centered_wid.value_or(game_term->wid);
+    (*h) = game_term->centered_hgt.value_or(game_term->hgt);
     return 0;
 }
 

--- a/src/term/z-term.h
+++ b/src/term/z-term.h
@@ -77,6 +77,9 @@ struct term_type {
     TERM_LEN wid{}; //!< Window Width(max 255)
     TERM_LEN hgt{}; //!< Window Height(max 255)
 
+    std::optional<TERM_LEN> centered_wid{};
+    std::optional<TERM_LEN> centered_hgt{};
+
     TERM_LEN offset_x{};
     TERM_LEN offset_y{};
 
@@ -134,7 +137,7 @@ private:
 class TermCenteredOffsetSetter {
 public:
     TermCenteredOffsetSetter(std::optional<TERM_LEN> width, std::optional<TERM_LEN> height);
-    ~TermCenteredOffsetSetter() = default;
+    ~TermCenteredOffsetSetter();
     TermCenteredOffsetSetter(const TermCenteredOffsetSetter &) = delete;
     TermCenteredOffsetSetter &operator=(const TermCenteredOffsetSetter &) = delete;
     TermCenteredOffsetSetter(TermCenteredOffsetSetter &&) = delete;
@@ -142,6 +145,9 @@ public:
 
 private:
     std::optional<TermOffsetSetter> tos;
+    term_type *term;
+    std::optional<TERM_LEN> orig_centered_wid;
+    std::optional<TERM_LEN> orig_centered_hgt;
 };
 
 /**** Available Constants ****/

--- a/src/view/display-inventory.cpp
+++ b/src/view/display-inventory.cpp
@@ -28,8 +28,6 @@
  */
 COMMAND_CODE show_inventory(PlayerType *player_ptr, int target_item, BIT_FLAGS mode, const ItemTester &item_tester)
 {
-    TermOffsetSetter tos(0, std::nullopt);
-
     COMMAND_CODE i;
     int k, l, z = 0;
     ItemEntity *o_ptr;

--- a/src/window/main-window-equipments.cpp
+++ b/src/window/main-window-equipments.cpp
@@ -31,8 +31,6 @@
  */
 COMMAND_CODE show_equipment(PlayerType *player_ptr, int target_item, BIT_FLAGS mode, const ItemTester &item_tester)
 {
-    TermOffsetSetter tos(0, std::nullopt);
-
     COMMAND_CODE i;
     int j, k, l;
     ItemEntity *o_ptr;


### PR DESCRIPTION
#3040 の作業の一部です。

店舗・建物内の画面をウィンドウ中央に表示します。店舗・建物内で行えることは一通り試したつもりですが、漏れがないかご確認ください。

また、建物内のコマンドの「街の概要」の表示で使用されている show_file を中央化したため、店舗・建物内の画面表示以外で show_file を使用しているものも中央に表示されるようになっています。（ヘルプや知識の表示の一部など）
