### PR TITLE
[Feature] 例外メッセージに追加情報を付与する

### DIFF
--- a/src/autopick/autopick-reader-writer.cpp
+++ b/src/autopick/autopick-reader-writer.cpp
@@ -4,11 +4,11 @@
 #include "autopick/autopick-util.h"
 #include "io/files-util.h"
 #include "io/read-pref-file.h"
+#include "system/angband-exceptions.h"
 #include "system/player-type-definition.h"
 #include "util/angband-files.h"
 #include "util/string-processor.h"
 #include "view/display-messages.h"
-#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -53,8 +53,10 @@ std::string pickpref_filename(PlayerType *player_ptr, int filename_mode)
     case PT_WITH_PNAME:
         return format("%s-%s.prf", namebase, player_ptr->base_name);
 
-    default:
-        throw std::invalid_argument(format("The value of argument 'filename_mode' is invalid: %d", filename_mode));
+    default: {
+        const auto msg = format("The value of argument 'filename_mode' is invalid: %d", filename_mode);
+        THROW_EXCEPTION(std::invalid_argument, msg);
+    }
     }
 }
 

--- a/src/core/show-file.cpp
+++ b/src/core/show-file.cpp
@@ -3,6 +3,7 @@
 #include "io/files-util.h"
 #include "io/input-key-acceptor.h"
 #include "main/sound-of-music.h"
+#include "system/angband-exceptions.h"
 #include "system/angband-version.h"
 #include "system/player-type-definition.h"
 #include "term/gameterm.h"
@@ -181,7 +182,7 @@ bool show_file(PlayerType *player_ptr, bool show_version, std::string_view name_
 
     const auto open_error_mes = format(_("'%s'をオープンできません。", "Cannot open '%s'."), name.data());
     if (!fff) {
-        throw std::runtime_error(open_error_mes);
+        THROW_EXCEPTION(std::runtime_error, open_error_mes);
     }
 
     const auto caption_str = caption.str();
@@ -247,7 +248,7 @@ bool show_file(PlayerType *player_ptr, bool show_version, std::string_view name_
             angband_fclose(fff);
             fff = angband_fopen(path_reopen, FileOpenMode::READ);
             if (!fff) {
-                throw std::runtime_error(open_error_mes);
+                THROW_EXCEPTION(std::runtime_error, open_error_mes);
             }
 
             next = 0;

--- a/src/info-reader/fixed-map-parser.cpp
+++ b/src/info-reader/fixed-map-parser.cpp
@@ -17,6 +17,7 @@
 #include "player-info/class-info.h"
 #include "player-info/race-info.h"
 #include "realm/realm-names-table.h"
+#include "system/angband-exceptions.h"
 #include "system/floor-type-definition.h"
 #include "system/player-type-definition.h"
 #include "util/angband-files.h"
@@ -25,7 +26,6 @@
 #include "world/world.h"
 #include <algorithm>
 #include <sstream>
-#include <stdexcept>
 
 static concptr variant = "ZANGBAND";
 
@@ -338,7 +338,7 @@ static void parse_quest_info_aux(std::string_view file_name, std::set<QuestId> &
         if (key_list_ref.find(q) != key_list_ref.end()) {
             std::stringstream ss;
             ss << _("重複したQuestID ", "Duplicated Quest Id ") << enum2i(q) << '(' << file_name << ", L" << line << ')';
-            throw std::runtime_error(ss.str());
+            THROW_EXCEPTION(std::runtime_error, ss.str());
         }
 
         key_list_ref.insert(q);
@@ -349,7 +349,7 @@ static void parse_quest_info_aux(std::string_view file_name, std::set<QuestId> &
     if (fp == nullptr) {
         std::stringstream ss;
         ss << _("ファイルが見つかりません (", "File is not found (") << file_name << ')';
-        throw std::runtime_error(ss.str());
+        THROW_EXCEPTION(std::runtime_error, ss.str());
     }
 
     char buf[4096];

--- a/src/player-base/player-race.cpp
+++ b/src/player-base/player-race.cpp
@@ -9,6 +9,7 @@
 #include "player-base/player-class.h"
 #include "player-info/mimic-info-table.h"
 #include "player/race-info-table.h"
+#include "system/angband-exceptions.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
 #include "system/player-type-definition.h"
@@ -79,7 +80,7 @@ const player_race_info *PlayerRace::get_info() const
     case MimicKindType::VAMPIRE:
         return &mimic_info.at(this->player_ptr->mimic_form);
     default:
-        throw("Invalid MimicKindType was specified!");
+        THROW_EXCEPTION(std::logic_error, "Invalid MimicKindType was specified!");
     }
 }
 
@@ -167,7 +168,7 @@ int16_t PlayerRace::speed() const
     case MimicKindType::VAMPIRE:
         return result + 3;
     default:
-        throw("Invalid MimicKindType was specified!");
+        THROW_EXCEPTION(std::logic_error, "Invalid MimicKindType was specified!");
     }
 }
 

