### PR TITLE
[Fix] 秩序の指輪の命中補正の表記方法

### DIFF
--- a/src/flavor/flavor-describer.cpp
+++ b/src/flavor/flavor-describer.cpp
@@ -29,6 +29,7 @@
 #include "smith/object-smith.h"
 #include "smith/smith-types.h"
 #include "sv-definition/sv-lite-types.h"
+#include "sv-definition/sv-ring-types.h"
 #include "sv-definition/sv-weapon-types.h"
 #include "system/baseitem-info.h"
 #include "system/floor-type-definition.h"
@@ -132,7 +133,7 @@ static bool should_show_slaying_bonus(const ItemEntity &item)
         const auto &baseitem = baseitems_info[item.bi_id];
         const auto base_has_no_bonus = (baseitem.to_h == 0) && (baseitem.to_d == 0);
         const auto item_has_bonus = (item.to_h != 0) || (item.to_d != 0);
-        if (base_has_no_bonus && item_has_bonus) {
+        if ((base_has_no_bonus && item_has_bonus) || (item.bi_key.sval() == SV_RING_LAW)) {
             return true;
         }
     }


### PR DESCRIPTION
Resolves #3118 

(+5) だけでは命中補正であることが分かりづらいので、(+5,+0) のように殺戮
修正の表記でわかりやすくする。