### PR TITLE
[Fix] 体格オートローラで指定した値で止まらない

### DIFF
--- a/src/birth/auto-roller.cpp
+++ b/src/birth/auto-roller.cpp
@@ -3,6 +3,7 @@
 #include "birth/birth-util.h"
 #include "cmd-io/cmd-gameoption.h"
 #include "io/input-key-acceptor.h"
+#include "locale/japanese.h"
 #include "main/sound-of-music.h"
 #include "player-info/class-info.h"
 #include "player-info/race-info.h"
@@ -444,10 +445,10 @@ bool get_chara_limits(PlayerType *player_ptr, chara_limit_type *chara_limit_ptr)
     }
 #ifdef JP
     /*身長と体重の単位をcmとkgに*/
-    mval[2] = mval[2] * 254 / 100;
-    mval[3] = mval[3] * 254 / 100;
-    mval[4] = mval[4] * 4536 / 10000;
-    mval[5] = mval[5] * 4536 / 10000;
+    mval[2] = inch_to_cm(mval[2]);
+    mval[3] = inch_to_cm(mval[3]);
+    mval[4] = lb_to_kg(mval[4]);
+    mval[5] = lb_to_kg(mval[5]);
 #endif
     for (auto i = 0; i < MAXITEMS; i++) {
         cval[i] = mval[i];

--- a/src/birth/birth-wizard.cpp
+++ b/src/birth/birth-wizard.cpp
@@ -18,6 +18,7 @@
 #include "core/asking-player.h"
 #include "game-option/birth-options.h"
 #include "io/input-key-acceptor.h"
+#include "locale/japanese.h"
 #include "main/sound-definitions-table.h"
 #include "main/sound-of-music.h"
 #include "player-base/player-class.h"
@@ -381,10 +382,12 @@ static bool decide_body_spec(PlayerType *player_ptr, chara_limit_type chara_limi
         if ((player_ptr->age < chara_limit.agemin) || (player_ptr->age > chara_limit.agemax)) {
             *accept = false;
         }
-        if ((player_ptr->ht < chara_limit.htmin) || (player_ptr->ht > chara_limit.htmax)) {
+        const auto ht = _(inch_to_cm(player_ptr->ht), player_ptr->ht);
+        if ((ht < chara_limit.htmin) || (ht > chara_limit.htmax)) {
             *accept = false;
         }
-        if ((player_ptr->wt < chara_limit.wtmin) || (player_ptr->wt > chara_limit.wtmax)) {
+        const auto wt = _(lb_to_kg(player_ptr->wt), player_ptr->wt);
+        if ((wt < chara_limit.wtmin) || (wt > chara_limit.wtmax)) {
             *accept = false;
         }
         if ((player_ptr->sc < chara_limit.scmin) || (player_ptr->sc > chara_limit.scmax)) {

--- a/src/locale/japanese.h
+++ b/src/locale/japanese.h
@@ -29,6 +29,25 @@ int utf8_to_euc(char *utf8_str, size_t utf8_str_len, char *euc_buf, size_t euc_b
 int euc_to_utf8(const char *euc_str, size_t euc_str_len, char *utf8_buf, size_t utf8_buf_len);
 #endif
 
+/*!
+ * @brief インチ→cm変換
+ */
+constexpr int inch_to_cm(int inch)
+{
+    return inch * 254 / 100;
+}
+
+/*!
+ * @brief ポンド→kg変換
+ *
+ * 体重表記用
+ * アイテムの重量は0.5kg単位にするためlb_to_kg_integer/fractionを使用する
+ */
+constexpr int lb_to_kg(int lb)
+{
+    return lb * 4536 / 10000;
+}
+
 #else
 
 constexpr bool is_kinsoku(std::string_view)

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -13,6 +13,7 @@
 #include "info-reader/fixed-map-parser.h"
 #include "inventory/inventory-slot-types.h"
 #include "knowledge/knowledge-mutations.h"
+#include "locale/japanese.h"
 #include "mind/mind-elementalist.h"
 #include "mutation/mutation-flag-types.h"
 #include "object/object-info.h"
@@ -125,8 +126,8 @@ static void display_phisique(PlayerType *player_ptr)
 {
 #ifdef JP
     display_player_one_line(ENTRY_AGE, format("%d才", (int)player_ptr->age), TERM_L_BLUE);
-    display_player_one_line(ENTRY_HEIGHT, format("%dcm", (int)((player_ptr->ht * 254) / 100)), TERM_L_BLUE);
-    display_player_one_line(ENTRY_WEIGHT, format("%dkg", (int)((player_ptr->wt * 4536) / 10000)), TERM_L_BLUE);
+    display_player_one_line(ENTRY_HEIGHT, format("%dcm", inch_to_cm(player_ptr->ht)), TERM_L_BLUE);
+    display_player_one_line(ENTRY_WEIGHT, format("%dkg", lb_to_kg(player_ptr->wt)), TERM_L_BLUE);
     display_player_one_line(ENTRY_SOCIAL, format("%d  ", (int)player_ptr->sc), TERM_L_BLUE);
 #else
     display_player_one_line(ENTRY_AGE, format("%d", (int)player_ptr->age), TERM_L_BLUE);


### PR DESCRIPTION
Resolves #3429 

日本語版では体格オートローラの身長・体重表示をcm/kgにする修正を加えたが、身長・体重の決定時に制限値と比較する際cm/kgに変換する処理が入っていないため正しく制限値との比較できていない。
制限値との比較時にもcm/kgへの変換を行うようにする。

これと関連して、整数値での inch → cm の変換を行う都合上存在しない身長というのがあるため、その範囲をオートローラで指定するとやはり止まらないという問題があります。
例えば 64インチ → 162cm、65インチ → 165cm となるため、オートローラで身長に163-164cmを指定すると、生成可能な範囲であるにもかかわらず止まらないという現象が発生します。
これを抜本的に解決するには、身長の内部値をインチからcmに変更するくらいしかなさそうで、セーブファイルのバージョンアップも必要となりやや面倒そうです。