### PR TITLE
モンスターのHPバー管理をHealthBarTracker に移した

### DIFF
--- a/Hengband/Hengband/Hengband.vcxproj
+++ b/Hengband/Hengband/Hengband.vcxproj
@@ -629,6 +629,7 @@
     <ClCompile Include="..\..\src\timed-effect\player-stun.cpp" />
     <ClCompile Include="..\..\src\timed-effect\timed-effects.cpp" />
     <ClCompile Include="..\..\src\tracking\baseitem-tracker.cpp" />
+    <ClCompile Include="..\..\src\tracking\health-bar-tracker.cpp" />
     <ClCompile Include="..\..\src\tracking\lore-tracker.cpp" />
     <ClCompile Include="..\..\src\util\candidate-selector.cpp" />
     <ClCompile Include="..\..\src\util\rng-xoshiro.cpp" />
@@ -1441,6 +1442,7 @@
     <ClInclude Include="..\..\src\timed-effect\player-stun.h" />
     <ClInclude Include="..\..\src\timed-effect\timed-effects.h" />
     <ClInclude Include="..\..\src\tracking\baseitem-tracker.h" />
+    <ClInclude Include="..\..\src\tracking\health-bar-tracker.h" />
     <ClInclude Include="..\..\src\tracking\lore-tracker.h" />
     <ClInclude Include="..\..\src\util\bit-flags-calculator.h" />
     <ClInclude Include="..\..\src\util\buffer-shaper.h" />

--- a/Hengband/Hengband/Hengband.vcxproj.filters
+++ b/Hengband/Hengband/Hengband.vcxproj.filters
@@ -2505,6 +2505,9 @@
     <ClCompile Include="..\..\src\tracking\baseitem-tracker.cpp">
       <Filter>tracking</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\tracking\health-bar-tracker.cpp">
+      <Filter>tracking</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5422,6 +5425,9 @@
       <Filter>tracking</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\tracking\baseitem-tracker.h">
+      <Filter>tracking</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\tracking\health-bar-tracker.h">
       <Filter>tracking</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -967,6 +967,7 @@ hengband_SOURCES = \
 	timed-effect/timed-effects.cpp timed-effect/timed-effects.h \
 	\
 	tracking/baseitem-tracker.cpp tracking/baseitem-tracker.h \
+	tracking/health-bar-tracker.cpp tracking/health-bar-tracker.h \
 	tracking/lore-tracker.cpp tracking/lore-tracker.h \
 	\
 	util/angband-files.cpp util/angband-files.h \

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -57,6 +57,7 @@
 #include "target/target-types.h"
 #include "term/screen-processor.h"
 #include "timed-effect/timed-effects.h"
+#include "tracking/health-bar-tracker.h"
 #include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
 #include "util/string-processor.h"
@@ -270,9 +271,7 @@ bool do_cmd_riding(PlayerType *player_ptr, bool force)
         }
 
         player_ptr->riding = grid.m_idx;
-
-        /* Hack -- remove tracked monster */
-        if (player_ptr->riding == player_ptr->health_who) {
+        if (HealthBarTracker::get_instance().is_tracking(player_ptr->riding)) {
             health_track(player_ptr, 0);
         }
     }

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -55,6 +55,7 @@
 #include "system/redrawing-flags-updater.h"
 #include "term/screen-processor.h"
 #include "timed-effect/timed-effects.h"
+#include "tracking/health-bar-tracker.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "window/display-sub-windows.h"
@@ -363,10 +364,7 @@ void process_player(PlayerType *player_ptr)
                         m_ptr->mflag2.reset(MonsterConstantFlagType::MARK);
                         m_ptr->ml = false;
                         update_monster(player_ptr, m_idx, false);
-                        if (player_ptr->health_who == m_idx) {
-                            rfu.set_flag(MainWindowRedrawingFlag::HEALTH);
-                        }
-
+                        HealthBarTracker::get_instance().set_flag_if_tracking(m_idx);
                         if (player_ptr->riding == m_idx) {
                             rfu.set_flag(MainWindowRedrawingFlag::UHEALTH);
                         }

