### PR TITLE
ケット・シー及びイェンダーの魔法使い(YENDER_WIZARD_2)を地上で倒すとハングアップするバグを修正

### DIFF
--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -546,12 +546,18 @@ void switch_special_death(PlayerType *player_ptr, monster_death_type *md_ptr, At
         on_dead_dragon_centipede(player_ptr, md_ptr);
         return;
     case MonsterRaceId::CAIT_SITH:
+        if (player_ptr->current_floor_ptr->dun_level <= 0) {
+            return;
+        }
         drop_specific_item_on_dead(player_ptr, md_ptr, kind_is_boots);
         return;
     case MonsterRaceId::YENDOR_WIZARD_1:
         on_dead_random_artifact(player_ptr, md_ptr, kind_is_amulet);
         return;
     case MonsterRaceId::YENDOR_WIZARD_2:
+        if (player_ptr->current_floor_ptr->dun_level <= 0) {
+            return;
+        }
         drop_specific_item_on_dead(player_ptr, md_ptr, kind_is_amulet);
         return;
     case MonsterRaceId::MANIMANI:


### PR DESCRIPTION
fixes #3595 

ケット・シーが地上でトランプの召喚魔法によって敵対召喚されることを想定していないため地上で倒すと靴の生成に失敗し、その失敗したアイテムをドロップしてしまっていた。
これがハングアップの原因となっていたため、ドロップしないように修正した。

ついでにアミュレットをドロップする方のイェンダーの魔法使いも同様に修正した（恐らく地上で戦闘することはないだろうが念のため）