### PR TITLE
シンボルエディタのシンボルが非表示になることがある不具合を修正した

### DIFF
--- a/src/io-dump/dump-util.cpp
+++ b/src/io-dump/dump-util.cpp
@@ -64,8 +64,8 @@ bool visual_mode_command(char ch, bool *visual_list_ptr,
         }
 
         *visual_list_ptr = true;
-        *attr_top_ptr = std::max<byte>(0, (*cur_attr_ptr & 0x7f) - 5);
-        *char_left_ptr = std::max<byte>(0, *cur_char_ptr - 10);
+        *attr_top_ptr = std::max<int8_t>(0, (*cur_attr_ptr & 0x7f) - 5);
+        *char_left_ptr = std::max<int8_t>(0, *cur_char_ptr - 10);
         attr_old = *cur_attr_ptr;
         char_old = *cur_char_ptr;
         return true;
@@ -85,7 +85,7 @@ bool visual_mode_command(char ch, bool *visual_list_ptr,
     case 'p': {
         if (attr_idx || (!(char_idx & 0x80) && char_idx)) {
             *cur_attr_ptr = attr_idx;
-            *attr_top_ptr = std::max<byte>(0, (*cur_attr_ptr & 0x7f) - 5);
+            *attr_top_ptr = std::max<int8_t>(0, (*cur_attr_ptr & 0x7f) - 5);
             if (!*visual_list_ptr) {
                 *need_redraw = true;
             }
@@ -94,7 +94,7 @@ bool visual_mode_command(char ch, bool *visual_list_ptr,
         if (char_idx) {
             /* Set the char */
             *cur_char_ptr = char_idx;
-            *char_left_ptr = std::max<byte>(0, *cur_char_ptr - 10);
+            *char_left_ptr = std::max<int8_t>(0, *cur_char_ptr - 10);
             if (!*visual_list_ptr) {
                 *need_redraw = true;
             }


### PR DESCRIPTION
掲題の通りです
byte にキャストしたことで、負方向にオーバーフローした時「255と0は255の方が大きい」のように判断されて異常な結果になったようです
モンスター・アイテム・地形 全て修正されたようです
ご確認下さい