### PR TITLE
画面再描画/プレイヤーステータスフラグ群をコンパイル時定数化した

### DIFF
--- a/src/action/activation-execution.cpp
+++ b/src/action/activation-execution.cpp
@@ -260,7 +260,7 @@ void exe_activate(PlayerType *player_ptr, INVENTORY_IDX item)
     sound(SOUND_ZAP);
     if (activation_index(ae_ptr->o_ptr) > RandomArtActType::NONE) {
         (void)activate_artifact(player_ptr, ae_ptr->o_ptr);
-        const auto flags = {
+        static constexpr auto flags = {
             SubWindowRedrawingFlag::INVENTORY,
             SubWindowRedrawingFlag::EQUIPMENT,
         };

--- a/src/action/movement-execution.cpp
+++ b/src/action/movement-execution.cpp
@@ -371,7 +371,7 @@ void exe_movement(PlayerType *player_ptr, DIRECTION dir, bool do_pickup, bool br
 
     if (p_can_kill_walls) {
         cave_alter_feat(player_ptr, y, x, TerrainCharacteristics::HURT_DISI);
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::FLOW);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::FLOW);
     }
 
     uint32_t mpe_mode = MPE_ENERGY_USE;

--- a/src/action/tunnel-execution.cpp
+++ b/src/action/tunnel-execution.cpp
@@ -84,7 +84,7 @@ bool exe_tunnel(PlayerType *player_ptr, POSITION y, POSITION x)
             sound(SOUND_DIG_THROUGH);
             msg_format(_("%sをくずした。", "You have removed the %s."), name);
             cave_alter_feat(player_ptr, y, x, TerrainCharacteristics::TUNNEL);
-            RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::FLOW);
+            RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::FLOW);
         } else {
             msg_format(_("%sをくずしている。", "You dig into the %s."), name);
             more = true;
@@ -97,7 +97,7 @@ bool exe_tunnel(PlayerType *player_ptr, POSITION y, POSITION x)
                 msg_format(_("%sを切り払った。", "You have cleared away the %s."), name);
             } else {
                 msg_print(_("穴を掘り終えた。", "You have finished the tunnel."));
-                RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::FLOW);
+                RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::FLOW);
             }
 
             if (f_ptr->flags.has(TerrainCharacteristics::GLASS)) {

--- a/src/artifact/random-art-generator.cpp
+++ b/src/artifact/random-art-generator.cpp
@@ -421,7 +421,7 @@ static void generate_unnatural_random_artifact(
     msg_format_wizard(player_ptr, CHEAT_OBJECT,
         _("パワー %d で 価値 %d のランダムアーティファクト生成 バイアスは「%s」", "Random artifact generated - Power:%d Value:%d Bias:%s."), max_powers,
         total_flags, artifact_bias_name[o_ptr->artifact_bias]);
-    const auto flags = {
+    static constexpr auto flags = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
         SubWindowRedrawingFlag::FLOOR_ITEMS,

--- a/src/autopick/autopick-destroyer.cpp
+++ b/src/autopick/autopick-destroyer.cpp
@@ -157,5 +157,5 @@ void auto_destroy_item(PlayerType *player_ptr, ItemEntity *o_ptr, int autopick_i
 
     autopick_last_destroyed_object = *o_ptr;
     o_ptr->marked.set(OmType::AUTODESTROY);
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::AUTO_DESTRUCTION);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::AUTO_DESTRUCTION);
 }

--- a/src/autopick/autopick-util.cpp
+++ b/src/autopick/autopick-util.cpp
@@ -79,7 +79,7 @@ void auto_inscribe_item(ItemEntity *o_ptr, int idx)
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
     };

--- a/src/autopick/autopick-util.cpp
+++ b/src/autopick/autopick-util.cpp
@@ -84,7 +84,7 @@ void auto_inscribe_item(ItemEntity *o_ptr, int idx)
         SubWindowRedrawingFlag::EQUIPMENT,
     };
     rfu.set_flags(flags_swrf);
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::COMBINATION,
     };

--- a/src/autopick/autopick-util.cpp
+++ b/src/autopick/autopick-util.cpp
@@ -85,8 +85,8 @@ void auto_inscribe_item(ItemEntity *o_ptr, int idx)
     };
     rfu.set_flags(flags_swrf);
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::COMBINATION,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::COMBINATION,
     };
     rfu.set_flags(flags_srf);
 }

--- a/src/avatar/avatar.cpp
+++ b/src/avatar/avatar.cpp
@@ -462,7 +462,7 @@ void chg_virtue(PlayerType *player_ptr, Virtue virtue_id, int amount)
             }
         }
 
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
         return;
     }
 }

--- a/src/birth/birth-wizard.cpp
+++ b/src/birth/birth-wizard.cpp
@@ -439,7 +439,7 @@ static bool display_auto_roller_result(PlayerType *player_ptr, bool prev, char *
 {
     BIT_FLAGS mode = 0;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags = {
+    static constexpr auto flags = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::HP,
     };

--- a/src/birth/birth-wizard.cpp
+++ b/src/birth/birth-wizard.cpp
@@ -440,8 +440,8 @@ static bool display_auto_roller_result(PlayerType *player_ptr, bool prev, char *
     BIT_FLAGS mode = 0;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::HP,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::HP,
     };
     while (true) {
         rfu.set_flags(flags);

--- a/src/birth/quick-start.cpp
+++ b/src/birth/quick-start.cpp
@@ -64,7 +64,7 @@ bool ask_quick_start(PlayerType *player_ptr)
     ap_ptr = &personality_info[player_ptr->ppersonality];
 
     get_extra(player_ptr, false);
-    const auto flags = {
+    static constexpr auto flags = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::HP,
     };

--- a/src/birth/quick-start.cpp
+++ b/src/birth/quick-start.cpp
@@ -65,8 +65,8 @@ bool ask_quick_start(PlayerType *player_ptr)
 
     get_extra(player_ptr, false);
     static constexpr auto flags = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::HP,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::HP,
     };
     RedrawingFlagsUpdater::get_instance().set_flags(flags);
     update_creature(player_ptr);

--- a/src/cmd-action/cmd-hissatsu.cpp
+++ b/src/cmd-action/cmd-hissatsu.cpp
@@ -426,5 +426,5 @@ void do_cmd_gain_hissatsu(PlayerType *player_ptr)
         PlayerEnergy(player_ptr).set_player_turn_energy(100);
     }
 
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::SPELLS);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::SPELLS);
 }

--- a/src/cmd-action/cmd-hissatsu.cpp
+++ b/src/cmd-action/cmd-hissatsu.cpp
@@ -356,7 +356,7 @@ void do_cmd_hissatsu(PlayerType *player_ptr)
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::MP);
-    const auto flags = {
+    static constexpr auto flags = {
         SubWindowRedrawingFlag::PLAYER,
         SubWindowRedrawingFlag::SPELL,
     };

--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -1290,7 +1290,7 @@ bool do_cmd_mane(PlayerType *player_ptr, bool baigaesi)
     PlayerEnergy(player_ptr).set_player_turn_energy(100);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::IMITATION);
-    const auto flags = {
+    static constexpr auto flags = {
         SubWindowRedrawingFlag::PLAYER,
         SubWindowRedrawingFlag::SPELL,
     };

--- a/src/cmd-action/cmd-mind.cpp
+++ b/src/cmd-action/cmd-mind.cpp
@@ -427,7 +427,7 @@ void do_cmd_mind(PlayerType *player_ptr)
     process_hard_concentration(player_ptr, cm_ptr);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::MP);
-    const auto flags = {
+    static constexpr auto flags = {
         SubWindowRedrawingFlag::PLAYER,
         SubWindowRedrawingFlag::SPELL,
     };

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -497,7 +497,7 @@ void do_cmd_rest(PlayerType *player_ptr)
     player_ptr->resting = command_arg;
     player_ptr->action = ACTION_REST;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     rfu.set_flag(MainWindowRedrawingFlag::ACTION);
     handle_stuff(player_ptr);
     term_fresh();

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -308,7 +308,7 @@ bool do_cmd_riding(PlayerType *player_ptr, bool force)
         StatusRedrawingFlag::BONUS,
     };
     rfu.set_flags(flags_srf);
-    const auto flags_mwrf = {
+    static constexpr auto flags_mwrf = {
         MainWindowRedrawingFlag::MAP,
         MainWindowRedrawingFlag::EXTRA,
         MainWindowRedrawingFlag::UHEALTH,

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -160,7 +160,7 @@ void do_cmd_pet_dismiss(PlayerType *player_ptr)
                 msg_format(_("%sから降りた。", "You dismount from %s. "), friend_name.data());
 
                 player_ptr->riding = 0;
-                rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+                rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
                 static constexpr auto flags = {
                     MainWindowRedrawingFlag::EXTRA,
                     MainWindowRedrawingFlag::UHEALTH,
@@ -169,7 +169,7 @@ void do_cmd_pet_dismiss(PlayerType *player_ptr)
             }
 
             msg_format(_("%s を放した。", "Dismissed %s."), friend_name.data());
-            rfu.set_flag(StatusRedrawingFlag::BONUS);
+            rfu.set_flag(StatusRecalculatingFlag::BONUS);
             rfu.set_flag(SubWindowRedrawingFlag::MESSAGE);
 
             delete_monster_idx(player_ptr, pet_ctr);
@@ -303,9 +303,9 @@ bool do_cmd_riding(PlayerType *player_ptr, bool force)
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::UN_VIEW,
-        StatusRedrawingFlag::UN_LITE,
-        StatusRedrawingFlag::BONUS,
+        StatusRecalculatingFlag::UN_VIEW,
+        StatusRecalculatingFlag::UN_LITE,
+        StatusRecalculatingFlag::BONUS,
     };
     rfu.set_flags(flags_srf);
     static constexpr auto flags_mwrf = {
@@ -820,7 +820,7 @@ void do_cmd_pet(PlayerType *player_ptr)
             player_ptr->pet_extra_flags |= (PF_TWO_HANDS);
         }
 
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
         handle_stuff(player_ptr);
         break;
     }

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -302,7 +302,7 @@ bool do_cmd_riding(PlayerType *player_ptr, bool force)
     PlayerEnergy(player_ptr).set_player_turn_energy(100);
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::UN_VIEW,
         StatusRedrawingFlag::UN_LITE,
         StatusRedrawingFlag::BONUS,

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -161,7 +161,7 @@ void do_cmd_pet_dismiss(PlayerType *player_ptr)
 
                 player_ptr->riding = 0;
                 rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
-                const auto flags = {
+                static constexpr auto flags = {
                     MainWindowRedrawingFlag::EXTRA,
                     MainWindowRedrawingFlag::UHEALTH,
                 };

--- a/src/cmd-action/cmd-racial.cpp
+++ b/src/cmd-action/cmd-racial.cpp
@@ -508,7 +508,7 @@ void do_cmd_racial_power(PlayerType *player_ptr)
         MainWindowRedrawingFlag::MP,
     };
     rfu.set_flags(flags_mwrf);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::PLAYER,
         SubWindowRedrawingFlag::SPELL,
     };

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -703,8 +703,8 @@ static void change_realm2(PlayerType *player_ptr, int16_t next_realm)
     player_ptr->realm2 = next_realm;
 
     static constexpr auto flags = {
-        StatusRedrawingFlag::REORDER,
-        StatusRedrawingFlag::SPELLS,
+        StatusRecalculatingFlag::REORDER,
+        StatusRecalculatingFlag::SPELLS,
     };
     RedrawingFlagsUpdater::get_instance().set_flags(flags);
     handle_stuff(player_ptr);
@@ -917,7 +917,7 @@ void do_cmd_study(PlayerType *player_ptr)
     player_ptr->learned_spells++;
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(StatusRedrawingFlag::SPELLS);
+    rfu.set_flag(StatusRecalculatingFlag::SPELLS);
     update_creature(player_ptr);
     rfu.set_flag(SubWindowRedrawingFlag::ITEM_KNOWLEDGTE);
 }

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -702,7 +702,7 @@ static void change_realm2(PlayerType *player_ptr, int16_t next_realm)
     player_ptr->old_realm |= 1U << (player_ptr->realm2 - 1);
     player_ptr->realm2 = next_realm;
 
-    const auto flags = {
+    static constexpr auto flags = {
         StatusRedrawingFlag::REORDER,
         StatusRedrawingFlag::SPELLS,
     };
@@ -1363,7 +1363,7 @@ bool do_cmd_cast(PlayerType *player_ptr)
         }
     }
 
-    const auto flags = {
+    static constexpr auto flags = {
         SubWindowRedrawingFlag::PLAYER,
         SubWindowRedrawingFlag::SPELL,
     };

--- a/src/cmd-building/cmd-building.cpp
+++ b/src/cmd-building/cmd-building.cpp
@@ -424,7 +424,7 @@ void do_cmd_building(PlayerType *player_ptr)
         MainWindowRedrawingFlag::MAP,
     };
     rfu.set_flags(flags_mwrf);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::OVERHEAD,
         SubWindowRedrawingFlag::DUNGEON,
     };

--- a/src/cmd-building/cmd-building.cpp
+++ b/src/cmd-building/cmd-building.cpp
@@ -409,7 +409,7 @@ void do_cmd_building(PlayerType *player_ptr)
     term_clear();
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::VIEW,
         StatusRedrawingFlag::MONSTER_STATUSES,
         StatusRedrawingFlag::BONUS,

--- a/src/cmd-building/cmd-building.cpp
+++ b/src/cmd-building/cmd-building.cpp
@@ -410,11 +410,11 @@ void do_cmd_building(PlayerType *player_ptr)
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::VIEW,
-        StatusRedrawingFlag::MONSTER_STATUSES,
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::LITE,
-        StatusRedrawingFlag::MONSTER_LITE,
+        StatusRecalculatingFlag::VIEW,
+        StatusRecalculatingFlag::MONSTER_STATUSES,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::LITE,
+        StatusRecalculatingFlag::MONSTER_LITE,
     };
     rfu.set_flags(flags_srf);
     static constexpr auto flags_mwrf = {

--- a/src/cmd-building/cmd-building.cpp
+++ b/src/cmd-building/cmd-building.cpp
@@ -417,7 +417,7 @@ void do_cmd_building(PlayerType *player_ptr)
         StatusRedrawingFlag::MONSTER_LITE,
     };
     rfu.set_flags(flags_srf);
