### PR TITLE
[Refactor] jsonのパース処理を行う関数を独立したファイルへ分離

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -404,6 +404,7 @@
     <ClCompile Include="..\..\src\info-reader\feature-reader.cpp" />
     <ClCompile Include="..\..\src\info-reader\general-parser.cpp" />
     <ClCompile Include="..\..\src\info-reader\info-reader-util.cpp" />
+    <ClCompile Include="..\..\src\info-reader\json-reader-util.cpp" />
     <ClCompile Include="..\..\src\info-reader\baseitem-tokens-table.cpp" />
     <ClCompile Include="..\..\src\info-reader\baseitem-reader.cpp" />
     <ClCompile Include="..\..\src\info-reader\magic-reader.cpp" />
@@ -1190,6 +1191,7 @@
     <ClInclude Include="..\..\src\info-reader\feature-reader.h" />
     <ClInclude Include="..\..\src\info-reader\general-parser.h" />
     <ClInclude Include="..\..\src\info-reader\info-reader-util.h" />
+    <ClInclude Include="..\..\src\info-reader\json-reader-util.h" />
     <ClInclude Include="..\..\src\info-reader\baseitem-tokens-table.h" />
     <ClInclude Include="..\..\src\info-reader\baseitem-reader.h" />
     <ClInclude Include="..\..\src\info-reader\magic-reader.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -956,6 +956,9 @@
     <ClCompile Include="..\..\src\info-reader\info-reader-util.cpp">
       <Filter>info-reader</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\info-reader\json-reader-util.cpp">
+      <Filter>info-reader</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\info-reader\feature-reader.cpp">
       <Filter>info-reader</Filter>
     </ClCompile>
@@ -3585,6 +3588,9 @@
       <Filter>term</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\info-reader\info-reader-util.h">
+      <Filter>info-reader</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\info-reader\json-reader-util.h">
       <Filter>info-reader</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\info-reader\parse-error-types.h">

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -270,6 +270,7 @@ hengband_SOURCES = \
 	info-reader/fixed-map-parser.cpp info-reader/fixed-map-parser.h \
 	info-reader/general-parser.cpp info-reader/general-parser.h \
 	info-reader/info-reader-util.cpp info-reader/info-reader-util.h \
+	info-reader/json-reader-util.cpp info-reader/json-reader-util.h \
 	info-reader/magic-reader.cpp info-reader/magic-reader.h \
 	info-reader/parse-error-types.h \
 	info-reader/race-info-tokens-table.cpp info-reader/race-info-tokens-table.h \

--- a/src/info-reader/artifact-reader.cpp
+++ b/src/info-reader/artifact-reader.cpp
@@ -3,6 +3,7 @@
 #include "artifact/random-art-effects.h"
 #include "info-reader/baseitem-tokens-table.h"
 #include "info-reader/info-reader-util.h"
+#include "info-reader/json-reader-util.h"
 #include "info-reader/parse-error-types.h"
 #include "locale/japanese.h"
 #include "main/angband-headers.h"

--- a/src/info-reader/baseitem-reader.cpp
+++ b/src/info-reader/baseitem-reader.cpp
@@ -8,6 +8,7 @@
 #include "artifact/random-art-effects.h"
 #include "info-reader/baseitem-tokens-table.h"
 #include "info-reader/info-reader-util.h"
+#include "info-reader/json-reader-util.h"
 #include "info-reader/parse-error-types.h"
 #include "locale/japanese.h"
 #include "main/angband-headers.h"

--- a/src/info-reader/info-reader-util.cpp
+++ b/src/info-reader/info-reader-util.cpp
@@ -1,5 +1,6 @@
 #include "info-reader/info-reader-util.h"
 #include "artifact/random-art-effects.h"
+#include "info-reader/parse-error-types.h"
 #include "main/angband-headers.h"
 #include "object-enchant/activation-info-table.h"
 #include "util/enum-converter.h"
