### PR TITLE
[Feature] HTTP通信機能クラス

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -269,6 +269,11 @@
     <ClCompile Include="..\..\src\cmd-action\cmd-tunnel.cpp" />
     <ClCompile Include="..\..\src\action\movement-execution.cpp" />
     <ClCompile Include="..\..\src\core\score-util.cpp" />
+    <ClCompile Include="..\..\src\io\curl-data-receiver.cpp" />
+    <ClCompile Include="..\..\src\io\curl-data-sender.cpp" />
+    <ClCompile Include="..\..\src\io\curl-easy-session.cpp" />
+    <ClCompile Include="..\..\src\io\curl-slist.cpp" />
+    <ClCompile Include="..\..\src\io\http-client.cpp" />
     <ClCompile Include="..\..\src\item-info\flavor-initializer.cpp" />
     <ClCompile Include="..\..\src\load\item\item-loader-base.cpp" />
     <ClCompile Include="..\..\src\load\item\item-loader-factory.cpp" />
@@ -961,6 +966,11 @@
     <ClInclude Include="..\..\src\action\open-close-execution.h" />
     <ClInclude Include="..\..\src\action\open-util.h" />
     <ClInclude Include="..\..\src\action\run-execution.h" />
+    <ClInclude Include="..\..\src\io\curl-data-receiver.h" />
+    <ClInclude Include="..\..\src\io\curl-data-sender.h" />
+    <ClInclude Include="..\..\src\io\curl-easy-session.h" />
+    <ClInclude Include="..\..\src\io\curl-slist.h" />
+    <ClInclude Include="..\..\src\io\http-client.h" />
     <ClInclude Include="..\..\src\item-info\flavor-initializer.h" />
     <ClInclude Include="..\..\src\load\item\item-loader-version-types.h" />
     <ClInclude Include="..\..\src\load\item\item-loader-base.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2475,6 +2475,21 @@
     <ClCompile Include="..\..\src\system\redrawing-flags-updater.cpp">
       <Filter>system</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\io\curl-data-receiver.cpp">
+      <Filter>io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io\curl-data-sender.cpp">
+      <Filter>io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io\curl-easy-session.cpp">
+      <Filter>io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io\curl-slist.cpp">
+      <Filter>io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\io\http-client.cpp">
+      <Filter>io</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5357,6 +5372,21 @@
     </ClInclude>
     <ClInclude Include="..\..\src\system\redrawing-flags-updater.h">
       <Filter>system</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\curl-data-receiver.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\curl-data-sender.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\curl-easy-session.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\curl-slist.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\http-client.h">
+      <Filter>io</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -290,10 +290,15 @@ hengband_SOURCES = \
 	inventory/recharge-processor.cpp inventory/recharge-processor.h \
 	\
 	io/command-repeater.cpp io/command-repeater.h \
+	io/curl-data-receiver.cpp io/curl-data-receiver.h \
+	io/curl-data-sender.cpp io/curl-data-sender.h \
+	io/curl-easy-session.cpp io/curl-easy-session.h \
+	io/curl-slist.cpp io/curl-slist.h \
 	io/cursor.cpp io/cursor.h \
 	io/exit-panic.cpp io/exit-panic.h \
 	io/files-util.cpp io/files-util.h \
 	io/gf-descriptions.cpp io/gf-descriptions.h \
+	io/http-client.cpp io/http-client.h \
 	io/input-key-acceptor.cpp io/input-key-acceptor.h \
 	io/input-key-processor.cpp io/input-key-processor.h \
 	io/input-key-requester.cpp io/input-key-requester.h \

