### PR TITLE
修行僧で酔っ払いの薬を飲むと時々記憶を失い、その他のクラスでは記憶を失わない不具合を解消した

### DIFF
--- a/src/object-use/quaff/quaff-effects.cpp
+++ b/src/object-use/quaff/quaff-effects.cpp
@@ -274,7 +274,7 @@ bool QuaffEffects::booze()
         ident = true;
     }
 
-    if (!is_monk || !one_in_(13)) {
+    if (is_monk || !one_in_(13)) {
         return ident;
     }
 


### PR DESCRIPTION
Discord で「そろそろGood first issue でも直していこう」という話が出てきたので修正しました
ご確認下さい