### PR TITLE
[Fix] 突然変異の炎のブレス威力表記がレベルx1になっていたものを実際通り、レベルx2に修正。

### DIFF
--- a/src/racial/mutation-racial-selector.cpp
+++ b/src/racial/mutation-racial-selector.cpp
@@ -22,7 +22,7 @@ void select_mutation_racial(PlayerType *player_ptr, rc_type *rc_ptr)
 
     if (player_ptr->muta.has(PlayerMutationType::BR_FIRE)) {
         rpi = rpi_type(_("炎のブレス", "Fire Breath"));
-        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl);
+        rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 2);
         rpi.text = _("火炎のブレスを放つ", "Fires a breath of fire.");
         rpi.min_level = 20;
         rpi.cost = rc_ptr->lvl;


### PR DESCRIPTION
レベルx2が本来正しいようなので表記修正。マゴ爺(HP350)をブレス4発で焼殺したので、実ダメージ検証済。