### PR TITLE
買い物や自宅のアイテム選択中にESCキーが反応しない不具合を修正した

### DIFF
--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -170,11 +170,11 @@ int get_stock(COMMAND_CODE *com_val, concptr pmt, int i, int j, [[maybe_unused]]
     const auto prompt = format("(Items %c-%c, ESC to exit) %s", lo, hi, pmt);
 #endif
 
-    char command;
+    auto command = ESCAPE;
     while (true) {
         const auto command_opt = input_command(prompt);
         if (!command_opt.has_value()) {
-            continue;
+            break;
         }
 
         command = command_opt.value();


### PR DESCRIPTION
掲題の通りです、ご確認下さい
回避策はあるので緊急リリースまでは不要と思われます