### PR TITLE
baseitems_info をBaseitemList::instance() に差し替えた

### DIFF
--- a/src/artifact/fixed-art-generator.cpp
+++ b/src/artifact/fixed-art-generator.cpp
@@ -400,7 +400,7 @@ bool make_artifact_special(PlayerType *player_ptr, ItemEntity *o_ptr)
          * ベースアイテムの生成階層が足りない場合1/(不足階層*5)を満たさないと除外される。
          */
         const auto bi_id = lookup_baseitem_id(artifact.bi_key);
-        const auto &baseitem = baseitems_info[bi_id];
+        const auto &baseitem = BaseitemList::get_instance().get_baseitem(bi_id);
         if (baseitem.level > floor_ptr->object_level) {
             int d = (baseitem.level - floor_ptr->object_level) * 5;
             if (!one_in_(d)) {

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -33,7 +33,7 @@
  */
 static void reset_baseitem_idenditication_flags()
 {
-    for (auto &baseitem : baseitems_info) {
+    for (auto &baseitem : BaseitemList::get_instance()) {
         baseitem.tried = false;
         baseitem.aware = false;
     }

--- a/src/birth/inventory-initializer.cpp
+++ b/src/birth/inventory-initializer.cpp
@@ -280,5 +280,5 @@ void player_outfit(PlayerType *player_ptr)
         add_outfit(player_ptr, q_ptr);
     }
 
-    baseitems_info[lookup_baseitem_id({ ItemKindType::POTION, SV_POTION_WATER })].mark_as_aware();
+    BaseitemList::get_instance().get_baseitem(lookup_baseitem_id({ ItemKindType::POTION, SV_POTION_WATER })).mark_as_aware();
 }

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -149,7 +149,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
             }
 
             auto_dump_printf(auto_dump_stream, _("\n# アイテムの[色/文字]の設定\n\n", "\n# Object attr/char definitions\n\n"));
-            for (const auto &baseitem : baseitems_info) {
+            for (const auto &baseitem : BaseitemList::get_instance()) {
                 if (!baseitem.is_valid()) {
                     continue;
                 }
@@ -288,8 +288,9 @@ void do_cmd_visuals(PlayerType *player_ptr)
             static auto choice_msg = _("アイテムの[色/文字]を変更します", "Change object attr/chars");
             static short bi_id = 0;
             prt(format(_("コマンド: %s", "Command: %s"), choice_msg), 15, 0);
+            auto &baseitems = BaseitemList::get_instance();
             while (true) {
-                auto &baseitem = baseitems_info[bi_id];
+                auto &baseitem = baseitems.get_baseitem(bi_id);
                 int c;
                 const auto &cc_def = baseitem.cc_def;
                 auto &cc_config = baseitem.cc_config;
@@ -322,14 +323,14 @@ void do_cmd_visuals(PlayerType *player_ptr)
                     std::optional<short> new_baseitem_id;
                     const auto previous_bi_id = bi_id;
                     while (true) {
-                        new_baseitem_id = input_new_visual_id(ch, bi_id, static_cast<short>(baseitems_info.size()));
+                        new_baseitem_id = input_new_visual_id(ch, bi_id, static_cast<short>(baseitems.size()));
                         if (!new_baseitem_id) {
                             bi_id = previous_bi_id;
                             break;
                         }
 
                         bi_id = *new_baseitem_id;
-                        if (baseitems_info[bi_id].is_valid()) {
+                        if (baseitems.get_baseitem(bi_id).is_valid()) {
                             break;
                         }
                     }

--- a/src/core/visuals-reseter.cpp
+++ b/src/core/visuals-reseter.cpp
@@ -19,7 +19,7 @@ void reset_visuals(PlayerType *player_ptr)
         }
     }
 
-    for (auto &baseitem : baseitems_info) {
+    for (auto &baseitem : BaseitemList::get_instance()) {
         baseitem.cc_config = baseitem.cc_def;
     }
 

--- a/src/flavor/named-item-describer.cpp
+++ b/src/flavor/named-item-describer.cpp
@@ -216,7 +216,7 @@ static std::string describe_vowel(const ItemEntity &item, std::string_view basen
         vowel = is_a_vowel(modstr[0]);
         break;
     case '%':
-        vowel = is_a_vowel(baseitems_info[item.bi_id].name[0]);
+        vowel = is_a_vowel(item.get_baseitem().name[0]);
         break;
     default:
         vowel = is_a_vowel(basename[0]);

--- a/src/flavor/tval-description-switcher.cpp
+++ b/src/flavor/tval-description-switcher.cpp
@@ -98,7 +98,7 @@ static std::string flavor_name_of(const ItemEntity &item, const describe_option_
     const auto &baseitem = item.get_baseitem();
     return any_bits(opt.mode, OD_FORCE_FLAVOR)
                ? baseitem.flavor_name
-               : baseitems_info[baseitem.flavor].flavor_name;
+               : BaseitemList::get_instance().get_baseitem(baseitem.flavor).flavor_name;
 }
 
 static std::pair<std::string, std::string> describe_amulet(const ItemEntity &item, const describe_option_type &opt)

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -175,7 +175,8 @@ bool make_gold(PlayerType *player_ptr, ItemEntity *j_ptr)
     }
 
     j_ptr->prep(OBJ_GOLD_LIST + i);
-    const auto base = baseitems_info[OBJ_GOLD_LIST + i].cost;
+    const auto &baseitems = BaseitemList::get_instance();
+    const auto base = baseitems.get_baseitem(OBJ_GOLD_LIST + i).cost;
     j_ptr->pval = (base + (8L * randint1(base)) + randint1(8));
     return true;
 }

--- a/src/info-reader/baseitem-reader.cpp
+++ b/src/info-reader/baseitem-reader.cpp
@@ -49,6 +49,7 @@ errr parse_baseitems_info(std::string_view buf, angband_header *head)
 {
     (void)head;
     const auto &tokens = str_split(buf, ':', false, 10);
+    auto &baseitems = BaseitemList::get_instance();
 
     // N:index:name_ja
     if (tokens[0] == "N") {
@@ -61,13 +62,14 @@ errr parse_baseitems_info(std::string_view buf, angband_header *head)
             return PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
         }
 
-        if (i >= static_cast<int>(baseitems_info.size())) {
-            baseitems_info.resize(i + 1);
+        if (i >= static_cast<int>(baseitems.size())) {
+            baseitems.resize(i + 1);
         }
 
         error_idx = i;
-        auto &baseitem = baseitems_info[i];
-        baseitem.idx = static_cast<short>(i);
+        const short s = static_cast<short>(i);
+        auto &baseitem = baseitems.get_baseitem(s);
+        baseitem.idx = s;
 #ifdef JP
         baseitem.name = tokens[2];
 #endif
@@ -78,7 +80,7 @@ errr parse_baseitems_info(std::string_view buf, angband_header *head)
         return PARSE_ERROR_NONE;
     }
 
-    if (baseitems_info.empty()) {
+    if (baseitems.empty()) {
         return PARSE_ERROR_MISSING_RECORD_HEADER;
     }
 
@@ -89,7 +91,7 @@ errr parse_baseitems_info(std::string_view buf, angband_header *head)
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
 
-        auto &baseitem = *baseitems_info.rbegin();
+        auto &baseitem = *baseitems.rbegin();
         baseitem.name = tokens[1];
         if (tokens.size() > 2) {
             baseitem.flavor_name = tokens[2];
@@ -105,7 +107,7 @@ errr parse_baseitems_info(std::string_view buf, angband_header *head)
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
 
-        auto &baseitem = *baseitems_info.rbegin();
+        auto &baseitem = *baseitems.rbegin();
 #ifdef JP
         if (buf[2] == '$') {
             return PARSE_ERROR_NONE;
@@ -137,7 +139,7 @@ errr parse_baseitems_info(std::string_view buf, angband_header *head)
             return PARSE_ERROR_GENERIC;
         }
 
-        auto &baseitem = *baseitems_info.rbegin();
+        auto &baseitem = *baseitems.rbegin();
         baseitem.cc_def = ColoredChar(color, tokens[1][0]);
         return PARSE_ERROR_NONE;
     }
@@ -151,7 +153,7 @@ errr parse_baseitems_info(std::string_view buf, angband_header *head)
         constexpr auto base = 10;
         const auto tval = i2enum<ItemKindType>(std::stoi(tokens[1], nullptr, base));
         const auto sval = std::stoi(tokens[2], nullptr, base);
-        auto &baseitem = *baseitems_info.rbegin();
+        auto &baseitem = *baseitems.rbegin();
         baseitem.bi_key = { tval, sval };
         info_set_value(baseitem.pval, tokens[3]);
         if ((tval == ItemKindType::ROD) && (baseitem.pval <= 0)) {
@@ -167,7 +169,7 @@ errr parse_baseitems_info(std::string_view buf, angband_header *head)
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
 
-        auto &baseitem = *baseitems_info.rbegin();
+        auto &baseitem = *baseitems.rbegin();
         info_set_value(baseitem.level, tokens[1]);
         info_set_value(baseitem.weight, tokens[2]);
         info_set_value(baseitem.cost, tokens[3]);
@@ -187,7 +189,7 @@ errr parse_baseitems_info(std::string_view buf, angband_header *head)
                 return PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
             }
 
-            auto &baseitem = *baseitems_info.rbegin();
+            auto &baseitem = *baseitems.rbegin();
             auto &table = baseitem.alloc_tables[i];
             info_set_value(table.level, rarity[0]);
             info_set_value(table.chance, rarity[1]);
@@ -208,7 +210,7 @@ errr parse_baseitems_info(std::string_view buf, angband_header *head)
             return PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
         }
 
-        auto &baseitem = *baseitems_info.rbegin();
+        auto &baseitem = *baseitems.rbegin();
         info_set_value(baseitem.ac, tokens[1]);
         info_set_value(baseitem.dd, dice[0]);
         info_set_value(baseitem.ds, dice[1]);
@@ -229,7 +231,7 @@ errr parse_baseitems_info(std::string_view buf, angband_header *head)
             return PARSE_ERROR_INVALID_FLAG;
         }
 
-        auto &baseitem = *baseitems_info.rbegin();
+        auto &baseitem = *baseitems.rbegin();
         baseitem.act_idx = n;
         return PARSE_ERROR_NONE;
     }
@@ -246,7 +248,7 @@ errr parse_baseitems_info(std::string_view buf, angband_header *head)
                 continue;
             }
 
-            auto &baseitem = *baseitems_info.rbegin();
+            auto &baseitem = *baseitems.rbegin();
             if (!grab_one_baseitem_flag(baseitem, f)) {
                 return PARSE_ERROR_INVALID_FLAG;
             }

--- a/src/io-dump/special-class-dump.cpp
+++ b/src/io-dump/special-class-dump.cpp
@@ -42,7 +42,7 @@ static void dump_magic_eater(PlayerType *player_ptr, FILE *fff)
     }
 
     fprintf(fff, _("\n\n  [取り込んだ魔法道具]\n", "\n\n  [Magic devices eaten]\n"));
