### PR TITLE
[Fix] 足元の魔道具の魔力を吸収するとクラッシュする

### DIFF
--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -618,9 +618,12 @@ static void display_found_item_list(PlayerType *player_ptr)
     // ItemKindTypeがGOLD
     std::vector<ItemEntity *> found_item_list;
     for (auto &item : floor_ptr->o_list) {
-        auto item_entity_ptr = &item;
-        if (item_entity_ptr->is_valid() && item_entity_ptr->marked.has(OmType::FOUND) && item_entity_ptr->bi_key.tval() != ItemKindType::GOLD) {
-            found_item_list.push_back(item_entity_ptr);
+        const auto is_item_to_display =
+            item.is_valid() && (item.number > 0) &&
+            item.marked.has(OmType::FOUND) && (item.bi_key.tval() != ItemKindType::GOLD);
+
+        if (is_item_to_display) {
+            found_item_list.push_back(&item);
         }
     }
 


### PR DESCRIPTION
Resolves #3144 

魔力を吸収してItemEntityのnumberが0になった瞬間に発見済みのアイテムのウィンドウ更新処理が走り、その中でアイテムの値段計算時にnumberによるゼロ除算が発生してクラッシュする。
表示するアイテムリストを作成する時にnumberが0以下のものは除外するようにして対応する。

コールチェインや、更新したくないフラグのサブウィンドウまで更新されてしまうなど構造的な問題は多々あるが、すぐに抜本的に解決するのは難しい。さすがにクラッシュバグを放置しておくのはまずいので、ひとまず発見済みのアイテムリストからnumberが0のものを除外するようにしておく。