### PR TITLE
chore: clangでのビルドテストにlibc++を使用する

### DIFF
--- a/.github/workflows/pull-request-status-check.yml
+++ b/.github/workflows/pull-request-status-check.yml
@@ -27,7 +27,7 @@ jobs:
     uses: ./.github/workflows/build-with-autotools.yml
     with:
       cxx: clang++-14
-      cxx-flags: "-pipe -O3 -Werror -Wall -Wextra -Wno-unused-const-variable -Wno-invalid-source-encoding"
+      cxx-flags: "-pipe -O3 -Werror -Wall -Wextra -Wno-unused-const-variable -Wno-invalid-source-encoding -stdlib=libc++"
       configure-opts: "--disable-pch"
       use-ccache: true
 

--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -550,7 +550,7 @@ bool PlayerClass::has_ninja_speed() const
  */
 std::span<const std::string> PlayerClass::get_subtitle_candidates() const
 {
-    static const std::span<const std::string> candidates(diary_subtitles);
+    static const std::span<const std::string> candidates(diary_subtitles.begin(), diary_subtitles.end());
     const auto max = diary_subtitles.size();
     if (this->is_tough()) {
         return candidates.subspan(0, max - 1);

--- a/src/util/sha256.cpp
+++ b/src/util/sha256.cpp
@@ -1,4 +1,4 @@
-/*!
+﻿/*!
  * @brief SHA-256ハッシュ値計算クラスの定義
  *
  * RFC 6234のリファレンス実装を参考にC++20で実装
@@ -142,7 +142,7 @@ void SHA256::update(const std::byte *message_array, size_t length)
  */
 void SHA256::update(std::string_view message)
 {
-    const auto message_as_byte = std::as_bytes(std::span(message));
+    const auto message_as_byte = std::as_bytes(std::span(message.begin(), message.end()));
     this->update(message_as_byte.data(), message_as_byte.size_bytes());
 }
 


### PR DESCRIPTION
clang++-14とlibstdc++の組み合わせでコンパイルエラーが発生しているので、
clangでのビルドには標準C++ライブラリにlibc++を指定するようにする。