### PR TITLE
[Feature] SHA-256ハッシュ値計算クラス

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -625,6 +625,7 @@
     <ClCompile Include="..\..\src\timed-effect\player-stun.cpp" />
     <ClCompile Include="..\..\src\timed-effect\timed-effects.cpp" />
     <ClCompile Include="..\..\src\util\rng-xoshiro.cpp" />
+    <ClCompile Include="..\..\src\util\sha256.cpp" />
     <ClCompile Include="..\..\src\view\display-inventory.cpp" />
     <ClCompile Include="..\..\src\view\display-map.cpp" />
     <ClCompile Include="..\..\src\view\display-self-info.cpp" />
@@ -1817,6 +1818,7 @@
     <ClInclude Include="..\..\src\util\angband-files.h" />
     <ClInclude Include="..\..\src\util\object-sort.h" />
     <ClInclude Include="..\..\src\util\rng-xoshiro.h" />
+    <ClInclude Include="..\..\src\util\sha256.h" />
     <ClInclude Include="..\..\src\util\string-processor.h" />
     <ClInclude Include="..\..\src\view\display-birth.h" />
     <ClInclude Include="..\..\src\view\display-inventory.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2484,6 +2484,9 @@
     <ClCompile Include="..\..\src\net\http-client.cpp">
       <Filter>net</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\util\sha256.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5377,6 +5380,9 @@
       <Filter>net</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\util\finalizer.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\sha256.h">
       <Filter>util</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -972,6 +972,7 @@ hengband_SOURCES = \
 	util/point-2d.h \
 	util/probability-table.h \
 	util/rng-xoshiro.cpp util/rng-xoshiro.h \
+	util/sha256.cpp util/sha256.h \
 	util/sort.cpp util/sort.h \
 	util/string-processor.cpp util/string-processor.h \
 	\
@@ -1045,6 +1046,7 @@ EXTRA_hengband_SOURCES = \
 	main-win/main-win-tokenizer.cpp main-win/main-win-tokenizer.h \
 	main-win/main-win-utils.cpp main-win/main-win-utils.h \
 	main-win/wav-reader.cpp main-win/wav-reader.h \
+	test/test-sha256.cpp \
 	wall.bmp \
 	stdafx.cpp stdafx.h
 

