### PR TITLE
autopick-key-flag-process.h に定義されていた関数マクロを削除し、普通の関数に置き換えた

### DIFF
--- a/src/autopick/autopick-editor-util.cpp
+++ b/src/autopick/autopick-editor-util.cpp
@@ -64,7 +64,7 @@ void toggle_keyword(text_body_type *tb, BIT_FLAGS flg)
         }
 
         if (add) {
-            ADD_FLG(flg);
+            entry->add(flg);
         } else {
             entry->remove(flg);
         }
@@ -194,7 +194,7 @@ void add_keyword(text_body_type *tb, BIT_FLAGS flg)
             }
         }
 
-        ADD_FLG(flg);
+        entry->add(flg);
         tb->lines_list[y] = autopick_line_from_entry(*entry);
         tb->dirty_flags |= DIRTY_ALL;
         tb->changed = true;

--- a/src/autopick/autopick-editor-util.cpp
+++ b/src/autopick/autopick-editor-util.cpp
@@ -44,29 +44,29 @@ void toggle_keyword(text_body_type *tb, BIT_FLAGS flg)
         if (FLG_NOUN_BEGIN <= flg && flg <= FLG_NOUN_END) {
             int i;
             for (i = FLG_NOUN_BEGIN; i <= FLG_NOUN_END; i++) {
-                REM_FLG(i);
+                entry->remove(i);
             }
         } else if (FLG_UNAWARE <= flg && flg <= FLG_STAR_IDENTIFIED) {
             int i;
             for (i = FLG_UNAWARE; i <= FLG_STAR_IDENTIFIED; i++) {
-                REM_FLG(i);
+                entry->remove(i);
             }
         } else if (FLG_ARTIFACT <= flg && flg <= FLG_AVERAGE) {
             int i;
             for (i = FLG_ARTIFACT; i <= FLG_AVERAGE; i++) {
-                REM_FLG(i);
+                entry->remove(i);
             }
         } else if (FLG_RARE <= flg && flg <= FLG_COMMON) {
             int i;
             for (i = FLG_RARE; i <= FLG_COMMON; i++) {
-                REM_FLG(i);
+                entry->remove(i);
             }
         }
 
         if (add) {
             ADD_FLG(flg);
         } else {
-            REM_FLG(flg);
+            entry->remove(flg);
         }
 
         tb->lines_list[y] = autopick_line_from_entry(*entry);
