### PR TITLE
optional::value() を*optional へ差し替えた その2

### DIFF
--- a/src/blue-magic/learnt-power-getter.cpp
+++ b/src/blue-magic/learnt-power-getter.cpp
@@ -128,7 +128,7 @@ static std::optional<BlueMagicType> select_blue_magic_kind_by_symbol()
             return std::nullopt;
         }
 
-        switch (command.value()) {
+        switch (*command) {
         case 'A':
         case 'a':
             return BlueMagicType::BOLT;
@@ -376,7 +376,7 @@ static std::optional<MonsterAbilityType> select_learnt_spells_by_symbol(PlayerTy
                 break;
             }
 
-            choice = choice_opt.value();
+            choice = *choice_opt;
         }
 
         if (first_show_list || (choice == ' ') || (choice == '*') || (choice == '?')) {
@@ -435,17 +435,16 @@ static std::optional<MonsterAbilityType> select_learnt_spells_by_menu(PlayerType
     while (!selected_spell) {
         describe_blue_magic_name(player_ptr, menu_line, bluemage_data, spells);
 
-        const auto choice_opt = input_command(prompt, true);
-        if (!choice_opt) {
+        const auto choice = input_command(prompt, true);
+        if (!choice) {
             break;
         }
 
-        const auto choice = choice_opt.value();
         if (choice == '0') {
             break;
         }
 
-        if (!switch_blue_magic_choice(choice, menu_line, bluemage_data, spells)) {
+        if (!switch_blue_magic_choice(*choice, menu_line, bluemage_data, spells)) {
             continue;
         }
 

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -45,7 +45,7 @@ static std::optional<T> input_new_visual_id(int i, T initial_visual_id, int max)
             return std::nullopt;
         }
 
-        return static_cast<T>(new_visual_id.value());
+        return static_cast<T>(*new_visual_id);
     }
 
     if (isupper(i)) {

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -511,7 +511,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX i_idx, ItemEntity *j_ptr, SP
     if (tval == ItemKindType::NONE) {
         chance = (player_ptr->skill_thb + ((weapon_exps[0] - median_skill_exp) / bow_magnification + bonus) * BTH_PLUS_ADJ);
     } else {
-        const auto sval = j_ptr->bi_key.sval().value();
+        const auto sval = *j_ptr->bi_key.sval();
         if (j_ptr->is_cross_bow()) {
             chance = (player_ptr->skill_thb + (weapon_exps[sval] / xbow_magnification + bonus) * BTH_PLUS_ADJ);
         } else {
@@ -1063,7 +1063,7 @@ int critical_shot(PlayerType *player_ptr, WEIGHT weight, int plus_ammo, int plus
     if (tval == ItemKindType::NONE) {
         power = player_ptr->skill_thb + ((weapon_exps[0] - median_skill_exp) / bow_magnification + bonus) * BTH_PLUS_ADJ;
     } else {
-        const auto sval = item.bi_key.sval().value();
+        const auto sval = *item.bi_key.sval();
         const auto weapon_exp = weapon_exps[sval];
         if (player_ptr->tval_ammo == ItemKindType::BOLT) {
             power = (player_ptr->skill_thb + (weapon_exp / xbow_magnification + bonus) * BTH_PLUS_ADJ);
@@ -1118,7 +1118,7 @@ int calc_crit_ratio_shot(PlayerType *player_ptr, int plus_ammo, int plus_bow)
     /* Extract "shot" power */
     auto i = player_ptr->to_h_b + plus_ammo;
     const auto tval = j_ptr->bi_key.tval();
-    const auto sval = j_ptr->bi_key.sval().value();
+    const auto sval = *j_ptr->bi_key.sval();
     if (player_ptr->tval_ammo == ItemKindType::BOLT) {
         i = (player_ptr->skill_thb + (player_ptr->weapon_exp[tval][sval] / 400 + i) * BTH_PLUS_ADJ);
     } else {

--- a/src/core/show-file.cpp
+++ b/src/core/show-file.cpp
@@ -481,7 +481,7 @@ bool show_file(PlayerType *player_ptr, bool show_version, std::string_view name_
 
             angband_fclose(fff);
             fff = angband_fopen(path_reopen, FileOpenMode::READ);
-            const auto &path_xtemp = path_build(ANGBAND_DIR_USER, xtmp.value());
+            const auto &path_xtemp = path_build(ANGBAND_DIR_USER, *xtmp);
             auto *ffp = angband_fopen(path_xtemp, FileOpenMode::WRITE);
 
             if (!(fff && ffp)) {

--- a/src/flavor/named-item-describer.cpp
+++ b/src/flavor/named-item-describer.cpp
@@ -286,7 +286,7 @@ static std::string describe_unique_name_after_body_en(const ItemEntity &item, co
     std::stringstream ss;
 
     if (item.is_random_artifact()) {
-        ss << ' ' << item.randart_name.value();
+        ss << ' ' << *item.randart_name;
         return ss.str();
     }
 

--- a/src/flavor/named-item-describer.cpp
+++ b/src/flavor/named-item-describer.cpp
@@ -93,7 +93,7 @@ static std::string describe_unique_name_before_body_ja(const ItemEntity &item, c
     }
 
     if (item.is_random_artifact()) {
-        const std::string_view name_sv = item.randart_name.value();
+        const std::string_view name_sv = *item.randart_name;
 
         /* '『' から始まらない伝説のアイテムの名前は最初に付加する */
         /* 英語版のセーブファイルから来た 'of XXX' は,「XXXの」と表示する */
@@ -102,7 +102,7 @@ static std::string describe_unique_name_before_body_ja(const ItemEntity &item, c
             ss << name_sv.substr(3) << "の";
             return ss.str();
         } else if (!name_sv.starts_with("『") && !name_sv.starts_with("《") && !name_sv.starts_with('\'')) {
-            return item.randart_name.value();
+            return *item.randart_name;
         }
     }
 
@@ -129,7 +129,7 @@ static std::optional<std::string> describe_random_artifact_name_after_body_ja(co
         return std::nullopt;
     }
 
-    const std::string_view name_sv = item.randart_name.value();
+    const std::string_view name_sv = *item.randart_name;
     if (name_sv.starts_with("『") || name_sv.starts_with("《")) {
         return item.randart_name;
     }

--- a/src/flavor/object-flavor.cpp
+++ b/src/flavor/object-flavor.cpp
@@ -52,8 +52,8 @@ std::string get_table_name_aux()
 {
     std::stringstream ss;
 #ifdef JP
-    ss << get_random_line("aname_j.txt", 1).value();
-    ss << get_random_line("aname_j.txt", 2).value();
+    ss << *get_random_line("aname_j.txt", 1);
+    ss << *get_random_line("aname_j.txt", 2);
     return ss.str();
 #else
     static const std::vector<std::string_view> syllables = {
@@ -75,7 +75,7 @@ std::string get_table_name_aux()
     } else {
         testcounter = randint1(2) + 1;
         while (testcounter--) {
-            ss << get_random_line("elvish.txt", 0).value();
+            ss << *get_random_line("elvish.txt", 0);
         }
     }
 
@@ -103,8 +103,8 @@ std::string get_table_name()
 std::string get_table_sindarin_aux()
 {
     std::stringstream ss;
-    ss << get_random_line("sname.txt", 1).value();
-    ss << get_random_line("sname.txt", 2).value();
+    ss << *get_random_line("sname.txt", 1);
+    ss << *get_random_line("sname.txt", 2);
     auto name = ss.str();
     return _(sindarin_to_kana(name), name);
 }

--- a/src/floor/pattern-walk.cpp
+++ b/src/floor/pattern-walk.cpp
@@ -69,7 +69,7 @@ void pattern_teleport(PlayerType *player_ptr)
             return;
         }
 
-        command_arg = input_level.value();
+        command_arg = *input_level;
     } else if (input_check(_("通常テレポート？", "Normal teleport? "))) {
         teleport_player(player_ptr, 200, TELEPORT_SPONTANEOUS);
         return;

--- a/src/io/record-play-movie.cpp
+++ b/src/io/record-play-movie.cpp
@@ -349,7 +349,7 @@ void prepare_movie_hooks(PlayerType *player_ptr)
         return;
     }
 
-    const auto &path = path_build(ANGBAND_DIR_USER, movie_filename.value());
+    const auto &path = path_build(ANGBAND_DIR_USER, *movie_filename);
     auto fd = fd_open(path, O_RDONLY);
     if (fd >= 0) {
         const auto &filename = path.string();

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -1605,7 +1605,7 @@ static void process_menus(PlayerType *player_ptr, WORD wCmd)
             ofn.Flags = OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR | OFN_HIDEREADONLY;
             const auto &filename = get_open_filename(&ofn, ANGBAND_DIR_SAVE, savefile, MAIN_WIN_MAX_PATH);
             if (filename) {
-                savefile = filename.value();
+                savefile = *filename;
                 validate_file(savefile);
                 game_in_progress = true;
             }
@@ -1675,7 +1675,7 @@ static void process_menus(PlayerType *player_ptr, WORD wCmd)
             ofn.Flags = OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR;
             const auto &filename = get_open_filename(&ofn, ANGBAND_DIR_USER, savefile, MAIN_WIN_MAX_PATH);
             if (filename) {
-                savefile = filename.value();
+                savefile = *filename;
                 prepare_browse_movie_without_path_build(savefile);
                 movie_in_progress = true;
             }
@@ -1962,7 +1962,7 @@ static void process_menus(PlayerType *player_ptr, WORD wCmd)
         ofn.Flags = OFN_FILEMUSTEXIST | OFN_HIDEREADONLY;
         const auto &filename = get_open_filename(&ofn, "", wallpaper_path, MAIN_WIN_MAX_PATH);
         if (filename) {
-            wallpaper_path = filename.value();
+            wallpaper_path = *filename;
             change_bg_mode(bg_mode::BG_ONE, true, true);
         }
         break;

--- a/src/market/play-gamble.cpp
+++ b/src/market/play-gamble.cpp
@@ -39,14 +39,13 @@ void gamble_comm(PlayerType *player_ptr, int cmd)
     auto maxbet = player_ptr->lev * 200;
     maxbet = std::min(maxbet, player_ptr->au);
     constexpr auto prompt = _("賭け金？", "Your wager ?");
-    const auto wager_opt = input_integer(prompt, 1, maxbet, 1);
-    if (!wager_opt) {
+    const auto wager = input_integer(prompt, 1, maxbet, 1);
+    if (!wager) {
         msg_print(nullptr);
         screen_load();
         return;
     }
 
-    auto wager = wager_opt.value();
     if (wager > player_ptr->au) {
         msg_print(_("おい！金が足りないじゃないか！出ていけ！", "Hey! You don't have the gold - get out of here!"));
         msg_print(nullptr);
@@ -59,9 +58,9 @@ void gamble_comm(PlayerType *player_ptr, int cmd)
     auto odds = 0;
     auto oldgold = player_ptr->au;
     prt(format(_("ゲーム前の所持金: %9d", "Gold before game: %9d"), oldgold), 20, 2);
-    prt(format(_("現在の掛け金:     %9d", "Current Wager:    %9d"), wager), 21, 2);
+    prt(format(_("現在の掛け金:     %9d", "Current Wager:    %9d"), *wager), 21, 2);
     while (true) {
-        player_ptr->au -= wager;
+        player_ptr->au -= *wager;
         switch (cmd) {
         case BACT_IN_BETWEEN: {
             c_put_str(TERM_GREEN, _("イン・ビトイーン", "In Between"), 5, 2);
@@ -120,12 +119,11 @@ void gamble_comm(PlayerType *player_ptr, int cmd)
             prt("0  1  2  3  4  5  6  7  8  9", 7, 5);
             prt("--------------------------------", 8, 3);
             while (true) {
-                const auto choice_opt = input_integer(_("何番？", "Pick a number"), 0, 9);
-                if (!choice_opt) {
+                const auto choice = input_integer(_("何番？", "Pick a number"), 0, 9);
+                if (!choice) {
                     continue;
                 }
 
-                auto choice = choice_opt.value();
                 msg_print(nullptr);
                 auto roll1 = randint0(10);
                 prt(format(_("ルーレットは回り、止まった。勝者は %d番だ。", "The wheel spins to a stop and the winner is %d"), roll1), 13, 3);
@@ -228,7 +226,7 @@ void gamble_comm(PlayerType *player_ptr, int cmd)
 
         if (win) {
             prt(_("あなたの勝ち", "YOU WON"), 16, 37);
-            player_ptr->au += odds * wager;
+            player_ptr->au += odds * *wager;
             prt(format(_("倍率: %d", "Payoff: %d"), odds), 17, 37);
         } else {
             prt(_("あなたの負け", "You Lost"), 16, 37);

--- a/src/mind/mind-archer.cpp
+++ b/src/mind/mind-archer.cpp
@@ -62,12 +62,11 @@ static bool select_ammo_creation_type(ammo_creation_type &type, PLAYER_LEVEL ple
     }
 
     while (type == AMMO_NONE) {
-        const auto command = input_command(prompt, true);
-        if (!command) {
+        const auto ch = input_command(prompt, true);
+        if (!ch) {
             return false;
         }
 
-        const auto ch = command.value();
         if (ch == 'S' || ch == 's') {
             type = AMMO_SHOT;
             break;

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -730,7 +730,7 @@ static bool get_element_power(PlayerType *player_ptr, SPELL_IDX *sn, bool only_b
                 break;
             }
 
-            choice = new_choice.value();
+            choice = *new_choice;
         }
 
         auto should_redraw_cursor = true;

--- a/src/mind/mind-power-getter.cpp
+++ b/src/mind/mind-power-getter.cpp
@@ -153,7 +153,7 @@ bool MindPowerGetter::decide_mind_choice(std::string_view prompt, const bool onl
                 break;
             }
 
-            this->choice = command.value();
+            this->choice = *command;
         }
 
         if (!interpret_mind_key_input(only_browse)) {

--- a/src/mind/mind-sniper.cpp
+++ b/src/mind/mind-sniper.cpp
@@ -300,7 +300,7 @@ static int get_snipe_power(PlayerType *player_ptr, COMMAND_CODE *sn, bool only_b
                 break;
             }
 
-            choice = new_choice.value();
+            choice = *new_choice;
         }
 
         /* Request redraw */

--- a/src/mind/mind-weaponsmith.cpp
+++ b/src/mind/mind-weaponsmith.cpp
@@ -237,7 +237,7 @@ static COMMAND_CODE choose_essence(void)
                 return 0;
             }
 
-            choice = new_choice.value();
+            choice = *new_choice;
             if (isupper(choice)) {
                 choice = (char)tolower(choice);
             }
@@ -346,15 +346,14 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
             display_smith_effect_list(smith, smith_effect_list, menu_line, page * effect_num_per_page, effect_num_per_page);
 
             const auto page_effect_num = std::min<int>(effect_num_per_page, smith_effect_list.size() - (page * effect_num_per_page));
-            const auto command = input_command(prompt);
-            if (!command) {
+            const auto choice = input_command(prompt);
+            if (!choice) {
                 break;
             }
 
-            const auto choice = command.value();
             auto should_redraw_cursor = true;
             if (use_menu) {
-                switch (choice) {
+                switch (*choice) {
                 case '0': {
                     screen_load();
                     return;
@@ -419,7 +418,7 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
             }
 
             if (!use_menu) {
-                i = A2I(choice);
+                i = A2I(*choice);
             }
 
             effect_idx = page * effect_num_per_page + i;
@@ -484,7 +483,7 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
                 return;
             }
 
-            o_ptr->pval = num_enchants.value();
+            o_ptr->pval = *num_enchants;
         }
 
         add_essence_count = o_ptr->pval;
@@ -495,7 +494,7 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
             return;
         }
 
-        add_essence_count = num_enchants.value();
+        add_essence_count = *num_enchants;
     }
 
     msg_format(_("エッセンスを%d個使用します。", "It will take %d essences."), use_essence * add_essence_count);
@@ -630,14 +629,13 @@ void do_cmd_kaji(PlayerType *player_ptr, bool only_browse)
                     prt(_("  d) エッセンス付加", "  d) Add essence"), 5, 14);
                     prt(_("  e) 武器/防具強化", "  e) Enchant weapon/armor"), 6, 14);
                     std::string prompt = _(format("どの能力を%sますか:", only_browse ? "調べ" : "使い"), "Command :");
-                    const auto command = input_command(prompt, true);
-                    if (!command) {
+                    const auto choice = input_command(prompt, true);
+                    if (!choice) {
                         screen_load();
                         return;
                     }
 
-                    const auto choice = command.value();
-                    switch (choice) {
+                    switch (*choice) {
                     case 'A':
                     case 'a':
                         mode = 1;

--- a/src/monster-floor/monster-generator.cpp
+++ b/src/monster-floor/monster-generator.cpp
@@ -455,7 +455,7 @@ bool alloc_horde(PlayerType *player_ptr, POSITION y, POSITION x, summon_specific
         return true;
     }
 
-    auto *r_ptr = &monraces_info[r_idx.value()];
+    auto *r_ptr = &monraces_info[*r_idx];
     if (floor_ptr->m_list[m_idx].mflag2.has(MonsterConstantFlagType::CHAMELEON)) {
         r_ptr = &monraces_info[floor_ptr->m_list[m_idx].r_idx];
     }

--- a/src/monster/monster-describer.cpp
+++ b/src/monster/monster-describer.cpp
@@ -138,7 +138,7 @@ static std::string get_describing_monster_name(const MonsterEntity &monster, con
         constexpr auto filename = _("silly_j.txt", "silly.txt");
         const auto silly_name = get_random_line(filename, enum2i(monster.r_idx));
         if (silly_name) {
-            return silly_name.value();
+            return *silly_name;
         }
     }
 
@@ -192,7 +192,7 @@ static std::string describe_non_pet(const PlayerType &player, const MonsterEntit
 {
     const auto fake_name = get_fake_monster_name(player, monster, name, mode);
     if (fake_name) {
-        return fake_name.value();
+        return *fake_name;
     }
 
     if (any_bits(mode, MD_INDEF_VISIBLE)) {
@@ -243,12 +243,12 @@ std::string monster_desc(PlayerType *player_ptr, const MonsterEntity *m_ptr, BIT
 {
     const auto pronoun = decide_monster_personal_pronoun(*m_ptr, mode);
     if (pronoun) {
-        return pronoun.value();
+        return *pronoun;
     }
 
     const auto pronoun_self = get_monster_self_pronoun(*m_ptr, mode);
     if (pronoun_self) {
-        return pronoun_self.value();
+        return *pronoun_self;
     }
 
     const auto is_hallucinated = player_ptr->effects()->hallucination()->is_hallucinated();

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -70,7 +70,7 @@ static int get_hack_dir(PlayerType *player_ptr)
             break;
         }
 
-        auto command = command_opt.value();
+        auto command = *command_opt;
         if (use_menu && (command == '\r')) {
             command = 't';
         }

--- a/src/object-enchant/vorpal-weapon.cpp
+++ b/src/object-enchant/vorpal-weapon.cpp
@@ -64,7 +64,7 @@ static void print_chainsword_noise(ItemEntity *o_ptr)
 
     const auto chainsword_noise = get_random_line(_("chainswd_j.txt", "chainswd.txt"), 0);
     if (chainsword_noise) {
-        msg_print(chainsword_noise.value());
+        msg_print(*chainsword_noise);
     }
 }
 

--- a/src/object-use/quaff/quaff-effects.cpp
+++ b/src/object-use/quaff/quaff-effects.cpp
@@ -48,13 +48,13 @@ QuaffEffects::QuaffEffects(PlayerType *player_ptr)
 {
 }
 
-bool QuaffEffects::influence(const ItemEntity &o_ref)
+bool QuaffEffects::influence(const ItemEntity &item)
 {
-    if (o_ref.bi_key.tval() != ItemKindType::POTION) {
+    if (item.bi_key.tval() != ItemKindType::POTION) {
         return false;
     }
 
-    switch (o_ref.bi_key.sval().value()) {
+    switch (*item.bi_key.sval()) {
     case SV_POTION_WATER:
         msg_print(_("口の中がさっぱりした。", "That was refreshing."));
         msg_print(_("のどの渇きが少しおさまった。", "You feel less thirsty."));

--- a/src/object-use/quaff/quaff-effects.h
+++ b/src/object-use/quaff/quaff-effects.h
@@ -6,7 +6,7 @@ class QuaffEffects {
 public:
     QuaffEffects(PlayerType *player_ptr);
 
-    bool influence(const ItemEntity &o_ref);
+    bool influence(const ItemEntity &item);
 
 private:
     PlayerType *player_ptr;

--- a/src/object-use/read/parchment-read-executor.cpp
+++ b/src/object-use/read/parchment-read-executor.cpp
@@ -32,7 +32,7 @@ bool ParchmentReadExecutor::read()
 {
     screen_save();
     std::stringstream ss;
-    ss << "book-" << std::setfill('0') << std::right << std::setw(3) << this->o_ptr->bi_key.sval().value();
+    ss << "book-" << std::setfill('0') << std::right << std::setw(3) << *this->o_ptr->bi_key.sval();
     ss << "_" << _("jp", "en") << ".txt";
     const auto item_name = describe_flavor(this->player_ptr, this->o_ptr, OD_NAME_ONLY);
     auto path = path_build(ANGBAND_DIR_FILE, "books");

--- a/src/object-use/read/scroll-read-executor.cpp
+++ b/src/object-use/read/scroll-read-executor.cpp
@@ -59,7 +59,7 @@ bool ScrollReadExecutor::read()
 {
     auto used_up = true;
     auto *floor_ptr = this->player_ptr->current_floor_ptr;
-    switch (this->o_ptr->bi_key.sval().value()) {
+    switch (*this->o_ptr->bi_key.sval()) {
     case SV_SCROLL_DARKNESS:
         if (!has_resist_blind(this->player_ptr) && !has_resist_dark(this->player_ptr)) {
             (void)BadStatusSetter(this->player_ptr).mod_blindness(3 + randint1(5));

--- a/src/object-use/use-execution.cpp
+++ b/src/object-use/use-execution.cpp
@@ -102,7 +102,7 @@ void ObjectUseEntity::execute()
     }
 
     sound(SOUND_ZAP);
-    auto ident = staff_effect(this->player_ptr, o_ptr->bi_key.sval().value(), &use_charge, false, false, o_ptr->is_aware());
+    auto ident = staff_effect(this->player_ptr, *o_ptr->bi_key.sval(), &use_charge, false, false, o_ptr->is_aware());
     if (!(o_ptr->is_aware())) {
         chg_virtue(this->player_ptr, Virtue::PATIENCE, -1);
         chg_virtue(this->player_ptr, Virtue::CHANCE, 1);

--- a/src/object-use/zaprod-execution.cpp
+++ b/src/object-use/zaprod-execution.cpp
@@ -122,7 +122,7 @@ void ObjectZapRodEntity::execute(INVENTORY_IDX i_idx)
     }
 
     sound(SOUND_ZAP);
-    auto ident = rod_effect(this->player_ptr, o_ptr->bi_key.sval().value(), dir, &use_charge, false);
+    auto ident = rod_effect(this->player_ptr, *o_ptr->bi_key.sval(), dir, &use_charge, false);
     if (use_charge) {
         o_ptr->timeout += baseitem.pval;
     }

--- a/src/object-use/zapwand-execution.cpp
+++ b/src/object-use/zapwand-execution.cpp
@@ -106,7 +106,7 @@ void ObjectZapWandEntity::execute(INVENTORY_IDX i_idx)
     }
 
     sound(SOUND_ZAP);
-    auto ident = wand_effect(this->player_ptr, sval.value(), dir, false, false);
+    auto ident = wand_effect(this->player_ptr, *sval, dir, false, false);
     using Srf = StatusRecalculatingFlag;
     EnumClassFlagGroup<Srf> flags_srf = { Srf::COMBINATION, Srf::REORDER };
     if (rfu.has(Srf::AUTO_DESTRUCTION)) {
@@ -114,7 +114,7 @@ void ObjectZapWandEntity::execute(INVENTORY_IDX i_idx)
     }
 
     rfu.reset_flags(flags_srf);
-    if (!(o_ptr->is_aware())) {
+    if (!o_ptr->is_aware()) {
         chg_virtue(this->player_ptr, Virtue::PATIENCE, -1);
         chg_virtue(this->player_ptr, Virtue::CHANCE, 1);
         chg_virtue(this->player_ptr, Virtue::KNOWLEDGE, -1);

--- a/src/object/object-broken.cpp
+++ b/src/object/object-broken.cpp
@@ -208,7 +208,7 @@ bool potion_smash_effect(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, PO
     int dam = 0;
     bool angry = false;
     const auto &baseitem = baseitems_info[bi_id];
-    switch (baseitem.bi_key.sval().value()) {
+    switch (*baseitem.bi_key.sval()) {
     case SV_POTION_SALT_WATER:
     case SV_POTION_SLIME_MOLD:
     case SV_POTION_LOSE_MEMORIES:

--- a/src/object/object-kind-hook.cpp
+++ b/src/object/object-kind-hook.cpp
@@ -197,7 +197,7 @@ static const std::map<ItemKindType, std::vector<int>> &create_baseitems_cache()
             continue;
         }
 
-        cache[tval].push_back(bi_key.sval().value());
+        cache[tval].push_back(*bi_key.sval());
     }
 
     return cache;

--- a/src/player-base/player-race.cpp
+++ b/src/player-base/player-race.cpp
@@ -46,7 +46,7 @@ TrFlags PlayerRace::tr_flags() const
             continue;
         }
         if (cond.pclass) {
-            auto is_class_equal = PlayerClass(this->player_ptr).equals(cond.pclass.value());
+            auto is_class_equal = PlayerClass(this->player_ptr).equals(*cond.pclass);
             if (cond.not_class && is_class_equal) {
                 continue;
             }

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -1760,7 +1760,7 @@ bool has_not_ninja_weapon(PlayerType *player_ptr, int i)
 
     const auto &item = player_ptr->inventory_list[INVEN_MAIN_HAND + i];
     const auto tval = item.bi_key.tval();
-    const auto sval = item.bi_key.sval().value();
+    const auto sval = *item.bi_key.sval();
     return PlayerClass(player_ptr).equals(PlayerClassType::NINJA) &&
            !((player_ptr->weapon_exp_max[tval][sval] > PlayerSkill::weapon_exp_at(PlayerSkillRank::BEGINNER)) &&
                (player_ptr->inventory_list[INVEN_SUB_HAND - i].bi_key.tval() != ItemKindType::SHIELD));
@@ -1774,7 +1774,7 @@ bool has_not_monk_weapon(PlayerType *player_ptr, int i)
 
     const auto &item = player_ptr->inventory_list[INVEN_MAIN_HAND + i];
     const auto tval = item.bi_key.tval();
-    const auto sval = item.bi_key.sval().value();
+    const auto sval = *item.bi_key.sval();
     PlayerClass pc(player_ptr);
     return pc.is_martial_arts_pro() && (player_ptr->weapon_exp_max[tval][sval] == PlayerSkill::weapon_exp_at(PlayerSkillRank::UNSKILLED));
 }

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -2334,7 +2334,7 @@ static short calc_to_hit(PlayerType *player_ptr, INVENTORY_IDX slot, bool is_rea
 
         /* Traind bonuses */
         const auto tval = o_ptr->bi_key.tval();
-        const auto sval = o_ptr->bi_key.sval().value();
+        const auto sval = *o_ptr->bi_key.sval();
         hit += (player_ptr->weapon_exp[tval][sval] - PlayerSkill::weapon_exp_at(PlayerSkillRank::BEGINNER)) / 200;
 
         /* Weight penalty */

--- a/src/player/process-name.cpp
+++ b/src/player/process-name.cpp
@@ -140,7 +140,7 @@ void get_name(PlayerType *player_ptr)
     const auto name = input_string(prompt, max_name_size, initial_name);
     if (name) {
         if (!name->empty()) {
-            angband_strcpy(player_ptr->name, name.value(), copy_size);
+            angband_strcpy(player_ptr->name, *name, copy_size);
         }
 
         return;

--- a/src/room/rooms-pit-nest.cpp
+++ b/src/room/rooms-pit-nest.cpp
@@ -279,7 +279,7 @@ bool build_type5(PlayerType *player_ptr, dun_data_type *dd_ptr)
             return false;
         }
 
-        const auto *r_ptr = &monraces_info[r_idx.value()];
+        const auto *r_ptr = &monraces_info[*r_idx];
 
         /* Note the alignment */
         if (r_ptr->kind_flags.has(MonsterKindType::EVIL)) {
@@ -289,7 +289,7 @@ bool build_type5(PlayerType *player_ptr, dun_data_type *dd_ptr)
             align.sub_align |= SUB_ALIGN_GOOD;
         }
 
-        nest_mon_info[i].r_idx = r_idx.value();
+        nest_mon_info[i].r_idx = *r_idx;
         nest_mon_info[i].used = false;
     }
 

--- a/src/spell-kind/spells-genocide.cpp
+++ b/src/spell-kind/spells-genocide.cpp
@@ -134,7 +134,7 @@ bool symbol_genocide(PlayerType *player_ptr, int power, bool player_cast)
     while (true) {
         const auto command = input_command(prompt);
         if (command) {
-            symbol = command.value();
+            symbol = *command;
             break;
         }
     }

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -534,21 +534,20 @@ bool reset_recall(PlayerType *player_ptr)
     constexpr auto prompt = _("何階にセットしますか？", "Reset to which level?");
     const auto min_level = dungeons_info[select_dungeon].mindepth;
     const auto max_level = max_dlv[select_dungeon];
-    const auto reset_level_opt = input_numerics(prompt, min_level, max_level, player_ptr->current_floor_ptr->dun_level);
-    if (!reset_level_opt) {
+    const auto reset_level = input_numerics(prompt, min_level, max_level, player_ptr->current_floor_ptr->dun_level);
+    if (!reset_level) {
         return false;
     }
 
-    const auto reset_level = reset_level_opt.value();
-    max_dlv[select_dungeon] = reset_level;
+    max_dlv[select_dungeon] = *reset_level;
     if (record_maxdepth) {
         constexpr auto note = _("フロア・リセットで", "using a scroll of reset recall");
         exe_write_diary(player_ptr, DiaryKind::TRUMP, select_dungeon, note);
     }
 #ifdef JP
-    msg_format("%sの帰還レベルを %d 階にセット。", dungeons_info[select_dungeon].name.data(), reset_level);
+    msg_format("%sの帰還レベルを %d 階にセット。", dungeons_info[select_dungeon].name.data(), *reset_level);
 #else
-    msg_format("Recall depth set to level %d (%d').", reset_level, reset_level * 50);
+    msg_format("Recall depth set to level %d (%d').", *reset_level, *reset_level * 50);
 #endif
     return true;
 }

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -153,7 +153,7 @@ std::pair<bool, std::optional<char>> SpellHex::select_spell_stopping(std::string
             return { false, std::nullopt };
         }
 
-        auto choice = choice_opt.value();
+        auto choice = *choice_opt;
         if (isupper(choice)) {
             choice = static_cast<char>(tolower(choice));
         }

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -170,17 +170,16 @@ std::optional<short> input_stock(std::string_view fmt, int min, int max, [[maybe
 
     std::optional<char> command;
     while (true) {
-        const auto command_opt = input_command(prompt);
-        if (!command_opt) {
+        const auto command_alpha = input_command(prompt);
+        if (!command_alpha) {
             break;
         }
 
-        const auto command_alpha = command_opt.value();
         std::optional<int> command_num;
-        if (islower(command_alpha)) {
-            command_num = A2I(command_alpha);
-        } else if (isupper(command_alpha)) {
-            command_num = A2I(tolower(command_alpha)) + 26;
+        if (islower(*command_alpha)) {
+            command_num = A2I(*command_alpha);
+        } else if (isupper(*command_alpha)) {
+            command_num = A2I(tolower(*command_alpha)) + 26;
         }
 
         if (command_num && (*command_num >= min) && (*command_num <= max)) {

--- a/src/target/target-getter.cpp
+++ b/src/target/target-getter.cpp
@@ -61,7 +61,7 @@ bool get_aim_dir(PlayerType *player_ptr, int *dp)
             break;
         }
 
-        auto command = command_opt.value();
+        auto command = *command_opt;
         if (use_menu && (command == '\r')) {
             command = 't';
         }
@@ -131,8 +131,7 @@ bool get_direction(PlayerType *player_ptr, int *dp)
             return false;
         }
 
-        const auto ch = command.value();
-        dir = get_keymap_dir(ch);
+        dir = get_keymap_dir(*command);
         if (dir == 0) {
             bell();
         }
@@ -196,13 +195,12 @@ bool get_rep_dir(PlayerType *player_ptr, int *dp, bool under)
             return false;
         }
 
-        const auto ch = command.value();
-        if (under && ((ch == '5') || (ch == '-') || (ch == '.'))) {
+        if (under && ((command == '5') || (command == '-') || (command == '.'))) {
             dir = 5;
             break;
         }
 
-        dir = get_keymap_dir(ch);
+        dir = get_keymap_dir(*command);
         if (dir == 0) {
             bell();
         }

--- a/src/test/test-sha256.cpp
+++ b/src/test/test-sha256.cpp
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
                 continue;
             }
 
-            std::cout << util::to_string(hash.value()) << "  " << arg << std::endl;
+            std::cout << util::to_string(*hash) << "  " << arg << std::endl;
         }
         return 0;
     }

--- a/src/util/sort.cpp
+++ b/src/util/sort.cpp
@@ -292,8 +292,8 @@ bool ang_sort_art_comp(PlayerType *player_ptr, vptr u, vptr v, int a, int b)
     /* Sort by monster level */
     if (*why >= 2) {
         /* Extract levels */
-        z1 = artifact_w1.bi_key.sval().value();
-        z2 = artifact_w2.bi_key.sval().value();
+        z1 = *artifact_w1.bi_key.sval();
+        z2 = *artifact_w2.bi_key.sval();
 
         /* Compare levels */
         if (z1 < z2) {

--- a/src/view/object-describer.cpp
+++ b/src/view/object-describer.cpp
@@ -78,7 +78,7 @@ void display_koff(PlayerType *player_ptr)
     item.prep(player_ptr->tracking_bi_id);
     const auto item_name = describe_flavor(player_ptr, &item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
     term_putstr(0, 0, -1, TERM_WHITE, item_name);
-    const auto sval = item.bi_key.sval().value();
+    const auto sval = *item.bi_key.sval();
     const short use_realm = tval2realm(item.bi_key.tval());
 
     if (player_ptr->realm1 || player_ptr->realm2) {

--- a/src/wizard/wizard-game-modifier.cpp
+++ b/src/wizard/wizard-game-modifier.cpp
@@ -112,7 +112,7 @@ void wiz_enter_quest(PlayerType *player_ptr)
         return;
     }
 
-    auto q_idx = quest_num.value();
+    auto q_idx = *quest_num;
     init_flags = i2enum<init_flags_type>(INIT_SHOW_TEXT | INIT_ASSIGN);
     player_ptr->current_floor_ptr->quest_number = q_idx;
     parse_fixed_map(player_ptr, QUEST_DEFINITION_LIST, 0, 0, 0, 0);
@@ -148,7 +148,7 @@ void wiz_restore_monster_max_num(MonsterRaceId r_idx)
             return;
         }
 
-        r_idx = restore_monrace_id.value();
+        r_idx = *restore_monrace_id;
     }
 
     auto *r_ptr = &monraces_info[r_idx];

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -401,7 +401,7 @@ static void wiz_display_item(PlayerType *player_ptr, ItemEntity *o_ptr)
     auto line = 4;
     const auto &bi_key = o_ptr->bi_key;
     const auto item_level = o_ptr->get_baseitem().level;
-    prt(format("kind = %-5d  level = %-4d  tval = %-5d  sval = %-5d", o_ptr->bi_id, item_level, enum2i(bi_key.tval()), bi_key.sval().value()), line, j);
+    prt(format("kind = %-5d  level = %-4d  tval = %-5d  sval = %-5d", o_ptr->bi_id, item_level, enum2i(bi_key.tval()), *bi_key.sval()), line, j);
     prt(format("number = %-3d  wgt = %-6d  ac = %-5d    damage = %dd%d", o_ptr->number, o_ptr->weight, o_ptr->ac, o_ptr->dd, o_ptr->ds), ++line, j);
     prt(format("pval = %-5d  toac = %-5d  tohit = %-4d  todam = %-4d", o_ptr->pval, o_ptr->to_a, o_ptr->to_h, o_ptr->to_d), ++line, j);
     prt(format("fixed_artifact_idx = %-4d  ego_idx = %-4d  cost = %d", enum2i(o_ptr->fixed_artifact_idx), enum2i(o_ptr->ego_idx), object_value_real(o_ptr)), ++line, j);

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -235,7 +235,7 @@ void wiz_restore_aware_flag_of_fixed_arfifact(FixedArtifactId reset_artifact_idx
         return;
     }
 
-    artifacts.get_artifact(input_artifact_id.value()).is_generated = aware;
+    artifacts.get_artifact(*input_artifact_id).is_generated = aware;
     msg_print(message);
 }
 
@@ -260,7 +260,7 @@ void wiz_modify_item_activation(PlayerType *player_ptr)
         return;
     }
 
-    auto act_idx = act_id.value();
+    auto act_idx = *act_id;
     o_ptr->art_flags.set(TR_ACTIVATE);
     o_ptr->activation_id = act_idx;
 }
@@ -472,16 +472,15 @@ static void wiz_statistics(PlayerType *player_ptr, ItemEntity *o_ptr)
             break;
         }
 
-        const auto ch = command.value();
         BIT_FLAGS mode;
         std::string quality;
-        if (ch == 'n' || ch == 'N') {
+        if (command == 'n' || command == 'N') {
             mode = 0L;
             quality = "normal";
-        } else if (ch == 'g' || ch == 'G') {
+        } else if (command == 'g' || command == 'G') {
             mode = AM_GOOD;
             quality = "good";
-        } else if (ch == 'e' || ch == 'E') {
+        } else if (command == 'e' || command == 'E') {
             mode = AM_GOOD | AM_GREAT;
             quality = "excellent";
         } else {
@@ -491,7 +490,7 @@ static void wiz_statistics(PlayerType *player_ptr, ItemEntity *o_ptr)
         constexpr auto p = "Enter number of items to roll: ";
         const auto rolls_opt = input_numerics(p, 0, MAX_INT, rolls);
         if (rolls_opt) {
-            rolls = rolls_opt.value();
+            rolls = *rolls_opt;
         }
 
         constexpr auto q = "Rolls: %d  Correct: %d  Matches: %d  Better: %d  Worse: %d  Other: %d";
@@ -580,8 +579,7 @@ static void wiz_reroll_item(PlayerType *player_ptr, ItemEntity *o_ptr)
             break;
         }
 
-        const auto ch = command.value();
-        if (ch == 'A' || ch == 'a') {
+        if (command == 'A' || command == 'a') {
             changed = true;
             break;
         }
@@ -591,7 +589,7 @@ static void wiz_reroll_item(PlayerType *player_ptr, ItemEntity *o_ptr)
             q_ptr->fixed_artifact_idx = FixedArtifactId::NONE;
         }
 
-        switch (tolower(ch)) {
+        switch (tolower(*command)) {
         /* Apply bad magic, but first clear object */
         case 'w':
             q_ptr->prep(o_ptr->bi_id);
@@ -674,28 +672,28 @@ static void wiz_tweak_item(PlayerType *player_ptr, ItemEntity *o_ptr)
         return;
     }
 
-    o_ptr->pval = pval.value();
+    o_ptr->pval = *pval;
     wiz_display_item(player_ptr, o_ptr);
     const auto bonus_ac = input_numerics("Enter new AC Bonus setting: ", -MAX_SHORT, MAX_SHORT, o_ptr->to_a);
     if (!bonus_ac) {
         return;
     }
 
-    o_ptr->to_a = bonus_ac.value();
+    o_ptr->to_a = *bonus_ac;
     wiz_display_item(player_ptr, o_ptr);
     const auto bonus_hit = input_numerics("Enter new Hit Bonus setting: ", -MAX_SHORT, MAX_SHORT, o_ptr->to_h);
     if (!bonus_hit) {
         return;
     }
 
-    o_ptr->to_h = bonus_hit.value();
+    o_ptr->to_h = *bonus_hit;
     wiz_display_item(player_ptr, o_ptr);
     const auto bonus_damage = input_numerics("Enter new Damage Bonus setting: ", -MAX_SHORT, MAX_SHORT, o_ptr->to_d);
     if (!bonus_damage) {
         return;
     }
 
-    o_ptr->to_d = bonus_damage.value();
+    o_ptr->to_d = *bonus_damage;
     wiz_display_item(player_ptr, o_ptr);
 }
 
@@ -709,15 +707,14 @@ static void wiz_quantity_item(ItemEntity *o_ptr)
         return;
     }
 
-    const auto quantity_opt = input_numerics("Quantity: ", 1, 99, o_ptr->number);
-    if (!quantity_opt) {
+    const auto quantity = input_numerics("Quantity: ", 1, 99, o_ptr->number);
+    if (!quantity) {
         return;
     }
 
-    const auto quantity = quantity_opt.value();
-    o_ptr->number = quantity;
+    o_ptr->number = *quantity;
     if (o_ptr->bi_key.tval() == ItemKindType::ROD) {
-        o_ptr->pval = o_ptr->pval * o_ptr->number / quantity;
+        o_ptr->pval = o_ptr->pval * o_ptr->number / *quantity;
     }
 }
 
@@ -755,25 +752,24 @@ void wiz_modify_item(PlayerType *player_ptr)
             break;
         }
 
-        const auto ch = command.value();
-        if (ch == 'A' || ch == 'a') {
+        if (command == 'A' || command == 'a') {
             changed = true;
             break;
         }
 
-        if (ch == 's' || ch == 'S') {
+        if (command == 's' || command == 'S') {
             wiz_statistics(player_ptr, q_ptr);
         }
 
-        if (ch == 'r' || ch == 'R') {
+        if (command == 'r' || command == 'R') {
             wiz_reroll_item(player_ptr, q_ptr);
         }
 
-        if (ch == 't' || ch == 'T') {
+        if (command == 't' || command == 'T') {
             wiz_tweak_item(player_ptr, q_ptr);
         }
 
-        if (ch == 'q' || ch == 'Q') {
+        if (command == 'q' || command == 'Q') {
             wiz_quantity_item(q_ptr);
         }
     }
@@ -874,7 +870,7 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
     while (true) {
         const auto pray_opt = input_string(_("何をお望み？ ", "For what do you wish?"), MAX_NLEN);
         if (pray_opt) {
-            pray = pray_opt.value();
+            pray = *pray_opt;
             break;
         }
 

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -137,12 +137,11 @@ static std::optional<short> wiz_select_tval()
         prt(format("[%c] %s", listsym[list], tvals[list].desc), row, col);
     }
 
-    const auto item_type_opt = input_command(_("アイテム種別を選んで下さい", "Get what type of object? "));
-    if (!item_type_opt) {
+    const auto item_type = input_command(_("アイテム種別を選んで下さい", "Get what type of object? "));
+    if (!item_type) {
         return std::nullopt;
     }
 
-    const auto item_type = item_type_opt.value();
     short selection;
     auto max_num = list;
     for (selection = 0; selection < max_num; selection++) {
@@ -185,10 +184,9 @@ static short wiz_select_sval(const ItemKindType tval, std::string_view tval_desc
         return 0;
     }
 
-    const auto ch = command.value();
     short selection;
     for (selection = 0; selection < max_num; selection++) {
-        if (listsym[selection] == ch) {
+        if (listsym[selection] == command) {
             break;
         }
     }
@@ -420,28 +418,26 @@ void wiz_change_status(PlayerType *player_ptr)
             return;
         }
 
-        auto stat = new_ability_score.value();
-        player_ptr->stat_cur[i] = stat;
-        player_ptr->stat_max[i] = stat;
+        player_ptr->stat_cur[i] = *new_ability_score;
+        player_ptr->stat_max[i] = *new_ability_score;
     }
 
     const auto unskilled = PlayerSkill::weapon_exp_at(PlayerSkillRank::UNSKILLED);
     const auto master = PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER);
-    const auto proficiency_opt = input_numerics(_("熟練度", "Proficiency"), unskilled, master, static_cast<short>(master));
-    if (!proficiency_opt) {
+    const auto proficiency = input_numerics(_("熟練度", "Proficiency"), unskilled, master, static_cast<short>(master));
+    if (!proficiency) {
         return;
     }
 
-    const auto proficiency = proficiency_opt.value();
     for (auto tval : TV_WEAPON_RANGE) {
         for (int i = 0; i < 64; i++) {
-            player_ptr->weapon_exp[tval][i] = proficiency;
+            player_ptr->weapon_exp[tval][i] = *proficiency;
         }
     }
 
     PlayerSkill(player_ptr).limit_weapon_skills_by_max_value();
     for (auto j : PLAYER_SKILL_KIND_TYPE_RANGE) {
-        player_ptr->skill_exp[j] = proficiency;
+        player_ptr->skill_exp[j] = *proficiency;
         auto short_pclass = enum2i(player_ptr->pclass);
         if (player_ptr->skill_exp[j] > class_skills_info[short_pclass].s_max[j]) {
             player_ptr->skill_exp[j] = class_skills_info[short_pclass].s_max[j];
@@ -450,11 +446,11 @@ void wiz_change_status(PlayerType *player_ptr)
 
     int k;
     for (k = 0; k < 32; k++) {
-        player_ptr->spell_exp[k] = std::min(PlayerSkill::spell_exp_at(PlayerSkillRank::MASTER), proficiency);
+        player_ptr->spell_exp[k] = std::min(PlayerSkill::spell_exp_at(PlayerSkillRank::MASTER), *proficiency);
     }
 
     for (; k < 64; k++) {
-        player_ptr->spell_exp[k] = std::min(PlayerSkill::spell_exp_at(PlayerSkillRank::EXPERT), proficiency);
+        player_ptr->spell_exp[k] = std::min(PlayerSkill::spell_exp_at(PlayerSkillRank::EXPERT), *proficiency);
     }
 
     const auto gold = input_numerics("Gold: ", 0, MAX_INT, player_ptr->au);
@@ -462,19 +458,18 @@ void wiz_change_status(PlayerType *player_ptr)
         return;
     }
 
-    player_ptr->au = gold.value();
+    player_ptr->au = *gold;
     if (PlayerRace(player_ptr).equals(PlayerRaceType::ANDROID)) {
         return;
     }
 
-    const auto experience_opt = input_numerics("Experience: ", 0, MAX_INT, player_ptr->max_exp);
-    if (!experience_opt) {
+    const auto experience = input_numerics("Experience: ", 0, MAX_INT, player_ptr->max_exp);
+    if (!experience) {
         return;
     }
 
-    const auto experience = experience_opt.value();
-    player_ptr->max_exp = experience;
-    player_ptr->exp = experience;
+    player_ptr->max_exp = *experience;
+    player_ptr->exp = *experience;
     player_ptr->exp_frac = 0;
 }
 
@@ -498,13 +493,13 @@ void wiz_create_feature(PlayerType *player_ptr)
         return;
     }
 
-    const auto f_val2 = input_numerics(_("偽装地形ID", "FeatureID"), 0, max, f_val1.value());
+    const auto f_val2 = input_numerics(_("偽装地形ID", "FeatureID"), 0, max, *f_val1);
     if (!f_val2) {
         return;
     }
 
-    cave_set_feat(player_ptr, y, x, f_val1.value());
-    grid.mimic = f_val2.value();
+    cave_set_feat(player_ptr, y, x, *f_val1);
+    grid.mimic = *f_val2;
     const auto &terrain = grid.get_terrain_mimic();
     if (terrain.flags.has(TerrainCharacteristics::RUNE_PROTECTION) || terrain.flags.has(TerrainCharacteristics::RUNE_EXPLOSION)) {
         grid.info |= CAVE_OBJECT;
@@ -528,14 +523,7 @@ static std::optional<short> select_debugging_dungeon(short initial_dungeon_id)
         return static_cast<short>(std::clamp(static_cast<int>(command_arg), DUNGEON_ANGBAND, DUNGEON_DARKNESS));
     }
 
-    while (true) {
-        const auto dungeon_id = input_numerics("Jump which dungeon", DUNGEON_ANGBAND, DUNGEON_DARKNESS, initial_dungeon_id);
-        if (!dungeon_id) {
-            return std::nullopt;
-        }
-
-        return dungeon_id.value();
-    }
+    return input_numerics("Jump which dungeon", DUNGEON_ANGBAND, DUNGEON_DARKNESS, initial_dungeon_id);
 }
 
 /*
@@ -596,8 +584,8 @@ void wiz_jump_to_dungeon(PlayerType *player_ptr)
     const auto &floor = *player_ptr->current_floor_ptr;
     const auto is_in_dungeon = floor.is_in_dungeon();
     const auto dungeon_idx = is_in_dungeon ? floor.dungeon_idx : static_cast<short>(DUNGEON_ANGBAND);
-    const auto dungeon_id_opt = select_debugging_dungeon(dungeon_idx);
-    if (!dungeon_id_opt) {
+    const auto dungeon_id = select_debugging_dungeon(dungeon_idx);
+    if (!dungeon_id) {
         if (!is_in_dungeon) {
             return;
         }
@@ -609,8 +597,7 @@ void wiz_jump_to_dungeon(PlayerType *player_ptr)
         return;
     }
 
-    const auto dungeon_id = dungeon_id_opt.value();
-    const auto level_opt = select_debugging_floor(floor, dungeon_id);
+    const auto level_opt = select_debugging_floor(floor, *dungeon_id);
     if (!level_opt) {
         return;
     }
@@ -621,7 +608,7 @@ void wiz_jump_to_dungeon(PlayerType *player_ptr)
         do_cmd_save_game(player_ptr, true);
     }
 
-    wiz_jump_floor(player_ptr, dungeon_id, level);
+    wiz_jump_floor(player_ptr, *dungeon_id, level);
 }
 
 /*!
@@ -671,7 +658,7 @@ void wiz_reset_race(PlayerType *player_ptr)
         return;
     }
 
-    player_ptr->prace = new_race.value();
+    player_ptr->prace = *new_race;
     rp_ptr = &race_info[enum2i(player_ptr->prace)];
     change_birth_flags();
     handle_stuff(player_ptr);
@@ -688,7 +675,7 @@ void wiz_reset_class(PlayerType *player_ptr)
         return;
     }
 
-    const auto new_class_enum = new_class_opt.value();
+    const auto new_class_enum = *new_class_opt;
     const auto new_class = enum2i(new_class_enum);
     player_ptr->pclass = new_class_enum;
     cp_ptr = &class_info[new_class];
@@ -714,8 +701,8 @@ void wiz_reset_realms(PlayerType *player_ptr)
         return;
     }
 
-    player_ptr->realm1 = new_realm1.value();
-    player_ptr->realm2 = new_realm2.value();
+    player_ptr->realm1 = *new_realm1;
+    player_ptr->realm2 = *new_realm2;
     change_birth_flags();
     handle_stuff(player_ptr);
 }
@@ -776,7 +763,7 @@ void set_gametime(void)
         return;
     }
 
-    w_ptr->dungeon_turn = w_ptr->game_turn = game_time.value();
+    w_ptr->dungeon_turn = w_ptr->game_turn = *game_time;
 }
 
 /*!

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -597,18 +597,17 @@ void wiz_jump_to_dungeon(PlayerType *player_ptr)
         return;
     }
 
-    const auto level_opt = select_debugging_floor(floor, *dungeon_id);
-    if (!level_opt) {
+    const auto level = select_debugging_floor(floor, *dungeon_id);
+    if (!level) {
         return;
     }
 
-    const auto level = level_opt.value();
-    msg_format("You jump to dungeon level %d.", level);
+    msg_format("You jump to dungeon level %d.", *level);
     if (autosave_l) {
         do_cmd_save_game(player_ptr, true);
     }
 
-    wiz_jump_floor(player_ptr, *dungeon_id, level);
+    wiz_jump_floor(player_ptr, *dungeon_id, *level);
 }
 
 /*!

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -67,7 +67,7 @@ void wiz_debug_spell(PlayerType *player_ptr)
     }
 
     for (const auto &d : debug_spell_commands_list) {
-        if (spell.value() != d.command_name) {
+        if (*spell != d.command_name) {
             continue;
         }
 
@@ -81,7 +81,7 @@ void wiz_debug_spell(PlayerType *player_ptr)
                 return;
             }
 
-            (d.command_function.spell3.spell_function)(player_ptr, power.value());
+            (d.command_function.spell3.spell_function)(player_ptr, *power);
             return;
         }
         case 4: {
@@ -229,7 +229,7 @@ void wiz_summon_specific_monster(PlayerType *player_ptr, MonsterRaceId r_idx)
             return;
         }
 
-        r_idx = new_monrace_id.value();
+        r_idx = *new_monrace_id;
     }
 
     (void)summon_named_creature(player_ptr, 0, player_ptr->y, player_ptr->x, r_idx, PM_ALLOW_SLEEP | PM_ALLOW_GROUP);
@@ -250,7 +250,7 @@ void wiz_summon_pet(PlayerType *player_ptr, MonsterRaceId r_idx)
             return;
         }
 
-        r_idx = new_monrace_id.value();
+        r_idx = *new_monrace_id;
     }
 
     (void)summon_named_creature(player_ptr, 0, player_ptr->y, player_ptr->x, r_idx, PM_ALLOW_SLEEP | PM_ALLOW_GROUP | PM_FORCE_PET);
@@ -272,7 +272,7 @@ void wiz_kill_target(PlayerType *player_ptr, int initial_dam, AttributeType effe
             return;
         }
 
-        dam = input_dam.value();
+        dam = *input_dam;
     }
 
     constexpr auto max = enum2i(AttributeType::MAX);
@@ -296,7 +296,7 @@ void wiz_kill_target(PlayerType *player_ptr, int initial_dam, AttributeType effe
             return;
         }
 
-        idx = input_effect_id.value();
+        idx = *input_effect_id;
         screen_load();
     }
 


### PR DESCRIPTION
Discord の議論通り、PRを別に分けました
変更範囲でnulloptにアクセスしている可能性のある箇所をご確認下さい
(作業中は特に見当たりませんでしたが、BaseitemInfo::sval 辺りは怪しいかも？ もちろん他に想定外なnullopt の可能性もあり)

※ svalの仕様
「巻物の内どれか」等、tval は固定しつつsval はランダムに選択する場面があります
この場合sval をnullopt にしてlookup ルーチンに渡します
そこで生成されるベースアイテムIDは確定します (sval がnon-null になる)
この都合上、ItemEntity::bi\_key から呼び出されるsval はnon-null のはずです

備考1：現在ItemEntity にnullopt なsval を渡す設計が存在しない
備考2：今後、ItemEntity のコンストラクタとしてBaseitemKey を渡し、lookup を前提としたコンストラクタを追加する予定はある