### PR TITLE
ang_sort_comp_distance() / ang_sort_comp_importance() / ang_sort_swap_position() を廃止する準備

### DIFF
--- a/src/target/grid-selector.cpp
+++ b/src/target/grid-selector.cpp
@@ -12,6 +12,7 @@
 #include "io/screen-util.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
+#include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "target/target-checker.h"
 #include "term/screen-processor.h"
@@ -81,7 +82,7 @@ static void tgt_pt_prepare(PlayerType *player_ptr, std::vector<POSITION> &ys, st
         }
     }
 
-    ang_sort(player_ptr, xs.data(), ys.data(), size(ys), ang_sort_comp_distance, ang_sort_swap_position);
+    ang_sort(player_ptr, ys, xs, size(ys), ang_sort_comp_distance);
 }
 
 /*!

--- a/src/target/grid-selector.cpp
+++ b/src/target/grid-selector.cpp
@@ -82,7 +82,7 @@ static void tgt_pt_prepare(PlayerType *player_ptr, std::vector<POSITION> &ys, st
         }
     }
 
-    ang_sort(player_ptr, ys, xs, SortKind::DISTANCE);
+    ang_sort(*player_ptr->current_floor_ptr, player_ptr->get_position(), ys, xs, SortKind::DISTANCE);
 }
 
 /*!

--- a/src/target/grid-selector.cpp
+++ b/src/target/grid-selector.cpp
@@ -82,7 +82,7 @@ static void tgt_pt_prepare(PlayerType *player_ptr, std::vector<POSITION> &ys, st
         }
     }
 
-    ang_sort(player_ptr, ys, xs, size(ys), ang_sort_comp_distance);
+    ang_sort(player_ptr, ys, xs, SortKind::DISTANCE);
 }
 
 /*!

--- a/src/target/target-preparation.cpp
+++ b/src/target/target-preparation.cpp
@@ -162,9 +162,9 @@ void target_set_prepare(PlayerType *player_ptr, std::vector<POSITION> &ys, std::
     }
 
     if (mode & (TARGET_KILL)) {
-        ang_sort(player_ptr, ys, xs, SortKind::DISTANCE);
+        ang_sort(*player_ptr->current_floor_ptr, player_ptr->get_position(), ys, xs, SortKind::DISTANCE);
     } else {
-        ang_sort(player_ptr, ys, xs, SortKind::IMPORTANCE);
+        ang_sort(*player_ptr->current_floor_ptr, player_ptr->get_position(), ys, xs, SortKind::IMPORTANCE);
     }
 
     // 乗っているモンスターがターゲットリストの先頭にならないようにする調整。

--- a/src/target/target-preparation.cpp
+++ b/src/target/target-preparation.cpp
@@ -162,9 +162,9 @@ void target_set_prepare(PlayerType *player_ptr, std::vector<POSITION> &ys, std::
     }
 
     if (mode & (TARGET_KILL)) {
-        ang_sort(player_ptr, xs.data(), ys.data(), size(ys), ang_sort_comp_distance, ang_sort_swap_position);
+        ang_sort(player_ptr, ys, xs, size(ys), ang_sort_comp_distance);
     } else {
-        ang_sort(player_ptr, xs.data(), ys.data(), size(ys), ang_sort_comp_importance, ang_sort_swap_position);
+        ang_sort(player_ptr, ys, xs, size(ys), ang_sort_comp_importance);
     }
 
     // 乗っているモンスターがターゲットリストの先頭にならないようにする調整。

--- a/src/target/target-preparation.cpp
+++ b/src/target/target-preparation.cpp
@@ -162,9 +162,9 @@ void target_set_prepare(PlayerType *player_ptr, std::vector<POSITION> &ys, std::
     }
 
     if (mode & (TARGET_KILL)) {
-        ang_sort(player_ptr, ys, xs, size(ys), ang_sort_comp_distance);
+        ang_sort(player_ptr, ys, xs, SortKind::DISTANCE);
     } else {
-        ang_sort(player_ptr, ys, xs, size(ys), ang_sort_comp_importance);
+        ang_sort(player_ptr, ys, xs, SortKind::IMPORTANCE);
     }
 
     // 乗っているモンスターがターゲットリストの先頭にならないようにする調整。

--- a/src/util/sort.cpp
+++ b/src/util/sort.cpp
@@ -9,9 +9,7 @@
 #include "system/grid-type-definition.h"
 #include "system/monster-entity.h"
 #include "system/monster-race-info.h"
-#include "system/player-type-definition.h"
 #include "system/terrain-type-definition.h"
-#include "util/point-2d.h"
 
 namespace {
 /*
@@ -152,14 +150,12 @@ bool ang_sort_comp_importance(const FloorType &floor, const Pos2D &p_pos, std::v
  * @param ang_sort_comp 比較用の関数ポインタ
  * @param ang_sort_swap スワップ用の関数ポインタ
  */
