### PR TITLE
[Feature] HTTP通信機能クラス

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -279,6 +279,9 @@
     <ClCompile Include="..\..\src\monster-race\race-brightness-mask.cpp" />
     <ClCompile Include="..\..\src\monster-race\race-feature-mask.cpp" />
     <ClCompile Include="..\..\src\monster\monster-pain-describer.cpp" />
+    <ClCompile Include="..\..\src\net\curl-easy-session.cpp" />
+    <ClCompile Include="..\..\src\net\curl-slist.cpp" />
+    <ClCompile Include="..\..\src\net\http-client.cpp" />
     <ClCompile Include="..\..\src\object-enchant\enchanter-factory.cpp" />
     <ClCompile Include="..\..\src\mspell\mspell-attack\abstract-mspell.cpp" />
     <ClCompile Include="..\..\src\mspell\mspell-data.cpp" />
@@ -992,6 +995,9 @@
     <ClInclude Include="..\..\src\mspell\mspell-attack\abstract-mspell.h" />
     <ClInclude Include="..\..\src\mspell\mspell-data.h" />
     <ClInclude Include="..\..\src\mspell\mspell-result.h" />
+    <ClInclude Include="..\..\src\net\curl-easy-session.h" />
+    <ClInclude Include="..\..\src\net\curl-slist.h" />
+    <ClInclude Include="..\..\src\net\http-client.h" />
     <ClInclude Include="..\..\src\object-enchant\enchanter-factory.h" />
     <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-soft-armor.h" />
     <ClInclude Include="..\..\src\object-enchant\others\apply-magic-lite.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2475,6 +2475,15 @@
     <ClCompile Include="..\..\src\system\redrawing-flags-updater.cpp">
       <Filter>system</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\net\curl-easy-session.cpp">
+      <Filter>net</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\net\curl-slist.cpp">
+      <Filter>net</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\net\http-client.cpp">
+      <Filter>net</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5358,6 +5367,15 @@
     <ClInclude Include="..\..\src\system\redrawing-flags-updater.h">
       <Filter>system</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\net\http-client.h">