-    const auto flags_mwrf = {
+    static constexpr auto flags_mwrf = {
         MainWindowRedrawingFlag::BASIC,
         MainWindowRedrawingFlag::EXTRA,
         MainWindowRedrawingFlag::EQUIPPY,

--- a/src/cmd-io/cmd-floor.cpp
+++ b/src/cmd-io/cmd-floor.cpp
@@ -98,7 +98,7 @@ void do_cmd_locate(PlayerType *player_ptr)
 
     verify_panel(player_ptr);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+    rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
     static constexpr auto flags = {
         SubWindowRedrawingFlag::OVERHEAD,

--- a/src/cmd-io/cmd-floor.cpp
+++ b/src/cmd-io/cmd-floor.cpp
@@ -40,7 +40,7 @@ void do_cmd_target(PlayerType *player_ptr)
  */
 void do_cmd_look(PlayerType *player_ptr)
 {
-    const auto flags = {
+    static constexpr auto flags = {
         SubWindowRedrawingFlag::SIGHT_MONSTERS,
         SubWindowRedrawingFlag::FLOOR_ITEMS,
     };
@@ -100,7 +100,7 @@ void do_cmd_locate(PlayerType *player_ptr)
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
-    const auto flags = {
+    static constexpr auto flags = {
         SubWindowRedrawingFlag::OVERHEAD,
         SubWindowRedrawingFlag::DUNGEON,
     };

--- a/src/cmd-io/cmd-process-screen.cpp
+++ b/src/cmd-io/cmd-process-screen.cpp
@@ -349,7 +349,7 @@ static bool update_use_graphics(PlayerType *player_ptr)
 
     use_graphics = false;
     reset_visuals(player_ptr);
-    const auto flags = {
+    static constexpr auto flags = {
         MainWindowRedrawingFlag::WIPE,
         MainWindowRedrawingFlag::BASIC,
         MainWindowRedrawingFlag::EXTRA,
@@ -391,7 +391,7 @@ void do_cmd_save_screen(PlayerType *player_ptr)
 
     use_graphics = true;
     reset_visuals(player_ptr);
-    const auto flags = {
+    static constexpr auto flags = {
         MainWindowRedrawingFlag::WIPE,
         MainWindowRedrawingFlag::BASIC,
         MainWindowRedrawingFlag::EXTRA,

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -245,7 +245,7 @@ void exe_eat_food(PlayerType *player_ptr, INVENTORY_IDX item)
      * the pack.
      */
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    using Srf = StatusRedrawingFlag;
+    using Srf = StatusRecalculatingFlag;
     EnumClassFlagGroup<Srf> flags_srf = { Srf::COMBINATION, Srf::REORDER };
     if (rfu.has(Srf::AUTO_DESTRUCTION)) {
         flags_srf.set(Srf::AUTO_DESTRUCTION);

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -203,7 +203,7 @@ static bool exe_eat_charge_of_magic_device(PlayerType *player_ptr, ItemEntity *o
         floor_item_charges(player_ptr->current_floor_ptr, 0 - inventory);
     }
 
-    const auto flags = {
+    static constexpr auto flags = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
     };

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -270,7 +270,7 @@ void exe_eat_food(PlayerType *player_ptr, INVENTORY_IDX item)
         gain_exp(player_ptr, (lev + (player_ptr->lev >> 1)) / player_ptr->lev);
     }
 
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
         SubWindowRedrawingFlag::PLAYER,

--- a/src/cmd-item/cmd-equipment.cpp
+++ b/src/cmd-item/cmd-equipment.cpp
@@ -349,7 +349,7 @@ void do_cmd_wield(PlayerType *player_ptr)
     }
 
     calc_android_exp(player_ptr);
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::TORCH,
         StatusRedrawingFlag::MP,
@@ -410,7 +410,7 @@ void do_cmd_takeoff(PlayerType *player_ptr)
     (void)inven_takeoff(player_ptr, item, 255);
     verify_equip_slot(player_ptr, item);
     calc_android_exp(player_ptr);
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::TORCH,
         StatusRedrawingFlag::MP,

--- a/src/cmd-item/cmd-equipment.cpp
+++ b/src/cmd-item/cmd-equipment.cpp
@@ -72,7 +72,7 @@ static void do_curse_on_equip(OBJECT_IDX slot, ItemEntity *o_ptr, PlayerType *pl
         chariot->curse_flags.set(CurseTraitType::VUL_CURSE);
 
         msg_format(_("『銀の戦車』プラス『アヌビス神』二刀流ッ！", "*Silver Chariot* plus *Anubis God* Two Swords!"));
-        rfu.set_flag(StatusRedrawingFlag::BONUS);
+        rfu.set_flag(StatusRecalculatingFlag::BONUS);
         return;
     }
 
@@ -86,7 +86,7 @@ static void do_curse_on_equip(OBJECT_IDX slot, ItemEntity *o_ptr, PlayerType *pl
     o_ptr->curse_flags.set(CurseTraitType::HEAVY_CURSE);
     msg_format(_("悪意に満ちた黒いオーラが%sをとりまいた...", "There is a malignant black aura surrounding your %s..."), item_name.data());
     o_ptr->feeling = FEEL_NONE;
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
 }
 
 /*!
@@ -350,9 +350,9 @@ void do_cmd_wield(PlayerType *player_ptr)
 
     calc_android_exp(player_ptr);
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::TORCH,
-        StatusRedrawingFlag::MP,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::TORCH,
+        StatusRecalculatingFlag::MP,
     };
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flags(flags_srf);
@@ -395,7 +395,7 @@ void do_cmd_takeoff(PlayerType *player_ptr)
             o_ptr->ident |= (IDENT_SENSE);
             o_ptr->curse_flags.clear();
             o_ptr->feeling = FEEL_NONE;
-            rfu.set_flag(StatusRedrawingFlag::BONUS);
+            rfu.set_flag(StatusRecalculatingFlag::BONUS);
             rfu.set_flag(SubWindowRedrawingFlag::EQUIPMENT);
             msg_print(_("呪いを打ち破った。", "You break the curse."));
         } else {
@@ -411,9 +411,9 @@ void do_cmd_takeoff(PlayerType *player_ptr)
     verify_equip_slot(player_ptr, item);
     calc_android_exp(player_ptr);
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::TORCH,
-        StatusRedrawingFlag::MP,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::TORCH,
+        StatusRecalculatingFlag::MP,
     };
     rfu.set_flags(flags_srf);
     rfu.set_flag(MainWindowRedrawingFlag::EQUIPPY);

--- a/src/cmd-item/cmd-equipment.cpp
+++ b/src/cmd-item/cmd-equipment.cpp
@@ -357,7 +357,7 @@ void do_cmd_wield(PlayerType *player_ptr)
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flags(flags_srf);
     rfu.set_flag(MainWindowRedrawingFlag::EQUIPPY);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
         SubWindowRedrawingFlag::PLAYER,
@@ -417,7 +417,7 @@ void do_cmd_takeoff(PlayerType *player_ptr)
     };
     rfu.set_flags(flags_srf);
     rfu.set_flag(MainWindowRedrawingFlag::EQUIPPY);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
         SubWindowRedrawingFlag::PLAYER,

--- a/src/cmd-item/cmd-item.cpp
+++ b/src/cmd-item/cmd-item.cpp
@@ -198,7 +198,7 @@ void do_cmd_uninscribe(PlayerType *player_ptr)
         StatusRedrawingFlag::BONUS,
     };
     rfu.set_flags(flags_srf);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
         SubWindowRedrawingFlag::FLOOR_ITEMS,
@@ -238,7 +238,7 @@ void do_cmd_inscribe(PlayerType *player_ptr)
             StatusRedrawingFlag::BONUS,
         };
         rfu.set_flags(flags_srf);
-        const auto flags_swrf = {
+        static constexpr auto flags_swrf = {
             SubWindowRedrawingFlag::INVENTORY,
             SubWindowRedrawingFlag::EQUIPMENT,
             SubWindowRedrawingFlag::FLOOR_ITEMS,

--- a/src/cmd-item/cmd-item.cpp
+++ b/src/cmd-item/cmd-item.cpp
@@ -193,7 +193,7 @@ void do_cmd_uninscribe(PlayerType *player_ptr)
     msg_print(_("銘を消した。", "Inscription removed."));
     o_ptr->inscription.reset();
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::COMBINATION,
         StatusRedrawingFlag::BONUS,
     };
@@ -233,7 +233,7 @@ void do_cmd_inscribe(PlayerType *player_ptr)
     if (get_string(_("銘: ", "Inscription: "), out_val, MAX_INSCRIPTION)) {
         o_ptr->inscription.emplace(out_val);
         auto &rfu = RedrawingFlagsUpdater::get_instance();
-        const auto flags_srf = {
+        static constexpr auto flags_srf = {
             StatusRedrawingFlag::COMBINATION,
             StatusRedrawingFlag::BONUS,
         };

--- a/src/cmd-item/cmd-item.cpp
+++ b/src/cmd-item/cmd-item.cpp
@@ -194,8 +194,8 @@ void do_cmd_uninscribe(PlayerType *player_ptr)
     o_ptr->inscription.reset();
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::COMBINATION,
-        StatusRedrawingFlag::BONUS,
+        StatusRecalculatingFlag::COMBINATION,
+        StatusRecalculatingFlag::BONUS,
     };
     rfu.set_flags(flags_srf);
     static constexpr auto flags_swrf = {
@@ -234,8 +234,8 @@ void do_cmd_inscribe(PlayerType *player_ptr)
         o_ptr->inscription.emplace(out_val);
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         static constexpr auto flags_srf = {
-            StatusRedrawingFlag::COMBINATION,
-            StatusRedrawingFlag::BONUS,
+            StatusRecalculatingFlag::COMBINATION,
+            StatusRecalculatingFlag::BONUS,
         };
         rfu.set_flags(flags_srf);
         static constexpr auto flags_swrf = {

--- a/src/cmd-item/cmd-refill.cpp
+++ b/src/cmd-item/cmd-refill.cpp
@@ -56,7 +56,7 @@ static void do_cmd_refill_lamp(PlayerType *player_ptr)
     }
 
     vary_item(player_ptr, item, -1);
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::TORCH);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::TORCH);
 }
 
 /*!
@@ -96,7 +96,7 @@ static void do_cmd_refill_torch(PlayerType *player_ptr)
     }
 
     vary_item(player_ptr, item, -1);
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::TORCH);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::TORCH);
 }
 
 /*!

--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -57,7 +57,7 @@ void do_cmd_redraw(PlayerType *player_ptr)
         StatusRedrawingFlag::MONSTER_STATUSES,
     };
     rfu.set_flags(flags_srf);
-    const auto flags_mwrf = {
+    static constexpr auto flags_mwrf = {
         MainWindowRedrawingFlag::WIPE,
         MainWindowRedrawingFlag::BASIC,
         MainWindowRedrawingFlag::EXTRA,
@@ -144,7 +144,7 @@ void do_cmd_player_status(PlayerType *player_ptr)
 
     screen_load();
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_mwrf = {
+    static constexpr auto flags_mwrf = {
         MainWindowRedrawingFlag::WIPE,
         MainWindowRedrawingFlag::BASIC,
         MainWindowRedrawingFlag::EXTRA,

--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -65,7 +65,7 @@ void do_cmd_redraw(PlayerType *player_ptr)
         MainWindowRedrawingFlag::MAP,
     };
     rfu.set_flags(flags_mwrf);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
         SubWindowRedrawingFlag::SPELL,

--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -41,7 +41,7 @@ void do_cmd_redraw(PlayerType *player_ptr)
     term_xtra(TERM_XTRA_REACT, 0);
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::COMBINATION,
         StatusRedrawingFlag::REORDER,
         StatusRedrawingFlag::TORCH,

--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -42,19 +42,19 @@ void do_cmd_redraw(PlayerType *player_ptr)
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::COMBINATION,
-        StatusRedrawingFlag::REORDER,
-        StatusRedrawingFlag::TORCH,
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::HP,
-        StatusRedrawingFlag::MP,
-        StatusRedrawingFlag::SPELLS,
-        StatusRedrawingFlag::UN_VIEW,
-        StatusRedrawingFlag::UN_LITE,
-        StatusRedrawingFlag::VIEW,
-        StatusRedrawingFlag::LITE,
-        StatusRedrawingFlag::MONSTER_LITE,
-        StatusRedrawingFlag::MONSTER_STATUSES,
+        StatusRecalculatingFlag::COMBINATION,
+        StatusRecalculatingFlag::REORDER,
+        StatusRecalculatingFlag::TORCH,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::HP,
+        StatusRecalculatingFlag::MP,
+        StatusRecalculatingFlag::SPELLS,
+        StatusRecalculatingFlag::UN_VIEW,
+        StatusRecalculatingFlag::UN_LITE,
+        StatusRecalculatingFlag::VIEW,
+        StatusRecalculatingFlag::LITE,
+        StatusRecalculatingFlag::MONSTER_LITE,
+        StatusRecalculatingFlag::MONSTER_STATUSES,
     };
     rfu.set_flags(flags_srf);
     static constexpr auto flags_mwrf = {

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -665,7 +665,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX item, ItemEntity *j_ptr, SPE
                     }
                     /* Forget the wall */
                     reset_bits(g_ptr->info, (CAVE_MARK));
-                    const auto flags = {
+                    static constexpr auto flags = {
                         StatusRedrawingFlag::VIEW,
                         StatusRedrawingFlag::LITE,
                         StatusRedrawingFlag::FLOW,

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -666,10 +666,10 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX item, ItemEntity *j_ptr, SPE
                     /* Forget the wall */
                     reset_bits(g_ptr->info, (CAVE_MARK));
                     static constexpr auto flags = {
-                        StatusRedrawingFlag::VIEW,
-                        StatusRedrawingFlag::LITE,
-                        StatusRedrawingFlag::FLOW,
-                        StatusRedrawingFlag::MONSTER_LITE,
+                        StatusRecalculatingFlag::VIEW,
+                        StatusRecalculatingFlag::LITE,
+                        StatusRecalculatingFlag::FLOW,
+                        StatusRecalculatingFlag::MONSTER_LITE,
                     };
                     RedrawingFlagsUpdater::get_instance().set_flags(flags);
 

--- a/src/core/disturbance.cpp
+++ b/src/core/disturbance.cpp
@@ -35,8 +35,8 @@ void disturb(PlayerType *player_ptr, bool stop_search, bool stop_travel)
         }
 
         static constexpr auto flags = {
-            StatusRedrawingFlag::TORCH,
-            StatusRedrawingFlag::FLOW,
+            StatusRecalculatingFlag::TORCH,
+            StatusRecalculatingFlag::FLOW,
         };
         rfu.set_flags(flags);
     }
@@ -47,7 +47,7 @@ void disturb(PlayerType *player_ptr, bool stop_search, bool stop_travel)
             verify_panel(player_ptr);
         }
 
-        rfu.set_flag(StatusRedrawingFlag::TORCH);
+        rfu.set_flag(StatusRecalculatingFlag::TORCH);
     }
 
     if (flush_disturb) {

--- a/src/core/disturbance.cpp
+++ b/src/core/disturbance.cpp
@@ -34,7 +34,7 @@ void disturb(PlayerType *player_ptr, bool stop_search, bool stop_travel)
             verify_panel(player_ptr);
         }
 
-        const auto flags = {
+        static constexpr auto flags = {
             StatusRedrawingFlag::TORCH,
             StatusRedrawingFlag::FLOW,
         };

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -122,7 +122,7 @@ static void send_waiting_record(PlayerType *player_ptr)
         quit(0);
     }
 
-    const auto flags = {
+    static constexpr auto flags = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::HP,
         StatusRedrawingFlag::MP,

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -123,10 +123,10 @@ static void send_waiting_record(PlayerType *player_ptr)
     }
 
     static constexpr auto flags = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::HP,
-        StatusRedrawingFlag::MP,
-        StatusRedrawingFlag::SPELLS,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::HP,
+        StatusRecalculatingFlag::MP,
+        StatusRecalculatingFlag::SPELLS,
     };
     RedrawingFlagsUpdater::get_instance().set_flags(flags);
     update_creature(player_ptr);

--- a/src/core/object-compressor.cpp
+++ b/src/core/object-compressor.cpp
@@ -58,7 +58,7 @@ void compact_objects(PlayerType *player_ptr, int size)
         msg_print(_("アイテム情報を圧縮しています...", "Compacting objects..."));
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         rfu.set_flag(MainWindowRedrawingFlag::MAP);
-        const auto flags_swrf = {
+        static constexpr auto flags_swrf = {
             SubWindowRedrawingFlag::OVERHEAD,
             SubWindowRedrawingFlag::DUNGEON,
         };

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -229,7 +229,7 @@ void process_player(PlayerType *player_ptr)
         } else {
             set_current_ki(player_ptr, false, -40);
         }
-        rfu.set_flag(StatusRedrawingFlag::BONUS);
+        rfu.set_flag(StatusRecalculatingFlag::BONUS);
     }
 
     if (player_ptr->action == ACTION_LEARN) {
@@ -399,7 +399,7 @@ void process_player(PlayerType *player_ptr)
 
             if (player_ptr->timewalk && (player_ptr->energy_need > -1000)) {
                 rfu.set_flag(MainWindowRedrawingFlag::MAP);
-                rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+                rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
                 static constexpr auto flags_swrf = {
                     SubWindowRedrawingFlag::OVERHEAD,
                     SubWindowRedrawingFlag::DUNGEON,

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -400,7 +400,7 @@ void process_player(PlayerType *player_ptr)
             if (player_ptr->timewalk && (player_ptr->energy_need > -1000)) {
                 rfu.set_flag(MainWindowRedrawingFlag::MAP);
                 rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
-                const auto flags_swrf = {
+                static constexpr auto flags_swrf = {
                     SubWindowRedrawingFlag::OVERHEAD,
                     SubWindowRedrawingFlag::DUNGEON,
                 };

--- a/src/core/stuff-handler.cpp
+++ b/src/core/stuff-handler.cpp
@@ -60,7 +60,7 @@ void health_track(PlayerType *player_ptr, MONSTER_IDX m_idx)
 bool update_player()
 {
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::COMBINATION,
         StatusRedrawingFlag::REORDER,
     };
@@ -77,7 +77,7 @@ bool redraw_player(PlayerType *player_ptr)
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::MP);
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::COMBINATION,
         StatusRedrawingFlag::REORDER,
     };

--- a/src/core/stuff-handler.cpp
+++ b/src/core/stuff-handler.cpp
@@ -61,8 +61,8 @@ bool update_player()
 {
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::COMBINATION,
-        StatusRedrawingFlag::REORDER,
+        StatusRecalculatingFlag::COMBINATION,
+        StatusRecalculatingFlag::REORDER,
     };
     rfu.set_flags(flags_srf);
     rfu.set_flag(SubWindowRedrawingFlag::INVENTORY);
@@ -78,8 +78,8 @@ bool redraw_player(PlayerType *player_ptr)
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::MP);
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::COMBINATION,
-        StatusRedrawingFlag::REORDER,
+        StatusRecalculatingFlag::COMBINATION,
+        StatusRecalculatingFlag::REORDER,
     };
     rfu.set_flags(flags_srf);
     rfu.set_flag(SubWindowRedrawingFlag::INVENTORY);

--- a/src/core/window-redrawer.cpp
+++ b/src/core/window-redrawer.cpp
@@ -92,7 +92,7 @@ void redraw_stuff(PlayerType *player_ptr)
     }
 
     if (rfu.has(MainWindowRedrawingFlag::BASIC)) {
-        const auto flags = {
+        static constexpr auto flags = {
             MainWindowRedrawingFlag::BASIC,
             MainWindowRedrawingFlag::TITLE,
             MainWindowRedrawingFlag::ABILITY_SCORE,
@@ -183,7 +183,7 @@ void redraw_stuff(PlayerType *player_ptr)
     }
 
     if (rfu.has(MainWindowRedrawingFlag::EXTRA)) {
-        const auto flags = {
+        static constexpr auto flags = {
             MainWindowRedrawingFlag::EXTRA,
             MainWindowRedrawingFlag::CUT,
             MainWindowRedrawingFlag::STUN,

--- a/src/dungeon/dungeon-processor.cpp
+++ b/src/dungeon/dungeon-processor.cpp
@@ -66,17 +66,17 @@ static void redraw_character_xtra(PlayerType *player_ptr)
     };
     rfu.set_flags(flags_mwrf);
     auto flags_srf = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::HP,
-        StatusRedrawingFlag::MP,
-        StatusRedrawingFlag::SPELLS,
-        StatusRedrawingFlag::VIEW,
-        StatusRedrawingFlag::LITE,
-        StatusRedrawingFlag::MONSTER_LITE,
-        StatusRedrawingFlag::TORCH,
-        StatusRedrawingFlag::MONSTER_STATUSES,
-        StatusRedrawingFlag::DISTANCE,
-        StatusRedrawingFlag::FLOW,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::HP,
+        StatusRecalculatingFlag::MP,
+        StatusRecalculatingFlag::SPELLS,
+        StatusRecalculatingFlag::VIEW,
+        StatusRecalculatingFlag::LITE,
+        StatusRecalculatingFlag::MONSTER_LITE,
+        StatusRecalculatingFlag::TORCH,
+        StatusRecalculatingFlag::MONSTER_STATUSES,
+        StatusRecalculatingFlag::DISTANCE,
+        StatusRecalculatingFlag::FLOW,
     };
     rfu.set_flags(flags_srf);
     handle_stuff(player_ptr);
@@ -141,12 +141,12 @@ void process_dungeon(PlayerType *player_ptr, bool load_game)
 
     redraw_character_xtra(player_ptr);
     auto flags_srf = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::HP,
-        StatusRedrawingFlag::MP,
-        StatusRedrawingFlag::SPELLS,
-        StatusRedrawingFlag::COMBINATION,
-        StatusRedrawingFlag::REORDER,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::HP,
+        StatusRecalculatingFlag::MP,
+        StatusRecalculatingFlag::SPELLS,
+        StatusRecalculatingFlag::COMBINATION,
+        StatusRecalculatingFlag::REORDER,
     };
     RedrawingFlagsUpdater::get_instance().set_flags(flags_srf);
     handle_stuff(player_ptr);

--- a/src/dungeon/dungeon-processor.cpp
+++ b/src/dungeon/dungeon-processor.cpp
@@ -47,7 +47,7 @@ static void redraw_character_xtra(PlayerType *player_ptr)
 {
     w_ptr->character_xtra = true;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
         SubWindowRedrawingFlag::SPELL,

--- a/src/dungeon/dungeon-processor.cpp
+++ b/src/dungeon/dungeon-processor.cpp
@@ -57,7 +57,7 @@ static void redraw_character_xtra(PlayerType *player_ptr)
         SubWindowRedrawingFlag::DUNGEON,
     };
     rfu.set_flags(flags_swrf);
-    const auto flags_mwrf = {
+    static constexpr auto flags_mwrf = {
         MainWindowRedrawingFlag::WIPE,
         MainWindowRedrawingFlag::BASIC,
         MainWindowRedrawingFlag::EXTRA,

--- a/src/dungeon/quest-completion-checker.cpp
+++ b/src/dungeon/quest-completion-checker.cpp
@@ -240,7 +240,7 @@ Pos2D QuestCompletionChecker::make_stairs(const bool create_stairs)
 
     msg_print(_("魔法の階段が現れた...", "A magical staircase appears..."));
     cave_set_feat(this->player_ptr, y, x, feat_down_stair);
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::FLOW);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::FLOW);
     return Pos2D(y, x);
 }
 

--- a/src/effect/effect-feature.cpp
+++ b/src/effect/effect-feature.cpp
@@ -255,7 +255,7 @@ bool affect_feature(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITIO
         }
 
         cave_alter_feat(player_ptr, y, x, TerrainCharacteristics::HURT_ROCK);
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::FLOW);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::FLOW);
         break;
     }
     case AttributeType::MAKE_DOOR: {
@@ -433,7 +433,7 @@ bool affect_feature(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITIO
         }
 
         cave_alter_feat(player_ptr, y, x, TerrainCharacteristics::HURT_ROCK);
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::FLOW);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::FLOW);
         break;
     }
     case AttributeType::SOUND: {
@@ -455,7 +455,7 @@ bool affect_feature(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITIO
         }
 
         cave_alter_feat(player_ptr, y, x, TerrainCharacteristics::HURT_ROCK);
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::FLOW);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::FLOW);
         break;
     }
     case AttributeType::DISINTEGRATE: {
@@ -468,7 +468,7 @@ bool affect_feature(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITIO
         }
 
         cave_alter_feat(player_ptr, y, x, TerrainCharacteristics::HURT_DISI);
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::FLOW);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::FLOW);
         break;
     }
     default:

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -437,7 +437,7 @@ void effect_player_lite(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
         MainWindowRedrawingFlag::TIMED_EFFECT,
     };
     rfu.set_flags(flags_mwrf);