--- a/src/core/stuff-handler.cpp
+++ b/src/core/stuff-handler.cpp
@@ -4,6 +4,7 @@
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "tracking/baseitem-tracker.h"
+#include "tracking/health-bar-tracker.h"
 
 /*!
  * @brief 全更新処理をチェックして処理していく
@@ -36,8 +37,7 @@ void health_track(PlayerType *player_ptr, short m_idx)
         return;
     }
 
-    player_ptr->health_who = m_idx;
-    RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::HEALTH);
+    HealthBarTracker::get_instance().set_trackee(m_idx);
 }
 
 bool update_player()

--- a/src/effect/effect-monster-oldies.cpp
+++ b/src/effect/effect-monster-oldies.cpp
@@ -13,6 +13,7 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
+#include "tracking/health-bar-tracker.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 
@@ -80,14 +81,10 @@ ProcessResult effect_monster_star_heal(PlayerType *player_ptr, EffectMonster *em
         em_ptr->m_ptr->maxhp = em_ptr->m_ptr->max_maxhp;
     }
 
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
     if (!em_ptr->dam) {
-        if (player_ptr->health_who == em_ptr->g_ptr->m_idx) {
-            rfu.set_flag(MainWindowRedrawingFlag::HEALTH);
-        }
-
+        HealthBarTracker::get_instance().set_flag_if_tracking(em_ptr->g_ptr->m_idx);
         if (player_ptr->riding == em_ptr->g_ptr->m_idx) {
-            rfu.set_flag(MainWindowRedrawingFlag::UHEALTH);
+            RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);
         }
 
         return ProcessResult::PROCESS_FALSE;
@@ -175,13 +172,9 @@ ProcessResult effect_monster_old_heal(PlayerType *player_ptr, EffectMonster *em_
         }
     }
 
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    if (player_ptr->health_who == em_ptr->g_ptr->m_idx) {
-        rfu.set_flag(MainWindowRedrawingFlag::HEALTH);
-    }
-
+    HealthBarTracker::get_instance().set_flag_if_tracking(em_ptr->g_ptr->m_idx);
     if (player_ptr->riding == em_ptr->g_ptr->m_idx) {
-        rfu.set_flag(MainWindowRedrawingFlag::UHEALTH);
+        RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);
     }
 
     em_ptr->note = _("は体力を回復したようだ。", " looks healthier.");

--- a/src/effect/effect-monster-spirit.cpp
+++ b/src/effect/effect-monster-spirit.cpp
@@ -12,6 +12,7 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
+#include "tracking/health-bar-tracker.h"
 #include "util/bit-flags-calculator.h"
 #include "util/string-processor.h"
 #include "view/display-messages.h"
@@ -49,13 +50,9 @@ ProcessResult effect_monster_drain_mana(PlayerType *player_ptr, EffectMonster *e
         em_ptr->m_caster_ptr->hp = em_ptr->m_caster_ptr->maxhp;
     }
 
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    if (player_ptr->health_who == em_ptr->src_idx) {
-        rfu.set_flag(MainWindowRedrawingFlag::HEALTH);
-    }
-
+    HealthBarTracker::get_instance().set_flag_if_tracking(em_ptr->src_idx);
     if (player_ptr->riding == em_ptr->src_idx) {
-        rfu.set_flag(MainWindowRedrawingFlag::UHEALTH);
+        RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);
     }
 
     if (em_ptr->see_s_msg) {

--- a/src/effect/effect-monster.cpp
+++ b/src/effect/effect-monster.cpp
@@ -47,6 +47,7 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
+#include "tracking/health-bar-tracker.h"
 #include "tracking/lore-tracker.h"
 #include "util/bit-flags-calculator.h"
 #include "util/string-processor.h"
@@ -235,13 +236,9 @@ static bool deal_effect_damage_from_monster(PlayerType *player_ptr, EffectMonste
         return false;
     }
 
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    if (player_ptr->health_who == em_ptr->g_ptr->m_idx) {
-        rfu.set_flag(MainWindowRedrawingFlag::HEALTH);
-    }
-
+    HealthBarTracker::get_instance().set_flag_if_tracking(em_ptr->g_ptr->m_idx);
     if (player_ptr->riding == em_ptr->g_ptr->m_idx) {
-        rfu.set_flag(MainWindowRedrawingFlag::UHEALTH);
+        RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);
     }
 
     (void)set_monster_csleep(player_ptr, em_ptr->g_ptr->m_idx, 0);
@@ -625,8 +622,7 @@ static void update_phase_out_stat(PlayerType *player_ptr, EffectMonster *em_ptr)
         return;
     }
 
-    player_ptr->health_who = em_ptr->g_ptr->m_idx;
-    RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::HEALTH);
+    HealthBarTracker::get_instance().set_trackee(em_ptr->g_ptr->m_idx);
     handle_stuff(player_ptr);
 }
 

--- a/src/effect/effect-player-spirit.cpp
+++ b/src/effect/effect-player-spirit.cpp
@@ -11,6 +11,7 @@
 #include "system/monster-entity.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
+#include "tracking/health-bar-tracker.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 
@@ -59,9 +60,7 @@ void effect_player_drain_mana(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
         ep_ptr->m_ptr->hp = ep_ptr->m_ptr->maxhp;
     }
 
-    if (player_ptr->health_who == ep_ptr->src_idx) {
-        rfu.set_flag(MainWindowRedrawingFlag::HEALTH);
-    }
+    HealthBarTracker::get_instance().set_flag_if_tracking(ep_ptr->src_idx);
     if (player_ptr->riding == ep_ptr->src_idx) {
         rfu.set_flag(MainWindowRedrawingFlag::UHEALTH);
     }

--- a/src/melee/melee-postprocess.cpp
+++ b/src/melee/melee-postprocess.cpp
@@ -39,6 +39,7 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
+#include "tracking/health-bar-tracker.h"
 #include "util/bit-flags-calculator.h"
 #include "util/string-processor.h"
 #include "view/display-messages.h"
@@ -79,13 +80,9 @@ static void prepare_redraw(PlayerType *player_ptr, mam_pp_type *mam_pp_ptr)
         return;
     }
 
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    if (player_ptr->health_who == mam_pp_ptr->m_idx) {
-        rfu.set_flag(MainWindowRedrawingFlag::HEALTH);
-    }
-
+    HealthBarTracker::get_instance().set_flag_if_tracking(mam_pp_ptr->m_idx);
     if (player_ptr->riding == mam_pp_ptr->m_idx) {
-        rfu.set_flag(MainWindowRedrawingFlag::UHEALTH);
+        RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);
     }
 }
 

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -32,6 +32,7 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
+#include "tracking/health-bar-tracker.h"
 #include "util/string-processor.h"
 #include "view/display-messages.h"
 
@@ -47,13 +48,9 @@ static void heal_monster_by_melee(PlayerType *player_ptr, mam_type *mam_ptr)
         mam_ptr->m_ptr->hp = mam_ptr->m_ptr->maxhp;
     }
 
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    if (player_ptr->health_who == mam_ptr->m_idx) {
-        rfu.set_flag(MainWindowRedrawingFlag::HEALTH);
-    }
-
+    HealthBarTracker::get_instance().set_flag_if_tracking(mam_ptr->m_idx);
     if (player_ptr->riding == mam_ptr->m_idx) {
-        rfu.set_flag(MainWindowRedrawingFlag::UHEALTH);
+        RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);
     }
 
     if (mam_ptr->see_m && did_heal) {
@@ -185,13 +182,9 @@ static void redraw_health_bar(PlayerType *player_ptr, mam_type *mam_ptr)
         return;
     }
 
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    if (player_ptr->health_who == mam_ptr->t_idx) {
-        rfu.set_flag(MainWindowRedrawingFlag::HEALTH);
-    }
-
+    HealthBarTracker::get_instance().set_flag_if_tracking(mam_ptr->t_idx);
     if (player_ptr->riding == mam_ptr->t_idx) {
-        rfu.set_flag(MainWindowRedrawingFlag::UHEALTH);
+        RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);
     }
 }
 

--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -29,6 +29,7 @@
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "timed-effect/timed-effects.h"
+#include "tracking/health-bar-tracker.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "world/world-object.h"
@@ -250,13 +251,9 @@ bool process_un_power(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
     recovery = std::min(recovery, monap_ptr->m_ptr->maxhp - monap_ptr->m_ptr->hp);
     monap_ptr->m_ptr->hp += recovery;
 
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    if (player_ptr->health_who == monap_ptr->m_idx) {
-        rfu.set_flag(MainWindowRedrawingFlag::HEALTH);
-    }
-
+    HealthBarTracker::get_instance().set_flag_if_tracking(monap_ptr->m_idx);
     if (player_ptr->riding == monap_ptr->m_idx) {
-        rfu.set_flag(MainWindowRedrawingFlag::UHEALTH);
+        RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);
     }
 
     monap_ptr->o_ptr->pval = !is_magic_mastery || (monap_ptr->o_ptr->pval == 1) ? 0 : monap_ptr->o_ptr->pval - drain;
@@ -264,6 +261,7 @@ bool process_un_power(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
         StatusRecalculatingFlag::COMBINATION,
         StatusRecalculatingFlag::REORDER,
     };
+    auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flags(flags);
     rfu.set_flag(SubWindowRedrawingFlag::INVENTORY);
     return true;
@@ -302,13 +300,9 @@ void process_drain_life(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr, 
         monap_ptr->m_ptr->hp = monap_ptr->m_ptr->maxhp;
     }
 
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    if (player_ptr->health_who == monap_ptr->m_idx) {
-        rfu.set_flag(MainWindowRedrawingFlag::HEALTH);
-    }
-
+    HealthBarTracker::get_instance().set_flag_if_tracking(monap_ptr->m_idx);
     if (player_ptr->riding == monap_ptr->m_idx) {
-        rfu.set_flag(MainWindowRedrawingFlag::UHEALTH);
+        RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);
     }
 
     if (monap_ptr->m_ptr->ml && did_heal) {

--- a/src/monster-floor/monster-remover.cpp
+++ b/src/monster-floor/monster-remover.cpp
@@ -16,6 +16,7 @@
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "target/target-checker.h"
+#include "tracking/health-bar-tracker.h"
 
 /*!
  * @brief モンスター配列からモンスターを消去する / Delete a monster by index.
@@ -64,7 +65,7 @@ void delete_monster_idx(PlayerType *player_ptr, MONSTER_IDX i)
         target_who = 0;
     }
 
-    if (i == player_ptr->health_who) {
+    if (HealthBarTracker::get_instance().is_tracking(i)) {
         health_track(player_ptr, 0);
     }
 

--- a/src/monster/monster-compaction.cpp
+++ b/src/monster/monster-compaction.cpp
@@ -14,6 +14,7 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "target/target-checker.h"
+#include "tracking/health-bar-tracker.h"
 #include "view/display-messages.h"
 
 /*!
@@ -59,7 +60,7 @@ static void compact_monsters_aux(PlayerType *player_ptr, MONSTER_IDX i1, MONSTER
         player_ptr->riding = i2;
     }
 
-    if (player_ptr->health_who == i1) {
+    if (HealthBarTracker::get_instance().is_tracking(i1)) {
         health_track(player_ptr, i2);
     }
 

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -38,6 +38,7 @@
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "timed-effect/timed-effects.h"
+#include "tracking/health-bar-tracker.h"
 #include "tracking/lore-tracker.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
@@ -426,13 +427,9 @@ void MonsterDamageProcessor::get_exp_from_mon(const MonsterEntity &monster, int 
 
 void MonsterDamageProcessor::set_redraw()
 {
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    if (this->player_ptr->health_who == this->m_idx) {
-        rfu.set_flag(MainWindowRedrawingFlag::HEALTH);
-    }
-
+    HealthBarTracker::get_instance().set_flag_if_tracking(this->m_idx);
     if (this->player_ptr->riding == this->m_idx) {
-        rfu.set_flag(MainWindowRedrawingFlag::UHEALTH);
+        RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);
     }
 }
 

--- a/src/monster/monster-status-setter.cpp
+++ b/src/monster/monster-status-setter.cpp
@@ -21,6 +21,7 @@
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "target/projection-path-calculator.h"
+#include "tracking/health-bar-tracker.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 #include <string>
@@ -107,10 +108,7 @@ bool set_monster_csleep(PlayerType *player_ptr, MONSTER_IDX m_idx, int v)
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     if (m_ptr->ml) {
-        if (player_ptr->health_who == m_idx) {
-            rfu.set_flag(MainWindowRedrawingFlag::HEALTH);
-        }
-
+        HealthBarTracker::get_instance().set_flag_if_tracking(m_idx);
         if (player_ptr->riding == m_idx) {
             rfu.set_flag(MainWindowRedrawingFlag::UHEALTH);
         }
@@ -292,13 +290,9 @@ bool set_monster_monfear(PlayerType *player_ptr, MONSTER_IDX m_idx, int v)
     }
 
     if (m_ptr->ml) {
-        auto &rfu = RedrawingFlagsUpdater::get_instance();
-        if (player_ptr->health_who == m_idx) {
-            rfu.set_flag(MainWindowRedrawingFlag::HEALTH);
-        }
-
+        HealthBarTracker::get_instance().set_flag_if_tracking(m_idx);
         if (player_ptr->riding == m_idx) {
-            rfu.set_flag(MainWindowRedrawingFlag::UHEALTH);
+            RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);
         }
     }
 
@@ -342,13 +336,9 @@ bool set_monster_invulner(PlayerType *player_ptr, MONSTER_IDX m_idx, int v, bool
     }
 
     if (m_ptr->ml) {
-        auto &rfu = RedrawingFlagsUpdater::get_instance();
-        if (player_ptr->health_who == m_idx) {
-            rfu.set_flag(MainWindowRedrawingFlag::HEALTH);
-        }
-
+        HealthBarTracker::get_instance().set_flag_if_tracking(m_idx);
         if (player_ptr->riding == m_idx) {
-            rfu.set_flag(MainWindowRedrawingFlag::UHEALTH);
+            RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);
         }
     }
 

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -38,6 +38,7 @@
 #include "system/redrawing-flags-updater.h"
 #include "target/projection-path-calculator.h"
 #include "timed-effect/timed-effects.h"
+#include "tracking/health-bar-tracker.h"
 #include "util/bit-flags-calculator.h"
 #include "world/world.h"
 
@@ -482,13 +483,9 @@ static void update_invisible_monster(PlayerType *player_ptr, um_type *um_ptr, MO
     m_ptr->ml = true;
     lite_spot(player_ptr, um_ptr->fy, um_ptr->fx);
 
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    if (player_ptr->health_who == m_idx) {
-        rfu.set_flag(MainWindowRedrawingFlag::HEALTH);
-    }
-
+    HealthBarTracker::get_instance().set_flag_if_tracking(m_idx);
     if (player_ptr->riding == m_idx) {
-        rfu.set_flag(MainWindowRedrawingFlag::UHEALTH);
+        RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);
     }
 
     if (!player_ptr->effects()->hallucination().is_hallucinated()) {
@@ -522,13 +519,9 @@ static void update_visible_monster(PlayerType *player_ptr, um_type *um_ptr, MONS
     um_ptr->m_ptr->ml = false;
     lite_spot(player_ptr, um_ptr->fy, um_ptr->fx);
 
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    if (player_ptr->health_who == m_idx) {
-        rfu.set_flag(MainWindowRedrawingFlag::HEALTH);
-    }
-
+    HealthBarTracker::get_instance().set_flag_if_tracking(m_idx);
     if (player_ptr->riding == m_idx) {
-        rfu.set_flag(MainWindowRedrawingFlag::UHEALTH);
+        RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);
     }
 
     if (um_ptr->do_disturb && (disturb_pets || um_ptr->m_ptr->is_hostile())) {

--- a/src/mspell/mspell-status.cpp
+++ b/src/mspell/mspell-status.cpp
@@ -33,6 +33,7 @@
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "timed-effect/timed-effects.h"
+#include "tracking/health-bar-tracker.h"
 #include "view/display-messages.h"
 
 mspell_cast_msg_bad_status_to_player::mspell_cast_msg_bad_status_to_player(concptr blind, concptr not_blind, concptr resist, concptr saved_throw)
@@ -613,13 +614,9 @@ MonsterSpellResult spell_RF6_HEAL(PlayerType *player_ptr, MONSTER_IDX m_idx, MON
     }
 
     monspell_message_base(player_ptr, m_idx, t_idx, msg, !seen, target_type);
-    auto &rfu = RedrawingFlagsUpdater::get_instance();
-    if (player_ptr->health_who == m_idx) {
-        rfu.set_flag(MainWindowRedrawingFlag::HEALTH);
-    }
-
+    HealthBarTracker::get_instance().set_flag_if_tracking(m_idx);
     if (player_ptr->riding == m_idx) {
-        rfu.set_flag(MainWindowRedrawingFlag::UHEALTH);
+        RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);
     }
 
     if (!m_ptr->is_fearful()) {

--- a/src/spell-kind/spells-polymorph.cpp
+++ b/src/spell-kind/spells-polymorph.cpp
@@ -17,6 +17,7 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "target/target-checker.h"
+#include "tracking/health-bar-tracker.h"
 #include "util/bit-flags-calculator.h"
 
 /*!
@@ -75,7 +76,7 @@ bool polymorph_monster(PlayerType *player_ptr, POSITION y, POSITION x)
     MonsterRaceId new_r_idx;
     MonsterRaceId old_r_idx = m_ptr->r_idx;
     bool targeted = target_who == g_ptr->m_idx;
-    bool health_tracked = player_ptr->health_who == g_ptr->m_idx;
+    auto health_tracked = HealthBarTracker::get_instance().is_tracking(g_ptr->m_idx);
 
     if (floor_ptr->inside_arena || AngbandSystem::get_instance().is_phase_out()) {
         return false;

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -236,8 +236,6 @@ public:
     bool teleport_town{};
     bool enter_dungeon{}; /* Just enter the dungeon */
 