-void exe_ang_sort(PlayerType *player_ptr, std::vector<int> &ys, std::vector<int> &xs, int p, int q, SortKind kind)
+void exe_ang_sort(const FloorType &floor, const Pos2D &p_pos, std::vector<int> &ys, std::vector<int> &xs, int p, int q, SortKind kind)
 {
     if (p >= q) {
         return;
     }
 
-    const auto &floor = *player_ptr->current_floor_ptr;
-    const auto p_pos = player_ptr->get_position();
     int z = p;
     int a = p;
     int b = q;
@@ -212,10 +208,10 @@ void exe_ang_sort(PlayerType *player_ptr, std::vector<int> &ys, std::vector<int>
     }
 
     /* Recurse left side */
-    exe_ang_sort(player_ptr, ys, xs, p, b, kind);
+    exe_ang_sort(floor, p_pos, ys, xs, p, b, kind);
 
     /* Recurse right side */
-    exe_ang_sort(player_ptr, ys, xs, b + 1, q, kind);
+    exe_ang_sort(floor, p_pos, ys, xs, b + 1, q, kind);
 }
 }
 
@@ -228,7 +224,7 @@ void exe_ang_sort(PlayerType *player_ptr, std::vector<int> &ys, std::vector<int>
  * @param ang_sort_comp 比較用の関数ポインタ
  * @param ang_sort_swap スワップ用の関数ポインタ
  */
-void ang_sort(PlayerType *player_ptr, std::vector<int> &ys, std::vector<int> &xs, SortKind kind)
+void ang_sort(const FloorType &floor, const Pos2D &p_pos, std::vector<int> &ys, std::vector<int> &xs, SortKind kind)
 {
-    exe_ang_sort(player_ptr, ys, xs, 0, std::ssize(ys) - 1, kind);
+    exe_ang_sort(floor, p_pos, ys, xs, 0, std::ssize(ys) - 1, kind);
 }

--- a/src/util/sort.cpp
+++ b/src/util/sort.cpp
@@ -11,6 +11,7 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "system/terrain-type-definition.h"
+#include "util/point-2d.h"
 
 /*
  * @brief クイックソートの実行 / Quick sort in place
@@ -80,28 +81,27 @@ void ang_sort(PlayerType *player_ptr, std::vector<int> &ys, std::vector<int> &xs
 bool ang_sort_comp_distance(PlayerType *player_ptr, std::vector<int> &ys, std::vector<int> &xs, int a, int b)
 {
     /* Absolute distance components */
-    POSITION kx = xs[a];
-    kx -= player_ptr->x;
-    kx = std::abs(kx);
-    POSITION ky = ys[a];
-    ky -= player_ptr->y;
-    ky = std::abs(ky);
+    const auto p_pos = player_ptr->get_position();
+    auto xa = xs[a];
+    xa -= p_pos.x;
+    xa = std::abs(xa);
+    auto ya = ys[a];
+    ya -= p_pos.y;
+    ya = std::abs(ya);
 
     /* Approximate Double Distance to the first point */
-    POSITION da = ((kx > ky) ? (kx + kx + ky) : (ky + ky + kx));
+    auto da = (xa > ya) ? (xa + xa + ya) : (ya + ya + xa);
 
     /* Absolute distance components */
-    kx = xs[b];
-    kx -= player_ptr->x;
-    kx = std::abs(kx);
-    ky = ys[b];
-    ky -= player_ptr->y;
-    ky = std::abs(ky);
+    auto xb = xs[b];
+    xb -= p_pos.x;
+    xb = std::abs(xb);
+    auto yb = ys[b];
+    yb -= p_pos.y;
+    yb = std::abs(yb);
 
     /* Approximate Double Distance to the first point */
-    POSITION db = ((kx > ky) ? (kx + kx + ky) : (ky + ky + kx));
-
-    /* Compare the distances */
+    auto db = (xb > yb) ? (xb + xb + yb) : (yb + yb + xb);
     return da <= db;
 }
 

