### PR TITLE
FlagGroupクラスのコンストラクタをconstexpr化する

### DIFF
--- a/src/util/enum-range.h
+++ b/src/util/enum-range.h
@@ -21,9 +21,7 @@ public:
         // std::iterator_traits に対応するための定義
         using difference_type = int;
         using value_type = EnumType;
-        using pointer = const EnumType *;
-        using reference = const EnumType &;
-        using iterator_category = std::input_iterator_tag;
+        using iterator_concept = std::input_iterator_tag;
 
         /*!
          * @brief 引数で与えた列挙値を指すイテレータオブジェクトを生成する
@@ -46,14 +44,26 @@ public:
         }
 
         /*!
-         * @brief イテレータをインクリメントする
+         * @brief イテレータを前置インクリメントする
          *
          * @return *this の参照
          */
-        iterator &operator++() noexcept
+        constexpr iterator &operator++() noexcept
         {
             ++index;
             return *this;
+        }
+
+        /*!
+         * @brief イテレータを後置インクリメントする
+         *
+         * @return *this の参照
+         */
+        constexpr iterator operator++(int) noexcept
+        {
+            auto old = *this;
+            ++*this;
+            return old;
         }
 
         /*!
@@ -65,17 +75,6 @@ public:
         constexpr bool operator==(const iterator &other) const noexcept
         {
             return index == other.index;
-        }
-
-        /*!
-         * @brief 2つのイテレータが指している列挙値が等しくないかどうか調べる
-         *
-         * @param other 比較対象となるイテレータ
-         * @return 2つのイテレータが指している列挙値が等しくなければ true、そうでなければ false
-         */
-        constexpr bool operator!=(const iterator &other) const noexcept
-        {
-            return !this->operator==(other);
         }
 
     private:

--- a/src/util/flag-group.h
+++ b/src/util/flag-group.h
@@ -1,10 +1,28 @@
 ﻿#pragma once
 
 #include <bitset>
+#include <concepts>
+#include <iterator>
 #include <optional>
+#include <type_traits>
 
 template <typename T>
 class EnumRange;
+
+namespace flag_group {
+
+/**
+ * @brief 型がFlagGroupクラスで使用するフラグを指すイテレータであることを表すコンセプト
+ *
+ * Iter の型が以下の要件を満たすことを表す
+ *
+ * - 入力イテレータである
+ * - そのイテレータが指す要素の型が FlagType である
+ */
+template <typename Iter, typename FlagType>
+concept FlagIter = std::input_iterator<Iter> && std::same_as<std::iter_value_t<Iter>, FlagType>;
+
+}
 
 namespace flag_group::detail {
 
@@ -114,11 +132,9 @@ public:
      * @param first 範囲の開始位置を示す入力イテレータ
      * @param last 範囲の終了位置を示す入力イテレータ
      */
-    template <typename InputIter>
+    template <flag_group::FlagIter<FlagType> InputIter>
     FlagGroup(InputIter first, InputIter last)
     {
-        static_assert(std::is_same<typename std::iterator_traits<InputIter>::value_type, FlagType>::value, "Iterator value type is invalid");
-
         for (; first != last; ++first) {
             set(*first);
         }
@@ -157,7 +173,7 @@ public:
      * @param last 範囲の終了位置を示す入力イテレータ
      * @return *thisを返す
      */
-    template <typename InputIter>
+    template <flag_group::FlagIter<FlagType> InputIter>
     FlagGroup<FlagType, MAX> &set(InputIter first, InputIter last)
     {
         return set(FlagGroup(first, last));
@@ -195,7 +211,7 @@ public:
      * @param last 範囲の終了位置を示す入力イテレータ
      * @return *thisを返す
      */
-    template <typename InputIter>
+    template <flag_group::FlagIter<FlagType> InputIter>
     FlagGroup<FlagType, MAX> &reset(InputIter first, InputIter last)
     {
         return reset(FlagGroup(first, last));
@@ -269,7 +285,7 @@ public:
      * @param last 範囲の終了位置を示す入力イテレータ
      * @return すべてのフラグがONであればtrue、そうでなければfalse
      */
-    template <typename InputIter>
+    template <flag_group::FlagIter<FlagType> InputIter>
     [[nodiscard]] bool has_all_of(InputIter first, InputIter last) const
     {
         return has_all_of(FlagGroup(first, last));
@@ -294,7 +310,7 @@ public:
      * @param last 範囲の終了位置を示す入力イテレータ
      * @return いずれかのフラグがONであればtrue、そうでなければfalse
      */
-    template <typename InputIter>
+    template <flag_group::FlagIter<FlagType> InputIter>
     [[nodiscard]] bool has_any_of(InputIter first, InputIter last) const
     {
         return has_any_of(FlagGroup(first, last));
@@ -319,7 +335,7 @@ public:
      * @param last 範囲の終了位置を示す入力イテレータ
      * @return すべてのフラグがOFFであればtrue、そうでなければfalse
      */
-    template <typename InputIter>
+    template <flag_group::FlagIter<FlagType> InputIter>
     [[nodiscard]] bool has_none_of(InputIter first, InputIter last) const
     {
         return !has_any_of(first, last);


### PR DESCRIPTION
Resolves #3362 

次のように、VSCode上で定数をマウスホバーすることで定数の値が表示される、すなわちコンパイル時定数になっていることがわかります。

constexpr な initializer_list でのコンストラクタ呼び出し
<img width="1103" alt="image" src="https://github.com/hengband/hengband/assets/1501750/fc82fa10-d10a-44db-bfc7-2d97cc7a5e34">

constexpr な EnumRange でのコンストラクタ呼び出し
<img width="1114" alt="image" src="https://github.com/hengband/hengband/assets/1501750/881e6cbd-cdc4-451c-9366-f8db2045d84a">
