### PR TITLE
Fix X11 graphics

### DIFF
--- a/hengband.spec
+++ b/hengband.spec
@@ -1,6 +1,5 @@
 %define version 3.0.0.91
-%define release 1
-%global debug_package %{nil}
+%define release 2
 
 Summary: hengband %{version}
 Name: hengband
@@ -44,7 +43,7 @@ rm -rf %{buildroot}
 %install
 mkdir -p %{buildroot}/%{_bindir}
 mkdir -p %{buildroot}/%{_datadir}/games/hengband
-%makeinstall
+%make_install bindir=%{_bindir}
 cp -R lib/ -p %{buildroot}/%{_datadir}/games/hengband/
 find %{buildroot}/%{_datadir}/games/hengband/ -type f -name "Makefile*" -exec rm {} \;
 find %{buildroot}/%{_datadir}/games/hengband/ -type f -name "delete.me*" -exec rm {} \;
@@ -96,6 +95,9 @@ exit 0
 %license lib/help/jlicense.txt
 
 %changelog
+
+* Sun Oct 22 2023 Shiro Hara <white@vx-xv.com>
+- Fix the graphic mode is not available on X11
 
 * Wed Oct 18 2023 Shiro Hara <white@vx-xv.com>
 - hengband RPM 3.0.0.91(Alpha)

--- a/src/main-x11.cpp
+++ b/src/main-x11.cpp
@@ -2579,6 +2579,7 @@ errr init_x11(int argc, char *argv[])
     }
 
 #ifndef USE_XFT
+    char filename[1024]{};
     switch (arg_graphics) {
     case GRAPHICS_ORIGINAL: {
         const auto &path = path_build(ANGBAND_DIR_XTRA, "graf/8x8.bmp");
@@ -2586,6 +2587,7 @@ errr init_x11(int argc, char *argv[])
             use_graphics = true;
             pict_wid = pict_hgt = 8;
             ANGBAND_GRAF = "old";
+            strcpy(filename, path.string().c_str());
         }
         break;
     }
@@ -2595,6 +2597,7 @@ errr init_x11(int argc, char *argv[])
             use_graphics = true;
             pict_wid = pict_hgt = 16;
             ANGBAND_GRAF = "new";
+            strcpy(filename, path.string().c_str());
         }
         break;
     }
@@ -2603,7 +2606,6 @@ errr init_x11(int argc, char *argv[])
     if (use_graphics) {
         Display *dpy = Metadpy->dpy;
         XImage *tiles_raw;
-        char filename[1024]{};
         tiles_raw = ReadBMP(dpy, filename);
         for (i = 0; i < num_term; i++) {
             term_data *td = &data[i];

--- a/src/main-x11.cpp
+++ b/src/main-x11.cpp
@@ -2587,7 +2587,7 @@ errr init_x11(int argc, char *argv[])
             use_graphics = true;
             pict_wid = pict_hgt = 8;
             ANGBAND_GRAF = "old";
-            strcpy(filename, path.string().c_str());
+            angband_strcpy(filename, path.string().data(), sizeof(filename));
         }
         break;
     }
@@ -2597,7 +2597,7 @@ errr init_x11(int argc, char *argv[])
             use_graphics = true;
             pict_wid = pict_hgt = 16;
             ANGBAND_GRAF = "new";
-            strcpy(filename, path.string().c_str());
+            angband_strcpy(filename, path.string().data(), sizeof(filename));
         }
         break;
     }


### PR DESCRIPTION
- X11で"-g"をつけて起動するとSIGSEGVで落ちる不具合を修正。原因はタイルのファイル名を空のまま、ReadBMP関数を呼び出し。
- 本修正版を3.0.0.91-2としてCoprで公開