### PR TITLE
地形の思い出フラグを読み込む際モンスターの種族情報を書き換えてしまっているバグを修正

### DIFF
--- a/src/load/lore-loader.cpp
+++ b/src/load/lore-loader.cpp
@@ -62,7 +62,7 @@ static void migrate_old_misc_flags(MonsterRaceInfo *r_ptr, BIT_FLAGS old_flags1,
 static void migrate_old_feature_flags(MonsterRaceInfo *r_ptr, BIT_FLAGS old_flags)
 {
     if (!loading_savefile_version_is_older_than(19)) {
-        rd_FlagGroup(r_ptr->feature_flags, rd_byte);
+        rd_FlagGroup(r_ptr->r_feature_flags, rd_byte);
         return;
     }
 


### PR DESCRIPTION
Fix #3873 

バグの関係上3.0.1.8-Betaでセーブした際の地形関連思い出フラグの消失は取り戻せないのであしからず