### PR TITLE
[Refactor] グローバル変数 hack_m_idx_ii を削除する

### DIFF
--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -327,8 +327,8 @@ static void init_riding_pet(PlayerType *player_ptr, bool new_game)
 
     MonsterRaceId pet_r_idx = pc.equals(PlayerClassType::CAVALRY) ? MonsterRaceId::HORSE : MonsterRaceId::YASE_HORSE;
     auto *r_ptr = &monraces_info[pet_r_idx];
-    place_specific_monster(player_ptr, 0, player_ptr->y, player_ptr->x - 1, pet_r_idx, (PM_FORCE_PET | PM_NO_KAGE));
-    auto *m_ptr = &player_ptr->current_floor_ptr->m_list[hack_m_idx_ii];
+    auto m_idx = place_specific_monster(player_ptr, 0, player_ptr->y, player_ptr->x - 1, pet_r_idx, (PM_FORCE_PET | PM_NO_KAGE));
+    auto *m_ptr = &player_ptr->current_floor_ptr->m_list[*m_idx];
     m_ptr->mspeed = r_ptr->speed;
     m_ptr->maxhp = r_ptr->hit_dice.floored_expected_value();
     m_ptr->max_maxhp = m_ptr->maxhp;

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -77,8 +77,8 @@ static void process_fishing(PlayerType *player_ptr)
         msg_print(nullptr);
         if (MonraceList::is_valid(r_idx) && one_in_(2)) {
             const auto pos = player_ptr->get_neighbor(player_ptr->fishing_dir);
-            if (place_specific_monster(player_ptr, 0, pos.y, pos.x, r_idx, PM_NO_KAGE)) {
-                const auto m_name = monster_desc(player_ptr, &floor_ptr->m_list[floor_ptr->get_grid(pos).m_idx], 0);
+            if (auto m_idx = place_specific_monster(player_ptr, 0, pos.y, pos.x, r_idx, PM_NO_KAGE)) {
+                const auto m_name = monster_desc(player_ptr, &floor_ptr->m_list[*m_idx], 0);
                 msg_print(_(format("%sが釣れた！", m_name.data()), "You have a good catch!"));
                 success = true;
             }

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -133,9 +133,9 @@ static void parse_qtw_D(PlayerType *player_ptr, qtwg_type *qtwg_ptr, char *s)
                 }
             }
 
