### PR TITLE
describe_flavor() の引数からchar *を除去し、戻り値をstd::string に変えた

### DIFF
--- a/src/action/activation-execution.cpp
+++ b/src/action/activation-execution.cpp
@@ -162,9 +162,8 @@ static bool activate_artifact(PlayerType *player_ptr, ItemEntity *o_ptr)
     }
 
     auto *act_ptr = tmp_act_ptr.value();
-    GAME_TEXT name[MAX_NLEN];
-    describe_flavor(player_ptr, name, o_ptr, OD_NAME_ONLY | OD_OMIT_PREFIX | OD_BASE_NAME);
-    if (!switch_activation(player_ptr, &o_ptr, act_ptr, name)) {
+    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY | OD_OMIT_PREFIX | OD_BASE_NAME);
+    if (!switch_activation(player_ptr, &o_ptr, act_ptr, item_name.data())) {
         return false;
     }
 

--- a/src/action/weapon-shield.cpp
+++ b/src/action/weapon-shield.cpp
@@ -23,19 +23,18 @@
 void verify_equip_slot(PlayerType *player_ptr, INVENTORY_IDX item)
 {
     ItemEntity *o_ptr, *new_o_ptr;
-    GAME_TEXT o_name[MAX_NLEN];
-
+    std::string item_name;
     if (item == INVEN_MAIN_HAND) {
         if (!has_melee_weapon(player_ptr, INVEN_SUB_HAND)) {
             return;
         }
 
         o_ptr = &player_ptr->inventory_list[INVEN_SUB_HAND];
-        describe_flavor(player_ptr, o_name, o_ptr, 0);
+        item_name = describe_flavor(player_ptr, o_ptr, 0);
 
         if (o_ptr->is_cursed()) {
             if (o_ptr->allow_two_hands_wielding() && can_two_hands_wielding(player_ptr)) {
-                msg_format(_("%sを両手で構えた。", "You are wielding %s with both hands."), o_name);
+                msg_format(_("%sを両手で構えた。", "You are wielding %s with both hands."), item_name.data());
             }
             return;
         }
@@ -45,9 +44,10 @@ void verify_equip_slot(PlayerType *player_ptr, INVENTORY_IDX item)
         inven_item_increase(player_ptr, INVEN_SUB_HAND, -((int)o_ptr->number));
         inven_item_optimize(player_ptr, INVEN_SUB_HAND);
         if (new_o_ptr->allow_two_hands_wielding() && can_two_hands_wielding(player_ptr)) {
-            msg_format(_("%sを両手で構えた。", "You are wielding %s with both hands."), o_name);
+            msg_format(_("%sを両手で構えた。", "You are wielding %s with both hands."), item_name.data());
         } else {
-            msg_format(_("%sを%sで構えた。", "You are wielding %s in your %s hand."), o_name, (left_hander ? _("左手", "left") : _("右手", "right")));
+            const auto mes = _("%sを%sで構えた。", "You are wielding %s in your %s hand.");
+            msg_format(mes, item_name.data(), (left_hander ? _("左手", "left") : _("右手", "right")));
         }
         return;
     }
@@ -58,12 +58,12 @@ void verify_equip_slot(PlayerType *player_ptr, INVENTORY_IDX item)
 
     o_ptr = &player_ptr->inventory_list[INVEN_MAIN_HAND];
     if (o_ptr->bi_id) {
-        describe_flavor(player_ptr, o_name, o_ptr, 0);
+        item_name = describe_flavor(player_ptr, o_ptr, 0);
     }
 
     if (has_melee_weapon(player_ptr, INVEN_MAIN_HAND)) {
         if (o_ptr->allow_two_hands_wielding() && can_two_hands_wielding(player_ptr)) {
-            msg_format(_("%sを両手で構えた。", "You are wielding %s with both hands."), o_name);
+            msg_format(_("%sを両手で構えた。", "You are wielding %s with both hands."), item_name.data());
         }
 
         return;
@@ -77,5 +77,5 @@ void verify_equip_slot(PlayerType *player_ptr, INVENTORY_IDX item)
     new_o_ptr->copy_from(o_ptr);
     inven_item_increase(player_ptr, INVEN_MAIN_HAND, -((int)o_ptr->number));
     inven_item_optimize(player_ptr, INVEN_MAIN_HAND);
-    msg_format(_("%sを持ち替えた。", "You shifted %s to your other hand."), o_name);
+    msg_format(_("%sを持ち替えた。", "You shifted %s to your other hand."), item_name.data());
 }

--- a/src/autopick/autopick-destroyer.cpp
+++ b/src/autopick/autopick-destroyer.cpp
@@ -150,9 +150,8 @@ void auto_destroy_item(PlayerType *player_ptr, ItemEntity *o_ptr, int autopick_i
 
     disturb(player_ptr, false, false);
     if (!can_player_destroy_object(player_ptr, o_ptr)) {
-        GAME_TEXT o_name[MAX_NLEN];
-        describe_flavor(player_ptr, o_name, o_ptr, 0);
-        msg_format(_("%sは破壊不能だ。", "You cannot auto-destroy %s."), o_name);
+        const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+        msg_format(_("%sは破壊不能だ。", "You cannot auto-destroy %s."), item_name.data());
         return;
     }
 

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -506,14 +506,13 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, It
         return;
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NO_PLURAL | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NO_PLURAL | OD_NAME_ONLY));
 
     /*
      * If necessary, add a '^' which indicates the
      * beginning of line.
      */
-    entry->name = std::string(is_hat_added ? "^" : "").append(o_name);
+    entry->name = std::string(is_hat_added ? "^" : "").append(item_name);
     str_tolower(entry->name.data());
 }
 

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -726,10 +726,9 @@ concptr autopick_line_from_entry_kill(autopick_type *entry)
  */
 bool entry_from_choosed_object(PlayerType *player_ptr, autopick_type *entry)
 {
-    concptr q = _("どのアイテムを登録しますか? ", "Enter which item? ");
-    concptr s = _("アイテムを持っていない。", "You have nothing to enter.");
-    ItemEntity *o_ptr;
-    o_ptr = choose_object(player_ptr, nullptr, q, s, USE_INVEN | USE_FLOOR | USE_EQUIP);
+    constexpr auto q = _("どのアイテムを登録しますか? ", "Enter which item? ");
+    constexpr auto s = _("アイテムを持っていない。", "You have nothing to enter.");
+    auto *o_ptr = choose_object(player_ptr, nullptr, q, s, USE_INVEN | USE_FLOOR | USE_EQUIP);
     if (!o_ptr) {
         return false;
     }

--- a/src/autopick/autopick-finder.cpp
+++ b/src/autopick/autopick-finder.cpp
@@ -23,7 +23,6 @@
 #include "term/term-color-types.h"
 #include "util/int-char-converter.h"
 #include "util/string-processor.h"
-#include <string>
 
 /*!
  * @brief 与えられたアイテムが自動拾いのリストに登録されているかどうかを検索する
@@ -36,16 +35,15 @@
  */
 int find_autopick_list(PlayerType *player_ptr, ItemEntity *o_ptr)
 {
-    GAME_TEXT o_name[MAX_NLEN];
     if (o_ptr->bi_key.tval() == ItemKindType::GOLD) {
         return -1;
     }
 
-    describe_flavor(player_ptr, o_name, o_ptr, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NO_PLURAL));
-    str_tolower(o_name);
+    auto item_name = describe_flavor(player_ptr, o_ptr, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NO_PLURAL));
+    str_tolower(item_name.data());
     for (auto i = 0U; i < autopick_list.size(); i++) {
         autopick_type *entry = &autopick_list[i];
-        if (is_autopick_match(player_ptr, o_ptr, entry, o_name)) {
+        if (is_autopick_match(player_ptr, o_ptr, entry, item_name.data())) {
             return i;
         }
     }
@@ -68,9 +66,8 @@ bool get_object_for_search(PlayerType *player_ptr, ItemEntity **o_handle, concpt
 
     *o_handle = o_ptr;
     string_free(*search_strp);
-    char buf[MAX_NLEN + 20];
-    describe_flavor(player_ptr, buf, *o_handle, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NO_PLURAL));
-    *search_strp = string_make(format("<%s>", buf).data());
+    const auto item_name = describe_flavor(player_ptr, *o_handle, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NO_PLURAL));
+    *search_strp = string_make(format("<%s>", item_name.data()).data());
     return true;
 }
 
@@ -85,9 +82,8 @@ bool get_destroyed_object_for_search(PlayerType *player_ptr, ItemEntity **o_hand
 
     *o_handle = &autopick_last_destroyed_object;
     string_free(*search_strp);
-    char buf[MAX_NLEN + 20];
-    describe_flavor(player_ptr, buf, *o_handle, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NO_PLURAL));
-    *search_strp = string_make(format("<%s>", buf).data());
+    const auto item_name = describe_flavor(player_ptr, *o_handle, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NO_PLURAL));
+    *search_strp = string_make(format("<%s>", item_name.data()).data());
     return true;
 }
 
@@ -315,11 +311,10 @@ byte get_string_for_search(PlayerType *player_ptr, ItemEntity **o_handle, concpt
 void search_for_object(PlayerType *player_ptr, text_body_type *tb, ItemEntity *o_ptr, bool forward)
 {
     autopick_type an_entry, *entry = &an_entry;
-    GAME_TEXT o_name[MAX_NLEN];
     int bypassed_cy = -1;
     int i = tb->cy;
-    describe_flavor(player_ptr, o_name, o_ptr, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NO_PLURAL));
-    str_tolower(o_name);
+    auto item_name = describe_flavor(player_ptr, o_ptr, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NO_PLURAL));
+    str_tolower(item_name.data());
 
     while (true) {
         bool match;
@@ -337,7 +332,7 @@ void search_for_object(PlayerType *player_ptr, text_body_type *tb, ItemEntity *o
             continue;
         }
 
-        match = is_autopick_match(player_ptr, o_ptr, entry, o_name);
+        match = is_autopick_match(player_ptr, o_ptr, entry, item_name.data());
         if (!match) {
             continue;
         }

--- a/src/autopick/autopick-registry.cpp
+++ b/src/autopick/autopick-registry.cpp
@@ -131,9 +131,8 @@ bool autopick_autoregister(PlayerType *player_ptr, ItemEntity *o_ptr)
     }
 
     if ((o_ptr->is_known() && o_ptr->is_fixed_or_random_artifact()) || ((o_ptr->ident & IDENT_SENSE) && (o_ptr->feeling == FEEL_TERRIBLE || o_ptr->feeling == FEEL_SPECIAL))) {
-        GAME_TEXT o_name[MAX_NLEN];
-        describe_flavor(player_ptr, o_name, o_ptr, 0);
-        msg_format(_("%sは破壊不能だ。", "You cannot auto-destroy %s."), o_name);
+        const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+        msg_format(_("%sは破壊不能だ。", "You cannot auto-destroy %s."), item_name.data());
         return false;
     }
 

--- a/src/autopick/autopick.cpp
+++ b/src/autopick/autopick.cpp
@@ -33,6 +33,7 @@
 #include "term/screen-processor.h"
 #include "view/display-messages.h"
 #include "window/display-sub-windows.h"
+#include <sstream>
 
 /*!
  * @brief Auto-destroy marked item
@@ -46,8 +47,7 @@ static void autopick_delayed_alter_aux(PlayerType *player_ptr, INVENTORY_IDX ite
         return;
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
     if (item >= 0) {
         inven_item_increase(player_ptr, item, -(o_ptr->number));
         inven_item_optimize(player_ptr, item);
@@ -55,7 +55,7 @@ static void autopick_delayed_alter_aux(PlayerType *player_ptr, INVENTORY_IDX ite
         delete_object_idx(player_ptr, 0 - item);
     }
 
-    msg_format(_("%sを自動破壊します。", "Auto-destroying %s."), o_name);
+    msg_format(_("%sを自動破壊します。", "Auto-destroying %s."), item_name.data());
 }
 
 /*!
@@ -114,9 +114,8 @@ void autopick_pickup_items(PlayerType *player_ptr, grid_type *g_ptr)
 
         disturb(player_ptr, false, false);
         if (!check_store_item_to_inventory(player_ptr, o_ptr)) {
-            GAME_TEXT o_name[MAX_NLEN];
-            describe_flavor(player_ptr, o_name, o_ptr, 0);
-            msg_format(_("ザックには%sを入れる隙間がない。", "You have no room for %s."), o_name);
+            const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+            msg_format(_("ザックには%sを入れる隙間がない。", "You have no room for %s."), item_name.data());
             o_ptr->marked.set(OmType::SUPRESS_MESSAGE);
             continue;
         }
@@ -130,10 +129,10 @@ void autopick_pickup_items(PlayerType *player_ptr, grid_type *g_ptr)
             continue;
         }
 
-        GAME_TEXT o_name[MAX_NLEN];
-        describe_flavor(player_ptr, o_name, o_ptr, 0);
-        auto prompt = std::string(_(o_name, "Pick up ")).append(_("を拾いますか", o_name)).append("? ");
-        if (!get_check(prompt)) {
+        const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+        std::stringstream ss;
+        ss << _(item_name, "Pick up ") << _("を拾いますか", item_name) << "? ";
+        if (!get_check(ss.str())) {
             o_ptr->marked.set({ OmType::SUPRESS_MESSAGE, OmType::NO_QUERY });
             continue;
         }

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -277,7 +277,7 @@ void exe_eat_food(PlayerType *player_ptr, INVENTORY_IDX item)
     const auto corpse_r_idx = i2enum<MonsterRaceId>(o_ptr->pval);
     if (food_type == PlayerRaceFoodType::CORPSE && (bi_key == BaseitemKey(ItemKindType::CORPSE, SV_CORPSE) && angband_strchr("pht", monraces_info[corpse_r_idx].d_char))) {
         const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
-        msg_format(_("%sは燃え上り灰になった。精力を吸収した気がする。", "%^s is burnt to ashes.  You absorb its vitality!"), item_name.data());
+        msg_format(_("%sは燃え上り灰になった。精力を吸収した気がする。", "%s^ is burnt to ashes.  You absorb its vitality!"), item_name.data());
         (void)set_food(player_ptr, PY_FOOD_MAX - 1);
 
         player_ptr->update |= inventory_flags;

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -276,9 +276,8 @@ void exe_eat_food(PlayerType *player_ptr, INVENTORY_IDX item)
     /* Balrogs change humanoid corpses to energy */
     const auto corpse_r_idx = i2enum<MonsterRaceId>(o_ptr->pval);
     if (food_type == PlayerRaceFoodType::CORPSE && (bi_key == BaseitemKey(ItemKindType::CORPSE, SV_CORPSE) && angband_strchr("pht", monraces_info[corpse_r_idx].d_char))) {
-        GAME_TEXT o_name[MAX_NLEN];
-        describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
-        msg_format(_("%sは燃え上り灰になった。精力を吸収した気がする。", "%s^ is burnt to ashes.  You absorb its vitality!"), o_name);
+        const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+        msg_format(_("%sは燃え上り灰になった。精力を吸収した気がする。", "%^s is burnt to ashes.  You absorb its vitality!"), item_name.data());
         (void)set_food(player_ptr, PY_FOOD_MAX - 1);
 
         player_ptr->update |= inventory_flags;

--- a/src/cmd-item/cmd-equipment.cpp
+++ b/src/cmd-item/cmd-equipment.cpp
@@ -82,10 +82,9 @@ static void do_curse_on_equip(OBJECT_IDX slot, ItemEntity *o_ptr, PlayerType *pl
         return;
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     o_ptr->curse_flags.set(CurseTraitType::HEAVY_CURSE);
-    msg_format(_("悪意に満ちた黒いオーラが%sをとりまいた...", "There is a malignant black aura surrounding your %s..."), o_name);
+    msg_format(_("悪意に満ちた黒いオーラが%sをとりまいた...", "There is a malignant black aura surrounding your %s..."), item_name.data());
     o_ptr->feeling = FEEL_NONE;
     player_ptr->update |= (PU_BONUS);
 }
@@ -104,11 +103,11 @@ void do_cmd_equip(PlayerType *player_ptr)
     (void)show_equipment(player_ptr, 0, USE_FULL, AllMatchItemTester());
     auto weight = calc_inventory_weight(player_ptr);
     auto weight_lim = calc_weight_limit(player_ptr);
-    std::string out_val;
+    const auto mes = _("装備： 合計 %3d.%1d kg (限界の%d%%) コマンド: ", "Equipment: carrying %d.%d pounds (%d%% of capacity). Command: ");
 #ifdef JP
-    out_val = format("装備： 合計 %3d.%1d kg (限界の%d%%) コマンド: ", lb_to_kg_integer(weight), lb_to_kg_fraction(weight), weight * 100 / weight_lim);
+    const auto out_val = format(mes, lb_to_kg_integer(weight), lb_to_kg_fraction(weight), weight * 100 / weight_lim);
 #else
-    out_val = format("Equipment: carrying %d.%d pounds (%d%% of capacity). Command: ", weight / 10, weight % 10, weight * 100 / weight_lim);
+    const auto out_val = format(mes, weight / 10, weight % 10, weight * 100 / weight_lim);
 #endif
 
     prt(out_val, 0, 0);
@@ -137,7 +136,6 @@ void do_cmd_wield(PlayerType *player_ptr)
     ItemEntity *q_ptr;
     ItemEntity *o_ptr;
     concptr act;
-    GAME_TEXT o_name[MAX_NLEN];
     OBJECT_IDX need_switch_wielding = 0;
     PlayerClass(player_ptr).break_samurai_stance({ SamuraiStanceType::MUSOU });
 
@@ -226,11 +224,11 @@ void do_cmd_wield(PlayerType *player_ptr)
     }
 
     if (player_ptr->inventory_list[slot].is_cursed()) {
-        describe_flavor(player_ptr, o_name, &player_ptr->inventory_list[slot], OD_OMIT_PREFIX | OD_NAME_ONLY);
+        const auto item_name = describe_flavor(player_ptr, &player_ptr->inventory_list[slot], OD_OMIT_PREFIX | OD_NAME_ONLY);
 #ifdef JP
-        msg_format("%s%sは呪われているようだ。", describe_use(player_ptr, slot), o_name);
+        msg_format("%s%sは呪われているようだ。", describe_use(player_ptr, slot), item_name.data());
 #else
-        msg_format("The %s you are %s appears to be cursed.", o_name, describe_use(player_ptr, slot));
+        msg_format("The %s you are %s appears to be cursed.", item_name.data(), describe_use(player_ptr, slot));
 #endif
         return;
     }
@@ -239,8 +237,8 @@ void do_cmd_wield(PlayerType *player_ptr)
     should_equip_cursed |= any_bits(o_ptr->ident, IDENT_SENSE) && (FEEL_BROKEN <= o_ptr->feeling) && (o_ptr->feeling <= FEEL_CURSED);
     should_equip_cursed &= confirm_wear;
     if (should_equip_cursed) {
-        describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
-        if (!get_check(format(_("本当に%s{呪われている}を使いますか？", "Really use the %s {cursed}? "), o_name))) {
+        const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+        if (!get_check(format(_("本当に%s{呪われている}を使いますか？", "Really use the %s {cursed}? "), item_name.data()))) {
             return;
         }
     }
@@ -251,10 +249,10 @@ void do_cmd_wield(PlayerType *player_ptr)
     should_change_vampire &= !pr.equals(PlayerRaceType::VAMPIRE);
     should_change_vampire &= !pr.equals(PlayerRaceType::ANDROID);
     if (should_change_vampire) {
-        describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+        const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
         constexpr auto mes = _("%sを装備すると吸血鬼になります。よろしいですか？",
             "%s will transform you into a vampire permanently when equipped. Do you become a vampire? ");
-        if (!get_check(format(mes, o_name))) {
+        if (!get_check(format(mes, item_name.data()))) {
             return;
         }
     }
@@ -265,12 +263,11 @@ void do_cmd_wield(PlayerType *player_ptr)
         ItemEntity *switch_o_ptr = &player_ptr->inventory_list[need_switch_wielding];
         ItemEntity object_tmp;
         ItemEntity *otmp_ptr = &object_tmp;
-        GAME_TEXT switch_name[MAX_NLEN];
-        describe_flavor(player_ptr, switch_name, switch_o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+        const auto item_name = describe_flavor(player_ptr, switch_o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
         otmp_ptr->copy_from(switch_o_ptr);
         switch_o_ptr->copy_from(slot_o_ptr);
         slot_o_ptr->copy_from(otmp_ptr);
-        msg_format(_("%sを%sに構えなおした。", "You wield %s at %s hand."), switch_name,
+        msg_format(_("%sを%sに構えなおした。", "You wield %s at %s hand."), item_name.data(),
             (slot == INVEN_MAIN_HAND) ? (left_hander ? _("左手", "left") : _("右手", "right")) : (left_hander ? _("右手", "right") : _("左手", "left")));
         slot = need_switch_wielding;
     }
@@ -334,8 +331,8 @@ void do_cmd_wield(PlayerType *player_ptr)
         break;
     }
 
-    describe_flavor(player_ptr, o_name, o_ptr, 0);
-    msg_format(act, o_name, index_to_label(slot));
+    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    msg_format(act, item_name.data(), index_to_label(slot));
     if (o_ptr->is_cursed()) {
         msg_print(_("うわ！ すさまじく冷たい！", "Oops! It feels deathly cold!"));
         chg_virtue(player_ptr, V_HARMONY, -1);
@@ -343,7 +340,6 @@ void do_cmd_wield(PlayerType *player_ptr)
     }
 
     do_curse_on_equip(slot, o_ptr, player_ptr);
-
     if (o_ptr->is_specific_artifact(FixedArtifactId::STONEMASK) && !pr.equals(PlayerRaceType::VAMPIRE) && !pr.equals(PlayerRaceType::ANDROID)) {
         change_race(player_ptr, PlayerRaceType::VAMPIRE, "");
     }

--- a/src/cmd-item/cmd-item.cpp
+++ b/src/cmd-item/cmd-item.cpp
@@ -152,11 +152,9 @@ void do_cmd_drop(PlayerType *player_ptr)
 void do_cmd_observe(PlayerType *player_ptr)
 {
     OBJECT_IDX item;
-    ItemEntity *o_ptr;
-    GAME_TEXT o_name[MAX_NLEN];
-    concptr q = _("どのアイテムを調べますか? ", "Examine which item? ");
-    concptr s = _("調べられるアイテムがない。", "You have nothing to examine.");
-    o_ptr = choose_object(player_ptr, &item, q, s, (USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT));
+    const auto q = _("どのアイテムを調べますか? ", "Examine which item? ");
+    const auto s = _("調べられるアイテムがない。", "You have nothing to examine.");
+    auto *o_ptr = choose_object(player_ptr, &item, q, s, (USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT));
     if (!o_ptr) {
         return;
     }
@@ -166,8 +164,8 @@ void do_cmd_observe(PlayerType *player_ptr)
         return;
     }
 
-    describe_flavor(player_ptr, o_name, o_ptr, 0);
-    msg_format(_("%sを調べている...", "Examining %s..."), o_name);
+    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    msg_format(_("%sを調べている...", "Examining %s..."), item_name.data());
     if (!screen_object(player_ptr, o_ptr, SCROBJ_FORCE_DETAIL)) {
         msg_print(_("特に変わったところはないようだ。", "You see nothing special."));
     }
@@ -207,18 +205,16 @@ void do_cmd_uninscribe(PlayerType *player_ptr)
 void do_cmd_inscribe(PlayerType *player_ptr)
 {
     OBJECT_IDX item;
-    ItemEntity *o_ptr;
-    GAME_TEXT o_name[MAX_NLEN];
     char out_val[MAX_INSCRIPTION + 1] = "";
-    concptr q = _("どのアイテムに銘を刻みますか? ", "Inscribe which item? ");
-    concptr s = _("銘を刻めるアイテムがない。", "You have nothing to inscribe.");
-    o_ptr = choose_object(player_ptr, &item, q, s, (USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT));
+    const auto q = _("どのアイテムに銘を刻みますか? ", "Inscribe which item? ");
+    const auto s = _("銘を刻めるアイテムがない。", "You have nothing to inscribe.");
+    auto *o_ptr = choose_object(player_ptr, &item, q, s, (USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT));
     if (!o_ptr) {
         return;
     }
 
-    describe_flavor(player_ptr, o_name, o_ptr, OD_OMIT_INSCRIPTION);
-    msg_format(_("%sに銘を刻む。", "Inscribing %s."), o_name);
+    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_OMIT_INSCRIPTION);
+    msg_format(_("%sに銘を刻む。", "Inscribing %s."), item_name.data());
     msg_print(nullptr);
     strcpy(out_val, "");
     if (o_ptr->is_inscribed()) {

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -162,21 +162,16 @@ void do_cmd_visuals(PlayerType *player_ptr)
                     continue;
                 }
 
-                std::string o_name("");
-                GAME_TEXT char_o_name[MAX_NLEN]{};
+                std::string item_name;
                 if (baseitem.flavor == 0) {
-                    o_name = strip_name(baseitem.idx);
+                    item_name = strip_name(baseitem.idx);
                 } else {
                     ItemEntity dummy;
                     dummy.prep(baseitem.idx);
-                    describe_flavor(player_ptr, char_o_name, &dummy, OD_FORCE_FLAVOR);
+                    item_name = describe_flavor(player_ptr, &dummy, OD_FORCE_FLAVOR);
                 }
 
-                if (o_name == "") {
-                    o_name = char_o_name;
-                }
-
-                auto_dump_printf(auto_dump_stream, "# %s\n", o_name.data());
+                auto_dump_printf(auto_dump_stream, "# %s\n", item_name.data());
                 auto_dump_printf(auto_dump_stream, "K:%d:0x%02X/0x%02X\n\n", (int)baseitem.idx, (byte)(baseitem.x_attr), (byte)(baseitem.x_char));
             }
 

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -512,8 +512,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX item, ItemEntity *j_ptr, SPE
         snipe_type = SP_NONE;
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, OD_OMIT_PREFIX);
+    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_OMIT_PREFIX);
 
     /* Use the proper number of shots */
     auto thits = player_ptr->num_fire;
