### PR TITLE
PlayerType::dungeon_idx をFloorType::dungeon_idx へ吸収合併した

### DIFF
--- a/src/action/action-limited.cpp
+++ b/src/action/action-limited.cpp
@@ -28,7 +28,8 @@
  */
 bool cmd_limit_cast(PlayerType *player_ptr)
 {
-    if (player_ptr->current_floor_ptr->is_in_dungeon() && (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_MAGIC))) {
+    const auto &floor = *player_ptr->current_floor_ptr;
+    if (floor.is_in_dungeon() && (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::NO_MAGIC))) {
         msg_print(_("ダンジョンが魔法を吸収した！", "The dungeon absorbs all attempted magic!"));
         msg_print(nullptr);
         return true;

--- a/src/avatar/avatar-changer.cpp
+++ b/src/avatar/avatar-changer.cpp
@@ -63,7 +63,7 @@ void AvatarChanger::change_virtue_non_beginner()
 {
     auto *floor_ptr = this->player_ptr->current_floor_ptr;
     auto *r_ptr = &monraces_info[m_ptr->r_idx];
-    if (dungeons_info[this->player_ptr->dungeon_idx].flags.has(DungeonFeatureType::BEGINNER)) {
+    if (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::BEGINNER)) {
         return;
     }
 

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -148,8 +148,9 @@ void player_wipe_without_name(PlayerType *player_ptr)
 
     player_ptr->max_plv = player_ptr->lev = 1;
     player_ptr->arena_number = 0;
-    player_ptr->current_floor_ptr->inside_arena = false;
-    player_ptr->current_floor_ptr->quest_number = QuestId::NONE;
+    auto floor_ptr = player_ptr->current_floor_ptr;
+    floor_ptr->inside_arena = false;
+    floor_ptr->quest_number = QuestId::NONE;
 
     player_ptr->exit_bldg = true;
     player_ptr->knows_daily_bounty = false;
@@ -160,7 +161,7 @@ void player_wipe_without_name(PlayerType *player_ptr)
         player_ptr->virtues[i] = 0;
     }
 
-    player_ptr->dungeon_idx = 0;
+    floor_ptr->dungeon_idx = 0;
     if (vanilla_town || ironman_downward) {
         player_ptr->recall_dungeon = DUNGEON_ANGBAND;
     } else {

--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -170,11 +170,18 @@ static void natural_attack(PlayerType *player_ptr, MONSTER_IDX m_idx, PlayerMuta
  */
 bool do_cmd_attack(PlayerType *player_ptr, POSITION y, POSITION x, combat_options mode)
 {
-    auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
-    auto *m_ptr = &player_ptr->current_floor_ptr->m_list[g_ptr->m_idx];
+    auto &floor = *player_ptr->current_floor_ptr;
+    auto *g_ptr = &floor.grid_array[y][x];
+    auto *m_ptr = &floor.m_list[g_ptr->m_idx];
     auto *r_ptr = &monraces_info[m_ptr->r_idx];
 
-    const std::initializer_list<PlayerMutationType> mutation_attack_methods = { PlayerMutationType::HORNS, PlayerMutationType::BEAK, PlayerMutationType::SCOR_TAIL, PlayerMutationType::TRUNK, PlayerMutationType::TENTACLES };
+    const auto mutation_attack_methods = {
+        PlayerMutationType::HORNS,
+        PlayerMutationType::BEAK,
+        PlayerMutationType::SCOR_TAIL,
+        PlayerMutationType::TRUNK,
+        PlayerMutationType::TENTACLES,
+    };
 
     disturb(player_ptr, false, true);
 
@@ -211,7 +218,7 @@ bool do_cmd_attack(PlayerType *player_ptr, POSITION y, POSITION x, combat_option
         }
     }
 
-    if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE)) {
+    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE)) {
         sound(SOUND_ATTACK_FAILED);
         msg_print(_("なぜか攻撃することができない。", "Something prevents you from attacking."));
         return false;

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -165,7 +165,7 @@ void do_cmd_go_up(PlayerType *player_ptr)
             up_num = 1;
         }
 
-        if (player_ptr->current_floor_ptr->dun_level - up_num < dungeons_info[player_ptr->dungeon_idx].mindepth) {
+        if (player_ptr->current_floor_ptr->dun_level - up_num < dungeons_info[floor_ptr->dungeon_idx].mindepth) {
             up_num = player_ptr->current_floor_ptr->dun_level;
         }
     }
@@ -280,7 +280,7 @@ void do_cmd_go_down(PlayerType *player_ptr)
 
         player_ptr->oldpx = player_ptr->x;
         player_ptr->oldpy = player_ptr->y;
-        player_ptr->dungeon_idx = target_dungeon;
+        floor_ptr->dungeon_idx = target_dungeon;
         prepare_change_floor_mode(player_ptr, CFM_FIRST_FLOOR);
     }
 
