### PR TITLE
[Chore] MSVCのビルドテストでCached LFS checkoutを使用する

### DIFF
--- a/.github/workflows/build-test-with-msvc.yml
+++ b/.github/workflows/build-test-with-msvc.yml
@@ -11,9 +11,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
-        with:
-          lfs: true
+        uses: nschloe/action-cached-lfs-checkout@v1
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1


### PR DESCRIPTION
Resolves #3511

残りの転送量がすでに100MBちょいくらいしか残っていないので、早急にマージする必要があります。
また、キャッシュが有効になった状態でビルドテストを実行するため、**仕掛中のPRは必ずこのPRがマージ後のブランチにリベースするようにしてください**。