### PR TITLE
[Fix] スポイラーの魔法領域出力の内容がおかしい

### DIFF
--- a/src/player/player-realm.cpp
+++ b/src/player/player-realm.cpp
@@ -89,7 +89,7 @@ const LocalizedString &PlayerRealm::get_name(int realm)
     return it->second;
 }
 
-const magic_type &PlayerRealm::get_spell_info(int realm, int spell_idx)
+const magic_type &PlayerRealm::get_spell_info(int realm, int spell_idx, std::optional<PlayerClassType> pclass)
 {
     if (spell_idx < 0 || 32 <= spell_idx) {
         THROW_EXCEPTION(std::invalid_argument, format("Invalid spell idx: %d", spell_idx));
@@ -98,6 +98,9 @@ const magic_type &PlayerRealm::get_spell_info(int realm, int spell_idx)
     const auto realm_enum = i2enum<magic_realm_type>(realm);
 
     if (MAGIC_REALM_RANGE.contains(realm_enum)) {
+        if (pclass) {
+            return class_magics_info.at(enum2i(*pclass)).info[realm - 1][spell_idx];
+        }
         return mp_ptr->info[realm - 1][spell_idx];
     }
     if (TECHNIC_REALM_RANGE.contains(realm_enum)) {

--- a/src/player/player-realm.h
+++ b/src/player/player-realm.h
@@ -4,6 +4,7 @@
 #include "system/angband.h"
 #include "util/flag-group.h"
 #include <cstdint>
+#include <optional>
 #include <vector>
 
 using RealmChoices = FlagGroup<magic_realm_type, REALM_MAX>;
@@ -18,7 +19,7 @@ public:
     PlayerRealm(PlayerType *player_ptr);
 
     static const LocalizedString &get_name(int realm);
-    static const magic_type &get_spell_info(int realm, int num);
+    static const magic_type &get_spell_info(int realm, int num, std::optional<PlayerClassType> pclass = std::nullopt);
     static ItemKindType get_book(int realm);
     static RealmChoices get_realm1_choices(PlayerClassType pclass);
     static RealmChoices get_realm2_choices(PlayerClassType pclass);

--- a/src/wizard/wizard-spoiler.cpp
+++ b/src/wizard/wizard-spoiler.cpp
@@ -210,9 +210,8 @@ static SpoilerOutputResultType spoil_player_spell()
 
         const auto choices = PlayerRealm::get_realm1_choices(pclass) | PlayerRealm::get_realm2_choices(pclass);
         const auto is_every_magic = pclass == PlayerClassType::SORCERER || pclass == PlayerClassType::RED_MAGE;
-        for (const auto realm : MAGIC_REALM_RANGE) {
-            /// @todo 歌・武芸・呪術への対応
-            if (!is_every_magic && choices.has_not(realm)) {
+        for (const auto realm : EnumRange(REALM_LIFE, REALM_MAX)) {
+            if (!(is_every_magic && MAGIC_REALM_RANGE.contains(realm)) && choices.has_not(realm)) {
                 continue;
             }
 

--- a/src/wizard/wizard-spoiler.cpp
+++ b/src/wizard/wizard-spoiler.cpp
@@ -182,11 +182,10 @@ static SpoilerOutputResultType spoil_player_spell()
 
     PlayerType dummy_p;
     dummy_p.lev = 1;
-    for (auto c = 0; c < PLAYER_CLASS_TYPE_MAX; c++) {
-        auto class_ptr = &class_info.at(i2enum<PlayerClassType>(c));
-        spoil_out(format("[[Class: %s]]\n", class_ptr->title.data()));
+    for (const auto pclass : EnumRange(PlayerClassType::WARRIOR, PlayerClassType::MAX)) {
+        spoil_out(format("[[Class: %s]]\n", class_info.at(pclass).title.data()));
 
-        auto magic_ptr = &class_magics_info[c];
+        const auto *magic_ptr = &class_magics_info[enum2i(pclass)];
         std::string book_name = _("なし", "None");
         if (magic_ptr->spell_book != ItemKindType::NONE) {
             ItemEntity item({ magic_ptr->spell_book, 0 });
@@ -198,24 +197,24 @@ static SpoilerOutputResultType spoil_player_spell()
         }
 
         constexpr auto mes = "BookType:%s Stat:%s %s%s%sType:%d Weight:%d\n";
-        const auto &spell = wiz_spell_stat[magic_ptr->spell_stat];
+        const auto &spell_stat_txt = wiz_spell_stat[magic_ptr->spell_stat];
         auto trainable = magic_ptr->is_spell_trainable ? "Trainable " : "";
         auto glove = magic_ptr->has_glove_mp_penalty ? "GlovePenalty " : "";
         auto failcap = magic_ptr->has_magic_fail_rate_cap ? "5%FailCap " : "";
         auto spell_type = enum2i(magic_ptr->spell_book);
-        spoil_out(format(mes, book_name.data(), spell.data(), glove, failcap, trainable, spell_type, magic_ptr->spell_weight));
+        spoil_out(format(mes, book_name.data(), spell_stat_txt.data(), glove, failcap, trainable, spell_type, magic_ptr->spell_weight));
         if (magic_ptr->spell_book == ItemKindType::NONE) {
             spoil_out(_("呪文なし\n\n", "No spells.\n\n"));
             continue;
         }
 
-        for (int16_t r = 1; r < MAX_MAGIC; r++) {
-            spoil_out(format("[Realm: %s]\n", PlayerRealm::get_name(r).data()));
+        for (const auto realm : MAGIC_REALM_RANGE) {
+            spoil_out(format("[Realm: %s]\n", PlayerRealm::get_name(realm).data()));
             spoil_out("Name                     Lv Cst Dif Exp\n");
             for (SPELL_IDX i = 0; i < 32; i++) {
-                auto spell_ptr = &magic_ptr->info[r][i];
-                const auto spell_name = exe_spell(&dummy_p, r, i, SpellProcessType::NAME);
-                spoil_out(format("%-24s %2d %3d %3d %3d\n", spell_name->data(), spell_ptr->slevel, spell_ptr->smana, spell_ptr->sfail, spell_ptr->sexp));
+                const auto &spell = PlayerRealm::get_spell_info(realm, i, pclass);
+                const auto spell_name = exe_spell(&dummy_p, realm, i, SpellProcessType::NAME);
+                spoil_out(format("%-24s %2d %3d %3d %3d\n", spell_name->data(), spell.slevel, spell.smana, spell.sfail, spell.sexp));
             }
             spoil_out("\n");
         }

--- a/src/wizard/wizard-spoiler.cpp
+++ b/src/wizard/wizard-spoiler.cpp
@@ -208,7 +208,14 @@ static SpoilerOutputResultType spoil_player_spell()
             continue;
         }
 
+        const auto choices = PlayerRealm::get_realm1_choices(pclass) | PlayerRealm::get_realm2_choices(pclass);
+        const auto is_every_magic = pclass == PlayerClassType::SORCERER || pclass == PlayerClassType::RED_MAGE;
         for (const auto realm : MAGIC_REALM_RANGE) {
+            /// @todo 歌・武芸・呪術への対応
+            if (!is_every_magic && choices.has_not(realm)) {
+                continue;
+            }
+
             spoil_out(format("[Realm: %s]\n", PlayerRealm::get_name(realm).data()));
             spoil_out("Name                     Lv Cst Dif Exp\n");
             for (SPELL_IDX i = 0; i < 32; i++) {


### PR DESCRIPTION
Resolves #4366

また、ついでに使用可能な領域の情報のみを出力するようにしました。