--- a/src/util/sort.cpp
+++ b/src/util/sort.cpp
@@ -13,18 +13,6 @@
 #include "system/terrain-type-definition.h"
 
 /*
- * Sorting hook -- swap function -- by "distance to player"
- *
- * We use "u" and "v" to point to arrays of "x" and "y" positions,
- * and sort the arrays by distance to the player.
- */
-static void ang_sort_swap_position(std::vector<int> &ys, std::vector<int> &xs, int a, int b)
-{
-    std::swap(xs[a], xs[b]);
-    std::swap(ys[a], ys[b]);
-}
-
-/*
  * @brief クイックソートの実行 / Quick sort in place
  * @param u アイテムやモンスター等への配列
  * @param v 条件基準IDへの参照ポインタ
@@ -57,8 +45,8 @@ static void exe_ang_sort(PlayerType *player_ptr, std::vector<int> &ys, std::vect
             break;
         }
 
-        ang_sort_swap_position(ys, xs, a, b);
-
+        std::swap(xs[a], xs[b]);
+        std::swap(ys[a], ys[b]);
         a++, b--;
     }
 

--- a/src/util/sort.cpp
+++ b/src/util/sort.cpp
@@ -22,7 +22,7 @@
  * @param ang_sort_comp 比較用の関数ポインタ
  * @param ang_sort_swap スワップ用の関数ポインタ
  */
