### PR TITLE
[Fix] ウィンドウの縦幅が大きいとCandidateSelectorがクラッシュ

### DIFF
--- a/src/util/candidate-selector.cpp
+++ b/src/util/candidate-selector.cpp
@@ -61,5 +61,5 @@ std::pair<size_t, std::optional<size_t>> CandidateSelector::process_input(char c
 void CandidateSelector::set_max_per_page(size_t max)
 {
     const auto &[wid, hgt] = term_get_size();
-    this->max_per_page = std::min<size_t>(max, hgt - 2);
+    this->max_per_page = std::min({ max, static_cast<size_t>(hgt - 2), i2sym.size() });
 }


### PR DESCRIPTION
ウィンドウの縦幅が大きく、選択肢の数が多いときに選択用のシンボルの配列の要素数を超えてしまっているのが原因。
最大でもそれ以下になるように1ページの選択肢の表示数を制限する。

#4032 でエンバグの修正なので、個別のIssueはなし。