+      <Filter>net</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\net\curl-easy-session.h">
+      <Filter>net</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\net\curl-slist.h">
+      <Filter>net</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\src\wall.bmp" />
@@ -5615,6 +5633,9 @@
     </Filter>
     <Filter Include="item-info">
       <UniqueIdentifier>{3aefd2e8-8dd8-41dd-bc6b-7dadd75dfd6b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="net">
+      <UniqueIdentifier>{6f311bdc-4407-49b7-96ab-bc2ed187b61c}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/configure.ac
+++ b/configure.ac
@@ -153,7 +153,7 @@ AC_PROG_GCC_TRADITIONAL
 AC_FUNC_MEMCMP
 AC_FUNC_STRFTIME
 AC_FUNC_VPRINTF
-AC_CHECK_FUNCS(gethostname mkdir select socket strtol vsnprintf mkstemp usleep)
+AC_CHECK_FUNCS(gethostname mkdir select socket strtol mkstemp usleep)
 
 AC_CONFIG_FILES(Makefile src/Makefile lib/Makefile lib/apex/Makefile \
 	lib/bone/Makefile lib/data/Makefile \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -570,6 +570,10 @@ hengband_SOURCES = \
 	mutation/mutation-processor.cpp mutation/mutation-processor.h \
 	mutation/mutation-techniques.cpp mutation/mutation-techniques.h \
 	\
+	net/curl-easy-session.cpp net/curl-easy-session.h \
+	net/curl-slist.cpp net/curl-slist.h \
+	net/http-client.cpp net/http-client.h \
+	\
 	object/item-tester-hooker.cpp object/item-tester-hooker.h \
 	object/object-broken.cpp object/object-broken.h \
 	object/object-flags.cpp object/object-flags.h \

--- a/src/io/report.cpp
+++ b/src/io/report.cpp
@@ -14,6 +14,7 @@
 #include "io-dump/character-dump.h"
 #include "io/input-key-acceptor.h"
 #include "mind/mind-elementalist.h"
+#include "net/http-client.h"
 #include "player-base/player-class.h"
 #include "player-info/class-info.h"
 #include "player-info/race-info.h"
@@ -41,100 +42,55 @@
 #include <vector>
 
 #ifdef WORLD_SCORE
-#ifdef WINDOWS
-#define CURL_STATICLIB
-#endif
-#include <curl/curl.h>
 
 concptr screen_dump = nullptr;
 
-/*
- * internet resource value
- */
-#define HTTP_TIMEOUT 30 /*!< デフォルトのタイムアウト時間(秒) / Timeout length (second) */
-
 #ifdef JP
-#define SCORE_PATH "http://mars.kmc.gr.jp/~dis/heng_score/register_score.php" /*!< スコア開示URL */
-#else
-#define SCORE_PATH "http://moon.kmc.gr.jp/hengband/hengscore-en/score.cgi" /*!< スコア開示URL */
+constexpr auto SCORE_POST_URL = "http://mars.kmc.gr.jp/~dis/heng_score/register_score.php"; /*!< スコア開示URL */
 #endif
 
-size_t read_callback(char *buffer, size_t size, size_t nitems, void *userdata)
+static constexpr auto get_score_content_type()
 {
-    auto &data = *static_cast<std::span<const char> *>(userdata);
-    const auto copy_size = std::min<size_t>(size * nitems, data.size());
-
-    std::copy_n(data.begin(), copy_size, buffer);
-    data = data.subspan(copy_size);
-
-    return copy_size;
+#ifdef JP
+#ifdef SJIS
+    return "text/plain; charset=SHIFT_JIS";
+#endif
+#ifdef EUC
+    return "text/plain; charset=EUC-JP";
+#endif
+#else
+    return "text/plain; charset=ASCII";
+#endif
 }
 
 /*!
- * @brief HTTPによるダンプ内容伝送
- * @param url 伝送先URL
- * @param buf 伝送内容バッファ
- * @return 送信に成功した場合TRUE、失敗した場合FALSE
+ * @brief スコアサーバにスコアを送信する
+ * @param score_data 送信するスコアデータ
+ * @return 送信に成功した場合true、失敗した場合false
  */
-static bool http_post(concptr url, const std::vector<char> &buf)
+static bool post_score_to_score_server(PlayerType *player_ptr, const std::string &score_data)
 {
-    bool succeeded = false;
-    CURL *curl = curl_easy_init();
-    if (curl == nullptr) {
-        return false;
-    }
+    http::Client client;
+    client.user_agent = format("Hengband %d.%d.%d", H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH);
 
-    struct curl_slist *slist = nullptr;
-    slist = curl_slist_append(slist,
-#ifdef JP
-#ifdef SJIS
-        "Content-Type: text/plain; charset=SHIFT_JIS"
-#endif
-#ifdef EUC
-        "Content-Type: text/plain; charset=EUC-JP"
-#endif
-#else
-        "Content-Type: text/plain; charset=ASCII"
-#endif
-    );
+    term_clear();
 
-    curl_easy_setopt(curl, CURLOPT_URL, url);
-    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, slist);
+    while (true) {
+        term_fresh();
+        prt(_("スコア送信中...", "Sending the score..."), 0, 0);
+        term_fresh();
 
-    char user_agent[64];
-    snprintf(user_agent, sizeof(user_agent), "Hengband %d.%d.%d", H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH);
-    curl_easy_setopt(curl, CURLOPT_USERAGENT, user_agent);
+        const auto res = client.post(SCORE_POST_URL, score_data, get_score_content_type());
+        if (res.has_value() && (res->status == 200)) {
+            return true;
+        }
 
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);
-
-    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
-    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, HTTP_TIMEOUT);
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, HTTP_TIMEOUT);
-
-    curl_easy_setopt(curl, CURLOPT_POST, 1);
-
-    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);
-    curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 10);
-    curl_easy_setopt(curl, CURLOPT_POSTREDIR, CURL_REDIR_POST_ALL);
-
-    std::span<const char> data(buf);
-    curl_easy_setopt(curl, CURLOPT_READDATA, &data);
-    curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_callback);
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, data.size());
-
-    if (curl_easy_perform(curl) == CURLE_OK) {
-        long response_code;
-        curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
-        if (response_code == 200) {
-            succeeded = true;
+        prt(_("スコア・サーバへの送信に失敗しました。", "Failed to send to the score server."), 0, 0);
+        (void)inkey();
+        if (!get_check_strict(player_ptr, _("もう一度接続を試みますか? ", "Try again? "), CHECK_NO_HISTORY)) {
+            return false;
         }
     }
-
-    curl_slist_free_all(slist);
-    curl_easy_cleanup(curl);
-
-    return succeeded;
 }
 
 /*!
@@ -341,26 +297,7 @@ bool report_score(PlayerType *player_ptr)
                  << screen_dump;
     }
 
-    const auto score = score_ss.str();
-    const std::vector<char> score_data(score.begin(), score.end());
-
-    term_clear();
-    while (true) {
-        term_fresh();
-        prt(_("スコア送信中...", "Sending the score..."), 0, 0);
-        term_fresh();
-        if (http_post(SCORE_PATH, score_data)) {
-            return true;
-        }
-
-        prt(_("スコア・サーバへの送信に失敗しました。", "Failed to send to the score server."), 0, 0);
-        (void)inkey();
-        if (get_check_strict(player_ptr, _("もう一度接続を試みますか? ", "Try again? "), CHECK_NO_HISTORY)) {
-            continue;
-        }
-
-        return false;
-    }
+    return post_score_to_score_server(player_ptr, score_ss.str());
 }
 #else
 concptr screen_dump = nullptr;

--- a/src/net/curl-easy-session.cpp
+++ b/src/net/curl-easy-session.cpp
@@ -1,0 +1,99 @@
+﻿#include "net/curl-easy-session.h"
+
+#if defined(WORLD_SCORE)
+
+namespace libcurl {
+
+namespace {
+
+    size_t write_callback(char *buf, size_t size, size_t nitems, EasySession::SendHandler *userdata)
+    {
+        return (*userdata)(buf, size * nitems);
+    }
+
+    size_t read_callback(char *buf, size_t size, size_t nitems, EasySession::ReceiveHandler *userdata)
+    {
+        return (*userdata)(buf, size * nitems);
+    }
+
+}
+
+class EasySession::Impl {
+public:
+    Impl()
+        : handle_(curl_easy_init(), curl_easy_cleanup)
+    {
+    }
+    ~Impl() = default;
+    Impl(const Impl &) = delete;
+    Impl &operator=(const Impl &) = delete;
+    Impl(Impl &&) = default;
+    Impl &operator=(Impl &&) = default;
+
+    std::unique_ptr<CURL, decltype(&curl_easy_cleanup)> handle_;
+    SendHandler send_handler_;
+    ReceiveHandler receive_handler_;
+};
+
+EasySession::EasySession()
+    : pimpl_(std::make_unique<Impl>())
+{
+}
+
+EasySession::~EasySession() = default;
+EasySession::EasySession(EasySession &&) = default;
+EasySession &EasySession::operator=(EasySession &&) = default;
+
+bool EasySession::is_valid() const
+{
+    return pimpl_->handle_ != nullptr;
+}
+
+void EasySession::common_setup(const std::string &url, int timeout_sec)
+{
+    this->setopt(CURLOPT_URL, url.data());
+
+    this->setopt(CURLOPT_NOSIGNAL, 1);
+
+    if (timeout_sec > 0) {
+        this->setopt(CURLOPT_CONNECTTIMEOUT, timeout_sec);
+        this->setopt(CURLOPT_TIMEOUT, timeout_sec);
+    }
+}
+
+void EasySession::sender_setup(SendHandler handler, long post_field_size)
+{
+    pimpl_->send_handler_ = std::move(handler);
+    if (!pimpl_->send_handler_) {
+        return;
+    }
+
+    this->setopt(CURLOPT_READDATA, &pimpl_->send_handler_);
+    this->setopt(CURLOPT_READFUNCTION, read_callback);
+    this->setopt(CURLOPT_POSTFIELDSIZE, post_field_size);
+}
+
+void EasySession::receiver_setup(ReceiveHandler handler)
+{
+    pimpl_->receive_handler_ = std::move(handler);
+    if (!pimpl_->receive_handler_) {
+        return;
+    }
+
+    this->setopt(CURLOPT_WRITEDATA, &pimpl_->receive_handler_);
+    this->setopt(CURLOPT_WRITEFUNCTION, write_callback);
+}
+
+bool EasySession::perform()
+{
+    return curl_easy_perform(pimpl_->handle_.get()) == CURLE_OK;
+}
+
+CURL *EasySession::get_curl_handle()
+{
+    return pimpl_->handle_.get();
+}
+
+}
+
+#endif

--- a/src/net/curl-easy-session.h
+++ b/src/net/curl-easy-session.h
@@ -1,0 +1,59 @@
+﻿#pragma once
+
+#include "system/angband.h"
+#include <functional>
+#include <memory>
+#include <string>
+
+#if defined(WORLD_SCORE)
+
+#ifdef WINDOWS
+#define CURL_STATICLIB
+#endif
+#include <curl/curl.h>
+
+namespace libcurl {
+
+/*!
+ * @brief libcurl easy session の薄いラッパークラス
+ */
+class EasySession {
+public:
+    using SendHandler = std::function<size_t(char *, size_t)>;
+    using ReceiveHandler = std::function<size_t(char *, size_t)>;
+
+    EasySession();
+    ~EasySession();
+    EasySession(const EasySession &) = delete;
+    EasySession &operator=(const EasySession &) = delete;
+    EasySession(EasySession &&);
+    EasySession &operator=(EasySession &&);
+
+    bool is_valid() const;
+    void common_setup(const std::string &url, int timeout_sec = 0);
+    void sender_setup(SendHandler handler, long post_field_size);
+    void receiver_setup(ReceiveHandler handler);
+    bool perform();
+
+    template <typename T>
+    void setopt(CURLoption opt, T param)
+    {
+        curl_easy_setopt(this->get_curl_handle(), opt, param);
+    }
+
+    template <typename T>
+    bool getinfo(CURLINFO info, T arg)
+    {
+        return curl_easy_getinfo(this->get_curl_handle(), info, arg) == CURLE_OK;
+    }
+
+private:
+    CURL *get_curl_handle();
+
+    class Impl;
+    std::unique_ptr<Impl> pimpl_;
+};
+
+}
+
+#endif

