### PR TITLE
[Fix] フロア・リセットで提示される階層の初期値がおかしい

### DIFF
--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -533,7 +533,7 @@ bool reset_recall(PlayerType *player_ptr)
     constexpr auto prompt = _("何階にセットしますか？", "Reset to which level?");
     const auto min_level = dungeons_info[select_dungeon].mindepth;
     const auto max_level = max_dlv[select_dungeon];
-    const auto reset_level = input_numerics(prompt, min_level, max_level, player_ptr->current_floor_ptr->dun_level);
+    const auto reset_level = input_numerics(prompt, min_level, max_level, max_level);
     if (!reset_level) {
         return false;
     }


### PR DESCRIPTION
初期値として現在のダンジョンの階層を表示しているため、不自然な値となってしまっている。
選択したダンジョンの最深到達階層を初期値として表示するように修正する。

Resolves #3797 