### PR TITLE
Include the schema directory in the output of 'make dist'

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,6 +22,9 @@ visual_studio_files = \
 	Hengband/Hengband/Hengband.vcxproj.filters \
 	Hengband/Hengband/packages.config
 
+schema_files = \
+	schema/MonraceDefinitions.schema.json
+
 EXTRA_DIST = \
 	autopick.txt \
 	autopick_eng.txt \
@@ -31,6 +34,7 @@ EXTRA_DIST = \
 	readme-eng.md \
 	THIRD-PARTY-NOTICES.txt \
 	hengband.spec \
-	$(visual_studio_files)
+	$(visual_studio_files) \
+	$(schema_files)
 
 SUBDIRS = src lib


### PR DESCRIPTION
Resolves https://github.com/hengband/hengband/issues/4047 .

This change uses an approach like that used for the Visual Studio files.  An alternative would be to create a Makefile.am file in the schema directory and recurse into that directory from the top-level Makefile.am.  That is the approach used for the lib and src directories.