### PR TITLE
MonraceList クラスを定義し、monraces_info へのアクセスをカプセル化し、もって分離/合体ユニークの処理を一般化した

### DIFF
--- a/src/dungeon/quest.cpp
+++ b/src/dungeon/quest.cpp
@@ -215,7 +215,7 @@ void determine_random_questor(PlayerType *player_ptr, QuestType *q_ptr)
             continue;
         }
 
-        if (monrace.no_suitable_questor_bounty()) {
+        if (MonraceList::get_instance().can_unify_separate(r_idx)) {
             continue;
         }
 

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -325,13 +325,13 @@ void determine_daily_bounty(PlayerType *player_ptr, bool conv_old)
 void determine_bounty_uniques(PlayerType *player_ptr)
 {
     get_mon_num_prep_bounty(player_ptr);
-
-    auto is_suitable_for_bounty = [](MonsterRaceId r_idx) {
+    const auto &monraces = MonraceList::get_instance();
+    auto is_suitable_for_bounty = [&monraces](MonsterRaceId r_idx) {
         const auto &monrace = monraces_info[r_idx];
         bool is_suitable = monrace.kind_flags.has(MonsterKindType::UNIQUE);
         is_suitable &= monrace.drop_flags.has_any_of({ MonsterDropType::DROP_CORPSE, MonsterDropType::DROP_SKELETON });
         is_suitable &= monrace.rarity <= 100;
-        is_suitable &= !monrace.no_suitable_questor_bounty();
+        is_suitable &= !monraces.can_unify_separate(r_idx);
         return is_suitable;
     };
 

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -327,8 +327,8 @@ void determine_bounty_uniques(PlayerType *player_ptr)
     get_mon_num_prep_bounty(player_ptr);
     const auto &monraces = MonraceList::get_instance();
     auto is_suitable_for_bounty = [&monraces](MonsterRaceId r_idx) {
-        const auto &monrace = monraces_info[r_idx];
-        bool is_suitable = monrace.kind_flags.has(MonsterKindType::UNIQUE);
+        const auto &monrace = monraces[r_idx];
+        auto is_suitable = monrace.kind_flags.has(MonsterKindType::UNIQUE);
         is_suitable &= monrace.drop_flags.has_any_of({ MonsterDropType::DROP_CORPSE, MonsterDropType::DROP_SKELETON });
         is_suitable &= monrace.rarity <= 100;
         is_suitable &= !monraces.can_unify_separate(r_idx);

--- a/src/monster-floor/monster-remover.cpp
+++ b/src/monster-floor/monster-remover.cpp
@@ -105,34 +105,13 @@ void delete_monster_idx(PlayerType *player_ptr, MONSTER_IDX i)
 }
 
 /*!
- * @brief プレイヤーのフロア離脱に伴う全モンスター配列の消去 / Delete/Remove all the monsters when the player leaves the level
+ * @brief プレイヤーのフロア離脱に伴う全モンスター配列の消去
  * @param player_ptr プレイヤーへの参照ポインタ
- * @details
- * This is an efficient method of simulating multiple calls to the
- * "delete_monster()" function, with no visual effects.
+ * @details 視覚効果なしでdelete_monster() をフロア全体に対して呼び出す.
  */
 void wipe_monsters_list(PlayerType *player_ptr)
 {
-    if (!monraces_info[MonsterRaceId::BANORLUPART].max_num) {
-        if (monraces_info[MonsterRaceId::BANOR].max_num) {
-            monraces_info[MonsterRaceId::BANOR].max_num = 0;
-            monraces_info[MonsterRaceId::BANOR].r_pkills++;
-            monraces_info[MonsterRaceId::BANOR].r_akills++;
-            if (monraces_info[MonsterRaceId::BANOR].r_tkills < MAX_SHORT) {
-                monraces_info[MonsterRaceId::BANOR].r_tkills++;
-            }
-        }
-
-        if (monraces_info[MonsterRaceId::LUPART].max_num) {
-            monraces_info[MonsterRaceId::LUPART].max_num = 0;
-            monraces_info[MonsterRaceId::LUPART].r_pkills++;
-            monraces_info[MonsterRaceId::LUPART].r_akills++;
-            if (monraces_info[MonsterRaceId::LUPART].r_tkills < MAX_SHORT) {
-                monraces_info[MonsterRaceId::LUPART].r_tkills++;
-            }
-        }
-    }
-
+    MonraceList::get_instance().defeat_separated_uniques();
     auto *floor_ptr = player_ptr->current_floor_ptr;
     for (int i = floor_ptr->m_max - 1; i >= 1; i--) {
         auto *m_ptr = &floor_ptr->m_list[i];

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -136,13 +136,8 @@ static bool check_unique_placeable(PlayerType *player_ptr, MonsterRaceId r_idx, 
         return false;
     }
 
-    if (r_idx == MonsterRaceId::BANORLUPART) {
-        if (monraces_info[MonsterRaceId::BANOR].cur_num > 0) {
-            return false;
-        }
-        if (monraces_info[MonsterRaceId::LUPART].cur_num > 0) {
-            return false;
-        }
+    if (!MonraceList::get_instance().is_selectable(r_idx)) {
+        return false;
     }
 
     if (any_bits(r_ptr->flags1, RF1_FORCE_DEPTH) && (player_ptr->current_floor_ptr->dun_level < r_ptr->level) && (!ironman_nightmare || any_bits(r_ptr->flags1, RF1_QUESTOR))) {

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -219,73 +219,9 @@ void MonsterDamageProcessor::death_special_flag_monster()
 void MonsterDamageProcessor::death_unique_monster(MonsterRaceId r_idx)
 {
     monraces_info[r_idx].max_num = 0;
-    std::vector<MonsterRaceId> combined_unique_vec;
-    if (!check_combined_unique(r_idx, &combined_unique_vec)) {
-        return;
-    }
-
-    combined_uniques uniques;
-    const int one_unit = 3;
-    for (auto i = 0U; i < combined_unique_vec.size(); i += one_unit) {
-        auto unique = std::make_tuple(combined_unique_vec[i], combined_unique_vec[i + 1], combined_unique_vec[i + 2]);
-        uniques.push_back(unique);
-    }
-
-    this->death_combined_uniques(r_idx, uniques);
-}
-
-/*
- * @brief 死亡したモンスターが分裂/合体を行う特殊ユニークか否かの判定処理
- * @param r_idx 死亡したモンスターの種族番号
- * @param united_uniques 分裂/合体を行う特殊ユニーク
- * @details 合体後、合体前1、合体前2 の順にpush_backすること
- */
-bool MonsterDamageProcessor::check_combined_unique(const MonsterRaceId r_idx, std::vector<MonsterRaceId> *combined_unique_vec)
-{
-    combined_unique_vec->push_back(MonsterRaceId::BANORLUPART);
-    combined_unique_vec->push_back(MonsterRaceId::BANOR);
-    combined_unique_vec->push_back(MonsterRaceId::LUPART);
-
-    for (const auto &unique : *combined_unique_vec) {
-        if (r_idx == unique) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-/*!
- * @brief 分裂/合体を行う特殊ユニークの死亡処理
- * @details 分裂/合体が A = B + C という図式の時、Aが死亡した場合BとCも死亡処理を行う。
- * BもしくはCが死亡した場合、Aの死亡処理を行う。
- * @param r_idx 実際に死亡したモンスターの種族ID
- * @param combined_uniques 分裂/合体を行う特殊ユニークのリスト
- */
-void MonsterDamageProcessor::death_combined_uniques(const MonsterRaceId r_idx, const combined_uniques &combined_uniques)
-{
-    auto death_r_idx = [](MonsterRaceId r_idx) {
-        auto &r_ref = monraces_info[r_idx];
-        r_ref.max_num = 0;
-        r_ref.r_pkills++;
-        r_ref.r_akills++;
-        if (r_ref.r_tkills < MAX_SHORT) {
-            r_ref.r_tkills++;
-        }
-    };
-
-    for (auto [united, split1, split2] : combined_uniques) {
-        if ((r_idx == split1) || (r_idx == split2)) {
-            death_r_idx(united);
-            continue;
-        }
-
-        if (r_idx != united) {
-            continue;
-        }
-
-        death_r_idx(split1);
-        death_r_idx(split2);
+    auto &monraces = MonraceList::get_instance();
+    if (monraces.can_unify_separate(r_idx)) {
+        monraces.kill_unified_unique(r_idx);
     }
 }
 

--- a/src/monster/monster-damage.h
+++ b/src/monster/monster-damage.h
@@ -12,7 +12,6 @@ enum class MonsterRaceId : int16_t;
 class MonsterRaceInfo;
 class MonsterEntity;
 class PlayerType;
-typedef std::vector<std::tuple<MonsterRaceId, MonsterRaceId, MonsterRaceId>> combined_uniques;
 class MonsterDamageProcessor {
 public:
     MonsterDamageProcessor(PlayerType *player_ptr, MONSTER_IDX m_idx, int dam, bool *fear, AttributeType type);
@@ -31,8 +30,6 @@ private:
     bool process_dead_exp_virtue(std::string_view note, MonsterEntity *exp_mon);
     void death_special_flag_monster();
     void death_unique_monster(MonsterRaceId r_idx);
-    bool check_combined_unique(const MonsterRaceId r_idx, std::vector<MonsterRaceId> *combined_uniques);
-    void death_combined_uniques(const MonsterRaceId r_idx, const combined_uniques &combined_uniques);
     void increase_kill_numbers();
     void death_amberites(std::string_view m_name);
     void dying_scream(std::string_view m_name);

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -147,6 +147,7 @@ MonsterRaceId get_mon_num(PlayerType *player_ptr, DEPTH min_level, DEPTH max_lev
     ProbabilityTable<int> prob_table;
 
     /* Process probabilities */
+    const auto &monraces = MonraceList::get_instance();
     for (auto i = 0U; i < alloc_race_table.size(); i++) {
         const auto &entry = alloc_race_table[i];
         if (entry.level < min_level) {
@@ -166,13 +167,8 @@ MonsterRaceId get_mon_num(PlayerType *player_ptr, DEPTH min_level, DEPTH max_lev
                 continue;
             }
 
-            if (r_idx == MonsterRaceId::BANORLUPART) {
-                if (monraces_info[MonsterRaceId::BANOR].cur_num > 0) {
-                    continue;
-                }
-                if (monraces_info[MonsterRaceId::LUPART].cur_num > 0) {
-                    continue;
-                }
+            if (!monraces.is_selectable(r_idx)) {
+                continue;
             }
         }
 

--- a/src/mspell/mspell-selector.cpp
+++ b/src/mspell/mspell-selector.cpp
@@ -338,10 +338,13 @@ MonsterAbilityType choose_attack_spell(PlayerType *player_ptr, msa_type *msa_ptr
         }
     }
 
-    if ((distance(player_ptr->y, player_ptr->x, m_ptr->fy, m_ptr->fx) < 4) && (!attack.empty() || r_ptr->ability_flags.has(MonsterAbilityType::TRAPS)) && (randint0(100) < 75) && !w_ptr->timewalk_m_idx) {
-        if (!tactic.empty()) {
-            return rand_choice(tactic);
-        }
+    auto should_select_tactic = distance(player_ptr->y, player_ptr->x, m_ptr->fy, m_ptr->fx) < 4;
+    should_select_tactic &= !attack.empty() || r_ptr->ability_flags.has(MonsterAbilityType::TRAPS);
+    should_select_tactic &= randint0(100) < 75;
+    should_select_tactic &= w_ptr->timewalk_m_idx == 0;
+    should_select_tactic &= !tactic.empty();
+    if (should_select_tactic) {
+        return rand_choice(tactic);
     }
 
     if (!summon.empty() && (randint0(100) < 40)) {

--- a/src/mspell/mspell-selector.cpp
+++ b/src/mspell/mspell-selector.cpp
@@ -313,30 +313,28 @@ MonsterAbilityType choose_attack_spell(PlayerType *player_ptr, msa_type *msa_ptr
     }
 
     if (!special.empty()) {
-        bool success = false;
-        switch (m_ptr->r_idx) {
+        const auto r_idx = m_ptr->r_idx;
+        if (MonraceList::get_instance().is_unified(r_idx) && (randint0(100) < 70)) {
+            return rand_choice(special);
+        }
+
+        switch (r_idx) {
         case MonsterRaceId::OHMU:
         case MonsterRaceId::BANOR:
         case MonsterRaceId::LUPART:
             break;
-        case MonsterRaceId::BANORLUPART:
-            if (randint0(100) < 70) {
-                success = true;
-            }
-            break;
         case MonsterRaceId::ROLENTO:
             if (randint0(100) < 40) {
-                success = true;
+                return rand_choice(special);
             }
+
             break;
         default:
             if (randint0(100) < 50) {
-                success = true;
+                return rand_choice(special);
             }
+
             break;
-        }
-        if (success) {
-            return rand_choice(special);
         }
     }
 

--- a/src/mspell/mspell-special.cpp
+++ b/src/mspell/mspell-special.cpp
@@ -40,11 +40,11 @@
 #include "view/display-messages.h"
 
 /*!
- * @brief バーノール・ルパートのRF6_SPECIALの処理。分裂・合体。 /
+ * @brief ユニークの分離・合体処理
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param m_idx 呪文を唱えるモンスターID
  */
-static MonsterSpellResult spell_RF6_SPECIAL_BANORLUPART(PlayerType *player_ptr, MONSTER_IDX m_idx)
+static MonsterSpellResult spell_RF6_SPECIAL_UNIFICATION(PlayerType *player_ptr, MONSTER_IDX m_idx)
 {
     auto *floor_ptr = player_ptr->current_floor_ptr;
     auto *m_ptr = &floor_ptr->m_list[m_idx];
@@ -246,29 +246,24 @@ static MonsterSpellResult spell_RF6_SPECIAL_B(PlayerType *player_ptr, POSITION y
  */
 MonsterSpellResult spell_RF6_SPECIAL(PlayerType *player_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx, MONSTER_IDX t_idx, int target_type)
 {
-    auto *floor_ptr = player_ptr->current_floor_ptr;
-    auto *m_ptr = &floor_ptr->m_list[m_idx];
-    auto *r_ptr = &m_ptr->get_monrace();
+    const auto &floor = *player_ptr->current_floor_ptr;
+    const auto &monster = floor.m_list[m_idx];
+    const auto &monrace = monster.get_monrace();
+    const auto r_idx = monster.r_idx;
+    if (MonraceList::get_instance().can_unify_separate(r_idx)) {
+        return spell_RF6_SPECIAL_UNIFICATION(player_ptr, m_idx);
+    }
 
-    switch (m_ptr->r_idx) {
+    switch (r_idx) {
     case MonsterRaceId::OHMU:
         return MonsterSpellResult::make_invalid();
-
-    case MonsterRaceId::BANORLUPART:
-    case MonsterRaceId::BANOR:
-    case MonsterRaceId::LUPART:
-        return spell_RF6_SPECIAL_BANORLUPART(player_ptr, m_idx);
-
     case MonsterRaceId::ROLENTO:
         return spell_RF6_SPECIAL_ROLENTO(player_ptr, y, x, m_idx, t_idx, target_type);
-        break;
-
     default:
-        if (r_ptr->d_char == 'B') {
+        if (monrace.d_char == 'B') {
             return spell_RF6_SPECIAL_B(player_ptr, y, x, m_idx, t_idx, target_type);
-            break;
-        } else {
-            return MonsterSpellResult::make_invalid();
         }
+
+        return MonsterSpellResult::make_invalid();
     }
 }

--- a/src/mspell/mspell-special.cpp
+++ b/src/mspell/mspell-special.cpp
@@ -74,8 +74,7 @@ static MonsterSpellResult spell_RF6_SPECIAL_UNIFICATION(PlayerType *player_ptr, 
         }
 
         const auto &m_name = monraces[it_unified->first].name;
-        const auto fmt = _("%sが分裂した！", "%s splits into two persons!");
-        msg_print(format(fmt, m_name.data()));
+        msg_format(_("%sが分離した！", "%s splits!"), m_name.data());
         return MonsterSpellResult::make_valid();
     }
 

--- a/src/system/monster-race-info.cpp
+++ b/src/system/monster-race-info.cpp
@@ -116,3 +116,21 @@ void MonraceList::kill_unified_unique(const MonsterRaceId r_idx)
         }
     }
 }
+
+/*!
+ * @brief 合体ユニークの生成可能確認
+ * @param r_idx 生成しようとしているモンスターの種族ID
+ * @return 合体後ユニークが生成可能か否か
+ * @details 分離も合体もしないならば常にtrue
+ * 分離ユニークもtrueだが、通常レアリティ255のためこのメソッドとは別処理で生成不能
+ * 分離/合体が A = B + C + D という図式の時、B・C・Dのいずれか1体がフロア内に生成済の場合、Aの生成を抑制する
+ */
+bool MonraceList::is_selectable(const MonsterRaceId r_idx) const
+{
+    const auto it = unified_uniques.find(r_idx);
+    if (it == unified_uniques.end()) {
+        return true;
+    }
+
+    return std::all_of(it->second.begin(), it->second.end(), [](const auto x) { return monraces_info[x].cur_num == 0; });
+}

--- a/src/system/monster-race-info.cpp
+++ b/src/system/monster-race-info.cpp
@@ -160,3 +160,8 @@ void MonraceList::defeat_separated_uniques()
         }
     }
 }
+
+bool MonraceList::is_unified(const MonsterRaceId r_idx) const
+{
+    return unified_uniques.contains(r_idx);
+}

--- a/src/system/monster-race-info.cpp
+++ b/src/system/monster-race-info.cpp
@@ -1,4 +1,5 @@
 #include "system/monster-race-info.h"
+#include "monster-race/monster-race.h"
 #include "monster-race/race-indice-types.h"
 #include "monster/horror-descriptions.h"
 #include <algorithm>
@@ -75,4 +76,43 @@ bool MonraceList::can_unify_separate(const MonsterRaceId r_idx) const
     }
 
     return std::any_of(unified_uniques.begin(), unified_uniques.end(), [&r_idx](const auto &x) { return x.second.contains(r_idx); });
+}
+
+/*!
+ * @brief 合体ユニークの死亡処理
+ * @details 分離/合体が A = B + C + D という図式の時、Aが死亡した場合BとCとDも死亡処理を行う。
+ * B・C・Dのいずれかが死亡した場合、その死亡したユニークに加えてAの死亡処理も行う。
+ * v3.0.0 α89現在は、分離後のユニーク数は2のみ。3以上は将来の拡張。
+ * @param r_idx 実際に死亡したモンスターの種族ID
+ */
+void MonraceList::kill_unified_unique(const MonsterRaceId r_idx)
+{
+    auto kill_monrace = [](MonsterRaceId r_idx) {
+        auto &monrace = monraces_info[r_idx];
+        monrace.max_num = 0;
+        monrace.r_pkills++;
+        monrace.r_akills++;
+        if (monrace.r_tkills < MAX_SHORT) {
+            monrace.r_tkills++;
+        }
+    };
+
+    const auto it_unique = unified_uniques.find(r_idx);
+    if (it_unique != unified_uniques.end()) {
+        kill_monrace(it_unique->first);
+        for (const auto separate : it_unique->second) {
+            kill_monrace(separate);
+        }
+
+        return;
+    }
+
+    for (const auto &[unified_unique, separates] : unified_uniques) {
+        const auto it_separate = separates.find(r_idx);
+        if (it_separate != separates.end()) {
+            kill_monrace(*it_separate);
+            kill_monrace(unified_unique);
+            return;
+        }
+    }
 }

--- a/src/system/monster-race-info.cpp
+++ b/src/system/monster-race-info.cpp
@@ -58,6 +58,11 @@ const std::map<MonsterRaceId, std::set<MonsterRaceId>> MonraceList::unified_uniq
 
 MonraceList MonraceList::instance{};
 
+const std::map<MonsterRaceId, std::set<MonsterRaceId>> &MonraceList::get_unified_uniques()
+{
+    return unified_uniques;
+}
+
 MonraceList &MonraceList::get_instance()
 {
     return instance;
@@ -164,4 +169,14 @@ void MonraceList::defeat_separated_uniques()
 bool MonraceList::is_unified(const MonsterRaceId r_idx) const
 {
     return unified_uniques.contains(r_idx);
+}
+
+/*!
+ * @brief 合体ユニークの各分離ユニークが全員フロアにいるかをチェックする
+ * @return 全員が現在フロアに生成されているか
+ */
+bool MonraceList::exists_separates(const MonsterRaceId r_idx) const
+{
+    const auto &separates = unified_uniques.at(r_idx);
+    return std::all_of(separates.begin(), separates.end(), [](const auto x) { return monraces_info[x].cur_num > 0; });
 }

--- a/src/system/monster-race-info.cpp
+++ b/src/system/monster-race-info.cpp
@@ -134,3 +134,29 @@ bool MonraceList::is_selectable(const MonsterRaceId r_idx) const
 
     return std::all_of(it->second.begin(), it->second.end(), [](const auto x) { return monraces_info[x].cur_num == 0; });
 }
+
+/*!
+ * @brief 合体ユニークが撃破済の状態でフロアから離脱した時に、各分離ユニークも撃破済状態へと変更する
+ */
+void MonraceList::defeat_separated_uniques()
+{
+    for (const auto &[unified_unique, separates] : unified_uniques) {
+        if (monraces_info[unified_unique].max_num > 0) {
+            continue;
+        }
+
+        for (const auto separate : separates) {
+            auto &monrace = monraces_info[separate];
+            if (monrace.max_num == 0) {
+                continue;
+            }
+
+            monrace.max_num = 0;
+            monrace.r_pkills++;
+            monrace.r_akills++;
+            if (monrace.r_tkills < MAX_SHORT) {
+                monrace.r_tkills++;
+            }
+        }
+    }
+}

--- a/src/system/monster-race-info.cpp
+++ b/src/system/monster-race-info.cpp
@@ -51,20 +51,28 @@ std::string MonsterRaceInfo::get_died_message() const
     return is_explodable ? _("は爆発して粉々になった。", " explodes into tiny shreds.") : _("を倒した。", " is destroyed.");
 }
 
-/*!
- * @brief モンスターが特殊能力上、賞金首から排除する必要があるかどうかを返す
- * @return 賞金首から排除するか否か
- * @details 実質バーノール＝ルパート用
- * @todo idxに依存している。monraces_info が既にmapなのでMonsterRaceList クラスのオブジェクトメソッドに移す
- */
-bool MonsterRaceInfo::no_suitable_questor_bounty() const
+const std::map<MonsterRaceId, std::set<MonsterRaceId>> MonraceList::unified_uniques = {
+    { MonsterRaceId::BANORLUPART, { MonsterRaceId::BANOR, MonsterRaceId::LUPART } },
+};
+
+MonraceList MonraceList::instance{};
+
+MonraceList &MonraceList::get_instance()
 {
-    switch (this->idx) {
-    case MonsterRaceId::BANORLUPART:
-    case MonsterRaceId::BANOR:
-    case MonsterRaceId::LUPART:
+    return instance;
+}
+
+/*!
+ * @brief 合体/分離ユニーク判定
+ * @param r_idx 調査対象のモンスター種族ID
+ * @return 合体/分離ユニークか否か
+ * @details 合体/分離ユニークは、賞金首にもランダムクエスト討伐対象にもならない.
+ */
+bool MonraceList::can_unify_separate(const MonsterRaceId r_idx) const
+{
+    if (unified_uniques.contains(r_idx)) {
         return true;
-    default:
-        return false;
     }
+
+    return std::any_of(unified_uniques.begin(), unified_uniques.end(), [&r_idx](const auto &x) { return x.second.contains(r_idx); });
 }

--- a/src/system/monster-race-info.h
+++ b/src/system/monster-race-info.h
@@ -153,6 +153,7 @@ public:
 
     static MonraceList &get_instance();
     bool can_unify_separate(const MonsterRaceId r_idx) const;
+    void kill_unified_unique(const MonsterRaceId r_idx);
 
 private:
     MonraceList() = default;

--- a/src/system/monster-race-info.h
+++ b/src/system/monster-race-info.h
@@ -142,6 +142,7 @@ public:
     bool has_living_flag() const;
     bool is_explodable() const;
     std::string get_died_message() const;
+    void kill_unique();
 };
 
 class MonraceList {
@@ -150,6 +151,8 @@ public:
     MonraceList(const MonraceList &) = delete;
     MonraceList &operator=(const MonraceList &) = delete;
     MonraceList &operator=(MonraceList &&) = delete;
+    MonsterRaceInfo &operator[](const MonsterRaceId r_idx);
+    const MonsterRaceInfo &operator[](const MonsterRaceId r_idx) const;
 
     static const std::map<MonsterRaceId, std::set<MonsterRaceId>> &get_unified_uniques();
     static MonraceList &get_instance();

--- a/src/system/monster-race-info.h
+++ b/src/system/monster-race-info.h
@@ -16,6 +16,8 @@
 #include "monster-race/race-wilderness-flags.h"
 #include "system/angband.h"
 #include "util/flag-group.h"
+#include <map>
+#include <set>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -140,5 +142,22 @@ public:
     bool has_living_flag() const;
     bool is_explodable() const;
     std::string get_died_message() const;
-    bool no_suitable_questor_bounty() const;
+};
+
+class MonraceList {
+public:
+    MonraceList(MonraceList &&) = delete;
+    MonraceList(const MonraceList &) = delete;
+    MonraceList &operator=(const MonraceList &) = delete;
+    MonraceList &operator=(MonraceList &&) = delete;
+
+    static MonraceList &get_instance();
+    bool can_unify_separate(const MonsterRaceId r_idx) const;
+
+private:
+    MonraceList() = default;
+
+    static MonraceList instance;
+
+    const static std::map<MonsterRaceId, std::set<MonsterRaceId>> unified_uniques;
 };

--- a/src/system/monster-race-info.h
+++ b/src/system/monster-race-info.h
@@ -155,6 +155,7 @@ public:
     bool can_unify_separate(const MonsterRaceId r_idx) const;
     void kill_unified_unique(const MonsterRaceId r_idx);
     bool is_selectable(const MonsterRaceId r_idx) const;
+    void defeat_separated_uniques();
 
 private:
     MonraceList() = default;

--- a/src/system/monster-race-info.h
+++ b/src/system/monster-race-info.h
@@ -151,12 +151,14 @@ public:
     MonraceList &operator=(const MonraceList &) = delete;
     MonraceList &operator=(MonraceList &&) = delete;
 
+    static const std::map<MonsterRaceId, std::set<MonsterRaceId>> &get_unified_uniques();
     static MonraceList &get_instance();
     bool can_unify_separate(const MonsterRaceId r_idx) const;
     void kill_unified_unique(const MonsterRaceId r_idx);
     bool is_selectable(const MonsterRaceId r_idx) const;
     void defeat_separated_uniques();
     bool is_unified(const MonsterRaceId r_idx) const;
+    bool exists_separates(const MonsterRaceId r_idx) const;
 
 private:
     MonraceList() = default;

--- a/src/system/monster-race-info.h
+++ b/src/system/monster-race-info.h
@@ -156,6 +156,7 @@ public:
     void kill_unified_unique(const MonsterRaceId r_idx);
     bool is_selectable(const MonsterRaceId r_idx) const;
     void defeat_separated_uniques();
+    bool is_unified(const MonsterRaceId r_idx) const;
 
 private:
     MonraceList() = default;

--- a/src/system/monster-race-info.h
+++ b/src/system/monster-race-info.h
@@ -154,6 +154,7 @@ public:
     static MonraceList &get_instance();
     bool can_unify_separate(const MonsterRaceId r_idx) const;
     void kill_unified_unique(const MonsterRaceId r_idx);
+    bool is_selectable(const MonsterRaceId r_idx) const;
 
 private:
     MonraceList() = default;

--- a/src/system/monster-race-info.h
+++ b/src/system/monster-race-info.h
@@ -159,6 +159,8 @@ public:
     void defeat_separated_uniques();
     bool is_unified(const MonsterRaceId r_idx) const;
     bool exists_separates(const MonsterRaceId r_idx) const;
+    bool is_separated(const MonsterRaceId r_idx) const;
+    bool can_select_separate(const MonsterRaceId r_idx, const int hp, const int maxhp) const;
 
 private:
     MonraceList() = default;


### PR DESCRIPTION
掲題の通りです
Model 側にかなり処理を寄せたので扱いやすくなったと思います
分離/合体ユニーク定義は一旦private 化してgetter で取り出すようにしていますが、ここまでしなくていいかもしれません
(元々private で済むと思ったが周辺設計上取り出さないといけないことに気付いた)
動作周りは問題ないかと思いますが上記設計を特にご確認下さい

確認済動作：
- 合体ユニークの分離
- 片方のHPが半分未満になった時の、分離ユニークの合体 (両方半分以上ならば合体しない)
- 合体ユニークを撃破してからフロア移動すれば各分離ユニークも撃破済になる
- 分離ユニークの内1体でも倒すと、即座に合体ユニークが撃破済になる
- 分離ユニークの内1体でも倒してからフロア移動すると、他の分離ユニークが撃破済になる

既存不具合 (このPRより前からあったもの)：
#3631 

将来の予定：
- 呪文定義をSPECIAL からUNIFICATION へ汎用化