### PR TITLE
Change hengband.spec version

### DIFF
--- a/hengband.spec
+++ b/hengband.spec
@@ -1,4 +1,4 @@
-%define version 3.0.0Alpha78
+%define version 3.0.0Alpha81
 %define release 1
 %global debug_package %{nil}
 
@@ -94,6 +94,9 @@ exit 0
 %license lib/help/jlicense.txt
 
 %changelog
+
+* Thu May 04 2023 Shiro Hara <white@vx-xv.com>
+- hengband RPM 3.0.0Alpha release 81
 
 * Mon Feb 20 2023 Shiro Hara <white@vx-xv.com>
 - hengband RPM 3.0.0Alpha release 78


### PR DESCRIPTION
hengband.specのバージョンを3.0.0Alpha81に変更しました。

以下URLでこのバージョンのrpm配布も開始しています。
https://copr.fedorainfracloud.org/coprs/whitehara/hengband/