### PR TITLE
[Fix] サブウィンドウにモンスターの思い出を表示すると重くなる

### DIFF
--- a/src/monster/monster-processor-util.cpp
+++ b/src/monster/monster-processor-util.cpp
@@ -299,6 +299,7 @@ void save_old_race_flags(MonsterRaceId monster_race_idx, old_race_flags *old_rac
     old_race_flags_ptr->old_r_resistance_flags = r_ptr->r_resistance_flags;
     old_race_flags_ptr->old_r_ability_flags = r_ptr->r_ability_flags;
     old_race_flags_ptr->old_r_behavior_flags = r_ptr->r_behavior_flags;
+    old_race_flags_ptr->old_r_kind_flags = r_ptr->r_kind_flags;
     old_race_flags_ptr->old_r_drop_flags = r_ptr->r_drop_flags;
     old_race_flags_ptr->old_r_feature_flags = r_ptr->r_feature_flags;
 


### PR DESCRIPTION
Resolves #3113 

update_player_window関数でモンスターの思い出の状態が更新されたかを比較し、更新されていた場合はPW_MONSTERフラグを立ててサブウィンドウのモンスターの思い出の表示を更新するようになっている。しかし比較を行うための更新前のフラグold_r_kind_flagsの初期化が抜けてしまっているため、r_kind_flagsのいず れかのフラグがONの場合つねに更新されたと判定されてしまう。その結果ゲーム
ターン経過毎に毎回モンスターの思い出の再描画が実行され、非常に動作が重たくなってしまう。
正しくold_r_kind_flagsをr_kind_flagsで初期化するようにしておく。