### PR TITLE
[Experiment] GitHub Actions で使用可能な最大バージョンまでClang とGCC を引き上げた

### DIFF
--- a/.github/workflows/create-cache-for-ccache.yml
+++ b/.github/workflows/create-cache-for-ccache.yml
@@ -13,8 +13,8 @@ jobs:
     name: Japanese version with clang (without using pre-compiled headers)
     uses: ./.github/workflows/build-with-autotools.yml
     with:
-      cxx: clang++-14
-      cxx-flags: "-pipe -O3 -Werror -Wall -Wextra -Wno-unused-const-variable -Wno-invalid-source-encoding -stdlib=libc++"
+      cxx: clang++-15
+      cxx-flags: "-pipe -O3 -Werror -Wall -Wextra -Wno-unused-const-variable -Wno-invalid-source-encoding -stdlib=libc++ -std=c++20"
       configure-opts: "--disable-pch"
       use-ccache: true
 
@@ -22,16 +22,16 @@ jobs:
     name: Japanese version with gcc
     uses: ./.github/workflows/build-with-autotools.yml
     with:
-      cxx: g++-11
-      cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
+      cxx: g++-13
+      cxx-flags: "-pipe -O3 -Werror -Wall -Wextra -std=c++20"
       use-ccache: true
 
   gcc_english:
     name: English version with gcc
     uses: ./.github/workflows/build-with-autotools.yml
     with:
-      cxx: g++-11
-      cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
+      cxx: g++-13
+      cxx-flags: "-pipe -O3 -Werror -Wall -Wextra -std=c++20"
       configure-opts: "--disable-japanese"
       distcheck: true
       use-ccache: true

--- a/.github/workflows/pull-request-status-check.yml
+++ b/.github/workflows/pull-request-status-check.yml
@@ -26,8 +26,8 @@ jobs:
     name: Build Japanese version with clang (without using pre-compiled headers)
     uses: ./.github/workflows/build-with-autotools.yml
     with:
-      cxx: clang++-14
-      cxx-flags: "-pipe -O3 -Werror -Wall -Wextra -Wno-unused-const-variable -Wno-invalid-source-encoding -stdlib=libc++"
+      cxx: clang++-15
+      cxx-flags: "-pipe -O3 -Werror -Wall -Wextra -Wno-unused-const-variable -Wno-invalid-source-encoding -stdlib=libc++ -std=c++20"
       configure-opts: "--disable-pch"
       use-ccache: true
 
@@ -35,16 +35,16 @@ jobs:
     name: Build Japanese version with gcc
     uses: ./.github/workflows/build-with-autotools.yml
     with:
-      cxx: g++-11
-      cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
+      cxx: g++-13
+      cxx-flags: "-pipe -O3 -Werror -Wall -Wextra -std=c++20"
       use-ccache: true
 
   build_test_english:
     name: Build English version with gcc
     uses: ./.github/workflows/build-with-autotools.yml
     with:
-      cxx: g++-11
-      cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
+      cxx: g++-13
+      cxx-flags: "-pipe -O3 -Werror -Wall -Wextra -std=c++20"
       configure-opts: "--disable-japanese"
       distcheck: true
       use-ccache: true


### PR DESCRIPTION
Clangはv15、GCCはv13に上げてみました
実験です、deprecated になっているコードがコンパイル警告 (実質エラー)になるかを確認するために行います
開発チームで合意が取れた後にマージするものとし、一旦ドラフトにしておきます
(マイルストーンも空)