### PR TITLE
[Fix] モンスターが動くとクラッシュする

### DIFF
--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -106,7 +106,7 @@ bool update_riding_monster(PlayerType *player_ptr, turn_flags *turn_flags_ptr, M
 void update_player_type(PlayerType *player_ptr, turn_flags *turn_flags_ptr, MonsterRaceInfo *r_ptr)
 {
     using Mbt = MonsterBrightnessType;
-    const auto &except_has_lite = EnumClassFlagGroup<Mbt>(self_ld_mask).set({ Mbt::HAS_DARK_1, Mbt::HAS_DARK_2 });
+    const auto except_has_lite = EnumClassFlagGroup<Mbt>(self_ld_mask).set({ Mbt::HAS_DARK_1, Mbt::HAS_DARK_2 });
     if (turn_flags_ptr->do_view) {
         player_ptr->update |= PU_FLOW;
         player_ptr->window_flags |= PW_OVERHEAD | PW_DUNGEON;


### PR DESCRIPTION
一時オブジェクトから自身の参照を返すメソッドを呼び出した結果を参照変数で受けているため、その参照変数を使用する時にすでに実態がなくなっており、ダングリング参照になってしまっている。
&を削除してコピーを受け取るようにして修正する。