### PR TITLE
[Fix] カメレオンやたぬきが化けない

### DIFF
--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -345,7 +345,7 @@ void process_player(PlayerType *player_ptr)
                     continue;
                 }
 
-                r_ptr = &m_ptr->get_real_monrace();
+                r_ptr = &m_ptr->get_appearance_monrace();
 
                 // モンスターのシンボル/カラーの更新
                 if (m_ptr->ml && r_ptr->visual_flags.has_any_of({ MonsterVisualType::MULTI_COLOR, MonsterVisualType::SHAPECHANGER })) {

--- a/src/main/scene-table-monster.cpp
+++ b/src/main/scene-table-monster.cpp
@@ -88,8 +88,8 @@ static bool is_high_rate(PlayerType *player_ptr, MONSTER_IDX m_idx1, MONSTER_IDX
     auto floor_ptr = player_ptr->current_floor_ptr;
     auto m_ptr1 = &floor_ptr->m_list[m_idx1];
     auto m_ptr2 = &floor_ptr->m_list[m_idx2];
-    auto ap_r_ptr1 = &m_ptr1->get_real_monrace();
-    auto ap_r_ptr2 = &m_ptr2->get_real_monrace();
+    auto ap_r_ptr1 = &m_ptr1->get_appearance_monrace();
+    auto ap_r_ptr2 = &m_ptr2->get_appearance_monrace();
 
     /* Unique monsters first */
     if (ap_r_ptr1->kind_flags.has(MonsterKindType::UNIQUE) != ap_r_ptr2->kind_flags.has(MonsterKindType::UNIQUE)) {
@@ -140,7 +140,7 @@ static void update_target_monster(PlayerType *player_ptr, MONSTER_IDX m_idx)
 
         if (do_dwap) {
             auto *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
-            auto *ap_r_ptr = &m_ptr->get_real_monrace();
+            auto *ap_r_ptr = &m_ptr->get_appearance_monrace();
             scene_target_monster.m_idx = m_idx;
             scene_target_monster.ap_r_ptr = ap_r_ptr;
             scene_target_monster.last_seen = get_game_turn();
@@ -245,7 +245,7 @@ void refresh_scene_monster(PlayerType *player_ptr, const std::vector<MONSTER_IDX
                 clear_scene_target_monster();
             } else {
                 auto *m_ptr = &player_ptr->current_floor_ptr->m_list[scene_target_monster.m_idx];
-                auto *ap_r_ptr = &m_ptr->get_real_monrace();
+                auto *ap_r_ptr = &m_ptr->get_appearance_monrace();
                 if (ap_r_ptr != scene_target_monster.ap_r_ptr) {
                     // 死亡、チェンジモンスター、etc.
                     clear_scene_target_monster();

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -468,7 +468,7 @@ bool process_monster_movement(PlayerType *player_ptr, turn_flags *turn_flags_ptr
             break;
         }
 
-        const auto &ap_r_ref = m_ptr->get_real_monrace();
+        const auto &ap_r_ref = m_ptr->get_appearance_monrace();
         const auto is_projectable = projectable(player_ptr, player_ptr->y, player_ptr->x, m_ptr->fy, m_ptr->fx);
         const auto can_see = disturb_near && m_ptr->mflag.has(MonsterTemporaryFlagType::VIEW) && is_projectable;
         const auto is_high_level = disturb_high && (ap_r_ref.r_tkills > 0) && (ap_r_ref.level >= player_ptr->lev);
@@ -513,7 +513,7 @@ static bool can_speak(const MonsterRaceInfo &ap_r_ref, MonsterSpeakType mon_spea
 
 static std::string_view get_speak_filename(MonsterEntity *m_ptr)
 {
-    const auto &ap_r_ref = m_ptr->get_real_monrace();
+    const auto &ap_r_ref = m_ptr->get_appearance_monrace();
     if (m_ptr->is_fearful() && can_speak(ap_r_ref, MonsterSpeakType::SPEAK_FEAR)) {
         return _("monfear_j.txt", "monfear.txt");
     }
@@ -557,7 +557,7 @@ void process_speak_sound(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION oy,
         msg_print(_("重厚な足音が聞こえた。", "You hear heavy steps."));
     }
 
-    auto can_speak = m_ptr->get_real_monrace().speak_flags.any();
+    auto can_speak = m_ptr->get_appearance_monrace().speak_flags.any();
     constexpr auto chance_speak = 8;
     if (!can_speak || !aware || !one_in_(chance_speak) || !player_has_los_bold(player_ptr, oy, ox) || !projectable(player_ptr, oy, ox, player_ptr->y, player_ptr->x)) {
         return;

--- a/src/monster/monster-describer.cpp
+++ b/src/monster/monster-describer.cpp
@@ -102,14 +102,14 @@ static std::optional<std::string> decide_monster_personal_pronoun(const MonsterE
         return std::nullopt;
     }
 
-    const auto &monrace = monster.get_real_monrace();
+    const auto &monrace = monster.get_appearance_monrace();
     const auto kind = get_monster_pronoun_kind(monrace, pron);
     return get_monster_personal_pronoun(kind, mode);
 }
 
 static std::optional<std::string> get_monster_self_pronoun(const MonsterEntity &monster, const BIT_FLAGS mode)
 {
-    const auto &monrace = monster.get_real_monrace();
+    const auto &monrace = monster.get_appearance_monrace();
     constexpr BIT_FLAGS self = MD_POSSESSIVE | MD_OBJECTIVE;
     if (!match_bits(mode, self, self)) {
         return std::nullopt;
@@ -128,7 +128,7 @@ static std::optional<std::string> get_monster_self_pronoun(const MonsterEntity &
 
 static std::string get_describing_monster_name(const MonsterEntity &monster, const bool is_hallucinated, const BIT_FLAGS mode)
 {
-    const auto &monrace = monster.get_real_monrace();
+    const auto &monrace = monster.get_appearance_monrace();
     if (!is_hallucinated || any_bits(mode, MD_IGNORE_HALLU)) {
         return any_bits(mode, MD_TRUE_NAME) ? monster.get_real_monrace().name : monrace.name;
     }
@@ -170,7 +170,7 @@ static std::string replace_monster_name_undefined(std::string_view name)
 
 static std::optional<std::string> get_fake_monster_name(const PlayerType &player, const MonsterEntity &monster, const std::string &name, const BIT_FLAGS mode)
 {
-    const auto &monrace = monster.get_real_monrace();
+    const auto &monrace = monster.get_appearance_monrace();
     const auto is_hallucinated = player.effects()->hallucination()->is_hallucinated();
     if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) || (is_hallucinated && none_bits(mode, MD_IGNORE_HALLU))) {
         return std::nullopt;
@@ -224,7 +224,7 @@ static std::string add_cameleon_name(const MonsterEntity &monster, const BIT_FLA
         return "";
     }
 
-    const auto &monrace = monster.get_real_monrace();
+    const auto &monrace = monster.get_appearance_monrace();
     if (monrace.kind_flags.has(MonsterKindType::UNIQUE)) {
         return _("(カメレオンの王)", "(Chameleon Lord)");
     }

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -519,7 +519,7 @@ static void update_invisible_monster(PlayerType *player_ptr, um_type *um_ptr, MO
         }
     }
 
-    if (w_ptr->is_loading_now && w_ptr->character_dungeon && !player_ptr->phase_out && m_ptr->get_real_monrace().flags2 & RF2_ELDRITCH_HORROR) {
+    if (w_ptr->is_loading_now && w_ptr->character_dungeon && !player_ptr->phase_out && m_ptr->get_appearance_monrace().flags2 & RF2_ELDRITCH_HORROR) {
         m_ptr->mflag.set(MonsterTemporaryFlagType::SANITY_BLAST);
     }
 
@@ -581,7 +581,7 @@ void update_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, bool full)
     um_type tmp_um;
     um_type *um_ptr = initialize_um_type(player_ptr, &tmp_um, m_idx, full);
     if (disturb_high) {
-        auto *ap_r_ptr = &um_ptr->m_ptr->get_real_monrace();
+        auto *ap_r_ptr = &um_ptr->m_ptr->get_appearance_monrace();
         if (ap_r_ptr->r_tkills && ap_r_ptr->level >= player_ptr->lev) {
             um_ptr->do_disturb = true;
         }

--- a/src/player/eldritch-horror.cpp
+++ b/src/player/eldritch-horror.cpp
@@ -91,7 +91,7 @@ void sanity_blast(PlayerType *player_ptr, MonsterEntity *m_ptr, bool necro)
 
     int power = 100;
     if (!necro && m_ptr) {
-        auto *r_ptr = &m_ptr->get_real_monrace();
+        auto *r_ptr = &m_ptr->get_appearance_monrace();
         const auto m_name = monster_desc(player_ptr, m_ptr, 0);
         power = r_ptr->level / 2;
         if (r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE)) {

--- a/src/system/monster-entity.cpp
+++ b/src/system/monster-entity.cpp
@@ -56,7 +56,7 @@ bool MonsterEntity::is_mimicry() const
         return true;
     }
 
-    const auto &r_ref = this->get_real_monrace();
+    const auto &r_ref = this->get_appearance_monrace();
     const auto mimic_symbols = "/|\\()[]=$,.!?&`#%<>+~";
     if (angband_strchr(mimic_symbols, r_ref.d_char) == nullptr) {
         return false;
@@ -91,6 +91,11 @@ MonsterRaceId MonsterEntity::get_real_monrace_id() const
 MonsterRaceInfo &MonsterEntity::get_real_monrace() const
 {
     return monraces_info[this->get_real_monrace_id()];
+}
+
+MonsterRaceInfo &MonsterEntity::get_appearance_monrace() const
+{
+    return monraces_info[this->ap_r_idx];
 }
 
 MonsterRaceInfo &MonsterEntity::get_monrace() const
@@ -202,7 +207,7 @@ byte MonsterEntity::get_temporary_speed() const
  */
 bool MonsterEntity::has_living_flag(bool is_apperance) const
 {
-    const auto &monrace = is_apperance ? this->get_real_monrace() : this->get_monrace();
+    const auto &monrace = is_apperance ? this->get_appearance_monrace() : this->get_monrace();
     return monrace.has_living_flag();
 }
 

--- a/src/system/monster-entity.h
+++ b/src/system/monster-entity.h
@@ -65,6 +65,7 @@ public:
     bool is_valid() const;
     MonsterRaceId get_real_monrace_id() const;
     MonsterRaceInfo &get_real_monrace() const;
+    MonsterRaceInfo &get_appearance_monrace() const;
     MonsterRaceInfo &get_monrace() const;
     short get_remaining_sleep() const;
     short get_remaining_acceleration() const;

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -94,7 +94,7 @@ bool show_gold_on_floor = false;
  */
 static std::string evaluate_monster_exp(PlayerType *player_ptr, MonsterEntity *m_ptr)
 {
-    MonsterRaceInfo *ap_r_ptr = &m_ptr->get_real_monrace();
+    MonsterRaceInfo *ap_r_ptr = &m_ptr->get_appearance_monrace();
     if ((player_ptr->lev >= PY_MAX_LEVEL) || PlayerRace(player_ptr).equals(PlayerRaceType::ANDROID)) {
         return "**";
     }
@@ -221,7 +221,7 @@ static void describe_grid_monster(PlayerType *player_ptr, GridExamination *ge_pt
 
 static void describe_monster_person(GridExamination *ge_ptr)
 {
-    const auto &monrace = ge_ptr->m_ptr->get_real_monrace();
+    const auto &monrace = ge_ptr->m_ptr->get_appearance_monrace();
     ge_ptr->s1 = _("それは", "It is ");
     if (monrace.flags1 & RF1_FEMALE) {
         ge_ptr->s1 = _("彼女は", "She is ");

--- a/src/view/display-map.cpp
+++ b/src/view/display-map.cpp
@@ -313,7 +313,7 @@ void map_info(PlayerType *player_ptr, POSITION y, POSITION x, TERM_COLOR *ap, ch
         return;
     }
 
-    auto *r_ptr = &m_ptr->get_real_monrace();
+    auto *r_ptr = &m_ptr->get_appearance_monrace();
     feat_priority = 30;
     if (is_hallucinated) {
         if (r_ptr->visual_flags.has_all_of({ MonsterVisualType::CLEAR, MonsterVisualType::CLEAR_COLOR })) {

--- a/src/view/display-monster-status.cpp
+++ b/src/view/display-monster-status.cpp
@@ -42,7 +42,7 @@ std::string look_mon_desc(MonsterEntity *m_ptr, BIT_FLAGS mode)
     }
 
     concptr clone = m_ptr->mflag2.has(MonsterConstantFlagType::CLONED) ? ", clone" : "";
-    MonsterRaceInfo *ap_r_ptr = &m_ptr->get_real_monrace();
+    MonsterRaceInfo *ap_r_ptr = &m_ptr->get_appearance_monrace();
     if (ap_r_ptr->r_tkills && m_ptr->mflag2.has_not(MonsterConstantFlagType::KAGE)) {
         return format(_("レベル%d, %s%s%s", "Level %d, %s%s%s"), ap_r_ptr->level, desc, attitude, clone);
     }

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -219,7 +219,7 @@ void print_monster_list(FloorType *floor_ptr, const std::vector<MONSTER_IDX> &mo
 
 static void print_pet_list_oneline(PlayerType *player_ptr, const MonsterEntity &monster, TERM_LEN x, TERM_LEN y, TERM_LEN width)
 {
-    const auto &monrace = monster.get_real_monrace();
+    const auto &monrace = monster.get_appearance_monrace();
     const auto name = monster_desc(player_ptr, &monster, MD_ASSUME_VISIBLE | MD_INDEF_VISIBLE | MD_NO_OWNER);
     const auto &[bar_color, bar_len] = monster.get_hp_bar_data();
     const auto is_visible = monster.ml && !player_ptr->effects()->hallucination()->is_hallucinated();
@@ -567,7 +567,7 @@ static void display_floor_item_list(PlayerType *player_ptr, const int y, const i
         if (is_hallucinated) {
             line = format(_("(X:%03d Y:%03d) 何か奇妙な物の足元の発見済みアイテム一覧", "Found items at (%03d,%03d) under something strange"), x, y);
         } else {
-            const MonsterRaceInfo *const r_ptr = &m_ptr->get_real_monrace();
+            const MonsterRaceInfo *const r_ptr = &m_ptr->get_appearance_monrace();
             line = format(_("(X:%03d Y:%03d) %sの足元の発見済みアイテム一覧", "Found items at (%03d,%03d) under %s"), x, y, r_ptr->name.data());
         }
     } else {


### PR DESCRIPTION
Resolves #3669 

以下のコミットで見た目の種族 ap_r_idx を参照している箇所を
get_real_monrace() で置き換えるという根本的な誤りをおかしている。

- 5c9a3ad1787d7e13006ce68ab4173770158ff562
- 6c732ff1c979d770d43b8b9f0c708e508186f117

ap_r_idx を参照する、get_appearance_monrace() を実装し、それを呼ぶよう 修正する。