### PR TITLE
[Fix] モンスターの思い出で一部の情報が表示されない

### DIFF
--- a/src/view/display-lore-status.cpp
+++ b/src/view/display-lore-status.cpp
@@ -51,12 +51,12 @@ void display_monster_concrete_abilities(lore_type *lore_ptr)
         lore_ptr->color[lore_ptr->vn++] = TERM_WHITE;
     }
 
-    if (lore_ptr->feature_flags.has(MonsterFeatureType::CAN_FLY)) {
+    if (lore_ptr->r_ptr->feature_flags.has(MonsterFeatureType::CAN_FLY)) {
         lore_ptr->vp[lore_ptr->vn] = _("空を飛ぶ", "fly");
         lore_ptr->color[lore_ptr->vn++] = TERM_WHITE;
     }
 
-    if (lore_ptr->feature_flags.has(MonsterFeatureType::CAN_SWIM)) {
+    if (lore_ptr->r_ptr->feature_flags.has(MonsterFeatureType::CAN_SWIM)) {
         lore_ptr->vp[lore_ptr->vn] = _("水を渡る", "swim");
         lore_ptr->color[lore_ptr->vn++] = TERM_WHITE;
     }
@@ -126,7 +126,7 @@ void display_monster_abilities(lore_type *lore_ptr)
 
 void display_monster_constitutions(lore_type *lore_ptr)
 {
-    if (lore_ptr->feature_flags.has(MonsterFeatureType::AQUATIC)) {
+    if (lore_ptr->r_ptr->feature_flags.has(MonsterFeatureType::AQUATIC)) {
         hooked_roff(format(_("%s^は水中に棲んでいる。", "%s^ lives in water.  "), Who::who(lore_ptr->msex)));
     }
 


### PR DESCRIPTION
Resolves #3102

AQUANTIC・CAN_SWIM・CAN_FLYの3つのフラグは元々思い出記録フラグが無く、無条件で表示されていたが、PASS_WALLやKILL_WALLと一緒にMonsterFeatureTypeに統合された時に思い出記録フラグがあるものとして扱われるようになった結果表示されることが無くなってしまっていた。
以前の仕様の通りにするため、これらのフラグは思い出を考慮せず直接モンスターのfeature_flagsを見るように修正する。