### PR TITLE
RedrawingFlagsUpdater クラスを作った

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -312,6 +312,7 @@
     <ClCompile Include="..\..\src\save\player-class-specific-data-writer.cpp" />
     <ClCompile Include="..\..\src\specific-object\stone-of-lore.cpp" />
     <ClCompile Include="..\..\src\spell-class\spells-mirror-master.cpp" />
+    <ClCompile Include="..\..\src\system\redrawing-flags-updater.cpp" />
     <ClCompile Include="..\..\src\system\floor-type-definition.cpp" />
     <ClCompile Include="..\..\src\system\grid-type-definition.cpp" />
     <ClCompile Include="..\..\src\grid\feature-action-flags.cpp" />
@@ -1394,6 +1395,7 @@
     <ClInclude Include="..\..\src\store\service-checker.h" />
     <ClInclude Include="..\..\src\system\alloc-entries.h" />
     <ClInclude Include="..\..\src\system\angband-exceptions.h" />
+    <ClInclude Include="..\..\src\system\redrawing-flags-updater.h" />
     <ClInclude Include="..\..\src\system\dungeon-data-definition.h" />
     <ClInclude Include="..\..\src\system\floor-type-definition.h" />
     <ClInclude Include="..\..\src\system\grid-type-definition.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2478,6 +2478,9 @@
     <ClCompile Include="..\..\src\system\monster-race-info.cpp">
       <Filter>system</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\system\redrawing-flags-updater.cpp">
+      <Filter>system</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5372,6 +5375,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\item-info\flavor-initializer.h">
       <Filter>item-info</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\redrawing-flags-updater.h">
+      <Filter>system</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -925,6 +925,7 @@ hengband_SOURCES = \
 	system/monster-entity.cpp system/monster-entity.h \
 	system/monster-race-info.cpp system/monster-race-info.h \
 	system/player-type-definition.cpp system/player-type-definition.h \
+	system/redrawing-flags-updater.cpp system/redrawing-flags-updater.h \
 	system/system-variables.cpp system/system-variables.h \
 	system/terrain-type-definition.cpp system/terrain-type-definition.h \
 	system/gamevalue.h \

--- a/src/action/activation-execution.cpp
+++ b/src/action/activation-execution.cpp
@@ -259,7 +259,7 @@ void exe_activate(PlayerType *player_ptr, INVENTORY_IDX item)
     sound(SOUND_ZAP);
     if (activation_index(ae_ptr->o_ptr) > RandomArtActType::NONE) {
         (void)activate_artifact(player_ptr, ae_ptr->o_ptr);
-        player_ptr->window_flags |= PW_INVEN | PW_EQUIP;
+        player_ptr->window_flags |= PW_INVENTORY | PW_EQUIPMENT;
         return;
     }
 

--- a/src/artifact/random-art-generator.cpp
+++ b/src/artifact/random-art-generator.cpp
@@ -421,7 +421,7 @@ static void generate_unnatural_random_artifact(
     msg_format_wizard(player_ptr, CHEAT_OBJECT,
         _("パワー %d で 価値 %d のランダムアーティファクト生成 バイアスは「%s」", "Random artifact generated - Power:%d Value:%d Bias:%s."), max_powers,
         total_flags, artifact_bias_name[o_ptr->artifact_bias]);
-    set_bits(player_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_FLOOR_ITEM_LIST | PW_FOUND_ITEM_LIST);
+    set_bits(player_ptr->window_flags, PW_INVENTORY | PW_EQUIPMENT | PW_FLOOR_ITEMS | PW_FOUND_ITEMS);
 }
 
 /*!

--- a/src/autopick/autopick-destroyer.cpp
+++ b/src/autopick/autopick-destroyer.cpp
@@ -157,5 +157,5 @@ void auto_destroy_item(PlayerType *player_ptr, ItemEntity *o_ptr, int autopick_i
 
     autopick_last_destroyed_object = *o_ptr;
     o_ptr->marked.set(OmType::AUTODESTROY);
-    player_ptr->update |= PU_AUTODESTROY;
+    player_ptr->update |= PU_AUTO_DESTRUCTION;
 }

--- a/src/autopick/autopick-util.cpp
+++ b/src/autopick/autopick-util.cpp
@@ -67,9 +67,9 @@ void auto_inscribe_item(PlayerType *player_ptr, ItemEntity *o_ptr, int idx)
         o_ptr->inscription = autopick_list[idx].insc;
     }
 
-    player_ptr->window_flags |= (PW_EQUIP | PW_INVEN);
+    player_ptr->window_flags |= (PW_EQUIPMENT | PW_INVENTORY);
     player_ptr->update |= (PU_BONUS);
-    player_ptr->update |= (PU_COMBINE);
+    player_ptr->update |= (PU_COMBINATION);
 }
 
 /*!

--- a/src/birth/birth-stat.cpp
+++ b/src/birth/birth-stat.cpp
@@ -188,5 +188,5 @@ void get_max_stats(PlayerType *player_ptr)
     }
 
     player_ptr->knowledge &= ~(KNOW_STAT);
-    player_ptr->redraw |= (PR_STATS);
+    player_ptr->redraw |= (PR_ABILITY_SCORE);
 }

--- a/src/birth/character-builder.cpp
+++ b/src/birth/character-builder.cpp
@@ -126,6 +126,6 @@ void player_birth(PlayerType *player_ptr)
     }
 
     if (!window_flag[2]) {
-        window_flag[2] |= PW_INVEN;
+        window_flag[2] |= PW_INVENTORY;
     }
 }

--- a/src/blue-magic/blue-magic-checker.cpp
+++ b/src/blue-magic/blue-magic-checker.cpp
@@ -62,7 +62,7 @@ void learn_spell(PlayerType *player_ptr, MonsterAbilityType monspell)
         gain_exp(player_ptr, monster_power.level * monster_power.smana);
         sound(SOUND_STUDY);
         bluemage_data->new_magic_learned = true;
-        player_ptr->redraw |= PR_STATE;
+        player_ptr->redraw |= PR_ACTION;
     }
 }
 

--- a/src/cmd-action/cmd-hissatsu.cpp
+++ b/src/cmd-action/cmd-hissatsu.cpp
@@ -359,7 +359,7 @@ void do_cmd_hissatsu(PlayerType *player_ptr)
     if (player_ptr->csp < 0) {
         player_ptr->csp = 0;
     }
-    player_ptr->redraw |= (PR_MANA);
+    player_ptr->redraw |= (PR_MP);
     player_ptr->window_flags |= (PW_PLAYER | PW_SPELL);
 }
 

--- a/src/cmd-action/cmd-mind.cpp
+++ b/src/cmd-action/cmd-mind.cpp
@@ -425,7 +425,7 @@ void do_cmd_mind(PlayerType *player_ptr)
 
     mind_turn_passing(player_ptr, cm_ptr);
     process_hard_concentration(player_ptr, cm_ptr);
-    player_ptr->redraw |= PR_MANA;
+    player_ptr->redraw |= PR_MP;
     player_ptr->window_flags |= PW_PLAYER;
     player_ptr->window_flags |= PW_SPELL;
 }

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -348,7 +348,7 @@ void do_cmd_walk(PlayerType *player_ptr, bool pickup)
 {
     if (command_arg) {
         command_rep = command_arg - 1;
-        player_ptr->redraw |= PR_STATE;
+        player_ptr->redraw |= PR_ACTION;
         command_arg = 0;
     }
 
@@ -426,7 +426,7 @@ void do_cmd_stay(PlayerType *player_ptr, bool pickup)
     uint32_t mpe_mode = MPE_STAYING | MPE_ENERGY_USE;
     if (command_arg) {
         command_rep = command_arg - 1;
-        player_ptr->redraw |= (PR_STATE);
+        player_ptr->redraw |= (PR_ACTION);
         command_arg = 0;
     }
 
@@ -493,7 +493,7 @@ void do_cmd_rest(PlayerType *player_ptr)
     player_ptr->resting = command_arg;
     player_ptr->action = ACTION_REST;
     player_ptr->update |= PU_BONUS;
-    player_ptr->redraw |= (PR_STATE);
+    player_ptr->redraw |= (PR_ACTION);
     handle_stuff(player_ptr);
     term_fresh();
 }

--- a/src/cmd-action/cmd-open-close.cpp
+++ b/src/cmd-action/cmd-open-close.cpp
@@ -122,7 +122,7 @@ void do_cmd_open(PlayerType *player_ptr)
 
     if (command_arg) {
         command_rep = command_arg - 1;
-        player_ptr->redraw |= PR_STATE;
+        player_ptr->redraw |= PR_ACTION;
         command_arg = 0;
     }
 
@@ -175,7 +175,7 @@ void do_cmd_close(PlayerType *player_ptr)
 
     if (command_arg) {
         command_rep = command_arg - 1;
-        player_ptr->redraw |= (PR_STATE);
+        player_ptr->redraw |= (PR_ACTION);
         command_arg = 0;
     }
 
@@ -231,7 +231,7 @@ void do_cmd_disarm(PlayerType *player_ptr)
 
     if (command_arg) {
         command_rep = command_arg - 1;
-        player_ptr->redraw |= (PR_STATE);
+        player_ptr->redraw |= (PR_ACTION);
         command_arg = 0;
     }
 
@@ -291,7 +291,7 @@ void do_cmd_bash(PlayerType *player_ptr)
 
     if (command_arg) {
         command_rep = command_arg - 1;
-        player_ptr->redraw |= (PR_STATE);
+        player_ptr->redraw |= (PR_ACTION);
         command_arg = 0;
     }
 

--- a/src/cmd-action/cmd-others.cpp
+++ b/src/cmd-action/cmd-others.cpp
@@ -48,7 +48,7 @@ void do_cmd_search(PlayerType *player_ptr)
 {
     if (command_arg) {
         command_rep = command_arg - 1;
-        player_ptr->redraw |= PR_STATE;
+        player_ptr->redraw |= PR_ACTION;
         command_arg = 0;
     }
 
@@ -114,7 +114,7 @@ void do_cmd_alter(PlayerType *player_ptr)
 
     if (command_arg) {
         command_rep = command_arg - 1;
-        player_ptr->redraw |= PR_STATE;
+        player_ptr->redraw |= PR_ACTION;
         command_arg = 0;
     }
 

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -161,7 +161,7 @@ void do_cmd_pet_dismiss(PlayerType *player_ptr)
 
                 player_ptr->riding = 0;
 
-                player_ptr->update |= (PU_MONSTERS);
+                player_ptr->update |= (PU_MONSTER_STATUSES);
                 player_ptr->redraw |= (PR_EXTRA | PR_UHEALTH);
             }
 

--- a/src/cmd-action/cmd-racial.cpp
+++ b/src/cmd-action/cmd-racial.cpp
@@ -503,6 +503,6 @@ void do_cmd_racial_power(PlayerType *player_ptr)
         return;
     }
 
-    set_bits(player_ptr->redraw, PR_HP | PR_MANA);
+    set_bits(player_ptr->redraw, PR_HP | PR_MP);
     set_bits(player_ptr->window_flags, PW_PLAYER | PW_SPELL);
 }

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -921,7 +921,7 @@ void do_cmd_study(PlayerType *player_ptr)
     update_creature(player_ptr);
 
     /* Redraw object recall */
-    player_ptr->window_flags |= (PW_OBJECT);
+    player_ptr->window_flags |= (PW_ITEM_KNOWLEDGTE);
 }
 
 /*!
@@ -1184,7 +1184,7 @@ bool do_cmd_cast(PlayerType *player_ptr)
             }
 
             gain_exp(player_ptr, e * s_ptr->slevel);
-            player_ptr->window_flags |= (PW_OBJECT);
+            player_ptr->window_flags |= (PW_ITEM_KNOWLEDGTE);
 
             switch (realm) {
             case REALM_LIFE:
@@ -1320,7 +1320,7 @@ bool do_cmd_cast(PlayerType *player_ptr)
     } else {
         over_exerted = true;
     }
-    player_ptr->redraw |= (PR_MANA);
+    player_ptr->redraw |= (PR_MP);
 
     /* Over-exert the player */
     if (over_exerted) {

--- a/src/cmd-action/cmd-tunnel.cpp
+++ b/src/cmd-action/cmd-tunnel.cpp
@@ -39,7 +39,7 @@ void do_cmd_tunnel(PlayerType *player_ptr)
 
     if (command_arg) {
         command_rep = command_arg - 1;
-        player_ptr->redraw |= PR_STATE;
+        player_ptr->redraw |= PR_ACTION;
         command_arg = 0;
     }
 

--- a/src/cmd-building/cmd-building.cpp
+++ b/src/cmd-building/cmd-building.cpp
@@ -408,7 +408,7 @@ void do_cmd_building(PlayerType *player_ptr)
     w_ptr->character_icky_depth--;
     term_clear();
 
-    player_ptr->update |= (PU_VIEW | PU_MONSTERS | PU_BONUS | PU_LITE | PU_MON_LITE);
+    player_ptr->update |= (PU_VIEW | PU_MONSTER_STATUSES | PU_BONUS | PU_LITE | PU_MONSTER_LITE);
     player_ptr->redraw |= (PR_BASIC | PR_EXTRA | PR_EQUIPPY | PR_MAP);
     player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
 }

--- a/src/cmd-io/cmd-floor.cpp
+++ b/src/cmd-io/cmd-floor.cpp
@@ -41,7 +41,7 @@ void do_cmd_target(PlayerType *player_ptr)
  */
 void do_cmd_look(PlayerType *player_ptr)
 {
-    set_bits(player_ptr->window_flags, PW_MONSTER_LIST | PW_FLOOR_ITEM_LIST);
+    set_bits(player_ptr->window_flags, PW_SIGHT_MONSTERS | PW_FLOOR_ITEMS);
     handle_stuff(player_ptr);
     if (target_set(player_ptr, TARGET_LOOK)) {
         msg_print(_("ターゲット決定。", "Target Selected."));
@@ -94,7 +94,7 @@ void do_cmd_locate(PlayerType *player_ptr)
     }
 
     verify_panel(player_ptr);
-    player_ptr->update |= PU_MONSTERS;
+    player_ptr->update |= PU_MONSTER_STATUSES;
     player_ptr->redraw |= PR_MAP;
     player_ptr->window_flags |= PW_OVERHEAD | PW_DUNGEON;
     handle_stuff(player_ptr);

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -169,7 +169,7 @@ static bool exe_eat_charge_of_magic_device(PlayerType *player_ptr, ItemEntity *o
     if (o_ptr->pval == 0) {
         msg_format(_("この%sにはもう魔力が残っていない。", "The %s has no charges left."), staff);
         o_ptr->ident |= IDENT_EMPTY;
-        player_ptr->window_flags |= PW_INVEN;
+        player_ptr->window_flags |= PW_INVENTORY;
         return true;
     }
 
@@ -203,7 +203,7 @@ static bool exe_eat_charge_of_magic_device(PlayerType *player_ptr, ItemEntity *o
         floor_item_charges(player_ptr->current_floor_ptr, 0 - inventory);
     }
 
-    player_ptr->window_flags |= PW_INVEN | PW_EQUIP;
+    player_ptr->window_flags |= PW_INVENTORY | PW_EQUIPMENT;
     return true;
 }
 
@@ -242,8 +242,8 @@ void exe_eat_food(PlayerType *player_ptr, INVENTORY_IDX item)
      * do not rearrange the inventory before the food item is destroyed in
      * the pack.
      */
-    BIT_FLAGS inventory_flags = (PU_COMBINE | PU_REORDER | (player_ptr->update & PU_AUTODESTROY));
-    player_ptr->update &= ~(PU_COMBINE | PU_REORDER | PU_AUTODESTROY);
+    BIT_FLAGS inventory_flags = (PU_COMBINATION | PU_REORDER | (player_ptr->update & PU_AUTO_DESTRUCTION));
+    player_ptr->update &= ~(PU_COMBINATION | PU_REORDER | PU_AUTO_DESTRUCTION);
 
     if (!(o_ptr->is_aware())) {
         chg_virtue(player_ptr, Virtue::KNOWLEDGE, -1);
@@ -263,7 +263,7 @@ void exe_eat_food(PlayerType *player_ptr, INVENTORY_IDX item)
         gain_exp(player_ptr, (lev + (player_ptr->lev >> 1)) / player_ptr->lev);
     }
 
-    player_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
+    player_ptr->window_flags |= (PW_INVENTORY | PW_EQUIPMENT | PW_PLAYER);
 
     /* Undeads drain recharge of magic device */
     if (exe_eat_charge_of_magic_device(player_ptr, o_ptr, item)) {

--- a/src/cmd-item/cmd-equipment.cpp
+++ b/src/cmd-item/cmd-equipment.cpp
@@ -345,9 +345,9 @@ void do_cmd_wield(PlayerType *player_ptr)
     }
 
     calc_android_exp(player_ptr);
-    player_ptr->update |= PU_BONUS | PU_TORCH | PU_MANA;
+    player_ptr->update |= PU_BONUS | PU_TORCH | PU_MP;
     player_ptr->redraw |= PR_EQUIPPY;
-    player_ptr->window_flags |= PW_INVEN | PW_EQUIP | PW_PLAYER;
+    player_ptr->window_flags |= PW_INVENTORY | PW_EQUIPMENT | PW_PLAYER;
 }
 
 /*!
@@ -380,7 +380,7 @@ void do_cmd_takeoff(PlayerType *player_ptr)
             o_ptr->curse_flags.clear();
             o_ptr->feeling = FEEL_NONE;
             player_ptr->update |= PU_BONUS;
-            player_ptr->window_flags |= PW_EQUIP;
+            player_ptr->window_flags |= PW_EQUIPMENT;
             msg_print(_("呪いを打ち破った。", "You break the curse."));
         } else {
             msg_print(_("装備を外せなかった。", "You couldn't remove the equipment."));
@@ -394,7 +394,7 @@ void do_cmd_takeoff(PlayerType *player_ptr)
     (void)inven_takeoff(player_ptr, item, 255);
     verify_equip_slot(player_ptr, item);
     calc_android_exp(player_ptr);
-    player_ptr->update |= PU_BONUS | PU_TORCH | PU_MANA;
+    player_ptr->update |= PU_BONUS | PU_TORCH | PU_MP;
     player_ptr->redraw |= PR_EQUIPPY;
-    player_ptr->window_flags |= PW_INVEN | PW_EQUIP | PW_PLAYER;
+    player_ptr->window_flags |= PW_INVENTORY | PW_EQUIPMENT | PW_PLAYER;
 }

--- a/src/cmd-item/cmd-item.cpp
+++ b/src/cmd-item/cmd-item.cpp
@@ -193,8 +193,8 @@ void do_cmd_uninscribe(PlayerType *player_ptr)
 
     msg_print(_("銘を消した。", "Inscription removed."));
     o_ptr->inscription.reset();
-    set_bits(player_ptr->update, PU_COMBINE);
-    set_bits(player_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_FLOOR_ITEM_LIST | PW_FOUND_ITEM_LIST);
+    set_bits(player_ptr->update, PU_COMBINATION);
+    set_bits(player_ptr->window_flags, PW_INVENTORY | PW_EQUIPMENT | PW_FLOOR_ITEMS | PW_FOUND_ITEMS);
     set_bits(player_ptr->update, PU_BONUS);
 }
 
@@ -223,8 +223,8 @@ void do_cmd_inscribe(PlayerType *player_ptr)
 
     if (get_string(_("銘: ", "Inscription: "), out_val, MAX_INSCRIPTION)) {
         o_ptr->inscription.emplace(out_val);
-        set_bits(player_ptr->update, PU_COMBINE);
-        set_bits(player_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_FLOOR_ITEM_LIST | PW_FOUND_ITEM_LIST);
+        set_bits(player_ptr->update, PU_COMBINATION);
+        set_bits(player_ptr->window_flags, PW_INVENTORY | PW_EQUIPMENT | PW_FLOOR_ITEMS | PW_FOUND_ITEMS);
         set_bits(player_ptr->update, PU_BONUS);
     }
 }

--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -41,17 +41,17 @@ void do_cmd_redraw(PlayerType *player_ptr)
 {
     term_xtra(TERM_XTRA_REACT, 0);
 
-    player_ptr->update |= (PU_COMBINE | PU_REORDER);
+    player_ptr->update |= (PU_COMBINATION | PU_REORDER);
     player_ptr->update |= (PU_TORCH);
-    player_ptr->update |= (PU_BONUS | PU_HP | PU_MANA | PU_SPELLS);
+    player_ptr->update |= (PU_BONUS | PU_HP | PU_MP | PU_SPELLS);
     player_ptr->update |= (PU_UN_VIEW | PU_UN_LITE);
-    player_ptr->update |= (PU_VIEW | PU_LITE | PU_MON_LITE);
-    player_ptr->update |= (PU_MONSTERS);
+    player_ptr->update |= (PU_VIEW | PU_LITE | PU_MONSTER_LITE);
+    player_ptr->update |= (PU_MONSTER_STATUSES);
 
     player_ptr->redraw |= (PR_WIPE | PR_BASIC | PR_EXTRA | PR_MAP | PR_EQUIPPY);
 
-    player_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER);
-    player_ptr->window_flags |= (PW_MESSAGE | PW_OVERHEAD | PW_DUNGEON | PW_MONSTER | PW_OBJECT);
+    player_ptr->window_flags |= (PW_INVENTORY | PW_EQUIPMENT | PW_SPELL | PW_PLAYER);
+    player_ptr->window_flags |= (PW_MESSAGE | PW_OVERHEAD | PW_DUNGEON | PW_MONSTER_LORE | PW_ITEM_KNOWLEDGTE);
 
     update_playtime();
     handle_stuff(player_ptr);

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -445,7 +445,7 @@ static MULTIPLY calc_shot_damage_with_slay(
 
         if ((flags.has(TR_FORCE_WEAPON)) && (player_ptr->csp > (player_ptr->msp / 30))) {
             player_ptr->csp -= (1 + (player_ptr->msp / 30));
-            set_bits(player_ptr->redraw, PR_MANA);
+            set_bits(player_ptr->redraw, PR_MP);
             mult = mult * 5 / 2;
         }
         break;
@@ -665,7 +665,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX item, ItemEntity *j_ptr, SPE
                     }
                     /* Forget the wall */
                     reset_bits(g_ptr->info, (CAVE_MARK));
-                    set_bits(player_ptr->update, PU_VIEW | PU_LITE | PU_FLOW | PU_MON_LITE);
+                    set_bits(player_ptr->update, PU_VIEW | PU_LITE | PU_FLOW | PU_MONSTER_LITE);
 
                     /* Destroy the wall */
                     cave_alter_feat(player_ptr, ny, nx, TerrainCharacteristics::HURT_ROCK);