@@ -190,7 +190,7 @@ void add_keyword(text_body_type *tb, BIT_FLAGS flg)
         if (FLG_NOUN_BEGIN <= flg && flg <= FLG_NOUN_END) {
             int i;
             for (i = FLG_NOUN_BEGIN; i <= FLG_NOUN_END; i++) {
-                REM_FLG(i);
+                entry->remove(i);
             }
         }
 

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -250,49 +250,70 @@ bool autopick_new_entry(autopick_type *entry, concptr str, bool allow_default)
 
     int prev_flg = -1;
     if (MATCH_KEY2(KEY_ARTIFACT)) {
-        ADD_FLG_NOUN(FLG_ARTIFACT);
+        entry->add(FLG_ARTIFACT);
+        prev_flg = FLG_ARTIFACT;
     }
 
     if (MATCH_KEY2(KEY_ITEMS)) {
-        ADD_FLG_NOUN(FLG_ITEMS);
+        entry->add(FLG_ITEMS);
+        prev_flg = FLG_ITEMS;
     } else if (MATCH_KEY2(KEY_WEAPONS)) {
-        ADD_FLG_NOUN(FLG_WEAPONS);
+        entry->add(FLG_WEAPONS);
+        prev_flg = FLG_WEAPONS;
     } else if (MATCH_KEY2(KEY_FAVORITE_WEAPONS)) {
-        ADD_FLG_NOUN(FLG_FAVORITE_WEAPONS);
+        entry->add(FLG_FAVORITE_WEAPONS);
+        prev_flg = FLG_FAVORITE_WEAPONS;
     } else if (MATCH_KEY2(KEY_ARMORS)) {
-        ADD_FLG_NOUN(FLG_ARMORS);
+        entry->add(FLG_ARMORS);
+        prev_flg = FLG_ARMORS;
     } else if (MATCH_KEY2(KEY_MISSILES)) {
-        ADD_FLG_NOUN(FLG_MISSILES);
+        entry->add(FLG_MISSILES);
+        prev_flg = FLG_MISSILES;
     } else if (MATCH_KEY2(KEY_DEVICES)) {
-        ADD_FLG_NOUN(FLG_DEVICES);
+        entry->add(FLG_DEVICES);
+        prev_flg = FLG_DEVICES;
     } else if (MATCH_KEY2(KEY_LIGHTS)) {
-        ADD_FLG_NOUN(FLG_LIGHTS);
+        entry->add(FLG_LIGHTS);
+        prev_flg = FLG_LIGHTS;
     } else if (MATCH_KEY2(KEY_JUNKS)) {
-        ADD_FLG_NOUN(FLG_JUNKS);
+        entry->add(FLG_JUNKS);
+        prev_flg = FLG_JUNKS;
     } else if (MATCH_KEY2(KEY_CORPSES)) {
-        ADD_FLG_NOUN(FLG_CORPSES);
+        entry->add(FLG_CORPSES);
+        prev_flg = FLG_CORPSES;
     } else if (MATCH_KEY2(KEY_SPELLBOOKS)) {
-        ADD_FLG_NOUN(FLG_SPELLBOOKS);
+        entry->add(FLG_SPELLBOOKS);
+        prev_flg = FLG_SPELLBOOKS;
     } else if (MATCH_KEY2(KEY_HAFTED)) {
-        ADD_FLG_NOUN(FLG_HAFTED);
+        entry->add(FLG_HAFTED);
+        prev_flg = FLG_HAFTED;
     } else if (MATCH_KEY2(KEY_SHIELDS)) {
-        ADD_FLG_NOUN(FLG_SHIELDS);
+        entry->add(FLG_SHIELDS);
+        prev_flg = FLG_SHIELDS;
     } else if (MATCH_KEY2(KEY_BOWS)) {
-        ADD_FLG_NOUN(FLG_BOWS);
+        entry->add(FLG_BOWS);
+        prev_flg = FLG_BOWS;
     } else if (MATCH_KEY2(KEY_RINGS)) {
-        ADD_FLG_NOUN(FLG_RINGS);
+        entry->add(FLG_RINGS);
+        prev_flg = FLG_RINGS;
     } else if (MATCH_KEY2(KEY_AMULETS)) {
-        ADD_FLG_NOUN(FLG_AMULETS);
+        entry->add(FLG_AMULETS);
+        prev_flg = FLG_AMULETS;
     } else if (MATCH_KEY2(KEY_SUITS)) {
-        ADD_FLG_NOUN(FLG_SUITS);
+        entry->add(FLG_SUITS);
+        prev_flg = FLG_SUITS;
     } else if (MATCH_KEY2(KEY_CLOAKS)) {
-        ADD_FLG_NOUN(FLG_CLOAKS);
+        entry->add(FLG_CLOAKS);
+        prev_flg = FLG_CLOAKS;
     } else if (MATCH_KEY2(KEY_HELMS)) {
-        ADD_FLG_NOUN(FLG_HELMS);
+        entry->add(FLG_HELMS);
+        prev_flg = FLG_HELMS;
     } else if (MATCH_KEY2(KEY_GLOVES)) {
-        ADD_FLG_NOUN(FLG_GLOVES);
+        entry->add(FLG_GLOVES);
+        prev_flg = FLG_GLOVES;
     } else if (MATCH_KEY2(KEY_BOOTS)) {
-        ADD_FLG_NOUN(FLG_BOOTS);
+        entry->add(FLG_BOOTS);
+        prev_flg = FLG_BOOTS;
     }
 
     if (*ptr == ':') {
@@ -305,7 +326,8 @@ bool autopick_new_entry(autopick_type *entry, concptr str, bool allow_default)
 #endif
     else if (*ptr == '\0') {
         if (prev_flg == -1) {
-            ADD_FLG_NOUN(FLG_ITEMS);
+            entry->add(FLG_ITEMS);
+            prev_flg = FLG_ITEMS;
         }
     } else {
         if (prev_flg != -1) {

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -26,6 +26,7 @@
 #include "system/player-type-definition.h"
 #include "util/quarks.h"
 #include "util/string-processor.h"
+#include <optional>
 #include <sstream>
 #include <string>
 
@@ -250,7 +251,7 @@ bool autopick_new_entry(autopick_type *entry, concptr str, bool allow_default)
         }
     }
 
-    auto previous_flag = -1;
+    std::optional<int> previous_flag = std::nullopt;
     if (MATCH_KEY2(KEY_ARTIFACT)) {
         entry->add(FLG_ARTIFACT);
         previous_flag = FLG_ARTIFACT;
@@ -327,13 +328,13 @@ bool autopick_new_entry(autopick_type *entry, concptr str, bool allow_default)
     }
 #endif
     else if (*ptr == '\0') {
-        if (previous_flag == -1) {
+        if (!previous_flag.has_value()) {
             entry->add(FLG_ITEMS);
             previous_flag = FLG_ITEMS;
         }
     } else {
-        if (previous_flag != -1) {
-            entry->flags[previous_flag / 32] &= ~(1UL << (previous_flag % 32));
+        if (previous_flag.has_value()) {
+            entry->remove(previous_flag.value());
             ptr = prev_ptr;
         }
     }

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -413,7 +413,7 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, It
     }
 
     if (object_is_bounty(player_ptr, o_ptr)) {
-        REM_FLG(FLG_WORTHLESS);
+        entry->remove(FLG_WORTHLESS);
         ADD_FLG(FLG_WANTED);
     }
 

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -122,25 +122,25 @@ bool autopick_new_entry(autopick_type *entry, concptr str, bool allow_default)
     while (old_ptr != ptr) {
         old_ptr = ptr;
         if (MATCH_KEY(KEY_ALL)) {
-            ADD_FLG(FLG_ALL);
+            entry->add(FLG_ALL);
         }
         if (MATCH_KEY(KEY_COLLECTING)) {
-            ADD_FLG(FLG_COLLECTING);
+            entry->add(FLG_COLLECTING);
         }
         if (MATCH_KEY(KEY_UNAWARE)) {
-            ADD_FLG(FLG_UNAWARE);
+            entry->add(FLG_UNAWARE);
         }
         if (MATCH_KEY(KEY_UNIDENTIFIED)) {
-            ADD_FLG(FLG_UNIDENTIFIED);
+            entry->add(FLG_UNIDENTIFIED);
         }
         if (MATCH_KEY(KEY_IDENTIFIED)) {
-            ADD_FLG(FLG_IDENTIFIED);
+            entry->add(FLG_IDENTIFIED);
         }
         if (MATCH_KEY(KEY_STAR_IDENTIFIED)) {
-            ADD_FLG(FLG_STAR_IDENTIFIED);
+            entry->add(FLG_STAR_IDENTIFIED);
         }
         if (MATCH_KEY(KEY_BOOSTED)) {
-            ADD_FLG(FLG_BOOSTED);
+            entry->add(FLG_BOOSTED);
         }
 
         /*** Weapons whose dd*ds is more than nn ***/
@@ -160,7 +160,7 @@ bool autopick_new_entry(autopick_type *entry, concptr str, bool allow_default)
 
             if (k > 0 && k <= 2) {
                 (void)MATCH_KEY(KEY_DICE);
-                ADD_FLG(FLG_MORE_DICE);
+                entry->add(FLG_MORE_DICE);
             } else {
                 ptr = prev_ptr;
             }
@@ -189,62 +189,62 @@ bool autopick_new_entry(autopick_type *entry, concptr str, bool allow_default)
                     ptr++;
                 }
 #endif
-                ADD_FLG(FLG_MORE_BONUS);
+                entry->add(FLG_MORE_BONUS);
             } else {
                 ptr = prev_ptr;
             }
         }
 
         if (MATCH_KEY(KEY_WORTHLESS)) {
-            ADD_FLG(FLG_WORTHLESS);
+            entry->add(FLG_WORTHLESS);
         }
         if (MATCH_KEY(KEY_EGO)) {
-            ADD_FLG(FLG_EGO);
+            entry->add(FLG_EGO);
         }
         if (MATCH_KEY(KEY_GOOD)) {
-            ADD_FLG(FLG_GOOD);
+            entry->add(FLG_GOOD);
         }
         if (MATCH_KEY(KEY_NAMELESS)) {
-            ADD_FLG(FLG_NAMELESS);
+            entry->add(FLG_NAMELESS);
         }
         if (MATCH_KEY(KEY_AVERAGE)) {
-            ADD_FLG(FLG_AVERAGE);
+            entry->add(FLG_AVERAGE);
         }
         if (MATCH_KEY(KEY_RARE)) {
-            ADD_FLG(FLG_RARE);
+            entry->add(FLG_RARE);
         }
         if (MATCH_KEY(KEY_COMMON)) {
-            ADD_FLG(FLG_COMMON);
+            entry->add(FLG_COMMON);
         }
         if (MATCH_KEY(KEY_WANTED)) {
-            ADD_FLG(FLG_WANTED);
+            entry->add(FLG_WANTED);
         }
         if (MATCH_KEY(KEY_UNIQUE)) {
-            ADD_FLG(FLG_UNIQUE);
+            entry->add(FLG_UNIQUE);
         }
         if (MATCH_KEY(KEY_HUMAN)) {
-            ADD_FLG(FLG_HUMAN);
+            entry->add(FLG_HUMAN);
         }
         if (MATCH_KEY(KEY_UNREADABLE)) {
-            ADD_FLG(FLG_UNREADABLE);
+            entry->add(FLG_UNREADABLE);
         }
         if (MATCH_KEY(KEY_REALM1)) {
-            ADD_FLG(FLG_REALM1);
+            entry->add(FLG_REALM1);
         }
         if (MATCH_KEY(KEY_REALM2)) {
-            ADD_FLG(FLG_REALM2);
+            entry->add(FLG_REALM2);
         }
         if (MATCH_KEY(KEY_FIRST)) {
-            ADD_FLG(FLG_FIRST);
+            entry->add(FLG_FIRST);
         }
         if (MATCH_KEY(KEY_SECOND)) {
-            ADD_FLG(FLG_SECOND);
+            entry->add(FLG_SECOND);
         }
         if (MATCH_KEY(KEY_THIRD)) {
-            ADD_FLG(FLG_THIRD);
+            entry->add(FLG_THIRD);
         }
         if (MATCH_KEY(KEY_FOURTH)) {
-            ADD_FLG(FLG_FOURTH);
+            entry->add(FLG_FOURTH);
         }
     }
 
