### PR TITLE
[Feature] メッセージ履歴の改良

### DIFF
--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -15,6 +15,7 @@
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 #include "term/z-form.h"
+#include "util/buffer-shaper.h"
 #include "util/int-char-converter.h"
 #include "util/string-processor.h"
 #include "view/display-messages.h"
@@ -181,6 +182,103 @@ void do_cmd_message_one(void)
 }
 
 /*!
+ * @brief メッセージ履歴表示で最も古いメッセージを表示する時の基準メッセージ番号を計算する
+ *
+ * メッセージ履歴はウィンドウの幅によって表示行数が変わるため、最も古いメッセージを表示する時にいくつメッセージが
+ * 表示できるかを実際に計算して基準メッセージ番号を求める.
+ *
+ * @param num_lines メッセージ表示行数
+ * @param width ウィンドウの幅
+ * @return 計算した基準メッセージ番号
+ */
+static int calc_oldest_base_msg_num(int num_lines, int width)
+{
+    auto lines_count = 0;
+
+    for (auto oldest_base_msg_num = message_num(); oldest_base_msg_num > 0; --oldest_base_msg_num) {
+        const auto msg_str = message_str(oldest_base_msg_num - 1);
+        const auto lines = shape_buffer(*msg_str, width);
+        lines_count += std::ssize(lines);
+        if (lines_count > num_lines) {
+            return oldest_base_msg_num;
+        }
+    }
+
+    return 0;
+}
+
+/*!
+ * @brief メッセージ履歴を表示する
+ *
+ * 基準メッセージ番号を指定して、メッセージ履歴を表示する。
+ * メッセージの表示は基準メッセージ番号のものから古いほうへ、画面下から上に向かって行われる。
+ * num_nowで指定したメッセージ番号より新しいメッセージは白で表示し、それ以外は灰色で表示する。
+ * また、指定した文字列を黄色でハイライト表示する。
+ *
+ * @param base_msg_num 基準メッセージ番号
+ * @param num_now 表示色を切り替える境界となるメッセージ番号
+ * @param num_lines 表示行数
+ * @param width ウィンドウの幅
+ * @param shower ハイライト表示する文字列
+ * @return 表示したメッセージ数
+ */
+static int display_message_history(int base_msg_num, int num_now, int num_lines, int width, const std::string &shower)
+{
+    auto displayed_lines = 0;
+
+    int displayed_msg_count;
+    for (displayed_msg_count = 0; (displayed_lines < num_lines); displayed_msg_count++) {
+        const auto msg_num = base_msg_num + displayed_msg_count;
+        if (msg_num >= message_num()) {
+            break;
+        }
+
+        const auto msg_str = message_str(msg_num);
+        const auto color = (msg_num < num_now) ? TERM_WHITE : TERM_SLATE;
+
+        auto lines = shape_buffer(*msg_str, width);
+        if (displayed_lines + std::ssize(lines) > num_lines) {
+            break;
+        }
+
+        std::reverse(lines.begin(), lines.end());
+
+        for (const auto &line : lines) {
+            const auto y = num_lines + 1 - displayed_lines;
+            c_prt(color, line, y, 0);
+            displayed_lines++;
+
+            if (shower.empty()) {
+                continue;
+            }
+
+            /// @todo ハイライト表示する文字列の途中で折り返されると正しくハイライト表示されない。
+            /// もともとメッセージ履歴自体を折り返して保存していた時も同様の問題があった。
+            /// あまり使われていない機能と思われ、処理が複雑になるので、現状はそのままとしている。
+
+            /// @note ダメ文字対策でstringを使わない.
+            const auto *str = line.data();
+            while (true) {
+                str = angband_strstr(str, shower);
+                if (str == nullptr) {
+                    break;
+                }
+
+                const auto len = shower.length();
+                term_putstr(str - line.data(), y, len, TERM_YELLOW, shower);
+                str += len;
+            }
+        }
+    }
+
+    for (auto i = displayed_lines; i < num_lines; ++i) {
+        term_erase(0, num_lines + 1 - i);
+    }
+
+    return displayed_msg_count;
+}
+
+/*!
  * @brief メッセージのログを表示するコマンドのメインルーチン
  * Recall the most recent message
  * @details
@@ -207,47 +305,25 @@ void do_cmd_messages(int num_now)
     std::string shower("");
     const auto &[wid, hgt] = term_get_size();
     auto num_lines = hgt - 4;
-    auto n = message_num();
-    auto i = 0;
+    auto base_msg_num = 0;
     screen_save();
     term_clear();
+
+    const auto oldest_base_msg_num = calc_oldest_base_msg_num(num_lines, wid);
+
     while (true) {
-        int j;
-        int skey;
-        for (j = 0; (j < num_lines) && (i + j < n); j++) {
-            const auto msg_str = message_str(i + j);
-            const auto *msg = msg_str->data();
-            c_prt((i + j < num_now ? TERM_WHITE : TERM_SLATE), msg, num_lines + 1 - j, 0);
-            if (shower.empty()) {
-                continue;
-            }
+        const auto displayed_msg_count = display_message_history(base_msg_num, num_now, num_lines, wid, shower);
 
-            // @details ダメ文字対策でstringを使わない.
-            const auto *str = msg;
-            while (true) {
-                str = angband_strstr(str, shower);
-                if (str == nullptr) {
-                    break;
-                }
-
-                const auto len = shower.length();
-                term_putstr(str - msg, num_lines + 1 - j, len, TERM_YELLOW, shower);
-                str += len;
-            }
-        }
-
-        for (; j < num_lines; j++) {
-            term_erase(0, num_lines + 1 - j);
-        }
-
-        prt(format(_("以前のメッセージ %d-%d 全部で(%d)", "Message Recall (%d-%d of %d)"), i, i + j - 1, n), 0, 0);
+        constexpr auto fmt = _("以前のメッセージ %d-%d 全部で(%d)", "Message Recall (%d-%d of %d)");
+        prt(format(fmt, base_msg_num, base_msg_num + displayed_msg_count - 1, message_num()), 0, 0);
         prt(_("[ 'p' で更に古いもの, 'n' で更に新しいもの, '/' で検索, ESC で中断 ]", "[Press 'p' for older, 'n' for newer, ..., or ESCAPE]"), hgt - 1, 0);
-        skey = inkey_special(true);
+
+        const auto skey = inkey_special(true);
         if (skey == ESCAPE) {
             break;
         }
 
-        j = i;
+        const auto prev_base_msg_num = base_msg_num;
         switch (skey) {
         case '=': {
             prt(_("強調: ", "Show: "), hgt - 1, 0);
@@ -274,11 +350,11 @@ void do_cmd_messages(int num_now)
             }
 
             shower = finder_str;
-            for (int z = i + 1; z < n; z++) {
+            for (auto msg_num = base_msg_num + 1; msg_num < message_num(); msg_num++) {
                 // @details ダメ文字対策でstringを使わない.
-                const auto msg = message_str(z);
+                const auto msg = message_str(msg_num);
                 if (str_find(*msg, finder_str)) {
-                    i = z;
+                    base_msg_num = msg_num;
                     break;
                 }
             }
@@ -286,41 +362,41 @@ void do_cmd_messages(int num_now)
             break;
         }
         case SKEY_TOP:
-            i = n - num_lines;
+            base_msg_num = oldest_base_msg_num;
             break;
         case SKEY_BOTTOM:
-            i = 0;
+            base_msg_num = 0;
             break;
         case '8':
         case SKEY_UP:
         case '\n':
         case '\r':
-            i = std::min(i + 1, n - num_lines);
+            base_msg_num = std::min(base_msg_num + 1, oldest_base_msg_num);
             break;
         case '+':
-            i = std::min(i + 10, n - num_lines);
+            base_msg_num = std::min(base_msg_num + 10, oldest_base_msg_num);
             break;
         case 'p':
         case KTRL('P'):
         case ' ':
         case SKEY_PGUP:
-            i = std::min(i + num_lines, n - num_lines);
+            base_msg_num = std::min(base_msg_num + displayed_msg_count, oldest_base_msg_num);
             break;
         case 'n':
         case KTRL('N'):
         case SKEY_PGDOWN:
-            i = std::max(0, i - num_lines);
+            base_msg_num = std::max(0, base_msg_num - displayed_msg_count);
             break;
         case '-':
-            i = std::max(0, i - 10);
+            base_msg_num = std::max(0, base_msg_num - 10);
             break;
         case '2':
         case SKEY_DOWN:
-            i = std::max(0, i - 1);
+            base_msg_num = std::max(0, base_msg_num - 1);
             break;
         }
 
-        if (i == j) {
+        if (base_msg_num == prev_base_msg_num) {
             bell();
         }
     }

--- a/src/view/display-messages.cpp
+++ b/src/view/display-messages.cpp
@@ -91,38 +91,8 @@ std::shared_ptr<const std::string> message_str(int age)
 
 static void message_add_aux(std::string str)
 {
-    std::string splitted;
-
     if (str.empty()) {
         return;
-    }
-
-    // MAIN_TERM_MIN_COLS桁を超えるメッセージはMAIN_TERM_MIN_COLS桁ずつ分割する
-    if (str.length() > MAIN_TERM_MIN_COLS) {
-        int n;
-#ifdef JP
-        for (n = 0; n < MAIN_TERM_MIN_COLS; n++) {
-            if (iskanji(str[n])) {
-                n++;
-            }
-        }
-
-        /* 最後の文字が漢字半分 */
-        if (n == MAIN_TERM_MIN_COLS + 1) {
-            n = MAIN_TERM_MIN_COLS - 1;
-        }
-#else
-        for (n = MAIN_TERM_MIN_COLS; n > MAIN_TERM_MIN_COLS - 20; n--) {
-            if (str[n] == ' ') {
-                break;
-            }
-        }
-        if (n == MAIN_TERM_MIN_COLS - 20) {
-            n = MAIN_TERM_MIN_COLS;
-        }
-#endif
-        splitted = str.substr(n);
-        str = str.substr(0, n);
     }
 
     // 直前と同じメッセージの場合、「～ <xNN>」と表示する
@@ -177,10 +147,6 @@ static void message_add_aux(std::string str)
 
     if (message_history.size() == MESSAGE_MAX) {
         message_history.pop_back();
-    }
-
-    if (!splitted.empty()) {
-        message_add_aux(std::move(splitted));
     }
 }
 


### PR DESCRIPTION
Resolves #4036 

# 動作チェックしてほしいポイント

まず長い名前のアイテムやモンスターのメッセージを表示させるなどして、長いメッセージ履歴をある程度の量保存したうえで、以下の点を見ていただきたいです。

- サブウィンドウの大きさを変えた時の挙動（動的にウィンドウサイズに合わせて表示内容が変わる）
- メッセージ履歴コマンド（^P）での各種操作（メイン画面なので、ウィンドウサイズ変更を反映させるには一旦メッセージ履歴画面を抜ける必要あり）
- 死亡時にダンプ出力した時にファイルに記録される「死ぬ直前のメッセージ」

なお注意点として、このPRで起動する以前に記録された長いメッセージはすでに分割されて別々のメッセージとして保存されているために対応出来ません。また、このPRでメッセージ履歴に記録された長いメッセージは現在のdevelopで起動すると起動時に80桁で分割されて別々のメッセージ履歴として扱われるようになります。
