### PR TITLE
落馬ダメージ処理クラスを作成し、グローバル変数 rakubadam_p, rakubadam_m を削除する

### DIFF
--- a/src/effect/effect-monster.cpp
+++ b/src/effect/effect-monster.cpp
@@ -657,7 +657,7 @@ static void postprocess_by_effected_pet(PlayerType *player_ptr, EffectMonster *e
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param em_ptr モンスター効果構造体への参照ポインタ
  */
-static void postprocess_by_riding_pet_effected(PlayerType *player_ptr, EffectMonster *em_ptr)
+static void postprocess_by_riding_pet_effected(PlayerType *player_ptr, EffectMonster *em_ptr, FallOffHorseEffect *fall_off_horse_effect)
 {
     if (!player_ptr->riding || (player_ptr->riding != em_ptr->g_ptr->m_idx) || (em_ptr->dam <= 0)) {
         return;
@@ -667,7 +667,9 @@ static void postprocess_by_riding_pet_effected(PlayerType *player_ptr, EffectMon
         em_ptr->dam = (em_ptr->dam + 1) / 2;
     }
 
-    rakubadam_m = (em_ptr->dam > 200) ? 200 : em_ptr->dam;
+    if (fall_off_horse_effect) {
+        fall_off_horse_effect->set_shake_off(em_ptr->dam);
+    }
 }
 
 /*!
@@ -693,10 +695,10 @@ static void postprocess_by_taking_photo(PlayerType *player_ptr, EffectMonster *e
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param em_ptr モンスター効果構造体への参照ポインタ
  */
-static void exe_affect_monster_postprocess(PlayerType *player_ptr, EffectMonster *em_ptr)
+static void exe_affect_monster_postprocess(PlayerType *player_ptr, EffectMonster *em_ptr, FallOffHorseEffect *fall_off_horse_effect)
 {
     postprocess_by_effected_pet(player_ptr, em_ptr);
-    postprocess_by_riding_pet_effected(player_ptr, em_ptr);
+    postprocess_by_riding_pet_effected(player_ptr, em_ptr, fall_off_horse_effect);
     postprocess_by_taking_photo(player_ptr, em_ptr);
     project_m_n++;
     project_m_x = em_ptr->x;
@@ -723,7 +725,7 @@ static void exe_affect_monster_postprocess(PlayerType *player_ptr, EffectMonster
  */
 bool affect_monster(
     PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION r, POSITION y, POSITION x, int dam, AttributeType attribute, BIT_FLAGS flag, bool see_s_msg,
-    std::optional<CapturedMonsterType *> cap_mon_ptr)
+    std::optional<CapturedMonsterType *> cap_mon_ptr, FallOffHorseEffect *fall_off_horse_effect)
 {
     EffectMonster tmp_effect(player_ptr, src_idx, r, y, x, dam, attribute, flag, see_s_msg);
     auto *em_ptr = &tmp_effect;
@@ -757,6 +759,6 @@ bool affect_monster(
         RedrawingFlagsUpdater::get_instance().set_flag(SubWindowRedrawingFlag::MONSTER_LORE);
     }
 
-    exe_affect_monster_postprocess(player_ptr, em_ptr);
+    exe_affect_monster_postprocess(player_ptr, em_ptr, fall_off_horse_effect);
     return em_ptr->obvious;
 }

--- a/src/effect/effect-monster.h
+++ b/src/effect/effect-monster.h
@@ -5,5 +5,6 @@
 #include <optional>
 
 class CapturedMonsterType;
+class FallOffHorseEffect;
 class PlayerType;
-bool affect_monster(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION r, POSITION y, POSITION x, int dam, AttributeType typ, BIT_FLAGS flag, bool see_s_msg, std::optional<CapturedMonsterType *> cap_mon_ptr = std::nullopt);
+bool affect_monster(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION r, POSITION y, POSITION x, int dam, AttributeType typ, BIT_FLAGS flag, bool see_s_msg, std::optional<CapturedMonsterType *> cap_mon_ptr = std::nullopt, FallOffHorseEffect *fall_off_horse_effect = nullptr);

--- a/src/effect/effect-player.cpp
+++ b/src/effect/effect-player.cpp
@@ -192,7 +192,7 @@ static void describe_effect_source(PlayerType *player_ptr, EffectPlayerType *ep_
  * @return 何か一つでも効力があればTRUEを返す / TRUE if any "effects" of the projection were observed, else FALSE
  */
 bool affect_player(MONSTER_IDX src_idx, PlayerType *player_ptr, concptr src_name, int r, POSITION y, POSITION x, int dam, AttributeType attribute,
-    BIT_FLAGS flag, project_func project)
+    BIT_FLAGS flag, FallOffHorseEffect &fall_off_horse_effect, project_func project)
 {
     EffectPlayerType tmp_effect(src_idx, dam, attribute, flag);
     auto *ep_ptr = &tmp_effect;
@@ -219,8 +219,8 @@ bool affect_player(MONSTER_IDX src_idx, PlayerType *player_ptr, concptr src_name
         }
     }
 
-    if (player_ptr->riding && ep_ptr->dam > 0) {
-        rakubadam_p = (ep_ptr->dam > 200) ? 200 : ep_ptr->dam;
+    if (player_ptr->riding) {
+        fall_off_horse_effect.set_fall_off(ep_ptr->dam);
     }
 
     disturb(player_ptr, true, true);

--- a/src/effect/effect-player.h
+++ b/src/effect/effect-player.h
@@ -5,6 +5,7 @@
 #include <optional>
 
 class MonsterEntity;
+class FallOffHorseEffect;
 class EffectPlayerType {
 public:
     DEPTH rlev; // モンスターのレベル (但し0のモンスターは1になる).
@@ -27,4 +28,4 @@ using project_func = ProjectResult (*)(
     PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION rad, POSITION y, POSITION x, int dam, AttributeType typ, BIT_FLAGS flag, std::optional<CapturedMonsterType *> cap_mon_ptr);
 
 bool affect_player(MONSTER_IDX src_idx, PlayerType *player_ptr, concptr src_name, int r, POSITION y, POSITION x, int dam, AttributeType typ, BIT_FLAGS flag,
-    project_func project);
+    FallOffHorseEffect &fall_off_horse_effect, project_func project);

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -70,8 +70,6 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITIO
     POSITION gx[1024]{};
     POSITION gy[1024]{};
     POSITION gm[32]{};
-    rakubadam_p = 0;
-    rakubadam_m = 0;
     monster_target_y = player_ptr->y;
     monster_target_x = player_ptr->x;
 

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -352,6 +352,7 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITIO
         }
     }
 
+    FallOffHorseEffect fall_off_horse_effect(player_ptr);
     if (flag & (PROJECT_KILL)) {
         project_m_n = 0;
         project_m_x = 0;
@@ -474,7 +475,7 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITIO
                 }
             }
 
-            if (affect_monster(player_ptr, src_idx, effective_dist, pos.y, pos.x, dam, typ, flag, see_s_msg, cap_mon_ptr)) {
+            if (affect_monster(player_ptr, src_idx, effective_dist, pos.y, pos.x, dam, typ, flag, see_s_msg, cap_mon_ptr, &fall_off_horse_effect)) {
                 res.notice = true;
             }
         }
@@ -552,27 +553,14 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITIO
                 who_name = monster_desc(player_ptr, &floor.m_list[src_idx], MD_WRONGDOER_NAME);
             }
 
