### PR TITLE
optional 型へのhas_value() アクセスを統一した

### DIFF
--- a/src/action/activation-execution.cpp
+++ b/src/action/activation-execution.cpp
@@ -61,7 +61,7 @@ static void decide_activation_level(ae_type *ae_ptr)
 
     if (ae_ptr->o_ptr->is_random_artifact()) {
         auto act_ptr = find_activation_info(ae_ptr->o_ptr);
-        if (act_ptr.has_value()) {
+        if (act_ptr) {
             ae_ptr->lev = act_ptr.value()->level;
         }
 
@@ -156,7 +156,7 @@ static bool check_activation_conditions(PlayerType *player_ptr, ae_type *ae_ptr)
 static bool activate_artifact(PlayerType *player_ptr, ItemEntity *o_ptr)
 {
     auto tmp_act_ptr = find_activation_info(o_ptr);
-    if (!tmp_act_ptr.has_value()) {
+    if (!tmp_act_ptr) {
         msg_print("Activation information is not found.");
         return false;
     }

--- a/src/artifact/artifact-info.cpp
+++ b/src/artifact/artifact-info.cpp
@@ -24,7 +24,7 @@
  */
 RandomArtActType activation_index(const ItemEntity *o_ptr)
 {
-    if (auto act_idx = Smith::object_activation(o_ptr); act_idx.has_value()) {
+    if (auto act_idx = Smith::object_activation(o_ptr); act_idx) {
         return act_idx.value();
     }
 

--- a/src/artifact/random-art-characteristics.cpp
+++ b/src/artifact/random-art-characteristics.cpp
@@ -150,7 +150,7 @@ std::string get_random_name(const ItemEntity &item, bool armour, int power)
     auto filename = get_random_art_filename(armour, power);
     auto random_artifact_name = get_random_line(filename.data(), item.artifact_bias);
 #ifdef JP
-    if (random_artifact_name.has_value()) {
+    if (random_artifact_name) {
         return random_artifact_name.value();
     }
 

--- a/src/artifact/random-art-generator.cpp
+++ b/src/artifact/random-art-generator.cpp
@@ -399,7 +399,7 @@ static std::string name_unnatural_random_artifact(PlayerType *player_ptr, ItemEn
         return ss.str();
     };
     const auto new_name = input_string(prompt, 160);
-    if (new_name.has_value() && !new_name->empty()) {
+    if (new_name && !new_name->empty()) {
         return wrap_name(new_name.value());
     }
 

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -327,12 +327,12 @@ bool autopick_new_entry(autopick_type *entry, concptr str, bool allow_default)
     }
 #endif
     else if (*ptr == '\0') {
-        if (!previous_flag.has_value()) {
+        if (!previous_flag) {
             entry->add(FLG_ITEMS);
             previous_flag = FLG_ITEMS;
         }
     } else {
-        if (previous_flag.has_value()) {
+        if (previous_flag) {
             entry->remove(previous_flag.value());
             ptr = prev_ptr;
         }

--- a/src/blue-magic/blue-magic-caster.cpp
+++ b/src/blue-magic/blue-magic-caster.cpp
@@ -139,7 +139,7 @@ static bool cast_blue_teleport_back(PlayerType *player_ptr)
     }
 
     const auto m_name = exe_blue_teleport_back(player_ptr);
-    if (!m_name.has_value()) {
+    if (!m_name) {
         return true;
     }
 

--- a/src/blue-magic/learnt-power-getter.cpp
+++ b/src/blue-magic/learnt-power-getter.cpp
@@ -69,7 +69,7 @@ static std::optional<BlueMagicType> select_blue_magic_type_by_menu()
 
     screen_save();
 
-    while (!type.has_value()) {
+    while (!type) {
         prt(format(_(" %s ボルト", " %s bolt"), (menu_line == 1) ? _("》", "> ") : "  "), 2, 14);
         prt(format(_(" %s ボール", " %s ball"), (menu_line == 2) ? _("》", "> ") : "  "), 3, 14);
         prt(format(_(" %s ブレス", " %s breath"), (menu_line == 3) ? _("》", "> ") : "  "), 4, 14);
@@ -124,7 +124,7 @@ static std::optional<BlueMagicType> select_blue_magic_kind_by_symbol()
         "[A] bolt, [B] ball, [C] breath, [D] summoning, [E] others:");
     while (true) {
         const auto command = input_command(candidate_desc, true);
-        if (!command.has_value()) {
+        if (!command) {
             return std::nullopt;
         }
 
@@ -368,11 +368,11 @@ static std::optional<MonsterAbilityType> select_learnt_spells_by_symbol(PlayerTy
     auto show_list = false;
     std::optional<MonsterAbilityType> selected_spell;
 
-    while (!selected_spell.has_value()) {
+    while (!selected_spell) {
         auto choice = '\0';
         if (!first_show_list) {
             const auto choice_opt = input_command(prompt, true);
-            if (!choice_opt.has_value()) {
+            if (!choice_opt) {
                 break;
             }
 
@@ -432,11 +432,11 @@ static std::optional<MonsterAbilityType> select_learnt_spells_by_menu(PlayerType
 
     screen_save();
 
-    while (!selected_spell.has_value()) {
+    while (!selected_spell) {
         describe_blue_magic_name(player_ptr, menu_line, bluemage_data, spells);
 
         const auto choice_opt = input_command(prompt, true);
-        if (!choice_opt.has_value()) {
+        if (!choice_opt) {
             break;
         }
 
@@ -489,19 +489,19 @@ std::optional<MonsterAbilityType> get_learned_power(PlayerType *player_ptr)
     }
 
     if (auto repeat_spell = check_blue_magic_repeat();
-        repeat_spell.has_value()) {
+        repeat_spell) {
         return repeat_spell;
     }
 
     auto type = (use_menu)
                     ? select_blue_magic_type_by_menu()
                     : select_blue_magic_kind_by_symbol();
-    if (!type.has_value()) {
+    if (!type) {
         return std::nullopt;
     }
 
     auto spells = sweep_learnt_spells(*bluemage_data, type.value());
-    if (!spells.has_value() || spells->empty()) {
+    if (!spells || spells->empty()) {
         return std::nullopt;
     }
 
@@ -512,7 +512,7 @@ std::optional<MonsterAbilityType> get_learned_power(PlayerType *player_ptr)
     RedrawingFlagsUpdater::get_instance().set_flag(SubWindowRedrawingFlag::SPELL);
     handle_stuff(player_ptr);
 
-    if (!selected_spell.has_value()) {
+    if (!selected_spell) {
         return std::nullopt;
     }
 

--- a/src/cmd-action/cmd-hissatsu.cpp
+++ b/src/cmd-action/cmd-hissatsu.cpp
@@ -112,7 +112,7 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
             choice = ' ';
         } else {
             const auto new_choice = input_command(prompt);
-            if (!new_choice.has_value()) {
+            if (!new_choice) {
                 break;
             }
 

--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -169,7 +169,7 @@ static int get_mane_power(PlayerType *player_ptr, int *sn, bool baigaesi)
             choice = ' ';
         } else {
             const auto new_choice = input_command(prompt, true);
-            if (!new_choice.has_value()) {
+            if (!new_choice) {
                 break;
             }
 

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -447,7 +447,7 @@ static bool input_rest_turns()
     constexpr auto p = _("休憩 (0-9999, '*' で HP/MP全快, '&' で必要なだけ): ", "Rest (0-9999, '*' for HP/SP, '&' as needed): ");
     while (true) {
         const auto rest_turns_opt = input_string(p, 4, "&");
-        if (!rest_turns_opt.has_value()) {
+        if (!rest_turns_opt) {
             return false;
         }
 

--- a/src/cmd-action/cmd-others.cpp
+++ b/src/cmd-action/cmd-others.cpp
@@ -147,7 +147,7 @@ static void accept_winner_message(PlayerType *player_ptr)
     std::optional<std::string> buf;
     while (true) {
         buf = input_string(_("*勝利*メッセージ: ", "*Winning* message: "), 1024);
-        if (!buf.has_value()) {
+        if (!buf) {
             continue;
         }
 

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -354,7 +354,7 @@ static void do_name_pet(PlayerType *player_ptr)
     }
 
     const auto new_name = input_string(_("名前: ", "Name: "), 15, initial_name);
-    if (!new_name.has_value()) {
+    if (!new_name) {
         return;
     }
 
@@ -563,7 +563,7 @@ void do_cmd_pet(PlayerType *player_ptr)
                 choice = ' ';
             } else {
                 const auto new_choice = input_command(prompt, true);
-                if (!new_choice.has_value()) {
+                if (!new_choice) {
                     break;
                 }
 

--- a/src/cmd-action/cmd-racial.cpp
+++ b/src/cmd-action/cmd-racial.cpp
@@ -334,7 +334,7 @@ static bool racial_power_process_input(PlayerType *player_ptr, rc_type *rc_ptr)
             rc_ptr->choice = ' ';
         } else {
             const auto choice = input_command(rc_ptr->out_val);
-            if (!choice.has_value()) {
+            if (!choice) {
                 return false;
             }
 

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -388,7 +388,7 @@ static int get_spell(PlayerType *player_ptr, SPELL_IDX *sn, std::string_view pro
             choice = ' ';
         } else {
             const auto new_choice = input_command(prompt, true);
-            if (!new_choice.has_value()) {
+            if (!new_choice) {
                 break;
             }
 

--- a/src/cmd-io/cmd-diary.cpp
+++ b/src/cmd-io/cmd-diary.cpp
@@ -47,7 +47,7 @@ static void display_diary(PlayerType *player_ptr)
 static void add_diary_note(PlayerType *player_ptr)
 {
     const auto input_str = input_string(_("内容: ", "diary note: "), 1000);
-    if (input_str.has_value()) {
+    if (input_str) {
         exe_write_diary(player_ptr, DiaryKind::DESCRIPTION, 0, input_str.value());
     }
 }

--- a/src/cmd-io/cmd-dump.cpp
+++ b/src/cmd-io/cmd-dump.cpp
@@ -51,7 +51,7 @@
 void do_cmd_pref(PlayerType *player_ptr)
 {
     const auto input_str = input_string(_("設定変更コマンド: ", "Pref: "), 80);
-    if (!input_str.has_value()) {
+    if (!input_str) {
         return;
     }
 
@@ -211,7 +211,7 @@ void do_cmd_colors(PlayerType *player_ptr)
 void do_cmd_note(void)
 {
     const auto note_opt = input_string(_("メモ: ", "Note: "), 60);
-    if (!note_opt.has_value() || note_opt->empty()) {
+    if (!note_opt || note_opt->empty()) {
         return;
     }
 

--- a/src/cmd-io/cmd-floor.cpp
+++ b/src/cmd-io/cmd-floor.cpp
@@ -73,7 +73,7 @@ void do_cmd_locate(PlayerType *player_ptr)
         auto dir = 0;
         while (dir == 0) {
             const auto command = input_command(prompt, true);
-            if (!command.has_value()) {
+            if (!command) {
                 break;
             }
 

--- a/src/cmd-io/cmd-gameoption.cpp
+++ b/src/cmd-io/cmd-gameoption.cpp
@@ -573,7 +573,7 @@ void do_cmd_options(PlayerType *player_ptr)
             prt(format(_("現在ウェイト量(msec): %d", "Current Delay Factor(msec): %d"), delay_factor), 19, 0);
             constexpr auto prompt = _("コマンド: ウェイト量(msec)", "Command: Delay Factor(msec)");
             const auto new_delay_factor = input_integer(prompt, 0, 1000, delay_factor);
-            if (new_delay_factor.has_value()) {
+            if (new_delay_factor) {
                 delay_factor = new_delay_factor.value();
             }
 

--- a/src/cmd-io/cmd-lore.cpp
+++ b/src/cmd-io/cmd-lore.cpp
@@ -48,7 +48,7 @@ void do_cmd_query_symbol(PlayerType *player_ptr)
     constexpr auto prompt = _("知りたい文字を入力して下さい(記号 or ^A全,^Uユ,^N非ユ,^R乗馬,^M名前): ",
         "Enter character to be identified(^A:All,^U:Uniqs,^N:Non uniqs,^M:Name): ");
     const auto sym_opt = input_command(prompt);
-    if (!sym_opt.has_value()) {
+    if (!sym_opt) {
         return;
     }
 
@@ -77,7 +77,7 @@ void do_cmd_query_symbol(PlayerType *player_ptr)
     } else if (sym == KTRL('M')) {
         all = true;
         const auto monster_name_opt = input_string(_("名前(英語の場合小文字で可)", "Enter name:"), MAX_MONSTER_NAME);
-        if (!monster_name_opt.has_value()) {
+        if (!monster_name_opt) {
             return;
         }
 

--- a/src/cmd-io/cmd-process-screen.cpp
+++ b/src/cmd-io/cmd-process-screen.cpp
@@ -235,7 +235,7 @@ void exe_cmd_save_screen_html(const std::filesystem::path &path, bool need_messa
 static void exe_cmd_save_screen_html_with_naming()
 {
     const auto filename = input_string(_("ファイル名: ", "File name: "), 80, "screen.html");
-    if (!filename.has_value()) {
+    if (!filename) {
         return;
     }
 

--- a/src/cmd-item/cmd-item.cpp
+++ b/src/cmd-item/cmd-item.cpp
@@ -222,7 +222,7 @@ void do_cmd_inscribe(PlayerType *player_ptr)
     msg_print(nullptr);
     const auto initial_inscription = o_ptr->is_inscribed() ? o_ptr->inscription.value() : "";
     const auto input_inscription = input_string(_("銘: ", "Inscription: "), MAX_INSCRIPTION, initial_inscription);
-    if (!input_inscription.has_value()) {
+    if (!input_inscription) {
         return;
     }
 

--- a/src/cmd-item/cmd-magiceat.cpp
+++ b/src/cmd-item/cmd-magiceat.cpp
@@ -143,7 +143,7 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
     auto magic_eater_data = PlayerClass(player_ptr).get_specific_data<magic_eater_data_type>();
 
     if (auto result = check_magic_eater_spell_repeat(magic_eater_data.get());
-        result.has_value()) {
+        result) {
         return result;
     }
 
@@ -204,7 +204,7 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
     } else {
         while (true) {
             const auto new_choice = input_command(_("[A] 杖, [B] 魔法棒, [C] ロッド:", "[A] staff, [B] wand, [C] rod:"), true);
-            if (!new_choice.has_value()) {
+            if (!new_choice) {
                 return std::nullopt;
             }
 
@@ -357,7 +357,7 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
         }
 
         const auto choice_opt = input_command(prompt);
-        if (!choice_opt.has_value()) {
+        if (!choice_opt) {
             break;
         }
 
@@ -546,7 +546,7 @@ bool do_cmd_magic_eater(PlayerType *player_ptr, bool only_browse, bool powerful)
 
     auto result = select_magic_eater(player_ptr, only_browse);
     PlayerEnergy energy(player_ptr);
-    if (!result.has_value()) {
+    if (!result) {
         energy.reset_player_turn();
         return false;
     }
@@ -590,7 +590,7 @@ bool do_cmd_magic_eater(PlayerType *player_ptr, bool only_browse, bool powerful)
         switch (bi_key.tval()) {
         case ItemKindType::ROD: {
             const auto sval = bi_key.sval();
-            if (!sval.has_value()) {
+            if (!sval) {
                 return false;
             }
 
@@ -607,7 +607,7 @@ bool do_cmd_magic_eater(PlayerType *player_ptr, bool only_browse, bool powerful)
         }
         case ItemKindType::WAND: {
             const auto sval = bi_key.sval();
-            if (!sval.has_value()) {
+            if (!sval) {
                 return false;
             }
 
@@ -620,7 +620,7 @@ bool do_cmd_magic_eater(PlayerType *player_ptr, bool only_browse, bool powerful)
         }
         default:
             const auto sval = bi_key.sval();
-            if (!sval.has_value()) {
+            if (!sval) {
                 return false;
             }
 
@@ -639,7 +639,7 @@ bool do_cmd_magic_eater(PlayerType *player_ptr, bool only_browse, bool powerful)
 
     auto magic_eater_data = PlayerClass(player_ptr).get_specific_data<magic_eater_data_type>();
     const auto opt_sval = bi_key.sval();
-    if (!opt_sval.has_value()) {
+    if (!opt_sval) {
         return false;
     }
 

--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -108,7 +108,7 @@ static std::optional<int> input_status_command(PlayerType *player_ptr, int page)
     case 'f': {
         const auto initial_filename = format("%s.txt", player_ptr->base_name);
         const auto input_filename = input_string(_("ファイル名: ", "File name: "), 80, initial_filename);
-        if (!input_filename.has_value()) {
+        if (!input_filename) {
             return page;
         }
 
@@ -150,7 +150,7 @@ void do_cmd_player_status(PlayerType *player_ptr)
 
         term_putstr(2, 23, -1, TERM_WHITE, prompt);
         auto next_page = input_status_command(player_ptr, page);
-        if (!next_page.has_value()) {
+        if (!next_page) {
             break;
         }
 

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -41,7 +41,7 @@ static std::optional<T> input_new_visual_id(int i, T initial_visual_id, int max)
 {
     if (iscntrl(i)) {
         const auto new_visual_id = input_integer("Input new number", 0, max - 1, initial_visual_id);
-        if (!new_visual_id.has_value()) {
+        if (!new_visual_id) {
             return std::nullopt;
         }
 
@@ -242,7 +242,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
                 switch (c) {
                 case 'n': {
                     const auto new_monrace_id_opt = input_new_visual_id(ch, num, static_cast<short>(monraces_info.size()));
-                    if (!new_monrace_id_opt.has_value()) {
+                    if (!new_monrace_id_opt) {
                         break;
                     }
 
@@ -253,7 +253,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
                 }
                 case 'a': {
                     const auto visual_id = input_new_visual_id(ch, r_ptr->x_attr, 256);
-                    if (!visual_id.has_value()) {
+                    if (!visual_id) {
                         break;
                     }
 
@@ -263,7 +263,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
                 }
                 case 'c': {
                     const auto visual_id = input_new_visual_id(ch, r_ptr->x_char, 256);
-                    if (!visual_id.has_value()) {
+                    if (!visual_id) {
                         break;
                     }
 
@@ -323,7 +323,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
                     const auto previous_bi_id = bi_id;
                     while (true) {
                         new_baseitem_id = input_new_visual_id(ch, bi_id, static_cast<short>(baseitems_info.size()));
-                        if (!new_baseitem_id.has_value()) {
+                        if (!new_baseitem_id) {
                             bi_id = previous_bi_id;
                             break;
                         }
@@ -338,7 +338,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
                 }
                 case 'a': {
                     const auto visual_id = input_new_visual_id(ch, baseitem.x_attr, 256);
-                    if (!visual_id.has_value()) {
+                    if (!visual_id) {
                         break;
                     }
 
@@ -348,7 +348,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
                 }
                 case 'c': {
                     const auto visual_id = input_new_visual_id(ch, baseitem.x_char, 256);
-                    if (!visual_id.has_value()) {
+                    if (!visual_id) {
                         break;
                     }
 
@@ -428,7 +428,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
                 }
                 case 'a': {
                     const auto visual_id = input_new_visual_id(ch, terrain.x_attr[lighting_level], 256);
-                    if (!visual_id.has_value()) {
+                    if (!visual_id) {
                         break;
                     }
 
@@ -438,7 +438,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
                 }
                 case 'c': {
                     const auto visual_id = input_new_visual_id(ch, terrain.x_char[lighting_level], 256);
-                    if (!visual_id.has_value()) {
+                    if (!visual_id) {
                         break;
                     }
 
@@ -448,7 +448,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
                 }
                 case 'l': {
                     const auto visual_id = input_new_visual_id(ch, lighting_level, F_LIT_MAX);
-                    if (!visual_id.has_value()) {
+                    if (!visual_id) {
                         break;
                     }
 

--- a/src/core/asking-player.cpp
+++ b/src/core/asking-player.cpp
@@ -455,7 +455,7 @@ std::optional<int> input_integer(std::string_view prompt, int min, int max, int 
     auto digit = std::max(std::to_string(min).length(), std::to_string(max).length());
     while (true) {
         const auto input_str = input_string(ss.str(), digit, std::to_string(initial_value), false);
-        if (!input_str.has_value()) {
+        if (!input_str) {
             return std::nullopt;
         }
 

--- a/src/core/asking-player.h
+++ b/src/core/asking-player.h
@@ -30,7 +30,7 @@ std::optional<T> input_numerics(std::string_view prompt, int min, int max, T ini
     requires std::is_integral_v<T> || std::is_enum_v<T>
 {
     auto result = input_integer(prompt, min, max, static_cast<int>(initial_value));
-    if (!result.has_value()) {
+    if (!result) {
         return std::nullopt;
     }
 

--- a/src/core/show-file.cpp
+++ b/src/core/show-file.cpp
@@ -475,7 +475,7 @@ bool show_file(PlayerType *player_ptr, bool show_version, std::string_view name_
 
         if (skey == '|') {
             const auto xtmp = input_string(_("ファイル名: ", "File name: "), 80);
-            if (!xtmp.has_value()) {
+            if (!xtmp) {
                 continue;
             }
 

--- a/src/flavor/flavor-describer.cpp
+++ b/src/flavor/flavor-describer.cpp
@@ -46,7 +46,7 @@ static std::string describe_chest_trap(const ItemEntity &item)
     }
 
     auto trap_kind = trap_kinds.first();
-    if (!trap_kind.has_value()) {
+    if (!trap_kind) {
         return _("(施錠)", " (Locked)");
     }
 

--- a/src/flavor/flavor-util.cpp
+++ b/src/flavor/flavor-util.cpp
@@ -31,7 +31,7 @@ static std::string inscribe_flags_aux(const std::vector<flag_insc_table> &fi_vec
     std::stringstream ss;
 
     for (const auto &fi : fi_vec) {
-        if (flags.has(fi.flag) && (!fi.except_flag.has_value() || flags.has_not(fi.except_flag.value()))) {
+        if (flags.has(fi.flag) && (!fi.except_flag || flags.has_not(fi.except_flag.value()))) {
             const auto flag_str = _(is_kanji ? fi.japanese : fi.english, fi.english);
             ss << flag_str;
         }
@@ -50,7 +50,7 @@ static std::string inscribe_flags_aux(const std::vector<flag_insc_table> &fi_vec
 static bool has_flag_of(const std::vector<flag_insc_table> &fi_vec, const TrFlags &flags)
 {
     for (const auto &fi : fi_vec) {
-        if (flags.has(fi.flag) && (!fi.except_flag.has_value() || flags.has_not(fi.except_flag.value()))) {
+        if (flags.has(fi.flag) && (!fi.except_flag || flags.has_not(fi.except_flag.value()))) {
             return true;
         }
     }

--- a/src/flavor/named-item-describer.cpp
+++ b/src/flavor/named-item-describer.cpp
@@ -192,7 +192,7 @@ static std::string describe_unique_name_after_body_ja(const ItemEntity &item, co
         return "";
     }
 
-    if (auto body = describe_random_artifact_name_after_body_ja(item); body.has_value()) {
+    if (auto body = describe_random_artifact_name_after_body_ja(item); body) {
         return body.value();
     }
 

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -84,7 +84,7 @@ static void object_mention(PlayerType *player_ptr, ItemEntity *o_ptr)
 static int get_base_floor(FloorType *floor_ptr, BIT_FLAGS mode, std::optional<int> rq_mon_level)
 {
     if (any_bits(mode, AM_GREAT)) {
-        if (rq_mon_level.has_value()) {
+        if (rq_mon_level) {
             return rq_mon_level.value() + 10 + randint1(10);
         } else {
             return floor_ptr->object_level + 15;

--- a/src/floor/pattern-walk.cpp
+++ b/src/floor/pattern-walk.cpp
@@ -65,7 +65,7 @@ void pattern_teleport(PlayerType *player_ptr)
 
         constexpr auto prompt = _("テレポート先", "Teleport to level");
         const auto input_level = input_numerics(prompt, min_level, max_level, current_level);
-        if (!input_level.has_value()) {
+        if (!input_level) {
             return;
         }
 

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -240,7 +240,7 @@ static void occur_chainsword_effect(PlayerType *player_ptr)
     }
 
     const auto noise = get_random_line(_("chainswd_j.txt", "chainswd.txt"), 0);
-    if (noise.has_value()) {
+    if (noise) {
         msg_print(noise.value());
     }
 

--- a/src/io/files-util.cpp
+++ b/src/io/files-util.cpp
@@ -201,7 +201,7 @@ std::optional<std::string> get_random_line_ja_only(concptr file_name, int entry,
     std::optional<std::string> line;
     for (auto i = 0; i < count; i++) {
         line = get_random_line(file_name, entry);
-        if (!line.has_value()) {
+        if (!line) {
             return std::nullopt;
         }
 

--- a/src/io/input-key-processor.cpp
+++ b/src/io/input-key-processor.cpp
@@ -688,7 +688,7 @@ void process_command(PlayerType *player_ptr)
         if (one_in_(2)) {
             sound(SOUND_ILLEGAL);
             const auto error_mes = get_random_line(_("error_j.txt", "error.txt"), 0);
-            if (error_mes.has_value()) {
+            if (error_mes) {
                 msg_print(error_mes.value());
             }
         } else {

--- a/src/io/input-key-requester.cpp
+++ b/src/io/input-key-requester.cpp
@@ -324,7 +324,7 @@ void InputKeyRequestor::sweep_confirmation_equipments()
 
 void InputKeyRequestor::confirm_command(const std::optional<std::string> &inscription, const int caret_command)
 {
-    if (!inscription.has_value()) {
+    if (!inscription) {
         return;
     }
 

--- a/src/io/record-play-movie.cpp
+++ b/src/io/record-play-movie.cpp
@@ -345,7 +345,7 @@ void prepare_movie_hooks(PlayerType *player_ptr)
     auto initial_movie_filename = ss.str();
     constexpr auto prompt = _("ムービー記録ファイル: ", "Movie file name: ");
     const auto movie_filename = input_string(prompt, 80, initial_movie_filename.data());
-    if (!movie_filename.has_value()) {
+    if (!movie_filename) {
         return;
     }
 

--- a/src/io/report.cpp
+++ b/src/io/report.cpp
@@ -81,7 +81,7 @@ static bool post_score_to_score_server(PlayerType *player_ptr, const std::string
         term_fresh();
 
         const auto res = client.post(SCORE_POST_URL, score_data, get_score_content_type());
-        if (res.has_value() && (res->status == 200)) {
+        if (res && (res->status == 200)) {
             return true;
         }
 

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -304,7 +304,7 @@ void do_cmd_knowledge_monsters(PlayerType *player_ptr, bool *need_redraw, bool v
     byte char_left = 0;
     monster_lore_mode mode;
     const int browser_rows = hgt - 8;
-    if (!direct_r_idx.has_value()) {
+    if (!direct_r_idx) {
         mode = visual_only ? MONSTER_LORE_DEBUG : MONSTER_LORE_NORMAL;
         int len;
         for (IDX i = 0; monster_group_text[i] != nullptr; i++) {
@@ -338,7 +338,7 @@ void do_cmd_knowledge_monsters(PlayerType *player_ptr, bool *need_redraw, bool v
         if (redraw) {
             clear_from(0);
             prt(format(_("%s - モンスター", "%s - monsters"), !visual_only ? _("知識", "Knowledge") : _("表示", "Visuals")), 2, 0);
-            if (!direct_r_idx.has_value()) {
+            if (!direct_r_idx) {
                 prt(_("グループ", "Group"), 4, 0);
             }
             prt(_("名前", "Name"), 4, max + 3);
@@ -354,7 +354,7 @@ void do_cmd_knowledge_monsters(PlayerType *player_ptr, bool *need_redraw, bool v
                 term_putch(i, 5, TERM_WHITE, '=');
             }
 
-            if (!direct_r_idx.has_value()) {
+            if (!direct_r_idx) {
                 for (IDX i = 0; i < browser_rows; i++) {
                     term_putch(max + 1, 6 + i, TERM_WHITE, '|');
                 }
@@ -363,7 +363,7 @@ void do_cmd_knowledge_monsters(PlayerType *player_ptr, bool *need_redraw, bool v
             redraw = false;
         }
 
-        if (!direct_r_idx.has_value()) {
+        if (!direct_r_idx) {
             if (grp_cur < grp_top) {
                 grp_top = grp_cur;
             }
@@ -426,7 +426,7 @@ void do_cmd_knowledge_monsters(PlayerType *player_ptr, bool *need_redraw, bool v
 
         char ch = inkey();
         if (visual_mode_command(ch, &visual_list, browser_rows - 1, wid - (max + 3), &attr_top, &char_left, attr_ptr, char_ptr, need_redraw)) {
-            if (direct_r_idx.has_value()) {
+            if (direct_r_idx) {
                 switch (ch) {
                 case '\n':
                 case '\r':

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -1604,7 +1604,7 @@ static void process_menus(PlayerType *player_ptr, WORD wCmd)
             ofn.nFilterIndex = 1;
             ofn.Flags = OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR | OFN_HIDEREADONLY;
             const auto &filename = get_open_filename(&ofn, ANGBAND_DIR_SAVE, savefile, MAIN_WIN_MAX_PATH);
-            if (filename.has_value()) {
+            if (filename) {
                 savefile = filename.value();
                 validate_file(savefile);
                 game_in_progress = true;
@@ -1674,7 +1674,7 @@ static void process_menus(PlayerType *player_ptr, WORD wCmd)
             ofn.nFilterIndex = 1;
             ofn.Flags = OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR;
             const auto &filename = get_open_filename(&ofn, ANGBAND_DIR_USER, savefile, MAIN_WIN_MAX_PATH);
-            if (filename.has_value()) {
+            if (filename) {
                 savefile = filename.value();
                 prepare_browse_movie_without_path_build(savefile);
                 movie_in_progress = true;
@@ -1961,7 +1961,7 @@ static void process_menus(PlayerType *player_ptr, WORD wCmd)
         ofn.lpstrTitle = _(L"壁紙を選んでね。", L"Choose wall paper.");
         ofn.Flags = OFN_FILEMUSTEXIST | OFN_HIDEREADONLY;
         const auto &filename = get_open_filename(&ofn, "", wallpaper_path, MAIN_WIN_MAX_PATH);
-        if (filename.has_value()) {
+        if (filename) {
             wallpaper_path = filename.value();
             change_bg_mode(bg_mode::BG_ONE, true, true);
         }

--- a/src/main-win/main-win-utils.h
+++ b/src/main-win/main-win-utils.h
@@ -40,7 +40,7 @@ public:
 
     WCHAR *wc_str()
     {
-        return buf.has_value() ? (*buf).data() : NULL;
+        return buf ? (*buf).data() : NULL;
     }
 
 protected:
@@ -75,7 +75,7 @@ public:
 
     char *c_str()
     {
-        return buf.has_value() ? (*buf).data() : NULL;
+        return buf ? (*buf).data() : NULL;
     }
 
 protected:

--- a/src/market/arena.cpp
+++ b/src/market/arena.cpp
@@ -330,7 +330,7 @@ bool monster_arena_comm(PlayerType *player_ptr)
     maxbet = std::min(maxbet, player_ptr->au);
     constexpr auto prompt = _("賭け金？", "Your wager? ");
     const auto wager_opt = input_integer(prompt, 1, maxbet, 1);
-    if (!wager_opt.has_value()) {
+    if (!wager_opt) {
         screen_load();
         return false;
     }

--- a/src/market/building-monster.cpp
+++ b/src/market/building-monster.cpp
@@ -36,7 +36,7 @@ bool research_mon(PlayerType *player_ptr)
     constexpr auto prompt = _("モンスターの文字を入力して下さい(記号 or ^A全,^Uユ,^N非ユ,^M名前):",
         "Enter character to be identified(^A:All,^U:Uniqs,^N:Non uniqs,^M:Name): ");
     const auto sym_opt = input_command(prompt, false);
-    if (!sym_opt.has_value()) {
+    if (!sym_opt) {
         screen_load();
         return false;
     }
@@ -63,7 +63,7 @@ bool research_mon(PlayerType *player_ptr)
     } else if (sym == KTRL('M')) {
         all = true;
         const auto monster_name_opt = input_string(_("名前(英語の場合小文字で可)", "Enter name:"), MAX_MONSTER_NAME);
-        if (!monster_name_opt.has_value()) {
+        if (!monster_name_opt) {
             screen_load();
             return false;
         }

--- a/src/market/play-gamble.cpp
+++ b/src/market/play-gamble.cpp
@@ -40,7 +40,7 @@ void gamble_comm(PlayerType *player_ptr, int cmd)
     maxbet = std::min(maxbet, player_ptr->au);
     constexpr auto prompt = _("賭け金？", "Your wager ?");
     const auto wager_opt = input_integer(prompt, 1, maxbet, 1);
-    if (!wager_opt.has_value()) {
+    if (!wager_opt) {
         msg_print(nullptr);
         screen_load();
         return;
@@ -121,7 +121,7 @@ void gamble_comm(PlayerType *player_ptr, int cmd)
             prt("--------------------------------", 8, 3);
             while (true) {
                 const auto choice_opt = input_integer(_("何番？", "Pick a number"), 0, 9);
-                if (!choice_opt.has_value()) {
+                if (!choice_opt) {
                     continue;
                 }
 

--- a/src/mind/mind-archer.cpp
+++ b/src/mind/mind-archer.cpp
@@ -63,7 +63,7 @@ static bool select_ammo_creation_type(ammo_creation_type &type, PLAYER_LEVEL ple
 
     while (type == AMMO_NONE) {
         const auto command = input_command(prompt, true);
-        if (!command.has_value()) {
+        if (!command) {
             return false;
         }
 

--- a/src/mind/mind-blue-mage.cpp
+++ b/src/mind/mind-blue-mage.cpp
@@ -36,7 +36,7 @@ bool do_cmd_cast_learned(PlayerType *player_ptr)
     }
 
     auto selected_spell = get_learned_power(player_ptr);
-    if (!selected_spell.has_value()) {
+    if (!selected_spell) {
         return false;
     }
 

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -726,7 +726,7 @@ static bool get_element_power(PlayerType *player_ptr, SPELL_IDX *sn, bool only_b
             choice = ' ';
         } else {
             const auto new_choice = input_command(prompt, true);
-            if (!new_choice.has_value()) {
+            if (!new_choice) {
                 break;
             }
 

--- a/src/mind/mind-power-getter.cpp
+++ b/src/mind/mind-power-getter.cpp
@@ -149,7 +149,7 @@ bool MindPowerGetter::decide_mind_choice(std::string_view prompt, const bool onl
             this->choice = ' ';
         } else {
             const auto command = input_command(prompt, true);
-            if (!command.has_value()) {
+            if (!command) {
                 break;
             }
 

--- a/src/mind/mind-sniper.cpp
+++ b/src/mind/mind-sniper.cpp
@@ -296,7 +296,7 @@ static int get_snipe_power(PlayerType *player_ptr, COMMAND_CODE *sn, bool only_b
             choice = ' ';
         } else {
             const auto new_choice = input_command(prompt);
-            if (!new_choice.has_value()) {
+            if (!new_choice) {
                 break;
             }
 

--- a/src/mind/mind-weaponsmith.cpp
+++ b/src/mind/mind-weaponsmith.cpp
@@ -232,7 +232,7 @@ static COMMAND_CODE choose_essence(void)
             }
 
             const auto new_choice = input_command(_("何を付加しますか:", "Command :"), true);
-            if (!new_choice.has_value()) {
+            if (!new_choice) {
                 screen_load();
                 return 0;
             }
@@ -347,7 +347,7 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
 
             const auto page_effect_num = std::min<int>(effect_num_per_page, smith_effect_list.size() - (page * effect_num_per_page));
             const auto command = input_command(prompt);
-            if (!command.has_value()) {
+            if (!command) {
                 break;
             }
 
@@ -480,7 +480,7 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
         } else if (o_ptr->pval == 0) {
             const auto limit = std::min(5, smith.get_addable_count(effect, o_ptr));
             const auto num_enchants = input_numerics<short>(prompt, 1, limit, 1);
-            if (!num_enchants.has_value()) {
+            if (!num_enchants) {
                 return;
             }
 
@@ -491,7 +491,7 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
     } else if (effect == SmithEffectType::SLAY_GLOVE) {
         const auto max_val = player_ptr->lev / 7 + 3;
         const auto num_enchants = input_numerics(prompt, 1, max_val, 1);
-        if (!num_enchants.has_value()) {
+        if (!num_enchants) {
             return;
         }
 
@@ -631,7 +631,7 @@ void do_cmd_kaji(PlayerType *player_ptr, bool only_browse)
                     prt(_("  e) 武器/防具強化", "  e) Enchant weapon/armor"), 6, 14);
                     std::string prompt = _(format("どの能力を%sますか:", only_browse ? "調べ" : "使い"), "Command :");
                     const auto command = input_command(prompt, true);
-                    if (!command.has_value()) {
+                    if (!command) {
                         screen_load();
                         return;
                     }

--- a/src/monster-floor/monster-generator.cpp
+++ b/src/monster-floor/monster-generator.cpp
@@ -425,7 +425,7 @@ bool alloc_horde(PlayerType *player_ptr, POSITION y, POSITION x, summon_specific
     get_mon_num_prep(player_ptr, get_monster_hook(player_ptr), get_monster_hook2(player_ptr, y, x));
 
     auto r_idx = select_horde_leader_r_idx(player_ptr);
-    if (!r_idx.has_value()) {
+    if (!r_idx) {
         return false;
     }
 

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -562,7 +562,7 @@ void process_speak_sound(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION oy,
     }
 
     const auto monmessage = get_random_line(filename.data(), enum2i(monster.ap_r_idx));
-    if (monmessage.has_value()) {
+    if (monmessage) {
         msg_format(_("%s^%s", "%s^ %s"), m_name.data(), monmessage->data());
     }
 }

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -277,7 +277,7 @@ void MonsterDamageProcessor::dying_scream(std::string_view m_name)
     }
 
     const auto death_mes = get_random_line(_("mondeath_j.txt", "mondeath.txt"), enum2i(m_ptr->r_idx));
-    if (death_mes.has_value()) {
+    if (death_mes) {
         msg_format("%s^ %s", m_name.data(), death_mes->data());
     }
 

--- a/src/monster/monster-describer.cpp
+++ b/src/monster/monster-describer.cpp
@@ -137,7 +137,7 @@ static std::string get_describing_monster_name(const MonsterEntity &monster, con
     if (one_in_(2)) {
         constexpr auto filename = _("silly_j.txt", "silly.txt");
         const auto silly_name = get_random_line(filename, enum2i(monster.r_idx));
-        if (silly_name.has_value()) {
+        if (silly_name) {
             return silly_name.value();
         }
     }
@@ -191,7 +191,7 @@ static std::optional<std::string> get_fake_monster_name(const PlayerType &player
 static std::string describe_non_pet(const PlayerType &player, const MonsterEntity &monster, const std::string &name, const BIT_FLAGS mode)
 {
     const auto fake_name = get_fake_monster_name(player, monster, name, mode);
-    if (fake_name.has_value()) {
+    if (fake_name) {
         return fake_name.value();
     }
 
@@ -242,12 +242,12 @@ static std::string add_cameleon_name(const MonsterEntity &monster, const BIT_FLA
 std::string monster_desc(PlayerType *player_ptr, const MonsterEntity *m_ptr, BIT_FLAGS mode)
 {
     const auto pronoun = decide_monster_personal_pronoun(*m_ptr, mode);
-    if (pronoun.has_value()) {
+    if (pronoun) {
         return pronoun.value();
     }
 
     const auto pronoun_self = get_monster_self_pronoun(*m_ptr, mode);
-    if (pronoun_self.has_value()) {
+    if (pronoun_self) {
         return pronoun_self.value();
     }
 

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -66,7 +66,7 @@ static int get_hack_dir(PlayerType *player_ptr)
                            ? _("方向 ('5'でターゲットへ, '*'でターゲット再選択, ESCで中断)? ", "Direction ('5' for target, '*' to re-target, Escape to cancel)? ")
                            : _("方向 ('*'でターゲット選択, ESCで中断)? ", "Direction ('*' to choose a target, Escape to cancel)? ");
         const auto command_opt = input_command(p, true);
-        if (!command_opt.has_value()) {
+        if (!command_opt) {
             break;
         }
 

--- a/src/net/http-client.cpp
+++ b/src/net/http-client.cpp
@@ -14,7 +14,7 @@ namespace {
 
     void setup_http_option(libcurl::EasySession &session, const std::optional<std::string> &user_agent)
     {
-        if (user_agent.has_value()) {
+        if (user_agent) {
             session.setopt(CURLOPT_USERAGENT, user_agent->data());
         }
 

--- a/src/object-enchant/others/apply-magic-amulet.cpp
+++ b/src/object-enchant/others/apply-magic-amulet.cpp
@@ -69,7 +69,7 @@ void AmuletEnchanter::apply_magic()
 void AmuletEnchanter::sval_enchant()
 {
     const auto sval = this->o_ptr->bi_key.sval();
-    if (!sval.has_value()) {
+    if (!sval) {
         return;
     }
 
@@ -265,7 +265,7 @@ void AmuletEnchanter::give_ego_index()
 void AmuletEnchanter::give_high_ego_index()
 {
     const auto sval = this->o_ptr->bi_key.sval();
-    if (!sval.has_value()) {
+    if (!sval) {
         return;
     }
 

--- a/src/object-enchant/others/apply-magic-lite.cpp
+++ b/src/object-enchant/others/apply-magic-lite.cpp
@@ -12,7 +12,7 @@ LiteEnchanter::LiteEnchanter(PlayerType *player_ptr, ItemEntity *o_ptr, int powe
     , power(power)
 {
     const auto sval = this->o_ptr->bi_key.sval();
-    if (!sval.has_value()) {
+    if (!sval) {
         return;
     }
 
@@ -86,7 +86,7 @@ void LiteEnchanter::give_cursed()
 void LiteEnchanter::add_dark_flag()
 {
     const auto sval = this->o_ptr->bi_key.sval();
-    if (!sval.has_value()) {
+    if (!sval) {
         return;
     }
 

--- a/src/object-enchant/others/apply-magic-others.cpp
+++ b/src/object-enchant/others/apply-magic-others.cpp
@@ -152,7 +152,7 @@ void OtherItemsEnchanter::generate_corpse()
         auto &r_ref = monraces_info[r_idx];
         auto check = (floor_ptr->dun_level < r_ref.level) ? (r_ref.level - floor_ptr->dun_level) : 0;
         const auto sval = this->o_ptr->bi_key.sval();
-        if (!sval.has_value()) {
+        if (!sval) {
             continue;
         }
 

--- a/src/object-enchant/others/apply-magic-ring.cpp
+++ b/src/object-enchant/others/apply-magic-ring.cpp
@@ -68,7 +68,7 @@ void RingEnchanter::apply_magic()
 void RingEnchanter::sval_enchant()
 {
     const auto sval = this->o_ptr->bi_key.sval();
-    if (!sval.has_value()) {
+    if (!sval) {
         return;
     }
 
@@ -406,7 +406,7 @@ void RingEnchanter::give_ego_index()
 void RingEnchanter::give_high_ego_index()
 {
     const auto sval = this->o_ptr->bi_key.sval();
-    if (!sval.has_value()) {
+    if (!sval) {
         return;
     }
 

--- a/src/object-enchant/protector/apply-magic-soft-armor.cpp
+++ b/src/object-enchant/protector/apply-magic-soft-armor.cpp
@@ -48,7 +48,7 @@ void SoftArmorEnchanter::apply_magic()
 void SoftArmorEnchanter::sval_enchant()
 {
     const auto sval = this->o_ptr->bi_key.sval();
-    if (!sval.has_value()) {
+    if (!sval) {
         return;
     }
 

--- a/src/object-enchant/vorpal-weapon.cpp
+++ b/src/object-enchant/vorpal-weapon.cpp
@@ -63,7 +63,7 @@ static void print_chainsword_noise(ItemEntity *o_ptr)
     }
 
     const auto chainsword_noise = get_random_line(_("chainswd_j.txt", "chainswd.txt"), 0);
-    if (chainsword_noise.has_value()) {
+    if (chainsword_noise) {
         msg_print(chainsword_noise.value());
     }
 }

--- a/src/object/object-info.cpp
+++ b/src/object/object-info.cpp
@@ -70,7 +70,7 @@ static concptr item_activation_aux(const ItemEntity *o_ptr)
 {
     static std::string activation_detail;
     auto tmp_act_ptr = find_activation_info(o_ptr);
-    if (!tmp_act_ptr.has_value()) {
+    if (!tmp_act_ptr) {
         return _("未定義", "something undefined");
     }
 

--- a/src/object/object-kind-hook.cpp
+++ b/src/object/object-kind-hook.cpp
@@ -250,7 +250,7 @@ static short exe_lookup(const BaseitemKey &key)
 short lookup_baseitem_id(const BaseitemKey &key)
 {
     const auto sval = key.sval();
-    if (sval.has_value()) {
+    if (sval) {
         return exe_lookup(key);
     }
 

--- a/src/object/object-value-calc.cpp
+++ b/src/object/object-value-calc.cpp
@@ -529,7 +529,7 @@ PRICE flag_cost(const ItemEntity *o_ptr, int plusses)
     /* Also, give some extra for activatable powers... */
     if (o_ptr->is_random_artifact() && o_ptr->art_flags.has(TR_ACTIVATE)) {
         auto act_ptr = find_activation_info(o_ptr);
-        if (act_ptr.has_value()) {
+        if (act_ptr) {
             total += act_ptr.value()->value;
         }
     }

--- a/src/player-base/player-race.cpp
+++ b/src/player-base/player-race.cpp
@@ -45,7 +45,7 @@ TrFlags PlayerRace::tr_flags() const
         if (this->player_ptr->lev < cond.level) {
             continue;
         }
-        if (cond.pclass.has_value()) {
+        if (cond.pclass) {
             auto is_class_equal = PlayerClass(this->player_ptr).equals(cond.pclass.value());
             if (cond.not_class && is_class_equal) {
                 continue;

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -473,7 +473,7 @@ int take_hit(PlayerType *player_ptr, int damage_type, int damage, std::string_vi
                 const auto prompt = winning_seppuku ? _("辞世の句: ", "Haiku: ") : _("断末魔の叫び: ", "Last words: ");
                 while (true) {
                     const auto input_last_words = input_string(prompt, max_last_words, death_message);
-                    if (!input_last_words.has_value()) {
+                    if (!input_last_words) {
                         continue;
                     }
 

--- a/src/player/process-name.cpp
+++ b/src/player/process-name.cpp
@@ -138,7 +138,7 @@ void get_name(PlayerType *player_ptr)
     const auto copy_size = sizeof(player_ptr->name);
     constexpr auto prompt = _("キャラクターの名前を入力して下さい: ", "Enter a name for your character: ");
     const auto name = input_string(prompt, max_name_size, initial_name);
-    if (name.has_value()) {
+    if (name) {
         if (!name->empty()) {
             angband_strcpy(player_ptr->name, name.value(), copy_size);
         }

--- a/src/room/rooms-pit-nest.cpp
+++ b/src/room/rooms-pit-nest.cpp
@@ -275,7 +275,7 @@ bool build_type5(PlayerType *player_ptr, dun_data_type *dd_ptr)
         };
 
         const auto r_idx = select_r_idx();
-        if (!r_idx.has_value()) {
+        if (!r_idx) {
             return false;
         }
 

--- a/src/save/item-writer.cpp
+++ b/src/save/item-writer.cpp
@@ -216,13 +216,13 @@ static void write_item_info(ItemEntity *o_ptr, const BIT_FLAGS flags)
     }
 
     if (any_bits(flags, SaveDataItemFlagType::SMITH)) {
-        if (o_ptr->smith_effect.has_value()) {
+        if (o_ptr->smith_effect) {
             wr_s16b(enum2i(o_ptr->smith_effect.value()));
         } else {
             wr_s16b(0);
         }
 
-        if (o_ptr->smith_act_idx.has_value()) {
+        if (o_ptr->smith_act_idx) {
             wr_s16b(enum2i(o_ptr->smith_act_idx.value()));
         } else {
             wr_s16b(0);

--- a/src/smith/object-smith.cpp
+++ b/src/smith/object-smith.cpp
@@ -97,7 +97,7 @@ concptr Smith::get_essence_name(SmithEssenceType essence)
 concptr Smith::get_effect_name(SmithEffectType effect)
 {
     auto info = find_smith_info(effect);
-    if (!info.has_value()) {
+    if (!info) {
         return _("不明", "Unknown");
     }
 
@@ -113,7 +113,7 @@ concptr Smith::get_effect_name(SmithEffectType effect)
 std::string Smith::get_need_essences_desc(SmithEffectType effect)
 {
     auto info = find_smith_info(effect);
-    if (!info.has_value() || info.value()->need_essences.empty()) {
+    if (!info || info.value()->need_essences.empty()) {
         return _("不明", "Unknown");
     }
 
@@ -138,7 +138,7 @@ std::string Smith::get_need_essences_desc(SmithEffectType effect)
 std::vector<SmithEssenceType> Smith::get_need_essences(SmithEffectType effect)
 {
     auto info = find_smith_info(effect);
-    if (!info.has_value()) {
+    if (!info) {
         return {};
     }
 
@@ -157,7 +157,7 @@ std::vector<SmithEssenceType> Smith::get_need_essences(SmithEffectType effect)
 int Smith::get_essence_consumption(SmithEffectType effect, const ItemEntity *o_ptr)
 {
     auto info = find_smith_info(effect);
-    if (!info.has_value()) {
+    if (!info) {
         return 0;
     }
 
@@ -184,7 +184,7 @@ int Smith::get_essence_consumption(SmithEffectType effect, const ItemEntity *o_p
 std::unique_ptr<ItemTester> Smith::get_item_tester(SmithEffectType effect)
 {
     auto info = find_smith_info(effect);
-    if (!info.has_value()) {
+    if (!info) {
         return std::make_unique<TvalItemTester>(ItemKindType::NONE);
     }
 
@@ -203,7 +203,7 @@ std::unique_ptr<ItemTester> Smith::get_item_tester(SmithEffectType effect)
 TrFlags Smith::get_effect_tr_flags(SmithEffectType effect)
 {
     auto info = find_smith_info(effect);
-    if (!info.has_value()) {
+    if (!info) {
         return {};
     }
 
@@ -263,7 +263,7 @@ std::vector<SmithEffectType> Smith::get_effect_list(SmithCategoryType category)
 int Smith::get_addable_count(SmithEffectType effect, const ItemEntity *o_ptr) const
 {
     auto info = find_smith_info(effect);
-    if (!info.has_value()) {
+    if (!info) {
         return 0;
     }
 
@@ -437,7 +437,7 @@ Smith::DrainEssenceResult Smith::drain_essence(ItemEntity *o_ptr)
 bool Smith::add_essence(SmithEffectType effect, ItemEntity *o_ptr, int number)
 {
     auto info = find_smith_info(effect);
-    if (!info.has_value()) {
+    if (!info) {
         return false;
     }
 
@@ -459,11 +459,11 @@ void Smith::erase_essence(ItemEntity *o_ptr) const
     o_ptr->smith_act_idx = std::nullopt;
 
     auto effect = Smith::object_effect(o_ptr);
-    if (!effect.has_value()) {
+    if (!effect) {
         return;
     }
     auto info = find_smith_info(effect.value());
-    if (!info.has_value()) {
+    if (!info) {
         return;
     }
 

--- a/src/smith/smith-info.cpp
+++ b/src/smith/smith-info.cpp
@@ -55,7 +55,7 @@ bool BasicSmithInfo::can_give_smith_effect(const ItemEntity *o_ptr) const
      * 残る具体的な絞り込みは BasicSmithInfo::can_give_smith_effect_impl およびその派生クラスで
      * オーバーライドした関数にて行う
      */
-    if (o_ptr->is_fixed_or_random_artifact() || o_ptr->smith_effect.has_value()) {
+    if (o_ptr->is_fixed_or_random_artifact() || o_ptr->smith_effect) {
         return false;
     }
 
@@ -109,7 +109,7 @@ void ActivationSmithInfo::erase_essence(ItemEntity *o_ptr) const
 
 bool ActivationSmithInfo::can_give_smith_effect(const ItemEntity *o_ptr) const
 {
-    if (o_ptr->is_fixed_or_random_artifact() || o_ptr->smith_act_idx.has_value()) {
+    if (o_ptr->is_fixed_or_random_artifact() || o_ptr->smith_act_idx) {
         return false;
     }
 

--- a/src/specific-object/monster-ball.cpp
+++ b/src/specific-object/monster-ball.cpp
@@ -29,7 +29,7 @@ static void inscribe_nickname(ItemEntity &item, const CapturedMonsterType &cap_m
     }
 
     auto &insc = item.inscription;
-    if (!insc.has_value()) {
+    if (!insc) {
         insc = "";
     }
 

--- a/src/spell-kind/spells-genocide.cpp
+++ b/src/spell-kind/spells-genocide.cpp
@@ -133,7 +133,7 @@ bool symbol_genocide(PlayerType *player_ptr, int power, bool player_cast)
     char symbol;
     while (true) {
         const auto command = input_command(prompt);
-        if (command.has_value()) {
+        if (command) {
             symbol = command.value();
             break;
         }

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -535,7 +535,7 @@ bool reset_recall(PlayerType *player_ptr)
     const auto min_level = dungeons_info[select_dungeon].mindepth;
     const auto max_level = max_dlv[select_dungeon];
     const auto reset_level_opt = input_numerics(prompt, min_level, max_level, player_ptr->current_floor_ptr->dun_level);
-    if (!reset_level_opt.has_value()) {
+    if (!reset_level_opt) {
         return false;
     }
 

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -113,9 +113,8 @@ bool SpellHex::stop_spells_with_selection()
     }
 
     screen_load();
-    const auto is_selected = choice.has_value();
-    if (is_selected) {
-        auto n = this->casting_spells[A2I(choice.value())];
+    if (choice) {
+        auto n = this->casting_spells[A2I(*choice)];
         exe_spell(this->player_ptr, REALM_HEX, n, SpellProcessType::STOP);
         this->reset_casting_flag(i2enum<spell_hex_type>(n));
     }
@@ -134,7 +133,7 @@ bool SpellHex::stop_spells_with_selection()
         MainWindowRedrawingFlag::MP,
     };
     rfu.set_flags(flags_mwrf);
-    return is_selected;
+    return choice.has_value();
 }
 
 /*!
@@ -150,7 +149,7 @@ std::pair<bool, std::optional<char>> SpellHex::select_spell_stopping(std::string
     while (true) {
         this->display_casting_spells_list();
         const auto choice_opt = input_command(prompt, true);
-        if (!choice_opt.has_value()) {
+        if (!choice_opt) {
             return { false, std::nullopt };
         }
 

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -145,14 +145,14 @@ void generate_amusement(PlayerType *player_ptr, int num, bool known)
         std::optional<FixedArtifactId> opt_a_idx(std::nullopt);
         if (insta_art || fixed_art) {
             opt_a_idx = sweep_amusement_artifact(insta_art, bi_id);
-            if (!opt_a_idx.has_value()) {
+            if (!opt_a_idx) {
                 continue;
             }
         }
 
         ItemEntity item;
         item.prep(bi_id);
-        if (opt_a_idx.has_value()) {
+        if (opt_a_idx) {
             item.fixed_artifact_idx = opt_a_idx.value();
         }
 

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -98,7 +98,7 @@ void display_rumor(PlayerType *player_ptr, bool ex)
     auto opt_rumor = get_random_line("rumors.txt", section);
 #endif
     std::string rumor;
-    if (opt_rumor.has_value()) {
+    if (opt_rumor) {
         rumor = std::move(opt_rumor.value());
     } else {
         rumor = _("嘘の噂もある。", "Some rumors are wrong.");

--- a/src/store/sell-order.cpp
+++ b/src/store/sell-order.cpp
@@ -129,7 +129,7 @@ void store_sell(PlayerType *player_ptr, StoreSaleType store_num)
         return;
     }
 
-    bool placed = false;
+    auto placed = false;
     if ((store_num != StoreSaleType::HOME) && (store_num != StoreSaleType::MUSEUM)) {
         const auto item_name = describe_flavor(player_ptr, q_ptr, 0);
         msg_format(_("%s(%c)を売却する。", "Selling %s (%c)."), item_name.data(), index_to_label(i_idx));

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -171,7 +171,7 @@ std::optional<short> input_stock(std::string_view fmt, int min, int max, [[maybe
     std::optional<char> command;
     while (true) {
         const auto command_opt = input_command(prompt);
-        if (!command_opt.has_value()) {
+        if (!command_opt) {
             break;
         }
 

--- a/src/system/baseitem-info.cpp
+++ b/src/system/baseitem-info.cpp
@@ -67,7 +67,7 @@ std::optional<int> BaseitemKey::sval() const
  */
 ItemKindType BaseitemKey::get_arrow_kind() const
 {
-    if ((this->type_value != ItemKindType::BOW) || !this->subtype_value.has_value()) {
+    if ((this->type_value != ItemKindType::BOW) || !this->subtype_value) {
         THROW_EXCEPTION(std::logic_error, ITEM_NOT_BOW);
     }
 
@@ -343,7 +343,7 @@ bool BaseitemKey::is_broken_weapon() const
         return false;
     }
 
-    if (!this->subtype_value.has_value()) {
+    if (!this->subtype_value) {
         return false;
     }
 
@@ -401,7 +401,7 @@ bool BaseitemKey::is_rare() const
         { ItemKindType::DRAG_ARMOR, { /* Any */ } },
     };
 
-    if (!this->subtype_value.has_value()) {
+    if (!this->subtype_value) {
         return false;
     }
 
@@ -415,7 +415,7 @@ bool BaseitemKey::is_rare() const
 
 short BaseitemKey::get_bow_energy() const
 {
-    if ((this->type_value != ItemKindType::BOW) || !this->subtype_value.has_value()) {
+    if ((this->type_value != ItemKindType::BOW) || !this->subtype_value) {
         THROW_EXCEPTION(std::logic_error, ITEM_NOT_BOW);
     }
 
@@ -435,7 +435,7 @@ short BaseitemKey::get_bow_energy() const
 
 int BaseitemKey::get_arrow_magnification() const
 {
-    if ((this->type_value != ItemKindType::BOW) || !this->subtype_value.has_value()) {
+    if ((this->type_value != ItemKindType::BOW) || !this->subtype_value) {
         THROW_EXCEPTION(std::logic_error, ITEM_NOT_BOW);
     }
 
@@ -456,7 +456,7 @@ int BaseitemKey::get_arrow_magnification() const
 
 bool BaseitemKey::is_aiming_rod() const
 {
-    if ((this->type_value != ItemKindType::ROD) || !this->subtype_value.has_value()) {
+    if ((this->type_value != ItemKindType::ROD) || !this->subtype_value) {
         THROW_EXCEPTION(std::logic_error, ITEM_NOT_ROD);
     }
 
@@ -485,7 +485,7 @@ bool BaseitemKey::is_aiming_rod() const
 
 bool BaseitemKey::is_lite_requiring_fuel() const
 {
-    if ((this->type_value != ItemKindType::LITE) || !this->subtype_value.has_value()) {
+    if ((this->type_value != ItemKindType::LITE) || !this->subtype_value) {
         THROW_EXCEPTION(std::logic_error, ITEM_NOT_LITE);
     }
 
@@ -525,7 +525,7 @@ bool BaseitemKey::is_armour() const
 
 bool BaseitemKey::is_cross_bow() const
 {
-    if ((this->type_value != ItemKindType::BOW) || !this->subtype_value.has_value()) {
+    if ((this->type_value != ItemKindType::BOW) || !this->subtype_value) {
         return false;
     }
 
@@ -540,7 +540,7 @@ bool BaseitemKey::is_cross_bow() const
 
 bool BaseitemKey::is_mushrooms() const
 {
-    if (!this->subtype_value.has_value()) {
+    if (!this->subtype_value) {
         return false;
     }
 

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -319,7 +319,7 @@ bool ItemEntity::is_ego() const
  */
 bool ItemEntity::is_smith() const
 {
-    return Smith::object_effect(this).has_value() || Smith::object_activation(this).has_value();
+    return Smith::object_effect(this) || Smith::object_activation(this);
 }
 
 /*!
@@ -329,7 +329,7 @@ bool ItemEntity::is_smith() const
  */
 bool ItemEntity::is_fixed_or_random_artifact() const
 {
-    return this->is_fixed_artifact() || this->randart_name.has_value();
+    return this->is_fixed_artifact() || this->randart_name;
 }
 
 /*!
@@ -837,12 +837,12 @@ TrFlags ItemEntity::get_flags() const
     }
 
     flags.set(this->art_flags);
-    if (auto effect = Smith::object_effect(this); effect.has_value()) {
+    if (auto effect = Smith::object_effect(this); effect) {
         auto tr_flags = Smith::get_effect_tr_flags(effect.value());
         flags.set(tr_flags);
     }
 
-    if (Smith::object_activation(this).has_value()) {
+    if (Smith::object_activation(this)) {
         flags.set(TR_ACTIVATE);
     }
 
@@ -876,12 +876,12 @@ TrFlags ItemEntity::get_flags_known() const
         flags.set(this->art_flags);
     }
 
-    if (auto effect = Smith::object_effect(this); effect.has_value()) {
+    if (auto effect = Smith::object_effect(this); effect) {
         auto tr_flags = Smith::get_effect_tr_flags(effect.value());
         flags.set(tr_flags);
     }
 
-    if (Smith::object_activation(this).has_value()) {
+    if (Smith::object_activation(this)) {
         flags.set(TR_ACTIVATE);
     }
 

--- a/src/target/target-getter.cpp
+++ b/src/target/target-getter.cpp
@@ -57,7 +57,7 @@ bool get_aim_dir(PlayerType *player_ptr, int *dp)
         }
 
         const auto command_opt = input_command(prompt, true);
-        if (!command_opt.has_value()) {
+        if (!command_opt) {
             break;
         }
 
@@ -127,7 +127,7 @@ bool get_direction(PlayerType *player_ptr, int *dp)
     constexpr auto prompt = _("方向 (ESCで中断)? ", "Direction (Escape to cancel)? ");
     while (dir == 0) {
         const auto command = input_command(prompt, true);
-        if (!command.has_value()) {
+        if (!command) {
             return false;
         }
 
@@ -192,7 +192,7 @@ bool get_rep_dir(PlayerType *player_ptr, int *dp, bool under)
                               : _("方向 (ESCで中断)? ", "Direction (Escape to cancel)? ");
     while (dir == 0) {
         const auto command = input_command(prompt, true);
-        if (!command.has_value()) {
+        if (!command) {
             return false;
         }
 

--- a/src/term/z-rand.cpp
+++ b/src/term/z-rand.cpp
@@ -158,7 +158,7 @@ int32_t Rand_external(int32_t m)
 
     static std::optional<Xoshiro128StarStar> urbg_external;
 
-    if (!urbg_external.has_value()) {
+    if (!urbg_external) {
         /* Initialize with new seed */
         auto seed = static_cast<uint32_t>(time(nullptr));
         urbg_external = Xoshiro128StarStar(seed);

--- a/src/term/z-term.cpp
+++ b/src/term/z-term.cpp
@@ -54,10 +54,10 @@ TermOffsetSetter::TermOffsetSetter(std::optional<TERM_LEN> x, std::optional<TERM
         return;
     }
 
-    if (x.has_value()) {
+    if (x) {
         this->term->offset_x = (x.value() > 0) ? x.value() : 0;
     }
-    if (y.has_value()) {
+    if (y) {
         this->term->offset_y = (y.value() > 0) ? y.value() : 0;
     }
 }
@@ -92,8 +92,8 @@ TermCenteredOffsetSetter::TermCenteredOffsetSetter(std::optional<TERM_LEN> width
         return;
     }
 
-    const auto offset_x = width.has_value() ? (game_term->wid - width.value()) / 2 : 0;
-    const auto offset_y = height.has_value() ? (game_term->hgt - height.value()) / 2 : 0;
+    const auto offset_x = width ? (game_term->wid - width.value()) / 2 : 0;
+    const auto offset_y = height ? (game_term->hgt - height.value()) / 2 : 0;
     this->tos.emplace(offset_x, offset_y);
 
     game_term->centered_wid = (width < game_term->wid) ? width : std::nullopt;

--- a/src/test/test-sha256.cpp
+++ b/src/test/test-sha256.cpp
@@ -87,7 +87,7 @@ int main(int argc, char *argv[])
     if (argc > 1) {
         for (auto arg : std::span(argv, argc).subspan(1)) {
             auto hash = util::SHA256::compute_filehash(arg);
-            if (!hash.has_value()) {
+            if (!hash) {
                 std::cout << "cannot open file: " << arg << std::endl;
                 continue;
             }

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -244,7 +244,7 @@ static std::optional<std::string> decide_death_in_quest(PlayerType *player_ptr)
 static std::string decide_current_floor(PlayerType *player_ptr)
 {
     if (auto death_cause = search_death_cause(player_ptr);
-        death_cause.has_value() || !w_ptr->character_dungeon) {
+        death_cause || !w_ptr->character_dungeon) {
         return death_cause.value_or("");
     }
 
@@ -253,7 +253,7 @@ static std::string decide_current_floor(PlayerType *player_ptr)
         return format(_("…あなたは現在、 %s にいる。", "...Now, you are in %s."), map_name(player_ptr).data());
     }
 
-    if (auto decision = decide_death_in_quest(player_ptr); decision.has_value()) {
+    if (auto decision = decide_death_in_quest(player_ptr); decision) {
         return decision.value();
     }
 

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -379,7 +379,7 @@ void print_health(PlayerType *player_ptr, bool riding)
         term_erase(col, y, max_width);
     }
 
-    if (!monster_idx.has_value()) {
+    if (!monster_idx) {
         return;
     }
 

--- a/src/wizard/wizard-game-modifier.cpp
+++ b/src/wizard/wizard-game-modifier.cpp
@@ -108,7 +108,7 @@ void wiz_enter_quest(PlayerType *player_ptr)
     auto &quest_list = QuestList::get_instance();
     const auto quest_max = enum2i(quest_list.rbegin()->first);
     const auto quest_num = input_numerics("QuestID", 0, quest_max - 1, QuestId::NONE);
-    if (!quest_num.has_value()) {
+    if (!quest_num) {
         return;
     }
 
@@ -144,7 +144,7 @@ void wiz_restore_monster_max_num(MonsterRaceId r_idx)
 {
     if (!MonsterRace(r_idx).is_valid()) {
         const auto restore_monrace_id = input_numerics("MonsterID", 1, monraces_info.size() - 1, MonsterRaceId::FILTHY_URCHIN);
-        if (!restore_monrace_id.has_value()) {
+        if (!restore_monrace_id) {
             return;
         }
 

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -231,7 +231,7 @@ void wiz_restore_aware_flag_of_fixed_arfifact(FixedArtifactId reset_artifact_idx
     }
 
     const auto input_artifact_id = input_numerics("Artifact ID", 1, max_a_idx, FixedArtifactId::GALADRIEL_PHIAL);
-    if (!input_artifact_id.has_value()) {
+    if (!input_artifact_id) {
         return;
     }
 
@@ -256,7 +256,7 @@ void wiz_modify_item_activation(PlayerType *player_ptr)
     constexpr auto min = enum2i(RandomArtActType::NONE);
     constexpr auto max = enum2i(RandomArtActType::MAX) - 1;
     const auto act_id = input_numerics<RandomArtActType>("Activation ID", min, max);
-    if (!act_id.has_value()) {
+    if (!act_id) {
         return;
     }
 
@@ -468,7 +468,7 @@ static void wiz_statistics(PlayerType *player_ptr, ItemEntity *o_ptr)
     while (true) {
         wiz_display_item(player_ptr, o_ptr);
         const auto command = input_command(prompt);
-        if (!command.has_value()) {
+        if (!command) {
             break;
         }
 
@@ -490,7 +490,7 @@ static void wiz_statistics(PlayerType *player_ptr, ItemEntity *o_ptr)
 
         constexpr auto p = "Enter number of items to roll: ";
         const auto rolls_opt = input_numerics(p, 0, MAX_INT, rolls);
-        if (rolls_opt.has_value()) {
+        if (rolls_opt) {
             rolls = rolls_opt.value();
         }
 
@@ -570,7 +570,7 @@ static void wiz_reroll_item(PlayerType *player_ptr, ItemEntity *o_ptr)
     while (true) {
         wiz_display_item(player_ptr, q_ptr);
         const auto command = input_command(prompt);
-        if (!command.has_value()) {
+        if (!command) {
             if (q_ptr->is_fixed_artifact()) {
                 q_ptr->get_fixed_artifact().is_generated = false;
                 q_ptr->fixed_artifact_idx = FixedArtifactId::NONE;
@@ -670,28 +670,28 @@ static void wiz_tweak_item(PlayerType *player_ptr, ItemEntity *o_ptr)
     }
 
     const auto pval = input_numerics("Enter new 'pval' setting: ", -MAX_SHORT, MAX_SHORT, o_ptr->pval);
-    if (!pval.has_value()) {
+    if (!pval) {
         return;
     }
 
     o_ptr->pval = pval.value();
     wiz_display_item(player_ptr, o_ptr);
     const auto bonus_ac = input_numerics("Enter new AC Bonus setting: ", -MAX_SHORT, MAX_SHORT, o_ptr->to_a);
-    if (!bonus_ac.has_value()) {
+    if (!bonus_ac) {
         return;
     }
 
     o_ptr->to_a = bonus_ac.value();
     wiz_display_item(player_ptr, o_ptr);
     const auto bonus_hit = input_numerics("Enter new Hit Bonus setting: ", -MAX_SHORT, MAX_SHORT, o_ptr->to_h);
-    if (!bonus_hit.has_value()) {
+    if (!bonus_hit) {
         return;
     }
 
     o_ptr->to_h = bonus_hit.value();
     wiz_display_item(player_ptr, o_ptr);
     const auto bonus_damage = input_numerics("Enter new Damage Bonus setting: ", -MAX_SHORT, MAX_SHORT, o_ptr->to_d);
-    if (!bonus_damage.has_value()) {
+    if (!bonus_damage) {
         return;
     }
 
@@ -710,7 +710,7 @@ static void wiz_quantity_item(ItemEntity *o_ptr)
     }
 
     const auto quantity_opt = input_numerics("Quantity: ", 1, 99, o_ptr->number);
-    if (!quantity_opt.has_value()) {
+    if (!quantity_opt) {
         return;
     }
 
@@ -750,7 +750,7 @@ void wiz_modify_item(PlayerType *player_ptr)
     while (true) {
         wiz_display_item(player_ptr, q_ptr);
         const auto command = input_command(prompt);
-        if (!command.has_value()) {
+        if (!command) {
             changed = false;
             break;
         }
@@ -873,7 +873,7 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
     std::string pray;
     while (true) {
         const auto pray_opt = input_string(_("何をお望み？ ", "For what do you wish?"), MAX_NLEN);
-        if (pray_opt.has_value()) {
+        if (pray_opt) {
             pray = pray_opt.value();
             break;
         }

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -138,7 +138,7 @@ static std::optional<short> wiz_select_tval()
     }
 
     const auto item_type_opt = input_command(_("アイテム種別を選んで下さい", "Get what type of object? "));
-    if (!item_type_opt.has_value()) {
+    if (!item_type_opt) {
         return std::nullopt;
     }
 
@@ -181,7 +181,7 @@ static short wiz_select_sval(const ItemKindType tval, std::string_view tval_desc
     auto max_num = num;
     const auto prompt = format(_("%s群の具体的なアイテムを選んで下さい", "What Kind of %s? "), tval_description.data());
     const auto command = input_command(prompt);
-    if (!command.has_value()) {
+    if (!command) {
         return 0;
     }
 
@@ -213,7 +213,7 @@ static short wiz_create_itemtype()
 {
     term_clear();
     auto selection = wiz_select_tval();
-    if (!selection.has_value()) {
+    if (!selection) {
         return 0;
     }
 
@@ -416,7 +416,7 @@ void wiz_change_status(PlayerType *player_ptr)
         const auto max_max_ability_score = player_ptr->stat_max_max[i];
         const auto max_ability_score = player_ptr->stat_max[i];
         const auto new_ability_score = input_numerics(stat_names[i], 3, max_max_ability_score, max_ability_score);
-        if (!new_ability_score.has_value()) {
+        if (!new_ability_score) {
             return;
         }
 
@@ -428,7 +428,7 @@ void wiz_change_status(PlayerType *player_ptr)
     const auto unskilled = PlayerSkill::weapon_exp_at(PlayerSkillRank::UNSKILLED);
     const auto master = PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER);
     const auto proficiency_opt = input_numerics(_("熟練度", "Proficiency"), unskilled, master, static_cast<short>(master));
-    if (!proficiency_opt.has_value()) {
+    if (!proficiency_opt) {
         return;
     }
 
@@ -458,7 +458,7 @@ void wiz_change_status(PlayerType *player_ptr)
     }
 
     const auto gold = input_numerics("Gold: ", 0, MAX_INT, player_ptr->au);
-    if (!gold.has_value()) {
+    if (!gold) {
         return;
     }
 
@@ -468,7 +468,7 @@ void wiz_change_status(PlayerType *player_ptr)
     }
 
     const auto experience_opt = input_numerics("Experience: ", 0, MAX_INT, player_ptr->max_exp);
-    if (!experience_opt.has_value()) {
+    if (!experience_opt) {
         return;
     }
 
@@ -494,12 +494,12 @@ void wiz_create_feature(PlayerType *player_ptr)
     auto &grid = player_ptr->current_floor_ptr->get_grid(pos);
     const int max = TerrainList::get_instance().size() - 1;
     const auto f_val1 = input_numerics(_("実地形ID", "FeatureID"), 0, max, grid.feat);
-    if (!f_val1.has_value()) {
+    if (!f_val1) {
         return;
     }
 
     const auto f_val2 = input_numerics(_("偽装地形ID", "FeatureID"), 0, max, f_val1.value());
-    if (!f_val2.has_value()) {
+    if (!f_val2) {
         return;
     }
 
@@ -530,7 +530,7 @@ static std::optional<short> select_debugging_dungeon(short initial_dungeon_id)
 
     while (true) {
         const auto dungeon_id = input_numerics("Jump which dungeon", DUNGEON_ANGBAND, DUNGEON_DARKNESS, initial_dungeon_id);
-        if (!dungeon_id.has_value()) {
+        if (!dungeon_id) {
             return std::nullopt;
         }
 
@@ -597,7 +597,7 @@ void wiz_jump_to_dungeon(PlayerType *player_ptr)
     const auto is_in_dungeon = floor.is_in_dungeon();
     const auto dungeon_idx = is_in_dungeon ? floor.dungeon_idx : static_cast<short>(DUNGEON_ANGBAND);
     const auto dungeon_id_opt = select_debugging_dungeon(dungeon_idx);
-    if (!dungeon_id_opt.has_value()) {
+    if (!dungeon_id_opt) {
         if (!is_in_dungeon) {
             return;
         }
@@ -611,7 +611,7 @@ void wiz_jump_to_dungeon(PlayerType *player_ptr)
 
     const auto dungeon_id = dungeon_id_opt.value();
     const auto level_opt = select_debugging_floor(floor, dungeon_id);
-    if (!level_opt.has_value()) {
+    if (!level_opt) {
         return;
     }
 
@@ -667,7 +667,7 @@ static void change_birth_flags()
 void wiz_reset_race(PlayerType *player_ptr)
 {
     const auto new_race = input_numerics("RaceID", 0, MAX_RACES - 1, player_ptr->prace);
-    if (!new_race.has_value()) {
+    if (!new_race) {
         return;
     }
 
@@ -684,7 +684,7 @@ void wiz_reset_race(PlayerType *player_ptr)
 void wiz_reset_class(PlayerType *player_ptr)
 {
     const auto new_class_opt = input_numerics("ClassID", 0, PLAYER_CLASS_TYPE_MAX - 1, player_ptr->pclass);
-    if (!new_class_opt.has_value()) {
+    if (!new_class_opt) {
         return;
     }
 
@@ -705,12 +705,12 @@ void wiz_reset_class(PlayerType *player_ptr)
 void wiz_reset_realms(PlayerType *player_ptr)
 {
     const auto new_realm1 = input_numerics("1st Realm (None=0)", 0, MAX_REALM - 1, player_ptr->realm1);
-    if (!new_realm1.has_value()) {
+    if (!new_realm1) {
         return;
     }
 
     const auto new_realm2 = input_numerics("2nd Realm (None=0)", 0, MAX_REALM - 1, player_ptr->realm2);
-    if (!new_realm2.has_value()) {
+    if (!new_realm2) {
         return;
     }
 
@@ -772,7 +772,7 @@ void wiz_dump_options(void)
 void set_gametime(void)
 {
     const auto game_time = input_integer("Dungeon Turn", 0, w_ptr->dungeon_turn_limit - 1);
-    if (!game_time.has_value()) {
+    if (!game_time) {
         return;
     }
 

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -62,7 +62,7 @@ static const std::vector<debug_spell_command> debug_spell_commands_list = {
 void wiz_debug_spell(PlayerType *player_ptr)
 {
     const auto spell = input_string("SPELL: ", 50);
-    if (!spell.has_value()) {
+    if (!spell) {
         return;
     }
 
@@ -77,7 +77,7 @@ void wiz_debug_spell(PlayerType *player_ptr)
             return;
         case 3: {
             const auto power = input_integer("POWER", -MAX_INT, MAX_INT);
-            if (!power.has_value()) {
+            if (!power) {
                 return;
             }
 
@@ -225,7 +225,7 @@ void wiz_summon_specific_monster(PlayerType *player_ptr, MonsterRaceId r_idx)
 {
     if (!MonsterRace(r_idx).is_valid()) {
         const auto new_monrace_id = input_numerics("MonsterID", 1, monraces_info.size() - 1, MonsterRaceId::FILTHY_URCHIN);
-        if (!new_monrace_id.has_value()) {
+        if (!new_monrace_id) {
             return;
         }
 
@@ -246,7 +246,7 @@ void wiz_summon_pet(PlayerType *player_ptr, MonsterRaceId r_idx)
 {
     if (!MonsterRace(r_idx).is_valid()) {
         const auto new_monrace_id = input_numerics("MonsterID", 1, monraces_info.size() - 1, MonsterRaceId::FILTHY_URCHIN);
-        if (!new_monrace_id.has_value()) {
+        if (!new_monrace_id) {
             return;
         }
 
@@ -268,7 +268,7 @@ void wiz_kill_target(PlayerType *player_ptr, int initial_dam, AttributeType effe
     auto dam = initial_dam;
     if (dam <= 0) {
         const auto input_dam = input_integer("Damage", 1, 1000000, 1000000);
-        if (!input_dam.has_value()) {
+        if (!input_dam) {
             return;
         }
 
@@ -291,7 +291,7 @@ void wiz_kill_target(PlayerType *player_ptr, int initial_dam, AttributeType effe
         }
 
         const auto input_effect_id = input_numerics("EffectID", 1, max - 1, idx);
-        if (!input_effect_id.has_value()) {
+        if (!input_effect_id) {
             screen_load();
             return;
         }


### PR DESCRIPTION
optional はhas\_value() / value() を使う記法と使わない記法がありますが、Discord での議論により使わない方へ統一することになりました
ご確認下さい
なお、コードの都合上、値の有無を保持すべき箇所が3箇所残っていて、それらではhas\_value() を残しています