### PR TITLE
[Feature] ./configure で言語標準に付与されるGNU拡張をOFFにする

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ AC_SUBST(DEFAULT_VAR_PATH)
 dnl Checks for programs.
 AC_LANG(C++)
 AC_PROG_CXX
-AX_CXX_COMPILE_STDCXX(20, [ext], [mandatory])
+AX_CXX_COMPILE_STDCXX(20, [noext], [mandatory])
 PKG_PROG_PKG_CONFIG
 
 AC_ARG_ENABLE(japanese,


### PR DESCRIPTION
現在の configure.ac 設定では言語標準として -std=gnu++20 が指定されるが、現在GNU拡張の機能は使っておらず、MSVCでコンパイルできる保証もないため、GNU拡張はOFFとし、 -std=c++20 が指定されるようにする。