### PR TITLE
[Fix] ペットのブレスがプレイヤーを巻き込む

### DIFF
--- a/src/mspell/mspell-judgement.cpp
+++ b/src/mspell/mspell-judgement.cpp
@@ -108,7 +108,7 @@ bool breath_direct(PlayerType *player_ptr, POSITION y1, POSITION x1, POSITION y2
     }
 
     projection_path grid_g(player_ptr, get_max_range(player_ptr), y1, x1, y2, x2, flg);
-    int i = 0;
+    auto path_n = 0;
     POSITION y = y1;
     POSITION x = x1;
     for (const auto &[ny, nx] : grid_g) {
@@ -128,12 +128,12 @@ bool breath_direct(PlayerType *player_ptr, POSITION y1, POSITION x1, POSITION y2
 
         y = ny;
         x = nx;
-        i++;
+        ++path_n;
     }
 
     bool hit2 = false;
     bool hityou = false;
-    if (i == 0) {
+    if (path_n == 0) {
         if (flg & PROJECT_DISI) {
             if (in_disintegration_range(player_ptr->current_floor_ptr, y1, x1, y2, x2) && (distance(y1, x1, y2, x2) <= rad)) {
                 hit2 = true;
@@ -161,8 +161,8 @@ bool breath_direct(PlayerType *player_ptr, POSITION y1, POSITION x1, POSITION y2
         POSITION gx[1024], gy[1024];
         POSITION gm[32];
         POSITION gm_rad = rad;
-        breath_shape(player_ptr, grid_g, grid_g.path_num(), &grids, gx, gy, gm, &gm_rad, rad, y1, x1, y, x, typ);
-        for (i = 0; i < grids; i++) {
+        breath_shape(player_ptr, grid_g, path_n, &grids, gx, gy, gm, &gm_rad, rad, y1, x1, y, x, typ);
+        for (auto i = 0; i < grids; i++) {
             y = gy[i];
             x = gx[i];
             if ((y == y2) && (x == x2)) {


### PR DESCRIPTION
プレイヤーを巻き込むかどうかのチェックで使用する breath_direct() 関数と実際にブレスを使用する project() 関数それぞれからの breath_shape() の呼び出しの第3引数 dist の値が、前者は障害物の有無を考慮せず後者は考慮しているため異なることがある。それによりブレスの形が巻き込みチェックと実際で変わってしまうためプレイヤーを意図せず巻き込んでしまっている。
breath_direct() 関数でも障害物の有無を考慮した値（元はiという変数名だったのでpath_nに変更する）を breath_shape() に渡すようにする。

修正は breath_direct() 関数ですが、 project() 関数側からの breath_share() の呼び出しも合わせてご確認ください。