### PR TITLE
[Fix] ターゲット比較関数がSTLのソート用比較関数の要件を満たしていない

### DIFF
--- a/src/target/target-sorter.cpp
+++ b/src/target/target-sorter.cpp
@@ -24,6 +24,10 @@ TargetSorter::TargetSorter(const Pos2D &p_pos)
  */
 bool TargetSorter::compare_importance(const FloorType &floor, const Pos2D &pos_a, const Pos2D &pos_b) const
 {
+    if (pos_a == pos_b) {
+        return false;
+    }
+
     const auto &grid1 = floor.get_grid(pos_a);
     const auto &grid2 = floor.get_grid(pos_b);
     const auto &monster_a = floor.m_list[grid1.m_idx];
@@ -126,6 +130,10 @@ bool TargetSorter::compare_importance(const FloorType &floor, const Pos2D &pos_a
  */
 bool TargetSorter::compare_distance(const Pos2D &pos_a, const Pos2D &pos_b) const
 {
+    if (pos_a == pos_b) {
+        return false;
+    }
+
     const auto distance_a = this->calc_double_distance(pos_a);
     const auto distance_b = this->calc_double_distance(pos_b);
     return distance_a < distance_b;


### PR DESCRIPTION
TargetSorter::compare_importance がSTLのソートで使用する比較関数に要求 される `a < a == false` を満たしていないため、場合によってはデバッグ用ビルドのアサーションにひっかかることがある。
最初に2つの引数が同じかどうかをチェックし同じなら false を返すようにして、要件を満たすようにする。
TargetSorter::compare_distance に関しては要件を満たしていたが、同じ位置であれば距離を計算する必要もないのでこちらも先に引数が同じかをチェックする。

PR #4162 でのエンバグに対する修正のため、単独のIssueは無しです。