### PR TITLE
[Refactor] rakubadam_p のグローバル変数を削除した

### DIFF
--- a/src/effect/effect-player.cpp
+++ b/src/effect/effect-player.cpp
@@ -19,6 +19,7 @@
 #include "monster/monster-describer.h"
 #include "monster/monster-description-types.h"
 #include "monster/monster-util.h"
+#include "pet/pet-fall-off.h"
 #include "player-base/player-class.h"
 #include "player-info/samurai-data-type.h"
 #include "player/player-status-flags.h"
@@ -220,7 +221,11 @@ bool affect_player(MONSTER_IDX src_idx, PlayerType *player_ptr, concptr src_name
     }
 
     if (player_ptr->riding && ep_ptr->dam > 0) {
-        rakubadam_p = (ep_ptr->dam > 200) ? 200 : ep_ptr->dam;
+        const auto damage_for_falling_off = (ep_ptr->dam > 200) ? 200 : ep_ptr->dam;
+        const auto m_name = monster_desc(player_ptr, &player_ptr->current_floor_ptr->m_list[player_ptr->riding], 0);
+        if (process_fall_off_horse(player_ptr, damage_for_falling_off, false)) {
+            msg_format(_("%s^から落ちてしまった！", "You have fallen from %s."), m_name.data());
+        }
     }
 
     disturb(player_ptr, true, true);

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -70,7 +70,6 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITIO
     POSITION gx[1024]{};
     POSITION gy[1024]{};
     POSITION gm[32]{};
-    rakubadam_p = 0;
     rakubadam_m = 0;
     monster_target_y = player_ptr->y;
     monster_target_x = player_ptr->x;
@@ -555,6 +554,7 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITIO
             if (affect_player(src_idx, player_ptr, who_name.data(), effective_dist, pos.y, pos.x, dam, typ, flag, project)) {
                 res.notice = true;
                 res.affected_player = true;
+                break;
             }
         }
     }
@@ -564,12 +564,6 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITIO
         if (rakubadam_m > 0) {
             if (process_fall_off_horse(player_ptr, rakubadam_m, false)) {
                 msg_format(_("%s^に振り落とされた！", "%s^ has thrown you off!"), m_name.data());
-            }
-        }
-
-        if (player_ptr->riding && rakubadam_p > 0) {
-            if (process_fall_off_horse(player_ptr, rakubadam_p, false)) {
-                msg_format(_("%s^から落ちてしまった！", "You have fallen from %s."), m_name.data());
             }
         }
     }

--- a/src/effect/spells-effect-util.cpp
+++ b/src/effect/spells-effect-util.cpp
@@ -2,7 +2,6 @@
 #include "monster-race/race-indice-types.h"
 
 int rakubadam_m;
-int rakubadam_p;
 bool sukekaku;
 
 int project_length = 0;

--- a/src/effect/spells-effect-util.h
+++ b/src/effect/spells-effect-util.h
@@ -4,7 +4,6 @@
 #include <string>
 
 extern int rakubadam_m; /*!< 振り落とされた際のダメージ量 */
-extern int rakubadam_p; /*!< 落馬した際のダメージ量 */
 
 enum class MonsterRaceId : int16_t;
 

--- a/src/spell-class/spells-mirror-master.cpp
+++ b/src/spell-class/spells-mirror-master.cpp
@@ -248,7 +248,6 @@ void SpellsMirrorMaster::project_seeker_ray(int target_x, int target_y, int dam)
 {
     constexpr auto typ = AttributeType::SEEKER;
     BIT_FLAGS flag = PROJECT_BEAM | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM | PROJECT_THRU | PROJECT_MIRROR;
-    rakubadam_p = 0;
     rakubadam_m = 0;
     monster_target_y = this->player_ptr->y;
     monster_target_x = this->player_ptr->x;
@@ -433,7 +432,6 @@ void SpellsMirrorMaster::project_super_ray(int target_x, int target_y, int dam)
     POSITION x2;
     constexpr auto typ = AttributeType::SUPER_RAY;
     BIT_FLAGS flag = PROJECT_BEAM | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM | PROJECT_THRU | PROJECT_MIRROR;
-    rakubadam_p = 0;
     rakubadam_m = 0;
     monster_target_y = this->player_ptr->y;
     monster_target_x = this->player_ptr->x;


### PR DESCRIPTION
close #4340 
この変更はプレイヤーが2つ以上の位置に同時にいる場合は落馬しかけてダメージを受ける処理がその位置の数分実行されてしまうが、そのようなことはまずないため挙動への影響はないと思われる