### PR TITLE
BaseitemKey のコンストラクタをコンパイル時定数に置き換えた

### DIFF
--- a/src/system/baseitem-info.cpp
+++ b/src/system/baseitem-info.cpp
@@ -26,12 +26,6 @@ constexpr auto ITEM_NOT_ROD = "This item is not a rod!";
 constexpr auto ITEM_NOT_LITE = "This item is not a lite!";
 }
 
-BaseitemKey::BaseitemKey(const ItemKindType type_value, const std::optional<int> &subtype_value)
-    : type_value(type_value)
-    , subtype_value(subtype_value)
-{
-}
-
 bool BaseitemKey::operator==(const BaseitemKey &other) const
 {
     return (this->type_value == other.type_value) && (this->subtype_value == other.subtype_value);

--- a/src/system/baseitem-info.h
+++ b/src/system/baseitem-info.h
@@ -12,7 +12,12 @@
 enum class ItemKindType : short;
 class BaseitemKey {
 public:
-    BaseitemKey(const ItemKindType type_value, const std::optional<int> &subtype_value = std::nullopt);
+    constexpr BaseitemKey(const ItemKindType type_value, const std::optional<int> &subtype_value = std::nullopt)
+        : type_value(type_value)
+        , subtype_value(subtype_value)
+    {
+    }
+
     bool operator==(const BaseitemKey &other) const;
     bool operator!=(const BaseitemKey &other) const
     {


### PR DESCRIPTION
掲題の通りです
修正範囲が狭いのでチケットはありません
「あるアイテムが特定のアイテムに一致するか比較する」という処理が複数箇所あり、「特定のアイテム」の方をコンパイル時定数として処理することで高速化を図ったものです
BaseitemKey は元々イミュータブル保証なので、この修正により更なる堅牢化も図れます
ご確認下さい