### PR TITLE
[Refactor] summon_specificで使用するグローバル変数の除去

### DIFF
--- a/src/monster-floor/monster-generator.h
+++ b/src/monster-floor/monster-generator.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "system/angband.h"
+#include <optional>
 
 enum summon_type : int;
 enum class MonsterRaceId : int16_t;
@@ -9,7 +10,7 @@ typedef bool (*summon_specific_pf)(PlayerType *, MONSTER_IDX, POSITION, POSITION
 
 bool mon_scatter(PlayerType *player_ptr, MonsterRaceId r_idx, POSITION *yp, POSITION *xp, POSITION y, POSITION x, POSITION max_dist);
 bool multiply_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, bool clone, BIT_FLAGS mode);
-bool place_specific_monster(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode);
+bool place_specific_monster(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx = std::nullopt);
 bool place_random_monster(PlayerType *player_ptr, POSITION y, POSITION x, BIT_FLAGS mode);
 bool alloc_horde(PlayerType *player_ptr, POSITION y, POSITION x, summon_specific_pf summon_specific);
 bool alloc_guardian(PlayerType *player_ptr, bool def_val);

--- a/src/monster-floor/monster-summon.h
+++ b/src/monster-floor/monster-summon.h
@@ -2,9 +2,6 @@
 
 #include "system/angband.h"
 
-extern int summon_specific_who;
-extern bool summon_unique_okay;
-
 enum summon_type : int;
 enum class MonsterRaceId : int16_t;
 class PlayerType;

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -76,7 +76,7 @@ static bool monster_hook_tanuki(PlayerType *player_ptr, MonsterRaceId r_idx)
     }
 
     auto hook_pf = get_monster_hook(player_ptr);
-    return (*hook_pf)(player_ptr, r_idx);
+    return hook_pf(player_ptr, r_idx);
 }
 
 /*!
@@ -257,9 +257,10 @@ static void warn_unique_generation(PlayerType *player_ptr, MonsterRaceId r_idx)
  * @param x 生成位置x座標
  * @param r_idx 生成モンスター種族
  * @param mode 生成オプション
+ * @param summoner_m_idx モンスターの召喚による場合、召喚主のモンスターID
  * @return 成功したらtrue
  */
-bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode)
+bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx)
 {
     auto &floor = *player_ptr->current_floor_ptr;
     auto *g_ptr = &floor.grid_array[y][x];
@@ -336,7 +337,7 @@ bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, 
     }
 
     if (r_ptr->misc_flags.has(MonsterMiscType::CHAMELEON)) {
-        choose_new_monster(player_ptr, g_ptr->m_idx, true, MonsterRace::empty_id());
+        choose_new_monster(player_ptr, g_ptr->m_idx, true, MonsterRace::empty_id(), summoner_m_idx);
         r_ptr = &m_ptr->get_monrace();
         m_ptr->mflag2.set(MonsterConstantFlagType::CHAMELEON);
         if (r_ptr->kind_flags.has(MonsterKindType::UNIQUE) && (!is_monster(src_idx))) {

--- a/src/monster-floor/one-monster-placer.h
+++ b/src/monster-floor/one-monster-placer.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include "system/angband.h"
+#include <optional>
 
 enum class MonsterRaceId : int16_t;
 class PlayerType;
-bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode);
+bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx = std::nullopt);

--- a/src/monster/monster-list.h
+++ b/src/monster/monster-list.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "system/angband.h"
+#include <optional>
 
 enum class MonsterRaceId : int16_t;
 class FloorType;
@@ -9,6 +10,6 @@ class PlayerType;
 MONSTER_IDX m_pop(FloorType *floor_ptr);
 
 MonsterRaceId get_mon_num(PlayerType *player_ptr, DEPTH min_level, DEPTH max_level, BIT_FLAGS mode);