--- a/src/combat/slaying.cpp
+++ b/src/combat/slaying.cpp
@@ -198,7 +198,7 @@ int calc_attack_damage_with_slay(PlayerType *player_ptr, ItemEntity *o_ptr, int 
 
         if (!pc.equals(PlayerClassType::SAMURAI) && (flags.has(TR_FORCE_WEAPON)) && (player_ptr->csp > (o_ptr->dd * o_ptr->ds / 5))) {
             player_ptr->csp -= (1 + (o_ptr->dd * o_ptr->ds / 5));
-            player_ptr->redraw |= (PR_MANA);
+            player_ptr->redraw |= (PR_MP);
             mult = mult * 3 / 2 + 20;
         }
 

--- a/src/core/disturbance.cpp
+++ b/src/core/disturbance.cpp
@@ -21,7 +21,7 @@ void disturb(PlayerType *player_ptr, bool stop_search, bool stop_travel)
 {
     if (command_rep) {
         command_rep = 0;
-        player_ptr->redraw |= PR_STATE;
+        player_ptr->redraw |= PR_ACTION;
     }
 
     if ((player_ptr->action == ACTION_REST) || (player_ptr->action == ACTION_FISH) || (stop_search && (player_ptr->action == ACTION_SEARCH))) {

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -124,7 +124,7 @@ static void send_waiting_record(PlayerType *player_ptr)
         quit(0);
     }
 
-    player_ptr->update |= (PU_BONUS | PU_HP | PU_MANA | PU_SPELLS);
+    player_ptr->update |= (PU_BONUS | PU_HP | PU_MP | PU_SPELLS);
     update_creature(player_ptr);
     player_ptr->is_dead = true;
     w_ptr->start_time = (uint32_t)time(nullptr);

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -244,7 +244,7 @@ void process_player(PlayerType *player_ptr)
             s64b_sub(&(player_ptr->csp), &(player_ptr->csp_frac), cost, cost_frac);
         }
 
-        player_ptr->redraw |= PR_MANA;
+        player_ptr->redraw |= PR_MP;
     }
 
     if (PlayerClass(player_ptr).samurai_stance_is(SamuraiStanceType::MUSOU)) {
@@ -252,7 +252,7 @@ void process_player(PlayerType *player_ptr)
             set_action(player_ptr, ACTION_NONE);
         } else {
             player_ptr->csp -= 2;
-            player_ptr->redraw |= (PR_MANA);
+            player_ptr->redraw |= (PR_MP);
         }
     }
 
@@ -291,7 +291,7 @@ void process_player(PlayerType *player_ptr)
                 if (!player_ptr->resting) {
                     set_action(player_ptr, ACTION_NONE);
                 }
-                player_ptr->redraw |= (PR_STATE);
+                player_ptr->redraw |= (PR_ACTION);
             }
 
             energy.set_player_turn_energy(100);
@@ -303,7 +303,7 @@ void process_player(PlayerType *player_ptr)
             travel_step(player_ptr);
         } else if (command_rep) {
             command_rep--;
-            player_ptr->redraw |= (PR_STATE);
+            player_ptr->redraw |= (PR_ACTION);
             handle_stuff(player_ptr);
             msg_flag = false;
             prt("", 0, 0);
@@ -311,7 +311,7 @@ void process_player(PlayerType *player_ptr)
         } else {
             move_cursor_relative(player_ptr->y, player_ptr->x);
 
-            player_ptr->window_flags |= PW_MONSTER_LIST;
+            player_ptr->window_flags |= PW_SIGHT_MONSTERS;
             window_stuff(player_ptr);
 
             can_save = true;
@@ -392,12 +392,12 @@ void process_player(PlayerType *player_ptr)
             if (player_ptr->action == ACTION_LEARN) {
                 auto mane_data = PlayerClass(player_ptr).get_specific_data<bluemage_data_type>();
                 mane_data->new_magic_learned = false;
-                player_ptr->redraw |= (PR_STATE);
+                player_ptr->redraw |= (PR_ACTION);
             }
 
             if (player_ptr->timewalk && (player_ptr->energy_need > -1000)) {
                 player_ptr->redraw |= (PR_MAP);
-                player_ptr->update |= (PU_MONSTERS);
+                player_ptr->update |= (PU_MONSTER_STATUSES);
                 player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
 
                 msg_print(_("「時は動きだす…」", "You feel time flowing around you once more."));

--- a/src/core/player-redraw-types.h
+++ b/src/core/player-redraw-types.h
@@ -1,32 +1,35 @@
 ﻿#pragma once
 
+// clang-format off
 enum player_redraw_type {
-    PR_MISC = 0x00000001L, /*!< 再描画フラグ: 種族と職業 / Display Race/Class */
-    PR_TITLE = 0x00000002L, /*!< 再描画フラグ: 称号 / Display Title */
-    PR_LEV = 0x00000004L, /*!< 再描画フラグ: レベル / Display Level */
-    PR_EXP = 0x00000008L, /*!< 再描画フラグ: 経験値 / Display Experience */
-    PR_STATS = 0x00000010L, /*!< 再描画フラグ: ステータス /  Display Stats */
-    PR_ARMOR = 0x00000020L, /*!< 再描画フラグ: AC / Display Armor */
-    PR_HP = 0x00000040L, /*!< 再描画フラグ: HP / Display Hitpoints */
-    PR_MANA = 0x00000080L, /*!< 再描画フラグ: MP / Display Mana */
-    PR_GOLD = 0x00000100L, /*!< 再描画フラグ: 所持金 / Display Gold */
-    PR_DEPTH = 0x00000200L, /*!< 再描画フラグ: ダンジョンの階 / Display Depth */
-    PR_EQUIPPY = 0x00000400L, /*!< 再描画フラグ: 装備シンボル / Display equippy chars */
-    PR_HEALTH = 0x00000800L, /*!< 再描画フラグ: モンスターのステータス / Display Health Bar */
-    PR_CUT = 0x00001000L, /*!< 再描画フラグ: 負傷度 / Display Extra (Cut) */
-    PR_STUN = 0x00002000L, /*!< 再描画フラグ: 朦朧度 / Display Extra (Stun) */
-    PR_HUNGER = 0x00004000L, /*!< 再描画フラグ: 空腹度 / Display Extra (Hunger) */
-    PR_STATUS = 0x00008000L, /*!< 再描画フラグ: プレイヤーの付与状態 /  Display Status Bar */
-    PR_XXX0 = 0x00010000L, /*!< (unused) */
-    PR_UHEALTH = 0x00020000L, /*!< 再描画フラグ: ペットのステータス / Display Uma Health Bar */
-    PR_XXX1 = 0x00040000L, /*!< (unused) */
-    PR_XXX2 = 0x00080000L, /*!< (unused) */
-    PR_STATE = 0x00100000L, /*!< 再描画フラグ: プレイヤーの行動状態 / Display Extra (State) */
-    PR_SPEED = 0x00200000L, /*!< 再描画フラグ: 加速 / Display Extra (Speed) */
-    PR_STUDY = 0x00400000L, /*!< 再描画フラグ: 学習 / Display Extra (Study) */
-    PR_IMITATION = 0x00800000L, /*!< 再描画フラグ: ものまね / Display Extra (Imitation) */
-    PR_EXTRA = 0x01000000L, /*!< 再描画フラグ: 拡張ステータス全体 / Display Extra Info */
-    PR_BASIC = 0x02000000L, /*!< 再描画フラグ: 基本ステータス全体 / Display Basic Info */
-    PR_MAP = 0x04000000L, /*!< 再描画フラグ: ゲームマップ / Display Map */
-    PR_WIPE = 0x08000000L, /*!< 再描画フラグ: 画面消去 / Hack -- Total Redraw */
+    PR_MISC          = 0x00000001L, /*!< 再描画フラグ: 種族と職業 / Display Race/Class */
+    PR_TITLE         = 0x00000002L, /*!< 再描画フラグ: 称号 / Display Title */
+    PR_LEVEL         = 0x00000004L, /*!< 再描画フラグ: レベル / Display Level */
+    PR_EXP           = 0x00000008L, /*!< 再描画フラグ: 経験値 / Display Experience */
+    PR_ABILITY_SCORE = 0x00000010L, /*!< 再描画フラグ: ステータス /  Display Stats */
+    PR_AC            = 0x00000020L, /*!< 再描画フラグ: AC / Display Armor */
+    PR_HP            = 0x00000040L, /*!< 再描画フラグ: HP / Display Hitpoints */
+    PR_MP            = 0x00000080L, /*!< 再描画フラグ: MP / Display Mana */
+    PR_GOLD          = 0x00000100L, /*!< 再描画フラグ: 所持金 / Display Gold */
+    PR_DEPTH         = 0x00000200L, /*!< 再描画フラグ: ダンジョンの階 / Display Depth */
+    PR_EQUIPPY       = 0x00000400L, /*!< 再描画フラグ: 装備シンボル / Display equippy chars */
+    PR_HEALTH        = 0x00000800L, /*!< 再描画フラグ: モンスターのステータス / Display Health Bar */
+    PR_CUT           = 0x00001000L, /*!< 再描画フラグ: 負傷度 / Display Extra (Cut) */
+    PR_STUN          = 0x00002000L, /*!< 再描画フラグ: 朦朧度 / Display Extra (Stun) */
+    PR_HUNGER        = 0x00004000L, /*!< 再描画フラグ: 空腹度 / Display Extra (Hunger) */
+    PR_TIMED_EFFECT  = 0x00008000L, /*!< 再描画フラグ: プレイヤーの付与状態 /  Display Status Bar */
+    PR_XXX0          = 0x00010000L, /*!< (unused) */
+    PR_UHEALTH       = 0x00020000L, /*!< 再描画フラグ: ペットのステータス / Display Uma Health Bar */
+    PR_XXX1          = 0x00040000L, /*!< (unused) */
+    PR_XXX2          = 0x00080000L, /*!< (unused) */
+    PR_ACTION        = 0x00100000L, /*!< 再描画フラグ: プレイヤーの行動状態 / Display Extra (State) */
+    PR_SPEED         = 0x00200000L, /*!< 再描画フラグ: 加速 / Display Extra (Speed) */
+    PR_STUDY         = 0x00400000L, /*!< 再描画フラグ: 学習 / Display Extra (Study) */
+    PR_IMITATION     = 0x00800000L, /*!< 再描画フラグ: ものまね / Display Extra (Imitation) */
+    PR_EXTRA         = 0x01000000L, /*!< 再描画フラグ: 拡張ステータス全体 / Display Extra Info */
+    PR_BASIC         = 0x02000000L, /*!< 再描画フラグ: 基本ステータス全体 / Display Basic Info */
+    PR_MAP           = 0x04000000L, /*!< 再描画フラグ: ゲームマップ / Display Map */
+    PR_WIPE          = 0x08000000L, /*!< 再描画フラグ: 画面消去 / Hack -- Total Redraw */
 };
+
+// clang-format on

--- a/src/core/player-update-types.h
+++ b/src/core/player-update-types.h
@@ -1,21 +1,24 @@
 ﻿#pragma once
 
+// clang-format off
 enum player_update_type {
-    PU_BONUS = 0x00000001L, /*!< ステータス更新フラグ: 能力値修正 / Calculate bonuses */
-    PU_TORCH = 0x00000002L, /*!< ステータス更新フラグ: 光源半径 / Calculate torch radius */
-    PU_HP = 0x00000010L, /*!< ステータス更新フラグ: HP / Calculate chp and mhp */
-    PU_MANA = 0x00000020L, /*!< ステータス更新フラグ: MP / Calculate csp and msp */
-    PU_SPELLS = 0x00000040L, /*!< ステータス更新フラグ: 魔法学習数 / Calculate spells */
-    PU_COMBINE = 0x00000100L, /*!< アイテム処理フラグ: アイテムの結合を要する / Combine the pack */
-    PU_REORDER = 0x00000200L, /*!< アイテム処理フラグ: アイテムの並び替えを要する / Reorder the pack */
-    PU_AUTODESTROY = 0x00000400L, /*!< アイテム処理フラグ: アイテムの自動破壊を要する / Auto-destroy marked item */
-    PU_UN_VIEW = 0x00010000L, /*!< ステータス更新フラグ: 地形の視界外化 / Forget view */
-    PU_UN_LITE = 0x00020000L, /*!< ステータス更新フラグ: 明暗範囲の視界外化 / Forget lite */
-    PU_VIEW = 0x00100000L, /*!< ステータス更新フラグ: 視界 / Update view */
-    PU_LITE = 0x00200000L, /*!< ステータス更新フラグ: 明暗範囲 / Update lite */
-    PU_MON_LITE = 0x00400000L, /*!< ステータス更新フラグ: モンスターの光源範囲 / Monster illumination */
-    PU_DELAY_VIS = 0x00800000L, /*!< ステータス更新フラグ: 視界の追加更新 / Mega-Hack -- Delayed visual update */
-    PU_MONSTERS = 0x01000000L, /*!< ステータス更新フラグ: モンスターのステータス / Update monsters */
-    PU_DISTANCE = 0x02000000L, /*!< ステータス更新フラグ: プレイヤーとモンスターの距離 / Update distances */
-    PU_FLOW = 0x10000000L, /*!< ステータス更新フラグ: プレイヤーから各マスへの到達距離 / Update flow */
+    PU_BONUS            = 0x00000001L, /*!< ステータス更新フラグ: 能力値修正 / Calculate bonuses */
+    PU_TORCH            = 0x00000002L, /*!< ステータス更新フラグ: 光源半径 / Calculate torch radius */
+    PU_HP               = 0x00000010L, /*!< ステータス更新フラグ: HP / Calculate chp and mhp */
+    PU_MP               = 0x00000020L, /*!< ステータス更新フラグ: MP / Calculate csp and msp */
+    PU_SPELLS           = 0x00000040L, /*!< ステータス更新フラグ: 魔法学習数 / Calculate spells */
+    PU_COMBINATION      = 0x00000100L, /*!< アイテム処理フラグ: アイテムの結合を要する / Combine the pack */
+    PU_REORDER          = 0x00000200L, /*!< アイテム処理フラグ: アイテムの並び替えを要する / Reorder the pack */
+    PU_AUTO_DESTRUCTION = 0x00000400L, /*!< アイテム処理フラグ: アイテムの自動破壊を要する / Auto-destroy marked item */
+    PU_UN_VIEW          = 0x00010000L, /*!< ステータス更新フラグ: 地形の視界外化 / Forget view */
+    PU_UN_LITE          = 0x00020000L, /*!< ステータス更新フラグ: 明暗範囲の視界外化 / Forget lite */
+    PU_VIEW             = 0x00100000L, /*!< ステータス更新フラグ: 視界 / Update view */
+    PU_LITE             = 0x00200000L, /*!< ステータス更新フラグ: 明暗範囲 / Update lite */
+    PU_MONSTER_LITE     = 0x00400000L, /*!< ステータス更新フラグ: モンスターの光源範囲 / Monster illumination */
+    PU_DELAY_VISIBILITY = 0x00800000L, /*!< ステータス更新フラグ: 視界の追加更新 / Mega-Hack -- Delayed visual update */
+    PU_MONSTER_STATUSES = 0x01000000L, /*!< ステータス更新フラグ: モンスターのステータス / Update monsters */
+    PU_DISTANCE         = 0x02000000L, /*!< ステータス更新フラグ: プレイヤーとモンスターの距離 / Update distances */
+    PU_FLOW             = 0x10000000L, /*!< ステータス更新フラグ: プレイヤーから各マスへの到達距離 / Update flow */
 };
+
+// clang-format on

--- a/src/core/stuff-handler.cpp
+++ b/src/core/stuff-handler.cpp
@@ -28,7 +28,7 @@ void handle_stuff(PlayerType *player_ptr)
 void monster_race_track(PlayerType *player_ptr, MonsterRaceId r_idx)
 {
     player_ptr->monster_race_idx = r_idx;
-    player_ptr->window_flags |= (PW_MONSTER);
+    player_ptr->window_flags |= (PW_MONSTER_LORE);
 }
 
 /*
@@ -37,7 +37,7 @@ void monster_race_track(PlayerType *player_ptr, MonsterRaceId r_idx)
 void object_kind_track(PlayerType *player_ptr, short bi_id)
 {
     player_ptr->tracking_bi_id = bi_id;
-    player_ptr->window_flags |= (PW_OBJECT);
+    player_ptr->window_flags |= (PW_ITEM_KNOWLEDGTE);
 }
 
 /*
@@ -58,8 +58,8 @@ void health_track(PlayerType *player_ptr, MONSTER_IDX m_idx)
 
 bool update_player(PlayerType *player_ptr)
 {
-    player_ptr->update |= PU_COMBINE | PU_REORDER;
-    player_ptr->window_flags |= PW_INVEN;
+    player_ptr->update |= PU_COMBINATION | PU_REORDER;
+    player_ptr->window_flags |= PW_INVENTORY;
     return true;
 }
 
@@ -69,8 +69,8 @@ bool redraw_player(PlayerType *player_ptr)
         player_ptr->csp = player_ptr->msp;
     }
 
-    player_ptr->redraw |= PR_MANA;
-    player_ptr->update |= PU_COMBINE | PU_REORDER;
-    player_ptr->window_flags |= PW_INVEN;
+    player_ptr->redraw |= PR_MP;
+    player_ptr->update |= PU_COMBINATION | PU_REORDER;
+    player_ptr->window_flags |= PW_INVENTORY;
     return true;
 }

--- a/src/core/window-redrawer.cpp
+++ b/src/core/window-redrawer.cpp
@@ -93,9 +93,9 @@ void redraw_stuff(PlayerType *player_ptr)
 
     if (player_ptr->redraw & (PR_BASIC)) {
         player_ptr->redraw &= ~(PR_BASIC);
-        player_ptr->redraw &= ~(PR_MISC | PR_TITLE | PR_STATS);
-        player_ptr->redraw &= ~(PR_LEV | PR_EXP | PR_GOLD);
-        player_ptr->redraw &= ~(PR_ARMOR | PR_HP | PR_MANA);
+        player_ptr->redraw &= ~(PR_MISC | PR_TITLE | PR_ABILITY_SCORE);
+        player_ptr->redraw &= ~(PR_LEVEL | PR_EXP | PR_GOLD);
+        player_ptr->redraw &= ~(PR_AC | PR_HP | PR_MP);
         player_ptr->redraw &= ~(PR_DEPTH | PR_HEALTH | PR_UHEALTH);
         print_frame_basic(player_ptr);
         WorldTurnProcessor(player_ptr).print_time();
@@ -117,8 +117,8 @@ void redraw_stuff(PlayerType *player_ptr)
         print_title(player_ptr);
     }
 
-    if (player_ptr->redraw & (PR_LEV)) {
-        player_ptr->redraw &= ~(PR_LEV);
+    if (player_ptr->redraw & (PR_LEVEL)) {
+        player_ptr->redraw &= ~(PR_LEVEL);
         print_level(player_ptr);
     }
 
@@ -127,8 +127,8 @@ void redraw_stuff(PlayerType *player_ptr)
         print_exp(player_ptr);
     }
 
-    if (player_ptr->redraw & (PR_STATS)) {
-        player_ptr->redraw &= ~(PR_STATS);
+    if (player_ptr->redraw & (PR_ABILITY_SCORE)) {
+        player_ptr->redraw &= ~(PR_ABILITY_SCORE);
         print_stat(player_ptr, A_STR);
         print_stat(player_ptr, A_INT);
         print_stat(player_ptr, A_WIS);
@@ -137,13 +137,13 @@ void redraw_stuff(PlayerType *player_ptr)
         print_stat(player_ptr, A_CHR);
     }
 
-    if (player_ptr->redraw & (PR_STATUS)) {
-        player_ptr->redraw &= ~(PR_STATUS);
+    if (player_ptr->redraw & (PR_TIMED_EFFECT)) {
+        player_ptr->redraw &= ~(PR_TIMED_EFFECT);
         print_status(player_ptr);
     }
 
-    if (player_ptr->redraw & (PR_ARMOR)) {
-        player_ptr->redraw &= ~(PR_ARMOR);
+    if (player_ptr->redraw & (PR_AC)) {
+        player_ptr->redraw &= ~(PR_AC);
         print_ac(player_ptr);
     }
 
@@ -152,8 +152,8 @@ void redraw_stuff(PlayerType *player_ptr)
         print_hp(player_ptr);
     }
 
-    if (player_ptr->redraw & (PR_MANA)) {
-        player_ptr->redraw &= ~(PR_MANA);
+    if (player_ptr->redraw & (PR_MP)) {
+        player_ptr->redraw &= ~(PR_MP);
         print_sp(player_ptr);
     }
 
@@ -181,7 +181,7 @@ void redraw_stuff(PlayerType *player_ptr)
         player_ptr->redraw &= ~(PR_EXTRA);
         player_ptr->redraw &= ~(PR_CUT | PR_STUN);
         player_ptr->redraw &= ~(PR_HUNGER);
-        player_ptr->redraw &= ~(PR_STATE | PR_SPEED | PR_STUDY | PR_IMITATION | PR_STATUS);
+        player_ptr->redraw &= ~(PR_ACTION | PR_SPEED | PR_STUDY | PR_IMITATION | PR_TIMED_EFFECT);
         print_frame_extra(player_ptr);
     }
 
@@ -200,8 +200,8 @@ void redraw_stuff(PlayerType *player_ptr)
         print_hunger(player_ptr);
     }
 
-    if (player_ptr->redraw & (PR_STATE)) {
-        player_ptr->redraw &= ~(PR_STATE);
+    if (player_ptr->redraw & (PR_ACTION)) {
+        player_ptr->redraw &= ~(PR_ACTION);
         print_state(player_ptr);
     }
 
@@ -244,13 +244,13 @@ void window_stuff(PlayerType *player_ptr)
     }
     BIT_FLAGS window_flags = player_ptr->window_flags & mask;
 
-    if (window_flags & (PW_INVEN)) {
-        player_ptr->window_flags &= ~(PW_INVEN);
+    if (window_flags & (PW_INVENTORY)) {
+        player_ptr->window_flags &= ~(PW_INVENTORY);
         fix_inventory(player_ptr);
     }
 
-    if (window_flags & (PW_EQUIP)) {
-        player_ptr->window_flags &= ~(PW_EQUIP);
+    if (window_flags & (PW_EQUIPMENT)) {
+        player_ptr->window_flags &= ~(PW_EQUIPMENT);
         fix_equip(player_ptr);
     }
 
@@ -265,8 +265,8 @@ void window_stuff(PlayerType *player_ptr)
     }
 
     // モンスターBGM対応のため、視界内モンスター表示のサブウインドウなし時も処理を行う
-    if (player_ptr->window_flags & (PW_MONSTER_LIST)) {
-        player_ptr->window_flags &= ~(PW_MONSTER_LIST);
+    if (player_ptr->window_flags & (PW_SIGHT_MONSTERS)) {
+        player_ptr->window_flags &= ~(PW_SIGHT_MONSTERS);
         fix_monster_list(player_ptr);
     }
 
@@ -285,24 +285,24 @@ void window_stuff(PlayerType *player_ptr)
         fix_dungeon(player_ptr);
     }
 
-    if (window_flags & (PW_MONSTER)) {
-        player_ptr->window_flags &= ~(PW_MONSTER);
+    if (window_flags & (PW_MONSTER_LORE)) {
+        player_ptr->window_flags &= ~(PW_MONSTER_LORE);
         fix_monster(player_ptr);
     }
 
-    if (window_flags & (PW_OBJECT)) {
-        player_ptr->window_flags &= ~(PW_OBJECT);
+    if (window_flags & (PW_ITEM_KNOWLEDGTE)) {
+        player_ptr->window_flags &= ~(PW_ITEM_KNOWLEDGTE);
         fix_object(player_ptr);
     }
 
-    if (any_bits(window_flags, PW_FLOOR_ITEM_LIST)) {
-        reset_bits(player_ptr->window_flags, PW_FLOOR_ITEM_LIST);
+    if (any_bits(window_flags, PW_FLOOR_ITEMS)) {
+        reset_bits(player_ptr->window_flags, PW_FLOOR_ITEMS);
         // ウィンドウサイズ変更に対応できず。カーソル位置を取る必要がある。
         fix_floor_item_list(player_ptr, player_ptr->y, player_ptr->x);
     }
 
-    if (any_bits(window_flags, PW_FOUND_ITEM_LIST)) {
-        reset_bits(player_ptr->window_flags, PW_FOUND_ITEM_LIST);
+    if (any_bits(window_flags, PW_FOUND_ITEMS)) {
+        reset_bits(player_ptr->window_flags, PW_FOUND_ITEMS);
         fix_found_item_list(player_ptr);
     }
 }

--- a/src/core/window-redrawer.h
+++ b/src/core/window-redrawer.h
@@ -7,21 +7,21 @@
  * @brief サブウィンドウ描画フラグ
  */
 enum window_redraw_type {
-    PW_INVEN           = 1U <<  0, /*!<サブウィンドウ描画フラグ: 所持品-装備品 / Display inven/equip */
-    PW_EQUIP           = 1U <<  1, /*!<サブウィンドウ描画フラグ: 装備品-所持品 / Display equip/inven */
+    PW_INVENTORY       = 1U <<  0, /*!<サブウィンドウ描画フラグ: 所持品-装備品 / Display inven/equip */
+    PW_EQUIPMENT       = 1U <<  1, /*!<サブウィンドウ描画フラグ: 装備品-所持品 / Display equip/inven */
     PW_SPELL           = 1U <<  2, /*!<サブウィンドウ描画フラグ: 魔法一覧 / Display spell list */
     PW_PLAYER          = 1U <<  3, /*!<サブウィンドウ描画フラグ: プレイヤーのステータス / Display character */
-    PW_MONSTER_LIST    = 1U <<  4, /*!<サブウィンドウ描画フラグ: 視界内モンスターの一覧 / Display monster list */
+    PW_SIGHT_MONSTERS  = 1U <<  4, /*!<サブウィンドウ描画フラグ: 視界内モンスターの一覧 / Display monster list */
     PW_MESSAGE         = 1U <<  6, /*!<サブウィンドウ描画フラグ: メッセージログ / Display messages */
     PW_OVERHEAD        = 1U <<  7, /*!<サブウィンドウ描画フラグ: 周辺の光景 / Display overhead view */
-    PW_MONSTER         = 1U <<  8, /*!<サブウィンドウ描画フラグ: モンスターの思い出 / Display monster recall */
-    PW_OBJECT          = 1U <<  9, /*!<サブウィンドウ描画フラグ: アイテムの知識 / Display object recall */
+    PW_MONSTER_LORE    = 1U <<  8, /*!<サブウィンドウ描画フラグ: モンスターの思い出 / Display monster recall */
+    PW_ITEM_KNOWLEDGTE = 1U <<  9, /*!<サブウィンドウ描画フラグ: アイテムの知識 / Display object recall */
     PW_DUNGEON         = 1U << 10, /*!<サブウィンドウ描画フラグ: ダンジョンの地形 / Display dungeon view */
     PW_SNAPSHOT        = 1U << 11, /*!<サブウィンドウ描画フラグ: 記念写真 / Display snap-shot */
-    PW_FLOOR_ITEM_LIST = 1U << 12, /*!<サブウィンドウ描画フラグ: 床上のアイテム一覧 / Display items on grid */
-    PW_FOUND_ITEM_LIST = 1U << 13, /*!<サブウィンドウ描画フラグ: 発見済みのアイテム一覧 / Display found items*/
+    PW_FLOOR_ITEMS     = 1U << 12, /*!<サブウィンドウ描画フラグ: 床上のアイテム一覧 / Display items on grid */
+    PW_FOUND_ITEMS     = 1U << 13, /*!<サブウィンドウ描画フラグ: 発見済みのアイテム一覧 / Display found items*/
 
-    PW_ALL = (PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER | PW_MONSTER_LIST | PW_MESSAGE | PW_OVERHEAD | PW_MONSTER | PW_OBJECT | PW_DUNGEON | PW_SNAPSHOT | PW_FLOOR_ITEM_LIST | PW_FOUND_ITEM_LIST),
+    PW_ALL = (PW_INVENTORY | PW_EQUIPMENT | PW_SPELL | PW_PLAYER | PW_SIGHT_MONSTERS | PW_MESSAGE | PW_OVERHEAD | PW_MONSTER_LORE | PW_ITEM_KNOWLEDGTE | PW_DUNGEON | PW_SNAPSHOT | PW_FLOOR_ITEMS | PW_FOUND_ITEMS),
 };
 
 // clang-format on

--- a/src/dungeon/dungeon-processor.cpp
+++ b/src/dungeon/dungeon-processor.cpp
@@ -101,13 +101,13 @@ void process_dungeon(PlayerType *player_ptr, bool load_game)
     msg_erase();
 
     w_ptr->character_xtra = true;
-    set_bits(player_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER | PW_MONSTER | PW_OVERHEAD | PW_DUNGEON);
+    set_bits(player_ptr->window_flags, PW_INVENTORY | PW_EQUIPMENT | PW_SPELL | PW_PLAYER | PW_MONSTER_LORE | PW_OVERHEAD | PW_DUNGEON);
     set_bits(player_ptr->redraw, PR_WIPE | PR_BASIC | PR_EXTRA | PR_EQUIPPY | PR_MAP);
-    set_bits(player_ptr->update, PU_BONUS | PU_HP | PU_MANA | PU_SPELLS | PU_VIEW | PU_LITE | PU_MON_LITE | PU_TORCH | PU_MONSTERS | PU_DISTANCE | PU_FLOW);
+    set_bits(player_ptr->update, PU_BONUS | PU_HP | PU_MP | PU_SPELLS | PU_VIEW | PU_LITE | PU_MONSTER_LITE | PU_TORCH | PU_MONSTER_STATUSES | PU_DISTANCE | PU_FLOW);
     handle_stuff(player_ptr);
 
     w_ptr->character_xtra = false;
-    set_bits(player_ptr->update, PU_BONUS | PU_HP | PU_MANA | PU_SPELLS | PU_COMBINE | PU_REORDER);
+    set_bits(player_ptr->update, PU_BONUS | PU_HP | PU_MP | PU_SPELLS | PU_COMBINATION | PU_REORDER);
     handle_stuff(player_ptr);
     term_fresh();
 

--- a/src/effect/effect-monster-psi.cpp
+++ b/src/effect/effect-monster-psi.cpp
@@ -267,7 +267,7 @@ static void effect_monster_psi_drain_resist(PlayerType *player_ptr, effect_monst
         player_ptr->csp = 0;
     }
 
-    set_bits(player_ptr->redraw, PR_MANA);
+    set_bits(player_ptr->redraw, PR_MP);
     set_bits(player_ptr->window_flags, PW_SPELL);
     take_hit(player_ptr, DAMAGE_ATTACK, em_ptr->dam, em_ptr->killer);
     em_ptr->dam = 0;
@@ -287,7 +287,7 @@ static void effect_monster_psi_drain_change_power(PlayerType *player_ptr, effect
 
     b = std::min(player_ptr->msp, player_ptr->csp + b);
     player_ptr->csp = b;
-    set_bits(player_ptr->redraw, PR_MANA);
+    set_bits(player_ptr->redraw, PR_MP);
     set_bits(player_ptr->window_flags, PW_SPELL);
 }
 

--- a/src/effect/effect-monster.cpp
+++ b/src/effect/effect-monster.cpp
@@ -749,7 +749,7 @@ bool affect_monster(
 
     lite_spot(player_ptr, em_ptr->y, em_ptr->x);
     if ((player_ptr->monster_race_idx == em_ptr->m_ptr->r_idx) && (em_ptr->seen || !monster_is_valid)) {
-        player_ptr->window_flags |= (PW_MONSTER);
+        player_ptr->window_flags |= (PW_MONSTER_LORE);
     }
 
     exe_affect_monster_postprocess(player_ptr, em_ptr);

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -432,8 +432,8 @@ void effect_player_lite(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
     player_ptr->wraith_form = 0;
     msg_print(_("閃光のため非物質的な影の存在でいられなくなった。", "The light forces you out of your incorporeal shadow form."));
 
-    player_ptr->redraw |= (PR_MAP | PR_STATUS);
-    player_ptr->update |= (PU_MONSTERS);
+    player_ptr->redraw |= (PR_MAP | PR_TIMED_EFFECT);
+    player_ptr->update |= (PU_MONSTER_STATUSES);
     player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
 }
 

--- a/src/effect/effect-player-spirit.cpp
+++ b/src/effect/effect-player-spirit.cpp
@@ -40,7 +40,7 @@ void effect_player_drain_mana(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
         player_ptr->csp -= ep_ptr->dam;
     }
 
-    player_ptr->redraw |= (PR_MANA);
+    player_ptr->redraw |= (PR_MP);
     player_ptr->window_flags |= (PW_PLAYER | PW_SPELL);
 
     if ((ep_ptr->who <= 0) || (ep_ptr->m_ptr->hp >= ep_ptr->m_ptr->maxhp)) {
@@ -95,7 +95,7 @@ void effect_player_mind_blast(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
         player_ptr->csp_frac = 0;
     }
 
-    player_ptr->redraw |= PR_MANA;
+    player_ptr->redraw |= PR_MP;
     ep_ptr->get_damage = take_hit(player_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
 }
 
@@ -114,7 +114,7 @@ void effect_player_brain_smash(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
             player_ptr->csp = 0;
             player_ptr->csp_frac = 0;
         }
-        player_ptr->redraw |= PR_MANA;
+        player_ptr->redraw |= PR_MP;
     }
 
     ep_ptr->get_damage = take_hit(player_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);

--- a/src/floor/floor-events.cpp
+++ b/src/floor/floor-events.cpp
@@ -62,7 +62,7 @@ void day_break(PlayerType *player_ptr)
         }
     }
 
-    player_ptr->update |= PU_MONSTERS | PU_MON_LITE;
+    player_ptr->update |= PU_MONSTER_STATUSES | PU_MONSTER_LITE;
     player_ptr->redraw |= PR_MAP;
     player_ptr->window_flags |= PW_OVERHEAD | PW_DUNGEON;
     if ((floor_ptr->grid_array[player_ptr->y][player_ptr->x].info & CAVE_GLOW) != 0) {
@@ -94,7 +94,7 @@ void night_falls(PlayerType *player_ptr)
         }
     }
 
