### PR TITLE
[Refactor] message_strの戻り値を変更

### DIFF
--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -161,7 +161,7 @@ void do_cmd_player_status(PlayerType *player_ptr)
  */
 void do_cmd_message_one(void)
 {
-    prt(format("> %s", message_str(0).data()), 0, 0);
+    prt(format("> %s", message_str(0)->data()), 0, 0);
 }
 
 /*!
@@ -201,7 +201,7 @@ void do_cmd_messages(int num_now)
         int skey;
         for (j = 0; (j < num_lines) && (i + j < n); j++) {
             const auto msg_str = message_str(i + j);
-            const auto *msg = msg_str.data();
+            const auto *msg = msg_str->data();
             c_prt((i + j < num_now ? TERM_WHITE : TERM_SLATE), msg, num_lines + 1 - j, 0);
             if (shower.empty()) {
                 continue;
@@ -264,7 +264,7 @@ void do_cmd_messages(int num_now)
             for (int z = i + 1; z < n; z++) {
                 // @details ダメ文字対策でstringを使わない.
                 const auto msg_str = message_str(z);
-                const auto *msg = msg_str.data();
+                const auto *msg = msg_str->data();
                 if (angband_strstr(msg, finder_str) != nullptr) {
                     i = z;
                     break;

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -145,7 +145,7 @@ static void dump_aux_last_message(PlayerType *player_ptr, FILE *fff)
     if (!w_ptr->total_winner) {
         fprintf(fff, _("\n  [死ぬ直前のメッセージ]\n\n", "\n  [Last Messages]\n\n"));
         for (int i = std::min(message_num(), 30); i >= 0; i--) {
-            fprintf(fff, "> %s\n", message_str((int16_t)i).data());
+            fprintf(fff, "> %s\n", message_str(i)->data());
         }
 
         fputc('\n', fff);

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -110,7 +110,7 @@ static bool wr_savefile_new(PlayerType *player_ptr, SaveType type)
 
     wr_u32b(tmp32u);
     for (int i = tmp32u - 1; i >= 0; i--) {
-        wr_string(message_str(i));
+        wr_string(*message_str(i));
     }
 
     uint16_t tmp16u = static_cast<uint16_t>(monraces_info.size());

--- a/src/view/display-messages.cpp
+++ b/src/view/display-messages.cpp
@@ -80,13 +80,13 @@ int32_t message_num(void)
  * @param age メッセージの世代
  * @return メッセージの文字列ポインタ
  */
-std::string message_str(int age)
+std::shared_ptr<const std::string> message_str(int age)
 {
     if ((age < 0) || (age >= message_num())) {
-        return "";
+        return std::make_shared<const std::string>("");
     }
 
-    return *message_history[age];
+    return message_history[age];
 }
 
 static void message_add_aux(std::string str)

--- a/src/view/display-messages.h
+++ b/src/view/display-messages.h
@@ -2,6 +2,7 @@
 
 #include "system/angband.h"
 #include <concepts>
+#include <memory>
 #include <string>
 #include <string_view>
 
@@ -15,7 +16,7 @@ extern bool msg_flag;
 extern COMMAND_CODE now_message;
 
 int32_t message_num(void);
-std::string message_str(int age);
+std::shared_ptr<const std::string> message_str(int age);
 void message_add(std::string_view msg);
 void msg_erase(void);
 void msg_print(std::string_view msg);

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -432,7 +432,7 @@ void fix_message(void)
             TERM_LEN w, h;
             term_get_size(&w, &h);
             for (short i = 0; i < h; i++) {
-                term_putstr(0, (h - 1) - i, -1, (byte)((i < now_message) ? TERM_WHITE : TERM_SLATE), message_str(i));
+                term_putstr(0, (h - 1) - i, -1, (byte)((i < now_message) ? TERM_WHITE : TERM_SLATE), *message_str(i));
                 TERM_LEN x, y;
                 term_locate(&x, &y);
                 term_erase(x, y, 255);


### PR DESCRIPTION
message_strの戻り値をstd::stringからstd::shared_ptr<const std::string>に 変更する。
もともとmessage_strで得られるメッセージ履歴はshared_ptrで管理している
ため、こうすうることにより文字列を毎回コピーせずにすむようになる。

https://github.com/hengband/hengband/pull/3435#pullrequestreview-1496330468 にてコメントした関連作業ですので、単独Issueはなしです。