-static void exe_ang_sort(PlayerType *player_ptr, std::vector<int> &ys, std::vector<int> &xs, int p, int q, bool (*ang_sort_comp)(PlayerType *, std::vector<int> &, std::vector<int> &, int, int))
+static void exe_ang_sort(PlayerType *player_ptr, std::vector<int> &ys, std::vector<int> &xs, int p, int q, SortKind kind)
 {
     if (p >= q) {
         return;
@@ -33,14 +33,42 @@ static void exe_ang_sort(PlayerType *player_ptr, std::vector<int> &ys, std::vect
     int b = q;
     while (true) {
         /* Slide i2 */
-        while (!(*ang_sort_comp)(player_ptr, ys, xs, b, z)) {
-            b--;
-        }
+        auto is_less_i2 = false;
+        do {
+            switch (kind) {
+            case SortKind::DISTANCE:
+                is_less_i2 = ang_sort_comp_distance(player_ptr, ys, xs, b, z);
+                break;
+            case SortKind::IMPORTANCE:
+                is_less_i2 = ang_sort_comp_importance(player_ptr, ys, xs, b, z);
+                break;
+            default:
+                THROW_EXCEPTION(std::logic_error, "Invalid Sort Kind was specified!");
+            }
+
+            if (!is_less_i2) {
+                b--;
+            }
+        } while (!is_less_i2);
 
         /* Slide i1 */
-        while (!(*ang_sort_comp)(player_ptr, ys, xs, z, a)) {
-            a++;
-        }
+        auto is_less_i1 = false;
+        do {
+            switch (kind) {
+            case SortKind::DISTANCE:
+                is_less_i1 = ang_sort_comp_distance(player_ptr, ys, xs, z, a);
+                break;
+            case SortKind::IMPORTANCE:
+                is_less_i1 = ang_sort_comp_importance(player_ptr, ys, xs, z, a);
+                break;
+            default:
+                THROW_EXCEPTION(std::logic_error, "Invalid Sort Kind was specified!");
+            }
+
+            if (!is_less_i1) {
+                a++;
+            }
+        } while (!is_less_i1);
 
         if (a >= b) {
             break;
@@ -52,10 +80,10 @@ static void exe_ang_sort(PlayerType *player_ptr, std::vector<int> &ys, std::vect
     }
 
     /* Recurse left side */
-    exe_ang_sort(player_ptr, ys, xs, p, b, ang_sort_comp);
+    exe_ang_sort(player_ptr, ys, xs, p, b, kind);
 
     /* Recurse right side */
-    exe_ang_sort(player_ptr, ys, xs, b + 1, q, ang_sort_comp);
+    exe_ang_sort(player_ptr, ys, xs, b + 1, q, kind);
 }
 
 /*
@@ -67,9 +95,9 @@ static void exe_ang_sort(PlayerType *player_ptr, std::vector<int> &ys, std::vect
  * @param ang_sort_comp 比較用の関数ポインタ
  * @param ang_sort_swap スワップ用の関数ポインタ
  */
-void ang_sort(PlayerType *player_ptr, std::vector<int> &ys, std::vector<int> &xs, int n, bool (*ang_sort_comp)(PlayerType *, std::vector<int> &, std::vector<int> &, int, int))
+void ang_sort(PlayerType *player_ptr, std::vector<int> &ys, std::vector<int> &xs, SortKind kind)
 {
-    exe_ang_sort(player_ptr, ys, xs, 0, n - 1, ang_sort_comp);
+    exe_ang_sort(player_ptr, ys, xs, 0, std::ssize(ys) - 1, kind);
 }
 
 /*

--- a/src/util/sort.h
+++ b/src/util/sort.h
@@ -2,7 +2,12 @@
 
 #include <vector>
 
+enum class SortKind {
+    DISTANCE,
+    IMPORTANCE,
+};
+
 class PlayerType;
-void ang_sort(PlayerType *player_ptr, std::vector<int> &ys, std::vector<int> &xs, int n, bool (*ang_sort_comp)(PlayerType *, std::vector<int> &, std::vector<int> &, int, int));
+void ang_sort(PlayerType *player_ptr, std::vector<int> &ys, std::vector<int> &xs, SortKind kind);
 bool ang_sort_comp_distance(PlayerType *player_ptr, std::vector<int> &ys, std::vector<int> &xs, int a, int b);
 bool ang_sort_comp_importance(PlayerType *player_ptr, std::vector<int> &ys, std::vector<int> &xs, int a, int b);

--- a/src/util/sort.h
+++ b/src/util/sort.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "util/point-2d.h"
 #include <vector>
 
 enum class SortKind {
@@ -7,5 +8,5 @@ enum class SortKind {
     IMPORTANCE,
 };
 
-class PlayerType;
-void ang_sort(PlayerType *player_ptr, std::vector<int> &ys, std::vector<int> &xs, SortKind kind);
+class FloorType;
+void ang_sort(const FloorType &floor, const Pos2D &p_pos, std::vector<int> &ys, std::vector<int> &xs, SortKind kind);

--- a/src/util/sort.h
+++ b/src/util/sort.h
@@ -1,11 +1,8 @@
 #pragma once
 
-#include "system/angband.h"
+#include <vector>
 
-#include "system/player-type-definition.h"
-void ang_sort(PlayerType *player_ptr, vptr u, vptr v, int n, bool (*ang_sort_comp)(PlayerType *, vptr, vptr, int, int),
-    void (*ang_sort_swap)(PlayerType *, vptr, vptr, int, int));
-
-bool ang_sort_comp_distance(PlayerType *player_ptr, vptr u, vptr v, int a, int b);
-bool ang_sort_comp_importance(PlayerType *player_ptr, vptr u, vptr v, int a, int b);
-void ang_sort_swap_position(PlayerType *player_ptr, vptr u, vptr v, int a, int b);
+class PlayerType;
+void ang_sort(PlayerType *player_ptr, std::vector<int> &ys, std::vector<int> &xs, int n, bool (*ang_sort_comp)(PlayerType *, std::vector<int> &, std::vector<int> &, int, int));
+bool ang_sort_comp_distance(PlayerType *player_ptr, std::vector<int> &ys, std::vector<int> &xs, int a, int b);
+bool ang_sort_comp_importance(PlayerType *player_ptr, std::vector<int> &ys, std::vector<int> &xs, int a, int b);

--- a/src/util/sort.h
+++ b/src/util/sort.h
@@ -9,5 +9,3 @@ enum class SortKind {
 
 class PlayerType;
 void ang_sort(PlayerType *player_ptr, std::vector<int> &ys, std::vector<int> &xs, SortKind kind);
-bool ang_sort_comp_distance(PlayerType *player_ptr, std::vector<int> &ys, std::vector<int> &xs, int a, int b);
-bool ang_sort_comp_importance(PlayerType *player_ptr, std::vector<int> &ys, std::vector<int> &xs, int a, int b);


### PR DESCRIPTION
このソートメソッドをFloorType に置くのは重すぎるので、最終的にターゲット選択専用のクラスを作ってutil/ からtarget/ に隔離します
look でdevelopと同じようにターゲットが動くのをチェック済です
ご確認下さい
(Doxygenは横着してほったらかしてますが次回の移設PRで整備します)