### PR TITLE
汎用的な時止めメッセージを実装した

### DIFF
--- a/src/monster/monster-status-setter.cpp
+++ b/src/monster/monster-status-setter.cpp
@@ -27,6 +27,7 @@
 #include "target/projection-path-calculator.h"
 #include "view/display-messages.h"
 #include "world/world.h"
+#include <string>
 
 /*!
  * @brief モンスターをペットにする
@@ -379,6 +380,7 @@ bool set_monster_invulner(PlayerType *player_ptr, MONSTER_IDX m_idx, int v, bool
  * @param who 時間停止を行う敵の種族番号
  * @param vs_player TRUEならば時間停止開始処理を行う
  * @return 時間停止が行われている状態ならばTRUEを返す
+ * @details monster_desc() は視認外のモンスターについて「何か」と返してくるので、この関数ではLOSや透明視等を判定する必要はない
  */
 bool set_monster_timewalk(PlayerType *player_ptr, int num, MonsterRaceId who, bool vs_player)
 {
@@ -389,24 +391,23 @@ bool set_monster_timewalk(PlayerType *player_ptr, int num, MonsterRaceId who, bo
 
     if (vs_player) {
         const auto m_name = monster_desc(player_ptr, m_ptr, 0);
-
-        concptr mes;
+        std::string mes;
         switch (who) {
         case MonsterRaceId::DIO:
-            mes = _("「『ザ・ワールド』！　時は止まった！」", "%s yells 'The World! Time has stopped!'");
+            mes = _("「『ザ・ワールド』！　時は止まった！」", format("%s yells 'The World! Time has stopped!'", m_name.data()));
             break;
         case MonsterRaceId::WONG:
-            mes = _("「時よ！」", "%s yells 'Time!'");
+            mes = _("「時よ！」", format("%s yells 'Time!'", m_name.data()));
             break;
         case MonsterRaceId::DIAVOLO:
-            mes = _("『キング・クリムゾン』！", "%s yells 'King Crison!'");
+            mes = _("『キング・クリムゾン』！", format("%s yells 'King Crison!'", m_name.data()));
             break;
         default:
-            mes = "hek!";
+            mes = format(_("%sは時を止めた！", "%s stops the time!"), m_name.data());
             break;
         }
 
-        msg_format(mes, m_name.data());
+        msg_print(mes);
         msg_print(nullptr);
     }
 
@@ -438,7 +439,7 @@ bool set_monster_timewalk(PlayerType *player_ptr, int num, MonsterRaceId who, bo
     rfu.set_flags(flags);
     w_ptr->timewalk_m_idx = 0;
     if (vs_player || (player_has_los_bold(player_ptr, m_ptr->fy, m_ptr->fx) && projectable(player_ptr, player_ptr->y, player_ptr->x, m_ptr->fy, m_ptr->fx))) {
-        concptr mes;
+        std::string mes;
         switch (who) {
         case MonsterRaceId::DIAVOLO:
             mes = _("これが我が『キング・クリムゾン』の能力！　『時間を消し去って』飛び越えさせた…！！",


### PR DESCRIPTION
今まで「hek!」だったのを汎用的なセリフに置き換えました
玲音 (透明視あり・なし)に浴びせられた時の動作を確認済です
ご確認下さい

備考：
上記は何らかの理由で異常な処理が走り、結果時止めに至った旨のメッセージだったらしい