### PR TITLE
[Chore] プリコンパイルヘッダを使用しないようにする

### DIFF
--- a/.github/workflows/create-cache-for-ccache.yml
+++ b/.github/workflows/create-cache-for-ccache.yml
@@ -26,6 +26,7 @@ jobs:
       runner: ubuntu-24.04
       cxx: g++-13
       cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
+      configure-opts: "--disable-pch"
       use-ccache: true
 
   gcc_english:
@@ -35,6 +36,6 @@ jobs:
       runner: ubuntu-24.04
       cxx: g++-13
       cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
-      configure-opts: "--disable-japanese"
+      configure-opts: "--disable-pch --disable-japanese"
       distcheck: true
       use-ccache: true

--- a/.github/workflows/pull-request-status-check.yml
+++ b/.github/workflows/pull-request-status-check.yml
@@ -46,6 +46,7 @@ jobs:
       runner: ubuntu-24.04
       cxx: g++-13
       cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
+      configure-opts: "--disable-pch"
       use-ccache: true
 
   build_test_english:
@@ -55,7 +56,7 @@ jobs:
       runner: ubuntu-24.04
       cxx: g++-13
       cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
-      configure-opts: "--disable-japanese"
+      configure-opts: "--disable-pch --disable-japanese"
       distcheck: true
       use-ccache: true
 


### PR DESCRIPTION
ヘッダのインクルード不足によるコンパイルエラーを検出するため、GCCによるビルドテストでプリコンパイルヘッダを使用しないようにする。