### PR TITLE
[Refactor] フロア移動周りの可読性向上

### DIFF
--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -395,7 +395,7 @@ static void update_floor(PlayerType *player_ptr)
     }
 
     if (new_floor_id == 0) {
-        new_floor_id = get_new_floor_id(player_ptr);
+        new_floor_id = get_unused_floor_id(player_ptr);
     }
 
     saved_floor_type *sf_ptr;

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -200,9 +200,14 @@ static void update_unique_artifact(FloorType *floor_ptr, int16_t cur_floor_id)
     }
 }
 
+static bool is_visited_floor(saved_floor_type *sf_ptr)
+{
+    return sf_ptr->last_visit != 0;
+}
+
 static void check_visited_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr, bool *loaded)
 {
-    if ((sf_ptr->last_visit == 0) || !load_floor(player_ptr, sf_ptr, 0)) {
+    if (!is_visited_floor(sf_ptr) || !load_floor(player_ptr, sf_ptr, 0)) {
         return;
     }
 
@@ -317,7 +322,7 @@ static void new_floor_allocation(PlayerType *player_ptr, saved_floor_type *sf_pt
 
 static void check_dead_end(PlayerType *player_ptr, saved_floor_type *sf_ptr)
 {
-    if (sf_ptr->last_visit == 0) {
+    if (!is_visited_floor(sf_ptr)) {
         generate_floor(player_ptr);
         return;
     }

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -327,6 +327,24 @@ static void new_floor_allocation(PlayerType *player_ptr, saved_floor_type *sf_pt
     }
 }
 
+/*!
+ * @brief プレイヤー足元に階段を設置する
+ * @param player_ptr プレイヤーへの参照ポインタ
+ */
+static void set_stairs(PlayerType *player_ptr)
+{
+    auto &floor = *player_ptr->current_floor_ptr;
+    auto *g_ptr = &floor.grid_array[player_ptr->y][player_ptr->x];
+    if ((player_ptr->change_floor_mode & CFM_UP) && !inside_quest(floor.get_quest_id())) {
+        g_ptr->feat = (player_ptr->change_floor_mode & CFM_SHAFT) ? feat_state(&floor, feat_down_stair, TerrainCharacteristics::SHAFT) : feat_down_stair;
+    } else if ((player_ptr->change_floor_mode & CFM_DOWN) && !ironman_downward) {
+        g_ptr->feat = (player_ptr->change_floor_mode & CFM_SHAFT) ? feat_state(&floor, feat_up_stair, TerrainCharacteristics::SHAFT) : feat_up_stair;
+    }
+
+    g_ptr->mimic = 0;
+    g_ptr->special = player_ptr->floor_id;
+}
+
 static void update_new_floor_feature(PlayerType *player_ptr, saved_floor_type *sf_ptr, const bool loaded)
 {
     if (loaded) {
@@ -347,15 +365,7 @@ static void update_new_floor_feature(PlayerType *player_ptr, saved_floor_type *s
         return;
     }
 
-    auto *g_ptr = &floor.grid_array[player_ptr->y][player_ptr->x];
-    if ((player_ptr->change_floor_mode & CFM_UP) && !inside_quest(floor.get_quest_id())) {
-        g_ptr->feat = (player_ptr->change_floor_mode & CFM_SHAFT) ? feat_state(&floor, feat_down_stair, TerrainCharacteristics::SHAFT) : feat_down_stair;
-    } else if ((player_ptr->change_floor_mode & CFM_DOWN) && !ironman_downward) {
-        g_ptr->feat = (player_ptr->change_floor_mode & CFM_SHAFT) ? feat_state(&floor, feat_up_stair, TerrainCharacteristics::SHAFT) : feat_up_stair;
-    }
-
-    g_ptr->mimic = 0;
-    g_ptr->special = player_ptr->floor_id;
+    set_stairs(player_ptr);
 }
 
 static void cut_off_the_upstair(PlayerType *player_ptr)

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -230,7 +230,7 @@ static void check_visited_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr
 
 static void update_floor_id(PlayerType *player_ptr, saved_floor_type *sf_ptr)
 {
-    if (player_ptr->floor_id == 0) {
+    if (!player_ptr->in_saved_floor()) {
         if (player_ptr->change_floor_mode & CFM_UP) {
             sf_ptr->lower_floor_id = 0;
         } else if (player_ptr->change_floor_mode & CFM_DOWN) {

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -410,7 +410,7 @@ static void exe_leave_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr)
     jump_floors(player_ptr);
     exit_to_wilderness(player_ptr);
     kill_saved_floors(player_ptr, sf_ptr);
-    if (player_ptr->floor_id == 0) {
+    if (!player_ptr->in_saved_floor()) {
         return;
     }
 

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -385,7 +385,7 @@ static void refresh_new_floor_id(PlayerType *player_ptr, Grid *g_ptr)
         return;
     }
 
-    new_floor_id = get_new_floor_id(player_ptr);
+    new_floor_id = get_unused_floor_id(player_ptr);
     if ((g_ptr != nullptr) && !feat_uses_special(g_ptr->feat)) {
         g_ptr->special = new_floor_id;
     }

--- a/src/floor/floor-save-util.cpp
+++ b/src/floor/floor-save-util.cpp
@@ -10,3 +10,13 @@ FLOOR_IDX max_floor_id; /*!< Number of floor_id used from birth */
 FLOOR_IDX new_floor_id; /*!<次のフロアのID / floor_id of the destination */
 uint32_t latest_visit_mark; /*!<フロアを渡った回数？(確認中) / Max number of visit_mark */
 MonsterEntity party_mon[MAX_PARTY_MON]; /*!< フロア移動に保存するペットモンスターの配列 */
+
+/*!
+ * @brief フロアIDが0でないとき、すなわち保存済フロアの場合真を返す。
+ * @param sf_ptr 保存フロアのポインタ
+ * @return フロアIDが0でないときtrue、0のときfalseを返す。
+ */
+bool is_saved_floor(saved_floor_type *sf_ptr)
+{
+    return sf_ptr->floor_id != 0;
+}

--- a/src/floor/floor-save-util.h
+++ b/src/floor/floor-save-util.h
@@ -23,3 +23,4 @@ extern FLOOR_IDX max_floor_id;
 extern FLOOR_IDX new_floor_id;
 extern uint32_t latest_visit_mark;
 extern MonsterEntity party_mon[MAX_PARTY_MON];
+extern bool is_saved_floor(saved_floor_type *sf_ptr);

--- a/src/floor/floor-save.cpp
+++ b/src/floor/floor-save.cpp
@@ -165,13 +165,13 @@ static FLOOR_IDX find_oldest_floor_idx(PlayerType *player_ptr)
 }
 
 /*!
- * @brief 新規に利用可能な保存フロアを返す / Initialize new saved floor and get its floor id.
+ * @brief 新規に利用可能なフロアIDを返す / Initialize new floor and get its floor id.
  * @param player_ptr プレイヤーへの参照ポインタ
- * @return 利用可能な保存フロアID
+ * @return 利用可能なフロアID
  * @details
  * If number of saved floors are already MAX_SAVED_FLOORS, kill the oldest one.
  */
-FLOOR_IDX get_new_floor_id(PlayerType *player_ptr)
+FLOOR_IDX get_unused_floor_id(PlayerType *player_ptr)
 {
     saved_floor_type *sf_ptr = nullptr;
     FLOOR_IDX fl_idx;

--- a/src/floor/floor-save.cpp
+++ b/src/floor/floor-save.cpp
@@ -92,7 +92,7 @@ void clear_saved_floor_files(PlayerType *player_ptr)
 {
     for (int i = 0; i < MAX_SAVED_FLOORS; i++) {
         saved_floor_type *sf_ptr = &saved_floors[i];
-        if ((sf_ptr->floor_id == 0) || (sf_ptr->floor_id == player_ptr->floor_id)) {
+        if (!is_saved_floor(sf_ptr) || (sf_ptr->floor_id == player_ptr->floor_id)) {
             continue;
         }
 
@@ -130,7 +130,7 @@ saved_floor_type *get_sf_ptr(FLOOR_IDX floor_id)
  */
 void kill_saved_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr)
 {
-    if (!sf_ptr || (sf_ptr->floor_id == 0)) {
+    if (!sf_ptr || !is_saved_floor(sf_ptr)) {
         return;
     }
 
@@ -177,7 +177,7 @@ FLOOR_IDX get_new_floor_id(PlayerType *player_ptr)
     FLOOR_IDX fl_idx;
     for (fl_idx = 0; fl_idx < MAX_SAVED_FLOORS; fl_idx++) {
         sf_ptr = &saved_floors[fl_idx];
-        if (!sf_ptr->floor_id) {
+        if (!is_saved_floor(sf_ptr)) {
             break;
         }
     }

--- a/src/floor/floor-save.h
+++ b/src/floor/floor-save.h
@@ -8,6 +8,6 @@ void init_saved_floors(PlayerType *player_ptr, bool force);
 void clear_saved_floor_files(PlayerType *player_ptr);
 saved_floor_type *get_sf_ptr(FLOOR_IDX floor_id);
 void kill_saved_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr);
-FLOOR_IDX get_new_floor_id(PlayerType *player_ptr);
+FLOOR_IDX get_unused_floor_id(PlayerType *player_ptr);
 void precalc_cur_num_of_pet(PlayerType *player_ptr);
 extern FLOOR_IDX max_floor_id;

--- a/src/load/dungeon-loader.cpp
+++ b/src/load/dungeon-loader.cpp
@@ -33,7 +33,7 @@ static errr rd_dungeon(PlayerType *player_ptr)
     if (h_older_than(1, 5, 0, 0)) {
         err = rd_dungeon_old(player_ptr);
         if (floor.dungeon_idx) {
-            player_ptr->floor_id = get_new_floor_id(player_ptr);
+            player_ptr->floor_id = get_unused_floor_id(player_ptr);
             get_sf_ptr(player_ptr->floor_id)->dun_level = floor.dun_level;
         }
 

--- a/src/load/dungeon-loader.cpp
+++ b/src/load/dungeon-loader.cpp
@@ -62,7 +62,7 @@ static errr rd_dungeon(PlayerType *player_ptr)
 
         for (int i = 0; i < num; i++) {
             saved_floor_type *sf_ptr = &saved_floors[i];
-            if (!sf_ptr->floor_id) {
+            if (!is_saved_floor(sf_ptr)) {
                 continue;
             }
             if (rd_byte() != 0) {

--- a/src/save/floor-writer.cpp
+++ b/src/save/floor-writer.cpp
@@ -195,7 +195,7 @@ bool wr_dungeon(PlayerType *player_ptr)
 
     for (int i = 0; i < MAX_SAVED_FLOORS; i++) {
         saved_floor_type *sf_ptr = &saved_floors[i];
-        if (!sf_ptr->floor_id) {
+        if (!is_saved_floor(sf_ptr)) {
             continue;
         }
         if (!load_floor(player_ptr, sf_ptr, (SLF_SECOND | SLF_NO_KILL))) {

--- a/src/save/floor-writer.cpp
+++ b/src/save/floor-writer.cpp
@@ -167,7 +167,7 @@ bool wr_dungeon(PlayerType *player_ptr)
     RedrawingFlagsUpdater::get_instance().set_flags(flags);
     wr_s16b(max_floor_id);
     wr_byte((byte)player_ptr->current_floor_ptr->dungeon_idx);
-    if (!player_ptr->floor_id) {
+    if (!player_ptr->in_saved_floor()) {
         /* No array elements */
         wr_byte(0);
         wr_saved_floor(player_ptr, nullptr);

--- a/src/spell-kind/spells-grid.cpp
+++ b/src/spell-kind/spells-grid.cpp
@@ -90,7 +90,7 @@ void stair_creation(PlayerType *player_ptr)
     saved_floor_type *sf_ptr;
     sf_ptr = get_sf_ptr(player_ptr->floor_id);
     if (!sf_ptr) {
-        player_ptr->floor_id = get_new_floor_id(player_ptr);
+        player_ptr->floor_id = get_unused_floor_id(player_ptr);
         sf_ptr = get_sf_ptr(player_ptr->floor_id);
     }
 
@@ -133,7 +133,7 @@ void stair_creation(PlayerType *player_ptr)
             }
         }
     } else {
-        dest_floor_id = get_new_floor_id(player_ptr);
+        dest_floor_id = get_unused_floor_id(player_ptr);
         if (up) {
             sf_ptr->upper_floor_id = dest_floor_id;
         } else {

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -124,3 +124,8 @@ bool PlayerType::is_located_at(const Pos2D &pos) const
 {
     return (this->y == pos.y) && (this->x == pos.x);
 }
+
+bool PlayerType::in_saved_floor() const
+{
+    return this->floor_id != 0;
+}

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -405,6 +405,7 @@ public:
     Pos2D get_position() const;
     bool is_located_at_running_destination() const;
     bool is_located_at(const Pos2D &pos) const;
+    bool in_saved_floor() const;
 
 private:
     std::shared_ptr<TimedEffects> timed_effects;


### PR DESCRIPTION
フロア移動関連の処理で難読な部分を少しでも改善する。
動作変更は行わず、関数への切り出しと括り方の変更のみ。