### PR TITLE
[Fix/Refactor] アイテムを投げた時にクラッシュ

### DIFF
--- a/src/util/point-2d.h
+++ b/src/util/point-2d.h
@@ -45,16 +45,10 @@ struct Vector2D {
 /**
  * @brief 2次元平面上の座標を表すクラス
  */
-template <std::integral T>
+template <typename T>
 struct Point2D {
     T y{};
     T x{};
-    constexpr Point2D()
-        : y(static_cast<T>(0))
-        , x(static_cast<T>(0))
-    {
-    }
-
     constexpr Point2D(T y, T x)
         : y(y)
         , x(x)


### PR DESCRIPTION
a6070543a410f90e で置換する変数を誤っているのが原因。
原因を修正するとともにもう少しコードをわかりやすくする。