-    player_ptr->update |= PU_MONSTERS | PU_MON_LITE;
+    player_ptr->update |= PU_MONSTER_STATUSES | PU_MONSTER_LITE;
     player_ptr->redraw |= PR_MAP;
     player_ptr->window_flags |= PW_OVERHEAD | PW_DUNGEON;
 
@@ -338,7 +338,7 @@ void glow_deep_lava_and_bldg(PlayerType *player_ptr)
         }
     }
 
-    player_ptr->update |= PU_VIEW | PU_LITE | PU_MON_LITE;
+    player_ptr->update |= PU_VIEW | PU_LITE | PU_MONSTER_LITE;
     player_ptr->redraw |= PR_MAP;
 }
 

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -231,7 +231,7 @@ void floor_item_increase(PlayerType *player_ptr, INVENTORY_IDX item, ITEM_NUMBER
     num -= o_ptr->number;
     o_ptr->number += num;
 
-    set_bits(player_ptr->window_flags, PW_FLOOR_ITEM_LIST | PW_FOUND_ITEM_LIST);
+    set_bits(player_ptr->window_flags, PW_FLOOR_ITEMS | PW_FOUND_ITEMS);
 }
 
 /*!
@@ -252,7 +252,7 @@ void floor_item_optimize(PlayerType *player_ptr, INVENTORY_IDX item)
 
     delete_object_idx(player_ptr, item);
 
-    set_bits(player_ptr->window_flags, PW_FLOOR_ITEM_LIST | PW_FOUND_ITEM_LIST);
+    set_bits(player_ptr->window_flags, PW_FLOOR_ITEMS | PW_FOUND_ITEMS);
 }
 
 /*!
@@ -279,7 +279,7 @@ void delete_object_idx(PlayerType *player_ptr, OBJECT_IDX o_idx)
     j_ptr->wipe();
     floor_ptr->o_cnt--;
 
-    set_bits(player_ptr->window_flags, PW_FLOOR_ITEM_LIST | PW_FOUND_ITEM_LIST);
+    set_bits(player_ptr->window_flags, PW_FLOOR_ITEMS | PW_FOUND_ITEMS);
 }
 
 /*!
@@ -560,7 +560,7 @@ OBJECT_IDX drop_near(PlayerType *player_ptr, ItemEntity *j_ptr, PERCENTAGE chanc
     sound(SOUND_DROP);
 
     if (player_bold(player_ptr, by, bx)) {
-        set_bits(player_ptr->window_flags, PW_FLOOR_ITEM_LIST | PW_FOUND_ITEM_LIST);
+        set_bits(player_ptr->window_flags, PW_FLOOR_ITEMS | PW_FOUND_ITEMS);
     }
 
     if (chance && player_bold(player_ptr, by, bx)) {

--- a/src/grid/feature.cpp
+++ b/src/grid/feature.cpp
@@ -244,7 +244,7 @@ void cave_set_feat(PlayerType *player_ptr, POSITION y, POSITION x, FEAT_IDX feat
     note_spot(player_ptr, y, x);
     lite_spot(player_ptr, y, x);
     if (old_los ^ f_ptr->flags.has(TerrainCharacteristics::LOS)) {
-        player_ptr->update |= PU_VIEW | PU_LITE | PU_MON_LITE | PU_MONSTERS;
+        player_ptr->update |= PU_VIEW | PU_LITE | PU_MONSTER_LITE | PU_MONSTER_STATUSES;
     }
 
     if (f_ptr->flags.has_not(TerrainCharacteristics::GLOW) || dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -363,7 +363,7 @@ void note_spot(PlayerType *player_ptr, POSITION y, POSITION x)
 
         /* Memorize objects */
         o_ptr->marked.set(OmType::FOUND);
-        player_ptr->window_flags |= PW_FOUND_ITEM_LIST;
+        player_ptr->window_flags |= PW_FOUND_ITEMS;
     }
 
     /* Hack -- memorize grids */

--- a/src/hpmp/hp-mp-regenerator.cpp
+++ b/src/hpmp/hp-mp-regenerator.cpp
@@ -108,7 +108,7 @@ void regenmana(PlayerType *player_ptr, MANA_POINT upkeep_factor, MANA_POINT rege
     }
 
     if (old_csp != player_ptr->csp) {
-        player_ptr->redraw |= (PR_MANA);
+        player_ptr->redraw |= (PR_MP);
         player_ptr->window_flags |= (PW_PLAYER);
         player_ptr->window_flags |= (PW_SPELL);
         wild_regen = 20;
@@ -246,10 +246,10 @@ void regenerate_captured_monsters(PlayerType *player_ptr)
     }
 
     if (heal) {
-        player_ptr->update |= (PU_COMBINE);
+        player_ptr->update |= (PU_COMBINATION);
         // FIXME 広域マップ移動で1歩毎に何度も再描画されて重くなる。現在はボール中モンスターのHP回復でボールの表示は変わらないためコメントアウトする。
-        // player_ptr->window_flags |= (PW_INVEN);
-        // player_ptr->window_flags |= (PW_EQUIP);
+        // player_ptr->window_flags |= (PW_INVENTORY);
+        // player_ptr->window_flags |= (PW_EQUIPMENT);
         wild_regen = 20;
     }
 }

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -311,11 +311,11 @@ bool get_item_floor(PlayerType *player_ptr, COMMAND_CODE *cp, concptr pmt, concp
                 continue;
             }
 
-            if (window_flag[i] & PW_INVEN) {
+            if (window_flag[i] & PW_INVENTORY) {
                 ni++;
             }
 
-            if (window_flag[i] & PW_EQUIP) {
+            if (window_flag[i] & PW_EQUIPMENT) {
                 ne++;
             }
         }
@@ -325,7 +325,7 @@ bool get_item_floor(PlayerType *player_ptr, COMMAND_CODE *cp, concptr pmt, concp
             fis_ptr->toggle = !fis_ptr->toggle;
         }
 
-        player_ptr->window_flags |= (PW_INVEN | PW_EQUIP);
+        player_ptr->window_flags |= (PW_INVENTORY | PW_EQUIPMENT);
         handle_stuff(player_ptr);
         COMMAND_CODE get_item_label = 0;
         if (command_wrk == USE_INVEN) {
@@ -664,7 +664,7 @@ bool get_item_floor(PlayerType *player_ptr, COMMAND_CODE *cp, concptr pmt, concp
                 g_ptr->o_idx_list.rotate(player_ptr->current_floor_ptr);
             }
 
-            player_ptr->window_flags |= PW_FLOOR_ITEM_LIST;
+            player_ptr->window_flags |= PW_FLOOR_ITEMS;
             window_stuff(player_ptr);
 
             fis_ptr->floor_num = scan_floor_items(player_ptr, fis_ptr->floor_list, player_ptr->y, player_ptr->x, SCAN_FLOOR_ITEM_TESTER | SCAN_FLOOR_ONLY_MARKED, item_tester);
@@ -880,7 +880,7 @@ bool get_item_floor(PlayerType *player_ptr, COMMAND_CODE *cp, concptr pmt, concp
         toggle_inventory_equipment(player_ptr);
     }
 
-    player_ptr->window_flags |= (PW_INVEN | PW_EQUIP);
+    player_ptr->window_flags |= (PW_INVENTORY | PW_EQUIPMENT);
     handle_stuff(player_ptr);
     prt("", 0, 0);
     if (fis_ptr->oops && str) {

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -425,7 +425,7 @@ static void curse_drain_mp(PlayerType *player_ptr)
         player_ptr->csp_frac = 0;
     }
 
-    player_ptr->redraw |= PR_MANA;
+    player_ptr->redraw |= PR_MP;
 }
 
 static void occur_curse_effects(PlayerType *player_ptr)

--- a/src/inventory/inventory-object.cpp
+++ b/src/inventory/inventory-object.cpp
@@ -55,9 +55,9 @@ void inven_item_increase(PlayerType *player_ptr, INVENTORY_IDX item, ITEM_NUMBER
 
     o_ptr->number += num;
     player_ptr->update |= (PU_BONUS);
-    player_ptr->update |= (PU_MANA);
-    player_ptr->update |= (PU_COMBINE);
-    player_ptr->window_flags |= (PW_INVEN | PW_EQUIP);
+    player_ptr->update |= (PU_MP);
+    player_ptr->update |= (PU_COMBINATION);
+    player_ptr->window_flags |= (PW_INVENTORY | PW_EQUIPMENT);
 
     if (o_ptr->number || !player_ptr->ele_attack) {
         return;
@@ -93,9 +93,9 @@ void inven_item_optimize(PlayerType *player_ptr, INVENTORY_IDX item)
         (&player_ptr->inventory_list[item])->wipe();
         player_ptr->update |= PU_BONUS;
         player_ptr->update |= PU_TORCH;
-        player_ptr->update |= PU_MANA;
+        player_ptr->update |= PU_MP;
 
-        player_ptr->window_flags |= PW_EQUIP;
+        player_ptr->window_flags |= PW_EQUIPMENT;
         player_ptr->window_flags |= PW_SPELL;
         return;
     }
@@ -107,7 +107,7 @@ void inven_item_optimize(PlayerType *player_ptr, INVENTORY_IDX item)
     }
 
     (&player_ptr->inventory_list[i])->wipe();
-    player_ptr->window_flags |= PW_INVEN;
+    player_ptr->window_flags |= PW_INVENTORY;
     player_ptr->window_flags |= PW_SPELL;
 }
 
@@ -214,7 +214,7 @@ void combine_pack(PlayerType *player_ptr)
                     }
                 }
 
-                player_ptr->window_flags |= (PW_INVEN);
+                player_ptr->window_flags |= (PW_INVENTORY);
                 combined = true;
                 break;
             }
@@ -271,7 +271,7 @@ void reorder_pack(PlayerType *player_ptr)
         }
 
         (&player_ptr->inventory_list[j])->copy_from(q_ptr);
-        player_ptr->window_flags |= (PW_INVEN);
+        player_ptr->window_flags |= (PW_INVENTORY);
     }
 
     if (flag) {
@@ -316,7 +316,7 @@ int16_t store_item_to_inventory(PlayerType *player_ptr, ItemEntity *o_ptr)
             object_absorb(j_ptr, o_ptr);
 
             player_ptr->update |= (PU_BONUS);
-            player_ptr->window_flags |= (PW_INVEN | PW_PLAYER);
+            player_ptr->window_flags |= (PW_INVENTORY | PW_PLAYER);
             return j;
         }
     }
@@ -356,8 +356,8 @@ int16_t store_item_to_inventory(PlayerType *player_ptr, ItemEntity *o_ptr)
     j_ptr->marked.clear().set(OmType::TOUCHED);
 
     player_ptr->inven_cnt++;
-    player_ptr->update |= (PU_BONUS | PU_COMBINE | PU_REORDER);
-    player_ptr->window_flags |= (PW_INVEN | PW_PLAYER);
+    player_ptr->update |= (PU_BONUS | PU_COMBINATION | PU_REORDER);
+    player_ptr->window_flags |= (PW_INVENTORY | PW_PLAYER);
 
     return i;
 }

--- a/src/inventory/item-getter.cpp
+++ b/src/inventory/item-getter.cpp
@@ -303,11 +303,11 @@ bool get_item(PlayerType *player_ptr, OBJECT_IDX *cp, concptr pmt, concptr str, 
                 continue;
             }
 
-            if (window_flag[i] & (PW_INVEN)) {
+            if (window_flag[i] & (PW_INVENTORY)) {
                 ni++;
             }
 
-            if (window_flag[i] & (PW_EQUIP)) {
+            if (window_flag[i] & (PW_EQUIPMENT)) {
                 ne++;
             }
         }
@@ -317,7 +317,7 @@ bool get_item(PlayerType *player_ptr, OBJECT_IDX *cp, concptr pmt, concptr str, 
             item_selection_ptr->toggle = !item_selection_ptr->toggle;
         }
 
-        player_ptr->window_flags |= (PW_INVEN | PW_EQUIP);
+        player_ptr->window_flags |= (PW_INVENTORY | PW_EQUIPMENT);
         handle_stuff(player_ptr);
 
         if (!command_wrk) {
@@ -640,7 +640,7 @@ bool get_item(PlayerType *player_ptr, OBJECT_IDX *cp, concptr pmt, concptr str, 
         toggle_inventory_equipment(player_ptr);
     }
 
-    player_ptr->window_flags |= (PW_INVEN | PW_EQUIP);
+    player_ptr->window_flags |= (PW_INVENTORY | PW_EQUIPMENT);
     handle_stuff(player_ptr);
     prt("", 0, 0);
     if (item_selection_ptr->oops && str) {

--- a/src/inventory/player-inventory.cpp
+++ b/src/inventory/player-inventory.cpp
@@ -242,7 +242,7 @@ void describe_pickup_item(PlayerType *player_ptr, OBJECT_IDX o_idx)
 void carry(PlayerType *player_ptr, bool pickup)
 {
     verify_panel(player_ptr);
-    player_ptr->update |= PU_MONSTERS;
+    player_ptr->update |= PU_MONSTER_STATUSES;
     player_ptr->redraw |= PR_MAP;
     player_ptr->window_flags |= PW_OVERHEAD;
     handle_stuff(player_ptr);

--- a/src/inventory/recharge-processor.cpp
+++ b/src/inventory/recharge-processor.cpp
@@ -72,7 +72,7 @@ void recharge_magic_items(PlayerType *player_ptr)
     }
 
     if (changed) {
-        player_ptr->window_flags |= (PW_EQUIP);
+        player_ptr->window_flags |= (PW_EQUIPMENT);
         wild_regen = 20;
     }
 
@@ -109,7 +109,7 @@ void recharge_magic_items(PlayerType *player_ptr)
     }
 
     if (changed) {
-        player_ptr->window_flags |= (PW_INVEN);
+        player_ptr->window_flags |= (PW_INVENTORY);
         wild_regen = 20;
     }
 

--- a/src/io/cursor.cpp
+++ b/src/io/cursor.cpp
@@ -134,7 +134,7 @@ bool change_panel(PlayerType *player_ptr, POSITION dy, POSITION dx)
     panel_col_min = x;
     panel_bounds_center();
 
-    player_ptr->update |= (PU_MONSTERS);
+    player_ptr->update |= (PU_MONSTER_STATUSES);
     player_ptr->redraw |= (PR_MAP);
     handle_stuff(player_ptr);
     return true;

--- a/src/io/input-key-processor.cpp
+++ b/src/io/input-key-processor.cpp
@@ -189,7 +189,7 @@ void process_command(PlayerType *player_ptr)
             msg_print(_("ウィザードモード突入。", "Wizard mode on."));
         }
 
-        player_ptr->update |= (PU_MONSTERS);
+        player_ptr->update |= (PU_MONSTER_STATUSES);
         player_ptr->redraw |= (PR_TITLE);
         break;
     }

