### PR TITLE
[Refactor] クエストの説明テキストの処理

### DIFF
--- a/src/dungeon/quest.cpp
+++ b/src/dungeon/quest.cpp
@@ -38,8 +38,7 @@
 #include <sstream>
 #include <stdexcept>
 
-char quest_text[10][80]; /*!< Quest text */
-int quest_text_line; /*!< Current line of the quest text */
+std::vector<std::string> quest_text_lines; /*!< Quest text */
 QuestId leaving_quest = QuestId::NONE;
 
 /*!

--- a/src/dungeon/quest.h
+++ b/src/dungeon/quest.h
@@ -159,9 +159,10 @@ private:
     ~QuestList() = default;
 };
 
-extern char quest_text[10][80];
-extern int quest_text_line;
+extern std::vector<std::string> quest_text_lines;
 extern QuestId leaving_quest;
+
+constexpr auto QUEST_TEST_LINES_MAX = 10;
 
 class FloorType;
 class ItemEntity;

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -327,9 +327,8 @@ static int parse_qtw_Q(qtwg_type *qtwg_ptr, char **zz)
     }
 
     if (zz[1][0] == 'T') {
-        if (init_flags & INIT_SHOW_TEXT) {
-            strcpy(quest_text[quest_text_line], zz[2]);
-            quest_text_line++;
+        if ((init_flags & INIT_SHOW_TEXT) && (std::ssize(quest_text_lines) < QUEST_TEST_LINES_MAX)) {
+            quest_text_lines.emplace_back(zz[2]);
         }
 
         return PARSE_ERROR_NONE;

--- a/src/knowledge/knowledge-quests.cpp
+++ b/src/knowledge/knowledge-quests.cpp
@@ -70,11 +70,9 @@ static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
         }
 
         const auto old_quest = player_ptr->current_floor_ptr->quest_number;
-        for (int j = 0; j < 10; j++) {
-            quest_text[j][0] = '\0';
-        }
 
-        quest_text_line = 0;
+        quest_text_lines.clear();
+
         player_ptr->current_floor_ptr->quest_number = q_idx;
         init_flags = INIT_SHOW_TEXT;
         parse_fixed_map(player_ptr, QUEST_DEFINITION_LIST, 0, 0, 0, 0);
@@ -144,10 +142,8 @@ static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
                 continue;
             }
 
-            int k = 0;
-            while (quest_text[k][0] && k < 10) {
-                fprintf(fff, "    %s\n", quest_text[k]);
-                k++;
+            for (const auto &line : quest_text_lines) {
+                fprintf(fff, "    %s\n", line.data());
             }
 
             continue;

--- a/src/market/building-quest.cpp
+++ b/src/market/building-quest.cpp
@@ -23,11 +23,7 @@
  */
 static void get_questinfo(PlayerType *player_ptr, QuestId questnum, bool do_init)
 {
-    for (int i = 0; i < 10; i++) {
-        quest_text[i][0] = '\0';
-    }
-
-    quest_text_line = 0;
+    quest_text_lines.clear();
 
     auto *floor_ptr = player_ptr->current_floor_ptr;
     QuestId old_quest = floor_ptr->quest_number;
@@ -57,8 +53,8 @@ static void print_questinfo(PlayerType *player_ptr, QuestId questnum, bool do_in
     prt(format(_("クエスト情報 (危険度: %d 階相当)", "Quest Information (Danger level: %d)"), (int)q_ptr->level), 5, 0);
     prt(q_ptr->name, 7, 0);
 
-    for (int i = 0; i < 10; i++) {
-        c_put_str(TERM_YELLOW, quest_text[i], i + 8, 0);
+    for (auto i = 0; i < std::ssize(quest_text_lines); i++) {
+        c_put_str(TERM_YELLOW, quest_text_lines[i], i + 8, 0);
     }
 }
 

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -454,11 +454,9 @@ static std::string decide_target_floor(PlayerType *player_ptr, GridExamination *
         const QuestId number = i2enum<QuestId>(ge_ptr->g_ptr->special);
         const auto *q_ptr = &quest_list[number];
         std::string_view msg(_("クエスト「%s」(%d階相当)", "the entrance to the quest '%s'(level %d)"));
-        for (int j = 0; j < 10; j++) {
-            quest_text[j][0] = '\0';
-        }
 
-        quest_text_line = 0;
+        quest_text_lines.clear();
+
         floor_ptr->quest_number = number;
         init_flags = INIT_NAME_ONLY;
         parse_fixed_map(player_ptr, QUEST_DEFINITION_LIST, 0, 0, 0, 0);

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -225,12 +225,9 @@ static std::optional<std::string> decide_death_in_quest(PlayerType *player_ptr)
         return std::nullopt;
     }
 
-    for (int i = 0; i < 10; i++) {
-        quest_text[i][0] = '\0';
-    }
+    quest_text_lines.clear();
 
     const auto &quest_list = QuestList::get_instance();
-    quest_text_line = 0;
     init_flags = INIT_NAME_ONLY;
     parse_fixed_map(player_ptr, QUEST_DEFINITION_LIST, 0, 0, 0, 0);
     return std::string(format(_("…あなたは現在、 クエスト「%s」を遂行中だ。", "...Now, you are in the quest '%s'."), quest_list[floor_ptr->quest_number].name.data()));


### PR DESCRIPTION
クエストの説明テキストを保持する変数を固定配列から std::vector<std::string> に変更する。

#3204 に関連して、strcpyの使用箇所の1つに関連するリファクタリングです。