### PR TITLE
[Feature] HTTP通信の進捗のコールバック機能

### DIFF
--- a/src/net/curl-easy-session.cpp
+++ b/src/net/curl-easy-session.cpp
@@ -16,6 +16,10 @@ namespace {
         return (*userdata)(buf, size * nitems);
     }
 
+    int progress_callback(EasySession::ProgressHandler *userdata, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow)
+    {
+        return (*userdata)(dltotal, dlnow, ultotal, ulnow) ? 0 : 1;
+    }
 }
 
 class EasySession::Impl {
@@ -33,6 +37,7 @@ public:
     std::unique_ptr<CURL, decltype(&curl_easy_cleanup)> handle_;
     SendHandler send_handler_;
     ReceiveHandler receive_handler_;
+    ProgressHandler progress_handler_;
 };
 
 EasySession::EasySession()
@@ -81,6 +86,19 @@ void EasySession::receiver_setup(ReceiveHandler handler)
 
     this->setopt(CURLOPT_WRITEDATA, &pimpl_->receive_handler_);
     this->setopt(CURLOPT_WRITEFUNCTION, write_callback);
+}
+
+void EasySession::progress_setup(ProgressHandler handler)
+{
+    pimpl_->progress_handler_ = std::move(handler);
+    if (!pimpl_->progress_handler_) {
+        this->setopt(CURLOPT_NOPROGRESS, 1);
+        return;
+    }
+
+    this->setopt(CURLOPT_NOPROGRESS, 0);
+    this->setopt(CURLOPT_XFERINFODATA, &pimpl_->progress_handler_);
+    this->setopt(CURLOPT_XFERINFOFUNCTION, progress_callback);
 }
 
 bool EasySession::perform()

--- a/src/net/curl-easy-session.h
+++ b/src/net/curl-easy-session.h
@@ -21,6 +21,7 @@ class EasySession {
 public:
     using SendHandler = std::function<size_t(char *, size_t)>;
     using ReceiveHandler = std::function<size_t(char *, size_t)>;
+    using ProgressHandler = std::function<bool(curl_off_t, curl_off_t, curl_off_t, curl_off_t)>;
 
     EasySession();
     ~EasySession();
@@ -33,6 +34,7 @@ public:
     void common_setup(const std::string &url, int timeout_sec = 0);
     void sender_setup(SendHandler handler, long post_field_size);
     void receiver_setup(ReceiveHandler handler);
+    void progress_setup(ProgressHandler handler);
     bool perform();
 
     template <typename T>

--- a/src/net/http-client.h
+++ b/src/net/http-client.h
@@ -2,6 +2,7 @@
 
 #include "system/angband.h"
 #include <filesystem>
+#include <functional>
 #include <optional>
 #include <string>
 
@@ -14,11 +15,23 @@ struct Response {
     std::string body;
 };
 
+struct Progress {
+    size_t total; ///< 通信の総バイト数。0の場合は不明
+    size_t now; ///< 通信済みのバイト数
+};
+
 class HttpContentBase;
 class Client {
 public:
-    std::optional<Response> get(const std::string &url);
-    std::optional<Response> get(const std::string &url, const std::filesystem::path &path);
+    /*!
+     * @brief HTTP GET通信のコールバック関数の型
+     * @param progress 進捗状況。libcurlの仕様によりnow/totalが0で呼ばれることがあるのでそれを考慮すること
+     * @return 通信を継続する場合はtrue、中断する場合はfalseを返す
+     */
+    using GetRequestProgressHandler = std::function<bool(Progress)>;
+
+    std::optional<Response> get(const std::string &url, GetRequestProgressHandler progress_handler = {});
+    std::optional<Response> get(const std::string &url, const std::filesystem::path &path, GetRequestProgressHandler progress_handler = {});
     std::optional<Response> post(const std::string &url, const std::string &post_data, const std::string &media_type);
 
     std::optional<std::string> user_agent;


### PR DESCRIPTION
http::Client の get メソッドの引数にコールバック関数を指定することで、HTTP通信の進捗状況の表示や通信の中断を行えるようにする。

#3474 実装のための機能の1つです。

```c++
    http::Client client;
    auto handler = [](http::Progress progress) {
        std::cout << "progress: " << progress.now << "/" << progress.total << std::endl;
        return true;
    };
    const auto url = "https://github.com/hengband/hengband.xtra/blob/master/music/The_Serpent_of_Chaos.mp3?raw=true";
    if (auto res = client.get(url, "The_Serpent_of_Chaos.mp3", handler);
        res && res->status == 200) {
        std::cout << "Downloaded: " << res->body << std::endl;
    }
```

上記のコードで、以下の出力が得られるのを確認しています。

```c++
progress: 0/0
progress: 0/0
progress: 0/0
progress: 0/0
(略)
progress: 0/0
progress: 0/0
progress: 7687/1925021
progress: 7687/1925021
progress: 10443/1925021
progress: 10443/1925021
progress: 11821/1925021
progress: 11821/1925021
(略)
progress: 1915447/1925021
progress: 1915447/1925021
progress: 1925021/1925021
progress: 1925021/1925021
progress: 1925021/1925021
progress: 1925021/1925021
Downloaded: The_Serpent_of_Chaos.mp3
```
