### PR TITLE
モンスター撃破時に経験値が入らない不具合を修正した to develop

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 dnl Process this file with autoconf to produce a configure script.
-AC_INIT(hengband, 3.0.1.13-Beta)
+AC_INIT(hengband, 3.0.1.14-Beta)
 
 AC_CONFIG_MACRO_DIRS([m4])
 AC_CONFIG_HEADERS(src/autoconf.h)

--- a/doxygen/Hengband.doxyfile
+++ b/doxygen/Hengband.doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = Hengband
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 3.0.1.13-Beta
+PROJECT_NUMBER         = 3.0.1.14-Beta
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -84,14 +84,16 @@ MonsterDamageProcessor::MonsterDamageProcessor(PlayerType *player_ptr, MONSTER_I
 }
 
 /*!
- * @brief モンスターのHPをダメージに応じて減算する /
+ * @brief モンスターのHPをダメージに応じて減算する
  * @return モンスターが生きていればfalse、死んだらtrue
+ * @details exp_mon をコピーしているのは、撃破時の経験値を算出する頃にはmonsterが無効モンスターになっているため.
  */
 bool MonsterDamageProcessor::mon_take_hit(std::string_view note)
 {
     auto &monster = this->player_ptr->current_floor_ptr->m_list[this->m_idx];
+    const MonsterEntity exp_mon = monster;
     auto exp_dam = (monster.hp > this->dam) ? this->dam : monster.hp;
-    this->get_exp_from_mon(monster, exp_dam);
+    this->get_exp_from_mon(exp_mon, exp_dam);
     if (this->genocide_chaos_patron()) {
         return true;
     }
@@ -106,7 +108,7 @@ bool MonsterDamageProcessor::mon_take_hit(std::string_view note)
         msg_format(_("合計%d/%dのダメージを与えた。", "You do %d (out of %d) damage."), monster.dealt_damage, monster.maxhp);
     }
 
-    if (this->process_dead_exp_virtue(note, monster)) {
+    if (this->process_dead_exp_virtue(note, exp_mon)) {
         return true;
     }
 
@@ -128,7 +130,7 @@ bool MonsterDamageProcessor::genocide_chaos_patron()
     return this->m_idx == 0;
 }
 
-bool MonsterDamageProcessor::process_dead_exp_virtue(std::string_view note, const MonsterEntity &exp_monster)
+bool MonsterDamageProcessor::process_dead_exp_virtue(std::string_view note, const MonsterEntity &exp_mon)
 {
     auto &monster = this->player_ptr->current_floor_ptr->m_list[this->m_idx];
     auto &monrace = monster.get_real_monrace();
@@ -158,7 +160,7 @@ bool MonsterDamageProcessor::process_dead_exp_virtue(std::string_view note, cons
     this->show_bounty_message(m_name);
     monster_death(this->player_ptr, this->m_idx, true, this->attribute_flags);
     this->summon_special_unique();
-    this->get_exp_from_mon(exp_monster, exp_monster.max_maxhp * 2);
+    this->get_exp_from_mon(exp_mon, exp_mon.max_maxhp * 2);
     *this->fear = false;
     return true;
 }

--- a/src/monster/monster-damage.h
+++ b/src/monster/monster-damage.h
@@ -27,7 +27,7 @@ private:
     AttributeFlags attribute_flags{};
     void get_exp_from_mon(const MonsterEntity &monster, int exp_dam);
     bool genocide_chaos_patron();
-    bool process_dead_exp_virtue(std::string_view note, const MonsterEntity &monster);
+    bool process_dead_exp_virtue(std::string_view note, const MonsterEntity &exp_mon);
     void death_special_flag_monster();
     void death_unique_monster(MonsterRaceId r_idx);
     void increase_kill_numbers();

--- a/src/system/angband-version.h
+++ b/src/system/angband-version.h
@@ -24,7 +24,7 @@ constexpr std::string_view ROOT_VARIANT_NAME("Hengband");
 #define H_VER_MAJOR 3 //!< ゲームのバージョン定義(メジャー番号)
 #define H_VER_MINOR 0 //!< ゲームのバージョン定義(マイナー番号)
 #define H_VER_PATCH 1 //!< ゲームのバージョン定義(パッチ番号)
-#define H_VER_EXTRA 13 //!< ゲームのバージョン定義(エクストラ番号)
+#define H_VER_EXTRA 14 //!< ゲームのバージョン定義(エクストラ番号)
 
 /*!
  * @brief セーブファイルのバージョン(3.0.0から導入)


### PR DESCRIPTION
#4169 のコピーは必要なものだと判明しました
元に戻しましたのでご確認下さい
(手元では上手く再現しませんでした、再現する環境で試してみて下さい)