### PR TITLE
Update hengband.spec for 3.0.1.11

### DIFF
--- a/hengband.spec
+++ b/hengband.spec
@@ -1,4 +1,4 @@
-%define version 3.0.1.10
+%define version 3.0.1.11
 %define release 1
 
 Summary: hengband %{version}
@@ -150,6 +150,9 @@ exit 0
 %license lib/help/jlicense.txt
 
 %changelog
+* Wed Apr 17 2024 Shiro Hara <white@vx-xv.com>
+- hengband RPM 3.0.1.11(Beta)
+
 * Mon Apr 01 2024 Shiro Hara <white@vx-xv.com>
 - hengband RPM 3.0.1.10(Beta)
 


### PR DESCRIPTION
- hengband.specを3.0.1.11にバージョンアップ
- 同バージョンをCoprにて配布開始 https://copr.fedorainfracloud.org/coprs/whitehara/hengband/