--- a/src/test/test-sha256.cpp
+++ b/src/test/test-sha256.cpp
@@ -1,0 +1,111 @@
+﻿/*!
+ * @brief sha256ハッシュ値計算クラスのテストプログラム
+ *
+ * srcディレクトリで以下のコマンドでコンパイルして実行する
+ *
+ * g++ -std=c++20 -I. term/z-util.cpp term/z-form.cpp system/angband-version.cpp util/sha256.cpp test/test-sha256.cpp
+ *
+ * 引数を指定した場合は、そのファイルのハッシュ値を計算する
+ * 引数がない場合は、RFC 6234のテストドライバより抜粋したSHA-256のテストパターンのハッシュ値を計算して比較する
+ */
+
+#include "util/sha256.h"
+
+#include <cassert>
+#include <iostream>
+#include <span>
+#include <string_view>
+
+/*
+ * RFC 6234 で定義されているテストパターン
+ */
+#define TEST1 "abc"
+#define TEST2_1 \
+    "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
+#define TEST2_2a \
+    "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
+#define TEST2_2b \
+    "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu"
+#define TEST2_2 TEST2_2a TEST2_2b
+#define TEST3 "a" /* times 1000000 */
+#define TEST4a "01234567012345670123456701234567"
+#define TEST4b "01234567012345670123456701234567"
+/* an exact multiple of 512 bits */
+#define TEST4 TEST4a TEST4b /* times 10 */
+
+#define TEST7_256 \
+    "\xbe\x27\x46\xc6\xdb\x52\x76\x5f\xdb\x2f\x88\x70\x0f\x9a\x73"
+#define TEST8_256 \
+    "\xe3\xd7\x25\x70\xdc\xdd\x78\x7c\xe3\x88\x7a\xb2\xcd\x68\x46\x52"
+#define TEST9_256                                                      \
+    "\x3e\x74\x03\x71\xc8\x10\xc2\xb9\x9f\xc0\x4e\x80\x49\x07\xef\x7c" \
+    "\xf2\x6b\xe2\x8b\x57\xcb\x58\xa3\xe2\xf3\xc0\x07\x16\x6e\x49\xc1" \
+    "\x2e\x9b\xa3\x4c\x01\x04\x06\x91\x29\xea\x76\x15\x64\x25\x45\x70" \
+    "\x3a\x2b\xd9\x01\xe1\x6e\xb0\xe0\x5d\xeb\xa0\x14\xeb\xff\x64\x06" \
+    "\xa0\x7d\x54\x36\x4e\xff\x74\x2d\xa7\x79\xb0\xb3"
+#define TEST10_256                                                     \
+    "\x83\x26\x75\x4e\x22\x77\x37\x2f\x4f\xc1\x2b\x20\x52\x7a\xfe\xf0" \
+    "\x4d\x8a\x05\x69\x71\xb1\x1a\xd5\x71\x23\xa7\xc1\x37\x76\x00\x00" \
+    "\xd7\xbe\xf6\xf3\xc1\xf7\xa9\x08\x3a\xa3\x9d\x81\x0d\xb3\x10\x77" \
+    "\x7d\xab\x8b\x1e\x7f\x02\xb8\x4a\x26\xc7\x73\x32\x5f\x8b\x23\x74" \
+    "\xde\x7a\x4b\x5a\x58\xcb\x5c\x5c\xf3\x5b\xce\xe6\xfb\x94\x6e\x5b" \
+    "\xd6\x94\xfa\x59\x3a\x8b\xeb\x3f\x9d\x65\x92\xec\xed\xaa\x66\xca" \
+    "\x82\xa2\x9d\x0c\x51\xbc\xf9\x33\x62\x30\xe5\xd7\x84\xe4\xc0\xa4" \
+    "\x3f\x8d\x79\xa3\x0a\x16\x5c\xba\xbe\x45\x2b\x77\x4b\x9c\x71\x09" \
+    "\xa9\x7d\x13\x8f\x12\x92\x28\x96\x6f\x6c\x0a\xdc\x10\x6a\xad\x5a" \
+    "\x9f\xdd\x30\x82\x57\x69\xb2\xc6\x71\xaf\x67\x59\xdf\x28\xeb\x39" \
+    "\x3d\x54\xd6"
+
+template <size_t N>
+constexpr auto length(const char (&)[N])
+{
+    return N - 1;
+}
+
+struct {
+    const char *test_pattern; ///< テストパターン
+    size_t length; ///< テストパターンのバイト長
+    long repeat_count; ///< テストパターンの繰り返し回数
+    std::byte extra_bits; ///< 追加ビット
+    int num_of_extra_bits; ///< 追加ビットのビット数
+    std::string expected; ///< 期待されるハッシュ値
+} tests[] = {
+    { TEST1, length(TEST1), 1, std::byte(0), 0, "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad" },
+    { TEST2_1, length(TEST2_1), 1, std::byte(0), 0, "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1" },
+    { TEST3, length(TEST3), 1000000, std::byte(0), 0, "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0" },
+    { TEST4, length(TEST4), 10, std::byte(0), 0, "594847328451bdfa85056225462cc1d867d877fb388df0ce35f25ab5562bfbb5" },
+    { "", 0, 0, std::byte(0x68), 5, "d6d3e02a31a84a8caa9718ed6c2057be09db45e7823eb5079ce7a573a3760f95" },
+    { "\x19", 1, 1, std::byte(0), 0, "68aa2e2ee5dff96e3355e6c7ee373e3d6a4e17f75f9518d843709c0c9bc3e3d4" },
+    { TEST7_256, length(TEST7_256), 1, std::byte(0x60), 3, "77ec1dc89c821ff2a1279089fa091b35b8cd960bcaf7de01c6a7680756beb972" },
+    { TEST8_256, length(TEST8_256), 1, std::byte(0), 0, "175ee69b02ba9b58e2b0a5fd13819cea573f3940a94f825128cf4209beabb4e8" },
+    { TEST9_256, length(TEST9_256), 1, std::byte(0xA0), 3, "3e9ad6468bbbad2ac3c2cdc292e018ba5fd70b960cf1679777fce708fdb066e9" },
+    { TEST10_256, length(TEST10_256), 1, std::byte(0), 0, "97dbca7df46d62c8a422c941dd7e835b8ad3361763f7e9b2d95f4f0da6e1ccbc" },
+};
+
+int main(int argc, char *argv[])
+{
+    if (argc > 1) {
+        for (auto arg : std::span(argv, argc).subspan(1)) {
+            auto hash = util::SHA256::compute_filehash(arg);
+            if (!hash.has_value()) {
+                std::cout << "cannot open file: " << arg << std::endl;
+                continue;
+            }
+
+            std::cout << util::to_string(hash.value()) << "  " << arg << std::endl;
+        }
+        return 0;
+    }
+
+    util::SHA256 hash;
+    for (const auto &test : tests) {
+        hash.reset();
+        auto test_array = std::as_bytes(std::span(test.test_pattern, test.length));
+        for (auto i = 0; i < test.repeat_count; ++i) {
+            hash.update(test_array.data(), test_array.size());
+        }
+        hash.final_bits(test.extra_bits, test.num_of_extra_bits);
+
+        assert(util::to_string(hash.digest()) == test.expected);
+    }
+}

