### PR TITLE
[Fix] 種族がバルログの時に簡易自動破壊のleave_specialが機能しない

### DIFF
--- a/src/autopick/autopick-destroyer.cpp
+++ b/src/autopick/autopick-destroyer.cpp
@@ -51,15 +51,18 @@ static bool is_leave_special_item(PlayerType *player_ptr, ItemEntity *o_ptr)
         if (o_ptr->is_corpse() && angband_strchr("pht", o_ptr->get_monrace().symbol_definition.character)) {
             return false;
         }
-    } else if (pc.equals(PlayerClassType::ARCHER)) {
+    }
+    if (pc.equals(PlayerClassType::ARCHER)) {
         if ((tval == ItemKindType::SKELETON) || (bi_key == BaseitemKey(ItemKindType::CORPSE, SV_SKELETON))) {
             return false;
         }
-    } else if (pc.equals(PlayerClassType::NINJA)) {
+    }
+    if (pc.equals(PlayerClassType::NINJA)) {
         if (tval == ItemKindType::LITE && o_ptr->ego_idx == EgoType::LITE_DARKNESS && o_ptr->is_known()) {
             return false;
         }
-    } else if (pc.is_tamer()) {
+    }
+    if (pc.is_tamer()) {
         if (bi_key == BaseitemKey(ItemKindType::WAND, SV_WAND_HEAL_MONSTER) && o_ptr->is_aware()) {
             return false;
         }


### PR DESCRIPTION
Fix #4242 