### PR TITLE
静的警告の解消 その7

### DIFF
--- a/src/autopick/autopick-describer.cpp
+++ b/src/autopick/autopick-describer.cpp
@@ -233,13 +233,13 @@ static void describe_autpick_jp(char *buff, const autopick_type &entry, autopick
         angband_strcat(tmp, describer->insc, MAX_INSCRIPTION);
         angband_strcat(buff, format("に「%s」", tmp), MAX_INSCRIPTION + 6);
 
-        if (angband_strstr(describer->insc, "%%all")) {
+        if (str_find(describer->insc, "%%all")) {
             strcat(buff, "(%%allは全能力を表す英字の記号で置換)");
-        } else if (angband_strstr(describer->insc, "%all")) {
+        } else if (str_find(describer->insc, "%all")) {
             strcat(buff, "(%allは全能力を表す記号で置換)");
-        } else if (angband_strstr(describer->insc, "%%")) {
+        } else if (str_find(describer->insc, "%%")) {
             strcat(buff, "(%%は追加能力を表す英字の記号で置換)");
-        } else if (angband_strstr(describer->insc, "%")) {
+        } else if (str_find(describer->insc, "%")) {
             strcat(buff, "(%は追加能力を表す記号で置換)");
         }
 

--- a/src/autopick/autopick-matcher.cpp
+++ b/src/autopick/autopick-matcher.cpp
@@ -347,7 +347,7 @@ bool is_autopick_match(PlayerType *player_ptr, ItemEntity *o_ptr, const autopick
             return false;
         }
     } else {
-        if (angband_strstr(item_name.data(), entry.name) == nullptr) {
+        if (!str_find(std::string(item_name), entry.name)) {
             return false;
         }
     }

--- a/src/cmd-io/cmd-gameoption.cpp
+++ b/src/cmd-io/cmd-gameoption.cpp
@@ -572,7 +572,7 @@ void do_cmd_options(PlayerType *player_ptr)
             clear_from(18);
             prt(format(_("現在ウェイト量(msec): %d", "Current Delay Factor(msec): %d"), delay_factor), 19, 0);
             constexpr auto prompt = _("コマンド: ウェイト量(msec)", "Command: Delay Factor(msec)");
-            const auto new_delay_factor = input_value_int(prompt, 0, 1000, delay_factor);
+            const auto new_delay_factor = input_integer(prompt, 0, 1000, delay_factor);
             if (new_delay_factor.has_value()) {
                 delay_factor = new_delay_factor.value();
             }

--- a/src/cmd-io/cmd-lore.cpp
+++ b/src/cmd-io/cmd-lore.cpp
@@ -135,9 +135,9 @@ void do_cmd_query_symbol(PlayerType *player_ptr)
             }
 
 #ifdef JP
-            if (angband_strstr(temp2, temp) || angband_strstr(r_ref.name.data(), temp))
+            if (str_find(temp2, temp) || str_find(r_ref.name, temp))
 #else
-            if (angband_strstr(temp2, temp))
+            if (str_find(temp2, temp))
 #endif
                 who.push_back(r_ref.idx);
         }

--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -209,7 +209,12 @@ void do_cmd_messages(int num_now)
 
             // @details ダメ文字対策でstringを使わない.
             const auto *str = msg;
