### PR TITLE
タイルを選択するとエラーになる不具合を修正した

### DIFF
--- a/src/main-win/graphics-win.cpp
+++ b/src/main-win/graphics-win.cpp
@@ -137,20 +137,23 @@ graphics_mode change_graphics(graphics_mode arg)
     infGraph.OffsetX = ox;
     infGraph.OffsetY = oy;
 
-    if (!name_mask.empty()) {
-        const auto &path_mask = path_build(ANGBAND_DIR_XTRA_GRAF, name_mask);
-        const auto &filename_mask = path_mask.string();
-        infGraph.hBitmapMask = read_graphic(filename_mask.data());
-        if (!infGraph.hBitmapMask) {
-            plog_fmt(_("ビットマップ '%s' を読み込めません。", "Cannot read bitmap file '%s'"), name_mask.data());
-            ANGBAND_GRAF = "ascii";
-            current_graphics_mode = graphics_mode::GRAPHICS_NONE;
-            return current_graphics_mode;
-        }
+    if (name_mask.empty()) {
+        current_graphics_mode = arg;
+        return arg;
     }
 
-    current_graphics_mode = arg;
-    return arg;
+    const auto &path_mask = path_build(ANGBAND_DIR_XTRA_GRAF, name_mask);
+    const auto &filename_mask = path_mask.string();
+    infGraph.hBitmapMask = read_graphic(filename_mask.data());
+    if (infGraph.hBitmapMask) {
+        current_graphics_mode = arg;
+        return arg;
+    }
+
+    plog_fmt(_("ビットマップ '%s' を読み込めません。", "Cannot read bitmap file '%s'"), name_mask.data());
+    ANGBAND_GRAF = "ascii";
+    current_graphics_mode = graphics_mode::GRAPHICS_NONE;
+    return current_graphics_mode;
 }
 }
 

--- a/src/main-win/graphics-win.cpp
+++ b/src/main-win/graphics-win.cpp
@@ -137,7 +137,7 @@ graphics_mode change_graphics(graphics_mode arg)
     infGraph.OffsetX = ox;
     infGraph.OffsetY = oy;
 
-    if (name_mask.empty()) {
+    if (!name_mask.empty()) {
         const auto &path_mask = path_build(ANGBAND_DIR_XTRA_GRAF, name_mask);
         const auto &filename_mask = path_mask.string();
         infGraph.hBitmapMask = read_graphic(filename_mask.data());


### PR DESCRIPTION
詳細はチケットをご参照下さい
ついでにearly return にコードを変更しました
ご確認下さい
(ファイナライザでグローバル変数を弄るまではしなくてもよかろうと思ったのでそのまま)