### PR TITLE
ItemEntity のコンストラクタにベースアイテムID とBaseitemKey を受け取るコンストラクタ2種を追加した

### DIFF
--- a/src/artifact/fixed-art-generator.cpp
+++ b/src/artifact/fixed-art-generator.cpp
@@ -24,7 +24,6 @@
 #include "player/player-sex.h"
 #include "specific-object/bloody-moon.h"
 #include "system/artifact-type-definition.h"
-#include "system/baseitem-info.h"
 #include "system/floor-type-definition.h"
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
@@ -258,10 +257,7 @@ bool create_named_art(PlayerType *player_ptr, FixedArtifactId a_idx, POSITION y,
         return false;
     }
 
-    const auto &baseitems = BaseitemList::get_instance();
-    const auto bi_id = baseitems.lookup_baseitem_id(artifact.bi_key);
-    ItemEntity item;
-    item.generate(bi_id);
+    ItemEntity item(artifact.bi_key);
     item.fixed_artifact_idx = a_idx;
     apply_artifact(player_ptr, &item);
     if (drop_near(player_ptr, &item, -1, y, x) == 0) {
@@ -395,8 +391,7 @@ bool make_artifact_special(PlayerType *player_ptr, ItemEntity *o_ptr)
          * ベースアイテムの生成階層が足りない場合1/(不足階層*5)を満たさないと除外される。
          */
         const auto &baseitems = BaseitemList::get_instance();
-        const auto bi_id = baseitems.lookup_baseitem_id(artifact.bi_key);
-        const auto &baseitem = baseitems.get_baseitem(bi_id);
+        const auto &baseitem = baseitems.lookup_baseitem(artifact.bi_key);
         if (baseitem.level > floor_ptr->object_level) {
             int d = (baseitem.level - floor_ptr->object_level) * 5;
             if (!one_in_(d)) {
@@ -404,10 +399,8 @@ bool make_artifact_special(PlayerType *player_ptr, ItemEntity *o_ptr)
             }
         }
 
-        /*! @note 前述の条件を満たしたら、後のIDのアーティファクトはチェックせずすぐ確定し生成処理に移す /
-         * Assign the template. Mega-Hack -- mark the item as an artifact. Hack: Some artifacts get random extra powers. Success. */
-        o_ptr->generate(bi_id);
-
+        //<! @note 前述の条件を満たしたら、後のIDのアーティファクトはチェックせずすぐ確定し生成処理に移す.
+        o_ptr->generate(artifact.bi_key);
         o_ptr->fixed_artifact_idx = a_idx;
         return true;
     }

--- a/src/artifact/fixed-art-generator.cpp
+++ b/src/artifact/fixed-art-generator.cpp
@@ -261,7 +261,7 @@ bool create_named_art(PlayerType *player_ptr, FixedArtifactId a_idx, POSITION y,
     const auto &baseitems = BaseitemList::get_instance();
     const auto bi_id = baseitems.lookup_baseitem_id(artifact.bi_key);
     ItemEntity item;
-    item.prep(bi_id);
+    item.generate(bi_id);
     item.fixed_artifact_idx = a_idx;
     apply_artifact(player_ptr, &item);
     if (drop_near(player_ptr, &item, -1, y, x) == 0) {
@@ -406,7 +406,7 @@ bool make_artifact_special(PlayerType *player_ptr, ItemEntity *o_ptr)
 
         /*! @note 前述の条件を満たしたら、後のIDのアーティファクトはチェックせずすぐ確定し生成処理に移す /
          * Assign the template. Mega-Hack -- mark the item as an artifact. Hack: Some artifacts get random extra powers. Success. */
-        o_ptr->prep(bi_id);
+        o_ptr->generate(bi_id);
 
         o_ptr->fixed_artifact_idx = a_idx;
         return true;

--- a/src/birth/inventory-initializer.cpp
+++ b/src/birth/inventory-initializer.cpp
@@ -103,7 +103,7 @@ static void decide_initial_items(PlayerType *player_ptr, ItemEntity *q_ptr)
         /* Demon can drain vitality from humanoid corpse */
         get_mon_num_prep(player_ptr, monster_hook_human, nullptr);
         for (int i = rand_range(3, 4); i > 0; i--) {
-            q_ptr->prep(baseitems.lookup_baseitem_id({ ItemKindType::CORPSE, SV_CORPSE }));
+            q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::CORPSE, SV_CORPSE }));
             q_ptr->pval = enum2i(get_mon_num(player_ptr, 0, 2, PM_NONE));
             if (q_ptr->pval) {
                 q_ptr->number = 1;
@@ -117,26 +117,26 @@ static void decide_initial_items(PlayerType *player_ptr, ItemEntity *q_ptr)
     case PlayerRaceType::ZOMBIE:
     case PlayerRaceType::SPECTRE:
         /* Staff (of Nothing) */
-        q_ptr->prep(baseitems.lookup_baseitem_id({ ItemKindType::STAFF, SV_STAFF_NOTHING }));
+        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::STAFF, SV_STAFF_NOTHING }));
         q_ptr->number = 1;
         add_outfit(player_ptr, q_ptr);
         break;
     case PlayerRaceType::ENT:
         /* Potions of Water */
-        q_ptr->prep(baseitems.lookup_baseitem_id({ ItemKindType::POTION, SV_POTION_WATER }));
+        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::POTION, SV_POTION_WATER }));
         q_ptr->number = (ITEM_NUMBER)rand_range(15, 23);
         add_outfit(player_ptr, q_ptr);
         break;
     case PlayerRaceType::ANDROID:
         /* Flasks of oil */
-        q_ptr->prep(baseitems.lookup_baseitem_id({ ItemKindType::FLASK }));
+        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::FLASK }));
         ItemMagicApplier(player_ptr, q_ptr, 1, AM_NO_FIXED_ART).execute();
         q_ptr->number = (ITEM_NUMBER)rand_range(7, 12);
         add_outfit(player_ptr, q_ptr);
         break;
     default:
         /* Food rations */
-        q_ptr->prep(baseitems.lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_RATION }));
+        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_RATION }));
         q_ptr->number = (ITEM_NUMBER)rand_range(3, 7);
         add_outfit(player_ptr, q_ptr);
     }
@@ -159,11 +159,11 @@ void player_outfit(PlayerType *player_ptr)
     PlayerRace pr(player_ptr);
     auto &baseitems = BaseitemList::get_instance();
     if (pr.equals(PlayerRaceType::VAMPIRE) && !pc.equals(PlayerClassType::NINJA)) {
-        q_ptr->prep(baseitems.lookup_baseitem_id({ ItemKindType::SCROLL, SV_SCROLL_DARKNESS }));
+        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::SCROLL, SV_SCROLL_DARKNESS }));
         q_ptr->number = (ITEM_NUMBER)rand_range(2, 5);
         add_outfit(player_ptr, q_ptr);
     } else if (!pc.equals(PlayerClassType::NINJA)) {
-        q_ptr->prep(baseitems.lookup_baseitem_id({ ItemKindType::LITE, SV_LITE_TORCH }));
+        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::LITE, SV_LITE_TORCH }));
         q_ptr->number = (ITEM_NUMBER)rand_range(3, 7);
         q_ptr->fuel = rand_range(3, 7) * 500;
 
@@ -172,72 +172,72 @@ void player_outfit(PlayerType *player_ptr)
 
     q_ptr = &forge;
     if (pr.equals(PlayerRaceType::MERFOLK)) {
-        q_ptr->prep(baseitems.lookup_baseitem_id({ ItemKindType::RING, SV_RING_LEVITATION_FALL }));
+        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::RING, SV_RING_LEVITATION_FALL }));
         q_ptr->number = 1;
         add_outfit(player_ptr, q_ptr);
     }
 
     if (pc.equals(PlayerClassType::RANGER) || pc.equals(PlayerClassType::CAVALRY)) {
-        q_ptr->prep(baseitems.lookup_baseitem_id({ ItemKindType::ARROW, SV_AMMO_NORMAL }));
+        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::ARROW, SV_AMMO_NORMAL }));
         q_ptr->number = (byte)rand_range(15, 20);
         add_outfit(player_ptr, q_ptr);
     }
 
     if (pc.equals(PlayerClassType::RANGER)) {
-        q_ptr->prep(baseitems.lookup_baseitem_id({ ItemKindType::BOW, SV_SHORT_BOW }));
+        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::BOW, SV_SHORT_BOW }));
         add_outfit(player_ptr, q_ptr);
     } else if (pc.equals(PlayerClassType::ARCHER)) {
-        q_ptr->prep(baseitems.lookup_baseitem_id({ ItemKindType::ARROW, SV_AMMO_NORMAL }));
+        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::ARROW, SV_AMMO_NORMAL }));
         q_ptr->number = (ITEM_NUMBER)rand_range(15, 20);
         add_outfit(player_ptr, q_ptr);
     } else if (pc.equals(PlayerClassType::HIGH_MAGE) || pc.equals(PlayerClassType::ELEMENTALIST)) {
-        q_ptr->prep(baseitems.lookup_baseitem_id({ ItemKindType::WAND, SV_WAND_MAGIC_MISSILE }));
+        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::WAND, SV_WAND_MAGIC_MISSILE }));
         q_ptr->number = 1;
         q_ptr->pval = (PARAMETER_VALUE)rand_range(25, 30);
         add_outfit(player_ptr, q_ptr);
     } else if (pc.equals(PlayerClassType::SORCERER)) {
         for (auto book_tval = enum2i(ItemKindType::LIFE_BOOK); book_tval <= enum2i(ItemKindType::LIFE_BOOK) + MAX_MAGIC - 1; book_tval++) {
-            q_ptr->prep(baseitems.lookup_baseitem_id({ i2enum<ItemKindType>(book_tval), 0 }));
+            q_ptr->generate(baseitems.lookup_baseitem_id({ i2enum<ItemKindType>(book_tval), 0 }));
             q_ptr->number = 1;
             add_outfit(player_ptr, q_ptr);
         }
     } else if (pc.equals(PlayerClassType::TOURIST)) {
         if (player_ptr->ppersonality != PERSONALITY_SEXY) {
-            q_ptr->prep(baseitems.lookup_baseitem_id({ ItemKindType::SHOT, SV_AMMO_LIGHT }));
+            q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::SHOT, SV_AMMO_LIGHT }));
             q_ptr->number = rand_range(15, 20);
             add_outfit(player_ptr, q_ptr);
         }
 
-        q_ptr->prep(baseitems.lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_BISCUIT }));
+        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_BISCUIT }));
         q_ptr->number = rand_range(2, 4);
 
         add_outfit(player_ptr, q_ptr);
 
-        q_ptr->prep(baseitems.lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_WAYBREAD }));
+        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_WAYBREAD }));
         q_ptr->number = rand_range(2, 4);
 
         add_outfit(player_ptr, q_ptr);
 
-        q_ptr->prep(baseitems.lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_JERKY }));
+        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_JERKY }));
         q_ptr->number = rand_range(1, 3);
 
         add_outfit(player_ptr, q_ptr);
 
-        q_ptr->prep(baseitems.lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_PINT_OF_ALE }));
+        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_PINT_OF_ALE }));
         q_ptr->number = rand_range(2, 4);
 
         add_outfit(player_ptr, q_ptr);
 
-        q_ptr->prep(baseitems.lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_PINT_OF_WINE }));
+        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_PINT_OF_WINE }));
         q_ptr->number = rand_range(2, 4);
 
         add_outfit(player_ptr, q_ptr);
     } else if (pc.equals(PlayerClassType::NINJA)) {
-        q_ptr->prep(baseitems.lookup_baseitem_id({ ItemKindType::SPIKE, 0 }));
+        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::SPIKE, 0 }));
         q_ptr->number = rand_range(15, 20);
         add_outfit(player_ptr, q_ptr);
     } else if (pc.equals(PlayerClassType::SNIPER)) {
-        q_ptr->prep(baseitems.lookup_baseitem_id({ ItemKindType::BOLT, SV_AMMO_NORMAL }));
+        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::BOLT, SV_AMMO_NORMAL }));
         q_ptr->number = rand_range(15, 20);
         add_outfit(player_ptr, q_ptr);
     }
@@ -271,7 +271,7 @@ void player_outfit(PlayerType *player_ptr)
         }
 
         q_ptr = &forge;
