### PR TITLE
[Fix] クエスト「もの言えぬ証人」のクローカーのマスが暗い

### DIFF
--- a/lib/edit/quests/034_DumpWitness.txt
+++ b/lib/edit/quests/034_DumpWitness.txt
@@ -56,7 +56,7 @@ F:%:FLOOR:10:0:395
 
 
 # Cloaker
-F:(:FLOOR:8:243
+F:(:FLOOR:10:243
 # Death sword
 F:|:FLOOR:8:107
 # Killer bee


### PR DESCRIPTION
Resolves #3551 

クエスト「もの言えぬ証人」は部屋の中が最初から明るく照らされた状態になっているが、クローカーのいるマスだけ照らされていない状態になっている。
モンスターを設置しているマスが暗いのはチュートリアルクエストとして範囲の狭い光源の危険性を認知してもらうための意図的なものだったが、これについては扉の奥のデスソードでも伝えられ、クローカーのマスに関してはやや不自然な挙動ではあるので最初からあかるく照らされた状態に修正する。
