### PR TITLE
VS2022 で出ているコンパイル警告を解消した

### DIFF
--- a/src/action/activation-execution.cpp
+++ b/src/action/activation-execution.cpp
@@ -214,7 +214,7 @@ static bool activate_whistle(PlayerType *player_ptr, ae_type *ae_ptr)
         }
     }
 
-    uint16_t dummy_why;
+    short dummy_why = 0;
     ang_sort(player_ptr, who.data(), &dummy_why, who.size(), ang_sort_comp_pet, ang_sort_swap_hook);
     for (auto pet_ctr : who) {
         teleport_monster_to(player_ptr, pet_ctr, player_ptr->y, player_ptr->x, 100, TELEPORT_PASSIVE);

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -1009,7 +1009,7 @@ void ItemEntity::mark_as_known()
 /*!
  * @brief オブジェクトを試行済にする
  */
-void ItemEntity::mark_as_tried()
+void ItemEntity::mark_as_tried() const
 {
     this->get_baseitem().mark_as_tried();
 }

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -150,7 +150,7 @@ public:
     std::string explain_activation() const;
 
     void mark_as_known();
-    void mark_as_tried();
+    void mark_as_tried() const;
 
 private:
     int get_baseitem_price() const;


### PR DESCRIPTION
掲題の通りです
ご確認下さい

activation-execution は、処理を追っていくと最終的に使われていない (ので変数名がdummy)ことが分かっています
それなら符号もどうでも良いのでshort としました