### PR TITLE
SMART/STUPID フラグの更新処理が無意味なものになっていたので修正した

### DIFF
--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -222,11 +222,11 @@ static POSITION decide_updated_distance(PlayerType *player_ptr, um_type *um_ptr)
 
 static void update_smart_stupid_flags(MonsterRaceInfo *r_ptr)
 {
-    if (r_ptr->r_behavior_flags.has(MonsterBehaviorType::SMART)) {
+    if (r_ptr->behavior_flags.has(MonsterBehaviorType::SMART)) {
         r_ptr->r_behavior_flags.set(MonsterBehaviorType::SMART);
     }
 
-    if (r_ptr->r_behavior_flags.has(MonsterBehaviorType::STUPID)) {
+    if (r_ptr->behavior_flags.has(MonsterBehaviorType::STUPID)) {
         r_ptr->r_behavior_flags.set(MonsterBehaviorType::STUPID);
     }
 }


### PR DESCRIPTION
掲題の通りです
元コード (v2.2.1)は以下の通りです

```c
else if (r_ptr->flags2 & (RF2_WEIRD_MIND))
{
  /* One in ten individuals are detectable */
  if ((m_idx % 10) == 5)
  {
    /* Detectable */
    flag = TRUE;

    if (is_original_ap(m_ptr) && !p_ptr->image)
    {
      /* Memorize flags */
      r_ptr->r_flags2 |= (RF2_WEIRD_MIND);

      /* Hack -- Memorize mental flags */
      if (r_ptr->flags2 & (RF2_SMART)) r_ptr->r_flags2 |= (RF2_SMART);
      if (r_ptr->flags2 & (RF2_STUPID)) r_ptr->r_flags2 |= (RF2_STUPID);
    }
  }
}
```