### PR TITLE
自動拾い設定ファイルへの書き込み時に(null)が出力される事象を修正した

### DIFF
--- a/src/autopick/autopick-reader-writer.cpp
+++ b/src/autopick/autopick-reader-writer.cpp
@@ -173,6 +173,10 @@ bool write_text_lines(std::string_view filename, const std::vector<concptr> &lin
     }
 
     for (const auto *line : lines) {
+        if (line == nullptr) {
+            break;
+        }
+
         angband_fputs(fff, line, 1024);
     }
 


### PR DESCRIPTION
掲題の通りです
ご確認下さい

元のコード：
```cpp
bool write_text_lines(concptr filename, concptr *lines_list)
{
    char buf[1024];
    path_build(buf, sizeof(buf), ANGBAND_DIR_USER, filename);
    FILE *fff;
    fff = angband_fopen(buf, "w");
    if (!fff) {
        return false;
    }

    for (int lines = 0; lines_list[lines]; lines++) {
        angband_fputs(fff, lines_list[lines], 1024);
    }

    angband_fclose(fff);
    return true;
}
```

今のコード (同じはず)：
```cpp
bool write_text_lines(std::string_view filename, const std::vector<concptr> &lines)
{
    char buf[1024];
    path_build(buf, sizeof(buf), ANGBAND_DIR_USER, filename);
    auto *fff = angband_fopen(buf, FileOpenMode::WRITE);
    if (!fff) {
        return false;
    }

    for (const auto *line : lines) {
        if (line == nullptr) { // このifが抜けていたのでバグ発生
            break;
        }

        angband_fputs(fff, line, 1024);
    }

    angband_fclose(fff);
    return true;
}
```