### PR TITLE
[Chore] CIのビルドテストのGCCのバージョンを13に更新

### DIFF
--- a/.github/workflows/build-with-autotools.yml
+++ b/.github/workflows/build-with-autotools.yml
@@ -3,6 +3,9 @@ name: Build with Autotools
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        required: true
       cxx:
         type: string
         required: true
@@ -21,7 +24,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/create-cache-for-ccache.yml
+++ b/.github/workflows/create-cache-for-ccache.yml
@@ -13,6 +13,7 @@ jobs:
     name: Japanese version with clang (without using pre-compiled headers)
     uses: ./.github/workflows/build-with-autotools.yml
     with:
+      runner: ubuntu-22.04
       cxx: clang++-14
       cxx-flags: "-pipe -O3 -Werror -Wall -Wextra -Wno-unused-const-variable -Wno-invalid-source-encoding -stdlib=libc++"
       configure-opts: "--disable-pch"
@@ -22,6 +23,7 @@ jobs:
     name: Japanese version with gcc
     uses: ./.github/workflows/build-with-autotools.yml
     with:
+      runner: ubuntu-22.04
       cxx: g++-11
       cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
       use-ccache: true
@@ -30,6 +32,7 @@ jobs:
     name: English version with gcc
     uses: ./.github/workflows/build-with-autotools.yml
     with:
+      runner: ubuntu-22.04
       cxx: g++-11
       cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
       configure-opts: "--disable-japanese"

--- a/.github/workflows/create-cache-for-ccache.yml
+++ b/.github/workflows/create-cache-for-ccache.yml
@@ -23,8 +23,8 @@ jobs:
     name: Japanese version with gcc
     uses: ./.github/workflows/build-with-autotools.yml
     with:
-      runner: ubuntu-22.04
-      cxx: g++-11
+      runner: ubuntu-24.04
+      cxx: g++-13
       cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
       use-ccache: true
 
@@ -32,8 +32,8 @@ jobs:
     name: English version with gcc
     uses: ./.github/workflows/build-with-autotools.yml
     with:
-      runner: ubuntu-22.04
-      cxx: g++-11
+      runner: ubuntu-24.04
+      cxx: g++-13
       cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
       configure-opts: "--disable-japanese"
       distcheck: true

--- a/.github/workflows/pull-request-status-check.yml
+++ b/.github/workflows/pull-request-status-check.yml
@@ -36,8 +36,8 @@ jobs:
     name: Build Japanese version with gcc
     uses: ./.github/workflows/build-with-autotools.yml
     with:
-      runner: ubuntu-22.04
-      cxx: g++-11
+      runner: ubuntu-24.04
+      cxx: g++-13
       cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
       use-ccache: true
 
@@ -45,8 +45,8 @@ jobs:
     name: Build English version with gcc
     uses: ./.github/workflows/build-with-autotools.yml
     with:
-      runner: ubuntu-22.04
-      cxx: g++-11
+      runner: ubuntu-24.04
+      cxx: g++-13
       cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
       configure-opts: "--disable-japanese"
       distcheck: true

--- a/.github/workflows/pull-request-status-check.yml
+++ b/.github/workflows/pull-request-status-check.yml
@@ -26,6 +26,7 @@ jobs:
     name: Build Japanese version with clang (without using pre-compiled headers)
     uses: ./.github/workflows/build-with-autotools.yml
     with:
+      runner: ubuntu-22.04
       cxx: clang++-14
       cxx-flags: "-pipe -O3 -Werror -Wall -Wextra -Wno-unused-const-variable -Wno-invalid-source-encoding -stdlib=libc++"
       configure-opts: "--disable-pch"
@@ -35,6 +36,7 @@ jobs:
     name: Build Japanese version with gcc
     uses: ./.github/workflows/build-with-autotools.yml
     with:
+      runner: ubuntu-22.04
       cxx: g++-11
       cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
       use-ccache: true
@@ -43,6 +45,7 @@ jobs:
     name: Build English version with gcc
     uses: ./.github/workflows/build-with-autotools.yml
     with:
+      runner: ubuntu-22.04
       cxx: g++-11
       cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
       configure-opts: "--disable-japanese"


### PR DESCRIPTION
GitHub Actions の ubuntu-24.04 でGCC 13を使えるのでバージョンを更新したいが、Clangのバージョンはデフォルトで使用可能な最小バージョンが16であり、事情により14を使いたいので、GCCとClangでrunnerを切り替えられるようにしてGCCのみ
 ubuntu-24.04 で GCC 13 でビルドするようにする。

そもそもrunnerの切り替えが上手く動くかわからないので、一旦PRを上げて動作を見てみる。