### PR TITLE
[Chore] MSVCでのビルドテストを行うワークフロー

### DIFF
--- a/.github/workflows/build-test-with-msvc.yml
+++ b/.github/workflows/build-test-with-msvc.yml
@@ -1,0 +1,30 @@
+﻿name: Build test with MSVC
+on:
+  workflow_call:
+
+  # 手動トリガーを許可
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-2022
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1
+
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v1
+
+      - name: Restore Nuget Packages
+        run: |
+          NuGet restore .\Hengband\Hengband.sln
+
+      - name: Run build test
+        run: |
+          MSBuild -warnAsError .\Hengband\Hengband.sln /t:Rebuild /p:Configuration=Debug

--- a/.github/workflows/pull-request-status-check.yml
+++ b/.github/workflows/pull-request-status-check.yml
@@ -51,3 +51,8 @@ jobs:
       configure-opts: "--disable-japanese"
       distcheck: true
       use-ccache: true
+
+  build_test_with_msvc:
+    name: Build test with MSVC
+    needs: [check_bom, check_format]
+    uses: ./.github/workflows/build-test-with-msvc.yml

--- a/.github/workflows/pull-request-status-check.yml
+++ b/.github/workflows/pull-request-status-check.yml
@@ -24,7 +24,6 @@ jobs:
 
   build_test_clang_without_pch:
     name: Build Japanese version with clang (without using pre-compiled headers)
-    needs: [check_bom, check_format]
     uses: ./.github/workflows/build-with-autotools.yml
     with:
       cxx: clang++-14
@@ -54,5 +53,4 @@ jobs:
 
   build_test_with_msvc:
     name: Build test with MSVC
-    needs: [check_bom, check_format]
     uses: ./.github/workflows/build-test-with-msvc.yml

--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -122,7 +122,7 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <TargetMachine>MachineX86</TargetMachine>
-      <AdditionalDependencies>winmm.lib;gdiplus.lib;Ws2_32.lib;Wldap32.lib;Crypt32.lib;Normaliz.lib;curl\lib\libcurl_a.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>winmm.lib;gdiplus.lib;Ws2_32.lib;Wldap32.lib;Crypt32.lib;Normaliz.lib;curl\lib\libcurl_a_debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ShowProgress>LinkVerbose</ShowProgress>
       <SubSystem>Windows</SubSystem>
     </Link>
@@ -155,7 +155,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <TargetMachine>MachineX86</TargetMachine>
       <ShowProgress>LinkVerbose</ShowProgress>
-      <AdditionalDependencies>winmm.lib;gdiplus.lib;Ws2_32.lib;Wldap32.lib;Crypt32.lib;Normaliz.lib;curl\lib\libcurl_a.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>winmm.lib;gdiplus.lib;Ws2_32.lib;Wldap32.lib;Crypt32.lib;Normaliz.lib;curl\lib\libcurl_a_debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>

--- a/Hengband/Hengband/curl/lib/libcurl_a_debug.lib
+++ b/Hengband/Hengband/curl/lib/libcurl_a_debug.lib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a5e2c366e9dad9a4712693b360a34e003de034723b3ec16010c894bf6a64fdf
+size 11150452

--- a/Makefile.am
+++ b/Makefile.am
@@ -17,6 +17,7 @@ visual_studio_files = \
 	Hengband/Hengband/curl/include/curl/urlapi.h \
 	Hengband/Hengband/curl/include/curl/websockets.h \
 	Hengband/Hengband/curl/lib/libcurl_a.lib \
+	Hengband/Hengband/curl/lib/libcurl_a_debug.lib \
 	Hengband/Hengband/Hengband.vcxproj \
 	Hengband/Hengband/Hengband.vcxproj.filters \
 	Hengband/Hengband/packages.config


### PR DESCRIPTION
#3470 のMSVCでのビルドテストの実装。

自動リリースはいろいろ調整が必要になると思われるので、とりあえず簡単に追加できそうなビルドテストを試す。
実際にビルドテストする設定でCIを走らせてみるため、一旦ドラフトで提出。

※わざとMSVCのみで警告がでるようにソースを一部編集してある。