### PR TITLE
format() をangband::format() に変えた

### DIFF
--- a/src/action/movement-execution.cpp
+++ b/src/action/movement-execution.cpp
@@ -228,17 +228,17 @@ void exe_movement(PlayerType *player_ptr, DIRECTION dir, bool do_pickup, bool br
         } else if (f_ptr->flags.has(TerrainCharacteristics::CAN_SWIM) && (riding_r_ptr->feature_flags.has(MonsterFeatureType::CAN_SWIM))) {
             /* Allow moving */
         } else if (f_ptr->flags.has(TerrainCharacteristics::WATER) && riding_r_ptr->feature_flags.has_not(MonsterFeatureType::AQUATIC) && (f_ptr->flags.has(TerrainCharacteristics::DEEP) || riding_r_ptr->aura_flags.has(MonsterAuraType::FIRE))) {
-            msg_print(_(format("%sの上に行けない。", terrains_info[g_ptr->get_feat_mimic()].name.data()), "Can't swim."));
+            msg_print(_(angband::format("%sの上に行けない。", terrains_info[g_ptr->get_feat_mimic()].name.data()), "Can't swim."));
             energy.reset_player_turn();
             can_move = false;
             disturb(player_ptr, false, true);
         } else if (f_ptr->flags.has_not(TerrainCharacteristics::WATER) && riding_r_ptr->feature_flags.has(MonsterFeatureType::AQUATIC)) {
-            msg_print(_(format("%sから上がれない。", terrains_info[floor_ptr->grid_array[player_ptr->y][player_ptr->x].get_feat_mimic()].name.data()), "Can't land."));
+            msg_print(_(angband::format("%sから上がれない。", terrains_info[floor_ptr->grid_array[player_ptr->y][player_ptr->x].get_feat_mimic()].name.data()), "Can't land."));
             energy.reset_player_turn();
             can_move = false;
             disturb(player_ptr, false, true);
         } else if (f_ptr->flags.has(TerrainCharacteristics::LAVA) && riding_r_ptr->resistance_flags.has_none_of(RFR_EFF_IM_FIRE_MASK)) {
-            msg_print(_(format("%sの上に行けない。", terrains_info[g_ptr->get_feat_mimic()].name.data()), "Too hot to go through."));
+            msg_print(_(angband::format("%sの上に行けない。", terrains_info[g_ptr->get_feat_mimic()].name.data()), "Too hot to go through."));
             energy.reset_player_turn();
             can_move = false;
             disturb(player_ptr, false, true);

--- a/src/autopick/autopick-command-menu.cpp
+++ b/src/autopick/autopick-command-menu.cpp
@@ -51,7 +51,7 @@ static void redraw_edit_command_menu(bool *redraw, int level, int start, char *l
             com_key_str[0] = '\0';
         }
 
-        const auto str = format("| %c) %-*s %2s | ", *menu_key + 'a', max_len, menu_data[i].name, com_key_str);
+        const auto str = angband::format("| %c) %-*s %2s | ", *menu_key + 'a', max_len, menu_data[i].name, com_key_str);
 
         term_putstr(col0, row1++, -1, TERM_WHITE, str);
 
@@ -103,7 +103,7 @@ int do_command_menu(int level, int start)
     bool redraw = true;
     while (true) {
         redraw_edit_command_menu(&redraw, level, start, linestr, &menu_key, max_len);
-        prt(format(_("(a-%c) コマンド:", "(a-%c) Command:"), menu_key + 'a' - 1), 0, 0);
+        prt(angband::format(_("(a-%c) コマンド:", "(a-%c) Command:"), menu_key + 'a' - 1), 0, 0);
         char key = inkey();
         if (key == ESCAPE) {
             return 0;

--- a/src/autopick/autopick-describer.cpp
+++ b/src/autopick/autopick-describer.cpp
@@ -231,7 +231,7 @@ static void describe_autpick_jp(char *buff, const autopick_type &entry, autopick
     if (describer->insc) {
         char tmp[MAX_INSCRIPTION + 1] = "";
         angband_strcat(tmp, describer->insc, MAX_INSCRIPTION);
-        angband_strcat(buff, format("に「%s」", tmp), MAX_INSCRIPTION + 6);
+        angband_strcat(buff, angband::format("に「%s」", tmp), MAX_INSCRIPTION + 6);
 
         if (angband_strstr(describer->insc, "%%all")) {
             strcat(buff, "(%%allは全能力を表す英字の記号で置換)");
@@ -488,7 +488,7 @@ void describe_autopick_en(char *buff, const autopick_type &entry, autopick_descr
     }
 
     if (describer->insc) {
-        strncat(buff, format("and inscribe \"%s\"", describer->insc).data(), 80);
+        strncat(buff, angband::format("and inscribe \"%s\"", describer->insc).data(), 80);
 
         if (angband_strstr(describer->insc, "%all")) {
             strcat(buff, ", replacing %all with code string representing all abilities,");

--- a/src/autopick/autopick-drawer.cpp
+++ b/src/autopick/autopick-drawer.cpp
@@ -222,11 +222,11 @@ void draw_text_editor(PlayerType *player_ptr, text_body_type *tb)
     }
 
     if (tb->dirty_flags & DIRTY_NOT_FOUND) {
-        str1 = format(_("パターンが見つかりません: %s", "Pattern not found: %s"), tb->search_str);
+        str1 = angband::format(_("パターンが見つかりません: %s", "Pattern not found: %s"), tb->search_str);
     } else if (tb->dirty_flags & DIRTY_SKIP_INACTIVE) {
-        str1 = format(_("無効状態の行をスキップしました。(%sを検索中)", "Some inactive lines are skipped. (Searching %s)"), tb->search_str);
+        str1 = angband::format(_("無効状態の行をスキップしました。(%sを検索中)", "Some inactive lines are skipped. (Searching %s)"), tb->search_str);
     } else if (tb->dirty_flags & DIRTY_INACTIVE) {
-        str1 = format(_("無効状態の行だけが見付かりました。(%sを検索中)", "Found only an inactive line. (Searching %s)"), tb->search_str);
+        str1 = angband::format(_("無効状態の行だけが見付かりました。(%sを検索中)", "Found only an inactive line. (Searching %s)"), tb->search_str);
     } else if (tb->dirty_flags & DIRTY_NO_SEARCH) {
         str1 = _("検索するパターンがありません(^S で検索)。", "No pattern to search. (Press ^S to search.)");
     } else if (tb->lines_list[tb->cy][0] == '#') {

--- a/src/autopick/autopick-editor-command.cpp
+++ b/src/autopick/autopick-editor-command.cpp
@@ -603,7 +603,7 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
         draw_text_editor(player_ptr, tb);
         term_erase(0, tb->cy - tb->upper + 1, tb->wid);
         term_putstr(0, tb->cy - tb->upper + 1, tb->wid - 1, TERM_YELLOW,
-            format(_("C:%d:<コマンドキー>: ", "C:%d:<Keypress>: "), (rogue_like_commands ? KEYMAP_MODE_ROGUE : KEYMAP_MODE_ORIG)));
+            angband::format(_("C:%d:<コマンドキー>: ", "C:%d:<Keypress>: "), (rogue_like_commands ? KEYMAP_MODE_ROGUE : KEYMAP_MODE_ORIG)));
 
         if (!insert_keymap_line(tb)) {
             break;

--- a/src/autopick/autopick-finder.cpp
+++ b/src/autopick/autopick-finder.cpp
@@ -67,7 +67,7 @@ bool get_object_for_search(PlayerType *player_ptr, ItemEntity **o_handle, concpt
     *o_handle = o_ptr;
     string_free(*search_strp);
     const auto item_name = describe_flavor(player_ptr, *o_handle, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NO_PLURAL));
-    *search_strp = string_make(format("<%s>", item_name.data()).data());
+    *search_strp = string_make(angband::format("<%s>", item_name.data()).data());
     return true;
 }
 
@@ -83,7 +83,7 @@ bool get_destroyed_object_for_search(PlayerType *player_ptr, ItemEntity **o_hand
     *o_handle = &autopick_last_destroyed_object;
     string_free(*search_strp);
     const auto item_name = describe_flavor(player_ptr, *o_handle, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NO_PLURAL));
-    *search_strp = string_make(format("<%s>", item_name.data()).data());
+    *search_strp = string_make(angband::format("<%s>", item_name.data()).data());
     return true;
 }
 

--- a/src/autopick/autopick-inserter-killer.cpp
+++ b/src/autopick/autopick-inserter-killer.cpp
@@ -105,7 +105,7 @@ bool insert_macro_line(text_body_type *tb)
     tb->cx = 0;
     insert_return_code(tb);
     string_free(tb->lines_list[tb->cy]);
-    tb->lines_list[tb->cy] = string_make(format("P:%s", tmp).data());
+    tb->lines_list[tb->cy] = string_make(angband::format("P:%s", tmp).data());
 
     i = macro_find_exact(buf);
     if (i == -1) {
@@ -116,7 +116,7 @@ bool insert_macro_line(text_body_type *tb)
 
     insert_return_code(tb);
     string_free(tb->lines_list[tb->cy]);
-    tb->lines_list[tb->cy] = string_make(format("A:%s", tmp).data());
+    tb->lines_list[tb->cy] = string_make(angband::format("A:%s", tmp).data());
 
     return true;
 }
@@ -151,7 +151,7 @@ bool insert_keymap_line(text_body_type *tb)
     tb->cx = 0;
     insert_return_code(tb);
     string_free(tb->lines_list[tb->cy]);
-    tb->lines_list[tb->cy] = string_make(format("C:%d:%s", mode, tmp).data());
+    tb->lines_list[tb->cy] = string_make(angband::format("C:%d:%s", mode, tmp).data());
 
     concptr act = keymap_act[mode][(byte)(buf[0])];
     if (act) {
@@ -160,7 +160,7 @@ bool insert_keymap_line(text_body_type *tb)
 
     insert_return_code(tb);
     string_free(tb->lines_list[tb->cy]);
-    tb->lines_list[tb->cy] = string_make(format("A:%s", tmp).data());
+    tb->lines_list[tb->cy] = string_make(angband::format("A:%s", tmp).data());
 
     return true;
 }

--- a/src/autopick/autopick-reader-writer.cpp
+++ b/src/autopick/autopick-reader-writer.cpp
@@ -48,13 +48,13 @@ std::string pickpref_filename(PlayerType *player_ptr, int filename_mode)
 
     switch (filename_mode) {
     case PT_DEFAULT:
-        return format("%s.prf", namebase);
+        return angband::format("%s.prf", namebase);
 
     case PT_WITH_PNAME:
-        return format("%s-%s.prf", namebase, player_ptr->base_name);
+        return angband::format("%s-%s.prf", namebase, player_ptr->base_name);
 
     default: {
-        const auto msg = format("The value of argument 'filename_mode' is invalid: %d", filename_mode);
+        const auto msg = angband::format("The value of argument 'filename_mode' is invalid: %d", filename_mode);
         THROW_EXCEPTION(std::invalid_argument, msg);
     }
     }

--- a/src/avatar/avatar.cpp
+++ b/src/avatar/avatar.cpp
@@ -496,7 +496,7 @@ void dump_virtues(PlayerType *player_ptr, FILE *out_file)
         GAME_TEXT vir_name[20];
         int tester = player_ptr->virtues[v_nr];
         strcpy(vir_name, virtue_names.at(player_ptr->vir_types[v_nr]).data());
-        const std::string vir_val_str = format(" (%d)", tester);
+        const std::string vir_val_str = angband::format(" (%d)", tester);
         const auto vir_val = show_actual_value ? vir_val_str.data() : "";
         if ((player_ptr->vir_types[v_nr] == Virtue::NONE) || (player_ptr->vir_types[v_nr] >= Virtue::MAX)) {
             fprintf(out_file, _("おっと。%sの情報なし。", "Oops. No info about %s."), vir_name);

--- a/src/birth/birth-select-realm.cpp
+++ b/src/birth/birth-select-realm.cpp
@@ -400,7 +400,7 @@ bool get_player_realms(PlayerType *player_ptr)
 
     if (player_ptr->realm2) {
         /* Print the realm */
-        c_put_str(TERM_L_BLUE, format("%s, %s", realm_names[player_ptr->realm1], realm_names[player_ptr->realm2]), 6, 15);
+        c_put_str(TERM_L_BLUE, angband::format("%s, %s", realm_names[player_ptr->realm1], realm_names[player_ptr->realm2]), 6, 15);
     }
 
     return true;

--- a/src/birth/birth-wizard.cpp
+++ b/src/birth/birth-wizard.cpp
@@ -403,9 +403,9 @@ static bool display_auto_roller_count(PlayerType *player_ptr, const int col)
 
     birth_put_stats(player_ptr);
     if (auto_upper_round) {
-        put_str(format("%d%09d", auto_upper_round, auto_round), 10, col + 20);
+        put_str(angband::format("%d%09d", auto_upper_round, auto_round), 10, col + 20);
     } else {
-        put_str(format("%10d", auto_round), 10, col + 20);
+        put_str(angband::format("%10d", auto_round), 10, col + 20);
     }
     term_fresh();
     inkey_scan = true;

--- a/src/birth/character-builder.cpp
+++ b/src/birth/character-builder.cpp
@@ -60,28 +60,28 @@ static void write_birth_diary(PlayerType *player_ptr)
 
     exe_write_diary(player_ptr, DiaryKind::GAMESTART, 1, _("-------- 新規ゲーム開始 --------", "------- Started New Game -------"));
     exe_write_diary(player_ptr, DiaryKind::DIALY, 0);
-    const auto mes_sex = format(_("%s性別に%sを選択した。", "%schose %s gender."), indent, sex_info[player_ptr->psex].title);
+    const auto mes_sex = angband::format(_("%s性別に%sを選択した。", "%schose %s gender."), indent, sex_info[player_ptr->psex].title);
     exe_write_diary(player_ptr, DiaryKind::DESCRIPTION, 1, mes_sex);
-    const auto mes_race = format(_("%s種族に%sを選択した。", "%schose %s race."), indent, race_info[enum2i(player_ptr->prace)].title);
+    const auto mes_race = angband::format(_("%s種族に%sを選択した。", "%schose %s race."), indent, race_info[enum2i(player_ptr->prace)].title);
     exe_write_diary(player_ptr, DiaryKind::DESCRIPTION, 1, mes_race);
-    const auto mes_class = format(_("%s職業に%sを選択した。", "%schose %s class."), indent, class_info[enum2i(player_ptr->pclass)].title);
+    const auto mes_class = angband::format(_("%s職業に%sを選択した。", "%schose %s class."), indent, class_info[enum2i(player_ptr->pclass)].title);
     exe_write_diary(player_ptr, DiaryKind::DESCRIPTION, 1, mes_class);
     if (player_ptr->realm1) {
-        const std::string mes_realm2 = player_ptr->realm2 ? format(_("と%s", " and %s realms"), realm_names[player_ptr->realm2]) : _("", " realm");
-        const auto mes_realm = format(_("%s魔法の領域に%s%sを選択した。", "%schose %s%s."), indent, realm_names[player_ptr->realm1], mes_realm2.data());
+        const std::string mes_realm2 = player_ptr->realm2 ? angband::format(_("と%s", " and %s realms"), realm_names[player_ptr->realm2]) : _("", " realm");
+        const auto mes_realm = angband::format(_("%s魔法の領域に%s%sを選択した。", "%schose %s%s."), indent, realm_names[player_ptr->realm1], mes_realm2.data());
         exe_write_diary(player_ptr, DiaryKind::DESCRIPTION, 1, mes_realm);
     }
 
     if (player_ptr->element) {
-        const auto mes_element = format(_("%s元素系統に%sを選択した。", "%schose %s system."), indent, get_element_title(player_ptr->element));
+        const auto mes_element = angband::format(_("%s元素系統に%sを選択した。", "%schose %s system."), indent, get_element_title(player_ptr->element));
         exe_write_diary(player_ptr, DiaryKind::DESCRIPTION, 1, mes_element);
     }
 
-    const auto mes_personality = format(_("%s性格に%sを選択した。", "%schose %s personality."), indent, personality_info[player_ptr->ppersonality].title);
+    const auto mes_personality = angband::format(_("%s性格に%sを選択した。", "%schose %s personality."), indent, personality_info[player_ptr->ppersonality].title);
     exe_write_diary(player_ptr, DiaryKind::DESCRIPTION, 1, mes_personality);
     if (PlayerClass(player_ptr).equals(PlayerClassType::CHAOS_WARRIOR)) {
         const auto fmt_patron = _("%s守護神%sと契約を交わした。", "%smade a contract with patron %s.");
-        const auto mes_patron = format(fmt_patron, indent, patron_list[player_ptr->chaos_patron].name.data());
+        const auto mes_patron = angband::format(fmt_patron, indent, patron_list[player_ptr->chaos_patron].name.data());
         exe_write_diary(player_ptr, DiaryKind::DESCRIPTION, 1, mes_patron);
     }
 }

--- a/src/birth/history-editor.cpp
+++ b/src/birth/history-editor.cpp
@@ -47,10 +47,10 @@ void edit_history(PlayerType *player_ptr)
 #ifdef JP
         if (iskanji2(player_ptr->history[y], x)) {
             char kanji[3] = { player_ptr->history[y][x], player_ptr->history[y][x + 1], '\0' };
-            c_put_str(TERM_L_BLUE, format("%s", kanji), y + 12, x + 10);
+            c_put_str(TERM_L_BLUE, angband::format("%s", kanji), y + 12, x + 10);
         } else
 #endif
-            c_put_str(TERM_L_BLUE, format("%c", player_ptr->history[y][x]), y + 12, x + 10);
+            c_put_str(TERM_L_BLUE, angband::format("%c", player_ptr->history[y][x]), y + 12, x + 10);
 
         term_gotoxy(x + 10, y + 12);
         int skey = inkey_special(true);

--- a/src/blue-magic/learnt-info.cpp
+++ b/src/blue-magic/learnt-info.cpp
@@ -36,7 +36,7 @@ static std::string set_bluemage_damage(PlayerType *player_ptr, MonsterAbilityTyp
     int dice_side = monspell_bluemage_damage(player_ptr, ms_type, plev, DICE_SIDE);
     int dice_mult = monspell_bluemage_damage(player_ptr, ms_type, plev, DICE_MULT);
     int dice_div = monspell_bluemage_damage(player_ptr, ms_type, plev, DICE_DIV);
-    return format(" %s %s", msg, dice_to_string(base_damage, dice_num, dice_side, dice_mult, dice_div).data());
+    return angband::format(" %s %s", msg, dice_to_string(base_damage, dice_num, dice_side, dice_mult, dice_div).data());
 }
 
 /*!
@@ -114,19 +114,19 @@ std::string learnt_info(PlayerType *player_ptr, MonsterAbilityType power)
     case MonsterAbilityType::MISSILE:
         return set_bluemage_damage(player_ptr, power, plev, KWD_DAM);
     case MonsterAbilityType::HASTE:
-        return format(" %sd%d+%d", KWD_DURATION, 20 + plev, plev);
+        return angband::format(" %sd%d+%d", KWD_DURATION, 20 + plev, plev);
     case MonsterAbilityType::HEAL:
         return set_bluemage_damage(player_ptr, power, plev, KWD_HEAL);
     case MonsterAbilityType::INVULNER:
-        return format(" %sd7+7", KWD_DURATION);
+        return angband::format(" %sd7+7", KWD_DURATION);
     case MonsterAbilityType::BLINK:
-        return format(" %s10", KWD_SPHERE);
+        return angband::format(" %s10", KWD_SPHERE);
     case MonsterAbilityType::TPORT:
-        return format(" %s%d", KWD_SPHERE, plev * 5);
+        return angband::format(" %s%d", KWD_SPHERE, plev * 5);
     case MonsterAbilityType::PSY_SPEAR:
         return set_bluemage_damage(player_ptr, power, plev, KWD_DAM);
     case MonsterAbilityType::RAISE_DEAD:
-        return format(" %s5", KWD_SPHERE);
+        return angband::format(" %s5", KWD_SPHERE);
     default:
         return std::string();
     }

--- a/src/blue-magic/learnt-power-getter.cpp
+++ b/src/blue-magic/learnt-power-getter.cpp
@@ -70,11 +70,11 @@ static std::optional<BlueMagicType> select_blue_magic_type_by_menu()
     screen_save();
 
     while (!type.has_value()) {
-        prt(format(_(" %s ボルト", " %s bolt"), (menu_line == 1) ? _("》", "> ") : "  "), 2, 14);
-        prt(format(_(" %s ボール", " %s ball"), (menu_line == 2) ? _("》", "> ") : "  "), 3, 14);
-        prt(format(_(" %s ブレス", " %s breath"), (menu_line == 3) ? _("》", "> ") : "  "), 4, 14);
-        prt(format(_(" %s 召喚", " %s sommoning"), (menu_line == 4) ? _("》", "> ") : "  "), 5, 14);
-        prt(format(_(" %s その他", " %s others"), (menu_line == 5) ? _("》", "> ") : "  "), 6, 14);
+        prt(angband::format(_(" %s ボルト", " %s bolt"), (menu_line == 1) ? _("》", "> ") : "  "), 2, 14);
+        prt(angband::format(_(" %s ボール", " %s ball"), (menu_line == 2) ? _("》", "> ") : "  "), 3, 14);
+        prt(angband::format(_(" %s ブレス", " %s breath"), (menu_line == 3) ? _("》", "> ") : "  "), 4, 14);
+        prt(angband::format(_(" %s 召喚", " %s sommoning"), (menu_line == 4) ? _("》", "> ") : "  "), 5, 14);
+        prt(angband::format(_(" %s その他", " %s others"), (menu_line == 5) ? _("》", "> ") : "  "), 6, 14);
         prt(_("どの種類の魔法を使いますか？", "use which type of magic? "), 0, 0);
 
         auto choice = inkey();
@@ -332,7 +332,7 @@ static void describe_blue_magic_name(PlayerType *player_ptr, int menu_line, cons
         char header[80];
         close_blue_magic_name(header, sizeof(header), i, menu_line);
         const auto info = learnt_info(player_ptr, spell);
-        const auto psi_desc = format("%s %-26s %3d %3d%%%s", header, mp.name, need_mana, chance, info.data());
+        const auto psi_desc = angband::format("%s %-26s %3d %3d%%%s", header, mp.name, need_mana, chance, info.data());
         prt(psi_desc, y_base + i + 1, x_base);
     }
 

--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -189,7 +189,7 @@ bool do_cmd_attack(PlayerType *player_ptr, POSITION y, POSITION x, combat_option
 
     if (!can_attack_with_main_hand(player_ptr) && !can_attack_with_sub_hand(player_ptr) && player_ptr->muta.has_none_of(mutation_attack_methods)) {
         sound(SOUND_ATTACK_FAILED);
-        msg_print(_(format("%s攻撃できない。", (empty_hands(player_ptr, false) == EMPTY_HAND_NONE) ? "両手がふさがって" : ""), "You cannot attack."));
+        msg_print(_(angband::format("%s攻撃できない。", (empty_hands(player_ptr, false) == EMPTY_HAND_NONE) ? "両手がふさがって" : ""), "You cannot attack."));
         return false;
     }
 

--- a/src/cmd-action/cmd-hissatsu.cpp
+++ b/src/cmd-action/cmd-hissatsu.cpp
@@ -238,12 +238,12 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
                         } else {
                             letter = '0' + line - 27;
                         }
-                        psi_desc = format("  %c)", letter);
+                        psi_desc = angband::format("  %c)", letter);
                     }
 
                     /* Dump the spell --(-- */
                     const auto spell_name = exe_spell(player_ptr, REALM_HISSATSU, i, SpellProcessType::NAME);
-                    psi_desc.append(format(" %-18s%2d %3d", spell_name->data(), spell.slevel, spell.smana));
+                    psi_desc.append(angband::format(" %-18s%2d %3d", spell_name->data(), spell.slevel, spell.smana));
                     prt(psi_desc, y + (line % 17) + (line >= 17), x + (line / 17) * 30);
                     prt("", y + (line % 17) + (line >= 17) + 1, x + (line / 17) * 30);
                 }

--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -92,23 +92,23 @@ static std::string mane_info(PlayerType *player_ptr, MonsterAbilityType power, i
         Mat::PSY_SPEAR, Mat::BO_VOID, Mat::BO_ABYSS, Mat::BA_VOID, Mat::BA_ABYSS, Mat::BR_VOID, Mat::BR_ABYSS
     };
     if ((power_int > 2 && power_int < 41) || (power_int > 41 && power_int < 59) || flags.has(power)) {
-        return format(" %s%d", KWD_DAM, (int)dam);
+        return angband::format(" %s%d", KWD_DAM, (int)dam);
     }
     switch (power) {
     case MonsterAbilityType::DRAIN_MANA:
-        return format(" %sd%d+%d", KWD_HEAL, plev * 3, plev);
+        return angband::format(" %sd%d+%d", KWD_HEAL, plev * 3, plev);
     case MonsterAbilityType::HASTE:
-        return format(" %sd%d+%d", KWD_DURATION, 20 + plev, plev);
+        return angband::format(" %sd%d+%d", KWD_DURATION, 20 + plev, plev);
     case MonsterAbilityType::HEAL:
-        return format(" %s%d", KWD_HEAL, plev * 6);
+        return angband::format(" %s%d", KWD_HEAL, plev * 6);
     case MonsterAbilityType::INVULNER:
-        return format(" %sd7+7", KWD_DURATION);
+        return angband::format(" %sd7+7", KWD_DURATION);
     case MonsterAbilityType::BLINK:
-        return format(" %s10", KWD_SPHERE);
+        return angband::format(" %s10", KWD_SPHERE);
     case MonsterAbilityType::TPORT:
-        return format(" %s%d", KWD_SPHERE, plev * 5);
+        return angband::format(" %s%d", KWD_SPHERE, plev * 5);
     case MonsterAbilityType::RAISE_DEAD:
-        return format(" %s5", KWD_SPHERE);
+        return angband::format(" %s5", KWD_SPHERE);
     default:
         return std::string();
     }
@@ -226,7 +226,7 @@ static int get_mane_power(PlayerType *player_ptr, int *sn, bool baigaesi)
                     const auto comment = mane_info(player_ptr, mane.spell, (baigaesi ? mane.damage * 2 : mane.damage));
 
                     /* Dump the spell --(-- */
-                    prt(format("  %c) %-30s %3d%%%s", I2A(i), spell.name, chance, comment.data()), y + i + 1, x);
+                    prt(angband::format("  %c) %-30s %3d%%%s", I2A(i), spell.name, chance, comment.data()), y + i + 1, x);
                 }
 
                 /* Clear the bottom line */

--- a/src/cmd-action/cmd-mind.cpp
+++ b/src/cmd-action/cmd-mind.cpp
@@ -239,7 +239,7 @@ static void check_mind_mindcrafter(PlayerType *player_ptr, cm_type *cm_ptr)
         return;
     }
 
-    msg_print(_(format("%sの力が制御できない氾流となって解放された！", cm_ptr->mind_explanation), "Your mind unleashes its power in an uncontrollable storm!"));
+    msg_print(_(angband::format("%sの力が制御できない氾流となって解放された！", cm_ptr->mind_explanation), "Your mind unleashes its power in an uncontrollable storm!"));
     project(player_ptr, PROJECT_WHO_UNCTRL_POWER, 2 + cm_ptr->plev / 10, player_ptr->y, player_ptr->x, cm_ptr->plev * 2, AttributeType::MANA,
         PROJECT_JUMP | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM);
     player_ptr->csp = std::max(0, player_ptr->csp - cm_ptr->plev * std::max(1, cm_ptr->plev / 10));
@@ -267,7 +267,7 @@ static void check_mind_mirror_master(PlayerType *player_ptr, cm_type *cm_ptr)
         return;
     }
 
-    msg_print(_(format("%sの力が制御できない氾流となって解放された！", cm_ptr->mind_explanation), "Your mind unleashes its power in an uncontrollable storm!"));
+    msg_print(_(angband::format("%sの力が制御できない氾流となって解放された！", cm_ptr->mind_explanation), "Your mind unleashes its power in an uncontrollable storm!"));
     project(player_ptr, PROJECT_WHO_UNCTRL_POWER, 2 + cm_ptr->plev / 10, player_ptr->y, player_ptr->x, cm_ptr->plev * 2, AttributeType::MANA,
         PROJECT_JUMP | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM);
     player_ptr->csp = std::max(0, player_ptr->csp - cm_ptr->plev * std::max(1, cm_ptr->plev / 10));
@@ -359,7 +359,7 @@ static void mind_reflection(PlayerType *player_ptr, cm_type *cm_ptr)
     }
 
     player_ptr->csp = std::max(0, player_ptr->csp - cm_ptr->mana_cost);
-    msg_print(_(format("%sを集中しすぎて気を失ってしまった！", cm_ptr->mind_explanation), "You faint from the effort!"));
+    msg_print(_(angband::format("%sを集中しすぎて気を失ってしまった！", cm_ptr->mind_explanation), "You faint from the effort!"));
     (void)BadStatusSetter(player_ptr).mod_paralysis(randint1(5 * oops + 1));
     if (randint0(100) >= 50) {
         return;

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -406,7 +406,7 @@ void do_cmd_pet(PlayerType *player_ptr)
     auto target_of_pet_appearance = is_hallucinated ? _("何か奇妙な物", "something strange") : taget_of_pet;
     auto mes = _("ペットのターゲットを指定 (現在：%s)", "specify a target of pet (now:%s)");
     auto target_name = player_ptr->pet_t_m_idx > 0 ? target_of_pet_appearance : _("指定なし", "nothing");
-    auto target_ask = format(mes, target_name);
+    auto target_ask = angband::format(mes, target_name);
     power_desc[num] = target_ask;
     powers[num++] = PET_TARGET;
     power_desc[num] = _("近くにいろ", "stay close");
@@ -554,7 +554,7 @@ void do_cmd_pet(PlayerType *player_ptr)
             screen_save();
             prompt = _("(コマンド、ESC=終了) コマンドを選んでください:", "(Command, ESC=exit) Choose command from menu.");
         } else {
-            prompt = format(_("(コマンド %c-%c、'*'=一覧、ESC=終了) コマンドを選んでください:", "(Command %c-%c, *=List, ESC=exit) Select a command: "),
+            prompt = angband::format(_("(コマンド %c-%c、'*'=一覧、ESC=終了) コマンドを選んでください:", "(Command %c-%c, *=List, ESC=exit) Select a command: "),
                 I2A(0), I2A(num - 1));
         }
 
@@ -630,9 +630,9 @@ void do_cmd_pet(PlayerType *player_ptr)
                         /* Letter/number for power selection */
                         std::stringstream ss;
                         if (use_menu) {
-                            ss << format("%c%s ", (control == command_idx) ? '*' : ' ', (control == (menu_line - 1)) ? _("》", "> ") : "  ");
+                            ss << angband::format("%c%s ", (control == command_idx) ? '*' : ' ', (control == (menu_line - 1)) ? _("》", "> ") : "  ");
                         } else {
-                            ss << format("%c%c) ", (control == command_idx) ? '*' : ' ', I2A(control));
+                            ss << angband::format("%c%c) ", (control == command_idx) ? '*' : ' ', I2A(control));
                         }
 
                         ss << power_desc[control];

--- a/src/cmd-action/cmd-racial.cpp
+++ b/src/cmd-action/cmd-racial.cpp
@@ -85,12 +85,12 @@ static void racial_power_display_list(PlayerType *player_ptr, rc_type *rc_ptr)
                 letter = '0' + ctr - 26;
             }
 
-            dummy = format(" %c) ", letter);
+            dummy = angband::format(" %c) ", letter);
         }
 
         auto &rpi = rc_ptr->power_desc[ctr];
         dummy.append(
-            format("%-30.30s %2d %4d %3d%% %s", rpi.racial_name.data(), rpi.min_level, rpi.cost, 100 - racial_chance(player_ptr, &rc_ptr->power_desc[ctr]),
+            angband::format("%-30.30s %2d %4d %3d%% %s", rpi.racial_name.data(), rpi.min_level, rpi.cost, 100 - racial_chance(player_ptr, &rc_ptr->power_desc[ctr]),
                 rpi.info.data())
                 .data());
 

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -101,17 +101,17 @@ std::string info_string_dice(concptr str, DICE_NUMBER dice, DICE_SID sides, int 
 {
     /* Fix value */
     if (!dice) {
-        return format("%s%d", str, base);
+        return angband::format("%s%d", str, base);
     }
 
     /* Dice only */
     else if (!base) {
-        return format("%s%dd%d", str, dice, sides);
+        return angband::format("%s%dd%d", str, dice, sides);
     }
 
     /* Dice plus base value */
     else {
-        return format("%s%dd%d%+d", str, dice, sides, base);
+        return angband::format("%s%dd%d%+d", str, dice, sides, base);
     }
 }
 
@@ -135,7 +135,7 @@ std::string info_damage(DICE_NUMBER dice, DICE_SID sides, int base)
  */
 std::string info_duration(int base, DICE_SID sides)
 {
-    return format(_("期間:%d+1d%d", "dur %d+1d%d"), base, sides);
+    return angband::format(_("期間:%d+1d%d", "dur %d+1d%d"), base, sides);
 }
 
 /*!
@@ -145,7 +145,7 @@ std::string info_duration(int base, DICE_SID sides)
  */
 std::string info_range(POSITION range)
 {
-    return format(_("範囲:%d", "range %d"), range);
+    return angband::format(_("範囲:%d", "range %d"), range);
 }
 
 /*!
@@ -168,7 +168,7 @@ std::string info_heal(DICE_NUMBER dice, DICE_SID sides, int base)
  */
 std::string info_delay(int base, DICE_SID sides)
 {
-    return format(_("遅延:%d+1d%d", "delay %d+1d%d"), base, sides);
+    return angband::format(_("遅延:%d+1d%d", "delay %d+1d%d"), base, sides);
 }
 
 /*!
@@ -178,7 +178,7 @@ std::string info_delay(int base, DICE_SID sides)
  */
 std::string info_multi_damage(int dam)
 {
-    return format(_("損傷:各%d", "dam %d each"), dam);
+    return angband::format(_("損傷:各%d", "dam %d each"), dam);
 }
 
 /*!
@@ -189,7 +189,7 @@ std::string info_multi_damage(int dam)
  */
 std::string info_multi_damage_dice(DICE_NUMBER dice, DICE_SID sides)
 {
-    return format(_("損傷:各%dd%d", "dam %dd%d each"), dice, sides);
+    return angband::format(_("損傷:各%dd%d", "dam %dd%d each"), dice, sides);
 }
 
 /*!
@@ -199,7 +199,7 @@ std::string info_multi_damage_dice(DICE_NUMBER dice, DICE_SID sides)
  */
 std::string info_power(int power)
 {
-    return format(_("効力:%d", "power %d"), power);
+    return angband::format(_("効力:%d", "power %d"), power);
 }
 
 /*!
@@ -213,7 +213,7 @@ std::string info_power(int power)
  */
 std::string info_power_dice(DICE_NUMBER dice, DICE_SID sides)
 {
-    return format(_("効力:%dd%d", "power %dd%d"), dice, sides);
+    return angband::format(_("効力:%dd%d", "power %dd%d"), dice, sides);
 }
 
 /*!
@@ -223,7 +223,7 @@ std::string info_power_dice(DICE_NUMBER dice, DICE_SID sides)
  */
 std::string info_radius(POSITION rad)
 {
-    return format(_("半径:%d", "rad %d"), rad);
+    return angband::format(_("半径:%d", "rad %d"), rad);
 }
 
 /*!
@@ -234,9 +234,9 @@ std::string info_radius(POSITION rad)
 std::string info_weight(WEIGHT weight)
 {
 #ifdef JP
-    return format("最大重量:%d.%dkg", lb_to_kg_integer(weight), lb_to_kg_fraction(weight));
+    return angband::format("最大重量:%d.%dkg", lb_to_kg_integer(weight), lb_to_kg_fraction(weight));
 #else
-    return format("max wgt %d", weight / 10);
+    return angband::format("max wgt %d", weight / 10);
 #endif
 }
 
@@ -697,7 +697,7 @@ static void change_realm2(PlayerType *player_ptr, int16_t next_realm)
     player_ptr->spell_forgotten2 = 0L;
 
     constexpr auto fmt_realm = _("魔法の領域を%sから%sに変更した。", "changed magic realm from %s to %s.");
-    const auto mes = format(fmt_realm, realm_names[player_ptr->realm2], realm_names[next_realm]);
+    const auto mes = angband::format(fmt_realm, realm_names[player_ptr->realm2], realm_names[next_realm]);
     exe_write_diary(player_ptr, DiaryKind::DESCRIPTION, 0, mes);
     player_ptr->old_realm |= 1U << (player_ptr->realm2 - 1);
     player_ptr->realm2 = next_realm;
@@ -856,9 +856,9 @@ void do_cmd_study(PlayerType *player_ptr)
             return;
         }
 #ifdef JP
-        if (!get_check(format("%sの%sをさらに学びます。よろしいですか？", spell_name->data(), p)))
+        if (!get_check(angband::format("%sの%sをさらに学びます。よろしいですか？", spell_name->data(), p)))
 #else
-        if (!get_check(format("You will study a %s of %s again. Are you sure? ", p, spell_name->data())))
+        if (!get_check(angband::format("You will study a %s of %s again. Are you sure? ", p, spell_name->data())))
 #endif
         {
             return;

--- a/src/cmd-io/cmd-autopick.cpp
+++ b/src/cmd-io/cmd-autopick.cpp
@@ -162,9 +162,9 @@ void do_cmd_edit_autopick(PlayerType *player_ptr)
                 "(^Q:Quit, ^W:Save&Quit, ESC:Menu, Other:Input text)"),
             0, 0);
         if (!tb->mark) {
-            prt(format("(%d,%d)", tb->cx, tb->cy), 0, 60);
+            prt(angband::format("(%d,%d)", tb->cx, tb->cy), 0, 60);
         } else {
-            prt(format("(%d,%d)-(%d,%d)", tb->mx, tb->my, tb->cx, tb->cy), 0, 60);
+            prt(angband::format("(%d,%d)-(%d,%d)", tb->mx, tb->my, tb->cx, tb->cy), 0, 60);
         }
 
         term_gotoxy(tb->cx - tb->left, tb->cy - tb->upper + 1);

--- a/src/cmd-io/cmd-diary.cpp
+++ b/src/cmd-io/cmd-diary.cpp
@@ -30,9 +30,9 @@ static void display_diary(PlayerType *player_ptr)
     const auto choice = Rand_external(subtitle_candidates.size());
     const auto &subtitle = subtitle_candidates[choice];
 #ifdef JP
-    const auto diary_title = format("「%s%s%sの伝説 -%s-」", ap_ptr->title, ap_ptr->no ? "の" : "", player_ptr->name, subtitle.data());
+    const auto diary_title = angband::format("「%s%s%sの伝説 -%s-」", ap_ptr->title, ap_ptr->no ? "の" : "", player_ptr->name, subtitle.data());
 #else
-    const auto diary_title = format("Legend of %s %s '%s'", ap_ptr->title, player_ptr->name, subtitle.data());
+    const auto diary_title = angband::format("Legend of %s %s '%s'", ap_ptr->title, player_ptr->name, subtitle.data());
 #endif
 
     std::stringstream ss;
@@ -61,14 +61,14 @@ static void do_cmd_last_get(PlayerType *player_ptr)
         return;
     }
 
-    const auto record = format(_("%sの入手を記録します。", "Do you really want to record getting %s? "), record_o_name);
+    const auto record = angband::format(_("%sの入手を記録します。", "Do you really want to record getting %s? "), record_o_name);
     if (!get_check(record)) {
         return;
     }
 
     GAME_TURN turn_tmp = w_ptr->game_turn;
     w_ptr->game_turn = record_turn;
-    const auto mes = format(_("%sを手に入れた。", "discover %s."), record_o_name);
+    const auto mes = angband::format(_("%sを手に入れた。", "discover %s."), record_o_name);
     exe_write_diary(player_ptr, DiaryKind::DESCRIPTION, 0, mes);
     w_ptr->game_turn = turn_tmp;
 }

--- a/src/cmd-io/cmd-dump.cpp
+++ b/src/cmd-io/cmd-dump.cpp
@@ -135,13 +135,13 @@ void do_cmd_colors(PlayerType *player_ptr)
                 clear_from(10);
                 for (byte j = 0; j < 16; j++) {
                     term_putstr(j * 4, 20, -1, a, "###");
-                    term_putstr(j * 4, 22, -1, j, format("%3d", j));
+                    term_putstr(j * 4, 22, -1, j, angband::format("%3d", j));
                 }
 
                 name = ((a < 16) ? color_names[a] : _("未定義", "undefined"));
-                term_putstr(5, 10, -1, TERM_WHITE, format(_("カラー = %d, 名前 = %s", "Color = %d, Name = %s"), a, name));
+                term_putstr(5, 10, -1, TERM_WHITE, angband::format(_("カラー = %d, 名前 = %s", "Color = %d, Name = %s"), a, name));
                 term_putstr(5, 12, -1, TERM_WHITE,
-                    format("K = 0x%02x / R,G,B = 0x%02x,0x%02x,0x%02x", angband_color_table[a][0], angband_color_table[a][1], angband_color_table[a][2],
+                    angband::format("K = 0x%02x / R,G,B = 0x%02x,0x%02x,0x%02x", angband_color_table[a][0], angband_color_table[a][1], angband_color_table[a][2],
                         angband_color_table[a][3]));
                 term_putstr(0, 14, -1, TERM_WHITE, _("コマンド (n/N/k/K/r/R/g/G/b/B): ", "Command (n/N/k/K/r/R/g/G/b/B): "));
                 i = inkey();

--- a/src/cmd-io/cmd-floor.cpp
+++ b/src/cmd-io/cmd-floor.cpp
@@ -71,7 +71,7 @@ void do_cmd_locate(PlayerType *player_ptr)
     constexpr auto fmt = _("マップ位置 [%d(%02d),%d(%02d)] (プレイヤーの%s)  方向?", "Map sector [%d(%02d),%d(%02d)], which is%s your sector.  Direction?");
     while (true) {
         std::string_view dirstring = dirstrings[(y2 < y1) ? 0 : ((y2 > y1) ? 2 : 1)][(x2 < x1) ? 0 : ((x2 > x1) ? 2 : 1)];
-        std::string out_val = format(fmt, y2 / (hgt / 2), y2 % (hgt / 2), x2 / (wid / 2), x2 % (wid / 2), dirstring.data());
+        std::string out_val = angband::format(fmt, y2 / (hgt / 2), y2 % (hgt / 2), x2 / (wid / 2), x2 % (wid / 2), dirstring.data());
 
         dir = 0;
         while (!dir) {

--- a/src/cmd-io/cmd-gameoption.cpp
+++ b/src/cmd-io/cmd-gameoption.cpp
@@ -96,17 +96,17 @@ static void do_cmd_options_autosave(PlayerType *player_ptr, concptr info)
     int i, k = 0, n = 2;
     term_clear();
     while (true) {
-        prt(format(_("%s ( リターンで次へ, y/n でセット, F で頻度を入力, ESC で決定 ) ", "%s (RET to advance, y/n to set, 'F' for frequency, ESC to accept) "), info), 0, 0);
+        prt(angband::format(_("%s ( リターンで次へ, y/n でセット, F で頻度を入力, ESC で決定 ) ", "%s (RET to advance, y/n to set, 'F' for frequency, ESC to accept) "), info), 0, 0);
         for (i = 0; i < n; i++) {
             byte a = TERM_WHITE;
             if (i == k) {
                 a = TERM_L_BLUE;
             }
 
-            c_prt(a, format("%-48s: %s (%s)", autosave_info[i].o_desc, (*autosave_info[i].o_var ? _("はい  ", "yes") : _("いいえ", "no ")), autosave_info[i].o_text), i + 2, 0);
+            c_prt(a, angband::format("%-48s: %s (%s)", autosave_info[i].o_desc, (*autosave_info[i].o_var ? _("はい  ", "yes") : _("いいえ", "no ")), autosave_info[i].o_text), i + 2, 0);
         }
 
-        prt(format(_("自動セーブの頻度： %d ターン毎", "Timed autosave frequency: every %d turns"), autosave_freq), 5, 0);
+        prt(angband::format(_("自動セーブの頻度： %d ターン毎", "Timed autosave frequency: every %d turns"), autosave_freq), 5, 0);
         move_cursor(k + 2, 50);
         ch = inkey();
         switch (ch) {
@@ -148,7 +148,7 @@ static void do_cmd_options_autosave(PlayerType *player_ptr, concptr info)
         case 'f':
         case 'F': {
             autosave_freq = toggle_frequency(autosave_freq);
-            prt(format(_("自動セーブの頻度： %d ターン毎", "Timed autosave frequency: every %d turns"), autosave_freq), 5, 0);
+            prt(angband::format(_("自動セーブの頻度： %d ターン毎", "Timed autosave frequency: every %d turns"), autosave_freq), 5, 0);
             break;
         }
 
@@ -336,7 +336,7 @@ static void do_cmd_options_cheat(PlayerType *player_ptr, concptr info)
     auto k = 0U;
     const auto n = cheat_info.size();
     while (true) {
-        prt(format(_("%s ( リターンで次へ, y/n でセット, ESC で決定 )", "%s (RET to advance, y/n to set, ESC to accept) "), info), 0, 0);
+        prt(angband::format(_("%s ( リターンで次へ, y/n でセット, ESC で決定 )", "%s (RET to advance, y/n to set, ESC to accept) "), info), 0, 0);
 
 #ifdef JP
         /* 詐欺オプションをうっかりいじってしまう人がいるようなので注意 */
@@ -352,7 +352,7 @@ static void do_cmd_options_cheat(PlayerType *player_ptr, concptr info)
             }
 
             const auto yesno = *cheat_info[i].o_var ? _("はい  ", "yes") : _("いいえ", "no ");
-            c_prt(enum2i(a), format("%-48s: %s (%s)", cheat_info[i].o_desc, yesno, cheat_info[i].o_text), i + 2, 0);
+            c_prt(enum2i(a), angband::format("%-48s: %s (%s)", cheat_info[i].o_desc, yesno, cheat_info[i].o_text), i + 2, 0);
         }
 
         move_cursor(k + 2, 50);
@@ -453,7 +453,7 @@ void do_cmd_options(PlayerType *player_ptr)
                 if (i == y) {
                     a = TERM_L_BLUE;
                 }
-                term_putstr(5, option_fields[i].row, -1, a, format("(%c) %s", toupper(option_fields[i].key), option_fields[i].name));
+                term_putstr(5, option_fields[i].row, -1, a, angband::format("(%c) %s", toupper(option_fields[i].key), option_fields[i].name));
             }
 
             prt(_("<方向>で移動, Enterで決定, ESCでキャンセル, ?でヘルプ: ", "Move to <dir>, Select to Enter, Cancel to ESC, ? to help: "), 21, 0);
@@ -570,7 +570,7 @@ void do_cmd_options(PlayerType *player_ptr)
         case 'D':
         case 'd': {
             clear_from(18);
-            prt(format(_("現在ウェイト量(msec): %d", "Current Delay Factor(msec): %d"), delay_factor), 19, 0);
+            prt(angband::format(_("現在ウェイト量(msec): %d", "Current Delay Factor(msec): %d"), delay_factor), 19, 0);
             (void)get_value(_("コマンド: ウェイト量(msec)", "Command: Delay Factor(msec)"), 0, 1000, &delay_factor);
             clear_from(18);
             break;
@@ -580,7 +580,7 @@ void do_cmd_options(PlayerType *player_ptr)
             clear_from(18);
             prt(_("コマンド: 低ヒットポイント警告", "Command: Hitpoint Warning"), 19, 0);
             while (true) {
-                prt(format(_("現在の低ヒットポイント警告: %d0%%", "Current hitpoint warning: %d0%%"), hitpoint_warn), 22, 0);
+                prt(angband::format(_("現在の低ヒットポイント警告: %d0%%", "Current hitpoint warning: %d0%%"), hitpoint_warn), 22, 0);
                 prt(_("低ヒットポイント警告 (0-9) ESCで決定: ", "Hitpoint Warning (0-9 or ESC to accept): "), 20, 0);
                 k = inkey();
                 if (k == ESCAPE) {
@@ -602,7 +602,7 @@ void do_cmd_options(PlayerType *player_ptr)
             clear_from(18);
             prt(_("コマンド: 低魔力色閾値", "Command: Mana Color Threshold"), 19, 0);
             while (true) {
-                prt(format(_("現在の低魔力色閾値: %d0%%", "Current mana color threshold: %d0%%"), mana_warn), 22, 0);
+                prt(angband::format(_("現在の低魔力色閾値: %d0%%", "Current mana color threshold: %d0%%"), mana_warn), 22, 0);
                 prt(_("低魔力閾値 (0-9) ESCで決定: ", "Mana color Threshold (0-9 or ESC to accept): "), 20, 0);
                 k = inkey();
                 if (k == ESCAPE) {
@@ -663,7 +663,7 @@ void do_cmd_options_aux(PlayerType *player_ptr, game_option_types page, concptr 
     while (true) {
         DIRECTION dir;
         constexpr auto command = _("%s (リターン:次, %sESC:終了, ?:ヘルプ) ", "%s (RET:next, %s, ?:help) ");
-        prt(format(command, info, browse_only ? _("", "ESC:exit") : _("y/n:変更, ", "y/n:change, ESC:accept")), 0, 0);
+        prt(angband::format(command, info, browse_only ? _("", "ESC:exit") : _("y/n:変更, ", "y/n:change, ESC:accept")), 0, 0);
         if (page == OPT_PAGE_AUTODESTROY) {
             constexpr auto mes = _("以下のオプションは、簡易自動破壊を使用するときのみ有効", "Following options will protect items from easy auto-destroyer.");
             c_prt(TERM_YELLOW, mes, 6, _(6, 3));
@@ -675,7 +675,7 @@ void do_cmd_options_aux(PlayerType *player_ptr, game_option_types page, concptr 
                 a = TERM_L_BLUE;
             }
 
-            std::string label = format("%-48s: %s (%.19s)", option_info[opt[i]].o_desc, (*option_info[opt[i]].o_var ? _("はい  ", "yes") : _("いいえ", "no ")),
+            std::string label = angband::format("%-48s: %s (%.19s)", option_info[opt[i]].o_desc, (*option_info[opt[i]].o_var ? _("はい  ", "yes") : _("いいえ", "no ")),
                 option_info[opt[i]].o_text);
             if ((page == OPT_PAGE_AUTODESTROY) && i > 2) {
                 c_prt(a, label, i + 5, 0);

--- a/src/cmd-io/cmd-knowledge.cpp
+++ b/src/cmd-io/cmd-knowledge.cpp
@@ -31,7 +31,7 @@ void do_cmd_knowledge(PlayerType *player_ptr)
     TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, MAIN_TERM_MIN_ROWS);
     while (true) {
         term_clear();
-        prt(format(_("%d/2 ページ", "page %d/2"), (p + 1)), 2, 65);
+        prt(angband::format(_("%d/2 ページ", "page %d/2"), (p + 1)), 2, 65);
         prt(_("現在の知識を確認する", "Display current knowledge"), 3, 0);
         if (p == 0) {
             prt(_("(1) 既知の伝説のアイテム                 の一覧", "(1) Display known artifacts"), 6, 5);

--- a/src/cmd-io/cmd-lore.cpp
+++ b/src/cmd-io/cmd-lore.cpp
@@ -81,11 +81,11 @@ void do_cmd_query_symbol(PlayerType *player_ptr)
             temp[0] = 0;
             return;
         }
-        buf = format(_("名前:%sにマッチ", "Monsters' names with \"%s\""), temp);
+        buf = angband::format(_("名前:%sにマッチ", "Monsters' names with \"%s\""), temp);
     } else if (ident_info[ident_i]) {
-        buf = format("%c - %s.", sym, ident_info[ident_i] + 2);
+        buf = angband::format("%c - %s.", sym, ident_info[ident_i] + 2);
     } else {
-        buf = format("%c - %s", sym, _("無効な文字", "Unknown Symbol"));
+        buf = angband::format("%c - %s", sym, _("無効な文字", "Unknown Symbol"));
     }
 
     prt(buf, 0, 0);

--- a/src/cmd-item/cmd-equipment.cpp
+++ b/src/cmd-item/cmd-equipment.cpp
@@ -105,9 +105,9 @@ void do_cmd_equip(PlayerType *player_ptr)
     auto weight_lim = calc_weight_limit(player_ptr);
     const auto mes = _("装備： 合計 %3d.%1d kg (限界の%d%%) コマンド: ", "Equipment: carrying %d.%d pounds (%d%% of capacity). Command: ");
 #ifdef JP
-    const auto out_val = format(mes, lb_to_kg_integer(weight), lb_to_kg_fraction(weight), weight * 100 / weight_lim);
+    const auto out_val = angband::format(mes, lb_to_kg_integer(weight), lb_to_kg_fraction(weight), weight * 100 / weight_lim);
 #else
-    const auto out_val = format(mes, weight / 10, weight % 10, weight * 100 / weight_lim);
+    const auto out_val = angband::format(mes, weight / 10, weight % 10, weight * 100 / weight_lim);
 #endif
 
     prt(out_val, 0, 0);
@@ -238,7 +238,7 @@ void do_cmd_wield(PlayerType *player_ptr)
     should_equip_cursed &= confirm_wear;
     if (should_equip_cursed) {
         const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
-        if (!get_check(format(_("本当に%s{呪われている}を使いますか？", "Really use the %s {cursed}? "), item_name.data()))) {
+        if (!get_check(angband::format(_("本当に%s{呪われている}を使いますか？", "Really use the %s {cursed}? "), item_name.data()))) {
             return;
         }
     }
@@ -252,7 +252,7 @@ void do_cmd_wield(PlayerType *player_ptr)
         const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
         constexpr auto mes = _("%sを装備すると吸血鬼になります。よろしいですか？",
             "%s will transform you into a vampire permanently when equipped. Do you become a vampire? ");
-        if (!get_check(format(mes, item_name.data()))) {
+        if (!get_check(angband::format(mes, item_name.data()))) {
             return;
         }
     }

--- a/src/cmd-item/cmd-item.cpp
+++ b/src/cmd-item/cmd-item.cpp
@@ -86,9 +86,9 @@ void do_cmd_inven(PlayerType *player_ptr)
     WEIGHT weight_lim = calc_weight_limit(player_ptr);
     std::string out_val;
 #ifdef JP
-    out_val = format("持ち物： 合計 %3d.%1d kg (限界の%ld%%) コマンド: ", lb_to_kg_integer(weight), lb_to_kg_fraction(weight),
+    out_val = angband::format("持ち物： 合計 %3d.%1d kg (限界の%ld%%) コマンド: ", lb_to_kg_integer(weight), lb_to_kg_fraction(weight),
 #else
-    out_val = format("Inventory: carrying %d.%d pounds (%ld%% of capacity). Command: ", weight / 10, weight % 10,
+    out_val = angband::format("Inventory: carrying %d.%d pounds (%ld%% of capacity). Command: ", weight / 10, weight % 10,
 #endif
         (long int)(weight * 100) / weight_lim);
 

--- a/src/cmd-item/cmd-magiceat.cpp
+++ b/src/cmd-item/cmd-magiceat.cpp
@@ -155,13 +155,13 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
 
         while (tval == ItemKindType::NONE) {
 #ifdef JP
-            prt(format(" %s 杖", (menu_line == 1) ? "》" : "  "), 2, 14);
-            prt(format(" %s 魔法棒", (menu_line == 2) ? "》" : "  "), 3, 14);
-            prt(format(" %s ロッド", (menu_line == 3) ? "》" : "  "), 4, 14);
+            prt(angband::format(" %s 杖", (menu_line == 1) ? "》" : "  "), 2, 14);
+            prt(angband::format(" %s 魔法棒", (menu_line == 2) ? "》" : "  "), 3, 14);
+            prt(angband::format(" %s ロッド", (menu_line == 3) ? "》" : "  "), 4, 14);
 #else
-            prt(format(" %s staff", (menu_line == 1) ? "> " : "  "), 2, 14);
-            prt(format(" %s wand", (menu_line == 2) ? "> " : "  "), 3, 14);
-            prt(format(" %s rod", (menu_line == 3) ? "> " : "  "), 4, 14);
+            prt(angband::format(" %s staff", (menu_line == 1) ? "> " : "  "), 2, 14);
+            prt(angband::format(" %s wand", (menu_line == 2) ? "> " : "  "), 3, 14);
+            prt(angband::format(" %s rod", (menu_line == 3) ? "> " : "  "), 4, 14);
 #endif
 
             if (only_browse) {
@@ -269,11 +269,11 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
 
             /* Print header(s) */
 #ifdef JP
-            prt(format("                           %s 失率                           %s 失率", (tval == ItemKindType::ROD ? "  状態  " : "使用回数"),
+            prt(angband::format("                           %s 失率                           %s 失率", (tval == ItemKindType::ROD ? "  状態  " : "使用回数"),
                     (tval == ItemKindType::ROD ? "  状態  " : "使用回数")),
                 y++, x);
 #else
-            prt(format("                           %s Fail                           %s Fail", (tval == ItemKindType::ROD ? "  Stat  " : " Charges"),
+            prt(angband::format("                           %s Fail                           %s Fail", (tval == ItemKindType::ROD ? "  Stat  " : " Charges"),
                     (tval == ItemKindType::ROD ? "  Stat  " : " Charges")),
                 y++, x);
 #endif
@@ -303,7 +303,7 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
                     } else {
                         letter = '0' + sval_ctr - 26;
                     }
-                    dummy = format("%c)", letter);
+                    dummy = angband::format("%c)", letter);
                 }
                 x1 = ((sval_ctr < item_group_size / 2) ? x : x + 40);
                 y1 = ((sval_ctr < item_group_size / 2) ? y + sval_ctr : y + sval_ctr - item_group_size / 2);
@@ -330,7 +330,7 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
                 if (bi_id) {
                     if (tval == ItemKindType::ROD) {
                         dummy.append(
-                            format(_(" %-22.22s 充填:%2d/%2d%3d%%", " %-22.22s   (%2d/%2d) %3d%%"), baseitem.name.data(),
+                            angband::format(_(" %-22.22s 充填:%2d/%2d%3d%%", " %-22.22s   (%2d/%2d) %3d%%"), baseitem.name.data(),
                                 item.charge ? (item.charge - 1) / (EATER_ROD_CHARGE * baseitem.pval) + 1 : 0,
                                 item.count, chance)
                                 .data());
@@ -339,7 +339,7 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
                         }
                     } else {
                         dummy.append(
-                            format(" %-22.22s    %2d/%2d %3d%%", baseitem.name.data(), (int16_t)(item.charge / EATER_CHARGE),
+                            angband::format(" %-22.22s    %2d/%2d %3d%%", baseitem.name.data(), (int16_t)(item.charge / EATER_CHARGE),
                                 item.count, chance)
                                 .data());
                         if (item.charge < EATER_CHARGE) {

--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -161,7 +161,7 @@ void do_cmd_player_status(PlayerType *player_ptr)
  */
 void do_cmd_message_one(void)
 {
-    prt(format("> %s", message_str(0)), 0, 0);
+    prt(angband::format("> %s", message_str(0)), 0, 0);
 }
 
 /*!
@@ -221,7 +221,7 @@ void do_cmd_messages(int num_now)
             term_erase(0, num_lines + 1 - j, 255);
         }
 
-        prt(format(_("以前のメッセージ %d-%d 全部で(%d)", "Message Recall (%d-%d of %d)"), i, i + j - 1, n), 0, 0);
+        prt(angband::format(_("以前のメッセージ %d-%d 全部で(%d)", "Message Recall (%d-%d of %d)"), i, i + j - 1, n), 0, 0);
         prt(_("[ 'p' で更に古いもの, 'n' で更に新しいもの, '/' で検索, ESC で中断 ]", "[Press 'p' for older, 'n' for newer, ..., or ESCAPE]"), hgt - 1, 0);
         skey = inkey_special(true);
         if (skey == ESCAPE) {

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -40,7 +40,7 @@ static bool cmd_visuals_aux(int i, IDX *num, IDX max)
     if (iscntrl(i)) {
         char str[10] = "";
         strnfmt(str, sizeof(str), "%d", *num);
-        if (!get_string(format("Input new number(0-%d): ", max - 1), str, 4)) {
+        if (!get_string(angband::format("Input new number(0-%d): ", max - 1), str, 4)) {
             return false;
         }
 
@@ -75,7 +75,7 @@ static void print_visuals_menu(concptr choice_msg)
     prt(_("(8) アイテムの   色/文字 を変更する (シンボルエディタ)", "(8) Change object attr/chars (visual mode)"), 11, 5);
     prt(_("(9) 地形の       色/文字 を変更する (シンボルエディタ)", "(9) Change feature attr/chars (visual mode)"), 12, 5);
     prt(_("(R) 画面表示方法の初期化", "(R) Reset visuals"), 13, 5);
-    prt(format(_("コマンド: %s", "Command: %s"), choice_msg ? choice_msg : _("", "")), 15, 0);
+    prt(angband::format(_("コマンド: %s", "Command: %s"), choice_msg ? choice_msg : _("", "")), 15, 0);
 }
 
 /*
@@ -215,7 +215,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
             IDX num = 0;
             static concptr choice_msg = _("モンスターの[色/文字]を変更します", "Change monster attr/chars");
             static MonsterRaceId r = monraces_info.begin()->second.idx;
-            prt(format(_("コマンド: %s", "Command: %s"), choice_msg), 15, 0);
+            prt(angband::format(_("コマンド: %s", "Command: %s"), choice_msg), 15, 0);
             while (true) {
                 auto *r_ptr = &monraces_info[r];
                 int c;
@@ -226,11 +226,11 @@ void do_cmd_visuals(PlayerType *player_ptr)
                 TERM_COLOR ca = r_ptr->x_attr;
                 byte cc = r_ptr->x_char;
 
-                term_putstr(5, 17, -1, TERM_WHITE, format(_("モンスター = %d, 名前 = %-40.40s", "Monster = %d, Name = %-40.40s"), enum2i(r), r_ptr->name.data()));
-                term_putstr(10, 19, -1, TERM_WHITE, format(_("初期値  色 / 文字 = %3u / %3u", "Default attr/char = %3u / %3u"), da, dc));
+                term_putstr(5, 17, -1, TERM_WHITE, angband::format(_("モンスター = %d, 名前 = %-40.40s", "Monster = %d, Name = %-40.40s"), enum2i(r), r_ptr->name.data()));
+                term_putstr(10, 19, -1, TERM_WHITE, angband::format(_("初期値  色 / 文字 = %3u / %3u", "Default attr/char = %3u / %3u"), da, dc));
                 term_putstr(40, 19, -1, TERM_WHITE, empty_symbol);
                 term_queue_bigchar(43, 19, da, dc, 0, 0);
-                term_putstr(10, 20, -1, TERM_WHITE, format(_("現在値  色 / 文字 = %3u / %3u", "Current attr/char = %3u / %3u"), ca, cc));
+                term_putstr(10, 20, -1, TERM_WHITE, angband::format(_("現在値  色 / 文字 = %3u / %3u", "Current attr/char = %3u / %3u"), ca, cc));
                 term_putstr(40, 20, -1, TERM_WHITE, empty_symbol);
                 term_queue_bigchar(43, 20, ca, cc, 0, 0);
                 term_putstr(0, 22, -1, TERM_WHITE, _("コマンド (n/N/^N/a/A/^A/c/C/^C/v/V/^V): ", "Command (n/N/^N/a/A/^A/c/C/^C/v/V/^V): "));
@@ -285,7 +285,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
         case '5': {
             static concptr choice_msg = _("アイテムの[色/文字]を変更します", "Change object attr/chars");
             static short k = 0;
-            prt(format(_("コマンド: %s", "Command: %s"), choice_msg), 15, 0);
+            prt(angband::format(_("コマンド: %s", "Command: %s"), choice_msg), 15, 0);
             while (true) {
                 auto &baseitem = baseitems_info[k];
                 int c;
@@ -297,12 +297,12 @@ void do_cmd_visuals(PlayerType *player_ptr)
                 auto cc = baseitem.x_char;
 
                 term_putstr(5, 17, -1, TERM_WHITE,
-                    format(
+                    angband::format(
                         _("アイテム = %d, 名前 = %-40.40s", "Object = %d, Name = %-40.40s"), k, (!baseitem.flavor ? baseitem.name : baseitem.flavor_name).data()));
-                term_putstr(10, 19, -1, TERM_WHITE, format(_("初期値  色 / 文字 = %3d / %3d", "Default attr/char = %3d / %3d"), da, dc));
+                term_putstr(10, 19, -1, TERM_WHITE, angband::format(_("初期値  色 / 文字 = %3d / %3d", "Default attr/char = %3d / %3d"), da, dc));
                 term_putstr(40, 19, -1, TERM_WHITE, empty_symbol);
                 term_queue_bigchar(43, 19, da, dc, 0, 0);
-                term_putstr(10, 20, -1, TERM_WHITE, format(_("現在値  色 / 文字 = %3d / %3d", "Current attr/char = %3d / %3d"), ca, cc));
+                term_putstr(10, 20, -1, TERM_WHITE, angband::format(_("現在値  色 / 文字 = %3d / %3d", "Current attr/char = %3d / %3d"), ca, cc));
                 term_putstr(40, 20, -1, TERM_WHITE, empty_symbol);
                 term_queue_bigchar(43, 20, ca, cc, 0, 0);
                 term_putstr(0, 22, -1, TERM_WHITE, _("コマンド (n/N/^N/a/A/^A/c/C/^C/v/V/^V): ", "Command (n/N/^N/a/A/^A/c/C/^C/v/V/^V): "));
@@ -358,7 +358,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
             static concptr choice_msg = _("地形の[色/文字]を変更します", "Change feature attr/chars");
             static IDX f = 0;
             static IDX lighting_level = F_LIT_STANDARD;
-            prt(format(_("コマンド: %s", "Command: %s"), choice_msg), 15, 0);
+            prt(angband::format(_("コマンド: %s", "Command: %s"), choice_msg), 15, 0);
             while (true) {
                 auto *f_ptr = &terrains_info[f];
                 int c;
@@ -371,12 +371,12 @@ void do_cmd_visuals(PlayerType *player_ptr)
 
                 prt("", 17, 5);
                 term_putstr(5, 17, -1, TERM_WHITE,
-                    format(_("地形 = %d, 名前 = %s, 明度 = %s", "Terrain = %d, Name = %s, Lighting = %s"), f, (f_ptr->name.data()),
+                    angband::format(_("地形 = %d, 名前 = %s, 明度 = %s", "Terrain = %d, Name = %s, Lighting = %s"), f, (f_ptr->name.data()),
                         lighting_level_str[lighting_level]));
-                term_putstr(10, 19, -1, TERM_WHITE, format(_("初期値  色 / 文字 = %3d / %3d", "Default attr/char = %3d / %3d"), da, dc));
+                term_putstr(10, 19, -1, TERM_WHITE, angband::format(_("初期値  色 / 文字 = %3d / %3d", "Default attr/char = %3d / %3d"), da, dc));
                 term_putstr(40, 19, -1, TERM_WHITE, empty_symbol);
                 term_queue_bigchar(43, 19, da, dc, 0, 0);
-                term_putstr(10, 20, -1, TERM_WHITE, format(_("現在値  色 / 文字 = %3d / %3d", "Current attr/char = %3d / %3d"), ca, cc));
+                term_putstr(10, 20, -1, TERM_WHITE, angband::format(_("現在値  色 / 文字 = %3d / %3d", "Current attr/char = %3d / %3d"), ca, cc));
                 term_putstr(40, 20, -1, TERM_WHITE, empty_symbol);
                 term_queue_bigchar(43, 20, ca, cc, 0, 0);
                 term_putstr(0, 22, -1, TERM_WHITE,

--- a/src/core/game-closer.cpp
+++ b/src/core/game-closer.cpp
@@ -116,11 +116,11 @@ static void kingly(PlayerType *player_ptr)
 #ifdef JP
     put_str("Veni, Vidi, Vici!", 15, 31);
     put_str("来た、見た、勝った！", 16, 30);
-    put_str(format("偉大なる%s万歳！", sp_ptr->winner), 17, 29);
+    put_str(angband::format("偉大なる%s万歳！", sp_ptr->winner), 17, 29);
 #else
     put_str("Veni, Vidi, Vici!", 15, 31);
     put_str("I came, I saw, I conquered!", 16, 26);
-    put_str(format("All Hail the Mighty %s!", sp_ptr->winner), 17, 27);
+    put_str(angband::format("All Hail the Mighty %s!", sp_ptr->winner), 17, 27);
 #endif
 
     if (!seppuku) {

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -290,7 +290,7 @@ static void generate_world(PlayerType *player_ptr, bool new_game)
         return;
     }
 
-    const auto mes = format(_("%sに降り立った。", "arrived in %s."), map_name(player_ptr).data());
+    const auto mes = angband::format(_("%sに降り立った。", "arrived in %s."), map_name(player_ptr).data());
     exe_write_diary(player_ptr, DiaryKind::DESCRIPTION, 0, mes);
 }
 

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -87,7 +87,7 @@ static void process_fishing(PlayerType *player_ptr)
             x = player_ptr->x + ddx[player_ptr->fishing_dir];
             if (place_monster_aux(player_ptr, 0, y, x, r_idx, PM_NO_KAGE)) {
                 const auto m_name = monster_desc(player_ptr, &floor_ptr->m_list[floor_ptr->grid_array[y][x].m_idx], 0);
-                msg_print(_(format("%sが釣れた！", m_name.data()), "You have a good catch!"));
+                msg_print(_(angband::format("%sが釣れた！", m_name.data()), "You have a good catch!"));
                 success = true;
             }
         }

--- a/src/core/score-util.cpp
+++ b/src/core/score-util.cpp
@@ -36,7 +36,7 @@ errr highscore_read(high_score *score)
 
 void high_score::copy_info(const PlayerType &player)
 {
-    const auto name = format("%-.15s", player.name);
+    const auto name = angband::format("%-.15s", player.name);
     std::copy_n(name.begin(), name.length(), this->who);
 
 #ifdef SET_UID
@@ -44,22 +44,22 @@ void high_score::copy_info(const PlayerType &player)
 #else
     const auto tmp_uid = 0;
 #endif
-    const auto uid_str = format("%7u", tmp_uid);
+    const auto uid_str = angband::format("%7u", tmp_uid);
     std::copy_n(uid_str.begin(), uid_str.length(), this->uid);
     this->sex[0] = player.psex ? 'm' : 'f';
-    const auto prace = format("%2d", std::min(enum2i(player.prace), MAX_RACES));
+    const auto prace = angband::format("%2d", std::min(enum2i(player.prace), MAX_RACES));
     std::copy_n(prace.begin(), prace.length(), this->p_r);
-    const auto pclass = format("%2d", enum2i(std::min(player.pclass, PlayerClassType::MAX)));
+    const auto pclass = angband::format("%2d", enum2i(std::min(player.pclass, PlayerClassType::MAX)));
     std::copy_n(pclass.begin(), pclass.length(), this->p_c);
-    const auto ppersonality = format("%2d", std::min(player.ppersonality, MAX_PERSONALITIES));
+    const auto ppersonality = angband::format("%2d", std::min(player.ppersonality, MAX_PERSONALITIES));
     std::copy_n(ppersonality.begin(), ppersonality.length(), this->p_a);
-    const auto current_level = format("%3d", std::min<ushort>(player.lev, 999));
+    const auto current_level = angband::format("%3d", std::min<ushort>(player.lev, 999));
     std::copy_n(current_level.begin(), current_level.length(), this->cur_lev);
     const auto &floor = *player.current_floor_ptr;
-    const auto current_dungeon = format("%3d", floor.dun_level);
+    const auto current_dungeon = angband::format("%3d", floor.dun_level);
     std::copy_n(current_dungeon.begin(), current_dungeon.length(), this->cur_dun);
-    const auto max_level = format("%3d", std::min<ushort>(player.max_plv, 999));
+    const auto max_level = angband::format("%3d", std::min<ushort>(player.max_plv, 999));
     std::copy_n(max_level.begin(), max_level.length(), this->max_lev);
-    const auto max_dungeon = format("%3d", max_dlv[floor.dungeon_idx]);
+    const auto max_dungeon = angband::format("%3d", max_dlv[floor.dungeon_idx]);
     std::copy_n(max_dungeon.begin(), max_dungeon.length(), this->max_dun);
 }

--- a/src/core/show-file.cpp
+++ b/src/core/show-file.cpp
@@ -180,7 +180,7 @@ bool show_file(PlayerType *player_ptr, bool show_version, std::string_view name_
         fff = angband_fopen(path_reopen, FileOpenMode::READ);
     }
 
-    const auto open_error_mes = format(_("'%s'をオープンできません。", "Cannot open '%s'."), name.data());
+    const auto open_error_mes = angband::format(_("'%s'をオープンできません。", "Cannot open '%s'."), name.data());
     if (!fff) {
         THROW_EXCEPTION(std::runtime_error, open_error_mes);
     }
@@ -305,10 +305,10 @@ bool show_file(PlayerType *player_ptr, bool show_version, std::string_view name_
 
         if (show_version) {
             constexpr auto title = _("[%s, %s, %d/%d]", "[%s, %s, Line %d/%d]");
-            prt(format(title, get_version().data(), caption_str.data(), line, size), 0, 0);
+            prt(angband::format(title, get_version().data(), caption_str.data(), line, size), 0, 0);
         } else {
             constexpr auto title = _("[%s, %d/%d]", "[%s, Line %d/%d]");
-            prt(format(title, caption_str.data(), line, size), 0, 0);
+            prt(angband::format(title, caption_str.data(), line, size), 0, 0);
         }
 
         if (size <= rows) {

--- a/src/effect/effect-monster-charm.cpp
+++ b/src/effect/effect-monster-charm.cpp
@@ -426,7 +426,7 @@ static void effect_monster_captured(PlayerType *player_ptr, EffectMonster *em_pt
     cap_mon_ptr->max_hp = static_cast<short>(em_ptr->m_ptr->max_maxhp);
     cap_mon_ptr->nickname = em_ptr->m_ptr->nickname;
     if ((em_ptr->g_ptr->m_idx == player_ptr->riding) && process_fall_off_horse(player_ptr, -1, false)) {
-        msg_print(_("地面に落とされた。", format("You have fallen from %s.", em_ptr->m_name)));
+        msg_print(_("地面に落とされた。", angband::format("You have fallen from %s.", em_ptr->m_name)));
     }
 
     delete_monster_idx(player_ptr, em_ptr->g_ptr->m_idx);
@@ -465,7 +465,7 @@ ProcessResult effect_monster_capture(PlayerType *player_ptr, EffectMonster *em_p
     auto capturable_hp = std::max(2, calcutate_capturable_hp(player_ptr, em_ptr->m_ptr, em_ptr->m_ptr->max_maxhp));
 
     if (threshold_hp < 2 || em_ptr->m_ptr->hp >= capturable_hp) {
-        msg_print(_("もっと弱らせないと。", format("You need to weaken %s more.", em_ptr->m_name)));
+        msg_print(_("もっと弱らせないと。", angband::format("You need to weaken %s more.", em_ptr->m_name)));
         em_ptr->skipped = true;
         return ProcessResult::PROCESS_CONTINUE;
     }
@@ -475,7 +475,7 @@ ProcessResult effect_monster_capture(PlayerType *player_ptr, EffectMonster *em_p
         return ProcessResult::PROCESS_TRUE;
     }
 
-    msg_print(_("うまく捕まえられなかった。", format("You failed to capture %s.", em_ptr->m_name)));
+    msg_print(_("うまく捕まえられなかった。", angband::format("You failed to capture %s.", em_ptr->m_name)));
     em_ptr->skipped = true;
     return ProcessResult::PROCESS_CONTINUE;
 }

--- a/src/effect/effect-monster-oldies.cpp
+++ b/src/effect/effect-monster-oldies.cpp
@@ -79,7 +79,7 @@ ProcessResult effect_monster_star_heal(PlayerType *player_ptr, EffectMonster *em
 
     if (em_ptr->m_ptr->maxhp < em_ptr->m_ptr->max_maxhp) {
         if (em_ptr->seen_msg) {
-            msg_print(_(format("%s^の強さが戻った。", em_ptr->m_name), format("%s^ recovers %s vitality.", em_ptr->m_name, em_ptr->m_poss)));
+            msg_print(_(angband::format("%s^の強さが戻った。", em_ptr->m_name), angband::format("%s^ recovers %s vitality.", em_ptr->m_name, em_ptr->m_poss)));
         }
         em_ptr->m_ptr->maxhp = em_ptr->m_ptr->max_maxhp;
     }
@@ -148,7 +148,7 @@ static void effect_monster_old_heal_recovery(PlayerType *player_ptr, EffectMonst
 
     if (em_ptr->m_ptr->is_fearful()) {
         if (em_ptr->seen_msg) {
-            msg_print(_(format("%s^は勇気を取り戻した。", em_ptr->m_name), format("%s^ recovers %s courage.", em_ptr->m_name, em_ptr->m_poss)));
+            msg_print(_(angband::format("%s^は勇気を取り戻した。", em_ptr->m_name), angband::format("%s^ recovers %s courage.", em_ptr->m_name, em_ptr->m_poss)));
         }
 
         (void)set_monster_monfear(player_ptr, em_ptr->g_ptr->m_idx, 0);

--- a/src/effect/effect-player.cpp
+++ b/src/effect/effect-player.cpp
@@ -213,7 +213,7 @@ bool affect_player(MONSTER_IDX who, PlayerType *player_ptr, concptr who_name, in
     SpellHex(player_ptr).store_vengeful_damage(ep_ptr->get_damage);
     if ((player_ptr->tim_eyeeye || SpellHex(player_ptr).is_spelling_specific(HEX_EYE_FOR_EYE)) && (ep_ptr->get_damage > 0) && !player_ptr->is_dead && (ep_ptr->who > 0)) {
         const auto m_name_self = monster_desc(player_ptr, ep_ptr->m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE | MD_OBJECTIVE);
-        msg_print(_(format("攻撃が%s自身を傷つけた！", ep_ptr->m_name), format("The attack of %s has wounded %s!", ep_ptr->m_name, m_name_self.data())));
+        msg_print(_(angband::format("攻撃が%s自身を傷つけた！", ep_ptr->m_name), angband::format("The attack of %s has wounded %s!", ep_ptr->m_name, m_name_self.data())));
         (*project)(player_ptr, 0, 0, ep_ptr->m_ptr->fy, ep_ptr->m_ptr->fx, ep_ptr->get_damage, AttributeType::MISSILE, PROJECT_KILL, std::nullopt);
         if (player_ptr->tim_eyeeye) {
             set_tim_eyeeye(player_ptr, player_ptr->tim_eyeeye - 5, true);

--- a/src/flavor/flavor-describer.cpp
+++ b/src/flavor/flavor-describer.cpp
@@ -149,7 +149,7 @@ static std::string describe_weapon_dice(PlayerType *player_ptr, const ItemEntity
 
     const auto is_bonus = (player_ptr->riding > 0) && item.is_lance();
     const auto bonus = is_bonus ? 2 : 0;
-    return format(" (%dd%d)", item.dd + bonus, item.ds);
+    return angband::format(" (%dd%d)", item.dd + bonus, item.ds);
 }
 
 static std::string describe_bow_power(PlayerType *player_ptr, const ItemEntity &item, const describe_option_type &opt)
@@ -161,7 +161,7 @@ static std::string describe_bow_power(PlayerType *player_ptr, const ItemEntity &
     }
 
     std::stringstream ss;
-    ss << format(" (x%d)", power);
+    ss << angband::format(" (x%d)", power);
 
     auto num_fire = 100;
     if (none_bits(opt.mode, OD_DEBUG)) {
@@ -177,7 +177,7 @@ static std::string describe_bow_power(PlayerType *player_ptr, const ItemEntity &
     }
 
     const auto fire_rate = item.get_bow_energy() / num_fire;
-    ss << format(" (%d.%dturn)", fire_rate / 100, fire_rate % 100);
+    ss << angband::format(" (%d.%dturn)", fire_rate / 100, fire_rate % 100);
 
     return ss.str();
 }
@@ -207,15 +207,15 @@ static std::string describe_accuracy_and_damage_bonus(const ItemEntity &item, co
     }
 
     if (should_show_slaying_bonus(item)) {
-        return format(" (%+d,%+d)", item.to_h, item.to_d);
+        return angband::format(" (%+d,%+d)", item.to_h, item.to_d);
     }
 
     if (item.to_h != 0) {
-        return format(" (%+d)", item.to_h);
+        return angband::format(" (%+d)", item.to_h);
     }
 
     if (item.to_d != 0) {
-        return format(" (%+d)", item.to_d);
+        return angband::format(" (%+d)", item.to_d);
     }
 
     return "";
@@ -241,7 +241,7 @@ static std::string describe_fire_energy(PlayerType *player_ptr, const ItemEntity
     const auto bow_bonus = bow.is_known() ? bow.to_h : 0;
     const auto percent = calc_crit_ratio_shot(player_ptr, ammo_bonus, bow_bonus);
 
-    ss << format("/%d.%02d%s", percent / 100, percent % 100, show_ammo_detail ? "% crit" : "%");
+    ss << angband::format("/%d.%02d%s", percent / 100, percent % 100, show_ammo_detail ? "% crit" : "%");
 
     return ss.str();
 }
@@ -295,20 +295,20 @@ static std::string describe_spike_detail(PlayerType *player_ptr)
     const auto energy_fire = 100 - player_ptr->lev;
     const auto avgdam_per_turn = 100 * avgdam / energy_fire;
 
-    return format(" (%d/%d)", avgdam, avgdam_per_turn);
+    return angband::format(" (%d/%d)", avgdam, avgdam_per_turn);
 }
 
 static std::string describe_known_item_ac(const ItemEntity &item)
 {
     if (should_show_ac_bonus(item)) {
-        return format(" [%d,%+d]", item.ac, item.to_a);
+        return angband::format(" [%d,%+d]", item.ac, item.to_a);
     }
 
     if (item.to_a == 0) {
         return "";
     }
 
-    return format(" [%+d]", item.to_a);
+    return angband::format(" [%+d]", item.to_a);
 }
 
 static std::string describe_ac(const ItemEntity &item, const describe_option_type &opt)
@@ -321,18 +321,18 @@ static std::string describe_ac(const ItemEntity &item, const describe_option_typ
         return "";
     }
 
-    return format(" [%d]", item.ac);
+    return angband::format(" [%d]", item.ac);
 }
 
 static std::string describe_charges_staff_wand(const ItemEntity &item)
 {
     std::string staff_num;
     if ((item.bi_key.tval() == ItemKindType::STAFF) && (item.number > 1)) {
-        staff_num = format("%dx ", item.number);
+        staff_num = angband::format("%dx ", item.number);
     }
 
     const auto charge_str = _("回分", (item.pval != 1 ? " charge" : " charges"));
-    return format(" (%s%d%s)", staff_num.data(), item.pval, charge_str);
+    return angband::format(" (%s%d%s)", staff_num.data(), item.pval, charge_str);
 }
 
 static std::string describe_charges_rod(const ItemEntity &item)
@@ -351,7 +351,7 @@ static std::string describe_charges_rod(const ItemEntity &item)
         num_of_charging = item.number;
     }
 
-    return format(" (%d%s)", num_of_charging, _("本 充填中", " charging"));
+    return angband::format(" (%d%s)", num_of_charging, _("本 充填中", " charging"));
 }
 
 static std::string describe_pval_type(const ItemEntity &item)
@@ -392,7 +392,7 @@ static std::string describe_pval(const ItemEntity &item)
     }
 
     const auto pval_type = describe_pval_type(item);
-    return format(" (%+d%s)", item.pval, pval_type.data());
+    return angband::format(" (%+d%s)", item.pval, pval_type.data());
 }
 
 static std::string describe_lamp_life(const ItemEntity &item)
@@ -496,7 +496,7 @@ static std::string describe_item_discount(const ItemEntity &item, bool hide_disc
         return "";
     }
 
-    return format("%d%s", item.discount, _("%引き", "% off"));
+    return angband::format("%d%s", item.discount, _("%引き", "% off"));
 }
 
 /*!
@@ -534,7 +534,7 @@ static std::string describe_inscription(const ItemEntity &item, const describe_o
     }
 
     const auto insc = ss.str();
-    return insc.empty() ? "" : format(" {%s}", insc.data());
+    return insc.empty() ? "" : angband::format(" {%s}", insc.data());
 }
 
 static describe_option_type decide_describe_option(const ItemEntity &item, BIT_FLAGS mode)

--- a/src/flavor/named-item-describer.cpp
+++ b/src/flavor/named-item-describer.cpp
@@ -142,7 +142,7 @@ static std::optional<std::string> describe_random_artifact_name_after_body_ja(co
 
     // "'foobar'" の foobar の部分を取り出し『foobar』と表記する
     // (英語版のセーブファイルのランダムアーティファクトを考慮)
-    return format("『%s』", name_sv.substr(1, name_sv.length() - 2).data());
+    return angband::format("『%s』", name_sv.substr(1, name_sv.length() - 2).data());
 }
 
 static std::string describe_fake_artifact_name_after_body_ja(const ItemEntity &item)
@@ -170,7 +170,7 @@ static std::string describe_fake_artifact_name_after_body_ja(const ItemEntity &i
     }
 
     auto str_aux = angband_strchr(item.inscription->data(), '#');
-    return format("『%s』", str_aux + 1);
+    return angband::format("『%s』", str_aux + 1);
 }
 
 /*!
@@ -422,14 +422,14 @@ std::string describe_named_item(PlayerType *player_ptr, const ItemEntity &item, 
 
 #ifdef JP
     if (item.is_smith() && none_bits(opt.mode, OD_BASE_NAME)) {
-        ss << format("鍛冶師%sの", player_ptr->name);
+        ss << angband::format("鍛冶師%sの", player_ptr->name);
     }
 
     ss << describe_unique_name_before_body_ja(item, opt);
 #endif
     if (item.is_spell_book()) {
         // svalは0から数えているので表示用に+1している
-        ss << format("Lv%d ", item.bi_key.sval().value() + 1);
+        ss << angband::format("Lv%d ", item.bi_key.sval().value() + 1);
     }
 
     ss << describe_body(item, opt, basename_sv, modstr);
@@ -438,7 +438,7 @@ std::string describe_named_item(PlayerType *player_ptr, const ItemEntity &item, 
     ss << describe_unique_name_after_body_ja(item, opt);
 #else
     if (item.is_smith() && none_bits(opt.mode, OD_BASE_NAME)) {
-        ss << format(" of %s the Smith", player_ptr->name);
+        ss << angband::format(" of %s the Smith", player_ptr->name);
     }
 
     ss << describe_unique_name_after_body_en(item, opt);

--- a/src/flavor/tval-description-switcher.cpp
+++ b/src/flavor/tval-description-switcher.cpp
@@ -36,13 +36,13 @@ static std::pair<std::string, std::string> describe_monster_ball(const ItemEntit
     }
 
 #ifdef JP
-    std::string modstr = format(" (%s)", r_ptr->name.data());
+    std::string modstr = angband::format(" (%s)", r_ptr->name.data());
 #else
     std::string modstr;
     if (r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE)) {
-        modstr = format(" (%s%s)", (is_a_vowel(r_ptr->name[0]) ? "an " : "a "), r_ptr->name.data());
+        modstr = angband::format(" (%s%s)", (is_a_vowel(r_ptr->name[0]) ? "an " : "a "), r_ptr->name.data());
     } else {
-        modstr = format(" (%s)", r_ptr->name.data());
+        modstr = angband::format(" (%s)", r_ptr->name.data());
     }
 #endif
     return { basename, modstr };
@@ -58,7 +58,7 @@ static std::pair<std::string, std::string> describe_statue(const ItemEntity &ite
 #else
     std::string modstr;
     if (r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE)) {
-        modstr = format("%s%s", (is_a_vowel(r_ptr->name[0]) ? "an " : "a "), r_ptr->name.data());
+        modstr = angband::format("%s%s", (is_a_vowel(r_ptr->name[0]) ? "an " : "a "), r_ptr->name.data());
     } else {
         modstr = r_ptr->name;
     }

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -91,7 +91,7 @@ static bool deal_damege_by_feat(PlayerType *player_ptr, grid_type *g_ptr, concpt
     if (player_ptr->levitation) {
         msg_print(msg_levitation);
         constexpr auto mes = _("%sの上に浮遊したダメージ", "flying over %s");
-        take_hit(player_ptr, DAMAGE_NOESCAPE, damage, format(mes, terrains_info[g_ptr->get_feat_mimic()].name.data()));
+        take_hit(player_ptr, DAMAGE_NOESCAPE, damage, angband::format(mes, terrains_info[g_ptr->get_feat_mimic()].name.data()));
 
         if (additional_effect != nullptr) {
             additional_effect(player_ptr, damage);

--- a/src/info-reader/feature-reader.cpp
+++ b/src/info-reader/feature-reader.cpp
@@ -263,7 +263,7 @@ errr init_feat_variables(void)
     /* Locked doors */
     FEAT_IDX i;
     for (i = 1; i < MAX_LJ_DOORS; i++) {
-        int16_t door = f_tag_to_index(format("LOCKED_DOOR_%d", i));
+        int16_t door = f_tag_to_index(angband::format("LOCKED_DOOR_%d", i));
         if (door < 0) {
             break;
         }
@@ -277,7 +277,7 @@ errr init_feat_variables(void)
 
     /* Jammed doors */
     for (i = 0; i < MAX_LJ_DOORS; i++) {
-        int16_t door = f_tag_to_index(format("JAMMED_DOOR_%d", i));
+        int16_t door = f_tag_to_index(angband::format("JAMMED_DOOR_%d", i));
         if (door < 0) {
             break;
         }
@@ -296,7 +296,7 @@ errr init_feat_variables(void)
 
     /* Locked glass doors */
     for (i = 1; i < MAX_LJ_DOORS; i++) {
-        int16_t door = f_tag_to_index(format("LOCKED_GLASS_DOOR_%d", i));
+        int16_t door = f_tag_to_index(angband::format("LOCKED_GLASS_DOOR_%d", i));
         if (door < 0) {
             break;
         }
@@ -310,7 +310,7 @@ errr init_feat_variables(void)
 
     /* Jammed glass doors */
     for (i = 0; i < MAX_LJ_DOORS; i++) {
-        int16_t door = f_tag_to_index(format("JAMMED_GLASS_DOOR_%d", i));
+        int16_t door = f_tag_to_index(angband::format("JAMMED_GLASS_DOOR_%d", i));
         if (door < 0) {
             break;
         }

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -577,7 +577,7 @@ static void dump_aux_home_museum(PlayerType *player_ptr, FILE *fff)
  */
 static std::string get_check_sum(void)
 {
-    return format("%02x%02x%02x%02x%02x%02x%02x%02x%02x", terrains_header.checksum, baseitems_header.checksum,
+    return angband::format("%02x%02x%02x%02x%02x%02x%02x%02x%02x", terrains_header.checksum, baseitems_header.checksum,
         artifacts_header.checksum, egos_header.checksum, monraces_header.checksum, dungeons_header.checksum,
         class_magics_header.checksum, class_skills_header.checksum, vaults_header.checksum);
 }

--- a/src/io/input-key-requester.cpp
+++ b/src/io/input-key-requester.cpp
@@ -182,7 +182,7 @@ char InputKeyRequestor::input_repeat_num()
         auto cmd = inkey();
         if ((cmd == 0x7F) || (cmd == KTRL('H'))) {
             command_arg = command_arg / 10;
-            prt(format(_("回数: %d", "Count: %d"), command_arg), 0, 0);
+            prt(angband::format(_("回数: %d", "Count: %d"), command_arg), 0, 0);
             continue;
         }
 
@@ -194,7 +194,7 @@ char InputKeyRequestor::input_repeat_num()
                 command_arg = command_arg * 10 + D2I(cmd);
             }
 
-            prt(format(_("回数: %d", "Count: %d"), command_arg), 0, 0);
+            prt(angband::format(_("回数: %d", "Count: %d"), command_arg), 0, 0);
             continue;
         }
 
@@ -214,12 +214,12 @@ bool InputKeyRequestor::process_repeat_num(short &cmd)
     cmd = this->input_repeat_num();
     if (command_arg == 0) {
         command_arg = 99;
-        prt(format(_("回数: %d", "Count: %d"), command_arg), 0, 0);
+        prt(angband::format(_("回数: %d", "Count: %d"), command_arg), 0, 0);
     }
 
     if (old_arg != 0) {
         command_arg = old_arg;
-        prt(format(_("回数: %d", "Count: %d"), command_arg), 0, 0);
+        prt(angband::format(_("回数: %d", "Count: %d"), command_arg), 0, 0);
     }
 
     if ((cmd != ' ') && (cmd != '\n') && (cmd != '\r')) {

--- a/src/io/read-pref-file.h
+++ b/src/io/read-pref-file.h
@@ -13,7 +13,7 @@ errr process_autopick_file(PlayerType *player_ptr, std::string_view name);
 errr process_histpref_file(PlayerType *player_ptr, std::string_view name);
 bool read_histpref(PlayerType *player_ptr);
 
-void auto_dump_printf(FILE *auto_dump_stream, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+void auto_dump_printf(FILE *auto_dump_stream, const char *fmt, ...) __attribute__((angband::format(printf, 2, 3)));
 bool open_auto_dump(FILE **fpp, const std::filesystem::path &path, std::string_view mark);
 void close_auto_dump(FILE **fpp, std::string_view mark);
 

--- a/src/io/record-play-movie.cpp
+++ b/src/io/record-play-movie.cpp
@@ -222,22 +222,22 @@ static int find_split(concptr str, int len)
 static errr send_text_to_chuukei_server(TERM_LEN x, TERM_LEN y, int len, TERM_COLOR col, concptr str)
 {
     if (len == 1) {
-        insert_ringbuf(format("s%c%c%c%c", x + 1, y + 1, col, *str));
+        insert_ringbuf(angband::format("s%c%c%c%c", x + 1, y + 1, col, *str));
         return (*old_text_hook)(x, y, len, col, str);
     }
 
     if (string_is_repeat(str, len)) {
         while (len > SPLIT_MAX) {
-            insert_ringbuf(format("n%c%c%c%c%c", x + 1, y + 1, SPLIT_MAX, col, *str));
+            insert_ringbuf(angband::format("n%c%c%c%c%c", x + 1, y + 1, SPLIT_MAX, col, *str));
             x += SPLIT_MAX;
             len -= SPLIT_MAX;
         }
 
         std::string formatted_text;
         if (len > 1) {
-            formatted_text = format("n%c%c%c%c%c", x + 1, y + 1, len, col, *str);
+            formatted_text = angband::format("n%c%c%c%c%c", x + 1, y + 1, len, col, *str);
         } else {
-            formatted_text = format("s%c%c%c%c", x + 1, y + 1, col, *str);
+            formatted_text = angband::format("s%c%c%c%c", x + 1, y + 1, col, *str);
         }
 
         insert_ringbuf(formatted_text);
@@ -253,24 +253,24 @@ static errr send_text_to_chuukei_server(TERM_LEN x, TERM_LEN y, int len, TERM_CO
 #endif
     while (len > SPLIT_MAX) {
         auto split_len = _(find_split(payload, SPLIT_MAX), SPLIT_MAX);
-        insert_ringbuf(format("t%c%c%c%c", x + 1, y + 1, split_len, col), std::string_view(payload, split_len));
+        insert_ringbuf(angband::format("t%c%c%c%c", x + 1, y + 1, split_len, col), std::string_view(payload, split_len));
         x += split_len;
         len -= split_len;
         payload += split_len;
     }
 
-    insert_ringbuf(format("t%c%c%c%c", x + 1, y + 1, len, col), std::string_view(payload, len));
+    insert_ringbuf(angband::format("t%c%c%c%c", x + 1, y + 1, len, col), std::string_view(payload, len));
     return (*old_text_hook)(x, y, len, col, str);
 }
 
 static errr send_wipe_to_chuukei_server(int x, int y, int len)
 {
     while (len > SPLIT_MAX) {
-        insert_ringbuf(format("w%c%c%c", x + 1, y + 1, SPLIT_MAX));
+        insert_ringbuf(angband::format("w%c%c%c", x + 1, y + 1, SPLIT_MAX));
         x += SPLIT_MAX;
         len -= SPLIT_MAX;
     }
-    insert_ringbuf(format("w%c%c%c", x + 1, y + 1, len));
+    insert_ringbuf(angband::format("w%c%c%c", x + 1, y + 1, len));
 
     return (*old_wipe_hook)(x, y, len);
 }
@@ -278,7 +278,7 @@ static errr send_wipe_to_chuukei_server(int x, int y, int len)
 static errr send_xtra_to_chuukei_server(int n, int v)
 {
     if (n == TERM_XTRA_CLEAR || n == TERM_XTRA_FRESH || n == TERM_XTRA_SHAPE) {
-        insert_ringbuf(format("x%c", n + 1));
+        insert_ringbuf(angband::format("x%c", n + 1));
 
         if (n == TERM_XTRA_FRESH) {
             insert_ringbuf("d", std::to_string(get_current_time() - epoch_time));
@@ -295,14 +295,14 @@ static errr send_xtra_to_chuukei_server(int n, int v)
 
 static errr send_curs_to_chuukei_server(int x, int y)
 {
-    insert_ringbuf(format("c%c%c", x + 1, y + 1));
+    insert_ringbuf(angband::format("c%c%c", x + 1, y + 1));
 
     return (*old_curs_hook)(x, y);
 }
 
 static errr send_bigcurs_to_chuukei_server(int x, int y)
 {
-    insert_ringbuf(format("C%c%c", x + 1, y + 1));
+    insert_ringbuf(angband::format("C%c%c", x + 1, y + 1));
 
     return (*old_bigcurs_hook)(x, y);
 }

--- a/src/io/write-diary.cpp
+++ b/src/io/write-diary.cpp
@@ -323,7 +323,7 @@ void exe_write_diary(PlayerType *player_ptr, DiaryKind dk, int num, std::string_
                       ? _("地上", "the surface")
                   : !(player_ptr->current_floor_ptr->dun_level + num)
                       ? _("地上", "the surface")
-                      : format(_("%d階", "level %d"), player_ptr->current_floor_ptr->dun_level + num);
+                      : angband::format(_("%d階", "level %d"), player_ptr->current_floor_ptr->dun_level + num);
         constexpr auto mes = _(" %2d:%02d %20s %sへ%s。\n", " %2d:%02d %20s %s %s.\n");
         fprintf(fff, mes, hour, min, note_level.data(), _(to.data(), note.data()), _(note.data(), to.data()));
         break;
@@ -383,7 +383,7 @@ void exe_write_diary(PlayerType *player_ptr, DiaryKind dk, int num, std::string_
         const auto &floor_ref = *player_ptr->current_floor_ptr;
         auto to = !floor_ref.is_in_dungeon()
                       ? _("地上", "the surface")
-                      : format(_("%d階(%s)", "level %d of %s"), floor.dun_level, floor.get_dungeon_definition().name.data());
+                      : angband::format(_("%d階(%s)", "level %d of %s"), floor.dun_level, floor.get_dungeon_definition().name.data());
         constexpr auto mes = _(" %2d:%02d %20s %sへとパターンの力で移動した。\n", " %2d:%02d %20s used Pattern to teleport to %s.\n");
         fprintf(fff, mes, hour, min, note_level.data(), to.data());
         break;

--- a/src/knowledge/knowledge-autopick.cpp
+++ b/src/knowledge/knowledge-autopick.cpp
@@ -60,9 +60,9 @@ void do_cmd_knowledge_autopick(PlayerType *player_ptr)
         }
 
         if (act & DO_DISPLAY) {
-            fprintf(fff, "%11s", format("[%s]", tmp).data());
+            fprintf(fff, "%11s", angband::format("[%s]", tmp).data());
         } else {
-            fprintf(fff, "%11s", format("(%s)", tmp).data());
+            fprintf(fff, "%11s", angband::format("(%s)", tmp).data());
         }
 
         tmp = autopick_line_from_entry(entry);

--- a/src/knowledge/knowledge-features.cpp
+++ b/src/knowledge/knowledge-features.cpp
@@ -71,12 +71,12 @@ static void display_feature_list(int col, int row, int per_page, FEAT_IDX *feat_
         attr = ((i + feat_top == feat_cur) ? TERM_L_BLUE : TERM_WHITE);
         c_prt(attr, f_ptr->name.data(), row_i, col);
         if (per_page == 1) {
-            c_prt(attr, format("(%s)", lighting_level_str[lighting_level]), row_i, col + 1 + f_ptr->name.size());
-            c_prt(attr, format("%02x/%02x", f_ptr->x_attr[lighting_level], (unsigned char)f_ptr->x_char[lighting_level]), row_i,
+            c_prt(attr, angband::format("(%s)", lighting_level_str[lighting_level]), row_i, col + 1 + f_ptr->name.size());
+            c_prt(attr, angband::format("%02x/%02x", f_ptr->x_attr[lighting_level], (unsigned char)f_ptr->x_char[lighting_level]), row_i,
                 f_idx_col - ((w_ptr->wizard || visual_only) ? 6 : 2));
         }
         if (w_ptr->wizard || visual_only) {
-            c_prt(attr, format("%d", f_idx), row_i, f_idx_col);
+            c_prt(attr, angband::format("%d", f_idx), row_i, f_idx_col);
         }
 
         term_queue_bigchar(lit_col[F_LIT_STANDARD], row_i, f_ptr->x_attr[F_LIT_STANDARD], f_ptr->x_char[F_LIT_STANDARD], 0, 0);
@@ -229,7 +229,7 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
             display_visual_list(max + 3, 7, browser_rows - 1, wid - (max + 3), attr_top, char_left);
         }
 
-        prt(format(_("<方向>%s, 'd'で標準光源効果%s, ESC", "<dir>%s, 'd' for default lighting%s, ESC"),
+        prt(angband::format(_("<方向>%s, 'd'で標準光源効果%s, ESC", "<dir>%s, 'd' for default lighting%s, ESC"),
                 visual_list ? _(", ENTERで決定, 'a'で対象明度変更", ", ENTER to accept, 'a' for lighting level")
                             : _(", 'v'でシンボル変更", ", 'v' for visuals"),
                 (attr_idx || char_idx) ? _(", 'c', 'p'でペースト", ", 'c', 'p' to paste") : _(", 'c'でコピー", ", 'c' to copy")),

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -197,11 +197,11 @@ static void display_object_list(int col, int row, int per_page, const std::vecto
         const auto o_name = is_flavor_only ? flavor_baseitem.flavor_name : strip_name(bi_id);
         c_prt(attr, o_name.data(), row + i, col);
         if (per_page == 1) {
-            c_prt(attr, format("%02x/%02x", flavor_baseitem.x_attr, flavor_baseitem.x_char), row + i, (w_ptr->wizard || visual_only) ? 64 : 68);
+            c_prt(attr, angband::format("%02x/%02x", flavor_baseitem.x_attr, flavor_baseitem.x_char), row + i, (w_ptr->wizard || visual_only) ? 64 : 68);
         }
 
         if (w_ptr->wizard || visual_only) {
-            c_prt(attr, format("%d", bi_id), row + i, 70);
+            c_prt(attr, angband::format("%d", bi_id), row + i, 70);
         }
 
         a = flavor_baseitem.x_attr;
@@ -306,7 +306,7 @@ void do_cmd_knowledge_objects(PlayerType *player_ptr, bool *need_redraw, bool vi
             clear_from(0);
 
 #ifdef JP
-            prt(format("%s - アイテム", !visual_only ? "知識" : "表示"), 2, 0);
+            prt(angband::format("%s - アイテム", !visual_only ? "知識" : "表示"), 2, 0);
             if (direct_k_idx < 0) {
                 prt("グループ", 4, 0);
             }
@@ -316,7 +316,7 @@ void do_cmd_knowledge_objects(PlayerType *player_ptr, bool *need_redraw, bool vi
             }
             prt("文字", 4, 74);
 #else
-            prt(format("%s - objects", !visual_only ? "Knowledge" : "Visuals"), 2, 0);
+            prt(angband::format("%s - objects", !visual_only ? "Knowledge" : "Visuals"), 2, 0);
             if (direct_k_idx < 0) {
                 prt("Group", 4, 0);
             }
@@ -380,11 +380,11 @@ void do_cmd_knowledge_objects(PlayerType *player_ptr, bool *need_redraw, bool vi
         auto &flavor_baseitem = !visual_only && baseitem.flavor ? baseitems_info[baseitem.flavor] : baseitem;
 
 #ifdef JP
-        prt(format("<方向>%s%s%s, ESC", (!visual_list && !visual_only) ? ", 'r'で詳細を見る" : "", visual_list ? ", ENTERで決定" : ", 'v'でシンボル変更",
+        prt(angband::format("<方向>%s%s%s, ESC", (!visual_list && !visual_only) ? ", 'r'で詳細を見る" : "", visual_list ? ", ENTERで決定" : ", 'v'でシンボル変更",
                 (attr_idx || char_idx) ? ", 'c', 'p'でペースト" : ", 'c'でコピー"),
             hgt - 1, 0);
 #else
-        prt(format("<dir>%s%s%s, ESC", (!visual_list && !visual_only) ? ", 'r' to recall" : "", visual_list ? ", ENTER to accept" : ", 'v' for visuals",
+        prt(angband::format("<dir>%s%s%s, ESC", (!visual_list && !visual_only) ? ", 'r' to recall" : "", visual_list ? ", ENTER to accept" : ", 'v' for visuals",
                 (attr_idx || char_idx) ? ", 'c', 'p' to paste" : ", 'c' to copy"),
             hgt - 1, 0);
 #endif

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -202,7 +202,7 @@ void do_cmd_knowledge_kill_count(PlayerType *player_ptr)
             if (dead) {
                 std::string details;
                 if (r_ptr->defeat_level && r_ptr->defeat_time) {
-                    details = format(_(" - レベル%2d - %d:%02d:%02d", " - level %2d - %d:%02d:%02d"), r_ptr->defeat_level, r_ptr->defeat_time / (60 * 60),
+                    details = angband::format(_(" - レベル%2d - %d:%02d:%02d", " - level %2d - %d:%02d:%02d"), r_ptr->defeat_level, r_ptr->defeat_time / (60 * 60),
                         (r_ptr->defeat_time / 60) % 60, r_ptr->defeat_time % 60);
                 }
 
@@ -263,18 +263,18 @@ static void display_monster_list(int col, int row, int per_page, const std::vect
         attr = ((i + mon_top == mon_cur) ? TERM_L_BLUE : TERM_WHITE);
         c_prt(attr, (r_ptr->name.data()), row + i, col);
         if (per_page == 1) {
-            c_prt(attr, format("%02x/%02x", r_ptr->x_attr, r_ptr->x_char), row + i, (w_ptr->wizard || visual_only) ? 56 : 61);
+            c_prt(attr, angband::format("%02x/%02x", r_ptr->x_attr, r_ptr->x_char), row + i, (w_ptr->wizard || visual_only) ? 56 : 61);
         }
 
         if (w_ptr->wizard || visual_only) {
-            c_prt(attr, format("%d", enum2i(r_idx)), row + i, 62);
+            c_prt(attr, angband::format("%d", enum2i(r_idx)), row + i, 62);
         }
 
         term_erase(69, row + i, 255);
         term_queue_bigchar(use_bigtile ? 69 : 70, row + i, r_ptr->x_attr, r_ptr->x_char, 0, 0);
         if (!visual_only) {
             if (r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE)) {
-                put_str(format("%5d", r_ptr->r_pkills), row + i, 73);
+                put_str(angband::format("%5d", r_ptr->r_pkills), row + i, 73);
             } else {
                 c_put_str((r_ptr->max_num == 0 ? TERM_L_DARK : TERM_WHITE), (r_ptr->max_num == 0 ? _("死亡", " dead") : _("生存", "alive")), row + i, 74);
             }
@@ -342,7 +342,7 @@ void do_cmd_knowledge_monsters(PlayerType *player_ptr, bool *need_redraw, bool v
     while (!flag) {
         if (redraw) {
             clear_from(0);
-            prt(format(_("%s - モンスター", "%s - monsters"), !visual_only ? _("知識", "Knowledge") : _("表示", "Visuals")), 2, 0);
+            prt(angband::format(_("%s - モンスター", "%s - monsters"), !visual_only ? _("知識", "Knowledge") : _("表示", "Visuals")), 2, 0);
             if (!direct_r_idx.has_value()) {
                 prt(_("グループ", "Group"), 4, 0);
             }
@@ -400,8 +400,8 @@ void do_cmd_knowledge_monsters(PlayerType *player_ptr, bool *need_redraw, bool v
             display_visual_list(max + 3, 7, browser_rows - 1, wid - (max + 3), attr_top, char_left);
         }
 
-        prt(format(_("%lu 種", "%lu Races"), r_idx_list.size()), 3, 26);
-        prt(format(_("<方向>%s%s%s, ESC", "<dir>%s%s%s, ESC"), (!visual_list && !visual_only) ? _(", 'r'で思い出を見る", ", 'r' to recall") : "",
+        prt(angband::format(_("%lu 種", "%lu Races"), r_idx_list.size()), 3, 26);
+        prt(angband::format(_("<方向>%s%s%s, ESC", "<dir>%s%s%s, ESC"), (!visual_list && !visual_only) ? _(", 'r'で思い出を見る", ", 'r' to recall") : "",
                 visual_list ? _(", ENTERで決定", ", ENTER to accept") : _(", 'v'でシンボル変更", ", 'v' for visuals"),
                 (attr_idx || char_idx) ? _(", 'c', 'p'でペースト", ", 'c', 'p' to paste") : _(", 'c'でコピー", ", 'c' to copy")),
             hgt - 1, 0);

--- a/src/knowledge/knowledge-quests.cpp
+++ b/src/knowledge/knowledge-quests.cpp
@@ -92,14 +92,14 @@ static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
                     const auto &monrace = monraces_info[quest.r_idx];
                     if (quest.max_num > 1) {
 #ifdef JP
-                        note = format(" - %d 体の%sを倒す。(あと %d 体)", (int)quest.max_num, monrace.name.data(), (int)(quest.max_num - quest.cur_num));
+                        note = angband::format(" - %d 体の%sを倒す。(あと %d 体)", (int)quest.max_num, monrace.name.data(), (int)(quest.max_num - quest.cur_num));
 #else
                         auto monster_name(monrace.name);
                         plural_aux(monster_name.data());
-                        note = format(" - kill %d %s, have killed %d.", (int)quest.max_num, monster_name.data(), (int)quest.cur_num);
+                        note = angband::format(" - kill %d %s, have killed %d.", (int)quest.max_num, monster_name.data(), (int)quest.cur_num);
 #endif
                     } else {
-                        note = format(_(" - %sを倒す。", " - kill %s."), monrace.name.data());
+                        note = angband::format(_(" - %sを倒す。", " - kill %s."), monrace.name.data());
                     }
 
                     break;
@@ -116,7 +116,7 @@ static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
                         item_name = describe_flavor(player_ptr, &item, OD_NAME_ONLY);
                     }
 
-                    note = format(_("\n   - %sを見つけ出す。", "\n   - Find %s."), item_name.data());
+                    note = angband::format(_("\n   - %sを見つけ出す。", "\n   - Find %s."), item_name.data());
                     break;
                 }
                 case QuestKindType::FIND_EXIT:
@@ -124,9 +124,9 @@ static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
                     break;
                 case QuestKindType::KILL_NUMBER:
 #ifdef JP
-                    note = format(" - %d 体のモンスターを倒す。(あと %d 体)", (int)quest.max_num, (int)(quest.max_num - quest.cur_num));
+                    note = angband::format(" - %d 体のモンスターを倒す。(あと %d 体)", (int)quest.max_num, (int)(quest.max_num - quest.cur_num));
 #else
-                    note = format(" - Kill %d monsters, have killed %d.", (int)quest.max_num, (int)quest.cur_num);
+                    note = angband::format(" - Kill %d monsters, have killed %d.", (int)quest.max_num, (int)quest.cur_num);
 #endif
                     break;
 
@@ -165,17 +165,17 @@ static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
         const auto &monrace = monraces_info[quest.r_idx];
         if (quest.max_num <= 1) {
             constexpr auto mes = _("  %s (%d 階) - %sを倒す。\n", "  %s (Dungeon level: %d)\n  Kill %s.\n");
-            rand_tmp_str = format(mes, quest.name.data(), (int)quest.level, monrace.name.data());
+            rand_tmp_str = angband::format(mes, quest.name.data(), (int)quest.level, monrace.name.data());
             continue;
         }
 
 #ifdef JP
-        rand_tmp_str = format("  %s (%d 階) - %d 体の%sを倒す。(あと %d 体)\n", quest.name.data(), (int)quest.level, (int)quest.max_num, monrace.name.data(),
+        rand_tmp_str = angband::format("  %s (%d 階) - %d 体の%sを倒す。(あと %d 体)\n", quest.name.data(), (int)quest.level, (int)quest.max_num, monrace.name.data(),
             (int)(quest.max_num - quest.cur_num));
 #else
         auto monster_name(monrace.name);
         plural_aux(monster_name.data());
-        rand_tmp_str = format("  %s (Dungeon level: %d)\n  Kill %d %s, have killed %d.\n", quest.name.data(), (int)quest.level, (int)quest.max_num,
+        rand_tmp_str = angband::format("  %s (Dungeon level: %d)\n  Kill %d %s, have killed %d.\n", quest.name.data(), (int)quest.level, (int)quest.max_num,
             monster_name.data(), (int)quest.cur_num);
 #endif
     }
@@ -207,7 +207,7 @@ static bool do_cmd_knowledge_quests_aux(PlayerType *player_ptr, FILE *fff, Quest
         }
     }
 
-    std::string playtime_str = format("%02d:%02d:%02d", quest.comptime / (60 * 60), (quest.comptime / 60) % 60, quest.comptime % 60);
+    std::string playtime_str = angband::format("%02d:%02d:%02d", quest.comptime / (60 * 60), (quest.comptime / 60) % 60, quest.comptime % 60);
 
     auto fputs_name_remain = [fff](const auto &name) {
         for (auto i = 1U; i < name.size(); ++i) {

--- a/src/knowledge/knowledge-uniques.cpp
+++ b/src/knowledge/knowledge-uniques.cpp
@@ -113,7 +113,7 @@ static void display_uniques(unique_list_type *unique_list_ptr, FILE *fff)
         std::string details;
 
         if (r_ptr->defeat_level && r_ptr->defeat_time) {
-            details = format(_(" - レベル%2d - %d:%02d:%02d", " - level %2d - %d:%02d:%02d"), r_ptr->defeat_level, r_ptr->defeat_time / (60 * 60),
+            details = angband::format(_(" - レベル%2d - %d:%02d:%02d", " - level %2d - %d:%02d:%02d"), r_ptr->defeat_level, r_ptr->defeat_time / (60 * 60),
                 (r_ptr->defeat_time / 60) % 60, r_ptr->defeat_time % 60);
         }
 

--- a/src/load/info-loader.cpp
+++ b/src/load/info-loader.cpp
@@ -60,7 +60,7 @@ void rd_version_info(void)
         }
     }
 
-    load_note(format(_("バージョン %d.%d.%d のセーブデータ(SAVE%u形式)をロード中...", "Loading a version %d.%d.%d savefile (SAVE%u format)..."),
+    load_note(angband::format(_("バージョン %d.%d.%d のセーブデータ(SAVE%u形式)をロード中...", "Loading a version %d.%d.%d savefile (SAVE%u format)..."),
         w_ptr->h_ver_major, w_ptr->h_ver_minor, w_ptr->h_ver_patch,
         loading_savefile_version));
 }

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -129,7 +129,7 @@ static errr load_hp(PlayerType *player_ptr)
 {
     auto tmp16u = rd_u16b();
     if (tmp16u > PY_MAX_LEVEL) {
-        load_note(format(_("ヒットポイント配列が大きすぎる(%u)！", "Too many (%u) hitpoint entries!"), tmp16u));
+        load_note(angband::format(_("ヒットポイント配列が大きすぎる(%u)！", "Too many (%u) hitpoint entries!"), tmp16u));
         return 25;
     }
 

--- a/src/load/old/load-v1-5-0.cpp
+++ b/src/load/old/load-v1-5-0.cpp
@@ -730,7 +730,7 @@ errr rd_dungeon_old(PlayerType *player_ptr)
     uint16_t limit;
     limit = rd_u16b();
     if (limit > w_ptr->max_o_idx) {
-        load_note(format(_("アイテムの配列が大きすぎる(%d)！", "Too many (%d) object entries!"), limit));
+        load_note(angband::format(_("アイテムの配列が大きすぎる(%d)！", "Too many (%d) object entries!"), limit));
         return 151;
     }
 
@@ -738,7 +738,7 @@ errr rd_dungeon_old(PlayerType *player_ptr)
     for (int i = 1; i < limit; i++) {
         OBJECT_IDX o_idx = o_pop(floor_ptr);
         if (i != o_idx) {
-            load_note(format(_("アイテム配置エラー (%d <> %d)", "Object allocation error (%d <> %d)"), i, o_idx));
+            load_note(angband::format(_("アイテム配置エラー (%d <> %d)", "Object allocation error (%d <> %d)"), i, o_idx));
             return 152;
         }
 
@@ -750,7 +750,7 @@ errr rd_dungeon_old(PlayerType *player_ptr)
 
     limit = rd_u16b();
     if (limit > w_ptr->max_m_idx) {
-        load_note(format(_("モンスターの配列が大きすぎる(%d)！", "Too many (%d) monster entries!"), limit));
+        load_note(angband::format(_("モンスターの配列が大きすぎる(%d)！", "Too many (%d) monster entries!"), limit));
         return 161;
     }
 
@@ -758,7 +758,7 @@ errr rd_dungeon_old(PlayerType *player_ptr)
     for (int i = 1; i < limit; i++) {
         auto m_idx = m_pop(floor_ptr);
         if (i != m_idx) {
-            load_note(format(_("モンスター配置エラー (%d <> %d)", "Monster allocation error (%d <> %d)"), i, m_idx));
+            load_note(angband::format(_("モンスター配置エラー (%d <> %d)", "Monster allocation error (%d <> %d)"), i, m_idx));
             return 162;
         }
 

--- a/src/load/quest-loader.cpp
+++ b/src/load/quest-loader.cpp
@@ -24,7 +24,7 @@ errr load_town(void)
         return 0;
     }
 
-    load_note(format(_("町が多すぎる(%u)！", "Too many (%u) towns!"), max_towns_load));
+    load_note(angband::format(_("町が多すぎる(%u)！", "Too many (%u) towns!"), max_towns_load));
     return 23;
 }
 

--- a/src/load/world-loader.cpp
+++ b/src/load/world-loader.cpp
@@ -189,7 +189,7 @@ errr analyze_wilderness(void)
     auto wild_y_size = rd_s32b();
 
     if ((wild_x_size > w_ptr->max_wild_x) || (wild_y_size > w_ptr->max_wild_y)) {
-        load_note(format(_("荒野が大きすぎる(%u/%u)！", "Wilderness is too big (%u/%u)!"), wild_x_size, wild_y_size));
+        load_note(angband::format(_("荒野が大きすぎる(%u/%u)！", "Wilderness is too big (%u/%u)!"), wild_x_size, wild_y_size));
         return 23;
     }
 

--- a/src/lore/monster-lore.cpp
+++ b/src/lore/monster-lore.cpp
@@ -194,7 +194,7 @@ void process_monster_lore(PlayerType *player_ptr, MonsterRaceId r_idx, monster_l
     display_lore_this(player_ptr, lore_ptr);
     display_monster_aura(lore_ptr);
     if (lore_ptr->flags2 & RF2_REFLECTING) {
-        hooked_roff(format(_("%s^は矢の呪文を跳ね返す。", "%s^ reflects bolt spells.  "), Who::who(lore_ptr->msex)));
+        hooked_roff(angband::format(_("%s^は矢の呪文を跳ね返す。", "%s^ reflects bolt spells.  "), Who::who(lore_ptr->msex)));
     }
 
     display_monster_collective(lore_ptr);

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -428,7 +428,7 @@ static void save_prefs(void)
     angband_dir_str = angband_dir_str.substr(0, path_length);
     const auto savefile_str = savefile.string();
     if (angband_dir_str == savefile_str) {
-        const auto relative_path = format(".\\%s", (savefile_str.data() + path_length));
+        const auto relative_path = angband::format(".\\%s", (savefile_str.data() + path_length));
         WritePrivateProfileStringA("Angband", "SaveFile", relative_path.data(), ini_file);
     } else {
         WritePrivateProfileStringA("Angband", "SaveFile", savefile_str.data(), ini_file);

--- a/src/market/arena.cpp
+++ b/src/market/arena.cpp
@@ -299,7 +299,7 @@ bool monster_arena_comm(PlayerType *player_ptr)
         }
 
         constexpr auto fmt = _("%d) %-58s  %4ld.%02ld倍", "%d) %-58s  %4ld.%02ld");
-        prt(format(fmt, i + 1, name.data(), (long int)mon_odds[i] / 100, (long int)mon_odds[i] % 100), 5 + i, 1);
+        prt(angband::format(fmt, i + 1, name.data(), (long int)mon_odds[i] / 100, (long int)mon_odds[i] % 100), 5 + i, 1);
     }
 
     prt(_("どれに賭けますか:", "Which monster: "), 0, 0);
@@ -340,7 +340,7 @@ bool monster_arena_comm(PlayerType *player_ptr)
      * the int16_t value returned by get_quantity().
      */
     out_val[0] = '\0';
-    if (!get_string(format(_("賭け金 (1-%ld)？", "Your wager (1-%ld) ? "), (long int)maxbet), out_val, 32)) {
+    if (!get_string(angband::format(_("賭け金 (1-%ld)？", "Your wager (1-%ld) ? "), (long int)maxbet), out_val, 32)) {
         screen_load();
         return false;
     }

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -58,7 +58,7 @@ bool exchange_cash(PlayerType *player_ptr)
 
         change = true;
         const auto item_name = describe_flavor(player_ptr, item_ptr, 0);
-        if (!get_check(format(_("%s を換金しますか？", "Convert %s into money? "), item_name.data()))) {
+        if (!get_check(angband::format(_("%s を換金しますか？", "Convert %s into money? "), item_name.data()))) {
             continue;
         }
 
@@ -77,7 +77,7 @@ bool exchange_cash(PlayerType *player_ptr)
 
         change = true;
         const auto item_name = describe_flavor(player_ptr, item_ptr, 0);
-        if (!get_check(format(_("%s を換金しますか？", "Convert %s into money? "), item_name.data()))) {
+        if (!get_check(angband::format(_("%s を換金しますか？", "Convert %s into money? "), item_name.data()))) {
             continue;
         }
 
@@ -96,7 +96,7 @@ bool exchange_cash(PlayerType *player_ptr)
 
         change = true;
         const auto item_name = describe_flavor(player_ptr, item_ptr, 0);
-        if (!get_check(format(_("%s を換金しますか？", "Convert %s into money? "), item_name.data()))) {
+        if (!get_check(angband::format(_("%s を換金しますか？", "Convert %s into money? "), item_name.data()))) {
             continue;
         }
 
@@ -115,7 +115,7 @@ bool exchange_cash(PlayerType *player_ptr)
 
         change = true;
         const auto item_name = describe_flavor(player_ptr, item_ptr, 0);
-        if (!get_check(format(_("%s を換金しますか？", "Convert %s into money? "), item_name.data()))) {
+        if (!get_check(angband::format(_("%s を換金しますか？", "Convert %s into money? "), item_name.data()))) {
             continue;
         }
 
@@ -135,7 +135,7 @@ bool exchange_cash(PlayerType *player_ptr)
 
         change = true;
         const auto item_name = describe_flavor(player_ptr, item_ptr, 0);
-        if (!get_check(format(_("%s を換金しますか？", "Convert %s into money? "), item_name.data()))) {
+        if (!get_check(angband::format(_("%s を換金しますか？", "Convert %s into money? "), item_name.data()))) {
             continue;
         }
 
@@ -162,7 +162,7 @@ bool exchange_cash(PlayerType *player_ptr)
             ItemEntity forge;
 
             const auto item_name = describe_flavor(player_ptr, item_ptr, 0);
-            if (!get_check(format(_("%sを渡しますか？", "Hand %s over? "), item_name.data()))) {
+            if (!get_check(angband::format(_("%sを渡しますか？", "Hand %s over? "), item_name.data()))) {
                 continue;
             }
 
@@ -173,7 +173,7 @@ bool exchange_cash(PlayerType *player_ptr)
             auto num = static_cast<int>(std::count_if(std::begin(w_ptr->bounties), std::end(w_ptr->bounties),
                 [](const auto &b_ref) { return b_ref.is_achieved; }));
 
-            msg_print(_(format("これで合計 %d ポイント獲得しました。", num), format("You earned %d point%s total.", num, (num > 1 ? "s" : ""))));
+            msg_print(_(angband::format("これで合計 %d ポイント獲得しました。", num), angband::format("You earned %d point%s total.", num, (num > 1 ? "s" : ""))));
 
             (&forge)->prep(lookup_baseitem_id(prize_list[num - 1]));
             ItemMagicApplier(player_ptr, &forge, player_ptr->current_floor_ptr->object_level, AM_NO_FIXED_ART).execute();
@@ -215,9 +215,9 @@ void today_target(PlayerType *player_ptr)
 
     clear_bldg(4, 18);
     c_put_str(TERM_YELLOW, _("本日の賞金首", "Wanted monster that changes from day to day"), 5, 10);
-    c_put_str(TERM_YELLOW, format(_("ターゲット： %s", "target: %s"), r_ptr->name.data()), 6, 10);
-    prt(format(_("死体 ---- $%d", "corpse   ---- $%d"), (int)r_ptr->level * 50 + 100), 8, 10);
-    prt(format(_("骨   ---- $%d", "skeleton ---- $%d"), (int)r_ptr->level * 30 + 60), 9, 10);
+    c_put_str(TERM_YELLOW, angband::format(_("ターゲット： %s", "target: %s"), r_ptr->name.data()), 6, 10);
+    prt(angband::format(_("死体 ---- $%d", "corpse   ---- $%d"), (int)r_ptr->level * 50 + 100), 8, 10);
+    prt(angband::format(_("骨   ---- $%d", "skeleton ---- $%d"), (int)r_ptr->level * 30 + 60), 9, 10);
     player_ptr->knows_daily_bounty = true;
 }
 
@@ -252,7 +252,7 @@ void show_bounty(void)
         auto color = is_achieved ? TERM_RED : TERM_WHITE;
         auto done_mark = is_achieved ? _("(済)", "(done)") : "";
 
-        c_prt(color, format("%s %s", r_ptr->name.data(), done_mark), y + 7, 10);
+        c_prt(color, angband::format("%s %s", r_ptr->name.data(), done_mark), y + 7, 10);
 
         y = (y + 1) % 10;
         if (!y && (i < std::size(w_ptr->bounties) - 1)) {

--- a/src/market/building-craft-armor.cpp
+++ b/src/market/building-craft-armor.cpp
@@ -45,8 +45,8 @@ bool eval_ac(ARMOUR_CLASS iAC)
     screen_save();
     clear_bldg(0, 22);
 
-    put_str(format(_("あなたの現在のAC: %3d", "Your current AC : %3d"), iAC), row++, 0);
-    put_str(format(_("ダメージ軽減率  : %3d%%", "Protection rate : %3d%%"), protection), row++, 0);
+    put_str(angband::format(_("あなたの現在のAC: %3d", "Your current AC : %3d"), iAC), row++, 0);
+    put_str(angband::format(_("ダメージ軽減率  : %3d%%", "Protection rate : %3d%%"), protection), row++, 0);
     row++;
 
     put_str(_("敵のレベル      :", "Level of Monster:"), row + 0, 0);
@@ -58,15 +58,15 @@ bool eval_ac(ARMOUR_CLASS iAC)
         int dodge; /* 回避率(%) */
         int average; /* ダメージ期待値 */
 
-        put_str(format("%3d", lvl), row + 0, col);
+        put_str(angband::format("%3d", lvl), row + 0, col);
 
         /* 回避率を計算 */
         dodge = 5 + (std::min(100, 100 * (iAC * 3 / 4) / quality) * 9 + 5) / 10;
-        put_str(format("%3d%%", dodge), row + 1, col);
+        put_str(angband::format("%3d%%", dodge), row + 1, col);
 
         /* 100点の攻撃に対してのダメージ期待値を計算 */
         average = (100 - dodge) * (100 - protection) / 100;
-        put_str(format("%3d", average), row + 2, col);
+        put_str(angband::format("%3d", average), row + 2, col);
     }
 
     display_wrap_around(memo, 70, row + 4, 4);

--- a/src/market/building-craft-fix.cpp
+++ b/src/market/building-craft-fix.cpp
@@ -115,7 +115,7 @@ static std::pair<bool, ItemEntity *> select_repairing_broken_weapon(PlayerType *
 static void display_reparing_weapon(PlayerType *player_ptr, ItemEntity *o_ptr, const int row)
 {
     const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
-    prt(format(_("修復する武器　： %s", "Repairing: %s"), item_name.data()), row + 3, 2);
+    prt(angband::format(_("修復する武器　： %s", "Repairing: %s"), item_name.data()), row + 3, 2);
 }
 
 static void display_repair_success_message(PlayerType *player_ptr, ItemEntity *o_ptr, const int cost)
@@ -160,9 +160,9 @@ static PRICE repair_broken_weapon_aux(PlayerType *player_ptr, PRICE bcost)
     }
 
     const auto item_name = describe_flavor(player_ptr, mo_ptr, OD_NAME_ONLY);
-    prt(format(_("材料とする武器： %s", "Material : %s"), item_name.data()), row + 4, 2);
+    prt(angband::format(_("材料とする武器： %s", "Material : %s"), item_name.data()), row + 4, 2);
     const auto cost = bcost + object_value_real(o_ptr) * 2;
-    if (!get_check(format(_("＄%dかかりますがよろしいですか？ ", "Costs %d gold, okay? "), cost))) {
+    if (!get_check(angband::format(_("＄%dかかりますがよろしいですか？ ", "Costs %d gold, okay? "), cost))) {
         return 0;
     }
 

--- a/src/market/building-craft-weapon.cpp
+++ b/src/market/building-craft-weapon.cpp
@@ -102,7 +102,7 @@ static void show_weapon_dmg(int r, int c, int mindice, int maxdice, int blows, i
     c_put_str(color, attr, r, c);
     int mindam = blows * (mindice + dam_bonus);
     int maxdam = blows * (maxdice + dam_bonus);
-    put_str(format(_("１ターン: %d-%d ダメージ", "Attack: %d-%d damage"), mindam, maxdam), r, c + 8);
+    put_str(angband::format(_("１ターン: %d-%d ダメージ", "Attack: %d-%d damage"), mindam, maxdam), r, c + 8);
 }
 
 /*!
@@ -315,10 +315,10 @@ static void list_weapon(PlayerType *player_ptr, ItemEntity *o_ptr, TERM_LEN row,
     const auto hit_reliability = player_ptr->skill_thn + (player_ptr->to_h[0] + o_ptr->to_h) * BTH_PLUS_ADJ;
     const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
     c_put_str(TERM_YELLOW, item_name, row, col);
-    put_str(format(_("攻撃回数: %d", "Number of Blows: %d"), player_ptr->num_blow[0]), row + 1, col);
+    put_str(angband::format(_("攻撃回数: %d", "Number of Blows: %d"), player_ptr->num_blow[0]), row + 1, col);
 
     put_str(_("命中率:  0  50 100 150 200 (敵のAC)", "To Hit:  0  50 100 150 200 (AC)"), row + 2, col);
-    put_str(format("        %2d  %2d  %2d  %2d  %2d (%%)",
+    put_str(angband::format("        %2d  %2d  %2d  %2d  %2d (%%)",
                 (int)hit_chance(player_ptr, hit_reliability, 0),
                 (int)hit_chance(player_ptr, hit_reliability, 50),
                 (int)hit_chance(player_ptr, hit_reliability, 100),
@@ -327,12 +327,12 @@ static void list_weapon(PlayerType *player_ptr, ItemEntity *o_ptr, TERM_LEN row,
         row + 3, col);
     c_put_str(TERM_YELLOW, _("可能なダメージ:", "Possible Damage:"), row + 5, col);
 
-    put_str(format(_("攻撃一回につき %d-%d", "One Strike: %d-%d damage"),
+    put_str(angband::format(_("攻撃一回につき %d-%d", "One Strike: %d-%d damage"),
                 (int)(eff_dd + o_ptr->to_d + player_ptr->to_d[0]),
                 (int)(eff_ds * eff_dd + o_ptr->to_d + player_ptr->to_d[0])),
         row + 6, col + 1);
 
-    put_str(format(_("１ターンにつき %d-%d", "One Attack: %d-%d damage"),
+    put_str(angband::format(_("１ターンにつき %d-%d", "One Attack: %d-%d damage"),
                 (int)(player_ptr->num_blow[0] * (eff_dd + o_ptr->to_d + player_ptr->to_d[0])),
                 (int)(player_ptr->num_blow[0] * (eff_ds * eff_dd + o_ptr->to_d + player_ptr->to_d[0]))),
         row + 7, col + 1);
@@ -399,11 +399,11 @@ PRICE compare_weapons(PlayerType *player_ptr, PRICE bcost)
 
         w_ptr->character_xtra = old_character_xtra;
 #ifdef JP
-        put_str(format("[ 比較対象: 's'で変更 ($%d) ]", cost), 1, (wid + mgn));
+        put_str(angband::format("[ 比較対象: 's'で変更 ($%d) ]", cost), 1, (wid + mgn));
         put_str("(一番高いダメージが適用されます。複数の倍打効果は足し算されません。)", row + 4, 0);
         prt("現在の技量から判断すると、あなたの武器は以下のような威力を発揮します:", 0, 0);
 #else
-        put_str(format("[ 's' Select secondary weapon($%d) ]", cost), 1, (wid + mgn));
+        put_str(angband::format("[ 's' Select secondary weapon($%d) ]", cost), 1, (wid + mgn));
         put_str("(Only highest damage applies per monster. Special damage not cumulative.)", row + 4, 0);
         prt("Based on your current abilities, here is what your weapons will do", 0, 0);
 #endif

--- a/src/market/building-enchanter.cpp
+++ b/src/market/building-enchanter.cpp
@@ -26,8 +26,8 @@ bool enchant_item(PlayerType *player_ptr, PRICE cost, HIT_PROB to_hit, int to_da
 {
     clear_bldg(4, 18);
     int maxenchant = (player_ptr->lev / 5);
-    prt(format(_("現在のあなたの技量だと、+%d まで改良できます。", "  Based on your skill, we can improve up to +%d."), maxenchant), 5, 0);
-    prt(format(_(" 改良の料金は一個につき＄%d です。", "  The price for the service is %d gold per item."), cost), 7, 0);
+    prt(angband::format(_("現在のあなたの技量だと、+%d まで改良できます。", "  Based on your skill, we can improve up to +%d."), maxenchant), 5, 0);
+    prt(angband::format(_(" 改良の料金は一個につき＄%d です。", "  The price for the service is %d gold per item."), cost), 7, 0);
 
     const auto q = _("どのアイテムを改良しますか？", "Improve which item? ");
     const auto s = _("改良できるものがありません。", "You have nothing to improve.");

--- a/src/market/building-monster.cpp
+++ b/src/market/building-monster.cpp
@@ -73,11 +73,11 @@ bool research_mon(PlayerType *player_ptr)
             return false;
         }
 
-        buf = format(_("名前:%sにマッチ", "Monsters' names with \"%s\""), temp);
+        buf = angband::format(_("名前:%sにマッチ", "Monsters' names with \"%s\""), temp);
     } else if (ident_info[ident_i]) {
-        buf = format("%c - %s.", sym, ident_info[ident_i] + 2);
+        buf = angband::format("%c - %s.", sym, ident_info[ident_i] + 2);
     } else {
-        buf = format("%c - %s", sym, _("無効な文字", "Unknown Symbol"));
+        buf = angband::format("%c - %s", sym, _("無効な文字", "Unknown Symbol"));
     }
 
     /* Display the result */

--- a/src/market/building-quest.cpp
+++ b/src/market/building-quest.cpp
@@ -55,7 +55,7 @@ static void print_questinfo(PlayerType *player_ptr, QuestId questnum, bool do_in
 
     const auto &quest_list = QuestList::get_instance();
     const auto *q_ptr = &quest_list[questnum];
-    prt(format(_("クエスト情報 (危険度: %d 階相当)", "Quest Information (Danger level: %d)"), (int)q_ptr->level), 5, 0);
+    prt(angband::format(_("クエスト情報 (危険度: %d 階相当)", "Quest Information (Danger level: %d)"), (int)q_ptr->level), 5, 0);
     prt(q_ptr->name, 7, 0);
 
     for (int i = 0; i < 10; i++) {
@@ -91,7 +91,7 @@ void castle_quest(PlayerType *player_ptr)
         put_str(_("CTRL-Qを使えばクエストの状態がチェックできます。", "Use CTRL-Q to check the status of your quest."), 9, 0);
 
         get_questinfo(player_ptr, q_index, false);
-        put_str(format(_("現在のクエスト「%s」", "Current quest is '%s'."), q_ptr->name.data()), 11, 0);
+        put_str(angband::format(_("現在のクエスト「%s」", "Current quest is '%s'."), q_ptr->name.data()), 11, 0);
 
         if (q_ptr->type != QuestKindType::KILL_LEVEL || q_ptr->dungeon == 0) {
             put_str(_("クエストを終わらせたら戻って来て下さい。", "Return when you have completed your quest."), 12, 0);

--- a/src/market/building-recharger.cpp
+++ b/src/market/building-recharger.cpp
@@ -117,9 +117,9 @@ void building_recharge(PlayerType *player_ptr)
 
     if (tval == ItemKindType::ROD) {
 #ifdef JP
-        if (get_check(format("そのロッドを＄%d で再充填しますか？", price)))
+        if (get_check(angband::format("そのロッドを＄%d で再充填しますか？", price)))
 #else
-        if (get_check(format("Recharge the %s for %d gold? ", ((o_ptr->number > 1) ? "rods" : "rod"), price)))
+        if (get_check(angband::format("Recharge the %s for %d gold? ", ((o_ptr->number > 1) ? "rods" : "rod"), price)))
 #endif
 
         {
@@ -136,7 +136,7 @@ void building_recharge(PlayerType *player_ptr)
         }
 
         const auto mes = _("一回分＄%d で何回分充填しますか？", "Add how many charges for %d gold apiece? ");
-        const auto charges = get_quantity(format(mes, price), std::min(player_ptr->au / price, max_charges));
+        const auto charges = get_quantity(angband::format(mes, price), std::min(player_ptr->au / price, max_charges));
         if (charges < 1) {
             return;
         }
@@ -228,7 +228,7 @@ void building_recharge_all(PlayerType *player_ptr)
         return;
     }
 
-    if (!get_check(format(_("すべてのアイテムを ＄%d で再充填しますか？", "Recharge all items for %d gold? "), total_cost))) {
+    if (!get_check(angband::format(_("すべてのアイテムを ＄%d で再充填しますか？", "Recharge all items for %d gold? "), total_cost))) {
         return;
     }
 

--- a/src/market/building-service.cpp
+++ b/src/market/building-service.cpp
@@ -85,7 +85,7 @@ void display_buikding_service(PlayerType *player_ptr, building_type *bldg)
     byte action_color;
 
     term_clear();
-    prt(format("%s (%s) %35s", bldg->owner_name, bldg->owner_race, bldg->name), 2, 1);
+    prt(angband::format("%s (%s) %35s", bldg->owner_name, bldg->owner_race, bldg->name), 2, 1);
 
     for (int i = 0; i < 8; i++) {
         if (!bldg->letters[i]) {
@@ -98,13 +98,13 @@ void display_buikding_service(PlayerType *player_ptr, building_type *bldg)
                 action_color = TERM_WHITE;
             } else if (is_owner(player_ptr, bldg)) {
                 action_color = TERM_YELLOW;
-                buff = format(_("($%ld)", "(%ldgp)"), (long int)bldg->member_costs[i]);
+                buff = angband::format(_("($%ld)", "(%ldgp)"), (long int)bldg->member_costs[i]);
             } else {
                 action_color = TERM_YELLOW;
-                buff = format(_("($%ld)", "(%ldgp)"), (long int)bldg->other_costs[i]);
+                buff = angband::format(_("($%ld)", "(%ldgp)"), (long int)bldg->other_costs[i]);
             }
 
-            c_put_str(action_color, format(" %c) %s %s", bldg->letters[i], bldg->act_names[i], buff.data()), 19 + (i / 2), 35 * (i % 2));
+            c_put_str(action_color, angband::format(" %c) %s %s", bldg->letters[i], bldg->act_names[i], buff.data()), 19 + (i / 2), 35 * (i % 2));
             continue;
         }
 
@@ -116,13 +116,13 @@ void display_buikding_service(PlayerType *player_ptr, building_type *bldg)
                 action_color = TERM_WHITE;
             } else if (is_owner(player_ptr, bldg)) {
                 action_color = TERM_YELLOW;
-                buff = format(_("($%ld)", "(%ldgp)"), (long int)bldg->member_costs[i]);
+                buff = angband::format(_("($%ld)", "(%ldgp)"), (long int)bldg->member_costs[i]);
             } else {
                 action_color = TERM_YELLOW;
-                buff = format(_("($%ld)", "(%ldgp)"), (long int)bldg->other_costs[i]);
+                buff = angband::format(_("($%ld)", "(%ldgp)"), (long int)bldg->other_costs[i]);
             }
 
-            c_put_str(action_color, format(" %c) %s %s", bldg->letters[i], bldg->act_names[i], buff.data()), 19 + (i / 2), 35 * (i % 2));
+            c_put_str(action_color, angband::format(" %c) %s %s", bldg->letters[i], bldg->act_names[i], buff.data()), 19 + (i / 2), 35 * (i % 2));
             continue;
         }
 
@@ -131,12 +131,12 @@ void display_buikding_service(PlayerType *player_ptr, building_type *bldg)
             buff = _("(閉店)", "(closed)");
         } else if (bldg->member_costs[i] != 0) {
             action_color = TERM_YELLOW;
-            buff = format(_("($%ld)", "(%ldgp)"), (long int)bldg->member_costs[i]);
+            buff = angband::format(_("($%ld)", "(%ldgp)"), (long int)bldg->member_costs[i]);
         } else {
             action_color = TERM_WHITE;
         }
 
-        c_put_str(action_color, format(" %c) %s %s", bldg->letters[i], bldg->act_names[i], buff.data()), 19 + (i / 2), 35 * (i % 2));
+        c_put_str(action_color, angband::format(" %c) %s %s", bldg->letters[i], bldg->act_names[i], buff.data()), 19 + (i / 2), 35 * (i % 2));
     }
 
     prt(_(" ESC) 建物を出る", " ESC) Exit building"), 23, 0);

--- a/src/market/building-util.cpp
+++ b/src/market/building-util.cpp
@@ -23,5 +23,5 @@ void clear_bldg(int min_row, int max_row)
 void building_prt_gold(PlayerType *player_ptr)
 {
     prt(_("手持ちのお金: ", "Gold Remaining: "), 23, 53);
-    prt(format("%9ld", (long)player_ptr->au), 23, 68);
+    prt(angband::format("%9ld", (long)player_ptr->au), 23, 68);
 }

--- a/src/market/play-gamble.cpp
+++ b/src/market/play-gamble.cpp
@@ -54,7 +54,7 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
      * Use get_string() because we may need more than
      * the int16_t value returned by get_quantity().
      */
-    if (!get_string(format(_("賭け金 (1-%ld)？", "Your wager (1-%ld) ? "), (long int)maxbet), out_val, 32)) {
+    if (!get_string(angband::format(_("賭け金 (1-%ld)？", "Your wager (1-%ld) ? "), (long int)maxbet), out_val, 32)) {
         msg_print(nullptr);
         screen_load();
         return true;
@@ -82,8 +82,8 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
     odds = 0;
     oldgold = player_ptr->au;
 
-    prt(format(_("ゲーム前の所持金: %9ld", "Gold before game: %9ld"), (long int)oldgold), 20, 2);
-    prt(format(_("現在の掛け金:     %9ld", "Current Wager:    %9ld"), (long int)wager), 21, 2);
+    prt(angband::format(_("ゲーム前の所持金: %9ld", "Gold before game: %9ld"), (long int)oldgold), 20, 2);
+    prt(angband::format(_("現在の掛け金:     %9ld", "Current Wager:    %9ld"), (long int)wager), 21, 2);
 
     do {
         player_ptr->au -= wager;
@@ -97,9 +97,9 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
             roll2 = randint1(10);
             choice = randint1(10);
 
-            prt(format(_("黒ダイス: %d        黒ダイス: %d", "Black die: %d       Black Die: %d"), roll1, roll2), 8, 3);
+            prt(angband::format(_("黒ダイス: %d        黒ダイス: %d", "Black die: %d       Black Die: %d"), roll1, roll2), 8, 3);
 
-            prt(format(_("赤ダイス: %d", "Red die: %d"), choice), 11, 14);
+            prt(angband::format(_("赤ダイス: %d", "Red die: %d"), choice), 11, 14);
             if (((choice > roll1) && (choice < roll2)) || ((choice < roll1) && (choice > roll2))) {
                 win = 1;
             }
@@ -113,7 +113,7 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
             roll2 = randint1(6);
             roll3 = roll1 + roll2;
             choice = roll3;
-            prt(format(_("１振りめ: %d %d      Total: %d", "First roll: %d %d    Total: %d"), roll1, roll2, roll3), 7, 5);
+            prt(angband::format(_("１振りめ: %d %d      Total: %d", "First roll: %d %d    Total: %d"), roll1, roll2, roll3), 7, 5);
             if ((roll3 == 7) || (roll3 == 11)) {
                 win = 1;
             } else if ((roll3 == 2) || (roll3 == 3) || (roll3 == 12)) {
@@ -126,7 +126,7 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
                     roll1 = randint1(6);
                     roll2 = randint1(6);
                     roll3 = roll1 + roll2;
-                    prt(format(_("出目: %d %d          合計:      %d", "Roll result: %d %d   Total:     %d"), roll1, roll2, roll3), 8, 5);
+                    prt(angband::format(_("出目: %d %d          合計:      %d", "Roll result: %d %d   Total:     %d"), roll1, roll2, roll3), 8, 5);
                     if (roll3 == choice) {
                         win = 1;
                     } else if (roll3 == 7) {
@@ -160,7 +160,7 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
             }
             msg_print(nullptr);
             roll1 = randint0(10);
-            prt(format(_("ルーレットは回り、止まった。勝者は %d番だ。", "The wheel spins to a stop and the winner is %d"), roll1), 13, 3);
+            prt(angband::format(_("ルーレットは回り、止まった。勝者は %d番だ。", "The wheel spins to a stop and the winner is %d"), roll1), 13, 3);
             prt("", 9, 0);
             prt("*", 9, (3 * roll1 + 5));
             if (roll1 == choice) {
@@ -249,13 +249,13 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
 
             player_ptr->au += odds * wager;
 
-            prt(format(_("倍率: %d", "Payoff: %d"), odds), 17, 37);
+            prt(angband::format(_("倍率: %d", "Payoff: %d"), odds), 17, 37);
         } else {
             prt(_("あなたの負け", "You Lost"), 16, 37);
             prt("", 17, 37);
         }
 
-        prt(format(_("現在の所持金:     %9ld", "Current Gold:     %9ld"), (long int)player_ptr->au), 22, 2);
+        prt(angband::format(_("現在の所持金:     %9ld", "Current Gold:     %9ld"), (long int)player_ptr->au), 22, 2);
         prt(_("もう一度(Y/N)？", "Again(Y/N)?"), 18, 37);
 
         move_cursor(18, 52);

--- a/src/market/poker.cpp
+++ b/src/market/poker.cpp
@@ -568,7 +568,7 @@ static void display_cards(void)
             if (IS_JOKER(cards[i])) {
                 c_put_str(TERM_VIOLET, joker_grph[j], j + 6, 2 + i * 16);
             } else {
-                c_put_str(suitcolor[SUIT_OF(cards[i])], format(card_grph[NUM_OF(cards[i])][j], suit[SUIT_OF(cards[i])], suit[SUIT_OF(cards[i])]), j + 6, 2 + i * 16);
+                c_put_str(suitcolor[SUIT_OF(cards[i])], angband::format(card_grph[NUM_OF(cards[i])][j], suit[SUIT_OF(cards[i])], suit[SUIT_OF(cards[i])]), j + 6, 2 + i * 16);
             }
             prt(_("┃", "| "), j + 6, i * 16 + 14);
         }

--- a/src/mind/mind-archer.cpp
+++ b/src/mind/mind-archer.cpp
@@ -134,7 +134,7 @@ bool create_ammo(PlayerType *player_ptr)
         q_ptr->discount = 99;
         int16_t slot = store_item_to_inventory(player_ptr, q_ptr);
         const auto item_name = describe_flavor(player_ptr, q_ptr, 0);
-        msg_print(_(format("%sを作った。", item_name.data()), "You make some ammo."));
+        msg_print(_(angband::format("%sを作った。", item_name.data()), "You make some ammo."));
         if (slot >= 0) {
             autopick_alter_item(player_ptr, slot, false);
         }
@@ -161,7 +161,7 @@ bool create_ammo(PlayerType *player_ptr)
         ItemMagicApplier(player_ptr, q_ptr, player_ptr->lev, AM_NO_FIXED_ART).execute();
         q_ptr->discount = 99;
         const auto item_name = describe_flavor(player_ptr, q_ptr, 0);
-        msg_print(_(format("%sを作った。", item_name.data()), "You make some ammo."));
+        msg_print(_(angband::format("%sを作った。", item_name.data()), "You make some ammo."));
         vary_item(player_ptr, item, -1);
         int16_t slot = store_item_to_inventory(player_ptr, q_ptr);
         if (slot >= 0) {
@@ -188,7 +188,7 @@ bool create_ammo(PlayerType *player_ptr)
         ItemMagicApplier(player_ptr, q_ptr, player_ptr->lev, AM_NO_FIXED_ART).execute();
         q_ptr->discount = 99;
         const auto item_name = describe_flavor(player_ptr, q_ptr, 0);
-        msg_print(_(format("%sを作った。", item_name.data()), "You make some ammo."));
+        msg_print(_(angband::format("%sを作った。", item_name.data()), "You make some ammo."));
         vary_item(player_ptr, item, -1);
         int16_t slot = store_item_to_inventory(player_ptr, q_ptr);
         if (slot >= 0) {

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -376,7 +376,7 @@ static std::string get_element_tip(PlayerType *player_ptr, int spell_idx)
     auto realm = i2enum<ElementRealmType>(player_ptr->element);
     auto spell = i2enum<ElementSpells>(spell_idx);
     auto elem = element_powers.at(spell).elem;
-    return format(element_tips.at(spell).data(), element_types.at(realm).name[elem].data());
+    return angband::format(element_tips.at(spell).data(), element_types.at(realm).name[elem].data());
 }
 
 /*!
@@ -419,34 +419,34 @@ static std::string get_element_effect_info(PlayerType *player_ptr, int spell_idx
 
     switch (spell) {
     case ElementSpells::BOLT_1ST:
-        return format(" %s%dd%d", KWD_DAM, 3 + ((plev - 1) / 5), 4);
+        return angband::format(" %s%dd%d", KWD_DAM, 3 + ((plev - 1) / 5), 4);
     case ElementSpells::CURE:
-        return format(" %s%dd%d", KWD_HEAL, 2, 8);
+        return angband::format(" %s%dd%d", KWD_HEAL, 2, 8);
     case ElementSpells::BOLT_2ND:
-        return format(" %s%dd%d", KWD_DAM, 8 + ((plev - 5) / 4), 8);
+        return angband::format(" %s%dd%d", KWD_DAM, 8 + ((plev - 5) / 4), 8);
     case ElementSpells::BALL_3RD:
-        return format(" %s%d", KWD_DAM, (50 + plev * 2));
+        return angband::format(" %s%d", KWD_DAM, (50 + plev * 2));
     case ElementSpells::BALL_1ST:
-        return format(" %s%d", KWD_DAM, 55 + plev);
+        return angband::format(" %s%d", KWD_DAM, 55 + plev);
     case ElementSpells::BREATH_2ND:
         dam = p_ptr->chp / 2;
-        return format(" %s%d", KWD_DAM, (dam > 150) ? 150 : dam);
+        return angband::format(" %s%d", KWD_DAM, (dam > 150) ? 150 : dam);
     case ElementSpells::ANNIHILATE:
-        return format(" %s%d", _("効力:", "pow "), 50 + plev);
+        return angband::format(" %s%d", _("効力:", "pow "), 50 + plev);
     case ElementSpells::BOLT_3RD:
-        return format(" %s%dd%d", KWD_DAM, 12 + ((plev - 5) / 4), 8);
+        return angband::format(" %s%dd%d", KWD_DAM, 12 + ((plev - 5) / 4), 8);
     case ElementSpells::WAVE_1ST:
-        return format(" %s50+d%d", KWD_DAM, plev * 3);
+        return angband::format(" %s50+d%d", KWD_DAM, plev * 3);
     case ElementSpells::BALL_2ND:
-        return format(" %s%d", KWD_DAM, 75 + plev * 3 / 2);
+        return angband::format(" %s%d", KWD_DAM, 75 + plev * 3 / 2);
     case ElementSpells::BURST_1ST:
-        return format(" %s%dd%d", KWD_DAM, 6 + plev / 8, 7);
+        return angband::format(" %s%dd%d", KWD_DAM, 6 + plev / 8, 7);
     case ElementSpells::STORM_2ND:
-        return format(" %s%d", KWD_DAM, 115 + plev * 5 / 2);
+        return angband::format(" %s%d", KWD_DAM, 115 + plev * 5 / 2);
     case ElementSpells::BREATH_1ST:
-        return format(" %s%d", KWD_DAM, p_ptr->chp * 2 / 3);
+        return angband::format(" %s%d", KWD_DAM, p_ptr->chp * 2 / 3);
     case ElementSpells::STORM_3ND:
-        return format(" %s%d", KWD_DAM, 300 + plev * 5);
+        return angband::format(" %s%d", KWD_DAM, 300 + plev * 5);
     default:
         return std::string();
     }
@@ -793,12 +793,12 @@ static bool get_element_power(PlayerType *player_ptr, SPELL_IDX *sn, bool only_b
                             desc = "     ";
                         }
                     } else {
-                        desc = format("  %c) ", I2A(i));
+                        desc = angband::format("  %c) ", I2A(i));
                     }
 
                     concptr s = get_element_name(player_ptr->element, elem);
-                    std::string name = format(spell.name, s);
-                    desc.append(format("%-30s%2d %4d %3d%%%s", name.data(), spell.min_lev, mana_cost, chance, comment.data()));
+                    std::string name = angband::format(spell.name, s);
+                    desc.append(angband::format("%-30s%2d %4d %3d%%%s", name.data(), spell.min_lev, mana_cost, chance, comment.data()));
                     prt(desc, y + i + 1, x);
                 }
 
@@ -1112,7 +1112,7 @@ static void display_realm_cursor(int i, int n, term_color_type color)
         name = element_types.at(i2enum<ElementRealmType>(i + 1)).title.data();
     }
 
-    c_put_str(color, format("%c) %s", sym, name), 12 + (i / 5), 2 + 15 * (i % 5));
+    c_put_str(color, angband::format("%c) %s", sym, name), 12 + (i / 5), 2 + 15 * (i % 5));
 }
 
 /*!
@@ -1167,7 +1167,7 @@ static int get_element_realm(PlayerType *player_ptr, int is, int n)
     int os = cs;
     int k;
 
-    std::string buf = format(_("領域を選んで下さい(%c-%c) ('='初期オプション設定): ", "Choose a realm (%c-%c) ('=' for options): "), I2A(0), I2A(n - 1));
+    std::string buf = angband::format(_("領域を選んで下さい(%c-%c) ('='初期オプション設定): ", "Choose a realm (%c-%c) ('=' for options): "), I2A(0), I2A(n - 1));
 
     while (true) {
         display_realm_cursor(os, n, TERM_WHITE);
@@ -1285,7 +1285,7 @@ void switch_element_racial(PlayerType *player_ptr, rc_type *rc_ptr)
         break;
     case ElementRealmType::ICE:
         rpi = rpi_type(_("周辺フリーズ", "Sleep monsters"));
-        rpi.info = format("%s%d", KWD_POWER, 20 + plev * 3 / 2);
+        rpi.info = angband::format("%s%d", KWD_POWER, 20 + plev * 3 / 2);
         rpi.text = _("視界内の全てのモンスターを眠らせる。抵抗されると無効。", "Attempts to put all monsters in sight to sleep.");
         rpi.min_level = 10;
         rpi.cost = 15;
@@ -1295,7 +1295,7 @@ void switch_element_racial(PlayerType *player_ptr, rc_type *rc_ptr)
         break;
     case ElementRealmType::SKY:
         rpi = rpi_type(_("魔力充填", "Recharging"));
-        rpi.info = format("%s%d", KWD_POWER, 120);
+        rpi.info = angband::format("%s%d", KWD_POWER, 120);
         rpi.text = _("杖/魔法棒の充填回数を増やすか、充填中のロッドの充填時間を減らす。", "Recharges staffs, wands or rods.");
         rpi.min_level = 20;
         rpi.cost = 15;
@@ -1314,7 +1314,7 @@ void switch_element_racial(PlayerType *player_ptr, rc_type *rc_ptr)
         break;
     case ElementRealmType::DARKNESS:
         rpi = rpi_type(_("闇の扉", "Door to darkness"));
-        rpi.info = format("%s%d", KWD_SPHERE, 15 + plev / 2);
+        rpi.info = angband::format("%s%d", KWD_SPHERE, 15 + plev / 2);
         rpi.min_level = 5;
         rpi.cost = 5 + plev / 7;
         rpi.stat = A_WIS;
@@ -1332,7 +1332,7 @@ void switch_element_racial(PlayerType *player_ptr, rc_type *rc_ptr)
         break;
     case ElementRealmType::EARTH:
         rpi = rpi_type(_("地震", "Earthquake"));
-        rpi.info = format("%s%d", KWD_SPHERE, 10);
+        rpi.info = angband::format("%s%d", KWD_SPHERE, 10);
         rpi.text = _("周囲のダンジョンを揺らし、壁と床をランダムに入れ変える。", "Shakes dungeon structure, and results in random swapping of floors and walls.");
         rpi.min_level = 25;
         rpi.cost = 15;

--- a/src/mind/mind-info.cpp
+++ b/src/mind/mind-info.cpp
@@ -10,32 +10,32 @@ static std::string switch_mind_mindcrafter(PlayerType *player_ptr, const PLAYER_
 {
     switch (power) {
     case 1:
-        return format(" %s%dd%d", KWD_DAM, 3 + ((plev - 1) / 4), 3 + plev / 15);
+        return angband::format(" %s%dd%d", KWD_DAM, 3 + ((plev - 1) / 4), 3 + plev / 15);
     case 2:
-        return format(" %s10", KWD_SPHERE);
+        return angband::format(" %s10", KWD_SPHERE);
     case 3:
-        return format(" %s%d", KWD_SPHERE, plev * 5);
+        return angband::format(" %s%d", KWD_SPHERE, plev * 5);
     case 5:
-        return format(" %s%dd8", KWD_DAM, 8 + ((plev - 5) / 4));
+        return angband::format(" %s%dd8", KWD_DAM, 8 + ((plev - 5) / 4));
     case 6:
-        return format(" %s%d", KWD_DURATION, plev);
+        return angband::format(" %s%d", KWD_DURATION, plev);
     case 8:
-        return format((plev < 25 ? " %s%d" : " %sd%d"), KWD_DAM, (plev < 25 ? plev * 3 / 2 : plev * ((plev - 5) / 10 + 1)));
+        return angband::format((plev < 25 ? " %s%d" : " %sd%d"), KWD_DAM, (plev < 25 ? plev * 3 / 2 : plev * ((plev - 5) / 10 + 1)));
     case 9:
-        return format(" %s10+d%d", KWD_DURATION, plev * 3 / 2);
+        return angband::format(" %s10+d%d", KWD_DURATION, plev * 3 / 2);
 #ifdef JP
     case 10:
-        return format(" 最大重量:%d.%dkg", lb_to_kg_integer(plev * 15), lb_to_kg_fraction(plev * 15));
+        return angband::format(" 最大重量:%d.%dkg", lb_to_kg_integer(plev * 15), lb_to_kg_fraction(plev * 15));
 #else
     case 10:
-        return format(" max wgt %d", plev * 15);
+        return angband::format(" max wgt %d", plev * 15);
 #endif
     case 11:
-        return format(" %s%dd6", KWD_DAM, plev / 2);
+        return angband::format(" %s%dd6", KWD_DAM, plev / 2);
     case 12:
-        return format(" %sd%d+%d", KWD_DAM, plev * 3, plev * 3);
+        return angband::format(" %sd%d+%d", KWD_DAM, plev * 3, plev * 3);
     case 13:
-        return format(_(" 行動:%ld回", " %ld acts."), (long int)(player_ptr->csp + 100 - player_ptr->energy_need - 50) / 100);
+        return angband::format(_(" 行動:%ld回", " %ld acts."), (long int)(player_ptr->csp + 100 - player_ptr->energy_need - 50) / 100);
     default:
         return std::string();
     }
@@ -50,27 +50,27 @@ static std::string switch_mind_ki(PlayerType *player_ptr, const PLAYER_LEVEL ple
 
     switch (power) {
     case 0:
-        return format(" %s%dd4", KWD_DAM, 3 + ((plev - 1) / 5) + boost / 12);
+        return angband::format(" %s%dd4", KWD_DAM, 3 + ((plev - 1) / 5) + boost / 12);
     case 2:
-        return format(" %s%d+d30", KWD_DURATION, 30 + boost / 5);
+        return angband::format(" %s%d+d30", KWD_DURATION, 30 + boost / 5);
     case 3:
-        return format(" %s%dd5", KWD_DAM, 5 + ((plev - 1) / 5) + boost / 10);
+        return angband::format(" %s%dd5", KWD_DAM, 5 + ((plev - 1) / 5) + boost / 10);
     case 4:
-        return format(" %s%d+d20", KWD_DURATION, 20 + boost / 5);
+        return angband::format(" %s%d+d20", KWD_DURATION, 20 + boost / 5);
     case 6:
-        return format(" %s%d+d%d", KWD_DURATION, 15 + boost / 7, plev / 2);
+        return angband::format(" %s%d+d%d", KWD_DURATION, 15 + boost / 7, plev / 2);
     case 7:
-        return format(" %s%dd8", KWD_DAM, 8 + ((plev - 5) / 4) + boost / 12);
+        return angband::format(" %s%dd8", KWD_DAM, 8 + ((plev - 5) / 4) + boost / 12);
     case 8:
-        return format(" %s10d6+%d", KWD_DAM, plev * 3 / 2 + boost * 3 / 5);
+        return angband::format(" %s10d6+%d", KWD_DAM, plev * 3 / 2 + boost * 3 / 5);
     case 10:
-        return format(_(" 最大%d体", " max %d"), 1 + boost / 100);
+        return angband::format(_(" 最大%d体", " max %d"), 1 + boost / 100);
     case 11:
-        return format(" %s%d", KWD_DAM, 100 + plev + boost);
+        return angband::format(" %s%d", KWD_DAM, 100 + plev + boost);
     case 12:
-        return format(" %s%dd15", KWD_DAM, 10 + plev / 2 + boost * 3 / 10);
+        return angband::format(" %s%dd15", KWD_DAM, 10 + plev / 2 + boost * 3 / 10);
     case 13:
-        return format(_(" 行動:%d+d16回", " %d+d16 acts"), 16 + boost / 20);
+        return angband::format(_(" 行動:%d+d16回", " %d+d16 acts"), 16 + boost / 20);
     default:
         return std::string();
     }
@@ -80,29 +80,29 @@ static std::string switch_mind_mirror_master(const PLAYER_LEVEL plev, const int 
 {
     switch (power) {
     case 2:
-        return format(" %s%dd4", KWD_DAM, 3 + ((plev - 1) / 5));
+        return angband::format(" %s%dd4", KWD_DAM, 3 + ((plev - 1) / 5));
     case 3:
-        return format(" %s10", KWD_SPHERE);
+        return angband::format(" %s10", KWD_SPHERE);
     case 5:
-        return format(" %s%d", KWD_SPHERE, plev * 5);
+        return angband::format(" %s%d", KWD_SPHERE, plev * 5);
     case 6:
-        return format(" %s20+d20", KWD_DURATION);
+        return angband::format(" %s20+d20", KWD_DURATION);
     case 8:
-        return format(" %s%dd8", KWD_DAM, 8 + ((plev - 5) / 4));
+        return angband::format(" %s%dd8", KWD_DAM, 8 + ((plev - 5) / 4));
     case 10:
-        return format(" %s%dd8", KWD_DAM, 11 + (plev - 5) / 4);
+        return angband::format(" %s%dd8", KWD_DAM, 11 + (plev - 5) / 4);
     case 12:
-        return format(" %s20+d20", KWD_DURATION);
+        return angband::format(" %s20+d20", KWD_DURATION);
     case 13:
-        return format(" %s150+d%d", KWD_DAM, plev * 2);
+        return angband::format(" %s150+d%d", KWD_DAM, plev * 2);
     case 16:
-        return format(" %s%d", KWD_SPHERE, plev / 2 + 10);
+        return angband::format(" %s%d", KWD_SPHERE, plev / 2 + 10);
     case 18:
-        return format(" %s6+d6", KWD_DURATION);
+        return angband::format(" %s6+d6", KWD_DURATION);
     case 19:
-        return format(" %s%d", KWD_DAM, plev * 11 + 5);
+        return angband::format(" %s%d", KWD_DAM, plev * 11 + 5);
     case 20:
-        return format(" %s4+d4", KWD_DURATION);
+        return angband::format(" %s4+d4", KWD_DURATION);
     default:
         return std::string();
     }
@@ -112,23 +112,23 @@ static std::string switch_mind_ninja(const PLAYER_LEVEL plev, const int power)
 {
     switch (power) {
     case 2:
-        return format(" %s10", KWD_SPHERE);
+        return angband::format(" %s10", KWD_SPHERE);
     case 4:
-        return format(" %s%d", KWD_SPHERE, plev * 5);
+        return angband::format(" %s%d", KWD_SPHERE, plev * 5);
     case 5:
-        return format(" %s30", KWD_SPHERE);
+        return angband::format(" %s30", KWD_SPHERE);
     case 8:
-        return format(" %s20+d20", KWD_DURATION);
+        return angband::format(" %s20+d20", KWD_DURATION);
     case 9:
-        return format(" %s%d", KWD_DAM, (50 + plev) / 2);
+        return angband::format(" %s%d", KWD_DAM, (50 + plev) / 2);
     case 16:
-        return format(" %s%d+d%d", KWD_DURATION, plev / 2, plev / 2);
+        return angband::format(" %s%d+d%d", KWD_DURATION, plev / 2, plev / 2);
     case 17:
-        return format(" %s%d*3", KWD_DAM, (75 + plev * 2 / 3) / 2);
+        return angband::format(" %s%d*3", KWD_DAM, (75 + plev * 2 / 3) / 2);
     case 18:
-        return format(" %s%dd10", KWD_DAM, 6 + plev / 8);
+        return angband::format(" %s%dd10", KWD_DAM, 6 + plev / 8);
     case 19:
-        return format(" %s6+d6", KWD_DURATION);
+        return angband::format(" %s6+d6", KWD_DURATION);
     default:
         return std::string();
     }

--- a/src/mind/mind-power-getter.cpp
+++ b/src/mind/mind-power-getter.cpp
@@ -227,7 +227,7 @@ bool MindPowerGetter::display_minds_chance(const bool only_browse)
 
         prt("", y, x);
         put_str(_("名前", "Name"), y, x + 5);
-        put_str(format(_("Lv   %s   失率 効果", "Lv   %s   Fail Info"),
+        put_str(angband::format(_("Lv   %s   失率 効果", "Lv   %s   Fail Info"),
                     ((this->use_mind == MindKindType::BERSERKER) || (this->use_mind == MindKindType::NINJUTSU)) ? "HP" : "MP"),
             y, x + 35);
         display_each_mind_chance();
@@ -265,10 +265,10 @@ void MindPowerGetter::display_each_mind_chance()
                 psi_desc = "     ";
             }
         } else {
-            psi_desc = format("  %c) ", I2A(this->index));
+            psi_desc = angband::format("  %c) ", I2A(this->index));
         }
 
-        psi_desc.append(format("%-30s%2d %4d%s %3d%%%s", this->spell->name, this->spell->min_lev, mana_cost,
+        psi_desc.append(angband::format("%-30s%2d %4d%s %3d%%%s", this->spell->name, this->spell->min_lev, mana_cost,
             (((this->use_mind == MindKindType::MINDCRAFTER) && (this->index == 13)) ? _("～", "~ ") : "  "), chance, comment.data()));
         prt(psi_desc, y + this->index + 1, x);
     }

--- a/src/mind/mind-sniper.cpp
+++ b/src/mind/mind-sniper.cpp
@@ -329,8 +329,8 @@ static int get_snipe_power(PlayerType *player_ptr, COMMAND_CODE *sn, bool only_b
                     } else if (spell.mana_cost > sniper_data->concent) {
                         tcol = TERM_L_BLUE;
                     }
-                    term_putstr(x, y + i + 1, -1, tcol, (spell.min_lev > plev) ? "   ) " : format("  %c) ", I2A(i)));
-                    term_putstr(x + 5, y + i + 1, -1, tcol, format("%-30s%2d %4d", spell.name, spell.min_lev, spell.mana_cost));
+                    term_putstr(x, y + i + 1, -1, tcol, (spell.min_lev > plev) ? "   ) " : angband::format("  %c) ", I2A(i)));
+                    term_putstr(x + 5, y + i + 1, -1, tcol, angband::format("%-30s%2d %4d", spell.name, spell.min_lev, spell.mana_cost));
                 }
 
                 /* Clear the bottom line */

--- a/src/mind/mind-weaponsmith.cpp
+++ b/src/mind/mind-weaponsmith.cpp
@@ -73,9 +73,9 @@ static void display_essence(PlayerType *player_ptr)
              ++num, ++ei) {
             auto name = Smith::get_essence_name(essences[ei]);
             auto amount = smith.get_essence_num_of_posessions(essences[ei]);
-            prt(format("%-11s %5d", name, amount), 2 + num % row_count, 8 + (num / row_count) * column_width);
+            prt(angband::format("%-11s %5d", name, amount), 2 + num % row_count, 8 + (num / row_count) * column_width);
         }
-        prt(format(_("現在所持しているエッセンス %d/%d", "List of all essences you have. %d/%d"), (page + 1), page_max), 0, 0);
+        prt(angband::format(_("現在所持しているエッセンス %d/%d", "List of all essences you have. %d/%d"), (page + 1), page_max), 0, 0);
 
         auto key = inkey();
         if (key == ESCAPE) {
@@ -133,7 +133,7 @@ static void drain_essence(PlayerType *player_ptr)
 
     if (o_ptr->is_known() && !o_ptr->is_nameless()) {
         const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
-        if (!get_check(format(_("本当に%sから抽出してよろしいですか？", "Really extract from %s? "), item_name.data()))) {
+        if (!get_check(angband::format(_("本当に%sから抽出してよろしいですか？", "Really extract from %s? "), item_name.data()))) {
             return;
         }
     }
@@ -187,10 +187,10 @@ static COMMAND_CODE choose_essence(void)
             int i;
             for (i = 0; i < mode_max; i++)
 #ifdef JP
-                prt(format(" %s %s", (menu_line == 1 + i) ? "》" : "  ", menu_name[i]), 2 + i, 14);
+                prt(angband::format(" %s %s", (menu_line == 1 + i) ? "》" : "  ", menu_name[i]), 2 + i, 14);
             prt("どの種類のエッセンス付加を行いますか？", 0, 0);
 #else
-                prt(format(" %s %s", (menu_line == 1 + i) ? "> " : "  ", menu_name[i]), 2 + i, 14);
+                prt(angband::format(" %s %s", (menu_line == 1 + i) ? "> " : "  ", menu_name[i]), 2 + i, 14);
             prt("Choose from menu.", 0, 0);
 #endif
 
@@ -229,7 +229,7 @@ static COMMAND_CODE choose_essence(void)
             int i;
 
             for (i = 0; i < mode_max; i++) {
-                prt(format("  %c) %s", 'a' + i, menu_name[i]), 2 + i, 14);
+                prt(angband::format("  %c) %s", 'a' + i, menu_name[i]), 2 + i, 14);
             }
 
             if (!get_com(_("何を付加しますか:", "Command :"), &choice, true)) {
@@ -270,9 +270,9 @@ static void display_smith_effect_list(const Smith &smith, const std::vector<Smit
     }
 
 #ifdef JP
-    prt(format("   %-45s %6s/%s", "能力(必要エッセンス)", "所持数", "必要数"), 1, x);
+    prt(angband::format("   %-45s %6s/%s", "能力(必要エッセンス)", "所持数", "必要数"), 1, x);
 #else
-    prt(format("   %-44s %7s/%s", "Ability (needed essence)", "Possess", "Needs"), 1, x);
+    prt(angband::format("   %-44s %7s/%s", "Ability (needed essence)", "Possess", "Needs"), 1, x);
 #endif
 
     for (int ctr = 0U, ei = start_idx; ctr < line_max && ei < static_cast<int>(smith_effect_list.size()); ++ctr, ++ei) {
@@ -341,7 +341,7 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
 
         while (!flag) {
             if (page_max > 1) {
-                std::string page_str = format("%d/%d", page + 1, page_max);
+                std::string page_str = angband::format("%d/%d", page + 1, page_max);
                 strnfmt(out_val, 78, _("(SPACEで次ページ, ESCで中断) どの能力を付加しますか？ %s", "(SPACE=next, ESC=exit) Add which ability? %s"), page_str.data());
             } else {
                 strnfmt(out_val, 78, _("(ESCで中断) どの能力を付加しますか？", "(ESC=exit) Add which ability? "));
@@ -483,7 +483,7 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
             char tmp_val[8] = "1";
             auto limit = std::min(5, smith.get_addable_count(effect, o_ptr));
 
-            if (!get_string(format(_("いくつ付加しますか？ (1-%d): ", "Enchant how many? (1-%d): "), limit), tmp_val, 1)) {
+            if (!get_string(angband::format(_("いくつ付加しますか？ (1-%d): ", "Enchant how many? (1-%d): "), limit), tmp_val, 1)) {
                 return;
             }
             o_ptr->pval = static_cast<PARAMETER_VALUE>(std::clamp(atoi(tmp_val), 1, limit));
@@ -493,7 +493,7 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
     } else if (effect == SmithEffectType::SLAY_GLOVE) {
         char tmp_val[8] = "1";
         const auto max_val = player_ptr->lev / 7 + 3;
-        if (!get_string(format(_("いくつ付加しますか？ (1-%d):", "Enchant how many? (1-%d):"), max_val), tmp_val, 2)) {
+        if (!get_string(angband::format(_("いくつ付加しますか？ (1-%d):", "Enchant how many? (1-%d):"), max_val), tmp_val, 2)) {
             return;
         }
         add_essence_count = std::clamp(atoi(tmp_val), 1, max_val);
@@ -533,7 +533,7 @@ static void erase_essence(PlayerType *player_ptr)
     }
 
     const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
-    if (!get_check(format(_("よろしいですか？ [%s]", "Are you sure? [%s]"), item_name.data()))) {
+    if (!get_check(angband::format(_("よろしいですか？ [%s]", "Are you sure? [%s]"), item_name.data()))) {
         return;
     }
 
@@ -579,19 +579,19 @@ void do_cmd_kaji(PlayerType *player_ptr, bool only_browse)
             if (use_menu) {
                 while (!mode) {
 #ifdef JP
-                    prt(format(" %s エッセンス一覧", (menu_line == 1) ? "》" : "  "), 2, 14);
-                    prt(format(" %s エッセンス抽出", (menu_line == 2) ? "》" : "  "), 3, 14);
-                    prt(format(" %s エッセンス消去", (menu_line == 3) ? "》" : "  "), 4, 14);
-                    prt(format(" %s エッセンス付加", (menu_line == 4) ? "》" : "  "), 5, 14);
-                    prt(format(" %s 武器/防具強化", (menu_line == 5) ? "》" : "  "), 6, 14);
-                    prt(format("どの種類の技術を%sますか？", only_browse ? "調べ" : "使い"), 0, 0);
+                    prt(angband::format(" %s エッセンス一覧", (menu_line == 1) ? "》" : "  "), 2, 14);
+                    prt(angband::format(" %s エッセンス抽出", (menu_line == 2) ? "》" : "  "), 3, 14);
+                    prt(angband::format(" %s エッセンス消去", (menu_line == 3) ? "》" : "  "), 4, 14);
+                    prt(angband::format(" %s エッセンス付加", (menu_line == 4) ? "》" : "  "), 5, 14);
+                    prt(angband::format(" %s 武器/防具強化", (menu_line == 5) ? "》" : "  "), 6, 14);
+                    prt(angband::format("どの種類の技術を%sますか？", only_browse ? "調べ" : "使い"), 0, 0);
 #else
-                    prt(format(" %s List essences", (menu_line == 1) ? "> " : "  "), 2, 14);
-                    prt(format(" %s Extract essence", (menu_line == 2) ? "> " : "  "), 3, 14);
-                    prt(format(" %s Remove essence", (menu_line == 3) ? "> " : "  "), 4, 14);
-                    prt(format(" %s Add essence", (menu_line == 4) ? "> " : "  "), 5, 14);
-                    prt(format(" %s Enchant weapon/armor", (menu_line == 5) ? "> " : "  "), 6, 14);
-                    prt(format("Choose command from menu."), 0, 0);
+                    prt(angband::format(" %s List essences", (menu_line == 1) ? "> " : "  "), 2, 14);
+                    prt(angband::format(" %s Extract essence", (menu_line == 2) ? "> " : "  "), 3, 14);
+                    prt(angband::format(" %s Remove essence", (menu_line == 3) ? "> " : "  "), 4, 14);
+                    prt(angband::format(" %s Add essence", (menu_line == 4) ? "> " : "  "), 5, 14);
+                    prt(angband::format(" %s Enchant weapon/armor", (menu_line == 5) ? "> " : "  "), 6, 14);
+                    prt(angband::format("Choose command from menu."), 0, 0);
 #endif
                     choice = inkey();
                     switch (choice) {
@@ -631,7 +631,7 @@ void do_cmd_kaji(PlayerType *player_ptr, bool only_browse)
                     prt(_("  d) エッセンス付加", "  d) Add essence"), 5, 14);
                     prt(_("  e) 武器/防具強化", "  e) Enchant weapon/armor"), 6, 14);
 #ifdef JP
-                    if (!get_com(format("どの能力を%sますか:", only_browse ? "調べ" : "使い"), &choice, true))
+                    if (!get_com(angband::format("どの能力を%sますか:", only_browse ? "調べ" : "使い"), &choice, true))
 #else
                     if (!get_com("Command :", &choice, true))
 #endif

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -90,7 +90,7 @@ void MonsterAttackPlayer::make_attack_normal()
     angband_strcpy(this->m_name, monster_desc(this->player_ptr, this->m_ptr, 0), sizeof(this->m_name));
     angband_strcpy(this->ddesc, monster_desc(this->player_ptr, this->m_ptr, MD_WRONGDOER_NAME), sizeof(this->ddesc));
     if (PlayerClass(this->player_ptr).samurai_stance_is(SamuraiStanceType::IAI)) {
-        msg_print(_("相手が襲いかかる前に素早く武器を振るった。", format("You took sen, drew and cut in one motion before %s moved.", this->m_name)));
+        msg_print(_("相手が襲いかかる前に素早く武器を振るった。", angband::format("You took sen, drew and cut in one motion before %s moved.", this->m_name)));
         if (do_cmd_attack(this->player_ptr, this->m_ptr->fy, this->m_ptr->fx, HISSATSU_IAI)) {
             return;
         }

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -394,7 +394,7 @@ void MonsterDamageProcessor::show_kill_message(std::string_view note, std::strin
 void MonsterDamageProcessor::show_explosion_message(std::string_view died_mes, std::string_view m_name)
 {
     std::stringstream ss;
-    ss << _(m_name, format("%s^", m_name.data()));
+    ss << _(m_name, angband::format("%s^", m_name.data()));
     ss << died_mes;
     msg_print(ss.str());
     return;

--- a/src/monster/monster-describer.cpp
+++ b/src/monster/monster-describer.cpp
@@ -162,10 +162,10 @@ static std::string replace_monster_name_undefined(std::string_view name)
     if (name.starts_with("』")) {
         constexpr auto ja_char_length = 2;
         const auto name_without_brackets = name.substr(0, name.length() - ja_char_length);
-        return format("%s？』", name_without_brackets.data());
+        return angband::format("%s？』", name_without_brackets.data());
     }
 
-    return format("%s？", name.data());
+    return angband::format("%s？", name.data());
 }
 #endif
 
@@ -178,11 +178,11 @@ static std::optional<std::string> get_fake_monster_name(const PlayerType &player
     }
 
     if (monster.mflag2.has(MonsterConstantFlagType::CHAMELEON) && none_bits(mode, MD_TRUE_NAME)) {
-        return _(replace_monster_name_undefined(name), format("%s?", name.data()));
+        return _(replace_monster_name_undefined(name), angband::format("%s?", name.data()));
     }
 
     if (player.phase_out && !(player.riding && (&player.current_floor_ptr->m_list[player.riding] == &monster))) {
-        return format(_("%sもどき", "fake %s"), name.data());
+        return angband::format(_("%sもどき", "fake %s"), name.data());
     }
 
     return name;
@@ -255,7 +255,7 @@ std::string monster_desc(PlayerType *player_ptr, const MonsterEntity *m_ptr, BIT
     const auto name = get_describing_monster_name(*m_ptr, is_hallucinated, mode);
     std::stringstream ss;
     if (m_ptr->is_pet() && !m_ptr->is_original_ap()) {
-        ss << _(replace_monster_name_undefined(name), format("%s?", name.data()));
+        ss << _(replace_monster_name_undefined(name), angband::format("%s?", name.data()));
     } else {
         ss << describe_non_pet(*player_ptr, *m_ptr, name, mode);
     }

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -385,7 +385,7 @@ void choose_new_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, bool born, Mo
         if (!(r_ptr->flags7 & RF7_RIDING)) {
             if (process_fall_off_horse(player_ptr, 0, true)) {
                 const auto m_name = monster_desc(player_ptr, m_ptr, 0);
-                msg_print(_("地面に落とされた。", format("You have fallen from %s.", m_name.data())));
+                msg_print(_("地面に落とされた。", angband::format("You have fallen from %s.", m_name.data())));
             }
         }
     }

--- a/src/monster/monster-pain-describer.cpp
+++ b/src/monster/monster-pain-describer.cpp
@@ -200,7 +200,7 @@ std::string MonsterPainDescriber::describe(int dam)
 
     if (dam == 0) {
         if (this->m_ptr->ml) {
-            return format(_("%s^はダメージを受けていない。", "%s^ is unharmed."), m_name.data());
+            return angband::format(_("%s^はダメージを受けていない。", "%s^ is unharmed."), m_name.data());
         }
         return "";
     }
@@ -215,7 +215,7 @@ std::string MonsterPainDescriber::describe(int dam)
         }
 
         const auto msg = table.lower_bound(percentage)->second;
-        return format("%s^%s", m_name.data(), msg);
+        return angband::format("%s^%s", m_name.data(), msg);
     }
 
     return "";

--- a/src/monster/monster-status-setter.cpp
+++ b/src/monster/monster-status-setter.cpp
@@ -394,16 +394,16 @@ bool set_monster_timewalk(PlayerType *player_ptr, int num, MonsterRaceId who, bo
         std::string mes;
         switch (who) {
         case MonsterRaceId::DIO:
-            mes = _("「『ザ・ワールド』！　時は止まった！」", format("%s yells 'The World! Time has stopped!'", m_name.data()));
+            mes = _("「『ザ・ワールド』！　時は止まった！」", angband::format("%s yells 'The World! Time has stopped!'", m_name.data()));
             break;
         case MonsterRaceId::WONG:
-            mes = _("「時よ！」", format("%s yells 'Time!'", m_name.data()));
+            mes = _("「時よ！」", angband::format("%s yells 'Time!'", m_name.data()));
             break;
         case MonsterRaceId::DIAVOLO:
-            mes = _("『キング・クリムゾン』！", format("%s yells 'King Crison!'", m_name.data()));
+            mes = _("『キング・クリムゾン』！", angband::format("%s yells 'King Crison!'", m_name.data()));
             break;
         default:
-            mes = format(_("%sは時を止めた！", "%s stops the time!"), m_name.data());
+            mes = angband::format(_("%sは時を止めた！", "%s stops the time!"), m_name.data());
             break;
         }
 

--- a/src/mspell/mspell-special.cpp
+++ b/src/mspell/mspell-special.cpp
@@ -215,7 +215,7 @@ static MonsterSpellResult spell_RF6_SPECIAL_B(PlayerType *player_ptr, POSITION y
         int get_damage = take_hit(player_ptr, DAMAGE_NOESCAPE, dam, m_name);
         if (player_ptr->tim_eyeeye && get_damage > 0 && !player_ptr->is_dead) {
             const auto m_name_self = monster_desc(player_ptr, m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE | MD_OBJECTIVE);
-            msg_print(_(format("攻撃が%s自身を傷つけた！", m_name.data()), format("The attack of %s has wounded %s!", m_name.data(), m_name_self.data())));
+            msg_print(_(angband::format("攻撃が%s自身を傷つけた！", m_name.data()), angband::format("The attack of %s has wounded %s!", m_name.data(), m_name_self.data())));
             project(player_ptr, 0, 0, m_ptr->fy, m_ptr->fx, get_damage, AttributeType::MISSILE, PROJECT_KILL);
             set_tim_eyeeye(player_ptr, player_ptr->tim_eyeeye - 5, true);
         }

--- a/src/mspell/mspell-status.cpp
+++ b/src/mspell/mspell-status.cpp
@@ -492,9 +492,9 @@ MonsterSpellResult spell_RF6_HASTE(PlayerType *player_ptr, MONSTER_IDX m_idx, MO
     const auto m_poss = monster_desc(player_ptr, m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE);
 
     mspell_cast_msg msg(_("%s^が何かをつぶやいた。", "%s^ mumbles."),
-        _("%s^が自分の体に念を送った。", format("%%s^ concentrates on %s body.", m_poss.data())),
-        _("%s^が自分の体に念を送った。", format("%%s^ concentrates on %s body.", m_poss.data())),
-        _("%s^が自分の体に念を送った。", format("%%s^ concentrates on %s body.", m_poss.data())));
+        _("%s^が自分の体に念を送った。", angband::format("%%s^ concentrates on %s body.", m_poss.data())),
+        _("%s^が自分の体に念を送った。", angband::format("%%s^ concentrates on %s body.", m_poss.data())),
+        _("%s^が自分の体に念を送った。", angband::format("%%s^ concentrates on %s body.", m_poss.data())));
 
     monspell_message_base(player_ptr, m_idx, t_idx, msg, player_ptr->effects()->blindness()->is_blind(), target_type);
 
@@ -594,9 +594,9 @@ MonsterSpellResult spell_RF6_HEAL(PlayerType *player_ptr, MONSTER_IDX m_idx, MON
     const auto m_poss = monster_desc(player_ptr, m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE);
 
     msg.to_player_true = _("%s^が何かをつぶやいた。", "%s^ mumbles.");
-    msg.to_mons_true = _("%s^は自分の傷に念を集中した。", format("%%s^ concentrates on %s wounds.", m_poss.data()));
-    msg.to_player_false = _("%s^が自分の傷に集中した。", format("%%s^ concentrates on %s wounds.", m_poss.data()));
-    msg.to_mons_false = _("%s^は自分の傷に念を集中した。", format("%%s^ concentrates on %s wounds.", m_poss.data()));
+    msg.to_mons_true = _("%s^は自分の傷に念を集中した。", angband::format("%%s^ concentrates on %s wounds.", m_poss.data()));
+    msg.to_player_false = _("%s^が自分の傷に集中した。", angband::format("%%s^ concentrates on %s wounds.", m_poss.data()));
+    msg.to_mons_false = _("%s^は自分の傷に念を集中した。", angband::format("%%s^ concentrates on %s wounds.", m_poss.data()));
 
     monspell_message_base(player_ptr, m_idx, t_idx, msg, is_blind, target_type);
 
@@ -634,7 +634,7 @@ MonsterSpellResult spell_RF6_HEAL(PlayerType *player_ptr, MONSTER_IDX m_idx, MON
 
     if (see_monster(player_ptr, m_idx)) {
         const auto m_name = monster_name(player_ptr, m_idx);
-        msg_print(_(format("%s^は勇気を取り戻した。", m_name.data()), format("%s^ recovers %s courage.", m_name.data(), m_poss.data())));
+        msg_print(_(angband::format("%s^は勇気を取り戻した。", m_name.data()), angband::format("%s^ recovers %s courage.", m_name.data(), m_poss.data())));
     }
 
     return res;

--- a/src/perception/identification.cpp
+++ b/src/perception/identification.cpp
@@ -807,7 +807,7 @@ bool screen_object(PlayerType *player_ptr, ItemEntity *o_ptr, BIT_FLAGS mode)
         auto statue_r_idx = i2enum<MonsterRaceId>(o_ptr->pval);
         auto *r_ptr = &monraces_info[statue_r_idx];
         int namelen = strlen(r_ptr->name.data());
-        prt(format("%s: '", r_ptr->name.data()), 1, 15);
+        prt(angband::format("%s: '", r_ptr->name.data()), 1, 15);
         term_queue_bigchar(18 + namelen, 1, r_ptr->x_attr, r_ptr->x_char, 0, 0);
         prt("'", 1, (use_bigtile ? 20 : 19) + namelen);
     } else {

--- a/src/player-info/alignment.cpp
+++ b/src/player-info/alignment.cpp
@@ -31,7 +31,7 @@ std::string PlayerAlignment::get_alignment_description(bool with_value)
 {
     auto s = alignment_label();
     if (with_value || show_actual_value) {
-        return format(_("%s(%ld)", "%s (%ld)"), s, static_cast<long>(this->player_ptr->alignment));
+        return angband::format(_("%s(%ld)", "%s (%ld)"), s, static_cast<long>(this->player_ptr->alignment));
     }
 
     return s;

--- a/src/player/patron.cpp
+++ b/src/player/patron.cpp
@@ -362,7 +362,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
 
             const auto item_name = describe_flavor(this->player_ptr, &this->player_ptr->inventory_list[slot], OD_NAME_ONLY);
             (void)curse_weapon_object(this->player_ptr, false, &this->player_ptr->inventory_list[slot]);
-            reward = format(_("%sが破壊された。", "destroying %s"), item_name.data());
+            reward = angband::format(_("%sが破壊された。", "destroying %s"), item_name.data());
             break;
         }
         case REW_CURSE_AR: {
@@ -374,7 +374,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
             msg_print(_("「汝、防具に頼ることなかれ。」", "'Thou reliest too much on thine equipment.'"));
             const auto item_name = describe_flavor(this->player_ptr, &this->player_ptr->inventory_list[INVEN_BODY], OD_NAME_ONLY);
             (void)curse_armor(this->player_ptr);
-            reward = format(_("%sが破壊された。", "destroying %s"), item_name.data());
+            reward = angband::format(_("%sが破壊された。", "destroying %s"), item_name.data());
             break;
         }
         case REW_PISS_OFF: {
@@ -405,7 +405,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
 
                     const auto item_name = describe_flavor(this->player_ptr, &this->player_ptr->inventory_list[slot], OD_NAME_ONLY);
                     (void)curse_weapon_object(this->player_ptr, false, &this->player_ptr->inventory_list[slot]);
-                    reward = format(_("%sが破壊された。", "destroying %s"), item_name.data());
+                    reward = angband::format(_("%sが破壊された。", "destroying %s"), item_name.data());
                 } else {
                     if (!this->player_ptr->inventory_list[INVEN_BODY].is_valid()) {
                         break;
@@ -413,7 +413,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
 
                     const auto item_name = describe_flavor(this->player_ptr, &this->player_ptr->inventory_list[INVEN_BODY], OD_NAME_ONLY);
                     (void)curse_armor(this->player_ptr);
-                    reward = format(_("%sが破壊された。", "destroying %s"), item_name.data());
+                    reward = angband::format(_("%sが破壊された。", "destroying %s"), item_name.data());
                 }
                 break;
             default:
@@ -516,7 +516,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
     }
 
     if (!reward.empty()) {
-        const auto note = format(_("パトロンの報酬で%s", "The patron rewarded you with %s."), reward.data());
+        const auto note = angband::format(_("パトロンの報酬で%s", "The patron rewarded you with %s."), reward.data());
         exe_write_diary(this->player_ptr, DiaryKind::DESCRIPTION, 0, note);
     }
 }

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -413,9 +413,9 @@ int take_hit(PlayerType *player_ptr, int damage_type, int damage, std::string_vi
 
                 auto hallucintion_state = is_hallucinated ? _("幻覚に歪んだ", "hallucinatingly distorted ") : "";
 #ifdef JP
-                player_ptr->died_from = format("%s%s%s", paralysis_state, hallucintion_state, hit_from.data());
+                player_ptr->died_from = angband::format("%s%s%s", paralysis_state, hallucintion_state, hit_from.data());
 #else
-                player_ptr->died_from = format("%s%s%s", hallucintion_state, hit_from.data(), paralysis_state);
+                player_ptr->died_from = angband::format("%s%s%s", hallucintion_state, hit_from.data(), paralysis_state);
 #endif
             }
 
@@ -433,13 +433,13 @@ int take_hit(PlayerType *player_ptr, int damage_type, int damage, std::string_vi
                 } else if (inside_quest(q_idx) && (QuestType::is_fixed(q_idx) && !((q_idx == QuestId::OBERON) || (q_idx == QuestId::SERPENT)))) {
                     place = _("クエスト", "in a quest");
                 } else {
-                    place = format(_("%d階", "on level %d"), static_cast<int>(floor.dun_level));
+                    place = angband::format(_("%d階", "on level %d"), static_cast<int>(floor.dun_level));
                 }
 
 #ifdef JP
-                const auto note = format("%sで%sに殺された。", place.data(), player_ptr->died_from.data());
+                const auto note = angband::format("%sで%sに殺された。", place.data(), player_ptr->died_from.data());
 #else
-                const auto note = format("killed by %s %s.", player_ptr->died_from.data(), place.data());
+                const auto note = angband::format("killed by %s %s.", player_ptr->died_from.data(), place.data());
 #endif
                 exe_write_diary(player_ptr, DiaryKind::DESCRIPTION, 0, note);
             }
@@ -488,7 +488,7 @@ int take_hit(PlayerType *player_ptr, int damage_type, int damage, std::string_vi
                 death_message = player_last_words;
                 if (death_message.empty()) {
 #ifdef JP
-                    death_message = format("あなたは%sました。", android ? "壊れ" : "死に");
+                    death_message = angband::format("あなたは%sました。", android ? "壊れ" : "死に");
 #else
                     death_message = android ? "You are broken." : "You die.";
 #endif

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -2975,12 +2975,12 @@ void check_experience(PlayerType *player_ptr)
                 while (true) {
                     int n;
 
-                    prt(format(_("        a) 腕力 (現在値 %s)", "        a) Str (cur %s)"), cnv_stat(player_ptr->stat_max[0]).data()), 2, 14);
-                    prt(format(_("        b) 知能 (現在値 %s)", "        b) Int (cur %s)"), cnv_stat(player_ptr->stat_max[1]).data()), 3, 14);
-                    prt(format(_("        c) 賢さ (現在値 %s)", "        c) Wis (cur %s)"), cnv_stat(player_ptr->stat_max[2]).data()), 4, 14);
-                    prt(format(_("        d) 器用 (現在値 %s)", "        d) Dex (cur %s)"), cnv_stat(player_ptr->stat_max[3]).data()), 5, 14);
-                    prt(format(_("        e) 耐久 (現在値 %s)", "        e) Con (cur %s)"), cnv_stat(player_ptr->stat_max[4]).data()), 6, 14);
-                    prt(format(_("        f) 魅力 (現在値 %s)", "        f) Chr (cur %s)"), cnv_stat(player_ptr->stat_max[5]).data()), 7, 14);
+                    prt(angband::format(_("        a) 腕力 (現在値 %s)", "        a) Str (cur %s)"), cnv_stat(player_ptr->stat_max[0]).data()), 2, 14);
+                    prt(angband::format(_("        b) 知能 (現在値 %s)", "        b) Int (cur %s)"), cnv_stat(player_ptr->stat_max[1]).data()), 3, 14);
+                    prt(angband::format(_("        c) 賢さ (現在値 %s)", "        c) Wis (cur %s)"), cnv_stat(player_ptr->stat_max[2]).data()), 4, 14);
+                    prt(angband::format(_("        d) 器用 (現在値 %s)", "        d) Dex (cur %s)"), cnv_stat(player_ptr->stat_max[3]).data()), 5, 14);
+                    prt(angband::format(_("        e) 耐久 (現在値 %s)", "        e) Con (cur %s)"), cnv_stat(player_ptr->stat_max[4]).data()), 6, 14);
+                    prt(angband::format(_("        f) 魅力 (現在値 %s)", "        f) Chr (cur %s)"), cnv_stat(player_ptr->stat_max[5]).data()), 7, 14);
 
                     prt("", 8, 14);
                     prt(_("        どの能力値を上げますか？", "        Which stat do you want to raise?"), 1, 14);
@@ -3049,16 +3049,16 @@ void check_experience(PlayerType *player_ptr)
 std::string cnv_stat(int val)
 {
     if (val <= 18) {
-        return format("    %2d", val);
+        return angband::format("    %2d", val);
     }
 
     int bonus = (val - 18);
     if (bonus >= 220) {
         return "18/***";
     } else if (bonus >= 100) {
-        return format("18/%03d", bonus);
+        return angband::format("18/%03d", bonus);
     } else {
-        return format(" 18/%02d", bonus);
+        return angband::format(" 18/%02d", bonus);
     }
 }
 

--- a/src/player/process-death.cpp
+++ b/src/player/process-death.cpp
@@ -70,11 +70,11 @@ static void show_tomb_line(std::string_view str, int row)
  */
 static void show_basic_params(PlayerType *player_ptr)
 {
-    show_tomb_line(format(_("レベル: %d", "Level: %d"), (int)player_ptr->lev), GRAVE_LEVEL_ROW);
+    show_tomb_line(angband::format(_("レベル: %d", "Level: %d"), (int)player_ptr->lev), GRAVE_LEVEL_ROW);
 
-    show_tomb_line(format(_("経験値: %ld", "Exp: %ld"), (long)player_ptr->exp), GRAVE_EXP_ROW);
+    show_tomb_line(angband::format(_("経験値: %ld", "Exp: %ld"), (long)player_ptr->exp), GRAVE_EXP_ROW);
 
-    show_tomb_line(format(_("所持金: %ld", "AU: %ld"), (long)player_ptr->au), GRAVE_AU_ROW);
+    show_tomb_line(angband::format(_("所持金: %ld", "AU: %ld"), (long)player_ptr->au), GRAVE_AU_ROW);
 }
 
 #ifdef JP
@@ -141,14 +141,14 @@ static void show_dead_place(PlayerType *player_ptr, int extra_line)
     if (player_ptr->current_floor_ptr->dun_level == 0) {
         concptr field_name = player_ptr->town_num ? "街" : "荒野";
         if (streq(player_ptr->died_from, "途中終了")) {
-            place = format("%sで死んだ", field_name);
+            place = angband::format("%sで死んだ", field_name);
         } else {
-            place = format("に%sで殺された", field_name);
+            place = angband::format("に%sで殺された", field_name);
         }
     } else if (streq(player_ptr->died_from, "途中終了")) {
-        place = format("地下 %d 階で死んだ", (int)player_ptr->current_floor_ptr->dun_level);
+        place = angband::format("地下 %d 階で死んだ", (int)player_ptr->current_floor_ptr->dun_level);
     } else {
-        place = format("に地下 %d 階で殺された", (int)player_ptr->current_floor_ptr->dun_level);
+        place = angband::format("に地下 %d 階で殺された", (int)player_ptr->current_floor_ptr->dun_level);
     }
 
     show_tomb_line(place, GRAVE_DEAD_PLACE_ROW + extra_line);
@@ -182,9 +182,9 @@ static void show_tomb_detail(PlayerType *player_ptr)
  */
 static void show_tomb_detail(PlayerType *player_ptr)
 {
-    show_tomb_line(format("Killed on Level %d", player_ptr->current_floor_ptr->dun_level), GRAVE_DEAD_PLACE_ROW);
+    show_tomb_line(angband::format("Killed on Level %d", player_ptr->current_floor_ptr->dun_level), GRAVE_DEAD_PLACE_ROW);
 
-    auto lines = shape_buffer(format("by %s.", player_ptr->died_from.data()).data(), GRAVE_LINE_WIDTH + 1);
+    auto lines = shape_buffer(angband::format("by %s.", player_ptr->died_from.data()).data(), GRAVE_LINE_WIDTH + 1);
     show_tomb_line(lines[0], GRAVE_KILLER_NAME_ROW);
     if (lines.size() == 1) {
         return;
@@ -227,7 +227,7 @@ void print_tomb(PlayerType *player_ptr)
     show_tomb_detail(player_ptr);
 
     time_t ct = time((time_t *)0);
-    show_tomb_line(format("%-.24s", ctime(&ct)), GRAVE_DEAD_DATETIME_ROW);
+    show_tomb_line(angband::format("%-.24s", ctime(&ct)), GRAVE_DEAD_DATETIME_ROW);
     msg_format(_("さようなら、%s!", "Goodbye, %s!"), player_ptr->name);
 }
 
@@ -314,12 +314,12 @@ static void show_dead_home_items(PlayerType *player_ptr)
             term_clear();
             for (int j = 0; (j < 12) && (i < store_ptr->stock_num); j++, i++) {
                 const auto *o_ptr = &store_ptr->stock[i];
-                prt(format("%c) ", I2A(j)), j + 2, 4);
+                prt(angband::format("%c) ", I2A(j)), j + 2, 4);
                 const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
                 c_put_str(tval_to_attr[enum2i(o_ptr->bi_key.tval())], item_name, j + 2, 7);
             }
 
-            prt(format(_("我が家に置いてあったアイテム ( %d ページ): -続く-", "Your home contains (page %d): -more-"), k + 1), 0, 0);
+            prt(angband::format(_("我が家に置いてあったアイテム ( %d ページ): -続く-", "Your home contains (page %d): -more-"), k + 1), 0, 0);
             if (inkey() == ESCAPE) {
                 return;
             }

--- a/src/racial/class-racial-switcher.cpp
+++ b/src/racial/class-racial-switcher.cpp
@@ -34,7 +34,7 @@ void switch_class_racial(PlayerType *player_ptr, rc_type *rc_ptr)
     case PlayerClassType::MAGE:
     case PlayerClassType::SORCERER:
         rpi = rpi_type(_("魔力食い", "Eat Magic"));
-        rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl * 2);
+        rpi.info = angband::format("%s%d", KWD_POWER, rc_ptr->lvl * 2);
         rpi.text = _("魔法道具から魔力を吸収してMPを回復する。", "Absorbs mana from a magic device to heal your SP.");
         rpi.min_level = 25;
         rpi.cost = 1;
@@ -53,7 +53,7 @@ void switch_class_racial(PlayerType *player_ptr, rc_type *rc_ptr)
             rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         } else {
             rpi = rpi_type(_("召魂", "Evocation"));
-            rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl * 4);
+            rpi.info = angband::format("%s%d", KWD_POWER, rc_ptr->lvl * 4);
             rpi.text = _("視界内の全てのモンスターにダメージを与え、恐怖させ、遠くへ飛ばす。", "Deals damage to all monster in your sight, makes them scared and tereports then away.");
             rpi.min_level = 42;
             rpi.cost = 40;
@@ -65,7 +65,7 @@ void switch_class_racial(PlayerType *player_ptr, rc_type *rc_ptr)
         break;
     case PlayerClassType::ROGUE:
         rpi = rpi_type(_("ヒット＆アウェイ", "Hit and Away"));
-        rpi.info = format("%s%d", KWD_SPHERE, 30);
+        rpi.info = angband::format("%s%d", KWD_SPHERE, 30);
         rpi.text = _("対象のモンスターを攻撃したあと短距離テレポートする。", "Attacks a monster then tereports you a short range.");
         rpi.min_level = 8;
         rpi.cost = 12;
@@ -86,7 +86,7 @@ void switch_class_racial(PlayerType *player_ptr, rc_type *rc_ptr)
     case PlayerClassType::PALADIN:
         if (is_good_realm(player_ptr->realm1)) {
             rpi = rpi_type(_("ホーリー・ランス", "Holy Lance"));
-            rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 3);
+            rpi.info = angband::format("%s%d", KWD_DAM, rc_ptr->lvl * 3);
             rpi.text = _("聖なる炎のビームを放つ。", "Fires a beam of holy fire.");
             rpi.min_level = 30;
             rpi.cost = 30;
@@ -95,7 +95,7 @@ void switch_class_racial(PlayerType *player_ptr, rc_type *rc_ptr)
             rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         } else {
             rpi = rpi_type(_("ヘル・ランス", "Hell Lance"));
-            rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 3);
+            rpi.info = angband::format("%s%d", KWD_DAM, rc_ptr->lvl * 3);
             rpi.text = _("地獄の業火のビームを放つ。", "Fires a beam of hell fire.");
             rpi.min_level = 30;
             rpi.cost = 30;
@@ -124,7 +124,7 @@ void switch_class_racial(PlayerType *player_ptr, rc_type *rc_ptr)
         break;
     case PlayerClassType::CHAOS_WARRIOR:
         rpi = rpi_type(_("幻惑の光", "Confusing Light"));
-        rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl * 4);
+        rpi.info = angband::format("%s%d", KWD_POWER, rc_ptr->lvl * 4);
         rpi.text = _("周辺のモンスターを減速・朦朧・混乱・朦朧・恐怖・睡眠させようとする。抵抗されると無効。",
             "Tries to make all monsters in your sight slowed, stunned, confused, scared, sleeped.");
         rpi.min_level = 40;
@@ -153,7 +153,7 @@ void switch_class_racial(PlayerType *player_ptr, rc_type *rc_ptr)
     case PlayerClassType::MINDCRAFTER:
     case PlayerClassType::FORCETRAINER:
         rpi = rpi_type(_("明鏡止水", "Clear Mind"));
-        rpi.info = format("%s%d", KWD_MANA, 3 + rc_ptr->lvl / 20);
+        rpi.info = angband::format("%s%d", KWD_MANA, 3 + rc_ptr->lvl / 20);
         rpi.text = _("精神を集中してMPを少し回復する。", "Concentrates deeply to heal your SP a little.");
         rpi.min_level = 15;
         rpi.cost = 0;
@@ -189,7 +189,7 @@ void switch_class_racial(PlayerType *player_ptr, rc_type *rc_ptr)
         break;
     case PlayerClassType::BEASTMASTER:
         rpi = rpi_type(_("生物支配", "Dominate a Living Thing"));
-        rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl);
+        rpi.info = angband::format("%s%d", KWD_POWER, rc_ptr->lvl);
         rpi.text = _("1体のモンスターをペットにする。抵抗されると無効。", "Attempts to charm a monster.");
         rpi.min_level = 1;
         rpi.cost = (player_ptr->lev + 3) / 4;
@@ -198,7 +198,7 @@ void switch_class_racial(PlayerType *player_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
 
         rpi = rpi_type(_("真・生物支配", "Dominate Living Things"));
-        rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl);
+        rpi.info = angband::format("%s%d", KWD_POWER, rc_ptr->lvl);
         rpi.text = _("周辺のモンスターをペットにする。抵抗されると無効。", "Attempts to charm a monsters in your sight.");
         rpi.min_level = 30;
         rpi.cost = (player_ptr->lev + 20) / 2;
@@ -306,7 +306,7 @@ void switch_class_racial(PlayerType *player_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
 
         rpi = rpi_type(_("静水", "Mirror Concentration"));
-        rpi.info = format("%s%d", KWD_MANA, 5 + rc_ptr->lvl * rc_ptr->lvl / 100);
+        rpi.info = angband::format("%s%d", KWD_MANA, 5 + rc_ptr->lvl * rc_ptr->lvl / 100);
         rpi.text = _("精神を集中してMPを少し回復する。", "Concentrates deeply to heal your SP a little.");
         rpi.min_level = 30;
         rpi.cost = 0;
@@ -334,7 +334,7 @@ void switch_class_racial(PlayerType *player_ptr, rc_type *rc_ptr)
         break;
     case PlayerClassType::ELEMENTALIST:
         rpi = rpi_type(_("明鏡止水", "Clear Mind"));
-        rpi.info = format("%s%d", KWD_MANA, 3 + rc_ptr->lvl / 20);
+        rpi.info = angband::format("%s%d", KWD_MANA, 3 + rc_ptr->lvl / 20);
         rpi.text = _("精神を集中してMPを少し回復する。", "Concentrates deeply to heal your SP a little.");
         rpi.min_level = 15;
         rpi.cost = 0;

--- a/src/racial/mutation-racial-selector.cpp
+++ b/src/racial/mutation-racial-selector.cpp
@@ -11,7 +11,7 @@ void select_mutation_racial(PlayerType *player_ptr, rc_type *rc_ptr)
     rpi_type rpi;
     if (player_ptr->muta.has(PlayerMutationType::SPIT_ACID)) {
         rpi = rpi_type(_("酸の唾", "Spit Acid"));
-        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl);
+        rpi.info = angband::format("%s%d", KWD_DAM, rc_ptr->lvl);
         rpi.text = _("酸のボールを放つ", "Fires a boll of acid.");
         rpi.min_level = 9;
         rpi.cost = 9;
@@ -22,7 +22,7 @@ void select_mutation_racial(PlayerType *player_ptr, rc_type *rc_ptr)
 
     if (player_ptr->muta.has(PlayerMutationType::BR_FIRE)) {
         rpi = rpi_type(_("炎のブレス", "Fire Breath"));
-        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl);
+        rpi.info = angband::format("%s%d", KWD_DAM, rc_ptr->lvl);
         rpi.text = _("火炎のブレスを放つ", "Fires a breath of fire.");
         rpi.min_level = 20;
         rpi.cost = rc_ptr->lvl;
@@ -33,7 +33,7 @@ void select_mutation_racial(PlayerType *player_ptr, rc_type *rc_ptr)
 
     if (player_ptr->muta.has(PlayerMutationType::HYPN_GAZE)) {
         rpi = rpi_type(_("催眠睨み", "Hypnotic Gaze"));
-        rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl);
+        rpi.info = angband::format("%s%d", KWD_POWER, rc_ptr->lvl);
         rpi.text = _("モンスター1体をペットにする。抵抗されると無効。", "Attempts to charm a monster.");
         rpi.min_level = 12;
         rpi.cost = 12;
@@ -45,9 +45,9 @@ void select_mutation_racial(PlayerType *player_ptr, rc_type *rc_ptr)
     if (player_ptr->muta.has(PlayerMutationType::TELEKINES)) {
         rpi = rpi_type(_("念動力", "Telekinesis"));
 #ifdef JP
-        rpi.info = format("最大重量: %d.%dkg", lb_to_kg_integer(rc_ptr->lvl * 10), lb_to_kg_fraction(rc_ptr->lvl * 10));
+        rpi.info = angband::format("最大重量: %d.%dkg", lb_to_kg_integer(rc_ptr->lvl * 10), lb_to_kg_fraction(rc_ptr->lvl * 10));
 #else
-        rpi.info = format("max wgt %d", rc_ptr->lvl * 10);
+        rpi.info = angband::format("max wgt %d", rc_ptr->lvl * 10);
 #endif
         rpi.text = _("アイテムを自分の足元へ移動させる。", "Pulls a distant item close to you.");
         rpi.min_level = 9;
@@ -59,7 +59,7 @@ void select_mutation_racial(PlayerType *player_ptr, rc_type *rc_ptr)
 
     if (player_ptr->muta.has(PlayerMutationType::VTELEPORT)) {
         rpi = rpi_type(_("テレポート", "Teleport"));
-        rpi.info = format("%s%d", KWD_SPHERE, 10 + rc_ptr->lvl * 4);
+        rpi.info = angband::format("%s%d", KWD_SPHERE, 10 + rc_ptr->lvl * 4);
         rpi.text = _("遠距離のテレポートをする。", "Teleports you a long distance.");
         rpi.min_level = 7;
         rpi.cost = 7;
@@ -70,7 +70,7 @@ void select_mutation_racial(PlayerType *player_ptr, rc_type *rc_ptr)
 
     if (player_ptr->muta.has(PlayerMutationType::MIND_BLST)) {
         rpi = rpi_type(_("精神攻撃", "Mind Blast"));
-        rpi.info = format("%s%dd%d", KWD_DAM, 3 + (rc_ptr->lvl - 1) / 5, 3);
+        rpi.info = angband::format("%s%dd%d", KWD_DAM, 3 + (rc_ptr->lvl - 1) / 5, 3);
         rpi.text = _("モンスター1体に精神攻撃を行う。", "Deals a PSI damage to a monster.");
         rpi.min_level = 5;
         rpi.cost = 3;
@@ -81,7 +81,7 @@ void select_mutation_racial(PlayerType *player_ptr, rc_type *rc_ptr)
 
     if (player_ptr->muta.has(PlayerMutationType::RADIATION)) {
         rpi = rpi_type(_("放射能", "Emit Radiation"));
-        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
+        rpi.info = angband::format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
         rpi.text = _("自分を中心とする放射性廃棄物のボールを放つ。", "Burst nuke ball.");
         rpi.min_level = 15;
         rpi.cost = 15;
@@ -92,7 +92,7 @@ void select_mutation_racial(PlayerType *player_ptr, rc_type *rc_ptr)
 
     if (player_ptr->muta.has(PlayerMutationType::VAMPIRISM)) {
         rpi = rpi_type(_("吸血", "Vampiric Drain"));
-        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
+        rpi.info = angband::format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
         rpi.text = _("隣接したモンスター1体から生命力を吸い取る。吸い取った生命力によって満腹度があがる。",
             "Drains and transfers HP from a monster near by you. You will also gain nutritional sustenance from this.");
         rpi.min_level = 2;
@@ -124,7 +124,7 @@ void select_mutation_racial(PlayerType *player_ptr, rc_type *rc_ptr)
 
     if (player_ptr->muta.has(PlayerMutationType::BLINK)) {
         rpi = rpi_type(_("ショート・テレポート", "Blink"));
-        rpi.info = format("%s%d", KWD_SPHERE, 10);
+        rpi.info = angband::format("%s%d", KWD_SPHERE, 10);
         rpi.text = _("近距離のテレポートをする。", "Teleports you a short distance.");
         rpi.min_level = 3;
         rpi.cost = 3;
@@ -145,7 +145,7 @@ void select_mutation_racial(PlayerType *player_ptr, rc_type *rc_ptr)
 
     if (player_ptr->muta.has(PlayerMutationType::SWAP_POS)) {
         rpi = rpi_type(_("位置交換", "Swap Position"));
-        rpi.info = format("%s%d", KWD_SPHERE, 10 + rc_ptr->lvl * 3 / 2);
+        rpi.info = angband::format("%s%d", KWD_SPHERE, 10 + rc_ptr->lvl * 3 / 2);
         rpi.text = _("対象のモンスター1体を位置を交換する。", "Swaps positions between you and a target monster.");
         rpi.min_level = 15;
         rpi.cost = 12;
@@ -186,7 +186,7 @@ void select_mutation_racial(PlayerType *player_ptr, rc_type *rc_ptr)
 
     if (player_ptr->muta.has(PlayerMutationType::BERSERK)) {
         rpi = rpi_type(_("狂戦士化", "Berserk"));
-        rpi.info = format("%s%d+d%d", KWD_DURATION, 25, 25);
+        rpi.info = angband::format("%s%d+d%d", KWD_DURATION, 25, 25);
         rpi.text = _("狂戦士化し、恐怖を除去する。防御力が少し低下する。", "Gives a bonus to hit and HP, immunity to fear for a while. But decreases AC.");
         rpi.min_level = 8;
         rpi.cost = 8;
@@ -227,7 +227,7 @@ void select_mutation_racial(PlayerType *player_ptr, rc_type *rc_ptr)
 
     if (player_ptr->muta.has(PlayerMutationType::RESIST)) {
         rpi = rpi_type(_("エレメント耐性", "Resist Elements"));
-        rpi.info = format("%s%d+d%d", KWD_DURATION, 20, 20);
+        rpi.info = angband::format("%s%d+d%d", KWD_DURATION, 20, 20);
         rpi.text = _("1つ以上の元素の一時耐性を得る。", "Gains one or more resitances for elements.");
         rpi.min_level = 10;
         rpi.cost = 12;
@@ -238,7 +238,7 @@ void select_mutation_racial(PlayerType *player_ptr, rc_type *rc_ptr)
 
     if (player_ptr->muta.has(PlayerMutationType::EARTHQUAKE)) {
         rpi = rpi_type(_("地震", "Earthquake"));
-        rpi.info = format("%s%d", KWD_SPHERE, 10);
+        rpi.info = angband::format("%s%d", KWD_SPHERE, 10);
         rpi.text = _("周囲のダンジョンを揺らし、壁と床をランダムに入れ変える。", "Shakes dungeon structure, and results in random swapping of floors and walls.");
         rpi.min_level = 12;
         rpi.cost = 12;
@@ -249,7 +249,7 @@ void select_mutation_racial(PlayerType *player_ptr, rc_type *rc_ptr)
 
     if (player_ptr->muta.has(PlayerMutationType::EAT_MAGIC)) {
         rpi = rpi_type(_("魔力食い", "Eat Magic"));
-        rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl * 2);
+        rpi.info = angband::format("%s%d", KWD_POWER, rc_ptr->lvl * 2);
         rpi.text = _("魔法道具から魔力を吸収してMPを回復する。", "Absorbs mana from a magic device to heal your SP.");
         rpi.min_level = 17;
         rpi.cost = 1;
@@ -280,7 +280,7 @@ void select_mutation_racial(PlayerType *player_ptr, rc_type *rc_ptr)
 
     if (player_ptr->muta.has(PlayerMutationType::HIT_AND_AWAY)) {
         rpi = rpi_type(_("ヒット＆アウェイ", "Panic Hit"));
-        rpi.info = format("%s%d", KWD_SPHERE, 30);
+        rpi.info = angband::format("%s%d", KWD_SPHERE, 30);
         rpi.text = _("対象のモンスターを攻撃したあと短距離テレポートする。", "Attacks a monster then tereports you a short range.");
         rpi.min_level = 10;
         rpi.cost = 12;
@@ -291,7 +291,7 @@ void select_mutation_racial(PlayerType *player_ptr, rc_type *rc_ptr)
 
     if (player_ptr->muta.has(PlayerMutationType::DAZZLE)) {
         rpi = rpi_type(_("眩惑", "Dazzle"));
-        rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl * 4);
+        rpi.info = angband::format("%s%d", KWD_POWER, rc_ptr->lvl * 4);
         rpi.text = _("周辺のモンスターを混乱・朦朧・恐怖させようとする。抵抗されると無効。",
             "Tries to make all monsters in your sight confused, stunned, scared.");
         rpi.min_level = 7;
@@ -303,7 +303,7 @@ void select_mutation_racial(PlayerType *player_ptr, rc_type *rc_ptr)
 
     if (player_ptr->muta.has(PlayerMutationType::LASER_EYE)) {
         rpi = rpi_type(_("レーザー・アイ", "Laser Eye"));
-        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
+        rpi.info = angband::format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
         rpi.text = _("閃光のビームを放つ。", "Fires a beam of light.");
         rpi.min_level = 7;
         rpi.cost = 10;
@@ -325,7 +325,7 @@ void select_mutation_racial(PlayerType *player_ptr, rc_type *rc_ptr)
 
     if (player_ptr->muta.has(PlayerMutationType::BANISH)) {
         rpi = rpi_type(_("邪悪消滅", "Banish Evil"));
-        rpi.info = format("%s%d", KWD_POWER, 50 + rc_ptr->lvl);
+        rpi.info = angband::format("%s%d", KWD_POWER, 50 + rc_ptr->lvl);
         rpi.text = _("邪悪なモンスター1体を階から消滅させる。", "Erase a evil monster from current level.");
         rpi.min_level = 25;
         rpi.cost = 25;
@@ -336,7 +336,7 @@ void select_mutation_racial(PlayerType *player_ptr, rc_type *rc_ptr)
 
     if (player_ptr->muta.has(PlayerMutationType::COLD_TOUCH)) {
         rpi = rpi_type(_("凍結の手", "Cold Touch"));
-        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
+        rpi.info = angband::format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
         rpi.text = _("冷気のビームを放つ。", "Fires a beam of cold.");
         rpi.min_level = 2;
         rpi.cost = 2;

--- a/src/racial/race-racial-command-setter.cpp
+++ b/src/racial/race-racial-command-setter.cpp
@@ -13,7 +13,7 @@ void set_mimic_racial_command(PlayerType *player_ptr, rc_type *rc_ptr)
     case MimicKindType::DEMON:
     case MimicKindType::DEMON_LORD:
         rpi = rpi_type(_("地獄/火炎のブレス", "Nether or Fire Breath"));
-        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 3);
+        rpi.info = angband::format("%s%d", KWD_DAM, rc_ptr->lvl * 3);
         rpi.text = _("火炎または地獄のブレスを放つ。", "Fires a breath of fire or nether.");
         rpi.min_level = 15;
         rpi.cost = 10 + rc_ptr->lvl / 3;
@@ -23,7 +23,7 @@ void set_mimic_racial_command(PlayerType *player_ptr, rc_type *rc_ptr)
         return;
     case MimicKindType::VAMPIRE:
         rpi = rpi_type(_("吸血", "Vampiric Drain"));
-        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
+        rpi.info = angband::format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
         rpi.text = _("隣接したモンスター1体から生命力を吸い取る。吸い取った生命力によって満腹度があがる。",
             "Drains and transfers HP from a monster near by you. You will also gain nutritional sustenance from this.");
         rpi.min_level = 2;
@@ -68,7 +68,7 @@ void set_race_racial_command(PlayerType *player_ptr, rc_type *rc_ptr)
         break;
     case PlayerRaceType::GNOME:
         rpi = rpi_type(_("ショート・テレポート", "Blink"));
-        rpi.info = format("%s%d", KWD_SPHERE, 10);
+        rpi.info = angband::format("%s%d", KWD_SPHERE, 10);
         rpi.text = _("近距離のテレポートをする。", "Teleports you a short distance.");
         rpi.min_level = 5;
         rpi.cost = 5;
@@ -87,7 +87,7 @@ void set_race_racial_command(PlayerType *player_ptr, rc_type *rc_ptr)
         break;
     case PlayerRaceType::HALF_TROLL:
         rpi = rpi_type(_("狂戦士化", "Berserk"));
-        rpi.info = format("%s%d+d%d", KWD_DURATION, 10, rc_ptr->lvl);
+        rpi.info = angband::format("%s%d+d%d", KWD_DURATION, 10, rc_ptr->lvl);
         rpi.text = _("狂戦士化し、恐怖を除去する。防御力が少し低下する。", "Gives a bonus to hit and HP, immunity to fear for a while. But decreases AC.");
         rpi.min_level = 10;
         rpi.cost = 12;
@@ -97,7 +97,7 @@ void set_race_racial_command(PlayerType *player_ptr, rc_type *rc_ptr)
         break;
     case PlayerRaceType::BARBARIAN:
         rpi = rpi_type(_("狂戦士化", "Berserk"));
-        rpi.info = format("%s%d+d%d", KWD_DURATION, 10, rc_ptr->lvl);
+        rpi.info = angband::format("%s%d+d%d", KWD_DURATION, 10, rc_ptr->lvl);
         rpi.text = _("狂戦士化し、恐怖を除去する。防御力が少し低下する。", "Gives a bonus to hit and HP, immunity to fear for a while. But decreases AC.");
         rpi.min_level = 8;
         rpi.cost = 10;
@@ -152,7 +152,7 @@ void set_race_racial_command(PlayerType *player_ptr, rc_type *rc_ptr)
         break;
     case PlayerRaceType::CYCLOPS:
         rpi = rpi_type(_("岩石投げ", "Throw Boulder"));
-        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 3 / 2);
+        rpi.info = angband::format("%s%d", KWD_DAM, rc_ptr->lvl * 3 / 2);
         rpi.text = _("弱い魔法のボールを放つ", "Fires a weak boll of magic.");
         rpi.min_level = 20;
         rpi.cost = 15;
@@ -180,7 +180,7 @@ void set_race_racial_command(PlayerType *player_ptr, rc_type *rc_ptr)
         break;
     case PlayerRaceType::KLACKON:
         rpi = rpi_type(_("酸の唾", "Spit Acid"));
-        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl);
+        rpi.info = angband::format("%s%d", KWD_DAM, rc_ptr->lvl);
         if (rc_ptr->lvl >= 25) {
             rpi.text = _("酸のボールを放つ", "Fires a boll of acid.");
         } else {
@@ -194,7 +194,7 @@ void set_race_racial_command(PlayerType *player_ptr, rc_type *rc_ptr)
         break;
     case PlayerRaceType::KOBOLD:
         rpi = rpi_type(_("毒のダーツ", "Poison Dart"));
-        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl);
+        rpi.info = angband::format("%s%d", KWD_DAM, rc_ptr->lvl);
         rpi.text = _("毒の矢を放つ", "Fires a bolt of poison.");
         rpi.min_level = 12;
         rpi.cost = 8;
@@ -204,7 +204,7 @@ void set_race_racial_command(PlayerType *player_ptr, rc_type *rc_ptr)
         break;
     case PlayerRaceType::DARK_ELF:
         rpi = rpi_type(_("マジック・ミサイル", "Magic Missile"));
-        rpi.info = format("%s%dd%d", KWD_DAM, 3 + ((rc_ptr->lvl - 1) / 5), 4);
+        rpi.info = angband::format("%s%dd%d", KWD_DAM, 3 + ((rc_ptr->lvl - 1) / 5), 4);
         rpi.text = _("弱い魔法の矢を放つ。", "Fires a weak bolt of magic.");
         rpi.min_level = 2;
         rpi.cost = 2;
@@ -214,7 +214,7 @@ void set_race_racial_command(PlayerType *player_ptr, rc_type *rc_ptr)
         break;
     case PlayerRaceType::DRACONIAN:
         rpi = rpi_type(_("ブレス", "Breath Weapon"));
-        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
+        rpi.info = angband::format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
         rpi.text = _("元素のブレスを放つ", "Fires a breath of an element.");
         rpi.min_level = 1;
         rpi.cost = rc_ptr->lvl;
@@ -224,7 +224,7 @@ void set_race_racial_command(PlayerType *player_ptr, rc_type *rc_ptr)
         break;
     case PlayerRaceType::MIND_FLAYER:
         rpi = rpi_type(_("精神攻撃", "Mind Blast"));
-        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl);
+        rpi.info = angband::format("%s%d", KWD_DAM, rc_ptr->lvl);
         rpi.text = _("モンスター1体に精神攻撃を行う。", "Deals a PSI damage to a monster.");
         rpi.min_level = 15;
         rpi.cost = 12;
@@ -240,7 +240,7 @@ void set_race_racial_command(PlayerType *player_ptr, rc_type *rc_ptr)
             rpi = rpi_type(_("ファイア・ボルト", "Fire Bolt"));
             rpi.text = _("火炎の矢を放つ。", "Fires a bolt of fire.");
         }
-        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl);
+        rpi.info = angband::format("%s%d", KWD_DAM, rc_ptr->lvl);
         rpi.min_level = 9;
         rpi.cost = 15;
         rpi.stat = A_WIS;
@@ -249,7 +249,7 @@ void set_race_racial_command(PlayerType *player_ptr, rc_type *rc_ptr)
         break;
     case PlayerRaceType::GOLEM:
         rpi = rpi_type(_("肌石化", "Stone Skin"));
-        rpi.info = format("%s%d+d%d", KWD_DURATION, 30, 20);
+        rpi.info = angband::format("%s%d+d%d", KWD_DURATION, 30, 20);
         rpi.text = _("一定期間防御力を高める。", "Increases your AC temporary");
         rpi.min_level = 20;
         rpi.cost = 15;
@@ -269,7 +269,7 @@ void set_race_racial_command(PlayerType *player_ptr, rc_type *rc_ptr)
         break;
     case PlayerRaceType::VAMPIRE:
         rpi = rpi_type(_("吸血", "Vampiric Drain"));
-        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
+        rpi.info = angband::format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
         rpi.text = _("隣接したモンスター1体から生命力を吸い取る。吸い取った生命力によって満腹度があがる。",
             "Drains and transfers HP from a monster near by you. You will also gain nutritional sustenance from this.");
         rpi.min_level = 2;
@@ -280,7 +280,7 @@ void set_race_racial_command(PlayerType *player_ptr, rc_type *rc_ptr)
         break;
     case PlayerRaceType::SPRITE:
         rpi = rpi_type(_("眠り粉", "Sleeping Dust"));
-        rpi.info = format("%s%d", KWD_POWER, rc_ptr->lvl);
+        rpi.info = angband::format("%s%d", KWD_POWER, rc_ptr->lvl);
         rpi.text = _("モンスター1体を眠らせる。抵抗されると無効。", "Attempts to put a monster to sleep.");
         rpi.min_level = 12;
         rpi.cost = 12;
@@ -290,7 +290,7 @@ void set_race_racial_command(PlayerType *player_ptr, rc_type *rc_ptr)
         break;
     case PlayerRaceType::BALROG:
         rpi = rpi_type(_("地獄/火炎のブレス", "Nether or Fire Breath"));
-        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 3);
+        rpi.info = angband::format("%s%d", KWD_DAM, rc_ptr->lvl * 3);
         rpi.text = _("火炎または地獄のブレスを放つ。", "Fires a breath of fire or nether.");
         rpi.min_level = 15;
         rpi.cost = 10 + rc_ptr->lvl / 3;
@@ -300,7 +300,7 @@ void set_race_racial_command(PlayerType *player_ptr, rc_type *rc_ptr)
         break;
     case PlayerRaceType::KUTAR:
         rpi = rpi_type(_("横に伸びる", "Expand Horizontally"));
-        rpi.info = format("%s%d+d%d", KWD_DURATION, 30, 20);
+        rpi.info = angband::format("%s%d+d%d", KWD_DURATION, 30, 20);
         rpi.text = _("横に伸びて防御力を高める。魔法防御力は低下する。",
             "Expands your body horizontally then increases AC, but decreases your magic resistance for curses.");
         rpi.min_level = 20;
@@ -312,35 +312,35 @@ void set_race_racial_command(PlayerType *player_ptr, rc_type *rc_ptr)
     case PlayerRaceType::ANDROID:
         if (player_ptr->lev < 10) {
             rpi = rpi_type(_("レイガン", "Ray Gun"));
-            rpi.info = format("%s%d", KWD_DAM, (rc_ptr->lvl + 1) / 2);
+            rpi.info = angband::format("%s%d", KWD_DAM, (rc_ptr->lvl + 1) / 2);
             rpi.text = _("弱い魔法の矢を放つ。", "Fires a weak bolt of magic.");
             rpi.min_level = 1;
             rpi.cost = 7;
             rpi.fail = 8;
         } else if (player_ptr->lev < 25) {
             rpi = rpi_type(_("ブラスター", "Blaster"));
-            rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl);
+            rpi.info = angband::format("%s%d", KWD_DAM, rc_ptr->lvl);
             rpi.text = _("弱い魔法の矢を放つ。", "Fires a weak bolt of magic.");
             rpi.min_level = 10;
             rpi.cost = 13;
             rpi.fail = 10;
         } else if (player_ptr->lev < 35) {
             rpi = rpi_type(_("バズーカ", "Bazooka"));
-            rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
+            rpi.info = angband::format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
             rpi.text = _("弱い魔法のボールを放つ。", "Fires a weak ball of magic.");
             rpi.min_level = 25;
             rpi.cost = 26;
             rpi.fail = 12;
         } else if (player_ptr->lev < 45) {
             rpi = rpi_type(_("ビームキャノン", "Beam Cannon"));
-            rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
+            rpi.info = angband::format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
             rpi.text = _("弱い魔法のビームを放つ。", "Fires a beam bolt of magic.");
             rpi.min_level = 35;
             rpi.cost = 40;
             rpi.fail = 15;
         } else {
             rpi = rpi_type(_("ロケット", "Rocket"));
-            rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 5);
+            rpi.info = angband::format("%s%d", KWD_DAM, rc_ptr->lvl * 5);
             rpi.text = _("ロケットを放つ。", "Fires a magic rocket.");
             rpi.min_level = 45;
             rpi.cost = 60;

--- a/src/realm/realm-chaos.cpp
+++ b/src/realm/realm-chaos.cpp
@@ -694,7 +694,7 @@ std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spel
 
         {
             if (info) {
-                return format("%s150 / 250", KWD_DAM);
+                return angband::format("%s150 / 250", KWD_DAM);
             }
 
             if (cast) {
@@ -782,7 +782,7 @@ std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spel
         }
         {
             if (info) {
-                return format("%s3 * 175", KWD_DAM);
+                return angband::format("%s3 * 175", KWD_DAM);
             }
 
             if (cast) {

--- a/src/realm/realm-crusade.cpp
+++ b/src/realm/realm-crusade.cpp
@@ -377,7 +377,7 @@ std::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX sp
         auto dam_sides = plev * 6;
         auto heal = 100;
         if (info) {
-            return format(_("損:1d%d/回%d", "dam:d%d/h%d"), dam_sides, heal);
+            return angband::format(_("損:1d%d/回%d", "dam:d%d/h%d"), dam_sides, heal);
         }
 
         if (cast) {
@@ -714,7 +714,7 @@ std::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX sp
             int power = plev * 4;
 
             if (info) {
-                return format(_("回%d/損%d+%d", "h%d/dm%d+%d"), heal, d_dam, b_dam / 2);
+                return angband::format(_("回%d/損%d+%d", "h%d/dm%d+%d"), heal, d_dam, b_dam / 2);
             }
             if (cast) {
                 project(player_ptr, 0, 1, player_ptr->y, player_ptr->x, b_dam, AttributeType::HOLY_FIRE, PROJECT_KILL);

--- a/src/realm/realm-death.cpp
+++ b/src/realm/realm-death.cpp
@@ -595,7 +595,7 @@ std::optional<std::string> do_death_spell(PlayerType *player_ptr, SPELL_IDX spel
             int dam = 100;
 
             if (info) {
-                return format("%s3*%d", KWD_DAM, dam);
+                return angband::format("%s3*%d", KWD_DAM, dam);
             }
 
             if (cast) {

--- a/src/realm/realm-demon.cpp
+++ b/src/realm/realm-demon.cpp
@@ -549,7 +549,7 @@ std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spe
             int sides2 = plev * 2;
 
             if (info) {
-                return format("%sd%d+d%d", KWD_DAM, sides1, sides2);
+                return angband::format("%sd%d+d%d", KWD_DAM, sides1, sides2);
             }
 
             if (cast) {
@@ -660,7 +660,7 @@ std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spe
             POSITION rad = 3 + plev / 20;
 
             if (info) {
-                return format("%s%d+%d", KWD_DAM, dam / 2, dam / 2);
+                return angband::format("%s%d+%d", KWD_DAM, dam / 2, dam / 2);
             }
 
             if (cast) {

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -175,7 +175,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
             const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
             auto f = object_flags(o_ptr);
 
-            if (!get_check(format(_("本当に %s を呪いますか？", "Do you curse %s, really？"), item_name.data()))) {
+            if (!get_check(angband::format(_("本当に %s を呪いますか？", "Do you curse %s, really？"), item_name.data()))) {
                 return "";
             }
 
@@ -530,7 +530,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
             const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
             auto f = object_flags(o_ptr);
 
-            if (!get_check(format(_("本当に %s を呪いますか？", "Do you curse %s, really？"), item_name.data()))) {
+            if (!get_check(angband::format(_("本当に %s を呪いますか？", "Do you curse %s, really？"), item_name.data()))) {
                 return "";
             }
 

--- a/src/realm/realm-nature.cpp
+++ b/src/realm/realm-nature.cpp
@@ -95,7 +95,7 @@ std::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spe
             POSITION range = plev / 6 + 2;
 
             if (info) {
-                return format("%s%dd%d %s%d", KWD_DAM, dice, sides, KWD_RANGE, range);
+                return angband::format("%s%dd%d %s%d", KWD_DAM, dice, sides, KWD_RANGE, range);
             }
 
             if (cast) {
@@ -764,7 +764,7 @@ std::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spe
             POSITION q_rad = 20 + plev / 2;
 
             if (info) {
-                return format("%s%d+%d", KWD_DAM, d_dam, b_dam / 2);
+                return angband::format("%s%d+%d", KWD_DAM, d_dam, b_dam / 2);
             }
 
             if (cast) {

--- a/src/realm/realm-song.cpp
+++ b/src/realm/realm-song.cpp
@@ -755,7 +755,7 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
             DICE_SID e_sides = plev * 3;
 
             if (info) {
-                return format("%s1d%d+1d%d", KWD_DAM, m_sides, e_sides);
+                return angband::format("%s1d%d+1d%d", KWD_DAM, m_sides, e_sides);
             }
 
             if (cont) {

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -163,7 +163,7 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
             if (m_idx) {
                 auto *m_ptr = &floor_ptr->m_list[m_idx];
                 const auto m_name = monster_desc(player_ptr, m_ptr, MD_WRONGDOER_NAME);
-                killer = format(_("%sの起こした地震", "an earthquake caused by %s"), m_name.data());
+                killer = angband::format(_("%sの起こした地震", "an earthquake caused by %s"), m_name.data());
             } else {
                 killer = _("地震", "an earthquake");
             }

--- a/src/spell-kind/spells-genocide.cpp
+++ b/src/spell-kind/spells-genocide.cpp
@@ -107,7 +107,7 @@ bool genocide_aux(PlayerType *player_ptr, MONSTER_IDX m_idx, int power, bool pla
     }
 
     if (player_cast) {
-        take_hit(player_ptr, DAMAGE_GENO, randint1(dam_side), format(_("%s^の呪文を唱えた疲労", "the strain of casting %s^"), spell_name));
+        take_hit(player_ptr, DAMAGE_GENO, randint1(dam_side), angband::format(_("%s^の呪文を唱えた疲労", "the strain of casting %s^"), spell_name));
     }
 
     move_cursor_relative(player_ptr->y, player_ptr->x);

--- a/src/spell-kind/spells-sight.cpp
+++ b/src/spell-kind/spells-sight.cpp
@@ -405,10 +405,10 @@ std::string probed_monster_info(PlayerType *player_ptr, MonsterEntity *m_ptr, Mo
 
     const auto speed = m_ptr->get_temporary_speed() - STANDARD_SPEED;
     constexpr auto mes = _("%s ... 属性:%s HP:%d/%d AC:%d 速度:%s%d 経験:", "%s ... align:%s HP:%d/%d AC:%d speed:%s%d exp:");
-    auto result = format(mes, m_name.data(), align, (int)m_ptr->hp, (int)m_ptr->maxhp, r_ptr->ac, (speed > 0) ? "+" : "", speed);
+    auto result = angband::format(mes, m_name.data(), align, (int)m_ptr->hp, (int)m_ptr->maxhp, r_ptr->ac, (speed > 0) ? "+" : "", speed);
 
     if (MonsterRace(r_ptr->next_r_idx).is_valid()) {
-        result.append(format("%d/%d ", m_ptr->exp, r_ptr->next_exp));
+        result.append(angband::format("%d/%d ", m_ptr->exp, r_ptr->next_exp));
     } else {
         result.append("xxx ");
     }

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -261,7 +261,7 @@ bool teleport_level_other(PlayerType *player_ptr)
     auto has_immune = r_ptr->resistance_flags.has_any_of(RFR_EFF_RESIST_NEXUS_MASK) || r_ptr->resistance_flags.has(MonsterResistanceType::RESIST_TELEPORT);
 
     if (has_immune || (r_ptr->flags1 & RF1_QUESTOR) || (r_ptr->level + randint1(50) > player_ptr->lev + randint1(60))) {
-        msg_print(_("しかし効果がなかった！", format("%s^ is unaffected!", m_name.data())));
+        msg_print(_("しかし効果がなかった！", angband::format("%s^ is unaffected!", m_name.data())));
     } else {
         teleport_level(player_ptr, target_m_idx);
     }
@@ -423,7 +423,7 @@ static DUNGEON_IDX choose_dungeon(concptr note, POSITION y, POSITION x)
         prt(_("      選べるダンジョンがない。", "      No dungeon is available."), y, x);
     }
 
-    prt(format(_("どのダンジョン%sしますか:", "Which dungeon do you %s?: "), note), 0, 0);
+    prt(angband::format(_("どのダンジョン%sしますか:", "Which dungeon do you %s?: "), note), 0, 0);
     while (true) {
         auto i = inkey();
         if ((i == ESCAPE) || dun.empty()) {
@@ -513,7 +513,7 @@ bool free_level_recall(PlayerType *player_ptr)
     }
 
     const auto mes = _("%sの何階にテレポートしますか？", "Teleport to which level of %s? ");
-    QUANTITY amt = get_quantity(format(mes, dungeon.name.data()), (QUANTITY)max_depth);
+    QUANTITY amt = get_quantity(angband::format(mes, dungeon.name.data()), (QUANTITY)max_depth);
     if (amt <= 0) {
         return false;
     }

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -185,7 +185,7 @@ void SpellHex::display_casting_spells_list()
     for (auto spell : this->casting_spells) {
         term_erase(x, y + n + 1, 255);
         const auto spell_name = exe_spell(this->player_ptr, REALM_HEX, spell, SpellProcessType::NAME);
-        put_str(format("%c)  %s", I2A(n), spell_name->data()), y + n + 1, x + 2);
+        put_str(angband::format("%c)  %s", I2A(n), spell_name->data()), y + n + 1, x + 2);
         n++;
     }
 }

--- a/src/spell/spell-info.cpp
+++ b/src/spell/spell-info.cpp
@@ -303,11 +303,11 @@ void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell, SPELL_IDX *spe
                 out_val = "     ";
             }
         } else {
-            out_val = format("  %c) ", I2A(i));
+            out_val = angband::format("  %c) ", I2A(i));
         }
 
         if (s_ptr->slevel >= 99) {
-            out_val.append(format("%-30s", _("(判読不能)", "(illegible)")));
+            out_val.append(angband::format("%-30s", _("(判読不能)", "(illegible)")));
             c_prt(TERM_L_DARK, out_val, y + i + 1, x);
             continue;
         }
@@ -339,9 +339,9 @@ void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell, SPELL_IDX *spe
 
         const auto spell_name = exe_spell(player_ptr, use_realm, spell, SpellProcessType::NAME);
         if (use_realm == REALM_HISSATSU) {
-            out_val.append(format("%-25s %2d %4d", spell_name->data(), s_ptr->slevel, need_mana));
+            out_val.append(angband::format("%-25s %2d %4d", spell_name->data(), s_ptr->slevel, need_mana));
         } else {
-            out_val.append(format("%-25s%c%-4s %2d %4d %3d%% %s", spell_name->data(), (max ? '!' : ' '), ryakuji, s_ptr->slevel,
+            out_val.append(angband::format("%-25s%c%-4s %2d %4d %3d%% %s", spell_name->data(), (max ? '!' : ' '), ryakuji, s_ptr->slevel,
                 need_mana, spell_chance(player_ptr, spell, use_realm), comment));
         }
 

--- a/src/spell/spells-summon.cpp
+++ b/src/spell/spells-summon.cpp
@@ -335,7 +335,7 @@ void mitokohmon(PlayerType *player_ptr)
 
     msg_print(_(
         "「者ども、ひかえおろう！！！このお方をどなたとこころえる。」",
-        format("%s^ says 'WHO do you think this person is! Bow your head, down to your knees!'", sukekakusan)));
+        angband::format("%s^ says 'WHO do you think this person is! Bow your head, down to your knees!'", sukekakusan)));
     sukekaku = true;
     stun_monsters(player_ptr, 120);
     confuse_monsters(player_ptr, 120);

--- a/src/status/shape-changer.cpp
+++ b/src/status/shape-changer.cpp
@@ -172,7 +172,7 @@ void do_poly_self(PlayerType *player_ptr)
     if ((power > randint0(30)) && one_in_(6)) {
         int tmp = 0;
         power -= 20;
-        msg_print(_(format("%sの構成が変化した！", pr.equals(PlayerRaceType::ANDROID) ? "機械" : "内臓"), "Your internal organs are rearranged!"));
+        msg_print(_(angband::format("%sの構成が変化した！", pr.equals(PlayerRaceType::ANDROID) ? "機械" : "内臓"), "Your internal organs are rearranged!"));
 
         while (tmp < A_MAX) {
             (void)dec_stat(player_ptr, tmp, randint1(6) + 6, one_in_(3));

--- a/src/store/museum.cpp
+++ b/src/store/museum.cpp
@@ -34,7 +34,7 @@ void museum_remove_object(PlayerType *player_ptr)
     auto *o_ptr = &st_ptr->stock[item];
     const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
     msg_print(_("展示をやめさせたアイテムは二度と見ることはできません！", "Once removed from the Museum, an item will be gone forever!"));
-    if (!get_check(format(_("本当に%sの展示をやめさせますか？", "Really order to remove %s from the Museum? "), item_name.data()))) {
+    if (!get_check(angband::format(_("本当に%sの展示をやめさせますか？", "Really order to remove %s from the Museum? "), item_name.data()))) {
         return;
     }
 

--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -52,7 +52,7 @@ static std::optional<PRICE> prompt_to_buy(PlayerType *player_ptr, ItemEntity *o_
     auto price_ask = price_item(player_ptr, o_ptr, ot_ptr->inflate, false, store_num);
 
     price_ask *= o_ptr->number;
-    const auto s = format(_("買値 $%ld で買いますか？", "Do you buy for $%ld? "), static_cast<long>(price_ask));
+    const auto s = angband::format(_("買値 $%ld で買いますか？", "Do you buy for $%ld? "), static_cast<long>(price_ask));
     if (get_check_strict(player_ptr, s, CHECK_DEFAULT_Y)) {
         return price_ask;
     }
@@ -143,8 +143,8 @@ static void shuffle_store(PlayerType *player_ptr, StoreSaleType store_num)
     msg_print(_("店主は引退した。", "The shopkeeper retires."));
     store_shuffle(player_ptr, store_num);
     prt("", 3, 0);
-    put_str(format("%s (%s)", ot_ptr->owner_name, race_info[enum2i(ot_ptr->owner_race)].title), 3, 10);
-    prt(format("%s (%ld)", terrains_info[cur_store_feat].name.data(), (long)(ot_ptr->max_cost)), 3, 50);
+    put_str(angband::format("%s (%s)", ot_ptr->owner_name, race_info[enum2i(ot_ptr->owner_race)].title), 3, 10);
+    prt(angband::format("%s (%ld)", terrains_info[cur_store_feat].name.data(), (long)(ot_ptr->max_cost)), 3, 50);
 }
 
 static void switch_store_stock(PlayerType *player_ptr, const int i, const COMMAND_CODE item, StoreSaleType store_num)

--- a/src/store/sell-order.cpp
+++ b/src/store/sell-order.cpp
@@ -54,7 +54,7 @@ static std::optional<PRICE> prompt_to_sell(PlayerType *player_ptr, ItemEntity *o
 
     price_ask = std::min(price_ask, ot_ptr->max_cost);
     price_ask *= o_ptr->number;
-    const auto s = format(_("売値 $%ld で売りますか？", "Do you sell for $%ld? "), static_cast<long>(price_ask));
+    const auto s = angband::format(_("売値 $%ld で売りますか？", "Do you sell for $%ld? "), static_cast<long>(price_ask));
     if (get_check_strict(player_ptr, s, CHECK_DEFAULT_Y)) {
         return price_ask;
     }
@@ -200,7 +200,7 @@ void store_sell(PlayerType *player_ptr, StoreSaleType store_num)
             msg_print(_("博物館に寄贈したものは取り出すことができません！！", "You cannot take back items which have been donated to the Museum!!"));
         }
 
-        if (!get_check(format(_("本当に%sを寄贈しますか？", "Really give %s to the Museum? "), museum_item_name.data()))) {
+        if (!get_check(angband::format(_("本当に%sを寄贈しますか？", "Really give %s to the Museum? "), museum_item_name.data()))) {
             return;
         }
 

--- a/src/system/angband-version.cpp
+++ b/src/system/angband-version.cpp
@@ -23,9 +23,9 @@ std::string get_version()
     }
 
     if (VERSION_STATUS != VersionStatusType::RELEASE) {
-        return format(_("変愚蛮怒 %d.%d.%d%s%d", "Hengband %d.%d.%d%s%d"), H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH, expr.data(), H_VER_EXTRA);
+        return angband::format(_("変愚蛮怒 %d.%d.%d%s%d", "Hengband %d.%d.%d%s%d"), H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH, expr.data(), H_VER_EXTRA);
     } else {
         concptr mode = IS_STABLE_VERSION ? _("安定版", "Stable") : _("開発版", "Developing");
-        return format(_("変愚蛮怒 %d.%d.%d.%d(%s)", "Hengband %d.%d.%d.%d(%s)"), H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH, H_VER_EXTRA, mode);
+        return angband::format(_("変愚蛮怒 %d.%d.%d.%d(%s)", "Hengband %d.%d.%d.%d(%s)"), H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH, H_VER_EXTRA, mode);
     }
 }

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -85,7 +85,7 @@ std::string PlayerType::decrease_ability_random()
     }
 
     RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
-    return format(_("あなたは以前ほど%sなくなってしまった...。", "You're not as %s as you used to be..."), act.data());
+    return angband::format(_("あなたは以前ほど%sなくなってしまった...。", "You're not as %s as you used to be..."), act.data());
 }
 
 /*

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -121,7 +121,7 @@ static std::string evaluate_monster_exp(PlayerType *player_ptr, MonsterEntity *m
     s64b_div(&exp_adv, &exp_adv_frac, exp_mon, exp_mon_frac);
 
     auto num = std::min<uint>(999, exp_adv_frac);
-    return format("%03ld", (long int)num);
+    return angband::format("%03ld", (long int)num);
 }
 
 static void describe_scan_result(PlayerType *player_ptr, GridExamination *ge_ptr)
@@ -179,7 +179,7 @@ static bool describe_grid_lore(PlayerType *player_ptr, GridExamination *ge_ptr)
 {
     screen_save();
     screen_roff(player_ptr, ge_ptr->m_ptr->ap_r_idx, MONSTER_LORE_NORMAL);
-    term_addstr(-1, TERM_WHITE, format(_("  [r思 %s%s]", "  [r,%s%s]"), ge_ptr->x_info, ge_ptr->info));
+    term_addstr(-1, TERM_WHITE, angband::format(_("  [r思 %s%s]", "  [r,%s%s]"), ge_ptr->x_info, ge_ptr->info));
     ge_ptr->query = inkey();
     screen_load();
     return ge_ptr->query != 'r';
@@ -464,7 +464,7 @@ static std::string decide_target_floor(PlayerType *player_ptr, GridExamination *
         init_flags = INIT_NAME_ONLY;
         parse_fixed_map(player_ptr, QUEST_DEFINITION_LIST, 0, 0, 0, 0);
         floor_ptr->quest_number = old_quest;
-        return format(msg.data(), q_ptr->name.data(), q_ptr->level);
+        return angband::format(msg.data(), q_ptr->name.data(), q_ptr->level);
     }
 
     if (ge_ptr->f_ptr->flags.has(TerrainCharacteristics::BLDG) && !floor_ptr->inside_arena) {
@@ -473,7 +473,7 @@ static std::string decide_target_floor(PlayerType *player_ptr, GridExamination *
 
     if (ge_ptr->f_ptr->flags.has(TerrainCharacteristics::ENTRANCE)) {
         const auto &dungeon = dungeons_info[ge_ptr->g_ptr->special];
-        return format(_("%s(%d階相当)", "%s(level %d)"), dungeon.text.data(), dungeon.mindepth);
+        return angband::format(_("%s(%d階相当)", "%s(level %d)"), dungeon.text.data(), dungeon.mindepth);
     }
 
     if (ge_ptr->f_ptr->flags.has(TerrainCharacteristics::TOWN)) {
@@ -500,7 +500,7 @@ static void describe_grid_monster_all(GridExamination *ge_ptr)
 
     std::string f_idx_str;
     if (ge_ptr->g_ptr->mimic) {
-        f_idx_str = format("%d/%d", ge_ptr->g_ptr->feat, ge_ptr->g_ptr->mimic);
+        f_idx_str = angband::format("%d/%d", ge_ptr->g_ptr->feat, ge_ptr->g_ptr->mimic);
     } else {
         f_idx_str = std::to_string(ge_ptr->g_ptr->feat);
     }

--- a/src/term/z-form.cpp
+++ b/src/term/z-form.cpp
@@ -6,73 +6,73 @@
  * @detail
  * Legal format characters: %,n,p,c,s,d,i,o,u,X,x,E,e,F,f,G,g.
  *
- * Format("%%")
+ * angband::format("%%")
  *   Append the literal "%".
  *   No legal modifiers.
  *
- * Format("%n", int *np)
+ * angband::format("%n", int *np)
  *   Save the current length into (*np).
  *   No legal modifiers.
  *
- * Format("%p", vptr v)
+ * angband::format("%p", vptr v)
  *   Append the pointer "v" (implementation varies).
  *   No legal modifiers.
  *
- * Format("%E", double r)
- * Format("%F", double r)
- * Format("%G", double r)
- * Format("%e", double r)
- * Format("%f", double r)
- * Format("%g", double r)
+ * angband::format("%E", double r)
+ * angband::format("%F", double r)
+ * angband::format("%G", double r)
+ * angband::format("%e", double r)
+ * angband::format("%f", double r)
+ * angband::format("%g", double r)
  *   Append the double "r", in various formats.
  *
- * Format("%LE", long double r)
- * Format("%LF", long double r)
- * Format("%LG", long double r)
- * Format("%Le", long double r)
- * Format("%Lf", long double r)
- * Format("%Lg", long double r)
+ * angband::format("%LE", long double r)
+ * angband::format("%LF", long double r)
+ * angband::format("%LG", long double r)
+ * angband::format("%Le", long double r)
+ * angband::format("%Lf", long double r)
+ * angband::format("%Lg", long double r)
  *   Append the long double "r", in various formats.
  *
- * Format("%ld", long int i)
+ * angband::format("%ld", long int i)
  *   Append the long integer "i".
  *
- * Format("%lld", long long int i)
+ * angband::format("%lld", long long int i)
  *   Append the long long integer "i".
  *
- * Format("%d", int i)
+ * angband::format("%d", int i)
  *   Append the integer "i".
  *
- * Format("%lu", unsigned long int i)
+ * angband::format("%lu", unsigned long int i)
  *   Append the unsigned long integer "i".
  *
- * Format("%llu", unsigned long long int i)
+ * angband::format("%llu", unsigned long long int i)
  *   Append the unsigned long long integer "i".
  *
- * Format("%u", unsigned int i)
+ * angband::format("%u", unsigned int i)
  *   Append the unsigned integer "i".
  *
- * Format("%lo", unsigned long int i)
+ * angband::format("%lo", unsigned long int i)
  *   Append the unsigned long integer "i", in octal.
  *
- * Format("%o", unsigned int i)
+ * angband::format("%o", unsigned int i)
  *   Append the unsigned integer "i", in octal.
  *
- * Format("%lX", unsigned long int i)
+ * angband::format("%lX", unsigned long int i)
  *   Note -- use all capital letters
- * Format("%lx", unsigned long int i)
+ * angband::format("%lx", unsigned long int i)
  *   Append the unsigned long integer "i", in hexidecimal.
  *
- * Format("%X", unsigned int i)
+ * angband::format("%X", unsigned int i)
  *   Note -- use all capital letters
- * Format("%x", unsigned int i)
+ * angband::format("%x", unsigned int i)
  *   Append the unsigned integer "i", in hexidecimal.
  *
- * Format("%c", char c)
+ * angband::format("%c", char c)
  *   Append the character "c".
  *   Do not use the "+" or "0" flags.
  *
- * Format("%s", const char *s)
+ * angband::format("%s", const char *s)
  *   Append the string "s".
  *   Do not use the "+" or "0" flags.
  *   Note that a "nullptr" value of "s" is converted to the empty string.
@@ -97,6 +97,23 @@ std::string vformat(const char *fmt, va_list vp)
 
         format_buf.resize(format_buf.size() * 2);
     }
+}
+}
+
+/*
+ * Do a vstrnfmt() into (see above) into a (growable) static buffer.
+ * This buffer is usable for very short term formatting of results.
+ * Note that the buffer is (technically) writable, but only up to
+ * the length of the string contained inside it.
+ */
+namespace angband {
+std::string format(const char *fmt, ...)
+{
+    va_list vp;
+    va_start(vp, fmt);
+    auto res = vformat(fmt, vp);
+    va_end(vp);
+    return res;
 }
 }
 
@@ -358,21 +375,6 @@ uint32_t strnfmt(char *buf, uint32_t max, const char *fmt, ...)
     auto len = vstrnfmt(buf, max, fmt, vp);
     va_end(vp);
     return len;
-}
-
-/*
- * Do a vstrnfmt() into (see above) into a (growable) static buffer.
- * This buffer is usable for very short term formatting of results.
- * Note that the buffer is (technically) writable, but only up to
- * the length of the string contained inside it.
- */
-std::string format(const char *fmt, ...)
-{
-    va_list vp;
-    va_start(vp, fmt);
-    auto res = vformat(fmt, vp);
-    va_end(vp);
-    return res;
 }
 
 /*

--- a/src/term/z-form.h
+++ b/src/term/z-form.h
@@ -10,9 +10,12 @@
 #include "system/h-basic.h"
 #include <string>
 
+namespace angband {
+std::string format(const char *fmt, ...) __attribute__((angband::format(printf, 1, 2)));
+}
+
 uint32_t vstrnfmt(char *buf, uint32_t max, const char *fmt, va_list vp);
-uint32_t strnfmt(char *buf, uint32_t max, const char *fmt, ...) __attribute__((format(printf, 3, 4)));
-std::string format(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
-void plog_fmt(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
-void quit_fmt(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
-void core_fmt(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+uint32_t strnfmt(char *buf, uint32_t max, const char *fmt, ...) __attribute__((angband::format(printf, 3, 4)));
+void plog_fmt(const char *fmt, ...) __attribute__((angband::format(printf, 1, 2)));
+void quit_fmt(const char *fmt, ...) __attribute__((angband::format(printf, 1, 2)));
+void core_fmt(const char *fmt, ...) __attribute__((angband::format(printf, 1, 2)));

--- a/src/util/angband-files.cpp
+++ b/src/util/angband-files.cpp
@@ -170,7 +170,7 @@ std::filesystem::path path_build(const std::filesystem::path &path, std::string_
     constexpr auto max_path_length = 1024;
     const auto path_str = path_ret.string();
     if (path_str.length() > max_path_length) {
-        THROW_EXCEPTION(std::runtime_error, format("Path is too long! %s", path_str.data()));
+        THROW_EXCEPTION(std::runtime_error, angband::format("Path is too long! %s", path_str.data()));
     }
 
     return path_ret;

--- a/src/view/display-lore-attacks.cpp
+++ b/src/view/display-lore-attacks.cpp
@@ -20,11 +20,11 @@
 static void display_monster_blow_jp(lore_type *lore_ptr, int attack_numbers, int d1, int d2, int m)
 {
     if (attack_numbers == 0) {
-        hooked_roff(format("%s^は", Who::who(lore_ptr->msex)));
+        hooked_roff(angband::format("%s^は", Who::who(lore_ptr->msex)));
     }
 
     if (d1 && d2 && (lore_ptr->know_everything || know_damage(lore_ptr->r_idx, m))) {
-        hook_c_roff(TERM_L_WHITE, format(" %dd%d ", d1, d2));
+        hook_c_roff(TERM_L_WHITE, angband::format(" %dd%d ", d1, d2));
         hooked_roff("のダメージで");
     }
 
@@ -69,7 +69,7 @@ static void display_monster_blow_jp(lore_type *lore_ptr, int attack_numbers, int
 static void display_monster_blow_en(lore_type *lore_ptr, int attack_numbers, int d1, int d2, int m)
 {
     if (attack_numbers == 0) {
-        hooked_roff(format("%s^ can ", Who::who(lore_ptr->msex)));
+        hooked_roff(angband::format("%s^ can ", Who::who(lore_ptr->msex)));
     } else if (attack_numbers < lore_ptr->count - 1) {
         hooked_roff(", ");
     } else {
@@ -87,7 +87,7 @@ static void display_monster_blow_en(lore_type *lore_ptr, int attack_numbers, int
         hook_c_roff(lore_ptr->qc, lore_ptr->q);
         if (d1 && d2 && (lore_ptr->know_everything || know_damage(lore_ptr->r_idx, m))) {
             hooked_roff(" with damage");
-            hook_c_roff(TERM_L_WHITE, format(" %dd%d", d1, d2));
+            hook_c_roff(TERM_L_WHITE, angband::format(" %dd%d", d1, d2));
         }
     }
 }
@@ -139,8 +139,8 @@ void display_monster_blows(lore_type *lore_ptr)
     if (attack_numbers > 0) {
         hooked_roff(_("。", ".  "));
     } else if (lore_ptr->behavior_flags.has(MonsterBehaviorType::NEVER_BLOW)) {
-        hooked_roff(format(_("%s^は物理的な攻撃方法を持たない。", "%s^ has no physical attacks.  "), Who::who(lore_ptr->msex)));
+        hooked_roff(angband::format(_("%s^は物理的な攻撃方法を持たない。", "%s^ has no physical attacks.  "), Who::who(lore_ptr->msex)));
     } else {
-        hooked_roff(format(_("%s攻撃については何も知らない。", "Nothing is known about %s attack.  "), Who::whose(lore_ptr->msex)));
+        hooked_roff(angband::format(_("%s攻撃については何も知らない。", "Nothing is known about %s attack.  "), Who::whose(lore_ptr->msex)));
     }
 }

--- a/src/view/display-lore-drops.cpp
+++ b/src/view/display-lore-drops.cpp
@@ -15,7 +15,7 @@ void display_monster_drop_quantity(lore_type *lore_ptr)
     } else if (lore_ptr->drop_quantity == 2) {
         hooked_roff(_("一つか二つの", " one or two"));
     } else {
-        hooked_roff(format(_(" %d 個までの", " up to %d"), lore_ptr->drop_quantity));
+        hooked_roff(angband::format(_(" %d 個までの", " up to %d"), lore_ptr->drop_quantity));
     }
 }
 
@@ -103,7 +103,7 @@ void display_monster_drops(lore_type *lore_ptr)
         return;
     }
 
-    hooked_roff(format(_("%s^は", "%s^ may carry"), Who::who(lore_ptr->msex)));
+    hooked_roff(angband::format(_("%s^は", "%s^ may carry"), Who::who(lore_ptr->msex)));
 #ifdef JP
 #else
     lore_ptr->sin = false;

--- a/src/view/display-lore-magics.cpp
+++ b/src/view/display-lore-magics.cpp
@@ -12,7 +12,7 @@ void display_monster_breath(lore_type *lore_ptr)
     }
 
     lore_ptr->breath = true;
-    hooked_roff(format(_("%s^は", "%s^"), Who::who(lore_ptr->msex)));
+    hooked_roff(angband::format(_("%s^は", "%s^"), Who::who(lore_ptr->msex)));
     for (int n = 0; n < lore_ptr->vn; n++) {
 #ifdef JP
         if (n != 0) {
@@ -46,7 +46,7 @@ void display_monster_magic_types(lore_type *lore_ptr)
     if (lore_ptr->breath) {
         hooked_roff(_("、なおかつ", ", and is also"));
     } else {
-        hooked_roff(format(_("%s^は", "%s^ is"), Who::who(lore_ptr->msex)));
+        hooked_roff(angband::format(_("%s^は", "%s^ is"), Who::who(lore_ptr->msex)));
     }
 
 #ifdef JP
@@ -93,10 +93,10 @@ void display_mosnter_magic_possibility(lore_type *lore_ptr)
     int m = lore_ptr->r_ptr->r_cast_spell;
     int n = lore_ptr->r_ptr->freq_spell;
     if (m > 100 || lore_ptr->know_everything) {
-        hooked_roff(format(_("(確率:1/%d)", "; 1 time in %d"), 100 / n));
+        hooked_roff(angband::format(_("(確率:1/%d)", "; 1 time in %d"), 100 / n));
     } else if (m) {
         n = ((n + 9) / 10) * 10;
-        hooked_roff(format(_("(確率:約1/%d)", "; about 1 time in %d"), 100 / n));
+        hooked_roff(angband::format(_("(確率:約1/%d)", "; about 1 time in %d"), 100 / n));
     }
 
     hooked_roff(_("。", ".  "));

--- a/src/view/display-lore-status.cpp
+++ b/src/view/display-lore-status.cpp
@@ -19,12 +19,12 @@ void display_monster_hp_ac(lore_type *lore_ptr)
         return;
     }
 
-    hooked_roff(format(_("%s^は AC%d の防御力と", "%s^ has an armor rating of %d"), Who::who(lore_ptr->msex), lore_ptr->r_ptr->ac));
+    hooked_roff(angband::format(_("%s^は AC%d の防御力と", "%s^ has an armor rating of %d"), Who::who(lore_ptr->msex), lore_ptr->r_ptr->ac));
     if ((lore_ptr->flags1 & RF1_FORCE_MAXHP) || (lore_ptr->r_ptr->hside == 1)) {
         auto hp = lore_ptr->r_ptr->hdice * (lore_ptr->nightmare ? 2 : 1) * lore_ptr->r_ptr->hside;
-        hooked_roff(format(_(" %d の体力がある。", " and a life rating of %d.  "), std::min(MONSTER_MAXHP, hp)));
+        hooked_roff(angband::format(_(" %d の体力がある。", " and a life rating of %d.  "), std::min(MONSTER_MAXHP, hp)));
     } else {
-        hooked_roff(format(
+        hooked_roff(angband::format(
             _(" %dd%d の体力がある。", " and a life rating of %dd%d.  "), lore_ptr->r_ptr->hdice * (lore_ptr->nightmare ? 2 : 1), lore_ptr->r_ptr->hside));
     }
 }
@@ -98,7 +98,7 @@ void display_monster_abilities(lore_type *lore_ptr)
         return;
     }
 
-    hooked_roff(format(_("%s^は", "%s^"), Who::who(lore_ptr->msex)));
+    hooked_roff(angband::format(_("%s^は", "%s^"), Who::who(lore_ptr->msex)));
     for (int n = 0; n < lore_ptr->vn; n++) {
 #ifdef JP
         if (n != lore_ptr->vn - 1) {
@@ -127,41 +127,41 @@ void display_monster_abilities(lore_type *lore_ptr)
 void display_monster_constitutions(lore_type *lore_ptr)
 {
     if (lore_ptr->r_ptr->feature_flags.has(MonsterFeatureType::AQUATIC)) {
-        hooked_roff(format(_("%s^は水中に棲んでいる。", "%s^ lives in water.  "), Who::who(lore_ptr->msex)));
+        hooked_roff(angband::format(_("%s^は水中に棲んでいる。", "%s^ lives in water.  "), Who::who(lore_ptr->msex)));
     }
 
     if (lore_ptr->brightness_flags.has_any_of({ MonsterBrightnessType::SELF_LITE_1, MonsterBrightnessType::SELF_LITE_2 })) {
-        hooked_roff(format(_("%s^は光っている。", "%s^ is shining.  "), Who::who(lore_ptr->msex)));
+        hooked_roff(angband::format(_("%s^は光っている。", "%s^ is shining.  "), Who::who(lore_ptr->msex)));
     }
 
     if (lore_ptr->brightness_flags.has_any_of({ MonsterBrightnessType::SELF_DARK_1, MonsterBrightnessType::SELF_DARK_2 })) {
-        hook_c_roff(TERM_L_DARK, format(_("%s^は暗黒に包まれている。", "%s^ is surrounded by darkness.  "), Who::who(lore_ptr->msex)));
+        hook_c_roff(TERM_L_DARK, angband::format(_("%s^は暗黒に包まれている。", "%s^ is surrounded by darkness.  "), Who::who(lore_ptr->msex)));
     }
 
     if (lore_ptr->flags2 & RF2_INVISIBLE) {
-        hooked_roff(format(_("%s^は透明で目に見えない。", "%s^ is invisible.  "), Who::who(lore_ptr->msex)));
+        hooked_roff(angband::format(_("%s^は透明で目に見えない。", "%s^ is invisible.  "), Who::who(lore_ptr->msex)));
     }
 
     if (lore_ptr->flags2 & RF2_COLD_BLOOD) {
-        hooked_roff(format(_("%s^は冷血動物である。", "%s^ is cold blooded.  "), Who::who(lore_ptr->msex)));
+        hooked_roff(angband::format(_("%s^は冷血動物である。", "%s^ is cold blooded.  "), Who::who(lore_ptr->msex)));
     }
 
     if (lore_ptr->flags2 & RF2_EMPTY_MIND) {
-        hooked_roff(format(_("%s^はテレパシーでは感知できない。", "%s^ is not detected by telepathy.  "), Who::who(lore_ptr->msex)));
+        hooked_roff(angband::format(_("%s^はテレパシーでは感知できない。", "%s^ is not detected by telepathy.  "), Who::who(lore_ptr->msex)));
     } else if (lore_ptr->flags2 & RF2_WEIRD_MIND) {
-        hooked_roff(format(_("%s^はまれにテレパシーで感知できる。", "%s^ is rarely detected by telepathy.  "), Who::who(lore_ptr->msex)));
+        hooked_roff(angband::format(_("%s^はまれにテレパシーで感知できる。", "%s^ is rarely detected by telepathy.  "), Who::who(lore_ptr->msex)));
     }
 
     if (lore_ptr->flags2 & RF2_MULTIPLY) {
-        hook_c_roff(TERM_L_UMBER, format(_("%s^は爆発的に増殖する。", "%s^ breeds explosively.  "), Who::who(lore_ptr->msex)));
+        hook_c_roff(TERM_L_UMBER, angband::format(_("%s^は爆発的に増殖する。", "%s^ breeds explosively.  "), Who::who(lore_ptr->msex)));
     }
 
     if (lore_ptr->flags2 & RF2_REGENERATE) {
-        hook_c_roff(TERM_L_WHITE, format(_("%s^は素早く体力を回復する。", "%s^ regenerates quickly.  "), Who::who(lore_ptr->msex)));
+        hook_c_roff(TERM_L_WHITE, angband::format(_("%s^は素早く体力を回復する。", "%s^ regenerates quickly.  "), Who::who(lore_ptr->msex)));
     }
 
     if (lore_ptr->flags7 & RF7_RIDING) {
-        hook_c_roff(TERM_SLATE, format(_("%s^に乗ることができる。", "%s^ is suitable for riding.  "), Who::who(lore_ptr->msex)));
+        hook_c_roff(TERM_SLATE, angband::format(_("%s^に乗ることができる。", "%s^ is suitable for riding.  "), Who::who(lore_ptr->msex)));
     }
 }
 
@@ -194,7 +194,7 @@ void display_monster_weakness(lore_type *lore_ptr)
         return;
     }
 
-    hooked_roff(format(_("%s^には", "%s^"), Who::who(lore_ptr->msex)));
+    hooked_roff(angband::format(_("%s^には", "%s^"), Who::who(lore_ptr->msex)));
     for (int n = 0; n < lore_ptr->vn; n++) {
 #ifdef JP
         if (n != 0) {
@@ -329,7 +329,7 @@ void display_monster_resistances(lore_type *lore_ptr)
         return;
     }
 
-    hooked_roff(format(_("%s^は", "%s^"), Who::who(lore_ptr->msex)));
+    hooked_roff(angband::format(_("%s^は", "%s^"), Who::who(lore_ptr->msex)));
     for (int n = 0; n < lore_ptr->vn; n++) {
 #ifdef JP
         if (n != 0) {
@@ -357,12 +357,12 @@ void display_monster_evolution(lore_type *lore_ptr)
     }
 
     if (MonsterRace(lore_ptr->r_ptr->next_r_idx).is_valid()) {
-        hooked_roff(format(_("%s^は経験を積むと、", "%s^ will evolve into "), Who::who(lore_ptr->msex)));
-        hook_c_roff(TERM_YELLOW, format("%s", monraces_info[lore_ptr->r_ptr->next_r_idx].name.data()));
+        hooked_roff(angband::format(_("%s^は経験を積むと、", "%s^ will evolve into "), Who::who(lore_ptr->msex)));
+        hook_c_roff(TERM_YELLOW, angband::format("%s", monraces_info[lore_ptr->r_ptr->next_r_idx].name.data()));
 
-        hooked_roff(_(format("に進化する。"), format(" when %s gets enough experience.  ", Who::who(lore_ptr->msex))));
+        hooked_roff(_(angband::format("に進化する。"), angband::format(" when %s gets enough experience.  ", Who::who(lore_ptr->msex))));
     } else if (lore_ptr->r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE)) {
-        hooked_roff(format(_("%sは進化しない。", "%s won't evolve.  "), Who::who(lore_ptr->msex)));
+        hooked_roff(angband::format(_("%sは進化しない。", "%s won't evolve.  "), Who::who(lore_ptr->msex)));
     }
 }
 
@@ -400,7 +400,7 @@ void display_monster_immunities(lore_type *lore_ptr)
         return;
     }
 
-    hooked_roff(format(_("%s^は", "%s^"), Who::who(lore_ptr->msex)));
+    hooked_roff(angband::format(_("%s^は", "%s^"), Who::who(lore_ptr->msex)));
     for (int n = 0; n < lore_ptr->vn; n++) {
 #ifdef JP
         if (n != 0) {
@@ -456,6 +456,6 @@ void display_monster_alert(lore_type *lore_ptr)
         act = _("をかなり警戒しており", "is ever vigilant for");
     }
 
-    hooked_roff(_(format("%s^は侵入者%s、 %d フィート先から侵入者に気付くことがある。", Who::who(lore_ptr->msex), act, 10 * lore_ptr->r_ptr->aaf),
-        format("%s^ %s intruders, which %s may notice from %d feet.  ", Who::who(lore_ptr->msex), act, Who::who(lore_ptr->msex), 10 * lore_ptr->r_ptr->aaf)));
+    hooked_roff(_(angband::format("%s^は侵入者%s、 %d フィート先から侵入者に気付くことがある。", Who::who(lore_ptr->msex), act, 10 * lore_ptr->r_ptr->aaf),
+        angband::format("%s^ %s intruders, which %s may notice from %d feet.  ", Who::who(lore_ptr->msex), act, Who::who(lore_ptr->msex), 10 * lore_ptr->r_ptr->aaf)));
 }

--- a/src/view/display-lore.cpp
+++ b/src/view/display-lore.cpp
@@ -61,7 +61,7 @@ void roff_top(MonsterRaceId r_idx)
 
     if (w_ptr->wizard || cheat_know) {
         term_addstr(-1, TERM_WHITE, "[");
-        term_addstr(-1, TERM_L_BLUE, format("%d", enum2i(r_idx)));
+        term_addstr(-1, TERM_L_BLUE, angband::format("%d", enum2i(r_idx)));
         term_addstr(-1, TERM_WHITE, "] ");
     }
 
@@ -134,14 +134,14 @@ static bool display_kill_unique(lore_type *lore_ptr)
 
     bool dead = (lore_ptr->r_ptr->max_num == 0);
     if (lore_ptr->r_ptr->r_deaths) {
-        hooked_roff(format(_("%s^はあなたの先祖を %d 人葬っている", "%s^ has slain %d of your ancestors"), Who::who(lore_ptr->msex), lore_ptr->r_ptr->r_deaths));
+        hooked_roff(angband::format(_("%s^はあなたの先祖を %d 人葬っている", "%s^ has slain %d of your ancestors"), Who::who(lore_ptr->msex), lore_ptr->r_ptr->r_deaths));
 
         if (dead) {
             hooked_roff(
-                _(format("が、すでに仇討ちは果たしている！"), format(", but you have avenged %s!  ", plural(lore_ptr->r_ptr->r_deaths, "him", "them"))));
+                _(angband::format("が、すでに仇討ちは果たしている！"), angband::format(", but you have avenged %s!  ", plural(lore_ptr->r_ptr->r_deaths, "him", "them"))));
         } else {
             hooked_roff(
-                _(format("のに、まだ仇討ちを果たしていない。"), format(", who %s unavenged.  ", plural(lore_ptr->r_ptr->r_deaths, "remains", "remain"))));
+                _(angband::format("のに、まだ仇討ちを果たしていない。"), angband::format(", who %s unavenged.  ", plural(lore_ptr->r_ptr->r_deaths, "remains", "remain"))));
         }
 
         hooked_roff("\n");
@@ -160,28 +160,28 @@ static bool display_kill_unique(lore_type *lore_ptr)
 
 static void display_killed(lore_type *lore_ptr)
 {
-    hooked_roff(_(format("このモンスターはあなたの先祖を %d 人葬っている", lore_ptr->r_ptr->r_deaths),
-        format("%d of your ancestors %s been killed by this creature, ", lore_ptr->r_ptr->r_deaths, plural(lore_ptr->r_ptr->r_deaths, "has", "have"))));
+    hooked_roff(_(angband::format("このモンスターはあなたの先祖を %d 人葬っている", lore_ptr->r_ptr->r_deaths),
+        angband::format("%d of your ancestors %s been killed by this creature, ", lore_ptr->r_ptr->r_deaths, plural(lore_ptr->r_ptr->r_deaths, "has", "have"))));
 
     if (lore_ptr->r_ptr->r_pkills) {
-        hooked_roff(format(_("が、あなたはこのモンスターを少なくとも %d 体は倒している。", "and you have exterminated at least %d of the creatures.  "),
+        hooked_roff(angband::format(_("が、あなたはこのモンスターを少なくとも %d 体は倒している。", "and you have exterminated at least %d of the creatures.  "),
             lore_ptr->r_ptr->r_pkills));
     } else if (lore_ptr->r_ptr->r_tkills) {
-        hooked_roff(format(
+        hooked_roff(angband::format(
             _("が、あなたの先祖はこのモンスターを少なくとも %d 体は倒している。", "and your ancestors have exterminated at least %d of the creatures.  "),
             lore_ptr->r_ptr->r_tkills));
     } else {
-        hooked_roff(format(_("が、まだ%sを倒したことはない。", "and %s is not ever known to have been defeated.  "), Who::who(lore_ptr->msex)));
+        hooked_roff(angband::format(_("が、まだ%sを倒したことはない。", "and %s is not ever known to have been defeated.  "), Who::who(lore_ptr->msex)));
     }
 }
 
 static void display_no_killed(lore_type *lore_ptr)
 {
     if (lore_ptr->r_ptr->r_pkills) {
-        hooked_roff(format(
+        hooked_roff(angband::format(
             _("あなたはこのモンスターを少なくとも %d 体は殺している。", "You have killed at least %d of these creatures.  "), lore_ptr->r_ptr->r_pkills));
     } else if (lore_ptr->r_ptr->r_tkills) {
-        hooked_roff(format(_("あなたの先祖はこのモンスターを少なくとも %d 体は殺している。", "Your ancestors have killed at least %d of these creatures.  "),
+        hooked_roff(angband::format(_("あなたの先祖はこのモンスターを少なくとも %d 体は殺している。", "Your ancestors have killed at least %d of these creatures.  "),
             lore_ptr->r_ptr->r_tkills));
     } else {
         hooked_roff(_("このモンスターを倒したことはない。", "No battles to the death are recalled.  "));
@@ -207,16 +207,16 @@ static void display_number_of_nazguls(lore_type *lore_ptr)
     int killed = lore_ptr->r_ptr->r_akills;
     if (remain == 0) {
 #ifdef JP
-        hooked_roff(format("%sはかつて %d 体存在した。", Who::who(lore_ptr->msex, (killed > 1)), killed));
+        hooked_roff(angband::format("%sはかつて %d 体存在した。", Who::who(lore_ptr->msex, (killed > 1)), killed));
 #else
-        hooked_roff(format("You already killed all %d of %s.  ", killed, Who::whom(lore_ptr->msex, (killed > 1))));
+        hooked_roff(angband::format("You already killed all %d of %s.  ", killed, Who::whom(lore_ptr->msex, (killed > 1))));
 #endif
     } else {
 #ifdef JP
-        hooked_roff(format("%sはまだ %d 体生きている。", Who::who(lore_ptr->msex, (remain + killed > 1)), remain));
+        hooked_roff(angband::format("%sはまだ %d 体生きている。", Who::who(lore_ptr->msex, (remain + killed > 1)), remain));
 #else
         concptr be = (remain > 1) ? "are" : "is";
-        hooked_roff(format("%d of %s %s still alive.  ", remain, Who::whom(lore_ptr->msex, (remain + killed > 1)), be));
+        hooked_roff(angband::format("%d of %s %s still alive.  ", remain, Who::whom(lore_ptr->msex, (remain + killed > 1)), be));
 #endif
     }
 }
@@ -251,14 +251,14 @@ bool display_where_to_appear(lore_type *lore_ptr)
 {
     lore_ptr->old = false;
     if (lore_ptr->r_ptr->level == 0) {
-        hooked_roff(format(_("%s^は町に住み", "%s^ lives in the town"), Who::who(lore_ptr->msex)));
+        hooked_roff(angband::format(_("%s^は町に住み", "%s^ lives in the town"), Who::who(lore_ptr->msex)));
         lore_ptr->old = true;
     } else if (lore_ptr->r_ptr->r_tkills || lore_ptr->know_everything) {
         if (depth_in_feet) {
-            hooked_roff(format(
+            hooked_roff(angband::format(
                 _("%s^は通常地下 %d フィートで出現し", "%s^ is normally found at depths of %d feet"), Who::who(lore_ptr->msex), lore_ptr->r_ptr->level * 50));
         } else {
-            hooked_roff(format(_("%s^は通常地下 %d 階で出現し", "%s^ is normally found on dungeon level %d"), Who::who(lore_ptr->msex), lore_ptr->r_ptr->level));
+            hooked_roff(angband::format(_("%s^は通常地下 %d 階で出現し", "%s^ is normally found on dungeon level %d"), Who::who(lore_ptr->msex), lore_ptr->r_ptr->level));
         }
 
         lore_ptr->old = true;
@@ -272,7 +272,7 @@ bool display_where_to_appear(lore_type *lore_ptr)
     if (lore_ptr->old) {
         hooked_roff(_("、", ", and "));
     } else {
-        hooked_roff(format(_("%s^は", "%s^ "), Who::who(lore_ptr->msex)));
+        hooked_roff(angband::format(_("%s^は", "%s^ "), Who::who(lore_ptr->msex)));
         lore_ptr->old = true;
     }
 
@@ -350,7 +350,7 @@ void display_monster_never_move(lore_type *lore_ptr)
     if (lore_ptr->old) {
         hooked_roff(_("、しかし", ", but "));
     } else {
-        hooked_roff(format(_("%s^は", "%s^ "), Who::who(lore_ptr->msex)));
+        hooked_roff(angband::format(_("%s^は", "%s^ "), Who::who(lore_ptr->msex)));
         lore_ptr->old = true;
     }
 
@@ -443,9 +443,9 @@ void display_monster_exp(PlayerType *player_ptr, lore_type *lore_ptr)
     const auto exp_decimal = ((base_exp % player_factor * 1000 / player_factor) + 5) / 10;
 
 #ifdef JP
-    hooked_roff(format(" %d レベルのキャラクタにとって 約%d.%02d ポイントの経験となる。", player_ptr->lev, exp_integer, exp_decimal));
+    hooked_roff(angband::format(" %d レベルのキャラクタにとって 約%d.%02d ポイントの経験となる。", player_ptr->lev, exp_integer, exp_decimal));
 #else
-    hooked_roff(format(" is worth about %d.%02d point%s", exp_integer, exp_decimal, ((exp_integer == 1) && (exp_decimal == 0)) ? "" : "s"));
+    hooked_roff(angband::format(" is worth about %d.%02d point%s", exp_integer, exp_decimal, ((exp_integer == 1) && (exp_decimal == 0)) ? "" : "s"));
 
     concptr ordinal;
     switch (player_ptr->lev % 10) {
@@ -475,7 +475,7 @@ void display_monster_exp(PlayerType *player_ptr, lore_type *lore_ptr)
         break;
     }
 
-    hooked_roff(format(" for a%s %d%s level character.  ", vowel, player_ptr->lev, ordinal));
+    hooked_roff(angband::format(" for a%s %d%s level character.  ", vowel, player_ptr->lev, ordinal));
 #endif
 }
 
@@ -486,19 +486,19 @@ void display_monster_aura(lore_type *lore_ptr)
     auto has_cold_aura = lore_ptr->aura_flags.has(MonsterAuraType::COLD);
     if (has_fire_aura && has_elec_aura && has_cold_aura) {
         hook_c_roff(
-            TERM_VIOLET, format(_("%s^は炎と氷とスパークに包まれている。", "%s^ is surrounded by flames, ice and electricity.  "), Who::who(lore_ptr->msex)));
+            TERM_VIOLET, angband::format(_("%s^は炎と氷とスパークに包まれている。", "%s^ is surrounded by flames, ice and electricity.  "), Who::who(lore_ptr->msex)));
     } else if (has_fire_aura && has_elec_aura) {
-        hook_c_roff(TERM_L_RED, format(_("%s^は炎とスパークに包まれている。", "%s^ is surrounded by flames and electricity.  "), Who::who(lore_ptr->msex)));
+        hook_c_roff(TERM_L_RED, angband::format(_("%s^は炎とスパークに包まれている。", "%s^ is surrounded by flames and electricity.  "), Who::who(lore_ptr->msex)));
     } else if (has_fire_aura && has_cold_aura) {
-        hook_c_roff(TERM_BLUE, format(_("%s^は炎と氷に包まれている。", "%s^ is surrounded by flames and ice.  "), Who::who(lore_ptr->msex)));
+        hook_c_roff(TERM_BLUE, angband::format(_("%s^は炎と氷に包まれている。", "%s^ is surrounded by flames and ice.  "), Who::who(lore_ptr->msex)));
     } else if (has_cold_aura && has_elec_aura) {
-        hook_c_roff(TERM_L_GREEN, format(_("%s^は氷とスパークに包まれている。", "%s^ is surrounded by ice and electricity.  "), Who::who(lore_ptr->msex)));
+        hook_c_roff(TERM_L_GREEN, angband::format(_("%s^は氷とスパークに包まれている。", "%s^ is surrounded by ice and electricity.  "), Who::who(lore_ptr->msex)));
     } else if (has_fire_aura) {
-        hook_c_roff(TERM_RED, format(_("%s^は炎に包まれている。", "%s^ is surrounded by flames.  "), Who::who(lore_ptr->msex)));
+        hook_c_roff(TERM_RED, angband::format(_("%s^は炎に包まれている。", "%s^ is surrounded by flames.  "), Who::who(lore_ptr->msex)));
     } else if (has_cold_aura) {
-        hook_c_roff(TERM_BLUE, format(_("%s^は氷に包まれている。", "%s^ is surrounded by ice.  "), Who::who(lore_ptr->msex)));
+        hook_c_roff(TERM_BLUE, angband::format(_("%s^は氷に包まれている。", "%s^ is surrounded by ice.  "), Who::who(lore_ptr->msex)));
     } else if (has_elec_aura) {
-        hook_c_roff(TERM_L_BLUE, format(_("%s^はスパークに包まれている。", "%s^ is surrounded by electricity.  "), Who::who(lore_ptr->msex)));
+        hook_c_roff(TERM_L_BLUE, angband::format(_("%s^はスパークに包まれている。", "%s^ is surrounded by electricity.  "), Who::who(lore_ptr->msex)));
     }
 }
 
@@ -549,12 +549,12 @@ static void display_monster_escort_contents(lore_type *lore_ptr)
 
         const auto *rf_ptr = &monraces_info[r_idx];
         if (rf_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
-            hooked_roff(format(_("、%s", ", %s"), rf_ptr->name.data()));
+            hooked_roff(angband::format(_("、%s", ", %s"), rf_ptr->name.data()));
             continue;
         }
 
 #ifdef JP
-        hooked_roff(format("、 %dd%d 体の%s", dd, ds, rf_ptr->name.data()));
+        hooked_roff(angband::format("、 %dd%d 体の%s", dd, ds, rf_ptr->name.data()));
 #else
         auto plural = (dd * ds > 1);
         GAME_TEXT name[MAX_NLEN];
@@ -562,7 +562,7 @@ static void display_monster_escort_contents(lore_type *lore_ptr)
         if (plural) {
             plural_aux(name);
         }
-        hooked_roff(format(",%dd%d %s", dd, ds, name));
+        hooked_roff(angband::format(",%dd%d %s", dd, ds, name));
 #endif
     }
 
@@ -572,10 +572,10 @@ static void display_monster_escort_contents(lore_type *lore_ptr)
 void display_monster_collective(lore_type *lore_ptr)
 {
     if ((lore_ptr->flags1 & RF1_ESCORT) || (lore_ptr->flags1 & RF1_ESCORTS) || lore_ptr->reinforce) {
-        hooked_roff(format(_("%s^は通常護衛を伴って現れる。", "%s^ usually appears with escorts.  "), Who::who(lore_ptr->msex)));
+        hooked_roff(angband::format(_("%s^は通常護衛を伴って現れる。", "%s^ usually appears with escorts.  "), Who::who(lore_ptr->msex)));
         display_monster_escort_contents(lore_ptr);
     } else if (lore_ptr->flags1 & RF1_FRIENDS) {
-        hooked_roff(format(_("%s^は通常集団で現れる。", "%s^ usually appears in groups.  "), Who::who(lore_ptr->msex)));
+        hooked_roff(angband::format(_("%s^は通常集団で現れる。", "%s^ usually appears in groups.  "), Who::who(lore_ptr->msex)));
     }
 }
 
@@ -643,7 +643,7 @@ void display_monster_sometimes(lore_type *lore_ptr)
         return;
     }
 
-    hooked_roff(format(_("%s^は", "%s^"), Who::who(lore_ptr->msex)));
+    hooked_roff(angband::format(_("%s^は", "%s^"), Who::who(lore_ptr->msex)));
     for (int n = 0; n < lore_ptr->vn; n++) {
 #ifdef JP
         if (n != lore_ptr->vn - 1) {

--- a/src/view/display-messages.cpp
+++ b/src/view/display-messages.cpp
@@ -149,7 +149,7 @@ static void message_add_aux(std::string str)
         }
 
         if (str == last_message && (j < 1000)) {
-            str = format("%s <x%d>", str.data(), j + 1);
+            str = angband::format("%s <x%d>", str.data(), j + 1);
             message_history.pop_front();
             if (!now_message) {
                 now_message++;
@@ -337,7 +337,7 @@ void msg_print(std::string_view msg)
 
     std::string msg_includes_turn;
     if (cheat_turn) {
-        msg = msg_includes_turn = format("T:%d - %s", w_ptr->game_turn, msg.data());
+        msg = msg_includes_turn = angband::format("T:%d - %s", w_ptr->game_turn, msg.data());
     }
 
     if ((msg_head_pos > 0) && ((msg_head_pos + msg.size()) > 72)) {

--- a/src/view/display-messages.h
+++ b/src/view/display-messages.h
@@ -20,4 +20,4 @@ void msg_erase(void);
 void msg_print(std::string_view msg);
 void msg_print(std::nullptr_t);
 void msg_format(std::string_view fmt, ...);
-void msg_format(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+void msg_format(const char *fmt, ...) __attribute__((angband::format(printf, 1, 2)));

--- a/src/view/display-monster-status.cpp
+++ b/src/view/display-monster-status.cpp
@@ -42,8 +42,8 @@ std::string look_mon_desc(MonsterEntity *m_ptr, BIT_FLAGS mode)
     concptr clone = m_ptr->mflag2.has(MonsterConstantFlagType::CLONED) ? ", clone" : "";
     MonsterRaceInfo *ap_r_ptr = &monraces_info[m_ptr->ap_r_idx];
     if (ap_r_ptr->r_tkills && m_ptr->mflag2.has_not(MonsterConstantFlagType::KAGE)) {
-        return format(_("レベル%d, %s%s%s", "Level %d, %s%s%s"), ap_r_ptr->level, desc, attitude, clone);
+        return angband::format(_("レベル%d, %s%s%s", "Level %d, %s%s%s"), ap_r_ptr->level, desc, attitude, clone);
     }
 
-    return format(_("レベル???, %s%s%s", "Level ???, %s%s%s"), desc, attitude, clone);
+    return angband::format(_("レベル???, %s%s%s", "Level ???, %s%s%s"), desc, attitude, clone);
 }

--- a/src/view/display-player-middle.cpp
+++ b/src/view/display-player-middle.cpp
@@ -53,7 +53,7 @@ static void display_player_melee_bonus(PlayerType *player_ptr, int hand, int han
 
     show_tohit += player_ptr->skill_thn / BTH_PLUS_ADJ;
 
-    std::string buf = format("(%+d,%+d)", (int)show_tohit, (int)show_todam);
+    std::string buf = angband::format("(%+d,%+d)", (int)show_tohit, (int)show_todam);
     if (!has_melee_weapon(player_ptr, INVEN_MAIN_HAND) && !has_melee_weapon(player_ptr, INVEN_SUB_HAND)) {
         display_player_one_line(ENTRY_BARE_HAND, buf, TERM_L_BLUE);
     } else if (has_two_handed_weapons(player_ptr)) {
@@ -87,7 +87,7 @@ static void display_sub_hand(PlayerType *player_ptr)
     uint stance_num = enum2i(pc.get_monk_stance()) - 1;
 
     if (stance_num < monk_stances.size()) {
-        display_player_one_line(ENTRY_POSTURE, format(_("%sの構え", "%s form"), monk_stances[stance_num].desc), TERM_YELLOW);
+        display_player_one_line(ENTRY_POSTURE, angband::format(_("%sの構え", "%s form"), monk_stances[stance_num].desc), TERM_YELLOW);
     }
 }
 
@@ -123,7 +123,7 @@ static void display_bow_hit_damage(PlayerType *player_ptr)
     }
 
     show_tohit += player_ptr->skill_thb / BTH_PLUS_ADJ;
-    display_player_one_line(ENTRY_SHOOT_HIT_DAM, format("(%+d,%+d)", show_tohit, show_todam), TERM_L_BLUE);
+    display_player_one_line(ENTRY_SHOOT_HIT_DAM, angband::format("(%+d,%+d)", show_tohit, show_todam), TERM_L_BLUE);
 }
 
 /*!
@@ -142,7 +142,7 @@ static void display_shoot_magnification(PlayerType *player_ptr)
         tmul = tmul * (100 + (int)(adj_str_td[player_ptr->stat_index[A_STR]]) - 128);
     }
 
-    display_player_one_line(ENTRY_SHOOT_POWER, format("x%d.%02d", tmul / 100, tmul % 100), TERM_L_BLUE);
+    display_player_one_line(ENTRY_SHOOT_POWER, angband::format("x%d.%02d", tmul / 100, tmul % 100), TERM_L_BLUE);
 }
 
 /*!
@@ -225,10 +225,10 @@ static void display_player_speed(PlayerType *player_ptr, TERM_COLOR attr, int ba
             if (player_ptr->lightspeed) {
                 buf = _("光速化 (+99)", "Lightspeed (+99)");
             } else {
-                buf = format("(%+d%+d)", base_speed - tmp_speed, tmp_speed);
+                buf = angband::format("(%+d%+d)", base_speed - tmp_speed, tmp_speed);
             }
         } else {
-            buf = format(_("乗馬中 (%+d%+d)", "Riding (%+d%+d)"), base_speed - tmp_speed, tmp_speed);
+            buf = angband::format(_("乗馬中 (%+d%+d)", "Riding (%+d%+d)"), base_speed - tmp_speed, tmp_speed);
         }
 
         if (tmp_speed > 0) {
@@ -238,14 +238,14 @@ static void display_player_speed(PlayerType *player_ptr, TERM_COLOR attr, int ba
         }
     } else {
         if (!player_ptr->riding) {
-            buf = format("(%+d)", base_speed);
+            buf = angband::format("(%+d)", base_speed);
         } else {
-            buf = format(_("乗馬中 (%+d)", "Riding (%+d)"), base_speed);
+            buf = angband::format(_("乗馬中 (%+d)", "Riding (%+d)"), base_speed);
         }
     }
 
     display_player_one_line(ENTRY_SPEED, buf, attr);
-    display_player_one_line(ENTRY_LEVEL, format("%d", player_ptr->lev), TERM_L_GREEN);
+    display_player_one_line(ENTRY_LEVEL, angband::format("%d", player_ptr->lev), TERM_L_GREEN);
 }
 
 /*!
@@ -257,13 +257,13 @@ static void display_player_exp(PlayerType *player_ptr)
     PlayerRace pr(player_ptr);
     int e = pr.equals(PlayerRaceType::ANDROID) ? ENTRY_EXP_ANDR : ENTRY_CUR_EXP;
     if (player_ptr->exp >= player_ptr->max_exp) {
-        display_player_one_line(e, format("%d", player_ptr->exp), TERM_L_GREEN);
+        display_player_one_line(e, angband::format("%d", player_ptr->exp), TERM_L_GREEN);
     } else {
-        display_player_one_line(e, format("%d", player_ptr->exp), TERM_YELLOW);
+        display_player_one_line(e, angband::format("%d", player_ptr->exp), TERM_YELLOW);
     }
 
     if (!pr.equals(PlayerRaceType::ANDROID)) {
-        display_player_one_line(ENTRY_MAX_EXP, format("%d", player_ptr->max_exp), TERM_L_GREEN);
+        display_player_one_line(ENTRY_MAX_EXP, angband::format("%d", player_ptr->max_exp), TERM_L_GREEN);
     }
 
     e = pr.equals(PlayerRaceType::ANDROID) ? ENTRY_EXP_TO_ADV_ANDR : ENTRY_EXP_TO_ADV;
@@ -271,9 +271,9 @@ static void display_player_exp(PlayerType *player_ptr)
     if (player_ptr->lev >= PY_MAX_LEVEL) {
         display_player_one_line(e, "*****", TERM_L_GREEN);
     } else if (pr.equals(PlayerRaceType::ANDROID)) {
-        display_player_one_line(e, format("%d", player_exp_a[player_ptr->lev - 1] * player_ptr->expfact / 100), TERM_L_GREEN);
+        display_player_one_line(e, angband::format("%d", player_exp_a[player_ptr->lev - 1] * player_ptr->expfact / 100), TERM_L_GREEN);
     } else {
-        display_player_one_line(e, format("%d", player_exp[player_ptr->lev - 1] * player_ptr->expfact / 100), TERM_L_GREEN);
+        display_player_one_line(e, angband::format("%d", player_exp[player_ptr->lev - 1] * player_ptr->expfact / 100), TERM_L_GREEN);
     }
 }
 
@@ -288,27 +288,27 @@ static void display_playtime_in_game(PlayerType *player_ptr)
 
     std::string buf;
     if (day < MAX_DAYS) {
-        buf = format(_("%d日目 %2d:%02d", "Day %d %2d:%02d"), day, hour, min);
+        buf = angband::format(_("%d日目 %2d:%02d", "Day %d %2d:%02d"), day, hour, min);
     } else {
-        buf = format(_("*****日目 %2d:%02d", "Day ***** %2d:%02d"), hour, min);
+        buf = angband::format(_("*****日目 %2d:%02d", "Day ***** %2d:%02d"), hour, min);
     }
 
     display_player_one_line(ENTRY_DAY, buf, TERM_L_GREEN);
 
     if (player_ptr->chp >= player_ptr->mhp) {
-        display_player_one_line(ENTRY_HP, format("%4d/%4d", player_ptr->chp, player_ptr->mhp), TERM_L_GREEN);
+        display_player_one_line(ENTRY_HP, angband::format("%4d/%4d", player_ptr->chp, player_ptr->mhp), TERM_L_GREEN);
     } else if (player_ptr->chp > (player_ptr->mhp * hitpoint_warn) / 10) {
-        display_player_one_line(ENTRY_HP, format("%4d/%4d", player_ptr->chp, player_ptr->mhp), TERM_YELLOW);
+        display_player_one_line(ENTRY_HP, angband::format("%4d/%4d", player_ptr->chp, player_ptr->mhp), TERM_YELLOW);
     } else {
-        display_player_one_line(ENTRY_HP, format("%4d/%4d", player_ptr->chp, player_ptr->mhp), TERM_RED);
+        display_player_one_line(ENTRY_HP, angband::format("%4d/%4d", player_ptr->chp, player_ptr->mhp), TERM_RED);
     }
 
     if (player_ptr->csp >= player_ptr->msp) {
-        display_player_one_line(ENTRY_SP, format("%4d/%4d", player_ptr->csp, player_ptr->msp), TERM_L_GREEN);
+        display_player_one_line(ENTRY_SP, angband::format("%4d/%4d", player_ptr->csp, player_ptr->msp), TERM_L_GREEN);
     } else if (player_ptr->csp > (player_ptr->msp * mana_warn) / 10) {
-        display_player_one_line(ENTRY_SP, format("%4d/%4d", player_ptr->csp, player_ptr->msp), TERM_YELLOW);
+        display_player_one_line(ENTRY_SP, angband::format("%4d/%4d", player_ptr->csp, player_ptr->msp), TERM_YELLOW);
     } else {
-        display_player_one_line(ENTRY_SP, format("%4d/%4d", player_ptr->csp, player_ptr->msp), TERM_RED);
+        display_player_one_line(ENTRY_SP, angband::format("%4d/%4d", player_ptr->csp, player_ptr->msp), TERM_RED);
     }
 }
 
@@ -322,7 +322,7 @@ static void display_real_playtime(void)
     uint32_t play_hour = w_ptr->play_time / (60 * 60);
     uint32_t play_min = (w_ptr->play_time / 60) % 60;
     uint32_t play_sec = w_ptr->play_time % 60;
-    display_player_one_line(ENTRY_PLAY_TIME, format("%.2u:%.2u:%.2u", play_hour, play_min, play_sec), TERM_L_GREEN);
+    display_player_one_line(ENTRY_PLAY_TIME, angband::format("%.2u:%.2u:%.2u", play_hour, play_min, play_sec), TERM_L_GREEN);
 }
 
 /*!
@@ -339,7 +339,7 @@ void display_player_middle(PlayerType *player_ptr)
     display_sub_hand(player_ptr);
     display_bow_hit_damage(player_ptr);
     display_shoot_magnification(player_ptr);
-    display_player_one_line(ENTRY_BASE_AC, format("[%d,%+d]", player_ptr->dis_ac, player_ptr->dis_to_a), TERM_L_BLUE);
+    display_player_one_line(ENTRY_BASE_AC, angband::format("[%d,%+d]", player_ptr->dis_ac, player_ptr->dis_to_a), TERM_L_BLUE);
 
     int base_speed = player_ptr->pspeed - STANDARD_SPEED;
     if (player_ptr->action == ACTION_SEARCH) {
@@ -350,7 +350,7 @@ void display_player_middle(PlayerType *player_ptr)
     int tmp_speed = calc_temporary_speed(player_ptr);
     display_player_speed(player_ptr, attr, base_speed, tmp_speed);
     display_player_exp(player_ptr);
-    display_player_one_line(ENTRY_GOLD, format("%d", player_ptr->au), TERM_L_GREEN);
+    display_player_one_line(ENTRY_GOLD, angband::format("%d", player_ptr->au), TERM_L_GREEN);
     display_playtime_in_game(player_ptr);
     display_real_playtime();
 }

--- a/src/view/display-player-misc-info.cpp
+++ b/src/view/display-player-misc-info.cpp
@@ -32,7 +32,7 @@ void display_player_misc_info(PlayerType *player_ptr)
     put_str(_("ＨＰ  :", "Hits  :"), 7, 1);
     put_str(_("ＭＰ  :", "Mana  :"), 8, 1);
 
-    c_put_str(TERM_L_BLUE, format("%d", (int)player_ptr->lev), 6, 9);
-    c_put_str(TERM_L_BLUE, format("%d/%d", (int)player_ptr->chp, (int)player_ptr->mhp), 7, 9);
-    c_put_str(TERM_L_BLUE, format("%d/%d", (int)player_ptr->csp, (int)player_ptr->msp), 8, 9);
+    c_put_str(TERM_L_BLUE, angband::format("%d", (int)player_ptr->lev), 6, 9);
+    c_put_str(TERM_L_BLUE, angband::format("%d/%d", (int)player_ptr->chp, (int)player_ptr->mhp), 7, 9);
+    c_put_str(TERM_L_BLUE, angband::format("%d/%d", (int)player_ptr->csp, (int)player_ptr->msp), 8, 9);
 }

--- a/src/view/display-player-stat-info.cpp
+++ b/src/view/display-player-stat-info.cpp
@@ -123,13 +123,13 @@ static void display_basic_stat_name(PlayerType *player_ptr, int stat_num, int ro
  */
 static void display_basic_stat_value(PlayerType *player_ptr, int stat_num, int r_adj, int e_adj, int row, int stat_col)
 {
-    c_put_str(TERM_L_BLUE, format("%3d", r_adj), row + stat_num + 1, stat_col + 13);
+    c_put_str(TERM_L_BLUE, angband::format("%3d", r_adj), row + stat_num + 1, stat_col + 13);
 
-    c_put_str(TERM_L_BLUE, format("%3d", (int)cp_ptr->c_adj[stat_num]), row + stat_num + 1, stat_col + 16);
+    c_put_str(TERM_L_BLUE, angband::format("%3d", (int)cp_ptr->c_adj[stat_num]), row + stat_num + 1, stat_col + 16);
 
-    c_put_str(TERM_L_BLUE, format("%3d", (int)ap_ptr->a_adj[stat_num]), row + stat_num + 1, stat_col + 19);
+    c_put_str(TERM_L_BLUE, angband::format("%3d", (int)ap_ptr->a_adj[stat_num]), row + stat_num + 1, stat_col + 19);
 
-    c_put_str(TERM_L_BLUE, format("%3d", (int)e_adj), row + stat_num + 1, stat_col + 22);
+    c_put_str(TERM_L_BLUE, angband::format("%3d", (int)e_adj), row + stat_num + 1, stat_col + 22);
 
     c_put_str(TERM_L_GREEN, cnv_stat(player_ptr->stat_top[stat_num]), row + stat_num + 1, stat_col + 26);
 

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -124,18 +124,18 @@ static void display_magic_realms(PlayerType *player_ptr)
 static void display_phisique(PlayerType *player_ptr)
 {
 #ifdef JP
-    display_player_one_line(ENTRY_AGE, format("%d才", (int)player_ptr->age), TERM_L_BLUE);
-    display_player_one_line(ENTRY_HEIGHT, format("%dcm", (int)((player_ptr->ht * 254) / 100)), TERM_L_BLUE);
-    display_player_one_line(ENTRY_WEIGHT, format("%dkg", (int)((player_ptr->wt * 4536) / 10000)), TERM_L_BLUE);
-    display_player_one_line(ENTRY_SOCIAL, format("%d  ", (int)player_ptr->sc), TERM_L_BLUE);
+    display_player_one_line(ENTRY_AGE, angband::format("%d才", (int)player_ptr->age), TERM_L_BLUE);
+    display_player_one_line(ENTRY_HEIGHT, angband::format("%dcm", (int)((player_ptr->ht * 254) / 100)), TERM_L_BLUE);
+    display_player_one_line(ENTRY_WEIGHT, angband::format("%dkg", (int)((player_ptr->wt * 4536) / 10000)), TERM_L_BLUE);
+    display_player_one_line(ENTRY_SOCIAL, angband::format("%d  ", (int)player_ptr->sc), TERM_L_BLUE);
 #else
-    display_player_one_line(ENTRY_AGE, format("%d", (int)player_ptr->age), TERM_L_BLUE);
-    display_player_one_line(ENTRY_HEIGHT, format("%d", (int)player_ptr->ht), TERM_L_BLUE);
-    display_player_one_line(ENTRY_WEIGHT, format("%d", (int)player_ptr->wt), TERM_L_BLUE);
-    display_player_one_line(ENTRY_SOCIAL, format("%d", (int)player_ptr->sc), TERM_L_BLUE);
+    display_player_one_line(ENTRY_AGE, angband::format("%d", (int)player_ptr->age), TERM_L_BLUE);
+    display_player_one_line(ENTRY_HEIGHT, angband::format("%d", (int)player_ptr->ht), TERM_L_BLUE);
+    display_player_one_line(ENTRY_WEIGHT, angband::format("%d", (int)player_ptr->wt), TERM_L_BLUE);
+    display_player_one_line(ENTRY_SOCIAL, angband::format("%d", (int)player_ptr->sc), TERM_L_BLUE);
 #endif
     std::string alg = PlayerAlignment(player_ptr).get_alignment_description();
-    display_player_one_line(ENTRY_ALIGN, format("%s", alg.data()), TERM_L_BLUE);
+    display_player_one_line(ENTRY_ALIGN, angband::format("%s", alg.data()), TERM_L_BLUE);
 }
 
 /*!
@@ -176,16 +176,16 @@ static std::optional<std::string> search_death_cause(PlayerType *player_ptr)
     }
 
     if (w_ptr->total_winner) {
-        return format(_("…あなたは勝利の後%sした。", "...You %s after winning."),
+        return angband::format(_("…あなたは勝利の後%sした。", "...You %s after winning."),
             streq(player_ptr->died_from, "Seppuku") ? _("切腹", "committed seppuku") : _("引退", "retired from the adventure"));
     }
 
     if (!floor_ptr->dun_level) {
         constexpr auto killed_monster = _("…あなたは%sで%sに殺された。", "...You were killed by %s in %s.");
 #ifdef JP
-        return format(killed_monster, map_name(player_ptr).data(), player_ptr->died_from.data());
+        return angband::format(killed_monster, map_name(player_ptr).data(), player_ptr->died_from.data());
 #else
-        return format(killed_monster, player_ptr->died_from.data(), map_name(player_ptr).data());
+        return angband::format(killed_monster, player_ptr->died_from.data(), map_name(player_ptr).data());
 #endif
     }
 
@@ -200,17 +200,17 @@ static std::optional<std::string> search_death_cause(PlayerType *player_ptr)
         const auto *q_ptr = &quest_list[floor_ptr->quest_number];
         constexpr auto killed_quest = _("…あなたは、クエスト「%s」で%sに殺された。", "...You were killed by %s in the quest '%s'.");
 #ifdef JP
-        return format(killed_quest, q_ptr->name.data(), player_ptr->died_from.data());
+        return angband::format(killed_quest, q_ptr->name.data(), player_ptr->died_from.data());
 #else
-        return format(killed_quest, player_ptr->died_from.data(), q_ptr->name.data());
+        return angband::format(killed_quest, player_ptr->died_from.data(), q_ptr->name.data());
 #endif
     }
 
     constexpr auto killed_floor = _("…あなたは、%sの%d階で%sに殺された。", "...You were killed by %s on level %d of %s.");
 #ifdef JP
-    return format(killed_floor, map_name(player_ptr).data(), (int)floor_ptr->dun_level, player_ptr->died_from.data());
+    return angband::format(killed_floor, map_name(player_ptr).data(), (int)floor_ptr->dun_level, player_ptr->died_from.data());
 #else
-    return format(killed_floor, player_ptr->died_from.data(), floor_ptr->dun_level, map_name(player_ptr).data());
+    return angband::format(killed_floor, player_ptr->died_from.data(), floor_ptr->dun_level, map_name(player_ptr).data());
 #endif
 }
 
@@ -235,7 +235,7 @@ static std::optional<std::string> decide_death_in_quest(PlayerType *player_ptr)
     quest_text_line = 0;
     init_flags = INIT_NAME_ONLY;
     parse_fixed_map(player_ptr, QUEST_DEFINITION_LIST, 0, 0, 0, 0);
-    return std::string(format(_("…あなたは現在、 クエスト「%s」を遂行中だ。", "...Now, you are in the quest '%s'."), quest_list[floor_ptr->quest_number].name.data()));
+    return std::string(angband::format(_("…あなたは現在、 クエスト「%s」を遂行中だ。", "...Now, you are in the quest '%s'."), quest_list[floor_ptr->quest_number].name.data()));
 }
 
 /*!
@@ -252,7 +252,7 @@ static std::string decide_current_floor(PlayerType *player_ptr)
 
     auto *floor_ptr = player_ptr->current_floor_ptr;
     if (floor_ptr->dun_level == 0) {
-        return format(_("…あなたは現在、 %s にいる。", "...Now, you are in %s."), map_name(player_ptr).data());
+        return angband::format(_("…あなたは現在、 %s にいる。", "...Now, you are in %s."), map_name(player_ptr).data());
     }
 
     if (auto decision = decide_death_in_quest(player_ptr); decision.has_value()) {
@@ -261,9 +261,9 @@ static std::string decide_current_floor(PlayerType *player_ptr)
 
     constexpr auto mes = _("…あなたは現在、 %s の %d 階で探索している。", "...Now, you are exploring level %d of %s.");
 #ifdef JP
-    return format(mes, map_name(player_ptr).data(), (int)floor_ptr->dun_level);
+    return angband::format(mes, map_name(player_ptr).data(), (int)floor_ptr->dun_level);
 #else
-    return format(mes, (int)floor_ptr->dun_level, map_name(player_ptr).data());
+    return angband::format(mes, (int)floor_ptr->dun_level, map_name(player_ptr).data());
 #endif
 }
 

--- a/src/view/display-scores.cpp
+++ b/src/view/display-scores.cpp
@@ -73,7 +73,7 @@ void display_scores(int from, int to, int note, high_score *score)
         term_clear();
         put_str(_("                変愚蛮怒: 勇者の殿堂", "                Hengband Hall of Fame"), 0, 0);
         if (k > 0) {
-            put_str(format(_("( %d 位以下 )", "(from position %d)"), k + 1), 0, 40);
+            put_str(angband::format(_("( %d 位以下 )", "(from position %d)"), k + 1), 0, 40);
         }
 
         for (auto n = 0, j = k; (j < num_scores) && (n < per_screen); place++, j++, n++) {
@@ -119,69 +119,69 @@ void display_scores(int from, int to, int note, high_score *score)
 
             std::string alt_when;
             if ((*when == '@') && strlen(when) == 9) {
-                alt_when = format("%.4s-%.2s-%.2s", when + 1, when + 5, when + 7);
+                alt_when = angband::format("%.4s-%.2s-%.2s", when + 1, when + 5, when + 7);
                 when = alt_when.data();
             }
 
             std::string out_val;
 #ifdef JP
-            /* out_val = format("%3d.%9s  %s%s%sという名の%sの%s (レベル %d)", */
-            out_val = format("%3d.%9s  %s%s%s - %s%s (レベル %d)", place, the_score.pts, personality_info[pa].title, (personality_info[pa].no ? "の" : ""),
+            /* out_val = angband::format("%3d.%9s  %s%s%sという名の%sの%s (レベル %d)", */
+            out_val = angband::format("%3d.%9s  %s%s%s - %s%s (レベル %d)", place, the_score.pts, personality_info[pa].title, (personality_info[pa].no ? "の" : ""),
                 the_score.who, race_info[pr].title, class_info[pc].title, clev);
 
 #else
-            out_val = format("%3d.%9s  %s %s the %s %s, Level %d", place, the_score.pts, personality_info[pa].title, the_score.who, race_info[pr].title,
+            out_val = angband::format("%3d.%9s  %s %s the %s %s, Level %d", place, the_score.pts, personality_info[pa].title, the_score.who, race_info[pr].title,
                 class_info[pc].title, clev);
 #endif
             if (mlev > clev) {
-                out_val.append(format(_(" (最高%d)", " (Max %d)"), mlev));
+                out_val.append(angband::format(_(" (最高%d)", " (Max %d)"), mlev));
             }
 
             c_put_str(attr, out_val, n * 4 + 2, 0);
 #ifdef JP
             if (mdun != 0) {
-                out_val = format("    最高%3d階", mdun);
+                out_val = angband::format("    最高%3d階", mdun);
             } else {
                 out_val = "             ";
             }
 
             /* 死亡原因をオリジナルより細かく表示 */
             if (streq(the_score.how, "yet")) {
-                out_val.append(format("  まだ生きている (%d%s)", cdun, "階"));
+                out_val.append(angband::format("  まだ生きている (%d%s)", cdun, "階"));
             } else if (streq(the_score.how, "ripe")) {
-                out_val.append(format("  勝利の後に引退 (%d%s)", cdun, "階"));
+                out_val.append(angband::format("  勝利の後に引退 (%d%s)", cdun, "階"));
             } else if (streq(the_score.how, "Seppuku")) {
-                out_val.append(format("  勝利の後に切腹 (%d%s)", cdun, "階"));
+                out_val.append(angband::format("  勝利の後に切腹 (%d%s)", cdun, "階"));
             } else {
                 codeconv(the_score.how);
                 if (!cdun) {
-                    out_val.append(format("  地上で%sに殺された", the_score.how));
+                    out_val.append(angband::format("  地上で%sに殺された", the_score.how));
                 } else {
-                    out_val.append(format("  %d階で%sに殺された", cdun, the_score.how));
+                    out_val.append(angband::format("  %d階で%sに殺された", cdun, the_score.how));
                 }
             }
 #else
             if (!cdun) {
-                out_val = format("               Killed by %s on the surface", the_score.how);
+                out_val = angband::format("               Killed by %s on the surface", the_score.how);
             } else {
-                out_val = format("               Killed by %s on %s %d", the_score.how, "Dungeon Level", cdun);
+                out_val = angband::format("               Killed by %s on %s %d", the_score.how, "Dungeon Level", cdun);
             }
 
             if (mdun > cdun) {
-                out_val.append(format(" (Max %d)", mdun));
+                out_val.append(angband::format(" (Max %d)", mdun));
             }
 #endif
             c_put_str(attr, out_val, n * 4 + 3, 0);
 #ifdef JP
             /* 日付を 19yy/mm/dd の形式に変更する */
             if (strlen(when) == 8 && when[2] == '/' && when[5] == '/') {
-                alt_when = format("%d%s/%.5s", 19 + (when[6] < '8'), when + 6, when);
+                alt_when = angband::format("%d%s/%.5s", 19 + (when[6] < '8'), when + 6, when);
                 when = alt_when.data();
             }
 
-            out_val = format("        (ユーザー:%s, 日付:%s, 所持金:%s, ターン:%s)", user, when, gold, aged);
+            out_val = angband::format("        (ユーザー:%s, 日付:%s, 所持金:%s, ターン:%s)", user, when, gold, aged);
 #else
-            out_val = format("               (User %s, Date %s, Gold %s, Turn %s).", user, when, gold, aged);
+            out_val = angband::format("               (User %s, Date %s, Gold %s, Turn %s).", user, when, gold, aged);
 #endif
 
             c_put_str(attr, out_val, n * 4 + 4, 0);

--- a/src/view/display-self-info.cpp
+++ b/src/view/display-self-info.cpp
@@ -45,31 +45,31 @@ void display_virtue(PlayerType *player_ptr, self_info_type *self_ptr)
         std::string vir_desc;
         int tester = player_ptr->virtues[v_nr];
         if (tester < -100) {
-            vir_desc = format(_("[%s]の対極 (%d)", "You are the polar opposite of %s (%d)."), vir_name, tester);
+            vir_desc = angband::format(_("[%s]の対極 (%d)", "You are the polar opposite of %s (%d)."), vir_name, tester);
         } else if (tester < -80) {
-            vir_desc = format(_("[%s]の大敵 (%d)", "You are an arch-enemy of %s (%d)."), vir_name, tester);
+            vir_desc = angband::format(_("[%s]の大敵 (%d)", "You are an arch-enemy of %s (%d)."), vir_name, tester);
         } else if (tester < -60) {
-            vir_desc = format(_("[%s]の強敵 (%d)", "You are a bitter enemy of %s (%d)."), vir_name, tester);
+            vir_desc = angband::format(_("[%s]の強敵 (%d)", "You are a bitter enemy of %s (%d)."), vir_name, tester);
         } else if (tester < -40) {
-            vir_desc = format(_("[%s]の敵 (%d)", "You are an enemy of %s (%d)."), vir_name, tester);
+            vir_desc = angband::format(_("[%s]の敵 (%d)", "You are an enemy of %s (%d)."), vir_name, tester);
         } else if (tester < -20) {
-            vir_desc = format(_("[%s]の罪者 (%d)", "You have sinned against %s (%d)."), vir_name, tester);
+            vir_desc = angband::format(_("[%s]の罪者 (%d)", "You have sinned against %s (%d)."), vir_name, tester);
         } else if (tester < 0) {
-            vir_desc = format(_("[%s]の迷道者 (%d)", "You have strayed from the path of %s (%d)."), vir_name, tester);
+            vir_desc = angband::format(_("[%s]の迷道者 (%d)", "You have strayed from the path of %s (%d)."), vir_name, tester);
         } else if (tester == 0) {
-            vir_desc = format(_("[%s]の中立者 (%d)", "You are neutral to %s (%d)."), vir_name, tester);
+            vir_desc = angband::format(_("[%s]の中立者 (%d)", "You are neutral to %s (%d)."), vir_name, tester);
         } else if (tester < 20) {
-            vir_desc = format(_("[%s]の小徳者 (%d)", "You are somewhat virtuous in %s (%d)."), vir_name, tester);
+            vir_desc = angband::format(_("[%s]の小徳者 (%d)", "You are somewhat virtuous in %s (%d)."), vir_name, tester);
         } else if (tester < 40) {
-            vir_desc = format(_("[%s]の中徳者 (%d)", "You are virtuous in %s (%d)."), vir_name, tester);
+            vir_desc = angband::format(_("[%s]の中徳者 (%d)", "You are virtuous in %s (%d)."), vir_name, tester);
         } else if (tester < 60) {
-            vir_desc = format(_("[%s]の高徳者 (%d)", "You are very virtuous in %s (%d)."), vir_name, tester);
+            vir_desc = angband::format(_("[%s]の高徳者 (%d)", "You are very virtuous in %s (%d)."), vir_name, tester);
         } else if (tester < 80) {
-            vir_desc = format(_("[%s]の覇者 (%d)", "You are a champion of %s (%d)."), vir_name, tester);
+            vir_desc = angband::format(_("[%s]の覇者 (%d)", "You are a champion of %s (%d)."), vir_name, tester);
         } else if (tester < 100) {
-            vir_desc = format(_("[%s]の偉大な覇者 (%d)", "You are a great champion of %s (%d)."), vir_name, tester);
+            vir_desc = angband::format(_("[%s]の偉大な覇者 (%d)", "You are a great champion of %s (%d)."), vir_name, tester);
         } else {
-            vir_desc = format(_("[%s]の具現者 (%d)", "You are the living embodiment of %s (%d)."), vir_name, tester);
+            vir_desc = angband::format(_("[%s]の具現者 (%d)", "You are the living embodiment of %s (%d)."), vir_name, tester);
         }
 
         angband_strcpy(self_ptr->v_string[v_nr], vir_desc, sizeof(self_ptr->v_string[v_nr]));

--- a/src/view/display-store.cpp
+++ b/src/view/display-store.cpp
@@ -30,7 +30,7 @@
 void store_prt_gold(PlayerType *player_ptr)
 {
     prt(_("手持ちのお金: ", "Gold Remaining: "), 19 + xtra_stock, 53);
-    prt(format("%9ld", (long)player_ptr->au), 19 + xtra_stock, 68);
+    prt(angband::format("%9ld", (long)player_ptr->au), 19 + xtra_stock, 68);
 }
 
 /*!
@@ -46,7 +46,7 @@ void display_entry(PlayerType *player_ptr, int pos, StoreSaleType store_num)
     int i = (pos % store_bottom);
 
     /* Label it, clear the line --(-- */
-    prt(format("%c) ", ((i > 25) ? toupper(I2A(i - 26)) : I2A(i))), i + 6, 0);
+    prt(angband::format("%c) ", ((i > 25) ? toupper(I2A(i - 26)) : I2A(i))), i + 6, 0);
 
     int cur_col = 3;
     if (show_item_graph) {
@@ -73,7 +73,7 @@ void display_entry(PlayerType *player_ptr, int pos, StoreSaleType store_num)
 
         if (show_weights) {
             WEIGHT wgt = o_ptr->weight;
-            put_str(format(_("%3d.%1d kg", "%3d.%d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10)), i + 6, _(67, 68));
+            put_str(angband::format(_("%3d.%1d kg", "%3d.%d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10)), i + 6, _(67, 68));
         }
 
         return;
@@ -89,11 +89,11 @@ void display_entry(PlayerType *player_ptr, int pos, StoreSaleType store_num)
 
     if (show_weights) {
         int wgt = o_ptr->weight;
-        put_str(format("%3d.%1d", _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10)), i + 6, _(60, 61));
+        put_str(angband::format("%3d.%1d", _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10)), i + 6, _(60, 61));
     }
 
     const auto price = price_item(player_ptr, o_ptr, ot_ptr->inflate, false, store_num);
-    put_str(format("%9ld  ", (long)price), i + 6, 68);
+    put_str(angband::format("%9ld  ", (long)price), i + 6, 68);
 }
 
 /*!
@@ -121,7 +121,7 @@ void display_store_inventory(PlayerType *player_ptr, StoreSaleType store_num)
     put_str(_("          ", "        "), 5, _(20, 22));
     if (st_ptr->stock_num > store_bottom) {
         prt(_("-続く-", "-more-"), k + 6, 3);
-        put_str(format(_("(%dページ)  ", "(Page %d)  "), store_top / store_bottom + 1), 5, _(20, 22));
+        put_str(angband::format(_("(%dページ)  ", "(Page %d)  "), store_top / store_bottom + 1), 5, _(20, 22));
     }
 
     if (store_num == StoreSaleType::HOME || store_num == StoreSaleType::MUSEUM) {
@@ -130,7 +130,7 @@ void display_store_inventory(PlayerType *player_ptr, StoreSaleType store_num)
             k /= 10;
         }
 
-        put_str(format(_("アイテム数:  %4d/%4d", "Objects:  %4d/%4d"), st_ptr->stock_num, k), 19 + xtra_stock, _(27, 30));
+        put_str(angband::format(_("アイテム数:  %4d/%4d", "Objects:  %4d/%4d"), st_ptr->stock_num, k), 19 + xtra_stock, _(27, 30));
     }
 }
 
@@ -170,9 +170,9 @@ void display_store(PlayerType *player_ptr, StoreSaleType store_num)
     concptr store_name = terrains_info[cur_store_feat].name.data();
     concptr owner_name = (ot_ptr->owner_name);
     concptr race_name = race_info[enum2i(ot_ptr->owner_race)].title;
-    put_str(format("%s (%s)", owner_name, race_name), 3, 10);
+    put_str(angband::format("%s (%s)", owner_name, race_name), 3, 10);
 
-    prt(format("%s (%ld)", store_name, (long)(ot_ptr->max_cost)), 3, 50);
+    prt(angband::format("%s (%ld)", store_name, (long)(ot_ptr->max_cost)), 3, 50);
 
     put_str(_("商品の一覧", "Item Description"), 5, 5);
     if (show_weights) {

--- a/src/view/status-first-page.cpp
+++ b/src/view/status-first-page.cpp
@@ -183,7 +183,7 @@ static std::pair<std::string, TERM_COLOR> likert(int x, int y)
     std::string desc;
 
     if (show_actual_value) {
-        desc = format("%3d-", x);
+        desc = angband::format("%3d-", x);
     }
 
     if (x < 0) {
@@ -230,7 +230,7 @@ static std::pair<std::string, TERM_COLOR> likert(int x, int y)
         return make_pair(desc.append(_("英雄的", "Heroic")), TERM_BLUE);
     }
     default: {
-        desc.append(format(_("伝説的[%d]", "Legendary[%d]"), (int)((((x / y) - 17) * 5) / 2)));
+        desc.append(angband::format(_("伝説的[%d]", "Legendary[%d]"), (int)((((x / y) - 17) * 5) / 2)));
         return make_pair(desc, TERM_VIOLET);
     }
     }
@@ -359,22 +359,22 @@ static void display_first_page(PlayerType *player_ptr, int xthb, int *damage, in
     display_player_one_line(ENTRY_SKILL_DIG, sd.first, sd.second);
 
     if (!muta_att) {
-        display_player_one_line(ENTRY_BLOWS, format("%d+%d", blows1, blows2), TERM_L_BLUE);
+        display_player_one_line(ENTRY_BLOWS, angband::format("%d+%d", blows1, blows2), TERM_L_BLUE);
     } else {
-        display_player_one_line(ENTRY_BLOWS, format("%d+%d+%d", blows1, blows2, muta_att), TERM_L_BLUE);
+        display_player_one_line(ENTRY_BLOWS, angband::format("%d+%d+%d", blows1, blows2, muta_att), TERM_L_BLUE);
     }
 
-    display_player_one_line(ENTRY_SHOTS, format("%d.%02d", shots, shot_frac), TERM_L_BLUE);
+    display_player_one_line(ENTRY_SHOTS, angband::format("%d.%02d", shots, shot_frac), TERM_L_BLUE);
 
     std::string desc;
     if ((damage[0] + damage[1]) == 0) {
         desc = "nil!";
     } else {
-        desc = format("%d+%d", blows1 * damage[0] / 100, blows2 * damage[1] / 100);
+        desc = angband::format("%d+%d", blows1 * damage[0] / 100, blows2 * damage[1] / 100);
     }
 
     display_player_one_line(ENTRY_AVG_DMG, desc, TERM_L_BLUE);
-    display_player_one_line(ENTRY_INFRA, format("%d feet", player_ptr->see_infra * 10), TERM_WHITE);
+    display_player_one_line(ENTRY_INFRA, angband::format("%d feet", player_ptr->see_infra * 10), TERM_WHITE);
 }
 
 /*!

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -153,9 +153,9 @@ static void print_monster_line(TERM_LEN x, TERM_LEN y, MonsterEntity *m_ptr, int
         return;
     }
     if (r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
-        buf = format(_("%3s(覚%2d)", "%3s(%2d)"), MonsterRace(r_idx).is_bounty(true) ? "  W" : "  U", n_awake);
+        buf = angband::format(_("%3s(覚%2d)", "%3s(%2d)"), MonsterRace(r_idx).is_bounty(true) ? "  W" : "  U", n_awake);
     } else {
-        buf = format(_("%3d(覚%2d)", "%3d(%2d)"), n_same, n_awake);
+        buf = angband::format(_("%3d(覚%2d)", "%3d(%2d)"), n_same, n_awake);
     }
     term_addstr(-1, TERM_WHITE, buf);
 
@@ -163,14 +163,14 @@ static void print_monster_line(TERM_LEN x, TERM_LEN y, MonsterEntity *m_ptr, int
     term_add_bigch(r_ptr->x_attr, r_ptr->x_char);
 
     if (r_ptr->r_tkills && m_ptr->mflag2.has_not(MonsterConstantFlagType::KAGE)) {
-        buf = format(" %2d", (int)r_ptr->level);
+        buf = angband::format(" %2d", (int)r_ptr->level);
     } else {
         buf = " ??";
     }
 
     term_addstr(-1, TERM_WHITE, buf);
 
-    term_addstr(-1, TERM_WHITE, format(" %s ", r_ptr->name.data()));
+    term_addstr(-1, TERM_WHITE, angband::format(" %s ", r_ptr->name.data()));
 }
 
 /*!
@@ -318,7 +318,7 @@ static void display_equipment(PlayerType *player_ptr, const ItemTester &item_tes
         term_putstr(cur_col, cur_row, n, attr, item_name);
         if (show_weights) {
             int wgt = o_ptr->weight * o_ptr->number;
-            tmp_val = format(_("%3d.%1d kg", "%3d.%1d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
+            tmp_val = angband::format(_("%3d.%1d kg", "%3d.%1d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
             prt(tmp_val, cur_row, wid - (show_labels ? 28 : 9));
         }
 
@@ -530,13 +530,13 @@ static void display_floor_item_list(PlayerType *player_ptr, const int y, const i
     // 先頭行を書く。
     auto is_hallucinated = player_ptr->effects()->hallucination()->is_hallucinated();
     if (player_bold(player_ptr, y, x)) {
-        line = format(_("(X:%03d Y:%03d) あなたの足元のアイテム一覧", "Items at (%03d,%03d) under you"), x, y);
+        line = angband::format(_("(X:%03d Y:%03d) あなたの足元のアイテム一覧", "Items at (%03d,%03d) under you"), x, y);
     } else if (const auto *m_ptr = monster_on_floor_items(floor_ptr, g_ptr); m_ptr != nullptr) {
         if (is_hallucinated) {
-            line = format(_("(X:%03d Y:%03d) 何か奇妙な物の足元の発見済みアイテム一覧", "Found items at (%03d,%03d) under something strange"), x, y);
+            line = angband::format(_("(X:%03d Y:%03d) 何か奇妙な物の足元の発見済みアイテム一覧", "Found items at (%03d,%03d) under something strange"), x, y);
         } else {
             const MonsterRaceInfo *const r_ptr = &monraces_info[m_ptr->ap_r_idx];
-            line = format(_("(X:%03d Y:%03d) %sの足元の発見済みアイテム一覧", "Found items at (%03d,%03d) under %s"), x, y, r_ptr->name.data());
+            line = angband::format(_("(X:%03d Y:%03d) %sの足元の発見済みアイテム一覧", "Found items at (%03d,%03d) under %s"), x, y, r_ptr->name.data());
         }
     } else {
         const TerrainType *const f_ptr = &terrains_info[g_ptr->feat];
@@ -544,13 +544,13 @@ static void display_floor_item_list(PlayerType *player_ptr, const int y, const i
         std::string buf;
 
         if (f_ptr->flags.has(TerrainCharacteristics::STORE) || (f_ptr->flags.has(TerrainCharacteristics::BLDG) && !floor_ptr->inside_arena)) {
-            buf = format(_("%sの入口", "on the entrance of %s"), fn);
+            buf = angband::format(_("%sの入口", "on the entrance of %s"), fn);
         } else if (f_ptr->flags.has(TerrainCharacteristics::WALL)) {
-            buf = format(_("%sの中", "in %s"), fn);
+            buf = angband::format(_("%sの中", "in %s"), fn);
         } else {
-            buf = format(_("%s", "on %s"), fn);
+            buf = angband::format(_("%s", "on %s"), fn);
         }
-        line = format(_("(X:%03d Y:%03d) %sの上の発見済みアイテム一覧", "Found items at (X:%03d Y:%03d) %s"), x, y, buf.data());
+        line = angband::format(_("(X:%03d Y:%03d) %sの上の発見済みアイテム一覧", "Found items at (X:%03d Y:%03d) %s"), x, y, buf.data());
     }
     term_addstr(-1, TERM_WHITE, line);
 
@@ -651,7 +651,7 @@ static void display_found_item_list(PlayerType *player_ptr)
 
         // アイテムシンボル表示
         const auto symbol_code = item->get_symbol();
-        const auto symbol = format(" %c ", symbol_code);
+        const auto symbol = angband::format(" %c ", symbol_code);
         const auto color_code_for_symbol = item->get_color();
         term_addstr(-1, color_code_for_symbol, symbol);
 
@@ -660,7 +660,7 @@ static void display_found_item_list(PlayerType *player_ptr)
         term_addstr(-1, color_code_for_item, item_name);
 
         // アイテム座標表示
-        const auto item_location = format("(X:%3d Y:%3d)", item->ix, item->iy);
+        const auto item_location = angband::format("(X:%3d Y:%3d)", item->ix, item->iy);
         prt(item_location, term_y, term_w - item_location.length() - 1);
 
         ++term_y;
@@ -780,7 +780,7 @@ static void display_spell_list(PlayerType *player_ptr)
 
             const auto comment = mindcraft_info(player_ptr, use_mind, i);
             constexpr auto fmt = "  %c) %-30s%2d %4d %3d%%%s";
-            term_putstr(x, y + i + 1, -1, a, format(fmt, I2A(i), spell.name, spell.min_lev, spell.mana_cost, chance, comment.data()));
+            term_putstr(x, y + i + 1, -1, a, angband::format(fmt, I2A(i), spell.name, spell.min_lev, spell.mana_cost, chance, comment.data()));
         }
 
         return;
@@ -820,7 +820,7 @@ static void display_spell_list(PlayerType *player_ptr)
             }
 
             m[j] = y + n;
-            term_putstr(x, m[j], -1, a, format("%c/%c) %-20.20s", I2A(n / 8), I2A(n % 8), name));
+            term_putstr(x, m[j], -1, a, angband::format("%c/%c) %-20.20s", I2A(n / 8), I2A(n % 8), name));
             n++;
         }
     }

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -60,7 +60,7 @@ void print_title(PlayerType *player_ptr)
  */
 void print_level(PlayerType *player_ptr)
 {
-    std::string tmp = format("%5d", player_ptr->lev);
+    std::string tmp = angband::format("%5d", player_ptr->lev);
     if (player_ptr->lev >= player_ptr->max_plv) {
         put_str(_("レベル ", "LEVEL "), ROW_LEVEL, 0);
         c_put_str(TERM_L_GREEN, tmp, ROW_LEVEL, COL_LEVEL + 7);
@@ -79,12 +79,12 @@ void print_exp(PlayerType *player_ptr)
 
     PlayerRace pr(player_ptr);
     if ((!exp_need) || pr.equals(PlayerRaceType::ANDROID)) {
-        out_val = format("%8ld", (long)player_ptr->exp);
+        out_val = angband::format("%8ld", (long)player_ptr->exp);
     } else {
         if (player_ptr->lev >= PY_MAX_LEVEL) {
             out_val = "********";
         } else {
-            out_val = format("%8ld", (long)(player_exp[player_ptr->lev - 1] * player_ptr->expfact / 100L) - player_ptr->exp);
+            out_val = angband::format("%8ld", (long)(player_exp[player_ptr->lev - 1] * player_ptr->expfact / 100L) - player_ptr->exp);
         }
     }
 
@@ -108,7 +108,7 @@ void print_ac(PlayerType *player_ptr)
 {
     /* AC の表示方式を変更している */
     put_str(_(" ＡＣ(     )", "Cur AC "), ROW_AC, COL_AC);
-    c_put_str(TERM_L_GREEN, format("%5d", player_ptr->dis_ac + player_ptr->dis_to_a), ROW_AC, COL_AC + _(6, 7));
+    c_put_str(TERM_L_GREEN, angband::format("%5d", player_ptr->dis_ac + player_ptr->dis_to_a), ROW_AC, COL_AC + _(6, 7));
 }
 
 /*!
@@ -126,10 +126,10 @@ void print_hp(PlayerType *player_ptr)
         color = TERM_RED;
     }
 
-    c_put_str(color, format("%4ld", (long int)player_ptr->chp), ROW_CURHP, COL_CURHP + 3);
+    c_put_str(color, angband::format("%4ld", (long int)player_ptr->chp), ROW_CURHP, COL_CURHP + 3);
     put_str("/", ROW_CURHP, COL_CURHP + 7);
     color = TERM_L_GREEN;
-    c_put_str(color, format("%4ld", (long int)player_ptr->mhp), ROW_CURHP, COL_CURHP + 8);
+    c_put_str(color, angband::format("%4ld", (long int)player_ptr->mhp), ROW_CURHP, COL_CURHP + 8);
 }
 
 /*!
@@ -151,10 +151,10 @@ void print_sp(PlayerType *player_ptr)
         color = TERM_RED;
     }
 
-    c_put_str(color, format("%4ld", (long int)player_ptr->csp), ROW_CURSP, COL_CURSP + 3);
+    c_put_str(color, angband::format("%4ld", (long int)player_ptr->csp), ROW_CURSP, COL_CURSP + 3);
     put_str("/", ROW_CURSP, COL_CURSP + 7);
     color = TERM_L_GREEN;
-    c_put_str(color, format("%4ld", (long int)player_ptr->msp), ROW_CURSP, COL_CURSP + 8);
+    c_put_str(color, angband::format("%4ld", (long int)player_ptr->msp), ROW_CURSP, COL_CURSP + 8);
 }
 
 /*!
@@ -164,7 +164,7 @@ void print_sp(PlayerType *player_ptr)
 void print_gold(PlayerType *player_ptr)
 {
     put_str(_("＄ ", "AU "), ROW_GOLD, COL_GOLD);
-    c_put_str(TERM_L_GREEN, format("%9ld", (long)player_ptr->au), ROW_GOLD, COL_GOLD + 3);
+    c_put_str(TERM_L_GREEN, angband::format("%9ld", (long)player_ptr->au), ROW_GOLD, COL_GOLD + 3);
 }
 
 /*!
@@ -182,20 +182,20 @@ void print_depth(PlayerType *player_ptr)
 
     auto *floor_ptr = player_ptr->current_floor_ptr;
     if (!floor_ptr->dun_level) {
-        c_prt(attr, format("%7s", _("地上", "Surf.")), row_depth, col_depth);
+        c_prt(attr, angband::format("%7s", _("地上", "Surf.")), row_depth, col_depth);
         return;
     }
 
     if (inside_quest(floor_ptr->quest_number) && !floor_ptr->dungeon_idx) {
-        c_prt(attr, format("%7s", _("地上", "Quest")), row_depth, col_depth);
+        c_prt(attr, angband::format("%7s", _("地上", "Quest")), row_depth, col_depth);
         return;
     }
 
     std::string depths;
     if (depth_in_feet) {
-        depths = format(_("%d ft", "%d ft"), (int)floor_ptr->dun_level * 50);
+        depths = angband::format(_("%d ft", "%d ft"), (int)floor_ptr->dun_level * 50);
     } else {
-        depths = format(_("%d 階", "Lev %d"), (int)floor_ptr->dun_level);
+        depths = angband::format(_("%d 階", "Lev %d"), (int)floor_ptr->dun_level);
     }
 
     switch (player_ptr->feeling) {
@@ -234,7 +234,7 @@ void print_depth(PlayerType *player_ptr)
         break; /* Boring place */
     }
 
-    c_prt(attr, format("%7s", depths.data()), row_depth, col_depth);
+    c_prt(attr, angband::format("%7s", depths.data()), row_depth, col_depth);
 }
 
 /*!
@@ -287,9 +287,9 @@ static void print_health_monster_in_arena_for_wizard(PlayerType *player_ptr)
         auto &monster = player_ptr->current_floor_ptr->m_list[monster_list_index];
         if (MonsterRace(monster.r_idx).is_valid()) {
             term_putstr(col - 2, row + row_offset, 2, monraces_info[monster.r_idx].x_attr,
-                format("%c", monraces_info[monster.r_idx].x_char));
-            term_putstr(col - 1, row + row_offset, 5, TERM_WHITE, format("%5d", monster.hp));
-            term_putstr(col + 5, row + row_offset, 6, TERM_WHITE, format("%5d", monster.max_maxhp));
+                angband::format("%c", monraces_info[monster.r_idx].x_char));
+            term_putstr(col - 1, row + row_offset, 5, TERM_WHITE, angband::format("%5d", monster.hp));
+            term_putstr(col + 5, row + row_offset, 6, TERM_WHITE, angband::format("%5d", monster.max_maxhp));
         }
     }
 }

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -159,12 +159,12 @@ void print_state(PlayerType *player_ptr)
     std::string text;
     if (command_rep) {
         if (command_rep > 999) {
-            text = format("%2d00", command_rep / 100);
+            text = angband::format("%2d00", command_rep / 100);
         } else {
-            text = format("  %2d", command_rep);
+            text = angband::format("  %2d", command_rep);
         }
 
-        c_put_str(attr, format("%5.5s", text.data()), ROW_STATE, COL_STATE);
+        c_put_str(attr, angband::format("%5.5s", text.data()), ROW_STATE, COL_STATE);
         return;
     }
 
@@ -175,7 +175,7 @@ void print_state(PlayerType *player_ptr)
     }
     case ACTION_REST:
         if (player_ptr->resting > 0) {
-            text = format("%4d", player_ptr->resting);
+            text = angband::format("%4d", player_ptr->resting);
         } else if (player_ptr->resting == COMMAND_ARG_REST_FULL_HEALING) {
             text = "****";
         } else if (player_ptr->resting == COMMAND_ARG_REST_UNTIL_DONE) {
@@ -246,7 +246,7 @@ void print_state(PlayerType *player_ptr)
     }
     }
 
-    c_put_str(attr, format("%5.5s", text.data()), ROW_STATE, COL_STATE);
+    c_put_str(attr, angband::format("%5.5s", text.data()), ROW_STATE, COL_STATE);
 }
 
 /*!
@@ -283,7 +283,7 @@ void print_speed(PlayerType *player_ptr)
         } else {
             attr = TERM_L_GREEN;
         }
-        buf = format("%s(+%d)", (player_ptr->riding ? _("乗馬", "Ride") : _("加速", "Fast")), speed);
+        buf = angband::format("%s(+%d)", (player_ptr->riding ? _("乗馬", "Ride") : _("加速", "Fast")), speed);
     } else if (speed < 0) {
         auto is_slow = player_ptr->effects()->deceleration()->is_slow();
         if (player_ptr->riding) {
@@ -302,13 +302,13 @@ void print_speed(PlayerType *player_ptr)
         } else {
             attr = TERM_L_UMBER;
         }
-        buf = format("%s(%d)", (player_ptr->riding ? _("乗馬", "Ride") : _("減速", "Slow")), speed);
+        buf = angband::format("%s(%d)", (player_ptr->riding ? _("乗馬", "Ride") : _("減速", "Slow")), speed);
     } else if (player_ptr->riding) {
         attr = TERM_GREEN;
         buf = _("乗馬中", "Riding");
     }
 
-    c_put_str(attr, format("%-9s", buf.data()), row_speed, col_speed);
+    c_put_str(attr, angband::format("%-9s", buf.data()), row_speed, col_speed);
 }
 
 /*!

--- a/src/wizard/artifact-analyzer.cpp
+++ b/src/wizard/artifact-analyzer.cpp
@@ -213,13 +213,13 @@ static void analyze_misc_magic(ItemEntity *o_ptr, concptr *misc_list)
     std::string desc;
     if (flags.has(TR_LITE_FUEL)) {
         if (rad > 0) {
-            desc = format(_("それは燃料補給によって明かり(半径 %d)を授ける。", "It provides light (radius %d) when fueled."), (int)rad);
+            desc = angband::format(_("それは燃料補給によって明かり(半径 %d)を授ける。", "It provides light (radius %d) when fueled."), (int)rad);
         }
     } else {
         if (rad > 0) {
-            desc = format(_("永久光源(半径 %d)", "Permanent Light(radius %d)"), (int)rad);
+            desc = angband::format(_("永久光源(半径 %d)", "Permanent Light(radius %d)"), (int)rad);
         } else if (rad < 0) {
-            desc = format(_("永久光源(半径-%d)。", "Permanent Light(radius -%d)"), (int)-rad);
+            desc = angband::format(_("永久光源(半径-%d)。", "Permanent Light(radius -%d)"), (int)-rad);
         }
     }
 

--- a/src/wizard/items-spoiler.cpp
+++ b/src/wizard/items-spoiler.cpp
@@ -41,12 +41,12 @@ static std::string describe_dam_or_ac(const ItemEntity &item)
     case ItemKindType::SHOT:
     case ItemKindType::BOLT:
     case ItemKindType::ARROW:
-        return format("%dd%d", item.dd, item.ds);
+        return angband::format("%dd%d", item.dd, item.ds);
     case ItemKindType::HAFTED:
     case ItemKindType::POLEARM:
     case ItemKindType::SWORD:
     case ItemKindType::DIGGING:
-        return format("%dd%d", item.dd, item.ds);
+        return angband::format("%dd%d", item.dd, item.ds);
     case ItemKindType::BOOTS:
     case ItemKindType::GLOVES:
     case ItemKindType::CLOAK:
@@ -56,7 +56,7 @@ static std::string describe_dam_or_ac(const ItemEntity &item)
     case ItemKindType::SOFT_ARMOR:
     case ItemKindType::HARD_ARMOR:
     case ItemKindType::DRAG_ARMOR:
-        return format("%d", item.ac);
+        return angband::format("%d", item.ac);
     default:
         return {};
     }
@@ -76,7 +76,7 @@ static std::string describe_chance(const ItemEntity &item)
     for (auto i = 0U; i < baseitem.alloc_tables.size(); i++) {
         const auto &[level, chance] = baseitem.alloc_tables[i];
         if (chance > 0) {
-            ss << format("%s%3dF:%+4d", (i != 0 ? "/" : ""), level, 100 / chance);
+            ss << angband::format("%s%3dF:%+4d", (i != 0 ? "/" : ""), level, 100 / chance);
         }
     }
 
@@ -91,7 +91,7 @@ static std::string describe_chance(const ItemEntity &item)
  */
 static std::string describe_weight(const ItemEntity &item)
 {
-    return format("%3d.%d", (int)(item.weight / 10), (int)(item.weight % 10));
+    return angband::format("%3d.%d", (int)(item.weight / 10), (int)(item.weight % 10));
 }
 
 /*!

--- a/src/wizard/monster-info-spoiler.cpp
+++ b/src/wizard/monster-info-spoiler.cpp
@@ -121,18 +121,18 @@ SpoilerOutputResultType spoil_mon_desc(concptr fname, std::function<bool(const M
         }
         nam.append(name.front());
 
-        std::string lev = format("%d", (int)r_ptr->level);
-        std::string rar = format("%d", (int)r_ptr->rarity);
-        std::string spd = format("%+d", r_ptr->speed - STANDARD_SPEED);
-        std::string ac = format("%d", r_ptr->ac);
+        std::string lev = angband::format("%d", (int)r_ptr->level);
+        std::string rar = angband::format("%d", (int)r_ptr->rarity);
+        std::string spd = angband::format("%+d", r_ptr->speed - STANDARD_SPEED);
+        std::string ac = angband::format("%d", r_ptr->ac);
         std::string hp;
         if (any_bits(r_ptr->flags1, RF1_FORCE_MAXHP) || (r_ptr->hside == 1)) {
-            hp = format("%d", r_ptr->hdice * r_ptr->hside);
+            hp = angband::format("%d", r_ptr->hdice * r_ptr->hside);
         } else {
-            hp = format("%dd%d", r_ptr->hdice, r_ptr->hside);
+            hp = angband::format("%dd%d", r_ptr->hdice, r_ptr->hside);
         }
 
-        std::string symbol = format("%s '%c'", attr_to_text(r_ptr), r_ptr->d_char);
+        std::string symbol = angband::format("%s '%c'", attr_to_text(r_ptr), r_ptr->d_char);
         fprintf(spoiler_file, "%-45.45s%4s %4s %4s %7s %7s  %19.19s\n",
             nam.data(), lev.data(), rar.data(), spd.data(), hp.data(),
             ac.data(), symbol.data());
@@ -193,22 +193,22 @@ SpoilerOutputResultType spoil_mon_info(concptr fname)
             spoil_out("[N] ");
         }
 
-        spoil_out(format(_("%s/%s  (", "%s%s ("), r_ptr->name.data(), _(r_ptr->E_name.data(), ""))); /* ---)--- */
+        spoil_out(angband::format(_("%s/%s  (", "%s%s ("), r_ptr->name.data(), _(r_ptr->E_name.data(), ""))); /* ---)--- */
         spoil_out(attr_to_text(r_ptr));
-        spoil_out(format(" '%c')\n", r_ptr->d_char));
+        spoil_out(angband::format(" '%c')\n", r_ptr->d_char));
         spoil_out("=== ");
-        spoil_out(format("Num:%d  ", enum2i(r_idx)));
-        spoil_out(format("Lev:%d  ", (int)r_ptr->level));
-        spoil_out(format("Rar:%d  ", r_ptr->rarity));
-        spoil_out(format("Spd:%+d  ", r_ptr->speed - STANDARD_SPEED));
+        spoil_out(angband::format("Num:%d  ", enum2i(r_idx)));
+        spoil_out(angband::format("Lev:%d  ", (int)r_ptr->level));
+        spoil_out(angband::format("Rar:%d  ", r_ptr->rarity));
+        spoil_out(angband::format("Spd:%+d  ", r_ptr->speed - STANDARD_SPEED));
         if (any_bits(r_ptr->flags1, RF1_FORCE_MAXHP) || (r_ptr->hside == 1)) {
-            spoil_out(format("Hp:%d  ", r_ptr->hdice * r_ptr->hside));
+            spoil_out(angband::format("Hp:%d  ", r_ptr->hdice * r_ptr->hside));
         } else {
-            spoil_out(format("Hp:%dd%d  ", r_ptr->hdice, r_ptr->hside));
+            spoil_out(angband::format("Hp:%dd%d  ", r_ptr->hdice, r_ptr->hside));
         }
 
-        spoil_out(format("Ac:%d  ", r_ptr->ac));
-        spoil_out(format("Exp:%ld\n", (long)(r_ptr->mexp)));
+        spoil_out(angband::format("Ac:%d  ", r_ptr->ac));
+        spoil_out(angband::format("Exp:%ld\n", (long)(r_ptr->mexp)));
         output_monster_spoiler(r_idx, roff_func);
         spoil_out({}, true);
     }

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -294,11 +294,11 @@ static void prt_alloc(const BaseitemKey &bi_key, TERM_LEN row, TERM_LEN col)
 
     for (auto i = 0; i < 22; i++) {
         term_putch(col, row + i + 1, TERM_WHITE, '|');
-        prt(format("%2dF", (i * 5)), row + i + 1, col);
+        prt(angband::format("%2dF", (i * 5)), row + i + 1, col);
         if ((i * BASEITEM_MAX_DEPTH / 22 <= home) && (home < (i + 1) * BASEITEM_MAX_DEPTH / 22)) {
-            c_prt(TERM_RED, format("%3d.%04d%%", display[i] / 1000, display[i] % 1000), row + i + 1, col + 3);
+            c_prt(TERM_RED, angband::format("%3d.%04d%%", display[i] / 1000, display[i] % 1000), row + i + 1, col + 3);
         } else {
-            c_prt(TERM_WHITE, format("%3d.%04d%%", display[i] / 1000, display[i] % 1000), row + i + 1, col + 3);
+            c_prt(TERM_WHITE, angband::format("%3d.%04d%%", display[i] / 1000, display[i] % 1000), row + i + 1, col + 3);
         }
     }
 
@@ -351,15 +351,15 @@ static void wiz_display_item(PlayerType *player_ptr, ItemEntity *o_ptr)
     auto line = 4;
     const auto &bi_key = o_ptr->bi_key;
     const auto item_level = o_ptr->get_baseitem().level;
-    prt(format("kind = %-5d  level = %-4d  tval = %-5d  sval = %-5d", o_ptr->bi_id, item_level, enum2i(bi_key.tval()), bi_key.sval().value()), line, j);
-    prt(format("number = %-3d  wgt = %-6d  ac = %-5d    damage = %dd%d", o_ptr->number, o_ptr->weight, o_ptr->ac, o_ptr->dd, o_ptr->ds), ++line, j);
-    prt(format("pval = %-5d  toac = %-5d  tohit = %-4d  todam = %-4d", o_ptr->pval, o_ptr->to_a, o_ptr->to_h, o_ptr->to_d), ++line, j);
-    prt(format("fixed_artifact_idx = %-4d  ego_idx = %-4d  cost = %d", enum2i(o_ptr->fixed_artifact_idx), enum2i(o_ptr->ego_idx), object_value_real(o_ptr)), ++line, j);
-    prt(format("ident = %04x  activation_id = %-4d  timeout = %-d", o_ptr->ident, enum2i(o_ptr->activation_id), o_ptr->timeout), ++line, j);
-    prt(format("chest_level = %-4d  fuel = %-d", o_ptr->chest_level, o_ptr->fuel), ++line, j);
-    prt(format("smith_hit = %-4d  smith_damage = %-4d", o_ptr->smith_hit, o_ptr->smith_damage), ++line, j);
-    prt(format("cursed  = %-4lX  captured_monster_speed = %-4d", o_ptr->curse_flags.to_ulong(), o_ptr->captured_monster_speed), ++line, j);
-    prt(format("captured_monster_max_hp = %-4d  captured_monster_max_hp = %-4d", o_ptr->captured_monster_current_hp, o_ptr->captured_monster_max_hp), ++line, j);
+    prt(angband::format("kind = %-5d  level = %-4d  tval = %-5d  sval = %-5d", o_ptr->bi_id, item_level, enum2i(bi_key.tval()), bi_key.sval().value()), line, j);
+    prt(angband::format("number = %-3d  wgt = %-6d  ac = %-5d    damage = %dd%d", o_ptr->number, o_ptr->weight, o_ptr->ac, o_ptr->dd, o_ptr->ds), ++line, j);
+    prt(angband::format("pval = %-5d  toac = %-5d  tohit = %-4d  todam = %-4d", o_ptr->pval, o_ptr->to_a, o_ptr->to_h, o_ptr->to_d), ++line, j);
+    prt(angband::format("fixed_artifact_idx = %-4d  ego_idx = %-4d  cost = %d", enum2i(o_ptr->fixed_artifact_idx), enum2i(o_ptr->ego_idx), object_value_real(o_ptr)), ++line, j);
+    prt(angband::format("ident = %04x  activation_id = %-4d  timeout = %-d", o_ptr->ident, enum2i(o_ptr->activation_id), o_ptr->timeout), ++line, j);
+    prt(angband::format("chest_level = %-4d  fuel = %-d", o_ptr->chest_level, o_ptr->fuel), ++line, j);
+    prt(angband::format("smith_hit = %-4d  smith_damage = %-4d", o_ptr->smith_hit, o_ptr->smith_damage), ++line, j);
+    prt(angband::format("cursed  = %-4lX  captured_monster_speed = %-4d", o_ptr->curse_flags.to_ulong(), o_ptr->captured_monster_speed), ++line, j);
+    prt(angband::format("captured_monster_max_hp = %-4d  captured_monster_max_hp = %-4d", o_ptr->captured_monster_current_hp, o_ptr->captured_monster_max_hp), ++line, j);
 
     prt("+------------FLAGS1------------+", ++line, j);
     prt("AFFECT........SLAY........BRAND.", ++line, j);
@@ -458,7 +458,7 @@ static void wiz_statistics(PlayerType *player_ptr, ItemEntity *o_ptr)
                     break; // stop rolling
                 }
 
-                prt(format(q, i, correct, matches, better, worse, other), 0, 0);
+                prt(angband::format(q, i, correct, matches, better, worse, other), 0, 0);
                 term_fresh();
             }
 

--- a/src/wizard/wizard-messages.h
+++ b/src/wizard/wizard-messages.h
@@ -5,4 +5,4 @@
 
 class PlayerType;
 void msg_print_wizard(PlayerType *player_ptr, int cheat_type, std::string_view msg);
-void msg_format_wizard(PlayerType *player_ptr, int cheat_type, const char *fmt, ...) __attribute__((format(printf, 3, 4)));
+void msg_format_wizard(PlayerType *player_ptr, int cheat_type, const char *fmt, ...) __attribute__((angband::format(printf, 3, 4)));

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -132,7 +132,7 @@ static std::optional<short> wiz_select_tval()
         auto row = 2 + (list % 20);
         auto col = _(32, 24) * (list / 20);
         ch = listsym[list];
-        prt(format("[%c] %s", ch, tvals[list].desc), row, col);
+        prt(angband::format("[%c] %s", ch, tvals[list].desc), row, col);
     }
 
     auto max_num = list;
@@ -172,12 +172,12 @@ static short wiz_select_sval(const ItemKindType tval, concptr tval_description)
         auto col = _(30, 32) * (num / 20);
         ch = listsym[num];
         const auto buf = strip_name(baseitem.idx);
-        prt(format("[%c] %s", ch, buf.data()), row, col);
+        prt(angband::format("[%c] %s", ch, buf.data()), row, col);
         choice[num++] = baseitem.idx;
     }
 
     auto max_num = num;
-    if (!get_com(format(_("%s群の具体的なアイテムを選んで下さい", "What Kind of %s? "), tval_description), &ch, false)) {
+    if (!get_com(angband::format(_("%s群の具体的なアイテムを選んで下さい", "What Kind of %s? "), tval_description), &ch, false)) {
         return 0;
     }
 
@@ -302,7 +302,7 @@ static std::optional<FixedArtifactId> wiz_select_named_artifact(PlayerType *play
             put_str(ss.str(), i + 1, 15);
         }
         if (page_max > 1) {
-            put_str(format("-- more (%lu/%lu) --", current_page + 1, page_max), page_item_count + 1, 15);
+            put_str(angband::format("-- more (%lu/%lu) --", current_page + 1, page_max), page_item_count + 1, 15);
         }
 
         char cmd = ESCAPE;
@@ -615,9 +615,9 @@ static void wiz_jump_floor(PlayerType *player_ptr, DUNGEON_IDX dun_idx, DEPTH de
     leave_quest_check(player_ptr);
     auto to = !floor.is_in_dungeon()
                   ? _("地上", "the surface")
-                  : format(_("%d階(%s)", "level %d of %s"), floor.dun_level, floor.get_dungeon_definition().name.data());
+                  : angband::format(_("%d階(%s)", "level %d of %s"), floor.dun_level, floor.get_dungeon_definition().name.data());
     constexpr auto mes = _("%sへとウィザード・テレポートで移動した。\n", "You wizard-teleported to %s.\n");
-    msg_print_wizard(player_ptr, 2, format(mes, to.data()));
+    msg_print_wizard(player_ptr, 2, angband::format(mes, to.data()));
     floor.quest_number = QuestId::NONE;
     PlayerEnergy(player_ptr).reset_player_turn();
     player_ptr->energy_need = 0;

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -260,7 +260,7 @@ void wiz_kill_target(PlayerType *player_ptr, int dam, AttributeType effect_idx, 
             const auto &gf_description = gf_descriptions[i];
             auto name = std::string_view(gf_description.name).substr(3); // 先頭の"GF_"を取り除く
             auto num = enum2i(gf_description.num);
-            put_str(format("%03d:%-.10s^", num, name.data()), 1 + i / 5, 1 + (i % 5) * 16);
+            put_str(angband::format("%03d:%-.10s^", num, name.data()), 1 + i / 5, 1 + (i % 5) * 16);
         }
 
         if (!get_value("EffectID", 1, max - 1, &idx)) {

--- a/src/wizard/wizard-spoiler.cpp
+++ b/src/wizard/wizard-spoiler.cpp
@@ -182,14 +182,14 @@ static SpoilerOutputResultType spoil_player_spell(concptr fname)
         return SpoilerOutputResultType::FILE_OPEN_FAILED;
     }
 
-    spoil_out(format("Player spells for %s\n", get_version().data()));
+    spoil_out(angband::format("Player spells for %s\n", get_version().data()));
     spoil_out("------------------------------------------\n\n");
 
     PlayerType dummy_p;
     dummy_p.lev = 1;
     for (auto c = 0; c < PLAYER_CLASS_TYPE_MAX; c++) {
         auto class_ptr = &class_info[c];
-        spoil_out(format("[[Class: %s]]\n", class_ptr->title));
+        spoil_out(angband::format("[[Class: %s]]\n", class_ptr->title));
 
         auto magic_ptr = &class_magics_info[c];
         auto book_name = "なし";
@@ -205,19 +205,19 @@ static SpoilerOutputResultType spoil_player_spell(concptr fname)
 
         constexpr auto mes = "BookType:%s Stat:%s Xtra:%x Type:%d Weight:%d\n";
         const auto &spell = wiz_spell_stat[magic_ptr->spell_stat];
-        spoil_out(format(mes, book_name, spell.data(), magic_ptr->spell_xtra, magic_ptr->spell_type, magic_ptr->spell_weight));
+        spoil_out(angband::format(mes, book_name, spell.data(), magic_ptr->spell_xtra, magic_ptr->spell_type, magic_ptr->spell_weight));
         if (magic_ptr->spell_book == ItemKindType::NONE) {
             spoil_out(_("呪文なし\n\n", "No spells.\n\n"));
             continue;
         }
 
         for (int16_t r = 1; r < MAX_MAGIC; r++) {
-            spoil_out(format("[Realm: %s]\n", realm_names[r]));
+            spoil_out(angband::format("[Realm: %s]\n", realm_names[r]));
             spoil_out("Name                     Lv Cst Dif Exp\n");
             for (SPELL_IDX i = 0; i < 32; i++) {
                 auto spell_ptr = &magic_ptr->info[r][i];
                 const auto spell_name = exe_spell(&dummy_p, r, i, SpellProcessType::NAME);
-                spoil_out(format("%-24s %2d %3d %3d %3d\n", spell_name->data(), spell_ptr->slevel, spell_ptr->smana, spell_ptr->sfail, spell_ptr->sexp));
+                spoil_out(angband::format("%-24s %2d %3d %3d %3d\n", spell_name->data(), spell_ptr->slevel, spell_ptr->smana, spell_ptr->sfail, spell_ptr->sexp));
             }
             spoil_out("\n");
         }

--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -111,12 +111,12 @@ void WorldTurnProcessor::print_time()
     c_put_str(TERM_WHITE, "             ", row, COL_DAY);
     extract_day_hour_min(this->player_ptr, &day, &this->hour, &this->min);
     if (day < 1000) {
-        c_put_str(TERM_WHITE, format(_("%2d日目", "Day%3d"), day), row, COL_DAY);
+        c_put_str(TERM_WHITE, angband::format(_("%2d日目", "Day%3d"), day), row, COL_DAY);
     } else {
         c_put_str(TERM_WHITE, _("***日目", "Day***"), row, COL_DAY);
     }
 
-    c_put_str(TERM_WHITE, format("%2d:%02d", this->hour, this->min), row, COL_DAY + 7);
+    c_put_str(TERM_WHITE, angband::format("%2d:%02d", this->hour, this->min), row, COL_DAY + 7);
 }
 
 void WorldTurnProcessor::process_downward()


### PR DESCRIPTION
(現状こうしなくとも全て問題なく動作はするのでマージするかは悩みどころですが、取り敢えずコンパイルできたのでPR出しておきます)

静的解析警告は文字列操作周りもいくらか含まれるのでformat() が複数箇所呼び出されており、今後も単調増加していくことが見込まれます
Apple Clang でいつ実装されるかはさておき、既にC++20でのコンパイル環境である以上、std::format() とは異なる機能 (%s^)があることを明確に示す意味合いもあります
単純置換ですがご確認下さい