### PR TITLE
[Fix] C画面近接ダメージの計算を修正

### DIFF
--- a/src/combat/attack-criticality.cpp
+++ b/src/combat/attack-criticality.cpp
@@ -21,23 +21,24 @@
  *
  * @param k クリティカルの強度を決定する値
  * @param base_dam クリティカル適用前のダメージ
+ * @param mult 期待値計算時のdam倍率
  * @return クリティカルを適用したダメージと、クリティカル発生時に表示するメッセージと、クリティカル効果音のタプルを返す
  */
-std::tuple<int, concptr, sound_type> apply_critical_norm_damage(int k, int base_dam)
+std::tuple<int, concptr, sound_type> apply_critical_norm_damage(int k, int base_dam, int mult)
 {
     if (k < 400) {
-        return { 2 * base_dam + 5, _("手ごたえがあった！", "It was a good hit!"), SOUND_GOOD_HIT };
+        return { 2 * base_dam + 5 * mult, _("手ごたえがあった！", "It was a good hit!"), SOUND_GOOD_HIT };
     }
     if (k < 700) {
-        return { 2 * base_dam + 10, _("かなりの手ごたえがあった！", "It was a great hit!"), SOUND_GREAT_HIT };
+        return { 2 * base_dam + 10 * mult, _("かなりの手ごたえがあった！", "It was a great hit!"), SOUND_GREAT_HIT };
     }
     if (k < 900) {
-        return { 3 * base_dam + 15, _("会心の一撃だ！", "It was a superb hit!"), SOUND_SUPERB_HIT };
+        return { 3 * base_dam + 15 * mult, _("会心の一撃だ！", "It was a superb hit!"), SOUND_SUPERB_HIT };
     }
     if (k < 1300) {
-        return { 3 * base_dam + 20, _("最高の会心の一撃だ！", "It was a *GREAT* hit!"), SOUND_STAR_GREAT_HIT };
+        return { 3 * base_dam + 20 * mult, _("最高の会心の一撃だ！", "It was a *GREAT* hit!"), SOUND_STAR_GREAT_HIT };
     }
-    return { ((7 * base_dam) / 2) + 25, _("比類なき最高の会心の一撃だ！", "It was a *SUPERB* hit!"), SOUND_STAR_SUPERB_HIT };
+    return { ((7 * base_dam) / 2) + 25 * mult, _("比類なき最高の会心の一撃だ！", "It was a *SUPERB* hit!"), SOUND_STAR_SUPERB_HIT };
 }
 
 /*!

--- a/src/combat/attack-criticality.h
+++ b/src/combat/attack-criticality.h
@@ -8,6 +8,6 @@
 
 struct player_attack_type;
 class PlayerType;
-std::tuple<int, concptr, sound_type> apply_critical_norm_damage(int k, int base_dam);
+std::tuple<int, concptr, sound_type> apply_critical_norm_damage(int k, int base_dam, int mult = 1);
 int critical_norm(PlayerType *player_ptr, WEIGHT weight, int plus, int dam, int16_t meichuu, combat_options mode, bool impact = false);
 void critical_attack(PlayerType *player_ptr, player_attack_type *pa_ptr);

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -1195,9 +1195,9 @@ int calc_expect_crit_shot(PlayerType *player_ptr, WEIGHT weight, int plus_ammo, 
  * @brief 攻撃時クリティカルによるダメージ期待値修正計算（重量と毒針処理） / critical happens at i / 10000
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param weight 武器の重量
- * @param plus 武器のダメージ修正
+ * @param plus 武器の命中修正
  * @param dam 基本ダメージ
- * @param meichuu 命中値
+ * @param meichuu 武器以外の命中修正
  * @param dokubari 毒針処理か否か
  * @param impact 強撃かどうか
  * @return ダメージ期待値
@@ -1244,4 +1244,95 @@ int calc_expect_crit(PlayerType *player_ptr, WEIGHT weight, int plus, int dam, i
     num /= pow;
 
     return num;
+}
+
+/*!
+ * @brief 攻撃時スレイによるダメージ期待値修正計算 / critical happens at i / 10000
+ * @param dam 基本ダメージ
+ * @param mult スレイ倍率（掛け算部分）
+ * @param div スレイ倍率（割り算部分）
+ * @param force 理力特別計算フラグ
+ * @return ダメージ期待値
+ */
+static int calc_slaydam(int dam, int mult, int div, bool force)
+{
+    int tmp;
+    if (force) {
+        tmp = dam * 60;
+        tmp *= mult * 3;
+        tmp /= div * 2;
+        tmp += dam * 60 * 2;
+        tmp /= 60;
+        return tmp;
+    }
+
+    tmp = dam * 60;
+    tmp *= mult;
+    tmp /= div;
+    tmp /= 60;
+    return tmp;
+}
+
+/*!
+ * @brief 攻撃時の期待値計算（スレイ→重量クリティカル→切れ味効果）
+ * @param player_ptr プレイヤーへの参照ポインタ
+ * @param dam 基本ダメージ
+ * @param to_h 武器以外の命中修正
+ * @param o_ptr 武器への参照ポインタ
+ * @return ダメージ期待値
+ */
+uint32_t calc_expect_dice(
+    PlayerType *player_ptr, uint32_t dam, int16_t to_h, ItemEntity *o_ptr)
+{
+    auto flags = o_ptr->get_flags_known();
+    bool impact = player_ptr->impact != 0;
+
+    int vorpal_mult = 1;
+    int vorpal_div = 1;
+    const auto is_vorpal_blade = o_ptr->is_specific_artifact(FixedArtifactId::VORPAL_BLADE);
+    const auto is_chainsword = o_ptr->is_specific_artifact(FixedArtifactId::CHAINSWORD);
+    if (o_ptr->is_fully_known() && (is_vorpal_blade || is_chainsword)) {
+        /* vorpal blade */
+        vorpal_mult = 5;
+        vorpal_div = 3;
+    } else if (flags.has(TR_VORPAL)) {
+        /* vorpal flag only */
+        vorpal_mult = 11;
+        vorpal_div = 9;
+    }
+
+    // 理力
+    bool is_force = !PlayerClass(player_ptr).equals(PlayerClassType::SAMURAI);
+    is_force &= flags.has(TR_FORCE_WEAPON);
+    is_force &= player_ptr->csp > (o_ptr->dd * o_ptr->ds / 5);
+
+    dam = calc_slaydam(dam, 1, 1, is_force);
+    dam = calc_expect_crit(player_ptr, o_ptr->weight, o_ptr->to_h, dam, to_h, false, impact);
+    dam = calc_slaydam(dam, vorpal_mult, vorpal_div, false);
+    return dam;
+}
+
+/*!
+ * @brief 攻撃時の期待値計算（スレイ→重量クリティカル→切れ味効果）
+ * @param player_ptr プレイヤーへの参照ポインタ
+ * @param dam 基本ダメージ
+ * @param mult スレイ倍率（掛け算部分）
+ * @param div スレイ倍率（割り算部分）
+ * @param force 理力特別計算フラグ
+ * @param weight 重量
+ * @param plus 武器命中修正
+ * @param meichuu 武器以外の命中修正
+ * @param dokubari 毒針処理か否か
+ * @param impact 強撃か否か
+ * @param vorpal_mult 切れ味倍率（掛け算部分）
+ * @param vorpal_div 切れ味倍率（割り算部分）
+ * @return ダメージ期待値
+ */
+uint32_t calc_expect_dice(
+    PlayerType *player_ptr, uint32_t dam, int mult, int div, bool force, WEIGHT weight, int plus, int16_t meichuu, bool dokubari, bool impact, int vorpal_mult, int vorpal_div)
+{
+    dam = calc_slaydam(dam, mult, div, force);
+    dam = calc_expect_crit(player_ptr, weight, plus, dam, meichuu, dokubari, impact);
+    dam = calc_slaydam(dam, vorpal_mult, vorpal_div, false);
+    return dam;
 }

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -1200,9 +1200,10 @@ int calc_expect_crit_shot(PlayerType *player_ptr, WEIGHT weight, int plus_ammo, 
  * @param meichuu 武器以外の命中修正
  * @param dokubari 毒針処理か否か
  * @param impact 強撃かどうか
+ * @param mult 期待値計算時のdam倍率
  * @return ダメージ期待値
  */
-int calc_expect_crit(PlayerType *player_ptr, WEIGHT weight, int plus, int dam, int16_t meichuu, bool dokubari, bool impact)
+int calc_expect_crit(PlayerType *player_ptr, WEIGHT weight, int plus, int dam, int16_t meichuu, bool dokubari, bool impact, int mult)
 {
     if (dokubari) {
         return dam;
@@ -1214,11 +1215,11 @@ int calc_expect_crit(PlayerType *player_ptr, WEIGHT weight, int plus, int dam, i
     }
 
     // 通常ダメージdam、武器重量weightでクリティカルが発生した時のクリティカルダメージ期待値
-    auto calc_weight_expect_dam = [](int dam, WEIGHT weight) {
+    auto calc_weight_expect_dam = [](int dam, WEIGHT weight, int mult) {
         int sum = 0;
         for (int d = 1; d <= 650; ++d) {
             int k = weight + d;
-            sum += std::get<0>(apply_critical_norm_damage(k, dam));
+            sum += std::get<0>(apply_critical_norm_damage(k, dam, mult));
         }
         return sum / 650;
     };
@@ -1227,11 +1228,11 @@ int calc_expect_crit(PlayerType *player_ptr, WEIGHT weight, int plus, int dam, i
 
     if (impact) {
         for (int d = 1; d <= 650; ++d) {
-            num += calc_weight_expect_dam(dam, weight + d);
+            num += calc_weight_expect_dam(dam, weight + d, mult);
         }
         num /= 650;
     } else {
-        num += calc_weight_expect_dam(dam, weight);
+        num += calc_weight_expect_dam(dam, weight, mult);
     }
 
     int pow = PlayerClass(player_ptr).equals(PlayerClassType::NINJA) ? 4444 : 5000;

--- a/src/combat/shoot.h
+++ b/src/combat/shoot.h
@@ -11,7 +11,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX i_idx, ItemEntity *j_ptr, SP
 int critical_shot(PlayerType *player_ptr, WEIGHT weight, int plus_ammo, int plus_bow, int dam);
 int calc_crit_ratio_shot(PlayerType *player_ptr, int plus_ammo, int plus_bow);
 int calc_expect_crit_shot(PlayerType *player_ptr, WEIGHT weight, int plus_ammo, int plus_bow, int dam);
-int calc_expect_crit(PlayerType *player_ptr, WEIGHT weight, int plus, int dam, int16_t meichuu, bool dokubari, bool impact);
+int calc_expect_crit(PlayerType *player_ptr, WEIGHT weight, int plus, int dam, int16_t meichuu, bool dokubari, bool impact, int mult = 1);
 uint32_t calc_expect_dice(
     PlayerType *player_ptr, uint32_t dam, int16_t to_h, ItemEntity *o_ptr);
 uint32_t calc_expect_dice(

--- a/src/combat/shoot.h
+++ b/src/combat/shoot.h
@@ -7,8 +7,12 @@ class MonsterEntity;
 class ItemEntity;
 class PlayerType;
 bool test_hit_fire(PlayerType *player_ptr, int chance, MonsterEntity *m_ptr, int vis, std::string_view item_name);
+void exe_fire(PlayerType *player_ptr, INVENTORY_IDX i_idx, ItemEntity *j_ptr, SPELL_IDX snipe_type);
 int critical_shot(PlayerType *player_ptr, WEIGHT weight, int plus_ammo, int plus_bow, int dam);
 int calc_crit_ratio_shot(PlayerType *player_ptr, int plus_ammo, int plus_bow);
 int calc_expect_crit_shot(PlayerType *player_ptr, WEIGHT weight, int plus_ammo, int plus_bow, int dam);
 int calc_expect_crit(PlayerType *player_ptr, WEIGHT weight, int plus, int dam, int16_t meichuu, bool dokubari, bool impact);
-void exe_fire(PlayerType *player_ptr, INVENTORY_IDX i_idx, ItemEntity *j_ptr, SPELL_IDX snipe_type);
+uint32_t calc_expect_dice(
+    PlayerType *player_ptr, uint32_t dam, int16_t to_h, ItemEntity *o_ptr);
+uint32_t calc_expect_dice(
+    PlayerType *player_ptr, uint32_t dam, int mult, int div, bool force, WEIGHT weight, int plus, int16_t meichuu, bool dokubari, bool impact, int vorpal_mult, int vorpal_div);

--- a/src/market/building-craft-weapon.cpp
+++ b/src/market/building-craft-weapon.cpp
@@ -28,58 +28,6 @@
 #include "world/world.h"
 
 /*!
- * @brief 攻撃時スレイによるダメージ期待値修正計算 / critical happens at i / 10000
- * @param dam 基本ダメージ
- * @param mult スレイ倍率（掛け算部分）
- * @param div スレイ倍率（割り算部分）
- * @param force 理力特別計算フラグ
- * @return ダメージ期待値
- */
-static int calc_slaydam(int dam, int mult, int div, bool force)
-{
-    int tmp;
-    if (force) {
-        tmp = dam * 60;
-        tmp *= mult * 3;
-        tmp /= div * 2;
-        tmp += dam * 60 * 2;
-        tmp /= 60;
-        return tmp;
-    }
-
-    tmp = dam * 60;
-    tmp *= mult;
-    tmp /= div;
-    tmp /= 60;
-    return tmp;
-}
-
-/*!
- * @brief 攻撃時の期待値計算（スレイ→重量クリティカル→切れ味効果）
- * @param player_ptr プレイヤーへの参照ポインタ
- * @param dam 基本ダメージ
- * @param mult スレイ倍率（掛け算部分）
- * @param div スレイ倍率（割り算部分）
- * @param force 理力特別計算フラグ
- * @param weight 重量
- * @param plus 武器ダメージ修正
- * @param meichuu 命中値
- * @param dokubari 毒針処理か否か
- * @param impact 強撃か否か
- * @param vorpal_mult 切れ味倍率（掛け算部分）
- * @param vorpal_div 切れ味倍率（割り算部分）
- * @return ダメージ期待値
- */
-static uint32_t calc_expect_dice(
-    PlayerType *player_ptr, uint32_t dam, int mult, int div, bool force, WEIGHT weight, int plus, int16_t meichuu, bool dokubari, bool impact, int vorpal_mult, int vorpal_div)
-{
-    dam = calc_slaydam(dam, mult, div, force);
-    dam = calc_expect_crit(player_ptr, weight, plus, dam, meichuu, dokubari, impact);
-    dam = calc_slaydam(dam, vorpal_mult, vorpal_div, false);
-    return dam;
-}
-
-/*!
  * @brief 武器の各条件毎のダメージ期待値を表示する。
  * @param r 表示行
  * @param c 表示列

--- a/src/mind/monk-attack.cpp
+++ b/src/mind/monk-attack.cpp
@@ -174,7 +174,7 @@ static int process_monk_additional_effect(player_attack_type *pa_ptr, int *stun_
  * @param player_ptr プレイヤーへの参照ポインタ
  * @return 重さ
  */
-static WEIGHT calc_monk_attack_weight(PlayerType *player_ptr)
+WEIGHT calc_monk_attack_weight(PlayerType *player_ptr)
 {
     WEIGHT weight = 8;
     PlayerClass pc(player_ptr);

--- a/src/mind/monk-attack.h
+++ b/src/mind/monk-attack.h
@@ -1,6 +1,8 @@
 #pragma once
+#include <system/h-type.h>
 
 struct player_attack_type;
 class PlayerType;
 void process_monk_attack(PlayerType *player_ptr, player_attack_type *pa_ptr);
 bool double_attack(PlayerType *player_ptr);
+WEIGHT calc_monk_attack_weight(PlayerType *player_ptr);

--- a/src/view/status-first-page.cpp
+++ b/src/view/status-first-page.cpp
@@ -11,6 +11,7 @@
 #include "combat/shoot.h"
 #include "game-option/text-display-options.h"
 #include "inventory/inventory-slot-types.h"
+#include "mind/monk-attack.h"
 #include "mutation/mutation-flag-types.h"
 #include "object-enchant/special-object-flags.h"
 #include "object-enchant/tr-types.h"
@@ -97,6 +98,11 @@ static bool calc_weapon_damage_limit(PlayerType *player_ptr, int hand, int *dama
     } else {
         *basedam = monk_ave_damage[level][0];
     }
+    bool impact = player_ptr->impact != 0;
+    WEIGHT weight = player_ptr->lev * calc_monk_attack_weight(player_ptr);
+    int to_h = player_ptr->lev * 7 / 10; // 命中計算が煩雑なのでおよその値を使用する
+
+    *basedam = calc_expect_crit(player_ptr, weight, to_h, *basedam, player_ptr->to_h[0], false, impact, 100);
 
     damage[hand] += *basedam;
     if (o_ptr->bi_key == BaseitemKey(ItemKindType::SWORD, SV_POISON_NEEDLE)) {

--- a/src/view/status-first-page.cpp
+++ b/src/view/status-first-page.cpp
@@ -137,40 +137,6 @@ static bool calc_weapon_one_hand(ItemEntity *o_ptr, int hand, int *damage, int *
 }
 
 /*!
- * @brief ヴォーパル武器等によるダメージ強化
- * @param player_ptr プレイヤーへの参照ポインタ
- * @param o_ptr 装備中の武器への参照ポインタ
- * @param basedam 素手における直接攻撃のダメージ
- * @param flags オブジェクトフラグ群
- * @return 強化後の素手ダメージ
- * @todo ヴォーパル計算処理が building-craft-weapon::compare_weapon_aux() と多重実装.
- */
-static int strengthen_basedam(PlayerType *player_ptr, ItemEntity *o_ptr, int basedam, const TrFlags &flags)
-{
-    const auto is_vorpal_blade = o_ptr->is_specific_artifact(FixedArtifactId::VORPAL_BLADE);
-    const auto is_chainsword = o_ptr->is_specific_artifact(FixedArtifactId::CHAINSWORD);
-    if (o_ptr->is_fully_known() && (is_vorpal_blade || is_chainsword)) {
-        /* vorpal blade */
-        basedam *= 5;
-        basedam /= 3;
-    } else if (flags.has(TR_VORPAL)) {
-        /* vorpal flag only */
-        basedam *= 11;
-        basedam /= 9;
-    }
-
-    // 理力
-    bool is_force = !PlayerClass(player_ptr).equals(PlayerClassType::SAMURAI);
-    is_force &= flags.has(TR_FORCE_WEAPON);
-    is_force &= player_ptr->csp > (o_ptr->dd * o_ptr->ds / 5);
-    if (is_force) {
-        basedam = basedam * 7 / 2;
-    }
-
-    return basedam;
-}
-
-/*!
  * @brief 技能ランクの表示基準を定める
  * Returns a "rating" of x depending on y
  * @param x 技能値
@@ -264,23 +230,19 @@ static void calc_two_hands(PlayerType *player_ptr, int *damage, int *to_h)
         }
 
         to_h[i] = 0;
-        auto poison_needle = false;
-        if (o_ptr->bi_key == BaseitemKey(ItemKindType::SWORD, SV_POISON_NEEDLE)) {
-            poison_needle = true;
-        }
 
         if (o_ptr->is_known()) {
             damage[i] += o_ptr->to_d * 100;
             to_h[i] += o_ptr->to_h;
         }
 
-        basedam = ((o_ptr->dd + player_ptr->to_dd[i]) * (o_ptr->ds + player_ptr->to_ds[i] + 1)) * 50;
-        auto flags = o_ptr->get_flags_known();
+        int mindice = (o_ptr->dd + player_ptr->to_dd[i]);
+        int maxdice = (o_ptr->dd + player_ptr->to_dd[i]) * (o_ptr->ds + player_ptr->to_ds[i]);
 
-        bool impact = player_ptr->impact != 0;
-        basedam = calc_expect_crit(player_ptr, o_ptr->weight, to_h[i], basedam, player_ptr->dis_to_h[i], poison_needle, impact);
-        basedam = strengthen_basedam(player_ptr, o_ptr, basedam, flags);
-        damage[i] += basedam;
+        basedam = calc_expect_dice(player_ptr, mindice, p_ptr->to_h[i], o_ptr);
+        basedam += calc_expect_dice(player_ptr, maxdice, p_ptr->to_h[i], o_ptr);
+        damage[i] += basedam * 50; // x100 for display
+
         if (o_ptr->bi_key == BaseitemKey(ItemKindType::SWORD, SV_POISON_NEEDLE)) {
             damage[i] = 1;
         }


### PR DESCRIPTION
Issue #1989 の内容。

・武器攻撃力表示計算の微妙な差異（理力クリティカル切断の適用順）の修正
・素手攻撃力表示にクリティカルを考慮
・ついでに武器匠との二重実装の解消