### PR TITLE
Update spec

### DIFF
--- a/hengband.spec
+++ b/hengband.spec
@@ -1,4 +1,4 @@
-%define version 3.0.1.3
+%define version 3.0.1.4
 %define release 1
 
 Summary: hengband %{version}
@@ -96,7 +96,10 @@ exit 0
 
 %changelog
 
-* Mon Dec 11 2023 whitehara <white@vx-xv.com>
+* Wed Dec 27 2023 Shiro Hara <white@vx-xv.com>
+- hengband RPM 3.0.1.4(Beta)
+
+* Mon Dec 11 2023 Shiro Hara <white@vx-xv.com>
 - hengband RPM 3.0.1.3(Beta)
 
 * Mon Nov 27 2023 Shiro Hara <white@vx-xv.com>


### PR DESCRIPTION
- hengband.specのバージョンを3.0.1.4に更新
- 同バージョンのrpmをCoprにて配布開始 https://copr.fedorainfracloud.org/coprs/whitehara/hengband/