-            if (affect_player(src_idx, player_ptr, who_name.data(), effective_dist, pos.y, pos.x, dam, typ, flag, project)) {
+            if (affect_player(src_idx, player_ptr, who_name.data(), effective_dist, pos.y, pos.x, dam, typ, flag, fall_off_horse_effect, project)) {
                 res.notice = true;
                 res.affected_player = true;
             }
         }
     }
 
-    if (player_ptr->riding) {
-        const auto m_name = monster_desc(player_ptr, &floor.m_list[player_ptr->riding], 0);
-        if (rakubadam_m > 0) {
-            if (process_fall_off_horse(player_ptr, rakubadam_m, false)) {
-                msg_format(_("%s^に振り落とされた！", "%s^ has thrown you off!"), m_name.data());
-            }
-        }
-
-        if (player_ptr->riding && rakubadam_p > 0) {
-            if (process_fall_off_horse(player_ptr, rakubadam_p, false)) {
-                msg_format(_("%s^から落ちてしまった！", "You have fallen from %s."), m_name.data());
-            }
-        }
-    }
+    fall_off_horse_effect.apply();
 
     return res;
 }

--- a/src/effect/spells-effect-util.cpp
+++ b/src/effect/spells-effect-util.cpp
@@ -1,5 +1,12 @@
 #include "effect/spells-effect-util.h"
 #include "monster-race/race-indice-types.h"
+#include "monster/monster-describer.h"
+#include "pet/pet-fall-off.h"
+#include "system/floor-type-definition.h"
+#include "system/monster-entity.h"
+#include "system/player-type-definition.h"
+#include "view/display-messages.h"
+#include <algorithm>
 
 int rakubadam_m;
 int rakubadam_p;
