### PR TITLE
askfor() の引数からchar* を除去し、戻り値をoptional<string> に変えた

### DIFF
--- a/src/cmd-io/cmd-dump.cpp
+++ b/src/cmd-io/cmd-dump.cpp
@@ -64,9 +64,9 @@ void do_cmd_pref(PlayerType *player_ptr)
  */
 void do_cmd_colors(PlayerType *player_ptr)
 {
-    char tmp[160];
     FILE *auto_dump_stream;
     screen_save();
+    const auto initial_filename = format("%s.prf", player_ptr->base_name);
     while (true) {
         term_clear();
         prt(_("[ カラーの設定 ]", "Interact with Colors"), 2, 0);
@@ -83,12 +83,12 @@ void do_cmd_colors(PlayerType *player_ptr)
         case '1': {
             prt(_("コマンド: ユーザー設定ファイルをロードします", "Command: Load a user pref file"), 8, 0);
             prt(_("ファイル: ", "File: "), 10, 0);
-            strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
-            if (!askfor(tmp, 70)) {
+            const auto ask_result = askfor(70, initial_filename);
+            if (!ask_result) {
                 continue;
             }
 
-            (void)process_pref_file(player_ptr, tmp, true);
+            (void)process_pref_file(player_ptr, *ask_result, true);
             term_xtra(TERM_XTRA_REACT, 0);
             term_redraw();
             break;
@@ -97,12 +97,12 @@ void do_cmd_colors(PlayerType *player_ptr)
             constexpr auto mark = "Colors";
             prt(_("コマンド: カラーの設定をファイルに書き出します", "Command: Dump colors"), 8, 0);
             prt(_("ファイル: ", "File: "), 10, 0);
-            strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
-            if (!askfor(tmp, 70)) {
+            const auto ask_result = askfor(70, initial_filename);
+            if (!ask_result) {
                 continue;
             }
 
-            const auto &path = path_build(ANGBAND_DIR_USER, tmp);
+            const auto &path = path_build(ANGBAND_DIR_USER, *ask_result);
             if (!open_auto_dump(&auto_dump_stream, path, mark)) {
                 continue;
             }

--- a/src/cmd-io/cmd-macro.cpp
+++ b/src/cmd-io/cmd-macro.cpp
@@ -226,10 +226,9 @@ void do_cmd_macros(PlayerType *player_ptr)
             }
 
             // マクロの作成時に参照するためmacro_bufにコピーする
-            strncpy(macro_buf, macro_actions[k].data(), sizeof(macro_buf) - 1);
+            angband_strcpy(macro_buf, macro_actions[k].data(), sizeof(macro_buf));
             char tmp[81]{};
-            angband_strcpy(tmp, macro_buf, 80);
-            tmp[80] = '\0';
+            angband_strcpy(tmp, macro_buf, sizeof(tmp));
             ascii_to_text(buf, tmp, sizeof(buf));
             prt(buf, 22, 0);
             msg_print(_("マクロを確認しました。", "Found a macro."));
@@ -289,11 +288,10 @@ void do_cmd_macros(PlayerType *player_ptr)
             }
 
             // マクロの作成時に参照するためmacro_bufにコピーする
-            strncpy(macro_buf, act, sizeof(macro_buf) - 1);
+            angband_strcpy(macro_buf, act, sizeof(macro_buf));
             // too long macro must die
             char tmp[81]{};
-            strncpy(tmp, macro_buf, 80);
-            tmp[80] = '\0';
+            angband_strcpy(tmp, macro_buf, sizeof(tmp));
             ascii_to_text(buf, tmp, sizeof(buf));
             prt(buf, 22, 0);
             msg_print(_("キー配置を確認しました。", "Found a keymap."));

--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -252,14 +252,10 @@ void do_cmd_messages(int num_now)
         switch (skey) {
         case '=': {
             prt(_("強調: ", "Show: "), hgt - 1, 0);
-            char ask[81]{};
-            angband_strcpy(ask, shower_str, 80);
-            const auto back_str(shower_str);
-            if (askfor(ask, 80)) {
-                shower = ask;
-                shower_str = ask;
-            } else {
-                shower_str = back_str;
+            const auto ask_result = askfor(80, shower_str);
+            if (ask_result) {
+                shower = *ask_result;
+                shower_str = *ask_result;
             }
 
             continue;
@@ -267,15 +263,12 @@ void do_cmd_messages(int num_now)
         case '/':
         case KTRL('s'): {
             prt(_("検索: ", "Find: "), hgt - 1, 0);
-            char ask[81]{};
-            angband_strcpy(ask, finder_str, 80);
-            const auto back_str(finder_str);
-            if (!askfor(ask, 80)) {
-                finder_str = back_str;
+            const auto ask_result = askfor(80, finder_str);
+            if (!ask_result) {
                 continue;
             }
 
-            finder_str = ask;
+            finder_str = *ask_result;
             if (finder_str.empty()) {
                 shower = "";
                 continue;

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -82,7 +82,6 @@ static void print_visuals_menu(concptr choice_msg)
 void do_cmd_visuals(PlayerType *player_ptr)
 {
     FILE *auto_dump_stream;
-    char tmp[160];
     bool need_redraw = false;
     concptr empty_symbol = "<< ? >>";
     if (use_bigtile) {
@@ -90,6 +89,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
     }
 
     screen_save();
+    const auto initial_filename = format("%s.prf", player_ptr->base_name);
     while (true) {
         term_clear();
         print_visuals_menu(nullptr);
@@ -102,24 +102,24 @@ void do_cmd_visuals(PlayerType *player_ptr)
         case '0': {
             prt(_("コマンド: ユーザー設定ファイルのロード", "Command: Load a user pref file"), 15, 0);
             prt(_("ファイル: ", "File: "), 17, 0);
-            strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
-            if (!askfor(tmp, 70)) {
+            const auto ask_result = askfor(70, initial_filename);
+            if (!ask_result) {
                 continue;
             }
 
-            (void)process_pref_file(player_ptr, tmp, true);
+            (void)process_pref_file(player_ptr, *ask_result, true);
             need_redraw = true;
             break;
         }
         case '1': {
             prt(_("コマンド: モンスターの[色/文字]をファイルに書き出します", "Command: Dump monster attr/chars"), 15, 0);
             prt(_("ファイル: ", "File: "), 17, 0);
-            strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
-            if (!askfor(tmp, 70)) {
+            const auto ask_result = askfor(70, initial_filename);
+            if (!ask_result) {
                 continue;
             }
 
-            const auto &path = path_build(ANGBAND_DIR_USER, tmp);
+            const auto &path = path_build(ANGBAND_DIR_USER, *ask_result);
             constexpr auto mark = "Monster attr/chars";
             if (!open_auto_dump(&auto_dump_stream, path, mark)) {
                 continue;
@@ -138,12 +138,12 @@ void do_cmd_visuals(PlayerType *player_ptr)
         case '2': {
             prt(_("コマンド: アイテムの[色/文字]をファイルに書き出します", "Command: Dump object attr/chars"), 15, 0);
             prt(_("ファイル: ", "File: "), 17, 0);
-            strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
-            if (!askfor(tmp, 70)) {
+            const auto ask_result = askfor(70, initial_filename);
+            if (!ask_result) {
                 continue;
             }
 
-            const auto &path = path_build(ANGBAND_DIR_USER, tmp);
+            const auto &path = path_build(ANGBAND_DIR_USER, *ask_result);
             constexpr auto mark = "Object attr/chars";
             if (!open_auto_dump(&auto_dump_stream, path, mark)) {
                 continue;
@@ -175,12 +175,12 @@ void do_cmd_visuals(PlayerType *player_ptr)
         case '3': {
             prt(_("コマンド: 地形の[色/文字]をファイルに書き出します", "Command: Dump feature attr/chars"), 15, 0);
             prt(_("ファイル: ", "File: "), 17, 0);
-            strnfmt(tmp, sizeof(tmp), "%s.prf", player_ptr->base_name);
-            if (!askfor(tmp, 70)) {
+            const auto ask_result = askfor(70, initial_filename);
+            if (!ask_result) {
                 continue;
             }
 
-            const auto &path = path_build(ANGBAND_DIR_USER, tmp);
+            const auto &path = path_build(ANGBAND_DIR_USER, *ask_result);
             constexpr auto mark = "Feature attr/chars";
             if (!open_auto_dump(&auto_dump_stream, path, mark)) {
                 continue;

--- a/src/core/asking-player.h
+++ b/src/core/asking-player.h
@@ -15,7 +15,7 @@ enum class UserCheck {
 };
 
 class PlayerType;
-bool askfor(char *buf, int len, bool numpad_cursor = true);
+std::optional<std::string> askfor(int len, std::string_view initial_value = "", bool numpad_cursor = true);
 std::optional<std::string> input_string(std::string_view prompt, int len, std::string_view initial_value = "", bool numpad_cursor = true);
 bool input_check(std::string_view prompt);
 bool input_check_strict(PlayerType *player_ptr, std::string_view prompt, UserCheck one_mode);

--- a/src/core/show-file.cpp
+++ b/src/core/show-file.cpp
@@ -142,8 +142,6 @@ bool show_file(PlayerType *player_ptr, bool show_version, std::string_view name_
     int wid, hgt;
     term_get_size(&wid, &hgt);
 
-    char finder_str[81] = "";
-    char shower_str[81] = "";
     char hook[68][32]{};
     auto stripped_names = str_split(name_with_tag, '#');
     auto &name = stripped_names[0];
@@ -236,7 +234,9 @@ bool show_file(PlayerType *player_ptr, bool show_version, std::string_view name_
     term_clear();
 
     std::string find;
+    std::string finder_str;
     std::string shower;
+    std::string shower_str;
     while (true) {
         if (line >= size - rows) {
             line = size - rows;
@@ -336,33 +336,31 @@ bool show_file(PlayerType *player_ptr, bool show_version, std::string_view name_
             break;
         case '=': {
             prt(_("強調: ", "Show: "), hgt - 1, 0);
-            char back_str[81];
-            strcpy(back_str, shower_str);
-            if (!askfor(shower_str, 80)) {
-                strcpy(shower_str, back_str);
+            auto ask_result = askfor(80, shower_str);
+            if (!ask_result) {
                 break;
             }
 
-            if (!shower_str[0]) {
+            shower_str = *ask_result;
+            if (shower_str.empty()) {
                 shower.clear();
                 break;
             }
 
-            str_tolower(shower_str);
+            str_tolower(shower_str.data());
             shower = shower_str;
             break;
         }
         case '/':
         case KTRL('s'): {
             prt(_("検索: ", "Find: "), hgt - 1, 0);
-            char back_str[81];
-            strcpy(back_str, finder_str);
-            if (!askfor(finder_str, 80)) {
-                strcpy(finder_str, back_str);
+            auto ask_result = askfor(80, finder_str);
+            if (!ask_result) {
                 break;
             }
 
-            if (!finder_str[0]) {
+            finder_str = *ask_result;
+            if (finder_str.empty()) {
                 shower.clear();
                 break;
             }
@@ -370,29 +368,26 @@ bool show_file(PlayerType *player_ptr, bool show_version, std::string_view name_
             find = finder_str;
             back = line;
             line = line + 1;
-            str_tolower(finder_str);
+            str_tolower(finder_str.data());
             shower = finder_str;
             break;
         }
         case '#': {
-            char tmp[81];
             prt(_("行: ", "Goto Line: "), hgt - 1, 0);
             constexpr auto initial_goto = "0";
             while (true) {
-                strcpy(tmp, initial_goto);
-                if (!askfor(tmp, 10)) {
+                const auto ask_result = askfor(10, initial_goto);
+                if (!ask_result) {
                     break;
                 }
 
                 try {
-                    line = std::stoi(tmp);
+                    line = std::stoi(*ask_result);
                     break;
                 } catch (std::invalid_argument const &) {
                     prt(_("数値を入力して下さい。", "Please input numeric value."), hgt - 1, 0);
-                    continue;
                 } catch (std::out_of_range const &) {
                     prt(_("入力可能な数値の範囲を超えています。", "Input value overflows the maximum number."), hgt - 1, 0);
-                    continue;
                 }
             }
 
@@ -406,13 +401,12 @@ bool show_file(PlayerType *player_ptr, bool show_version, std::string_view name_
             break;
         case '%': {
             prt(_("ファイル・ネーム: ", "Goto File: "), hgt - 1, 0);
-            char tmp[81];
-            strcpy(tmp, _("jhelp.hlp", "help.hlp"));
-            if (!askfor(tmp, 80)) {
+            const auto ask_result = askfor(80, _("jhelp.hlp", "help.hlp"));
+            if (!ask_result) {
                 break;
             }
 
-            if (!show_file(player_ptr, true, tmp, 0, mode)) {
+            if (!show_file(player_ptr, true, *ask_result, 0, mode)) {
                 skey = 'q';
             }
 

--- a/src/player/process-death.cpp
+++ b/src/player/process-death.cpp
@@ -335,17 +335,14 @@ static void export_player_info(PlayerType *player_ptr)
     prt(_("キャラクターの記録をファイルに書き出すことができます。", "You may now dump a character record to one or more files."), 21, 0);
     prt(_("リターンキーでキャラクターを見ます。ESCで中断します。", "Then, hit RETURN to see the character, or ESC to abort."), 22, 0);
     while (true) {
-        char out_val[160] = "";
         put_str(_("ファイルネーム: ", "Filename: "), 23, 0);
-        if (!askfor(out_val, 60)) {
+        const auto ask_result = askfor(60);
+        if (!ask_result || ask_result->empty()) {
             return;
-        }
-        if (!out_val[0]) {
-            break;
         }
 
         screen_save();
-        file_character(player_ptr, out_val);
+        file_character(player_ptr, *ask_result);
         screen_load();
     }
 }


### PR DESCRIPTION
~~【注意！】このコードはマクロ作成時にクラッシュします~~
**修正しました**

見た目だけそれっぽくリファクタリングしました
が、外から降ってきたchar[] を弄くり回すことに特化したコードなので、関数内部でstring を宣言するとあまりうまく行きません
カーソルを左方向に動かす都合上、stringstreamやvector\<char\>もちょっと使いにくいです
何か良さげなアイディアがあるととても助かります

なお本件をもって静的解析警告を全部除去できます
(ここまで来といてaskforと直接関係ないんちゃうかとは思いつつ無視)