### PR TITLE
視界内モンスターが表示されない不具合を解消した

### DIFF
--- a/src/system/monster-entity.cpp
+++ b/src/system/monster-entity.cpp
@@ -125,7 +125,7 @@ bool MonsterEntity::is_mimicry() const
     }
 
     const auto &monrace = this->get_appearance_monrace();
-    if (monrace.symbol_char_is_any_of(R"(/|\()[]="$,.!?&`#%<>+~)")) {
+    if (!monrace.symbol_char_is_any_of(R"(/|\()[]="$,.!?&`#%<>+~)")) {
         return false;
     }
 


### PR DESCRIPTION
ミミック系モンスターの判定が反転していたのが原因でした
ご確認下さい