-        q_ptr->prep(baseitems.lookup_baseitem_id({ tv, sv }));
+        q_ptr->generate(baseitems.lookup_baseitem_id({ tv, sv }));
 
         /* Only assassins get a poisoned weapon */
         if (((tv == ItemKindType::SWORD) || (tv == ItemKindType::HAFTED)) && (pc.equals(PlayerClassType::ROGUE) && (player_ptr->realm1 == REALM_DEATH))) {

--- a/src/birth/inventory-initializer.cpp
+++ b/src/birth/inventory-initializer.cpp
@@ -28,7 +28,6 @@
 #include "sv-definition/sv-staff-types.h"
 #include "sv-definition/sv-wand-types.h"
 #include "sv-definition/sv-weapon-types.h"
-#include "system/baseitem-info.h"
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "util/enum-converter.h"
@@ -82,7 +81,7 @@ void wield_all(PlayerType *player_ptr)
  * @details アイテムを既知のものとした上でwield_all()関数により装備させる。
  * @param o_ptr 処理したいオブジェクト構造体の参照ポインタ
  */
-void add_outfit(PlayerType *player_ptr, ItemEntity *o_ptr)
+static void add_outfit(PlayerType *player_ptr, ItemEntity *o_ptr)
 {
     object_aware(player_ptr, o_ptr);
     o_ptr->mark_as_known();
@@ -93,7 +92,6 @@ void add_outfit(PlayerType *player_ptr, ItemEntity *o_ptr)
 
 static void decide_initial_items(PlayerType *player_ptr, ItemEntity *q_ptr)
 {
-    const auto &baseitems = BaseitemList::get_instance();
     switch (player_ptr->prace) {
     case PlayerRaceType::VAMPIRE:
         /* Nothing! */
@@ -103,7 +101,7 @@ static void decide_initial_items(PlayerType *player_ptr, ItemEntity *q_ptr)
         /* Demon can drain vitality from humanoid corpse */
         get_mon_num_prep(player_ptr, monster_hook_human, nullptr);
         for (int i = rand_range(3, 4); i > 0; i--) {
-            q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::CORPSE, SV_CORPSE }));
+            q_ptr->generate({ ItemKindType::CORPSE, SV_CORPSE });
             q_ptr->pval = enum2i(get_mon_num(player_ptr, 0, 2, PM_NONE));
             if (q_ptr->pval) {
                 q_ptr->number = 1;
@@ -117,26 +115,26 @@ static void decide_initial_items(PlayerType *player_ptr, ItemEntity *q_ptr)
     case PlayerRaceType::ZOMBIE:
     case PlayerRaceType::SPECTRE:
         /* Staff (of Nothing) */
-        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::STAFF, SV_STAFF_NOTHING }));
+        q_ptr->generate({ ItemKindType::STAFF, SV_STAFF_NOTHING });
         q_ptr->number = 1;
         add_outfit(player_ptr, q_ptr);
         break;
     case PlayerRaceType::ENT:
         /* Potions of Water */
-        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::POTION, SV_POTION_WATER }));
+        q_ptr->generate({ ItemKindType::POTION, SV_POTION_WATER });
         q_ptr->number = (ITEM_NUMBER)rand_range(15, 23);
         add_outfit(player_ptr, q_ptr);
         break;
     case PlayerRaceType::ANDROID:
         /* Flasks of oil */
-        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::FLASK }));
+        q_ptr->generate({ ItemKindType::FLASK });
         ItemMagicApplier(player_ptr, q_ptr, 1, AM_NO_FIXED_ART).execute();
         q_ptr->number = (ITEM_NUMBER)rand_range(7, 12);
         add_outfit(player_ptr, q_ptr);
         break;
     default:
         /* Food rations */
-        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_RATION }));
+        q_ptr->generate({ ItemKindType::FOOD, SV_FOOD_RATION });
         q_ptr->number = (ITEM_NUMBER)rand_range(3, 7);
         add_outfit(player_ptr, q_ptr);
     }

--- a/src/birth/inventory-initializer.cpp
+++ b/src/birth/inventory-initializer.cpp
@@ -79,64 +79,69 @@ void wield_all(PlayerType *player_ptr)
 /*!
  * @brief 初期所持アイテムの処理 / Add an outfit object
  * @details アイテムを既知のものとした上でwield_all()関数により装備させる。
- * @param o_ptr 処理したいオブジェクト構造体の参照ポインタ
+ * @param item 処理したいアイテムへの参照
  */
-static void add_outfit(PlayerType *player_ptr, ItemEntity *o_ptr)
+static void add_outfit(PlayerType *player_ptr, ItemEntity &item)
 {
-    object_aware(player_ptr, o_ptr);
-    o_ptr->mark_as_known();
-    int16_t slot = store_item_to_inventory(player_ptr, o_ptr);
+    object_aware(player_ptr, &item);
+    item.mark_as_known();
+    const auto slot = store_item_to_inventory(player_ptr, &item);
     autopick_alter_item(player_ptr, slot, false);
     wield_all(player_ptr);
 }
 
-static void decide_initial_items(PlayerType *player_ptr, ItemEntity *q_ptr)
+static void decide_initial_items(PlayerType *player_ptr)
 {
     switch (player_ptr->prace) {
     case PlayerRaceType::VAMPIRE:
         /* Nothing! */
         /* Vampires can drain blood of creatures */
-        break;
+        return;
     case PlayerRaceType::BALROG:
         /* Demon can drain vitality from humanoid corpse */
         get_mon_num_prep(player_ptr, monster_hook_human, nullptr);
         for (int i = rand_range(3, 4); i > 0; i--) {
-            q_ptr->generate({ ItemKindType::CORPSE, SV_CORPSE });
-            q_ptr->pval = enum2i(get_mon_num(player_ptr, 0, 2, PM_NONE));
-            if (q_ptr->pval) {
-                q_ptr->number = 1;
-                add_outfit(player_ptr, q_ptr);
+            ItemEntity item({ ItemKindType::CORPSE, SV_CORPSE });
+            item.pval = enum2i(get_mon_num(player_ptr, 0, 2, PM_NONE));
+            if (item.pval) {
+                item.number = 1;
+                add_outfit(player_ptr, item);
             }
         }
 
-        break;
+        return;
     case PlayerRaceType::SKELETON:
     case PlayerRaceType::GOLEM:
     case PlayerRaceType::ZOMBIE:
-    case PlayerRaceType::SPECTRE:
+    case PlayerRaceType::SPECTRE: {
         /* Staff (of Nothing) */
-        q_ptr->generate({ ItemKindType::STAFF, SV_STAFF_NOTHING });
-        q_ptr->number = 1;
-        add_outfit(player_ptr, q_ptr);
-        break;
-    case PlayerRaceType::ENT:
+        ItemEntity item({ ItemKindType::STAFF, SV_STAFF_NOTHING });
+        item.number = 1;
+        add_outfit(player_ptr, item);
+        return;
+    }
+    case PlayerRaceType::ENT: {
         /* Potions of Water */
-        q_ptr->generate({ ItemKindType::POTION, SV_POTION_WATER });
-        q_ptr->number = (ITEM_NUMBER)rand_range(15, 23);
-        add_outfit(player_ptr, q_ptr);
-        break;
-    case PlayerRaceType::ANDROID:
+        ItemEntity item({ ItemKindType::POTION, SV_POTION_WATER });
+        item.number = (ITEM_NUMBER)rand_range(15, 23);
+        add_outfit(player_ptr, item);
+        return;
+    }
+    case PlayerRaceType::ANDROID: {
         /* Flasks of oil */
-        q_ptr->generate({ ItemKindType::FLASK });
-        ItemMagicApplier(player_ptr, q_ptr, 1, AM_NO_FIXED_ART).execute();
-        q_ptr->number = (ITEM_NUMBER)rand_range(7, 12);
-        add_outfit(player_ptr, q_ptr);
-        break;
-    default:
+        ItemEntity item(ItemKindType::FLASK);
+        ItemMagicApplier(player_ptr, &item, 1, AM_NO_FIXED_ART).execute();
+        item.number = (ITEM_NUMBER)rand_range(7, 12);
+        add_outfit(player_ptr, item);
+        return;
+    }
+    default: {
         /* Food rations */
-        q_ptr->generate({ ItemKindType::FOOD, SV_FOOD_RATION });
-        q_ptr->number = (ITEM_NUMBER)rand_range(3, 7);
-        add_outfit(player_ptr, q_ptr);
+        ItemEntity item({ ItemKindType::FOOD, SV_FOOD_RATION });
+        item.number = (ITEM_NUMBER)rand_range(3, 7);
+        add_outfit(player_ptr, item);
+        return;
+    }
     }
 }
 
@@ -146,98 +151,84 @@ static void decide_initial_items(PlayerType *player_ptr, ItemEntity *q_ptr)
  */
 void player_outfit(PlayerType *player_ptr)
 {
-    ItemEntity *q_ptr;
-    ItemEntity forge;
-    q_ptr = &forge;
-
-    decide_initial_items(player_ptr, q_ptr);
-    q_ptr = &forge;
-
+    decide_initial_items(player_ptr);
     PlayerClass pc(player_ptr);
     PlayerRace pr(player_ptr);
-    auto &baseitems = BaseitemList::get_instance();
     if (pr.equals(PlayerRaceType::VAMPIRE) && !pc.equals(PlayerClassType::NINJA)) {
-        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::SCROLL, SV_SCROLL_DARKNESS }));
-        q_ptr->number = (ITEM_NUMBER)rand_range(2, 5);
-        add_outfit(player_ptr, q_ptr);
+        ItemEntity item({ ItemKindType::SCROLL, SV_SCROLL_DARKNESS });
+        item.number = (ITEM_NUMBER)rand_range(2, 5);
+        add_outfit(player_ptr, item);
     } else if (!pc.equals(PlayerClassType::NINJA)) {
-        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::LITE, SV_LITE_TORCH }));
-        q_ptr->number = (ITEM_NUMBER)rand_range(3, 7);
-        q_ptr->fuel = rand_range(3, 7) * 500;
-
-        add_outfit(player_ptr, q_ptr);
+        ItemEntity item({ ItemKindType::LITE, SV_LITE_TORCH });
+        item.number = (ITEM_NUMBER)rand_range(3, 7);
+        item.fuel = rand_range(3, 7) * 500;
+        add_outfit(player_ptr, item);
     }
 
-    q_ptr = &forge;
     if (pr.equals(PlayerRaceType::MERFOLK)) {
-        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::RING, SV_RING_LEVITATION_FALL }));
-        q_ptr->number = 1;
-        add_outfit(player_ptr, q_ptr);
+        ItemEntity item({ ItemKindType::RING, SV_RING_LEVITATION_FALL });
+        item.number = 1;
+        add_outfit(player_ptr, item);
     }
 
     if (pc.equals(PlayerClassType::RANGER) || pc.equals(PlayerClassType::CAVALRY)) {
-        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::ARROW, SV_AMMO_NORMAL }));
-        q_ptr->number = (byte)rand_range(15, 20);
-        add_outfit(player_ptr, q_ptr);
+        ItemEntity item({ ItemKindType::ARROW, SV_AMMO_NORMAL });
+        item.number = (byte)rand_range(15, 20);
+        add_outfit(player_ptr, item);
     }
 
     if (pc.equals(PlayerClassType::RANGER)) {
-        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::BOW, SV_SHORT_BOW }));
-        add_outfit(player_ptr, q_ptr);
+        ItemEntity item({ ItemKindType::BOW, SV_SHORT_BOW });
+        add_outfit(player_ptr, item);
     } else if (pc.equals(PlayerClassType::ARCHER)) {
-        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::ARROW, SV_AMMO_NORMAL }));
-        q_ptr->number = (ITEM_NUMBER)rand_range(15, 20);
-        add_outfit(player_ptr, q_ptr);
+        ItemEntity item({ ItemKindType::ARROW, SV_AMMO_NORMAL });
+        item.number = (ITEM_NUMBER)rand_range(15, 20);
+        add_outfit(player_ptr, item);
     } else if (pc.equals(PlayerClassType::HIGH_MAGE) || pc.equals(PlayerClassType::ELEMENTALIST)) {
-        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::WAND, SV_WAND_MAGIC_MISSILE }));
-        q_ptr->number = 1;
-        q_ptr->pval = (PARAMETER_VALUE)rand_range(25, 30);
-        add_outfit(player_ptr, q_ptr);
+        ItemEntity item({ ItemKindType::WAND, SV_WAND_MAGIC_MISSILE });
+        item.number = 1;
+        item.pval = (PARAMETER_VALUE)rand_range(25, 30);
+        add_outfit(player_ptr, item);
     } else if (pc.equals(PlayerClassType::SORCERER)) {
         for (auto book_tval = enum2i(ItemKindType::LIFE_BOOK); book_tval <= enum2i(ItemKindType::LIFE_BOOK) + MAX_MAGIC - 1; book_tval++) {
-            q_ptr->generate(baseitems.lookup_baseitem_id({ i2enum<ItemKindType>(book_tval), 0 }));
-            q_ptr->number = 1;
-            add_outfit(player_ptr, q_ptr);
+            ItemEntity item({ i2enum<ItemKindType>(book_tval), 0 });
+            item.number = 1;
+            add_outfit(player_ptr, item);
         }
     } else if (pc.equals(PlayerClassType::TOURIST)) {
         if (player_ptr->ppersonality != PERSONALITY_SEXY) {
-            q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::SHOT, SV_AMMO_LIGHT }));
-            q_ptr->number = rand_range(15, 20);
-            add_outfit(player_ptr, q_ptr);
+            ItemEntity item({ ItemKindType::SHOT, SV_AMMO_LIGHT });
+            item.number = rand_range(15, 20);
+            add_outfit(player_ptr, item);
         }
 
-        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_BISCUIT }));
-        q_ptr->number = rand_range(2, 4);
+        ItemEntity item_biscuit({ ItemKindType::FOOD, SV_FOOD_BISCUIT });
+        item_biscuit.number = rand_range(2, 4);
+        add_outfit(player_ptr, item_biscuit);
 
-        add_outfit(player_ptr, q_ptr);
+        ItemEntity item_waybread({ ItemKindType::FOOD, SV_FOOD_WAYBREAD });
+        item_waybread.number = rand_range(2, 4);
+        add_outfit(player_ptr, item_waybread);
 
-        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_WAYBREAD }));
-        q_ptr->number = rand_range(2, 4);
+        ItemEntity item_jerky({ ItemKindType::FOOD, SV_FOOD_JERKY });
+        item_jerky.number = rand_range(1, 3);
+        add_outfit(player_ptr, item_jerky);
 
-        add_outfit(player_ptr, q_ptr);
+        ItemEntity item_ale({ ItemKindType::FOOD, SV_FOOD_PINT_OF_ALE });
+        item_ale.number = rand_range(2, 4);
+        add_outfit(player_ptr, item_ale);
 