-    IDX health_who{}; /* Health bar trackee */
-
     int16_t new_spells{}; /* Number of spells available */
     int16_t old_spells{};
 

--- a/src/tracking/health-bar-tracker.cpp
+++ b/src/tracking/health-bar-tracker.cpp
@@ -1,0 +1,44 @@
+/*!
+ * @brief メインウィンドウ左にあるモンスターのヘルスバーを表示させる対象のモンスターインデックスを管理するクラス
+ * @author Hourier
+ * @date 2024/06/08
+ */
+
+#include "tracking/health-bar-tracker.h"
+#include "system/monster-race-info.h"
+#include "system/redrawing-flags-updater.h"
+
+HealthBarTracker HealthBarTracker::instance{};
+
+HealthBarTracker &HealthBarTracker::get_instance()
+{
+    return instance;
+}
+
+bool HealthBarTracker::is_tracking() const
+{
+    return this->tracking_m_idx > 0;
+}
+
+bool HealthBarTracker::is_tracking(short m_idx) const
+{
+    return this->tracking_m_idx == m_idx;
+}
+
+short HealthBarTracker::get_trackee() const
+{
+    return this->tracking_m_idx;
+}
+
+void HealthBarTracker::set_trackee(short m_idx)
+{
+    this->tracking_m_idx = m_idx;
+    RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::HEALTH);
+}
+
+void HealthBarTracker::set_flag_if_tracking(short m_idx) const
+{
+    if (this->is_tracking(m_idx)) {
+        RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::HEALTH);
+    }
+}

