### PR TITLE
[Feature] オートローラーの単位をcm、kgに

### DIFF
--- a/src/birth/auto-roller.cpp
+++ b/src/birth/auto-roller.cpp
@@ -371,7 +371,7 @@ bool get_chara_limits(PlayerType *player_ptr, chara_limit_type *chara_limit_ptr)
 {
 #define MAXITEMS 8
 
-    concptr itemname[] = { _("年齢", "age"), _("身長(インチ)", "height"), _("体重(ポンド)", "weight"), _("社会的地位", "social class") };
+    concptr itemname[] = { _("年齢", "age"), _("身長(cm)", "height"), _("体重(kg)", "weight"), _("社会的地位", "social class") };
 
     clear_from(10);
     put_str(_("2/4/6/8で項目選択、+/-で値の増減、Enterで次へ", "2/4/6/8 for Select, +/- for Change value, Enter for Goto next"), 11, 10);
@@ -441,7 +441,16 @@ bool get_chara_limits(PlayerType *player_ptr, chara_limit_type *chara_limit_ptr)
         }
 
         mval[i] = m;
-        cval[i] = m;
+    }
+#ifdef JP
+    /*身長と体重の単位をcmとkgに*/
+    mval[2] = mval[2] * 254 / 100;
+    mval[3] = mval[3] * 254 / 100;
+    mval[4] = mval[4] * 4536 / 10000;
+    mval[5] = mval[5] * 4536 / 10000;
+#endif
+    for (auto i = 0; i < MAXITEMS; i++) {
+        cval[i] = mval[i];
     }
 
     for (int i = 0; i < 4; i++) {


### PR DESCRIPTION
オートローラーの生い立ちで表示される単位を日本語ではinch,lbでなくcm,kgに。

#1987 体格オートローラー修正の問題です。
現verだと、
`C3680	ユーザー定義文字列リテラルを、一致しないリテラル サフィックス識別子と連結することはできません
Hengband	src\locale\japanese.cpp`
というエラーが出るので、一週間ほど前のモノでビルドして正常に動きました。

単位変換関数はsrc/view/display-player.cppと同じなので、dumpと同じ数値になると思います。
▼適用時
![スクリーンショット 2023-06-02 052907](https://github.com/hengband/hengband/assets/108442898/4777dee6-1da6-46b8-94f7-36ea040d68d9)
▼現行版
![スクリーンショット 2023-06-02 055529](https://github.com/hengband/hengband/assets/108442898/77a43aea-bf17-4f3f-90bf-3a72a251b711)