-        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_JERKY }));
-        q_ptr->number = rand_range(1, 3);
-
-        add_outfit(player_ptr, q_ptr);
-
-        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_PINT_OF_ALE }));
-        q_ptr->number = rand_range(2, 4);
-
-        add_outfit(player_ptr, q_ptr);
-
-        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_PINT_OF_WINE }));
-        q_ptr->number = rand_range(2, 4);
-
-        add_outfit(player_ptr, q_ptr);
+        ItemEntity item_wine({ ItemKindType::FOOD, SV_FOOD_PINT_OF_WINE });
+        item_wine.number = rand_range(2, 4);
+        add_outfit(player_ptr, item_wine);
     } else if (pc.equals(PlayerClassType::NINJA)) {
-        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::SPIKE, 0 }));
-        q_ptr->number = rand_range(15, 20);
-        add_outfit(player_ptr, q_ptr);
+        ItemEntity item({ ItemKindType::SPIKE, 0 });
+        item.number = rand_range(15, 20);
+        add_outfit(player_ptr, item);
     } else if (pc.equals(PlayerClassType::SNIPER)) {
-        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::BOLT, SV_AMMO_NORMAL }));
-        q_ptr->number = rand_range(15, 20);
-        add_outfit(player_ptr, q_ptr);
+        ItemEntity item({ ItemKindType::BOLT, SV_AMMO_NORMAL });
+        item.number = rand_range(15, 20);
+        add_outfit(player_ptr, item);
     }
 
     // @todo 本来read-onlyであるべきプリセットテーブルを書き換えている. 良くないパターン.
@@ -252,31 +243,29 @@ void player_outfit(PlayerType *player_ptr)
     }
 
     for (auto i = 0; i < 3; i++) {
-        auto &[tv, sv] = player_init[enum2i(player_ptr->pclass)][i];
-        if (pr.equals(PlayerRaceType::ANDROID) && ((tv == ItemKindType::SOFT_ARMOR) || (tv == ItemKindType::HARD_ARMOR))) {
+        auto &[tval, sval] = player_init[enum2i(player_ptr->pclass)][i];
+        if (pr.equals(PlayerRaceType::ANDROID) && ((tval == ItemKindType::SOFT_ARMOR) || (tval == ItemKindType::HARD_ARMOR))) {
             continue;
         }
 
-        if (tv == ItemKindType::SORCERY_BOOK) {
-            tv = i2enum<ItemKindType>(enum2i(ItemKindType::LIFE_BOOK) + player_ptr->realm1 - 1);
-        } else if (tv == ItemKindType::DEATH_BOOK) {
-            tv = i2enum<ItemKindType>(enum2i(ItemKindType::LIFE_BOOK) + player_ptr->realm2 - 1);
-        } else if (tv == ItemKindType::RING && sv == SV_RING_RES_FEAR && pr.equals(PlayerRaceType::BARBARIAN)) {
-            sv = SV_RING_SUSTAIN_STR;
-        } else if (tv == ItemKindType::RING && sv == SV_RING_SUSTAIN_INT && pr.equals(PlayerRaceType::MIND_FLAYER)) {
-            tv = ItemKindType::POTION;
-            sv = SV_POTION_RESTORE_MANA;
+        if (tval == ItemKindType::SORCERY_BOOK) {
+            tval = i2enum<ItemKindType>(enum2i(ItemKindType::LIFE_BOOK) + player_ptr->realm1 - 1);
+        } else if (tval == ItemKindType::DEATH_BOOK) {
+            tval = i2enum<ItemKindType>(enum2i(ItemKindType::LIFE_BOOK) + player_ptr->realm2 - 1);
+        } else if (tval == ItemKindType::RING && sval == SV_RING_RES_FEAR && pr.equals(PlayerRaceType::BARBARIAN)) {
+            sval = SV_RING_SUSTAIN_STR;
+        } else if (tval == ItemKindType::RING && sval == SV_RING_SUSTAIN_INT && pr.equals(PlayerRaceType::MIND_FLAYER)) {
+            tval = ItemKindType::POTION;
+            sval = SV_POTION_RESTORE_MANA;
         }
-
-        q_ptr = &forge;
-        q_ptr->generate(baseitems.lookup_baseitem_id({ tv, sv }));
 
         /* Only assassins get a poisoned weapon */
-        if (((tv == ItemKindType::SWORD) || (tv == ItemKindType::HAFTED)) && (pc.equals(PlayerClassType::ROGUE) && (player_ptr->realm1 == REALM_DEATH))) {
-            q_ptr->ego_idx = EgoType::BRAND_POIS;
+        ItemEntity item({ tval, sval });
+        if (((tval == ItemKindType::SWORD) || (tval == ItemKindType::HAFTED)) && (pc.equals(PlayerClassType::ROGUE) && (player_ptr->realm1 == REALM_DEATH))) {
+            item.ego_idx = EgoType::BRAND_POIS;
         }
 
-        add_outfit(player_ptr, q_ptr);
+        add_outfit(player_ptr, item);
     }
 
     BaseitemList::get_instance().mark_common_items_as_aware();

--- a/src/birth/inventory-initializer.cpp
+++ b/src/birth/inventory-initializer.cpp
@@ -31,6 +31,7 @@
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "util/enum-converter.h"
+#include "util/enum-range.h"
 #include <tuple>
 
 /*!
@@ -190,8 +191,8 @@ void player_outfit(PlayerType *player_ptr)
         item.pval = (PARAMETER_VALUE)rand_range(25, 30);
         add_outfit(player_ptr, item);
     } else if (pc.equals(PlayerClassType::SORCERER)) {
-        for (auto book_tval = enum2i(ItemKindType::LIFE_BOOK); book_tval <= enum2i(ItemKindType::LIFE_BOOK) + MAX_MAGIC - 1; book_tval++) {
-            ItemEntity item({ i2enum<ItemKindType>(book_tval), 0 });
+        for (const auto tval : TV_MAGIC_BOOK_RANGE) {
+            ItemEntity item({ tval, 0 });
             item.number = 1;
             add_outfit(player_ptr, item);
         }

--- a/src/birth/inventory-initializer.h
+++ b/src/birth/inventory-initializer.h
@@ -1,7 +1,5 @@
 #pragma once
 
-class ItemEntity;
 class PlayerType;
 void wield_all(PlayerType *player_ptr);
-void add_outfit(PlayerType *player_ptr, ItemEntity *o_ptr);
 void player_outfit(PlayerType *player_ptr);

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -302,7 +302,7 @@ void exe_eat_food(PlayerType *player_ptr, INVENTORY_IDX i_idx)
             auto *q_ptr = &forge;
 
             msg_print(_("食べ物がアゴを素通りして落ちた！", "The food falls through your jaws!"));
-            q_ptr->prep(BaseitemList::get_instance().lookup_baseitem_id(bi_key));
+            q_ptr->generate(BaseitemList::get_instance().lookup_baseitem_id(bi_key));
 
             /* Drop the object from heaven */
             (void)drop_near(player_ptr, q_ptr, -1, player_ptr->y, player_ptr->x);

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -42,7 +42,6 @@
 #include "status/experience.h"
 #include "sv-definition/sv-food-types.h"
 #include "sv-definition/sv-other-types.h"
-#include "system/baseitem-info.h"
 #include "system/item-entity.h"
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
@@ -298,14 +297,11 @@ void exe_eat_food(PlayerType *player_ptr, INVENTORY_IDX i_idx)
     if (PlayerRace(player_ptr).equals(PlayerRaceType::SKELETON)) {
         const auto sval = bi_key.sval();
         if ((sval != SV_FOOD_WAYBREAD) && (sval >= SV_FOOD_BISCUIT)) {
-            ItemEntity forge;
-            auto *q_ptr = &forge;
-
+            ItemEntity item(bi_key);
             msg_print(_("食べ物がアゴを素通りして落ちた！", "The food falls through your jaws!"));
-            q_ptr->generate(BaseitemList::get_instance().lookup_baseitem_id(bi_key));
 
             /* Drop the object from heaven */
-            (void)drop_near(player_ptr, q_ptr, -1, player_ptr->y, player_ptr->x);
+            (void)drop_near(player_ptr, &item, -1, player_ptr->y, player_ptr->x);
         } else {
             msg_print(_("食べ物がアゴを素通りして落ち、消えた！", "The food falls through your jaws and vanishes!"));
         }

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -15,7 +15,6 @@
 #include "knowledge/lighting-level-table.h"
 #include "main/sound-of-music.h"
 #include "monster-race/monster-race.h"
-#include "system/baseitem-info.h"
 #include "system/item-entity.h"
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
@@ -158,8 +157,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
                 if (baseitem.flavor == 0) {
                     item_name = baseitem.stripped_name();
                 } else {
-                    ItemEntity dummy;
-                    dummy.generate(baseitem.idx);
+                    ItemEntity dummy(baseitem.idx);
                     item_name = describe_flavor(player_ptr, &dummy, OD_FORCE_FLAVOR);
                 }
 

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -159,7 +159,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
                     item_name = baseitem.stripped_name();
                 } else {
                     ItemEntity dummy;
-                    dummy.prep(baseitem.idx);
+                    dummy.generate(baseitem.idx);
                     item_name = describe_flavor(player_ptr, &dummy, OD_FORCE_FLAVOR);
                 }
 

--- a/src/effect/effect-monster.cpp
+++ b/src/effect/effect-monster.cpp
@@ -689,7 +689,7 @@ static void postprocess_by_taking_photo(PlayerType *player_ptr, EffectMonster *e
     }
 
     ItemEntity item;
-    item.prep(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::STATUE, SV_PHOTO }));
+    item.generate(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::STATUE, SV_PHOTO }));
     item.pval = em_ptr->photo;
     item.ident |= (IDENT_FULL_KNOWN);
     (void)drop_near(player_ptr, &item, -1, player_ptr->y, player_ptr->x);

--- a/src/effect/effect-monster.cpp
+++ b/src/effect/effect-monster.cpp
@@ -42,7 +42,6 @@
 #include "spell-kind/spells-teleport.h"
 #include "sv-definition/sv-other-types.h"
 #include "system/angband-system.h"
-#include "system/baseitem-info.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
@@ -688,8 +687,7 @@ static void postprocess_by_taking_photo(PlayerType *player_ptr, EffectMonster *e
         return;
     }
 
-    ItemEntity item;
-    item.generate(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::STATUE, SV_PHOTO }));
+    ItemEntity item({ ItemKindType::STATUE, SV_PHOTO });
     item.pval = em_ptr->photo;
     item.ident |= (IDENT_FULL_KNOWN);
     (void)drop_near(player_ptr, &item, -1, player_ptr->y, player_ptr->x);

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -26,7 +26,6 @@
 #include "room/rooms-vault.h"
 #include "sv-definition/sv-scroll-types.h"
 #include "system/artifact-type-definition.h"
-#include "system/baseitem-info.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
@@ -84,9 +83,7 @@ static void generate_artifact(PlayerType *player_ptr, qtwg_type *qtwg_ptr, const
         return;
     }
 
-    const auto bi_id = BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::SCROLL, SV_SCROLL_ACQUIREMENT });
-    ItemEntity item;
-    item.generate(bi_id);
+    ItemEntity item({ ItemKindType::SCROLL, SV_SCROLL_ACQUIREMENT });
     drop_here(player_ptr->current_floor_ptr, &item, *qtwg_ptr->y, *qtwg_ptr->x);
 }
 
@@ -176,17 +173,15 @@ static void parse_qtw_D(PlayerType *player_ptr, qtwg_type *qtwg_ptr, char *s)
             g_ptr->mimic = g_ptr->feat;
             g_ptr->feat = conv_dungeon_feat(floor_ptr, letter[idx].trap);
         } else if (object_index) {
-            ItemEntity tmp_object;
-            auto *o_ptr = &tmp_object;
-            o_ptr->generate(object_index);
-            if (o_ptr->bi_key.tval() == ItemKindType::GOLD) {
+            ItemEntity item(object_index);
+            if (item.bi_key.tval() == ItemKindType::GOLD) {
                 coin_type = object_index - OBJ_GOLD_LIST;
-                make_gold(player_ptr, o_ptr);
+                make_gold(player_ptr, &item);
                 coin_type = 0;
             }
 
-            ItemMagicApplier(player_ptr, o_ptr, floor_ptr->base_level, AM_NO_FIXED_ART | AM_GOOD).execute();
-            drop_here(floor_ptr, o_ptr, *qtwg_ptr->y, *qtwg_ptr->x);
+            ItemMagicApplier(player_ptr, &item, floor_ptr->base_level, AM_NO_FIXED_ART | AM_GOOD).execute();
+            drop_here(floor_ptr, &item, *qtwg_ptr->y, *qtwg_ptr->x);
         }
 
         generate_artifact(player_ptr, qtwg_ptr, letter[idx].artifact);

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -86,7 +86,7 @@ static void generate_artifact(PlayerType *player_ptr, qtwg_type *qtwg_ptr, const
 
     const auto bi_id = BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::SCROLL, SV_SCROLL_ACQUIREMENT });
     ItemEntity item;
-    item.prep(bi_id);
+    item.generate(bi_id);
     drop_here(player_ptr->current_floor_ptr, &item, *qtwg_ptr->y, *qtwg_ptr->x);
 }
 
