### PR TITLE
タイル情報の書き出しがおかしいバグを修正

### DIFF
--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -128,7 +128,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
             auto_dump_printf(auto_dump_stream, _("\n# モンスターの[色/文字]の設定\n\n", "\n# Monster attr/char definitions\n\n"));
             for (const auto &[monrace_id, monrace] : monraces_info) {
                 auto_dump_printf(auto_dump_stream, "# %s\n", monrace.name.data());
-                auto_dump_printf(auto_dump_stream, "R:%d:0x%02X/0x%02X\n\n", enum2i(monrace_id), monrace.x_attr, monrace.x_char);
+                auto_dump_printf(auto_dump_stream, "R:%d:0x%02X/0x%02X\n\n", enum2i(monrace_id), monrace.x_attr, static_cast<byte>(monrace.x_char));
             }
 
             close_auto_dump(&auto_dump_stream, mark);

--- a/src/io/interpret-pref-file.cpp
+++ b/src/io/interpret-pref-file.cpp
@@ -40,7 +40,6 @@ static errr interpret_r_token(char *buf)
         return 1;
     }
 
-    MonsterRaceInfo *r_ptr;
     int i = (int)strtol(zz[0], nullptr, 0);
     TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], nullptr, 0);
     auto n2 = static_cast<char>(strtol(zz[2], nullptr, 0));
@@ -48,7 +47,7 @@ static errr interpret_r_token(char *buf)
         return 1;
     }
 
-    r_ptr = &monraces_info[i2enum<MonsterRaceId>(i)];
+    auto *r_ptr = &monraces_info[i2enum<MonsterRaceId>(i)];
     if (n1 || (!(n2 & 0x80) && n2)) {
         r_ptr->x_attr = n1;
     } /* Allow TERM_DARK text */


### PR DESCRIPTION
#3675 の事象の原因と考えられるバグだが、確証がないためClose のリンクは現状はしないでおく