-            while ((str = angband_strstr(str, shower)) != nullptr) {
+            while (true) {
+                str = angband_strstr(str, shower);
+                if (str == nullptr) {
+                    break;
+                }
+
                 const auto len = shower.length();
                 term_putstr(str - msg, num_lines + 1 - j, len, TERM_YELLOW, shower);
                 str += len;
@@ -263,9 +268,8 @@ void do_cmd_messages(int num_now)
             shower = finder_str;
             for (int z = i + 1; z < n; z++) {
                 // @details ダメ文字対策でstringを使わない.
-                const auto msg_str = message_str(z);
-                const auto *msg = msg_str->data();
-                if (angband_strstr(msg, finder_str) != nullptr) {
+                const auto msg = message_str(z);
+                if (str_find(*msg, finder_str)) {
                     i = z;
                     break;
                 }

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -40,7 +40,7 @@ template <typename T>
 static std::optional<T> input_new_visual_id(int i, T initial_visual_id, int max)
 {
     if (iscntrl(i)) {
-        const auto new_visual_id = input_value_int("Input new number", 0, max - 1, initial_visual_id);
+        const auto new_visual_id = input_integer("Input new number", 0, max - 1, initial_visual_id);
         if (!new_visual_id.has_value()) {
             return std::nullopt;
         }

--- a/src/core/asking-player.cpp
+++ b/src/core/asking-player.cpp
@@ -439,7 +439,7 @@ void pause_line(int row)
     prt("", row, 0);
 }
 
-std::optional<int> input_value_int(std::string_view prompt, int min, int max, int initial_value)
+std::optional<int> input_integer(std::string_view prompt, int min, int max, int initial_value)
 {
     std::stringstream ss;
     char tmp_val[12] = "";

--- a/src/core/asking-player.h
+++ b/src/core/asking-player.h
@@ -21,13 +21,13 @@ bool get_check_strict(PlayerType *player_ptr, std::string_view prompt, BIT_FLAGS
 bool get_com(std::string_view prompt, char *command, bool z_escape);
 QUANTITY get_quantity(std::optional<std::string_view> prompt_opt, QUANTITY max);
 void pause_line(int row);
-std::optional<int> input_value_int(std::string_view prompt, int min, int max, int initial_value = 0);
+std::optional<int> input_integer(std::string_view prompt, int min, int max, int initial_value = 0);
 
 template <typename T>
-std::optional<T> input_value(std::string_view prompt, int min, int max, T initial_value = static_cast<T>(0))
+std::optional<T> input_numerics(std::string_view prompt, int min, int max, T initial_value = static_cast<T>(0))
     requires std::is_integral_v<T> || std::is_enum_v<T>
 {
-    auto result = input_value_int(prompt, min, max, static_cast<int>(initial_value));
+    auto result = input_integer(prompt, min, max, static_cast<int>(initial_value));
     if (!result.has_value()) {
         return std::nullopt;
     }

--- a/src/core/show-file.cpp
+++ b/src/core/show-file.cpp
@@ -281,7 +281,7 @@ bool show_file(PlayerType *player_ptr, bool show_version, std::string_view name_
                 char lc_buf[1024];
                 strcpy(lc_buf, str);
                 str_tolower(lc_buf);
-                if (!angband_strstr(lc_buf, find)) {
+                if (!str_find(lc_buf, find)) {
                     continue;
                 }
             }

--- a/src/floor/pattern-walk.cpp
+++ b/src/floor/pattern-walk.cpp
@@ -34,6 +34,7 @@
 #include "view/display-messages.h"
 #include "world/world-movement-processor.h"
 #include "world/world.h"
+#include <algorithm>
 
 /*!
  * @brief パターン終点到達時のテレポート処理を行う
@@ -41,22 +42,19 @@
  */
 void pattern_teleport(PlayerType *player_ptr)
 {
-    DEPTH min_level = 0;
-    DEPTH max_level = 99;
-
+    auto min_level = 0;
+    auto max_level = 99;
+    auto current_level = static_cast<short>(player_ptr->current_floor_ptr->dun_level);
     if (get_check(_("他の階にテレポートしますか？", "Teleport level? "))) {
-        char ppp[80];
-        char tmp_val[160];
-
         if (ironman_downward) {
-            min_level = player_ptr->current_floor_ptr->dun_level;
+            min_level = current_level;
         }
 
         const auto &floor = *player_ptr->current_floor_ptr;
         if (floor.dungeon_idx == DUNGEON_ANGBAND) {
             if (floor.dun_level > 100) {
                 max_level = MAX_DEPTH - 1;
-            } else if (player_ptr->current_floor_ptr->dun_level == 100) {
+            } else if (current_level == 100) {
                 max_level = 100;
             }
         } else {
@@ -65,25 +63,18 @@ void pattern_teleport(PlayerType *player_ptr)
             min_level = dungeon.mindepth;
         }
 
-        strnfmt(ppp, sizeof(ppp), _("テレポート先:(%d-%d)", "Teleport to level (%d-%d): "), (int)min_level, (int)max_level);
-        strnfmt(tmp_val, sizeof(tmp_val), "%d", (int)player_ptr->current_floor_ptr->dun_level);
-        if (!get_string(ppp, tmp_val, 10)) {
+        constexpr auto prompt = _("テレポート先", "Teleport to level");
+        const auto input_level = input_value(prompt, min_level, max_level, current_level);
+        if (!input_level.has_value()) {
             return;
         }
 
-        command_arg = (COMMAND_ARG)atoi(tmp_val);
+        command_arg = input_level.value();
     } else if (get_check(_("通常テレポート？", "Normal teleport? "))) {
         teleport_player(player_ptr, 200, TELEPORT_SPONTANEOUS);
         return;
     } else {
         return;
-    }
-
-    if (command_arg < min_level) {
-        command_arg = (COMMAND_ARG)min_level;
-    }
-    if (command_arg > max_level) {
-        command_arg = (COMMAND_ARG)max_level;
     }
 
     msg_format(_("%d 階にテレポートしました。", "You teleport to dungeon level %d."), command_arg);

--- a/src/floor/pattern-walk.cpp
+++ b/src/floor/pattern-walk.cpp
@@ -64,7 +64,7 @@ void pattern_teleport(PlayerType *player_ptr)
         }
 
         constexpr auto prompt = _("テレポート先", "Teleport to level");
-        const auto input_level = input_value(prompt, min_level, max_level, current_level);
+        const auto input_level = input_numerics(prompt, min_level, max_level, current_level);
         if (!input_level.has_value()) {
             return;
         }

--- a/src/io/record-play-movie.cpp
+++ b/src/io/record-play-movie.cpp
@@ -52,10 +52,10 @@ static struct {
 
 /* リングバッファ構造体 */
 static struct {
-    std::vector<char> buf;
-    int wptr;
-    int rptr;
-    int inlen;
+    std::vector<char> buf{};
+    int wptr = 0;
+    int rptr = 0;
+    int inlen = 0;
 } ring;
 
 /*

--- a/src/market/arena.cpp
+++ b/src/market/arena.cpp
@@ -264,11 +264,6 @@ void update_gambling_monsters(PlayerType *player_ptr)
  */
 bool monster_arena_comm(PlayerType *player_ptr)
 {
-    PRICE maxbet;
-    PRICE wager;
-    char out_val[MAX_MONSTER_NAME];
-    concptr p;
-
     if ((w_ptr->game_turn - w_ptr->arena_start_turn) > TURNS_PER_TICK * 250) {
         update_gambling_monsters(player_ptr);
         w_ptr->arena_start_turn = w_ptr->game_turn;
@@ -329,40 +324,21 @@ bool monster_arena_comm(PlayerType *player_ptr)
         }
     }
 
-    maxbet = player_ptr->lev * 200;
-
-    /* We can't bet more than we have */
+    auto maxbet = player_ptr->lev * 200;
     maxbet = std::min(maxbet, player_ptr->au);
-
-    /*
-     * Get the wager
-     * Use get_string() because we may need more than
-     * the int16_t value returned by get_quantity().
-     */
-    out_val[0] = '\0';
-    if (!get_string(format(_("賭け金 (1-%ld)？", "Your wager (1-%ld) ? "), (long int)maxbet), out_val, 32)) {
+    constexpr auto prompt = _("賭け金？", "Your wager? ");
+    const auto wager_opt = input_value_int(prompt, 1, maxbet, 1);
+    if (!wager_opt.has_value()) {
         screen_load();
         return false;
     }
 
-    for (p = out_val; *p == ' '; p++) {
-        ;
-    }
-
-    wager = atol(p);
+    auto wager = wager_opt.value();
     if (wager > player_ptr->au) {
         msg_print(_("おい！金が足りないじゃないか！出ていけ！", "Hey! You don't have the gold - get out of here!"));
-
         msg_print(nullptr);
         screen_load();
         return false;
-    } else if (wager > maxbet) {
-        msg_format(_("%ldゴールドだけ受けよう。残りは取っときな。", "I'll take %ld gold of that. Keep the rest."), (long int)maxbet);
-
-        wager = maxbet;
-    } else if (wager < 1) {
-        msg_print(_("ＯＫ、１ゴールドでいこう。", "Ok, we'll start with 1 gold."));
-        wager = 1;
     }
 
     msg_print(nullptr);

--- a/src/market/arena.cpp
+++ b/src/market/arena.cpp
@@ -327,7 +327,7 @@ bool monster_arena_comm(PlayerType *player_ptr)
     auto maxbet = player_ptr->lev * 200;
     maxbet = std::min(maxbet, player_ptr->au);
     constexpr auto prompt = _("賭け金？", "Your wager? ");
-    const auto wager_opt = input_value_int(prompt, 1, maxbet, 1);
+    const auto wager_opt = input_integer(prompt, 1, maxbet, 1);
     if (!wager_opt.has_value()) {
         screen_load();
         return false;

--- a/src/market/building-monster.cpp
+++ b/src/market/building-monster.cpp
@@ -124,9 +124,9 @@ bool research_mon(PlayerType *player_ptr)
             }
 
 #ifdef JP
-            if (angband_strstr(temp2.data(), temp) || angband_strstr(monrace.name.data(), temp))
+            if (str_find(temp2, temp) || str_find(monrace.name, temp))
 #else
-            if (angband_strstr(temp2.data(), temp))
+            if (str_find(temp2, temp))
 #endif
                 who.push_back(monrace_id);
         } else if (all || (monrace.d_char == sym)) {

--- a/src/market/play-gamble.cpp
+++ b/src/market/play-gamble.cpp
@@ -40,7 +40,7 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
     auto maxbet = player_ptr->lev * 200;
     maxbet = std::min(maxbet, player_ptr->au);
     constexpr auto prompt = _("賭け金？", "Your wager ?");
-    const auto wager_opt = input_value_int(prompt, 1, maxbet, 1);
+    const auto wager_opt = input_integer(prompt, 1, maxbet, 1);
     if (!wager_opt.has_value()) {
         msg_print(nullptr);
         screen_load();
@@ -125,7 +125,7 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
             prt("0  1  2  3  4  5  6  7  8  9", 7, 5);
             prt("--------------------------------", 8, 3);
             while (true) {
-                const auto choice_opt = input_value_int(_("何番？", "Pick a number"), 0, 9);
+                const auto choice_opt = input_integer(_("何番？", "Pick a number"), 0, 9);
                 if (!choice_opt.has_value()) {
                     continue;
                 }

--- a/src/market/play-gamble.cpp
+++ b/src/market/play-gamble.cpp
@@ -22,17 +22,7 @@
  */
 bool gamble_comm(PlayerType *player_ptr, int cmd)
 {
-    int i;
-    int roll1, roll2, roll3, choice, odds, win;
-    int32_t wager;
-    int32_t maxbet;
-    int32_t oldgold;
-
-    char out_val[160] = "", again;
-    concptr p;
-
     screen_save();
-
     if (cmd == BACT_GAMBLE_RULES) {
         (void)show_file(player_ptr, true, _("jgambling.txt", "gambling.txt"), 0, 0);
         screen_load();
@@ -47,55 +37,43 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
     }
 
     clear_bldg(5, 23);
-    maxbet = player_ptr->lev * 200;
+    auto maxbet = player_ptr->lev * 200;
     maxbet = std::min(maxbet, player_ptr->au);
-
-    /*
-     * Use get_string() because we may need more than
-     * the int16_t value returned by get_quantity().
-     */
-    if (!get_string(format(_("賭け金 (1-%ld)？", "Your wager (1-%ld) ? "), (long int)maxbet), out_val, 32)) {
+    constexpr auto prompt = _("賭け金？", "Your wager ?");
+    const auto wager_opt = input_value_int(prompt, 1, maxbet, 1);
+    if (!wager_opt.has_value()) {
         msg_print(nullptr);
         screen_load();
         return true;
     }
 
-    for (p = out_val; *p == ' '; p++) {
-        ;
-    }
-
-    wager = atol(p);
+    auto wager = wager_opt.value();
     if (wager > player_ptr->au) {
         msg_print(_("おい！金が足りないじゃないか！出ていけ！", "Hey! You don't have the gold - get out of here!"));
         msg_print(nullptr);
         screen_load();
         return false;
-    } else if (wager > maxbet) {
-        msg_format(_("%ldゴールドだけ受けよう。残りは取っときな。", "I'll take %ld gold of that. Keep the rest."), (long int)maxbet);
-        wager = maxbet;
-    } else if (wager < 1) {
-        msg_print(_("ＯＫ、１ゴールドからはじめよう。", "Ok, we'll start with 1 gold."));
-        wager = 1;
     }
+
     msg_print(nullptr);
-    win = 0;
-    odds = 0;
-    oldgold = player_ptr->au;
+    auto win = 0;
+    auto odds = 0;
+    auto oldgold = player_ptr->au;
 
-    prt(format(_("ゲーム前の所持金: %9ld", "Gold before game: %9ld"), (long int)oldgold), 20, 2);
-    prt(format(_("現在の掛け金:     %9ld", "Current Wager:    %9ld"), (long int)wager), 21, 2);
+    prt(format(_("ゲーム前の所持金: %9d", "Gold before game: %9d"), oldgold), 20, 2);
+    prt(format(_("現在の掛け金:     %9d", "Current Wager:    %9d"), wager), 21, 2);
 
-    do {
+    while (true) {
         player_ptr->au -= wager;
         switch (cmd) {
-        case BACT_IN_BETWEEN: /* Game of In-Between */
+        case BACT_IN_BETWEEN: {
             c_put_str(TERM_GREEN, _("イン・ビトイーン", "In Between"), 5, 2);
 
             odds = 4;
             win = 0;
-            roll1 = randint1(10);
-            roll2 = randint1(10);
-            choice = randint1(10);
+            auto roll1 = randint1(10);
+            auto roll2 = randint1(10);
+            auto choice = randint1(10);
 
             prt(format(_("黒ダイス: %d        黒ダイス: %d", "Black die: %d       Black Die: %d"), roll1, roll2), 8, 3);
 
@@ -103,16 +81,18 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
             if (((choice > roll1) && (choice < roll2)) || ((choice < roll1) && (choice > roll2))) {
                 win = 1;
             }
+
             break;
-        case BACT_CRAPS: /* Game of Craps */
+        }
+        case BACT_CRAPS: {
             c_put_str(TERM_GREEN, _("クラップス", "Craps"), 5, 2);
 
             win = 3;
             odds = 2;
-            roll1 = randint1(6);
-            roll2 = randint1(6);
-            roll3 = roll1 + roll2;
-            choice = roll3;
+            auto roll1 = randint1(6);
+            auto roll2 = randint1(6);
+            auto roll3 = roll1 + roll2;
+            auto choice = roll3;
             prt(format(_("１振りめ: %d %d      Total: %d", "First roll: %d %d    Total: %d"), roll1, roll2, roll3), 7, 5);
             if ((roll3 == 7) || (roll3 == 11)) {
                 win = 1;
@@ -136,39 +116,36 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
             }
 
             break;
-
-        case BACT_SPIN_WHEEL: /* Spin the Wheel Game */
+        }
+        case BACT_SPIN_WHEEL: {
             win = 0;
             odds = 9;
             c_put_str(TERM_GREEN, _("ルーレット", "Wheel"), 5, 2);
 
             prt("0  1  2  3  4  5  6  7  8  9", 7, 5);
             prt("--------------------------------", 8, 3);
-            strcpy(out_val, "");
-            get_string(_("何番？ (0-9): ", "Pick a number (0-9): "), out_val, 32);
+            while (true) {
+                const auto choice_opt = input_value_int(_("何番？", "Pick a number"), 0, 9);
+                if (!choice_opt.has_value()) {
+                    continue;
+                }
 
-            for (p = out_val; iswspace(*p); p++) {
-                ;
+                auto choice = choice_opt.value();
+                msg_print(nullptr);
+                auto roll1 = randint0(10);
+                prt(format(_("ルーレットは回り、止まった。勝者は %d番だ。", "The wheel spins to a stop and the winner is %d"), roll1), 13, 3);
+                prt("", 9, 0);
+                prt("*", 9, (3 * roll1 + 5));
+                if (roll1 == choice) {
+                    win = 1;
+                }
+
+                break;
             }
-            choice = atol(p);
-            if (choice < 0) {
-                msg_print(_("0番にしとくぜ。", "I'll put you down for 0."));
-                choice = 0;
-            } else if (choice > 9) {
-                msg_print(_("ＯＫ、9番にしとくぜ。", "Ok, I'll put you down for 9."));
-                choice = 9;
-            }
-            msg_print(nullptr);
-            roll1 = randint0(10);
-            prt(format(_("ルーレットは回り、止まった。勝者は %d番だ。", "The wheel spins to a stop and the winner is %d"), roll1), 13, 3);
-            prt("", 9, 0);
-            prt("*", 9, (3 * roll1 + 5));
-            if (roll1 == choice) {
-                win = 1;
-            }
+
             break;
-
-        case BACT_DICE_SLOTS: /* The Dice Slots */
+        }
+        case BACT_DICE_SLOTS: {
             c_put_str(TERM_GREEN, _("ダイス・スロット", "Dice Slots"), 5, 2);
             c_put_str(TERM_YELLOW, _("レモン   レモン            2", "Lemon    Lemon             2"), 6, 37);
             c_put_str(TERM_YELLOW, _("レモン   レモン   レモン   5", "Lemon    Lemon    Lemon    5"), 7, 37);
@@ -179,24 +156,24 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
             c_put_str(TERM_RED, _("チェリー チェリー チェリー 1000", "Cherry   Cherry   Cherry   1000"), 12, 37);
 
             win = 0;
-            roll1 = randint1(21);
-            for (i = 6; i > 0; i--) {
+            auto roll1 = randint1(21);
+            for (auto i = 6; i > 0; i--) {
                 if ((roll1 - i) < 1) {
                     roll1 = 7 - i;
                     break;
                 }
                 roll1 -= i;
             }
-            roll2 = randint1(21);
-            for (i = 6; i > 0; i--) {
+            auto roll2 = randint1(21);
+            for (auto i = 6; i > 0; i--) {
                 if ((roll2 - i) < 1) {
                     roll2 = 7 - i;
                     break;
                 }
                 roll2 -= i;
             }
-            choice = randint1(21);
-            for (i = 6; i > 0; i--) {
+            auto choice = randint1(21);
+            for (auto i = 6; i > 0; i--) {
                 if ((choice - i) < 1) {
                     choice = 7 - i;
                     break;
@@ -234,13 +211,16 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
                 win = 1;
                 odds = 2;
             }
+
             break;
+        }
         case BACT_POKER:
             win = 0;
             odds = do_poker();
             if (odds) {
                 win = 1;
             }
+
             break;
         }
 
@@ -255,22 +235,26 @@ bool gamble_comm(PlayerType *player_ptr, int cmd)
             prt("", 17, 37);
         }
 
-        prt(format(_("現在の所持金:     %9ld", "Current Gold:     %9ld"), (long int)player_ptr->au), 22, 2);
+        prt(format(_("現在の所持金:     %9d", "Current Gold:     %9d"), player_ptr->au), 22, 2);
         prt(_("もう一度(Y/N)？", "Again(Y/N)?"), 18, 37);
 
         move_cursor(18, 52);
-        again = inkey();
+        auto again = inkey();
         prt("", 16, 37);
         prt("", 17, 37);
         prt("", 18, 37);
         if (wager > player_ptr->au) {
             msg_print(_("おい！金が足りないじゃないか！ここから出て行け！", "Hey! You don't have the gold - get out of here!"));
             msg_print(nullptr);
-
-            /* Get out here */
             break;
         }
-    } while ((again == 'y') || (again == 'Y'));
+
+        if ((again == 'y') || (again == 'Y')) {
+            continue;
+        }
+
+        break;
+    }
 
     prt("", 18, 37);
     if (player_ptr->au >= oldgold) {

--- a/src/mind/mind-weaponsmith.cpp
+++ b/src/mind/mind-weaponsmith.cpp
@@ -468,6 +468,7 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
         return;
     }
 
+    constexpr auto prompt = _("いくつ付加しますか？", "Enchant how many?");
     const auto attribute_flags = Smith::get_effect_tr_flags(effect);
     auto add_essence_count = 1;
     if (attribute_flags.has_any_of(TR_PVAL_FLAG_MASK)) {
@@ -480,23 +481,24 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
             }
             o_ptr->pval = 1;
         } else if (o_ptr->pval == 0) {
-            char tmp_val[8] = "1";
-            auto limit = std::min(5, smith.get_addable_count(effect, o_ptr));
-
-            if (!get_string(format(_("いくつ付加しますか？ (1-%d): ", "Enchant how many? (1-%d): "), limit), tmp_val, 1)) {
+            const auto limit = std::min(5, smith.get_addable_count(effect, o_ptr));
+            const auto num_enchants = input_value<short>(prompt, 1, limit, 1);
+            if (!num_enchants.has_value()) {
                 return;
             }
-            o_ptr->pval = static_cast<PARAMETER_VALUE>(std::clamp(atoi(tmp_val), 1, limit));
+
+            o_ptr->pval = num_enchants.value();
         }
 
         add_essence_count = o_ptr->pval;
     } else if (effect == SmithEffectType::SLAY_GLOVE) {
-        char tmp_val[8] = "1";
         const auto max_val = player_ptr->lev / 7 + 3;
-        if (!get_string(format(_("いくつ付加しますか？ (1-%d):", "Enchant how many? (1-%d):"), max_val), tmp_val, 2)) {
+        const auto num_enchants = input_value(prompt, 1, max_val, 1);
+        if (!num_enchants.has_value()) {
             return;
         }
-        add_essence_count = std::clamp(atoi(tmp_val), 1, max_val);
+
+        add_essence_count = num_enchants.value();
     }
 
     msg_format(_("エッセンスを%d個使用します。", "It will take %d essences."), use_essence * add_essence_count);

--- a/src/mind/mind-weaponsmith.cpp
+++ b/src/mind/mind-weaponsmith.cpp
@@ -482,7 +482,7 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
             o_ptr->pval = 1;
         } else if (o_ptr->pval == 0) {
             const auto limit = std::min(5, smith.get_addable_count(effect, o_ptr));
-            const auto num_enchants = input_value<short>(prompt, 1, limit, 1);
+            const auto num_enchants = input_numerics<short>(prompt, 1, limit, 1);
             if (!num_enchants.has_value()) {
                 return;
             }
@@ -493,7 +493,7 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
         add_essence_count = o_ptr->pval;
     } else if (effect == SmithEffectType::SLAY_GLOVE) {
         const auto max_val = player_ptr->lev / 7 + 3;
-        const auto num_enchants = input_value(prompt, 1, max_val, 1);
+        const auto num_enchants = input_numerics(prompt, 1, max_val, 1);
         if (!num_enchants.has_value()) {
             return;
         }

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -552,7 +552,7 @@ bool reset_recall(PlayerType *player_ptr)
     constexpr auto prompt = _("何階にセットしますか？", "Reset to which level?");
     const auto min_level = dungeons_info[select_dungeon].mindepth;
     const auto max_level = max_dlv[select_dungeon];
-    const auto reset_level_opt = input_value(prompt, min_level, max_level, player_ptr->current_floor_ptr->dun_level);
+    const auto reset_level_opt = input_numerics(prompt, min_level, max_level, player_ptr->current_floor_ptr->dun_level);
     if (!reset_level_opt.has_value()) {
         return false;
     }

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -42,6 +42,7 @@
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 #include "world/world.h"
+#include <algorithm>
 
 /*!
  * @brief テレポート・レベルが効かないモンスターであるかどうかを判定する
@@ -538,9 +539,7 @@ bool free_level_recall(PlayerType *player_ptr)
  */
 bool reset_recall(PlayerType *player_ptr)
 {
-    int select_dungeon, dummy = 0;
-
-    select_dungeon = choose_dungeon(_("をセット", "reset"), 2, 14);
+    auto select_dungeon = choose_dungeon(_("をセット", "reset"), 2, 14);
     if (ironman_downward) {
         msg_print(_("何も起こらなかった。", "Nothing happens."));
         return true;
@@ -549,37 +548,25 @@ bool reset_recall(PlayerType *player_ptr)
     if (!select_dungeon) {
         return false;
     }
-    char ppp[80];
-    constexpr auto mes = _("何階にセットしますか (%d-%d):", "Reset to which level (%d-%d): ");
-    strnfmt(ppp, sizeof(ppp), mes, (int)dungeons_info[select_dungeon].mindepth, (int)max_dlv[select_dungeon]);
-    char tmp_val[160];
-    strnfmt(tmp_val, sizeof(tmp_val), "%d", (int)std::max(player_ptr->current_floor_ptr->dun_level, 1));
 
-    if (!get_string(ppp, tmp_val, 10)) {
+    constexpr auto prompt = _("何階にセットしますか？", "Reset to which level?");
+    const auto min_level = dungeons_info[select_dungeon].mindepth;
+    const auto max_level = max_dlv[select_dungeon];
+    const auto reset_level_opt = input_value(prompt, min_level, max_level, player_ptr->current_floor_ptr->dun_level);
+    if (!reset_level_opt.has_value()) {
         return false;
     }
 
-    dummy = atoi(tmp_val);
-    if (dummy < 1) {
-        dummy = 1;
-    }
-    if (dummy > max_dlv[select_dungeon]) {
-        dummy = max_dlv[select_dungeon];
-    }
-    if (dummy < dungeons_info[select_dungeon].mindepth) {
-        dummy = dungeons_info[select_dungeon].mindepth;
-    }
-
-    max_dlv[select_dungeon] = dummy;
-
+    const auto reset_level = reset_level_opt.value();
+    max_dlv[select_dungeon] = reset_level;
     if (record_maxdepth) {
         constexpr auto note = _("フロア・リセットで", "using a scroll of reset recall");
         exe_write_diary(player_ptr, DiaryKind::TRUMP, select_dungeon, note);
     }
 #ifdef JP
-    msg_format("%sの帰還レベルを %d 階にセット。", dungeons_info[select_dungeon].name.data(), dummy);
+    msg_format("%sの帰還レベルを %d 階にセット。", dungeons_info[select_dungeon].name.data(), reset_level);
 #else
-    msg_format("Recall depth set to level %d (%d').", dummy, dummy * 50);
+    msg_format("Recall depth set to level %d (%d').", reset_level, reset_level * 50);
 #endif
     return true;
 }

--- a/src/util/string-processor.cpp
+++ b/src/util/string-processor.cpp
@@ -595,6 +595,16 @@ int strrncmp(const char *s1, const char *s2, int len)
     return 0;
 }
 
+/*
+ * @brief マルチバイト文字のダメ文字('\')を考慮しつつ文字列比較を行う
+ * @param src 比較元の文字列
+ * @param find 比較したい文字列
+ */
+bool str_find(const std::string &src, std::string_view find)
+{
+    return angband_strstr(src.data(), find) != nullptr;
+}
+
 /**
  * @brief 文字列の両端の空白を削除する
  *

--- a/src/util/string-processor.h
+++ b/src/util/string-processor.h
@@ -29,6 +29,7 @@ char *angband_strchr(concptr ptr, char ch);
 char *ltrim(char *p);
 char *rtrim(char *p);
 int strrncmp(const char *s1, const char *s2, int len);
+bool str_find(const std::string &src, std::string_view find);
 std::string str_trim(std::string_view str);
 std::string str_rtrim(std::string_view str);
 std::string str_ltrim(std::string_view str);

--- a/src/wizard/wizard-game-modifier.cpp
+++ b/src/wizard/wizard-game-modifier.cpp
@@ -107,7 +107,7 @@ void wiz_enter_quest(PlayerType *player_ptr)
 {
     auto &quest_list = QuestList::get_instance();
     const auto quest_max = enum2i(quest_list.rbegin()->first);
-    const auto quest_num = input_value("QuestID", 0, quest_max - 1, QuestId::NONE);
+    const auto quest_num = input_numerics("QuestID", 0, quest_max - 1, QuestId::NONE);
     if (!quest_num.has_value()) {
         return;
     }
@@ -143,7 +143,7 @@ void wiz_complete_quest(PlayerType *player_ptr)
 void wiz_restore_monster_max_num(MonsterRaceId r_idx)
 {
     if (!MonsterRace(r_idx).is_valid()) {
-        const auto restore_monrace_id = input_value("MonsterID", 1, monraces_info.size() - 1, MonsterRaceId::FILTHY_URCHIN);
+        const auto restore_monrace_id = input_numerics("MonsterID", 1, monraces_info.size() - 1, MonsterRaceId::FILTHY_URCHIN);
         if (!restore_monrace_id.has_value()) {
             return;
         }

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -48,6 +48,7 @@
 #include <algorithm>
 #include <limits>
 #include <sstream>
+#include <string>
 #include <tuple>
 #include <vector>
 
@@ -92,17 +93,6 @@ void display_wizard_sub_menu()
         put_str(ss.str(), r++, c);
     }
 }
-}
-
-/*!
- * @brief キャスト先の型の最小値、最大値でclampする。
- */
-template <typename T>
-T clamp_cast(int val)
-{
-    return static_cast<T>(std::clamp(val,
-        static_cast<int>(std::numeric_limits<T>::min()),
-        static_cast<int>(std::numeric_limits<T>::max())));
 }
 
 void wiz_restore_aware_flag_of_fixed_arfifact(FixedArtifactId reset_artifact_idx, bool aware = false);
@@ -470,26 +460,21 @@ static void wiz_display_item(PlayerType *player_ptr, ItemEntity *o_ptr)
  */
 static void wiz_statistics(PlayerType *player_ptr, ItemEntity *o_ptr)
 {
-    concptr q = "Rolls: %ld  Correct: %ld  Matches: %ld  Better: %ld  Worse: %ld  Other: %ld";
-    concptr p = "Enter number of items to roll: ";
-    char tmp_val[80];
-
+    constexpr auto pmt = "Roll for [n]ormal, [g]ood, or [e]xcellent treasure? ";
     if (o_ptr->is_fixed_artifact()) {
         o_ptr->get_fixed_artifact().is_generated = false;
     }
 
-    uint32_t i, matches, better, worse, other, correct;
-    uint32_t test_roll = 1000000;
-    char ch;
-    concptr quality;
-    BIT_FLAGS mode;
+    auto rolls = 1000000;
     while (true) {
-        concptr pmt = "Roll for [n]ormal, [g]ood, or [e]xcellent treasure? ";
         wiz_display_item(player_ptr, o_ptr);
+        char ch;
         if (!get_com(pmt, &ch, false)) {
             break;
         }
 
+        BIT_FLAGS mode;
+        std::string quality;
         if (ch == 'n' || ch == 'N') {
             mode = 0L;
             quality = "normal";
@@ -503,53 +488,60 @@ static void wiz_statistics(PlayerType *player_ptr, ItemEntity *o_ptr)
             break;
         }
 
-        strnfmt(tmp_val, sizeof(tmp_val), "%ld", (long int)test_roll);
-        if (get_string(p, tmp_val, 10)) {
-            test_roll = atol(tmp_val);
+        constexpr auto p = "Enter number of items to roll: ";
+        const auto rolls_opt = input_value(p, 0, MAX_INT, rolls);
+        if (rolls_opt.has_value()) {
+            rolls = rolls_opt.value();
         }
-        test_roll = std::max<uint>(1, test_roll);
-        msg_format("Creating a lot of %s items. Base level = %d.", quality, player_ptr->current_floor_ptr->dun_level);
-        msg_print(nullptr);
 
-        correct = matches = better = worse = other = 0;
-        for (i = 0; i <= test_roll; i++) {
-            if ((i < 100) || (i % 100 == 0)) {
+        constexpr auto q = "Rolls: %d  Correct: %d  Matches: %d  Better: %d  Worse: %d  Other: %d";
+        msg_format("Creating a lot of %s items. Base level = %d.", quality.data(), player_ptr->current_floor_ptr->dun_level);
+        msg_print(nullptr);
+        auto correct = 0;
+        auto matches = 0;
+        auto better = 0;
+        auto worse = 0;
+        auto other = 0;
+        auto count = 0;
+        for (; count <= rolls; count++) {
+            if ((count < 100) || (count % 100 == 0)) {
                 inkey_scan = true;
                 if (inkey()) {
                     flush();
                     break; // stop rolling
                 }
 
-                prt(format(q, i, correct, matches, better, worse, other), 0, 0);
+                prt(format(q, count, correct, matches, better, worse, other), 0, 0);
                 term_fresh();
             }
 
-            ItemEntity forge;
-            auto *q_ptr = &forge;
-            q_ptr->wipe();
-            make_object(player_ptr, q_ptr, mode);
-            if (q_ptr->is_fixed_artifact()) {
-                q_ptr->get_fixed_artifact().is_generated = false;
+            ItemEntity item;
+            if (!make_object(player_ptr, &item, mode)) {
+                continue;
             }
 
-            if (o_ptr->bi_key != q_ptr->bi_key) {
+            if (item.is_fixed_artifact()) {
+                item.get_fixed_artifact().is_generated = false;
+            }
+
+            if (o_ptr->bi_key != item.bi_key) {
                 continue;
             }
 
             correct++;
-            const auto is_same_fixed_artifact_idx = o_ptr->is_specific_artifact(q_ptr->fixed_artifact_idx);
-            if ((q_ptr->pval == o_ptr->pval) && (q_ptr->to_a == o_ptr->to_a) && (q_ptr->to_h == o_ptr->to_h) && (q_ptr->to_d == o_ptr->to_d) && is_same_fixed_artifact_idx) {
+            const auto is_same_fixed_artifact_idx = o_ptr->is_specific_artifact(item.fixed_artifact_idx);
+            if ((item.pval == o_ptr->pval) && (item.to_a == o_ptr->to_a) && (item.to_h == o_ptr->to_h) && (item.to_d == o_ptr->to_d) && is_same_fixed_artifact_idx) {
                 matches++;
-            } else if ((q_ptr->pval >= o_ptr->pval) && (q_ptr->to_a >= o_ptr->to_a) && (q_ptr->to_h >= o_ptr->to_h) && (q_ptr->to_d >= o_ptr->to_d)) {
+            } else if ((item.pval >= o_ptr->pval) && (item.to_a >= o_ptr->to_a) && (item.to_h >= o_ptr->to_h) && (item.to_d >= o_ptr->to_d)) {
                 better++;
-            } else if ((q_ptr->pval <= o_ptr->pval) && (q_ptr->to_a <= o_ptr->to_a) && (q_ptr->to_h <= o_ptr->to_h) && (q_ptr->to_d <= o_ptr->to_d)) {
+            } else if ((item.pval <= o_ptr->pval) && (item.to_a <= o_ptr->to_a) && (item.to_h <= o_ptr->to_h) && (item.to_d <= o_ptr->to_d)) {
                 worse++;
             } else {
                 other++;
             }
         }
 
-        msg_format(q, i, correct, matches, better, worse, other);
+        msg_format(q, count, correct, matches, better, worse, other);
         msg_print(nullptr);
     }
 
@@ -676,45 +668,38 @@ static void wiz_tweak_item(PlayerType *player_ptr, ItemEntity *o_ptr)
         return;
     }
 
-    concptr p = "Enter new 'pval' setting: ";
-    char tmp_val[80];
-    strnfmt(tmp_val, sizeof(tmp_val), "%d", o_ptr->pval);
-    if (!get_string(p, tmp_val, 5)) {
+    const auto pval = input_value("Enter new 'pval' setting: ", -MAX_SHORT, MAX_SHORT, o_ptr->pval);
+    if (!pval.has_value()) {
         return;
     }
 
-    o_ptr->pval = clamp_cast<int16_t>(atoi(tmp_val));
+    o_ptr->pval = pval.value();
     wiz_display_item(player_ptr, o_ptr);
-    p = "Enter new 'to_a' setting: ";
-    strnfmt(tmp_val, sizeof(tmp_val), "%d", o_ptr->to_a);
-    if (!get_string(p, tmp_val, 5)) {
+    const auto bonus_ac = input_value("Enter new AC Bonus setting: ", -MAX_SHORT, MAX_SHORT, o_ptr->to_a);
+    if (!bonus_ac.has_value()) {
         return;
     }
 
-    o_ptr->to_a = clamp_cast<int16_t>(atoi(tmp_val));
+    o_ptr->to_a = bonus_ac.value();
     wiz_display_item(player_ptr, o_ptr);
-    p = "Enter new 'to_h' setting: ";
-    strnfmt(tmp_val, sizeof(tmp_val), "%d", o_ptr->to_h);
-    if (!get_string(p, tmp_val, 5)) {
+    const auto bonus_hit = input_value("Enter new Hit Bonus setting: ", -MAX_SHORT, MAX_SHORT, o_ptr->to_h);
+    if (!bonus_hit.has_value()) {
         return;
     }
 
-    o_ptr->to_h = clamp_cast<int16_t>(atoi(tmp_val));
+    o_ptr->to_h = bonus_hit.value();
     wiz_display_item(player_ptr, o_ptr);
-    p = "Enter new 'to_d' setting: ";
-    strnfmt(tmp_val, sizeof(tmp_val), "%d", (int)o_ptr->to_d);
-    if (!get_string(p, tmp_val, 5)) {
+    const auto bonus_damage = input_value("Enter new Damage Bonus setting: ", -MAX_SHORT, MAX_SHORT, o_ptr->to_d);
+    if (!bonus_damage.has_value()) {
         return;
     }
 
-    o_ptr->to_d = clamp_cast<int16_t>(atoi(tmp_val));
+    o_ptr->to_d = bonus_damage.value();
     wiz_display_item(player_ptr, o_ptr);
 }
 
 /*!
- * @brief 検査対象のアイテムの数を変更する /
- * Change the quantity of a the item
- * @param player_ptr プレイヤーへの参照ポインタ
+ * @brief 検査対象のアイテムの数を変更する
  * @param o_ptr 変更するアイテム情報構造体の参照ポインタ
  */
 static void wiz_quantity_item(ItemEntity *o_ptr)
@@ -723,24 +708,15 @@ static void wiz_quantity_item(ItemEntity *o_ptr)
         return;
     }
 
-    int tmp_qnt = o_ptr->number;
-    char tmp_val[100];
-    strnfmt(tmp_val, sizeof(tmp_val), "%d", (int)o_ptr->number);
-    if (get_string("Quantity: ", tmp_val, 2)) {
-        int tmp_int = atoi(tmp_val);
-        if (tmp_int < 1) {
-            tmp_int = 1;
-        }
-
-        if (tmp_int > 99) {
-            tmp_int = 99;
-        }
-
-        o_ptr->number = (byte)tmp_int;
+    const auto quantity_opt = input_value("Quantity: ", 1, 99, o_ptr->number);
+    if (!quantity_opt.has_value()) {
+        return;
     }
 
+    const auto quantity = quantity_opt.value();
+    o_ptr->number = quantity;
     if (o_ptr->bi_key.tval() == ItemKindType::ROD) {
-        o_ptr->pval = o_ptr->pval * o_ptr->number / tmp_qnt;
+        o_ptr->pval = o_ptr->pval * o_ptr->number / quantity;
     }
 }
 

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -231,7 +231,7 @@ void wiz_restore_aware_flag_of_fixed_arfifact(FixedArtifactId reset_artifact_idx
         return;
     }
 
-    const auto input_artifact_id = input_value("Artifact ID", 1, max_a_idx, FixedArtifactId::GALADRIEL_PHIAL);
+    const auto input_artifact_id = input_numerics("Artifact ID", 1, max_a_idx, FixedArtifactId::GALADRIEL_PHIAL);
     if (!input_artifact_id.has_value()) {
         return;
     }
@@ -256,7 +256,7 @@ void wiz_modify_item_activation(PlayerType *player_ptr)
 
     constexpr auto min = enum2i(RandomArtActType::NONE);
     constexpr auto max = enum2i(RandomArtActType::MAX) - 1;
-    const auto act_id = input_value<RandomArtActType>("Activation ID", min, max);
+    const auto act_id = input_numerics<RandomArtActType>("Activation ID", min, max);
     if (!act_id.has_value()) {
         return;
     }
@@ -489,7 +489,7 @@ static void wiz_statistics(PlayerType *player_ptr, ItemEntity *o_ptr)
         }
 
         constexpr auto p = "Enter number of items to roll: ";
-        const auto rolls_opt = input_value(p, 0, MAX_INT, rolls);
+        const auto rolls_opt = input_numerics(p, 0, MAX_INT, rolls);
         if (rolls_opt.has_value()) {
             rolls = rolls_opt.value();
         }
@@ -668,28 +668,28 @@ static void wiz_tweak_item(PlayerType *player_ptr, ItemEntity *o_ptr)
         return;
     }
 
-    const auto pval = input_value("Enter new 'pval' setting: ", -MAX_SHORT, MAX_SHORT, o_ptr->pval);
+    const auto pval = input_numerics("Enter new 'pval' setting: ", -MAX_SHORT, MAX_SHORT, o_ptr->pval);
     if (!pval.has_value()) {
         return;
     }
 
     o_ptr->pval = pval.value();
     wiz_display_item(player_ptr, o_ptr);
-    const auto bonus_ac = input_value("Enter new AC Bonus setting: ", -MAX_SHORT, MAX_SHORT, o_ptr->to_a);
+    const auto bonus_ac = input_numerics("Enter new AC Bonus setting: ", -MAX_SHORT, MAX_SHORT, o_ptr->to_a);
     if (!bonus_ac.has_value()) {
         return;
     }
 
     o_ptr->to_a = bonus_ac.value();
     wiz_display_item(player_ptr, o_ptr);
-    const auto bonus_hit = input_value("Enter new Hit Bonus setting: ", -MAX_SHORT, MAX_SHORT, o_ptr->to_h);
+    const auto bonus_hit = input_numerics("Enter new Hit Bonus setting: ", -MAX_SHORT, MAX_SHORT, o_ptr->to_h);
     if (!bonus_hit.has_value()) {
         return;
     }
 
     o_ptr->to_h = bonus_hit.value();
     wiz_display_item(player_ptr, o_ptr);
-    const auto bonus_damage = input_value("Enter new Damage Bonus setting: ", -MAX_SHORT, MAX_SHORT, o_ptr->to_d);
+    const auto bonus_damage = input_numerics("Enter new Damage Bonus setting: ", -MAX_SHORT, MAX_SHORT, o_ptr->to_d);
     if (!bonus_damage.has_value()) {
         return;
     }
@@ -708,7 +708,7 @@ static void wiz_quantity_item(ItemEntity *o_ptr)
         return;
     }
 
-    const auto quantity_opt = input_value("Quantity: ", 1, 99, o_ptr->number);
+    const auto quantity_opt = input_numerics("Quantity: ", 1, 99, o_ptr->number);
     if (!quantity_opt.has_value()) {
         return;
     }

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -405,7 +405,7 @@ void wiz_change_status(PlayerType *player_ptr)
     for (int i = 0; i < A_MAX; i++) {
         const auto max_max_ability_score = player_ptr->stat_max_max[i];
         const auto max_ability_score = player_ptr->stat_max[i];
-        const auto new_ability_score = input_value(stat_names[i], 3, max_max_ability_score, max_ability_score);
+        const auto new_ability_score = input_numerics(stat_names[i], 3, max_max_ability_score, max_ability_score);
         if (!new_ability_score.has_value()) {
             return;
         }
@@ -417,7 +417,7 @@ void wiz_change_status(PlayerType *player_ptr)
 
     const auto unskilled = PlayerSkill::weapon_exp_at(PlayerSkillRank::UNSKILLED);
     const auto master = PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER);
-    const auto proficiency_opt = input_value(_("熟練度", "Proficiency"), unskilled, master, static_cast<short>(master));
+    const auto proficiency_opt = input_numerics(_("熟練度", "Proficiency"), unskilled, master, static_cast<short>(master));
     if (!proficiency_opt.has_value()) {
         return;
     }
@@ -447,7 +447,7 @@ void wiz_change_status(PlayerType *player_ptr)
         player_ptr->spell_exp[k] = std::min(PlayerSkill::spell_exp_at(PlayerSkillRank::EXPERT), proficiency);
     }
 
-    const auto gold = input_value("Gold: ", 0, MAX_INT, player_ptr->au);
+    const auto gold = input_numerics("Gold: ", 0, MAX_INT, player_ptr->au);
     if (!gold.has_value()) {
         return;
     }
@@ -458,7 +458,7 @@ void wiz_change_status(PlayerType *player_ptr)
         return;
     }
 
-    const auto experience_opt = input_value("Experience: ", 0, MAX_INT, player_ptr->max_exp);
+    const auto experience_opt = input_numerics("Experience: ", 0, MAX_INT, player_ptr->max_exp);
     if (!experience_opt.has_value()) {
         return;
     }
@@ -485,12 +485,12 @@ void wiz_create_feature(PlayerType *player_ptr)
 
     auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
     const int max = terrains_info.size() - 1;
-    const auto f_val1 = input_value(_("実地形ID", "FeatureID"), 0, max, g_ptr->feat);
+    const auto f_val1 = input_numerics(_("実地形ID", "FeatureID"), 0, max, g_ptr->feat);
     if (!f_val1.has_value()) {
         return;
     }
 
-    const auto f_val2 = input_value(_("偽装地形ID", "FeatureID"), 0, max, f_val1.value());
+    const auto f_val2 = input_numerics(_("偽装地形ID", "FeatureID"), 0, max, f_val1.value());
     if (!f_val2.has_value()) {
         return;
     }
@@ -521,7 +521,7 @@ static std::optional<short> select_debugging_dungeon(short initial_dungeon_id)
     }
 
     while (true) {
-        const auto dungeon_id = input_value("Jump which dungeon", DUNGEON_ANGBAND, DUNGEON_DARKNESS, initial_dungeon_id);
+        const auto dungeon_id = input_numerics("Jump which dungeon", DUNGEON_ANGBAND, DUNGEON_DARKNESS, initial_dungeon_id);
         if (!dungeon_id.has_value()) {
             return std::nullopt;
         }
@@ -547,7 +547,7 @@ static std::optional<int> select_debugging_floor(const FloorType &floor, int dun
         initial_depth = min_depth;
     }
 
-    return input_value("Jump to level", min_depth, max_depth, initial_depth);
+    return input_numerics("Jump to level", min_depth, max_depth, initial_depth);
 }
 
 /*!
@@ -658,7 +658,7 @@ static void change_birth_flags()
  */
 void wiz_reset_race(PlayerType *player_ptr)
 {
-    const auto new_race = input_value("RaceID", 0, MAX_RACES - 1, player_ptr->prace);
+    const auto new_race = input_numerics("RaceID", 0, MAX_RACES - 1, player_ptr->prace);
     if (!new_race.has_value()) {
         return;
     }
@@ -675,7 +675,7 @@ void wiz_reset_race(PlayerType *player_ptr)
  */
 void wiz_reset_class(PlayerType *player_ptr)
 {
-    const auto new_class_opt = input_value("ClassID", 0, PLAYER_CLASS_TYPE_MAX - 1, player_ptr->pclass);
+    const auto new_class_opt = input_numerics("ClassID", 0, PLAYER_CLASS_TYPE_MAX - 1, player_ptr->pclass);
     if (!new_class_opt.has_value()) {
         return;
     }
@@ -696,12 +696,12 @@ void wiz_reset_class(PlayerType *player_ptr)
  */
 void wiz_reset_realms(PlayerType *player_ptr)
 {
-    const auto new_realm1 = input_value("1st Realm (None=0)", 0, MAX_REALM - 1, player_ptr->realm1);
+    const auto new_realm1 = input_numerics("1st Realm (None=0)", 0, MAX_REALM - 1, player_ptr->realm1);
     if (!new_realm1.has_value()) {
         return;
     }
 
-    const auto new_realm2 = input_value("2nd Realm (None=0)", 0, MAX_REALM - 1, player_ptr->realm2);
+    const auto new_realm2 = input_numerics("2nd Realm (None=0)", 0, MAX_REALM - 1, player_ptr->realm2);
     if (!new_realm2.has_value()) {
         return;
     }
@@ -763,7 +763,7 @@ void wiz_dump_options(void)
  */
 void set_gametime(void)
 {
-    const auto game_time = input_value_int("Dungeon Turn", 0, w_ptr->dungeon_turn_limit - 1);
+    const auto game_time = input_integer("Dungeon Turn", 0, w_ptr->dungeon_turn_limit - 1);
     if (!game_time.has_value()) {
         return;
     }

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -57,15 +57,13 @@ static const std::vector<debug_spell_command> debug_spell_commands_list = {
 
 /*!
  * @brief コマンド入力により任意にスペル効果を起こす / Wizard spells
- * @return 実際にテレポートを行ったらTRUEを返す
+ * @param player_ptr プレイヤーへの参照ポインタ
  */
-bool wiz_debug_spell(PlayerType *player_ptr)
+void wiz_debug_spell(PlayerType *player_ptr)
 {
     char tmp_val[50] = "\0";
-    int tmp_int;
-
     if (!get_string("SPELL: ", tmp_val, 32)) {
-        return false;
+        return;
     }
 
     for (const auto &d : debug_spell_commands_list) {
@@ -76,32 +74,29 @@ bool wiz_debug_spell(PlayerType *player_ptr)
         switch (d.type) {
         case 2:
             (d.command_function.spell2.spell_function)(player_ptr);
-            return true;
-            break;
-        case 3:
-            tmp_val[0] = '\0';
-            if (!get_string("POWER:", tmp_val, 32)) {
-                return false;
+            return;
+        case 3: {
+            const auto power = input_value_int("POWER", -MAX_INT, MAX_INT);
+            if (!power.has_value()) {
+                return;
             }
-            tmp_int = atoi(tmp_val);
-            (d.command_function.spell3.spell_function)(player_ptr, tmp_int);
-            return true;
-            break;
-        case 4:
-            (d.command_function.spell4.spell_function)(player_ptr, true, &tmp_int);
-            return true;
-            break;
+
+            (d.command_function.spell3.spell_function)(player_ptr, power.value());
+            return;
+        }
+        case 4: {
+            auto count = 0;
+            (d.command_function.spell4.spell_function)(player_ptr, true, &count);
+            return;
+        }
         case 5:
             (d.command_function.spell5.spell_function)(player_ptr);
-            return true;
-            break;
+            return;
         default:
-            break;
+            msg_format("Command not found.");
+            return;
         }
     }
-
-    msg_format("Command not found.");
-    return false;
 }
 
 /*!

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -76,7 +76,7 @@ void wiz_debug_spell(PlayerType *player_ptr)
             (d.command_function.spell2.spell_function)(player_ptr);
             return;
         case 3: {
-            const auto power = input_value_int("POWER", -MAX_INT, MAX_INT);
+            const auto power = input_integer("POWER", -MAX_INT, MAX_INT);
             if (!power.has_value()) {
                 return;
             }
@@ -224,7 +224,7 @@ void wiz_summon_random_monster(PlayerType *player_ptr, int num)
 void wiz_summon_specific_monster(PlayerType *player_ptr, MonsterRaceId r_idx)
 {
     if (!MonsterRace(r_idx).is_valid()) {
-        const auto new_monrace_id = input_value("MonsterID", 1, monraces_info.size() - 1, MonsterRaceId::FILTHY_URCHIN);
+        const auto new_monrace_id = input_numerics("MonsterID", 1, monraces_info.size() - 1, MonsterRaceId::FILTHY_URCHIN);
         if (!new_monrace_id.has_value()) {
             return;
         }
@@ -245,7 +245,7 @@ void wiz_summon_specific_monster(PlayerType *player_ptr, MonsterRaceId r_idx)
 void wiz_summon_pet(PlayerType *player_ptr, MonsterRaceId r_idx)
 {
     if (!MonsterRace(r_idx).is_valid()) {
-        const auto new_monrace_id = input_value("MonsterID", 1, monraces_info.size() - 1, MonsterRaceId::FILTHY_URCHIN);
+        const auto new_monrace_id = input_numerics("MonsterID", 1, monraces_info.size() - 1, MonsterRaceId::FILTHY_URCHIN);
         if (!new_monrace_id.has_value()) {
             return;
         }
@@ -267,7 +267,7 @@ void wiz_kill_target(PlayerType *player_ptr, int initial_dam, AttributeType effe
 {
     auto dam = initial_dam;
     if (dam <= 0) {
-        const auto input_dam = input_value_int("Damage", 1, 1000000, 1000000);
+        const auto input_dam = input_integer("Damage", 1, 1000000, 1000000);
         if (!input_dam.has_value()) {
             return;
         }
@@ -290,7 +290,7 @@ void wiz_kill_target(PlayerType *player_ptr, int initial_dam, AttributeType effe
             put_str(format("%03d:%-.10s^", num, name.data()), 1 + i / 5, 1 + (i % 5) * 16);
         }
 
-        const auto input_effect_id = input_value("EffectID", 1, max - 1, idx);
+        const auto input_effect_id = input_numerics("EffectID", 1, max - 1, idx);
         if (!input_effect_id.has_value()) {
             screen_load();
             return;

--- a/src/wizard/wizard-spells.h
+++ b/src/wizard/wizard-spells.h
@@ -36,7 +36,7 @@ struct debug_spell_command {
     spell_functions command_function;
 };
 
-bool wiz_debug_spell(PlayerType *player_ptr);
+void wiz_debug_spell(PlayerType *player_ptr);
 void wiz_dimension_door(PlayerType *player_ptr);
 void wiz_summon_horde(PlayerType *player_ptr);
 void wiz_teleport_back(PlayerType *player_ptr);


### PR DESCRIPTION
※ 厳密には静的警告はget\_string() やaskfor() 周りの文字列操作部分で起きているので、その準備

概ね以下の3点を実施しました (3つ目がそこそこ重い)
ご確認下さい
- angband\_strstr() のラッピング
- 構造体の未初期化警告対応
- get\_string() のシグネチャ変更に備えたinput\_value() への呼び出し変更