@@ -766,7 +765,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX item, ItemEntity *j_ptr, SPE
                 }
 
                 /* Did we hit it (penalize range) */
-                if (test_hit_fire(player_ptr, chance - cur_dis, m_ptr, m_ptr->ml, o_name)) {
+                if (test_hit_fire(player_ptr, chance - cur_dis, m_ptr, m_ptr->ml, item_name.data())) {
                     bool fear = false;
                     auto tdam = tdam_base; //!< @note 実際に与えるダメージ
                     auto base_dam = tdam; //!< @note 補正前の与えるダメージ(無傷、全ての耐性など)
@@ -777,7 +776,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX item, ItemEntity *j_ptr, SPE
                     /* Handle unseen monster */
                     if (!visible) {
                         /* Invisible monster */
-                        msg_format(_("%sが敵を捕捉した。", "The %s finds a mark."), o_name);
+                        msg_format(_("%sが敵を捕捉した。", "The %s finds a mark."), item_name.data());
                     }
 
                     /* Handle visible monster */
@@ -785,7 +784,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX item, ItemEntity *j_ptr, SPE
                         /* Get "the monster" or "it" */
                         const auto m_name = monster_desc(player_ptr, m_ptr, 0);
 
-                        msg_format(_("%sが%sに命中した。", "The %s hits %s."), o_name, m_name.data());
+                        msg_format(_("%sが%sに命中した。", "The %s hits %s."), item_name.data(), m_name.data());
 
                         if (m_ptr->ml) {
                             if (!player_ptr->effects()->hallucination()->is_hallucinated()) {
@@ -859,7 +858,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX item, ItemEntity *j_ptr, SPE
                             const auto m_name = monster_desc(player_ptr, m_ptr, 0);
 
                             stick_to = true;
-                            msg_format(_("%sは%sに突き刺さった！", "%s^ is stuck in %s!"), o_name, m_name.data());
+                            msg_format(_("%sは%sに突き刺さった！", "%^s is stuck in %s!"), item_name.data(), m_name.data());
                         }
 
                         if (const auto pain_message = MonsterPainDescriber(player_ptr, c_mon_ptr->m_idx).describe(tdam);
@@ -955,7 +954,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX item, ItemEntity *j_ptr, SPE
             OBJECT_IDX o_idx = o_pop(player_ptr->current_floor_ptr);
 
             if (!o_idx) {
-                msg_format(_("%sはどこかへ行った。", "The %s went somewhere."), o_name);
+                msg_format(_("%sはどこかへ行った。", "The %s went somewhere."), item_name.data());
                 if (q_ptr->is_fixed_artifact()) {
                     artifacts_info.at(j_ptr->fixed_artifact_idx).is_generated = false;
                 }

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -858,7 +858,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX item, ItemEntity *j_ptr, SPE
                             const auto m_name = monster_desc(player_ptr, m_ptr, 0);
 
                             stick_to = true;
-                            msg_format(_("%sは%sに突き刺さった！", "%^s is stuck in %s!"), item_name.data(), m_name.data());
+                            msg_format(_("%sは%sに突き刺さった！", "%s^ is stuck in %s!"), item_name.data(), m_name.data());
                         }
 
                         if (const auto pain_message = MonsterPainDescriber(player_ptr, c_mon_ptr->m_idx).describe(tdam);

--- a/src/effect/effect-item.cpp
+++ b/src/effect/effect-item.cpp
@@ -260,22 +260,22 @@ bool affect_item(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITION y
             continue;
         }
 
-        GAME_TEXT o_name[MAX_NLEN];
+        std::string item_name("");
         if (known && o_ptr->marked.has(OmType::FOUND)) {
             is_item_affected = true;
-            describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+            item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
         }
 
         if ((is_fixed_or_random_artifact || ignore)) {
             if (known && o_ptr->marked.has(OmType::FOUND)) {
-                msg_format(_("%sは影響を受けない！", (plural ? "The %s are unaffected!" : "The %s is unaffected!")), o_name);
+                msg_format(_("%sは影響を受けない！", (plural ? "The %s are unaffected!" : "The %s is unaffected!")), item_name.data());
             }
 
             continue;
         }
 
         if (known && o_ptr->marked.has(OmType::FOUND) && note_kill) {
-            msg_format(_("%sは%s", "The %s%s"), o_name, note_kill);
+            msg_format(_("%sは%s", "The %s%s"), item_name.data(), note_kill);
         }
 
         short bi_id = o_ptr->bi_id;

--- a/src/flavor/flavor-describer.cpp
+++ b/src/flavor/flavor-describer.cpp
@@ -571,14 +571,13 @@ static describe_option_type decide_describe_option(const ItemEntity &item, BIT_F
 }
 
 /*!
- * @brief オブジェクトの各表記を返すメイン関数 / Creates a description of the item "o_ptr", and stores it in "out_val".
+ * @brief オブジェクトの各表記を返す
  * @param player_ptr プレイヤーへの参照ポインタ
- * @param buf 表記を返すための文字列参照ポインタ
  * @param o_ptr 特性短縮表記を得たいオブジェクト構造体の参照ポインタ
  * @param mode 表記に関するオプション指定
- * @return 現在クエスト達成目的のアイテムならばTRUEを返す
+ * @return modeに応じたオブジェクトの表記
  */
-void describe_flavor(PlayerType *player_ptr, char *buf, const ItemEntity *o_ptr, const BIT_FLAGS mode)
+std::string describe_flavor(PlayerType *player_ptr, const ItemEntity *o_ptr, BIT_FLAGS mode)
 {
     const auto &item = *o_ptr;
     const auto opt = decide_describe_option(item, mode);
@@ -586,8 +585,7 @@ void describe_flavor(PlayerType *player_ptr, char *buf, const ItemEntity *o_ptr,
     desc_ss << describe_named_item(player_ptr, item, opt);
 
     if (any_bits(mode, OD_NAME_ONLY) || (o_ptr->bi_id == 0)) {
-        angband_strcpy(buf, desc_ss.str().data(), MAX_NLEN);
-        return;
+        return desc_ss.str();
     }
 
     desc_ss << describe_chest(item, opt)
@@ -606,16 +604,14 @@ void describe_flavor(PlayerType *player_ptr, char *buf, const ItemEntity *o_ptr,
 
     desc_ss << describe_ac(item, opt);
     if (any_bits(mode, OD_NAME_AND_ENCHANT)) {
-        angband_strcpy(buf, desc_ss.str().data(), MAX_NLEN);
-        return;
+        return desc_ss.str();
     }
 
     desc_ss << describe_remaining(item, opt);
     if (any_bits(mode, OD_OMIT_INSCRIPTION)) {
-        angband_strcpy(buf, desc_ss.str().data(), MAX_NLEN);
-        return;
+        return desc_ss.str();
     }
 
     desc_ss << describe_inscription(item, opt);
-    angband_strcpy(buf, desc_ss.str().data(), MAX_NLEN);
+    return desc_ss.str();
 }

--- a/src/flavor/flavor-describer.cpp
+++ b/src/flavor/flavor-describer.cpp
@@ -581,37 +581,37 @@ std::string describe_flavor(PlayerType *player_ptr, const ItemEntity *o_ptr, BIT
 {
     const auto &item = *o_ptr;
     const auto opt = decide_describe_option(item, mode);
-    std::stringstream desc_ss;
-    desc_ss << describe_named_item(player_ptr, item, opt);
+    std::stringstream ss;
+    ss << describe_named_item(player_ptr, item, opt);
 
     if (any_bits(mode, OD_NAME_ONLY) || (o_ptr->bi_id == 0)) {
-        return desc_ss.str();
+        return ss.str();
     }
 
-    desc_ss << describe_chest(item, opt)
-            << describe_weapon_dice_or_bow_power(player_ptr, item, opt)
-            << describe_accuracy_and_damage_bonus(item, opt);
+    ss << describe_chest(item, opt)
+       << describe_weapon_dice_or_bow_power(player_ptr, item, opt)
+       << describe_accuracy_and_damage_bonus(item, opt);
 
     if (none_bits(mode, OD_DEBUG)) {
         const auto &bow = player_ptr->inventory_list[INVEN_BOW];
         const auto tval = item.bi_key.tval();
         if ((bow.bi_id != 0) && (tval == bow.get_arrow_kind())) {
-            desc_ss << describe_ammo_detail(player_ptr, item, bow, opt);
+            ss << describe_ammo_detail(player_ptr, item, bow, opt);
         } else if (PlayerClass(player_ptr).equals(PlayerClassType::NINJA) && (tval == ItemKindType::SPIKE)) {
-            desc_ss << describe_spike_detail(player_ptr);
+            ss << describe_spike_detail(player_ptr);
         }
     }
 
-    desc_ss << describe_ac(item, opt);
+    ss << describe_ac(item, opt);
     if (any_bits(mode, OD_NAME_AND_ENCHANT)) {
-        return desc_ss.str();
+        return ss.str();
     }
 
-    desc_ss << describe_remaining(item, opt);
+    ss << describe_remaining(item, opt);
     if (any_bits(mode, OD_OMIT_INSCRIPTION)) {
-        return desc_ss.str();
+        return ss.str();
     }
 
-    desc_ss << describe_inscription(item, opt);
-    return desc_ss.str();
+    ss << describe_inscription(item, opt);
+    return ss.str();
 }

--- a/src/flavor/flavor-describer.h
+++ b/src/flavor/flavor-describer.h
@@ -1,7 +1,8 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include <string>
 
 class ItemEntity;
 class PlayerType;
-void describe_flavor(PlayerType *player_ptr, char *buf, const ItemEntity *o_ptr, const BIT_FLAGS mode);
+std::string describe_flavor(PlayerType *player_ptr, const ItemEntity *o_ptr, const BIT_FLAGS mode);

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -76,9 +76,8 @@ static void object_mention(PlayerType *player_ptr, ItemEntity *o_ptr)
     object_known(o_ptr);
 
     o_ptr->ident |= (IDENT_FULL_KNOWN);
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, 0);
-    msg_format_wizard(player_ptr, CHEAT_OBJECT, _("%sを生成しました。", "%s was generated."), o_name);
+    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    msg_format_wizard(player_ptr, CHEAT_OBJECT, _("%sを生成しました。", "%s was generated."), item_name.data());
 }
 
 static int get_base_floor(FloorType *floor_ptr, BIT_FLAGS mode, std::optional<int> rq_mon_level)
@@ -341,19 +340,18 @@ OBJECT_IDX drop_near(PlayerType *player_ptr, ItemEntity *j_ptr, PERCENTAGE chanc
     POSITION ty, tx = 0;
     OBJECT_IDX o_idx = 0;
     grid_type *g_ptr;
-    GAME_TEXT o_name[MAX_NLEN];
     bool flag = false;
     bool done = false;
 #ifdef JP
 #else
     bool plural = (j_ptr->number != 1);
 #endif
-    describe_flavor(player_ptr, o_name, j_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, j_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     if (!j_ptr->is_fixed_or_random_artifact() && (randint0(100) < chance)) {
 #ifdef JP
-        msg_format("%sは消えた。", o_name);
+        msg_format("%sは消えた。", item_name.data());
 #else
-        msg_format("The %s disappear%s.", o_name, (plural ? "" : "s"));
+        msg_format("The %s disappear%s.", item_name.data(), (plural ? "" : "s"));
 #endif
         if (w_ptr->wizard) {
             msg_print(_("(破損)", "(breakage)"));
@@ -431,9 +429,9 @@ OBJECT_IDX drop_near(PlayerType *player_ptr, ItemEntity *j_ptr, PERCENTAGE chanc
 
     if (!flag && !j_ptr->is_fixed_or_random_artifact()) {
 #ifdef JP
-        msg_format("%sは消えた。", o_name);
+        msg_format("%sは消えた。", item_name.data());
 #else
-        msg_format("The %s disappear%s.", o_name, (plural ? "" : "s"));
+        msg_format("The %s disappear%s.", item_name.data(), (plural ? "" : "s"));
 #endif
         if (w_ptr->wizard) {
             msg_print(_("(床スペースがない)", "(no floor space)"));
@@ -472,9 +470,9 @@ OBJECT_IDX drop_near(PlayerType *player_ptr, ItemEntity *j_ptr, PERCENTAGE chanc
 
         if (!candidates) {
 #ifdef JP
-            msg_format("%sは消えた。", o_name);
+            msg_format("%sは消えた。", item_name.data());
 #else
-            msg_format("The %s disappear%s.", o_name, (plural ? "" : "s"));
+            msg_format("The %s disappear%s.", item_name.data(), (plural ? "" : "s"));
 #endif
 
             if (w_ptr->wizard) {
@@ -527,9 +525,9 @@ OBJECT_IDX drop_near(PlayerType *player_ptr, ItemEntity *j_ptr, PERCENTAGE chanc
 
     if (!done && !o_idx) {
 #ifdef JP
-        msg_format("%sは消えた。", o_name);
+        msg_format("%sは消えた。", item_name.data());
 #else
-        msg_format("The %s disappear%s.", o_name, (plural ? "" : "s"));
+        msg_format("The %s disappear%s.", item_name.data(), (plural ? "" : "s"));
 #endif
         if (w_ptr->wizard) {
             msg_print(_("(アイテムが多過ぎる)", "(too many objects)"));
@@ -609,16 +607,15 @@ void floor_item_charges(FloorType *floor_ptr, INVENTORY_IDX inventory)
 void floor_item_describe(PlayerType *player_ptr, INVENTORY_IDX item)
 {
     auto *o_ptr = &player_ptr->current_floor_ptr->o_list[item];
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
 #ifdef JP
     if (o_ptr->number <= 0) {
-        msg_format("床上には、もう%sはない。", o_name);
+        msg_format("床上には、もう%sはない。", item_name.data());
     } else {
-        msg_format("床上には、まだ %sがある。", o_name);
+        msg_format("床上には、まだ %sがある。", item_name.data());
     }
 #else
-    msg_format("You see %s.", o_name);
+    msg_format("You see %s.", item_name.data());
 #endif
 }
 

--- a/src/floor/floor-streams.cpp
+++ b/src/floor/floor-streams.cpp
@@ -364,11 +364,9 @@ void build_streamer(PlayerType *player_ptr, FEAT_IDX feat, int chance)
                     /* Hack -- Preserve unknown artifacts */
                     if (o_ptr->is_fixed_artifact()) {
                         artifacts_info.at(o_ptr->fixed_artifact_idx).is_generated = false;
-
                         if (cheat_peek) {
-                            GAME_TEXT o_name[MAX_NLEN];
-                            describe_flavor(player_ptr, o_name, o_ptr, (OD_NAME_ONLY | OD_STORE));
-                            msg_format(_("伝説のアイテム (%s) はストリーマーにより削除された。", "Artifact (%s) was deleted by streamer."), o_name);
+                            const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_NAME_ONLY | OD_STORE));
+                            msg_format(_("伝説のアイテム (%s) はストリーマーにより削除された。", "Artifact (%s) was deleted by streamer."), item_name.data());
                         }
                     } else if (cheat_peek && o_ptr->is_random_artifact()) {
                         msg_print(_("ランダム・アーティファクトの1つはストリーマーにより削除された。", "One of the random artifacts was deleted by streamer."));

--- a/src/floor/object-scanner.cpp
+++ b/src/floor/object-scanner.cpp
@@ -15,6 +15,7 @@
 #include "term/screen-processor.h"
 #include "term/z-form.h"
 #include "util/string-processor.h"
+#include <array>
 
 /*!
  * @brief 床に落ちているオブジェクトの数を返す / scan floor items
@@ -105,11 +106,10 @@ COMMAND_CODE show_floor_items(PlayerType *player_ptr, int target_item, POSITION 
     COMMAND_CODE i, m;
     int j, k, l;
     ItemEntity *o_ptr;
-    GAME_TEXT o_name[MAX_NLEN];
     char tmp_val[80];
     COMMAND_CODE out_index[23];
     TERM_COLOR out_color[23];
-    char out_desc[23][MAX_NLEN];
+    std::array<std::string, 23> descriptions{};
     COMMAND_CODE target_item_label = 0;
     OBJECT_IDX floor_list[23];
     ITEM_NUMBER floor_num;
@@ -122,12 +122,12 @@ COMMAND_CODE show_floor_items(PlayerType *player_ptr, int target_item, POSITION 
     auto *floor_ptr = player_ptr->current_floor_ptr;
     for (k = 0, i = 0; i < floor_num && i < 23; i++) {
         o_ptr = &floor_ptr->o_list[floor_list[i]];
-        describe_flavor(player_ptr, o_name, o_ptr, 0);
+        const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
         out_index[k] = i;
         const auto tval = o_ptr->bi_key.tval();
         out_color[k] = tval_to_attr[enum2i(tval) & 0x7F];
-        strcpy(out_desc[k], o_name);
-        l = strlen(out_desc[k]) + 5;
+        descriptions[k] = item_name;
+        l = descriptions[k].length() + 5;
         if (show_weights) {
             l += 9;
         }
@@ -166,7 +166,7 @@ COMMAND_CODE show_floor_items(PlayerType *player_ptr, int target_item, POSITION 
         }
 
         put_str(tmp_val, j + 1, col);
-        c_put_str(out_color[j], out_desc[j], j + 1, col + 3);
+        c_put_str(out_color[j], descriptions[j], j + 1, col + 3);
         if (show_weights && (o_ptr->bi_key.tval() != ItemKindType::GOLD)) {
             int wgt = o_ptr->weight * o_ptr->number;
             strnfmt(tmp_val, sizeof(tmp_val), _("%3d.%1d kg", "%3d.%1d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -50,6 +50,7 @@
 #include "view/display-messages.h"
 #include "world/world.h"
 #include <functional>
+#include <sstream>
 
 /*!
  * @brief 地形によるダメージを与える / Deal damage from feature.
@@ -151,15 +152,14 @@ void process_player_hp_mp(PlayerType *player_ptr)
         auto flags = object_flags(o_ptr);
 
         if ((player_ptr->inventory_list[INVEN_LITE].bi_key.tval() != ItemKindType::NONE) && flags.has_not(TR_DARK_SOURCE) && !has_resist_lite(player_ptr)) {
-            GAME_TEXT o_name[MAX_NLEN];
-            describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
-            msg_format(_("%sがあなたのアンデッドの肉体を焼き焦がした！", "The %s scorches your undead flesh!"), o_name);
-
+            const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+            msg_format(_("%sがあなたのアンデッドの肉体を焼き焦がした！", "The %s scorches your undead flesh!"), item_name.data());
             cave_no_regen = true;
-
             if (!is_invuln(player_ptr)) {
-                describe_flavor(player_ptr, o_name, o_ptr, OD_NAME_ONLY);
-                take_hit(player_ptr, DAMAGE_NOESCAPE, 1, std::string(_(o_name, "wielding ")).append(_("を装備したダメージ", o_name)).data());
+                const auto wielding_item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
+                std::stringstream ss;
+                ss << _(wielding_item_name, "wielding ") << _("を装備したダメージ", wielding_item_name);
+                take_hit(player_ptr, DAMAGE_NOESCAPE, 1, ss.str().data());
             }
         }
     }

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -178,7 +178,6 @@ static void curse_teleport(PlayerType *player_ptr)
         return;
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
     ItemEntity *o_ptr;
     int i_keep = 0, count = 0;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
@@ -204,13 +203,13 @@ static void curse_teleport(PlayerType *player_ptr)
     }
 
     o_ptr = &player_ptr->inventory_list[i_keep];
-    describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
-    msg_format(_("%sがテレポートの能力を発動させようとしている。", "Your %s tries to teleport you."), o_name);
+    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    msg_format(_("%sがテレポートの能力を発動させようとしている。", "Your %s tries to teleport you."), item_name.data());
     if (get_check_strict(player_ptr, _("テレポートしますか？", "Teleport? "), CHECK_OKAY_CANCEL)) {
         disturb(player_ptr, false, true);
         teleport_player(player_ptr, 50, TELEPORT_SPONTANEOUS);
     } else {
-        msg_format(_("%sに{.}(ピリオド)と銘を刻むと発動を抑制できます。", "You can inscribe {.} on your %s to disable random teleportation. "), o_name);
+        msg_format(_("%sに{.}(ピリオド)と銘を刻むと発動を抑制できます。", "You can inscribe {.} on your %s to disable random teleportation. "), item_name.data());
         disturb(player_ptr, true, true);
     }
 }
@@ -258,17 +257,15 @@ static void multiply_low_curse(PlayerType *player_ptr)
         return;
     }
 
-    ItemEntity *o_ptr;
-    o_ptr = choose_cursed_obj_name(player_ptr, CurseTraitType::ADD_L_CURSE);
+    auto *o_ptr = choose_cursed_obj_name(player_ptr, CurseTraitType::ADD_L_CURSE);
     auto new_curse = get_curse(0, o_ptr);
     if (o_ptr->curse_flags.has(new_curse)) {
         return;
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     o_ptr->curse_flags.set(new_curse);
-    msg_format(_("悪意に満ちた黒いオーラが%sをとりまいた...", "There is a malignant black aura surrounding your %s..."), o_name);
+    msg_format(_("悪意に満ちた黒いオーラが%sをとりまいた...", "There is a malignant black aura surrounding your %s..."), item_name.data());
     o_ptr->feeling = FEEL_NONE;
     player_ptr->update |= (PU_BONUS);
 }
@@ -286,10 +283,9 @@ static void multiply_high_curse(PlayerType *player_ptr)
         return;
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     o_ptr->curse_flags.set(new_curse);
-    msg_format(_("悪意に満ちた黒いオーラが%sをとりまいた...", "There is a malignant black aura surrounding your %s..."), o_name);
+    msg_format(_("悪意に満ちた黒いオーラが%sをとりまいた...", "There is a malignant black aura surrounding your %s..."), item_name.data());
     o_ptr->feeling = FEEL_NONE;
     player_ptr->update |= (PU_BONUS);
 }
@@ -306,10 +302,9 @@ static void persist_curse(PlayerType *player_ptr)
         return;
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     o_ptr->curse_flags.set(CurseTraitType::HEAVY_CURSE);
-    msg_format(_("悪意に満ちた黒いオーラが%sをとりまいた...", "There is a malignant black aura surrounding your %s..."), o_name);
+    msg_format(_("悪意に満ちた黒いオーラが%sをとりまいた...", "There is a malignant black aura surrounding your %s..."), item_name.data());
     o_ptr->feeling = FEEL_NONE;
     player_ptr->update |= (PU_BONUS);
 }
@@ -321,36 +316,32 @@ static void curse_call_monster(PlayerType *player_ptr)
     auto *floor_ptr = player_ptr->current_floor_ptr;
     if (player_ptr->cursed.has(CurseTraitType::CALL_ANIMAL) && one_in_(2500)) {
         if (summon_specific(player_ptr, 0, player_ptr->y, player_ptr->x, floor_ptr->dun_level, SUMMON_ANIMAL, call_type)) {
-            GAME_TEXT o_name[MAX_NLEN];
-            describe_flavor(player_ptr, o_name, choose_cursed_obj_name(player_ptr, CurseTraitType::CALL_ANIMAL), obj_desc_type);
-            msg_format(_("%sが動物を引き寄せた！", "Your %s has attracted an animal!"), o_name);
+            const auto item_name = describe_flavor(player_ptr, choose_cursed_obj_name(player_ptr, CurseTraitType::CALL_ANIMAL), obj_desc_type);
+            msg_format(_("%sが動物を引き寄せた！", "Your %s has attracted an animal!"), item_name.data());
             disturb(player_ptr, false, true);
         }
     }
 
     if (player_ptr->cursed.has(CurseTraitType::CALL_DEMON) && one_in_(1111)) {
         if (summon_specific(player_ptr, 0, player_ptr->y, player_ptr->x, floor_ptr->dun_level, SUMMON_DEMON, call_type)) {
-            GAME_TEXT o_name[MAX_NLEN];
-            describe_flavor(player_ptr, o_name, choose_cursed_obj_name(player_ptr, CurseTraitType::CALL_DEMON), obj_desc_type);
-            msg_format(_("%sが悪魔を引き寄せた！", "Your %s has attracted a demon!"), o_name);
+            const auto item_name = describe_flavor(player_ptr, choose_cursed_obj_name(player_ptr, CurseTraitType::CALL_DEMON), obj_desc_type);
+            msg_format(_("%sが悪魔を引き寄せた！", "Your %s has attracted a demon!"), item_name.data());
             disturb(player_ptr, false, true);
         }
     }
 
     if (player_ptr->cursed.has(CurseTraitType::CALL_DRAGON) && one_in_(800)) {
         if (summon_specific(player_ptr, 0, player_ptr->y, player_ptr->x, floor_ptr->dun_level, SUMMON_DRAGON, call_type)) {
-            GAME_TEXT o_name[MAX_NLEN];
-            describe_flavor(player_ptr, o_name, choose_cursed_obj_name(player_ptr, CurseTraitType::CALL_DRAGON), obj_desc_type);
-            msg_format(_("%sがドラゴンを引き寄せた！", "Your %s has attracted a dragon!"), o_name);
+            const auto item_name = describe_flavor(player_ptr, choose_cursed_obj_name(player_ptr, CurseTraitType::CALL_DRAGON), obj_desc_type);
+            msg_format(_("%sがドラゴンを引き寄せた！", "Your %s has attracted a dragon!"), item_name.data());
             disturb(player_ptr, false, true);
         }
     }
 
     if (player_ptr->cursed.has(CurseTraitType::CALL_UNDEAD) && one_in_(1111)) {
         if (summon_specific(player_ptr, 0, player_ptr->y, player_ptr->x, floor_ptr->dun_level, SUMMON_UNDEAD, call_type)) {
-            GAME_TEXT o_name[MAX_NLEN];
-            describe_flavor(player_ptr, o_name, choose_cursed_obj_name(player_ptr, CurseTraitType::CALL_UNDEAD), obj_desc_type);
-            msg_format(_("%sが死霊を引き寄せた！", "Your %s has attracted an undead!"), o_name);
+            const auto item_name = describe_flavor(player_ptr, choose_cursed_obj_name(player_ptr, CurseTraitType::CALL_UNDEAD), obj_desc_type);
+            msg_format(_("%sが死霊を引き寄せた！", "Your %s has attracted an undead!"), item_name.data());
             disturb(player_ptr, false, true);
         }
     }
@@ -415,10 +406,9 @@ static void curse_drain_hp(PlayerType *player_ptr)
         return;
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, choose_cursed_obj_name(player_ptr, CurseTraitType::DRAIN_HP), (OD_OMIT_PREFIX | OD_NAME_ONLY));
-    msg_format(_("%sはあなたの体力を吸収した！", "Your %s drains HP from you!"), o_name);
-    take_hit(player_ptr, DAMAGE_LOSELIFE, std::min(player_ptr->lev * 2, 100), o_name);
+    const auto item_name = describe_flavor(player_ptr, choose_cursed_obj_name(player_ptr, CurseTraitType::DRAIN_HP), (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    msg_format(_("%sはあなたの体力を吸収した！", "Your %s drains HP from you!"), item_name.data());
+    take_hit(player_ptr, DAMAGE_LOSELIFE, std::min(player_ptr->lev * 2, 100), item_name.data());
 }
 
 static void curse_drain_mp(PlayerType *player_ptr)
@@ -427,9 +417,8 @@ static void curse_drain_mp(PlayerType *player_ptr)
         return;
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, choose_cursed_obj_name(player_ptr, CurseTraitType::DRAIN_MANA), (OD_OMIT_PREFIX | OD_NAME_ONLY));
-    msg_format(_("%sはあなたの魔力を吸収した！", "Your %s drains mana from you!"), o_name);
+    const auto item_name = describe_flavor(player_ptr, choose_cursed_obj_name(player_ptr, CurseTraitType::DRAIN_MANA), (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    msg_format(_("%sはあなたの魔力を吸収した！", "Your %s drains mana from you!"), item_name.data());
     player_ptr->csp -= std::min<short>(player_ptr->lev, 50);
     if (player_ptr->csp < 0) {
         player_ptr->csp = 0;

--- a/src/inventory/inventory-damage.cpp
+++ b/src/inventory/inventory-damage.cpp
@@ -30,8 +30,6 @@ void inventory_damage(PlayerType *player_ptr, const ObjectBreaker &breaker, int 
     INVENTORY_IDX i;
     int j, amt;
     ItemEntity *o_ptr;
-    GAME_TEXT o_name[MAX_NLEN];
-
     if (check_multishadow(player_ptr) || player_ptr->current_floor_ptr->inside_arena) {
         return;
     }
@@ -65,13 +63,13 @@ void inventory_damage(PlayerType *player_ptr, const ObjectBreaker &breaker, int 
             continue;
         }
 
-        describe_flavor(player_ptr, o_name, o_ptr, OD_OMIT_PREFIX);
+        const auto item_name = describe_flavor(player_ptr, o_ptr, OD_OMIT_PREFIX);
 
         msg_format(_("%s(%c)が%s壊れてしまった！", "%sour %s (%c) %s destroyed!"),
 #ifdef JP
-            o_name, index_to_label(i), ((o_ptr->number > 1) ? ((amt == o_ptr->number) ? "全部" : (amt > 1 ? "何個か" : "一個")) : ""));
+            item_name.data(), index_to_label(i), ((o_ptr->number > 1) ? ((amt == o_ptr->number) ? "全部" : (amt > 1 ? "何個か" : "一個")) : ""));
 #else
-            ((o_ptr->number > 1) ? ((amt == o_ptr->number) ? "All of y" : (amt > 1 ? "Some of y" : "One of y")) : "Y"), o_name, index_to_label(i),
+            ((o_ptr->number > 1) ? ((amt == o_ptr->number) ? "All of y" : (amt > 1 ? "Some of y" : "One of y")) : "Y"), item_name.data(), index_to_label(i),
             ((amt > 1) ? "were" : "was"));
 #endif
 

--- a/src/inventory/inventory-object.cpp
+++ b/src/inventory/inventory-object.cpp
@@ -124,9 +124,7 @@ void drop_from_inventory(PlayerType *player_ptr, INVENTORY_IDX item, ITEM_NUMBER
 {
     ItemEntity forge;
     ItemEntity *q_ptr;
-    ItemEntity *o_ptr;
-    GAME_TEXT o_name[MAX_NLEN];
-    o_ptr = &player_ptr->inventory_list[item];
+    auto *o_ptr = &player_ptr->inventory_list[item];
     if (amt <= 0) {
         return;
     }
@@ -145,8 +143,8 @@ void drop_from_inventory(PlayerType *player_ptr, INVENTORY_IDX item, ITEM_NUMBER
     distribute_charges(o_ptr, q_ptr, amt);
 
     q_ptr->number = amt;
-    describe_flavor(player_ptr, o_name, q_ptr, 0);
-    msg_format(_("%s(%c)を落とした。", "You drop %s (%c)."), o_name, index_to_label(item));
+    const auto item_name = describe_flavor(player_ptr, q_ptr, 0);
+    msg_format(_("%s(%c)を落とした。", "You drop %s (%c)."), item_name.data(), index_to_label(item));
     (void)drop_near(player_ptr, q_ptr, 0, player_ptr->y, player_ptr->x);
     vary_item(player_ptr, item, -amt);
 }
@@ -411,7 +409,6 @@ INVENTORY_IDX inven_takeoff(PlayerType *player_ptr, INVENTORY_IDX item, ITEM_NUM
     ItemEntity *q_ptr;
     ItemEntity *o_ptr;
     concptr act;
-    GAME_TEXT o_name[MAX_NLEN];
     o_ptr = &player_ptr->inventory_list[item];
     if (amt <= 0) {
         return -1;
@@ -423,7 +420,7 @@ INVENTORY_IDX inven_takeoff(PlayerType *player_ptr, INVENTORY_IDX item, ITEM_NUM
     q_ptr = &forge;
     q_ptr->copy_from(o_ptr);
     q_ptr->number = amt;
-    describe_flavor(player_ptr, o_name, q_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, q_ptr, 0);
     if (((item == INVEN_MAIN_HAND) || (item == INVEN_SUB_HAND)) && o_ptr->is_melee_weapon()) {
         act = _("を装備からはずした", "You were wielding");
     } else if (item == INVEN_BOW) {
@@ -439,9 +436,9 @@ INVENTORY_IDX inven_takeoff(PlayerType *player_ptr, INVENTORY_IDX item, ITEM_NUM
 
     slot = store_item_to_inventory(player_ptr, q_ptr);
 #ifdef JP
-    msg_format("%s(%c)%s。", o_name, index_to_label(slot), act);
+    msg_format("%s(%c)%s。", item_name.data(), index_to_label(slot), act);
 #else
-    msg_format("%s %s (%c).", act, o_name, index_to_label(slot));
+    msg_format("%s %s (%c).", act, item_name.data(), index_to_label(slot));
 #endif
 
     return slot;

--- a/src/inventory/inventory-util.cpp
+++ b/src/inventory/inventory-util.cpp
@@ -18,6 +18,7 @@
 #include "util/int-char-converter.h"
 #include "util/quarks.h"
 #include "util/string-processor.h"
+#include <sstream>
 
 /*!
  * @brief プレイヤーの所持/装備オブジェクトIDが指輪枠かを返す /
@@ -284,7 +285,6 @@ INVENTORY_IDX label_to_inventory(PlayerType *player_ptr, int c)
  */
 bool verify(PlayerType *player_ptr, concptr prompt, INVENTORY_IDX item)
 {
-    GAME_TEXT o_name[MAX_NLEN];
     ItemEntity *o_ptr;
     if (item >= 0) {
         o_ptr = &player_ptr->inventory_list[item];
@@ -292,13 +292,14 @@ bool verify(PlayerType *player_ptr, concptr prompt, INVENTORY_IDX item)
         o_ptr = &player_ptr->current_floor_ptr->o_list[0 - item];
     }
 
-    describe_flavor(player_ptr, o_name, o_ptr, 0);
-    std::string out_val = prompt;
+    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    std::stringstream ss;
+    ss << prompt;
 #ifndef JP
-    out_val.append(" ");
+    ss << ' ';
 #endif
-    out_val.append(o_name).append(_("ですか? ", "? "));
-    return get_check(out_val);
+    ss << item_name << _("ですか? ", "? ");
+    return get_check(ss.str());
 }
 
 /*!

--- a/src/inventory/pack-overflow.cpp
+++ b/src/inventory/pack-overflow.cpp
@@ -20,19 +20,17 @@ void pack_overflow(PlayerType *player_ptr)
         return;
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
-    ItemEntity *o_ptr;
     update_creature(player_ptr);
     if (!player_ptr->inventory_list[INVEN_PACK].bi_id) {
         return;
     }
 
-    o_ptr = &player_ptr->inventory_list[INVEN_PACK];
+    auto *o_ptr = &player_ptr->inventory_list[INVEN_PACK];
     disturb(player_ptr, false, true);
     msg_print(_("ザックからアイテムがあふれた！", "Your pack overflows!"));
 
-    describe_flavor(player_ptr, o_name, o_ptr, 0);
-    msg_format(_("%s(%c)を落とした。", "You drop %s (%c)."), o_name, index_to_label(INVEN_PACK));
+    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    msg_format(_("%s(%c)を落とした。", "You drop %s (%c)."), item_name.data(), index_to_label(INVEN_PACK));
     (void)drop_near(player_ptr, o_ptr, 0, player_ptr->y, player_ptr->x);
 
     vary_item(player_ptr, INVEN_PACK, -255);

--- a/src/inventory/recharge-processor.cpp
+++ b/src/inventory/recharge-processor.cpp
@@ -29,15 +29,14 @@ static void recharged_notice(PlayerType *player_ptr, ItemEntity *o_ptr)
     auto s = angband_strchr(o_ptr->inscription->data(), '!');
     while (s) {
         if (s[1] == '!') {
-            GAME_TEXT o_name[MAX_NLEN];
-            describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+            const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
 #ifdef JP
-            msg_format("%sは再充填された。", o_name);
+            msg_format("%sは再充填された。", item_name.data());
 #else
             if (o_ptr->number > 1) {
-                msg_format("Your %s are recharged.", o_name);
+                msg_format("Your %s are recharged.", item_name.data());
             } else {
-                msg_format("Your %s is recharged.", o_name);
+                msg_format("Your %s is recharged.", item_name.data());
             }
 #endif
             disturb(player_ptr, false, false);

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -496,16 +496,17 @@ static void dump_aux_mutations(PlayerType *player_ptr, FILE *fff)
  */
 static void dump_aux_equipment_inventory(PlayerType *player_ptr, FILE *fff)
 {
-    GAME_TEXT o_name[MAX_NLEN];
     if (player_ptr->equip_cnt) {
         fprintf(fff, _("  [キャラクタの装備]\n\n", "  [Character Equipment]\n\n"));
         for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-            describe_flavor(player_ptr, o_name, &player_ptr->inventory_list[i], 0);
-            if ((((i == INVEN_MAIN_HAND) && can_attack_with_sub_hand(player_ptr)) || ((i == INVEN_SUB_HAND) && can_attack_with_main_hand(player_ptr))) && has_two_handed_weapons(player_ptr)) {
-                strcpy(o_name, _("(武器を両手持ち)", "(wielding with two-hands)"));
+            auto item_name = describe_flavor(player_ptr, &player_ptr->inventory_list[i], 0);
+            auto is_two_handed = ((i == INVEN_MAIN_HAND) && can_attack_with_sub_hand(player_ptr));
+            is_two_handed |= ((i == INVEN_SUB_HAND) && can_attack_with_main_hand(player_ptr));
+            if (is_two_handed && has_two_handed_weapons(player_ptr)) {
+                item_name = _("(武器を両手持ち)", "(wielding with two-hands)");
             }
 
-            fprintf(fff, "%c) %s\n", index_to_label(i), o_name);
+            fprintf(fff, "%c) %s\n", index_to_label(i), item_name.data());
         }
 
         fprintf(fff, "\n\n");
@@ -517,8 +518,9 @@ static void dump_aux_equipment_inventory(PlayerType *player_ptr, FILE *fff)
         if (!player_ptr->inventory_list[i].bi_id) {
             break;
         }
-        describe_flavor(player_ptr, o_name, &player_ptr->inventory_list[i], 0);
-        fprintf(fff, "%c) %s\n", index_to_label(i), o_name);
+
+        const auto item_name = describe_flavor(player_ptr, &player_ptr->inventory_list[i], 0);
+        fprintf(fff, "%c) %s\n", index_to_label(i), item_name.data());
     }
 
     fprintf(fff, "\n\n");
@@ -530,20 +532,17 @@ static void dump_aux_equipment_inventory(PlayerType *player_ptr, FILE *fff)
  */
 static void dump_aux_home_museum(PlayerType *player_ptr, FILE *fff)
 {
-    store_type *store_ptr;
-    store_ptr = &towns_info[1].store[enum2i(StoreSaleType::HOME)];
-
-    GAME_TEXT o_name[MAX_NLEN];
+    const auto *store_ptr = &towns_info[1].store[enum2i(StoreSaleType::HOME)];
     if (store_ptr->stock_num) {
         fprintf(fff, _("  [我が家のアイテム]\n", "  [Home Inventory]\n"));
-
-        TERM_LEN x = 1;
-        for (int i = 0; i < store_ptr->stock_num; i++) {
+        auto page = 1;
+        for (auto i = 0; i < store_ptr->stock_num; i++) {
             if ((i % 12) == 0) {
-                fprintf(fff, _("\n ( %d ページ )\n", "\n ( page %d )\n"), x++);
+                fprintf(fff, _("\n ( %d ページ )\n", "\n ( page %d )\n"), page++);
             }
-            describe_flavor(player_ptr, o_name, &store_ptr->stock[i], 0);
-            fprintf(fff, "%c) %s\n", I2A(i % 12), o_name);
+
+            const auto item_name = describe_flavor(player_ptr, &store_ptr->stock[i], 0);
+            fprintf(fff, "%c) %s\n", I2A(i % 12), item_name.data());
         }
 
         fprintf(fff, "\n\n");
@@ -557,13 +556,14 @@ static void dump_aux_home_museum(PlayerType *player_ptr, FILE *fff)
 
     fprintf(fff, _("  [博物館のアイテム]\n", "  [Museum]\n"));
 
-    TERM_LEN x = 1;
-    for (int i = 0; i < store_ptr->stock_num; i++) {
+    auto page = 1;
+    for (auto i = 0; i < store_ptr->stock_num; i++) {
         if ((i % 12) == 0) {
-            fprintf(fff, _("\n ( %d ページ )\n", "\n ( page %d )\n"), x++);
+            fprintf(fff, _("\n ( %d ページ )\n", "\n ( page %d )\n"), page++);
         }
-        describe_flavor(player_ptr, o_name, &store_ptr->stock[i], 0);
-        fprintf(fff, "%c) %s\n", I2A(i % 12), o_name);
+
+        const auto item_name = describe_flavor(player_ptr, &store_ptr->stock[i], 0);
+        fprintf(fff, "%c) %s\n", I2A(i % 12), item_name.data());
     }
 
     fprintf(fff, "\n\n");

--- a/src/knowledge/knowledge-inventory.cpp
+++ b/src/knowledge/knowledge-inventory.cpp
@@ -152,8 +152,7 @@ static void display_identified_resistances_flag(ItemEntity *o_ptr, FILE *fff)
  */
 static void do_cmd_knowledge_inventory_aux(PlayerType *player_ptr, FILE *fff, ItemEntity *o_ptr, char *where)
 {
-    char tmp_item_name[MAX_NLEN];
-    describe_flavor(player_ptr, tmp_item_name, o_ptr, OD_NAME_ONLY);
+    auto tmp_item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
     constexpr auto max_item_length = 26;
     auto item_name = str_substr(tmp_item_name, 0, max_item_length);
     std::stringstream ss;

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -101,12 +101,11 @@ void do_cmd_knowledge_artifacts(PlayerType *player_ptr)
     ang_sort(player_ptr, whats.data(), &why, whats.size(), ang_sort_art_comp, ang_sort_art_swap);
     for (auto a_idx : whats) {
         const auto &a_ref = artifacts_info.at(a_idx);
-        GAME_TEXT base_name[MAX_NLEN];
-        strcpy(base_name, _("未知の伝説のアイテム", "Unknown Artifact"));
+        constexpr auto unknown_art = _("未知の伝説のアイテム", "Unknown Artifact");
         const auto bi_id = lookup_baseitem_id(a_ref.bi_key);
         constexpr auto template_basename = _("     %s\n", "     The %s\n");
         if (bi_id == 0) {
-            fprintf(fff, template_basename, base_name);
+            fprintf(fff, template_basename, unknown_art);
             continue;
         }
 
@@ -114,8 +113,8 @@ void do_cmd_knowledge_artifacts(PlayerType *player_ptr)
         item.prep(bi_id);
         item.fixed_artifact_idx = a_idx;
         item.ident |= IDENT_STORE;
-        describe_flavor(player_ptr, base_name, &item, (OD_OMIT_PREFIX | OD_NAME_ONLY));
-        fprintf(fff, template_basename, base_name);
+        const auto item_name = describe_flavor(player_ptr, &item, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+        fprintf(fff, template_basename, item_name.data());
     }
 
     angband_fclose(fff);

--- a/src/knowledge/knowledge-quests.cpp
+++ b/src/knowledge/knowledge-quests.cpp
@@ -52,7 +52,6 @@ static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
 {
     const auto &quest_list = QuestList::get_instance();
     std::string rand_tmp_str;
-    GAME_TEXT name[MAX_NLEN];
     MonsterRaceInfo *r_ptr;
     int rand_level = 100;
     int total = 0;
@@ -91,16 +90,17 @@ static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
 #ifdef JP
                         note = format(" - %d 体の%sを倒す。(あと %d 体)", (int)q_ref.max_num, r_ptr->name.data(), (int)(q_ref.max_num - q_ref.cur_num));
 #else
-                        angband_strcpy(name, r_ptr->name.data(), sizeof(name));
-                        plural_aux(name);
-                        note = format(" - kill %d %s, have killed %d.", (int)q_ref.max_num, name, (int)q_ref.cur_num);
+                        auto monster_name(r_ptr->name);
+                        plural_aux(monster_name.data());
+                        note = format(" - kill %d %s, have killed %d.", (int)q_ref.max_num, monster_name.data(), (int)q_ref.cur_num);
 #endif
                     } else {
                         note = format(_(" - %sを倒す。", " - kill %s."), r_ptr->name.data());
                     }
 
                     break;
-                case QuestKindType::FIND_ARTIFACT:
+                case QuestKindType::FIND_ARTIFACT: {
+                    std::string item_name("");
                     if (q_ref.reward_artifact_idx != FixedArtifactId::NONE) {
                         const auto &a_ref = artifacts_info.at(q_ref.reward_artifact_idx);
                         ItemEntity item;
@@ -108,11 +108,12 @@ static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
                         item.prep(bi_id);
                         item.fixed_artifact_idx = q_ref.reward_artifact_idx;
                         item.ident = IDENT_STORE;
-                        describe_flavor(player_ptr, name, &item, OD_NAME_ONLY);
+                        item_name = describe_flavor(player_ptr, &item, OD_NAME_ONLY);
                     }
 
-                    note = format(_("\n   - %sを見つけ出す。", "\n   - Find %s."), name);
+                    note = format(_("\n   - %sを見つけ出す。", "\n   - Find %s."), item_name.data());
                     break;
+                }
                 case QuestKindType::FIND_EXIT:
                     note = _(" - 出口に到達する。", " - Reach exit.");
                     break;
@@ -166,11 +167,10 @@ static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
         rand_tmp_str = format("  %s (%d 階) - %d 体の%sを倒す。(あと %d 体)\n", q_ref.name, (int)q_ref.level, (int)q_ref.max_num, r_ptr->name.data(),
             (int)(q_ref.max_num - q_ref.cur_num));
 #else
-        angband_strcpy(name, r_ptr->name.data(), sizeof(name));
-        plural_aux(name);
-
-        rand_tmp_str = format("  %s (Dungeon level: %d)\n  Kill %d %s, have killed %d.\n", q_ref.name, (int)q_ref.level, (int)q_ref.max_num, name,
-            (int)q_ref.cur_num);
+        auto monster_name(r_ptr->name);
+        plural_aux(monster_name.data());
+        rand_tmp_str = format("  %s (Dungeon level: %d)\n  Kill %d %s, have killed %d.\n", q_ref.name, (int)q_ref.level, (int)q_ref.max_num,
+            monster_name.data(), (int)q_ref.cur_num);
 #endif
     }
 

--- a/src/knowledge/knowledge-self.cpp
+++ b/src/knowledge/knowledge-self.cpp
@@ -208,37 +208,27 @@ void do_cmd_knowledge_home(PlayerType *player_ptr)
 #endif
     fprintf(fff, _("  [ 我が家のアイテム ]\n", "  [Home Inventory]\n"));
     constexpr auto close_bracket = ")";
-    GAME_TEXT o_name[MAX_NLEN];
     for (auto i = 0; i < store.stock_num; i++) {
 #ifdef JP
         if ((i % 12) == 0) {
             fprintf(fff, "\n ( %d ページ )\n", x++);
         }
 
-        describe_flavor(player_ptr, o_name, &store.stock[i], 0);
-        if (strlen(o_name) <= 80 - 3) {
-            fprintf(fff, "%c%s %s\n", I2A(i % 12), close_bracket, o_name);
+        const auto item_name = describe_flavor(player_ptr, &store.stock[i], 0);
+        const int item_length = item_name.length();
+        if (item_length <= 80 - 3) {
+            fprintf(fff, "%c%s %s\n", I2A(i % 12), close_bracket, item_name.data());
             continue;
         }
 
-        auto n = 0;
-        for (auto *t = o_name; n < 80 - 3; n++, t++) {
-            if (iskanji(*t)) {
-                t++;
-                n++;
-            }
-        }
-
         /* 最後が漢字半分 */
-        if (n == 81 - 3) {
-            n = 79 - 3;
-        }
-
-        fprintf(fff, "%c%s %.*s\n", I2A(i % 12), close_bracket, n, o_name);
-        fprintf(fff, "   %.77s\n", o_name + n);
+        constexpr auto max_length = 81 - 3;
+        const auto n = item_length >= max_length ? 79 - 3 : item_length;
+        fprintf(fff, "%c%s %.*s\n", I2A(i % 12), close_bracket, n, item_name.substr(0, n).data());
+        fprintf(fff, "   %.77s\n", item_name.substr(n).data());
 #else
-        describe_flavor(player_ptr, o_name, &store.stock[i], 0);
-        fprintf(fff, "%c%s %s\n", I2A(i % 12), close_bracket, o_name);
+        const auto item_name = describe_flavor(player_ptr, &store.stock[i], 0);
+        fprintf(fff, "%c%s %s\n", I2A(i % 12), close_bracket, item_name.data());
 #endif
     }
 

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -48,7 +48,6 @@
 bool exchange_cash(PlayerType *player_ptr)
 {
     auto change = false;
-    GAME_TEXT o_name[MAX_NLEN];
     for (INVENTORY_IDX i = 0; i <= INVEN_SUB_HAND; i++) {
         const auto item_ptr = &player_ptr->inventory_list[i];
         const auto r_idx_of_item = static_cast<MonsterRaceId>(item_ptr->pval);
@@ -57,8 +56,8 @@ bool exchange_cash(PlayerType *player_ptr)
         }
 
         change = true;
-        describe_flavor(player_ptr, o_name, item_ptr, 0);
-        if (!get_check(format(_("%s を換金しますか？", "Convert %s into money? "), o_name))) {
+        const auto item_name = describe_flavor(player_ptr, item_ptr, 0);
+        if (!get_check(format(_("%s を換金しますか？", "Convert %s into money? "), item_name.data()))) {
             continue;
         }
 
@@ -76,8 +75,8 @@ bool exchange_cash(PlayerType *player_ptr)
         }
 
         change = true;
-        describe_flavor(player_ptr, o_name, item_ptr, 0);
-        if (!get_check(format(_("%s を換金しますか？", "Convert %s into money? "), o_name))) {
+        const auto item_name = describe_flavor(player_ptr, item_ptr, 0);
+        if (!get_check(format(_("%s を換金しますか？", "Convert %s into money? "), item_name.data()))) {
             continue;
         }
 
@@ -95,8 +94,8 @@ bool exchange_cash(PlayerType *player_ptr)
         }
 
         change = true;
-        describe_flavor(player_ptr, o_name, item_ptr, 0);
-        if (!get_check(format(_("%s を換金しますか？", "Convert %s into money? "), o_name))) {
+        const auto item_name = describe_flavor(player_ptr, item_ptr, 0);
+        if (!get_check(format(_("%s を換金しますか？", "Convert %s into money? "), item_name.data()))) {
             continue;
         }
 
@@ -114,8 +113,8 @@ bool exchange_cash(PlayerType *player_ptr)
         }
 
         change = true;
-        describe_flavor(player_ptr, o_name, item_ptr, 0);
-        if (!get_check(format(_("%s を換金しますか？", "Convert %s into money? "), o_name))) {
+        const auto item_name = describe_flavor(player_ptr, item_ptr, 0);
+        if (!get_check(format(_("%s を換金しますか？", "Convert %s into money? "), item_name.data()))) {
             continue;
         }
 
@@ -134,8 +133,8 @@ bool exchange_cash(PlayerType *player_ptr)
         }
 
         change = true;
-        describe_flavor(player_ptr, o_name, item_ptr, 0);
-        if (!get_check(format(_("%s を換金しますか？", "Convert %s into money? "), o_name))) {
+        const auto item_name = describe_flavor(player_ptr, item_ptr, 0);
+        if (!get_check(format(_("%s を換金しますか？", "Convert %s into money? "), item_name.data()))) {
             continue;
         }
 
@@ -161,8 +160,8 @@ bool exchange_cash(PlayerType *player_ptr)
             INVENTORY_IDX item_new;
             ItemEntity forge;
 
-            describe_flavor(player_ptr, o_name, item_ptr, 0);
-            if (!get_check(format(_("%sを渡しますか？", "Hand %s over? "), o_name))) {
+            const auto item_name = describe_flavor(player_ptr, item_ptr, 0);
+            if (!get_check(format(_("%sを渡しますか？", "Hand %s over? "), item_name.data()))) {
                 continue;
             }
 
@@ -187,8 +186,8 @@ bool exchange_cash(PlayerType *player_ptr)
              * there is at least one empty slot.
              */
             item_new = store_item_to_inventory(player_ptr, &forge);
-            describe_flavor(player_ptr, o_name, &forge, 0);
-            msg_format(_("%s(%c)を貰った。", "You get %s (%c). "), o_name, index_to_label(item_new));
+            const auto got_item_name = describe_flavor(player_ptr, &forge, 0);
+            msg_format(_("%s(%c)を貰った。", "You get %s (%c). "), got_item_name.data(), index_to_label(item_new));
 
             autopick_alter_item(player_ptr, item_new, false);
             handle_stuff(player_ptr);

--- a/src/market/building-craft-fix.cpp
+++ b/src/market/building-craft-fix.cpp
@@ -114,19 +114,17 @@ static std::pair<bool, ItemEntity *> select_repairing_broken_weapon(PlayerType *
 
 static void display_reparing_weapon(PlayerType *player_ptr, ItemEntity *o_ptr, const int row)
 {
-    char item_name[MAX_NLEN];
-    describe_flavor(player_ptr, item_name, o_ptr, OD_NAME_ONLY);
-    prt(format(_("修復する武器　： %s", "Repairing: %s"), item_name), row + 3, 2);
+    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
+    prt(format(_("修復する武器　： %s", "Repairing: %s"), item_name.data()), row + 3, 2);
 }
 
 static void display_repair_success_message(PlayerType *player_ptr, ItemEntity *o_ptr, const int cost)
 {
-    char item_name[MAX_NLEN];
-    describe_flavor(player_ptr, item_name, o_ptr, OD_NAME_ONLY);
+    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
 #ifdef JP
-    msg_format("＄%dで%sに修復しました。", cost, item_name);
+    msg_format("＄%dで%sに修復しました。", cost, item_name.data());
 #else
-    msg_format("Repaired into %s for %d gold.", item_name, cost);
+    msg_format("Repaired into %s for %d gold.", item_name.data(), cost);
 #endif
     msg_print(nullptr);
 }
@@ -161,17 +159,15 @@ static PRICE repair_broken_weapon_aux(PlayerType *player_ptr, PRICE bcost)
         return 0;
     }
 
-    char basenm[MAX_NLEN];
-    describe_flavor(player_ptr, basenm, mo_ptr, OD_NAME_ONLY);
-    prt(format(_("材料とする武器： %s", "Material : %s"), basenm), row + 4, 2);
+    const auto item_name = describe_flavor(player_ptr, mo_ptr, OD_NAME_ONLY);
+    prt(format(_("材料とする武器： %s", "Material : %s"), item_name.data()), row + 4, 2);
     const auto cost = bcost + object_value_real(o_ptr) * 2;
     if (!get_check(format(_("＄%dかかりますがよろしいですか？ ", "Costs %d gold, okay? "), cost))) {
         return 0;
     }
 
     if (player_ptr->au < cost) {
-        describe_flavor(player_ptr, basenm, o_ptr, OD_NAME_ONLY);
-        msg_format(_("%sを修復するだけのゴールドがありません！", "You do not have the gold to repair %s!"), basenm);
+        msg_format(_("%sを修復するだけのゴールドがありません！", "You do not have the gold to repair %s!"), item_name.data());
         msg_print(nullptr);
         return 0;
     }

--- a/src/market/building-craft-fix.cpp
+++ b/src/market/building-craft-fix.cpp
@@ -92,8 +92,8 @@ static std::pair<bool, ItemEntity *> select_repairing_broken_weapon(PlayerType *
 {
     prt(_("修復には材料となるもう1つの武器が必要です。", "Hand one material weapon to repair a broken weapon."), row, 2);
     prt(_("材料に使用した武器はなくなります！", "The material weapon will disappear after repairing!!"), row + 1, 2);
-    const auto q = _("どの折れた武器を修復しますか？", "Repair which broken weapon? ");
-    const auto s = _("修復できる折れた武器がありません。", "You have no broken weapon to repair.");
+    constexpr auto q = _("どの折れた武器を修復しますか？", "Repair which broken weapon? ");
+    constexpr auto s = _("修復できる折れた武器がありません。", "You have no broken weapon to repair.");
     auto *o_ptr = choose_object(player_ptr, item, q, s, (USE_INVEN | USE_EQUIP), FuncItemTester(&ItemEntity::is_broken_weapon));
     if (o_ptr == nullptr) {
         return { false, nullptr };

--- a/src/market/building-craft-weapon.cpp
+++ b/src/market/building-craft-weapon.cpp
@@ -310,14 +310,11 @@ static void compare_weapon_aux(PlayerType *player_ptr, ItemEntity *o_ptr, int co
  */
 static void list_weapon(PlayerType *player_ptr, ItemEntity *o_ptr, TERM_LEN row, TERM_LEN col)
 {
-    GAME_TEXT o_name[MAX_NLEN];
-
-    DICE_NUMBER eff_dd = o_ptr->dd + player_ptr->to_dd[0];
-    DICE_SID eff_ds = o_ptr->ds + player_ptr->to_ds[0];
-    auto hit_reliability = player_ptr->skill_thn + (player_ptr->to_h[0] + o_ptr->to_h) * BTH_PLUS_ADJ;
-
-    describe_flavor(player_ptr, o_name, o_ptr, OD_NAME_ONLY);
-    c_put_str(TERM_YELLOW, o_name, row, col);
+    const auto eff_dd = o_ptr->dd + player_ptr->to_dd[0];
+    const auto eff_ds = o_ptr->ds + player_ptr->to_ds[0];
+    const auto hit_reliability = player_ptr->skill_thn + (player_ptr->to_h[0] + o_ptr->to_h) * BTH_PLUS_ADJ;
+    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
+    c_put_str(TERM_YELLOW, item_name.data(), row, col);
     put_str(format(_("攻撃回数: %d", "Number of Blows: %d"), player_ptr->num_blow[0]), row + 1, col);
 
     put_str(_("命中率:  0  50 100 150 200 (敵のAC)", "To Hit:  0  50 100 150 200 (AC)"), row + 2, col);

--- a/src/market/building-enchanter.cpp
+++ b/src/market/building-enchanter.cpp
@@ -29,21 +29,19 @@ bool enchant_item(PlayerType *player_ptr, PRICE cost, HIT_PROB to_hit, int to_da
     prt(format(_("現在のあなたの技量だと、+%d まで改良できます。", "  Based on your skill, we can improve up to +%d."), maxenchant), 5, 0);
     prt(format(_(" 改良の料金は一個につき＄%d です。", "  The price for the service is %d gold per item."), cost), 7, 0);
 
-    concptr q = _("どのアイテムを改良しますか？", "Improve which item? ");
-    concptr s = _("改良できるものがありません。", "You have nothing to improve.");
+    const auto q = _("どのアイテムを改良しますか？", "Improve which item? ");
+    const auto s = _("改良できるものがありません。", "You have nothing to improve.");
 
     OBJECT_IDX item;
-    ItemEntity *o_ptr;
-    o_ptr = choose_object(player_ptr, &item, q, s, (USE_INVEN | USE_EQUIP | IGNORE_BOTHHAND_SLOT), item_tester);
+    auto *o_ptr = choose_object(player_ptr, &item, q, s, (USE_INVEN | USE_EQUIP | IGNORE_BOTHHAND_SLOT), item_tester);
     if (!o_ptr) {
         return false;
     }
 
-    char tmp_str[MAX_NLEN];
     const PRICE total_cost = cost * o_ptr->number;
     if (player_ptr->au < total_cost) {
-        describe_flavor(player_ptr, tmp_str, o_ptr, OD_NAME_ONLY);
-        msg_format(_("%sを改良するだけのゴールドがありません！", "You do not have the gold to improve %s!"), tmp_str);
+        const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
+        msg_format(_("%sを改良するだけのゴールドがありません！", "You do not have the gold to improve %s!"), item_name.data());
         return false;
     }
 
@@ -77,11 +75,11 @@ bool enchant_item(PlayerType *player_ptr, PRICE cost, HIT_PROB to_hit, int to_da
         return false;
     }
 
-    describe_flavor(player_ptr, tmp_str, o_ptr, OD_NAME_AND_ENCHANT);
+    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_AND_ENCHANT);
 #ifdef JP
-    msg_format("＄%dで%sに改良しました。", total_cost, tmp_str);
+    msg_format("＄%dで%sに改良しました。", total_cost, item_name.data());
 #else
-    msg_format("Improved into %s for %d gold.", tmp_str, total_cost);
+    msg_format("Improved into %s for %d gold.", item_name.data(), total_cost);
 #endif
 
     player_ptr->au -= total_cost;

--- a/src/market/building-recharger.cpp
+++ b/src/market/building-recharger.cpp
@@ -150,7 +150,7 @@ void building_recharge(PlayerType *player_ptr)
 #ifdef JP
     msg_format("%sを＄%d で再充填しました。", item_name.data(), price);
 #else
-    msg_format("%^s %s recharged for %d gold.", item_name.data(), ((o_ptr->number > 1) ? "were" : "was"), price);
+    msg_format("%s^ %s recharged for %d gold.", item_name.data(), ((o_ptr->number > 1) ? "were" : "was"), price);
 #endif
     player_ptr->update |= (PU_COMBINE | PU_REORDER);
     player_ptr->window_flags |= (PW_INVEN);

--- a/src/market/building-recharger.cpp
+++ b/src/market/building-recharger.cpp
@@ -48,19 +48,14 @@ void building_recharge(PlayerType *player_ptr)
      * We don't want to give the player free info about
      * the level of the item or the number of charges.
      */
-    char tmp_str[MAX_NLEN];
     if (!o_ptr->is_known()) {
         msg_format(_("充填する前に鑑定されている必要があります！", "The item must be identified first!"));
         msg_print(nullptr);
-
-        if ((player_ptr->au >= 50) && get_check(_("＄50で鑑定しますか？ ", "Identify for 50 gold? ")))
-
-        {
+        if ((player_ptr->au >= 50) && get_check(_("＄50で鑑定しますか？ ", "Identify for 50 gold? "))) {
             player_ptr->au -= 50;
             identify_item(player_ptr, o_ptr);
-            describe_flavor(player_ptr, tmp_str, o_ptr, 0);
-            msg_format(_("%s です。", "You have: %s."), tmp_str);
-
+            const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+            msg_format(_("%s です。", "You have: %s."), item_name.data());
             autopick_alter_item(player_ptr, item, false);
             building_prt_gold(player_ptr);
         }
@@ -111,11 +106,11 @@ void building_recharge(PlayerType *player_ptr)
     }
 
     if (player_ptr->au < price) {
-        describe_flavor(player_ptr, tmp_str, o_ptr, OD_NAME_ONLY);
+        const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
 #ifdef JP
-        msg_format("%sを再充填するには＄%d 必要です！", tmp_str, price);
+        msg_format("%sを再充填するには＄%d 必要です！", item_name.data(), price);
 #else
-        msg_format("You need %d gold to recharge %s!", price, tmp_str);
+        msg_format("You need %d gold to recharge %s!", price, item_name.data());
 #endif
         return;
     }
@@ -151,11 +146,11 @@ void building_recharge(PlayerType *player_ptr)
         o_ptr->ident &= ~(IDENT_EMPTY);
     }
 
-    describe_flavor(player_ptr, tmp_str, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
 #ifdef JP
-    msg_format("%sを＄%d で再充填しました。", tmp_str, price);
+    msg_format("%sを＄%d で再充填しました。", item_name.data(), price);
 #else
-    msg_format("%s^ %s recharged for %d gold.", tmp_str, ((o_ptr->number > 1) ? "were" : "was"), price);
+    msg_format("%^s %s recharged for %d gold.", item_name.data(), ((o_ptr->number > 1) ? "were" : "was"), price);
 #endif
     player_ptr->update |= (PU_COMBINE | PU_REORDER);
     player_ptr->window_flags |= (PW_INVEN);

--- a/src/mind/mind-archer.cpp
+++ b/src/mind/mind-archer.cpp
@@ -17,6 +17,7 @@
 #include "object/item-use-flags.h"
 #include "object/object-kind-hook.h"
 #include "perception/object-perception.h"
+#include "system/angband.h"
 #include "system/baseitem-info.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
@@ -132,9 +133,8 @@ bool create_ammo(PlayerType *player_ptr)
         ItemMagicApplier(player_ptr, q_ptr, player_ptr->lev, AM_NO_FIXED_ART).execute();
         q_ptr->discount = 99;
         int16_t slot = store_item_to_inventory(player_ptr, q_ptr);
-        GAME_TEXT o_name[MAX_NLEN];
-        describe_flavor(player_ptr, o_name, q_ptr, 0);
-        msg_print(_(format("%sを作った。", o_name), "You make some ammo."));
+        const auto item_name = describe_flavor(player_ptr, q_ptr, 0);
+        msg_print(_(format("%sを作った。", item_name.data()), "You make some ammo."));
         if (slot >= 0) {
             autopick_alter_item(player_ptr, slot, false);
         }
@@ -160,9 +160,8 @@ bool create_ammo(PlayerType *player_ptr)
         object_known(q_ptr);
         ItemMagicApplier(player_ptr, q_ptr, player_ptr->lev, AM_NO_FIXED_ART).execute();
         q_ptr->discount = 99;
-        GAME_TEXT o_name[MAX_NLEN];
-        describe_flavor(player_ptr, o_name, q_ptr, 0);
-        msg_print(_(format("%sを作った。", o_name), "You make some ammo."));
+        const auto item_name = describe_flavor(player_ptr, q_ptr, 0);
+        msg_print(_(format("%sを作った。", item_name.data()), "You make some ammo."));
         vary_item(player_ptr, item, -1);
         int16_t slot = store_item_to_inventory(player_ptr, q_ptr);
         if (slot >= 0) {
@@ -188,9 +187,8 @@ bool create_ammo(PlayerType *player_ptr)
         object_known(q_ptr);
         ItemMagicApplier(player_ptr, q_ptr, player_ptr->lev, AM_NO_FIXED_ART).execute();
         q_ptr->discount = 99;
-        GAME_TEXT o_name[MAX_NLEN];
-        describe_flavor(player_ptr, o_name, q_ptr, 0);
-        msg_print(_(format("%sを作った。", o_name), "You make some ammo."));
+        const auto item_name = describe_flavor(player_ptr, q_ptr, 0);
+        msg_print(_(format("%sを作った。", item_name.data()), "You make some ammo."));
         vary_item(player_ptr, item, -1);
         int16_t slot = store_item_to_inventory(player_ptr, q_ptr);
         if (slot >= 0) {

--- a/src/mind/mind-mage.cpp
+++ b/src/mind/mind-mage.cpp
@@ -29,8 +29,6 @@
 bool eat_magic(PlayerType *player_ptr, int power)
 {
     byte fail_type = 1;
-    GAME_TEXT o_name[MAX_NLEN];
-
     const auto q = _("どのアイテムから魔力を吸収しますか？", "Drain which item? ");
     const auto s = _("魔力を吸収できるアイテムがありません。", "You have nothing to drain.");
     short item;
@@ -97,8 +95,8 @@ bool eat_magic(PlayerType *player_ptr, int power)
     }
 
     if (o_ptr->is_fixed_artifact()) {
-        describe_flavor(player_ptr, o_name, o_ptr, OD_NAME_ONLY);
-        msg_format(_("魔力が逆流した！%sは完全に魔力を失った。", "The recharging backfires - %s is completely drained!"), o_name);
+        const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
+        msg_format(_("魔力が逆流した！%sは完全に魔力を失った。", "The recharging backfires - %s is completely drained!"), item_name.data());
         if (tval == ItemKindType::ROD) {
             o_ptr->timeout = baseitem.pval * o_ptr->number;
         } else if (o_ptr->is_wand_staff()) {
@@ -108,7 +106,7 @@ bool eat_magic(PlayerType *player_ptr, int power)
         return redraw_player(player_ptr);
     }
 
-    describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
 
     /* Mages recharge objects more safely. */
     if (PlayerClass(player_ptr).is_wizard()) {
@@ -167,14 +165,15 @@ bool eat_magic(PlayerType *player_ptr, int power)
             msg_print(_("ロッドは破損を免れたが、魔力は全て失なわれた。", "You save your rod from destruction, but all charges are lost."));
             o_ptr->timeout = baseitem.pval * o_ptr->number;
         } else if (tval == ItemKindType::WAND) {
-            msg_format(_("%sは破損を免れたが、魔力が全て失われた。", "You save your %s from destruction, but all charges are lost."), o_name);
+            constexpr auto mes = _("%sは破損を免れたが、魔力が全て失われた。", "You save your %s from destruction, but all charges are lost.");
+            msg_format(mes, item_name.data());
             o_ptr->pval = 0;
         }
     }
 
     if (fail_type == 2) {
         if (o_ptr->number > 1) {
-            msg_format(_("乱暴な魔法のために%sが一本壊れた！", "Wild magic consumes one of your %s!"), o_name);
+            msg_format(_("乱暴な魔法のために%sが一本壊れた！", "Wild magic consumes one of your %s!"), item_name.data());
             /* Reduce rod stack maximum timeout, drain wands. */
             if (tval == ItemKindType::ROD) {
                 o_ptr->timeout = std::min<short>(o_ptr->timeout, baseitem.pval * (o_ptr->number - 1));
@@ -182,7 +181,7 @@ bool eat_magic(PlayerType *player_ptr, int power)
                 o_ptr->pval = o_ptr->pval * (o_ptr->number - 1) / o_ptr->number;
             }
         } else {
-            msg_format(_("乱暴な魔法のために%sが壊れた！", "Wild magic consumes your %s!"), o_name);
+            msg_format(_("乱暴な魔法のために%sが壊れた！", "Wild magic consumes your %s!"), item_name.data());
         }
 
         vary_item(player_ptr, item, -1);
@@ -190,9 +189,9 @@ bool eat_magic(PlayerType *player_ptr, int power)
 
     if (fail_type == 3) {
         if (o_ptr->number > 1) {
-            msg_format(_("乱暴な魔法のために%sが全て壊れた！", "Wild magic consumes all your %s!"), o_name);
+            msg_format(_("乱暴な魔法のために%sが全て壊れた！", "Wild magic consumes all your %s!"), item_name.data());
         } else {
-            msg_format(_("乱暴な魔法のために%sが壊れた！", "Wild magic consumes your %s!"), o_name);
+            msg_format(_("乱暴な魔法のために%sが壊れた！", "Wild magic consumes your %s!"), item_name.data());
         }
 
         vary_item(player_ptr, item, -999);

--- a/src/mind/mind-magic-eater.cpp
+++ b/src/mind/mind-magic-eater.cpp
@@ -73,9 +73,8 @@ bool import_magic_device(PlayerType *player_ptr)
         }
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, 0);
-    msg_format(_("%sの魔力を取り込んだ。", "You absorb magic of %s."), o_name);
+    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    msg_format(_("%sの魔力を取り込んだ。", "You absorb magic of %s."), item_name.data());
 
     vary_item(player_ptr, item, -999);
     PlayerEnergy(player_ptr).set_player_turn_energy(100);

--- a/src/mind/mind-mindcrafter.cpp
+++ b/src/mind/mind-mindcrafter.cpp
@@ -68,18 +68,16 @@ bool psychometry(PlayerType *player_ptr)
     }
 
     item_feel_type feel = pseudo_value_check_heavy(o_ptr);
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
-
+    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     if (!feel) {
-        msg_format(_("%sからは特に変わった事は感じとれなかった。", "You do not perceive anything unusual about the %s."), o_name);
+        msg_format(_("%sからは特に変わった事は感じとれなかった。", "You do not perceive anything unusual about the %s."), item_name.data());
         return true;
     }
 
 #ifdef JP
-    msg_format("%sは%sという感じがする...", o_name, game_inscriptions[feel]);
+    msg_format("%sは%sという感じがする...", item_name.data(), game_inscriptions[feel]);
 #else
-    msg_format("You feel that the %s %s %s...", o_name, ((o_ptr->number == 1) ? "is" : "are"), game_inscriptions[feel]);
+    msg_format("You feel that the %s %s %s...", item_name.data(), ((o_ptr->number == 1) ? "is" : "are"), game_inscriptions[feel]);
 #endif
 
     set_bits(o_ptr->ident, IDENT_SENSE);

--- a/src/mind/mind-priest.cpp
+++ b/src/mind/mind-priest.cpp
@@ -35,10 +35,8 @@ bool bless_weapon(PlayerType *player_ptr)
         return false;
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
+    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
     auto flags = object_flags(o_ptr);
-
     if (o_ptr->is_cursed()) {
         auto can_disturb_blessing = o_ptr->curse_flags.has(CurseTraitType::HEAVY_CURSE) && (randint1(100) < 33);
         can_disturb_blessing |= flags.has(TR_ADD_L_CURSE);
@@ -47,18 +45,18 @@ bool bless_weapon(PlayerType *player_ptr)
         can_disturb_blessing |= o_ptr->curse_flags.has(CurseTraitType::PERMA_CURSE);
         if (can_disturb_blessing) {
 #ifdef JP
-            msg_format("%sを覆う黒いオーラは祝福を跳ね返した！", o_name);
+            msg_format("%sを覆う黒いオーラは祝福を跳ね返した！", item_name.data());
 #else
-            msg_format("The black aura on %s %s disrupts the blessing!", ((item >= 0) ? "your" : "the"), o_name);
+            msg_format("The black aura on %s %s disrupts the blessing!", ((item >= 0) ? "your" : "the"), item_name.data());
 #endif
 
             return true;
         }
 
 #ifdef JP
-        msg_format("%s から邪悪なオーラが消えた。", o_name);
+        msg_format("%s から邪悪なオーラが消えた。", item_name.data());
 #else
-        msg_format("A malignant aura leaves %s %s.", ((item >= 0) ? "your" : "the"), o_name);
+        msg_format("A malignant aura leaves %s %s.", ((item >= 0) ? "your" : "the"), item_name.data());
 #endif
         o_ptr->curse_flags.clear();
         set_bits(o_ptr->ident, IDENT_SENSE);
@@ -77,18 +75,18 @@ bool bless_weapon(PlayerType *player_ptr)
      */
     if (flags.has(TR_BLESSED)) {
 #ifdef JP
-        msg_format("%s は既に祝福されている。", o_name);
+        msg_format("%s は既に祝福されている。", item_name.data());
 #else
-        msg_format("%s %s %s blessed already.", ((item >= 0) ? "Your" : "The"), o_name, ((o_ptr->number > 1) ? "were" : "was"));
+        msg_format("%s %s %s blessed already.", ((item >= 0) ? "Your" : "The"), item_name.data(), ((o_ptr->number > 1) ? "were" : "was"));
 #endif
         return true;
     }
 
     if (!(o_ptr->is_fixed_or_random_artifact() || o_ptr->is_ego()) || one_in_(3)) {
 #ifdef JP
-        msg_format("%sは輝いた！", o_name);
+        msg_format("%sは輝いた！", item_name.data());
 #else
-        msg_format("%s %s shine%s!", ((item >= 0) ? "Your" : "The"), o_name, ((o_ptr->number > 1) ? "" : "s"));
+        msg_format("%s %s shine%s!", ((item >= 0) ? "Your" : "The"), item_name.data(), ((o_ptr->number > 1) ? "" : "s"));
 #endif
         o_ptr->art_flags.set(TR_BLESSED);
         o_ptr->discount = 99;
@@ -130,9 +128,9 @@ bool bless_weapon(PlayerType *player_ptr)
             msg_print(_("周囲が凡庸な雰囲気で満ちた...", "There is a static feeling in the air..."));
 
 #ifdef JP
-            msg_format("%s は劣化した！", o_name);
+            msg_format("%s は劣化した！", item_name.data());
 #else
-            msg_format("%s %s %s disenchanted!", ((item >= 0) ? "Your" : "The"), o_name, ((o_ptr->number > 1) ? "were" : "was"));
+            msg_format("%s %s %s disenchanted!", ((item >= 0) ? "Your" : "The"), item_name.data(), ((o_ptr->number > 1) ? "were" : "was"));
 #endif
         }
     }

--- a/src/mind/mind-weaponsmith.cpp
+++ b/src/mind/mind-weaponsmith.cpp
@@ -120,9 +120,8 @@ static void drain_essence(PlayerType *player_ptr)
     }
 
     if (o_ptr->is_known() && !o_ptr->is_nameless()) {
-        GAME_TEXT o_name[MAX_NLEN];
-        describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
-        if (!get_check(format(_("本当に%sから抽出してよろしいですか？", "Really extract from %s? "), o_name))) {
+        const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+        if (!get_check(format(_("本当に%sから抽出してよろしいですか？", "Really extract from %s? "), item_name.data()))) {
             return;
         }
     }
@@ -311,7 +310,6 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
     concptr q, s;
     ItemEntity *o_ptr;
     char out_val[160];
-    GAME_TEXT o_name[MAX_NLEN];
     int menu_line = (use_menu ? 1 : 0);
 
     Smith smith(player_ptr);
@@ -448,8 +446,7 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
         return;
     }
 
-    describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
-
+    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     const auto use_essence = Smith::get_essence_consumption(effect, o_ptr);
     if (o_ptr->number > 1) {
         msg_format(_("%d個あるのでエッセンスは%d必要です。", "For %d items, it will take %d essences."), o_ptr->number, use_essence);
@@ -507,7 +504,7 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
 
     auto effect_name = Smith::get_effect_name(effect);
 
-    _(msg_format("%sに%sの能力を付加しました。", o_name, effect_name), msg_format("You have added ability of %s to %s.", effect_name, o_name));
+    _(msg_format("%sに%sの能力を付加しました。", item_name.data(), effect_name), msg_format("You have added ability of %s to %s.", effect_name, item_name.data()));
     player_ptr->update |= (PU_COMBINE | PU_REORDER);
     player_ptr->window_flags |= (PW_INVEN);
 }
@@ -517,21 +514,16 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
  */
 static void erase_essence(PlayerType *player_ptr)
 {
+    const auto q = _("どのアイテムのエッセンスを消去しますか？", "Remove from which item? ");
+    const auto s = _("エッセンスを付加したアイテムがありません。", "You have nothing with added essence to remove.");
     OBJECT_IDX item;
-    concptr q, s;
-    ItemEntity *o_ptr;
-    GAME_TEXT o_name[MAX_NLEN];
-
-    q = _("どのアイテムのエッセンスを消去しますか？", "Remove from which item? ");
-    s = _("エッセンスを付加したアイテムがありません。", "You have nothing with added essence to remove.");
-
-    o_ptr = choose_object(player_ptr, &item, q, s, (USE_INVEN | USE_FLOOR), FuncItemTester(&ItemEntity::is_smith));
+    auto *o_ptr = choose_object(player_ptr, &item, q, s, (USE_INVEN | USE_FLOOR), FuncItemTester(&ItemEntity::is_smith));
     if (!o_ptr) {
         return;
     }
 
-    describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
-    if (!get_check(format(_("よろしいですか？ [%s]", "Are you sure? [%s]"), o_name))) {
+    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    if (!get_check(format(_("よろしいですか？ [%s]", "Are you sure? [%s]"), item_name.data()))) {
         return;
     }
 

--- a/src/monster-attack/monster-attack-player.h
+++ b/src/monster-attack/monster-attack-player.h
@@ -31,7 +31,6 @@ public:
     bool obvious = false;
     int damage = 0;
     bool blinked = false;
-    GAME_TEXT o_name[MAX_NLEN]{};
     int get_damage = 0;
     GAME_TEXT ddesc[MAX_MONSTER_NAME]{};
     ARMOUR_CLASS ac = 0;

--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -150,11 +150,11 @@ void process_eat_item(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
             continue;
         }
 
-        describe_flavor(player_ptr, monap_ptr->o_name, monap_ptr->o_ptr, OD_OMIT_PREFIX);
+        const auto item_name = describe_flavor(player_ptr, monap_ptr->o_ptr, OD_OMIT_PREFIX);
 #ifdef JP
-        msg_format("%s(%c)を%s盗まれた！", monap_ptr->o_name, index_to_label(i_idx), ((monap_ptr->o_ptr->number > 1) ? "一つ" : ""));
+        msg_format("%s(%c)を%s盗まれた！", item_name.data(), index_to_label(i_idx), ((monap_ptr->o_ptr->number > 1) ? "一つ" : ""));
 #else
-        msg_format("%sour %s (%c) was stolen!", ((monap_ptr->o_ptr->number > 1) ? "One of y" : "Y"), monap_ptr->o_name, index_to_label(i_idx));
+        msg_format("%sour %s (%c) was stolen!", ((monap_ptr->o_ptr->number > 1) ? "One of y" : "Y"), item_name.data(), index_to_label(i_idx));
 #endif
         chg_virtue(player_ptr, V_SACRIFICE, 1);
         o_idx = o_pop(player_ptr->current_floor_ptr);
@@ -181,11 +181,11 @@ void process_eat_food(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
             continue;
         }
 
-        describe_flavor(player_ptr, monap_ptr->o_name, monap_ptr->o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+        const auto item_name = describe_flavor(player_ptr, monap_ptr->o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
 #ifdef JP
-        msg_format("%s(%c)を%s食べられてしまった！", monap_ptr->o_name, index_to_label(i_idx), ((monap_ptr->o_ptr->number > 1) ? "一つ" : ""));
+        msg_format("%s(%c)を%s食べられてしまった！", item_name.data(), index_to_label(i_idx), ((monap_ptr->o_ptr->number > 1) ? "一つ" : ""));
 #else
-        msg_format("%sour %s (%c) was eaten!", ((monap_ptr->o_ptr->number > 1) ? "One of y" : "Y"), monap_ptr->o_name, index_to_label(i_idx));
+        msg_format("%sour %s (%c) was eaten!", ((monap_ptr->o_ptr->number > 1) ? "One of y" : "Y"), item_name.data(), index_to_label(i_idx));
 #endif
         inven_item_increase(player_ptr, i_idx, -1);
         inven_item_optimize(player_ptr, i_idx);

--- a/src/monster-floor/monster-object.cpp
+++ b/src/monster-floor/monster-object.cpp
@@ -189,7 +189,6 @@ void update_object_by_monster_movement(PlayerType *player_ptr, turn_flags *turn_
     for (auto it = g_ptr->o_idx_list.begin(); it != g_ptr->o_idx_list.end();) {
         EnumClassFlagGroup<MonsterKindType> flg_monster_kind;
         EnumClassFlagGroup<MonsterResistanceType> flgr;
-        GAME_TEXT o_name[MAX_NLEN];
         OBJECT_IDX this_o_idx = *it++;
         auto *o_ptr = &player_ptr->current_floor_ptr->o_list[this_o_idx];
 
@@ -201,14 +200,14 @@ void update_object_by_monster_movement(PlayerType *player_ptr, turn_flags *turn_
         }
 
         auto flags = object_flags(o_ptr);
-        describe_flavor(player_ptr, o_name, o_ptr, 0);
+        const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
         const auto m_name = monster_desc(player_ptr, m_ptr, MD_INDEF_HIDDEN);
         update_object_flags(flags, flg_monster_kind, flgr);
 
         auto is_unpickable_object = o_ptr->is_fixed_or_random_artifact();
         is_unpickable_object |= r_ptr->kind_flags.has_any_of(flg_monster_kind);
         is_unpickable_object |= !r_ptr->resistance_flags.has_all_of(flgr) && r_ptr->resistance_flags.has_not(MonsterResistanceType::RESIST_ALL);
-        monster_pickup_object(player_ptr, turn_flags_ptr, m_idx, o_ptr, is_unpickable_object, ny, nx, m_name, o_name, this_o_idx);
+        monster_pickup_object(player_ptr, turn_flags_ptr, m_idx, o_ptr, is_unpickable_object, ny, nx, m_name, item_name, this_o_idx);
     }
 }
 

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -234,9 +234,7 @@ static void warn_unique_generation(PlayerType *player_ptr, MonsterRaceId r_idx)
         return;
     }
 
-    concptr color;
-    ItemEntity *o_ptr;
-    GAME_TEXT o_name[MAX_NLEN];
+    std::string color;
     if (r_ptr->level > player_ptr->lev + 30) {
         color = _("黒く", "black");
     } else if (r_ptr->level > player_ptr->lev + 15) {
@@ -251,12 +249,12 @@ static void warn_unique_generation(PlayerType *player_ptr, MonsterRaceId r_idx)
         color = _("白く", "white");
     }
 
-    o_ptr = choose_warning_item(player_ptr);
+    auto *o_ptr = choose_warning_item(player_ptr);
     if (o_ptr != nullptr) {
-        describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
-        msg_format(_("%sは%s光った。", "%s glows %s."), o_name, color);
+        const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+        msg_format(_("%sは%s光った。", "%s glows %s."), item_name.data(), color.data());
     } else {
-        msg_format(_("%s光る物が頭に浮かんだ。", "A %s image forms in your mind."), color);
+        msg_format(_("%s光る物が頭に浮かんだ。", "A %s image forms in your mind."), color.data());
     }
 }
 

--- a/src/object-enchant/object-curse.cpp
+++ b/src/object-enchant/object-curse.cpp
@@ -74,16 +74,16 @@ void curse_equipment(PlayerType *player_ptr, PERCENTAGE chance, PERCENTAGE heavy
     if (!o_ptr->bi_id) {
         return;
     }
+
     auto oflags = object_flags(o_ptr);
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
 
     /* Extra, biased saving throw for blessed items */
     if (oflags.has(TR_BLESSED)) {
 #ifdef JP
-        msg_format("祝福された%sは呪いを跳ね返した！", o_name);
+        msg_format("祝福された%sは呪いを跳ね返した！", item_name.data());
 #else
-        msg_format("Your blessed %s resist%s cursing!", o_name, ((o_ptr->number > 1) ? "" : "s"));
+        msg_format("Your blessed %s resist%s cursing!", item_name.data(), ((o_ptr->number > 1) ? "" : "s"));
 #endif
         /* Hmmm -- can we wear multiple items? If not, this is unnecessary */
         return;
@@ -116,7 +116,7 @@ void curse_equipment(PlayerType *player_ptr, PERCENTAGE chance, PERCENTAGE heavy
     }
 
     if (changed) {
-        msg_format(_("悪意に満ちた黒いオーラが%sをとりまいた...", "There is a malignant black aura surrounding %s..."), o_name);
+        msg_format(_("悪意に満ちた黒いオーラが%sをとりまいた...", "There is a malignant black aura surrounding %s..."), item_name.data());
         o_ptr->feeling = FEEL_NONE;
     }
 

--- a/src/object-use/read/parchment-read-executor.cpp
+++ b/src/object-use/read/parchment-read-executor.cpp
@@ -28,13 +28,12 @@ bool ParchmentReadExecutor::is_identified() const
 
 bool ParchmentReadExecutor::read()
 {
-    GAME_TEXT o_name[MAX_NLEN]{};
     char buf[1024]{};
     screen_save();
     auto q = format("book-%d_jp.txt", this->o_ptr->bi_key.sval().value());
-    describe_flavor(this->player_ptr, o_name, this->o_ptr, OD_NAME_ONLY);
+    const auto item_name = describe_flavor(this->player_ptr, this->o_ptr, OD_NAME_ONLY);
     (void)path_build(buf, sizeof(buf), ANGBAND_DIR_FILE, q.data());
-    (void)show_file(this->player_ptr, true, buf, o_name, 0, 0);
+    (void)show_file(this->player_ptr, true, buf, item_name.data(), 0, 0);
     screen_load();
     return false;
 }

--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -110,7 +110,7 @@ void ObjectThrowEntity::calc_throw_range()
     torch_flags(this->q_ptr, this->obj_flags);
     distribute_charges(this->o_ptr, this->q_ptr, 1);
     this->q_ptr->number = 1;
-    describe_flavor(this->player_ptr, this->o_name, this->q_ptr, OD_OMIT_PREFIX);
+    this->o_name = describe_flavor(this->player_ptr, this->q_ptr, OD_OMIT_PREFIX);
     if (this->player_ptr->mighty_throw) {
         this->mult += 3;
     }
@@ -219,7 +219,7 @@ void ObjectThrowEntity::exe_throw()
         auto *floor_ptr = this->player_ptr->current_floor_ptr;
         this->g_ptr = &floor_ptr->grid_array[this->y][this->x];
         this->m_ptr = &floor_ptr->m_list[this->g_ptr->m_idx];
-        angband_strcpy(this->m_name, monster_name(this->player_ptr, this->g_ptr->m_idx).data(), sizeof(this->m_name));
+        this->m_name = monster_name(this->player_ptr, this->g_ptr->m_idx);
         this->visible = this->m_ptr->ml;
         this->hit_body = true;
         this->attack_racial_power();
@@ -256,7 +256,7 @@ void ObjectThrowEntity::display_potion_throw()
         return;
     }
 
-    msg_format(_("%sは砕け散った！", "The %s shatters!"), this->o_name);
+    msg_format(_("%sは砕け散った！", "The %s shatters!"), this->o_name.data());
     if (!potion_smash_effect(this->player_ptr, 0, this->y, this->x, this->q_ptr->bi_id)) {
         this->do_drop = false;
         return;
@@ -292,7 +292,7 @@ void ObjectThrowEntity::check_boomerang_throw()
         this->back_chance += 100;
     }
 
-    describe_flavor(this->player_ptr, this->o2_name, this->q_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
+    this->o2_name = describe_flavor(this->player_ptr, this->q_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
     this->process_boomerang_throw();
 }
 
@@ -462,18 +462,18 @@ void ObjectThrowEntity::attack_racial_power()
 
     if (fear && this->m_ptr->ml) {
         sound(SOUND_FLEE);
-        msg_format(_("%s^は恐怖して逃げ出した！", "%s^ flees in terror!"), this->m_name);
+        msg_format(_("%s^は恐怖して逃げ出した！", "%s^ flees in terror!"), this->m_name.data());
     }
 }
 
 void ObjectThrowEntity::display_attack_racial_power()
 {
     if (!this->visible) {
-        msg_format(_("%sが敵を捕捉した。", "The %s finds a mark."), this->o_name);
+        msg_format(_("%sが敵を捕捉した。", "The %s finds a mark."), this->o_name.data());
         return;
     }
 
-    msg_format(_("%sが%sに命中した。", "The %s hits %s."), this->o_name, this->m_name);
+    msg_format(_("%sが%sに命中した。", "The %s hits %s."), this->o_name.data(), this->m_name.data());
     if (!this->m_ptr->ml) {
         return;
     }
@@ -518,7 +518,7 @@ void ObjectThrowEntity::calc_racial_power_damage()
 void ObjectThrowEntity::process_boomerang_throw()
 {
     if ((this->back_chance <= 30) || (one_in_(100) && !this->super_boomerang)) {
-        msg_format(_("%sが返ってこなかった！", "%s doesn't come back!"), this->o2_name);
+        msg_format(_("%sが返ってこなかった！", "%s doesn't come back!"), this->o2_name.data());
         return;
     }
 
@@ -549,13 +549,13 @@ void ObjectThrowEntity::display_boomerang_throw()
 {
     const auto is_blind = this->player_ptr->effects()->blindness()->is_blind();
     if ((this->back_chance > 37) && !is_blind && (this->item >= 0)) {
-        msg_format(_("%sが手元に返ってきた。", "%s comes back to you."), this->o2_name);
+        msg_format(_("%sが手元に返ってきた。", "%s comes back to you."), this->o2_name.data());
         this->come_back = true;
         return;
     }
 
     auto back_message = this->item >= 0 ? _("%sを受け損ねた！", "%s comes back, but you can't catch!") : _("%sが返ってきた。", "%s comes back.");
-    msg_format(back_message, this->o2_name);
+    msg_format(back_message, this->o2_name.data());
     this->y = this->player_ptr->y;
     this->x = this->player_ptr->x;
 }

--- a/src/object-use/throw-execution.h
+++ b/src/object-use/throw-execution.h
@@ -4,11 +4,11 @@
  * @brief 投擲処理関連ヘッダ
  */
 
+#include "object-enchant/tr-flags.h"
 #include "system/angband.h"
 #include "system/system-variables.h"
-
-#include "object-enchant/tr-flags.h"
 #include "util/flag-group.h"
+#include <string>
 
 struct grid_type;
 class MonsterEntity;
@@ -62,15 +62,15 @@ private:
     ItemEntity *o_ptr{};
     bool hit_wall = false;
     bool return_when_thrown = false;
-    GAME_TEXT o_name[MAX_NLEN]{};
+    std::string o_name{};
     TrFlags obj_flags{};
     bool come_back = false;
     bool do_drop = true;
     grid_type *g_ptr{};
     MonsterEntity *m_ptr{};
-    GAME_TEXT m_name[MAX_NLEN]{};
+    std::string m_name{};
     int back_chance{};
-    char o2_name[MAX_NLEN]{};
+    std::string o2_name{};
     bool super_boomerang{};
 
     bool check_what_throw();

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -358,7 +358,6 @@ bool process_warning(PlayerType *player_ptr, POSITION xx, POSITION yy)
 {
     POSITION mx, my;
     grid_type *g_ptr;
-    GAME_TEXT o_name[MAX_NLEN];
 
 #define WARNING_AWARE_RANGE 12
     int dam_max = 0;
@@ -536,13 +535,14 @@ bool process_warning(PlayerType *player_ptr, POSITION xx, POSITION yy)
 
         if (dam_max > player_ptr->chp / 2) {
             auto *o_ptr = choose_warning_item(player_ptr);
-
-            if (o_ptr) {
-                describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+            std::string item_name;
+            if (o_ptr != nullptr) {
+                item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
             } else {
-                strcpy(o_name, _("体", "body")); /* Warning ability without item */
+                item_name = _("体", "body");
             }
-            msg_format(_("%sが鋭く震えた！", "Your %s pulsates sharply!"), o_name);
+
+            msg_format(_("%sが鋭く震えた！", "Your %s pulsates sharply!"), item_name.data());
 
             disturb(player_ptr, false, true);
             return get_check(_("本当にこのまま進むか？", "Really want to go ahead? "));
@@ -559,12 +559,14 @@ bool process_warning(PlayerType *player_ptr, POSITION xx, POSITION yy)
     }
 
     auto *o_ptr = choose_warning_item(player_ptr);
+    std::string item_name;
     if (o_ptr != nullptr) {
-        describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+        item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     } else {
-        strcpy(o_name, _("体", "body")); /* Warning ability without item */
+        item_name = _("体", "body");
     }
-    msg_format(_("%sが鋭く震えた！", "Your %s pulsates sharply!"), o_name);
+
+    msg_format(_("%sが鋭く震えた！", "Your %s pulsates sharply!"), item_name.data());
     disturb(player_ptr, false, true);
     return get_check(_("本当にこのまま進むか？", "Really want to go ahead? "));
 }

--- a/src/perception/identification.cpp
+++ b/src/perception/identification.cpp
@@ -38,8 +38,6 @@
 bool screen_object(PlayerType *player_ptr, ItemEntity *o_ptr, BIT_FLAGS mode)
 {
     concptr info[128];
-    GAME_TEXT o_name[MAX_NLEN];
-
     int trivial_info = 0;
     auto flags = object_flags(o_ptr);
 
@@ -793,13 +791,14 @@ bool screen_object(PlayerType *player_ptr, ItemEntity *o_ptr, BIT_FLAGS mode)
     int wid, hgt;
     term_get_size(&wid, &hgt);
 
+    std::string item_name;
     if (!(mode & SCROBJ_FAKE_OBJECT)) {
-        describe_flavor(player_ptr, o_name, o_ptr, 0);
+        item_name = describe_flavor(player_ptr, o_ptr, 0);
     } else {
-        describe_flavor(player_ptr, o_name, o_ptr, (OD_NAME_ONLY | OD_STORE));
+        item_name = describe_flavor(player_ptr, o_ptr, (OD_NAME_ONLY | OD_STORE));
     }
 
-    prt(o_name, 0, 0);
+    prt(item_name, 0, 0);
     for (int k = 1; k < hgt; k++) {
         prt("", k, 13);
     }

--- a/src/perception/object-perception.cpp
+++ b/src/perception/object-perception.cpp
@@ -69,15 +69,11 @@ void object_aware(PlayerType *player_ptr, const ItemEntity *o_ptr)
     // playrecordに識別したアイテムを記録
     ItemEntity forge;
     ItemEntity *q_ptr;
-    GAME_TEXT o_name[MAX_NLEN];
-
     q_ptr = &forge;
     q_ptr->copy_from(o_ptr);
-
     q_ptr->number = 1;
-    describe_flavor(player_ptr, o_name, q_ptr, OD_NAME_ONLY);
-
-    exe_write_diary(player_ptr, DIARY_FOUND, 0, o_name);
+    const auto item_name = describe_flavor(player_ptr, q_ptr, OD_NAME_ONLY);
+    exe_write_diary(player_ptr, DIARY_FOUND, 0, item_name.data());
 }
 
 /*!

--- a/src/perception/simple-perception.cpp
+++ b/src/perception/simple-perception.cpp
@@ -37,7 +37,6 @@
 static void sense_inventory_aux(PlayerType *player_ptr, INVENTORY_IDX slot, bool heavy)
 {
     auto *o_ptr = &player_ptr->inventory_list[slot];
-    GAME_TEXT o_name[MAX_NLEN];
     if (o_ptr->ident & (IDENT_SENSE)) {
         return;
     }
@@ -98,20 +97,20 @@ static void sense_inventory_aux(PlayerType *player_ptr, INVENTORY_IDX slot, bool
         disturb(player_ptr, false, false);
     }
 
-    describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     if (slot >= INVEN_MAIN_HAND) {
 #ifdef JP
-        msg_format("%s%s(%c)は%sという感じがする...", describe_use(player_ptr, slot), o_name, index_to_label(slot), game_inscriptions[feel]);
+        msg_format("%s%s(%c)は%sという感じがする...", describe_use(player_ptr, slot), item_name.data(), index_to_label(slot), game_inscriptions[feel]);
 #else
-        msg_format("You feel the %s (%c) you are %s %s %s...", o_name, index_to_label(slot), describe_use(player_ptr, slot),
+        msg_format("You feel the %s (%c) you are %s %s %s...", item_name.data(), index_to_label(slot), describe_use(player_ptr, slot),
             ((o_ptr->number == 1) ? "is" : "are"), game_inscriptions[feel]);
 #endif
 
     } else {
 #ifdef JP
-        msg_format("ザックの中の%s(%c)は%sという感じがする...", o_name, index_to_label(slot), game_inscriptions[feel]);
+        msg_format("ザックの中の%s(%c)は%sという感じがする...", item_name.data(), index_to_label(slot), game_inscriptions[feel]);
 #else
-        msg_format("You feel the %s (%c) in your pack %s %s...", o_name, index_to_label(slot), ((o_ptr->number == 1) ? "is" : "are"), game_inscriptions[feel]);
+        msg_format("You feel the %s (%c) in your pack %s %s...", item_name.data(), index_to_label(slot), ((o_ptr->number == 1) ? "is" : "are"), game_inscriptions[feel]);
 #endif
     }
 

--- a/src/player-attack/attack-chaos-effect.cpp
+++ b/src/player-attack/attack-chaos-effect.cpp
@@ -279,10 +279,11 @@ static void attack_golden_hammer(PlayerType *player_ptr, player_attack_type *pa_
  */
 void change_monster_stat(PlayerType *player_ptr, player_attack_type *pa_ptr, const POSITION y, const POSITION x, int *num)
 {
-    auto *r_ptr = &monraces_info[pa_ptr->m_ptr->r_idx];
-    auto *o_ptr = &player_ptr->inventory_list[INVEN_MAIN_HAND + pa_ptr->hand];
-
-    if (any_bits(player_ptr->special_attack, ATTACK_CONFUSE) || pa_ptr->chaos_effect == CE_CONFUSION || pa_ptr->mode == HISSATSU_CONF || SpellHex(player_ptr).is_spelling_specific(HEX_CONFUSION)) {
+    auto should_confuse = any_bits(player_ptr->special_attack, ATTACK_CONFUSE);
+    should_confuse |= pa_ptr->chaos_effect == CE_CONFUSION;
+    should_confuse |= pa_ptr->mode == HISSATSU_CONF;
+    should_confuse |= SpellHex(player_ptr).is_spelling_specific(HEX_CONFUSION);
+    if (should_confuse) {
         attack_confuse(player_ptr, pa_ptr);
     }
 
@@ -306,11 +307,12 @@ void change_monster_stat(PlayerType *player_ptr, player_attack_type *pa_ptr, con
         attack_teleport_away(player_ptr, pa_ptr, num);
     }
 
-    if (pa_ptr->chaos_effect == CE_POLYMORPH && randint1(90) > r_ptr->level) {
+    if (pa_ptr->chaos_effect == CE_POLYMORPH && (randint1(90) > monraces_info[pa_ptr->m_ptr->r_idx].level)) {
         attack_polymorph(player_ptr, pa_ptr, y, x);
     }
 
-    if (o_ptr->is_specific_artifact(FixedArtifactId::G_HAMMER)) {
+    const auto &item = player_ptr->inventory_list[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
+    if (item.is_specific_artifact(FixedArtifactId::G_HAMMER)) {
         attack_golden_hammer(player_ptr, pa_ptr);
     }
 }

--- a/src/player-attack/attack-chaos-effect.cpp
+++ b/src/player-attack/attack-chaos-effect.cpp
@@ -260,12 +260,11 @@ static void attack_golden_hammer(PlayerType *player_ptr, player_attack_type *pa_
     }
 
     auto *q_ptr = &floor_ptr->o_list[m_ptr->hold_o_idx_list.front()];
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, q_ptr, OD_NAME_ONLY);
+    const auto item_name = describe_flavor(player_ptr, q_ptr, OD_NAME_ONLY);
     q_ptr->held_m_idx = 0;
     q_ptr->marked.clear().set(OmType::TOUCHED);
     m_ptr->hold_o_idx_list.pop_front();
-    msg_format(_("%sを奪った。", "You snatched %s."), o_name);
+    msg_format(_("%sを奪った。", "You snatched %s."), item_name.data());
     store_item_to_inventory(player_ptr, q_ptr);
 }
 

--- a/src/player/patron.cpp
+++ b/src/player/patron.cpp
@@ -147,8 +147,6 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
     int type;
     patron_reward effect;
     std::string reward;
-    GAME_TEXT o_name[MAX_NLEN];
-
     int count = 0;
 
     if (!chosen_reward) {
@@ -404,27 +402,25 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
                     slot = INVEN_MAIN_HAND;
                 }
             }
-            describe_flavor(player_ptr, o_name, &this->player_ptr->inventory_list[slot], OD_NAME_ONLY);
+
+            const auto item_name = describe_flavor(this->player_ptr, &this->player_ptr->inventory_list[slot], OD_NAME_ONLY);
             (void)curse_weapon_object(player_ptr, false, &this->player_ptr->inventory_list[slot]);
-            reward = format(_("%sが破壊された。", "destroying %s"), o_name);
+            reward = format(_("%sが破壊された。", "destroying %s"), item_name.data());
             break;
         }
 
-        case REW_CURSE_AR:
-
+        case REW_CURSE_AR: {
             if (!this->player_ptr->inventory_list[INVEN_BODY].bi_id) {
                 break;
             }
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「汝、防具に頼ることなかれ。」", "'Thou reliest too much on thine equipment.'"));
-
-            describe_flavor(player_ptr, o_name, &this->player_ptr->inventory_list[INVEN_BODY], OD_NAME_ONLY);
+            const auto item_name = describe_flavor(player_ptr, &this->player_ptr->inventory_list[INVEN_BODY], OD_NAME_ONLY);
             (void)curse_armor(player_ptr);
-            reward = format(_("%sが破壊された。", "destroying %s"), o_name);
+            reward = format(_("%sが破壊された。", "destroying %s"), item_name.data());
             break;
-
-        case REW_PISS_OFF:
-
+        }
+        case REW_PISS_OFF: {
             msg_format(_("%sの声がささやいた:", "The voice of %s whispers:"), this->name.data());
             msg_print(_("「我を怒りしめた罪を償うべし。」", "'Now thou shalt pay for annoying me.'"));
 
@@ -450,16 +446,18 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
                             slot = INVEN_MAIN_HAND;
                         }
                     }
-                    describe_flavor(player_ptr, o_name, &this->player_ptr->inventory_list[slot], OD_NAME_ONLY);
+
+                    const auto item_name = describe_flavor(this->player_ptr, &this->player_ptr->inventory_list[slot], OD_NAME_ONLY);
                     (void)curse_weapon_object(player_ptr, false, &this->player_ptr->inventory_list[slot]);
-                    reward = format(_("%sが破壊された。", "destroying %s"), o_name);
+                    reward = format(_("%sが破壊された。", "destroying %s"), item_name.data());
                 } else {
                     if (!this->player_ptr->inventory_list[INVEN_BODY].bi_id) {
                         break;
                     }
-                    describe_flavor(player_ptr, o_name, &this->player_ptr->inventory_list[INVEN_BODY], OD_NAME_ONLY);
+
+                    const auto item_name = describe_flavor(player_ptr, &this->player_ptr->inventory_list[INVEN_BODY], OD_NAME_ONLY);
                     (void)curse_armor(player_ptr);
-                    reward = format(_("%sが破壊された。", "destroying %s"), o_name);
+                    reward = format(_("%sが破壊された。", "destroying %s"), item_name.data());
                 }
                 break;
             default:
@@ -470,7 +468,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
                 break;
             }
             break;
-
+        }
         case REW_WRATH:
 
             msg_format(_("%sの声が轟き渡った:", "The voice of %s thunders:"), this->name.data());

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -119,20 +119,19 @@ static bool acid_minus_ac(PlayerType *player_ptr)
         return false;
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
+    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
     auto flags = object_flags(o_ptr);
     if (o_ptr->ac + o_ptr->to_a <= 0) {
-        msg_format(_("%sは既にボロボロだ！", "Your %s is already fully corroded!"), o_name);
+        msg_format(_("%sは既にボロボロだ！", "Your %s is already fully corroded!"), item_name.data());
         return false;
     }
 
     if (flags.has(TR_IGNORE_ACID)) {
-        msg_format(_("しかし%sには効果がなかった！", "Your %s is unaffected!"), o_name);
+        msg_format(_("しかし%sには効果がなかった！", "Your %s is unaffected!"), item_name.data());
         return true;
     }
 
-    msg_format(_("%sが酸で腐食した！", "Your %s is corroded!"), o_name);
+    msg_format(_("%sが酸で腐食した！", "Your %s is corroded!"), item_name.data());
     o_ptr->to_a--;
     player_ptr->update |= PU_BONUS;
     player_ptr->window_flags |= PW_EQUIP | PW_PLAYER;

--- a/src/player/process-death.cpp
+++ b/src/player/process-death.cpp
@@ -314,11 +314,10 @@ static void show_dead_home_items(PlayerType *player_ptr)
         for (int i = 0, k = 0; i < store_ptr->stock_num; k++) {
             term_clear();
             for (int j = 0; (j < 12) && (i < store_ptr->stock_num); j++, i++) {
-                GAME_TEXT o_name[MAX_NLEN];
                 const auto *o_ptr = &store_ptr->stock[i];
                 prt(format("%c) ", I2A(j)), j + 2, 4);
-                describe_flavor(player_ptr, o_name, o_ptr, 0);
-                c_put_str(tval_to_attr[enum2i(o_ptr->bi_key.tval())], o_name, j + 2, 7);
+                const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+                c_put_str(tval_to_attr[enum2i(o_ptr->bi_key.tval())], item_name, j + 2, 7);
             }
 
             prt(format(_("我が家に置いてあったアイテム ( %d ページ): -続く-", "Your home contains (page %d): -more-"), k + 1), 0, 0);

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -174,16 +174,15 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
                 return "";
             }
 
-            GAME_TEXT o_name[MAX_NLEN];
-            describe_flavor(player_ptr, o_name, o_ptr, OD_NAME_ONLY);
+            const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
             auto f = object_flags(o_ptr);
 
-            if (!get_check(format(_("本当に %s を呪いますか？", "Do you curse %s, really？"), o_name))) {
+            if (!get_check(format(_("本当に %s を呪いますか？", "Do you curse %s, really？"), item_name.data()))) {
                 return "";
             }
 
             if (!one_in_(3) && (o_ptr->is_fixed_or_random_artifact() || f.has(TR_BLESSED))) {
-                msg_format(_("%s は呪いを跳ね返した。", "%s resists the effect."), o_name);
+                msg_format(_("%s は呪いを跳ね返した。", "%s resists the effect."), item_name.data());
                 if (one_in_(3)) {
                     if (o_ptr->to_d > 0) {
                         o_ptr->to_d -= randint1(3) % 2;
@@ -203,11 +202,11 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
                             o_ptr->to_a = 0;
                         }
                     }
-                    msg_format(_("%s は劣化してしまった。", "Your %s was disenchanted!"), o_name);
+                    msg_format(_("%s は劣化してしまった。", "Your %s was disenchanted!"), item_name.data());
                 }
             } else {
                 int curse_rank = 0;
-                msg_format(_("恐怖の暗黒オーラがあなたの%sを包み込んだ！", "A terrible black aura blasts your %s!"), o_name);
+                msg_format(_("恐怖の暗黒オーラがあなたの%sを包み込んだ！", "A terrible black aura blasts your %s!"), item_name.data());
                 o_ptr->curse_flags.set(CurseTraitType::CURSED);
 
                 if (o_ptr->is_fixed_or_random_artifact() || o_ptr->is_ego()) {
@@ -521,29 +520,24 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
             return _("装備している防具に呪いをかける。", "Curse a piece of armour that you are wielding.");
         }
         if (cast) {
+            const auto q = _("どれを呪いますか？", "Which piece of armour do you curse?");
+            const auto s = _("防具を装備していない。", "You're not wearing any armor.");
             OBJECT_IDX item;
-            concptr q, s;
-            GAME_TEXT o_name[MAX_NLEN];
-            ItemEntity *o_ptr;
-
-            q = _("どれを呪いますか？", "Which piece of armour do you curse?");
-            s = _("防具を装備していない。", "You're not wearing any armor.");
-
-            o_ptr = choose_object(player_ptr, &item, q, s, (USE_EQUIP), FuncItemTester(&ItemEntity::is_protector));
+            auto *o_ptr = choose_object(player_ptr, &item, q, s, (USE_EQUIP), FuncItemTester(&ItemEntity::is_protector));
             if (!o_ptr) {
                 return "";
             }
 
             o_ptr = &player_ptr->inventory_list[item];
-            describe_flavor(player_ptr, o_name, o_ptr, OD_NAME_ONLY);
+            const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
             auto f = object_flags(o_ptr);
 
-            if (!get_check(format(_("本当に %s を呪いますか？", "Do you curse %s, really？"), o_name))) {
+            if (!get_check(format(_("本当に %s を呪いますか？", "Do you curse %s, really？"), item_name.data()))) {
                 return "";
             }
 
             if (!one_in_(3) && (o_ptr->is_fixed_or_random_artifact() || f.has(TR_BLESSED))) {
-                msg_format(_("%s は呪いを跳ね返した。", "%s resists the effect."), o_name);
+                msg_format(_("%s は呪いを跳ね返した。", "%s resists the effect."), item_name.data());
                 if (one_in_(3)) {
                     if (o_ptr->to_d > 0) {
                         o_ptr->to_d -= randint1(3) % 2;
@@ -563,11 +557,11 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
                             o_ptr->to_a = 0;
                         }
                     }
-                    msg_format(_("%s は劣化してしまった。", "Your %s was disenchanted!"), o_name);
+                    msg_format(_("%s は劣化してしまった。", "Your %s was disenchanted!"), item_name.data());
                 }
             } else {
                 int curse_rank = 0;
-                msg_format(_("恐怖の暗黒オーラがあなたの%sを包み込んだ！", "A terrible black aura blasts your %s!"), o_name);
+                msg_format(_("恐怖の暗黒オーラがあなたの%sを包み込んだ！", "A terrible black aura blasts your %s!"), item_name.data());
                 o_ptr->curse_flags.set(CurseTraitType::CURSED);
 
                 if (o_ptr->is_fixed_or_random_artifact() || o_ptr->is_ego()) {

--- a/src/spell-kind/magic-item-recharger.cpp
+++ b/src/spell-kind/magic-item-recharger.cpp
@@ -119,10 +119,9 @@ bool recharge(PlayerType *player_ptr, int power)
         return update_player(player_ptr);
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
     if (o_ptr->is_fixed_artifact()) {
-        describe_flavor(player_ptr, o_name, o_ptr, OD_NAME_ONLY);
-        msg_format(_("魔力が逆流した！%sは完全に魔力を失った。", "The recharging backfires - %s is completely drained!"), o_name);
+        const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
+        msg_format(_("魔力が逆流した！%sは完全に魔力を失った。", "The recharging backfires - %s is completely drained!"), item_name.data());
         if ((tval == ItemKindType::ROD) && (o_ptr->timeout < 10000)) {
             o_ptr->timeout = (o_ptr->timeout + 100) * 2;
         } else if (o_ptr->is_wand_staff()) {
@@ -131,7 +130,7 @@ bool recharge(PlayerType *player_ptr, int power)
         return update_player(player_ptr);
     }
 
-    describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     auto fail_type = 1;
     if (PlayerClass(player_ptr).is_wizard()) {
         /* 10% chance to blow up one rod, otherwise draining. */
@@ -192,16 +191,16 @@ bool recharge(PlayerType *player_ptr, int power)
                 o_ptr->timeout = (o_ptr->timeout + 100) * 2;
             }
         } else if (tval == ItemKindType::WAND) {
-            msg_format(_("%sは破損を免れたが、魔力が全て失われた。", "You save your %s from destruction, but all charges are lost."), o_name);
+            msg_format(_("%sは破損を免れたが、魔力が全て失われた。", "You save your %s from destruction, but all charges are lost."), item_name.data());
             o_ptr->pval = 0;
         }
 
         break;
     case 2:
         if (o_ptr->number > 1) {
-            msg_format(_("乱暴な魔法のために%sが一本壊れた！", "Wild magic consumes one of your %s!"), o_name);
+            msg_format(_("乱暴な魔法のために%sが一本壊れた！", "Wild magic consumes one of your %s!"), item_name.data());
         } else {
-            msg_format(_("乱暴な魔法のために%sが壊れた！", "Wild magic consumes your %s!"), o_name);
+            msg_format(_("乱暴な魔法のために%sが壊れた！", "Wild magic consumes your %s!"), item_name.data());
         }
 
         if (tval == ItemKindType::ROD) {
@@ -216,9 +215,9 @@ bool recharge(PlayerType *player_ptr, int power)
         break;
     case 3:
         if (o_ptr->number > 1) {
-            msg_format(_("乱暴な魔法のために%sが全て壊れた！", "Wild magic consumes all your %s!"), o_name);
+            msg_format(_("乱暴な魔法のために%sが全て壊れた！", "Wild magic consumes all your %s!"), item_name.data());
         } else {
-            msg_format(_("乱暴な魔法のために%sが壊れた！", "Wild magic consumes your %s!"), o_name);
+            msg_format(_("乱暴な魔法のために%sが壊れた！", "Wild magic consumes your %s!"), item_name.data());
         }
 
         vary_item(player_ptr, item, -999);

--- a/src/spell-kind/spells-enchant.cpp
+++ b/src/spell-kind/spells-enchant.cpp
@@ -17,7 +17,6 @@
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "view/display-messages.h"
-
 #include <memory>
 
 /*!
@@ -36,42 +35,41 @@ bool artifact_scroll(PlayerType *player_ptr)
         return false;
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
 #ifdef JP
-    msg_format("%s は眩い光を発した！", o_name);
+    msg_format("%s は眩い光を発した！", item_name.data());
 #else
-    msg_format("%s %s radiate%s a blinding light!", ((item >= 0) ? "Your" : "The"), o_name, ((o_ptr->number > 1) ? "" : "s"));
+    msg_format("%s %s radiate%s a blinding light!", ((item >= 0) ? "Your" : "The"), item_name.data(), ((o_ptr->number > 1) ? "" : "s"));
 #endif
 
     bool okay = false;
     if (o_ptr->is_fixed_or_random_artifact()) {
 #ifdef JP
-        msg_format("%sは既に伝説のアイテムです！", o_name);
+        msg_format("%sは既に伝説のアイテムです！", item_name.data());
 #else
-        msg_format("The %s %s already %s!", o_name, ((o_ptr->number > 1) ? "are" : "is"), ((o_ptr->number > 1) ? "artifacts" : "an artifact"));
+        msg_format("The %s %s already %s!", item_name.data(), ((o_ptr->number > 1) ? "are" : "is"), ((o_ptr->number > 1) ? "artifacts" : "an artifact"));
 #endif
         okay = false;
     } else if (o_ptr->is_ego()) {
 #ifdef JP
-        msg_format("%sは既に名のあるアイテムです！", o_name);
+        msg_format("%sは既に名のあるアイテムです！", item_name.data());
 #else
-        msg_format("The %s %s already %s!", o_name, ((o_ptr->number > 1) ? "are" : "is"), ((o_ptr->number > 1) ? "ego items" : "an ego item"));
+        msg_format("The %s %s already %s!", item_name.data(), ((o_ptr->number > 1) ? "are" : "is"), ((o_ptr->number > 1) ? "ego items" : "an ego item"));
 #endif
         okay = false;
     } else if (o_ptr->is_smith()) {
 #ifdef JP
-        msg_format("%sは既に強化されています！", o_name);
+        msg_format("%sは既に強化されています！", item_name.data());
 #else
-        msg_format("The %s %s already %s!", o_name, ((o_ptr->number > 1) ? "are" : "is"), ((o_ptr->number > 1) ? "customized items" : "a customized item"));
+        msg_format("The %s %s already %s!", item_name.data(), ((o_ptr->number > 1) ? "are" : "is"), ((o_ptr->number > 1) ? "customized items" : "a customized item"));
 #endif
     } else {
         if (o_ptr->number > 1) {
             msg_print(_("複数のアイテムに魔法をかけるだけのエネルギーはありません！", "Not enough energy to enchant more than one object!"));
 #ifdef JP
-            msg_format("%d 個の%sが壊れた！", (o_ptr->number) - 1, o_name);
+            msg_format("%d 個の%sが壊れた！", (o_ptr->number) - 1, item_name.data());
 #else
-            msg_format("%d of your %s %s destroyed!", (o_ptr->number) - 1, o_name, (o_ptr->number > 2 ? "were" : "was"));
+            msg_format("%d of your %s %s destroyed!", (o_ptr->number) - 1, item_name.data(), (o_ptr->number > 2 ? "were" : "was"));
 #endif
 
             if (item >= 0) {
@@ -99,8 +97,8 @@ bool artifact_scroll(PlayerType *player_ptr)
     }
 
     if (record_rand_art) {
-        describe_flavor(player_ptr, o_name, o_ptr, OD_NAME_ONLY);
-        exe_write_diary(player_ptr, DIARY_ART_SCROLL, 0, o_name);
+        const auto diary_item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
+        exe_write_diary(player_ptr, DIARY_ART_SCROLL, 0, diary_item_name.data());
     }
 
     chg_virtue(player_ptr, V_ENCHANT, 1);

--- a/src/spell-kind/spells-equipment.cpp
+++ b/src/spell-kind/spells-equipment.cpp
@@ -64,13 +64,12 @@ bool apply_disenchant(PlayerType *player_ptr, BIT_FLAGS mode)
         return false;
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     if (o_ptr->is_fixed_or_random_artifact() && (randint0(100) < 71)) {
 #ifdef JP
-        msg_format("%s(%c)は劣化を跳ね返した！", o_name, index_to_label(t));
+        msg_format("%s(%c)は劣化を跳ね返した！", item_name.data(), index_to_label(t));
 #else
-        msg_format("Your %s (%c) resist%s disenchantment!", o_name, index_to_label(t), ((o_ptr->number != 1) ? "" : "s"));
+        msg_format("Your %s (%c) resist%s disenchantment!", item_name.data(), index_to_label(t), ((o_ptr->number != 1) ? "" : "s"));
 #endif
         return true;
     }
@@ -114,9 +113,9 @@ bool apply_disenchant(PlayerType *player_ptr, BIT_FLAGS mode)
     }
 
 #ifdef JP
-    msg_format("%s(%c)は劣化してしまった！", o_name, index_to_label(t));
+    msg_format("%s(%c)は劣化してしまった！", item_name.data(), index_to_label(t));
 #else
-    msg_format("Your %s (%c) %s disenchanted!", o_name, index_to_label(t), ((o_ptr->number != 1) ? "were" : "was"));
+    msg_format("Your %s (%c) %s disenchanted!", item_name.data(), index_to_label(t), ((o_ptr->number != 1) ? "were" : "was"));
 #endif
     chg_virtue(player_ptr, V_HARMONY, 1);
     chg_virtue(player_ptr, V_ENCHANT, -2);

--- a/src/spell-kind/spells-fetcher.cpp
+++ b/src/spell-kind/spells-fetcher.cpp
@@ -106,7 +106,7 @@ void fetch_item(PlayerType *player_ptr, DIRECTION dir, WEIGHT wgt, bool require_
     o_ptr->ix = player_ptr->x;
 
     const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
-    msg_format(_("%^sがあなたの足元に飛んできた。", "%^s flies through the air to your feet."), item_name.data());
+    msg_format(_("%s^があなたの足元に飛んできた。", "%s^ flies through the air to your feet."), item_name.data());
     note_spot(player_ptr, player_ptr->y, player_ptr->x);
     player_ptr->redraw |= PR_MAP;
 }

--- a/src/spell-kind/spells-fetcher.cpp
+++ b/src/spell-kind/spells-fetcher.cpp
@@ -41,8 +41,6 @@ void fetch_item(PlayerType *player_ptr, DIRECTION dir, WEIGHT wgt, bool require_
 {
     grid_type *g_ptr;
     ItemEntity *o_ptr;
-    GAME_TEXT o_name[MAX_NLEN];
-
     if (!player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x].o_idx_list.empty()) {
         msg_print(_("自分の足の下にある物は取れません。", "You can't fetch when you're already standing on something."));
         return;
@@ -104,13 +102,11 @@ void fetch_item(PlayerType *player_ptr, DIRECTION dir, WEIGHT wgt, bool require_
     OBJECT_IDX i = g_ptr->o_idx_list.front();
     g_ptr->o_idx_list.pop_front();
     player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x].o_idx_list.add(player_ptr->current_floor_ptr, i); /* 'move' it */
-
     o_ptr->iy = player_ptr->y;
     o_ptr->ix = player_ptr->x;
 
-    describe_flavor(player_ptr, o_name, o_ptr, OD_NAME_ONLY);
-    msg_format(_("%s^があなたの足元に飛んできた。", "%s^ flies through the air to your feet."), o_name);
-
+    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
+    msg_format(_("%^sがあなたの足元に飛んできた。", "%^s flies through the air to your feet."), item_name.data());
     note_spot(player_ptr, player_ptr->y, player_ptr->x);
     player_ptr->redraw |= PR_MAP;
 }

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -349,9 +349,8 @@ bool destroy_area(PlayerType *player_ptr, POSITION y1, POSITION x1, POSITION r, 
                         artifacts_info.at(o_ptr->fixed_artifact_idx).is_generated = false;
 
                         if (in_generate && cheat_peek) {
-                            GAME_TEXT o_name[MAX_NLEN];
-                            describe_flavor(player_ptr, o_name, o_ptr, (OD_NAME_ONLY | OD_STORE));
-                            msg_format(_("伝説のアイテム (%s) は生成中に*破壊*された。", "Artifact (%s) was *destroyed* during generation."), o_name);
+                            const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_NAME_ONLY | OD_STORE));
+                            msg_format(_("伝説のアイテム (%s) は生成中に*破壊*された。", "Artifact (%s) was *destroyed* during generation."), item_name.data());
                         }
                     } else if (in_generate && cheat_peek && o_ptr->is_random_artifact()) {
                         msg_print(

--- a/src/spell-kind/spells-perception.cpp
+++ b/src/spell-kind/spells-perception.cpp
@@ -126,7 +126,7 @@ bool ident_spell(PlayerType *player_ptr, bool only_equip)
 
     const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
     if (item >= INVEN_MAIN_HAND) {
-        msg_format(_("%^s: %s(%c)。", "%^s: %s (%c)."), describe_use(player_ptr, item), item_name.data(), index_to_label(item));
+        msg_format(_("%s^: %s(%c)。", "%s^: %s (%c)."), describe_use(player_ptr, item), item_name.data(), index_to_label(item));
     } else if (item >= 0) {
         msg_format(_("ザック中: %s(%c)。", "In your pack: %s (%c)."), item_name.data(), index_to_label(item));
     } else {
@@ -183,7 +183,7 @@ bool identify_fully(PlayerType *player_ptr, bool only_equip)
 
     const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
     if (item >= INVEN_MAIN_HAND) {
-        msg_format(_("%^s: %s(%c)。", "%^s: %s (%c)."), describe_use(player_ptr, item), item_name.data(), index_to_label(item));
+        msg_format(_("%s^: %s(%c)。", "%s^: %s (%c)."), describe_use(player_ptr, item), item_name.data(), index_to_label(item));
     } else if (item >= 0) {
         msg_format(_("ザック中: %s(%c)。", "In your pack: %s (%c)."), item_name.data(), index_to_label(item));
     } else {

--- a/src/spell-kind/spells-perception.cpp
+++ b/src/spell-kind/spells-perception.cpp
@@ -25,6 +25,7 @@
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
+#include "util/string-processor.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 #include <memory>
@@ -57,14 +58,8 @@ void identify_pack(PlayerType *player_ptr)
  */
 bool identify_item(PlayerType *player_ptr, ItemEntity *o_ptr)
 {
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, 0);
-
-    bool old_known = false;
-    if (any_bits(o_ptr->ident, IDENT_KNOWN)) {
-        old_known = true;
-    }
-
+    const auto known_item_name = describe_flavor(player_ptr, o_ptr, 0);
+    const auto old_known = any_bits(o_ptr->ident, IDENT_KNOWN);
     if (!o_ptr->is_fully_known()) {
         if (o_ptr->is_fixed_or_random_artifact() || one_in_(5)) {
             chg_virtue(player_ptr, V_KNOWLEDGE, 1);
@@ -78,16 +73,16 @@ bool identify_item(PlayerType *player_ptr, ItemEntity *o_ptr)
     set_bits(player_ptr->update, PU_BONUS | PU_COMBINE | PU_REORDER);
     set_bits(player_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_PLAYER | PW_FLOOR_ITEM_LIST | PW_FOUND_ITEM_LIST);
 
-    strcpy(record_o_name, o_name);
+    angband_strcpy(record_o_name, known_item_name.data(), MAX_NLEN);
     record_turn = w_ptr->game_turn;
 
-    describe_flavor(player_ptr, o_name, o_ptr, OD_NAME_ONLY);
-
+    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
     if (record_fix_art && !old_known && o_ptr->is_fixed_artifact()) {
-        exe_write_diary(player_ptr, DIARY_ART, 0, o_name);
+        exe_write_diary(player_ptr, DIARY_ART, 0, item_name.data());
     }
+
     if (record_rand_art && !old_known && o_ptr->is_random_artifact()) {
-        exe_write_diary(player_ptr, DIARY_ART, 0, o_name);
+        exe_write_diary(player_ptr, DIARY_ART, 0, item_name.data());
     }
 
     return old_known;
@@ -129,14 +124,13 @@ bool ident_spell(PlayerType *player_ptr, bool only_equip)
 
     bool old_known = identify_item(player_ptr, o_ptr);
 
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
     if (item >= INVEN_MAIN_HAND) {
-        msg_format(_("%s^: %s(%c)。", "%s^: %s (%c)."), describe_use(player_ptr, item), o_name, index_to_label(item));
+        msg_format(_("%^s: %s(%c)。", "%^s: %s (%c)."), describe_use(player_ptr, item), item_name.data(), index_to_label(item));
     } else if (item >= 0) {
-        msg_format(_("ザック中: %s(%c)。", "In your pack: %s (%c)."), o_name, index_to_label(item));
+        msg_format(_("ザック中: %s(%c)。", "In your pack: %s (%c)."), item_name.data(), index_to_label(item));
     } else {
-        msg_format(_("床上: %s。", "On the ground: %s."), o_name);
+        msg_format(_("床上: %s。", "On the ground: %s."), item_name.data());
     }
 
     autopick_alter_item(player_ptr, item, (bool)(destroy_identify && !old_known));
@@ -187,14 +181,13 @@ bool identify_fully(PlayerType *player_ptr, bool only_equip)
     handle_stuff(player_ptr);
     player_ptr->update |= (PU_COMBINE | PU_REORDER);
 
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
     if (item >= INVEN_MAIN_HAND) {
-        msg_format(_("%s^: %s(%c)。", "%s^: %s (%c)."), describe_use(player_ptr, item), o_name, index_to_label(item));
+        msg_format(_("%^s: %s(%c)。", "%^s: %s (%c)."), describe_use(player_ptr, item), item_name.data(), index_to_label(item));
     } else if (item >= 0) {
-        msg_format(_("ザック中: %s(%c)。", "In your pack: %s (%c)."), o_name, index_to_label(item));
+        msg_format(_("ザック中: %s(%c)。", "In your pack: %s (%c)."), item_name.data(), index_to_label(item));
     } else {
-        msg_format(_("床上: %s。", "On the ground: %s."), o_name);
+        msg_format(_("床上: %s。", "On the ground: %s."), item_name.data());
     }
 
     (void)screen_object(player_ptr, o_ptr, 0L);

--- a/src/spell-realm/spells-craft.cpp
+++ b/src/spell-realm/spells-craft.cpp
@@ -278,17 +278,15 @@ bool pulish_shield(PlayerType *player_ptr)
         return false;
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
-
+    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
     auto is_pulish_successful = (o_ptr->bi_id > 0) && !o_ptr->is_fixed_or_random_artifact() && !o_ptr->is_ego();
     is_pulish_successful &= !o_ptr->is_cursed();
     is_pulish_successful &= (o_ptr->bi_key.sval() != SV_MIRROR_SHIELD);
     if (is_pulish_successful) {
 #ifdef JP
-        msg_format("%sは輝いた！", o_name);
+        msg_format("%sは輝いた！", item_name.data());
 #else
-        msg_format("%s %s shine%s!", ((item >= 0) ? "Your" : "The"), o_name, ((o_ptr->number > 1) ? "" : "s"));
+        msg_format("%s %s shine%s!", ((item >= 0) ? "Your" : "The"), item_name.data(), ((o_ptr->number > 1) ? "" : "s"));
 #endif
         o_ptr->ego_idx = EgoType::REFLECTION;
         enchant_equipment(player_ptr, o_ptr, randint0(3) + 4, ENCH_TOAC);

--- a/src/spell-realm/spells-nature.cpp
+++ b/src/spell-realm/spells-nature.cpp
@@ -28,22 +28,21 @@ bool rustproof(PlayerType *player_ptr)
         return false;
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
+    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
     o_ptr->art_flags.set(TR_IGNORE_ACID);
     if ((o_ptr->to_a < 0) && !o_ptr->is_cursed()) {
 #ifdef JP
-        msg_format("%sは新品同様になった！", o_name);
+        msg_format("%sは新品同様になった！", item_name.data());
 #else
-        msg_format("%s %s look%s as good as new!", ((item >= 0) ? "Your" : "The"), o_name, ((o_ptr->number > 1) ? "" : "s"));
+        msg_format("%s %s look%s as good as new!", ((item >= 0) ? "Your" : "The"), item_name.data(), ((o_ptr->number > 1) ? "" : "s"));
 #endif
         o_ptr->to_a = 0;
     }
 
 #ifdef JP
-    msg_format("%sは腐食しなくなった。", o_name);
+    msg_format("%sは腐食しなくなった。", item_name.data());
 #else
-    msg_format("%s %s %s now protected against corrosion.", ((item >= 0) ? "Your" : "The"), o_name, ((o_ptr->number > 1) ? "are" : "is"));
+    msg_format("%s %s %s now protected against corrosion.", ((item >= 0) ? "Your" : "The"), item_name.data(), ((o_ptr->number > 1) ? "are" : "is"));
 #endif
     calc_android_exp(player_ptr);
     return true;

--- a/src/spell-realm/spells-sorcery.cpp
+++ b/src/spell-realm/spells-sorcery.cpp
@@ -47,14 +47,13 @@ bool alchemy(PlayerType *player_ptr)
 
     ITEM_NUMBER old_number = o_ptr->number;
     o_ptr->number = amt;
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
     o_ptr->number = old_number;
 
     if (!force) {
         if (confirm_destroy || (o_ptr->get_price() > 0)) {
             char out_val[MAX_NLEN + 40];
-            strnfmt(out_val, sizeof(out_val), _("本当に%sを金に変えますか？", "Really turn %s to gold? "), o_name);
+            strnfmt(out_val, sizeof(out_val), _("本当に%sを金に変えますか？", "Really turn %s to gold? "), item_name.data());
             if (!get_check(out_val)) {
                 return false;
             }
@@ -62,13 +61,13 @@ bool alchemy(PlayerType *player_ptr)
     }
 
     if (!can_player_destroy_object(player_ptr, o_ptr)) {
-        msg_format(_("%sを金に変えることに失敗した。", "You fail to turn %s to gold!"), o_name);
+        msg_format(_("%sを金に変えることに失敗した。", "You fail to turn %s to gold!"), item_name.data());
         return false;
     }
 
     PRICE price = object_value_real(o_ptr);
     if (price <= 0) {
-        msg_format(_("%sをニセの金に変えた。", "You turn %s to fool's gold."), o_name);
+        msg_format(_("%sをニセの金に変えた。", "You turn %s to fool's gold."), item_name.data());
         vary_item(player_ptr, item, -amt);
         return true;
     }
@@ -82,8 +81,8 @@ bool alchemy(PlayerType *player_ptr)
     if (price > 30000) {
         price = 30000;
     }
-    msg_format(_("%sを＄%d の金に変えた。", "You turn %s to %d coins worth of gold."), o_name, price);
 
+    msg_format(_("%sを＄%d の金に変えた。", "You turn %s to %d coins worth of gold."), item_name.data(), price);
     player_ptr->au += price;
     player_ptr->redraw |= PR_GOLD;
     player_ptr->window_flags |= PW_PLAYER;

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -223,19 +223,18 @@ bool curse_armor(PlayerType *player_ptr)
         return false;
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, OD_OMIT_PREFIX);
+    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_OMIT_PREFIX);
 
     if (o_ptr->is_fixed_or_random_artifact() && one_in_(2)) {
 #ifdef JP
-        msg_format("%sが%sを包み込もうとしたが、%sはそれを跳ね返した！", "恐怖の暗黒オーラ", "防具", o_name);
+        msg_format("%sが%sを包み込もうとしたが、%sはそれを跳ね返した！", "恐怖の暗黒オーラ", "防具", item_name.data());
 #else
-        msg_format("A %s tries to %s, but your %s resists the effects!", "terrible black aura", "surround your armor", o_name);
+        msg_format("A %s tries to %s, but your %s resists the effects!", "terrible black aura", "surround your armor", item_name.data());
 #endif
         return true;
     }
 
-    msg_format(_("恐怖の暗黒オーラがあなたの%sを包み込んだ！", "A terrible black aura blasts your %s!"), o_name);
+    msg_format(_("恐怖の暗黒オーラがあなたの%sを包み込んだ！", "A terrible black aura blasts your %s!"), item_name.data());
     chg_virtue(player_ptr, V_ENCHANT, -5);
     o_ptr->fixed_artifact_idx = FixedArtifactId::NONE;
     o_ptr->ego_idx = EgoType::BLASTED;
@@ -268,20 +267,18 @@ bool curse_weapon_object(PlayerType *player_ptr, bool force, ItemEntity *o_ptr)
         return false;
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, OD_OMIT_PREFIX);
-
+    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_OMIT_PREFIX);
     if (o_ptr->is_fixed_or_random_artifact() && one_in_(2) && !force) {
 #ifdef JP
-        msg_format("%sが%sを包み込もうとしたが、%sはそれを跳ね返した！", "恐怖の暗黒オーラ", "武器", o_name);
+        msg_format("%sが%sを包み込もうとしたが、%sはそれを跳ね返した！", "恐怖の暗黒オーラ", "武器", item_name.data());
 #else
-        msg_format("A %s tries to %s, but your %s resists the effects!", "terrible black aura", "surround your weapon", o_name);
+        msg_format("A %s tries to %s, but your %s resists the effects!", "terrible black aura", "surround your weapon", item_name.data());
 #endif
         return true;
     }
 
     if (!force) {
-        msg_format(_("恐怖の暗黒オーラがあなたの%sを包み込んだ！", "A terrible black aura blasts your %s!"), o_name);
+        msg_format(_("恐怖の暗黒オーラがあなたの%sを包み込んだ！", "A terrible black aura blasts your %s!"), item_name.data());
     }
 
     chg_virtue(player_ptr, V_ENCHANT, -5);
@@ -472,12 +469,11 @@ bool enchant_spell(PlayerType *player_ptr, HIT_PROB num_hit, int num_dam, ARMOUR
         return false;
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
 #ifdef JP
-    msg_format("%s は明るく輝いた！", o_name);
+    msg_format("%s は明るく輝いた！", item_name.data());
 #else
-    msg_format("%s %s glow%s brightly!", ((item >= 0) ? "Your" : "The"), o_name, ((o_ptr->number > 1) ? "" : "s"));
+    msg_format("%s %s glow%s brightly!", ((item >= 0) ? "Your" : "The"), item_name.data(), ((o_ptr->number > 1) ? "" : "s"));
 #endif
 
     auto is_enchant_successful = false;
@@ -541,9 +537,7 @@ void brand_weapon(PlayerType *player_ptr, int brand_type)
         return;
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
-
+    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     concptr act = nullptr;
     switch (brand_type) {
     case 17:
@@ -632,7 +626,7 @@ void brand_weapon(PlayerType *player_ptr, int brand_type)
         break;
     }
 
-    msg_format(_("あなたの%s%s", "Your %s %s"), o_name, act);
+    msg_format(_("あなたの%s%s", "Your %s %s"), item_name.data(), act);
     enchant_equipment(player_ptr, o_ptr, randint0(3) + 4, ENCH_TOHIT | ENCH_TODAM);
     o_ptr->discount = 99;
     chg_virtue(player_ptr, V_ENCHANT, 2);

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -583,9 +583,8 @@ bool cosmic_cast_off(PlayerType *player_ptr, ItemEntity **o_ptr_ptr)
     OBJECT_IDX old_o_idx = drop_near(player_ptr, &forge, 0, player_ptr->y, player_ptr->x);
     *o_ptr_ptr = &player_ptr->current_floor_ptr->o_list[old_o_idx];
 
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, &forge, OD_NAME_ONLY);
-    msg_format(_("%sを脱ぎ捨てた。", "You cast off %s."), o_name);
+    const auto item_name = describe_flavor(player_ptr, &forge, OD_NAME_ONLY);
+    msg_format(_("%sを脱ぎ捨てた。", "You cast off %s."), item_name.data());
     sound(SOUND_TAKE_OFF);
 
     /* Get effects */

--- a/src/store/cmd-store.cpp
+++ b/src/store/cmd-store.cpp
@@ -174,12 +174,11 @@ void do_cmd_store(PlayerType *player_ptr)
                 int item_pos;
                 ItemEntity forge;
                 ItemEntity *q_ptr;
-                GAME_TEXT o_name[MAX_NLEN];
                 msg_print(_("ザックからアイテムがあふれてしまった！", "Your pack overflows!"));
                 q_ptr = &forge;
                 q_ptr->copy_from(o_ptr);
-                describe_flavor(player_ptr, o_name, q_ptr, 0);
-                msg_format(_("%sが落ちた。(%c)", "You drop %s (%c)."), o_name, index_to_label(item));
+                const auto item_name = describe_flavor(player_ptr, q_ptr, 0);
+                msg_format(_("%sが落ちた。(%c)", "You drop %s (%c)."), item_name.data(), index_to_label(item));
                 vary_item(player_ptr, item, -255);
                 handle_stuff(player_ptr);
 

--- a/src/store/museum.cpp
+++ b/src/store/museum.cpp
@@ -31,17 +31,14 @@ void museum_remove_object(PlayerType *player_ptr)
     }
 
     item = item + store_top;
-    ItemEntity *o_ptr;
-    o_ptr = &st_ptr->stock[item];
-
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, 0);
+    auto *o_ptr = &st_ptr->stock[item];
+    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
     msg_print(_("展示をやめさせたアイテムは二度と見ることはできません！", "Once removed from the Museum, an item will be gone forever!"));
-    if (!get_check(format(_("本当に%sの展示をやめさせますか？", "Really order to remove %s from the Museum? "), o_name))) {
+    if (!get_check(format(_("本当に%sの展示をやめさせますか？", "Really order to remove %s from the Museum? "), item_name.data()))) {
         return;
     }
 
-    msg_format(_("%sの展示をやめさせた。", "You ordered to remove %s."), o_name);
+    msg_format(_("%sの展示をやめさせた。", "You ordered to remove %s."), item_name.data());
     store_item_increase(item, -o_ptr->number);
     store_item_optimize(item);
     (void)combine_and_reorder_home(player_ptr, StoreSaleType::MUSEUM);

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -236,9 +236,8 @@ void store_examine(PlayerType *player_ptr, StoreSaleType store_num)
         return;
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, 0);
-    msg_format(_("%sを調べている...", "Examining %s..."), o_name);
+    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    msg_format(_("%sを調べている...", "Examining %s..."), item_name.data());
     if (!screen_object(player_ptr, o_ptr, SCROBJ_FORCE_DETAIL)) {
         msg_print(_("特に変わったところはないようだ。", "You see nothing special."));
     }

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -247,14 +247,12 @@ static void describe_monster_person(eg_type *eg_ptr)
 static uint16_t describe_monster_item(PlayerType *player_ptr, eg_type *eg_ptr)
 {
     for (const auto this_o_idx : eg_ptr->m_ptr->hold_o_idx_list) {
-        GAME_TEXT o_name[MAX_NLEN];
-        ItemEntity *o_ptr;
-        o_ptr = &player_ptr->current_floor_ptr->o_list[this_o_idx];
-        describe_flavor(player_ptr, o_name, o_ptr, 0);
+        auto *o_ptr = &player_ptr->current_floor_ptr->o_list[this_o_idx];
+        const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
 #ifdef JP
-        strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s[%s]", eg_ptr->s1, o_name, eg_ptr->s2, eg_ptr->s3, eg_ptr->info);
+        strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s[%s]", eg_ptr->s1, item_name.data(), eg_ptr->s2, eg_ptr->s3, eg_ptr->info);
 #else
-        strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s [%s]", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, o_name, eg_ptr->info);
+        strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s [%s]", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, item_name.data(), eg_ptr->info);
 #endif
         prt(eg_ptr->out_val, 0, 0);
         move_cursor_relative(eg_ptr->y, eg_ptr->x);
@@ -318,14 +316,12 @@ static int16_t describe_footing(PlayerType *player_ptr, eg_type *eg_ptr)
         return CONTINUOUS_DESCRIPTION;
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
-    ItemEntity *o_ptr;
-    o_ptr = &player_ptr->current_floor_ptr->o_list[eg_ptr->floor_list[0]];
-    describe_flavor(player_ptr, o_name, o_ptr, 0);
+    auto *o_ptr = &player_ptr->current_floor_ptr->o_list[eg_ptr->floor_list[0]];
+    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
 #ifdef JP
-    strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s[%s]", eg_ptr->s1, o_name, eg_ptr->s2, eg_ptr->s3, eg_ptr->info);
+    strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s[%s]", eg_ptr->s1, item_name.data(), eg_ptr->s2, eg_ptr->s3, eg_ptr->info);
 #else
-    strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s [%s]", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, o_name, eg_ptr->info);
+    strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s [%s]", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, item_name.data(), eg_ptr->info);
 #endif
     prt(eg_ptr->out_val, 0, 0);
     move_cursor_relative(eg_ptr->y, eg_ptr->x);
@@ -412,13 +408,12 @@ static int16_t describe_footing_sight(PlayerType *player_ptr, eg_type *eg_ptr, I
         return CONTINUOUS_DESCRIPTION;
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
     eg_ptr->boring = false;
-    describe_flavor(player_ptr, o_name, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
 #ifdef JP
-    strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s[%s]", eg_ptr->s1, o_name, eg_ptr->s2, eg_ptr->s3, eg_ptr->info);
+    strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s[%s]", eg_ptr->s1, item_name.data(), eg_ptr->s2, eg_ptr->s3, eg_ptr->info);
 #else
-    strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s [%s]", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, o_name, eg_ptr->info);
+    strnfmt(eg_ptr->out_val, sizeof(eg_ptr->out_val), "%s%s%s%s [%s]", eg_ptr->s1, eg_ptr->s2, eg_ptr->s3, item_name.data(), eg_ptr->info);
 #endif
     prt(eg_ptr->out_val, 0, 0);
     move_cursor_relative(eg_ptr->y, eg_ptr->x);

--- a/src/view/display-inventory.cpp
+++ b/src/view/display-inventory.cpp
@@ -31,11 +31,10 @@ COMMAND_CODE show_inventory(PlayerType *player_ptr, int target_item, BIT_FLAGS m
     COMMAND_CODE i;
     int k, l, z = 0;
     ItemEntity *o_ptr;
-    GAME_TEXT o_name[MAX_NLEN];
     char tmp_val[80];
     COMMAND_CODE out_index[23];
     TERM_COLOR out_color[23];
-    char out_desc[23][MAX_NLEN];
+    std::array<std::string, 23> out_desc{};
     COMMAND_CODE target_item_label = 0;
     char inven_label[52 + 1];
 
@@ -59,15 +58,14 @@ COMMAND_CODE show_inventory(PlayerType *player_ptr, int target_item, BIT_FLAGS m
             continue;
         }
 
-        describe_flavor(player_ptr, o_name, o_ptr, 0);
         out_index[k] = i;
         out_color[k] = tval_to_attr[enum2i(o_ptr->bi_key.tval()) % 128];
         if (o_ptr->timeout) {
             out_color[k] = TERM_L_DARK;
         }
 
-        (void)strcpy(out_desc[k], o_name);
-        l = strlen(out_desc[k]) + 5;
+        out_desc[k] = describe_flavor(player_ptr, o_ptr, 0);
+        l = out_desc[k].length() + 5;
         if (show_weights) {
             l += 9;
         }
@@ -141,10 +139,9 @@ COMMAND_CODE show_inventory(PlayerType *player_ptr, int target_item, BIT_FLAGS m
  */
 void display_inventory(PlayerType *player_ptr, const ItemTester &item_tester)
 {
-    int i, n, z = 0;
+    int i, z = 0;
     TERM_COLOR attr = TERM_WHITE;
     char tmp_val[80];
-    GAME_TEXT o_name[MAX_NLEN];
     TERM_LEN wid, hgt;
 
     if (!player_ptr || !player_ptr->inventory_list) {
@@ -177,8 +174,7 @@ void display_inventory(PlayerType *player_ptr, const ItemTester &item_tester)
         int cur_col = 3;
         term_erase(cur_col, i, 255);
         term_putstr(0, i, cur_col, TERM_WHITE, tmp_val);
-        describe_flavor(player_ptr, o_name, o_ptr, 0);
-        n = strlen(o_name);
+        const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
         attr = tval_to_attr[enum2i(o_ptr->bi_key.tval()) % 128];
         if (o_ptr->timeout) {
             attr = TERM_L_DARK;
@@ -195,7 +191,7 @@ void display_inventory(PlayerType *player_ptr, const ItemTester &item_tester)
             cur_col += 2;
         }
 
-        term_putstr(cur_col, i, n, attr, o_name);
+        term_putstr(cur_col, i, item_name.length(), attr, item_name);
 
         if (show_weights) {
             int wgt = o_ptr->weight * o_ptr->number;

--- a/src/view/display-store.cpp
+++ b/src/view/display-store.cpp
@@ -64,15 +64,14 @@ void display_entry(PlayerType *player_ptr, int pos, StoreSaleType store_num)
     /* Describe an item in the home */
     int maxwid = 75;
     if ((store_num == StoreSaleType::HOME) || (store_num == StoreSaleType::MUSEUM)) {
-        maxwid = 75;
         if (show_weights) {
             maxwid -= 10;
         }
 
-        GAME_TEXT o_name[MAX_NLEN];
-        describe_flavor(player_ptr, o_name, o_ptr, 0);
-        o_name[maxwid] = '\0';
-        c_put_str(tval_to_attr[enum2i(o_ptr->bi_key.tval())], o_name, i + 6, cur_col);
+        // 元々マルチバイト文字のことが考慮されていない.
+        const auto item_name = describe_flavor(player_ptr, o_ptr, 0).substr(0, maxwid);
+        c_put_str(tval_to_attr[enum2i(o_ptr->bi_key.tval())], item_name.data(), i + 6, cur_col);
+
         if (show_weights) {
             WEIGHT wgt = o_ptr->weight;
             put_str(format(_("%3d.%1d kg", "%3d.%d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10)), i + 6, _(67, 68));
@@ -86,10 +85,9 @@ void display_entry(PlayerType *player_ptr, int pos, StoreSaleType store_num)
         maxwid -= 7;
     }
 
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, 0);
-    o_name[maxwid] = '\0';
-    c_put_str(tval_to_attr[enum2i(o_ptr->bi_key.tval())], o_name, i + 6, cur_col);
+    // 元々マルチバイト文字のことが考慮されていない.
+    const auto item_name = describe_flavor(player_ptr, o_ptr, 0).substr(0, maxwid);
+    c_put_str(tval_to_attr[enum2i(o_ptr->bi_key.tval())], item_name.data(), i + 6, cur_col);
 
     if (show_weights) {
         int wgt = o_ptr->weight;
@@ -97,7 +95,6 @@ void display_entry(PlayerType *player_ptr, int pos, StoreSaleType store_num)
     }
 
     const auto price = price_item(player_ptr, o_ptr, ot_ptr->inflate, false, store_num);
-
     put_str(format("%9ld  ", (long)price), i + 6, 68);
 }
 

--- a/src/view/object-describer.cpp
+++ b/src/view/object-describer.cpp
@@ -47,16 +47,15 @@ void inven_item_charges(const ItemEntity &item)
 void inven_item_describe(PlayerType *player_ptr, short item)
 {
     auto *o_ptr = &player_ptr->inventory_list[item];
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
 #ifdef JP
     if (o_ptr->number <= 0) {
-        msg_format("もう%sを持っていない。", o_name);
+        msg_format("もう%sを持っていない。", item_name.data());
     } else {
-        msg_format("まだ %sを持っている。", o_name);
+        msg_format("まだ %sを持っている。", item_name.data());
     }
 #else
-    msg_format("You have %s.", o_name);
+    msg_format("You have %s.", item_name.data());
 #endif
 }
 
@@ -77,10 +76,8 @@ void display_koff(PlayerType *player_ptr)
 
     ItemEntity item;
     item.prep(player_ptr->tracking_bi_id);
-    GAME_TEXT o_name[MAX_NLEN];
-    describe_flavor(player_ptr, o_name, &item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
-
-    term_putstr(0, 0, -1, TERM_WHITE, o_name);
+    const auto item_name = describe_flavor(player_ptr, &item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
+    term_putstr(0, 0, -1, TERM_WHITE, item_name);
     const auto sval = item.bi_key.sval().value();
     const short use_realm = tval2realm(item.bi_key.tval());
 

--- a/src/window/main-window-equipments.cpp
+++ b/src/window/main-window-equipments.cpp
@@ -55,8 +55,7 @@ COMMAND_CODE show_equipment(PlayerType *player_ptr, int target_item, BIT_FLAGS m
             continue;
         }
 
-        GAME_TEXT item_name[MAX_NLEN]{};
-        describe_flavor(player_ptr, item_name, o_ptr, 0);
+        const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
         if (is_two_handed) {
             out_desc[k] = _("(武器を両手持ち)", "(wielding with two-hands)");
             out_color[k] = TERM_WHITE;

--- a/src/window/main-window-util.cpp
+++ b/src/window/main-window-util.cpp
@@ -129,15 +129,13 @@ void print_map(PlayerType *player_ptr)
  */
 static void display_shortened_item_name(PlayerType *player_ptr, ItemEntity *o_ptr, int y)
 {
-    char buf[MAX_NLEN];
-    describe_flavor(player_ptr, buf, o_ptr, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NAME_ONLY));
+    auto item_name = describe_flavor(player_ptr, o_ptr, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NAME_ONLY));
     auto attr = tval_to_attr[enum2i(o_ptr->bi_key.tval()) % 128];
     if (player_ptr->effects()->hallucination()->is_hallucinated()) {
         attr = TERM_WHITE;
-        strcpy(buf, _("何か奇妙な物", "something strange"));
+        item_name = _("何か奇妙な物", "something strange");
     }
 
-    std::string item_name(buf);
     for (const auto &simplified_str : simplify_list) {
         const auto &replacing = simplified_str.first;
 #ifndef JP

--- a/src/wizard/artifact-analyzer.cpp
+++ b/src/wizard/artifact-analyzer.cpp
@@ -53,9 +53,9 @@ static concptr *spoiler_flag_aux(const TrFlags &art_flags, const flag_desc *flag
  * @param o_ptr 記述を得たいオブジェクトの参照ポインタ
  * @param desc_ptr 記述内容を返すための文字列参照ポインタ
  */
-static void analyze_general(PlayerType *player_ptr, ItemEntity *o_ptr, char *desc_ptr)
+static std::string analyze_general(PlayerType *player_ptr, ItemEntity *o_ptr)
 {
-    describe_flavor(player_ptr, desc_ptr, o_ptr, OD_NAME_AND_ENCHANT | OD_STORE | OD_DEBUG);
+    return describe_flavor(player_ptr, o_ptr, OD_NAME_AND_ENCHANT | OD_STORE | OD_DEBUG);
 }
 
 /*!
@@ -311,7 +311,7 @@ static void analyze_misc(ItemEntity *o_ptr, char *misc_desc, size_t misc_desc_sz
  */
 void object_analyze(PlayerType *player_ptr, ItemEntity *o_ptr, obj_desc_list *desc_ptr)
 {
-    analyze_general(player_ptr, o_ptr, desc_ptr->description);
+    angband_strcpy(desc_ptr->description, analyze_general(player_ptr, o_ptr).data(), MAX_NLEN);
     analyze_pval(o_ptr, &desc_ptr->pval_info);
     analyze_brand(o_ptr, desc_ptr->brands);
     analyze_slay(o_ptr, desc_ptr->slays);
@@ -334,7 +334,7 @@ void object_analyze(PlayerType *player_ptr, ItemEntity *o_ptr, obj_desc_list *de
  */
 void random_artifact_analyze(PlayerType *player_ptr, ItemEntity *o_ptr, obj_desc_list *desc_ptr)
 {
-    analyze_general(player_ptr, o_ptr, desc_ptr->description);
+    angband_strcpy(desc_ptr->description, analyze_general(player_ptr, o_ptr).data(), MAX_NLEN);
     analyze_pval(o_ptr, &desc_ptr->pval_info);
     analyze_brand(o_ptr, desc_ptr->brands);
     analyze_slay(o_ptr, desc_ptr->slays);

--- a/src/wizard/items-spoiler.cpp
+++ b/src/wizard/items-spoiler.cpp
@@ -43,7 +43,8 @@ static void describe_baseitem_info(PlayerType *player_ptr,
         return;
     }
 
-    describe_flavor(player_ptr, name, q_ptr, OD_NAME_ONLY | OD_STORE);
+    auto item_name = describe_flavor(player_ptr, q_ptr, OD_NAME_ONLY | OD_STORE);
+    name = item_name.data();
     switch (q_ptr->bi_key.tval()) {
     case ItemKindType::SHOT:
     case ItemKindType::BOLT:

--- a/src/wizard/spoiler-util.h
+++ b/src/wizard/spoiler-util.h
@@ -26,7 +26,7 @@ struct pval_info_type {
 };
 
 struct obj_desc_list {
-    char description[MAX_NLEN]; /* "The Longsword Dragonsmiter (6d4) (+20, +25)" */
+    char description[MAX_NLEN]{}; /* "The Longsword Dragonsmiter (6d4) (+20, +25)" */
     pval_info_type pval_info; /* Description of what is affected by an object's pval */
     concptr slays[N_ELEMENTS(slay_flags_desc) + 1]; /* A list of an object's slaying preferences */
     concptr brands[N_ELEMENTS(brand_flags_desc) + 1]; /* A list if an object's elemental brands */

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -196,9 +196,9 @@ void wiz_restore_aware_flag_of_fixed_arfifact(FixedArtifactId reset_artifact_idx
  */
 void wiz_modify_item_activation(PlayerType *player_ptr)
 {
-    auto q = _("どのアイテムの発動を変更しますか？ ", "Which object? ");
-    auto s = _("発動を変更するアイテムがない。", "Nothing to do with.");
-    OBJECT_IDX item;
+    constexpr auto q = _("どのアイテムの発動を変更しますか？ ", "Which object? ");
+    constexpr auto s = _("発動を変更するアイテムがない。", "Nothing to do with.");
+    short item;
     auto *o_ptr = choose_object(player_ptr, &item, q, s, USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT);
     if (!o_ptr) {
         return;
@@ -673,11 +673,10 @@ static void wiz_quantity_item(ItemEntity *o_ptr)
  */
 void wiz_modify_item(PlayerType *player_ptr)
 {
-    concptr q = "Play with which object? ";
-    concptr s = "You have nothing to play with.";
-    OBJECT_IDX item;
-    ItemEntity *o_ptr;
-    o_ptr = choose_object(player_ptr, &item, q, s, USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT);
+    constexpr auto q = "Play with which object? ";
+    constexpr auto s = "You have nothing to play with.";
+    short item;
+    auto *o_ptr = choose_object(player_ptr, &item, q, s, USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT);
     if (!o_ptr) {
         return;
     }

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -339,9 +339,8 @@ static void wiz_display_item(PlayerType *player_ptr, ItemEntity *o_ptr)
     }
 
     prt_alloc(o_ptr->bi_key, 1, 0);
-    char buf[256];
-    describe_flavor(player_ptr, buf, o_ptr, OD_STORE);
-    prt(buf, 2, j);
+    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_STORE);
+    prt(item_name, 2, j);
 
     auto line = 4;
     const auto &bi_key = o_ptr->bi_key;
@@ -791,8 +790,6 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
     char *str = buf;
     ItemEntity forge;
     auto *o_ptr = &forge;
-    char o_name[MAX_NLEN];
-
     bool wish_art = false;
     bool wish_randart = false;
     bool wish_ego = false;
@@ -879,7 +876,6 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
     std::vector<short> k_ids;
     std::vector<EgoType> e_ids;
     if (exam_base) {
-        int len;
         int max_len = 0;
         for (const auto &baseitem : baseitems_info) {
             if (baseitem.idx == 0 || baseitem.name.empty()) {
@@ -887,17 +883,18 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
             }
 
             o_ptr->prep(baseitem.idx);
-            describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
-#ifndef JP
-            str_tolower(o_name);
+#ifdef JP
+            const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
+#else
+            auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
+            str_tolower(item_name.data());
 #endif
             if (cheat_xtra) {
-                msg_format("Matching object No.%d %s", baseitem.idx, o_name);
+                msg_format("Matching object No.%d %s", baseitem.idx, item_name.data());
             }
 
-            len = strlen(o_name);
-
-            if (_(!strrncmp(str, o_name, len), !strncmp(str, o_name, len))) {
+            const int len = item_name.length();
+            if (std::string(str).find(item_name) != std::string::npos) {
                 if (len > max_len) {
                     k_ids.push_back(baseitem.idx);
                     max_len = len;
@@ -914,15 +911,16 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
                     continue;
                 }
 
-                strcpy(o_name, e_ref.name.data());
-#ifndef JP
-                str_tolower(o_name);
+                std::string item_name(e_ref.name);
+#ifdef JP
+#else
+                str_tolower(item_name.data());
 #endif
                 if (cheat_xtra) {
-                    msg_format("matching ego no.%d %s...", enum2i(e_ref.idx), o_name);
+                    msg_format("matching ego no.%d %s...", enum2i(e_ref.idx), item_name.data());
                 }
 
-                if (_(!strncmp(str, o_name, strlen(o_name)), !strrncmp(str, o_name, strlen(o_name)))) {
+                if (std::string(str).find(item_name) != std::string::npos) {
                     if (is_slot_able_to_be_ego(player_ptr, o_ptr) != e_ref.slot) {
                         continue;
                     }
@@ -954,9 +952,11 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
             o_ptr->prep(bi_id);
             o_ptr->fixed_artifact_idx = a_idx;
 
-            describe_flavor(player_ptr, o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
-#ifndef JP
-            str_tolower(o_name);
+#ifdef JP
+            const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
+#else
+            auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
+            str_tolower(item_name.data());
 #endif
             a_str = a_desc;
             strcpy(a_desc, a_ref.name.data());
@@ -992,12 +992,12 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
 
             str_tolower(a_str);
 #endif
-
+            const auto match_name = _(item_name.data() + 2, item_name.data());
             if (cheat_xtra) {
-                msg_format("Matching artifact No.%d %s(%s)", enum2i(a_idx), a_desc, _(&o_name[2], o_name));
+                msg_format("Matching artifact No.%d %s(%s)", enum2i(a_idx), a_desc, match_name);
             }
 
-            std::vector<const char *> l = { a_str, a_ref.name.data(), _(&o_name[2], o_name) };
+            std::vector<const char *> l = { a_str, a_ref.name.data(), match_name };
             for (size_t c = 0; c < l.size(); c++) {
                 if (!strcmp(str, l.at(c))) {
                     len = strlen(l.at(c));

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -271,9 +271,7 @@ static std::string wiz_make_named_artifact_desc(PlayerType *player_ptr, FixedArt
     item.prep(lookup_baseitem_id(a_ref.bi_key));
     item.fixed_artifact_idx = a_idx;
     object_known(&item);
-    char buf[MAX_NLEN];
-    describe_flavor(player_ptr, buf, &item, OD_NAME_ONLY);
-    return buf;
+    return describe_flavor(player_ptr, &item, OD_NAME_ONLY);
 }
 
 /**

--- a/src/wizard/wizard-spoiler.cpp
+++ b/src/wizard/wizard-spoiler.cpp
@@ -196,13 +196,12 @@ static SpoilerOutputResultType spoil_player_spell(concptr fname)
 
         auto magic_ptr = &class_magics_info[c];
         concptr book_name = "なし";
-        char name_buffer[200];
         if (magic_ptr->spell_book != ItemKindType::NONE) {
             ItemEntity book;
             auto o_ptr = &book;
             o_ptr->prep(lookup_baseitem_id({ magic_ptr->spell_book, 0 }));
-            describe_flavor(&dummy_p, name_buffer, o_ptr, OD_NAME_ONLY);
-            book_name = name_buffer;
+            const auto item_name = describe_flavor(&dummy_p, o_ptr, OD_NAME_ONLY);
+            book_name = item_name.data();
             char *s = angband_strchr(book_name, '[');
             *s = '\0';
         }


### PR DESCRIPTION
掲題の通りです、ご確認下さい
(できれば引数のconst化もしたかったですが別件で対応します)

本件をもって、以下のような型の変数もごそっと減りました
今後はMAX\_NLEN の撲滅に向けて動き始められる見込みです
```GAME_TEXT name[MAX_NLEN];```