--- a/src/net/curl-slist.cpp
+++ b/src/net/curl-slist.cpp
@@ -1,0 +1,65 @@
+﻿#include "net/curl-slist.h"
+
+#if defined(WORLD_SCORE)
+
+namespace libcurl {
+
+class SList::Impl {
+public:
+    Impl()
+        : slist(nullptr, curl_slist_free_all)
+    {
+    }
+    ~Impl() = default;
+    Impl(const Impl &) = delete;
+    Impl &operator=(const Impl &) = delete;
+    Impl(Impl &&) = default;
+    Impl &operator=(Impl &&) = default;
+
+    std::unique_ptr<curl_slist, decltype(&curl_slist_free_all)> slist;
+    bool valid = true;
+};
+
+SList::SList()
+    : pimpl_(std::make_unique<Impl>())
+{
+}
+
+SList::~SList() = default;
+SList::SList(SList &&) = default;
+SList &SList::operator=(SList &&) = default;
+
+bool SList::is_valid() const
+{
+    return pimpl_->valid;
+}
+
+void SList::append(const char *str)
+{
+    if (!pimpl_->valid) {
+        return;
+    }
+
+    auto result = curl_slist_append(pimpl_->slist.get(), str);
+    if (result == nullptr) {
+        pimpl_->valid = false;
+        return;
+    }
+
+    pimpl_->slist.release();
+    pimpl_->slist.reset(result);
+}
+
+void SList::append(const std::string &str)
+{
+    this->append(str.data());
+}
+
+curl_slist *SList::get()
+{
+    return pimpl_->slist.get();
+}
+
+}
+
+#endif

