### PR TITLE
[Feature] エラー情報送信機能

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -276,6 +276,7 @@
     <ClCompile Include="..\..\src\load\item\item-loader-factory.cpp" />
     <ClCompile Include="..\..\src\load\monster\monster-loader-factory.cpp" />
     <ClCompile Include="..\..\src\load\player-class-specific-data-loader.cpp" />
+    <ClCompile Include="..\..\src\main-win\main-win-exception.cpp" />
     <ClCompile Include="..\..\src\monster-race\race-brightness-mask.cpp" />
     <ClCompile Include="..\..\src\monster-race\race-feature-mask.cpp" />
     <ClCompile Include="..\..\src\monster\monster-pain-describer.cpp" />
@@ -980,6 +981,7 @@
     <ClInclude Include="..\..\src\load\old\monster-flag-types-savefile50.h" />
     <ClInclude Include="..\..\src\load\player-class-specific-data-loader.h" />
     <ClInclude Include="..\..\src\load\savedata-old-flag-types.h" />
+    <ClInclude Include="..\..\src\main-win\main-win-exception.h" />
     <ClInclude Include="..\..\src\market\bounty-type-definition.h" />
     <ClInclude Include="..\..\src\monster-race\monster-aura-types.h" />
     <ClInclude Include="..\..\src\monster-race\monster-kind-mask.h" />

--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -282,6 +282,7 @@
     <ClCompile Include="..\..\src\net\curl-easy-session.cpp" />
     <ClCompile Include="..\..\src\net\curl-slist.cpp" />
     <ClCompile Include="..\..\src\net\http-client.cpp" />
+    <ClCompile Include="..\..\src\net\report-error.cpp" />
     <ClCompile Include="..\..\src\object-enchant\enchanter-factory.cpp" />
     <ClCompile Include="..\..\src\mspell\mspell-attack\abstract-mspell.cpp" />
     <ClCompile Include="..\..\src\mspell\mspell-data.cpp" />
@@ -1001,6 +1002,7 @@
     <ClInclude Include="..\..\src\net\curl-easy-session.h" />
     <ClInclude Include="..\..\src\net\curl-slist.h" />
     <ClInclude Include="..\..\src\net\http-client.h" />
+    <ClInclude Include="..\..\src\net\report-error.h" />
     <ClInclude Include="..\..\src\object-enchant\enchanter-factory.h" />
     <ClInclude Include="..\..\src\object-enchant\protector\apply-magic-soft-armor.h" />
     <ClInclude Include="..\..\src\object-enchant\others\apply-magic-lite.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2490,6 +2490,9 @@
     <ClCompile Include="..\..\src\net\report-error.cpp">
       <Filter>net</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\main-win\main-win-exception.cpp">
+      <Filter>main-win</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5396,6 +5399,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\net\report-error.h">
       <Filter>net</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main-win\main-win-exception.h">
+      <Filter>main-win</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2487,6 +2487,9 @@
     <ClCompile Include="..\..\src\util\sha256.cpp">
       <Filter>util</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\net\report-error.cpp">
+      <Filter>net</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5390,6 +5393,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\external-lib\include-json.h">
       <Filter>external-lib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\net\report-error.h">
+      <Filter>net</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,8 @@ AC_ARG_ENABLE(fontset,
 [  --disable-fontset       disable fontset support], use_fontset=no, use_fontset=yes)
 AC_ARG_ENABLE([xft],
 	AS_HELP_STRING([--enable-xft], [Enable xft support]))
