### PR TITLE
[Fix] 博物館で240個までしかアイテムが表示されない

### DIFF
--- a/src/store/store-key-processor.cpp
+++ b/src/store/store-key-processor.cpp
@@ -95,7 +95,7 @@ void store_process_command(PlayerType *player_ptr, StoreSaleType store_num)
              * 隠しオプション(powerup_home)がセットされていないときは
              * 我が家では 2 ページまでしか表示しない
              */
-            auto inven_max = store_get_stock_max(StoreSaleType::HOME, powerup_home);
+            auto inven_max = store_get_stock_max(store_num, powerup_home);
             if (store_top >= st_ptr->stock_num || store_top >= inven_max) {
                 store_top = 0;
             }


### PR DESCRIPTION
Resolves #3542 

アイテムの個数の上限を得る関数 store_get_stock_max を常に引数 StoreSaleType::HOME で呼んでしまっており、我が家と同等の個数しか表示できなくなってしまっている。
引数に実際の店舗の値を渡すように修正する。
