### PR TITLE
[Fix] 床置きした固定アーティファクトが階移動で消滅する

### DIFF
--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -552,6 +552,11 @@ OBJECT_IDX drop_near(PlayerType *player_ptr, ItemEntity *j_ptr, PERCENTAGE chanc
         done = true;
     }
 
+    if (j_ptr->is_artifact() && w_ptr->character_dungeon) {
+        auto &artifact = artifacts_info.at(j_ptr->fixed_artifact_idx);
+        artifact.floor_id = player_ptr->floor_id;
+    }
+
     note_spot(player_ptr, by, bx);
     lite_spot(player_ptr, by, bx);
     sound(SOUND_DROP);

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -185,15 +185,7 @@ bool drop_single_artifact(PlayerType *player_ptr, monster_death_type *md_ptr, Fi
         return false;
     }
 
-    if (!create_named_art(player_ptr, a_idx, md_ptr->md_y, md_ptr->md_x)) {
-        return false;
-    }
-
-    if (w_ptr->character_dungeon) {
-        a_ref.floor_id = player_ptr->floor_id;
-    }
-
-    return true;
+    return create_named_art(player_ptr, a_idx, md_ptr->md_y, md_ptr->md_x);
 }
 
 static short drop_dungeon_final_artifact(PlayerType *player_ptr, monster_death_type *md_ptr)
@@ -211,11 +203,7 @@ static short drop_dungeon_final_artifact(PlayerType *player_ptr, monster_death_t
         return bi_id;
     }
 
-    if (create_named_art(player_ptr, a_idx, md_ptr->md_y, md_ptr->md_x)) {
-        if (w_ptr->character_dungeon) {
-            a_ref.floor_id = player_ptr->floor_id;
-        }
-    }
+    create_named_art(player_ptr, a_idx, md_ptr->md_y, md_ptr->md_x);
 
     return dungeon.final_object ? bi_id : 0;
 }

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -43,7 +43,6 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "view/display-messages.h"
-#include "world/world.h"
 
 /*!
  * @brief 死亡召喚に使用するモード選択
@@ -187,13 +186,7 @@ static void on_dead_sacred_treasures(PlayerType *player_ptr, monster_death_type 
         a_ptr = &artifacts_info.at(a_idx);
     } while (a_ptr->is_generated);
 
-    if (!create_named_art(player_ptr, a_idx, md_ptr->md_y, md_ptr->md_x)) {
-        return;
-    }
-
-    if (w_ptr->character_dungeon) {
-        a_ptr->floor_id = player_ptr->floor_id;
-    }
+    create_named_art(player_ptr, a_idx, md_ptr->md_y, md_ptr->md_x);
 }
 
 static void on_dead_serpent(PlayerType *player_ptr, monster_death_type *md_ptr)

--- a/src/object-enchant/item-magic-applier.cpp
+++ b/src/object-enchant/item-magic-applier.cpp
@@ -185,9 +185,6 @@ bool ItemMagicApplier::set_fixed_artifact_generation_info()
     apply_artifact(this->player_ptr, this->o_ptr);
     auto &a_ref = artifacts_info.at(this->o_ptr->fixed_artifact_idx);
     a_ref.is_generated = true;
-    if (w_ptr->character_dungeon) {
-        a_ref.floor_id = this->player_ptr->floor_id;
-    }
 
     return true;
 }


### PR DESCRIPTION
#3111 で言及した仕組みにより、床に固定アーティファクトを置いて階層を移動
すると元の階層に戻ってきた時に固定アーティファクトが消えてしまう。
drop_near関数に固定アーティファクトへの階層IDの記録を集約することで、固
定アーティファクトを持ち運んだ後に床置きした場合でも、階層を移動して戻っ
てきた時に消滅してしまわないようにする。