### PR TITLE
ItemEntity にget_artifact() メソッドを追加し、ArtifactsInfo から取得していた処理を差し替えた

### DIFF
--- a/src/action/activation-execution.cpp
+++ b/src/action/activation-execution.cpp
@@ -55,7 +55,7 @@
 static void decide_activation_level(ae_type *ae_ptr)
 {
     if (ae_ptr->o_ptr->is_fixed_artifact()) {
-        ae_ptr->lev = ArtifactsInfo::get_instance().get_artifact(ae_ptr->o_ptr->fixed_artifact_idx).level;
+        ae_ptr->lev = ae_ptr->o_ptr->get_fixed_artifact().level;
         return;
     }
 

--- a/src/artifact/artifact-info.cpp
+++ b/src/artifact/artifact-info.cpp
@@ -29,7 +29,7 @@ RandomArtActType activation_index(const ItemEntity *o_ptr)
     }
 
     if (o_ptr->is_fixed_artifact()) {
-        const auto &artifact = ArtifactsInfo::get_instance().get_artifact(o_ptr->fixed_artifact_idx);
+        const auto &artifact = o_ptr->get_fixed_artifact();
         if (artifact.flags.has(TR_ACTIVATE)) {
             return artifact.act_idx;
         }

--- a/src/artifact/fixed-art-generator.cpp
+++ b/src/artifact/fixed-art-generator.cpp
@@ -225,7 +225,7 @@ static void invest_curse_to_fixed_artifact(const ArtifactType &artifact, ItemEnt
  */
 void apply_artifact(PlayerType *player_ptr, ItemEntity *o_ptr)
 {
-    const auto &artifact = ArtifactsInfo::get_instance().get_artifact(o_ptr->fixed_artifact_idx);
+    const auto &artifact = o_ptr->get_fixed_artifact();
     o_ptr->pval = artifact.pval;
     o_ptr->ac = artifact.ac;
     o_ptr->dd = artifact.dd;

--- a/src/flavor/flavor-util.cpp
+++ b/src/flavor/flavor-util.cpp
@@ -75,7 +75,7 @@ std::string get_ability_abbreviation(const ItemEntity &item, bool is_kanji, bool
         flags.reset(baseitem.flags);
 
         if (item.is_fixed_artifact()) {
-            const auto &artifact = ArtifactsInfo::get_instance().get_artifact(item.fixed_artifact_idx);
+            const auto &artifact = item.get_fixed_artifact();
             flags.reset(artifact.flags);
         }
 

--- a/src/flavor/named-item-describer.cpp
+++ b/src/flavor/named-item-describer.cpp
@@ -32,9 +32,8 @@ static std::string get_fullname_if_set(const ItemEntity &item, const describe_op
         return "";
     }
 
-    const auto fixed_art_id = item.fixed_artifact_idx;
     const auto is_known_artifact = opt.known && item.is_fixed_artifact() && none_bits(opt.mode, OD_BASE_NAME);
-    return is_known_artifact ? ArtifactsInfo::get_instance().get_artifact(fixed_art_id).name : item.get_baseitem().name;
+    return is_known_artifact ? item.get_fixed_artifact().name : item.get_baseitem().name;
 }
 
 #ifdef JP
@@ -110,7 +109,7 @@ static std::string describe_unique_name_before_body_ja(const ItemEntity &item, c
     }
 
     if (item.is_fixed_artifact() && object_flags(&item).has_not(TR_FULL_NAME)) {
-        const auto &artifact = ArtifactsInfo::get_instance().get_artifact(item.fixed_artifact_idx);
+        const auto &artifact = item.get_fixed_artifact();
         /* '『' から始まらない伝説のアイテムの名前は最初に付加する */
         if (artifact.name.find("『", 0, 2) != 0) {
             return artifact.name;
@@ -200,7 +199,7 @@ static std::string describe_unique_name_after_body_ja(const ItemEntity &item, co
     }
 
     if (item.is_fixed_artifact()) {
-        const auto &artifact = ArtifactsInfo::get_instance().get_artifact(item.fixed_artifact_idx);
+        const auto &artifact = item.get_fixed_artifact();
         if (artifact.name.find("『", 0, 2) == 0) {
             return artifact.name;
         }

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -195,7 +195,7 @@ static void update_unique_artifact(FloorType *floor_ptr, int16_t cur_floor_id)
         }
 
         if (o_ref.is_fixed_artifact()) {
-            ArtifactsInfo::get_instance().get_artifact(o_ref.fixed_artifact_idx).floor_id = cur_floor_id;
+            o_ref.get_fixed_artifact().floor_id = cur_floor_id;
         }
     }
 }
@@ -295,7 +295,7 @@ static void new_floor_allocation(PlayerType *player_ptr, saved_floor_type *sf_pt
             continue;
         }
 
-        auto &artifact = ArtifactsInfo::get_instance().get_artifact(o_ptr->fixed_artifact_idx);
+        auto &artifact = o_ptr->get_fixed_artifact();
         if (artifact.floor_id == new_floor_id) {
             artifact.is_generated = true;
         } else {

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -283,7 +283,7 @@ static void preserve_info(PlayerType *player_ptr)
         }
 
         if (o_ptr->is_fixed_artifact()) {
-            ArtifactsInfo::get_instance().get_artifact(o_ptr->fixed_artifact_idx).floor_id = 0;
+            o_ptr->get_fixed_artifact().floor_id = 0;
         }
     }
 }

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -458,7 +458,7 @@ OBJECT_IDX drop_near(PlayerType *player_ptr, ItemEntity *j_ptr, PERCENTAGE chanc
         flag = true;
     }
 
-    auto &artifact = ArtifactsInfo::get_instance().get_artifact(j_ptr->fixed_artifact_idx);
+    auto &artifact = j_ptr->get_fixed_artifact();
     if (!flag) {
         int candidates = 0, pick;
         for (ty = 1; ty < floor_ptr->height - 1; ty++) {

--- a/src/floor/floor-streams.cpp
+++ b/src/floor/floor-streams.cpp
@@ -363,7 +363,7 @@ void build_streamer(PlayerType *player_ptr, FEAT_IDX feat, int chance)
 
                     /* Hack -- Preserve unknown artifacts */
                     if (o_ptr->is_fixed_artifact()) {
-                        ArtifactsInfo::get_instance().get_artifact(o_ptr->fixed_artifact_idx).is_generated = false;
+                        o_ptr->get_fixed_artifact().is_generated = false;
                         if (cheat_peek) {
                             const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_NAME_ONLY | OD_STORE));
                             msg_format(_("伝説のアイテム (%s) はストリーマーにより削除された。", "Artifact (%s) was deleted by streamer."), item_name.data());

--- a/src/floor/floor-util.cpp
+++ b/src/floor/floor-util.cpp
@@ -133,7 +133,7 @@ void wipe_o_list(FloorType *floor_ptr)
 
         if (!w_ptr->character_dungeon || preserve_mode) {
             if (o_ptr->is_fixed_artifact() && !o_ptr->is_known()) {
-                ArtifactsInfo::get_instance().get_artifact(o_ptr->fixed_artifact_idx).is_generated = false;
+                o_ptr->get_fixed_artifact().is_generated = false;
             }
         }
 

--- a/src/grid/object-placer.cpp
+++ b/src/grid/object-placer.cpp
@@ -90,7 +90,7 @@ void place_object(PlayerType *player_ptr, POSITION y, POSITION x, BIT_FLAGS mode
     OBJECT_IDX o_idx = o_pop(floor_ptr);
     if (o_idx == 0) {
         if (q_ptr->is_fixed_artifact()) {
-            ArtifactsInfo::get_instance().get_artifact(q_ptr->fixed_artifact_idx).is_generated = false;
+            q_ptr->get_fixed_artifact().is_generated = false;
         }
 
         return;

--- a/src/load/old/load-v1-5-0.cpp
+++ b/src/load/old/load-v1-5-0.cpp
@@ -133,7 +133,7 @@ void rd_item_old(ItemEntity *o_ptr)
                 o_ptr->curse_flags.set(CurseTraitType::PERMA_CURSE);
             }
             if (o_ptr->is_fixed_artifact()) {
-                const auto &artifact = ArtifactsInfo::get_instance().get_artifact(o_ptr->fixed_artifact_idx);
+                const auto &artifact = o_ptr->get_fixed_artifact();
                 if (artifact.gen_flags.has(ItemGenerationTraitType::HEAVY_CURSE)) {
                     o_ptr->curse_flags.set(CurseTraitType::HEAVY_CURSE);
                 }
@@ -340,7 +340,7 @@ void rd_item_old(ItemEntity *o_ptr)
     }
 
     if (o_ptr->is_fixed_artifact()) {
-        const auto &artifact = ArtifactsInfo::get_instance().get_artifact(o_ptr->fixed_artifact_idx);
+        const auto &artifact = o_ptr->get_fixed_artifact();
         if (artifact.name.empty()) {
             o_ptr->fixed_artifact_idx = FixedArtifactId::NONE;
         }

--- a/src/object-enchant/item-magic-applier.cpp
+++ b/src/object-enchant/item-magic-applier.cpp
@@ -183,7 +183,7 @@ bool ItemMagicApplier::set_fixed_artifact_generation_info()
     }
 
     apply_artifact(this->player_ptr, this->o_ptr);
-    ArtifactsInfo::get_instance().get_artifact(this->o_ptr->fixed_artifact_idx).is_generated = true;
+    this->o_ptr->get_fixed_artifact().is_generated = true;
     return true;
 }
 

--- a/src/object/object-flags.cpp
+++ b/src/object/object-flags.cpp
@@ -56,7 +56,7 @@ TrFlags object_flags(const ItemEntity *o_ptr)
     auto flags = baseitem.flags;
 
     if (o_ptr->is_fixed_artifact()) {
-        flags = ArtifactsInfo::get_instance().get_artifact(o_ptr->fixed_artifact_idx).flags;
+        flags = o_ptr->get_fixed_artifact().flags;
     }
 
     if (o_ptr->is_ego()) {
@@ -105,7 +105,7 @@ TrFlags object_flags_known(const ItemEntity *o_ptr)
 
     if (o_ptr->is_fully_known()) {
         if (o_ptr->is_fixed_artifact()) {
-            flags = ArtifactsInfo::get_instance().get_artifact(o_ptr->fixed_artifact_idx).flags;
+            flags = o_ptr->get_fixed_artifact().flags;
         }
 
         flags.set(o_ptr->art_flags);

--- a/src/object/object-value-calc.cpp
+++ b/src/object/object-value-calc.cpp
@@ -26,7 +26,7 @@ PRICE flag_cost(const ItemEntity *o_ptr, int plusses)
     flags.reset(baseitem.flags);
 
     if (o_ptr->is_fixed_artifact()) {
-        const auto &artifact = ArtifactsInfo::get_instance().get_artifact(o_ptr->fixed_artifact_idx);
+        const auto &artifact = o_ptr->get_fixed_artifact();
         flags.reset(artifact.flags);
     } else if (o_ptr->is_ego()) {
         const auto &ego = o_ptr->get_ego();

--- a/src/object/object-value.cpp
+++ b/src/object/object-value.cpp
@@ -46,7 +46,7 @@ PRICE object_value_real(const ItemEntity *o_ptr)
     PRICE value = baseitem.cost;
     auto flags = object_flags(o_ptr);
     if (o_ptr->is_fixed_artifact()) {
-        const auto &artifact = ArtifactsInfo::get_instance().get_artifact(o_ptr->fixed_artifact_idx);
+        const auto &artifact = o_ptr->get_fixed_artifact();
         if (!artifact.cost) {
             return 0;
         }

--- a/src/perception/identification.cpp
+++ b/src/perception/identification.cpp
@@ -41,8 +41,7 @@ bool screen_object(PlayerType *player_ptr, ItemEntity *o_ptr, BIT_FLAGS mode)
     int trivial_info = 0;
     auto flags = object_flags(o_ptr);
 
-    const auto &artifacts = ArtifactsInfo::get_instance();
-    const auto item_text = o_ptr->is_fixed_artifact() ? artifacts.get_artifact(o_ptr->fixed_artifact_idx).text.data() : o_ptr->get_baseitem().text.data();
+    const auto item_text = o_ptr->is_fixed_artifact() ? o_ptr->get_fixed_artifact().text.data() : o_ptr->get_baseitem().text.data();
     const auto item_text_lines = shape_buffer(item_text, 77 - 15);
 
     int i = 0;

--- a/src/racial/racial-android.cpp
+++ b/src/racial/racial-android.cpp
@@ -84,7 +84,7 @@ void calc_android_exp(PlayerType *player_ptr)
         q_ptr->curse_flags.clear();
 
         if (o_ptr->is_fixed_artifact()) {
-            const auto &artifact = ArtifactsInfo::get_instance().get_artifact(o_ptr->fixed_artifact_idx);
+            const auto &artifact = o_ptr->get_fixed_artifact();
             level = (level + std::max(artifact.level - 8, 5)) / 2;
             level += std::min(20, artifact.rarity / (artifact.gen_flags.has(ItemGenerationTraitType::INSTA_ART) ? 10 : 3));
         } else if (o_ptr->is_ego()) {

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -340,14 +340,13 @@ bool destroy_area(PlayerType *player_ptr, POSITION y1, POSITION x1, POSITION r, 
             /* During generation, destroyed artifacts are "preserved" */
             if (preserve_mode || in_generate) {
                 /* Scan all objects in the grid */
-                const auto &artifacts = ArtifactsInfo::get_instance();
                 for (const auto this_o_idx : g_ptr->o_idx_list) {
                     ItemEntity *o_ptr;
                     o_ptr = &floor_ptr->o_list[this_o_idx];
 
                     /* Hack -- Preserve unknown artifacts */
                     if (o_ptr->is_fixed_artifact() && (!o_ptr->is_known() || in_generate)) {
-                        artifacts.get_artifact(o_ptr->fixed_artifact_idx).is_generated = false;
+                        o_ptr->get_fixed_artifact().is_generated = false;
 
                         if (in_generate && cheat_peek) {
                             const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_NAME_ONLY | OD_STORE));

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -19,6 +19,7 @@
 #include "sv-definition/sv-lite-types.h"
 #include "sv-definition/sv-other-types.h"
 #include "sv-definition/sv-weapon-types.h"
+#include "system/artifact-type-definition.h"
 #include "system/baseitem-info.h"
 #include "system/monster-race-info.h"
 #include "term/term-color-types.h"
@@ -813,4 +814,9 @@ BaseitemInfo &ItemEntity::get_baseitem() const
 EgoItemDefinition &ItemEntity::get_ego() const
 {
     return egos_info.at(this->ego_idx);
+}
+
+ArtifactType &ItemEntity::get_fixed_artifact() const
+{
+    return ArtifactsInfo::get_instance().get_artifact(this->fixed_artifact_idx);
 }

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -22,6 +22,7 @@ enum class ItemKindType : short;
 enum class SmithEffectType : int16_t;
 enum class RandomArtActType : short;
 
+class ArtifactType;
 class EgoItemDefinition;
 class BaseitemInfo;
 class ItemEntity {
@@ -138,6 +139,7 @@ public:
 
     BaseitemInfo &get_baseitem() const;
     EgoItemDefinition &get_ego() const;
+    ArtifactType &get_fixed_artifact() const;
 
 private:
     int get_baseitem_price() const;

--- a/src/wizard/artifact-analyzer.cpp
+++ b/src/wizard/artifact-analyzer.cpp
@@ -259,7 +259,7 @@ static void analyze_misc_magic(ItemEntity *o_ptr, concptr *misc_list)
  */
 static void analyze_addition(ItemEntity *o_ptr, char *addition, size_t addition_sz)
 {
-    const auto &artifact = ArtifactsInfo::get_instance().get_artifact(o_ptr->fixed_artifact_idx);
+    const auto &artifact = o_ptr->get_fixed_artifact();
     strcpy(addition, "");
 
     if (artifact.gen_flags.has_all_of({ ItemGenerationTraitType::XTRA_POWER, ItemGenerationTraitType::XTRA_H_RES })) {
@@ -296,7 +296,7 @@ static void analyze_addition(ItemEntity *o_ptr, char *addition, size_t addition_
  */
 static void analyze_misc(ItemEntity *o_ptr, char *misc_desc, size_t misc_desc_sz)
 {
-    const auto &artifact = ArtifactsInfo::get_instance().get_artifact(o_ptr->fixed_artifact_idx);
+    const auto &artifact = o_ptr->get_fixed_artifact();
     const auto *mes = _("レベル %d, 希少度 %u, %d.%d kg, ＄%ld", "Level %d, Rarity %u, %d.%d lbs, %ld Gold");
     strnfmt(misc_desc, misc_desc_sz, mes, (int)artifact.level, artifact.rarity,
         _(lb_to_kg_integer(artifact.weight), artifact.weight / 10), _(lb_to_kg_fraction(artifact.weight), artifact.weight % 10), (long int)artifact.cost);

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -406,9 +406,8 @@ static void wiz_statistics(PlayerType *player_ptr, ItemEntity *o_ptr)
     concptr p = "Enter number of items to roll: ";
     char tmp_val[80];
 
-    const auto &artifacts = ArtifactsInfo::get_instance();
     if (o_ptr->is_fixed_artifact()) {
-        artifacts.get_artifact(o_ptr->fixed_artifact_idx).is_generated = false;
+        o_ptr->get_fixed_artifact().is_generated = false;
     }
 
     uint32_t i, matches, better, worse, other, correct;
@@ -462,7 +461,7 @@ static void wiz_statistics(PlayerType *player_ptr, ItemEntity *o_ptr)
             q_ptr->wipe();
             make_object(player_ptr, q_ptr, mode);
             if (q_ptr->is_fixed_artifact()) {
-                artifacts.get_artifact(q_ptr->fixed_artifact_idx).is_generated = false;
+                q_ptr->get_fixed_artifact().is_generated = false;
             }
 
             if (o_ptr->bi_key != q_ptr->bi_key) {
@@ -487,7 +486,7 @@ static void wiz_statistics(PlayerType *player_ptr, ItemEntity *o_ptr)
     }
 
     if (o_ptr->is_fixed_artifact()) {
-        artifacts.get_artifact(o_ptr->fixed_artifact_idx).is_generated = true;
+        o_ptr->get_fixed_artifact().is_generated = true;
     }
 }
 
@@ -509,12 +508,11 @@ static void wiz_reroll_item(PlayerType *player_ptr, ItemEntity *o_ptr)
 
     char ch;
     bool changed = false;
-    const auto &artifacts = ArtifactsInfo::get_instance();
     while (true) {
         wiz_display_item(player_ptr, q_ptr);
         if (!get_com("[a]ccept, [w]orthless, [c]ursed, [n]ormal, [g]ood, [e]xcellent, [s]pecial? ", &ch, false)) {
             if (q_ptr->is_fixed_artifact()) {
-                artifacts.get_artifact(q_ptr->fixed_artifact_idx).is_generated = false;
+                q_ptr->get_fixed_artifact().is_generated = false;
                 q_ptr->fixed_artifact_idx = FixedArtifactId::NONE;
             }
 
@@ -528,7 +526,7 @@ static void wiz_reroll_item(PlayerType *player_ptr, ItemEntity *o_ptr)
         }
 
         if (q_ptr->is_fixed_artifact()) {
-            artifacts.get_artifact(q_ptr->fixed_artifact_idx).is_generated = false;
+            q_ptr->get_fixed_artifact().is_generated = false;
             q_ptr->fixed_artifact_idx = FixedArtifactId::NONE;
         }
 


### PR DESCRIPTION
掲題の通りです
これでbi\_id 関係のリファクタリングは一段落です