### PR TITLE
[Refactor] 善良な魔法領域かどうかの判定

### DIFF
--- a/src/birth/birth-select-realm.cpp
+++ b/src/birth/birth-select-realm.cpp
@@ -51,7 +51,7 @@ static void impose_first_realm(PlayerType *player_ptr, RealmChoices &choices)
         return;
     }
 
-    if (is_good_realm(player_ptr->realm1)) {
+    if (PlayerRealm(player_ptr).realm1().is_good_attribute()) {
         choices.reset({ REALM_DEATH, REALM_DAEMON });
     } else {
         choices.reset({ REALM_LIFE, REALM_CRUSADE });

--- a/src/cmd-item/cmd-destroy.cpp
+++ b/src/cmd-item/cmd-destroy.cpp
@@ -25,9 +25,9 @@
 #include "player-info/samurai-data-type.h"
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
+#include "player/player-realm.h"
 #include "player/special-defense-types.h"
 #include "racial/racial-android.h"
-#include "realm/realm-names-table.h"
 #include "status/action-setter.h"
 #include "status/experience.h"
 #include "system/baseitem-info.h"
@@ -129,7 +129,7 @@ static bool decide_magic_book_exp(PlayerType *player_ptr, const ItemEntity &dest
     }
 
     auto is_good_magic_realm = (tval == ItemKindType::LIFE_BOOK) || (tval == ItemKindType::CRUSADE_BOOK);
-    if (is_good_realm(player_ptr->realm1)) {
+    if (PlayerRealm(player_ptr).realm1().is_good_attribute()) {
         return !is_good_magic_realm;
     } else {
         return is_good_magic_realm;

--- a/src/object-hook/hook-magic.cpp
+++ b/src/object-hook/hook-magic.cpp
@@ -60,10 +60,11 @@ bool item_tester_learn_spell(PlayerType *player_ptr, const ItemEntity *o_ptr)
         return false;
     }
 
+    PlayerRealm pr(player_ptr);
     auto choices = PlayerRealm::get_realm2_choices(player_ptr->pclass);
     PlayerClass pc(player_ptr);
     if (pc.equals(PlayerClassType::PRIEST)) {
-        if (is_good_realm(player_ptr->realm1)) {
+        if (PlayerRealm(player_ptr).realm1().is_good_attribute()) {
             choices.reset({ REALM_DEATH, REALM_DAEMON });
         } else {
             choices.reset({ REALM_LIFE, REALM_CRUSADE });
@@ -80,6 +81,5 @@ bool item_tester_learn_spell(PlayerType *player_ptr, const ItemEntity *o_ptr)
         return false;
     }
 
-    PlayerRealm pr(player_ptr);
     return (pr.realm1().get_book() == tval) || (pr.realm2().get_book() == tval) || choices.has(realm);
 }

--- a/src/player-info/class-ability-info.cpp
+++ b/src/player-info/class-ability-info.cpp
@@ -1,6 +1,6 @@
 #include "player-info/class-ability-info.h"
 #include "player-info/self-info-util.h"
-#include "realm/realm-names-table.h"
+#include "player/player-realm.h"
 #include "realm/realm-types.h"
 #include "system/player-type-definition.h"
 
@@ -26,7 +26,7 @@ void set_class_ability_info(PlayerType *player_ptr, self_info_type *self_ptr)
 
         break;
     case PlayerClassType::PRIEST:
-        if (is_good_realm(player_ptr->realm1)) {
+        if (PlayerRealm(player_ptr).realm1().is_good_attribute()) {
             if (player_ptr->lev > 34) {
                 self_ptr->info_list.emplace_back(_("あなたは武器を祝福することができる。(70 MP)", "You can bless a weapon (cost 70)."));
             }
@@ -52,7 +52,7 @@ void set_class_ability_info(PlayerType *player_ptr, self_info_type *self_ptr)
 
         break;
     case PlayerClassType::PALADIN:
-        if (is_good_realm(player_ptr->realm1)) {
+        if (PlayerRealm(player_ptr).realm1().is_good_attribute()) {
             if (player_ptr->lev > 29) {
                 self_ptr->info_list.emplace_back(_("あなたは聖なる槍を放つことができる。(30 MP)", "You can fire a holy spear (cost 30)."));
             }

--- a/src/player/player-realm.cpp
+++ b/src/player/player-realm.cpp
@@ -131,3 +131,8 @@ ItemKindType PlayerRealm::Realm::get_book() const
 {
     return PlayerRealm::get_book(this->realm);
 }
+
+bool PlayerRealm::Realm::is_good_attribute() const
+{
+    return this->realm == REALM_LIFE || this->realm == REALM_CRUSADE;
+}

--- a/src/player/player-realm.h
+++ b/src/player/player-realm.h
@@ -26,6 +26,7 @@ public:
         Realm(int realm);
         const magic_type &get_spell_info(int num) const;
         ItemKindType get_book() const;
+        bool is_good_attribute() const;
 
     private:
         int realm;

--- a/src/racial/class-racial-switcher.cpp
+++ b/src/racial/class-racial-switcher.cpp
@@ -1,8 +1,8 @@
 #include "racial/class-racial-switcher.h"
 #include "cmd-action/cmd-spell.h"
 #include "mind/mind-elementalist.h"
+#include "player/player-realm.h"
 #include "racial/racial-util.h"
-#include "realm/realm-names-table.h"
 #include "realm/realm-types.h"
 #include "system/player-type-definition.h"
 
@@ -43,7 +43,7 @@ void switch_class_racial(PlayerType *player_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         break;
     case PlayerClassType::PRIEST:
-        if (is_good_realm(player_ptr->realm1)) {
+        if (PlayerRealm(player_ptr).realm1().is_good_attribute()) {
             rpi = rpi_type(_("武器祝福", "Bless Weapon"));
             rpi.text = _("武器を祝福する。抵抗されることがある。", "Blesses a weapon. Some weapons can resist it.");
             rpi.min_level = 35;
@@ -84,7 +84,7 @@ void switch_class_racial(PlayerType *player_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         break;
     case PlayerClassType::PALADIN:
-        if (is_good_realm(player_ptr->realm1)) {
+        if (PlayerRealm(player_ptr).realm1().is_good_attribute()) {
             rpi = rpi_type(_("ホーリー・ランス", "Holy Lance"));
             rpi.info = format("%s%d", KWD_DAM, rc_ptr->lvl * 3);
             rpi.text = _("聖なる炎のビームを放つ。", "Fires a beam of holy fire.");

--- a/src/racial/racial-switcher.cpp
+++ b/src/racial/racial-switcher.cpp
@@ -52,13 +52,13 @@
 #include "player-status/player-hand-types.h"
 #include "player/attack-defense-types.h"
 #include "player/player-damage.h"
+#include "player/player-realm.h"
 #include "player/player-status.h"
 #include "racial/racial-android.h"
 #include "racial/racial-balrog.h"
 #include "racial/racial-draconian.h"
 #include "racial/racial-kutar.h"
 #include "racial/racial-vampire.h"
-#include "realm/realm-names-table.h"
 #include "spell-class/spells-mirror-master.h"
 #include "spell-kind/spells-beam.h"
 #include "spell-kind/spells-detection.h"
@@ -105,7 +105,7 @@ bool switch_class_racial_execution(PlayerType *player_ptr, const int32_t command
     case PlayerClassType::SORCERER:
         return eat_magic(player_ptr, player_ptr->lev * 2);
     case PlayerClassType::PRIEST:
-        if (!is_good_realm(player_ptr->realm1)) {
+        if (!PlayerRealm(player_ptr).realm1().is_good_attribute()) {
             (void)dispel_monsters(player_ptr, player_ptr->lev * 4);
             turn_monsters(player_ptr, player_ptr->lev * 4);
             banish_monsters(player_ptr, player_ptr->lev * 4);
@@ -125,7 +125,7 @@ bool switch_class_racial_execution(PlayerType *player_ptr, const int32_t command
             return false;
         }
 
-        fire_beam(player_ptr, is_good_realm(player_ptr->realm1) ? AttributeType::HOLY_FIRE : AttributeType::HELL_FIRE, dir, player_ptr->lev * 3);
+        fire_beam(player_ptr, PlayerRealm(player_ptr).realm1().is_good_attribute() ? AttributeType::HOLY_FIRE : AttributeType::HELL_FIRE, dir, player_ptr->lev * 3);
         return true;
     case PlayerClassType::WARRIOR_MAGE:
         if (command == -3) {

--- a/src/realm/realm-names-table.h
+++ b/src/realm/realm-names-table.h
@@ -19,6 +19,5 @@ constexpr auto VALID_REALM = std::ssize(MAGIC_REALM_RANGE) + std::ssize(TECHNIC_
 enum class ItemKindType : short;
 #define tval2realm(A) (i2enum<magic_realm_type>((A)-ItemKindType::LIFE_BOOK + 1))
 #define technic2magic(A) (is_magic(A) ? (A) : (A)-MIN_TECHNIC + 1 + MAX_MAGIC)
-#define is_good_realm(REALM) ((REALM) == REALM_LIFE || (REALM) == REALM_CRUSADE)
 
 extern const std::vector<LocalizedString> realm_names;


### PR DESCRIPTION
#4357 の一環

善良な魔法領域かどうかの判定を行うマクロ is_good_realm を廃止し、PlayerRealmクラスのメンバ関数 is_good_attribute を代わりに使用する。