@@ -178,7 +178,7 @@ static void parse_qtw_D(PlayerType *player_ptr, qtwg_type *qtwg_ptr, char *s)
         } else if (object_index) {
             ItemEntity tmp_object;
             auto *o_ptr = &tmp_object;
-            o_ptr->prep(object_index);
+            o_ptr->generate(object_index);
             if (o_ptr->bi_key.tval() == ItemKindType::GOLD) {
                 coin_type = object_index - OBJ_GOLD_LIST;
                 make_gold(player_ptr, o_ptr);

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -29,7 +29,6 @@
 #include "perception/object-perception.h"
 #include "system/alloc-entries.h"
 #include "system/artifact-type-definition.h"
-#include "system/baseitem-info.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -140,7 +140,7 @@ bool make_object(PlayerType *player_ptr, ItemEntity *j_ptr, BIT_FLAGS mode, std:
             return false;
         }
 
-        j_ptr->prep(bi_id);
+        j_ptr->generate(bi_id);
     }
 
     ItemMagicApplier(player_ptr, j_ptr, floor_ptr->object_level, mode).execute();
@@ -174,7 +174,7 @@ bool make_gold(PlayerType *player_ptr, ItemEntity *j_ptr)
         i = MAX_GOLD - 1;
     }
 
-    j_ptr->prep(OBJ_GOLD_LIST + i);
+    j_ptr->generate(OBJ_GOLD_LIST + i);
     const auto &baseitems = BaseitemList::get_instance();
     const auto base = baseitems.get_baseitem(OBJ_GOLD_LIST + i).cost;
     j_ptr->pval = (base + (8L * randint1(base)) + randint1(8));

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -96,7 +96,7 @@ void do_cmd_knowledge_artifacts(PlayerType *player_ptr)
         const auto bi_id = baseitems.lookup_baseitem_id(artifact.bi_key);
         constexpr auto template_basename = _("     %s\n", "     The %s\n");
         ItemEntity item;
-        item.prep(bi_id);
+        item.generate(bi_id);
         item.fixed_artifact_idx = a_idx;
         item.ident |= IDENT_STORE;
         const auto item_name = describe_flavor(player_ptr, &item, (OD_OMIT_PREFIX | OD_NAME_ONLY));
@@ -214,7 +214,7 @@ static void desc_obj_fake(PlayerType *player_ptr, short bi_id)
     ItemEntity ObjectType_body;
     o_ptr = &ObjectType_body;
     o_ptr->wipe();
-    o_ptr->prep(bi_id);
+    o_ptr->generate(bi_id);
 
     o_ptr->ident |= IDENT_KNOWN;
     handle_stuff(player_ptr);

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -19,7 +19,6 @@
 #include "perception/identification.h"
 #include "perception/object-perception.h"
 #include "system/artifact-type-definition.h"
-#include "system/baseitem-info.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
@@ -95,8 +94,7 @@ void do_cmd_knowledge_artifacts(PlayerType *player_ptr)
         const auto &artifact = ArtifactsInfo::get_instance().get_artifact(a_idx);
         const auto bi_id = baseitems.lookup_baseitem_id(artifact.bi_key);
         constexpr auto template_basename = _("     %s\n", "     The %s\n");
-        ItemEntity item;
-        item.generate(bi_id);
+        ItemEntity item(bi_id);
         item.fixed_artifact_idx = a_idx;
         item.ident |= IDENT_STORE;
         const auto item_name = describe_flavor(player_ptr, &item, (OD_OMIT_PREFIX | OD_NAME_ONLY));
@@ -210,16 +208,10 @@ static void display_object_list(int col, int row, int per_page, const std::vecto
  */
 static void desc_obj_fake(PlayerType *player_ptr, short bi_id)
 {
-    ItemEntity *o_ptr;
-    ItemEntity ObjectType_body;
-    o_ptr = &ObjectType_body;
-    o_ptr->wipe();
-    o_ptr->generate(bi_id);
-
-    o_ptr->ident |= IDENT_KNOWN;
+    ItemEntity item(bi_id);
+    item.ident |= IDENT_KNOWN;
     handle_stuff(player_ptr);
-
-    if (screen_object(player_ptr, o_ptr, SCROBJ_FAKE_OBJECT | SCROBJ_FORCE_DETAIL)) {
+    if (screen_object(player_ptr, &item, SCROBJ_FAKE_OBJECT | SCROBJ_FORCE_DETAIL)) {
         return;
     }
 

--- a/src/knowledge/knowledge-quests.cpp
+++ b/src/knowledge/knowledge-quests.cpp
@@ -107,7 +107,7 @@ static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
                         const auto &artifact = quest.get_reward();
                         ItemEntity item;
                         const auto bi_id = baseitems.lookup_baseitem_id(artifact.bi_key);
-                        item.prep(bi_id);
+                        item.generate(bi_id);
                         item.fixed_artifact_idx = quest.reward_artifact_idx;
                         item.ident = IDENT_STORE;
                         item_name = describe_flavor(player_ptr, &item, OD_NAME_ONLY);

--- a/src/knowledge/knowledge-quests.cpp
+++ b/src/knowledge/knowledge-quests.cpp
@@ -16,7 +16,6 @@
 #include "monster-race/monster-race.h"
 #include "object-enchant/special-object-flags.h"
 #include "system/artifact-type-definition.h"
-#include "system/baseitem-info.h"
 #include "system/dungeon-info.h"
 #include "system/floor-type-definition.h"
 #include "system/item-entity.h"
@@ -50,7 +49,6 @@ void do_cmd_checkquest(PlayerType *player_ptr)
 static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
 {
     const auto &quest_list = QuestList::get_instance();
-    const auto &baseitems = BaseitemList::get_instance();
     std::string rand_tmp_str;
     int rand_level = 100;
     int total = 0;
@@ -105,9 +103,7 @@ static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
                     std::string item_name("");
                     if (quest.has_reward()) {
                         const auto &artifact = quest.get_reward();
-                        ItemEntity item;
-                        const auto bi_id = baseitems.lookup_baseitem_id(artifact.bi_key);
-                        item.generate(bi_id);
+                        ItemEntity item(artifact.bi_key);
                         item.fixed_artifact_idx = quest.reward_artifact_idx;
                         item.ident = IDENT_STORE;
                         item_name = describe_flavor(player_ptr, &item, OD_NAME_ONLY);

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -22,7 +22,6 @@
 #include "object/object-info.h"
 #include "perception/object-perception.h"
 #include "sv-definition/sv-other-types.h"
-#include "system/baseitem-info.h"
 #include "system/dungeon-info.h"
 #include "system/floor-type-definition.h"
 #include "system/item-entity.h"
@@ -170,11 +169,8 @@ bool exchange_cash(PlayerType *player_ptr)
 
             msg_print(_(format("これで合計 %d ポイント獲得しました。", num), format("You earned %d point%s total.", num, (num > 1 ? "s" : ""))));
 
-            const auto bi_id = BaseitemList::get_instance().lookup_baseitem_id(prize_list[num - 1]);
-            ItemEntity item;
-            item.generate(bi_id);
+            ItemEntity item(prize_list[num - 1]);
             ItemMagicApplier(player_ptr, &item, player_ptr->current_floor_ptr->object_level, AM_NO_FIXED_ART).execute();
-
             object_aware(player_ptr, &item);
             item.mark_as_known();
 

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -172,7 +172,7 @@ bool exchange_cash(PlayerType *player_ptr)
 
             const auto bi_id = BaseitemList::get_instance().lookup_baseitem_id(prize_list[num - 1]);
             ItemEntity item;
-            item.prep(bi_id);
+            item.generate(bi_id);
             ItemMagicApplier(player_ptr, &item, player_ptr->current_floor_ptr->object_level, AM_NO_FIXED_ART).execute();
 
             object_aware(player_ptr, &item);

--- a/src/mind/mind-archer.cpp
+++ b/src/mind/mind-archer.cpp
@@ -125,7 +125,7 @@ bool create_ammo(PlayerType *player_ptr)
 
         ItemEntity forge;
         auto *q_ptr = &forge;
-        q_ptr->prep(baseitems.lookup_baseitem_id({ ItemKindType::SHOT, m_bonus(1, player_ptr->lev) + 1 }));
+        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::SHOT, m_bonus(1, player_ptr->lev) + 1 }));
         q_ptr->number = (byte)rand_range(15, 30);
         object_aware(player_ptr, q_ptr);
         q_ptr->mark_as_known();
@@ -153,7 +153,7 @@ bool create_ammo(PlayerType *player_ptr)
 
         ItemEntity forge;
         q_ptr = &forge;
-        q_ptr->prep(baseitems.lookup_baseitem_id({ ItemKindType::ARROW, m_bonus(1, player_ptr->lev) + 1 }));
+        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::ARROW, m_bonus(1, player_ptr->lev) + 1 }));
         q_ptr->number = (byte)rand_range(5, 10);
         object_aware(player_ptr, q_ptr);
         q_ptr->mark_as_known();
@@ -180,7 +180,7 @@ bool create_ammo(PlayerType *player_ptr)
 
         ItemEntity forge;
         q_ptr = &forge;
-        q_ptr->prep(baseitems.lookup_baseitem_id({ ItemKindType::BOLT, m_bonus(1, player_ptr->lev) + 1 }));
+        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::BOLT, m_bonus(1, player_ptr->lev) + 1 }));
         q_ptr->number = (byte)rand_range(4, 8);
         object_aware(player_ptr, q_ptr);
         q_ptr->mark_as_known();

--- a/src/mind/mind-archer.cpp
+++ b/src/mind/mind-archer.cpp
@@ -16,7 +16,6 @@
 #include "object/item-use-flags.h"
 #include "perception/object-perception.h"
 #include "system/angband.h"
-#include "system/baseitem-info.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
@@ -103,7 +102,6 @@ bool create_ammo(PlayerType *player_ptr)
         return false;
     }
 
-    const auto &baseitems = BaseitemList::get_instance();
     switch (ext) {
     case AMMO_SHOT: {
         int dir;
@@ -123,16 +121,14 @@ bool create_ammo(PlayerType *player_ptr)
             return true;
         }
 
-        ItemEntity forge;
-        auto *q_ptr = &forge;
-        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::SHOT, m_bonus(1, player_ptr->lev) + 1 }));
-        q_ptr->number = (byte)rand_range(15, 30);
-        object_aware(player_ptr, q_ptr);
-        q_ptr->mark_as_known();
-        ItemMagicApplier(player_ptr, q_ptr, player_ptr->lev, AM_NO_FIXED_ART).execute();
-        q_ptr->discount = 99;
-        int16_t slot = store_item_to_inventory(player_ptr, q_ptr);
-        const auto item_name = describe_flavor(player_ptr, q_ptr, 0);
+        ItemEntity item({ ItemKindType::SHOT, m_bonus(1, player_ptr->lev) + 1 });
+        item.number = (byte)rand_range(15, 30);
+        object_aware(player_ptr, &item);
+        item.mark_as_known();
+        ItemMagicApplier(player_ptr, &item, player_ptr->lev, AM_NO_FIXED_ART).execute();
+        item.discount = 99;
+        int16_t slot = store_item_to_inventory(player_ptr, &item);
+        const auto item_name = describe_flavor(player_ptr, &item, 0);
         msg_print(_(format("%sを作った。", item_name.data()), "You make some ammo."));
         if (slot >= 0) {
             autopick_alter_item(player_ptr, slot, false);
@@ -146,23 +142,21 @@ bool create_ammo(PlayerType *player_ptr)
         constexpr auto q = _("どのアイテムから作りますか？ ", "Convert which item? ");
         constexpr auto s = _("材料を持っていない。", "You have no item to convert.");
         short i_idx;
-        auto *q_ptr = choose_object(player_ptr, &i_idx, q, s, USE_INVEN | USE_FLOOR, FuncItemTester(&ItemEntity::is_convertible));
-        if (!q_ptr) {
+        auto *item_ptr = choose_object(player_ptr, &i_idx, q, s, USE_INVEN | USE_FLOOR, FuncItemTester(&ItemEntity::is_convertible));
+        if (item_ptr == nullptr) {
             return false;
         }
 
-        ItemEntity forge;
-        q_ptr = &forge;
-        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::ARROW, m_bonus(1, player_ptr->lev) + 1 }));
-        q_ptr->number = (byte)rand_range(5, 10);
-        object_aware(player_ptr, q_ptr);
-        q_ptr->mark_as_known();
-        ItemMagicApplier(player_ptr, q_ptr, player_ptr->lev, AM_NO_FIXED_ART).execute();
-        q_ptr->discount = 99;
-        const auto item_name = describe_flavor(player_ptr, q_ptr, 0);
+        item_ptr->generate({ ItemKindType::ARROW, m_bonus(1, player_ptr->lev) + 1 });
+        item_ptr->number = (byte)rand_range(5, 10);
+        object_aware(player_ptr, item_ptr);
+        item_ptr->mark_as_known();
+        ItemMagicApplier(player_ptr, item_ptr, player_ptr->lev, AM_NO_FIXED_ART).execute();
+        item_ptr->discount = 99;
+        const auto item_name = describe_flavor(player_ptr, item_ptr, 0);
         msg_print(_(format("%sを作った。", item_name.data()), "You make some ammo."));
         vary_item(player_ptr, i_idx, -1);
-        int16_t slot = store_item_to_inventory(player_ptr, q_ptr);
+        int16_t slot = store_item_to_inventory(player_ptr, item_ptr);
         if (slot >= 0) {
             autopick_alter_item(player_ptr, slot, false);
         }
@@ -173,23 +167,21 @@ bool create_ammo(PlayerType *player_ptr)
         constexpr auto q = _("どのアイテムから作りますか？ ", "Convert which item? ");
         constexpr auto s = _("材料を持っていない。", "You have no item to convert.");
         short i_idx;
