### PR TITLE
path_build() のシグネチャを変える準備 その3

### DIFF
--- a/src/floor/floor-save.cpp
+++ b/src/floor/floor-save.cpp
@@ -29,7 +29,7 @@ static std::string get_saved_floor_name(int level)
 {
     char ext[32];
     strnfmt(ext, sizeof(ext), ".F%02d", level);
-    return std::string(savefile).append(ext);
+    return savefile.string().append(ext);
 }
 
 static void check_saved_tmp_files(const int fd, bool *force)

--- a/src/io/files-util.cpp
+++ b/src/io/files-util.cpp
@@ -41,13 +41,9 @@ std::filesystem::path ANGBAND_DIR_DEBUG_SAVE; //*< Savefiles for debug data
 std::filesystem::path ANGBAND_DIR_USER; //!< User "preference" files (ascii) These files are rarely portable between platforms
 std::filesystem::path ANGBAND_DIR_XTRA; //!< Various extra files (binary) These files are rarely portable between platforms
 
-/*
- * Buffer to hold the current savefile name
- * 'savefile' holds full path name. 'savefile_base' holds only base name.
- */
-char savefile[1024];
-char savefile_base[40];
-char debug_savefile[1024];
+std::filesystem::path savefile;
+std::string savefile_base;
+std::filesystem::path debug_savefile;
 
 /*!
  * @brief プレイヤーステータスをファイルダンプ出力する
@@ -225,9 +221,9 @@ static errr counts_seek(PlayerType *player_ptr, int fd, uint32_t where, bool fla
     char temp1[128]{}, temp2[128]{};
     auto short_pclass = enum2i(player_ptr->pclass);
 #ifdef SAVEFILE_USE_UID
-    strnfmt(temp1, sizeof(temp1), "%d.%s.%d%d%d", player_ptr->player_uid, savefile_base, short_pclass, player_ptr->ppersonality, player_ptr->age);
+    strnfmt(temp1, sizeof(temp1), "%d.%s.%d%d%d", player_ptr->player_uid, savefile_base.data(), short_pclass, player_ptr->ppersonality, player_ptr->age);
 #else
-    strnfmt(temp1, sizeof(temp1), "%s.%d%d%d", savefile_base, short_pclass, player_ptr->ppersonality, player_ptr->age);
+    strnfmt(temp1, sizeof(temp1), "%s.%d%d%d", savefile_base.data(), short_pclass, player_ptr->ppersonality, player_ptr->age);
 #endif
     for (int i = 0; temp1[i]; i++) {
         temp1[i] ^= (i + 1) * 63;

--- a/src/io/files-util.h
+++ b/src/io/files-util.h
@@ -5,9 +5,9 @@
 #include <optional>
 #include <string>
 
-extern char savefile[1024];
-extern char savefile_base[40];
-extern char debug_savefile[1024];
+extern std::filesystem::path savefile; //!< セーブファイルのフルパス
+extern std::string savefile_base; //!< セーブファイル名
+extern std::filesystem::path debug_savefile; //!< デバッグセーブファイルのフルパス
 
 extern std::filesystem::path ANGBAND_DIR;
 extern std::filesystem::path ANGBAND_DIR_APEX;

--- a/src/load/floor-loader.cpp
+++ b/src/load/floor-loader.cpp
@@ -287,7 +287,7 @@ bool load_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr, BIT_FLAGS mode
         old_loading_savefile_version = loading_savefile_version;
     }
 
-    std::string floor_savefile = savefile;
+    auto floor_savefile = savefile.string();
     char ext[32];
     strnfmt(ext, sizeof(ext), ".F%02d", (int)sf_ptr->savefile_id);
     floor_savefile.append(ext);

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -346,12 +346,13 @@ bool load_savedata(PlayerType *player_ptr, bool *new_game)
     auto what = "generic";
     w_ptr->game_turn = 0;
     player_ptr->is_dead = false;
-    if (!savefile[0]) {
+    if (savefile.empty()) {
         return true;
     }
 
+    const auto &savefile_str = savefile.string();
 #ifndef WINDOWS
-    if (access(savefile, 0) < 0) {
+    if (access(savefile_str.data(), 0) < 0) {
         msg_print(_("セーブファイルがありません。", "Savefile does not exist."));
         msg_print(nullptr);
         *new_game = true;
@@ -367,7 +368,7 @@ bool load_savedata(PlayerType *player_ptr, bool *new_game)
     constexpr auto version_length = variant_length + 6;
     char tmp_ver[version_length]{};
     if (!err) {
-        fd = fd_open(savefile, O_RDONLY);
+        fd = fd_open(savefile_str.data(), O_RDONLY);
         if (fd < 0) {
             err = true;
         }
@@ -410,7 +411,7 @@ bool load_savedata(PlayerType *player_ptr, bool *new_game)
     }
 
     if (err) {
-        msg_format("%s: %s", what, savefile);
+        msg_format("%s: %s", what, savefile_str.data());
         msg_print(nullptr);
         return false;
     }

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -519,7 +519,6 @@ static void load_prefs(void)
     GetPrivateProfileStringA("Angband", "BackGroundBitmap", DEFAULT_BG_FILENAME, wallpaper_file, 1023, ini_file);
     char savefile_buf[1024]{};
     GetPrivateProfileStringA("Angband", "SaveFile", "", savefile_buf, 1023, ini_file);
-
     if (strncmp(".\\", savefile_buf, 2) == 0) {
         std::string angband_dir_str(ANGBAND_DIR.string());
         const auto path_length = angband_dir_str.length() - 4; // "\lib" を除く.

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -1907,9 +1907,9 @@ static void process_menus(PlayerType *player_ptr, WORD wCmd)
         break;
     }
     case IDM_OPTIONS_OPEN_MUSIC_DIR: {
-        std::vector<char> buf(MAIN_WIN_MAX_PATH);
-        path_build(&buf[0], MAIN_WIN_MAX_PATH, ANGBAND_DIR_XTRA_MUSIC, "music.cfg");
-        open_dir_in_explorer(&buf[0]);
+        char buf[MAIN_WIN_MAX_PATH];
+        path_build(buf, MAIN_WIN_MAX_PATH, ANGBAND_DIR_XTRA_MUSIC, "music.cfg");
+        open_dir_in_explorer(buf);
         break;
     }
     case IDM_OPTIONS_SOUND: {
@@ -1931,9 +1931,9 @@ static void process_menus(PlayerType *player_ptr, WORD wCmd)
         break;
     }
     case IDM_OPTIONS_OPEN_SOUND_DIR: {
-        std::vector<char> buf(MAIN_WIN_MAX_PATH);
-        path_build(&buf[0], MAIN_WIN_MAX_PATH, ANGBAND_DIR_XTRA_SOUND, "sound.cfg");
-        open_dir_in_explorer(&buf[0]);
+        char buf[MAIN_WIN_MAX_PATH];
+        path_build(buf, MAIN_WIN_MAX_PATH, ANGBAND_DIR_XTRA_SOUND, "sound.cfg");
+        open_dir_in_explorer(buf);
         break;
     }
     case IDM_OPTIONS_NO_BG: {

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -2657,11 +2657,11 @@ static void init_stuff()
 
     validate_file(path);
     path_build(path, sizeof(path), ANGBAND_DIR_XTRA, "graf");
-    ANGBAND_DIR_XTRA_GRAF = string_make(path);
+    ANGBAND_DIR_XTRA_GRAF = path;
     validate_dir(ANGBAND_DIR_XTRA_GRAF, true);
 
     path_build(path, sizeof(path), ANGBAND_DIR_XTRA, "sound");
-    ANGBAND_DIR_XTRA_SOUND = string_make(path);
+    ANGBAND_DIR_XTRA_SOUND = path;
     validate_dir(ANGBAND_DIR_XTRA_SOUND, false);
 
     path_build(path, sizeof(path), ANGBAND_DIR_XTRA, "music");

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -2665,7 +2665,7 @@ static void init_stuff()
     validate_dir(ANGBAND_DIR_XTRA_SOUND, false);
 
     path_build(path, sizeof(path), ANGBAND_DIR_XTRA, "music");
-    ANGBAND_DIR_XTRA_MUSIC = string_make(path);
+    ANGBAND_DIR_XTRA_MUSIC = path;
     validate_dir(ANGBAND_DIR_XTRA_MUSIC, false);
 
     for (i = 0; special_key_list[i]; ++i) {

--- a/src/main-win/graphics-win.cpp
+++ b/src/main-win/graphics-win.cpp
@@ -22,7 +22,7 @@ ULONG_PTR gdiplusToken;
 // interface object
 Graphics graphic{};
 
-concptr ANGBAND_DIR_XTRA_GRAF;
+std::filesystem::path ANGBAND_DIR_XTRA_GRAF;
 
 /*!
  * 現在使用中のタイルID(0ならば未使用)

--- a/src/main-win/graphics-win.h
+++ b/src/main-win/graphics-win.h
@@ -5,7 +5,7 @@
  */
 
 #include "system/h-type.h"