--- a/src/io/curl-data-receiver.cpp
+++ b/src/io/curl-data-receiver.cpp
@@ -1,0 +1,34 @@
+﻿#include "io/curl-data-receiver.h"
+
+using namespace curl_util;
+
+void StringReceiver::prepare_to_receive()
+{
+    this->received_str.clear();
+}
+
+size_t StringReceiver::receive(char *buf, size_t n)
+{
+    this->received_str.append(buf, n);
+    return n;
+}
+
+/*!
+ * @brief 受信した文字列への参照を取得する
+ *
+ * @return 受信した文字列への参照
+ */
+const std::string &StringReceiver::get_received_str() const
+{
+    return this->received_str;
+}
+
+/*!
+ * @brief 受信した文字列をムーブセマンティクスにより取得する
+ *
+ * @return 受信した文字列
+ */
+std::string StringReceiver::release_received_str()
+{
+    return std::move(this->received_str);
+}

--- a/src/io/curl-data-receiver.h
+++ b/src/io/curl-data-receiver.h
@@ -1,0 +1,40 @@
+﻿#pragma once
+
+#include <concepts>
+#include <cstddef>
+#include <memory>
+#include <string>
+
+namespace curl_util {
+
+/*!
+ * @brief データ受信抽象クラス
+ */
+class AbstractDataReceiver {
+public:
+    virtual ~AbstractDataReceiver() = default;
+    virtual void prepare_to_receive() = 0;
+    virtual size_t receive(char *buf, size_t n) = 0;
+};
+
+/*!
+ * @brief 文字列データ受信クラス
+ */
+class StringReceiver : public AbstractDataReceiver {
+public:
+    void prepare_to_receive() override;
+    size_t receive(char *buf, size_t n) override;
+    const std::string &get_received_str() const;
+    std::string release_received_str();
+
+private:
+    std::string received_str;
+};
+
+template <std::derived_from<AbstractDataReceiver> T>
+auto create_receiver()
+{
+    return std::make_shared<T>();
+}
+
+}

--- a/src/io/curl-data-sender.cpp
+++ b/src/io/curl-data-sender.cpp
@@ -1,0 +1,3 @@
+﻿#include "io/curl-data-sender.h"
+
+using namespace curl_util;

--- a/src/io/curl-data-sender.h
+++ b/src/io/curl-data-sender.h
@@ -1,0 +1,84 @@
+﻿#pragma once
+
+#include <algorithm>
+#include <concepts>
+#include <cstddef>
+#include <memory>
+#include <span>
+#include <vector>
+
+namespace curl_util {
+
+/*!
+ * @brief Tがstd::span<U>に変換可能であることを示すコンセプト
+ */
+// TODO CIのclang-formatとのバージョンの違いのためか整形が異なるので一時的にOFFにしておく
+// clang-format off
+template <typename T, typename U>
+concept ConvertibleToSpanOf =
+    requires(T t) {
+        {
+            std::span{ t }
+        } -> std::convertible_to<std::span<U>>;
+    };
+// clang-format on
+
+/*!
+ * @brief データ送信抽象クラス
+ */
+class AbstractDataSender {
+public:
+    virtual ~AbstractDataSender() = default;
+    virtual void prepare_to_send() = 0;
+    virtual size_t send(char *buf, size_t n) = 0;
+    virtual size_t remain_size() = 0;
+};
+
+/*!
+ * @brief バイト列データ送信クラス
+ */
+template <ConvertibleToSpanOf<char> T>
+class ByteSequenceSender : public AbstractDataSender {
+public:
+    ByteSequenceSender(const T &send_data)
+        : send_data(send_data)
+    {
+    }
+    ByteSequenceSender(T &&send_data)
+        : send_data(std::move(send_data))
+    {
+    }
+
+    void prepare_to_send() override
+    {
+        this->remain_to_send = this->send_data;
+    }
+
+    size_t send(char *buf, size_t n) override
+    {
+        const auto send_size = std::min<size_t>(n, this->remain_to_send.size());
+
+        std::copy_n(this->remain_to_send.begin(), send_size, buf);
+        this->remain_to_send = this->remain_to_send.subspan(send_size);
+
+        return send_size;
+    }
+
+    size_t remain_size() override
+    {
+        return this->remain_to_send.size();
+    }
+
+private:
+    T send_data;
+    std::span<char> remain_to_send;
+};
+
+template <typename T>
+    requires std::same_as<std::remove_cvref_t<T>, std::vector<char>> || std::same_as<std::remove_cvref_t<T>, std::string>
+auto create_sender(T &&send_data)
+{
+    return std::make_shared<ByteSequenceSender<std::remove_cvref_t<T>>>(std::forward<T>(send_data));
+}
+
+}