--- a/src/util/sha256.cpp
+++ b/src/util/sha256.cpp
@@ -1,0 +1,329 @@
+﻿/*!
+ * @brief SHA-256ハッシュ値計算クラスの定義
+ *
+ * RFC 6234のリファレンス実装を参考にC++20で実装
+ */
+
+/***************** See RFC 6234 for details. *******************/
+/* Copyright (c) 2011 IETF Trust and the persons identified as */
+/* authors of the code.  All rights reserved.                  */
+/* See sha256.h for terms of use and redistribution.           */
+
+#include "util/sha256.h"
+#include "system/angband-exceptions.h"
+#include "util/enum-converter.h"
+#include <algorithm>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <span>
+#include <sstream>
+
+namespace util {
+
+namespace {
+
+    constexpr auto shift_right(uint32_t word, uint32_t shift)
+    {
+        return word >> shift;
+    }
+
+    constexpr auto rotate_right(uint32_t word, uint32_t shift)
+    {
+        return (word >> shift) | (word << (32 - shift));
+    }
+
+    constexpr auto big_sigma0(uint32_t word)
+    {
+        return rotate_right(word, 2) ^ rotate_right(word, 13) ^ rotate_right(word, 22);
+    }
+
+    constexpr auto big_sigma1(uint32_t word)
+    {
+        return rotate_right(word, 6) ^ rotate_right(word, 11) ^ rotate_right(word, 25);
+    }
+
+    constexpr auto small_sigma0(uint32_t word)
+    {
+        return rotate_right(word, 7) ^ rotate_right(word, 18) ^ shift_right(word, 3);
+    }
+
+    constexpr auto small_sigma1(uint32_t word)
+    {
+        return rotate_right(word, 17) ^ rotate_right(word, 19) ^ shift_right(word, 10);
+    }
+
+    constexpr auto sha_ch(uint32_t x, uint32_t y, uint32_t z)
+    {
+        return (x & (y ^ z)) ^ z;
+    }
+
+    constexpr auto sha_maj(uint32_t x, uint32_t y, uint32_t z)
+    {
+        return (x & (y | z)) | (y & z);
+    }
+
+    /// @brief SHA-256の初期ハッシュ値
+    constexpr std::array<uint32_t, SHA256::DIGEST_SIZE / 4> INITIAL_HASH{ {
+        // clang-format off
+        0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A,
+        0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19,
+        // clang-format on
+    } };
+}
+
+struct SHA256::Impl {
+    void add_length(size_t length);
+    void process_message_block();
+    void finalize(std::byte pad_byte);
+    void pad_message(std::byte pad_byte);
+
+    std::array<uint32_t, SHA256::DIGEST_SIZE / 4> hash_ = INITIAL_HASH;
+    uint64_t length_ = 0;
+    int message_block_index_ = 0;
+    std::array<std::byte, SHA256::BLOCK_SIZE> message_blocks_{};
+    bool computed_ = false;
+};
+
+SHA256::SHA256()
+    : pimpl_(std::make_unique<Impl>())
+{
+}
+
+SHA256::~SHA256() = default;
+
+/*!
+ * @brief ハッシュ値計算をリセットする
+ */
+void SHA256::reset()
+{
+    pimpl_->hash_ = INITIAL_HASH;
+    pimpl_->length_ = 0;
+    pimpl_->message_block_index_ = 0;
+    pimpl_->message_blocks_.fill(std::byte(0));
+    pimpl_->computed_ = false;
+}
+
+/*!
+ * @brief メッセージ(バイト列)をハッシュ値に追加する
+ *
+ * @param message_array 追加するメッセージ
+ * @param length メッセージのバイト数
+ */
+void SHA256::update(const std::byte *message_array, size_t length)
+{
+    if (length == 0) {
+        return;
+    }
+
+    if (pimpl_->computed_) {
+        THROW_EXCEPTION(std::logic_error, "SHA256::update() called after compute.");
+    }
+
+    pimpl_->add_length(8 * length);
+
+    std::span remain(message_array, length);
+    while (!remain.empty()) {
+        const auto copy_size = std::min<int>(remain.size(), BLOCK_SIZE - pimpl_->message_block_index_);
+        std::copy_n(remain.begin(), copy_size, pimpl_->message_blocks_.begin() + pimpl_->message_block_index_);
+        pimpl_->message_block_index_ += copy_size;
+        remain = remain.subspan(copy_size);
+
+        if (pimpl_->message_block_index_ == BLOCK_SIZE) {
+            pimpl_->process_message_block();
+        }
+    }
+}
+
+/*!
+ * @brief メッセージ(文字列)をハッシュ値に追加する
+ *
+ * @param message 追加するメッセージ
+ */
+void SHA256::update(std::string_view message)
+{
+    const auto message_as_byte = std::as_bytes(std::span(message));
+    this->update(message_as_byte.data(), message_as_byte.size_bytes());
+}
+
+/*!
+ * @brief 最終ブロックのビット列をハッシュ値に追加する
+ *
+ * 最終ブロックのデータが1バイトに満たない場合に使用される。
+ * 一般的にはバイト単位での追加を行うため、通常このメソッドは呼び出されない。
+ *
+ * @param message_bits 追加するビット列
+ * @param length 追加するビット列の長さ(0～7)
+ */
+void SHA256::final_bits(std::byte message_bits, size_t length)
+{
+    if (pimpl_->computed_) {
+        THROW_EXCEPTION(std::logic_error, "SHA256::final_bits() called after compute.");
+    }
+
+    if (length >= 8) {
+        THROW_EXCEPTION(std::invalid_argument, "SHA256::final_bits() called with length >= 8.");
+    }
+
+    static constexpr std::array<std::byte, 8> masks{ { //
+        std::byte(0x00), std::byte(0x80), std::byte(0xC0), std::byte(0xE0),
+        std::byte(0xF0), std::byte(0xF8), std::byte(0xFC), std::byte(0xFE) } };
+    static constexpr std::array<std::byte, 8> markbits{ { //
+        std::byte(0x80), std::byte(0x40), std::byte(0x20), std::byte(0x10),
+        std::byte(0x08), std::byte(0x04), std::byte(0x02), std::byte(0x01) } };
+
+    pimpl_->add_length(length);
+    pimpl_->finalize((message_bits & masks[length]) | markbits[length]);
+}
+
+/*!
+ * @brief ハッシュ値を取得する
+ *
+ * @return ハッシュ値
+ */
+SHA256::Digest SHA256::digest()
+{
+    if (!pimpl_->computed_) {
+        pimpl_->finalize(std::byte(0x80));
+    }
+
+    Digest result{};
+    for (auto i = 0; i < SHA256::DIGEST_SIZE; ++i) {
+        result[i] = std::byte(pimpl_->hash_[i / 4] >> 8 * (3 - (i % 4)));
+    }
+
+    return result;
+}
+
+void SHA256::Impl::add_length(size_t length)
+{
+    if (std::numeric_limits<decltype(length_)>::max() - length < length_) {
+        THROW_EXCEPTION(std::overflow_error, "SHA256::add_length() overflow.");
+    }
+
+    length_ += length;
+}
+
+void SHA256::Impl::process_message_block()
+{
+    static constexpr std::array<uint32_t, BLOCK_SIZE> k{ {
+        // clang-format off
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b,
+        0x59f111f1, 0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01,
+        0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7,
+        0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+        0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152,
+        0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+        0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+        0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819,
+        0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116, 0x1e376c08,
+        0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f,
+        0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+        0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+        // clang-format on
+    } };
+    std::array<uint32_t, BLOCK_SIZE> w{};
+
+    for (auto i = 0, i4 = 0; i4 < BLOCK_SIZE; ++i, i4 += 4) {
+        w[i] = (static_cast<uint32_t>(message_blocks_[i4]) << 24) |
+               (static_cast<uint32_t>(message_blocks_[i4 + 1]) << 16) |
+               (static_cast<uint32_t>(message_blocks_[i4 + 2]) << 8) |
+               (static_cast<uint32_t>(message_blocks_[i4 + 3]));
+    }
+
+    for (auto i = 16; i < BLOCK_SIZE; ++i) {
+        w[i] = small_sigma1(w[i - 2]) + w[i - 7] + small_sigma0(w[i - 15]) + w[i - 16];
+    }
+
+    auto h = hash_;
+
+    for (auto i = 0; i < BLOCK_SIZE; ++i) {
+        const auto tmp1 = h[7] + big_sigma1(h[4]) + sha_ch(h[4], h[5], h[6]) + k[i] + w[i];
+        const auto tmp2 = big_sigma0(h[0]) + sha_maj(h[0], h[1], h[2]);
+        std::copy_backward(h.begin(), h.end() - 1, h.end());
+        h[4] += tmp1;
+        h[0] = tmp1 + tmp2;
+    }
+
+    std::transform(hash_.begin(), hash_.end(), h.begin(),
+        hash_.begin(), std::plus<uint32_t>{});
+
+    message_block_index_ = 0;
+}
+
+void SHA256::Impl::finalize(std::byte pad_byte)
+{
+    this->pad_message(pad_byte);
+    message_blocks_.fill(std::byte(0));
+    length_ = 0;
+    computed_ = true;
+}
+
+void SHA256::Impl::pad_message(std::byte pad_byte)
+{
+    message_blocks_[message_block_index_++] = pad_byte;
+
+    const std::span whole(message_blocks_);
+
+    if (const auto remain = whole.subspan(message_block_index_); remain.size() < 8) {
+        std::fill(remain.begin(), remain.end(), std::byte(0));
+        this->process_message_block();
+    }
+
+    const auto zerofill_span = whole.first(BLOCK_SIZE - 8).subspan(message_block_index_);
+    std::fill(zerofill_span.begin(), zerofill_span.end(), std::byte(0));
+
+    const auto length_span = whole.last(8);
+    for (auto i = 0; i < 8; ++i) {
+        length_span[i] = std::byte((length_ >> (BLOCK_SIZE - 8 - i * 8)) & 0xff);
+    }
+
+    this->process_message_block();
+}
+
+/*!
+ * @brief ファイルのSHA-256ハッシュ値を計算する
+ *
+ * @param path ファイルパス
+ * @return ハッシュ値を返す。ファイルの読み込みに失敗した場合はstd::nulloptを返す。
+ */
+std::optional<SHA256::Digest> SHA256::compute_filehash(const std::filesystem::path &path)
+{
+    std::ifstream ifs(path, std::ios::binary);
+    if (!ifs) {
+        return std::nullopt;
+    }
+
+    SHA256 hash;
+    std::array<char, 1024> buf{};
+    const auto buf_as_bytes = std::as_bytes(std::span(buf));
+    while (ifs) {
+        ifs.read(buf.data(), buf.size());
+        hash.update(buf_as_bytes.data(), ifs.gcount());
+    }
+
+    if (ifs.bad()) {
+        return std::nullopt;
+    }
+
+    return hash.digest();
+}
+
+/*!
+ * @brief ハッシュ値を文字列に変換する
+ *
+ * @param digest ハッシュ値
+ * @return ハッシュ値を16進数文字列表記に変換したもの
+ */
+std::string to_string(const SHA256::Digest &digest)
+{
+    std::stringstream ss;
+    for (const auto byte : digest) {
+        ss << std::hex << std::setfill('0') << std::setw(2) << std::to_integer<int>(byte);
+    }
+
+    return ss.str();
+}
+
+}

