### PR TITLE
Prevent unhandled exception when corpse-eating player tries to eat

### DIFF
--- a/src/object-hook/hook-expendable.cpp
+++ b/src/object-hook/hook-expendable.cpp
@@ -35,9 +35,11 @@ bool item_tester_hook_eatable(PlayerType *player_ptr, const ItemEntity *o_ptr)
             return true;
         }
     } else if (food_type == PlayerRaceFoodType::CORPSE) {
-        const auto &monrace = o_ptr->get_monrace();
-        if (o_ptr->is_corpse() && angband_strchr("pht", monrace.symbol_definition.character)) {
-            return true;
+        if (o_ptr->is_corpse()) {
+            const auto &monrace = o_ptr->get_monrace();
+            if (angband_strchr("pht", monrace.symbol_definition.character)) {
+                return true;
+            }
         }
     }
 


### PR DESCRIPTION
That is a regression introduced by 837179e4d1a735595e246830084e1bca9db2527b.  Resolves https://github.com/hengband/hengband/issues/4237 .