### PR TITLE
[Refactor] 魔法領域の選択候補の取得方法

### DIFF
--- a/src/object-hook/hook-magic.cpp
+++ b/src/object-hook/hook-magic.cpp
@@ -60,13 +60,13 @@ bool item_tester_learn_spell(PlayerType *player_ptr, const ItemEntity *o_ptr)
         return false;
     }
 
-    int32_t choices = realm_choices2[enum2i(player_ptr->pclass)];
+    auto choices = PlayerRealm::get_realm2_choices(player_ptr->pclass);
     PlayerClass pc(player_ptr);
     if (pc.equals(PlayerClassType::PRIEST)) {
         if (is_good_realm(player_ptr->realm1)) {
-            choices &= ~(CH_DEATH | CH_DAEMON);
+            choices.reset({ REALM_DEATH, REALM_DAEMON });
         } else {
-            choices &= ~(CH_LIFE | CH_CRUSADE);
+            choices.reset({ REALM_LIFE, REALM_CRUSADE });
         }
     }
 
@@ -75,10 +75,11 @@ bool item_tester_learn_spell(PlayerType *player_ptr, const ItemEntity *o_ptr)
         return true;
     }
 
-    if (!is_magic(tval2realm(tval))) {
+    const auto realm = tval2realm(tval);
+    if (!is_magic(realm)) {
         return false;
     }
 
     PlayerRealm pr(player_ptr);
-    return (pr.realm1().get_book() == tval) || (pr.realm2().get_book() == tval) || (choices & (0x0001U << (tval2realm(tval) - 1)));
+    return (pr.realm1().get_book() == tval) || (pr.realm2().get_book() == tval) || choices.has(realm);
 }

--- a/src/player/player-realm.cpp
+++ b/src/player/player-realm.cpp
@@ -25,77 +25,36 @@ const std::map<magic_realm_type, ItemKindType> realm_books = {
     { REALM_HEX, ItemKindType::HEX_BOOK },
 };
 
-}
-
 /*!
  * 職業毎に選択可能な第一領域魔法テーブル
  */
