### PR TITLE
Include <sstream> since prepare_movie_hooks() uses std::stringstream

### DIFF
--- a/src/io/record-play-movie.cpp
+++ b/src/io/record-play-movie.cpp
@@ -18,6 +18,7 @@
 #include "util/angband-files.h"
 #include "view/display-messages.h"
 #include <algorithm>
+#include <sstream>
 
 #ifdef WINDOWS
 #include <windows.h>


### PR DESCRIPTION
Resolves https://github.com/hengband/hengband/issues/3225 .