### PR TITLE
[Feature] プレイヤー名を中央寄せして表示する

### DIFF
--- a/src/birth/birth-select-personality.cpp
+++ b/src/birth/birth-select-personality.cpp
@@ -7,6 +7,7 @@
 #include "term/term-color-types.h"
 #include "term/z-form.h"
 #include "util/int-char-converter.h"
+#include "view/display-player-misc-info.h"
 #include <sstream>
 
 static std::string birth_personality_label(int cs, concptr sym)
@@ -251,17 +252,6 @@ bool get_player_personality(PlayerType *player_ptr)
 
     player_ptr->ppersonality = (player_personality_type)k;
     ap_ptr = &personality_info[player_ptr->ppersonality];
-    char tmp[64];
-#ifdef JP
-    strcpy(tmp, ap_ptr->title);
-    if (ap_ptr->no == 1) {
-        strcat(tmp, "の");
-    }
-#else
-    strcpy(tmp, ap_ptr->title);
-    strcat(tmp, " ");
-#endif
-    strcat(tmp, player_ptr->name);
-    c_put_str(TERM_L_BLUE, tmp, 1, 34);
+    display_player_name(player_ptr);
     return true;
 }

--- a/src/birth/birth-wizard.cpp
+++ b/src/birth/birth-wizard.cpp
@@ -40,6 +40,7 @@
 #include "util/int-char-converter.h"
 #include "util/string-processor.h"
 #include "view/display-birth.h" // 暫定。後で消す予定。
+#include "view/display-player-misc-info.h"
 #include "view/display-player.h" // 暫定。後で消す.
 #include "view/display-util.h"
 #include "world/world.h"
@@ -58,11 +59,10 @@
 static void display_initial_birth_message(PlayerType *player_ptr)
 {
     term_clear();
-    put_str(_("名前  :", "Name  :"), 1, 26);
+    display_player_name(player_ptr, true);
     put_str(_("性別        :", "Sex         :"), 3, 1);
     put_str(_("種族        :", "Race        :"), 4, 1);
     put_str(_("職業        :", "Class       :"), 5, 1);
-    c_put_str(TERM_L_BLUE, player_ptr->name, 1, 34);
     put_str(_("キャラクターを作成します。('S'やり直す, 'Q'終了, '?'ヘルプ)", "Make your character. ('S' Restart, 'Q' Quit, '?' Help)"), 8, 10);
     put_str(_("注意：《性別》の違いはゲーム上ほとんど影響を及ぼしません。", "Note: Your 'sex' does not have any significant gameplay effects."), 23, 5);
 }
@@ -237,8 +237,7 @@ static bool let_player_select_personality(PlayerType *player_ptr)
             break;
         }
 
-        c_put_str(TERM_L_BLUE, player_ptr->name, 1, 34);
-        prt("", 1, 34 + strlen(player_ptr->name));
+        display_player_name(player_ptr, true);
     }
 
     return true;

--- a/src/player/process-name.cpp
+++ b/src/player/process-name.cpp
@@ -9,6 +9,7 @@
 #include "term/term-color-types.h"
 #include "util/angband-files.h"
 #include "util/string-processor.h"
+#include "view/display-player-misc-info.h"
 #include "world/world.h"
 #include <sstream>
 #ifdef SAVEFILE_USE_UID
@@ -142,17 +143,5 @@ void get_name(PlayerType *player_ptr)
         angband_strcpy(player_ptr->name, "PLAYER", max_name_size);
     }
 
-    std::stringstream ss;
-    ss << ap_ptr->title;
-#ifdef JP
-    if (ap_ptr->no == 1) {
-        ss << "の";
-    }
-#else
-    ss << " ";
-#endif
-    ss << player_ptr->name;
-    term_erase(34, 1, 255);
-    c_put_str(TERM_L_BLUE, ss.str(), 1, 34);
-    clear_from(22);
+    display_player_misc_info(player_ptr);
 }