@@ -338,34 +338,34 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, It
     // We can always use the ^ mark in English.
     bool is_hat_added = _(false, true);
     if (!o_ptr->is_aware()) {
-        ADD_FLG(FLG_UNAWARE);
+        entry->add(FLG_UNAWARE);
         is_hat_added = true;
     } else if (!o_ptr->is_known()) {
         if (!(o_ptr->ident & IDENT_SENSE)) {
-            ADD_FLG(FLG_UNIDENTIFIED);
+            entry->add(FLG_UNIDENTIFIED);
             is_hat_added = true;
         } else {
             switch (o_ptr->feeling) {
             case FEEL_AVERAGE:
             case FEEL_GOOD:
-                ADD_FLG(FLG_NAMELESS);
+                entry->add(FLG_NAMELESS);
                 is_hat_added = true;
                 break;
 
             case FEEL_BROKEN:
             case FEEL_CURSED:
-                ADD_FLG(FLG_NAMELESS);
-                ADD_FLG(FLG_WORTHLESS);
+                entry->add(FLG_NAMELESS);
+                entry->add(FLG_WORTHLESS);
                 is_hat_added = true;
                 break;
 
             case FEEL_TERRIBLE:
             case FEEL_WORTHLESS:
-                ADD_FLG(FLG_WORTHLESS);
+                entry->add(FLG_WORTHLESS);
                 break;
 
             case FEEL_EXCELLENT:
-                ADD_FLG(FLG_EGO);
+                entry->add(FLG_EGO);
                 break;
 
             case FEEL_UNCURSED:
@@ -389,16 +389,16 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, It
 #endif
                 name = false;
                 if (!o_ptr->is_rare()) {
-                    ADD_FLG(FLG_COMMON);
+                    entry->add(FLG_COMMON);
                 }
             }
 
-            ADD_FLG(FLG_EGO);
+            entry->add(FLG_EGO);
         } else if (o_ptr->is_fixed_or_random_artifact()) {
-            ADD_FLG(FLG_ARTIFACT);
+            entry->add(FLG_ARTIFACT);
         } else {
             if (o_ptr->is_equipment()) {
-                ADD_FLG(FLG_NAMELESS);
+                entry->add(FLG_NAMELESS);
             }
 
             is_hat_added = true;
@@ -408,28 +408,28 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, It
     if (o_ptr->is_melee_weapon()) {
         const auto &baseitem = o_ptr->get_baseitem();
         if ((o_ptr->dd != baseitem.dd) || (o_ptr->ds != baseitem.ds)) {
-            ADD_FLG(FLG_BOOSTED);
+            entry->add(FLG_BOOSTED);
         }
     }
 
     if (object_is_bounty(player_ptr, o_ptr)) {
         entry->remove(FLG_WORTHLESS);
-        ADD_FLG(FLG_WANTED);
+        entry->add(FLG_WANTED);
     }
 
     const auto r_idx = i2enum<MonsterRaceId>(o_ptr->pval);
     const auto &bi_key = o_ptr->bi_key;
     const auto tval = bi_key.tval();
     if ((tval == ItemKindType::CORPSE || tval == ItemKindType::STATUE) && monraces_info[r_idx].kind_flags.has(MonsterKindType::UNIQUE)) {
-        ADD_FLG(FLG_UNIQUE);
+        entry->add(FLG_UNIQUE);
     }
 
     if (tval == ItemKindType::CORPSE && angband_strchr("pht", monraces_info[r_idx].d_char)) {
-        ADD_FLG(FLG_HUMAN);
+        entry->add(FLG_HUMAN);
     }
 
     if (o_ptr->is_spell_book() && !check_book_realm(player_ptr, bi_key)) {
-        ADD_FLG(FLG_UNREADABLE);
+        entry->add(FLG_UNREADABLE);
         if (tval != ItemKindType::ARCANE_BOOK) {
             name = false;
         }
@@ -439,61 +439,61 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, It
     auto realm_except_class = pc.equals(PlayerClassType::SORCERER) || pc.equals(PlayerClassType::RED_MAGE);
 
     if ((get_realm1_book(player_ptr) == tval) && !realm_except_class) {
-        ADD_FLG(FLG_REALM1);
+        entry->add(FLG_REALM1);
         name = false;
     }
 
     if ((get_realm2_book(player_ptr) == tval) && !realm_except_class) {
-        ADD_FLG(FLG_REALM2);
+        entry->add(FLG_REALM2);
         name = false;
     }
 
     const auto sval = bi_key.sval();
     if (o_ptr->is_spell_book() && (sval == 0)) {
-        ADD_FLG(FLG_FIRST);
+        entry->add(FLG_FIRST);
     }
     if (o_ptr->is_spell_book() && (sval == 1)) {
-        ADD_FLG(FLG_SECOND);
+        entry->add(FLG_SECOND);
     }
     if (o_ptr->is_spell_book() && (sval == 2)) {
-        ADD_FLG(FLG_THIRD);
+        entry->add(FLG_THIRD);
     }
     if (o_ptr->is_spell_book() && (sval == 3)) {
-        ADD_FLG(FLG_FOURTH);
+        entry->add(FLG_FOURTH);
     }
 
     if (o_ptr->is_ammo()) {
-        ADD_FLG(FLG_MISSILES);
+        entry->add(FLG_MISSILES);
     } else if (tval == ItemKindType::SCROLL || o_ptr->is_wand_staff() || o_ptr->is_wand_rod()) {
-        ADD_FLG(FLG_DEVICES);
+        entry->add(FLG_DEVICES);
     } else if (tval == ItemKindType::LITE) {
-        ADD_FLG(FLG_LIGHTS);
+        entry->add(FLG_LIGHTS);
     } else if (o_ptr->is_junk()) {
-        ADD_FLG(FLG_JUNKS);
+        entry->add(FLG_JUNKS);
     } else if (tval == ItemKindType::CORPSE) {
-        ADD_FLG(FLG_CORPSES);
+        entry->add(FLG_CORPSES);
     } else if (o_ptr->is_spell_book()) {
-        ADD_FLG(FLG_SPELLBOOKS);
+        entry->add(FLG_SPELLBOOKS);
     } else if (o_ptr->is_melee_weapon()) {
-        ADD_FLG(FLG_WEAPONS);
+        entry->add(FLG_WEAPONS);
     } else if (tval == ItemKindType::SHIELD) {
-        ADD_FLG(FLG_SHIELDS);
+        entry->add(FLG_SHIELDS);
     } else if (tval == ItemKindType::BOW) {
-        ADD_FLG(FLG_BOWS);
+        entry->add(FLG_BOWS);
     } else if (tval == ItemKindType::RING) {
-        ADD_FLG(FLG_RINGS);
+        entry->add(FLG_RINGS);
     } else if (tval == ItemKindType::AMULET) {
-        ADD_FLG(FLG_AMULETS);
+        entry->add(FLG_AMULETS);
     } else if (o_ptr->is_armour()) {
-        ADD_FLG(FLG_SUITS);
+        entry->add(FLG_SUITS);
     } else if (tval == ItemKindType::CLOAK) {
-        ADD_FLG(FLG_CLOAKS);
+        entry->add(FLG_CLOAKS);
     } else if (tval == ItemKindType::HELM) {
-        ADD_FLG(FLG_HELMS);
+        entry->add(FLG_HELMS);
     } else if (tval == ItemKindType::GLOVES) {
-        ADD_FLG(FLG_GLOVES);
+        entry->add(FLG_GLOVES);
     } else if (tval == ItemKindType::BOOTS) {
-        ADD_FLG(FLG_BOOTS);
+        entry->add(FLG_BOOTS);
     }
 
     if (!name) {

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -250,72 +250,72 @@ bool autopick_new_entry(autopick_type *entry, concptr str, bool allow_default)
         }
     }
 
-    int prev_flg = -1;
+    auto previous_flag = -1;
     if (MATCH_KEY2(KEY_ARTIFACT)) {
         entry->add(FLG_ARTIFACT);
-        prev_flg = FLG_ARTIFACT;
+        previous_flag = FLG_ARTIFACT;
     }
 
     if (MATCH_KEY2(KEY_ITEMS)) {
         entry->add(FLG_ITEMS);
-        prev_flg = FLG_ITEMS;
+        previous_flag = FLG_ITEMS;
     } else if (MATCH_KEY2(KEY_WEAPONS)) {
         entry->add(FLG_WEAPONS);
-        prev_flg = FLG_WEAPONS;
+        previous_flag = FLG_WEAPONS;
     } else if (MATCH_KEY2(KEY_FAVORITE_WEAPONS)) {
         entry->add(FLG_FAVORITE_WEAPONS);
-        prev_flg = FLG_FAVORITE_WEAPONS;
+        previous_flag = FLG_FAVORITE_WEAPONS;
     } else if (MATCH_KEY2(KEY_ARMORS)) {
         entry->add(FLG_ARMORS);
-        prev_flg = FLG_ARMORS;
+        previous_flag = FLG_ARMORS;
     } else if (MATCH_KEY2(KEY_MISSILES)) {
         entry->add(FLG_MISSILES);
-        prev_flg = FLG_MISSILES;
+        previous_flag = FLG_MISSILES;
     } else if (MATCH_KEY2(KEY_DEVICES)) {
         entry->add(FLG_DEVICES);
-        prev_flg = FLG_DEVICES;
+        previous_flag = FLG_DEVICES;
     } else if (MATCH_KEY2(KEY_LIGHTS)) {
         entry->add(FLG_LIGHTS);
-        prev_flg = FLG_LIGHTS;
+        previous_flag = FLG_LIGHTS;
     } else if (MATCH_KEY2(KEY_JUNKS)) {
         entry->add(FLG_JUNKS);
-        prev_flg = FLG_JUNKS;
+        previous_flag = FLG_JUNKS;
     } else if (MATCH_KEY2(KEY_CORPSES)) {
         entry->add(FLG_CORPSES);
-        prev_flg = FLG_CORPSES;
+        previous_flag = FLG_CORPSES;
     } else if (MATCH_KEY2(KEY_SPELLBOOKS)) {
         entry->add(FLG_SPELLBOOKS);
-        prev_flg = FLG_SPELLBOOKS;
+        previous_flag = FLG_SPELLBOOKS;
     } else if (MATCH_KEY2(KEY_HAFTED)) {
         entry->add(FLG_HAFTED);
-        prev_flg = FLG_HAFTED;
+        previous_flag = FLG_HAFTED;
     } else if (MATCH_KEY2(KEY_SHIELDS)) {
         entry->add(FLG_SHIELDS);
-        prev_flg = FLG_SHIELDS;
+        previous_flag = FLG_SHIELDS;
     } else if (MATCH_KEY2(KEY_BOWS)) {
         entry->add(FLG_BOWS);
-        prev_flg = FLG_BOWS;
+        previous_flag = FLG_BOWS;
     } else if (MATCH_KEY2(KEY_RINGS)) {
         entry->add(FLG_RINGS);
-        prev_flg = FLG_RINGS;
+        previous_flag = FLG_RINGS;
     } else if (MATCH_KEY2(KEY_AMULETS)) {
         entry->add(FLG_AMULETS);
-        prev_flg = FLG_AMULETS;
+        previous_flag = FLG_AMULETS;
     } else if (MATCH_KEY2(KEY_SUITS)) {
         entry->add(FLG_SUITS);
-        prev_flg = FLG_SUITS;
+        previous_flag = FLG_SUITS;
     } else if (MATCH_KEY2(KEY_CLOAKS)) {
         entry->add(FLG_CLOAKS);
-        prev_flg = FLG_CLOAKS;
+        previous_flag = FLG_CLOAKS;
     } else if (MATCH_KEY2(KEY_HELMS)) {
         entry->add(FLG_HELMS);
-        prev_flg = FLG_HELMS;
+        previous_flag = FLG_HELMS;
     } else if (MATCH_KEY2(KEY_GLOVES)) {
         entry->add(FLG_GLOVES);
-        prev_flg = FLG_GLOVES;
+        previous_flag = FLG_GLOVES;
     } else if (MATCH_KEY2(KEY_BOOTS)) {
         entry->add(FLG_BOOTS);
-        prev_flg = FLG_BOOTS;
+        previous_flag = FLG_BOOTS;
     }
 
     if (*ptr == ':') {
@@ -327,13 +327,13 @@ bool autopick_new_entry(autopick_type *entry, concptr str, bool allow_default)
     }
 #endif
     else if (*ptr == '\0') {
-        if (prev_flg == -1) {
+        if (previous_flag == -1) {
             entry->add(FLG_ITEMS);
-            prev_flg = FLG_ITEMS;
+            previous_flag = FLG_ITEMS;
         }
     } else {
-        if (prev_flg != -1) {
-            entry->flags[prev_flg / 32] &= ~(1UL << (prev_flg % 32));
+        if (previous_flag != -1) {
+            entry->flags[previous_flag / 32] &= ~(1UL << (previous_flag % 32));
             ptr = prev_ptr;
         }
     }
@@ -674,7 +674,7 @@ concptr autopick_line_from_entry(const autopick_type &entry)
         ss << shape_autopick_key(KEY_ARTIFACT);
     }
 
-    bool sepa_flag = true;
+    auto should_separate = true;
     if (entry.has(FLG_ITEMS)) {
         ss << KEY_ITEMS;
     } else if (entry.has(FLG_WEAPONS)) {
@@ -716,11 +716,11 @@ concptr autopick_line_from_entry(const autopick_type &entry)
     } else if (entry.has(FLG_BOOTS)) {
         ss << KEY_BOOTS;
     } else if (!entry.has(FLG_ARTIFACT)) {
-        sepa_flag = false;
+        should_separate = false;
     }
 
     if (!entry.name.empty()) {
-        if (sepa_flag) {
+        if (should_separate) {
             ss << ":";
         }
 

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -26,6 +26,8 @@
 #include "system/player-type-definition.h"
 #include "util/quarks.h"
 #include "util/string-processor.h"
+#include <sstream>
+#include <string>
 
 #ifdef JP
 static char kanji_colon[] = "：";
@@ -533,199 +535,226 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, It
     str_tolower(entry->name.data());
 }
 
+std::string shape_autopick_key(const std::string &key)
+{
+#ifdef JP
+    return key;
+#else
+    std::stringstream ss;
+    ss << key << ' ';
+    return ss.str();
+#endif
+}
+
 /*!
  * @brief Reconstruct preference line from entry
  */
 concptr autopick_line_from_entry(const autopick_type &entry)
 {
-    char buf[MAX_LINELEN]{};
+    std::stringstream ss;
     if (!(entry.action & DO_DISPLAY)) {
-        strcat(buf, "(");
-    }
-    if (entry.action & DO_QUERY_AUTOPICK) {
-        strcat(buf, ";");
-    }
-    if (entry.action & DO_AUTODESTROY) {
-        strcat(buf, "!");
-    }
-    if (entry.action & DONT_AUTOPICK) {
-        strcat(buf, "~");
+        ss << '(';
     }
 
-    char *ptr;
-    ptr = buf;
+    if (entry.action & DO_QUERY_AUTOPICK) {
+        ss << ';';
+    }
+
+    if (entry.action & DO_AUTODESTROY) {
+        ss << '!';
+    }
+
+    if (entry.action & DONT_AUTOPICK) {
+        ss << '~';
+    }
+
     if (entry.has(FLG_ALL)) {
-        ADD_KEY(KEY_ALL);
+        ss << shape_autopick_key(KEY_ALL);
     }
     if (entry.has(FLG_COLLECTING)) {
-        ADD_KEY(KEY_COLLECTING);
+        ss << shape_autopick_key(KEY_COLLECTING);
     }
     if (entry.has(FLG_UNAWARE)) {
-        ADD_KEY(KEY_UNAWARE);
+        ss << shape_autopick_key(KEY_UNAWARE);
     }
     if (entry.has(FLG_UNIDENTIFIED)) {
-        ADD_KEY(KEY_UNIDENTIFIED);
+        ss << shape_autopick_key(KEY_UNIDENTIFIED);
     }
     if (entry.has(FLG_IDENTIFIED)) {
-        ADD_KEY(KEY_IDENTIFIED);
+        ss << shape_autopick_key(KEY_IDENTIFIED);
     }
     if (entry.has(FLG_STAR_IDENTIFIED)) {
-        ADD_KEY(KEY_STAR_IDENTIFIED);
+        ss << shape_autopick_key(KEY_STAR_IDENTIFIED);
     }
     if (entry.has(FLG_BOOSTED)) {
-        ADD_KEY(KEY_BOOSTED);
+        ss << shape_autopick_key(KEY_BOOSTED);
     }
 
     if (entry.has(FLG_MORE_DICE)) {
-        ADD_KEY(KEY_MORE_THAN);
-        strcat(ptr, format("%d", entry.dice).data());
-        ADD_KEY(KEY_DICE);
+        ss << shape_autopick_key(KEY_MORE_THAN);
+        ss << entry.dice;
+        ss << shape_autopick_key(KEY_DICE);
     }
 
     if (entry.has(FLG_MORE_BONUS)) {
-        ADD_KEY(KEY_MORE_BONUS);
-        strcat(ptr, format("%d", entry.bonus).data());
-        ADD_KEY(KEY_MORE_BONUS2);
+        ss << shape_autopick_key(KEY_MORE_BONUS);
+        ss << entry.bonus;
+        ss << shape_autopick_key(KEY_MORE_BONUS2);
     }
 
     if (entry.has(FLG_UNREADABLE)) {
-        ADD_KEY(KEY_UNREADABLE);
+        ss << shape_autopick_key(KEY_UNREADABLE);
     }
+
     if (entry.has(FLG_REALM1)) {
-        ADD_KEY(KEY_REALM1);
+        ss << shape_autopick_key(KEY_REALM1);
     }
+
     if (entry.has(FLG_REALM2)) {
-        ADD_KEY(KEY_REALM2);
+        ss << shape_autopick_key(KEY_REALM2);
     }
+
     if (entry.has(FLG_FIRST)) {
-        ADD_KEY(KEY_FIRST);
+        ss << shape_autopick_key(KEY_FIRST);
     }
+
     if (entry.has(FLG_SECOND)) {
-        ADD_KEY(KEY_SECOND);
+        ss << shape_autopick_key(KEY_SECOND);
     }
+
     if (entry.has(FLG_THIRD)) {
-        ADD_KEY(KEY_THIRD);
+        ss << shape_autopick_key(KEY_THIRD);
     }
+
     if (entry.has(FLG_FOURTH)) {
-        ADD_KEY(KEY_FOURTH);
+        ss << shape_autopick_key(KEY_FOURTH);
     }
+
     if (entry.has(FLG_WANTED)) {
-        ADD_KEY(KEY_WANTED);
+        ss << shape_autopick_key(KEY_WANTED);
     }
+
     if (entry.has(FLG_UNIQUE)) {
-        ADD_KEY(KEY_UNIQUE);
+        ss << shape_autopick_key(KEY_UNIQUE);
     }
+
     if (entry.has(FLG_HUMAN)) {
-        ADD_KEY(KEY_HUMAN);
+        ss << shape_autopick_key(KEY_HUMAN);
     }
+
     if (entry.has(FLG_WORTHLESS)) {
-        ADD_KEY(KEY_WORTHLESS);
+        ss << shape_autopick_key(KEY_WORTHLESS);
     }
+
     if (entry.has(FLG_GOOD)) {
-        ADD_KEY(KEY_GOOD);
+        ss << shape_autopick_key(KEY_GOOD);
     }
+
     if (entry.has(FLG_NAMELESS)) {
-        ADD_KEY(KEY_NAMELESS);
+        ss << shape_autopick_key(KEY_NAMELESS);
     }
+
     if (entry.has(FLG_AVERAGE)) {
-        ADD_KEY(KEY_AVERAGE);
+        ss << shape_autopick_key(KEY_AVERAGE);
     }
+
     if (entry.has(FLG_RARE)) {
-        ADD_KEY(KEY_RARE);
+        ss << shape_autopick_key(KEY_RARE);
     }
+
     if (entry.has(FLG_COMMON)) {
-        ADD_KEY(KEY_COMMON);
+        ss << shape_autopick_key(KEY_COMMON);
     }
+
     if (entry.has(FLG_EGO)) {
-        ADD_KEY(KEY_EGO);
+        ss << shape_autopick_key(KEY_EGO);
     }
 
     if (entry.has(FLG_ARTIFACT)) {
-        ADD_KEY(KEY_ARTIFACT);
+        ss << shape_autopick_key(KEY_ARTIFACT);
     }
 
     bool sepa_flag = true;
     if (entry.has(FLG_ITEMS)) {
-        ADD_KEY2(KEY_ITEMS);
+        ss << KEY_ITEMS;
     } else if (entry.has(FLG_WEAPONS)) {
-        ADD_KEY2(KEY_WEAPONS);
+        ss << KEY_WEAPONS;
     } else if (entry.has(FLG_FAVORITE_WEAPONS)) {
-        ADD_KEY2(KEY_FAVORITE_WEAPONS);
+        ss << KEY_FAVORITE_WEAPONS;
     } else if (entry.has(FLG_ARMORS)) {
-        ADD_KEY2(KEY_ARMORS);
+        ss << KEY_ARMORS;
     } else if (entry.has(FLG_MISSILES)) {
-        ADD_KEY2(KEY_MISSILES);
+        ss << KEY_MISSILES;
     } else if (entry.has(FLG_DEVICES)) {
-        ADD_KEY2(KEY_DEVICES);
+        ss << KEY_DEVICES;
     } else if (entry.has(FLG_LIGHTS)) {
-        ADD_KEY2(KEY_LIGHTS);
+        ss << KEY_LIGHTS;
     } else if (entry.has(FLG_JUNKS)) {
-        ADD_KEY2(KEY_JUNKS);
+        ss << KEY_JUNKS;
     } else if (entry.has(FLG_CORPSES)) {
-        ADD_KEY2(KEY_CORPSES);
+        ss << KEY_CORPSES;
     } else if (entry.has(FLG_SPELLBOOKS)) {
-        ADD_KEY2(KEY_SPELLBOOKS);
+        ss << KEY_SPELLBOOKS;
     } else if (entry.has(FLG_HAFTED)) {
-        ADD_KEY2(KEY_HAFTED);
+        ss << KEY_HAFTED;
     } else if (entry.has(FLG_SHIELDS)) {
-        ADD_KEY2(KEY_SHIELDS);
+        ss << KEY_SHIELDS;
     } else if (entry.has(FLG_BOWS)) {
-        ADD_KEY2(KEY_BOWS);
+        ss << KEY_BOWS;
     } else if (entry.has(FLG_RINGS)) {
-        ADD_KEY2(KEY_RINGS);
+        ss << KEY_RINGS;
     } else if (entry.has(FLG_AMULETS)) {
-        ADD_KEY2(KEY_AMULETS);
+        ss << KEY_AMULETS;
     } else if (entry.has(FLG_SUITS)) {
-        ADD_KEY2(KEY_SUITS);
+        ss << KEY_SUITS;
     } else if (entry.has(FLG_CLOAKS)) {
-        ADD_KEY2(KEY_CLOAKS);
+        ss << KEY_CLOAKS;
     } else if (entry.has(FLG_HELMS)) {
-        ADD_KEY2(KEY_HELMS);
+        ss << KEY_HELMS;
     } else if (entry.has(FLG_GLOVES)) {
-        ADD_KEY2(KEY_GLOVES);
+        ss << KEY_GLOVES;
     } else if (entry.has(FLG_BOOTS)) {
-        ADD_KEY2(KEY_BOOTS);
+        ss << KEY_BOOTS;
     } else if (!entry.has(FLG_ARTIFACT)) {
         sepa_flag = false;
     }
 
     if (!entry.name.empty()) {
         if (sepa_flag) {
-            strcat(buf, ":");
+            ss << ":";
         }
 
-        int i = strlen(buf);
-        int j = 0;
-        while (entry.name[j] && i < MAX_LINELEN - 2 - 1) {
+        const auto i = ss.tellp();
+        auto j = 0;
+        while (entry.name[j] && (i < MAX_LINELEN - 2 - 1)) {
 #ifdef JP
             if (iskanji(entry.name[j])) {
-                buf[i++] = entry.name[j++];
+                ss << entry.name[j++];
             }
 #endif
-            buf[i++] = entry.name[j++];
+            ss << entry.name[j++];
         }
-        buf[i] = '\0';
     }
 
     if (entry.insc.empty()) {
-        return string_make(buf);
+        auto str = ss.str();
+        return string_make(str.data());
     }
 
-    int i, j = 0;
-    strcat(buf, "#");
-    i = strlen(buf);
-
-    while (entry.insc[j] && i < MAX_LINELEN - 2) {
+    ss << '#';
+    const auto i = ss.tellp();
+    auto j = 0;
+    while (entry.insc[j] && (i < MAX_LINELEN - 2)) {
 #ifdef JP
         if (iskanji(entry.insc[j])) {
-            buf[i++] = entry.insc[j++];
+            ss << entry.insc[j++];
         }
 #endif
-        buf[i++] = entry.insc[j++];
+        ss << entry.insc[j++];
     }
 
-    buf[i] = '\0';
-    return string_make(buf);
+    auto str = ss.str();
+    return string_make(str.data());
 }
 
 /*!

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -725,16 +725,7 @@ concptr autopick_line_from_entry(const autopick_type &entry)
             ss << ":";
         }
 
-        const auto i = ss.tellp();
-        auto j = 0;
-        while (entry.name[j] && (i < MAX_LINELEN - 2 - 1)) {
-#ifdef JP
-            if (iskanji(entry.name[j])) {
-                ss << entry.name[j++];
-            }
-#endif
-            ss << entry.name[j++];
-        }
+        ss << entry.name;
     }
 
     if (entry.insc.empty()) {
@@ -742,18 +733,7 @@ concptr autopick_line_from_entry(const autopick_type &entry)
         return string_make(str.data());
     }
 
-    ss << '#';
-    const auto i = ss.tellp();
-    auto j = 0;
-    while (entry.insc[j] && (i < MAX_LINELEN - 2)) {
-#ifdef JP
-        if (iskanji(entry.insc[j])) {
-            ss << entry.insc[j++];
-        }
-#endif
-        ss << entry.insc[j++];
-    }
-
+    ss << '#' << entry.insc;
     auto str = ss.str();
     return string_make(str.data());
 }

--- a/src/autopick/autopick-key-flag-process.h
+++ b/src/autopick/autopick-key-flag-process.h
@@ -6,10 +6,3 @@
 #define MATCH_KEY2(KEY) (!strncmp(ptr, KEY, strlen(KEY))                                             \
                              ? (prev_ptr = ptr, ptr += strlen(KEY), (' ' == *ptr) ? ptr++ : 0, true) \
                              : false)
-
-#ifdef JP
-#define ADD_KEY(KEY) strcat(ptr, KEY)
-#else
-#define ADD_KEY(KEY) (strcat(ptr, KEY), strcat(ptr, " "))
-#endif
-#define ADD_KEY2(KEY) strcat(ptr, KEY)

--- a/src/autopick/autopick-key-flag-process.h
+++ b/src/autopick/autopick-key-flag-process.h
@@ -14,5 +14,4 @@
 #endif
 #define ADD_KEY2(KEY) strcat(ptr, KEY)
 
-#define ADD_FLG(FLG) (entry->flags[FLG / 32] |= (1UL << (FLG % 32)))
-#define ADD_FLG_NOUN(FLG) (ADD_FLG(FLG), prev_flg = FLG)
+#define ADD_FLG_NOUN(FLG) (entry->add(FLG), prev_flg = FLG)

--- a/src/autopick/autopick-key-flag-process.h
+++ b/src/autopick/autopick-key-flag-process.h
@@ -13,5 +13,3 @@
 #define ADD_KEY(KEY) (strcat(ptr, KEY), strcat(ptr, " "))
 #endif
 #define ADD_KEY2(KEY) strcat(ptr, KEY)
-
-#define ADD_FLG_NOUN(FLG) (entry->add(FLG), prev_flg = FLG)

--- a/src/autopick/autopick-key-flag-process.h
+++ b/src/autopick/autopick-key-flag-process.h
@@ -15,5 +15,4 @@
 #define ADD_KEY2(KEY) strcat(ptr, KEY)
 
 #define ADD_FLG(FLG) (entry->flags[FLG / 32] |= (1UL << (FLG % 32)))
-#define REM_FLG(FLG) (entry->flags[FLG / 32] &= ~(1UL << (FLG % 32)))
 #define ADD_FLG_NOUN(FLG) (ADD_FLG(FLG), prev_flg = FLG)

--- a/src/autopick/autopick-util.cpp
+++ b/src/autopick/autopick-util.cpp
@@ -8,6 +8,7 @@
 #include "object-enchant/item-feeling.h"
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
+#include "util/bit-flags-calculator.h"
 #include "util/quarks.h"
 
 /*!
@@ -26,6 +27,11 @@ ItemEntity autopick_last_destroyed_object;
 bool autopick_type::has(int flag) const
 {
     return this->flags[flag / 32] & (1UL << (flag % 32));
+}
+
+void autopick_type::remove(int flag)
+{
+    reset_bits(this->flags[flag / 32], 1UL << (flag % 32));
 }
 
 /*!

--- a/src/autopick/autopick-util.cpp
+++ b/src/autopick/autopick-util.cpp
@@ -29,6 +29,11 @@ bool autopick_type::has(int flag) const
     return this->flags[flag / 32] & (1UL << (flag % 32));
 }
 
+void autopick_type::add(int flag)
+{
+    set_bits(this->flags[flag / 32], 1UL << (flag % 32));
+}
+
 void autopick_type::remove(int flag)
 {
     reset_bits(this->flags[flag / 32], 1UL << (flag % 32));

--- a/src/autopick/autopick-util.h
+++ b/src/autopick/autopick-util.h
@@ -32,6 +32,7 @@ struct autopick_type {
     byte dice; /*!< 武器のダイス値基準値 / Weapons which have more than 'dice' dice match */
     byte bonus; /*!< アイテムのボーナス基準値 / Items which have more than 'bonus' magical bonus match */
     bool has(int flag) const;
+    void remove(int flag);
 };
 
 /*

--- a/src/autopick/autopick-util.h
+++ b/src/autopick/autopick-util.h
@@ -32,6 +32,7 @@ struct autopick_type {
     byte dice; /*!< 武器のダイス値基準値 / Weapons which have more than 'dice' dice match */
     byte bonus; /*!< アイテムのボーナス基準値 / Items which have more than 'bonus' magical bonus match */
     bool has(int flag) const;
+    void add(int flag);
     void remove(int flag);
 };
 


### PR DESCRIPTION
MATCH\_KEY() 及びMATCH\_KEY2() は複雑過ぎたので残しています
拾う・破壊する・銘をつける・放置する・前方一致、全て機能しています
ご確認下さい