### PR TITLE
MonraceList::sort_level() を実装し、ang_sort_comp_monster_level() とang_sort_swap_hook() を廃止した

### DIFF
--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -55,8 +55,9 @@ static std::vector<MonsterRaceId> collect_monsters(PlayerType *player_ptr, IDX g
     bool grp_wanted = (monster_group_char[grp_cur] == (char *)-3L);
     bool grp_amberite = (monster_group_char[grp_cur] == (char *)-4L);
 
+    const auto &monraces = MonraceList::get_instance();
     std::vector<MonsterRaceId> monrace_ids;
-    for (const auto &[monrace_id, monrace] : monraces_info) {
+    for (const auto &[monrace_id, monrace] : monraces) {
         if (((mode != MONSTER_LORE_DEBUG) && (mode != MONSTER_LORE_RESEARCH)) && !cheat_know && !monrace.r_sights) {
             continue;
         }
@@ -94,8 +95,7 @@ static std::vector<MonsterRaceId> collect_monsters(PlayerType *player_ptr, IDX g
         }
     }
 
-    auto dummy_why = 0;
-    ang_sort(player_ptr, monrace_ids.data(), &dummy_why, monrace_ids.size(), ang_sort_comp_monster_level, ang_sort_swap_hook);
+    std::stable_sort(monrace_ids.begin(), monrace_ids.end(), [&monraces](auto x, auto y) { return monraces.order_level(x, y); });
     return monrace_ids;
 }
 

--- a/src/system/monster-race-info.cpp
+++ b/src/system/monster-race-info.cpp
@@ -416,6 +416,29 @@ bool MonraceList::order(MonsterRaceId id1, MonsterRaceId id2, bool is_detailed) 
     return id1 <= id2;
 }
 
+bool MonraceList::MonraceList::order_level(MonsterRaceId id1, MonsterRaceId id2) const
+{
+    const auto &monrace1 = monraces_info[id1];
+    const auto &monrace2 = monraces_info[id2];
+    if (monrace1.level < monrace2.level) {
+        return true;
+    }
+
+    if (monrace1.level > monrace2.level) {
+        return false;
+    }
+
+    if (monrace1.kind_flags.has_not(MonsterKindType::UNIQUE) && monrace2.kind_flags.has(MonsterKindType::UNIQUE)) {
+        return true;
+    }
+
+    if (monrace1.kind_flags.has(MonsterKindType::UNIQUE) && monrace2.kind_flags.has_not(MonsterKindType::UNIQUE)) {
+        return false;
+    }
+
+    return id1 <= id2;
+}
+
 void MonraceList::reset_all_visuals()
 {
     for (auto &[_, monrace] : monraces_info) {

--- a/src/system/monster-race-info.h
+++ b/src/system/monster-race-info.h
@@ -179,6 +179,7 @@ public:
     int calc_figurine_value(const MonsterRaceId r_idx) const;
     int calc_capture_value(const MonsterRaceId r_idx) const;
     bool order(MonsterRaceId id1, MonsterRaceId id2, bool is_detailed = false) const;
+    bool order_level(MonsterRaceId id1, MonsterRaceId id2) const;
 
     void reset_all_visuals();
 

--- a/src/util/sort.cpp
+++ b/src/util/sort.cpp
@@ -276,67 +276,6 @@ void ang_sort_swap_quest_num(PlayerType *player_ptr, vptr u, vptr v, int a, int 
 }
 
 /*!
- * @brief モンスター種族情報を特定の基準によりソートするためのスワップ処理
- * Sorting hook -- Swap function -- see below
- * @param u モンスター種族情報の入れるポインタ
- * @param v 未使用
- * @param a スワップするモンスター種族のID1
- * @param b スワップするモンスター種族のID2
- * @details
- * We use "u" to point to array of monster indexes,
- * and "v" to select the type of sorting to perform.
- */
-void ang_sort_swap_hook(PlayerType *player_ptr, vptr u, vptr v, int a, int b)
-{
-    /* Unused */
-    (void)player_ptr;
-    (void)v;
-
-    uint16_t *who = (uint16_t *)(u);
-    uint16_t holder;
-
-    holder = who[a];
-    who[a] = who[b];
-    who[b] = holder;
-}
-
-/*
- * hook function to sort monsters by level
- */
-bool ang_sort_comp_monster_level(PlayerType *player_ptr, vptr u, vptr v, int a, int b)
-{
-    /* Unused */
-    (void)player_ptr;
-    (void)v;
-
-    MonsterRaceId *who = (MonsterRaceId *)(u);
-
-    auto w1 = who[a];
-    auto w2 = who[b];
-
-    MonsterRaceInfo *r_ptr1 = &monraces_info[w1];
-    MonsterRaceInfo *r_ptr2 = &monraces_info[w2];
-
-    if (r_ptr2->level > r_ptr1->level) {
-        return true;
-    }
-
-    if (r_ptr1->level > r_ptr2->level) {
-        return false;
-    }
-
-    if (r_ptr2->kind_flags.has(MonsterKindType::UNIQUE) && r_ptr1->kind_flags.has_not(MonsterKindType::UNIQUE)) {
-        return true;
-    }
-
-    if (r_ptr1->kind_flags.has(MonsterKindType::UNIQUE) && r_ptr2->kind_flags.has_not(MonsterKindType::UNIQUE)) {
-        return false;
-    }
-
-    return w1 <= w2;
-}
-
-/*!
  * @brief フロア保存時のgrid情報テンプレートをソートするための比較処理
  * @param u gridテンプレートの参照ポインタ
  * @param v 未使用

--- a/src/util/sort.h
+++ b/src/util/sort.h
@@ -13,8 +13,5 @@ void ang_sort_swap_position(PlayerType *player_ptr, vptr u, vptr v, int a, int b
 bool ang_sort_comp_quest_num(PlayerType *player_ptr, vptr u, vptr v, int a, int b);
 void ang_sort_swap_quest_num(PlayerType *player_ptr, vptr u, vptr v, int a, int b);
 
-void ang_sort_swap_hook(PlayerType *player_ptr, vptr u, vptr v, int a, int b);
-bool ang_sort_comp_monster_level(PlayerType *player_ptr, vptr u, vptr v, int a, int b);
-
 bool ang_sort_comp_cave_temp(PlayerType *player_ptr, vptr u, vptr v, int a, int b);
 void ang_sort_swap_cave_temp(PlayerType *player_ptr, vptr u, vptr v, int a, int b);


### PR DESCRIPTION
倒したモンスターの一覧はdevelopと変わらないように見えます
ご確認下さい
(#4141 とバッティングする可能性がある場合はしばらく保留とします)