-        auto *q_ptr = choose_object(player_ptr, &i_idx, q, s, (USE_INVEN | USE_FLOOR), FuncItemTester(&ItemEntity::is_convertible));
-        if (!q_ptr) {
+        auto *item_ptr = choose_object(player_ptr, &i_idx, q, s, (USE_INVEN | USE_FLOOR), FuncItemTester(&ItemEntity::is_convertible));
+        if (!item_ptr) {
             return false;
         }
 
-        ItemEntity forge;
-        q_ptr = &forge;
-        q_ptr->generate(baseitems.lookup_baseitem_id({ ItemKindType::BOLT, m_bonus(1, player_ptr->lev) + 1 }));
-        q_ptr->number = (byte)rand_range(4, 8);
-        object_aware(player_ptr, q_ptr);
-        q_ptr->mark_as_known();
-        ItemMagicApplier(player_ptr, q_ptr, player_ptr->lev, AM_NO_FIXED_ART).execute();
-        q_ptr->discount = 99;
-        const auto item_name = describe_flavor(player_ptr, q_ptr, 0);
+        item_ptr->generate({ ItemKindType::BOLT, m_bonus(1, player_ptr->lev) + 1 });
+        item_ptr->number = (byte)rand_range(4, 8);
+        object_aware(player_ptr, item_ptr);
+        item_ptr->mark_as_known();
+        ItemMagicApplier(player_ptr, item_ptr, player_ptr->lev, AM_NO_FIXED_ART).execute();
+        item_ptr->discount = 99;
+        const auto item_name = describe_flavor(player_ptr, item_ptr, 0);
         msg_print(_(format("%sを作った。", item_name.data()), "You make some ammo."));
         vary_item(player_ptr, i_idx, -1);
-        int16_t slot = store_item_to_inventory(player_ptr, q_ptr);
+        int16_t slot = store_item_to_inventory(player_ptr, item_ptr);
         if (slot >= 0) {
             autopick_alter_item(player_ptr, slot, false);
         }

--- a/src/mind/mind-chaos-warrior.cpp
+++ b/src/mind/mind-chaos-warrior.cpp
@@ -70,7 +70,7 @@ void acquire_chaos_weapon(PlayerType *player_ptr)
     ItemEntity forge;
     auto *q_ptr = &forge;
 
-    q_ptr->prep(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::SWORD, sval }));
+    q_ptr->generate(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::SWORD, sval }));
     q_ptr->to_h = 3 + randint1(player_ptr->current_floor_ptr->dun_level) % 10;
     q_ptr->to_d = 3 + randint1(player_ptr->current_floor_ptr->dun_level) % 10;
     one_resistance(q_ptr);

--- a/src/mind/mind-chaos-warrior.cpp
+++ b/src/mind/mind-chaos-warrior.cpp
@@ -3,7 +3,6 @@
 #include "object-enchant/object-boost.h"
 #include "object-enchant/object-ego.h"
 #include "sv-definition/sv-weapon-types.h"
-#include "system/baseitem-info.h"
 #include "system/floor-type-definition.h"
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
@@ -67,13 +66,10 @@ void acquire_chaos_weapon(PlayerType *player_ptr)
     std::span<const sv_sword_type> candidates(weapons.begin(), player_ptr->lev);
     const auto sval = rand_choice(candidates);
 
-    ItemEntity forge;
-    auto *q_ptr = &forge;
-
-    q_ptr->generate(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::SWORD, sval }));
-    q_ptr->to_h = 3 + randint1(player_ptr->current_floor_ptr->dun_level) % 10;
-    q_ptr->to_d = 3 + randint1(player_ptr->current_floor_ptr->dun_level) % 10;
-    one_resistance(q_ptr);
-    q_ptr->ego_idx = EgoType::CHAOTIC;
-    (void)drop_near(player_ptr, q_ptr, -1, player_ptr->y, player_ptr->x);
+    ItemEntity item({ ItemKindType::SWORD, sval });
+    item.to_h = 3 + randint1(player_ptr->current_floor_ptr->dun_level) % 10;
+    item.to_d = 3 + randint1(player_ptr->current_floor_ptr->dun_level) % 10;
+    one_resistance(&item);
+    item.ego_idx = EgoType::CHAOTIC;
+    (void)drop_near(player_ptr, &item, -1, player_ptr->y, player_ptr->x);
 }

--- a/src/mind/mind-hobbit.cpp
+++ b/src/mind/mind-hobbit.cpp
@@ -9,7 +9,7 @@
 bool create_ration(PlayerType *player_ptr)
 {
     ItemEntity item;
-    item.prep(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_RATION }));
+    item.generate(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_RATION }));
     (void)drop_near(player_ptr, &item, -1, player_ptr->y, player_ptr->x);
     msg_print(_("食事を料理して作った。", "You cook some food."));
     return true;

--- a/src/mind/mind-hobbit.cpp
+++ b/src/mind/mind-hobbit.cpp
@@ -1,15 +1,13 @@
 #include "mind/mind-hobbit.h"
 #include "floor/floor-object.h"
 #include "sv-definition/sv-food-types.h"
-#include "system/baseitem-info.h"
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "view/display-messages.h"
 
 bool create_ration(PlayerType *player_ptr)
 {
-    ItemEntity item;
-    item.generate(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_RATION }));
+    ItemEntity item({ ItemKindType::FOOD, SV_FOOD_RATION });
     (void)drop_near(player_ptr, &item, -1, player_ptr->y, player_ptr->x);
     msg_print(_("食事を料理して作った。", "You cook some food."));
     return true;

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -112,7 +112,7 @@ bool kawarimi(PlayerType *player_ptr, bool success)
     teleport_player(player_ptr, 10 + randint1(90), TELEPORT_SPONTANEOUS);
     q_ptr->wipe();
     const int sv_wooden_statue = 0;
-    q_ptr->prep(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::STATUE, sv_wooden_statue }));
+    q_ptr->generate(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::STATUE, sv_wooden_statue }));
 
     q_ptr->pval = enum2i(MonsterRaceId::NINJA);
     (void)drop_near(player_ptr, q_ptr, -1, y, x);

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -45,7 +45,6 @@
 #include "status/body-improvement.h"
 #include "status/element-resistance.h"
 #include "status/temporary-resistance.h"
-#include "system/baseitem-info.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
@@ -79,8 +78,6 @@ bool kawarimi(PlayerType *player_ptr, bool success)
         return false;
     }
 
-    ItemEntity forge;
-    auto *q_ptr = &forge;
     if (player_ptr->is_dead) {
         return false;
     }
@@ -110,12 +107,10 @@ bool kawarimi(PlayerType *player_ptr, bool success)
     POSITION x = player_ptr->x;
 
     teleport_player(player_ptr, 10 + randint1(90), TELEPORT_SPONTANEOUS);
-    q_ptr->wipe();
-    const int sv_wooden_statue = 0;
-    q_ptr->generate(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::STATUE, sv_wooden_statue }));
-
-    q_ptr->pval = enum2i(MonsterRaceId::NINJA);
-    (void)drop_near(player_ptr, q_ptr, -1, y, x);
+    constexpr int sv_wooden_statue = 0;
+    ItemEntity item({ ItemKindType::STATUE, sv_wooden_statue });
+    item.pval = enum2i(MonsterRaceId::NINJA);
+    (void)drop_near(player_ptr, &item, -1, y, x);
 
     if (success) {
         msg_print(_("攻撃を受ける前に素早く身をひるがえした。", "You have turned around just before the attack hit you."));

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -94,7 +94,7 @@ static void on_defeat_arena_monster(PlayerType *player_ptr, MonsterDeath *md_ptr
     const auto tval = arena.key.tval();
     if (tval > ItemKindType::NONE) {
         ItemEntity item;
-        item.prep(BaseitemList::get_instance().lookup_baseitem_id(arena.key));
+        item.generate(BaseitemList::get_instance().lookup_baseitem_id(arena.key));
         ItemMagicApplier(player_ptr, &item, floor_ptr->object_level, AM_NO_FIXED_ART).execute();
         (void)drop_near(player_ptr, &item, -1, md_ptr->md_y, md_ptr->md_x);
     }
@@ -140,7 +140,7 @@ static void drop_corpse(PlayerType *player_ptr, MonsterDeath *md_ptr)
     }
 
     ItemEntity item;
-    item.prep(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::CORPSE, (corpse ? SV_CORPSE : SV_SKELETON) }));
+    item.generate(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::CORPSE, (corpse ? SV_CORPSE : SV_SKELETON) }));
     ItemMagicApplier(player_ptr, &item, floor_ptr->object_level, AM_NO_FIXED_ART).execute();
     item.pval = enum2i(md_ptr->m_ptr->r_idx);
     (void)drop_near(player_ptr, &item, -1, md_ptr->md_y, md_ptr->md_x);
@@ -219,7 +219,7 @@ static void drop_artifacts(PlayerType *player_ptr, MonsterDeath *md_ptr)
     if (bi_id != 0) {
         ItemEntity forge;
         auto *q_ptr = &forge;
-        q_ptr->prep(bi_id);
+        q_ptr->generate(bi_id);
         ItemMagicApplier(player_ptr, q_ptr, floor_ptr->object_level, AM_NO_FIXED_ART | AM_GOOD).execute();
         (void)drop_near(player_ptr, q_ptr, -1, md_ptr->md_y, md_ptr->md_x);
     }

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -180,7 +180,7 @@ bool drop_single_artifact(PlayerType *player_ptr, MonsterDeath *md_ptr, FixedArt
     return create_named_art(player_ptr, a_idx, md_ptr->md_y, md_ptr->md_x);
 }
 
-static short drop_dungeon_final_artifact(PlayerType *player_ptr, MonsterDeath *md_ptr)
+static std::optional<short> drop_dungeon_final_artifact(PlayerType *player_ptr, MonsterDeath *md_ptr)
 {
     const auto &dungeon = player_ptr->current_floor_ptr->get_dungeon_definition();
     const auto has_reward = dungeon.final_object > 0;
@@ -196,8 +196,7 @@ static short drop_dungeon_final_artifact(PlayerType *player_ptr, MonsterDeath *m
     }
 
     create_named_art(player_ptr, a_idx, md_ptr->md_y, md_ptr->md_x);
-
-    return dungeon.final_object ? bi_id : 0;
+    return dungeon.final_object ? std::make_optional<short>(bi_id) : std::nullopt;
 }
 
 static void drop_artifacts(PlayerType *player_ptr, MonsterDeath *md_ptr)
@@ -214,13 +213,12 @@ static void drop_artifacts(PlayerType *player_ptr, MonsterDeath *md_ptr)
     }
 
     const auto bi_id = drop_dungeon_final_artifact(player_ptr, md_ptr);
-    if (bi_id == 0) {
-        return;
+    if (bi_id) {
+        ItemEntity item(*bi_id);
+        ItemMagicApplier(player_ptr, &item, floor_ptr->object_level, AM_NO_FIXED_ART | AM_GOOD).execute();
+        (void)drop_near(player_ptr, &item, -1, md_ptr->md_y, md_ptr->md_x);
     }
 
-    ItemEntity item(bi_id);
-    ItemMagicApplier(player_ptr, &item, floor_ptr->object_level, AM_NO_FIXED_ART | AM_GOOD).execute();
-    (void)drop_near(player_ptr, &item, -1, md_ptr->md_y, md_ptr->md_x);
     msg_format(_("あなたは%sを制覇した！", "You have conquered %s!"), dungeon.name.data());
 }
 

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -93,8 +93,7 @@ static void on_defeat_arena_monster(PlayerType *player_ptr, MonsterDeath *md_ptr
     const auto &arena = arena_info[player_ptr->arena_number];
     const auto tval = arena.key.tval();
     if (tval > ItemKindType::NONE) {
-        ItemEntity item;
-        item.generate(BaseitemList::get_instance().lookup_baseitem_id(arena.key));
+        ItemEntity item(arena.key);
         ItemMagicApplier(player_ptr, &item, floor_ptr->object_level, AM_NO_FIXED_ART).execute();
         (void)drop_near(player_ptr, &item, -1, md_ptr->md_y, md_ptr->md_x);
     }
@@ -139,8 +138,7 @@ static void drop_corpse(PlayerType *player_ptr, MonsterDeath *md_ptr)
         }
     }
 
-    ItemEntity item;
-    item.generate(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::CORPSE, (corpse ? SV_CORPSE : SV_SKELETON) }));
+    ItemEntity item({ ItemKindType::CORPSE, (corpse ? SV_CORPSE : SV_SKELETON) });
     ItemMagicApplier(player_ptr, &item, floor_ptr->object_level, AM_NO_FIXED_ART).execute();
     item.pval = enum2i(md_ptr->m_ptr->r_idx);
     (void)drop_near(player_ptr, &item, -1, md_ptr->md_y, md_ptr->md_x);
@@ -215,15 +213,14 @@ static void drop_artifacts(PlayerType *player_ptr, MonsterDeath *md_ptr)
         return;
     }
 
