### PR TITLE
[Fix] configureの--enable-chuukeiオプションを削除

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,8 +59,6 @@ AC_ARG_ENABLE([xft],
 	AS_HELP_STRING([--enable-xft], [Enable xft support]))
 AC_ARG_ENABLE(worldscore,
 [  --disable-worldscore    disable worldscore support], worldscore=no)
-AC_ARG_ENABLE(chuukei,
-[  --enable-chuukei        enable internet chuukei support], AC_DEFINE(CHUUKEI, 1, [Chuukei mode]))
 AC_ARG_ENABLE([pch],
 [  --disable-pch           disable use of precompiled headers],
 enable_pch=no, enable_pch=yes)


### PR DESCRIPTION
すでに削除済みの機能なのでconfigureからも削除する。

configure.acの編集をしてて気づいたので。些細な修正なのでIssueなし。