### PR TITLE
[Fix] 呪術魔法の我慢が正常に機能していない

### DIFF
--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -493,11 +493,13 @@ void MonsterAttackPlayer::increase_blow_type_seen(const int ap_cnt)
 
 void MonsterAttackPlayer::postprocess_monster_blows()
 {
-    SpellHex spell_hex(this->player_ptr, this);
+    SpellHex spell_hex(this->player_ptr);
     spell_hex.store_vengeful_damage(this->get_damage);
-    spell_hex.eyes_on_eyes();
+    spell_hex.eyes_on_eyes(this->m_idx, this->get_damage);
     musou_counterattack(this->player_ptr, this);
-    spell_hex.thief_teleport();
+    if (this->blinked && this->alive) {
+        spell_hex.thief_teleport(this->m_idx);
+    }
     auto *r_ptr = &this->m_ptr->get_monrace();
     if (this->player_ptr->is_dead && (r_ptr->r_deaths < MAX_SHORT) && !this->player_ptr->current_floor_ptr->inside_arena) {
         r_ptr->r_deaths++;

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -40,6 +40,7 @@
 #include "player/player-damage.h"
 #include "player/player-skill.h"
 #include "player/special-defense-types.h"
+#include "spell-kind/spells-teleport.h"
 #include "spell-realm/spells-hex.h"
 #include "status/action-setter.h"
 #include "status/bad-status-setter.h"
@@ -497,9 +498,7 @@ void MonsterAttackPlayer::postprocess_monster_blows()
     spell_hex.store_vengeful_damage(this->get_damage);
     spell_hex.eyes_on_eyes(this->m_idx, this->get_damage);
     musou_counterattack(this->player_ptr, this);
-    if (this->blinked && this->alive) {
-        spell_hex.thief_teleport(this->m_idx);
-    }
+    this->process_thief_teleport(spell_hex);
     auto *r_ptr = &this->m_ptr->get_monrace();
     if (this->player_ptr->is_dead && (r_ptr->r_deaths < MAX_SHORT) && !this->player_ptr->current_floor_ptr->inside_arena) {
         r_ptr->r_deaths++;
@@ -511,4 +510,18 @@ void MonsterAttackPlayer::postprocess_monster_blows()
     }
 
     PlayerClass(this->player_ptr).break_samurai_stance({ SamuraiStanceType::IAI });
+}
+
+void MonsterAttackPlayer::process_thief_teleport(const SpellHex &spell_hex)
+{
+    if (!this->blinked || !this->alive || this->player_ptr->is_dead) {
+        return;
+    }
+
+    if (spell_hex.check_hex_barrier(this->m_idx, HEX_ANTI_TELE)) {
+        msg_print(_("泥棒は笑って逃げ...ようとしたがバリアに防がれた。", "The thief flees laughing...? But a magic barrier obstructs it."));
+    } else {
+        msg_print(_("泥棒は笑って逃げた！", "The thief flees laughing!"));
+        teleport_away(this->player_ptr, this->m_idx, MAX_PLAYER_SIGHT * 2 + 5, TELEPORT_SPONTANEOUS);
+    }
 }

--- a/src/monster-attack/monster-attack-player.h
+++ b/src/monster-attack/monster-attack-player.h
@@ -5,6 +5,7 @@
 enum class RaceBlowEffectType;
 enum class RaceBlowMethodType;
 class PlayerType;
+class SpellHex;
 class MonsterEntity;
 class ItemEntity;
 class MonsterAttackPlayer {
@@ -58,4 +59,5 @@ private:
     void gain_armor_exp();
     void increase_blow_type_seen(const int ap_cnt);
     void postprocess_monster_blows();
+    void process_thief_teleport(const SpellHex &spell_hex);
 };

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -3,8 +3,9 @@
 #include "core/window-redrawer.h"
 #include "effect/effect-characteristics.h"
 #include "effect/effect-processor.h"
-#include "monster-attack/monster-attack-player.h"
 #include "monster-race/monster-race.h"
+#include "monster/monster-describer.h"
+#include "monster/monster-description-types.h"
 #include "player-base/player-class.h"
 #include "player-info/spell-hex-data-type.h"
 #include "player/attack-defense-types.h"
@@ -27,11 +28,6 @@
 #include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
-#ifdef JP
-#else
-#include "monster/monster-describer.h"
-#include "monster/monster-description-types.h"
-#endif
 
 /*!< 呪術の最大詠唱数 */
 constexpr int MAX_KEEP = 4;
@@ -49,12 +45,6 @@ SpellHex::SpellHex(PlayerType *player_ptr)
     if (this->casting_spells.size() > MAX_KEEP) {
         THROW_EXCEPTION(std::logic_error, "Invalid numbers of hex magics keep!");
     }
-}
-
-SpellHex::SpellHex(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
-    : player_ptr(player_ptr)
-    , monap_ptr(monap_ptr)
-{
 }
 
 /*!
@@ -374,49 +364,43 @@ void SpellHex::interrupt_spelling()
 
 /*!
  * @brief 呪術「目には目を」の効果処理
- * @param this->player_ptr プレイヤーへの参照ポインタ
- * @param monap_ptr モンスターからプレイヤーへの直接攻撃構造体への参照ポインタ
+ * @param m_idx モンスターのインデックス
+ * @param dam プレイヤーが受けたダメージ
  */
-void SpellHex::eyes_on_eyes()
+void SpellHex::eyes_on_eyes(MONSTER_IDX m_idx, int dam)
 {
-    if (this->monap_ptr == nullptr) {
-        THROW_EXCEPTION(std::logic_error, "Invalid constructor was used!");
-    }
-
     const auto is_eyeeye_finished = (this->player_ptr->tim_eyeeye == 0) && !this->is_spelling_specific(HEX_EYE_FOR_EYE);
-    if (is_eyeeye_finished || (this->monap_ptr->get_damage == 0) || this->player_ptr->is_dead) {
+    if (is_eyeeye_finished || (dam == 0) || this->player_ptr->is_dead) {
         return;
     }
 
+    const auto &monster = this->player_ptr->current_floor_ptr->m_list[m_idx];
+    const auto m_name = monster_desc(this->player_ptr, &monster, 0);
 #ifdef JP
-    msg_format("攻撃が%s自身を傷つけた！", this->monap_ptr->m_name);
+    msg_format("攻撃が%s自身を傷つけた！", m_name.data());
 #else
-    const auto m_name_self = monster_desc(this->player_ptr, this->monap_ptr->m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE | MD_OBJECTIVE);
-    msg_format("The attack of %s has wounded %s!", this->monap_ptr->m_name, m_name_self.data());
+    const auto m_name_self = monster_desc(this->player_ptr, &monster, MD_PRON_VISIBLE | MD_POSSESSIVE | MD_OBJECTIVE);
+    msg_format("The attack of %s has wounded %s!", m_name.data(), m_name_self.data());
 #endif
-    const auto y = this->monap_ptr->m_ptr->fy;
-    const auto x = this->monap_ptr->m_ptr->fx;
-    project(this->player_ptr, 0, 0, y, x, this->monap_ptr->get_damage, AttributeType::MISSILE, PROJECT_KILL);
+    const auto y = monster.fy;
+    const auto x = monster.fx;
+    project(this->player_ptr, 0, 0, y, x, dam, AttributeType::MISSILE, PROJECT_KILL);
     if (this->player_ptr->tim_eyeeye) {
         set_tim_eyeeye(this->player_ptr, this->player_ptr->tim_eyeeye - 5, true);
     }
 }
 
-void SpellHex::thief_teleport()
+void SpellHex::thief_teleport(MONSTER_IDX m_idx)
 {
-    if (this->monap_ptr == nullptr) {
-        THROW_EXCEPTION(std::logic_error, "Invalid constructor was used!");
-    }
-
-    if (!this->monap_ptr->blinked || !this->monap_ptr->alive || this->player_ptr->is_dead) {
+    if (this->player_ptr->is_dead) {
         return;
     }
 
-    if (this->check_hex_barrier(this->monap_ptr->m_idx, HEX_ANTI_TELE)) {
+    if (this->check_hex_barrier(m_idx, HEX_ANTI_TELE)) {
         msg_print(_("泥棒は笑って逃げ...ようとしたがバリアに防がれた。", "The thief flees laughing...? But a magic barrier obstructs it."));
     } else {
         msg_print(_("泥棒は笑って逃げた！", "The thief flees laughing!"));
-        teleport_away(this->player_ptr, this->monap_ptr->m_idx, MAX_PLAYER_SIGHT * 2 + 5, TELEPORT_SPONTANEOUS);
+        teleport_away(this->player_ptr, m_idx, MAX_PLAYER_SIGHT * 2 + 5, TELEPORT_SPONTANEOUS);
     }
 }
 

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -11,7 +11,6 @@
 #include "player/attack-defense-types.h"
 #include "player/player-skill.h"
 #include "realm/realm-hex-numbers.h"
-#include "spell-kind/spells-teleport.h"
 #include "spell-realm/spells-crusade.h"
 #include "spell-realm/spells-song.h"
 #include "spell/spell-info.h"
@@ -387,20 +386,6 @@ void SpellHex::eyes_on_eyes(MONSTER_IDX m_idx, int dam)
     project(this->player_ptr, 0, 0, y, x, dam, AttributeType::MISSILE, PROJECT_KILL);
     if (this->player_ptr->tim_eyeeye) {
         set_tim_eyeeye(this->player_ptr, this->player_ptr->tim_eyeeye - 5, true);
-    }
-}
-
-void SpellHex::thief_teleport(MONSTER_IDX m_idx)
-{
-    if (this->player_ptr->is_dead) {
-        return;
-    }
-
-    if (this->check_hex_barrier(m_idx, HEX_ANTI_TELE)) {
-        msg_print(_("泥棒は笑って逃げ...ようとしたがバリアに防がれた。", "The thief flees laughing...? But a magic barrier obstructs it."));
-    } else {
-        msg_print(_("泥棒は笑って逃げた！", "The thief flees laughing!"));
-        teleport_away(this->player_ptr, m_idx, MAX_PLAYER_SIGHT * 2 + 5, TELEPORT_SPONTANEOUS);
     }
 }
 

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -30,7 +30,6 @@ public:
     bool is_spelling_any() const;
     void interrupt_spelling();
     void eyes_on_eyes(MONSTER_IDX, int dam);
-    void thief_teleport(MONSTER_IDX m_idx);
     void set_casting_flag(spell_hex_type type);
     void reset_casting_flag(spell_hex_type type);
     int32_t get_casting_num() const;

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -12,13 +12,11 @@ enum class SpellHexRevengeType : byte {
     REVENGE = 2,
 };
 
-class MonsterAttackPlayer;
 class PlayerType;
 struct spell_hex_data_type;
 class SpellHex {
 public:
     SpellHex(PlayerType *player_ptr);
-    SpellHex(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr);
     virtual ~SpellHex() = default;
 
     bool stop_spells_with_selection();
@@ -31,8 +29,8 @@ public:
     bool is_spelling_specific(int hex) const;
     bool is_spelling_any() const;
     void interrupt_spelling();
-    void eyes_on_eyes();
-    void thief_teleport();
+    void eyes_on_eyes(MONSTER_IDX, int dam);
+    void thief_teleport(MONSTER_IDX m_idx);
     void set_casting_flag(spell_hex_type type);
     void reset_casting_flag(spell_hex_type type);
     int32_t get_casting_num() const;
@@ -46,7 +44,6 @@ public:
 private:
     PlayerType *player_ptr;
     std::vector<int> casting_spells;
-    MonsterAttackPlayer *monap_ptr = nullptr;
     std::shared_ptr<spell_hex_data_type> spell_hex_data;
 
     std::pair<bool, std::optional<char>> select_spell_stopping(std::string_view prompt);


### PR DESCRIPTION
Resolves #4181 

SpellHexクラスのMonsterAttackPlayer*を第2引数に受け取るコンストラクタでメンバ変数spell_hex_dataを正しく初期化していないため、このコンストラクタで生成したオブジェクト経由では正しくダメージが蓄積されない。
これが原因で、モンスターの直接攻撃によるダメージが我慢の反撃ダメージに蓄積されていなかった。
また、魔法やブレスによる攻撃はこのコンストラクタを使用していないため正しく蓄積が機能していた。
そもそもMonsterAttackPlayer*をメンバに持つほどの必要性が感じられないので、このコンストラクタを削除し、現在MonsterAttackPlayer*を使用しているメソッドには直接必要な引数を渡すようにする。
