### PR TITLE
[Fix] 不足しているSTLヘッダのinclude文を追加

### DIFF
--- a/src/market/building-monster.cpp
+++ b/src/market/building-monster.cpp
@@ -14,6 +14,7 @@
 #include "util/string-processor.h"
 #include "view/display-lore.h"
 #include "view/display-messages.h"
+#include <algorithm>
 
 /*!
  * @brief 施設でモンスターの情報を知るメインルーチン / research_mon -KMW-

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -29,6 +29,7 @@
 #include "util/bit-flags-calculator.h"
 #include "util/enum-converter.h"
 #include "util/string-processor.h"
+#include <algorithm>
 #include <sstream>
 
 ItemEntity::ItemEntity()


### PR DESCRIPTION
GCC 13においてプリコンパイルヘッダの指定無しの時にSTLヘッダのinclude不足によりコンパイルエラーとなるファイルがあるので、必要なヘッダのinclude文を追加する。

includeの追加だけであり、ごく軽微な修正なのでIssue無し。