### PR TITLE
デバッグセーブに関するグローバル変数と、古いデバッグセーブを削除するルーチンを除去した

### DIFF
--- a/src/io/files-util.cpp
+++ b/src/io/files-util.cpp
@@ -40,13 +40,11 @@ std::filesystem::path ANGBAND_DIR_HELP; //!< Help files (normal) for the online 
 std::filesystem::path ANGBAND_DIR_INFO; //!< Help files (spoilers) for the online help (ascii) These files are portable between platforms
 std::filesystem::path ANGBAND_DIR_PREF; //!< Default user "preference" files (ascii) These files are rarely portable between platforms
 std::filesystem::path ANGBAND_DIR_SAVE; //!< Savefiles for current characters (binary)
-std::filesystem::path ANGBAND_DIR_DEBUG_SAVE; //*< Savefiles for debug data
 std::filesystem::path ANGBAND_DIR_USER; //!< User "preference" files (ascii) These files are rarely portable between platforms
 std::filesystem::path ANGBAND_DIR_XTRA; //!< Various extra files (binary) These files are rarely portable between platforms
 
 std::filesystem::path savefile;
 std::string savefile_base;
-std::filesystem::path debug_savefile;
 
 /*!
  * @brief プレイヤーステータスをファイルダンプ出力する

--- a/src/io/files-util.h
+++ b/src/io/files-util.h
@@ -8,7 +8,6 @@
 
 extern std::filesystem::path savefile; //!< セーブファイルのフルパス
 extern std::string savefile_base; //!< セーブファイル名
-extern std::filesystem::path debug_savefile; //!< デバッグセーブファイルのフルパス
 
 extern std::filesystem::path ANGBAND_DIR;
 extern std::filesystem::path ANGBAND_DIR_APEX;
@@ -21,7 +20,6 @@ extern std::filesystem::path ANGBAND_DIR_HELP;
 extern std::filesystem::path ANGBAND_DIR_INFO;
 extern std::filesystem::path ANGBAND_DIR_PREF;
 extern std::filesystem::path ANGBAND_DIR_SAVE;
-extern std::filesystem::path ANGBAND_DIR_DEBUG_SAVE;
 extern std::filesystem::path ANGBAND_DIR_USER;
 extern std::filesystem::path ANGBAND_DIR_XTRA;
 

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -2656,7 +2656,6 @@ static void init_stuff()
     validate_dir(ANGBAND_DIR_INFO, false);
     validate_dir(ANGBAND_DIR_PREF, true);
     validate_dir(ANGBAND_DIR_SAVE, false);
-    validate_dir(ANGBAND_DIR_DEBUG_SAVE, false);
     validate_dir(ANGBAND_DIR_USER, true);
     validate_dir(ANGBAND_DIR_XTRA, true);
     const auto path_news = path_build(ANGBAND_DIR_FILE, _("news_j.txt", "news.txt"));


### PR DESCRIPTION
デバッグセーブ機能がなくなったので、残っていた変数や処理も消しました
古いデバッグデーブは残りますが、悪さはしないのとリリースノートにこの旨記載することで各自の環境でデバッグセーブを削除して頂く運用としたいと思います
ご確認下さい