### PR TITLE
グリッドから地形へのアクセスをカプセル化する準備 その2

### DIFF
--- a/src/cmd-action/cmd-others.cpp
+++ b/src/cmd-action/cmd-others.cpp
@@ -67,37 +67,34 @@ static bool exe_alter(PlayerType *player_ptr)
         return false;
     }
 
-    POSITION y = player_ptr->y + ddy[dir];
-    POSITION x = player_ptr->x + ddx[dir];
-    Grid *g_ptr;
-    g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
-    FEAT_IDX feat = g_ptr->get_feat_mimic();
-    TerrainType *f_ptr;
-    f_ptr = &terrains_info[feat];
+    const Pos2D pos(player_ptr->y + ddy[dir], player_ptr->x + ddx[dir]);
+    const auto &grid = player_ptr->current_floor_ptr->get_grid(pos);
+    auto feat = grid.get_feat_mimic();
+    const auto &terrain = terrains_info[feat];
     PlayerEnergy(player_ptr).set_player_turn_energy(100);
-    if (g_ptr->m_idx) {
-        do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
+    if (grid.m_idx) {
+        do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_NONE);
         return false;
     }
 
-    if (f_ptr->flags.has(TerrainCharacteristics::OPEN)) {
-        return exe_open(player_ptr, y, x);
+    if (terrain.flags.has(TerrainCharacteristics::OPEN)) {
+        return exe_open(player_ptr, pos.y, pos.x);
     }
 
-    if (f_ptr->flags.has(TerrainCharacteristics::BASH)) {
-        return exe_bash(player_ptr, y, x, dir);
+    if (terrain.flags.has(TerrainCharacteristics::BASH)) {
+        return exe_bash(player_ptr, pos.y, pos.x, dir);
     }
 
-    if (f_ptr->flags.has(TerrainCharacteristics::TUNNEL)) {
-        return exe_tunnel(player_ptr, y, x);
+    if (terrain.flags.has(TerrainCharacteristics::TUNNEL)) {
+        return exe_tunnel(player_ptr, pos.y, pos.x);
     }
 
-    if (f_ptr->flags.has(TerrainCharacteristics::CLOSE)) {
-        return exe_close(player_ptr, y, x);
+    if (terrain.flags.has(TerrainCharacteristics::CLOSE)) {
+        return exe_close(player_ptr, pos.y, pos.x);
     }
 
-    if (f_ptr->flags.has(TerrainCharacteristics::DISARM)) {
-        return exe_disarm(player_ptr, y, x, dir);
+    if (terrain.flags.has(TerrainCharacteristics::DISARM)) {
+        return exe_disarm(player_ptr, pos.y, pos.x, dir);
     }
 
     msg_print(_("何もない空中を攻撃した。", "You attack the empty air."));

--- a/src/cmd-action/cmd-travel.cpp
+++ b/src/cmd-action/cmd-travel.cpp
@@ -26,17 +26,18 @@
 static int travel_flow_cost(PlayerType *player_ptr, POSITION y, POSITION x)
 {
     int cost = 1;
-    auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
-    auto *f_ptr = &terrains_info[g_ptr->feat];
-    if (f_ptr->flags.has(TerrainCharacteristics::AVOID_RUN)) {
+    const Pos2D pos(y, x);
+    const auto &grid = player_ptr->current_floor_ptr->get_grid(pos);
+    const auto &terrain = terrains_info[grid.feat];
+    if (terrain.flags.has(TerrainCharacteristics::AVOID_RUN)) {
         cost += 1;
     }
 
-    if (f_ptr->flags.has_all_of({ TerrainCharacteristics::WATER, TerrainCharacteristics::DEEP }) && !player_ptr->levitation) {
+    if (terrain.flags.has_all_of({ TerrainCharacteristics::WATER, TerrainCharacteristics::DEEP }) && !player_ptr->levitation) {
         cost += 5;
     }
 
-    if (f_ptr->flags.has(TerrainCharacteristics::LAVA)) {
+    if (terrain.flags.has(TerrainCharacteristics::LAVA)) {
         int lava = 2;
         if (!has_resist_fire(player_ptr)) {
             lava *= 2;
@@ -46,19 +47,19 @@ static int travel_flow_cost(PlayerType *player_ptr, POSITION y, POSITION x)
             lava *= 2;
         }
 
-        if (f_ptr->flags.has(TerrainCharacteristics::DEEP)) {
+        if (terrain.flags.has(TerrainCharacteristics::DEEP)) {
             lava *= 2;
         }
 
         cost += lava;
     }
 
-    if (g_ptr->is_mark()) {
-        if (f_ptr->flags.has(TerrainCharacteristics::DOOR)) {
+    if (grid.is_mark()) {
+        if (terrain.flags.has(TerrainCharacteristics::DOOR)) {
             cost += 1;
         }
 
-        if (f_ptr->flags.has(TerrainCharacteristics::TRAP)) {
+        if (terrain.flags.has(TerrainCharacteristics::TRAP)) {
             cost += 10;
         }
     }
@@ -74,41 +75,47 @@ static int travel_flow_cost(PlayerType *player_ptr, POSITION y, POSITION x)
  * @param n 現在のコスト
  * @param wall プレイヤーが壁の中にいるならばTRUE
  */
-static void travel_flow_aux(PlayerType *player_ptr, POSITION y, POSITION x, int n, bool wall)
+static void travel_flow_aux(PlayerType *player_ptr, const Pos2D pos, int n, bool wall)
 {
-    auto *floor_ptr = player_ptr->current_floor_ptr;
-    auto *g_ptr = &floor_ptr->grid_array[y][x];
-    auto *f_ptr = &terrains_info[g_ptr->feat];
-    if (!in_bounds(floor_ptr, y, x)) {
+    auto &floor = *player_ptr->current_floor_ptr;
+    auto &grid = floor.get_grid(pos);
+    auto &terrain = terrains_info[grid.feat];
+    if (!in_bounds(&floor, pos.y, pos.x)) {
         return;
     }
 
-    if (floor_ptr->dun_level > 0 && !(g_ptr->info & CAVE_KNOWN)) {
+    if (floor.dun_level > 0 && !(grid.info & CAVE_KNOWN)) {
         return;
     }
 
-    int add_cost = 1;
-    int from_wall = (n / TRAVEL_UNABLE);
-    if (f_ptr->flags.has(TerrainCharacteristics::WALL) || f_ptr->flags.has(TerrainCharacteristics::CAN_DIG) || (f_ptr->flags.has(TerrainCharacteristics::DOOR) && floor_ptr->grid_array[y][x].mimic) || (f_ptr->flags.has_not(TerrainCharacteristics::MOVE) && f_ptr->flags.has(TerrainCharacteristics::CAN_FLY) && !player_ptr->levitation)) {
+    auto add_cost = 1;
+    auto from_wall = (n / TRAVEL_UNABLE);
+    auto is_wall = terrain.flags.has_any_of({ TerrainCharacteristics::WALL, TerrainCharacteristics::CAN_DIG });
+    is_wall |= terrain.flags.has(TerrainCharacteristics::DOOR) && (grid.mimic > 0);
+    auto can_move = terrain.flags.has_not(TerrainCharacteristics::MOVE);
+    can_move &= terrain.flags.has(TerrainCharacteristics::CAN_FLY);
+    can_move &= !player_ptr->levitation;
+    if (is_wall || can_move) {
         if (!wall || !from_wall) {
             return;
         }
 
         add_cost += TRAVEL_UNABLE;
     } else {
-        add_cost = travel_flow_cost(player_ptr, y, x);
+        add_cost = travel_flow_cost(player_ptr, pos.y, pos.x);
     }
 
-    int base_cost = (n % TRAVEL_UNABLE);
-    int cost = base_cost + add_cost;
-    if (travel.cost[y][x] <= cost) {
+    auto base_cost = (n % TRAVEL_UNABLE);
+    auto cost = base_cost + add_cost;
+    auto &travel_cost = travel.cost[pos.y][pos.x];
+    if (travel_cost <= cost) {
         return;
     }
 
-    travel.cost[y][x] = cost;
-    int old_head = flow_head;
-    temp2_y[flow_head] = y;
-    temp2_x[flow_head] = x;
+    travel_cost = cost;
+    auto old_head = flow_head;
+    temp2_y[flow_head] = pos.y;
+    temp2_x[flow_head] = pos.x;
     if (++flow_head == MAX_SHORT) {
         flow_head = 0;
     }
@@ -124,26 +131,22 @@ static void travel_flow_aux(PlayerType *player_ptr, POSITION y, POSITION x, int 
  * @param ty 目標地点のY座標
  * @param tx 目標地点のX座標
  */
-static void travel_flow(PlayerType *player_ptr, POSITION ty, POSITION tx)
+static void travel_flow(PlayerType *player_ptr, const Pos2D pos)
 {
     flow_head = flow_tail = 0;
-    bool wall = false;
-    auto *f_ptr = &terrains_info[player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x].feat];
-    if (f_ptr->flags.has_not(TerrainCharacteristics::MOVE)) {
-        wall = true;
-    }
+    const auto &terrain = terrains_info[player_ptr->current_floor_ptr->get_grid(player_ptr->get_position()).feat];
+    auto wall = terrain.flags.has(TerrainCharacteristics::MOVE);
 
-    travel_flow_aux(player_ptr, ty, tx, 0, wall);
-    POSITION x, y;
+    travel_flow_aux(player_ptr, pos, 0, wall);
     while (flow_head != flow_tail) {
-        y = temp2_y[flow_tail];
-        x = temp2_x[flow_tail];
+        const Pos2D pos_flow(temp2_y[flow_tail], temp2_x[flow_tail]);
         if (++flow_tail == MAX_SHORT) {
             flow_tail = 0;
         }
 
-        for (DIRECTION d = 0; d < 8; d++) {
-            travel_flow_aux(player_ptr, y + ddy_ddd[d], x + ddx_ddd[d], travel.cost[y][x], wall);
+        for (auto d = 0; d < 8; d++) {
+            const Pos2D pos_neighbor(pos_flow.y + ddy_ddd[d], pos_flow.x + ddx_ddd[d]);
+            travel_flow_aux(player_ptr, pos_neighbor, travel.cost[pos_flow.y][pos_flow.x], wall);
         }
     }
 
@@ -155,7 +158,7 @@ static void travel_flow(PlayerType *player_ptr, POSITION ty, POSITION tx)
  */
 void do_cmd_travel(PlayerType *player_ptr)
 {
-    POSITION x, y;
+    int x, y;
     if ((travel.x != 0) && (travel.y != 0) && (travel.x != player_ptr->x) && (travel.y != player_ptr->y) && input_check(_("トラベルを継続しますか？", "Do you continue to travel? "))) {
         y = travel.y;
         x = travel.x;
@@ -163,30 +166,34 @@ void do_cmd_travel(PlayerType *player_ptr)
         return;
     }
 
-    if ((x == player_ptr->x) && (y == player_ptr->y)) {
+    const Pos2D pos(y, x);
+    if (player_ptr->is_located_at(pos)) {
         msg_print(_("すでにそこにいます！", "You are already there!!"));
         return;
     }
 
-    auto *floor_ptr = player_ptr->current_floor_ptr;
-    TerrainType *f_ptr;
-    f_ptr = &terrains_info[floor_ptr->grid_array[y][x].feat];
-    if ((floor_ptr->grid_array[y][x].info & CAVE_MARK) && (f_ptr->flags.has(TerrainCharacteristics::WALL) || f_ptr->flags.has(TerrainCharacteristics::CAN_DIG) || (f_ptr->flags.has(TerrainCharacteristics::DOOR) && floor_ptr->grid_array[y][x].mimic))) {
+    const auto &floor = *player_ptr->current_floor_ptr;
+    const auto &grid = floor.get_grid(pos);
+    const auto &terrain = terrains_info[grid.feat];
+    const auto is_marked = any_bits(grid.info, CAVE_MARK);
+    const auto is_wall = terrain.flags.has_any_of({ TerrainCharacteristics::WALL, TerrainCharacteristics::CAN_DIG });
+    const auto is_door = terrain.flags.has(TerrainCharacteristics::DOOR) && (grid.mimic > 0);
+    if (is_marked && (is_wall || is_door)) {
         msg_print(_("そこには行くことができません！", "You cannot travel there!"));
         return;
     }
 
     forget_travel_flow(player_ptr->current_floor_ptr);
-    travel_flow(player_ptr, y, x);
+    travel_flow(player_ptr, pos);
     travel.x = x;
     travel.y = y;
     travel.run = 255;
     travel.dir = 0;
-    POSITION dx = abs(player_ptr->x - x);
-    POSITION dy = abs(player_ptr->y - y);
-    POSITION sx = ((x == player_ptr->x) || (dx < dy)) ? 0 : ((x > player_ptr->x) ? 1 : -1);
-    POSITION sy = ((y == player_ptr->y) || (dy < dx)) ? 0 : ((y > player_ptr->y) ? 1 : -1);
-    for (int i = 1; i <= 9; i++) {
+    auto dx = std::abs(player_ptr->x - x);
+    auto dy = std::abs(player_ptr->y - y);
+    auto sx = ((x == player_ptr->x) || (dx < dy)) ? 0 : ((x > player_ptr->x) ? 1 : -1);
+    auto sy = ((y == player_ptr->y) || (dy < dx)) ? 0 : ((y > player_ptr->y) ? 1 : -1);
+    for (auto i = 1; i <= 9; i++) {
         if ((sx == ddx[i]) && (sy == ddy[i])) {
             travel.dir = i;
         }

--- a/src/cmd-building/cmd-building.cpp
+++ b/src/cmd-building/cmd-building.cpp
@@ -312,15 +312,15 @@ void do_cmd_building(PlayerType *player_ptr)
 
     PlayerEnergy energy(player_ptr);
     energy.set_player_turn_energy(100);
-
-    if (!cave_has_flag_bold(player_ptr->current_floor_ptr, player_ptr->y, player_ptr->x, TerrainCharacteristics::BLDG)) {
+    const auto p_pos = player_ptr->get_position();
+    if (!cave_has_flag_bold(player_ptr->current_floor_ptr, p_pos.y, p_pos.x, TerrainCharacteristics::BLDG)) {
         msg_print(_("ここには建物はない。", "You see no building here."));
         return;
     }
 
     TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, MAIN_TERM_MIN_ROWS);
 
-    int which = terrains_info[player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x].feat].subtype;
+    int which = terrains_info[player_ptr->current_floor_ptr->get_grid(p_pos).feat].subtype;
 
     building_type *bldg;
     bldg = &buildings[which];

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -412,13 +412,14 @@ void do_cmd_visuals(PlayerType *player_ptr)
                     const auto previous_terrain_id = terrain_id;
                     while (true) {
                         new_terrain_id = input_new_visual_id(ch, terrain_id, static_cast<short>(TerrainList::get_instance().size()));
-                        if (!new_terrain_id.has_value()) {
+                        if (!new_terrain_id) {
                             terrain_id = previous_terrain_id;
                             break;
                         }
 
-                        terrain_id = new_terrain_id.value();
-                        if (!terrains_info[terrain_id].name.empty() && (terrains_info[terrain_id].mimic == terrain_id)) {
+                        terrain_id = *new_terrain_id;
+                        const auto &new_terrain = terrains[terrain_id];
+                        if (!new_terrain.name.empty() && (new_terrain.mimic == terrain_id)) {
                             break;
                         }
                     }

--- a/src/effect/effect-feature.cpp
+++ b/src/effect/effect-feature.cpp
@@ -171,7 +171,7 @@ bool affect_feature(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITIO
         break;
     }
     case AttributeType::KILL_TRAP: {
-        if (is_hidden_door(player_ptr, &grid)) {
+        if (is_hidden_door(player_ptr, grid)) {
             disclose_grid(player_ptr, y, x);
             if (known) {
                 obvious = true;

--- a/src/floor/cave-generator.cpp
+++ b/src/floor/cave-generator.cpp
@@ -129,16 +129,14 @@ static bool decide_tunnel_planned_site(PlayerType *player_ptr, dun_data_type *dd
 
 static void make_tunnels(PlayerType *player_ptr, dun_data_type *dd_ptr)
 {
-    for (int j = 0; j < dd_ptr->tunn_n; j++) {
-        Grid *g_ptr;
-        TerrainType *f_ptr;
-        dd_ptr->tunnel_y = dd_ptr->tunn[j].y;
-        dd_ptr->tunnel_x = dd_ptr->tunn[j].x;
-        g_ptr = &player_ptr->current_floor_ptr->grid_array[dd_ptr->tunnel_y][dd_ptr->tunnel_x];
-        f_ptr = &terrains_info[g_ptr->feat];
-        if (f_ptr->flags.has_not(TerrainCharacteristics::MOVE) || f_ptr->flags.has_none_of({ TerrainCharacteristics::WATER, TerrainCharacteristics::LAVA })) {
-            g_ptr->mimic = 0;
-            place_grid(player_ptr, g_ptr, GB_FLOOR);
+    for (auto i = 0; i < dd_ptr->tunn_n; i++) {
+        dd_ptr->tunnel_y = dd_ptr->tunn[i].y;
+        dd_ptr->tunnel_x = dd_ptr->tunn[i].x;
+        auto &grid = player_ptr->current_floor_ptr->grid_array[dd_ptr->tunnel_y][dd_ptr->tunnel_x];
+        const auto &terrain = terrains_info[grid.feat];
+        if (terrain.flags.has_not(TerrainCharacteristics::MOVE) || terrain.flags.has_none_of({ TerrainCharacteristics::WATER, TerrainCharacteristics::LAVA })) {
+            grid.mimic = 0;
+            place_grid(player_ptr, &grid, GB_FLOOR);
         }
     }
 }
@@ -294,8 +292,8 @@ static void place_bound_perm_wall(PlayerType *player_ptr, Grid *g_ptr)
         return;
     }
 
-    auto *f_ptr = &terrains_info[g_ptr->feat];
-    if (f_ptr->flags.has_any_of({ TerrainCharacteristics::HAS_GOLD, TerrainCharacteristics::HAS_ITEM }) && f_ptr->flags.has_not(TerrainCharacteristics::SECRET)) {
+    const auto &terrain = terrains_info[g_ptr->feat];
+    if (terrain.flags.has_any_of({ TerrainCharacteristics::HAS_GOLD, TerrainCharacteristics::HAS_ITEM }) && terrain.flags.has_not(TerrainCharacteristics::SECRET)) {
         g_ptr->feat = feat_state(player_ptr->current_floor_ptr, g_ptr->feat, TerrainCharacteristics::ENSECRET);
     }
 

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -89,7 +89,7 @@ static int16_t conv_terrain2feat[MAX_WILDERNESS];
  */
 static void set_floor_and_wall_aux(int16_t feat_type[100], const std::array<feat_prob, DUNGEON_FEAT_PROB_NUM> &prob)
 {
-    int lim[DUNGEON_FEAT_PROB_NUM];
+    std::array<int, DUNGEON_FEAT_PROB_NUM> lim{};
     lim[0] = prob[0].percent;
     for (int i = 1; i < DUNGEON_FEAT_PROB_NUM; i++) {
         lim[i] = lim[i - 1] + prob[i].percent;

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -147,13 +147,9 @@ bool new_player_spot(PlayerType *player_ptr)
  * @param g_ptr マス構造体の参照ポインタ
  * @return 隠されたドアがあるならTRUEを返す。
  */
-bool is_hidden_door(PlayerType *player_ptr, Grid *g_ptr)
+bool is_hidden_door(PlayerType *player_ptr, const Grid &grid)
 {
-    if ((g_ptr->mimic || g_ptr->cave_has_flag(TerrainCharacteristics::SECRET)) && is_closed_door(player_ptr, g_ptr->feat)) {
-        return true;
-    } else {
-        return false;
-    }
+    return (grid.mimic || grid.cave_has_flag(TerrainCharacteristics::SECRET)) && is_closed_door(player_ptr, grid.feat);
 }
 
 /*!

--- a/src/grid/grid.h
+++ b/src/grid/grid.h
@@ -48,7 +48,7 @@ class PlayerType;
 class MonsterRaceInfo;
 enum class TerrainCharacteristics;
 bool new_player_spot(PlayerType *player_ptr);
-bool is_hidden_door(PlayerType *player_ptr, Grid *g_ptr);
+bool is_hidden_door(PlayerType *player_ptr, const Grid &grid);
 bool player_can_enter(PlayerType *player_ptr, FEAT_IDX feature, BIT_FLAGS16 mode);
 bool feat_uses_special(FEAT_IDX f_idx);
 void update_local_illumination(PlayerType *player_ptr, POSITION y, POSITION x);

--- a/src/monster-floor/monster-sweep-grid.cpp
+++ b/src/monster-floor/monster-sweep-grid.cpp
@@ -274,7 +274,7 @@ void MonsterSweepGrid::sweep_movable_grid(POSITION *yp, POSITION *xp, bool no_fl
     if (grid.get_cost(&monrace)) {
         this->best = 999;
     } else if (grid.when) {
-        const Pos2D p_pos(this->player_ptr->y, this->player_ptr->x);
+        const auto p_pos = this->player_ptr->get_position();
         if (floor.get_grid(p_pos).when - grid.when > 127) {
             return;
         }

--- a/src/pet/pet-util.cpp
+++ b/src/pet/pet-util.cpp
@@ -24,7 +24,7 @@ int total_friends = 0;
  * @param now_riding trueなら下馬処理、falseならば騎乗処理
  * @return 可能ならばtrueを返す
  */
-bool can_player_ride_pet(PlayerType *player_ptr, Grid *g_ptr, bool now_riding)
+bool can_player_ride_pet(PlayerType *player_ptr, const Grid *g_ptr, bool now_riding)
 {
     bool old_character_xtra = w_ptr->character_xtra;
     MONSTER_IDX old_riding = player_ptr->riding;

--- a/src/pet/pet-util.h
+++ b/src/pet/pet-util.h
@@ -44,5 +44,5 @@ extern int total_friends;
 
 class Grid;
 class PlayerType;
-bool can_player_ride_pet(PlayerType *player_ptr, Grid *g_ptr, bool now_riding);
+bool can_player_ride_pet(PlayerType *player_ptr, const Grid *g_ptr, bool now_riding);
 PERCENTAGE calculate_upkeep(PlayerType *player_ptr);

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -61,16 +61,16 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
     }
 
     bool map[32][32]{};
-    for (POSITION y = 0; y < 32; y++) {
-        for (POSITION x = 0; x < 32; x++) {
+    for (auto y = 0; y < 32; y++) {
+        for (auto x = 0; x < 32; x++) {
             map[y][x] = false;
         }
     }
 
-    int damage = 0;
-    bool hurt = false;
-    for (POSITION dy = -r; dy <= r; dy++) {
-        for (POSITION dx = -r; dx <= r; dx++) {
+    auto damage = 0;
+    auto hurt = false;
+    for (auto dy = -r; dy <= r; dy++) {
+        for (auto dx = -r; dx <= r; dx++) {
             const Pos2D pos(cy + dy, cx + dx);
             if (!in_bounds(floor_ptr, pos.y, pos.x)) {
                 continue;
@@ -101,9 +101,9 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
     auto sn = 0;
     Pos2D p_pos_new(0, 0); // 落石を避けた後のプレイヤー座標
     if (hurt && !has_pass_wall(player_ptr) && !has_kill_wall(player_ptr)) {
-        for (DIRECTION i = 0; i < 8; i++) {
-            POSITION y = player_ptr->y + ddy_ddd[i];
-            POSITION x = player_ptr->x + ddx_ddd[i];
+        for (auto i = 0; i < 8; i++) {
+            auto y = player_ptr->y + ddy_ddd[i];
+            auto x = player_ptr->x + ddx_ddd[i];
             if (!is_cave_empty_bold(player_ptr, y, x)) {
                 continue;
             }
@@ -168,8 +168,8 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
         }
     }
 
-    for (POSITION dy = -r; dy <= r; dy++) {
-        for (POSITION dx = -r; dx <= r; dx++) {
+    for (auto dy = -r; dy <= r; dy++) {
+        for (auto dx = -r; dx <= r; dx++) {
             const Pos2D pos(cy + dy, cx + dx);
             if (!map[16 + pos.y - cy][16 + pos.x - cx]) {
                 continue;
@@ -279,10 +279,10 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
     }
 
     clear_mon_lite(floor_ptr);
-    for (POSITION dy = -r; dy <= r; dy++) {
-        for (POSITION dx = -r; dx <= r; dx++) {
-            POSITION yy = cy + dy;
-            POSITION xx = cx + dx;
+    for (auto dy = -r; dy <= r; dy++) {
+        for (auto dx = -r; dx <= r; dx++) {
+            auto yy = cy + dy;
+            auto xx = cx + dx;
             if (!map[16 + yy - cy][16 + xx - cx]) {
                 continue;
             }
@@ -312,21 +312,20 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
         }
     }
 
-    for (POSITION dy = -r; dy <= r; dy++) {
-        for (POSITION dx = -r; dx <= r; dx++) {
-            POSITION yy = cy + dy;
-            POSITION xx = cx + dx;
-            if (!in_bounds(floor_ptr, yy, xx)) {
+    for (auto dy = -r; dy <= r; dy++) {
+        for (auto dx = -r; dx <= r; dx++) {
+            const Pos2D pos(cy + dy, cx + dx);
+            if (!in_bounds(floor_ptr, pos.y, pos.x)) {
                 continue;
             }
 
-            if (distance(cy, cx, yy, xx) > r) {
+            if (distance(cy, cx, pos.y, pos.x) > r) {
                 continue;
             }
 
-            auto *g_ptr = &floor_ptr->grid_array[yy][xx];
-            if (g_ptr->is_mirror()) {
-                g_ptr->info |= CAVE_GLOW;
+            auto &grid = floor_ptr->get_grid(pos);
+            if (grid.is_mirror()) {
+                grid.info |= CAVE_GLOW;
                 continue;
             }
 
@@ -334,16 +333,15 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
                 continue;
             }
 
-            Grid *cc_ptr;
-            for (DIRECTION ii = 0; ii < 9; ii++) {
-                POSITION yyy = yy + ddy_ddd[ii];
-                POSITION xxx = xx + ddx_ddd[ii];
-                if (!in_bounds2(floor_ptr, yyy, xxx)) {
+            for (auto j = 0; j < 9; j++) {
+                const Pos2D pos_neighbor(pos.y + ddy_ddd[j], pos.x + ddx_ddd[j]);
+                if (!in_bounds2(floor_ptr, pos_neighbor.y, pos_neighbor.x)) {
                     continue;
                 }
-                cc_ptr = &floor_ptr->grid_array[yyy][xxx];
-                if (terrains_info[cc_ptr->get_feat_mimic()].flags.has(TerrainCharacteristics::GLOW)) {
-                    g_ptr->info |= CAVE_GLOW;
+
+                const auto &grid_neighbor = floor_ptr->get_grid(pos_neighbor);
+                if (terrains_info[grid_neighbor.get_feat_mimic()].flags.has(TerrainCharacteristics::GLOW)) {
+                    grid.info |= CAVE_GLOW;
                     break;
                 }
             }

--- a/src/spell-kind/spells-fetcher.cpp
+++ b/src/spell-kind/spells-fetcher.cpp
@@ -40,7 +40,7 @@
 void fetch_item(PlayerType *player_ptr, DIRECTION dir, WEIGHT wgt, bool require_los)
 {
     auto &floor = *player_ptr->current_floor_ptr;
-    const Pos2D p_pos(player_ptr->y, player_ptr->x);
+    const auto p_pos = player_ptr->get_position();
     if (!floor.get_grid(p_pos).o_idx_list.empty()) {
         msg_print(_("自分の足の下にある物は取れません。", "You can't fetch when you're already standing on something."));
         return;

--- a/src/store/cmd-store.cpp
+++ b/src/store/cmd-store.cpp
@@ -60,9 +60,9 @@ void do_cmd_store(PlayerType *player_ptr)
     xtra_stock = std::min(14 + 26, ((hgt > MAIN_TERM_MIN_ROWS) ? (hgt - MAIN_TERM_MIN_ROWS) : 0));
     store_bottom = MIN_STOCK + xtra_stock;
 
-    auto *floor_ptr = player_ptr->current_floor_ptr;
-    const auto *g_ptr = &floor_ptr->grid_array[player_ptr->y][player_ptr->x];
-    if (!g_ptr->cave_has_flag(TerrainCharacteristics::STORE)) {
+    auto &floor = *player_ptr->current_floor_ptr;
+    const auto &grid = floor.get_grid(player_ptr->get_position());
+    if (!grid.cave_has_flag(TerrainCharacteristics::STORE)) {
         msg_print(_("ここには店がありません。", "You see no store here."));
         return;
     }
@@ -74,13 +74,13 @@ void do_cmd_store(PlayerType *player_ptr)
     //   inner_town_num は、施設内で C コマンドなどを使ったときにそのままでは現在地の偽装がバレる
     //   ため、それを糊塗するためのグローバル変数。
     //   この辺はリファクタしたい。
-    StoreSaleType store_num = i2enum<StoreSaleType>(terrains_info[g_ptr->feat].subtype);
+    const auto store_num = i2enum<StoreSaleType>(terrains_info[grid.feat].subtype);
     old_town_num = player_ptr->town_num;
     if ((store_num == StoreSaleType::HOME) || (store_num == StoreSaleType::MUSEUM)) {
         player_ptr->town_num = 1;
     }
 
-    if (floor_ptr->is_in_dungeon()) {
+    if (floor.is_in_dungeon()) {
         player_ptr->town_num = VALID_TOWNS;
     }
 
@@ -103,14 +103,14 @@ void do_cmd_store(PlayerType *player_ptr)
         store.last_visit = w_ptr->game_turn;
     }
 
-    forget_lite(floor_ptr);
-    forget_view(floor_ptr);
+    forget_lite(&floor);
+    forget_view(&floor);
     w_ptr->character_icky_depth = 1;
     command_arg = 0;
     command_rep = 0;
     command_new = 0;
     get_com_no_macros = true;
-    cur_store_feat = g_ptr->feat;
+    cur_store_feat = grid.feat;
     st_ptr = &towns_info[player_ptr->town_num].stores[store_num];
     ot_ptr = &owners.at(store_num)[st_ptr->owner];
     store_top = 0;


### PR DESCRIPTION
terrains_info[] へアクセスしているグリッドへのポインタを参照に差し替えました (一部周辺設計の都合で例外あり)
ご確認下さい