### PR TITLE
spoiler_file グローバル変数の使用箇所削減 その2

### DIFF
--- a/src/wizard/monster-info-spoiler.cpp
+++ b/src/wizard/monster-info-spoiler.cpp
@@ -79,15 +79,15 @@ SpoilerOutputResultType spoil_mon_desc(std::string_view filename, std::function<
     PlayerType dummy;
     uint16_t why = 2;
     const auto &path = path_build(ANGBAND_DIR_USER, filename);
-    spoiler_file = angband_fopen(path, FileOpenMode::WRITE);
-    if (!spoiler_file) {
+    std::ofstream ofs(path);
+    if (!ofs) {
         return SpoilerOutputResultType::FILE_OPEN_FAILED;
     }
 
-    fprintf(spoiler_file, "Monster Spoilers for %s\n", get_version().data());
-    fprintf(spoiler_file, "------------------------------------------\n\n");
-    fprintf(spoiler_file, "%-45.45s%4s %4s %4s %7s %7s  %19.19s\n", "Name", "Lev", "Rar", "Spd", "Hp", "Ac", "Visual Info");
-    fprintf(spoiler_file, "%-45.45s%4s %4s %4s %7s %7s  %4.19s\n",
+    ofs << format("Monster Spoilers for %s\n", get_version().data());
+    ofs << "------------------------------------------\n\n";
+    ofs << format("%-45.45s%4s %4s %4s %7s %7s  %19.19s\n", "Name", "Lev", "Rar", "Spd", "Hp", "Ac", "Visual Info");
+    ofs << format("%-45.45s%4s %4s %4s %7s %7s  %4.19s\n",
         "---------------------------------------------"
         "----"
         "----------",
@@ -134,18 +134,17 @@ SpoilerOutputResultType spoil_mon_desc(std::string_view filename, std::function<
         }
 
         const auto symbol = format("%s '%c'", attr_to_text(r_ptr), r_ptr->d_char);
-        fprintf(spoiler_file, "%-45.45s%4s %4s %4s %7s %7s  %19.19s\n",
+        ofs << format("%-45.45s%4s %4s %4s %7s %7s  %19.19s\n",
             nam.data(), lev.data(), rar.data(), spd.data(), hp.data(),
             ac.data(), symbol.data());
 
         for (auto i = 1U; i < name.size(); ++i) {
-            fprintf(spoiler_file, "    %s\n", name[i].data());
+            ofs << format("    %s\n", name[i].data());
         }
     }
 
-    fprintf(spoiler_file, "\n");
-    return ferror(spoiler_file) || angband_fclose(spoiler_file) ? SpoilerOutputResultType::FILE_CLOSE_FAILED
-                                                                : SpoilerOutputResultType::SUCCESSFUL;
+    ofs << '\n';
+    return ofs.good() ? SpoilerOutputResultType::SUCCESSFUL : SpoilerOutputResultType::FILE_CLOSE_FAILED;
 }
 
 /*!

--- a/src/wizard/monster-info-spoiler.cpp
+++ b/src/wizard/monster-info-spoiler.cpp
@@ -14,6 +14,7 @@
 #include "util/string-processor.h"
 #include "view/display-lore.h"
 #include "view/display-messages.h"
+#include "wizard/spoiler-util.h"
 
 /*!
  * @brief シンボル職の記述名を返す /
@@ -156,7 +157,7 @@ SpoilerOutputResultType spoil_mon_desc(std::string_view filename, std::function<
 static void roff_func(TERM_COLOR attr, std::string_view str)
 {
     (void)attr;
-    spoil_out(str.data());
+    spoil_out(str);
 }
 
 /*!

--- a/src/wizard/monster-info-spoiler.cpp
+++ b/src/wizard/monster-info-spoiler.cpp
@@ -73,11 +73,11 @@ static concptr attr_to_text(MonsterRaceInfo *r_ptr)
     return _("変な色の", "Icky");
 }
 
-SpoilerOutputResultType spoil_mon_desc(concptr fname, std::function<bool(const MonsterRaceInfo *)> filter_monster)
+SpoilerOutputResultType spoil_mon_desc(std::string_view filename, std::function<bool(const MonsterRaceInfo *)> filter_monster)
 {
     PlayerType dummy;
     uint16_t why = 2;
-    const auto &path = path_build(ANGBAND_DIR_USER, fname);
+    const auto &path = path_build(ANGBAND_DIR_USER, filename);
     spoiler_file = angband_fopen(path, FileOpenMode::WRITE);
     if (!spoiler_file) {
         return SpoilerOutputResultType::FILE_OPEN_FAILED;
@@ -164,10 +164,10 @@ static void roff_func(TERM_COLOR attr, std::string_view str)
  * Create a spoiler file for monsters (-SHAWN-)
  * @param fname ファイル名
  */
-SpoilerOutputResultType spoil_mon_info(concptr fname)
+SpoilerOutputResultType spoil_mon_info()
 {
     PlayerType dummy;
-    const auto &path = path_build(ANGBAND_DIR_USER, fname);
+    const auto &path = path_build(ANGBAND_DIR_USER, "mon-info.txt");
     spoiler_file = angband_fopen(path, FileOpenMode::WRITE);
     if (!spoiler_file) {
         return SpoilerOutputResultType::FILE_OPEN_FAILED;

--- a/src/wizard/monster-info-spoiler.h
+++ b/src/wizard/monster-info-spoiler.h
@@ -1,11 +1,9 @@
 #pragma once
 
-#include "system/angband.h"
 #include "wizard/spoiler-util.h"
-
 #include <functional>
+#include <string_view>
 
 class MonsterRaceInfo;
-SpoilerOutputResultType spoil_mon_desc_all(concptr fname);
-SpoilerOutputResultType spoil_mon_desc(concptr fname, std::function<bool(const MonsterRaceInfo *)> filter_monster = nullptr);
-SpoilerOutputResultType spoil_mon_info(concptr fname);
+SpoilerOutputResultType spoil_mon_desc(std::string_view filename, std::function<bool(const MonsterRaceInfo *)> filter_monster = nullptr);
+SpoilerOutputResultType spoil_mon_info();

--- a/src/wizard/monster-info-spoiler.h
+++ b/src/wizard/monster-info-spoiler.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "wizard/spoiler-util.h"
 #include <functional>
 #include <string_view>
 
+enum class SpoilerOutputResultType;
 class MonsterRaceInfo;
 SpoilerOutputResultType spoil_mon_desc(std::string_view filename, std::function<bool(const MonsterRaceInfo *)> filter_monster = nullptr);
 SpoilerOutputResultType spoil_mon_info();

--- a/src/wizard/wizard-spoiler.cpp
+++ b/src/wizard/wizard-spoiler.cpp
@@ -95,6 +95,8 @@ static auto get_mon_evol_roots()
 
 /*!
  * @brief 進化ツリーをスポイラー出力するメインルーチン
+ *
+ * fprintf() に'%' (壁)を渡すとフォーマット指定子扱いされるので、関数の外でフォーマットしてはいけない.
  */
 static SpoilerOutputResultType spoil_mon_evol()
 {
@@ -110,14 +112,14 @@ static SpoilerOutputResultType spoil_mon_evol()
     spoil_out("------------------------------------------\n\n");
     for (auto r_idx : get_mon_evol_roots()) {
         auto r_ptr = &monraces_info[r_idx];
-        fprintf(spoiler_file, _("[%d]: %s (レベル%d, '%c')\n", "[%d]: %s (Level %d, '%c')\n"), enum2i(r_idx), r_ptr->name.data(), (int)r_ptr->level, r_ptr->d_char);
-
+        constexpr auto fmt_before = _("[%d]: %s (レベル%d, '%c')\n", "[%d]: %s (Level %d, '%c')\n");
+        fprintf(spoiler_file, fmt_before, enum2i(r_idx), r_ptr->name.data(), (int)r_ptr->level, r_ptr->d_char);
         for (auto n = 1; MonsterRace(r_ptr->next_r_idx).is_valid(); n++) {
             fprintf(spoiler_file, "%*s-(%d)-> ", n * 2, "", r_ptr->next_exp);
             fprintf(spoiler_file, "[%d]: ", enum2i(r_ptr->next_r_idx));
             r_ptr = &monraces_info[r_ptr->next_r_idx];
-
-            fprintf(spoiler_file, _("%s (レベル%d, '%c')\n", "%s (Level %d, '%c')\n"), r_ptr->name.data(), (int)r_ptr->level, r_ptr->d_char);
+            constexpr auto fmt_after = _("%s (レベル%d, '%c')\n", "%s (Level %d, '%c')\n");
+            fprintf(spoiler_file, fmt_after, r_ptr->name.data(), (int)r_ptr->level, r_ptr->d_char);
         }
 
         fputc('\n', spoiler_file);
@@ -173,9 +175,9 @@ static SpoilerOutputResultType spoil_categorized_mon_desc()
     return status;
 }
 
-static SpoilerOutputResultType spoil_player_spell(concptr fname)
+static SpoilerOutputResultType spoil_player_spell()
 {
-    const auto &path = path_build(ANGBAND_DIR_USER, fname);
+    const auto &path = path_build(ANGBAND_DIR_USER, "spells.txt");
     spoiler_file = angband_fopen(path, FileOpenMode::WRITE);
     if (!spoiler_file) {
         return SpoilerOutputResultType::FILE_OPEN_FAILED;
@@ -263,13 +265,13 @@ void exe_output_spoilers(void)
             status = spoil_categorized_mon_desc();
             break;
         case '5':
-            status = spoil_mon_info("mon-info.txt");
+            status = spoil_mon_info();
             break;
         case '6':
             status = spoil_mon_evol();
             break;
         case '7':
-            status = spoil_player_spell("spells.txt");
+            status = spoil_player_spell();
             break;
         default:
             bell();
@@ -320,7 +322,7 @@ SpoilerOutputResultType output_all_spoilers()
         return status;
     }
 
-    status = spoil_mon_info("mon-info.txt");
+    status = spoil_mon_info();
     if (status != SpoilerOutputResultType::SUCCESSFUL) {
         return status;
     }

--- a/src/wizard/wizard-spoiler.cpp
+++ b/src/wizard/wizard-spoiler.cpp
@@ -95,11 +95,10 @@ static auto get_mon_evol_roots()
 
 /*!
  * @brief 進化ツリーをスポイラー出力するメインルーチン
- * @param filename 出力ファイル名
  */
-static SpoilerOutputResultType spoil_mon_evol(std::string_view filename)
+static SpoilerOutputResultType spoil_mon_evol()
 {
-    const auto &path = path_build(ANGBAND_DIR_USER, filename);
+    const auto &path = path_build(ANGBAND_DIR_USER, "mon-evol.txt");
     spoiler_file = angband_fopen(path, FileOpenMode::WRITE);
     if (!spoiler_file) {
         return SpoilerOutputResultType::FILE_OPEN_FAILED;
@@ -267,7 +266,7 @@ void exe_output_spoilers(void)
             status = spoil_mon_info("mon-info.txt");
             break;
         case '6':
-            status = spoil_mon_evol("mon-evol.txt");
+            status = spoil_mon_evol();
             break;
         case '7':
             status = spoil_player_spell("spells.txt");
@@ -326,7 +325,7 @@ SpoilerOutputResultType output_all_spoilers()
         return status;
     }
 
-    status = spoil_mon_evol("mon-evol.txt");
+    status = spoil_mon_evol();
     if (status != SpoilerOutputResultType::SUCCESSFUL) {
         return status;
     }


### PR DESCRIPTION
モンスタースポイラー関係のファイル読み込みをofstream へ差し替えました
これ以上減らすには、roff\_func() を関数ポインタへ代入してる箇所を全て書き換える必要があります
かなり非現実的な箇所にofstream への依存が発生するので、そもそも~~fu~~hack\_c\_roff グローバル変数を何とかしないといけません
v3.0β に間に合わないと思われるので中期的な対応になる想定ですが、どなたか調べて頂けると嬉しいです