### PR TITLE
[Feature] オプション画面をウィンドウ中央に表示する

### DIFF
--- a/src/cmd-io/cmd-autopick.cpp
+++ b/src/cmd-io/cmd-autopick.cpp
@@ -152,6 +152,8 @@ void do_cmd_edit_autopick(PlayerType *player_ptr)
         }
     }
 
+    TermCenteredOffsetSetter tcos(std::nullopt, std::nullopt);
+
     screen_save();
     while (quit == APE_QUIT) {
         int com_id = 0;

--- a/src/cmd-io/cmd-gameoption.cpp
+++ b/src/cmd-io/cmd-gameoption.cpp
@@ -428,6 +428,8 @@ void extract_option_vars(void)
  */
 void do_cmd_options(PlayerType *player_ptr)
 {
+    TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, MAIN_TERM_MIN_ROWS);
+
     char k;
     int d, skey;
     TERM_LEN i, y = 0;


### PR DESCRIPTION
オプション画面は 80x24 で表示することを想定しているので、ウィンドウ中央に表示する。

#3040 の作業の一部です。