### PR TITLE
MonsterPainDescriber のPlayerType 依存をなくした

### DIFF
--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -837,15 +837,14 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX i_idx, ItemEntity *j_ptr, SP
 
                     /* No death */
                     else {
+                        const auto m_name = monster_desc(player_ptr, m_ptr, 0);
                         /* STICK TO */
                         if (q_ptr->is_fixed_artifact() && (sniper_concent == 0)) {
-                            const auto m_name = monster_desc(player_ptr, m_ptr, 0);
-
                             stick_to = true;
                             msg_format(_("%sは%sに突き刺さった！", "%s^ is stuck in %s!"), item_name.data(), m_name.data());
                         }
 
-                        const auto pain_message = MonsterPainDescriber(player_ptr, m_ptr).describe(tdam);
+                        const auto pain_message = MonsterPainDescriber(m_name, m_ptr).describe(tdam);
                         if (pain_message) {
                             msg_print(*pain_message);
                         }
@@ -856,7 +855,6 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX i_idx, ItemEntity *j_ptr, SP
                         }
 
                         if (fear && m_ptr->ml) {
-                            const auto m_name = monster_desc(player_ptr, m_ptr, 0);
                             sound(SOUND_FLEE);
                             msg_format(_("%s^は恐怖して逃げ出した！", "%s^ flees in terror!"), m_name.data());
                         }

--- a/src/effect/effect-monster.cpp
+++ b/src/effect/effect-monster.cpp
@@ -210,7 +210,8 @@ static void effect_damage_makes_sleep(PlayerType *player_ptr, EffectMonster *em_
     if (!em_ptr->note.empty() && em_ptr->seen_msg) {
         msg_format("%s^%s", em_ptr->m_name, em_ptr->note.data());
     } else if (em_ptr->see_s_msg) {
-        const auto pain_message = MonsterPainDescriber(player_ptr, em_ptr->m_ptr).describe(em_ptr->dam);
+        const auto m_name = monster_desc(player_ptr, em_ptr->m_ptr, 0);
+        const auto pain_message = MonsterPainDescriber(m_name, em_ptr->m_ptr).describe(em_ptr->dam);
         if (pain_message) {
             msg_print(*pain_message);
         }
@@ -305,7 +306,8 @@ static bool deal_effect_damage_from_player(PlayerType *player_ptr, EffectMonster
     if (!em_ptr->note.empty() && em_ptr->seen) {
         msg_format(_("%s%s", "%s^%s"), em_ptr->m_name, em_ptr->note.data());
     } else if (em_ptr->known && (em_ptr->dam || !em_ptr->do_fear)) {
-        const auto pain_message = MonsterPainDescriber(player_ptr, em_ptr->m_ptr).describe(em_ptr->dam);
+        const auto m_name = monster_desc(player_ptr, em_ptr->m_ptr, 0);
+        const auto pain_message = MonsterPainDescriber(m_name, em_ptr->m_ptr).describe(em_ptr->dam);
         if (pain_message) {
             msg_print(*pain_message);
         }

--- a/src/monster/monster-pain-describer.cpp
+++ b/src/monster/monster-pain-describer.cpp
@@ -179,8 +179,8 @@ static const std::vector<pain_message_type>
         { [](const MonsterEntity &) { return true; }, pain_messages_common },
     };
 
-MonsterPainDescriber::MonsterPainDescriber(PlayerType *player_ptr, const MonsterEntity *m_ptr)
-    : player_ptr(player_ptr)
+MonsterPainDescriber::MonsterPainDescriber(std::string m_name, const MonsterEntity *m_ptr)
+    : m_name(m_name)
     , m_ptr(m_ptr)
 {
 }
@@ -192,8 +192,6 @@ MonsterPainDescriber::MonsterPainDescriber(PlayerType *player_ptr, const Monster
  */
 std::optional<std::string> MonsterPainDescriber::describe(int dam)
 {
-    const auto m_name = monster_desc(player_ptr, this->m_ptr, 0);
-
     if (dam == 0) {
         if (this->m_ptr->ml) {
             return format(_("%s^はダメージを受けていない。", "%s^ is unharmed."), m_name.data());

--- a/src/monster/monster-pain-describer.h
+++ b/src/monster/monster-pain-describer.h
@@ -7,11 +7,11 @@ class MonsterEntity;
 
 class MonsterPainDescriber {
 public:
-    MonsterPainDescriber(PlayerType *player_ptr, const MonsterEntity *m_ptr);
+    MonsterPainDescriber(std::string m_name, const MonsterEntity *m_ptr);
 
     std::optional<std::string> describe(int dam);
 
 private:
-    PlayerType *player_ptr;
+    std::string m_name;
     const MonsterEntity *m_ptr;
 };

--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -455,7 +455,7 @@ void ObjectThrowEntity::attack_racial_power()
     if (mdp.mon_take_hit(this->m_ptr->get_died_message())) {
         return;
     }
-    const auto pain_message = MonsterPainDescriber(player_ptr, this->m_ptr).describe(this->tdam);
+    const auto pain_message = MonsterPainDescriber(this->m_name, this->m_ptr).describe(this->tdam);
     if (pain_message) {
         msg_print(*pain_message);
     }


### PR DESCRIPTION
Resolve #3959 
PlayerType 依存を外部に移しただけだが、MonsterPainDescriber の隠蔽化がやりやすくなる