### PR TITLE
[Fix] 施設入場不可メッセージがズレるエラーを修正。

### DIFF
--- a/src/cmd-building/cmd-building.cpp
+++ b/src/cmd-building/cmd-building.cpp
@@ -318,8 +318,6 @@ void do_cmd_building(PlayerType *player_ptr)
         return;
     }
 
-    TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, MAIN_TERM_MIN_ROWS);
-
     int which = player_ptr->current_floor_ptr->get_grid(p_pos).get_terrain().subtype;
 
     building_type *bldg;
@@ -345,6 +343,8 @@ void do_cmd_building(PlayerType *player_ptr)
 
         return;
     }
+
+    TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, MAIN_TERM_MIN_ROWS);
 
     auto &system = AngbandSystem::get_instance();
     if (system.is_phase_out()) {


### PR DESCRIPTION
 * 表示前にメインウィンドウの `term_type` 内 `offset_x` と `offset_y` が先に `TermCenteredOffsetSetter` でウィンドウサイズに応じて中央に回ってしまうのが原因だった。