### PR TITLE
静的解析警告対応 その8

### DIFF
--- a/src/artifact/random-art-generator.cpp
+++ b/src/artifact/random-art-generator.cpp
@@ -389,7 +389,7 @@ static std::string name_unnatural_random_artifact(PlayerType *player_ptr, ItemEn
         return get_random_name(*o_ptr, o_ptr->is_protector(), power_level);
     }
 
-    concptr ask_msg = _("このアーティファクトを何と名付けますか？", "What do you want to call the artifact? ");
+    constexpr auto prompt = _("このアーティファクトを何と名付けますか？", "What do you want to call the artifact? ");
     object_aware(player_ptr, o_ptr);
     object_known(o_ptr);
     o_ptr->ident |= IDENT_FULL_KNOWN;
@@ -401,16 +401,16 @@ static std::string name_unnatural_random_artifact(PlayerType *player_ptr, ItemEn
         ss << _("《", "'") << name << _("》", "'");
         return ss.str();
     };
-    char new_name[160] = "";
-    if (!input_string(ask_msg, new_name, sizeof new_name) || !new_name[0]) {
-        if (one_in_(2)) {
-            return wrap_name(get_table_sindarin_aux());
-        } else {
-            return wrap_name(get_table_name_aux());
-        }
+    const auto new_name = input_string(prompt, 160);
+    if (new_name.has_value() && !new_name->empty()) {
+        return wrap_name(new_name.value());
     }
 
-    return wrap_name(new_name);
+    if (one_in_(2)) {
+        return wrap_name(get_table_sindarin_aux());
+    }
+
+    return wrap_name(get_table_name_aux());
 }
 
 static void generate_unnatural_random_artifact(

--- a/src/artifact/random-art-generator.cpp
+++ b/src/artifact/random-art-generator.cpp
@@ -402,7 +402,7 @@ static std::string name_unnatural_random_artifact(PlayerType *player_ptr, ItemEn
         return ss.str();
     };
     char new_name[160] = "";
-    if (!get_string(ask_msg, new_name, sizeof new_name) || !new_name[0]) {
+    if (!input_string(ask_msg, new_name, sizeof new_name) || !new_name[0]) {
         if (one_in_(2)) {
             return wrap_name(get_table_sindarin_aux());
         } else {

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -463,7 +463,7 @@ void do_cmd_rest(PlayerType *player_ptr)
         concptr p = _("休憩 (0-9999, '*' で HP/MP全快, '&' で必要なだけ): ", "Rest (0-9999, '*' for HP/SP, '&' as needed): ");
         char out_val[80];
         strcpy(out_val, "&");
-        if (!get_string(p, out_val, 4)) {
+        if (!input_string(p, out_val, 4)) {
             return;
         }
 

--- a/src/cmd-action/cmd-others.cpp
+++ b/src/cmd-action/cmd-others.cpp
@@ -150,7 +150,7 @@ static void accept_winner_message(PlayerType *player_ptr)
     char buf[1024] = "";
     play_music(TERM_XTRA_MUSIC_BASIC, MUSIC_BASIC_WINNER);
     do {
-        while (!get_string(_("*勝利*メッセージ: ", "*Winning* message: "), buf, sizeof(buf))) {
+        while (!input_string(_("*勝利*メッセージ: ", "*Winning* message: "), buf, sizeof(buf))) {
             ;
         }
     } while (!get_check_strict(player_ptr, _("よろしいですか？", "Are you sure? "), CHECK_NO_HISTORY));

--- a/src/cmd-action/cmd-others.cpp
+++ b/src/cmd-action/cmd-others.cpp
@@ -147,16 +147,21 @@ static void accept_winner_message(PlayerType *player_ptr)
         return;
     }
 
-    char buf[1024] = "";
     play_music(TERM_XTRA_MUSIC_BASIC, MUSIC_BASIC_WINNER);
-    do {
-        while (!input_string(_("*勝利*メッセージ: ", "*Winning* message: "), buf, sizeof(buf))) {
-            ;
+    std::optional<std::string> buf;
+    while (true) {
+        buf = input_string(_("*勝利*メッセージ: ", "*Winning* message: "), 1024);
+        if (!buf.has_value()) {
+            continue;
         }
-    } while (!get_check_strict(player_ptr, _("よろしいですか？", "Are you sure? "), CHECK_NO_HISTORY));
 
-    if (buf[0]) {
-        player_ptr->last_message = buf;
+        if (!get_check_strict(player_ptr, _("よろしいですか？", "Are you sure? "), CHECK_NO_HISTORY)) {
+            break;
+        }
+    }
+
+    if (!buf->empty()) {
+        player_ptr->last_message = buf.value();
         msg_print(player_ptr->last_message);
     }
 }

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -350,25 +350,20 @@ static void do_name_pet(PlayerType *player_ptr)
     msg_format(_("%sに名前をつける。", "Name %s."), monster_desc(player_ptr, m_ptr, 0).data());
     msg_print(nullptr);
 
-    /* Start with nothing */
-    char out_val[20]{};
-
-    /* Use old inscription */
     auto old_name = false;
+    std::string initial_name("");
     if (m_ptr->is_named()) {
-        /* Start with the old inscription */
-        angband_strcpy(out_val, m_ptr->nickname, sizeof(out_val));
+        initial_name = m_ptr->nickname;
         old_name = true;
     }
 
-    /* Get a new inscription (possibly empty) */
-    if (!input_string(_("名前: ", "Name: "), out_val, 15)) {
+    const auto new_name = input_string(_("名前: ", "Name: "), 15, initial_name);
+    if (!new_name.has_value()) {
         return;
     }
 
-    if (out_val[0]) {
-        /* Save the inscription */
-        m_ptr->nickname = out_val;
+    if (!new_name->empty()) {
+        m_ptr->nickname = new_name.value();
         if (record_named_pet) {
             exe_write_diary(player_ptr, DiaryKind::NAMED_PET, RECORD_NAMED_PET_NAME, monster_desc(player_ptr, m_ptr, MD_INDEF_VISIBLE));
         }

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -360,7 +360,7 @@ static void do_name_pet(PlayerType *player_ptr)
         }
 
         /* Get a new inscription (possibly empty) */
-        if (get_string(_("名前: ", "Name: "), out_val, 15)) {
+        if (input_string(_("名前: ", "Name: "), out_val, 15)) {
             if (out_val[0]) {
                 /* Save the inscription */
                 m_ptr->nickname = out_val;

--- a/src/cmd-io/cmd-diary.cpp
+++ b/src/cmd-io/cmd-diary.cpp
@@ -46,9 +46,9 @@ static void display_diary(PlayerType *player_ptr)
  */
 static void add_diary_note(PlayerType *player_ptr)
 {
-    char tmp[80]{};
-    if (input_string(_("内容: ", "diary note: "), tmp, 79)) {
-        exe_write_diary(player_ptr, DiaryKind::DESCRIPTION, 0, tmp);
+    const auto input_str = input_string(_("内容: ", "diary note: "), 1000);
+    if (input_str.has_value()) {
+        exe_write_diary(player_ptr, DiaryKind::DESCRIPTION, 0, input_str.value());
     }
 }
 

--- a/src/cmd-io/cmd-diary.cpp
+++ b/src/cmd-io/cmd-diary.cpp
@@ -47,7 +47,7 @@ static void display_diary(PlayerType *player_ptr)
 static void add_diary_note(PlayerType *player_ptr)
 {
     char tmp[80]{};
-    if (get_string(_("内容: ", "diary note: "), tmp, 79)) {
+    if (input_string(_("内容: ", "diary note: "), tmp, 79)) {
         exe_write_diary(player_ptr, DiaryKind::DESCRIPTION, 0, tmp);
     }
 }

--- a/src/cmd-io/cmd-dump.cpp
+++ b/src/cmd-io/cmd-dump.cpp
@@ -50,13 +50,13 @@
  */
 void do_cmd_pref(PlayerType *player_ptr)
 {
-    char buf[80];
-    strcpy(buf, "");
-    if (!input_string(_("設定変更コマンド: ", "Pref: "), buf, 80)) {
+    const auto input_str = input_string(_("設定変更コマンド: ", "Pref: "), 80);
+    if (!input_str.has_value()) {
         return;
     }
 
-    (void)interpret_pref_file(player_ptr, buf);
+    auto buf(input_str.value());
+    (void)interpret_pref_file(player_ptr, buf.data());
 }
 
 /*
@@ -198,16 +198,13 @@ void do_cmd_colors(PlayerType *player_ptr)
  */
 void do_cmd_note(void)
 {
-    char buf[80];
-    strcpy(buf, "");
-    if (!input_string(_("メモ: ", "Note: "), buf, 60)) {
-        return;
-    }
-    if (!buf[0] || (buf[0] == ' ')) {
+    const auto note_opt = input_string(_("メモ: ", "Note: "), 60);
+    if (!note_opt.has_value() || note_opt->empty()) {
         return;
     }
 
-    msg_format(_("メモ: %s", "Note: %s"), buf);
+    const auto note(note_opt.value());
+    msg_format(_("メモ: %s", "Note: %s"), note.data());
 }
 
 /*

--- a/src/cmd-io/cmd-dump.cpp
+++ b/src/cmd-io/cmd-dump.cpp
@@ -52,7 +52,7 @@ void do_cmd_pref(PlayerType *player_ptr)
 {
     char buf[80];
     strcpy(buf, "");
-    if (!get_string(_("設定変更コマンド: ", "Pref: "), buf, 80)) {
+    if (!input_string(_("設定変更コマンド: ", "Pref: "), buf, 80)) {
         return;
     }
 
@@ -200,7 +200,7 @@ void do_cmd_note(void)
 {
     char buf[80];
     strcpy(buf, "");
-    if (!get_string(_("メモ: ", "Note: "), buf, 60)) {
+    if (!input_string(_("メモ: ", "Note: "), buf, 60)) {
         return;
     }
     if (!buf[0] || (buf[0] == ' ')) {

--- a/src/cmd-io/cmd-lore.cpp
+++ b/src/cmd-io/cmd-lore.cpp
@@ -43,8 +43,6 @@ void do_cmd_query_symbol(PlayerType *player_ptr)
     bool uniq = false;
     bool norm = false;
     bool ride = false;
-    char temp[MAX_MONSTER_NAME] = "";
-
     bool recall = false;
 
     uint16_t why = 0;
@@ -63,6 +61,7 @@ void do_cmd_query_symbol(PlayerType *player_ptr)
     }
 
     std::string buf;
+    std::string monster_name("");
     if (sym == KTRL('A')) {
         all = true;
         buf = _("全モンスターのリスト", "Full monster list.");
@@ -77,11 +76,13 @@ void do_cmd_query_symbol(PlayerType *player_ptr)
         buf = _("乗馬可能モンスターのリスト", "Ridable monster list.");
     } else if (sym == KTRL('M')) {
         all = true;
-        if (!input_string(_("名前(英語の場合小文字で可)", "Enter name:"), temp, 70)) {
-            temp[0] = 0;
+        const auto monster_name_opt = input_string(_("名前(英語の場合小文字で可)", "Enter name:"), MAX_MONSTER_NAME);
+        if (!monster_name_opt.has_value()) {
             return;
         }
-        buf = format(_("名前:%sにマッチ", "Monsters' names with \"%s\""), temp);
+
+        monster_name = monster_name_opt.value();
+        buf = format(_("名前:%sにマッチ", "Monsters' names with \"%s\""), monster_name.data());
     } else if (ident_info[ident_i]) {
         buf = format("%c - %s.", sym, ident_info[ident_i] + 2);
     } else {
@@ -89,65 +90,62 @@ void do_cmd_query_symbol(PlayerType *player_ptr)
     }
 
     prt(buf, 0, 0);
-    std::vector<MonsterRaceId> who;
-    for (const auto &[r_idx, r_ref] : monraces_info) {
-        if (!cheat_know && !r_ref.r_sights) {
+    std::vector<MonsterRaceId> monraces;
+    for (const auto &[monrace_id, monrace] : monraces_info) {
+        if (!cheat_know && !monrace.r_sights) {
             continue;
         }
 
-        if (norm && r_ref.kind_flags.has(MonsterKindType::UNIQUE)) {
+        if (norm && monrace.kind_flags.has(MonsterKindType::UNIQUE)) {
             continue;
         }
 
-        if (uniq && r_ref.kind_flags.has_not(MonsterKindType::UNIQUE)) {
+        if (uniq && monrace.kind_flags.has_not(MonsterKindType::UNIQUE)) {
             continue;
         }
 
-        if (ride && !(r_ref.flags7 & (RF7_RIDING))) {
+        if (ride && !(monrace.flags7 & (RF7_RIDING))) {
             continue;
         }
 
-        if (temp[0]) {
-            TERM_LEN xx;
-            char temp2[MAX_MONSTER_NAME];
-
-            for (xx = 0; temp[xx] && xx < MAX_MONSTER_NAME; xx++) {
+        if (!monster_name.empty()) {
+            for (size_t xx = 0; xx < monster_name.length(); xx++) {
 #ifdef JP
-                if (iskanji(temp[xx])) {
+                if (iskanji(monster_name[xx])) {
                     xx++;
                     continue;
                 }
 #endif
-                if (isupper(temp[xx])) {
-                    temp[xx] = (char)tolower(temp[xx]);
+                if (isupper(monster_name[xx])) {
+                    monster_name[xx] = (char)tolower(monster_name[xx]);
                 }
             }
 
 #ifdef JP
-            strcpy(temp2, r_ref.E_name.data());
+            auto temp2(monrace.E_name);
 #else
-            strcpy(temp2, r_ref.name.data());
+            auto temp2(monrace.name);
 #endif
-            for (xx = 0; temp2[xx] && xx < MAX_MONSTER_NAME; xx++) {
+            for (size_t xx = 0; xx < temp2.length(); xx++) {
                 if (isupper(temp2[xx])) {
                     temp2[xx] = (char)tolower(temp2[xx]);
                 }
             }
 
 #ifdef JP
-            if (str_find(temp2, temp) || str_find(r_ref.name, temp))
+            if (str_find(temp2, monster_name) || str_find(monrace.name, monster_name))
 #else
-            if (str_find(temp2, temp))
+            if (str_find(temp2, monster_name))
 #endif
-                who.push_back(r_ref.idx);
+                monraces.push_back(monrace_id);
         }
 
-        else if (all || (r_ref.d_char == sym)) {
-            who.push_back(r_ref.idx);
+        else if (all || (monrace.d_char == sym)) {
+            monraces.push_back(monrace_id);
         }
     }
 
-    if (who.empty()) {
+    if (monraces.empty()) {
         return;
     }
 
@@ -155,7 +153,7 @@ void do_cmd_query_symbol(PlayerType *player_ptr)
     query = inkey();
     prt(buf, 0, 0);
     why = 2;
-    ang_sort(player_ptr, who.data(), &why, who.size(), ang_sort_comp_hook, ang_sort_swap_hook);
+    ang_sort(player_ptr, monraces.data(), &why, monraces.size(), ang_sort_comp_hook, ang_sort_swap_hook);
     if (query == 'k') {
         why = 4;
         query = 'y';
@@ -166,18 +164,18 @@ void do_cmd_query_symbol(PlayerType *player_ptr)
     }
 
     if (why == 4) {
-        ang_sort(player_ptr, who.data(), &why, who.size(), ang_sort_comp_hook, ang_sort_swap_hook);
+        ang_sort(player_ptr, monraces.data(), &why, monraces.size(), ang_sort_comp_hook, ang_sort_swap_hook);
     }
 
-    auto i = who.size() - 1;
+    auto i = monraces.size() - 1;
     while (true) {
-        auto r_idx = who[i];
+        auto r_idx = monraces[i];
         monster_race_track(player_ptr, r_idx);
         handle_stuff(player_ptr);
         while (true) {
             if (recall) {
                 screen_save();
-                screen_roff(player_ptr, who[i], MONSTER_LORE_NORMAL);
+                screen_roff(player_ptr, monraces[i], MONSTER_LORE_NORMAL);
             }
 
             roff_top(r_idx);
@@ -198,7 +196,7 @@ void do_cmd_query_symbol(PlayerType *player_ptr)
         }
 
         if (query == '-') {
-            if (++i == who.size()) {
+            if (++i == monraces.size()) {
                 i = 0;
                 if (!expand_list) {
                     break;
@@ -206,7 +204,7 @@ void do_cmd_query_symbol(PlayerType *player_ptr)
             }
         } else {
             if (i-- == 0) {
-                i = who.size() - 1;
+                i = monraces.size() - 1;
                 if (!expand_list) {
                     break;
                 }

--- a/src/cmd-io/cmd-lore.cpp
+++ b/src/cmd-io/cmd-lore.cpp
@@ -77,7 +77,7 @@ void do_cmd_query_symbol(PlayerType *player_ptr)
         buf = _("乗馬可能モンスターのリスト", "Ridable monster list.");
     } else if (sym == KTRL('M')) {
         all = true;
-        if (!get_string(_("名前(英語の場合小文字で可)", "Enter name:"), temp, 70)) {
+        if (!input_string(_("名前(英語の場合小文字で可)", "Enter name:"), temp, 70)) {
             temp[0] = 0;
             return;
         }

--- a/src/cmd-io/cmd-process-screen.cpp
+++ b/src/cmd-io/cmd-process-screen.cpp
@@ -235,12 +235,12 @@ void exe_cmd_save_screen_html(const std::filesystem::path &path, bool need_messa
  */
 static void exe_cmd_save_screen_html_with_naming()
 {
-    char tmp[256] = "screen.html";
-    if (!input_string(_("ファイル名: ", "File name: "), tmp, 80)) {
+    const auto filename = input_string(_("ファイル名: ", "File name: "), 80, "screen.html");
+    if (!filename.has_value()) {
         return;
     }
 
-    auto path = path_build(ANGBAND_DIR_USER, tmp);
+    auto path = path_build(ANGBAND_DIR_USER, filename.value());
     msg_print(nullptr);
     exe_cmd_save_screen_html(path, true);
 }

--- a/src/cmd-io/cmd-process-screen.cpp
+++ b/src/cmd-io/cmd-process-screen.cpp
@@ -236,7 +236,7 @@ void exe_cmd_save_screen_html(const std::filesystem::path &path, bool need_messa
 static void exe_cmd_save_screen_html_with_naming()
 {
     char tmp[256] = "screen.html";
-    if (!get_string(_("ファイル名: ", "File name: "), tmp, 80)) {
+    if (!input_string(_("ファイル名: ", "File name: "), tmp, 80)) {
         return;
     }
 

--- a/src/cmd-item/cmd-item.cpp
+++ b/src/cmd-item/cmd-item.cpp
@@ -213,7 +213,6 @@ void do_cmd_uninscribe(PlayerType *player_ptr)
 void do_cmd_inscribe(PlayerType *player_ptr)
 {
     OBJECT_IDX item;
-    char out_val[MAX_INSCRIPTION + 1] = "";
     const auto q = _("どのアイテムに銘を刻みますか? ", "Inscribe which item? ");
     const auto s = _("銘を刻めるアイテムがない。", "You have nothing to inscribe.");
     auto *o_ptr = choose_object(player_ptr, &item, q, s, (USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT));
@@ -224,27 +223,26 @@ void do_cmd_inscribe(PlayerType *player_ptr)
     const auto item_name = describe_flavor(player_ptr, o_ptr, OD_OMIT_INSCRIPTION);
     msg_format(_("%sに銘を刻む。", "Inscribing %s."), item_name.data());
     msg_print(nullptr);
-    strcpy(out_val, "");
-    if (o_ptr->is_inscribed()) {
-        angband_strcpy(out_val, o_ptr->inscription.value(), MAX_INSCRIPTION);
+    const auto initial_inscription = o_ptr->is_inscribed() ? o_ptr->inscription.value() : "";
+    const auto input_inscription = input_string(_("銘: ", "Inscription: "), MAX_INSCRIPTION, initial_inscription);
+    if (!input_inscription.has_value()) {
+        return;
     }
 
-    if (input_string(_("銘: ", "Inscription: "), out_val, MAX_INSCRIPTION)) {
-        o_ptr->inscription.emplace(out_val);
-        auto &rfu = RedrawingFlagsUpdater::get_instance();
-        static constexpr auto flags_srf = {
-            StatusRecalculatingFlag::COMBINATION,
-            StatusRecalculatingFlag::BONUS,
-        };
-        rfu.set_flags(flags_srf);
-        static constexpr auto flags_swrf = {
-            SubWindowRedrawingFlag::INVENTORY,
-            SubWindowRedrawingFlag::EQUIPMENT,
-            SubWindowRedrawingFlag::FLOOR_ITEMS,
-            SubWindowRedrawingFlag::FOUND_ITEMS,
-        };
-        rfu.set_flags(flags_swrf);
-    }
+    o_ptr->inscription.emplace(input_inscription.value());
+    auto &rfu = RedrawingFlagsUpdater::get_instance();
+    static constexpr auto flags_srf = {
+        StatusRecalculatingFlag::COMBINATION,
+        StatusRecalculatingFlag::BONUS,
+    };
+    rfu.set_flags(flags_srf);
+    static constexpr auto flags_swrf = {
+        SubWindowRedrawingFlag::INVENTORY,
+        SubWindowRedrawingFlag::EQUIPMENT,
+        SubWindowRedrawingFlag::FLOOR_ITEMS,
+        SubWindowRedrawingFlag::FOUND_ITEMS,
+    };
+    rfu.set_flags(flags_swrf);
 }
 
 /*!

--- a/src/cmd-item/cmd-item.cpp
+++ b/src/cmd-item/cmd-item.cpp
@@ -229,7 +229,7 @@ void do_cmd_inscribe(PlayerType *player_ptr)
         angband_strcpy(out_val, o_ptr->inscription.value(), MAX_INSCRIPTION);
     }
 
-    if (get_string(_("銘: ", "Inscription: "), out_val, MAX_INSCRIPTION)) {
+    if (input_string(_("銘: ", "Inscription: "), out_val, MAX_INSCRIPTION)) {
         o_ptr->inscription.emplace(out_val);
         auto &rfu = RedrawingFlagsUpdater::get_instance();
         static constexpr auto flags_srf = {

--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -127,7 +127,7 @@ void do_cmd_player_status(PlayerType *player_ptr)
             process_player_name(player_ptr);
         } else if (c == 'f') {
             strnfmt(tmp, sizeof(tmp), "%s.txt", player_ptr->base_name);
-            if (get_string(_("ファイル名: ", "File name: "), tmp, 80)) {
+            if (input_string(_("ファイル名: ", "File name: "), tmp, 80)) {
                 if (tmp[0] && (tmp[0] != ' ')) {
                     update_playtime();
                     file_character(player_ptr, tmp);

--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -102,7 +102,6 @@ void do_cmd_redraw(PlayerType *player_ptr)
 void do_cmd_player_status(PlayerType *player_ptr)
 {
     int mode = 0;
-    char tmp[160];
     screen_save();
     while (true) {
         TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, MAIN_TERM_MIN_ROWS);
@@ -126,11 +125,13 @@ void do_cmd_player_status(PlayerType *player_ptr)
             get_name(player_ptr);
             process_player_name(player_ptr);
         } else if (c == 'f') {
-            strnfmt(tmp, sizeof(tmp), "%s.txt", player_ptr->base_name);
-            if (input_string(_("ファイル名: ", "File name: "), tmp, 80)) {
-                if (tmp[0] && (tmp[0] != ' ')) {
+            const auto initial_filename = format("%s.txt", player_ptr->base_name);
+            const auto input_filename = input_string(_("ファイル名: ", "File name: "), 80, initial_filename);
+            if (input_filename.has_value()) {
+                const auto &filename = str_ltrim(input_filename.value());
+                if (!filename.empty()) {
                     update_playtime();
-                    file_character(player_ptr, tmp);
+                    file_character(player_ptr, filename);
                 }
             }
         } else if (c == 'h') {

--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -103,6 +103,7 @@ void do_cmd_player_status(PlayerType *player_ptr)
 {
     int mode = 0;
     screen_save();
+    constexpr auto prompt = _("['c'で名前変更, 'f'でファイルへ書出, 'h'でモード変更, ESCで終了]", "['c' to change name, 'f' to file, 'h' to change mode, or ESC]");
     while (true) {
         TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, MAIN_TERM_MIN_ROWS);
 
@@ -114,30 +115,38 @@ void do_cmd_player_status(PlayerType *player_ptr)
             (void)display_player(player_ptr, mode);
         }
 
-        term_putstr(2, 23, -1, TERM_WHITE,
-            _("['c'で名前変更, 'f'でファイルへ書出, 'h'でモード変更, ESCで終了]", "['c' to change name, 'f' to file, 'h' to change mode, or ESC]"));
-        char c = inkey();
+        term_putstr(2, 23, -1, TERM_WHITE, prompt);
+        auto c = inkey();
         if (c == ESCAPE) {
             break;
         }
 
-        if (c == 'c') {
+        switch (c) {
+        case 'c':
             get_name(player_ptr);
             process_player_name(player_ptr);
-        } else if (c == 'f') {
+            break;
+        case 'f': {
             const auto initial_filename = format("%s.txt", player_ptr->base_name);
             const auto input_filename = input_string(_("ファイル名: ", "File name: "), 80, initial_filename);
-            if (input_filename.has_value()) {
-                const auto &filename = str_ltrim(input_filename.value());
-                if (!filename.empty()) {
-                    update_playtime();
-                    file_character(player_ptr, filename);
-                }
+            if (!input_filename.has_value()) {
+                break;
             }
-        } else if (c == 'h') {
+
+            const auto &filename = str_ltrim(input_filename.value());
+            if (!filename.empty()) {
+                update_playtime();
+                file_character(player_ptr, filename);
+            }
+
+            break;
+        }
+        case 'h':
             mode++;
-        } else {
+            break;
+        default:
             bell();
+            break;
         }
 
         msg_erase();

--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -20,6 +20,7 @@
 #include "view/display-messages.h"
 #include "view/display-player.h"
 #include "world/world.h"
+#include <optional>
 
 /*!
  * @brief 画面を再描画するコマンドのメインルーチン
@@ -96,59 +97,64 @@ void do_cmd_redraw(PlayerType *player_ptr)
     }
 }
 
+static std::optional<int> input_status_command(PlayerType *player_ptr, int page)
+{
+    auto c = inkey();
+    switch (c) {
+    case 'c':
+        get_name(player_ptr);
+        process_player_name(player_ptr);
+        return page;
+    case 'f': {
+        const auto initial_filename = format("%s.txt", player_ptr->base_name);
+        const auto input_filename = input_string(_("ファイル名: ", "File name: "), 80, initial_filename);
+        if (!input_filename.has_value()) {
+            return page;
+        }
+
+        const auto &filename = str_ltrim(input_filename.value());
+        if (!filename.empty()) {
+            update_playtime();
+            file_character(player_ptr, filename);
+        }
+
+        return page;
+    }
+    case 'h':
+        return page + 1;
+    case ESCAPE:
+        return std::nullopt;
+    default:
+        bell();
+        return page;
+    }
+}
+
 /*!
  * @brief プレイヤーのステータス表示
  */
 void do_cmd_player_status(PlayerType *player_ptr)
 {
-    int mode = 0;
+    auto page = 0;
     screen_save();
     constexpr auto prompt = _("['c'で名前変更, 'f'でファイルへ書出, 'h'でモード変更, ESCで終了]", "['c' to change name, 'f' to file, 'h' to change mode, or ESC]");
     while (true) {
         TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, MAIN_TERM_MIN_ROWS);
 
         update_playtime();
-        (void)display_player(player_ptr, mode);
-
-        if (mode == 5) {
-            mode = 0;
-            (void)display_player(player_ptr, mode);
+        (void)display_player(player_ptr, page);
+        if (page == 5) {
+            page = 0;
+            (void)display_player(player_ptr, page);
         }
 
         term_putstr(2, 23, -1, TERM_WHITE, prompt);
-        auto c = inkey();
-        if (c == ESCAPE) {
+        auto next_page = input_status_command(player_ptr, page);
+        if (!next_page.has_value()) {
             break;
         }
 
-        switch (c) {
-        case 'c':
-            get_name(player_ptr);
-            process_player_name(player_ptr);
-            break;
-        case 'f': {
-            const auto initial_filename = format("%s.txt", player_ptr->base_name);
-            const auto input_filename = input_string(_("ファイル名: ", "File name: "), 80, initial_filename);
-            if (!input_filename.has_value()) {
-                break;
-            }
-
-            const auto &filename = str_ltrim(input_filename.value());
-            if (!filename.empty()) {
-                update_playtime();
-                file_character(player_ptr, filename);
-            }
-
-            break;
-        }
-        case 'h':
-            mode++;
-            break;
-        default:
-            bell();
-            break;
-        }
-
+        page = next_page.value();
         msg_erase();
     }
 

--- a/src/core/asking-player.cpp
+++ b/src/core/asking-player.cpp
@@ -226,7 +226,7 @@ bool askfor(char *buf, int len, bool numpad_cursor)
  *
  * We clear the input, and return FALSE, on "ESCAPE".
  */
-bool get_string(std::string_view prompt, char *buf, int len)
+bool input_string(std::string_view prompt, char *buf, int len)
 {
     bool res;
     msg_print(nullptr);
@@ -457,7 +457,7 @@ std::optional<int> input_integer(std::string_view prompt, int min, int max, int 
     ss << prompt << "(" << min << "-" << max << "): ";
     auto digit = std::max(std::to_string(min).length(), std::to_string(max).length());
     while (true) {
-        if (!get_string(ss.str().data(), tmp_val, digit)) {
+        if (!input_string(ss.str().data(), tmp_val, digit)) {
             return std::nullopt;
         }
 

--- a/src/core/asking-player.cpp
+++ b/src/core/asking-player.cpp
@@ -226,14 +226,19 @@ bool askfor(char *buf, int len, bool numpad_cursor)
  *
  * We clear the input, and return FALSE, on "ESCAPE".
  */
-bool input_string(std::string_view prompt, char *buf, int len)
+std::optional<std::string> input_string(std::string_view prompt, int len, std::string_view initial_value)
 {
-    bool res;
     msg_print(nullptr);
     prt(prompt, 0, 0);
-    res = askfor(buf, len);
+    char buf[1024]{};
+    angband_strcpy(buf, initial_value, sizeof(buf));
+    const auto res = askfor(buf, len);
     prt("", 0, 0);
-    return res;
+    if (!res) {
+        return std::nullopt;
+    }
+
+    return buf;
 }
 
 /*
@@ -452,17 +457,16 @@ void pause_line(int row)
 std::optional<int> input_integer(std::string_view prompt, int min, int max, int initial_value)
 {
     std::stringstream ss;
-    char tmp_val[12] = "";
-    std::to_chars(std::begin(tmp_val), std::end(tmp_val) - 1, initial_value);
     ss << prompt << "(" << min << "-" << max << "): ";
     auto digit = std::max(std::to_string(min).length(), std::to_string(max).length());
     while (true) {
-        if (!input_string(ss.str().data(), tmp_val, digit)) {
+        const auto input_str = input_string(ss.str(), digit, std::to_string(initial_value));
+        if (!input_str.has_value()) {
             return std::nullopt;
         }
 
         try {
-            auto val = std::stoi(tmp_val);
+            auto val = std::stoi(input_str.value());
             if ((val < min) || (val > max)) {
                 msg_format(_("%dから%dの間で指定して下さい。", "It must be between %d to %d."), min, max);
                 continue;

--- a/src/core/asking-player.h
+++ b/src/core/asking-player.h
@@ -15,7 +15,7 @@
 
 class PlayerType;
 bool askfor(char *buf, int len, bool numpad_cursor = true);
-bool input_string(std::string_view prompt, char *buf, int len);
+std::optional<std::string> input_string(std::string_view prompt, int len, std::string_view initial_value = "");
 bool get_check(std::string_view prompt);
 bool get_check_strict(PlayerType *player_ptr, std::string_view prompt, BIT_FLAGS mode);
 bool get_com(std::string_view prompt, char *command, bool z_escape);

--- a/src/core/asking-player.h
+++ b/src/core/asking-player.h
@@ -15,7 +15,7 @@
 
 class PlayerType;
 bool askfor(char *buf, int len, bool numpad_cursor = true);
-bool get_string(std::string_view prompt, char *buf, int len);
+bool input_string(std::string_view prompt, char *buf, int len);
 bool get_check(std::string_view prompt);
 bool get_check_strict(PlayerType *player_ptr, std::string_view prompt, BIT_FLAGS mode);
 bool get_com(std::string_view prompt, char *command, bool z_escape);

--- a/src/core/show-file.cpp
+++ b/src/core/show-file.cpp
@@ -466,7 +466,7 @@ bool show_file(PlayerType *player_ptr, bool show_version, std::string_view name_
             FILE *ffp;
             char xtmp[81] = "";
 
-            if (!get_string(_("ファイル名: ", "File name: "), xtmp, 80)) {
+            if (!input_string(_("ファイル名: ", "File name: "), xtmp, 80)) {
                 continue;
             }
 

--- a/src/core/show-file.cpp
+++ b/src/core/show-file.cpp
@@ -463,17 +463,15 @@ bool show_file(PlayerType *player_ptr, bool show_version, std::string_view name_
         }
 
         if (skey == '|') {
-            FILE *ffp;
-            char xtmp[81] = "";
-
-            if (!input_string(_("ファイル名: ", "File name: "), xtmp, 80)) {
+            const auto xtmp = input_string(_("ファイル名: ", "File name: "), 80);
+            if (!xtmp.has_value()) {
                 continue;
             }
 
             angband_fclose(fff);
             fff = angband_fopen(path_reopen, FileOpenMode::READ);
-            const auto &path_xtemp = path_build(ANGBAND_DIR_USER, xtmp);
-            ffp = angband_fopen(path_xtemp, FileOpenMode::WRITE);
+            const auto &path_xtemp = path_build(ANGBAND_DIR_USER, xtmp.value());
+            auto *ffp = angband_fopen(path_xtemp, FileOpenMode::WRITE);
 
             if (!(fff && ffp)) {
                 msg_print(_("ファイルを開けません。", "Failed to open file."));

--- a/src/io/files-util.cpp
+++ b/src/io/files-util.cpp
@@ -70,6 +70,8 @@ void file_character(PlayerType *player_ptr, std::string_view filename)
         (void)fd_close(fd);
         if (get_check_strict(player_ptr, ss.str(), CHECK_NO_HISTORY)) {
             fd = -1;
+        } else {
+            return;
         }
     }
 

--- a/src/io/files-util.cpp
+++ b/src/io/files-util.cpp
@@ -64,11 +64,11 @@ void file_character(PlayerType *player_ptr, std::string_view filename)
     const auto &path = path_build(ANGBAND_DIR_USER, filename);
     auto fd = fd_open(path, O_RDONLY);
     if (fd >= 0) {
-        const auto &filename = path.string();
-        std::string query = _("現存するファイル ", "Replace existing file ");
-        query.append(filename).append(_(" に上書きしますか? ", "? "));
+        const auto &path_str = path.string();
+        std::stringstream ss;
+        ss << _("現存するファイル ", "Replace existing file ") << path_str << _(" に上書きしますか? ", "? ");
         (void)fd_close(fd);
-        if (get_check_strict(player_ptr, query, CHECK_NO_HISTORY)) {
+        if (get_check_strict(player_ptr, ss.str(), CHECK_NO_HISTORY)) {
             fd = -1;
         }
     }

--- a/src/io/files-util.cpp
+++ b/src/io/files-util.cpp
@@ -18,6 +18,7 @@
 #include "io/uid-checker.h"
 #include "monster-race/monster-race.h"
 #include "monster-race/race-flags1.h"
+#include "system/angband-exceptions.h"
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
@@ -58,9 +59,9 @@ std::filesystem::path debug_savefile;
  * Allow the "full" flag to dump additional info,
  * and trigger its usage from various places in the code.
  */
-errr file_character(PlayerType *player_ptr, concptr name)
+void file_character(PlayerType *player_ptr, std::string_view filename)
 {
-    const auto &path = path_build(ANGBAND_DIR_USER, name);
+    const auto &path = path_build(ANGBAND_DIR_USER, filename);
     auto fd = fd_open(path, O_RDONLY);
     if (fd >= 0) {
         const auto &filename = path.string();
@@ -78,9 +79,7 @@ errr file_character(PlayerType *player_ptr, concptr name)
     }
 
     if (!fff) {
-        prt(_("キャラクタ情報のファイルへの書き出しに失敗しました！", "Character dump failed!"), 0, 0);
-        (void)inkey();
-        return -1;
+        THROW_EXCEPTION(std::runtime_error, _("キャラクタ情報のファイルへの書き出しに失敗しました！", "Character dump failed!"));
     }
 
     screen_save();
@@ -90,7 +89,6 @@ errr file_character(PlayerType *player_ptr, concptr name)
     angband_fclose(fff);
     msg_print(_("キャラクタ情報のファイルへの書き出しに成功しました。", "Character dump successful."));
     msg_print(nullptr);
-    return 0;
 }
 
 /*!

--- a/src/io/files-util.h
+++ b/src/io/files-util.h
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <optional>
 #include <string>
+#include <string_view>
 
 extern std::filesystem::path savefile; //!< セーブファイルのフルパス
 extern std::string savefile_base; //!< セーブファイル名
@@ -27,7 +28,7 @@ extern std::filesystem::path ANGBAND_DIR_XTRA;
 class PlayerType;
 typedef void (*update_playtime_pf)(void);
 
-errr file_character(PlayerType *player_ptr, concptr name);
+void file_character(PlayerType *player_ptr, std::string_view filename);
 std::optional<std::string> get_random_line(concptr file_name, int entry);
 void read_dead_file();
 

--- a/src/io/record-play-movie.cpp
+++ b/src/io/record-play-movie.cpp
@@ -343,7 +343,7 @@ void prepare_movie_hooks(PlayerType *player_ptr)
     std::stringstream ss;
     ss << player_ptr->base_name << ".amv";
     auto movie_filename = ss.str();
-    if (!get_string(_("ムービー記録ファイル: ", "Movie file name: "), movie_filename.data(), 80)) {
+    if (!input_string(_("ムービー記録ファイル: ", "Movie file name: "), movie_filename.data(), 80)) {
         return;
     }
 

--- a/src/io/record-play-movie.cpp
+++ b/src/io/record-play-movie.cpp
@@ -342,12 +342,14 @@ void prepare_movie_hooks(PlayerType *player_ptr)
 
     std::stringstream ss;
     ss << player_ptr->base_name << ".amv";
-    auto movie_filename = ss.str();
-    if (!input_string(_("ムービー記録ファイル: ", "Movie file name: "), movie_filename.data(), 80)) {
+    auto initial_movie_filename = ss.str();
+    constexpr auto prompt = _("ムービー記録ファイル: ", "Movie file name: ");
+    const auto movie_filename = input_string(prompt, 80, initial_movie_filename.data());
+    if (!movie_filename.has_value()) {
         return;
     }
 
-    const auto &path = path_build(ANGBAND_DIR_USER, movie_filename);
+    const auto &path = path_build(ANGBAND_DIR_USER, movie_filename.value());
     auto fd = fd_open(path, O_RDONLY);
     if (fd >= 0) {
         const auto &filename = path.string();

--- a/src/market/building-monster.cpp
+++ b/src/market/building-monster.cpp
@@ -32,10 +32,7 @@ bool research_mon(PlayerType *player_ptr)
     bool all = false;
     bool uniq = false;
     bool norm = false;
-    char temp[MAX_MONSTER_NAME] = "";
-
     screen_save();
-
     char sym;
     if (!get_com(
             _("モンスターの文字を入力して下さい(記号 or ^A全,^Uユ,^N非ユ,^M名前):", "Enter character to be identified(^A:All,^U:Uniqs,^N:Non uniqs,^M:Name): "),
@@ -53,8 +50,8 @@ bool research_mon(PlayerType *player_ptr)
         }
     }
 
-    /* XTRA HACK WHATSEARCH */
     std::string buf;
+    std::string monster_name("");
     if (sym == KTRL('A')) {
         all = true;
         buf = _("全モンスターのリスト", "Full monster list.");
@@ -66,27 +63,22 @@ bool research_mon(PlayerType *player_ptr)
         buf = _("ユニーク外モンスターのリスト", "Non-unique monster list.");
     } else if (sym == KTRL('M')) {
         all = true;
-        if (!input_string(_("名前(英語の場合小文字で可)", "Enter name:"), temp, 70)) {
-            temp[0] = 0;
+        const auto monster_name_opt = input_string(_("名前(英語の場合小文字で可)", "Enter name:"), MAX_MONSTER_NAME);
+        if (!monster_name_opt.has_value()) {
             screen_load();
-
             return false;
         }
 
-        buf = format(_("名前:%sにマッチ", "Monsters' names with \"%s\""), temp);
+        monster_name = monster_name_opt.value();
+        buf = format(_("名前:%sにマッチ", "Monsters' names with \"%s\""), monster_name.data());
     } else if (ident_info[ident_i]) {
         buf = format("%c - %s.", sym, ident_info[ident_i] + 2);
     } else {
         buf = format("%c - %s", sym, _("無効な文字", "Unknown Symbol"));
     }
 
-    /* Display the result */
     prt(buf, 16, 10);
-
-    /* Allocate the "who" array */
-    std::vector<MonsterRaceId> who;
-
-    /* Collect matching monsters */
+    std::vector<MonsterRaceId> monraces;
     for (const auto &[monrace_id, monrace] : monraces_info) {
         if (!MonsterRace(monrace_id).is_valid()) {
             continue;
@@ -103,16 +95,16 @@ bool research_mon(PlayerType *player_ptr)
         }
 
         /* 名前検索 */
-        if (temp[0]) {
-            for (int xx = 0; temp[xx] && xx < 80; xx++) {
+        if (!monster_name.empty()) {
+            for (size_t xx = 0; (xx < monster_name.length()); xx++) {
 #ifdef JP
-                if (iskanji(temp[xx])) {
+                if (iskanji(monster_name[xx])) {
                     xx++;
                     continue;
                 }
 #endif
-                if (isupper(temp[xx])) {
-                    temp[xx] = (char)tolower(temp[xx]);
+                if (isupper(monster_name[xx])) {
+                    monster_name[xx] = (char)tolower(monster_name[xx]);
                 }
             }
 
@@ -124,17 +116,17 @@ bool research_mon(PlayerType *player_ptr)
             }
 
 #ifdef JP
-            if (str_find(temp2, temp) || str_find(monrace.name, temp))
+            if (str_find(temp2, monster_name) || str_find(monrace.name, monster_name))
 #else
-            if (str_find(temp2, temp))
+            if (str_find(temp2, monster_name))
 #endif
-                who.push_back(monrace_id);
+                monraces.push_back(monrace_id);
         } else if (all || (monrace.d_char == sym)) {
-            who.push_back(monrace_id);
+            monraces.push_back(monrace_id);
         }
     }
 
-    if (who.empty()) {
+    if (monraces.empty()) {
         screen_load();
 
         return false;
@@ -144,21 +136,21 @@ bool research_mon(PlayerType *player_ptr)
     char query = 'y';
 
     if (why) {
-        ang_sort(player_ptr, who.data(), &why, who.size(), ang_sort_comp_hook, ang_sort_swap_hook);
+        ang_sort(player_ptr, monraces.data(), &why, monraces.size(), ang_sort_comp_hook, ang_sort_swap_hook);
     }
 
     uint i;
     static int old_sym = '\0';
     static uint old_i = 0;
-    if (old_sym == sym && old_i < who.size()) {
+    if (old_sym == sym && old_i < monraces.size()) {
         i = old_i;
     } else {
-        i = who.size() - 1;
+        i = monraces.size() - 1;
     }
 
     notpicked = true;
     while (notpicked) {
-        auto r_idx = who[i];
+        auto r_idx = monraces[i];
         roff_top(r_idx);
         term_addstr(-1, TERM_WHITE, _(" ['r'思い出, ' 'で続行, ESC]", " [(r)ecall, ESC, space to continue]"));
         while (true) {
@@ -185,7 +177,7 @@ bool research_mon(PlayerType *player_ptr)
         }
 
         if (query == '-') {
-            if (++i == who.size()) {
+            if (++i == monraces.size()) {
                 i = 0;
                 if (!expand_list) {
                     break;
@@ -196,7 +188,7 @@ bool research_mon(PlayerType *player_ptr)
         }
 
         if (i-- == 0) {
-            i = who.size() - 1;
+            i = monraces.size() - 1;
             if (!expand_list) {
                 break;
             }

--- a/src/market/building-monster.cpp
+++ b/src/market/building-monster.cpp
@@ -66,7 +66,7 @@ bool research_mon(PlayerType *player_ptr)
         buf = _("ユニーク外モンスターのリスト", "Non-unique monster list.");
     } else if (sym == KTRL('M')) {
         all = true;
-        if (!get_string(_("名前(英語の場合小文字で可)", "Enter name:"), temp, 70)) {
+        if (!input_string(_("名前(英語の場合小文字で可)", "Enter name:"), temp, 70)) {
             temp[0] = 0;
             screen_load();
 

--- a/src/market/play-gamble.h
+++ b/src/market/play-gamble.h
@@ -1,4 +1,4 @@
 ﻿#pragma once
 
 class PlayerType;
-bool gamble_comm(PlayerType *player_ptr, int cmd);
+void gamble_comm(PlayerType *player_ptr, int cmd);

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -475,11 +475,11 @@ int take_hit(PlayerType *player_ptr, int damage_type, int damage, std::string_vi
                 angband_strcpy(player_last_words, death_message, max_last_words);
                 do {
 #ifdef JP
-                    while (!get_string(winning_seppuku ? "辞世の句: " : "断末魔の叫び: ", player_last_words, max_last_words)) {
+                    while (!input_string(winning_seppuku ? "辞世の句: " : "断末魔の叫び: ", player_last_words, max_last_words)) {
                         ;
                     }
 #else
-                    while (!get_string("Last words: ", player_last_words, max_last_words)) {
+                    while (!input_string("Last words: ", player_last_words, max_last_words)) {
                         ;
                     }
 #endif

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -462,30 +462,28 @@ int take_hit(PlayerType *player_ptr, int damage_type, int damage, std::string_vi
 
                 msg_print(nullptr);
             } else {
-                std::optional<std::string> opt_death_message;
+                std::optional<std::string> death_message_opt;
                 if (winning_seppuku) {
-                    opt_death_message = get_random_line(_("seppuku_j.txt", "seppuku.txt"), 0);
+                    death_message_opt = get_random_line(_("seppuku_j.txt", "seppuku.txt"), 0);
                 } else {
-                    opt_death_message = get_random_line(_("death_j.txt", "death.txt"), 0);
+                    death_message_opt = get_random_line(_("death_j.txt", "death.txt"), 0);
                 }
 
-                auto &death_message = opt_death_message.value();
+                auto &death_message = death_message_opt.value();
                 constexpr auto max_last_words = 1024;
-                char player_last_words[max_last_words]{};
-                angband_strcpy(player_last_words, death_message, max_last_words);
-                do {
-#ifdef JP
-                    while (!input_string(winning_seppuku ? "辞世の句: " : "断末魔の叫び: ", player_last_words, max_last_words)) {
-                        ;
+                const auto prompt = winning_seppuku ? _("辞世の句: ", "Haiku") : _("断末魔の叫び: ", "Last words");
+                while (true) {
+                    const auto input_last_words = input_string(prompt, max_last_words, death_message);
+                    if (!input_last_words.has_value()) {
+                        continue;
                     }
-#else
-                    while (!input_string("Last words: ", player_last_words, max_last_words)) {
-                        ;
-                    }
-#endif
-                } while (winning_seppuku && !get_check_strict(player_ptr, _("よろしいですか？", "Are you sure? "), CHECK_NO_HISTORY));
 
-                death_message = player_last_words;
+                    if (get_check_strict(player_ptr, _("よろしいですか？", "Are you sure? "), CHECK_NO_HISTORY)) {
+                        death_message = input_last_words.value();
+                        break;
+                    }
+                }
+
                 if (death_message.empty()) {
 #ifdef JP
                     death_message = format("あなたは%sました。", android ? "壊れ" : "死に");

--- a/src/player/process-death.cpp
+++ b/src/player/process-death.cpp
@@ -345,7 +345,7 @@ static void export_player_info(PlayerType *player_ptr)
         }
 
         screen_save();
-        (void)file_character(player_ptr, out_val);
+        file_character(player_ptr, out_val);
         screen_load();
     }
 }
@@ -359,13 +359,10 @@ static void file_character_auto(PlayerType *player_ptr)
     struct tm *now_tm = localtime(&now_t);
 
     char datetime[32];
-    char filename[128];
-
     strftime(datetime, sizeof(datetime), "%Y-%m-%d_%H%M%S", now_tm);
-    strnfmt(filename, sizeof(filename), "%s_Autodump_%s.txt", p_ptr->name, datetime);
-
     screen_save();
-    (void)file_character(player_ptr, filename);
+    const auto filename = format("%s_Autodump_%s.txt", player_ptr->name, datetime);
+    file_character(player_ptr, filename);
     screen_load();
 }
 

--- a/src/player/process-name.cpp
+++ b/src/player/process-name.cpp
@@ -135,7 +135,7 @@ void get_name(PlayerType *player_ptr)
     char tmp[64];
     strcpy(tmp, player_ptr->name);
 
-    if (get_string(_("キャラクターの名前を入力して下さい: ", "Enter a name for your character: "), tmp, 15)) {
+    if (input_string(_("キャラクターの名前を入力して下さい: ", "Enter a name for your character: "), tmp, 15)) {
         strcpy(player_ptr->name, tmp);
     }
 

--- a/src/player/process-name.cpp
+++ b/src/player/process-name.cpp
@@ -132,28 +132,27 @@ void process_player_name(PlayerType *player_ptr, bool is_new_savefile)
  */
 void get_name(PlayerType *player_ptr)
 {
-    char tmp[64];
-    strcpy(tmp, player_ptr->name);
-
-    if (input_string(_("キャラクターの名前を入力して下さい: ", "Enter a name for your character: "), tmp, 15)) {
-        strcpy(player_ptr->name, tmp);
+    std::string initial_name(player_ptr->name);
+    const auto max_name_size = sizeof(player_ptr->name);
+    constexpr auto prompt = _("キャラクターの名前を入力して下さい: ", "Enter a name for your character: ");
+    const auto name = input_string(prompt, max_name_size, initial_name);
+    if (name.has_value() && !name->empty()) {
+        angband_strcpy(player_ptr->name, name.value(), max_name_size);
+    } else {
+        angband_strcpy(player_ptr->name, "PLAYER", max_name_size);
     }
 
-    if (strlen(player_ptr->name) == 0) {
-        strcpy(player_ptr->name, "PLAYER");
-    }
-
-    strcpy(tmp, ap_ptr->title);
+    std::stringstream ss;
+    ss << ap_ptr->title;
 #ifdef JP
     if (ap_ptr->no == 1) {
-        strcat(tmp, "の");
+        ss << "の";
     }
 #else
-    strcat(tmp, " ");
+    ss << " ";
 #endif
-    strcat(tmp, player_ptr->name);
-
+    ss << player_ptr->name;
     term_erase(34, 1, 255);
-    c_put_str(TERM_L_BLUE, tmp, 1, 34);
+    c_put_str(TERM_L_BLUE, ss.str(), 1, 34);
     clear_from(22);
 }

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -840,7 +840,7 @@ static void wishing_puff_of_smoke(void)
  */
 WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, bool allow_ego, bool confirm)
 {
-    concptr fixed_str[] = {
+    const std::array<std::string, _(4, 6)> fixed_expressions = {
 #ifdef JP
         "燃えない",
         "錆びない",
@@ -854,20 +854,19 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
         "corrodeproof",
         "fixed",
 #endif
-        nullptr,
     };
 
     ItemEntity forge;
     auto *o_ptr = &forge;
-    bool wish_art = false;
-    bool wish_randart = false;
-    bool wish_ego = false;
-    bool exam_base = true;
-    bool ok_art = randint0(100) < prob;
-    bool ok_ego = randint0(100) < 50 + prob;
-    bool must = prob < 0;
-    bool blessed = false;
-    bool fixed = true;
+    auto wish_art = false;
+    auto wish_randart = false;
+    auto wish_ego = false;
+    auto exam_base = true;
+    auto ok_art = randint0(100) < prob;
+    auto ok_ego = randint0(100) < 50 + prob;
+    auto must = prob < 0;
+    auto blessed = false;
+    auto fixed = true;
 
     std::string pray;
     while (true) {
@@ -907,9 +906,9 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
         blessed = true;
     }
 
-    for (int i = 0; fixed_str[i] != nullptr; i++) {
-        int len = strlen(fixed_str[i]);
-        if (!strncmp(str, fixed_str[i], len)) {
+    for (const auto &expression : fixed_expressions) {
+        auto len = expression.length();
+        if (!std::string_view(str).starts_with(expression)) {
             str = ltrim(str + len);
             fixed = true;
             break;
@@ -950,10 +949,10 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
         msg_format("Wishing %s....", pray.data());
     }
 
-    std::vector<short> k_ids;
-    std::vector<EgoType> e_ids;
+    std::vector<short> baseitem_ids;
+    std::vector<EgoType> ego_ids;
     if (exam_base) {
-        int max_len = 0;
+        auto max_len = 0;
         for (const auto &baseitem : baseitems_info) {
             if (baseitem.idx == 0 || baseitem.name.empty()) {
                 continue;
@@ -973,14 +972,14 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
             const int len = item_name.length();
             if (std::string(str).find(item_name) != std::string::npos) {
                 if (len > max_len) {
-                    k_ids.push_back(baseitem.idx);
+                    baseitem_ids.push_back(baseitem.idx);
                     max_len = len;
                 }
             }
         }
 
-        if (allow_ego && k_ids.size() == 1) {
-            short bi_id = k_ids.back();
+        if (allow_ego && baseitem_ids.size() == 1) {
+            short bi_id = baseitem_ids.back();
             o_ptr->prep(bi_id);
 
             for (const auto &[e_idx, ego] : egos_info) {
@@ -1002,20 +1001,20 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
                         continue;
                     }
 
-                    e_ids.push_back(ego.idx);
+                    ego_ids.push_back(ego.idx);
                 }
             }
         }
     }
 
-    std::vector<FixedArtifactId> a_ids;
+    std::vector<FixedArtifactId> artifact_ids;
 
     if (allow_art) {
         char a_desc[MAX_NLEN] = "\0";
         char *a_str = a_desc;
 
         int len;
-        int mlen = 0;
+        auto mlen = 0;
         for (const auto &[a_idx, artifact] : artifacts_info) {
             if (a_idx == FixedArtifactId::NONE || artifact.name.empty()) {
                 continue;
@@ -1059,7 +1058,7 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
             /* remove quotes */
             if (a_str[0] == '\'') {
                 a_str += 1;
-                char *s = strchr(a_desc, '\'');
+                auto *s = angband_strchr(a_desc, '\'');
                 *s = '\0';
             }
             /* remove 'of ' */
@@ -1079,7 +1078,7 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
                 if (!strcmp(str, l.at(c))) {
                     len = strlen(l.at(c));
                     if (len > mlen) {
-                        a_ids.push_back(a_idx);
+                        artifact_ids.push_back(a_idx);
                         mlen = len;
                     }
                 }
@@ -1087,13 +1086,13 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
         }
     }
 
-    if (w_ptr->wizard && (a_ids.size() > 1 || e_ids.size() > 1)) {
+    if (w_ptr->wizard && ((artifact_ids.size() > 1) || (ego_ids.size() > 1))) {
         msg_print(_("候補が多すぎる！", "Too many matches!"));
         return WishResultType::FAIL;
     }
 
-    if (a_ids.size() == 1) {
-        const auto a_idx = a_ids.back();
+    if (artifact_ids.size() == 1) {
+        const auto a_idx = artifact_ids.back();
         const auto &artifact = ArtifactsInfo::get_instance().get_artifact(a_idx);
         if (must || (ok_art && !artifact.is_generated)) {
             (void)create_named_art(player_ptr, a_idx, player_ptr->y, player_ptr->x);
@@ -1104,13 +1103,13 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
         return WishResultType::ARTIFACT;
     }
 
-    if (!allow_ego && (wish_ego || e_ids.size() > 0)) {
+    if (!allow_ego && (wish_ego || ego_ids.size() > 0)) {
         msg_print(_("エゴアイテムは願えない！", "Can not wish ego item."));
         return WishResultType::NOTHING;
     }
 
-    if (k_ids.size() == 1) {
-        const auto bi_id = k_ids.back();
+    if (baseitem_ids.size() == 1) {
+        const auto bi_id = baseitem_ids.back();
         const auto &baseitem = baseitems_info[bi_id];
         auto a_idx = FixedArtifactId::NONE;
         if (baseitem.gen_flags.has(ItemGenerationTraitType::INSTA_ART)) {
@@ -1152,15 +1151,15 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
         }
 
         WishResultType res = WishResultType::NOTHING;
-        if (allow_ego && (wish_ego || e_ids.size() > 0)) {
+        if (allow_ego && (wish_ego || ego_ids.size() > 0)) {
             if (must || ok_ego) {
-                if (e_ids.size() > 0) {
+                if (ego_ids.size() > 0) {
                     o_ptr->prep(bi_id);
-                    o_ptr->ego_idx = e_ids[0];
+                    o_ptr->ego_idx = ego_ids[0];
                     apply_ego(o_ptr, player_ptr->current_floor_ptr->base_level);
                 } else {
-                    int max_roll = 1000;
-                    int i = 0;
+                    auto max_roll = 1000;
+                    auto i = 0;
                     for (i = 0; i < max_roll; i++) {
                         o_ptr->prep(bi_id);
                         ItemMagicApplier(player_ptr, o_ptr, baseitem.level, AM_GREAT | AM_NO_FIXED_ART).execute();
@@ -1172,8 +1171,8 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
                             break;
                         }
 
-                        EgoType e_idx = EgoType::NONE;
-                        for (auto e : e_ids) {
+                        auto e_idx = EgoType::NONE;
+                        for (auto e : ego_ids) {
                             if (o_ptr->ego_idx == e) {
                                 e_idx = e;
                                 break;
@@ -1196,13 +1195,14 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
 
             res = WishResultType::EGO;
         } else {
-            for (int i = 0; i < 100; i++) {
+            for (auto i = 0; i < 100; i++) {
                 o_ptr->prep(bi_id);
                 ItemMagicApplier(player_ptr, o_ptr, 0, AM_NO_FIXED_ART).execute();
                 if (!o_ptr->is_cursed()) {
                     break;
                 }
             }
+
             res = WishResultType::NORMAL;
         }
 
@@ -1216,7 +1216,6 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
         }
 
         (void)drop_near(player_ptr, o_ptr, -1, player_ptr->y, player_ptr->x);
-
         return res;
     }
 

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -872,7 +872,7 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
     bool fixed = true;
 
     while (1) {
-        if (get_string(_("何をお望み？ ", "For what do you wish?"), buf, (MAX_NLEN - 1))) {
+        if (input_string(_("何をお望み？ ", "For what do you wish?"), buf, (MAX_NLEN - 1))) {
             break;
         }
         if (confirm) {

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -61,13 +61,13 @@ static const std::vector<debug_spell_command> debug_spell_commands_list = {
  */
 void wiz_debug_spell(PlayerType *player_ptr)
 {
-    char tmp_val[50] = "\0";
-    if (!input_string("SPELL: ", tmp_val, 32)) {
+    const auto spell = input_string("SPELL: ", 50);
+    if (!spell.has_value()) {
         return;
     }
 
     for (const auto &d : debug_spell_commands_list) {
-        if (strcmp(tmp_val, d.command_name) != 0) {
+        if (spell.value() != d.command_name) {
             continue;
         }
 

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -62,7 +62,7 @@ static const std::vector<debug_spell_command> debug_spell_commands_list = {
 void wiz_debug_spell(PlayerType *player_ptr)
 {
     char tmp_val[50] = "\0";
-    if (!get_string("SPELL: ", tmp_val, 32)) {
+    if (!input_string("SPELL: ", tmp_val, 32)) {
         return;
     }
 


### PR DESCRIPTION
主にget\_string() 周りのリファクタリングです
numerics と同様に、input\_string() へ改名しています

取り敢えず以下の項目は確認済です (CIに諸々チェックさせたいので先出し)：
- アーティファクト命名
- ペット命名
- 休憩