### PR TITLE
Update the Version in hengband.spec

### DIFF
--- a/hengband.spec
+++ b/hengband.spec
@@ -1,4 +1,4 @@
-%define version 3.0.0Alpha85
+%define version 3.0.0.85
 %define release 1
 %global debug_package %{nil}
 
@@ -97,8 +97,8 @@ exit 0
 
 %changelog
 
-* Tue Jun 13 2023 Shiro Hara <white@vx-xv.com>
-- hengband RPM 3.0.0Alpha release 85
+* Wed Jun 14 2023 Shiro Hara <white@vx-xv.com>
+- hengband RPM 3.0.0.85(Alpha)
 
 * Mon May 29 2023 Shiro Hara <white@vx-xv.com>
 - hengband RPM 3.0.0Alpha release 84

--- a/hengband.spec
+++ b/hengband.spec
@@ -1,4 +1,4 @@
-%define version 3.0.0Alpha84
+%define version 3.0.0Alpha85
 %define release 1
 %global debug_package %{nil}
 
@@ -96,6 +96,9 @@ exit 0
 %license lib/help/jlicense.txt
 
 %changelog
+
+* Tue Jun 13 2023 Shiro Hara <white@vx-xv.com>
+- hengband RPM 3.0.0Alpha release 85
 
 * Mon May 29 2023 Shiro Hara <white@vx-xv.com>
 - hengband RPM 3.0.0Alpha release 84


### PR DESCRIPTION
- hengband.specのバージョンを3.0.0Alpha85に更新
- coprにて同バージョンのrpmを配信開始 https://copr.fedorainfracloud.org/coprs/whitehara/hengband/build/6070484/