--- a/src/io/curl-easy-session.cpp
+++ b/src/io/curl-easy-session.cpp
@@ -1,0 +1,71 @@
+﻿#include "io/curl-easy-session.h"
+#include "io/curl-data-receiver.h"
+#include "io/curl-data-sender.h"
+
+using namespace curl_util;
+
+namespace {
+
+size_t read_callback(char *buf, size_t size, size_t nitems, AbstractDataSender *userdata)
+{
+    return userdata->send(buf, size * nitems);
+}
+
+size_t write_callback(char *buf, size_t size, size_t nitems, AbstractDataReceiver *userdata)
+{
+    return userdata->receive(buf, size * nitems);
+}
+
+}
+
+CurlEasySession::CurlEasySession()
+    : handle_(curl_easy_init(), curl_easy_cleanup)
+{
+}
+
+bool CurlEasySession::is_valid() const
+{
+    return handle_ != nullptr;
+}
+
+void CurlEasySession::common_setup(const std::string &url, int timeout_sec)
+{
+    this->setopt(CURLOPT_URL, url.data());
+
+    this->setopt(CURLOPT_NOSIGNAL, 1);
+
+    if (timeout_sec > 0) {
+        this->setopt(CURLOPT_CONNECTTIMEOUT, timeout_sec);
+        this->setopt(CURLOPT_TIMEOUT, timeout_sec);
+    }
+}
+
+void CurlEasySession::sender_setup(std::shared_ptr<AbstractDataSender> sender)
+{
+    this->sender_ = std::move(sender);
+    if (!this->sender_) {
+        return;
+    }
+
+    this->sender_->prepare_to_send();
+    this->setopt(CURLOPT_READDATA, this->sender_.get());
+    this->setopt(CURLOPT_READFUNCTION, read_callback);
+    this->setopt(CURLOPT_POSTFIELDSIZE, this->sender_->remain_size());
+}
+
+void CurlEasySession::receiver_setup(std::shared_ptr<AbstractDataReceiver> receiver)
+{
+    this->receiver_ = std::move(receiver);
+    if (!this->receiver_) {
+        return;
+    }
+
+    this->receiver_->prepare_to_receive();
+    this->setopt(CURLOPT_WRITEDATA, this->receiver_.get());
+    this->setopt(CURLOPT_WRITEFUNCTION, write_callback);
+}
+
+bool CurlEasySession::perform()
+{
+    return curl_easy_perform(handle_.get()) == CURLE_OK;
+}

--- a/src/io/curl-easy-session.h
+++ b/src/io/curl-easy-session.h
@@ -1,0 +1,54 @@
+﻿#pragma once
+
+#include "system/angband.h"
+#include <memory>
+#include <string>
+#ifdef WINDOWS
+#define CURL_STATICLIB
+#endif
+#include <curl/curl.h>
+
+namespace curl_util {
+
+class AbstractDataSender;
+class AbstractDataReceiver;
+
+/*!
+ * @brief libcurl easy session の薄いラッパークラス
+ */
+class CurlEasySession {
+public:
+    using CurlHandle = std::unique_ptr<CURL, void (*)(CURL *)>;
+
+    CurlEasySession();
+    ~CurlEasySession() = default;
+    CurlEasySession(const CurlEasySession &) = delete;
+    CurlEasySession &operator=(const CurlEasySession &) = delete;
+    CurlEasySession(CurlEasySession &&) = default;
+    CurlEasySession &operator=(CurlEasySession &&) = default;
+
+    bool is_valid() const;
+    void common_setup(const std::string &url, int timeout_sec = 0);
+    void sender_setup(std::shared_ptr<AbstractDataSender> sender);
+    void receiver_setup(std::shared_ptr<AbstractDataReceiver> receiver);
+    bool perform();
+
+    template <typename T>
+    void setopt(CURLoption opt, T param)
+    {
+        curl_easy_setopt(this->handle_.get(), opt, param);
+    }
+
+    template <typename T>
+    bool getinfo(CURLINFO info, T arg) const
+    {
+        return curl_easy_getinfo(this->handle_.get(), info, arg) == CURLE_OK;
+    }
+
+private:
+    CurlHandle handle_;
+    std::shared_ptr<AbstractDataSender> sender_;
+    std::shared_ptr<AbstractDataReceiver> receiver_;
+};
+
+}