-    rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+    rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
     static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::OVERHEAD,
         SubWindowRedrawingFlag::DUNGEON,

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -438,7 +438,7 @@ void effect_player_lite(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
     };
     rfu.set_flags(flags_mwrf);
     rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::OVERHEAD,
         SubWindowRedrawingFlag::DUNGEON,
     };

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -432,7 +432,7 @@ void effect_player_lite(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
     msg_print(_("閃光のため非物質的な影の存在でいられなくなった。", "The light forces you out of your incorporeal shadow form."));
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_mwrf = {
+    static constexpr auto flags_mwrf = {
         MainWindowRedrawingFlag::MAP,
         MainWindowRedrawingFlag::TIMED_EFFECT,
     };

--- a/src/effect/effect-player-spirit.cpp
+++ b/src/effect/effect-player-spirit.cpp
@@ -42,7 +42,7 @@ void effect_player_drain_mana(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::MP);
-    const auto flags = {
+    static constexpr auto flags = {
         SubWindowRedrawingFlag::PLAYER,
         SubWindowRedrawingFlag::SPELL,
     };

--- a/src/floor/floor-events.cpp
+++ b/src/floor/floor-events.cpp
@@ -52,7 +52,7 @@ static void update_sun_light(PlayerType *player_ptr)
     };
     rfu.set_flags(flags_srf);
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
-    const auto flags = {
+    static constexpr auto flags = {
         SubWindowRedrawingFlag::OVERHEAD,
         SubWindowRedrawingFlag::DUNGEON,
     };

--- a/src/floor/floor-events.cpp
+++ b/src/floor/floor-events.cpp
@@ -47,8 +47,8 @@ static void update_sun_light(PlayerType *player_ptr)
 {
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::MONSTER_STATUSES,
-        StatusRedrawingFlag::MONSTER_LITE,
+        StatusRecalculatingFlag::MONSTER_STATUSES,
+        StatusRecalculatingFlag::MONSTER_LITE,
     };
     rfu.set_flags(flags_srf);
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
@@ -354,9 +354,9 @@ void glow_deep_lava_and_bldg(PlayerType *player_ptr)
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::VIEW,
-        StatusRedrawingFlag::LITE,
-        StatusRedrawingFlag::MONSTER_LITE,
+        StatusRecalculatingFlag::VIEW,
+        StatusRecalculatingFlag::LITE,
+        StatusRecalculatingFlag::MONSTER_LITE,
     };
     rfu.set_flags(flags_srf);
     rfu.set_flag(MainWindowRedrawingFlag::MAP);

--- a/src/floor/floor-events.cpp
+++ b/src/floor/floor-events.cpp
@@ -46,7 +46,7 @@
 static void update_sun_light(PlayerType *player_ptr)
 {
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::MONSTER_STATUSES,
         StatusRedrawingFlag::MONSTER_LITE,
     };
@@ -353,7 +353,7 @@ void glow_deep_lava_and_bldg(PlayerType *player_ptr)
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::VIEW,
         StatusRedrawingFlag::LITE,
         StatusRedrawingFlag::MONSTER_LITE,

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -231,7 +231,7 @@ void floor_item_increase(PlayerType *player_ptr, INVENTORY_IDX item, ITEM_NUMBER
 
     num -= o_ptr->number;
     o_ptr->number += num;
-    const auto flags = {
+    static constexpr auto flags = {
         SubWindowRedrawingFlag::FLOOR_ITEMS,
         SubWindowRedrawingFlag::FOUND_ITEMS,
     };
@@ -255,7 +255,7 @@ void floor_item_optimize(PlayerType *player_ptr, INVENTORY_IDX item)
     }
 
     delete_object_idx(player_ptr, item);
-    const auto flags = {
+    static constexpr auto flags = {
         SubWindowRedrawingFlag::FLOOR_ITEMS,
         SubWindowRedrawingFlag::FOUND_ITEMS,
     };
@@ -285,7 +285,7 @@ void delete_object_idx(PlayerType *player_ptr, OBJECT_IDX o_idx)
 
     j_ptr->wipe();
     floor_ptr->o_cnt--;
-    const auto flags = {
+    static constexpr auto flags = {
         SubWindowRedrawingFlag::FLOOR_ITEMS,
         SubWindowRedrawingFlag::FOUND_ITEMS,
     };
@@ -570,7 +570,7 @@ OBJECT_IDX drop_near(PlayerType *player_ptr, ItemEntity *j_ptr, PERCENTAGE chanc
     sound(SOUND_DROP);
 
     if (player_bold(player_ptr, by, bx)) {
-        const auto flags = {
+        static constexpr auto flags = {
             SubWindowRedrawingFlag::FLOOR_ITEMS,
             SubWindowRedrawingFlag::FOUND_ITEMS,
         };

--- a/src/grid/feature.cpp
+++ b/src/grid/feature.cpp
@@ -250,7 +250,7 @@ void cave_set_feat(PlayerType *player_ptr, POSITION y, POSITION x, FEAT_IDX feat
     note_spot(player_ptr, y, x);
     lite_spot(player_ptr, y, x);
     if (old_los ^ f_ptr->flags.has(TerrainCharacteristics::LOS)) {
-        const auto flags = {
+        static constexpr auto flags = {
             StatusRedrawingFlag::VIEW,
             StatusRedrawingFlag::LITE,
             StatusRedrawingFlag::MONSTER_LITE,

--- a/src/grid/feature.cpp
+++ b/src/grid/feature.cpp
@@ -251,10 +251,10 @@ void cave_set_feat(PlayerType *player_ptr, POSITION y, POSITION x, FEAT_IDX feat
     lite_spot(player_ptr, y, x);
     if (old_los ^ f_ptr->flags.has(TerrainCharacteristics::LOS)) {
         static constexpr auto flags = {
-            StatusRedrawingFlag::VIEW,
-            StatusRedrawingFlag::LITE,
-            StatusRedrawingFlag::MONSTER_LITE,
-            StatusRedrawingFlag::MONSTER_STATUSES,
+            StatusRecalculatingFlag::VIEW,
+            StatusRecalculatingFlag::LITE,
+            StatusRecalculatingFlag::MONSTER_LITE,
+            StatusRecalculatingFlag::MONSTER_STATUSES,
         };
         RedrawingFlagsUpdater::get_instance().set_flags(flags);
     }

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -432,7 +432,7 @@ void lite_spot(PlayerType *player_ptr, POSITION y, POSITION x)
         }
 
         term_queue_bigchar(panel_col_of(x), y - panel_row_prt, a, c, ta, tc);
-        const auto flags = {
+        static constexpr auto flags = {
             SubWindowRedrawingFlag::OVERHEAD,
             SubWindowRedrawingFlag::DUNGEON,
         };

--- a/src/hpmp/hp-mp-regenerator.cpp
+++ b/src/hpmp/hp-mp-regenerator.cpp
@@ -110,7 +110,7 @@ void regenmana(PlayerType *player_ptr, MANA_POINT upkeep_factor, MANA_POINT rege
     if (old_csp != player_ptr->csp) {
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         rfu.set_flag(MainWindowRedrawingFlag::MP);
-        const auto flags = {
+        static constexpr auto flags = {
             SubWindowRedrawingFlag::PLAYER,
             SubWindowRedrawingFlag::SPELL,
         };

--- a/src/hpmp/hp-mp-regenerator.cpp
+++ b/src/hpmp/hp-mp-regenerator.cpp
@@ -251,7 +251,7 @@ void regenerate_captured_monsters(PlayerType *player_ptr)
     }
 
     if (heal) {
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::COMBINATION);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::COMBINATION);
 
         /*!
          * @todo FIXME 広域マップ移動で1歩毎に何度も再描画されて重くなる.

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -306,7 +306,7 @@ bool get_item_floor(PlayerType *player_ptr, COMMAND_CODE *cp, concptr pmt, concp
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags = {
+    static constexpr auto flags = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
     };

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -283,7 +283,7 @@ static void multiply_low_curse(PlayerType *player_ptr)
     o_ptr->curse_flags.set(new_curse);
     msg_format(_("悪意に満ちた黒いオーラが%sをとりまいた...", "There is a malignant black aura surrounding your %s..."), item_name.data());
     o_ptr->feeling = FEEL_NONE;
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
 }
 
 static void multiply_high_curse(PlayerType *player_ptr)
@@ -303,7 +303,7 @@ static void multiply_high_curse(PlayerType *player_ptr)
     o_ptr->curse_flags.set(new_curse);
     msg_format(_("悪意に満ちた黒いオーラが%sをとりまいた...", "There is a malignant black aura surrounding your %s..."), item_name.data());
     o_ptr->feeling = FEEL_NONE;
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
 }
 
 static void persist_curse(PlayerType *player_ptr)
@@ -322,7 +322,7 @@ static void persist_curse(PlayerType *player_ptr)
     o_ptr->curse_flags.set(CurseTraitType::HEAVY_CURSE);
     msg_format(_("悪意に満ちた黒いオーラが%sをとりまいた...", "There is a malignant black aura surrounding your %s..."), item_name.data());
     o_ptr->feeling = FEEL_NONE;
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
 }
 
 static void curse_call_monster(PlayerType *player_ptr)

--- a/src/inventory/inventory-object.cpp
+++ b/src/inventory/inventory-object.cpp
@@ -122,7 +122,7 @@ void inven_item_optimize(PlayerType *player_ptr, INVENTORY_IDX item)
     }
 
     (&player_ptr->inventory_list[i])->wipe();
-    const auto flags = {
+    static constexpr auto flags = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::SPELL,
     };

--- a/src/inventory/inventory-object.cpp
+++ b/src/inventory/inventory-object.cpp
@@ -61,7 +61,7 @@ void inven_item_increase(PlayerType *player_ptr, INVENTORY_IDX item, ITEM_NUMBER
         StatusRedrawingFlag::COMBINATION,
     };
     rfu.set_flags(flags_srf);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
     };
@@ -107,7 +107,7 @@ void inven_item_optimize(PlayerType *player_ptr, INVENTORY_IDX item)
             StatusRedrawingFlag::MP,
         };
         rfu.set_flags(flags_srf);
-        const auto flags_swrf = {
+        static constexpr auto flags_swrf = {
             SubWindowRedrawingFlag::EQUIPMENT,
             SubWindowRedrawingFlag::SPELL,
         };
@@ -324,7 +324,7 @@ int16_t store_item_to_inventory(PlayerType *player_ptr, ItemEntity *o_ptr)
 
     ItemEntity *j_ptr;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::PLAYER,
     };

--- a/src/inventory/inventory-object.cpp
+++ b/src/inventory/inventory-object.cpp
@@ -55,7 +55,7 @@ void inven_item_increase(PlayerType *player_ptr, INVENTORY_IDX item, ITEM_NUMBER
 
     o_ptr->number += num;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::MP,
         StatusRedrawingFlag::COMBINATION,
@@ -101,7 +101,7 @@ void inven_item_optimize(PlayerType *player_ptr, INVENTORY_IDX item)
     if (item >= INVEN_MAIN_HAND) {
         player_ptr->equip_cnt--;
         (&player_ptr->inventory_list[item])->wipe();
-        const auto flags_srf = {
+        static constexpr auto flags_srf = {
             StatusRedrawingFlag::BONUS,
             StatusRedrawingFlag::TORCH,
             StatusRedrawingFlag::MP,
@@ -378,7 +378,7 @@ int16_t store_item_to_inventory(PlayerType *player_ptr, ItemEntity *o_ptr)
     j_ptr->marked.clear().set(OmType::TOUCHED);
 
     player_ptr->inven_cnt++;
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::COMBINATION,
         StatusRedrawingFlag::REORDER,

--- a/src/inventory/inventory-object.cpp
+++ b/src/inventory/inventory-object.cpp
@@ -56,9 +56,9 @@ void inven_item_increase(PlayerType *player_ptr, INVENTORY_IDX item, ITEM_NUMBER
     o_ptr->number += num;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::MP,
-        StatusRedrawingFlag::COMBINATION,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::MP,
+        StatusRecalculatingFlag::COMBINATION,
     };
     rfu.set_flags(flags_srf);
     static constexpr auto flags_swrf = {
@@ -102,9 +102,9 @@ void inven_item_optimize(PlayerType *player_ptr, INVENTORY_IDX item)
         player_ptr->equip_cnt--;
         (&player_ptr->inventory_list[item])->wipe();
         static constexpr auto flags_srf = {
-            StatusRedrawingFlag::BONUS,
-            StatusRedrawingFlag::TORCH,
-            StatusRedrawingFlag::MP,
+            StatusRecalculatingFlag::BONUS,
+            StatusRecalculatingFlag::TORCH,
+            StatusRecalculatingFlag::MP,
         };
         rfu.set_flags(flags_srf);
         static constexpr auto flags_swrf = {
@@ -337,7 +337,7 @@ int16_t store_item_to_inventory(PlayerType *player_ptr, ItemEntity *o_ptr)
         n = j;
         if (object_similar(j_ptr, o_ptr)) {
             object_absorb(j_ptr, o_ptr);
-            rfu.set_flag(StatusRedrawingFlag::BONUS);
+            rfu.set_flag(StatusRecalculatingFlag::BONUS);
             rfu.set_flags(flags_swrf);
             return j;
         }
@@ -379,9 +379,9 @@ int16_t store_item_to_inventory(PlayerType *player_ptr, ItemEntity *o_ptr)
 
     player_ptr->inven_cnt++;
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::COMBINATION,
-        StatusRedrawingFlag::REORDER,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::COMBINATION,
+        StatusRecalculatingFlag::REORDER,
     };
     rfu.set_flags(flags_srf);
     rfu.set_flags(flags_swrf);

--- a/src/inventory/item-getter.cpp
+++ b/src/inventory/item-getter.cpp
@@ -295,7 +295,7 @@ bool get_item(PlayerType *player_ptr, OBJECT_IDX *cp, concptr pmt, concptr str, 
         screen_save();
     }
 
-    const auto flags = {
+    static constexpr auto flags = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
     };

--- a/src/inventory/player-inventory.cpp
+++ b/src/inventory/player-inventory.cpp
@@ -244,7 +244,7 @@ void carry(PlayerType *player_ptr, bool pickup)
 {
     verify_panel(player_ptr);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+    rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
     rfu.set_flag(SubWindowRedrawingFlag::OVERHEAD);
     handle_stuff(player_ptr);

--- a/src/io/cursor.cpp
+++ b/src/io/cursor.cpp
@@ -133,7 +133,7 @@ bool change_panel(PlayerType *player_ptr, POSITION dy, POSITION dx)
     panel_col_min = x;
     panel_bounds_center();
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+    rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
     handle_stuff(player_ptr);
     return true;

--- a/src/io/input-key-processor.cpp
+++ b/src/io/input-key-processor.cpp
@@ -189,7 +189,7 @@ void process_command(PlayerType *player_ptr)
         }
 
         auto &rfu = RedrawingFlagsUpdater::get_instance();
-        rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+        rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
         rfu.set_flag(MainWindowRedrawingFlag::TITLE);
         break;
     }

--- a/src/io/report.cpp
+++ b/src/io/report.cpp
@@ -310,7 +310,7 @@ concptr make_screen_dump(PlayerType *player_ptr)
         use_graphics = false;
         reset_visuals(player_ptr);
 
-        const auto flags = {
+        static constexpr auto flags = {
             MainWindowRedrawingFlag::WIPE,
             MainWindowRedrawingFlag::BASIC,
             MainWindowRedrawingFlag::EXTRA,
@@ -410,7 +410,7 @@ concptr make_screen_dump(PlayerType *player_ptr)
 
     use_graphics = true;
     reset_visuals(player_ptr);
-    const auto flags = {
+    static constexpr auto flags = {
         MainWindowRedrawingFlag::WIPE,
         MainWindowRedrawingFlag::BASIC,
         MainWindowRedrawingFlag::EXTRA,

--- a/src/io/screen-util.cpp
+++ b/src/io/screen-util.cpp
@@ -56,17 +56,17 @@ void resize_map()
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::TORCH,
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::HP,
-        StatusRedrawingFlag::MP,
-        StatusRedrawingFlag::SPELLS,
-        StatusRedrawingFlag::UN_VIEW,
-        StatusRedrawingFlag::UN_LITE,
-        StatusRedrawingFlag::VIEW,
-        StatusRedrawingFlag::LITE,
-        StatusRedrawingFlag::MONSTER_LITE,
-        StatusRedrawingFlag::MONSTER_STATUSES,
+        StatusRecalculatingFlag::TORCH,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::HP,
+        StatusRecalculatingFlag::MP,
+        StatusRecalculatingFlag::SPELLS,
+        StatusRecalculatingFlag::UN_VIEW,
+        StatusRecalculatingFlag::UN_LITE,
+        StatusRecalculatingFlag::VIEW,
+        StatusRecalculatingFlag::LITE,
+        StatusRecalculatingFlag::MONSTER_LITE,
+        StatusRecalculatingFlag::MONSTER_STATUSES,
     };
     rfu.set_flags(flags_srf);
     static constexpr auto flags_mwrf = {

--- a/src/io/screen-util.cpp
+++ b/src/io/screen-util.cpp
@@ -69,7 +69,7 @@ void resize_map()
         StatusRedrawingFlag::MONSTER_STATUSES,
     };
     rfu.set_flags(flags_srf);
-    const auto flags_mwrf = {
+    static constexpr auto flags_mwrf = {
         MainWindowRedrawingFlag::WIPE,
         MainWindowRedrawingFlag::BASIC,
         MainWindowRedrawingFlag::EXTRA,

--- a/src/io/screen-util.cpp
+++ b/src/io/screen-util.cpp
@@ -55,7 +55,7 @@ void resize_map()
     verify_panel(p_ptr);
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::TORCH,
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::HP,

--- a/src/market/building-craft-fix.cpp
+++ b/src/market/building-craft-fix.cpp
@@ -301,7 +301,7 @@ static PRICE repair_broken_weapon_aux(PlayerType *player_ptr, PRICE bcost)
     inven_item_increase(player_ptr, mater, -1);
     inven_item_optimize(player_ptr, mater);
 
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
     return cost;
 }

--- a/src/market/building-craft-weapon.cpp
+++ b/src/market/building-craft-weapon.cpp
@@ -386,7 +386,7 @@ PRICE compare_weapons(PlayerType *player_ptr, PRICE bcost)
                 i_ptr->copy_from(o_ptr[i]);
             }
 
-            rfu.set_flag(StatusRedrawingFlag::BONUS);
+            rfu.set_flag(StatusRecalculatingFlag::BONUS);
             handle_stuff(player_ptr);
 
             list_weapon(player_ptr, o_ptr[i], row, col);
@@ -394,7 +394,7 @@ PRICE compare_weapons(PlayerType *player_ptr, PRICE bcost)
             i_ptr->copy_from(&orig_weapon);
         }
 
-        rfu.set_flag(StatusRedrawingFlag::BONUS);
+        rfu.set_flag(StatusRecalculatingFlag::BONUS);
         handle_stuff(player_ptr);
 
         w_ptr->character_xtra = old_character_xtra;

--- a/src/market/building-recharger.cpp
+++ b/src/market/building-recharger.cpp
@@ -153,7 +153,7 @@ void building_recharge(PlayerType *player_ptr)
     msg_format("%s^ %s recharged for %d gold.", item_name.data(), ((o_ptr->number > 1) ? "were" : "was"), price);
 #endif
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags = {
+    static constexpr auto flags = {
         StatusRedrawingFlag::COMBINATION,
         StatusRedrawingFlag::REORDER,
     };
@@ -270,7 +270,7 @@ void building_recharge_all(PlayerType *player_ptr)
     msg_format(_("＄%d で再充填しました。", "You pay %d gold."), total_cost);
     msg_print(nullptr);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags = {
+    static constexpr auto flags = {
         StatusRedrawingFlag::COMBINATION,
         StatusRedrawingFlag::REORDER,
     };

--- a/src/market/building-recharger.cpp
+++ b/src/market/building-recharger.cpp
@@ -154,8 +154,8 @@ void building_recharge(PlayerType *player_ptr)
 #endif
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags = {
-        StatusRedrawingFlag::COMBINATION,
-        StatusRedrawingFlag::REORDER,
+        StatusRecalculatingFlag::COMBINATION,
+        StatusRecalculatingFlag::REORDER,
     };
     rfu.set_flags(flags);
     rfu.set_flag(SubWindowRedrawingFlag::INVENTORY);
@@ -271,8 +271,8 @@ void building_recharge_all(PlayerType *player_ptr)
     msg_print(nullptr);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags = {
-        StatusRedrawingFlag::COMBINATION,
-        StatusRedrawingFlag::REORDER,
+        StatusRecalculatingFlag::COMBINATION,
+        StatusRecalculatingFlag::REORDER,
     };
     rfu.set_flags(flags);
     rfu.set_flag(SubWindowRedrawingFlag::INVENTORY);

--- a/src/mind/mind-archer.cpp
+++ b/src/mind/mind-archer.cpp
@@ -140,7 +140,7 @@ bool create_ammo(PlayerType *player_ptr)
         }
 
         cave_alter_feat(player_ptr, y, x, TerrainCharacteristics::HURT_ROCK);
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::FLOW);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::FLOW);
         return true;
     }
     case AMMO_ARROW: {

--- a/src/mind/mind-blue-mage.cpp
+++ b/src/mind/mind-blue-mage.cpp
@@ -91,7 +91,7 @@ bool do_cmd_cast_learned(PlayerType *player_ptr)
     PlayerEnergy(player_ptr).set_player_turn_energy(100);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::MP);
-    const auto flags = {
+    static constexpr auto flags = {
         SubWindowRedrawingFlag::PLAYER,
         SubWindowRedrawingFlag::SPELL,
     };

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -890,7 +890,7 @@ static bool try_cast_element_spell(PlayerType *player_ptr, SPELL_IDX spell_idx, 
         PlayerEnergy(player_ptr).set_player_turn_energy(100);
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         rfu.set_flag(MainWindowRedrawingFlag::MP);
-        const auto flags_swrf = {
+        static constexpr auto flags_swrf = {
             SubWindowRedrawingFlag::PLAYER,
             SubWindowRedrawingFlag::SPELL,
         };
@@ -943,7 +943,7 @@ void do_cmd_element(PlayerType *player_ptr)
     PlayerEnergy(player_ptr).set_player_turn_energy(100);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::MP);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::PLAYER,
         SubWindowRedrawingFlag::SPELL,
     };

--- a/src/mind/mind-force-trainer.cpp
+++ b/src/mind/mind-force-trainer.cpp
@@ -139,7 +139,7 @@ void set_lightspeed(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
 
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
 }
 
@@ -256,7 +256,7 @@ bool shock_power(PlayerType *player_ptr)
     lite_spot(player_ptr, ty, tx);
 
     if (r_ptr->brightness_flags.has_any_of(ld_mask)) {
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::MONSTER_LITE);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::MONSTER_LITE);
     }
 
     return true;
@@ -306,7 +306,7 @@ bool cast_force_spell(PlayerType *player_ptr, MindForceTrainerType spell)
     case MindForceTrainerType::IMPROVE_FORCE:
         msg_print(_("気を練った。", "You improved the Force."));
         set_current_ki(player_ptr, false, 70 + plev);
-        rfu.set_flag(StatusRedrawingFlag::BONUS);
+        rfu.set_flag(StatusRecalculatingFlag::BONUS);
         if (randint1(get_current_ki(player_ptr)) > (plev * 4 + 120)) {
             msg_print(_("気が暴走した！", "The Force exploded!"));
             fire_ball(player_ptr, AttributeType::MANA, 0, get_current_ki(player_ptr) / 2, 10);
@@ -378,6 +378,6 @@ bool cast_force_spell(PlayerType *player_ptr, MindForceTrainerType spell)
     }
 
     set_current_ki(player_ptr, true, 0);
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     return true;
 }

--- a/src/mind/mind-magic-resistance.cpp
+++ b/src/mind/mind-magic-resistance.cpp
@@ -49,7 +49,7 @@ bool set_resist_magic(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
 
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
     return true;
 }

--- a/src/mind/mind-mindcrafter.cpp
+++ b/src/mind/mind-mindcrafter.cpp
@@ -90,7 +90,7 @@ bool psychometry(PlayerType *player_ptr)
         StatusRedrawingFlag::REORDER,
     };
     rfu.set_flags(flags_srf);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
         SubWindowRedrawingFlag::PLAYER,

--- a/src/mind/mind-mindcrafter.cpp
+++ b/src/mind/mind-mindcrafter.cpp
@@ -85,7 +85,7 @@ bool psychometry(PlayerType *player_ptr)
     o_ptr->marked.set(OmType::TOUCHED);
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::COMBINATION,
         StatusRedrawingFlag::REORDER,
     };

--- a/src/mind/mind-mindcrafter.cpp
+++ b/src/mind/mind-mindcrafter.cpp
@@ -86,8 +86,8 @@ bool psychometry(PlayerType *player_ptr)
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::COMBINATION,
-        StatusRedrawingFlag::REORDER,
+        StatusRecalculatingFlag::COMBINATION,
+        StatusRecalculatingFlag::REORDER,
     };
     rfu.set_flags(flags_srf);
     static constexpr auto flags_swrf = {

--- a/src/mind/mind-mirror-master.cpp
+++ b/src/mind/mind-mirror-master.cpp
@@ -279,7 +279,7 @@ bool set_multishadow(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
 
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
     return true;
 }
@@ -327,7 +327,7 @@ bool set_dustrobe(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
 
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
     return true;
 }

--- a/src/mind/mind-monk.cpp
+++ b/src/mind/mind-monk.cpp
@@ -24,7 +24,7 @@ static void set_stance(PlayerType *player_ptr, const MonkStanceType new_stance)
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     rfu.set_flag(MainWindowRedrawingFlag::ACTION);
     msg_format(_("%sの構えをとった。", "You assume the %s stance."), monk_stances[enum2i(new_stance) - 1].desc);
     pc.set_monk_stance(new_stance);

--- a/src/mind/mind-priest.cpp
+++ b/src/mind/mind-priest.cpp
@@ -63,7 +63,7 @@ bool bless_weapon(PlayerType *player_ptr)
         set_bits(o_ptr->ident, IDENT_SENSE);
         o_ptr->feeling = FEEL_NONE;
         rfu.set_flag(StatusRedrawingFlag::BONUS);
-        const auto flags = {
+        static constexpr auto flags = {
             SubWindowRedrawingFlag::EQUIPMENT,
             SubWindowRedrawingFlag::FLOOR_ITEMS,
             SubWindowRedrawingFlag::FOUND_ITEMS,

--- a/src/mind/mind-priest.cpp
+++ b/src/mind/mind-priest.cpp
@@ -142,7 +142,7 @@ bool bless_weapon(PlayerType *player_ptr)
     }
 
     rfu.set_flag(StatusRedrawingFlag::BONUS);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::EQUIPMENT,
         SubWindowRedrawingFlag::PLAYER,
         SubWindowRedrawingFlag::FLOOR_ITEMS,

--- a/src/mind/mind-priest.cpp
+++ b/src/mind/mind-priest.cpp
@@ -62,7 +62,7 @@ bool bless_weapon(PlayerType *player_ptr)
         o_ptr->curse_flags.clear();
         set_bits(o_ptr->ident, IDENT_SENSE);
         o_ptr->feeling = FEEL_NONE;
-        rfu.set_flag(StatusRedrawingFlag::BONUS);
+        rfu.set_flag(StatusRecalculatingFlag::BONUS);
         static constexpr auto flags = {
             SubWindowRedrawingFlag::EQUIPMENT,
             SubWindowRedrawingFlag::FLOOR_ITEMS,
@@ -141,7 +141,7 @@ bool bless_weapon(PlayerType *player_ptr)
         }
     }
 
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::EQUIPMENT,
         SubWindowRedrawingFlag::PLAYER,

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -448,7 +448,7 @@ bool choose_samurai_stance(PlayerType *player_ptr)
         PlayerClass(player_ptr).set_samurai_stance(new_stance);
     }
 
-    const auto flags = {
+    static constexpr auto flags = {
         MainWindowRedrawingFlag::ACTION,
         MainWindowRedrawingFlag::TIMED_EFFECT,
     };

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -440,8 +440,8 @@ bool choose_samurai_stance(PlayerType *player_ptr)
         msg_print(_("構え直した。", "You reassume a stance."));
     } else {
         static constexpr auto flags_srf = {
-            StatusRedrawingFlag::BONUS,
-            StatusRedrawingFlag::MONSTER_STATUSES,
+            StatusRecalculatingFlag::BONUS,
+            StatusRecalculatingFlag::MONSTER_STATUSES,
         };
         rfu.set_flags(flags_srf);
         msg_format(_("%sの型で構えた。", "You assume the %s stance."), samurai_stances[enum2i(new_stance) - 1].desc);

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -439,7 +439,7 @@ bool choose_samurai_stance(PlayerType *player_ptr)
     if (PlayerClass(player_ptr).samurai_stance_is(new_stance)) {
         msg_print(_("構え直した。", "You reassume a stance."));
     } else {
-        const auto flags_srf = {
+        static constexpr auto flags_srf = {
             StatusRedrawingFlag::BONUS,
             StatusRedrawingFlag::MONSTER_STATUSES,
         };

--- a/src/mind/mind-sniper.cpp
+++ b/src/mind/mind-sniper.cpp
@@ -132,8 +132,8 @@ void SniperData::reset_concentration_flag()
     this->reset_concent = false;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::MONSTER_STATUSES,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::MONSTER_STATUSES,
     };
     rfu.set_flags(flags);
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);

--- a/src/mind/mind-sniper.cpp
+++ b/src/mind/mind-sniper.cpp
@@ -131,7 +131,7 @@ void SniperData::reset_concentration_flag()
 {
     this->reset_concent = false;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags = {
+    static constexpr auto flags = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::MONSTER_STATUSES,
     };

--- a/src/mind/mind-sniper.cpp
+++ b/src/mind/mind-sniper.cpp
@@ -629,7 +629,7 @@ void do_cmd_snipe(PlayerType *player_ptr)
         MainWindowRedrawingFlag::MP,
     };
     rfu.set_flags(flags_mwrf);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::PLAYER,
         SubWindowRedrawingFlag::SPELL,
     };

--- a/src/mind/mind-sniper.cpp
+++ b/src/mind/mind-sniper.cpp
@@ -624,7 +624,7 @@ void do_cmd_snipe(PlayerType *player_ptr)
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_mwrf = {
+    static constexpr auto flags_mwrf = {
         MainWindowRedrawingFlag::HP,
         MainWindowRedrawingFlag::MP,
     };

--- a/src/mind/mind-warrior-mage.cpp
+++ b/src/mind/mind-warrior-mage.cpp
@@ -10,7 +10,7 @@ bool comvert_hp_to_mp(PlayerType *player_ptr)
     constexpr auto mes = _("ＨＰからＭＰへの無謀な変換", "thoughtless conversion from HP to SP");
     auto gain_sp = take_hit(player_ptr, DAMAGE_USELIFE, player_ptr->lev, mes) / 5;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags = {
+    static constexpr auto flags = {
         MainWindowRedrawingFlag::HP,
         MainWindowRedrawingFlag::MP,
     };
@@ -39,7 +39,7 @@ bool comvert_mp_to_hp(PlayerType *player_ptr)
         msg_print(_("変換に失敗した。", "You failed to convert."));
     }
 
-    const auto flags = {
+    static constexpr auto flags = {
         MainWindowRedrawingFlag::HP,
         MainWindowRedrawingFlag::MP,
     };

--- a/src/mind/mind-weaponsmith.cpp
+++ b/src/mind/mind-weaponsmith.cpp
@@ -108,8 +108,8 @@ static void set_smith_redrawing_flags()
 {
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags = {
-        StatusRedrawingFlag::COMBINATION,
-        StatusRedrawingFlag::REORDER,
+        StatusRecalculatingFlag::COMBINATION,
+        StatusRecalculatingFlag::REORDER,
     };
     rfu.set_flags(flags);
     rfu.set_flag(SubWindowRedrawingFlag::INVENTORY);

--- a/src/mind/mind-weaponsmith.cpp
+++ b/src/mind/mind-weaponsmith.cpp
@@ -107,7 +107,7 @@ static void display_essence(PlayerType *player_ptr)
 static void set_smith_redrawing_flags()
 {
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags = {
+    static constexpr auto flags = {
         StatusRedrawingFlag::COMBINATION,
         StatusRedrawingFlag::REORDER,
     };

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -474,7 +474,7 @@ void MonsterAttackPlayer::gain_armor_exp()
     }
 
     this->player_ptr->skill_exp[PlayerSkillKindType::SHIELD] = std::min<short>(max, cur + increment);
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
 }
 
 /*!

--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -263,8 +263,8 @@ bool process_un_power(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
 
     monap_ptr->o_ptr->pval = !is_magic_mastery || (monap_ptr->o_ptr->pval == 1) ? 0 : monap_ptr->o_ptr->pval - drain;
     static constexpr auto flags = {
-        StatusRedrawingFlag::COMBINATION,
-        StatusRedrawingFlag::REORDER,
+        StatusRecalculatingFlag::COMBINATION,
+        StatusRecalculatingFlag::REORDER,
     };
     rfu.set_flags(flags);
     rfu.set_flag(SubWindowRedrawingFlag::INVENTORY);

--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -262,7 +262,7 @@ bool process_un_power(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
     }
 
     monap_ptr->o_ptr->pval = !is_magic_mastery || (monap_ptr->o_ptr->pval == 1) ? 0 : monap_ptr->o_ptr->pval - drain;
-    const auto flags = {
+    static constexpr auto flags = {
         StatusRedrawingFlag::COMBINATION,
         StatusRedrawingFlag::REORDER,
     };

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -389,7 +389,7 @@ void monster_death(PlayerType *player_ptr, MONSTER_IDX m_idx, bool drop_item, At
     }
 
     if (md_ptr->r_ptr->brightness_flags.has_any_of(ld_mask)) {
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::MONSTER_LITE);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::MONSTER_LITE);
     }
 
     write_pet_death(player_ptr, md_ptr);

--- a/src/monster-floor/monster-lite.cpp
+++ b/src/monster-floor/monster-lite.cpp
@@ -341,7 +341,7 @@ void update_mon_lite(PlayerType *player_ptr)
         floor_ptr->grid_array[y][x].info &= ~(CAVE_TEMP | CAVE_XTRA);
     }
 
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::DELAY_VISIBILITY);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::DELAY_VISIBILITY);
     player_ptr->monlite = (floor_ptr->grid_array[player_ptr->y][player_ptr->x].info & CAVE_MNLT) != 0;
     auto ninja_data = PlayerClass(player_ptr).get_specific_data<ninja_data_type>();
     if (!ninja_data || !ninja_data->s_stealth) {

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -211,7 +211,7 @@ static bool process_door(PlayerType *player_ptr, turn_flags *turn_flags_ptr, Mon
         if (!m_ptr->is_valid()) {
             auto &rfu = RedrawingFlagsUpdater::get_instance();
             rfu.set_flag(StatusRedrawingFlag::FLOW);
-            const auto flags = {
+            static constexpr auto flags = {
                 SubWindowRedrawingFlag::OVERHEAD,
                 SubWindowRedrawingFlag::DUNGEON,
             };
@@ -351,7 +351,7 @@ static bool process_post_dig_wall(PlayerType *player_ptr, turn_flags *turn_flags
     if (!m_ptr->is_valid()) {
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         rfu.set_flag(StatusRedrawingFlag::FLOW);
-        const auto flags = {
+        static constexpr auto flags = {
             SubWindowRedrawingFlag::OVERHEAD,
             SubWindowRedrawingFlag::DUNGEON,
         };

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -210,7 +210,7 @@ static bool process_door(PlayerType *player_ptr, turn_flags *turn_flags_ptr, Mon
         cave_alter_feat(player_ptr, ny, nx, TerrainCharacteristics::BASH);
         if (!m_ptr->is_valid()) {
             auto &rfu = RedrawingFlagsUpdater::get_instance();
-            rfu.set_flag(StatusRedrawingFlag::FLOW);
+            rfu.set_flag(StatusRecalculatingFlag::FLOW);
             static constexpr auto flags = {
                 SubWindowRedrawingFlag::OVERHEAD,
                 SubWindowRedrawingFlag::DUNGEON,
@@ -350,7 +350,7 @@ static bool process_post_dig_wall(PlayerType *player_ptr, turn_flags *turn_flags
 
     if (!m_ptr->is_valid()) {
         auto &rfu = RedrawingFlagsUpdater::get_instance();
-        rfu.set_flag(StatusRedrawingFlag::FLOW);
+        rfu.set_flag(StatusRecalculatingFlag::FLOW);
         static constexpr auto flags = {
             SubWindowRedrawingFlag::OVERHEAD,
             SubWindowRedrawingFlag::DUNGEON,

--- a/src/monster-floor/monster-remover.cpp
+++ b/src/monster-floor/monster-remover.cpp
@@ -100,7 +100,7 @@ void delete_monster_idx(PlayerType *player_ptr, MONSTER_IDX i)
     floor_ptr->m_cnt--;
     lite_spot(player_ptr, y, x);
     if (r_ptr->brightness_flags.has_any_of(ld_mask)) {
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::MONSTER_LITE);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::MONSTER_LITE);
     }
 }
 

--- a/src/monster-floor/monster-runaway.cpp
+++ b/src/monster-floor/monster-runaway.cpp
@@ -56,7 +56,7 @@ static void escape_monster(PlayerType *player_ptr, turn_flags *turn_flags_ptr, M
     }
 
     if (turn_flags_ptr->see_m) {
-        const auto flags = {
+        static constexpr auto flags = {
             MonsterSpeakType::SPEAK_ALL,
             MonsterSpeakType::SPEAK_BATTLE,
             MonsterSpeakType::SPEAK_FEAR,

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -416,7 +416,7 @@ bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSI
     auto is_awake_lightning_monster = r_ptr->brightness_flags.has_any_of(self_ld_mask);
     is_awake_lightning_monster |= r_ptr->brightness_flags.has_any_of(has_ld_mask) && !m_ptr->is_asleep();
     if (is_awake_lightning_monster) {
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::MONSTER_LITE);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::MONSTER_LITE);
     }
 
     update_monster(player_ptr, g_ptr->m_idx, true);

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -363,7 +363,7 @@ void choose_new_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, bool born, Mo
 
     auto old_r_idx = m_ptr->r_idx;
     if (monraces_info[old_r_idx].brightness_flags.has_any_of(ld_mask) || r_ptr->brightness_flags.has_any_of(ld_mask)) {
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::MONSTER_LITE);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::MONSTER_LITE);
     }
 
     if (born) {

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -152,7 +152,7 @@ void process_monster(PlayerType *player_ptr, MONSTER_IDX m_idx)
     }
 
     if (turn_flags_ptr->is_riding_mon) {
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     }
 
     process_angar(player_ptr, m_idx, turn_flags_ptr->see_m);

--- a/src/monster/monster-status-setter.cpp
+++ b/src/monster/monster-status-setter.cpp
@@ -134,7 +134,7 @@ bool set_monster_csleep(PlayerType *player_ptr, MONSTER_IDX m_idx, int v)
     }
 
     if (monraces_info[m_ptr->r_idx].brightness_flags.has_any_of(has_ld_mask)) {
-        rfu.set_flag(StatusRedrawingFlag::MONSTER_LITE);
+        rfu.set_flag(StatusRecalculatingFlag::MONSTER_LITE);
     }
 
     return true;
@@ -173,7 +173,7 @@ bool set_monster_fast(PlayerType *player_ptr, MONSTER_IDX m_idx, int v)
     }
 
     if ((player_ptr->riding == m_idx) && !player_ptr->leaving) {
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     }
 
     return true;
@@ -207,7 +207,7 @@ bool set_monster_slow(PlayerType *player_ptr, MONSTER_IDX m_idx, int v)
     }
 
     if ((player_ptr->riding == m_idx) && !player_ptr->leaving) {
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     }
 
     return true;
@@ -430,7 +430,7 @@ bool set_monster_timewalk(PlayerType *player_ptr, int num, MonsterRaceId who, bo
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
-    rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+    rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
     static constexpr auto flags = {
         SubWindowRedrawingFlag::OVERHEAD,
         SubWindowRedrawingFlag::DUNGEON,

--- a/src/monster/monster-status-setter.cpp
+++ b/src/monster/monster-status-setter.cpp
@@ -431,7 +431,7 @@ bool set_monster_timewalk(PlayerType *player_ptr, int num, MonsterRaceId who, bo
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
     rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
-    const auto flags = {
+    static constexpr auto flags = {
         SubWindowRedrawingFlag::OVERHEAD,
         SubWindowRedrawingFlag::DUNGEON,
     };

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -425,7 +425,7 @@ void monster_gain_exp(PlayerType *player_ptr, MONSTER_IDX m_idx, MonsterRaceId s
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     if (m_ptr->exp < r_ptr->next_exp) {
         if (m_idx == player_ptr->riding) {
-            rfu.set_flag(StatusRedrawingFlag::BONUS);
+            rfu.set_flag(StatusRecalculatingFlag::BONUS);
         }
 
         return;
@@ -508,6 +508,6 @@ void monster_gain_exp(PlayerType *player_ptr, MONSTER_IDX m_idx, MonsterRaceId s
     lite_spot(player_ptr, m_ptr->fy, m_ptr->fx);
 
     if (m_idx == player_ptr->riding) {
-        rfu.set_flag(StatusRedrawingFlag::BONUS);
+        rfu.set_flag(StatusRecalculatingFlag::BONUS);
     }
 }

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -109,7 +109,7 @@ void update_player_type(PlayerType *player_ptr, turn_flags *turn_flags_ptr, Mons
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     if (turn_flags_ptr->do_view) {
         rfu.set_flag(StatusRedrawingFlag::FLOW);
-        const auto flags = {
+        static constexpr auto flags = {
             SubWindowRedrawingFlag::OVERHEAD,
             SubWindowRedrawingFlag::DUNGEON,
         };

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -108,7 +108,7 @@ void update_player_type(PlayerType *player_ptr, turn_flags *turn_flags_ptr, Mons
     const auto except_has_lite = EnumClassFlagGroup<Mbt>(self_ld_mask).set({ Mbt::HAS_DARK_1, Mbt::HAS_DARK_2 });
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     if (turn_flags_ptr->do_view) {
-        rfu.set_flag(StatusRedrawingFlag::FLOW);
+        rfu.set_flag(StatusRecalculatingFlag::FLOW);
         static constexpr auto flags = {
             SubWindowRedrawingFlag::OVERHEAD,
             SubWindowRedrawingFlag::DUNGEON,
@@ -118,7 +118,7 @@ void update_player_type(PlayerType *player_ptr, turn_flags *turn_flags_ptr, Mons
 
     const auto has_lite = r_ptr->brightness_flags.has_any_of({ Mbt::HAS_LITE_1, Mbt::HAS_LITE_2 });
     if (turn_flags_ptr->do_move && (r_ptr->brightness_flags.has_any_of(except_has_lite) || (has_lite && !player_ptr->phase_out))) {
-        rfu.set_flag(StatusRedrawingFlag::MONSTER_LITE);
+        rfu.set_flag(StatusRecalculatingFlag::MONSTER_LITE);
     }
 }
 

--- a/src/mspell/mspell-dispel.cpp
+++ b/src/mspell/mspell-dispel.cpp
@@ -96,7 +96,7 @@ static void dispel_player(PlayerType *player_ptr)
 
         player_ptr->action = ACTION_NONE;
         auto &rfu = RedrawingFlagsUpdater::get_instance();
-        const auto flags_srf = {
+        static constexpr auto flags_srf = {
             StatusRedrawingFlag::BONUS,
             StatusRedrawingFlag::HP,
             StatusRedrawingFlag::MONSTER_STATUSES,

--- a/src/mspell/mspell-dispel.cpp
+++ b/src/mspell/mspell-dispel.cpp
@@ -97,9 +97,9 @@ static void dispel_player(PlayerType *player_ptr)
         player_ptr->action = ACTION_NONE;
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         static constexpr auto flags_srf = {
-            StatusRedrawingFlag::BONUS,
-            StatusRedrawingFlag::HP,
-            StatusRedrawingFlag::MONSTER_STATUSES,
+            StatusRecalculatingFlag::BONUS,
+            StatusRecalculatingFlag::HP,
+            StatusRecalculatingFlag::MONSTER_STATUSES,
         };
         rfu.set_flags(flags_srf);
         static constexpr auto flags_mwrf = {

--- a/src/mspell/mspell-dispel.cpp
+++ b/src/mspell/mspell-dispel.cpp
@@ -102,7 +102,7 @@ static void dispel_player(PlayerType *player_ptr)
             StatusRedrawingFlag::MONSTER_STATUSES,
         };
         rfu.set_flags(flags_srf);
-        const auto flags_mwrf = {
+        static constexpr auto flags_mwrf = {
             MainWindowRedrawingFlag::MAP,
             MainWindowRedrawingFlag::TIMED_EFFECT,
             MainWindowRedrawingFlag::ACTION,

--- a/src/mspell/mspell-dispel.cpp
+++ b/src/mspell/mspell-dispel.cpp
@@ -108,7 +108,7 @@ static void dispel_player(PlayerType *player_ptr)
             MainWindowRedrawingFlag::ACTION,
         };
         rfu.set_flags(flags_mwrf);
-        const auto flags_swrf = {
+        static constexpr auto flags_swrf = {
             SubWindowRedrawingFlag::OVERHEAD,
             SubWindowRedrawingFlag::DUNGEON,
         };

--- a/src/mspell/mspell-floor.cpp
+++ b/src/mspell/mspell-floor.cpp
@@ -127,7 +127,7 @@ MonsterSpellResult spell_RF6_BLINK(PlayerType *player_ptr, MONSTER_IDX m_idx, in
     teleport_away(player_ptr, m_idx, 10, TELEPORT_SPONTANEOUS);
 
     if (target_type == MONSTER_TO_PLAYER) {
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
     }
 
     return res;

--- a/src/mspell/mspell-special.cpp
+++ b/src/mspell/mspell-special.cpp
@@ -178,7 +178,7 @@ static MonsterSpellResult spell_RF6_SPECIAL_B(PlayerType *player_ptr, POSITION y
         simple_monspell_message(player_ptr, m_idx, t_idx, msg, target_type);
 
         teleport_away(player_ptr, m_idx, 10, TELEPORT_NONMAGICAL);
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
         return MonsterSpellResult::make_valid();
     }
 

--- a/src/mutation/mutation-investor-remover.cpp
+++ b/src/mutation/mutation-investor-remover.cpp
@@ -230,7 +230,7 @@ bool gain_mutation(PlayerType *player_ptr, MUTATION_IDX choose_mut)
     neutralize_other_status(player_ptr, gm_ptr);
 
     player_ptr->mutant_regenerate_mod = calc_mutant_regenerate_mod(player_ptr);
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
     return true;
 }
@@ -274,7 +274,7 @@ bool lose_mutation(PlayerType *player_ptr, MUTATION_IDX choose_mut)
         player_ptr->muta.reset(glm_ptr->muta_which);
     }
 
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
     player_ptr->mutant_regenerate_mod = calc_mutant_regenerate_mod(player_ptr);
     return true;
@@ -286,7 +286,7 @@ void lose_all_mutations(PlayerType *player_ptr)
         chg_virtue(player_ptr, Virtue::CHANCE, -5);
         msg_print(_("全ての突然変異が治った。", "You are cured of all mutations."));
         player_ptr->muta.clear();
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
         handle_stuff(player_ptr);
         player_ptr->mutant_regenerate_mod = calc_mutant_regenerate_mod(player_ptr);
     }

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -463,7 +463,7 @@ void process_world_aux_mutation(PlayerType *player_ptr)
         (void)set_invuln(player_ptr, randint1(8) + 8, false);
     }
 
-    const auto flags = {
+    static constexpr auto flags = {
         MainWindowRedrawingFlag::HP,
         MainWindowRedrawingFlag::MP,
     };

--- a/src/object-enchant/object-curse.cpp
+++ b/src/object-enchant/object-curse.cpp
@@ -120,5 +120,5 @@ void curse_equipment(PlayerType *player_ptr, PERCENTAGE chance, PERCENTAGE heavy
         o_ptr->feeling = FEEL_NONE;
     }
 
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
 }

--- a/src/object-hook/hook-expendable.cpp
+++ b/src/object-hook/hook-expendable.cpp
@@ -83,7 +83,7 @@ bool can_player_destroy_object(ItemEntity *o_ptr)
         o_ptr->ident |= IDENT_SENSE;
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         rfu.set_flag(StatusRedrawingFlag::COMBINATION);
-        const auto flags = {
+        static constexpr auto flags = {
             SubWindowRedrawingFlag::INVENTORY,
             SubWindowRedrawingFlag::EQUIPMENT,
         };

--- a/src/object-hook/hook-expendable.cpp
+++ b/src/object-hook/hook-expendable.cpp
@@ -82,7 +82,7 @@ bool can_player_destroy_object(ItemEntity *o_ptr)
         o_ptr->feeling = feel;
         o_ptr->ident |= IDENT_SENSE;
         auto &rfu = RedrawingFlagsUpdater::get_instance();
-        rfu.set_flag(StatusRedrawingFlag::COMBINATION);
+        rfu.set_flag(StatusRecalculatingFlag::COMBINATION);
         static constexpr auto flags = {
             SubWindowRedrawingFlag::INVENTORY,
             SubWindowRedrawingFlag::EQUIPMENT,

--- a/src/object-use/quaff/quaff-effects.cpp
+++ b/src/object-use/quaff/quaff-effects.cpp
@@ -504,7 +504,7 @@ bool QuaffEffects::new_life()
 {
     roll_hitdice(this->player_ptr, SPOP_NONE);
     get_max_stats(this->player_ptr);
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     lose_all_mutations(this->player_ptr);
     return true;
 }

--- a/src/object-use/quaff/quaff-execution.cpp
+++ b/src/object-use/quaff/quaff-execution.cpp
@@ -61,7 +61,7 @@ void ObjectQuaffEntity::execute(INVENTORY_IDX item)
         (void)potion_smash_effect(this->player_ptr, 0, this->player_ptr->y, this->player_ptr->x, o_ref.bi_id);
     }
 
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::COMBINATION,
         StatusRedrawingFlag::REORDER,
     };

--- a/src/object-use/quaff/quaff-execution.cpp
+++ b/src/object-use/quaff/quaff-execution.cpp
@@ -74,7 +74,7 @@ void ObjectQuaffEntity::execute(INVENTORY_IDX item)
         gain_exp(this->player_ptr, (o_ref.get_baseitem().level + (this->player_ptr->lev >> 1)) / this->player_ptr->lev);
     }
 
-    const auto flags = {
+    static constexpr auto flags = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
         SubWindowRedrawingFlag::PLAYER,

--- a/src/object-use/quaff/quaff-execution.cpp
+++ b/src/object-use/quaff/quaff-execution.cpp
@@ -62,8 +62,8 @@ void ObjectQuaffEntity::execute(INVENTORY_IDX item)
     }
 
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::COMBINATION,
-        StatusRedrawingFlag::REORDER,
+        StatusRecalculatingFlag::COMBINATION,
+        StatusRecalculatingFlag::REORDER,
     };
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flags(flags_srf);

--- a/src/object-use/read/read-execution.cpp
+++ b/src/object-use/read/read-execution.cpp
@@ -62,7 +62,7 @@ void ObjectReadEntity::execute(bool known)
     auto executor = ReadExecutorFactory::create(player_ptr, o_ptr, known);
     auto used_up = executor->read();
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    using Srf = StatusRedrawingFlag;
+    using Srf = StatusRecalculatingFlag;
     EnumClassFlagGroup<Srf> flags_srf = { Srf::COMBINATION, Srf::REORDER };
     if (rfu.has(Srf::AUTO_DESTRUCTION)) {
         flags_srf.set(Srf::AUTO_DESTRUCTION);

--- a/src/object-use/read/read-execution.cpp
+++ b/src/object-use/read/read-execution.cpp
@@ -72,7 +72,7 @@ void ObjectReadEntity::execute(bool known)
     this->change_virtue_as_read(*o_ptr);
     object_tried(o_ptr);
     this->gain_exp_from_item_use(o_ptr, executor->is_identified());
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
         SubWindowRedrawingFlag::PLAYER,

--- a/src/object-use/read/scroll-read-executor.cpp
+++ b/src/object-use/read/scroll-read-executor.cpp
@@ -343,7 +343,7 @@ bool ScrollReadExecutor::read()
         }
 
         this->player_ptr->add_spells++;
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::SPELLS);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::SPELLS);
         this->ident = true;
         break;
     case SV_SCROLL_GENOCIDE:

--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -310,9 +310,9 @@ void ObjectThrowEntity::process_boomerang_back()
         this->player_ptr->equip_cnt++;
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         static constexpr auto flags = {
-            StatusRedrawingFlag::BONUS,
-            StatusRedrawingFlag::TORCH,
-            StatusRedrawingFlag::MP,
+            StatusRecalculatingFlag::BONUS,
+            StatusRecalculatingFlag::TORCH,
+            StatusRecalculatingFlag::MP,
         };
         rfu.set_flags(flags);
         rfu.set_flag(SubWindowRedrawingFlag::EQUIPMENT);

--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -309,7 +309,7 @@ void ObjectThrowEntity::process_boomerang_back()
         this->o_ptr->copy_from(this->q_ptr);
         this->player_ptr->equip_cnt++;
         auto &rfu = RedrawingFlagsUpdater::get_instance();
-        const auto flags = {
+        static constexpr auto flags = {
             StatusRedrawingFlag::BONUS,
             StatusRedrawingFlag::TORCH,
             StatusRedrawingFlag::MP,

--- a/src/object-use/use-execution.cpp
+++ b/src/object-use/use-execution.cpp
@@ -123,7 +123,7 @@ void ObjectUseEntity::execute()
         gain_exp(this->player_ptr, (lev + (this->player_ptr->lev >> 1)) / this->player_ptr->lev);
     }
 
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
         SubWindowRedrawingFlag::PLAYER,

--- a/src/object-use/use-execution.cpp
+++ b/src/object-use/use-execution.cpp
@@ -92,7 +92,7 @@ void ObjectUseEntity::execute()
         msg_print(_("この杖にはもう魔力が残っていない。", "The staff has no charges left."));
         o_ptr->ident |= IDENT_EMPTY;
         auto &rfu = RedrawingFlagsUpdater::get_instance();
-        const auto flags = {
+        static constexpr auto flags = {
             StatusRedrawingFlag::COMBINATION,
             StatusRedrawingFlag::REORDER,
         };

--- a/src/object-use/use-execution.cpp
+++ b/src/object-use/use-execution.cpp
@@ -93,8 +93,8 @@ void ObjectUseEntity::execute()
         o_ptr->ident |= IDENT_EMPTY;
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         static constexpr auto flags = {
-            StatusRedrawingFlag::COMBINATION,
-            StatusRedrawingFlag::REORDER,
+            StatusRecalculatingFlag::COMBINATION,
+            StatusRecalculatingFlag::REORDER,
         };
         rfu.set_flags(flags);
         rfu.set_flag(SubWindowRedrawingFlag::INVENTORY);
@@ -110,7 +110,7 @@ void ObjectUseEntity::execute()
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    using Srf = StatusRedrawingFlag;
+    using Srf = StatusRecalculatingFlag;
     EnumClassFlagGroup<Srf> flags_srf = { Srf::COMBINATION, Srf::REORDER };
     if (rfu.has(Srf::AUTO_DESTRUCTION)) {
         flags_srf.set(Srf::AUTO_DESTRUCTION);

--- a/src/object-use/zaprod-execution.cpp
+++ b/src/object-use/zaprod-execution.cpp
@@ -128,7 +128,7 @@ void ObjectZapRodEntity::execute(INVENTORY_IDX item)
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::COMBINATION,
         StatusRedrawingFlag::REORDER,
     };

--- a/src/object-use/zaprod-execution.cpp
+++ b/src/object-use/zaprod-execution.cpp
@@ -129,8 +129,8 @@ void ObjectZapRodEntity::execute(INVENTORY_IDX item)
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::COMBINATION,
-        StatusRedrawingFlag::REORDER,
+        StatusRecalculatingFlag::COMBINATION,
+        StatusRecalculatingFlag::REORDER,
     };
     rfu.set_flags(flags_srf);
     if (!(o_ptr->is_aware())) {

--- a/src/object-use/zaprod-execution.cpp
+++ b/src/object-use/zaprod-execution.cpp
@@ -145,7 +145,7 @@ void ObjectZapRodEntity::execute(INVENTORY_IDX item)
         gain_exp(this->player_ptr, (lev + (this->player_ptr->lev >> 1)) / this->player_ptr->lev);
     }
 
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
         SubWindowRedrawingFlag::PLAYER,

--- a/src/object-use/zapwand-execution.cpp
+++ b/src/object-use/zapwand-execution.cpp
@@ -97,8 +97,8 @@ void ObjectZapWandEntity::execute(INVENTORY_IDX item)
         msg_print(_("この魔法棒にはもう魔力が残っていない。", "The wand has no charges left."));
         o_ptr->ident |= IDENT_EMPTY;
         static constexpr auto flags = {
-            StatusRedrawingFlag::COMBINATION,
-            StatusRedrawingFlag::REORDER,
+            StatusRecalculatingFlag::COMBINATION,
+            StatusRecalculatingFlag::REORDER,
         };
         rfu.set_flags(flags);
         rfu.set_flag(SubWindowRedrawingFlag::INVENTORY);
@@ -107,7 +107,7 @@ void ObjectZapWandEntity::execute(INVENTORY_IDX item)
 
     sound(SOUND_ZAP);
     auto ident = wand_effect(this->player_ptr, sval.value(), dir, false, false);
-    using Srf = StatusRedrawingFlag;
+    using Srf = StatusRecalculatingFlag;
     EnumClassFlagGroup<Srf> flags_srf = { Srf::COMBINATION, Srf::REORDER };
     if (rfu.has(Srf::AUTO_DESTRUCTION)) {
         flags_srf.set(Srf::AUTO_DESTRUCTION);

--- a/src/object-use/zapwand-execution.cpp
+++ b/src/object-use/zapwand-execution.cpp
@@ -126,7 +126,7 @@ void ObjectZapWandEntity::execute(INVENTORY_IDX item)
         gain_exp(this->player_ptr, (lev + (this->player_ptr->lev >> 1)) / this->player_ptr->lev);
     }
 
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
         SubWindowRedrawingFlag::PLAYER,

--- a/src/object-use/zapwand-execution.cpp
+++ b/src/object-use/zapwand-execution.cpp
@@ -96,7 +96,7 @@ void ObjectZapWandEntity::execute(INVENTORY_IDX item)
 
         msg_print(_("この魔法棒にはもう魔力が残っていない。", "The wand has no charges left."));
         o_ptr->ident |= IDENT_EMPTY;
-        const auto flags = {
+        static constexpr auto flags = {
             StatusRedrawingFlag::COMBINATION,
             StatusRedrawingFlag::REORDER,
         };

--- a/src/object/lite-processor.cpp
+++ b/src/object/lite-processor.cpp
@@ -60,8 +60,8 @@ void notice_lite_change(PlayerType *player_ptr, ItemEntity *o_ptr)
         disturb(player_ptr, false, true);
         msg_print(_("明かりが消えてしまった！", "Your light has gone out!"));
         static constexpr auto flags = {
-            StatusRedrawingFlag::TORCH,
-            StatusRedrawingFlag::BONUS,
+            StatusRecalculatingFlag::TORCH,
+            StatusRecalculatingFlag::BONUS,
         };
         rfu.set_flags(flags);
     } else if (o_ptr->ego_idx == EgoType::LITE_LONG) {

--- a/src/object/lite-processor.cpp
+++ b/src/object/lite-processor.cpp
@@ -59,7 +59,7 @@ void notice_lite_change(PlayerType *player_ptr, ItemEntity *o_ptr)
     } else if (o_ptr->fuel == 0) {
         disturb(player_ptr, false, true);
         msg_print(_("明かりが消えてしまった！", "Your light has gone out!"));
-        const auto flags = {
+        static constexpr auto flags = {
             StatusRedrawingFlag::TORCH,
             StatusRedrawingFlag::BONUS,
         };

--- a/src/perception/simple-perception.cpp
+++ b/src/perception/simple-perception.cpp
@@ -123,7 +123,7 @@ static void sense_inventory_aux(PlayerType *player_ptr, INVENTORY_IDX slot, bool
 
     autopick_alter_item(player_ptr, slot, destroy_feeling);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::COMBINATION,
         StatusRedrawingFlag::REORDER,
     };

--- a/src/perception/simple-perception.cpp
+++ b/src/perception/simple-perception.cpp
@@ -124,8 +124,8 @@ static void sense_inventory_aux(PlayerType *player_ptr, INVENTORY_IDX slot, bool
     autopick_alter_item(player_ptr, slot, destroy_feeling);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::COMBINATION,
-        StatusRedrawingFlag::REORDER,
+        StatusRecalculatingFlag::COMBINATION,
+        StatusRecalculatingFlag::REORDER,
     };
     rfu.set_flags(flags_srf);
     static constexpr auto flags_swrf = {

--- a/src/perception/simple-perception.cpp
+++ b/src/perception/simple-perception.cpp
@@ -128,7 +128,7 @@ static void sense_inventory_aux(PlayerType *player_ptr, INVENTORY_IDX slot, bool
         StatusRedrawingFlag::REORDER,
     };
     rfu.set_flags(flags_srf);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
     };

--- a/src/pet/pet-fall-off.cpp
+++ b/src/pet/pet-fall-off.cpp
@@ -161,12 +161,12 @@ bool process_fall_off_horse(PlayerType *player_ptr, int dam, bool force)
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::VIEW,
-        StatusRedrawingFlag::LITE,
-        StatusRedrawingFlag::FLOW,
-        StatusRedrawingFlag::MONSTER_LITE,
-        StatusRedrawingFlag::MONSTER_STATUSES,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::VIEW,
+        StatusRecalculatingFlag::LITE,
+        StatusRecalculatingFlag::FLOW,
+        StatusRecalculatingFlag::MONSTER_LITE,
+        StatusRecalculatingFlag::MONSTER_STATUSES,
     };
     rfu.set_flags(flags_srf);
     handle_stuff(player_ptr);

--- a/src/pet/pet-fall-off.cpp
+++ b/src/pet/pet-fall-off.cpp
@@ -160,7 +160,7 @@ bool process_fall_off_horse(PlayerType *player_ptr, int dam, bool force)
     player_ptr->riding_ryoute = player_ptr->old_riding_ryoute = false;
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::VIEW,
         StatusRedrawingFlag::LITE,

--- a/src/pet/pet-fall-off.cpp
+++ b/src/pet/pet-fall-off.cpp
@@ -175,7 +175,7 @@ bool process_fall_off_horse(PlayerType *player_ptr, int dam, bool force)
         SubWindowRedrawingFlag::DUNGEON,
     };
     rfu.set_flags(flags_swrf);
-    const auto flags_mwrf = {
+    static constexpr auto flags_mwrf = {
         MainWindowRedrawingFlag::EXTRA,
         MainWindowRedrawingFlag::UHEALTH,
     };

--- a/src/pet/pet-fall-off.cpp
+++ b/src/pet/pet-fall-off.cpp
@@ -170,7 +170,7 @@ bool process_fall_off_horse(PlayerType *player_ptr, int dam, bool force)
     };
     rfu.set_flags(flags_srf);
     handle_stuff(player_ptr);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::OVERHEAD,
         SubWindowRedrawingFlag::DUNGEON,
     };

--- a/src/pet/pet-util.cpp
+++ b/src/pet/pet-util.cpp
@@ -42,7 +42,7 @@ bool can_player_ride_pet(PlayerType *player_ptr, grid_type *g_ptr, bool now_ridi
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
 
     bool p_can_enter = player_can_enter(player_ptr, g_ptr->feat, CEM_P_CAN_ENTER_PATTERN);
@@ -55,7 +55,7 @@ bool can_player_ride_pet(PlayerType *player_ptr, grid_type *g_ptr, bool now_ridi
 
     player_ptr->riding_ryoute = old_riding_two_hands;
     player_ptr->old_riding_ryoute = old_old_riding_two_hands;
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
 
     w_ptr->character_xtra = old_character_xtra;

--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -397,8 +397,8 @@ bool PlayerClass::lose_balance()
     this->set_samurai_stance(SamuraiStanceType::NONE);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::MONSTER_STATUSES,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::MONSTER_STATUSES,
     };
     rfu.set_flags(flags_srf);
     static constexpr auto flags_mwrf = {

--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -396,7 +396,7 @@ bool PlayerClass::lose_balance()
 
     this->set_samurai_stance(SamuraiStanceType::NONE);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::MONSTER_STATUSES,
     };

--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -401,7 +401,7 @@ bool PlayerClass::lose_balance()
         StatusRedrawingFlag::MONSTER_STATUSES,
     };
     rfu.set_flags(flags_srf);
-    const auto flags_mwrf = {
+    static constexpr auto flags_mwrf = {
         MainWindowRedrawingFlag::ACTION,
         MainWindowRedrawingFlag::TIMED_EFFECT,
     };

--- a/src/player-status/player-basic-statistics.cpp
+++ b/src/player-status/player-basic-statistics.cpp
@@ -171,7 +171,7 @@ void PlayerBasicStatistics::update_index_status()
 
     this->player_ptr->stat_index[status] = (int16_t)index;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags = {
+    static constexpr auto flags = {
         StatusRedrawingFlag::MP,
         StatusRedrawingFlag::SPELLS,
     };

--- a/src/player-status/player-basic-statistics.cpp
+++ b/src/player-status/player-basic-statistics.cpp
@@ -172,11 +172,11 @@ void PlayerBasicStatistics::update_index_status()
     this->player_ptr->stat_index[status] = (int16_t)index;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags = {
-        StatusRedrawingFlag::MP,
-        StatusRedrawingFlag::SPELLS,
+        StatusRecalculatingFlag::MP,
+        StatusRecalculatingFlag::SPELLS,
     };
     if (status == A_CON) {
-        rfu.set_flag(StatusRedrawingFlag::HP);
+        rfu.set_flag(StatusRecalculatingFlag::HP);
     } else if (status == A_INT) {
         if (mp_ptr->spell_stat == A_INT) {
             rfu.set_flags(flags);

--- a/src/player/digestion-processor.cpp
+++ b/src/player/digestion-processor.cpp
@@ -215,7 +215,7 @@ bool set_food(PlayerType *player_ptr, TIME_EFFECT v)
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     rfu.set_flag(MainWindowRedrawingFlag::HUNGER);
     handle_stuff(player_ptr);
 

--- a/src/player/eldritch-horror.cpp
+++ b/src/player/eldritch-horror.cpp
@@ -316,6 +316,6 @@ void sanity_blast(PlayerType *player_ptr, MonsterEntity *m_ptr, bool necro)
         break;
     }
 
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
 }

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -121,7 +121,7 @@ static bool acid_minus_ac(PlayerType *player_ptr)
     msg_format(_("%sが酸で腐食した！", "Your %s is corroded!"), item_name.data());
     o_ptr->to_a--;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::EQUIPMENT,
         SubWindowRedrawingFlag::PLAYER,

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -122,7 +122,7 @@ static bool acid_minus_ac(PlayerType *player_ptr)
     o_ptr->to_a--;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(StatusRedrawingFlag::BONUS);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::EQUIPMENT,
         SubWindowRedrawingFlag::PLAYER,
     };

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -176,7 +176,7 @@ bool move_player_effect(PlayerType *player_ptr, POSITION ny, POSITION nx, BIT_FL
             rfu.set_flag(MainWindowRedrawingFlag::MAP);
         }
 
-        const auto flags_srf = {
+        static constexpr auto flags_srf = {
             StatusRedrawingFlag::VIEW,
             StatusRedrawingFlag::LITE,
             StatusRedrawingFlag::FLOW,

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -184,7 +184,7 @@ bool move_player_effect(PlayerType *player_ptr, POSITION ny, POSITION nx, BIT_FL
             StatusRedrawingFlag::DISTANCE,
         };
         rfu.set_flags(flags_srf);
-        const auto flags_swrf = {
+        static constexpr auto flags_swrf = {
             SubWindowRedrawingFlag::OVERHEAD,
             SubWindowRedrawingFlag::DUNGEON,
         };
@@ -246,7 +246,7 @@ bool move_player_effect(PlayerType *player_ptr, POSITION ny, POSITION nx, BIT_FL
 
     // 自動拾い/自動破壊により床上のアイテムリストが変化した可能性があるので表示を更新
     if (!player_ptr->running) {
-        const auto flags_swrf = {
+        static constexpr auto flags_swrf = {
             SubWindowRedrawingFlag::FLOOR_ITEMS,
             SubWindowRedrawingFlag::FOUND_ITEMS,
         };

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -172,16 +172,16 @@ bool move_player_effect(PlayerType *player_ptr, POSITION ny, POSITION nx, BIT_FL
         verify_panel(player_ptr);
         if (mpe_mode & MPE_FORGET_FLOW) {
             forget_flow(floor_ptr);
-            rfu.set_flag(StatusRedrawingFlag::UN_VIEW);
+            rfu.set_flag(StatusRecalculatingFlag::UN_VIEW);
             rfu.set_flag(MainWindowRedrawingFlag::MAP);
         }
 
         static constexpr auto flags_srf = {
-            StatusRedrawingFlag::VIEW,
-            StatusRedrawingFlag::LITE,
-            StatusRedrawingFlag::FLOW,
-            StatusRedrawingFlag::MONSTER_LITE,
-            StatusRedrawingFlag::DISTANCE,
+            StatusRecalculatingFlag::VIEW,
+            StatusRecalculatingFlag::LITE,
+            StatusRecalculatingFlag::FLOW,
+            StatusRecalculatingFlag::MONSTER_LITE,
+            StatusRecalculatingFlag::DISTANCE,
         };
         rfu.set_flags(flags_srf);
         static constexpr auto flags_swrf = {
@@ -217,7 +217,7 @@ bool move_player_effect(PlayerType *player_ptr, POSITION ny, POSITION nx, BIT_FL
 
         if (PlayerRace(player_ptr).equals(PlayerRaceType::MERFOLK)) {
             if (f_ptr->flags.has(Tc::WATER) ^ of_ptr->flags.has(Tc::WATER)) {
-                rfu.set_flag(StatusRedrawingFlag::BONUS);
+                rfu.set_flag(StatusRecalculatingFlag::BONUS);
                 update_creature(player_ptr);
             }
         }

--- a/src/player/player-skill.cpp
+++ b/src/player/player-skill.cpp
@@ -61,7 +61,7 @@ void gain_attack_skill_exp(PlayerType *player_ptr, short &exp, const GainAmountL
     }
 
     exp += static_cast<short>(gain_amount);
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
 }
 
 void gain_spell_skill_exp_aux(PlayerType *player_ptr, short &exp, const GainAmountList &gain_amount_list, int spell_level)
@@ -91,7 +91,7 @@ void gain_spell_skill_exp_aux(PlayerType *player_ptr, short &exp, const GainAmou
     }
 
     exp += static_cast<short>(gain_amount);
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
 }
 
 }
@@ -305,7 +305,7 @@ void PlayerSkill::gain_riding_skill_exp_on_melee_attack(const MonsterRaceInfo *r
     }
 
     this->player_ptr->skill_exp[PlayerSkillKindType::RIDING] = std::min<SUB_EXP>(max_exp, now_exp + inc);
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
 }
 
 void PlayerSkill::gain_riding_skill_exp_on_range_attack()
@@ -321,7 +321,7 @@ void PlayerSkill::gain_riding_skill_exp_on_range_attack()
     const auto &monrace = monraces_info[monster.r_idx];
     if (((this->player_ptr->skill_exp[PlayerSkillKindType::RIDING] - (RIDING_EXP_BEGINNER * 2)) / 200 < monrace.level) && one_in_(2)) {
         this->player_ptr->skill_exp[PlayerSkillKindType::RIDING] += 1;
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     }
 }
 
@@ -347,7 +347,7 @@ void PlayerSkill::gain_riding_skill_exp_on_fall_off_check(int dam)
     }
 
     this->player_ptr->skill_exp[PlayerSkillKindType::RIDING] = std::min<SUB_EXP>(max_exp, now_exp + inc);
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
 }
 
 void PlayerSkill::gain_spell_skill_exp(int realm, int spell_idx)
@@ -407,7 +407,7 @@ PlayerSkillRank PlayerSkill::gain_spell_skill_exp_over_learning(int spell_idx)
         exp = SPELL_EXP_BEGINNER + exp / 3;
     }
 
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     return PlayerSkill::spell_skill_rank(exp);
 }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -1006,7 +1006,7 @@ static void update_max_mana(PlayerType *player_ptr)
         player_ptr->msp = msp;
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         rfu.set_flag(MainWindowRedrawingFlag::MP);
-        const auto flags = {
+        static constexpr auto flags = {
             SubWindowRedrawingFlag::PLAYER,
             SubWindowRedrawingFlag::SPELL,
         };

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -3028,7 +3028,7 @@ void check_experience(PlayerType *player_ptr)
             MainWindowRedrawingFlag::TITLE,
         };
         rfu.set_flags(flags_mwrf);
-        const auto flags_swrf = {
+        static constexpr auto flags_swrf = {
             SubWindowRedrawingFlag::PLAYER,
             SubWindowRedrawingFlag::SPELL,
         };

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -2919,7 +2919,7 @@ void check_experience(PlayerType *player_ptr)
     while ((player_ptr->lev > 1) && (player_ptr->exp < ((android ? player_exp_a : player_exp)[player_ptr->lev - 2] * player_ptr->expfact / 100L))) {
         player_ptr->lev--;
         rfu.set_flags(flags_srf);
-        const auto flags_mwrf = {
+        static constexpr auto flags_mwrf = {
             MainWindowRedrawingFlag::LEVEL,
             MainWindowRedrawingFlag::TITLE,
         };
@@ -3023,7 +3023,7 @@ void check_experience(PlayerType *player_ptr)
         }
 
         rfu.set_flags(flags_srf);
-        const auto flags_mwrf = {
+        static constexpr auto flags_mwrf = {
             MainWindowRedrawingFlag::LEVEL,
             MainWindowRedrawingFlag::TITLE,
         };

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -382,7 +382,7 @@ static void update_bonuses(PlayerType *player_ptr)
     }
 
     if (player_ptr->telepathy != old_telepathy) {
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
     }
 
     auto is_esp_updated = player_ptr->esp_animal != old_esp_animal;
@@ -398,11 +398,11 @@ static void update_bonuses(PlayerType *player_ptr)
     is_esp_updated |= player_ptr->esp_nonliving != old_esp_nonliving;
     is_esp_updated |= player_ptr->esp_unique != old_esp_unique;
     if (is_esp_updated) {
-        rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+        rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
     }
 
     if (player_ptr->see_inv != old_see_inv) {
-        rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+        rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
     }
 
     if (player_ptr->pspeed != old_speed) {
@@ -2702,23 +2702,23 @@ void update_creature(PlayerType *player_ptr)
     }
 
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    if (rfu.has(StatusRedrawingFlag::AUTO_DESTRUCTION)) {
-        rfu.reset_flag(StatusRedrawingFlag::AUTO_DESTRUCTION);
+    if (rfu.has(StatusRecalculatingFlag::AUTO_DESTRUCTION)) {
+        rfu.reset_flag(StatusRecalculatingFlag::AUTO_DESTRUCTION);
         autopick_delayed_alter(player_ptr);
     }
 
-    if (rfu.has(StatusRedrawingFlag::COMBINATION)) {
-        rfu.reset_flag(StatusRedrawingFlag::COMBINATION);
+    if (rfu.has(StatusRecalculatingFlag::COMBINATION)) {
+        rfu.reset_flag(StatusRecalculatingFlag::COMBINATION);
         combine_pack(player_ptr);
     }
 
-    if (rfu.has(StatusRedrawingFlag::REORDER)) {
-        rfu.reset_flag(StatusRedrawingFlag::REORDER);
+    if (rfu.has(StatusRecalculatingFlag::REORDER)) {
+        rfu.reset_flag(StatusRecalculatingFlag::REORDER);
         reorder_pack(player_ptr);
     }
 
-    if (rfu.has(StatusRedrawingFlag::BONUS)) {
-        rfu.reset_flag(StatusRedrawingFlag::BONUS);
+    if (rfu.has(StatusRecalculatingFlag::BONUS)) {
+        rfu.reset_flag(StatusRecalculatingFlag::BONUS);
         PlayerAlignment(player_ptr).update_alignment();
         PlayerSkill ps(player_ptr);
         ps.apply_special_weapon_skill_max_values();
@@ -2726,23 +2726,23 @@ void update_creature(PlayerType *player_ptr)
         update_bonuses(player_ptr);
     }
 
-    if (rfu.has(StatusRedrawingFlag::TORCH)) {
-        rfu.reset_flag(StatusRedrawingFlag::TORCH);
+    if (rfu.has(StatusRecalculatingFlag::TORCH)) {
+        rfu.reset_flag(StatusRecalculatingFlag::TORCH);
         update_lite_radius(player_ptr);
     }
 
-    if (rfu.has(StatusRedrawingFlag::HP)) {
-        rfu.reset_flag(StatusRedrawingFlag::HP);
+    if (rfu.has(StatusRecalculatingFlag::HP)) {
+        rfu.reset_flag(StatusRecalculatingFlag::HP);
         update_max_hitpoints(player_ptr);
     }
 
-    if (rfu.has(StatusRedrawingFlag::MP)) {
-        rfu.reset_flag(StatusRedrawingFlag::MP);
+    if (rfu.has(StatusRecalculatingFlag::MP)) {
+        rfu.reset_flag(StatusRecalculatingFlag::MP);
         update_max_mana(player_ptr);
     }
 
-    if (rfu.has(StatusRedrawingFlag::SPELLS)) {
-        rfu.reset_flag(StatusRedrawingFlag::SPELLS);
+    if (rfu.has(StatusRecalculatingFlag::SPELLS)) {
+        rfu.reset_flag(StatusRecalculatingFlag::SPELLS);
         update_num_of_spells(player_ptr);
     }
 
@@ -2750,48 +2750,48 @@ void update_creature(PlayerType *player_ptr)
         return;
     }
 
-    if (rfu.has(StatusRedrawingFlag::UN_LITE)) {
-        rfu.reset_flag(StatusRedrawingFlag::UN_LITE);
+    if (rfu.has(StatusRecalculatingFlag::UN_LITE)) {
+        rfu.reset_flag(StatusRecalculatingFlag::UN_LITE);
         forget_lite(floor_ptr);
     }
 
-    if (rfu.has(StatusRedrawingFlag::UN_VIEW)) {
-        rfu.reset_flag(StatusRedrawingFlag::UN_VIEW);
+    if (rfu.has(StatusRecalculatingFlag::UN_VIEW)) {
+        rfu.reset_flag(StatusRecalculatingFlag::UN_VIEW);
         forget_view(floor_ptr);
     }
 
-    if (rfu.has(StatusRedrawingFlag::VIEW)) {
-        rfu.reset_flag(StatusRedrawingFlag::VIEW);
+    if (rfu.has(StatusRecalculatingFlag::VIEW)) {
+        rfu.reset_flag(StatusRecalculatingFlag::VIEW);
         update_view(player_ptr);
     }
 
-    if (rfu.has(StatusRedrawingFlag::LITE)) {
-        rfu.reset_flag(StatusRedrawingFlag::LITE);
+    if (rfu.has(StatusRecalculatingFlag::LITE)) {
+        rfu.reset_flag(StatusRecalculatingFlag::LITE);
         update_lite(player_ptr);
     }
 
-    if (rfu.has(StatusRedrawingFlag::FLOW)) {
-        rfu.reset_flag(StatusRedrawingFlag::FLOW);
+    if (rfu.has(StatusRecalculatingFlag::FLOW)) {
+        rfu.reset_flag(StatusRecalculatingFlag::FLOW);
         update_flow(player_ptr);
     }
 
-    if (rfu.has(StatusRedrawingFlag::DISTANCE)) {
-        rfu.reset_flag(StatusRedrawingFlag::DISTANCE);
+    if (rfu.has(StatusRecalculatingFlag::DISTANCE)) {
+        rfu.reset_flag(StatusRecalculatingFlag::DISTANCE);
         update_monsters(player_ptr, true);
     }
 
-    if (rfu.has(StatusRedrawingFlag::MONSTER_LITE)) {
-        rfu.reset_flag(StatusRedrawingFlag::MONSTER_LITE);
+    if (rfu.has(StatusRecalculatingFlag::MONSTER_LITE)) {
+        rfu.reset_flag(StatusRecalculatingFlag::MONSTER_LITE);
         update_mon_lite(player_ptr);
     }
 
-    if (rfu.has(StatusRedrawingFlag::DELAY_VISIBILITY)) {
-        rfu.reset_flag(StatusRedrawingFlag::DELAY_VISIBILITY);
+    if (rfu.has(StatusRecalculatingFlag::DELAY_VISIBILITY)) {
+        rfu.reset_flag(StatusRecalculatingFlag::DELAY_VISIBILITY);
         delayed_visual_update(player_ptr);
     }
 
-    if (rfu.has(StatusRedrawingFlag::MONSTER_STATUSES)) {
-        rfu.reset_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+    if (rfu.has(StatusRecalculatingFlag::MONSTER_STATUSES)) {
+        rfu.reset_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
         update_monsters(player_ptr, false);
     }
 }
@@ -2911,10 +2911,10 @@ void check_experience(PlayerType *player_ptr)
     bool android = pr.equals(PlayerRaceType::ANDROID);
     PLAYER_LEVEL old_lev = player_ptr->lev;
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::HP,
-        StatusRedrawingFlag::MP,
-        StatusRedrawingFlag::SPELLS,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::HP,
+        StatusRecalculatingFlag::MP,
+        StatusRecalculatingFlag::SPELLS,
     };
     while ((player_ptr->lev > 1) && (player_ptr->exp < ((android ? player_exp_a : player_exp)[player_ptr->lev - 2] * player_ptr->expfact / 100L))) {
         player_ptr->lev--;

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -2910,7 +2910,7 @@ void check_experience(PlayerType *player_ptr)
     PlayerRace pr(player_ptr);
     bool android = pr.equals(PlayerRaceType::ANDROID);
     PLAYER_LEVEL old_lev = player_ptr->lev;
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::HP,
         StatusRedrawingFlag::MP,

--- a/src/player/player-view.cpp
+++ b/src/player/player-view.cpp
@@ -379,5 +379,5 @@ void update_view(PlayerType *player_ptr)
         cave_redraw_later(floor_ptr, py, px);
     }
 
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::DELAY_VISIBILITY);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::DELAY_VISIBILITY);
 }

--- a/src/player/process-death.cpp
+++ b/src/player/process-death.cpp
@@ -381,7 +381,7 @@ void show_death_info(PlayerType *player_ptr)
     inventory_aware(player_ptr);
     home_aware(player_ptr);
 
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
     flush();
     msg_erase();

--- a/src/racial/racial-kutar.cpp
+++ b/src/racial/racial-kutar.cpp
@@ -49,7 +49,7 @@ bool set_leveling(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
 
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
     return true;
 }

--- a/src/racial/racial-switcher.cpp
+++ b/src/racial/racial-switcher.cpp
@@ -154,7 +154,7 @@ bool switch_class_racial_execution(PlayerType *player_ptr, const int32_t command
                 return false;
             }
 
-            RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+            RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
             return true;
         }
 
@@ -247,7 +247,7 @@ bool switch_class_racial_execution(PlayerType *player_ptr, const int32_t command
             return false;
         }
 
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
         return true;
     case PlayerClassType::BLUE_MAGE:
         set_action(player_ptr, player_ptr->action == ACTION_LEARN ? ACTION_NONE : ACTION_LEARN);

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -724,7 +724,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
                     set_action(player_ptr, ACTION_NONE);
                 }
 
-                const auto flags = {
+                static constexpr auto flags = {
                     StatusRedrawingFlag::BONUS,
                     StatusRedrawingFlag::HP,
                     StatusRedrawingFlag::MP,

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -971,7 +971,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
             StatusRedrawingFlag::SPELLS,
         };
         rfu.set_flags(flags_srf);
-        const auto flags_mwrf = {
+        static constexpr auto flags_mwrf = {
             MainWindowRedrawingFlag::EXTRA,
             MainWindowRedrawingFlag::HP,
             MainWindowRedrawingFlag::MP,

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -229,7 +229,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
                 o_ptr->curse_flags.set(get_curse(curse_rank, o_ptr));
             }
 
-            RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+            RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
             should_continue = false;
         }
         break;
@@ -585,7 +585,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
                 o_ptr->curse_flags.set(get_curse(curse_rank, o_ptr));
             }
 
-            RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+            RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
             should_continue = false;
         }
         break;
@@ -710,7 +710,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
                         player_ptr->stat_cur[i] = player_ptr->stat_max[i];
                     }
 
-                    rfu.set_flag(StatusRedrawingFlag::BONUS);
+                    rfu.set_flag(StatusRecalculatingFlag::BONUS);
                     flag = true;
                 }
             }
@@ -725,10 +725,10 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
                 }
 
                 static constexpr auto flags = {
-                    StatusRedrawingFlag::BONUS,
-                    StatusRedrawingFlag::HP,
-                    StatusRedrawingFlag::MP,
-                    StatusRedrawingFlag::SPELLS,
+                    StatusRecalculatingFlag::BONUS,
+                    StatusRecalculatingFlag::HP,
+                    StatusRecalculatingFlag::MP,
+                    StatusRecalculatingFlag::SPELLS,
                 };
                 rfu.set_flags(flags);
                 rfu.set_flag(MainWindowRedrawingFlag::EXTRA);
@@ -965,10 +965,10 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
     if (!info) {
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         static constexpr auto flags_srf = {
-            StatusRedrawingFlag::BONUS,
-            StatusRedrawingFlag::HP,
-            StatusRedrawingFlag::MP,
-            StatusRedrawingFlag::SPELLS,
+            StatusRecalculatingFlag::BONUS,
+            StatusRecalculatingFlag::HP,
+            StatusRecalculatingFlag::MP,
+            StatusRecalculatingFlag::SPELLS,
         };
         rfu.set_flags(flags_srf);
         static constexpr auto flags_mwrf = {

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -964,7 +964,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
 
     if (!info) {
         auto &rfu = RedrawingFlagsUpdater::get_instance();
-        const auto flags_srf = {
+        static constexpr auto flags_srf = {
             StatusRedrawingFlag::BONUS,
             StatusRedrawingFlag::HP,
             StatusRedrawingFlag::MP,

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -427,7 +427,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                     lite_spot(player_ptr, ty, tx);
 
                     if (monraces_info[m_ptr->r_idx].brightness_flags.has_any_of(ld_mask)) {
-                        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::MONSTER_LITE);
+                        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::MONSTER_LITE);
                     }
                 }
             }
@@ -487,7 +487,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
 
             /* Destroy the feature */
             cave_alter_feat(player_ptr, y, x, TerrainCharacteristics::HURT_ROCK);
-            RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::FLOW);
+            RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::FLOW);
         }
         break;
 

--- a/src/realm/realm-song.cpp
+++ b/src/realm/realm-song.cpp
@@ -1094,7 +1094,7 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
             auto &rfu = RedrawingFlagsUpdater::get_instance();
             rfu.set_flag(MainWindowRedrawingFlag::MAP);
             rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
-            const auto flags = {
+            static constexpr auto flags = {
                 SubWindowRedrawingFlag::OVERHEAD,
                 SubWindowRedrawingFlag::DUNGEON,
             };
@@ -1108,7 +1108,7 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
                 auto &rfu = RedrawingFlagsUpdater::get_instance();
                 rfu.set_flag(MainWindowRedrawingFlag::MAP);
                 rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
-                const auto flags = {
+                static constexpr auto flags = {
                     SubWindowRedrawingFlag::OVERHEAD,
                     SubWindowRedrawingFlag::DUNGEON,
                 };

--- a/src/realm/realm-song.cpp
+++ b/src/realm/realm-song.cpp
@@ -45,7 +45,7 @@ static void start_singing(PlayerType *player_ptr, SPELL_IDX spell, int32_t song)
     set_action(player_ptr, ACTION_SING);
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
 }
 
@@ -305,14 +305,14 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
 
             (void)hp_player(player_ptr, 10);
             (void)BadStatusSetter(player_ptr).set_fear(0);
-            RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::HP);
+            RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::HP);
             start_singing(player_ptr, spell, MUSIC_HERO);
         }
 
         if (stop) {
             if (!player_ptr->hero) {
                 msg_print(_("ヒーローの気分が消え失せた。", "The heroism wears off."));
-                RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::HP);
+                RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::HP);
             }
         }
 
@@ -961,14 +961,14 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
             msg_print(_("英雄の歌を口ずさんだ．．．", "You chant a powerful, heroic call to arms..."));
             (void)hp_player(player_ptr, 10);
             (void)BadStatusSetter(player_ptr).set_fear(0);
-            RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::HP);
+            RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::HP);
             start_singing(player_ptr, spell, MUSIC_SHERO);
         }
 
         if (stop) {
             if (!player_ptr->hero) {
                 msg_print(_("ヒーローの気分が消え失せた。", "The heroism wears off."));
-                RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::HP);
+                RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::HP);
             }
 
             if (!player_ptr->effects()->acceleration()->is_fast()) {
@@ -1093,7 +1093,7 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
             msg_print(_("フィンゴルフィンの冥王への挑戦を歌った．．．", "You recall the valor of Fingolfin's challenge to the Dark Lord..."));
             auto &rfu = RedrawingFlagsUpdater::get_instance();
             rfu.set_flag(MainWindowRedrawingFlag::MAP);
-            rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+            rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
             static constexpr auto flags = {
                 SubWindowRedrawingFlag::OVERHEAD,
                 SubWindowRedrawingFlag::DUNGEON,
@@ -1107,7 +1107,7 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
                 msg_print(_("無敵ではなくなった。", "The invulnerability wears off."));
                 auto &rfu = RedrawingFlagsUpdater::get_instance();
                 rfu.set_flag(MainWindowRedrawingFlag::MAP);
-                rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+                rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
                 static constexpr auto flags = {
                     SubWindowRedrawingFlag::OVERHEAD,
                     SubWindowRedrawingFlag::DUNGEON,

--- a/src/save/floor-writer.cpp
+++ b/src/save/floor-writer.cpp
@@ -156,7 +156,7 @@ bool wr_dungeon(PlayerType *player_ptr)
     forget_lite(player_ptr->current_floor_ptr);
     forget_view(player_ptr->current_floor_ptr);
     clear_mon_lite(player_ptr->current_floor_ptr);
-    const auto flags = {
+    static constexpr auto flags = {
         StatusRedrawingFlag::VIEW,
         StatusRedrawingFlag::LITE,
         StatusRedrawingFlag::MONSTER_LITE,

--- a/src/save/floor-writer.cpp
+++ b/src/save/floor-writer.cpp
@@ -157,12 +157,12 @@ bool wr_dungeon(PlayerType *player_ptr)
     forget_view(player_ptr->current_floor_ptr);
     clear_mon_lite(player_ptr->current_floor_ptr);
     static constexpr auto flags = {
-        StatusRedrawingFlag::VIEW,
-        StatusRedrawingFlag::LITE,
-        StatusRedrawingFlag::MONSTER_LITE,
-        StatusRedrawingFlag::MONSTER_STATUSES,
-        StatusRedrawingFlag::DISTANCE,
-        StatusRedrawingFlag::FLOW,
+        StatusRecalculatingFlag::VIEW,
+        StatusRecalculatingFlag::LITE,
+        StatusRecalculatingFlag::MONSTER_LITE,
+        StatusRecalculatingFlag::MONSTER_STATUSES,
+        StatusRecalculatingFlag::DISTANCE,
+        StatusRecalculatingFlag::FLOW,
     };
     RedrawingFlagsUpdater::get_instance().set_flags(flags);
     wr_s16b(max_floor_id);

--- a/src/specific-object/bloody-moon.cpp
+++ b/src/specific-object/bloody-moon.cpp
@@ -96,7 +96,7 @@ bool activate_bloody_moon(PlayerType *player_ptr, ItemEntity *o_ptr)
         calc_android_exp(player_ptr);
     }
 
-    const auto flags = {
+    static constexpr auto flags = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::HP,
     };

--- a/src/specific-object/bloody-moon.cpp
+++ b/src/specific-object/bloody-moon.cpp
@@ -97,8 +97,8 @@ bool activate_bloody_moon(PlayerType *player_ptr, ItemEntity *o_ptr)
     }
 
     static constexpr auto flags = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::HP,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::HP,
     };
     RedrawingFlagsUpdater::get_instance().set_flags(flags);
     return true;

--- a/src/specific-object/torch.cpp
+++ b/src/specific-object/torch.cpp
@@ -164,9 +164,9 @@ void update_lite_radius(PlayerType *player_ptr)
     }
 
     static constexpr auto flags = {
-        StatusRedrawingFlag::LITE,
-        StatusRedrawingFlag::MONSTER_LITE,
-        StatusRedrawingFlag::MONSTER_STATUSES,
+        StatusRecalculatingFlag::LITE,
+        StatusRecalculatingFlag::MONSTER_LITE,
+        StatusRecalculatingFlag::MONSTER_STATUSES,
     };
     RedrawingFlagsUpdater::get_instance().set_flags(flags);
     player_ptr->old_lite = player_ptr->cur_lite;
@@ -341,5 +341,5 @@ void update_lite(PlayerType *player_ptr)
         cave_redraw_later(floor_ptr, y, x);
     }
 
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::DELAY_VISIBILITY);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::DELAY_VISIBILITY);
 }