-void choose_new_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, bool born, MonsterRaceId r_idx);
+void choose_new_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, bool born, MonsterRaceId r_idx, std::optional<MONSTER_IDX> summoner_m_idx = std::nullopt);
 byte get_mspeed(FloorType *player_ptr, MonsterRaceInfo *r_ptr);
 int get_monster_crowd_number(FloorType *floor_ptr, MONSTER_IDX m_idx);

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -177,31 +177,31 @@ monsterrace_hook_type get_monster_hook(PlayerType *player_ptr)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
     if ((floor.dun_level > 0) || (floor.is_in_quest())) {
-        return (monsterrace_hook_type)mon_hook_dungeon;
+        return mon_hook_dungeon;
     }
 
     switch (wilderness[player_ptr->wilderness_y][player_ptr->wilderness_x].terrain) {
     case TERRAIN_TOWN:
-        return (monsterrace_hook_type)mon_hook_town;
+        return mon_hook_town;
     case TERRAIN_DEEP_WATER:
-        return (monsterrace_hook_type)mon_hook_ocean;
+        return mon_hook_ocean;
     case TERRAIN_SHALLOW_WATER:
     case TERRAIN_SWAMP:
-        return (monsterrace_hook_type)mon_hook_shore;
+        return mon_hook_shore;
     case TERRAIN_DIRT:
     case TERRAIN_DESERT:
-        return (monsterrace_hook_type)mon_hook_waste;
+        return mon_hook_waste;
     case TERRAIN_GRASS:
-        return (monsterrace_hook_type)mon_hook_grass;
+        return mon_hook_grass;
     case TERRAIN_TREES:
-        return (monsterrace_hook_type)mon_hook_wood;
+        return mon_hook_wood;
     case TERRAIN_SHALLOW_LAVA:
     case TERRAIN_DEEP_LAVA:
-        return (monsterrace_hook_type)mon_hook_volcano;
+        return mon_hook_volcano;
     case TERRAIN_MOUNTAIN:
-        return (monsterrace_hook_type)mon_hook_mountain;
+        return mon_hook_mountain;
     default:
-        return (monsterrace_hook_type)mon_hook_dungeon;
+        return mon_hook_dungeon;
     }
 }
 
@@ -214,14 +214,14 @@ monsterrace_hook_type get_monster_hook2(PlayerType *player_ptr, POSITION y, POSI
     const Pos2D pos(y, x);
     const auto &terrain = player_ptr->current_floor_ptr->get_grid(pos).get_terrain();
     if (terrain.flags.has(TerrainCharacteristics::WATER)) {
-        return terrain.flags.has(TerrainCharacteristics::DEEP) ? (monsterrace_hook_type)mon_hook_deep_water : (monsterrace_hook_type)mon_hook_shallow_water;
+        return terrain.flags.has(TerrainCharacteristics::DEEP) ? mon_hook_deep_water : mon_hook_shallow_water;
     }
 
     if (terrain.flags.has(TerrainCharacteristics::LAVA)) {
-        return (monsterrace_hook_type)mon_hook_lava;
+        return mon_hook_lava;
     }
 
-    return (monsterrace_hook_type)mon_hook_floor;
+    return mon_hook_floor;
 }
 
 /*!

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -235,7 +235,7 @@ monsterrace_hook_type get_monster_hook2(PlayerType *player_ptr, POSITION y, POSI
  * モンスター生成テーブル alloc_race_table の各要素の基本重み prob1 を指定条件
  * に従って変更し、結果を prob2 に書き込む。
  */