-            place_specific_monster(player_ptr, 0, *qtwg_ptr->y, *qtwg_ptr->x, r_idx, (PM_ALLOW_SLEEP | PM_NO_KAGE));
-            if (clone) {
-                floor_ptr->m_list[hack_m_idx_ii].mflag2.set(MonsterConstantFlagType::CLONED);
+            const auto m_idx = place_specific_monster(player_ptr, 0, *qtwg_ptr->y, *qtwg_ptr->x, r_idx, (PM_ALLOW_SLEEP | PM_NO_KAGE));
+            if (clone && m_idx) {
+                floor_ptr->m_list[*m_idx].mflag2.set(MonsterConstantFlagType::CLONED);
                 r_ref.cur_num = old_cur_num;
                 r_ref.max_num = old_max_num;
             }

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -240,8 +240,10 @@ static void generate_gambling_arena(PlayerType *player_ptr)
     build_battle(player_ptr, &y, &x);
     player_place(player_ptr, y, x);
     for (MONSTER_IDX i = 0; i < 4; i++) {
-        place_specific_monster(player_ptr, 0, player_ptr->y + 8 + (i / 2) * 4, player_ptr->x - 2 + (i % 2) * 4, battle_mon_list[i], (PM_NO_KAGE | PM_NO_PET));
-        set_friendly(&floor_ptr->m_list[floor_ptr->grid_array[player_ptr->y + 8 + (i / 2) * 4][player_ptr->x - 2 + (i % 2) * 4].m_idx]);
+        const auto m_idx = place_specific_monster(player_ptr, 0, player_ptr->y + 8 + (i / 2) * 4, player_ptr->x - 2 + (i % 2) * 4, battle_mon_list[i], (PM_NO_KAGE | PM_NO_PET));
+        if (m_idx) {
+            set_friendly(&floor_ptr->m_list[*m_idx]);
+        }
     }
 
     for (MONSTER_IDX i = 1; i < floor_ptr->m_max; i++) {

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -586,12 +586,12 @@ void hit_trap(PlayerType *player_ptr, bool break_trap)
                     continue;
                 }
 
-                if (summon_specific(player_ptr, 0, y1, x1, lev, SUMMON_ARMAGE_EVIL, (PM_NO_PET))) {
-                    evil_idx = hack_m_idx_ii;
+                if (auto m_idx = summon_specific(player_ptr, 0, y1, x1, lev, SUMMON_ARMAGE_EVIL, (PM_NO_PET))) {
+                    evil_idx = *m_idx;
                 }
 
-                if (summon_specific(player_ptr, 0, y1, x1, lev, SUMMON_ARMAGE_GOOD, (PM_NO_PET))) {
-                    good_idx = hack_m_idx_ii;
+                if (auto m_idx = summon_specific(player_ptr, 0, y1, x1, lev, SUMMON_ARMAGE_GOOD, (PM_NO_PET))) {
+                    good_idx = *m_idx;
                 }
 
                 /* Let them fight each other */

--- a/src/monster-floor/monster-generator.h
+++ b/src/monster-floor/monster-generator.h
@@ -6,12 +6,12 @@
 enum summon_type : int;
 enum class MonsterRaceId : int16_t;
 class PlayerType;
-typedef bool (*summon_specific_pf)(PlayerType *, MONSTER_IDX, POSITION, POSITION, DEPTH, summon_type, BIT_FLAGS);
+using summon_specific_pf = std::optional<MONSTER_IDX>(PlayerType *, MONSTER_IDX, POSITION, POSITION, DEPTH, summon_type, BIT_FLAGS);
 
 bool mon_scatter(PlayerType *player_ptr, MonsterRaceId r_idx, POSITION *yp, POSITION *xp, POSITION y, POSITION x, POSITION max_dist);
-bool multiply_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, bool clone, BIT_FLAGS mode);
-bool place_specific_monster(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx = std::nullopt);
-bool place_random_monster(PlayerType *player_ptr, POSITION y, POSITION x, BIT_FLAGS mode);
+std::optional<MONSTER_IDX> multiply_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, bool clone, BIT_FLAGS mode);
+std::optional<MONSTER_IDX> place_specific_monster(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx = std::nullopt);
+std::optional<MONSTER_IDX> place_random_monster(PlayerType *player_ptr, POSITION y, POSITION x, BIT_FLAGS mode);
 bool alloc_horde(PlayerType *player_ptr, POSITION y, POSITION x, summon_specific_pf summon_specific);
 bool alloc_guardian(PlayerType *player_ptr, bool def_val);
 bool alloc_monster(PlayerType *player_ptr, int min_dis, BIT_FLAGS mode, summon_specific_pf summon_specific, int max_dis = 65535);

--- a/src/monster-floor/monster-summon.h
+++ b/src/monster-floor/monster-summon.h
@@ -5,5 +5,5 @@
 enum summon_type : int;
 enum class MonsterRaceId : int16_t;
 class PlayerType;
-bool summon_specific(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y1, POSITION x1, DEPTH lev, summon_type type, BIT_FLAGS mode);
-bool summon_named_creature(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION oy, POSITION ox, MonsterRaceId r_idx, BIT_FLAGS mode);
+std::optional<MONSTER_IDX> summon_specific(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y1, POSITION x1, DEPTH lev, summon_type type, BIT_FLAGS mode);
+std::optional<MONSTER_IDX> summon_named_creature(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION oy, POSITION ox, MonsterRaceId r_idx, BIT_FLAGS mode);

--- a/src/monster-floor/one-monster-placer.h
+++ b/src/monster-floor/one-monster-placer.h
@@ -5,4 +5,4 @@
 
 enum class MonsterRaceId : int16_t;
 class PlayerType;
-bool place_monster_one(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx = std::nullopt);
+std::optional<MONSTER_IDX> place_monster_one(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSITION x, MonsterRaceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx = std::nullopt);

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -452,8 +452,8 @@ void process_special(PlayerType *player_ptr, MONSTER_IDX m_idx)
     BIT_FLAGS p_mode = m_ptr->is_pet() ? PM_FORCE_PET : PM_NONE;
 
     for (int k = 0; k < A_MAX; k++) {
-        if (summon_specific(player_ptr, m_idx, m_ptr->fy, m_ptr->fx, rlev, SUMMON_MOLD, (PM_ALLOW_GROUP | p_mode))) {
-            if (player_ptr->current_floor_ptr->m_list[hack_m_idx_ii].ml) {
+        if (auto summoned_m_idx = summon_specific(player_ptr, m_idx, m_ptr->fy, m_ptr->fx, rlev, SUMMON_MOLD, (PM_ALLOW_GROUP | p_mode))) {
+            if (player_ptr->current_floor_ptr->m_list[*summoned_m_idx].ml) {
                 count++;
             }
         }
@@ -499,8 +499,8 @@ bool decide_monster_multiplication(PlayerType *player_ptr, MONSTER_IDX m_idx, PO
 
     constexpr auto chance_reproduction = 8;
     if ((k < 4) && (!k || !randint0(k * chance_reproduction))) {
-        if (multiply_monster(player_ptr, m_idx, false, (m_ptr->is_pet() ? PM_FORCE_PET : 0))) {
-            if (player_ptr->current_floor_ptr->m_list[hack_m_idx_ii].ml && is_original_ap_and_seen(player_ptr, m_ptr)) {
+        if (auto multiplied_m_idx = multiply_monster(player_ptr, m_idx, false, (m_ptr->is_pet() ? PM_FORCE_PET : 0))) {
+            if (player_ptr->current_floor_ptr->m_list[*multiplied_m_idx].ml && is_original_ap_and_seen(player_ptr, m_ptr)) {
                 r_ptr->r_misc_flags.set(MonsterMiscType::MULTIPLY);
             }
 

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -30,7 +30,6 @@ enum dungeon_mode_type {
 };
 
 MONSTER_IDX hack_m_idx = 0; /* Hack -- see "process_monsters()" */
-MONSTER_IDX hack_m_idx_ii = 0;
 
 /**
  * @brief モンスターがダンジョンに出現できる条件を満たしているかのフラグ判定関数(AND)

--- a/src/monster/monster-util.h
+++ b/src/monster/monster-util.h
@@ -9,7 +9,6 @@ class PlayerType;
 using monsterrace_hook_type = std::function<bool(PlayerType *, MonsterRaceId)>;
 
 extern MONSTER_IDX hack_m_idx;
-extern MONSTER_IDX hack_m_idx_ii;
 enum summon_type : int;
 
 monsterrace_hook_type get_monster_hook(PlayerType *player_ptr);

--- a/src/mspell/mspell-special.cpp
+++ b/src/mspell/mspell-special.cpp
@@ -66,9 +66,13 @@ static MonsterSpellResult spell_RF6_SPECIAL_UNIFICATION(PlayerType *player_ptr, 
 
         delete_monster_idx(player_ptr, floor_ptr->grid_array[m_ptr->fy][m_ptr->fx].m_idx);
         for (const auto separate : it_unified->second) {
-            summon_named_creature(player_ptr, 0, dummy_y, dummy_x, separate, MD_NONE);
-            floor_ptr->m_list[hack_m_idx_ii].hp = separated_hp;
-            floor_ptr->m_list[hack_m_idx_ii].maxhp = separated_maxhp;
+            auto summoned_m_idx = summon_named_creature(player_ptr, 0, dummy_y, dummy_x, separate, MD_NONE);
+            if (!summoned_m_idx) {
+                continue;
+            }
+
+            floor_ptr->m_list[*summoned_m_idx].hp = separated_hp;
+            floor_ptr->m_list[*summoned_m_idx].maxhp = separated_maxhp;
         }
 
         const auto &m_name = monraces.get_monrace(it_unified->first).name;
@@ -103,9 +107,10 @@ static MonsterSpellResult spell_RF6_SPECIAL_UNIFICATION(PlayerType *player_ptr, 
             delete_monster_idx(player_ptr, k);
         }
 
-        summon_named_creature(player_ptr, 0, dummy_y, dummy_x, unified_unique, MD_NONE);
-        floor_ptr->m_list[hack_m_idx_ii].hp = unified_hp;
-        floor_ptr->m_list[hack_m_idx_ii].maxhp = unified_maxhp;
+        if (auto summoned_m_idx = summon_named_creature(player_ptr, 0, dummy_y, dummy_x, unified_unique, MD_NONE)) {
+            floor_ptr->m_list[*summoned_m_idx].hp = unified_hp;
+            floor_ptr->m_list[*summoned_m_idx].maxhp = unified_maxhp;
+        }
         std::vector<std::string> m_names;
         for (const auto &separate : separates) {
             const auto &monrace = monraces.get_monrace(separate);

--- a/src/specific-object/monster-ball.cpp
+++ b/src/specific-object/monster-ball.cpp
@@ -100,11 +100,12 @@ static bool release_monster(PlayerType *player_ptr, ItemEntity &item, DIRECTION 
         return false;
     }
 
-    if (!place_specific_monster(player_ptr, 0, pos.y, pos.x, monrace.idx, PM_FORCE_PET | PM_NO_KAGE)) {
+    const auto m_idx = place_specific_monster(player_ptr, 0, pos.y, pos.x, monrace.idx, PM_FORCE_PET | PM_NO_KAGE);
+    if (!m_idx) {
         return false;
     }
 
-    auto &monster = player_ptr->current_floor_ptr->m_list[hack_m_idx_ii];
+    auto &monster = player_ptr->current_floor_ptr->m_list[*m_idx];
     if (item.captured_monster_speed > 0) {
         monster.mspeed = item.captured_monster_speed;
     }

--- a/src/spell/spells-summon.cpp
+++ b/src/spell/spells-summon.cpp
@@ -251,7 +251,7 @@ bool summon_kin_player(PlayerType *player_ptr, DEPTH level, POSITION y, POSITION
     if (!pet) {
         mode |= PM_NO_PET;
     }
-    return summon_specific(player_ptr, (pet ? -1 : 0), y, x, level, SUMMON_KIN, mode);
+    return summon_specific(player_ptr, (pet ? -1 : 0), y, x, level, SUMMON_KIN, mode).has_value();
 }
 
 /*!


### PR DESCRIPTION
Resolves #4349 

グローバル変数 hack_m_idx_ii はモンスターの生成を行う関数によって生成されたモンスターに、関数呼び出し直後にアクセスする用途で使用されている。
しかし、モンスター生成関数は集団生成などが発生すると内部でネストして呼び出されることがあり、その中でさらに hack_m_idx_ii が上書きされてしまう可能性があるため、hack_m_idx_ii が本当に想定している対象のモンスターを指しているのか疑問が残る。
hack_m_idx_ii の使用箇所に関連するモンスター生成関数の戻り値を単純な生成に成功したかを示すboolの代わりに成功した場合に生成したモンスターのIDを `std::optional<MONSTER_IDX>` で返すようにし、それを使用してモンスターにアクセスするように変更し、hack_m_idx_ii は削除する。