### PR TITLE
[Fix]両手がふさがっていてもふらつかないバグを修正

### DIFF
--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -1975,8 +1975,8 @@ static bool is_riding_two_hands(PlayerType *player_ptr)
     if (has_two_handed_weapons(player_ptr) || (empty_hands(player_ptr, false) == EMPTY_HAND_NONE)) {
         return true;
     }
- 
-    if (any_bits(player_ptr->pet_extra_flags, PF_TWO_HANDS)) { 
+
+    if (any_bits(player_ptr->pet_extra_flags, PF_TWO_HANDS)) {
         switch (player_ptr->pclass) {
         case PlayerClassType::MONK:
         case PlayerClassType::FORCETRAINER:

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -1931,7 +1931,7 @@ static ARMOUR_CLASS calc_to_ac(PlayerType *player_ptr, bool is_real_value)
  * * EASY2_WEAPONによる軽減
  * * SUPPORTIVEを左に装備した場合の軽減
  * * 武蔵セットによる免除
- * * 竿状武器による増加 
+ * * 竿状武器による増加
  */
 int16_t calc_double_weapon_penalty(PlayerType *player_ptr, INVENTORY_IDX slot)
 {
@@ -1983,9 +1983,10 @@ static bool is_riding_two_hands(PlayerType *player_ptr)
         case PlayerClassType::BERSERKER:
             return (empty_hands(player_ptr, false) != EMPTY_HAND_NONE) && !has_melee_weapon(player_ptr, INVEN_MAIN_HAND) && !has_melee_weapon(player_ptr, INVEN_SUB_HAND);
         default:
-            return false;
+            break;
         }
     }
+    return false;
 }
 
 static int16_t calc_riding_bow_penalty(PlayerType *player_ptr)

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -1931,7 +1931,7 @@ static ARMOUR_CLASS calc_to_ac(PlayerType *player_ptr, bool is_real_value)
  * * EASY2_WEAPONによる軽減
  * * SUPPORTIVEを左に装備した場合の軽減
  * * 武蔵セットによる免除
- * * 竿状武器による増加
+ * * 竿状武器による増加 
  */
 int16_t calc_double_weapon_penalty(PlayerType *player_ptr, INVENTORY_IDX slot)
 {

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -1986,6 +1986,7 @@ static bool is_riding_two_hands(PlayerType *player_ptr)
             break;
         }
     }
+
     return false;
 }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -1968,7 +1968,7 @@ int16_t calc_double_weapon_penalty(PlayerType *player_ptr, INVENTORY_IDX slot)
 
 static bool is_riding_two_hands(PlayerType *player_ptr)
 {
-    if (!player_ptr->riding || none_bits(player_ptr->pet_extra_flags, PF_TWO_HANDS)) {
+    if (!player_ptr->riding) {
         return false;
     }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -1975,14 +1975,16 @@ static bool is_riding_two_hands(PlayerType *player_ptr)
     if (has_two_handed_weapons(player_ptr) || (empty_hands(player_ptr, false) == EMPTY_HAND_NONE)) {
         return true;
     }
-
-    switch (player_ptr->pclass) {
-    case PlayerClassType::MONK:
-    case PlayerClassType::FORCETRAINER:
-    case PlayerClassType::BERSERKER:
-        return (empty_hands(player_ptr, false) != EMPTY_HAND_NONE) && !has_melee_weapon(player_ptr, INVEN_MAIN_HAND) && !has_melee_weapon(player_ptr, INVEN_SUB_HAND);
-    default:
-        return false;
+ 
+    if (any_bits(player_ptr->pet_extra_flags, PF_TWO_HANDS)) { 
+        switch (player_ptr->pclass) {
+        case PlayerClassType::MONK:
+        case PlayerClassType::FORCETRAINER:
+        case PlayerClassType::BERSERKER:
+            return (empty_hands(player_ptr, false) != EMPTY_HAND_NONE) && !has_melee_weapon(player_ptr, INVEN_MAIN_HAND) && !has_melee_weapon(player_ptr, INVEN_SUB_HAND);
+        default:
+            return false;
+        }
     }
 }
 


### PR DESCRIPTION
#3781 のバグ修正です。
none_bits(player_ptr->pet_extra_flags, PF_TWO_HANDS)の判定を削除…ではなくご指摘いただき判定位置を変更しました。
[このコミット](https://github.com/hengband/hengband/commit/dbec38d8106a6001c912cad2c3c1429e79309bc6)で追加された判定です。
PF_TWO_HANDSフラグはペットに騎乗時に、ペットに命令→両手持ちしたときにTrueになるフラグのようです。

▼変更適用後のスクリーンショット
![スクリーンショット 2023-12-16 212702](https://github.com/hengband/hengband/assets/108442898/80462366-7cd5-4ef9-974b-ea9688fdc332)