--- a/src/net/curl-slist.h
+++ b/src/net/curl-slist.h
@@ -1,0 +1,40 @@
+﻿#pragma once
+
+#include "system/angband.h"
+#include <memory>
+#include <string>
+
+#if defined(WORLD_SCORE)
+
+#ifdef WINDOWS
+#define CURL_STATICLIB
+#endif
+#include <curl/curl.h>
+
+namespace libcurl {
+
+/*!
+ * @brief libcurl string list の薄いラッパークラス
+ */
+class SList {
+public:
+    SList();
+    ~SList();
+    SList(const SList &) = delete;
+    SList &operator=(const SList &) = delete;
+    SList(SList &&);
+    SList &operator=(SList &&);
+
+    bool is_valid() const;
+    void append(const char *str);
+    void append(const std::string &str);
+    curl_slist *get();
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> pimpl_;
+};
+
+}
+
+#endif

--- a/src/net/http-client.cpp
+++ b/src/net/http-client.cpp
@@ -1,0 +1,104 @@
+﻿#include "net/http-client.h"
+#include "net/curl-easy-session.h"
+#include "net/curl-slist.h"
+#include <string_view>
+
+#if defined(WORLD_SCORE)
+
+namespace http {
+
+namespace {
+
+    constexpr auto HTTP_CONNECTION_TIMEOUT = 10; //!< HTTP接続タイムアウト時間(秒)
+
+    void setup_http_option(libcurl::EasySession &session, const std::optional<std::string> &user_agent)
+    {
+        if (user_agent.has_value()) {
+            session.setopt(CURLOPT_USERAGENT, user_agent->data());
+        }
+
+        session.setopt(CURLOPT_FOLLOWLOCATION, 1);
+        session.setopt(CURLOPT_MAXREDIRS, 10);
+        session.setopt(CURLOPT_POSTREDIR, CURL_REDIR_POST_ALL);
+    }
+
+}
+
+/*!
+ * @brief HTTP GETリクエストを送信する
+ * @param url リクエストの送信先URL
+ * @return 送信に成功した場合Responseオブジェクト、失敗した場合std::nullopt
+ */
+std::optional<Response> Client::get(const std::string &url)
+{
+    libcurl::EasySession session;
+    if (!session.is_valid()) {
+        return std::nullopt;
+    }
+
+    session.common_setup(url, HTTP_CONNECTION_TIMEOUT);
+    setup_http_option(session, this->user_agent);
+
+    Response response{};
+    auto receiver = [&response](char *buf, size_t n) {
+        response.body.append(buf, n);
+        return n;
+    };
+    session.receiver_setup(std::move(receiver));
+
+    if (!session.perform()) {
+        return std::nullopt;
+    }
+
+    session.getinfo(CURLINFO_RESPONSE_CODE, &response.status);
+    return std::make_optional(std::move(response));
+}
+
+/*!
+ * @brief HTTP POSTリクエストを送信する
+ * @param url リクエストの送信先URL
+ * @param post_data POSTデータ本体
+ * @param media_type POSTデータのメディアタイプ(Content-Typeヘッダの内容)
+ * @return 送信に成功した場合Responseオブジェクト、失敗した場合std::nullopt
+ */
+std::optional<Response> Client::post(const std::string &url, const std::string &post_data, const std::string &media_type)
+{
+    libcurl::EasySession session;
+    libcurl::SList headers;
+    headers.append(format("Content-Type: %s", media_type.data()));
+
+    if (!session.is_valid() || !headers.is_valid()) {
+        return std::nullopt;
+    }
+
+    session.common_setup(url, HTTP_CONNECTION_TIMEOUT);
+    setup_http_option(session, this->user_agent);
+
+    session.setopt(CURLOPT_HTTPHEADER, headers.get());
+    session.setopt(CURLOPT_POST, 1);
+
+    auto sender = [data = std::string_view(post_data)](char *buf, size_t n) mutable {
+        const auto len = data.copy(buf, n);
+        data.remove_prefix(len);
+        return len;
+    };
+    session.sender_setup(std::move(sender), post_data.length());
+
+    Response response{};
+    auto receiver = [&response](char *buf, size_t n) {
+        response.body.append(buf, n);
+        return n;
+    };
+    session.receiver_setup(std::move(receiver));
+
+    if (!session.perform()) {
+        return std::nullopt;
+    }
+
+    session.getinfo(CURLINFO_RESPONSE_CODE, &response.status);
+    return std::make_optional(std::move(response));
+}
+
+}
+
+#endif

