### PR TITLE
[Fix] 名前の長いアイテムを博物館に寄贈しようとするとクラッシュする

### DIFF
--- a/src/term/z-term.cpp
+++ b/src/term/z-term.cpp
@@ -586,9 +586,7 @@ static void term_queue_chars(TERM_LEN x, TERM_LEN y, int n, TERM_COLOR a, std::s
      * (条件追加：タイルの1文字目でない事を確かめるように。)
      */
     {
-        int w, h;
-        term_get_size(&w, &h);
-        if (x != w && !(scr_aa[x] & AF_TILE1) && (scr_aa[x] & AF_KANJI2)) {
+        if ((x < game_term->wid) && !(scr_aa[x] & AF_TILE1) && (scr_aa[x] & AF_KANJI2)) {
             scr_cc[x] = ' ';
             scr_aa[x] &= AF_KANJIC;
             if (x1 < 0) {


### PR DESCRIPTION
Fix #3036 

名前の長いアイテムを博物館に寄贈しようとすると、ゲーム画面の右端まで確認メッセージが到達するが、この時ゲーム画面の実際の横幅ではなく中央寄せした時の幅で境界をチェックしているので配列外アクセスが発生している。
正しくゲーム画面の幅を得るように修正する。

#3036 の直接の原因はこれです。

ところで、これはこれとしてget_checkで長い質問文になると、行におさまりきらず[y/n]の問い合わせをされていることがわからないという別の問題があります。

↓本当に無敵の（略）『強靭なるゾート』の人形を寄贈しますか？[y/n] が見切れている。サブウィンドウにメッセージを表示していないと[y/n]の入力待ちであることがわからない。

![image](https://github.com/hengband/hengband/assets/1501750/b56ff3e1-a2b6-4640-8529-622857c48114)
