### PR TITLE
[Refactor] strnfmtとvstrnfmtをそれぞれformatとvformatで置き換える

### DIFF
--- a/src/autopick/autopick-editor-command.cpp
+++ b/src/autopick/autopick-editor-command.cpp
@@ -555,8 +555,7 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
         if (!can_insert_line(tb, 2)) {
             break;
         }
-        char expression[80];
-        strnfmt(expression, sizeof(expression), "?:[AND [EQU $RACE %s] [EQU $CLASS %s] [GEQ $LEVEL %02d]]",
+        const auto expression = format("?:[AND [EQU $RACE %s] [EQU $CLASS %s] [GEQ $LEVEL %02d]]",
 #ifdef JP
             rp_ptr->E_title, cp_ptr->E_title,
 #else
@@ -566,7 +565,7 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
         tb->cx = 0;
         insert_return_code(tb);
         string_free(tb->lines_list[tb->cy]);
-        tb->lines_list[tb->cy] = string_make(expression);
+        tb->lines_list[tb->cy] = string_make(expression.data());
         tb->cy++;
         insert_return_code(tb);
         string_free(tb->lines_list[tb->cy]);

--- a/src/birth/auto-roller.cpp
+++ b/src/birth/auto-roller.cpp
@@ -171,24 +171,22 @@ static std::string cursor_of_adjusted_stat(const int *cval, int cs)
 {
     auto j = rp_ptr->r_adj[cs] + cp_ptr->c_adj[cs] + ap_ptr->a_adj[cs];
     auto m = adjust_stat(17, j);
-    char maxv[20];
+    std::string maxv;
     if (m > 18) {
-        strnfmt(maxv, sizeof(maxv), "18/%02d", (m - 18));
+        maxv = format("18/%02d", (m - 18));
     } else {
-        strnfmt(maxv, sizeof(maxv), "%2d", m);
+        maxv = format("%2d", m);
     }
 
     m = adjust_stat(cval[cs], j);
-    char inp[20];
+    std::string inp;
     if (m > 18) {
-        strnfmt(inp, sizeof(inp), "18/%02d", (m - 18));
+        inp = format("18/%02d", (m - 18));
     } else {
-        strnfmt(inp, sizeof(inp), "%2d", m);
+        inp = format("%2d", m);
     }
 
-    char cur[60];
-    strnfmt(cur, sizeof(cur), "%6s       %2d   %+3d  %+3d  %+3d  =  %6s  %6s", stat_names[cs], cval[cs], rp_ptr->r_adj[cs], cp_ptr->c_adj[cs], ap_ptr->a_adj[cs], inp, maxv);
-    return cur;
+    return format("%6s       %2d   %+3d  %+3d  %+3d  =  %6s  %6s", stat_names[cs], cval[cs], rp_ptr->r_adj[cs], cp_ptr->c_adj[cs], ap_ptr->a_adj[cs], inp.data(), maxv.data());
 }
 
 /*!
@@ -197,16 +195,14 @@ static std::string cursor_of_adjusted_stat(const int *cval, int cs)
  */
 static void display_autoroller_chance(int *cval)
 {
-    concptr buf;
-    char work[60];
+    std::string buf;
     autoroll_chance = get_autoroller_prob(cval);
     if (autoroll_chance == -999) {
         buf = _("確率: 不可能(合計86超)       ", "Prob: Impossible(>86 tot stats)");
     } else if (autoroll_chance < 1) {
         buf = _("確率: 非常に容易(1/10000以上)", "Prob: Quite Easy(>1/10000)     ");
     } else {
-        strnfmt(work, sizeof(work), _("確率: 約 1/%8d00             ", "Prob: ~ 1/%8d00                "), autoroll_chance);
-        buf = work;
+        buf = format(_("確率: 約 1/%8d00             ", "Prob: ~ 1/%8d00                "), autoroll_chance);
     }
     put_str(buf, 23, 25);
 }
@@ -455,16 +451,15 @@ bool get_chara_limits(PlayerType *player_ptr, chara_limit_type *chara_limit_ptr)
     }
 
     for (int i = 0; i < 4; i++) {
-        char buf[40];
-        strnfmt(buf, sizeof(buf), "%-12s (%3d - %3d)", itemname[i], mval[i * 2], mval[i * 2 + 1]);
+        auto buf = format("%-12s (%3d - %3d)", itemname[i], mval[i * 2], mval[i * 2 + 1]);
         put_str(buf, 14 + i, 20);
         for (int j = 0; j < 2; j++) {
-            strnfmt(buf, sizeof(buf), "     %3d", cval[i * 2 + j]);
+            buf = format("     %3d", cval[i * 2 + j]);
             put_str(buf, 14 + i, 45 + 8 * j);
         }
     }
 
-    char cur[40] = "";
+    std::string cur;
     int cs = 0;
     int os = MAXITEMS;
     while (true) {
@@ -479,7 +474,7 @@ bool get_chara_limits(PlayerType *player_ptr, chara_limit_type *chara_limit_ptr)
             if (cs == MAXITEMS) {
                 c_put_str(TERM_YELLOW, accept, 19, 35);
             } else {
-                strnfmt(cur, sizeof(cur), "     %3d", cval[cs]);
+                cur = format("     %3d", cval[cs]);
                 c_put_str(TERM_YELLOW, cur, 14 + cs / 2, 45 + 8 * (cs % 2));
             }
 

--- a/src/birth/birth-select-class.cpp
+++ b/src/birth/birth-select-class.cpp
@@ -68,21 +68,21 @@ static std::string display_class_stat(int cs, int *os, const std::string &cur, c
         c_put_str(TERM_L_BLUE, cp_ptr->title, 3, 40);
         put_str(_("の職業修正", ": Class modification"), 3, 40 + strlen(cp_ptr->title));
         put_str(_("腕力 知能 賢さ 器用 耐久 魅力 経験 ", "Str  Int  Wis  Dex  Con  Chr   EXP "), 4, 40);
-        char buf[80];
-        strnfmt(buf, sizeof(buf), "%+3d  %+3d  %+3d  %+3d  %+3d  %+3d %+4d%% ", cp_ptr->c_adj[0], cp_ptr->c_adj[1], cp_ptr->c_adj[2], cp_ptr->c_adj[3], cp_ptr->c_adj[4], cp_ptr->c_adj[5], cp_ptr->c_exp);
-        c_put_str(TERM_L_BLUE, buf, 5, 40);
+        const auto stats = format("%+3d  %+3d  %+3d  %+3d  %+3d  %+3d %+4d%% ", cp_ptr->c_adj[0], cp_ptr->c_adj[1], cp_ptr->c_adj[2], cp_ptr->c_adj[3], cp_ptr->c_adj[4], cp_ptr->c_adj[5], cp_ptr->c_exp);
+        c_put_str(TERM_L_BLUE, stats, 5, 40);
 
         put_str("HD", 6, 40);
-        strnfmt(buf, sizeof(buf), "%+3d", cp_ptr->c_mhp);
-        c_put_str(TERM_L_BLUE, buf, 6, 42);
+        const auto hd = format("%+3d", cp_ptr->c_mhp);
+        c_put_str(TERM_L_BLUE, hd, 6, 42);
 
         put_str(_("隠密", "Stealth"), 6, 47);
+        std::string stealth;
         if (i2enum<PlayerClassType>(cs) == PlayerClassType::BERSERKER) {
-            angband_strcpy(buf, " xx", sizeof(buf));
+            stealth = " xx";
         } else {
-            strnfmt(buf, sizeof(buf), " %+2d", cp_ptr->c_stl);
+            stealth = format(" %+2d", cp_ptr->c_stl);
         }
-        c_put_str(TERM_L_BLUE, buf, 6, _(51, 54));
+        c_put_str(TERM_L_BLUE, stealth, 6, _(51, 54));
     }
 
     c_put_str(TERM_YELLOW, result, 13 + (cs / 4), 2 + 19 * (cs % 4));
@@ -136,8 +136,7 @@ static bool select_class(PlayerType *player_ptr, concptr sym, int *k)
             break;
         }
 
-        char buf[80];
-        strnfmt(buf, sizeof(buf), _("職業を選んで下さい (%c-%c) ('='初期オプション設定, 灰色:勝利済): ", "Choose a class (%c-%c) ('=' for options, Gray is winner): "), sym[0], sym[PLAYER_CLASS_TYPE_MAX - 1]);
+        const auto buf = format(_("職業を選んで下さい (%c-%c) ('='初期オプション設定, 灰色:勝利済): ", "Choose a class (%c-%c) ('=' for options, Gray is winner): "), sym[0], sym[PLAYER_CLASS_TYPE_MAX - 1]);
 
         put_str(buf, 10, 6);
         char c = inkey();

--- a/src/birth/birth-select-personality.cpp
+++ b/src/birth/birth-select-personality.cpp
@@ -59,17 +59,16 @@ static std::string display_personality_stat(int cs, int *os, const std::string &
         c_put_str(TERM_L_BLUE, ap_ptr->title, 3, 40);
         put_str(_("の性格修正", ": Personality modification"), 3, 40 + strlen(ap_ptr->title));
         put_str(_("腕力 知能 賢さ 器用 耐久 魅力      ", "Str  Int  Wis  Dex  Con  Chr       "), 4, 40);
-        char buf[80];
-        strnfmt(buf, sizeof(buf), "%+3d  %+3d  %+3d  %+3d  %+3d  %+3d       ", ap_ptr->a_adj[0], ap_ptr->a_adj[1], ap_ptr->a_adj[2], ap_ptr->a_adj[3], ap_ptr->a_adj[4], ap_ptr->a_adj[5]);
-        c_put_str(TERM_L_BLUE, buf, 5, 40);
+        const auto stats = format("%+3d  %+3d  %+3d  %+3d  %+3d  %+3d       ", ap_ptr->a_adj[0], ap_ptr->a_adj[1], ap_ptr->a_adj[2], ap_ptr->a_adj[3], ap_ptr->a_adj[4], ap_ptr->a_adj[5]);
+        c_put_str(TERM_L_BLUE, stats, 5, 40);
 
         put_str("HD", 6, 40);
-        strnfmt(buf, sizeof(buf), "%+3d", ap_ptr->a_mhp);
-        c_put_str(TERM_L_BLUE, buf, 6, 42);
+        const auto hd = format("%+3d", ap_ptr->a_mhp);
+        c_put_str(TERM_L_BLUE, hd, 6, 42);
 
         put_str(_("隠密", "Stealth"), 6, 47);
-        strnfmt(buf, sizeof(buf), "%+3d", ap_ptr->a_stl);
-        c_put_str(TERM_L_BLUE, buf, 6, _(51, 54));
+        const auto stealth = format("%+3d", ap_ptr->a_stl);
+        c_put_str(TERM_L_BLUE, stealth, 6, _(51, 54));
     }
 
     c_put_str(TERM_YELLOW, result, 12 + (cs / 4), 2 + 18 * (cs % 4));
@@ -167,8 +166,7 @@ static bool select_personality(PlayerType *player_ptr, int *k, concptr sym)
             break;
         }
 