@@ -59,50 +60,6 @@ void append_english_text(std::string &text, std::string_view add)
 #endif
 
 /*!
- * @brief JSON Objectから文字列をセットする
- *
- * 引数で与えられたJSON Objectから日本語版の場合は"ja"、英語版の場合は"en"のキーで文字列を取得し、
- * data に格納する。キーが存在しない場合は is_required が真の場合はエラーを返し、偽の場合は何もせずに終了する。
- *
- * @param json 文字列の格納されたJSON Object
- * @param data 文字列を格納する変数への参照
- * @param is_required 必須かどうか
- * @return エラーコード
- */
-errr info_set_string(const nlohmann::json &json, std::string &data, bool is_required)
-{
-    const auto unexist_result = is_required ? PARSE_ERROR_TOO_FEW_ARGUMENTS : PARSE_ERROR_NONE;
-
-    if (json.is_null()) {
-        return unexist_result;
-    }
-
-    if (!json.is_object()) {
-        return PARSE_ERROR_TOO_FEW_ARGUMENTS;
-    }
-
-#ifdef JP
-    const auto &ja_str = json.find("ja");
-    if (ja_str == json.end()) {
-        return unexist_result;
-    }
-    auto ja_str_sys = utf8_to_sys(ja_str->get<std::string>());
-    if (!ja_str_sys) {
-        return PARSE_ERROR_INVALID_FLAG;
-    }
-    data = std::move(*ja_str_sys);
-#else
-    const auto &en_str = json.find("en");
-    if (en_str == json.end()) {
-        return unexist_result;
-    }
-    data = en_str->get<std::string>();
-#endif
-
-    return PARSE_ERROR_NONE;
-}
-
-/*!
  * @brief ダイスを表す文字列を解析してダイスの値をセットする
  *
  * 引数で与えられた文字列 "XdY" をダイスの値に変換し、X を dd に、Y を ds に格納する。
@@ -113,7 +70,7 @@ errr info_set_string(const nlohmann::json &json, std::string &data, bool is_requ
  * @param ds ダイスの面数を格納する変数への参照
  * @return エラーコード
  */
