### PR TITLE
monraces_info からMonsterRaceInfo を取得している箇所をMonraceList に差し替えた その1

### DIFF
--- a/src/autopick/autopick-destroyer.cpp
+++ b/src/autopick/autopick-destroyer.cpp
@@ -48,8 +48,7 @@ static bool is_leave_special_item(PlayerType *player_ptr, ItemEntity *o_ptr)
     const auto &bi_key = o_ptr->bi_key;
     const auto tval = bi_key.tval();
     if (PlayerRace(player_ptr).equals(PlayerRaceType::BALROG)) {
-        const auto r_idx = i2enum<MonsterRaceId>(o_ptr->pval);
-        if (o_ptr->is_corpse() && angband_strchr("pht", monraces_info[r_idx].symbol_definition.character)) {
+        if (o_ptr->is_corpse() && angband_strchr("pht", o_ptr->get_monrace().symbol_definition.character)) {
             return false;
         }
     } else if (pc.equals(PlayerClassType::ARCHER)) {

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -433,15 +433,18 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, co
         entry->add(FLG_WANTED);
     }
 
-    const auto r_idx = i2enum<MonsterRaceId>(o_ptr->pval);
     const auto &bi_key = o_ptr->bi_key;
     const auto tval = bi_key.tval();
-    if ((tval == ItemKindType::CORPSE || tval == ItemKindType::STATUE) && monraces_info[r_idx].kind_flags.has(MonsterKindType::UNIQUE)) {
-        entry->add(FLG_UNIQUE);
+    if ((tval == ItemKindType::CORPSE) || (tval == ItemKindType::STATUE)) {
+        if (o_ptr->get_monrace().kind_flags.has(MonsterKindType::UNIQUE)) {
+            entry->add(FLG_UNIQUE);
+        }
     }
 
-    if (tval == ItemKindType::CORPSE && angband_strchr("pht", monraces_info[r_idx].symbol_definition.character)) {
-        entry->add(FLG_HUMAN);
+    if (tval == ItemKindType::CORPSE) {
+        if (angband_strchr("pht", o_ptr->get_monrace().symbol_definition.character)) {
+            entry->add(FLG_HUMAN);
+        }
     }
 
     if (o_ptr->is_spell_book() && !check_book_realm(player_ptr, bi_key)) {

--- a/src/autopick/autopick-matcher.cpp
+++ b/src/autopick/autopick-matcher.cpp
@@ -296,13 +296,18 @@ bool is_autopick_match(PlayerType *player_ptr, const ItemEntity *o_ptr, const au
     const auto &bi_key = o_ptr->bi_key;
     const auto tval = bi_key.tval();
     const auto sval = *bi_key.sval();
-    const auto r_idx = i2enum<MonsterRaceId>(o_ptr->pval);
-    if (entry.has(FLG_UNIQUE) && ((tval != ItemKindType::CORPSE && tval != ItemKindType::STATUE) || monraces_info[r_idx].kind_flags.has_not(MonsterKindType::UNIQUE))) {
-        return false;
+    if (entry.has(FLG_UNIQUE) && o_ptr->has_monrace()) {
+        const auto &monrace = o_ptr->get_monrace();
+        if (((tval != ItemKindType::CORPSE && tval != ItemKindType::STATUE) || monrace.kind_flags.has_not(MonsterKindType::UNIQUE))) {
+            return false;
+        }
     }
 
-    if (entry.has(FLG_HUMAN) && (tval != ItemKindType::CORPSE || !angband_strchr("pht", monraces_info[r_idx].symbol_definition.character))) {
-        return false;
+    if (entry.has(FLG_HUMAN) && o_ptr->has_monrace()) {
+        const auto &monrace = o_ptr->get_monrace();
+        if ((tval != ItemKindType::CORPSE || !angband_strchr("pht", monrace.symbol_definition.character))) {
+            return false;
+        }
     }
 
     if (entry.has(FLG_UNREADABLE) && check_book_realm(player_ptr, bi_key)) {

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -281,16 +281,16 @@ void exe_eat_food(PlayerType *player_ptr, INVENTORY_IDX i_idx)
     auto food_type = PlayerRace(player_ptr).food();
 
     /* Balrogs change humanoid corpses to energy */
-    const auto corpse_r_idx = i2enum<MonsterRaceId>(o_ptr->pval);
-    const auto search = angband_strchr("pht", monraces_info[corpse_r_idx].symbol_definition.character);
-    if (food_type == PlayerRaceFoodType::CORPSE && o_ptr->is_corpse() && (search != nullptr)) {
-        const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
-        msg_format(_("%sは燃え上り灰になった。精力を吸収した気がする。", "%s^ is burnt to ashes.  You absorb its vitality!"), item_name.data());
-        (void)set_food(player_ptr, PY_FOOD_MAX - 1);
+    if (food_type == PlayerRaceFoodType::CORPSE && o_ptr->is_corpse()) {
+        if (angband_strchr("pht", o_ptr->get_monrace().symbol_definition.character) != nullptr) {
+            const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+            msg_format(_("%sは燃え上り灰になった。精力を吸収した気がする。", "%s^ is burnt to ashes.  You absorb its vitality!"), item_name.data());
+            (void)set_food(player_ptr, PY_FOOD_MAX - 1);
 
-        rfu.set_flags(flags_srf);
-        vary_item(player_ptr, i_idx, -1);
-        return;
+            rfu.set_flags(flags_srf);
+            vary_item(player_ptr, i_idx, -1);
+            return;
+        }
     }
 
     if (PlayerRace(player_ptr).equals(PlayerRaceType::SKELETON)) {

--- a/src/effect/effect-item.cpp
+++ b/src/effect/effect-item.cpp
@@ -19,6 +19,7 @@
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
 #include "system/monster-entity.h"
+#include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
@@ -233,7 +234,7 @@ bool affect_item(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION r, POSITI
             }
 
             for (int i = 0; i < o_ptr->number; i++) {
-                auto corpse_r_idx = i2enum<MonsterRaceId>(o_ptr->pval);
+                const auto &monrace = o_ptr->get_monrace();
                 const auto sval = *o_ptr->bi_key.sval();
                 if (((sval == SV_CORPSE) && (randint1(100) > 80)) || ((sval == SV_SKELETON) && (randint1(100) > 60))) {
                     if (!note_kill) {
@@ -241,7 +242,7 @@ bool affect_item(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION r, POSITI
                     }
 
                     continue;
-                } else if (summon_named_creature(player_ptr, src_idx, y, x, corpse_r_idx, mode)) {
+                } else if (summon_named_creature(player_ptr, src_idx, y, x, monrace.idx, mode)) {
                     note_kill = _("生き返った。", " revived.");
                 } else if (!note_kill) {
                     note_kill = _("灰になった。", (plural ? " become dust." : " becomes dust."));

--- a/src/flavor/named-item-describer.cpp
+++ b/src/flavor/named-item-describer.cpp
@@ -248,10 +248,9 @@ static std::string describe_item_count_or_article_en(const ItemEntity &item, con
         return prefix;
     }
 
-    const auto corpse_r_idx = i2enum<MonsterRaceId>(item.pval);
-    auto is_unique_corpse = item.bi_key.tval() == ItemKindType::CORPSE;
-    is_unique_corpse &= monraces_info[corpse_r_idx].kind_flags.has(MonsterKindType::UNIQUE);
-    if ((opt.known && item.is_fixed_or_random_artifact()) || is_unique_corpse) {
+    auto is_unique_item = opt.known && item.is_fixed_or_random_artifact();
+    is_unique_item |= (item.bi_key.tval() == ItemKindType::CORPSE) && item.get_monrace().kind_flags.has(MonsterKindType::UNIQUE);
+    if (is_unique_item) {
         return "The ";
     }
 

--- a/src/flavor/tval-description-switcher.cpp
+++ b/src/flavor/tval-description-switcher.cpp
@@ -23,8 +23,7 @@
 static std::pair<std::string, std::string> describe_monster_ball(const ItemEntity &item, const describe_option_type &opt)
 {
     const auto &basename = item.get_baseitem().name;
-    const auto monrace_id = i2enum<MonsterRaceId>(item.pval);
-    const auto &monrace = monraces_info[monrace_id];
+    const auto &monrace = item.get_monrace();
     if (!opt.known) {
         return { basename, "" };
     }
@@ -49,8 +48,7 @@ static std::pair<std::string, std::string> describe_monster_ball(const ItemEntit
 static std::pair<std::string, std::string> describe_statue(const ItemEntity &item)
 {
     const auto &basename = item.get_baseitem().name;
-    const auto monrace_id = i2enum<MonsterRaceId>(item.pval);
-    const auto &monrace = monraces_info[monrace_id];
+    const auto &monrace = item.get_monrace();
 #ifdef JP
     const auto &modstr = monrace.name;
 #else
@@ -66,8 +64,7 @@ static std::pair<std::string, std::string> describe_statue(const ItemEntity &ite
 
 static std::pair<std::string, std::string> describe_corpse(const ItemEntity &item)
 {
-    const auto monrace_id = i2enum<MonsterRaceId>(item.pval);
-    const auto &monrace = monraces_info[monrace_id];
+    const auto &monrace = item.get_monrace();
 #ifdef JP
     const auto basename = "#%";
 #else

--- a/src/hpmp/hp-mp-regenerator.cpp
+++ b/src/hpmp/hp-mp-regenerator.cpp
@@ -227,8 +227,7 @@ void regenerate_captured_monsters(PlayerType *player_ptr)
         }
 
         heal = true;
-        const auto r_idx = i2enum<MonsterRaceId>(o_ptr->pval);
-        const auto *r_ptr = &monraces_info[r_idx];
+        const auto &monrace = o_ptr->get_monrace();
         if (o_ptr->captured_monster_current_hp < o_ptr->captured_monster_max_hp) {
             short frac = o_ptr->captured_monster_max_hp / 100;
             if (!frac) {
@@ -237,7 +236,7 @@ void regenerate_captured_monsters(PlayerType *player_ptr)
                 }
             }
 
-            if (r_ptr->misc_flags.has(MonsterMiscType::REGENERATE)) {
+            if (monrace.misc_flags.has(MonsterMiscType::REGENERATE)) {
                 frac *= 2;
             }
 

--- a/src/load/old/load-v1-5-0.cpp
+++ b/src/load/old/load-v1-5-0.cpp
@@ -261,11 +261,11 @@ void rd_item_old(ItemEntity *o_ptr)
         }
 
         if (tval == ItemKindType::CAPTURE) {
-            const auto &r_ref = monraces_info[i2enum<MonsterRaceId>(o_ptr->pval)];
-            if (r_ref.misc_flags.has(MonsterMiscType::FORCE_MAXHP)) {
-                o_ptr->captured_monster_max_hp = maxroll(r_ref.hdice, r_ref.hside);
+            const auto &monrace = o_ptr->get_monrace();
+            if (monrace.misc_flags.has(MonsterMiscType::FORCE_MAXHP)) {
+                o_ptr->captured_monster_max_hp = maxroll(monrace.hdice, monrace.hside);
             } else {
-                o_ptr->captured_monster_max_hp = damroll(r_ref.hdice, r_ref.hside);
+                o_ptr->captured_monster_max_hp = damroll(monrace.hdice, monrace.hside);
             }
             if (ironman_nightmare) {
                 o_ptr->captured_monster_max_hp = std::min<short>(MONSTER_MAXHP, o_ptr->captured_monster_max_hp * 2L);

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -45,141 +45,147 @@ bool exchange_cash(PlayerType *player_ptr)
     auto change = false;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     for (INVENTORY_IDX i = 0; i <= INVEN_SUB_HAND; i++) {
-        const auto item_ptr = &player_ptr->inventory_list[i];
-        const auto r_idx_of_item = static_cast<MonsterRaceId>(item_ptr->pval);
-        if ((item_ptr->bi_key.tval() != ItemKindType::CAPTURE) || (r_idx_of_item != MonsterRaceId::TSUCHINOKO)) {
+        const auto &item = player_ptr->inventory_list[i];
+        if (item.bi_key.tval() != ItemKindType::CAPTURE) {
+            continue;
+        }
+
+        if (item.get_monrace().idx != MonsterRaceId::TSUCHINOKO) {
             continue;
         }
 
         change = true;
-        const auto item_name = describe_flavor(player_ptr, item_ptr, 0);
+        const auto item_name = describe_flavor(player_ptr, &item, 0);
         if (!input_check(format(_("%s を換金しますか？", "Convert %s into money? "), item_name.data()))) {
             continue;
         }
 
-        msg_format(_("賞金 %ld＄を手に入れた。", "You get %ldgp."), (long int)(1000000L * item_ptr->number));
-        player_ptr->au += 1000000L * item_ptr->number;
+        msg_format(_("賞金 %ld＄を手に入れた。", "You get %ldgp."), (long int)(1000000L * item.number));
+        player_ptr->au += 1000000L * item.number;
         rfu.set_flag(MainWindowRedrawingFlag::GOLD);
-        vary_item(player_ptr, i, -item_ptr->number);
+        vary_item(player_ptr, i, -item.number);
     }
 
     for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
-        const auto item_ptr = &player_ptr->inventory_list[i];
-        const auto r_idx_of_item = static_cast<MonsterRaceId>(item_ptr->pval);
-        if (!item_ptr->is_corpse() || (r_idx_of_item != MonsterRaceId::TSUCHINOKO)) {
+        const auto &item = player_ptr->inventory_list[i];
+        if (!item.is_corpse()) {
+            continue;
+        }
+
+        if (item.get_monrace().idx != MonsterRaceId::TSUCHINOKO) {
             continue;
         }
 
         change = true;
-        const auto item_name = describe_flavor(player_ptr, item_ptr, 0);
+        const auto item_name = describe_flavor(player_ptr, &item, 0);
         if (!input_check(format(_("%s を換金しますか？", "Convert %s into money? "), item_name.data()))) {
             continue;
         }
 
-        msg_format(_("賞金 %ld＄を手に入れた。", "You get %ldgp."), (long int)(200000L * item_ptr->number));
-        player_ptr->au += 200000L * item_ptr->number;
+        msg_format(_("賞金 %ld＄を手に入れた。", "You get %ldgp."), (long int)(200000L * item.number));
+        player_ptr->au += 200000L * item.number;
         rfu.set_flag(MainWindowRedrawingFlag::GOLD);
-        vary_item(player_ptr, i, -item_ptr->number);
+        vary_item(player_ptr, i, -item.number);
     }
 
     for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
-        const auto item_ptr = &player_ptr->inventory_list[i];
-        const auto r_idx_of_item = static_cast<MonsterRaceId>(item_ptr->pval);
-        if ((item_ptr->bi_key != BaseitemKey(ItemKindType::CORPSE, SV_SKELETON)) || (r_idx_of_item != MonsterRaceId::TSUCHINOKO)) {
+        const auto &item = player_ptr->inventory_list[i];
+        if (item.bi_key != BaseitemKey(ItemKindType::CORPSE, SV_SKELETON)) {
+            continue;
+        }
+
+        if (item.get_monrace().idx != MonsterRaceId::TSUCHINOKO) {
             continue;
         }
 
         change = true;
-        const auto item_name = describe_flavor(player_ptr, item_ptr, 0);
+        const auto item_name = describe_flavor(player_ptr, &item, 0);
         if (!input_check(format(_("%s を換金しますか？", "Convert %s into money? "), item_name.data()))) {
             continue;
         }
 
-        msg_format(_("賞金 %ld＄を手に入れた。", "You get %ldgp."), (long int)(100000L * item_ptr->number));
-        player_ptr->au += 100000L * item_ptr->number;
+        msg_format(_("賞金 %ld＄を手に入れた。", "You get %ldgp."), (long int)(100000L * item.number));
+        player_ptr->au += 100000L * item.number;
         rfu.set_flag(MainWindowRedrawingFlag::GOLD);
-        vary_item(player_ptr, i, -item_ptr->number);
+        vary_item(player_ptr, i, -item.number);
     }
 
     for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
-        const auto item_ptr = &player_ptr->inventory_list[i];
-        const auto r_idx_of_item = static_cast<MonsterRaceId>(item_ptr->pval);
-        if (!item_ptr->is_corpse() || (monraces_info[r_idx_of_item].name != monraces_info[w_ptr->today_mon].name)) {
+        const auto &item = player_ptr->inventory_list[i];
+        if (!item.is_corpse() || (item.get_monrace().name != monraces_info[w_ptr->today_mon].name)) {
             continue;
         }
 
         change = true;
-        const auto item_name = describe_flavor(player_ptr, item_ptr, 0);
+        const auto item_name = describe_flavor(player_ptr, &item, 0);
         if (!input_check(format(_("%s を換金しますか？", "Convert %s into money? "), item_name.data()))) {
             continue;
         }
 
         constexpr auto mes = _("賞金 %ld＄を手に入れた。", "You get %ldgp.");
-        msg_format(mes, (long int)((monraces_info[w_ptr->today_mon].level * 50 + 100) * item_ptr->number));
-        player_ptr->au += (monraces_info[w_ptr->today_mon].level * 50 + 100) * item_ptr->number;
+        msg_format(mes, (long int)((monraces_info[w_ptr->today_mon].level * 50 + 100) * item.number));
+        player_ptr->au += (monraces_info[w_ptr->today_mon].level * 50 + 100) * item.number;
         rfu.set_flag(MainWindowRedrawingFlag::GOLD);
-        vary_item(player_ptr, i, -item_ptr->number);
+        vary_item(player_ptr, i, -item.number);
     }
 
     for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
-        const auto item_ptr = &player_ptr->inventory_list[i];
-        const auto r_idx_of_item = static_cast<MonsterRaceId>(item_ptr->pval);
-        if ((item_ptr->bi_key != BaseitemKey(ItemKindType::CORPSE, SV_SKELETON)) || (monraces_info[r_idx_of_item].name != monraces_info[w_ptr->today_mon].name)) {
+        const auto &item = player_ptr->inventory_list[i];
+        if ((item.bi_key != BaseitemKey(ItemKindType::CORPSE, SV_SKELETON)) || (item.get_monrace().name != monraces_info[w_ptr->today_mon].name)) {
             continue;
         }
 
         change = true;
-        const auto item_name = describe_flavor(player_ptr, item_ptr, 0);
+        const auto item_name = describe_flavor(player_ptr, &item, 0);
         if (!input_check(format(_("%s を換金しますか？", "Convert %s into money? "), item_name.data()))) {
             continue;
         }
 
         constexpr auto mes = _("賞金 %ld＄を手に入れた。", "You get %ldgp.");
-        msg_format(mes, (long int)((monraces_info[w_ptr->today_mon].level * 30 + 60) * item_ptr->number));
-        player_ptr->au += (monraces_info[w_ptr->today_mon].level * 30 + 60) * item_ptr->number;
+        msg_format(mes, (long int)((monraces_info[w_ptr->today_mon].level * 30 + 60) * item.number));
+        player_ptr->au += (monraces_info[w_ptr->today_mon].level * 30 + 60) * item.number;
         rfu.set_flag(MainWindowRedrawingFlag::GOLD);
-        vary_item(player_ptr, i, -item_ptr->number);
+        vary_item(player_ptr, i, -item.number);
     }
 
-    for (auto &[r_idx, is_achieved] : w_ptr->bounties) {
+    for (auto &[monrace_id, is_achieved] : w_ptr->bounties) {
         if (is_achieved) {
             continue;
         }
 
         for (INVENTORY_IDX i = INVEN_PACK - 1; i >= 0; i--) {
-            const auto item_ptr = &player_ptr->inventory_list[i];
-            const auto r_idx_of_item = static_cast<MonsterRaceId>(item_ptr->pval);
-            if ((item_ptr->bi_key.tval() != ItemKindType::CORPSE) || (r_idx_of_item != r_idx)) {
+            auto &item = player_ptr->inventory_list[i];
+            if ((item.bi_key.tval() != ItemKindType::CORPSE) || (item.get_monrace().idx != monrace_id)) {
                 continue;
             }
 
             INVENTORY_IDX inventory_new;
-            const auto item_name = describe_flavor(player_ptr, item_ptr, 0);
+            const auto item_name = describe_flavor(player_ptr, &item, 0);
             if (!input_check(format(_("%sを渡しますか？", "Hand %s over? "), item_name.data()))) {
                 continue;
             }
 
-            vary_item(player_ptr, i, -item_ptr->number);
+            vary_item(player_ptr, i, -item.number);
             chg_virtue(player_ptr, Virtue::JUSTICE, 5);
             is_achieved = true;
 
             auto num = static_cast<int>(std::count_if(std::begin(w_ptr->bounties), std::end(w_ptr->bounties),
-                [](const auto &b_ref) { return b_ref.is_achieved; }));
+                [](const auto &bounty) { return bounty.is_achieved; }));
 
             msg_print(_(format("これで合計 %d ポイント獲得しました。", num), format("You earned %d point%s total.", num, (num > 1 ? "s" : ""))));
 
-            ItemEntity item(prize_list[num - 1]);
-            ItemMagicApplier(player_ptr, &item, player_ptr->current_floor_ptr->object_level, AM_NO_FIXED_ART).execute();
-            object_aware(player_ptr, &item);
-            item.mark_as_known();
+            ItemEntity prize_item(prize_list[num - 1]);
+            ItemMagicApplier(player_ptr, &prize_item, player_ptr->current_floor_ptr->object_level, AM_NO_FIXED_ART).execute();
+            object_aware(player_ptr, &prize_item);
+            prize_item.mark_as_known();
 
             /*
              * Hand it --- Assume there is an empty slot.
              * Since a corpse is handed at first,
              * there is at least one empty slot.
              */
-            inventory_new = store_item_to_inventory(player_ptr, &item);
-            const auto got_item_name = describe_flavor(player_ptr, &item, 0);
+            inventory_new = store_item_to_inventory(player_ptr, &prize_item);
+            const auto got_item_name = describe_flavor(player_ptr, &prize_item, 0);
             msg_format(_("%s(%c)を貰った。", "You get %s (%c). "), got_item_name.data(), index_to_label(inventory_new));
 
             autopick_alter_item(player_ptr, inventory_new, false);

--- a/src/monster/monster-info.cpp
+++ b/src/monster/monster-info.cpp
@@ -138,7 +138,7 @@ bool monster_can_cross_terrain(PlayerType *player_ptr, FEAT_IDX feat, const Mons
  * @param mode オプション
  * @return 踏破可能ならばTRUEを返す
  */
-bool monster_can_enter(PlayerType *player_ptr, POSITION y, POSITION x, MonsterRaceInfo *r_ptr, BIT_FLAGS16 mode)
+bool monster_can_enter(PlayerType *player_ptr, POSITION y, POSITION x, const MonsterRaceInfo *r_ptr, BIT_FLAGS16 mode)
 {
     const Pos2D pos(y, x);
     auto &grid = player_ptr->current_floor_ptr->get_grid(pos);

--- a/src/monster/monster-info.h
+++ b/src/monster/monster-info.h
@@ -13,7 +13,7 @@ class MonsterRaceInfo;
 class MonsterEntity;
 class PlayerType;
 bool monster_can_cross_terrain(PlayerType *player_ptr, FEAT_IDX feat, const MonsterRaceInfo *r_ptr, BIT_FLAGS16 mode);
-bool monster_can_enter(PlayerType *player_ptr, POSITION y, POSITION x, MonsterRaceInfo *r_ptr, BIT_FLAGS16 mode);
+bool monster_can_enter(PlayerType *player_ptr, POSITION y, POSITION x, const MonsterRaceInfo *r_ptr, BIT_FLAGS16 mode);
 bool monster_has_hostile_align(PlayerType *player_ptr, MonsterEntity *m_ptr, int pa_good, int pa_evil, const MonsterRaceInfo *r_ptr);
 bool is_original_ap_and_seen(PlayerType *player_ptr, const MonsterEntity *m_ptr);
 std::string monster_name(PlayerType *player_ptr, MONSTER_IDX m_idx);

--- a/src/mspell/mspell-checker.cpp
+++ b/src/mspell/mspell-checker.cpp
@@ -118,8 +118,8 @@ bool raise_possible(PlayerType *player_ptr, MonsterEntity *m_ptr)
             for (const auto this_o_idx : g_ptr->o_idx_list) {
                 const auto &item = floor_ptr->o_list[this_o_idx];
                 if (item.bi_key.tval() == ItemKindType::CORPSE) {
-                    auto corpse_r_idx = i2enum<MonsterRaceId>(item.pval);
-                    if (!monster_has_hostile_align(player_ptr, m_ptr, 0, 0, &monraces_info[corpse_r_idx])) {
+                    const auto &monrace = item.get_monrace();
+                    if (!monster_has_hostile_align(player_ptr, m_ptr, 0, 0, &monrace)) {
                         return true;
                     }
                 }

--- a/src/object-hook/hook-expendable.cpp
+++ b/src/object-hook/hook-expendable.cpp
@@ -35,8 +35,8 @@ bool item_tester_hook_eatable(PlayerType *player_ptr, const ItemEntity *o_ptr)
             return true;
         }
     } else if (food_type == PlayerRaceFoodType::CORPSE) {
-        auto corpse_r_idx = i2enum<MonsterRaceId>(o_ptr->pval);
-        if (o_ptr->is_corpse() && angband_strchr("pht", monraces_info[corpse_r_idx].symbol_definition.character)) {
+        const auto &monrace = o_ptr->get_monrace();
+        if (o_ptr->is_corpse() && angband_strchr("pht", monrace.symbol_definition.character)) {
             return true;
         }
     }

--- a/src/object-hook/hook-quest.cpp
+++ b/src/object-hook/hook-quest.cpp
@@ -28,14 +28,12 @@ bool object_is_bounty(PlayerType *player_ptr, const ItemEntity *o_ptr)
         return false;
     }
 
-    const auto corpse_monrace_id = i2enum<MonsterRaceId>(o_ptr->pval);
-    const auto &monraces = MonraceList::get_instance();
-    const auto &monrace = monraces.get_monrace(corpse_monrace_id);
+    const auto &monrace = o_ptr->get_monrace();
     if (player_ptr->knows_daily_bounty && (monrace.name == monraces_info[w_ptr->today_mon].name)) {
         return true;
     }
 
-    if (corpse_monrace_id == MonsterRaceId::TSUCHINOKO) {
+    if (monrace.idx == MonsterRaceId::TSUCHINOKO) {
         return true;
     }
 

--- a/src/object/object-value.cpp
+++ b/src/object/object-value.cpp
@@ -207,8 +207,7 @@ PRICE object_value_real(const ItemEntity *o_ptr)
         break;
     }
     case ItemKindType::FIGURINE: {
-        auto figure_r_idx = i2enum<MonsterRaceId>(o_ptr->pval);
-        DEPTH level = monraces_info[figure_r_idx].level;
+        const auto level = o_ptr->get_monrace().level;
         if (level < 20) {
             value = level * 50L;
         } else if (level < 30) {
@@ -223,11 +222,11 @@ PRICE object_value_real(const ItemEntity *o_ptr)
         break;
     }
     case ItemKindType::CAPTURE: {
-        auto captured_monrace_id = i2enum<MonsterRaceId>(o_ptr->pval);
-        if (!MonraceList::is_valid(captured_monrace_id)) {
+        const auto &monrace = o_ptr->get_monrace();
+        if (!monrace.is_valid()) {
             value = 1000L;
         } else {
-            value = ((monraces_info[captured_monrace_id].level) * 50L + 1000);
+            value = monrace.level * 50 + 1000;
         }
         break;
     }

--- a/src/perception/identification.cpp
+++ b/src/perception/identification.cpp
@@ -96,11 +96,10 @@ bool screen_object(PlayerType *player_ptr, ItemEntity *o_ptr, BIT_FLAGS mode)
     }
 
     if (bi_key.tval() == ItemKindType::STATUE) {
-        auto statue_r_idx = i2enum<MonsterRaceId>(o_ptr->pval);
-        auto *r_ptr = &monraces_info[statue_r_idx];
-        if (statue_r_idx == MonsterRaceId::BULLGATES) {
+        const auto &monrace = o_ptr->get_monrace();
+        if (monrace.idx == MonsterRaceId::BULLGATES) {
             info[i++] = _("それは部屋に飾ると恥ずかしい。", "It is shameful.");
-        } else if (r_ptr->misc_flags.has(MonsterMiscType::ELDRITCH_HORROR)) {
+        } else if (monrace.misc_flags.has(MonsterMiscType::ELDRITCH_HORROR)) {
             info[i++] = _("それは部屋に飾ると恐い。", "It is fearful.");
         } else {
             info[i++] = _("それは部屋に飾ると楽しい。", "It is cheerful.");
@@ -797,12 +796,11 @@ bool screen_object(PlayerType *player_ptr, ItemEntity *o_ptr, BIT_FLAGS mode)
     }
 
     if (bi_key == BaseitemKey(ItemKindType::STATUE, SV_PHOTO)) {
-        auto statue_r_idx = i2enum<MonsterRaceId>(o_ptr->pval);
-        const auto &monrace = monraces_info[statue_r_idx];
-        int namelen = strlen(monrace.name.data());
+        const auto &monrace = o_ptr->get_monrace();
+        const auto name_length = monrace.name.length();
         prt(format("%s: '", monrace.name.data()), 1, 15);
-        term_queue_bigchar(18 + namelen, 1, { monrace.symbol_config, {} });
-        prt("'", 1, (use_bigtile ? 20 : 19) + namelen);
+        term_queue_bigchar(18 + name_length, 1, { monrace.symbol_config, {} });
+        prt("'", 1, (use_bigtile ? 20 : 19) + name_length);
     } else {
         prt(_("     アイテムの能力:", "     Item Attributes:"), 1, 15);
     }

--- a/src/specific-object/monster-ball.cpp
+++ b/src/specific-object/monster-ball.cpp
@@ -94,13 +94,13 @@ static void restore_monster_nickname(MonsterEntity &monster, ItemEntity &item)
 
 static bool release_monster(PlayerType *player_ptr, ItemEntity &item, DIRECTION dir)
 {
-    const auto r_idx = i2enum<MonsterRaceId>(item.pval);
+    const auto &monrace = item.get_monrace();
     const auto pos = player_ptr->get_neighbor(dir);
-    if (!monster_can_enter(player_ptr, pos.y, pos.x, &monraces_info[r_idx], 0)) {
+    if (!monster_can_enter(player_ptr, pos.y, pos.x, &monrace, 0)) {
         return false;
     }
 
-    if (!place_specific_monster(player_ptr, 0, pos.y, pos.x, r_idx, PM_FORCE_PET | PM_NO_KAGE)) {
+    if (!place_specific_monster(player_ptr, 0, pos.y, pos.x, monrace.idx, PM_FORCE_PET | PM_NO_KAGE)) {
         return false;
     }
 

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -120,7 +120,7 @@ struct AmusementRewardItemVisitor {
         ItemMagicApplier(player_ptr, &item, 1, AM_NO_FIXED_ART).execute();
 
         if (this->flag == AmusementFlagType::NO_UNIQUE) {
-            if (monraces_info[i2enum<MonsterRaceId>(item.pval)].kind_flags.has(MonsterKindType::UNIQUE)) {
+            if (item.has_monrace() && item.get_monrace().kind_flags.has(MonsterKindType::UNIQUE)) {
                 return std::nullopt;
             }
         }

--- a/src/spell/spells-summon.cpp
+++ b/src/spell/spells-summon.cpp
@@ -224,10 +224,7 @@ bool cast_summon_greater_demon(PlayerType *player_ptr)
         return false;
     }
 
-    PLAYER_LEVEL plev = player_ptr->lev;
-    auto corpse_r_idx = i2enum<MonsterRaceId>(o_ptr->pval);
-    int summon_lev = plev * 2 / 3 + monraces_info[corpse_r_idx].level;
-
+    const auto summon_lev = player_ptr->lev * 2 / 3 + o_ptr->get_monrace().level;
     if (summon_specific(player_ptr, -1, player_ptr->y, player_ptr->x, summon_lev, SUMMON_HI_DEMON, (PM_ALLOW_GROUP | PM_FORCE_PET))) {
         msg_print(_("硫黄の悪臭が充満した。", "The area fills with a stench of sulphur and brimstone."));
         msg_print(_("「ご用でございますか、ご主人様」", "'What is thy bidding... Master?'"));

--- a/src/store/service-checker.cpp
+++ b/src/store/service-checker.cpp
@@ -100,7 +100,7 @@ static bool check_store_temple(const ItemEntity &item)
         return true;
     case ItemKindType::FIGURINE:
     case ItemKindType::STATUE: {
-        const auto &monrace = monraces_info[i2enum<MonsterRaceId>(item.pval)];
+        const auto &monrace = item.get_monrace();
         if (monrace.kind_flags.has_not(MonsterKindType::EVIL)) {
             auto can_sell = monrace.kind_flags.has(MonsterKindType::GOOD);
             can_sell |= monrace.kind_flags.has(MonsterKindType::ANIMAL);

--- a/src/system/baseitem-info.cpp
+++ b/src/system/baseitem-info.cpp
@@ -557,6 +557,20 @@ bool BaseitemKey::is_corpse() const
     return *this == BaseitemKey(ItemKindType::CORPSE, SV_CORPSE);
 }
 
+bool BaseitemKey::is_monster() const
+{
+    switch (this->type_value) {
+    case ItemKindType::SKELETON:
+    case ItemKindType::FIGURINE:
+    case ItemKindType::STATUE:
+    case ItemKindType::CORPSE:
+    case ItemKindType::CAPTURE:
+        return true;
+    default:
+        return false;
+    }
+}
+
 bool BaseitemKey::is_mushrooms() const
 {
     if (!this->subtype_value) {

--- a/src/system/baseitem-info.h
+++ b/src/system/baseitem-info.h
@@ -84,6 +84,7 @@ public:
     bool is_lance() const;
     bool is_readable() const;
     bool is_corpse() const;
+    bool is_monster() const;
 
 private:
     ItemKindType type_value;

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -30,6 +30,7 @@ class ArtifactType;
 class BaseitemInfo;
 class DisplaySymbol;
 class EgoItemDefinition;
+class MonsterRaceInfo;
 class ItemEntity {
 public:
     ItemEntity();
@@ -154,6 +155,8 @@ public:
     TrFlags get_flags() const;
     TrFlags get_flags_known() const;
     std::string explain_activation() const;
+    bool has_monrace() const;
+    const MonsterRaceInfo &get_monrace() const;
 
     void mark_as_known();
     void mark_as_tried() const;

--- a/src/system/monster-race-info.cpp
+++ b/src/system/monster-race-info.cpp
@@ -204,6 +204,37 @@ int MonsterRaceInfo::calc_power() const
     return power;
 }
 
+int MonsterRaceInfo::calc_figurine_value() const
+{
+    const auto figurine_level = this->level;
+    if (figurine_level < 20) {
+        return figurine_level * 50;
+    }
+
+    if (figurine_level < 30) {
+        return 1000 + (figurine_level - 20) * 150;
+    }
+
+    if (figurine_level < 40) {
+        return 2500 + (figurine_level - 30) * 350;
+    }
+
+    if (figurine_level < 50) {
+        return 6000 + (figurine_level - 40) * 800;
+    }
+
+    return 14000 + (figurine_level - 50) * 2000;
+}
+
+int MonsterRaceInfo::calc_capture_value() const
+{
+    if (!this->is_valid()) {
+        return 1000;
+    }
+
+    return this->level * 50 + 1000;
+}
+
 const std::map<MonsterRaceId, std::set<MonsterRaceId>> MonraceList::unified_uniques = {
     { MonsterRaceId::BANORLUPART, { MonsterRaceId::BANOR, MonsterRaceId::LUPART } },
 };
@@ -276,6 +307,11 @@ std::map<MonsterRaceId, MonsterRaceInfo>::reverse_iterator MonraceList::rend()
 std::map<MonsterRaceId, MonsterRaceInfo>::const_reverse_iterator MonraceList::rend() const
 {
     return monraces_info.crend();
+}
+
+size_t MonraceList::size() const
+{
+    return monraces_info.size();
 }
 
 /*!
@@ -447,37 +483,6 @@ bool MonraceList::can_select_separate(const MonsterRaceId monrace_id, const int 
     }
 
     return std::all_of(found_separates.begin(), found_separates.end(), [this](const auto x) { return this->get_monrace(x).max_num > 0; });
-}
-
-int MonraceList::calc_figurine_value(const MonsterRaceId monrace_id) const
-{
-    const auto level = this->get_monrace(monrace_id).level;
-    if (level < 20) {
-        return level * 50;
-    }
-
-    if (level < 30) {
-        return 1000 + (level - 20) * 150;
-    }
-
-    if (level < 40) {
-        return 2500 + (level - 30) * 350;
-    }
-
-    if (level < 50) {
-        return 6000 + (level - 40) * 800;
-    }
-
-    return 14000 + (level - 50) * 2000;
-}
-
-int MonraceList::calc_capture_value(const MonsterRaceId monrace_id) const
-{
-    if (monrace_id == MonsterRaceId::PLAYER) {
-        return 1000;
-    }
-
-    return this->get_monrace(monrace_id).level * 50 + 1000;
 }
 
 bool MonraceList::order(MonsterRaceId id1, MonsterRaceId id2, bool is_detailed) const

--- a/src/system/monster-race-info.h
+++ b/src/system/monster-race-info.h
@@ -150,6 +150,8 @@ public:
     const MonsterRaceInfo &get_next() const;
     bool is_bounty(bool unachieved_only) const;
     int calc_power() const;
+    int calc_figurine_value() const;
+    int calc_capture_value() const;
 };
 
 extern std::map<MonsterRaceId, MonsterRaceInfo> monraces_info;
@@ -173,6 +175,7 @@ public:
     std::map<MonsterRaceId, MonsterRaceInfo>::const_reverse_iterator rbegin() const;
     std::map<MonsterRaceId, MonsterRaceInfo>::reverse_iterator rend();
     std::map<MonsterRaceId, MonsterRaceInfo>::const_reverse_iterator rend() const;
+    size_t size() const;
     MonsterRaceInfo &get_monrace(MonsterRaceId monrace_id);
     const MonsterRaceInfo &get_monrace(MonsterRaceId monrace_id) const;
     const std::vector<MonsterRaceId> &get_valid_monrace_ids() const;
@@ -184,8 +187,6 @@ public:
     bool exists_separates(const MonsterRaceId r_idx) const;
     bool is_separated(const MonsterRaceId r_idx) const;
     bool can_select_separate(const MonsterRaceId morace_id, const int hp, const int maxhp) const;
-    int calc_figurine_value(const MonsterRaceId monrace_id) const;
-    int calc_capture_value(const MonsterRaceId morace_id) const;
     bool order(MonsterRaceId id1, MonsterRaceId id2, bool is_detailed = false) const;
     bool order_level(MonsterRaceId id1, MonsterRaceId id2) const;
     MonsterRaceId pick_id_at_random() const;

--- a/src/util/object-sort.cpp
+++ b/src/util/object-sort.cpp
@@ -107,6 +107,7 @@ bool object_sort_comp(PlayerType *player_ptr, ItemEntity *o_ptr, int32_t o_value
     }
 
     switch (o_tval) {
+    case ItemKindType::SKELETON:
     case ItemKindType::FIGURINE:
     case ItemKindType::STATUE:
     case ItemKindType::CORPSE:

--- a/src/util/object-sort.cpp
+++ b/src/util/object-sort.cpp
@@ -111,13 +111,13 @@ bool object_sort_comp(PlayerType *player_ptr, ItemEntity *o_ptr, int32_t o_value
     case ItemKindType::STATUE:
     case ItemKindType::CORPSE:
     case ItemKindType::CAPTURE: {
-        auto o_r_idx = i2enum<MonsterRaceId>(o_ptr->pval);
-        auto j_r_idx = i2enum<MonsterRaceId>(j_ptr->pval);
-        if (monraces_info[o_r_idx].level < monraces_info[j_r_idx].level) {
+        const auto &monrace1 = o_ptr->get_monrace();
+        const auto &monrace2 = j_ptr->get_monrace();
+        if (monrace1.level < monrace2.level) {
             return true;
         }
 
-        if ((monraces_info[o_r_idx].level == monraces_info[j_r_idx].level) && (o_ptr->pval < j_ptr->pval)) {
+        if ((monrace1.level == monrace2.level) && (o_ptr->pval < j_ptr->pval)) {
             return true;
         }
 


### PR DESCRIPTION
~~PlayerType::monster\_race\_idx が曲者ですが暫定措置で別途対応します~~
~~また、~~ 以前からMonsterRaceId 5000番とかいう変なオブジェクトが生成されていましたが (悪さはしなかった)、原因が判明したので修正しています
原因：ItemEntityのpvalだけ見ていて、それがモンスターかろくすっぽ判定していない箇所があった

一応起動及び軽く骨/死体の生成を試しましたが特に問題なさそうです
ご確認下さい