--- a/src/view/display-player-misc-info.cpp
+++ b/src/view/display-player-misc-info.cpp
@@ -1,4 +1,5 @@
-﻿#include "player-info/class-info.h"
+﻿#include "view/display-player-misc-info.h"
+#include "player-info/class-info.h"
 #include "player-info/mimic-info-table.h"
 #include "player/player-personality.h"
 #include "player/player-sex.h"
@@ -7,6 +8,34 @@
 #include "term/term-color-types.h"
 #include "term/z-form.h"
 #include "view/display-player-stat-info.h"
+#include <sstream>
+
+/*!
+ * @brief 画面上部にプレイヤーの名前を表示する
+ *
+ * @param name_only trueならば名前のみ表示する。falseならばプレイヤーの性格も表示する。
+ */
+void display_player_name(PlayerType *player_ptr, bool name_only)
+{
+    std::stringstream ss;
+    if (!name_only) {
+        ss << ap_ptr->title << _(ap_ptr->no == 1 ? "の" : "", " ");
+    }
+    ss << player_ptr->name;
+    const auto display_name = ss.str();
+
+    constexpr std::string_view header = _("名前  : ", "Name  : ");
+    const auto length = header.length() + display_name.length();
+
+    int w, h;
+    term_get_size(&w, &h);
+    const auto center_col = (w - length) / 2 - 4; // ヘッダがあるぶん少し左に寄せたほうが見やすい
+    constexpr auto row = 1;
+
+    term_erase(0, row, 255);
+    term_putstr(center_col, row, -1, TERM_WHITE, header);
+    term_putstr(center_col + header.length(), row, -1, TERM_L_BLUE, display_name);
+}
 
 /*!
  * @brief プレイヤーの特性フラグ一覧表示2a /
@@ -15,15 +44,12 @@
  */
 void display_player_misc_info(PlayerType *player_ptr)
 {
-    put_str(_("名前  :", "Name  :"), 1, 26);
+    display_player_name(player_ptr);
+
     put_str(_("性別  :", "Sex   :"), 3, 1);
     put_str(_("種族  :", "Race  :"), 4, 1);
     put_str(_("職業  :", "Class :"), 5, 1);
 
-    std::string tmp = ap_ptr->title;
-    tmp.append(_(ap_ptr->no == 1 ? "の" : "", " ")).append(player_ptr->name);
-
-    c_put_str(TERM_L_BLUE, tmp, 1, 34);
     c_put_str(TERM_L_BLUE, sp_ptr->title, 3, 9);
     c_put_str(TERM_L_BLUE, (player_ptr->mimic_form != MimicKindType::NONE ? mimic_info.at(player_ptr->mimic_form).title : rp_ptr->title), 4, 9);
     c_put_str(TERM_L_BLUE, cp_ptr->title, 5, 9);

--- a/src/view/display-player-misc-info.h
+++ b/src/view/display-player-misc-info.h
@@ -1,4 +1,5 @@
 ﻿#pragma once
 
 class PlayerType;
+void display_player_name(PlayerType *player_ptr, bool name_only = false);
 void display_player_misc_info(PlayerType *player_ptr);

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -84,10 +84,7 @@ static bool display_player_info(PlayerType *player_ptr, int mode)
  */
 static void display_player_basic_info(PlayerType *player_ptr)
 {
-    std::string tmp = ap_ptr->title;
-    tmp.append(_(ap_ptr->no == 1 ? "の" : "", " ")).append(player_ptr->name);
-
-    display_player_one_line(ENTRY_NAME, tmp, TERM_L_BLUE);
+    display_player_name(player_ptr);
     display_player_one_line(ENTRY_SEX, sp_ptr->title, TERM_L_BLUE);
     display_player_one_line(ENTRY_RACE, (player_ptr->mimic_form != MimicKindType::NONE ? mimic_info.at(player_ptr->mimic_form).title : rp_ptr->title), TERM_L_BLUE);
     display_player_one_line(ENTRY_CLASS, cp_ptr->title, TERM_L_BLUE);


### PR DESCRIPTION
Resolves #3488

画面上部に表示するプレイヤー名の表示位置が固定されているため、名前が長いと右側に偏って表示されてしまう。
名前（性格含む）の長さを考慮し、中央に寄せてバランスよく表示するように変更する。

