### PR TITLE
アーティファクトスポイラー周りのシグネチャ整理

### DIFF
--- a/src/io-dump/random-art-info-dumper.cpp
+++ b/src/io-dump/random-art-info-dumper.cpp
@@ -24,12 +24,12 @@
 static void spoiler_print_randart(ItemEntity *o_ptr, obj_desc_list *art_ptr)
 {
     const auto finalizer = util::make_finalizer([art_ptr]() {
-        fprintf(spoiler_file, "%s%s\n\n", spoiler_indent, art_ptr->misc_desc.data());
+        fprintf(spoiler_file, "%s%s\n\n", spoiler_indent.data(), art_ptr->misc_desc.data());
     });
     const auto *pval_ptr = &art_ptr->pval_info;
     fprintf(spoiler_file, "%s\n", art_ptr->description.data());
     if (!o_ptr->is_fully_known()) {
-        fprintf(spoiler_file, _("%s不明\n", "%sUnknown\n"), spoiler_indent);
+        fprintf(spoiler_file, _("%s不明\n", "%sUnknown\n"), spoiler_indent.data());
         return;
     }
 
@@ -46,7 +46,7 @@ static void spoiler_print_randart(ItemEntity *o_ptr, obj_desc_list *art_ptr)
     spoiler_outlist(_("維持:", "Sustain"), art_ptr->sustenances, item_separator);
     spoiler_outlist("", art_ptr->misc_magic, list_separator);
     if (!art_ptr->activation.empty()) {
-        fprintf(spoiler_file, _("%s発動: %s\n", "%sActivates for %s\n"), spoiler_indent, art_ptr->activation.data());
+        fprintf(spoiler_file, _("%s発動: %s\n", "%sActivates for %s\n"), spoiler_indent.data(), art_ptr->activation.data());
     }
 }
 

--- a/src/object/object-info.cpp
+++ b/src/object/object-info.cpp
@@ -40,7 +40,7 @@
  * @param o_ptr 名称を取得する元のオブジェクト構造体参照ポインタ
  * @return std::string 発動名称を返す文字列ポインタ
  */
