### PR TITLE
グローバル変数 error_lineをなくした

### DIFF
--- a/src/info-reader/general-parser.cpp
+++ b/src/info-reader/general-parser.cpp
@@ -29,12 +29,12 @@ dungeon_grid letter[255];
  * @param buf 読み取りに使うバッファ領域
  * @param head ヘッダ構造体
  * @param parse_info_txt_line パース関数
- * @return エラーコード
+ * @return エラーコード, エラー行番号
  */
-errr init_info_txt(FILE *fp, char *buf, angband_header *head, Parser parse_info_txt_line)
+std::tuple<errr, int> init_info_txt(FILE *fp, char *buf, angband_header *head, Parser parse_info_txt_line)
 {
     error_idx = -1;
-    error_line = 0;
+    auto error_line = 0;
 
     util::SHA256 sha256;
 
@@ -46,7 +46,7 @@ errr init_info_txt(FILE *fp, char *buf, angband_header *head, Parser parse_info_
         }
 
         if (!line.substr(1).starts_with(':')) {
-            return PARSE_ERROR_GENERIC;
+            return { PARSE_ERROR_GENERIC, error_line };
         }
 
         if (line.starts_with('V')) {
@@ -60,13 +60,13 @@ errr init_info_txt(FILE *fp, char *buf, angband_header *head, Parser parse_info_
         }
 
         if (auto err = parse_info_txt_line(line, head); err != 0) {
-            return err;
+            return { err, error_line };
         }
     }
 
     head->digest = sha256.digest();
 
-    return 0;
+    return { PARSE_ERROR_NONE, error_line };
 }
 
 /*!

--- a/src/info-reader/general-parser.h
+++ b/src/info-reader/general-parser.h
@@ -4,6 +4,7 @@
 #include "system/angband.h"
 #include <functional>
 #include <string_view>
+#include <tuple>
 
 enum class FixedArtifactId : short;
 enum parse_error_type : int;
@@ -26,6 +27,6 @@ struct angband_header;
 class FloorType;
 
 using Parser = std::function<errr(std::string_view, angband_header *)>;
-errr init_info_txt(FILE *fp, char *buf, angband_header *head, Parser parse_info_txt_line);
+std::tuple<errr, int> init_info_txt(FILE *fp, char *buf, angband_header *head, Parser parse_info_txt_line);
 parse_error_type parse_line_feature(FloorType *floor_ptr, char *buf);
 parse_error_type parse_line_building(char *buf);

--- a/src/info-reader/info-reader-util.h
+++ b/src/info-reader/info-reader-util.h
@@ -10,7 +10,6 @@
  * Size of memory reserved for initialization of some arrays
  */
 extern int error_idx; //!< エラーが発生したinfo ID
-extern int error_line; //!< エラーが発生した行
 
 enum class RandomArtActType : short;
 RandomArtActType grab_one_activation_flag(concptr what);

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -109,14 +109,14 @@ static errr init_info(std::string_view filename, angband_header &head, InfoType 
     }
 
     char buf[1024]{};
-    const auto err = init_info_txt(fp, buf, &head, parser);
+    const auto &[error_code, error_line] = init_info_txt(fp, buf, &head, parser);
     angband_fclose(fp);
-    if (err) {
-        const auto oops = (((err > 0) && (err < PARSE_ERROR_MAX)) ? err_str[err] : _("未知の", "unknown"));
+    if (error_code != PARSE_ERROR_NONE) {
+        const auto oops = (((error_code > 0) && (error_code < PARSE_ERROR_MAX)) ? err_str[error_code] : _("未知の", "unknown"));
 #ifdef JP
         msg_format("'%s'ファイルの %d 行目にエラー。", filename.data(), error_line);
 #else
-        msg_format("Error %d at line %d of '%s'.", err, error_line, filename.data());
+        msg_format("Error %d at line %d of '%s'.", error_code, error_line, filename.data());
 #endif
         msg_format(_("レコード %d は '%s' エラーがあります。", "Record %d contains a '%s' error."), error_idx, oops);
         msg_format(_("構文 '%s'。", "Parsing '%s'."), buf);


### PR DESCRIPTION
resolve #3702 

変更範囲は非常に少ないためとりあえず返り値の型を変えて他もそれに合わせた