### PR TITLE
[Fix] 正当なUTF-8で guess_convert_to_system_encoding() が失敗する

### DIFF
--- a/src/locale/japanese.h
+++ b/src/locale/japanese.h
@@ -21,6 +21,7 @@ void euc2sjis(char *str);
 byte codeconv(char *str);
 bool iskanji2(concptr s, int x);
 std::optional<std::string> sys_to_utf8(std::string_view str);
+std::optional<std::string> utf8_to_sys(std::string_view utf8_str);
 void guess_convert_to_system_encoding(char *strbuf, int buflen);
 
 int lb_to_kg_integer(int x);


### PR DESCRIPTION
guess_convert_to_system_encoding() に正当なUTF-8文字列を渡しているにもかかわらず変換に失敗することがある。これは関数内で使用されている angband_strcpy() がマルチバイト文字としてShift-JISかEUC-JPを想定しておりUTF-8は対象外であるため誤動作することが原因となっている。
新たにUTF-8文字列に対し正しく動作する utf8_to_sys() を実装し、guess_convert_to_system_encoding() 内でUTF-8からシステムの文字コードに変換する ときにこれを使用するようにする。
また、utf8_to_sys() 自体を単体で使えるようにするため、グローバルスコープに追加する。