### PR TITLE
[Fix] 呪術と歌の詠唱時の配列範囲外アクセス

### DIFF
--- a/src/player/player-skill.cpp
+++ b/src/player/player-skill.cpp
@@ -4,6 +4,7 @@
 #include "player-base/player-race.h"
 #include "player-info/class-info.h"
 #include "player/player-realm.h"
+#include "realm/realm-names-table.h"
 #include "sv-definition/sv-weapon-types.h"
 #include "system/floor-type-definition.h"
 #include "system/item-entity.h"
@@ -352,12 +353,12 @@ void PlayerSkill::gain_riding_skill_exp_on_fall_off_check(int dam)
 
 void PlayerSkill::gain_spell_skill_exp(int realm, int spell_idx)
 {
-    if ((realm < 1) || ((static_cast<int>(std::size(mp_ptr->info)) < realm) && (realm != REALM_MUSIC) && (realm != REALM_HEX))) {
-        return;
-    }
+    auto is_valid_realm = is_magic(realm) ||
+                          (realm == REALM_MUSIC) || (realm == REALM_HEX);
+    is_valid_realm &= (realm == this->player_ptr->realm1) || (realm == this->player_ptr->realm2);
+    const auto is_valid_spell_idx = (0 <= spell_idx) && (spell_idx < 32);
 
-    if (((spell_idx < 0) || (32 <= spell_idx)) ||
-        ((realm != this->player_ptr->realm1) && (realm != this->player_ptr->realm2))) {
+    if (!is_valid_realm || !is_valid_spell_idx) {
         return;
     }
 
@@ -365,7 +366,7 @@ void PlayerSkill::gain_spell_skill_exp(int realm, int spell_idx)
     constexpr GainAmountList gain_amount_list_second{ { 60, 8, 2, 0 } };
 
     const auto is_first_realm = (realm == this->player_ptr->realm1);
-    const auto *s_ptr = &mp_ptr->info[realm - 1][spell_idx];
+    const auto *s_ptr = is_magic(realm) ? &mp_ptr->info[realm - 1][spell_idx] : &technic_info[realm - MIN_TECHNIC][spell_idx];
 
     gain_spell_skill_exp_aux(this->player_ptr, this->player_ptr->spell_exp[spell_idx + (is_first_realm ? 0 : 32)],
         (is_first_realm ? gain_amount_list_first : gain_amount_list_second), s_ptr->slevel);

--- a/src/realm/realm-names-table.h
+++ b/src/realm/realm-names-table.h
@@ -12,7 +12,7 @@
 #include "util/enum-converter.h"
 
 #define VALID_REALM (MAX_REALM + MAX_MAGIC - MIN_TECHNIC + 1)
-#define is_magic(A) (((A) > REALM_NONE) && ((A) < MAX_MAGIC + 1))
+#define is_magic(A) (((A) > REALM_NONE) && ((A) <= MAX_MAGIC))
 
 enum class ItemKindType : short;
 #define tval2realm(A) ((A)-ItemKindType::LIFE_BOOK + 1)


### PR DESCRIPTION
Resolves #3407 

呪術と歌を詠唱した時、誤ってmp_ptr->infoの要素にアクセスしているため配列範囲外アクセスが発生する。
呪術と歌の時は正しいtechnic_infoの要素にアクセスするよう修正する。

バージョン2.2.1の段階では正しく同様の場合分けがなされていましたが、リファクタリングのどこかの段階で場合分けが消えてしまったようです。（スキル経験値周りは私がリファクタリングしたので、その前の段階で消えてなければ私が犯人かもしれない）