### PR TITLE
[Refacotr] MONSTER_IDX周りの処理の可読性向上

### DIFF
--- a/src/action/movement-execution.cpp
+++ b/src/action/movement-execution.cpp
@@ -26,7 +26,6 @@
 #include "monster/monster-info.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
-#include "monster/monster-util.h"
 #include "mutation/mutation-flag-types.h"
 #include "object/warning.h"
 #include "player-base/player-class.h"
@@ -166,7 +165,7 @@ void exe_movement(PlayerType *player_ptr, DIRECTION dir, bool do_pickup, bool br
     std::string m_name;
     bool can_move = true;
     bool do_past = false;
-    if (is_monster(grid.m_idx) && (m_ptr->ml || p_can_enter || p_can_kill_walls)) {
+    if (grid.has_monster() && (m_ptr->ml || p_can_enter || p_can_kill_walls)) {
         auto *r_ptr = &m_ptr->get_monrace();
         auto effects = player_ptr->effects();
         auto is_stunned = effects->stun()->is_stunned();

--- a/src/action/movement-execution.cpp
+++ b/src/action/movement-execution.cpp
@@ -26,6 +26,7 @@
 #include "monster/monster-info.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
+#include "monster/monster-util.h"
 #include "mutation/mutation-flag-types.h"
 #include "object/warning.h"
 #include "player-base/player-class.h"
@@ -165,7 +166,7 @@ void exe_movement(PlayerType *player_ptr, DIRECTION dir, bool do_pickup, bool br
     std::string m_name;
     bool can_move = true;
     bool do_past = false;
-    if (grid.m_idx && (m_ptr->ml || p_can_enter || p_can_kill_walls)) {
+    if (is_monster(grid.m_idx) && (m_ptr->ml || p_can_enter || p_can_kill_walls)) {
         auto *r_ptr = &m_ptr->get_monrace();
         auto effects = player_ptr->effects();
         auto is_stunned = effects->stun()->is_stunned();

--- a/src/action/mutation-execution.cpp
+++ b/src/action/mutation-execution.cpp
@@ -23,6 +23,7 @@
 #include "monster/monster-description-types.h"
 #include "monster/monster-flag-types.h"
 #include "monster/monster-info.h"
+#include "monster/monster-util.h"
 #include "mutation/mutation-flag-types.h"
 #include "mutation/mutation-techniques.h"
 #include "object-enchant/item-feeling.h"
@@ -247,7 +248,7 @@ bool exe_mutation_power(PlayerType *player_ptr, PlayerMutationType power)
         const auto y = player_ptr->y + ddy[dir];
         const auto x = player_ptr->x + ddx[dir];
         const auto &grid = floor.grid_array[y][x];
-        if (!grid.m_idx) {
+        if (!is_monster(grid.m_idx)) {
             msg_print(_("邪悪な存在を感じとれません！", "You sense no evil there!"));
             return true;
         }
@@ -287,7 +288,7 @@ bool exe_mutation_power(PlayerType *player_ptr, PlayerMutationType power)
         const auto y = player_ptr->y + ddy[dir];
         const auto x = player_ptr->x + ddx[dir];
         auto &grid = floor.grid_array[y][x];
-        if (!grid.m_idx) {
+        if (!is_monster(grid.m_idx)) {
             msg_print(_("あなたは何もない場所で手を振った。", "You wave your hands in the air."));
             return true;
         }

--- a/src/action/mutation-execution.cpp
+++ b/src/action/mutation-execution.cpp
@@ -23,7 +23,6 @@
 #include "monster/monster-description-types.h"
 #include "monster/monster-flag-types.h"
 #include "monster/monster-info.h"
-#include "monster/monster-util.h"
 #include "mutation/mutation-flag-types.h"
 #include "mutation/mutation-techniques.h"
 #include "object-enchant/item-feeling.h"
@@ -248,7 +247,7 @@ bool exe_mutation_power(PlayerType *player_ptr, PlayerMutationType power)
         const auto y = player_ptr->y + ddy[dir];
         const auto x = player_ptr->x + ddx[dir];
         const auto &grid = floor.grid_array[y][x];
-        if (!is_monster(grid.m_idx)) {
+        if (!grid.has_monster()) {
             msg_print(_("邪悪な存在を感じとれません！", "You sense no evil there!"));
             return true;
         }
@@ -288,7 +287,7 @@ bool exe_mutation_power(PlayerType *player_ptr, PlayerMutationType power)
         const auto y = player_ptr->y + ddy[dir];
         const auto x = player_ptr->x + ddx[dir];
         auto &grid = floor.grid_array[y][x];
-        if (!is_monster(grid.m_idx)) {
+        if (!grid.has_monster()) {
             msg_print(_("あなたは何もない場所で手を振った。", "You wave your hands in the air."));
             return true;
         }

--- a/src/action/run-execution.cpp
+++ b/src/action/run-execution.cpp
@@ -13,6 +13,7 @@
 #include "grid/grid.h"
 #include "main/sound-definitions-table.h"
 #include "main/sound-of-music.h"
+#include "monster/monster-util.h"
 #include "object/object-mark-types.h"
 #include "player-status/player-energy.h"
 #include "player/player-status-flags.h"
@@ -226,7 +227,7 @@ static bool run_test(PlayerType *player_ptr)
         int new_dir = cycle[chome[prev_dir] + i];
         const Pos2D pos(player_ptr->y + ddy[new_dir], player_ptr->x + ddx[new_dir]);
         const auto &grid = floor.get_grid(pos);
-        if (grid.m_idx) {
+        if (is_monster(grid.m_idx)) {
             const auto &monster = floor.m_list[grid.m_idx];
             if (monster.ml) {
                 return true;

--- a/src/action/run-execution.cpp
+++ b/src/action/run-execution.cpp
@@ -13,7 +13,6 @@
 #include "grid/grid.h"
 #include "main/sound-definitions-table.h"
 #include "main/sound-of-music.h"
-#include "monster/monster-util.h"
 #include "object/object-mark-types.h"
 #include "player-status/player-energy.h"
 #include "player/player-status-flags.h"
@@ -227,7 +226,7 @@ static bool run_test(PlayerType *player_ptr)
         int new_dir = cycle[chome[prev_dir] + i];
         const Pos2D pos(player_ptr->y + ddy[new_dir], player_ptr->x + ddx[new_dir]);
         const auto &grid = floor.get_grid(pos);
-        if (is_monster(grid.m_idx)) {
+        if (grid.has_monster()) {
             const auto &monster = floor.m_list[grid.m_idx];
             if (monster.ml) {
                 return true;

--- a/src/action/travel-execution.cpp
+++ b/src/action/travel-execution.cpp
@@ -13,6 +13,7 @@
 #include "game-option/special-options.h"
 #include "grid/feature.h"
 #include "grid/grid.h"
+#include "monster/monster-util.h"
 #include "player-status/player-energy.h"
 #include "player/player-move.h"
 #include "system/floor-type-definition.h"
@@ -61,7 +62,7 @@ static DIRECTION travel_test(PlayerType *player_ptr, DIRECTION prev_dir)
         POSITION row = player_ptr->y + ddy[dir];
         POSITION col = player_ptr->x + ddx[dir];
         g_ptr = &floor_ptr->grid_array[row][col];
-        if (g_ptr->m_idx) {
+        if (is_monster(g_ptr->m_idx)) {
             auto *m_ptr = &floor_ptr->m_list[g_ptr->m_idx];
             if (m_ptr->ml) {
                 return 0;

--- a/src/action/travel-execution.cpp
+++ b/src/action/travel-execution.cpp
@@ -13,7 +13,6 @@
 #include "game-option/special-options.h"
 #include "grid/feature.h"
 #include "grid/grid.h"
-#include "monster/monster-util.h"
 #include "player-status/player-energy.h"
 #include "player/player-move.h"
 #include "system/floor-type-definition.h"
@@ -62,7 +61,7 @@ static DIRECTION travel_test(PlayerType *player_ptr, DIRECTION prev_dir)
         POSITION row = player_ptr->y + ddy[dir];
         POSITION col = player_ptr->x + ddx[dir];
         g_ptr = &floor_ptr->grid_array[row][col];
-        if (is_monster(g_ptr->m_idx)) {
+        if (g_ptr->has_monster()) {
             auto *m_ptr = &floor_ptr->m_list[g_ptr->m_idx];
             if (m_ptr->ml) {
                 return 0;

--- a/src/blue-magic/blue-magic-caster.cpp
+++ b/src/blue-magic/blue-magic-caster.cpp
@@ -18,6 +18,7 @@
 #include "monster/monster-describer.h"
 #include "monster/monster-info.h"
 #include "monster/monster-status.h"
+#include "monster/monster-util.h"
 #include "mspell/mspell-damage-calculator.h"
 #include "spell-kind/spells-launcher.h"
 #include "spell-kind/spells-lite.h"
@@ -99,7 +100,7 @@ static std::optional<std::string> exe_blue_teleport_back(PlayerType *player_ptr)
     const auto &floor = *player_ptr->current_floor_ptr;
     const Pos2D pos(target_row, target_col);
     const auto &grid = floor.get_grid(pos);
-    if ((grid.m_idx == 0) || !grid.has_los() || !projectable(player_ptr, player_ptr->y, player_ptr->x, target_row, target_col)) {
+    if (!is_monster(grid.m_idx) || !grid.has_los() || !projectable(player_ptr, player_ptr->y, player_ptr->x, target_row, target_col)) {
         return std::nullopt;
     }
 

--- a/src/blue-magic/blue-magic-caster.cpp
+++ b/src/blue-magic/blue-magic-caster.cpp
@@ -18,7 +18,6 @@
 #include "monster/monster-describer.h"
 #include "monster/monster-info.h"
 #include "monster/monster-status.h"
-#include "monster/monster-util.h"
 #include "mspell/mspell-damage-calculator.h"
 #include "spell-kind/spells-launcher.h"
 #include "spell-kind/spells-lite.h"
@@ -100,7 +99,7 @@ static std::optional<std::string> exe_blue_teleport_back(PlayerType *player_ptr)
     const auto &floor = *player_ptr->current_floor_ptr;
     const Pos2D pos(target_row, target_col);
     const auto &grid = floor.get_grid(pos);
-    if (!is_monster(grid.m_idx) || !grid.has_los() || !projectable(player_ptr, player_ptr->y, player_ptr->x, target_row, target_col)) {
+    if (!grid.has_monster() || !grid.has_los() || !projectable(player_ptr, player_ptr->y, player_ptr->x, target_row, target_col)) {
         return std::nullopt;
     }
 

--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -34,7 +34,6 @@
 #include "monster/monster-info.h"
 #include "monster/monster-processor.h"
 #include "monster/monster-status.h"
-#include "monster/monster-util.h"
 #include "mspell/monster-power-table.h"
 #include "player-base/player-class.h"
 #include "player-info/mane-data-type.h"
@@ -961,7 +960,7 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
         const auto &floor = *player_ptr->current_floor_ptr;
         const Pos2D pos(target_row, target_col);
         const auto &grid_target = floor.get_grid(pos);
-        auto should_teleport = !is_monster(grid_target.m_idx);
+        auto should_teleport = !grid_target.has_monster();
         should_teleport &= grid_target.has_los();
         should_teleport &= projectable(player_ptr, player_ptr->y, player_ptr->x, target_row, target_col);
         if (!should_teleport) {

--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -960,7 +960,7 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
         const auto &floor = *player_ptr->current_floor_ptr;
         const Pos2D pos(target_row, target_col);
         const auto &grid_target = floor.get_grid(pos);
-        auto should_teleport = !grid_target.has_monster();
+        auto should_teleport = grid_target.has_monster();
         should_teleport &= grid_target.has_los();
         should_teleport &= projectable(player_ptr, player_ptr->y, player_ptr->x, target_row, target_col);
         if (!should_teleport) {

--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -34,6 +34,7 @@
 #include "monster/monster-info.h"
 #include "monster/monster-processor.h"
 #include "monster/monster-status.h"
+#include "monster/monster-util.h"
 #include "mspell/monster-power-table.h"
 #include "player-base/player-class.h"
 #include "player-info/mane-data-type.h"
@@ -960,7 +961,7 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
         const auto &floor = *player_ptr->current_floor_ptr;
         const Pos2D pos(target_row, target_col);
         const auto &grid_target = floor.get_grid(pos);
-        auto should_teleport = grid_target.m_idx == 0;
+        auto should_teleport = !is_monster(grid_target.m_idx);
         should_teleport &= grid_target.has_los();
         should_teleport &= projectable(player_ptr, player_ptr->y, player_ptr->x, target_row, target_col);
         if (!should_teleport) {

--- a/src/cmd-action/cmd-open-close.cpp
+++ b/src/cmd-action/cmd-open-close.cpp
@@ -11,7 +11,6 @@
 #include "inventory/inventory-object.h"
 #include "inventory/inventory-slot-types.h"
 #include "io/input-key-requester.h"
-#include "monster/monster-util.h"
 #include "object/tval-types.h"
 #include "player-base/player-class.h"
 #include "player-info/samurai-data-type.h"
@@ -131,7 +130,7 @@ void do_cmd_open(PlayerType *player_ptr)
         const auto o_idx = chest_check(player_ptr->current_floor_ptr, pos, false);
         if (grid.get_terrain_mimic().flags.has_not(TerrainCharacteristics::OPEN) && !o_idx) {
             msg_print(_("そこには開けるものが見当たらない。", "You see nothing there to open."));
-        } else if (is_monster(grid.m_idx) && player_ptr->riding != grid.m_idx) {
+        } else if (grid.has_monster() && player_ptr->riding != grid.m_idx) {
             PlayerEnergy(player_ptr).set_player_turn_energy(100);
             msg_print(_("モンスターが立ちふさがっている！", "There is a monster in the way!"));
             do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_NONE);
@@ -180,7 +179,7 @@ void do_cmd_close(PlayerType *player_ptr)
         const auto &grid = player_ptr->current_floor_ptr->get_grid(pos);
         if (grid.get_terrain_mimic().flags.has_not(TerrainCharacteristics::CLOSE)) {
             msg_print(_("そこには閉じるものが見当たらない。", "You see nothing there to close."));
-        } else if (is_monster(grid.m_idx)) {
+        } else if (grid.has_monster()) {
             PlayerEnergy(player_ptr).set_player_turn_energy(100);
             msg_print(_("モンスターが立ちふさがっている！", "There is a monster in the way!"));
             do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_NONE);
@@ -232,7 +231,7 @@ void do_cmd_disarm(PlayerType *player_ptr)
         const auto o_idx = chest_check(player_ptr->current_floor_ptr, pos, true);
         if (!is_trap(player_ptr, feat) && !o_idx) {
             msg_print(_("そこには解除するものが見当たらない。", "You see nothing there to disarm."));
-        } else if (is_monster(grid.m_idx) && player_ptr->riding != grid.m_idx) {
+        } else if (grid.has_monster() && player_ptr->riding != grid.m_idx) {
             msg_print(_("モンスターが立ちふさがっている！", "There is a monster in the way!"));
             do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_NONE);
         } else if (o_idx) {
@@ -285,7 +284,7 @@ void do_cmd_bash(PlayerType *player_ptr)
         const Grid &grid = player_ptr->current_floor_ptr->get_grid(pos);
         if (grid.get_terrain_mimic().flags.has_not(TerrainCharacteristics::BASH)) {
             msg_print(_("そこには体当たりするものが見当たらない。", "You see nothing there to bash."));
-        } else if (is_monster(grid.m_idx)) {
+        } else if (grid.has_monster()) {
             PlayerEnergy(player_ptr).set_player_turn_energy(100);
             msg_print(_("モンスターが立ちふさがっている！", "There is a monster in the way!"));
             do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_NONE);
@@ -356,7 +355,7 @@ void do_cmd_spike(PlayerType *player_ptr)
         msg_print(_("そこにはくさびを打てるものが見当たらない。", "You see nothing there to spike."));
     } else if (!get_spike(player_ptr, &i_idx)) {
         msg_print(_("くさびを持っていない！", "You have no spikes!"));
-    } else if (is_monster(grid.m_idx)) {
+    } else if (grid.has_monster()) {
         PlayerEnergy(player_ptr).set_player_turn_energy(100);
         msg_print(_("モンスターが立ちふさがっている！", "There is a monster in the way!"));
         do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_NONE);

--- a/src/cmd-action/cmd-open-close.cpp
+++ b/src/cmd-action/cmd-open-close.cpp
@@ -11,6 +11,7 @@
 #include "inventory/inventory-object.h"
 #include "inventory/inventory-slot-types.h"
 #include "io/input-key-requester.h"
+#include "monster/monster-util.h"
 #include "object/tval-types.h"
 #include "player-base/player-class.h"
 #include "player-info/samurai-data-type.h"
@@ -130,7 +131,7 @@ void do_cmd_open(PlayerType *player_ptr)
         const auto o_idx = chest_check(player_ptr->current_floor_ptr, pos, false);
         if (grid.get_terrain_mimic().flags.has_not(TerrainCharacteristics::OPEN) && !o_idx) {
             msg_print(_("そこには開けるものが見当たらない。", "You see nothing there to open."));
-        } else if (grid.m_idx && player_ptr->riding != grid.m_idx) {
+        } else if (is_monster(grid.m_idx) && player_ptr->riding != grid.m_idx) {
             PlayerEnergy(player_ptr).set_player_turn_energy(100);
             msg_print(_("モンスターが立ちふさがっている！", "There is a monster in the way!"));
             do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_NONE);
@@ -179,7 +180,7 @@ void do_cmd_close(PlayerType *player_ptr)
         const auto &grid = player_ptr->current_floor_ptr->get_grid(pos);
         if (grid.get_terrain_mimic().flags.has_not(TerrainCharacteristics::CLOSE)) {
             msg_print(_("そこには閉じるものが見当たらない。", "You see nothing there to close."));
-        } else if (grid.m_idx) {
+        } else if (is_monster(grid.m_idx)) {
             PlayerEnergy(player_ptr).set_player_turn_energy(100);
             msg_print(_("モンスターが立ちふさがっている！", "There is a monster in the way!"));
             do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_NONE);
@@ -231,7 +232,7 @@ void do_cmd_disarm(PlayerType *player_ptr)
         const auto o_idx = chest_check(player_ptr->current_floor_ptr, pos, true);
         if (!is_trap(player_ptr, feat) && !o_idx) {
             msg_print(_("そこには解除するものが見当たらない。", "You see nothing there to disarm."));
-        } else if (grid.m_idx && player_ptr->riding != grid.m_idx) {
+        } else if (is_monster(grid.m_idx) && player_ptr->riding != grid.m_idx) {
             msg_print(_("モンスターが立ちふさがっている！", "There is a monster in the way!"));
             do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_NONE);
         } else if (o_idx) {
@@ -284,7 +285,7 @@ void do_cmd_bash(PlayerType *player_ptr)
         const Grid &grid = player_ptr->current_floor_ptr->get_grid(pos);
         if (grid.get_terrain_mimic().flags.has_not(TerrainCharacteristics::BASH)) {
             msg_print(_("そこには体当たりするものが見当たらない。", "You see nothing there to bash."));
-        } else if (grid.m_idx) {
+        } else if (is_monster(grid.m_idx)) {
             PlayerEnergy(player_ptr).set_player_turn_energy(100);
             msg_print(_("モンスターが立ちふさがっている！", "There is a monster in the way!"));
             do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_NONE);
@@ -355,7 +356,7 @@ void do_cmd_spike(PlayerType *player_ptr)
         msg_print(_("そこにはくさびを打てるものが見当たらない。", "You see nothing there to spike."));
     } else if (!get_spike(player_ptr, &i_idx)) {
         msg_print(_("くさびを持っていない！", "You have no spikes!"));
-    } else if (grid.m_idx) {
+    } else if (is_monster(grid.m_idx)) {
         PlayerEnergy(player_ptr).set_player_turn_energy(100);
         msg_print(_("モンスターが立ちふさがっている！", "There is a monster in the way!"));
         do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_NONE);

--- a/src/cmd-action/cmd-others.cpp
+++ b/src/cmd-action/cmd-others.cpp
@@ -23,7 +23,6 @@
 #include "io/write-diary.h"
 #include "main/music-definitions-table.h"
 #include "main/sound-of-music.h"
-#include "monster/monster-util.h"
 #include "player-base/player-class.h"
 #include "player-info/samurai-data-type.h"
 #include "player-status/player-energy.h"
@@ -72,7 +71,7 @@ static bool exe_alter(PlayerType *player_ptr)
     const auto &grid = player_ptr->current_floor_ptr->get_grid(pos);
     const auto &terrain = grid.get_terrain_mimic();
     PlayerEnergy(player_ptr).set_player_turn_energy(100);
-    if (is_monster(grid.m_idx)) {
+    if (grid.has_monster()) {
         do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_NONE);
         return false;
     }

--- a/src/cmd-action/cmd-others.cpp
+++ b/src/cmd-action/cmd-others.cpp
@@ -23,6 +23,7 @@
 #include "io/write-diary.h"
 #include "main/music-definitions-table.h"
 #include "main/sound-of-music.h"
+#include "monster/monster-util.h"
 #include "player-base/player-class.h"
 #include "player-info/samurai-data-type.h"
 #include "player-status/player-energy.h"
@@ -71,7 +72,7 @@ static bool exe_alter(PlayerType *player_ptr)
     const auto &grid = player_ptr->current_floor_ptr->get_grid(pos);
     const auto &terrain = grid.get_terrain_mimic();
     PlayerEnergy(player_ptr).set_player_turn_energy(100);
-    if (grid.m_idx) {
+    if (is_monster(grid.m_idx)) {
         do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_NONE);
         return false;
     }

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -28,6 +28,7 @@
 #include "monster/monster-info.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
+#include "monster/monster-util.h"
 #include "monster/smart-learn-types.h"
 #include "object-hook/hook-weapon.h"
 #include "pet/pet-util.h"
@@ -218,7 +219,7 @@ bool do_cmd_riding(PlayerType *player_ptr, bool force)
             return false;
         }
 
-        if (grid.m_idx) {
+        if (is_monster(grid.m_idx)) {
             PlayerEnergy(player_ptr).set_player_turn_energy(100);
 
             msg_print(_("モンスターが立ちふさがっている！", "There is a monster in the way!"));
@@ -237,7 +238,7 @@ bool do_cmd_riding(PlayerType *player_ptr, bool force)
 
         const auto *m_ptr = &player_ptr->current_floor_ptr->m_list[grid.m_idx];
 
-        if (!grid.m_idx || !m_ptr->ml) {
+        if (!is_monster(grid.m_idx) || !m_ptr->ml) {
             msg_print(_("その場所にはモンスターはいません。", "There is no monster here."));
             return false;
         }
@@ -326,7 +327,7 @@ static void do_name_pet(PlayerType *player_ptr)
     target_pet = old_target_pet;
     auto &floor = *player_ptr->current_floor_ptr;
     const auto &grid = floor.grid_array[target_row][target_col];
-    if (grid.m_idx == 0) {
+    if (!is_monster(grid.m_idx)) {
         return;
     }
 
@@ -703,7 +704,7 @@ void do_cmd_pet(PlayerType *player_ptr)
             player_ptr->pet_t_m_idx = 0;
         } else {
             auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[target_row][target_col];
-            if (g_ptr->m_idx && (player_ptr->current_floor_ptr->m_list[g_ptr->m_idx].ml)) {
+            if (is_monster(g_ptr->m_idx) && (player_ptr->current_floor_ptr->m_list[g_ptr->m_idx].ml)) {
                 player_ptr->pet_t_m_idx = player_ptr->current_floor_ptr->grid_array[target_row][target_col].m_idx;
                 player_ptr->pet_follow_distance = PET_DESTROY_DIST;
             } else {

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -28,7 +28,6 @@
 #include "monster/monster-info.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
-#include "monster/monster-util.h"
 #include "monster/smart-learn-types.h"
 #include "object-hook/hook-weapon.h"
 #include "pet/pet-util.h"
@@ -219,7 +218,7 @@ bool do_cmd_riding(PlayerType *player_ptr, bool force)
             return false;
         }
 
-        if (is_monster(grid.m_idx)) {
+        if (grid.has_monster()) {
             PlayerEnergy(player_ptr).set_player_turn_energy(100);
 
             msg_print(_("モンスターが立ちふさがっている！", "There is a monster in the way!"));
@@ -238,7 +237,7 @@ bool do_cmd_riding(PlayerType *player_ptr, bool force)
 
         const auto *m_ptr = &player_ptr->current_floor_ptr->m_list[grid.m_idx];
 
-        if (!is_monster(grid.m_idx) || !m_ptr->ml) {
+        if (!grid.has_monster() || !m_ptr->ml) {
             msg_print(_("その場所にはモンスターはいません。", "There is no monster here."));
             return false;
         }
@@ -327,7 +326,7 @@ static void do_name_pet(PlayerType *player_ptr)
     target_pet = old_target_pet;
     auto &floor = *player_ptr->current_floor_ptr;
     const auto &grid = floor.grid_array[target_row][target_col];
-    if (!is_monster(grid.m_idx)) {
+    if (!grid.has_monster()) {
         return;
     }
 
@@ -704,7 +703,7 @@ void do_cmd_pet(PlayerType *player_ptr)
             player_ptr->pet_t_m_idx = 0;
         } else {
             auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[target_row][target_col];
-            if (is_monster(g_ptr->m_idx) && (player_ptr->current_floor_ptr->m_list[g_ptr->m_idx].ml)) {
+            if (g_ptr->has_monster() && (player_ptr->current_floor_ptr->m_list[g_ptr->m_idx].ml)) {
                 player_ptr->pet_t_m_idx = player_ptr->current_floor_ptr->grid_array[target_row][target_col].m_idx;
                 player_ptr->pet_follow_distance = PET_DESTROY_DIST;
             } else {

--- a/src/cmd-action/cmd-tunnel.cpp
+++ b/src/cmd-action/cmd-tunnel.cpp
@@ -5,6 +5,7 @@
 #include "floor/geometry.h"
 #include "grid/grid.h"
 #include "io/input-key-requester.h"
+#include "monster/monster-util.h"
 #include "player-base/player-class.h"
 #include "player-info/samurai-data-type.h"
 #include "player-status/player-energy.h"
@@ -56,7 +57,7 @@ void do_cmd_tunnel(PlayerType *player_ptr)
         msg_print(_("ドアは掘れない。", "You cannot tunnel through doors."));
     } else if (terrain_mimic.flags.has_not(TerrainCharacteristics::TUNNEL)) {
         msg_print(_("そこは掘れない。", "You can't tunnel through that."));
-    } else if (grid.m_idx) {
+    } else if (is_monster(grid.m_idx)) {
         PlayerEnergy(player_ptr).set_player_turn_energy(100);
         msg_print(_("モンスターが立ちふさがっている！", "There is a monster in the way!"));
         do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_NONE);

--- a/src/cmd-action/cmd-tunnel.cpp
+++ b/src/cmd-action/cmd-tunnel.cpp
@@ -5,7 +5,6 @@
 #include "floor/geometry.h"
 #include "grid/grid.h"
 #include "io/input-key-requester.h"
-#include "monster/monster-util.h"
 #include "player-base/player-class.h"
 #include "player-info/samurai-data-type.h"
 #include "player-status/player-energy.h"
@@ -57,7 +56,7 @@ void do_cmd_tunnel(PlayerType *player_ptr)
         msg_print(_("ドアは掘れない。", "You cannot tunnel through doors."));
     } else if (terrain_mimic.flags.has_not(TerrainCharacteristics::TUNNEL)) {
         msg_print(_("そこは掘れない。", "You can't tunnel through that."));
-    } else if (is_monster(grid.m_idx)) {
+    } else if (grid.has_monster()) {
         PlayerEnergy(player_ptr).set_player_turn_energy(100);
         msg_print(_("モンスターが立ちふさがっている！", "There is a monster in the way!"));
         do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_NONE);

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -38,7 +38,6 @@
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
 #include "monster/monster-update.h"
-#include "monster/monster-util.h"
 #include "object/object-broken.h"
 #include "object/object-info.h"
 #include "object/object-mark-types.h"
@@ -633,7 +632,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX i_idx, ItemEntity *j_ptr, SP
             if (snipe_type == SP_KILL_WALL) {
                 g_ptr = &floor_ptr->grid_array[ny][nx];
 
-                if (g_ptr->cave_has_flag(TerrainCharacteristics::HURT_ROCK) && !is_monster(g_ptr->m_idx)) {
+                if (g_ptr->cave_has_flag(TerrainCharacteristics::HURT_ROCK) && !g_ptr->has_monster()) {
                     if (any_bits(g_ptr->info, (CAVE_MARK))) {
                         msg_print(_("岩が砕け散った。", "Wall rocks were shattered."));
                     }
@@ -656,7 +655,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX i_idx, ItemEntity *j_ptr, SP
             }
 
             /* Stopped by walls/doors */
-            if (!cave_has_flag_bold(floor_ptr, ny, nx, TerrainCharacteristics::PROJECT) && !is_monster(floor_ptr->grid_array[ny][nx].m_idx)) {
+            if (!cave_has_flag_bold(floor_ptr, ny, nx, TerrainCharacteristics::PROJECT) && !floor_ptr->grid_array[ny][nx].has_monster()) {
                 break;
             }
 
@@ -715,7 +714,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX i_idx, ItemEntity *j_ptr, SP
             y = ny;
 
             /* Monster here, Try to hit it */
-            if (is_monster(floor_ptr->grid_array[y][x].m_idx)) {
+            if (floor_ptr->grid_array[y][x].has_monster()) {
                 sound(SOUND_SHOOT_HIT);
                 Grid *c_mon_ptr = &floor_ptr->grid_array[y][x];
 

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -38,6 +38,7 @@
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
 #include "monster/monster-update.h"
+#include "monster/monster-util.h"
 #include "object/object-broken.h"
 #include "object/object-info.h"
 #include "object/object-mark-types.h"
@@ -632,7 +633,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX i_idx, ItemEntity *j_ptr, SP
             if (snipe_type == SP_KILL_WALL) {
                 g_ptr = &floor_ptr->grid_array[ny][nx];
 
-                if (g_ptr->cave_has_flag(TerrainCharacteristics::HURT_ROCK) && !g_ptr->m_idx) {
+                if (g_ptr->cave_has_flag(TerrainCharacteristics::HURT_ROCK) && !is_monster(g_ptr->m_idx)) {
                     if (any_bits(g_ptr->info, (CAVE_MARK))) {
                         msg_print(_("岩が砕け散った。", "Wall rocks were shattered."));
                     }
@@ -655,7 +656,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX i_idx, ItemEntity *j_ptr, SP
             }
 
             /* Stopped by walls/doors */
-            if (!cave_has_flag_bold(floor_ptr, ny, nx, TerrainCharacteristics::PROJECT) && !floor_ptr->grid_array[ny][nx].m_idx) {
+            if (!cave_has_flag_bold(floor_ptr, ny, nx, TerrainCharacteristics::PROJECT) && !is_monster(floor_ptr->grid_array[ny][nx].m_idx)) {
                 break;
             }
 
@@ -714,7 +715,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX i_idx, ItemEntity *j_ptr, SP
             y = ny;
 
             /* Monster here, Try to hit it */
-            if (floor_ptr->grid_array[y][x].m_idx) {
+            if (is_monster(floor_ptr->grid_array[y][x].m_idx)) {
                 sound(SOUND_SHOOT_HIT);
                 Grid *c_mon_ptr = &floor_ptr->grid_array[y][x];
 

--- a/src/effect/effect-feature.cpp
+++ b/src/effect/effect-feature.cpp
@@ -44,7 +44,7 @@ static bool cave_naked_bold(PlayerType *player_ptr, const Pos2D &pos)
 /*!
  * @brief 汎用的なビーム/ボルト/ボール系による地形効果処理 / We are called from "project()" to "damage" terrain features
  * @param player_ptr プレイヤーへの参照ポインタ
- * @param who 魔法を発動したモンスター(0ならばプレイヤー) / Index of "source" monster (zero for "player")
+ * @param src_idx 魔法を発動したモンスター(0ならばプレイヤー) / Index of "source" monster (zero for "player")
  * @param r 効果半径(ビーム/ボルト = 0 / ボール = 1以上) / Radius of explosion (0 = beam/bolt, 1 to 9 = ball)
  * @param y 目標Y座標 / Target y location (or location to travel "towards")
  * @param x 目標X座標 / Target x location (or location to travel "towards")
@@ -67,7 +67,7 @@ static bool cave_naked_bold(PlayerType *player_ptr, const Pos2D &pos)
  * Perhaps we should affect doors?
  * </pre>
  */
-bool affect_feature(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITION y, POSITION x, int dam, AttributeType typ)
+bool affect_feature(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION r, POSITION y, POSITION x, int dam, AttributeType typ)
 {
     const Pos2D pos(y, x);
     auto &floor = *player_ptr->current_floor_ptr;
@@ -77,7 +77,7 @@ bool affect_feature(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITIO
     auto obvious = false;
     auto known = grid.has_los();
 
-    who = who ? who : 0;
+    src_idx = src_idx ? src_idx : 0;
     dam = (dam + r) / (r + 1);
 
     if (terrain.flags.has(TerrainCharacteristics::TREE)) {

--- a/src/effect/effect-feature.cpp
+++ b/src/effect/effect-feature.cpp
@@ -355,7 +355,7 @@ bool affect_feature(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION r, POS
         if (player_can_see_bold(player_ptr, y, x)) {
             obvious = true;
         }
-        if (is_monster(grid.m_idx)) {
+        if (grid.has_monster()) {
             update_monster(player_ptr, grid.m_idx, false);
         }
 
@@ -408,7 +408,7 @@ bool affect_feature(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION r, POS
         if (player_can_see_bold(player_ptr, y, x)) {
             obvious = true;
         }
-        if (is_monster(grid.m_idx)) {
+        if (grid.has_monster()) {
             update_monster(player_ptr, grid.m_idx, false);
         }
 

--- a/src/effect/effect-feature.cpp
+++ b/src/effect/effect-feature.cpp
@@ -12,6 +12,7 @@
 #include "mind/mind-elementalist.h"
 #include "mind/mind-ninja.h"
 #include "monster/monster-update.h"
+#include "monster/monster-util.h"
 #include "player/special-defense-types.h"
 #include "room/door-definition.h"
 #include "spell-class/spells-mirror-master.h"
@@ -77,7 +78,7 @@ bool affect_feature(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION r, POS
     auto obvious = false;
     auto known = grid.has_los();
 
-    src_idx = src_idx ? src_idx : 0;
+    src_idx = is_monster(src_idx) ? src_idx : 0;
     dam = (dam + r) / (r + 1);
 
     if (terrain.flags.has(TerrainCharacteristics::TREE)) {
@@ -354,7 +355,7 @@ bool affect_feature(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION r, POS
         if (player_can_see_bold(player_ptr, y, x)) {
             obvious = true;
         }
-        if (grid.m_idx) {
+        if (is_monster(grid.m_idx)) {
             update_monster(player_ptr, grid.m_idx, false);
         }
 
@@ -407,7 +408,7 @@ bool affect_feature(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION r, POS
         if (player_can_see_bold(player_ptr, y, x)) {
             obvious = true;
         }
-        if (grid.m_idx) {
+        if (is_monster(grid.m_idx)) {
             update_monster(player_ptr, grid.m_idx, false);
         }
 

--- a/src/effect/effect-feature.h
+++ b/src/effect/effect-feature.h
@@ -4,4 +4,4 @@
 #include "system/angband.h"
 
 class PlayerType;
-bool affect_feature(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITION y, POSITION x, int dam, AttributeType typ);
+bool affect_feature(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION r, POSITION y, POSITION x, int dam, AttributeType typ);

--- a/src/effect/effect-item.cpp
+++ b/src/effect/effect-item.cpp
@@ -7,6 +7,7 @@
 #include "monster-floor/monster-summon.h"
 #include "monster-floor/place-monster-types.h"
 #include "monster/monster-info.h"
+#include "monster/monster-util.h"
 #include "object-enchant/tr-types.h"
 #include "object-hook/hook-expendable.h"
 #include "object/object-broken.h"
@@ -42,7 +43,7 @@ bool affect_item(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION r, POSITI
 
     auto is_item_affected = false;
     const auto known = grid.has_los();
-    src_idx = src_idx ? src_idx : 0;
+    src_idx = is_monster(src_idx) ? src_idx : 0;
     dam = (dam + r) / (r + 1);
     std::set<OBJECT_IDX> processed_list;
     for (auto it = grid.o_idx_list.begin(); it != grid.o_idx_list.end();) {
@@ -227,7 +228,7 @@ bool affect_item(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION r, POSITI
             }
 
             BIT_FLAGS mode = 0L;
-            if (!src_idx || player_ptr->current_floor_ptr->m_list[src_idx].is_pet()) {
+            if (is_monster(src_idx) || player_ptr->current_floor_ptr->m_list[src_idx].is_pet()) {
                 mode |= PM_FORCE_PET;
             }
 

--- a/src/effect/effect-item.cpp
+++ b/src/effect/effect-item.cpp
@@ -26,7 +26,7 @@
 /*!
  * @brief 汎用的なビーム/ボルト/ボール系によるアイテムオブジェクトへの効果処理 / Handle a beam/bolt/ball causing damage to a monster.
  * @param player_ptr プレイヤーへの参照ポインタ
- * @param who 魔法を発動したモンスター(0ならばプレイヤー) / Index of "source" monster (zero for "player")
+ * @param src_idx 魔法を発動したモンスター(0ならばプレイヤー) / Index of "source" monster (zero for "player")
  * @param r 効果半径(ビーム/ボルト = 0 / ボール = 1以上) / Radius of explosion (0 = beam/bolt, 1 to 9 = ball)
  * @param y 目標Y座標 / Target y location (or location to travel "towards")
  * @param x 目標X座標 / Target x location (or location to travel "towards")
@@ -34,7 +34,7 @@
  * @param typ 効果属性 / Type of damage to apply to monsters (and objects)
  * @return 何か一つでも効力があればTRUEを返す / TRUE if any "effects" of the projection were observed, else FALSE
  */
-bool affect_item(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITION y, POSITION x, int dam, AttributeType typ)
+bool affect_item(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION r, POSITION y, POSITION x, int dam, AttributeType typ)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
     const Pos2D pos(y, x);
@@ -42,7 +42,7 @@ bool affect_item(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITION y
 
     auto is_item_affected = false;
     const auto known = grid.has_los();
-    who = who ? who : 0;
+    src_idx = src_idx ? src_idx : 0;
     dam = (dam + r) / (r + 1);
     std::set<OBJECT_IDX> processed_list;
     for (auto it = grid.o_idx_list.begin(); it != grid.o_idx_list.end();) {
@@ -227,7 +227,7 @@ bool affect_item(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITION y
             }
 
             BIT_FLAGS mode = 0L;
-            if (!who || player_ptr->current_floor_ptr->m_list[who].is_pet()) {
+            if (!src_idx || player_ptr->current_floor_ptr->m_list[src_idx].is_pet()) {
                 mode |= PM_FORCE_PET;
             }
 
@@ -240,7 +240,7 @@ bool affect_item(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITION y
                     }
 
                     continue;
-                } else if (summon_named_creature(player_ptr, who, y, x, corpse_r_idx, mode)) {
+                } else if (summon_named_creature(player_ptr, src_idx, y, x, corpse_r_idx, mode)) {
                     note_kill = _("生き返った。", " revived.");
                 } else if (!note_kill) {
                     note_kill = _("灰になった。", (plural ? " become dust." : " becomes dust."));
@@ -281,7 +281,7 @@ bool affect_item(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITION y
         const auto is_potion = o_ptr->is_potion();
         delete_object_idx(player_ptr, this_o_idx);
         if (is_potion) {
-            (void)potion_smash_effect(player_ptr, who, y, x, bi_id);
+            (void)potion_smash_effect(player_ptr, src_idx, y, x, bi_id);
 
             // 薬の破壊効果によりリストの次のアイテムが破壊された可能性があるのでリストの最初から処理をやり直す
             // 処理済みのアイテムは processed_list に登録されており、スキップされる

--- a/src/effect/effect-item.h
+++ b/src/effect/effect-item.h
@@ -4,4 +4,4 @@
 #include "system/angband.h"
 
 class PlayerType;
-bool affect_item(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITION y, POSITION x, int dam, AttributeType typ);
+bool affect_item(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION r, POSITION y, POSITION x, int dam, AttributeType typ);

--- a/src/effect/effect-monster-curse.cpp
+++ b/src/effect/effect-monster-curse.cpp
@@ -2,6 +2,7 @@
 #include "effect/effect-monster-util.h"
 #include "monster-race/monster-race.h"
 #include "monster-race/race-indice-types.h"
+#include "monster/monster-util.h"
 #include "system/monster-entity.h"
 #include "system/monster-race-info.h"
 #include "view/display-messages.h"
@@ -11,7 +12,7 @@ ProcessResult effect_monster_curse_1(EffectMonster *em_ptr)
     if (em_ptr->seen) {
         em_ptr->obvious = true;
     }
-    if (!em_ptr->src_idx) {
+    if (is_player(em_ptr->src_idx)) {
         msg_format(_("%sを指差して呪いをかけた。", "You point at %s and curse."), em_ptr->m_name);
     }
     if (randint0(100 + (em_ptr->caster_lev / 2)) < (em_ptr->r_ptr->level + 35)) {
@@ -27,7 +28,7 @@ ProcessResult effect_monster_curse_2(EffectMonster *em_ptr)
     if (em_ptr->seen) {
         em_ptr->obvious = true;
     }
-    if (!em_ptr->src_idx) {
+    if (is_player(em_ptr->src_idx)) {
         msg_format(_("%sを指差して恐ろしげに呪いをかけた。", "You point at %s and curse horribly."), em_ptr->m_name);
     }
 
@@ -44,7 +45,7 @@ ProcessResult effect_monster_curse_3(EffectMonster *em_ptr)
     if (em_ptr->seen) {
         em_ptr->obvious = true;
     }
-    if (!em_ptr->src_idx) {
+    if (is_player(em_ptr->src_idx)) {
         msg_format(_("%sを指差し、恐ろしげに呪文を唱えた！", "You point at %s, incanting terribly!"), em_ptr->m_name);
     }
 
@@ -61,13 +62,13 @@ ProcessResult effect_monster_curse_4(EffectMonster *em_ptr)
     if (em_ptr->seen) {
         em_ptr->obvious = true;
     }
-    if (!em_ptr->src_idx) {
+    if (is_player(em_ptr->src_idx)) {
         msg_format(_("%sの秘孔を突いて、「お前は既に死んでいる」と叫んだ。",
                        "You point at %s, screaming the word, 'DIE!'."),
             em_ptr->m_name);
     }
 
-    if ((randint0(100 + (em_ptr->caster_lev / 2)) < (em_ptr->r_ptr->level + 35)) && ((em_ptr->src_idx <= 0) || (em_ptr->m_caster_ptr->r_idx != MonsterRaceId::KENSHIROU))) {
+    if ((randint0(100 + (em_ptr->caster_lev / 2)) < (em_ptr->r_ptr->level + 35)) && (!is_monster(em_ptr->src_idx) || (em_ptr->m_caster_ptr->r_idx != MonsterRaceId::KENSHIROU))) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->dam = 0;
     }

--- a/src/effect/effect-monster-curse.cpp
+++ b/src/effect/effect-monster-curse.cpp
@@ -11,7 +11,7 @@ ProcessResult effect_monster_curse_1(EffectMonster *em_ptr)
     if (em_ptr->seen) {
         em_ptr->obvious = true;
     }
-    if (!em_ptr->who) {
+    if (!em_ptr->src_idx) {
         msg_format(_("%sを指差して呪いをかけた。", "You point at %s and curse."), em_ptr->m_name);
     }
     if (randint0(100 + (em_ptr->caster_lev / 2)) < (em_ptr->r_ptr->level + 35)) {
@@ -27,7 +27,7 @@ ProcessResult effect_monster_curse_2(EffectMonster *em_ptr)
     if (em_ptr->seen) {
         em_ptr->obvious = true;
     }
-    if (!em_ptr->who) {
+    if (!em_ptr->src_idx) {
         msg_format(_("%sを指差して恐ろしげに呪いをかけた。", "You point at %s and curse horribly."), em_ptr->m_name);
     }
 
@@ -44,7 +44,7 @@ ProcessResult effect_monster_curse_3(EffectMonster *em_ptr)
     if (em_ptr->seen) {
         em_ptr->obvious = true;
     }
-    if (!em_ptr->who) {
+    if (!em_ptr->src_idx) {
         msg_format(_("%sを指差し、恐ろしげに呪文を唱えた！", "You point at %s, incanting terribly!"), em_ptr->m_name);
     }
 
@@ -61,13 +61,13 @@ ProcessResult effect_monster_curse_4(EffectMonster *em_ptr)
     if (em_ptr->seen) {
         em_ptr->obvious = true;
     }
-    if (!em_ptr->who) {
+    if (!em_ptr->src_idx) {
         msg_format(_("%sの秘孔を突いて、「お前は既に死んでいる」と叫んだ。",
                        "You point at %s, screaming the word, 'DIE!'."),
             em_ptr->m_name);
     }
 
-    if ((randint0(100 + (em_ptr->caster_lev / 2)) < (em_ptr->r_ptr->level + 35)) && ((em_ptr->who <= 0) || (em_ptr->m_caster_ptr->r_idx != MonsterRaceId::KENSHIROU))) {
+    if ((randint0(100 + (em_ptr->caster_lev / 2)) < (em_ptr->r_ptr->level + 35)) && ((em_ptr->src_idx <= 0) || (em_ptr->m_caster_ptr->r_idx != MonsterRaceId::KENSHIROU))) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->dam = 0;
     }

--- a/src/effect/effect-monster-oldies.cpp
+++ b/src/effect/effect-monster-oldies.cpp
@@ -7,6 +7,7 @@
 #include "monster/monster-info.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
+#include "monster/monster-util.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
 #include "system/monster-entity.h"
@@ -100,7 +101,7 @@ ProcessResult effect_monster_star_heal(PlayerType *player_ptr, EffectMonster *em
 // who == 0ならばプレイヤーなので、それの判定.
 static void effect_monster_old_heal_check_player(PlayerType *player_ptr, EffectMonster *em_ptr)
 {
-    if (em_ptr->src_idx != 0) {
+    if (is_monster(em_ptr->src_idx)) {
         return;
     }
 
@@ -170,7 +171,7 @@ ProcessResult effect_monster_old_heal(PlayerType *player_ptr, EffectMonster *em_
     effect_monster_old_heal_check_player(player_ptr, em_ptr);
     if (em_ptr->m_ptr->r_idx == MonsterRaceId::LEPER) {
         em_ptr->heal_leper = true;
-        if (!em_ptr->src_idx) {
+        if (is_player(em_ptr->src_idx)) {
             chg_virtue(player_ptr, Virtue::COMPASSION, 5);
         }
     }
@@ -199,7 +200,7 @@ ProcessResult effect_monster_old_speed(PlayerType *player_ptr, EffectMonster *em
         em_ptr->note = _("の動きが速くなった。", " starts moving faster.");
     }
 
-    if (!em_ptr->src_idx) {
+    if (is_player(em_ptr->src_idx)) {
         if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
             chg_virtue(player_ptr, Virtue::INDIVIDUALISM, 1);
         }

--- a/src/effect/effect-monster-oldies.cpp
+++ b/src/effect/effect-monster-oldies.cpp
@@ -100,7 +100,7 @@ ProcessResult effect_monster_star_heal(PlayerType *player_ptr, EffectMonster *em
 // who == 0ならばプレイヤーなので、それの判定.
 static void effect_monster_old_heal_check_player(PlayerType *player_ptr, EffectMonster *em_ptr)
 {
-    if (em_ptr->who != 0) {
+    if (em_ptr->src_idx != 0) {
         return;
     }
 
@@ -170,7 +170,7 @@ ProcessResult effect_monster_old_heal(PlayerType *player_ptr, EffectMonster *em_
     effect_monster_old_heal_check_player(player_ptr, em_ptr);
     if (em_ptr->m_ptr->r_idx == MonsterRaceId::LEPER) {
         em_ptr->heal_leper = true;
-        if (!em_ptr->who) {
+        if (!em_ptr->src_idx) {
             chg_virtue(player_ptr, Virtue::COMPASSION, 5);
         }
     }
@@ -199,7 +199,7 @@ ProcessResult effect_monster_old_speed(PlayerType *player_ptr, EffectMonster *em
         em_ptr->note = _("の動きが速くなった。", " starts moving faster.");
     }
 
-    if (!em_ptr->who) {
+    if (!em_ptr->src_idx) {
         if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
             chg_virtue(player_ptr, Virtue::INDIVIDUALISM, 1);
         }

--- a/src/effect/effect-monster-spirit.cpp
+++ b/src/effect/effect-monster-spirit.cpp
@@ -32,7 +32,7 @@ ProcessResult effect_monster_drain_mana(PlayerType *player_ptr, EffectMonster *e
         return ProcessResult::PROCESS_CONTINUE;
     }
 
-    if (em_ptr->who <= 0) {
+    if (em_ptr->src_idx <= 0) {
         msg_format(_("%sから精神エネルギーを吸いとった。", "You draw psychic energy from %s."), em_ptr->m_name);
         (void)hp_player(player_ptr, em_ptr->dam);
         em_ptr->dam = 0;
@@ -50,11 +50,11 @@ ProcessResult effect_monster_drain_mana(PlayerType *player_ptr, EffectMonster *e
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    if (player_ptr->health_who == em_ptr->who) {
+    if (player_ptr->health_who == em_ptr->src_idx) {
         rfu.set_flag(MainWindowRedrawingFlag::HEALTH);
     }
 
-    if (player_ptr->riding == em_ptr->who) {
+    if (player_ptr->riding == em_ptr->src_idx) {
         rfu.set_flag(MainWindowRedrawingFlag::UHEALTH);
     }
 
@@ -72,7 +72,7 @@ ProcessResult effect_monster_mind_blast(PlayerType *player_ptr, EffectMonster *e
     if (em_ptr->seen) {
         em_ptr->obvious = true;
     }
-    if (!em_ptr->who) {
+    if (!em_ptr->src_idx) {
         msg_format(_("%sをじっと睨んだ。", "You gaze intently at %s."), em_ptr->m_name);
     }
 
@@ -105,7 +105,7 @@ ProcessResult effect_monster_mind_blast(PlayerType *player_ptr, EffectMonster *e
         em_ptr->note = _("は精神攻撃を食らった。", " is blasted by psionic energy.");
         em_ptr->note_dies = _("の精神は崩壊し、肉体は抜け殻となった。", " collapses, a mindless husk.");
 
-        if (em_ptr->who > 0) {
+        if (em_ptr->src_idx > 0) {
             em_ptr->do_conf = randint0(4) + 4;
         } else {
             em_ptr->do_conf = randint0(8) + 8;
@@ -120,7 +120,7 @@ ProcessResult effect_monster_brain_smash(PlayerType *player_ptr, EffectMonster *
     if (em_ptr->seen) {
         em_ptr->obvious = true;
     }
-    if (!em_ptr->who) {
+    if (!em_ptr->src_idx) {
         msg_format(_("%sをじっと睨んだ。", "You gaze intently at %s."), em_ptr->m_name);
     }
 
@@ -154,7 +154,7 @@ ProcessResult effect_monster_brain_smash(PlayerType *player_ptr, EffectMonster *
     } else {
         em_ptr->note = _("は精神攻撃を食らった。", " is blasted by psionic energy.");
         em_ptr->note_dies = _("の精神は崩壊し、肉体は抜け殻となった。", " collapses, a mindless husk.");
-        if (em_ptr->who > 0) {
+        if (em_ptr->src_idx > 0) {
             em_ptr->do_conf = randint0(4) + 4;
             em_ptr->do_stun = randint0(4) + 4;
         } else {

--- a/src/effect/effect-monster-spirit.cpp
+++ b/src/effect/effect-monster-spirit.cpp
@@ -7,6 +7,7 @@
 #include "monster/monster-info.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
+#include "monster/monster-util.h"
 #include "system/grid-type-definition.h"
 #include "system/monster-entity.h"
 #include "system/monster-race-info.h"
@@ -32,7 +33,7 @@ ProcessResult effect_monster_drain_mana(PlayerType *player_ptr, EffectMonster *e
         return ProcessResult::PROCESS_CONTINUE;
     }
 
-    if (em_ptr->src_idx <= 0) {
+    if (!is_monster(em_ptr->src_idx)) {
         msg_format(_("%sから精神エネルギーを吸いとった。", "You draw psychic energy from %s."), em_ptr->m_name);
         (void)hp_player(player_ptr, em_ptr->dam);
         em_ptr->dam = 0;
@@ -72,7 +73,7 @@ ProcessResult effect_monster_mind_blast(PlayerType *player_ptr, EffectMonster *e
     if (em_ptr->seen) {
         em_ptr->obvious = true;
     }
-    if (!em_ptr->src_idx) {
+    if (is_player(em_ptr->src_idx)) {
         msg_format(_("%sをじっと睨んだ。", "You gaze intently at %s."), em_ptr->m_name);
     }
 
@@ -105,7 +106,7 @@ ProcessResult effect_monster_mind_blast(PlayerType *player_ptr, EffectMonster *e
         em_ptr->note = _("は精神攻撃を食らった。", " is blasted by psionic energy.");
         em_ptr->note_dies = _("の精神は崩壊し、肉体は抜け殻となった。", " collapses, a mindless husk.");
 
-        if (em_ptr->src_idx > 0) {
+        if (is_monster(em_ptr->src_idx)) {
             em_ptr->do_conf = randint0(4) + 4;
         } else {
             em_ptr->do_conf = randint0(8) + 8;
@@ -120,7 +121,7 @@ ProcessResult effect_monster_brain_smash(PlayerType *player_ptr, EffectMonster *
     if (em_ptr->seen) {
         em_ptr->obvious = true;
     }
-    if (!em_ptr->src_idx) {
+    if (is_player(em_ptr->src_idx)) {
         msg_format(_("%sをじっと睨んだ。", "You gaze intently at %s."), em_ptr->m_name);
     }
 
@@ -154,7 +155,7 @@ ProcessResult effect_monster_brain_smash(PlayerType *player_ptr, EffectMonster *
     } else {
         em_ptr->note = _("は精神攻撃を食らった。", " is blasted by psionic energy.");
         em_ptr->note_dies = _("の精神は崩壊し、肉体は抜け殻となった。", " collapses, a mindless husk.");
-        if (em_ptr->src_idx > 0) {
+        if (is_monster(em_ptr->src_idx)) {
             em_ptr->do_conf = randint0(4) + 4;
             em_ptr->do_stun = randint0(4) + 4;
         } else {

--- a/src/effect/effect-monster-switcher.cpp
+++ b/src/effect/effect-monster-switcher.cpp
@@ -26,6 +26,7 @@
 #include "monster/monster-info.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
+#include "monster/monster-util.h"
 #include "player/player-damage.h"
 #include "spell-kind/spells-genocide.h"
 #include "system/grid-type-definition.h"
@@ -136,8 +137,8 @@ ProcessResult effect_monster_hand_doom(EffectMonster *em_ptr)
         return ProcessResult::PROCESS_CONTINUE;
     }
 
-    if ((em_ptr->src_idx > 0) ? ((em_ptr->caster_lev + randint1(em_ptr->dam)) > (em_ptr->r_ptr->level + 10 + randint1(20)))
-                          : (((em_ptr->caster_lev / 2) + randint1(em_ptr->dam)) > (em_ptr->r_ptr->level + randint1(200)))) {
+    if (is_monster(em_ptr->src_idx) ? ((em_ptr->caster_lev + randint1(em_ptr->dam)) > (em_ptr->r_ptr->level + 10 + randint1(20)))
+                                    : (((em_ptr->caster_lev / 2) + randint1(em_ptr->dam)) > (em_ptr->r_ptr->level + randint1(200)))) {
         em_ptr->dam = ((40 + randint1(20)) * em_ptr->m_ptr->hp) / 100;
         if (em_ptr->m_ptr->hp < em_ptr->dam) {
             em_ptr->dam = em_ptr->m_ptr->hp - 1;
@@ -264,7 +265,7 @@ ProcessResult effect_monster_genocide(PlayerType *player_ptr, EffectMonster *em_
     }
 
     std::string_view spell_name(_("モンスター消滅", "Genocide One"));
-    if (genocide_aux(player_ptr, em_ptr->g_ptr->m_idx, em_ptr->dam, !em_ptr->src_idx, (em_ptr->r_ptr->level + 1) / 2, spell_name.data())) {
+    if (genocide_aux(player_ptr, em_ptr->g_ptr->m_idx, em_ptr->dam, is_player(em_ptr->src_idx), (em_ptr->r_ptr->level + 1) / 2, spell_name.data())) {
         if (em_ptr->seen_msg) {
             msg_format(_("%sは消滅した！", "%s^ disappeared!"), em_ptr->m_name);
         }
@@ -278,7 +279,7 @@ ProcessResult effect_monster_genocide(PlayerType *player_ptr, EffectMonster *em_
 
 ProcessResult effect_monster_photo(PlayerType *player_ptr, EffectMonster *em_ptr)
 {
-    if (!em_ptr->src_idx) {
+    if (is_player(em_ptr->src_idx)) {
         msg_format(_("%sを写真に撮った。", "You take a photograph of %s."), em_ptr->m_name);
     }
 

--- a/src/effect/effect-monster-switcher.cpp
+++ b/src/effect/effect-monster-switcher.cpp
@@ -136,7 +136,7 @@ ProcessResult effect_monster_hand_doom(EffectMonster *em_ptr)
         return ProcessResult::PROCESS_CONTINUE;
     }
 
-    if ((em_ptr->who > 0) ? ((em_ptr->caster_lev + randint1(em_ptr->dam)) > (em_ptr->r_ptr->level + 10 + randint1(20)))
+    if ((em_ptr->src_idx > 0) ? ((em_ptr->caster_lev + randint1(em_ptr->dam)) > (em_ptr->r_ptr->level + 10 + randint1(20)))
                           : (((em_ptr->caster_lev / 2) + randint1(em_ptr->dam)) > (em_ptr->r_ptr->level + randint1(200)))) {
         em_ptr->dam = ((40 + randint1(20)) * em_ptr->m_ptr->hp) / 100;
         if (em_ptr->m_ptr->hp < em_ptr->dam) {
@@ -264,7 +264,7 @@ ProcessResult effect_monster_genocide(PlayerType *player_ptr, EffectMonster *em_
     }
 
     std::string_view spell_name(_("モンスター消滅", "Genocide One"));
-    if (genocide_aux(player_ptr, em_ptr->g_ptr->m_idx, em_ptr->dam, !em_ptr->who, (em_ptr->r_ptr->level + 1) / 2, spell_name.data())) {
+    if (genocide_aux(player_ptr, em_ptr->g_ptr->m_idx, em_ptr->dam, !em_ptr->src_idx, (em_ptr->r_ptr->level + 1) / 2, spell_name.data())) {
         if (em_ptr->seen_msg) {
             msg_format(_("%sは消滅した！", "%s^ disappeared!"), em_ptr->m_name);
         }
@@ -278,7 +278,7 @@ ProcessResult effect_monster_genocide(PlayerType *player_ptr, EffectMonster *em_
 
 ProcessResult effect_monster_photo(PlayerType *player_ptr, EffectMonster *em_ptr)
 {
-    if (!em_ptr->who) {
+    if (!em_ptr->src_idx) {
         msg_format(_("%sを写真に撮った。", "You take a photograph of %s."), em_ptr->m_name);
     }
 

--- a/src/effect/effect-monster-util.cpp
+++ b/src/effect/effect-monster-util.cpp
@@ -11,6 +11,7 @@
 #include "monster-race/monster-race.h"
 #include "monster/monster-info.h"
 #include "monster/monster-status.h"
+#include "monster/monster-util.h"
 #include "system/angband-system.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
@@ -44,12 +45,12 @@ EffectMonster::EffectMonster(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITI
     auto *floor_ptr = player_ptr->current_floor_ptr;
     this->g_ptr = &floor_ptr->grid_array[this->y][this->x];
     this->m_ptr = &floor_ptr->m_list[this->g_ptr->m_idx];
-    this->m_caster_ptr = (this->src_idx > 0) ? &floor_ptr->m_list[this->src_idx] : nullptr;
+    this->m_caster_ptr = is_monster(this->src_idx) ? &floor_ptr->m_list[this->src_idx] : nullptr;
     this->r_ptr = &this->m_ptr->get_monrace();
     this->seen = this->m_ptr->ml;
     this->seen_msg = is_seen(player_ptr, this->m_ptr);
     this->slept = this->m_ptr->is_asleep();
     this->known = (this->m_ptr->cdis <= MAX_PLAYER_SIGHT) || AngbandSystem::get_instance().is_phase_out();
     this->note_dies = this->m_ptr->get_died_message();
-    this->caster_lev = (this->src_idx > 0) ? this->m_caster_ptr->get_monrace().level : (player_ptr->lev * 2);
+    this->caster_lev = is_monster(this->src_idx) ? this->m_caster_ptr->get_monrace().level : (player_ptr->lev * 2);
 }

--- a/src/effect/effect-monster-util.cpp
+++ b/src/effect/effect-monster-util.cpp
@@ -22,7 +22,7 @@
  * @brief EffectMonster構造体のコンストラクタ
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param em_ptr モンスター効果構造体への参照ポインタ
- * @param who 魔法を発動したモンスター (0ならばプレイヤー)
+ * @param src_idx 魔法を発動したモンスター (0ならばプレイヤー)
  * @param r 効果半径(ビーム/ボルト = 0 / ボール = 1以上) / Radius of explosion (0 = beam/bolt, 1 to 9 = ball)
  * @param y 目標y座標 / Target y location (or location to travel "towards")
  * @param x 目標x座標 / Target x location (or location to travel "towards")
@@ -31,8 +31,8 @@
  * @param flag 効果フラグ
  * @param see_s_msg TRUEならばメッセージを表示する
  */
-EffectMonster::EffectMonster(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITION y, POSITION x, int dam, AttributeType attribute, BIT_FLAGS flag, bool see_s_msg)
-    : who(who)
+EffectMonster::EffectMonster(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION r, POSITION y, POSITION x, int dam, AttributeType attribute, BIT_FLAGS flag, bool see_s_msg)
+    : src_idx(src_idx)
     , r(r)
     , y(y)
     , x(x)
@@ -44,12 +44,12 @@ EffectMonster::EffectMonster(PlayerType *player_ptr, MONSTER_IDX who, POSITION r
     auto *floor_ptr = player_ptr->current_floor_ptr;
     this->g_ptr = &floor_ptr->grid_array[this->y][this->x];
     this->m_ptr = &floor_ptr->m_list[this->g_ptr->m_idx];
-    this->m_caster_ptr = (this->who > 0) ? &floor_ptr->m_list[this->who] : nullptr;
+    this->m_caster_ptr = (this->src_idx > 0) ? &floor_ptr->m_list[this->src_idx] : nullptr;
     this->r_ptr = &this->m_ptr->get_monrace();
     this->seen = this->m_ptr->ml;
     this->seen_msg = is_seen(player_ptr, this->m_ptr);
     this->slept = this->m_ptr->is_asleep();
     this->known = (this->m_ptr->cdis <= MAX_PLAYER_SIGHT) || AngbandSystem::get_instance().is_phase_out();
     this->note_dies = this->m_ptr->get_died_message();
-    this->caster_lev = (this->who > 0) ? this->m_caster_ptr->get_monrace().level : (player_ptr->lev * 2);
+    this->caster_lev = (this->src_idx > 0) ? this->m_caster_ptr->get_monrace().level : (player_ptr->lev * 2);
 }

--- a/src/effect/effect-monster-util.h
+++ b/src/effect/effect-monster-util.h
@@ -10,7 +10,7 @@ class MonsterRaceInfo;
 class PlayerType;
 class EffectMonster {
 public:
-    EffectMonster(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITION y, POSITION x, int dam, AttributeType attribute, BIT_FLAGS flag, bool see_s_msg);
+    EffectMonster(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION r, POSITION y, POSITION x, int dam, AttributeType attribute, BIT_FLAGS flag, bool see_s_msg);
 
     char killer[MAX_MONSTER_NAME]{};
     bool obvious = false;
@@ -29,7 +29,7 @@ public:
     short photo = 0;
     std::string note = "";
 
-    MONSTER_IDX who;
+    MONSTER_IDX src_idx;
     POSITION r;
     POSITION y;
     POSITION x;

--- a/src/effect/effect-monster.cpp
+++ b/src/effect/effect-monster.cpp
@@ -64,7 +64,7 @@
  */
 static ProcessResult is_affective(PlayerType *player_ptr, EffectMonster *em_ptr)
 {
-    if (!is_monster(em_ptr->g_ptr->m_idx)) {
+    if (!em_ptr->g_ptr->has_monster()) {
         return ProcessResult::PROCESS_FALSE;
     }
     if (is_monster(em_ptr->src_idx) && (em_ptr->g_ptr->m_idx == em_ptr->src_idx)) {

--- a/src/effect/effect-monster.h
+++ b/src/effect/effect-monster.h
@@ -6,4 +6,4 @@
 
 class CapturedMonsterType;
 class PlayerType;
-bool affect_monster(PlayerType *player_ptr, MONSTER_IDX who, POSITION r, POSITION y, POSITION x, int dam, AttributeType typ, BIT_FLAGS flag, bool see_s_msg, std::optional<CapturedMonsterType *> cap_mon_ptr = std::nullopt);
+bool affect_monster(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION r, POSITION y, POSITION x, int dam, AttributeType typ, BIT_FLAGS flag, bool see_s_msg, std::optional<CapturedMonsterType *> cap_mon_ptr = std::nullopt);

--- a/src/effect/effect-player-spirit.cpp
+++ b/src/effect/effect-player-spirit.cpp
@@ -26,7 +26,7 @@ void effect_player_drain_mana(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
         return;
     }
 
-    if (ep_ptr->who > 0) {
+    if (ep_ptr->src_idx > 0) {
         msg_format(_("%s^に精神エネルギーを吸い取られてしまった！", "%s^ draws psychic energy from you!"), ep_ptr->m_name);
     } else {
         msg_print(_("精神エネルギーを吸い取られてしまった！", "Your psychic energy is drained!"));
@@ -48,7 +48,7 @@ void effect_player_drain_mana(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
     };
     rfu.set_flags(flags);
 
-    if ((ep_ptr->who <= 0) || (ep_ptr->m_ptr->hp >= ep_ptr->m_ptr->maxhp)) {
+    if ((ep_ptr->src_idx <= 0) || (ep_ptr->m_ptr->hp >= ep_ptr->m_ptr->maxhp)) {
         ep_ptr->dam = 0;
         return;
     }
@@ -58,10 +58,10 @@ void effect_player_drain_mana(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
         ep_ptr->m_ptr->hp = ep_ptr->m_ptr->maxhp;
     }
 
-    if (player_ptr->health_who == ep_ptr->who) {
+    if (player_ptr->health_who == ep_ptr->src_idx) {
         rfu.set_flag(MainWindowRedrawingFlag::HEALTH);
     }
-    if (player_ptr->riding == ep_ptr->who) {
+    if (player_ptr->riding == ep_ptr->src_idx) {
         rfu.set_flag(MainWindowRedrawingFlag::UHEALTH);
     }
 

--- a/src/effect/effect-player-spirit.cpp
+++ b/src/effect/effect-player-spirit.cpp
@@ -3,6 +3,7 @@
 #include "core/window-redrawer.h"
 #include "effect/effect-player.h"
 #include "mind/mind-mirror-master.h"
+#include "monster/monster-util.h"
 #include "player/player-damage.h"
 #include "player/player-status-flags.h"
 #include "status/bad-status-setter.h"
@@ -26,7 +27,7 @@ void effect_player_drain_mana(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
         return;
     }
 
-    if (ep_ptr->src_idx > 0) {
+    if (is_monster(ep_ptr->src_idx)) {
         msg_format(_("%s^に精神エネルギーを吸い取られてしまった！", "%s^ draws psychic energy from you!"), ep_ptr->m_name);
     } else {
         msg_print(_("精神エネルギーを吸い取られてしまった！", "Your psychic energy is drained!"));
@@ -48,7 +49,7 @@ void effect_player_drain_mana(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
     };
     rfu.set_flags(flags);
 
-    if ((ep_ptr->src_idx <= 0) || (ep_ptr->m_ptr->hp >= ep_ptr->m_ptr->maxhp)) {
+    if (!is_monster(ep_ptr->src_idx) || (ep_ptr->m_ptr->hp >= ep_ptr->m_ptr->maxhp)) {
         ep_ptr->dam = 0;
         return;
     }

--- a/src/effect/effect-player.cpp
+++ b/src/effect/effect-player.cpp
@@ -42,20 +42,20 @@
 /*!
  * @brief EffectPlayerType構造体を初期化する
  * @param ep_ptr 初期化前の構造体
- * @param who 魔法を唱えたモンスター (0ならプレイヤー自身)
+ * @param src_idx 魔法を唱えたモンスター (0ならプレイヤー自身)
  * @param dam 基本威力
  * @param attribute 効果属性
  * @param flag 効果フラグ
  * @param monspell 効果元のモンスター魔法ID
  * @return 初期化後の構造体ポインタ
  */
-EffectPlayerType::EffectPlayerType(MONSTER_IDX who, int dam, AttributeType attribute, BIT_FLAGS flag)
+EffectPlayerType::EffectPlayerType(MONSTER_IDX src_idx, int dam, AttributeType attribute, BIT_FLAGS flag)
     : rlev(0)
     , m_ptr(nullptr)
     , killer("")
     , m_name("")
     , get_damage(0)
-    , who(who)
+    , src_idx(src_idx)
     , dam(dam)
     , attribute(attribute)
     , flag(flag)
@@ -92,9 +92,9 @@ static bool process_bolt_reflection(PlayerType *player_ptr, EffectPlayerType *ep
     msg_print(mes);
     POSITION t_y;
     POSITION t_x;
-    if (ep_ptr->who > 0) {
+    if (ep_ptr->src_idx > 0) {
         auto *floor_ptr = player_ptr->current_floor_ptr;
-        auto *m_ptr = &floor_ptr->m_list[ep_ptr->who];
+        auto *m_ptr = &floor_ptr->m_list[ep_ptr->src_idx];
         do {
             t_y = m_ptr->fy - 1 + randint1(3);
             t_x = m_ptr->fx - 1 + randint1(3);
@@ -131,13 +131,13 @@ static ProcessResult check_continue_player_effect(PlayerType *player_ptr, Effect
 
     auto is_effective = ep_ptr->dam > 0;
     is_effective &= randint0(55) < (player_ptr->lev * 3 / 5 + 20);
-    is_effective &= ep_ptr->who > 0;
-    is_effective &= ep_ptr->who != player_ptr->riding;
+    is_effective &= ep_ptr->src_idx > 0;
+    is_effective &= ep_ptr->src_idx != player_ptr->riding;
     if (is_effective && kawarimi(player_ptr, true)) {
         return ProcessResult::PROCESS_FALSE;
     }
 
-    if ((ep_ptr->who == 0) || (ep_ptr->who == player_ptr->riding)) {
+    if ((ep_ptr->src_idx == 0) || (ep_ptr->src_idx == player_ptr->riding)) {
         return ProcessResult::PROCESS_FALSE;
     }
 
@@ -152,19 +152,19 @@ static ProcessResult check_continue_player_effect(PlayerType *player_ptr, Effect
  * @brief 魔法を発したモンスター名を記述する
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param ep_ptr プレイヤー効果構造体への参照ポインタ
- * @param who_name モンスター名
+ * @param src_name モンスター名
  */
-static void describe_effect_source(PlayerType *player_ptr, EffectPlayerType *ep_ptr, concptr who_name)
+static void describe_effect_source(PlayerType *player_ptr, EffectPlayerType *ep_ptr, concptr src_name)
 {
-    if (ep_ptr->who > 0) {
-        ep_ptr->m_ptr = &player_ptr->current_floor_ptr->m_list[ep_ptr->who];
+    if (ep_ptr->src_idx > 0) {
+        ep_ptr->m_ptr = &player_ptr->current_floor_ptr->m_list[ep_ptr->src_idx];
         ep_ptr->rlev = ep_ptr->m_ptr->get_monrace().level >= 1 ? ep_ptr->m_ptr->get_monrace().level : 1;
         angband_strcpy(ep_ptr->m_name, monster_desc(player_ptr, ep_ptr->m_ptr, 0), sizeof(ep_ptr->m_name));
-        angband_strcpy(ep_ptr->killer, who_name, sizeof(ep_ptr->killer));
+        angband_strcpy(ep_ptr->killer, src_name, sizeof(ep_ptr->killer));
         return;
     }
 
-    switch (ep_ptr->who) {
+    switch (ep_ptr->src_idx) {
     case PROJECT_WHO_UNCTRL_POWER:
         strcpy(ep_ptr->killer, _("制御できない力の氾流", "uncontrollable power storm"));
         break;
@@ -181,8 +181,8 @@ static void describe_effect_source(PlayerType *player_ptr, EffectPlayerType *ep_
 
 /*!
  * @brief 汎用的なビーム/ボルト/ボール系によるプレイヤーへの効果処理 / Helper function for "project()" below.
- * @param who 魔法を発動したモンスター(0ならばプレイヤー、負値ならば自然発生) / Index of "source" monster (zero for "player")
- * @param who_name 効果を起こしたモンスターの名前
+ * @param src_idx 魔法を発動したモンスター(0ならばプレイヤー、負値ならば自然発生) / Index of "source" monster (zero for "player")
+ * @param src_name 効果を起こしたモンスターの名前
  * @param r 効果半径(ビーム/ボルト = 0 / ボール = 1以上) / Radius of explosion (0 = beam/bolt, 1 to 9 = ball)
  * @param y 目標Y座標 / Target y location (or location to travel "towards")
  * @param x 目標X座標 / Target x location (or location to travel "towards")
@@ -192,10 +192,10 @@ static void describe_effect_source(PlayerType *player_ptr, EffectPlayerType *ep_
  * @param monspell 効果元のモンスター魔法ID
  * @return 何か一つでも効力があればTRUEを返す / TRUE if any "effects" of the projection were observed, else FALSE
  */
-bool affect_player(MONSTER_IDX who, PlayerType *player_ptr, concptr who_name, int r, POSITION y, POSITION x, int dam, AttributeType attribute,
+bool affect_player(MONSTER_IDX src_idx, PlayerType *player_ptr, concptr src_name, int r, POSITION y, POSITION x, int dam, AttributeType attribute,
     BIT_FLAGS flag, project_func project)
 {
-    EffectPlayerType tmp_effect(who, dam, attribute, flag);
+    EffectPlayerType tmp_effect(src_idx, dam, attribute, flag);
     auto *ep_ptr = &tmp_effect;
     auto check_result = check_continue_player_effect(player_ptr, ep_ptr, { y, x }, project);
     if (check_result != ProcessResult::PROCESS_CONTINUE) {
@@ -207,11 +207,11 @@ bool affect_player(MONSTER_IDX who, PlayerType *player_ptr, concptr who_name, in
     }
 
     ep_ptr->dam = (ep_ptr->dam + r) / (r + 1);
-    describe_effect_source(player_ptr, ep_ptr, who_name);
+    describe_effect_source(player_ptr, ep_ptr, src_name);
     switch_effects_player(player_ptr, ep_ptr);
 
     SpellHex(player_ptr).store_vengeful_damage(ep_ptr->get_damage);
-    if ((player_ptr->tim_eyeeye || SpellHex(player_ptr).is_spelling_specific(HEX_EYE_FOR_EYE)) && (ep_ptr->get_damage > 0) && !player_ptr->is_dead && (ep_ptr->who > 0)) {
+    if ((player_ptr->tim_eyeeye || SpellHex(player_ptr).is_spelling_specific(HEX_EYE_FOR_EYE)) && (ep_ptr->get_damage > 0) && !player_ptr->is_dead && (ep_ptr->src_idx > 0)) {
         const auto m_name_self = monster_desc(player_ptr, ep_ptr->m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE | MD_OBJECTIVE);
         msg_print(_(format("攻撃が%s自身を傷つけた！", ep_ptr->m_name), format("The attack of %s has wounded %s!", ep_ptr->m_name, m_name_self.data())));
         (*project)(player_ptr, 0, 0, ep_ptr->m_ptr->fy, ep_ptr->m_ptr->fx, ep_ptr->get_damage, AttributeType::MISSILE, PROJECT_KILL, std::nullopt);
@@ -225,7 +225,7 @@ bool affect_player(MONSTER_IDX who, PlayerType *player_ptr, concptr who_name, in
     }
 
     disturb(player_ptr, true, true);
-    if (ep_ptr->dam && ep_ptr->who && (ep_ptr->who != player_ptr->riding)) {
+    if (ep_ptr->dam && ep_ptr->src_idx && (ep_ptr->src_idx != player_ptr->riding)) {
         (void)kawarimi(player_ptr, false);
     }
 

--- a/src/effect/effect-player.h
+++ b/src/effect/effect-player.h
@@ -13,18 +13,18 @@ public:
     GAME_TEXT m_name[MAX_NLEN];
     int get_damage;
 
-    MONSTER_IDX who;
+    MONSTER_IDX src_idx;
     int dam;
     AttributeType attribute;
     BIT_FLAGS flag;
-    EffectPlayerType(MONSTER_IDX who, int dam, AttributeType attribute, BIT_FLAGS flag);
+    EffectPlayerType(MONSTER_IDX src_idx, int dam, AttributeType attribute, BIT_FLAGS flag);
 };
 
 struct ProjectResult;
 class CapturedMonsterType;
 class PlayerType;
 using project_func = ProjectResult (*)(
-    PlayerType *player_ptr, MONSTER_IDX who, POSITION rad, POSITION y, POSITION x, int dam, AttributeType typ, BIT_FLAGS flag, std::optional<CapturedMonsterType *> cap_mon_ptr);
+    PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION rad, POSITION y, POSITION x, int dam, AttributeType typ, BIT_FLAGS flag, std::optional<CapturedMonsterType *> cap_mon_ptr);
 
-bool affect_player(MONSTER_IDX who, PlayerType *player_ptr, concptr who_name, int r, POSITION y, POSITION x, int dam, AttributeType typ, BIT_FLAGS flag,
+bool affect_player(MONSTER_IDX src_idx, PlayerType *player_ptr, concptr src_name, int r, POSITION y, POSITION x, int dam, AttributeType typ, BIT_FLAGS flag,
     project_func project);

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -23,6 +23,7 @@
 #include "monster/monster-describer.h"
 #include "monster/monster-description-types.h"
 #include "monster/monster-info.h"
+#include "monster/monster-util.h"
 #include "pet/pet-fall-off.h"
 #include "player/player-status.h"
 #include "spell-class/spells-mirror-master.h"
@@ -81,10 +82,10 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITIO
     if (any_bits(flag, PROJECT_JUMP)) {
         x1 = target_x;
         y1 = target_y;
-    } else if (src_idx <= 0) {
+    } else if (!is_monster(src_idx)) {
         x1 = player_ptr->x;
         y1 = player_ptr->y;
-    } else if (src_idx > 0) {
+    } else if (is_monster(src_idx)) {
         x1 = player_ptr->current_floor_ptr->m_list[src_idx].fx;
         y1 = player_ptr->current_floor_ptr->m_list[src_idx].fy;
     } else {
@@ -305,8 +306,8 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITIO
     update_creature(player_ptr);
 
     if (flag & PROJECT_KILL) {
-        see_s_msg = (src_idx > 0) ? is_seen(player_ptr, &player_ptr->current_floor_ptr->m_list[src_idx])
-                                  : (!src_idx ? true : (player_can_see_bold(player_ptr, y1, x1) && projectable(player_ptr, player_ptr->y, player_ptr->x, y1, x1)));
+        see_s_msg = is_monster(src_idx) ? is_seen(player_ptr, &player_ptr->current_floor_ptr->m_list[src_idx])
+                                        : (is_player(src_idx) ? true : (player_can_see_bold(player_ptr, y1, x1) && projectable(player_ptr, player_ptr->y, player_ptr->x, y1, x1)));
     }
 
     if (flag & (PROJECT_GRID)) {
@@ -393,7 +394,7 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITIO
                         } else {
                             msg_print(_("攻撃は跳ね返った！", "The attack bounces!"));
                         }
-                    } else if (src_idx <= 0) {
+                    } else if (!is_monster(src_idx)) {
                         sound(SOUND_REFLECT);
                     }
 
@@ -482,7 +483,7 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITIO
         if (!src_idx && (project_m_n == 1) && none_bits(flag, PROJECT_JUMP)) {
             const Pos2D pos_project(project_m_y, project_m_x);
             const auto &grid = floor.get_grid(pos_project);
-            if (grid.m_idx > 0) {
+            if (is_monster(grid.m_idx)) {
                 auto &monster = floor.m_list[grid.m_idx];
                 if (monster.ml) {
                     if (!player_ptr->effects()->hallucination()->is_hallucinated()) {
@@ -548,7 +549,7 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITIO
             }
 
             std::string who_name;
-            if (src_idx > 0) {
+            if (is_monster(src_idx)) {
                 who_name = monster_desc(player_ptr, &floor.m_list[src_idx], MD_WRONGDOER_NAME);
             }
 

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -483,7 +483,7 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITIO
         if (!src_idx && (project_m_n == 1) && none_bits(flag, PROJECT_JUMP)) {
             const Pos2D pos_project(project_m_y, project_m_x);
             const auto &grid = floor.get_grid(pos_project);
-            if (is_monster(grid.m_idx)) {
+            if (grid.has_monster()) {
                 auto &monster = floor.m_list[grid.m_idx];
                 if (monster.ml) {
                     if (!player_ptr->effects()->hallucination()->is_hallucinated()) {

--- a/src/effect/effect-processor.h
+++ b/src/effect/effect-processor.h
@@ -15,5 +15,5 @@ class CapturedMonsterType;
 class EffectPlayerType;
 class PlayerType;
 ProjectResult project(
-    PlayerType *player_ptr, const MONSTER_IDX who, POSITION rad, POSITION y, POSITION x, const int dam, const AttributeType typ,
+    PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITION rad, POSITION y, POSITION x, const int dam, const AttributeType typ,
     BIT_FLAGS flag, std::optional<CapturedMonsterType *> cap_mon_ptr = std::nullopt);

--- a/src/floor/floor-streams.cpp
+++ b/src/floor/floor-streams.cpp
@@ -28,6 +28,7 @@
 #include "grid/grid.h"
 #include "monster-race/monster-race.h"
 #include "monster/monster-info.h"
+#include "monster/monster-util.h"
 #include "room/lake-types.h"
 #include "spell-kind/spells-floor.h"
 #include "system/artifact-type-definition.h"
@@ -343,7 +344,7 @@ void build_streamer(PlayerType *player_ptr, FEAT_IDX feat, int chance)
             }
 
             auto *r_ptr = &monraces_info[floor.m_list[grid.m_idx].r_idx];
-            if (grid.m_idx && !(streamer.flags.has(TerrainCharacteristics::PLACE) && monster_can_cross_terrain(player_ptr, feat, r_ptr, 0))) {
+            if (is_monster(grid.m_idx) && !(streamer.flags.has(TerrainCharacteristics::PLACE) && monster_can_cross_terrain(player_ptr, feat, r_ptr, 0))) {
                 /* Delete the monster (if any) */
                 delete_monster(player_ptr, pos.y, pos.x);
             }

--- a/src/floor/floor-streams.cpp
+++ b/src/floor/floor-streams.cpp
@@ -28,7 +28,6 @@
 #include "grid/grid.h"
 #include "monster-race/monster-race.h"
 #include "monster/monster-info.h"
-#include "monster/monster-util.h"
 #include "room/lake-types.h"
 #include "spell-kind/spells-floor.h"
 #include "system/artifact-type-definition.h"
@@ -344,7 +343,7 @@ void build_streamer(PlayerType *player_ptr, FEAT_IDX feat, int chance)
             }
 
             auto *r_ptr = &monraces_info[floor.m_list[grid.m_idx].r_idx];
-            if (is_monster(grid.m_idx) && !(streamer.flags.has(TerrainCharacteristics::PLACE) && monster_can_cross_terrain(player_ptr, feat, r_ptr, 0))) {
+            if (grid.has_monster() && !(streamer.flags.has(TerrainCharacteristics::PLACE) && monster_can_cross_terrain(player_ptr, feat, r_ptr, 0))) {
                 /* Delete the monster (if any) */
                 delete_monster(player_ptr, pos.y, pos.x);
             }

--- a/src/floor/object-allocator.cpp
+++ b/src/floor/object-allocator.cpp
@@ -11,6 +11,7 @@
 #include "grid/object-placer.h"
 #include "grid/trap.h"
 #include "monster-race/monster-race.h"
+#include "monster/monster-util.h"
 #include "system/dungeon-info.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
@@ -62,7 +63,7 @@ static bool alloc_stairs_aux(PlayerType *player_ptr, POSITION y, POSITION x, int
 {
     auto *floor_ptr = player_ptr->current_floor_ptr;
     auto *g_ptr = &floor_ptr->grid_array[y][x];
-    if (!g_ptr->is_floor() || pattern_tile(floor_ptr, y, x) || !g_ptr->o_idx_list.empty() || (g_ptr->m_idx != 0) || next_to_walls(floor_ptr, y, x) < walls) {
+    if (!g_ptr->is_floor() || pattern_tile(floor_ptr, y, x) || !g_ptr->o_idx_list.empty() || is_monster(g_ptr->m_idx) || next_to_walls(floor_ptr, y, x) < walls) {
         return false;
     }
 
@@ -194,7 +195,7 @@ void alloc_object(PlayerType *player_ptr, dap_type set, dungeon_allocation_type 
             x = randint0(floor_ptr->width);
             const Pos2D pos(y, x);
             const auto &grid = floor_ptr->get_grid(pos);
-            if (!grid.is_floor() || !grid.o_idx_list.empty() || grid.m_idx) {
+            if (!grid.is_floor() || !grid.o_idx_list.empty() || is_monster(grid.m_idx)) {
                 continue;
             }
 

--- a/src/floor/object-allocator.cpp
+++ b/src/floor/object-allocator.cpp
@@ -11,7 +11,6 @@
 #include "grid/object-placer.h"
 #include "grid/trap.h"
 #include "monster-race/monster-race.h"
-#include "monster/monster-util.h"
 #include "system/dungeon-info.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
@@ -63,7 +62,7 @@ static bool alloc_stairs_aux(PlayerType *player_ptr, POSITION y, POSITION x, int
 {
     auto *floor_ptr = player_ptr->current_floor_ptr;
     auto *g_ptr = &floor_ptr->grid_array[y][x];
-    if (!g_ptr->is_floor() || pattern_tile(floor_ptr, y, x) || !g_ptr->o_idx_list.empty() || is_monster(g_ptr->m_idx) || next_to_walls(floor_ptr, y, x) < walls) {
+    if (!g_ptr->is_floor() || pattern_tile(floor_ptr, y, x) || !g_ptr->o_idx_list.empty() || g_ptr->has_monster() || next_to_walls(floor_ptr, y, x) < walls) {
         return false;
     }
 
@@ -195,7 +194,7 @@ void alloc_object(PlayerType *player_ptr, dap_type set, dungeon_allocation_type 
             x = randint0(floor_ptr->width);
             const Pos2D pos(y, x);
             const auto &grid = floor_ptr->get_grid(pos);
-            if (!grid.is_floor() || !grid.o_idx_list.empty() || is_monster(grid.m_idx)) {
+            if (!grid.is_floor() || !grid.o_idx_list.empty() || grid.has_monster()) {
                 continue;
             }
 

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -551,7 +551,7 @@ void wilderness_gen(PlayerType *player_ptr)
                     continue;
                 }
 
-                if (is_monster(grid.m_idx)) {
+                if (grid.has_monster()) {
                     delete_monster_idx(player_ptr, grid.m_idx);
                 }
 
@@ -569,7 +569,7 @@ void wilderness_gen(PlayerType *player_ptr)
                     continue;
                 }
 
-                if (is_monster(grid.m_idx)) {
+                if (grid.has_monster()) {
                     delete_monster_idx(player_ptr, grid.m_idx);
                 }
 

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -551,7 +551,7 @@ void wilderness_gen(PlayerType *player_ptr)
                     continue;
                 }
 
-                if (grid.m_idx != 0) {
+                if (is_monster(grid.m_idx)) {
                     delete_monster_idx(player_ptr, grid.m_idx);
                 }
 
@@ -569,7 +569,7 @@ void wilderness_gen(PlayerType *player_ptr)
                     continue;
                 }
 
-                if (grid.m_idx != 0) {
+                if (is_monster(grid.m_idx)) {
                     delete_monster_idx(player_ptr, grid.m_idx);
                 }
 

--- a/src/grid/feature.cpp
+++ b/src/grid/feature.cpp
@@ -7,6 +7,7 @@
 #include "grid/lighting-colors-table.h"
 #include "mind/mind-ninja.h"
 #include "monster/monster-update.h"
+#include "monster/monster-util.h"
 #include "player/special-defense-types.h"
 #include "room/door-definition.h"
 #include "system/dungeon-info.h"
@@ -234,7 +235,7 @@ void cave_set_feat(PlayerType *player_ptr, POSITION y, POSITION x, FEAT_IDX feat
         g_ptr->info &= ~(CAVE_MARK);
     }
 
-    if (g_ptr->m_idx) {
+    if (is_monster(g_ptr->m_idx)) {
         update_monster(player_ptr, g_ptr->m_idx, false);
     }
 
@@ -264,7 +265,7 @@ void cave_set_feat(PlayerType *player_ptr, POSITION y, POSITION x, FEAT_IDX feat
         auto *cc_ptr = &floor_ptr->grid_array[yy][xx];
         cc_ptr->info |= CAVE_GLOW;
         if (cc_ptr->is_view()) {
-            if (cc_ptr->m_idx) {
+            if (is_monster(cc_ptr->m_idx)) {
                 update_monster(player_ptr, cc_ptr->m_idx, false);
             }
 

--- a/src/grid/feature.cpp
+++ b/src/grid/feature.cpp
@@ -7,7 +7,6 @@
 #include "grid/lighting-colors-table.h"
 #include "mind/mind-ninja.h"
 #include "monster/monster-update.h"
-#include "monster/monster-util.h"
 #include "player/special-defense-types.h"
 #include "room/door-definition.h"
 #include "system/dungeon-info.h"
@@ -235,7 +234,7 @@ void cave_set_feat(PlayerType *player_ptr, POSITION y, POSITION x, FEAT_IDX feat
         g_ptr->info &= ~(CAVE_MARK);
     }
 
-    if (is_monster(g_ptr->m_idx)) {
+    if (g_ptr->has_monster()) {
         update_monster(player_ptr, g_ptr->m_idx, false);
     }
 
@@ -265,7 +264,7 @@ void cave_set_feat(PlayerType *player_ptr, POSITION y, POSITION x, FEAT_IDX feat
         auto *cc_ptr = &floor_ptr->grid_array[yy][xx];
         cc_ptr->info |= CAVE_GLOW;
         if (cc_ptr->is_view()) {
-            if (is_monster(cc_ptr->m_idx)) {
+            if (cc_ptr->has_monster()) {
                 update_monster(player_ptr, cc_ptr->m_idx, false);
             }
 

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -37,6 +37,7 @@
 #include "monster/monster-info.h"
 #include "monster/monster-status.h"
 #include "monster/monster-update.h"
+#include "monster/monster-util.h"
 #include "object/item-tester-hooker.h"
 #include "object/object-mark-types.h"
 #include "player-info/class-info.h"
@@ -84,7 +85,7 @@ bool new_player_spot(PlayerType *player_ptr)
         const auto &grid = player_ptr->current_floor_ptr->get_grid({ y, x });
 
         /* Must be a "naked" floor grid */
-        if (grid.m_idx) {
+        if (is_monster(grid.m_idx)) {
             continue;
         }
         if (floor.is_in_dungeon()) {
@@ -184,7 +185,7 @@ static void update_local_illumination_aux(PlayerType *player_ptr, int y, int x)
         return;
     }
 
-    if (grid.m_idx > 0) {
+    if (is_monster(grid.m_idx)) {
         update_monster(player_ptr, grid.m_idx, false);
     }
 
@@ -849,7 +850,7 @@ bool cave_monster_teleportable_bold(PlayerType *player_ptr, MONSTER_IDX m_idx, P
         return false;
     }
 
-    if (grid.m_idx && (grid.m_idx != m_idx)) {
+    if (is_monster(grid.m_idx) && (grid.m_idx != m_idx)) {
         return false;
     }
     if (player_ptr->is_located_at(pos)) {
@@ -896,7 +897,7 @@ bool cave_player_teleportable_bold(PlayerType *player_ptr, POSITION y, POSITION 
         return false;
     }
 
-    if (grid.m_idx && (grid.m_idx != player_ptr->riding)) {
+    if (is_monster(grid.m_idx) && (grid.m_idx != player_ptr->riding)) {
         return false;
     }
 
@@ -1060,7 +1061,7 @@ void place_grid(PlayerType *player_ptr, Grid *g_ptr, grid_bold_type gb_type)
         return;
     }
 
-    if (g_ptr->m_idx > 0) {
+    if (is_monster(g_ptr->m_idx)) {
         delete_monster_idx(player_ptr, g_ptr->m_idx);
     }
 }

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -37,7 +37,6 @@
 #include "monster/monster-info.h"
 #include "monster/monster-status.h"
 #include "monster/monster-update.h"
-#include "monster/monster-util.h"
 #include "object/item-tester-hooker.h"
 #include "object/object-mark-types.h"
 #include "player-info/class-info.h"
@@ -85,7 +84,7 @@ bool new_player_spot(PlayerType *player_ptr)
         const auto &grid = player_ptr->current_floor_ptr->get_grid({ y, x });
 
         /* Must be a "naked" floor grid */
-        if (is_monster(grid.m_idx)) {
+        if (grid.has_monster()) {
             continue;
         }
         if (floor.is_in_dungeon()) {
@@ -185,7 +184,7 @@ static void update_local_illumination_aux(PlayerType *player_ptr, int y, int x)
         return;
     }
 
-    if (is_monster(grid.m_idx)) {
+    if (grid.has_monster()) {
         update_monster(player_ptr, grid.m_idx, false);
     }
 
@@ -850,7 +849,7 @@ bool cave_monster_teleportable_bold(PlayerType *player_ptr, MONSTER_IDX m_idx, P
         return false;
     }
 
-    if (is_monster(grid.m_idx) && (grid.m_idx != m_idx)) {
+    if (grid.has_monster() && (grid.m_idx != m_idx)) {
         return false;
     }
     if (player_ptr->is_located_at(pos)) {
@@ -897,7 +896,7 @@ bool cave_player_teleportable_bold(PlayerType *player_ptr, POSITION y, POSITION 
         return false;
     }
 
-    if (is_monster(grid.m_idx) && (grid.m_idx != player_ptr->riding)) {
+    if (grid.has_monster() && (grid.m_idx != player_ptr->riding)) {
         return false;
     }
 
@@ -1061,7 +1060,7 @@ void place_grid(PlayerType *player_ptr, Grid *g_ptr, grid_bold_type gb_type)
         return;
     }
 
-    if (is_monster(g_ptr->m_idx)) {
+    if (g_ptr->has_monster()) {
         delete_monster_idx(player_ptr, g_ptr->m_idx);
     }
 }

--- a/src/io/cursor.cpp
+++ b/src/io/cursor.cpp
@@ -7,6 +7,7 @@
 #include "game-option/special-options.h"
 #include "grid/feature.h"
 #include "io/screen-util.h"
+#include "monster/monster-util.h"
 #include "player/player-status.h"
 #include "system/angband-system.h"
 #include "system/floor-type-definition.h"
@@ -57,7 +58,7 @@ void print_path(PlayerType *player_ptr, POSITION y, POSITION x)
             TERM_COLOR ta = default_color;
             auto tc = '*';
 
-            if (g_ptr->m_idx && floor_ptr->m_list[g_ptr->m_idx].ml) {
+            if (is_monster(g_ptr->m_idx) && floor_ptr->m_list[g_ptr->m_idx].ml) {
                 map_info(player_ptr, ny, nx, &a, &c, &ta, &tc);
 
                 if (!is_ascii_graphics(a)) {

--- a/src/io/cursor.cpp
+++ b/src/io/cursor.cpp
@@ -7,7 +7,6 @@
 #include "game-option/special-options.h"
 #include "grid/feature.h"
 #include "io/screen-util.h"
-#include "monster/monster-util.h"
 #include "player/player-status.h"
 #include "system/angband-system.h"
 #include "system/floor-type-definition.h"
@@ -58,7 +57,7 @@ void print_path(PlayerType *player_ptr, POSITION y, POSITION x)
             TERM_COLOR ta = default_color;
             auto tc = '*';
 
-            if (is_monster(g_ptr->m_idx) && floor_ptr->m_list[g_ptr->m_idx].ml) {
+            if (g_ptr->has_monster() && floor_ptr->m_list[g_ptr->m_idx].ml) {
                 map_info(player_ptr, ny, nx, &a, &c, &ta, &tc);
 
                 if (!is_ascii_graphics(a)) {

--- a/src/melee/melee-postprocess.h
+++ b/src/melee/melee-postprocess.h
@@ -5,4 +5,4 @@
 #include <string_view>
 
 class PlayerType;
-void mon_take_hit_mon(PlayerType *player_ptr, MONSTER_IDX m_idx, int dam, bool *dead, bool *fear, std::string_view note, MONSTER_IDX who);
+void mon_take_hit_mon(PlayerType *player_ptr, MONSTER_IDX m_idx, int dam, bool *dead, bool *fear, std::string_view note, MONSTER_IDX src_idx);

--- a/src/mind/mind-berserker.cpp
+++ b/src/mind/mind-berserker.cpp
@@ -6,7 +6,6 @@
 #include "grid/feature.h"
 #include "grid/grid.h"
 #include "mind/mind-numbers.h"
-#include "monster/monster-util.h"
 #include "player-attack/player-attack.h"
 #include "player/player-move.h"
 #include "spell-kind/earthquake.h"
@@ -43,7 +42,7 @@ bool cast_berserk_spell(PlayerType *player_ptr, MindBerserkerType spell)
 
         y = player_ptr->y + ddy[dir];
         x = player_ptr->x + ddx[dir];
-        if (!is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+        if (!player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
             msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
             return false;
         }
@@ -55,7 +54,7 @@ bool cast_berserk_spell(PlayerType *player_ptr, MindBerserkerType spell)
 
         y += ddy[dir];
         x += ddx[dir];
-        if (player_can_enter(player_ptr, player_ptr->current_floor_ptr->grid_array[y][x].feat, 0) && !is_trap(player_ptr, player_ptr->current_floor_ptr->grid_array[y][x].feat) && !is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+        if (player_can_enter(player_ptr, player_ptr->current_floor_ptr->grid_array[y][x].feat, 0) && !is_trap(player_ptr, player_ptr->current_floor_ptr->grid_array[y][x].feat) && !player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
             msg_print(nullptr);
             (void)move_player_effect(player_ptr, y, x, MPE_FORGET_FLOW | MPE_HANDLE_STUFF | MPE_DONT_PICKUP);
         }

--- a/src/mind/mind-berserker.cpp
+++ b/src/mind/mind-berserker.cpp
@@ -6,6 +6,7 @@
 #include "grid/feature.h"
 #include "grid/grid.h"
 #include "mind/mind-numbers.h"
+#include "monster/monster-util.h"
 #include "player-attack/player-attack.h"
 #include "player/player-move.h"
 #include "spell-kind/earthquake.h"
@@ -42,7 +43,7 @@ bool cast_berserk_spell(PlayerType *player_ptr, MindBerserkerType spell)
 
         y = player_ptr->y + ddy[dir];
         x = player_ptr->x + ddx[dir];
-        if (!player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+        if (!is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
             msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
             return false;
         }
@@ -54,7 +55,7 @@ bool cast_berserk_spell(PlayerType *player_ptr, MindBerserkerType spell)
 
         y += ddy[dir];
         x += ddx[dir];
-        if (player_can_enter(player_ptr, player_ptr->current_floor_ptr->grid_array[y][x].feat, 0) && !is_trap(player_ptr, player_ptr->current_floor_ptr->grid_array[y][x].feat) && !player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+        if (player_can_enter(player_ptr, player_ptr->current_floor_ptr->grid_array[y][x].feat, 0) && !is_trap(player_ptr, player_ptr->current_floor_ptr->grid_array[y][x].feat) && !is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
             msg_print(nullptr);
             (void)move_player_effect(player_ptr, y, x, MPE_FORGET_FLOW | MPE_HANDLE_STUFF | MPE_DONT_PICKUP);
         }

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -35,6 +35,7 @@
 #include "monster-race/race-brightness-flags.h"
 #include "monster-race/race-flags-resistance.h"
 #include "monster/monster-describer.h"
+#include "monster/monster-util.h"
 #include "player-base/player-class.h"
 #include "player-info/equipment-info.h"
 #include "player-status/player-energy.h"
@@ -1063,7 +1064,7 @@ ProcessResult effect_monster_elemental_genocide(PlayerType *player_ptr, EffectMo
         return ProcessResult::PROCESS_TRUE;
     }
 
-    if (genocide_aux(player_ptr, em_ptr->g_ptr->m_idx, em_ptr->dam, !em_ptr->src_idx, (em_ptr->r_ptr->level + 1) / 2, _("モンスター消滅", "Genocide One"))) {
+    if (genocide_aux(player_ptr, em_ptr->g_ptr->m_idx, em_ptr->dam, is_player(em_ptr->src_idx), (em_ptr->r_ptr->level + 1) / 2, _("モンスター消滅", "Genocide One"))) {
         if (em_ptr->seen_msg) {
             msg_format(_("%sは消滅した！", "%s^ disappeared!"), em_ptr->m_name);
         }

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -1063,7 +1063,7 @@ ProcessResult effect_monster_elemental_genocide(PlayerType *player_ptr, EffectMo
         return ProcessResult::PROCESS_TRUE;
     }
 
-    if (genocide_aux(player_ptr, em_ptr->g_ptr->m_idx, em_ptr->dam, !em_ptr->who, (em_ptr->r_ptr->level + 1) / 2, _("モンスター消滅", "Genocide One"))) {
+    if (genocide_aux(player_ptr, em_ptr->g_ptr->m_idx, em_ptr->dam, !em_ptr->src_idx, (em_ptr->r_ptr->level + 1) / 2, _("モンスター消滅", "Genocide One"))) {
         if (em_ptr->seen_msg) {
             msg_format(_("%sは消滅した！", "%s^ disappeared!"), em_ptr->m_name);
         }

--- a/src/mind/mind-force-trainer.cpp
+++ b/src/mind/mind-force-trainer.cpp
@@ -17,7 +17,6 @@
 #include "monster/monster-describer.h"
 #include "monster/monster-status.h"
 #include "monster/monster-update.h"
-#include "monster/monster-util.h"
 #include "pet/pet-util.h"
 #include "player-base/player-class.h"
 #include "player-info/equipment-info.h"
@@ -212,7 +211,7 @@ bool shock_power(PlayerType *player_ptr)
     PLAYER_LEVEL plev = player_ptr->lev;
     int dam = damroll(8 + ((plev - 5) / 4) + boost / 12, 8);
     fire_beam(player_ptr, AttributeType::MISSILE, dir, dam);
-    if (!is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+    if (!player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
         return true;
     }
 

--- a/src/mind/mind-force-trainer.cpp
+++ b/src/mind/mind-force-trainer.cpp
@@ -17,6 +17,7 @@
 #include "monster/monster-describer.h"
 #include "monster/monster-status.h"
 #include "monster/monster-update.h"
+#include "monster/monster-util.h"
 #include "pet/pet-util.h"
 #include "player-base/player-class.h"
 #include "player-info/equipment-info.h"
@@ -211,7 +212,7 @@ bool shock_power(PlayerType *player_ptr)
     PLAYER_LEVEL plev = player_ptr->lev;
     int dam = damroll(8 + ((plev - 5) / 4) + boost / 12, 8);
     fire_beam(player_ptr, AttributeType::MISSILE, dir, dam);
-    if (!player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+    if (!is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
         return true;
     }
 

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -23,6 +23,7 @@
 #include "monster/monster-describer.h"
 #include "monster/monster-status.h"
 #include "monster/monster-update.h"
+#include "monster/monster-util.h"
 #include "object-enchant/trc-types.h"
 #include "object/object-kind-hook.h"
 #include "player-attack/player-attack.h"
@@ -179,7 +180,7 @@ bool rush_attack(PlayerType *player_ptr, bool *mdeath)
             continue;
         }
 
-        if (!grid_new.m_idx) {
+        if (!is_monster(grid_new.m_idx)) {
             if (tm_idx) {
                 msg_print(_("失敗！", "Failed!"));
             } else {

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -23,7 +23,6 @@
 #include "monster/monster-describer.h"
 #include "monster/monster-status.h"
 #include "monster/monster-update.h"
-#include "monster/monster-util.h"
 #include "object-enchant/trc-types.h"
 #include "object/object-kind-hook.h"
 #include "player-attack/player-attack.h"
@@ -180,7 +179,7 @@ bool rush_attack(PlayerType *player_ptr, bool *mdeath)
             continue;
         }
 
-        if (!is_monster(grid_new.m_idx)) {
+        if (!grid_new.has_monster()) {
             if (tm_idx) {
                 msg_print(_("失敗！", "Failed!"));
             } else {

--- a/src/mind/mind-warrior.cpp
+++ b/src/mind/mind-warrior.cpp
@@ -1,7 +1,6 @@
 #include "mind/mind-warrior.h"
 #include "cmd-action/cmd-attack.h"
 #include "floor/geometry.h"
-#include "monster/monster-util.h"
 #include "spell-kind/spells-teleport.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
@@ -22,7 +21,7 @@ bool hit_and_away(PlayerType *player_ptr)
     }
     POSITION y = player_ptr->y + ddy[dir];
     POSITION x = player_ptr->x + ddx[dir];
-    if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+    if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
         do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
         if (randint0(player_ptr->skill_dis) < 7) {
             msg_print(_("うまく逃げられなかった。", "You failed to run away."));
@@ -54,7 +53,7 @@ bool sword_dancing(PlayerType *player_ptr)
         g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
 
         /* Hack -- attack monsters */
-        if (is_monster(g_ptr->m_idx)) {
+        if (g_ptr->has_monster()) {
             do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
         } else {
             msg_print(_("攻撃が空をきった。", "You attack the empty air."));

--- a/src/mind/mind-warrior.cpp
+++ b/src/mind/mind-warrior.cpp
@@ -1,6 +1,7 @@
 #include "mind/mind-warrior.h"
 #include "cmd-action/cmd-attack.h"
 #include "floor/geometry.h"
+#include "monster/monster-util.h"
 #include "spell-kind/spells-teleport.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
@@ -21,7 +22,7 @@ bool hit_and_away(PlayerType *player_ptr)
     }
     POSITION y = player_ptr->y + ddy[dir];
     POSITION x = player_ptr->x + ddx[dir];
-    if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+    if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
         do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
         if (randint0(player_ptr->skill_dis) < 7) {
             msg_print(_("うまく逃げられなかった。", "You failed to run away."));
@@ -53,7 +54,7 @@ bool sword_dancing(PlayerType *player_ptr)
         g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
 
         /* Hack -- attack monsters */
-        if (g_ptr->m_idx) {
+        if (is_monster(g_ptr->m_idx)) {
             do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
         } else {
             msg_print(_("攻撃が空をきった。", "You attack the empty air."));

--- a/src/mind/monk-attack.cpp
+++ b/src/mind/monk-attack.cpp
@@ -18,7 +18,6 @@
 #include "monster-race/monster-race.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
-#include "monster/monster-util.h"
 #include "player-attack/player-attack.h"
 #include "player-base/player-class.h"
 #include "player-info/monk-data-type.h"
@@ -273,7 +272,7 @@ bool double_attack(PlayerType *player_ptr)
     }
     POSITION y = player_ptr->y + ddy[dir];
     POSITION x = player_ptr->x + ddx[dir];
-    if (!is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+    if (!player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
         msg_print(_("その方向にはモンスターはいません。", "You don't see any monster in this direction"));
         msg_print(nullptr);
         return true;
@@ -288,7 +287,7 @@ bool double_attack(PlayerType *player_ptr)
     }
 
     do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
-    if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+    if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
         handle_stuff(player_ptr);
         do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
     }

--- a/src/mind/monk-attack.cpp
+++ b/src/mind/monk-attack.cpp
@@ -18,6 +18,7 @@
 #include "monster-race/monster-race.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
+#include "monster/monster-util.h"
 #include "player-attack/player-attack.h"
 #include "player-base/player-class.h"
 #include "player-info/monk-data-type.h"
@@ -272,7 +273,7 @@ bool double_attack(PlayerType *player_ptr)
     }
     POSITION y = player_ptr->y + ddy[dir];
     POSITION x = player_ptr->x + ddx[dir];
-    if (!player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+    if (!is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
         msg_print(_("その方向にはモンスターはいません。", "You don't see any monster in this direction"));
         msg_print(nullptr);
         return true;
@@ -287,7 +288,7 @@ bool double_attack(PlayerType *player_ptr)
     }
 
     do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
-    if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+    if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
         handle_stuff(player_ptr);
         do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
     }

--- a/src/monster-attack/monster-attack-processor.cpp
+++ b/src/monster-attack/monster-attack-processor.cpp
@@ -14,7 +14,6 @@
 #include "monster/monster-processor-util.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
-#include "monster/monster-util.h"
 #include "system/dungeon-info.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
@@ -123,7 +122,7 @@ static bool exe_monster_attack_to_monster(PlayerType *player_ptr, MONSTER_IDX m_
  */
 bool process_monster_attack_to_monster(PlayerType *player_ptr, turn_flags *turn_flags_ptr, MONSTER_IDX m_idx, Grid *g_ptr, bool can_cross)
 {
-    if (!turn_flags_ptr->do_move || !is_monster(g_ptr->m_idx)) {
+    if (!turn_flags_ptr->do_move || !g_ptr->has_monster()) {
         return false;
     }
 

--- a/src/monster-attack/monster-attack-processor.cpp
+++ b/src/monster-attack/monster-attack-processor.cpp
@@ -14,6 +14,7 @@
 #include "monster/monster-processor-util.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
+#include "monster/monster-util.h"
 #include "system/dungeon-info.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
@@ -122,7 +123,7 @@ static bool exe_monster_attack_to_monster(PlayerType *player_ptr, MONSTER_IDX m_
  */
 bool process_monster_attack_to_monster(PlayerType *player_ptr, turn_flags *turn_flags_ptr, MONSTER_IDX m_idx, Grid *g_ptr, bool can_cross)
 {
-    if (!turn_flags_ptr->do_move || (g_ptr->m_idx == 0)) {
+    if (!turn_flags_ptr->do_move || !is_monster(g_ptr->m_idx)) {
         return false;
     }
 

--- a/src/monster-floor/monster-generator.cpp
+++ b/src/monster-floor/monster-generator.cpp
@@ -165,14 +165,14 @@ bool multiply_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, bool clone, BIT
 
 /*!
  * @brief モンスターを目標地点に集団生成する / Attempt to place a "group" of monsters around the given location
- * @param who 召喚主のモンスター情報ID
+ * @param src_idx 召喚主のモンスター情報ID
  * @param y 中心生成位置y座標
  * @param x 中心生成位置x座標
  * @param r_idx 生成モンスター種族
  * @param mode 生成オプション
  * @return 成功したらtrue
  */
-static bool place_monster_group(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode)
+static bool place_monster_group(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode)
 {
     auto *r_ptr = &monraces_info[r_idx];
     auto total = randint1(10);
@@ -218,7 +218,7 @@ static bool place_monster_group(PlayerType *player_ptr, MONSTER_IDX who, POSITIO
                 continue;
             }
 
-            if (place_monster_one(player_ptr, who, my, mx, r_idx, mode)) {
+            if (place_monster_one(player_ptr, src_idx, my, mx, r_idx, mode)) {
                 hack_y[hack_n] = my;
                 hack_x[hack_n] = mx;
                 hack_n++;
@@ -280,7 +280,7 @@ static bool place_monster_can_escort(PlayerType *player_ptr, MonsterRaceId r_idx
 /*!
  * @brief 特定モンスターを生成する
  * @param player_ptr プレイヤーへの参照ポインタ
- * @param who 召喚主のモンスター情報ID
+ * @param src_idx 召喚主のモンスター情報ID
  * @param y 生成地点y座標
  * @param x 生成地点x座標
  * @param r_idx 生成するモンスターの種族ID
@@ -288,7 +288,7 @@ static bool place_monster_can_escort(PlayerType *player_ptr, MonsterRaceId r_idx
  * @return 生成に成功したらtrue
  * @details 護衛も一緒に生成する
  */
-bool place_specific_monster(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode)
+bool place_specific_monster(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode)
 {
     auto *r_ptr = &monraces_info[r_idx];
 
@@ -296,7 +296,7 @@ bool place_specific_monster(PlayerType *player_ptr, MONSTER_IDX who, POSITION y,
         mode |= PM_KAGE;
     }
 
-    if (!place_monster_one(player_ptr, who, y, x, r_idx, mode)) {
+    if (!place_monster_one(player_ptr, src_idx, y, x, r_idx, mode)) {
         return false;
     }
     if (!(mode & PM_ALLOW_GROUP)) {
@@ -328,7 +328,7 @@ bool place_specific_monster(PlayerType *player_ptr, MONSTER_IDX who, POSITION y,
     }
 
     if (r_ptr->misc_flags.has(MonsterMiscType::HAS_FRIENDS)) {
-        (void)place_monster_group(player_ptr, who, y, x, r_idx, mode);
+        (void)place_monster_group(player_ptr, src_idx, y, x, r_idx, mode);
     }
 
     if (r_ptr->misc_flags.has_not(MonsterMiscType::ESCORT)) {

--- a/src/monster-floor/monster-generator.h
+++ b/src/monster-floor/monster-generator.h
@@ -9,7 +9,7 @@ typedef bool (*summon_specific_pf)(PlayerType *, MONSTER_IDX, POSITION, POSITION
 
 bool mon_scatter(PlayerType *player_ptr, MonsterRaceId r_idx, POSITION *yp, POSITION *xp, POSITION y, POSITION x, POSITION max_dist);
 bool multiply_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, bool clone, BIT_FLAGS mode);
-bool place_specific_monster(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode);
+bool place_specific_monster(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode);
 bool place_random_monster(PlayerType *player_ptr, POSITION y, POSITION x, BIT_FLAGS mode);
 bool alloc_horde(PlayerType *player_ptr, POSITION y, POSITION x, summon_specific_pf summon_specific);
 bool alloc_guardian(PlayerType *player_ptr, bool def_val);

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -27,6 +27,7 @@
 #include "monster/monster-processor-util.h"
 #include "monster/monster-status.h"
 #include "monster/monster-update.h"
+#include "monster/monster-util.h"
 #include "pet/pet-util.h"
 #include "player/player-status-flags.h"
 #include "system/angband-system.h"
@@ -66,7 +67,7 @@ static bool process_wall(PlayerType *player_ptr, turn_flags *turn_flags_ptr, con
         return true;
     }
 
-    if (grid.m_idx > 0) {
+    if (is_monster(grid.m_idx)) {
         turn_flags_ptr->do_move = true;
         return true;
     }

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -27,7 +27,6 @@
 #include "monster/monster-processor-util.h"
 #include "monster/monster-status.h"
 #include "monster/monster-update.h"
-#include "monster/monster-util.h"
 #include "pet/pet-util.h"
 #include "player/player-status-flags.h"
 #include "system/angband-system.h"
@@ -67,7 +66,7 @@ static bool process_wall(PlayerType *player_ptr, turn_flags *turn_flags_ptr, con
         return true;
     }
 
-    if (is_monster(grid.m_idx)) {
+    if (grid.has_monster()) {
         turn_flags_ptr->do_move = true;
         return true;
     }

--- a/src/monster-floor/monster-remover.cpp
+++ b/src/monster-floor/monster-remover.cpp
@@ -9,7 +9,6 @@
 #include "monster/monster-info.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
-#include "monster/monster-util.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
@@ -159,7 +158,7 @@ void delete_monster(PlayerType *player_ptr, POSITION y, POSITION x)
     }
 
     g_ptr = &floor_ptr->grid_array[y][x];
-    if (is_monster(g_ptr->m_idx)) {
+    if (g_ptr->has_monster()) {
         delete_monster_idx(player_ptr, g_ptr->m_idx);
     }
 }

--- a/src/monster-floor/monster-remover.cpp
+++ b/src/monster-floor/monster-remover.cpp
@@ -9,6 +9,7 @@
 #include "monster/monster-info.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
+#include "monster/monster-util.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
@@ -158,7 +159,7 @@ void delete_monster(PlayerType *player_ptr, POSITION y, POSITION x)
     }
 
     g_ptr = &floor_ptr->grid_array[y][x];
-    if (g_ptr->m_idx) {
+    if (is_monster(g_ptr->m_idx)) {
         delete_monster_idx(player_ptr, g_ptr->m_idx);
     }
 }

--- a/src/monster-floor/monster-summon.cpp
+++ b/src/monster-floor/monster-summon.cpp
@@ -161,7 +161,7 @@ bool summon_specific(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y1, P
     summon_specific_type = SUMMON_NONE;
 
     bool notice = false;
-    if (src_idx <= 0) {
+    if (!is_monster(src_idx)) {
         notice = true;
     } else {
         auto *m_ptr = &player_ptr->current_floor_ptr->m_list[src_idx];

--- a/src/monster-floor/monster-summon.cpp
+++ b/src/monster-floor/monster-summon.cpp
@@ -117,7 +117,7 @@ DEPTH get_dungeon_or_wilderness_level(PlayerType *player_ptr)
 /*!
  * @brief モンスターを召喚により配置する / Place a monster (of the specified "type") near the given location. Return TRUE if a monster was actually summoned.
  * @param player_ptr プレイヤーへの参照ポインタ
- * @param who 召喚主のモンスター情報ID
+ * @param src_idx 召喚主のモンスター情報ID
  * @param y1 目標地点y座標
  * @param x1 目標地点x座標
  * @param lev 相当生成階
@@ -125,7 +125,7 @@ DEPTH get_dungeon_or_wilderness_level(PlayerType *player_ptr)
  * @param mode 生成オプション
  * @return 召喚できたらtrueを返す
  */
-bool summon_specific(PlayerType *player_ptr, MONSTER_IDX who, POSITION y1, POSITION x1, DEPTH lev, summon_type type, BIT_FLAGS mode)
+bool summon_specific(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y1, POSITION x1, DEPTH lev, summon_type type, BIT_FLAGS mode)
 {
     auto *floor_ptr = player_ptr->current_floor_ptr;
     if (floor_ptr->inside_arena) {
@@ -137,7 +137,7 @@ bool summon_specific(PlayerType *player_ptr, MONSTER_IDX who, POSITION y1, POSIT
         return false;
     }
 
-    summon_specific_who = who;
+    summon_specific_who = src_idx;
     summon_specific_type = type;
     summon_unique_okay = (mode & PM_ALLOW_UNIQUE) != 0;
     get_mon_num_prep(player_ptr, summon_specific_okay, get_monster_hook2(player_ptr, y, x));
@@ -153,7 +153,7 @@ bool summon_specific(PlayerType *player_ptr, MONSTER_IDX who, POSITION y1, POSIT
         mode |= PM_NO_KAGE;
     }
 
-    if (!place_specific_monster(player_ptr, who, y, x, r_idx, mode)) {
+    if (!place_specific_monster(player_ptr, src_idx, y, x, r_idx, mode)) {
         summon_specific_type = SUMMON_NONE;
         return false;
     }
@@ -161,10 +161,10 @@ bool summon_specific(PlayerType *player_ptr, MONSTER_IDX who, POSITION y1, POSIT
     summon_specific_type = SUMMON_NONE;
 
     bool notice = false;
-    if (who <= 0) {
+    if (src_idx <= 0) {
         notice = true;
     } else {
-        auto *m_ptr = &player_ptr->current_floor_ptr->m_list[who];
+        auto *m_ptr = &player_ptr->current_floor_ptr->m_list[src_idx];
         if (m_ptr->is_pet()) {
             notice = true;
         } else if (is_seen(player_ptr, m_ptr)) {
@@ -184,14 +184,14 @@ bool summon_specific(PlayerType *player_ptr, MONSTER_IDX who, POSITION y1, POSIT
 /*!
  * @brief 特定モンスター種族を召喚により生成する / A "dangerous" function, creates a pet of the specified type
  * @param player_ptr プレイヤーへの参照ポインタ
- * @param who 召喚主のモンスター情報ID
+ * @param src_idx 召喚主のモンスター情報ID
  * @param oy 目標地点y座標
  * @param ox 目標地点x座標
  * @param r_idx 生成するモンスター種族ID
  * @param mode 生成オプション
  * @return 召喚できたらtrueを返す
  */
-bool summon_named_creature(PlayerType *player_ptr, MONSTER_IDX who, POSITION oy, POSITION ox, MonsterRaceId r_idx, BIT_FLAGS mode)
+bool summon_named_creature(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION oy, POSITION ox, MonsterRaceId r_idx, BIT_FLAGS mode)
 {
     if (!MonsterRace(r_idx).is_valid() || (r_idx >= static_cast<MonsterRaceId>(monraces_info.size()))) {
         return false;
@@ -202,5 +202,5 @@ bool summon_named_creature(PlayerType *player_ptr, MONSTER_IDX who, POSITION oy,
         return false;
     }
 
-    return place_specific_monster(player_ptr, who, y, x, r_idx, (mode | PM_NO_KAGE));
+    return place_specific_monster(player_ptr, src_idx, y, x, r_idx, (mode | PM_NO_KAGE));
 }

--- a/src/monster-floor/monster-summon.h
+++ b/src/monster-floor/monster-summon.h
@@ -8,5 +8,5 @@ extern bool summon_unique_okay;
 enum summon_type : int;
 enum class MonsterRaceId : int16_t;
 class PlayerType;
-bool summon_specific(PlayerType *player_ptr, MONSTER_IDX who, POSITION y1, POSITION x1, DEPTH lev, summon_type type, BIT_FLAGS mode);
-bool summon_named_creature(PlayerType *player_ptr, MONSTER_IDX who, POSITION oy, POSITION ox, MonsterRaceId r_idx, BIT_FLAGS mode);
+bool summon_specific(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y1, POSITION x1, DEPTH lev, summon_type type, BIT_FLAGS mode);
+bool summon_named_creature(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION oy, POSITION ox, MonsterRaceId r_idx, BIT_FLAGS mode);

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -169,7 +169,7 @@ static bool check_quest_placeable(const FloorType &floor, MonsterRaceId r_idx)
     int number_mon = 0;
     for (int i2 = 0; i2 < floor.width; ++i2) {
         for (int j2 = 0; j2 < floor.height; j2++) {
-            auto quest_monster = is_monster(floor.grid_array[j2][i2].m_idx);
+            auto quest_monster = floor.grid_array[j2][i2].has_monster();
             quest_monster &= (floor.m_list[floor.grid_array[j2][i2].m_idx].r_idx == q_ptr->r_idx);
             if (quest_monster) {
                 number_mon++;
@@ -285,7 +285,7 @@ bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, 
 
     g_ptr->m_idx = m_pop(&floor);
     hack_m_idx_ii = g_ptr->m_idx;
-    if (!is_monster(g_ptr->m_idx)) {
+    if (!g_ptr->has_monster()) {
         return false;
     }
 

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -252,14 +252,14 @@ static void warn_unique_generation(PlayerType *player_ptr, MonsterRaceId r_idx)
 /*!
  * @brief モンスターを一体生成する / Attempt to place a monster of the given race at the given location.
  * @param player_ptr プレイヤーへの参照ポインタ
- * @param who 召喚を行ったモンスターID
+ * @param src_idx 召喚を行ったモンスターID
  * @param y 生成位置y座標
  * @param x 生成位置x座標
  * @param r_idx 生成モンスター種族
  * @param mode 生成オプション
  * @return 成功したらtrue
  */
-bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode)
+bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode)
 {
     auto &floor = *player_ptr->current_floor_ptr;
     auto *g_ptr = &floor.grid_array[y][x];
@@ -296,15 +296,15 @@ bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSI
 
     m_ptr->mflag.clear();
     m_ptr->mflag2.clear();
-    if (any_bits(mode, PM_MULTIPLY) && (who > 0) && !floor.m_list[who].is_original_ap()) {
-        m_ptr->ap_r_idx = floor.m_list[who].ap_r_idx;
-        if (floor.m_list[who].mflag2.has(MonsterConstantFlagType::KAGE)) {
+    if (any_bits(mode, PM_MULTIPLY) && (src_idx > 0) && !floor.m_list[src_idx].is_original_ap()) {
+        m_ptr->ap_r_idx = floor.m_list[src_idx].ap_r_idx;
+        if (floor.m_list[src_idx].mflag2.has(MonsterConstantFlagType::KAGE)) {
             m_ptr->mflag2.set(MonsterConstantFlagType::KAGE);
         }
     }
 
-    if ((who > 0) && r_ptr->kind_flags.has_none_of(alignment_mask)) {
-        m_ptr->sub_align = floor.m_list[who].sub_align;
+    if ((src_idx > 0) && r_ptr->kind_flags.has_none_of(alignment_mask)) {
+        m_ptr->sub_align = floor.m_list[src_idx].sub_align;
     } else {
         m_ptr->sub_align = SUB_ALIGN_NEUTRAL;
         if (r_ptr->kind_flags.has(MonsterKindType::EVIL)) {
@@ -328,9 +328,9 @@ bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSI
     m_ptr->nickname.clear();
     m_ptr->exp = 0;
 
-    if (who > 0 && floor.m_list[who].is_pet()) {
+    if (src_idx > 0 && floor.m_list[src_idx].is_pet()) {
         set_bits(mode, PM_FORCE_PET);
-        m_ptr->parent_m_idx = who;
+        m_ptr->parent_m_idx = src_idx;
     } else {
         m_ptr->parent_m_idx = 0;
     }
@@ -339,7 +339,7 @@ bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSI
         choose_new_monster(player_ptr, g_ptr->m_idx, true, MonsterRace::empty_id());
         r_ptr = &m_ptr->get_monrace();
         m_ptr->mflag2.set(MonsterConstantFlagType::CHAMELEON);
-        if (r_ptr->kind_flags.has(MonsterKindType::UNIQUE) && (who <= 0)) {
+        if (r_ptr->kind_flags.has(MonsterKindType::UNIQUE) && (src_idx <= 0)) {
             m_ptr->sub_align = SUB_ALIGN_NEUTRAL;
         }
     } else if (any_bits(mode, PM_KAGE) && none_bits(mode, PM_FORCE_PET)) {
@@ -358,7 +358,7 @@ bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSI
     m_ptr->ml = false;
     if (any_bits(mode, PM_FORCE_PET)) {
         set_pet(player_ptr, m_ptr);
-    } else if (((who == 0) && r_ptr->behavior_flags.has(MonsterBehaviorType::FRIENDLY)) || is_friendly_idx(player_ptr, who) || any_bits(mode, PM_FORCE_FRIENDLY)) {
+    } else if (((src_idx == 0) && r_ptr->behavior_flags.has(MonsterBehaviorType::FRIENDLY)) || is_friendly_idx(player_ptr, src_idx) || any_bits(mode, PM_FORCE_FRIENDLY)) {
         if (!monster_has_hostile_align(player_ptr, nullptr, 0, -1, r_ptr) && !player_ptr->current_floor_ptr->inside_arena) {
             set_friendly(m_ptr);
         }

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -169,7 +169,7 @@ static bool check_quest_placeable(const FloorType &floor, MonsterRaceId r_idx)
     int number_mon = 0;
     for (int i2 = 0; i2 < floor.width; ++i2) {
         for (int j2 = 0; j2 < floor.height; j2++) {
-            auto quest_monster = (floor.grid_array[j2][i2].m_idx > 0);
+            auto quest_monster = is_monster(floor.grid_array[j2][i2].m_idx);
             quest_monster &= (floor.m_list[floor.grid_array[j2][i2].m_idx].r_idx == q_ptr->r_idx);
             if (quest_monster) {
                 number_mon++;
@@ -285,7 +285,7 @@ bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, 
 
     g_ptr->m_idx = m_pop(&floor);
     hack_m_idx_ii = g_ptr->m_idx;
-    if (!g_ptr->m_idx) {
+    if (!is_monster(g_ptr->m_idx)) {
         return false;
     }
 
@@ -296,14 +296,14 @@ bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, 
 
     m_ptr->mflag.clear();
     m_ptr->mflag2.clear();
-    if (any_bits(mode, PM_MULTIPLY) && (src_idx > 0) && !floor.m_list[src_idx].is_original_ap()) {
+    if (any_bits(mode, PM_MULTIPLY) && is_monster(src_idx) && !floor.m_list[src_idx].is_original_ap()) {
         m_ptr->ap_r_idx = floor.m_list[src_idx].ap_r_idx;
         if (floor.m_list[src_idx].mflag2.has(MonsterConstantFlagType::KAGE)) {
             m_ptr->mflag2.set(MonsterConstantFlagType::KAGE);
         }
     }
 
-    if ((src_idx > 0) && r_ptr->kind_flags.has_none_of(alignment_mask)) {
+    if (is_monster(src_idx) && r_ptr->kind_flags.has_none_of(alignment_mask)) {
         m_ptr->sub_align = floor.m_list[src_idx].sub_align;
     } else {
         m_ptr->sub_align = SUB_ALIGN_NEUTRAL;
@@ -328,7 +328,7 @@ bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, 
     m_ptr->nickname.clear();
     m_ptr->exp = 0;
 
-    if (src_idx > 0 && floor.m_list[src_idx].is_pet()) {
+    if (is_monster(src_idx) && floor.m_list[src_idx].is_pet()) {
         set_bits(mode, PM_FORCE_PET);
         m_ptr->parent_m_idx = src_idx;
     } else {
@@ -339,7 +339,7 @@ bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, 
         choose_new_monster(player_ptr, g_ptr->m_idx, true, MonsterRace::empty_id());
         r_ptr = &m_ptr->get_monrace();
         m_ptr->mflag2.set(MonsterConstantFlagType::CHAMELEON);
-        if (r_ptr->kind_flags.has(MonsterKindType::UNIQUE) && (src_idx <= 0)) {
+        if (r_ptr->kind_flags.has(MonsterKindType::UNIQUE) && (!is_monster(src_idx))) {
             m_ptr->sub_align = SUB_ALIGN_NEUTRAL;
         }
     } else if (any_bits(mode, PM_KAGE) && none_bits(mode, PM_FORCE_PET)) {
@@ -358,7 +358,7 @@ bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, 
     m_ptr->ml = false;
     if (any_bits(mode, PM_FORCE_PET)) {
         set_pet(player_ptr, m_ptr);
-    } else if (((src_idx == 0) && r_ptr->behavior_flags.has(MonsterBehaviorType::FRIENDLY)) || is_friendly_idx(player_ptr, src_idx) || any_bits(mode, PM_FORCE_FRIENDLY)) {
+    } else if ((is_player(src_idx) && r_ptr->behavior_flags.has(MonsterBehaviorType::FRIENDLY)) || is_friendly_idx(player_ptr, src_idx) || any_bits(mode, PM_FORCE_FRIENDLY)) {
         if (!monster_has_hostile_align(player_ptr, nullptr, 0, -1, r_ptr) && !player_ptr->current_floor_ptr->inside_arena) {
             set_friendly(m_ptr);
         }

--- a/src/monster-floor/one-monster-placer.h
+++ b/src/monster-floor/one-monster-placer.h
@@ -4,4 +4,4 @@
 
 enum class MonsterRaceId : int16_t;
 class PlayerType;
-bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode);
+bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode);

--- a/src/monster/monster-info.cpp
+++ b/src/monster/monster-info.cpp
@@ -19,6 +19,7 @@
 #include "monster/monster-describer.h"
 #include "monster/monster-flag-types.h"
 #include "monster/monster-status.h"
+#include "monster/monster-util.h"
 #include "monster/smart-learn-types.h"
 #include "player/player-status-flags.h"
 #include "system/floor-type-definition.h"
@@ -147,7 +148,7 @@ bool monster_can_enter(PlayerType *player_ptr, POSITION y, POSITION x, MonsterRa
     if (player_ptr->is_located_at(pos)) {
         return false;
     }
-    if (grid.m_idx) {
+    if (is_monster(grid.m_idx)) {
         return false;
     }
 

--- a/src/monster/monster-info.cpp
+++ b/src/monster/monster-info.cpp
@@ -19,7 +19,6 @@
 #include "monster/monster-describer.h"
 #include "monster/monster-flag-types.h"
 #include "monster/monster-status.h"
-#include "monster/monster-util.h"
 #include "monster/smart-learn-types.h"
 #include "player/player-status-flags.h"
 #include "system/floor-type-definition.h"
@@ -148,7 +147,7 @@ bool monster_can_enter(PlayerType *player_ptr, POSITION y, POSITION x, MonsterRa
     if (player_ptr->is_located_at(pos)) {
         return false;
     }
-    if (is_monster(grid.m_idx)) {
+    if (grid.has_monster()) {
         return false;
     }
 

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -449,7 +449,7 @@ int get_monster_crowd_number(FloorType *floor_ptr, MONSTER_IDX m_idx)
         if (!in_bounds(floor_ptr, ay, ax)) {
             continue;
         }
-        if (is_monster(floor_ptr->grid_array[ay][ax].m_idx)) {
+        if (floor_ptr->grid_array[ay][ax].has_monster()) {
             count++;
         }
     }

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -449,7 +449,7 @@ int get_monster_crowd_number(FloorType *floor_ptr, MONSTER_IDX m_idx)
         if (!in_bounds(floor_ptr, ay, ax)) {
             continue;
         }
-        if (floor_ptr->grid_array[ay][ax].m_idx > 0) {
+        if (is_monster(floor_ptr->grid_array[ay][ax].m_idx)) {
             count++;
         }
     }

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -452,7 +452,7 @@ bool decide_monster_multiplication(PlayerType *player_ptr, MONSTER_IDX m_idx, PO
                 continue;
             }
 
-            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+            if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
                 k++;
             }
         }

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -452,7 +452,7 @@ bool decide_monster_multiplication(PlayerType *player_ptr, MONSTER_IDX m_idx, PO
                 continue;
             }
 
-            if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
                 k++;
             }
         }

--- a/src/monster/monster-status-setter.cpp
+++ b/src/monster/monster-status-setter.cpp
@@ -360,12 +360,12 @@ bool set_monster_invulner(PlayerType *player_ptr, MONSTER_IDX m_idx, int v, bool
  * @brief モンスターの時間停止処理
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param num 時間停止を行った敵が行動できる回数
- * @param who 時間停止を行う敵の種族番号
+ * @param src_idx 時間停止を行う敵の種族番号
  * @param vs_player TRUEならば時間停止開始処理を行う
  * @return 時間停止が行われている状態ならばTRUEを返す
  * @details monster_desc() は視認外のモンスターについて「何か」と返してくるので、この関数ではLOSや透明視等を判定する必要はない
  */
-bool set_monster_timewalk(PlayerType *player_ptr, int num, MonsterRaceId who, bool vs_player)
+bool set_monster_timewalk(PlayerType *player_ptr, int num, MonsterRaceId src_idx, bool vs_player)
 {
     auto &floor = *player_ptr->current_floor_ptr;
     auto *m_ptr = &floor.m_list[hack_m_idx];
@@ -376,7 +376,7 @@ bool set_monster_timewalk(PlayerType *player_ptr, int num, MonsterRaceId who, bo
     if (vs_player) {
         const auto m_name = monster_desc(player_ptr, m_ptr, 0);
         std::string mes;
-        switch (who) {
+        switch (src_idx) {
         case MonsterRaceId::DIO:
             mes = _("「『ザ・ワールド』！　時は止まった！」", format("%s yells 'The World! Time has stopped!'", m_name.data()));
             break;
@@ -426,7 +426,7 @@ bool set_monster_timewalk(PlayerType *player_ptr, int num, MonsterRaceId who, bo
     should_output_message &= projectable(player_ptr, player_ptr->y, player_ptr->x, m_ptr->fy, m_ptr->fx);
     if (vs_player || should_output_message) {
         std::string mes;
-        switch (who) {
+        switch (src_idx) {
         case MonsterRaceId::DIAVOLO:
             mes = _("これが我が『キング・クリムゾン』の能力！　『時間を消し去って』飛び越えさせた…！！",
                 "This is the ability of my 'King Crimson'! 'Erase the time' and let it jump over... !!");

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -21,7 +21,6 @@
 #include "monster/monster-info.h"
 #include "monster/monster-processor-util.h"
 #include "monster/monster-status.h"
-#include "monster/monster-util.h"
 #include "monster/smart-learn-types.h"
 #include "player-base/player-class.h"
 #include "player-info/samurai-data-type.h"
@@ -78,7 +77,7 @@ bool update_riding_monster(PlayerType *player_ptr, turn_flags *turn_flags_ptr, M
     }
 
     player_ptr->current_floor_ptr->grid_array[oy][ox].m_idx = g_ptr->m_idx;
-    if (is_monster(g_ptr->m_idx)) {
+    if (g_ptr->has_monster()) {
         y_ptr->fy = oy;
         y_ptr->fx = ox;
         update_monster(player_ptr, g_ptr->m_idx, true);

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -21,6 +21,7 @@
 #include "monster/monster-info.h"
 #include "monster/monster-processor-util.h"
 #include "monster/monster-status.h"
+#include "monster/monster-util.h"
 #include "monster/smart-learn-types.h"
 #include "player-base/player-class.h"
 #include "player-info/samurai-data-type.h"
@@ -77,7 +78,7 @@ bool update_riding_monster(PlayerType *player_ptr, turn_flags *turn_flags_ptr, M
     }
 
     player_ptr->current_floor_ptr->grid_array[oy][ox].m_idx = g_ptr->m_idx;
-    if (g_ptr->m_idx) {
+    if (is_monster(g_ptr->m_idx)) {
         y_ptr->fy = oy;
         y_ptr->fx = ox;
         update_monster(player_ptr, g_ptr->m_idx, true);

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -361,3 +361,13 @@ errr get_mon_num_prep_bounty(PlayerType *player_ptr)
 {
     return do_get_mon_num_prep(player_ptr, nullptr, nullptr, false);
 }
+
+bool is_player(MONSTER_IDX m_idx)
+{
+    return m_idx == 0;
+}
+
+bool is_monster(MONSTER_IDX m_idx)
+{
+    return m_idx > 0;
+}

--- a/src/monster/monster-util.h
+++ b/src/monster/monster-util.h
@@ -16,3 +16,5 @@ monsterrace_hook_type get_monster_hook(PlayerType *player_ptr);
 monsterrace_hook_type get_monster_hook2(PlayerType *player_ptr, POSITION y, POSITION x);
 errr get_mon_num_prep(PlayerType *player_ptr, monsterrace_hook_type hook1, monsterrace_hook_type hook2);
 errr get_mon_num_prep_bounty(PlayerType *player_ptr);
+bool is_player(MONSTER_IDX m_idx);
+bool is_monster(MONSTER_IDX m_idx);

--- a/src/mspell/mspell-checker.cpp
+++ b/src/mspell/mspell-checker.cpp
@@ -29,6 +29,7 @@
 #include "monster/monster-flag-types.h"
 #include "monster/monster-info.h"
 #include "monster/monster-status.h"
+#include "monster/monster-util.h"
 #include "mspell/assign-monster-spell.h"
 #include "mspell/improper-mspell-remover.h"
 #include "mspell/mspell-judgement.h"
@@ -166,7 +167,7 @@ bool clean_shot(PlayerType *player_ptr, POSITION y1, POSITION x1, POSITION y2, P
     for (const auto &[y, x] : grid_g) {
         const Pos2D pos(y, x);
         const auto &grid = floor_ptr->get_grid(pos);
-        if ((grid.m_idx > 0) && (y != y2 || x != x2)) {
+        if (is_monster(grid.m_idx) && (y != y2 || x != x2)) {
             auto *m_ptr = &floor_ptr->m_list[grid.m_idx];
             if (is_friend == m_ptr->is_pet()) {
                 return false;

--- a/src/mspell/mspell-checker.cpp
+++ b/src/mspell/mspell-checker.cpp
@@ -167,7 +167,7 @@ bool clean_shot(PlayerType *player_ptr, POSITION y1, POSITION x1, POSITION y2, P
     for (const auto &[y, x] : grid_g) {
         const Pos2D pos(y, x);
         const auto &grid = floor_ptr->get_grid(pos);
-        if (is_monster(grid.m_idx) && (y != y2 || x != x2)) {
+        if (grid.has_monster() && (y != y2 || x != x2)) {
             auto *m_ptr = &floor_ptr->m_list[grid.m_idx];
             if (is_friend == m_ptr->is_pet()) {
                 return false;

--- a/src/mspell/mspell-judgement.cpp
+++ b/src/mspell/mspell-judgement.cpp
@@ -20,6 +20,7 @@
 #include "monster-race/monster-race.h"
 #include "monster-race/race-flags-resistance.h"
 #include "monster/monster-status.h"
+#include "monster/monster-util.h"
 #include "player-base/player-class.h"
 #include "player-base/player-race.h"
 #include "player-info/race-info.h"
@@ -65,7 +66,7 @@ bool direct_beam(PlayerType *player_ptr, POSITION y1, POSITION x1, POSITION y2, 
         const auto &grid = floor.get_grid(pos);
         if (y == y2 && x == x2) {
             hit2 = true;
-        } else if (is_friend && grid.m_idx > 0 && !m_ptr->is_hostile_to_melee(floor.m_list[grid.m_idx])) {
+        } else if (is_friend && is_monster(grid.m_idx) && !m_ptr->is_hostile_to_melee(floor.m_list[grid.m_idx])) {
             return false;
         }
 

--- a/src/mspell/mspell-judgement.cpp
+++ b/src/mspell/mspell-judgement.cpp
@@ -20,7 +20,6 @@
 #include "monster-race/monster-race.h"
 #include "monster-race/race-flags-resistance.h"
 #include "monster/monster-status.h"
-#include "monster/monster-util.h"
 #include "player-base/player-class.h"
 #include "player-base/player-race.h"
 #include "player-info/race-info.h"
@@ -66,7 +65,7 @@ bool direct_beam(PlayerType *player_ptr, POSITION y1, POSITION x1, POSITION y2, 
         const auto &grid = floor.get_grid(pos);
         if (y == y2 && x == x2) {
             hit2 = true;
-        } else if (is_friend && is_monster(grid.m_idx) && !m_ptr->is_hostile_to_melee(floor.m_list[grid.m_idx])) {
+        } else if (is_friend && grid.has_monster() && !m_ptr->is_hostile_to_melee(floor.m_list[grid.m_idx])) {
             return false;
         }
 

--- a/src/mutation/mutation-techniques.cpp
+++ b/src/mutation/mutation-techniques.cpp
@@ -9,6 +9,7 @@
 #include "floor/geometry.h"
 #include "grid/grid.h"
 #include "monster/monster-info.h"
+#include "monster/monster-util.h"
 #include "player/digestion-processor.h"
 #include "player/player-move.h"
 #include "player/player-status.h"
@@ -43,7 +44,7 @@ bool eat_rock(PlayerType *player_ptr)
         msg_print(_("この地形は食べられない。", "You cannot eat this feature."));
     } else if (terrain.flags.has(TerrainCharacteristics::PERMANENT)) {
         msg_format(_("いてっ！この%sはあなたの歯より硬い！", "Ouch!  This %s is harder than your teeth!"), terrain_mimic.name.data());
-    } else if (grid.m_idx) {
+    } else if (is_monster(grid.m_idx)) {
         const auto &monster = player_ptr->current_floor_ptr->m_list[grid.m_idx];
         msg_print(_("何かが邪魔しています！", "There's something in the way!"));
         if (!monster.ml || !monster.is_pet()) {

--- a/src/mutation/mutation-techniques.cpp
+++ b/src/mutation/mutation-techniques.cpp
@@ -9,7 +9,6 @@
 #include "floor/geometry.h"
 #include "grid/grid.h"
 #include "monster/monster-info.h"
-#include "monster/monster-util.h"
 #include "player/digestion-processor.h"
 #include "player/player-move.h"
 #include "player/player-status.h"
@@ -44,7 +43,7 @@ bool eat_rock(PlayerType *player_ptr)
         msg_print(_("この地形は食べられない。", "You cannot eat this feature."));
     } else if (terrain.flags.has(TerrainCharacteristics::PERMANENT)) {
         msg_format(_("いてっ！この%sはあなたの歯より硬い！", "Ouch!  This %s is harder than your teeth!"), terrain_mimic.name.data());
-    } else if (is_monster(grid.m_idx)) {
+    } else if (grid.has_monster()) {
         const auto &monster = player_ptr->current_floor_ptr->m_list[grid.m_idx];
         msg_print(_("何かが邪魔しています！", "There's something in the way!"));
         if (!monster.ml || !monster.is_pet()) {

--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -38,7 +38,6 @@
 #include "monster/monster-pain-describer.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
-#include "monster/monster-util.h"
 #include "object-enchant/tr-types.h"
 #include "object-hook/hook-expendable.h"
 #include "object-hook/hook-weapon.h"
@@ -264,7 +263,7 @@ void ObjectThrowEntity::display_potion_throw()
 
     auto *floor_ptr = this->player_ptr->current_floor_ptr;
     auto *angry_m_ptr = &floor_ptr->m_list[floor_ptr->grid_array[this->y][this->x].m_idx];
-    if (!is_monster(floor_ptr->grid_array[this->y][this->x].m_idx) || !angry_m_ptr->is_friendly() || angry_m_ptr->is_invulnerable()) {
+    if (!floor_ptr->grid_array[this->y][this->x].has_monster() || !angry_m_ptr->is_friendly() || angry_m_ptr->is_invulnerable()) {
         this->do_drop = false;
         return;
     }

--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -38,6 +38,7 @@
 #include "monster/monster-pain-describer.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
+#include "monster/monster-util.h"
 #include "object-enchant/tr-types.h"
 #include "object-hook/hook-expendable.h"
 #include "object-hook/hook-weapon.h"
@@ -263,7 +264,7 @@ void ObjectThrowEntity::display_potion_throw()
 
     auto *floor_ptr = this->player_ptr->current_floor_ptr;
     auto *angry_m_ptr = &floor_ptr->m_list[floor_ptr->grid_array[this->y][this->x].m_idx];
-    if ((floor_ptr->grid_array[this->y][this->x].m_idx == 0) || !angry_m_ptr->is_friendly() || angry_m_ptr->is_invulnerable()) {
+    if (!is_monster(floor_ptr->grid_array[this->y][this->x].m_idx) || !angry_m_ptr->is_friendly() || angry_m_ptr->is_invulnerable()) {
         this->do_drop = false;
         return;
     }

--- a/src/object/object-broken.cpp
+++ b/src/object/object-broken.cpp
@@ -201,7 +201,7 @@ bool ObjectBreaker::can_destroy(ItemEntity *o_ptr) const
  *    o_ptr --- pointer to the potion object.
  * </pre>
  */
-bool potion_smash_effect(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSITION x, short bi_id)
+bool potion_smash_effect(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, short bi_id)
 {
     int radius = 2;
     AttributeType dt = AttributeType::NONE;
@@ -335,7 +335,7 @@ bool potion_smash_effect(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, PO
         break;
     }
 
-    (void)project(player_ptr, who, radius, y, x, dam, dt, (PROJECT_JUMP | PROJECT_ITEM | PROJECT_KILL));
+    (void)project(player_ptr, src_idx, radius, y, x, dam, dt, (PROJECT_JUMP | PROJECT_ITEM | PROJECT_KILL));
     return angry;
 }
 

--- a/src/object/object-broken.h
+++ b/src/object/object-broken.h
@@ -6,7 +6,7 @@
 class ItemEntity;
 class PlayerType;
 
-bool potion_smash_effect(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSITION x, short bi_id);
+bool potion_smash_effect(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, short bi_id);
 PERCENTAGE breakage_chance(PlayerType *player_ptr, ItemEntity *o_ptr, bool has_archer_bonus, SPELL_IDX snipe_type);
 
 class ObjectBreaker {

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -17,7 +17,6 @@
 #include "monster-race/race-indice-types.h"
 #include "monster/monster-info.h"
 #include "monster/monster-status.h"
-#include "monster/monster-util.h"
 #include "mspell/mspell-damage-calculator.h"
 #include "mutation/mutation-flag-types.h"
 #include "object-enchant/tr-types.h"
@@ -367,7 +366,7 @@ bool process_warning(PlayerType *player_ptr, POSITION xx, POSITION yy)
 
             const auto *g_ptr = &floor.grid_array[my][mx];
 
-            if (!is_monster(g_ptr->m_idx)) {
+            if (!g_ptr->has_monster()) {
                 continue;
             }
 

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -17,6 +17,7 @@
 #include "monster-race/race-indice-types.h"
 #include "monster/monster-info.h"
 #include "monster/monster-status.h"
+#include "monster/monster-util.h"
 #include "mspell/mspell-damage-calculator.h"
 #include "mutation/mutation-flag-types.h"
 #include "object-enchant/tr-types.h"
@@ -366,7 +367,7 @@ bool process_warning(PlayerType *player_ptr, POSITION xx, POSITION yy)
 
             const auto *g_ptr = &floor.grid_array[my][mx];
 
-            if (!g_ptr->m_idx) {
+            if (!is_monster(g_ptr->m_idx)) {
                 continue;
             }
 

--- a/src/pet/pet-fall-off.cpp
+++ b/src/pet/pet-fall-off.cpp
@@ -13,6 +13,7 @@
 #include "monster-attack/monster-attack-player.h"
 #include "monster-race/monster-race.h"
 #include "monster/monster-describer.h"
+#include "monster/monster-util.h"
 #include "pet/pet-util.h"
 #include "player-base/player-class.h"
 #include "player/player-damage.h"
@@ -111,7 +112,7 @@ bool process_fall_off_horse(PlayerType *player_ptr, int dam, bool force)
             Grid *g_ptr;
             g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
 
-            if (g_ptr->m_idx) {
+            if (is_monster(g_ptr->m_idx)) {
                 continue;
             }
 

--- a/src/pet/pet-fall-off.cpp
+++ b/src/pet/pet-fall-off.cpp
@@ -13,7 +13,6 @@
 #include "monster-attack/monster-attack-player.h"
 #include "monster-race/monster-race.h"
 #include "monster/monster-describer.h"
-#include "monster/monster-util.h"
 #include "pet/pet-util.h"
 #include "player-base/player-class.h"
 #include "player/player-damage.h"
@@ -112,7 +111,7 @@ bool process_fall_off_horse(PlayerType *player_ptr, int dam, bool force)
             Grid *g_ptr;
             g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
 
-            if (is_monster(g_ptr->m_idx)) {
+            if (g_ptr->has_monster()) {
                 continue;
             }
 

--- a/src/player-attack/player-attack.cpp
+++ b/src/player-attack/player-attack.cpp
@@ -28,6 +28,7 @@
 #include "monster/monster-describer.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
+#include "monster/monster-util.h"
 #include "object-enchant/tr-types.h"
 #include "object-enchant/vorpal-weapon.h"
 #include "object-hook/hook-weapon.h"
@@ -519,7 +520,7 @@ static void cause_earthquake(PlayerType *player_ptr, player_attack_type *pa_ptr,
     }
 
     earthquake(player_ptr, player_ptr->y, player_ptr->x, 10, 0);
-    if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx == 0) {
+    if (!is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
         *(pa_ptr->mdeath) = true;
     }
 }
@@ -612,7 +613,7 @@ void massacre(PlayerType *player_ptr)
         POSITION x = player_ptr->x + ddx_ddd[dir];
         g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
         m_ptr = &player_ptr->current_floor_ptr->m_list[g_ptr->m_idx];
-        if (g_ptr->m_idx && (m_ptr->ml || cave_has_flag_bold(player_ptr->current_floor_ptr, y, x, TerrainCharacteristics::PROJECT))) {
+        if (is_monster(g_ptr->m_idx) && (m_ptr->ml || cave_has_flag_bold(player_ptr->current_floor_ptr, y, x, TerrainCharacteristics::PROJECT))) {
             do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
         }
     }

--- a/src/player-attack/player-attack.cpp
+++ b/src/player-attack/player-attack.cpp
@@ -520,7 +520,7 @@ static void cause_earthquake(PlayerType *player_ptr, player_attack_type *pa_ptr,
     }
 
     earthquake(player_ptr, player_ptr->y, player_ptr->x, 10, 0);
-    if (!is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+    if (!player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
         *(pa_ptr->mdeath) = true;
     }
 }
@@ -613,7 +613,7 @@ void massacre(PlayerType *player_ptr)
         POSITION x = player_ptr->x + ddx_ddd[dir];
         g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
         m_ptr = &player_ptr->current_floor_ptr->m_list[g_ptr->m_idx];
-        if (is_monster(g_ptr->m_idx) && (m_ptr->ml || cave_has_flag_bold(player_ptr->current_floor_ptr, y, x, TerrainCharacteristics::PROJECT))) {
+        if (g_ptr->has_monster() && (m_ptr->ml || cave_has_flag_bold(player_ptr->current_floor_ptr, y, x, TerrainCharacteristics::PROJECT))) {
             do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
         }
     }

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -34,7 +34,6 @@
 #include "monster-race/monster-race-hook.h"
 #include "monster-race/monster-race.h"
 #include "monster/monster-update.h"
-#include "monster/monster-util.h"
 #include "monster/smart-learn-types.h"
 #include "mutation/mutation-calculator.h"
 #include "mutation/mutation-flag-types.h"
@@ -174,7 +173,7 @@ static void delayed_visual_update(PlayerType *player_ptr)
         }
 
         lite_spot(player_ptr, y, x);
-        if (is_monster(g_ptr->m_idx)) {
+        if (g_ptr->has_monster()) {
             update_monster(player_ptr, g_ptr->m_idx, false);
         }
 
@@ -2817,7 +2816,7 @@ bool player_has_no_spellbooks(PlayerType *player_ptr)
  */
 bool player_place(PlayerType *player_ptr, POSITION y, POSITION x)
 {
-    if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+    if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
         return false;
     }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -34,6 +34,7 @@
 #include "monster-race/monster-race-hook.h"
 #include "monster-race/monster-race.h"
 #include "monster/monster-update.h"
+#include "monster/monster-util.h"
 #include "monster/smart-learn-types.h"
 #include "mutation/mutation-calculator.h"
 #include "mutation/mutation-flag-types.h"
@@ -173,7 +174,7 @@ static void delayed_visual_update(PlayerType *player_ptr)
         }
 
         lite_spot(player_ptr, y, x);
-        if (g_ptr->m_idx) {
+        if (is_monster(g_ptr->m_idx)) {
             update_monster(player_ptr, g_ptr->m_idx, false);
         }
 
@@ -2816,7 +2817,7 @@ bool player_has_no_spellbooks(PlayerType *player_ptr)
  */
 bool player_place(PlayerType *player_ptr, POSITION y, POSITION x)
 {
-    if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx != 0) {
+    if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
         return false;
     }
 

--- a/src/racial/racial-vampire.cpp
+++ b/src/racial/racial-vampire.cpp
@@ -2,6 +2,7 @@
 #include "dungeon/dungeon-flag-types.h"
 #include "floor/geometry.h"
 #include "hpmp/hp-mp-processor.h"
+#include "monster/monster-util.h"
 #include "player/digestion-processor.h"
 #include "player/player-status.h"
 #include "spell-kind/spells-specific-bolt.h"
@@ -29,7 +30,7 @@ bool vampirism(PlayerType *player_ptr)
     POSITION x = player_ptr->x + ddx[dir];
     const auto *g_ptr = &floor.grid_array[y][x];
     stop_mouth(player_ptr);
-    if (!(g_ptr->m_idx)) {
+    if (!is_monster(g_ptr->m_idx)) {
         msg_print(_("何もない場所に噛みついた！", "You bite into thin air!"));
         return false;
     }

--- a/src/racial/racial-vampire.cpp
+++ b/src/racial/racial-vampire.cpp
@@ -2,7 +2,6 @@
 #include "dungeon/dungeon-flag-types.h"
 #include "floor/geometry.h"
 #include "hpmp/hp-mp-processor.h"
-#include "monster/monster-util.h"
 #include "player/digestion-processor.h"
 #include "player/player-status.h"
 #include "spell-kind/spells-specific-bolt.h"
@@ -30,7 +29,7 @@ bool vampirism(PlayerType *player_ptr)
     POSITION x = player_ptr->x + ddx[dir];
     const auto *g_ptr = &floor.grid_array[y][x];
     stop_mouth(player_ptr);
-    if (!is_monster(g_ptr->m_idx)) {
+    if (!g_ptr->has_monster()) {
         msg_print(_("何もない場所に噛みついた！", "You bite into thin air!"));
         return false;
     }

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -20,6 +20,7 @@
 #include "inventory/inventory-slot-types.h"
 #include "io/input-key-requester.h"
 #include "monster-race/monster-race.h"
+#include "monster/monster-util.h"
 #include "object-enchant/object-curse.h"
 #include "object-enchant/tr-types.h"
 #include "object-enchant/trc-types.h"
@@ -841,7 +842,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
                     if (dir == 5) {
                         continue;
                     }
-                    if (floor_ptr->grid_array[dy][dx].m_idx) {
+                    if (is_monster(floor_ptr->grid_array[dy][dx].m_idx)) {
                         flag = true;
                     }
                 }

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -20,7 +20,6 @@
 #include "inventory/inventory-slot-types.h"
 #include "io/input-key-requester.h"
 #include "monster-race/monster-race.h"
-#include "monster/monster-util.h"
 #include "object-enchant/object-curse.h"
 #include "object-enchant/tr-types.h"
 #include "object-enchant/trc-types.h"
@@ -842,7 +841,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
                     if (dir == 5) {
                         continue;
                     }
-                    if (is_monster(floor_ptr->grid_array[dy][dx].m_idx)) {
+                    if (floor_ptr->grid_array[dy][dx].has_monster()) {
                         flag = true;
                     }
                 }

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -26,6 +26,7 @@
 #include "monster/monster-describer.h"
 #include "monster/monster-info.h"
 #include "monster/monster-update.h"
+#include "monster/monster-util.h"
 #include "object-enchant/tr-types.h"
 #include "player-info/equipment-info.h"
 #include "player/player-damage.h"
@@ -122,7 +123,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
 
             y = player_ptr->y + ddy_cdd[cdir];
             x = player_ptr->x + ddx_cdd[cdir];
-            if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
             } else {
                 msg_print(_("攻撃は空を切った。", "You attack the empty air."));
@@ -130,7 +131,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
 
             y = player_ptr->y + ddy_cdd[(cdir + 7) % 8];
             x = player_ptr->x + ddx_cdd[(cdir + 7) % 8];
-            if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
             } else {
                 msg_print(_("攻撃は空を切った。", "You attack the empty air."));
@@ -138,7 +139,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
 
             y = player_ptr->y + ddy_cdd[(cdir + 1) % 8];
             x = player_ptr->x + ddx_cdd[(cdir + 1) % 8];
-            if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
             } else {
                 msg_print(_("攻撃は空を切った。", "You attack the empty air."));
@@ -183,7 +184,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_FIRE);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -226,7 +227,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_MINEUCHI);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -283,7 +284,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
 
             const auto *floor_ptr = player_ptr->current_floor_ptr;
             const auto &grid = floor_ptr->grid_array[y][x];
-            if (!grid.m_idx) {
+            if (!is_monster(grid.m_idx)) {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
                 return std::nullopt;
             }
@@ -324,7 +325,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_POISON);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -355,7 +356,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_ZANMA);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -386,7 +387,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             x = player_ptr->x + ddx[dir];
 
             const auto &floor = *player_ptr->current_floor_ptr;
-            if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -395,7 +396,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::NO_MELEE)) {
                 return "";
             }
-            if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
                 int i;
                 POSITION ty = y, tx = x;
                 POSITION oy = y, ox = x;
@@ -475,7 +476,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_HAGAN);
             }
 
@@ -511,7 +512,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_COLD);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -542,7 +543,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_KYUSHO);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -572,7 +573,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_MAJIN);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -603,7 +604,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_SUTEMI);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -634,7 +635,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_ELEC);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -678,7 +679,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 x = player_ptr->x + ddx_ddd[dir];
                 auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
                 auto *m_ptr = &player_ptr->current_floor_ptr->m_list[g_ptr->m_idx];
-                if ((g_ptr->m_idx == 0) || (!m_ptr->ml && !cave_has_flag_bold(player_ptr->current_floor_ptr, y, x, TerrainCharacteristics::PROJECT))) {
+                if (!is_monster(g_ptr->m_idx) || (!m_ptr->ml && !cave_has_flag_bold(player_ptr->current_floor_ptr, y, x, TerrainCharacteristics::PROJECT))) {
                     continue;
                 }
 
@@ -714,7 +715,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_QUAKE);
             } else {
                 earthquake(player_ptr, player_ptr->y, player_ptr->x, 10, 0);
@@ -814,7 +815,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 x = player_ptr->x + ddx[dir];
                 g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
 
-                if (g_ptr->m_idx) {
+                if (is_monster(g_ptr->m_idx)) {
                     do_cmd_attack(player_ptr, y, x, HISSATSU_3DAN);
                 } else {
                     msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -826,7 +827,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 }
 
                 /* Monster is dead? */
-                if (!g_ptr->m_idx) {
+                if (!is_monster(g_ptr->m_idx)) {
                     break;
                 }
 
@@ -896,7 +897,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_DRAIN);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -1012,9 +1013,9 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
-                if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+                if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
                     handle_stuff(player_ptr);
                     do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
                 }
@@ -1107,7 +1108,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (player_ptr->current_floor_ptr->grid_array[y][x].m_idx) {
+            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_UNDEAD);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -26,7 +26,6 @@
 #include "monster/monster-describer.h"
 #include "monster/monster-info.h"
 #include "monster/monster-update.h"
-#include "monster/monster-util.h"
 #include "object-enchant/tr-types.h"
 #include "player-info/equipment-info.h"
 #include "player/player-damage.h"
@@ -123,7 +122,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
 
             y = player_ptr->y + ddy_cdd[cdir];
             x = player_ptr->x + ddx_cdd[cdir];
-            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+            if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
             } else {
                 msg_print(_("攻撃は空を切った。", "You attack the empty air."));
@@ -131,7 +130,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
 
             y = player_ptr->y + ddy_cdd[(cdir + 7) % 8];
             x = player_ptr->x + ddx_cdd[(cdir + 7) % 8];
-            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+            if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
             } else {
                 msg_print(_("攻撃は空を切った。", "You attack the empty air."));
@@ -139,7 +138,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
 
             y = player_ptr->y + ddy_cdd[(cdir + 1) % 8];
             x = player_ptr->x + ddx_cdd[(cdir + 1) % 8];
-            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+            if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
             } else {
                 msg_print(_("攻撃は空を切った。", "You attack the empty air."));
@@ -184,7 +183,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+            if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_FIRE);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -227,7 +226,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+            if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_MINEUCHI);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -284,7 +283,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
 
             const auto *floor_ptr = player_ptr->current_floor_ptr;
             const auto &grid = floor_ptr->grid_array[y][x];
-            if (!is_monster(grid.m_idx)) {
+            if (!grid.has_monster()) {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
                 return std::nullopt;
             }
@@ -325,7 +324,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+            if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_POISON);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -356,7 +355,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+            if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_ZANMA);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -387,7 +386,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             x = player_ptr->x + ddx[dir];
 
             const auto &floor = *player_ptr->current_floor_ptr;
-            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+            if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -396,7 +395,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::NO_MELEE)) {
                 return "";
             }
-            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+            if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
                 int i;
                 POSITION ty = y, tx = x;
                 POSITION oy = y, ox = x;
@@ -476,7 +475,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+            if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_HAGAN);
             }
 
@@ -512,7 +511,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+            if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_COLD);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -543,7 +542,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+            if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_KYUSHO);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -573,7 +572,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+            if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_MAJIN);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -604,7 +603,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+            if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_SUTEMI);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -635,7 +634,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+            if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_ELEC);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -679,7 +678,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 x = player_ptr->x + ddx_ddd[dir];
                 auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
                 auto *m_ptr = &player_ptr->current_floor_ptr->m_list[g_ptr->m_idx];
-                if (!is_monster(g_ptr->m_idx) || (!m_ptr->ml && !cave_has_flag_bold(player_ptr->current_floor_ptr, y, x, TerrainCharacteristics::PROJECT))) {
+                if (!g_ptr->has_monster() || (!m_ptr->ml && !cave_has_flag_bold(player_ptr->current_floor_ptr, y, x, TerrainCharacteristics::PROJECT))) {
                     continue;
                 }
 
@@ -715,7 +714,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+            if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_QUAKE);
             } else {
                 earthquake(player_ptr, player_ptr->y, player_ptr->x, 10, 0);
@@ -815,7 +814,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 x = player_ptr->x + ddx[dir];
                 g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
 
-                if (is_monster(g_ptr->m_idx)) {
+                if (g_ptr->has_monster()) {
                     do_cmd_attack(player_ptr, y, x, HISSATSU_3DAN);
                 } else {
                     msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -827,7 +826,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 }
 
                 /* Monster is dead? */
-                if (!is_monster(g_ptr->m_idx)) {
+                if (!g_ptr->has_monster()) {
                     break;
                 }
 
@@ -897,7 +896,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+            if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_DRAIN);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
@@ -1013,9 +1012,9 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+            if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
-                if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+                if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
                     handle_stuff(player_ptr);
                     do_cmd_attack(player_ptr, y, x, HISSATSU_NONE);
                 }
@@ -1108,7 +1107,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             y = player_ptr->y + ddy[dir];
             x = player_ptr->x + ddx[dir];
 
-            if (is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx)) {
+            if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
                 do_cmd_attack(player_ptr, y, x, HISSATSU_UNDEAD);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));

--- a/src/room/vault-builder.cpp
+++ b/src/room/vault-builder.cpp
@@ -8,7 +8,6 @@
 #include "grid/trap.h"
 #include "monster-floor/monster-generator.h"
 #include "monster-floor/place-monster-types.h"
-#include "monster/monster-util.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
 #include "system/player-type-definition.h"
@@ -28,7 +27,7 @@ static bool player_grid(PlayerType *player_ptr, Grid *g_ptr)
 static bool is_cave_empty_grid(PlayerType *player_ptr, Grid *g_ptr)
 {
     bool is_empty_grid = g_ptr->cave_has_flag(TerrainCharacteristics::PLACE);
-    is_empty_grid &= !is_monster(g_ptr->m_idx);
+    is_empty_grid &= !g_ptr->has_monster();
     is_empty_grid &= !player_grid(player_ptr, g_ptr);
     return is_empty_grid;
 }
@@ -140,7 +139,7 @@ static void vault_trap_aux(FloorType *floor_ptr, POSITION y, POSITION x, POSITIO
         }
 
         g_ptr = &floor_ptr->grid_array[y1][x1];
-        if (!g_ptr->is_floor() || !g_ptr->o_idx_list.empty() || is_monster(g_ptr->m_idx)) {
+        if (!g_ptr->is_floor() || !g_ptr->o_idx_list.empty() || g_ptr->has_monster()) {
             continue;
         }
 

--- a/src/room/vault-builder.cpp
+++ b/src/room/vault-builder.cpp
@@ -8,6 +8,7 @@
 #include "grid/trap.h"
 #include "monster-floor/monster-generator.h"
 #include "monster-floor/place-monster-types.h"
+#include "monster/monster-util.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
 #include "system/player-type-definition.h"
@@ -27,7 +28,7 @@ static bool player_grid(PlayerType *player_ptr, Grid *g_ptr)
 static bool is_cave_empty_grid(PlayerType *player_ptr, Grid *g_ptr)
 {
     bool is_empty_grid = g_ptr->cave_has_flag(TerrainCharacteristics::PLACE);
-    is_empty_grid &= g_ptr->m_idx == 0;
+    is_empty_grid &= !is_monster(g_ptr->m_idx);
     is_empty_grid &= !player_grid(player_ptr, g_ptr);
     return is_empty_grid;
 }
@@ -139,7 +140,7 @@ static void vault_trap_aux(FloorType *floor_ptr, POSITION y, POSITION x, POSITIO
         }
 
         g_ptr = &floor_ptr->grid_array[y1][x1];
-        if (!g_ptr->is_floor() || !g_ptr->o_idx_list.empty() || g_ptr->m_idx) {
+        if (!g_ptr->is_floor() || !g_ptr->o_idx_list.empty() || is_monster(g_ptr->m_idx)) {
             continue;
         }
 

--- a/src/spell-class/spells-mirror-master.cpp
+++ b/src/spell-class/spells-mirror-master.cpp
@@ -24,7 +24,6 @@
 #include "io/cursor.h"
 #include "io/screen-util.h"
 #include "monster/monster-update.h"
-#include "monster/monster-util.h"
 #include "pet/pet-util.h"
 #include "spell-kind/spells-teleport.h"
 #include "system/angband-system.h"
@@ -63,7 +62,7 @@ void SpellsMirrorMaster::remove_mirror(int y, int x)
             reset_bits(g_ptr->info, CAVE_MARK);
         }
 
-        if (is_monster(g_ptr->m_idx)) {
+        if (g_ptr->has_monster()) {
             update_monster(this->player_ptr, g_ptr->m_idx, false);
         }
 
@@ -197,7 +196,7 @@ void SpellsMirrorMaster::seal_of_mirror(const int dam)
                 continue;
             }
 
-            if (!is_monster(g_ref.m_idx)) {
+            if (!g_ref.has_monster()) {
                 this->remove_mirror(y, x);
             }
         }
@@ -335,7 +334,7 @@ void SpellsMirrorMaster::project_seeker_ray(int target_x, int target_y, int dam)
             }
             const auto &grid = floor.grid_array[project_m_y][project_m_x];
             const auto &monster = floor.m_list[grid.m_idx];
-            if (project_m_n == 1 && is_monster(grid.m_idx) && monster.ml) {
+            if (project_m_n == 1 && grid.has_monster() && monster.ml) {
                 if (!this->player_ptr->effects()->hallucination()->is_hallucinated()) {
                     monster_race_track(this->player_ptr, monster.ap_r_idx);
                 }
@@ -432,7 +431,7 @@ static bool activate_super_ray_effect(PlayerType *player_ptr, int y, int x, int 
     const auto *floor_ptr = player_ptr->current_floor_ptr;
     const auto *g_ptr = &floor_ptr->grid_array[project_m_y][project_m_x];
     const auto *m_ptr = &floor_ptr->m_list[g_ptr->m_idx];
-    if (project_m_n == 1 && is_monster(g_ptr->m_idx) && m_ptr->ml) {
+    if (project_m_n == 1 && g_ptr->has_monster() && m_ptr->ml) {
         if (!player_ptr->effects()->hallucination()->is_hallucinated()) {
             monster_race_track(player_ptr, m_ptr->ap_r_idx);
         }

--- a/src/spell-class/spells-mirror-master.cpp
+++ b/src/spell-class/spells-mirror-master.cpp
@@ -24,6 +24,7 @@
 #include "io/cursor.h"
 #include "io/screen-util.h"
 #include "monster/monster-update.h"
+#include "monster/monster-util.h"
 #include "pet/pet-util.h"
 #include "spell-kind/spells-teleport.h"
 #include "system/angband-system.h"
@@ -62,7 +63,7 @@ void SpellsMirrorMaster::remove_mirror(int y, int x)
             reset_bits(g_ptr->info, CAVE_MARK);
         }
 
-        if (g_ptr->m_idx) {
+        if (is_monster(g_ptr->m_idx)) {
             update_monster(this->player_ptr, g_ptr->m_idx, false);
         }
 
@@ -196,7 +197,7 @@ void SpellsMirrorMaster::seal_of_mirror(const int dam)
                 continue;
             }
 
-            if (g_ref.m_idx == 0) {
+            if (!is_monster(g_ref.m_idx)) {
                 this->remove_mirror(y, x);
             }
         }
@@ -334,7 +335,7 @@ void SpellsMirrorMaster::project_seeker_ray(int target_x, int target_y, int dam)
             }
             const auto &grid = floor.grid_array[project_m_y][project_m_x];
             const auto &monster = floor.m_list[grid.m_idx];
-            if (project_m_n == 1 && grid.m_idx > 0 && monster.ml) {
+            if (project_m_n == 1 && is_monster(grid.m_idx) && monster.ml) {
                 if (!this->player_ptr->effects()->hallucination()->is_hallucinated()) {
                     monster_race_track(this->player_ptr, monster.ap_r_idx);
                 }
@@ -431,7 +432,7 @@ static bool activate_super_ray_effect(PlayerType *player_ptr, int y, int x, int 
     const auto *floor_ptr = player_ptr->current_floor_ptr;
     const auto *g_ptr = &floor_ptr->grid_array[project_m_y][project_m_x];
     const auto *m_ptr = &floor_ptr->m_list[g_ptr->m_idx];
-    if (project_m_n == 1 && g_ptr->m_idx > 0 && m_ptr->ml) {
+    if (project_m_n == 1 && is_monster(g_ptr->m_idx) && m_ptr->ml) {
         if (!player_ptr->effects()->hallucination()->is_hallucinated()) {
             monster_race_track(player_ptr, m_ptr->ap_r_idx);
         }

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -20,6 +20,7 @@
 #include "monster/monster-info.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-update.h"
+#include "monster/monster-util.h"
 #include "monster/smart-learn-types.h"
 #include "player/player-damage.h"
 #include "player/player-move.h"
@@ -110,7 +111,7 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
                 continue;
             }
 
-            if (floor_ptr->grid_array[y][x].m_idx) {
+            if (is_monster(floor_ptr->grid_array[y][x].m_idx)) {
                 continue;
             }
 
@@ -178,7 +179,7 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
                 continue;
             }
 
-            if (!grid.m_idx) {
+            if (!is_monster(grid.m_idx)) {
                 continue;
             }
 
@@ -218,7 +219,7 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
                         continue;
                     }
 
-                    if (grid_neighbor.m_idx) {
+                    if (is_monster(grid_neighbor.m_idx)) {
                         continue;
                     }
 
@@ -249,7 +250,7 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
                     msg_format(_("%s^は岩石に埋もれてしまった！", "%s^ is embedded in the rock!"), m_name.data());
                 }
 
-                if (grid.m_idx) {
+                if (is_monster(grid.m_idx)) {
                     const auto &m_ref = floor_ptr->m_list[grid.m_idx];
                     if (record_named_pet && m_ref.is_named_pet()) {
                         const auto m2_name = monster_desc(player_ptr, m_ptr, MD_INDEF_VISIBLE);

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -20,7 +20,6 @@
 #include "monster/monster-info.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-update.h"
-#include "monster/monster-util.h"
 #include "monster/smart-learn-types.h"
 #include "player/player-damage.h"
 #include "player/player-move.h"
@@ -111,7 +110,7 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
                 continue;
             }
 
-            if (is_monster(floor_ptr->grid_array[y][x].m_idx)) {
+            if (floor_ptr->grid_array[y][x].has_monster()) {
                 continue;
             }
 
@@ -179,7 +178,7 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
                 continue;
             }
 
-            if (!is_monster(grid.m_idx)) {
+            if (!grid.has_monster()) {
                 continue;
             }
 
@@ -219,7 +218,7 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
                         continue;
                     }
 
-                    if (is_monster(grid_neighbor.m_idx)) {
+                    if (grid_neighbor.has_monster()) {
                         continue;
                     }
 
@@ -250,7 +249,7 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
                     msg_format(_("%s^は岩石に埋もれてしまった！", "%s^ is embedded in the rock!"), m_name.data());
                 }
 
-                if (is_monster(grid.m_idx)) {
+                if (grid.has_monster()) {
                     const auto &m_ref = floor_ptr->m_list[grid.m_idx];
                     if (record_named_pet && m_ref.is_named_pet()) {
                         const auto m2_name = monster_desc(player_ptr, m_ptr, MD_INDEF_VISIBLE);

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -33,6 +33,7 @@
 #include "monster/monster-description-types.h"
 #include "monster/monster-info.h"
 #include "monster/monster-status.h"
+#include "monster/monster-util.h"
 #include "monster/smart-learn-types.h"
 #include "object-enchant/special-object-flags.h"
 #include "object/object-mark-types.h"
@@ -335,7 +336,7 @@ bool destroy_area(PlayerType *player_ptr, const POSITION y1, const POSITION x1, 
                 continue;
             }
 
-            if (grid.m_idx) {
+            if (is_monster(grid.m_idx)) {
                 auto &monster = floor.m_list[grid.m_idx];
                 auto &monrace = monster.get_monrace();
 

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -33,7 +33,6 @@
 #include "monster/monster-description-types.h"
 #include "monster/monster-info.h"
 #include "monster/monster-status.h"
-#include "monster/monster-util.h"
 #include "monster/smart-learn-types.h"
 #include "object-enchant/special-object-flags.h"
 #include "object/object-mark-types.h"
@@ -336,7 +335,7 @@ bool destroy_area(PlayerType *player_ptr, const POSITION y1, const POSITION x1, 
                 continue;
             }
 
-            if (is_monster(grid.m_idx)) {
+            if (grid.has_monster()) {
                 auto &monster = floor.m_list[grid.m_idx];
                 auto &monrace = monster.get_monrace();
 

--- a/src/spell-kind/spells-launcher.cpp
+++ b/src/spell-kind/spells-launcher.cpp
@@ -131,7 +131,7 @@ bool fire_ball_hide(PlayerType *player_ptr, AttributeType typ, DIRECTION dir, in
 /*!
  * @brief メテオ系スペルの発動 / Cast a meteor spell
  * @param player_ptr プレイヤーへの参照ポインタ
- * @param who スぺル詠唱者のモンスターID(0=プレイヤー)
+ * @param src_idx スぺル詠唱者のモンスターID(0=プレイヤー)
  * @param typ 効果属性
  * @param dam 威力
  * @param rad 半径
@@ -147,10 +147,10 @@ bool fire_ball_hide(PlayerType *player_ptr, AttributeType typ, DIRECTION dir, in
  * Option to hurt the player.
  * </pre>
  */
-bool fire_meteor(PlayerType *player_ptr, MONSTER_IDX who, AttributeType typ, POSITION y, POSITION x, int dam, POSITION rad)
+bool fire_meteor(PlayerType *player_ptr, MONSTER_IDX src_idx, AttributeType typ, POSITION y, POSITION x, int dam, POSITION rad)
 {
     BIT_FLAGS flg = PROJECT_STOP | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL;
-    return project(player_ptr, who, rad, y, x, dam, typ, flg).notice;
+    return project(player_ptr, src_idx, rad, y, x, dam, typ, flg).notice;
 }
 
 /*!

--- a/src/spell-kind/spells-launcher.h
+++ b/src/spell-kind/spells-launcher.h
@@ -10,7 +10,7 @@ bool fire_ball(PlayerType *player_ptr, AttributeType typ, DIRECTION dir, int dam
 bool fire_breath(PlayerType *player_ptr, AttributeType typ, DIRECTION dir, int dam, POSITION rad);
 bool fire_rocket(PlayerType *player_ptr, AttributeType typ, DIRECTION dir, int dam, POSITION rad);
 bool fire_ball_hide(PlayerType *player_ptr, AttributeType typ, DIRECTION dir, int dam, POSITION rad);
-bool fire_meteor(PlayerType *player_ptr, MONSTER_IDX who, AttributeType typ, POSITION x, POSITION y, int dam, POSITION rad);
+bool fire_meteor(PlayerType *player_ptr, MONSTER_IDX src_idx, AttributeType typ, POSITION x, POSITION y, int dam, POSITION rad);
 bool fire_bolt(PlayerType *player_ptr, AttributeType typ, DIRECTION dir, int dam);
 bool fire_blast(PlayerType *player_ptr, AttributeType typ, DIRECTION dir, DICE_NUMBER dd, DICE_SID ds, int num, int dev);
 bool fire_beam(PlayerType *player_ptr, AttributeType typ, DIRECTION dir, int dam);

--- a/src/spell-kind/spells-lite.cpp
+++ b/src/spell-kind/spells-lite.cpp
@@ -14,6 +14,7 @@
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
 #include "monster/monster-update.h"
+#include "monster/monster-util.h"
 #include "player/special-defense-types.h"
 #include "spell-kind/spells-launcher.h"
 #include "system/angband-system.h"
@@ -62,7 +63,7 @@ static void cave_temp_room_lite(PlayerType *player_ptr, const std::vector<Pos2D>
         auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
         g_ptr->info &= ~(CAVE_TEMP);
         g_ptr->info |= (CAVE_GLOW);
-        if (g_ptr->m_idx) {
+        if (is_monster(g_ptr->m_idx)) {
             PERCENTAGE chance = 25;
             auto *m_ptr = &player_ptr->current_floor_ptr->m_list[g_ptr->m_idx];
             auto *r_ptr = &m_ptr->get_monrace();
@@ -132,7 +133,7 @@ static void cave_temp_room_unlite(PlayerType *player_ptr, const std::vector<Pos2
             note_spot(player_ptr, point.y, point.x);
         }
 
-        if (grid.m_idx) {
+        if (is_monster(grid.m_idx)) {
             update_monster(player_ptr, grid.m_idx, false);
         }
 

--- a/src/spell-kind/spells-lite.cpp
+++ b/src/spell-kind/spells-lite.cpp
@@ -14,7 +14,6 @@
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
 #include "monster/monster-update.h"
-#include "monster/monster-util.h"
 #include "player/special-defense-types.h"
 #include "spell-kind/spells-launcher.h"
 #include "system/angband-system.h"
@@ -63,7 +62,7 @@ static void cave_temp_room_lite(PlayerType *player_ptr, const std::vector<Pos2D>
         auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
         g_ptr->info &= ~(CAVE_TEMP);
         g_ptr->info |= (CAVE_GLOW);
-        if (is_monster(g_ptr->m_idx)) {
+        if (g_ptr->has_monster()) {
             PERCENTAGE chance = 25;
             auto *m_ptr = &player_ptr->current_floor_ptr->m_list[g_ptr->m_idx];
             auto *r_ptr = &m_ptr->get_monrace();
@@ -133,7 +132,7 @@ static void cave_temp_room_unlite(PlayerType *player_ptr, const std::vector<Pos2
             note_spot(player_ptr, point.y, point.x);
         }
 
-        if (is_monster(grid.m_idx)) {
+        if (grid.has_monster()) {
             update_monster(player_ptr, grid.m_idx, false);
         }
 

--- a/src/spell-kind/spells-neighbor.cpp
+++ b/src/spell-kind/spells-neighbor.cpp
@@ -108,15 +108,15 @@ bool sleep_monsters_touch(PlayerType *player_ptr)
 /*!
  * @brief 死者復活処理(起点より周囲5マス)
  * @param player_ptr プレイヤーへの参照ポインタ
- * @param who 術者モンスターID(0ならばプレイヤー)
+ * @param src_idx 術者モンスターID(0ならばプレイヤー)
  * @param y 起点Y座標
  * @param x 起点X座標
  * @return 作用が実際にあった場合TRUEを返す
  */
-bool animate_dead(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSITION x)
+bool animate_dead(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x)
 {
     BIT_FLAGS flg = PROJECT_ITEM | PROJECT_HIDE;
-    return project(player_ptr, who, 5, y, x, 0, AttributeType::ANIM_DEAD, flg).notice;
+    return project(player_ptr, src_idx, 5, y, x, 0, AttributeType::ANIM_DEAD, flg).notice;
 }
 
 /*!

--- a/src/spell-kind/spells-neighbor.h
+++ b/src/spell-kind/spells-neighbor.h
@@ -11,5 +11,5 @@ bool wall_stone(PlayerType *player_ptr);
 bool destroy_doors_touch(PlayerType *player_ptr);
 bool disarm_traps_touch(PlayerType *player_ptr);
 bool sleep_monsters_touch(PlayerType *player_ptr);
-bool animate_dead(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSITION x);
+bool animate_dead(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x);
 void wall_breaker(PlayerType *player_ptr);

--- a/src/spell-kind/spells-sight.cpp
+++ b/src/spell-kind/spells-sight.cpp
@@ -211,9 +211,9 @@ bool crusade(PlayerType *player_ptr)
 /*!
  * @brief 視界内モンスターを怒らせる処理 / Wake up all monsters, and speed up "los" monsters.
  * @param player_ptr プレイヤーへの参照ポインタ
- * @param who 怒らせる原因を起こしたモンスター(0ならばプレイヤー)
+ * @param src_idx 怒らせる原因を起こしたモンスター(0ならばプレイヤー)
  */
-void aggravate_monsters(PlayerType *player_ptr, MONSTER_IDX who)
+void aggravate_monsters(PlayerType *player_ptr, MONSTER_IDX src_idx)
 {
     auto sleep = false;
     auto speed = false;
@@ -223,7 +223,7 @@ void aggravate_monsters(PlayerType *player_ptr, MONSTER_IDX who)
         if (!monster.is_valid()) {
             continue;
         }
-        if (i == who) {
+        if (i == src_idx) {
             continue;
         }
 

--- a/src/spell-kind/spells-sight.h
+++ b/src/spell-kind/spells-sight.h
@@ -11,7 +11,7 @@ bool project_all_los(PlayerType *player_ptr, AttributeType typ, int dam);
 bool speed_monsters(PlayerType *player_ptr);
 bool slow_monsters(PlayerType *player_ptr, int power);
 bool sleep_monsters(PlayerType *player_ptr, int power);
-void aggravate_monsters(PlayerType *player_ptr, MONSTER_IDX who);
+void aggravate_monsters(PlayerType *player_ptr, MONSTER_IDX src_idx);
 bool banish_evil(PlayerType *player_ptr, int dist);
 bool turn_undead(PlayerType *player_ptr);
 bool dispel_evil(PlayerType *player_ptr, int dam);

--- a/src/spell-kind/spells-teleport.cpp
+++ b/src/spell-kind/spells-teleport.cpp
@@ -26,7 +26,6 @@
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
 #include "monster/monster-update.h"
-#include "monster/monster-util.h"
 #include "mutation/mutation-flag-types.h"
 #include "object-enchant/tr-types.h"
 #include "player-base/player-class.h"
@@ -72,7 +71,7 @@ bool teleport_swap(PlayerType *player_ptr, DIRECTION dir)
 
     Grid *g_ptr;
     g_ptr = &player_ptr->current_floor_ptr->grid_array[ty][tx];
-    if (!is_monster(g_ptr->m_idx) || (g_ptr->m_idx == player_ptr->riding)) {
+    if (!g_ptr->has_monster() || (g_ptr->m_idx == player_ptr->riding)) {
         msg_print(_("それとは場所を交換できません。", "You can't trade places with that!"));
         return false;
     }
@@ -515,7 +514,7 @@ void teleport_player_to(PlayerType *player_ptr, POSITION ny, POSITION nx, telepo
 
         bool is_anywhere = w_ptr->wizard;
         is_anywhere &= (mode & TELEPORT_PASSIVE) == 0;
-        is_anywhere &= is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx) || player_ptr->current_floor_ptr->grid_array[y][x].m_idx == player_ptr->riding;
+        is_anywhere &= player_ptr->current_floor_ptr->grid_array[y][x].has_monster() || player_ptr->current_floor_ptr->grid_array[y][x].m_idx == player_ptr->riding;
         if (is_anywhere) {
             break;
         }

--- a/src/spell-kind/spells-teleport.cpp
+++ b/src/spell-kind/spells-teleport.cpp
@@ -26,6 +26,7 @@
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
 #include "monster/monster-update.h"
+#include "monster/monster-util.h"
 #include "mutation/mutation-flag-types.h"
 #include "object-enchant/tr-types.h"
 #include "player-base/player-class.h"
@@ -71,7 +72,7 @@ bool teleport_swap(PlayerType *player_ptr, DIRECTION dir)
 
     Grid *g_ptr;
     g_ptr = &player_ptr->current_floor_ptr->grid_array[ty][tx];
-    if (!g_ptr->m_idx || (g_ptr->m_idx == player_ptr->riding)) {
+    if (!is_monster(g_ptr->m_idx) || (g_ptr->m_idx == player_ptr->riding)) {
         msg_print(_("それとは場所を交換できません。", "You can't trade places with that!"));
         return false;
     }
@@ -514,7 +515,7 @@ void teleport_player_to(PlayerType *player_ptr, POSITION ny, POSITION nx, telepo
 
         bool is_anywhere = w_ptr->wizard;
         is_anywhere &= (mode & TELEPORT_PASSIVE) == 0;
-        is_anywhere &= (player_ptr->current_floor_ptr->grid_array[y][x].m_idx > 0) || player_ptr->current_floor_ptr->grid_array[y][x].m_idx == player_ptr->riding;
+        is_anywhere &= is_monster(player_ptr->current_floor_ptr->grid_array[y][x].m_idx) || player_ptr->current_floor_ptr->grid_array[y][x].m_idx == player_ptr->riding;
         if (is_anywhere) {
             break;
         }

--- a/src/spell-realm/spells-chaos.cpp
+++ b/src/spell-realm/spells-chaos.cpp
@@ -11,6 +11,7 @@
 #include "monster/monster-describer.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
+#include "monster/monster-util.h"
 #include "player-info/class-info.h"
 #include "player/player-damage.h"
 #include "spell-kind/spells-floor.h"
@@ -162,7 +163,7 @@ bool vanish_dungeon(PlayerType *player_ptr)
             const auto &terrrain = grid.get_terrain();
             grid.info &= ~(CAVE_ROOM | CAVE_ICKY);
             const auto &monster = floor.m_list[grid.m_idx];
-            if (grid.m_idx && monster.is_asleep()) {
+            if (is_monster(grid.m_idx) && monster.is_asleep()) {
                 (void)set_monster_csleep(player_ptr, grid.m_idx, 0);
                 if (monster.ml) {
                     const auto m_name = monster_desc(player_ptr, &monster, 0);

--- a/src/spell-realm/spells-chaos.cpp
+++ b/src/spell-realm/spells-chaos.cpp
@@ -11,7 +11,6 @@
 #include "monster/monster-describer.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
-#include "monster/monster-util.h"
 #include "player-info/class-info.h"
 #include "player/player-damage.h"
 #include "spell-kind/spells-floor.h"
@@ -163,7 +162,7 @@ bool vanish_dungeon(PlayerType *player_ptr)
             const auto &terrrain = grid.get_terrain();
             grid.info &= ~(CAVE_ROOM | CAVE_ICKY);
             const auto &monster = floor.m_list[grid.m_idx];
-            if (is_monster(grid.m_idx) && monster.is_asleep()) {
+            if (grid.has_monster() && monster.is_asleep()) {
                 (void)set_monster_csleep(player_ptr, grid.m_idx, 0);
                 if (monster.ml) {
                     const auto m_name = monster_desc(player_ptr, &monster, 0);

--- a/src/spell-realm/spells-crusade.cpp
+++ b/src/spell-realm/spells-crusade.cpp
@@ -14,7 +14,6 @@
 #include "floor/geometry.h"
 #include "game-option/disturbance-options.h"
 #include "grid/feature-flag-types.h"
-#include "monster/monster-util.h"
 #include "spell-realm/spells-crusade.h"
 #include "spell/range-calc.h"
 #include "system/angband-system.h"
@@ -62,7 +61,7 @@ bool cast_wrath_of_the_god(PlayerType *player_ptr, int dam, POSITION rad)
         if (!cave_has_flag_bold(&floor, pos_to.y, pos_to.x, TerrainCharacteristics::PROJECT)) {
             break;
         }
-        if ((dir != 5) && is_monster(floor.get_grid(pos_to).m_idx)) {
+        if ((dir != 5) && floor.get_grid(pos_to).has_monster()) {
             break;
         }
 

--- a/src/spell-realm/spells-crusade.cpp
+++ b/src/spell-realm/spells-crusade.cpp
@@ -14,6 +14,7 @@
 #include "floor/geometry.h"
 #include "game-option/disturbance-options.h"
 #include "grid/feature-flag-types.h"
+#include "monster/monster-util.h"
 #include "spell-realm/spells-crusade.h"
 #include "spell/range-calc.h"
 #include "system/angband-system.h"
@@ -61,7 +62,7 @@ bool cast_wrath_of_the_god(PlayerType *player_ptr, int dam, POSITION rad)
         if (!cave_has_flag_bold(&floor, pos_to.y, pos_to.x, TerrainCharacteristics::PROJECT)) {
             break;
         }
-        if ((dir != 5) && floor.get_grid(pos_to).m_idx != 0) {
+        if ((dir != 5) && is_monster(floor.get_grid(pos_to).m_idx)) {
             break;
         }
 

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -25,7 +25,6 @@
 #include "main/sound-of-music.h"
 #include "mind/mind-force-trainer.h"
 #include "monster/monster-describer.h"
-#include "monster/monster-util.h"
 #include "object/object-kind-hook.h"
 #include "player-base/player-class.h"
 #include "player-info/class-info.h"
@@ -547,7 +546,7 @@ bool fishing(PlayerType *player_ptr)
         return false;
     }
 
-    if (is_monster(floor_ptr->grid_array[y][x].m_idx)) {
+    if (floor_ptr->grid_array[y][x].has_monster()) {
         const auto m_name = monster_desc(player_ptr, &floor_ptr->m_list[floor_ptr->grid_array[y][x].m_idx], 0);
         msg_format(_("%sが邪魔だ！", "%s^ is standing in your way."), m_name.data());
         PlayerEnergy(player_ptr).reset_player_turn();

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -25,6 +25,7 @@
 #include "main/sound-of-music.h"
 #include "mind/mind-force-trainer.h"
 #include "monster/monster-describer.h"
+#include "monster/monster-util.h"
 #include "object/object-kind-hook.h"
 #include "player-base/player-class.h"
 #include "player-info/class-info.h"
@@ -546,7 +547,7 @@ bool fishing(PlayerType *player_ptr)
         return false;
     }
 
-    if (floor_ptr->grid_array[y][x].m_idx) {
+    if (is_monster(floor_ptr->grid_array[y][x].m_idx)) {
         const auto m_name = monster_desc(player_ptr, &floor_ptr->m_list[floor_ptr->grid_array[y][x].m_idx], 0);
         msg_format(_("%sが邪魔だ！", "%s^ is standing in your way."), m_name.data());
         PlayerEnergy(player_ptr).reset_player_turn();

--- a/src/spell/spells-summon.cpp
+++ b/src/spell/spells-summon.cpp
@@ -12,6 +12,7 @@
 #include "monster-race/race-indice-types.h"
 #include "monster/monster-info.h"
 #include "monster/monster-status.h"
+#include "monster/monster-util.h"
 #include "monster/smart-learn-types.h"
 #include "object/item-tester-hooker.h"
 #include "object/item-use-flags.h"
@@ -270,7 +271,7 @@ int summon_cyber(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITI
     /* Summoned by a monster */
     BIT_FLAGS mode = PM_ALLOW_GROUP;
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    if (src_idx > 0) {
+    if (is_monster(src_idx)) {
         auto *m_ptr = &floor_ptr->m_list[src_idx];
         if (m_ptr->is_pet()) {
             mode |= PM_FORCE_PET;

--- a/src/spell/spells-summon.cpp
+++ b/src/spell/spells-summon.cpp
@@ -55,7 +55,7 @@ bool trump_summoning(PlayerType *player_ptr, int num, bool pet, POSITION y, POSI
         lev = plev * 2 / 3 + randint1(plev / 2);
     }
 
-    MONSTER_IDX who;
+    MONSTER_IDX src_idx;
     if (pet) {
         /* Become pet */
         mode |= PM_FORCE_PET;
@@ -69,18 +69,18 @@ bool trump_summoning(PlayerType *player_ptr, int num, bool pet, POSITION y, POSI
         }
 
         /* Player is who summons */
-        who = -1;
+        src_idx = -1;
     } else {
         /* Prevent taming, allow unique monster */
         mode |= PM_NO_PET;
 
         /* Behave as if they appear by themselfs */
-        who = 0;
+        src_idx = 0;
     }
 
     bool success = false;
     for (int i = 0; i < num; i++) {
-        if (summon_specific(player_ptr, who, y, x, lev, type, mode)) {
+        if (summon_specific(player_ptr, src_idx, y, x, lev, type, mode)) {
             success = true;
         }
     }
@@ -260,18 +260,18 @@ bool summon_kin_player(PlayerType *player_ptr, DEPTH level, POSITION y, POSITION
 /*!
  * @brief サイバーデーモンの召喚
  * @param player_ptr プレイヤーへの参照ポインタ
- * @param who 召喚主のモンスターID(0ならばプレイヤー)
+ * @param src_idx 召喚主のモンスターID(0ならばプレイヤー)
  * @param y 召喚位置Y座標
  * @param x 召喚位置X座標
  * @return 作用が実際にあった場合TRUEを返す
  */
-int summon_cyber(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSITION x)
+int summon_cyber(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x)
 {
     /* Summoned by a monster */
     BIT_FLAGS mode = PM_ALLOW_GROUP;
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    if (who > 0) {
-        auto *m_ptr = &floor_ptr->m_list[who];
+    if (src_idx > 0) {
+        auto *m_ptr = &floor_ptr->m_list[src_idx];
         if (m_ptr->is_pet()) {
             mode |= PM_FORCE_PET;
         }
@@ -284,7 +284,7 @@ int summon_cyber(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSITION x
 
     int count = 0;
     for (int i = 0; i < max_cyber; i++) {
-        count += summon_specific(player_ptr, who, y, x, 100, SUMMON_CYBER, mode);
+        count += summon_specific(player_ptr, src_idx, y, x, 100, SUMMON_CYBER, mode);
     }
 
     return count;

--- a/src/spell/spells-summon.h
+++ b/src/spell/spells-summon.h
@@ -15,6 +15,6 @@ bool cast_summon_octopus(PlayerType *player_ptr);
 bool cast_summon_greater_demon(PlayerType *player_ptr);
 bool summon_kin_player(PlayerType *player_ptr, DEPTH level, POSITION y, POSITION x, BIT_FLAGS mode);
 void mitokohmon(PlayerType *player_ptr);
-int summon_cyber(PlayerType *player_ptr, MONSTER_IDX who, POSITION y, POSITION x);
+int summon_cyber(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x);
 int activate_hi_summon(PlayerType *player_ptr, POSITION y, POSITION x, bool can_pet);
 void cast_invoke_spirits(PlayerType *player_ptr, DIRECTION dir);

--- a/src/system/grid-type-definition.cpp
+++ b/src/system/grid-type-definition.cpp
@@ -1,4 +1,5 @@
 #include "system/grid-type-definition.h"
+#include "monster/monster-util.h"
 #include "system/angband-system.h"
 #include "system/monster-race-info.h"
 #include "system/terrain-type-definition.h"
@@ -89,6 +90,11 @@ bool Grid::is_rune_protection() const
 bool Grid::is_rune_explosion() const
 {
     return this->is_object() && TerrainList::get_instance()[this->mimic].flags.has(TerrainCharacteristics::RUNE_EXPLOSION);
+}
+
+bool Grid::has_monster() const
+{
+    return is_monster(this->m_idx);
 }
 
 byte Grid::get_cost(const MonsterRaceInfo *r_ptr) const

--- a/src/system/grid-type-definition.h
+++ b/src/system/grid-type-definition.h
@@ -83,6 +83,7 @@ public:
     bool is_mirror() const;
     bool is_rune_protection() const;
     bool is_rune_explosion() const;
+    bool has_monster() const;
     byte get_cost(const MonsterRaceInfo *r_ptr) const;
     byte get_distance(const MonsterRaceInfo *r_ptr) const;
     FEAT_IDX get_feat_mimic() const;

--- a/src/target/projection-path-calculator.cpp
+++ b/src/target/projection-path-calculator.cpp
@@ -3,7 +3,6 @@
 #include "effect/spells-effect-util.h"
 #include "floor/cave.h"
 #include "grid/feature-flag-types.h"
-#include "monster/monster-util.h"
 #include "spell-class/spells-mirror-master.h"
 #include "system/angband-system.h"
 #include "system/floor-type-definition.h"
@@ -124,7 +123,7 @@ static bool project_stop(PlayerType *player_ptr, projection_path_type *pp_ptr)
         }
     }
 
-    if (any_bits(pp_ptr->flag, PROJECT_STOP) && !pp_ptr->position->empty() && (player_ptr->is_located_at(pos) || is_monster(grid.m_idx))) {
+    if (any_bits(pp_ptr->flag, PROJECT_STOP) && !pp_ptr->position->empty() && (player_ptr->is_located_at(pos) || grid.has_monster())) {
         return true;
     }
 

--- a/src/target/projection-path-calculator.cpp
+++ b/src/target/projection-path-calculator.cpp
@@ -3,6 +3,7 @@
 #include "effect/spells-effect-util.h"
 #include "floor/cave.h"
 #include "grid/feature-flag-types.h"
+#include "monster/monster-util.h"
 #include "spell-class/spells-mirror-master.h"
 #include "system/angband-system.h"
 #include "system/floor-type-definition.h"
@@ -123,7 +124,7 @@ static bool project_stop(PlayerType *player_ptr, projection_path_type *pp_ptr)
         }
     }
 
-    if (any_bits(pp_ptr->flag, PROJECT_STOP) && !pp_ptr->position->empty() && (player_ptr->is_located_at(pos) || grid.m_idx != 0)) {
+    if (any_bits(pp_ptr->flag, PROJECT_STOP) && !pp_ptr->position->empty() && (player_ptr->is_located_at(pos) || is_monster(grid.m_idx))) {
         return true;
     }
 

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -20,7 +20,6 @@
 #include "monster/monster-describer.h"
 #include "monster/monster-description-types.h"
 #include "monster/monster-flag-types.h"
-#include "monster/monster-util.h"
 #include "object/item-tester-hooker.h"
 #include "object/object-mark-types.h"
 #include "player-base/player-race.h"
@@ -271,7 +270,7 @@ static bool within_char_util(const short input)
 
 static short describe_grid(PlayerType *player_ptr, GridExamination *ge_ptr)
 {
-    if (!is_monster(ge_ptr->g_ptr->m_idx) || !player_ptr->current_floor_ptr->m_list[ge_ptr->g_ptr->m_idx].ml) {
+    if (!ge_ptr->g_ptr->has_monster() || !player_ptr->current_floor_ptr->m_list[ge_ptr->g_ptr->m_idx].ml) {
         return CONTINUOUS_DESCRIPTION;
     }
 

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -20,6 +20,7 @@
 #include "monster/monster-describer.h"
 #include "monster/monster-description-types.h"
 #include "monster/monster-flag-types.h"
+#include "monster/monster-util.h"
 #include "object/item-tester-hooker.h"
 #include "object/object-mark-types.h"
 #include "player-base/player-race.h"
@@ -270,7 +271,7 @@ static bool within_char_util(const short input)
 
 static short describe_grid(PlayerType *player_ptr, GridExamination *ge_ptr)
 {
-    if ((ge_ptr->g_ptr->m_idx == 0) || !player_ptr->current_floor_ptr->m_list[ge_ptr->g_ptr->m_idx].ml) {
+    if (!is_monster(ge_ptr->g_ptr->m_idx) || !player_ptr->current_floor_ptr->m_list[ge_ptr->g_ptr->m_idx].ml) {
         return CONTINUOUS_DESCRIPTION;
     }
 

--- a/src/target/target-preparation.cpp
+++ b/src/target/target-preparation.cpp
@@ -6,6 +6,7 @@
 #include "monster/monster-flag-types.h"
 #include "monster/monster-info.h"
 #include "monster/monster-status.h"
+#include "monster/monster-util.h"
 #include "object/object-mark-types.h"
 #include "system/angband-system.h"
 #include "system/floor-type-definition.h"
@@ -86,7 +87,7 @@ static bool target_set_accept(PlayerType *player_ptr, const Pos2D &pos)
     }
 
     const auto &grid = floor.get_grid(pos);
-    if (grid.m_idx) {
+    if (is_monster(grid.m_idx)) {
         auto &monster = floor.m_list[grid.m_idx];
         if (monster.ml) {
             return true;

--- a/src/target/target-preparation.cpp
+++ b/src/target/target-preparation.cpp
@@ -6,7 +6,6 @@
 #include "monster/monster-flag-types.h"
 #include "monster/monster-info.h"
 #include "monster/monster-status.h"
-#include "monster/monster-util.h"
 #include "object/object-mark-types.h"
 #include "system/angband-system.h"
 #include "system/floor-type-definition.h"
@@ -87,7 +86,7 @@ static bool target_set_accept(PlayerType *player_ptr, const Pos2D &pos)
     }
 
     const auto &grid = floor.get_grid(pos);
-    if (is_monster(grid.m_idx)) {
+    if (grid.has_monster()) {
         auto &monster = floor.m_list[grid.m_idx];
         if (monster.ml) {
             return true;

--- a/src/util/sort.cpp
+++ b/src/util/sort.cpp
@@ -4,7 +4,6 @@
 #include "grid/grid.h"
 #include "monster-race/monster-race.h"
 #include "monster/monster-flag-types.h"
-#include "monster/monster-util.h"
 #include "system/artifact-type-definition.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
@@ -138,14 +137,14 @@ bool ang_sort_comp_importance(PlayerType *player_ptr, vptr u, vptr v, int a, int
 
     /* Extract monster race */
     MonsterRaceInfo *ap_r_ptr_a;
-    if (is_monster(grid_a.m_idx) && monster_a.ml) {
+    if (grid_a.has_monster() && monster_a.ml) {
         ap_r_ptr_a = &monster_a.get_appearance_monrace();
     } else {
         ap_r_ptr_a = nullptr;
     }
 
     MonsterRaceInfo *ap_r_ptr_b;
-    if (is_monster(grid_b.m_idx) && monster_b.ml) {
+    if (grid_b.has_monster() && monster_b.ml) {
         ap_r_ptr_b = &monster_b.get_appearance_monrace();
     } else {
         ap_r_ptr_b = nullptr;

--- a/src/util/sort.cpp
+++ b/src/util/sort.cpp
@@ -4,6 +4,7 @@
 #include "grid/grid.h"
 #include "monster-race/monster-race.h"
 #include "monster/monster-flag-types.h"
+#include "monster/monster-util.h"
 #include "system/artifact-type-definition.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
@@ -137,14 +138,14 @@ bool ang_sort_comp_importance(PlayerType *player_ptr, vptr u, vptr v, int a, int
 
     /* Extract monster race */
     MonsterRaceInfo *ap_r_ptr_a;
-    if (grid_a.m_idx && monster_a.ml) {
+    if (is_monster(grid_a.m_idx) && monster_a.ml) {
         ap_r_ptr_a = &monster_a.get_appearance_monrace();
     } else {
         ap_r_ptr_a = nullptr;
     }
 
     MonsterRaceInfo *ap_r_ptr_b;
-    if (grid_b.m_idx && monster_b.ml) {
+    if (is_monster(grid_b.m_idx) && monster_b.ml) {
         ap_r_ptr_b = &monster_b.get_appearance_monrace();
     } else {
         ap_r_ptr_b = nullptr;

--- a/src/view/display-map.cpp
+++ b/src/view/display-map.cpp
@@ -9,6 +9,7 @@
 #include "grid/feature.h"
 #include "grid/grid.h"
 #include "monster-race/monster-race.h"
+#include "monster/monster-util.h"
 #include "object/object-info.h"
 #include "object/object-mark-types.h"
 #include "system/baseitem-info.h"
@@ -301,7 +302,7 @@ void map_info(PlayerType *player_ptr, POSITION y, POSITION x, TERM_COLOR *ap, ch
         break;
     }
 
-    if (grid.m_idx && display_autopick != 0) {
+    if (is_monster(grid.m_idx) && display_autopick != 0) {
         set_term_color(player_ptr, y, x, ap, cp);
         return;
     }

--- a/src/view/display-map.cpp
+++ b/src/view/display-map.cpp
@@ -9,7 +9,6 @@
 #include "grid/feature.h"
 #include "grid/grid.h"
 #include "monster-race/monster-race.h"
-#include "monster/monster-util.h"
 #include "object/object-info.h"
 #include "object/object-mark-types.h"
 #include "system/baseitem-info.h"
@@ -302,7 +301,7 @@ void map_info(PlayerType *player_ptr, POSITION y, POSITION x, TERM_COLOR *ap, ch
         break;
     }
 
-    if (is_monster(grid.m_idx) && display_autopick != 0) {
+    if (grid.has_monster() && display_autopick != 0) {
         set_term_color(player_ptr, y, x, ap, cp);
         return;
     }

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -16,7 +16,6 @@
 #include "monster-race/monster-race.h"
 #include "monster/monster-describer.h"
 #include "monster/monster-description-types.h"
-#include "monster/monster-util.h"
 #include "object/item-tester-hooker.h"
 #include "object/object-info.h"
 #include "player-base/player-class.h"
@@ -528,7 +527,7 @@ void fix_object(PlayerType *player_ptr)
  */
 static const MonsterEntity *monster_on_floor_items(FloorType *floor_ptr, const Grid *g_ptr)
 {
-    if (!is_monster(g_ptr->m_idx)) {
+    if (!g_ptr->has_monster()) {
         return nullptr;
     }
 

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -16,6 +16,7 @@
 #include "monster-race/monster-race.h"
 #include "monster/monster-describer.h"
 #include "monster/monster-description-types.h"
+#include "monster/monster-util.h"
 #include "object/item-tester-hooker.h"
 #include "object/object-info.h"
 #include "player-base/player-class.h"
@@ -527,7 +528,7 @@ void fix_object(PlayerType *player_ptr)
  */
 static const MonsterEntity *monster_on_floor_items(FloorType *floor_ptr, const Grid *g_ptr)
 {
-    if (g_ptr->m_idx == 0) {
+    if (!is_monster(g_ptr->m_idx)) {
         return nullptr;
     }
 

--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -22,6 +22,7 @@
 #include "monster-floor/monster-summon.h"
 #include "monster/monster-describer.h"
 #include "monster/monster-status.h"
+#include "monster/monster-util.h"
 #include "mutation/mutation-processor.h"
 #include "object/lite-processor.h"
 #include "perception/simple-perception.h"
@@ -146,7 +147,7 @@ void WorldTurnProcessor::process_monster_arena()
     for (auto x = 0; x < floor_ptr->width; ++x) {
         for (auto y = 0; y < floor_ptr->height; y++) {
             auto *g_ptr = &floor_ptr->grid_array[y][x];
-            if ((g_ptr->m_idx > 0) && (g_ptr->m_idx != this->player_ptr->riding)) {
+            if (is_monster(g_ptr->m_idx) && (g_ptr->m_idx != this->player_ptr->riding)) {
                 number_mon++;
                 win_m_idx = g_ptr->m_idx;
             }

--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -22,7 +22,6 @@
 #include "monster-floor/monster-summon.h"
 #include "monster/monster-describer.h"
 #include "monster/monster-status.h"
-#include "monster/monster-util.h"
 #include "mutation/mutation-processor.h"
 #include "object/lite-processor.h"
 #include "perception/simple-perception.h"
@@ -147,7 +146,7 @@ void WorldTurnProcessor::process_monster_arena()
     for (auto x = 0; x < floor_ptr->width; ++x) {
         for (auto y = 0; y < floor_ptr->height; y++) {
             auto *g_ptr = &floor_ptr->grid_array[y][x];
-            if (is_monster(g_ptr->m_idx) && (g_ptr->m_idx != this->player_ptr->riding)) {
+            if (g_ptr->has_monster() && (g_ptr->m_idx != this->player_ptr->riding)) {
                 number_mon++;
                 win_m_idx = g_ptr->m_idx;
             }


### PR DESCRIPTION
関連して2点。
・発生源を示している"who"が一見して発生源のことだとわからないのでsrc_idxにリネーム
・MONSTER_IDXと0との比較が一見してプレイヤーIDとの比較かモンスターの存在判定かわからないので関数化して明確化する