--- a/src/io/curl-slist.cpp
+++ b/src/io/curl-slist.cpp
@@ -1,0 +1,39 @@
+﻿#include "io/curl-slist.h"
+
+using namespace curl_util;
+
+CurlSList::CurlSList()
+    : slist(nullptr, curl_slist_free_all)
+{
+}
+
+bool CurlSList::is_valid() const
+{
+    return this->valid;
+}
+
+void CurlSList::append(const char *str)
+{
+    if (!this->valid) {
+        return;
+    }
+
+    auto result = curl_slist_append(this->slist.get(), str);
+    if (result == nullptr) {
+        this->valid = false;
+        return;
+    }
+
+    this->slist.release();
+    this->slist.reset(result);
+}
+
+void CurlSList::append(const std::string &str)
+{
+    this->append(str.data());
+}
+
+curl_slist *CurlSList::get()
+{
+    return this->slist.get();
+}

--- a/src/io/curl-slist.h
+++ b/src/io/curl-slist.h
@@ -1,0 +1,37 @@
+﻿#pragma once
+
+#include "system/angband.h"
+#include <memory>
+#include <string>
+#ifdef WINDOWS
+#define CURL_STATICLIB
+#endif
+#include <curl/curl.h>
+
+namespace curl_util {
+
+/*!
+ * @brief libcurl string list の薄いラッパークラス
+ */
+class CurlSList {
+public:
+    using SList = std::unique_ptr<curl_slist, void (*)(curl_slist *)>;
+
+    CurlSList();
+    ~CurlSList() = default;
+    CurlSList(const CurlSList &) = delete;
+    CurlSList &operator=(const CurlSList &) = delete;
+    CurlSList(CurlSList &&) = default;
+    CurlSList &operator=(CurlSList &&) = default;
+
+    bool is_valid() const;
+    void append(const char *str);
+    void append(const std::string &str);
+    curl_slist *get();
+
+private:
+    SList slist;
+    bool valid = true;
+};
+
+}