-static errr do_get_mon_num_prep(PlayerType *player_ptr, const monsterrace_hook_type hook1, const monsterrace_hook_type hook2, const bool restrict_to_dungeon)
+static errr do_get_mon_num_prep(PlayerType *player_ptr, const monsterrace_hook_type &hook1, const monsterrace_hook_type &hook2, const bool restrict_to_dungeon)
 {
     const FloorType *const floor_ptr = player_ptr->current_floor_ptr;
 
@@ -346,7 +346,7 @@ static errr do_get_mon_num_prep(PlayerType *player_ptr, const monsterrace_hook_t
  *
  * get_mon_num() を呼ぶ前に get_mon_num_prep() 系関数のいずれかを呼ぶこと。
  */
-errr get_mon_num_prep(PlayerType *player_ptr, const monsterrace_hook_type hook1, const monsterrace_hook_type hook2)
+errr get_mon_num_prep(PlayerType *player_ptr, const monsterrace_hook_type &hook1, const monsterrace_hook_type &hook2)
 {
     return do_get_mon_num_prep(player_ptr, hook1, hook2, true);
 }

--- a/src/monster/monster-util.h
+++ b/src/monster/monster-util.h
@@ -1,16 +1,16 @@
 #pragma once
 
 #include "system/angband.h"
+#include <functional>
 
 enum class MonsterRaceId : int16_t;
 class PlayerType;
-typedef bool (*monsterrace_hook_type)(PlayerType *, MonsterRaceId);
+using monsterrace_hook_type = std::function<bool(PlayerType *, MonsterRaceId)>;
 
 extern MONSTER_IDX hack_m_idx;
 extern MONSTER_IDX hack_m_idx_ii;
 extern int chameleon_change_m_idx;
 enum summon_type : int;
-extern summon_type summon_specific_type;
 
 monsterrace_hook_type get_monster_hook(PlayerType *player_ptr);
 monsterrace_hook_type get_monster_hook2(PlayerType *player_ptr, POSITION y, POSITION x);

--- a/src/monster/monster-util.h
+++ b/src/monster/monster-util.h
@@ -14,7 +14,7 @@ enum summon_type : int;
 
 monsterrace_hook_type get_monster_hook(PlayerType *player_ptr);
 monsterrace_hook_type get_monster_hook2(PlayerType *player_ptr, POSITION y, POSITION x);
-errr get_mon_num_prep(PlayerType *player_ptr, monsterrace_hook_type hook1, monsterrace_hook_type hook2);
+errr get_mon_num_prep(PlayerType *player_ptr, const monsterrace_hook_type &hook1, const monsterrace_hook_type &hook2);
 errr get_mon_num_prep_bounty(PlayerType *player_ptr);
 bool is_player(MONSTER_IDX m_idx);
 bool is_monster(MONSTER_IDX m_idx);

--- a/src/mspell/summon-checker.cpp
+++ b/src/mspell/summon-checker.cpp
@@ -17,10 +17,10 @@
  * @return 召喚条件が一致するならtrue
  * @details
  */
-bool check_summon_specific(PlayerType *player_ptr, MonsterRaceId summoner_idx, MonsterRaceId r_idx)
+bool check_summon_specific(PlayerType *player_ptr, MonsterRaceId summoner_idx, MonsterRaceId r_idx, summon_type type)
 {
     const auto &monrace = monraces_info[r_idx];
-    switch (summon_specific_type) {
+    switch (type) {
     case SUMMON_ANT:
         return monrace.d_char == 'a';
     case SUMMON_SPIDER:

--- a/src/mspell/summon-checker.h
+++ b/src/mspell/summon-checker.h
@@ -2,6 +2,7 @@
 
 #include "system/angband.h"
 
+enum summon_type : int;
 enum class MonsterRaceId : int16_t;
 class PlayerType;
-bool check_summon_specific(PlayerType *player_ptr, MonsterRaceId summoner_idx, MonsterRaceId r_idx);
+bool check_summon_specific(PlayerType *player_ptr, MonsterRaceId summoner_idx, MonsterRaceId r_idx, summon_type type);


### PR DESCRIPTION
summon_specific()で使用する以下のグローバル変数を除去し、引数で渡すように変更する。
- summon_specific_who
- summon_specific_type
- summon_unique_okay