### PR TITLE
[Feature] PlayerRealm::Realm クラス

### DIFF
--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -457,12 +457,12 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, co
     auto realm_except_class = pc.equals(PlayerClassType::SORCERER) || pc.equals(PlayerClassType::RED_MAGE);
 
     PlayerRealm pr(player_ptr);
-    if ((pr.get_realm1_book() == tval) && !realm_except_class) {
+    if ((pr.realm1().get_book() == tval) && !realm_except_class) {
         entry->add(FLG_REALM1);
         name = false;
     }
 
-    if ((pr.get_realm2_book() == tval) && !realm_except_class) {
+    if ((pr.realm2().get_book() == tval) && !realm_except_class) {
         entry->add(FLG_REALM2);
         name = false;
     }

--- a/src/autopick/autopick-matcher.cpp
+++ b/src/autopick/autopick-matcher.cpp
@@ -317,11 +317,11 @@ bool is_autopick_match(PlayerType *player_ptr, const ItemEntity *o_ptr, const au
     auto realm_except_class = pc.equals(PlayerClassType::SORCERER) || pc.equals(PlayerClassType::RED_MAGE);
 
     PlayerRealm pr(player_ptr);
-    if (entry.has(FLG_REALM1) && ((pr.get_realm1_book() != tval) || realm_except_class)) {
+    if (entry.has(FLG_REALM1) && ((pr.realm1().get_book() != tval) || realm_except_class)) {
         return false;
     }
 
-    if (entry.has(FLG_REALM2) && ((pr.get_realm2_book() != tval) || realm_except_class)) {
+    if (entry.has(FLG_REALM2) && ((pr.realm2().get_book() != tval) || realm_except_class)) {
         return false;
     }
 

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -770,9 +770,9 @@ void do_cmd_study(PlayerType *player_ptr)
     const auto tval = o_ptr->bi_key.tval();
     const auto sval = *o_ptr->bi_key.sval();
     PlayerRealm pr(player_ptr);
-    if (tval == pr.get_realm2_book()) {
+    if (tval == pr.realm2().get_book()) {
         increment = 32;
-    } else if (tval != pr.get_realm1_book()) {
+    } else if (tval != pr.realm1().get_book()) {
         if (!input_check(_("本当に魔法の領域を変更しますか？", "Really, change magic realm? "))) {
             return;
         }
@@ -1003,7 +1003,7 @@ bool do_cmd_cast(PlayerType *player_ptr)
 
     const auto tval = o_ptr->bi_key.tval();
     const auto sval = *o_ptr->bi_key.sval();
-    if (!is_every_magic && (tval == PlayerRealm(player_ptr).get_realm2_book())) {
+    if (!is_every_magic && (tval == PlayerRealm(player_ptr).realm2().get_book())) {
         increment = 32;
     }
 

--- a/src/knowledge/knowledge-experiences.cpp
+++ b/src/knowledge/knowledge-experiences.cpp
@@ -89,7 +89,7 @@ void do_cmd_knowledge_spell_exp(PlayerType *player_ptr)
     if (player_ptr->realm1 != REALM_NONE) {
         fprintf(fff, _("%sの魔法書\n", "%s Spellbook\n"), realm_names[player_ptr->realm1].data());
         for (SPELL_IDX i = 0; i < 32; i++) {
-            const auto &spell = pr.get_realm1_spell_info(i);
+            const auto &spell = pr.realm1().get_spell_info(i);
 
             if (spell.slevel >= 99) {
                 continue;
@@ -125,7 +125,7 @@ void do_cmd_knowledge_spell_exp(PlayerType *player_ptr)
     if (player_ptr->realm2 != REALM_NONE) {
         fprintf(fff, _("%sの魔法書\n", "\n%s Spellbook\n"), realm_names[player_ptr->realm2].data());
         for (SPELL_IDX i = 0; i < 32; i++) {
-            const auto &spell = pr.get_realm2_spell_info(i);
+            const auto &spell = pr.realm2().get_spell_info(i);
 
             if (spell.slevel >= 99) {
                 continue;

--- a/src/object-hook/hook-magic.cpp
+++ b/src/object-hook/hook-magic.cpp
@@ -80,5 +80,5 @@ bool item_tester_learn_spell(PlayerType *player_ptr, const ItemEntity *o_ptr)
     }
 
     PlayerRealm pr(player_ptr);
-    return (pr.get_realm1_book() == tval) || (pr.get_realm2_book() == tval) || (choices & (0x0001U << (tval2realm(tval) - 1)));
+    return (pr.realm1().get_book() == tval) || (pr.realm2().get_book() == tval) || (choices & (0x0001U << (tval2realm(tval) - 1)));
 }

--- a/src/object/object-info.cpp
+++ b/src/object/object-info.cpp
@@ -119,7 +119,7 @@ bool check_book_realm(PlayerType *player_ptr, const BaseitemKey &bi_key)
     }
 
     PlayerRealm pr(player_ptr);
-    return (pr.get_realm1_book() == tval) || (pr.get_realm2_book() == tval);
+    return (pr.realm1().get_book() == tval) || (pr.realm2().get_book() == tval);
 }
 
 ItemEntity *ref_item(PlayerType *player_ptr, INVENTORY_IDX i_idx)

--- a/src/player/player-realm.cpp
+++ b/src/player/player-realm.cpp
@@ -98,7 +98,8 @@ const std::vector<BIT_FLAGS> realm_choices2 = {
 };
 
 PlayerRealm::PlayerRealm(PlayerType *player_ptr)
-    : player_ptr(player_ptr)
+    : realm1_(player_ptr->realm1)
+    , realm2_(player_ptr->realm2)
 {
 }
 
@@ -129,22 +130,27 @@ ItemKindType PlayerRealm::get_book(int realm)
     return it->second;
 }
 
-const magic_type &PlayerRealm::get_realm1_spell_info(int num) const
+const PlayerRealm::Realm &PlayerRealm::realm1() const
 {
-    return PlayerRealm::get_spell_info(this->player_ptr->realm1, num);
+    return this->realm1_;
 }
 
-const magic_type &PlayerRealm::get_realm2_spell_info(int num) const
+const PlayerRealm::Realm &PlayerRealm::realm2() const
 {
-    return PlayerRealm::get_spell_info(this->player_ptr->realm2, num);
+    return this->realm2_;
 }
 
-ItemKindType PlayerRealm::get_realm1_book() const
+PlayerRealm::Realm::Realm(int realm)
+    : realm(realm)
 {
-    return PlayerRealm::get_book(this->player_ptr->realm1);
 }
 
-ItemKindType PlayerRealm::get_realm2_book() const
+const magic_type &PlayerRealm::Realm::get_spell_info(int num) const
 {
-    return PlayerRealm::get_book(this->player_ptr->realm2);
+    return PlayerRealm::get_spell_info(this->realm, num);
+}
+
+ItemKindType PlayerRealm::Realm::get_book() const
+{
+    return PlayerRealm::get_book(this->realm);
 }

--- a/src/player/player-realm.h
+++ b/src/player/player-realm.h
@@ -32,13 +32,22 @@ public:
     static const magic_type &get_spell_info(int realm, int num);
     static ItemKindType get_book(int realm);
 
-    const magic_type &get_realm1_spell_info(int num) const;
-    const magic_type &get_realm2_spell_info(int num) const;
-    ItemKindType get_realm1_book() const;
-    ItemKindType get_realm2_book() const;
+    class Realm {
+    public:
+        Realm(int realm);
+        const magic_type &get_spell_info(int num) const;
+        ItemKindType get_book() const;
+
+    private:
+        int realm;
+    };
+
+    const Realm &realm1() const;
+    const Realm &realm2() const;
 
 private:
-    PlayerType *player_ptr;
+    Realm realm1_;
+    Realm realm2_;
 };
 
 extern const std::vector<BIT_FLAGS> realm_choices1;

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -555,8 +555,8 @@ static void update_num_of_spells(PlayerType *player_ptr)
             continue;
         }
 
-        const auto get_spell_info = (j < 32) ? &PlayerRealm::get_realm1_spell_info : &PlayerRealm::get_realm2_spell_info;
-        const auto &spell = (pr.*get_spell_info)(j % 32);
+        const auto &realm = (j < 32) ? pr.realm1() : pr.realm2();
+        const auto &spell = realm.get_spell_info(j % 32);
 
         if (spell.slevel <= player_ptr->lev) {
             continue;
@@ -651,8 +651,8 @@ static void update_num_of_spells(PlayerType *player_ptr)
             break;
         }
 
-        const auto get_spell_info = (j < 32) ? &PlayerRealm::get_realm1_spell_info : &PlayerRealm::get_realm2_spell_info;
-        const auto &spell = (pr.*get_spell_info)(j % 32);
+        const auto &realm = (j < 32) ? pr.realm1() : pr.realm2();
+        const auto &spell = realm.get_spell_info(j % 32);
 
         if (spell.slevel > player_ptr->lev) {
             continue;
@@ -692,7 +692,7 @@ static void update_num_of_spells(PlayerType *player_ptr)
     if (player_ptr->realm2 == REALM_NONE) {
         int k = 0;
         for (int j = 0; j < 32; j++) {
-            const auto &spell = pr.get_realm1_spell_info(j);
+            const auto &spell = pr.realm1().get_spell_info(j);
 
             if (spell.slevel > player_ptr->lev) {
                 continue;

--- a/src/util/object-sort.cpp
+++ b/src/util/object-sort.cpp
@@ -47,19 +47,21 @@ bool object_sort_comp(PlayerType *player_ptr, ItemEntity *o_ptr, int32_t o_value
     const auto o_tval = o_ptr->bi_key.tval();
     const auto j_tval = j_ptr->bi_key.tval();
     PlayerRealm pr(player_ptr);
-    if ((o_tval == pr.get_realm1_book()) && (j_tval != pr.get_realm1_book())) {
+    const auto realm1_book = pr.realm1().get_book();
+    const auto realm2_book = pr.realm2().get_book();
+    if ((o_tval == realm1_book) && (j_tval != realm1_book)) {
         return true;
     }
 
-    if ((j_tval == pr.get_realm1_book()) && (o_tval != pr.get_realm1_book())) {
+    if ((j_tval == realm1_book) && (o_tval != realm1_book)) {
         return false;
     }
 
-    if ((o_tval == pr.get_realm2_book()) && (j_tval != pr.get_realm2_book())) {
+    if ((o_tval == realm2_book) && (j_tval != realm2_book)) {
         return true;
     }
 
-    if ((j_tval == pr.get_realm2_book()) && (o_tval != pr.get_realm2_book())) {
+    if ((j_tval == realm2_book) && (o_tval != realm2_book)) {
         return false;
     }
 


### PR DESCRIPTION
PlayerRealmクラスにメンバ関数に第1領域と第2領域用それぞれに get_realm*_spell_info, get_realm*_book があるが、今後メンバ関数を追加 するごとに第1領域用と第2領域用が増えるのは好ましくない。
これを避けるため、PlayerRealmに領域ごとの処理をする内部クラスRealmを実装し、上述のメンバ関数を内部クラスに移動する。
PlayerRealm::realm* により第1領域か第2領域のPlayerRealm::Realmクラスのオブジェクトを返すようにし、それを経由してアクセスするように変更する。