### PR TITLE
[Refactor] マップの単色化処理

### DIFF
--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -260,16 +260,7 @@ void print_rel(PlayerType *player_ptr, char c, TERM_COLOR a, POSITION y, POSITIO
 {
     /* Only do "legal" locations */
     if (panel_contains(y, x)) {
-        /* Hack -- fake monochrome */
-        if (!use_graphics) {
-            if (w_ptr->timewalk_m_idx) {
-                a = TERM_DARK;
-            } else if (is_invuln(player_ptr) || player_ptr->timewalk) {
-                a = TERM_WHITE;
-            } else if (player_ptr->wraith_form) {
-                a = TERM_L_DARK;
-            }
-        }
+        a = get_monochrome_display_color(player_ptr).value_or(a);
 
         /* Draw the char using the attr */
         term_queue_bigchar(panel_col_of(x), y - panel_row_prt, { { a, c }, {} });
@@ -407,16 +398,7 @@ void lite_spot(PlayerType *player_ptr, POSITION y, POSITION x)
 {
     if (panel_contains(y, x) && in_bounds2(player_ptr->current_floor_ptr, y, x)) {
         auto ccp = map_info(player_ptr, { y, x });
-        if (!use_graphics) {
-            auto &cc_foreground = ccp.cc_foreground;
-            if (w_ptr->timewalk_m_idx) {
-                cc_foreground.color = TERM_DARK;
-            } else if (is_invuln(player_ptr) || player_ptr->timewalk) {
-                cc_foreground.color = TERM_WHITE;
-            } else if (player_ptr->wraith_form) {
-                cc_foreground.color = TERM_L_DARK;
-            }
-        }
+        ccp.cc_foreground.color = get_monochrome_display_color(player_ptr).value_or(ccp.cc_foreground.color);
 
         term_queue_bigchar(panel_col_of(x), y - panel_row_prt, ccp);
         static constexpr auto flags = {

--- a/src/io/cursor.cpp
+++ b/src/io/cursor.cpp
@@ -64,17 +64,7 @@ void print_path(PlayerType *player_ptr, POSITION y, POSITION x)
                 }
             }
 
-            if (!use_graphics) {
-                auto &cc_foreground = ccp.cc_foreground;
-                if (w_ptr->timewalk_m_idx) {
-                    cc_foreground.color = TERM_DARK;
-                } else if (is_invuln(player_ptr) || player_ptr->timewalk) {
-                    cc_foreground.color = TERM_WHITE;
-                } else if (player_ptr->wraith_form) {
-                    cc_foreground.color = TERM_L_DARK;
-                }
-            }
-
+            ccp.cc_foreground.color = get_monochrome_display_color(player_ptr).value_or(ccp.cc_foreground.color);
             ccp.cc_foreground.character = '*';
             term_queue_bigchar(panel_col_of(pos_path.x), pos_path.y - panel_row_prt, ccp);
         }

--- a/src/view/display-map.cpp
+++ b/src/view/display-map.cpp
@@ -11,6 +11,7 @@
 #include "monster-race/monster-race.h"
 #include "object/object-info.h"
 #include "object/object-mark-types.h"
+#include "player/player-status.h"
 #include "system/baseitem-info.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
@@ -338,4 +339,35 @@ ColoredCharPair map_info(PlayerType *player_ptr, const Pos2D &pos)
 
     ccp.cc_foreground = set_term_color(player_ptr, pos, { ccp.cc_foreground.color, cc_config.character });
     return ccp;
+}
+
+/*!
+ * @brief 単色表示色を取得する
+ *
+ * 以下のゲームの状態にしたがってマップを単色表示する場合にその色を返す。
+ * なお、タイル表示モードでは適用されない。
+ *
+ * - モンスターが時間停止スキルを使用中: TERM_DARK(マップが黒一色となりなにも表示されない)
+ * - プレイヤーが無敵状態もしくは時間停止スキルを使用中: TERM_WHITE
+ * - プレイヤーが幽体化スキルを使用中: TERM_L_DARK
+ *
+ * @return 単色表示色。単色表示を行わない場合はstd::nullopt
+ */
+std::optional<uint8_t> get_monochrome_display_color(PlayerType *player_ptr)
+{
+    if (use_graphics) {
+        return std::nullopt;
+    }
+
+    if (w_ptr->timewalk_m_idx) {
+        return TERM_DARK;
+    }
+    if (is_invuln(player_ptr) || player_ptr->timewalk) {
+        return TERM_WHITE;
+    }
+    if (player_ptr->wraith_form) {
+        return TERM_L_DARK;
+    }
+
+    return std::nullopt;
 }

--- a/src/view/display-map.h
+++ b/src/view/display-map.h
@@ -3,8 +3,10 @@
 #include "util/point-2d.h"
 #include "view/colored-char.h"
 #include <cstdint>
+#include <optional>
 
 extern uint8_t display_autopick;
 
 class PlayerType;
 ColoredCharPair map_info(PlayerType *player_ptr, const Pos2D &pos);
+std::optional<uint8_t> get_monochrome_display_color(PlayerType *player_ptr);

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -474,16 +474,7 @@ static void display_dungeon(PlayerType *player_ptr)
             }
 
             auto ccp = map_info(player_ptr, { y, x });
-            auto &cc_foreground = ccp.cc_foreground;
-            if (!use_graphics) {
-                if (w_ptr->timewalk_m_idx) {
-                    cc_foreground.color = TERM_DARK;
-                } else if (is_invuln(player_ptr) || player_ptr->timewalk) {
-                    cc_foreground.color = TERM_WHITE;
-                } else if (player_ptr->wraith_form) {
-                    cc_foreground.color = TERM_L_DARK;
-                }
-            }
+            ccp.cc_foreground.color = get_monochrome_display_color(player_ptr).value_or(ccp.cc_foreground.color);
 
             term_queue_char(pos_x, pos_y, ccp);
         }

