### PR TITLE
[Fix] ランダムアーティファクトが床に落ちるとクラッシュする 

### DIFF
--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -399,7 +399,7 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, It
             }
 
             ADD_FLG(FLG_EGO);
-        } else if (o_ptr->is_artifact()) {
+        } else if (o_ptr->is_fixed_or_random_artifact()) {
             ADD_FLG(FLG_ARTIFACT);
         } else {
             if (o_ptr->is_equipment()) {

--- a/src/autopick/autopick-matcher.cpp
+++ b/src/autopick/autopick-matcher.cpp
@@ -94,7 +94,7 @@ bool is_autopick_match(PlayerType *player_ptr, ItemEntity *o_ptr, autopick_type 
     }
 
     if (IS_FLG(FLG_ARTIFACT)) {
-        if (!o_ptr->is_known() || !o_ptr->is_artifact()) {
+        if (!o_ptr->is_known() || !o_ptr->is_fixed_or_random_artifact()) {
             return false;
         }
     }

--- a/src/autopick/autopick-registry.cpp
+++ b/src/autopick/autopick-registry.cpp
@@ -130,7 +130,7 @@ bool autopick_autoregister(PlayerType *player_ptr, ItemEntity *o_ptr)
         return false;
     }
 
-    if ((o_ptr->is_known() && o_ptr->is_artifact()) || ((o_ptr->ident & IDENT_SENSE) && (o_ptr->feeling == FEEL_TERRIBLE || o_ptr->feeling == FEEL_SPECIAL))) {
+    if ((o_ptr->is_known() && o_ptr->is_fixed_or_random_artifact()) || ((o_ptr->ident & IDENT_SENSE) && (o_ptr->feeling == FEEL_TERRIBLE || o_ptr->feeling == FEEL_SPECIAL))) {
         GAME_TEXT o_name[MAX_NLEN];
         describe_flavor(player_ptr, o_name, o_ptr, 0);
         msg_format(_("%sは破壊不能だ。", "You cannot auto-destroy %s."), o_name);

--- a/src/core/object-compressor.cpp
+++ b/src/core/object-compressor.cpp
@@ -91,7 +91,7 @@ void compact_objects(PlayerType *player_ptr, int size)
             }
 
             int chance = 90;
-            if (o_ptr->is_artifact() && (cnt < 1000)) {
+            if (o_ptr->is_fixed_or_random_artifact() && (cnt < 1000)) {
                 chance = 100;
             }
 

--- a/src/effect/effect-item.cpp
+++ b/src/effect/effect-item.cpp
@@ -65,7 +65,7 @@ bool affect_item(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITION y
         bool plural = (o_ptr->number > 1);
 #endif
         auto flags = object_flags(o_ptr);
-        bool is_artifact = o_ptr->is_artifact();
+        bool is_fixed_or_random_artifact = o_ptr->is_fixed_or_random_artifact();
         switch (typ) {
         case AttributeType::ACID: {
             if (BreakerAcid().hates(o_ptr)) {
@@ -266,7 +266,7 @@ bool affect_item(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITION y
             describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
         }
 
-        if ((is_artifact || ignore)) {
+        if ((is_fixed_or_random_artifact || ignore)) {
             if (known && o_ptr->marked.has(OmType::FOUND)) {
                 msg_format(_("%sは影響を受けない！", (plural ? "The %s are unaffected!" : "The %s is unaffected!")), o_name);
             }

--- a/src/flavor/named-item-describer.cpp
+++ b/src/flavor/named-item-describer.cpp
@@ -256,7 +256,7 @@ static std::string describe_item_count_or_article_en(const ItemEntity &item, con
     const auto corpse_r_idx = i2enum<MonsterRaceId>(item.pval);
     auto is_unique_corpse = item.bi_key.tval() == ItemKindType::CORPSE;
     is_unique_corpse &= monraces_info[corpse_r_idx].kind_flags.has(MonsterKindType::UNIQUE);
-    if ((opt.known && item.is_artifact()) || is_unique_corpse) {
+    if ((opt.known && item.is_fixed_or_random_artifact()) || is_unique_corpse) {
         return "The ";
     }
 
@@ -273,7 +273,7 @@ static std::string describe_item_count_or_definite_article_en(const ItemEntity &
         return prefix;
     }
 
-    if (opt.known && item.is_artifact()) {
+    if (opt.known && item.is_fixed_or_random_artifact()) {
         return "The ";
     }
 

--- a/src/floor/floor-events.cpp
+++ b/src/floor/floor-events.cpp
@@ -165,7 +165,7 @@ static byte get_dungeon_feeling(PlayerType *player_ptr)
             delta += e_ptr->rating * base;
         }
 
-        if (o_ptr->is_artifact()) {
+        if (o_ptr->is_fixed_or_random_artifact()) {
             PRICE cost = object_value_real(o_ptr);
             delta += 10 * base;
             if (cost > 10000L) {

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -349,7 +349,7 @@ OBJECT_IDX drop_near(PlayerType *player_ptr, ItemEntity *j_ptr, PERCENTAGE chanc
     bool plural = (j_ptr->number != 1);
 #endif
     describe_flavor(player_ptr, o_name, j_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
-    if (!j_ptr->is_artifact() && (randint0(100) < chance)) {
+    if (!j_ptr->is_fixed_or_random_artifact() && (randint0(100) < chance)) {
 #ifdef JP
         msg_format("%sは消えた。", o_name);
 #else
@@ -429,7 +429,7 @@ OBJECT_IDX drop_near(PlayerType *player_ptr, ItemEntity *j_ptr, PERCENTAGE chanc
         }
     }
 
-    if (!flag && !j_ptr->is_artifact()) {
+    if (!flag && !j_ptr->is_fixed_or_random_artifact()) {
 #ifdef JP
         msg_format("%sは消えた。", o_name);
 #else

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -552,7 +552,7 @@ OBJECT_IDX drop_near(PlayerType *player_ptr, ItemEntity *j_ptr, PERCENTAGE chanc
         done = true;
     }
 
-    if (j_ptr->is_artifact() && w_ptr->character_dungeon) {
+    if (j_ptr->is_fixed_artifact() && w_ptr->character_dungeon) {
         auto &artifact = artifacts_info.at(j_ptr->fixed_artifact_idx);
         artifact.floor_id = player_ptr->floor_id;
     }

--- a/src/grid/stair.cpp
+++ b/src/grid/stair.cpp
@@ -78,7 +78,7 @@ bool cave_valid_bold(FloorType *floor_ptr, POSITION y, POSITION x)
     for (const auto this_o_idx : g_ptr->o_idx_list) {
         ItemEntity *o_ptr;
         o_ptr = &floor_ptr->o_list[this_o_idx];
-        if (o_ptr->is_artifact()) {
+        if (o_ptr->is_fixed_or_random_artifact()) {
             return false;
         }
     }

--- a/src/inventory/inventory-damage.cpp
+++ b/src/inventory/inventory-damage.cpp
@@ -44,7 +44,7 @@ void inventory_damage(PlayerType *player_ptr, const ObjectBreaker &breaker, int 
         }
 
         /* Hack -- for now, skip artifacts */
-        if (o_ptr->is_artifact()) {
+        if (o_ptr->is_fixed_or_random_artifact()) {
             continue;
         }
 

--- a/src/knowledge/knowledge-inventory.cpp
+++ b/src/knowledge/knowledge-inventory.cpp
@@ -74,7 +74,7 @@ static bool determine_spcial_item_type(ItemEntity *o_ptr, ItemKindType tval)
     is_special_item_type |= bi_key == BaseitemKey(ItemKindType::HELM, SV_DRAGON_HELM);
     is_special_item_type |= bi_key == BaseitemKey(ItemKindType::GLOVES, SV_SET_OF_DRAGON_GLOVES);
     is_special_item_type |= bi_key == BaseitemKey(ItemKindType::BOOTS, SV_PAIR_OF_DRAGON_GREAVE);
-    is_special_item_type |= o_ptr->is_artifact();
+    is_special_item_type |= o_ptr->is_fixed_or_random_artifact();
     return (o_ptr->is_wearable() && o_ptr->is_ego()) || is_special_item_type;
 }
 

--- a/src/market/building-craft-fix.cpp
+++ b/src/market/building-craft-fix.cpp
@@ -99,7 +99,7 @@ static std::pair<bool, ItemEntity *> select_repairing_broken_weapon(PlayerType *
         return { false, nullptr };
     }
 
-    if (!o_ptr->is_ego() && !o_ptr->is_artifact()) {
+    if (!o_ptr->is_ego() && !o_ptr->is_fixed_or_random_artifact()) {
         msg_format(_("それは直してもしょうがないぜ。", "It is worthless to repair."));
         return { false, o_ptr };
     }

--- a/src/mind/mind-priest.cpp
+++ b/src/mind/mind-priest.cpp
@@ -84,7 +84,7 @@ bool bless_weapon(PlayerType *player_ptr)
         return true;
     }
 
-    if (!(o_ptr->is_artifact() || o_ptr->is_ego()) || one_in_(3)) {
+    if (!(o_ptr->is_fixed_or_random_artifact() || o_ptr->is_ego()) || one_in_(3)) {
 #ifdef JP
         msg_format("%sは輝いた！", o_name);
 #else

--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -146,7 +146,7 @@ void process_eat_item(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
             continue;
         }
 
-        if (monap_ptr->o_ptr->is_artifact()) {
+        if (monap_ptr->o_ptr->is_fixed_or_random_artifact()) {
             continue;
         }
 

--- a/src/monster-floor/monster-object.cpp
+++ b/src/monster-floor/monster-object.cpp
@@ -205,7 +205,7 @@ void update_object_by_monster_movement(PlayerType *player_ptr, turn_flags *turn_
         const auto m_name = monster_desc(player_ptr, m_ptr, MD_INDEF_HIDDEN);
         update_object_flags(flags, flg_monster_kind, flgr);
 
-        auto is_unpickable_object = o_ptr->is_artifact();
+        auto is_unpickable_object = o_ptr->is_fixed_or_random_artifact();
         is_unpickable_object |= r_ptr->kind_flags.has_any_of(flg_monster_kind);
         is_unpickable_object |= !r_ptr->resistance_flags.has_all_of(flgr) && r_ptr->resistance_flags.has_not(MonsterResistanceType::RESIST_ALL);
         monster_pickup_object(player_ptr, turn_flags_ptr, m_idx, o_ptr, is_unpickable_object, ny, nx, m_name, o_name, this_o_idx);

--- a/src/object-enchant/object-curse.cpp
+++ b/src/object-enchant/object-curse.cpp
@@ -91,7 +91,7 @@ void curse_equipment(PlayerType *player_ptr, PERCENTAGE chance, PERCENTAGE heavy
 
     bool changed = false;
     int curse_power = 0;
-    if ((randint1(100) <= heavy_chance) && (o_ptr->is_artifact() || o_ptr->is_ego())) {
+    if ((randint1(100) <= heavy_chance) && (o_ptr->is_fixed_or_random_artifact() || o_ptr->is_ego())) {
         if (o_ptr->curse_flags.has_not(CurseTraitType::HEAVY_CURSE)) {
             changed = true;
         }

--- a/src/object-hook/hook-expendable.cpp
+++ b/src/object-hook/hook-expendable.cpp
@@ -70,7 +70,7 @@ bool item_tester_hook_quaff(PlayerType *player_ptr, const ItemEntity *o_ptr)
 bool can_player_destroy_object(PlayerType *player_ptr, ItemEntity *o_ptr)
 {
     /* Artifacts cannot be destroyed */
-    if (!o_ptr->is_artifact()) {
+    if (!o_ptr->is_fixed_or_random_artifact()) {
         return true;
     }
 

--- a/src/perception/simple-perception.cpp
+++ b/src/perception/simple-perception.cpp
@@ -438,7 +438,7 @@ void sense_inventory2(PlayerType *player_ptr)
  */
 item_feel_type pseudo_value_check_heavy(ItemEntity *o_ptr)
 {
-    if (o_ptr->is_artifact()) {
+    if (o_ptr->is_fixed_or_random_artifact()) {
         if (o_ptr->is_cursed() || o_ptr->is_broken()) {
             return FEEL_TERRIBLE;
         }
@@ -493,7 +493,7 @@ item_feel_type pseudo_value_check_light(ItemEntity *o_ptr)
         return FEEL_BROKEN;
     }
 
-    if (o_ptr->is_artifact()) {
+    if (o_ptr->is_fixed_or_random_artifact()) {
         return FEEL_UNCURSED;
     }
 

--- a/src/racial/racial-android.cpp
+++ b/src/racial/racial-android.cpp
@@ -139,7 +139,7 @@ void calc_android_exp(PlayerType *player_ptr)
         is_dragon_protector |= bi_key == BaseitemKey(ItemKindType::GLOVES, SV_SET_OF_DRAGON_GLOVES);
         is_dragon_protector |= bi_key == BaseitemKey(ItemKindType::BOOTS, SV_PAIR_OF_DRAGON_GREAVE);
         const auto is_diamond_edge = bi_key == BaseitemKey(ItemKindType::SWORD, SV_DIAMOND_EDGE);
-        if (o_ptr->is_artifact() || o_ptr->is_ego() || is_dragon_protector || is_diamond_edge) {
+        if (o_ptr->is_fixed_or_random_artifact() || o_ptr->is_ego() || is_dragon_protector || is_diamond_edge) {
             if (level > 65) {
                 level = 35 + (level - 65) / 5;
             } else if (level > 35) {

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -182,7 +182,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
                 return "";
             }
 
-            if (!one_in_(3) && (o_ptr->is_artifact() || f.has(TR_BLESSED))) {
+            if (!one_in_(3) && (o_ptr->is_fixed_or_random_artifact() || f.has(TR_BLESSED))) {
                 msg_format(_("%s は呪いを跳ね返した。", "%s resists the effect."), o_name);
                 if (one_in_(3)) {
                     if (o_ptr->to_d > 0) {
@@ -210,7 +210,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
                 msg_format(_("恐怖の暗黒オーラがあなたの%sを包み込んだ！", "A terrible black aura blasts your %s!"), o_name);
                 o_ptr->curse_flags.set(CurseTraitType::CURSED);
 
-                if (o_ptr->is_artifact() || o_ptr->is_ego()) {
+                if (o_ptr->is_fixed_or_random_artifact() || o_ptr->is_ego()) {
 
                     if (one_in_(3)) {
                         o_ptr->curse_flags.set(CurseTraitType::HEAVY_CURSE);
@@ -542,7 +542,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
                 return "";
             }
 
-            if (!one_in_(3) && (o_ptr->is_artifact() || f.has(TR_BLESSED))) {
+            if (!one_in_(3) && (o_ptr->is_fixed_or_random_artifact() || f.has(TR_BLESSED))) {
                 msg_format(_("%s は呪いを跳ね返した。", "%s resists the effect."), o_name);
                 if (one_in_(3)) {
                     if (o_ptr->to_d > 0) {
@@ -570,7 +570,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
                 msg_format(_("恐怖の暗黒オーラがあなたの%sを包み込んだ！", "A terrible black aura blasts your %s!"), o_name);
                 o_ptr->curse_flags.set(CurseTraitType::CURSED);
 
-                if (o_ptr->is_artifact() || o_ptr->is_ego()) {
+                if (o_ptr->is_fixed_or_random_artifact() || o_ptr->is_ego()) {
 
                     if (one_in_(3)) {
                         o_ptr->curse_flags.set(CurseTraitType::HEAVY_CURSE);

--- a/src/smith/object-smith.cpp
+++ b/src/smith/object-smith.cpp
@@ -347,7 +347,7 @@ Smith::DrainEssenceResult Smith::drain_essence(ItemEntity *o_ptr)
         }
     }
 
-    const auto is_artifact = o_ptr->is_artifact();
+    const auto is_fixed_or_random_artifact = o_ptr->is_fixed_or_random_artifact();
 
     // アイテムをエッセンス抽出後の状態にする
     const ItemEntity old_o = *o_ptr;
@@ -384,7 +384,7 @@ Smith::DrainEssenceResult Smith::drain_essence(ItemEntity *o_ptr)
         }
     }
 
-    if (is_artifact) {
+    if (is_fixed_or_random_artifact) {
         drain_values[SmithEssenceType::UNIQUE] += 10;
     }
 

--- a/src/smith/smith-info.cpp
+++ b/src/smith/smith-info.cpp
@@ -57,7 +57,7 @@ bool BasicSmithInfo::can_give_smith_effect(const ItemEntity *o_ptr) const
      * 残る具体的な絞り込みは BasicSmithInfo::can_give_smith_effect_impl およびその派生クラスで
      * オーバーライドした関数にて行う
      */
-    if (o_ptr->is_artifact() || o_ptr->smith_effect.has_value()) {
+    if (o_ptr->is_fixed_or_random_artifact() || o_ptr->smith_effect.has_value()) {
         return false;
     }
 
@@ -111,7 +111,7 @@ void ActivationSmithInfo::erase_essence(ItemEntity *o_ptr) const
 
 bool ActivationSmithInfo::can_give_smith_effect(const ItemEntity *o_ptr) const
 {
-    if (o_ptr->is_artifact() || o_ptr->smith_act_idx.has_value()) {
+    if (o_ptr->is_fixed_or_random_artifact() || o_ptr->smith_act_idx.has_value()) {
         return false;
     }
 

--- a/src/spell-kind/spells-detection.cpp
+++ b/src/spell-kind/spells-detection.cpp
@@ -317,7 +317,7 @@ bool detect_objects_magic(PlayerType *player_ptr, POSITION range)
 
         auto has_bonus = o_ptr->to_a > 0;
         has_bonus |= o_ptr->to_h + o_ptr->to_d > 0;
-        if (o_ptr->is_artifact() || o_ptr->is_ego() || is_object_magically(o_ptr->bi_key.tval()) || o_ptr->is_spell_book() || has_bonus) {
+        if (o_ptr->is_fixed_or_random_artifact() || o_ptr->is_ego() || is_object_magically(o_ptr->bi_key.tval()) || o_ptr->is_spell_book() || has_bonus) {
             o_ptr->marked.set(OmType::FOUND);
             lite_spot(player_ptr, y, x);
             detect = true;

--- a/src/spell-kind/spells-enchant.cpp
+++ b/src/spell-kind/spells-enchant.cpp
@@ -45,7 +45,7 @@ bool artifact_scroll(PlayerType *player_ptr)
 #endif
 
     bool okay = false;
-    if (o_ptr->is_artifact()) {
+    if (o_ptr->is_fixed_or_random_artifact()) {
 #ifdef JP
         msg_format("%sは既に伝説のアイテムです！", o_name);
 #else

--- a/src/spell-kind/spells-equipment.cpp
+++ b/src/spell-kind/spells-equipment.cpp
@@ -66,7 +66,7 @@ bool apply_disenchant(PlayerType *player_ptr, BIT_FLAGS mode)
 
     GAME_TEXT o_name[MAX_NLEN];
     describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
-    if (o_ptr->is_artifact() && (randint0(100) < 71)) {
+    if (o_ptr->is_fixed_or_random_artifact() && (randint0(100) < 71)) {
 #ifdef JP
         msg_format("%s(%c)は劣化を跳ね返した！", o_name, index_to_label(t));
 #else

--- a/src/spell-kind/spells-perception.cpp
+++ b/src/spell-kind/spells-perception.cpp
@@ -66,7 +66,7 @@ bool identify_item(PlayerType *player_ptr, ItemEntity *o_ptr)
     }
 
     if (!o_ptr->is_fully_known()) {
-        if (o_ptr->is_artifact() || one_in_(5)) {
+        if (o_ptr->is_fixed_or_random_artifact() || one_in_(5)) {
             chg_virtue(player_ptr, V_KNOWLEDGE, 1);
         }
     }

--- a/src/spell-realm/spells-craft.cpp
+++ b/src/spell-realm/spells-craft.cpp
@@ -281,7 +281,7 @@ bool pulish_shield(PlayerType *player_ptr)
     GAME_TEXT o_name[MAX_NLEN];
     describe_flavor(player_ptr, o_name, o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
 
-    auto is_pulish_successful = (o_ptr->bi_id > 0) && !o_ptr->is_artifact() && !o_ptr->is_ego();
+    auto is_pulish_successful = (o_ptr->bi_id > 0) && !o_ptr->is_fixed_or_random_artifact() && !o_ptr->is_ego();
     is_pulish_successful &= !o_ptr->is_cursed();
     is_pulish_successful &= (o_ptr->bi_key.sval() != SV_MIRROR_SHIELD);
     if (is_pulish_successful) {

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -226,7 +226,7 @@ bool curse_armor(PlayerType *player_ptr)
     GAME_TEXT o_name[MAX_NLEN];
     describe_flavor(player_ptr, o_name, o_ptr, OD_OMIT_PREFIX);
 
-    if (o_ptr->is_artifact() && one_in_(2)) {
+    if (o_ptr->is_fixed_or_random_artifact() && one_in_(2)) {
 #ifdef JP
         msg_format("%sが%sを包み込もうとしたが、%sはそれを跳ね返した！", "恐怖の暗黒オーラ", "防具", o_name);
 #else
@@ -271,7 +271,7 @@ bool curse_weapon_object(PlayerType *player_ptr, bool force, ItemEntity *o_ptr)
     GAME_TEXT o_name[MAX_NLEN];
     describe_flavor(player_ptr, o_name, o_ptr, OD_OMIT_PREFIX);
 
-    if (o_ptr->is_artifact() && one_in_(2) && !force) {
+    if (o_ptr->is_fixed_or_random_artifact() && one_in_(2) && !force) {
 #ifdef JP
         msg_format("%sが%sを包み込もうとしたが、%sはそれを跳ね返した！", "恐怖の暗黒オーラ", "武器", o_name);
 #else
@@ -314,7 +314,7 @@ void brand_bolts(PlayerType *player_ptr)
             continue;
         }
 
-        if (o_ptr->is_artifact() || o_ptr->is_ego()) {
+        if (o_ptr->is_fixed_or_random_artifact() || o_ptr->is_ego()) {
             continue;
         }
 
@@ -375,7 +375,7 @@ bool enchant_equipment(PlayerType *player_ptr, ItemEntity *o_ptr, int n, int efl
 
     int chance;
     auto res = false;
-    auto a = o_ptr->is_artifact();
+    auto a = o_ptr->is_fixed_or_random_artifact();
     auto force = (eflag & ENCH_FORCE);
     for (int i = 0; i < n; i++) {
         if (!force && randint0(prob) >= 100) {
@@ -529,7 +529,7 @@ void brand_weapon(PlayerType *player_ptr, int brand_type)
     auto special_weapon = bi_key == BaseitemKey(ItemKindType::SWORD, SV_POISON_NEEDLE);
     special_weapon |= bi_key == BaseitemKey(ItemKindType::POLEARM, SV_DEATH_SCYTHE);
     special_weapon |= bi_key == BaseitemKey(ItemKindType::SWORD, SV_DIAMOND_EDGE);
-    const auto is_normal_item = (o_ptr->bi_id > 0) && !o_ptr->is_artifact() && !o_ptr->is_ego() && !o_ptr->is_cursed() && !special_weapon;
+    const auto is_normal_item = (o_ptr->bi_id > 0) && !o_ptr->is_fixed_or_random_artifact() && !o_ptr->is_ego() && !o_ptr->is_cursed() && !special_weapon;
     if (!is_normal_item) {
         if (flush_failure) {
             flush();

--- a/src/store/service-checker.cpp
+++ b/src/store/service-checker.cpp
@@ -287,7 +287,7 @@ static int mass_book_produce(const PRICE cost)
 static int mass_equipment_produce(const ItemEntity &item, const PRICE cost)
 {
     int size = 1;
-    if (item.is_artifact() || item.is_ego()) {
+    if (item.is_fixed_or_random_artifact() || item.is_ego()) {
         return size;
     }
 

--- a/src/store/store-util.cpp
+++ b/src/store/store-util.cpp
@@ -152,7 +152,7 @@ bool store_object_similar(ItemEntity *o_ptr, ItemEntity *j_ptr)
         return false;
     }
 
-    if (o_ptr->is_artifact() || j_ptr->is_artifact()) {
+    if (o_ptr->is_fixed_or_random_artifact() || j_ptr->is_fixed_or_random_artifact()) {
         return false;
     }
 

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -290,7 +290,7 @@ void store_shuffle(PlayerType *player_ptr, StoreSaleType store_num)
     for (int i = 0; i < st_ptr->stock_num; i++) {
         ItemEntity *o_ptr;
         o_ptr = &st_ptr->stock[i];
-        if (o_ptr->is_artifact()) {
+        if (o_ptr->is_fixed_or_random_artifact()) {
             continue;
         }
 

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -322,11 +322,11 @@ bool ItemEntity::is_smith() const
 }
 
 /*!
- * @brief アイテムがアーティファクトかを返す /
+ * @brief アイテムが固定アーティファクトもしくはランダムアーティファクトであるかを返す /
  * Check if an object is artifact
- * @return アーティファクトならばtrueを返す
+ * @return 固定アーティファクトもしくはランダムアーティファクトならばtrueを返す
  */
-bool ItemEntity::is_artifact() const
+bool ItemEntity::is_fixed_or_random_artifact() const
 {
     return this->is_fixed_artifact() || this->randart_name.has_value();
 }
@@ -348,7 +348,7 @@ bool ItemEntity::is_fixed_artifact() const
  */
 bool ItemEntity::is_random_artifact() const
 {
-    return this->is_artifact() && !this->is_fixed_artifact();
+    return this->is_fixed_or_random_artifact() && !this->is_fixed_artifact();
 }
 
 /*!
@@ -358,7 +358,7 @@ bool ItemEntity::is_random_artifact() const
  */
 bool ItemEntity::is_nameless() const
 {
-    return !this->is_artifact() && !this->is_ego() && !this->is_smith();
+    return !this->is_fixed_or_random_artifact() && !this->is_ego() && !this->is_smith();
 }
 
 bool ItemEntity::is_valid() const
@@ -570,7 +570,7 @@ bool ItemEntity::can_pile(const ItemEntity *j_ptr) const
         return false;
     }
 
-    if (this->is_artifact() || j_ptr->is_artifact()) {
+    if (this->is_fixed_or_random_artifact() || j_ptr->is_fixed_or_random_artifact()) {
         return false;
     }
 

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -94,7 +94,7 @@ public:
     bool is_rare() const;
     bool is_ego() const;
     bool is_smith() const;
-    bool is_artifact() const;
+    bool is_fixed_or_random_artifact() const;
     bool is_fixed_artifact() const;
     bool is_random_artifact() const;
     bool is_nameless() const;

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -498,7 +498,7 @@ static void wiz_statistics(PlayerType *player_ptr, ItemEntity *o_ptr)
  */
 static void wiz_reroll_item(PlayerType *player_ptr, ItemEntity *o_ptr)
 {
-    if (o_ptr->is_artifact()) {
+    if (o_ptr->is_fixed_or_random_artifact()) {
         return;
     }
 
@@ -561,7 +561,7 @@ static void wiz_reroll_item(PlayerType *player_ptr, ItemEntity *o_ptr)
         case 's':
             q_ptr->prep(o_ptr->bi_id);
             ItemMagicApplier(player_ptr, q_ptr, player_ptr->current_floor_ptr->dun_level, AM_GOOD | AM_GREAT | AM_SPECIAL).execute();
-            if (!q_ptr->is_artifact()) {
+            if (!q_ptr->is_fixed_or_random_artifact()) {
                 become_random_artifact(player_ptr, q_ptr, false);
             }
 
@@ -591,7 +591,7 @@ static void wiz_reroll_item(PlayerType *player_ptr, ItemEntity *o_ptr)
  */
 static void wiz_tweak_item(PlayerType *player_ptr, ItemEntity *o_ptr)
 {
-    if (o_ptr->is_artifact()) {
+    if (o_ptr->is_fixed_or_random_artifact()) {
         return;
     }
 
@@ -638,7 +638,7 @@ static void wiz_tweak_item(PlayerType *player_ptr, ItemEntity *o_ptr)
  */
 static void wiz_quantity_item(ItemEntity *o_ptr)
 {
-    if (o_ptr->is_artifact()) {
+    if (o_ptr->is_fixed_or_random_artifact()) {
         return;
     }
 


### PR DESCRIPTION
https://github.com/hengband/hengband/commit/c0d486f1489bc2419274f8643c7c5c371ac4b1c6 で固定アーティファクトへのフロアIDの記録をdrop_near関数に移した
際、固定アーティファクトかどうかの判定をis_artifact()としてしまったため、
ランダムアーティファクトに対して固定アーティファクトのテーブルの検索を
行ってしまいクラッシュする。
正しくis_fixed_artifact()に修正する。

修正コミットは1行だけですが、加えて紛らわしい名前のためバグの原因となったis_artifact()関数をis_fixed_or_random_artifact()に改名するコミットも追加しています。