-        char buf[80];
-        strnfmt(buf, sizeof(buf), _("性格を選んで下さい (%c-%c) ('='初期オプション設定): ", "Choose a personality (%c-%c) ('=' for options): "), sym[0], sym[MAX_PERSONALITIES - 1]);
+        const auto buf = format(_("性格を選んで下さい (%c-%c) ('='初期オプション設定): ", "Choose a personality (%c-%c) ('=' for options): "), sym[0], sym[MAX_PERSONALITIES - 1]);
         put_str(buf, 10, 10);
         char c = inkey();
         if (c == 'Q') {

--- a/src/birth/birth-select-race.cpp
+++ b/src/birth/birth-select-race.cpp
@@ -57,21 +57,20 @@ static std::string display_race_stat(int cs, int *os, const std::string &cur, co
         put_str(_("腕力 知能 賢さ 器用 耐久 魅力 経験 ", "Str  Int  Wis  Dex  Con  Chr   EXP "), 4, 40);
         put_str(_("の種族修正", ": Race modification"), 3, 40 + strlen(rp_ptr->title));
 
-        char buf[80];
-        strnfmt(buf, sizeof(buf), "%+3d  %+3d  %+3d  %+3d  %+3d  %+3d %+4d%% ", rp_ptr->r_adj[0], rp_ptr->r_adj[1], rp_ptr->r_adj[2], rp_ptr->r_adj[3], rp_ptr->r_adj[4], rp_ptr->r_adj[5], (rp_ptr->r_exp - 100));
-        c_put_str(TERM_L_BLUE, buf, 5, 40);
+        const auto stats = format("%+3d  %+3d  %+3d  %+3d  %+3d  %+3d %+4d%% ", rp_ptr->r_adj[0], rp_ptr->r_adj[1], rp_ptr->r_adj[2], rp_ptr->r_adj[3], rp_ptr->r_adj[4], rp_ptr->r_adj[5], (rp_ptr->r_exp - 100));
+        c_put_str(TERM_L_BLUE, stats, 5, 40);
 
         put_str("HD ", 6, 40);
-        strnfmt(buf, sizeof(buf), "%2d", rp_ptr->r_mhp);
-        c_put_str(TERM_L_BLUE, buf, 6, 43);
+        const auto hd = format("%2d", rp_ptr->r_mhp);
+        c_put_str(TERM_L_BLUE, hd, 6, 43);
 
         put_str(_("隠密", "Stealth"), 6, 47);
-        strnfmt(buf, sizeof(buf), "%+2d", rp_ptr->r_stl);
-        c_put_str(TERM_L_BLUE, buf, 6, _(52, 55));
+        const auto stealth = format("%+2d", rp_ptr->r_stl);
+        c_put_str(TERM_L_BLUE, stealth, 6, _(52, 55));
 
         put_str(_("赤外線視力", "Infra"), 6, _(56, 59));
-        strnfmt(buf, sizeof(buf), _("%2dft", "%2dft"), 10 * rp_ptr->infra);
-        c_put_str(TERM_L_BLUE, buf, 6, _(67, 65));
+        const auto infra = format(_("%2dft", "%2dft"), 10 * rp_ptr->infra);
+        c_put_str(TERM_L_BLUE, infra, 6, _(67, 65));
     }
 
     c_put_str(TERM_YELLOW, result, 12 + (cs / 5), 1 + 16 * (cs % 5));
@@ -117,8 +116,7 @@ static bool select_race(PlayerType *player_ptr, char *sym, int *k)
             break;
         }
 
-        char buf[80];
-        strnfmt(buf, sizeof(buf), _("種族を選んで下さい (%c-%c) ('='初期オプション設定): ", "Choose a race (%c-%c) ('=' for options): "), sym[0], sym[MAX_RACES - 1]);
+        const auto buf = format(_("種族を選んで下さい (%c-%c) ('='初期オプション設定): ", "Choose a race (%c-%c) ('=' for options): "), sym[0], sym[MAX_RACES - 1]);
         put_str(buf, 10, 10);
         char c = inkey();
         if (c == 'Q') {

--- a/src/birth/birth-select-realm.cpp
+++ b/src/birth/birth-select-realm.cpp
@@ -13,6 +13,7 @@
 #include "term/z-form.h"
 #include "util/int-char-converter.h"
 #include "view/display-util.h"
+#include <string>
 
 static const byte REALM_SELECT_CANCEL = 255;
 
@@ -21,9 +22,8 @@ struct birth_realm_type {
     int n;
     char p2;
     char sym[VALID_REALM];
-    char buf[80];
     int picks[VALID_REALM];
-    char cur[80];
+    std::string cur;
     int k;
     int os;
 };
@@ -150,8 +150,8 @@ static void analyze_realms(const PlayerType *player_ptr, const uint32_t choices,
 
         birth_realm_ptr->sym[birth_realm_ptr->n] = I2A(birth_realm_ptr->n);
 
-        strnfmt(birth_realm_ptr->buf, sizeof(birth_realm_ptr->buf), "%c%c %s", birth_realm_ptr->sym[birth_realm_ptr->n], birth_realm_ptr->p2, realm_names[i + 1]);
-        put_str(birth_realm_ptr->buf, 12 + (birth_realm_ptr->n / 5), 2 + 15 * (birth_realm_ptr->n % 5));
+        const auto buf = format("%c%c %s", birth_realm_ptr->sym[birth_realm_ptr->n], birth_realm_ptr->p2, realm_names[i + 1]);
+        put_str(buf, 12 + (birth_realm_ptr->n / 5), 2 + 15 * (birth_realm_ptr->n % 5));
         birth_realm_ptr->picks[birth_realm_ptr->n++] = i + 1;
     }
 }
