### PR TITLE
[Chore] ccacheが使用するキャッシュを分け、ビルドテストを並列に実行できるようにする

### DIFF
--- a/.github/workflows/build-with-autotools.yml
+++ b/.github/workflows/build-with-autotools.yml
@@ -37,6 +37,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ steps.calculate-cache-key.outputs.key }}
+          max-size: "200M"
 
       - name: Configuring ccache to use precompiled headers
         if: ${{ inputs.use-ccache }}

--- a/.github/workflows/build-with-autotools.yml
+++ b/.github/workflows/build-with-autotools.yml
@@ -27,8 +27,16 @@ jobs:
         with:
           submodules: true
 
+      - id: calculate-cache-key
+        name: Calculate cache key for ccache
+        run: |
+          key=$(echo "${{ inputs.cxx }} ${{ inputs.cxx-flags }} ${{ inputs.configure-opts }}" | sha256sum | cut -d' ' -f1)
+          echo "key=$key" >> $GITHUB_OUTPUT
+
       - if: ${{ inputs.use-ccache }}
         uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ steps.calculate-cache-key.outputs.key }}
 
       - name: Configuring ccache to use precompiled headers
         if: ${{ inputs.use-ccache }}

--- a/.github/workflows/create-cache-for-ccache.yml
+++ b/.github/workflows/create-cache-for-ccache.yml
@@ -20,7 +20,6 @@ jobs:
 
   gcc_japanese:
     name: Japanese version with gcc
-    needs: clang_without_pch_japanese
     uses: ./.github/workflows/build-with-autotools.yml
     with:
       cxx: g++-11
@@ -29,7 +28,6 @@ jobs:
 
   gcc_english:
     name: English version with gcc
-    needs: gcc_japanese
     uses: ./.github/workflows/build-with-autotools.yml
     with:
       cxx: g++-11

--- a/.github/workflows/pull-request-status-check.yml
+++ b/.github/workflows/pull-request-status-check.yml
@@ -33,7 +33,6 @@ jobs:
 
   build_test_japanese:
     name: Build Japanese version with gcc
-    needs: build_test_clang_without_pch
     uses: ./.github/workflows/build-with-autotools.yml
     with:
       cxx: g++-11
@@ -42,7 +41,6 @@ jobs:
 
   build_test_english:
     name: Build English version with gcc
-    needs: build_test_japanese
     uses: ./.github/workflows/build-with-autotools.yml
     with:
       cxx: g++-11


### PR DESCRIPTION
Resolves #3522 

詳しい変更内容はコミットログをご確認ください。