### PR TITLE
PlayerRealmクラスを作り、魔法情報へのアクセスをカプセル化する

### DIFF
--- a/src/cmd-action/cmd-hissatsu.cpp
+++ b/src/cmd-action/cmd-hissatsu.cpp
@@ -30,6 +30,7 @@
 #include "player-info/samurai-data-type.h"
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
+#include "player/player-realm.h"
 #include "player/special-defense-types.h"
 #include "spell/spells-execution.h"
 #include "spell/technic-info-table.h"
@@ -41,8 +42,6 @@
 #include "term/z-form.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
-
-#define TECHNIC_HISSATSU (REALM_HISSATSU - MIN_TECHNIC)
 
 /*!
  * @brief 使用可能な剣術を選択する /
@@ -71,7 +70,6 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
     char choice;
     concptr p = _("必殺剣", "special attack");
     COMMAND_CODE code;
-    magic_type spell;
     int menu_line = (use_menu ? 1 : 0);
 
     /* Assume cancelled */
@@ -81,7 +79,7 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
     if (repeat_pull(&code)) {
         *sn = (SPELL_IDX)code;
         /* Verify the spell */
-        if (technic_info[TECHNIC_HISSATSU][*sn].slevel <= plev) {
+        if (0 <= *sn && *sn < 32 && PlayerRealm::get_spell_info(REALM_HISSATSU, *sn)->slevel <= plev) {
             /* Success */
             return true;
         }
@@ -93,7 +91,7 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
     int i;
     int selections[32]{};
     for (i = 0; i < 32; i++) {
-        if (technic_info[TECHNIC_HISSATSU][i].slevel <= PY_MAX_LEVEL) {
+        if (PlayerRealm::get_spell_info(REALM_HISSATSU, i)->slevel <= PY_MAX_LEVEL) {
             selections[num] = i;
             num++;
         }
@@ -209,7 +207,7 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
                 prt("", y + 1, x);
                 /* Dump the spells */
                 for (i = 0, line = 0; i < 32; i++) {
-                    spell = technic_info[TECHNIC_HISSATSU][i];
+                    const auto &spell = *PlayerRealm::get_spell_info(REALM_HISSATSU, i);
 
                     if (spell.slevel > PY_MAX_LEVEL) {
                         continue;
@@ -309,7 +307,6 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
 void do_cmd_hissatsu(PlayerType *player_ptr)
 {
     SPELL_IDX n = 0;
-    magic_type spell;
 
     if (cmd_limit_confused(player_ptr)) {
         return;
@@ -332,7 +329,7 @@ void do_cmd_hissatsu(PlayerType *player_ptr)
         return;
     }
 
-    spell = technic_info[TECHNIC_HISSATSU][n];
+    const auto &spell = *PlayerRealm::get_spell_info(REALM_HISSATSU, n);
 
     /* Verify "dangerous" spells */
     if (spell.smana > player_ptr->csp) {
@@ -403,7 +400,7 @@ void do_cmd_gain_hissatsu(PlayerType *player_ptr)
             continue;
         }
 
-        if (technic_info[TECHNIC_HISSATSU][i].slevel > player_ptr->lev) {
+        if (PlayerRealm::get_spell_info(REALM_HISSATSU, i)->slevel > player_ptr->lev) {
             continue;
         }
 

--- a/src/cmd-action/cmd-hissatsu.cpp
+++ b/src/cmd-action/cmd-hissatsu.cpp
@@ -79,7 +79,7 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
     if (repeat_pull(&code)) {
         *sn = (SPELL_IDX)code;
         /* Verify the spell */
-        if (0 <= *sn && *sn < 32 && PlayerRealm::get_spell_info(REALM_HISSATSU, *sn)->slevel <= plev) {
+        if (0 <= *sn && *sn < 32 && PlayerRealm::get_spell_info(REALM_HISSATSU, *sn).slevel <= plev) {
             /* Success */
             return true;
         }
@@ -91,7 +91,7 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
     int i;
     int selections[32]{};
     for (i = 0; i < 32; i++) {
-        if (PlayerRealm::get_spell_info(REALM_HISSATSU, i)->slevel <= PY_MAX_LEVEL) {
+        if (PlayerRealm::get_spell_info(REALM_HISSATSU, i).slevel <= PY_MAX_LEVEL) {
             selections[num] = i;
             num++;
         }
@@ -207,7 +207,7 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
                 prt("", y + 1, x);
                 /* Dump the spells */
                 for (i = 0, line = 0; i < 32; i++) {
-                    const auto &spell = *PlayerRealm::get_spell_info(REALM_HISSATSU, i);
+                    const auto &spell = PlayerRealm::get_spell_info(REALM_HISSATSU, i);
 
                     if (spell.slevel > PY_MAX_LEVEL) {
                         continue;
@@ -329,7 +329,7 @@ void do_cmd_hissatsu(PlayerType *player_ptr)
         return;
     }
 
-    const auto &spell = *PlayerRealm::get_spell_info(REALM_HISSATSU, n);
+    const auto &spell = PlayerRealm::get_spell_info(REALM_HISSATSU, n);
 
     /* Verify "dangerous" spells */
     if (spell.smana > player_ptr->csp) {
@@ -400,7 +400,7 @@ void do_cmd_gain_hissatsu(PlayerType *player_ptr)
             continue;
         }
 
-        if (PlayerRealm::get_spell_info(REALM_HISSATSU, i)->slevel > player_ptr->lev) {
+        if (PlayerRealm::get_spell_info(REALM_HISSATSU, i).slevel > player_ptr->lev) {
             continue;
         }
 

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -264,14 +264,8 @@ std::string info_weight(WEIGHT weight)
  */
 static bool spell_okay(PlayerType *player_ptr, int spell, bool learned, bool study_pray, int use_realm)
 {
-    const magic_type *s_ptr;
-
     /* Access the spell */
-    if (!is_magic(use_realm)) {
-        s_ptr = &technic_info[use_realm - MIN_TECHNIC][spell];
-    } else {
-        s_ptr = &mp_ptr->info[use_realm - 1][spell];
-    }
+    const auto *s_ptr = PlayerRealm::get_spell_info(use_realm, spell);
 
     /* Spell is illegal */
     if (s_ptr->slevel > player_ptr->lev) {
@@ -944,7 +938,6 @@ bool do_cmd_cast(PlayerType *player_ptr)
     int16_t use_realm;
     MANA_POINT need_mana;
 
-    const magic_type *s_ptr;
     auto over_exerted = false;
 
     /* Require spell ability */
@@ -1054,11 +1047,7 @@ bool do_cmd_cast(PlayerType *player_ptr)
         }
     }
 
-    if (!is_magic(use_realm)) {
-        s_ptr = &technic_info[use_realm - MIN_TECHNIC][spell];
-    } else {
-        s_ptr = &mp_ptr->info[realm - 1][spell];
-    }
+    const auto *s_ptr = PlayerRealm::get_spell_info(use_realm, spell);
 
     /* Extract mana consumption rate */
     need_mana = mod_need_mana(player_ptr, s_ptr->smana, spell, realm);

--- a/src/knowledge/knowledge-experiences.cpp
+++ b/src/knowledge/knowledge-experiences.cpp
@@ -89,9 +89,9 @@ void do_cmd_knowledge_spell_exp(PlayerType *player_ptr)
     if (player_ptr->realm1 != REALM_NONE) {
         fprintf(fff, _("%sの魔法書\n", "%s Spellbook\n"), realm_names[player_ptr->realm1].data());
         for (SPELL_IDX i = 0; i < 32; i++) {
-            const auto *s_ptr = pr.get_realm1_spell_info(i);
+            const auto &spell = pr.get_realm1_spell_info(i);
 
-            if (s_ptr->slevel >= 99) {
+            if (spell.slevel >= 99) {
                 continue;
             }
             SUB_EXP spell_exp = player_ptr->spell_exp[i];
@@ -125,9 +125,9 @@ void do_cmd_knowledge_spell_exp(PlayerType *player_ptr)
     if (player_ptr->realm2 != REALM_NONE) {
         fprintf(fff, _("%sの魔法書\n", "\n%s Spellbook\n"), realm_names[player_ptr->realm2].data());
         for (SPELL_IDX i = 0; i < 32; i++) {
-            const auto *s_ptr = pr.get_realm2_spell_info(i);
+            const auto &spell = pr.get_realm2_spell_info(i);
 
-            if (s_ptr->slevel >= 99) {
+            if (spell.slevel >= 99) {
                 continue;
             }
 

--- a/src/knowledge/knowledge-experiences.cpp
+++ b/src/knowledge/knowledge-experiences.cpp
@@ -10,6 +10,7 @@
 #include "game-option/text-display-options.h"
 #include "io-dump/dump-util.h"
 #include "player-info/class-info.h"
+#include "player/player-realm.h"
 #include "player/player-skill.h"
 #include "player/player-status.h"
 #include "realm/realm-names-table.h"
@@ -83,15 +84,12 @@ void do_cmd_knowledge_spell_exp(PlayerType *player_ptr)
         return;
     }
 
+    PlayerRealm pr(player_ptr);
+
     if (player_ptr->realm1 != REALM_NONE) {
         fprintf(fff, _("%sの魔法書\n", "%s Spellbook\n"), realm_names[player_ptr->realm1].data());
         for (SPELL_IDX i = 0; i < 32; i++) {
-            const magic_type *s_ptr;
-            if (!is_magic(player_ptr->realm1)) {
-                s_ptr = &technic_info[player_ptr->realm1 - MIN_TECHNIC][i];
-            } else {
-                s_ptr = &mp_ptr->info[player_ptr->realm1 - 1][i];
-            }
+            const auto *s_ptr = pr.get_realm1_spell_info(i);
 
             if (s_ptr->slevel >= 99) {
                 continue;
@@ -127,12 +125,7 @@ void do_cmd_knowledge_spell_exp(PlayerType *player_ptr)
     if (player_ptr->realm2 != REALM_NONE) {
         fprintf(fff, _("%sの魔法書\n", "\n%s Spellbook\n"), realm_names[player_ptr->realm2].data());
         for (SPELL_IDX i = 0; i < 32; i++) {
-            const magic_type *s_ptr;
-            if (!is_magic(player_ptr->realm1)) {
-                s_ptr = &technic_info[player_ptr->realm2 - MIN_TECHNIC][i];
-            } else {
-                s_ptr = &mp_ptr->info[player_ptr->realm2 - 1][i];
-            }
+            const auto *s_ptr = pr.get_realm2_spell_info(i);
 
             if (s_ptr->slevel >= 99) {
                 continue;

--- a/src/player/player-realm.cpp
+++ b/src/player/player-realm.cpp
@@ -1,6 +1,10 @@
 #include "player/player-realm.h"
 #include "object/tval-types.h"
+#include "player-info/class-info.h"
+#include "realm/realm-types.h"
+#include "system/angband-exceptions.h"
 #include "system/player-type-definition.h"
+#include "util/enum-converter.h"
 
 /*!
  * 職業毎に選択可能な第一領域魔法テーブル
@@ -71,6 +75,39 @@ const std::vector<BIT_FLAGS> realm_choices2 = {
     (CH_NONE), /* Sniper */
     (CH_NONE), /* Elementalist */
 };
+
+PlayerRealm::PlayerRealm(PlayerType *player_ptr)
+    : player_ptr(player_ptr)
+{
+}
+
+const magic_type *PlayerRealm::get_spell_info(int realm, int spell_idx)
+{
+    if (spell_idx < 0 || 32 <= spell_idx) {
+        THROW_EXCEPTION(std::invalid_argument, format("Invalid spell idx: %d", spell_idx));
+    }
+
+    const auto realm_enum = i2enum<magic_realm_type>(realm);
+
+    if (MAGIC_REALM_RANGE.contains(realm_enum)) {
+        return &mp_ptr->info[realm - 1][spell_idx];
+    }
+    if (TECHNIC_REALM_RANGE.contains(realm_enum)) {
+        return &technic_info[realm - MIN_TECHNIC][spell_idx];
+    }
+
+    THROW_EXCEPTION(std::invalid_argument, format("Invalid realm: %d", realm));
+}
+
+const magic_type *PlayerRealm::get_realm1_spell_info(int num) const
+{
+    return PlayerRealm::get_spell_info(this->player_ptr->realm1, num);
+}
+
+const magic_type *PlayerRealm::get_realm2_spell_info(int num) const
+{
+    return PlayerRealm::get_spell_info(this->player_ptr->realm2, num);
+}
 
 ItemKindType get_realm1_book(PlayerType *player_ptr)
 {

--- a/src/player/player-realm.cpp
+++ b/src/player/player-realm.cpp
@@ -81,7 +81,7 @@ PlayerRealm::PlayerRealm(PlayerType *player_ptr)
 {
 }
 
-const magic_type *PlayerRealm::get_spell_info(int realm, int spell_idx)
+const magic_type &PlayerRealm::get_spell_info(int realm, int spell_idx)
 {
     if (spell_idx < 0 || 32 <= spell_idx) {
         THROW_EXCEPTION(std::invalid_argument, format("Invalid spell idx: %d", spell_idx));
@@ -90,21 +90,21 @@ const magic_type *PlayerRealm::get_spell_info(int realm, int spell_idx)
     const auto realm_enum = i2enum<magic_realm_type>(realm);
 
     if (MAGIC_REALM_RANGE.contains(realm_enum)) {
-        return &mp_ptr->info[realm - 1][spell_idx];
+        return mp_ptr->info[realm - 1][spell_idx];
     }
     if (TECHNIC_REALM_RANGE.contains(realm_enum)) {
-        return &technic_info[realm - MIN_TECHNIC][spell_idx];
+        return technic_info[realm - MIN_TECHNIC][spell_idx];
     }
 
     THROW_EXCEPTION(std::invalid_argument, format("Invalid realm: %d", realm));
 }
 
-const magic_type *PlayerRealm::get_realm1_spell_info(int num) const
+const magic_type &PlayerRealm::get_realm1_spell_info(int num) const
 {
     return PlayerRealm::get_spell_info(this->player_ptr->realm1, num);
 }
 
-const magic_type *PlayerRealm::get_realm2_spell_info(int num) const
+const magic_type &PlayerRealm::get_realm2_spell_info(int num) const
 {
     return PlayerRealm::get_spell_info(this->player_ptr->realm2, num);
 }

--- a/src/player/player-realm.h
+++ b/src/player/player-realm.h
@@ -22,6 +22,21 @@ enum choosable_realm {
     CH_HEX = 0x20000,
 };
 
+class PlayerType;
+struct magic_type;
+class PlayerRealm {
+public:
+    PlayerRealm(PlayerType *player_ptr);
+
+    static const magic_type *get_spell_info(int realm, int num);
+
+    const magic_type *get_realm1_spell_info(int num) const;
+    const magic_type *get_realm2_spell_info(int num) const;
+
+private:
+    PlayerType *player_ptr;
+};
+
 extern const std::vector<BIT_FLAGS> realm_choices1;
 extern const std::vector<BIT_FLAGS> realm_choices2;
 

--- a/src/player/player-realm.h
+++ b/src/player/player-realm.h
@@ -28,10 +28,10 @@ class PlayerRealm {
 public:
     PlayerRealm(PlayerType *player_ptr);
 
-    static const magic_type *get_spell_info(int realm, int num);
+    static const magic_type &get_spell_info(int realm, int num);
 
-    const magic_type *get_realm1_spell_info(int num) const;
-    const magic_type *get_realm2_spell_info(int num) const;
+    const magic_type &get_realm1_spell_info(int num) const;
+    const magic_type &get_realm2_spell_info(int num) const;
 
 private:
     PlayerType *player_ptr;

--- a/src/player/player-skill.cpp
+++ b/src/player/player-skill.cpp
@@ -365,10 +365,10 @@ void PlayerSkill::gain_spell_skill_exp(int realm, int spell_idx)
     constexpr GainAmountList gain_amount_list_second{ { 60, 8, 2, 0 } };
 
     const auto is_first_realm = (realm == this->player_ptr->realm1);
-    const auto *s_ptr = PlayerRealm::get_spell_info(realm, spell_idx);
+    const auto &spell = PlayerRealm::get_spell_info(realm, spell_idx);
 
     gain_spell_skill_exp_aux(this->player_ptr, this->player_ptr->spell_exp[spell_idx + (is_first_realm ? 0 : 32)],
-        (is_first_realm ? gain_amount_list_first : gain_amount_list_second), s_ptr->slevel);
+        (is_first_realm ? gain_amount_list_first : gain_amount_list_second), spell.slevel);
 }
 
 void PlayerSkill::gain_continuous_spell_skill_exp(int realm, int spell_idx)
@@ -378,11 +378,11 @@ void PlayerSkill::gain_continuous_spell_skill_exp(int realm, int spell_idx)
         return;
     }
 
-    const auto *s_ptr = PlayerRealm::get_spell_info(realm, spell_idx);
+    const auto &spell = PlayerRealm::get_spell_info(realm, spell_idx);
 
     const GainAmountList gain_amount_list{ 5, (one_in_(2) ? 1 : 0), (one_in_(5) ? 1 : 0), (one_in_(5) ? 1 : 0) };
 
-    gain_spell_skill_exp_aux(this->player_ptr, this->player_ptr->spell_exp[spell_idx], gain_amount_list, s_ptr->slevel);
+    gain_spell_skill_exp_aux(this->player_ptr, this->player_ptr->spell_exp[spell_idx], gain_amount_list, spell.slevel);
 }
 
 PlayerSkillRank PlayerSkill::gain_spell_skill_exp_over_learning(int spell_idx)

--- a/src/player/player-skill.cpp
+++ b/src/player/player-skill.cpp
@@ -365,7 +365,7 @@ void PlayerSkill::gain_spell_skill_exp(int realm, int spell_idx)
     constexpr GainAmountList gain_amount_list_second{ { 60, 8, 2, 0 } };
 
     const auto is_first_realm = (realm == this->player_ptr->realm1);
-    const auto *s_ptr = is_magic(realm) ? &mp_ptr->info[realm - 1][spell_idx] : &technic_info[realm - MIN_TECHNIC][spell_idx];
+    const auto *s_ptr = PlayerRealm::get_spell_info(realm, spell_idx);
 
     gain_spell_skill_exp_aux(this->player_ptr, this->player_ptr->spell_exp[spell_idx + (is_first_realm ? 0 : 32)],
         (is_first_realm ? gain_amount_list_first : gain_amount_list_second), s_ptr->slevel);
@@ -378,7 +378,7 @@ void PlayerSkill::gain_continuous_spell_skill_exp(int realm, int spell_idx)
         return;
     }
 
-    const auto *s_ptr = &technic_info[realm - MIN_TECHNIC][spell_idx];
+    const auto *s_ptr = PlayerRealm::get_spell_info(realm, spell_idx);
 
     const GainAmountList gain_amount_list{ 5, (one_in_(2) ? 1 : 0), (one_in_(5) ? 1 : 0), (one_in_(5) ? 1 : 0) };
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -556,9 +556,9 @@ static void update_num_of_spells(PlayerType *player_ptr)
         }
 
         const auto get_spell_info = (j < 32) ? &PlayerRealm::get_realm1_spell_info : &PlayerRealm::get_realm2_spell_info;
-        const auto *s_ptr = (pr.*get_spell_info)(j % 32);
+        const auto &spell = (pr.*get_spell_info)(j % 32);
 
-        if (s_ptr->slevel <= player_ptr->lev) {
+        if (spell.slevel <= player_ptr->lev) {
             continue;
         }
 
@@ -652,9 +652,9 @@ static void update_num_of_spells(PlayerType *player_ptr)
         }
 
         const auto get_spell_info = (j < 32) ? &PlayerRealm::get_realm1_spell_info : &PlayerRealm::get_realm2_spell_info;
-        const auto *s_ptr = (pr.*get_spell_info)(j % 32);
+        const auto &spell = (pr.*get_spell_info)(j % 32);
 
-        if (s_ptr->slevel > player_ptr->lev) {
+        if (spell.slevel > player_ptr->lev) {
             continue;
         }
 
@@ -692,9 +692,9 @@ static void update_num_of_spells(PlayerType *player_ptr)
     if (player_ptr->realm2 == REALM_NONE) {
         int k = 0;
         for (int j = 0; j < 32; j++) {
-            const auto *s_ptr = pr.get_realm1_spell_info(j);
+            const auto &spell = pr.get_realm1_spell_info(j);
 
-            if (s_ptr->slevel > player_ptr->lev) {
+            if (spell.slevel > player_ptr->lev) {
                 continue;
             }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -73,6 +73,7 @@
 #include "player/player-move.h"
 #include "player/player-personality-types.h"
 #include "player/player-personality.h"
+#include "player/player-realm.h"
 #include "player/player-skill.h"
 #include "player/player-status-flags.h"
 #include "player/player-status-table.h"
@@ -542,6 +543,7 @@ static void update_num_of_spells(PlayerType *player_ptr)
         }
     }
 
+    PlayerRealm pr(player_ptr);
     player_ptr->new_spells = num_allowed + player_ptr->add_spells + num_boukyaku - player_ptr->learned_spells;
     for (int i = 63; i >= 0; i--) {
         if (!player_ptr->spell_learned1 && !player_ptr->spell_learned2) {
@@ -553,18 +555,8 @@ static void update_num_of_spells(PlayerType *player_ptr)
             continue;
         }
 
-        const magic_type *s_ptr;
-        if (!is_magic((j < 32) ? player_ptr->realm1 : player_ptr->realm2)) {
-            if (j < 32) {
-                s_ptr = &technic_info[player_ptr->realm1 - MIN_TECHNIC][j];
-            } else {
-                s_ptr = &technic_info[player_ptr->realm2 - MIN_TECHNIC][j % 32];
-            }
-        } else if (j < 32) {
-            s_ptr = &mp_ptr->info[player_ptr->realm1 - 1][j];
-        } else {
-            s_ptr = &mp_ptr->info[player_ptr->realm2 - 1][j % 32];
-        }
+        const auto get_spell_info = (j < 32) ? &PlayerRealm::get_realm1_spell_info : &PlayerRealm::get_realm2_spell_info;
+        const auto *s_ptr = (pr.*get_spell_info)(j % 32);
 
         if (s_ptr->slevel <= player_ptr->lev) {
             continue;
@@ -659,18 +651,8 @@ static void update_num_of_spells(PlayerType *player_ptr)
             break;
         }
 
-        const magic_type *s_ptr;
-        if (!is_magic((j < 32) ? player_ptr->realm1 : player_ptr->realm2)) {
-            if (j < 32) {
-                s_ptr = &technic_info[player_ptr->realm1 - MIN_TECHNIC][j];
-            } else {
-                s_ptr = &technic_info[player_ptr->realm2 - MIN_TECHNIC][j % 32];
-            }
-        } else if (j < 32) {
-            s_ptr = &mp_ptr->info[player_ptr->realm1 - 1][j];
-        } else {
-            s_ptr = &mp_ptr->info[player_ptr->realm2 - 1][j % 32];
-        }
+        const auto get_spell_info = (j < 32) ? &PlayerRealm::get_realm1_spell_info : &PlayerRealm::get_realm2_spell_info;
+        const auto *s_ptr = (pr.*get_spell_info)(j % 32);
 
         if (s_ptr->slevel > player_ptr->lev) {
             continue;
@@ -710,12 +692,7 @@ static void update_num_of_spells(PlayerType *player_ptr)
     if (player_ptr->realm2 == REALM_NONE) {
         int k = 0;
         for (int j = 0; j < 32; j++) {
-            const magic_type *s_ptr;
-            if (!is_magic(player_ptr->realm1)) {
-                s_ptr = &technic_info[player_ptr->realm1 - MIN_TECHNIC][j];
-            } else {
-                s_ptr = &mp_ptr->info[player_ptr->realm1 - 1][j];
-            }
+            const auto *s_ptr = pr.get_realm1_spell_info(j);
 
             if (s_ptr->slevel > player_ptr->lev) {
                 continue;

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -58,11 +58,11 @@
 /*!
  * @brief 剣術の各処理を行う
  * @param player_ptr プレイヤーへの参照ポインタ
- * @param spell 剣術ID
+ * @param spell_id 剣術ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::CAST)
  * @return SpellProcessType::NAME / SPELL_DESC 時には文字列を返す。SpellProcessType::CAST時は std::nullopt を返す。
  */
-std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
+std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell_id, SpellProcessType mode)
 {
     bool name = mode == SpellProcessType::NAME;
     bool desc = mode == SpellProcessType::DESCRIPTION;
@@ -70,7 +70,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
 
     PLAYER_LEVEL plev = player_ptr->lev;
 
-    switch (spell) {
+    switch (spell_id) {
     case 0:
         if (name) {
             return _("飛飯綱", "Tobi-Izuna");
@@ -820,7 +820,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             const int mana_cost_per_monster = 8;
             bool is_new = true;
             bool mdeath;
-            const auto *s_ptr = PlayerRealm::get_spell_info(REALM_HISSATSU, spell);
+            const auto &spell = PlayerRealm::get_spell_info(REALM_HISSATSU, spell_id);
 
             do {
                 if (!rush_attack(player_ptr, &mdeath)) {
@@ -828,7 +828,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 }
                 if (is_new) {
                     /* Reserve needed mana point */
-                    player_ptr->csp -= s_ptr->smana;
+                    player_ptr->csp -= spell.smana;
                     is_new = false;
                 } else {
                     player_ptr->csp -= mana_cost_per_monster;
@@ -848,7 +848,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             }
 
             /* Restore reserved mana */
-            player_ptr->csp += s_ptr->smana;
+            player_ptr->csp += spell.smana;
         }
         break;
 

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -29,6 +29,7 @@
 #include "player-info/equipment-info.h"
 #include "player/player-damage.h"
 #include "player/player-move.h"
+#include "player/player-realm.h"
 #include "spell-kind/earthquake.h"
 #include "spell-kind/spells-detection.h"
 #include "spell-kind/spells-launcher.h"
@@ -819,6 +820,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             const int mana_cost_per_monster = 8;
             bool is_new = true;
             bool mdeath;
+            const auto *s_ptr = PlayerRealm::get_spell_info(REALM_HISSATSU, spell);
 
             do {
                 if (!rush_attack(player_ptr, &mdeath)) {
@@ -826,7 +828,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 }
                 if (is_new) {
                     /* Reserve needed mana point */
-                    player_ptr->csp -= technic_info[REALM_HISSATSU - MIN_TECHNIC][26].smana;
+                    player_ptr->csp -= s_ptr->smana;
                     is_new = false;
                 } else {
                     player_ptr->csp -= mana_cost_per_monster;
@@ -846,7 +848,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             }
 
             /* Restore reserved mana */
-            player_ptr->csp += technic_info[REALM_HISSATSU - MIN_TECHNIC][26].smana;
+            player_ptr->csp += s_ptr->smana;
         }
         break;
 

--- a/src/realm/realm-types.h
+++ b/src/realm/realm-types.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "util/enum-range.h"
+
 enum magic_realm_type {
     REALM_NONE = 0,
     REALM_LIFE = 1,
@@ -19,3 +21,6 @@ enum magic_realm_type {
     REALM_HEX = 18,
     MAX_REALM = 18,
 };
+
+constexpr auto MAGIC_REALM_RANGE = EnumRangeInclusive(REALM_LIFE, REALM_CRUSADE);
+constexpr auto TECHNIC_REALM_RANGE = EnumRangeInclusive(REALM_MUSIC, REALM_HEX);

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -8,6 +8,7 @@
 #include "player-base/player-class.h"
 #include "player-info/spell-hex-data-type.h"
 #include "player/attack-defense-types.h"
+#include "player/player-realm.h"
 #include "player/player-skill.h"
 #include "realm/realm-hex-numbers.h"
 #include "spell-realm/spells-crusade.h"
@@ -267,7 +268,7 @@ int SpellHex::calc_need_mana()
 {
     auto need_mana = 0;
     for (auto spell : this->casting_spells) {
-        const auto *s_ptr = &technic_info[REALM_HEX - MIN_TECHNIC][spell];
+        const auto *s_ptr = PlayerRealm::get_spell_info(REALM_HEX, spell);
         need_mana += mod_need_mana(this->player_ptr, s_ptr->smana, spell, REALM_HEX);
     }
 

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -267,9 +267,9 @@ bool SpellHex::check_restart()
 int SpellHex::calc_need_mana()
 {
     auto need_mana = 0;
-    for (auto spell : this->casting_spells) {
-        const auto *s_ptr = PlayerRealm::get_spell_info(REALM_HEX, spell);
-        need_mana += mod_need_mana(this->player_ptr, s_ptr->smana, spell, REALM_HEX);
+    for (auto spell_id : this->casting_spells) {
+        const auto &spell = PlayerRealm::get_spell_info(REALM_HEX, spell_id);
+        need_mana += mod_need_mana(this->player_ptr, spell.smana, spell_id, REALM_HEX);
     }
 
     return need_mana;

--- a/src/spell-realm/spells-song.cpp
+++ b/src/spell-realm/spells-song.cpp
@@ -39,10 +39,10 @@ void check_music(PlayerType *player_ptr)
         return;
     }
 
-    int spell = get_singing_song_id(player_ptr);
-    const auto *s_ptr = PlayerRealm::get_spell_info(REALM_MUSIC, spell);
+    const auto spell_id = get_singing_song_id(player_ptr);
+    const auto &spell = PlayerRealm::get_spell_info(REALM_MUSIC, spell_id);
 
-    MANA_POINT need_mana = mod_need_mana(player_ptr, s_ptr->smana, spell, REALM_MUSIC);
+    MANA_POINT need_mana = mod_need_mana(player_ptr, spell.smana, spell_id, REALM_MUSIC);
     uint32_t need_mana_frac = 0;
 
     s64b_rshift(&need_mana, &need_mana_frac, 1);
@@ -78,8 +78,8 @@ void check_music(PlayerType *player_ptr)
         rfu.set_flags(flags_swrf);
     }
 
-    PlayerSkill(player_ptr).gain_continuous_spell_skill_exp(REALM_MUSIC, spell);
-    exe_spell(player_ptr, REALM_MUSIC, spell, SpellProcessType::CONTNUATION);
+    PlayerSkill(player_ptr).gain_continuous_spell_skill_exp(REALM_MUSIC, spell_id);
+    exe_spell(player_ptr, REALM_MUSIC, spell_id, SpellProcessType::CONTNUATION);
 }
 
 /*!

--- a/src/spell-realm/spells-song.cpp
+++ b/src/spell-realm/spells-song.cpp
@@ -6,6 +6,7 @@
 #include "player-base/player-class.h"
 #include "player-info/bard-data-type.h"
 #include "player/attack-defense-types.h"
+#include "player/player-realm.h"
 #include "player/player-skill.h"
 #include "player/player-status.h"
 #include "realm/realm-song-numbers.h"
@@ -39,8 +40,7 @@ void check_music(PlayerType *player_ptr)
     }
 
     int spell = get_singing_song_id(player_ptr);
-    const magic_type *s_ptr;
-    s_ptr = &technic_info[REALM_MUSIC - MIN_TECHNIC][spell];
+    const auto *s_ptr = PlayerRealm::get_spell_info(REALM_MUSIC, spell);
 
     MANA_POINT need_mana = mod_need_mana(player_ptr, s_ptr->smana, spell, REALM_MUSIC);
     uint32_t need_mana_frac = 0;

--- a/src/spell/spell-info.cpp
+++ b/src/spell/spell-info.cpp
@@ -27,17 +27,17 @@
  * Modify mana consumption rate using spell exp and dec_mana
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param need_mana 基本消費MP
- * @param spell 呪文ID
+ * @param spell_id 呪文ID
  * @param realm 魔法領域
  * @return 消費MP
  */
-MANA_POINT mod_need_mana(PlayerType *player_ptr, MANA_POINT need_mana, SPELL_IDX spell, int16_t realm)
+MANA_POINT mod_need_mana(PlayerType *player_ptr, MANA_POINT need_mana, SPELL_IDX spell_id, int16_t realm)
 {
 #define MANA_CONST 2400
 #define MANA_DIV 4
 #define DEC_MANA_DIV 3
     if ((realm > REALM_NONE) && (realm <= MAX_REALM)) {
-        need_mana = need_mana * (MANA_CONST + PlayerSkill::spell_exp_at(PlayerSkillRank::EXPERT) - PlayerSkill(player_ptr).exp_of_spell(realm, spell)) + (MANA_CONST - 1);
+        need_mana = need_mana * (MANA_CONST + PlayerSkill::spell_exp_at(PlayerSkillRank::EXPERT) - PlayerSkill(player_ptr).exp_of_spell(realm, spell_id)) + (MANA_CONST - 1);
         need_mana *= player_ptr->dec_mana ? DEC_MANA_DIV : MANA_DIV;
         need_mana /= MANA_CONST * MANA_DIV;
         if (need_mana < 1) {
@@ -111,11 +111,11 @@ PERCENTAGE mod_spell_chance_2(PlayerType *player_ptr, PERCENTAGE chance)
  * @brief 呪文の失敗率計算メインルーチン /
  * Returns spell chance of failure for spell -RAK-
  * @param player_ptr プレイヤーへの参照ポインタ
- * @param spell 呪文ID
+ * @param spell_id 呪文ID
  * @param use_realm 魔法領域ID
  * @return 失敗率(%)
  */
-PERCENTAGE spell_chance(PlayerType *player_ptr, SPELL_IDX spell, int16_t use_realm)
+PERCENTAGE spell_chance(PlayerType *player_ptr, SPELL_IDX spell_id, int16_t use_realm)
 {
     if (mp_ptr->spell_book == ItemKindType::NONE) {
         return 100;
@@ -124,17 +124,17 @@ PERCENTAGE spell_chance(PlayerType *player_ptr, SPELL_IDX spell, int16_t use_rea
         return 0;
     }
 
-    const auto *s_ptr = PlayerRealm::get_spell_info(use_realm, spell);
+    const auto &spell = PlayerRealm::get_spell_info(use_realm, spell_id);
 
-    PERCENTAGE chance = s_ptr->sfail;
-    chance -= 3 * (player_ptr->lev - s_ptr->slevel);
+    PERCENTAGE chance = spell.sfail;
+    chance -= 3 * (player_ptr->lev - spell.slevel);
     chance -= 3 * (adj_mag_stat[player_ptr->stat_index[mp_ptr->spell_stat]] - 1);
     if (player_ptr->riding) {
         const auto &riding_monrace = player_ptr->current_floor_ptr->m_list[player_ptr->riding].get_monrace();
         chance += (std::max(riding_monrace.level - player_ptr->skill_exp[PlayerSkillKindType::RIDING] / 100 - 10, 0));
     }
 
-    MANA_POINT need_mana = mod_need_mana(player_ptr, s_ptr->smana, spell, use_realm);
+    MANA_POINT need_mana = mod_need_mana(player_ptr, spell.smana, spell_id, use_realm);
     if (need_mana > player_ptr->csp) {
         chance += 5 * (need_mana - player_ptr->csp);
     }
@@ -194,7 +194,7 @@ PERCENTAGE spell_chance(PlayerType *player_ptr, SPELL_IDX spell, int16_t use_rea
     }
 
     if ((use_realm == player_ptr->realm1) || (use_realm == player_ptr->realm2) || pc.is_every_magic()) {
-        auto exp = PlayerSkill(player_ptr).exp_of_spell(use_realm, spell);
+        auto exp = PlayerSkill(player_ptr).exp_of_spell(use_realm, spell_id);
         if (exp >= PlayerSkill::spell_exp_at(PlayerSkillRank::EXPERT)) {
             chance--;
         }
@@ -210,14 +210,14 @@ PERCENTAGE spell_chance(PlayerType *player_ptr, SPELL_IDX spell, int16_t use_rea
  * @brief 呪文情報の表示処理 /
  * Print a list of spells (for browsing or casting or viewing)
  * @param player_ptr 術者の参照ポインタ
- * @param target_spell 呪文ID
- * @param spells 表示するスペルID配列の参照ポインタ
+ * @param target_spell_id 呪文ID
+ * @param spell_ids 表示するスペルID配列の参照ポインタ
  * @param num 表示するスペルの数(spellsの要素数)
  * @param y 表示メッセージ左上Y座標
  * @param x 表示メッセージ左上X座標
  * @param use_realm 魔法領域ID
  */
-void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell, SPELL_IDX *spells, int num, TERM_LEN y, TERM_LEN x, int16_t use_realm)
+void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell_id, const SPELL_IDX *spell_ids, int num, TERM_LEN y, TERM_LEN x, int16_t use_realm)
 {
     if (((use_realm <= REALM_NONE) || (use_realm > MAX_REALM)) && AngbandWorld::get_instance().wizard) {
         msg_print(_("警告！ print_spell が領域なしに呼ばれた", "Warning! print_spells called with null realm"));
@@ -248,17 +248,17 @@ void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell, SPELL_IDX *spe
     char ryakuji[5];
     bool max = false;
     for (i = 0; i < num; i++) {
-        SPELL_IDX spell = spells[i];
-        const auto *s_ptr = PlayerRealm::get_spell_info(use_realm, spell);
+        const auto spell_id = spell_ids[i];
+        const auto &spell = PlayerRealm::get_spell_info(use_realm, spell_id);
 
         MANA_POINT need_mana;
         if (use_realm == REALM_HISSATSU) {
-            need_mana = s_ptr->smana;
+            need_mana = spell.smana;
         } else {
-            auto exp = PlayerSkill(player_ptr).exp_of_spell(use_realm, spell);
-            need_mana = mod_need_mana(player_ptr, s_ptr->smana, spell, use_realm);
+            auto exp = PlayerSkill(player_ptr).exp_of_spell(use_realm, spell_id);
+            need_mana = mod_need_mana(player_ptr, spell.smana, spell_id, use_realm);
             PlayerSkillRank skill_rank;
-            if ((increment == 64) || (s_ptr->slevel >= 99)) {
+            if ((increment == 64) || (spell.slevel >= 99)) {
                 skill_rank = PlayerSkillRank::UNSKILLED;
             } else {
                 skill_rank = PlayerSkill::spell_skill_rank(exp);
@@ -269,7 +269,7 @@ void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell, SPELL_IDX *spe
                 max = true;
             } else if ((increment == 32) && (skill_rank >= PlayerSkillRank::EXPERT)) {
                 max = true;
-            } else if (s_ptr->slevel >= 99) {
+            } else if (spell.slevel >= 99) {
                 max = true;
             } else if (pc.equals(PlayerClassType::RED_MAGE) && (skill_rank >= PlayerSkillRank::SKILLED)) {
                 max = true;
@@ -281,8 +281,8 @@ void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell, SPELL_IDX *spe
         }
 
         std::string out_val;
-        if (use_menu && target_spell) {
-            if (i == (target_spell - 1)) {
+        if (use_menu && target_spell_id) {
+            if (i == (target_spell_id - 1)) {
                 out_val = _("  》 ", "  >  ");
             } else {
                 out_val = "     ";
@@ -291,43 +291,43 @@ void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell, SPELL_IDX *spe
             out_val = format("  %c) ", I2A(i));
         }
 
-        if (s_ptr->slevel >= 99) {
+        if (spell.slevel >= 99) {
             out_val.append(format("%-30s", _("(判読不能)", "(illegible)")));
             c_prt(TERM_L_DARK, out_val, y + i + 1, x);
             continue;
         }
 
-        const auto info = exe_spell(player_ptr, use_realm, spell, SpellProcessType::INFO);
+        const auto info = exe_spell(player_ptr, use_realm, spell_id, SpellProcessType::INFO);
         concptr comment = info->data();
         byte line_attr = TERM_WHITE;
         if (pc.is_every_magic()) {
-            if (s_ptr->slevel > player_ptr->max_plv) {
+            if (spell.slevel > player_ptr->max_plv) {
                 comment = _("未知", "unknown");
                 line_attr = TERM_L_BLUE;
-            } else if (s_ptr->slevel > player_ptr->lev) {
+            } else if (spell.slevel > player_ptr->lev) {
                 comment = _("忘却", "forgotten");
                 line_attr = TERM_YELLOW;
             }
         } else if ((use_realm != player_ptr->realm1) && (use_realm != player_ptr->realm2)) {
             comment = _("未知", "unknown");
             line_attr = TERM_L_BLUE;
-        } else if ((use_realm == player_ptr->realm1) ? ((player_ptr->spell_forgotten1 & (1UL << spell))) : ((player_ptr->spell_forgotten2 & (1UL << spell)))) {
+        } else if ((use_realm == player_ptr->realm1) ? ((player_ptr->spell_forgotten1 & (1UL << spell_id))) : ((player_ptr->spell_forgotten2 & (1UL << spell_id)))) {
             comment = _("忘却", "forgotten");
             line_attr = TERM_YELLOW;
-        } else if (!((use_realm == player_ptr->realm1) ? (player_ptr->spell_learned1 & (1UL << spell)) : (player_ptr->spell_learned2 & (1UL << spell)))) {
+        } else if (!((use_realm == player_ptr->realm1) ? (player_ptr->spell_learned1 & (1UL << spell_id)) : (player_ptr->spell_learned2 & (1UL << spell_id)))) {
             comment = _("未知", "unknown");
             line_attr = TERM_L_BLUE;
-        } else if (!((use_realm == player_ptr->realm1) ? (player_ptr->spell_worked1 & (1UL << spell)) : (player_ptr->spell_worked2 & (1UL << spell)))) {
+        } else if (!((use_realm == player_ptr->realm1) ? (player_ptr->spell_worked1 & (1UL << spell_id)) : (player_ptr->spell_worked2 & (1UL << spell_id)))) {
             comment = _("未経験", "untried");
             line_attr = TERM_L_GREEN;
         }
 
-        const auto spell_name = exe_spell(player_ptr, use_realm, spell, SpellProcessType::NAME);
+        const auto spell_name = exe_spell(player_ptr, use_realm, spell_id, SpellProcessType::NAME);
         if (use_realm == REALM_HISSATSU) {
-            out_val.append(format("%-25s %2d %4d", spell_name->data(), s_ptr->slevel, need_mana));
+            out_val.append(format("%-25s %2d %4d", spell_name->data(), spell.slevel, need_mana));
         } else {
-            out_val.append(format("%-25s%c%-4s %2d %4d %3d%% %s", spell_name->data(), (max ? '!' : ' '), ryakuji, s_ptr->slevel,
-                need_mana, spell_chance(player_ptr, spell, use_realm), comment));
+            out_val.append(format("%-25s%c%-4s %2d %4d %3d%% %s", spell_name->data(), (max ? '!' : ' '), ryakuji, spell.slevel,
+                need_mana, spell_chance(player_ptr, spell_id, use_realm), comment));
         }
 
         c_prt(line_attr, out_val, y + i + 1, x);

--- a/src/spell/spell-info.cpp
+++ b/src/spell/spell-info.cpp
@@ -2,6 +2,7 @@
 #include "io/input-key-requester.h"
 #include "player-base/player-class.h"
 #include "player-info/class-info.h"
+#include "player/player-realm.h"
 #include "player/player-skill.h"
 #include "player/player-status-table.h"
 #include "player/player-status.h"
@@ -123,12 +124,7 @@ PERCENTAGE spell_chance(PlayerType *player_ptr, SPELL_IDX spell, int16_t use_rea
         return 0;
     }
 
-    const magic_type *s_ptr;
-    if (!is_magic(use_realm)) {
-        s_ptr = &technic_info[use_realm - MIN_TECHNIC][spell];
-    } else {
-        s_ptr = &mp_ptr->info[use_realm - 1][spell];
-    }
+    const auto *s_ptr = PlayerRealm::get_spell_info(use_realm, spell);
 
     PERCENTAGE chance = s_ptr->sfail;
     chance -= 3 * (player_ptr->lev - s_ptr->slevel);
@@ -249,17 +245,11 @@ void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell, SPELL_IDX *spe
     }
 
     int i;
-    const magic_type *s_ptr;
     char ryakuji[5];
     bool max = false;
     for (i = 0; i < num; i++) {
         SPELL_IDX spell = spells[i];
-
-        if (!is_magic(use_realm)) {
-            s_ptr = &technic_info[use_realm - MIN_TECHNIC][spell];
-        } else {
-            s_ptr = &mp_ptr->info[use_realm - 1][spell];
-        }
+        const auto *s_ptr = PlayerRealm::get_spell_info(use_realm, spell);
 
         MANA_POINT need_mana;
         if (use_realm == REALM_HISSATSU) {

--- a/src/spell/spell-info.h
+++ b/src/spell/spell-info.h
@@ -3,8 +3,8 @@
 #include "system/angband.h"
 
 class PlayerType;
-MANA_POINT mod_need_mana(PlayerType *player_ptr, MANA_POINT need_mana, SPELL_IDX spell, int16_t realm);
+MANA_POINT mod_need_mana(PlayerType *player_ptr, MANA_POINT need_mana, SPELL_IDX spell_id, int16_t realm);
 PERCENTAGE mod_spell_chance_1(PlayerType *player_ptr, PERCENTAGE chance);
 PERCENTAGE mod_spell_chance_2(PlayerType *player_ptr, PERCENTAGE chance);
-PERCENTAGE spell_chance(PlayerType *player_ptr, SPELL_IDX spell, int16_t realm);
-void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell, SPELL_IDX *spells, int num, TERM_LEN y, TERM_LEN x, int16_t realm);
+PERCENTAGE spell_chance(PlayerType *player_ptr, SPELL_IDX spell_id, int16_t realm);
+void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell_id, const SPELL_IDX *spell_ids, int num, TERM_LEN y, TERM_LEN x, int16_t realm);

--- a/src/util/enum-range.h
+++ b/src/util/enum-range.h
@@ -97,6 +97,18 @@ public:
     }
 
     /*!
+     * @brief 引数で与えた列挙値が範囲に含まれるかどうか調べる
+     *
+     * @param val 調べる列挙値
+     * @return true 引数で与えた列挙値が範囲に含まれる
+     * @return false 引数で与えた列挙値が範囲に含まれない
+     */
+    constexpr bool contains(EnumType val) const noexcept
+    {
+        return begin_val <= val && val < end_val;
+    }
+
+    /*!
      * @brief 範囲の最初の列挙値を指すイテレータを取得する
      *
      * @return 範囲の最初の列挙値を指すイテレータ
@@ -156,6 +168,18 @@ public:
     constexpr EnumRangeInclusive(EnumType first, EnumType last) noexcept
         : range(first, static_cast<EnumType>(std::underlying_type_t<EnumType>(last) + 1))
     {
+    }
+
+    /*!
+     * @brief 引数で与えた列挙値が範囲に含まれるかどうか調べる
+     *
+     * @param val 調べる列挙値
+     * @return true 引数で与えた列挙値が範囲に含まれる
+     * @return false 引数で与えた列挙値が範囲に含まれない
+     */
+    constexpr bool contains(EnumType val) const noexcept
+    {
+        return range.contains(val);
     }
 
     /*!

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -828,11 +828,11 @@ static void display_spell_list(PlayerType *player_ptr)
             byte a = TERM_WHITE;
 
             const auto realm = (j < 1) ? player_ptr->realm1 : player_ptr->realm2;
-            const auto *s_ptr = PlayerRealm::get_spell_info(realm, i % 32);
+            const auto &spell = PlayerRealm::get_spell_info(realm, i % 32);
             const auto spell_name = exe_spell(player_ptr, realm, i % 32, SpellProcessType::NAME);
             auto name = spell_name->data();
 
-            if (s_ptr->slevel >= 99) {
+            if (spell.slevel >= 99) {
                 name = _("(判読不能)", "(illegible)");
                 a = TERM_L_DARK;
             } else if ((j < 1) ? ((player_ptr->spell_forgotten1 & (1UL << i))) : ((player_ptr->spell_forgotten2 & (1UL << (i % 32))))) {

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -21,6 +21,7 @@
 #include "object/object-info.h"
 #include "player-base/player-class.h"
 #include "player-info/class-info.h"
+#include "player/player-realm.h"
 #include "player/player-status-flags.h"
 #include "player/player-status-table.h"
 #include "player/player-status.h"
@@ -718,7 +719,6 @@ static void display_spell_list(PlayerType *player_ptr)
 {
     TERM_LEN y, x;
     int m[9]{};
-    const magic_type *s_ptr;
 
     clear_from(0);
 
@@ -827,13 +827,8 @@ static void display_spell_list(PlayerType *player_ptr)
         for (int i = 0; i < 32; i++) {
             byte a = TERM_WHITE;
 
-            if (!is_magic((j < 1) ? player_ptr->realm1 : player_ptr->realm2)) {
-                s_ptr = &technic_info[((j < 1) ? player_ptr->realm1 : player_ptr->realm2) - MIN_TECHNIC][i % 32];
-            } else {
-                s_ptr = &mp_ptr->info[((j < 1) ? player_ptr->realm1 : player_ptr->realm2) - 1][i % 32];
-            }
-
             const auto realm = (j < 1) ? player_ptr->realm1 : player_ptr->realm2;
+            const auto *s_ptr = PlayerRealm::get_spell_info(realm, i % 32);
             const auto spell_name = exe_spell(player_ptr, realm, i % 32, SpellProcessType::NAME);
             auto name = spell_name->data();
 


### PR DESCRIPTION
#4357 の一環

変更行数が多く見えますが、最後のコミットは関数の戻り値をポインタから参照に変更したことにより、現在の魔法情報へのポインタ変数 s_ptr を参照変数 spell に変えたのと、それに合わせて spell を魔法IDとして使用しており名前が被ってしまう箇所を spell_id という名前にする単純変換にすぎないので、実質的な変更行数は最後のコミットを除いたものになります。