### PR TITLE
ang_sort_comp_quest_num() / ang_sort_swap_quest_num() を廃止した

### DIFF
--- a/src/dungeon/quest.cpp
+++ b/src/dungeon/quest.cpp
@@ -170,6 +170,13 @@ size_t QuestList::size() const
     return this->quests.size();
 }
 
+bool QuestList::order_completed(QuestId id1, QuestId id2) const
+{
+    const auto &quest1 = this->get_quest(id1);
+    const auto &quest2 = this->get_quest(id2);
+    return (quest1.comptime != quest2.comptime) ? (quest1.comptime < quest2.comptime) : (quest1.level <= quest2.level);
+}
+
 /*!
  * @brief ランダムクエストの討伐ユニークを決める / Determine the random quest uniques
  * @param quest クエスト構造体への参照

--- a/src/dungeon/quest.cpp
+++ b/src/dungeon/quest.cpp
@@ -170,11 +170,19 @@ size_t QuestList::size() const
     return this->quests.size();
 }
 
+std::vector<QuestId> QuestList::get_sorted_quest_ids() const
+{
+    std::vector<QuestId> quest_ids;
+    std::transform(++this->quests.begin(), this->quests.end(), std::back_inserter(quest_ids), [](const auto &x) { return x.first; });
+    std::stable_sort(quest_ids.begin(), quest_ids.end(), [this](auto x, auto y) { return this->order_completed(x, y); });
+    return quest_ids;
+}
+
 bool QuestList::order_completed(QuestId id1, QuestId id2) const
 {
     const auto &quest1 = this->get_quest(id1);
     const auto &quest2 = this->get_quest(id2);
-    return (quest1.comptime != quest2.comptime) ? (quest1.comptime < quest2.comptime) : (quest1.level <= quest2.level);
+    return (quest1.comptime != quest2.comptime) ? (quest1.comptime < quest2.comptime) : (quest1.level < quest2.level);
 }
 
 /*!

--- a/src/dungeon/quest.h
+++ b/src/dungeon/quest.h
@@ -132,6 +132,10 @@ public:
     using reverse_iterator = std::map<QuestId, QuestType>::reverse_iterator;
     using const_iterator = std::map<QuestId, QuestType>::const_iterator;
     using const_reverse_iterator = std::map<QuestId, QuestType>::const_reverse_iterator;
+    QuestList(const QuestList &) = delete;
+    QuestList(QuestList &&) = delete;
+    QuestList &operator=(const QuestList &) = delete;
+    QuestList &operator=(QuestList &&) = delete;
     static QuestList &get_instance();
 
     void initialize();
@@ -148,15 +152,13 @@ public:
     iterator find(QuestId id);
     const_iterator find(QuestId id) const;
     size_t size() const;
-    QuestList(const QuestList &) = delete;
-    QuestList(QuestList &&) = delete;
-    QuestList &operator=(const QuestList &) = delete;
-    QuestList &operator=(QuestList &&) = delete;
 
 private:
     static QuestList instance;
     std::map<QuestId, QuestType> quests;
     QuestList() = default;
+
+    bool order_completed(QuestId id1, QuestId id2) const;
 };
 
 extern std::vector<std::string> quest_text_lines;

--- a/src/dungeon/quest.h
+++ b/src/dungeon/quest.h
@@ -152,6 +152,7 @@ public:
     iterator find(QuestId id);
     const_iterator find(QuestId id) const;
     size_t size() const;
+    std::vector<QuestId> get_sorted_quest_ids() const;
 
 private:
     static QuestList instance;

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -118,13 +118,7 @@ static void dump_aux_quest(PlayerType *player_ptr, FILE *fff)
     fprintf(fff, _("\n\n  [クエスト情報]\n", "\n\n  [Quest Information]\n"));
 
     const auto &quests = QuestList::get_instance();
-    std::vector<QuestId> quest_ids;
-    for (const auto &[quest_id, quest] : quests) {
-        quest_ids.push_back(quest_id);
-    }
-
-    auto dummy = 0;
-    ang_sort(player_ptr, quest_ids.data(), &dummy, quest_ids.size(), ang_sort_comp_quest_num, ang_sort_swap_quest_num);
+    const auto quest_ids = quests.get_sorted_quest_ids();
     fputc('\n', fff);
     do_cmd_knowledge_quests_completed(player_ptr, fff, quest_ids);
     fputc('\n', fff);

--- a/src/knowledge/knowledge-quests.cpp
+++ b/src/knowledge/knowledge-quests.cpp
@@ -309,15 +309,8 @@ void do_cmd_knowledge_quests(PlayerType *player_ptr)
         return;
     }
 
-    std::vector<QuestId> quest_ids;
     const auto &quests = QuestList::get_instance();
-    for (const auto &[quest_id, quest] : quests) {
-        quest_ids.push_back(quest_id);
-    }
-
-    auto dummy = 0;
-    ang_sort(player_ptr, quest_ids.data(), &dummy, quest_ids.size(), ang_sort_comp_quest_num, ang_sort_swap_quest_num);
-
+    const auto quest_ids = quests.get_sorted_quest_ids();
     do_cmd_knowledge_quests_current(player_ptr, fff);
     fputc('\n', fff);
     do_cmd_knowledge_quests_completed(player_ptr, fff, quest_ids);

--- a/src/system/floor-type-definition.cpp
+++ b/src/system/floor-type-definition.cpp
@@ -159,7 +159,7 @@ bool FloorType::order_pet_whistle(short index1, short index2) const
         return *is_ordered;
     }
 
-    return index1 <= index2;
+    return index1 < index2;
 }
 
 /*!
@@ -185,5 +185,5 @@ bool FloorType::order_pet_dismission(short index1, short index2, short riding_in
         return *is_ordered;
     }
 
-    return index1 <= index2;
+    return index1 < index2;
 }

--- a/src/system/monster-race-info.cpp
+++ b/src/system/monster-race-info.cpp
@@ -413,7 +413,7 @@ bool MonraceList::order(MonsterRaceId id1, MonsterRaceId id2, bool is_detailed) 
         return false;
     }
 
-    return id1 <= id2;
+    return id1 < id2;
 }
 
 bool MonraceList::MonraceList::order_level(MonsterRaceId id1, MonsterRaceId id2) const
@@ -436,7 +436,7 @@ bool MonraceList::MonraceList::order_level(MonsterRaceId id1, MonsterRaceId id2)
         return false;
     }
 
-    return id1 <= id2;
+    return id1 < id2;
 }
 
 void MonraceList::reset_all_visuals()

--- a/src/util/sort.cpp
+++ b/src/util/sort.cpp
@@ -250,31 +250,6 @@ void ang_sort_swap_position(PlayerType *player_ptr, vptr u, vptr v, int a, int b
     y[b] = temp;
 }
 
-bool ang_sort_comp_quest_num(PlayerType *player_ptr, vptr u, vptr v, int a, int b)
-{
-    /* Unused */
-    (void)player_ptr;
-    (void)v;
-
-    const auto &quests = QuestList::get_instance();
-    QuestId *q_num = (QuestId *)u;
-    const auto *qa = &quests.get_quest(q_num[a]);
-    const auto *qb = &quests.get_quest(q_num[b]);
-    return (qa->comptime != qb->comptime) ? (qa->comptime < qb->comptime) : (qa->level <= qb->level);
-}
-
-void ang_sort_swap_quest_num(PlayerType *player_ptr, vptr u, vptr v, int a, int b)
-{
-    /* Unused */
-    (void)player_ptr;
-    (void)v;
-
-    QuestId *q_num = (QuestId *)u;
-    QuestId tmp = q_num[a];
-    q_num[a] = q_num[b];
-    q_num[b] = tmp;
-}
-
 /*!
  * @brief フロア保存時のgrid情報テンプレートをソートするための比較処理
  * @param u gridテンプレートの参照ポインタ

--- a/src/util/sort.h
+++ b/src/util/sort.h
@@ -10,8 +10,5 @@ bool ang_sort_comp_distance(PlayerType *player_ptr, vptr u, vptr v, int a, int b
 bool ang_sort_comp_importance(PlayerType *player_ptr, vptr u, vptr v, int a, int b);
 void ang_sort_swap_position(PlayerType *player_ptr, vptr u, vptr v, int a, int b);
 
-bool ang_sort_comp_quest_num(PlayerType *player_ptr, vptr u, vptr v, int a, int b);
-void ang_sort_swap_quest_num(PlayerType *player_ptr, vptr u, vptr v, int a, int b);
-
 bool ang_sort_comp_cave_temp(PlayerType *player_ptr, vptr u, vptr v, int a, int b);
 void ang_sort_swap_cave_temp(PlayerType *player_ptr, vptr u, vptr v, int a, int b);


### PR DESCRIPTION
新しいソート用メソッド`QuestList::get_sorted_quest_ids()` は現時点で動作しません
ステップ実行しましたが原因がまだ不明なので見て頂けると助かります
動作OKまでドラフトにしておきます
ご確認下さい