### PR TITLE
カオスパトロン報酬が時々異常になる不具合を修正した

### DIFF
--- a/src/player/patron.cpp
+++ b/src/player/patron.cpp
@@ -316,10 +316,10 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             msg_format(_("%sの声が鳴り響いた:", "The voice of %s rings out:"), this->name.data());
             msg_print(_("「留まるのだ、下僕よ。余が汝の肉体を鍛えん。」", "'Stay, mortal, and let me mold thee.'"));
 
-            if (one_in_(3) && !(this->boost_stat != A_RANDOM)) {
-                do_inc_stat(player_ptr, this->boost_stat);
+            if ((this->boost_stat == A_RANDOM) || !one_in_(3)) {
+                do_inc_stat(this->player_ptr, randint0(6));
             } else {
-                do_inc_stat(player_ptr, randint0(6));
+                do_inc_stat(this->player_ptr, this->boost_stat);
             }
             reward = _("能力値が上がった。", "increasing a stat");
             break;
@@ -328,10 +328,10 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「下僕よ、余は汝に飽みたり。」", "'I grow tired of thee, mortal.'"));
 
-            if (one_in_(3) && !(this->boost_stat != A_RANDOM)) {
-                do_dec_stat(player_ptr, this->boost_stat);
+            if ((this->boost_stat == A_RANDOM) || !one_in_(3)) {
+                do_dec_stat(this->player_ptr, randint0(6));
             } else {
-                (void)do_dec_stat(player_ptr, randint0(6));
+                do_dec_stat(this->player_ptr, this->boost_stat);
             }
             reward = _("能力値が下がった。", "decreasing a stat");
             break;

--- a/src/player/patron.cpp
+++ b/src/player/patron.cpp
@@ -187,25 +187,20 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
 
     if (one_in_(6) && !chosen_reward) {
         msg_format(_("%s^は褒美としてあなたを突然変異させた。", "%s^ rewards you with a mutation!"), this->name.data());
-        (void)gain_mutation(player_ptr, 0);
+        (void)gain_mutation(this->player_ptr, 0);
         reward = _("変異した。", "mutation");
     } else {
+        const auto *floor_ptr = this->player_ptr->current_floor_ptr;
         switch (chosen_reward ? chosen_reward : effect) {
-
         case REW_POLY_SLF:
-
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「汝、新たなる姿を必要とせり！」", "'Thou needst a new form, mortal!'"));
-
-            do_poly_self(player_ptr);
+            do_poly_self(this->player_ptr);
             reward = _("変異した。", "polymorphing");
             break;
-
         case REW_GAIN_EXP:
-
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「汝は良く行いたり！続けよ！」", "'Well done, mortal! Lead on!'"));
-
             if (PlayerRace(this->player_ptr).equals(PlayerRaceType::ANDROID)) {
                 msg_print(_("しかし何も起こらなかった。", "But, nothing happens."));
             } else if (this->player_ptr->exp < PY_MAX_EXP) {
@@ -213,373 +208,316 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
                 if (ee > 100000L) {
                     ee = 100000L;
                 }
-                msg_print(_("更に経験を積んだような気がする。", "You feel more experienced."));
 
-                gain_exp(player_ptr, ee);
+                msg_print(_("更に経験を積んだような気がする。", "You feel more experienced."));
+                gain_exp(this->player_ptr, ee);
                 reward = _("経験値を得た", "experience");
             }
+
             break;
-
         case REW_LOSE_EXP:
-
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「下僕よ、汝それに値せず。」", "'Thou didst not deserve that, slave.'"));
-
             if (PlayerRace(this->player_ptr).equals(PlayerRaceType::ANDROID)) {
                 msg_print(_("しかし何も起こらなかった。", "But, nothing happens."));
             } else {
-                lose_exp(player_ptr, this->player_ptr->exp / 6);
+                lose_exp(this->player_ptr, this->player_ptr->exp / 6);
                 reward = _("経験値を失った。", "losing experience");
             }
-            break;
 
+            break;
         case REW_GOOD_OBJ:
             msg_format(_("%sの声がささやいた:", "The voice of %s whispers:"), this->name.data());
             msg_print(_("「我が与えし物を賢明に使うべし。」", "'Use my gift wisely.'"));
-
-            acquirement(player_ptr, this->player_ptr->y, this->player_ptr->x, 1, false, false, false);
+            acquirement(this->player_ptr, this->player_ptr->y, this->player_ptr->x, 1, false, false, false);
             reward = _("上質なアイテムを手に入れた。", "a good item");
             break;
-
         case REW_GREA_OBJ:
-
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「我が与えし物を賢明に使うべし。」", "'Use my gift wisely.'"));
-
-            acquirement(player_ptr, this->player_ptr->y, this->player_ptr->x, 1, true, false, false);
+            acquirement(this->player_ptr, this->player_ptr->y, this->player_ptr->x, 1, true, false, false);
             reward = _("高級品のアイテムを手に入れた。", "an excellent item");
             break;
-
         case REW_CHAOS_WP:
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「汝の行いは貴き剣に値せり。」", "'Thy deed hath earned thee a worthy blade.'"));
-            acquire_chaos_weapon(player_ptr);
+            acquire_chaos_weapon(this->player_ptr);
             reward = _("(混沌)の武器を手に入れた。", "chaos weapon");
             break;
-
         case REW_GOOD_OBS:
-
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「汝の行いは貴き報いに値せり。」", "'Thy deed hath earned thee a worthy reward.'"));
-
-            acquirement(player_ptr, this->player_ptr->y, this->player_ptr->x, randint1(2) + 1, false, false, false);
+            acquirement(this->player_ptr, this->player_ptr->y, this->player_ptr->x, randint1(2) + 1, false, false, false);
             reward = _("上質なアイテムを手に入れた。", "good items");
             break;
-
         case REW_GREA_OBS:
-
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「下僕よ、汝の献身への我が惜しみ無き報いを見るがよい。」", "'Behold, mortal, how generously I reward thy loyalty.'"));
-
-            acquirement(player_ptr, this->player_ptr->y, this->player_ptr->x, randint1(2) + 1, true, false, false);
+            acquirement(this->player_ptr, this->player_ptr->y, this->player_ptr->x, randint1(2) + 1, true, false, false);
             reward = _("高級品のアイテムを手に入れた。", "excellent items");
             break;
-
         case REW_TY_CURSE:
             msg_format(_("%sの声が轟き渡った:", "The voice of %s thunders:"), this->name.data());
             msg_print(_("「下僕よ、汝傲慢なり。」", "'Thou art growing arrogant, mortal.'"));
-
-            (void)activate_ty_curse(player_ptr, false, &count);
+            (void)activate_ty_curse(this->player_ptr, false, &count);
             reward = _("禍々しい呪いをかけられた。", "cursing");
             break;
-
         case REW_SUMMON_M:
-
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「我が下僕たちよ、かの傲慢なる者を倒すべし！」", "'My pets, destroy the arrogant mortal!'"));
-
             for (int i = 0, summon_num = randint1(5) + 1; i < summon_num; i++) {
-                (void)summon_specific(player_ptr, 0, this->player_ptr->y, this->player_ptr->x, this->player_ptr->current_floor_ptr->dun_level, SUMMON_NONE,
+                (void)summon_specific(this->player_ptr, 0, this->player_ptr->y, this->player_ptr->x, floor_ptr->dun_level, SUMMON_NONE,
                     (PM_ALLOW_GROUP | PM_ALLOW_UNIQUE | PM_NO_PET));
             }
+
             reward = _("モンスターを召喚された。", "summoning hostile monsters");
             break;
-
         case REW_H_SUMMON:
-
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「汝、より強き敵を必要とせり！」", "'Thou needst worthier opponents!'"));
-
-            activate_hi_summon(player_ptr, this->player_ptr->y, this->player_ptr->x, false);
+            activate_hi_summon(this->player_ptr, this->player_ptr->y, this->player_ptr->x, false);
             reward = _("モンスターを召喚された。", "summoning many hostile monsters");
             break;
-
         case REW_DO_HAVOC:
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「死と破壊こそ我が喜びなり！」", "'Death and destruction! This pleaseth me!'"));
-
-            call_chaos(player_ptr);
+            call_chaos(this->player_ptr);
             reward = _("カオスの力が渦巻いた。", "calling chaos");
             break;
-
         case REW_GAIN_ABL:
             msg_format(_("%sの声が鳴り響いた:", "The voice of %s rings out:"), this->name.data());
             msg_print(_("「留まるのだ、下僕よ。余が汝の肉体を鍛えん。」", "'Stay, mortal, and let me mold thee.'"));
-
             if ((this->boost_stat == A_RANDOM) || !one_in_(3)) {
                 do_inc_stat(this->player_ptr, randint0(6));
             } else {
                 do_inc_stat(this->player_ptr, this->boost_stat);
             }
+
             reward = _("能力値が上がった。", "increasing a stat");
             break;
-
         case REW_LOSE_ABL:
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「下僕よ、余は汝に飽みたり。」", "'I grow tired of thee, mortal.'"));
-
             if ((this->boost_stat == A_RANDOM) || !one_in_(3)) {
                 do_dec_stat(this->player_ptr, randint0(6));
             } else {
                 do_dec_stat(this->player_ptr, this->boost_stat);
             }
+
             reward = _("能力値が下がった。", "decreasing a stat");
             break;
-
         case REW_RUIN_ABL:
-
             msg_format(_("%sの声が轟き渡った:", "The voice of %s thunders:"), this->name.data());
             msg_print(_("「汝、謙虚たることを学ぶべし！」", "'Thou needst a lesson in humility, mortal!'"));
             msg_print(_("あなたは以前より弱くなった！", "You feel less powerful!"));
-
             for (int stat = 0; stat < A_MAX; stat++) {
-                (void)dec_stat(player_ptr, stat, 10 + randint1(15), true);
+                (void)dec_stat(this->player_ptr, stat, 10 + randint1(15), true);
             }
+
             reward = _("全能力値が下がった。", "decreasing all stats");
             break;
-
         case REW_POLY_WND:
-
             msg_format(_("%sの力が触れるのを感じた。", "You feel the power of %s touch you."), this->name.data());
-            do_poly_wounds(player_ptr);
+            do_poly_wounds(this->player_ptr);
             reward = _("傷が変化した。", "polymorphing wounds");
             break;
-
         case REW_AUGM_ABL:
-
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
-
             msg_print(_("「我がささやかなる賜物を受けとるがよい！」", "'Receive this modest gift from me!'"));
-
             for (int stat = 0; stat < A_MAX; stat++) {
-                (void)do_inc_stat(player_ptr, stat);
+                (void)do_inc_stat(this->player_ptr, stat);
             }
+
             reward = _("全能力値が上がった。", "increasing all stats");
             break;
-
         case REW_HURT_LOT:
-
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「苦しむがよい、無能な愚か者よ！」", "'Suffer, pathetic fool!'"));
-
-            fire_ball(player_ptr, AttributeType::DISINTEGRATE, 0, this->player_ptr->lev * 4, 4);
-            take_hit(player_ptr, DAMAGE_NOESCAPE, this->player_ptr->lev * 4, wrath_reason.data());
+            fire_ball(this->player_ptr, AttributeType::DISINTEGRATE, 0, this->player_ptr->lev * 4, 4);
+            take_hit(this->player_ptr, DAMAGE_NOESCAPE, this->player_ptr->lev * 4, wrath_reason.data());
             reward = _("分解の球が発生した。", "generating disintegration ball");
             break;
-
         case REW_HEAL_FUL:
-
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
-            (void)restore_level(player_ptr);
-            (void)restore_all_status(player_ptr);
-            (void)true_healing(player_ptr, 5000);
+            (void)restore_level(this->player_ptr);
+            (void)restore_all_status(this->player_ptr);
+            (void)true_healing(this->player_ptr, 5000);
             reward = _("体力が回復した。", "healing");
             break;
-
         case REW_CURSE_WP: {
             inventory_slot_type slot;
-
-            if (!has_melee_weapon(player_ptr, INVEN_MAIN_HAND) && !has_melee_weapon(player_ptr, INVEN_SUB_HAND)) {
+            if (!has_melee_weapon(this->player_ptr, INVEN_MAIN_HAND) && !has_melee_weapon(this->player_ptr, INVEN_SUB_HAND)) {
                 break;
             }
+
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「汝、武器に頼ることなかれ。」", "'Thou reliest too much on thy weapon.'"));
-
             slot = INVEN_MAIN_HAND;
-            if (has_melee_weapon(player_ptr, INVEN_SUB_HAND)) {
+            if (has_melee_weapon(this->player_ptr, INVEN_SUB_HAND)) {
                 slot = INVEN_SUB_HAND;
-                if (has_melee_weapon(player_ptr, INVEN_MAIN_HAND) && one_in_(2)) {
+                if (has_melee_weapon(this->player_ptr, INVEN_MAIN_HAND) && one_in_(2)) {
                     slot = INVEN_MAIN_HAND;
                 }
             }
 
             const auto item_name = describe_flavor(this->player_ptr, &this->player_ptr->inventory_list[slot], OD_NAME_ONLY);
-            (void)curse_weapon_object(player_ptr, false, &this->player_ptr->inventory_list[slot]);
+            (void)curse_weapon_object(this->player_ptr, false, &this->player_ptr->inventory_list[slot]);
             reward = format(_("%sが破壊された。", "destroying %s"), item_name.data());
             break;
         }
-
         case REW_CURSE_AR: {
             if (!this->player_ptr->inventory_list[INVEN_BODY].bi_id) {
                 break;
             }
+
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「汝、防具に頼ることなかれ。」", "'Thou reliest too much on thine equipment.'"));
-            const auto item_name = describe_flavor(player_ptr, &this->player_ptr->inventory_list[INVEN_BODY], OD_NAME_ONLY);
-            (void)curse_armor(player_ptr);
+            const auto item_name = describe_flavor(this->player_ptr, &this->player_ptr->inventory_list[INVEN_BODY], OD_NAME_ONLY);
+            (void)curse_armor(this->player_ptr);
             reward = format(_("%sが破壊された。", "destroying %s"), item_name.data());
             break;
         }
         case REW_PISS_OFF: {
             msg_format(_("%sの声がささやいた:", "The voice of %s whispers:"), this->name.data());
             msg_print(_("「我を怒りしめた罪を償うべし。」", "'Now thou shalt pay for annoying me.'"));
-
             switch (randint1(4)) {
             case 1:
-                (void)activate_ty_curse(player_ptr, false, &count);
+                (void)activate_ty_curse(this->player_ptr, false, &count);
                 reward = _("禍々しい呪いをかけられた。", "cursing");
                 break;
             case 2:
-                activate_hi_summon(player_ptr, this->player_ptr->y, this->player_ptr->x, false);
+                activate_hi_summon(this->player_ptr, this->player_ptr->y, this->player_ptr->x, false);
                 reward = _("モンスターを召喚された。", "summoning hostile monsters");
                 break;
             case 3:
                 if (one_in_(2)) {
                     inventory_slot_type slot;
-                    if (!has_melee_weapon(player_ptr, INVEN_MAIN_HAND) && !has_melee_weapon(player_ptr, INVEN_SUB_HAND)) {
+                    if (!has_melee_weapon(this->player_ptr, INVEN_MAIN_HAND) && !has_melee_weapon(this->player_ptr, INVEN_SUB_HAND)) {
                         break;
                     }
                     slot = INVEN_MAIN_HAND;
-                    if (has_melee_weapon(player_ptr, INVEN_SUB_HAND)) {
+                    if (has_melee_weapon(this->player_ptr, INVEN_SUB_HAND)) {
                         slot = INVEN_SUB_HAND;
-                        if (has_melee_weapon(player_ptr, INVEN_MAIN_HAND) && one_in_(2)) {
+                        if (has_melee_weapon(this->player_ptr, INVEN_MAIN_HAND) && one_in_(2)) {
                             slot = INVEN_MAIN_HAND;
                         }
                     }
 
                     const auto item_name = describe_flavor(this->player_ptr, &this->player_ptr->inventory_list[slot], OD_NAME_ONLY);
-                    (void)curse_weapon_object(player_ptr, false, &this->player_ptr->inventory_list[slot]);
+                    (void)curse_weapon_object(this->player_ptr, false, &this->player_ptr->inventory_list[slot]);
                     reward = format(_("%sが破壊された。", "destroying %s"), item_name.data());
                 } else {
                     if (!this->player_ptr->inventory_list[INVEN_BODY].bi_id) {
                         break;
                     }
 
-                    const auto item_name = describe_flavor(player_ptr, &this->player_ptr->inventory_list[INVEN_BODY], OD_NAME_ONLY);
-                    (void)curse_armor(player_ptr);
+                    const auto item_name = describe_flavor(this->player_ptr, &this->player_ptr->inventory_list[INVEN_BODY], OD_NAME_ONLY);
+                    (void)curse_armor(this->player_ptr);
                     reward = format(_("%sが破壊された。", "destroying %s"), item_name.data());
                 }
                 break;
             default:
                 for (int stat = 0; stat < A_MAX; stat++) {
-                    (void)dec_stat(player_ptr, stat, 10 + randint1(15), true);
+                    (void)dec_stat(this->player_ptr, stat, 10 + randint1(15), true);
                 }
                 reward = _("全能力値が下がった。", "decreasing all stats");
                 break;
             }
+
             break;
         }
         case REW_WRATH:
-
             msg_format(_("%sの声が轟き渡った:", "The voice of %s thunders:"), this->name.data());
             msg_print(_("「死ぬがよい、下僕よ！」", "'Die, mortal!'"));
-
-            take_hit(player_ptr, DAMAGE_LOSELIFE, this->player_ptr->lev * 4, wrath_reason.data());
+            take_hit(this->player_ptr, DAMAGE_LOSELIFE, this->player_ptr->lev * 4, wrath_reason.data());
             for (int stat = 0; stat < A_MAX; stat++) {
-                (void)dec_stat(player_ptr, stat, 10 + randint1(15), false);
+                (void)dec_stat(this->player_ptr, stat, 10 + randint1(15), false);
             }
-            activate_hi_summon(player_ptr, this->player_ptr->y, this->player_ptr->x, false);
-            (void)activate_ty_curse(player_ptr, false, &count);
+
+            activate_hi_summon(this->player_ptr, this->player_ptr->y, this->player_ptr->x, false);
+            (void)activate_ty_curse(this->player_ptr, false, &count);
             if (one_in_(2)) {
                 inventory_slot_type slot = INVEN_NONE;
-
-                if (has_melee_weapon(player_ptr, INVEN_MAIN_HAND)) {
+                if (has_melee_weapon(this->player_ptr, INVEN_MAIN_HAND)) {
                     slot = INVEN_MAIN_HAND;
-                    if (has_melee_weapon(player_ptr, INVEN_SUB_HAND) && one_in_(2)) {
+                    if (has_melee_weapon(this->player_ptr, INVEN_SUB_HAND) && one_in_(2)) {
                         slot = INVEN_SUB_HAND;
                     }
-                } else if (has_melee_weapon(player_ptr, INVEN_SUB_HAND)) {
+                } else if (has_melee_weapon(this->player_ptr, INVEN_SUB_HAND)) {
                     slot = INVEN_SUB_HAND;
                 }
 
                 if (slot) {
-                    (void)curse_weapon_object(player_ptr, false, &this->player_ptr->inventory_list[slot]);
+                    (void)curse_weapon_object(this->player_ptr, false, &this->player_ptr->inventory_list[slot]);
                 }
             }
+
             if (one_in_(2)) {
-                (void)curse_armor(player_ptr);
+                (void)curse_armor(this->player_ptr);
             }
+
             break;
-
         case REW_DESTRUCT:
-
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「死と破壊こそ我が喜びなり！」", "'Death and destruction! This pleaseth me!'"));
-
-            (void)destroy_area(player_ptr, this->player_ptr->y, this->player_ptr->x, 25, false);
+            (void)destroy_area(this->player_ptr, this->player_ptr->y, this->player_ptr->x, 25, false);
             reward = _("ダンジョンが*破壊*された。", "*destruct*ing dungeon");
             break;
-
         case REW_GENOCIDE:
-
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「我、汝の敵を抹殺せん！」", "'Let me relieve thee of thine oppressors!'"));
-            (void)symbol_genocide(player_ptr, 0, false);
+            (void)symbol_genocide(this->player_ptr, 0, false);
             reward = _("モンスターが抹殺された。", "genociding monsters");
             break;
-
         case REW_MASS_GEN:
-
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「我、汝の敵を抹殺せん！」", "'Let me relieve thee of thine oppressors!'"));
-
-            (void)mass_genocide(player_ptr, 0, false);
+            (void)mass_genocide(this->player_ptr, 0, false);
             reward = _("モンスターが抹殺された。", "genociding nearby monsters");
             break;
-
         case REW_DISPEL_C:
-
             msg_format(_("%sの力が敵を攻撃するのを感じた！", "You can feel the power of %s assault your enemies!"), this->name.data());
-            (void)dispel_monsters(player_ptr, this->player_ptr->lev * 4);
+            (void)dispel_monsters(this->player_ptr, this->player_ptr->lev * 4);
             break;
-
         case REW_IGNORE:
-
             msg_format(_("%sはあなたを無視した。", "%s ignores you."), this->name.data());
             break;
-
         case REW_SER_DEMO:
-
             msg_format(_("%sは褒美として悪魔の使いをよこした！", "%s rewards you with a demonic servant!"), this->name.data());
-
-            if (!summon_specific(player_ptr, -1, this->player_ptr->y, this->player_ptr->x, this->player_ptr->current_floor_ptr->dun_level, SUMMON_DEMON, PM_FORCE_PET)) {
+            if (!summon_specific(this->player_ptr, -1, this->player_ptr->y, this->player_ptr->x, floor_ptr->dun_level, SUMMON_DEMON, PM_FORCE_PET)) {
                 msg_print(_("何も現れなかった...", "Nobody ever turns up..."));
             } else {
                 reward = _("悪魔がペットになった。", "a demonic servant");
             }
 
             break;
-
         case REW_SER_MONS:
             msg_format(_("%sは褒美として使いをよこした！", "%s rewards you with a servant!"), this->name.data());
-
-            if (!summon_specific(player_ptr, -1, this->player_ptr->y, this->player_ptr->x, this->player_ptr->current_floor_ptr->dun_level, SUMMON_NONE, PM_FORCE_PET)) {
+            if (!summon_specific(this->player_ptr, -1, this->player_ptr->y, this->player_ptr->x, floor_ptr->dun_level, SUMMON_NONE, PM_FORCE_PET)) {
                 msg_print(_("何も現れなかった...", "Nobody ever turns up..."));
             } else {
                 reward = _("モンスターがペットになった。", "a servant");
             }
 
             break;
-
         case REW_SER_UNDE:
             msg_format(_("%sは褒美としてアンデッドの使いをよこした。", "%s rewards you with an undead servant!"), this->name.data());
-
-            if (!summon_specific(player_ptr, -1, this->player_ptr->y, this->player_ptr->x, this->player_ptr->current_floor_ptr->dun_level, SUMMON_UNDEAD, PM_FORCE_PET)) {
+            if (!summon_specific(this->player_ptr, -1, this->player_ptr->y, this->player_ptr->x, floor_ptr->dun_level, SUMMON_UNDEAD, PM_FORCE_PET)) {
                 msg_print(_("何も現れなかった...", "Nobody ever turns up..."));
             } else {
                 reward = _("アンデッドがペットになった。", "an undead servant");
             }
 
             break;
-
         default:
             msg_format(_("%sの声がどもった:", "The voice of %s stammers:"), this->name.data());
             msg_format(_("「あー、あー、答えは %d/%d。質問は何？」", "'Uh... uh... the answer's %d/%d, what's the question?'"), type, effect);
         }
     }
+
     if (!reward.empty()) {
         const auto note = format(_("パトロンの報酬で%s", "The patron rewarded you with %s."), reward.data());
-        exe_write_diary(player_ptr, DIARY_DESCRIPTION, 0, note.data());
+        exe_write_diary(this->player_ptr, DIARY_DESCRIPTION, 0, note.data());
     }
 }
 


### PR DESCRIPTION
「ランダムにアビリティスコアを上昇/下降させるカオスパトロン」が選ばれていた場合、確率的に表題の事象が起きることが分かりました
論理学的にそれがありえなくなるよう修正しました
ご確認下さい