+AC_ARG_ENABLE(net,
+[  --disable-net           disable networking support], use_net=no)
 AC_ARG_ENABLE(worldscore,
 [  --disable-worldscore    disable worldscore support], worldscore=no)
 AC_ARG_ENABLE([pch],
@@ -79,12 +81,18 @@ fi
 
 AC_CHECK_LIB(iconv, iconv_open)
 
+if test "$use_net" = no; then
+  AC_DEFINE(DISABLE_NET, 1, [Disable networking support])
+  worldscore=no;
+else
+  PKG_CHECK_MODULES(libcurl, [libcurl])
+fi
+
 dnl The world score server is currently only available in Japanese.
 if test "$use_japanese" = no; then
   worldscore=no
 fi
 if test "$worldscore" != no; then
-  PKG_CHECK_MODULES(libcurl, [libcurl])
   AC_DEFINE(WORLD_SCORE, 1, [Allow the game to send scores to the score server])
 fi
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -576,6 +576,7 @@ hengband_SOURCES = \
 	net/curl-easy-session.cpp net/curl-easy-session.h \
 	net/curl-slist.cpp net/curl-slist.h \
 	net/http-client.cpp net/http-client.h \
+	net/report-error.cpp net/report-error.h \
 	\
 	object/item-tester-hooker.cpp object/item-tester-hooker.h \
 	object/object-broken.cpp object/object-broken.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1040,6 +1040,7 @@ EXTRA_hengband_SOURCES = \
 	main-win/main-win-bg.cpp main-win/main-win-bg.h \
 	main-win/main-win-cfg-reader.cpp main-win/main-win-cfg-reader.h \
 	main-win/main-win-define.h \
+	main-win/main-win-exception.cpp main-win/main-win-exception.h \
 	main-win/main-win-file-utils.cpp main-win/main-win-file-utils.h \
 	main-win/main-win-mci.cpp main-win/main-win-mci.h \
 	main-win/main-win-menuitem.h \

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -102,6 +102,7 @@
 #include "main-win/commandline-win.h"
 #include "main-win/graphics-win.h"
 #include "main-win/main-win-bg.h"
+#include "main-win/main-win-exception.h"
 #include "main-win/main-win-file-utils.h"
 #include "main-win/main-win-mci.h"
 #include "main-win/main-win-menuitem.h"
@@ -2756,10 +2757,9 @@ static void register_wndclass(void)
 }
 
 /*!
- * @brief (Windows固有)Windowsアプリケーションとしてのエントリポイント
+ * @brief ゲームのメインルーチン
  */