--- a/src/io/screen-util.cpp
+++ b/src/io/screen-util.cpp
@@ -55,10 +55,10 @@ void resize_map()
     panel_col_min = p_ptr->current_floor_ptr->width;
     verify_panel(p_ptr);
 
-    p_ptr->update |= (PU_TORCH | PU_BONUS | PU_HP | PU_MANA | PU_SPELLS);
+    p_ptr->update |= (PU_TORCH | PU_BONUS | PU_HP | PU_MP | PU_SPELLS);
     p_ptr->update |= (PU_UN_VIEW | PU_UN_LITE);
-    p_ptr->update |= (PU_VIEW | PU_LITE | PU_MON_LITE);
-    p_ptr->update |= (PU_MONSTERS);
+    p_ptr->update |= (PU_VIEW | PU_LITE | PU_MONSTER_LITE);
+    p_ptr->update |= (PU_MONSTER_STATUSES);
     p_ptr->redraw |= (PR_WIPE | PR_BASIC | PR_EXTRA | PR_MAP | PR_EQUIPPY);
 
     handle_stuff(p_ptr);

--- a/src/lore/lore-store.cpp
+++ b/src/lore/lore-store.cpp
@@ -105,7 +105,7 @@ int lore_do_probe(PlayerType *player_ptr, MonsterRaceId r_idx)
     r_ptr->r_can_evolve = true;
 
     if (player_ptr->monster_race_idx == r_idx) {
-        player_ptr->window_flags |= (PW_MONSTER);
+        player_ptr->window_flags |= (PW_MONSTER_LORE);
     }
 
     return n;
@@ -141,6 +141,6 @@ void lore_treasure(PlayerType *player_ptr, MONSTER_IDX m_idx, ITEM_NUMBER num_it
         r_ptr->r_drop_flags.set(MonsterDropType::DROP_GREAT);
     }
     if (player_ptr->monster_race_idx == m_ptr->r_idx) {
-        player_ptr->window_flags |= (PW_MONSTER);
+        player_ptr->window_flags |= (PW_MONSTER_LORE);
     }
 }

--- a/src/market/arena.cpp
+++ b/src/market/arena.cpp
@@ -139,7 +139,7 @@ static void see_arena_poster(PlayerType *player_ptr)
     msg_format(_("%s に挑戦するものはいないか？", "Do I hear any challenges against: %s"), name);
 
     player_ptr->monster_race_idx = arena_info[player_ptr->arena_number].r_idx;
-    player_ptr->window_flags |= (PW_MONSTER);
+    player_ptr->window_flags |= (PW_MONSTER_LORE);
     handle_stuff(player_ptr);
 }
 

--- a/src/market/building-recharger.cpp
+++ b/src/market/building-recharger.cpp
@@ -152,8 +152,8 @@ void building_recharge(PlayerType *player_ptr)
 #else
     msg_format("%s^ %s recharged for %d gold.", item_name.data(), ((o_ptr->number > 1) ? "were" : "was"), price);
 #endif
-    player_ptr->update |= (PU_COMBINE | PU_REORDER);
-    player_ptr->window_flags |= (PW_INVEN);
+    player_ptr->update |= (PU_COMBINATION | PU_REORDER);
+    player_ptr->window_flags |= (PW_INVENTORY);
     player_ptr->au -= price;
 }
 
@@ -264,7 +264,7 @@ void building_recharge_all(PlayerType *player_ptr)
 
     msg_format(_("＄%d で再充填しました。", "You pay %d gold."), total_cost);
     msg_print(nullptr);
-    player_ptr->update |= (PU_COMBINE | PU_REORDER);
-    player_ptr->window_flags |= (PW_INVEN);
+    player_ptr->update |= (PU_COMBINATION | PU_REORDER);
+    player_ptr->window_flags |= (PW_INVENTORY);
     player_ptr->au -= total_cost;
 }

--- a/src/mind/mind-blue-mage.cpp
+++ b/src/mind/mind-blue-mage.cpp
@@ -89,7 +89,7 @@ bool do_cmd_cast_learned(PlayerType *player_ptr)
     }
 
     PlayerEnergy(player_ptr).set_player_turn_energy(100);
-    player_ptr->redraw |= PR_MANA;
+    player_ptr->redraw |= PR_MP;
     player_ptr->window_flags |= PW_PLAYER | PW_SPELL;
     return true;
 }

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -887,7 +887,7 @@ static bool try_cast_element_spell(PlayerType *player_ptr, SPELL_IDX spell_idx, 
         player_ptr->csp = std::max(0, player_ptr->csp - player_ptr->msp * 10 / (20 + randint1(10)));
 
         PlayerEnergy(player_ptr).set_player_turn_energy(100);
-        set_bits(player_ptr->redraw, PR_MANA);
+        set_bits(player_ptr->redraw, PR_MP);
         set_bits(player_ptr->window_flags, PW_PLAYER | PW_SPELL);
 
         return false;
@@ -936,7 +936,7 @@ void do_cmd_element(PlayerType *player_ptr)
     }
 
     PlayerEnergy(player_ptr).set_player_turn_energy(100);
-    set_bits(player_ptr->redraw, PR_MANA);
+    set_bits(player_ptr->redraw, PR_MP);
     set_bits(player_ptr->window_flags, PW_PLAYER | PW_SPELL);
 }
 

--- a/src/mind/mind-force-trainer.cpp
+++ b/src/mind/mind-force-trainer.cpp
@@ -89,7 +89,7 @@ bool clear_mind(PlayerType *player_ptr)
         player_ptr->csp_frac = 0;
     }
 
-    player_ptr->redraw |= (PR_MANA);
+    player_ptr->redraw |= (PR_MP);
     return true;
 }
 
@@ -176,7 +176,7 @@ bool set_tim_sh_force(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->tim_sh_touki = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;
@@ -256,7 +256,7 @@ bool shock_power(PlayerType *player_ptr)
     lite_spot(player_ptr, ty, tx);
 
     if (r_ptr->brightness_flags.has_any_of(ld_mask)) {
-        player_ptr->update |= (PU_MON_LITE);
+        player_ptr->update |= (PU_MONSTER_LITE);
     }
 
     return true;

--- a/src/mind/mind-magic-resistance.cpp
+++ b/src/mind/mind-magic-resistance.cpp
@@ -40,7 +40,7 @@ bool set_resist_magic(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->resist_magic = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;

--- a/src/mind/mind-mindcrafter.cpp
+++ b/src/mind/mind-mindcrafter.cpp
@@ -84,8 +84,8 @@ bool psychometry(PlayerType *player_ptr)
     o_ptr->feeling = feel;
     o_ptr->marked.set(OmType::TOUCHED);
 
-    set_bits(player_ptr->update, PU_COMBINE | PU_REORDER);
-    set_bits(player_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_PLAYER | PW_FLOOR_ITEM_LIST | PW_FOUND_ITEM_LIST);
+    set_bits(player_ptr->update, PU_COMBINATION | PU_REORDER);
+    set_bits(player_ptr->window_flags, PW_INVENTORY | PW_EQUIPMENT | PW_PLAYER | PW_FLOOR_ITEMS | PW_FOUND_ITEMS);
 
     bool okay = false;
     switch (o_ptr->bi_key.tval()) {

--- a/src/mind/mind-mirror-master.cpp
+++ b/src/mind/mind-mirror-master.cpp
@@ -221,7 +221,7 @@ bool set_multishadow(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->multishadow = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;
@@ -268,7 +268,7 @@ bool set_dustrobe(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->dustrobe = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;

--- a/src/mind/mind-monk.cpp
+++ b/src/mind/mind-monk.cpp
@@ -25,7 +25,7 @@ static void set_stance(PlayerType *player_ptr, const MonkStanceType new_stance)
     }
 
     player_ptr->update |= PU_BONUS;
-    player_ptr->redraw |= PR_STATE;
+    player_ptr->redraw |= PR_ACTION;
     msg_format(_("%sの構えをとった。", "You assume the %s stance."), monk_stances[enum2i(new_stance) - 1].desc);
     pc.set_monk_stance(new_stance);
 }
@@ -87,7 +87,7 @@ bool choose_monk_stance(PlayerType *player_ptr)
     }
 
     set_stance(player_ptr, new_stance);
-    player_ptr->redraw |= PR_STATE;
+    player_ptr->redraw |= PR_ACTION;
     screen_load();
     return true;
 }

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -102,7 +102,7 @@ bool kawarimi(PlayerType *player_ptr, bool success)
     if (!success && one_in_(3)) {
         msg_print(_("変わり身失敗！逃げられなかった。", "Kawarimi failed! You couldn't run away."));
         ninja_data->kawarimi = false;
-        player_ptr->redraw |= (PR_STATUS);
+        player_ptr->redraw |= (PR_TIMED_EFFECT);
         return false;
     }
 
@@ -124,7 +124,7 @@ bool kawarimi(PlayerType *player_ptr, bool success)
     }
 
     ninja_data->kawarimi = false;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
     return true;
 }
 
@@ -360,7 +360,7 @@ bool set_superstealth(PlayerType *player_ptr, bool set)
     if (!notice) {
         return false;
     }
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (disturb_state) {
         disturb(player_ptr, false, false);
@@ -409,7 +409,7 @@ bool cast_ninja_spell(PlayerType *player_ptr, MindNinjaType spell)
         if (ninja_data && !ninja_data->kawarimi) {
             msg_print(_("敵の攻撃に対して敏感になった。", "You are now prepared to evade any attacks."));
             ninja_data->kawarimi = true;
-            player_ptr->redraw |= (PR_STATUS);
+            player_ptr->redraw |= (PR_TIMED_EFFECT);
         }
 
         break;

--- a/src/mind/mind-priest.cpp
+++ b/src/mind/mind-priest.cpp
@@ -62,7 +62,7 @@ bool bless_weapon(PlayerType *player_ptr)
         set_bits(o_ptr->ident, IDENT_SENSE);
         o_ptr->feeling = FEEL_NONE;
         set_bits(player_ptr->update, PU_BONUS);
-        set_bits(player_ptr->window_flags, PW_EQUIP | PW_FLOOR_ITEM_LIST | PW_FOUND_ITEM_LIST);
+        set_bits(player_ptr->window_flags, PW_EQUIPMENT | PW_FLOOR_ITEMS | PW_FOUND_ITEMS);
     }
 
     /*
@@ -136,7 +136,7 @@ bool bless_weapon(PlayerType *player_ptr)
     }
 
     set_bits(player_ptr->update, PU_BONUS);
-    set_bits(player_ptr->window_flags, PW_EQUIP | PW_PLAYER | PW_FLOOR_ITEM_LIST | PW_FOUND_ITEM_LIST);
+    set_bits(player_ptr->window_flags, PW_EQUIPMENT | PW_PLAYER | PW_FLOOR_ITEMS | PW_FOUND_ITEMS);
     calc_android_exp(player_ptr);
     return true;
 }

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -366,7 +366,7 @@ void concentration(PlayerType *player_ptr)
         player_ptr->csp_frac = 0;
     }
 
-    player_ptr->redraw |= PR_MANA;
+    player_ptr->redraw |= PR_MP;
 }
 
 /*!
@@ -439,12 +439,12 @@ bool choose_samurai_stance(PlayerType *player_ptr)
     if (PlayerClass(player_ptr).samurai_stance_is(new_stance)) {
         msg_print(_("構え直した。", "You reassume a stance."));
     } else {
-        player_ptr->update |= (PU_BONUS | PU_MONSTERS);
+        player_ptr->update |= (PU_BONUS | PU_MONSTER_STATUSES);
         msg_format(_("%sの型で構えた。", "You assume the %s stance."), samurai_stances[enum2i(new_stance) - 1].desc);
         PlayerClass(player_ptr).set_samurai_stance(new_stance);
     }
 
-    player_ptr->redraw |= (PR_STATE | PR_STATUS);
+    player_ptr->redraw |= (PR_ACTION | PR_TIMED_EFFECT);
     screen_load();
     return true;
 }
@@ -527,5 +527,5 @@ void musou_counterattack(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
     msg_format(_("%s^に反撃した！", "You counterattacked %s!"), m_target_name.data());
     do_cmd_attack(player_ptr, monap_ptr->m_ptr->fy, monap_ptr->m_ptr->fx, HISSATSU_COUNTER);
     monap_ptr->fear = false;
-    player_ptr->redraw |= (PR_MANA);
+    player_ptr->redraw |= (PR_MP);
 }

--- a/src/mind/mind-sniper.cpp
+++ b/src/mind/mind-sniper.cpp
@@ -146,8 +146,8 @@ static bool snipe_concentrate(PlayerType *player_ptr)
     msg_format(_("集中した。(集中度 %d)", "You concentrate deeply. (lvl %d)"), sniper_data->concent);
     sniper_data->reset_concent = false;
 
-    player_ptr->update |= (PU_BONUS | PU_MONSTERS);
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->update |= (PU_BONUS | PU_MONSTER_STATUSES);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
     return true;
 }
 
@@ -170,8 +170,8 @@ void reset_concentration(PlayerType *player_ptr, bool msg)
     sniper_data->concent = 0;
     sniper_data->reset_concent = false;
 
-    player_ptr->update |= (PU_BONUS | PU_MONSTERS);
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->update |= (PU_BONUS | PU_MONSTER_STATUSES);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 }
 
 /*!
@@ -619,7 +619,7 @@ void do_cmd_snipe(PlayerType *player_ptr)
     if (!cast) {
         return;
     }
-    player_ptr->redraw |= (PR_HP | PR_MANA);
+    player_ptr->redraw |= (PR_HP | PR_MP);
     player_ptr->window_flags |= (PW_PLAYER);
     player_ptr->window_flags |= (PW_SPELL);
 }

--- a/src/mind/mind-warrior-mage.cpp
+++ b/src/mind/mind-warrior-mage.cpp
@@ -10,7 +10,7 @@ bool comvert_hp_to_mp(PlayerType *player_ptr)
     int gain_sp = take_hit(player_ptr, DAMAGE_USELIFE, player_ptr->lev, _("ＨＰからＭＰへの無謀な変換", "thoughtless conversion from HP to SP")) / 5;
     if (!gain_sp) {
         msg_print(_("変換に失敗した。", "You failed to convert."));
-        player_ptr->redraw |= (PR_HP | PR_MANA);
+        player_ptr->redraw |= (PR_HP | PR_MP);
         return true;
     }
 
@@ -20,7 +20,7 @@ bool comvert_hp_to_mp(PlayerType *player_ptr)
         player_ptr->csp_frac = 0;
     }
 
-    player_ptr->redraw |= (PR_HP | PR_MANA);
+    player_ptr->redraw |= (PR_HP | PR_MP);
     return true;
 }
 
@@ -33,6 +33,6 @@ bool comvert_mp_to_hp(PlayerType *player_ptr)
         msg_print(_("変換に失敗した。", "You failed to convert."));
     }
 
-    player_ptr->redraw |= (PR_HP | PR_MANA);
+    player_ptr->redraw |= (PR_HP | PR_MP);
     return true;
 }

--- a/src/mind/mind-weaponsmith.cpp
+++ b/src/mind/mind-weaponsmith.cpp
@@ -144,8 +144,8 @@ static void drain_essence(PlayerType *player_ptr)
 
     /* Apply autodestroy/inscription to the drained item */
     autopick_alter_item(player_ptr, item, true);