--- a/src/player-info/alignment.cpp
+++ b/src/player-info/alignment.cpp
@@ -9,6 +9,7 @@
 #include "monster/monster-status.h"
 #include "player-info/equipment-info.h"
 #include "player-info/race-info.h"
+#include "system/angband-exceptions.h"
 #include "system/floor-type-definition.h"
 #include "system/item-entity.h"
 #include "system/monster-entity.h"
@@ -87,7 +88,7 @@ void PlayerAlignment::update_alignment()
     case MimicKindType::VAMPIRE:
         break;
     default:
-        throw("Invalid MimicKindType was specified!");
+        THROW_EXCEPTION(std::logic_error, "Invalid MimicKindType was specified!");
     }
 
     for (int i = 0; i < 2; i++) {

--- a/src/spell-kind/magic-item-recharger.cpp
+++ b/src/spell-kind/magic-item-recharger.cpp
@@ -21,6 +21,7 @@
 #include "object/item-tester-hooker.h"
 #include "object/item-use-flags.h"
 #include "player-base/player-class.h"
+#include "system/angband-exceptions.h"
 #include "system/baseitem-info.h"
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
@@ -223,7 +224,7 @@ bool recharge(PlayerType *player_ptr, int power)
         vary_item(player_ptr, item, -999);
         break;
     default:
-        throw std::logic_error("Invalid fail type!");
+        THROW_EXCEPTION(std::logic_error, "Invalid fail type!");
     }
 
     return update_player();

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -17,6 +17,7 @@
 #include "spell/spells-execution.h"
 #include "spell/technic-info-table.h"
 #include "status/action-setter.h"
+#include "system/angband-exceptions.h"
 #include "system/floor-type-definition.h"
 #include "system/monster-entity.h"
 #include "system/monster-race-info.h"
@@ -49,7 +50,7 @@ SpellHex::SpellHex(PlayerType *player_ptr)
     HexSpellFlagGroup::get_flags(this->spell_hex_data->casting_spells, std::back_inserter(this->casting_spells));
 
     if (this->casting_spells.size() > MAX_KEEP) {
-        throw("Invalid numbers of hex magics keep!");
+        THROW_EXCEPTION(std::logic_error, "Invalid numbers of hex magics keep!");
     }
 }
 
