### PR TITLE
MonsterPainDescriber の MONSTER_IDX に依存したコンストラクタをなくした

### DIFF
--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -845,7 +845,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX i_idx, ItemEntity *j_ptr, SP
                             msg_format(_("%sは%sに突き刺さった！", "%s^ is stuck in %s!"), item_name.data(), m_name.data());
                         }
 
-                        const auto pain_message = MonsterPainDescriber(player_ptr, c_mon_ptr->m_idx).describe(tdam);
+                        const auto pain_message = MonsterPainDescriber(player_ptr, m_ptr).describe(tdam);
                         if (pain_message) {
                             msg_print(*pain_message);
                         }

--- a/src/effect/effect-monster.cpp
+++ b/src/effect/effect-monster.cpp
@@ -210,7 +210,7 @@ static void effect_damage_makes_sleep(PlayerType *player_ptr, EffectMonster *em_
     if (!em_ptr->note.empty() && em_ptr->seen_msg) {
         msg_format("%s^%s", em_ptr->m_name, em_ptr->note.data());
     } else if (em_ptr->see_s_msg) {
-        const auto pain_message = MonsterPainDescriber(player_ptr, em_ptr->g_ptr->m_idx).describe(em_ptr->dam);
+        const auto pain_message = MonsterPainDescriber(player_ptr, em_ptr->m_ptr).describe(em_ptr->dam);
         if (pain_message) {
             msg_print(*pain_message);
         }
@@ -305,7 +305,7 @@ static bool deal_effect_damage_from_player(PlayerType *player_ptr, EffectMonster
     if (!em_ptr->note.empty() && em_ptr->seen) {
         msg_format(_("%s%s", "%s^%s"), em_ptr->m_name, em_ptr->note.data());
     } else if (em_ptr->known && (em_ptr->dam || !em_ptr->do_fear)) {
-        const auto pain_message = MonsterPainDescriber(player_ptr, em_ptr->g_ptr->m_idx).describe(em_ptr->dam);
+        const auto pain_message = MonsterPainDescriber(player_ptr, em_ptr->m_ptr).describe(em_ptr->dam);
         if (pain_message) {
             msg_print(*pain_message);
         }

--- a/src/monster/monster-pain-describer.cpp
+++ b/src/monster/monster-pain-describer.cpp
@@ -185,11 +185,6 @@ MonsterPainDescriber::MonsterPainDescriber(PlayerType *player_ptr, const Monster
 {
 }
 
-MonsterPainDescriber::MonsterPainDescriber(PlayerType *player_ptr, MONSTER_IDX m_idx)
-    : MonsterPainDescriber(player_ptr, &player_ptr->current_floor_ptr->m_list[m_idx])
-{
-}
-
 /*!
  * @brief ダメージを受けたモンスターの様子を記述する
  * @param dam モンスターが受けたダメージ

--- a/src/monster/monster-pain-describer.h
+++ b/src/monster/monster-pain-describer.h
@@ -8,7 +8,6 @@ class MonsterEntity;
 class MonsterPainDescriber {
 public:
     MonsterPainDescriber(PlayerType *player_ptr, const MonsterEntity *m_ptr);
-    MonsterPainDescriber(PlayerType *player_ptr, MONSTER_IDX m_idx);
 
     std::optional<std::string> describe(int dam);
 

--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -455,8 +455,7 @@ void ObjectThrowEntity::attack_racial_power()
     if (mdp.mon_take_hit(this->m_ptr->get_died_message())) {
         return;
     }
-
-    const auto pain_message = MonsterPainDescriber(player_ptr, this->g_ptr->m_idx).describe(this->tdam);
+    const auto pain_message = MonsterPainDescriber(player_ptr, this->m_ptr).describe(this->tdam);
     if (pain_message) {
         msg_print(*pain_message);
     }


### PR DESCRIPTION
Resolve #3961 