### PR TITLE
[Fix]アリーナの出口が開く条件がおかしいのを修正

### DIFF
--- a/src/cmd-building/cmd-building.cpp
+++ b/src/cmd-building/cmd-building.cpp
@@ -338,7 +338,7 @@ void do_cmd_building(PlayerType *player_ptr)
     }
 
     if ((which == 2) && player_ptr->current_floor_ptr->inside_arena) {
-        if (w_ptr->get_arena() && player_ptr->current_floor_ptr->m_cnt > 0) {
+        if (!w_ptr->get_arena() && player_ptr->current_floor_ptr->m_cnt > 0) {
             prt(_("ゲートは閉まっている。モンスターがあなたを待っている！", "The gates are closed.  The monster awaits!"), 0, 0);
         } else {
             prepare_change_floor_mode(player_ptr, CFM_SAVE_FLOORS | CFM_NO_RETURN);


### PR DESCRIPTION
#3791 #3792 のバグ修正。
[リファクター](https://github.com/hengband/hengband/commit/fb2116246e5879595bfff5d3b494840c5660b21d)の際に真偽値反転が抜けていたので追加。
get_arena()は闘技場内に入ってから、闘技場のペットでないモンスターが(1体でいいので)死ぬまでtrueになる。
騎兵の場合さらに挙動がおかしくなるのは、闘技場出口から出られない条件を、get_arena() && 「モンスター数>0」で判定しているため。（「モンスター数>0」は敵モンスターが必ず生成される現仕様では(多分)意味のない判定式であるが、「モンスター数>0」が無ければほとんどの@さんは出られないところだった？）