-
+    const auto &baseitems = BaseitemList::get_instance();
     for (auto tval : { ItemKindType::STAFF, ItemKindType::WAND, ItemKindType::ROD }) {
         switch (tval) {
         case ItemKindType::STAFF:
@@ -71,7 +71,7 @@ static void dump_magic_eater(PlayerType *player_ptr, FILE *fff)
                 continue;
             }
 
-            const auto buf = format("%23s (%2d)", baseitems_info[bi_id].name.data(), item.count);
+            const auto buf = format("%23s (%2d)", baseitems.get_baseitem(bi_id).name.data(), item.count);
             desc_list.emplace_back(buf);
         }
 

--- a/src/io/interpret-pref-file.cpp
+++ b/src/io/interpret-pref-file.cpp
@@ -73,12 +73,13 @@ static errr interpret_k_token(char *buf)
     const auto i = static_cast<short>(std::stoi(zz[0], nullptr, 0));
     const auto color = static_cast<uint8_t>(std::stoi(zz[1], nullptr, 0));
     const auto character = static_cast<char>(std::stoi(zz[2], nullptr, 0));
-    if (i >= static_cast<int>(baseitems_info.size())) {
+    auto &baseitems = BaseitemList::get_instance();
+    if (i >= static_cast<int>(baseitems.size())) {
         return 1;
     }
 
     /* Allow TERM_DARK text */
-    auto &baseitem = baseitems_info[i];
+    auto &baseitem = baseitems.get_baseitem(i);
     if ((color > 0) || (((character & 0x80) == 0) && (character != 0))) {
         baseitem.cc_config.color = color;
     }
@@ -212,7 +213,7 @@ static errr interpret_u_token(char *buf)
     const auto tval = i2enum<ItemKindType>(std::stoi(zz[0], nullptr, 0));
     const auto n1 = static_cast<uint8_t>(std::stoi(zz[1], nullptr, 0));
     const auto n2 = static_cast<char>(strtol(zz[2], nullptr, 0));
-    for (auto &baseitem : baseitems_info) {
+    for (auto &baseitem : BaseitemList::get_instance()) {
         if (baseitem.is_valid() && (baseitem.bi_key.tval() == tval)) {
             if (n1) {
                 baseitem.cc_def.color = n1;

--- a/src/item-info/flavor-initializer.cpp
+++ b/src/item-info/flavor-initializer.cpp
@@ -17,7 +17,8 @@
 static void shuffle_flavors(ItemKindType tval)
 {
     std::vector<std::reference_wrapper<IDX>> flavor_idx_ref_list;
-    for (const auto &baseitem : baseitems_info) {
+    auto &baseitems = BaseitemList::get_instance();
+    for (auto &baseitem : baseitems) {
         if (baseitem.bi_key.tval() != tval) {
             continue;
         }
@@ -30,7 +31,7 @@ static void shuffle_flavors(ItemKindType tval)
             continue;
         }
 
-        flavor_idx_ref_list.push_back(baseitems_info[baseitem.idx].flavor);
+        flavor_idx_ref_list.push_back(baseitem.flavor);
     }
 
     rand_shuffle(flavor_idx_ref_list.begin(), flavor_idx_ref_list.end());
@@ -45,7 +46,8 @@ void initialize_items_flavor()
     const Xoshiro128StarStar rng_backup = system.get_rng();
     Xoshiro128StarStar flavor_rng(system.get_seed_flavor());
     system.set_rng(flavor_rng);
-    for (auto &baseitem : baseitems_info) {
+    auto &baseitems = BaseitemList::get_instance();
+    for (auto &baseitem : baseitems) {
         if (baseitem.flavor_name.empty()) {
             continue;
         }
@@ -62,7 +64,7 @@ void initialize_items_flavor()
     shuffle_flavors(ItemKindType::POTION);
     shuffle_flavors(ItemKindType::SCROLL);
     system.set_rng(rng_backup);
-    for (auto &baseitem : baseitems_info) {
+    for (auto &baseitem : baseitems) {
         if (!baseitem.is_valid()) {
             continue;
         }

--- a/src/knowledge/knowledge-experiences.cpp
+++ b/src/knowledge/knowledge-experiences.cpp
@@ -34,7 +34,7 @@ void do_cmd_knowledge_weapon_exp(PlayerType *player_ptr)
     for (auto tval : { ItemKindType::SWORD, ItemKindType::POLEARM, ItemKindType::HAFTED, ItemKindType::DIGGING, ItemKindType::BOW }) {
         for (int num = 0; num < 64; num++) {
             BaseitemKey bi_key(tval, num);
-            for (const auto &baseitem : baseitems_info) {
+            for (const auto &baseitem : BaseitemList::get_instance()) {
                 if (baseitem.bi_key != bi_key) {
                     continue;
                 }

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -150,7 +150,7 @@ static short collect_objects(int grp_cur, std::vector<short> &object_idx, BIT_FL
 {
     short object_cnt = 0;
     const auto group_tval = object_group_tval[grp_cur];
-    for (const auto &baseitem : baseitems_info) {
+    for (const auto &baseitem : BaseitemList::get_instance()) {
         if (baseitem.name.empty() || !check_baseitem_chance(mode, baseitem)) {
             continue;
         }
@@ -182,13 +182,14 @@ static short collect_objects(int grp_cur, std::vector<short> &object_idx, BIT_FL
  */
 static void display_object_list(int col, int row, int per_page, const std::vector<short> &object_idx, int object_cur, int object_top, bool visual_only)
 {
+    const auto &baseitems = BaseitemList::get_instance();
     int i;
     for (i = 0; i < per_page && (object_idx[object_top + i] >= 0); i++) {
         const short bi_id = object_idx[object_top + i];
-        const auto &baseitem = baseitems_info[bi_id];
+        const auto &baseitem = baseitems.get_baseitem(bi_id);
         TERM_COLOR attr = ((baseitem.aware || visual_only) ? TERM_WHITE : TERM_SLATE);
         byte cursor = ((baseitem.aware || visual_only) ? TERM_L_BLUE : TERM_BLUE);
-        const auto &flavor_baseitem = !visual_only && baseitem.flavor ? baseitems_info[baseitem.flavor] : baseitem;
+        const auto &flavor_baseitem = !visual_only && baseitem.flavor ? baseitems.get_baseitem(baseitem.flavor) : baseitem;
 
         attr = ((i + object_top == object_cur) ? cursor : attr);
         const auto is_flavor_only = (baseitem.flavor != 0) && (visual_only || !baseitem.aware);
@@ -251,7 +252,8 @@ void do_cmd_knowledge_objects(PlayerType *player_ptr, bool *need_redraw, bool vi
 
     const auto &[wid, hgt] = term_get_size();
     auto browser_rows = hgt - 8;
-    std::vector<short> object_idx(baseitems_info.size());
+    auto &baseitems = BaseitemList::get_instance();
+    std::vector<short> object_idx(baseitems.size());
 
     int len;
     int max = 0;
@@ -272,8 +274,8 @@ void do_cmd_knowledge_objects(PlayerType *player_ptr, bool *need_redraw, bool vi
         object_old = -1;
         object_cnt = 0;
     } else {
-        auto &baseitem = baseitems_info[direct_k_idx];
-        auto &flavor_baseitem = !visual_only && baseitem.flavor ? baseitems_info[baseitem.flavor] : baseitem;
+        auto &baseitem = baseitems.get_baseitem(direct_k_idx);
+        auto &flavor_baseitem = !visual_only && baseitem.flavor ? baseitems.get_baseitem(baseitem.flavor) : baseitem;
         object_idx[0] = direct_k_idx;
         object_old = direct_k_idx;
         object_cnt = 1;
@@ -370,8 +372,8 @@ void do_cmd_knowledge_objects(PlayerType *player_ptr, bool *need_redraw, bool vi
             display_visual_list(max + 3, 7, browser_rows - 1, wid - (max + 3), attr_top, char_left);
         }
 
-        auto &baseitem = baseitems_info[object_idx[object_cur]];
-        auto &flavor_baseitem = !visual_only && baseitem.flavor ? baseitems_info[baseitem.flavor] : baseitem;
+        auto &baseitem = baseitems.get_baseitem(object_idx[object_cur]);
+        auto &flavor_baseitem = !visual_only && baseitem.flavor ? baseitems.get_baseitem(baseitem.flavor) : baseitem;
 
 #ifdef JP
         prt(format("<方向>%s%s%s, ESC", (!visual_list && !visual_only) ? ", 'r'で詳細を見る" : "", visual_list ? ", ENTERで決定" : ", 'v'でシンボル変更",

--- a/src/load/item/item-loader-base.cpp
+++ b/src/load/item/item-loader-base.cpp
@@ -14,8 +14,9 @@ void ItemLoaderBase::load_item()
 {
     auto loading_max_k_idx = rd_u16b();
     BaseitemInfo dummy;
-    for (auto i = 0U; i < loading_max_k_idx; i++) {
-        auto &baseitem = i < baseitems_info.size() ? baseitems_info[i] : dummy;
+    auto &baseitems = BaseitemList::get_instance();
+    for (uint16_t i = 0; i < loading_max_k_idx; i++) {
+        auto &baseitem = i < baseitems.size() ? baseitems.get_baseitem(i) : dummy;
         const auto tmp8u = rd_byte();
         baseitem.aware = any_bits(tmp8u, 0x01);
         baseitem.tried = any_bits(tmp8u, 0x02);

--- a/src/main/game-data-initializer.cpp
+++ b/src/main/game-data-initializer.cpp
@@ -127,7 +127,8 @@ void init_items_alloc()
 {
     short num[MAX_DEPTH]{};
     auto alloc_kind_size = 0;
-    for (const auto &baseitem : baseitems_info) {
+    const auto &baseitems = BaseitemList::get_instance();
+    for (const auto &baseitem : baseitems) {
         for (const auto &[level, chance] : baseitem.alloc_tables) {
             if (chance != 0) {
                 alloc_kind_size++;
@@ -146,7 +147,7 @@ void init_items_alloc()
 
     alloc_kind_table.assign(alloc_kind_size, {});
     short aux[MAX_DEPTH]{};
-    for (const auto &baseitem : baseitems_info) {
+    for (const auto &baseitem : baseitems) {
         for (const auto &[level, chance] : baseitem.alloc_tables) {
             if (chance == 0) {
                 continue;

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -199,7 +199,7 @@ errr init_artifacts_info()
 errr init_baseitems_info()
 {
     init_header(&baseitems_header);
-    return init_info("BaseitemDefinitions.txt", baseitems_header, baseitems_info, parse_baseitems_info);
+    return init_info("BaseitemDefinitions.txt", baseitems_header, BaseitemList::get_instance().get_raw_vector(), parse_baseitems_info);
 }
 
 /*!

--- a/src/market/building-craft-fix.cpp
+++ b/src/market/building-craft-fix.cpp
@@ -171,10 +171,11 @@ static PRICE repair_broken_weapon_aux(PlayerType *player_ptr, PRICE bcost)
     }
 
     short bi_id;
+    const auto &baseitems = BaseitemList::get_instance();
     if (o_ptr->bi_key.sval() == SV_BROKEN_DAGGER) {
         auto n = 1;
         bi_id = 0;
-        for (const auto &baseitem : baseitems_info) {
+        for (const auto &baseitem : baseitems) {
             if (baseitem.bi_key.tval() != ItemKindType::SWORD) {
                 continue;
             }
@@ -197,7 +198,7 @@ static PRICE repair_broken_weapon_aux(PlayerType *player_ptr, PRICE bcost)
         auto tval = (one_in_(5) ? mo_ptr->bi_key.tval() : ItemKindType::SWORD);
         while (true) {
             bi_id = lookup_baseitem_id({ tval });
-            const auto &baseitem = baseitems_info[bi_id];
+            const auto &baseitem = baseitems.get_baseitem(bi_id);
             const auto sval = baseitem.bi_key.sval();
             if (tval == ItemKindType::SWORD) {
                 if ((sval == SV_BROKEN_DAGGER) || (sval == SV_BROKEN_SWORD) || (sval == SV_DIAMOND_EDGE) || (sval == SV_POISON_NEEDLE)) {
@@ -228,7 +229,7 @@ static PRICE repair_broken_weapon_aux(PlayerType *player_ptr, PRICE bcost)
     dd_bonus += mo_ptr->dd - baseitem_mo.dd;
     ds_bonus += mo_ptr->ds - baseitem_mo.ds;
 
-    const auto &baseitem = baseitems_info[bi_id];
+    const auto &baseitem = baseitems.get_baseitem(bi_id);
     o_ptr->bi_id = bi_id;
     o_ptr->weight = baseitem.weight;
     o_ptr->bi_key = baseitem.bi_key;

--- a/src/object/object-broken.cpp
+++ b/src/object/object-broken.cpp
@@ -207,7 +207,7 @@ bool potion_smash_effect(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y
     auto dt = AttributeType::NONE;
     auto dam = 0;
     auto angry = false;
-    const auto &baseitem = baseitems_info[bi_id];
+    const auto &baseitem = BaseitemList::get_instance().get_baseitem(bi_id);
     switch (*baseitem.bi_key.sval()) {
     case SV_POTION_SALT_WATER:
     case SV_POTION_SLIME_MOLD:

--- a/src/object/object-kind-hook.cpp
+++ b/src/object/object-kind-hook.cpp
@@ -25,7 +25,7 @@ static const int SV_BOOK_MIN_GOOD = 2;
  */
 bool kind_is_cloak(short bi_id)
 {
-    return baseitems_info[bi_id].bi_key.tval() == ItemKindType::CLOAK;
+    return BaseitemList::get_instance().get_baseitem(bi_id).bi_key.tval() == ItemKindType::CLOAK;
 }
 
 /*!
@@ -35,7 +35,7 @@ bool kind_is_cloak(short bi_id)
  */
 bool kind_is_polearm(short bi_id)
 {
-    return baseitems_info[bi_id].bi_key.tval() == ItemKindType::POLEARM;
+    return BaseitemList::get_instance().get_baseitem(bi_id).bi_key.tval() == ItemKindType::POLEARM;
 }
 
 /*!
@@ -45,7 +45,7 @@ bool kind_is_polearm(short bi_id)
  */
 bool kind_is_sword(short bi_id)
 {
-    const auto &baseitem = baseitems_info[bi_id];
+    const auto &baseitem = BaseitemList::get_instance().get_baseitem(bi_id);
     return (baseitem.bi_key.tval() == ItemKindType::SWORD) && (baseitem.bi_key.sval() > 2);
 }
 
@@ -56,7 +56,7 @@ bool kind_is_sword(short bi_id)
  */
 bool kind_is_book(short bi_id)
 {
-    const auto &baseitem = baseitems_info[bi_id];
+    const auto &baseitem = BaseitemList::get_instance().get_baseitem(bi_id);
     return baseitem.bi_key.is_spell_book();
 }
 
@@ -67,7 +67,7 @@ bool kind_is_book(short bi_id)
  */
 bool kind_is_good_book(short bi_id)
 {
-    const auto &baseitem = baseitems_info[bi_id];
+    const auto &baseitem = BaseitemList::get_instance().get_baseitem(bi_id);
     return baseitem.bi_key.is_high_level_book();
 }
 
@@ -78,7 +78,7 @@ bool kind_is_good_book(short bi_id)
  */
 bool kind_is_armor(short bi_id)
 {
-    return baseitems_info[bi_id].bi_key.tval() == ItemKindType::HARD_ARMOR;
+    return BaseitemList::get_instance().get_baseitem(bi_id).bi_key.tval() == ItemKindType::HARD_ARMOR;
 }
 
 /*!
@@ -88,7 +88,7 @@ bool kind_is_armor(short bi_id)
  */
 bool kind_is_hafted(short bi_id)
 {
-    return baseitems_info[bi_id].bi_key.tval() == ItemKindType::HAFTED;
+    return BaseitemList::get_instance().get_baseitem(bi_id).bi_key.tval() == ItemKindType::HAFTED;
 }
 
 /*!
@@ -98,7 +98,7 @@ bool kind_is_hafted(short bi_id)
  */
 bool kind_is_potion(short bi_id)
 {
-    return baseitems_info[bi_id].bi_key.tval() == ItemKindType::POTION;
+    return BaseitemList::get_instance().get_baseitem(bi_id).bi_key.tval() == ItemKindType::POTION;
 }
 
 /*!
@@ -108,7 +108,7 @@ bool kind_is_potion(short bi_id)
  */
 bool kind_is_boots(short bi_id)
 {
-    return baseitems_info[bi_id].bi_key.tval() == ItemKindType::BOOTS;
+    return BaseitemList::get_instance().get_baseitem(bi_id).bi_key.tval() == ItemKindType::BOOTS;
 }
 
 /*!
@@ -118,7 +118,7 @@ bool kind_is_boots(short bi_id)
  */
 bool kind_is_amulet(short bi_id)
 {
-    return baseitems_info[bi_id].bi_key.tval() == ItemKindType::AMULET;
+    return BaseitemList::get_instance().get_baseitem(bi_id).bi_key.tval() == ItemKindType::AMULET;
 }
 
 /*!
@@ -129,7 +129,7 @@ bool kind_is_amulet(short bi_id)
  */
 bool kind_is_good(short bi_id)
 {
-    const auto &baseitem = baseitems_info[bi_id];
+    const auto &baseitem = BaseitemList::get_instance().get_baseitem(bi_id);
     switch (baseitem.bi_key.tval()) {
         /* Armor -- Good unless damaged */
     case ItemKindType::HARD_ARMOR:
@@ -190,7 +190,7 @@ bool kind_is_good(short bi_id)
 static const std::map<ItemKindType, std::vector<int>> &create_baseitems_cache()
 {
     static std::map<ItemKindType, std::vector<int>> cache;
-    for (const auto &baseitem : baseitems_info) {
+    for (const auto &baseitem : BaseitemList::get_instance()) {
         if (!baseitem.is_valid()) {
             continue;
         }
@@ -210,7 +210,7 @@ static const std::map<ItemKindType, std::vector<int>> &create_baseitems_cache()
 static const std::map<BaseitemKey, short> &create_baseitem_index_chache()
 {
     static std::map<BaseitemKey, short> cache;
-    for (const auto &baseitem : baseitems_info) {
+    for (const auto &baseitem : BaseitemList::get_instance()) {
         if (!baseitem.is_valid()) {
             continue;
         }

--- a/src/save/item-writer.cpp
+++ b/src/save/item-writer.cpp
@@ -274,7 +274,7 @@ void wr_item(ItemEntity *o_ptr)
 void wr_perception(short bi_id)
 {
     byte tmp8u = 0;
-    const auto &baseitem = baseitems_info[bi_id];
+    const auto &baseitem = BaseitemList::get_instance().get_baseitem(bi_id);
     if (baseitem.aware) {
         tmp8u |= 0x01;
     }

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -119,7 +119,7 @@ static bool wr_savefile_new(PlayerType *player_ptr, SaveType type)
         wr_lore(i2enum<MonsterRaceId>(r_idx));
     }
 
-    tmp16u = static_cast<uint16_t>(baseitems_info.size());
+    tmp16u = static_cast<uint16_t>(BaseitemList::get_instance().size());
     wr_u16b(tmp16u);
     for (short bi_id = 0; bi_id < tmp16u; bi_id++) {
         wr_perception(bi_id);

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -95,6 +95,7 @@ static const std::array<AmuseDefinition, 13> amuse_info = { {
 
 static std::optional<FixedArtifactId> sweep_amusement_artifact(const bool insta_art, const short bi_id)
 {
+    const auto &baseitems = BaseitemList::get_instance();
     for (const auto &[a_idx, artifact] : artifacts_info) {
         if (a_idx == FixedArtifactId::NONE) {
             continue;
@@ -104,7 +105,7 @@ static std::optional<FixedArtifactId> sweep_amusement_artifact(const bool insta_
             continue;
         }
 
-        if (artifact.bi_key != baseitems_info[bi_id].bi_key) {
+        if (artifact.bi_key != baseitems.get_baseitem(bi_id).bi_key) {
             continue;
         }
 
@@ -131,6 +132,7 @@ void generate_amusement(PlayerType *player_ptr, int num, bool known)
         pt.entry_item(&am_ref, am_ref.prob);
     }
 
+    const auto &baseitems = BaseitemList::get_instance();
     for (auto i = 0; i < num; i++) {
         auto am_ptr = pt.pick_one_at_random();
         const auto bi_id = lookup_baseitem_id(am_ptr->key);
@@ -138,7 +140,7 @@ void generate_amusement(PlayerType *player_ptr, int num, bool known)
             continue;
         }
 
-        const auto insta_art = baseitems_info[bi_id].gen_flags.has(ItemGenerationTraitType::INSTA_ART);
+        const auto insta_art = baseitems.get_baseitem(bi_id).gen_flags.has(ItemGenerationTraitType::INSTA_ART);
         const auto flag = am_ptr->flag;
         const auto fixed_art = flag == AmusementFlagType::FIXED_ART;
         std::optional<FixedArtifactId> opt_a_idx;

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -479,9 +479,10 @@ bool restore_mana(PlayerType *player_ptr, bool magic_eater)
         }
 
         auto sval = 0;
+        const auto &baseitems = BaseitemList::get_instance();
         for (auto &item : magic_eater_data->get_item_group(ItemKindType::ROD)) {
             const auto bi_id = lookup_baseitem_id({ ItemKindType::ROD, sval });
-            item.charge -= ((item.count < 10) ? EATER_ROD_CHARGE * 3 : item.count * EATER_ROD_CHARGE / 3) * baseitems_info[bi_id].pval;
+            item.charge -= ((item.count < 10) ? EATER_ROD_CHARGE * 3 : item.count * EATER_ROD_CHARGE / 3) * baseitems.get_baseitem(bi_id).pval;
             item.charge = std::max(item.charge, 0);
             ++sval;
         }

--- a/src/system/alloc-entries.cpp
+++ b/src/system/alloc-entries.cpp
@@ -9,5 +9,5 @@ std::vector<alloc_entry> alloc_kind_table;
 
 BaseitemInfo &alloc_entry::get_baseitem() const
 {
-    return baseitems_info[this->index];
+    return BaseitemList::get_instance().get_baseitem(this->index);
 }

--- a/src/system/baseitem-info.cpp
+++ b/src/system/baseitem-info.cpp
@@ -710,8 +710,6 @@ void BaseitemInfo::mark_as_aware()
     this->aware = true;
 }
 
-std::vector<BaseitemInfo> baseitems_info;
-
 BaseitemList BaseitemList::instance{};
 
 BaseitemList &BaseitemList::get_instance()

--- a/src/system/baseitem-info.h
+++ b/src/system/baseitem-info.h
@@ -143,8 +143,6 @@ public:
     void mark_as_aware();
 };
 
-extern std::vector<BaseitemInfo> baseitems_info;
-
 class BaseitemList {
 public:
     BaseitemList(BaseitemList &&) = delete;

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -59,7 +59,7 @@ void ItemEntity::copy_from(const ItemEntity *j_ptr)
  */
 void ItemEntity::prep(short new_bi_id)
 {
-    const auto &baseitem = baseitems_info[new_bi_id];
+    const auto &baseitem = BaseitemList::get_instance().get_baseitem(new_bi_id);
     auto old_stack_idx = this->stack_idx;
     this->wipe();
     this->stack_idx = old_stack_idx;
@@ -590,7 +590,7 @@ TERM_COLOR ItemEntity::get_color() const
     const auto &baseitem = this->get_baseitem();
     const auto flavor = baseitem.flavor;
     if (flavor != 0) {
-        return baseitems_info[flavor].cc_config.color;
+        return BaseitemList::get_instance().get_baseitem(flavor).cc_config.color;
     }
 
     const auto &cc_config = baseitem.cc_config;
@@ -614,7 +614,7 @@ char ItemEntity::get_symbol() const
 {
     const auto &baseitem = this->get_baseitem();
     const auto flavor = baseitem.flavor;
-    return flavor ? baseitems_info[flavor].cc_config.character : baseitem.cc_config.character;
+    return flavor ? BaseitemList::get_instance().get_baseitem(flavor).cc_config.character : baseitem.cc_config.character;
 }
 
 /*!
@@ -788,7 +788,7 @@ bool ItemEntity::has_activation() const
 
 BaseitemInfo &ItemEntity::get_baseitem() const
 {
-    return baseitems_info[this->bi_id];
+    return BaseitemList::get_instance().get_baseitem(this->bi_id);
 }
 
 EgoItemDefinition &ItemEntity::get_ego() const

--- a/src/view/display-map.cpp
+++ b/src/view/display-map.cpp
@@ -46,7 +46,8 @@ const std::string image_monsters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQR
 ColoredChar image_object()
 {
     if (use_graphics) {
-        std::span<BaseitemInfo> candidates(baseitems_info.begin() + 1, baseitems_info.end());
+        auto &baseitems = BaseitemList::get_instance();
+        const std::span<BaseitemInfo> candidates(baseitems.begin() + 1, baseitems.end());
         const auto &baseitem = rand_choice(candidates);
         return baseitem.cc_config;
     }
@@ -66,8 +67,8 @@ ColoredChar image_monster()
         return { monrace.x_attr, monrace.x_char };
     }
 
-    auto color = randnum1<uint8_t>(15);
-    auto character = one_in_(25) ? rand_choice(image_objects) : rand_choice(image_monsters);
+    const auto color = randnum1<uint8_t>(15);
+    const auto character = one_in_(25) ? rand_choice(image_objects) : rand_choice(image_monsters);
     return { color, character };
 }
 

--- a/src/wizard/items-spoiler.cpp
+++ b/src/wizard/items-spoiler.cpp
@@ -130,7 +130,7 @@ SpoilerOutputResultType spoil_obj_desc()
     for (const auto &[tval_list, name] : group_item_list) {
         std::vector<short> whats;
         for (auto tval : tval_list) {
-            for (const auto &baseitem : baseitems_info) {
+            for (const auto &baseitem : BaseitemList::get_instance()) {
                 if ((baseitem.bi_key.tval() == tval) && baseitem.gen_flags.has_not(ItemGenerationTraitType::INSTA_ART)) {
                     whats.push_back(baseitem.idx);
                 }

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -951,7 +951,7 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
     std::vector<EgoType> ego_ids;
     if (exam_base) {
         auto max_len = 0;
-        for (const auto &baseitem : baseitems_info) {
+        for (const auto &baseitem : BaseitemList::get_instance()) {
             if (!baseitem.is_valid()) {
                 continue;
             }
@@ -1108,7 +1108,7 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
 
     if (baseitem_ids.size() == 1) {
         const auto bi_id = baseitem_ids.back();
-        const auto &baseitem = baseitems_info[bi_id];
+        const auto &baseitem = BaseitemList::get_instance().get_baseitem(bi_id);
         auto a_idx = FixedArtifactId::NONE;
         if (baseitem.gen_flags.has(ItemGenerationTraitType::INSTA_ART)) {
             for (const auto &[a_idx_loop, artifact_loop] : artifacts_info) {

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -138,7 +138,7 @@ static std::optional<tval_desc> wiz_select_tval()
 static std::optional<short> wiz_select_sval(const tval_desc &td)
 {
     std::vector<short> bi_ids;
-    for (const auto &baseitem : baseitems_info) {
+    for (const auto &baseitem : BaseitemList::get_instance()) {
         if (!baseitem.is_valid() || baseitem.bi_key.tval() != td.tval) {
             continue;
         }
@@ -149,8 +149,9 @@ static std::optional<short> wiz_select_sval(const tval_desc &td)
     const auto prompt = format(_("%s群の具体的なアイテムを選んで下さい", "What Kind of %s? "), td.desc);
 
     CandidateSelector cs(prompt, 15);
+    const auto &baseitems = BaseitemList::get_instance();
     const auto choice = cs.select(bi_ids,
-        [](short bi_id) { return baseitems_info[bi_id].stripped_name(); });
+        [&baseitems](short bi_id) { return baseitems.get_baseitem(bi_id).stripped_name(); });
     return (choice != bi_ids.end()) ? std::make_optional(*choice) : std::nullopt;
 }
 
@@ -193,7 +194,7 @@ void wiz_create_item(PlayerType *player_ptr)
         return;
     }
 
-    const auto &baseitem = baseitems_info[*bi_id];
+    const auto &baseitem = BaseitemList::get_instance().get_baseitem(*bi_id);
     if (baseitem.gen_flags.has(ItemGenerationTraitType::INSTA_ART)) {
         for (const auto &[a_idx, artifact] : artifacts_info) {
             if ((a_idx == FixedArtifactId::NONE) || (artifact.bi_key != baseitem.bi_key)) {
@@ -568,7 +569,7 @@ void wiz_jump_to_dungeon(PlayerType *player_ptr)
  */
 void wiz_learn_items_all(PlayerType *player_ptr)
 {
-    for (const auto &baseitem : baseitems_info) {
+    for (const auto &baseitem : BaseitemList::get_instance()) {
         if (baseitem.is_valid() && baseitem.level <= command_arg) {
             ItemEntity item;
             item.prep(baseitem.idx);


### PR DESCRIPTION
一部説明変数を追加している箇所もありますが、ほぼ機械的置換です
ご確認下さい

備忘：以下のコードは少し気持ち悪いが、単なるshort型ではなくreference\_wrapper\<short\>なので、baseitem.flavor とするとコンパイルできなかった
`flavor_idx_ref_list.push_back(baseitems.get_baseitem(baseitem.idx).flavor);`