@@ -297,7 +297,7 @@ void do_cmd_go_down(PlayerType *player_ptr)
 
     if (!floor_ptr->is_in_dungeon()) {
         player_ptr->enter_dungeon = true;
-        down_num = dungeons_info[player_ptr->dungeon_idx].mindepth;
+        down_num = dungeons_info[floor_ptr->dungeon_idx].mindepth;
     }
 
     if (record_stair) {
@@ -312,7 +312,7 @@ void do_cmd_go_down(PlayerType *player_ptr)
         msg_print(_("わざと落とし戸に落ちた。", "You deliberately jump through the trap door."));
     } else {
         if (target_dungeon) {
-            msg_format(_("%sへ入った。", "You entered %s."), dungeons_info[player_ptr->dungeon_idx].text.data());
+            msg_format(_("%sへ入った。", "You entered %s."), dungeons_info[floor_ptr->dungeon_idx].text.data());
         } else {
             if (is_echizen(player_ptr)) {
                 msg_print(_("なんだこの階段は！", "What's this STAIRWAY!"));

--- a/src/cmd-io/cmd-dump.cpp
+++ b/src/cmd-io/cmd-dump.cpp
@@ -228,13 +228,13 @@ void do_cmd_feeling(PlayerType *player_ptr)
         return;
     }
 
-    const auto &floor_ref = *player_ptr->current_floor_ptr;
-    if (inside_quest(floor_ref.quest_number) && !inside_quest(random_quest_number(player_ptr, floor_ref.dun_level))) {
+    const auto &floor = *player_ptr->current_floor_ptr;
+    if (inside_quest(floor.quest_number) && !inside_quest(random_quest_number(floor, floor.dun_level))) {
         msg_print(_("典型的なクエストのダンジョンのようだ。", "Looks like a typical quest level."));
         return;
     }
 
-    if (player_ptr->town_num && !floor_ref.is_in_dungeon()) {
+    if (player_ptr->town_num && !floor.is_in_dungeon()) {
         if (towns_info[player_ptr->town_num].name == _("荒野", "wilderness")) {
             msg_print(_("何かありそうな荒野のようだ。", "Looks like a strange wilderness."));
             return;
@@ -244,7 +244,7 @@ void do_cmd_feeling(PlayerType *player_ptr)
         return;
     }
 
-    if (!floor_ref.is_in_dungeon()) {
+    if (!floor.is_in_dungeon()) {
         msg_print(_("典型的な荒野のようだ。", "Looks like a typical wilderness."));
         return;
     }

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -278,7 +278,7 @@ static void generate_world(PlayerType *player_ptr, bool new_game)
     panel_row_min = floor_ptr->height;
     panel_col_min = floor_ptr->width;
 
-    set_floor_and_wall(player_ptr->dungeon_idx);
+    set_floor_and_wall(floor_ptr->dungeon_idx);
     initialize_items_flavor();
     prt(_("お待ち下さい...", "Please wait..."), 0, 0);
     term_fresh();

--- a/src/core/scores.cpp
+++ b/src/core/scores.cpp
@@ -226,9 +226,10 @@ errr top_twenty(PlayerType *player_ptr)
 
     /* Save the level and such */
     snprintf(the_score.cur_lev, sizeof(the_score.cur_lev), "%3d", std::min<ushort>(player_ptr->lev, 999));
-    snprintf(the_score.cur_dun, sizeof(the_score.cur_dun), "%3d", (int)player_ptr->current_floor_ptr->dun_level);
+    const auto &floor = *player_ptr->current_floor_ptr;
+    snprintf(the_score.cur_dun, sizeof(the_score.cur_dun), "%3d", floor.dun_level);
     snprintf(the_score.max_lev, sizeof(the_score.max_lev), "%3d", std::min<ushort>(player_ptr->max_plv, 999));
-    snprintf(the_score.max_dun, sizeof(the_score.max_dun), "%3d", (int)max_dlv[player_ptr->dungeon_idx]);
+    snprintf(the_score.max_dun, sizeof(the_score.max_dun), "%3d", max_dlv[floor.dungeon_idx]);
 
     /* Save the cause of death (31 chars) */
     if (player_ptr->died_from.size() >= sizeof(the_score.how)) {
@@ -331,9 +332,10 @@ errr predict_score(PlayerType *player_ptr)
 
     /* Save the level and such */
     snprintf(the_score.cur_lev, sizeof(the_score.cur_lev), "%3d", std::min<ushort>(player_ptr->lev, 999));
-    snprintf(the_score.cur_dun, sizeof(the_score.cur_dun), "%3d", (int)player_ptr->current_floor_ptr->dun_level);
+    const auto &floor = *player_ptr->current_floor_ptr;
+    snprintf(the_score.cur_dun, sizeof(the_score.cur_dun), "%3d", floor.dun_level);
     snprintf(the_score.max_lev, sizeof(the_score.max_lev), "%3d", std::min<ushort>(player_ptr->max_plv, 999));
-    snprintf(the_score.max_dun, sizeof(the_score.max_dun), "%3d", (int)max_dlv[player_ptr->dungeon_idx]);
+    snprintf(the_score.max_dun, sizeof(the_score.max_dun), "%3d", max_dlv[floor.dungeon_idx]);
 
     /* まだ死んでいないときの識別文字 */
     strcpy(the_score.how, _("yet", "nobody (yet!)"));

--- a/src/dungeon/dungeon-processor.cpp
+++ b/src/dungeon/dungeon-processor.cpp
@@ -84,8 +84,8 @@ static void redraw_character_xtra(PlayerType *player_ptr)
  */
 void process_dungeon(PlayerType *player_ptr, bool load_game)
 {
-    auto *floor_ptr = player_ptr->current_floor_ptr;
-    floor_ptr->base_level = floor_ptr->dun_level;
+    auto &floor = *player_ptr->current_floor_ptr;
+    floor.base_level = floor.dun_level;
     w_ptr->is_loading_now = false;
     player_ptr->leaving = false;
 
@@ -101,7 +101,7 @@ void process_dungeon(PlayerType *player_ptr, bool load_game)
     health_track(player_ptr, 0);
 
     disturb(player_ptr, true, true);
-    auto quest_num = quest_number(player_ptr, floor_ptr->dun_level);
+    auto quest_num = quest_number(floor, floor.dun_level);
     const auto &quest_list = QuestList::get_instance();
     auto *questor_ptr = &monraces_info[quest_list[quest_num].r_idx];
     if (inside_quest(quest_num)) {
@@ -112,10 +112,10 @@ void process_dungeon(PlayerType *player_ptr, bool load_game)
         player_ptr->max_plv = player_ptr->lev;
     }
 
-    if ((max_dlv[player_ptr->dungeon_idx] < floor_ptr->dun_level) && !inside_quest(floor_ptr->quest_number)) {
-        max_dlv[player_ptr->dungeon_idx] = floor_ptr->dun_level;
+    if ((max_dlv[floor.dungeon_idx] < floor.dun_level) && !inside_quest(floor.quest_number)) {
+        max_dlv[floor.dungeon_idx] = floor.dun_level;
         if (record_maxdepth) {
-            exe_write_diary(player_ptr, DIARY_MAXDEAPTH, floor_ptr->dun_level, nullptr);
+            exe_write_diary(player_ptr, DIARY_MAXDEAPTH, floor.dun_level, nullptr);
         }
     }
 
@@ -162,14 +162,14 @@ void process_dungeon(PlayerType *player_ptr, bool load_game)
         return;
     }
 
-    if (!inside_quest(floor_ptr->quest_number) && (player_ptr->dungeon_idx == DUNGEON_ANGBAND)) {
-        quest_discovery(random_quest_number(player_ptr, floor_ptr->dun_level));
-        floor_ptr->quest_number = random_quest_number(player_ptr, floor_ptr->dun_level);
+    if (!inside_quest(floor.quest_number) && (floor.dungeon_idx == DUNGEON_ANGBAND)) {
+        quest_discovery(random_quest_number(floor, floor.dun_level));
+        floor.quest_number = random_quest_number(floor, floor.dun_level);
     }
 
-    const auto &dungeon = dungeons_info[player_ptr->dungeon_idx];
+    const auto &dungeon = dungeons_info[floor.dungeon_idx];
     const auto guardian = dungeon.final_guardian;
-    if ((floor_ptr->dun_level == dungeon.maxdepth) && MonsterRace(guardian).is_valid()) {
+    if ((floor.dun_level == dungeon.maxdepth) && MonsterRace(guardian).is_valid()) {
         const auto &guardian_ref = monraces_info[guardian];
         if (guardian_ref.max_num) {
 #ifdef JP
@@ -184,30 +184,30 @@ void process_dungeon(PlayerType *player_ptr, bool load_game)
         set_superstealth(player_ptr, false);
     }
 
-    floor_ptr->monster_level = floor_ptr->base_level;
-    floor_ptr->object_level = floor_ptr->base_level;
+    floor.monster_level = floor.base_level;
+    floor.object_level = floor.base_level;
     w_ptr->is_loading_now = true;
-    if (player_ptr->energy_need > 0 && !player_ptr->phase_out && (floor_ptr->dun_level || player_ptr->leaving_dungeon || floor_ptr->inside_arena)) {
+    if (player_ptr->energy_need > 0 && !player_ptr->phase_out && (floor.dun_level || player_ptr->leaving_dungeon || floor.inside_arena)) {
         player_ptr->energy_need = 0;
     }
 
     player_ptr->leaving_dungeon = false;
-    mproc_init(floor_ptr);
+    mproc_init(&floor);
 
     while (true) {
-        if ((floor_ptr->m_cnt + 32 > w_ptr->max_m_idx) && !player_ptr->phase_out) {
+        if ((floor.m_cnt + 32 > w_ptr->max_m_idx) && !player_ptr->phase_out) {
             compact_monsters(player_ptr, 64);
         }
 
-        if ((floor_ptr->m_cnt + 32 < floor_ptr->m_max) && !player_ptr->phase_out) {
+        if ((floor.m_cnt + 32 < floor.m_max) && !player_ptr->phase_out) {
             compact_monsters(player_ptr, 0);
         }
 
-        if (floor_ptr->o_cnt + 32 > w_ptr->max_o_idx) {
+        if (floor.o_cnt + 32 > w_ptr->max_o_idx) {
             compact_objects(player_ptr, 64);
         }
 
-        if (floor_ptr->o_cnt + 32 < floor_ptr->o_max) {
+        if (floor.o_cnt + 32 < floor.o_max) {
             compact_objects(player_ptr, 0);
         }
 

--- a/src/dungeon/quest-monster-placer.cpp
+++ b/src/dungeon/quest-monster-placer.cpp
@@ -30,7 +30,7 @@ bool place_quest_monsters(PlayerType *player_ptr)
         auto no_quest_monsters = quest.status != QuestStatusType::TAKEN;
         no_quest_monsters |= (quest.type != QuestKindType::KILL_LEVEL && quest.type != QuestKindType::RANDOM);
         no_quest_monsters |= quest.level != floor_ptr->dun_level;
-        no_quest_monsters |= player_ptr->dungeon_idx != quest.dungeon;
+        no_quest_monsters |= floor_ptr->dungeon_idx != quest.dungeon;
         no_quest_monsters |= any_bits(quest.flags, QUEST_FLAG_PRESET);
 
         if (no_quest_monsters) {

--- a/src/dungeon/quest.cpp
+++ b/src/dungeon/quest.cpp
@@ -345,12 +345,11 @@ void quest_discovery(QuestId q_idx)
  * @param level 検索対象になる階
  * @return クエストIDを返す。該当がない場合0を返す。
  */
-QuestId quest_number(PlayerType *player_ptr, DEPTH level)
+QuestId quest_number(const FloorType &floor, DEPTH level)
 {
-    auto *floor_ptr = player_ptr->current_floor_ptr;
     const auto &quest_list = QuestList::get_instance();
-    if (inside_quest(floor_ptr->quest_number)) {
-        return floor_ptr->quest_number;
+    if (inside_quest(floor.quest_number)) {
+        return floor.quest_number;
     }
 
     for (const auto &[q_idx, quest] : quest_list) {
@@ -361,13 +360,13 @@ QuestId quest_number(PlayerType *player_ptr, DEPTH level)
         auto depth_quest = (quest.type == QuestKindType::KILL_LEVEL);
         depth_quest &= !(quest.flags & QUEST_FLAG_PRESET);
         depth_quest &= (quest.level == level);
-        depth_quest &= (quest.dungeon == player_ptr->dungeon_idx);
+        depth_quest &= (quest.dungeon == floor.dungeon_idx);
         if (depth_quest) {
             return q_idx;
         }
     }
 
-    return random_quest_number(player_ptr, level);
+    return random_quest_number(floor, level);
 }
 
 /*!
@@ -376,9 +375,9 @@ QuestId quest_number(PlayerType *player_ptr, DEPTH level)
  * @param level 検索対象になる階
  * @return クエストIDを返す。該当がない場合0を返す。
  */
-QuestId random_quest_number(PlayerType *player_ptr, DEPTH level)
+QuestId random_quest_number(const FloorType &floor, DEPTH level)
 {
-    if (player_ptr->dungeon_idx != DUNGEON_ANGBAND) {
+    if (floor.dungeon_idx != DUNGEON_ANGBAND) {
         return QuestId::NONE;
     }
 

--- a/src/dungeon/quest.h
+++ b/src/dungeon/quest.h
@@ -162,6 +162,7 @@ extern char quest_text[10][80];
 extern int quest_text_line;
 extern QuestId leaving_quest;
 
+class FloorType;
 class ItemEntity;
 class PlayerType;
 void determine_random_questor(PlayerType *player_ptr, QuestType *q_ptr);
@@ -169,8 +170,8 @@ void record_quest_final_status(QuestType *q_ptr, PLAYER_LEVEL lev, QuestStatusTy
 void complete_quest(PlayerType *player_ptr, QuestId quest_num);
 void check_find_art_quest_completion(PlayerType *player_ptr, ItemEntity *o_ptr);
 void quest_discovery(QuestId q_idx);
-QuestId quest_number(PlayerType *player_ptr, DEPTH level);
-QuestId random_quest_number(PlayerType *player_ptr, DEPTH level);
+QuestId quest_number(const FloorType &floor, DEPTH level);
+QuestId random_quest_number(const FloorType &floor, DEPTH level);
 void leave_quest_check(PlayerType *player_ptr);
 void leave_tower_check(PlayerType *player_ptr);
 void exe_enter_quest(PlayerType *player_ptr, QuestId quest_idx);

--- a/src/effect/effect-feature.cpp
+++ b/src/effect/effect-feature.cpp
@@ -340,7 +340,7 @@ bool affect_feature(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITIO
     }
     case AttributeType::LITE_WEAK:
     case AttributeType::LITE: {
-        if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+        if (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
             break;
         }
 

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -282,15 +282,16 @@ static void reset_unique_by_floor_change(PlayerType *player_ptr)
 static void new_floor_allocation(PlayerType *player_ptr, saved_floor_type *sf_ptr)
 {
     GAME_TURN tmp_last_visit = sf_ptr->last_visit;
-    int alloc_chance = dungeons_info[player_ptr->dungeon_idx].max_m_alloc_chance;
+    const auto &floor = *player_ptr->current_floor_ptr;
+    int alloc_chance = dungeons_info[floor.dungeon_idx].max_m_alloc_chance;
     while (tmp_last_visit > w_ptr->game_turn) {
         tmp_last_visit -= TURNS_PER_TICK * TOWN_DAWN;
     }
 
     GAME_TURN absence_ticks = (w_ptr->game_turn - tmp_last_visit) / TURNS_PER_TICK;
     reset_unique_by_floor_change(player_ptr);
-    for (MONSTER_IDX i = 1; i < player_ptr->current_floor_ptr->o_max; i++) {
-        auto *o_ptr = &player_ptr->current_floor_ptr->o_list[i];
+    for (MONSTER_IDX i = 1; i < floor.o_max; i++) {
+        const auto *o_ptr = &floor.o_list[i];
         if (!o_ptr->is_valid() || !o_ptr->is_fixed_artifact()) {
             continue;
         }
@@ -339,16 +340,17 @@ static void update_new_floor_feature(PlayerType *player_ptr, saved_floor_type *s
 
     check_dead_end(player_ptr, sf_ptr);
     sf_ptr->last_visit = w_ptr->game_turn;
-    sf_ptr->dun_level = player_ptr->current_floor_ptr->dun_level;
+    auto &floor = *player_ptr->current_floor_ptr;
+    sf_ptr->dun_level = floor.dun_level;
     if ((player_ptr->change_floor_mode & CFM_NO_RETURN) != 0) {
         return;
     }
 
-    auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x];
-    if ((player_ptr->change_floor_mode & CFM_UP) && !inside_quest(quest_number(player_ptr, player_ptr->current_floor_ptr->dun_level))) {
-        g_ptr->feat = (player_ptr->change_floor_mode & CFM_SHAFT) ? feat_state(player_ptr->current_floor_ptr, feat_down_stair, TerrainCharacteristics::SHAFT) : feat_down_stair;
+    auto *g_ptr = &floor.grid_array[player_ptr->y][player_ptr->x];
+    if ((player_ptr->change_floor_mode & CFM_UP) && !inside_quest(quest_number(floor, floor.dun_level))) {
+        g_ptr->feat = (player_ptr->change_floor_mode & CFM_SHAFT) ? feat_state(&floor, feat_down_stair, TerrainCharacteristics::SHAFT) : feat_down_stair;
     } else if ((player_ptr->change_floor_mode & CFM_DOWN) && !ironman_downward) {
-        g_ptr->feat = (player_ptr->change_floor_mode & CFM_SHAFT) ? feat_state(player_ptr->current_floor_ptr, feat_up_stair, TerrainCharacteristics::SHAFT) : feat_up_stair;
+        g_ptr->feat = (player_ptr->change_floor_mode & CFM_SHAFT) ? feat_state(&floor, feat_up_stair, TerrainCharacteristics::SHAFT) : feat_up_stair;
     }
 
     g_ptr->mimic = 0;

--- a/src/floor/floor-events.cpp
+++ b/src/floor/floor-events.cpp
@@ -277,8 +277,8 @@ static byte get_dungeon_feeling(PlayerType *player_ptr)
  */
 void update_dungeon_feeling(PlayerType *player_ptr)
 {
-    auto *floor_ptr = player_ptr->current_floor_ptr;
-    if (!floor_ptr->dun_level) {
+    const auto &floor = *player_ptr->current_floor_ptr;
+    if (!floor.dun_level) {
         return;
     }
 
@@ -286,12 +286,12 @@ void update_dungeon_feeling(PlayerType *player_ptr)
         return;
     }
 
-    int delay = std::max(10, 150 - player_ptr->skill_fos) * (150 - floor_ptr->dun_level) * TURNS_PER_TICK / 100;
+    int delay = std::max(10, 150 - player_ptr->skill_fos) * (150 - floor.dun_level) * TURNS_PER_TICK / 100;
     if (w_ptr->game_turn < player_ptr->feeling_turn + delay && !cheat_xtra) {
         return;
     }
 
-    auto quest_num = quest_number(player_ptr, floor_ptr->dun_level);
+    auto quest_num = quest_number(floor, floor.dun_level);
     const auto &quest_list = QuestList::get_instance();
 
     auto dungeon_quest = (quest_num == QuestId::OBERON);
@@ -324,11 +324,11 @@ void update_dungeon_feeling(PlayerType *player_ptr)
  */
 void glow_deep_lava_and_bldg(PlayerType *player_ptr)
 {
-    if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    auto *floor_ptr = player_ptr->current_floor_ptr;
+    if (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
         return;
     }
 
-    auto *floor_ptr = player_ptr->current_floor_ptr;
     for (POSITION y = 0; y < floor_ptr->height; y++) {
         for (POSITION x = 0; x < floor_ptr->width; x++) {
             grid_type *g_ptr;

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -494,7 +494,6 @@ static bool floor_is_connected(const FloorType *const floor_ptr, const IsWallFun
 void generate_floor(PlayerType *player_ptr)
 {
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    floor_ptr->dungeon_idx = player_ptr->dungeon_idx;
     set_floor_and_wall(floor_ptr->dungeon_idx);
     for (int num = 0; true; num++) {
         bool okay = true;

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -129,7 +129,7 @@ bool make_object(PlayerType *player_ptr, ItemEntity *j_ptr, BIT_FLAGS mode, std:
             get_obj_index_prep();
         }
 
-        auto bi_id = get_obj_index(player_ptr, base, mode);
+        auto bi_id = get_obj_index(floor_ptr, base, mode);
         if (get_obj_index_hook) {
             get_obj_index_hook = nullptr;
             get_obj_index_prep();

--- a/src/floor/floor-streams.cpp
+++ b/src/floor/floor-streams.cpp
@@ -470,7 +470,7 @@ void place_trees(PlayerType *player_ptr, POSITION x, POSITION y)
                 g_ptr->mimic = 0;
 
                 /* Light area since is open above */
-                if (dungeons_info[player_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::DARKNESS)) {
+                if (dungeons_info[floor_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::DARKNESS)) {
                     floor_ptr->grid_array[j][i].info |= (CAVE_GLOW | CAVE_ROOM);
                 }
             }

--- a/src/floor/floor-util.cpp
+++ b/src/floor/floor-util.cpp
@@ -210,6 +210,6 @@ std::string map_name(PlayerType *player_ptr)
     } else if (!floor_ptr->dun_level && player_ptr->town_num) {
         return towns_info[player_ptr->town_num].name;
     } else {
-        return dungeons_info[player_ptr->dungeon_idx].name;
+        return dungeons_info[floor_ptr->dungeon_idx].name;
     }
 }

--- a/src/floor/object-allocator.cpp
+++ b/src/floor/object-allocator.cpp
@@ -82,30 +82,30 @@ bool alloc_stairs(PlayerType *player_ptr, FEAT_IDX feat, int num, int walls)
 {
     int shaft_num = 0;
     auto *f_ptr = &terrains_info[feat];
-    auto *floor_ptr = player_ptr->current_floor_ptr;
+    auto &floor = *player_ptr->current_floor_ptr;
     if (f_ptr->flags.has(TerrainCharacteristics::LESS)) {
-        if (ironman_downward || !floor_ptr->dun_level) {
+        if (ironman_downward || !floor.dun_level) {
             return true;
         }
 
-        if (floor_ptr->dun_level > dungeons_info[floor_ptr->dungeon_idx].mindepth) {
+        if (floor.dun_level > dungeons_info[floor.dungeon_idx].mindepth) {
             shaft_num = (randint1(num + 1)) / 2;
         }
     } else if (f_ptr->flags.has(TerrainCharacteristics::MORE)) {
-        auto q_idx = quest_number(player_ptr, floor_ptr->dun_level);
+        auto q_idx = quest_number(floor, floor.dun_level);
         const auto &quest_list = QuestList::get_instance();
-        if (floor_ptr->dun_level > 1 && inside_quest(q_idx)) {
+        if (floor.dun_level > 1 && inside_quest(q_idx)) {
             auto *r_ptr = &monraces_info[quest_list[q_idx].r_idx];
             if (r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE) || 0 < r_ptr->max_num) {
                 return true;
             }
         }
 
-        if (floor_ptr->dun_level >= dungeons_info[floor_ptr->dungeon_idx].maxdepth) {
+        if (floor.dun_level >= dungeons_info[floor.dungeon_idx].maxdepth) {
             return true;
         }
 
-        if ((floor_ptr->dun_level < dungeons_info[floor_ptr->dungeon_idx].maxdepth - 1) && !inside_quest(quest_number(player_ptr, floor_ptr->dun_level + 1))) {
+        if ((floor.dun_level < dungeons_info[floor.dungeon_idx].maxdepth - 1) && !inside_quest(quest_number(floor, floor.dun_level + 1))) {
             shaft_num = (randint1(num) + 1) / 2;
         }
     } else {
@@ -116,8 +116,8 @@ bool alloc_stairs(PlayerType *player_ptr, FEAT_IDX feat, int num, int walls)
         while (true) {
             grid_type *g_ptr;
             int candidates = 0;
-            const POSITION max_x = floor_ptr->width - 1;
-            for (POSITION y = 1; y < floor_ptr->height - 1; y++) {
+            const POSITION max_x = floor.width - 1;
+            for (POSITION y = 1; y < floor.height - 1; y++) {
                 for (POSITION x = 1; x < max_x; x++) {
                     if (alloc_stairs_aux(player_ptr, y, x, walls)) {
                         candidates++;
@@ -137,8 +137,8 @@ bool alloc_stairs(PlayerType *player_ptr, FEAT_IDX feat, int num, int walls)
             int pick = randint1(candidates);
             POSITION y;
             POSITION x = max_x;
-            for (y = 1; y < floor_ptr->height - 1; y++) {
-                for (x = 1; x < floor_ptr->width - 1; x++) {
+            for (y = 1; y < floor.height - 1; y++) {
+                for (x = 1; x < floor.width - 1; x++) {
                     if (alloc_stairs_aux(player_ptr, y, x, walls)) {
                         pick--;
                         if (pick == 0) {
@@ -152,9 +152,9 @@ bool alloc_stairs(PlayerType *player_ptr, FEAT_IDX feat, int num, int walls)
                 }
             }
 
-            g_ptr = &floor_ptr->grid_array[y][x];
+            g_ptr = &floor.grid_array[y][x];
             g_ptr->mimic = 0;
-            g_ptr->feat = (i < shaft_num) ? feat_state(player_ptr->current_floor_ptr, feat, TerrainCharacteristics::SHAFT) : feat;
+            g_ptr->feat = (i < shaft_num) ? feat_state(&floor, feat, TerrainCharacteristics::SHAFT) : feat;
             g_ptr->info &= ~(CAVE_FLOOR);
             break;
         }

--- a/src/floor/pattern-walk.cpp
+++ b/src/floor/pattern-walk.cpp
@@ -52,15 +52,17 @@ void pattern_teleport(PlayerType *player_ptr)
             min_level = player_ptr->current_floor_ptr->dun_level;
         }
 
-        if (player_ptr->dungeon_idx == DUNGEON_ANGBAND) {
-            if (player_ptr->current_floor_ptr->dun_level > 100) {
+        const auto &floor = *player_ptr->current_floor_ptr;
+        if (floor.dungeon_idx == DUNGEON_ANGBAND) {
+            if (floor.dun_level > 100) {
                 max_level = MAX_DEPTH - 1;
             } else if (player_ptr->current_floor_ptr->dun_level == 100) {
                 max_level = 100;
             }
         } else {
-            max_level = dungeons_info[player_ptr->dungeon_idx].maxdepth;
-            min_level = dungeons_info[player_ptr->dungeon_idx].mindepth;
+            const auto &dungeon = dungeons_info[floor.dungeon_idx];
+            max_level = dungeon.maxdepth;
+            min_level = dungeon.mindepth;
         }
 
         strnfmt(ppp, sizeof(ppp), _("テレポート先:(%d-%d)", "Teleport to level (%d-%d): "), (int)min_level, (int)max_level);

--- a/src/grid/door.cpp
+++ b/src/grid/door.cpp
@@ -106,7 +106,7 @@ void place_locked_door(PlayerType *player_ptr, POSITION y, POSITION x)
         return;
     }
 
-    set_cave_feat(floor_ptr, y, x, feat_locked_door_random(dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::GLASS_DOOR) ? DOOR_GLASS_DOOR : DOOR_DOOR));
+    set_cave_feat(floor_ptr, y, x, feat_locked_door_random(dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::GLASS_DOOR) ? DOOR_GLASS_DOOR : DOOR_DOOR));
     floor_ptr->grid_array[y][x].info &= ~(CAVE_FLOOR);
     delete_monster(player_ptr, y, x);
 }

--- a/src/grid/feature-generator.cpp
+++ b/src/grid/feature-generator.cpp
@@ -62,9 +62,9 @@ static bool decide_cavern(const FloorType &floor_ref, const dungeon_type &dungeo
  */
 void gen_caverns_and_lakes(PlayerType *player_ptr, dungeon_type *dungeon_ptr, dun_data_type *dd_ptr)
 {
-    auto *floor_ptr = player_ptr->current_floor_ptr;
+    const auto &floor = *player_ptr->current_floor_ptr;
     constexpr auto chance_destroyed = 18;
-    if ((floor_ptr->dun_level > 30) && one_in_(chance_destroyed * 2) && small_levels && dungeon_ptr->flags.has(DungeonFeatureType::DESTROY)) {
+    if ((floor.dun_level > 30) && one_in_(chance_destroyed * 2) && small_levels && dungeon_ptr->flags.has(DungeonFeatureType::DESTROY)) {
         dd_ptr->destroyed = true;
         build_lake(player_ptr, one_in_(2) ? LAKE_T_CAVE : LAKE_T_EARTH_VAULT);
     }
@@ -73,12 +73,12 @@ void gen_caverns_and_lakes(PlayerType *player_ptr, dungeon_type *dungeon_ptr, du
     if (one_in_(chance_water) && !dd_ptr->empty_level && !dd_ptr->destroyed && dungeon_ptr->flags.has_any_of(DF_LAKE_MASK)) {
         auto count = calc_cavern_terrains(*dungeon_ptr);
         if (dungeon_ptr->flags.has(DungeonFeatureType::LAKE_LAVA)) {
-            if ((floor_ptr->dun_level > 80) && (randint0(count) < 2)) {
+            if ((floor.dun_level > 80) && (randint0(count) < 2)) {
                 dd_ptr->laketype = LAKE_T_LAVA;
             }
 
             count -= 2;
-            if (!dd_ptr->laketype && (floor_ptr->dun_level > 80) && one_in_(count)) {
+            if (!dd_ptr->laketype && (floor.dun_level > 80) && one_in_(count)) {
                 dd_ptr->laketype = LAKE_T_FIRE_VAULT;
             }
 
@@ -86,12 +86,12 @@ void gen_caverns_and_lakes(PlayerType *player_ptr, dungeon_type *dungeon_ptr, du
         }
 
         if (dungeon_ptr->flags.has(DungeonFeatureType::LAKE_WATER) && !dd_ptr->laketype) {
-            if ((floor_ptr->dun_level > 50) && randint0(count) < 2) {
+            if ((floor.dun_level > 50) && randint0(count) < 2) {
                 dd_ptr->laketype = LAKE_T_WATER;
             }
 
             count -= 2;
-            if (!dd_ptr->laketype && (floor_ptr->dun_level > 50) && one_in_(count)) {
+            if (!dd_ptr->laketype && (floor.dun_level > 50) && one_in_(count)) {
                 dd_ptr->laketype = LAKE_T_WATER_VAULT;
             }
 
@@ -99,19 +99,19 @@ void gen_caverns_and_lakes(PlayerType *player_ptr, dungeon_type *dungeon_ptr, du
         }
 
         if (dungeon_ptr->flags.has(DungeonFeatureType::LAKE_RUBBLE) && !dd_ptr->laketype) {
-            if ((floor_ptr->dun_level > 35) && (randint0(count) < 2)) {
+            if ((floor.dun_level > 35) && (randint0(count) < 2)) {
                 dd_ptr->laketype = LAKE_T_CAVE;
             }
 
             count -= 2;
-            if (!dd_ptr->laketype && (floor_ptr->dun_level > 35) && one_in_(count)) {
+            if (!dd_ptr->laketype && (floor.dun_level > 35) && one_in_(count)) {
                 dd_ptr->laketype = LAKE_T_EARTH_VAULT;
             }
 
             count--;
         }
 
-        if ((floor_ptr->dun_level > 5) && dungeon_ptr->flags.has(DungeonFeatureType::LAKE_TREE) && !dd_ptr->laketype) {
+        if ((floor.dun_level > 5) && dungeon_ptr->flags.has(DungeonFeatureType::LAKE_TREE) && !dd_ptr->laketype) {
             dd_ptr->laketype = LAKE_T_AIR_VAULT;
         }
 
@@ -121,14 +121,14 @@ void gen_caverns_and_lakes(PlayerType *player_ptr, dungeon_type *dungeon_ptr, du
         }
     }
 
-    const auto should_build_cavern = decide_cavern(*floor_ptr, *dungeon_ptr, *dd_ptr);
+    const auto should_build_cavern = decide_cavern(floor, *dungeon_ptr, *dd_ptr);
     if (should_build_cavern) {
         dd_ptr->cavern = true;
         msg_print_wizard(player_ptr, CHEAT_DUNGEON, _("洞窟を生成。", "Cavern on level."));
         build_cavern(player_ptr);
     }
 
-    if (inside_quest(quest_number(player_ptr, floor_ptr->dun_level))) {
+    if (inside_quest(quest_number(floor, floor.dun_level))) {
         dd_ptr->destroyed = false;
     }
 }
@@ -201,7 +201,7 @@ void try_door(PlayerType *player_ptr, dt_type *dt_ptr, POSITION y, POSITION x)
 
     bool can_place_door = randint0(100) < dt_ptr->dun_tun_jct;
     can_place_door &= possible_doorway(floor_ptr, y, x);
-    can_place_door &= dungeons_info[player_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::NO_DOORS);
+    can_place_door &= dungeons_info[floor_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::NO_DOORS);
     if (can_place_door) {
         place_random_door(player_ptr, y, x, false);
     }

--- a/src/grid/feature.cpp
+++ b/src/grid/feature.cpp
@@ -258,7 +258,7 @@ void cave_set_feat(PlayerType *player_ptr, POSITION y, POSITION x, FEAT_IDX feat
         RedrawingFlagsUpdater::get_instance().set_flags(flags);
     }
 
-    if (f_ptr->flags.has_not(TerrainCharacteristics::GLOW) || dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    if (f_ptr->flags.has_not(TerrainCharacteristics::GLOW) || dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
         return;
     }
 

--- a/src/grid/stair.cpp
+++ b/src/grid/stair.cpp
@@ -21,14 +21,13 @@ void place_random_stairs(PlayerType *player_ptr, POSITION y, POSITION x)
 {
     bool up_stairs = true;
     bool down_stairs = true;
-    grid_type *g_ptr;
-    auto *floor_ptr = player_ptr->current_floor_ptr;
-    g_ptr = &floor_ptr->grid_array[y][x];
+    auto &floor = *player_ptr->current_floor_ptr;
+    const auto *g_ptr = &floor.grid_array[y][x];
     if (!g_ptr->is_floor() || !g_ptr->o_idx_list.empty()) {
         return;
     }
 
-    if (!floor_ptr->dun_level) {
+    if (!floor.dun_level) {
         up_stairs = false;
     }
 
@@ -36,11 +35,11 @@ void place_random_stairs(PlayerType *player_ptr, POSITION y, POSITION x)
         up_stairs = false;
     }
 
-    if (floor_ptr->dun_level >= dungeons_info[player_ptr->dungeon_idx].maxdepth) {
+    if (floor.dun_level >= dungeons_info[floor.dungeon_idx].maxdepth) {
         down_stairs = false;
     }
 
-    if (inside_quest(quest_number(player_ptr, floor_ptr->dun_level)) && (floor_ptr->dun_level > 1)) {
+    if (inside_quest(quest_number(floor, floor.dun_level)) && (floor.dun_level > 1)) {
         down_stairs = false;
     }
 
@@ -53,9 +52,9 @@ void place_random_stairs(PlayerType *player_ptr, POSITION y, POSITION x)
     }
 
     if (up_stairs) {
-        set_cave_feat(floor_ptr, y, x, feat_up_stair);
+        set_cave_feat(&floor, y, x, feat_up_stair);
     } else if (down_stairs) {
-        set_cave_feat(floor_ptr, y, x, feat_down_stair);
+        set_cave_feat(&floor, y, x, feat_down_stair);
     }
 }
 

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -161,13 +161,14 @@ void init_normal_traps(void)
  * That is, it does not make sense to have spiked pits at 50 feet.\n
  * Actually, it is not this routine, but the "trap instantiation"\n
  * code, which should also check for "trap doors" on quest levels.\n
+ * @todo 引数はFloorType に差し替え可能
  */
 FEAT_IDX choose_random_trap(PlayerType *player_ptr)
 {
     FEAT_IDX feat;
 
     /* Pick a trap */
-    auto *floor_ptr = player_ptr->current_floor_ptr;
+    const auto &floor = *player_ptr->current_floor_ptr;
     while (true) {
         feat = rand_choice(normal_traps);
 
@@ -177,12 +178,12 @@ FEAT_IDX choose_random_trap(PlayerType *player_ptr)
         }
 
         /* Hack -- no trap doors on special levels */
-        if (floor_ptr->inside_arena || inside_quest(quest_number(player_ptr, floor_ptr->dun_level))) {
+        if (floor.inside_arena || inside_quest(quest_number(floor, floor.dun_level))) {
             continue;
         }
 
         /* Hack -- no trap doors on the deepest level */
-        if (floor_ptr->dun_level >= dungeons_info[floor_ptr->dungeon_idx].maxdepth) {
+        if (floor.dun_level >= dungeons_info[floor.dungeon_idx].maxdepth) {
             continue;
         }
 

--- a/src/io/input-key-processor.cpp
+++ b/src/io/input-key-processor.cpp
@@ -404,7 +404,7 @@ void process_command(PlayerType *player_ptr)
             break;
         }
 
-        const auto &dungeon = dungeons_info[player_ptr->dungeon_idx];
+        const auto &dungeon = dungeons_info[floor_ptr->dungeon_idx];
         auto non_magic_class = pc.equals(PlayerClassType::BERSERKER);
         non_magic_class |= pc.equals(PlayerClassType::SMITH);
         if (floor_ptr->dun_level && dungeon.flags.has(DungeonFeatureType::NO_MAGIC) && !non_magic_class) {

--- a/src/load/dungeon-loader.cpp
+++ b/src/load/dungeon-loader.cpp
@@ -29,18 +29,19 @@ static errr rd_dungeon(PlayerType *player_ptr)
 {
     init_saved_floors(player_ptr, false);
     errr err = 0;
+    auto &floor = *player_ptr->current_floor_ptr;
     if (h_older_than(1, 5, 0, 0)) {
         err = rd_dungeon_old(player_ptr);
-        if (player_ptr->dungeon_idx) {
+        if (floor.dungeon_idx) {
             player_ptr->floor_id = get_new_floor_id(player_ptr);
-            get_sf_ptr(player_ptr->floor_id)->dun_level = player_ptr->current_floor_ptr->dun_level;
+            get_sf_ptr(player_ptr->floor_id)->dun_level = floor.dun_level;
         }
 
         return err;
     }
 
     max_floor_id = rd_s16b();
-    player_ptr->dungeon_idx = rd_byte(); // @todo セーブデータの方を16ビットにするかdungeon_idxの定義を8ビットにした方が良い.
+    floor.dungeon_idx = rd_byte(); // @todo セーブデータの方を16ビットにするかdungeon_idxの定義を8ビットにした方が良い.
     auto num = rd_byte();
     if (num == 0) {
         err = rd_saved_floor(player_ptr, nullptr);

--- a/src/load/old/load-v1-5-0.cpp
+++ b/src/load/old/load-v1-5-0.cpp
@@ -557,9 +557,9 @@ errr rd_dungeon_old(PlayerType *player_ptr)
     auto *floor_ptr = player_ptr->current_floor_ptr;
     floor_ptr->dun_level = rd_s16b();
     if (h_older_than(0, 3, 8)) {
-        player_ptr->dungeon_idx = DUNGEON_ANGBAND;
+        floor_ptr->dungeon_idx = DUNGEON_ANGBAND;
     } else {
-        player_ptr->dungeon_idx = rd_byte();
+        floor_ptr->dungeon_idx = rd_byte();
     }
 
     floor_ptr->base_level = floor_ptr->dun_level;

--- a/src/load/old/load-v1-7-0.cpp
+++ b/src/load/old/load-v1-7-0.cpp
@@ -29,11 +29,12 @@ void set_exp_frac_old(PlayerType *player_ptr)
 
 void remove_water_cave(PlayerType *player_ptr)
 {
-    if (player_ptr->current_floor_ptr->quest_number != i2enum<QuestId>(OLD_QUEST_WATER_CAVE)) {
+    auto &floor = *player_ptr->current_floor_ptr;
+    if (floor.quest_number != i2enum<QuestId>(OLD_QUEST_WATER_CAVE)) {
         return;
     }
 
-    player_ptr->dungeon_idx = lite_town ? DUNGEON_ANGBAND : DUNGEON_GALGALS;
-    player_ptr->current_floor_ptr->dun_level = 1;
-    player_ptr->current_floor_ptr->quest_number = QuestId::NONE;
+    floor.dungeon_idx = lite_town ? DUNGEON_ANGBAND : DUNGEON_GALGALS;
+    floor.dun_level = 1;
+    floor.quest_number = QuestId::NONE;
 }

--- a/src/main/scene-table-floor.cpp
+++ b/src/main/scene-table-floor.cpp
@@ -43,7 +43,8 @@ static bool scene_basic(PlayerType *player_ptr, scene_type *value)
 
 static bool scene_quest(PlayerType *player_ptr, scene_type *value)
 {
-    const QuestId quest_id = quest_number(player_ptr, player_ptr->current_floor_ptr->dun_level);
+    const auto &floor = *player_ptr->current_floor_ptr;
+    const QuestId quest_id = quest_number(floor, floor.dun_level);
     const bool enable = (inside_quest(quest_id));
     if (enable) {
         value->type = TERM_XTRA_MUSIC_QUEST;
@@ -55,7 +56,8 @@ static bool scene_quest(PlayerType *player_ptr, scene_type *value)
 
 static bool scene_quest_basic(PlayerType *player_ptr, scene_type *value)
 {
-    const QuestId quest_id = quest_number(player_ptr, player_ptr->current_floor_ptr->dun_level);
+    const auto &floor = *player_ptr->current_floor_ptr;
+    const QuestId quest_id = quest_number(floor, floor.dun_level);
     const bool enable = (inside_quest(quest_id));
     if (enable) {
         value->type = TERM_XTRA_MUSIC_BASIC;
@@ -119,10 +121,11 @@ static bool scene_dungeon_feeling(PlayerType *player_ptr, scene_type *value)
 
 static bool scene_dungeon(PlayerType *player_ptr, scene_type *value)
 {
-    const bool enable = (player_ptr->dungeon_idx > 0);
+    const auto *floor_ptr = player_ptr->current_floor_ptr;
+    const bool enable = (floor_ptr->dungeon_idx > 0);
     if (enable) {
         value->type = TERM_XTRA_MUSIC_DUNGEON;
-        value->val = player_ptr->dungeon_idx;
+        value->val = floor_ptr->dungeon_idx;
     }
     return enable;
 }

--- a/src/melee/melee-spell-flags-checker.cpp
+++ b/src/melee/melee-spell-flags-checker.cpp
@@ -117,13 +117,15 @@ static void check_darkness(PlayerType *player_ptr, melee_spell_type *ms_ptr)
         return;
     }
 
-    bool vs_ninja = PlayerClass(player_ptr).equals(PlayerClassType::NINJA) && !ms_ptr->t_ptr->is_hostile();
-    bool can_use_lite_area = vs_ninja && ms_ptr->r_ptr->kind_flags.has_not(MonsterKindType::UNDEAD) && ms_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::HURT_LITE) && ms_ptr->r_ptr->brightness_flags.has_none_of(dark_mask);
+    const auto vs_ninja = PlayerClass(player_ptr).equals(PlayerClassType::NINJA) && !ms_ptr->t_ptr->is_hostile();
+    auto can_use_lite_area = vs_ninja && ms_ptr->r_ptr->kind_flags.has_not(MonsterKindType::UNDEAD);
+    can_use_lite_area &= ms_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::HURT_LITE);
+    can_use_lite_area &= ms_ptr->r_ptr->brightness_flags.has_none_of(dark_mask);
     if (ms_ptr->r_ptr->behavior_flags.has(MonsterBehaviorType::STUPID)) {
         return;
     }
 
-    if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    if (dungeons_info[player_ptr->current_floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
         ms_ptr->ability_flags.reset(MonsterAbilityType::DARKNESS);
         return;
     }

--- a/src/melee/melee-spell-util.cpp
+++ b/src/melee/melee-spell-util.cpp
@@ -26,7 +26,7 @@ melee_spell_type *initialize_melee_spell_type(PlayerType *player_ptr, melee_spel
     ms_ptr->see_m = is_seen(player_ptr, ms_ptr->m_ptr);
     ms_ptr->maneable = player_has_los_bold(player_ptr, ms_ptr->m_ptr->fy, ms_ptr->m_ptr->fx);
     ms_ptr->pet = ms_ptr->m_ptr->is_pet();
-    const auto &dungeon = dungeons_info[player_ptr->dungeon_idx];
+    const auto &dungeon = dungeons_info[floor_ptr->dungeon_idx];
     const auto is_in_dungeon = floor_ptr->is_in_dungeon();
     const auto is_in_random_quest = inside_quest(floor_ptr->quest_number) && !QuestType::is_fixed(floor_ptr->quest_number);
     ms_ptr->in_no_magic_dungeon = dungeon.flags.has(DungeonFeatureType::NO_MAGIC) && is_in_dungeon && !is_in_random_quest;

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -175,7 +175,7 @@ static bool check_same_monster(PlayerType *player_ptr, mam_type *mam_ptr)
         return false;
     }
 
-    if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE)) {
+    if (dungeons_info[player_ptr->current_floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE)) {
         return false;
     }
 

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -131,7 +131,7 @@ bool MonsterAttackPlayer::check_no_blow()
         return false;
     }
 
-    if (dungeons_info[this->player_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE)) {
+    if (dungeons_info[this->player_ptr->current_floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE)) {
         return false;
     }
 

--- a/src/monster-attack/monster-attack-processor.cpp
+++ b/src/monster-attack/monster-attack-processor.cpp
@@ -36,7 +36,8 @@
  */
 void exe_monster_attack_to_player(PlayerType *player_ptr, turn_flags *turn_flags_ptr, MONSTER_IDX m_idx, POSITION ny, POSITION nx)
 {
-    auto *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
+    auto &floor = *player_ptr->current_floor_ptr;
+    auto *m_ptr = &floor.m_list[m_idx];
     auto *r_ptr = &monraces_info[m_ptr->r_idx];
     if (!turn_flags_ptr->do_move || !player_bold(player_ptr, ny, nx)) {
         return;
@@ -50,7 +51,7 @@ void exe_monster_attack_to_player(PlayerType *player_ptr, turn_flags *turn_flags
         turn_flags_ptr->do_move = false;
     }
 
-    if (turn_flags_ptr->do_move && dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE) && !m_ptr->is_confused()) {
+    if (turn_flags_ptr->do_move && dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE) && !m_ptr->is_confused()) {
         if (r_ptr->behavior_flags.has_not(MonsterBehaviorType::STUPID)) {
             turn_flags_ptr->do_move = false;
         } else if (is_original_ap_and_seen(player_ptr, m_ptr)) {
@@ -77,7 +78,8 @@ void exe_monster_attack_to_player(PlayerType *player_ptr, turn_flags *turn_flags
  */
 static bool exe_monster_attack_to_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, grid_type *g_ptr)
 {
-    auto *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
+    auto &floor = *player_ptr->current_floor_ptr;
+    auto *m_ptr = &floor.m_list[m_idx];
     auto *r_ptr = &monraces_info[m_ptr->r_idx];
     MonsterEntity *y_ptr;
     y_ptr = &player_ptr->current_floor_ptr->m_list[g_ptr->m_idx];
@@ -95,7 +97,7 @@ static bool exe_monster_attack_to_monster(PlayerType *player_ptr, MONSTER_IDX m_
     if (monst_attack_monst(player_ptr, m_idx, g_ptr->m_idx)) {
         return true;
     }
-    if (dungeons_info[player_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::NO_MELEE)) {
+    if (dungeons_info[floor.dungeon_idx].flags.has_not(DungeonFeatureType::NO_MELEE)) {
         return false;
     }
     if (m_ptr->is_confused()) {

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -190,7 +190,7 @@ bool drop_single_artifact(PlayerType *player_ptr, monster_death_type *md_ptr, Fi
 
 static short drop_dungeon_final_artifact(PlayerType *player_ptr, monster_death_type *md_ptr)
 {
-    const auto &dungeon = dungeons_info[player_ptr->dungeon_idx];
+    const auto &dungeon = dungeons_info[player_ptr->current_floor_ptr->dungeon_idx];
     const auto has_reward = dungeon.final_object > 0;
     const auto bi_id = has_reward ? dungeon.final_object : lookup_baseitem_id({ ItemKindType::SCROLL, SV_SCROLL_ACQUIREMENT });
     if (dungeon.final_artifact == FixedArtifactId::NONE) {
@@ -215,7 +215,9 @@ static void drop_artifacts(PlayerType *player_ptr, monster_death_type *md_ptr)
     }
 
     drop_artifact_from_unique(player_ptr, md_ptr);
-    if (((md_ptr->r_ptr->flags7 & RF7_GUARDIAN) == 0) || (dungeons_info[player_ptr->dungeon_idx].final_guardian != md_ptr->m_ptr->r_idx)) {
+    const auto *floor_ptr = player_ptr->current_floor_ptr;
+    const auto &dungeon = dungeons_info[floor_ptr->dungeon_idx];
+    if (((md_ptr->r_ptr->flags7 & RF7_GUARDIAN) == 0) || (dungeon.final_guardian != md_ptr->m_ptr->r_idx)) {
         return;
     }
 
@@ -224,11 +226,11 @@ static void drop_artifacts(PlayerType *player_ptr, monster_death_type *md_ptr)
         ItemEntity forge;
         auto *q_ptr = &forge;
         q_ptr->prep(bi_id);
-        ItemMagicApplier(player_ptr, q_ptr, player_ptr->current_floor_ptr->object_level, AM_NO_FIXED_ART | AM_GOOD).execute();
+        ItemMagicApplier(player_ptr, q_ptr, floor_ptr->object_level, AM_NO_FIXED_ART | AM_GOOD).execute();
         (void)drop_near(player_ptr, q_ptr, -1, md_ptr->md_y, md_ptr->md_x);
     }
 
-    msg_format(_("あなたは%sを制覇した！", "You have conquered %s!"), dungeons_info[player_ptr->dungeon_idx].name.data());
+    msg_format(_("あなたは%sを制覇した！", "You have conquered %s!"), dungeon.name.data());
 }
 
 static void decide_drop_quality(monster_death_type *md_ptr)

--- a/src/monster-floor/monster-generator.cpp
+++ b/src/monster-floor/monster-generator.cpp
@@ -472,10 +472,10 @@ bool alloc_horde(PlayerType *player_ptr, POSITION y, POSITION x, summon_specific
  */
 bool alloc_guardian(PlayerType *player_ptr, bool def_val)
 {
-    MonsterRaceId guardian = dungeons_info[player_ptr->dungeon_idx].final_guardian;
     auto *floor_ptr = player_ptr->current_floor_ptr;
+    MonsterRaceId guardian = dungeons_info[floor_ptr->dungeon_idx].final_guardian;
     bool is_guardian_applicable = MonsterRace(guardian).is_valid();
-    is_guardian_applicable &= dungeons_info[player_ptr->dungeon_idx].maxdepth == floor_ptr->dun_level;
+    is_guardian_applicable &= dungeons_info[floor_ptr->dungeon_idx].maxdepth == floor_ptr->dun_level;
     is_guardian_applicable &= monraces_info[guardian].cur_num < monraces_info[guardian].max_num;
     if (!is_guardian_applicable) {
         return def_val;

--- a/src/monster-floor/monster-lite.cpp
+++ b/src/monster-floor/monster-lite.cpp
@@ -152,8 +152,9 @@ void update_mon_lite(PlayerType *player_ptr)
     std::vector<Pos2D> points;
 
     void (*add_mon_lite)(PlayerType *, std::vector<Pos2D> &, const POSITION, const POSITION, const monster_lite_type *);
-    int dis_lim = (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS) && !player_ptr->see_nocto) ? (MAX_PLAYER_SIGHT / 2 + 1) : (MAX_PLAYER_SIGHT + 3);
     auto *floor_ptr = player_ptr->current_floor_ptr;
+    const auto &dungeon = dungeons_info[floor_ptr->dungeon_idx];
+    auto dis_lim = (dungeon.flags.has(DungeonFeatureType::DARKNESS) && !player_ptr->see_nocto) ? (MAX_PLAYER_SIGHT / 2 + 1) : (MAX_PLAYER_SIGHT + 3);
     for (int i = 0; i < floor_ptr->mon_lite_n; i++) {
         grid_type *g_ptr;
         g_ptr = &floor_ptr->grid_array[floor_ptr->mon_lite_y[i]][floor_ptr->mon_lite_x[i]];
@@ -198,7 +199,7 @@ void update_mon_lite(PlayerType *player_ptr)
                     continue;
                 }
 
-                if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+                if (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
                     rad = 1;
                 }
 

--- a/src/monster-floor/monster-summon.cpp
+++ b/src/monster-floor/monster-summon.cpp
@@ -48,8 +48,9 @@ static bool summon_specific_okay(PlayerType *player_ptr, MonsterRaceId r_idx)
         return false;
     }
 
+    auto &floor = *player_ptr->current_floor_ptr;
     if (summon_specific_who > 0) {
-        auto *m_ptr = &player_ptr->current_floor_ptr->m_list[summon_specific_who];
+        auto *m_ptr = &floor.m_list[summon_specific_who];
         if (monster_has_hostile_align(player_ptr, m_ptr, 0, 0, r_ptr)) {
             return false;
         }
@@ -67,16 +68,17 @@ static bool summon_specific_okay(PlayerType *player_ptr, MonsterRaceId r_idx)
         return true;
     }
 
-    if ((summon_specific_who < 0) && (r_ptr->kind_flags.has(MonsterKindType::UNIQUE) || (r_ptr->population_flags.has(MonsterPopulationType::NAZGUL))) && monster_has_hostile_align(player_ptr, nullptr, 10, -10, r_ptr)) {
+    const auto is_like_unique = r_ptr->kind_flags.has(MonsterKindType::UNIQUE) || (r_ptr->population_flags.has(MonsterPopulationType::NAZGUL));
+    if ((summon_specific_who < 0) && is_like_unique && monster_has_hostile_align(player_ptr, nullptr, 10, -10, r_ptr)) {
         return false;
     }
 
-    if ((r_ptr->flags7 & RF7_CHAMELEON) && dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::CHAMELEON)) {
+    if ((r_ptr->flags7 & RF7_CHAMELEON) && dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::CHAMELEON)) {
         return true;
     }
 
     if (summon_specific_who > 0) {
-        auto *m_ptr = &player_ptr->current_floor_ptr->m_list[summon_specific_who];
+        auto *m_ptr = &floor.m_list[summon_specific_who];
         return check_summon_specific(player_ptr, m_ptr->r_idx, r_idx);
     } else {
         return check_summon_specific(player_ptr, MonsterRaceId::PLAYER, r_idx);

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -155,19 +155,18 @@ static bool check_unique_placeable(PlayerType *player_ptr, MonsterRaceId r_idx)
 
 /*!
  * @brief クエスト内に生成可能か評価する
- * @param player_ptr プレイヤーへの参照ポインタ
+ * @param floor フロアへの参照
  * @param r_idx 生成モンスター種族
  * @return 生成が可能ならTRUE、不可能ならFALSE
  */
-static bool check_quest_placeable(PlayerType *player_ptr, MonsterRaceId r_idx)
+static bool check_quest_placeable(const FloorType &floor, MonsterRaceId r_idx)
 {
-    auto *floor_ptr = player_ptr->current_floor_ptr;
-    if (!inside_quest(quest_number(player_ptr, floor_ptr->dun_level))) {
+    if (!inside_quest(quest_number(floor, floor.dun_level))) {
         return true;
     }
 
     const auto &quest_list = QuestList::get_instance();
-    QuestId number = quest_number(player_ptr, floor_ptr->dun_level);
+    QuestId number = quest_number(floor, floor.dun_level);
     const auto *q_ptr = &quest_list[number];
     if ((q_ptr->type != QuestKindType::KILL_LEVEL) && (q_ptr->type != QuestKindType::RANDOM)) {
         return true;
@@ -176,10 +175,10 @@ static bool check_quest_placeable(PlayerType *player_ptr, MonsterRaceId r_idx)
         return true;
     }
     int number_mon = 0;
-    for (int i2 = 0; i2 < floor_ptr->width; ++i2) {
-        for (int j2 = 0; j2 < floor_ptr->height; j2++) {
-            auto quest_monster = (floor_ptr->grid_array[j2][i2].m_idx > 0);
-            quest_monster &= (floor_ptr->m_list[floor_ptr->grid_array[j2][i2].m_idx].r_idx == q_ptr->r_idx);
+    for (int i2 = 0; i2 < floor.width; ++i2) {
+        for (int j2 = 0; j2 < floor.height; j2++) {
+            auto quest_monster = (floor.grid_array[j2][i2].m_idx > 0);
+            quest_monster &= (floor.m_list[floor.grid_array[j2][i2].m_idx].r_idx == q_ptr->r_idx);
             if (quest_monster) {
                 number_mon++;
             }
@@ -270,20 +269,20 @@ static void warn_unique_generation(PlayerType *player_ptr, MonsterRaceId r_idx)
  */
 bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode)
 {
-    auto *floor_ptr = player_ptr->current_floor_ptr;
-    auto *g_ptr = &floor_ptr->grid_array[y][x];
+    auto &floor = *player_ptr->current_floor_ptr;
+    auto *g_ptr = &floor.grid_array[y][x];
     auto *r_ptr = &monraces_info[r_idx];
     concptr name = r_ptr->name.data();
 
-    if (player_ptr->wild_mode || !in_bounds(floor_ptr, y, x) || !MonsterRace(r_idx).is_valid() || r_ptr->name.empty()) {
+    if (player_ptr->wild_mode || !in_bounds(&floor, y, x) || !MonsterRace(r_idx).is_valid() || r_ptr->name.empty()) {
         return false;
     }
 
-    if (none_bits(mode, PM_IGNORE_TERRAIN) && (pattern_tile(floor_ptr, y, x) || !monster_can_enter(player_ptr, y, x, r_ptr, 0))) {
+    if (none_bits(mode, PM_IGNORE_TERRAIN) && (pattern_tile(&floor, y, x) || !monster_can_enter(player_ptr, y, x, r_ptr, 0))) {
         return false;
     }
 
-    if (!check_unique_placeable(player_ptr, r_idx) || !check_quest_placeable(player_ptr, r_idx) || !check_procection_rune(player_ptr, r_idx, y, x)) {
+    if (!check_unique_placeable(player_ptr, r_idx) || !check_quest_placeable(floor, r_idx) || !check_procection_rune(player_ptr, r_idx, y, x)) {
         return false;
     }
 
@@ -292,28 +291,28 @@ bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSI
         reset_bits(mode, PM_KAGE);
     }
 
-    g_ptr->m_idx = m_pop(floor_ptr);
+    g_ptr->m_idx = m_pop(&floor);
     hack_m_idx_ii = g_ptr->m_idx;
     if (!g_ptr->m_idx) {
         return false;
     }
 
     MonsterEntity *m_ptr;
-    m_ptr = &floor_ptr->m_list[g_ptr->m_idx];
+    m_ptr = &floor.m_list[g_ptr->m_idx];
     m_ptr->r_idx = r_idx;
     m_ptr->ap_r_idx = initial_r_appearance(player_ptr, r_idx, mode);
 
     m_ptr->mflag.clear();
     m_ptr->mflag2.clear();
-    if (any_bits(mode, PM_MULTIPLY) && (who > 0) && !floor_ptr->m_list[who].is_original_ap()) {
-        m_ptr->ap_r_idx = floor_ptr->m_list[who].ap_r_idx;
-        if (floor_ptr->m_list[who].mflag2.has(MonsterConstantFlagType::KAGE)) {
+    if (any_bits(mode, PM_MULTIPLY) && (who > 0) && !floor.m_list[who].is_original_ap()) {
+        m_ptr->ap_r_idx = floor.m_list[who].ap_r_idx;
+        if (floor.m_list[who].mflag2.has(MonsterConstantFlagType::KAGE)) {
             m_ptr->mflag2.set(MonsterConstantFlagType::KAGE);
         }
     }
 
     if ((who > 0) && r_ptr->kind_flags.has_none_of(alignment_mask)) {
-        m_ptr->sub_align = floor_ptr->m_list[who].sub_align;
+        m_ptr->sub_align = floor.m_list[who].sub_align;
     } else {
         m_ptr->sub_align = SUB_ALIGN_NEUTRAL;
         if (r_ptr->kind_flags.has(MonsterKindType::EVIL)) {
@@ -326,7 +325,7 @@ bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSI
 
     m_ptr->fy = y;
     m_ptr->fx = x;
-    m_ptr->current_floor_ptr = floor_ptr;
+    m_ptr->current_floor_ptr = &floor;
 
     for (int cmi = 0; cmi < MAX_MTIMED; cmi++) {
         m_ptr->mtimed[cmi] = 0;
@@ -337,7 +336,7 @@ bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSI
     m_ptr->nickname.clear();
     m_ptr->exp = 0;
 
-    if (who > 0 && floor_ptr->m_list[who].is_pet()) {
+    if (who > 0 && floor.m_list[who].is_pet()) {
         set_bits(mode, PM_FORCE_PET);
         m_ptr->parent_m_idx = who;
     } else {
@@ -399,7 +398,7 @@ bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSI
 
     m_ptr->dealt_damage = 0;
 
-    m_ptr->mspeed = get_mspeed(floor_ptr, r_ptr);
+    m_ptr->mspeed = get_mspeed(&floor, r_ptr);
 
     if (any_bits(mode, PM_HASTE)) {
         (void)set_monster_fast(player_ptr, g_ptr->m_idx, 100);
@@ -438,7 +437,7 @@ bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSI
     }
 
     if (any_bits(r_ptr->flags2, RF2_MULTIPLY)) {
-        floor_ptr->num_repro++;
+        floor.num_repro++;
     }
 
     warn_unique_generation(player_ptr, r_idx);

--- a/src/monster-race/monster-race-hook.cpp
+++ b/src/monster-race/monster-race-hook.cpp
@@ -126,13 +126,13 @@ bool mon_hook_quest(PlayerType *player_ptr, MonsterRaceId r_idx)
  */
 bool mon_hook_dungeon(PlayerType *player_ptr, MonsterRaceId r_idx)
 {
-    const auto &floor_ref = *player_ptr->current_floor_ptr;
-    if (!floor_ref.is_in_dungeon() && !inside_quest(floor_ref.quest_number)) {
+    const auto &floor = *player_ptr->current_floor_ptr;
+    if (!floor.is_in_dungeon() && !inside_quest(floor.quest_number)) {
         return true;
     }
 
     auto *r_ptr = &monraces_info[r_idx];
-    dungeon_type *d_ptr = &dungeons_info[player_ptr->dungeon_idx];
+    dungeon_type *d_ptr = &dungeons_info[floor.dungeon_idx];
     if (r_ptr->wilderness_flags.has(MonsterWildernessType::WILD_ONLY)) {
         return d_ptr->mon_wilderness_flags.has(MonsterWildernessType::WILD_MOUNTAIN) && r_ptr->wilderness_flags.has(MonsterWildernessType::WILD_MOUNTAIN);
     }

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -115,7 +115,8 @@ MonsterRaceId get_mon_num(PlayerType *player_ptr, DEPTH min_level, DEPTH max_lev
     constexpr auto max_depth_nasty_monster = 25;
     auto chance_nasty = std::max(max_num_nasty_monsters, chance_nasty_monster - over_days / 2);
     auto nasty_level = std::min(max_depth_nasty_monster, over_days / 3);
-    if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::MAZE)) {
+    const auto &floor = *player_ptr->current_floor_ptr;
+    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::MAZE)) {
         chance_nasty = std::min(chance_nasty / 2, chance_nasty - 10);
         if (chance_nasty < 2) {
             chance_nasty = 2;
@@ -126,7 +127,7 @@ MonsterRaceId get_mon_num(PlayerType *player_ptr, DEPTH min_level, DEPTH max_lev
     }
 
     /* Boost the max_level */
-    if ((option & GMN_ARENA) || dungeons_info[player_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::BEGINNER)) {
+    if ((option & GMN_ARENA) || dungeons_info[floor.dungeon_idx].flags.has_not(DungeonFeatureType::BEGINNER)) {
         /* Nightmare mode allows more out-of depth monsters */
         if (ironman_nightmare && !randint0(chance_nasty)) {
             /* What a bizarre calculation */
@@ -341,7 +342,7 @@ void choose_new_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, bool born, Mo
             level = floor_ptr->dun_level;
         }
 
-        if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::CHAMELEON)) {
+        if (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::CHAMELEON)) {
             level += 2 + randint1(3);
         }
 

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -184,13 +184,14 @@ void update_player_window(PlayerType *player_ptr, old_race_flags *old_race_flags
 
 static um_type *initialize_um_type(PlayerType *player_ptr, um_type *um_ptr, MONSTER_IDX m_idx, bool full)
 {
-    um_ptr->m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
+    auto &floor = *player_ptr->current_floor_ptr;
+    um_ptr->m_ptr = &floor.m_list[m_idx];
     um_ptr->do_disturb = disturb_move;
     um_ptr->fy = um_ptr->m_ptr->fy;
     um_ptr->fx = um_ptr->m_ptr->fx;
     um_ptr->flag = false;
     um_ptr->easy = false;
-    um_ptr->in_darkness = dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS) && !player_ptr->see_nocto;
+    um_ptr->in_darkness = dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS) && !player_ptr->see_nocto;
     um_ptr->full = full;
     return um_ptr;
 }

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -75,13 +75,13 @@ static bool is_possible_monster_or(const EnumClassFlagGroup<T> &r_flags, const E
 
 /*!
  * @brief 指定されたモンスター種族がダンジョンの制限にかかるかどうかをチェックする / Some dungeon types restrict the possible monsters.
- * @param player_ptr プレイヤーへの参照ポインタ
+ * @param floor_ptr フロアへの参照ポインタ
  * @param r_idx チェックするモンスター種族ID
  * @return 召喚条件が一致するならtrue / Return TRUE is the monster is OK and FALSE otherwise
  */
-static bool restrict_monster_to_dungeon(PlayerType *player_ptr, MonsterRaceId r_idx)
+static bool restrict_monster_to_dungeon(const FloorType *floor_ptr, MonsterRaceId r_idx)
 {
-    const auto *d_ptr = &dungeons_info[player_ptr->dungeon_idx];
+    const auto *d_ptr = &dungeons_info[floor_ptr->dungeon_idx];
     const auto *r_ptr = &monraces_info[r_idx];
     if (d_ptr->flags.has(DungeonFeatureType::CHAMELEON)) {
         if (chameleon_change_m_idx) {
@@ -105,7 +105,6 @@ static bool restrict_monster_to_dungeon(PlayerType *player_ptr, MonsterRaceId r_
         }
     }
 
-    auto *floor_ptr = player_ptr->current_floor_ptr;
     if (d_ptr->flags.has(DungeonFeatureType::BEGINNER)) {
         if (r_ptr->level > floor_ptr->dun_level) {
             return false;
@@ -306,10 +305,10 @@ static errr do_get_mon_num_prep(PlayerType *player_ptr, const monsterrace_hook_t
             const bool in_random_quest = inside_quest(floor_ptr->quest_number) && !QuestType::is_fixed(floor_ptr->quest_number);
             const bool cond = !player_ptr->phase_out && floor_ptr->dun_level > 0 && !in_random_quest;
 
-            if (cond && !restrict_monster_to_dungeon(player_ptr, entry_r_idx)) {
+            if (cond && !restrict_monster_to_dungeon(floor_ptr, entry_r_idx)) {
                 // ダンジョンによる制約に掛かった場合、重みを special_div/64 倍する。
                 // 丸めは確率的に行う。
-                const int numer = entry->prob2 * dungeons_info[player_ptr->dungeon_idx].special_div;
+                const int numer = entry->prob2 * dungeons_info[floor_ptr->dungeon_idx].special_div;
                 const int q = numer / 64;
                 const int r = numer % 64;
                 entry->prob2 = (PROB)(randint0(64) < r ? q + 1 : q);

--- a/src/mspell/mspell-attack.cpp
+++ b/src/mspell/mspell-attack.cpp
@@ -58,7 +58,7 @@ static void set_no_magic_mask(msa_type *msa_ptr)
 static void check_mspell_stupid(PlayerType *player_ptr, msa_type *msa_ptr)
 {
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    msa_ptr->in_no_magic_dungeon = dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_MAGIC) && floor_ptr->dun_level && (!inside_quest(floor_ptr->quest_number) || QuestType::is_fixed(floor_ptr->quest_number));
+    msa_ptr->in_no_magic_dungeon = dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_MAGIC) && floor_ptr->dun_level && (!inside_quest(floor_ptr->quest_number) || QuestType::is_fixed(floor_ptr->quest_number));
     if (!msa_ptr->in_no_magic_dungeon || (msa_ptr->r_ptr->behavior_flags.has(MonsterBehaviorType::STUPID))) {
         return;
     }

--- a/src/mspell/mspell-lite.cpp
+++ b/src/mspell/mspell-lite.cpp
@@ -194,13 +194,16 @@ void decide_lite_area(PlayerType *player_ptr, msa_type *msa_ptr)
     }
 
     PlayerClass pc(player_ptr);
-    bool can_use_lite_area = pc.equals(PlayerClassType::NINJA) && msa_ptr->r_ptr->kind_flags.has_not(MonsterKindType::UNDEAD) && msa_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::HURT_LITE) && (msa_ptr->r_ptr->brightness_flags.has_none_of(dark_mask));
+    auto can_use_lite_area = pc.equals(PlayerClassType::NINJA);
+    can_use_lite_area &= msa_ptr->r_ptr->kind_flags.has_not(MonsterKindType::UNDEAD);
+    can_use_lite_area &= msa_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::HURT_LITE);
+    can_use_lite_area &= (msa_ptr->r_ptr->brightness_flags.has_none_of(dark_mask));
 
     if (msa_ptr->r_ptr->behavior_flags.has(MonsterBehaviorType::STUPID)) {
         return;
     }
 
-    if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    if (dungeons_info[player_ptr->current_floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
         msa_ptr->ability_flags.reset(MonsterAbilityType::DARKNESS);
         return;
     }

--- a/src/object-enchant/item-magic-applier.cpp
+++ b/src/object-enchant/item-magic-applier.cpp
@@ -74,13 +74,15 @@ void ItemMagicApplier::execute()
 std::tuple<int, int> ItemMagicApplier::calculate_chances()
 {
     auto chance_good = this->lev + 10;
-    if (chance_good > dungeons_info[this->player_ptr->dungeon_idx].obj_good) {
-        chance_good = dungeons_info[this->player_ptr->dungeon_idx].obj_good;
+    const auto &floor = *this->player_ptr->current_floor_ptr;
+    const auto &dungeon = dungeons_info[floor.dungeon_idx];
+    if (chance_good > dungeon.obj_good) {
+        chance_good = dungeon.obj_good;
     }
 
     auto chance_great = chance_good * 2 / 3;
-    if ((this->player_ptr->ppersonality != PERSONALITY_MUNCHKIN) && (chance_great > dungeons_info[this->player_ptr->dungeon_idx].obj_great)) {
-        chance_great = dungeons_info[this->player_ptr->dungeon_idx].obj_great;
+    if ((this->player_ptr->ppersonality != PERSONALITY_MUNCHKIN) && (chance_great > dungeon.obj_great)) {
+        chance_great = dungeon.obj_great;
     }
 
     if (has_good_luck(this->player_ptr)) {

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -355,29 +355,25 @@ static int blow_damcalc(MonsterEntity *m_ptr, PlayerType *player_ptr, MonsterBlo
 bool process_warning(PlayerType *player_ptr, POSITION xx, POSITION yy)
 {
     POSITION mx, my;
-    grid_type *g_ptr;
-
 #define WARNING_AWARE_RANGE 12
     int dam_max = 0;
     static int old_damage = 0;
 
+    auto &floor = *player_ptr->current_floor_ptr;
     for (mx = xx - WARNING_AWARE_RANGE; mx < xx + WARNING_AWARE_RANGE + 1; mx++) {
         for (my = yy - WARNING_AWARE_RANGE; my < yy + WARNING_AWARE_RANGE + 1; my++) {
             int dam_max0 = 0;
-            MonsterEntity *m_ptr;
-            MonsterRaceInfo *r_ptr;
-
-            if (!in_bounds(player_ptr->current_floor_ptr, my, mx) || (distance(my, mx, yy, xx) > WARNING_AWARE_RANGE)) {
+            if (!in_bounds(&floor, my, mx) || (distance(my, mx, yy, xx) > WARNING_AWARE_RANGE)) {
                 continue;
             }
 
-            g_ptr = &player_ptr->current_floor_ptr->grid_array[my][mx];
+            const auto *g_ptr = &floor.grid_array[my][mx];
 
             if (!g_ptr->m_idx) {
                 continue;
             }
 
-            m_ptr = &player_ptr->current_floor_ptr->m_list[g_ptr->m_idx];
+            auto *m_ptr = &floor.m_list[g_ptr->m_idx];
 
             if (m_ptr->is_asleep()) {
                 continue;
@@ -386,13 +382,13 @@ bool process_warning(PlayerType *player_ptr, POSITION xx, POSITION yy)
                 continue;
             }
 
-            r_ptr = &monraces_info[m_ptr->r_idx];
+            auto *r_ptr = &monraces_info[m_ptr->r_idx];
 
             /* Monster spells (only powerful ones)*/
             if (projectable(player_ptr, my, mx, yy, xx)) {
                 const auto flags = r_ptr->ability_flags;
 
-                if (dungeons_info[player_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::NO_MAGIC)) {
+                if (dungeons_info[floor.dungeon_idx].flags.has_not(DungeonFeatureType::NO_MAGIC)) {
                     if (flags.has(MonsterAbilityType::BA_CHAO)) {
                         spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BA_CHAO, AttributeType::CHAOS, g_ptr->m_idx, &dam_max0);
                     }
@@ -496,7 +492,7 @@ bool process_warning(PlayerType *player_ptr, POSITION xx, POSITION yy)
                 }
             }
             /* Monster melee attacks */
-            if (r_ptr->behavior_flags.has(MonsterBehaviorType::NEVER_BLOW) || dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE)) {
+            if (r_ptr->behavior_flags.has(MonsterBehaviorType::NEVER_BLOW) || dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE)) {
                 dam_max += dam_max0;
                 continue;
             }
@@ -549,7 +545,7 @@ bool process_warning(PlayerType *player_ptr, POSITION xx, POSITION yy)
         old_damage = old_damage / 2;
     }
 
-    g_ptr = &player_ptr->current_floor_ptr->grid_array[yy][xx];
+    auto *g_ptr = &floor.grid_array[yy][xx];
     bool is_warning = (!easy_disarm && is_trap(player_ptr, g_ptr->feat)) || (g_ptr->mimic && is_trap(player_ptr, g_ptr->feat));
     is_warning &= !one_in_(13);
     if (!is_warning) {

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -376,8 +376,8 @@ int take_hit(PlayerType *player_ptr, int damage_type, int damage, std::string_vi
             player_ptr->is_dead = true;
         }
 
-        const auto &floor_ref = *player_ptr->current_floor_ptr;
-        if (floor_ref.inside_arena) {
+        const auto &floor = *player_ptr->current_floor_ptr;
+        if (floor.inside_arena) {
             concptr m_name = monraces_info[arena_info[player_ptr->arena_number].r_idx].name.data();
             msg_format(_("あなたは%sの前に敗れ去った。", "You are beaten by %s."), m_name);
             msg_print(nullptr);
@@ -385,7 +385,7 @@ int take_hit(PlayerType *player_ptr, int damage_type, int damage, std::string_vi
                 exe_write_diary(player_ptr, DIARY_ARENA, -1 - player_ptr->arena_number, m_name);
             }
         } else {
-            const auto q_idx = quest_number(player_ptr, floor_ref.dun_level);
+            const auto q_idx = quest_number(floor, floor.dun_level);
             const auto seppuku = hit_from == "Seppuku";
             const auto winning_seppuku = w_ptr->total_winner && seppuku;
 
@@ -422,14 +422,14 @@ int take_hit(PlayerType *player_ptr, int damage_type, int damage, std::string_vi
             } else {
                 std::string place;
 
-                if (floor_ref.inside_arena) {
+                if (floor.inside_arena) {
                     place = _("アリーナ", "in the Arena");
-                } else if (!floor_ref.is_in_dungeon()) {
+                } else if (!floor.is_in_dungeon()) {
                     place = _("地上", "on the surface");
                 } else if (inside_quest(q_idx) && (QuestType::is_fixed(q_idx) && !((q_idx == QuestId::OBERON) || (q_idx == QuestId::SERPENT)))) {
                     place = _("クエスト", "in a quest");
                 } else {
-                    place = format(_("%d階", "on level %d"), static_cast<int>(floor_ref.dun_level));
+                    place = format(_("%d階", "on level %d"), static_cast<int>(floor.dun_level));
                 }
 
 #ifdef JP

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -190,7 +190,7 @@ bool move_player_effect(PlayerType *player_ptr, POSITION ny, POSITION nx, BIT_FL
             g_ptr->info &= ~(CAVE_UNSAFE);
         }
 
-        if (floor_ptr->dun_level && dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::FORGET)) {
+        if (floor_ptr->dun_level && dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::FORGET)) {
             wiz_dark(player_ptr);
         }
 

--- a/src/racial/racial-vampire.cpp
+++ b/src/racial/racial-vampire.cpp
@@ -14,7 +14,8 @@
 
 bool vampirism(PlayerType *player_ptr)
 {
-    if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE)) {
+    const auto &floor = *player_ptr->current_floor_ptr;
+    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE)) {
         msg_print(_("なぜか攻撃することができない。", "Something prevents you from attacking."));
         return false;
     }
@@ -26,8 +27,7 @@ bool vampirism(PlayerType *player_ptr)
 
     POSITION y = player_ptr->y + ddy[dir];
     POSITION x = player_ptr->x + ddx[dir];
-    grid_type *g_ptr;
-    g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
+    const auto *g_ptr = &floor.grid_array[y][x];
     stop_mouth(player_ptr);
     if (!(g_ptr->m_idx)) {
         msg_print(_("何もない場所に噛みついた！", "You bite into thin air!"));

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -388,13 +388,14 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
+            const auto &floor = *player_ptr->current_floor_ptr;
             if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
                 return std::nullopt;
             }
-            if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE)) {
+            if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE)) {
                 return "";
             }
             if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
@@ -805,6 +806,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 return std::nullopt;
             }
 
+            const auto &floor = *player_ptr->current_floor_ptr;
             for (i = 0; i < 3; i++) {
                 POSITION y, x;
                 POSITION ny, nx;
@@ -823,7 +825,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                     return std::nullopt;
                 }
 
-                if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE)) {
+                if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE)) {
                     return "";
                 }
 
@@ -1050,7 +1052,8 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE)) {
+            auto &floor = *player_ptr->current_floor_ptr;
+            if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE)) {
                 msg_print(_("なぜか攻撃することができない。", "Something prevents you from attacking."));
                 return "";
             }
@@ -1081,8 +1084,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 total_damage += (damage / 100);
             }
 
-            auto *floor_ptr = player_ptr->current_floor_ptr;
-            const auto is_bold = cave_has_flag_bold(floor_ptr, y, x, TerrainCharacteristics::PROJECT);
+            const auto is_bold = cave_has_flag_bold(&floor, y, x, TerrainCharacteristics::PROJECT);
             constexpr auto flags = PROJECT_KILL | PROJECT_JUMP | PROJECT_ITEM;
             project(player_ptr, 0, (is_bold ? 5 : 0), y, x, total_damage * 3 / 2, AttributeType::METEOR, flags);
         }

--- a/src/save/floor-writer.cpp
+++ b/src/save/floor-writer.cpp
@@ -166,7 +166,7 @@ bool wr_dungeon(PlayerType *player_ptr)
     };
     RedrawingFlagsUpdater::get_instance().set_flags(flags);
     wr_s16b(max_floor_id);
-    wr_byte((byte)player_ptr->dungeon_idx);
+    wr_byte((byte)player_ptr->current_floor_ptr->dungeon_idx);
     if (!player_ptr->floor_id) {
         /* No array elements */
         wr_byte(0);

--- a/src/specific-object/torch.cpp
+++ b/src/specific-object/torch.cpp
@@ -143,7 +143,7 @@ void update_lite_radius(PlayerType *player_ptr)
         player_ptr->cur_lite += rad;
     }
 
-    if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS) && player_ptr->cur_lite > 1) {
+    if (dungeons_info[player_ptr->current_floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS) && player_ptr->cur_lite > 1) {
         player_ptr->cur_lite = 1;
     }
 

--- a/src/spell-class/spells-mirror-master.cpp
+++ b/src/spell-class/spells-mirror-master.cpp
@@ -51,10 +51,11 @@ SpellsMirrorMaster::SpellsMirrorMaster(PlayerType *player_ptr)
 
 void SpellsMirrorMaster::remove_mirror(int y, int x)
 {
-    auto *g_ptr = &this->player_ptr->current_floor_ptr->grid_array[y][x];
+    auto &floor = *this->player_ptr->current_floor_ptr;
+    auto *g_ptr = &floor.grid_array[y][x];
     reset_bits(g_ptr->info, CAVE_OBJECT);
     g_ptr->mimic = 0;
-    if (dungeons_info[this->player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
         reset_bits(g_ptr->info, CAVE_GLOW);
         if (!view_torch_grids) {
             reset_bits(g_ptr->info, CAVE_MARK);

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -339,7 +339,7 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
                 continue;
             }
 
-            if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+            if (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
                 continue;
             }
 

--- a/src/spell-kind/spells-detection.cpp
+++ b/src/spell-kind/spells-detection.cpp
@@ -39,19 +39,20 @@
  */
 static bool detect_feat_flag(PlayerType *player_ptr, POSITION range, TerrainCharacteristics flag, bool known)
 {
-    if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    auto &floor = *player_ptr->current_floor_ptr;
+    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
 
-    grid_type *g_ptr;
     bool detect = false;
-    for (POSITION y = 1; y < player_ptr->current_floor_ptr->height - 1; y++) {
-        for (POSITION x = 1; x <= player_ptr->current_floor_ptr->width - 1; x++) {
+    for (POSITION y = 1; y < floor.height - 1; y++) {
+        for (POSITION x = 1; x <= floor.width - 1; x++) {
             int dist = distance(player_ptr->y, player_ptr->x, y, x);
             if (dist > range) {
                 continue;
             }
-            g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
+
+            auto *g_ptr = &floor.grid_array[y][x];
             if (flag == TerrainCharacteristics::TRAP) {
                 /* Mark as detected */
                 if (dist <= range && known) {
@@ -175,16 +176,17 @@ bool detect_treasure(PlayerType *player_ptr, POSITION range)
  */
 bool detect_objects_gold(PlayerType *player_ptr, POSITION range)
 {
+    auto &floor = *player_ptr->current_floor_ptr;
     POSITION range2 = range;
-    if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
         range2 /= 3;
     }
 
     /* Scan objects */
     bool detect = false;
     POSITION y, x;
-    for (OBJECT_IDX i = 1; i < player_ptr->current_floor_ptr->o_max; i++) {
-        auto *o_ptr = &player_ptr->current_floor_ptr->o_list[i];
+    for (OBJECT_IDX i = 1; i < floor.o_max; i++) {
+        auto *o_ptr = &floor.o_list[i];
 
         if (!o_ptr->is_valid()) {
             continue;
@@ -228,14 +230,15 @@ bool detect_objects_gold(PlayerType *player_ptr, POSITION range)
  */
 bool detect_objects_normal(PlayerType *player_ptr, POSITION range)
 {
+    auto &floor = *player_ptr->current_floor_ptr;
     POSITION range2 = range;
-    if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
         range2 /= 3;
     }
 
     bool detect = false;
-    for (OBJECT_IDX i = 1; i < player_ptr->current_floor_ptr->o_max; i++) {
-        auto *o_ptr = &player_ptr->current_floor_ptr->o_list[i];
+    for (OBJECT_IDX i = 1; i < floor.o_max; i++) {
+        auto *o_ptr = &floor.o_list[i];
 
         if (!o_ptr->is_valid()) {
             continue;
@@ -298,13 +301,14 @@ static bool is_object_magically(const ItemKindType tval)
  */
 bool detect_objects_magic(PlayerType *player_ptr, POSITION range)
 {
-    if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    auto &floor = *player_ptr->current_floor_ptr;
+    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
 
     auto detect = false;
-    for (OBJECT_IDX i = 1; i < player_ptr->current_floor_ptr->o_max; i++) {
-        auto *o_ptr = &player_ptr->current_floor_ptr->o_list[i];
+    for (OBJECT_IDX i = 1; i < floor.o_max; i++) {
+        auto *o_ptr = &floor.o_list[i];
         if (!o_ptr->is_valid() || o_ptr->is_held_by_monster()) {
             continue;
         }
@@ -340,13 +344,14 @@ bool detect_objects_magic(PlayerType *player_ptr, POSITION range)
  */
 bool detect_monsters_normal(PlayerType *player_ptr, POSITION range)
 {
-    if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    auto &floor = *player_ptr->current_floor_ptr;
+    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
 
     bool flag = false;
-    for (MONSTER_IDX i = 1; i < player_ptr->current_floor_ptr->m_max; i++) {
-        auto *m_ptr = &player_ptr->current_floor_ptr->m_list[i];
+    for (MONSTER_IDX i = 1; i < floor.m_max; i++) {
+        auto *m_ptr = &floor.m_list[i];
         auto *r_ptr = &monraces_info[m_ptr->r_idx];
         if (!m_ptr->is_valid()) {
             continue;
@@ -383,13 +388,14 @@ bool detect_monsters_normal(PlayerType *player_ptr, POSITION range)
  */
 bool detect_monsters_invis(PlayerType *player_ptr, POSITION range)
 {
-    if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    auto &floor = *player_ptr->current_floor_ptr;
+    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
 
     bool flag = false;
-    for (MONSTER_IDX i = 1; i < player_ptr->current_floor_ptr->m_max; i++) {
-        auto *m_ptr = &player_ptr->current_floor_ptr->m_list[i];
+    for (MONSTER_IDX i = 1; i < floor.m_max; i++) {
+        auto *m_ptr = &floor.m_list[i];
         auto *r_ptr = &monraces_info[m_ptr->r_idx];
 
         if (!m_ptr->is_valid()) {
@@ -432,13 +438,14 @@ bool detect_monsters_invis(PlayerType *player_ptr, POSITION range)
  */
 bool detect_monsters_evil(PlayerType *player_ptr, POSITION range)
 {
-    if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    auto &floor = *player_ptr->current_floor_ptr;
+    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
 
     bool flag = false;
-    for (MONSTER_IDX i = 1; i < player_ptr->current_floor_ptr->m_max; i++) {
-        auto *m_ptr = &player_ptr->current_floor_ptr->m_list[i];
+    for (MONSTER_IDX i = 1; i < floor.m_max; i++) {
+        auto *m_ptr = &floor.m_list[i];
         auto *r_ptr = &monraces_info[m_ptr->r_idx];
         if (!m_ptr->is_valid()) {
             continue;
@@ -480,13 +487,14 @@ bool detect_monsters_evil(PlayerType *player_ptr, POSITION range)
  */
 bool detect_monsters_nonliving(PlayerType *player_ptr, POSITION range)
 {
-    if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    auto &floor = *player_ptr->current_floor_ptr;
+    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
 
     bool flag = false;
-    for (MONSTER_IDX i = 1; i < player_ptr->current_floor_ptr->m_max; i++) {
-        auto *m_ptr = &player_ptr->current_floor_ptr->m_list[i];
+    for (MONSTER_IDX i = 1; i < floor.m_max; i++) {
+        auto *m_ptr = &floor.m_list[i];
         if (!m_ptr->is_valid()) {
             continue;
         }
@@ -523,13 +531,14 @@ bool detect_monsters_nonliving(PlayerType *player_ptr, POSITION range)
  */
 bool detect_monsters_mind(PlayerType *player_ptr, POSITION range)
 {
-    if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    auto &floor = *player_ptr->current_floor_ptr;
+    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
 
     bool flag = false;
-    for (MONSTER_IDX i = 1; i < player_ptr->current_floor_ptr->m_max; i++) {
-        auto *m_ptr = &player_ptr->current_floor_ptr->m_list[i];
+    for (MONSTER_IDX i = 1; i < floor.m_max; i++) {
+        auto *m_ptr = &floor.m_list[i];
         auto *r_ptr = &monraces_info[m_ptr->r_idx];
         if (!m_ptr->is_valid()) {
             continue;
@@ -569,13 +578,14 @@ bool detect_monsters_mind(PlayerType *player_ptr, POSITION range)
  */
 bool detect_monsters_string(PlayerType *player_ptr, POSITION range, concptr Match)
 {
-    if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    auto &floor = *player_ptr->current_floor_ptr;
+    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
 
     bool flag = false;
-    for (MONSTER_IDX i = 1; i < player_ptr->current_floor_ptr->m_max; i++) {
-        auto *m_ptr = &player_ptr->current_floor_ptr->m_list[i];
+    for (MONSTER_IDX i = 1; i < floor.m_max; i++) {
+        auto *m_ptr = &floor.m_list[i];
         auto *r_ptr = &monraces_info[m_ptr->r_idx];
         if (!m_ptr->is_valid()) {
             continue;

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -64,8 +64,9 @@
 void wiz_lite(PlayerType *player_ptr, bool ninja)
 {
     /* Memorize objects */
-    for (OBJECT_IDX i = 1; i < player_ptr->current_floor_ptr->o_max; i++) {
-        auto *o_ptr = &player_ptr->current_floor_ptr->o_list[i];
+    auto &floor = *player_ptr->current_floor_ptr;
+    for (OBJECT_IDX i = 1; i < floor.o_max; i++) {
+        auto *o_ptr = &floor.o_list[i];
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -76,10 +77,10 @@ void wiz_lite(PlayerType *player_ptr, bool ninja)
     }
 
     /* Scan all normal grids */
-    for (POSITION y = 1; y < player_ptr->current_floor_ptr->height - 1; y++) {
+    for (POSITION y = 1; y < floor.height - 1; y++) {
         /* Scan all normal grids */
-        for (POSITION x = 1; x < player_ptr->current_floor_ptr->width - 1; x++) {
-            auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
+        for (POSITION x = 1; x < floor.width - 1; x++) {
+            auto *g_ptr = &floor.grid_array[y][x];
 
             /* Memorize terrain of the grid */
             g_ptr->info |= (CAVE_KNOWN);
@@ -93,13 +94,13 @@ void wiz_lite(PlayerType *player_ptr, bool ninja)
             for (OBJECT_IDX i = 0; i < 9; i++) {
                 POSITION yy = y + ddy_ddd[i];
                 POSITION xx = x + ddx_ddd[i];
-                g_ptr = &player_ptr->current_floor_ptr->grid_array[yy][xx];
+                g_ptr = &floor.grid_array[yy][xx];
 
                 /* Feature code (applying "mimic" field) */
                 f_ptr = &terrains_info[g_ptr->get_feat_mimic()];
 
                 /* Perma-lite the grid */
-                if (dungeons_info[player_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::DARKNESS) && !ninja) {
+                if (dungeons_info[floor.dungeon_idx].flags.has_not(DungeonFeatureType::DARKNESS) && !ninja) {
                     g_ptr->info |= (CAVE_GLOW);
                 }
 
@@ -126,7 +127,7 @@ void wiz_lite(PlayerType *player_ptr, bool ninja)
     player_ptr->redraw |= (PR_MAP);
     player_ptr->window_flags |= (PW_OVERHEAD | PW_DUNGEON | PW_FOUND_ITEMS);
 
-    if (player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x].info & CAVE_GLOW) {
+    if (floor.grid_array[player_ptr->y][player_ptr->x].info & CAVE_GLOW) {
         set_superstealth(player_ptr, false);
     }
 }
@@ -197,19 +198,20 @@ void wiz_dark(PlayerType *player_ptr)
  */
 void map_area(PlayerType *player_ptr, POSITION range)
 {
-    if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    auto &floor = *player_ptr->current_floor_ptr;
+    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
 
     /* Scan that area */
-    for (POSITION y = 1; y < player_ptr->current_floor_ptr->height - 1; y++) {
-        for (POSITION x = 1; x < player_ptr->current_floor_ptr->width - 1; x++) {
+    for (POSITION y = 1; y < floor.height - 1; y++) {
+        for (POSITION x = 1; x < floor.width - 1; x++) {
             if (distance(player_ptr->y, player_ptr->x, y, x) > range) {
                 continue;
             }
 
             grid_type *g_ptr;
-            g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
+            g_ptr = &floor.grid_array[y][x];
 
             /* Memorize terrain of the grid */
             g_ptr->info |= (CAVE_KNOWN);
@@ -227,7 +229,7 @@ void map_area(PlayerType *player_ptr, POSITION range)
 
             /* Memorize known walls */
             for (int i = 0; i < 8; i++) {
-                g_ptr = &player_ptr->current_floor_ptr->grid_array[y + ddy_ddd[i]][x + ddx_ddd[i]];
+                g_ptr = &floor.grid_array[y + ddy_ddd[i]][x + ddx_ddd[i]];
 
                 /* Feature code (applying "mimic" field) */
                 feat = g_ptr->get_feat_mimic();

--- a/src/spell-kind/spells-genocide.cpp
+++ b/src/spell-kind/spells-genocide.cpp
@@ -33,10 +33,10 @@
 
 static bool is_in_special_floor(PlayerType *player_ptr)
 {
-    auto *floor_ptr = player_ptr->current_floor_ptr;
-    auto is_in_fixed_quest = inside_quest(floor_ptr->quest_number);
-    is_in_fixed_quest &= !inside_quest(random_quest_number(player_ptr, floor_ptr->dun_level));
-    return is_in_fixed_quest || floor_ptr->inside_arena || player_ptr->phase_out;
+    auto &floor = *player_ptr->current_floor_ptr;
+    auto is_in_fixed_quest = inside_quest(floor.quest_number);
+    is_in_fixed_quest &= !inside_quest(random_quest_number(floor, floor.dun_level));
+    return is_in_fixed_quest || floor.inside_arena || player_ptr->phase_out;
 }
 
 /*!
@@ -50,8 +50,8 @@ static bool is_in_special_floor(PlayerType *player_ptr)
  */
 bool genocide_aux(PlayerType *player_ptr, MONSTER_IDX m_idx, int power, bool player_cast, int dam_side, concptr spell_name)
 {
-    auto *floor_ptr = player_ptr->current_floor_ptr;
-    auto *m_ptr = &floor_ptr->m_list[m_idx];
+    auto &floor = *player_ptr->current_floor_ptr;
+    auto *m_ptr = &floor.m_list[m_idx];
     auto *r_ptr = &monraces_info[m_ptr->r_idx];
     if (m_ptr->is_pet() && !player_cast) {
         return false;
@@ -129,8 +129,8 @@ bool genocide_aux(PlayerType *player_ptr, MONSTER_IDX m_idx, int power, bool pla
  */
 bool symbol_genocide(PlayerType *player_ptr, int power, bool player_cast)
 {
-    auto *floor_ptr = player_ptr->current_floor_ptr;
-    bool is_special_floor = inside_quest(floor_ptr->quest_number) && !inside_quest(random_quest_number(player_ptr, floor_ptr->dun_level));
+    auto &floor = *player_ptr->current_floor_ptr;
+    bool is_special_floor = inside_quest(floor.quest_number) && !inside_quest(random_quest_number(floor, floor.dun_level));
     is_special_floor |= player_ptr->current_floor_ptr->inside_arena;
     is_special_floor |= player_ptr->phase_out;
     if (is_special_floor) {
@@ -172,17 +172,17 @@ bool symbol_genocide(PlayerType *player_ptr, int power, bool player_cast)
  */
 bool mass_genocide(PlayerType *player_ptr, int power, bool player_cast)
 {
-    auto *floor_ptr = player_ptr->current_floor_ptr;
-    bool is_special_floor = inside_quest(floor_ptr->quest_number) && !inside_quest(random_quest_number(player_ptr, floor_ptr->dun_level));
-    is_special_floor |= player_ptr->current_floor_ptr->inside_arena;
+    auto &floor = *player_ptr->current_floor_ptr;
+    bool is_special_floor = inside_quest(floor.quest_number) && !inside_quest(random_quest_number(floor, floor.dun_level));
+    is_special_floor |= floor.inside_arena;
     is_special_floor |= player_ptr->phase_out;
     if (is_special_floor) {
         return false;
     }
 
     bool result = false;
-    for (MONSTER_IDX i = 1; i < player_ptr->current_floor_ptr->m_max; i++) {
-        auto *m_ptr = &player_ptr->current_floor_ptr->m_list[i];
+    for (MONSTER_IDX i = 1; i < floor.m_max; i++) {
+        auto *m_ptr = &floor.m_list[i];
         if (!m_ptr->is_valid()) {
             continue;
         }
@@ -209,17 +209,17 @@ bool mass_genocide(PlayerType *player_ptr, int power, bool player_cast)
  */
 bool mass_genocide_undead(PlayerType *player_ptr, int power, bool player_cast)
 {
-    auto *floor_ptr = player_ptr->current_floor_ptr;
-    bool is_special_floor = inside_quest(floor_ptr->quest_number) && !inside_quest(random_quest_number(player_ptr, floor_ptr->dun_level));
-    is_special_floor |= player_ptr->current_floor_ptr->inside_arena;
+    auto &floor = *player_ptr->current_floor_ptr;
+    bool is_special_floor = inside_quest(floor.quest_number) && !inside_quest(random_quest_number(floor, floor.dun_level));
+    is_special_floor |= floor.inside_arena;
     is_special_floor |= player_ptr->phase_out;
     if (is_special_floor) {
         return false;
     }
 
     bool result = false;
-    for (MONSTER_IDX i = 1; i < player_ptr->current_floor_ptr->m_max; i++) {
-        auto *m_ptr = &player_ptr->current_floor_ptr->m_list[i];
+    for (MONSTER_IDX i = 1; i < floor.m_max; i++) {
+        auto *m_ptr = &floor.m_list[i];
         auto *r_ptr = &monraces_info[m_ptr->r_idx];
         if (!m_ptr->is_valid()) {
             continue;

--- a/src/spell-kind/spells-grid.cpp
+++ b/src/spell-kind/spells-grid.cpp
@@ -70,17 +70,17 @@ void stair_creation(PlayerType *player_ptr)
     }
 
     bool down = true;
-    auto *floor_ptr = player_ptr->current_floor_ptr;
-    if (inside_quest(quest_number(player_ptr, floor_ptr->dun_level)) || (floor_ptr->dun_level >= dungeons_info[player_ptr->dungeon_idx].maxdepth)) {
+    auto &floor = *player_ptr->current_floor_ptr;
+    if (inside_quest(quest_number(floor, floor.dun_level)) || (floor.dun_level >= dungeons_info[floor.dungeon_idx].maxdepth)) {
         down = false;
     }
 
-    if (!floor_ptr->dun_level || (!up && !down) || (inside_quest(floor_ptr->quest_number) && QuestType::is_fixed(floor_ptr->quest_number)) || floor_ptr->inside_arena || player_ptr->phase_out) {
+    if (!floor.dun_level || (!up && !down) || (inside_quest(floor.quest_number) && QuestType::is_fixed(floor.quest_number)) || floor.inside_arena || player_ptr->phase_out) {
         msg_print(_("効果がありません！", "There is no effect!"));
         return;
     }
 
-    if (!cave_valid_bold(floor_ptr, player_ptr->y, player_ptr->x)) {
+    if (!cave_valid_bold(&floor, player_ptr->y, player_ptr->x)) {
         msg_print(_("床上のアイテムが呪文を跳ね返した。", "The object resists the spell."));
         return;
     }
@@ -113,9 +113,9 @@ void stair_creation(PlayerType *player_ptr)
     }
 
     if (dest_floor_id) {
-        for (POSITION y = 0; y < floor_ptr->height; y++) {
-            for (POSITION x = 0; x < floor_ptr->width; x++) {
-                auto *g_ptr = &floor_ptr->grid_array[y][x];
+        for (POSITION y = 0; y < floor.height; y++) {
+            for (POSITION x = 0; x < floor.width; x++) {
+                auto *g_ptr = &floor.grid_array[y][x];
                 if (!g_ptr->special) {
                     continue;
                 }
@@ -144,13 +144,13 @@ void stair_creation(PlayerType *player_ptr)
     dest_sf_ptr = get_sf_ptr(dest_floor_id);
     if (up) {
         cave_set_feat(player_ptr, player_ptr->y, player_ptr->x,
-            (dest_sf_ptr->last_visit && (dest_sf_ptr->dun_level <= floor_ptr->dun_level - 2)) ? feat_state(player_ptr->current_floor_ptr, feat_up_stair, TerrainCharacteristics::SHAFT)
-                                                                                              : feat_up_stair);
+            (dest_sf_ptr->last_visit && (dest_sf_ptr->dun_level <= floor.dun_level - 2)) ? feat_state(&floor, feat_up_stair, TerrainCharacteristics::SHAFT)
+                                                                                         : feat_up_stair);
     } else {
         cave_set_feat(player_ptr, player_ptr->y, player_ptr->x,
-            (dest_sf_ptr->last_visit && (dest_sf_ptr->dun_level >= floor_ptr->dun_level + 2)) ? feat_state(player_ptr->current_floor_ptr, feat_down_stair, TerrainCharacteristics::SHAFT)
-                                                                                              : feat_down_stair);
+            (dest_sf_ptr->last_visit && (dest_sf_ptr->dun_level >= floor.dun_level + 2)) ? feat_state(&floor, feat_down_stair, TerrainCharacteristics::SHAFT)
+                                                                                         : feat_down_stair);
     }
 
-    floor_ptr->grid_array[player_ptr->y][player_ptr->x].special = dest_floor_id;
+    floor.grid_array[player_ptr->y][player_ptr->x].special = dest_floor_id;
 }

--- a/src/spell-kind/spells-lite.cpp
+++ b/src/spell-kind/spells-lite.cpp
@@ -422,7 +422,7 @@ bool starlight(PlayerType *player_ptr, bool magic)
  */
 bool lite_area(PlayerType *player_ptr, int dam, POSITION rad)
 {
-    if (dungeons_info[player_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    if (dungeons_info[player_ptr->current_floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
         msg_print(_("ダンジョンが光を吸収した。", "The darkness of this dungeon absorbs your light."));
         return false;
     }

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -27,6 +27,7 @@
 #include "store/store-util.h"
 #include "sv-definition/sv-lite-types.h"
 #include "sv-definition/sv-scroll-types.h"
+#include "system/floor-type-definition.h"
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
@@ -326,7 +327,7 @@ static void store_create(PlayerType *player_ptr, short fix_k_idx, StoreSaleType 
         DEPTH level;
         if (store_num == StoreSaleType::BLACK) {
             level = 25 + randint0(25);
-            bi_id = get_obj_index(player_ptr, level, 0x00000000);
+            bi_id = get_obj_index(player_ptr->current_floor_ptr, level, 0x00000000);
             if (bi_id == 0) {
                 continue;
             }

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -70,7 +70,6 @@ public:
     int16_t arena_number{}; /* monster number in on_defeat_arena_monster -KMW- */
     bool phase_out{}; /*!< フェイズアウト状態(闘技場観戦状態などに利用、NPCの処理の対象にならず自身もほとんどの行動ができない) */
 
-    DUNGEON_IDX dungeon_idx{}; /* current dungeon index */
     POSITION wilderness_x{}; /* Coordinates in the wilderness */
     POSITION wilderness_y{};
     bool wild_mode{};

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -186,7 +186,7 @@ void print_depth(PlayerType *player_ptr)
         return;
     }
 
-    if (inside_quest(floor_ptr->quest_number) && !player_ptr->dungeon_idx) {
+    if (inside_quest(floor_ptr->quest_number) && !floor_ptr->dungeon_idx) {
         c_prt(attr, format("%7s", _("地上", "Quest")), row_depth, col_depth);
         return;
     }

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -535,7 +535,7 @@ static bool select_debugging_dungeon(PlayerType *player_ptr, DUNGEON_IDX *dungeo
 
     while (true) {
         char tmp_val[160];
-        strnfmt(tmp_val, sizeof(tmp_val), "%d", player_ptr->dungeon_idx);
+        strnfmt(tmp_val, sizeof(tmp_val), "%d", player_ptr->current_floor_ptr->dungeon_idx);
         if (!get_string("Jump which dungeon : ", tmp_val, 2)) {
             return false;
         }
@@ -602,22 +602,22 @@ static bool select_debugging_floor(PlayerType *player_ptr, int dungeon_type)
  */
 static void wiz_jump_floor(PlayerType *player_ptr, DUNGEON_IDX dun_idx, DEPTH depth)
 {
-    player_ptr->dungeon_idx = dun_idx;
-    auto &floor_ref = *player_ptr->current_floor_ptr;
-    floor_ref.dun_level = depth;
+    auto &floor = *player_ptr->current_floor_ptr;
+    floor.dungeon_idx = dun_idx;
+    floor.dun_level = depth;
     prepare_change_floor_mode(player_ptr, CFM_RAND_PLACE);
-    if (!floor_ref.is_in_dungeon()) {
-        player_ptr->dungeon_idx = 0;
+    if (!floor.is_in_dungeon()) {
+        floor.dungeon_idx = 0;
     }
 
-    floor_ref.inside_arena = false;
+    floor.inside_arena = false;
     player_ptr->wild_mode = false;
     leave_quest_check(player_ptr);
     if (record_stair) {
         exe_write_diary(player_ptr, DIARY_WIZ_TELE, 0, nullptr);
     }
 
-    floor_ref.quest_number = QuestId::NONE;
+    floor.quest_number = QuestId::NONE;
     PlayerEnergy(player_ptr).reset_player_turn();
     player_ptr->energy_need = 0;
     prepare_change_floor_mode(player_ptr, CFM_FIRST_FLOOR);
@@ -884,10 +884,10 @@ void cheat_death(PlayerType *player_ptr)
     player_ptr->phase_out = false;
     leaving_quest = QuestId::NONE;
     floor_ptr->quest_number = QuestId::NONE;
-    if (player_ptr->dungeon_idx) {
-        player_ptr->recall_dungeon = player_ptr->dungeon_idx;
+    if (floor_ptr->dungeon_idx) {
+        player_ptr->recall_dungeon = floor_ptr->dungeon_idx;
     }
-    player_ptr->dungeon_idx = 0;
+    floor_ptr->dungeon_idx = 0;
     if (lite_town || vanilla_town) {
         player_ptr->wilderness_y = 1;
         player_ptr->wilderness_x = 1;

--- a/src/world/world-movement-processor.cpp
+++ b/src/world/world-movement-processor.cpp
@@ -27,14 +27,15 @@
 void check_random_quest_auto_failure(PlayerType *player_ptr)
 {
     auto &quest_list = QuestList::get_instance();
-    if (player_ptr->dungeon_idx != DUNGEON_ANGBAND) {
+    const auto &floor = *player_ptr->current_floor_ptr;
+    if (floor.dungeon_idx != DUNGEON_ANGBAND) {
         return;
     }
     for (auto q_idx : EnumRange(QuestId::RANDOM_QUEST1, QuestId::RANDOM_QUEST10)) {
         auto &quest = quest_list[q_idx];
         auto is_taken_quest = (quest.type == QuestKindType::RANDOM);
         is_taken_quest &= (quest.status == QuestStatusType::TAKEN);
-        is_taken_quest &= (quest.level < player_ptr->current_floor_ptr->dun_level);
+        is_taken_quest &= (quest.level < floor.dun_level);
         if (!is_taken_quest) {
             continue;
         }
@@ -75,40 +76,40 @@ void execute_recall(PlayerType *player_ptr)
     auto *floor_ptr = player_ptr->current_floor_ptr;
     if (floor_ptr->dun_level || inside_quest(floor_ptr->quest_number) || player_ptr->enter_dungeon) {
         msg_print(_("上に引っ張りあげられる感じがする！", "You feel yourself yanked upwards!"));
-        if (player_ptr->dungeon_idx) {
-            player_ptr->recall_dungeon = player_ptr->dungeon_idx;
+        if (floor_ptr->dungeon_idx) {
+            player_ptr->recall_dungeon = floor_ptr->dungeon_idx;
         }
         if (record_stair) {
             exe_write_diary(player_ptr, DIARY_RECALL, floor_ptr->dun_level, nullptr);
         }
 
         floor_ptr->dun_level = 0;
-        player_ptr->dungeon_idx = 0;
+        floor_ptr->dungeon_idx = 0;
         leave_quest_check(player_ptr);
         leave_tower_check(player_ptr);
-        player_ptr->current_floor_ptr->quest_number = QuestId::NONE;
+        floor_ptr->quest_number = QuestId::NONE;
         player_ptr->leaving = true;
         sound(SOUND_TPLEVEL);
         return;
     }
 
     msg_print(_("下に引きずり降ろされる感じがする！", "You feel yourself yanked downwards!"));
-    player_ptr->dungeon_idx = player_ptr->recall_dungeon;
+    floor_ptr->dungeon_idx = player_ptr->recall_dungeon;
     if (record_stair) {
         exe_write_diary(player_ptr, DIARY_RECALL, floor_ptr->dun_level, nullptr);
     }
 
-    floor_ptr->dun_level = max_dlv[player_ptr->dungeon_idx];
+    floor_ptr->dun_level = max_dlv[floor_ptr->dungeon_idx];
     if (floor_ptr->dun_level < 1) {
         floor_ptr->dun_level = 1;
     }
-    if (ironman_nightmare && !randint0(666) && (player_ptr->dungeon_idx == DUNGEON_ANGBAND)) {
+    if (ironman_nightmare && !randint0(666) && (floor_ptr->dungeon_idx == DUNGEON_ANGBAND)) {
         if (floor_ptr->dun_level < 50) {
             floor_ptr->dun_level *= 2;
         } else if (floor_ptr->dun_level < 99) {
             floor_ptr->dun_level = (floor_ptr->dun_level + 99) / 2;
         } else if (floor_ptr->dun_level > 100) {
-            floor_ptr->dun_level = dungeons_info[player_ptr->dungeon_idx].maxdepth - 1;
+            floor_ptr->dun_level = dungeons_info[floor_ptr->dungeon_idx].maxdepth - 1;
         }
     }
 
@@ -140,7 +141,7 @@ void execute_recall(PlayerType *player_ptr)
  */
 void execute_floor_reset(PlayerType *player_ptr)
 {
-    auto *floor_ptr = player_ptr->current_floor_ptr;
+    const auto &floor = *player_ptr->current_floor_ptr;
     if (player_ptr->alter_reality == 0) {
         return;
     }
@@ -156,7 +157,7 @@ void execute_floor_reset(PlayerType *player_ptr)
     }
 
     disturb(player_ptr, false, true);
-    if (!inside_quest(quest_number(player_ptr, floor_ptr->dun_level)) && floor_ptr->dun_level) {
+    if (!inside_quest(quest_number(floor, floor.dun_level)) && floor.dun_level) {
         msg_print(_("世界が変わった！", "The world changes!"));
 
         /*

--- a/src/world/world-object.cpp
+++ b/src/world/world-object.cpp
@@ -66,13 +66,13 @@ OBJECT_IDX o_pop(FloorType *floor_ptr)
  * Note that if no objects are "appropriate", then this function will\n
  * fail, and return zero, but this should *almost* never happen.\n
  */
-OBJECT_IDX get_obj_index(PlayerType *player_ptr, DEPTH level, BIT_FLAGS mode)
+OBJECT_IDX get_obj_index(const FloorType *floor_ptr, DEPTH level, BIT_FLAGS mode)
 {
     if (level > MAX_DEPTH - 1) {
         level = MAX_DEPTH - 1;
     }
 
-    if ((level > 0) && dungeons_info[player_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::BEGINNER)) {
+    if ((level > 0) && dungeons_info[floor_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::BEGINNER)) {
         if (one_in_(CHANCE_BASEITEM_LEVEL_BOOST)) {
             level = 1 + (level * MAX_DEPTH / randint1(MAX_DEPTH));
         }

--- a/src/world/world-object.h
+++ b/src/world/world-object.h
@@ -3,6 +3,5 @@
 #include "system/angband.h"
 
 class FloorType;
-class PlayerType;
 OBJECT_IDX o_pop(FloorType *floor_ptr);
-OBJECT_IDX get_obj_index(PlayerType *player_ptr, DEPTH level, BIT_FLAGS mode);
+OBJECT_IDX get_obj_index(const FloorType *floor_ptr, DEPTH level, BIT_FLAGS mode);

--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -122,13 +122,13 @@ void WorldTurnProcessor::print_time()
 void WorldTurnProcessor::process_downward()
 {
     /* 帰還無しモード時のレベルテレポバグ対策 / Fix for level teleport bugs on ironman_downward.*/
-    if (!ironman_downward || (this->player_ptr->dungeon_idx == DUNGEON_ANGBAND) || (this->player_ptr->dungeon_idx == 0)) {
+    auto *floor_ptr = this->player_ptr->current_floor_ptr;
+    if (!ironman_downward || (floor_ptr->dungeon_idx == DUNGEON_ANGBAND) || (floor_ptr->dungeon_idx == 0)) {
         return;
     }
 
-    auto *floor_ptr = this->player_ptr->current_floor_ptr;
     floor_ptr->dun_level = 0;
-    this->player_ptr->dungeon_idx = 0;
+    floor_ptr->dungeon_idx = 0;
     prepare_change_floor_mode(this->player_ptr, CFM_FIRST_FLOOR | CFM_RAND_PLACE);
     floor_ptr->inside_arena = false;
     this->player_ptr->wild_mode = false;
@@ -305,7 +305,7 @@ void WorldTurnProcessor::shuffle_shopkeeper()
 void WorldTurnProcessor::decide_alloc_monster()
 {
     auto *floor_ptr = this->player_ptr->current_floor_ptr;
-    auto should_alloc = one_in_(dungeons_info[this->player_ptr->dungeon_idx].max_m_alloc_chance);
+    auto should_alloc = one_in_(dungeons_info[floor_ptr->dungeon_idx].max_m_alloc_chance);
     should_alloc &= !floor_ptr->inside_arena;
     should_alloc &= !inside_quest(floor_ptr->quest_number);
     should_alloc &= !this->player_ptr->phase_out;


### PR DESCRIPTION
掲題の通りです
フロア生成 (イーク洞・鉄獄・オーク洞)、階段上り下り、ランクエ辺り確認しましたが特に問題は起きていないようです
ご確認下さい

かなり単純置換気味ではありますが、PlayerType 引数が不要になった関数をFloorType にうっかり差し替えたら相当量のコールチェーンに手を入れるハメになりました
途中で切り上げて#3333 に分離しましたが、レビューの際はご注意下さい
(それだけPlayerType::dungeon\_idx にしか依存していなかったコードが多い)