### PR TITLE
[Fix] ダンジョンの主召喚が機能していない

### DIFF
--- a/src/monster-floor/monster-summon.cpp
+++ b/src/monster-floor/monster-summon.cpp
@@ -129,7 +129,7 @@ bool summon_specific(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y1, P
     auto summon_specific_hook = [src_idx, type, is_unique_allowed = (mode & PM_ALLOW_UNIQUE) != 0](PlayerType *player_ptr, MonsterRaceId r_idx) {
         return summon_specific_okay(player_ptr, r_idx, src_idx, type, is_unique_allowed);
     };
-    get_mon_num_prep(player_ptr, std::move(summon_specific_hook), get_monster_hook2(player_ptr, y, x));
+    get_mon_num_prep(player_ptr, std::move(summon_specific_hook), get_monster_hook2(player_ptr, y, x), type);
 
     DEPTH dlev = get_dungeon_or_wilderness_level(player_ptr);
     MonsterRaceId r_idx = get_mon_num(player_ptr, 0, (dlev + lev) / 2 + 5, mode);

--- a/src/monster/monster-util.h
+++ b/src/monster/monster-util.h
@@ -2,6 +2,7 @@
 
 #include "system/angband.h"
 #include <functional>
+#include <optional>
 
 enum class MonsterRaceId : int16_t;
 class PlayerType;
@@ -14,7 +15,7 @@ enum summon_type : int;
 
 monsterrace_hook_type get_monster_hook(PlayerType *player_ptr);
 monsterrace_hook_type get_monster_hook2(PlayerType *player_ptr, POSITION y, POSITION x);
-errr get_mon_num_prep(PlayerType *player_ptr, const monsterrace_hook_type &hook1, const monsterrace_hook_type &hook2);
+errr get_mon_num_prep(PlayerType *player_ptr, const monsterrace_hook_type &hook1, const monsterrace_hook_type &hook2, std::optional<summon_type> summon_specific_type = std::nullopt);
 errr get_mon_num_prep_bounty(PlayerType *player_ptr);
 bool is_player(MONSTER_IDX m_idx);
 bool is_monster(MONSTER_IDX m_idx);


### PR DESCRIPTION
Fix #3970 

PR #3886 での修正漏れ。グローバル変数 summon_specific_type の定義を削除していなかったためそれを使用するコードが残っていた。
summon_specific_type を必要な場所からオプション引数として渡すようにすることで対応する。