-    player_ptr->update |= (PU_COMBINE | PU_REORDER);
-    player_ptr->window_flags |= (PW_INVEN);
+    player_ptr->update |= (PU_COMBINATION | PU_REORDER);
+    player_ptr->window_flags |= (PW_INVENTORY);
 }
 
 /*!
@@ -505,8 +505,8 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
     auto effect_name = Smith::get_effect_name(effect);
 
     _(msg_format("%sに%sの能力を付加しました。", item_name.data(), effect_name), msg_format("You have added ability of %s to %s.", effect_name, item_name.data()));
-    player_ptr->update |= (PU_COMBINE | PU_REORDER);
-    player_ptr->window_flags |= (PW_INVEN);
+    player_ptr->update |= (PU_COMBINATION | PU_REORDER);
+    player_ptr->window_flags |= (PW_INVENTORY);
 }
 
 /*!
@@ -532,8 +532,8 @@ static void erase_essence(PlayerType *player_ptr)
     Smith(player_ptr).erase_essence(o_ptr);
 
     msg_print(_("エッセンスを取り去った。", "You removed all essence you have added."));
-    player_ptr->update |= (PU_COMBINE | PU_REORDER);
-    player_ptr->window_flags |= (PW_INVEN);
+    player_ptr->update |= (PU_COMBINATION | PU_REORDER);
+    player_ptr->window_flags |= (PW_INVENTORY);
 }
 
 /*!

--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -210,7 +210,7 @@ void process_eat_lite(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
         monap_ptr->obvious = true;
     }
 
-    player_ptr->window_flags |= (PW_EQUIP);
+    player_ptr->window_flags |= (PW_EQUIPMENT);
 }
 
 /*!
@@ -261,8 +261,8 @@ bool process_un_power(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
     }
 
     monap_ptr->o_ptr->pval = !is_magic_mastery || (monap_ptr->o_ptr->pval == 1) ? 0 : monap_ptr->o_ptr->pval - drain;
-    player_ptr->update |= PU_COMBINE | PU_REORDER;
-    player_ptr->window_flags |= PW_INVEN;
+    player_ptr->update |= PU_COMBINATION | PU_REORDER;
+    player_ptr->window_flags |= PW_INVENTORY;
     return true;
 }
 
@@ -326,7 +326,7 @@ void process_drain_mana(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
         player_ptr->csp_frac = 0;
     }
 
-    player_ptr->redraw |= (PR_MANA);
+    player_ptr->redraw |= (PR_MP);
 }
 
 /*!

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -388,7 +388,7 @@ void monster_death(PlayerType *player_ptr, MONSTER_IDX m_idx, bool drop_item, At
     }
 
     if (md_ptr->r_ptr->brightness_flags.has_any_of(ld_mask)) {
-        player_ptr->update |= PU_MON_LITE;
+        player_ptr->update |= PU_MONSTER_LITE;
     }
 
     write_pet_death(player_ptr, md_ptr);

--- a/src/monster-floor/monster-lite.cpp
+++ b/src/monster-floor/monster-lite.cpp
@@ -340,7 +340,7 @@ void update_mon_lite(PlayerType *player_ptr)
         floor_ptr->grid_array[y][x].info &= ~(CAVE_TEMP | CAVE_XTRA);
     }
 
-    player_ptr->update |= PU_DELAY_VIS;
+    player_ptr->update |= PU_DELAY_VISIBILITY;
     player_ptr->monlite = (floor_ptr->grid_array[player_ptr->y][player_ptr->x].info & CAVE_MNLT) != 0;
     auto ninja_data = PlayerClass(player_ptr).get_specific_data<ninja_data_type>();
     if (!ninja_data || !ninja_data->s_stealth) {

--- a/src/monster-floor/monster-object.cpp
+++ b/src/monster-floor/monster-object.cpp
@@ -156,7 +156,7 @@ static void monster_pickup_object(PlayerType *player_ptr, turn_flags *turn_flags
         o_ptr->iy = o_ptr->ix = 0;
         o_ptr->held_m_idx = m_idx;
         m_ptr->hold_o_idx_list.add(player_ptr->current_floor_ptr, this_o_idx);
-        player_ptr->window_flags |= PW_FOUND_ITEM_LIST;
+        player_ptr->window_flags |= PW_FOUND_ITEMS;
         return;
     }
 

--- a/src/monster-floor/monster-remover.cpp
+++ b/src/monster-floor/monster-remover.cpp
@@ -100,7 +100,7 @@ void delete_monster_idx(PlayerType *player_ptr, MONSTER_IDX i)
     floor_ptr->m_cnt--;
     lite_spot(player_ptr, y, x);
     if (r_ptr->brightness_flags.has_any_of(ld_mask)) {
-        player_ptr->update |= (PU_MON_LITE);
+        player_ptr->update |= (PU_MONSTER_LITE);
     }
 }
 

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -420,9 +420,9 @@ bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSI
     }
 
     if (r_ptr->brightness_flags.has_any_of(self_ld_mask)) {
-        set_bits(player_ptr->update, PU_MON_LITE);
+        set_bits(player_ptr->update, PU_MONSTER_LITE);
     } else if (r_ptr->brightness_flags.has_any_of(has_ld_mask) && !m_ptr->is_asleep()) {
-        set_bits(player_ptr->update, PU_MON_LITE);
+        set_bits(player_ptr->update, PU_MONSTER_LITE);
     }
     update_monster(player_ptr, g_ptr->m_idx, true);
 

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -360,7 +360,7 @@ void choose_new_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, bool born, Mo
 
     auto old_r_idx = m_ptr->r_idx;
     if (monraces_info[old_r_idx].brightness_flags.has_any_of(ld_mask) || r_ptr->brightness_flags.has_any_of(ld_mask)) {
-        player_ptr->update |= (PU_MON_LITE);
+        player_ptr->update |= (PU_MONSTER_LITE);
     }
 
     if (born) {

--- a/src/monster/monster-status-setter.cpp
+++ b/src/monster/monster-status-setter.cpp
@@ -134,7 +134,7 @@ bool set_monster_csleep(PlayerType *player_ptr, MONSTER_IDX m_idx, int v)
     }
 
     if (monraces_info[m_ptr->r_idx].brightness_flags.has_any_of(has_ld_mask)) {
-        player_ptr->update |= PU_MON_LITE;
+        player_ptr->update |= PU_MONSTER_LITE;
     }
 
     return true;
@@ -427,7 +427,7 @@ bool set_monster_timewalk(PlayerType *player_ptr, int num, MonsterRaceId who, bo
     }
 
     player_ptr->redraw |= PR_MAP;
-    player_ptr->update |= PU_MONSTERS;
+    player_ptr->update |= PU_MONSTER_STATUSES;
     player_ptr->window_flags |= PW_OVERHEAD | PW_DUNGEON;
     w_ptr->timewalk_m_idx = 0;
     if (vs_player || (player_has_los_bold(player_ptr, m_ptr->fy, m_ptr->fx) && projectable(player_ptr, player_ptr->y, player_ptr->x, m_ptr->fy, m_ptr->fx))) {

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -112,7 +112,7 @@ void update_player_type(PlayerType *player_ptr, turn_flags *turn_flags_ptr, Mons
     }
 
     if (turn_flags_ptr->do_move && (r_ptr->brightness_flags.has_any_of(except_has_lite) || (r_ptr->brightness_flags.has_any_of({ MonsterBrightnessType::HAS_LITE_1, MonsterBrightnessType::HAS_LITE_2 }) && !player_ptr->phase_out))) {
-        player_ptr->update |= PU_MON_LITE;
+        player_ptr->update |= PU_MONSTER_LITE;
     }
 }
 
@@ -175,7 +175,7 @@ void update_player_window(PlayerType *player_ptr, old_race_flags *old_race_flags
         (old_race_flags_ptr->old_r_blows3 != r_ptr->r_blows[3]) || (old_race_flags_ptr->old_r_cast_spell != r_ptr->r_cast_spell) ||
         (old_race_flags_ptr->old_r_behavior_flags != r_ptr->r_behavior_flags) || (old_race_flags_ptr->old_r_kind_flags != r_ptr->r_kind_flags) ||
         (old_race_flags_ptr->old_r_drop_flags != r_ptr->r_drop_flags) || (old_race_flags_ptr->old_r_feature_flags != r_ptr->r_feature_flags)) {
-        player_ptr->window_flags |= PW_MONSTER;
+        player_ptr->window_flags |= PW_MONSTER_LORE;
     }
 }
 

--- a/src/mspell/mspell-dispel.cpp
+++ b/src/mspell/mspell-dispel.cpp
@@ -96,8 +96,8 @@ static void dispel_player(PlayerType *player_ptr)
         }
 
         player_ptr->action = ACTION_NONE;
-        player_ptr->update |= (PU_BONUS | PU_HP | PU_MONSTERS);
-        player_ptr->redraw |= (PR_MAP | PR_STATUS | PR_STATE);
+        player_ptr->update |= (PU_BONUS | PU_HP | PU_MONSTER_STATUSES);
+        player_ptr->redraw |= (PR_MAP | PR_TIMED_EFFECT | PR_ACTION);
         player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
         player_ptr->energy_need += ENERGY_NEED();
     }

--- a/src/mspell/mspell-floor.cpp
+++ b/src/mspell/mspell-floor.cpp
@@ -127,7 +127,7 @@ MonsterSpellResult spell_RF6_BLINK(PlayerType *player_ptr, MONSTER_IDX m_idx, in
     teleport_away(player_ptr, m_idx, 10, TELEPORT_SPONTANEOUS);
 
     if (target_type == MONSTER_TO_PLAYER) {
-        player_ptr->update |= (PU_MONSTERS);
+        player_ptr->update |= (PU_MONSTER_STATUSES);
     }
 
     return res;

--- a/src/mspell/mspell-special.cpp
+++ b/src/mspell/mspell-special.cpp
@@ -178,7 +178,7 @@ static MonsterSpellResult spell_RF6_SPECIAL_B(PlayerType *player_ptr, POSITION y
         simple_monspell_message(player_ptr, m_idx, t_idx, msg, target_type);
 
         teleport_away(player_ptr, m_idx, 10, TELEPORT_NONMAGICAL);
-        player_ptr->update |= (PU_MONSTERS);
+        player_ptr->update |= (PU_MONSTER_STATUSES);
         return MonsterSpellResult::make_valid();
     }
 

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -473,7 +473,7 @@ void process_world_aux_mutation(PlayerType *player_ptr)
 
             hp_player(player_ptr, healing);
             player_ptr->csp -= healing;
-            player_ptr->redraw |= (PR_HP | PR_MANA);
+            player_ptr->redraw |= (PR_HP | PR_MP);
         }
     }
 
@@ -486,7 +486,7 @@ void process_world_aux_mutation(PlayerType *player_ptr)
             }
 
             player_ptr->csp += healing;
-            player_ptr->redraw |= (PR_HP | PR_MANA);
+            player_ptr->redraw |= (PR_HP | PR_MP);
             take_hit(player_ptr, DAMAGE_LOSELIFE, healing, _("頭に昇った血", "blood rushing to the head"));
         }
     }

--- a/src/object-activation/activation-others.cpp
+++ b/src/object-activation/activation-others.cpp
@@ -382,7 +382,7 @@ bool activate_protection_elbereth(PlayerType *player_ptr)
     (void)bss.set_blindness(0);
     (void)bss.hallucination(0);
     set_blessed(player_ptr, randint0(25) + 25, true);
-    set_bits(player_ptr->redraw, PR_STATS);
+    set_bits(player_ptr->redraw, PR_ABILITY_SCORE);
     return true;
 }
 

--- a/src/object-hook/hook-expendable.cpp
+++ b/src/object-hook/hook-expendable.cpp
@@ -82,8 +82,8 @@ bool can_player_destroy_object(PlayerType *player_ptr, ItemEntity *o_ptr)
 
         o_ptr->feeling = feel;
         o_ptr->ident |= IDENT_SENSE;
-        player_ptr->update |= (PU_COMBINE);
-        player_ptr->window_flags |= (PW_INVEN | PW_EQUIP);
+        player_ptr->update |= (PU_COMBINATION);
+        player_ptr->window_flags |= (PW_INVENTORY | PW_EQUIPMENT);
         return false;
     }
 

--- a/src/object-use/quaff/quaff-execution.cpp
+++ b/src/object-use/quaff/quaff-execution.cpp
@@ -61,7 +61,7 @@ void ObjectQuaffEntity::execute(INVENTORY_IDX item)
         (void)potion_smash_effect(this->player_ptr, 0, this->player_ptr->y, this->player_ptr->x, o_ref.bi_id);
     }
 
-    this->player_ptr->update |= PU_COMBINE | PU_REORDER;
+    this->player_ptr->update |= PU_COMBINATION | PU_REORDER;
     this->change_virtue_as_quaff(o_ref);
     object_tried(&o_ref);
     if (ident && !o_ref.is_aware()) {
@@ -69,7 +69,7 @@ void ObjectQuaffEntity::execute(INVENTORY_IDX item)
         gain_exp(this->player_ptr, (baseitems_info[o_ref.bi_id].level + (this->player_ptr->lev >> 1)) / this->player_ptr->lev);
     }
 
-    this->player_ptr->window_flags |= (PW_INVEN | PW_EQUIP | PW_PLAYER);
+    this->player_ptr->window_flags |= (PW_INVENTORY | PW_EQUIPMENT | PW_PLAYER);
     if (PlayerRace(this->player_ptr).equals(PlayerRaceType::SKELETON)) {
         return;
     }

--- a/src/object-use/read/read-execution.cpp
+++ b/src/object-use/read/read-execution.cpp
@@ -61,12 +61,12 @@ void ObjectReadEntity::execute(bool known)
 
     auto executor = ReadExecutorFactory::create(player_ptr, o_ptr, known);
     auto used_up = executor->read();
-    BIT_FLAGS inventory_flags = PU_COMBINE | PU_REORDER | (this->player_ptr->update & PU_AUTODESTROY);
-    reset_bits(this->player_ptr->update, PU_COMBINE | PU_REORDER | PU_AUTODESTROY);
+    BIT_FLAGS inventory_flags = PU_COMBINATION | PU_REORDER | (this->player_ptr->update & PU_AUTO_DESTRUCTION);
+    reset_bits(this->player_ptr->update, PU_COMBINATION | PU_REORDER | PU_AUTO_DESTRUCTION);
     this->change_virtue_as_read(*o_ptr);
     object_tried(o_ptr);
     this->gain_exp_from_item_use(o_ptr, executor->is_identified());
-    this->player_ptr->window_flags |= PW_INVEN | PW_EQUIP | PW_PLAYER;
+    this->player_ptr->window_flags |= PW_INVENTORY | PW_EQUIPMENT | PW_PLAYER;
     this->player_ptr->update |= inventory_flags;
     if (!used_up) {
         return;

--- a/src/object-use/read/scroll-read-executor.cpp
+++ b/src/object-use/read/scroll-read-executor.cpp
@@ -302,7 +302,7 @@ bool ScrollReadExecutor::read()
 
         msg_print(_("手が輝き始めた。", "Your hands begin to glow."));
         this->player_ptr->special_attack |= ATTACK_CONFUSE;
-        this->player_ptr->redraw |= PR_STATUS;
+        this->player_ptr->redraw |= PR_TIMED_EFFECT;
         this->ident = true;
         break;
     case SV_SCROLL_PROTECTION_FROM_EVIL: {

--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -308,8 +308,8 @@ void ObjectThrowEntity::process_boomerang_back()
         this->o_ptr = &player_ptr->inventory_list[this->item];
         this->o_ptr->copy_from(this->q_ptr);
         player_ptr->equip_cnt++;
-        player_ptr->update |= PU_BONUS | PU_TORCH | PU_MANA;
-        player_ptr->window_flags |= PW_EQUIP;
+        player_ptr->update |= PU_BONUS | PU_TORCH | PU_MP;
+        player_ptr->window_flags |= PW_EQUIPMENT;
         this->do_drop = false;
         return;
     }

--- a/src/object-use/use-execution.cpp
+++ b/src/object-use/use-execution.cpp
@@ -91,8 +91,8 @@ void ObjectUseEntity::execute()
 
         msg_print(_("この杖にはもう魔力が残っていない。", "The staff has no charges left."));
         o_ptr->ident |= IDENT_EMPTY;
-        this->player_ptr->update |= PU_COMBINE | PU_REORDER;
-        this->player_ptr->window_flags |= PW_INVEN;
+        this->player_ptr->update |= PU_COMBINATION | PU_REORDER;
+        this->player_ptr->window_flags |= PW_INVENTORY;
         return;
     }
 
@@ -109,15 +109,15 @@ void ObjectUseEntity::execute()
      * gain_exp() does not reorder the inventory before the charge
      * is deducted from the staff.
      */
-    BIT_FLAGS inventory_flags = PU_COMBINE | PU_REORDER | (this->player_ptr->update & PU_AUTODESTROY);
-    reset_bits(this->player_ptr->update, PU_COMBINE | PU_REORDER | PU_AUTODESTROY);
+    BIT_FLAGS inventory_flags = PU_COMBINATION | PU_REORDER | (this->player_ptr->update & PU_AUTO_DESTRUCTION);
+    reset_bits(this->player_ptr->update, PU_COMBINATION | PU_REORDER | PU_AUTO_DESTRUCTION);
     object_tried(o_ptr);
     if (ident && !o_ptr->is_aware()) {
         object_aware(this->player_ptr, o_ptr);
         gain_exp(this->player_ptr, (lev + (this->player_ptr->lev >> 1)) / this->player_ptr->lev);
     }
 
-    set_bits(this->player_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_PLAYER | PW_FLOOR_ITEM_LIST | PW_FOUND_ITEM_LIST);
+    set_bits(this->player_ptr->window_flags, PW_INVENTORY | PW_EQUIPMENT | PW_PLAYER | PW_FLOOR_ITEMS | PW_FOUND_ITEMS);
     set_bits(this->player_ptr->update, inventory_flags);
     if (!use_charge) {
         return;

--- a/src/object-use/zaprod-execution.cpp
+++ b/src/object-use/zaprod-execution.cpp
@@ -127,7 +127,7 @@ void ObjectZapRodEntity::execute(INVENTORY_IDX item)
         o_ptr->timeout += baseitem.pval;
     }
 
-    this->player_ptr->update |= PU_COMBINE | PU_REORDER;
+    this->player_ptr->update |= PU_COMBINATION | PU_REORDER;
     if (!(o_ptr->is_aware())) {
         chg_virtue(this->player_ptr, Virtue::PATIENCE, -1);
         chg_virtue(this->player_ptr, Virtue::CHANCE, 1);
@@ -140,7 +140,7 @@ void ObjectZapRodEntity::execute(INVENTORY_IDX item)
         gain_exp(this->player_ptr, (lev + (this->player_ptr->lev >> 1)) / this->player_ptr->lev);
     }
 
-    set_bits(this->player_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_PLAYER | PW_FLOOR_ITEM_LIST | PW_FOUND_ITEM_LIST);
+    set_bits(this->player_ptr->window_flags, PW_INVENTORY | PW_EQUIPMENT | PW_PLAYER | PW_FLOOR_ITEMS | PW_FOUND_ITEMS);
 }
 
 bool ObjectZapRodEntity::check_can_zap()

--- a/src/object-use/zapwand-execution.cpp
+++ b/src/object-use/zapwand-execution.cpp
@@ -95,8 +95,8 @@ void ObjectZapWandEntity::execute(INVENTORY_IDX item)
 
         msg_print(_("この魔法棒にはもう魔力が残っていない。", "The wand has no charges left."));
         o_ptr->ident |= IDENT_EMPTY;
-        this->player_ptr->update |= PU_COMBINE | PU_REORDER;
-        this->player_ptr->window_flags |= PW_INVEN;
+        this->player_ptr->update |= PU_COMBINATION | PU_REORDER;
+        this->player_ptr->window_flags |= PW_INVENTORY;
         return;
     }
 
@@ -108,8 +108,8 @@ void ObjectZapWandEntity::execute(INVENTORY_IDX item)
      * gain_exp() does not reorder the inventory before the charge
      * is deducted from the wand.
      */
-    BIT_FLAGS inventory_flags = (PU_COMBINE | PU_REORDER | (this->player_ptr->update & PU_AUTODESTROY));
-    reset_bits(this->player_ptr->update, PU_COMBINE | PU_REORDER | PU_AUTODESTROY);
+    BIT_FLAGS inventory_flags = (PU_COMBINATION | PU_REORDER | (this->player_ptr->update & PU_AUTO_DESTRUCTION));
+    reset_bits(this->player_ptr->update, PU_COMBINATION | PU_REORDER | PU_AUTO_DESTRUCTION);
     if (!(o_ptr->is_aware())) {
         chg_virtue(this->player_ptr, Virtue::PATIENCE, -1);
         chg_virtue(this->player_ptr, Virtue::CHANCE, 1);
@@ -122,7 +122,7 @@ void ObjectZapWandEntity::execute(INVENTORY_IDX item)
         gain_exp(this->player_ptr, (lev + (this->player_ptr->lev >> 1)) / this->player_ptr->lev);
     }
 
