### PR TITLE
[Refactor] 自動拾いのエディタのヤンクバッファ処理

### DIFF
--- a/src/autopick/autopick-editor-util.cpp
+++ b/src/autopick/autopick-editor-util.cpp
@@ -218,54 +218,16 @@ bool add_empty_line(text_body_type *tb)
     return true;
 }
 
-static chain_str_type *new_chain_str(concptr str)
-{
-    size_t len = strlen(str);
-    auto *chain = static_cast<chain_str_type *>(std::malloc(sizeof(chain_str_type) + len * sizeof(char)));
-    if (chain == nullptr) {
-        return nullptr;
-    }
-
-    strcpy(chain->s, str);
-    chain->next = nullptr;
-    return chain;
-}
-
 void kill_yank_chain(text_body_type *tb)
 {
-    chain_str_type *chain = tb->yank;
-    tb->yank = nullptr;
+    tb->yank.clear();
     tb->yank_eol = true;
-
-    while (chain) {
-        chain_str_type *next = chain->next;
-
-        std::free(chain);
-
-        chain = next;
-    }
 }
 
 void add_str_to_yank(text_body_type *tb, concptr str)
 {
     tb->yank_eol = false;
-    if (tb->yank == nullptr) {
-        tb->yank = new_chain_str(str);
-        return;
-    }
-
-    chain_str_type *chain;
-    chain = tb->yank;
-
-    while (true) {
-        if (!chain->next) {
-            chain->next = new_chain_str(str);
-            return;
-        }
-
-        /* Go to next */
-        chain = chain->next;
-    }
+    tb->yank.emplace_back(str);
 }
 
 /*!

--- a/src/autopick/autopick-util.h
+++ b/src/autopick/autopick-util.h
@@ -37,14 +37,6 @@ struct autopick_type {
 };
 
 /*
- * Struct for yank buffer
- */
-struct chain_str_type {
-    struct chain_str_type *next = nullptr;
-    char s[1]{};
-};
-
-/*
  * Data struct for text editor
  */
 class ItemEntity;
@@ -68,7 +60,7 @@ struct text_body_type {
     concptr search_str = "";
     concptr last_destroyed = "";
 
-    chain_str_type *yank = nullptr;
+    std::vector<std::string> yank{};
     bool yank_eol = false;
 
     std::vector<concptr> lines_list{};

--- a/src/cmd-io/cmd-autopick.cpp
+++ b/src/cmd-io/cmd-autopick.cpp
@@ -118,7 +118,7 @@ void do_cmd_edit_autopick(PlayerType *player_ptr)
     tb->old_wid = tb->old_hgt = -1;
     tb->old_com_id = 0;
 
-    tb->yank = nullptr;
+    tb->yank.clear();
     tb->search_o_ptr = nullptr;
     tb->search_str = nullptr;
     tb->last_destroyed = nullptr;


### PR DESCRIPTION
独自実装のリンクリストをstd::vector<std::string>に置き換えることで、mallocを使用しないようにする。

#3419 の一環。
これでX11のAPIの仕様のためmallocを使わざるを得ない箇所以外からmallocが撲滅されました。