### PR TITLE
壁抜けモンスターに騎乗すると無条件で壁抜けできる不具合を解消した

### DIFF
--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -499,23 +499,21 @@ bool has_kill_wall(PlayerType *player_ptr)
  * @brief プレイヤーが壁通過を持っているかを返す。
  * @param player_ptr プレイヤーへの参照ポインタ
  * @return 持っていたらTRUE
- * @details
- * * 時限で幽体化、壁抜けをもつか種族幽霊ならばひとまずTRUE。
- * * 但し騎乗中は乗騎が壁抜けを持っていなければ不能になる。
+ * @details 騎乗状態でなければ、時限または種族特性で壁抜けできるか否か.
+ * 騎乗状態ならば、そのモンスターとプレイヤーが両方壁抜けできるか否か.
  */
 bool has_pass_wall(PlayerType *player_ptr)
 {
-    if (player_ptr->wraith_form || player_ptr->tim_pass_wall || PlayerRace(player_ptr).equals(PlayerRaceType::SPECTRE)) {
-        return true;
-    }
-
+    auto can_player_pass_wall = player_ptr->wraith_form > 0;
+    can_player_pass_wall |= player_ptr->tim_pass_wall > 0;
+    can_player_pass_wall |= PlayerRace(player_ptr).equals(PlayerRaceType::SPECTRE);
     if (player_ptr->riding == 0) {
-        return false;
+        return can_player_pass_wall;
     }
 
     const auto &monster = player_ptr->current_floor_ptr->m_list[player_ptr->riding];
     const auto &monrace = monster.get_monrace();
-    return monrace.feature_flags.has(MonsterFeatureType::PASS_WALL);
+    return can_player_pass_wall && monrace.feature_flags.has(MonsterFeatureType::PASS_WALL);
 }
 
 /*!


### PR DESCRIPTION
別件で不具合が出ているため動作確認はしていません、一旦ドラフトにしておきます