-int WINAPI WinMain(
-    _In_ HINSTANCE hInst, [[maybe_unused]] _In_opt_ HINSTANCE hPrevInst, [[maybe_unused]] _In_ LPSTR lpCmdLine, [[maybe_unused]] _In_ int nCmdShow)
+int WINAPI game_main(_In_ HINSTANCE hInst)
 {
     setlocale(LC_ALL, "ja_JP");
     hInstance = hInst;
@@ -2848,4 +2848,19 @@ int WINAPI WinMain(
     quit(nullptr);
     return 0;
 }
+
+/*!
+ * @brief (Windows固有)Windowsアプリケーションとしてのエントリポイント
+ */
+int WINAPI WinMain(
+    _In_ HINSTANCE hInst, _In_opt_ HINSTANCE, _In_ LPSTR, _In_ int)
+{
+    try {
+        return game_main(hInst);
+    } catch (const std::exception &e) {
+        handle_unexpected_exception(e);
+        return 1;
+    }
+}
+
 #endif /* WINDOWS */

--- a/src/main-win/main-win-exception.cpp
+++ b/src/main-win/main-win-exception.cpp
@@ -1,0 +1,43 @@
+﻿#include "main-win/main-win-exception.h"
+#include "main-win/main-win-utils.h"
+#include "net/report-error.h"
+#include <sstream>
+
+/*!
+ * @brief 予期しない例外を処理する
+ *
+ * 予期しない例外が発生した場合、確認を取り例外のエラー情報を開発チームに送信する。
+ * その後、バグ報告ページを開くかどうか尋ね、開く場合はWebブラウザで開く。
+ *
+ * @param e 例外オブジェクト
+ */
+void handle_unexpected_exception(const std::exception &e)
+{
+    constexpr auto caption = _(L"予期しないエラー！", L"Unexpected error!");
+
+#if !defined(DISABLE_NET)
+    std::wstringstream report_confirm_msg_ss;
+    report_confirm_msg_ss
+        << to_wchar(e.what()).wc_str() << L"\n\n"
+        << _(L"開発チームにエラー情報を送信してよろしいですか？\n", L"Are you sure you want to send the error information to the development team?\n")
+        << _(L"※送信されるのはゲーム内の情報のみであり、個人情報が送信されることはありません。\n",
+               L"Only in-game information will be sent. No personal information will be sent.\n");
+
+    if (auto choice = MessageBoxW(NULL, report_confirm_msg_ss.str().data(), caption, MB_ICONEXCLAMATION | MB_YESNO | MB_ICONSTOP);
+        choice == IDYES) {
+        report_error(e.what());
+    }
+#endif
+
+    std::wstringstream issue_page_open_msg_ss;
+    issue_page_open_msg_ss
+        << _(L"エラー発生の詳しい状況を報告してくださると助かります。\n",
+               L"It would be helpful if you could report the detailed circumstances of the error.\n")
+        << _(L"バグ報告ページを開きますか？\n", L"Open bug report page?\n");
+
+    if (auto choice = MessageBoxW(NULL, issue_page_open_msg_ss.str().data(), caption, MB_ICONEXCLAMATION | MB_YESNO | MB_ICONSTOP);
+        choice == IDYES) {
+        constexpr auto url = "https://github.com/hengband/hengband/issues/new/choose";
+        ShellExecuteA(NULL, "open", url, NULL, NULL, SW_SHOWNORMAL);
+    }
+};

--- a/src/main-win/main-win-exception.h
+++ b/src/main-win/main-win-exception.h
@@ -1,0 +1,5 @@
+﻿#pragma once
+
+#include <stdexcept>
+
+void handle_unexpected_exception(const std::exception &e);

--- a/src/net/curl-easy-session.cpp
+++ b/src/net/curl-easy-session.cpp
@@ -1,6 +1,6 @@
 ﻿#include "net/curl-easy-session.h"
 
-#if defined(WORLD_SCORE)
+#if !defined(DISABLE_NET)
 
 namespace libcurl {
 

--- a/src/net/curl-easy-session.h
+++ b/src/net/curl-easy-session.h
@@ -5,7 +5,7 @@
 #include <memory>
 #include <string>
 
-#if defined(WORLD_SCORE)
+#if !defined(DISABLE_NET)
 
 #ifdef WINDOWS
 #define CURL_STATICLIB

--- a/src/net/curl-slist.cpp
+++ b/src/net/curl-slist.cpp
@@ -1,6 +1,6 @@
 ﻿#include "net/curl-slist.h"
 
-#if defined(WORLD_SCORE)
+#if !defined(DISABLE_NET)
 
 namespace libcurl {
 

--- a/src/net/curl-slist.h
+++ b/src/net/curl-slist.h
@@ -4,7 +4,7 @@
 #include <memory>
 #include <string>
 
-#if defined(WORLD_SCORE)
+#if !defined(DISABLE_NET)
 
 #ifdef WINDOWS
 #define CURL_STATICLIB

--- a/src/net/http-client.cpp
+++ b/src/net/http-client.cpp
@@ -4,7 +4,7 @@
 #include <fstream>
 #include <string_view>
 
-#if defined(WORLD_SCORE)
+#if !defined(DISABLE_NET)
 
 namespace http {
 

--- a/src/net/http-client.h
+++ b/src/net/http-client.h
@@ -6,7 +6,7 @@
 #include <optional>
 #include <string>
 
-#if defined(WORLD_SCORE)
+#if !defined(DISABLE_NET)
 
 namespace http {
 

--- a/src/net/report-error.cpp
+++ b/src/net/report-error.cpp
@@ -1,0 +1,72 @@
+﻿#include "external-lib/include-json.h"
+#include "locale/japanese.h"
+#include "net/http-client.h"
+#include "system/angband-version.h"
+#include <sstream>
+#include <string_view>
+
+#if !defined(DISABLE_NET)
+
+namespace {
+
+/*!
+ * @brief エラーレポート送信用のWebhook URLを取得する
+ * @return 取得に成功した場合はWebhook URL、失敗した場合は空文字列
+ */
+std::string fetch_webhook_url_for_sending_error_report()
+{
+    http::Client client;
+    constexpr auto url = "https://hengband.github.io/api/report-error";
+    const auto response = client.get(url);
+    if (!response || (response->status != 200)) {
+        return "";
+    }
+
+    const auto json = nlohmann::json::parse(response->body);
+    return json["webhook_url"];
+}
+
+/*!
+ * @brief 送信するエラーレポートのJSONオブジェクトを作成する
+ *
+ * @param message エラーメッセージ
+ * @return 作成したJSONオブジェクト
+ */
+nlohmann::json create_report_json(std::string_view message)
+{
+    nlohmann::json webhook;
+    webhook["username"] = "Hengband Error Report";
+    constexpr auto conv_error_msg = "Cannot convert to UTF-8";
+    nlohmann::json embed;
+    embed["title"] = sys_to_utf8(get_version()).value_or(conv_error_msg);
+    embed["description"] = sys_to_utf8(message).value_or(conv_error_msg);
+    embed["color"] = 0xff0000; // red
+    webhook["embeds"].push_back(std::move(embed));
+
+    return webhook;
+}
+
+}
+
+/*!
+ * @brief エラーレポートを送信する
+ *
+ * @param description 送信するエラーの説明
+ * @return 送信に成功した場合はtrue、失敗した場合はfalse
+ */
+bool report_error(std::string_view description)
+{
+    const auto webhook_url = fetch_webhook_url_for_sending_error_report();
+    if (webhook_url.empty()) {
+        return false;
+    }
+
+    const auto report_json = create_report_json(description);
+
+    http::Client client;
+    const auto response = client.post(webhook_url, report_json.dump(), "application/json");
+
+    return (response && (response->status == 200));
+}
+
+#endif // !defined(DISABLE_NET)

--- a/src/net/report-error.h
+++ b/src/net/report-error.h
@@ -1,0 +1,11 @@
+﻿#pragma once
+
+#include "system/angband.h"
+
+#if !defined(DISABLE_NET)
+
+#include <string_view>
+
+bool report_error(std::string_view description);
+
+#endif // !defined(DISABLE_NET)

--- a/src/system/angband-exceptions.h
+++ b/src/system/angband-exceptions.h
@@ -1,6 +1,5 @@
 ﻿#pragma once
 
-#include "system/angband-version.h"
 #include <concepts>
 #include <filesystem>
 #include <sstream>
@@ -19,7 +18,7 @@ template <std::derived_from<std::exception> T>
 [[noreturn]] void throw_exception(std::string_view msg, std::filesystem::path path, int line)
 {
     std::stringstream ss;
-    ss << get_version() << ": " << path.filename().string() << ':' << line << ": " << msg;
+    ss << path.filename().string() << ':' << line << ": " << msg;
     throw T(ss.str());
 }
 


### PR DESCRIPTION
Resolves #3386 

上記 Issue について、Windows版で予期していない例外捕捉時に確認ダイアログを表示し、例外メッセージをWebhookでDiscordに送信する機能を実装しました。

送信時の仕組みとしては、https://hengband.github.io/api/report-error からWebhook URLを取得し、そこにバージョンと例外メッセージを送信するようになっています。現在は公式サーバの #変愚蛮怒開発 にWebhookが送信されるようになっています。
また、その後バグ報告のページを開くか問い合わせ、OKの場合はWebブラウザで [New Issue](https://github.com/hengband/hengband/issues/new/choose)のページを開きます。

また、意図的に例外を起こすウィザードコマンドを一時的に追加しています。
`^a @` で SPELL: に 'exception' と入力すると、例外を発生させることができます。このコミットは最終的には削除する予定です。

例外発生時の確認メッセージの内容や手順など、これで良いかどうか確認・ご意見をよろしくおねがいします。