### PR TITLE
[Fix] メインウィンドウ左のプレイヤーの状態表示

### DIFF
--- a/src/window/main-window-row-column.h
+++ b/src/window/main-window-row-column.h
@@ -43,22 +43,22 @@
 #define ROW_CURSP 15
 #define COL_CURSP 0 /* "Cur SP xxxxx" */
 
-#define ROW_RIDING_INFO 16
+#define ROW_RIDING_INFO 19
 #define COL_RIDING_INFO 0 /* "xxxxxxxxxxxx" */
 
-#define ROW_INFO 17
+#define ROW_INFO 20
 #define COL_INFO 0 /* "xxxxxxxxxxxx" */
 
-#define ROW_CUT (-6)
+#define ROW_CUT 16
 #define COL_CUT 0 /* <cut> */
 
-#define ROW_STUN (-5)
+#define ROW_STUN 17
 #define COL_STUN 0 /* <stun> */
 
-#define ROW_HUNGRY (-4)
+#define ROW_HUNGRY 18
 #define COL_HUNGRY 0 /* "Weak" / "Hungry" / "Full" / "Gorged" */
 
-#define ROW_STATE (-4)
+#define ROW_STATE 18
 #define COL_STATE 7 /* <state> */
 
 #define ROW_DAY (-3)

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -81,16 +81,14 @@ void print_stat(PlayerType *player_ptr, int stat)
  */
 void print_cut(PlayerType *player_ptr)
 {
-    TERM_LEN width, height;
-    term_get_size(&width, &height);
     auto player_cut = player_ptr->effects()->cut();
     if (!player_cut->is_cut()) {
-        put_str("            ", height + ROW_CUT, COL_CUT);
+        put_str("            ", ROW_CUT, COL_CUT);
         return;
     }
 
     auto [color, stat] = player_cut->get_expr();
-    c_put_str(color, stat.data(), height + ROW_CUT, COL_CUT);
+    c_put_str(color, stat.data(), ROW_CUT, COL_CUT);
 }
 
 /*!
@@ -99,16 +97,14 @@ void print_cut(PlayerType *player_ptr)
  */
 void print_stun(PlayerType *player_ptr)
 {
-    TERM_LEN width, height;
-    term_get_size(&width, &height);
     auto player_stun = player_ptr->effects()->stun();
     if (!player_stun->is_stunned()) {
-        put_str("            ", height + ROW_STUN, COL_STUN);
+        put_str("            ", ROW_STUN, COL_STUN);
         return;
     }
 
     auto [color, stat] = player_stun->get_expr();
-    c_put_str(color, stat.data(), height + ROW_STUN, COL_STUN);
+    c_put_str(color, stat.data(), ROW_STUN, COL_STUN);
 }
 
 /*!
@@ -121,36 +117,32 @@ void print_hunger(PlayerType *player_ptr)
         return;
     }
 
-    TERM_LEN width, height;
-    term_get_size(&width, &height);
-    const auto row = height + ROW_HUNGRY;
-
     if (player_ptr->food < PY_FOOD_FAINT) {
-        c_put_str(TERM_RED, _("衰弱  ", "Weak  "), row, COL_HUNGRY);
+        c_put_str(TERM_RED, _("衰弱  ", "Weak  "), ROW_HUNGRY, COL_HUNGRY);
         return;
     }
 
     if (player_ptr->food < PY_FOOD_WEAK) {
-        c_put_str(TERM_ORANGE, _("衰弱  ", "Weak  "), row, COL_HUNGRY);
+        c_put_str(TERM_ORANGE, _("衰弱  ", "Weak  "), ROW_HUNGRY, COL_HUNGRY);
         return;
     }
 
     if (player_ptr->food < PY_FOOD_ALERT) {
-        c_put_str(TERM_YELLOW, _("空腹  ", "Hungry"), row, COL_HUNGRY);
+        c_put_str(TERM_YELLOW, _("空腹  ", "Hungry"), ROW_HUNGRY, COL_HUNGRY);
         return;
     }
 
     if (player_ptr->food < PY_FOOD_FULL) {
-        c_put_str(TERM_L_GREEN, "      ", row, COL_HUNGRY);
+        c_put_str(TERM_L_GREEN, "      ", ROW_HUNGRY, COL_HUNGRY);
         return;
     }
 
     if (player_ptr->food < PY_FOOD_MAX) {
-        c_put_str(TERM_L_GREEN, _("満腹  ", "Full  "), row, COL_HUNGRY);
+        c_put_str(TERM_L_GREEN, _("満腹  ", "Full  "), ROW_HUNGRY, COL_HUNGRY);
         return;
     }
 
-    c_put_str(TERM_GREEN, _("食過ぎ", "Gorged"), row, COL_HUNGRY);
+    c_put_str(TERM_GREEN, _("食過ぎ", "Gorged"), ROW_HUNGRY, COL_HUNGRY);
 }
 
 /*!
@@ -163,9 +155,6 @@ void print_hunger(PlayerType *player_ptr)
  */
 void print_state(PlayerType *player_ptr)
 {
-    TERM_LEN width, height;
-    term_get_size(&width, &height);
-
     TERM_COLOR attr = TERM_WHITE;
     std::string text;
     if (command_rep) {
@@ -175,7 +164,7 @@ void print_state(PlayerType *player_ptr)
             text = format("  %2d", command_rep);
         }
 
-        c_put_str(attr, format("%5.5s", text.data()), height + ROW_STATE, COL_STATE);
+        c_put_str(attr, format("%5.5s", text.data()), ROW_STATE, COL_STATE);
         return;
     }
 
@@ -257,7 +246,7 @@ void print_state(PlayerType *player_ptr)
     }
     }
 
-    c_put_str(attr, format("%5.5s", text.data()), height + ROW_STATE, COL_STATE);
+    c_put_str(attr, format("%5.5s", text.data()), ROW_STATE, COL_STATE);
 }
 
 /*!


### PR DESCRIPTION
メインウィンドウを大きくしていると切り傷・朦朧・空腹状態などが左下で見に
くいという意見があったので、プレイヤーのHP/MP表示の下に移動する。

サンプル：
![image](https://user-images.githubusercontent.com/1501750/219907235-cf1cd0f7-00ec-4248-941c-0772c9e8b9e6.png)