--- a/src/specific-object/torch.cpp
+++ b/src/specific-object/torch.cpp
@@ -163,7 +163,7 @@ void update_lite_radius(PlayerType *player_ptr)
         return;
     }
 
-    const auto flags = {
+    static constexpr auto flags = {
         StatusRedrawingFlag::LITE,
         StatusRedrawingFlag::MONSTER_LITE,
         StatusRedrawingFlag::MONSTER_STATUSES,

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -375,7 +375,7 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
         MainWindowRedrawingFlag::MAP,
     };
     rfu.set_flags(flags_mwrf);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::OVERHEAD,
         SubWindowRedrawingFlag::DUNGEON,
     };

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -360,13 +360,13 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::UN_VIEW,
-        StatusRedrawingFlag::UN_LITE,
-        StatusRedrawingFlag::VIEW,
-        StatusRedrawingFlag::LITE,
-        StatusRedrawingFlag::FLOW,
-        StatusRedrawingFlag::MONSTER_LITE,
-        StatusRedrawingFlag::MONSTER_STATUSES,
+        StatusRecalculatingFlag::UN_VIEW,
+        StatusRecalculatingFlag::UN_LITE,
+        StatusRecalculatingFlag::VIEW,
+        StatusRecalculatingFlag::LITE,
+        StatusRecalculatingFlag::FLOW,
+        StatusRecalculatingFlag::MONSTER_LITE,
+        StatusRecalculatingFlag::MONSTER_STATUSES,
     };
     rfu.set_flags(flags_srf);
     static constexpr auto flags_mwrf = {

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -369,7 +369,7 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
         StatusRedrawingFlag::MONSTER_STATUSES,
     };
     rfu.set_flags(flags_srf);