@@ -165,13 +165,13 @@ static void move_birth_realm_cursor(birth_realm_type *birth_realm_ptr)
     c_put_str(TERM_WHITE, birth_realm_ptr->cur, 12 + (birth_realm_ptr->os / 5), 2 + 15 * (birth_realm_ptr->os % 5));
 
     if (birth_realm_ptr->cs == birth_realm_ptr->n) {
-        strnfmt(birth_realm_ptr->cur, sizeof(birth_realm_ptr->cur), "%c%c %s", '*', birth_realm_ptr->p2, _("ランダム", "Random"));
+        birth_realm_ptr->cur = format("%c%c %s", '*', birth_realm_ptr->p2, _("ランダム", "Random"));
     } else {
-        strnfmt(birth_realm_ptr->cur, sizeof(birth_realm_ptr->cur), "%c%c %s", birth_realm_ptr->sym[birth_realm_ptr->cs], birth_realm_ptr->p2,
+        birth_realm_ptr->cur = format("%c%c %s", birth_realm_ptr->sym[birth_realm_ptr->cs], birth_realm_ptr->p2,
             realm_names[birth_realm_ptr->picks[birth_realm_ptr->cs]]);
-        strnfmt(birth_realm_ptr->buf, sizeof(birth_realm_ptr->buf), "%s", realm_names[birth_realm_ptr->picks[birth_realm_ptr->cs]]);
-        c_put_str(TERM_L_BLUE, birth_realm_ptr->buf, 3, 40);
-        prt(_("の特徴", ": Characteristic"), 3, 40 + strlen(birth_realm_ptr->buf));
+        const auto buf = format("%s", realm_names[birth_realm_ptr->picks[birth_realm_ptr->cs]]);
+        c_put_str(TERM_L_BLUE, buf, 3, 40);
+        prt(_("の特徴", ": Characteristic"), 3, 40 + buf.length());
         prt(realm_subinfo[technic2magic(birth_realm_ptr->picks[birth_realm_ptr->cs]) - 1], 4, 40);
     }
 
@@ -219,10 +219,10 @@ static bool get_a_realm(PlayerType *player_ptr, birth_realm_type *birth_realm_pt
             break;
         }
 
-        strnfmt(birth_realm_ptr->buf, sizeof(birth_realm_ptr->buf), _("領域を選んで下さい(%c-%c) ('='初期オプション設定): ", "Choose a realm (%c-%c) ('=' for options): "),
+        const auto buf = format(_("領域を選んで下さい(%c-%c) ('='初期オプション設定): ", "Choose a realm (%c-%c) ('=' for options): "),
             birth_realm_ptr->sym[0], birth_realm_ptr->sym[birth_realm_ptr->n - 1]);
 
-        put_str(birth_realm_ptr->buf, 10, 10);
+        put_str(buf, 10, 10);
         char c = inkey();
         interpret_realm_select_key(birth_realm_ptr, c);
         if (c == 'S') {
@@ -286,7 +286,7 @@ static byte select_realm(PlayerType *player_ptr, uint32_t choices, int *count)
     birth_realm_type tmp_birth_realm;
     birth_realm_type *birth_realm_ptr = initialize_birth_realm_type(&tmp_birth_realm);
     analyze_realms(player_ptr, choices, birth_realm_ptr);
-    strnfmt(birth_realm_ptr->cur, sizeof(birth_realm_ptr->cur), "%c%c %s", '*', birth_realm_ptr->p2, _("ランダム", "Random"));
+    birth_realm_ptr->cur = format("%c%c %s", '*', birth_realm_ptr->p2, _("ランダム", "Random"));
     if (get_a_realm(player_ptr, birth_realm_ptr)) {
         return REALM_SELECT_CANCEL;
     }

--- a/src/birth/birth-wizard.cpp
+++ b/src/birth/birth-wizard.cpp
@@ -128,8 +128,7 @@ static bool get_player_sex(PlayerType *player_ptr)
             break;
         }
 
-        char buf[80];
-        strnfmt(buf, sizeof(buf), _("性別を選んで下さい (%c-%c) ('='初期オプション設定): ", "Choose a sex (%c-%c) ('=' for options): "), I2A(0), I2A(1));
+        const auto buf = format(_("性別を選んで下さい (%c-%c) ('='初期オプション設定): ", "Choose a sex (%c-%c) ('=' for options): "), I2A(0), I2A(1));
         put_str(buf, 10, 10);
         char c = inkey();
         if (c == 'Q') {
@@ -283,23 +282,24 @@ static void display_initial_options(PlayerType *player_ptr)
     put_str("                                   ", 3, 40);
     put_str(_("修正の合計値", "Your total modification"), 3, 40);
     put_str(_("腕力 知能 賢さ 器用 耐久 魅力 経験 ", "Str  Int  Wis  Dex  Con  Chr   EXP "), 4, 40);
-    strnfmt(buf, sizeof(buf), "%+3d  %+3d  %+3d  %+3d  %+3d  %+3d %+4d%% ", adj[0], adj[1], adj[2], adj[3], adj[4], adj[5], expfact_mod);
+    const auto stats = format("%+3d  %+3d  %+3d  %+3d  %+3d  %+3d %+4d%% ", adj[0], adj[1], adj[2], adj[3], adj[4], adj[5], expfact_mod);
     c_put_str(TERM_L_BLUE, buf, 5, 40);
 
     put_str("HD ", 6, 40);
-    strnfmt(buf, sizeof(buf), "%2d", rp_ptr->r_mhp + cp_ptr->c_mhp + ap_ptr->a_mhp);
+    const auto hd = format("%2d", rp_ptr->r_mhp + cp_ptr->c_mhp + ap_ptr->a_mhp);
     c_put_str(TERM_L_BLUE, buf, 6, 43);
 
     put_str(_("隠密", "Stealth"), 6, 47);
+    std::string stealth;
     if (PlayerClass(player_ptr).equals(PlayerClassType::BERSERKER)) {
-        angband_strcpy(buf, "xx", sizeof(buf));
+        stealth = "xx";
     } else {
-        strnfmt(buf, sizeof(buf), "%+2d", rp_ptr->r_stl + cp_ptr->c_stl + ap_ptr->a_stl);
+        stealth = format("%+2d", rp_ptr->r_stl + cp_ptr->c_stl + ap_ptr->a_stl);
     }
     c_put_str(TERM_L_BLUE, buf, 6, _(52, 55));
 
     put_str(_("赤外線視力", "Infra"), 6, _(56, 59));
-    strnfmt(buf, sizeof(buf), _("%2dft", "%2dft"), 10 * rp_ptr->infra);
+    const auto infra = format(_("%2dft", "%2dft"), 10 * rp_ptr->infra);
     c_put_str(TERM_L_BLUE, buf, 6, _(67, 65));
 
     clear_from(10);
@@ -317,16 +317,16 @@ static void display_auto_roller_success_rate(const int col)
     put_str(_("最小値", " Limit"), 2, col + 13);
     put_str(_("現在値", "  Roll"), 2, col + 24);
 
-    char buf[32];
+    std::string prob;
 
     if (autoroll_chance >= 1) {
-        strnfmt(buf, sizeof(buf), _("確率 :  1/%8d00", "Prob :  1/%8d00"), autoroll_chance);
+        prob = format(_("確率 :  1/%8d00", "Prob :  1/%8d00"), autoroll_chance);
     } else if (autoroll_chance == -999) {
-        angband_strcpy(buf, _("確率 :     不可能", "Prob :     Impossible"), sizeof(buf));
+        prob = _("確率 :     不可能", "Prob :     Impossible");
     } else {
-        angband_strcpy(buf, _("確率 :     1/10000以上", "Prob :     >1/10000"), sizeof(buf));
+        prob = _("確率 :     1/10000以上", "Prob :     >1/10000");
     }
-    put_str(buf, 11, col + 10);
+    put_str(prob, 11, col + 10);
 
     put_str(_("注意 : 体格等のオートローラを併用時は、上記確率より困難です。", "Note : Prob may be lower when you use the 'autochara' option."), 22, 5);
 

--- a/src/blue-magic/learnt-power-getter.cpp
+++ b/src/blue-magic/learnt-power-getter.cpp
@@ -345,9 +345,8 @@ static void describe_blue_magic_name(PlayerType *player_ptr, int menu_line, cons
  */
 static bool confirm_cast_blue_magic(MonsterAbilityType spell)
 {
-    char tmp_val[160];
-    (void)strnfmt(tmp_val, 78, _("%sの魔法を唱えますか？", "Use %s? "), monster_powers.at(spell).name);
-    return input_check(tmp_val);
+    const auto prompt = format(_("%sの魔法を唱えますか？", "Use %s? "), monster_powers.at(spell).name);
+    return input_check(prompt);
 }
 
 /*!

--- a/src/cmd-action/cmd-racial.cpp
+++ b/src/cmd-action/cmd-racial.cpp
@@ -113,7 +113,7 @@ static void racial_power_make_prompt(rc_type *rc_ptr)
         fmt = _("(特殊能力 %c-%c, '*'で一覧, '/'で閲覧, ESCで中断) どの能力を使いますか？", "(Powers %c-%c, *=List, /=Browse, ESC=exit) Use which power? ");
     }
 
-    (void)strnfmt(rc_ptr->out_val, 78, fmt, I2A(0), (rc_ptr->power_count() <= 26) ? I2A(rc_ptr->power_count() - 1) : '0' + rc_ptr->power_count() - 27);
+    rc_ptr->out_val = format(fmt, I2A(0), (rc_ptr->power_count() <= 26) ? I2A(rc_ptr->power_count() - 1) : '0' + rc_ptr->power_count() - 27);
 }
 
 /*!
@@ -293,9 +293,8 @@ static bool ask_invoke_racial_power(rc_type *rc_ptr)
         return true;
     }
 
-    char tmp_val[160];
-    (void)strnfmt(tmp_val, 78, _("%sを使いますか？ ", "Use %s? "), rc_ptr->power_desc[rc_ptr->command_code].racial_name.data());
-    return input_check(tmp_val);
+    const auto prompt = format(_("%sを使いますか？ ", "Use %s? "), rc_ptr->power_desc[rc_ptr->command_code].racial_name.data());
+    return input_check(prompt);
 }
 
 static void racial_power_display_explanation(PlayerType *player_ptr, rc_type *rc_ptr)

--- a/src/floor/floor-save.cpp
+++ b/src/floor/floor-save.cpp
@@ -27,8 +27,7 @@
 
 static std::string get_saved_floor_name(int level)
 {
-    char ext[32];
-    strnfmt(ext, sizeof(ext), ".F%02d", level);
+    const auto ext = format(".F%02d", level);
     return savefile.string().append(ext);
 }
 

--- a/src/floor/object-scanner.cpp
+++ b/src/floor/object-scanner.cpp
@@ -106,7 +106,6 @@ COMMAND_CODE show_floor_items(PlayerType *player_ptr, int target_item, POSITION 
     COMMAND_CODE i, m;
     int j, k, l;
     ItemEntity *o_ptr;
-    char tmp_val[80]{};
     COMMAND_CODE out_index[23]{};
     TERM_COLOR out_color[23]{};
     std::array<std::string, 23> descriptions{};
@@ -153,23 +152,24 @@ COMMAND_CODE show_floor_items(PlayerType *player_ptr, int target_item, POSITION 
         m = floor_list[out_index[j]];
         o_ptr = &floor_ptr->o_list[m];
         prt("", j + 1, col ? col - 2 : col);
+        std::string head;
         if (use_menu && target_item) {
             if (j == (target_item - 1)) {
-                angband_strcpy(tmp_val, _("》", "> "), sizeof(tmp_val));
+                head = _("》", "> ");
                 target_item_label = m;
             } else {
-                angband_strcpy(tmp_val, "   ", sizeof(tmp_val));
+                head = "   ";
             }
         } else {
-            strnfmt(tmp_val, sizeof(tmp_val), "%c)", floor_label[j]);
+            head = format("%c)", floor_label[j]);
         }
 
-        put_str(tmp_val, j + 1, col);
+        put_str(head, j + 1, col);
         c_put_str(out_color[j], descriptions[j], j + 1, col + 3);
         if (show_weights && (o_ptr->bi_key.tval() != ItemKindType::GOLD)) {
             int wgt = o_ptr->weight * o_ptr->number;
-            strnfmt(tmp_val, sizeof(tmp_val), _("%3d.%1d kg", "%3d.%1d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
-            prt(tmp_val, j + 1, wid - 9);
+            const auto weight = format(_("%3d.%1d kg", "%3d.%1d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
+            prt(weight, j + 1, wid - 9);
         }
     }
 

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -360,8 +360,7 @@ bool get_item_floor(PlayerType *player_ptr, COMMAND_CODE *cp, concptr pmt, concp
         if (command_wrk == USE_INVEN) {
             angband_strcpy(fis_ptr->out_val, _("持ち物:", "Inven:"), sizeof(fis_ptr->out_val));
             if (!use_menu) {
-                char tmp_val[80];
-                strnfmt(tmp_val, sizeof(tmp_val), _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(fis_ptr->i1), index_to_label(fis_ptr->i2));
+                const auto tmp_val = format(_("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(fis_ptr->i1), index_to_label(fis_ptr->i2));
                 angband_strcat(fis_ptr->out_val, tmp_val, sizeof(fis_ptr->out_val));
             }
 
@@ -391,8 +390,7 @@ bool get_item_floor(PlayerType *player_ptr, COMMAND_CODE *cp, concptr pmt, concp
         } else if (command_wrk == (USE_EQUIP)) {
             angband_strcpy(fis_ptr->out_val, _("装備品:", "Equip:"), sizeof(fis_ptr->out_val));
             if (!use_menu) {
-                char tmp_val[80];
-                strnfmt(tmp_val, sizeof(tmp_val), _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(fis_ptr->e1), index_to_label(fis_ptr->e2));
+                const auto tmp_val = format(_("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(fis_ptr->e1), index_to_label(fis_ptr->e2));
                 angband_strcat(fis_ptr->out_val, tmp_val, sizeof(fis_ptr->out_val));
             }
 
@@ -422,8 +420,7 @@ bool get_item_floor(PlayerType *player_ptr, COMMAND_CODE *cp, concptr pmt, concp
         } else if (command_wrk == USE_FLOOR) {
             angband_strcpy(fis_ptr->out_val, _("床上:", "Floor:"), sizeof(fis_ptr->out_val));
             if (!use_menu) {
-                char tmp_val[80];
-                strnfmt(tmp_val, sizeof(tmp_val), _("%c-%c,'(',')',", " %c-%c,'(',')',"), fis_ptr->n1, fis_ptr->n2);
+                const auto tmp_val = format(_("%c-%c,'(',')',", " %c-%c,'(',')',"), fis_ptr->n1, fis_ptr->n2);
                 angband_strcat(fis_ptr->out_val, tmp_val, sizeof(fis_ptr->out_val));
             }
 
@@ -455,8 +452,7 @@ bool get_item_floor(PlayerType *player_ptr, COMMAND_CODE *cp, concptr pmt, concp
         }
 
         angband_strcat(fis_ptr->out_val, " ESC", sizeof(fis_ptr->out_val));
-        strnfmt(fis_ptr->tmp_val, sizeof(fis_ptr->tmp_val), "(%s) %s", fis_ptr->out_val, pmt);
-        prt(fis_ptr->tmp_val, 0, 0);
+        prt(format("(%s) %s", fis_ptr->out_val, pmt), 0, 0);
         fis_ptr->which = inkey();
         if (use_menu) {
             int max_line = 1;

--- a/src/inventory/item-getter.cpp
+++ b/src/inventory/item-getter.cpp
@@ -339,8 +339,7 @@ bool get_item(PlayerType *player_ptr, OBJECT_IDX *cp, concptr pmt, concptr str, 
         if (!command_wrk) {
             angband_strcpy(item_selection_ptr->out_val, _("持ち物:", "Inven:"), sizeof(item_selection_ptr->out_val));
             if ((item_selection_ptr->i1 <= item_selection_ptr->i2) && !use_menu) {
-                char tmp_val[80];
-                strnfmt(tmp_val, sizeof(tmp_val), _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(item_selection_ptr->i1), index_to_label(item_selection_ptr->i2));
+                const auto tmp_val = format(_("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(item_selection_ptr->i1), index_to_label(item_selection_ptr->i2));
                 angband_strcat(item_selection_ptr->out_val, tmp_val, sizeof(item_selection_ptr->out_val));
             }
 
@@ -349,15 +348,13 @@ bool get_item(PlayerType *player_ptr, OBJECT_IDX *cp, concptr pmt, concptr str, 
             }
 
             if (item_selection_ptr->equip) {
-                char tmp_val[80];
-                strnfmt(tmp_val, sizeof(tmp_val), _(" %s 装備品,", " %s for Equip,"), use_menu ? _("'4'or'6'", "4 or 6") : _("'/'", "/"));
+                const auto tmp_val = format(_(" %s 装備品,", " %s for Equip,"), use_menu ? _("'4'or'6'", "4 or 6") : _("'/'", "/"));
                 angband_strcat(item_selection_ptr->out_val, tmp_val, sizeof(item_selection_ptr->out_val));
             }
         } else {
             angband_strcpy(item_selection_ptr->out_val, _("装備品:", "Equip:"), sizeof(item_selection_ptr->out_val));
             if ((item_selection_ptr->e1 <= item_selection_ptr->e2) && !use_menu) {
-                char tmp_val[80];
-                strnfmt(tmp_val, sizeof(tmp_val), _("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(item_selection_ptr->e1), index_to_label(item_selection_ptr->e2));
+                const auto tmp_val = format(_("%c-%c,'(',')',", " %c-%c,'(',')',"), index_to_label(item_selection_ptr->e1), index_to_label(item_selection_ptr->e2));
                 angband_strcat(item_selection_ptr->out_val, tmp_val, sizeof(item_selection_ptr->out_val));
             }
 
@@ -366,8 +363,7 @@ bool get_item(PlayerType *player_ptr, OBJECT_IDX *cp, concptr pmt, concptr str, 
             }
 
             if (item_selection_ptr->inven) {
-                char tmp_val[80];
-                strnfmt(tmp_val, sizeof(tmp_val), _(" %s 持ち物,", " %s for Inven,"), use_menu ? _("'4'or'6'", "4 or 6") : _("'/'", "'/'"));
+                const auto tmp_val = format(_(" %s 持ち物,", " %s for Inven,"), use_menu ? _("'4'or'6'", "4 or 6") : _("'/'", "'/'"));
                 angband_strcat(item_selection_ptr->out_val, tmp_val, sizeof(item_selection_ptr->out_val));
             }
         }
@@ -381,8 +377,7 @@ bool get_item(PlayerType *player_ptr, OBJECT_IDX *cp, concptr pmt, concptr str, 
         }
 
         angband_strcat(item_selection_ptr->out_val, " ESC", sizeof(item_selection_ptr->out_val));
-        strnfmt(item_selection_ptr->tmp_val, sizeof(item_selection_ptr->tmp_val), "(%s) %s", item_selection_ptr->out_val, pmt);
-        prt(item_selection_ptr->tmp_val, 0, 0);
+        prt(format("(%s) %s", item_selection_ptr->out_val, pmt), 0, 0);
         item_selection_ptr->which = inkey();
         if (use_menu) {
             int max_line = (command_wrk ? item_selection_ptr->max_equip : item_selection_ptr->max_inven);

--- a/src/inventory/item-selection-util.h
+++ b/src/inventory/item-selection-util.h
@@ -26,7 +26,6 @@ struct fis_type {
     bool allow_inven;
     bool allow_floor;
     bool toggle;
-    char tmp_val[320];
     char out_val[160];
     ITEM_NUMBER floor_num;
     OBJECT_IDX floor_list[23];
@@ -55,7 +54,6 @@ struct item_selection_type {
     bool floor;
     bool allow_floor;
     bool toggle;
-    char tmp_val[320];
     char out_val[160];
     int menu_line;
     int max_inven;

--- a/src/inventory/player-inventory.cpp
+++ b/src/inventory/player-inventory.cpp
@@ -162,11 +162,10 @@ void py_pickup_floor(PlayerType *player_ptr, bool pickup)
         return;
     }
 
-    char out_val[MAX_NLEN + 20];
     auto *o_ptr = &player_ptr->current_floor_ptr->o_list[floor_o_idx];
     const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
-    strnfmt(out_val, sizeof(out_val), _("%sを拾いますか? ", "Pick up %s? "), item_name.data());
-    if (!input_check(out_val)) {
+    const auto prompt = format(_("%sを拾いますか? ", "Pick up %s? "), item_name.data());
+    if (!input_check(prompt)) {
         return;
     }
 
@@ -288,9 +287,8 @@ void carry(PlayerType *player_ptr, bool pickup)
 
         int is_pickup_successful = true;
         if (carry_query_flag) {
-            char out_val[MAX_NLEN + 20];
-            strnfmt(out_val, sizeof(out_val), _("%sを拾いますか? ", "Pick up %s? "), item_name.data());
-            is_pickup_successful = input_check(out_val);
+            const auto prompt = format(_("%sを拾いますか? ", "Pick up %s? "), item_name.data());
+            is_pickup_successful = input_check(prompt);
         }
 
         if (is_pickup_successful) {

--- a/src/io-dump/dump-remover.cpp
+++ b/src/io-dump/dump-remover.cpp
@@ -18,12 +18,10 @@ void remove_auto_dump(const std::filesystem::path &orig_file, std::string_view a
     bool changed = false;
     int line_num = 0;
     long header_location = 0;
-    char header_mark_str[80];
-    char footer_mark_str[80];
 
-    strnfmt(header_mark_str, sizeof(header_mark_str), auto_dump_header, auto_dump_mark.data());
-    strnfmt(footer_mark_str, sizeof(footer_mark_str), auto_dump_footer, auto_dump_mark.data());
-    size_t mark_len = strlen(footer_mark_str);
+    const auto header_mark_str = format(auto_dump_header, auto_dump_mark.data());
+    const auto footer_mark_str = format(auto_dump_footer, auto_dump_mark.data());
+    size_t mark_len = footer_mark_str.length();
 
     FILE *orig_fff;
     orig_fff = angband_fopen(orig_file, FileOpenMode::READ);
@@ -50,7 +48,7 @@ void remove_auto_dump(const std::filesystem::path &orig_file, std::string_view a
         }
 
         if (!between_mark) {
-            if (!strcmp(buf->data(), header_mark_str)) {
+            if (!strcmp(buf->data(), header_mark_str.data())) {
                 header_location = ftell(orig_fff);
                 line_num = 0;
                 between_mark = true;
@@ -62,7 +60,7 @@ void remove_auto_dump(const std::filesystem::path &orig_file, std::string_view a
             continue;
         }
 
-        if (!strncmp(buf->data(), footer_mark_str, mark_len)) {
+        if (!strncmp(buf->data(), footer_mark_str.data(), mark_len)) {
             int tmp;
             if (!sscanf(buf->data() + mark_len, " (%d)", &tmp) || tmp != line_num) {
                 fseek(orig_fff, header_location, SEEK_SET);

--- a/src/io/files-util.cpp
+++ b/src/io/files-util.cpp
@@ -22,6 +22,7 @@
 #include "term/screen-processor.h"
 #include "term/z-form.h"
 #include "util/angband-files.h"
+#include "util/string-processor.h"
 #include "view/display-messages.h"
 #include <algorithm>
 #ifdef SAVEFILE_USE_UID
@@ -232,10 +233,11 @@ static errr counts_seek(PlayerType *player_ptr, int fd, uint32_t where, bool fla
     auto short_pclass = enum2i(player_ptr->pclass);
 #ifdef SAVEFILE_USE_UID
     const auto user_id = UnixUserIds::get_instance().get_user_id();
-    strnfmt(temp1, sizeof(temp1), "%d.%s.%d%d%d", user_id, savefile_base.string().data(), short_pclass, player_ptr->ppersonality, player_ptr->age);
+    const auto header = format("%d.%s.%d%d%d", user_id, savefile_base.string().data(), short_pclass, player_ptr->ppersonality, player_ptr->age);
 #else
-    strnfmt(temp1, sizeof(temp1), "%s.%d%d%d", savefile_base.string().data(), short_pclass, player_ptr->ppersonality, player_ptr->age);
+    const auto header = format("%s.%d%d%d", savefile_base.string().data(), short_pclass, player_ptr->ppersonality, player_ptr->age);
 #endif
+    angband_strcpy(temp1, header, sizeof(temp1));
     for (int i = 0; temp1[i]; i++) {
         temp1[i] ^= (i + 1) * 63;
     }

--- a/src/io/input-key-requester.cpp
+++ b/src/io/input-key-requester.cpp
@@ -90,7 +90,7 @@ void InputKeyRequestor::process_input_command()
         this->process_control_command(cmd);
         auto act = keymap_act[this->mode][(byte)(cmd)];
         if (act && !inkey_next) {
-            (void)strnfmt(request_command_buffer, sizeof(request_command_buffer), "%s", act);
+            angband_strcpy(request_command_buffer, act, sizeof(request_command_buffer));
             inkey_next = request_command_buffer;
             continue;
         }

--- a/src/io/pref-file-expressor.cpp
+++ b/src/io/pref-file-expressor.cpp
@@ -209,7 +209,8 @@ concptr process_pref_file_expr(PlayerType *player_ptr, char **sp, char *fp)
         v = realm_names[player_ptr->realm2];
 #endif
     } else if (streq(b + 1, "LEVEL")) {
-        strnfmt(tmp, sizeof(tmp), "%02d", player_ptr->lev);
+        const auto plev = format("%02d", player_ptr->lev);
+        angband_strcpy(tmp, plev, sizeof(tmp));
         v = tmp;
     } else if (streq(b + 1, "AUTOREGISTER")) {
         if (player_ptr->autopick_autoregister) {
@@ -218,7 +219,8 @@ concptr process_pref_file_expr(PlayerType *player_ptr, char **sp, char *fp)
             v = "0";
         }
     } else if (streq(b + 1, "MONEY")) {
-        strnfmt(tmp, sizeof(tmp), "%09ld", (long int)player_ptr->au);
+        const auto au = format("%09ld", (long int)player_ptr->au);
+        angband_strcpy(tmp, au, sizeof(tmp));
         v = tmp;
     }
 

--- a/src/io/read-pref-file.cpp
+++ b/src/io/read-pref-file.cpp
@@ -210,24 +210,20 @@ errr process_histpref_file(PlayerType *player_ptr, std::string_view name)
 }
 
 /*!
- * @brief prfファイルのフォーマットに従った内容を出力する /
- * Dump a formatted line, using "vstrnfmt()".
+ * @brief prfファイルのフォーマットに従った内容を出力する
  * @param fmt 出力内容
  */
 void auto_dump_printf(FILE *auto_dump_stream, const char *fmt, ...)
 {
     va_list vp;
-    char buf[1024];
     va_start(vp, fmt);
-    (void)vstrnfmt(buf, sizeof(buf), fmt, vp);
+    const auto buf = vformat(fmt, vp);
     va_end(vp);
-    for (auto p = buf; *p; p++) {
-        if (*p == '\n') {
-            auto_dump_line_num++;
-        }
-    }
 
-    fprintf(auto_dump_stream, "%s", buf);
+    // '\n'はSJISのマルチバイト文字のコードに含まれないため、ダメ文字を考慮する必要はない
+    auto_dump_line_num += std::count(buf.begin(), buf.end(), '\n');
+
+    fprintf(auto_dump_stream, "%s", buf.data());
 }
 
 /*!

--- a/src/io/read-pref-file.cpp
+++ b/src/io/read-pref-file.cpp
@@ -239,8 +239,7 @@ void auto_dump_printf(FILE *auto_dump_stream, const char *fmt, ...)
  */
 bool open_auto_dump(FILE **fpp, const std::filesystem::path &path, std::string_view mark)
 {
-    char header_mark_str[80];
-    strnfmt(header_mark_str, sizeof(header_mark_str), auto_dump_header, mark.data());
+    const auto header_mark_str = format(auto_dump_header, mark.data());
     remove_auto_dump(path, mark);
     *fpp = angband_fopen(path, FileOpenMode::APPEND);
     if (!fpp) {
@@ -250,7 +249,7 @@ bool open_auto_dump(FILE **fpp, const std::filesystem::path &path, std::string_v
         return false;
     }
 
-    fprintf(*fpp, "%s\n", header_mark_str);
+    fprintf(*fpp, "%s\n", header_mark_str.data());
     auto_dump_line_num = 0;
     auto_dump_printf(*fpp, _("# *警告!!* 以降の行は自動生成されたものです。\n", "# *Warning!*  The lines below are an automatic dump.\n"));
     auto_dump_printf(
@@ -265,12 +264,11 @@ bool open_auto_dump(FILE **fpp, const std::filesystem::path &path, std::string_v
  */
 void close_auto_dump(FILE **fpp, std::string_view mark)
 {
-    char footer_mark_str[80];
-    strnfmt(footer_mark_str, sizeof(footer_mark_str), auto_dump_footer, mark.data());
+    const auto footer_mark_str = format(auto_dump_footer, mark.data());
     auto_dump_printf(*fpp, _("# *警告!!* 以降の行は自動生成されたものです。\n", "# *Warning!*  The lines below are an automatic dump.\n"));
     auto_dump_printf(
         *fpp, _("# *警告!!* 後で自動的に削除されるので編集しないでください。\n", "# Don't edit them; changes will be deleted and replaced automatically.\n"));
-    fprintf(*fpp, "%s (%d)\n", footer_mark_str, auto_dump_line_num);
+    fprintf(*fpp, "%s (%d)\n", footer_mark_str.data(), auto_dump_line_num);
     angband_fclose(*fpp);
 }
 

--- a/src/load/floor-loader.cpp
+++ b/src/load/floor-loader.cpp
@@ -292,8 +292,7 @@ bool load_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr, BIT_FLAGS mode
     }
 
     auto floor_savefile = savefile.string();
-    char ext[32];
-    strnfmt(ext, sizeof(ext), ".F%02d", (int)sf_ptr->savefile_id);
+    const auto ext = format(".F%02d", (int)sf_ptr->savefile_id);
     floor_savefile.append(ext);
 
     safe_setuid_grab();

--- a/src/main-cap.cpp
+++ b/src/main-cap.cpp
@@ -256,9 +256,8 @@ static void do_cs(int y1, int y2)
 #endif
 
 #ifdef USE_HARDCODE
-    char temp[64];
-    strnfmt(temp, sizeof(temp), cs, y1, y2);
-    tp(temp);
+    auto temp = format(cs, y1, y2);
+    tp(temp.data());
 #endif
 }
 
@@ -275,9 +274,8 @@ static void do_cm(int x, int y)
 #endif
 
 #ifdef USE_HARDCODE
-    char temp[64];
-    strnfmt(temp, sizeof(temp), cm, y + 1, x + 1);
-    tp(temp);
+    auto temp = format(cm, y + 1, x + 1);
+    tp(temp.data());
 #endif
 }
 

--- a/src/main-x11.cpp
+++ b/src/main-x11.cpp
@@ -1093,7 +1093,6 @@ static void react_keypress(XKeyEvent *xev)
     XKeyEvent *ev = (XKeyEvent *)(xev);
     KeySym ks;
     char buf[128];
-    char msg[128];
 
 #ifdef USE_XIM
     int valid_keysym = true;
@@ -1173,16 +1172,17 @@ static void react_keypress(XKeyEvent *xev)
     }
     }
 
+    std::string msg;
     if (ks) {
-        strnfmt(msg, sizeof(msg), "%c%s%s%s%s_%lX%c", 31, mc ? "N" : "", ms ? "S" : "", mo ? "O" : "", mx ? "M" : "", (unsigned long)(ks), 13);
+        msg = format("%c%s%s%s%s_%lX%c", 31, mc ? "N" : "", ms ? "S" : "", mo ? "O" : "", mx ? "M" : "", (unsigned long)(ks), 13);
     } else {
-        strnfmt(msg, sizeof(msg), "%c%s%s%s%sK_%X%c", 31, mc ? "N" : "", ms ? "S" : "", mo ? "O" : "", mx ? "M" : "", ev->keycode, 13);
+        msg = format("%c%s%s%s%sK_%X%c", 31, mc ? "N" : "", ms ? "S" : "", mo ? "O" : "", mx ? "M" : "", ev->keycode, 13);
     }
 
-    send_keys(msg);
+    send_keys(msg.data());
 
-    if (n && !macro_patterns.empty() && (macro_find_exact(msg) < 0)) {
-        macro_add(msg, buf);
+    if (n && !macro_patterns.empty() && (macro_find_exact(msg.data()) < 0)) {
+        macro_add(msg.data(), buf);
     }
 }
 

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -197,7 +197,6 @@ static void redraw_health_bar(PlayerType *player_ptr, mam_type *mam_ptr)
 
 static void describe_silly_melee(mam_type *mam_ptr)
 {
-    char temp[MAX_NLEN];
     if ((mam_ptr->act == nullptr) || !mam_ptr->see_either) {
         return;
     }
@@ -207,17 +206,18 @@ static void describe_silly_melee(mam_type *mam_ptr)
         mam_ptr->act = rand_choice(silly_attacks2);
     }
 
-    strnfmt(temp, sizeof(temp), mam_ptr->act, mam_ptr->t_name);
-    msg_format("%s^は%s", mam_ptr->m_name, temp);
+    const auto temp = format(mam_ptr->act, mam_ptr->t_name);
+    msg_format("%s^は%s", mam_ptr->m_name, temp.data());
 #else
+    std::string temp;
     if (mam_ptr->do_silly_attack) {
         mam_ptr->act = rand_choice(silly_attacks);
-        strnfmt(temp, sizeof(temp), "%s %s.", mam_ptr->act, mam_ptr->t_name);
+        temp = format("%s %s.", mam_ptr->act, mam_ptr->t_name);
     } else {
-        strnfmt(temp, sizeof(temp), mam_ptr->act, mam_ptr->t_name);
+        temp = format(mam_ptr->act, mam_ptr->t_name);
     }
 
-    msg_format("%s^ %s", mam_ptr->m_name, temp);
+    msg_format("%s^ %s", mam_ptr->m_name, temp.data());
 #endif
 }
 

--- a/src/mind/mind-monk.cpp
+++ b/src/mind/mind-monk.cpp
@@ -44,8 +44,7 @@ bool choose_monk_stance(PlayerType *player_ptr)
     prt(_(" a) 構えをとく", " a) No form"), 2, 20);
     for (auto i = 0U; i < monk_stances.size(); i++) {
         if (player_ptr->lev >= monk_stances[i].min_level) {
-            char buf[80];
-            strnfmt(buf, sizeof(buf), " %c) %-12s  %s", I2A(i + 1), monk_stances[i].desc, monk_stances[i].info);
+            const auto buf = format(" %c) %-12s  %s", I2A(i + 1), monk_stances[i].desc, monk_stances[i].info);
             prt(buf, 3 + i, 20);
         }
     }

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -369,7 +369,6 @@ void concentration(PlayerType *player_ptr)
 bool choose_samurai_stance(PlayerType *player_ptr)
 {
     char choice;
-    char buf[80];
 
     if (cmd_limit_confused(player_ptr)) {
         return false;
@@ -390,7 +389,7 @@ bool choose_samurai_stance(PlayerType *player_ptr)
     prt(_(" a) 型を崩す", " a) No Form"), 2, 20);
     for (auto i = 0U; i < samurai_stances.size(); i++) {
         if (player_ptr->lev >= samurai_stances[i].min_level) {
-            strnfmt(buf, sizeof(buf), _(" %c) %sの型    %s", " %c) Stance of %-12s  %s"), I2A(i + 1), samurai_stances[i].desc, samurai_stances[i].info);
+            const auto buf = format(_(" %c) %sの型    %s", " %c) Stance of %-12s  %s"), I2A(i + 1), samurai_stances[i].desc, samurai_stances[i].info);
             prt(buf, 3 + i, 20);
         }
     }

--- a/src/mind/mind-sniper.cpp
+++ b/src/mind/mind-sniper.cpp
@@ -202,7 +202,6 @@ void display_snipe_list(PlayerType *player_ptr)
     TERM_LEN x = 1;
     PLAYER_LEVEL plev = player_ptr->lev;
     snipe_power spell;
-    char psi_desc[80];
 
     /* Display a list of spells */
     prt("", y, x);
@@ -218,7 +217,7 @@ void display_snipe_list(PlayerType *player_ptr)
             continue;
         }
 
-        strnfmt(psi_desc, sizeof(psi_desc), "  %c) %-30s%2d %4d", I2A(i), spell.name, spell.min_lev, spell.mana_cost);
+        const auto psi_desc = format("  %c) %-30s%2d %4d", I2A(i), spell.name, spell.min_lev, spell.mana_cost);
 
         TERM_COLOR tcol = (spell.mana_cost > sniper_data->concent) ? TERM_SLATE : TERM_WHITE;
         term_putstr(x, y + i + 1, -1, tcol, psi_desc);

--- a/src/racial/racial-util.h
+++ b/src/racial/racial-util.h
@@ -55,7 +55,7 @@ struct rc_type {
     bool is_warrior{}; //!< 戦士/狂戦士かどうか
     bool is_chosen{}; //!< 選択したかどうか
     char choice{}; //!< コマンドキー
-    char out_val[160]{}; //!< 出力文字列用バッファ
+    std::string out_val{}; //!< 出力文字列
     int menu_line{}; //!< 現在選択中の行
 
     /*!

--- a/src/save/floor-writer.cpp
+++ b/src/save/floor-writer.cpp
@@ -263,8 +263,7 @@ bool save_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr, BIT_FLAGS mode
     }
 
     auto floor_savefile = savefile.string();
-    char ext[32];
-    strnfmt(ext, sizeof(ext), ".F%02d", (int)sf_ptr->savefile_id);
+    const auto ext = format(".F%02d", (int)sf_ptr->savefile_id);
     floor_savefile.append(ext);
     safe_setuid_grab();
     fd_kill(floor_savefile);

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -274,13 +274,11 @@ bool tele_town(PlayerType *player_ptr)
     auto num = 0;
     const int towns_size = towns_info.size();
     for (auto i = 1; i < towns_size; i++) {
-        char buf[80];
-
         if ((i == VALID_TOWNS) || (i == SECRET_TOWN) || (i == player_ptr->town_num) || !(player_ptr->visit & (1UL << (i - 1)))) {
             continue;
         }
 
-        strnfmt(buf, sizeof(buf), "%c) %-20s", I2A(i - 1), towns_info[i].name.data());
+        const auto buf = format("%c) %-20s", I2A(i - 1), towns_info[i].name.data());
         prt(buf, 5 + i, 5);
         num++;
     }

--- a/src/spell-realm/spells-sorcery.cpp
+++ b/src/spell-realm/spells-sorcery.cpp
@@ -51,8 +51,7 @@ bool alchemy(PlayerType *player_ptr)
 
     if (!force) {
         if (confirm_destroy || (o_ptr->get_price() > 0)) {
-            char out_val[MAX_NLEN + 40];
-            strnfmt(out_val, sizeof(out_val), _("本当に%sを金に変えますか？", "Really turn %s to gold? "), item_name.data());
+            const auto out_val = format(_("本当に%sを金に変えますか？", "Really turn %s to gold? "), item_name.data());
             if (!input_check(out_val)) {
                 return false;
             }

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -61,7 +61,6 @@ public:
     concptr s3 = "";
     concptr x_info = "";
     char query = '\001';
-    char out_val[MAX_NLEN + 80]{};
     OBJECT_IDX floor_list[23]{};
     ITEM_NUMBER floor_num = 0;
     Grid *g_ptr;
@@ -158,11 +157,11 @@ static ProcessResult describe_hallucinated_target(PlayerType *player_ptr, GridEx
 
     concptr name = _("何か奇妙な物", "something strange");
 #ifdef JP
-    strnfmt(ge_ptr->out_val, sizeof(ge_ptr->out_val), "%s%s%s%s [%s]", ge_ptr->s1, name, ge_ptr->s2, ge_ptr->s3, ge_ptr->info);
+    const auto out_val = format("%s%s%s%s [%s]", ge_ptr->s1, name, ge_ptr->s2, ge_ptr->s3, ge_ptr->info);
 #else
-    strnfmt(ge_ptr->out_val, sizeof(ge_ptr->out_val), "%s%s%s%s [%s]", ge_ptr->s1, ge_ptr->s2, ge_ptr->s3, name, ge_ptr->info);
+    const auto out_val = format("%s%s%s%s [%s]", ge_ptr->s1, ge_ptr->s2, ge_ptr->s3, name, ge_ptr->info);
 #endif
-    prt(ge_ptr->out_val, 0, 0);
+    prt(out_val, 0, 0);
     move_cursor_relative(ge_ptr->y, ge_ptr->x);
     ge_ptr->query = inkey();
     if ((ge_ptr->query != '\r') && (ge_ptr->query != '\n')) {
@@ -199,13 +198,13 @@ static void describe_grid_monster(PlayerType *player_ptr, GridExamination *ge_pt
         std::string acount = evaluate_monster_exp(player_ptr, ge_ptr->m_ptr);
         const auto mon_desc = look_mon_desc(ge_ptr->m_ptr, 0x01);
 #ifdef JP
-        strnfmt(ge_ptr->out_val, sizeof(ge_ptr->out_val), "[%s]%s%s(%s)%s%s [r思 %s%s]", acount.data(), ge_ptr->s1, m_name.data(), mon_desc.data(), ge_ptr->s2, ge_ptr->s3,
+        const auto out_val = format("[%s]%s%s(%s)%s%s [r思 %s%s]", acount.data(), ge_ptr->s1, m_name.data(), mon_desc.data(), ge_ptr->s2, ge_ptr->s3,
             ge_ptr->x_info, ge_ptr->info);
 #else
-        strnfmt(ge_ptr->out_val, sizeof(ge_ptr->out_val), "[%s]%s%s%s%s(%s) [r, %s%s]", acount.data(), ge_ptr->s1, ge_ptr->s2, ge_ptr->s3, m_name.data(), mon_desc.data(),
+        const auto out_val = format("[%s]%s%s%s%s(%s) [r, %s%s]", acount.data(), ge_ptr->s1, ge_ptr->s2, ge_ptr->s3, m_name.data(), mon_desc.data(),
             ge_ptr->x_info, ge_ptr->info);
 #endif
-        prt(ge_ptr->out_val, 0, 0);
+        prt(out_val, 0, 0);
         move_cursor_relative(ge_ptr->y, ge_ptr->x);
         ge_ptr->query = inkey();
         if (ge_ptr->query != 'r') {
@@ -240,11 +239,11 @@ static short describe_monster_item(PlayerType *player_ptr, GridExamination *ge_p
         auto *o_ptr = &player_ptr->current_floor_ptr->o_list[this_o_idx];
         const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
 #ifdef JP
-        strnfmt(ge_ptr->out_val, sizeof(ge_ptr->out_val), "%s%s%s%s[%s]", ge_ptr->s1, item_name.data(), ge_ptr->s2, ge_ptr->s3, ge_ptr->info);
+        const auto out_val = format("%s%s%s%s[%s]", ge_ptr->s1, item_name.data(), ge_ptr->s2, ge_ptr->s3, ge_ptr->info);
 #else
-        strnfmt(ge_ptr->out_val, sizeof(ge_ptr->out_val), "%s%s%s%s [%s]", ge_ptr->s1, ge_ptr->s2, ge_ptr->s3, item_name.data(), ge_ptr->info);
+        const auto out_val = format("%s%s%s%s [%s]", ge_ptr->s1, ge_ptr->s2, ge_ptr->s3, item_name.data(), ge_ptr->info);
 #endif
-        prt(ge_ptr->out_val, 0, 0);
+        prt(out_val, 0, 0);
         move_cursor_relative(ge_ptr->y, ge_ptr->x);
         ge_ptr->query = inkey();
         if ((ge_ptr->query != '\r') && (ge_ptr->query != '\n') && (ge_ptr->query != ' ') && (ge_ptr->query != 'x')) {
@@ -309,11 +308,11 @@ static short describe_footing(PlayerType *player_ptr, GridExamination *ge_ptr)
     auto *o_ptr = &player_ptr->current_floor_ptr->o_list[ge_ptr->floor_list[0]];
     const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
 #ifdef JP
-    strnfmt(ge_ptr->out_val, sizeof(ge_ptr->out_val), "%s%s%s%s[%s]", ge_ptr->s1, item_name.data(), ge_ptr->s2, ge_ptr->s3, ge_ptr->info);
+    const auto out_val = format("%s%s%s%s[%s]", ge_ptr->s1, item_name.data(), ge_ptr->s2, ge_ptr->s3, ge_ptr->info);
 #else
-    strnfmt(ge_ptr->out_val, sizeof(ge_ptr->out_val), "%s%s%s%s [%s]", ge_ptr->s1, ge_ptr->s2, ge_ptr->s3, item_name.data(), ge_ptr->info);
+    const auto out_val = format("%s%s%s%s [%s]", ge_ptr->s1, ge_ptr->s2, ge_ptr->s3, item_name.data(), ge_ptr->info);
 #endif
-    prt(ge_ptr->out_val, 0, 0);
+    prt(out_val, 0, 0);
     move_cursor_relative(ge_ptr->y, ge_ptr->x);
     ge_ptr->query = inkey();
     return ge_ptr->query;
@@ -326,11 +325,11 @@ static short describe_footing_items(GridExamination *ge_ptr)
     }
 
 #ifdef JP
-    strnfmt(ge_ptr->out_val, sizeof(ge_ptr->out_val), "%s %d個のアイテム%s%s ['x'で一覧, %s]", ge_ptr->s1, (int)ge_ptr->floor_num, ge_ptr->s2, ge_ptr->s3, ge_ptr->info);
+    const auto out_val = format("%s %d個のアイテム%s%s ['x'で一覧, %s]", ge_ptr->s1, (int)ge_ptr->floor_num, ge_ptr->s2, ge_ptr->s3, ge_ptr->info);
 #else
-    strnfmt(ge_ptr->out_val, sizeof(ge_ptr->out_val), "%s%s%sa pile of %d items [x,%s]", ge_ptr->s1, ge_ptr->s2, ge_ptr->s3, (int)ge_ptr->floor_num, ge_ptr->info);
+    const auto out_val = format("%s%s%sa pile of %d items [x,%s]", ge_ptr->s1, ge_ptr->s2, ge_ptr->s3, (int)ge_ptr->floor_num, ge_ptr->info);
 #endif
-    prt(ge_ptr->out_val, 0, 0);
+    prt(out_val, 0, 0);
     move_cursor_relative(ge_ptr->y, ge_ptr->x);
     ge_ptr->query = inkey();
     if (ge_ptr->query != 'x' && ge_ptr->query != ' ') {
@@ -348,11 +347,11 @@ static char describe_footing_many_items(PlayerType *player_ptr, GridExamination 
         (void)show_floor_items(player_ptr, 0, ge_ptr->y, ge_ptr->x, min_width, AllMatchItemTester());
         show_gold_on_floor = false;
 #ifdef JP
-        strnfmt(ge_ptr->out_val, sizeof(ge_ptr->out_val), "%s %d個のアイテム%s%s [Enterで次へ, %s]", ge_ptr->s1, (int)ge_ptr->floor_num, ge_ptr->s2, ge_ptr->s3, ge_ptr->info);
+        const auto out_val = format("%s %d個のアイテム%s%s [Enterで次へ, %s]", ge_ptr->s1, (int)ge_ptr->floor_num, ge_ptr->s2, ge_ptr->s3, ge_ptr->info);
 #else
-        strnfmt(ge_ptr->out_val, sizeof(ge_ptr->out_val), "%s%s%sa pile of %d items [Enter,%s]", ge_ptr->s1, ge_ptr->s2, ge_ptr->s3, (int)ge_ptr->floor_num, ge_ptr->info);
+        const auto out_val = format("%s%s%sa pile of %d items [Enter,%s]", ge_ptr->s1, ge_ptr->s2, ge_ptr->s3, (int)ge_ptr->floor_num, ge_ptr->info);
 #endif
-        prt(ge_ptr->out_val, 0, 0);
+        prt(out_val, 0, 0);
         ge_ptr->query = inkey();
         screen_load();
         if (ge_ptr->query != '\n' && ge_ptr->query != '\r') {
@@ -401,11 +400,11 @@ static short describe_footing_sight(PlayerType *player_ptr, GridExamination *ge_
     ge_ptr->boring = false;
     const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
 #ifdef JP
-    strnfmt(ge_ptr->out_val, sizeof(ge_ptr->out_val), "%s%s%s%s[%s]", ge_ptr->s1, item_name.data(), ge_ptr->s2, ge_ptr->s3, ge_ptr->info);
+    const auto out_val = format("%s%s%s%s[%s]", ge_ptr->s1, item_name.data(), ge_ptr->s2, ge_ptr->s3, ge_ptr->info);
 #else
-    strnfmt(ge_ptr->out_val, sizeof(ge_ptr->out_val), "%s%s%s%s [%s]", ge_ptr->s1, ge_ptr->s2, ge_ptr->s3, item_name.data(), ge_ptr->info);
+    const auto out_val = format("%s%s%s%s [%s]", ge_ptr->s1, ge_ptr->s2, ge_ptr->s3, item_name.data(), ge_ptr->info);
 #endif
-    prt(ge_ptr->out_val, 0, 0);
+    prt(out_val, 0, 0);
     move_cursor_relative(ge_ptr->y, ge_ptr->x);
     ge_ptr->query = inkey();
     if ((ge_ptr->query != '\r') && (ge_ptr->query != '\n') && (ge_ptr->query != ' ') && (ge_ptr->query != 'x')) {
@@ -482,15 +481,14 @@ static std::string decide_target_floor(PlayerType *player_ptr, GridExamination *
     return ge_ptr->terrain_ptr->name;
 }
 
-static void describe_grid_monster_all(GridExamination *ge_ptr)
+static std::string describe_grid_monster_all(GridExamination *ge_ptr)
 {
     if (!w_ptr->wizard) {
 #ifdef JP
-        strnfmt(ge_ptr->out_val, sizeof(ge_ptr->out_val), "%s%s%s%s[%s]", ge_ptr->s1, ge_ptr->name.data(), ge_ptr->s2, ge_ptr->s3, ge_ptr->info);
+        return format("%s%s%s%s[%s]", ge_ptr->s1, ge_ptr->name.data(), ge_ptr->s2, ge_ptr->s3, ge_ptr->info);
 #else
-        strnfmt(ge_ptr->out_val, sizeof(ge_ptr->out_val), "%s%s%s%s [%s]", ge_ptr->s1, ge_ptr->s2, ge_ptr->s3, ge_ptr->name.data(), ge_ptr->info);
+        return format("%s%s%s%s [%s]", ge_ptr->s1, ge_ptr->s2, ge_ptr->s3, ge_ptr->name.data(), ge_ptr->info);
 #endif
-        return;
     }
 
     std::string f_idx_str;
@@ -501,11 +499,11 @@ static void describe_grid_monster_all(GridExamination *ge_ptr)
     }
 
 #ifdef JP
-    strnfmt(ge_ptr->out_val, sizeof(ge_ptr->out_val), "%s%s%s%s[%s] %x %s %d %d %d (%d,%d) %d", ge_ptr->s1, ge_ptr->name.data(), ge_ptr->s2, ge_ptr->s3, ge_ptr->info,
+    return format("%s%s%s%s[%s] %x %s %d %d %d (%d,%d) %d", ge_ptr->s1, ge_ptr->name.data(), ge_ptr->s2, ge_ptr->s3, ge_ptr->info,
         (uint)ge_ptr->g_ptr->info, f_idx_str.data(), ge_ptr->g_ptr->dists[FLOW_NORMAL], ge_ptr->g_ptr->costs[FLOW_NORMAL], ge_ptr->g_ptr->when, (int)ge_ptr->y,
         (int)ge_ptr->x, travel.cost[ge_ptr->y][ge_ptr->x]);
 #else
-    strnfmt(ge_ptr->out_val, sizeof(ge_ptr->out_val), "%s%s%s%s [%s] %x %s %d %d %d (%d,%d)", ge_ptr->s1, ge_ptr->s2, ge_ptr->s3, ge_ptr->name.data(), ge_ptr->info, ge_ptr->g_ptr->info,
+    return format("%s%s%s%s [%s] %x %s %d %d %d (%d,%d)", ge_ptr->s1, ge_ptr->s2, ge_ptr->s3, ge_ptr->name.data(), ge_ptr->info, ge_ptr->g_ptr->info,
         f_idx_str.data(), ge_ptr->g_ptr->dists[FLOW_NORMAL], ge_ptr->g_ptr->costs[FLOW_NORMAL], ge_ptr->g_ptr->when, (int)ge_ptr->y, (int)ge_ptr->x);
 #endif
 }
@@ -595,8 +593,7 @@ char examine_grid(PlayerType *player_ptr, const POSITION y, const POSITION x, ta
     }
 #endif
 
-    describe_grid_monster_all(ge_ptr);
-    prt(ge_ptr->out_val, 0, 0);
+    prt(describe_grid_monster_all(ge_ptr), 0, 0);
     move_cursor_relative(y, x);
     ge_ptr->query = inkey();
     if ((ge_ptr->query != '\r') && (ge_ptr->query != '\n')) {

--- a/src/target/target-setter.cpp
+++ b/src/target/target-setter.cpp
@@ -186,9 +186,8 @@ static void describe_projectablity(PlayerType *player_ptr, ts_type *ts_ptr)
         return;
     }
 
-    char cheatinfo[30];
-    strnfmt(cheatinfo, sizeof(cheatinfo), " X:%d Y:%d LOS:%d LOP:%d", ts_ptr->x,
-        ts_ptr->y,
+    const auto cheatinfo = format(" X:%d Y:%d LOS:%d LOP:%d",
+        ts_ptr->x, ts_ptr->y,
         los(player_ptr, player_ptr->y, player_ptr->x, ts_ptr->y, ts_ptr->x),
         projectable(player_ptr, player_ptr->y, player_ptr->x, ts_ptr->y, ts_ptr->x));
     angband_strcat(ts_ptr->info, cheatinfo, sizeof(ts_ptr->info));
@@ -430,10 +429,9 @@ static void describe_grid_wizard(PlayerType *player_ptr, ts_type *ts_ptr)
     }
 
     constexpr auto fmt = " X:%d Y:%d LOS:%d LOP:%d SPECIAL:%d";
-    char cheatinfo[100];
     const auto is_los = los(player_ptr, player_ptr->y, player_ptr->x, ts_ptr->y, ts_ptr->x);
     const auto is_projectable = projectable(player_ptr, player_ptr->y, player_ptr->x, ts_ptr->y, ts_ptr->x);
-    strnfmt(cheatinfo, sizeof(cheatinfo), fmt, ts_ptr->x, ts_ptr->y, is_los, is_projectable, ts_ptr->g_ptr->special);
+    const auto cheatinfo = format(fmt, ts_ptr->x, ts_ptr->y, is_los, is_projectable, ts_ptr->g_ptr->special);
     angband_strcat(ts_ptr->info, cheatinfo, sizeof(ts_ptr->info));
 }
 

--- a/src/term/z-form.cpp
+++ b/src/term/z-form.cpp
@@ -86,20 +86,6 @@
 #include <vector>
 
 namespace {
-std::string vformat(const char *fmt, va_list vp)
-{
-    std::vector<char> format_buf(1024);
-    while (true) {
-        const auto len = vstrnfmt(format_buf.data(), format_buf.size(), fmt, vp);
-        if (len < format_buf.size() - 1) {
-            return std::string(format_buf.data());
-        }
-
-        format_buf.resize(format_buf.size() * 2);
-    }
-}
-}
-
 /*!
  * @brief 2バイト文字、及び文頭の大文字小文字を考慮しつつ、文字列のフォーマットを行う
  * @details 文頭を大文字にするには'%s^'とする.
@@ -347,13 +333,21 @@ uint32_t vstrnfmt(char *buf, uint32_t max, const char *fmt, va_list vp)
     buf[n] = '\0';
     return n;
 }
+}
 
-/*
- * Do a vstrnfmt() into (see above) into a (growable) static buffer.
- * This buffer is usable for very short term formatting of results.
- * Note that the buffer is (technically) writable, but only up to
- * the length of the string contained inside it.
- */
+std::string vformat(const char *fmt, va_list vp)
+{
+    std::vector<char> format_buf(1024);
+    while (true) {
+        const auto len = vstrnfmt(format_buf.data(), format_buf.size(), fmt, vp);
+        if (len < format_buf.size() - 1) {
+            return std::string(format_buf.data(), len);
+        }
+
+        format_buf.resize(format_buf.size() * 2);
+    }
+}
+
 std::string format(const char *fmt, ...)
 {
     va_list vp;

--- a/src/term/z-form.cpp
+++ b/src/term/z-form.cpp
@@ -349,18 +349,6 @@ uint32_t vstrnfmt(char *buf, uint32_t max, const char *fmt, va_list vp)
 }
 
 /*
- * Do a vstrnfmt (see above) into a buffer of a given size.
- */
-uint32_t strnfmt(char *buf, uint32_t max, const char *fmt, ...)
-{
-    va_list vp;
-    va_start(vp, fmt);
-    auto len = vstrnfmt(buf, max, fmt, vp);
-    va_end(vp);
-    return len;
-}
-
-/*
  * Do a vstrnfmt() into (see above) into a (growable) static buffer.
  * This buffer is usable for very short term formatting of results.
  * Note that the buffer is (technically) writable, but only up to

--- a/src/term/z-form.h
+++ b/src/term/z-form.h
@@ -11,7 +11,6 @@
 #include <string>
 
 uint32_t vstrnfmt(char *buf, uint32_t max, const char *fmt, va_list vp);
-uint32_t strnfmt(char *buf, uint32_t max, const char *fmt, ...) __attribute__((format(printf, 3, 4)));
 std::string format(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
 void plog_fmt(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
 void quit_fmt(const char *fmt, ...) __attribute__((format(printf, 1, 2)));

--- a/src/term/z-form.h
+++ b/src/term/z-form.h
@@ -10,7 +10,7 @@
 #include "system/h-basic.h"
 #include <string>
 
-uint32_t vstrnfmt(char *buf, uint32_t max, const char *fmt, va_list vp);
+std::string vformat(const char *fmt, va_list vp);
 std::string format(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
 void plog_fmt(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
 void quit_fmt(const char *fmt, ...) __attribute__((format(printf, 1, 2)));

--- a/src/util/angband-files.cpp
+++ b/src/util/angband-files.cpp
@@ -146,9 +146,9 @@ static errr path_temp(char *buf, int max)
     }
 
 #if !defined(WIN32) || (defined(_MSC_VER) && (_MSC_VER >= 1900))
-    (void)strnfmt(buf, max, "%s", s);
+    angband_strcpy(buf, s, max);
 #else
-    (void)strnfmt(buf, max, ".%s", s);
+    angband_strcpy(buf, format(".%s", s), max);
 #endif
 
     return 0;

--- a/src/view/display-inventory.cpp
+++ b/src/view/display-inventory.cpp
@@ -31,7 +31,6 @@ COMMAND_CODE show_inventory(PlayerType *player_ptr, int target_item, BIT_FLAGS m
     COMMAND_CODE i;
     int k, l, z = 0;
     ItemEntity *o_ptr;
-    char tmp_val[80];
     COMMAND_CODE out_index[23]{};
     TERM_COLOR out_color[23]{};
     std::array<std::string, 23> out_desc{};
@@ -90,20 +89,21 @@ COMMAND_CODE show_inventory(PlayerType *player_ptr, int target_item, BIT_FLAGS m
         i = out_index[j];
         o_ptr = &player_ptr->inventory_list[i];
         prt("", j + 1, col ? col - 2 : col);
+        std::string head;
         if (use_menu && target_item) {
             if (j == (target_item - 1)) {
-                angband_strcpy(tmp_val, _("》", "> "), sizeof(tmp_val));
+                head = _("》", "> ");
                 target_item_label = i;
             } else {
-                angband_strcpy(tmp_val, "  ", sizeof(tmp_val));
+                head = "  ";
             }
         } else if (i <= INVEN_PACK) {
-            strnfmt(tmp_val, sizeof(tmp_val), "%c)", inven_label[i]);
+            head = format("%c)", inven_label[i]);
         } else {
-            strnfmt(tmp_val, sizeof(tmp_val), "%c)", index_to_label(i));
+            head = format("%c)", index_to_label(i));
         }
 
-        put_str(tmp_val, j + 1, col);
+        put_str(head, j + 1, col);
         cur_col = col + 3;
         if (show_item_graph) {
             term_queue_bigchar(cur_col, j + 1, { o_ptr->get_symbol(), {} });
@@ -117,8 +117,8 @@ COMMAND_CODE show_inventory(PlayerType *player_ptr, int target_item, BIT_FLAGS m
         c_put_str(out_color[j], out_desc[j], j + 1, cur_col);
         if (show_weights) {
             int wgt = o_ptr->weight * o_ptr->number;
-            strnfmt(tmp_val, sizeof(tmp_val), _("%3d.%1d kg", "%3d.%1d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
-            prt(tmp_val, j + 1, wid - 9);
+            const auto weight = format(_("%3d.%1d kg", "%3d.%1d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
+            prt(weight, j + 1, wid - 9);
         }
     }
 
@@ -138,7 +138,6 @@ void display_inventory(PlayerType *player_ptr, const ItemTester &item_tester)
 {
     int i, z = 0;
     TERM_COLOR attr = TERM_WHITE;
-    char tmp_val[80];
     if (!player_ptr || !player_ptr->inventory_list) {
         return;
     }
@@ -159,15 +158,15 @@ void display_inventory(PlayerType *player_ptr, const ItemTester &item_tester)
 
         auto o_ptr = &player_ptr->inventory_list[i];
         auto do_disp = item_tester.okay(o_ptr);
-        angband_strcpy(tmp_val, "   ", sizeof(tmp_val));
+        std::string label = "   ";
         if (do_disp) {
-            tmp_val[0] = index_to_label(i);
-            tmp_val[1] = ')';
+            label[0] = index_to_label(i);
+            label[1] = ')';
         }
 
         int cur_col = 3;
         term_erase(cur_col, i);
-        term_putstr(0, i, cur_col, TERM_WHITE, tmp_val);
+        term_putstr(0, i, cur_col, TERM_WHITE, label);
         const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
         attr = tval_to_attr[enum2i(o_ptr->bi_key.tval()) % 128];
         if (o_ptr->timeout) {
@@ -187,10 +186,10 @@ void display_inventory(PlayerType *player_ptr, const ItemTester &item_tester)
 
         if (show_weights) {
             int wgt = o_ptr->weight * o_ptr->number;
-            strnfmt(tmp_val, sizeof(tmp_val), _("%3d.%1d kg", "%3d.%1d lb"),
+            const auto weight = format(_("%3d.%1d kg", "%3d.%1d lb"),
                 _(lb_to_kg_integer(wgt), wgt / 10),
                 _(lb_to_kg_fraction(wgt), wgt % 10));
-            prt(tmp_val, i, wid - 9);
+            prt(weight, i, wid - 9);
         }
     }
 

--- a/src/view/display-messages.cpp
+++ b/src/view/display-messages.cpp
@@ -351,9 +351,8 @@ void msg_print(std::nullptr_t)
 void msg_format(const char *fmt, ...)
 {
     va_list vp;
-    char buf[1024];
     va_start(vp, fmt);
-    (void)vstrnfmt(buf, sizeof(buf), fmt, vp);
+    const auto buf = vformat(fmt, vp);
     va_end(vp);
     msg_print(buf);
 }

--- a/src/window/main-window-equipments.cpp
+++ b/src/window/main-window-equipments.cpp
@@ -34,7 +34,6 @@ COMMAND_CODE show_equipment(PlayerType *player_ptr, int target_item, BIT_FLAGS m
     COMMAND_CODE i;
     int j, k, l;
     ItemEntity *o_ptr;
-    char tmp_val[80];
     COMMAND_CODE out_index[23]{};
     TERM_COLOR out_color[23]{};
     std::array<std::string, 23> out_desc{};
@@ -94,20 +93,21 @@ COMMAND_CODE show_equipment(PlayerType *player_ptr, int target_item, BIT_FLAGS m
         i = out_index[j];
         o_ptr = &player_ptr->inventory_list[i];
         prt("", j + 1, col ? col - 2 : col);
+        std::string head;
         if (use_menu && target_item) {
             if (j == (target_item - 1)) {
-                angband_strcpy(tmp_val, _("》", "> "), sizeof(tmp_val));
+                head = _("》", "> ");
                 target_item_label = i;
             } else {
-                angband_strcpy(tmp_val, "  ", sizeof(tmp_val));
+                head = "  ";
             }
         } else if (i >= INVEN_MAIN_HAND) {
-            strnfmt(tmp_val, sizeof(tmp_val), "%c)", equip_label[i - INVEN_MAIN_HAND]);
+            head = format("%c)", equip_label[i - INVEN_MAIN_HAND]);
         } else {
-            strnfmt(tmp_val, sizeof(tmp_val), "%c)", index_to_label(i));
+            head = format("%c)", index_to_label(i));
         }
 
-        put_str(tmp_val, j + 1, col);
+        put_str(head, j + 1, col);
         int cur_col = col + 3;
         if (show_item_graph) {
             term_queue_bigchar(cur_col, j + 1, { o_ptr->get_symbol(), {} });
@@ -119,8 +119,8 @@ COMMAND_CODE show_equipment(PlayerType *player_ptr, int target_item, BIT_FLAGS m
         }
 
         if (show_labels) {
-            strnfmt(tmp_val, sizeof(tmp_val), _("%-7s: ", "%-14s: "), mention_use(player_ptr, i));
-            put_str(tmp_val, j + 1, cur_col);
+            const auto label = format(_("%-7s: ", "%-14s: "), mention_use(player_ptr, i));
+            put_str(label, j + 1, cur_col);
             c_put_str(out_color[j], out_desc[j], j + 1, _(cur_col + 9, cur_col + 16));
         } else {
             c_put_str(out_color[j], out_desc[j], j + 1, cur_col);
@@ -131,8 +131,8 @@ COMMAND_CODE show_equipment(PlayerType *player_ptr, int target_item, BIT_FLAGS m
         }
 
         int wgt = o_ptr->weight * o_ptr->number;
-        strnfmt(tmp_val, sizeof(tmp_val), _("%3d.%1d kg", "%3d.%d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
-        prt(tmp_val, j + 1, wid - 9);
+        const auto weight = format(_("%3d.%1d kg", "%3d.%d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10));
+        prt(weight, j + 1, wid - 9);
     }
 
     if (j && (j < 23)) {

--- a/src/wizard/wizard-messages.cpp
+++ b/src/wizard/wizard-messages.cpp
@@ -62,9 +62,8 @@ void msg_format_wizard(PlayerType *player_ptr, int cheat_type, const char *fmt, 
     }
 
     va_list vp;
-    char buf[1024];
     va_start(vp, fmt);
-    (void)vstrnfmt(buf, 1024, fmt, vp);
+    const auto buf = vformat(fmt, vp);
     va_end(vp);
     msg_print_wizard(player_ptr, cheat_type, buf);
 }


### PR DESCRIPTION
Resolves #3392

関数の引数に渡されたポインタへの書き込みや、静的変数への書き込みなどはいきなり std::string として扱うのは影響範囲が大きくなるため、このPRでは一旦 format で作成した文字列オブジェクトを angband_strcpy で書き込む形で対処しています。