### PR TITLE
[Fix]両手がふさがっていてもふらつかないバグを修正

### DIFF
--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -1968,7 +1968,7 @@ int16_t calc_double_weapon_penalty(PlayerType *player_ptr, INVENTORY_IDX slot)
 
 static bool is_riding_two_hands(PlayerType *player_ptr)
 {
-    if (!player_ptr->riding || none_bits(player_ptr->pet_extra_flags, PF_TWO_HANDS)) {
+    if (!player_ptr->riding) {
         return false;
     }
 
@@ -1976,14 +1976,18 @@ static bool is_riding_two_hands(PlayerType *player_ptr)
         return true;
     }
 
-    switch (player_ptr->pclass) {
-    case PlayerClassType::MONK:
-    case PlayerClassType::FORCETRAINER:
-    case PlayerClassType::BERSERKER:
-        return (empty_hands(player_ptr, false) != EMPTY_HAND_NONE) && !has_melee_weapon(player_ptr, INVEN_MAIN_HAND) && !has_melee_weapon(player_ptr, INVEN_SUB_HAND);
-    default:
-        return false;
+    if (any_bits(player_ptr->pet_extra_flags, PF_TWO_HANDS)) {
+        switch (player_ptr->pclass) {
+        case PlayerClassType::MONK:
+        case PlayerClassType::FORCETRAINER:
+        case PlayerClassType::BERSERKER:
+            return (empty_hands(player_ptr, false) != EMPTY_HAND_NONE) && !has_melee_weapon(player_ptr, INVEN_MAIN_HAND) && !has_melee_weapon(player_ptr, INVEN_SUB_HAND);
+        default:
+            break;
+        }
     }
+
+    return false;
 }
 
 static int16_t calc_riding_bow_penalty(PlayerType *player_ptr)


### PR DESCRIPTION
先ほどブランチ削除で閉じてしまった #3795 の出し直しです。
#3781 のバグ修正で、none_bits(player_ptr->pet_extra_flags, PF_TWO_HANDS)の判定位置を変更しました。
[このコミット](https://github.com/hengband/hengband/commit/dbec38d8106a6001c912cad2c3c1429e79309bc6)で追加された判定です。

▼変更適用後のスクリーンショット
![スクリーンショット 2023-12-16 212702](https://github.com/hengband/hengband/assets/108442898/80462366-7cd5-4ef9-974b-ea9688fdc332)