-    const auto flags_mwrf = {
+    static constexpr auto flags_mwrf = {
         MainWindowRedrawingFlag::HEALTH,
         MainWindowRedrawingFlag::UHEALTH,
         MainWindowRedrawingFlag::MAP,

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -359,7 +359,7 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::UN_VIEW,
         StatusRedrawingFlag::UN_LITE,
         StatusRedrawingFlag::VIEW,

--- a/src/spell-kind/spells-curse-removal.cpp
+++ b/src/spell-kind/spells-curse-removal.cpp
@@ -38,7 +38,7 @@ static int exe_curse_removal(PlayerType *player_ptr, int all)
         o_ptr->curse_flags.clear();
         o_ptr->ident |= IDENT_SENSE;
         o_ptr->feeling = FEEL_NONE;
-        rfu.set_flag(StatusRedrawingFlag::BONUS);
+        rfu.set_flag(StatusRecalculatingFlag::BONUS);
         rfu.set_flag(SubWindowRedrawingFlag::EQUIPMENT);
         count++;
     }

--- a/src/spell-kind/spells-equipment.cpp
+++ b/src/spell-kind/spells-equipment.cpp
@@ -103,7 +103,7 @@ bool apply_disenchant(PlayerType *player_ptr, BIT_FLAGS mode)
     chg_virtue(player_ptr, Virtue::HARMONY, 1);
     chg_virtue(player_ptr, Virtue::ENCHANT, -2);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     static constexpr auto flags = {
         SubWindowRedrawingFlag::EQUIPMENT,
         SubWindowRedrawingFlag::PLAYER,

--- a/src/spell-kind/spells-equipment.cpp
+++ b/src/spell-kind/spells-equipment.cpp
@@ -104,7 +104,7 @@ bool apply_disenchant(PlayerType *player_ptr, BIT_FLAGS mode)
     chg_virtue(player_ptr, Virtue::ENCHANT, -2);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(StatusRedrawingFlag::BONUS);
-    const auto flags = {
+    static constexpr auto flags = {
         SubWindowRedrawingFlag::EQUIPMENT,
         SubWindowRedrawingFlag::PLAYER,
     };

--- a/src/spell-kind/spells-fetcher.cpp
+++ b/src/spell-kind/spells-fetcher.cpp
@@ -157,7 +157,7 @@ bool fetch_monster(PlayerType *player_ptr)
     lite_spot(player_ptr, target_row, target_col);
     lite_spot(player_ptr, ty, tx);
     if (monraces_info[m_ptr->r_idx].brightness_flags.has_any_of(ld_mask)) {
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::MONSTER_LITE);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::MONSTER_LITE);
     }
 
     if (m_ptr->ml) {

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -124,7 +124,7 @@ void wiz_lite(PlayerType *player_ptr, bool ninja)
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::OVERHEAD,
         SubWindowRedrawingFlag::DUNGEON,
         SubWindowRedrawingFlag::FOUND_ITEMS,
@@ -193,7 +193,7 @@ void wiz_dark(PlayerType *player_ptr)
     };
     rfu.set_flags(flags_srf);
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::OVERHEAD,
         SubWindowRedrawingFlag::DUNGEON,
         SubWindowRedrawingFlag::FOUND_ITEMS,
@@ -254,7 +254,7 @@ void map_area(PlayerType *player_ptr, POSITION range)
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::OVERHEAD,
         SubWindowRedrawingFlag::DUNGEON,
     };
