### PR TITLE
FloorChangeModesStore クラスを作ってPlayerType::change_floor_mode を廃止した

### DIFF
--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -155,12 +155,12 @@ void do_cmd_go_up(PlayerType *player_ptr)
         player_ptr->current_floor_ptr->dun_level = 0;
         up_num = 0;
     } else {
+        auto &fcms = FloorChangeModesStore::get_instace();
+        fcms->set({ FloorChangeMode::SAVE_FLOORS, FloorChangeMode::UP });
+        up_num = 1;
         if (terrain.flags.has(TerrainCharacteristics::SHAFT)) {
-            prepare_change_floor_mode(player_ptr, CFM_SAVE_FLOORS | CFM_UP | CFM_SHAFT);
-            up_num = 2;
-        } else {
-            prepare_change_floor_mode(player_ptr, CFM_SAVE_FLOORS | CFM_UP);
-            up_num = 1;
+            fcms->set(FloorChangeMode::SHAFT);
+            up_num *= 2;
         }
 
         if (player_ptr->current_floor_ptr->dun_level - up_num < floor.get_dungeon_definition().mindepth) {
@@ -260,6 +260,7 @@ void do_cmd_go_down(PlayerType *player_ptr)
     }
 
     short target_dungeon = 0;
+    auto &fcms = FloorChangeModesStore::get_instace();
     if (!floor.is_in_underground()) {
         target_dungeon = terrain.flags.has(TerrainCharacteristics::ENTRANCE) ? grid.special : DUNGEON_ANGBAND;
         if (ironman_downward && (target_dungeon != DUNGEON_ANGBAND)) {
@@ -279,7 +280,7 @@ void do_cmd_go_down(PlayerType *player_ptr)
         player_ptr->oldpx = player_ptr->x;
         player_ptr->oldpy = player_ptr->y;
         floor.set_dungeon_index(target_dungeon);
-        prepare_change_floor_mode(player_ptr, CFM_FIRST_FLOOR);
+        fcms->set(FloorChangeMode::FIRST_FLOOR);
     }
 
     PlayerEnergy(player_ptr).set_player_turn_energy(100);
@@ -326,14 +327,13 @@ void do_cmd_go_down(PlayerType *player_ptr)
     player_ptr->leaving = true;
 
     if (fall_trap) {
-        prepare_change_floor_mode(player_ptr, CFM_SAVE_FLOORS | CFM_DOWN | CFM_RAND_PLACE | CFM_RAND_CONNECT);
+        fcms->set({ FloorChangeMode::SAVE_FLOORS, FloorChangeMode::DOWN, FloorChangeMode::RANDOM_PLACE, FloorChangeMode::RANDOM_CONNECT });
         return;
     }
 
+    fcms->set({ FloorChangeMode::SAVE_FLOORS, FloorChangeMode::DOWN });
     if (terrain.flags.has(TerrainCharacteristics::SHAFT)) {
-        prepare_change_floor_mode(player_ptr, CFM_SAVE_FLOORS | CFM_DOWN | CFM_SHAFT);
-    } else {
-        prepare_change_floor_mode(player_ptr, CFM_SAVE_FLOORS | CFM_DOWN);
+        fcms->set(FloorChangeMode::SHAFT);
     }
 }
 

--- a/src/cmd-building/cmd-building.cpp
+++ b/src/cmd-building/cmd-building.cpp
@@ -337,11 +337,12 @@ void do_cmd_building(PlayerType *player_ptr)
         return;
     }
 
