### PR TITLE
display_group_list() の引数をconcptr[] からvector<string> に変えた

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -833,7 +833,7 @@
     <ClCompile Include="..\..\src\cmd-io\feeling-table.cpp" />
     <ClCompile Include="..\..\src\knowledge\lighting-level-table.cpp" />
     <ClCompile Include="..\..\src\knowledge\monster-group-table.cpp" />
-    <ClCompile Include="..\..\src\knowledge\object-group-table.cpp" />
+    <ClCompile Include="..\..\src\knowledge\item-group-table.cpp" />
     <ClCompile Include="..\..\src\melee\melee-postprocess.cpp" />
     <ClCompile Include="..\..\src\combat\shoot.cpp" />
     <ClCompile Include="..\..\src\mspell\mspell-attack\mspell-bolt.cpp" />
@@ -1816,7 +1816,7 @@
     <ClInclude Include="..\..\src\cmd-io\feeling-table.h" />
     <ClInclude Include="..\..\src\knowledge\lighting-level-table.h" />
     <ClInclude Include="..\..\src\knowledge\monster-group-table.h" />
-    <ClInclude Include="..\..\src\knowledge\object-group-table.h" />
+    <ClInclude Include="..\..\src\knowledge\item-group-table.h" />
     <ClInclude Include="..\..\src\melee\melee-postprocess.h" />
     <ClInclude Include="..\..\src\combat\shoot.h" />
     <ClInclude Include="..\..\src\core\show-file.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -749,7 +749,7 @@
     <ClCompile Include="..\..\src\io-dump\special-class-dump.cpp">
       <Filter>io-dump</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\knowledge\object-group-table.cpp">
+    <ClCompile Include="..\..\src\knowledge\item-group-table.cpp">
       <Filter>knowledge</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\floor\floor-object.cpp">
@@ -3302,7 +3302,7 @@
     <ClInclude Include="..\..\src\io-dump\special-class-dump.h">
       <Filter>io-dump</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\knowledge\object-group-table.h">
+    <ClInclude Include="..\..\src\knowledge\item-group-table.h">
       <Filter>knowledge</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\floor\floor-object.h">

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -321,6 +321,7 @@ hengband_SOURCES = \
 	\
 	item-info/flavor-initializer.cpp item-info/flavor-initializer.h \
 	\
+	knowledge/item-group-table.cpp knowledge/item-group-table.h \
 	knowledge/knowledge-autopick.cpp knowledge/knowledge-autopick.h \
 	knowledge/knowledge-experiences.cpp knowledge/knowledge-experiences.h \
 	knowledge/knowledge-features.cpp knowledge/knowledge-features.h \
@@ -333,7 +334,6 @@ hengband_SOURCES = \
 	knowledge/knowledge-quests.cpp knowledge/knowledge-quests.h \
 	knowledge/lighting-level-table.cpp knowledge/lighting-level-table.h \
 	knowledge/monster-group-table.cpp knowledge/monster-group-table.h \
-	knowledge/object-group-table.cpp knowledge/object-group-table.h \
 	\
 	load/angband-version-comparer.cpp load/angband-version-comparer.h \
 	load/birth-loader.cpp load/birth-loader.h \

--- a/src/io-dump/dump-util.cpp
+++ b/src/io-dump/dump-util.cpp
@@ -190,10 +190,7 @@ bool open_temporary_file(FILE **fff, char *file_name)
 }
 
 /*!
- * @brief モンスター情報リスト中のグループを表示する /
- * Display the object groups.
- * @param col 開始行
- * @param row 開始列
+ * @brief モンスター情報リスト中のグループを表示する
  * @param wid 表示文字数幅
  * @param per_page リストの表示行
  * @param grp_idx グループのID配列
@@ -201,13 +198,14 @@ bool open_temporary_file(FILE **fff, char *file_name)
  * @param grp_cur 現在の選択ID
  * @param grp_top 現在の選択リスト最上部ID
  */