--- a/src/util/sha256.h
+++ b/src/util/sha256.h
@@ -78,7 +78,7 @@ public:
 
 private:
     struct Impl;
-    std::unique_ptr<Impl> pimpl_;
+    std::unique_ptr<Impl> pimpl;
 };
 
 std::string to_string(const SHA256::Digest &hash);

--- a/src/util/sha256.h
+++ b/src/util/sha256.h
@@ -1,0 +1,85 @@
+﻿/*!
+ * @brief SHA-256ハッシュ値計算クラスの宣言
+ */
+
+/***************** See RFC 6234 for details. *******************/
+/*
+   Copyright (c) 2011 IETF Trust and the persons identified as
+   authors of the code.  All rights reserved.
+
+   Redistribution and use in source and binary forms, with or
+   without modification, are permitted provided that the following
+   conditions are met:
+
+   - Redistributions of source code must retain the above
+     copyright notice, this list of conditions and
+     the following disclaimer.
+
+   - Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   - Neither the name of Internet Society, IETF or IETF Trust, nor
+     the names of specific contributors, may be used to endorse or
+     promote products derived from this software without specific
+     prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+   NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+   OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+   EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace util {
+
+/*!
+ * @brief SHA-256ハッシュ値計算クラス
+ */
+class SHA256 {
+public:
+    static constexpr auto DIGEST_SIZE = 32; ///< ハッシュ値のバイト数
+    static constexpr auto BLOCK_SIZE = 64; ///< ブロックサイズ
+    using Digest = std::array<std::byte, DIGEST_SIZE>; ///< ハッシュ値の型
+
+    SHA256();
+    ~SHA256();
+    SHA256(const SHA256 &) = delete;
+    SHA256 &operator=(const SHA256 &) = delete;
+    SHA256(SHA256 &&) = delete;
+    SHA256 &operator=(SHA256 &&) = delete;
+
+    void reset();
+    void update(const std::byte *message_array, size_t length);
+    void update(std::string_view message);
+    void final_bits(std::byte message_bits, size_t length);
+    Digest digest();
+
+    static std::optional<Digest> compute_filehash(const std::filesystem::path &path);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> pimpl_;
+};
+
+std::string to_string(const SHA256::Digest &hash);
+}


### PR DESCRIPTION
ファイルの同一性を確認するために、SHA-256ハッシュ値を計算するクラスを追加する。

#3474 の一環です。一気にやるとレビューが大変なので機能ごとにPRを出します。
Issue ではハッシュアルゴリズムとして MD5 と書いていましたが、実装難度はそんなに変わらないので SHA-256 にしました。

テストプログラムも追加していて、テストパターンを通過するのと、lib/xtra/music ディレクトリのmp3ファイルのハッシュが sha256sum コマンドと一致するのを確認しています。

https://github.com/hengband/hengband/assets/1501750/e850c2e0-4768-4d51-b074-77cae4c16dc4