-const std::vector<BIT_FLAGS> realm_choices1 = {
-    (CH_NONE), /* Warrior */
-    (CH_LIFE | CH_SORCERY | CH_NATURE | CH_CHAOS | CH_DEATH | CH_TRUMP | CH_ARCANE | CH_ENCHANT | CH_DAEMON | CH_CRUSADE), /* Mage */
-    (CH_LIFE | CH_DEATH | CH_DAEMON | CH_CRUSADE), /* Priest */
-    (CH_SORCERY | CH_DEATH | CH_TRUMP | CH_ARCANE | CH_ENCHANT), /* Rogue */
-    (CH_NATURE), /* Ranger */
-    (CH_CRUSADE | CH_DEATH), /* Paladin */
-    (CH_ARCANE), /* Warrior-Mage */
-    (CH_CHAOS | CH_DAEMON), /* Chaos-Warrior */
-    (CH_LIFE | CH_NATURE | CH_DEATH | CH_ENCHANT), /* Monk */
-    (CH_NONE), /* Mindcrafter */
-    (CH_LIFE | CH_SORCERY | CH_NATURE | CH_CHAOS | CH_DEATH | CH_TRUMP | CH_ARCANE | CH_ENCHANT | CH_DAEMON | CH_CRUSADE | CH_HEX), /* High-Mage */
-    (CH_ARCANE), /* Tourist */
-    (CH_NONE), /* Imitator */
-    (CH_TRUMP), /* Beastmaster */
-    (CH_NONE), /* Sorcerer */
-    (CH_NONE), /* Archer */
-    (CH_NONE), /* Magic eater */
-    (CH_MUSIC), /* Bard */
-    (CH_NONE), /* Red Mage */
-    (CH_HISSATSU), /* Samurai */
-    (CH_LIFE | CH_NATURE | CH_DEATH | CH_ENCHANT | CH_CRUSADE), /* ForceTrainer */
-    (CH_NONE), /* Blue Mage */
-    (CH_NONE), /* Cavalry */
-    (CH_NONE), /* Berserker */
-    (CH_NONE), /* Weaponsmith */
-    (CH_NONE), /* Mirror-master */
-    (CH_NONE), /* Ninja */
-    (CH_NONE), /* Sniper */
-    (CH_NONE), /* Elementalist */
+const std::map<PlayerClassType, RealmChoices> realm1_choices = {
+    { PlayerClassType::MAGE, { REALM_LIFE, REALM_SORCERY, REALM_NATURE, REALM_CHAOS, REALM_DEATH, REALM_TRUMP, REALM_ARCANE, REALM_CRAFT, REALM_DAEMON, REALM_CRUSADE } },
+    { PlayerClassType::PRIEST, { REALM_LIFE, REALM_DEATH, REALM_DAEMON, REALM_CRUSADE } },
+    { PlayerClassType::ROGUE, { REALM_SORCERY, REALM_DEATH, REALM_TRUMP, REALM_ARCANE, REALM_CRAFT } },
+    { PlayerClassType::RANGER, { REALM_NATURE } },
+    { PlayerClassType::PALADIN, { REALM_CRUSADE, REALM_DEATH } },
+    { PlayerClassType::WARRIOR_MAGE, { REALM_ARCANE } },
+    { PlayerClassType::CHAOS_WARRIOR, { REALM_CHAOS, REALM_DAEMON } },
+    { PlayerClassType::MONK, { REALM_LIFE, REALM_NATURE, REALM_DEATH, REALM_CRAFT } },
+    { PlayerClassType::HIGH_MAGE, { REALM_LIFE, REALM_SORCERY, REALM_NATURE, REALM_CHAOS, REALM_DEATH, REALM_TRUMP, REALM_ARCANE, REALM_CRAFT, REALM_DAEMON, REALM_CRUSADE, REALM_HEX } },
+    { PlayerClassType::TOURIST, { REALM_ARCANE } },
+    { PlayerClassType::BEASTMASTER, { REALM_TRUMP } },
+    { PlayerClassType::BARD, { REALM_MUSIC } },
+    { PlayerClassType::SAMURAI, { REALM_HISSATSU } },
+    { PlayerClassType::FORCETRAINER, { REALM_LIFE, REALM_NATURE, REALM_DEATH, REALM_CRAFT, REALM_CRUSADE } },
 };
 
 /*!
  * 職業毎に選択可能な第二領域魔法テーブル
  */
-const std::vector<BIT_FLAGS> realm_choices2 = {
-    (CH_NONE), /* Warrior */
-    (CH_LIFE | CH_SORCERY | CH_NATURE | CH_CHAOS | CH_DEATH | CH_TRUMP | CH_ARCANE | CH_ENCHANT | CH_DAEMON | CH_CRUSADE), /* Mage */
-    (CH_LIFE | CH_SORCERY | CH_NATURE | CH_CHAOS | CH_DEATH | CH_TRUMP | CH_ARCANE | CH_ENCHANT | CH_DAEMON | CH_CRUSADE), /* Priest */
-    (CH_NONE), /* Rogue */
-    (CH_SORCERY | CH_CHAOS | CH_DEATH | CH_TRUMP | CH_ARCANE | CH_DAEMON), /* Ranger */
-    (CH_NONE), /* Paladin */
-    (CH_LIFE | CH_NATURE | CH_CHAOS | CH_DEATH | CH_TRUMP | CH_ARCANE | CH_SORCERY | CH_ENCHANT | CH_DAEMON | CH_CRUSADE), /* Warrior-Mage */
-    (CH_NONE), /* Chaos-Warrior */
-    (CH_NONE), /* Monk */
-    (CH_NONE), /* Mindcrafter */
-    (CH_NONE), /* High-Mage */
-    (CH_NONE), /* Tourist */
-    (CH_NONE), /* Imitator */
-    (CH_NONE), /* Beastmanster */
-    (CH_NONE), /* Sorcerer */
-    (CH_NONE), /* Archer */
-    (CH_NONE), /* Magic eater */
-    (CH_NONE), /* Bard */
-    (CH_NONE), /* Red Mage */
-    (CH_NONE), /* Samurai */
-    (CH_NONE), /* ForceTrainer */
-    (CH_NONE), /* Blue Mage */
-    (CH_NONE), /* Cavalry */
-    (CH_NONE), /* Berserker */
-    (CH_NONE), /* Weaponsmith */
-    (CH_NONE), /* Mirror-master */
-    (CH_NONE), /* Ninja */
-    (CH_NONE), /* Sniper */
-    (CH_NONE), /* Elementalist */
+const std::map<PlayerClassType, RealmChoices> realm2_choices = {
+    { PlayerClassType::MAGE, { REALM_LIFE, REALM_SORCERY, REALM_NATURE, REALM_CHAOS, REALM_DEATH, REALM_TRUMP, REALM_ARCANE, REALM_CRAFT, REALM_DAEMON, REALM_CRUSADE } },
+    { PlayerClassType::PRIEST, { REALM_LIFE, REALM_SORCERY, REALM_NATURE, REALM_CHAOS, REALM_DEATH, REALM_TRUMP, REALM_ARCANE, REALM_CRAFT, REALM_DAEMON, REALM_CRUSADE } },
+    { PlayerClassType::RANGER, { REALM_SORCERY, REALM_CHAOS, REALM_DEATH, REALM_TRUMP, REALM_ARCANE, REALM_DAEMON } },
+    { PlayerClassType::WARRIOR_MAGE, { REALM_LIFE, REALM_NATURE, REALM_CHAOS, REALM_DEATH, REALM_TRUMP, REALM_ARCANE, REALM_SORCERY, REALM_CRAFT, REALM_DAEMON, REALM_CRUSADE } },
 };
+}
 
 PlayerRealm::PlayerRealm(PlayerType *player_ptr)
     : realm1_(player_ptr->realm1)
@@ -126,6 +85,24 @@ ItemKindType PlayerRealm::get_book(int realm)
     const auto it = realm_books.find(i2enum<magic_realm_type>(realm));
     if (it == realm_books.end()) {
         THROW_EXCEPTION(std::invalid_argument, format("Invalid realm: %d", realm));
+    }
+    return it->second;
+}
+
+RealmChoices PlayerRealm::get_realm1_choices(PlayerClassType pclass)
+{
+    const auto it = realm1_choices.find(pclass);
+    if (it == realm1_choices.end()) {
+        return {};
+    }
+    return it->second;
+}
+
+RealmChoices PlayerRealm::get_realm2_choices(PlayerClassType pclass)
+{
+    const auto it = realm2_choices.find(pclass);
+    if (it == realm2_choices.end()) {
+        return {};
     }
     return it->second;
 }