--- a/src/tracking/health-bar-tracker.h
+++ b/src/tracking/health-bar-tracker.h
@@ -1,0 +1,23 @@
+#pragma once
+
+class HealthBarTracker {
+public:
+    ~HealthBarTracker() = default;
+    HealthBarTracker(HealthBarTracker &&) = delete;
+    HealthBarTracker(const HealthBarTracker &) = delete;
+    HealthBarTracker &operator=(const HealthBarTracker &) = delete;
+    HealthBarTracker &operator=(HealthBarTracker &&) = delete;
+
+    static HealthBarTracker &get_instance();
+    bool is_tracking() const;
+    bool is_tracking(short m_idx) const;
+    short get_trackee() const;
+    void set_trackee(short m_idx);
+    void set_flag_if_tracking(short m_idx) const;
+
+private:
+    HealthBarTracker() = default;
+
+    static HealthBarTracker instance;
+    short tracking_m_idx;
+};

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -18,6 +18,7 @@
 #include "term/term-color-types.h"
 #include "term/z-form.h"
 #include "timed-effect/timed-effects.h"
+#include "tracking/health-bar-tracker.h"
 #include "util/string-processor.h"
 #include "window/main-window-row-column.h"
 #include "window/main-window-stat-poster.h"
@@ -363,8 +364,10 @@ void print_health(PlayerType *player_ptr, bool riding)
             print_health_monster_in_arena_for_wizard(player_ptr);
             return;
         }
-        if (player_ptr->health_who > 0) {
-            monster_idx = player_ptr->health_who;
+
+        auto &tracker = HealthBarTracker::get_instance();
+        if (tracker.is_tracking()) {
+            monster_idx = tracker.get_trackee();
         }
         row = ROW_INFO;
         col = COL_INFO;


### PR DESCRIPTION
適当なモンスターを召喚してlookしたり攻撃したりしてバーが引き続き表示されることはチェックしました
ご確認下さい