+    auto &fcms = FloorChangeModesStore::get_instace();
     if ((which == 2) && player_ptr->current_floor_ptr->inside_arena) {
         if (!w_ptr->get_arena() && player_ptr->current_floor_ptr->m_cnt > 0) {
             prt(_("ゲートは閉まっている。モンスターがあなたを待っている！", "The gates are closed.  The monster awaits!"), 0, 0);
         } else {
-            prepare_change_floor_mode(player_ptr, CFM_SAVE_FLOORS | CFM_NO_RETURN);
+            fcms->set({ FloorChangeMode::SAVE_FLOORS, FloorChangeMode::NO_RETURN });
             player_ptr->current_floor_ptr->inside_arena = false;
             player_ptr->leaving = true;
             command_new = SPECIAL_KEY_BUILDING;
@@ -355,7 +356,7 @@ void do_cmd_building(PlayerType *player_ptr)
 
     auto &system = AngbandSystem::get_instance();
     if (system.is_phase_out()) {
-        prepare_change_floor_mode(player_ptr, CFM_SAVE_FLOORS | CFM_NO_RETURN);
+        fcms->set({ FloorChangeMode::SAVE_FLOORS, FloorChangeMode::NO_RETURN });
         player_ptr->leaving = true;
         system.set_phase_out(false);
         command_new = SPECIAL_KEY_BUILDING;

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -166,9 +166,9 @@ static void init_random_seed(PlayerType *player_ptr, bool new_game)
         new_game = true;
         w_ptr->character_dungeon = false;
         init_random_seed = true;
-        init_saved_floors(player_ptr, false);
+        init_saved_floors(false);
     } else if (new_game) {
-        init_saved_floors(player_ptr, true);
+        init_saved_floors(true);
     }
 
     if (!new_game) {

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -360,7 +360,7 @@ static void decide_arena_death(PlayerType *player_ptr)
     player_ptr->chp_frac = 0;
     w_ptr->set_arena(true);
     reset_tim_flags(player_ptr);
-    prepare_change_floor_mode(player_ptr, CFM_SAVE_FLOORS | CFM_RAND_CONNECT);
+    FloorChangeModesStore::get_instace()->set({ FloorChangeMode::SAVE_FLOORS, FloorChangeMode::RANDOM_CONNECT });
     leave_floor(player_ptr);
 }
 

--- a/src/dungeon/quest.cpp
+++ b/src/dungeon/quest.cpp
@@ -375,7 +375,7 @@ void leave_quest_check(PlayerType *player_ptr)
         break;
     case QuestKindType::RANDOM:
         monraces_info[quest.r_idx].misc_flags.reset(MonsterMiscType::QUESTOR);
-        prepare_change_floor_mode(player_ptr, CFM_NO_RETURN);
+        FloorChangeModesStore::get_instace()->set(FloorChangeMode::NO_RETURN);
         break;
     default:
         break;

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -209,25 +209,26 @@ static bool is_visited_floor(saved_floor_type *sf_ptr)
 
 /*!
  * @brief フロア読込時にプレイヤー足元の地形に必要な情報を設定する
- * @params player_ptr プレイヤーへの参照ポインタ
+ * @param floor フロアへの参照
+ * @param p_pos プレイヤーの現在位置
  */
-static void set_player_grid(PlayerType *player_ptr)
+static void set_player_grid(FloorType &floor, const Pos2D &p_pos)
 {
     const auto &fcms = FloorChangeModesStore::get_instace();
     if (fcms->has_not(FloorChangeMode::NO_RETURN)) {
         return;
     }
 
-    auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x];
-    if (feat_uses_special(g_ptr->feat)) {
+    auto &grid = floor.get_grid(p_pos);
+    if (feat_uses_special(grid.feat)) {
         return;
     }
 
     if (fcms->has_any_of({ FloorChangeMode::DOWN, FloorChangeMode::UP })) {
-        g_ptr->feat = rand_choice(feat_ground_type);
+        grid.feat = rand_choice(feat_ground_type);
     }
 
-    g_ptr->special = 0;
+    grid.special = 0;
 }
 
 static void update_floor_id(PlayerType *player_ptr, saved_floor_type *sf_ptr)
@@ -402,7 +403,7 @@ static void update_floor(PlayerType *player_ptr)
     saved_floor_type *sf_ptr;
     sf_ptr = get_sf_ptr(new_floor_id);
     const bool loaded = is_visited_floor(sf_ptr) && load_floor(player_ptr, sf_ptr, 0);
-    set_player_grid(player_ptr);
+    set_player_grid(*player_ptr->current_floor_ptr, player_ptr->get_position());
     update_floor_id(player_ptr, sf_ptr);
 
     if (loaded) {

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -143,19 +143,20 @@ static void preserve_pet(PlayerType *player_ptr)
  * @brief 新フロアに移動元フロアに繋がる階段を配置する / Virtually teleport onto the stairs that is connecting between two floors.
  * @param sf_ptr 移動元の保存フロア構造体参照ポインタ
  */
-static void locate_connected_stairs(PlayerType *player_ptr, FloorType *floor_ptr, saved_floor_type *sf_ptr, BIT_FLAGS floor_mode)
+static void locate_connected_stairs(PlayerType *player_ptr, FloorType *floor_ptr, saved_floor_type *sf_ptr)
 {
     auto sx = 0;
     auto sy = 0;
     int x_table[20]{};
     int y_table[20]{};
     auto num = 0;
+    const auto &fcms = FloorChangeModesStore::get_instace();
     for (POSITION y = 0; y < floor_ptr->height; y++) {
         for (POSITION x = 0; x < floor_ptr->width; x++) {
             const auto &grid = floor_ptr->get_grid({ y, x });
             const auto &terrain = grid.get_terrain();
             auto ok = false;
-            if (floor_mode & CFM_UP) {
+            if (fcms->has(FloorChangeMode::UP)) {
                 if (terrain.flags.has_all_of({ TerrainCharacteristics::LESS, TerrainCharacteristics::STAIRS }) && terrain.flags.has_not(TerrainCharacteristics::SPECIAL)) {
                     ok = true;
                     if (grid.special && grid.special == sf_ptr->upper_floor_id) {
@@ -163,7 +164,7 @@ static void locate_connected_stairs(PlayerType *player_ptr, FloorType *floor_ptr
                         sy = y;
                     }
                 }
-            } else if (floor_mode & CFM_DOWN) {
+            } else if (fcms->has(FloorChangeMode::DOWN)) {
                 if (terrain.flags.has_all_of({ TerrainCharacteristics::MORE, TerrainCharacteristics::STAIRS }) && terrain.flags.has_not(TerrainCharacteristics::SPECIAL)) {
                     ok = true;
                     if (grid.special && grid.special == sf_ptr->lower_floor_id) {
@@ -192,7 +193,7 @@ static void locate_connected_stairs(PlayerType *player_ptr, FloorType *floor_ptr
     }
 
     if (num == 0) {
-        prepare_change_floor_mode(player_ptr, CFM_RAND_PLACE | CFM_NO_RETURN);
+        FloorChangeModesStore::get_instace()->set({ FloorChangeMode::RANDOM_PLACE, FloorChangeMode::NO_RETURN });
         if (!feat_uses_special(floor_ptr->grid_array[player_ptr->y][player_ptr->x].feat)) {
             floor_ptr->grid_array[player_ptr->y][player_ptr->x].special = 0;
         }
@@ -294,7 +295,7 @@ static void preserve_info(PlayerType *player_ptr)
 
 static Grid *set_grid_by_leaving_floor(PlayerType *player_ptr)
 {
-    if ((player_ptr->change_floor_mode & CFM_SAVE_FLOORS) == 0) {
+    if (FloorChangeModesStore::get_instace()->has_not(FloorChangeMode::SAVE_FLOORS)) {
         return nullptr;
     }
 
@@ -305,7 +306,7 @@ static Grid *set_grid_by_leaving_floor(PlayerType *player_ptr)
     }
 
     if (terrain.flags.has_all_of({ TerrainCharacteristics::STAIRS, TerrainCharacteristics::SHAFT })) {
-        prepare_change_floor_mode(player_ptr, CFM_SHAFT);
+        FloorChangeModesStore::get_instace()->set(FloorChangeMode::SHAFT);
     }
 
     return g_ptr;
@@ -313,29 +314,29 @@ static Grid *set_grid_by_leaving_floor(PlayerType *player_ptr)
 
 static void jump_floors(PlayerType *player_ptr)
 {
-    const auto mode = player_ptr->change_floor_mode;
-    if (none_bits(mode, CFM_DOWN | CFM_UP)) {
+    const auto &fcms = FloorChangeModesStore::get_instace();
+    if (fcms->has_none_of({ FloorChangeMode::DOWN, FloorChangeMode::UP })) {
         return;
     }
 
     auto move_num = 0;
-    if (any_bits(mode, CFM_DOWN)) {
+    if (fcms->has(FloorChangeMode::DOWN)) {
         move_num = 1;
-    } else if (any_bits(mode, CFM_UP)) {
+    } else if (fcms->has(FloorChangeMode::UP)) {
         move_num = -1;
     }
 
-    if (any_bits(mode, CFM_SHAFT)) {
+    if (fcms->has(FloorChangeMode::SHAFT)) {
         move_num *= 2;
     }
 
     auto &floor = *player_ptr->current_floor_ptr;
     const auto &dungeon = floor.get_dungeon_definition();
-    if (any_bits(mode, CFM_DOWN)) {
+    if (fcms->has(FloorChangeMode::DOWN)) {
         if (!floor.is_in_underground()) {
             move_num = dungeon.mindepth;
         }
-    } else if (any_bits(mode, CFM_UP)) {
+    } else if (fcms->has(FloorChangeMode::UP)) {
         if (floor.dun_level + move_num < dungeon.mindepth) {
             move_num = -floor.dun_level;
         }
@@ -344,6 +345,7 @@ static void jump_floors(PlayerType *player_ptr)
     floor.dun_level += move_num;
 }
 
+//!< @details SAVE_FLOORS フラグを抜く箇所に「TODO」のコメントがあった、何をするかは書いておらず詳細不明
 static void exit_to_wilderness(PlayerType *player_ptr)
 {
     auto &floor = *player_ptr->current_floor_ptr;
@@ -361,12 +363,13 @@ static void exit_to_wilderness(PlayerType *player_ptr)
     player_ptr->recall_dungeon = floor.dungeon_idx;
     player_ptr->word_recall = 0;
     floor.reset_dungeon_index();
-    player_ptr->change_floor_mode &= ~CFM_SAVE_FLOORS; // TODO
+    FloorChangeModesStore::get_instace()->reset(FloorChangeMode::SAVE_FLOORS);
 }
 
 static void kill_saved_floors(PlayerType *player_ptr, saved_floor_type *sf_ptr)
 {
-    if (!(player_ptr->change_floor_mode & CFM_SAVE_FLOORS)) {
+    const auto &fcms = FloorChangeModesStore::get_instace();
+    if (fcms->has_not(FloorChangeMode::SAVE_FLOORS)) {
         for (DUNGEON_IDX i = 0; i < MAX_SAVED_FLOORS; i++) {
             kill_saved_floor(player_ptr, &saved_floors[i]);
         }
@@ -374,7 +377,7 @@ static void kill_saved_floors(PlayerType *player_ptr, saved_floor_type *sf_ptr)
         latest_visit_mark = 1;
         return;
     }
-    if (player_ptr->change_floor_mode & CFM_NO_RETURN) {
+    if (fcms->has(FloorChangeMode::NO_RETURN)) {
         kill_saved_floor(player_ptr, sf_ptr);
     }
 }
@@ -393,13 +396,14 @@ static void refresh_new_floor_id(PlayerType *player_ptr, Grid *g_ptr)
 
 static void update_upper_lower_or_floor_id(PlayerType *player_ptr, saved_floor_type *sf_ptr)
 {
-    if ((player_ptr->change_floor_mode & CFM_RAND_CONNECT) == 0) {
+    const auto &fcms = FloorChangeModesStore::get_instace();
+    if (fcms->has_not(FloorChangeMode::RANDOM_CONNECT)) {
         return;
     }
 
-    if (player_ptr->change_floor_mode & CFM_UP) {
+    if (fcms->has(FloorChangeMode::UP)) {
         sf_ptr->upper_floor_id = new_floor_id;
-    } else if (player_ptr->change_floor_mode & CFM_DOWN) {
+    } else if (fcms->has(FloorChangeMode::DOWN)) {
         sf_ptr->lower_floor_id = new_floor_id;
     }
 }
@@ -416,7 +420,8 @@ static void exe_leave_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr)
 
     refresh_new_floor_id(player_ptr, g_ptr);
     update_upper_lower_or_floor_id(player_ptr, sf_ptr);
-    if (((player_ptr->change_floor_mode & CFM_SAVE_FLOORS) == 0) || ((player_ptr->change_floor_mode & CFM_NO_RETURN) != 0)) {
+    auto &fcms = FloorChangeModesStore::get_instace();
+    if (fcms->has_not(FloorChangeMode::SAVE_FLOORS) || fcms->has(FloorChangeMode::NO_RETURN)) {
         return;
     }
 
@@ -429,7 +434,7 @@ static void exe_leave_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr)
         return;
     }
 
-    prepare_change_floor_mode(player_ptr, CFM_NO_RETURN);
+    fcms->set(FloorChangeMode::NO_RETURN);
     kill_saved_floor(player_ptr, get_sf_ptr(player_ptr->floor_id));
 }
 
@@ -448,8 +453,8 @@ void leave_floor(PlayerType *player_ptr)
 
     preserve_info(player_ptr);
     saved_floor_type *sf_ptr = get_sf_ptr(player_ptr->floor_id);
-    if (player_ptr->change_floor_mode & CFM_RAND_CONNECT) {
-        locate_connected_stairs(player_ptr, player_ptr->current_floor_ptr, sf_ptr, player_ptr->change_floor_mode);
+    if (FloorChangeModesStore::get_instace()->has(FloorChangeMode::RANDOM_CONNECT)) {
+        locate_connected_stairs(player_ptr, player_ptr->current_floor_ptr, sf_ptr);
     }
 
     exe_leave_floor(player_ptr, sf_ptr);

--- a/src/floor/floor-mode-changer.cpp
+++ b/src/floor/floor-mode-changer.cpp
@@ -1,15 +1,4 @@
 #include "floor/floor-mode-changer.h"
-#include "system/player-type-definition.h"
-
-/*!
- * @brief フロア切り替え時の処理フラグを追加する / Prepare mode flags of changing floor
- * @param player_ptr プレイヤーへの参照ポインタ
- * @param mode 追加したい所持フラグ
- */
-void prepare_change_floor_mode(PlayerType *player_ptr, BIT_FLAGS mode)
-{
-    player_ptr->change_floor_mode |= mode;
-}
 
 FloorChangeModesStore FloorChangeModesStore::instance{};
 

--- a/src/floor/floor-mode-changer.cpp
+++ b/src/floor/floor-mode-changer.cpp
@@ -17,3 +17,13 @@ FloorChangeModesStore &FloorChangeModesStore::get_instace()
 {
     return instance;
 }
+
+EnumClassFlagGroup<FloorChangeMode> *FloorChangeModesStore::operator->()
+{
+    return &this->flag_change_modes;
+}
+
+const EnumClassFlagGroup<FloorChangeMode> *FloorChangeModesStore::operator->() const
+{
+    return &this->flag_change_modes;
+}

--- a/src/floor/floor-mode-changer.cpp
+++ b/src/floor/floor-mode-changer.cpp
@@ -10,3 +10,10 @@ void prepare_change_floor_mode(PlayerType *player_ptr, BIT_FLAGS mode)
 {
     player_ptr->change_floor_mode |= mode;
 }
+
+FloorChangeModesStore FloorChangeModesStore::instance{};
+
+FloorChangeModesStore &FloorChangeModesStore::get_instace()
+{
+    return instance;
+}

--- a/src/floor/floor-mode-changer.h
+++ b/src/floor/floor-mode-changer.h
@@ -22,6 +22,18 @@ enum cfm_type {
 class PlayerType;
 void prepare_change_floor_mode(PlayerType *player_ptr, BIT_FLAGS mode);
 
+enum class FloorChangeMode : short {
+    UP, //!< 上のフロアへ行く (階層は浅くなる).
+    DOWN, //!< 下のフロアへ行く (階層は深くなる).
+    SHAFT, //!< 坑道である (2階層分移動する).
+    RANDOM_PLACE, //!< 移動先フロアにランダム配置される.
+    RANDOM_CONNECT, //!< 移動先フロアの階段にランダム接続される.
+    SAVE_FLOORS, //!< 保存済フロアに移動する.
+    NO_RETURN, //!< 帰還などで移動元に戻らない.
+    FIRST_FLOOR, //!< 荒野からダンジョンの一番浅い階層に移動する.
+    MAX,
+};
+
 class FloorChangeModesStore {
 public:
     ~FloorChangeModesStore() = default;
@@ -31,7 +43,12 @@ public:
     FloorChangeModesStore &operator=(FloorChangeModesStore &&) = delete;
     static FloorChangeModesStore &get_instace();
 
+    EnumClassFlagGroup<FloorChangeMode> *operator->();
+    const EnumClassFlagGroup<FloorChangeMode> *operator->() const;
+
 private:
     static FloorChangeModesStore instance;
     FloorChangeModesStore() = default;
+
+    EnumClassFlagGroup<FloorChangeMode> flag_change_modes;
 };

--- a/src/floor/floor-mode-changer.h
+++ b/src/floor/floor-mode-changer.h
@@ -3,25 +3,6 @@
 #include "system/angband.h"
 #include "util/flag-group.h"
 
-/*!
- * @enum フロア切り替えモードのbit設定 / Change Floor Mode.
- */
-enum cfm_type {
-    CFM_UP = 0x0001, /*!< 上の階層に上る / Move up */
-    CFM_DOWN = 0x0002, /*!< 下の階層に下る /  Move down */
-    CFM_XXX1 = 0x0004, /*!< 未実装 / unused */
-    CFM_XXX2 = 0x0008, /*!< 未実装 / unused */
-    CFM_SHAFT = 0x0010, /*!< 坑道である(2階層分移動する) / Shaft */
-    CFM_RAND_PLACE = 0x0020, /*!< 移動先フロアにランダム配置される / Arrive at random grid */
-    CFM_RAND_CONNECT = 0x0040, /*!< 移動先フロアの階段にランダムに接続する / Connect with random stairs */
-    CFM_SAVE_FLOORS = 0x0080, /*!< 保存済フロアに移動する / Save floors */
-    CFM_NO_RETURN = 0x0100, /*!< 移動元に戻す手段が失われる / Flee from random quest etc... */
-    CFM_FIRST_FLOOR = 0x0200, /*!< ダンジョンに入った最初のフロアである / Create exit from the dungeon */
-};
-
-class PlayerType;
-void prepare_change_floor_mode(PlayerType *player_ptr, BIT_FLAGS mode);
-
 enum class FloorChangeMode : short {
     UP, //!< 上のフロアへ行く (階層は浅くなる).
     DOWN, //!< 下のフロアへ行く (階層は深くなる).

--- a/src/floor/floor-mode-changer.h
+++ b/src/floor/floor-mode-changer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "system/angband.h"
+#include "util/flag-group.h"
 
 /*!
  * @enum フロア切り替えモードのbit設定 / Change Floor Mode.
@@ -20,3 +21,17 @@ enum cfm_type {
 
 class PlayerType;
 void prepare_change_floor_mode(PlayerType *player_ptr, BIT_FLAGS mode);
+
+class FloorChangeModesStore {
+public:
+    ~FloorChangeModesStore() = default;
+    FloorChangeModesStore(const FloorChangeModesStore &) = delete;
+    FloorChangeModesStore(FloorChangeModesStore &&) = delete;
+    FloorChangeModesStore &operator=(const FloorChangeModesStore &) = delete;
+    FloorChangeModesStore &operator=(FloorChangeModesStore &&) = delete;
+    static FloorChangeModesStore &get_instace();
+
+private:
+    static FloorChangeModesStore instance;
+    FloorChangeModesStore() = default;
+};

--- a/src/floor/floor-save.cpp
+++ b/src/floor/floor-save.cpp
@@ -61,7 +61,7 @@ static void check_saved_tmp_files(const int fd, bool *force)
  * @param force テンポラリファイルが残っていた場合も警告なしで強制的に削除するフラグ
  * @details Make sure that old temporary files are not remaining as gurbages.
  */
-void init_saved_floors(PlayerType *player_ptr, bool force)
+void init_saved_floors(bool force)
 {
     auto fd = -1;
     for (int i = 0; i < MAX_SAVED_FLOORS; i++) {

--- a/src/floor/floor-save.cpp
+++ b/src/floor/floor-save.cpp
@@ -11,6 +11,7 @@
 
 #include "floor/floor-save.h"
 #include "core/asking-player.h"
+#include "floor/floor-mode-changer.h"
 #include "floor/floor-save-util.h"
 #include "io/files-util.h"
 #include "io/uid-checker.h"
@@ -80,7 +81,7 @@ void init_saved_floors(PlayerType *player_ptr, bool force)
     latest_visit_mark = 1;
     saved_floor_file_sign = (uint32_t)time(nullptr);
     new_floor_id = 0;
-    player_ptr->change_floor_mode = 0;
+    FloorChangeModesStore::get_instace()->clear();
 }
 
 /*!

--- a/src/floor/floor-save.h
+++ b/src/floor/floor-save.h
@@ -4,7 +4,7 @@
 
 class PlayerType;
 struct saved_floor_type;
-void init_saved_floors(PlayerType *player_ptr, bool force);
+void init_saved_floors(bool force);
 void clear_saved_floor_files(PlayerType *player_ptr);
 saved_floor_type *get_sf_ptr(FLOOR_IDX floor_id);
 void kill_saved_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr);

--- a/src/floor/pattern-walk.cpp
+++ b/src/floor/pattern-walk.cpp
@@ -91,7 +91,7 @@ void pattern_teleport(PlayerType *player_ptr)
      * Clear all saved floors
      * and create a first saved floor
      */
-    prepare_change_floor_mode(player_ptr, CFM_FIRST_FLOOR);
+    FloorChangeModesStore::get_instace()->set(FloorChangeMode::FIRST_FLOOR);
 
     check_random_quest_auto_failure(player_ptr);
 

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -418,7 +418,7 @@ void hit_trap(PlayerType *player_ptr, bool break_trap)
             }
 
             exe_write_diary(player_ptr, DiaryKind::DESCRIPTION, 0, _("落とし戸に落ちた", "fell through a trap door!"));
-            prepare_change_floor_mode(player_ptr, CFM_SAVE_FLOORS | CFM_DOWN | CFM_RAND_PLACE | CFM_RAND_CONNECT);
+            FloorChangeModesStore::get_instace()->set({ FloorChangeMode::SAVE_FLOORS, FloorChangeMode::DOWN, FloorChangeMode::RANDOM_PLACE, FloorChangeMode::RANDOM_CONNECT });
             player_ptr->leaving = true;
         }
         break;

--- a/src/load/dungeon-loader.cpp
+++ b/src/load/dungeon-loader.cpp
@@ -26,7 +26,7 @@
  */
 static errr rd_dungeon(PlayerType *player_ptr)
 {
-    init_saved_floors(player_ptr, false);
+    init_saved_floors(false);
     errr err = 0;
     auto &floor = *player_ptr->current_floor_ptr;
     if (h_older_than(1, 5, 0, 0)) {

--- a/src/market/arena.cpp
+++ b/src/market/arena.cpp
@@ -99,10 +99,7 @@ static bool check_battle_metal_babble(PlayerType *player_ptr)
 
     w_ptr->set_arena(false);
     reset_tim_flags(player_ptr);
-
-    /* Save the surface floor as saved floor */
-    prepare_change_floor_mode(player_ptr, CFM_SAVE_FLOORS);
-
+    FloorChangeModesStore::get_instace()->set(FloorChangeMode::SAVE_FLOORS);
     player_ptr->current_floor_ptr->inside_arena = true;
     player_ptr->leaving = true;
     return true;
@@ -138,8 +135,7 @@ static bool go_to_arena(PlayerType *player_ptr)
 
     w_ptr->set_arena(false);
     reset_tim_flags(player_ptr);
-    prepare_change_floor_mode(player_ptr, CFM_SAVE_FLOORS);
-
+    FloorChangeModesStore::get_instace()->set(FloorChangeMode::SAVE_FLOORS);
     player_ptr->current_floor_ptr->inside_arena = true;
     player_ptr->leaving = true;
     return true;
@@ -368,7 +364,7 @@ bool monster_arena_comm(PlayerType *player_ptr)
     player_ptr->au -= *wager;
     reset_tim_flags(player_ptr);
 
-    prepare_change_floor_mode(player_ptr, CFM_SAVE_FLOORS);
+    FloorChangeModesStore::get_instace()->set(FloorChangeMode::SAVE_FLOORS);
     AngbandSystem::get_instance().set_phase_out(true);
     player_ptr->leaving = true;
     screen_load();

--- a/src/monster-floor/monster-safety-hiding.cpp
+++ b/src/monster-floor/monster-safety-hiding.cpp
@@ -32,7 +32,7 @@
  */
 static coordinate_candidate sweep_safe_coordinate(PlayerType *player_ptr, MONSTER_IDX m_idx, const POSITION *y_offsets, const POSITION *x_offsets, int d)
 {
-    coordinate_candidate candidate = init_coordinate_candidate();
+    coordinate_candidate candidate;
     auto *floor_ptr = player_ptr->current_floor_ptr;
     auto *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
     for (POSITION i = 0, dx = x_offsets[0], dy = y_offsets[0]; dx != 0 || dy != 0; i++, dx = x_offsets[i], dy = y_offsets[i]) {
@@ -173,7 +173,7 @@ static void sweep_hiding_candidate(
 bool find_hiding(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION *yp, POSITION *xp)
 {
     auto *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
-    coordinate_candidate candidate = init_coordinate_candidate();
+    coordinate_candidate candidate;
     candidate.gdis = 999;
 
     for (POSITION d = 1; d < 10; d++) {

--- a/src/monster/monster-processor-util.cpp
+++ b/src/monster/monster-processor-util.cpp
@@ -35,19 +35,6 @@ turn_flags *init_turn_flags(MONSTER_IDX riding_idx, MONSTER_IDX m_idx, turn_flag
     turn_flags_ptr->did_kill_wall = false;
     return turn_flags_ptr;
 }
-/*!
- * @brief coordinate_candidate の初期化
- * @param なし
- * @return 初期化済の構造体
- */
-coordinate_candidate init_coordinate_candidate(void)
-{
-    coordinate_candidate candidate;
-    candidate.gy = 0;
-    candidate.gx = 0;
-    candidate.gdis = 0;
-    return candidate;
-}
 
 /*!
  * @brief モンスターの移動方向を保存する

--- a/src/monster/monster-processor-util.h
+++ b/src/monster/monster-processor-util.h
@@ -58,14 +58,13 @@ struct old_race_flags {
 };
 
 struct coordinate_candidate {
-    POSITION gy;
-    POSITION gx;
-    POSITION gdis;
+    POSITION gy = 0;
+    POSITION gx = 0;
+    int gdis = 0;
 };
 
 class MonsterEntity;
 turn_flags *init_turn_flags(MONSTER_IDX riding_idx, MONSTER_IDX m_idx, turn_flags *turn_flags_ptr);
-coordinate_candidate init_coordinate_candidate();
 
 void store_enemy_approch_direction(int *mm, POSITION y, POSITION x);
 void store_moves_val(int *mm, int y, int x);

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -91,6 +91,7 @@ void teleport_level(PlayerType *player_ptr, MONSTER_IDX m_idx)
     }
 
     const auto &dungeon = floor.get_dungeon_definition();
+    auto &fcms = FloorChangeModesStore::get_instace();
     if ((ironman_downward && (m_idx <= 0)) || (floor.dun_level <= dungeon.mindepth)) {
 #ifdef JP
         if (see_m) {
@@ -116,12 +117,12 @@ void teleport_level(PlayerType *player_ptr, MONSTER_IDX m_idx)
                 do_cmd_save_game(player_ptr, true);
             }
 
+            fcms->set(FloorChangeMode::RANDOM_PLACE);
             if (!floor.is_in_underground()) {
                 const auto &recall_dungeon = floor.get_dungeon_definition();
                 floor.dun_level = recall_dungeon.mindepth;
-                prepare_change_floor_mode(player_ptr, CFM_RAND_PLACE);
             } else {
-                prepare_change_floor_mode(player_ptr, CFM_SAVE_FLOORS | CFM_DOWN | CFM_RAND_PLACE | CFM_RAND_CONNECT);
+                fcms->set({ FloorChangeMode::SAVE_FLOORS, FloorChangeMode::DOWN, FloorChangeMode::RANDOM_CONNECT });
             }
 
             player_ptr->leaving = true;
@@ -146,8 +147,7 @@ void teleport_level(PlayerType *player_ptr, MONSTER_IDX m_idx)
                 do_cmd_save_game(player_ptr, true);
             }
 
-            prepare_change_floor_mode(player_ptr, CFM_SAVE_FLOORS | CFM_UP | CFM_RAND_PLACE | CFM_RAND_CONNECT);
-
+            fcms->set({ FloorChangeMode::SAVE_FLOORS, FloorChangeMode::UP, FloorChangeMode::RANDOM_PLACE, FloorChangeMode::RANDOM_CONNECT });
             leave_quest_check(player_ptr);
             floor.quest_number = QuestId::NONE;
             player_ptr->leaving = true;
@@ -172,7 +172,7 @@ void teleport_level(PlayerType *player_ptr, MONSTER_IDX m_idx)
                 do_cmd_save_game(player_ptr, true);
             }
 
-            prepare_change_floor_mode(player_ptr, CFM_SAVE_FLOORS | CFM_UP | CFM_RAND_PLACE | CFM_RAND_CONNECT);
+            fcms->set({ FloorChangeMode::SAVE_FLOORS, FloorChangeMode::UP, FloorChangeMode::RANDOM_PLACE, FloorChangeMode::RANDOM_CONNECT });
             player_ptr->leaving = true;
         }
     } else {
@@ -194,7 +194,7 @@ void teleport_level(PlayerType *player_ptr, MONSTER_IDX m_idx)
                 do_cmd_save_game(player_ptr, true);
             }
 
-            prepare_change_floor_mode(player_ptr, CFM_SAVE_FLOORS | CFM_DOWN | CFM_RAND_PLACE | CFM_RAND_CONNECT);
+            fcms->set({ FloorChangeMode::SAVE_FLOORS, FloorChangeMode::DOWN, FloorChangeMode::RANDOM_PLACE, FloorChangeMode::RANDOM_CONNECT });
             player_ptr->leaving = true;
         }
     }

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -194,7 +194,6 @@ public:
     bool is_dead{}; /* Player is dead */
     bool now_damaged{};
     bool ambush_flag{};
-    BIT_FLAGS change_floor_mode{}; /*!<フロア移行処理に関するフラグ / Mode flags for changing floor */
 
     MONSTER_IDX riding{}; /* Riding on a monster of this index */
 

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -504,7 +504,8 @@ static void wiz_jump_floor(PlayerType *player_ptr, DUNGEON_IDX dun_idx, DEPTH de
     auto &floor = *player_ptr->current_floor_ptr;
     floor.set_dungeon_index(dun_idx);
     floor.dun_level = depth;
-    prepare_change_floor_mode(player_ptr, CFM_RAND_PLACE);
+    auto &fcms = FloorChangeModesStore::get_instace();
+    fcms->set(FloorChangeMode::RANDOM_PLACE);
     if (!floor.is_in_underground()) {
         floor.reset_dungeon_index();
     }
@@ -520,7 +521,7 @@ static void wiz_jump_floor(PlayerType *player_ptr, DUNGEON_IDX dun_idx, DEPTH de
     floor.quest_number = QuestId::NONE;
     PlayerEnergy(player_ptr).reset_player_turn();
     player_ptr->energy_need = 0;
-    prepare_change_floor_mode(player_ptr, CFM_FIRST_FLOOR);
+    fcms->set(FloorChangeMode::FIRST_FLOOR);
     player_ptr->leaving = true;
 }
 

--- a/src/world/world-movement-processor.cpp
+++ b/src/world/world-movement-processor.cpp
@@ -127,7 +127,7 @@ void execute_recall(PlayerType *player_ptr)
      * Clear all saved floors
      * and create a first saved floor
      */
-    prepare_change_floor_mode(player_ptr, CFM_FIRST_FLOOR);
+    FloorChangeModesStore::get_instace()->set(FloorChangeMode::FIRST_FLOOR);
     player_ptr->leaving = true;
 
     check_random_quest_auto_failure(player_ptr);
@@ -159,12 +159,7 @@ void execute_floor_reset(PlayerType *player_ptr)
     disturb(player_ptr, false, true);
     if (!inside_quest(floor.get_quest_id()) && floor.dun_level) {
         msg_print(_("世界が変わった！", "The world changes!"));
-
-        /*
-         * Clear all saved floors
-         * and create a first saved floor
-         */
-        prepare_change_floor_mode(player_ptr, CFM_FIRST_FLOOR);
+        FloorChangeModesStore::get_instace()->set(FloorChangeMode::FIRST_FLOOR);
         player_ptr->leaving = true;
     } else {
         msg_print(_("世界が少しの間変化したようだ。", "The world seems to change for a moment!"));

--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -128,7 +128,7 @@ void WorldTurnProcessor::process_downward()
 
     floor_ptr->dun_level = 0;
     floor_ptr->reset_dungeon_index();
-    prepare_change_floor_mode(this->player_ptr, CFM_FIRST_FLOOR | CFM_RAND_PLACE);
+    FloorChangeModesStore::get_instace()->set({ FloorChangeMode::FIRST_FLOOR, FloorChangeMode::RANDOM_PLACE });
     floor_ptr->inside_arena = false;
     this->player_ptr->wild_mode = false;
     this->player_ptr->leaving = true;


### PR DESCRIPTION
掲題の通りです
イーク洞に入り、階段・坑道・フロア保存 (1F⇔2F、1F⇔3F)・ダンジョン出入り周りの動作をチェック済です
ご確認下さい