@@ -499,7 +499,7 @@ bool destroy_area(PlayerType *player_ptr, POSITION y1, POSITION x1, POSITION r, 
     };
     rfu.set_flags(flags_srf);
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::OVERHEAD,
         SubWindowRedrawingFlag::DUNGEON,
     };

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -122,7 +122,7 @@ void wiz_lite(PlayerType *player_ptr, bool ninja)
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+    rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
     static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::OVERHEAD,
@@ -184,12 +184,12 @@ void wiz_dark(PlayerType *player_ptr)
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::UN_VIEW,
-        StatusRedrawingFlag::UN_LITE,
-        StatusRedrawingFlag::VIEW,
-        StatusRedrawingFlag::LITE,
-        StatusRedrawingFlag::MONSTER_LITE,
-        StatusRedrawingFlag::MONSTER_STATUSES,
+        StatusRecalculatingFlag::UN_VIEW,
+        StatusRecalculatingFlag::UN_LITE,
+        StatusRecalculatingFlag::VIEW,
+        StatusRecalculatingFlag::LITE,
+        StatusRecalculatingFlag::MONSTER_LITE,
+        StatusRecalculatingFlag::MONSTER_STATUSES,
     };
     rfu.set_flags(flags_srf);
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
@@ -489,13 +489,13 @@ bool destroy_area(PlayerType *player_ptr, POSITION y1, POSITION x1, POSITION r, 
     forget_flow(floor_ptr);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::UN_VIEW,
-        StatusRedrawingFlag::UN_LITE,
-        StatusRedrawingFlag::VIEW,
-        StatusRedrawingFlag::LITE,
-        StatusRedrawingFlag::FLOW,
-        StatusRedrawingFlag::MONSTER_LITE,
-        StatusRedrawingFlag::MONSTER_STATUSES,
+        StatusRecalculatingFlag::UN_VIEW,
+        StatusRecalculatingFlag::UN_LITE,
+        StatusRecalculatingFlag::VIEW,
+        StatusRecalculatingFlag::LITE,
+        StatusRecalculatingFlag::FLOW,
+        StatusRecalculatingFlag::MONSTER_LITE,
+        StatusRecalculatingFlag::MONSTER_STATUSES,
     };
     rfu.set_flags(flags_srf);
     rfu.set_flag(MainWindowRedrawingFlag::MAP);

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -183,7 +183,7 @@ void wiz_dark(PlayerType *player_ptr)
     forget_travel_flow(player_ptr->current_floor_ptr);
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::UN_VIEW,
         StatusRedrawingFlag::UN_LITE,
         StatusRedrawingFlag::VIEW,
@@ -488,7 +488,7 @@ bool destroy_area(PlayerType *player_ptr, POSITION y1, POSITION x1, POSITION r, 
 
     forget_flow(floor_ptr);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::UN_VIEW,
         StatusRedrawingFlag::UN_LITE,
         StatusRedrawingFlag::VIEW,

--- a/src/spell-kind/spells-neighbor.cpp
+++ b/src/spell-kind/spells-neighbor.cpp
@@ -67,7 +67,7 @@ bool wall_stone(PlayerType *player_ptr)
     BIT_FLAGS flg = PROJECT_GRID | PROJECT_ITEM | PROJECT_HIDE;
     bool dummy = project(player_ptr, 0, 1, player_ptr->y, player_ptr->x, 0, AttributeType::STONE_WALL, flg).notice;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(StatusRedrawingFlag::FLOW);
+    rfu.set_flag(StatusRecalculatingFlag::FLOW);
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
     return dummy;
 }

