### PR TITLE
dungeon_type へのアクセスをカプセル化した

### DIFF
--- a/src/action/action-limited.cpp
+++ b/src/action/action-limited.cpp
@@ -29,7 +29,7 @@
 bool cmd_limit_cast(PlayerType *player_ptr)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
-    if (floor.is_in_dungeon() && (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::NO_MAGIC))) {
+    if (floor.is_in_dungeon() && (floor.get_dungeon_definition().flags.has(DungeonFeatureType::NO_MAGIC))) {
         msg_print(_("ダンジョンが魔法を吸収した！", "The dungeon absorbs all attempted magic!"));
         msg_print(nullptr);
         return true;

--- a/src/avatar/avatar-changer.cpp
+++ b/src/avatar/avatar-changer.cpp
@@ -63,7 +63,7 @@ void AvatarChanger::change_virtue_non_beginner()
 {
     auto *floor_ptr = this->player_ptr->current_floor_ptr;
     auto *r_ptr = &monraces_info[m_ptr->r_idx];
-    if (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::BEGINNER)) {
+    if (floor_ptr->get_dungeon_definition().flags.has(DungeonFeatureType::BEGINNER)) {
         return;
     }
 

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -148,10 +148,6 @@ void player_wipe_without_name(PlayerType *player_ptr)
 
     player_ptr->max_plv = player_ptr->lev = 1;
     player_ptr->arena_number = 0;
-    auto floor_ptr = player_ptr->current_floor_ptr;
-    floor_ptr->inside_arena = false;
-    floor_ptr->quest_number = QuestId::NONE;
-
     player_ptr->exit_bldg = true;
     player_ptr->knows_daily_bounty = false;
     update_gambling_monsters(player_ptr);
@@ -161,7 +157,6 @@ void player_wipe_without_name(PlayerType *player_ptr)
         player_ptr->virtues[i] = 0;
     }
 
-    floor_ptr->dungeon_idx = 0;
     if (vanilla_town || ironman_downward) {
         player_ptr->recall_dungeon = DUNGEON_ANGBAND;
     } else {

--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -218,7 +218,7 @@ bool do_cmd_attack(PlayerType *player_ptr, POSITION y, POSITION x, combat_option
         }
     }
 
-    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE)) {
+    if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::NO_MELEE)) {
         sound(SOUND_ATTACK_FAILED);
         msg_print(_("なぜか攻撃することができない。", "Something prevents you from attacking."));
         return false;

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -164,7 +164,7 @@ void do_cmd_go_up(PlayerType *player_ptr)
             up_num = 1;
         }
 
-        if (player_ptr->current_floor_ptr->dun_level - up_num < dungeons_info[floor_ptr->dungeon_idx].mindepth) {
+        if (player_ptr->current_floor_ptr->dun_level - up_num < floor_ptr->get_dungeon_definition().mindepth) {
             up_num = player_ptr->current_floor_ptr->dun_level;
         }
     }
@@ -294,9 +294,10 @@ void do_cmd_go_down(PlayerType *player_ptr)
         down_num += 1;
     }
 