--- a/src/window/main-window-util.cpp
+++ b/src/window/main-window-util.cpp
@@ -98,16 +98,7 @@ void print_map(PlayerType *player_ptr)
     for (auto y = ymin; y <= ymax; y++) {
         for (auto x = xmin; x <= xmax; x++) {
             auto ccp = map_info(player_ptr, { y, x });
-            if (!use_graphics) {
-                auto &cc_foreground = ccp.cc_foreground;
-                if (w_ptr->timewalk_m_idx) {
-                    cc_foreground.color = TERM_DARK;
-                } else if (is_invuln(player_ptr) || player_ptr->timewalk) {
-                    cc_foreground.color = TERM_WHITE;
-                } else if (player_ptr->wraith_form) {
-                    cc_foreground.color = TERM_L_DARK;
-                }
-            }
+            ccp.cc_foreground.color = get_monochrome_display_color(player_ptr).value_or(ccp.cc_foreground.color);
 
             term_queue_bigchar(panel_col_of(x), y - panel_row_prt, ccp);
         }
@@ -264,15 +255,7 @@ void display_map(PlayerType *player_ptr, int *cy, int *cx)
         term_gotoxy(COL_MAP, y);
         for (x = 0; x < wid + 2; ++x) {
             ColoredChar cc_foreground(ma[y][x], mc[y][x]);
-            if (!use_graphics) {
-                if (w_ptr->timewalk_m_idx) {
-                    cc_foreground.color = TERM_DARK;
-                } else if (is_invuln(player_ptr) || player_ptr->timewalk) {
-                    cc_foreground.color = TERM_WHITE;
-                } else if (player_ptr->wraith_form) {
-                    cc_foreground.color = TERM_L_DARK;
-                }
-            }
+            cc_foreground.color = get_monochrome_display_color(player_ptr).value_or(cc_foreground.color);
 
             term_add_bigch(cc_foreground);
         }


### PR DESCRIPTION
無敵状態時などに行われるマップの単色化処理のコピペを関数にまとめる。

表示の文字と色をまとめるPRをレビュー中に、マップの表示色を一時的に変更する処理が複数箇所にコピペされているのが気になったので、共通関数化しました。