@@ -16,4 +23,46 @@ POSITION monster_target_y;
 CapturedMonsterType::CapturedMonsterType()
     : r_idx(MonsterRaceId::PLAYER)
 {
+}
+
+FallOffHorseEffect::FallOffHorseEffect(PlayerType *player_ptr)
+    : player_ptr(player_ptr)
+{
+}
+
+void FallOffHorseEffect::set_shake_off(int damage)
+{
+    this->shake_off_damage = std::min(damage, FALL_OFF_DAMAGE_MAX);
+}
+
+void FallOffHorseEffect::set_fall_off(int damage)
+{
+    this->fall_off_damage = std::min(damage, FALL_OFF_DAMAGE_MAX);
+}
+
+void FallOffHorseEffect::apply() const
+{
+    if (!this->player_ptr->riding) {
+        return;
+    }
+
+    if (this->shake_off_damage <= 0 && this->fall_off_damage <= 0) {
+        return;
+    }
+
+    const auto &floor = *this->player_ptr->current_floor_ptr;
+    const auto m_name = monster_desc(this->player_ptr, &floor.m_list[player_ptr->riding], 0);
+
+    if (this->shake_off_damage > 0) {
+        if (process_fall_off_horse(this->player_ptr, this->shake_off_damage, false)) {
+            msg_format(_("%s^に振り落とされた！", "%s^ has thrown you off!"), m_name.data());
+            return;
+        }
+    }
+
+    if (this->fall_off_damage > 0) {
+        if (process_fall_off_horse(this->player_ptr, this->fall_off_damage, false)) {
+            msg_format(_("%s^から落ちてしまった！", "You have fallen from %s."), m_name.data());
+        }
+    }
 }

--- a/src/effect/spells-effect-util.cpp
+++ b/src/effect/spells-effect-util.cpp
@@ -8,8 +8,6 @@
 #include "view/display-messages.h"
 #include <algorithm>
 
-int rakubadam_m;
-int rakubadam_p;
 bool sukekaku;
 
 int project_length = 0;

--- a/src/effect/spells-effect-util.h
+++ b/src/effect/spells-effect-util.h
@@ -3,9 +3,6 @@
 #include "system/angband.h"
 #include <string>
 
-extern int rakubadam_m; /*!< 振り落とされた際のダメージ量 */
-extern int rakubadam_p; /*!< 落馬した際のダメージ量 */
-
 enum class MonsterRaceId : int16_t;
 class PlayerType;
 

--- a/src/effect/spells-effect-util.h
+++ b/src/effect/spells-effect-util.h
@@ -7,6 +7,7 @@ extern int rakubadam_m; /*!< 振り落とされた際のダメージ量 */
 extern int rakubadam_p; /*!< 落馬した際のダメージ量 */
 
 enum class MonsterRaceId : int16_t;
+class PlayerType;
 
 class CapturedMonsterType {
 public:
@@ -16,6 +17,21 @@ public:
     short current_hp = 0;
     short max_hp = 0;
     std::string nickname = "";
+};
+
+class FallOffHorseEffect {
+public:
+    FallOffHorseEffect(PlayerType *player_ptr);
+    void set_shake_off(int damage);
+    void set_fall_off(int damage);
+    void apply() const;
+
+private:
+    constexpr static int FALL_OFF_DAMAGE_MAX = 200;
+
+    PlayerType *player_ptr;
+    int shake_off_damage = 0; /*!< 振り落とされた際のダメージ量 */
+    int fall_off_damage = 0; /*!< 落馬した際のダメージ量 */
 };
 
 extern bool sukekaku;

--- a/src/spell-class/spells-mirror-master.cpp
+++ b/src/spell-class/spells-mirror-master.cpp
@@ -248,8 +248,6 @@ void SpellsMirrorMaster::project_seeker_ray(int target_x, int target_y, int dam)
 {
     constexpr auto typ = AttributeType::SEEKER;
     BIT_FLAGS flag = PROJECT_BEAM | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM | PROJECT_THRU | PROJECT_MIRROR;
-    rakubadam_p = 0;
-    rakubadam_m = 0;
     monster_target_y = this->player_ptr->y;
     monster_target_x = this->player_ptr->x;
     auto &floor = *this->player_ptr->current_floor_ptr;
@@ -433,8 +431,6 @@ void SpellsMirrorMaster::project_super_ray(int target_x, int target_y, int dam)
     POSITION x2;
     constexpr auto typ = AttributeType::SUPER_RAY;
     BIT_FLAGS flag = PROJECT_BEAM | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM | PROJECT_THRU | PROJECT_MIRROR;
-    rakubadam_p = 0;
-    rakubadam_m = 0;
     monster_target_y = this->player_ptr->y;
     monster_target_x = this->player_ptr->x;
     const auto &floor = *this->player_ptr->current_floor_ptr;


### PR DESCRIPTION
PR #4350 に関連する Discord 上での議論で、rakubadam_m も合わせて根本的な対応をしたほうがよいと考えましたので、 #4350 の代替案として実装しました。