-errr info_set_dice(const std::string_view dice_str, DICE_NUMBER &dd, DICE_SID &ds)
+errr info_set_dice(std::string_view dice_str, DICE_NUMBER &dd, DICE_SID &ds)
 {
     const auto &dice = str_split(dice_str, 'd', false, 2);
     if (dice.size() < 2) {
@@ -124,22 +81,4 @@ errr info_set_dice(const std::string_view dice_str, DICE_NUMBER &dd, DICE_SID &d
     ds = std::stoi(dice[1]);
 
     return PARSE_ERROR_NONE;
-}
-
-/*!
- * @brief JSON Objectからダイスの値を取得する
- * @param json ダイスの値が格納されたJSON Object
- * @param dd ダイスの数を格納する変数への参照
- * @param ds ダイスの面数を格納する変数への参照
- * @param is_required 必須かどうか
- * 必須でJSON Objectがnullや文字列でない場合はエラーを返す。必須でない場合は何もせずに終了する。
- * @return エラーコード
- */
-errr info_set_dice(const nlohmann::json &json, DICE_NUMBER &dd, DICE_SID &ds, bool is_required)
-{
-    if (json.is_null() || !json.is_string()) {
-        return is_required ? PARSE_ERROR_TOO_FEW_ARGUMENTS : PARSE_ERROR_NONE;
-    }
-
-    return info_set_dice(json.get<std::string>(), dd, ds);
 }

--- a/src/info-reader/info-reader-util.h
+++ b/src/info-reader/info-reader-util.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include "external-lib/include-json.h"
-#include "info-reader/parse-error-types.h"
-#include "locale/japanese.h"
 #include "system/angband.h"
 #include "util/bit-flags-calculator.h"
 #include <concepts>
@@ -25,9 +22,7 @@ RandomArtActType grab_one_activation_flag(std::string_view what);
 void append_english_text(std::string &text, std::string_view add);
 #endif
 
-errr info_set_string(const nlohmann::json &json, std::string &data, bool is_required);
-errr info_set_dice(const std::string_view dice_str, DICE_NUMBER &dd, DICE_SID &ds);
-errr info_set_dice(const nlohmann::json &json, DICE_NUMBER &dd, DICE_SID &ds, bool is_required);
+errr info_set_dice(std::string_view dice_str, DICE_NUMBER &dd, DICE_SID &ds);
 
 /// @note clang-formatによるconceptの整形が安定していないので抑制しておく
 // clang-format off
@@ -104,40 +99,4 @@ template <typename T>
 void info_set_value(T &arg, const std::string &val, int base = 10)
 {
     arg = static_cast<T>(std::stoi(val, nullptr, base));
-}
-
-using Range = std::pair<int, int>;
-
-template <typename T>
-concept IntegralOrEnum = std::integral<T> || std::is_enum_v<T>;
-
-/*!
- * @brief JSON Objectから整数値もしくはenum値を取得する
-
- * 引数で与えられたJSON Objectから整数値もしくはenum値を取得し、 data に格納する。
- *
- * @param json 整数値が格納されたJSON Object
- * @param data 値を格納する変数への参照
- * @param is_required 必須かどうか。
- * 必須でJSON Objectがnullの場合はエラーを返す。必須でない場合は何もせずに終了する。
- * @param range 取得した値の範囲を指定する。範囲外の値が取得された場合はエラーを返す。
- * @return エラーコード
- */
-template <IntegralOrEnum T>
-errr info_set_integer(const nlohmann::json &json, T &data, bool is_required, std::optional<Range> range = std::nullopt)
-{
-    if (json.is_null()) {
-        return is_required ? PARSE_ERROR_TOO_FEW_ARGUMENTS : PARSE_ERROR_NONE;
-    }
-    if (!json.is_number_integer()) {
-        return PARSE_ERROR_TOO_FEW_ARGUMENTS;
-    }
-
-    const auto value = json.get<T>();
-    if (range && (value < static_cast<T>(range->first) || value > static_cast<T>(range->second))) {
-        return PARSE_ERROR_INVALID_FLAG;
-    }
-
-    data = value;
-    return PARSE_ERROR_NONE;
 }

--- a/src/info-reader/json-reader-util.cpp
+++ b/src/info-reader/json-reader-util.cpp
@@ -1,0 +1,65 @@
+#include "info-reader/json-reader-util.h"
+#include "info-reader/info-reader-util.h"
+#include "locale/japanese.h"
+
+/*!
+ * @brief JSON Objectから文字列をセットする
+ *
+ * 引数で与えられたJSON Objectから日本語版の場合は"ja"、英語版の場合は"en"のキーで文字列を取得し、
+ * data に格納する。キーが存在しない場合は is_required が真の場合はエラーを返し、偽の場合は何もせずに終了する。
+ *
+ * @param json 文字列の格納されたJSON Object
+ * @param data 文字列を格納する変数への参照
+ * @param is_required 必須かどうか
+ * @return エラーコード
+ */
+errr info_set_string(const nlohmann::json &json, std::string &data, bool is_required)
+{
+    const auto unexist_result = is_required ? PARSE_ERROR_TOO_FEW_ARGUMENTS : PARSE_ERROR_NONE;
+
+    if (json.is_null()) {
+        return unexist_result;
+    }
+
+    if (!json.is_object()) {
+        return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+    }
+
+#ifdef JP
+    const auto &ja_str = json.find("ja");
+    if (ja_str == json.end()) {
+        return unexist_result;
+    }
+    auto ja_str_sys = utf8_to_sys(ja_str->get<std::string>());
+    if (!ja_str_sys) {
+        return PARSE_ERROR_INVALID_FLAG;
+    }
+    data = std::move(*ja_str_sys);
+#else
+    const auto &en_str = json.find("en");
+    if (en_str == json.end()) {
+        return unexist_result;
+    }
+    data = en_str->get<std::string>();
+#endif
+
+    return PARSE_ERROR_NONE;
+}
+
+/*!
+ * @brief JSON Objectからダイスの値を取得する
+ * @param json ダイスの値が格納されたJSON Object
+ * @param dd ダイスの数を格納する変数への参照
+ * @param ds ダイスの面数を格納する変数への参照
+ * @param is_required 必須かどうか
+ * 必須でJSON Objectがnullや文字列でない場合はエラーを返す。必須でない場合は何もせずに終了する。
+ * @return エラーコード
+ */
+errr info_set_dice(const nlohmann::json &json, DICE_NUMBER &dd, DICE_SID &ds, bool is_required)
+{
+    if (json.is_null() || !json.is_string()) {
+        return is_required ? PARSE_ERROR_TOO_FEW_ARGUMENTS : PARSE_ERROR_NONE;
+    }
+
+    return info_set_dice(json.get<std::string>(), dd, ds);
+}

--- a/src/info-reader/json-reader-util.h
+++ b/src/info-reader/json-reader-util.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "external-lib/include-json.h"
+#include "info-reader/parse-error-types.h"
+#include "system/angband.h"
+#include <concepts>
+#include <optional>
+#include <utility>
+
+using Range = std::pair<int, int>;
+
+template <typename T>
+concept IntegralOrEnum = std::integral<T> || std::is_enum_v<T>;
+
+errr info_set_string(const nlohmann::json &json, std::string &data, bool is_required);
+errr info_set_dice(const nlohmann::json &json, DICE_NUMBER &dd, DICE_SID &ds, bool is_required);
+
+/*!
+ * @brief JSON Objectから整数値もしくはenum値を取得する
+
+ * 引数で与えられたJSON Objectから整数値もしくはenum値を取得し、 data に格納する。
+ *
+ * @param json 整数値が格納されたJSON Object
+ * @param data 値を格納する変数への参照
+ * @param is_required 必須かどうか。
+ * 必須でJSON Objectがnullの場合はエラーを返す。必須でない場合は何もせずに終了する。
+ * @param range 取得した値の範囲を指定する。範囲外の値が取得された場合はエラーを返す。
+ * @return エラーコード
+ */
+template <IntegralOrEnum T>
+errr info_set_integer(const nlohmann::json &json, T &data, bool is_required, std::optional<Range> range = std::nullopt)
+{
+    if (json.is_null()) {
+        return is_required ? PARSE_ERROR_TOO_FEW_ARGUMENTS : PARSE_ERROR_NONE;
+    }
+    if (!json.is_number_integer()) {
+        return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+    }
+
+    const auto value = json.get<T>();
+    if (range && (value < static_cast<T>(range->first) || value > static_cast<T>(range->second))) {
+        return PARSE_ERROR_INVALID_FLAG;
+    }
+
+    data = value;
+    return PARSE_ERROR_NONE;
+}

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -1,6 +1,7 @@
 #include "info-reader/race-reader.h"
 #include "artifact/fixed-art-types.h"
 #include "info-reader/info-reader-util.h"
+#include "info-reader/json-reader-util.h"
 #include "info-reader/parse-error-types.h"
 #include "info-reader/race-info-tokens-table.h"
 #include "locale/japanese.h"


### PR DESCRIPTION
Resolves #4148 

nlohmann-json が不要にインクルードされるのを避けるため、jsonのパースを行う関数を独立したファイルへ分離する。

## 変更結果

ビルド環境
CPU: Ryzen 7 7735HS
OS: Ubuntu 24.04 on WSL2
コンパイラ: GCC 13

変更前

> Executed in  156.65 secs    fish           external
>    usr time   35.79 mins  239.00 micros   35.79 mins
>    sys time    2.42 mins    0.00 micros    2.42 mins
> 

変更後

> Executed in   78.93 secs    fish           external
>    usr time   17.22 mins  111.00 micros   17.22 mins
>    sys time    1.50 mins  121.00 micros    1.50 mins
> 

