### PR TITLE
[Fix] メッセージ表示位置のずれ

### DIFF
--- a/src/cmd-visual/cmd-map.cpp
+++ b/src/cmd-visual/cmd-map.cpp
@@ -6,6 +6,7 @@
 #include "term/screen-processor.h"
 #include "view/display-map.h"
 #include "window/main-window-util.h"
+#include <string_view>
 
 /*
  * Display a "small-scale" map of the dungeon for the player
@@ -23,7 +24,11 @@ void do_cmd_view_map(PlayerType *player_ptr)
     int cy, cx;
     display_map(player_ptr, &cy, &cx);
     if (autopick_list.empty() || player_ptr->wild_mode) {
-        put_str(_("何かキーを押すとゲームに戻ります", "Hit any key to continue"), 23, 30);
+        int wid, hgt;
+        term_get_size(&wid, &hgt);
+        constexpr auto msg = _("何かキーを押すとゲームに戻ります", "Hit any key to continue");
+        const auto center_x = (wid - std::string_view(msg).length()) / 2;
+        put_str(msg, hgt - 1, center_x);
         move_cursor(cy, cx);
         inkey(true);
         screen_load();

--- a/src/core/game-closer.cpp
+++ b/src/core/game-closer.cpp
@@ -164,6 +164,8 @@ void close_game(PlayerType *player_ptr)
         kingly(player_ptr);
     }
 
+    print_tomb(player_ptr);
+
     auto do_send = true;
     if (!cheat_save || get_check(_("死んだデータをセーブしますか？ ", "Save death? "))) {
         update_playtime();
@@ -176,7 +178,6 @@ void close_game(PlayerType *player_ptr)
         do_send = false;
     }
 
-    print_tomb(player_ptr);
     flush();
     show_death_info(player_ptr);
     term_clear();


### PR DESCRIPTION
Resolves #3410 

広域マップでの表示位置のずれに関しては、TermCenteredOffsetSetter は関係なく、表示座標が固定になっており元々ずれてたようです。