-
+#include <filesystem>
 #include <windows.h>
 
 /*
@@ -105,7 +105,7 @@ extern Graphics graphic;
 /*
  * Directory names
  */
-extern concptr ANGBAND_DIR_XTRA_GRAF;
+extern std::filesystem::path ANGBAND_DIR_XTRA_GRAF;
 
 /*!
  * @brief Creates a GDI bitmap from an image file

--- a/src/main-win/main-win-cfg-reader.cpp
+++ b/src/main-win/main-win-cfg-reader.cpp
@@ -76,7 +76,7 @@ void CfgData::insert(int key1_type, int key2_val, cfg_values *value)
  * @param dir .cfgファイルのディレクトリ
  * @param files .cfgファイル名。複数指定可能で、最初に見つかったファイルから読み取る。
  */
-CfgReader::CfgReader(concptr dir, std::initializer_list<concptr> files)
+CfgReader::CfgReader(std::filesystem::path dir, std::initializer_list<concptr> files)
 {
     this->dir = dir;
     this->cfg_path = find_any_file(dir, files);

--- a/src/main-win/main-win-cfg-reader.h
+++ b/src/main-win/main-win-cfg-reader.h
@@ -2,6 +2,7 @@
 
 #include "system/angband.h"
 #include <cstddef>
+#include <filesystem>
 #include <initializer_list>
 #include <unordered_map>
 #include <vector>
@@ -55,14 +56,14 @@ protected:
 
 class CfgReader {
 public:
-    CfgReader(concptr dir, std::initializer_list<concptr> files);
+    CfgReader(std::filesystem::path dir, std::initializer_list<concptr> files);
     CfgData *read_sections(std::initializer_list<cfg_section> sections);
-    concptr get_cfg_path()
+    std::string get_cfg_path()
     {
-        return cfg_path.data();
+        return cfg_path;
     }
 
 protected:
-    concptr dir;
+    std::filesystem::path dir;
     std::string cfg_path;
 };

--- a/src/main-win/main-win-music.cpp
+++ b/src/main-win/main-win-music.cpp
@@ -135,7 +135,7 @@ void load_music_prefs()
     CfgReader reader(ANGBAND_DIR_XTRA_MUSIC, { "music_debug.cfg", "music.cfg" });
 
     char device_type[256];
-    GetPrivateProfileStringA("Device", "type", "MPEGVideo", device_type, _countof(device_type), reader.get_cfg_path());
+    GetPrivateProfileStringA("Device", "type", "MPEGVideo", device_type, _countof(device_type), reader.get_cfg_path().data());
     mci_device_type = to_wchar(device_type).wc_str();
 
     // clang-format off

--- a/src/main-win/main-win-music.cpp
+++ b/src/main-win/main-win-music.cpp
@@ -33,7 +33,7 @@ static char current_music_path[MAIN_WIN_MAX_PATH];
 /*
  * Directory name
  */
-concptr ANGBAND_DIR_XTRA_MUSIC;
+std::filesystem::path ANGBAND_DIR_XTRA_MUSIC;
 
 /*
  * "music.cfg" data

--- a/src/main-win/main-win-music.cpp
+++ b/src/main-win/main-win-music.cpp
@@ -28,7 +28,7 @@ bool use_pause_music_inactive = false;
 static int current_music_type = TERM_XTRA_MUSIC_MUTE;
 static int current_music_id = 0;
 // current filename being played
-static char current_music_path[MAIN_WIN_MAX_PATH];
+static std::filesystem::path current_music_path;
 
 /*
  * Directory name
@@ -168,7 +168,7 @@ errr stop_music(void)
     mciSendCommandW(mci_open_parms.wDeviceID, MCI_CLOSE, MCI_WAIT, 0);
     current_music_type = TERM_XTRA_MUSIC_MUTE;
     current_music_id = 0;
-    strcpy(current_music_path, "\0");
+    current_music_path = "";
     return 0;
 }
 
@@ -194,14 +194,14 @@ errr play_music(int type, int val)
     path_build(buf, MAIN_WIN_MAX_PATH, ANGBAND_DIR_XTRA_MUSIC, filename);
 
     if (current_music_type != TERM_XTRA_MUSIC_MUTE) {
-        if (0 == strcmp(current_music_path, buf)) {
+        if (current_music_path.string() == std::string(buf)) {
             return 0;
         }
     } // now playing same file
 
     current_music_type = type;
     current_music_id = val;
-    strcpy(current_music_path, buf);
+    current_music_path = buf;
 
     to_wchar path(buf);
     mci_open_parms.lpstrDeviceType = mci_device_type.data();

--- a/src/main-win/main-win-music.h
+++ b/src/main-win/main-win-music.h
@@ -1,15 +1,14 @@
 ﻿#pragma once
 
 #include "main-win/main-win-cfg-reader.h"
-#include "system/h-type.h"
-
 #include "main/music-definitions-table.h"
-
+#include "system/h-type.h"
 #include <array>
+#include <filesystem>
 #include <windows.h>
 
 extern bool use_pause_music_inactive;
-extern concptr ANGBAND_DIR_XTRA_MUSIC;
+extern std::filesystem::path ANGBAND_DIR_XTRA_MUSIC;
 extern CfgData *music_cfg_data;
 
 namespace main_win_music {

--- a/src/main-win/main-win-sound.cpp
+++ b/src/main-win/main-win-sound.cpp
@@ -11,19 +11,16 @@
 #include "main-win/main-win-file-utils.h"
 #include "main-win/main-win-utils.h"
 #include "main-win/wav-reader.h"
-#include "util/angband-files.h"
-
 #include "main/sound-definitions-table.h"
-
+#include "util/angband-files.h"
 #include <memory>
-#include <queue>
-
 #include <mmsystem.h>
+#include <queue>
 
 /*
  * Directory name
  */
-concptr ANGBAND_DIR_XTRA_SOUND;
+std::filesystem::path ANGBAND_DIR_XTRA_SOUND;
 
 /*
  * "sound.cfg" data
@@ -253,7 +250,7 @@ void finalize_sound(void)
  * @retval 1 設定なし
  * @retval -1 PlaySoundの戻り値が正常終了以外
  */
-errr play_sound(int val, int volume)
+int play_sound(int val, int volume)
 {
     auto filename = sound_cfg_data->get_rand(TERM_XTRA_SOUND, val);
     if (!filename) {

--- a/src/main-win/main-win-sound.h
+++ b/src/main-win/main-win-sound.h
@@ -1,15 +1,15 @@
 ﻿#pragma once
 
 #include "main-win/main-win-cfg-reader.h"
-#include "system/h-type.h"
 #include <array>
+#include <filesystem>
 
-extern concptr ANGBAND_DIR_XTRA_SOUND;
+extern std::filesystem::path ANGBAND_DIR_XTRA_SOUND;
 extern CfgData *sound_cfg_data;
 
 void load_sound_prefs(void);
 void finalize_sound(void);
-errr play_sound(int val, int volume);
+int play_sound(int val, int volume);
 
 /*! 音量 100%,90%,…,10% それぞれに割り当てる実際の値(効果音の音声データの振幅を volume/SOUND_VOLUME_MAX 倍する) */
 constexpr std::array<int, 10> SOUND_VOLUME_TABLE = { { 1000, 800, 600, 450, 350, 250, 170, 100, 50, 20 } };

--- a/src/main-win/main-win-utils.cpp
+++ b/src/main-win/main-win-utils.cpp
@@ -60,10 +60,11 @@ void save_screen_as_html(HWND hWnd)
  * @brief 対象ファイルを選択した状態でエクスプローラーを開く
  * @param filename 対象ファイル
  */
-void open_dir_in_explorer(char *filename)
+void open_dir_in_explorer(std::string_view filename)
 {
-    std::string str = "/select," + std::string(filename);
-    ShellExecuteW(NULL, NULL, L"explorer.exe", to_wchar(str.data()).wc_str(), NULL, SW_SHOWNORMAL);
+    std::stringstream ss;
+    ss << "/select," << filename;
+    ShellExecuteW(NULL, NULL, L"explorer.exe", to_wchar(ss.str().data()).wc_str(), NULL, SW_SHOWNORMAL);
 }
 
 /*!

--- a/src/main-win/main-win-utils.h
+++ b/src/main-win/main-win-utils.h
@@ -84,5 +84,5 @@ protected:
 
 bool is_already_running(void);
 void save_screen_as_html(HWND hWnd);
-void open_dir_in_explorer(char *filename);
+void open_dir_in_explorer(std::string_view filename);
 std::optional<std::string> get_open_filename(OPENFILENAMEW *ofn, const std::filesystem::path &dirname, std::string_view filename, DWORD max_name_size);

--- a/src/main-win/main-win-utils.h
+++ b/src/main-win/main-win-utils.h
@@ -7,6 +7,8 @@
 #include "system/angband.h"
 #include <filesystem>
 #include <optional>
+#include <string>
+#include <string_view>
 #include <vector>
 #include <windows.h>
 
@@ -83,4 +85,4 @@ protected:
 bool is_already_running(void);
 void save_screen_as_html(HWND hWnd);
 void open_dir_in_explorer(char *filename);
-bool get_open_filename(OPENFILENAMEW *ofn, const std::filesystem::path &dirname, char *filename, DWORD max_name_size);
+std::optional<std::string> get_open_filename(OPENFILENAMEW *ofn, const std::filesystem::path &dirname, std::string_view filename, DWORD max_name_size);

--- a/src/main/angband-initializer.cpp
+++ b/src/main/angband-initializer.cpp
@@ -97,7 +97,9 @@ void init_file_paths(const std::filesystem::path &libpath)
     struct tm *t = localtime(&now);
     char tmp[128];
     strftime(tmp, sizeof(tmp), "%Y-%m-%d-%H-%M-%S", t);
-    path_build(debug_savefile, sizeof(debug_savefile), ANGBAND_DIR_DEBUG_SAVE, tmp);
+    char savefile_buf[1024]{};
+    path_build(savefile_buf, sizeof(savefile_buf), ANGBAND_DIR_DEBUG_SAVE, tmp);
+    debug_savefile = savefile_buf;
 
     remove_old_debug_savefiles();
 }

--- a/src/player/process-name.cpp
+++ b/src/player/process-name.cpp
@@ -86,7 +86,7 @@ void process_player_name(PlayerType *player_ptr, bool is_new_savefile)
     }
 
     auto is_modified = false;
-    if (is_new_savefile && (!savefile[0] || !keep_savefile)) {
+    if (is_new_savefile && (savefile.empty() || !keep_savefile)) {
         std::string temp;
 
 #ifdef SAVEFILE_USE_UID
@@ -97,12 +97,15 @@ void process_player_name(PlayerType *player_ptr, bool is_new_savefile)
         /* Rename the savefile, using the player_ptr->base_name */
         temp = player_ptr->base_name;
 #endif
-        path_build(savefile, sizeof(savefile), ANGBAND_DIR_SAVE, temp);
+        char buf[1024];
+        path_build(buf, sizeof(buf), ANGBAND_DIR_SAVE, temp);
+        savefile = buf;
         is_modified = true;
     }
 
     if (is_modified || !savefile_base[0]) {
-        auto s = savefile;
+        const auto &savefile_str = savefile.string();
+        auto s = savefile_str.data();
         while (true) {
             auto t = angband_strstr(s, PATH_SEP);
             if (!t) {
@@ -112,9 +115,9 @@ void process_player_name(PlayerType *player_ptr, bool is_new_savefile)
         }
 
 #ifdef SAVEFILE_USE_UID
-        strcpy(savefile_base, angband_strstr(s, ".") + 1);
+        savefile_base = angband_strstr(s, ".") + 1;
 #else
-        strcpy(savefile_base, s);
+        savefile_base = s;
 #endif
     }
 

--- a/src/save/floor-writer.cpp
+++ b/src/save/floor-writer.cpp
@@ -247,7 +247,7 @@ bool save_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr, BIT_FLAGS mode
         old_x_stamp = x_stamp;
     }
 
-    std::string floor_savefile = savefile;
+    auto floor_savefile = savefile.string();
     char ext[32];
     strnfmt(ext, sizeof(ext), ".F%02d", (int)sf_ptr->savefile_id);
     floor_savefile.append(ext);

--- a/src/util/angband-files.cpp
+++ b/src/util/angband-files.cpp
@@ -157,22 +157,19 @@ static errr path_temp(char *buf, int max)
  * @brief OSの差異を吸収しつつ、絶対パスを生成する.
  * @param buf ファイルのフルを返すバッファ
  * @param max bufのサイズ
- * @param directory ディレクトリ
+ * @param path file 引数があるディレクトリ
  * @param file ファイル名またはディレクトリ名
  * @todo buf, max は削除してファイル名が長すぎたら例外を送出する。またreturn で絶対パスを返すように書き換える.
  */
 void path_build(char *buf, int max, const std::filesystem::path &path, std::string_view file)
 {
-    if (file[0] == '~') {
+    if ((file[0] == '~') || (prefix(file, PATH_SEP)) || path.empty()) {
         (void)strnfmt(buf, max, "%s", file.data());
-    } else if (prefix(file, PATH_SEP)) {
-        (void)strnfmt(buf, max, "%s", file.data());
-    } else if (!path.string()[0]) {
-        (void)strnfmt(buf, max, "%s", file.data());
-    } else {
-        const auto &path_str = path.string();
-        (void)strnfmt(buf, max, "%s%s%s", path_str.data(), PATH_SEP, file.data());
+        return;
     }
+
+    const auto &path_str = path.string();
+    (void)strnfmt(buf, max, "%s%s%s", path_str.data(), PATH_SEP, file.data());
 }
 
 static std::string make_file_mode(const FileOpenMode mode, const bool is_binary)


### PR DESCRIPTION
あちこちpath で扱うべきグローバル変数等がchar\* やconcptr になっているので順次差し替えました
セーブ/ロード周りにも手を入れたので入念にチェック済です
ご確認下さい