### PR TITLE
[Fix] メイン画面左に表示されるモンスターの状態表示の一部が残る

### DIFF
--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -410,7 +410,7 @@ void print_health(PlayerType *player_ptr, bool riding)
         if (row_offset > extra_line_count) {
             break;
         }
-        if (col_offset + info.label.length() - 1 > max_width) { // 改行が必要かどうかチェック。length() - 1してるのは\0の分を文字数から取り除くため
+        if (col_offset + info.label.length() > max_width) { // 改行が必要かどうかチェック
             col_offset = 0;
             row_offset++;
         }


### PR DESCRIPTION
Resolves #3433 

表示幅の計算を誤っておりASCII12桁まで表示するべきところを13桁まで表示し
ているのが原因。消す処理は12桁分しか行われていないため、結果として13桁目
の文字が残る。
ヌル文字（'\0'）は文字列長には含まれていないのでコメントにあるように-1し
ているのが誤りである。正しい計算に修正する。