--- a/src/io/http-client.cpp
+++ b/src/io/http-client.cpp
@@ -1,0 +1,88 @@
+﻿#include "io/http-client.h"
+#include "io/curl-data-receiver.h"
+#include "io/curl-data-sender.h"
+#include "io/curl-easy-session.h"
+#include "io/curl-slist.h"
+#include "system/angband.h"
+#include <algorithm>
+#include <span>
+
+namespace {
+
+constexpr auto HTTP_TIMEOUT = 30; //!< HTTP接続タイムアウト時間(秒)
+
+void setup_http_option(curl_util::CurlEasySession &session, const std::optional<std::string> &user_agent)
+{
+    if (user_agent.has_value()) {
+        session.setopt(CURLOPT_USERAGENT, user_agent->data());
+    }
+
+    session.setopt(CURLOPT_FOLLOWLOCATION, 1);
+    session.setopt(CURLOPT_MAXREDIRS, 10);
+    session.setopt(CURLOPT_POSTREDIR, CURL_REDIR_POST_ALL);
+}
+
+}
+
+/*!
+ * @brief HTTP GETリクエストを送信する
+ * @param url リクエストの送信先URL
+ * @param receiver 応答データ受信クラスのオブジェクト
+ * @return 送信に成功した場合HTTPステータスコード、失敗した場合std::nullopt
+ */
+std::optional<int> HttpClient::perform_get_request(const std::string &url, std::shared_ptr<curl_util::AbstractDataReceiver> receiver)
+{
+    curl_util::CurlEasySession session;
+    if (!session.is_valid()) {
+        return std::nullopt;
+    }
+
+    session.common_setup(url, HTTP_TIMEOUT);
+    setup_http_option(session, url);
+
+    session.receiver_setup(std::move(receiver));
+
+    if (!session.perform()) {
+        return std::nullopt;
+    }
+
+    long response_code;
+    session.getinfo(CURLINFO_RESPONSE_CODE, &response_code);
+    return response_code;
+}
+
+/*!
+ * @brief HTTP POSTリクエストを送信する
+ * @param url リクエストの送信先URL
+ * @param sender POSTデータ送信クラスのオブジェクト
+ * @param media_type POSTデータのメディアタイプ(Content-Typeヘッダの内容)
+ * @param receiver 応答データ受信クラスのオブジェクト
+ * @return 送信に成功した場合HTTPステータスコード、失敗した場合std::nullopt
+ */
+std::optional<int> HttpClient::perform_post_request(const std::string &url, std::shared_ptr<curl_util::AbstractDataSender> sender, const std::string &media_type, std::shared_ptr<curl_util::AbstractDataReceiver> receiver)
+{
+    curl_util::CurlEasySession session;
+    curl_util::CurlSList headers;
+    headers.append(format("Content-Type: %s", media_type.data()));
+
+    if (!session.is_valid() || !headers.is_valid()) {
+        return std::nullopt;
+    }
+
+    session.common_setup(url, HTTP_TIMEOUT);
+    setup_http_option(session, url);
+
+    session.setopt(CURLOPT_HTTPHEADER, headers.get());
+    session.setopt(CURLOPT_POST, 1);
+
+    session.sender_setup(sender);
+    session.receiver_setup(receiver);
+
+    if (!session.perform()) {
+        return std::nullopt;
+    }
+
+    long response_code;
+    session.getinfo(CURLINFO_RESPONSE_CODE, &response_code);
+    return response_code;
+}

--- a/src/io/http-client.h
+++ b/src/io/http-client.h
@@ -1,0 +1,19 @@
+﻿#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace curl_util {
+class AbstractDataReceiver;
+class AbstractDataSender;
+}
+
+class HttpContentBase;
+class HttpClient {
+public:
+    std::optional<int> perform_get_request(const std::string &url, std::shared_ptr<curl_util::AbstractDataReceiver> receiver = nullptr);
+    std::optional<int> perform_post_request(const std::string &url, std::shared_ptr<curl_util::AbstractDataSender> sender, const std::string &media_type, std::shared_ptr<curl_util::AbstractDataReceiver> receiver = nullptr);
+
+    std::optional<std::string> user_agent;
+};


### PR DESCRIPTION
HTTP通信クラスがある程度できたので見てもらうため一旦PRとして提出します。

[テスト用スコアサーバ](https://mars.kmc.gr.jp/~dis/heng_score_test/score_ranking.php?&sort=newcome)に送信できることを確認済み。
※現状はスコア送信先はテスト用スコアサーバになっています。

また、以下のような処理で、WebからHTTP通信でデータを取得可能です。

```c++
    HttpClient hc;
    auto receiver = curl_util::create_receiver<curl_util::StringReceiver>();
    if (hc.perform_get_request("https://www.yahoo.co.jp", receiver) == 200) {
        std::cout << receiver->get_received_str() << std::endl;
    }
```

エラーレポートの送信先取得以外にも、スコア送信先URLをアプリ埋め込みではなく変愚蛮怒公式サイトのどこかに設置したjsonファイルから取得するなどといった用途にも使えるかもしれません。

peform_{get|post}_request に渡すSender/Receiverは抽象クラスなので、適切にインターフェースを実装したクラスを作成すれば、ファイルへのダウンロードやファイルからの送信なども可能になるはずです。頑張ればアプリのバージョン自動更新機能なども実装できてしまうかも？

とりあえず新たに追加したファイルは全部 io/ の下に置きましたが、 curl-* は他にディレクトリを作るなどしたほうがよいでしょうか。