-    short bi_id = drop_dungeon_final_artifact(player_ptr, md_ptr);
-    if (bi_id != 0) {
-        ItemEntity forge;
-        auto *q_ptr = &forge;
-        q_ptr->generate(bi_id);
-        ItemMagicApplier(player_ptr, q_ptr, floor_ptr->object_level, AM_NO_FIXED_ART | AM_GOOD).execute();
-        (void)drop_near(player_ptr, q_ptr, -1, md_ptr->md_y, md_ptr->md_x);
+    const auto bi_id = drop_dungeon_final_artifact(player_ptr, md_ptr);
+    if (bi_id == 0) {
+        return;
     }
 
+    ItemEntity item(bi_id);
+    ItemMagicApplier(player_ptr, &item, floor_ptr->object_level, AM_NO_FIXED_ART | AM_GOOD).execute();
+    (void)drop_near(player_ptr, &item, -1, md_ptr->md_y, md_ptr->md_x);
     msg_format(_("あなたは%sを制覇した！", "You have conquered %s!"), dungeon.name.data());
 }
 

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -37,7 +37,6 @@
 #include "sv-definition/sv-weapon-types.h"
 #include "system/angband-system.h"
 #include "system/artifact-type-definition.h"
-#include "system/baseitem-info.h"
 #include "system/floor-type-definition.h"
 #include "system/item-entity.h"
 #include "system/monster-entity.h"
@@ -126,8 +125,7 @@ static void on_dead_bloodletter(PlayerType *player_ptr, MonsterDeath *md_ptr)
         return;
     }
 
-    ItemEntity item;
-    item.generate(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::SWORD, SV_BLADE_OF_CHAOS }));
+    ItemEntity item({ ItemKindType::SWORD, SV_BLADE_OF_CHAOS });
     ItemMagicApplier(player_ptr, &item, player_ptr->current_floor_ptr->object_level, AM_NO_FIXED_ART | md_ptr->mo_mode).execute();
     (void)drop_near(player_ptr, &item, -1, md_ptr->md_y, md_ptr->md_x);
 }
@@ -195,15 +193,12 @@ static void on_dead_serpent(PlayerType *player_ptr, MonsterDeath *md_ptr)
         return;
     }
 
-    const auto &baseitems = BaseitemList::get_instance();
-    ItemEntity item_grond;
-    item_grond.generate(baseitems.lookup_baseitem_id({ ItemKindType::HAFTED, SV_GROND }));
+    ItemEntity item_grond({ ItemKindType::HAFTED, SV_GROND });
     item_grond.fixed_artifact_idx = FixedArtifactId::GROND;
     ItemMagicApplier(player_ptr, &item_grond, -1, AM_GOOD | AM_GREAT).execute();
     (void)drop_near(player_ptr, &item_grond, -1, md_ptr->md_y, md_ptr->md_x);
 
-    ItemEntity item_chaos;
-    item_chaos.generate(baseitems.lookup_baseitem_id({ ItemKindType::CROWN, SV_CHAOS }));
+    ItemEntity item_chaos({ ItemKindType::CROWN, SV_CHAOS });
     item_chaos.fixed_artifact_idx = FixedArtifactId::CHAOS;
     ItemMagicApplier(player_ptr, &item_chaos, -1, AM_GOOD | AM_GREAT).execute();
     (void)drop_near(player_ptr, &item_chaos, -1, md_ptr->md_y, md_ptr->md_x);
@@ -215,8 +210,7 @@ static void on_dead_death_sword(PlayerType *player_ptr, MonsterDeath *md_ptr)
         return;
     }
 
-    ItemEntity item;
-    item.generate(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::SWORD, randint1(2) }));
+    ItemEntity item({ ItemKindType::SWORD, randint1(2) });
     (void)drop_near(player_ptr, &item, -1, md_ptr->md_y, md_ptr->md_x);
 }
 
@@ -230,8 +224,7 @@ static void on_dead_can_angel(PlayerType *player_ptr, MonsterDeath *md_ptr)
         return;
     }
 
-    ItemEntity item;
-    item.generate(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::CHEST, SV_CHEST_KANDUME }));
+    ItemEntity item({ ItemKindType::CHEST, SV_CHEST_KANDUME });
     ItemMagicApplier(player_ptr, &item, player_ptr->current_floor_ptr->object_level, AM_NO_FIXED_ART).execute();
     (void)drop_near(player_ptr, &item, -1, md_ptr->md_y, md_ptr->md_x);
 }

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -127,7 +127,7 @@ static void on_dead_bloodletter(PlayerType *player_ptr, MonsterDeath *md_ptr)
     }
 
     ItemEntity item;
-    item.prep(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::SWORD, SV_BLADE_OF_CHAOS }));
+    item.generate(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::SWORD, SV_BLADE_OF_CHAOS }));
     ItemMagicApplier(player_ptr, &item, player_ptr->current_floor_ptr->object_level, AM_NO_FIXED_ART | md_ptr->mo_mode).execute();
     (void)drop_near(player_ptr, &item, -1, md_ptr->md_y, md_ptr->md_x);
 }
@@ -197,13 +197,13 @@ static void on_dead_serpent(PlayerType *player_ptr, MonsterDeath *md_ptr)
 
     const auto &baseitems = BaseitemList::get_instance();
     ItemEntity item_grond;
-    item_grond.prep(baseitems.lookup_baseitem_id({ ItemKindType::HAFTED, SV_GROND }));
+    item_grond.generate(baseitems.lookup_baseitem_id({ ItemKindType::HAFTED, SV_GROND }));
     item_grond.fixed_artifact_idx = FixedArtifactId::GROND;
     ItemMagicApplier(player_ptr, &item_grond, -1, AM_GOOD | AM_GREAT).execute();
     (void)drop_near(player_ptr, &item_grond, -1, md_ptr->md_y, md_ptr->md_x);
 
     ItemEntity item_chaos;
-    item_chaos.prep(baseitems.lookup_baseitem_id({ ItemKindType::CROWN, SV_CHAOS }));
+    item_chaos.generate(baseitems.lookup_baseitem_id({ ItemKindType::CROWN, SV_CHAOS }));
     item_chaos.fixed_artifact_idx = FixedArtifactId::CHAOS;
     ItemMagicApplier(player_ptr, &item_chaos, -1, AM_GOOD | AM_GREAT).execute();
     (void)drop_near(player_ptr, &item_chaos, -1, md_ptr->md_y, md_ptr->md_x);
@@ -216,7 +216,7 @@ static void on_dead_death_sword(PlayerType *player_ptr, MonsterDeath *md_ptr)
     }
 
     ItemEntity item;
-    item.prep(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::SWORD, randint1(2) }));
+    item.generate(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::SWORD, randint1(2) }));
     (void)drop_near(player_ptr, &item, -1, md_ptr->md_y, md_ptr->md_x);
 }
 
@@ -231,7 +231,7 @@ static void on_dead_can_angel(PlayerType *player_ptr, MonsterDeath *md_ptr)
     }
 
     ItemEntity item;
-    item.prep(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::CHEST, SV_CHEST_KANDUME }));
+    item.generate(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::CHEST, SV_CHEST_KANDUME }));
     ItemMagicApplier(player_ptr, &item, player_ptr->current_floor_ptr->object_level, AM_NO_FIXED_ART).execute();
     (void)drop_near(player_ptr, &item, -1, md_ptr->md_y, md_ptr->md_x);
 }

--- a/src/object/tval-types.h
+++ b/src/object/tval-types.h
@@ -76,3 +76,4 @@ enum class ItemKindType : short {
 
 constexpr auto TV_WEARABLE_RANGE = EnumRange(ItemKindType::BOW, ItemKindType::CARD);
 constexpr auto TV_WEAPON_RANGE = EnumRange(ItemKindType::BOW, ItemKindType::SWORD);
+constexpr auto TV_MAGIC_BOOK_RANGE = EnumRange(ItemKindType::LIFE_BOOK, ItemKindType::CRUSADE_BOOK);

--- a/src/realm/realm-nature.cpp
+++ b/src/realm/realm-nature.cpp
@@ -144,7 +144,7 @@ std::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spe
             if (cast) {
                 ItemEntity item;
                 msg_print(_("食料を生成した。", "A food ration is produced."));
-                item.prep(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_RATION }));
+                item.generate(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_RATION }));
                 (void)drop_near(player_ptr, &item, -1, player_ptr->y, player_ptr->x);
             }
         }

--- a/src/realm/realm-nature.cpp
+++ b/src/realm/realm-nature.cpp
@@ -35,7 +35,6 @@
 #include "status/buff-setter.h"
 #include "status/element-resistance.h"
 #include "sv-definition/sv-food-types.h"
-#include "system/baseitem-info.h"
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "target/target-getter.h"
@@ -142,9 +141,8 @@ std::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spe
 
         {
             if (cast) {
-                ItemEntity item;
                 msg_print(_("食料を生成した。", "A food ration is produced."));
-                item.generate(BaseitemList::get_instance().lookup_baseitem_id({ ItemKindType::FOOD, SV_FOOD_RATION }));
+                ItemEntity item({ ItemKindType::FOOD, SV_FOOD_RATION });
                 (void)drop_near(player_ptr, &item, -1, player_ptr->y, player_ptr->x);
             }
         }

--- a/src/smith/object-smith.cpp
+++ b/src/smith/object-smith.cpp
@@ -346,7 +346,7 @@ Smith::DrainEssenceResult Smith::drain_essence(ItemEntity *o_ptr)
 
     // アイテムをエッセンス抽出後の状態にする
     const ItemEntity old_o = *o_ptr;
-    o_ptr->prep(o_ptr->bi_id);
+    o_ptr->generate(o_ptr->bi_id);
     o_ptr->iy = old_o.iy;
     o_ptr->ix = old_o.ix;
     o_ptr->marked = old_o.marked;

--- a/src/spell-kind/spells-enchant.cpp
+++ b/src/spell-kind/spells-enchant.cpp
@@ -139,7 +139,7 @@ bool mundane_spell(PlayerType *player_ptr, bool only_equip)
     auto marked = o_ptr->marked;
     auto inscription = std::move(o_ptr->inscription);
 
-    o_ptr->prep(o_ptr->bi_id);
+    o_ptr->generate(o_ptr->bi_id);
 
     o_ptr->iy = iy;
     o_ptr->ix = ix;

--- a/src/spell-kind/spells-enchant.cpp
+++ b/src/spell-kind/spells-enchant.cpp
@@ -128,24 +128,21 @@ bool mundane_spell(PlayerType *player_ptr, bool only_equip)
     constexpr auto q = _("どのアイテムを凡庸化しますか？", "Mundanify which item? ");
     constexpr auto s = _("凡庸化できるアイテムがない。", "You have nothing to mundanify.");
     short i_idx;
-    auto *o_ptr = choose_object(player_ptr, &i_idx, q, s, (USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT), *item_tester);
-    if (!o_ptr) {
+    auto *item_ptr = choose_object(player_ptr, &i_idx, q, s, (USE_EQUIP | USE_INVEN | USE_FLOOR | IGNORE_BOTHHAND_SLOT), *item_tester);
+    if (item_ptr == nullptr) {
         return false;
     }
 
     msg_print(_("まばゆい閃光が走った！", "There is a bright flash of light!"));
-    POSITION iy = o_ptr->iy;
-    POSITION ix = o_ptr->ix;
-    auto marked = o_ptr->marked;
-    auto inscription = std::move(o_ptr->inscription);
-
-    o_ptr->generate(o_ptr->bi_id);
-
-    o_ptr->iy = iy;
-    o_ptr->ix = ix;
-    o_ptr->marked = marked;
-    o_ptr->inscription = std::move(inscription);
-
+    POSITION iy = item_ptr->iy;
+    POSITION ix = item_ptr->ix;
+    auto marked = item_ptr->marked;
+    auto inscription = std::move(item_ptr->inscription);
+    item_ptr->generate(item_ptr->bi_id);
+    item_ptr->iy = iy;
+    item_ptr->ix = ix;
+    item_ptr->marked = marked;
+    item_ptr->inscription = std::move(inscription);
     calc_android_exp(player_ptr);
     return true;
 }

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -147,7 +147,7 @@ void generate_amusement(PlayerType *player_ptr, int num, bool known)
         }
 
         ItemEntity item;
-        item.prep(baseitem.idx);
+        item.generate(baseitem.idx);
         if (opt_a_idx) {
             item.fixed_artifact_idx = *opt_a_idx;
         }

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -146,8 +146,7 @@ void generate_amusement(PlayerType *player_ptr, int num, bool known)
             }
         }
 
-        ItemEntity item;
-        item.generate(baseitem.idx);
+        ItemEntity item(baseitem.idx);
         if (opt_a_idx) {
             item.fixed_artifact_idx = *opt_a_idx;
         }

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -121,7 +121,7 @@ void display_rumor(PlayerType *player_ptr, bool ex)
         const auto &[a_idx, a_ptr] = get_artifact_definition(artifact_name);
         const auto bi_id = BaseitemList::get_instance().lookup_baseitem_id(a_ptr->bi_key);
         ItemEntity item;
-        item.prep(bi_id);
+        item.generate(bi_id);
         item.fixed_artifact_idx = a_idx;
         item.ident = IDENT_STORE;
         fullname = describe_flavor(player_ptr, &item, OD_NAME_ONLY);

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -120,8 +120,7 @@ void display_rumor(PlayerType *player_ptr, bool ex)
         const auto &artifact_name = tokens[1];
         const auto &[a_idx, a_ptr] = get_artifact_definition(artifact_name);
         const auto bi_id = BaseitemList::get_instance().lookup_baseitem_id(a_ptr->bi_key);
