### PR TITLE
string 型にnullptrを代入していた潜在的不具合を解消した

### DIFF
--- a/src/effect/effect-monster-charm.cpp
+++ b/src/effect/effect-monster-charm.cpp
@@ -261,7 +261,7 @@ static void effect_monster_domination_corrupted(PlayerType *player_ptr, effect_m
         return;
     }
 
-    em_ptr->note = nullptr;
+    em_ptr->note = "";
     msg_format(_("%s^の堕落した精神は攻撃を跳ね返した！",
                    (em_ptr->seen ? "%s^'s corrupted mind backlashes your attack!" : "%s^s corrupted mind backlashes your attack!")),
         em_ptr->m_name);


### PR DESCRIPTION
1箇所のみの修正です、ご確認下さい
正式に禁止されるのがC++23だったのでデバッグC++20環境では通り、リリースlatest環境ではエラーになった模様