--- a/src/spell-kind/spells-perception.cpp
+++ b/src/spell-kind/spells-perception.cpp
@@ -77,7 +77,7 @@ bool identify_item(PlayerType *player_ptr, ItemEntity *o_ptr)
         StatusRedrawingFlag::REORDER,
     };
     rfu.set_flags(flags_srf);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
         SubWindowRedrawingFlag::PLAYER,

--- a/src/spell-kind/spells-perception.cpp
+++ b/src/spell-kind/spells-perception.cpp
@@ -71,7 +71,7 @@ bool identify_item(PlayerType *player_ptr, ItemEntity *o_ptr)
     o_ptr->marked.set(OmType::TOUCHED);
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::COMBINATION,
         StatusRedrawingFlag::REORDER,

--- a/src/spell-kind/spells-perception.cpp
+++ b/src/spell-kind/spells-perception.cpp
@@ -72,9 +72,9 @@ bool identify_item(PlayerType *player_ptr, ItemEntity *o_ptr)
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::COMBINATION,
-        StatusRedrawingFlag::REORDER,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::COMBINATION,
+        StatusRecalculatingFlag::REORDER,
     };
     rfu.set_flags(flags_srf);
     static constexpr auto flags_swrf = {

--- a/src/spell-kind/spells-sight.cpp
+++ b/src/spell-kind/spells-sight.cpp
@@ -253,7 +253,7 @@ void aggravate_monsters(PlayerType *player_ptr, MONSTER_IDX who)
     }
 
     if (player_ptr->riding) {
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     }
 }
 

--- a/src/spell-kind/spells-teleport.cpp
+++ b/src/spell-kind/spells-teleport.cpp
@@ -196,7 +196,7 @@ bool teleport_away(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION dis, tele
     lite_spot(player_ptr, ny, nx);
 
     if (monraces_info[m_ptr->r_idx].brightness_flags.has_any_of(ld_mask)) {
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::MONSTER_LITE);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::MONSTER_LITE);
     }
 
     return true;
@@ -277,7 +277,7 @@ void teleport_monster_to(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION ty,
     lite_spot(player_ptr, ny, nx);
 
     if (monraces_info[m_ptr->r_idx].brightness_flags.has_any_of(ld_mask)) {
-        RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::MONSTER_LITE);
+        RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::MONSTER_LITE);
     }
 }
 

--- a/src/spell-realm/spells-arcane.cpp
+++ b/src/spell-realm/spells-arcane.cpp
@@ -37,5 +37,5 @@ void phlogiston(PlayerType *player_ptr)
         msg_print(_("照明用アイテムは満タンになった。", "Your light is full."));
     }
 
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::TORCH);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::TORCH);
 }

--- a/src/spell-realm/spells-chaos.cpp
+++ b/src/spell-realm/spells-chaos.cpp
@@ -186,7 +186,7 @@ bool vanish_dungeon(PlayerType *player_ptr)
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::UN_VIEW,
         StatusRedrawingFlag::UN_LITE,
         StatusRedrawingFlag::VIEW,

--- a/src/spell-realm/spells-chaos.cpp
+++ b/src/spell-realm/spells-chaos.cpp
@@ -197,7 +197,7 @@ bool vanish_dungeon(PlayerType *player_ptr)
     };
     rfu.set_flags(flags_srf);
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::OVERHEAD,
         SubWindowRedrawingFlag::DUNGEON,
     };

--- a/src/spell-realm/spells-chaos.cpp
+++ b/src/spell-realm/spells-chaos.cpp
@@ -187,13 +187,13 @@ bool vanish_dungeon(PlayerType *player_ptr)
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::UN_VIEW,
-        StatusRedrawingFlag::UN_LITE,
-        StatusRedrawingFlag::VIEW,
-        StatusRedrawingFlag::LITE,
-        StatusRedrawingFlag::FLOW,
-        StatusRedrawingFlag::MONSTER_LITE,
-        StatusRedrawingFlag::MONSTER_STATUSES,
+        StatusRecalculatingFlag::UN_VIEW,
+        StatusRecalculatingFlag::UN_LITE,
+        StatusRecalculatingFlag::VIEW,
+        StatusRecalculatingFlag::LITE,
+        StatusRecalculatingFlag::FLOW,
+        StatusRecalculatingFlag::MONSTER_LITE,
+        StatusRecalculatingFlag::MONSTER_STATUSES,
     };
     rfu.set_flags(flags_srf);
     rfu.set_flag(MainWindowRedrawingFlag::MAP);

--- a/src/spell-realm/spells-craft.cpp
+++ b/src/spell-realm/spells-craft.cpp
@@ -90,7 +90,7 @@ bool set_ele_attack(PlayerType *player_ptr, uint32_t attack_type, TIME_EFFECT v)
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
 
     return true;
@@ -153,7 +153,7 @@ bool set_ele_immune(PlayerType *player_ptr, uint32_t immune_type, TIME_EFFECT v)
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
 
     return true;

--- a/src/spell-realm/spells-crusade.cpp
+++ b/src/spell-realm/spells-crusade.cpp
@@ -152,7 +152,7 @@ bool set_tim_sh_holy(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
 
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
     return true;
 }
@@ -202,7 +202,7 @@ bool set_tim_eyeeye(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
 
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
     return true;
 }

--- a/src/spell-realm/spells-demon.cpp
+++ b/src/spell-realm/spells-demon.cpp
@@ -50,7 +50,7 @@ bool set_tim_sh_fire(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
 
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
     return true;
 }

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -74,7 +74,7 @@ void SpellHex::stop_all_spells()
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::HP,
         StatusRedrawingFlag::MP,
@@ -123,7 +123,7 @@ bool SpellHex::stop_spells_with_selection()
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::HP,
         StatusRedrawingFlag::MP,
@@ -246,7 +246,7 @@ bool SpellHex::process_mana_cost(const bool need_restart)
 
     msg_print(_("詠唱を再開した。", "You restart casting."));
     this->player_ptr->action = ACTION_SPELL;
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::HP,
         StatusRedrawingFlag::MONSTER_STATUSES,

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -81,7 +81,7 @@ void SpellHex::stop_all_spells()
         StatusRedrawingFlag::SPELLS,
     };
     rfu.set_flags(flags_srf);
-    const auto flags_mwrf = {
+    static constexpr auto flags_mwrf = {
         MainWindowRedrawingFlag::EXTRA,
         MainWindowRedrawingFlag::HP,
         MainWindowRedrawingFlag::MP,
@@ -130,7 +130,7 @@ bool SpellHex::stop_spells_with_selection()
         StatusRedrawingFlag::SPELLS,
     };
     rfu.set_flags(flags_srf);
-    const auto flags_mwrf = {
+    static constexpr auto flags_mwrf = {
         MainWindowRedrawingFlag::EXTRA,
         MainWindowRedrawingFlag::HP,
         MainWindowRedrawingFlag::MP,
@@ -252,7 +252,7 @@ bool SpellHex::process_mana_cost(const bool need_restart)
         StatusRedrawingFlag::MONSTER_STATUSES,
     };
     rfu.set_flags(flags_srf);
-    const auto flags_mwrf = {
+    static constexpr auto flags_mwrf = {
         MainWindowRedrawingFlag::MAP,
         MainWindowRedrawingFlag::TIMED_EFFECT,
         MainWindowRedrawingFlag::ACTION,

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -75,10 +75,10 @@ void SpellHex::stop_all_spells()
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::HP,
-        StatusRedrawingFlag::MP,
-        StatusRedrawingFlag::SPELLS,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::HP,
+        StatusRecalculatingFlag::MP,
+        StatusRecalculatingFlag::SPELLS,
     };
     rfu.set_flags(flags_srf);
     static constexpr auto flags_mwrf = {
@@ -124,10 +124,10 @@ bool SpellHex::stop_spells_with_selection()
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::HP,
-        StatusRedrawingFlag::MP,
-        StatusRedrawingFlag::SPELLS,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::HP,
+        StatusRecalculatingFlag::MP,
+        StatusRecalculatingFlag::SPELLS,
     };
     rfu.set_flags(flags_srf);
     static constexpr auto flags_mwrf = {
@@ -247,9 +247,9 @@ bool SpellHex::process_mana_cost(const bool need_restart)
     msg_print(_("詠唱を再開した。", "You restart casting."));
     this->player_ptr->action = ACTION_SPELL;
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::HP,
-        StatusRedrawingFlag::MONSTER_STATUSES,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::HP,
+        StatusRecalculatingFlag::MONSTER_STATUSES,
     };
     rfu.set_flags(flags_srf);
     static constexpr auto flags_mwrf = {

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -258,7 +258,7 @@ bool SpellHex::process_mana_cost(const bool need_restart)
         MainWindowRedrawingFlag::ACTION,
     };
     rfu.set_flags(flags_mwrf);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::OVERHEAD,
         SubWindowRedrawingFlag::DUNGEON,
     };

--- a/src/spell-realm/spells-song.cpp
+++ b/src/spell-realm/spells-song.cpp
@@ -65,7 +65,7 @@ void check_music(PlayerType *player_ptr)
             StatusRedrawingFlag::MONSTER_STATUSES,
         };
         rfu.set_flags(flags_srf);
-        const auto flags_mwrf = {
+        static constexpr auto flags_mwrf = {
             MainWindowRedrawingFlag::MAP,
             MainWindowRedrawingFlag::TIMED_EFFECT,
             MainWindowRedrawingFlag::ACTION,

--- a/src/spell-realm/spells-song.cpp
+++ b/src/spell-realm/spells-song.cpp
@@ -60,9 +60,9 @@ void check_music(PlayerType *player_ptr)
         msg_print(_("歌を再開した。", "You resume singing."));
         player_ptr->action = ACTION_SING;
         static constexpr auto flags_srf = {
-            StatusRedrawingFlag::BONUS,
-            StatusRedrawingFlag::HP,
-            StatusRedrawingFlag::MONSTER_STATUSES,
+            StatusRecalculatingFlag::BONUS,
+            StatusRecalculatingFlag::HP,
+            StatusRecalculatingFlag::MONSTER_STATUSES,
         };
         rfu.set_flags(flags_srf);
         static constexpr auto flags_mwrf = {
@@ -125,7 +125,7 @@ bool set_tim_stealth(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
 
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
     return true;
 }
@@ -156,7 +156,7 @@ void stop_singing(PlayerType *player_ptr)
     set_singing_song_effect(player_ptr, MUSIC_NONE);
     set_singing_song_id(player_ptr, 0);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
 }
 

--- a/src/spell-realm/spells-song.cpp
+++ b/src/spell-realm/spells-song.cpp
@@ -71,7 +71,7 @@ void check_music(PlayerType *player_ptr)
             MainWindowRedrawingFlag::ACTION,
         };
         rfu.set_flags(flags_mwrf);
-        const auto flags_swrf = {
+        static constexpr auto flags_swrf = {
             SubWindowRedrawingFlag::OVERHEAD,
             SubWindowRedrawingFlag::DUNGEON,
         };

--- a/src/spell-realm/spells-song.cpp
+++ b/src/spell-realm/spells-song.cpp
@@ -59,7 +59,7 @@ void check_music(PlayerType *player_ptr)
         set_interrupting_song_effect(player_ptr, MUSIC_NONE);
         msg_print(_("歌を再開した。", "You resume singing."));
         player_ptr->action = ACTION_SING;
-        const auto flags_srf = {
+        static constexpr auto flags_srf = {
             StatusRedrawingFlag::BONUS,
             StatusRedrawingFlag::HP,
             StatusRedrawingFlag::MONSTER_STATUSES,

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -253,7 +253,7 @@ bool curse_armor(PlayerType *player_ptr)
         StatusRedrawingFlag::MP,
     };
     rfu.set_flags(flags_srf);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
         SubWindowRedrawingFlag::PLAYER,
@@ -309,7 +309,7 @@ bool curse_weapon_object(PlayerType *player_ptr, bool force, ItemEntity *o_ptr)
         StatusRedrawingFlag::MP,
     };
     rfu.set_flags(flags_srf);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
         SubWindowRedrawingFlag::PLAYER,
@@ -466,7 +466,7 @@ bool enchant_equipment(ItemEntity *o_ptr, int n, int eflag)
         StatusRedrawingFlag::REORDER,
     };
     rfu.set_flags(flags_srf);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
         SubWindowRedrawingFlag::PLAYER,

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -249,8 +249,8 @@ bool curse_armor(PlayerType *player_ptr)
     o_ptr->ident |= IDENT_BROKEN;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::MP,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::MP,
     };
     rfu.set_flags(flags_srf);
     static constexpr auto flags_swrf = {
@@ -305,8 +305,8 @@ bool curse_weapon_object(PlayerType *player_ptr, bool force, ItemEntity *o_ptr)
     o_ptr->ident |= IDENT_BROKEN;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::MP,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::MP,
     };
     rfu.set_flags(flags_srf);
     static constexpr auto flags_swrf = {
@@ -461,9 +461,9 @@ bool enchant_equipment(ItemEntity *o_ptr, int n, int eflag)
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::COMBINATION,
-        StatusRedrawingFlag::REORDER,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::COMBINATION,
+        StatusRecalculatingFlag::REORDER,
     };
     rfu.set_flags(flags_srf);
     static constexpr auto flags_swrf = {

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -248,7 +248,7 @@ bool curse_armor(PlayerType *player_ptr)
     o_ptr->curse_flags.set(CurseTraitType::CURSED);
     o_ptr->ident |= IDENT_BROKEN;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::MP,
     };
@@ -304,7 +304,7 @@ bool curse_weapon_object(PlayerType *player_ptr, bool force, ItemEntity *o_ptr)
     o_ptr->curse_flags.set(CurseTraitType::CURSED);
     o_ptr->ident |= IDENT_BROKEN;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::MP,
     };
@@ -460,7 +460,7 @@ bool enchant_equipment(ItemEntity *o_ptr, int n, int eflag)
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::COMBINATION,
         StatusRedrawingFlag::REORDER,

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -216,7 +216,7 @@ bool time_walk(PlayerType *player_ptr)
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
     rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
-    const auto flags = {
+    static constexpr auto flags = {
         SubWindowRedrawingFlag::OVERHEAD,
         SubWindowRedrawingFlag::DUNGEON,
     };

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -215,7 +215,7 @@ bool time_walk(PlayerType *player_ptr)
     player_ptr->energy_need -= 1000 + (100 + player_ptr->csp - 50) * TURNS_PER_TICK / 10;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
-    rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+    rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
     static constexpr auto flags = {
         SubWindowRedrawingFlag::OVERHEAD,
         SubWindowRedrawingFlag::DUNGEON,
@@ -259,7 +259,7 @@ void roll_hitdice(PlayerType *player_ptr, spell_operation options)
 
     auto percent = (player_ptr->player_hp[PY_MAX_LEVEL - 1] * 200) / (2 * player_ptr->hitdie + ((PY_MAX_LEVEL - 1 + 3) * (player_ptr->hitdie + 1)));
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(StatusRedrawingFlag::HP);
+    rfu.set_flag(StatusRecalculatingFlag::HP);
     rfu.set_flag(MainWindowRedrawingFlag::HP);
     rfu.set_flag(SubWindowRedrawingFlag::PLAYER);
     if (!(options & SPOP_NO_UPDATE)) {
@@ -691,5 +691,5 @@ void status_shuffle(PlayerType *player_ptr)
         }
     }
 
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
 }

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -499,7 +499,7 @@ bool restore_mana(PlayerType *player_ptr, bool magic_eater)
     player_ptr->csp_frac = 0;
     msg_print(_("頭がハッキリとした。", "You feel your head clear."));
     rfu.set_flag(MainWindowRedrawingFlag::MP);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::SPELL,
         SubWindowRedrawingFlag::PLAYER,
     };

--- a/src/status/action-setter.cpp
+++ b/src/status/action-setter.cpp
@@ -60,7 +60,7 @@ void set_action(PlayerType *player_ptr, uint8_t typ)
     case ACTION_SAMURAI_STANCE:
         msg_print(_("型を崩した。", "You stop assuming the special stance."));
         PlayerClass(player_ptr).set_samurai_stance(SamuraiStanceType::NONE);
-        rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+        rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
         rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
         break;
     case ACTION_SING:
@@ -107,6 +107,6 @@ void set_action(PlayerType *player_ptr, uint8_t typ)
         break;
     }
 
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     rfu.set_flag(MainWindowRedrawingFlag::ACTION);
 }

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -102,7 +102,7 @@ bool BadStatusSetter::set_blindness(const TIME_EFFECT tmp_v)
     };
     rfu.set_flags(flags_srf);
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::OVERHEAD,
         SubWindowRedrawingFlag::DUNGEON,
     };
@@ -395,7 +395,7 @@ bool BadStatusSetter::hallucination(const TIME_EFFECT tmp_v)
     };
     rfu.set_flags(flags_mwrf);
     rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::OVERHEAD,
         SubWindowRedrawingFlag::DUNGEON,
     };

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -388,7 +388,7 @@ bool BadStatusSetter::hallucination(const TIME_EFFECT tmp_v)
         disturb(this->player_ptr, false, true);
     }
 
-    const auto flags_mwrf = {
+    static constexpr auto flags_mwrf = {
         MainWindowRedrawingFlag::MAP,
         MainWindowRedrawingFlag::HEALTH,
         MainWindowRedrawingFlag::UHEALTH,

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -92,7 +92,7 @@ bool BadStatusSetter::set_blindness(const TIME_EFFECT tmp_v)
         disturb(this->player_ptr, false, false);
     }
 
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::UN_VIEW,
         StatusRedrawingFlag::UN_LITE,
         StatusRedrawingFlag::VIEW,

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -93,12 +93,12 @@ bool BadStatusSetter::set_blindness(const TIME_EFFECT tmp_v)
     }
 
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::UN_VIEW,
-        StatusRedrawingFlag::UN_LITE,
-        StatusRedrawingFlag::VIEW,
-        StatusRedrawingFlag::LITE,
-        StatusRedrawingFlag::MONSTER_STATUSES,
-        StatusRedrawingFlag::MONSTER_LITE,
+        StatusRecalculatingFlag::UN_VIEW,
+        StatusRecalculatingFlag::UN_LITE,
+        StatusRecalculatingFlag::VIEW,
+        StatusRecalculatingFlag::LITE,
+        StatusRecalculatingFlag::MONSTER_STATUSES,
+        StatusRecalculatingFlag::MONSTER_LITE,
     };
     rfu.set_flags(flags_srf);
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
@@ -144,7 +144,7 @@ bool BadStatusSetter::set_confusion(const TIME_EFFECT tmp_v)
             if (this->player_ptr->action == ACTION_MONK_STANCE) {
                 msg_print(_("構えがとけた。", "You lose your stance."));
                 PlayerClass(player_ptr).set_monk_stance(MonkStanceType::NONE);
-                rfu.set_flag(StatusRedrawingFlag::BONUS);
+                rfu.set_flag(StatusRecalculatingFlag::BONUS);
                 rfu.set_flag(MainWindowRedrawingFlag::ACTION);
                 this->player_ptr->action = ACTION_NONE;
             } else if (this->player_ptr->action == ACTION_SAMURAI_STANCE) {
@@ -394,7 +394,7 @@ bool BadStatusSetter::hallucination(const TIME_EFFECT tmp_v)
         MainWindowRedrawingFlag::UHEALTH,
     };
     rfu.set_flags(flags_mwrf);
-    rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+    rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
     static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::OVERHEAD,
         SubWindowRedrawingFlag::DUNGEON,
@@ -450,7 +450,7 @@ bool BadStatusSetter::set_deceleration(const TIME_EFFECT tmp_v, bool do_dec)
         disturb(this->player_ptr, false, false);
     }
 
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(this->player_ptr);
     return true;
 }
@@ -489,7 +489,7 @@ bool BadStatusSetter::set_stun(const TIME_EFFECT tmp_v)
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     rfu.set_flag(MainWindowRedrawingFlag::STUN);
     handle_stuff(this->player_ptr);
     return true;
@@ -529,7 +529,7 @@ bool BadStatusSetter::set_cut(const TIME_EFFECT tmp_v)
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     rfu.set_flag(MainWindowRedrawingFlag::CUT);
     handle_stuff(this->player_ptr);
     return true;

--- a/src/status/base-status.cpp
+++ b/src/status/base-status.cpp
@@ -317,7 +317,7 @@ bool lose_all_info(PlayerType *player_ptr)
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::COMBINATION,
         StatusRedrawingFlag::REORDER,

--- a/src/status/base-status.cpp
+++ b/src/status/base-status.cpp
@@ -323,7 +323,7 @@ bool lose_all_info(PlayerType *player_ptr)
         StatusRedrawingFlag::REORDER,
     };
     rfu.set_flags(flags_srf);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
         SubWindowRedrawingFlag::PLAYER,

--- a/src/status/base-status.cpp
+++ b/src/status/base-status.cpp
@@ -70,7 +70,7 @@ bool inc_stat(PlayerType *player_ptr, int stat)
         player_ptr->stat_max[stat] = value;
     }
 
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     return true;
 }
 
@@ -179,7 +179,7 @@ bool dec_stat(PlayerType *player_ptr, int stat, int amount, int permanent)
         player_ptr->stat_max[stat] = max;
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         rfu.set_flag(MainWindowRedrawingFlag::ABILITY_SCORE);
-        rfu.set_flag(StatusRedrawingFlag::BONUS);
+        rfu.set_flag(StatusRecalculatingFlag::BONUS);
     }
 
     return res;
@@ -195,7 +195,7 @@ bool res_stat(PlayerType *player_ptr, int stat)
     if (player_ptr->stat_cur[stat] != player_ptr->stat_max[stat]) {
         player_ptr->stat_cur[stat] = player_ptr->stat_max[stat];
         auto &rfu = RedrawingFlagsUpdater::get_instance();
-        rfu.set_flag(StatusRedrawingFlag::BONUS);
+        rfu.set_flag(StatusRecalculatingFlag::BONUS);
         rfu.set_flag(MainWindowRedrawingFlag::ABILITY_SCORE);
         return true;
     }
