### PR TITLE
[Feature] HTTP通信でファイルに直接ダウンロードする

### DIFF
--- a/src/net/curl-easy-session.cpp
+++ b/src/net/curl-easy-session.cpp
@@ -57,7 +57,6 @@ void EasySession::common_setup(const std::string &url, int timeout_sec)
 
     if (timeout_sec > 0) {
         this->setopt(CURLOPT_CONNECTTIMEOUT, timeout_sec);
-        this->setopt(CURLOPT_TIMEOUT, timeout_sec);
     }
 }
 

--- a/src/net/http-client.h
+++ b/src/net/http-client.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "system/angband.h"
+#include <filesystem>
 #include <optional>
 #include <string>
 
@@ -17,6 +18,7 @@ class HttpContentBase;
 class Client {
 public:
     std::optional<Response> get(const std::string &url);
+    std::optional<Response> get(const std::string &url, const std::filesystem::path &path);
     std::optional<Response> post(const std::string &url, const std::string &post_data, const std::string &media_type);
 
     std::optional<std::string> user_agent;


### PR DESCRIPTION
http::Client に引数で指定したファイルに直接ダウンロードするメソッドを追加する。

#3474 実装のための機能の1つです。

以下のコードにより、The_Serpent_of_Chaos.mp3 がファイルにダウンロードできるのを確認済み。

```c++

    http::Client client;
    if (auto res = client.get("https://github.com/hengband/hengband.xtra/blob/master/music/The_Serpent_of_Chaos.mp3?raw=true", "The_Serpent_of_Chaos.mp3");
        res && res->status == 200) {
        std::cout << "Downloaded: " << res->body << std::endl;
    }
```