--- a/src/player/player-realm.h
+++ b/src/player/player-realm.h
@@ -1,28 +1,15 @@
 #pragma once
 
+#include "realm/realm-types.h"
 #include "system/angband.h"
+#include "util/flag-group.h"
+#include <cstdint>
 #include <vector>
 
-/* 職業ごとの選択可能な魔法領域 / Possible realms that can be chosen. */
-enum choosable_realm {
-    CH_NONE = 0x00,
-    CH_LIFE = 0x01,
-    CH_SORCERY = 0x02,
-    CH_NATURE = 0x04,
-    CH_CHAOS = 0x08,
-    CH_DEATH = 0x10,
-    CH_TRUMP = 0x20,
-    CH_ARCANE = 0x40,
-    CH_ENCHANT = 0x80,
-    CH_DAEMON = 0x100,
-    CH_CRUSADE = 0x200,
-
-    CH_MUSIC = 0x8000,
-    CH_HISSATSU = 0x10000,
-    CH_HEX = 0x20000,
-};
+using RealmChoices = FlagGroup<magic_realm_type, REALM_MAX>;
 
 enum class ItemKindType : short;
+enum class PlayerClassType : short;
 class PlayerType;
 struct magic_type;
 class PlayerRealm {
@@ -31,6 +18,8 @@ public:
 
     static const magic_type &get_spell_info(int realm, int num);
     static ItemKindType get_book(int realm);
+    static RealmChoices get_realm1_choices(PlayerClassType pclass);
+    static RealmChoices get_realm2_choices(PlayerClassType pclass);
 
     class Realm {
     public:
@@ -49,6 +38,3 @@ private:
     Realm realm1_;
     Realm realm2_;
 };
-
-extern const std::vector<BIT_FLAGS> realm_choices1;
-extern const std::vector<BIT_FLAGS> realm_choices2;

--- a/src/realm/realm-names-table.h
+++ b/src/realm/realm-names-table.h
@@ -13,7 +13,7 @@
 #include "util/enum-converter.h"
 #include <vector>
 
-#define VALID_REALM (MAX_REALM + MAX_MAGIC - MIN_TECHNIC + 1)
+constexpr auto VALID_REALM = std::ssize(MAGIC_REALM_RANGE) + std::ssize(TECHNIC_REALM_RANGE);
 #define is_magic(A) (((A) > REALM_NONE) && ((A) <= MAX_MAGIC))
 
 enum class ItemKindType : short;

--- a/src/realm/realm-names-table.h
+++ b/src/realm/realm-names-table.h
@@ -17,7 +17,7 @@ constexpr auto VALID_REALM = std::ssize(MAGIC_REALM_RANGE) + std::ssize(TECHNIC_
 #define is_magic(A) (((A) > REALM_NONE) && ((A) <= MAX_MAGIC))
 
 enum class ItemKindType : short;
-#define tval2realm(A) ((A)-ItemKindType::LIFE_BOOK + 1)
+#define tval2realm(A) (i2enum<magic_realm_type>((A)-ItemKindType::LIFE_BOOK + 1))
 #define technic2magic(A) (is_magic(A) ? (A) : (A)-MIN_TECHNIC + 1 + MAX_MAGIC)
 #define is_good_realm(REALM) ((REALM) == REALM_LIFE || (REALM) == REALM_CRUSADE)
 

--- a/src/realm/realm-types.h
+++ b/src/realm/realm-types.h
@@ -19,7 +19,7 @@ enum magic_realm_type {
     REALM_MUSIC = 16,
     REALM_HISSATSU = 17,
     REALM_HEX = 18,
-    MAX_REALM = 18,
+    REALM_MAX,
 };
 
 constexpr auto MAGIC_REALM_RANGE = EnumRangeInclusive(REALM_LIFE, REALM_CRUSADE);

--- a/src/spell/spell-info.cpp
+++ b/src/spell/spell-info.cpp
@@ -36,7 +36,8 @@ MANA_POINT mod_need_mana(PlayerType *player_ptr, MANA_POINT need_mana, SPELL_IDX
 #define MANA_CONST 2400
 #define MANA_DIV 4
 #define DEC_MANA_DIV 3
-    if ((realm > REALM_NONE) && (realm <= MAX_REALM)) {
+    const auto realm_enum = i2enum<magic_realm_type>(realm);
+    if (MAGIC_REALM_RANGE.contains(realm_enum) || TECHNIC_REALM_RANGE.contains(realm_enum)) {
         need_mana = need_mana * (MANA_CONST + PlayerSkill::spell_exp_at(PlayerSkillRank::EXPERT) - PlayerSkill(player_ptr).exp_of_spell(realm, spell_id)) + (MANA_CONST - 1);
         need_mana *= player_ptr->dec_mana ? DEC_MANA_DIV : MANA_DIV;
         need_mana /= MANA_CONST * MANA_DIV;
@@ -219,7 +220,8 @@ PERCENTAGE spell_chance(PlayerType *player_ptr, SPELL_IDX spell_id, int16_t use_
  */
 void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell_id, const SPELL_IDX *spell_ids, int num, TERM_LEN y, TERM_LEN x, int16_t use_realm)
 {
-    if (((use_realm <= REALM_NONE) || (use_realm > MAX_REALM)) && AngbandWorld::get_instance().wizard) {
+    const auto realm = i2enum<magic_realm_type>(use_realm);
+    if ((!MAGIC_REALM_RANGE.contains(realm) && !TECHNIC_REALM_RANGE.contains(realm)) && AngbandWorld::get_instance().wizard) {
         msg_print(_("警告！ print_spell が領域なしに呼ばれた", "Warning! print_spells called with null realm"));
     }
 

--- a/src/spell/technic-info-table.h
+++ b/src/spell/technic-info-table.h
@@ -3,7 +3,7 @@
 #include "realm/realm-types.h"
 #include "system/angband.h"
 
-#define NUM_TECHNIC (MAX_REALM - MIN_TECHNIC + 1)
+constexpr auto NUM_TECHNIC = std::ssize(TECHNIC_REALM_RANGE);
 
 /*
  * The "name" of spell 'N' is stored as spell_names[X][N],

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -637,12 +637,12 @@ void wiz_reset_class(PlayerType *player_ptr)
  */
 void wiz_reset_realms(PlayerType *player_ptr)
 {
-    const auto new_realm1 = input_numerics("1st Realm (None=0)", 0, MAX_REALM - 1, player_ptr->realm1);
+    const auto new_realm1 = input_numerics("1st Realm (None=0)", 0, REALM_MAX - 1, player_ptr->realm1);
     if (!new_realm1) {
         return;
     }
 
-    const auto new_realm2 = input_numerics("2nd Realm (None=0)", 0, MAX_REALM - 1, player_ptr->realm2);
+    const auto new_realm2 = input_numerics("2nd Realm (None=0)", 0, REALM_MAX - 1, player_ptr->realm2);
     if (!new_realm2) {
         return;
     }


### PR DESCRIPTION
#4357 の一環

魔法領域の選択候補の取得をグローバル配列変数 realm*_choices に直接アクセスして取得する方法から、PlayerRealmクラスの静的メンバ関数get_realm*_choices() で取得する方法に変更する。