@@ -318,9 +318,9 @@ bool lose_all_info(PlayerType *player_ptr)
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::COMBINATION,
-        StatusRedrawingFlag::REORDER,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::COMBINATION,
+        StatusRecalculatingFlag::REORDER,
     };
     rfu.set_flags(flags_srf);
     static constexpr auto flags_swrf = {

--- a/src/status/body-improvement.cpp
+++ b/src/status/body-improvement.cpp
@@ -76,7 +76,7 @@ bool set_invuln(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::OVERHEAD,
         SubWindowRedrawingFlag::DUNGEON,
     };

--- a/src/status/body-improvement.cpp
+++ b/src/status/body-improvement.cpp
@@ -93,7 +93,7 @@ bool set_invuln(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
             chg_virtue(player_ptr, Virtue::SACRIFICE, -3);
             chg_virtue(player_ptr, Virtue::VALOUR, -5);
             rfu.set_flag(MainWindowRedrawingFlag::MAP);
-            rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+            rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
             rfu.set_flags(flags_swrf);
         }
     } else {
@@ -101,7 +101,7 @@ bool set_invuln(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
             msg_print(_("無敵ではなくなった。", "The invulnerability wears off."));
             notice = true;
             rfu.set_flag(MainWindowRedrawingFlag::MAP);
-            rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+            rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
             rfu.set_flags(flags_swrf);
             player_ptr->energy_need += ENERGY_NEED();
         }
@@ -118,7 +118,7 @@ bool set_invuln(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
 
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
     return true;
 }
@@ -166,7 +166,7 @@ bool set_tim_regen(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
 
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
     return true;
 }
@@ -214,7 +214,7 @@ bool set_tim_reflect(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
 
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
     return true;
 }
@@ -262,7 +262,7 @@ bool set_pass_wall(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
 
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
     return true;
 }

--- a/src/status/buff-setter.cpp
+++ b/src/status/buff-setter.cpp
@@ -417,7 +417,7 @@ bool set_mimic(PlayerType *player_ptr, TIME_EFFECT v, MimicKindType mimic_race_i
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_mwrf = {
+    static constexpr auto flags_mwrf = {
         MainWindowRedrawingFlag::BASIC,
         MainWindowRedrawingFlag::TIMED_EFFECT,
     };

--- a/src/status/buff-setter.cpp
+++ b/src/status/buff-setter.cpp
@@ -505,7 +505,7 @@ bool set_wraith_form(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::OVERHEAD,
         SubWindowRedrawingFlag::DUNGEON,
     };

--- a/src/status/buff-setter.cpp
+++ b/src/status/buff-setter.cpp
@@ -160,7 +160,7 @@ bool set_acceleration(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     if (disturb_state) {
         disturb(player_ptr, false, false);
     }
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
     return true;
 }
@@ -213,7 +213,7 @@ bool set_shield(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
 
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
     return true;
 }
@@ -261,7 +261,7 @@ bool set_magicdef(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
 
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
     return true;
 }
@@ -309,7 +309,7 @@ bool set_blessed(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
 
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
     return true;
 }
@@ -358,8 +358,8 @@ bool set_hero(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     static constexpr auto flags = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::HP,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::HP,
     };
     RedrawingFlagsUpdater::get_instance().set_flags(flags);
     handle_stuff(player_ptr);
@@ -423,8 +423,8 @@ bool set_mimic(PlayerType *player_ptr, TIME_EFFECT v, MimicKindType mimic_race_i
     };
     rfu.set_flags(flags_mwrf);
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::HP,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::HP,
     };
     rfu.set_flags(flags_srf);
     handle_stuff(player_ptr);
@@ -480,8 +480,8 @@ bool set_shero(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     static constexpr auto flags = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::HP,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::HP,
     };
     RedrawingFlagsUpdater::get_instance().set_flags(flags);
     handle_stuff(player_ptr);
@@ -522,7 +522,7 @@ bool set_wraith_form(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
             chg_virtue(player_ptr, Virtue::SACRIFICE, -2);
             chg_virtue(player_ptr, Virtue::VALOUR, -5);
             rfu.set_flag(MainWindowRedrawingFlag::MAP);
-            rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+            rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
             rfu.set_flags(flags_swrf);
         }
     } else {
@@ -530,7 +530,7 @@ bool set_wraith_form(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
             msg_print(_("不透明になった感じがする。", "You feel opaque."));
             notice = true;
             rfu.set_flag(MainWindowRedrawingFlag::MAP);
-            rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+            rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
             rfu.set_flags(flags_swrf);
         }
     }
@@ -545,7 +545,7 @@ bool set_wraith_form(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
 
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
     return true;
 }
@@ -600,8 +600,8 @@ bool set_tsuyoshi(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     static constexpr auto flags = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::HP,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::HP,
     };
     rfu.set_flags(flags);
     handle_stuff(player_ptr);

--- a/src/status/buff-setter.cpp
+++ b/src/status/buff-setter.cpp
@@ -422,7 +422,7 @@ bool set_mimic(PlayerType *player_ptr, TIME_EFFECT v, MimicKindType mimic_race_i
         MainWindowRedrawingFlag::TIMED_EFFECT,
     };
     rfu.set_flags(flags_mwrf);
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::HP,
     };

--- a/src/status/buff-setter.cpp
+++ b/src/status/buff-setter.cpp
@@ -357,7 +357,7 @@ bool set_hero(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
 
-    const auto flags = {
+    static constexpr auto flags = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::HP,
     };
@@ -479,7 +479,7 @@ bool set_shero(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
 
-    const auto flags = {
+    static constexpr auto flags = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::HP,
     };
@@ -599,7 +599,7 @@ bool set_tsuyoshi(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
 
-    const auto flags = {
+    static constexpr auto flags = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::HP,
     };

--- a/src/status/shape-changer.cpp
+++ b/src/status/shape-changer.cpp
@@ -98,7 +98,7 @@ void change_race(PlayerType *player_ptr, PlayerRaceType new_race, concptr effect
     check_experience(player_ptr);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::BASIC);
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
 
     if (old_race != player_ptr->prace) {

--- a/src/status/sight-setter.cpp
+++ b/src/status/sight-setter.cpp
@@ -21,7 +21,7 @@ static bool update_sight(PlayerType *player_ptr, const bool notice)
         disturb(player_ptr, false, false);
     }
 
-    const auto flags = {
+    static constexpr auto flags = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::MONSTER_STATUSES,
     };

--- a/src/status/sight-setter.cpp
+++ b/src/status/sight-setter.cpp
@@ -22,8 +22,8 @@ static bool update_sight(PlayerType *player_ptr, const bool notice)
     }
 
     static constexpr auto flags = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::MONSTER_STATUSES,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::MONSTER_STATUSES,
     };
     rfu.set_flags(flags);
     handle_stuff(player_ptr);

--- a/src/status/temporary-resistance.cpp
+++ b/src/status/temporary-resistance.cpp
@@ -49,7 +49,7 @@ bool set_tim_levitation(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
 
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
     return true;
 }
@@ -91,7 +91,7 @@ bool set_ultimate_res(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
 
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
     return true;
 }
@@ -135,7 +135,7 @@ bool set_tim_res_nether(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
 
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
     return true;
 }
@@ -176,7 +176,7 @@ bool set_tim_res_time(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         disturb(player_ptr, false, false);
     }
 
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
     return true;
 }

--- a/src/store/cmd-store.cpp
+++ b/src/store/cmd-store.cpp
@@ -218,7 +218,7 @@ void do_cmd_store(PlayerType *player_ptr)
         StatusRedrawingFlag::MONSTER_STATUSES,
     };
     rfu.set_flags(flags_srf);
-    const auto flags_mwrf = {
+    static constexpr auto flags_mwrf = {
         MainWindowRedrawingFlag::BASIC,
         MainWindowRedrawingFlag::EXTRA,
         MainWindowRedrawingFlag::EQUIPPY,

--- a/src/store/cmd-store.cpp
+++ b/src/store/cmd-store.cpp
@@ -225,7 +225,7 @@ void do_cmd_store(PlayerType *player_ptr)
         MainWindowRedrawingFlag::MAP,
     };
     rfu.set_flags(flags_mwrf);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::OVERHEAD,
         SubWindowRedrawingFlag::DUNGEON,
     };

--- a/src/store/cmd-store.cpp
+++ b/src/store/cmd-store.cpp
@@ -189,7 +189,7 @@ void do_cmd_store(PlayerType *player_ptr)
             }
         }
 
-        if (rfu.has(StatusRedrawingFlag::BONUS)) {
+        if (rfu.has(StatusRecalculatingFlag::BONUS)) {
             display_store_inventory(player_ptr, store_num);
         }
 
@@ -212,10 +212,10 @@ void do_cmd_store(PlayerType *player_ptr)
     term_clear();
 
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::VIEW,
-        StatusRedrawingFlag::LITE,
-        StatusRedrawingFlag::MONSTER_LITE,
-        StatusRedrawingFlag::MONSTER_STATUSES,
+        StatusRecalculatingFlag::VIEW,
+        StatusRecalculatingFlag::LITE,
+        StatusRecalculatingFlag::MONSTER_LITE,
+        StatusRecalculatingFlag::MONSTER_STATUSES,
     };
     rfu.set_flags(flags_srf);
     static constexpr auto flags_mwrf = {

--- a/src/store/cmd-store.cpp
+++ b/src/store/cmd-store.cpp
@@ -211,7 +211,7 @@ void do_cmd_store(PlayerType *player_ptr)
     msg_erase();
     term_clear();
 
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::VIEW,
         StatusRedrawingFlag::LITE,
         StatusRedrawingFlag::MONSTER_LITE,

--- a/src/store/sell-order.cpp
+++ b/src/store/sell-order.cpp
@@ -232,7 +232,7 @@ void store_sell(PlayerType *player_ptr, StoreSaleType store_num)
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(StatusRedrawingFlag::BONUS);
+    rfu.set_flag(StatusRecalculatingFlag::BONUS);
     rfu.set_flag(SubWindowRedrawingFlag::PLAYER);
     handle_stuff(player_ptr);
 

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -84,7 +84,7 @@ std::string PlayerType::decrease_ability_random()
         this->stat_cur[k] = 3;
     }
 
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     return format(_("あなたは以前ほど%sなくなってしまった...。", "You're not as %s as you used to be..."), act.data());
 }
 
@@ -102,6 +102,6 @@ std::string PlayerType::decrease_ability_all()
         }
     }
 
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::BONUS);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     return _("あなたは以前ほど力強くなくなってしまった...。", "You're not as powerful as you used to be...");
 }

--- a/src/system/redrawing-flags-updater.cpp
+++ b/src/system/redrawing-flags-updater.cpp
@@ -33,7 +33,7 @@ bool RedrawingFlagsUpdater::has(SubWindowRedrawingFlag flag) const
     return this->sub_window_flags.has(flag);
 }
 
-bool RedrawingFlagsUpdater::has(StatusRedrawingFlag flag) const
+bool RedrawingFlagsUpdater::has(StatusRecalculatingFlag flag) const
 {
     return this->status_flags.has(flag);
 }
@@ -48,7 +48,7 @@ bool RedrawingFlagsUpdater::has_any_of(const EnumClassFlagGroup<SubWindowRedrawi
     return this->sub_window_flags.has_any_of(flags);
 }
 
-bool RedrawingFlagsUpdater::has_any_of(const EnumClassFlagGroup<StatusRedrawingFlag> &flags) const
+bool RedrawingFlagsUpdater::has_any_of(const EnumClassFlagGroup<StatusRecalculatingFlag> &flags) const
 {
     return this->status_flags.has_any_of(flags);
 }
@@ -63,7 +63,7 @@ void RedrawingFlagsUpdater::set_flag(SubWindowRedrawingFlag flag)
     this->sub_window_flags.set(flag);
 }
 
-void RedrawingFlagsUpdater::set_flag(StatusRedrawingFlag flag)
+void RedrawingFlagsUpdater::set_flag(StatusRecalculatingFlag flag)
 {
     this->status_flags.set(flag);
 }
@@ -78,7 +78,7 @@ void RedrawingFlagsUpdater::set_flags(const EnumClassFlagGroup<SubWindowRedrawin
     this->sub_window_flags.set(flags);
 }
 
-void RedrawingFlagsUpdater::set_flags(const EnumClassFlagGroup<StatusRedrawingFlag> &flags)
+void RedrawingFlagsUpdater::set_flags(const EnumClassFlagGroup<StatusRecalculatingFlag> &flags)
 {
     this->status_flags.set(flags);
 }
@@ -93,7 +93,7 @@ void RedrawingFlagsUpdater::reset_flag(SubWindowRedrawingFlag flag)
     this->sub_window_flags.reset(flag);
 }
 
-void RedrawingFlagsUpdater::reset_flag(StatusRedrawingFlag flag)
+void RedrawingFlagsUpdater::reset_flag(StatusRecalculatingFlag flag)
 {
     this->status_flags.reset(flag);
 }
@@ -108,7 +108,7 @@ void RedrawingFlagsUpdater::reset_flags(const EnumClassFlagGroup<SubWindowRedraw
     this->sub_window_flags.reset(flags);
 }
 
-void RedrawingFlagsUpdater::reset_flags(const EnumClassFlagGroup<StatusRedrawingFlag> &flags)
+void RedrawingFlagsUpdater::reset_flags(const EnumClassFlagGroup<StatusRecalculatingFlag> &flags)
 {
     this->status_flags.reset(flags);
 }

--- a/src/system/redrawing-flags-updater.h
+++ b/src/system/redrawing-flags-updater.h
@@ -70,7 +70,7 @@ inline constexpr auto ALL_SUB_WINDOW_FLAGS = {
     SubWindowRedrawingFlag::FOUND_ITEMS,
 };
 
-enum class StatusRedrawingFlag {
+enum class StatusRecalculatingFlag {
     BONUS, /*!< 能力値修正 */
     TORCH, /*!< 光源半径 */
     HP,
@@ -107,27 +107,27 @@ public:
 
     bool has(MainWindowRedrawingFlag flag) const;
     bool has(SubWindowRedrawingFlag flag) const;
-    bool has(StatusRedrawingFlag flag) const;
+    bool has(StatusRecalculatingFlag flag) const;
 
     bool has_any_of(const EnumClassFlagGroup<MainWindowRedrawingFlag> &flags) const;
     bool has_any_of(const EnumClassFlagGroup<SubWindowRedrawingFlag> &flags) const;
-    bool has_any_of(const EnumClassFlagGroup<StatusRedrawingFlag> &flags) const;
+    bool has_any_of(const EnumClassFlagGroup<StatusRecalculatingFlag> &flags) const;
 
     void set_flag(MainWindowRedrawingFlag flag);
     void set_flag(SubWindowRedrawingFlag flag);
-    void set_flag(StatusRedrawingFlag flag);
+    void set_flag(StatusRecalculatingFlag flag);
 
     void set_flags(const EnumClassFlagGroup<MainWindowRedrawingFlag> &flags);
     void set_flags(const EnumClassFlagGroup<SubWindowRedrawingFlag> &flags);
-    void set_flags(const EnumClassFlagGroup<StatusRedrawingFlag> &flags);
+    void set_flags(const EnumClassFlagGroup<StatusRecalculatingFlag> &flags);
 
     void reset_flag(MainWindowRedrawingFlag flag);
     void reset_flag(SubWindowRedrawingFlag flag);
-    void reset_flag(StatusRedrawingFlag flag);
+    void reset_flag(StatusRecalculatingFlag flag);
 
     void reset_flags(const EnumClassFlagGroup<MainWindowRedrawingFlag> &flags);
     void reset_flags(const EnumClassFlagGroup<SubWindowRedrawingFlag> &flags);
-    void reset_flags(const EnumClassFlagGroup<StatusRedrawingFlag> &flags);
+    void reset_flags(const EnumClassFlagGroup<StatusRecalculatingFlag> &flags);
 
     void fill_up_sub_flags();
     EnumClassFlagGroup<SubWindowRedrawingFlag> get_sub_intersection(const EnumClassFlagGroup<SubWindowRedrawingFlag> &flags);
@@ -139,5 +139,5 @@ private:
 
     EnumClassFlagGroup<MainWindowRedrawingFlag> main_window_flags{};
     EnumClassFlagGroup<SubWindowRedrawingFlag> sub_window_flags{};
-    EnumClassFlagGroup<StatusRedrawingFlag> status_flags{};
+    EnumClassFlagGroup<StatusRecalculatingFlag> status_flags{};
 };

--- a/src/target/grid-selector.cpp
+++ b/src/target/grid-selector.cpp
@@ -159,7 +159,7 @@ void tgt_pt_info::move_to_symbol(PlayerType *player_ptr)
         this->x = player_ptr->x;
         verify_panel(player_ptr);
         auto &rfu = RedrawingFlagsUpdater::get_instance();
-        rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+        rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
         rfu.set_flag(MainWindowRedrawingFlag::MAP);
         rfu.set_flag(SubWindowRedrawingFlag::OVERHEAD);
         handle_stuff(player_ptr);
@@ -303,7 +303,7 @@ bool tgt_pt(PlayerType *player_ptr, POSITION *x_ptr, POSITION *y_ptr)
     prt("", 0, 0);
     verify_panel(player_ptr);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+    rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
     rfu.set_flag(SubWindowRedrawingFlag::OVERHEAD);
     handle_stuff(player_ptr);

--- a/src/target/target-checker.cpp
+++ b/src/target/target-checker.cpp
@@ -126,7 +126,7 @@ void verify_panel(PlayerType *player_ptr)
 
     panel_bounds_center();
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+    rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
     static constexpr auto flags = {
         SubWindowRedrawingFlag::OVERHEAD,

--- a/src/target/target-checker.cpp
+++ b/src/target/target-checker.cpp
@@ -128,7 +128,7 @@ void verify_panel(PlayerType *player_ptr)
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
-    const auto flags = {
+    static constexpr auto flags = {
         SubWindowRedrawingFlag::OVERHEAD,
         SubWindowRedrawingFlag::DUNGEON,
     };

--- a/src/target/target-setter.cpp
+++ b/src/target/target-setter.cpp
@@ -601,7 +601,7 @@ bool target_set(PlayerType *player_ptr, target_type mode)
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
-    const auto flags = {
+    static constexpr auto flags = {
         SubWindowRedrawingFlag::OVERHEAD,
         SubWindowRedrawingFlag::FLOOR_ITEMS,
     };

--- a/src/target/target-setter.cpp
+++ b/src/target/target-setter.cpp
@@ -254,7 +254,7 @@ static void switch_target_input(PlayerType *player_ptr, ts_type *ts_ptr)
     case 'p': {
         verify_panel(player_ptr);
         auto &rfu = RedrawingFlagsUpdater::get_instance();
-        rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+        rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
         rfu.set_flag(MainWindowRedrawingFlag::MAP);
         rfu.set_flag(SubWindowRedrawingFlag::OVERHEAD);
         handle_stuff(player_ptr);
@@ -352,7 +352,7 @@ static void sweep_targets(PlayerType *player_ptr, ts_type *ts_ptr)
         panel_row_min = ts_ptr->y2;
         panel_col_min = ts_ptr->x2;
         panel_bounds_center();
-        rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+        rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
         rfu.set_flag(MainWindowRedrawingFlag::MAP);
         rfu.set_flag(SubWindowRedrawingFlag::OVERHEAD);
         handle_stuff(player_ptr);
@@ -455,7 +455,7 @@ static void switch_next_grid_command(PlayerType *player_ptr, ts_type *ts_ptr)
     case 'p': {
         verify_panel(player_ptr);
         auto &rfu = RedrawingFlagsUpdater::get_instance();
-        rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+        rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
         rfu.set_flag(MainWindowRedrawingFlag::MAP);
         rfu.set_flag(SubWindowRedrawingFlag::OVERHEAD);
         handle_stuff(player_ptr);
@@ -599,7 +599,7 @@ bool target_set(PlayerType *player_ptr, target_type mode)
     prt("", 0, 0);
     verify_panel(player_ptr);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    rfu.set_flag(StatusRedrawingFlag::MONSTER_STATUSES);
+    rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
     static constexpr auto flags = {
         SubWindowRedrawingFlag::OVERHEAD,

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -234,8 +234,8 @@ void wiz_identify_full_inventory(PlayerType *player_ptr)
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::COMBINATION,
-        StatusRedrawingFlag::REORDER,
+        StatusRecalculatingFlag::COMBINATION,
+        StatusRecalculatingFlag::REORDER,
     };
     rfu.set_flags(flags_srf);
     static constexpr auto flags_swrf = {
@@ -587,9 +587,9 @@ static void wiz_reroll_item(PlayerType *player_ptr, ItemEntity *o_ptr)
     o_ptr->copy_from(q_ptr);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::COMBINATION,
-        StatusRedrawingFlag::REORDER,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::COMBINATION,
+        StatusRecalculatingFlag::REORDER,
     };
     rfu.set_flags(flags_srf);
     static constexpr auto flags_swrf = {
@@ -745,9 +745,9 @@ void wiz_modify_item(PlayerType *player_ptr)
         o_ptr->copy_from(q_ptr);
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         static constexpr auto flags_srf = {
-            StatusRedrawingFlag::BONUS,
-            StatusRedrawingFlag::COMBINATION,
-            StatusRedrawingFlag::REORDER,
+            StatusRecalculatingFlag::BONUS,
+            StatusRecalculatingFlag::COMBINATION,
+            StatusRecalculatingFlag::REORDER,
         };
         rfu.set_flags(flags_srf);
         static constexpr auto flags_swrf = {

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -238,7 +238,7 @@ void wiz_identify_full_inventory(PlayerType *player_ptr)
         StatusRedrawingFlag::REORDER,
     };
     rfu.set_flags(flags_srf);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
     };
@@ -592,7 +592,7 @@ static void wiz_reroll_item(PlayerType *player_ptr, ItemEntity *o_ptr)
         StatusRedrawingFlag::REORDER,
     };
     rfu.set_flags(flags_srf);
-    const auto flags_swrf = {
+    static constexpr auto flags_swrf = {
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::EQUIPMENT,
         SubWindowRedrawingFlag::SPELL,
@@ -750,7 +750,7 @@ void wiz_modify_item(PlayerType *player_ptr)
             StatusRedrawingFlag::REORDER,
         };
         rfu.set_flags(flags_srf);
-        const auto flags_swrf = {
+        static constexpr auto flags_swrf = {
             SubWindowRedrawingFlag::INVENTORY,
             SubWindowRedrawingFlag::EQUIPMENT,
             SubWindowRedrawingFlag::SPELL,

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -233,7 +233,7 @@ void wiz_identify_full_inventory(PlayerType *player_ptr)
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::COMBINATION,
         StatusRedrawingFlag::REORDER,
     };
@@ -586,7 +586,7 @@ static void wiz_reroll_item(PlayerType *player_ptr, ItemEntity *o_ptr)
 
     o_ptr->copy_from(q_ptr);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::COMBINATION,
         StatusRedrawingFlag::REORDER,
@@ -744,7 +744,7 @@ void wiz_modify_item(PlayerType *player_ptr)
 
         o_ptr->copy_from(q_ptr);
         auto &rfu = RedrawingFlagsUpdater::get_instance();
-        const auto flags_srf = {
+        static constexpr auto flags_srf = {
             StatusRedrawingFlag::BONUS,
             StatusRedrawingFlag::COMBINATION,
             StatusRedrawingFlag::REORDER,

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -519,7 +519,7 @@ void wiz_create_feature(PlayerType *player_ptr)
 
     note_spot(player_ptr, y, x);
     lite_spot(player_ptr, y, x);
-    RedrawingFlagsUpdater::get_instance().set_flag(StatusRedrawingFlag::FLOW);
+    RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::FLOW);
 }
 
 /*!
@@ -677,10 +677,10 @@ static void change_birth_flags()
 {
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {
-        StatusRedrawingFlag::BONUS,
-        StatusRedrawingFlag::HP,
-        StatusRedrawingFlag::MP,
-        StatusRedrawingFlag::SPELLS,
+        StatusRecalculatingFlag::BONUS,
+        StatusRecalculatingFlag::HP,
+        StatusRecalculatingFlag::MP,
+        StatusRecalculatingFlag::SPELLS,
     };
     rfu.set_flag(SubWindowRedrawingFlag::PLAYER);
     rfu.set_flags(flags_srf);

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -676,7 +676,7 @@ void wiz_learn_items_all(PlayerType *player_ptr)
 static void change_birth_flags()
 {
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    const auto flags_srf = {
+    static constexpr auto flags_srf = {
         StatusRedrawingFlag::BONUS,
         StatusRedrawingFlag::HP,
         StatusRedrawingFlag::MP,

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -684,7 +684,7 @@ static void change_birth_flags()
     };
     rfu.set_flag(SubWindowRedrawingFlag::PLAYER);
     rfu.set_flags(flags_srf);
-    const auto flags_mwrf = {
+    static constexpr auto flags_mwrf = {
         MainWindowRedrawingFlag::BASIC,
         MainWindowRedrawingFlag::HP,
         MainWindowRedrawingFlag::MP,


### PR DESCRIPTION
掲題の通りです
ついでにStatusRedrawingFlag → StatusRecalculatingFlag へ改名しました
全てVS2022 のCtrl+H による単純置換です
ご確認下さい