-void display_group_list(int col, int row, int wid, int per_page, IDX grp_idx[], concptr group_text[], int grp_cur, int grp_top)
+void display_group_list(int wid, int per_page, const std::vector<short> &grp_idx, const std::vector<std::string> &group_text, int grp_cur, int grp_top)
 {
-    for (int i = 0; i < per_page && (grp_idx[i] >= 0); i++) {
-        int grp = grp_idx[grp_top + i];
-        TERM_COLOR attr = (grp_top + i == grp_cur) ? TERM_L_BLUE : TERM_WHITE;
-        term_erase(col, row + i, wid);
-        c_put_str(attr, group_text[grp], row + i, col);
+    const int size = std::min(grp_idx.size(), group_text.size());
+    for (auto i = 0; i < per_page && (i < size); i++) {
+        const auto grp = grp_idx[grp_top + i];
+        const auto attr = (grp_top + i == grp_cur) ? TERM_L_BLUE : TERM_WHITE;
+        term_erase(0, 6 + i, wid);
+        c_put_str(attr, group_text[grp], 6 + i, 0);
     }
 }
 

--- a/src/io-dump/dump-util.h
+++ b/src/io-dump/dump-util.h
@@ -3,6 +3,8 @@
 #include "system/angband.h"
 #include "system/terrain-type-definition.h"
 #include <map>
+#include <string>
+#include <vector>
 
 #define FILE_NAME_SIZE 1024
 
@@ -34,6 +36,6 @@ bool visual_mode_command(char ch, bool *visual_list_ptr, int height, int width,
 
 bool open_temporary_file(FILE **fff, char *file_name);
 void browser_cursor(char ch, int *column, IDX *grp_cur, int grp_cnt, IDX *list_cur, int list_cnt);
-void display_group_list(int col, int row, int wid, int per_page, IDX grp_idx[], concptr group_text[], int grp_cur, int grp_top);
+void display_group_list(int wid, int per_page, const std::vector<short> &grp_idx, const std::vector<std::string> &group_text, int grp_cur, int grp_top);
 void display_visual_list(int col, int row, int height, int width, TERM_COLOR attr_top, byte char_left);
 void place_visual_list_cursor(TERM_LEN col, TERM_LEN row, TERM_COLOR a, byte c, TERM_COLOR attr_top, byte char_left);

--- a/src/knowledge/item-group-table.cpp
+++ b/src/knowledge/item-group-table.cpp
@@ -4,14 +4,14 @@
  * @author Hourier
  */
 
-#include "knowledge/object-group-table.h"
+#include "knowledge/item-group-table.h"
 #include "locale/language-switcher.h"
 #include "object/tval-types.h"
 
 /*
  * Description of each monster group.
  */
-const std::vector<std::string> object_group_text = { _("キノコ", "Mushrooms"), _("薬", "Potions"), _("油つぼ", "Flasks"), _("巻物", "Scrolls"),
+const std::vector<std::string> ITEM_KIND_NAMES_GROUP = { _("キノコ", "Mushrooms"), _("薬", "Potions"), _("油つぼ", "Flasks"), _("巻物", "Scrolls"),
     _("指輪", "Rings"), _("アミュレット", "Amulets"), _("笛", "Whistles"), _("光源", "Lanterns"), _("魔法棒", "Wands"), _("杖", "Staffs"), _("ロッド", "Rods"),
     _("カード", "Cards"), _("モンスター・ボール", "Capture Balls"), _("羊皮紙", "Parchments"), _("くさび", "Spikes"), _("箱", "Boxes"), _("人形", "Figurines"),
     _("像", "Statues"), _("ゴミ", "Junk"), _("空のビン", "Bottles"), _("骨", "Skeletons"), _("死体", "Corpses"), _("刀剣類", "Swords"),
@@ -23,7 +23,7 @@ const std::vector<std::string> object_group_text = { _("キノコ", "Mushrooms")
 /*
  * TVALs of items in each group
  */
-const std::vector<ItemKindType> object_group_tval = {
+const std::vector<ItemKindType> ITEM_KINDS_GROUP = {
     ItemKindType::FOOD,
     ItemKindType::POTION,
     ItemKindType::FLASK,

--- a/src/knowledge/item-group-table.h
+++ b/src/knowledge/item-group-table.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+enum class ItemKindType : short;
+extern const std::vector<std::string> ITEM_KIND_NAMES_GROUP;
+extern const std::vector<ItemKindType> ITEM_KINDS_GROUP;

--- a/src/knowledge/knowledge-features.cpp
+++ b/src/knowledge/knowledge-features.cpp
@@ -111,26 +111,17 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
     const auto &[wid, hgt] = term_get_size();
     std::vector<FEAT_IDX> feat_idx(TerrainList::get_instance().size());
 
-    concptr feature_group_text[] = { "terrains", nullptr }; // @todo 後の関数呼び出しで要素数1の配列を定義する必要があるが、vector<string> の方が素直なので直す.
-    int len;
-    int max = 0;
-    int grp_cnt = 0;
+    const std::string terrain_group("terrains"); //!< @details 他と合わせるためgroupと呼ぶ.
+    const auto max_length = terrain_group.length();
     int feat_cnt;
-    short grp_idx[100]{};
+    std::vector<short> grp_idx;
     TERM_COLOR attr_top = 0;
     bool visual_list = false;
     byte char_left = 0;
     TERM_LEN browser_rows = hgt - 8;
     if (direct_f_idx < 0) {
-        for (short i = 0; feature_group_text[i] != nullptr; i++) {
-            len = strlen(feature_group_text[i]);
-            if (len > max) {
-                max = len;
-            }
-
-            if (collect_features(feat_idx.data(), 0x01)) {
-                grp_idx[grp_cnt++] = i;
-            }
+        if (collect_features(feat_idx.data(), 0x01)) {
+            grp_idx.push_back(0);
         }
 
         feat_cnt = 0;
@@ -140,15 +131,13 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
         feat_idx[0] = direct_f_idx;
         feat_cnt = 1;
         feat_idx[1] = -1;
-        (void)visual_mode_command('v', &visual_list, browser_rows - 1, wid - (max + 3), &attr_top, &char_left, &symbol_config.color,
+        (void)visual_mode_command('v', &visual_list, browser_rows - 1, wid - max_length + 5, &attr_top, &char_left, &symbol_config.color,
             &symbol_config.character, need_redraw);
 
         for (FEAT_IDX i = 0; i < F_LIT_MAX; i++) {
             symbols[i] = symbol_config;
         }
     }
-
-    grp_idx[grp_cnt] = -1;
 
     FEAT_IDX old_grp_cur = -1;
     FEAT_IDX grp_cur = 0;
@@ -170,7 +159,7 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
             if (direct_f_idx < 0) {
                 prt(_("グループ", "Group"), 4, 0);
             }
-            prt(_("名前", "Name"), 4, max + 3);
+            prt(_("名前", "Name"), 4, max_length + 5);
             if (use_bigtile) {
                 if (w_ptr->wizard || visual_only) {
                     prt("Idx", 4, 62);
@@ -189,7 +178,7 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
 
             if (direct_f_idx < 0) {
                 for (FEAT_IDX i = 0; i < browser_rows; i++) {
-                    term_putch(max + 1, 6 + i, { TERM_WHITE, '|' });
+                    term_putch(max_length + 1, 6 + i, { TERM_WHITE, '|' });
                 }
             }
 
@@ -204,7 +193,8 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
                 grp_top = grp_cur - browser_rows + 1;
             }
 
-            display_group_list(0, 6, max, browser_rows, grp_idx, feature_group_text, grp_cur, grp_top);
+            static const std::vector<short> terrain_group_num = { 0 }; // size - 1 を引数に入れる必要があるので0.
+            display_group_list(max_length, browser_rows, terrain_group_num, { terrain_group }, grp_cur, grp_top);
             if (old_grp_cur != grp_cur) {
                 old_grp_cur = grp_cur;
                 feat_cnt = collect_features(feat_idx.data(), 0x00);
@@ -219,11 +209,11 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
         }
 
         if (!visual_list) {
-            display_feature_list(max + 3, 6, browser_rows, feat_idx.data(), feat_cur, feat_top, visual_only, F_LIT_STANDARD);
+            display_feature_list(max_length + 5, 6, browser_rows, feat_idx.data(), feat_cur, feat_top, visual_only, F_LIT_STANDARD);
         } else {
             feat_top = feat_cur;
-            display_feature_list(max + 3, 6, 1, feat_idx.data(), feat_cur, feat_top, visual_only, *lighting_level);
-            display_visual_list(max + 3, 7, browser_rows - 1, wid - (max + 3), attr_top, char_left);
+            display_feature_list(max_length + 5, 6, 1, feat_idx.data(), feat_cur, feat_top, visual_only, *lighting_level);
+            display_visual_list(max_length + 5, 7, browser_rows - 1, wid - max_length + 5, attr_top, char_left);
         }
 
         prt(format(_("<方向>%s, 'd'で標準光源効果%s, ESC", "<dir>%s, 'd' for default lighting%s, ESC"),
@@ -235,11 +225,11 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
         auto &terrain = terrains[feat_idx[feat_cur]];
         symbol_orig = terrain.symbol_configs.at(*lighting_level);
         if (visual_list) {
-            place_visual_list_cursor(max + 3, 7, symbol_orig.color, static_cast<uint8_t>(symbol_orig.character), attr_top, char_left);
+            place_visual_list_cursor(max_length + 5, 7, symbol_orig.color, static_cast<uint8_t>(symbol_orig.character), attr_top, char_left);
         } else if (!column) {
             term_gotoxy(0, 6 + (grp_cur - grp_top));
         } else {
-            term_gotoxy(max + 3, 6 + (feat_cur - feat_top));
+            term_gotoxy(max_length + 5, 6 + (feat_cur - feat_top));
         }
 
         ch = inkey();
@@ -291,7 +281,7 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
             continue;
         }
 
-        if (visual_mode_command(ch, &visual_list, browser_rows - 1, wid - (max + 3), &attr_top, &char_left, &symbol_orig.color, &symbol_orig.character, need_redraw)) {
+        if (visual_mode_command(ch, &visual_list, browser_rows - 1, wid - max_length + 5, &attr_top, &char_left, &symbol_orig.color, &symbol_orig.character, need_redraw)) {
             switch (ch) {
             case ESCAPE:
                 terrain.symbol_configs = symbols;
@@ -352,7 +342,8 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
         }
 
         default: {
-            browser_cursor(ch, &column, &grp_cur, grp_cnt, &feat_cur, feat_cnt);
+            constexpr auto dummy_count = 0;
+            browser_cursor(ch, &column, &grp_cur, dummy_count, &feat_cur, feat_cnt);
             break;
         }
         }

--- a/src/knowledge/knowledge-features.cpp
+++ b/src/knowledge/knowledge-features.cpp
@@ -111,7 +111,7 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
     const auto &[wid, hgt] = term_get_size();
     std::vector<FEAT_IDX> feat_idx(TerrainList::get_instance().size());
 
-    const std::string terrain_group("terrains"); //!< @details 他と合わせるためgroupと呼ぶ.
+    const std::string terrain_group(_("地形    ", "Terrains")); //!< @details 他と合わせるためgroupと呼ぶ.
     const auto max_length = terrain_group.length();
     int feat_cnt;
     std::vector<short> grp_idx;
@@ -131,7 +131,7 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
         feat_idx[0] = direct_f_idx;
         feat_cnt = 1;
         feat_idx[1] = -1;
-        (void)visual_mode_command('v', &visual_list, browser_rows - 1, wid - max_length + 5, &attr_top, &char_left, &symbol_config.color,
+        (void)visual_mode_command('v', &visual_list, browser_rows - 1, wid - max_length + 3, &attr_top, &char_left, &symbol_config.color,
             &symbol_config.character, need_redraw);
 
         for (FEAT_IDX i = 0; i < F_LIT_MAX; i++) {
@@ -159,7 +159,7 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
             if (direct_f_idx < 0) {
                 prt(_("グループ", "Group"), 4, 0);
             }
-            prt(_("名前", "Name"), 4, max_length + 5);
+            prt(_("名前", "Name"), 4, max_length + 3);
             if (use_bigtile) {
                 if (w_ptr->wizard || visual_only) {
                     prt("Idx", 4, 62);
@@ -209,11 +209,11 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
         }
 
         if (!visual_list) {
-            display_feature_list(max_length + 5, 6, browser_rows, feat_idx.data(), feat_cur, feat_top, visual_only, F_LIT_STANDARD);
+            display_feature_list(max_length + 3, 6, browser_rows, feat_idx.data(), feat_cur, feat_top, visual_only, F_LIT_STANDARD);
         } else {
             feat_top = feat_cur;
-            display_feature_list(max_length + 5, 6, 1, feat_idx.data(), feat_cur, feat_top, visual_only, *lighting_level);
-            display_visual_list(max_length + 5, 7, browser_rows - 1, wid - max_length + 5, attr_top, char_left);
+            display_feature_list(max_length + 3, 6, 1, feat_idx.data(), feat_cur, feat_top, visual_only, *lighting_level);
+            display_visual_list(max_length + 3, 7, browser_rows - 1, wid - max_length + 3, attr_top, char_left);
         }
 
         prt(format(_("<方向>%s, 'd'で標準光源効果%s, ESC", "<dir>%s, 'd' for default lighting%s, ESC"),
@@ -225,11 +225,11 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
         auto &terrain = terrains[feat_idx[feat_cur]];
         symbol_orig = terrain.symbol_configs.at(*lighting_level);
         if (visual_list) {
-            place_visual_list_cursor(max_length + 5, 7, symbol_orig.color, static_cast<uint8_t>(symbol_orig.character), attr_top, char_left);
+            place_visual_list_cursor(max_length + 3, 7, symbol_orig.color, static_cast<uint8_t>(symbol_orig.character), attr_top, char_left);
         } else if (!column) {
             term_gotoxy(0, 6 + (grp_cur - grp_top));
         } else {
-            term_gotoxy(max_length + 5, 6 + (feat_cur - feat_top));
+            term_gotoxy(max_length + 3, 6 + (feat_cur - feat_top));
         }
 
         ch = inkey();
@@ -281,7 +281,7 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
             continue;
         }
 
-        if (visual_mode_command(ch, &visual_list, browser_rows - 1, wid - max_length + 5, &attr_top, &char_left, &symbol_orig.color, &symbol_orig.character, need_redraw)) {
+        if (visual_mode_command(ch, &visual_list, browser_rows - 1, wid - max_length + 3, &attr_top, &char_left, &symbol_orig.color, &symbol_orig.character, need_redraw)) {
             switch (ch) {
             case ESCAPE:
                 terrain.symbol_configs = symbols;

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -234,7 +234,7 @@ void do_cmd_knowledge_objects(PlayerType *player_ptr, bool *need_redraw, bool vi
     TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, std::nullopt);
 
     short object_old, object_top;
-    short grp_idx[100]{};
+    std::vector<short> grp_idx;
     int object_cnt;
 
     bool visual_list = false;
@@ -247,19 +247,16 @@ void do_cmd_knowledge_objects(PlayerType *player_ptr, bool *need_redraw, bool vi
     auto &baseitems = BaseitemList::get_instance();
     std::vector<short> object_idx(baseitems.size());
 
-    int len;
-    int max = 0;
-    int grp_cnt = 0;
+    const auto max_element = std::max_element(object_group_text.begin(), object_group_text.end(),
+        [](auto x, auto y) { return x.length() < y.length(); });
+    const int max_length = max_element->length();
+    const auto width = wid - (max_length + 3);
     if (direct_k_idx < 0) {
         mode = visual_only ? 0x03 : 0x01;
-        for (IDX i = 0; object_group_text[i] != nullptr; i++) {
-            len = strlen(object_group_text[i]);
-            if (len > max) {
-                max = len;
-            }
-
+        const auto size = static_cast<short>(object_group_text.size());
+        for (short i = 0; i < size; i++) {
             if (collect_objects(i, object_idx, mode)) {
-                grp_idx[grp_cnt++] = i;
+                grp_idx.push_back(i);
             }
         }
 
@@ -273,13 +270,11 @@ void do_cmd_knowledge_objects(PlayerType *player_ptr, bool *need_redraw, bool vi
         object_cnt = 1;
         object_idx[1] = -1;
         const auto height = browser_rows - 1;
-        const auto width = wid - (max + 3);
         auto &symbol_config = flavor_baseitem.symbol_config;
         (void)visual_mode_command(
             'v', &visual_list, height, width, &attr_top, &char_left, &symbol_config.color, &symbol_config.character, need_redraw);
     }
 
-    grp_idx[grp_cnt] = -1;
     mode = visual_only ? 0x02 : 0x00;
     IDX old_grp_cur = -1;
     IDX grp_cur = 0;
@@ -298,7 +293,7 @@ void do_cmd_knowledge_objects(PlayerType *player_ptr, bool *need_redraw, bool vi
             if (direct_k_idx < 0) {
                 prt("グループ", 4, 0);
             }
-            prt("名前", 4, max + 3);
+            prt("名前", 4, max_length + 3);
             if (w_ptr->wizard || visual_only) {
                 prt("Idx", 4, 70);
             }
@@ -308,7 +303,7 @@ void do_cmd_knowledge_objects(PlayerType *player_ptr, bool *need_redraw, bool vi
             if (direct_k_idx < 0) {
                 prt("Group", 4, 0);
             }
-            prt("Name", 4, max + 3);
+            prt("Name", 4, max_length + 3);
             if (w_ptr->wizard || visual_only) {
                 prt("Idx", 4, 70);
             }
@@ -321,7 +316,7 @@ void do_cmd_knowledge_objects(PlayerType *player_ptr, bool *need_redraw, bool vi
 
             if (direct_k_idx < 0) {
                 for (IDX i = 0; i < browser_rows; i++) {
-                    term_putch(max + 1, 6 + i, { TERM_WHITE, '|' });
+                    term_putch(max_length + 1, 6 + i, { TERM_WHITE, '|' });
                 }
             }
 
@@ -336,12 +331,8 @@ void do_cmd_knowledge_objects(PlayerType *player_ptr, bool *need_redraw, bool vi
                 grp_top = grp_cur - browser_rows + 1;
             }
 
-            std::vector<concptr> tmp_texts;
-            for (auto &text : object_group_text) {
-                tmp_texts.push_back(text);
-            }
-
-            display_group_list(0, 6, max, browser_rows, grp_idx, tmp_texts.data(), grp_cur, grp_top);
+            std::vector<std::string> tmp_texts = object_group_text;
+            display_group_list(max_length, browser_rows, grp_idx, tmp_texts, grp_cur, grp_top);
             if (old_grp_cur != grp_cur) {
                 old_grp_cur = grp_cur;
                 object_cnt = collect_objects(grp_idx[grp_cur], object_idx, mode);
@@ -357,11 +348,11 @@ void do_cmd_knowledge_objects(PlayerType *player_ptr, bool *need_redraw, bool vi
         }
 
         if (!visual_list) {
-            display_object_list(max + 3, 6, browser_rows, object_idx, object_cur, object_top, visual_only);
+            display_object_list(max_length + 3, 6, browser_rows, object_idx, object_cur, object_top, visual_only);
         } else {
             object_top = object_cur;
-            display_object_list(max + 3, 6, 1, object_idx, object_cur, object_top, visual_only);
-            display_visual_list(max + 3, 7, browser_rows - 1, wid - (max + 3), attr_top, char_left);
+            display_object_list(max_length + 3, 6, 1, object_idx, object_cur, object_top, visual_only);
+            display_visual_list(max_length + 3, 7, browser_rows - 1, wid - (max_length + 3), attr_top, char_left);
         }
 
         auto &baseitem = baseitems.get_baseitem(object_idx[object_cur]);
@@ -390,16 +381,15 @@ void do_cmd_knowledge_objects(PlayerType *player_ptr, bool *need_redraw, bool vi
 
         auto &symbol_config = flavor_baseitem.symbol_config;
         if (visual_list) {
-            place_visual_list_cursor(max + 3, 7, symbol_config.color, symbol_config.character, attr_top, char_left);
+            place_visual_list_cursor(max_length + 3, 7, symbol_config.color, symbol_config.character, attr_top, char_left);
         } else if (!column) {
             term_gotoxy(0, 6 + (grp_cur - grp_top));
         } else {
-            term_gotoxy(max + 3, 6 + (object_cur - object_top));
+            term_gotoxy(max_length + 3, 6 + (object_cur - object_top));
         }
 
         char ch = inkey();
         const auto height = browser_rows - 1;
-        const auto width = wid - (max + 3);
         if (visual_mode_command(
                 ch, &visual_list, height, width, &attr_top, &char_left, &symbol_config.color, &symbol_config.character, need_redraw)) {
             if (direct_k_idx >= 0) {
@@ -422,7 +412,7 @@ void do_cmd_knowledge_objects(PlayerType *player_ptr, bool *need_redraw, bool vi
 
         case 'R':
         case 'r': {
-            if (!visual_list && !visual_only && (grp_cnt > 0)) {
+            if (!visual_list && !visual_only && (grp_idx.size() > 0)) {
                 desc_obj_fake(player_ptr, object_idx[object_cur]);
                 redraw = true;
             }
@@ -431,7 +421,7 @@ void do_cmd_knowledge_objects(PlayerType *player_ptr, bool *need_redraw, bool vi
         }
 
         default: {
-            browser_cursor(ch, &column, &grp_cur, grp_cnt, &object_cur, object_cnt);
+            browser_cursor(ch, &column, &grp_cur, std::ssize(grp_idx), &object_cur, object_cnt);
             break;
         }
         }

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -13,7 +13,7 @@
 #include "inventory/inventory-slot-types.h"
 #include "io-dump/dump-util.h"
 #include "io/input-key-acceptor.h"
-#include "knowledge/object-group-table.h"
+#include "knowledge/item-group-table.h"
 #include "object-enchant/special-object-flags.h"
 #include "object/tval-types.h"
 #include "perception/identification.h"
@@ -147,7 +147,7 @@ static bool check_baseitem_chance(const BIT_FLAGS8 mode, const BaseitemInfo &bas
 static short collect_objects(int grp_cur, std::vector<short> &object_idx, BIT_FLAGS8 mode)
 {
     short object_cnt = 0;
-    const auto group_tval = object_group_tval[grp_cur];
+    const auto group_tval = ITEM_KINDS_GROUP[grp_cur];
     for (const auto &baseitem : BaseitemList::get_instance()) {
         if (baseitem.name.empty() || !check_baseitem_chance(mode, baseitem)) {
             continue;
@@ -247,13 +247,13 @@ void do_cmd_knowledge_objects(PlayerType *player_ptr, bool *need_redraw, bool vi
     auto &baseitems = BaseitemList::get_instance();
     std::vector<short> object_idx(baseitems.size());
 
-    const auto max_element = std::max_element(object_group_text.begin(), object_group_text.end(),
+    const auto max_element = std::max_element(ITEM_KIND_NAMES_GROUP.begin(), ITEM_KIND_NAMES_GROUP.end(),
         [](auto x, auto y) { return x.length() < y.length(); });
     const int max_length = max_element->length();
     const auto width = wid - (max_length + 3);
     if (direct_k_idx < 0) {
         mode = visual_only ? 0x03 : 0x01;
-        const auto size = static_cast<short>(object_group_text.size());
+        const auto size = static_cast<short>(ITEM_KIND_NAMES_GROUP.size());
         for (short i = 0; i < size; i++) {
             if (collect_objects(i, object_idx, mode)) {
                 grp_idx.push_back(i);
@@ -331,7 +331,7 @@ void do_cmd_knowledge_objects(PlayerType *player_ptr, bool *need_redraw, bool vi
                 grp_top = grp_cur - browser_rows + 1;
             }
 
-            std::vector<std::string> tmp_texts = object_group_text;
+            std::vector<std::string> tmp_texts = ITEM_KIND_NAMES_GROUP;
             display_group_list(max_length, browser_rows, grp_idx, tmp_texts, grp_cur, grp_top);
             if (old_grp_cur != grp_cur) {
                 old_grp_cur = grp_cur;

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -48,11 +48,11 @@
  */
 static std::vector<MonsterRaceId> collect_monsters(PlayerType *player_ptr, IDX grp_cur, monster_lore_mode mode)
 {
-    concptr group_char = monster_group_char[grp_cur];
-    bool grp_unique = (monster_group_char[grp_cur] == (char *)-1L);
-    bool grp_riding = (monster_group_char[grp_cur] == (char *)-2L);
-    bool grp_wanted = (monster_group_char[grp_cur] == (char *)-3L);
-    bool grp_amberite = (monster_group_char[grp_cur] == (char *)-4L);
+    const auto &group_char = monster_group_char[grp_cur];
+    const auto grp_unique = (monster_group_char[grp_cur] == "Uniques");
+    const auto grp_riding = (monster_group_char[grp_cur] == "Riding");
+    const auto grp_wanted = (monster_group_char[grp_cur] == "Wanted");
+    const auto grp_amberite = (monster_group_char[grp_cur] == "Amberites");
 
     const auto &monraces = MonraceList::get_instance();
     std::vector<MonsterRaceId> monrace_ids;
@@ -80,7 +80,7 @@ static std::vector<MonsterRaceId> collect_monsters(PlayerType *player_ptr, IDX g
                 continue;
             }
         } else {
-            if (angband_strchr(group_char, monrace.symbol_definition.character) == nullptr) {
+            if (angband_strchr(group_char.data(), monrace.symbol_definition.character) == nullptr) {
                 continue;
             }
         }
@@ -281,7 +281,9 @@ void do_cmd_knowledge_monsters(PlayerType *player_ptr, bool *need_redraw, bool v
     std::vector<MonsterRaceId> r_idx_list;
     std::vector<IDX> grp_idx;
 
-    int max = 0;
+    const auto max_element = std::max_element(monster_group_text.begin(), monster_group_text.end(),
+        [](const auto &x, const auto &y) { return x.length() < y.length(); });
+    const int max = max_element->length();
     bool visual_list = false;
     TERM_COLOR color_top = 0;
     byte character_left = 0;
@@ -289,14 +291,9 @@ void do_cmd_knowledge_monsters(PlayerType *player_ptr, bool *need_redraw, bool v
     const int browser_rows = hgt - 8;
     if (!direct_r_idx) {
         mode = visual_only ? MONSTER_LORE_DEBUG : MONSTER_LORE_NORMAL;
-        int len;
-        for (IDX i = 0; monster_group_text[i] != nullptr; i++) {
-            len = strlen(monster_group_text[i]);
-            if (len > max) {
-                max = len;
-            }
-
-            if ((monster_group_char[i] == ((char *)-1L)) || !collect_monsters(player_ptr, i, mode).empty()) {
+        const auto size = static_cast<short>(monster_group_text.size());
+        for (short i = 0; i < size; i++) {
+            if ((monster_group_char[i] == "Uniques") || !collect_monsters(player_ptr, i, mode).empty()) {
                 grp_idx.push_back(i);
             }
         }
@@ -308,7 +305,6 @@ void do_cmd_knowledge_monsters(PlayerType *player_ptr, bool *need_redraw, bool v
             &color_top, &character_left, &symbol_config.color, &symbol_config.character, need_redraw);
     }
 
-    grp_idx.push_back(-1); // Sentinel
     mode = visual_only ? MONSTER_LORE_RESEARCH : MONSTER_LORE_NONE;
     IDX old_grp_cur = -1;
     IDX grp_cur = 0;
@@ -356,7 +352,7 @@ void do_cmd_knowledge_monsters(PlayerType *player_ptr, bool *need_redraw, bool v
                 grp_top = grp_cur - browser_rows + 1;
             }
 
-            display_group_list(0, 6, max, browser_rows, grp_idx.data(), monster_group_text, grp_cur, grp_top);
+            display_group_list(max, browser_rows, grp_idx, monster_group_text, grp_cur, grp_top);
             if (old_grp_cur != grp_cur) {
                 old_grp_cur = grp_cur;
                 r_idx_list = collect_monsters(player_ptr, grp_idx[grp_cur], mode);
@@ -441,7 +437,7 @@ void do_cmd_knowledge_monsters(PlayerType *player_ptr, bool *need_redraw, bool v
         }
 
         default: {
-            browser_cursor(ch, &column, &grp_cur, grp_idx.size() - 1, &mon_cur, r_idx_list.size());
+            browser_cursor(ch, &column, &grp_cur, std::ssize(grp_idx), &mon_cur, r_idx_list.size());
 
             break;
         }

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -48,11 +48,11 @@
  */
 static std::vector<MonsterRaceId> collect_monsters(PlayerType *player_ptr, IDX grp_cur, monster_lore_mode mode)
 {
-    const auto &group_char = monster_group_char[grp_cur];
-    const auto grp_unique = (monster_group_char[grp_cur] == "Uniques");
-    const auto grp_riding = (monster_group_char[grp_cur] == "Riding");
-    const auto grp_wanted = (monster_group_char[grp_cur] == "Wanted");
-    const auto grp_amberite = (monster_group_char[grp_cur] == "Amberites");
+    const auto &group_char = MONRACE_CHARACTERS_GROUP[grp_cur];
+    const auto grp_unique = (MONRACE_CHARACTERS_GROUP[grp_cur] == "Uniques");
+    const auto grp_riding = (MONRACE_CHARACTERS_GROUP[grp_cur] == "Riding");
+    const auto grp_wanted = (MONRACE_CHARACTERS_GROUP[grp_cur] == "Wanted");
+    const auto grp_amberite = (MONRACE_CHARACTERS_GROUP[grp_cur] == "Amberites");
 
     const auto &monraces = MonraceList::get_instance();
     std::vector<MonsterRaceId> monrace_ids;
@@ -281,7 +281,7 @@ void do_cmd_knowledge_monsters(PlayerType *player_ptr, bool *need_redraw, bool v
     std::vector<MonsterRaceId> r_idx_list;
     std::vector<IDX> grp_idx;
 
-    const auto max_element = std::max_element(monster_group_text.begin(), monster_group_text.end(),
+    const auto max_element = std::max_element(MONSTER_KINDS_GROUP.begin(), MONSTER_KINDS_GROUP.end(),
         [](const auto &x, const auto &y) { return x.length() < y.length(); });
     const int max = max_element->length();
     bool visual_list = false;
@@ -291,9 +291,9 @@ void do_cmd_knowledge_monsters(PlayerType *player_ptr, bool *need_redraw, bool v
     const int browser_rows = hgt - 8;
     if (!direct_r_idx) {
         mode = visual_only ? MONSTER_LORE_DEBUG : MONSTER_LORE_NORMAL;
-        const auto size = static_cast<short>(monster_group_text.size());
+        const auto size = static_cast<short>(MONSTER_KINDS_GROUP.size());
         for (short i = 0; i < size; i++) {
-            if ((monster_group_char[i] == "Uniques") || !collect_monsters(player_ptr, i, mode).empty()) {
+            if ((MONRACE_CHARACTERS_GROUP[i] == "Uniques") || !collect_monsters(player_ptr, i, mode).empty()) {
                 grp_idx.push_back(i);
             }
         }
@@ -352,7 +352,7 @@ void do_cmd_knowledge_monsters(PlayerType *player_ptr, bool *need_redraw, bool v
                 grp_top = grp_cur - browser_rows + 1;
             }
 
-            display_group_list(max, browser_rows, grp_idx, monster_group_text, grp_cur, grp_top);
+            display_group_list(max, browser_rows, grp_idx, MONSTER_KINDS_GROUP, grp_cur, grp_top);
             if (old_grp_cur != grp_cur) {
                 old_grp_cur = grp_cur;
                 r_idx_list = collect_monsters(player_ptr, grp_idx[grp_cur], mode);

--- a/src/knowledge/monster-group-table.cpp
+++ b/src/knowledge/monster-group-table.cpp
@@ -5,32 +5,76 @@
  */
 
 #include "knowledge/monster-group-table.h"
+#include "locale/language-switcher.h"
 
 /*!
  * @todo 元々t (町人)がいなかったが、問題ないのか？
  * Description of each monster group.
  */
-concptr monster_group_text[] = {
-#ifdef JP
-    "ユニーク", "乗馬可能なモンスター", "賞金首", "アンバーの王族", "アリ", "コウモリ", "ムカデ", "ドラゴン", "目玉", "ネコ", "ゴーレム", "標準人間型生物",
-    "ベトベト", "ゼリー", "コボルド", "水棲生物", "モルド", "ナーガ", "オーク", "人間", "四足獣", "ネズミ", "スケルトン", "デーモン", "ボルテックス",
-    "イモムシ/大群", "イーク", "ゾンビ/ミイラ", "天使", "鳥", "犬", "エレメンタル", "トンボ", "ゴースト", "雑種", "昆虫", "ヘビ", "キラー・ビートル", "リッチ",
-    "多首の爬虫類", "謎の生物", "オーガ", "巨大人間型生物", "クイルスルグ", "爬虫類/両生類", "蜘蛛/サソリ/ダニ", "トロル", "バンパイア", "ワイト/レイス/等",
-    "ゾーン/ザレン/等", "イエティ", "ハウンド", "ミミック", "壁/植物/気体", "おばけキノコ", "球体", "プレイヤー",
-#else
-    "Uniques", "Ridable monsters", "Wanted monsters", "Amberite", "Ant", "Bat", "Centipede", "Dragon", "Floating Eye", "Feline", "Golem", "Hobbit/Elf/Dwarf",
-    "Icky Thing", "Jelly", "Kobold", "Aquatic monster", "Mold", "Naga", "Orc", "Person/Human", "Quadruped", "Rodent", "Skeleton", "Demon", "Vortex",
-    "Worm/Worm-Mass", "Yeek", "Zombie/Mummy", "Angel", "Bird", "Canine", "Elemental", "Dragon Fly", "Ghost", "Hybrid", "Insect", "Snake", "Killer Beetle",
-    "Lich", "Multi-Headed Reptile", "Mystery Living", "Ogre", "Giant Humanoid", "Quylthulg", "Reptile/Amphibian", "Spider/Scorpion/Tick", "Troll", "Vampire",
-    "Wight/Wraith/etc", "Xorn/Xaren/etc", "Yeti", "Zephyr Hound", "Mimic", "Wall/Plant/Gas", "Mushroom patch", "Ball", "Player",
-#endif
-    nullptr
+const std::vector<std::string> monster_group_text = {
+    _("ユニーク", "Uniques"),
+    _("乗馬可能なモンスター", "Ridable monsters"),
+    _("賞金首", "Wanted monsters"),
+    _("アンバーの王族", "Amberite"),
+    _("アリ", "Ant"),
+    _("コウモリ", "Bat"),
+    _("ムカデ", "Centipede"),
+    _("ドラゴン", "Dragon"),
+    _("目玉", "Floating Eye"),
+    _("ネコ", "Feline"),
+    _("ゴーレム", "Golem"),
+    _("標準人間型生物", "Hobbit/Elf/Dwarf"),
+    _("ベトベト", "Icky Thing"),
+    _("ゼリー", "Jelly"),
+    _("コボルド", "Kobold"),
+    _("水棲生物", "Aquatic monster"),
+    _("モルド", "Mold"),
+    _("ナーガ", "Naga"),
+    _("オーク", "Orc"),
+    _("人間", "Person/Human"),
+    _("四足獣", "Quadruped"),
+    _("ネズミ", "Rodent"),
+    _("スケルトン", "Skeleton"),
+    _("デーモン", "Demon"),
+    _("ボルテックス", "Vortex"),
+    _("イモムシ/大群", "Worm/Worm-Mass"),
+    _("イーク", "Yeek"),
+    _("ゾンビ/ミイラ", "Zombie/Mummy"),
+    _("天使", "Angel"),
+    _("鳥", "Bird"),
+    _("犬", "Canine"),
+    _("エレメンタル", "Elemental"),
+    _("トンボ", "Dragon Fly"),
+    _("ゴースト", "Ghost"),
+    _("雑種", "Hybrid"),
+    _("昆虫", "Insect"),
+    _("ヘビ", "Snake"),
+    _("キラー・ビートル", "Killer Beetle"),
+    _("リッチ", "Lich"),
+    _("多首の爬虫類", "Multi-Headed Reptile"),
+    _("謎の生物", "Mystery Living"),
+    _("オーガ", "Ogre"),
+    _("巨大人間型生物", "Giant Humanoid"),
+    _("クイルスルグ", "Quylthulg"),
+    _("爬虫類/両生類", "Reptile/Amphibian"),
+    _("蜘蛛/サソリ/ダニ", "Spider/Scorpion/Tick"),
+    _("トロル", "Troll"),
+    _("バンパイア", "Vampire"),
+    _("ワイト/レイス/等", "Wight/Wraith/etc"),
+    _("ゾーン/ザレン/等", "Xorn/Xaren/etc"),
+    _("イエティ", "Yeti"),
+    _("ハウンド", "Zephyr Hound"),
+    _("ミミック", "Mimic"),
+    _("壁/植物/気体", "Wall/Plant/Gas"),
+    _("おばけキノコ", "Mushroom patch"),
+    _("球体", "Ball"),
+    _("プレイヤー", "Player"),
 };
 
 /*
  * Symbols of monsters in each group. Note the "Uniques" group
  * is handled differently.
  */
-concptr monster_group_char[] = { (char *)-1L, (char *)-2L, (char *)-3L, (char *)-4L, "a", "b", "c", "dD", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o",
+const std::vector<std::string> monster_group_char = { "Uniques", "Riding", "Wanted", "Amberites", "a", "b", "c", "dD", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o",
     "pt", "q", "r", "s", "uU", "v", "w", "y", "z", "A", "B", "C", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "V", "W", "X",
-    "Y", "Z", "!$&()+./=>?[\\]`{|~", "#%", ",", "*", "@", nullptr };
+    "Y", "Z", "!$&()+./=>?[\\]`{|~", "#%", ",", "*", "@" };

--- a/src/knowledge/monster-group-table.cpp
+++ b/src/knowledge/monster-group-table.cpp
@@ -5,13 +5,12 @@
  */
 
 #include "knowledge/monster-group-table.h"
-#include "locale/language-switcher.h"
 
 /*!
- * @todo 元々t (町人)がいなかったが、問題ないのか？
- * Description of each monster group.
+ * @brief モンスターグループ表記
+ * @details 人間にはp/t 両方が含まれるなど、一部吸収合併されている (犬とハウンドは別).
  */
-const std::vector<std::string> monster_group_text = {
+const std::vector<std::string> MONSTER_KINDS_GROUP = {
     _("ユニーク", "Uniques"),
     _("乗馬可能なモンスター", "Ridable monsters"),
     _("賞金首", "Wanted monsters"),
@@ -31,7 +30,7 @@ const std::vector<std::string> monster_group_text = {
     _("モルド", "Mold"),
     _("ナーガ", "Naga"),
     _("オーク", "Orc"),
-    _("人間", "Person/Human"),
+    _("人間", "Person/Townsman"),
     _("四足獣", "Quadruped"),
     _("ネズミ", "Rodent"),
     _("スケルトン", "Skeleton"),
@@ -75,6 +74,6 @@ const std::vector<std::string> monster_group_text = {
  * Symbols of monsters in each group. Note the "Uniques" group
  * is handled differently.
  */
-const std::vector<std::string> monster_group_char = { "Uniques", "Riding", "Wanted", "Amberites", "a", "b", "c", "dD", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o",
+const std::vector<std::string> MONRACE_CHARACTERS_GROUP = { "Uniques", "Riding", "Wanted", "Amberites", "a", "b", "c", "dD", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o",
     "pt", "q", "r", "s", "uU", "v", "w", "y", "z", "A", "B", "C", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "V", "W", "X",
     "Y", "Z", "!$&()+./=>?[\\]`{|~", "#%", ",", "*", "@" };

--- a/src/knowledge/monster-group-table.h
+++ b/src/knowledge/monster-group-table.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "system/angband.h"
+#include <string>
+#include <vector>
 
-extern concptr monster_group_text[];
-extern concptr monster_group_char[];
+extern const std::vector<std::string> monster_group_text;
+extern const std::vector<std::string> monster_group_char;

--- a/src/knowledge/monster-group-table.h
+++ b/src/knowledge/monster-group-table.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include "locale/language-switcher.h" //!< ヘッダでインクルードしないと非Windows環境で日本語にならない.
 #include <string>
 #include <vector>
 
-extern const std::vector<std::string> monster_group_text;
-extern const std::vector<std::string> monster_group_char;
+extern const std::vector<std::string> MONSTER_KINDS_GROUP;
+extern const std::vector<std::string> MONRACE_CHARACTERS_GROUP;

--- a/src/knowledge/object-group-table.cpp
+++ b/src/knowledge/object-group-table.cpp
@@ -5,19 +5,20 @@
  */
 
 #include "knowledge/object-group-table.h"
+#include "locale/language-switcher.h"
 #include "object/tval-types.h"
 
 /*
  * Description of each monster group.
  */
-const std::vector<concptr> object_group_text = { _("キノコ", "Mushrooms"), _("薬", "Potions"), _("油つぼ", "Flasks"), _("巻物", "Scrolls"),
+const std::vector<std::string> object_group_text = { _("キノコ", "Mushrooms"), _("薬", "Potions"), _("油つぼ", "Flasks"), _("巻物", "Scrolls"),
     _("指輪", "Rings"), _("アミュレット", "Amulets"), _("笛", "Whistles"), _("光源", "Lanterns"), _("魔法棒", "Wands"), _("杖", "Staffs"), _("ロッド", "Rods"),
     _("カード", "Cards"), _("モンスター・ボール", "Capture Balls"), _("羊皮紙", "Parchments"), _("くさび", "Spikes"), _("箱", "Boxes"), _("人形", "Figurines"),
     _("像", "Statues"), _("ゴミ", "Junk"), _("空のビン", "Bottles"), _("骨", "Skeletons"), _("死体", "Corpses"), _("刀剣類", "Swords"),
     _("鈍器", "Blunt Weapons"), _("長柄武器", "Polearms"), _("採掘道具", "Diggers"), _("飛び道具", "Bows"), _("弾", "Shots"), _("矢", "Arrows"),
     _("ボルト", "Bolts"), _("軽装鎧", "Soft Armor"), _("重装鎧", "Hard Armor"), _("ドラゴン鎧", "Dragon Armor"), _("盾", "Shields"), _("クローク", "Cloaks"),
     _("籠手", "Gloves"), _("ヘルメット", "Helms"), _("冠", "Crowns"), _("ブーツ", "Boots"), _("魔法書", "Spellbooks"), _("財宝", "Treasure"),
-    _("何か", "Something"), nullptr };
+    _("何か", "Something") };
 
 /*
  * TVALs of items in each group
@@ -64,6 +65,5 @@ const std::vector<ItemKindType> object_group_tval = {
     ItemKindType::BOOTS,
     ItemKindType::LIFE_BOOK,
     ItemKindType::GOLD,
-    ItemKindType::NONE,
     ItemKindType::NONE,
 };

--- a/src/knowledge/object-group-table.h
+++ b/src/knowledge/object-group-table.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include <string>
-#include <vector>
-
-enum class ItemKindType : short;
-extern const std::vector<std::string> object_group_text;
-extern const std::vector<ItemKindType> object_group_tval;

--- a/src/knowledge/object-group-table.h
+++ b/src/knowledge/object-group-table.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "system/angband.h"
+#include <string>
 #include <vector>
 
 enum class ItemKindType : short;
-extern const std::vector<concptr> object_group_text;
+extern const std::vector<std::string> object_group_text;
 extern const std::vector<ItemKindType> object_group_tval;


### PR DESCRIPTION
動作確認しましたが特に問題なさそうです
display\_group\_list() の引数でgrp\_idx がありますが、vector 化したことで不要になったもののようにも見えます
欠番に対応している？ と思われますが、ひとまず残してあります
また呼び出している箇所の行/列が毎回同じなので引数からは除去しました (UI設計的に固定値で良さそう)

以上、ご確認下さい