-    set_bits(this->player_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_PLAYER | PW_FLOOR_ITEM_LIST | PW_FOUND_ITEM_LIST);
+    set_bits(this->player_ptr->window_flags, PW_INVENTORY | PW_EQUIPMENT | PW_PLAYER | PW_FLOOR_ITEMS | PW_FOUND_ITEMS);
     set_bits(this->player_ptr->update, inventory_flags);
     o_ptr->pval--;
     if (item >= 0) {

--- a/src/object/lite-processor.cpp
+++ b/src/object/lite-processor.cpp
@@ -48,7 +48,7 @@ void reduce_lite_life(PlayerType *player_ptr)
 void notice_lite_change(PlayerType *player_ptr, ItemEntity *o_ptr)
 {
     if ((o_ptr->fuel < 100) || (!(o_ptr->fuel % 100))) {
-        player_ptr->window_flags |= (PW_EQUIP);
+        player_ptr->window_flags |= (PW_EQUIPMENT);
     }
 
     if (player_ptr->effects()->blindness()->is_blind()) {

--- a/src/perception/simple-perception.cpp
+++ b/src/perception/simple-perception.cpp
@@ -118,8 +118,8 @@ static void sense_inventory_aux(PlayerType *player_ptr, INVENTORY_IDX slot, bool
     o_ptr->feeling = feel;
 
     autopick_alter_item(player_ptr, slot, destroy_feeling);
-    player_ptr->update |= (PU_COMBINE | PU_REORDER);
-    player_ptr->window_flags |= (PW_INVEN | PW_EQUIP);
+    player_ptr->update |= (PU_COMBINATION | PU_REORDER);
+    player_ptr->window_flags |= (PW_INVENTORY | PW_EQUIPMENT);
 }
 
 /*!

--- a/src/pet/pet-fall-off.cpp
+++ b/src/pet/pet-fall-off.cpp
@@ -160,7 +160,7 @@ bool process_fall_off_horse(PlayerType *player_ptr, int dam, bool force)
     player_ptr->pet_extra_flags &= ~(PF_TWO_HANDS);
     player_ptr->riding_ryoute = player_ptr->old_riding_ryoute = false;
 
-    player_ptr->update |= (PU_BONUS | PU_VIEW | PU_LITE | PU_FLOW | PU_MON_LITE | PU_MONSTERS);
+    player_ptr->update |= (PU_BONUS | PU_VIEW | PU_LITE | PU_FLOW | PU_MONSTER_LITE | PU_MONSTER_STATUSES);
     handle_stuff(player_ptr);
 
     player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);

--- a/src/player-attack/attack-chaos-effect.cpp
+++ b/src/player-attack/attack-chaos-effect.cpp
@@ -54,7 +54,7 @@ static void attack_confuse(PlayerType *player_ptr, player_attack_type *pa_ptr, b
     if (player_ptr->special_attack & ATTACK_CONFUSE) {
         player_ptr->special_attack &= ~(ATTACK_CONFUSE);
         msg_print(_("手の輝きがなくなった。", "Your hands stop glowing."));
-        player_ptr->redraw |= (PR_STATUS);
+        player_ptr->redraw |= (PR_TIMED_EFFECT);
     }
 
     auto *r_ptr = pa_ptr->r_ptr;
@@ -149,7 +149,7 @@ static void attack_dispel(PlayerType *player_ptr, player_attack_type *pa_ptr)
 
     auto sp = damroll(dd, 8);
     player_ptr->csp = std::min(player_ptr->msp, player_ptr->csp + sp);
-    set_bits(player_ptr->redraw, PR_MANA);
+    set_bits(player_ptr->redraw, PR_MP);
 }
 
 /*!

--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -396,9 +396,9 @@ bool PlayerClass::lose_balance()
 
     this->set_samurai_stance(SamuraiStanceType::NONE);
     this->player_ptr->update |= PU_BONUS;
-    this->player_ptr->update |= PU_MONSTERS;
-    this->player_ptr->redraw |= PR_STATE;
-    this->player_ptr->redraw |= PR_STATUS;
+    this->player_ptr->update |= PU_MONSTER_STATUSES;
+    this->player_ptr->redraw |= PR_ACTION;
+    this->player_ptr->redraw |= PR_TIMED_EFFECT;
     this->player_ptr->action = ACTION_NONE;
     return true;
 }

--- a/src/player-status/player-basic-statistics.cpp
+++ b/src/player-status/player-basic-statistics.cpp
@@ -107,7 +107,7 @@ void PlayerBasicStatistics::update_top_status()
 
     if (this->player_ptr->stat_top[status] != top) {
         this->player_ptr->stat_top[status] = (int16_t)top;
-        set_bits(this->player_ptr->redraw, PR_STATS);
+        set_bits(this->player_ptr->redraw, PR_ABILITY_SCORE);
         set_bits(this->player_ptr->window_flags, PW_PLAYER);
     }
 }
@@ -140,7 +140,7 @@ void PlayerBasicStatistics::update_use_status()
 
     if (this->player_ptr->stat_use[status] != use) {
         this->player_ptr->stat_use[status] = (int16_t)use;
-        set_bits(this->player_ptr->redraw, PR_STATS);
+        set_bits(this->player_ptr->redraw, PR_ABILITY_SCORE);
         set_bits(this->player_ptr->window_flags, PW_PLAYER);
     }
 }
@@ -173,15 +173,15 @@ void PlayerBasicStatistics::update_index_status()
         set_bits(this->player_ptr->update, PU_HP);
     } else if (status == A_INT) {
         if (mp_ptr->spell_stat == A_INT) {
-            set_bits(this->player_ptr->update, (PU_MANA | PU_SPELLS));
+            set_bits(this->player_ptr->update, (PU_MP | PU_SPELLS));
         }
     } else if (status == A_WIS) {
         if (mp_ptr->spell_stat == A_WIS) {
-            set_bits(this->player_ptr->update, (PU_MANA | PU_SPELLS));
+            set_bits(this->player_ptr->update, (PU_MP | PU_SPELLS));
         }
     } else if (status == A_CHR) {
         if (mp_ptr->spell_stat == A_CHR) {
-            set_bits(this->player_ptr->update, (PU_MANA | PU_SPELLS));
+            set_bits(this->player_ptr->update, (PU_MP | PU_SPELLS));
         }
     }
 

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -134,7 +134,7 @@ static bool acid_minus_ac(PlayerType *player_ptr)
     msg_format(_("%sが酸で腐食した！", "Your %s is corroded!"), item_name.data());
     o_ptr->to_a--;
     player_ptr->update |= PU_BONUS;
-    player_ptr->window_flags |= PW_EQUIP | PW_PLAYER;
+    player_ptr->window_flags |= PW_EQUIPMENT | PW_PLAYER;
     calc_android_exp(player_ptr);
     return true;
 }

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -176,7 +176,7 @@ bool move_player_effect(PlayerType *player_ptr, POSITION ny, POSITION nx, BIT_FL
             player_ptr->redraw |= PR_MAP;
         }
 
-        player_ptr->update |= PU_VIEW | PU_LITE | PU_FLOW | PU_MON_LITE | PU_DISTANCE;
+        player_ptr->update |= PU_VIEW | PU_LITE | PU_FLOW | PU_MONSTER_LITE | PU_DISTANCE;
         player_ptr->window_flags |= PW_OVERHEAD | PW_DUNGEON;
         if ((!player_ptr->effects()->blindness()->is_blind() && !no_lite(player_ptr)) || !is_trap(player_ptr, g_ptr->feat)) {
             g_ptr->info &= ~(CAVE_UNSAFE);
@@ -234,7 +234,7 @@ bool move_player_effect(PlayerType *player_ptr, POSITION ny, POSITION nx, BIT_FL
 
     if (!player_ptr->running) {
         // 自動拾い/自動破壊により床上のアイテムリストが変化した可能性があるので表示を更新
-        set_bits(player_ptr->window_flags, PW_FLOOR_ITEM_LIST | PW_FOUND_ITEM_LIST);
+        set_bits(player_ptr->window_flags, PW_FLOOR_ITEMS | PW_FOUND_ITEMS);
         window_stuff(player_ptr);
     }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -378,11 +378,11 @@ static void update_bonuses(PlayerType *player_ptr)
     player_ptr->dis_to_a = calc_to_ac(player_ptr, false);
 
     if (old_mighty_throw != player_ptr->mighty_throw) {
-        player_ptr->window_flags |= PW_INVEN;
+        player_ptr->window_flags |= PW_INVENTORY;
     }
 
     if (player_ptr->telepathy != old_telepathy) {
-        set_bits(player_ptr->update, PU_MONSTERS);
+        set_bits(player_ptr->update, PU_MONSTER_STATUSES);
     }
 
     auto is_esp_updated = player_ptr->esp_animal != old_esp_animal;
@@ -398,11 +398,11 @@ static void update_bonuses(PlayerType *player_ptr)
     is_esp_updated |= player_ptr->esp_nonliving != old_esp_nonliving;
     is_esp_updated |= player_ptr->esp_unique != old_esp_unique;
     if (is_esp_updated) {
-        set_bits(player_ptr->update, PU_MONSTERS);
+        set_bits(player_ptr->update, PU_MONSTER_STATUSES);
     }
 
     if (player_ptr->see_inv != old_see_inv) {
-        set_bits(player_ptr->update, PU_MONSTERS);
+        set_bits(player_ptr->update, PU_MONSTER_STATUSES);
     }
 
     if (player_ptr->pspeed != old_speed) {
@@ -410,7 +410,7 @@ static void update_bonuses(PlayerType *player_ptr)
     }
 
     if ((player_ptr->dis_ac != old_dis_ac) || (player_ptr->dis_to_a != old_dis_to_a)) {
-        set_bits(player_ptr->redraw, PR_ARMOR);
+        set_bits(player_ptr->redraw, PR_AC);
         set_bits(player_ptr->window_flags, PW_PLAYER);
     }
 
@@ -772,7 +772,7 @@ static void update_num_of_spells(PlayerType *player_ptr)
 
     player_ptr->old_spells = player_ptr->new_spells;
     set_bits(player_ptr->redraw, PR_STUDY);
-    set_bits(player_ptr->window_flags, PW_OBJECT);
+    set_bits(player_ptr->window_flags, PW_ITEM_KNOWLEDGTE);
 }
 
 /*!
@@ -799,7 +799,7 @@ static void update_max_mana(PlayerType *player_ptr)
     } else {
         if (mp_ptr->spell_first > player_ptr->lev) {
             player_ptr->msp = 0;
-            set_bits(player_ptr->redraw, PR_MANA);
+            set_bits(player_ptr->redraw, PR_MP);
             return;
         }
 
@@ -1002,7 +1002,7 @@ static void update_max_mana(PlayerType *player_ptr)
         }
 #endif
         player_ptr->msp = msp;
-        set_bits(player_ptr->redraw, PR_MANA);
+        set_bits(player_ptr->redraw, PR_MP);
         set_bits(player_ptr->window_flags, (PW_PLAYER | PW_SPELL));
     }
 
@@ -2675,13 +2675,13 @@ void update_creature(PlayerType *player_ptr)
     }
 
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    if (any_bits(player_ptr->update, (PU_AUTODESTROY))) {
-        reset_bits(player_ptr->update, PU_AUTODESTROY);
+    if (any_bits(player_ptr->update, (PU_AUTO_DESTRUCTION))) {
+        reset_bits(player_ptr->update, PU_AUTO_DESTRUCTION);
         autopick_delayed_alter(player_ptr);
     }
 
-    if (any_bits(player_ptr->update, (PU_COMBINE))) {
-        reset_bits(player_ptr->update, PU_COMBINE);
+    if (any_bits(player_ptr->update, (PU_COMBINATION))) {
+        reset_bits(player_ptr->update, PU_COMBINATION);
         combine_pack(player_ptr);
     }
 
@@ -2709,8 +2709,8 @@ void update_creature(PlayerType *player_ptr)
         update_max_hitpoints(player_ptr);
     }
 
-    if (any_bits(player_ptr->update, (PU_MANA))) {
-        reset_bits(player_ptr->update, PU_MANA);
+    if (any_bits(player_ptr->update, (PU_MP))) {
+        reset_bits(player_ptr->update, PU_MP);
         update_max_mana(player_ptr);
     }
 
@@ -2756,18 +2756,18 @@ void update_creature(PlayerType *player_ptr)
         update_monsters(player_ptr, true);
     }
 
-    if (any_bits(player_ptr->update, (PU_MON_LITE))) {
-        reset_bits(player_ptr->update, PU_MON_LITE);
+    if (any_bits(player_ptr->update, (PU_MONSTER_LITE))) {
+        reset_bits(player_ptr->update, PU_MONSTER_LITE);
         update_mon_lite(player_ptr);
     }
 
-    if (any_bits(player_ptr->update, (PU_DELAY_VIS))) {
-        reset_bits(player_ptr->update, PU_DELAY_VIS);
+    if (any_bits(player_ptr->update, (PU_DELAY_VISIBILITY))) {
+        reset_bits(player_ptr->update, PU_DELAY_VISIBILITY);
         delayed_visual_update(player_ptr);
     }
 
-    if (any_bits(player_ptr->update, (PU_MONSTERS))) {
-        reset_bits(player_ptr->update, PU_MONSTERS);
+    if (any_bits(player_ptr->update, (PU_MONSTER_STATUSES))) {
+        reset_bits(player_ptr->update, PU_MONSTER_STATUSES);
         update_monsters(player_ptr, false);
     }
 }
@@ -2887,8 +2887,8 @@ void check_experience(PlayerType *player_ptr)
     PLAYER_LEVEL old_lev = player_ptr->lev;
     while ((player_ptr->lev > 1) && (player_ptr->exp < ((android ? player_exp_a : player_exp)[player_ptr->lev - 2] * player_ptr->expfact / 100L))) {
         player_ptr->lev--;
-        set_bits(player_ptr->update, PU_BONUS | PU_HP | PU_MANA | PU_SPELLS);
-        set_bits(player_ptr->redraw, PR_LEV | PR_TITLE);
+        set_bits(player_ptr->update, PU_BONUS | PU_HP | PU_MP | PU_SPELLS);
+        set_bits(player_ptr->redraw, PR_LEVEL | PR_TITLE);
         set_bits(player_ptr->window_flags, PW_PLAYER);
         handle_stuff(player_ptr);
     }
@@ -2916,9 +2916,9 @@ void check_experience(PlayerType *player_ptr)
 
         sound(SOUND_LEVEL);
         msg_format(_("レベル %d にようこそ。", "Welcome to level %d."), player_ptr->lev);
-        set_bits(player_ptr->update, (PU_BONUS | PU_HP | PU_MANA | PU_SPELLS));
-        set_bits(player_ptr->redraw, (PR_LEV | PR_TITLE | PR_EXP));
-        set_bits(player_ptr->window_flags, (PW_PLAYER | PW_SPELL | PW_INVEN));
+        set_bits(player_ptr->update, (PU_BONUS | PU_HP | PU_MP | PU_SPELLS));
+        set_bits(player_ptr->redraw, (PR_LEVEL | PR_TITLE | PR_EXP));
+        set_bits(player_ptr->window_flags, (PW_PLAYER | PW_SPELL | PW_INVENTORY));
         player_ptr->level_up_message = true;
         handle_stuff(player_ptr);
 
@@ -2977,8 +2977,8 @@ void check_experience(PlayerType *player_ptr)
             level_reward = false;
         }
 
-        set_bits(player_ptr->update, PU_BONUS | PU_HP | PU_MANA | PU_SPELLS);
-        set_bits(player_ptr->redraw, (PR_LEV | PR_TITLE));
+        set_bits(player_ptr->update, PU_BONUS | PU_HP | PU_MP | PU_SPELLS);
+        set_bits(player_ptr->redraw, (PR_LEVEL | PR_TITLE));
         set_bits(player_ptr->window_flags, (PW_PLAYER | PW_SPELL));
         handle_stuff(player_ptr);
     }

--- a/src/player/player-view.cpp
+++ b/src/player/player-view.cpp
@@ -379,5 +379,5 @@ void update_view(PlayerType *player_ptr)
         cave_redraw_later(floor_ptr, py, px);
     }
 
-    player_ptr->update |= PU_DELAY_VIS;
+    player_ptr->update |= PU_DELAY_VISIBILITY;
 }

--- a/src/racial/racial-kutar.cpp
+++ b/src/racial/racial-kutar.cpp
@@ -40,7 +40,7 @@ bool set_leveling(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->tsubureru = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;

--- a/src/realm/realm-chaos.cpp
+++ b/src/realm/realm-chaos.cpp
@@ -126,7 +126,7 @@ std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spel
                 if (!(player_ptr->special_attack & ATTACK_CONFUSE)) {
                     msg_print(_("あなたの手は光り始めた。", "Your hands start glowing."));
                     player_ptr->special_attack |= ATTACK_CONFUSE;
-                    player_ptr->redraw |= (PR_STATUS);
+                    player_ptr->redraw |= (PR_TIMED_EFFECT);
                 }
             }
         }

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -724,7 +724,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
                     set_action(player_ptr, ACTION_NONE);
                 }
 
-                player_ptr->update |= (PU_BONUS | PU_HP | PU_MANA | PU_SPELLS);
+                player_ptr->update |= (PU_BONUS | PU_HP | PU_MP | PU_SPELLS);
                 player_ptr->redraw |= (PR_EXTRA);
 
                 return "";
@@ -956,8 +956,8 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
     }
 
     if (!info) {
-        player_ptr->update |= (PU_BONUS | PU_HP | PU_MANA | PU_SPELLS);
-        player_ptr->redraw |= (PR_EXTRA | PR_HP | PR_MANA);
+        player_ptr->update |= (PU_BONUS | PU_HP | PU_MP | PU_SPELLS);
+        player_ptr->redraw |= (PR_EXTRA | PR_HP | PR_MP);
     }
 
     return "";

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -426,7 +426,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                     lite_spot(player_ptr, ty, tx);
 
                     if (monraces_info[m_ptr->r_idx].brightness_flags.has_any_of(ld_mask)) {
-                        player_ptr->update |= (PU_MON_LITE);
+                        player_ptr->update |= (PU_MONSTER_LITE);
                     }
                 }
             }
@@ -951,7 +951,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 }
                 command_dir = 0;
 
-                player_ptr->redraw |= PR_MANA;
+                player_ptr->redraw |= PR_MP;
                 handle_stuff(player_ptr);
             } while (player_ptr->csp > mana_cost_per_monster);
 

--- a/src/realm/realm-song.cpp
+++ b/src/realm/realm-song.cpp
@@ -46,7 +46,7 @@ static void start_singing(PlayerType *player_ptr, SPELL_IDX spell, int32_t song)
     set_action(player_ptr, ACTION_SING);
 
     player_ptr->update |= (PU_BONUS);
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 }
 
 /*!
@@ -1092,7 +1092,7 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
             msg_print(_("フィンゴルフィンの冥王への挑戦を歌った．．．", "You recall the valor of Fingolfin's challenge to the Dark Lord..."));
 
             player_ptr->redraw |= (PR_MAP);
-            player_ptr->update |= (PU_MONSTERS);
+            player_ptr->update |= (PU_MONSTER_STATUSES);
             player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
 
             start_singing(player_ptr, spell, MUSIC_INVULN);
@@ -1103,7 +1103,7 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
                 msg_print(_("無敵ではなくなった。", "The invulnerability wears off."));
 
                 player_ptr->redraw |= (PR_MAP);
-                player_ptr->update |= (PU_MONSTERS);
+                player_ptr->update |= (PU_MONSTER_STATUSES);
                 player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
             }
         }

--- a/src/save/floor-writer.cpp
+++ b/src/save/floor-writer.cpp
@@ -156,8 +156,8 @@ bool wr_dungeon(PlayerType *player_ptr)
     forget_lite(player_ptr->current_floor_ptr);
     forget_view(player_ptr->current_floor_ptr);
     clear_mon_lite(player_ptr->current_floor_ptr);
-    player_ptr->update |= PU_VIEW | PU_LITE | PU_MON_LITE;
-    player_ptr->update |= PU_MONSTERS | PU_DISTANCE | PU_FLOW;
+    player_ptr->update |= PU_VIEW | PU_LITE | PU_MONSTER_LITE;
+    player_ptr->update |= PU_MONSTER_STATUSES | PU_DISTANCE | PU_FLOW;
     wr_s16b(max_floor_id);
     wr_byte((byte)player_ptr->dungeon_idx);
     if (!player_ptr->floor_id) {

--- a/src/specific-object/death-scythe.cpp
+++ b/src/specific-object/death-scythe.cpp
@@ -113,7 +113,7 @@ static void compensate_death_scythe_reflection_magnification(PlayerType *player_
 
     if (!PlayerClass(player_ptr).equals(PlayerClassType::SAMURAI) && (death_scythe_flags.has(TR_FORCE_WEAPON)) && (player_ptr->csp > (player_ptr->msp / 30))) {
         player_ptr->csp -= (1 + (player_ptr->msp / 30));
-        player_ptr->redraw |= (PR_MANA);
+        player_ptr->redraw |= (PR_MP);
         *magnification = *magnification * 3 / 2 + 20;
     }
 }

--- a/src/specific-object/stone-of-lore.cpp
+++ b/src/specific-object/stone-of-lore.cpp
@@ -55,7 +55,7 @@ void StoneOfLore::consume_mp()
 
     if (this->player_ptr->csp >= 20) {
         this->player_ptr->csp -= 20;
-        set_bits(this->player_ptr->redraw, PR_MANA);
+        set_bits(this->player_ptr->redraw, PR_MP);
         return;
     }
 
@@ -66,5 +66,5 @@ void StoneOfLore::consume_mp()
     BadStatusSetter bss(this->player_ptr);
     (void)bss.mod_paralysis(randint1(5 * oops + 1));
     (void)bss.mod_confusion(randint1(5 * oops + 1));
-    set_bits(this->player_ptr->redraw, PR_MANA);
+    set_bits(this->player_ptr->redraw, PR_MP);
 }

--- a/src/specific-object/torch.cpp
+++ b/src/specific-object/torch.cpp
@@ -163,7 +163,7 @@ void update_lite_radius(PlayerType *player_ptr)
         return;
     }
 
-    player_ptr->update |= PU_LITE | PU_MON_LITE | PU_MONSTERS;
+    player_ptr->update |= PU_LITE | PU_MONSTER_LITE | PU_MONSTER_STATUSES;
     player_ptr->old_lite = player_ptr->cur_lite;
 
     if (player_ptr->cur_lite > 0) {
@@ -337,5 +337,5 @@ void update_lite(PlayerType *player_ptr)
         cave_redraw_later(floor_ptr, y, x);
     }
 
-    player_ptr->update |= PU_DELAY_VIS;
+    player_ptr->update |= PU_DELAY_VISIBILITY;
 }

--- a/src/spell-class/spells-mirror-master.cpp
+++ b/src/spell-class/spells-mirror-master.cpp
@@ -170,7 +170,7 @@ bool SpellsMirrorMaster::mirror_concentration()
         this->player_ptr->csp_frac = 0;
     }
 
-    set_bits(this->player_ptr->redraw, PR_MANA);
+    set_bits(this->player_ptr->redraw, PR_MP);
     return true;
 }
 

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -374,7 +374,7 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
         }
     }
 
-    player_ptr->update |= (PU_UN_VIEW | PU_UN_LITE | PU_VIEW | PU_LITE | PU_FLOW | PU_MON_LITE | PU_MONSTERS);
+    player_ptr->update |= (PU_UN_VIEW | PU_UN_LITE | PU_VIEW | PU_LITE | PU_FLOW | PU_MONSTER_LITE | PU_MONSTER_STATUSES);
     player_ptr->redraw |= (PR_HEALTH | PR_UHEALTH | PR_MAP);
     player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
     if (floor_ptr->grid_array[player_ptr->y][player_ptr->x].info & CAVE_GLOW) {

--- a/src/spell-kind/spells-curse-removal.cpp
+++ b/src/spell-kind/spells-curse-removal.cpp
@@ -39,7 +39,7 @@ static int exe_curse_removal(PlayerType *player_ptr, int all)
         o_ptr->feeling = FEEL_NONE;
 
         player_ptr->update |= (PU_BONUS);
-        player_ptr->window_flags |= (PW_EQUIP);
+        player_ptr->window_flags |= (PW_EQUIPMENT);
         count++;
     }
 

--- a/src/spell-kind/spells-detection.cpp
+++ b/src/spell-kind/spells-detection.cpp
@@ -262,7 +262,7 @@ bool detect_objects_normal(PlayerType *player_ptr, POSITION range)
         detect = false;
     }
     if (detect) {
-        player_ptr->window_flags |= PW_FOUND_ITEM_LIST;
+        player_ptr->window_flags |= PW_FOUND_ITEMS;
         msg_print(_("アイテムの存在を感じとった！", "You sense the presence of objects!"));
     }
 
@@ -325,7 +325,7 @@ bool detect_objects_magic(PlayerType *player_ptr, POSITION range)
     }
 
     if (detect) {
-        player_ptr->window_flags |= PW_FOUND_ITEM_LIST;
+        player_ptr->window_flags |= PW_FOUND_ITEMS;
         msg_print(_("魔法のアイテムの存在を感じとった！", "You sense the presence of magic objects!"));
     }
 
@@ -405,7 +405,7 @@ bool detect_monsters_invis(PlayerType *player_ptr, POSITION range)
 
         if (r_ptr->flags2 & RF2_INVISIBLE) {
             if (player_ptr->monster_race_idx == m_ptr->r_idx) {
-                player_ptr->window_flags |= (PW_MONSTER);
+                player_ptr->window_flags |= (PW_MONSTER_LORE);
             }
 
             m_ptr->mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
@@ -455,7 +455,7 @@ bool detect_monsters_evil(PlayerType *player_ptr, POSITION range)
             if (m_ptr->is_original_ap()) {
                 r_ptr->r_kind_flags.set(MonsterKindType::EVIL);
                 if (player_ptr->monster_race_idx == m_ptr->r_idx) {
-                    player_ptr->window_flags |= (PW_MONSTER);
+                    player_ptr->window_flags |= (PW_MONSTER_LORE);
                 }
             }
 
@@ -499,7 +499,7 @@ bool detect_monsters_nonliving(PlayerType *player_ptr, POSITION range)
 
         if (!monster_living(m_ptr->r_idx)) {
             if (player_ptr->monster_race_idx == m_ptr->r_idx) {
-                player_ptr->window_flags |= (PW_MONSTER);
+                player_ptr->window_flags |= (PW_MONSTER_LORE);
             }
 
             m_ptr->mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
@@ -544,7 +544,7 @@ bool detect_monsters_mind(PlayerType *player_ptr, POSITION range)
 
         if (!(r_ptr->flags2 & RF2_EMPTY_MIND)) {
             if (player_ptr->monster_race_idx == m_ptr->r_idx) {
-                player_ptr->window_flags |= (PW_MONSTER);
+                player_ptr->window_flags |= (PW_MONSTER_LORE);
             }
 
             m_ptr->mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });
@@ -590,7 +590,7 @@ bool detect_monsters_string(PlayerType *player_ptr, POSITION range, concptr Matc
 
         if (angband_strchr(Match, r_ptr->d_char)) {
             if (player_ptr->monster_race_idx == m_ptr->r_idx) {
-                player_ptr->window_flags |= (PW_MONSTER);
+                player_ptr->window_flags |= (PW_MONSTER_LORE);
             }
 
             m_ptr->mflag2.set({ MonsterConstantFlagType::MARK, MonsterConstantFlagType::SHOW });

--- a/src/spell-kind/spells-equipment.cpp
+++ b/src/spell-kind/spells-equipment.cpp
@@ -120,7 +120,7 @@ bool apply_disenchant(PlayerType *player_ptr, BIT_FLAGS mode)
     chg_virtue(player_ptr, Virtue::HARMONY, 1);
     chg_virtue(player_ptr, Virtue::ENCHANT, -2);
     player_ptr->update |= (PU_BONUS);
-    player_ptr->window_flags |= (PW_EQUIP | PW_PLAYER);
+    player_ptr->window_flags |= (PW_EQUIPMENT | PW_PLAYER);
 
     calc_android_exp(player_ptr);
     return true;

--- a/src/spell-kind/spells-fetcher.cpp
+++ b/src/spell-kind/spells-fetcher.cpp
@@ -154,7 +154,7 @@ bool fetch_monster(PlayerType *player_ptr)
     lite_spot(player_ptr, target_row, target_col);
     lite_spot(player_ptr, ty, tx);
     if (monraces_info[m_ptr->r_idx].brightness_flags.has_any_of(ld_mask)) {
-        player_ptr->update |= (PU_MON_LITE);
+        player_ptr->update |= (PU_MONSTER_LITE);
     }
 
     if (m_ptr->ml) {

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -121,9 +121,9 @@ void wiz_lite(PlayerType *player_ptr, bool ninja)
         }
     }
 
-    player_ptr->update |= (PU_MONSTERS);
+    player_ptr->update |= (PU_MONSTER_STATUSES);
     player_ptr->redraw |= (PR_MAP);
-    player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON | PW_FOUND_ITEM_LIST);
+    player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON | PW_FOUND_ITEMS);
 
     if (player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x].info & CAVE_GLOW) {
         set_superstealth(player_ptr, false);
@@ -178,10 +178,10 @@ void wiz_dark(PlayerType *player_ptr)
     forget_travel_flow(player_ptr->current_floor_ptr);
 
     player_ptr->update |= (PU_UN_VIEW | PU_UN_LITE);
-    player_ptr->update |= (PU_VIEW | PU_LITE | PU_MON_LITE);
-    player_ptr->update |= (PU_MONSTERS);
+    player_ptr->update |= (PU_VIEW | PU_LITE | PU_MONSTER_LITE);
+    player_ptr->update |= (PU_MONSTER_STATUSES);
     player_ptr->redraw |= (PR_MAP);
-    player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON | PW_FOUND_ITEM_LIST);
+    player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON | PW_FOUND_ITEMS);
 }
 
 /*
@@ -467,7 +467,7 @@ bool destroy_area(PlayerType *player_ptr, POSITION y1, POSITION x1, POSITION r, 
     forget_flow(floor_ptr);
 
     /* Mega-Hack -- Forget the view and lite */
-    player_ptr->update |= (PU_UN_VIEW | PU_UN_LITE | PU_VIEW | PU_LITE | PU_FLOW | PU_MON_LITE | PU_MONSTERS);
+    player_ptr->update |= (PU_UN_VIEW | PU_UN_LITE | PU_VIEW | PU_LITE | PU_FLOW | PU_MONSTER_LITE | PU_MONSTER_STATUSES);
     player_ptr->redraw |= (PR_MAP);
     player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
 

--- a/src/spell-kind/spells-perception.cpp
+++ b/src/spell-kind/spells-perception.cpp
@@ -70,8 +70,8 @@ bool identify_item(PlayerType *player_ptr, ItemEntity *o_ptr)
     object_known(o_ptr);
     o_ptr->marked.set(OmType::TOUCHED);
 
-    set_bits(player_ptr->update, PU_BONUS | PU_COMBINE | PU_REORDER);
-    set_bits(player_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_PLAYER | PW_FLOOR_ITEM_LIST | PW_FOUND_ITEM_LIST);
+    set_bits(player_ptr->update, PU_BONUS | PU_COMBINATION | PU_REORDER);
+    set_bits(player_ptr->window_flags, PW_INVENTORY | PW_EQUIPMENT | PW_PLAYER | PW_FLOOR_ITEMS | PW_FOUND_ITEMS);
 
     angband_strcpy(record_o_name, known_item_name.data(), MAX_NLEN);
     record_turn = w_ptr->game_turn;
@@ -177,9 +177,9 @@ bool identify_fully(PlayerType *player_ptr, bool only_equip)
     o_ptr->ident |= (IDENT_FULL_KNOWN);
 
     /* Refrect item informaiton onto subwindows without updating inventory */
-    player_ptr->update &= ~(PU_COMBINE | PU_REORDER);
+    player_ptr->update &= ~(PU_COMBINATION | PU_REORDER);
     handle_stuff(player_ptr);
-    player_ptr->update |= (PU_COMBINE | PU_REORDER);
+    player_ptr->update |= (PU_COMBINATION | PU_REORDER);
 
     const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
     if (item >= INVEN_MAIN_HAND) {

--- a/src/spell-kind/spells-teleport.cpp
+++ b/src/spell-kind/spells-teleport.cpp
@@ -196,7 +196,7 @@ bool teleport_away(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION dis, tele
     lite_spot(player_ptr, ny, nx);
 
     if (monraces_info[m_ptr->r_idx].brightness_flags.has_any_of(ld_mask)) {
-        player_ptr->update |= (PU_MON_LITE);
+        player_ptr->update |= (PU_MONSTER_LITE);
     }
 
     return true;
@@ -277,7 +277,7 @@ void teleport_monster_to(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION ty,
     lite_spot(player_ptr, ny, nx);
 
     if (monraces_info[m_ptr->r_idx].brightness_flags.has_any_of(ld_mask)) {
-        player_ptr->update |= (PU_MON_LITE);
+        player_ptr->update |= (PU_MONSTER_LITE);
     }
 }
 

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -359,13 +359,13 @@ void reserve_alter_reality(PlayerType *player_ptr, TIME_EFFECT turns)
     if (player_ptr->alter_reality || turns == 0) {
         player_ptr->alter_reality = 0;
         msg_print(_("景色が元に戻った...", "The view around you returns to normal..."));
-        player_ptr->redraw |= PR_STATUS;
+        player_ptr->redraw |= PR_TIMED_EFFECT;
         return;
     }
 
     player_ptr->alter_reality = turns;
     msg_print(_("回りの景色が変わり始めた...", "The view around you begins to change..."));
-    player_ptr->redraw |= PR_STATUS;
+    player_ptr->redraw |= PR_TIMED_EFFECT;
 }
 
 /*!
@@ -469,7 +469,7 @@ bool recall_player(PlayerType *player_ptr, TIME_EFFECT turns)
     if (player_ptr->word_recall || turns == 0) {
         player_ptr->word_recall = 0;
         msg_print(_("張りつめた大気が流れ去った...", "A tension leaves the air around you..."));
-        player_ptr->redraw |= (PR_STATUS);
+        player_ptr->redraw |= (PR_TIMED_EFFECT);
         return true;
     }
 
@@ -484,7 +484,7 @@ bool recall_player(PlayerType *player_ptr, TIME_EFFECT turns)
 
     player_ptr->word_recall = turns;
     msg_print(_("回りの大気が張りつめてきた...", "The air about you becomes charged..."));
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
     return true;
 }
 
@@ -522,7 +522,7 @@ bool free_level_recall(PlayerType *player_ptr)
 
     msg_print(_("回りの大気が張りつめてきた...", "The air about you becomes charged..."));
 
-    player_ptr->redraw |= PR_STATUS;
+    player_ptr->redraw |= PR_TIMED_EFFECT;
     return true;
 }
 

--- a/src/spell-realm/spells-chaos.cpp
+++ b/src/spell-realm/spells-chaos.cpp
@@ -186,7 +186,7 @@ bool vanish_dungeon(PlayerType *player_ptr)
         }
     }
 
-    player_ptr->update |= (PU_UN_VIEW | PU_UN_LITE | PU_VIEW | PU_LITE | PU_FLOW | PU_MON_LITE | PU_MONSTERS);
+    player_ptr->update |= (PU_UN_VIEW | PU_UN_LITE | PU_VIEW | PU_LITE | PU_FLOW | PU_MONSTER_LITE | PU_MONSTER_STATUSES);
     player_ptr->redraw |= (PR_MAP);
     player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
     return true;

--- a/src/spell-realm/spells-craft.cpp
+++ b/src/spell-realm/spells-craft.cpp
@@ -88,7 +88,7 @@ bool set_ele_attack(PlayerType *player_ptr, uint32_t attack_type, TIME_EFFECT v)
     if (disturb_state) {
         disturb(player_ptr, false, false);
     }
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
     player_ptr->update |= (PU_BONUS);
     handle_stuff(player_ptr);
 
@@ -149,7 +149,7 @@ bool set_ele_immune(PlayerType *player_ptr, uint32_t immune_type, TIME_EFFECT v)
     if (disturb_state) {
         disturb(player_ptr, false, false);
     }
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
     player_ptr->update |= (PU_BONUS);
     handle_stuff(player_ptr);
 

--- a/src/spell-realm/spells-crusade.cpp
+++ b/src/spell-realm/spells-crusade.cpp
@@ -142,7 +142,7 @@ bool set_tim_sh_holy(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->tim_sh_holy = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;
@@ -190,7 +190,7 @@ bool set_tim_eyeeye(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->tim_eyeeye = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;

--- a/src/spell-realm/spells-demon.cpp
+++ b/src/spell-realm/spells-demon.cpp
@@ -40,7 +40,7 @@ bool set_tim_sh_fire(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->tim_sh_fire = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -74,8 +74,8 @@ void SpellHex::stop_all_spells()
         set_action(this->player_ptr, ACTION_NONE);
     }
 
-    this->player_ptr->update |= PU_BONUS | PU_HP | PU_MANA | PU_SPELLS;
-    this->player_ptr->redraw |= PR_EXTRA | PR_HP | PR_MANA;
+    this->player_ptr->update |= PU_BONUS | PU_HP | PU_MP | PU_SPELLS;
+    this->player_ptr->redraw |= PR_EXTRA | PR_HP | PR_MP;
 }
 
 /*!
@@ -111,8 +111,8 @@ bool SpellHex::stop_spells_with_selection()
         this->reset_casting_flag(i2enum<spell_hex_type>(n));
     }
 
-    this->player_ptr->update |= PU_BONUS | PU_HP | PU_MANA | PU_SPELLS;
-    this->player_ptr->redraw |= PR_EXTRA | PR_HP | PR_MANA;
+    this->player_ptr->update |= PU_BONUS | PU_HP | PU_MP | PU_SPELLS;
+    this->player_ptr->redraw |= PR_EXTRA | PR_HP | PR_MP;
     return is_selected;
 }
 
@@ -215,7 +215,7 @@ bool SpellHex::process_mana_cost(const bool need_restart)
     }
 
     s64b_sub(&(this->player_ptr->csp), &(this->player_ptr->csp_frac), need_mana, need_mana_frac);
-    this->player_ptr->redraw |= PR_MANA;
+    this->player_ptr->redraw |= PR_MP;
     if (!need_restart) {
         return true;
     }
@@ -223,8 +223,8 @@ bool SpellHex::process_mana_cost(const bool need_restart)
     msg_print(_("詠唱を再開した。", "You restart casting."));
     this->player_ptr->action = ACTION_SPELL;
     this->player_ptr->update |= PU_BONUS | PU_HP;
-    this->player_ptr->redraw |= PR_MAP | PR_STATUS | PR_STATE;
-    this->player_ptr->update |= PU_MONSTERS;
+    this->player_ptr->redraw |= PR_MAP | PR_TIMED_EFFECT | PR_ACTION;
+    this->player_ptr->update |= PU_MONSTER_STATUSES;
     this->player_ptr->window_flags |= PW_OVERHEAD | PW_DUNGEON;
     return true;
 }

--- a/src/spell-realm/spells-song.cpp
+++ b/src/spell-realm/spells-song.cpp
@@ -53,14 +53,14 @@ void check_music(PlayerType *player_ptr)
     } else {
         s64b_sub(&(player_ptr->csp), &(player_ptr->csp_frac), need_mana, need_mana_frac);
 
-        player_ptr->redraw |= PR_MANA;
+        player_ptr->redraw |= PR_MP;
         if (interupting_song_effect != 0) {
             set_singing_song_effect(player_ptr, interupting_song_effect);
             set_interrupting_song_effect(player_ptr, MUSIC_NONE);
             msg_print(_("歌を再開した。", "You resume singing."));
             player_ptr->action = ACTION_SING;
-            player_ptr->update |= (PU_BONUS | PU_HP | PU_MONSTERS);
-            player_ptr->redraw |= (PR_MAP | PR_STATUS | PR_STATE);
+            player_ptr->update |= (PU_BONUS | PU_HP | PU_MONSTER_STATUSES);
+            player_ptr->redraw |= (PR_MAP | PR_TIMED_EFFECT | PR_ACTION);
             player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
         }
     }
@@ -103,7 +103,7 @@ bool set_tim_stealth(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->tim_stealth = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;
@@ -143,7 +143,7 @@ void stop_singing(PlayerType *player_ptr)
     set_singing_song_effect(player_ptr, MUSIC_NONE);
     set_singing_song_id(player_ptr, 0);
     set_bits(player_ptr->update, PU_BONUS);
-    set_bits(player_ptr->redraw, PR_STATUS);
+    set_bits(player_ptr->redraw, PR_TIMED_EFFECT);
 }
 
 bool music_singing(PlayerType *player_ptr, int music_songs)

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -247,8 +247,8 @@ bool curse_armor(PlayerType *player_ptr)
     o_ptr->art_flags.clear();
     o_ptr->curse_flags.set(CurseTraitType::CURSED);
     o_ptr->ident |= IDENT_BROKEN;
-    player_ptr->update |= PU_BONUS | PU_MANA;
-    player_ptr->window_flags |= PW_INVEN | PW_EQUIP | PW_PLAYER;
+    player_ptr->update |= PU_BONUS | PU_MP;
+    player_ptr->window_flags |= PW_INVENTORY | PW_EQUIPMENT | PW_PLAYER;
     return true;
 }
 
@@ -293,8 +293,8 @@ bool curse_weapon_object(PlayerType *player_ptr, bool force, ItemEntity *o_ptr)
     o_ptr->art_flags.clear();
     o_ptr->curse_flags.set(CurseTraitType::CURSED);
     o_ptr->ident |= IDENT_BROKEN;
-    player_ptr->update |= PU_BONUS | PU_MANA;
-    player_ptr->window_flags |= PW_INVEN | PW_EQUIP | PW_PLAYER;
+    player_ptr->update |= PU_BONUS | PU_MP;
+    player_ptr->window_flags |= PW_INVENTORY | PW_EQUIPMENT | PW_PLAYER;
     return true;
 }
 
@@ -440,8 +440,8 @@ bool enchant_equipment(PlayerType *player_ptr, ItemEntity *o_ptr, int n, int efl
         return false;
     }
 
-    set_bits(player_ptr->update, PU_BONUS | PU_COMBINE | PU_REORDER);
-    set_bits(player_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_PLAYER | PW_FLOOR_ITEM_LIST | PW_FOUND_ITEM_LIST);
+    set_bits(player_ptr->update, PU_BONUS | PU_COMBINATION | PU_REORDER);
+    set_bits(player_ptr->window_flags, PW_INVENTORY | PW_EQUIPMENT | PW_PLAYER | PW_FLOOR_ITEMS | PW_FOUND_ITEMS);
     return true;
 }
 

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -215,7 +215,7 @@ bool time_walk(PlayerType *player_ptr)
 
     player_ptr->energy_need -= 1000 + (100 + player_ptr->csp - 50) * TURNS_PER_TICK / 10;
     player_ptr->redraw |= (PR_MAP);
-    player_ptr->update |= (PU_MONSTERS);
+    player_ptr->update |= (PU_MONSTER_STATUSES);
     player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
     handle_stuff(player_ptr);
     return true;
@@ -495,7 +495,7 @@ bool restore_mana(PlayerType *player_ptr, bool magic_eater)
     player_ptr->csp = player_ptr->msp;
     player_ptr->csp_frac = 0;
     msg_print(_("頭がハッキリとした。", "You feel your head clear."));
-    player_ptr->redraw |= (PR_MANA);
+    player_ptr->redraw |= (PR_MP);
     player_ptr->window_flags |= (PW_PLAYER);
     player_ptr->window_flags |= (PW_SPELL);
     return true;
@@ -547,7 +547,7 @@ bool fishing(PlayerType *player_ptr)
     }
 
     set_action(player_ptr, ACTION_FISH);
-    player_ptr->redraw |= (PR_STATE);
+    player_ptr->redraw |= (PR_ACTION);
     return true;
 }
 

--- a/src/status/action-setter.cpp
+++ b/src/status/action-setter.cpp
@@ -63,8 +63,8 @@ void set_action(PlayerType *player_ptr, uint8_t typ)
     case ACTION_SAMURAI_STANCE: {
         msg_print(_("型を崩した。", "You stop assuming the special stance."));
         PlayerClass(player_ptr).set_samurai_stance(SamuraiStanceType::NONE);
-        player_ptr->update |= (PU_MONSTERS);
-        player_ptr->redraw |= (PR_STATUS);
+        player_ptr->update |= (PU_MONSTER_STATUSES);
+        player_ptr->redraw |= (PR_TIMED_EFFECT);
         break;
     }
     case ACTION_SING: {
@@ -120,5 +120,5 @@ void set_action(PlayerType *player_ptr, uint8_t typ)
     }
 
     player_ptr->update |= (PU_BONUS);
-    player_ptr->redraw |= (PR_STATE);
+    player_ptr->redraw |= (PR_ACTION);
 }

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -83,7 +83,7 @@ bool BadStatusSetter::set_blindness(const TIME_EFFECT tmp_v)
     }
 
     blindness->set(v);
-    this->player_ptr->redraw |= PR_STATUS;
+    this->player_ptr->redraw |= PR_TIMED_EFFECT;
     if (!notice) {
         return false;
     }
@@ -92,7 +92,7 @@ bool BadStatusSetter::set_blindness(const TIME_EFFECT tmp_v)
         disturb(this->player_ptr, false, false);
     }
 
-    this->player_ptr->update |= PU_UN_VIEW | PU_UN_LITE | PU_VIEW | PU_LITE | PU_MONSTERS | PU_MON_LITE;
+    this->player_ptr->update |= PU_UN_VIEW | PU_UN_LITE | PU_VIEW | PU_LITE | PU_MONSTER_STATUSES | PU_MONSTER_LITE;
     this->player_ptr->redraw |= PR_MAP;
     this->player_ptr->window_flags |= PW_OVERHEAD | PW_DUNGEON;
     handle_stuff(this->player_ptr);
@@ -127,14 +127,14 @@ bool BadStatusSetter::set_confusion(const TIME_EFFECT tmp_v)
                 auto bluemage_data = PlayerClass(player_ptr).get_specific_data<bluemage_data_type>();
                 bluemage_data->new_magic_learned = false;
 
-                this->player_ptr->redraw |= PR_STATE;
+                this->player_ptr->redraw |= PR_ACTION;
                 this->player_ptr->action = ACTION_NONE;
             }
             if (this->player_ptr->action == ACTION_MONK_STANCE) {
                 msg_print(_("構えがとけた。", "You lose your stance."));
                 PlayerClass(player_ptr).set_monk_stance(MonkStanceType::NONE);
                 this->player_ptr->update |= PU_BONUS;
-                this->player_ptr->redraw |= PR_STATE;
+                this->player_ptr->redraw |= PR_ACTION;
                 this->player_ptr->action = ACTION_NONE;
             } else if (this->player_ptr->action == ACTION_SAMURAI_STANCE) {
                 msg_print(_("型が崩れた。", "You lose your stance."));
@@ -162,7 +162,7 @@ bool BadStatusSetter::set_confusion(const TIME_EFFECT tmp_v)
     }
 
     this->player_confusion->set(v);
-    this->player_ptr->redraw |= PR_STATUS;
+    this->player_ptr->redraw |= PR_TIMED_EFFECT;
     if (!notice) {
         return false;
     }
@@ -208,7 +208,7 @@ bool BadStatusSetter::set_poison(const TIME_EFFECT tmp_v)
     }
 
     player_poison->set(v);
-    this->player_ptr->redraw |= PR_STATUS;
+    this->player_ptr->redraw |= PR_TIMED_EFFECT;
     if (!notice) {
         return false;
     }
@@ -259,7 +259,7 @@ bool BadStatusSetter::set_fear(const TIME_EFFECT tmp_v)
     }
 
     fear->set(v);
-    this->player_ptr->redraw |= PR_STATUS;
+    this->player_ptr->redraw |= PR_TIMED_EFFECT;
     if (!notice) {
         return false;
     }
@@ -312,7 +312,7 @@ bool BadStatusSetter::set_paralysis(const TIME_EFFECT tmp_v)
     }
 
     paralysis->set(v);
-    this->player_ptr->redraw |= PR_STATUS;
+    this->player_ptr->redraw |= PR_TIMED_EFFECT;
     if (!notice) {
         return false;
     }
@@ -321,7 +321,7 @@ bool BadStatusSetter::set_paralysis(const TIME_EFFECT tmp_v)
         disturb(this->player_ptr, false, false);
     }
 
-    this->player_ptr->redraw |= PR_STATE;
+    this->player_ptr->redraw |= PR_ACTION;
     handle_stuff(this->player_ptr);
     return true;
 }
@@ -367,7 +367,7 @@ bool BadStatusSetter::hallucination(const TIME_EFFECT tmp_v)
     }
 
     hallucination->set(v);
-    this->player_ptr->redraw |= PR_STATUS;
+    this->player_ptr->redraw |= PR_TIMED_EFFECT;
     if (!notice) {
         return false;
     }
@@ -377,7 +377,7 @@ bool BadStatusSetter::hallucination(const TIME_EFFECT tmp_v)
     }
 
     this->player_ptr->redraw |= PR_MAP | PR_HEALTH | PR_UHEALTH;
-    this->player_ptr->update |= PU_MONSTERS;
+    this->player_ptr->update |= PU_MONSTER_STATUSES;
     this->player_ptr->window_flags |= PW_OVERHEAD | PW_DUNGEON;
     handle_stuff(this->player_ptr);
     return true;

--- a/src/status/base-status.cpp
+++ b/src/status/base-status.cpp
@@ -166,7 +166,7 @@ bool dec_stat(PlayerType *player_ptr, int stat, int amount, int permanent)
     if (res) {
         player_ptr->stat_cur[stat] = cur;
         player_ptr->stat_max[stat] = max;
-        player_ptr->redraw |= (PR_STATS);
+        player_ptr->redraw |= (PR_ABILITY_SCORE);
         player_ptr->update |= (PU_BONUS);
     }
 
@@ -183,7 +183,7 @@ bool res_stat(PlayerType *player_ptr, int stat)
     if (player_ptr->stat_cur[stat] != player_ptr->stat_max[stat]) {
         player_ptr->stat_cur[stat] = player_ptr->stat_max[stat];
         player_ptr->update |= (PU_BONUS);
-        player_ptr->redraw |= (PR_STATS);
+        player_ptr->redraw |= (PR_ABILITY_SCORE);
         return true;
     }
 
@@ -303,8 +303,8 @@ bool lose_all_info(PlayerType *player_ptr)
         o_ptr->ident &= ~(IDENT_SENSE);
     }
 
-    set_bits(player_ptr->update, PU_BONUS | PU_COMBINE | PU_REORDER);
-    set_bits(player_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_PLAYER | PW_FLOOR_ITEM_LIST | PW_FOUND_ITEM_LIST);
+    set_bits(player_ptr->update, PU_BONUS | PU_COMBINATION | PU_REORDER);
+    set_bits(player_ptr->window_flags, PW_INVENTORY | PW_EQUIPMENT | PW_PLAYER | PW_FLOOR_ITEMS | PW_FOUND_ITEMS);
     wiz_dark(player_ptr);
     return true;
 }

--- a/src/status/body-improvement.cpp
+++ b/src/status/body-improvement.cpp
@@ -46,7 +46,7 @@ bool set_protevil(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->protevil = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;
@@ -91,7 +91,7 @@ bool set_invuln(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
             chg_virtue(player_ptr, Virtue::VALOUR, -5);
 
             player_ptr->redraw |= (PR_MAP);
-            player_ptr->update |= (PU_MONSTERS);
+            player_ptr->update |= (PU_MONSTER_STATUSES);
 
             player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
         }
@@ -101,7 +101,7 @@ bool set_invuln(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
             notice = true;
 
             player_ptr->redraw |= (PR_MAP);
-            player_ptr->update |= (PU_MONSTERS);
+            player_ptr->update |= (PU_MONSTER_STATUSES);
 
             player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
 
@@ -110,7 +110,7 @@ bool set_invuln(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->invuln = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;
@@ -158,7 +158,7 @@ bool set_tim_regen(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->tim_regen = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;
@@ -206,7 +206,7 @@ bool set_tim_reflect(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->tim_reflect = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;
@@ -254,7 +254,7 @@ bool set_pass_wall(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->tim_pass_wall = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;

--- a/src/status/buff-setter.cpp
+++ b/src/status/buff-setter.cpp
@@ -200,7 +200,7 @@ bool set_shield(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->shield = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;
@@ -247,7 +247,7 @@ bool set_magicdef(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->magicdef = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;
@@ -294,7 +294,7 @@ bool set_blessed(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->blessed = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;
@@ -341,7 +341,7 @@ bool set_hero(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->hero = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;
@@ -406,7 +406,7 @@ bool set_mimic(PlayerType *player_ptr, TIME_EFFECT v, MimicKindType mimic_race_i
         disturb(player_ptr, false, true);
     }
 
-    player_ptr->redraw |= (PR_BASIC | PR_STATUS);
+    player_ptr->redraw |= (PR_BASIC | PR_TIMED_EFFECT);
     player_ptr->update |= (PU_BONUS | PU_HP);
 
     handle_stuff(player_ptr);
@@ -451,7 +451,7 @@ bool set_shero(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->shero = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;
@@ -496,7 +496,7 @@ bool set_wraith_form(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
             chg_virtue(player_ptr, Virtue::VALOUR, -5);
 
             player_ptr->redraw |= (PR_MAP);
-            player_ptr->update |= (PU_MONSTERS);
+            player_ptr->update |= (PU_MONSTER_STATUSES);
 
             player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
         }
@@ -506,14 +506,14 @@ bool set_wraith_form(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
             notice = true;
 
             player_ptr->redraw |= (PR_MAP);
-            player_ptr->update |= (PU_MONSTERS);
+            player_ptr->update |= (PU_MONSTER_STATUSES);
 
             player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON);
         }
     }
 
     player_ptr->wraith_form = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;
@@ -566,7 +566,7 @@ bool set_tsuyoshi(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->tsuyoshi = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;

--- a/src/status/element-resistance.cpp
+++ b/src/status/element-resistance.cpp
@@ -50,7 +50,7 @@ bool set_oppose_acid(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     if (!notice) {
         return false;
     }
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (disturb_state) {
         disturb(player_ptr, false, false);
@@ -97,7 +97,7 @@ bool set_oppose_elec(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     if (!notice) {
         return false;
     }
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (disturb_state) {
         disturb(player_ptr, false, false);
@@ -146,7 +146,7 @@ bool set_oppose_fire(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     if (!notice) {
         return false;
     }
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (disturb_state) {
         disturb(player_ptr, false, false);
@@ -192,7 +192,7 @@ bool set_oppose_cold(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     if (!notice) {
         return false;
     }
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (disturb_state) {
         disturb(player_ptr, false, false);
@@ -241,7 +241,7 @@ bool set_oppose_pois(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     if (!notice) {
         return false;
     }
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (disturb_state) {
         disturb(player_ptr, false, false);

--- a/src/status/sight-setter.cpp
+++ b/src/status/sight-setter.cpp
@@ -43,7 +43,7 @@ bool set_tim_esp(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->tim_esp = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;
@@ -53,7 +53,7 @@ bool set_tim_esp(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
     player_ptr->update |= (PU_BONUS);
-    player_ptr->update |= (PU_MONSTERS);
+    player_ptr->update |= (PU_MONSTER_STATUSES);
     handle_stuff(player_ptr);
     return true;
 }
@@ -91,7 +91,7 @@ bool set_tim_invis(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->tim_invis = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;
@@ -101,7 +101,7 @@ bool set_tim_invis(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
     player_ptr->update |= (PU_BONUS);
-    player_ptr->update |= (PU_MONSTERS);
+    player_ptr->update |= (PU_MONSTER_STATUSES);
     handle_stuff(player_ptr);
     return true;
 }
@@ -139,7 +139,7 @@ bool set_tim_infra(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->tim_infra = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;
@@ -149,7 +149,7 @@ bool set_tim_infra(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
     player_ptr->update |= (PU_BONUS);
-    player_ptr->update |= (PU_MONSTERS);
+    player_ptr->update |= (PU_MONSTER_STATUSES);
     handle_stuff(player_ptr);
     return true;
 }

--- a/src/status/temporary-resistance.cpp
+++ b/src/status/temporary-resistance.cpp
@@ -40,7 +40,7 @@ bool set_tim_levitation(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->tim_levitation = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;
@@ -83,7 +83,7 @@ bool set_ultimate_res(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->ult_res = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;
@@ -127,7 +127,7 @@ bool set_tim_res_nether(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->tim_res_nether = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
 
     if (!notice) {
         return false;
@@ -167,7 +167,7 @@ bool set_tim_res_time(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     player_ptr->tim_res_time = v;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
     if (!notice) {
         return false;
     }

--- a/src/store/cmd-store.cpp
+++ b/src/store/cmd-store.cpp
@@ -212,8 +212,8 @@ void do_cmd_store(PlayerType *player_ptr)
     msg_erase();
     term_clear();
 
-    player_ptr->update |= PU_VIEW | PU_LITE | PU_MON_LITE;
-    player_ptr->update |= PU_MONSTERS;
+    player_ptr->update |= PU_VIEW | PU_LITE | PU_MONSTER_LITE;
+    player_ptr->update |= PU_MONSTER_STATUSES;
     player_ptr->redraw |= PR_BASIC | PR_EXTRA | PR_EQUIPPY;
     player_ptr->redraw |= PR_MAP;
     player_ptr->window_flags |= PW_OVERHEAD | PW_DUNGEON;

--- a/src/system/redrawing-flags-updater.cpp
+++ b/src/system/redrawing-flags-updater.cpp
@@ -1,0 +1,121 @@
+﻿#include "system/redrawing-flags-updater.h"
+#include "util/enum-range.h"
+
+RedrawingFlagsUpdater RedrawingFlagsUpdater::instance{};
+
+RedrawingFlagsUpdater &RedrawingFlagsUpdater::get_instance()
+{
+    return instance;
+}
+
+bool RedrawingFlagsUpdater::any_main() const
+{
+    return this->main_window_flags.any();
+}
+
+bool RedrawingFlagsUpdater::any_sub() const
+{
+    return this->sub_window_flags.any();
+}
+
+bool RedrawingFlagsUpdater::any_stats() const
+{
+    return this->status_flags.any();
+}
+
+bool RedrawingFlagsUpdater::has(MainWindowRedrawingFlag flag) const
+{
+    return this->main_window_flags.has(flag);
+}
+
+bool RedrawingFlagsUpdater::has(SubWindowRedrawingFlag flag) const
+{
+    return this->sub_window_flags.has(flag);
+}
+
+bool RedrawingFlagsUpdater::has(StatusRedrawingFlag flag) const
+{
+    return this->status_flags.has(flag);
+}
+
+bool RedrawingFlagsUpdater::has_any_of(const EnumClassFlagGroup<MainWindowRedrawingFlag> &flags) const
+{
+    return this->main_window_flags.has_any_of(flags);
+}
+
+bool RedrawingFlagsUpdater::has_any_of(const EnumClassFlagGroup<SubWindowRedrawingFlag> &flags) const
+{
+    return this->sub_window_flags.has_any_of(flags);
+}
+
+bool RedrawingFlagsUpdater::has_any_of(const EnumClassFlagGroup<StatusRedrawingFlag> &flags) const
+{
+    return this->status_flags.has_any_of(flags);
+}
+
+void RedrawingFlagsUpdater::set_flag(MainWindowRedrawingFlag flag)
+{
+    this->main_window_flags.set(flag);
+}
+
+void RedrawingFlagsUpdater::set_flag(SubWindowRedrawingFlag flag)
+{
+    this->sub_window_flags.set(flag);
+}
+
+void RedrawingFlagsUpdater::set_flag(StatusRedrawingFlag flag)
+{
+    this->status_flags.set(flag);
+}
+
+void RedrawingFlagsUpdater::set_flags(const EnumClassFlagGroup<MainWindowRedrawingFlag> &flags)
+{
+    this->main_window_flags.set(flags);
+}
+
+void RedrawingFlagsUpdater::set_flags(const EnumClassFlagGroup<SubWindowRedrawingFlag> &flags)
+{
+    this->sub_window_flags.set(flags);
+}
+
+void RedrawingFlagsUpdater::set_flags(const EnumClassFlagGroup<StatusRedrawingFlag> &flags)
+{
+    this->status_flags.set(flags);
+}
+
+void RedrawingFlagsUpdater::reset_flag(MainWindowRedrawingFlag flag)
+{
+    this->main_window_flags.reset(flag);
+}
+
+void RedrawingFlagsUpdater::reset_flag(SubWindowRedrawingFlag flag)
+{
+    this->sub_window_flags.reset(flag);
+}
+
+void RedrawingFlagsUpdater::reset_flag(StatusRedrawingFlag flag)
+{
+    this->status_flags.reset(flag);
+}
+
+void RedrawingFlagsUpdater::reset_flags(const EnumClassFlagGroup<MainWindowRedrawingFlag> &flags)
+{
+    this->main_window_flags.reset(flags);
+}
+
+void RedrawingFlagsUpdater::reset_flags(const EnumClassFlagGroup<SubWindowRedrawingFlag> &flags)
+{
+    this->sub_window_flags.reset(flags);
+}
+
+void RedrawingFlagsUpdater::reset_flags(const EnumClassFlagGroup<StatusRedrawingFlag> &flags)
+{
+    this->status_flags.reset(flags);
+}
+
+void RedrawingFlagsUpdater::fill_up_sub_flags()
+{
+    for (const auto flag : EnumRange(SubWindowRedrawingFlag::INVENTORY, SubWindowRedrawingFlag::FOUND_ITEMS)) {
+        this->sub_window_flags.set(flag);
+    }
+}

--- a/src/system/redrawing-flags-updater.h
+++ b/src/system/redrawing-flags-updater.h
@@ -1,0 +1,120 @@
+﻿#pragma once
+
+#include "util/flag-group.h"
+
+enum class MainWindowRedrawingFlag {
+    MISC, /*!< 種族と職業 */
+    TITLE, /*!< 称号 */
+    LEVEL,
+    EXP, /*!< 経験値 */
+    ABILITY_SCORE,
+    AC,
+    HP,
+    MP,
+    GOLD,
+    DEPTH,
+    EQUIPPY, /*!< 装備シンボル */
+    HEALTH, /*!< モンスターのステータス */
+    CUT, /*!< 負傷度 */
+    STUN, /*!< 朦朧度 */
+    HUNGER, /*!< 空腹度 */
+    TIMED_EFFECT,
+    UHEALTH, /*!< ペットのステータス */
+    ACTION, /*!< プレイヤーの行動状態 */
+    SPEED, /*!< 加速 */
+    STUDY, /*!< 学習 */
+    IMITATION, /*!< ものまね */
+    EXTRA, /*!< 拡張ステータス全体 */
+    BASIC, /*!< 基本ステータス全体 */
+    MAP, /*!< ゲームマップ */
+    WIPE, /*!< 画面消去 */
+    MAX,
+};
+
+enum class SubWindowRedrawingFlag {
+    INVENTORY, /*!< 所持品-装備品 */
+    EQUIPMENT, /*!< 装備品-所持品 */
+    SPELL, /*!< 魔法一覧 */
+    PLAYER, /*!< プレイヤーのステータス */
+    SIGHT_MONSTERS, /*!< 視界内モンスターの一覧 */
+    MESSAGE, /*!< メッセージログ */
+    OVERHEAD, /*!< 周辺の光景 */
+    MONSTER_LORE, /*!< モンスターの思い出 */
+    ITEM_KNOWLEDGTE, /*!< アイテムの知識 */
+    DUNGEON, /*!< ダンジョンの地形 */
+    SNAPSHOT, /*!< 記念写真 */
+    FLOOR_ITEMS, /*!< 床上のアイテム一覧 */
+    FOUND_ITEMS, /*!< 発見済みのアイテム一覧 */
+    MAX,
+};
+
+enum class StatusRedrawingFlag {
+    BONUS, /*!< 能力値修正 */
+    TORCH, /*!< 光源半径 */
+    HP,
+    MP,
+    SPELLS, /*!< 魔法学習数 */
+    COMBINATION, /*!< アイテム処理フラグ: アイテムの結合を要する */
+    REORDER, /*!< アイテム処理フラグ: アイテムの並び替えを要する */
+    AUTO_DESTRUCTION, /*!< アイテム処理フラグ: アイテムの自動破壊を要する */
+    UN_VIEW, /*!< 地形の視界外化 */
+    UN_LITE, /*!< 明暗範囲の視界外化 */
+    VIEW, /*!< 視界 */
+    LITE, /*!< 明暗範囲 */
+    MONSTER_LITE, /*!< モンスターの光源範囲 */
+    DELAY_VISIBILITY, /*!< 視界の追加更新 */
+    MONSTER_STATUSES, /*!< モンスターのステータス */
+    DISTANCE, /*!< プレイヤーとモンスターの距離 */
+    FLOW, /*!< プレイヤーから各マスへの到達距離 */
+    MAX,
+};
+
+class RedrawingFlagsUpdater {
+public:
+    RedrawingFlagsUpdater(const RedrawingFlagsUpdater &) = delete;
+    RedrawingFlagsUpdater(RedrawingFlagsUpdater &&) = delete;
+    RedrawingFlagsUpdater &operator=(const RedrawingFlagsUpdater &) = delete;
+    RedrawingFlagsUpdater &operator=(RedrawingFlagsUpdater &&) = delete;
+    ~RedrawingFlagsUpdater() = default;
+
+    static RedrawingFlagsUpdater &get_instance();
+
+    bool any_main() const;
+    bool any_sub() const;
+    bool any_stats() const;
+
+    bool has(MainWindowRedrawingFlag flag) const;
+    bool has(SubWindowRedrawingFlag flag) const;
+    bool has(StatusRedrawingFlag flag) const;
+
+    bool has_any_of(const EnumClassFlagGroup<MainWindowRedrawingFlag> &flags) const;
+    bool has_any_of(const EnumClassFlagGroup<SubWindowRedrawingFlag> &flags) const;
+    bool has_any_of(const EnumClassFlagGroup<StatusRedrawingFlag> &flags) const;
+
+    void set_flag(MainWindowRedrawingFlag flag);
+    void set_flag(SubWindowRedrawingFlag flag);
+    void set_flag(StatusRedrawingFlag flag);
+
+    void set_flags(const EnumClassFlagGroup<MainWindowRedrawingFlag> &flags);
+    void set_flags(const EnumClassFlagGroup<SubWindowRedrawingFlag> &flags);
+    void set_flags(const EnumClassFlagGroup<StatusRedrawingFlag> &flags);
+
+    void reset_flag(MainWindowRedrawingFlag flag);
+    void reset_flag(SubWindowRedrawingFlag flag);
+    void reset_flag(StatusRedrawingFlag flag);
+
+    void reset_flags(const EnumClassFlagGroup<MainWindowRedrawingFlag> &flags);
+    void reset_flags(const EnumClassFlagGroup<SubWindowRedrawingFlag> &flags);
+    void reset_flags(const EnumClassFlagGroup<StatusRedrawingFlag> &flags);
+
+    void fill_up_sub_flags();
+
+private:
+    RedrawingFlagsUpdater() = default;
+
+    static RedrawingFlagsUpdater instance;
+
+    EnumClassFlagGroup<MainWindowRedrawingFlag> main_window_flags{};
+    EnumClassFlagGroup<SubWindowRedrawingFlag> sub_window_flags{};
+    EnumClassFlagGroup<StatusRedrawingFlag> status_flags{};
+};

--- a/src/target/grid-selector.cpp
+++ b/src/target/grid-selector.cpp
@@ -161,7 +161,7 @@ void tgt_pt_info::move_to_symbol(PlayerType *player_ptr)
         this->y = player_ptr->y;
         this->x = player_ptr->x;
         verify_panel(player_ptr);
-        player_ptr->update |= PU_MONSTERS;
+        player_ptr->update |= PU_MONSTER_STATUSES;
         player_ptr->redraw |= PR_MAP;
         player_ptr->window_flags |= PW_OVERHEAD;
         handle_stuff(player_ptr);
@@ -304,7 +304,7 @@ bool tgt_pt(PlayerType *player_ptr, POSITION *x_ptr, POSITION *y_ptr)
 
     prt("", 0, 0);
     verify_panel(player_ptr);
-    player_ptr->update |= PU_MONSTERS;
+    player_ptr->update |= PU_MONSTER_STATUSES;
     player_ptr->redraw |= PR_MAP;
     player_ptr->window_flags |= PW_OVERHEAD;
     handle_stuff(player_ptr);

--- a/src/target/target-checker.cpp
+++ b/src/target/target-checker.cpp
@@ -126,7 +126,7 @@ void verify_panel(PlayerType *player_ptr)
     }
 
     panel_bounds_center();
-    player_ptr->update |= PU_MONSTERS;
+    player_ptr->update |= PU_MONSTER_STATUSES;
     player_ptr->redraw |= PR_MAP;
     player_ptr->window_flags |= PW_OVERHEAD | PW_DUNGEON;
 }

--- a/src/target/target-setter.cpp
+++ b/src/target/target-setter.cpp
@@ -254,7 +254,7 @@ static void switch_target_input(PlayerType *player_ptr, ts_type *ts_ptr)
         return;
     case 'p': {
         verify_panel(player_ptr);
-        player_ptr->update |= PU_MONSTERS;
+        player_ptr->update |= PU_MONSTER_STATUSES;
         player_ptr->redraw |= PR_MAP;
         player_ptr->window_flags |= PW_OVERHEAD;
         handle_stuff(player_ptr);
@@ -351,7 +351,7 @@ static void sweep_targets(PlayerType *player_ptr, ts_type *ts_ptr)
         panel_row_min = ts_ptr->y2;
         panel_col_min = ts_ptr->x2;
         panel_bounds_center();
-        player_ptr->update |= PU_MONSTERS;
+        player_ptr->update |= PU_MONSTER_STATUSES;
         player_ptr->redraw |= PR_MAP;
         player_ptr->window_flags |= PW_OVERHEAD;
         handle_stuff(player_ptr);
@@ -451,7 +451,7 @@ static void switch_next_grid_command(PlayerType *player_ptr, ts_type *ts_ptr)
         break;
     case 'p':
         verify_panel(player_ptr);
-        player_ptr->update |= PU_MONSTERS;
+        player_ptr->update |= PU_MONSTER_STATUSES;
         player_ptr->redraw |= PR_MAP;
         player_ptr->window_flags |= PW_OVERHEAD;
         handle_stuff(player_ptr);
@@ -590,9 +590,9 @@ bool target_set(PlayerType *player_ptr, target_type mode)
     sweep_target_grids(player_ptr, ts_ptr);
     prt("", 0, 0);
     verify_panel(player_ptr);
-    set_bits(player_ptr->update, PU_MONSTERS);
+    set_bits(player_ptr->update, PU_MONSTER_STATUSES);
     set_bits(player_ptr->redraw, PR_MAP);
-    set_bits(player_ptr->window_flags, PW_OVERHEAD | PW_FLOOR_ITEM_LIST);
+    set_bits(player_ptr->window_flags, PW_OVERHEAD | PW_FLOOR_ITEMS);
     handle_stuff(player_ptr);
     return target_who != 0;
 }

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -118,7 +118,7 @@ static void display_sub_windows(window_redraw_type pw_flag, std::invocable auto 
  */
 void fix_inventory(PlayerType *player_ptr)
 {
-    display_sub_windows(PW_INVEN,
+    display_sub_windows(PW_INVENTORY,
         [player_ptr] {
             display_inventory(player_ptr, *fix_item_tester);
         });
@@ -241,7 +241,7 @@ void fix_monster_list(PlayerType *player_ptr)
     static std::vector<MONSTER_IDX> monster_list;
     std::once_flag once;
 
-    display_sub_windows(PW_MONSTER_LIST,
+    display_sub_windows(PW_SIGHT_MONSTERS,
         [player_ptr, &once] {
             int w, h;
             term_get_size(&w, &h);
@@ -339,7 +339,7 @@ static void display_equipment(PlayerType *player_ptr, const ItemTester &item_tes
  */
 void fix_equip(PlayerType *player_ptr)
 {
-    display_sub_windows(PW_EQUIP,
+    display_sub_windows(PW_EQUIPMENT,
         [player_ptr] {
             display_equipment(player_ptr, *fix_item_tester);
         });
@@ -460,7 +460,7 @@ void fix_monster(PlayerType *player_ptr)
     if (!MonsterRace(player_ptr->monster_race_idx).is_valid()) {
         return;
     }
-    display_sub_windows(PW_MONSTER,
+    display_sub_windows(PW_MONSTER_LORE,
         [player_ptr] {
             display_roff(player_ptr);
         });
@@ -473,7 +473,7 @@ void fix_monster(PlayerType *player_ptr)
  */
 void fix_object(PlayerType *player_ptr)
 {
-    display_sub_windows(PW_OBJECT,
+    display_sub_windows(PW_ITEM_KNOWLEDGTE,
         [player_ptr] {
             display_koff(player_ptr);
         });
@@ -587,7 +587,7 @@ static void display_floor_item_list(PlayerType *player_ptr, const int y, const i
  */
 void fix_floor_item_list(PlayerType *player_ptr, const int y, const int x)
 {
-    display_sub_windows(PW_FLOOR_ITEM_LIST,
+    display_sub_windows(PW_FLOOR_ITEMS,
         [player_ptr, y, x] {
             display_floor_item_list(player_ptr, y, x);
         });
@@ -668,7 +668,7 @@ static void display_found_item_list(PlayerType *player_ptr)
  */
 void fix_found_item_list(PlayerType *player_ptr)
 {
-    display_sub_windows(PW_FOUND_ITEM_LIST,
+    display_sub_windows(PW_FOUND_ITEMS,
         [player_ptr] {
             display_found_item_list(player_ptr);
         });
@@ -845,17 +845,17 @@ void toggle_inventory_equipment(PlayerType *player_ptr)
             continue;
         }
 
-        if (window_flag[i] & (PW_INVEN)) {
-            window_flag[i] &= ~(PW_INVEN);
-            window_flag[i] |= (PW_EQUIP);
-            player_ptr->window_flags |= (PW_EQUIP);
+        if (window_flag[i] & (PW_INVENTORY)) {
+            window_flag[i] &= ~(PW_INVENTORY);
+            window_flag[i] |= (PW_EQUIPMENT);
+            player_ptr->window_flags |= (PW_EQUIPMENT);
             continue;
         }
 
-        if (window_flag[i] & PW_EQUIP) {
-            window_flag[i] &= ~(PW_EQUIP);
-            window_flag[i] |= PW_INVEN;
-            player_ptr->window_flags |= PW_INVEN;
+        if (window_flag[i] & PW_EQUIPMENT) {
+            window_flag[i] &= ~(PW_EQUIPMENT);
+            window_flag[i] |= PW_INVENTORY;
+            player_ptr->window_flags |= PW_INVENTORY;
         }
     }
 }

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -233,10 +233,10 @@ void wiz_identify_full_inventory(PlayerType *player_ptr)
     }
 
     /* Refrect item informaiton onto subwindows without updating inventory */
-    reset_bits(player_ptr->update, PU_COMBINE | PU_REORDER);
+    reset_bits(player_ptr->update, PU_COMBINATION | PU_REORDER);
     handle_stuff(player_ptr);
-    set_bits(player_ptr->update, PU_COMBINE | PU_REORDER);
-    set_bits(player_ptr->window_flags, PW_INVEN | PW_EQUIP);
+    set_bits(player_ptr->update, PU_COMBINATION | PU_REORDER);
+    set_bits(player_ptr->window_flags, PW_INVENTORY | PW_EQUIPMENT);
 }
 
 /*!
@@ -581,8 +581,8 @@ static void wiz_reroll_item(PlayerType *player_ptr, ItemEntity *o_ptr)
     }
 
     o_ptr->copy_from(q_ptr);
-    set_bits(player_ptr->update, PU_BONUS | PU_COMBINE | PU_REORDER);
-    set_bits(player_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER | PW_FLOOR_ITEM_LIST | PW_FOUND_ITEM_LIST);
+    set_bits(player_ptr->update, PU_BONUS | PU_COMBINATION | PU_REORDER);
+    set_bits(player_ptr->window_flags, PW_INVENTORY | PW_EQUIPMENT | PW_SPELL | PW_PLAYER | PW_FLOOR_ITEMS | PW_FOUND_ITEMS);
 }
 
 /*!
@@ -725,8 +725,8 @@ void wiz_modify_item(PlayerType *player_ptr)
         msg_print("Changes accepted.");
 
         o_ptr->copy_from(q_ptr);
-        set_bits(player_ptr->update, PU_BONUS | PU_COMBINE | PU_REORDER);
-        set_bits(player_ptr->window_flags, PW_INVEN | PW_EQUIP | PW_SPELL | PW_PLAYER | PW_FLOOR_ITEM_LIST | PW_FOUND_ITEM_LIST);
+        set_bits(player_ptr->update, PU_BONUS | PU_COMBINATION | PU_REORDER);
+        set_bits(player_ptr->window_flags, PW_INVENTORY | PW_EQUIPMENT | PW_SPELL | PW_PLAYER | PW_FLOOR_ITEMS | PW_FOUND_ITEMS);
     } else {
         msg_print("Changes ignored.");
     }

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -693,8 +693,8 @@ void wiz_reset_race(PlayerType *player_ptr)
     rp_ptr = &race_info[enum2i(player_ptr->prace)];
 
     player_ptr->window_flags |= PW_PLAYER;
-    player_ptr->update |= PU_BONUS | PU_HP | PU_MANA | PU_SPELLS;
-    player_ptr->redraw |= PR_BASIC | PR_HP | PR_MANA | PR_STATS;
+    player_ptr->update |= PU_BONUS | PU_HP | PU_MP | PU_SPELLS;
+    player_ptr->redraw |= PR_BASIC | PR_HP | PR_MP | PR_ABILITY_SCORE;
     handle_stuff(player_ptr);
 }
 
@@ -714,8 +714,8 @@ void wiz_reset_class(PlayerType *player_ptr)
     mp_ptr = &class_magics_info[val];
     PlayerClass(player_ptr).init_specific_data();
     player_ptr->window_flags |= PW_PLAYER;
-    player_ptr->update |= PU_BONUS | PU_HP | PU_MANA | PU_SPELLS;
-    player_ptr->redraw |= PR_BASIC | PR_HP | PR_MANA | PR_STATS;
+    player_ptr->update |= PU_BONUS | PU_HP | PU_MP | PU_SPELLS;
+    player_ptr->redraw |= PR_BASIC | PR_HP | PR_MP | PR_ABILITY_SCORE;
     handle_stuff(player_ptr);
 }
 
@@ -738,7 +738,7 @@ void wiz_reset_realms(PlayerType *player_ptr)
     player_ptr->realm1 = static_cast<int16_t>(val1);
     player_ptr->realm2 = static_cast<int16_t>(val2);
     player_ptr->window_flags |= PW_PLAYER;
-    player_ptr->update |= PU_BONUS | PU_HP | PU_MANA | PU_SPELLS;
+    player_ptr->update |= PU_BONUS | PU_HP | PU_MP | PU_SPELLS;
     player_ptr->redraw |= PR_BASIC;
     handle_stuff(player_ptr);
 }

--- a/src/world/world-movement-processor.cpp
+++ b/src/world/world-movement-processor.cpp
@@ -66,7 +66,7 @@ void execute_recall(PlayerType *player_ptr)
     }
 
     player_ptr->word_recall--;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
     if (player_ptr->word_recall != 0) {
         return;
     }
@@ -150,7 +150,7 @@ void execute_floor_reset(PlayerType *player_ptr)
     }
 
     player_ptr->alter_reality--;
-    player_ptr->redraw |= (PR_STATUS);
+    player_ptr->redraw |= (PR_TIMED_EFFECT);
     if (player_ptr->alter_reality != 0) {
         return;
     }


### PR DESCRIPTION
PlayerType::update/redraw/window\_flags を移設する先のシングルトンクラスを作成しました
上記3フィールドは画面の再描画フラグなので、プレイヤーの状態とは直接関係がなく、よって分離するべきと判断します
ご確認下さい