--- a/src/net/http-client.h
+++ b/src/net/http-client.h
@@ -1,0 +1,27 @@
+﻿#pragma once
+
+#include "system/angband.h"
+#include <optional>
+#include <string>
+
+#if defined(WORLD_SCORE)
+
+namespace http {
+
+struct Response {
+    int status;
+    std::string body;
+};
+
+class HttpContentBase;
+class Client {
+public:
+    std::optional<Response> get(const std::string &url);
+    std::optional<Response> post(const std::string &url, const std::string &post_data, const std::string &media_type);
+
+    std::optional<std::string> user_agent;
+};
+
+}
+
+#endif


### PR DESCRIPTION
cpp-httplibを使用しない方針となったため、今後のHTTP通信を利用した機能の追加に備えて、必要最低限の機能を備えた以下の通りのシンプルなHTTP通信機能クラスを実装しました。

http 名前空間
- Client: HTTP通信クライアントクラス
- Response: HTTP通信の応答を保持する構造体

libcurl 名前空間
- EasySession: libcurl easy session APIの薄いラッパークラス
- SList: libcurl string list の薄いラッパークラス

これらを使用して現在のスコアサーバへのスコア送信機能を置き換えました。
また、cpp-httplibによる実装をrevertしたことで消えていた、buf_sprintfを使用せずstringstreamで送信ダンプを作成するようにするリファクタリングを復活させました。

[テスト用スコアサーバ](https://mars.kmc.gr.jp/~dis/heng_score_test/score_ranking.php?&sort=newcome)に送信できることを確認しています。また、現在の PR のブランチのスコア送信先はテスト用スコアサーバになっています。