### PR TITLE
[Fix] GitHub Actionsによる自動生成スポイラーページの公開に失敗する

### DIFF
--- a/.github/workflows/publish-spoiler-page.yml
+++ b/.github/workflows/publish-spoiler-page.yml
@@ -25,7 +25,7 @@ jobs:
         run: ./bootstrap
 
       - name: Configuration for Japanese version
-        run: ./configure --disable-worldscore
+        run: ./configure --disable-net
         env:
           CFLAGS: "-pipe"
 


### PR DESCRIPTION
ネット機能の実装により --disable-worldscore だけでは libcurl が依然とし て必要になったため、--disable-net を指定するようにして libcurl のインストールをしなくてもコンパイルできるように修正する。

この修正が適用された段階で自動生成スポイラーページ公開のGitHub Actionsを手動起動すると、3.0.0.87-Alpha公開後に追加されたサルーインが含まれてしまうので、とりあえず修正だけしておき公開は次回リリース時のCIにて行う。