### PR TITLE
アイテムのスポイラー出力時にクラッシュする不具合を修正した

### DIFF
--- a/src/flavor/tval-description-switcher.cpp
+++ b/src/flavor/tval-description-switcher.cpp
@@ -33,16 +33,16 @@ static std::pair<std::string, std::string> describe_monster_ball(const ItemEntit
     }
 
 #ifdef JP
-    const auto modstr = format(" (%s)", monrace.name.data());
+    const auto monrace_name = format(" (%s)", monrace.name.data());
 #else
-    std::string modstr;
+    std::string monrace_name;
     if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE)) {
-        modstr = format(" (%s%s)", (is_a_vowel(monrace.name[0]) ? "an " : "a "), monrace.name.data());
+        monrace_name = format(" (%s%s)", (is_a_vowel(monrace.name[0]) ? "an " : "a "), monrace.name.data());
     } else {
-        modstr = format(" (%s)", monrace.name.data());
+        monrace_name = format(" (%s)", monrace.name.data());
     }
 #endif
-    return { basename, modstr };
+    return { basename, monrace_name };
 }
 
 static std::pair<std::string, std::string> describe_statue(const ItemEntity &item)
@@ -50,16 +50,16 @@ static std::pair<std::string, std::string> describe_statue(const ItemEntity &ite
     const auto &basename = item.get_baseitem().name;
     const auto &monrace = item.get_monrace();
 #ifdef JP
-    const auto &modstr = monrace.name;
+    const auto &monrace_name = monrace.name;
 #else
-    std::string modstr;
+    std::string monrace_name;
     if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE)) {
-        modstr = format("%s%s", (is_a_vowel(monrace.name[0]) ? "an " : "a "), monrace.name.data());
+        monrace_name = format("%s%s", (is_a_vowel(monrace.name[0]) ? "an " : "a "), monrace.name.data());
     } else {
-        modstr = monrace.name;
+        monrace_name = monrace.name;
     }
 #endif
-    return { basename, modstr };
+    return { basename, monrace_name };
 }
 
 static std::pair<std::string, std::string> describe_corpse(const ItemEntity &item)

--- a/src/wizard/items-spoiler.cpp
+++ b/src/wizard/items-spoiler.cpp
@@ -95,15 +95,25 @@ static std::string describe_weight(const ItemEntity &item)
 
 /*!
  * @brief obj-desc.txt出力用にベースアイテムIDからItemEntityオブジェクトを生成する
- *
  * @param bi_id ベースアイテムID
  * @return obj-desc.txt出力用に使用するItemEntityオブジェクト
+ * @details 人形・像・死体類はpvalが0だと異常アイテム扱いで例外が飛ぶためダミー値を入れておく.
  */
 static ItemEntity prepare_item_for_obj_desc(short bi_id)
 {
     ItemEntity item(bi_id);
     item.ident |= IDENT_KNOWN;
-    item.pval = 0;
+    switch (item.bi_key.tval()) {
+    case ItemKindType::FIGURINE:
+    case ItemKindType::STATUE:
+    case ItemKindType::MONSTER_REMAINS:
+        item.pval = 1;
+        break;
+    default:
+        item.pval = 0;
+        break;
+    }
+
     item.to_a = 0;
     item.to_h = 0;
     item.to_d = 0;


### PR DESCRIPTION
私の環境では正常に出力されました
価格がおかしなことになっている (汚いイタズラ小僧のものが転記されている？)可能性はありますが、像や骨の価格は種族依存なので元々ダミー値ですし気にするほどではないと思われます
ご確認下さい