@@ -382,7 +383,7 @@ void SpellHex::interrupt_spelling()
 void SpellHex::eyes_on_eyes()
 {
     if (this->monap_ptr == nullptr) {
-        throw("Invalid constructor was used!");
+        THROW_EXCEPTION(std::logic_error, "Invalid constructor was used!");
     }
 
     const auto is_eyeeye_finished = (this->player_ptr->tim_eyeeye == 0) && !this->is_spelling_specific(HEX_EYE_FOR_EYE);
@@ -407,7 +408,7 @@ void SpellHex::eyes_on_eyes()
 void SpellHex::thief_teleport()
 {
     if (this->monap_ptr == nullptr) {
-        throw("Invalid constructor was used!");
+        THROW_EXCEPTION(std::logic_error, "Invalid constructor was used!");
     }
 
     if (!this->monap_ptr->blinked || !this->monap_ptr->alive || this->player_ptr->is_dead) {

--- a/src/status/bad-status-setter.cpp
+++ b/src/status/bad-status-setter.cpp
@@ -16,6 +16,7 @@
 #include "spell-realm/spells-hex.h"
 #include "status/base-status.h"
 #include "status/buff-setter.h"
+#include "system/angband-exceptions.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "timed-effect/player-blindness.h"
@@ -623,7 +624,7 @@ void BadStatusSetter::decrease_int_wis(const short v)
 
         return;
     default:
-        throw("Invalid random number is specified!");
+        THROW_EXCEPTION(std::logic_error, "Invalid random number is specified!");
     }
 }
 

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -7,6 +7,7 @@
 #include "monster-race/monster-race.h"
 #include "object-enchant/special-object-flags.h"
 #include "object/object-kind-hook.h"
+#include "system/angband-exceptions.h"
 #include "system/artifact-type-definition.h"
 #include "system/baseitem-info.h"
 #include "system/dungeon-info.h"
@@ -179,7 +180,7 @@ void display_rumor(PlayerType *player_ptr, bool ex)
             rumor_eff_format = _("%sに行ったことがある気がする。", "You feel you have been to %s.");
         }
     } else {
-        throw std::runtime_error("Unknown token exists in rumor.txt");
+        THROW_EXCEPTION(std::runtime_error, "Unknown token exists in rumor.txt");
     }
 
     const auto rumor_msg = bind_rumor_name(tokens[2], fullname);

--- a/src/system/angband-exceptions.h
+++ b/src/system/angband-exceptions.h
@@ -1,9 +1,37 @@
 ﻿#pragma once
 
+#include "system/angband-version.h"
+#include <concepts>
+#include <filesystem>
+#include <sstream>
 #include <stdexcept>
+#include <string_view>
 
 class SaveDataNotSupportedException : public std::runtime_error {
 public:
     SaveDataNotSupportedException() = delete;
     using std::runtime_error::runtime_error;
 };
+
+namespace angband::exception::detail {
+
+template <std::derived_from<std::exception> T>
+[[noreturn]] void throw_exception(std::string_view msg, std::filesystem::path path, int line)
+{
+    std::stringstream ss;
+    ss << get_version() << ": " << path.filename().string() << ':' << line << ": " << msg;
+    throw T(ss.str());
+}
+
+}
+
+/*!
+ * @brief EXCEPTION_T型の例外をスローする
+ *
+ * EXCEPTION_T型はstd::exceptionを継承している必要がある。
+ * 例外メッセージは "バージョン: ファイル名:行番号: MSG" となる
+ */
+#define THROW_EXCEPTION(EXCEPTION_T, MSG)                                                  \
+    do {                                                                                   \
+        angband::exception::detail::throw_exception<EXCEPTION_T>(MSG, __FILE__, __LINE__); \
+    } while (0)

--- a/src/system/angband-version.cpp
+++ b/src/system/angband-version.cpp
@@ -1,4 +1,5 @@
 ﻿#include "system/angband-version.h"
+#include "system/angband-exceptions.h"
 #include "system/angband.h"
 
 std::string get_version()
@@ -18,7 +19,7 @@ std::string get_version()
         expr = "";
         break;
     default:
