### PR TITLE
[Fix] 英語flavor textのロードで例外が発生する

### DIFF
--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -546,9 +546,9 @@ static errr set_mon_blows(const nlohmann::json &blow_data, MonsterRaceInfo &monr
         monrace.blows[blow_num].method = rbm->second;
         monrace.blows[blow_num].effect = rbe->second;
 
-        if (blow.value().find("damage_dice") != blow.value().end()) {
-            const auto &blow_dice = blow.value()["damage_dice"];
-            const auto &dice = str_split(blow_dice.get<std::string>(), 'd', false, 2);
+        const auto &blow_dice = blow.value().find("damage_dice");
+        if (blow_dice != blow.value().end()) {
+            const auto &dice = str_split(blow_dice->get<std::string>(), 'd', false, 2);
             info_set_value(monrace.blows[blow_num].d_dice, dice[0]);
             info_set_value(monrace.blows[blow_num].d_side, dice[1]);
         }
@@ -641,20 +641,21 @@ static errr set_mon_flavor(const nlohmann::json &flavor_data, MonsterRaceInfo &m
     }
 
 #ifdef JP
-    if (flavor_data.find("ja") == flavor_data.end()) {
+    const auto &flavor_ja = flavor_data.find("ja");
+    if (flavor_ja == flavor_data.end()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
-    const auto &flavor_ja = flavor_data["ja"];
-    const auto flavor_ja_sys = utf8_to_sys(flavor_ja.get<std::string>());
+    const auto flavor_ja_sys = utf8_to_sys(flavor_ja->get<std::string>());
     if (!flavor_ja_sys) {
         return PARSE_ERROR_INVALID_FLAG;
     }
     monrace.text = flavor_ja_sys.value();
 #else
-    if (flavor_data.find("en") == flavor_data.end()) {
+    const auto &flavor_en = flavor_data.find("en");
+    if (flavor_en == flavor_data.end()) {
         return PARSE_ERROR_NONE;
     }
-    monrace.text = flavor_data["en"].get<std::string>();
+    monrace.text = flavor_en->get<std::string>();
 #endif
     return PARSE_ERROR_NONE;
 }

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -641,22 +641,20 @@ static errr set_mon_flavor(const nlohmann::json &flavor_data, MonsterRaceInfo &m
     }
 
 #ifdef JP
-    const auto &flavor_ja = flavor_data["ja"];
-    if (!flavor_ja.is_string()) {
+    if (flavor_data.find("ja") == flavor_data.end()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
-
+    const auto &flavor_ja = flavor_data["ja"];
     const auto flavor_ja_sys = utf8_to_sys(flavor_ja.get<std::string>());
     if (!flavor_ja_sys) {
         return PARSE_ERROR_INVALID_FLAG;
     }
     monrace.text = flavor_ja_sys.value();
 #else
-    const auto &flavor_en = flavor_data["en"];
-    if (!flavor_en.is_string()) {
-        return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+    if (flavor_data.find("en") == flavor_data.end()) {
+        return PARSE_ERROR_NONE;
     }
-    monrace.text = flavor_en.get<std::string>();
+    monrace.text = flavor_data["en"].get<std::string>();
 #endif
     return PARSE_ERROR_NONE;
 }


### PR DESCRIPTION
 #4018 に関する修正

例外処理の不足により英語版のロード時にクラッシュしていた。
"flavor"の要素数が不足している場合の処理を修正。
要素の省略を許可して正常に処理を続けるようにした。

軽微な修正のためissueなし。