-static std::string item_activation_dragon_breath(ItemEntity *o_ptr)
+static std::string item_activation_dragon_breath(const ItemEntity *o_ptr)
 {
     std::string desc = _("", "breathe ");
     int n = 0;
@@ -67,7 +67,7 @@ static std::string item_activation_dragon_breath(ItemEntity *o_ptr)
  * @param o_ptr 名称を取得する元のオブジェクト構造体参照ポインタ
  * @return concptr 発動名称を返す文字列ポインタ
  */
-static concptr item_activation_aux(ItemEntity *o_ptr)
+static concptr item_activation_aux(const ItemEntity *o_ptr)
 {
     static std::string activation_detail;
     auto tmp_act_ptr = find_activation_info(o_ptr);
@@ -185,7 +185,7 @@ static concptr item_activation_aux(ItemEntity *o_ptr)
  * @param o_ptr 名称を取得する元のオブジェクト構造体参照ポインタ
  * @return concptr 発動名称を返す文字列ポインタ
  */
-std::string activation_explanation(ItemEntity *o_ptr)
+std::string activation_explanation(const ItemEntity *o_ptr)
 {
     auto flags = object_flags(o_ptr);
     if (flags.has_not(TR_ACTIVATE)) {

--- a/src/object/object-info.h
+++ b/src/object/object-info.h
@@ -9,7 +9,7 @@
 class BaseitemKey;
 class ItemEntity;
 class PlayerType;
-std::string activation_explanation(ItemEntity *o_ptr);
+std::string activation_explanation(const ItemEntity *o_ptr);
 char index_to_label(int i);
 int16_t wield_slot(PlayerType *player_ptr, const ItemEntity *o_ptr);
 bool check_book_realm(PlayerType *player_ptr, const BaseitemKey &bi_key);

--- a/src/wizard/artifact-analyzer.cpp
+++ b/src/wizard/artifact-analyzer.cpp
@@ -23,7 +23,7 @@
  * @param o_ptr 記述を得たいオブジェクトの参照ポインタ
  * @param desc_ptr 記述内容を返すための文字列参照ポインタ
  */
-static std::string analyze_general(PlayerType *player_ptr, ItemEntity *o_ptr)
+static std::string analyze_general(PlayerType *player_ptr, const ItemEntity *o_ptr)
 {
     return describe_flavor(player_ptr, o_ptr, OD_NAME_AND_ENCHANT | OD_STORE | OD_DEBUG);
 }
@@ -34,7 +34,7 @@ static std::string analyze_general(PlayerType *player_ptr, ItemEntity *o_ptr)
  * @param o_ptr オブジェクト構造体の参照ポインタ
  * @param slay_list 種族スレイ構造体の参照ポインタ
  */
-static std::vector<std::string> analyze_slay(ItemEntity *o_ptr)
+static std::vector<std::string> analyze_slay(const ItemEntity *o_ptr)
 {
     auto flags = object_flags(o_ptr);
     return extract_spoiler_flags(flags, slay_flags_desc);
@@ -46,7 +46,7 @@ static std::vector<std::string> analyze_slay(ItemEntity *o_ptr)
  * @param o_ptr オブジェクト構造体の参照ポインタ
  * @param brand_list 属性ブランド構造体の参照ポインタ
  */
-static std::vector<std::string> analyze_brand(ItemEntity *o_ptr)
+static std::vector<std::string> analyze_brand(const ItemEntity *o_ptr)
 {
     auto flags = object_flags(o_ptr);
     return extract_spoiler_flags(flags, brand_flags_desc);
@@ -58,7 +58,7 @@ static std::vector<std::string> analyze_brand(ItemEntity *o_ptr)
  * @param o_ptr オブジェクト構造体の参照ポインタ
  * @param resist_list 通常耐性構造体の参照ポインタ
  */
-static std::vector<std::string> analyze_resist(ItemEntity *o_ptr)
+static std::vector<std::string> analyze_resist(const ItemEntity *o_ptr)
 {
     auto flags = object_flags(o_ptr);
     return extract_spoiler_flags(flags, resist_flags_desc);
@@ -70,7 +70,7 @@ static std::vector<std::string> analyze_resist(ItemEntity *o_ptr)
  * @param o_ptr オブジェクト構造体の参照ポインタ
  * @param immune_list 免疫構造体の参照ポインタ
  */
-static std::vector<std::string> analyze_immune(ItemEntity *o_ptr)
+static std::vector<std::string> analyze_immune(const ItemEntity *o_ptr)
 {
     auto flags = object_flags(o_ptr);
     return extract_spoiler_flags(flags, immune_flags_desc);
@@ -82,7 +82,7 @@ static std::vector<std::string> analyze_immune(ItemEntity *o_ptr)
  * @param o_ptr オブジェクト構造体の参照ポインタ
  * @param immune_list 弱点構造体の参照ポインタ
  */
-static std::vector<std::string> analyze_vulnerable(ItemEntity *o_ptr)
+static std::vector<std::string> analyze_vulnerable(const ItemEntity *o_ptr)
 {
     auto flags = object_flags(o_ptr);
     return extract_spoiler_flags(flags, vulnerable_flags_desc);
@@ -94,7 +94,7 @@ static std::vector<std::string> analyze_vulnerable(ItemEntity *o_ptr)
  * @param o_ptr オブジェクト構造体の参照ポインタ
  * @param sustain_list 維持特性構造体の参照ポインタ
  */
-static std::vector<std::string> analyze_sustains(ItemEntity *o_ptr)
+static std::vector<std::string> analyze_sustains(const ItemEntity *o_ptr)
 {
     auto flags = object_flags(o_ptr);
     if (flags.has_all_of(EnumRange(TR_SUST_STR, TR_SUST_CHR))) {
@@ -115,7 +115,7 @@ static std::vector<std::string> analyze_sustains(ItemEntity *o_ptr)
  * @param o_ptr オブジェクト構造体の参照ポインタ
  * @param misc_list その他の特性構造体の参照ポインタ
  */
-static std::vector<std::string> analyze_misc_magic(ItemEntity *o_ptr)
+static std::vector<std::string> analyze_misc_magic(const ItemEntity *o_ptr)
 {
     std::vector<std::string> descriptions{};
     auto flags = object_flags(o_ptr);
@@ -199,7 +199,7 @@ static std::vector<std::string> analyze_misc_magic(ItemEntity *o_ptr)
  * @param addition 追加ランダム耐性構造体の参照ポインタ
  * @param addition_sz addition に書き込めるバイト数
  */
-static std::string analyze_addition(ItemEntity *o_ptr)
+static std::string analyze_addition(const ItemEntity *o_ptr)
 {
     const auto &artifact = o_ptr->get_fixed_artifact();
     std::stringstream ss;
@@ -239,7 +239,7 @@ static std::string analyze_addition(ItemEntity *o_ptr)
  * @param misc_desc 基本情報を収める文字列参照ポインタ
  * @param misc_desc_sz misc_desc に書き込めるバイト数
  */
-static std::string analyze_misc(ItemEntity *o_ptr)
+static std::string analyze_misc(const ItemEntity *o_ptr)
 {
     const auto &artifact = o_ptr->get_fixed_artifact();
     constexpr auto fmt = _("レベル %d, 希少度 %u, %d.%d kg, ＄%d", "Level %d, Rarity %u, %d.%d lbs, %d Gold");
@@ -254,7 +254,7 @@ static std::string analyze_misc(ItemEntity *o_ptr)
  * @param o_ptr オブジェクト構造体の参照ポインタ
  * @param desc_ptr 全アーティファクト情報を収める文字列参照ポインタ
  */
-void object_analyze(PlayerType *player_ptr, ItemEntity *o_ptr, obj_desc_list *desc_ptr)
+void object_analyze(PlayerType *player_ptr, const ItemEntity *o_ptr, obj_desc_list *desc_ptr)
 {
     desc_ptr->description = analyze_general(player_ptr, o_ptr);
     desc_ptr->pval_info.analyze(*o_ptr);
@@ -276,7 +276,7 @@ void object_analyze(PlayerType *player_ptr, ItemEntity *o_ptr, obj_desc_list *de
  * @param o_ptr ランダムアーティファクトのオブジェクト構造体参照ポインタ
  * @param desc_ptr 記述内容を収める構造体参照ポインタ
  */
-void random_artifact_analyze(PlayerType *player_ptr, ItemEntity *o_ptr, obj_desc_list *desc_ptr)
+void random_artifact_analyze(PlayerType *player_ptr, const ItemEntity *o_ptr, obj_desc_list *desc_ptr)
 {
     desc_ptr->description = analyze_general(player_ptr, o_ptr);
     desc_ptr->pval_info.analyze(*o_ptr);

--- a/src/wizard/artifact-analyzer.h
+++ b/src/wizard/artifact-analyzer.h
@@ -3,5 +3,5 @@
 class ItemEntity;
 struct obj_desc_list;
 class PlayerType;
-void object_analyze(PlayerType *player_ptr, ItemEntity *o_ptr, obj_desc_list *desc_ptr);
-void random_artifact_analyze(PlayerType *player_ptr, ItemEntity *o_ptr, obj_desc_list *desc_ptr);
+void object_analyze(PlayerType *player_ptr, const ItemEntity *o_ptr, obj_desc_list *desc_ptr);
+void random_artifact_analyze(PlayerType *player_ptr, const ItemEntity *o_ptr, obj_desc_list *desc_ptr);

--- a/src/wizard/fixed-artifacts-spoiler.cpp
+++ b/src/wizard/fixed-artifacts-spoiler.cpp
@@ -124,7 +124,9 @@ SpoilerOutputResultType spoil_fixed_artifact()
         return SpoilerOutputResultType::FILE_OPEN_FAILED;
     }
 
-    spoiler_underline(std::string("Artifact Spoilers for Hengband Version ").append(get_version()).data());
+    std::stringstream ss;
+    ss << "Artifact Spoilers for Hengband Version " << get_version();
+    spoiler_underline(ss.str());
     for (const auto &[tval_list, name] : group_artifact_list) {
         spoiler_blanklines(2);
         spoiler_underline(name);

--- a/src/wizard/fixed-artifacts-spoiler.cpp
+++ b/src/wizard/fixed-artifacts-spoiler.cpp
@@ -103,14 +103,14 @@ static void spoiler_print_art(obj_desc_list *art_ptr)
     spoiler_outlist("", art_ptr->misc_magic, list_separator);
 
     if (!art_ptr->addition.empty()) {
-        fprintf(spoiler_file, _("%s追加: %s\n", "%sAdditional %s\n"), spoiler_indent, art_ptr->addition.data());
+        fprintf(spoiler_file, _("%s追加: %s\n", "%sAdditional %s\n"), spoiler_indent.data(), art_ptr->addition.data());
     }
 
     if (!art_ptr->activation.empty()) {
-        fprintf(spoiler_file, _("%s発動: %s\n", "%sActivates for %s\n"), spoiler_indent, art_ptr->activation.data());
+        fprintf(spoiler_file, _("%s発動: %s\n", "%sActivates for %s\n"), spoiler_indent.data(), art_ptr->activation.data());
     }
 
-    fprintf(spoiler_file, "%s%s\n\n", spoiler_indent, art_ptr->misc_desc.data());
+    fprintf(spoiler_file, "%s%s\n\n", spoiler_indent.data(), art_ptr->misc_desc.data());
 }
 
 /*!

--- a/src/wizard/fixed-artifacts-spoiler.cpp
+++ b/src/wizard/fixed-artifacts-spoiler.cpp
@@ -57,35 +57,26 @@ void spoiler_outlist(std::string_view header, const std::vector<std::string> &de
 }
 
 /*!
- * @brief アーティファクト情報を出力するためにダミー生成を行う /
- * Hack -- Create a "forged" artifact
- * @param o_ptr 一時生成先を保管するオブジェクト構造体
+ * @brief アーティファクト情報を出力するためにダミー生成を行う
  * @param fixed_artifact_idx 生成するアーティファクトID
- * @return 生成が成功した場合TRUEを返す
+ * @return 生成したアーティファクト (連番で埋まっているので不存在例外は吐かない)
  */
-static bool make_fake_artifact(ItemEntity *o_ptr, FixedArtifactId fixed_artifact_idx)
+static ItemEntity make_fake_artifact(FixedArtifactId fixed_artifact_idx)
 {
     const auto &artifact = ArtifactsInfo::get_instance().get_artifact(fixed_artifact_idx);
-    if (artifact.name.empty()) {
-        return false;
-    }
-
     const auto bi_id = lookup_baseitem_id(artifact.bi_key);
-    if (bi_id == 0) {
-        return false;
-    }
-
-    o_ptr->prep(bi_id);
-    o_ptr->fixed_artifact_idx = fixed_artifact_idx;
-    o_ptr->pval = artifact.pval;
-    o_ptr->ac = artifact.ac;
-    o_ptr->dd = artifact.dd;
-    o_ptr->ds = artifact.ds;
-    o_ptr->to_a = artifact.to_a;
-    o_ptr->to_h = artifact.to_h;
-    o_ptr->to_d = artifact.to_d;
-    o_ptr->weight = artifact.weight;
-    return true;
+    ItemEntity item;
+    item.prep(bi_id);
+    item.fixed_artifact_idx = fixed_artifact_idx;
+    item.pval = artifact.pval;
+    item.ac = artifact.ac;
+    item.dd = artifact.dd;
+    item.ds = artifact.ds;
+    item.to_a = artifact.to_a;
+    item.to_h = artifact.to_h;
+    item.to_d = artifact.to_d;
+    item.weight = artifact.weight;
+    return item;
 }
 
 /*!
@@ -147,11 +138,7 @@ SpoilerOutputResultType spoil_fixed_artifact(concptr fname)
                     continue;
                 }
 
-                ItemEntity item;
-                if (!make_fake_artifact(&item, a_idx)) {
-                    continue;
-                }
-
+                const auto item = make_fake_artifact(a_idx);
                 PlayerType dummy;
                 obj_desc_list artifact_descriptions;
                 object_analyze(&dummy, &item, &artifact_descriptions);

--- a/src/wizard/fixed-artifacts-spoiler.cpp
+++ b/src/wizard/fixed-artifacts-spoiler.cpp
@@ -114,13 +114,11 @@ static void spoiler_print_art(obj_desc_list *art_ptr)
 }
 
 /*!
- * @brief アーティファクト情報のスポイラー出力を行うメインルーチン /
- * Create a spoiler file for artifacts
- * @param fname 生成ファイル名
+ * @brief アーティファクト情報のスポイラー出力を行うメインルーチン
  */
-SpoilerOutputResultType spoil_fixed_artifact(concptr fname)
+SpoilerOutputResultType spoil_fixed_artifact()
 {
-    const auto &path = path_build(ANGBAND_DIR_USER, fname);
+    const auto &path = path_build(ANGBAND_DIR_USER, "artifact.txt");
     spoiler_file = angband_fopen(path, FileOpenMode::WRITE);
     if (!spoiler_file) {
         return SpoilerOutputResultType::FILE_OPEN_FAILED;

--- a/src/wizard/fixed-artifacts-spoiler.h
+++ b/src/wizard/fixed-artifacts-spoiler.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include "system/angband.h"
-#include "wizard/spoiler-util.h"
+#include <string>
+#include <string_view>
+#include <vector>
 
+enum class SpoilerOutputResultType;
 void spoiler_outlist(std::string_view header, const std::vector<std::string> &descriptions, char seperator);
-SpoilerOutputResultType spoil_fixed_artifact(concptr fname);
+SpoilerOutputResultType spoil_fixed_artifact();

--- a/src/wizard/spoiler-util.cpp
+++ b/src/wizard/spoiler-util.cpp
@@ -5,7 +5,7 @@
 const char item_separator = ',';
 const char list_separator = _(',', ';');
 const int max_evolution_depth = 64;
-concptr spoiler_indent = "    ";
+const std::string spoiler_indent = "    ";
 
 /* The spoiler file being created */
 FILE *spoiler_file = nullptr;

--- a/src/wizard/spoiler-util.cpp
+++ b/src/wizard/spoiler-util.cpp
@@ -56,10 +56,10 @@ void spoiler_blanklines(int n)
  * Write a line to the spoiler file and then "underline" it with hypens
  * @param str 出力したい文字列
  */
-void spoiler_underline(concptr str)
+void spoiler_underline(std::string_view str)
 {
-    fprintf(spoiler_file, "%s\n", str);
-    spoiler_out_n_chars(strlen(str), '-');
+    fprintf(spoiler_file, "%s\n", str.data());
+    spoiler_out_n_chars(str.length(), '-');
     fprintf(spoiler_file, "\n");
 }
 

--- a/src/wizard/spoiler-util.h
+++ b/src/wizard/spoiler-util.h
@@ -49,7 +49,7 @@ struct obj_desc_list {
 extern const char item_separator;
 extern const char list_separator;
 extern const int max_evolution_depth;
-extern concptr spoiler_indent;
+extern const std::string spoiler_indent;
 extern FILE *spoiler_file;
 
 struct flag_desc;

--- a/src/wizard/spoiler-util.h
+++ b/src/wizard/spoiler-util.h
@@ -55,5 +55,5 @@ extern FILE *spoiler_file;
 struct flag_desc;
 std::vector<std::string> extract_spoiler_flags(const TrFlags &art_flags, const std::vector<flag_desc> &definitions);
 void spoiler_blanklines(int n);
-void spoiler_underline(concptr str);
+void spoiler_underline(std::string_view str);
 void spoil_out(std::string_view sv, bool flush_buffer = false);

--- a/src/wizard/wizard-spoiler.cpp
+++ b/src/wizard/wizard-spoiler.cpp
@@ -47,6 +47,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <string_view>
 
 static constexpr std::array<std::string_view, 6> wiz_spell_stat = { {
     _("腕力", "STR"),
@@ -62,7 +63,7 @@ static constexpr std::array<std::string_view, 6> wiz_spell_stat = { {
  *
  * @return 進化ツリーの一番根元となるモンスターのIDのリスト(std::setで、evol_root_sortによりソートされている)
  */
-static auto get_mon_evol_roots(void)
+static auto get_mon_evol_roots()
 {
     std::set<MonsterRaceId> evol_parents;
     std::set<MonsterRaceId> evol_children;
@@ -93,13 +94,12 @@ static auto get_mon_evol_roots(void)
 }
 
 /*!
- * @brief 進化ツリーをスポイラー出力するメインルーチン /
- * Print monsters' evolution information to file
- * @param fname 出力ファイル名
+ * @brief 進化ツリーをスポイラー出力するメインルーチン
+ * @param filename 出力ファイル名
  */
-static SpoilerOutputResultType spoil_mon_evol(concptr fname)
+static SpoilerOutputResultType spoil_mon_evol(std::string_view filename)
 {
-    const auto &path = path_build(ANGBAND_DIR_USER, fname);
+    const auto &path = path_build(ANGBAND_DIR_USER, filename);
     spoiler_file = angband_fopen(path, FileOpenMode::WRITE);
     if (!spoiler_file) {
         return SpoilerOutputResultType::FILE_OPEN_FAILED;
@@ -255,7 +255,7 @@ void exe_output_spoilers(void)
             status = spoil_obj_desc("obj-desc.txt");
             break;
         case '2':
-            status = spoil_fixed_artifact("artifact.txt");
+            status = spoil_fixed_artifact();
             break;
         case '3':
             status = spoil_mon_desc("mon-desc.txt");
@@ -306,7 +306,7 @@ SpoilerOutputResultType output_all_spoilers(void)
         return status;
     }
 
-    status = spoil_fixed_artifact("artifact.txt");
+    status = spoil_fixed_artifact();
     if (status != SpoilerOutputResultType::SUCCESSFUL) {
         return status;
     }


### PR DESCRIPTION
主に「引数にポインタを入れて関数内でアドレス代入」から「戻り値で返す」に変えたものです
固定/ランダムアーティファクト共に正常動作しています
ご確認下さい