### PR TITLE
[Feature] 2バイト文字を考慮しつつ部分文字列を切り出す関数

### DIFF
--- a/src/knowledge/knowledge-inventory.cpp
+++ b/src/knowledge/knowledge-inventory.cpp
@@ -155,7 +155,7 @@ static void do_cmd_knowledge_inventory_aux(PlayerType *player_ptr, FILE *fff, It
     char tmp_item_name[MAX_NLEN];
     describe_flavor(player_ptr, tmp_item_name, o_ptr, OD_NAME_ONLY);
     constexpr auto max_item_length = 26;
-    auto item_name = trim_kanji(std::string(tmp_item_name), max_item_length);
+    auto item_name = str_substr(tmp_item_name, 0, max_item_length);
     std::stringstream ss;
     ss << item_name;
     const int item_length = ss.tellp();

--- a/src/util/string-processor.h
+++ b/src/util/string-processor.h
@@ -1,7 +1,6 @@
 ﻿#pragma once
 
 #include "system/angband.h"
-#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -36,4 +35,6 @@ std::string str_ltrim(std::string_view str);
 std::vector<std::string> str_split(std::string_view str, char delim, bool trim = false, int num = 0);
 std::vector<std::string> str_separate(std::string_view str, size_t len);
 std::string str_erase(std::string str, std::string_view erase_chars);
-std::string trim_kanji(const std::string &str, std::optional<int> count = std::nullopt);
+std::string str_substr(std::string_view sv, size_t pos = 0, size_t n = std::string_view::npos);
+std::string str_substr(std::string &&str, size_t pos = 0, size_t n = std::string_view::npos);
+std::string str_substr(const char *str, size_t pos = 0, size_t n = std::string_view::npos);


### PR DESCRIPTION
Resolves #3083

2バイト文字を考慮しつつ部分文字列を切り出す関数 str_substr を実装する。
str_substr で trim_kanji 関数を置き換える。また、str_separate 関数の処理で str_substr を使用するように変更する。