+    const auto &dungeon = floor_ptr->get_dungeon_definition();
     if (!floor_ptr->is_in_dungeon()) {
         player_ptr->enter_dungeon = true;
-        down_num = dungeons_info[floor_ptr->dungeon_idx].mindepth;
+        down_num = dungeon.mindepth;
     }
 
     if (record_stair) {
@@ -311,7 +312,7 @@ void do_cmd_go_down(PlayerType *player_ptr)
         msg_print(_("わざと落とし戸に落ちた。", "You deliberately jump through the trap door."));
     } else {
         if (target_dungeon) {
-            msg_format(_("%sへ入った。", "You entered %s."), dungeons_info[floor_ptr->dungeon_idx].text.data());
+            msg_format(_("%sへ入った。", "You entered %s."), dungeon.text.data());
         } else {
             if (is_echizen(player_ptr)) {
                 msg_print(_("なんだこの階段は！", "What's this STAIRWAY!"));

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -260,7 +260,7 @@ void do_cmd_go_down(PlayerType *player_ptr)
         return;
     }
 
-    DUNGEON_IDX target_dungeon = 0;
+    short target_dungeon = 0;
     if (!floor_ptr->is_in_dungeon()) {
         target_dungeon = f_ptr->flags.has(TerrainCharacteristics::ENTRANCE) ? g_ptr->special : DUNGEON_ANGBAND;
         if (ironman_downward && (target_dungeon != DUNGEON_ANGBAND)) {
@@ -279,7 +279,7 @@ void do_cmd_go_down(PlayerType *player_ptr)
 
         player_ptr->oldpx = player_ptr->x;
         player_ptr->oldpy = player_ptr->y;
-        floor_ptr->dungeon_idx = target_dungeon;
+        floor_ptr->set_dungeon_index(target_dungeon);
         prepare_change_floor_mode(player_ptr, CFM_FIRST_FLOOR);
     }
 

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -183,6 +183,7 @@ static void init_world_floor_info(PlayerType *player_ptr)
 {
     w_ptr->character_dungeon = false;
     auto *floor_ptr = player_ptr->current_floor_ptr;
+    floor_ptr->reset_dungeon_index();
     floor_ptr->dun_level = 0;
     floor_ptr->quest_number = QuestId::NONE;
     floor_ptr->inside_arena = false;

--- a/src/dungeon/dungeon-processor.cpp
+++ b/src/dungeon/dungeon-processor.cpp
@@ -182,7 +182,7 @@ void process_dungeon(PlayerType *player_ptr, bool load_game)
         floor.quest_number = random_quest_number(floor, floor.dun_level);
     }
 
-    const auto &dungeon = dungeons_info[floor.dungeon_idx];
+    const auto &dungeon = floor.get_dungeon_definition();
     const auto guardian = dungeon.final_guardian;
     if ((floor.dun_level == dungeon.maxdepth) && MonsterRace(guardian).is_valid()) {
         const auto &guardian_ref = monraces_info[guardian];

--- a/src/effect/effect-feature.cpp
+++ b/src/effect/effect-feature.cpp
@@ -340,7 +340,7 @@ bool affect_feature(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITIO
     }
     case AttributeType::LITE_WEAK:
     case AttributeType::LITE: {
-        if (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+        if (floor_ptr->get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
             break;
         }
 

--- a/src/floor/cave-generator.cpp
+++ b/src/floor/cave-generator.cpp
@@ -204,7 +204,7 @@ static bool make_one_floor(PlayerType *player_ptr, dun_data_type *dd_ptr, dungeo
 {
     auto *floor_ptr = player_ptr->current_floor_ptr;
 
-    if (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_ROOM)) {
+    if (floor_ptr->get_dungeon_definition().flags.has(DungeonFeatureType::NO_ROOM)) {
         make_only_tunnel_points(floor_ptr, dd_ptr);
     } else {
         if (!generate_rooms(player_ptr, dd_ptr)) {
@@ -435,7 +435,7 @@ bool cave_gen(PlayerType *player_ptr, concptr *why)
     }
 
     dd_ptr->cent_n = 0;
-    auto *d_ptr = &dungeons_info[floor_ptr->dungeon_idx];
+    auto *d_ptr = &floor_ptr->get_dungeon_definition();
     constexpr auto chance_empty_floor = 24;
     if (ironman_empty_levels || (d_ptr->flags.has(DungeonFeatureType::ARENA) && (empty_levels && one_in_(chance_empty_floor)))) {
         dd_ptr->empty_level = true;

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -283,7 +283,7 @@ static void new_floor_allocation(PlayerType *player_ptr, saved_floor_type *sf_pt
 {
     GAME_TURN tmp_last_visit = sf_ptr->last_visit;
     const auto &floor = *player_ptr->current_floor_ptr;
-    int alloc_chance = dungeons_info[floor.dungeon_idx].max_m_alloc_chance;
+    auto alloc_chance = floor.get_dungeon_definition().max_m_alloc_chance;
     while (tmp_last_visit > w_ptr->game_turn) {
         tmp_last_visit -= TURNS_PER_TICK * TOWN_DAWN;
     }

--- a/src/floor/floor-events.cpp
+++ b/src/floor/floor-events.cpp
@@ -328,7 +328,7 @@ void update_dungeon_feeling(PlayerType *player_ptr)
 void glow_deep_lava_and_bldg(PlayerType *player_ptr)
 {
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    if (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    if (floor_ptr->get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         return;
     }
 

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -325,7 +325,7 @@ static void jump_floors(PlayerType *player_ptr)
     }
 
     auto &floor = *player_ptr->current_floor_ptr;
-    const auto &dungeon = dungeons_info[floor.dungeon_idx];
+    const auto &dungeon = floor.get_dungeon_definition();
     if (any_bits(mode, CFM_DOWN)) {
         if (!floor.is_in_dungeon()) {
             move_num = dungeon.mindepth;
@@ -348,7 +348,7 @@ static void exit_to_wilderness(PlayerType *player_ptr)
 
     player_ptr->leaving_dungeon = true;
     if (!vanilla_town && !lite_town) {
-        const auto &dungeon = dungeons_info[floor.dungeon_idx];
+        const auto &dungeon = floor.get_dungeon_definition();
         player_ptr->wilderness_y = dungeon.dy;
         player_ptr->wilderness_x = dungeon.dx;
     }

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -355,7 +355,7 @@ static void exit_to_wilderness(PlayerType *player_ptr)
 
     player_ptr->recall_dungeon = floor.dungeon_idx;
     player_ptr->word_recall = 0;
-    floor.dungeon_idx = 0;
+    floor.reset_dungeon_index();
     player_ptr->change_floor_mode &= ~CFM_SAVE_FLOORS; // TODO
 }
 

--- a/src/floor/floor-streams.cpp
+++ b/src/floor/floor-streams.cpp
@@ -149,7 +149,7 @@ static void recursive_river(FloorType *floor_ptr, POSITION x1, POSITION y1, POSI
 
                         /* Lava terrain glows */
                         if (terrains_info[feat1].flags.has(TerrainCharacteristics::LAVA)) {
-                            if (dungeons_info[floor_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::DARKNESS)) {
+                            if (floor_ptr->get_dungeon_definition().flags.has_not(DungeonFeatureType::DARKNESS)) {
                                 g_ptr->info |= CAVE_GLOW;
                             }
                         }
@@ -173,16 +173,15 @@ static void recursive_river(FloorType *floor_ptr, POSITION x1, POSITION y1, POSI
  */
 void add_river(FloorType *floor_ptr, dun_data_type *dd_ptr)
 {
-    dungeon_type *dungeon_ptr;
     POSITION y2, x2;
     POSITION y1 = 0, x1 = 0;
     POSITION wid;
     FEAT_IDX feat1 = 0, feat2 = 0;
 
-    dungeon_ptr = &dungeons_info[floor_ptr->dungeon_idx];
+    const auto &dungeon = floor_ptr->get_dungeon_definition();
 
     /* Choose water mainly */
-    if ((randint1(MAX_DEPTH * 2) - 1 > floor_ptr->dun_level) && dungeon_ptr->flags.has(DungeonFeatureType::WATER_RIVER)) {
+    if ((randint1(MAX_DEPTH * 2) - 1 > floor_ptr->dun_level) && dungeon.flags.has(DungeonFeatureType::WATER_RIVER)) {
         feat1 = feat_deep_water;
         feat2 = feat_shallow_water;
     } else /* others */
@@ -191,17 +190,17 @@ void add_river(FloorType *floor_ptr, dun_data_type *dd_ptr)
         FEAT_IDX select_shallow_feat[10];
         int select_id_max = 0, selected;
 
-        if (dungeon_ptr->flags.has(DungeonFeatureType::LAVA_RIVER)) {
+        if (dungeon.flags.has(DungeonFeatureType::LAVA_RIVER)) {
             select_deep_feat[select_id_max] = feat_deep_lava;
             select_shallow_feat[select_id_max] = feat_shallow_lava;
             select_id_max++;
         }
-        if (dungeon_ptr->flags.has(DungeonFeatureType::POISONOUS_RIVER)) {
+        if (dungeon.flags.has(DungeonFeatureType::POISONOUS_RIVER)) {
             select_deep_feat[select_id_max] = feat_deep_poisonous_puddle;
             select_shallow_feat[select_id_max] = feat_shallow_poisonous_puddle;
             select_id_max++;
         }
-        if (dungeon_ptr->flags.has(DungeonFeatureType::ACID_RIVER)) {
+        if (dungeon.flags.has(DungeonFeatureType::ACID_RIVER)) {
             select_deep_feat[select_id_max] = feat_deep_acid_puddle;
             select_shallow_feat[select_id_max] = feat_shallow_acid_puddle;
             select_id_max++;
@@ -470,7 +469,7 @@ void place_trees(PlayerType *player_ptr, POSITION x, POSITION y)
                 g_ptr->mimic = 0;
 
                 /* Light area since is open above */
-                if (dungeons_info[floor_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::DARKNESS)) {
+                if (floor_ptr->get_dungeon_definition().flags.has_not(DungeonFeatureType::DARKNESS)) {
                     floor_ptr->grid_array[j][i].info |= (CAVE_GLOW | CAVE_ROOM);
                 }
             }

--- a/src/floor/floor-util.cpp
+++ b/src/floor/floor-util.cpp
@@ -210,6 +210,6 @@ std::string map_name(PlayerType *player_ptr)
     } else if (!floor_ptr->dun_level && player_ptr->town_num) {
         return towns_info[player_ptr->town_num].name;
     } else {
-        return dungeons_info[floor_ptr->dungeon_idx].name;
+        return floor_ptr->get_dungeon_definition().name;
     }
 }

--- a/src/floor/object-allocator.cpp
+++ b/src/floor/object-allocator.cpp
@@ -83,12 +83,13 @@ bool alloc_stairs(PlayerType *player_ptr, FEAT_IDX feat, int num, int walls)
     int shaft_num = 0;
     auto *f_ptr = &terrains_info[feat];
     auto &floor = *player_ptr->current_floor_ptr;
+    const auto &dungeon = floor.get_dungeon_definition();
     if (f_ptr->flags.has(TerrainCharacteristics::LESS)) {
         if (ironman_downward || !floor.dun_level) {
             return true;
         }
 
-        if (floor.dun_level > dungeons_info[floor.dungeon_idx].mindepth) {
+        if (floor.dun_level > dungeon.mindepth) {
             shaft_num = (randint1(num + 1)) / 2;
         }
     } else if (f_ptr->flags.has(TerrainCharacteristics::MORE)) {
@@ -101,11 +102,11 @@ bool alloc_stairs(PlayerType *player_ptr, FEAT_IDX feat, int num, int walls)
             }
         }
 
-        if (floor.dun_level >= dungeons_info[floor.dungeon_idx].maxdepth) {
+        if (floor.dun_level >= dungeon.maxdepth) {
             return true;
         }
 
-        if ((floor.dun_level < dungeons_info[floor.dungeon_idx].maxdepth - 1) && !inside_quest(quest_number(floor, floor.dun_level + 1))) {
+        if ((floor.dun_level < dungeon.maxdepth - 1) && !inside_quest(quest_number(floor, floor.dun_level + 1))) {
             shaft_num = (randint1(num) + 1) / 2;
         }
     } else {

--- a/src/floor/pattern-walk.cpp
+++ b/src/floor/pattern-walk.cpp
@@ -60,7 +60,7 @@ void pattern_teleport(PlayerType *player_ptr)
                 max_level = 100;
             }
         } else {
-            const auto &dungeon = dungeons_info[floor.dungeon_idx];
+            const auto &dungeon = floor.get_dungeon_definition();
             max_level = dungeon.maxdepth;
             min_level = dungeon.mindepth;
         }

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -122,14 +122,12 @@ void set_floor_and_wall(DUNGEON_IDX type)
     }
 
     cur_type = type;
-    dungeon_type *d_ptr = &dungeons_info[type];
-
-    set_floor_and_wall_aux(feat_ground_type, d_ptr->floor);
-    set_floor_and_wall_aux(feat_wall_type, d_ptr->fill);
-
-    feat_wall_outer = d_ptr->outer_wall;
-    feat_wall_inner = d_ptr->inner_wall;
-    feat_wall_solid = d_ptr->outer_wall;
+    const auto &dungeon = dungeons_info[type];
+    set_floor_and_wall_aux(feat_ground_type, dungeon.floor);
+    set_floor_and_wall_aux(feat_wall_type, dungeon.fill);
+    feat_wall_outer = dungeon.outer_wall;
+    feat_wall_inner = dungeon.inner_wall;
+    feat_wall_solid = dungeon.outer_wall;
 }
 
 /*!

--- a/src/grid/door.cpp
+++ b/src/grid/door.cpp
@@ -64,15 +64,16 @@ void add_door(PlayerType *player_ptr, POSITION x, POSITION y)
 void place_secret_door(PlayerType *player_ptr, POSITION y, POSITION x, int type)
 {
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    if (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_DOORS)) {
+    const auto &dungeon = floor_ptr->get_dungeon_definition();
+    if (dungeon.flags.has(DungeonFeatureType::NO_DOORS)) {
         place_bold(player_ptr, y, x, GB_FLOOR);
         return;
     }
 
     if (type == DOOR_DEFAULT) {
-        type = (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::CURTAIN) && one_in_(dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_CAVE) ? 16 : 256))
+        type = (dungeon.flags.has(DungeonFeatureType::CURTAIN) && one_in_(dungeon.flags.has(DungeonFeatureType::NO_CAVE) ? 16 : 256))
                    ? DOOR_CURTAIN
-                   : (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::GLASS_DOOR) ? DOOR_GLASS_DOOR : DOOR_DOOR);
+                   : (dungeon.flags.has(DungeonFeatureType::GLASS_DOOR) ? DOOR_GLASS_DOOR : DOOR_DOOR);
     }
 
     place_closed_door(player_ptr, y, x, type);
@@ -101,12 +102,13 @@ void place_secret_door(PlayerType *player_ptr, POSITION y, POSITION x, int type)
 void place_locked_door(PlayerType *player_ptr, POSITION y, POSITION x)
 {
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    if (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_DOORS)) {
+    const auto &dungeon = floor_ptr->get_dungeon_definition();
+    if (dungeon.flags.has(DungeonFeatureType::NO_DOORS)) {
         place_bold(player_ptr, y, x, GB_FLOOR);
         return;
     }
 
-    set_cave_feat(floor_ptr, y, x, feat_locked_door_random(dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::GLASS_DOOR) ? DOOR_GLASS_DOOR : DOOR_DOOR));
+    set_cave_feat(floor_ptr, y, x, feat_locked_door_random(dungeon.flags.has(DungeonFeatureType::GLASS_DOOR) ? DOOR_GLASS_DOOR : DOOR_DOOR));
     floor_ptr->grid_array[y][x].info &= ~(CAVE_FLOOR);
     delete_monster(player_ptr, y, x);
 }
@@ -123,15 +125,15 @@ void place_random_door(PlayerType *player_ptr, POSITION y, POSITION x, bool room
     auto *floor_ptr = player_ptr->current_floor_ptr;
     auto *g_ptr = &floor_ptr->grid_array[y][x];
     g_ptr->mimic = 0;
-
-    if (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_DOORS)) {
+    const auto &dungeon = floor_ptr->get_dungeon_definition();
+    if (dungeon.flags.has(DungeonFeatureType::NO_DOORS)) {
         place_bold(player_ptr, y, x, GB_FLOOR);
         return;
     }
 
-    int type = (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::CURTAIN) && one_in_(dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_CAVE) ? 16 : 256))
+    int type = (dungeon.flags.has(DungeonFeatureType::CURTAIN) && one_in_(dungeon.flags.has(DungeonFeatureType::NO_CAVE) ? 16 : 256))
                    ? DOOR_CURTAIN
-                   : (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::GLASS_DOOR) ? DOOR_GLASS_DOOR : DOOR_DOOR);
+                   : (dungeon.flags.has(DungeonFeatureType::GLASS_DOOR) ? DOOR_GLASS_DOOR : DOOR_DOOR);
 
     int tmp = randint0(1000);
     FEAT_IDX feat = feat_none;
@@ -179,7 +181,7 @@ void place_random_door(PlayerType *player_ptr, POSITION y, POSITION x, bool room
 void place_closed_door(PlayerType *player_ptr, POSITION y, POSITION x, int type)
 {
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    if (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_DOORS)) {
+    if (floor_ptr->get_dungeon_definition().flags.has(DungeonFeatureType::NO_DOORS)) {
         place_bold(player_ptr, y, x, GB_FLOOR);
         return;
     }

--- a/src/grid/feature-generator.cpp
+++ b/src/grid/feature-generator.cpp
@@ -201,7 +201,7 @@ void try_door(PlayerType *player_ptr, dt_type *dt_ptr, POSITION y, POSITION x)
 
     bool can_place_door = randint0(100) < dt_ptr->dun_tun_jct;
     can_place_door &= possible_doorway(floor_ptr, y, x);
-    can_place_door &= dungeons_info[floor_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::NO_DOORS);
+    can_place_door &= floor_ptr->get_dungeon_definition().flags.has_not(DungeonFeatureType::NO_DOORS);
     if (can_place_door) {
         place_random_door(player_ptr, y, x, false);
     }

--- a/src/grid/feature.cpp
+++ b/src/grid/feature.cpp
@@ -205,10 +205,11 @@ void cave_set_feat(PlayerType *player_ptr, POSITION y, POSITION x, FEAT_IDX feat
     auto *floor_ptr = player_ptr->current_floor_ptr;
     auto *g_ptr = &floor_ptr->grid_array[y][x];
     auto *f_ptr = &terrains_info[feat];
+    const auto &dungeon = floor_ptr->get_dungeon_definition();
     if (!w_ptr->character_dungeon) {
         g_ptr->mimic = 0;
         g_ptr->feat = feat;
-        if (f_ptr->flags.has(TerrainCharacteristics::GLOW) && dungeons_info[floor_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::DARKNESS)) {
+        if (f_ptr->flags.has(TerrainCharacteristics::GLOW) && dungeon.flags.has_not(DungeonFeatureType::DARKNESS)) {
             for (DIRECTION i = 0; i < 9; i++) {
                 POSITION yy = y + ddy_ddd[i];
                 POSITION xx = x + ddx_ddd[i];
@@ -229,7 +230,7 @@ void cave_set_feat(PlayerType *player_ptr, POSITION y, POSITION x, FEAT_IDX feat
     g_ptr->mimic = 0;
     g_ptr->feat = feat;
     g_ptr->info &= ~(CAVE_OBJECT);
-    if (old_mirror && dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    if (old_mirror && dungeon.flags.has(DungeonFeatureType::DARKNESS)) {
         g_ptr->info &= ~(CAVE_GLOW);
         if (!view_torch_grids) {
             g_ptr->info &= ~(CAVE_MARK);
@@ -258,7 +259,7 @@ void cave_set_feat(PlayerType *player_ptr, POSITION y, POSITION x, FEAT_IDX feat
         RedrawingFlagsUpdater::get_instance().set_flags(flags);
     }
 
-    if (f_ptr->flags.has_not(TerrainCharacteristics::GLOW) || dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    if (f_ptr->flags.has_not(TerrainCharacteristics::GLOW) || dungeon.flags.has(DungeonFeatureType::DARKNESS)) {
         return;
     }
 
@@ -295,6 +296,7 @@ FEAT_IDX conv_dungeon_feat(FloorType *floor_ptr, FEAT_IDX newfeat)
         return newfeat;
     }
 
+    const auto &dungeon = floor_ptr->get_dungeon_definition();
     switch (f_ptr->subtype) {
     case CONVERT_TYPE_FLOOR:
         return rand_choice(feat_ground_type);
@@ -307,9 +309,9 @@ FEAT_IDX conv_dungeon_feat(FloorType *floor_ptr, FEAT_IDX newfeat)
     case CONVERT_TYPE_SOLID:
         return feat_wall_solid;
     case CONVERT_TYPE_STREAM1:
-        return dungeons_info[floor_ptr->dungeon_idx].stream1;
+        return dungeon.stream1;
     case CONVERT_TYPE_STREAM2:
-        return dungeons_info[floor_ptr->dungeon_idx].stream2;
+        return dungeon.stream2;
     default:
         return newfeat;
     }

--- a/src/grid/stair.cpp
+++ b/src/grid/stair.cpp
@@ -35,7 +35,7 @@ void place_random_stairs(PlayerType *player_ptr, POSITION y, POSITION x)
         up_stairs = false;
     }
 
-    if (floor.dun_level >= dungeons_info[floor.dungeon_idx].maxdepth) {
+    if (floor.dun_level >= floor.get_dungeon_definition().maxdepth) {
         down_stairs = false;
     }
 

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -183,7 +183,7 @@ FEAT_IDX choose_random_trap(PlayerType *player_ptr)
         }
 
         /* Hack -- no trap doors on the deepest level */
-        if (floor.dun_level >= dungeons_info[floor.dungeon_idx].maxdepth) {
+        if (floor.dun_level >= floor.get_dungeon_definition().maxdepth) {
             continue;
         }
 

--- a/src/io/input-key-processor.cpp
+++ b/src/io/input-key-processor.cpp
@@ -403,7 +403,7 @@ void process_command(PlayerType *player_ptr)
             break;
         }
 
-        const auto &dungeon = dungeons_info[floor_ptr->dungeon_idx];
+        const auto &dungeon = floor_ptr->get_dungeon_definition();
         auto non_magic_class = pc.equals(PlayerClassType::BERSERKER);
         non_magic_class |= pc.equals(PlayerClassType::SMITH);
         if (floor_ptr->dun_level && dungeon.flags.has(DungeonFeatureType::NO_MAGIC) && !non_magic_class) {

--- a/src/io/write-diary.cpp
+++ b/src/io/write-diary.cpp
@@ -92,10 +92,11 @@ static std::pair<QuestId, std::string> write_floor(const FloorType &floor)
         return make_pair(q_idx, std::string(_("クエスト:", "Quest:")));
     } else {
         char desc[40];
+        const auto &dungeon = floor.get_dungeon_definition();
 #ifdef JP
-        strnfmt(desc, sizeof(desc), "%d階(%s):", (int)floor.dun_level, dungeons_info[floor.dungeon_idx].name.data());
+        strnfmt(desc, sizeof(desc), "%d階(%s):", (int)floor.dun_level, dungeon.name.data());
 #else
-        strnfmt(desc, sizeof(desc), "%s L%d:", dungeons_info[floor.dungeon_idx].name.data(), (int)floor.dun_level);
+        strnfmt(desc, sizeof(desc), "%s L%d:", dungeon.name.data(), (int)floor.dun_level);
 #endif
         return make_pair(q_idx, std::string(desc));
     }
@@ -307,13 +308,13 @@ void exe_write_diary(PlayerType *player_ptr, DiaryKind dk, int num, std::string_
     }
     case DiaryKind::MAXDEAPTH: {
         constexpr auto mes = _(" %2d:%02d %20s %sの最深階%d階に到達した。\n", " %2d:%02d %20s reached level %d of %s for the first time.\n");
-        const auto &dungeon = dungeons_info[floor.dungeon_idx];
+        const auto &dungeon = floor.get_dungeon_definition();
         fprintf(fff, mes, hour, min, note_level.data(), _(dungeon.name.data(), num), _(num, dungeon.name.data()));
         break;
     }
     case DiaryKind::TRUMP: {
         constexpr auto mes = _(" %2d:%02d %20s %s%sの最深階を%d階にセットした。\n", " %2d:%02d %20s reset recall level of %s to %d %s.\n");
-        const auto &dungeon = dungeons_info[floor.dungeon_idx];
+        const auto &dungeon = floor.get_dungeon_definition();
         fprintf(fff, mes, hour, min, note_level.data(), note.data(), _(dungeon.name.data(), (int)max_dlv[num]), _((int)max_dlv[num], dungeon.name.data()));
         break;
     }
@@ -330,7 +331,7 @@ void exe_write_diary(PlayerType *player_ptr, DiaryKind dk, int num, std::string_
     case DiaryKind::RECALL:
         if (!num) {
             constexpr auto mes = _(" %2d:%02d %20s 帰還を使って%sの%d階へ下りた。\n", " %2d:%02d %20s recalled to dungeon level %d of %s.\n");
-            const auto &dungeon = dungeons_info[floor.dungeon_idx];
+            const auto &dungeon = floor.get_dungeon_definition();
             fprintf(fff, mes, hour, min, note_level.data(), _(dungeon.name.data(), (int)max_dlv[floor.dungeon_idx]), _((int)max_dlv[floor.dungeon_idx], dungeon.name.data()));
         } else {
             constexpr auto mes = _(" %2d:%02d %20s 帰還を使って地上へと戻った。\n", " %2d:%02d %20s recalled from dungeon to surface.\n");
@@ -382,7 +383,7 @@ void exe_write_diary(PlayerType *player_ptr, DiaryKind dk, int num, std::string_
         const auto &floor_ref = *player_ptr->current_floor_ptr;
         auto to = !floor_ref.is_in_dungeon()
                       ? _("地上", "the surface")
-                      : format(_("%d階(%s)", "level %d of %s"), floor.dun_level, dungeons_info[floor.dungeon_idx].name.data());
+                      : format(_("%d階(%s)", "level %d of %s"), floor.dun_level, floor.get_dungeon_definition().name.data());
         constexpr auto mes = _(" %2d:%02d %20s %sへとパターンの力で移動した。\n", " %2d:%02d %20s used Pattern to teleport to %s.\n");
         fprintf(fff, mes, hour, min, note_level.data(), to.data());
         break;

--- a/src/load/dungeon-loader.cpp
+++ b/src/load/dungeon-loader.cpp
@@ -41,7 +41,7 @@ static errr rd_dungeon(PlayerType *player_ptr)
     }
 
     max_floor_id = rd_s16b();
-    floor.dungeon_idx = rd_byte(); // @todo セーブデータの方を16ビットにするかdungeon_idxの定義を8ビットにした方が良い.
+    floor.set_dungeon_index(rd_byte()); // @todo セーブデータの方を16ビットにするかdungeon_idxの定義を8ビットにした方が良い.
     auto num = rd_byte();
     if (num == 0) {
         err = rd_saved_floor(player_ptr, nullptr);

--- a/src/load/old/load-v1-5-0.cpp
+++ b/src/load/old/load-v1-5-0.cpp
@@ -557,9 +557,9 @@ errr rd_dungeon_old(PlayerType *player_ptr)
     auto *floor_ptr = player_ptr->current_floor_ptr;
     floor_ptr->dun_level = rd_s16b();
     if (h_older_than(0, 3, 8)) {
-        floor_ptr->dungeon_idx = DUNGEON_ANGBAND;
+        floor_ptr->set_dungeon_index(DUNGEON_ANGBAND);
     } else {
-        floor_ptr->dungeon_idx = rd_byte();
+        floor_ptr->set_dungeon_index(rd_byte());
     }
 
     floor_ptr->base_level = floor_ptr->dun_level;

--- a/src/load/old/load-v1-7-0.cpp
+++ b/src/load/old/load-v1-7-0.cpp
@@ -34,7 +34,7 @@ void remove_water_cave(PlayerType *player_ptr)
         return;
     }
 
-    floor.dungeon_idx = lite_town ? DUNGEON_ANGBAND : DUNGEON_GALGALS;
+    floor.set_dungeon_index(lite_town ? DUNGEON_ANGBAND : DUNGEON_GALGALS);
     floor.dun_level = 1;
     floor.quest_number = QuestId::NONE;
 }

--- a/src/melee/melee-spell-util.cpp
+++ b/src/melee/melee-spell-util.cpp
@@ -26,7 +26,7 @@ melee_spell_type *initialize_melee_spell_type(PlayerType *player_ptr, melee_spel
     ms_ptr->see_m = is_seen(player_ptr, ms_ptr->m_ptr);
     ms_ptr->maneable = player_has_los_bold(player_ptr, ms_ptr->m_ptr->fy, ms_ptr->m_ptr->fx);
     ms_ptr->pet = ms_ptr->m_ptr->is_pet();
-    const auto &dungeon = dungeons_info[floor_ptr->dungeon_idx];
+    const auto &dungeon = floor_ptr->get_dungeon_definition();
     const auto is_in_dungeon = floor_ptr->is_in_dungeon();
     const auto is_in_random_quest = inside_quest(floor_ptr->quest_number) && !QuestType::is_fixed(floor_ptr->quest_number);
     ms_ptr->in_no_magic_dungeon = dungeon.flags.has(DungeonFeatureType::NO_MAGIC) && is_in_dungeon && !is_in_random_quest;

--- a/src/monster-attack/monster-attack-processor.cpp
+++ b/src/monster-attack/monster-attack-processor.cpp
@@ -51,7 +51,7 @@ void exe_monster_attack_to_player(PlayerType *player_ptr, turn_flags *turn_flags
         turn_flags_ptr->do_move = false;
     }
 
-    if (turn_flags_ptr->do_move && dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE) && !m_ptr->is_confused()) {
+    if (turn_flags_ptr->do_move && floor.get_dungeon_definition().flags.has(DungeonFeatureType::NO_MELEE) && !m_ptr->is_confused()) {
         if (r_ptr->behavior_flags.has_not(MonsterBehaviorType::STUPID)) {
             turn_flags_ptr->do_move = false;
         } else if (is_original_ap_and_seen(player_ptr, m_ptr)) {
@@ -97,7 +97,7 @@ static bool exe_monster_attack_to_monster(PlayerType *player_ptr, MONSTER_IDX m_
     if (monst_attack_monst(player_ptr, m_idx, g_ptr->m_idx)) {
         return true;
     }
-    if (dungeons_info[floor.dungeon_idx].flags.has_not(DungeonFeatureType::NO_MELEE)) {
+    if (floor.get_dungeon_definition().flags.has_not(DungeonFeatureType::NO_MELEE)) {
         return false;
     }
     if (m_ptr->is_confused()) {

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -215,7 +215,7 @@ static void drop_artifacts(PlayerType *player_ptr, monster_death_type *md_ptr)
 
     drop_artifact_from_unique(player_ptr, md_ptr);
     const auto *floor_ptr = player_ptr->current_floor_ptr;
-    const auto &dungeon = dungeons_info[floor_ptr->dungeon_idx];
+    const auto &dungeon = floor_ptr->get_dungeon_definition();
     if (((md_ptr->r_ptr->flags7 & RF7_GUARDIAN) == 0) || (dungeon.final_guardian != md_ptr->m_ptr->r_idx)) {
         return;
     }

--- a/src/monster-floor/monster-generator.cpp
+++ b/src/monster-floor/monster-generator.cpp
@@ -473,9 +473,10 @@ bool alloc_horde(PlayerType *player_ptr, POSITION y, POSITION x, summon_specific
 bool alloc_guardian(PlayerType *player_ptr, bool def_val)
 {
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    MonsterRaceId guardian = dungeons_info[floor_ptr->dungeon_idx].final_guardian;
+    const auto &dungeon = floor_ptr->get_dungeon_definition();
+    MonsterRaceId guardian = dungeon.final_guardian;
     bool is_guardian_applicable = MonsterRace(guardian).is_valid();
-    is_guardian_applicable &= dungeons_info[floor_ptr->dungeon_idx].maxdepth == floor_ptr->dun_level;
+    is_guardian_applicable &= dungeon.maxdepth == floor_ptr->dun_level;
     is_guardian_applicable &= monraces_info[guardian].cur_num < monraces_info[guardian].max_num;
     if (!is_guardian_applicable) {
         return def_val;

--- a/src/monster-floor/monster-lite.cpp
+++ b/src/monster-floor/monster-lite.cpp
@@ -153,7 +153,7 @@ void update_mon_lite(PlayerType *player_ptr)
 
     void (*add_mon_lite)(PlayerType *, std::vector<Pos2D> &, const POSITION, const POSITION, const monster_lite_type *);
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    const auto &dungeon = dungeons_info[floor_ptr->dungeon_idx];
+    const auto &dungeon = floor_ptr->get_dungeon_definition();
     auto dis_lim = (dungeon.flags.has(DungeonFeatureType::DARKNESS) && !player_ptr->see_nocto) ? (MAX_PLAYER_SIGHT / 2 + 1) : (MAX_PLAYER_SIGHT + 3);
     for (int i = 0; i < floor_ptr->mon_lite_n; i++) {
         grid_type *g_ptr;
@@ -199,7 +199,7 @@ void update_mon_lite(PlayerType *player_ptr)
                     continue;
                 }
 
-                if (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+                if (dungeon.flags.has(DungeonFeatureType::DARKNESS)) {
                     rad = 1;
                 }
 

--- a/src/monster-floor/monster-summon.cpp
+++ b/src/monster-floor/monster-summon.cpp
@@ -73,7 +73,7 @@ static bool summon_specific_okay(PlayerType *player_ptr, MonsterRaceId r_idx)
         return false;
     }
 
-    if ((r_ptr->flags7 & RF7_CHAMELEON) && dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::CHAMELEON)) {
+    if ((r_ptr->flags7 & RF7_CHAMELEON) && floor.get_dungeon_definition().flags.has(DungeonFeatureType::CHAMELEON)) {
         return true;
     }
 

--- a/src/monster-race/monster-race-hook.cpp
+++ b/src/monster-race/monster-race-hook.cpp
@@ -132,7 +132,7 @@ bool mon_hook_dungeon(PlayerType *player_ptr, MonsterRaceId r_idx)
     }
 
     auto *r_ptr = &monraces_info[r_idx];
-    dungeon_type *d_ptr = &dungeons_info[floor.dungeon_idx];
+    dungeon_type *d_ptr = &floor.get_dungeon_definition();
     if (r_ptr->wilderness_flags.has(MonsterWildernessType::WILD_ONLY)) {
         return d_ptr->mon_wilderness_flags.has(MonsterWildernessType::WILD_MOUNTAIN) && r_ptr->wilderness_flags.has(MonsterWildernessType::WILD_MOUNTAIN);
     }

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -343,7 +343,7 @@ void choose_new_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, bool born, Mo
             level = floor_ptr->dun_level;
         }
 
-        if (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::CHAMELEON)) {
+        if (floor_ptr->get_dungeon_definition().flags.has(DungeonFeatureType::CHAMELEON)) {
             level += 2 + randint1(3);
         }
 

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -116,7 +116,8 @@ MonsterRaceId get_mon_num(PlayerType *player_ptr, DEPTH min_level, DEPTH max_lev
     auto chance_nasty = std::max(max_num_nasty_monsters, chance_nasty_monster - over_days / 2);
     auto nasty_level = std::min(max_depth_nasty_monster, over_days / 3);
     const auto &floor = *player_ptr->current_floor_ptr;
-    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::MAZE)) {
+    const auto &dungeon = floor.get_dungeon_definition();
+    if (dungeon.flags.has(DungeonFeatureType::MAZE)) {
         chance_nasty = std::min(chance_nasty / 2, chance_nasty - 10);
         if (chance_nasty < 2) {
             chance_nasty = 2;
@@ -127,7 +128,7 @@ MonsterRaceId get_mon_num(PlayerType *player_ptr, DEPTH min_level, DEPTH max_lev
     }
 
     /* Boost the max_level */
-    if ((option & GMN_ARENA) || dungeons_info[floor.dungeon_idx].flags.has_not(DungeonFeatureType::BEGINNER)) {
+    if ((option & GMN_ARENA) || dungeon.flags.has_not(DungeonFeatureType::BEGINNER)) {
         /* Nightmare mode allows more out-of depth monsters */
         if (ironman_nightmare && !randint0(chance_nasty)) {
             /* What a bizarre calculation */

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -194,7 +194,7 @@ static um_type *initialize_um_type(PlayerType *player_ptr, um_type *um_ptr, MONS
     um_ptr->fx = um_ptr->m_ptr->fx;
     um_ptr->flag = false;
     um_ptr->easy = false;
-    um_ptr->in_darkness = dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS) && !player_ptr->see_nocto;
+    um_ptr->in_darkness = floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS) && !player_ptr->see_nocto;
     um_ptr->full = full;
     return um_ptr;
 }

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -81,7 +81,7 @@ static bool is_possible_monster_or(const EnumClassFlagGroup<T> &r_flags, const E
  */
 static bool restrict_monster_to_dungeon(const FloorType *floor_ptr, MonsterRaceId r_idx)
 {
-    const auto *d_ptr = &dungeons_info[floor_ptr->dungeon_idx];
+    const auto *d_ptr = &floor_ptr->get_dungeon_definition();
     const auto *r_ptr = &monraces_info[r_idx];
     if (d_ptr->flags.has(DungeonFeatureType::CHAMELEON)) {
         if (chameleon_change_m_idx) {
@@ -308,7 +308,7 @@ static errr do_get_mon_num_prep(PlayerType *player_ptr, const monsterrace_hook_t
             if (cond && !restrict_monster_to_dungeon(floor_ptr, entry_r_idx)) {
                 // ダンジョンによる制約に掛かった場合、重みを special_div/64 倍する。
                 // 丸めは確率的に行う。
-                const int numer = entry->prob2 * dungeons_info[floor_ptr->dungeon_idx].special_div;
+                const int numer = entry->prob2 * floor_ptr->get_dungeon_definition().special_div;
                 const int q = numer / 64;
                 const int r = numer % 64;
                 entry->prob2 = (PROB)(randint0(64) < r ? q + 1 : q);

--- a/src/mspell/mspell-attack.cpp
+++ b/src/mspell/mspell-attack.cpp
@@ -57,7 +57,7 @@ static void set_no_magic_mask(msa_type *msa_ptr)
 static void check_mspell_stupid(PlayerType *player_ptr, msa_type *msa_ptr)
 {
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    msa_ptr->in_no_magic_dungeon = dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_MAGIC) && floor_ptr->dun_level && (!inside_quest(floor_ptr->quest_number) || QuestType::is_fixed(floor_ptr->quest_number));
+    msa_ptr->in_no_magic_dungeon = floor_ptr->get_dungeon_definition().flags.has(DungeonFeatureType::NO_MAGIC) && floor_ptr->dun_level && (!inside_quest(floor_ptr->quest_number) || QuestType::is_fixed(floor_ptr->quest_number));
     if (!msa_ptr->in_no_magic_dungeon || (msa_ptr->r_ptr->behavior_flags.has(MonsterBehaviorType::STUPID))) {
         return;
     }

--- a/src/object-enchant/item-magic-applier.cpp
+++ b/src/object-enchant/item-magic-applier.cpp
@@ -75,7 +75,7 @@ std::tuple<int, int> ItemMagicApplier::calculate_chances()
 {
     auto chance_good = this->lev + 10;
     const auto &floor = *this->player_ptr->current_floor_ptr;
-    const auto &dungeon = dungeons_info[floor.dungeon_idx];
+    const auto &dungeon = floor.get_dungeon_definition();
     if (chance_good > dungeon.obj_good) {
         chance_good = dungeon.obj_good;
     }

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -360,6 +360,7 @@ bool process_warning(PlayerType *player_ptr, POSITION xx, POSITION yy)
     static int old_damage = 0;
 
     auto &floor = *player_ptr->current_floor_ptr;
+    const auto &dungeon = floor.get_dungeon_definition();
     for (mx = xx - WARNING_AWARE_RANGE; mx < xx + WARNING_AWARE_RANGE + 1; mx++) {
         for (my = yy - WARNING_AWARE_RANGE; my < yy + WARNING_AWARE_RANGE + 1; my++) {
             int dam_max0 = 0;
@@ -388,7 +389,7 @@ bool process_warning(PlayerType *player_ptr, POSITION xx, POSITION yy)
             if (projectable(player_ptr, my, mx, yy, xx)) {
                 const auto flags = r_ptr->ability_flags;
 
-                if (dungeons_info[floor.dungeon_idx].flags.has_not(DungeonFeatureType::NO_MAGIC)) {
+                if (dungeon.flags.has_not(DungeonFeatureType::NO_MAGIC)) {
                     if (flags.has(MonsterAbilityType::BA_CHAO)) {
                         spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BA_CHAO, AttributeType::CHAOS, g_ptr->m_idx, &dam_max0);
                     }
@@ -492,7 +493,7 @@ bool process_warning(PlayerType *player_ptr, POSITION xx, POSITION yy)
                 }
             }
             /* Monster melee attacks */
-            if (r_ptr->behavior_flags.has(MonsterBehaviorType::NEVER_BLOW) || dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE)) {
+            if (r_ptr->behavior_flags.has(MonsterBehaviorType::NEVER_BLOW) || dungeon.flags.has(DungeonFeatureType::NO_MELEE)) {
                 dam_max += dam_max0;
                 continue;
             }

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -193,7 +193,7 @@ bool move_player_effect(PlayerType *player_ptr, POSITION ny, POSITION nx, BIT_FL
             g_ptr->info &= ~(CAVE_UNSAFE);
         }
 
-        if (floor_ptr->dun_level && dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::FORGET)) {
+        if (floor_ptr->dun_level && floor_ptr->get_dungeon_definition().flags.has(DungeonFeatureType::FORGET)) {
             wiz_dark(player_ptr);
         }
 

--- a/src/racial/racial-vampire.cpp
+++ b/src/racial/racial-vampire.cpp
@@ -15,7 +15,7 @@
 bool vampirism(PlayerType *player_ptr)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
-    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE)) {
+    if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::NO_MELEE)) {
         msg_print(_("なぜか攻撃することができない。", "Something prevents you from attacking."));
         return false;
     }

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -394,7 +394,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
                 return std::nullopt;
             }
-            if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE)) {
+            if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::NO_MELEE)) {
                 return "";
             }
             if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
@@ -824,7 +824,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                     return std::nullopt;
                 }
 
-                if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE)) {
+                if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::NO_MELEE)) {
                     return "";
                 }
 
@@ -1052,7 +1052,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             x = player_ptr->x + ddx[dir];
 
             auto &floor = *player_ptr->current_floor_ptr;
-            if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::NO_MELEE)) {
+            if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::NO_MELEE)) {
                 msg_print(_("なぜか攻撃することができない。", "Something prevents you from attacking."));
                 return "";
             }

--- a/src/room/cave-filler.cpp
+++ b/src/room/cave-filler.cpp
@@ -490,7 +490,7 @@ bool generate_lake(PlayerType *player_ptr, POSITION y0, POSITION x0, POSITION xs
 
             floor_ptr->grid_array[y0 + y - yhsize][x0 + x - xhsize].info &= ~(CAVE_ICKY | CAVE_ROOM);
             if (cave_has_flag_bold(floor_ptr, y0 + y - yhsize, x0 + x - xhsize, TerrainCharacteristics::LAVA)) {
-                if (dungeons_info[floor_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::DARKNESS)) {
+                if (floor_ptr->get_dungeon_definition().flags.has_not(DungeonFeatureType::DARKNESS)) {
                     floor_ptr->grid_array[y0 + y - yhsize][x0 + x - xhsize].info |= CAVE_GLOW;
                 }
             }

--- a/src/room/room-generator.cpp
+++ b/src/room/room-generator.cpp
@@ -110,7 +110,8 @@ bool generate_rooms(PlayerType *player_ptr, dun_data_type *dd_ptr)
      * かつ「常に通常でない部屋を生成する」フラグがONならば、
      * GRATER_VAULTのみを生成対象とする。 / Ironman sees only Greater Vaults
      */
-    if (ironman_rooms && dungeons_info[floor_ptr->dungeon_idx].flags.has_none_of({ DungeonFeatureType::BEGINNER, DungeonFeatureType::CHAMELEON, DungeonFeatureType::SMALLEST })) {
+    const auto &dungeon = floor_ptr->get_dungeon_definition();
+    if (ironman_rooms && dungeon.flags.has_none_of({ DungeonFeatureType::BEGINNER, DungeonFeatureType::CHAMELEON, DungeonFeatureType::SMALLEST })) {
         for (auto r : ROOM_TYPE_LIST) {
             if (r == RoomType::GREATER_VAULT) {
                 prob_list[r] = 1;
@@ -118,7 +119,7 @@ bool generate_rooms(PlayerType *player_ptr, dun_data_type *dd_ptr)
                 prob_list[r] = 0;
             }
         }
-    } else if (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_VAULT)) {
+    } else if (dungeon.flags.has(DungeonFeatureType::NO_VAULT)) {
         /*! @details ダンジョンにNO_VAULTフラグがあるならば、LESSER_VAULT / GREATER_VAULT/ RANDOM_VAULTを除外 / Forbidden vaults */
         prob_list[RoomType::LESSER_VAULT] = 0;
         prob_list[RoomType::GREATER_VAULT] = 0;
@@ -126,16 +127,16 @@ bool generate_rooms(PlayerType *player_ptr, dun_data_type *dd_ptr)
     }
 
     /*! @details ダンジョンにBEGINNERフラグがあるならば、FIXED_ROOMを除外 / Forbidden vaults */
-    if (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::BEGINNER)) {
+    if (dungeon.flags.has(DungeonFeatureType::BEGINNER)) {
         prob_list[RoomType::FIXED] = 0;
     }
 
     /*! @details ダンジョンにNO_CAVEフラグがある場合、FRACAVEの生成枠がNORMALに与えられる。CRIPT、OVALの生成枠がINNER_Fに与えられる。/ NO_CAVE dungeon */
-    if (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_CAVE)) {
+    if (dungeon.flags.has(DungeonFeatureType::NO_CAVE)) {
         move_prob_list(RoomType::NORMAL, RoomType::FRACAVE, prob_list);
         move_prob_list(RoomType::INNER_FEAT, RoomType::CRYPT, prob_list);
         move_prob_list(RoomType::INNER_FEAT, RoomType::OVAL, prob_list);
-    } else if (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::CAVE)) {
+    } else if (dungeon.flags.has(DungeonFeatureType::CAVE)) {
         /*! @details ダンジョンにCAVEフラグがある場合、NORMALの生成枠がFRACAVEに与えられる。/ CAVE dungeon (Orc floor_ptr->grid_array etc.) */
         move_prob_list(RoomType::FRACAVE, RoomType::NORMAL, prob_list);
     } else if (dd_ptr->cavern || dd_ptr->empty_level) {
@@ -144,12 +145,12 @@ bool generate_rooms(PlayerType *player_ptr, dun_data_type *dd_ptr)
     }
 
     /*! @details ダンジョンに最初からGLASS_ROOMフラグがある場合、GLASS を生成から除外。/ Forbidden glass rooms */
-    if (dungeons_info[floor_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::GLASS_ROOM)) {
+    if (dungeon.flags.has_not(DungeonFeatureType::GLASS_ROOM)) {
         prob_list[RoomType::GLASS] = 0;
     }
 
     /*! @details ARCADEは同フラグがダンジョンにないと生成されない。 / Forbidden glass rooms */
-    if (dungeons_info[floor_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::ARCADE)) {
+    if (dungeon.flags.has_not(DungeonFeatureType::ARCADE)) {
         prob_list[RoomType::ARCADE] = 0;
     }
 

--- a/src/room/rooms-builder.cpp
+++ b/src/room/rooms-builder.cpp
@@ -91,7 +91,7 @@ void build_cavern(PlayerType *player_ptr)
     bool light = false;
     bool done = false;
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    if ((floor_ptr->dun_level <= randint1(50)) && dungeons_info[floor_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::DARKNESS)) {
+    if ((floor_ptr->dun_level <= randint1(50)) && floor_ptr->get_dungeon_definition().flags.has_not(DungeonFeatureType::DARKNESS)) {
         light = true;
     }
 

--- a/src/room/rooms-fractal.cpp
+++ b/src/room/rooms-fractal.cpp
@@ -44,7 +44,7 @@ bool build_type9(PlayerType *player_ptr, dun_data_type *dd_ptr)
     light = done = false;
     room = true;
 
-    if ((floor_ptr->dun_level <= randint1(25)) && dungeons_info[floor_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::DARKNESS)) {
+    if ((floor_ptr->dun_level <= randint1(25)) && floor_ptr->get_dungeon_definition().flags.has_not(DungeonFeatureType::DARKNESS)) {
         light = true;
     }
 

--- a/src/room/rooms-maze-vault.cpp
+++ b/src/room/rooms-maze-vault.cpp
@@ -101,7 +101,7 @@ void build_maze_vault(PlayerType *player_ptr, POSITION x0, POSITION y0, POSITION
 {
     msg_print_wizard(player_ptr, CHEAT_DUNGEON, _("迷路ランダムVaultを生成しました。", "Maze Vault."));
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    bool light = ((floor_ptr->dun_level <= randint1(25)) && is_vault && dungeons_info[floor_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::DARKNESS));
+    bool light = ((floor_ptr->dun_level <= randint1(25)) && is_vault && floor_ptr->get_dungeon_definition().flags.has_not(DungeonFeatureType::DARKNESS));
     POSITION dy = ysize / 2 - 1;
     POSITION dx = xsize / 2 - 1;
     POSITION y1 = y0 - dy;

--- a/src/room/rooms-normal.cpp
+++ b/src/room/rooms-normal.cpp
@@ -29,7 +29,8 @@ bool build_type1(PlayerType *player_ptr, dun_data_type *dd_ptr)
     grid_type *g_ptr;
 
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    bool curtain = (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::CURTAIN)) && one_in_(dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_CAVE) ? 48 : 512);
+    const auto &dungeon = floor_ptr->get_dungeon_definition();
+    bool curtain = (dungeon.flags.has(DungeonFeatureType::CURTAIN)) && one_in_(dungeon.flags.has(DungeonFeatureType::NO_CAVE) ? 48 : 512);
 
     /* Pick a room size */
     y1 = randint1(4);
@@ -58,7 +59,7 @@ bool build_type1(PlayerType *player_ptr, dun_data_type *dd_ptr)
     }
 
     /* Choose lite or dark */
-    light = ((floor_ptr->dun_level <= randint1(25)) && dungeons_info[floor_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::DARKNESS));
+    light = ((floor_ptr->dun_level <= randint1(25)) && dungeon.flags.has_not(DungeonFeatureType::DARKNESS));
 
     /* Get corner values */
     y1 = yval - ysize / 2;
@@ -156,7 +157,7 @@ bool build_type1(PlayerType *player_ptr, dun_data_type *dd_ptr)
     }
     /* Hack -- Occasional divided room */
     else if (one_in_(50)) {
-        bool curtain2 = (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::CURTAIN)) && one_in_(dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_CAVE) ? 2 : 128);
+        bool curtain2 = (dungeon.flags.has(DungeonFeatureType::CURTAIN)) && one_in_(dungeon.flags.has(DungeonFeatureType::NO_CAVE) ? 2 : 128);
 
         if (randint1(100) < 50) {
             /* Horizontal wall */
@@ -212,7 +213,7 @@ bool build_type2(PlayerType *player_ptr, dun_data_type *dd_ptr)
     }
 
     /* Choose lite or dark */
-    light = ((floor_ptr->dun_level <= randint1(25)) && dungeons_info[floor_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::DARKNESS));
+    light = ((floor_ptr->dun_level <= randint1(25)) && floor_ptr->get_dungeon_definition().flags.has_not(DungeonFeatureType::DARKNESS));
 
     /* Determine extents of the first room */
     y1a = yval - randint1(4);
@@ -326,7 +327,8 @@ bool build_type3(PlayerType *player_ptr, dun_data_type *dd_ptr)
     }
 
     /* Choose lite or dark */
-    light = ((floor_ptr->dun_level <= randint1(25)) && dungeons_info[floor_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::DARKNESS));
+    const auto &dungeon = floor_ptr->get_dungeon_definition();
+    light = ((floor_ptr->dun_level <= randint1(25)) && dungeon.flags.has_not(DungeonFeatureType::DARKNESS));
 
     /* For now, always 3x3 */
     wx = wy = 1;
@@ -502,9 +504,9 @@ bool build_type3(PlayerType *player_ptr, dun_data_type *dd_ptr)
 
             /* Sometimes shut using secret doors */
             if (one_in_(3)) {
-                int door_type = (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::CURTAIN) && one_in_(dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_CAVE) ? 16 : 256))
+                int door_type = (dungeon.flags.has(DungeonFeatureType::CURTAIN) && one_in_(dungeon.flags.has(DungeonFeatureType::NO_CAVE) ? 16 : 256))
                                     ? DOOR_CURTAIN
-                                    : (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::GLASS_DOOR) ? DOOR_GLASS_DOOR : DOOR_DOOR);
+                                    : (dungeon.flags.has(DungeonFeatureType::GLASS_DOOR) ? DOOR_GLASS_DOOR : DOOR_DOOR);
 
                 place_secret_door(player_ptr, yval, x1a - 1, door_type);
                 place_secret_door(player_ptr, yval, x2a + 1, door_type);
@@ -560,12 +562,13 @@ bool build_type4(PlayerType *player_ptr, dun_data_type *dd_ptr)
 
     /* Find and reserve some space in the dungeon.  Get center of room. */
     auto *floor_ptr = player_ptr->current_floor_ptr;
+    const auto &dungeon = floor_ptr->get_dungeon_definition();
     if (!find_space(player_ptr, dd_ptr, &yval, &xval, 11, 25)) {
         return false;
     }
 
     /* Choose lite or dark */
-    light = ((floor_ptr->dun_level <= randint1(25)) && dungeons_info[floor_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::DARKNESS));
+    light = ((floor_ptr->dun_level <= randint1(25)) && dungeon.flags.has_not(DungeonFeatureType::DARKNESS));
 
     /* Large room */
     y1 = yval - 4;
@@ -752,9 +755,9 @@ bool build_type4(PlayerType *player_ptr, dun_data_type *dd_ptr)
 
         /* Occasionally, some Inner rooms */
         if (one_in_(3)) {
-            int door_type = (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::CURTAIN) && one_in_(dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_CAVE) ? 16 : 256))
+            int door_type = (dungeon.flags.has(DungeonFeatureType::CURTAIN) && one_in_(dungeon.flags.has(DungeonFeatureType::NO_CAVE) ? 16 : 256))
                                 ? DOOR_CURTAIN
-                                : (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::GLASS_DOOR) ? DOOR_GLASS_DOOR : DOOR_DOOR);
+                                : (dungeon.flags.has(DungeonFeatureType::GLASS_DOOR) ? DOOR_GLASS_DOOR : DOOR_DOOR);
 
             /* Long horizontal walls */
             for (x = xval - 5; x <= xval + 5; x++) {
@@ -834,9 +837,9 @@ bool build_type4(PlayerType *player_ptr, dun_data_type *dd_ptr)
 
     /* Four small rooms. */
     case 5: {
-        int door_type = (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::CURTAIN) && one_in_(dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_CAVE) ? 16 : 256))
+        int door_type = (dungeon.flags.has(DungeonFeatureType::CURTAIN) && one_in_(dungeon.flags.has(DungeonFeatureType::NO_CAVE) ? 16 : 256))
                             ? DOOR_CURTAIN
-                            : (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::GLASS_DOOR) ? DOOR_GLASS_DOOR : DOOR_DOOR);
+                            : (dungeon.flags.has(DungeonFeatureType::GLASS_DOOR) ? DOOR_GLASS_DOOR : DOOR_DOOR);
 
         /* Inner "cross" */
         for (y = y1; y <= y2; y++) {
@@ -895,7 +898,7 @@ bool build_type11(PlayerType *player_ptr, dun_data_type *dd_ptr)
 
     /* Occasional light */
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    if ((randint1(floor_ptr->dun_level) <= 15) && dungeons_info[floor_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::DARKNESS)) {
+    if ((randint1(floor_ptr->dun_level) <= 15) && floor_ptr->get_dungeon_definition().flags.has_not(DungeonFeatureType::DARKNESS)) {
         light = true;
     }
 
@@ -949,7 +952,7 @@ bool build_type12(PlayerType *player_ptr, dun_data_type *dd_ptr)
 
     /* Occasional light */
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    if ((randint1(floor_ptr->dun_level) <= 5) && dungeons_info[floor_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::DARKNESS)) {
+    if ((randint1(floor_ptr->dun_level) <= 5) && floor_ptr->get_dungeon_definition().flags.has_not(DungeonFeatureType::DARKNESS)) {
         light = true;
     }
 

--- a/src/room/rooms-pit-nest.cpp
+++ b/src/room/rooms-pit-nest.cpp
@@ -232,7 +232,7 @@ bool build_type5(PlayerType *player_ptr, dun_data_type *dd_ptr)
     grid_type *g_ptr;
 
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    int cur_nest_type = pick_vault_type(floor_ptr, nest_types, dungeons_info[floor_ptr->dungeon_idx].nest);
+    int cur_nest_type = pick_vault_type(floor_ptr, nest_types, floor_ptr->get_dungeon_definition().nest);
     nest_pit_type *n_ptr;
 
     /* No type available */
@@ -475,7 +475,7 @@ bool build_type6(PlayerType *player_ptr, dun_data_type *dd_ptr)
     grid_type *g_ptr;
 
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    int cur_pit_type = pick_vault_type(floor_ptr, pit_types, dungeons_info[floor_ptr->dungeon_idx].pit);
+    int cur_pit_type = pick_vault_type(floor_ptr, pit_types, floor_ptr->get_dungeon_definition().pit);
     nest_pit_type *n_ptr;
 
     /* No type available */
@@ -785,7 +785,7 @@ bool build_type13(PlayerType *player_ptr, dun_data_type *dd_ptr)
     grid_type *g_ptr;
 
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    int cur_pit_type = pick_vault_type(floor_ptr, pit_types, dungeons_info[floor_ptr->dungeon_idx].pit);
+    int cur_pit_type = pick_vault_type(floor_ptr, pit_types, floor_ptr->get_dungeon_definition().pit);
     nest_pit_type *n_ptr;
 
     /* Only in Angband */

--- a/src/room/rooms-special.cpp
+++ b/src/room/rooms-special.cpp
@@ -47,7 +47,7 @@ bool build_type15(PlayerType *player_ptr, dun_data_type *dd_ptr)
     }
 
     /* Choose lite or dark */
-    light = ((floor_ptr->dun_level <= randint1(25)) && dungeons_info[floor_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::DARKNESS));
+    light = ((floor_ptr->dun_level <= randint1(25)) && floor_ptr->get_dungeon_definition().flags.has_not(DungeonFeatureType::DARKNESS));
 
     /* Get corner values */
     y1 = yval - ysize / 2;

--- a/src/room/rooms-trap.cpp
+++ b/src/room/rooms-trap.cpp
@@ -45,7 +45,7 @@ bool build_type14(PlayerType *player_ptr, dun_data_type *dd_ptr)
 
     /* Choose lite or dark */
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    light = ((floor_ptr->dun_level <= randint1(25)) && dungeons_info[floor_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::DARKNESS));
+    light = ((floor_ptr->dun_level <= randint1(25)) && floor_ptr->get_dungeon_definition().flags.has_not(DungeonFeatureType::DARKNESS));
 
     /* Get corner values */
     y1 = yval - ysize / 2;

--- a/src/room/rooms-vault.cpp
+++ b/src/room/rooms-vault.cpp
@@ -962,7 +962,7 @@ bool build_type10(PlayerType *player_ptr, dun_data_type *dd_ptr)
     /* Select type of vault */
     do {
         vtype = randint1(15);
-    } while (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::NO_CAVE) && ((vtype == 1) || (vtype == 3) || (vtype == 8) || (vtype == 9) || (vtype == 11)));
+    } while (floor_ptr->get_dungeon_definition().flags.has(DungeonFeatureType::NO_CAVE) && ((vtype == 1) || (vtype == 3) || (vtype == 8) || (vtype == 9) || (vtype == 11)));
 
     switch (vtype) {
         /* Build an appropriate room */

--- a/src/spell-class/spells-mirror-master.cpp
+++ b/src/spell-class/spells-mirror-master.cpp
@@ -55,7 +55,7 @@ void SpellsMirrorMaster::remove_mirror(int y, int x)
     auto *g_ptr = &floor.grid_array[y][x];
     reset_bits(g_ptr->info, CAVE_OBJECT);
     g_ptr->mimic = 0;
-    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         reset_bits(g_ptr->info, CAVE_GLOW);
         if (!view_torch_grids) {
             reset_bits(g_ptr->info, CAVE_MARK);

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -338,7 +338,7 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
                 continue;
             }
 
-            if (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+            if (floor_ptr->get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
                 continue;
             }
 

--- a/src/spell-kind/spells-detection.cpp
+++ b/src/spell-kind/spells-detection.cpp
@@ -41,7 +41,7 @@
 static bool detect_feat_flag(PlayerType *player_ptr, POSITION range, TerrainCharacteristics flag, bool known)
 {
     auto &floor = *player_ptr->current_floor_ptr;
-    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
 
@@ -179,7 +179,7 @@ bool detect_objects_gold(PlayerType *player_ptr, POSITION range)
 {
     auto &floor = *player_ptr->current_floor_ptr;
     POSITION range2 = range;
-    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range2 /= 3;
     }
 
@@ -233,7 +233,7 @@ bool detect_objects_normal(PlayerType *player_ptr, POSITION range)
 {
     auto &floor = *player_ptr->current_floor_ptr;
     POSITION range2 = range;
-    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range2 /= 3;
     }
 
@@ -303,7 +303,7 @@ static bool is_object_magically(const ItemKindType tval)
 bool detect_objects_magic(PlayerType *player_ptr, POSITION range)
 {
     auto &floor = *player_ptr->current_floor_ptr;
-    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
 
@@ -346,7 +346,7 @@ bool detect_objects_magic(PlayerType *player_ptr, POSITION range)
 bool detect_monsters_normal(PlayerType *player_ptr, POSITION range)
 {
     auto &floor = *player_ptr->current_floor_ptr;
-    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
 
@@ -390,7 +390,7 @@ bool detect_monsters_normal(PlayerType *player_ptr, POSITION range)
 bool detect_monsters_invis(PlayerType *player_ptr, POSITION range)
 {
     auto &floor = *player_ptr->current_floor_ptr;
-    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
 
@@ -441,7 +441,7 @@ bool detect_monsters_invis(PlayerType *player_ptr, POSITION range)
 bool detect_monsters_evil(PlayerType *player_ptr, POSITION range)
 {
     auto &floor = *player_ptr->current_floor_ptr;
-    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
 
@@ -491,7 +491,7 @@ bool detect_monsters_evil(PlayerType *player_ptr, POSITION range)
 bool detect_monsters_nonliving(PlayerType *player_ptr, POSITION range)
 {
     auto &floor = *player_ptr->current_floor_ptr;
-    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
 
@@ -536,7 +536,7 @@ bool detect_monsters_nonliving(PlayerType *player_ptr, POSITION range)
 bool detect_monsters_mind(PlayerType *player_ptr, POSITION range)
 {
     auto &floor = *player_ptr->current_floor_ptr;
-    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
 
@@ -584,7 +584,7 @@ bool detect_monsters_mind(PlayerType *player_ptr, POSITION range)
 bool detect_monsters_string(PlayerType *player_ptr, POSITION range, concptr Match)
 {
     auto &floor = *player_ptr->current_floor_ptr;
-    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
 

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -99,7 +99,7 @@ void wiz_lite(PlayerType *player_ptr, bool ninja)
                 f_ptr = &terrains_info[g_ptr->get_feat_mimic()];
 
                 /* Perma-lite the grid */
-                if (dungeons_info[floor.dungeon_idx].flags.has_not(DungeonFeatureType::DARKNESS) && !ninja) {
+                if (floor.get_dungeon_definition().flags.has_not(DungeonFeatureType::DARKNESS) && !ninja) {
                     g_ptr->info |= (CAVE_GLOW);
                 }
 
@@ -207,7 +207,7 @@ void wiz_dark(PlayerType *player_ptr)
 void map_area(PlayerType *player_ptr, POSITION range)
 {
     auto &floor = *player_ptr->current_floor_ptr;
-    if (dungeons_info[floor.dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+    if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
         range /= 3;
     }
 

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -456,7 +456,7 @@ bool destroy_area(PlayerType *player_ptr, POSITION y1, POSITION x1, POSITION r, 
                 continue;
             }
 
-            if (dungeons_info[floor_ptr->dungeon_idx].flags.has(DungeonFeatureType::DARKNESS)) {
+            if (floor_ptr->get_dungeon_definition().flags.has(DungeonFeatureType::DARKNESS)) {
                 continue;
             }
 

--- a/src/spell-kind/spells-grid.cpp
+++ b/src/spell-kind/spells-grid.cpp
@@ -71,7 +71,7 @@ void stair_creation(PlayerType *player_ptr)
 
     bool down = true;
     auto &floor = *player_ptr->current_floor_ptr;
-    if (inside_quest(quest_number(floor, floor.dun_level)) || (floor.dun_level >= dungeons_info[floor.dungeon_idx].maxdepth)) {
+    if (inside_quest(quest_number(floor, floor.dun_level)) || (floor.dun_level >= floor.get_dungeon_definition().maxdepth)) {
         down = false;
     }
 

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -122,7 +122,7 @@ void teleport_level(PlayerType *player_ptr, MONSTER_IDX m_idx)
 #endif
         if (m_idx <= 0) {
             if (!floor.is_in_dungeon()) {
-                floor.dungeon_idx = ironman_downward ? DUNGEON_ANGBAND : player_ptr->recall_dungeon;
+                floor.set_dungeon_index(ironman_downward ? DUNGEON_ANGBAND : player_ptr->recall_dungeon);
                 player_ptr->oldpy = player_ptr->y;
                 player_ptr->oldpx = player_ptr->x;
             }

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -56,7 +56,7 @@ bool is_teleport_level_ineffective(PlayerType *player_ptr, MONSTER_IDX idx)
     is_special_floor |= player_ptr->phase_out;
     is_special_floor |= inside_quest(floor.quest_number) && !inside_quest(random_quest_number(floor, floor.dun_level));
     auto is_invalid_floor = idx <= 0;
-    is_invalid_floor &= inside_quest(quest_number(floor, floor.dun_level)) || (floor.dun_level >= dungeons_info[floor.dungeon_idx].maxdepth);
+    is_invalid_floor &= inside_quest(quest_number(floor, floor.dun_level)) || (floor.dun_level >= floor.get_dungeon_definition().maxdepth);
     is_invalid_floor &= floor.dun_level >= 1;
     is_invalid_floor &= ironman_downward;
     return is_special_floor || is_invalid_floor;
@@ -109,7 +109,7 @@ void teleport_level(PlayerType *player_ptr, MONSTER_IDX m_idx)
         }
     }
 
-    const auto &dungeon = dungeons_info[floor.dungeon_idx];
+    const auto &dungeon = floor.get_dungeon_definition();
     if ((ironman_downward && (m_idx <= 0)) || (floor.dun_level <= dungeon.mindepth)) {
 #ifdef JP
         if (see_m) {

--- a/src/system/floor-type-definition.cpp
+++ b/src/system/floor-type-definition.cpp
@@ -1,6 +1,22 @@
 ﻿#include "system/floor-type-definition.h"
+#include "system/dungeon-info.h"
 
 bool FloorType::is_in_dungeon() const
 {
     return this->dun_level > 0;
+}
+
+void FloorType::set_dungeon_index(short dungeon_idx_)
+{
+    this->dungeon_idx = dungeon_idx_;
+}
+
+void FloorType::reset_dungeon_index()
+{
+    this->set_dungeon_index(0);
+}
+
+dungeon_type &FloorType::get_dungeon_definition() const
+{
+    return dungeons_info[this->dungeon_idx];
 }

--- a/src/system/floor-type-definition.h
+++ b/src/system/floor-type-definition.h
@@ -33,13 +33,14 @@ constexpr auto VIEW_MAX = 1536;
  */
 constexpr auto REDRAW_MAX = 2298;
 
+struct dungeon_type;
 struct grid_type;
 class MonsterEntity;
 class ItemEntity;
 class FloorType {
 public:
     FloorType() = default;
-    DUNGEON_IDX dungeon_idx = 0;
+    short dungeon_idx = 0;
     std::vector<std::vector<grid_type>> grid_array;
     DEPTH dun_level = 0; /*!< 現在の実ダンジョン階層 base_level の参照元となる / Current dungeon level */
     DEPTH base_level = 0; /*!< 基本生成レベル、後述のobject_level, monster_levelの参照元となる / Base dungeon level */
@@ -83,4 +84,7 @@ public:
     bool inside_arena = false; /* Is character inside on_defeat_arena_monster? */
 
     bool is_in_dungeon() const;
+    void set_dungeon_index(short dungeon_idx_); /*!< @todo 後でenum class にする */
+    void reset_dungeon_index();
+    dungeon_type &get_dungeon_definition() const;
 };

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -603,7 +603,7 @@ static bool select_debugging_floor(PlayerType *player_ptr, int dungeon_type)
 static void wiz_jump_floor(PlayerType *player_ptr, DUNGEON_IDX dun_idx, DEPTH depth)
 {
     auto &floor = *player_ptr->current_floor_ptr;
-    floor.dungeon_idx = dun_idx;
+    floor.set_dungeon_index(dun_idx);
     floor.dun_level = depth;
     prepare_change_floor_mode(player_ptr, CFM_RAND_PLACE);
     if (!floor.is_in_dungeon()) {

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -607,7 +607,7 @@ static void wiz_jump_floor(PlayerType *player_ptr, DUNGEON_IDX dun_idx, DEPTH de
     floor.dun_level = depth;
     prepare_change_floor_mode(player_ptr, CFM_RAND_PLACE);
     if (!floor.is_in_dungeon()) {
-        floor.dungeon_idx = 0;
+        floor.reset_dungeon_index();
     }
 
     floor.inside_arena = false;
@@ -879,7 +879,8 @@ void cheat_death(PlayerType *player_ptr)
     if (floor_ptr->dungeon_idx) {
         player_ptr->recall_dungeon = floor_ptr->dungeon_idx;
     }
-    floor_ptr->dungeon_idx = 0;
+
+    floor_ptr->reset_dungeon_index();
     if (lite_town || vanilla_town) {
         player_ptr->wilderness_y = 1;
         player_ptr->wilderness_x = 1;

--- a/src/world/world-movement-processor.cpp
+++ b/src/world/world-movement-processor.cpp
@@ -84,7 +84,7 @@ void execute_recall(PlayerType *player_ptr)
         }
 
         floor_ptr->dun_level = 0;
-        floor_ptr->dungeon_idx = 0;
+        floor_ptr->reset_dungeon_index();
         leave_quest_check(player_ptr);
         leave_tower_check(player_ptr);
         floor_ptr->quest_number = QuestId::NONE;

--- a/src/world/world-movement-processor.cpp
+++ b/src/world/world-movement-processor.cpp
@@ -109,7 +109,7 @@ void execute_recall(PlayerType *player_ptr)
         } else if (floor_ptr->dun_level < 99) {
             floor_ptr->dun_level = (floor_ptr->dun_level + 99) / 2;
         } else if (floor_ptr->dun_level > 100) {
-            floor_ptr->dun_level = dungeons_info[floor_ptr->dungeon_idx].maxdepth - 1;
+            floor_ptr->dun_level = floor_ptr->get_dungeon_definition().maxdepth - 1;
         }
     }
 

--- a/src/world/world-movement-processor.cpp
+++ b/src/world/world-movement-processor.cpp
@@ -94,7 +94,7 @@ void execute_recall(PlayerType *player_ptr)
     }
 
     msg_print(_("下に引きずり降ろされる感じがする！", "You feel yourself yanked downwards!"));
-    floor_ptr->dungeon_idx = player_ptr->recall_dungeon;
+    floor_ptr->set_dungeon_index(player_ptr->recall_dungeon);
     if (record_stair) {
         exe_write_diary(player_ptr, DiaryKind::RECALL, floor_ptr->dun_level);
     }

--- a/src/world/world-object.cpp
+++ b/src/world/world-object.cpp
@@ -72,7 +72,7 @@ OBJECT_IDX get_obj_index(const FloorType *floor_ptr, DEPTH level, BIT_FLAGS mode
         level = MAX_DEPTH - 1;
     }
 
-    if ((level > 0) && dungeons_info[floor_ptr->dungeon_idx].flags.has_not(DungeonFeatureType::BEGINNER)) {
+    if ((level > 0) && floor_ptr->get_dungeon_definition().flags.has_not(DungeonFeatureType::BEGINNER)) {
         if (one_in_(CHANCE_BASEITEM_LEVEL_BOOST)) {
             level = 1 + (level * MAX_DEPTH / randint1(MAX_DEPTH));
         }

--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -128,7 +128,7 @@ void WorldTurnProcessor::process_downward()
     }
 
     floor_ptr->dun_level = 0;
-    floor_ptr->dungeon_idx = 0;
+    floor_ptr->reset_dungeon_index();
     prepare_change_floor_mode(this->player_ptr, CFM_FIRST_FLOOR | CFM_RAND_PLACE);
     floor_ptr->inside_arena = false;
     this->player_ptr->wild_mode = false;

--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -305,7 +305,7 @@ void WorldTurnProcessor::shuffle_shopkeeper()
 void WorldTurnProcessor::decide_alloc_monster()
 {
     auto *floor_ptr = this->player_ptr->current_floor_ptr;
-    auto should_alloc = one_in_(dungeons_info[floor_ptr->dungeon_idx].max_m_alloc_chance);
+    auto should_alloc = one_in_(floor_ptr->get_dungeon_definition().max_m_alloc_chance);
     should_alloc &= !floor_ptr->inside_arena;
     should_alloc &= !inside_quest(floor_ptr->quest_number);
     should_alloc &= !this->player_ptr->phase_out;


### PR DESCRIPTION
FloorType::get\_dungeon() を実装した他、dungeon\_idx への書き込みもset/reset でカプセル化しました
ご確認下さい
game-play-initializer.cpp の処理は、FloorType のフィールド変数を初期化する処理がクラス定義側に入ったことにより不要となったため削除しました