### PR TITLE
[Refactor] その他の雑多な処理をDiceクラスにする

### DIFF
--- a/src/action/mutation-execution.cpp
+++ b/src/action/mutation-execution.cpp
@@ -118,7 +118,7 @@ bool exe_mutation_power(PlayerType *player_ptr, PlayerMutationType power)
         }
 
         msg_print(_("集中している...", "You concentrate..."));
-        fire_bolt(player_ptr, AttributeType::PSI, dir, damroll(3 + ((lvl - 1) / 5), 3));
+        fire_bolt(player_ptr, AttributeType::PSI, dir, Dice::roll(3 + ((lvl - 1) / 5), 3));
         return true;
     }
     case PlayerMutationType::RADIATION:
@@ -159,7 +159,7 @@ bool exe_mutation_power(PlayerType *player_ptr, PlayerMutationType power)
         (void)aggravate_monsters(player_ptr, 0);
         return true;
     case PlayerMutationType::ILLUMINE:
-        (void)lite_area(player_ptr, damroll(2, (lvl / 2)), (lvl / 10) + 1);
+        (void)lite_area(player_ptr, Dice::roll(2, (lvl / 2)), (lvl / 10) + 1);
         return true;
     case PlayerMutationType::DET_CURSE:
         for (int i = 0; i < INVEN_TOTAL; i++) {

--- a/src/artifact/random-art-generator.cpp
+++ b/src/artifact/random-art-generator.cpp
@@ -60,7 +60,7 @@ static bool weakening_artifact(ItemEntity *o_ptr)
     }
 
     if (o_ptr->to_d > 10) {
-        o_ptr->to_d = o_ptr->to_d - damroll(1, 6);
+        o_ptr->to_d = o_ptr->to_d - Dice::roll(1, 6);
         if (o_ptr->to_d < 10) {
             o_ptr->to_d = 10;
         }

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -1150,7 +1150,7 @@ bool do_cmd_cast(PlayerType *player_ptr)
                 sanity_blast(player_ptr, 0, true);
             } else {
                 msg_print(_("痛い！", "It hurts!"));
-                take_hit(player_ptr, DAMAGE_LOSELIFE, damroll(sval + 1, 6), _("暗黒魔法の逆流", "a miscast Death spell"));
+                take_hit(player_ptr, DAMAGE_LOSELIFE, Dice::roll(sval + 1, 6), _("暗黒魔法の逆流", "a miscast Death spell"));
 
                 if ((spell > 15) && one_in_(6) && !player_ptr->hold_exp) {
                     lose_exp(player_ptr, spell * 250);

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -77,27 +77,27 @@ static bool exe_eat_food_type_object(PlayerType *player_ptr, const BaseitemKey &
     case SV_FOOD_PARALYSIS:
         return !player_ptr->free_act && bss.mod_paralysis(randint0(10) + 10);
     case SV_FOOD_WEAKNESS:
-        take_hit(player_ptr, DAMAGE_NOESCAPE, damroll(6, 6), _("毒入り食料", "poisonous food"));
+        take_hit(player_ptr, DAMAGE_NOESCAPE, Dice::roll(6, 6), _("毒入り食料", "poisonous food"));
         (void)do_dec_stat(player_ptr, A_STR);
         return true;
     case SV_FOOD_SICKNESS:
-        take_hit(player_ptr, DAMAGE_NOESCAPE, damroll(6, 6), _("毒入り食料", "poisonous food"));
+        take_hit(player_ptr, DAMAGE_NOESCAPE, Dice::roll(6, 6), _("毒入り食料", "poisonous food"));
         (void)do_dec_stat(player_ptr, A_CON);
         return true;
     case SV_FOOD_STUPIDITY:
-        take_hit(player_ptr, DAMAGE_NOESCAPE, damroll(8, 8), _("毒入り食料", "poisonous food"));
+        take_hit(player_ptr, DAMAGE_NOESCAPE, Dice::roll(8, 8), _("毒入り食料", "poisonous food"));
         (void)do_dec_stat(player_ptr, A_INT);
         return true;
     case SV_FOOD_NAIVETY:
-        take_hit(player_ptr, DAMAGE_NOESCAPE, damroll(8, 8), _("毒入り食料", "poisonous food"));
+        take_hit(player_ptr, DAMAGE_NOESCAPE, Dice::roll(8, 8), _("毒入り食料", "poisonous food"));
         (void)do_dec_stat(player_ptr, A_WIS);
         return true;
     case SV_FOOD_UNHEALTH:
-        take_hit(player_ptr, DAMAGE_NOESCAPE, damroll(10, 10), _("毒入り食料", "poisonous food"));
+        take_hit(player_ptr, DAMAGE_NOESCAPE, Dice::roll(10, 10), _("毒入り食料", "poisonous food"));
         (void)do_dec_stat(player_ptr, A_CON);
         return true;
     case SV_FOOD_DISEASE:
-        take_hit(player_ptr, DAMAGE_NOESCAPE, damroll(10, 10), _("毒入り食料", "poisonous food"));
+        take_hit(player_ptr, DAMAGE_NOESCAPE, Dice::roll(10, 10), _("毒入り食料", "poisonous food"));
         (void)do_dec_stat(player_ptr, A_STR);
         return true;
     case SV_FOOD_CURE_POISON:
@@ -131,7 +131,7 @@ static bool exe_eat_food_type_object(PlayerType *player_ptr, const BaseitemKey &
     case SV_FOOD_WAYBREAD:
         msg_print(_("これはひじょうに美味だ。", "That tastes very good."));
         (void)bss.set_poison(0);
-        (void)hp_player(player_ptr, damroll(4, 8));
+        (void)hp_player(player_ptr, Dice::roll(4, 8));
         return true;
     case SV_FOOD_PINT_OF_ALE:
     case SV_FOOD_PINT_OF_WINE:

--- a/src/cmd-item/cmd-usestaff.cpp
+++ b/src/cmd-item/cmd-usestaff.cpp
@@ -130,7 +130,7 @@ int staff_effect(PlayerType *player_ptr, int sval, bool *use_charge, bool powerf
         break;
 
     case SV_STAFF_LITE: {
-        if (lite_area(player_ptr, damroll(2, 8), (powerful ? 4 : 2))) {
+        if (lite_area(player_ptr, Dice::roll(2, 8), (powerful ? 4 : 2))) {
             ident = true;
         }
         break;

--- a/src/cmd-item/cmd-zaprod.cpp
+++ b/src/cmd-item/cmd-zaprod.cpp
@@ -91,7 +91,7 @@ int rod_effect(PlayerType *player_ptr, int sval, int dir, bool *use_charge, bool
     }
 
     case SV_ROD_ILLUMINATION: {
-        if (lite_area(player_ptr, damroll(2, 8), (powerful ? 4 : 2))) {
+        if (lite_area(player_ptr, Dice::roll(2, 8), (powerful ? 4 : 2))) {
             ident = true;
         }
         break;
@@ -175,7 +175,7 @@ int rod_effect(PlayerType *player_ptr, int sval, int dir, bool *use_charge, bool
     }
 
     case SV_ROD_LITE: {
-        int dam = damroll((powerful ? 12 : 6), 8);
+        int dam = Dice::roll((powerful ? 12 : 6), 8);
         msg_print(_("青く輝く光線が放たれた。", "A line of blue shimmering light appears."));
         (void)lite_line(player_ptr, dir, dam);
         ident = true;
@@ -211,25 +211,25 @@ int rod_effect(PlayerType *player_ptr, int sval, int dir, bool *use_charge, bool
     }
 
     case SV_ROD_ACID_BOLT: {
-        fire_bolt_or_beam(player_ptr, 10, AttributeType::ACID, dir, damroll(6 + lev / 7, 8));
+        fire_bolt_or_beam(player_ptr, 10, AttributeType::ACID, dir, Dice::roll(6 + lev / 7, 8));
         ident = true;
         break;
     }
 
     case SV_ROD_ELEC_BOLT: {
-        fire_bolt_or_beam(player_ptr, 10, AttributeType::ELEC, dir, damroll(4 + lev / 9, 8));
+        fire_bolt_or_beam(player_ptr, 10, AttributeType::ELEC, dir, Dice::roll(4 + lev / 9, 8));
         ident = true;
         break;
     }
 
     case SV_ROD_FIRE_BOLT: {
-        fire_bolt_or_beam(player_ptr, 10, AttributeType::FIRE, dir, damroll(7 + lev / 6, 8));
+        fire_bolt_or_beam(player_ptr, 10, AttributeType::FIRE, dir, Dice::roll(7 + lev / 6, 8));
         ident = true;
         break;
     }
 
     case SV_ROD_COLD_BOLT: {
-        fire_bolt_or_beam(player_ptr, 10, AttributeType::COLD, dir, damroll(5 + lev / 8, 8));
+        fire_bolt_or_beam(player_ptr, 10, AttributeType::COLD, dir, Dice::roll(5 + lev / 8, 8));
         ident = true;
         break;
     }

--- a/src/cmd-item/cmd-zapwand.cpp
+++ b/src/cmd-item/cmd-zapwand.cpp
@@ -86,7 +86,7 @@ bool wand_effect(PlayerType *player_ptr, int sval, int dir, bool powerful, bool 
     /* Analyze the wand */
     switch (sval) {
     case SV_WAND_HEAL_MONSTER: {
-        int dam = damroll((powerful ? 20 : 10), 10);
+        int dam = Dice::roll((powerful ? 20 : 10), 10);
         if (heal_monster(player_ptr, dir, dam)) {
             ident = true;
         }
@@ -144,7 +144,7 @@ bool wand_effect(PlayerType *player_ptr, int sval, int dir, bool powerful, bool 
     }
 
     case SV_WAND_LITE: {
-        int dam = damroll((powerful ? 12 : 6), 8);
+        int dam = Dice::roll((powerful ? 12 : 6), 8);
         msg_print(_("青く輝く光線が放たれた。", "A line of blue shimmering light appears."));
         (void)lite_line(player_ptr, dir, dam);
         ident = true;
@@ -200,13 +200,13 @@ bool wand_effect(PlayerType *player_ptr, int sval, int dir, bool powerful, bool 
     }
 
     case SV_WAND_MAGIC_MISSILE: {
-        fire_bolt_or_beam(player_ptr, 20, AttributeType::MISSILE, dir, damroll(2 + lev / 10, 6));
+        fire_bolt_or_beam(player_ptr, 20, AttributeType::MISSILE, dir, Dice::roll(2 + lev / 10, 6));
         ident = true;
         break;
     }
 
     case SV_WAND_ACID_BOLT: {
-        fire_bolt_or_beam(player_ptr, 20, AttributeType::ACID, dir, damroll(6 + lev / 7, 8));
+        fire_bolt_or_beam(player_ptr, 20, AttributeType::ACID, dir, Dice::roll(6 + lev / 7, 8));
         ident = true;
         break;
     }
@@ -219,13 +219,13 @@ bool wand_effect(PlayerType *player_ptr, int sval, int dir, bool powerful, bool 
     }
 
     case SV_WAND_FIRE_BOLT: {
-        fire_bolt_or_beam(player_ptr, 20, AttributeType::FIRE, dir, damroll(7 + lev / 6, 8));
+        fire_bolt_or_beam(player_ptr, 20, AttributeType::FIRE, dir, Dice::roll(7 + lev / 6, 8));
         ident = true;
         break;
     }
 
     case SV_WAND_COLD_BOLT: {
-        fire_bolt_or_beam(player_ptr, 20, AttributeType::COLD, dir, damroll(5 + lev / 8, 8));
+        fire_bolt_or_beam(player_ptr, 20, AttributeType::COLD, dir, Dice::roll(5 + lev / 8, 8));
         ident = true;
         break;
     }
@@ -306,7 +306,7 @@ bool wand_effect(PlayerType *player_ptr, int sval, int dir, bool powerful, bool 
     }
 
     case SV_WAND_STRIKING: {
-        fire_bolt(player_ptr, AttributeType::METEOR, dir, damroll(15 + lev / 3, 13));
+        fire_bolt(player_ptr, AttributeType::METEOR, dir, Dice::roll(15 + lev / 3, 13));
         ident = true;
         break;
     }

--- a/src/combat/aura-counterattack.cpp
+++ b/src/combat/aura-counterattack.cpp
@@ -44,7 +44,7 @@ static void aura_fire_by_monster_attack(PlayerType *player_ptr, MonsterAttackPla
         return;
     }
 
-    int dam = damroll(2, 6);
+    int dam = Dice::roll(2, 6);
     dam = mon_damage_mod(player_ptr, monap_ptr->m_ptr, dam, false);
     msg_format(_("%s^は突然熱くなった！", "%s^ is suddenly very hot!"), monap_ptr->m_name);
     MonsterDamageProcessor mdp(player_ptr, monap_ptr->m_idx, dam, &monap_ptr->fear, AttributeType::FIRE);
@@ -69,7 +69,7 @@ static void aura_elec_by_monster_attack(PlayerType *player_ptr, MonsterAttackPla
         return;
     }
 
-    int dam = damroll(2, 6);
+    int dam = Dice::roll(2, 6);
     dam = mon_damage_mod(player_ptr, monap_ptr->m_ptr, dam, false);
     msg_format(_("%s^は電撃をくらった！", "%s^ gets zapped!"), monap_ptr->m_name);
     MonsterDamageProcessor mdp(player_ptr, monap_ptr->m_idx, dam, &monap_ptr->fear, AttributeType::ELEC);
@@ -94,7 +94,7 @@ static void aura_cold_by_monster_attack(PlayerType *player_ptr, MonsterAttackPla
         return;
     }
 
-    int dam = damroll(2, 6);
+    int dam = Dice::roll(2, 6);
     dam = mon_damage_mod(player_ptr, monap_ptr->m_ptr, dam, false);
     msg_format(_("%s^は冷気をくらった！", "%s^ is very cold!"), monap_ptr->m_name);
     MonsterDamageProcessor mdp(player_ptr, monap_ptr->m_idx, dam, &monap_ptr->fear, AttributeType::COLD);
@@ -116,7 +116,7 @@ static void aura_shards_by_monster_attack(PlayerType *player_ptr, MonsterAttackP
             r_ptr->r_resistance_flags.set(r_ptr->resistance_flags & RFR_EFF_RESIST_SHARDS_MASK);
         }
     } else {
-        int dam = damroll(2, 6);
+        int dam = Dice::roll(2, 6);
         dam = mon_damage_mod(player_ptr, monap_ptr->m_ptr, dam, false);
         msg_format(_("%s^は鏡の破片をくらった！", "%s^ gets sliced!"), monap_ptr->m_name);
         MonsterDamageProcessor mdp(player_ptr, monap_ptr->m_idx, dam, &monap_ptr->fear, AttributeType::SHARDS);
@@ -150,7 +150,7 @@ static void aura_holy_by_monster_attack(PlayerType *player_ptr, MonsterAttackPla
         return;
     }
 
-    int dam = damroll(2, 6);
+    int dam = Dice::roll(2, 6);
     dam = mon_damage_mod(player_ptr, monap_ptr->m_ptr, dam, false);
     msg_format(_("%s^は聖なるオーラで傷ついた！", "%s^ is injured by holy power!"), monap_ptr->m_name);
     MonsterDamageProcessor mdp(player_ptr, monap_ptr->m_idx, dam, &monap_ptr->fear, AttributeType::HOLY_FIRE);
@@ -179,7 +179,7 @@ static void aura_force_by_monster_attack(PlayerType *player_ptr, MonsterAttackPl
         return;
     }
 
-    int dam = damroll(2, 6);
+    int dam = Dice::roll(2, 6);
     dam = mon_damage_mod(player_ptr, monap_ptr->m_ptr, dam, false);
     msg_format(_("%s^が鋭い闘気のオーラで傷ついた！", "%s^ is injured by the Force"), monap_ptr->m_name);
     MonsterDamageProcessor mdp(player_ptr, monap_ptr->m_idx, dam, &monap_ptr->fear, AttributeType::MANA);

--- a/src/effect/effect-monster-evil.cpp
+++ b/src/effect/effect-monster-evil.cpp
@@ -111,7 +111,7 @@ ProcessResult effect_monster_turn_undead(PlayerType *player_ptr, EffectMonster *
         em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::UNDEAD);
     }
 
-    em_ptr->do_fear = damroll(3, (em_ptr->dam / 2)) + 1;
+    em_ptr->do_fear = Dice::roll(3, (em_ptr->dam / 2)) + 1;
     if (em_ptr->r_ptr->level > randint1((em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10)) + 10) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;
@@ -138,7 +138,7 @@ ProcessResult effect_monster_turn_evil(PlayerType *player_ptr, EffectMonster *em
         em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::EVIL);
     }
 
-    em_ptr->do_fear = damroll(3, (em_ptr->dam / 2)) + 1;
+    em_ptr->do_fear = Dice::roll(3, (em_ptr->dam / 2)) + 1;
     if (em_ptr->r_ptr->level > randint1((em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10)) + 10) {
         em_ptr->note = _("には効果がなかった。", " is unaffected.");
         em_ptr->obvious = false;
@@ -155,7 +155,7 @@ ProcessResult effect_monster_turn_all(EffectMonster *em_ptr)
         em_ptr->obvious = true;
     }
 
-    em_ptr->do_fear = damroll(3, (em_ptr->dam / 2)) + 1;
+    em_ptr->do_fear = Dice::roll(3, (em_ptr->dam / 2)) + 1;
     if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE) ||
         em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_FEAR) ||
         (em_ptr->r_ptr->level > randint1((em_ptr->dam - 10) < 1 ? 1 : (em_ptr->dam - 10)) + 10)) {

--- a/src/effect/effect-monster-oldies.cpp
+++ b/src/effect/effect-monster-oldies.cpp
@@ -272,7 +272,7 @@ ProcessResult effect_monster_old_conf(PlayerType *player_ptr, EffectMonster *em_
         em_ptr->obvious = true;
     }
 
-    em_ptr->do_conf = damroll(3, (em_ptr->dam / 2)) + 1;
+    em_ptr->do_conf = Dice::roll(3, (em_ptr->dam / 2)) + 1;
 
     bool has_resistance = em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
     has_resistance |= em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_CONF);
@@ -324,7 +324,7 @@ ProcessResult effect_monster_stun(EffectMonster *em_ptr)
         em_ptr->obvious = true;
     }
 
-    em_ptr->do_stun = damroll((em_ptr->caster_lev / 20) + 3, (em_ptr->dam)) + 1;
+    em_ptr->do_stun = Dice::roll((em_ptr->caster_lev / 20) + 3, (em_ptr->dam)) + 1;
 
     bool has_resistance = em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
     has_resistance |= (em_ptr->r_ptr->level > randint1(std::max(1, em_ptr->dam - 10)) + 10);

--- a/src/effect/effect-monster-psi.cpp
+++ b/src/effect/effect-monster-psi.cpp
@@ -258,7 +258,7 @@ static void effect_monster_psi_drain_resist(PlayerType *player_ptr, EffectMonste
     }
 
     msg_print(_("超能力パワーを吸いとられた！", "Your psychic energy is drained!"));
-    player_ptr->csp -= damroll(5, em_ptr->dam) / 2;
+    player_ptr->csp -= Dice::roll(5, em_ptr->dam) / 2;
     if (player_ptr->csp < 0) {
         player_ptr->csp = 0;
     }
@@ -277,7 +277,7 @@ static void effect_monster_psi_drain_resist(PlayerType *player_ptr, EffectMonste
  */
 static void effect_monster_psi_drain_change_power(PlayerType *player_ptr, EffectMonster *em_ptr)
 {
-    int b = damroll(5, em_ptr->dam) / 4;
+    int b = Dice::roll(5, em_ptr->dam) / 4;
     concptr str = PlayerClass(player_ptr).equals(PlayerClassType::MINDCRAFTER) ? _("超能力パワー", "psychic energy") : _("魔力", "mana");
     concptr msg = _("あなたは%sの苦痛を%sに変換した！", (em_ptr->seen ? "You convert %s's pain into %s!" : "You convert %ss pain into %s!"));
     msg_format(msg, em_ptr->m_name, str);
@@ -333,7 +333,7 @@ ProcessResult effect_monster_telekinesis(PlayerType *player_ptr, EffectMonster *
         }
     }
 
-    em_ptr->do_stun = damroll((em_ptr->caster_lev / 20) + 3, em_ptr->dam) + 1;
+    em_ptr->do_stun = Dice::roll((em_ptr->caster_lev / 20) + 3, em_ptr->dam) + 1;
     if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE) || (em_ptr->r_ptr->level > 5 + randint1(em_ptr->dam))) {
         em_ptr->do_stun = 0;
         em_ptr->obvious = false;

--- a/src/effect/effect-monster-resist-hurt.cpp
+++ b/src/effect/effect-monster-resist-hurt.cpp
@@ -574,7 +574,7 @@ static void effect_monster_gravity_slow(PlayerType *player_ptr, EffectMonster *e
 
 static void effect_monster_gravity_stun(EffectMonster *em_ptr)
 {
-    em_ptr->do_stun = damroll((em_ptr->caster_lev / 20) + 3, (em_ptr->dam)) + 1;
+    em_ptr->do_stun = Dice::roll((em_ptr->caster_lev / 20) + 3, (em_ptr->dam)) + 1;
     bool has_resistance = em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
     has_resistance |= (em_ptr->r_ptr->level > randint1(std::max(1, em_ptr->dam - 10)) + 10);
     if (has_resistance) {

--- a/src/effect/effect-monster-switcher.cpp
+++ b/src/effect/effect-monster-switcher.cpp
@@ -207,7 +207,7 @@ ProcessResult effect_monster_engetsu(PlayerType *player_ptr, EffectMonster *em_p
             if (em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE)) {
                 em_ptr->do_stun = 0;
             } else {
-                em_ptr->do_stun = damroll((player_ptr->lev / 10) + 3, (em_ptr->dam)) + 1;
+                em_ptr->do_stun = Dice::roll((player_ptr->lev / 10) + 3, (em_ptr->dam)) + 1;
                 done = true;
             }
             break;

--- a/src/effect/effect-player-curse.cpp
+++ b/src/effect/effect-player-curse.cpp
@@ -56,6 +56,6 @@ void effect_player_curse_4(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
     ep_ptr->get_damage = take_hit(player_ptr, DAMAGE_ATTACK, ep_ptr->dam, ep_ptr->killer);
     if (!check_multishadow(player_ptr)) {
-        (void)BadStatusSetter(player_ptr).mod_cut(damroll(10, 10));
+        (void)BadStatusSetter(player_ptr).mod_cut(static_cast<TIME_EFFECT>(Dice::roll(10, 10)));
     }
 }

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -613,7 +613,7 @@ void effect_player_icee(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
 
     BadStatusSetter bss(player_ptr);
     if (!has_resist_shard(player_ptr)) {
-        (void)bss.mod_cut(damroll(5, 8));
+        (void)bss.mod_cut(static_cast<TIME_EFFECT>(Dice::roll(5, 8)));
     }
 
     if (!has_resist_sound(player_ptr)) {

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -102,7 +102,7 @@ static void set_ammo_quantity(ItemEntity *j_ptr)
     auto is_ammo = j_ptr->is_ammo();
     is_ammo |= j_ptr->bi_key.tval() == ItemKindType::SPIKE;
     if (is_ammo && !j_ptr->is_fixed_artifact()) {
-        j_ptr->number = damroll(6, 7);
+        j_ptr->number = Dice::roll(6, 7);
     }
 }
 

--- a/src/floor/pattern-walk.cpp
+++ b/src/floor/pattern-walk.cpp
@@ -152,7 +152,7 @@ bool pattern_effect(PlayerType *player_ptr)
         if (PlayerRace(player_ptr).equals(PlayerRaceType::AMBERITE) && !one_in_(2)) {
             return true;
         } else if (!is_invuln(player_ptr)) {
-            take_hit(player_ptr, DAMAGE_NOESCAPE, damroll(1, 3), _("「パターン」を歩いたダメージ", "walking the Pattern"));
+            take_hit(player_ptr, DAMAGE_NOESCAPE, Dice::roll(1, 3), _("「パターン」を歩いたダメージ", "walking the Pattern"));
         }
         break;
     }

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -313,7 +313,7 @@ static void hit_trap_pit(PlayerType *player_ptr, TrapType trap_feat_type)
     }
 
     msg_format(_("%sに落ちてしまった！", "You have fallen into %s!"), trap_name);
-    dam = damroll(2, 6);
+    dam = Dice::roll(2, 6);
     if (((trap_feat_type != TrapType::SPIKED_PIT) && (trap_feat_type != TrapType::POISON_PIT)) || one_in_(2)) {
         take_hit(player_ptr, DAMAGE_NOESCAPE, dam, trap_name);
         return;
@@ -349,7 +349,7 @@ static bool hit_trap_dart(PlayerType *player_ptr)
 
     if (check_hit_from_monster_to_player(player_ptr, 125)) {
         msg_print(_("小さなダーツが飛んできて刺さった！", "A small dart hits you!"));
-        take_hit(player_ptr, DAMAGE_ATTACK, damroll(1, 4), _("ダーツの罠", "a dart trap"));
+        take_hit(player_ptr, DAMAGE_ATTACK, Dice::roll(1, 4), _("ダーツの罠", "a dart trap"));
         if (!check_multishadow(player_ptr)) {
             hit = true;
         }
@@ -413,7 +413,7 @@ void hit_trap(PlayerType *player_ptr, bool break_trap)
             }
 
             sound(SOUND_FALL);
-            const auto dam = damroll(2, 8);
+            const auto dam = Dice::roll(2, 8);
             constexpr auto name = _("落とし戸", "a trap door");
 
             take_hit(player_ptr, DAMAGE_NOESCAPE, dam, name);
@@ -464,14 +464,14 @@ void hit_trap(PlayerType *player_ptr, bool break_trap)
 
     case TrapType::FIRE: {
         msg_print(_("炎に包まれた！", "You are enveloped in flames!"));
-        const auto dam = damroll(4, 6);
+        const auto dam = Dice::roll(4, 6);
         (void)fire_dam(player_ptr, dam, _("炎のトラップ", "a fire trap"), false);
         break;
     }
 
     case TrapType::ACID: {
         msg_print(_("酸が吹きかけられた！", "You are splashed with acid!"));
-        const auto dam = damroll(4, 6);
+        const auto dam = Dice::roll(4, 6);
         (void)acid_dam(player_ptr, dam, _("酸のトラップ", "an acid trap"), false);
         break;
     }

--- a/src/info-reader/info-reader-util.cpp
+++ b/src/info-reader/info-reader-util.cpp
@@ -58,27 +58,3 @@ void append_english_text(std::string &text, std::string_view add)
     text.append(add_trimmed);
 }
 #endif
-
-/*!
- * @brief ダイスを表す文字列を解析してダイスの値をセットする
- *
- * 引数で与えられた文字列 "XdY" をダイスの値に変換し、X を dd に、Y を ds に格納する。
- * 文字列が正しくダイスとして解釈できない場合はエラーを返す。
- *
- * @param dice_str ダイスを表す文字列
- * @param dd ダイスの数を格納する変数への参照
- * @param ds ダイスの面数を格納する変数への参照
- * @return エラーコード
- */
-errr info_set_dice(std::string_view dice_str, DICE_NUMBER &dd, DICE_SID &ds)
-{
-    const auto &dice = str_split(dice_str, 'd', false, 2);
-    if (dice.size() < 2) {
-        return PARSE_ERROR_TOO_FEW_ARGUMENTS;
-    }
-
-    dd = std::stoi(dice[0]);
-    ds = std::stoi(dice[1]);
-
-    return PARSE_ERROR_NONE;
-}

--- a/src/info-reader/info-reader-util.h
+++ b/src/info-reader/info-reader-util.h
@@ -22,8 +22,6 @@ RandomArtActType grab_one_activation_flag(std::string_view what);
 void append_english_text(std::string &text, std::string_view add);
 #endif
 
-errr info_set_dice(std::string_view dice_str, DICE_NUMBER &dd, DICE_SID &ds);
-
 /// @note clang-formatによるconceptの整形が安定していないので抑制しておく
 // clang-format off
 /*!

--- a/src/info-reader/json-reader-util.cpp
+++ b/src/info-reader/json-reader-util.cpp
@@ -50,21 +50,11 @@ errr info_set_string(const nlohmann::json &json, std::string &data, bool is_requ
 /*!
  * @brief JSON Objectからダイスの値を取得する
  * @param json ダイスの値が格納されたJSON Object
- * @param dd ダイスの数を格納する変数への参照
- * @param ds ダイスの面数を格納する変数への参照
+ * @param dice ダイスの値を格納する変数への参照
  * @param is_required 必須かどうか
  * 必須でJSON Objectがnullや文字列でない場合はエラーを返す。必須でない場合は何もせずに終了する。
  * @return エラーコード
  */
-errr info_set_dice(const nlohmann::json &json, DICE_NUMBER &dd, DICE_SID &ds, bool is_required)
-{
-    if (json.is_null() || !json.is_string()) {
-        return is_required ? PARSE_ERROR_TOO_FEW_ARGUMENTS : PARSE_ERROR_NONE;
-    }
-
-    return info_set_dice(json.get<std::string>(), dd, ds);
-}
-
 errr info_set_dice(const nlohmann::json &json, Dice &dice, bool is_required)
 {
     if (json.is_null() || !json.is_string()) {

--- a/src/info-reader/json-reader-util.h
+++ b/src/info-reader/json-reader-util.h
@@ -15,7 +15,6 @@ template <typename T>
 concept IntegralOrEnum = std::integral<T> || std::is_enum_v<T>;
 
 errr info_set_string(const nlohmann::json &json, std::string &data, bool is_required);
-errr info_set_dice(const nlohmann::json &json, DICE_NUMBER &dd, DICE_SID &ds, bool is_required);
 errr info_set_dice(const nlohmann::json &json, Dice &dice, bool is_required);
 
 /*!

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -43,7 +43,7 @@ static void heal_monster_by_melee(PlayerType *player_ptr, mam_type *mam_ptr)
     }
 
     bool did_heal = mam_ptr->m_ptr->hp < mam_ptr->m_ptr->maxhp;
-    mam_ptr->m_ptr->hp += damroll(4, mam_ptr->damage / 6);
+    mam_ptr->m_ptr->hp += Dice::roll(4, mam_ptr->damage / 6);
     if (mam_ptr->m_ptr->hp > mam_ptr->m_ptr->maxhp) {
         mam_ptr->m_ptr->hp = mam_ptr->m_ptr->maxhp;
     }
@@ -99,7 +99,7 @@ static void aura_fire_by_melee(PlayerType *player_ptr, mam_type *mam_ptr)
         monrace_target.aura_flags.set(MonsterAuraType::FIRE);
     }
 
-    const auto dam = damroll(1 + ((monrace_target.level) / 26), 1 + ((monrace_target.level) / 17));
+    const auto dam = Dice::roll(1 + ((monrace_target.level) / 26), 1 + ((monrace_target.level) / 17));
     constexpr auto flags = PROJECT_KILL | PROJECT_STOP | PROJECT_AIMED;
     project(player_ptr, mam_ptr->t_idx, 0, mam_ptr->m_ptr->fy, mam_ptr->m_ptr->fx, dam, AttributeType::FIRE, flags);
 }
@@ -126,7 +126,7 @@ static void aura_cold_by_melee(PlayerType *player_ptr, mam_type *mam_ptr)
         monrace_target.aura_flags.set(MonsterAuraType::COLD);
     }
 
-    const auto dam = damroll(1 + ((monrace_target.level) / 26), 1 + ((monrace_target.level) / 17));
+    const auto dam = Dice::roll(1 + ((monrace_target.level) / 26), 1 + ((monrace_target.level) / 17));
     constexpr auto flags = PROJECT_KILL | PROJECT_STOP | PROJECT_AIMED;
     project(player_ptr, mam_ptr->t_idx, 0, monster.fy, monster.fx, dam, AttributeType::COLD, flags);
 }
@@ -153,7 +153,7 @@ static void aura_elec_by_melee(PlayerType *player_ptr, mam_type *mam_ptr)
         monrace_target.aura_flags.set(MonsterAuraType::ELEC);
     }
 
-    const auto dam = damroll(1 + ((monrace_target.level) / 26), 1 + ((monrace_target.level) / 17));
+    const auto dam = Dice::roll(1 + ((monrace_target.level) / 26), 1 + ((monrace_target.level) / 17));
     constexpr auto flags = PROJECT_KILL | PROJECT_STOP | PROJECT_AIMED;
     project(player_ptr, mam_ptr->t_idx, 0, monster.fy, monster.fx, dam, AttributeType::ELEC, flags);
 }

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -471,7 +471,7 @@ static bool cast_element_spell(PlayerType *player_ptr, SPELL_IDX spell_idx)
         if (!get_aim_dir(player_ptr, &dir)) {
             return false;
         }
-        dam = damroll(3 + ((plev - 1) / 5), 4);
+        dam = Dice::roll(3 + ((plev - 1) / 5), 4);
         typ = get_element_spells_type(player_ptr, power.elem);
         (void)fire_bolt(player_ptr, typ, dir, dam);
         break;
@@ -482,14 +482,14 @@ static bool cast_element_spell(PlayerType *player_ptr, SPELL_IDX spell_idx)
     case ElementSpells::PERCEPT:
         return psychometry(player_ptr);
     case ElementSpells::CURE:
-        (void)hp_player(player_ptr, damroll(2, 8));
+        (void)hp_player(player_ptr, Dice::roll(2, 8));
         (void)BadStatusSetter(player_ptr).mod_cut(-10);
         break;
     case ElementSpells::BOLT_2ND:
         if (!get_aim_dir(player_ptr, &dir)) {
             return false;
         }
-        dam = damroll(8 + ((plev - 5) / 4), 8);
+        dam = Dice::roll(8 + ((plev - 5) / 4), 8);
         typ = get_element_spells_type(player_ptr, power.elem);
         if (fire_bolt_or_beam(player_ptr, plev, typ, dir, dam)) {
             if (typ == AttributeType::HYPODYNAMIA) {
@@ -540,7 +540,7 @@ static bool cast_element_spell(PlayerType *player_ptr, SPELL_IDX spell_idx)
         if (!get_aim_dir(player_ptr, &dir)) {
             return false;
         }
-        dam = damroll(12 + ((plev - 5) / 4), 8);
+        dam = Dice::roll(12 + ((plev - 5) / 4), 8);
         typ = get_element_spells_type(player_ptr, power.elem);
         fire_bolt_or_beam(player_ptr, plev, typ, dir, dam);
         break;
@@ -564,7 +564,7 @@ static bool cast_element_spell(PlayerType *player_ptr, SPELL_IDX spell_idx)
     case ElementSpells::BURST_1ST:
         y = player_ptr->y;
         x = player_ptr->x;
-        num = damroll(4, 3);
+        num = Dice::roll(4, 3);
         typ = get_element_spells_type(player_ptr, power.elem);
         for (int k = 0; k < num; k++) {
             int attempts = 1000;
@@ -577,7 +577,7 @@ static bool cast_element_spell(PlayerType *player_ptr, SPELL_IDX spell_idx)
                     break;
                 }
             }
-            project(player_ptr, 0, 0, y, x, damroll(6 + plev / 8, 7), typ, (PROJECT_BEAM | PROJECT_THRU | PROJECT_GRID | PROJECT_KILL));
+            project(player_ptr, 0, 0, y, x, Dice::roll(6 + plev / 8, 7), typ, (PROJECT_BEAM | PROJECT_THRU | PROJECT_GRID | PROJECT_KILL));
         }
         break;
     case ElementSpells::STORM_2ND:
@@ -1371,7 +1371,7 @@ bool switch_element_execution(PlayerType *player_ptr)
 
     switch (realm) {
     case ElementRealmType::FIRE:
-        (void)lite_area(player_ptr, damroll(2, plev / 2), plev / 10);
+        (void)lite_area(player_ptr, Dice::roll(2, plev / 2), plev / 10);
         break;
     case ElementRealmType::ICE:
         (void)project(player_ptr, 0, 5, player_ptr->y, player_ptr->x, 1, AttributeType::COLD, PROJECT_ITEM);

--- a/src/mind/mind-force-trainer.cpp
+++ b/src/mind/mind-force-trainer.cpp
@@ -207,7 +207,7 @@ bool shock_power(PlayerType *player_ptr)
 
     auto pos = player_ptr->get_neighbor(dir);
     PLAYER_LEVEL plev = player_ptr->lev;
-    int dam = damroll(8 + ((plev - 5) / 4) + boost / 12, 8);
+    int dam = Dice::roll(8 + ((plev - 5) / 4) + boost / 12, 8);
     fire_beam(player_ptr, AttributeType::MISSILE, dir, dam);
     auto &floor = *player_ptr->current_floor_ptr;
     const auto &grid = floor.get_grid(pos);
@@ -279,10 +279,10 @@ bool cast_force_spell(PlayerType *player_ptr, MindForceTrainerType spell)
             return false;
         }
 
-        fire_ball(player_ptr, AttributeType::MISSILE, dir, damroll(3 + ((plev - 1) / 5) + boost / 12, 4), 0);
+        fire_ball(player_ptr, AttributeType::MISSILE, dir, Dice::roll(3 + ((plev - 1) / 5) + boost / 12, 4), 0);
         break;
     case MindForceTrainerType::FLASH_LIGHT:
-        (void)lite_area(player_ptr, damroll(2, (plev / 2)), (plev / 10) + 1);
+        (void)lite_area(player_ptr, Dice::roll(2, (plev / 2)), (plev / 10) + 1);
         break;
     case MindForceTrainerType::FLYING_TECHNIQUE:
         set_tim_levitation(player_ptr, randint1(30) + 30 + boost / 5, false);
@@ -293,7 +293,7 @@ bool cast_force_spell(PlayerType *player_ptr, MindForceTrainerType spell)
             return false;
         }
 
-        fire_beam(player_ptr, AttributeType::MISSILE, dir, damroll(5 + ((plev - 1) / 5) + boost / 10, 5));
+        fire_beam(player_ptr, AttributeType::MISSILE, dir, Dice::roll(5 + ((plev - 1) / 5) + boost / 10, 5));
         break;
     case MindForceTrainerType::MAGIC_RESISTANCE:
         set_resist_magic(player_ptr, randint1(20) + 20 + boost / 5, false);
@@ -323,7 +323,7 @@ bool cast_force_spell(PlayerType *player_ptr, MindForceTrainerType spell)
             return false;
         }
 
-        fire_ball(player_ptr, AttributeType::MISSILE, dir, damroll(10, 6) + plev * 3 / 2 + boost * 3 / 5, (plev < 30) ? 2 : 3);
+        fire_ball(player_ptr, AttributeType::MISSILE, dir, Dice::roll(10, 6) + plev * 3 / 2 + boost * 3 / 5, (plev < 30) ? 2 : 3);
         break;
     case MindForceTrainerType::DISPEL_MAGIC: {
         if (!target_set(player_ptr, TARGET_KILL)) {
@@ -365,7 +365,7 @@ bool cast_force_spell(PlayerType *player_ptr, MindForceTrainerType spell)
             return false;
         }
 
-        fire_beam(player_ptr, AttributeType::MANA, dir, damroll(10 + (plev / 2) + boost * 3 / 10, 15));
+        fire_beam(player_ptr, AttributeType::MANA, dir, Dice::roll(10 + (plev / 2) + boost * 3 / 10, 15));
         break;
     case MindForceTrainerType::LIGHT_SPEED:
         set_lightspeed(player_ptr, randint1(16) + 16 + boost / 20, false);

--- a/src/mind/mind-mindcrafter.cpp
+++ b/src/mind/mind-mindcrafter.cpp
@@ -184,9 +184,9 @@ bool cast_mindcrafter_spell(PlayerType *player_ptr, MindMindcrafterType spell)
         }
 
         if (randint1(100) < plev * 2) {
-            fire_beam(player_ptr, AttributeType::PSI, dir, damroll(3 + ((plev - 1) / 4), (3 + plev / 15)));
+            fire_beam(player_ptr, AttributeType::PSI, dir, Dice::roll(3 + ((plev - 1) / 4), (3 + plev / 15)));
         } else {
-            fire_ball(player_ptr, AttributeType::PSI, dir, damroll(3 + ((plev - 1) / 4), (3 + plev / 15)), 0);
+            fire_ball(player_ptr, AttributeType::PSI, dir, Dice::roll(3 + ((plev - 1) / 4), (3 + plev / 15)), 0);
         }
         break;
     case MindMindcrafterType::MINOR_DISPLACEMENT:
@@ -212,7 +212,7 @@ bool cast_mindcrafter_spell(PlayerType *player_ptr, MindMindcrafterType spell)
             return false;
         }
 
-        fire_ball(player_ptr, AttributeType::TELEKINESIS, dir, damroll(8 + ((plev - 5) / 4), 8), (plev > 20 ? (plev - 20) / 8 + 1 : 0));
+        fire_ball(player_ptr, AttributeType::TELEKINESIS, dir, Dice::roll(8 + ((plev - 5) / 4), 8), (plev > 20 ? (plev - 20) / 8 + 1 : 0));
         break;
     case MindMindcrafterType::CHARACTER_ARMOR:
         set_shield(player_ptr, (TIME_EFFECT)plev, false);
@@ -273,7 +273,7 @@ bool cast_mindcrafter_spell(PlayerType *player_ptr, MindMindcrafterType spell)
             return false;
         }
 
-        dam = damroll(plev / 2, 6);
+        dam = Dice::roll(plev / 2, 6);
         if (fire_ball(player_ptr, AttributeType::PSI_DRAIN, dir, dam, 0)) {
             player_ptr->energy_need += randnum1<short>(150);
         }

--- a/src/mind/mind-mirror-master.cpp
+++ b/src/mind/mind-mirror-master.cpp
@@ -406,9 +406,9 @@ bool cast_mirror_spell(PlayerType *player_ptr, MindMirrorMasterType spell)
         }
 
         if (plev > 9 && g_ptr->is_mirror()) {
-            fire_beam(player_ptr, AttributeType::LITE, dir, damroll(3 + ((plev - 1) / 5), 4));
+            fire_beam(player_ptr, AttributeType::LITE, dir, Dice::roll(3 + ((plev - 1) / 5), 4));
         } else {
-            fire_bolt(player_ptr, AttributeType::LITE, dir, damroll(3 + ((plev - 1) / 5), 4));
+            fire_bolt(player_ptr, AttributeType::LITE, dir, Dice::roll(3 + ((plev - 1) / 5), 4));
         }
 
         break;
@@ -416,7 +416,7 @@ bool cast_mirror_spell(PlayerType *player_ptr, MindMirrorMasterType spell)
         teleport_player(player_ptr, 10, TELEPORT_SPONTANEOUS);
         break;
     case MindMirrorMasterType::MIRROR_LIGHT:
-        (void)lite_area(player_ptr, damroll(2, (plev / 2)), (plev / 10) + 1);
+        (void)lite_area(player_ptr, Dice::roll(2, (plev / 2)), (plev / 10) + 1);
         break;
     case MindMirrorMasterType::WANDERING_MIRROR:
         teleport_player(player_ptr, plev * 5, TELEPORT_SPONTANEOUS);
@@ -436,7 +436,7 @@ bool cast_mirror_spell(PlayerType *player_ptr, MindMirrorMasterType spell)
             return false;
         }
 
-        fire_ball(player_ptr, AttributeType::SHARDS, dir, damroll(8 + ((plev - 5) / 4), 8), (plev > 20 ? (plev - 20) / 8 + 1 : 0));
+        fire_ball(player_ptr, AttributeType::SHARDS, dir, Dice::roll(8 + ((plev - 5) / 4), 8), (plev > 20 ? (plev - 20) / 8 + 1 : 0));
         break;
     case MindMirrorMasterType::SLEEPING_MIRROR:
         for (x = 0; x < player_ptr->current_floor_ptr->width; x++) {
@@ -454,7 +454,7 @@ bool cast_mirror_spell(PlayerType *player_ptr, MindMirrorMasterType spell)
             return false;
         }
 
-        SpellsMirrorMaster(player_ptr).seeker_ray(dir, damroll(11 + (plev - 5) / 4, 8));
+        SpellsMirrorMaster(player_ptr).seeker_ray(dir, Dice::roll(11 + (plev - 5) / 4, 8));
         break;
     case MindMirrorMasterType::SEALING_MIRROR:
         SpellsMirrorMaster(player_ptr).seal_of_mirror(plev * 4 + 100);

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -490,7 +490,7 @@ bool cast_ninja_spell(PlayerType *player_ptr, MindNinjaType spell)
         teleport_player(player_ptr, 30, TELEPORT_SPONTANEOUS);
         break;
     case MindNinjaType::PURGATORY_FLAME: {
-        int num = damroll(3, 9);
+        int num = Dice::roll(3, 9);
         for (int k = 0; k < num; k++) {
             AttributeType typ = one_in_(2) ? AttributeType::FIRE : one_in_(3) ? AttributeType::NETHER
                                                                               : AttributeType::PLASMA;
@@ -502,7 +502,7 @@ bool cast_ninja_spell(PlayerType *player_ptr, MindNinjaType spell)
                 }
             }
 
-            project(player_ptr, 0, 0, y, x, damroll(6 + plev / 8, 10), typ, (PROJECT_BEAM | PROJECT_THRU | PROJECT_GRID | PROJECT_KILL));
+            project(player_ptr, 0, 0, y, x, Dice::roll(6 + plev / 8, 10), typ, (PROJECT_BEAM | PROJECT_THRU | PROJECT_GRID | PROJECT_KILL));
         }
 
         break;

--- a/src/monster-attack/monster-attack-switcher.cpp
+++ b/src/monster-attack/monster-attack-switcher.cpp
@@ -217,7 +217,7 @@ static void calc_blow_paralysis(PlayerType *player_ptr, MonsterAttackPlayer *mon
  */
 static void calc_blow_drain_exp(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr, const int drain_value, const int hold_exp_prob)
 {
-    int32_t d = damroll(drain_value, 6) + (player_ptr->exp / 100) * MON_DRAIN_LIFE;
+    int32_t d = Dice::roll(drain_value, 6) + (player_ptr->exp / 100) * MON_DRAIN_LIFE;
     monap_ptr->obvious = true;
     int damage_ratio = 1000;
     if (has_hold_exp(player_ptr)) {
@@ -263,7 +263,7 @@ static void calc_blow_time(PlayerType *player_ptr, MonsterAttackPlayer *monap_pt
  */
 static void calc_blow_drain_life(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
 {
-    int32_t d = damroll(60, 6) + (player_ptr->exp / 100) * MON_DRAIN_LIFE;
+    int32_t d = Dice::roll(60, 6) + (player_ptr->exp / 100) * MON_DRAIN_LIFE;
     monap_ptr->obvious = true;
     if (player_ptr->hold_exp) {
         monap_ptr->damage = monap_ptr->damage * 9 / 10;
@@ -553,7 +553,7 @@ void switch_monster_blow_to_player(PlayerType *player_ptr, MonsterAttackPlayer *
                     return;
                 }
 
-                int32_t d = damroll(60, 6) + (player_ptr->exp / 100) * MON_DRAIN_LIFE;
+                int32_t d = Dice::roll(60, 6) + (player_ptr->exp / 100) * MON_DRAIN_LIFE;
 
                 bool resist_drain = check_drain_hp(player_ptr, d);
                 process_drain_life(player_ptr, monap_ptr, resist_drain);

--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -295,7 +295,7 @@ void process_drain_life(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr, 
     }
 
     bool did_heal = monap_ptr->m_ptr->hp < monap_ptr->m_ptr->maxhp;
-    monap_ptr->m_ptr->hp += damroll(4, monap_ptr->damage / 6);
+    monap_ptr->m_ptr->hp += Dice::roll(4, monap_ptr->damage / 6);
     if (monap_ptr->m_ptr->hp > monap_ptr->m_ptr->maxhp) {
         monap_ptr->m_ptr->hp = monap_ptr->m_ptr->maxhp;
     }

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -242,19 +242,19 @@ static int decide_drop_numbers(MonsterDeath *md_ptr, const bool drop_item, const
     }
 
     if (md_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_1D2)) {
-        drop_numbers += damroll(1, 2);
+        drop_numbers += Dice::roll(1, 2);
     }
 
     if (md_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_2D2)) {
-        drop_numbers += damroll(2, 2);
+        drop_numbers += Dice::roll(2, 2);
     }
 
     if (md_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_3D2)) {
-        drop_numbers += damroll(3, 2);
+        drop_numbers += Dice::roll(3, 2);
     }
 
     if (md_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_4D2)) {
-        drop_numbers += damroll(4, 2);
+        drop_numbers += Dice::roll(4, 2);
     }
 
     if (md_ptr->cloned && md_ptr->r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE)) {

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -289,7 +289,7 @@ static bool process_explosive_rune(PlayerType *player_ptr, turn_flags *turn_flag
         if (grid.info & CAVE_MARK) {
             msg_print(_("ルーンが爆発した！", "The rune explodes!"));
             BIT_FLAGS project_flags = PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_JUMP | PROJECT_NO_HANGEKI;
-            project(player_ptr, 0, 2, pos.y, pos.x, 2 * (player_ptr->lev + damroll(7, 7)), AttributeType::MANA, project_flags);
+            project(player_ptr, 0, 2, pos.y, pos.x, 2 * (player_ptr->lev + Dice::roll(7, 7)), AttributeType::MANA, project_flags);
         }
     } else {
         msg_print(_("爆発のルーンは解除された。", "An explosive rune was disarmed."));

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -440,7 +440,7 @@ bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, 
     if (randint1(BREAK_RUNE_EXPLOSION) > r_ptr->level) {
         if (any_bits(g_ptr->info, CAVE_MARK)) {
             msg_print(_("ルーンが爆発した！", "The rune explodes!"));
-            project(player_ptr, 0, 2, y, x, 2 * (player_ptr->lev + damroll(7, 7)), AttributeType::MANA,
+            project(player_ptr, 0, 2, y, x, 2 * (player_ptr->lev + Dice::roll(7, 7)), AttributeType::MANA,
                 (PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_JUMP | PROJECT_NO_HANGEKI));
         }
     } else {

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -518,7 +518,7 @@ void switch_special_death(PlayerType *player_ptr, MonsterDeath *md_ptr, Attribut
         on_dead_can_angel(player_ptr, md_ptr);
         return;
     case MonsterRaceId::ROLENTO:
-        (void)project(player_ptr, md_ptr->m_idx, 3, md_ptr->md_y, md_ptr->md_x, damroll(20, 10), AttributeType::FIRE, PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL);
+        (void)project(player_ptr, md_ptr->m_idx, 3, md_ptr->md_y, md_ptr->md_x, Dice::roll(20, 10), AttributeType::FIRE, PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL);
         return;
     case MonsterRaceId::MIDDLE_AQUA_FIRST:
     case MonsterRaceId::LARGE_AQUA_FIRST:

--- a/src/mspell/mspell-special.cpp
+++ b/src/mspell/mspell-special.cpp
@@ -209,7 +209,7 @@ static MonsterSpellResult spell_RF6_SPECIAL_B(PlayerType *player_ptr, POSITION y
     simple_monspell_message(player_ptr, m_idx, t_idx, msg, target_type);
 
     bool fear, dead; /* dummy */
-    int dam = damroll(4, 8);
+    int dam = Dice::roll(4, 8);
 
     if (monster_to_player || t_idx == player_ptr->riding) {
         teleport_player_to(player_ptr, m_ptr->fy, m_ptr->fx, i2enum<teleport_flags>(TELEPORT_NONMAGICAL | TELEPORT_PASSIVE));
@@ -226,7 +226,7 @@ static MonsterSpellResult spell_RF6_SPECIAL_B(PlayerType *player_ptr, POSITION y
     }
 
     simple_monspell_message(player_ptr, m_idx, t_idx, msg, target_type);
-    dam += damroll(6, 8);
+    dam += Dice::roll(6, 8);
 
     if (monster_to_player || (monster_to_monster && player_ptr->riding == t_idx)) {
         int get_damage = take_hit(player_ptr, DAMAGE_NOESCAPE, dam, m_name);

--- a/src/object-activation/activation-bolt-ball.cpp
+++ b/src/object-activation/activation-bolt-ball.cpp
@@ -20,7 +20,7 @@ bool activate_missile_1(PlayerType *player_ptr)
         return false;
     }
 
-    (void)fire_bolt(player_ptr, AttributeType::MISSILE, dir, damroll(2, 6));
+    (void)fire_bolt(player_ptr, AttributeType::MISSILE, dir, Dice::roll(2, 6));
     return true;
 }
 
@@ -56,7 +56,7 @@ bool activate_bolt_acid_1(PlayerType *player_ptr)
         return false;
     }
 
-    (void)fire_bolt(player_ptr, AttributeType::ACID, dir, damroll(5, 8));
+    (void)fire_bolt(player_ptr, AttributeType::ACID, dir, Dice::roll(5, 8));
     return true;
 }
 
@@ -68,7 +68,7 @@ bool activate_bolt_elec_1(PlayerType *player_ptr)
         return false;
     }
 
-    (void)fire_bolt(player_ptr, AttributeType::ELEC, dir, damroll(4, 8));
+    (void)fire_bolt(player_ptr, AttributeType::ELEC, dir, Dice::roll(4, 8));
     return true;
 }
 
@@ -80,7 +80,7 @@ bool activate_bolt_fire_1(PlayerType *player_ptr)
         return false;
     }
 
-    (void)fire_bolt(player_ptr, AttributeType::FIRE, dir, damroll(9, 8));
+    (void)fire_bolt(player_ptr, AttributeType::FIRE, dir, Dice::roll(9, 8));
     return true;
 }
 
@@ -92,7 +92,7 @@ bool activate_bolt_cold_1(PlayerType *player_ptr)
         return false;
     }
 
-    (void)fire_bolt(player_ptr, AttributeType::COLD, dir, damroll(6, 8));
+    (void)fire_bolt(player_ptr, AttributeType::COLD, dir, Dice::roll(6, 8));
     return true;
 }
 
@@ -334,7 +334,7 @@ bool activate_ball_water(PlayerType *player_ptr, std::string_view name)
 
 bool activate_ball_lite(PlayerType *player_ptr, std::string_view name)
 {
-    int num = damroll(5, 3);
+    int num = Dice::roll(5, 3);
     POSITION y = 0, x = 0;
     msg_format(_("%sが稲妻で覆われた...", "The %s is surrounded by lightning..."), name.data());
     for (int k = 0; k < num; k++) {

--- a/src/object-activation/activation-others.cpp
+++ b/src/object-activation/activation-others.cpp
@@ -65,7 +65,7 @@ bool activate_sunlight(PlayerType *player_ptr)
     }
 
     msg_print(_("太陽光線が放たれた。", "A line of sunlight appears."));
-    (void)lite_line(player_ptr, dir, damroll(6, 8));
+    (void)lite_line(player_ptr, dir, Dice::roll(6, 8));
     return true;
 }
 
@@ -137,7 +137,7 @@ bool activate_judgement(PlayerType *player_ptr, std::string_view name)
     wiz_lite(player_ptr, false);
 
     msg_format(_("%sはあなたの体力を奪った...", "The %s drains your vitality..."), name.data());
-    take_hit(player_ptr, DAMAGE_LOSELIFE, damroll(3, 8), _("審判の宝石", "the Jewel of Judgement"));
+    take_hit(player_ptr, DAMAGE_LOSELIFE, Dice::roll(3, 8), _("審判の宝石", "the Jewel of Judgement"));
 
     (void)detect_traps(player_ptr, DETECT_RAD_DEFAULT, true);
     (void)detect_doors(player_ptr, DETECT_RAD_DEFAULT);
@@ -353,7 +353,7 @@ bool activate_map_light(PlayerType *player_ptr)
 {
     msg_print(_("眩しく輝いた...", "It shines brightly..."));
     map_area(player_ptr, DETECT_RAD_MAP);
-    lite_area(player_ptr, damroll(2, 15), 3);
+    lite_area(player_ptr, Dice::roll(2, 15), 3);
     return true;
 }
 
@@ -387,7 +387,7 @@ bool activate_protection_elbereth(PlayerType *player_ptr)
 bool activate_light(PlayerType *player_ptr, std::string_view name)
 {
     msg_format(_("%sから澄んだ光があふれ出た...", "The %s wells with clear light..."), name.data());
-    (void)lite_area(player_ptr, damroll(2, 15), 3);
+    (void)lite_area(player_ptr, Dice::roll(2, 15), 3);
     return true;
 }
 

--- a/src/object-activation/activation-switcher.cpp
+++ b/src/object-activation/activation-switcher.cpp
@@ -362,7 +362,7 @@ bool switch_activation(PlayerType *player_ptr, ItemEntity **o_ptr_ptr, const Ran
         return activate_teleport_level(player_ptr);
     case RandomArtActType::STRAIN_HASTE:
         msg_format(_("%sはあなたの体力を奪った...", "The %s drains your vitality..."), name.data());
-        take_hit(player_ptr, DAMAGE_LOSELIFE, damroll(3, 8), _("加速した疲労", "the strain of haste"));
+        take_hit(player_ptr, DAMAGE_LOSELIFE, Dice::roll(3, 8), _("加速した疲労", "the strain of haste"));
         (void)mod_acceleration(player_ptr, 25 + randint1(25), false);
         return true;
     case RandomArtActType::FISHING:

--- a/src/object-use/quaff/quaff-effects.cpp
+++ b/src/object-use/quaff/quaff-effects.cpp
@@ -331,7 +331,7 @@ bool QuaffEffects::lose_memories()
 bool QuaffEffects::ruination()
 {
     msg_print(_("身も心も弱ってきて、精気が抜けていくようだ。", "Your nerves and muscles feel weak and lifeless!"));
-    take_hit(this->player_ptr, DAMAGE_LOSELIFE, damroll(10, 10), _("破滅の薬", "a potion of Ruination"));
+    take_hit(this->player_ptr, DAMAGE_LOSELIFE, Dice::roll(10, 10), _("破滅の薬", "a potion of Ruination"));
     (void)dec_stat(this->player_ptr, A_DEX, 25, true);
     (void)dec_stat(this->player_ptr, A_WIS, 25, true);
     (void)dec_stat(this->player_ptr, A_CON, 25, true);
@@ -348,7 +348,7 @@ bool QuaffEffects::ruination()
 bool QuaffEffects::detonation()
 {
     msg_print(_("体の中で激しい爆発が起きた！", "Massive explosions rupture your body!"));
-    take_hit(this->player_ptr, DAMAGE_NOESCAPE, damroll(50, 20), _("爆発の薬", "a potion of Detonation"));
+    take_hit(this->player_ptr, DAMAGE_NOESCAPE, Dice::roll(50, 20), _("爆発の薬", "a potion of Detonation"));
     BadStatusSetter bss(this->player_ptr);
     (void)bss.mod_stun(75);
     (void)bss.mod_cut(5000);

--- a/src/object-use/read/scroll-read-executor.cpp
+++ b/src/object-use/read/scroll-read-executor.cpp
@@ -231,7 +231,7 @@ bool ScrollReadExecutor::read()
 
         break;
     case SV_SCROLL_LIGHT:
-        if (lite_area(this->player_ptr, damroll(2, 8), 2)) {
+        if (lite_area(this->player_ptr, Dice::roll(2, 8), 2)) {
             this->ident = true;
         }
 

--- a/src/object/object-broken.cpp
+++ b/src/object/object-broken.cpp
@@ -277,7 +277,7 @@ bool potion_smash_effect(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y
     case SV_POTION_RUINATION:
     case SV_POTION_DETONATIONS:
         dt = AttributeType::SHARDS;
-        dam = damroll(25, 25);
+        dam = Dice::roll(25, 25);
         angry = true;
         break;
     case SV_POTION_DEATH:
@@ -291,20 +291,20 @@ bool potion_smash_effect(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y
         break;
     case SV_POTION_CURE_LIGHT:
         dt = AttributeType::OLD_HEAL;
-        dam = damroll(2, 3);
+        dam = Dice::roll(2, 3);
         break;
     case SV_POTION_CURE_SERIOUS:
         dt = AttributeType::OLD_HEAL;
-        dam = damroll(4, 3);
+        dam = Dice::roll(4, 3);
         break;
     case SV_POTION_CURE_CRITICAL:
     case SV_POTION_CURING:
         dt = AttributeType::OLD_HEAL;
-        dam = damroll(6, 3);
+        dam = Dice::roll(6, 3);
         break;
     case SV_POTION_HEALING:
         dt = AttributeType::OLD_HEAL;
-        dam = damroll(10, 10);
+        dam = Dice::roll(10, 10);
         break;
     case SV_POTION_RESTORE_EXP:
         dt = AttributeType::STAR_HEAL;
@@ -313,22 +313,22 @@ bool potion_smash_effect(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y
         break;
     case SV_POTION_LIFE:
         dt = AttributeType::STAR_HEAL;
-        dam = damroll(50, 50);
+        dam = Dice::roll(50, 50);
         radius = 1;
         break;
     case SV_POTION_STAR_HEALING:
         dt = AttributeType::OLD_HEAL;
-        dam = damroll(50, 50);
+        dam = Dice::roll(50, 50);
         radius = 1;
         break;
     case SV_POTION_RESTORE_MANA:
         dt = AttributeType::MANA;
-        dam = damroll(10, 10);
+        dam = Dice::roll(10, 10);
         radius = 1;
         break;
     case SV_POTION_POLY_SELF:
         dt = AttributeType::NEXUS;
-        dam = damroll(20, 20);
+        dam = Dice::roll(20, 20);
         radius = 1;
         break;
     default:

--- a/src/player-attack/attack-chaos-effect.cpp
+++ b/src/player-attack/attack-chaos-effect.cpp
@@ -143,7 +143,7 @@ static void attack_dispel(PlayerType *player_ptr, player_attack_type *pa_ptr)
     msg_print(_("武器が敵の魔力を吸い取った！", "The weapon drains mana from your enemy!"));
     dispel_monster_status(player_ptr, pa_ptr->m_idx);
 
-    auto sp = damroll(dd, 8);
+    auto sp = Dice::roll(dd, 8);
     player_ptr->csp = std::min(player_ptr->msp, player_ptr->csp + sp);
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::MP);
 }

--- a/src/player-attack/blood-sucking-processor.cpp
+++ b/src/player-attack/blood-sucking-processor.cpp
@@ -113,7 +113,7 @@ static void drain_result(PlayerType *player_ptr, player_attack_type *pa_ptr, boo
         return;
     }
 
-    int drain_heal = damroll(2, pa_ptr->drain_result / 6);
+    int drain_heal = Dice::roll(2, pa_ptr->drain_result / 6);
 
     if (SpellHex(player_ptr).is_spelling_specific(HEX_VAMP_BLADE)) {
         drain_heal *= 2;

--- a/src/player-attack/player-attack.cpp
+++ b/src/player-attack/player-attack.cpp
@@ -249,7 +249,7 @@ static MagicalBrandEffectType select_magical_brand_effect(PlayerType *player_ptr
  * @param pa_ptr プレイヤー攻撃情報への参照ポインタ
  * @return ダイス数
  */
-static DICE_NUMBER magical_brand_extra_dice(player_attack_type *pa_ptr)
+static int magical_brand_extra_dice(player_attack_type *pa_ptr)
 {
     switch (pa_ptr->magical_effect) {
     case MagicalBrandEffectType::NONE:

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -603,7 +603,7 @@ static void process_aura_damage(MonsterEntity *m_ptr, PlayerType *player_ptr, bo
         return;
     }
 
-    int aura_damage = damroll(1 + (r_ptr->level / 26), 1 + (r_ptr->level / 17));
+    int aura_damage = Dice::roll(1 + (r_ptr->level / 26), 1 + (r_ptr->level / 17));
     msg_print(message);
     (*dam_func)(player_ptr, aura_damage, monster_desc(player_ptr, m_ptr, MD_WRONGDOER_NAME).data(), true);
     if (is_original_ap_and_seen(player_ptr, m_ptr)) {

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -2820,7 +2820,7 @@ void wreck_the_pattern(PlayerType *player_ptr)
     msg_print(_("何か恐ろしい事が起こった！", "Something terrible happens!"));
 
     if (!is_invuln(player_ptr)) {
-        take_hit(player_ptr, DAMAGE_NOESCAPE, damroll(10, 8), _("パターン損壊", "corrupting the Pattern"));
+        take_hit(player_ptr, DAMAGE_NOESCAPE, Dice::roll(10, 8), _("パターン損壊", "corrupting the Pattern"));
     }
 
     auto to_ruin = randint1(45) + 35;

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -140,7 +140,7 @@ static int16_t calc_to_hit_bow(PlayerType *player_ptr, bool is_real_value);
 static int16_t calc_to_damage_misc(PlayerType *player_ptr);
 static int16_t calc_to_hit_misc(PlayerType *player_ptr);
 
-static DICE_NUMBER calc_to_weapon_dice_num(PlayerType *player_ptr, INVENTORY_IDX slot);
+static int calc_to_weapon_dice_num(PlayerType *player_ptr, INVENTORY_IDX slot);
 static player_hand main_attack_hand(PlayerType *player_ptr);
 
 /*** Player information ***/
@@ -2635,7 +2635,7 @@ static int16_t calc_to_hit_misc(PlayerType *player_ptr)
     return to_hit;
 }
 
-static DICE_NUMBER calc_to_weapon_dice_num(PlayerType *player_ptr, INVENTORY_IDX slot)
+static int calc_to_weapon_dice_num(PlayerType *player_ptr, INVENTORY_IDX slot)
 {
     auto *o_ptr = &player_ptr->inventory_list[slot];
     return (player_ptr->riding > 0) && o_ptr->is_lance() ? 2 : 0;

--- a/src/racial/racial-switcher.cpp
+++ b/src/racial/racial-switcher.cpp
@@ -415,7 +415,7 @@ bool switch_race_racial_execution(PlayerType *player_ptr, const int32_t command)
         }
 
         msg_print(_("マジック・ミサイルを放った。", "You cast a magic missile."));
-        (void)fire_bolt_or_beam(player_ptr, 10, AttributeType::MISSILE, dir, damroll(3 + ((player_ptr->lev - 1) / 5), 4));
+        (void)fire_bolt_or_beam(player_ptr, 10, AttributeType::MISSILE, dir, Dice::roll(3 + ((player_ptr->lev - 1) / 5), 4));
         return true;
     case PlayerRaceType::DRACONIAN:
         return draconian_breath(player_ptr);

--- a/src/realm/realm-chaos.cpp
+++ b/src/realm/realm-chaos.cpp
@@ -399,10 +399,10 @@ std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spel
 
         {
             int base = 12;
-            DICE_SID sides = 4;
+            const Dice dice(1, 4);
 
             if (cast) {
-                destroy_area(player_ptr, player_ptr->y, player_ptr->x, base + randint1(sides), false);
+                destroy_area(player_ptr, player_ptr->y, player_ptr->x, base + dice.roll(), false);
             }
         }
         break;

--- a/src/realm/realm-crusade.cpp
+++ b/src/realm/realm-crusade.cpp
@@ -644,10 +644,10 @@ std::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX sp
 
         {
             int base = 12;
-            DICE_SID sides = 4;
+            const Dice dice(1, 4);
 
             if (cast) {
-                destroy_area(player_ptr, player_ptr->y, player_ptr->x, base + randint1(sides), false);
+                destroy_area(player_ptr, player_ptr->y, player_ptr->x, base + dice.roll(), false);
             }
         }
         break;

--- a/src/realm/realm-nature.cpp
+++ b/src/realm/realm-nature.cpp
@@ -170,7 +170,7 @@ std::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spe
                 PlayerRace race(player_ptr);
                 if (race.life() == PlayerRaceLifeType::UNDEAD && race.tr_flags().has(TR_VUL_LITE) && !has_resist_lite(player_ptr)) {
                     msg_print(_("日の光があなたの肉体を焦がした！", "The daylight scorches your flesh!"));
-                    take_hit(player_ptr, DAMAGE_NOESCAPE, damroll(2, 2), _("日の光", "daylight"));
+                    take_hit(player_ptr, DAMAGE_NOESCAPE, Dice::roll(2, 2), _("日の光", "daylight"));
                 }
             }
         }

--- a/src/realm/realm-song.cpp
+++ b/src/realm/realm-song.cpp
@@ -744,16 +744,16 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
         }
 
         {
-            DICE_SID m_sides = plev * 3;
-            DICE_SID e_sides = plev * 3;
+            const Dice m_dice(1, plev * 3);
+            const Dice e_dice(1, plev * 3);
 
             if (info) {
-                return format("%s1d%d+1d%d", KWD_DAM, m_sides, e_sides);
+                return format("%s%s+%s", KWD_DAM, m_dice.to_string().data(), e_dice.to_string().data());
             }
 
             if (cont) {
-                dispel_monsters(player_ptr, randint1(m_sides));
-                dispel_evil(player_ptr, randint1(e_sides));
+                dispel_monsters(player_ptr, m_dice.roll());
+                dispel_evil(player_ptr, e_dice.roll());
             }
         }
         break;

--- a/src/specific-object/bloody-moon.cpp
+++ b/src/specific-object/bloody-moon.cpp
@@ -63,7 +63,7 @@ void get_bloody_moon_flags(ItemEntity *o_ptr)
 {
     o_ptr->art_flags = ArtifactList::get_instance().get_artifact(FixedArtifactId::BLOOD).flags;
 
-    for (int i = 0, count = damroll(2, 2); i < count; i++) {
+    for (int i = 0, count = Dice::roll(2, 2); i < count; i++) {
         const auto flag = rand_choice(BLOODY_MOON_SLAYING_FLAG_CANDIDATES);
         o_ptr->art_flags.set(flag);
     }

--- a/src/specific-object/chest.cpp
+++ b/src/specific-object/chest.cpp
@@ -145,14 +145,14 @@ void Chest::fire_trap(const Pos2D &pos, short item_idx)
     /* Lose strength */
     if (trap.has(ChestTrapType::LOSE_STR)) {
         msg_print(_("仕掛けられていた小さな針に刺されてしまった！", "A small needle has pricked you!"));
-        take_hit(this->player_ptr, DAMAGE_NOESCAPE, damroll(1, 4), _("毒針", "a poison needle"));
+        take_hit(this->player_ptr, DAMAGE_NOESCAPE, Dice::roll(1, 4), _("毒針", "a poison needle"));
         (void)do_dec_stat(this->player_ptr, A_STR);
     }
 
     /* Lose constitution */
     if (trap.has(ChestTrapType::LOSE_CON)) {
         msg_print(_("仕掛けられていた小さな針に刺されてしまった！", "A small needle has pricked you!"));
-        take_hit(this->player_ptr, DAMAGE_NOESCAPE, damroll(1, 4), _("毒針", "a poison needle"));
+        take_hit(this->player_ptr, DAMAGE_NOESCAPE, Dice::roll(1, 4), _("毒針", "a poison needle"));
         (void)do_dec_stat(this->player_ptr, A_CON);
     }
 
@@ -251,7 +251,7 @@ void Chest::fire_trap(const Pos2D &pos, short item_idx)
             }
 
             if (one_in_(6)) {
-                take_hit(this->player_ptr, DAMAGE_NOESCAPE, damroll(5, 20), _("破滅のトラップの宝箱", "a chest dispel-player trap"));
+                take_hit(this->player_ptr, DAMAGE_NOESCAPE, Dice::roll(5, 20), _("破滅のトラップの宝箱", "a chest dispel-player trap"));
                 continue;
             }
 
@@ -302,7 +302,7 @@ void Chest::fire_trap(const Pos2D &pos, short item_idx)
         msg_print(_("箱の中の物はすべて粉々に砕け散った！", "Everything inside the chest is destroyed!"));
         o_ptr->pval = 0;
         sound(SOUND_EXPLODE);
-        take_hit(this->player_ptr, DAMAGE_ATTACK, damroll(5, 8), _("爆発する箱", "an exploding chest"));
+        take_hit(this->player_ptr, DAMAGE_ATTACK, Dice::roll(5, 8), _("爆発する箱", "an exploding chest"));
     }
     /* Scatter contents. */
     if ((trap.has(ChestTrapType::SCATTER)) && o_ptr->is_valid()) {

--- a/src/specific-object/stone-of-lore.cpp
+++ b/src/specific-object/stone-of-lore.cpp
@@ -35,13 +35,13 @@ bool StoneOfLore::perilous_secrets()
 
     this->consume_mp();
     auto dam_source = _("危険な秘密", "perilous secrets");
-    take_hit(this->player_ptr, DAMAGE_LOSELIFE, damroll(1, 12), dam_source);
+    take_hit(this->player_ptr, DAMAGE_LOSELIFE, Dice::roll(1, 12), dam_source);
     if (one_in_(5)) {
         (void)BadStatusSetter(this->player_ptr).mod_confusion(randnum1<short>(10));
     }
 
     if (one_in_(20)) {
-        take_hit(this->player_ptr, DAMAGE_LOSELIFE, damroll(4, 10), dam_source);
+        take_hit(this->player_ptr, DAMAGE_LOSELIFE, Dice::roll(4, 10), dam_source);
     }
 
     return true;

--- a/src/spell-kind/blood-curse.cpp
+++ b/src/spell-kind/blood-curse.cpp
@@ -42,7 +42,7 @@ void blood_curse_to_enemy(PlayerType *player_ptr, MONSTER_IDX m_idx)
         case 5:
         case 6:
             if (!count) {
-                int extra_dam = damroll(10, 10);
+                int extra_dam = Dice::roll(10, 10);
                 msg_print(_("純粋な魔力の次元への扉が開いた！", "A portal opens to a plane of raw mana!"));
                 project(player_ptr, 0, 8, m_ptr->fy, m_ptr->fx, extra_dam, AttributeType::MANA, curse_flg);
                 if (!one_in_(6)) {
@@ -55,7 +55,7 @@ void blood_curse_to_enemy(PlayerType *player_ptr, MONSTER_IDX m_idx)
             if (!count) {
                 msg_print(_("空間が歪んだ！", "Space warps about you!"));
                 if (m_ptr->is_valid()) {
-                    teleport_away(player_ptr, g_ptr->m_idx, damroll(10, 10), TELEPORT_PASSIVE);
+                    teleport_away(player_ptr, g_ptr->m_idx, Dice::roll(10, 10), TELEPORT_PASSIVE);
                 }
                 if (one_in_(13)) {
                     count += activate_hi_summon(player_ptr, m_ptr->fy, m_ptr->fx, true);

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -142,7 +142,7 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
 
             msg_print(msg);
             if (is_damaged) {
-                damage = damroll(10, 4);
+                damage = Dice::roll(10, 4);
                 BadStatusSetter(player_ptr).mod_stun(randnum1<short>(50));
             }
 
@@ -240,7 +240,7 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
                 msg_format(_("%s^は苦痛で泣きわめいた！", "%s^ wails out in pain!"), m_name.data());
             }
 
-            damage = (sn ? damroll(4, 8) : (m_ptr->hp + 1));
+            damage = (sn ? Dice::roll(4, 8) : (m_ptr->hp + 1));
             (void)set_monster_csleep(player_ptr, grid.m_idx, 0);
             m_ptr->hp -= damage;
             if (m_ptr->hp < 0) {

--- a/src/spell-kind/magic-item-recharger.cpp
+++ b/src/spell-kind/magic-item-recharger.cpp
@@ -71,7 +71,7 @@ bool recharge(PlayerType *player_ptr, int power)
         if (one_in_(recharge_strength)) {
             is_recharge_successful = false;
         } else {
-            recharge_amount = (power * damroll(3, 2));
+            recharge_amount = (power * Dice::roll(3, 2));
             if (o_ptr->timeout > recharge_amount) {
                 o_ptr->timeout -= recharge_amount;
             } else {

--- a/src/spell-kind/spells-lite.cpp
+++ b/src/spell-kind/spells-lite.cpp
@@ -376,7 +376,7 @@ bool starlight(PlayerType *player_ptr, bool magic)
         msg_print(_("杖の先が明るく輝いた...", "The end of the staff glows brightly..."));
     }
 
-    int num = damroll(5, 3);
+    int num = Dice::roll(5, 3);
     auto y = 0;
     auto x = 0;
     for (int k = 0; k < num; k++) {
@@ -394,7 +394,7 @@ bool starlight(PlayerType *player_ptr, bool magic)
         }
 
         constexpr uint flags = PROJECT_BEAM | PROJECT_THRU | PROJECT_GRID | PROJECT_KILL | PROJECT_LOS;
-        project(player_ptr, 0, 0, y, x, damroll(6 + player_ptr->lev / 8, 10), AttributeType::LITE_WEAK, flags);
+        project(player_ptr, 0, 0, y, x, Dice::roll(6 + player_ptr->lev / 8, 10), AttributeType::LITE_WEAK, flags);
     }
 
     return true;

--- a/src/spell-kind/spells-neighbor.cpp
+++ b/src/spell-kind/spells-neighbor.cpp
@@ -151,7 +151,7 @@ void wall_breaker(PlayerType *player_ptr)
         return;
     }
 
-    int num = damroll(5, 3);
+    int num = Dice::roll(5, 3);
     for (int i = 0; i < num; i++) {
         while (true) {
             scatter(player_ptr, &y, &x, player_ptr->y, player_ptr->x, 10, PROJECT_NONE);

--- a/src/spell-kind/spells-random.cpp
+++ b/src/spell-kind/spells-random.cpp
@@ -119,7 +119,7 @@ bool activate_ty_curse(PlayerType *player_ptr, bool stop_ty, int *count)
         case 30:
         case 31:
             if (!(*count)) {
-                int dam = damroll(10, 10);
+                int dam = Dice::roll(10, 10);
                 msg_print(_("純粋な魔力の次元への扉が開いた！", "A portal opens to a plane of raw mana!"));
                 project(player_ptr, 0, 8, player_ptr->y, player_ptr->x, dam, AttributeType::MANA, flg);
                 take_hit(player_ptr, DAMAGE_NOESCAPE, dam, _("純粋な魔力の解放", "released pure mana"));
@@ -132,7 +132,7 @@ bool activate_ty_curse(PlayerType *player_ptr, bool stop_ty, int *count)
         case 33:
             if (!(*count)) {
                 msg_print(_("周囲の空間が歪んだ！", "Space warps about you!"));
-                teleport_player(player_ptr, damroll(10, 10), TELEPORT_PASSIVE);
+                teleport_player(player_ptr, Dice::roll(10, 10), TELEPORT_PASSIVE);
                 if (randint0(13)) {
                     (*count) += activate_hi_summon(player_ptr, player_ptr->y, player_ptr->x, false);
                 }
@@ -286,7 +286,7 @@ void wild_magic(PlayerType *player_ptr, int spell)
     case 12:
     case 13:
     case 14:
-        lite_area(player_ptr, damroll(2, 3), 2);
+        lite_area(player_ptr, Dice::roll(2, 3), 2);
         break;
     case 15:
         destroy_doors_touch(player_ptr);
@@ -401,7 +401,7 @@ void cast_wonder(PlayerType *player_ptr, DIRECTION dir)
     }
 
     if (die < 26) {
-        heal_monster(player_ptr, dir, damroll(4, 6));
+        heal_monster(player_ptr, dir, Dice::roll(4, 6));
         return;
     }
 
@@ -411,7 +411,7 @@ void cast_wonder(PlayerType *player_ptr, DIRECTION dir)
     }
 
     if (die < 36) {
-        fire_bolt_or_beam(player_ptr, beam_chance(player_ptr) - 10, AttributeType::MISSILE, dir, damroll(3 + ((plev - 1) / 5), 4));
+        fire_bolt_or_beam(player_ptr, beam_chance(player_ptr) - 10, AttributeType::MISSILE, dir, Dice::roll(3 + ((plev - 1) / 5), 4));
         return;
     }
 
@@ -426,27 +426,27 @@ void cast_wonder(PlayerType *player_ptr, DIRECTION dir)
     }
 
     if (die < 51) {
-        (void)lite_line(player_ptr, dir, damroll(6, 8));
+        (void)lite_line(player_ptr, dir, Dice::roll(6, 8));
         return;
     }
 
     if (die < 56) {
-        fire_bolt_or_beam(player_ptr, beam_chance(player_ptr) - 10, AttributeType::ELEC, dir, damroll(3 + ((plev - 5) / 4), 8));
+        fire_bolt_or_beam(player_ptr, beam_chance(player_ptr) - 10, AttributeType::ELEC, dir, Dice::roll(3 + ((plev - 5) / 4), 8));
         return;
     }
 
     if (die < 61) {
-        fire_bolt_or_beam(player_ptr, beam_chance(player_ptr) - 10, AttributeType::COLD, dir, damroll(5 + ((plev - 5) / 4), 8));
+        fire_bolt_or_beam(player_ptr, beam_chance(player_ptr) - 10, AttributeType::COLD, dir, Dice::roll(5 + ((plev - 5) / 4), 8));
         return;
     }
 
     if (die < 66) {
-        fire_bolt_or_beam(player_ptr, beam_chance(player_ptr), AttributeType::ACID, dir, damroll(6 + ((plev - 5) / 4), 8));
+        fire_bolt_or_beam(player_ptr, beam_chance(player_ptr), AttributeType::ACID, dir, Dice::roll(6 + ((plev - 5) / 4), 8));
         return;
     }
 
     if (die < 71) {
-        fire_bolt_or_beam(player_ptr, beam_chance(player_ptr), AttributeType::FIRE, dir, damroll(8 + ((plev - 5) / 4), 8));
+        fire_bolt_or_beam(player_ptr, beam_chance(player_ptr), AttributeType::FIRE, dir, Dice::roll(8 + ((plev - 5) / 4), 8));
         return;
     }
 

--- a/src/spell/spells-summon.cpp
+++ b/src/spell/spells-summon.cpp
@@ -492,21 +492,21 @@ void cast_invoke_spirits(PlayerType *player_ptr, DIRECTION dir)
     } else if (die < 31) {
         poly_monster(player_ptr, dir, plev);
     } else if (die < 36) {
-        fire_bolt_or_beam(player_ptr, beam_chance(player_ptr) - 10, AttributeType::MISSILE, dir, damroll(3 + ((plev - 1) / 5), 4));
+        fire_bolt_or_beam(player_ptr, beam_chance(player_ptr) - 10, AttributeType::MISSILE, dir, Dice::roll(3 + ((plev - 1) / 5), 4));
     } else if (die < 41) {
         confuse_monster(player_ptr, dir, plev);
     } else if (die < 46) {
         fire_ball(player_ptr, AttributeType::POIS, dir, 20 + (plev / 2), 3);
     } else if (die < 51) {
-        (void)lite_line(player_ptr, dir, damroll(6, 8));
+        (void)lite_line(player_ptr, dir, Dice::roll(6, 8));
     } else if (die < 56) {
-        fire_bolt_or_beam(player_ptr, beam_chance(player_ptr) - 10, AttributeType::ELEC, dir, damroll(3 + ((plev - 5) / 4), 8));
+        fire_bolt_or_beam(player_ptr, beam_chance(player_ptr) - 10, AttributeType::ELEC, dir, Dice::roll(3 + ((plev - 5) / 4), 8));
     } else if (die < 61) {
-        fire_bolt_or_beam(player_ptr, beam_chance(player_ptr) - 10, AttributeType::COLD, dir, damroll(5 + ((plev - 5) / 4), 8));
+        fire_bolt_or_beam(player_ptr, beam_chance(player_ptr) - 10, AttributeType::COLD, dir, Dice::roll(5 + ((plev - 5) / 4), 8));
     } else if (die < 66) {
-        fire_bolt_or_beam(player_ptr, beam_chance(player_ptr), AttributeType::ACID, dir, damroll(6 + ((plev - 5) / 4), 8));
+        fire_bolt_or_beam(player_ptr, beam_chance(player_ptr), AttributeType::ACID, dir, Dice::roll(6 + ((plev - 5) / 4), 8));
     } else if (die < 71) {
-        fire_bolt_or_beam(player_ptr, beam_chance(player_ptr), AttributeType::FIRE, dir, damroll(8 + ((plev - 5) / 4), 8));
+        fire_bolt_or_beam(player_ptr, beam_chance(player_ptr), AttributeType::FIRE, dir, Dice::roll(8 + ((plev - 5) / 4), 8));
     } else if (die < 76) {
         hypodynamic_bolt(player_ptr, dir, 75);
     } else if (die < 81) {

--- a/src/status/shape-changer.cpp
+++ b/src/status/shape-changer.cpp
@@ -30,7 +30,7 @@
 void do_poly_wounds(PlayerType *player_ptr)
 {
     int16_t hit_p = (player_ptr->mhp - player_ptr->chp);
-    int16_t change = damroll(player_ptr->lev, 5);
+    auto change = static_cast<TIME_EFFECT>(Dice::roll(player_ptr->lev, 5));
     auto nasty_effect = one_in_(5);
     const auto &player_cut = player_ptr->effects()->cut();
     if (!player_cut.is_cut() && (hit_p == 0) && !nasty_effect) {
@@ -176,7 +176,7 @@ void do_poly_self(PlayerType *player_ptr)
         }
         if (one_in_(6)) {
             msg_print(_("現在の姿で生きていくのは困難なようだ！", "You find living difficult in your present form!"));
-            take_hit(player_ptr, DAMAGE_LOSELIFE, damroll(randint1(10), player_ptr->lev), _("致命的な突然変異", "a lethal mutation"));
+            take_hit(player_ptr, DAMAGE_LOSELIFE, Dice::roll(randint1(10), player_ptr->lev), _("致命的な突然変異", "a lethal mutation"));
 
             power -= 10;
         }

--- a/src/store/service-checker.cpp
+++ b/src/store/service-checker.cpp
@@ -232,15 +232,15 @@ static int mass_lite_produce(const PRICE cost)
 {
     int size = 1;
     if (cost <= 5L) {
-        size += damroll(3, 5);
+        size += Dice::roll(3, 5);
     }
 
     if (cost <= 20L) {
-        size += damroll(3, 5);
+        size += Dice::roll(3, 5);
     }
 
     if (cost <= 50L) {
-        size += damroll(2, 2);
+        size += Dice::roll(2, 2);
     }
 
     return size;
@@ -250,20 +250,20 @@ static int mass_scroll_produce(const ItemEntity &item, const PRICE cost)
 {
     int size = 1;
     if (cost <= 60L) {
-        size += damroll(3, 5);
+        size += Dice::roll(3, 5);
     }
 
     if (cost <= 240L) {
-        size += damroll(1, 5);
+        size += Dice::roll(1, 5);
     }
 
     const auto sval = item.bi_key.sval();
     if (sval == SV_SCROLL_STAR_IDENTIFY) {
-        size += damroll(3, 5);
+        size += Dice::roll(3, 5);
     }
 
     if (sval == SV_SCROLL_STAR_REMOVE_CURSE) {
-        size += damroll(1, 4);
+        size += Dice::roll(1, 4);
     }
 
     return size;
@@ -273,11 +273,11 @@ static int mass_book_produce(const PRICE cost)
 {
     int size = 1;
     if (cost <= 50L) {
-        size += damroll(2, 3);
+        size += Dice::roll(2, 3);
     }
 
     if (cost <= 500L) {
-        size += damroll(1, 3);
+        size += Dice::roll(1, 3);
     }
 
     return size;
@@ -291,11 +291,11 @@ static int mass_equipment_produce(const ItemEntity &item, const PRICE cost)
     }
 
     if (cost <= 10L) {
-        size += damroll(3, 5);
+        size += Dice::roll(3, 5);
     }
 
     if (cost <= 100L) {
-        size += damroll(3, 5);
+        size += Dice::roll(3, 5);
     }
 
     return size;
@@ -305,15 +305,15 @@ static int mass_arrow_produce(const PRICE cost)
 {
     int size = 1;
     if (cost <= 5L) {
-        size += damroll(5, 5);
+        size += Dice::roll(5, 5);
     }
 
     if (cost <= 50L) {
-        size += damroll(5, 5);
+        size += Dice::roll(5, 5);
     }
 
     if (cost <= 500L) {
-        size += damroll(5, 5);
+        size += Dice::roll(5, 5);
     }
 
     return size;
@@ -323,11 +323,11 @@ static int mass_figurine_produce(const PRICE cost)
 {
     int size = 1;
     if (cost <= 100L) {
-        size += damroll(2, 2);
+        size += Dice::roll(2, 2);
     }
 
     if (cost <= 1000L) {
-        size += damroll(2, 2);
+        size += Dice::roll(2, 2);
     }
 
     return size;
@@ -341,9 +341,9 @@ static int mass_magic_produce(const PRICE cost, StoreSaleType store_num)
     }
 
     if (cost < 1601L) {
-        size += damroll(1, 5);
+        size += Dice::roll(1, 5);
     } else if (cost < 3201L) {
-        size += damroll(1, 3);
+        size += Dice::roll(1, 3);
     }
 
     return size;

--- a/src/system/h-type.h
+++ b/src/system/h-type.h
@@ -130,8 +130,6 @@ typedef int16_t SUB_EXP; /*!< ゲーム中の副経験値の型定義 */
 typedef int16_t PARAMETER_VALUE; /*!< ゲーム中のアイテム能力値の型定義 */
 typedef int32_t WEIGHT; /*!< ゲーム中の重量の型定義(ポンド) */
 
-typedef int DICE_NUMBER; /*!< ゲーム中のダイス数の型定義 */
-typedef int DICE_SID; /*!< ゲーム中のダイス面の型定義 */
 typedef int32_t PRICE; /*!< ゲーム中の金額価値の型定義 */
 
 typedef int POWER; /*!< 魔法の効力定義*/

--- a/src/term/z-rand.cpp
+++ b/src/term/z-rand.cpp
@@ -90,26 +90,6 @@ int16_t randnor(int mean, int stand)
 }
 
 /*
- * Generates damage for "2d6" style dice rolls
- */
-int16_t damroll(DICE_NUMBER num, DICE_SID sides)
-{
-    int i, sum = 0;
-    for (i = 0; i < num; i++) {
-        sum += randint1(sides);
-    }
-    return (int16_t)(sum);
-}
-
-/*
- * Same as above, but always maximal
- */
-int16_t maxroll(DICE_NUMBER num, DICE_SID sides)
-{
-    return num * sides;
-}
-
-/*
  * Given a numerator and a denominator, supply a properly rounded result,
  * using the RNG to smooth out remainders.  -LM-
  */

--- a/src/term/z-rand.h
+++ b/src/term/z-rand.h
@@ -102,8 +102,6 @@ int randint1(T max)
 
 void Rand_state_init();
 int16_t randnor(int mean, int stand);
-int16_t damroll(DICE_NUMBER num, DICE_SID sides);
-int16_t maxroll(DICE_NUMBER num, DICE_SID sides);
 int32_t div_round(int32_t n, int32_t d);
 int32_t Rand_external(int32_t m);
 


### PR DESCRIPTION
Close #4261 

#4261 関連のPR最後

適用しようと思えば他にもDiceクラスを適用できる箇所はあると思いますが、これでひとまず DICE_NUMBER と DICE_SID の型エイリアスが使用されていた部分については完全にDiceクラスで置き換わりました。

5つめのコミット b6d48896f7033bd2e75505980da39f05312b4601 は機械的な置換です。