### PR TITLE
[Feature] ウインドウ・フラグ「ペット一覧」

### DIFF
--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -312,7 +312,11 @@ void process_player(PlayerType *player_ptr)
         } else {
             move_cursor_relative(player_ptr->y, player_ptr->x);
 
-            rfu.set_flag(SubWindowRedrawingFlag::SIGHT_MONSTERS);
+            static constexpr auto flags = {
+                SubWindowRedrawingFlag::SIGHT_MONSTERS,
+                SubWindowRedrawingFlag::PETS,
+            };
+            rfu.set_flags(flags);
             window_stuff(player_ptr);
 
             can_save = true;

--- a/src/core/window-redrawer.cpp
+++ b/src/core/window-redrawer.cpp
@@ -286,6 +286,11 @@ void window_stuff(PlayerType *player_ptr)
         fix_monster_list(player_ptr);
     }
 
+    if (window_flags.has(SubWindowRedrawingFlag::PETS)) {
+        rfu.reset_flag(SubWindowRedrawingFlag::PETS);
+        fix_pet_list(player_ptr);
+    }
+
     if (window_flags.has(SubWindowRedrawingFlag::MESSAGE)) {
         rfu.reset_flag(SubWindowRedrawingFlag::MESSAGE);
         fix_message();

--- a/src/monster/monster-describer.cpp
+++ b/src/monster/monster-describer.cpp
@@ -209,7 +209,7 @@ static std::string describe_non_pet(const PlayerType &player, const MonsterEntit
     }
 
     std::stringstream ss;
-    if (monster.is_pet()) {
+    if (monster.is_pet() && none_bits(mode, MD_NO_OWNER)) {
         ss << _("あなたの", "your ");
     } else {
         ss << _("", "the ");

--- a/src/monster/monster-description-types.h
+++ b/src/monster/monster-description-types.h
@@ -12,6 +12,7 @@ enum monsetr_description_type {
     MD_ASSUME_VISIBLE = 0x00000080, /* Assume the monster is visible */
     MD_TRUE_NAME = 0x00000100, /* Chameleon's true name */
     MD_IGNORE_HALLU = 0x00000200, /* Ignore hallucination, and penetrate shape change */
+    MD_NO_OWNER = 0x00000400, /* Do not indicate the pet's owner as in "your" */
 };
 
 #define MD_WRONGDOER_NAME (MD_IGNORE_HALLU | MD_ASSUME_VISIBLE | MD_INDEF_VISIBLE) /* 加害明記向け */

--- a/src/system/monster-entity.cpp
+++ b/src/system/monster-entity.cpp
@@ -5,7 +5,9 @@
 #include "monster-race/race-kind-flags.h"
 #include "monster/monster-status.h"
 #include "system/monster-race-info.h"
+#include "term/term-color-types.h"
 #include "util/string-processor.h"
+#include <algorithm>
 
 bool MonsterEntity::is_friendly() const
 {
@@ -209,4 +211,34 @@ std::string MonsterEntity::get_died_message() const
 {
     const auto &monrace = monraces_info[this->r_idx];
     return monrace.get_died_message();
+}
+
+/*!
+ * @brief モンスターの状態（無敵、起きているか、HPの割合）に応じてHPバーの色と長さを算出する
+ * @return HPバーの色と長さ(1-10)のペア
+ */
+std::pair<TERM_COLOR, int> MonsterEntity::get_hp_bar_data() const
+{
+    const auto percent = (this->maxhp > 0) ? (100 * this->hp / this->maxhp) : 0;
+    const auto len = std::clamp(percent / 10 + 1, 1, 10);
+
+    if (this->is_invulnerable()) {
+        return { TERM_WHITE, len };
+    }
+    if (this->is_asleep()) {
+        return { TERM_BLUE, len };
+    }
+    if (percent >= 100) {
+        return { TERM_L_GREEN, len };
+    }
+    if (percent >= 60) {
+        return { TERM_YELLOW, len };
+    }
+    if (percent >= 25) {
+        return { TERM_ORANGE, len };
+    }
+    if (percent >= 10) {
+        return { TERM_L_RED, len };
+    }
+    return { TERM_RED, len };
 }

--- a/src/system/monster-entity.h
+++ b/src/system/monster-entity.h
@@ -84,4 +84,5 @@ public:
     bool has_living_flag(bool is_apperance = false) const;
     bool is_explodable() const;
     std::string get_died_message() const;
+    std::pair<TERM_COLOR, int> get_hp_bar_data() const;
 };

--- a/src/system/redrawing-flags-updater.cpp
+++ b/src/system/redrawing-flags-updater.cpp
@@ -115,7 +115,8 @@ void RedrawingFlagsUpdater::reset_flags(const EnumClassFlagGroup<StatusRecalcula
 
 void RedrawingFlagsUpdater::fill_up_sub_flags()
 {
-    this->sub_window_flags.set(ALL_SUB_WINDOW_FLAGS);
+    constexpr auto all_sub_window_flags = EnumRange(SubWindowRedrawingFlag::INVENTORY, SubWindowRedrawingFlag::FOUND_ITEMS);
+    this->sub_window_flags.set(all_sub_window_flags);
 }
 
 EnumClassFlagGroup<SubWindowRedrawingFlag> RedrawingFlagsUpdater::get_sub_intersection(const EnumClassFlagGroup<SubWindowRedrawingFlag> &flags)

--- a/src/system/redrawing-flags-updater.h
+++ b/src/system/redrawing-flags-updater.h
@@ -50,27 +50,6 @@ enum class SubWindowRedrawingFlag {
     MAX = 16,
 };
 
-/*!
- * @details 欠番があるためEnumRageをそのまま作るのが困難であり、代替として定義する.
- * 欠番が埋まったら不要となるので削除すること。
- */
-inline constexpr auto ALL_SUB_WINDOW_FLAGS = {
-    SubWindowRedrawingFlag::INVENTORY,
-    SubWindowRedrawingFlag::EQUIPMENT,
-    SubWindowRedrawingFlag::SPELL,
-    SubWindowRedrawingFlag::PLAYER,
-    SubWindowRedrawingFlag::SIGHT_MONSTERS,
-    SubWindowRedrawingFlag::PETS,
-    SubWindowRedrawingFlag::MESSAGE,
-    SubWindowRedrawingFlag::OVERHEAD,
-    SubWindowRedrawingFlag::MONSTER_LORE,
-    SubWindowRedrawingFlag::ITEM_KNOWLEDGE,
-    SubWindowRedrawingFlag::DUNGEON,
-    SubWindowRedrawingFlag::SNAPSHOT,
-    SubWindowRedrawingFlag::FLOOR_ITEMS,
-    SubWindowRedrawingFlag::FOUND_ITEMS,
-};
-
 enum class StatusRecalculatingFlag {
     BONUS, /*!< 能力値修正 */
     TORCH, /*!< 光源半径 */

--- a/src/system/redrawing-flags-updater.h
+++ b/src/system/redrawing-flags-updater.h
@@ -36,7 +36,7 @@ enum class SubWindowRedrawingFlag {
     SPELL = 2, /*!< 魔法一覧 */
     PLAYER = 3, /*!< プレイヤーのステータス */
     SIGHT_MONSTERS = 4, /*!< 視界内モンスターの一覧 */
-    /*!< 5は予約領域、セーブデータに影響があるので互換性を保つ変更をしない限り欠番埋め禁止 */
+    PETS = 5, /*!< ペットの一覧 */
     MESSAGE = 6, /*!< メッセージログ */
     OVERHEAD = 7, /*!< 周辺の光景 */
     MONSTER_LORE = 8, /*!< モンスターの思い出 */
@@ -60,6 +60,7 @@ inline constexpr auto ALL_SUB_WINDOW_FLAGS = {
     SubWindowRedrawingFlag::SPELL,
     SubWindowRedrawingFlag::PLAYER,
     SubWindowRedrawingFlag::SIGHT_MONSTERS,
+    SubWindowRedrawingFlag::PETS,
     SubWindowRedrawingFlag::MESSAGE,
     SubWindowRedrawingFlag::OVERHEAD,
     SubWindowRedrawingFlag::MONSTER_LORE,

--- a/src/target/target-preparation.cpp
+++ b/src/target/target-preparation.cpp
@@ -235,3 +235,60 @@ void target_sensing_monsters_prepare(PlayerType *player_ptr, std::vector<MONSTER
 
     std::sort(monster_list.begin(), monster_list.end(), comp_importance);
 }
+
+/*!
+ * @brief プレイヤーのペットの一覧を得る
+ *
+ * プレイヤーのペットのモンスターIDのリストを取得する。
+ * リストは以下の通り、重要なペットと考えられる順にソートされる。
+ *
+ * - 乗馬している
+ * - 名前をつけている
+ * - ユニークモンスター
+ * - LV順（降順）
+ * - モンスターID順（昇順）
+ *
+ * @return ペットのモンスターIDのリスト
+ */
+std::vector<MONSTER_IDX> target_pets_prepare(PlayerType *player_ptr)
+{
+    std::vector<MONSTER_IDX> pets;
+    const auto &floor = *player_ptr->current_floor_ptr;
+
+    for (auto i = 1; i < floor.m_max; ++i) {
+        const auto &monster = floor.m_list[i];
+
+        if (monster.is_valid() && monster.is_pet()) {
+            pets.push_back(i);
+        }
+    }
+
+    auto comp_importance = [riding_idx = player_ptr->riding, &floor](MONSTER_IDX idx1, MONSTER_IDX idx2) {
+        const auto &monster1 = floor.m_list[idx1];
+        const auto &monster2 = floor.m_list[idx2];
+        const auto &ap_monrace1 = monraces_info[monster1.ap_r_idx];
+        const auto &ap_monrace2 = monraces_info[monster2.ap_r_idx];
+
+        if ((riding_idx == idx1) != (riding_idx == idx2)) {
+            return riding_idx == idx1;
+        }
+
+        if (monster1.is_named_pet() != monster2.is_named_pet()) {
+            return monster1.is_named_pet();
+        }
+
+        if (ap_monrace1.kind_flags.has(MonsterKindType::UNIQUE) != ap_monrace2.kind_flags.has(MonsterKindType::UNIQUE)) {
+            return ap_monrace1.kind_flags.has(MonsterKindType::UNIQUE);
+        }
+
+        if (ap_monrace1.r_tkills && ap_monrace2.r_tkills && (ap_monrace1.level != ap_monrace2.level)) {
+            return ap_monrace1.level > ap_monrace2.level;
+        }
+
+        return idx1 < idx2;
+    };
+
+    std::sort(pets.begin(), pets.end(), comp_importance);
+
+    return pets;
+}

--- a/src/target/target-preparation.h
+++ b/src/target/target-preparation.h
@@ -8,3 +8,4 @@ class PlayerType;
 bool target_able(PlayerType *player_ptr, MONSTER_IDX m_idx);
 void target_set_prepare(PlayerType *player_ptr, std::vector<POSITION> &ys, std::vector<POSITION> &xs, BIT_FLAGS mode);
 void target_sensing_monsters_prepare(PlayerType *player_ptr, std::vector<MONSTER_IDX> &monster_list);
+std::vector<MONSTER_IDX> target_pets_prepare(PlayerType *player_ptr);

--- a/src/term/gameterm.cpp
+++ b/src/term/gameterm.cpp
@@ -112,7 +112,7 @@ const concptr window_flag_desc[32] = {
     _("呪文一覧", "Display spell list"),
     _("キャラクタ情報", "Display character"),
     _("視界内のモンスター表示", "Display monsters in sight"),
-    nullptr,
+    _("ペット一覧", "Display pets"),
     _("メッセージ", "Display messages"),
     _("ダンジョン全体図", "Display overhead view"),
     _("モンスターの思い出", "Display monster recall"),

--- a/src/window/display-sub-windows.h
+++ b/src/window/display-sub-windows.h
@@ -10,6 +10,7 @@ class ItemTester;
 void fix_inventory(PlayerType *player_ptr);
 void print_monster_list(FloorType *floor_ptr, const std::vector<MONSTER_IDX> &monster_list, TERM_LEN x, TERM_LEN y, TERM_LEN max_lines);
 void fix_monster_list(PlayerType *player_ptr);
+void fix_pet_list(PlayerType *player_ptr);
 void fix_equip(PlayerType *player_ptr);
 void fix_player(PlayerType *player_ptr);
 void fix_message(void);

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -329,36 +329,6 @@ static std::vector<condition_layout_info> get_condition_layout_info(const Monste
 }
 
 /*!
- * @brief 対象のモンスターの状態（無敵、起きているか、HPの割合）に応じてHPバーの色を算出する
- * @param monster 対象のモンスター
- * @return HPバーの色
- */
-static TERM_COLOR get_monster_hp_point_bar_color(const MonsterEntity &monster)
-{
-    auto pct = monster.maxhp > 0 ? 100 * monster.hp / monster.maxhp : 0;
-
-    if (monster.is_invulnerable()) {
-        return TERM_WHITE;
-    }
-    if (monster.is_asleep()) {
-        return TERM_BLUE;
-    }
-    if (pct >= 100) {
-        return TERM_L_GREEN;
-    }
-    if (pct >= 60) {
-        return TERM_YELLOW;
-    }
-    if (pct >= 25) {
-        return TERM_ORANGE;
-    }
-    if (pct >= 10) {
-        return TERM_L_RED;
-    }
-    return TERM_RED;
-}
-
-/*!
  * @brief モンスターの体力ゲージを表示する
  * @param riding TRUEならば騎乗中のモンスターの体力、FALSEならターゲットモンスターの体力を表示する。表示位置は固定。
  * @details
@@ -421,11 +391,7 @@ void print_health(PlayerType *player_ptr, bool riding)
         return;
     }
 
-    // HPの割合計算
-    int pct2 = monster.maxhp > 0 ? 100L * monster.hp / monster.max_maxhp : 0;
-    int len = (pct2 < 10) ? 1 : (pct2 < 90) ? (pct2 / 10 + 1)
-                                            : 10;
-    auto hit_point_bar_color = get_monster_hp_point_bar_color(monster);
+    const auto [hit_point_bar_color, len] = monster.get_hp_bar_data();
 
     term_putstr(col, row, max_width, TERM_WHITE, "[----------]");
     term_putstr(col + 1, row, len, hit_point_bar_color, "**********");


### PR DESCRIPTION
Resolves #3400 

一覧のソートの順序は以下の通り。

1. 乗馬
2. 名前をつけたペット
3. ユニーク
4. （判明しているなら）モンスターレベル降順
5. モンスターID（モンスター配列上のインデックス）昇順

サンプル：

<img width="685" alt="image" src="https://github.com/hengband/hengband/assets/1501750/36285d1d-d8a0-4aa3-9411-0b87ae81308a">