-        ItemEntity item;
-        item.generate(bi_id);
+        ItemEntity item(bi_id);
         item.fixed_artifact_idx = a_idx;
         item.ident = IDENT_STORE;
         fullname = describe_flavor(player_ptr, &item, OD_NAME_ONLY);

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -339,7 +339,7 @@ static void store_create(PlayerType *player_ptr, short fix_k_idx, StoreSaleType 
         ItemEntity forge;
         ItemEntity *q_ptr;
         q_ptr = &forge;
-        q_ptr->prep(bi_id);
+        q_ptr->generate(bi_id);
         ItemMagicApplier(player_ptr, q_ptr, level, AM_NO_FIXED_ART).execute();
         if (!store_will_buy(player_ptr, q_ptr, store_num)) {
             continue;

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -336,51 +336,48 @@ static void store_create(PlayerType *player_ptr, short fix_k_idx, StoreSaleType 
             level = rand_range(1, ow_ptr->level);
         }
 
-        ItemEntity forge;
-        ItemEntity *q_ptr;
-        q_ptr = &forge;
-        q_ptr->generate(bi_id);
-        ItemMagicApplier(player_ptr, q_ptr, level, AM_NO_FIXED_ART).execute();
-        if (!store_will_buy(player_ptr, q_ptr, store_num)) {
+        ItemEntity item(bi_id);
+        ItemMagicApplier(player_ptr, &item, level, AM_NO_FIXED_ART).execute();
+        if (!store_will_buy(player_ptr, &item, store_num)) {
             continue;
         }
 
-        auto pvals = store_same_magic_device_pvals(q_ptr);
+        const auto pvals = store_same_magic_device_pvals(&item);
         if (pvals.size() >= 2) {
             auto pval = rand_choice(pvals);
-            q_ptr->pval = pval;
+            item.pval = pval;
         }
 
-        const auto tval = q_ptr->bi_key.tval();
-        const auto sval = q_ptr->bi_key.sval();
+        const auto tval = item.bi_key.tval();
+        const auto sval = item.bi_key.sval();
         if (tval == ItemKindType::LITE) {
             if (sval == SV_LITE_TORCH) {
-                q_ptr->fuel = FUEL_TORCH / 2;
+                item.fuel = FUEL_TORCH / 2;
             }
 
             if (sval == SV_LITE_LANTERN) {
-                q_ptr->fuel = FUEL_LAMP / 2;
+                item.fuel = FUEL_LAMP / 2;
             }
         }
 
-        q_ptr->mark_as_known();
-        q_ptr->ident |= IDENT_STORE;
+        item.mark_as_known();
+        item.ident |= IDENT_STORE;
         if (tval == ItemKindType::CHEST) {
             continue;
         }
 
         if (store_num == StoreSaleType::BLACK) {
-            if (black_market_crap(player_ptr, q_ptr) || (q_ptr->get_price() < 10)) {
+            if (black_market_crap(player_ptr, &item) || (item.get_price() < 10)) {
                 continue;
             }
         } else {
-            if (q_ptr->get_price() <= 0) {
+            if (item.get_price() <= 0) {
                 continue;
             }
         }
 
-        mass_produce(q_ptr, store_num);
-        (void)store_carry(q_ptr);
+        mass_produce(&item, store_num);
+        (void)store_carry(&item);
         break;
     }
 }

--- a/src/system/baseitem-info.h
+++ b/src/system/baseitem-info.h
@@ -2,6 +2,7 @@
 
 #include "object-enchant/tr-flags.h"
 #include "object-enchant/trg-types.h"
+#include "object/tval-types.h"
 #include "system/angband.h"
 #include "util/flag-group.h"
 #include "view/colored-char.h"
@@ -10,9 +11,14 @@
 #include <string>
 #include <vector>
 
-enum class ItemKindType : short;
 class BaseitemKey {
 public:
+    constexpr BaseitemKey()
+        : type_value(ItemKindType::NONE)
+        , subtype_value(std::nullopt)
+    {
+    }
+
     constexpr BaseitemKey(const ItemKindType type_value, const std::optional<int> &subtype_value = std::nullopt)
         : type_value(type_value)
         , subtype_value(subtype_value)

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -36,6 +36,17 @@ ItemEntity::ItemEntity()
 {
 }
 
+ItemEntity::ItemEntity(short bi_id)
+{
+    this->generate(bi_id);
+}
+
+ItemEntity::ItemEntity(const BaseitemKey &bi_key)
+{
+    const auto &baseitems = BaseitemList::get_instance();
+    this->generate(baseitems.lookup_baseitem_id(bi_key));
+}
+
 /*!
  * @brief アイテムを初期化する
  */
@@ -51,6 +62,12 @@ void ItemEntity::wipe()
 void ItemEntity::copy_from(const ItemEntity *j_ptr)
 {
     *this = *j_ptr;
+}
+
+void ItemEntity::generate(const BaseitemKey &new_bi_key)
+{
+    const auto new_bi_id = BaseitemList::get_instance().lookup_baseitem_id(new_bi_key);
+    this->generate(new_bi_id);
 }
 
 /*!

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -57,7 +57,7 @@ void ItemEntity::copy_from(const ItemEntity *j_ptr)
  * @brief アイテム構造体にベースアイテムを作成する
  * @param bi_id 新たに作成したいベースアイテム情報のID
  */
-void ItemEntity::prep(short new_bi_id)
+void ItemEntity::generate(short new_bi_id)
 {
     const auto &baseitem = BaseitemList::get_instance().get_baseitem(new_bi_id);
     auto old_stack_idx = this->stack_idx;

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -31,6 +31,8 @@ class EgoItemDefinition;
 class ItemEntity {
 public:
     ItemEntity();
+    ItemEntity(short bi_id);
+    ItemEntity(const BaseitemKey &bi_key);
     short bi_id{}; /*!< ベースアイテムID (0は、不具合調査用の無効アイテム または 何も装備していない箇所のアイテム であることを示す) */
     POSITION iy{}; /*!< Y-position on map, or zero */
     POSITION ix{}; /*!< X-position on map, or zero */
@@ -76,6 +78,7 @@ public:
 
     void wipe();
     void copy_from(const ItemEntity *j_ptr);
+    void generate(const BaseitemKey &new_bi_key);
     void generate(short new_bi_id);
     bool is(ItemKindType tval) const;
     bool is_weapon() const;

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -76,7 +76,7 @@ public:
 
     void wipe();
     void copy_from(const ItemEntity *j_ptr);
-    void prep(short new_bi_id);
+    void generate(short new_bi_id);
     bool is(ItemKindType tval) const;
     bool is_weapon() const;
     bool is_weapon_ammo() const;

--- a/src/view/object-describer.cpp
+++ b/src/view/object-describer.cpp
@@ -75,7 +75,7 @@ void display_koff(PlayerType *player_ptr)
     }
 
     ItemEntity item;
-    item.prep(player_ptr->tracking_bi_id);
+    item.generate(player_ptr->tracking_bi_id);
     const auto item_name = describe_flavor(player_ptr, &item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
     term_putstr(0, 0, -1, TERM_WHITE, item_name);
     const auto sval = *item.bi_key.sval();

--- a/src/view/object-describer.cpp
+++ b/src/view/object-describer.cpp
@@ -74,8 +74,7 @@ void display_koff(PlayerType *player_ptr)
         term_erase(0, y);
     }
 
-    ItemEntity item;
-    item.generate(player_ptr->tracking_bi_id);
+    ItemEntity item(player_ptr->tracking_bi_id);
     const auto item_name = describe_flavor(player_ptr, &item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
     term_putstr(0, 0, -1, TERM_WHITE, item_name);
     const auto sval = *item.bi_key.sval();

--- a/src/wizard/fixed-artifacts-spoiler.cpp
+++ b/src/wizard/fixed-artifacts-spoiler.cpp
@@ -74,7 +74,7 @@ static ItemEntity make_fake_artifact(FixedArtifactId fixed_artifact_idx)
     const auto &artifact = ArtifactsInfo::get_instance().get_artifact(fixed_artifact_idx);
     const auto bi_id = BaseitemList::get_instance().lookup_baseitem_id(artifact.bi_key);
     ItemEntity item;
-    item.prep(bi_id);
+    item.generate(bi_id);
     item.fixed_artifact_idx = fixed_artifact_idx;
     item.pval = artifact.pval;
     item.ac = artifact.ac;

--- a/src/wizard/fixed-artifacts-spoiler.cpp
+++ b/src/wizard/fixed-artifacts-spoiler.cpp
@@ -2,7 +2,6 @@
 #include "io/files-util.h"
 #include "system/angband-version.h"
 #include "system/artifact-type-definition.h"
-#include "system/baseitem-info.h"
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "util/angband-files.h"
@@ -72,9 +71,7 @@ void spoiler_outlist(std::string_view header, const std::vector<std::string> &de
 static ItemEntity make_fake_artifact(FixedArtifactId fixed_artifact_idx)
 {
     const auto &artifact = ArtifactsInfo::get_instance().get_artifact(fixed_artifact_idx);
-    const auto bi_id = BaseitemList::get_instance().lookup_baseitem_id(artifact.bi_key);
-    ItemEntity item;
-    item.generate(bi_id);
+    ItemEntity item(artifact.bi_key);
     item.fixed_artifact_idx = fixed_artifact_idx;
     item.pval = artifact.pval;
     item.ac = artifact.ac;

--- a/src/wizard/items-spoiler.cpp
+++ b/src/wizard/items-spoiler.cpp
@@ -103,7 +103,7 @@ static std::string describe_weight(const ItemEntity &item)
 static ItemEntity prepare_item_for_obj_desc(short bi_id)
 {
     ItemEntity item;
-    item.prep(bi_id);
+    item.generate(bi_id);
     item.ident |= IDENT_KNOWN;
     item.pval = 0;
     item.to_a = 0;

--- a/src/wizard/items-spoiler.cpp
+++ b/src/wizard/items-spoiler.cpp
@@ -102,8 +102,7 @@ static std::string describe_weight(const ItemEntity &item)
  */
 static ItemEntity prepare_item_for_obj_desc(short bi_id)
 {
-    ItemEntity item;
-    item.generate(bi_id);
+    ItemEntity item(bi_id);
     item.ident |= IDENT_KNOWN;
     item.pval = 0;
     item.to_a = 0;

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -591,32 +591,32 @@ static void wiz_reroll_item(PlayerType *player_ptr, ItemEntity *o_ptr)
         switch (tolower(*command)) {
         /* Apply bad magic, but first clear object */
         case 'w':
-            q_ptr->prep(o_ptr->bi_id);
+            q_ptr->generate(o_ptr->bi_id);
             ItemMagicApplier(player_ptr, q_ptr, player_ptr->current_floor_ptr->dun_level, AM_NO_FIXED_ART | AM_GOOD | AM_GREAT | AM_CURSED).execute();
             break;
         /* Apply bad magic, but first clear object */
         case 'c':
-            q_ptr->prep(o_ptr->bi_id);
+            q_ptr->generate(o_ptr->bi_id);
             ItemMagicApplier(player_ptr, q_ptr, player_ptr->current_floor_ptr->dun_level, AM_NO_FIXED_ART | AM_GOOD | AM_CURSED).execute();
             break;
         /* Apply normal magic, but first clear object */
         case 'n':
-            q_ptr->prep(o_ptr->bi_id);
+            q_ptr->generate(o_ptr->bi_id);
             ItemMagicApplier(player_ptr, q_ptr, player_ptr->current_floor_ptr->dun_level, AM_NO_FIXED_ART).execute();
             break;
         /* Apply good magic, but first clear object */
         case 'g':
-            q_ptr->prep(o_ptr->bi_id);
+            q_ptr->generate(o_ptr->bi_id);
             ItemMagicApplier(player_ptr, q_ptr, player_ptr->current_floor_ptr->dun_level, AM_NO_FIXED_ART | AM_GOOD).execute();
             break;
         /* Apply great magic, but first clear object */
         case 'e':
-            q_ptr->prep(o_ptr->bi_id);
+            q_ptr->generate(o_ptr->bi_id);
             ItemMagicApplier(player_ptr, q_ptr, player_ptr->current_floor_ptr->dun_level, AM_NO_FIXED_ART | AM_GOOD | AM_GREAT).execute();
             break;
         /* Apply special magic, but first clear object */
         case 's':
-            q_ptr->prep(o_ptr->bi_id);
+            q_ptr->generate(o_ptr->bi_id);
             ItemMagicApplier(player_ptr, q_ptr, player_ptr->current_floor_ptr->dun_level, AM_GOOD | AM_GREAT | AM_SPECIAL).execute();
             if (!q_ptr->is_fixed_or_random_artifact()) {
                 become_random_artifact(player_ptr, q_ptr, false);
@@ -955,7 +955,7 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
                 continue;
             }
 
-            o_ptr->prep(baseitem.idx);
+            o_ptr->generate(baseitem.idx);
 #ifdef JP
             const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
 #else
@@ -977,7 +977,7 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
 
         if (allow_ego && baseitem_ids.size() == 1) {
             short bi_id = baseitem_ids.back();
-            o_ptr->prep(bi_id);
+            o_ptr->generate(bi_id);
 
             for (const auto &[e_idx, ego] : egos_info) {
                 if (ego.idx == EgoType::NONE || ego.name.empty()) {
@@ -1019,7 +1019,7 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
             }
 
             const auto bi_id = baseitems.lookup_baseitem_id(artifact.bi_key);
-            o_ptr->prep(bi_id);
+            o_ptr->generate(bi_id);
             o_ptr->fixed_artifact_idx = a_idx;
 
 #ifdef JP
@@ -1131,7 +1131,7 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
         if (wish_randart) {
             if (must || ok_art) {
                 do {
-                    o_ptr->prep(bi_id);
+                    o_ptr->generate(bi_id);
                     ItemMagicApplier(player_ptr, o_ptr, baseitem.level, AM_SPECIAL | AM_NO_FIXED_ART).execute();
                 } while (!o_ptr->is_random_artifact() || o_ptr->is_ego() || o_ptr->is_cursed());
 
@@ -1148,14 +1148,14 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
         if (allow_ego && (wish_ego || ego_ids.size() > 0)) {
             if (must || ok_ego) {
                 if (ego_ids.size() > 0) {
-                    o_ptr->prep(bi_id);
+                    o_ptr->generate(bi_id);
                     o_ptr->ego_idx = ego_ids[0];
                     apply_ego(o_ptr, player_ptr->current_floor_ptr->base_level);
                 } else {
                     auto max_roll = 1000;
                     auto i = 0;
                     for (i = 0; i < max_roll; i++) {
-                        o_ptr->prep(bi_id);
+                        o_ptr->generate(bi_id);
                         ItemMagicApplier(player_ptr, o_ptr, baseitem.level, AM_GREAT | AM_NO_FIXED_ART).execute();
                         if (o_ptr->is_random_artifact()) {
                             continue;
@@ -1190,7 +1190,7 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
             res = WishResultType::EGO;
         } else {
             for (auto i = 0; i < 100; i++) {
-                o_ptr->prep(bi_id);
+                o_ptr->generate(bi_id);
                 ItemMagicApplier(player_ptr, o_ptr, 0, AM_NO_FIXED_ART).execute();
                 if (!o_ptr->is_cursed()) {
                     break;

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -27,7 +27,6 @@
 #include "spell/spells-object.h"
 #include "system/alloc-entries.h"
 #include "system/artifact-type-definition.h"
-#include "system/baseitem-info.h"
 #include "system/floor-type-definition.h"
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
@@ -853,8 +852,6 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
 #endif
     };
 
-    ItemEntity forge;
-    auto *o_ptr = &forge;
     auto wish_art = false;
     auto wish_randart = false;
     auto wish_ego = false;
@@ -955,11 +952,11 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
                 continue;
             }
 
-            o_ptr->generate(baseitem.idx);
+            ItemEntity item(baseitem.idx);
 #ifdef JP
-            const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
+            const auto item_name = describe_flavor(player_ptr, &item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
 #else
-            auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
+            auto item_name = describe_flavor(player_ptr, &item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
             str_tolower(item_name.data());
 #endif
             if (cheat_xtra) {
@@ -976,9 +973,7 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
         }
 
         if (allow_ego && baseitem_ids.size() == 1) {
-            short bi_id = baseitem_ids.back();
-            o_ptr->generate(bi_id);
-
+            ItemEntity item(baseitem_ids.back());
             for (const auto &[e_idx, ego] : egos_info) {
                 if (ego.idx == EgoType::NONE || ego.name.empty()) {
                     continue;
@@ -994,7 +989,7 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
                 }
 
                 if (std::string(str).find(item_name) != std::string::npos) {
-                    if (is_slot_able_to_be_ego(player_ptr, o_ptr) != ego.slot) {
+                    if (is_slot_able_to_be_ego(player_ptr, &item) != ego.slot) {
                         continue;
                     }
 
@@ -1012,20 +1007,18 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
 
         int len;
         auto mlen = 0;
-        const auto &baseitems = BaseitemList::get_instance();
         for (const auto &[a_idx, artifact] : artifacts_info) {
             if (a_idx == FixedArtifactId::NONE || artifact.name.empty()) {
                 continue;
             }
 
-            const auto bi_id = baseitems.lookup_baseitem_id(artifact.bi_key);
-            o_ptr->generate(bi_id);
-            o_ptr->fixed_artifact_idx = a_idx;
+            ItemEntity item(artifact.bi_key);
+            item.fixed_artifact_idx = a_idx;
 
 #ifdef JP
-            const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
+            const auto item_name = describe_flavor(player_ptr, &item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
 #else
-            auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
+            auto item_name = describe_flavor(player_ptr, &item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
             str_tolower(item_name.data());
 #endif
             a_str = a_desc;
@@ -1130,13 +1123,14 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
 
         if (wish_randart) {
             if (must || ok_art) {
+                ItemEntity item;
                 do {
-                    o_ptr->generate(bi_id);
-                    ItemMagicApplier(player_ptr, o_ptr, baseitem.level, AM_SPECIAL | AM_NO_FIXED_ART).execute();
-                } while (!o_ptr->is_random_artifact() || o_ptr->is_ego() || o_ptr->is_cursed());
+                    item.generate(bi_id);
+                    ItemMagicApplier(player_ptr, &item, baseitem.level, AM_SPECIAL | AM_NO_FIXED_ART).execute();
+                } while (!item.is_random_artifact() || item.is_ego() || item.is_cursed());
 
-                if (o_ptr->is_random_artifact()) {
-                    drop_near(player_ptr, o_ptr, -1, player_ptr->y, player_ptr->x);
+                if (item.is_random_artifact()) {
+                    drop_near(player_ptr, &item, -1, player_ptr->y, player_ptr->x);
                 }
             } else {
                 wishing_puff_of_smoke();
@@ -1145,19 +1139,20 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
         }
 
         WishResultType res = WishResultType::NOTHING;
+        ItemEntity item;
         if (allow_ego && (wish_ego || ego_ids.size() > 0)) {
             if (must || ok_ego) {
                 if (ego_ids.size() > 0) {
-                    o_ptr->generate(bi_id);
-                    o_ptr->ego_idx = ego_ids[0];
-                    apply_ego(o_ptr, player_ptr->current_floor_ptr->base_level);
+                    item.generate(bi_id);
+                    item.ego_idx = ego_ids[0];
+                    apply_ego(&item, player_ptr->current_floor_ptr->base_level);
                 } else {
                     auto max_roll = 1000;
                     auto i = 0;
                     for (i = 0; i < max_roll; i++) {
-                        o_ptr->generate(bi_id);
-                        ItemMagicApplier(player_ptr, o_ptr, baseitem.level, AM_GREAT | AM_NO_FIXED_ART).execute();
-                        if (o_ptr->is_random_artifact()) {
+                        item.generate(bi_id);
+                        ItemMagicApplier(player_ptr, &item, baseitem.level, AM_GREAT | AM_NO_FIXED_ART).execute();
+                        if (item.is_random_artifact()) {
                             continue;
                         }
 
@@ -1167,7 +1162,7 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
 
                         auto e_idx = EgoType::NONE;
                         for (auto e : ego_ids) {
-                            if (o_ptr->ego_idx == e) {
+                            if (item.ego_idx == e) {
                                 e_idx = e;
                                 break;
                             }
@@ -1190,9 +1185,9 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
             res = WishResultType::EGO;
         } else {
             for (auto i = 0; i < 100; i++) {
-                o_ptr->generate(bi_id);
-                ItemMagicApplier(player_ptr, o_ptr, 0, AM_NO_FIXED_ART).execute();
-                if (!o_ptr->is_cursed()) {
+                item.generate(bi_id);
+                ItemMagicApplier(player_ptr, &item, 0, AM_NO_FIXED_ART).execute();
+                if (!item.is_cursed()) {
                     break;
                 }
             }
@@ -1200,16 +1195,16 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
             res = WishResultType::NORMAL;
         }
 
-        if (blessed && wield_slot(player_ptr, o_ptr) != -1) {
-            o_ptr->art_flags.set(TR_BLESSED);
+        if (blessed && wield_slot(player_ptr, &item) != -1) {
+            item.art_flags.set(TR_BLESSED);
         }
 
-        if (fixed && wield_slot(player_ptr, o_ptr) != -1) {
-            o_ptr->art_flags.set(TR_IGNORE_ACID);
-            o_ptr->art_flags.set(TR_IGNORE_FIRE);
+        if (fixed && wield_slot(player_ptr, &item) != -1) {
+            item.art_flags.set(TR_IGNORE_ACID);
+            item.art_flags.set(TR_IGNORE_FIRE);
         }
 
-        (void)drop_near(player_ptr, o_ptr, -1, player_ptr->y, player_ptr->x);
+        (void)drop_near(player_ptr, &item, -1, player_ptr->y, player_ptr->x);
         return res;
     }
 

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -206,8 +206,7 @@ void wiz_create_item(PlayerType *player_ptr)
         }
     }
 
-    ItemEntity item;
-    item.generate(*bi_id);
+    ItemEntity item(*bi_id);
     ItemMagicApplier(player_ptr, &item, player_ptr->current_floor_ptr->dun_level, AM_NO_FIXED_ART).execute();
     (void)drop_near(player_ptr, &item, -1, player_ptr->y, player_ptr->x);
     msg_print("Allocated.");
@@ -222,8 +221,7 @@ void wiz_create_item(PlayerType *player_ptr)
 static std::string wiz_make_named_artifact_desc(PlayerType *player_ptr, FixedArtifactId a_idx)
 {
     const auto &artifact = ArtifactsInfo::get_instance().get_artifact(a_idx);
-    ItemEntity item;
-    item.generate(BaseitemList::get_instance().lookup_baseitem_id(artifact.bi_key));
+    ItemEntity item(artifact.bi_key);
     item.fixed_artifact_idx = a_idx;
     item.mark_as_known();
     return describe_flavor(player_ptr, &item, OD_NAME_ONLY);
@@ -570,8 +568,7 @@ void wiz_learn_items_all(PlayerType *player_ptr)
 {
     for (const auto &baseitem : BaseitemList::get_instance()) {
         if (baseitem.is_valid() && baseitem.level <= command_arg) {
-            ItemEntity item;
-            item.generate(baseitem.idx);
+            ItemEntity item(baseitem.idx);
             object_aware(player_ptr, &item);
         }
     }

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -207,7 +207,7 @@ void wiz_create_item(PlayerType *player_ptr)
     }
 
     ItemEntity item;
-    item.prep(*bi_id);
+    item.generate(*bi_id);
     ItemMagicApplier(player_ptr, &item, player_ptr->current_floor_ptr->dun_level, AM_NO_FIXED_ART).execute();
     (void)drop_near(player_ptr, &item, -1, player_ptr->y, player_ptr->x);
     msg_print("Allocated.");
@@ -223,7 +223,7 @@ static std::string wiz_make_named_artifact_desc(PlayerType *player_ptr, FixedArt
 {
     const auto &artifact = ArtifactsInfo::get_instance().get_artifact(a_idx);
     ItemEntity item;
-    item.prep(BaseitemList::get_instance().lookup_baseitem_id(artifact.bi_key));
+    item.generate(BaseitemList::get_instance().lookup_baseitem_id(artifact.bi_key));
     item.fixed_artifact_idx = a_idx;
     item.mark_as_known();
     return describe_flavor(player_ptr, &item, OD_NAME_ONLY);
@@ -571,7 +571,7 @@ void wiz_learn_items_all(PlayerType *player_ptr)
     for (const auto &baseitem : BaseitemList::get_instance()) {
         if (baseitem.is_valid() && baseitem.level <= command_arg) {
             ItemEntity item;
-            item.prep(baseitem.idx);
+            item.generate(baseitem.idx);
             object_aware(player_ptr, &item);
         }
     }

--- a/src/wizard/wizard-spoiler.cpp
+++ b/src/wizard/wizard-spoiler.cpp
@@ -22,7 +22,6 @@
 #include "spell/spells-execution.h"
 #include "spell/spells-util.h"
 #include "system/angband-version.h"
-#include "system/baseitem-info.h"
 #include "system/item-entity.h"
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
@@ -185,7 +184,6 @@ static SpoilerOutputResultType spoil_player_spell()
 
     PlayerType dummy_p;
     dummy_p.lev = 1;
-    const auto &baseitems = BaseitemList::get_instance();
     for (auto c = 0; c < PLAYER_CLASS_TYPE_MAX; c++) {
         auto class_ptr = &class_info[c];
         spoil_out(format("[[Class: %s]]\n", class_ptr->title));
@@ -193,10 +191,8 @@ static SpoilerOutputResultType spoil_player_spell()
         auto magic_ptr = &class_magics_info[c];
         std::string book_name = _("なし", "None");
         if (magic_ptr->spell_book != ItemKindType::NONE) {
-            ItemEntity book;
-            auto o_ptr = &book;
-            o_ptr->generate(baseitems.lookup_baseitem_id({ magic_ptr->spell_book, 0 }));
-            book_name = describe_flavor(&dummy_p, o_ptr, OD_NAME_ONLY);
+            ItemEntity item({ magic_ptr->spell_book, 0 });
+            book_name = describe_flavor(&dummy_p, &item, OD_NAME_ONLY);
             auto *s = angband_strchr(book_name.data(), '[');
             if (s != nullptr) {
                 book_name.erase(s - book_name.data());

--- a/src/wizard/wizard-spoiler.cpp
+++ b/src/wizard/wizard-spoiler.cpp
@@ -195,7 +195,7 @@ static SpoilerOutputResultType spoil_player_spell()
         if (magic_ptr->spell_book != ItemKindType::NONE) {
             ItemEntity book;
             auto o_ptr = &book;
-            o_ptr->prep(baseitems.lookup_baseitem_id({ magic_ptr->spell_book, 0 }));
+            o_ptr->generate(baseitems.lookup_baseitem_id({ magic_ptr->spell_book, 0 }));
             book_name = describe_flavor(&dummy_p, o_ptr, OD_NAME_ONLY);
             auto *s = angband_strchr(book_name.data(), '[');
             if (s != nullptr) {


### PR DESCRIPTION
スコープが広くてポインタ変数になっている箇所もできるだけ分割して個別にItemEntity のオブジェクトを作成するようにしました
ほぼprep() メソッドを外から呼ぶ必要はなくなりました
ご確認下さい