### PR TITLE
最新のモンスター種族追加が反映されていないセーブデータを読み込むとそれらの種族が出現しなくなる不具合を解消した

### DIFF
--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -87,9 +87,9 @@ void player_wipe_without_name(PlayerType *player_ptr)
             continue;
         }
         r_ref.cur_num = 0;
-        r_ref.max_num = 100;
+        r_ref.max_num = MAX_MONSTER_NUM;
         if (r_ref.kind_flags.has(MonsterKindType::UNIQUE)) {
-            r_ref.max_num = 1;
+            r_ref.max_num = MAX_UNIQUE_NUM;
         } else if (r_ref.population_flags.has(MonsterPopulationType::NAZGUL)) {
             r_ref.max_num = MAX_NAZGUL_NUM;
         }

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -135,7 +135,7 @@ static void parse_qtw_D(PlayerType *player_ptr, qtwg_type *qtwg_ptr, char *s)
 
             if (r_ref.kind_flags.has(MonsterKindType::UNIQUE)) {
                 r_ref.cur_num = 0;
-                r_ref.max_num = 1;
+                r_ref.max_num = MAX_UNIQUE_NUM;
             } else if (r_ref.population_flags.has(MonsterPopulationType::NAZGUL)) {
                 if (r_ref.cur_num == r_ref.max_num) {
                     r_ref.max_num++;

--- a/src/load/lore-loader.cpp
+++ b/src/load/lore-loader.cpp
@@ -372,9 +372,9 @@ void load_lore(void)
     for (size_t i = loading_max_r_idx; i < monraces_info.size(); i++) {
         auto monrace_id = i2enum<MonsterRaceId>(i);
         auto &monrace = monraces_info[monrace_id];
-        auto max_num = 100;
+        auto max_num = MAX_MONSTER_NUM;
         if (monrace.kind_flags.has(MonsterKindType::UNIQUE) || any_bits(monrace.flags1, RF7_UNIQUE2)) {
-            max_num = 1;
+            max_num = MAX_UNIQUE_NUM;
         } else if (monrace.population_flags.has(MonsterPopulationType::NAZGUL)) {
             max_num = MAX_NAZGUL_NUM;
         }

--- a/src/load/lore-loader.cpp
+++ b/src/load/lore-loader.cpp
@@ -11,6 +11,7 @@
 #include "monster-race/race-flags7.h"
 #include "system/angband.h"
 #include "system/monster-race-info.h"
+#include "system/system-variables.h"
 #include "util/bit-flags-calculator.h"
 #include "util/enum-converter.h"
 
@@ -366,6 +367,19 @@ void load_lore(void)
         auto r_idx = static_cast<MonsterRaceId>(i);
         auto *r_ptr = i < monraces_info.size() ? &monraces_info[r_idx] : &dummy;
         rd_lore(r_ptr, r_idx);
+    }
+
+    for (size_t i = loading_max_r_idx; i < monraces_info.size(); i++) {
+        auto monrace_id = i2enum<MonsterRaceId>(i);
+        auto &monrace = monraces_info[monrace_id];
+        auto max_num = 100;
+        if (monrace.kind_flags.has(MonsterKindType::UNIQUE) || any_bits(monrace.flags1, RF7_UNIQUE2)) {
+            max_num = 1;
+        } else if (monrace.population_flags.has(MonsterPopulationType::NAZGUL)) {
+            max_num = MAX_NAZGUL_NUM;
+        }
+
+        monrace.max_num = max_num;
     }
 
     load_note(_("モンスターの思い出をロードしました", "Loaded Monster Memory"));

--- a/src/system/system-variables.h
+++ b/src/system/system-variables.h
@@ -2,7 +2,9 @@
 
 #include "system/angband.h"
 
-#define MAX_NAZGUL_NUM 5
+constexpr auto MAX_UNIQUE_NUM = 1;
+constexpr auto MAX_NAZGUL_NUM = 5;
+constexpr auto MAX_MONSTER_NUM = 100; /*!< 1種類の非ユニークモンスターが1フロアに存在できる最大数 */
 #define SCREEN_BUF_MAX_SIZE (1024 * 1024) /*!< Max size of screen dump buffer */
 #define PY_MAX_LEVEL 50 /*!< プレイヤーレベルの最大値 / Maximum level */
 #define PY_MAX_EXP 99999999L /*!< プレイヤー経験値の最大値 / Maximum exp */

--- a/src/wizard/wizard-game-modifier.cpp
+++ b/src/wizard/wizard-game-modifier.cpp
@@ -152,20 +152,20 @@ void wiz_restore_monster_max_num(MonsterRaceId r_idx)
     }
 
     auto *r_ptr = &monraces_info[r_idx];
-    auto n = 0;
+    std::optional<int> max_num;
     if (r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
-        n = 1;
+        max_num = MAX_UNIQUE_NUM;
     } else if (r_ptr->population_flags.has(MonsterPopulationType::NAZGUL)) {
-        n = MAX_NAZGUL_NUM;
+        max_num = MAX_NAZGUL_NUM;
     }
 
-    if (n == 0) {
+    if (!max_num) {
         msg_print(_("出現数に制限がないモンスターです。", "This monster can appear any time."));
         msg_print(nullptr);
         return;
     }
 
-    r_ptr->max_num = n;
+    r_ptr->max_num = *max_num;
     r_ptr->r_pkills = 0;
     r_ptr->r_akills = 0;
 


### PR DESCRIPTION
不具合の詳細及び修正方針はチケットをご参照下さい
不具合の再現及び修正結果の確認には添付のセーブデータを使えばOKです
ご確認下さい
[DEBUGGER_Alpha87.zip](https://github.com/hengband/hengband/files/13062901/DEBUGGER_Alpha87.zip)

なお、UNIQUE2フラグの取り扱いがUNIQUEと同じで良いのか不明瞭なのと、似通ったforループが2連続するところが少し疑問です
もしより良い修正方法があれば連絡頂ければ手直しします