### PR TITLE
[Refactor] mind_powers、mind_tips をstd::vectorにする

### DIFF
--- a/src/mind/mind-explanations-table.cpp
+++ b/src/mind/mind-explanations-table.cpp
@@ -1,7 +1,7 @@
 #include "mind/mind-explanations-table.h"
 
 /*! 特殊技能の一覧テーブル */
-mind_power const mind_powers[MAX_MINDKINDS] = {
+const std::vector<mind_power> mind_powers = {
     { {
         /* Level gained,  cost,  %fail,  name */
         { 1, 1, 15, _("霊視", "Precognition") },
@@ -20,13 +20,6 @@ mind_power const mind_powers[MAX_MINDKINDS] = {
         { 28, 10, 40, _("サイキック・ドレイン", "Psychic Drain") },
         { 35, 35, 75, _("光の剣", "Psycho-Spear") },
         { 45, 150, 85, _("完全な世界", "The World") },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
     } },
 
     { {
@@ -47,13 +40,6 @@ mind_power const mind_powers[MAX_MINDKINDS] = {
         { 32, 35, 65, _("爆発波", "Exploding Flame") },
         { 38, 42, 75, _("超カメハメ波", "Super Kamehameha") },
         { 44, 50, 80, _("光速移動", "Light Speed") },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
     } },
 
     { {
@@ -63,22 +49,6 @@ mind_power const mind_powers[MAX_MINDKINDS] = {
         { 20, 15, 0, _("トラップ粉砕", "Smash a Trap") },
         { 25, 20, 60, _("地震", "Quake") },
         { 30, 80, 75, _("皆殺し", "Massacre") },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
-        { 99, 0, 0, "" },
     } },
 
     { {
@@ -135,12 +105,11 @@ mind_power const mind_powers[MAX_MINDKINDS] = {
         { 34, 35, 50, _("霧隠れ", "Hide in Mist") },
         { 38, 40, 60, _("煉獄火炎", "Rengoku-Kaen") },
         { 41, 50, 55, _("分身", "Bunshin") },
-        { 99, 0, 0, "" },
     } },
 };
 
 /*! 特殊能力の解説文字列 */
-concptr const mind_tips[MAX_MINDKINDS][MAX_MIND_POWERS] = {
+const std::vector<std::vector<std::string>> mind_tips = {
     {
         _("近くの全ての見えるモンスターを感知する。レベル5で罠/"
           "扉、15で透明なモンスター、30で財宝とアイテムを感知できるようになる。レベル20で周辺の地形を感知し、45でその階全体を永久に照らし、"
@@ -166,13 +135,6 @@ concptr const mind_tips[MAX_MINDKINDS][MAX_MIND_POWERS] = {
         _("無傷球をも切り裂く純粋なエネルギーのビームを放つ。", "Fires a beam of pure energy which penetrates invulnerability barriers."),
         _("時を止める。全MPを消費し、消費したMPに応じて長く時を止めていられる。",
             "Stops time. Consumes all of your SP. The more SP consumed, the longer the duration of the spell."),
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
     },
     {
         _("ごく小さい気の球を放つ。", "Fires a very small energy ball."),
@@ -192,13 +154,6 @@ concptr const mind_tips[MAX_MINDKINDS][MAX_MIND_POWERS] = {
         _("自分を中心とした超巨大な炎の球を発生させる。", "Generates a huge ball of flame centered on you."),
         _("射程の長い、強力な気のビームを放つ。", "Fires a long, powerful energy beam."),
         _("しばらくの間、非常に速く動くことができる。", "Gives extremely fast speed."),
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
     },
     {
         _("近くの思考することができるモンスターを感知する。", "Detects all monsters except the mindless in your vicinity."),
@@ -207,22 +162,6 @@ concptr const mind_tips[MAX_MINDKINDS][MAX_MIND_POWERS] = {
         _("トラップにかかるが、そのトラップを破壊する。", "Sets off a trap, then destroys that trap."),
         _("周囲のダンジョンを揺らし、壁と床をランダムに入れ変える。", "Shakes dungeon structure, and results in random swapping of floors and walls."),
         _("全方向に向かって攻撃する。", "Attacks all adjacent monsters."),
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
     },
     {
         _("近くの全てのモンスターを感知する。レベル15で透明なモンスターを感知する。レベル25で一定時間テレパシーを得る。レベル35で周辺の地形を感知する。"
@@ -294,6 +233,5 @@ concptr const mind_tips[MAX_MINDKINDS][MAX_MIND_POWERS] = {
         _("ランダムな方向に何回か炎か地獄かプラズマのビームを放つ。", "Fires some number of beams of fire, nether or plasma in random directions."),
         _("全ての攻撃が、1/2の確率で無効になる。",
             "Creates shadows of yourself which gives you the ability to completely evade any attacks at one in two chance for a while."),
-        "",
     },
 };

--- a/src/mind/mind-explanations-table.h
+++ b/src/mind/mind-explanations-table.h
@@ -1,9 +1,7 @@
 #pragma once
 
 #include "system/angband.h"
-
-#define MAX_MINDKINDS 5 /* 職業特有の特殊能力数 */
-#define MAX_MIND_POWERS 21 /*!< 超能力の数 / Mindcraft */
+#include <vector>
 
 struct mind_type {
     PLAYER_LEVEL min_lev;
@@ -13,8 +11,8 @@ struct mind_type {
 };
 
 struct mind_power {
-    mind_type info[MAX_MIND_POWERS];
+    std::vector<mind_type> info;
 };
 
-extern mind_power const mind_powers[MAX_MINDKINDS];
-extern concptr const mind_tips[MAX_MINDKINDS][MAX_MIND_POWERS];
+extern const std::vector<mind_power> mind_powers;
+extern const std::vector<std::vector<std::string>> mind_tips;

--- a/src/mind/mind-power-getter.cpp
+++ b/src/mind/mind-power-getter.cpp
@@ -54,7 +54,7 @@ bool MindPowerGetter::get_mind_power(SPELL_IDX *sn, bool only_browse)
         return true;
     }
 
-    for (this->index = 0; this->index < MAX_MIND_POWERS; this->index++) {
+    for (this->index = 0; this->index < std::ssize(this->mind_ptr->info); this->index++) {
         if (mind_ptr->info[this->index].min_lev <= this->player_ptr->lev) {
             this->num++;
         }
@@ -253,7 +253,7 @@ void MindPowerGetter::display_each_mind_chance()
 {
     const auto has_weapon_main = has_melee_weapon(this->player_ptr, INVEN_MAIN_HAND);
     const auto has_weapon_sub = has_melee_weapon(this->player_ptr, INVEN_SUB_HAND);
-    for (this->index = 0; this->index < MAX_MIND_POWERS; this->index++) {
+    for (this->index = 0; this->index < std::ssize(mind_ptr->info); this->index++) {
         this->spell = &mind_ptr->info[this->index];
         if (this->spell->min_lev > this->player_ptr->lev) {
             break;

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -735,7 +735,6 @@ static void display_spell_list(PlayerType *player_ptr)
         PERCENTAGE minfail = 0;
         PLAYER_LEVEL plev = player_ptr->lev;
         PERCENTAGE chance = 0;
-        mind_type spell;
         MindKindType use_mind;
         bool use_hp = false;
 
@@ -772,9 +771,10 @@ static void display_spell_list(PlayerType *player_ptr)
             break;
         }
 
-        for (int i = 0; i < MAX_MIND_POWERS; i++) {
+        const auto &mind_power = mind_powers[enum2i(use_mind)];
+        for (int i = 0; i < std::ssize(mind_power.info); i++) {
             byte a = TERM_WHITE;
-            spell = mind_powers[static_cast<int>(use_mind)].info[i];
+            const auto &spell = mind_power.info[i];
             if (spell.min_lev > plev) {
                 break;
             }


### PR DESCRIPTION
数合わせのための空欄が気になったので二重vectorでmind_powersとmind_tipsを持つようにしました。
（mind_powers は 構造体のメンバを std::vector にしたことによる実質二重vector）

単体Issueはなし。