### PR TITLE
[Fix] powerfulフラグを持つペットがボールの範囲拡大を計算に入れていなかったのを修正

### DIFF
--- a/src/melee/melee-spell-flags-checker.cpp
+++ b/src/melee/melee-spell-flags-checker.cpp
@@ -183,6 +183,17 @@ static void check_melee_spell_distance(PlayerType *player_ptr, melee_spell_type 
         return;
     }
 
+    auto ball_when_powerful_rad4 = {
+        MonsterAbilityType::BA_ACID,
+        MonsterAbilityType::BA_ELEC,
+        MonsterAbilityType::BA_FIRE,
+        MonsterAbilityType::BA_COLD
+    };
+    auto *r_ptr = &monraces_info[ms_ptr->m_ptr->r_idx];
+    if (any_bits(r_ptr->flags2, RF2_POWERFUL)) {
+        ms_ptr->ability_flags.reset(ball_when_powerful_rad4);
+    };
+
     ms_ptr->ability_flags.reset(RF_ABILITY_BIG_BALL_MASK);
 }
 


### PR DESCRIPTION
#3607 よりペットがボール魔法でプレイヤーを巻き込む問題の解決
powerfulフラグを持つモンスターは一部のボール魔法の範囲が2ではなく4になる。
ペットがこれを考慮せず、プレイヤーを巻き込んでいたため、その場合該当ボール魔法を使わないよう修正。
年経た汚物エレメンタルがプレイヤーが範囲にいるとアシッドボールを使わなくなるのを確認。