### PR TITLE
[Fix] 荒野でレベルテレポートしたときダンジョン内に入らない

### DIFF
--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -118,7 +118,8 @@ void teleport_level(PlayerType *player_ptr, MONSTER_IDX m_idx)
             }
 
             if (!floor.is_in_dungeon()) {
-                floor.dun_level = dungeon.mindepth;
+                const auto &recall_dungeon = floor.get_dungeon_definition();
+                floor.dun_level = recall_dungeon.mindepth;
                 prepare_change_floor_mode(player_ptr, CFM_RAND_PLACE);
             } else {
                 prepare_change_floor_mode(player_ptr, CFM_SAVE_FLOORS | CFM_DOWN | CFM_RAND_PLACE | CFM_RAND_CONNECT);


### PR DESCRIPTION
Issue #3611 の件。
荒野でレベルテレポートを読んだとき、帰還先になっているダンジョンの最上階に移動するべきところ該当ダンジョンの地上入口に移動していた。 移動先の指定が誤っているためこれを修正する。