### PR TITLE
path_build() のシグネチャをchar*からstringへ差し替える準備 その1

### DIFF
--- a/src/autopick/autopick-reader-writer.cpp
+++ b/src/autopick/autopick-reader-writer.cpp
@@ -9,6 +9,7 @@
 #include "util/string-processor.h"
 #include "view/display-messages.h"
 #include <stdexcept>
+#include <string_view>
 
 /*!
  * @brief Load an autopick preference file
@@ -58,7 +59,7 @@ std::string pickpref_filename(PlayerType *player_ptr, int filename_mode)
 /*!
  * @brief Read whole lines of a file to memory
  */
-static std::vector<concptr> read_text_lines(concptr filename)
+static std::vector<concptr> read_text_lines(std::string_view filename)
 {
     FILE *fff;
 
@@ -142,17 +143,17 @@ std::vector<concptr> read_pickpref_text_lines(PlayerType *player_ptr, int *filen
     /* Try a filename with player name */
     *filename_mode_p = PT_WITH_PNAME;
     auto filename = pickpref_filename(player_ptr, *filename_mode_p);
-    std::vector<concptr> lines_list = read_text_lines(filename.data());
+    std::vector<concptr> lines_list = read_text_lines(filename);
 
     if (lines_list.empty()) {
         *filename_mode_p = PT_DEFAULT;
         filename = pickpref_filename(player_ptr, *filename_mode_p);
-        lines_list = read_text_lines(filename.data());
+        lines_list = read_text_lines(filename);
     }
 
     if (lines_list.empty()) {
         prepare_default_pickpref(player_ptr);
-        lines_list = read_text_lines(filename.data());
+        lines_list = read_text_lines(filename);
     }
 
     if (lines_list.empty()) {

--- a/src/autopick/autopick-reader-writer.cpp
+++ b/src/autopick/autopick-reader-writer.cpp
@@ -9,7 +9,9 @@
 #include "util/string-processor.h"
 #include "view/display-messages.h"
 #include <stdexcept>
+#include <string>
 #include <string_view>
+#include <vector>
 
 /*!
  * @brief Load an autopick preference file
@@ -61,17 +63,14 @@ std::string pickpref_filename(PlayerType *player_ptr, int filename_mode)
  */
 static std::vector<concptr> read_text_lines(std::string_view filename)
 {
-    FILE *fff;
-
-    int lines = 0;
     char buf[1024];
-
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, filename);
-    fff = angband_fopen(buf, FileOpenMode::READ);
+    auto *fff = angband_fopen(buf, FileOpenMode::READ);
     if (!fff) {
         return {};
     }
 
+    auto lines = 0;
     std::vector<concptr> lines_list(MAX_LINES);
     while (angband_fgets(fff, buf, sizeof(buf)) == 0) {
         lines_list[lines++] = string_make(buf);
@@ -93,34 +92,31 @@ static std::vector<concptr> read_text_lines(std::string_view filename)
  */
 static void prepare_default_pickpref(PlayerType *player_ptr)
 {
-    const concptr messages[] = { _("あなたは「自動拾いエディタ」を初めて起動しました。", "You have activated the Auto-Picker Editor for the first time."),
+    const std::vector<std::string> messages = { _("あなたは「自動拾いエディタ」を初めて起動しました。", "You have activated the Auto-Picker Editor for the first time."),
         _("自動拾いのユーザー設定ファイルがまだ書かれていないので、", "Since user pref file for autopick is not yet created,"),
-        _("基本的な自動拾い設定ファイルをlib/pref/picktype.prfからコピーします。", "the default setting is loaded from lib/pref/pickpref.prf ."), nullptr };
+        _("基本的な自動拾い設定ファイルをlib/pref/picktype.prfからコピーします。", "the default setting is loaded from lib/pref/pickpref.prf .") };
 
     const auto filename = pickpref_filename(player_ptr, PT_DEFAULT);
-    for (int i = 0; messages[i]; i++) {
-        msg_print(messages[i]);
+    for (const auto &message : messages) {
+        msg_print(message);
     }
 
     msg_print(nullptr);
     char buf[1024];
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, filename);
-    FILE *user_fp;
-    user_fp = angband_fopen(buf, FileOpenMode::WRITE);
+    auto *user_fp = angband_fopen(buf, FileOpenMode::WRITE);
     if (!user_fp) {
         return;
     }
 
     fprintf(user_fp, "#***\n");
-    for (int i = 0; messages[i]; i++) {
-        fprintf(user_fp, "#***  %s\n", messages[i]);
+    for (const auto &message : messages) {
+        fprintf(user_fp, "#***  %s\n", message.data());
     }
 
     fprintf(user_fp, "#***\n\n\n");
     path_build(buf, sizeof(buf), ANGBAND_DIR_PREF, filename);
-    FILE *pref_fp;
-    pref_fp = angband_fopen(buf, FileOpenMode::READ);
-
+    auto *pref_fp = angband_fopen(buf, FileOpenMode::READ);
     if (!pref_fp) {
         angband_fclose(user_fp);
         return;
@@ -171,8 +167,7 @@ bool write_text_lines(concptr filename, concptr *lines_list)
 {
     char buf[1024];
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, filename);
-    FILE *fff;
-    fff = angband_fopen(buf, FileOpenMode::WRITE);
+    auto *fff = angband_fopen(buf, FileOpenMode::WRITE);
     if (!fff) {
         return false;
     }

--- a/src/autopick/autopick-reader-writer.cpp
+++ b/src/autopick/autopick-reader-writer.cpp
@@ -104,7 +104,7 @@ static void prepare_default_pickpref(PlayerType *player_ptr)
 
     msg_print(nullptr);
     char buf[1024];
-    path_build(buf, sizeof(buf), ANGBAND_DIR_USER, filename.data());
+    path_build(buf, sizeof(buf), ANGBAND_DIR_USER, filename);
     FILE *user_fp;
     user_fp = angband_fopen(buf, FileOpenMode::WRITE);
     if (!user_fp) {
@@ -117,7 +117,7 @@ static void prepare_default_pickpref(PlayerType *player_ptr)
     }
 
     fprintf(user_fp, "#***\n\n\n");
-    path_build(buf, sizeof(buf), ANGBAND_DIR_PREF, filename.data());
+    path_build(buf, sizeof(buf), ANGBAND_DIR_PREF, filename);
     FILE *pref_fp;
     pref_fp = angband_fopen(buf, FileOpenMode::READ);
 

--- a/src/autopick/autopick-reader-writer.cpp
+++ b/src/autopick/autopick-reader-writer.cpp
@@ -163,7 +163,7 @@ std::vector<concptr> read_pickpref_text_lines(PlayerType *player_ptr, int *filen
 /*!
  * @brief Write whole lines of memory to a file.
  */
-bool write_text_lines(concptr filename, concptr *lines_list)
+bool write_text_lines(std::string_view filename, const std::vector<concptr> &lines)
 {
     char buf[1024];
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, filename);
@@ -172,8 +172,8 @@ bool write_text_lines(concptr filename, concptr *lines_list)
         return false;
     }
 
-    for (int lines = 0; lines_list[lines]; lines++) {
-        angband_fputs(fff, lines_list[lines], 1024);
+    for (const auto *line : lines) {
+        angband_fputs(fff, line, 1024);
     }
 
     angband_fclose(fff);

--- a/src/autopick/autopick-reader-writer.h
+++ b/src/autopick/autopick-reader-writer.h
@@ -1,12 +1,12 @@
 ﻿#pragma once
 
 #include "system/angband.h"
-
 #include <string>
+#include <string_view>
 #include <vector>
 
 class PlayerType;
 void autopick_load_pref(PlayerType *player_ptr, bool disp_mes);
 std::vector<concptr> read_pickpref_text_lines(PlayerType *player_ptr, int *filename_mode_p);
-bool write_text_lines(concptr filename, concptr *lines_list);
+bool write_text_lines(std::string_view filename, const std::vector<concptr> &lines);
 std::string pickpref_filename(PlayerType *player_ptr, int filename_mode);

--- a/src/autopick/autopick-registry.cpp
+++ b/src/autopick/autopick-registry.cpp
@@ -29,12 +29,12 @@ static const char autoregister_header[] = "?:$AUTOREGISTER";
 static bool clear_auto_register(PlayerType *player_ptr)
 {
     char pref_file[1024];
-    path_build(pref_file, sizeof(pref_file), ANGBAND_DIR_USER, pickpref_filename(player_ptr, PT_WITH_PNAME).data());
+    path_build(pref_file, sizeof(pref_file), ANGBAND_DIR_USER, pickpref_filename(player_ptr, PT_WITH_PNAME));
     FILE *pref_fff;
     pref_fff = angband_fopen(pref_file, FileOpenMode::READ);
 
     if (!pref_fff) {
-        path_build(pref_file, sizeof(pref_file), ANGBAND_DIR_USER, pickpref_filename(player_ptr, PT_DEFAULT).data());
+        path_build(pref_file, sizeof(pref_file), ANGBAND_DIR_USER, pickpref_filename(player_ptr, PT_DEFAULT));
         pref_fff = angband_fopen(pref_file, FileOpenMode::READ);
     }
 
@@ -145,11 +145,11 @@ bool autopick_autoregister(PlayerType *player_ptr, ItemEntity *o_ptr)
     char buf[1024];
     char pref_file[1024];
     FILE *pref_fff;
-    path_build(pref_file, sizeof(pref_file), ANGBAND_DIR_USER, pickpref_filename(player_ptr, PT_WITH_PNAME).data());
+    path_build(pref_file, sizeof(pref_file), ANGBAND_DIR_USER, pickpref_filename(player_ptr, PT_WITH_PNAME));
     pref_fff = angband_fopen(pref_file, FileOpenMode::READ);
 
     if (!pref_fff) {
-        path_build(pref_file, sizeof(pref_file), ANGBAND_DIR_USER, pickpref_filename(player_ptr, PT_DEFAULT).data());
+        path_build(pref_file, sizeof(pref_file), ANGBAND_DIR_USER, pickpref_filename(player_ptr, PT_DEFAULT));
         pref_fff = angband_fopen(pref_file, FileOpenMode::READ);
     }
 

--- a/src/autopick/autopick-registry.cpp
+++ b/src/autopick/autopick-registry.cpp
@@ -30,9 +30,7 @@ static bool clear_auto_register(PlayerType *player_ptr)
 {
     char pref_file[1024];
     path_build(pref_file, sizeof(pref_file), ANGBAND_DIR_USER, pickpref_filename(player_ptr, PT_WITH_PNAME));
-    FILE *pref_fff;
-    pref_fff = angband_fopen(pref_file, FileOpenMode::READ);
-
+    auto *pref_fff = angband_fopen(pref_file, FileOpenMode::READ);
     if (!pref_fff) {
         path_build(pref_file, sizeof(pref_file), ANGBAND_DIR_USER, pickpref_filename(player_ptr, PT_DEFAULT));
         pref_fff = angband_fopen(pref_file, FileOpenMode::READ);
@@ -43,8 +41,7 @@ static bool clear_auto_register(PlayerType *player_ptr)
     }
 
     char tmp_file[1024];
-    FILE *tmp_fff;
-    tmp_fff = angband_fopen_temp(tmp_file, sizeof(tmp_file));
+    auto *tmp_fff = angband_fopen_temp(tmp_file, sizeof(tmp_file));
     if (!tmp_fff) {
         fclose(pref_fff);
         msg_format(_("一時ファイル %s を作成できませんでした。", "Failed to create temporary file %s."), tmp_file);
@@ -52,8 +49,8 @@ static bool clear_auto_register(PlayerType *player_ptr)
         return false;
     }
 
-    bool autoregister = false;
-    int num = 0;
+    auto autoregister = false;
+    auto num = 0;
     char buf[1024];
     while (true) {
         if (angband_fgets(pref_fff, buf, sizeof(buf))) {
@@ -144,10 +141,8 @@ bool autopick_autoregister(PlayerType *player_ptr, ItemEntity *o_ptr)
 
     char buf[1024];
     char pref_file[1024];
-    FILE *pref_fff;
     path_build(pref_file, sizeof(pref_file), ANGBAND_DIR_USER, pickpref_filename(player_ptr, PT_WITH_PNAME));
-    pref_fff = angband_fopen(pref_file, FileOpenMode::READ);
-
+    auto *pref_fff = angband_fopen(pref_file, FileOpenMode::READ);
     if (!pref_fff) {
         path_build(pref_file, sizeof(pref_file), ANGBAND_DIR_USER, pickpref_filename(player_ptr, PT_DEFAULT));
         pref_fff = angband_fopen(pref_file, FileOpenMode::READ);

--- a/src/cmd-io/cmd-autopick.cpp
+++ b/src/cmd-io/cmd-autopick.cpp
@@ -204,7 +204,7 @@ void do_cmd_edit_autopick(PlayerType *player_ptr)
     const auto filename = pickpref_filename(player_ptr, tb->filename_mode);
 
     if (quit == APE_QUIT_AND_SAVE) {
-        write_text_lines(filename.data(), tb->lines_list.data());
+        write_text_lines(filename.data(), tb->lines_list);
     }
 
     free_text_lines(tb->lines_list);

--- a/src/cmd-io/cmd-diary.cpp
+++ b/src/cmd-io/cmd-diary.cpp
@@ -26,10 +26,10 @@
  */
 static void display_diary(PlayerType *player_ptr)
 {
-    std::stringstream file_name;
-    file_name << _("playrecord-", "playrec-") << savefile_base << ".txt";
+    std::stringstream ss;
+    ss << _("playrecord-", "playrec-") << savefile_base << ".txt";
     char buf[1024];
-    path_build(buf, sizeof(buf), ANGBAND_DIR_USER, file_name.str());
+    path_build(buf, sizeof(buf), ANGBAND_DIR_USER, ss.str());
 
     PlayerClass pc(player_ptr);
     const auto max_subtitles = diary_subtitles.size();

--- a/src/cmd-io/cmd-diary.cpp
+++ b/src/cmd-io/cmd-diary.cpp
@@ -29,7 +29,7 @@ static void display_diary(PlayerType *player_ptr)
     std::stringstream file_name;
     file_name << _("playrecord-", "playrec-") << savefile_base << ".txt";
     char buf[1024];
-    path_build(buf, sizeof(buf), ANGBAND_DIR_USER, file_name.str().data());
+    path_build(buf, sizeof(buf), ANGBAND_DIR_USER, file_name.str());
 
     PlayerClass pc(player_ptr);
     const auto max_subtitles = diary_subtitles.size();
@@ -90,20 +90,19 @@ static void do_cmd_last_get(PlayerType *player_ptr)
 /*!
  * @brief ファイル中の全日記記録を消去する /
  */
-static void do_cmd_erase_diary(void)
+static void do_cmd_erase_diary()
 {
-    char buf[256];
-    FILE *fff = nullptr;
-
     if (!get_check(_("本当に記録を消去しますか？", "Do you really want to delete all your records? "))) {
         return;
     }
-    std::string file_name = _("playrecord-", "playrec-");
-    file_name.append(savefile_base).append(".txt");
-    path_build(buf, sizeof(buf), ANGBAND_DIR_USER, file_name.data());
+
+    std::stringstream ss;
+    ss << _("playrecord-", "playrec-") << savefile_base << ".txt";
+    char buf[256];
+    path_build(buf, sizeof(buf), ANGBAND_DIR_USER, ss.str());
     fd_kill(buf);
 
-    fff = angband_fopen(buf, FileOpenMode::WRITE);
+    auto *fff = angband_fopen(buf, FileOpenMode::WRITE);
     if (fff) {
         angband_fclose(fff);
         msg_format(_("記録を消去しました。", "deleted record."));

--- a/src/cmd-io/cmd-dump.cpp
+++ b/src/cmd-io/cmd-dump.cpp
@@ -93,7 +93,7 @@ void do_cmd_colors(PlayerType *player_ptr)
             term_xtra(TERM_XTRA_REACT, 0);
             term_redraw();
         } else if (i == '2') {
-            static concptr mark = "Colors";
+            constexpr auto mark = "Colors";
             prt(_("コマンド: カラーの設定をファイルに書き出します", "Command: Dump colors"), 8, 0);
             prt(_("ファイル: ", "File: "), 10, 0);
             strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
@@ -113,7 +113,7 @@ void do_cmd_colors(PlayerType *player_ptr)
                 int gv = angband_color_table[i][2];
                 int bv = angband_color_table[i][3];
 
-                concptr name = _("未知", "unknown");
+                auto name = _("未知", "unknown");
                 if (!kv && !rv && !gv && !bv) {
                     continue;
                 }
@@ -267,14 +267,10 @@ void do_cmd_time(PlayerType *player_ptr)
 {
     int day, hour, min;
     extract_day_hour_min(player_ptr, &day, &hour, &min);
-
     std::string desc = _("変な時刻だ。", "It is a strange time.");
-
     std::string day_buf = (day < MAX_DAYS) ? std::to_string(day) : "*****";
-
-    msg_format(_("%s日目, 時刻は%d:%02d %sです。", "This is day %s. The time is %d:%02d %s."), day_buf.data(), (hour % 12 == 0) ? 12 : (hour % 12), min,
-        (hour < 12) ? "AM" : "PM");
-
+    constexpr auto mes = _("%s日目, 時刻は%d:%02d %sです。", "This is day %s. The time is %d:%02d %s.");
+    msg_format(mes, day_buf.data(), (hour % 12 == 0) ? 12 : (hour % 12), min, (hour < 12) ? "AM" : "PM");
     char buf[1024];
     if (!randint0(10) || player_ptr->effects()->hallucination()->is_hallucinated()) {
         path_build(buf, sizeof(buf), ANGBAND_DIR_FILE, _("timefun_j.txt", "timefun.txt"));
@@ -282,17 +278,15 @@ void do_cmd_time(PlayerType *player_ptr)
         path_build(buf, sizeof(buf), ANGBAND_DIR_FILE, _("timenorm_j.txt", "timenorm.txt"));
     }
 
-    FILE *fff;
-    fff = angband_fopen(buf, FileOpenMode::READ);
-
+    auto *fff = angband_fopen(buf, FileOpenMode::READ);
     if (!fff) {
         return;
     }
 
-    int full = hour * 100 + min;
-    int start = 9999;
-    int end = -9999;
-    int num = 0;
+    auto full = hour * 100 + min;
+    auto start = 9999;
+    auto end = -9999;
+    auto num = 0;
     while (!angband_fgets(fff, buf, sizeof(buf))) {
         if (!buf[0] || (buf[0] == '#')) {
             continue;

--- a/src/cmd-io/cmd-macro.cpp
+++ b/src/cmd-io/cmd-macro.cpp
@@ -23,7 +23,7 @@
  */
 static void macro_dump(FILE **fpp, concptr fname)
 {
-    static concptr mark = "Macro Dump";
+    constexpr auto mark = "Macro Dump";
     char buf[1024];
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, fname);
     if (!open_auto_dump(fpp, buf, mark)) {
@@ -32,7 +32,7 @@ static void macro_dump(FILE **fpp, concptr fname)
 
     auto_dump_printf(*fpp, _("\n# 自動マクロセーブ\n\n", "\n# Automatic macro dump\n\n"));
 
-    for (int i = 0; i < macro__num; i++) {
+    for (auto i = 0; i < macro__num; i++) {
         ascii_to_text(buf, macro__act[i], sizeof(buf));
         auto_dump_printf(*fpp, "A:%s\n", buf);
         ascii_to_text(buf, macro__pat[i], sizeof(buf));
@@ -105,7 +105,6 @@ static void do_cmd_macro_aux_keymap(char *buf)
 static errr keymap_dump(concptr fname)
 {
     FILE *auto_dump_stream;
-    static concptr mark = "Keymap Dump";
     char key[1024];
     char buf[1024];
     BIT_FLAGS mode;
@@ -116,6 +115,7 @@ static errr keymap_dump(concptr fname)
     }
 
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, fname);
+    constexpr auto mark = "Keymap Dump";
     if (!open_auto_dump(&auto_dump_stream, buf, mark)) {
         return -1;
     }

--- a/src/cmd-io/cmd-process-screen.cpp
+++ b/src/cmd-io/cmd-process-screen.cpp
@@ -204,8 +204,7 @@ void do_cmd_save_screen_html_aux(char *filename, int message)
 {
     TERM_LEN wid, hgt;
     term_get_size(&wid, &hgt);
-    FILE *fff;
-    fff = angband_fopen(filename, FileOpenMode::WRITE);
+    auto *fff = angband_fopen(filename, FileOpenMode::WRITE);
     if (!check_screen_html_can_open(fff, filename, message)) {
         return;
     }
@@ -216,8 +215,7 @@ void do_cmd_save_screen_html_aux(char *filename, int message)
 
     char buf[2048];
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, "htmldump.prf");
-    FILE *tmpfff;
-    tmpfff = angband_fopen(buf, FileOpenMode::READ);
+    auto *tmpfff = angband_fopen(buf, FileOpenMode::READ);
     write_html_header(tmpfff, fff, buf, sizeof(buf));
     screen_dump_lines(wid, hgt, fff);
     write_html_footer(tmpfff, fff, buf, sizeof(buf));
@@ -239,14 +237,12 @@ void do_cmd_save_screen_html_aux(char *filename, int message)
 static void do_cmd_save_screen_html(void)
 {
     char buf[1024], tmp[256] = "screen.html";
-
     if (!get_string(_("ファイル名: ", "File name: "), tmp, 80)) {
         return;
     }
+
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, tmp);
-
     msg_print(nullptr);
-
     do_cmd_save_screen_html_aux(buf, 1);
 }
 
@@ -305,10 +301,9 @@ static bool do_cmd_save_screen_text(int wid, int hgt)
 {
     TERM_COLOR a = 0;
     auto c = ' ';
-    FILE *fff;
     char buf[1024];
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, "dump.txt");
-    fff = angband_fopen(buf, FileOpenMode::WRITE);
+    auto *fff = angband_fopen(buf, FileOpenMode::WRITE);
     if (!check_screen_text_can_open(fff, buf)) {
         return false;
     }
@@ -481,12 +476,11 @@ static void draw_colored_characters(char buf[], FILE *fff, int wid, int hgt, boo
  */
 void do_cmd_load_screen(void)
 {
-    FILE *fff;
     char buf[1024];
     TERM_LEN wid, hgt;
     term_get_size(&wid, &hgt);
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, "dump.txt");
-    fff = angband_fopen(buf, FileOpenMode::READ);
+    auto *fff = angband_fopen(buf, FileOpenMode::READ);
     if (!fff) {
         msg_format(_("%s を開くことができませんでした。", "Failed to open %s."), buf);
         msg_print(nullptr);

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -115,7 +115,6 @@ void do_cmd_visuals(PlayerType *player_ptr)
             break;
         }
         case '1': {
-            static concptr mark = "Monster attr/chars";
             prt(_("コマンド: モンスターの[色/文字]をファイルに書き出します", "Command: Dump monster attr/chars"), 15, 0);
             prt(_("ファイル: ", "File: "), 17, 0);
             strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
@@ -124,6 +123,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
             }
 
             path_build(buf, sizeof(buf), ANGBAND_DIR_USER, tmp);
+            constexpr auto mark = "Monster attr/chars";
             if (!open_auto_dump(&auto_dump_stream, buf, mark)) {
                 continue;
             }
@@ -143,7 +143,6 @@ void do_cmd_visuals(PlayerType *player_ptr)
             break;
         }
         case '2': {
-            static concptr mark = "Object attr/chars";
             prt(_("コマンド: アイテムの[色/文字]をファイルに書き出します", "Command: Dump object attr/chars"), 15, 0);
             prt(_("ファイル: ", "File: "), 17, 0);
             strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
@@ -152,6 +151,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
             }
 
             path_build(buf, sizeof(buf), ANGBAND_DIR_USER, tmp);
+            constexpr auto mark = "Object attr/chars";
             if (!open_auto_dump(&auto_dump_stream, buf, mark)) {
                 continue;
             }
@@ -180,7 +180,6 @@ void do_cmd_visuals(PlayerType *player_ptr)
             break;
         }
         case '3': {
-            static concptr mark = "Feature attr/chars";
             prt(_("コマンド: 地形の[色/文字]をファイルに書き出します", "Command: Dump feature attr/chars"), 15, 0);
             prt(_("ファイル: ", "File: "), 17, 0);
             strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
@@ -189,6 +188,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
             }
 
             path_build(buf, sizeof(buf), ANGBAND_DIR_USER, tmp);
+            constexpr auto mark = "Feature attr/chars";
             if (!open_auto_dump(&auto_dump_stream, buf, mark)) {
                 continue;
             }

--- a/src/core/game-closer.cpp
+++ b/src/core/game-closer.cpp
@@ -144,7 +144,6 @@ static void kingly(PlayerType *player_ptr)
  */
 void close_game(PlayerType *player_ptr)
 {
-    bool do_send = true;
     handle_stuff(player_ptr);
     msg_print(nullptr);
     flush();
@@ -166,6 +165,7 @@ void close_game(PlayerType *player_ptr)
         kingly(player_ptr);
     }
 
+    auto do_send = true;
     if (!cheat_save || get_check(_("死んだデータをセーブしますか？ ", "Save death? "))) {
         update_playtime();
         w_ptr->sf_play_time += w_ptr->play_time;

--- a/src/core/scores.cpp
+++ b/src/core/scores.cpp
@@ -361,9 +361,7 @@ void show_highclass(PlayerType *player_ptr)
     screen_save();
     char buf[1024], out_val[256];
     path_build(buf, sizeof(buf), ANGBAND_DIR_APEX, "scores.raw");
-
     highscore_fd = fd_open(buf, O_RDONLY);
-
     if (highscore_fd < 0) {
         msg_print(_("スコア・ファイルが使用できません。", "Score file unavailable."));
         msg_print(nullptr);
@@ -443,9 +441,7 @@ void race_score(PlayerType *player_ptr, int race_num)
     /* rr9: TODO - pluralize the race */
     prt(std::string(_("最高の", "The Greatest of all the ")).append(race_info[race_num].title), 5, 15);
     path_build(buf, sizeof(buf), ANGBAND_DIR_APEX, "scores.raw");
-
     highscore_fd = fd_open(buf, O_RDONLY);
-
     if (highscore_fd < 0) {
         msg_print(_("スコア・ファイルが使用できません。", "Score file unavailable."));
         msg_print(nullptr);

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -10,6 +10,7 @@
 #include "grid/object-placer.h"
 #include "grid/trap.h"
 #include "info-reader/general-parser.h"
+#include "info-reader/parse-error-types.h"
 #include "info-reader/random-grid-effect-types.h"
 #include "io/tokenizer.h"
 #include "monster-floor/monster-generator.h"

--- a/src/floor/fixed-map-generator.h
+++ b/src/floor/fixed-map-generator.h
@@ -1,6 +1,5 @@
 ﻿#pragma once
 
-#include "info-reader/parse-error-types.h"
 #include "system/angband.h"
 
 // Quest/Town/World Generator
@@ -15,7 +14,8 @@ struct qtwg_type {
 };
 
 class PlayerType;
-typedef parse_error_type (*process_dungeon_file_pf)(PlayerType *, concptr, int, int, int, int);
+enum parse_error_type : int;
+typedef parse_error_type (*process_dungeon_file_pf)(PlayerType *, std::string_view, int, int, int, int);
 
 qtwg_type *initialize_quest_generator_type(qtwg_type *qg_ptr, char *buf, int ymin, int xmin, int ymax, int xmax, int *y, int *x);
 parse_error_type generate_fixed_map_floor(PlayerType *player_ptr, qtwg_type *qg_ptr, process_dungeon_file_pf parse_fixed_map);

--- a/src/info-reader/fixed-map-parser.cpp
+++ b/src/info-reader/fixed-map-parser.cpp
@@ -255,7 +255,7 @@ parse_error_type parse_fixed_map(PlayerType *player_ptr, std::string_view name, 
 {
     char buf[1024];
     path_build(buf, sizeof(buf), ANGBAND_DIR_EDIT, name);
-    FILE *fp = angband_fopen(buf, FileOpenMode::READ);
+    auto *fp = angband_fopen(buf, FileOpenMode::READ);
     if (fp == nullptr) {
         return PARSE_ERROR_GENERIC;
     }
@@ -294,7 +294,7 @@ parse_error_type parse_fixed_map(PlayerType *player_ptr, std::string_view name, 
 
     if (err != 0) {
         concptr oops = (((err > 0) && (err < PARSE_ERROR_MAX)) ? err_str[err] : "unknown");
-        msg_format("Error %d (%s) at line %d of '%s'.", err, oops, num, name);
+        msg_format("Error %d (%s) at line %d of '%s'.", err, oops, num, name.data());
         msg_format(_("'%s'を解析中。", "Parsing '%s'."), buf);
         msg_print(nullptr);
     }
@@ -330,7 +330,6 @@ static QuestId parse_quest_number(const std::vector<std::string> &token)
  */
 static void parse_quest_info_aux(std::string_view file_name, std::set<QuestId> &key_list_ref)
 {
-
     auto push_set = [&key_list_ref, &file_name](auto q, auto line) {
         if (q == QuestId::NONE) {
             return;

--- a/src/info-reader/fixed-map-parser.cpp
+++ b/src/info-reader/fixed-map-parser.cpp
@@ -11,6 +11,7 @@
 #include "floor/fixed-map-generator.h"
 #include "game-option/birth-options.h"
 #include "game-option/runtime-arguments.h"
+#include "info-reader/parse-error-types.h"
 #include "io/files-util.h"
 #include "main/init-error-messages-table.h"
 #include "player-info/class-info.h"
@@ -250,7 +251,7 @@ static concptr parse_fixed_map_expression(PlayerType *player_ptr, char **sp, cha
  * @param xmax 詳細不明
  * @return エラーコード
  */
-parse_error_type parse_fixed_map(PlayerType *player_ptr, concptr name, int ymin, int xmin, int ymax, int xmax)
+parse_error_type parse_fixed_map(PlayerType *player_ptr, std::string_view name, int ymin, int xmin, int ymax, int xmax)
 {
     char buf[1024];
     path_build(buf, sizeof(buf), ANGBAND_DIR_EDIT, name);
@@ -327,7 +328,7 @@ static QuestId parse_quest_number(const std::vector<std::string> &token)
  * @param file_name ファイル名
  * @param key_list キーになるQuestIdの配列
  */
-static void parse_quest_info_aux(const char *file_name, std::set<QuestId> &key_list_ref)
+static void parse_quest_info_aux(std::string_view file_name, std::set<QuestId> &key_list_ref)
 {
 
     auto push_set = [&key_list_ref, &file_name](auto q, auto line) {
@@ -384,7 +385,7 @@ static void parse_quest_info_aux(const char *file_name, std::set<QuestId> &key_l
  * @param file_name ファイル名
  * @return クエスト番号の配列
  */
-std::set<QuestId> parse_quest_info(const char *file_name)
+std::set<QuestId> parse_quest_info(std::string_view file_name)
 {
     std::set<QuestId> key_list;
     parse_quest_info_aux(file_name, key_list);

--- a/src/info-reader/fixed-map-parser.h
+++ b/src/info-reader/fixed-map-parser.h
@@ -1,10 +1,10 @@
 ﻿#pragma once
 
-#include "info-reader/parse-error-types.h"
-#include "system/angband.h"
 #include <set>
+#include <string_view>
 
 class PlayerType;
+enum parse_error_type : int;
 enum class QuestId : int16_t;
-parse_error_type parse_fixed_map(PlayerType *player_ptr, concptr name, int ymin, int xmin, int ymax, int xmax);
-std::set<QuestId> parse_quest_info(const char *file_name);
+parse_error_type parse_fixed_map(PlayerType *player_ptr, std::string_view name, int ymin, int xmin, int ymax, int xmax);
+std::set<QuestId> parse_quest_info(std::string_view file_name);

--- a/src/io-dump/dump-remover.cpp
+++ b/src/io-dump/dump-remover.cpp
@@ -12,7 +12,7 @@
  * @param orig_file 消去を行うファイル名
  * @param auto_dump_mark 出力するヘッダマーク
  */
-void remove_auto_dump(concptr orig_file, concptr auto_dump_mark)
+void remove_auto_dump(const std::filesystem::path &orig_file, std::string_view auto_dump_mark)
 {
     char buf[1024];
     bool between_mark = false;
@@ -22,8 +22,8 @@ void remove_auto_dump(concptr orig_file, concptr auto_dump_mark)
     char header_mark_str[80];
     char footer_mark_str[80];
 
-    strnfmt(header_mark_str, sizeof(header_mark_str), auto_dump_header, auto_dump_mark);
-    strnfmt(footer_mark_str, sizeof(footer_mark_str), auto_dump_footer, auto_dump_mark);
+    strnfmt(header_mark_str, sizeof(header_mark_str), auto_dump_header, auto_dump_mark.data());
+    strnfmt(footer_mark_str, sizeof(footer_mark_str), auto_dump_footer, auto_dump_mark.data());
     size_t mark_len = strlen(footer_mark_str);
 
     FILE *orig_fff;

--- a/src/io-dump/dump-remover.h
+++ b/src/io-dump/dump-remover.h
@@ -1,5 +1,6 @@
 ﻿#pragma once
 
-#include "system/angband.h"
+#include <filesystem>
+#include <string_view>
 
-void remove_auto_dump(concptr orig_file, concptr auto_dump_mark);
+void remove_auto_dump(const std::filesystem::path &orig_file, std::string_view auto_dump_mark);

--- a/src/io-dump/random-art-info-dumper.cpp
+++ b/src/io-dump/random-art-info-dumper.cpp
@@ -68,8 +68,6 @@ static void spoil_random_artifact_aux(PlayerType *player_ptr, ItemEntity *o_ptr,
  */
 void spoil_random_artifact(PlayerType *player_ptr, concptr fname)
 {
-    store_type *store_ptr;
-    ItemEntity *q_ptr;
     char buf[1024];
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, fname);
     spoiler_file = angband_fopen(buf, FileOpenMode::WRITE);
@@ -82,24 +80,24 @@ void spoil_random_artifact(PlayerType *player_ptr, concptr fname)
     for (const auto &[tval_list, name] : group_artifact_list) {
         for (auto tval : tval_list) {
             for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-                q_ptr = &player_ptr->inventory_list[i];
+                auto *q_ptr = &player_ptr->inventory_list[i];
                 spoil_random_artifact_aux(player_ptr, q_ptr, tval);
             }
 
             for (int i = 0; i < INVEN_PACK; i++) {
-                q_ptr = &player_ptr->inventory_list[i];
+                auto *q_ptr = &player_ptr->inventory_list[i];
                 spoil_random_artifact_aux(player_ptr, q_ptr, tval);
             }
 
-            store_ptr = &towns_info[1].store[enum2i(StoreSaleType::HOME)];
+            const auto *store_ptr = &towns_info[1].store[enum2i(StoreSaleType::HOME)];
             for (int i = 0; i < store_ptr->stock_num; i++) {
-                q_ptr = &store_ptr->stock[i];
+                auto *q_ptr = &store_ptr->stock[i];
                 spoil_random_artifact_aux(player_ptr, q_ptr, tval);
             }
 
             store_ptr = &towns_info[1].store[enum2i(StoreSaleType::MUSEUM)];
             for (int i = 0; i < store_ptr->stock_num; i++) {
-                q_ptr = &store_ptr->stock[i];
+                auto *q_ptr = &store_ptr->stock[i];
                 spoil_random_artifact_aux(player_ptr, q_ptr, tval);
             }
         }

--- a/src/io/files-util.cpp
+++ b/src/io/files-util.cpp
@@ -325,20 +325,19 @@ errr counts_write(PlayerType *player_ptr, int where, uint32_t count)
 }
 
 /*!
- * @brief 墓のアスキーアートテンプレを読み込む
- * @param buf テンプレへのバッファ
- * @param buf_size バッファの長さ
+ * @brief 墓のアスキーアートテンプレを読み込んで画面に表示する
  */
-void read_dead_file(char *buf, size_t buf_size)
+void read_dead_file()
 {
-    path_build(buf, buf_size, ANGBAND_DIR_FILE, _("dead_j.txt", "dead.txt"));
+    char buf[1024];
+    path_build(buf, sizeof(buf), ANGBAND_DIR_FILE, _("dead_j.txt", "dead.txt"));
     auto *fp = angband_fopen(buf, FileOpenMode::READ);
     if (!fp) {
         return;
     }
 
     int i = 0;
-    while (angband_fgets(fp, buf, buf_size) == 0) {
+    while (angband_fgets(fp, buf, sizeof(buf)) == 0) {
         put_str(buf, i++, 0);
     }
 

--- a/src/io/files-util.cpp
+++ b/src/io/files-util.cpp
@@ -63,7 +63,7 @@ errr file_character(PlayerType *player_ptr, concptr name)
 {
     char buf[1024];
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, name);
-    int fd = fd_open(buf, O_RDONLY);
+    auto fd = fd_open(buf, O_RDONLY);
     if (fd >= 0) {
         std::string query = _("現存するファイル ", "Replace existing file ");
         query.append(buf).append(_(" に上書きしますか? ", "? "));
@@ -271,15 +271,13 @@ uint32_t counts_read(PlayerType *player_ptr, int where)
 {
     char buf[1024];
     path_build(buf, sizeof(buf), ANGBAND_DIR_DATA, _("z_info_j.raw", "z_info.raw"));
-    int fd = fd_open(buf, O_RDONLY);
-
+    auto fd = fd_open(buf, O_RDONLY);
     uint32_t count = 0;
     if (counts_seek(player_ptr, fd, where, false) || fd_read(fd, (char *)(&count), sizeof(uint32_t))) {
         count = 0;
     }
 
     (void)fd_close(fd);
-
     return count;
 }
 
@@ -306,7 +304,7 @@ errr counts_write(PlayerType *player_ptr, int where, uint32_t count)
     }
 
     safe_setuid_grab(player_ptr);
-    errr err = fd_lock(fd, F_WRLCK);
+    auto err = fd_lock(fd, F_WRLCK);
     safe_setuid_drop();
     if (err) {
         return 1;
@@ -334,9 +332,7 @@ errr counts_write(PlayerType *player_ptr, int where, uint32_t count)
 void read_dead_file(char *buf, size_t buf_size)
 {
     path_build(buf, buf_size, ANGBAND_DIR_FILE, _("dead_j.txt", "dead.txt"));
-
-    FILE *fp;
-    fp = angband_fopen(buf, FileOpenMode::READ);
+    auto *fp = angband_fopen(buf, FileOpenMode::READ);
     if (!fp) {
         return;
     }

--- a/src/io/files-util.h
+++ b/src/io/files-util.h
@@ -28,7 +28,7 @@ typedef void (*update_playtime_pf)(void);
 
 errr file_character(PlayerType *player_ptr, concptr name);
 std::optional<std::string> get_random_line(concptr file_name, int entry);
-void read_dead_file(char *buf, size_t buf_size);
+void read_dead_file();
 
 #ifdef JP
 std::optional<std::string> get_random_line_ja_only(concptr file_name, int entry, int count);

--- a/src/io/inet.cpp
+++ b/src/io/inet.cpp
@@ -32,17 +32,9 @@ static int proxy_port;
 void set_proxy(char *default_url, int default_port)
 {
     char buf[1024];
-    size_t len;
-    FILE *fp;
-    char *s;
-
     path_build(buf, sizeof(buf), ANGBAND_DIR_PREF, "proxy.prf");
-
-    /* ファイルから設定を読む。 */
-    fp = angband_fopen(buf, FileOpenMode::READ);
-
+    auto *fp = angband_fopen(buf, FileOpenMode::READ);
     if (!fp) {
-        /* ファイルが存在しない場合はデフォルトを設定 */
         proxy = default_url;
         proxy_port = default_port;
         return;
@@ -55,9 +47,7 @@ void set_proxy(char *default_url, int default_port)
     }
 
     angband_fclose(fp);
-
-    /* ポインタを用意。 */
-    s = buf;
+    auto *s = buf;
 
     /* "http://" から始まっている場合はその部分をカットする。 */
 #if defined(WINDOWS)
@@ -71,7 +61,7 @@ void set_proxy(char *default_url, int default_port)
 #endif
 
     /* 文字列の長さを調べ、必要なメモリを確保 */
-    len = strlen(s);
+    auto len = strlen(s);
     proxy = static_cast<char *>(malloc(len + 1));
 
     /* ポート番号があるかどうかを調べ、あればproxy_portに設定。 */

--- a/src/io/read-pref-file.cpp
+++ b/src/io/read-pref-file.cpp
@@ -1,16 +1,7 @@
 ﻿/*
  * @brief プレイヤーのインターフェイスに関するコマンドの実装 / Interface commands
- * @date 2020/03/01
+ * @date 2023/04/30
  * @author Mogami & Hourier
- * -Mogami-
- * remove_auto_dump(orig_file, mark)
- *     Remove the old automatic dump of type "mark".
- * auto_dump_printf(fmt, ...)
- *     Dump a formatted string using fprintf().
- * open_auto_dump(buf, mark)
- *     Open a file, remove old dump, and add new header.
- * close_auto_dump(void)
- *     Add a footer, and close the file.
  */
 
 #include "io/read-pref-file.h"

--- a/src/io/read-pref-file.cpp
+++ b/src/io/read-pref-file.cpp
@@ -159,7 +159,6 @@ errr process_pref_file(PlayerType *player_ptr, concptr name, bool only_user_dir)
     errr err1 = 0;
     if (!only_user_dir) {
         path_build(buf, sizeof(buf), ANGBAND_DIR_PREF, name);
-
         err1 = process_pref_file_aux(player_ptr, buf, PREF_TYPE_NORMAL);
         if (err1 > 0) {
             return err1;

--- a/src/io/read-pref-file.cpp
+++ b/src/io/read-pref-file.cpp
@@ -234,18 +234,19 @@ void auto_dump_printf(FILE *auto_dump_stream, concptr fmt, ...)
 /*!
  * @brief prfファイルをファイルオープンする /
  * Open file to append auto dump.
- * @param buf ファイル名
+ * @param path ファイル名
  * @param mark 出力するヘッダマーク
  * @return ファイルポインタを取得できたらTRUEを返す
  */
-bool open_auto_dump(FILE **fpp, concptr buf, concptr mark)
+bool open_auto_dump(FILE **fpp, const std::filesystem::path &path, std::string_view mark)
 {
     char header_mark_str[80];
-    strnfmt(header_mark_str, sizeof(header_mark_str), auto_dump_header, mark);
-    remove_auto_dump(buf, mark);
-    *fpp = angband_fopen(buf, FileOpenMode::APPEND);
+    strnfmt(header_mark_str, sizeof(header_mark_str), auto_dump_header, mark.data());
+    remove_auto_dump(path, mark);
+    *fpp = angband_fopen(path, FileOpenMode::APPEND);
     if (!fpp) {
-        msg_format(_("%s を開くことができませんでした。", "Failed to open %s."), buf);
+        const auto &path_str = path.string();
+        msg_format(_("%s を開くことができませんでした。", "Failed to open %s."), path_str.data());
         msg_print(nullptr);
         return false;
     }
@@ -263,10 +264,10 @@ bool open_auto_dump(FILE **fpp, concptr buf, concptr mark)
  * Append foot part and close auto dump.
  * @param auto_dump_mark 出力するヘッダマーク
  */
-void close_auto_dump(FILE **fpp, concptr auto_dump_mark)
+void close_auto_dump(FILE **fpp, std::string_view mark)
 {
     char footer_mark_str[80];
-    strnfmt(footer_mark_str, sizeof(footer_mark_str), auto_dump_footer, auto_dump_mark);
+    strnfmt(footer_mark_str, sizeof(footer_mark_str), auto_dump_footer, mark.data());
     auto_dump_printf(*fpp, _("# *警告!!* 以降の行は自動生成されたものです。\n", "# *Warning!*  The lines below are an automatic dump.\n"));
     auto_dump_printf(
         *fpp, _("# *警告!!* 後で自動的に削除されるので編集しないでください。\n", "# Don't edit them; changes will be deleted and replaced automatically.\n"));

--- a/src/io/read-pref-file.h
+++ b/src/io/read-pref-file.h
@@ -1,6 +1,8 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include <filesystem>
+#include <string_view>
 
 extern char auto_dump_header[];
 extern char auto_dump_footer[];
@@ -12,7 +14,7 @@ errr process_histpref_file(PlayerType *player_ptr, concptr name);
 bool read_histpref(PlayerType *player_ptr);
 
 void auto_dump_printf(FILE *auto_dump_stream, concptr fmt, ...) __attribute__((format(printf, 2, 3)));
-bool open_auto_dump(FILE **fpp, concptr buf, concptr mark);
-void close_auto_dump(FILE **fpp, concptr auto_dump_mark);
+bool open_auto_dump(FILE **fpp, const std::filesystem::path &path, std::string_view mark);
+void close_auto_dump(FILE **fpp, std::string_view mark);
 
 void load_all_pref_files(PlayerType *player_ptr);

--- a/src/io/read-pref-file.h
+++ b/src/io/read-pref-file.h
@@ -8,12 +8,12 @@ extern char auto_dump_header[];
 extern char auto_dump_footer[];
 
 class PlayerType;
-errr process_pref_file(PlayerType *player_ptr, concptr name, bool only_user_dir = false);
-errr process_autopick_file(PlayerType *player_ptr, concptr name);
-errr process_histpref_file(PlayerType *player_ptr, concptr name);
+errr process_pref_file(PlayerType *player_ptr, std::string_view name, bool only_user_dir = false);
+errr process_autopick_file(PlayerType *player_ptr, std::string_view name);
+errr process_histpref_file(PlayerType *player_ptr, std::string_view name);
 bool read_histpref(PlayerType *player_ptr);
 
-void auto_dump_printf(FILE *auto_dump_stream, concptr fmt, ...) __attribute__((format(printf, 2, 3)));
+void auto_dump_printf(FILE *auto_dump_stream, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
 bool open_auto_dump(FILE **fpp, const std::filesystem::path &path, std::string_view mark);
 void close_auto_dump(FILE **fpp, std::string_view mark);
 

--- a/src/io/record-play-movie.cpp
+++ b/src/io/record-play-movie.cpp
@@ -339,37 +339,41 @@ void prepare_movie_hooks(PlayerType *player_ptr)
         disable_chuukei_server();
         fd_close(movie_fd);
         msg_print(_("録画を終了しました。", "Stopped recording."));
-    } else {
-        char filename[80];
-        strnfmt(filename, sizeof(filename), "%s.amv", player_ptr->base_name);
-        if (get_string(_("ムービー記録ファイル: ", "Movie file name: "), filename, 80)) {
-            char buf[1024];
-            path_build(buf, sizeof(buf), ANGBAND_DIR_USER, filename);
-            auto fd = fd_open(buf, O_RDONLY);
-            if (fd >= 0) {
-                (void)fd_close(fd);
-                std::string query = _("現存するファイルに上>書きしますか? (", "Replace existing file ");
-                query.append(buf);
-                query.append(_(")", "? "));
-                if (!get_check(query)) {
-                    return;
-                }
-
-                movie_fd = fd_open(buf, O_WRONLY | O_TRUNC);
-            } else {
-                movie_fd = fd_make(buf);
-            }
-
-            if (!movie_fd) {
-                msg_print(_("ファイルを開けません！", "Can not open file."));
-                return;
-            }
-
-            movie_mode = 1;
-            prepare_chuukei_hooks();
-            do_cmd_redraw(player_ptr);
-        }
+        return;
     }
+
+    std::stringstream ss;
+    ss << player_ptr->base_name << ".amv";
+    auto movie_filename = ss.str();
+    if (!get_string(_("ムービー記録ファイル: ", "Movie file name: "), movie_filename.data(), 80)) {
+        return;
+    }
+
+    char buf[1024];
+    path_build(buf, sizeof(buf), ANGBAND_DIR_USER, movie_filename);
+    auto fd = fd_open(buf, O_RDONLY);
+    if (fd >= 0) {
+        (void)fd_close(fd);
+        std::string query = _("現存するファイルに上>書きしますか? (", "Replace existing file ");
+        query.append(buf);
+        query.append(_(")", "? "));
+        if (!get_check(query)) {
+            return;
+        }
+
+        movie_fd = fd_open(buf, O_WRONLY | O_TRUNC);
+    } else {
+        movie_fd = fd_make(buf);
+    }
+
+    if (!movie_fd) {
+        msg_print(_("ファイルを開けません！", "Can not open file."));
+        return;
+    }
+
+    movie_mode = 1;
+    prepare_chuukei_hooks();
+    do_cmd_redraw(player_ptr);
 }
 
 static int handle_movie_timestamp_data(int timestamp)
@@ -515,7 +519,7 @@ static void update_term_size(int x, int y, int len)
     }
 }
 
-static bool flush_ringbuf_client(void)
+static bool flush_ringbuf_client()
 {
     char buf[1024];
 
@@ -616,7 +620,7 @@ static bool flush_ringbuf_client(void)
     return true;
 }
 
-void prepare_browse_movie_without_path_build(concptr filename)
+void prepare_browse_movie_without_path_build(std::string_view filename)
 {
     movie_fd = fd_open(filename, O_RDONLY);
     init_buffer();
@@ -645,7 +649,7 @@ void browse_movie(void)
 }
 
 #ifndef WINDOWS
-void prepare_browse_movie_with_path_build(concptr filename)
+void prepare_browse_movie_with_path_build(std::string_view filename)
 {
     char buf[1024];
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, filename);

--- a/src/io/record-play-movie.cpp
+++ b/src/io/record-play-movie.cpp
@@ -344,22 +344,13 @@ void prepare_movie_hooks(PlayerType *player_ptr)
         strnfmt(filename, sizeof(filename), "%s.amv", player_ptr->base_name);
         if (get_string(_("ムービー記録ファイル: ", "Movie file name: "), filename, 80)) {
             char buf[1024];
-            int fd;
-
             path_build(buf, sizeof(buf), ANGBAND_DIR_USER, filename);
-
-            fd = fd_open(buf, O_RDONLY);
-
-            /* Existing file */
+            auto fd = fd_open(buf, O_RDONLY);
             if (fd >= 0) {
                 (void)fd_close(fd);
-
-                /* Build query */
                 std::string query = _("現存するファイルに上>書きしますか? (", "Replace existing file ");
                 query.append(buf);
                 query.append(_(")", "? "));
-
-                /* Ask */
                 if (!get_check(query)) {
                     return;
                 }

--- a/src/io/record-play-movie.h
+++ b/src/io/record-play-movie.h
@@ -1,11 +1,11 @@
 ﻿#pragma once
 
-#include "system/angband.h"
+#include <string_view>
 
 class PlayerType;
 void prepare_movie_hooks(PlayerType *player_ptr);
-void prepare_browse_movie_without_path_build(concptr filename);
-void browse_movie(void);
+void prepare_browse_movie_without_path_build(std::string_view filename);
+void browse_movie();
 #ifndef WINDOWS
-void prepare_browse_movie_with_path_build(concptr filename);
+void prepare_browse_movie_with_path_build(std::string_view filename);
 #endif

--- a/src/io/write-diary.cpp
+++ b/src/io/write-diary.cpp
@@ -20,6 +20,7 @@
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "world/world.h"
+#include <sstream>
 
 bool write_level; //!< @todo *抹殺* したい…
 
@@ -55,10 +56,10 @@ concptr get_ordinal_number_suffix(int num)
  */
 static bool open_diary_file(FILE **fff, bool *disable_diary)
 {
-    std::string file_name = _("playrecord-", "playrec-");
-    file_name.append(savefile_base).append(".txt");
+    std::stringstream ss;
+    ss << _("playrecord-", "playrec-") << savefile_base << ".txt";
     char buf[1024];
-    path_build(buf, sizeof(buf), ANGBAND_DIR_USER, file_name);
+    path_build(buf, sizeof(buf), ANGBAND_DIR_USER, ss.str());
     *fff = angband_fopen(buf, FileOpenMode::APPEND);
     if (*fff) {
         return true;

--- a/src/io/write-diary.cpp
+++ b/src/io/write-diary.cpp
@@ -58,7 +58,7 @@ static bool open_diary_file(FILE **fff, bool *disable_diary)
     std::string file_name = _("playrecord-", "playrec-");
     file_name.append(savefile_base).append(".txt");
     char buf[1024];
-    path_build(buf, sizeof(buf), ANGBAND_DIR_USER, file_name.data());
+    path_build(buf, sizeof(buf), ANGBAND_DIR_USER, file_name);
     *fff = angband_fopen(buf, FileOpenMode::APPEND);
     if (*fff) {
         return true;

--- a/src/main-gcu.cpp
+++ b/src/main-gcu.cpp
@@ -602,7 +602,7 @@ static bool init_sound(void)
         wav.append(".wav");
 
         /* Access the sound */
-        path_build(buf, sizeof(buf), ANGBAND_DIR_XTRA_SOUND, wav.data());
+        path_build(buf, sizeof(buf), ANGBAND_DIR_XTRA_SOUND, wav);
 
         /* Save the sound filename, if it exists */
         if (check_file(buf)) {

--- a/src/main-win/graphics-win.cpp
+++ b/src/main-win/graphics-win.cpp
@@ -79,8 +79,8 @@ graphics_mode change_graphics(graphics_mode arg)
 
     char buf[MAIN_WIN_MAX_PATH];
     BYTE wid, hgt, twid, thgt, ox, oy;
-    concptr name;
-    concptr name_mask = nullptr;
+    std::string name;
+    std::string name_mask("");
 
     infGraph.delete_bitmap();
 
@@ -124,7 +124,7 @@ graphics_mode change_graphics(graphics_mode arg)
     path_build(buf, sizeof(buf), ANGBAND_DIR_XTRA_GRAF, name);
     infGraph.hBitmap = read_graphic(buf);
     if (!infGraph.hBitmap) {
-        plog_fmt(_("ビットマップ '%s' を読み込めません。", "Cannot read bitmap file '%s'"), name);
+        plog_fmt(_("ビットマップ '%s' を読み込めません。", "Cannot read bitmap file '%s'"), name.data());
         ANGBAND_GRAF = "ascii";
         current_graphics_mode = graphics_mode::GRAPHICS_NONE;
         return current_graphics_mode;
@@ -137,11 +137,11 @@ graphics_mode change_graphics(graphics_mode arg)
     infGraph.OffsetX = ox;
     infGraph.OffsetY = oy;
 
-    if (name_mask) {
+    if (name_mask.empty()) {
         path_build(buf, sizeof(buf), ANGBAND_DIR_XTRA_GRAF, name_mask);
         infGraph.hBitmapMask = read_graphic(buf);
         if (!infGraph.hBitmapMask) {
-            plog_fmt(_("ビットマップ '%s' を読み込めません。", "Cannot read bitmap file '%s'"), name_mask);
+            plog_fmt(_("ビットマップ '%s' を読み込めません。", "Cannot read bitmap file '%s'"), name_mask.data());
             ANGBAND_GRAF = "ascii";
             current_graphics_mode = graphics_mode::GRAPHICS_NONE;
             return current_graphics_mode;

--- a/src/main-win/main-win-cfg-reader.cpp
+++ b/src/main-win/main-win-cfg-reader.cpp
@@ -114,7 +114,7 @@ CfgData *CfgReader::read_sections(std::initializer_list<cfg_section> sections)
                 guess_convert_to_system_encoding(buf, MAIN_WIN_MAX_PATH);
 #endif
                 const int num = tokenize_whitespace(buf, SAMPLE_MAX, tokens);
-                for (int j = 0; j < num; j++) {
+                for (auto j = 0; j < num; j++) {
                     path_build(path, MAIN_WIN_MAX_PATH, dir, tokens[j]);
                     if (check_file(path)) {
                         filenames->push_back(string_make(tokens[j]));

--- a/src/main-win/main-win-music.cpp
+++ b/src/main-win/main-win-music.cpp
@@ -185,7 +185,7 @@ errr play_music(int type, int val)
         return 0;
     } // now playing
 
-    concptr filename = music_cfg_data->get_rand(type, val);
+    auto filename = music_cfg_data->get_rand(type, val);
     if (!filename) {
         return 1;
     } // no setting

--- a/src/main-win/main-win-sound.cpp
+++ b/src/main-win/main-win-sound.cpp
@@ -255,14 +255,13 @@ void finalize_sound(void)
  */
 errr play_sound(int val, int volume)
 {
-    concptr filename = sound_cfg_data->get_rand(TERM_XTRA_SOUND, val);
+    auto filename = sound_cfg_data->get_rand(TERM_XTRA_SOUND, val);
     if (!filename) {
         return 1;
     }
 
     char buf[MAIN_WIN_MAX_PATH];
     path_build(buf, MAIN_WIN_MAX_PATH, ANGBAND_DIR_XTRA_SOUND, filename);
-
     if (play_sound_impl(buf, volume)) {
         return 0;
     }

--- a/src/main-x11.cpp
+++ b/src/main-x11.cpp
@@ -1806,7 +1806,7 @@ static void init_sound(void)
     for (i = 1; i < SOUND_MAX; i++) {
         std::string wav = angband_sound_name[i];
         wav.append(".wav");
-        path_build(buf, sizeof(buf), dir_xtra_sound, wav.data());
+        path_build(buf, sizeof(buf), dir_xtra_sound, wav);
         if (check_file(buf)) {
             sound_file[i] = string_make(buf);
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,7 +85,7 @@ static void create_user_dir(void)
     mkdir(dirpath.data(), 0700);
 
     char subdirpath[1024]{};
-    path_build(subdirpath, sizeof(subdirpath), dirpath.data(), VARIANT_NAME.data());
+    path_build(subdirpath, sizeof(subdirpath), dirpath, VARIANT_NAME);
     mkdir(subdirpath, 0700);
 }
 

--- a/src/main/angband-initializer.cpp
+++ b/src/main/angband-initializer.cpp
@@ -92,7 +92,7 @@ void init_file_paths(char *libpath, char *varpath)
     path_build(buf, sizeof(buf), ANGBAND_DIR_SAVE, "log");
     ANGBAND_DIR_DEBUG_SAVE = string_make(buf);
 #ifdef PRIVATE_USER_PATH
-    path_build(buf, sizeof(buf), PRIVATE_USER_PATH, VARIANT_NAME.data());
+    path_build(buf, sizeof(buf), PRIVATE_USER_PATH, VARIANT_NAME);
     ANGBAND_DIR_USER = string_make(buf);
 #else
     strcpy(vartail, "user");

--- a/src/main/angband-initializer.cpp
+++ b/src/main/angband-initializer.cpp
@@ -224,13 +224,10 @@ void init_angband(PlayerType *player_ptr, bool no_term)
     }
 
     (void)fd_close(fd);
-
     if (!no_term) {
         term_clear();
-
         path_build(buf, sizeof(buf), ANGBAND_DIR_FILE, _("news_j.txt", "news.txt"));
-        FILE *fp;
-        fp = angband_fopen(buf, FileOpenMode::READ);
+        auto *fp = angband_fopen(buf, FileOpenMode::READ);
         if (fp) {
             int i = 0;
             while (0 == angband_fgets(fp, buf, sizeof(buf))) {

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -93,7 +93,7 @@ template <typename InfoType>
 static errr init_info(std::string_view filename, angband_header &head, InfoType &info, Parser parser, Retoucher retouch = nullptr)
 {
     char buf[1024];
-    path_build(buf, sizeof(buf), ANGBAND_DIR_EDIT, filename.data());
+    path_build(buf, sizeof(buf), ANGBAND_DIR_EDIT, filename);
 
     auto *fp = angband_fopen(buf, FileOpenMode::READ);
     if (!fp) {

--- a/src/object-use/read/parchment-read-executor.cpp
+++ b/src/object-use/read/parchment-read-executor.cpp
@@ -32,7 +32,7 @@ bool ParchmentReadExecutor::read()
     screen_save();
     auto q = format("book-%d_jp.txt", this->o_ptr->bi_key.sval().value());
     const auto item_name = describe_flavor(this->player_ptr, this->o_ptr, OD_NAME_ONLY);
-    (void)path_build(buf, sizeof(buf), ANGBAND_DIR_FILE, q.data());
+    path_build(buf, sizeof(buf), ANGBAND_DIR_FILE, q);
     (void)show_file(this->player_ptr, true, buf, item_name.data(), 0, 0);
     screen_load();
     return false;

--- a/src/player/process-death.cpp
+++ b/src/player/process-death.cpp
@@ -209,8 +209,7 @@ static void show_tomb_detail(PlayerType *player_ptr)
 void print_tomb(PlayerType *player_ptr)
 {
     term_clear();
-    char buf[1024];
-    read_dead_file(buf, sizeof(buf));
+    read_dead_file();
     concptr p = w_ptr->total_winner ? _("偉大なる者", "Magnificent") : player_titles[enum2i(player_ptr->pclass)][(player_ptr->lev - 1) / 5].data();
 
     show_tomb_line(player_ptr->name, GRAVE_PLAYER_NAME_ROW);

--- a/src/player/process-name.cpp
+++ b/src/player/process-name.cpp
@@ -97,7 +97,7 @@ void process_player_name(PlayerType *player_ptr, bool is_new_savefile)
         /* Rename the savefile, using the player_ptr->base_name */
         temp = player_ptr->base_name;
 #endif
-        path_build(savefile, sizeof(savefile), ANGBAND_DIR_SAVE, temp.data());
+        path_build(savefile, sizeof(savefile), ANGBAND_DIR_SAVE, temp);
         is_modified = true;
     }
 

--- a/src/player/process-name.cpp
+++ b/src/player/process-name.cpp
@@ -102,10 +102,9 @@ void process_player_name(PlayerType *player_ptr, bool is_new_savefile)
     }
 
     if (is_modified || !savefile_base[0]) {
-        concptr s = savefile;
+        auto s = savefile;
         while (true) {
-            concptr t;
-            t = angband_strstr(s, PATH_SEP);
+            auto t = angband_strstr(s, PATH_SEP);
             if (!t) {
                 break;
             }

--- a/src/util/angband-files.cpp
+++ b/src/util/angband-files.cpp
@@ -154,28 +154,18 @@ static errr path_temp(char *buf, int max)
 #endif
 
 /*!
- * @brief ファイル入出力のためのパス生成する。/ Create a new path by appending a file (or directory) to a path.
+ * @brief OSの差異を吸収しつつ、絶対パスを生成する.
  * @param buf ファイルのフルを返すバッファ
  * @param max bufのサイズ
- * @param path ファイルパス
- * @param file ファイル名
- * @return エラーコード(ただし常に0を返す)
- *
- * This requires no special processing on simple machines, except
- * for verifying the size of the filename, but note the ability to
- * bypass the given "path" with certain special file-names.
- *
- * Note that the "file" may actually be a "sub-path", including
- * a path and a file.
- *
- * Note that this function yields a path which must be "parsed"
- * using the "parse" function above.
+ * @param directory ディレクトリ
+ * @param file ファイル名またはディレクトリ名
+ * @todo buf, max は削除してファイル名が長すぎたら例外を送出する。またreturn で絶対パスを返すように書き換える.
  */
 void path_build(char *buf, int max, const std::filesystem::path &path, std::string_view file)
 {
     if (file[0] == '~') {
         (void)strnfmt(buf, max, "%s", file);
-    } else if (prefix(file, PATH_SEP) && !streq(PATH_SEP, "")) {
+    } else if (prefix(file, PATH_SEP)) {
         (void)strnfmt(buf, max, "%s", file);
     } else if (!path.string()[0]) {
         (void)strnfmt(buf, max, "%s", file);

--- a/src/util/angband-files.cpp
+++ b/src/util/angband-files.cpp
@@ -171,19 +171,18 @@ static errr path_temp(char *buf, int max)
  * Note that this function yields a path which must be "parsed"
  * using the "parse" function above.
  */
-errr path_build(char *buf, int max, concptr path, concptr file)
+void path_build(char *buf, int max, const std::filesystem::path &path, std::string_view file)
 {
     if (file[0] == '~') {
         (void)strnfmt(buf, max, "%s", file);
     } else if (prefix(file, PATH_SEP) && !streq(PATH_SEP, "")) {
         (void)strnfmt(buf, max, "%s", file);
-    } else if (!path[0]) {
+    } else if (!path.string()[0]) {
         (void)strnfmt(buf, max, "%s", file);
     } else {
-        (void)strnfmt(buf, max, "%s%s%s", path, PATH_SEP, file);
+        const auto &path_str = path.string();
+        (void)strnfmt(buf, max, "%s%s%s", path_str.data(), PATH_SEP, file);
     }
-
-    return 0;
 }
 
 static std::string make_file_mode(const FileOpenMode mode, const bool is_binary)

--- a/src/util/angband-files.cpp
+++ b/src/util/angband-files.cpp
@@ -164,14 +164,14 @@ static errr path_temp(char *buf, int max)
 void path_build(char *buf, int max, const std::filesystem::path &path, std::string_view file)
 {
     if (file[0] == '~') {
-        (void)strnfmt(buf, max, "%s", file);
+        (void)strnfmt(buf, max, "%s", file.data());
     } else if (prefix(file, PATH_SEP)) {
-        (void)strnfmt(buf, max, "%s", file);
+        (void)strnfmt(buf, max, "%s", file.data());
     } else if (!path.string()[0]) {
-        (void)strnfmt(buf, max, "%s", file);
+        (void)strnfmt(buf, max, "%s", file.data());
     } else {
         const auto &path_str = path.string();
-        (void)strnfmt(buf, max, "%s%s%s", path_str.data(), PATH_SEP, file);
+        (void)strnfmt(buf, max, "%s%s%s", path_str.data(), PATH_SEP, file.data());
     }
 }
 

--- a/src/util/angband-files.h
+++ b/src/util/angband-files.h
@@ -42,7 +42,7 @@ enum class FileOpenMode {
 };
 
 std::filesystem::path path_parse(std::string_view file);
-errr path_build(char *buf, int max, concptr path, concptr file);
+void path_build(char *buf, int max, const std::filesystem::path &path, std::string_view file);
 FILE *angband_fopen(const std::filesystem::path &file, const FileOpenMode mode, const bool is_binary = false);
 FILE *angband_fopen_temp(char *buf, int max);
 errr angband_fgets(FILE *fff, char *buf, ulong n);

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -752,8 +752,7 @@ void wiz_dump_options(void)
 {
     char buf[1024];
     path_build(buf, sizeof(buf), ANGBAND_DIR_USER, "opt_info.txt");
-    FILE *fff;
-    fff = angband_fopen(buf, FileOpenMode::APPEND);
+    auto *fff = angband_fopen(buf, FileOpenMode::APPEND);
     if (fff == nullptr) {
         msg_format(_("ファイル %s を開けませんでした。", "Failed to open file %s."), buf);
         msg_print(nullptr);

--- a/src/wizard/wizard-spoiler.cpp
+++ b/src/wizard/wizard-spoiler.cpp
@@ -45,6 +45,7 @@
 #include <array>
 #include <iterator>
 #include <set>
+#include <sstream>
 #include <string>
 
 static constexpr std::array<std::string_view, 6> wiz_spell_stat = { {
@@ -105,10 +106,10 @@ static SpoilerOutputResultType spoil_mon_evol(concptr fname)
         return SpoilerOutputResultType::FILE_OPEN_FAILED;
     }
 
-    spoil_out(std::string("Monster Spoilers for ").append(get_version()).append("\n"));
-
+    std::stringstream ss;
+    ss << "Monster Spoilers for " << get_version() << '\n';
+    spoil_out(ss.str());
     spoil_out("------------------------------------------\n\n");
-
     for (auto r_idx : get_mon_evol_roots()) {
         auto r_ptr = &monraces_info[r_idx];
         fprintf(spoiler_file, _("[%d]: %s (レベル%d, '%c')\n", "[%d]: %s (Level %d, '%c')\n"), enum2i(r_idx), r_ptr->name.data(), (int)r_ptr->level, r_ptr->d_char);
@@ -177,7 +178,6 @@ static SpoilerOutputResultType spoil_categorized_mon_desc()
 static SpoilerOutputResultType spoil_player_spell(concptr fname)
 {
     char buf[1024];
-
     path_build(buf, sizeof buf, ANGBAND_DIR_USER, fname);
     spoiler_file = angband_fopen(buf, FileOpenMode::WRITE);
     if (!spoiler_file) {
@@ -189,13 +189,12 @@ static SpoilerOutputResultType spoil_player_spell(concptr fname)
 
     PlayerType dummy_p;
     dummy_p.lev = 1;
-
-    for (int c = 0; c < PLAYER_CLASS_TYPE_MAX; c++) {
+    for (auto c = 0; c < PLAYER_CLASS_TYPE_MAX; c++) {
         auto class_ptr = &class_info[c];
         spoil_out(format("[[Class: %s]]\n", class_ptr->title));
 
         auto magic_ptr = &class_magics_info[c];
-        concptr book_name = "なし";
+        auto book_name = "なし";
         if (magic_ptr->spell_book != ItemKindType::NONE) {
             ItemEntity book;
             auto o_ptr = &book;


### PR DESCRIPTION
掲題の通りです
起動時の各種設定ファイル、セーブデータ、自動拾い設定ファイル、マクロ定義ファイルの読み出しに成功しました
ご確認下さい