-        throw("Invalid version status was specified!");
+        THROW_EXCEPTION(std::logic_error, "Invalid version status was specified!");
     }
 
     if (VERSION_STATUS != VersionStatusType::RELEASE) {

--- a/src/system/baseitem-info.cpp
+++ b/src/system/baseitem-info.cpp
@@ -16,8 +16,8 @@
 #include "sv-definition/sv-protector-types.h"
 #include "sv-definition/sv-rod-types.h"
 #include "sv-definition/sv-weapon-types.h"
+#include "system/angband-exceptions.h"
 #include <set>
-#include <stdexcept>
 #include <unordered_map>
 
 namespace {
@@ -68,7 +68,7 @@ std::optional<int> BaseitemKey::sval() const
 ItemKindType BaseitemKey::get_arrow_kind() const
 {
     if ((this->type_value != ItemKindType::BOW) || !this->subtype_value.has_value()) {
-        throw std::logic_error(ITEM_NOT_BOW);
+        THROW_EXCEPTION(std::logic_error, ITEM_NOT_BOW);
     }
 
     switch (this->subtype_value.value()) {
@@ -416,7 +416,7 @@ bool BaseitemKey::is_rare() const
 short BaseitemKey::get_bow_energy() const
 {
     if ((this->type_value != ItemKindType::BOW) || !this->subtype_value.has_value()) {
-        throw std::logic_error(ITEM_NOT_BOW);
+        THROW_EXCEPTION(std::logic_error, ITEM_NOT_BOW);
     }
 
     switch (this->subtype_value.value()) {
@@ -436,7 +436,7 @@ short BaseitemKey::get_bow_energy() const
 int BaseitemKey::get_arrow_magnification() const
 {
     if ((this->type_value != ItemKindType::BOW) || !this->subtype_value.has_value()) {
-        throw std::logic_error(ITEM_NOT_BOW);
+        THROW_EXCEPTION(std::logic_error, ITEM_NOT_BOW);
     }
 
     switch (this->subtype_value.value()) {
@@ -457,7 +457,7 @@ int BaseitemKey::get_arrow_magnification() const
 bool BaseitemKey::is_aiming_rod() const
 {
     if ((this->type_value != ItemKindType::ROD) || !this->subtype_value.has_value()) {
-        throw std::logic_error(ITEM_NOT_ROD);
+        THROW_EXCEPTION(std::logic_error, ITEM_NOT_ROD);
     }
 
     switch (this->subtype_value.value()) {
@@ -486,7 +486,7 @@ bool BaseitemKey::is_aiming_rod() const
 bool BaseitemKey::is_lite_requiring_fuel() const
 {
     if ((this->type_value != ItemKindType::LITE) || !this->subtype_value.has_value()) {
-        throw std::logic_error(ITEM_NOT_LITE);
+        THROW_EXCEPTION(std::logic_error, ITEM_NOT_LITE);
     }
 
     switch (this->subtype_value.value()) {

--- a/src/timed-effect/player-acceleration.cpp
+++ b/src/timed-effect/player-acceleration.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "timed-effect/player-acceleration.h"
-#include <stdexcept>
+#include "system/angband-exceptions.h"
 
 short PlayerAcceleration::current() const
 {
@@ -20,7 +20,7 @@ bool PlayerAcceleration::is_fast() const
 void PlayerAcceleration::set(short value)
 {
     if (value < 0) {
-        throw std::invalid_argument("Negative value can't be set in the player's acceleration parameter!");
+        THROW_EXCEPTION(std::invalid_argument, "Negative value can't be set in the player's acceleration parameter!");
     }
 
     this->acceleration = value;

--- a/src/timed-effect/player-blindness.cpp
+++ b/src/timed-effect/player-blindness.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "timed-effect/player-blindness.h"
-#include <stdexcept>
+#include "system/angband-exceptions.h"
 
 short PlayerBlindness::current() const
 {
@@ -20,7 +20,7 @@ bool PlayerBlindness::is_blind() const
 void PlayerBlindness::set(short value)
 {
     if (value < 0) {
-        throw std::invalid_argument("Negative value can't be set in the player's blindness parameter!");
+        THROW_EXCEPTION(std::invalid_argument, "Negative value can't be set in the player's blindness parameter!");
     }
 
     this->blindness = value;

--- a/src/timed-effect/player-cut.cpp
+++ b/src/timed-effect/player-cut.cpp
@@ -1,4 +1,5 @@
 ﻿#include "timed-effect/player-cut.h"
+#include "system/angband-exceptions.h"
 #include "system/angband.h"
 
 PlayerCutRank PlayerCut::get_rank(short value)
@@ -54,7 +55,7 @@ std::string_view PlayerCut::get_cut_mes(PlayerCutRank stun_rank)
     case PlayerCutRank::MORTAL:
         return _("致命的な傷を負ってしまった。", "You have been given a mortal wound.");
     default:
-        throw("Invalid StunRank was specified!");
+        THROW_EXCEPTION(std::logic_error, "Invalid CutRank is specified!");
     }
 }
 
@@ -122,7 +123,7 @@ std::tuple<term_color_type, std::string_view> PlayerCut::get_expr() const
     case PlayerCutRank::MORTAL:
         return std::make_tuple(TERM_L_RED, _("致命傷      ", "Mortal wound"));
     default:
-        throw("Invalid StunRank was specified!");
+        THROW_EXCEPTION(std::logic_error, "Invalid CutRank is specified!");
     }
 }
 
@@ -146,7 +147,7 @@ int PlayerCut::get_damage() const
     case PlayerCutRank::MORTAL:
         return 200;
     default:
-        throw("Invalid StunRank was specified!");
+        THROW_EXCEPTION(std::logic_error, "Invalid CutRank is specified!");
     }
 }
 

--- a/src/timed-effect/player-deceleration.cpp
+++ b/src/timed-effect/player-deceleration.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "timed-effect/player-deceleration.h"
-#include <stdexcept>
+#include "system/angband-exceptions.h"
 
 short PlayerDeceleration::current() const
 {
@@ -20,7 +20,7 @@ bool PlayerDeceleration::is_slow() const
 void PlayerDeceleration::set(short value)
 {
     if (value < 0) {
-        throw std::invalid_argument("Negative value can't be set in the player's deceleration parameter!");
+        THROW_EXCEPTION(std::invalid_argument, "Negative value can't be set in the player's deceleration parameter!");
     }
 
     this->deceleration = value;

--- a/src/timed-effect/player-poison.cpp
+++ b/src/timed-effect/player-poison.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "timed-effect/player-poison.h"
-#include <stdexcept>
+#include "system/angband-exceptions.h"
 
 short PlayerPoison::current() const
 {
@@ -20,7 +20,7 @@ bool PlayerPoison::is_poisoned() const
 void PlayerPoison::set(short value)
 {
     if (value < 0) {
-        throw std::invalid_argument("Negative value can't be set in the player's poison parameter!");
+        THROW_EXCEPTION(std::invalid_argument, "Negative value can't be set in the player's poison parameter!");
     }
 
     this->poison = value;

--- a/src/timed-effect/player-stun.cpp
+++ b/src/timed-effect/player-stun.cpp
@@ -1,4 +1,5 @@
 ﻿#include "timed-effect/player-stun.h"
+#include "system/angband-exceptions.h"
 #include "system/angband.h"
 
 enum class PlayerStunRank {
@@ -51,7 +52,7 @@ std::string_view PlayerStun::get_stun_mes(PlayerStunRank stun_rank)
     case PlayerStunRank::KNOCKED:
         return _("あなたはぶっ倒れた！", "You are knocked out!!");
     default:
-        throw("Invalid StunRank was specified!");
+        THROW_EXCEPTION(std::logic_error, "Invalid StunRank is specified!");
     }
 }
 
@@ -161,7 +162,7 @@ int PlayerStun::get_magic_chance_penalty() const
     case PlayerStunRank::KNOCKED:
         return 100;
     default:
-        throw("Invalid stun rank is specified!");
+        THROW_EXCEPTION(std::logic_error, "Invalid StunRank is specified!");
     }
 }
 
@@ -186,7 +187,7 @@ int PlayerStun::get_item_chance_penalty() const
     case PlayerStunRank::KNOCKED:
         return 100;
     default:
-        throw("Invalid stun rank is specified!");
+        THROW_EXCEPTION(std::logic_error, "Invalid StunRank is specified!");
     }
 }
 
@@ -214,7 +215,7 @@ short PlayerStun::get_damage_penalty() const
     case PlayerStunRank::KNOCKED:
         return 100;
     default:
-        throw("Invalid stun rank is specified!");
+        THROW_EXCEPTION(std::logic_error, "Invalid StunRank is specified!");
     }
 }
 
@@ -252,7 +253,7 @@ std::tuple<term_color_type, std::string_view> PlayerStun::get_expr() const
     case PlayerStunRank::KNOCKED:
         return std::make_tuple(TERM_VIOLET, _("昏倒        ", "Knocked out "));
     default:
-        throw("Invalid stun rank is specified!");
+        THROW_EXCEPTION(std::logic_error, "Invalid StunRank is specified!");
     }
 }
 

--- a/src/util/angband-files.cpp
+++ b/src/util/angband-files.cpp
@@ -1,5 +1,6 @@
 ﻿#include "util/angband-files.h"
 #include "locale/japanese.h"
+#include "system/angband-exceptions.h"
 #include "util/string-processor.h"
 #include <sstream>
 #include <string>
@@ -89,7 +90,7 @@ std::filesystem::path path_parse(const std::filesystem::path &path)
     constexpr auto user_size = 128;
     char user[user_size]{};
     if ((s != nullptr) && (s >= u + user_size)) {
-        throw std::runtime_error("User name is too long!");
+        THROW_EXCEPTION(std::runtime_error, "User name is too long!");
     }
 
     if (s != nullptr) {
@@ -113,7 +114,7 @@ std::filesystem::path path_parse(const std::filesystem::path &path)
     }
 
     if (pw == nullptr) {
-        throw std::runtime_error("Failed to get User ID!");
+        THROW_EXCEPTION(std::runtime_error, "Failed to get User ID!");
     }
 
     if (s == nullptr) {
@@ -169,7 +170,7 @@ std::filesystem::path path_build(const std::filesystem::path &path, std::string_
     constexpr auto max_path_length = 1024;
     const auto path_str = path_ret.string();
     if (path_str.length() > max_path_length) {
-        throw std::runtime_error(format("Path is too long! %s", path_str.data()));
+        THROW_EXCEPTION(std::runtime_error, format("Path is too long! %s", path_str.data()));
     }
 
     return path_ret;
@@ -189,7 +190,7 @@ static std::string make_file_mode(const FileOpenMode mode, const bool is_binary)
         ss << 'a';
         break;
     default:
-        throw std::logic_error("Invalid file mode is specified!");
+        THROW_EXCEPTION(std::logic_error, "Invalid file mode is specified!");
     }
 
     if (is_binary) {

--- a/src/util/probability-table.h
+++ b/src/util/probability-table.h
@@ -1,7 +1,7 @@
 ﻿#pragma once
 
+#include "system/angband-exceptions.h"
 #include "term/z-rand.h"
-
 #include <algorithm>
 #include <exception>
 #include <stdexcept>
@@ -109,7 +109,7 @@ public:
     IdType pick_one_at_random() const
     {
         if (empty()) {
-            throw std::runtime_error("There is no entry in the probability table.");
+            THROW_EXCEPTION(std::runtime_error, "There is no entry in the probability table.");
         }
 
         // probの合計の範囲からランダムでkeyを取得し、二分探索で選択する項目を決定する

--- a/src/wizard/wizard-messages.cpp
+++ b/src/wizard/wizard-messages.cpp
@@ -2,6 +2,7 @@
 #include "game-option/cheat-options.h"
 #include "game-option/cheat-types.h"
 #include "io/write-diary.h"
+#include "system/angband-exceptions.h"
 #include "view/display-messages.h"
 #include <array>
 #include <sstream>
@@ -11,7 +12,7 @@ void msg_print_wizard(PlayerType *player_ptr, int cheat_type, std::string_view m
 {
     constexpr auto max_type = 4;
     if ((cheat_type < 0) || (cheat_type >= max_type)) {
-        throw std::logic_error("Invalid cheat type is specified!");
+        THROW_EXCEPTION(std::logic_error, "Invalid cheat type is specified!");
     }
 
     if (!cheat_room && cheat_type == CHEAT_DUNGEON) {


### PR DESCRIPTION
#3386 の作業

引数に与えたメッセージに、アプリのバージョン・例外発生ソースファイルと行番号を付与して例外をスローするマクロ THROW_EXCEPTION を実装し、現状の throw で例外を投げている処理を置き換えました。（捕捉処理をしている SaveDataNotSupportedException は除く）