### PR TITLE
呪文定義ファイルを歌/武芸/呪術を含む形に拡張する

### DIFF
--- a/lib/edit/SpellDefinitions.jsonc
+++ b/lib/edit/SpellDefinitions.jsonc
@@ -4210,6 +4210,1269 @@
           ]
         }
       ]
+    },
+    {
+      "name": "MUSIC",
+      "books": [
+        {
+          "name": {
+            "ja": "[見習い教本]",
+            "en": "[Apprentice Handbook]"
+          },
+          "spells": [
+            {
+              "spell_id": 0,
+              "spell_tag": "Song_of_Holding",
+              "name": {
+                "ja": "遅鈍の歌",
+                "en": "Song of Holding"
+              },
+              "description": {
+                "ja": "視界内の全てのモンスターを減速させる。抵抗されると無効。",
+                "en": "Attempts to slow all monsters in sight."
+              }
+            },
+            {
+              "spell_id": 1,
+              "spell_tag": "Song_of_Blessing",
+              "name": {
+                "ja": "祝福の歌",
+                "en": "Song of Blessing"
+              },
+              "description": {
+                "ja": "命中率とACのボーナスを得る。",
+                "en": "Gives a bonus to hit and AC for a few turns."
+              }
+            },
+            {
+              "spell_id": 2,
+              "spell_tag": "Wrecking_Note",
+              "name": {
+                "ja": "崩壊の音色",
+                "en": "Wrecking Note"
+              },
+              "description": {
+                "ja": "轟音のボルトを放つ。",
+                "en": "Fires a bolt of sound."
+              }
+            },
+            {
+              "spell_id": 3,
+              "spell_tag": "Stun_Pattern",
+              "name": {
+                "ja": "朦朧の旋律",
+                "en": "Stun Pattern"
+              },
+              "description": {
+                "ja": "視界内の全てのモンスターを朦朧させる。抵抗されると無効。",
+                "en": "Attempts to stun all monsters in sight."
+              }
+            },
+            {
+              "spell_id": 4,
+              "spell_tag": "Flow_of_Life",
+              "name": {
+                "ja": "生命の流れ",
+                "en": "Flow of Life"
+              },
+              "description": {
+                "ja": "体力を少し回復させる。",
+                "en": "Heals HP a little."
+              }
+            },
+            {
+              "spell_id": 5,
+              "spell_tag": "Song_of_the_Sun",
+              "name": {
+                "ja": "太陽の歌",
+                "en": "Song of the Sun"
+              },
+              "description": {
+                "ja": "光源が照らしている範囲か部屋全体を永久に明るくする。",
+                "en": "Lights up nearby area and the inside of a room permanently."
+              }
+            },
+            {
+              "spell_id": 6,
+              "spell_tag": "Song_of_Fear",
+              "name": {
+                "ja": "恐怖の歌",
+                "en": "Song of Fear"
+              },
+              "description": {
+                "ja": "視界内の全てのモンスターを恐怖させる。抵抗されると無効。",
+                "en": "Attempts to scare all monsters in sight."
+              }
+            },
+            {
+              "spell_id": 7,
+              "spell_tag": "Heroic_Ballad",
+              "name": {
+                "ja": "戦いの歌",
+                "en": "Heroic Ballad"
+              },
+              "description": {
+                "ja": "ヒーロー気分になる。",
+                "en": "Removes fear. Gives a bonus to hit for a while. Heals you for 10 HP."
+              }
+            }
+          ]
+        },
+        {
+          "name": {
+            "ja": "[詩人楽曲集]",
+            "en": "[Minstrel's Music]"
+          },
+          "spells": [
+            {
+              "spell_id": 8,
+              "spell_tag": "Clairaudience",
+              "name": {
+                "ja": "霊的知覚",
+                "en": "Clairaudience"
+              },
+              "description": {
+                "ja": "近くの罠/扉/階段を感知する。レベル15で全てのモンスター、20で財宝とアイテムを感知できるようになる。レベル25で周辺の地形を感知し、40でその階全体を永久に照らし、ダンジョン内のすべてのアイテムを感知する。この効果は歌い続けることで順に起こる。",
+                "en": "Detects traps, doors and stairs in your vicinity. And detects all monsters at level 15, treasures and items at level 20. Maps nearby area at level 25. Lights and know the whole level at level 40. These effects accumulate as the song continues."
+              }
+            },
+            {
+              "spell_id": 9,
+              "spell_tag": "Soul Shriek",
+              "name": {
+                "ja": "魂の歌",
+                "en": "Soul Shriek"
+              },
+              "description": {
+                "ja": "視界内の全てのモンスターに対して精神攻撃を行う。",
+                "en": "Damages all monsters in sight with PSI damages."
+              }
+            },
+            {
+              "spell_id": 10,
+              "spell_tag": "Song_of_Lore",
+              "name": {
+                "ja": "知識の歌",
+                "en": "Song of Lore"
+              },
+              "description": {
+                "ja": "自分のいるマスと隣りのマスに落ちているアイテムを鑑定する。",
+                "en": "Identifies all items which are in the adjacent squares."
+              }
+            },
+            {
+              "spell_id": 11,
+              "spell_tag": "Hiding_Tune",
+              "name": {
+                "ja": "隠遁の歌",
+                "en": "Hiding Tune"
+              },
+              "description": {
+                "ja": "隠密行動能力を上昇させる。",
+                "en": "Gives improved stealth."
+              }
+            },
+            {
+              "spell_id": 12,
+              "spell_tag": "Illusion_Pattern",
+              "name": {
+                "ja": "幻影の旋律",
+                "en": "Illusion Pattern"
+              },
+              "description": {
+                "ja": "視界内の全てのモンスターを混乱させる。抵抗されると無効。",
+                "en": "Attempts to confuse all monsters in sight."
+              }
+            },
+            {
+              "spell_id": 13,
+              "spell_tag": "Doomcall",
+              "name": {
+                "ja": "破滅の叫び",
+                "en": "Doomcall"
+              },
+              "description": {
+                "ja": "視界内の全てのモンスターに対して轟音攻撃を行う。",
+                "en": "Damages all monsters in sight with booming sound."
+              }
+            },
+            {
+              "spell_id": 14,
+              "spell_tag": "Firiels_Song",
+              "name": {
+                "ja": "フィリエルの歌",
+                "en": "Firiel's Song"
+              },
+              "description": {
+                "ja": "周囲の死体や骨を生き返す。",
+                "en": "Resurrects nearby corpses and skeletons. And makes them your pets."
+              }
+            },
+            {
+              "spell_id": 15,
+              "spell_tag": "Fellowship_Chant",
+              "name": {
+                "ja": "旅の仲間",
+                "en": "Fellowship Chant"
+              },
+              "description": {
+                "ja": "視界内の全てのモンスターを魅了する。抵抗されると無効。",
+                "en": "Attempts to charm all monsters in sight."
+              }
+            }
+          ]
+        },
+        {
+          "name": {
+            "ja": "[リヴェンデルの竪琴]",
+            "en": "[Harps of Rivendell]"
+          },
+          "spells": [
+            {
+              "spell_id": 16,
+              "spell_tag": "Hrus_March",
+              "name": {
+                "ja": "フルゥの行進曲",
+                "en": "Hru's March"
+              },
+              "description": {
+                "ja": "壁を掘り進む。自分の足元のアイテムは蒸発する。",
+                "en": "Makes you be able to burrow into walls. Objects under your feet evaporate."
+              }
+            },
+            {
+              "spell_id": 17,
+              "spell_tag": "Finrods_Resistance",
+              "name": {
+                "ja": "フィンロドの護り",
+                "en": "Finrod's Resistance"
+              },
+              "description": {
+                "ja": "酸、電撃、炎、冷気、毒に対する耐性を得る。装備による耐性に累積する。",
+                "en": "Gives resistance to fire, cold, electricity, acid and poison. These resistances can be added to those from equipment for more powerful resistances."
+              }
+            },
+            {
+              "spell_id": 18,
+              "spell_tag": "Hobbit_Melodies",
+              "name": {
+                "ja": "ホビットのメロディ",
+                "en": "Hobbit Melodies"
+              },
+              "description": {
+                "ja": "加速する。",
+                "en": "Hastes you."
+              }
+            },
+            {
+              "spell_id": 19,
+              "spell_tag": "World_Contortion",
+              "name": {
+                "ja": "歪んだ世界",
+                "en": "World Contortion"
+              },
+              "description": {
+                "ja": "近くのモンスターをテレポートさせる。抵抗されると無効。",
+                "en": "Teleports all nearby monsters away unless resisted."
+              }
+            },
+            {
+              "spell_id": 20,
+              "spell_tag": "Dispelling_Chant",
+              "name": {
+                "ja": "退散の歌",
+                "en": "Dispelling Chant"
+              },
+              "description": {
+                "ja": "視界内の全てのモンスターにダメージを与える。邪悪なモンスターに特に大きなダメージを与える。",
+                "en": "Damages all monsters in sight. Hurts evil monsters greatly."
+              }
+            },
+            {
+              "spell_id": 21,
+              "spell_tag": "The_Voice_of_Saruman",
+              "name": {
+                "ja": "サルマンの甘言",
+                "en": "The Voice of Saruman"
+              },
+              "description": {
+                "ja": "視界内の全てのモンスターを減速させ、眠らせようとする。抵抗されると無効。",
+                "en": "Attempts to slow and put to sleep all monsters in sight."
+              }
+            },
+            {
+              "spell_id": 22,
+              "spell_tag": "Song_of_the_Tempest",
+              "name": {
+                "ja": "嵐の音色",
+                "en": "Song of the Tempest"
+              },
+              "description": {
+                "ja": "轟音のビームを放つ。",
+                "en": "Fires a beam of sound."
+              }
+            },
+            {
+              "spell_id": 23,
+              "spell_tag": "Ambarkanta",
+              "name": {
+                "ja": "もう一つの世界",
+                "en": "Ambarkanta"
+              },
+              "description": {
+                "ja": "現在の階を再構成する。",
+                "en": "Recreates current dungeon level."
+              }
+            }
+          ]
+        },
+        {
+          "name": {
+            "ja": "[ベレリアンドの詩]",
+            "en": "[Lays of Beleriand]"
+          },
+          "spells": [
+            {
+              "spell_id": 24,
+              "spell_tag": "Wrecking_Pattern",
+              "name": {
+                "ja": "破壊の旋律",
+                "en": "Wrecking Pattern"
+              },
+              "description": {
+                "ja": "周囲のダンジョンを揺らし、壁と床をランダムに入れ変える。",
+                "en": "Shakes dungeon structure, and results in random swapping of floors and walls."
+              }
+            },
+            {
+              "spell_id": 25,
+              "spell_tag": "Stationary_Shriek",
+              "name": {
+                "ja": "停滞の歌",
+                "en": "Stationary Shriek"
+              },
+              "description": {
+                "ja": "視界内の全てのモンスターを麻痺させようとする。抵抗されると無効。",
+                "en": "Attempts to freeze all monsters in sight."
+              }
+            },
+            {
+              "spell_id": 26,
+              "spell_tag": "Elbereths_Chant",
+              "name": {
+                "ja": "エルベレスの聖歌",
+                "en": "Elbereth's Chant"
+              },
+              "description": {
+                "ja": "自分のいる床の上に、モンスターが通り抜けたり召喚されたりすることができなくなるルーンを描く。",
+                "en": "Sets a rune on the floor beneath you. If you are on a rune, monsters cannot attack you but can try to break the rune."
+              }
+            },
+            {
+              "spell_id": 27,
+              "spell_tag": "The_Heros_Poem",
+              "name": {
+                "ja": "英雄の詩",
+                "en": "The Hero's Poem"
+              },
+              "description": {
+                "ja": "加速し、ヒーロー気分になり、視界内の全てのモンスターにダメージを与える。",
+                "en": "Hastes you. Gives heroism. Damages all monsters in sight."
+              }
+            },
+            {
+              "spell_id": 28,
+              "spell_tag": "Relief_of_Yavanna",
+              "name": {
+                "ja": "ヤヴァンナの助け",
+                "en": "Relief of Yavanna"
+              },
+              "description": {
+                "ja": "強力な回復の歌で、負傷と朦朧状態も全快する。",
+                "en": "Powerful healing song. Also completely heals cuts and being stunned."
+              }
+            },
+            {
+              "spell_id": 29,
+              "spell_tag": "Goddess_rebirth",
+              "name": {
+                "ja": "再生の歌",
+                "en": "Goddess's rebirth"
+              },
+              "description": {
+                "ja": "すべてのステータスと経験値を回復する。",
+                "en": "Restores all stats and experience."
+              }
+            },
+            {
+              "spell_id": 30,
+              "spell_tag": "Wizardry_of_Sauron",
+              "name": {
+                "ja": "サウロンの魔術",
+                "en": "Wizardry of Sauron"
+              },
+              "description": {
+                "ja": "非常に強力でごく小さい轟音の球を放つ。",
+                "en": "Fires an extremely powerful tiny ball of sound."
+              }
+            },
+            {
+              "spell_id": 31,
+              "spell_tag": "Fingolfins_Challenge",
+              "name": {
+                "ja": "フィンゴルフィンの挑戦",
+                "en": "Fingolfin's Challenge"
+              },
+              "description": {
+                "ja": "ダメージを受けなくなるバリアを張る。",
+                "en": "Generates a barrier which completely protects you from almost all damage."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "HISSATSU",
+      "books": [
+        {
+          "name": {
+            "ja": "[武芸諸譜]",
+            "en": "[Bugei Shofu]"
+          },
+          "spells": [
+            {
+              "spell_id": 0,
+              "spell_tag": "Tobi-Izuna",
+              "name": {
+                "ja": "飛飯綱",
+                "en": "Tobi-Izuna"
+              },
+              "description": {
+                "ja": "2マス離れたところにいるモンスターを攻撃する。",
+                "en": "Attacks a monster two squares away."
+              }
+            },
+            {
+              "spell_id": 1,
+              "spell_tag": "3-Way_Attack",
+              "name": {
+                "ja": "五月雨斬り",
+                "en": "3-Way Attack"
+              },
+              "description": {
+                "ja": "3方向に対して攻撃する。",
+                "en": "Attacks in 3 directions at one time."
+              }
+            },
+            {
+              "spell_id": 2,
+              "spell_tag": "Boomerang",
+              "name": {
+                "ja": "ブーメラン",
+                "en": "Boomerang"
+              },
+              "description": {
+                "ja": "武器を手元に戻ってくるように投げる。戻ってこないこともある。",
+                "en": "Throws current weapon. It'll return to your hand unless the action failed."
+              }
+            },
+            {
+              "spell_id": 3,
+              "spell_tag": "Burning_Strike",
+              "name": {
+                "ja": "焔霊",
+                "en": "Burning Strike"
+              },
+              "description": {
+                "ja": "火炎耐性のないモンスターに大ダメージを与える。",
+                "en": "Attacks a monster with more damage unless it has resistance to fire."
+              }
+            },
+            {
+              "spell_id": 4,
+              "spell_tag": "Detect_Ferocity",
+              "name": {
+                "ja": "殺気感知",
+                "en": "Detect Ferocity"
+              },
+              "description": {
+                "ja": "近くの思考することができるモンスターを感知する。",
+                "en": "Detects all monsters except the mindless in your vicinity."
+              }
+            },
+            {
+              "spell_id": 5,
+              "spell_tag": "Strike_to_Stun",
+              "name": {
+                "ja": "みね打ち",
+                "en": "Strike to Stun"
+              },
+              "description": {
+                "ja": "相手にダメージを与えないが、朦朧とさせる。",
+                "en": "Attempts to stun a monster next to you."
+              }
+            },
+            {
+              "spell_id": 6,
+              "spell_tag": "Counter",
+              "name": {
+                "ja": "カウンター",
+                "en": "Counter"
+              },
+              "description": {
+                "ja": "相手に攻撃されたときに反撃する。反撃するたびにMPを消費。",
+                "en": "Prepares to counterattack. When attacked by a monster, strikes back using SP each time."
+              }
+            },
+            {
+              "spell_id": 7,
+              "spell_tag": "Harainuke",
+              "name": {
+                "ja": "払い抜け",
+                "en": "Harainuke"
+              },
+              "description": {
+                "ja": "攻撃した後、反対側に抜ける。",
+                "en": "In one action, attacks a monster with your weapons normally and then moves to the space beyond the monster if that space is not blocked."
+              }
+            }
+          ]
+        },
+        {
+          "name": {
+            "ja": "[柳生武芸帳]",
+            "en": "[Yagyuu Bugeichou]"
+          },
+          "spells": [
+            {
+              "spell_id": 8,
+              "spell_tag": "Serpents_Tongue",
+              "name": {
+                "ja": "サーペンツタン",
+                "en": "Serpent's Tongue"
+              },
+              "description": {
+                "ja": "毒耐性のないモンスターに大ダメージを与える。",
+                "en": "Attacks a monster with more damage unless it has resistance to poison."
+              }
+            },
+            {
+              "spell_id": 9,
+              "spell_tag": "Zammaken",
+              "name": {
+                "ja": "斬魔剣弐の太刀",
+                "en": "Zammaken"
+              },
+              "description": {
+                "ja": "生命のない邪悪なモンスターに大ダメージを与えるが、他のモンスターには全く効果がない。",
+                "en": "Attacks an evil unliving monster with great damage. Has no effect on other monsters."
+              }
+            },
+            {
+              "spell_id": 10,
+              "spell_tag": "Wind_Blast",
+              "name": {
+                "ja": "裂風剣",
+                "en": "Wind Blast"
+              },
+              "description": {
+                "ja": "攻撃した相手を後方へ吹き飛ばす。",
+                "en": "Attacks an adjacent monster and blows it away."
+              }
+            },
+            {
+              "spell_id": 11,
+              "spell_tag": "Judge",
+              "name": {
+                "ja": "刀匠の目利き",
+                "en": "Judge"
+              },
+              "description": {
+                "ja": "武器・防具を1つ識別する。レベル45以上で武器・防具の能力を完全に知ることができる。",
+                "en": "Identifies a weapon or armor. *Identifies* the item at level 45."
+              }
+            },
+            {
+              "spell_id": 12,
+              "spell_tag": "Rock_Smash",
+              "name": {
+                "ja": "破岩斬",
+                "en": "Rock Smash"
+              },
+              "description": {
+                "ja": "岩を壊し、岩石系のモンスターに大ダメージを与える。",
+                "en": "Breaks rock or greatly damages a monster made of rocks."
+              }
+            },
+            {
+              "spell_id": 13,
+              "spell_tag": "Midare-Setsugekka",
+              "name": {
+                "ja": "乱れ雪月花",
+                "en": "Midare-Setsugekka"
+              },
+              "description": {
+                "ja": "攻撃回数が増え、冷気耐性のないモンスターに大ダメージを与える。",
+                "en": "Attacks a monster with an increased number of attacks and more damage unless it has resistance to cold."
+              }
+            },
+            {
+              "spell_id": 14,
+              "spell_tag": "Spot_Aiming",
+              "name": {
+                "ja": "急所突き",
+                "en": "Spot Aiming"
+              },
+              "description": {
+                "ja": "モンスターを一撃で倒す攻撃を繰り出す。失敗すると1点しかダメージを与えられない。",
+                "en": "Attempts to kill a monster instantly. If that fails, causes only 1HP of damage."
+              }
+            },
+            {
+              "spell_id": 15,
+              "spell_tag": "Majingiri",
+              "name": {
+                "ja": "魔神斬り",
+                "en": "Majingiri"
+              },
+              "description": {
+                "ja": "会心の一撃で攻撃する。攻撃がかわされやすい。",
+                "en": "Attempts to attack with a critical hit, but this attack is easy to evade for a monster."
+              }
+            }
+          ]
+        },
+        {
+          "name": {
+            "ja": "[五輪書]",
+            "en": "[Gorinnosho]"
+          },
+          "spells": [
+            {
+              "spell_id": 16,
+              "spell_tag": "Desperate_Attack",
+              "name": {
+                "ja": "捨て身",
+                "en": "Desperate Attack"
+              },
+              "description": {
+                "ja": "強力な攻撃を繰り出す。次のターンまでの間、食らうダメージが増える。",
+                "en": "Attacks with all of your power, but all damage you take will be doubled for one turn."
+              }
+            },
+            {
+              "spell_id": 17,
+              "spell_tag": "Lightning_Eagle",
+              "name": {
+                "ja": "雷撃鷲爪斬",
+                "en": "Lightning Eagle"
+              },
+              "description": {
+                "ja": "電撃耐性のないモンスターに非常に大きいダメージを与える。",
+                "en": "Attacks a monster with more damage unless it has resistance to electricity."
+              }
+            },
+            {
+              "spell_id": 18,
+              "spell_tag": "Rush_Attack",
+              "name": {
+                "ja": "入身",
+                "en": "Rush Attack"
+              },
+              "description": {
+                "ja": "素早く相手に近寄り攻撃する。",
+                "en": "Steps close to a monster and attacks at the same time."
+              }
+            },
+            {
+              "spell_id": 19,
+              "spell_tag": "Bloody_Maelstrom",
+              "name": {
+                "ja": "赤流渦",
+                "en": "Bloody Maelstrom"
+              },
+              "description": {
+                "ja": "自分自身も傷を作りつつ、その傷が深いほど大きい威力で全方向の敵を攻撃できる。生きていないモンスターには効果がない。",
+                "en": "Attacks all adjacent monsters with power corresponding to your cuts. Then increases your cuts. Has no effect on unliving monsters."
+              }
+            },
+            {
+              "spell_id": 20,
+              "spell_tag": "Earthquake_Blow",
+              "name": {
+                "ja": "激震撃",
+                "en": "Earthquake Blow"
+              },
+              "description": {
+                "ja": "地震を起こす。",
+                "en": "Shakes dungeon structure, and results in random swapping of floors and walls."
+              }
+            },
+            {
+              "spell_id": 21,
+              "spell_tag": "Crack",
+              "name": {
+                "ja": "地走り",
+                "en": "Crack"
+              },
+              "description": {
+                "ja": "衝撃波のビームを放つ。",
+                "en": "Fires a shock wave as a beam."
+              }
+            },
+            {
+              "spell_id": 22,
+              "spell_tag": "War_Cry",
+              "name": {
+                "ja": "気迫の雄叫び",
+                "en": "War Cry"
+              },
+              "description": {
+                "ja": "視界内の全モンスターに対して轟音の攻撃を行う。さらに、近くにいるモンスターを怒らせる。",
+                "en": "Damages all monsters in sight with sound. Aggravates nearby monsters."
+              }
+            },
+            {
+              "spell_id": 23,
+              "spell_tag": "Musou-Sandan",
+              "name": {
+                "ja": "無双三段",
+                "en": "Musou-Sandan"
+              },
+              "description": {
+                "ja": "強力な3段攻撃を繰り出す。",
+                "en": "Attacks with three powerful strikes."
+              }
+            }
+          ]
+        },
+        {
+          "name": {
+            "ja": "[北辰一刀流皆伝]",
+            "en": "[Hokusin Ittouryuu Kaiden]"
+          },
+          "spells": [
+            {
+              "spell_id": 24,
+              "spell_tag": "Vampires_Fang",
+              "name": {
+                "ja": "吸血鬼の牙",
+                "en": "Vampire's Fang"
+              },
+              "description": {
+                "ja": "攻撃した相手の体力を吸いとり、自分の体力を回復させる。生命を持たないモンスターには通じない。",
+                "en": "Attacks with vampiric strikes which absorb HP from a monster and heal you. Has no effect on unliving monsters."
+              }
+            },
+            {
+              "spell_id": 25,
+              "spell_tag": "Moon_Dazzling",
+              "name": {
+                "ja": "幻惑",
+                "en": "Moon Dazzling"
+              },
+              "description": {
+                "ja": "視界内の起きている全モンスターに朦朧、混乱、眠りを与えようとする。",
+                "en": "Attempts to stun, confuse and put to sleep all waking monsters."
+              }
+            },
+            {
+              "spell_id": 26,
+              "spell_tag": "Hundred_Slaughter",
+              "name": {
+                "ja": "百人斬り",
+                "en": "Hundred Slaughter"
+              },
+              "description": {
+                "ja": "連続して入身でモンスターを攻撃する。攻撃するたびにMPを消費。MPがなくなるか、モンスターを倒せなかったら百人斬りは終了する。",
+                "en": "Performs a series of rush attacks. The series continues as long as the attacked monster dies and you have sufficient SP."
+              }
+            },
+            {
+              "spell_id": 27,
+              "spell_tag": "Dragonic_Flash",
+              "name": {
+                "ja": "天翔龍閃",
+                "en": "Dragonic Flash"
+              },
+              "description": {
+                "ja": "視界内の場所を指定して、その場所と自分の間にいる全モンスターを攻撃し、その場所に移動する。",
+                "en": "Runs toward given location while attacking all monsters on the path."
+              }
+            },
+            {
+              "spell_id": 28,
+              "spell_tag": "Twin_Slash",
+              "name": {
+                "ja": "二重の剣撃",
+                "en": "Twin Slash"
+              },
+              "description": {
+                "ja": "1ターンで2度攻撃を行う。",
+                "en": "Attack twice in one turn."
+              }
+            },
+            {
+              "spell_id": 29,
+              "spell_tag": "Kofuku-Zettousei",
+              "name": {
+                "ja": "虎伏絶刀勢",
+                "en": "Kofuku-Zettousei"
+              },
+              "description": {
+                "ja": "強力な攻撃を行い、近くの場所にも効果が及ぶ。",
+                "en": "Performs a powerful attack which even affects nearby monsters."
+              }
+            },
+            {
+              "spell_id": 30,
+              "spell_tag": "Keiun-Kininken",
+              "name": {
+                "ja": "慶雲鬼忍剣",
+                "en": "Keiun-Kininken"
+              },
+              "description": {
+                "ja": "自分もダメージをくらうが、相手に非常に大きなダメージを与える。アンデッドには特に効果がある。",
+                "en": "Attacks a monster with extremely powerful damage, but you also take some damage. Hurts an undead monster greatly."
+              }
+            },
+            {
+              "spell_id": 31,
+              "spell_tag": "Harakiri",
+              "name": {
+                "ja": "切腹",
+                "en": "Harakiri"
+              },
+              "description": {
+                "ja": "「武士道とは、死ぬことと見つけたり。」",
+                "en": "'Bushido, the way of warriors, is found in death'"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "HEX",
+      "books": [
+        {
+          "name": {
+            "ja": "[呪術入門]",
+            "en": "[Handbook of Hex]"
+          },
+          "spells": [
+            {
+              "spell_id": 0,
+              "spell_tag": "Evily_blessing",
+              "name": {
+                "ja": "邪なる祝福",
+                "en": "Evily blessing"
+              },
+              "description": {
+                "ja": "祝福により攻撃精度と防御力が上がる。",
+                "en": "Attempts to increase +to_hit of a weapon and AC"
+              }
+            },
+            {
+              "spell_id": 1,
+              "spell_tag": "Cure_light_wounds",
+              "name": {
+                "ja": "軽傷の治癒",
+                "en": "Cure light wounds"
+              },
+              "description": {
+                "ja": "HPや傷を少し回復させる。",
+                "en": "Heals cuts and HP a little."
+              }
+            },
+            {
+              "spell_id": 2,
+              "spell_tag": "Demonic_aura",
+              "name": {
+                "ja": "悪魔のオーラ",
+                "en": "Demonic aura"
+              },
+              "description": {
+                "ja": "炎のオーラを身にまとい、回復速度が速くなる。",
+                "en": "Gives fire aura and regeneration."
+              }
+            },
+            {
+              "spell_id": 3,
+              "spell_tag": "Stinking_mist",
+              "name": {
+                "ja": "悪臭霧",
+                "en": "Stinking mist"
+              },
+              "description": {
+                "ja": "視界内のモンスターに微弱量の毒のダメージを与える。",
+                "en": "Deals a little poison damage to all monsters in your sight."
+              }
+            },
+            {
+              "spell_id": 4,
+              "spell_tag": "Extra_might",
+              "name": {
+                "ja": "腕力強化",
+                "en": "Extra might"
+              },
+              "description": {
+                "ja": "術者の腕力を上昇させる。",
+                "en": "Attempts to increase your strength."
+              }
+            },
+            {
+              "spell_id": 5,
+              "spell_tag": "Curse weapon",
+              "name": {
+                "ja": "武器呪縛",
+                "en": "Curse weapon"
+              },
+              "description": {
+                "ja": "装備している武器を呪う。",
+                "en": "Curses your weapon."
+              }
+            },
+            {
+              "spell_id": 6,
+              "spell_tag": "Evil_detection",
+              "name": {
+                "ja": "邪悪感知",
+                "en": "Evil detection"
+              },
+              "description": {
+                "ja": "周囲の邪悪なモンスターを感知する。",
+                "en": "Detects evil monsters."
+              }
+            },
+            {
+              "spell_id": 7,
+              "spell_tag": "Patience",
+              "name": {
+                "ja": "我慢",
+                "en": "Patience"
+              },
+              "description": {
+                "ja": "数ターン攻撃を耐えた後、受けたダメージを地獄の業火として周囲に放出する。",
+                "en": "Bursts hell fire strongly after enduring damage for a few turns."
+              }
+            }
+          ]
+        },
+        {
+          "name": {
+            "ja": "[上級呪法]",
+            "en": "[High Curse]"
+          },
+          "spells": [
+            {
+              "spell_id": 8,
+              "spell_tag": "Armor_of_ice",
+              "name": {
+                "ja": "氷の鎧",
+                "en": "Armor of ice"
+              },
+              "description": {
+                "ja": "氷のオーラを身にまとい、防御力が上昇する。",
+                "en": "Surrounds you with an icy aura and gives a bonus to AC."
+              }
+            },
+            {
+              "spell_id": 9,
+              "spell_tag": "Cure_serious_wounds",
+              "name": {
+                "ja": "重傷の治癒",
+                "en": "Cure serious wounds"
+              },
+              "description": {
+                "ja": "体力や傷を多少回復させる。",
+                "en": "Heals cuts and HP."
+              }
+            },
+            {
+              "spell_id": 10,
+              "spell_tag": "Inhale_potion",
+              "name": {
+                "ja": "薬品吸入",
+                "en": "Inhale potion"
+              },
+              "description": {
+                "ja": "呪文詠唱を中止することなく、薬の効果を得ることができる。",
+                "en": "Quaffs a potion without canceling spell casting."
+              }
+            },
+            {
+              "spell_id": 11,
+              "spell_tag": "Hypodynamic_mist",
+              "name": {
+                "ja": "衰弱の霧",
+                "en": "Hypodynamic mist"
+              },
+              "description": {
+                "ja": "視界内のモンスターに微弱量の衰弱属性のダメージを与える。",
+                "en": "Deals a little life-draining damage to all monsters in your sight."
+              }
+            },
+            {
+              "spell_id": 12,
+              "spell_tag": "Swords_to_runeswords",
+              "name": {
+                "ja": "魔剣化",
+                "en": "Swords to runeswords"
+              },
+              "description": {
+                "ja": "武器の攻撃力を上げる。切れ味を得、呪いに応じて与えるダメージが上昇し、善良なモンスターに対するダメージが2倍になる。",
+                "en": "Gives vorpal ability to your weapon. Increases damage from your weapon acccording to curse of your weapon."
+              }
+            },
+            {
+              "spell_id": 13,
+              "spell_tag": "Touch_of_confusion",
+              "name": {
+                "ja": "混乱の手",
+                "en": "Touch of confusion"
+              },
+              "description": {
+                "ja": "攻撃した際モンスターを混乱させる。",
+                "en": "Confuses a monster when you attack."
+              }
+            },
+            {
+              "spell_id": 14,
+              "spell_tag": "Building_up",
+              "name": {
+                "ja": "肉体強化",
+                "en": "Building up"
+              },
+              "description": {
+                "ja": "術者の腕力、器用さ、耐久力を上昇させる。攻撃回数の上限を 1 増加させる。",
+                "en": "Attempts to increases your strength, dexterity and constitusion."
+              }
+            },
+            {
+              "spell_id": 15,
+              "spell_tag": "Anti_teleport_barrier",
+              "name": {
+                "ja": "反テレポート結界",
+                "en": "Anti teleport barrier"
+              },
+              "description": {
+                "ja": "視界内のモンスターのテレポートを阻害するバリアを張る。",
+                "en": "Obstructs all teleportations by monsters in your sight."
+              }
+            }
+          ]
+        },
+        {
+          "name": {
+            "ja": "[怨恨呪縛]",
+            "en": "[Curse and Spelling]"
+          },
+          "spells": [
+            {
+              "spell_id": 16,
+              "spell_tag": "Cloak_of_shock",
+              "name": {
+                "ja": "衝撃のクローク",
+                "en": "Cloak of shock"
+              },
+              "description": {
+                "ja": "電気のオーラを身にまとい、動きが速くなる。",
+                "en": "Gives lightning aura and a bonus to speed."
+              }
+            },
+            {
+              "spell_id": 17,
+              "spell_tag": "Cure_critical_wounds",
+              "name": {
+                "ja": "致命傷の治癒",
+                "en": "Cure critical wounds"
+              },
+              "description": {
+                "ja": "体力や傷を回復させる。",
+                "en": "Heals cuts and HP greatly."
+              }
+            },
+            {
+              "spell_id": 18,
+              "spell_tag": "Recharging",
+              "name": {
+                "ja": "呪力封入",
+                "en": "Recharging"
+              },
+              "description": {
+                "ja": "魔法の道具に魔力を再充填する。",
+                "en": "Recharges a magic device."
+              }
+            },
+            {
+              "spell_id": 19,
+              "spell_tag": "Animate_Dead",
+              "name": {
+                "ja": "死者復活",
+                "en": "Animate Dead"
+              },
+              "description": {
+                "ja": "死体を蘇らせてペットにする。",
+                "en": "Raises corpses and skeletons from dead."
+              }
+            },
+            {
+              "spell_id": 20,
+              "spell_tag": "Curse_armor",
+              "name": {
+                "ja": "防具呪縛",
+                "en": "Curse armor"
+              },
+              "description": {
+                "ja": "装備している防具に呪いをかける。",
+                "en": "Curse a piece of armour that you are wielding."
+              }
+            },
+            {
+              "spell_id": 21,
+              "spell_tag": "Cloak_of_shadow",
+              "name": {
+                "ja": "影のクローク",
+                "en": "Cloak of shadow"
+              },
+              "description": {
+                "ja": "影のオーラを身にまとい、敵に影のダメージを与える。",
+                "en": "Gives aura of shadow."
+              }
+            },
+            {
+              "spell_id": 22,
+              "spell_tag": "Pain_to_mana",
+              "name": {
+                "ja": "苦痛を魔力に",
+                "en": "Pain to mana"
+              },
+              "description": {
+                "ja": "視界内のモンスターに精神ダメージ与え、魔力を吸い取る。",
+                "en": "Deals psychic damage to all monsters in sight and drains some mana."
+              }
+            },
+            {
+              "spell_id": 23,
+              "spell_tag": "Eye_for_an_eye",
+              "name": {
+                "ja": "目には目を",
+                "en": "Eye for an eye"
+              },
+              "description": {
+                "ja": "打撃や魔法で受けたダメージを、攻撃元のモンスターにも与える。",
+                "en": "Returns same damage which you got to the monster which damaged you."
+              }
+            }
+          ]
+        },
+        {
+          "name": {
+            "ja": "[禁呪法大全]",
+            "en": "[Forbidden Cursebook]"
+          },
+          "spells": [
+            {
+              "spell_id": 24,
+              "spell_tag": "Anti_multiply_barrier",
+              "name": {
+                "ja": "反増殖結界",
+                "en": "Anti multiply barrier"
+              },
+              "description": {
+                "ja": "その階の増殖するモンスターの増殖を阻止する。",
+                "en": "Obstructs all multiplying by monsters on entire floor."
+              }
+            },
+            {
+              "spell_id": 25,
+              "spell_tag": "Restoration",
+              "name": {
+                "ja": "全復活",
+                "en": "Restoration"
+              },
+              "description": {
+                "ja": "経験値を徐々に復活し、減少した能力値を回復させる。",
+                "en": "Restores experience and status."
+              }
+            },
+            {
+              "spell_id": 26,
+              "spell_tag": "Drain_curse_power",
+              "name": {
+                "ja": "呪力吸収",
+                "en": "Drain curse power"
+              },
+              "description": {
+                "ja": "呪われた装備品の呪いを吸収して魔力を回復する。",
+                "en": "Drains curse on your equipment and heals SP a little."
+              }
+            },
+            {
+              "spell_id": 27,
+              "spell_tag": "Swords_to_vampires",
+              "name": {
+                "ja": "吸血の刃",
+                "en": "Swords to vampires"
+              },
+              "description": {
+                "ja": "吸血属性で攻撃する。",
+                "en": "Gives vampiric ability to your weapon."
+              }
+            },
+            {
+              "spell_id": 28,
+              "spell_tag": "Word_of_stun",
+              "name": {
+                "ja": "朦朧の言葉",
+                "en": "Word of stun"
+              },
+              "description": {
+                "ja": "視界内のモンスターを朦朧とさせる。",
+                "en": "Stuns all monsters in your sight."
+              }
+            },
+            {
+              "spell_id": 29,
+              "spell_tag": "Moving_into_shadow",
+              "name": {
+                "ja": "影移動",
+                "en": "Moving into shadow"
+              },
+              "description": {
+                "ja": "モンスターの隣のマスに瞬間移動する。",
+                "en": "Teleports you close to a monster."
+              }
+            },
+            {
+              "spell_id": 30,
+              "spell_tag": "Anti_magic_barrier",
+              "name": {
+                "ja": "反魔法結界",
+                "en": "Anti magic barrier"
+              },
+              "description": {
+                "ja": "視界内のモンスターの魔法を阻害するバリアを張る。",
+                "en": "Obstructs all magic spells of monsters in your sight."
+              }
+            },
+            {
+              "spell_id": 31,
+              "spell_tag": "Revenge_sentence",
+              "name": {
+                "ja": "復讐の宣告",
+                "en": "Revenge sentence"
+              },
+              "description": {
+                "ja": "数ターン後にそれまで受けたダメージに応じた威力の地獄の劫火の弾を放つ。",
+                "en": "Fires a ball of hell fire to try avenging damage from a few turns."
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/schema/SpellDefinitions.schema.json
+++ b/schema/SpellDefinitions.schema.json
@@ -31,7 +31,10 @@
                             "ARCANE",
                             "CRAFT",
                             "DEMON",
-                            "CRUSADE"
+                            "CRUSADE",
+                            "MUSIC",
+                            "HISSATSU",
+                            "HEX"
                         ]
                     },
                     "books": {

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -43,6 +43,7 @@
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
+#include "system/spell-info-list.h"
 #include "target/grid-selector.h"
 #include "target/target-getter.h"
 #include "term/screen-processor.h"
@@ -71,15 +72,19 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
     auto stop = mode == SpellProcessType::STOP;
     auto should_continue = true;
     int power;
+
+    auto &list = SpellInfoList::get_instance().spell_list[REALM_HEX];
+
+    if (name) {
+        return list[spell].name;
+    }
+    if (description) {
+        return list[spell].description;
+    }
+
     switch (spell) {
         /*** 1st book (0-7) ***/
     case HEX_BLESS:
-        if (name) {
-            return _("邪なる祝福", "Evily blessing");
-        }
-        if (description) {
-            return _("祝福により攻撃精度と防御力が上がる。", "Attempts to increase +to_hit of a weapon and AC");
-        }
         if (cast) {
             if (!player_ptr->blessed) {
                 msg_print(_("高潔な気分になった！", "You feel righteous!"));
@@ -93,12 +98,6 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         break;
 
     case HEX_CURE_LIGHT: {
-        if (name) {
-            return _("軽傷の治癒", "Cure light wounds");
-        }
-        if (description) {
-            return _("HPや傷を少し回復させる。", "Heals cuts and HP a little.");
-        }
         const Dice dice(1, 10);
         if (info) {
             return info_heal(dice, 0);
@@ -112,12 +111,6 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         break;
     }
     case HEX_DEMON_AURA: {
-        if (name) {
-            return _("悪魔のオーラ", "Demonic aura");
-        }
-        if (description) {
-            return _("炎のオーラを身にまとい、回復速度が速くなる。", "Gives fire aura and regeneration.");
-        }
         if (cast) {
             msg_print(_("体が炎のオーラで覆われた。", "You are enveloped by a fiery aura!"));
         }
@@ -127,12 +120,6 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         break;
     }
     case HEX_STINKING_MIST: {
-        if (name) {
-            return _("悪臭霧", "Stinking mist");
-        }
-        if (description) {
-            return _("視界内のモンスターに微弱量の毒のダメージを与える。", "Deals a little poison damage to all monsters in your sight.");
-        }
         const Dice dice(1, player_ptr->lev / 2 + 5);
         if (info) {
             return info_damage(dice);
@@ -143,26 +130,12 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         break;
     }
     case HEX_XTRA_MIGHT: {
-        if (name) {
-            return _("腕力強化", "Extra might");
-        }
-        if (description) {
-            return _("術者の腕力を上昇させる。", "Attempts to increase your strength.");
-        }
         if (cast) {
             msg_print(_("何だか力が湧いて来る。", "You feel stronger."));
         }
         break;
     }
     case HEX_CURSE_WEAPON: {
-        if (name) {
-            return _("武器呪縛", "Curse weapon");
-        }
-
-        if (description) {
-            return _("装備している武器を呪う。", "Curses your weapon.");
-        }
-
         if (cast) {
             constexpr auto q = _("どれを呪いますか？", "Which weapon do you curse?");
             constexpr auto s = _("武器を装備していない。", "You're not wielding a weapon.");
@@ -233,12 +206,6 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         break;
     }
     case HEX_DETECT_EVIL: {
-        if (name) {
-            return _("邪悪感知", "Evil detection");
-        }
-        if (description) {
-            return _("周囲の邪悪なモンスターを感知する。", "Detects evil monsters.");
-        }
         if (info) {
             return info_range(MAX_PLAYER_SIGHT);
         }
@@ -248,14 +215,6 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         break;
     }
     case HEX_PATIENCE: {
-        if (name) {
-            return _("我慢", "Patience");
-        }
-
-        if (description) {
-            return _("数ターン攻撃を耐えた後、受けたダメージを地獄の業火として周囲に放出する。", "Bursts hell fire strongly after enduring damage for a few turns.");
-        }
-
         SpellHex spell_hex(player_ptr);
         power = std::min(200, spell_hex.get_revenge_power() * 2);
         if (info) {
@@ -301,12 +260,6 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
 
         /*** 2nd book (8-15) ***/
     case HEX_ICE_ARMOR: {
-        if (name) {
-            return _("氷の鎧", "Armor of ice");
-        }
-        if (description) {
-            return _("氷のオーラを身にまとい、防御力が上昇する。", "Surrounds you with an icy aura and gives a bonus to AC.");
-        }
         if (cast) {
             msg_print(_("体が氷の鎧で覆われた。", "You are enveloped by icy armor!"));
         }
@@ -316,12 +269,6 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         break;
     }
     case HEX_CURE_SERIOUS: {
-        if (name) {
-            return _("重傷の治癒", "Cure serious wounds");
-        }
-        if (description) {
-            return _("体力や傷を多少回復させる。", "Heals cuts and HP.");
-        }
         const Dice dice(2, 10);
         if (info) {
             return info_heal(dice);
@@ -335,14 +282,6 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         break;
     }
     case HEX_INHALE: {
-        if (name) {
-            return _("薬品吸入", "Inhale potion");
-        }
-
-        if (description) {
-            return _("呪文詠唱を中止することなく、薬の効果を得ることができる。", "Quaffs a potion without canceling spell casting.");
-        }
-
         SpellHex spell_hex(player_ptr);
         if (cast) {
             spell_hex.set_casting_flag(HEX_INHALE);
@@ -354,12 +293,6 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         break;
     }
     case HEX_VAMP_MIST: {
-        if (name) {
-            return _("衰弱の霧", "Hypodynamic mist");
-        }
-        if (description) {
-            return _("視界内のモンスターに微弱量の衰弱属性のダメージを与える。", "Deals a little life-draining damage to all monsters in your sight.");
-        }
         const Dice dice(1, player_ptr->lev / 2 + 5);
         if (info) {
             return info_damage(dice);
@@ -370,13 +303,6 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         break;
     }
     case HEX_RUNESWORD: {
-        if (name) {
-            return _("魔剣化", "Swords to runeswords");
-        }
-        if (description) {
-            return _("武器の攻撃力を上げる。切れ味を得、呪いに応じて与えるダメージが上昇し、善良なモンスターに対するダメージが2倍になる。",
-                "Gives vorpal ability to your weapon. Increases damage from your weapon acccording to curse of your weapon.");
-        }
         if (cast) {
 #ifdef JP
             msg_print("あなたの武器が黒く輝いた。");
@@ -398,12 +324,6 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         break;
     }
     case HEX_CONFUSION: {
-        if (name) {
-            return _("混乱の手", "Touch of confusion");
-        }
-        if (description) {
-            return _("攻撃した際モンスターを混乱させる。", "Confuses a monster when you attack.");
-        }
         if (cast) {
             msg_print(_("あなたの手が赤く輝き始めた。", "Your hands glow bright red."));
         }
@@ -413,25 +333,12 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         break;
     }
     case HEX_BUILDING: {
-        if (name) {
-            return _("肉体強化", "Building up");
-        }
-        if (description) {
-            return _(
-                "術者の腕力、器用さ、耐久力を上昇させる。攻撃回数の上限を 1 増加させる。", "Attempts to increases your strength, dexterity and constitusion.");
-        }
         if (cast) {
             msg_print(_("身体が強くなった気がした。", "You feel your body is more developed now."));
         }
         break;
     }
     case HEX_ANTI_TELE: {
-        if (name) {
-            return _("反テレポート結界", "Anti teleport barrier");
-        }
-        if (description) {
-            return _("視界内のモンスターのテレポートを阻害するバリアを張る。", "Obstructs all teleportations by monsters in your sight.");
-        }
         power = player_ptr->lev * 3 / 2;
         if (info) {
             return info_power(power);
@@ -443,12 +350,6 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
     }
         /*** 3rd book (16-23) ***/
     case HEX_SHOCK_CLOAK: {
-        if (name) {
-            return _("衝撃のクローク", "Cloak of shock");
-        }
-        if (description) {
-            return _("電気のオーラを身にまとい、動きが速くなる。", "Gives lightning aura and a bonus to speed.");
-        }
         if (cast) {
             msg_print(_("体が稲妻のオーラで覆われた。", "You are enveloped by an electrical aura!"));
         }
@@ -458,12 +359,6 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         break;
     }
     case HEX_CURE_CRITICAL: {
-        if (name) {
-            return _("致命傷の治癒", "Cure critical wounds");
-        }
-        if (description) {
-            return _("体力や傷を回復させる。", "Heals cuts and HP greatly.");
-        }
         const Dice dice(4, 10);
         if (info) {
             return info_heal(dice);
@@ -477,12 +372,6 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         break;
     }
     case HEX_RECHARGE: {
-        if (name) {
-            return _("呪力封入", "Recharging");
-        }
-        if (description) {
-            return _("魔法の道具に魔力を再充填する。", "Recharges a magic device.");
-        }
         power = player_ptr->lev * 2;
         if (info) {
             return info_power(power);
@@ -496,12 +385,6 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         break;
     }
     case HEX_RAISE_DEAD: {
-        if (name) {
-            return _("死者復活", "Animate Dead");
-        }
-        if (description) {
-            return _("死体を蘇らせてペットにする。", "Raises corpses and skeletons from dead.");
-        }
         if (cast) {
             msg_print(_("死者への呼びかけを始めた。", "You start to call the dead.!"));
         }
@@ -511,12 +394,6 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         break;
     }
     case HEX_CURSE_ARMOUR: {
-        if (name) {
-            return _("防具呪縛", "Curse armor");
-        }
-        if (description) {
-            return _("装備している防具に呪いをかける。", "Curse a piece of armour that you are wielding.");
-        }
         if (cast) {
             constexpr auto q = _("どれを呪いますか？", "Which piece of armour do you curse?");
             constexpr auto s = _("防具を装備していない。", "You're not wearing any armor.");
@@ -589,12 +466,6 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         break;
     }
     case HEX_SHADOW_CLOAK: {
-        if (name) {
-            return _("影のクローク", "Cloak of shadow");
-        }
-        if (description) {
-            return _("影のオーラを身にまとい、敵に影のダメージを与える。", "Gives aura of shadow.");
-        }
         if (cast) {
             auto *o_ptr = &player_ptr->inventory_list[INVEN_OUTER];
 
@@ -626,12 +497,6 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         break;
     }
     case HEX_PAIN_TO_MANA: {
-        if (name) {
-            return _("苦痛を魔力に", "Pain to mana");
-        }
-        if (description) {
-            return _("視界内のモンスターに精神ダメージ与え、魔力を吸い取る。", "Deals psychic damage to all monsters in sight and drains some mana.");
-        }
         const Dice dice(1, player_ptr->lev * 3 / 2);
         if (info) {
             return info_damage(dice);
@@ -642,12 +507,6 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         break;
     }
     case HEX_EYE_FOR_EYE: {
-        if (name) {
-            return _("目には目を", "Eye for an eye");
-        }
-        if (description) {
-            return _("打撃や魔法で受けたダメージを、攻撃元のモンスターにも与える。", "Returns same damage which you got to the monster which damaged you.");
-        }
         if (cast) {
             msg_print(_("復讐したい欲望にかられた。", "You feel very vengeful."));
         }
@@ -655,24 +514,12 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
     }
         /*** 4th book (24-31) ***/
     case HEX_ANTI_MULTI: {
-        if (name) {
-            return _("反増殖結界", "Anti multiply barrier");
-        }
-        if (description) {
-            return _("その階の増殖するモンスターの増殖を阻止する。", "Obstructs all multiplying by monsters on entire floor.");
-        }
         if (cast) {
             msg_print(_("増殖を阻止する呪いをかけた。", "You feel anyone can not multiply."));
         }
         break;
     }
     case HEX_RESTORE: {
-        if (name) {
-            return _("全復活", "Restoration");
-        }
-        if (description) {
-            return _("経験値を徐々に復活し、減少した能力値を回復させる。", "Restores experience and status.");
-        }
         if (cast) {
             msg_print(_("体が元の活力を取り戻し始めた。", "You feel your lost status starting to return."));
         }
@@ -736,12 +583,6 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         break;
     }
     case HEX_DRAIN_CURSE: {
-        if (name) {
-            return _("呪力吸収", "Drain curse power");
-        }
-        if (description) {
-            return _("呪われた装備品の呪いを吸収して魔力を回復する。", "Drains curse on your equipment and heals SP a little.");
-        }
         if (cast) {
             constexpr auto q = _("どの装備品から吸収しますか？", "Which cursed equipment do you drain mana from?");
             constexpr auto s = _("呪われたアイテムを装備していない。", "You have no cursed equipment.");
@@ -776,12 +617,6 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         break;
     }
     case HEX_VAMP_BLADE: {
-        if (name) {
-            return _("吸血の刃", "Swords to vampires");
-        }
-        if (description) {
-            return _("吸血属性で攻撃する。", "Gives vampiric ability to your weapon.");
-        }
         if (cast) {
 #ifdef JP
             msg_print("あなたの武器が血を欲している。");
@@ -803,12 +638,6 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         break;
     }
     case HEX_STUN_MONSTERS: {
-        if (name) {
-            return _("朦朧の言葉", "Word of stun");
-        }
-        if (description) {
-            return _("視界内のモンスターを朦朧とさせる。", "Stuns all monsters in your sight.");
-        }
         power = player_ptr->lev * 4;
         if (info) {
             return info_power(power);
@@ -819,12 +648,6 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         break;
     }
     case HEX_SHADOW_MOVE: {
-        if (name) {
-            return _("影移動", "Moving into shadow");
-        }
-        if (description) {
-            return _("モンスターの隣のマスに瞬間移動する。", "Teleports you close to a monster.");
-        }
         if (cast) {
             int i, dir;
             POSITION y, x;
@@ -869,12 +692,6 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         break;
     }
     case HEX_ANTI_MAGIC: {
-        if (name) {
-            return _("反魔法結界", "Anti magic barrier");
-        }
-        if (description) {
-            return _("視界内のモンスターの魔法を阻害するバリアを張る。", "Obstructs all magic spells of monsters in your sight.");
-        }
         power = player_ptr->lev * 3 / 2;
         if (info) {
             return info_power(power);
@@ -885,14 +702,6 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         break;
     }
     case HEX_REVENGE: {
-        if (name) {
-            return _("復讐の宣告", "Revenge sentence");
-        }
-
-        if (description) {
-            return _("数ターン後にそれまで受けたダメージに応じた威力の地獄の劫火の弾を放つ。", "Fires a ball of hell fire to try avenging damage from a few turns.");
-        }
-
         SpellHex spell_hex(player_ptr);
         power = spell_hex.get_revenge_power();
         if (info) {

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -46,6 +46,7 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
+#include "system/spell-info-list.h"
 #include "target/grid-selector.h"
 #include "target/projection-path-calculator.h"
 #include "target/target-getter.h"
@@ -70,15 +71,17 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
 
     PLAYER_LEVEL plev = player_ptr->lev;
 
+    auto &list = SpellInfoList::get_instance().spell_list[REALM_HISSATSU];
+
+    if (name) {
+        return list[spell_id].name;
+    }
+    if (desc) {
+        return list[spell_id].description;
+    }
+
     switch (spell_id) {
     case 0:
-        if (name) {
-            return _("飛飯綱", "Tobi-Izuna");
-        }
-        if (desc) {
-            return _("2マス離れたところにいるモンスターを攻撃する。", "Attacks a monster two squares away.");
-        }
-
         if (cast) {
             project_length = 2;
             int dir;
@@ -91,13 +94,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 1:
-        if (name) {
-            return _("五月雨斬り", "3-Way Attack");
-        }
-        if (desc) {
-            return _("3方向に対して攻撃する。", "Attacks in 3 directions at one time.");
-        }
-
         if (cast) {
             const auto cdir = get_direction_as_cdir(player_ptr);
             if (!cdir) {
@@ -122,14 +118,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 2:
-        if (name) {
-            return _("ブーメラン", "Boomerang");
-        }
-        if (desc) {
-            return _(
-                "武器を手元に戻ってくるように投げる。戻ってこないこともある。", "Throws current weapon. It'll return to your hand unless the action failed.");
-        }
-
         if (cast) {
             if (!ThrowCommand(player_ptr).do_cmd_throw(1, true, -1)) {
                 return std::nullopt;
@@ -138,13 +126,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 3:
-        if (name) {
-            return _("焔霊", "Burning Strike");
-        }
-        if (desc) {
-            return _("火炎耐性のないモンスターに大ダメージを与える。", "Attacks a monster with more damage unless it has resistance to fire.");
-        }
-
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir || (dir == 5)) {
@@ -162,26 +143,12 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 4:
-        if (name) {
-            return _("殺気感知", "Detect Ferocity");
-        }
-        if (desc) {
-            return _("近くの思考することができるモンスターを感知する。", "Detects all monsters except the mindless in your vicinity.");
-        }
-
         if (cast) {
             detect_monsters_mind(player_ptr, DETECT_RAD_DEFAULT);
         }
         break;
 
     case 5:
-        if (name) {
-            return _("みね打ち", "Strike to Stun");
-        }
-        if (desc) {
-            return _("相手にダメージを与えないが、朦朧とさせる。", "Attempts to stun a monster next to you.");
-        }
-
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir || (dir == 5)) {
@@ -199,14 +166,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 6:
-        if (name) {
-            return _("カウンター", "Counter");
-        }
-        if (desc) {
-            return _("相手に攻撃されたときに反撃する。反撃するたびにMPを消費。",
-                "Prepares to counterattack. When attacked by a monster, strikes back using SP each time.");
-        }
-
         if (cast) {
             if (player_ptr->riding) {
                 msg_print(_("乗馬中には無理だ。", "You cannot do it when riding."));
@@ -218,14 +177,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 7:
-        if (name) {
-            return _("払い抜け", "Harainuke");
-        }
-        if (desc) {
-            return _("攻撃した後、反対側に抜ける。",
-                "In one action, attacks a monster with your weapons normally and then moves to the space beyond the monster if that space is not blocked.");
-        }
-
         if (cast) {
             if (player_ptr->riding) {
                 msg_print(_("乗馬中には無理だ。", "You cannot do it when riding."));
@@ -260,13 +211,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 8:
-        if (name) {
-            return _("サーペンツタン", "Serpent's Tongue");
-        }
-        if (desc) {
-            return _("毒耐性のないモンスターに大ダメージを与える。", "Attacks a monster with more damage unless it has resistance to poison.");
-        }
-
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir || (dir == 5)) {
@@ -285,14 +229,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 9:
-        if (name) {
-            return _("斬魔剣弐の太刀", "Zammaken");
-        }
-        if (desc) {
-            return _("生命のない邪悪なモンスターに大ダメージを与えるが、他のモンスターには全く効果がない。",
-                "Attacks an evil unliving monster with great damage. Has no effect on other monsters.");
-        }
-
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir || (dir == 5)) {
@@ -311,13 +247,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 10:
-        if (name) {
-            return _("裂風剣", "Wind Blast");
-        }
-        if (desc) {
-            return _("攻撃した相手を後方へ吹き飛ばす。", "Attacks an adjacent monster and blows it away.");
-        }
-
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir || (dir == 5)) {
@@ -372,14 +301,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 11:
-        if (name) {
-            return _("刀匠の目利き", "Judge");
-        }
-        if (desc) {
-            return _("武器・防具を1つ識別する。レベル45以上で武器・防具の能力を完全に知ることができる。",
-                "Identifies a weapon or armor. *Identifies* the item at level 45.");
-        }
-
         if (cast) {
             if (plev > 44) {
                 if (!identify_fully(player_ptr, true)) {
@@ -394,13 +315,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 12:
-        if (name) {
-            return _("破岩斬", "Rock Smash");
-        }
-        if (desc) {
-            return _("岩を壊し、岩石系のモンスターに大ダメージを与える。", "Breaks rock or greatly damages a monster made of rocks.");
-        }
-
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir || (dir == 5)) {
@@ -424,14 +338,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 13:
-        if (name) {
-            return _("乱れ雪月花", "Midare-Setsugekka");
-        }
-        if (desc) {
-            return _("攻撃回数が増え、冷気耐性のないモンスターに大ダメージを与える。",
-                "Attacks a monster with an increased number of attacks and more damage unless it has resistance to cold.");
-        }
-
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir || (dir == 5)) {
@@ -450,14 +356,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 14:
-        if (name) {
-            return _("急所突き", "Spot Aiming");
-        }
-        if (desc) {
-            return _("モンスターを一撃で倒す攻撃を繰り出す。失敗すると1点しかダメージを与えられない。",
-                "Attempts to kill a monster instantly. If that fails, causes only 1HP of damage.");
-        }
-
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir || (dir == 5)) {
@@ -476,13 +374,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 15:
-        if (name) {
-            return _("魔神斬り", "Majingiri");
-        }
-        if (desc) {
-            return _("会心の一撃で攻撃する。攻撃がかわされやすい。", "Attempts to attack with a critical hit, but this attack is easy to evade for a monster.");
-        }
-
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir || (dir == 5)) {
@@ -501,14 +392,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 16:
-        if (name) {
-            return _("捨て身", "Desperate Attack");
-        }
-        if (desc) {
-            return _("強力な攻撃を繰り出す。次のターンまでの間、食らうダメージが増える。",
-                "Attacks with all of your power, but all damage you take will be doubled for one turn.");
-        }
-
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir || (dir == 5)) {
@@ -528,13 +411,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 17:
-        if (name) {
-            return _("雷撃鷲爪斬", "Lightning Eagle");
-        }
-        if (desc) {
-            return _("電撃耐性のないモンスターに非常に大きいダメージを与える。", "Attacks a monster with more damage unless it has resistance to electricity.");
-        }
-
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir || (dir == 5)) {
@@ -553,13 +429,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 18:
-        if (name) {
-            return _("入身", "Rush Attack");
-        }
-        if (desc) {
-            return _("素早く相手に近寄り攻撃する。", "Steps close to a monster and attacks at the same time.");
-        }
-
         if (cast) {
             if (!rush_attack(player_ptr, nullptr)) {
                 return std::nullopt;
@@ -568,15 +437,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 19:
-        if (name) {
-            return _("赤流渦", "Bloody Maelstrom");
-        }
-
-        if (desc) {
-            return _("自分自身も傷を作りつつ、その傷が深いほど大きい威力で全方向の敵を攻撃できる。生きていないモンスターには効果がない。",
-                "Attacks all adjacent monsters with power corresponding to your cuts. Then increases your cuts. Has no effect on unliving monsters.");
-        }
-
         if (cast) {
             const auto current_cut = player_ptr->effects()->cut().current();
             short new_cut = current_cut < 300 ? current_cut + 300 : current_cut * 2;
@@ -603,13 +463,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
 
         break;
     case 20:
-        if (name) {
-            return _("激震撃", "Earthquake Blow");
-        }
-        if (desc) {
-            return _("地震を起こす。", "Shakes dungeon structure, and results in random swapping of floors and walls.");
-        }
-
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir || (dir == 5)) {
@@ -627,13 +480,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 21:
-        if (name) {
-            return _("地走り", "Crack");
-        }
-        if (desc) {
-            return _("衝撃波のビームを放つ。", "Fires a shock wave as a beam.");
-        }
-
         if (cast) {
             int total_damage = 0, basedam, i;
             ItemEntity *o_ptr;
@@ -674,14 +520,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 22:
-        if (name) {
-            return _("気迫の雄叫び", "War Cry");
-        }
-        if (desc) {
-            return _("視界内の全モンスターに対して轟音の攻撃を行う。さらに、近くにいるモンスターを怒らせる。",
-                "Damages all monsters in sight with sound. Aggravates nearby monsters.");
-        }
-
         if (cast) {
             msg_print(_("雄叫びをあげた！", "You roar!"));
             project_all_los(player_ptr, AttributeType::SOUND, randint1(plev * 3));
@@ -690,13 +528,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 23:
-        if (name) {
-            return _("無双三段", "Musou-Sandan");
-        }
-        if (desc) {
-            return _("強力な3段攻撃を繰り出す。", "Attacks with three powerful strikes.");
-        }
-
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir || (dir == 5)) {
@@ -768,14 +599,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 24:
-        if (name) {
-            return _("吸血鬼の牙", "Vampire's Fang");
-        }
-        if (desc) {
-            return _("攻撃した相手の体力を吸いとり、自分の体力を回復させる。生命を持たないモンスターには通じない。",
-                "Attacks with vampiric strikes which absorb HP from a monster and heal you. Has no effect on unliving monsters.");
-        }
-
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir || (dir == 5)) {
@@ -794,13 +617,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 25:
-        if (name) {
-            return _("幻惑", "Moon Dazzling");
-        }
-        if (desc) {
-            return _("視界内の起きている全モンスターに朦朧、混乱、眠りを与えようとする。", "Attempts to stun, confuse and put to sleep all waking monsters.");
-        }
-
         if (cast) {
             msg_print(_("武器を不規則に揺らした．．．", "You irregularly wave your weapon..."));
             project_all_los(player_ptr, AttributeType::ENGETSU, plev * 4);
@@ -808,14 +624,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 26:
-        if (name) {
-            return _("百人斬り", "Hundred Slaughter");
-        }
-        if (desc) {
-            return _("連続して入身でモンスターを攻撃する。攻撃するたびにMPを消費。MPがなくなるか、モンスターを倒せなかったら百人斬りは終了する。",
-                "Performs a series of rush attacks. The series continues as long as the attacked monster dies and you have sufficient SP.");
-        }
-
         if (cast) {
             const int mana_cost_per_monster = 8;
             bool is_new = true;
@@ -853,14 +661,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 27:
-        if (name) {
-            return _("天翔龍閃", "Dragonic Flash");
-        }
-        if (desc) {
-            return _("視界内の場所を指定して、その場所と自分の間にいる全モンスターを攻撃し、その場所に移動する。",
-                "Runs toward given location while attacking all monsters on the path.");
-        }
-
         if (cast) {
             POSITION y, x;
 
@@ -884,13 +684,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 28:
-        if (name) {
-            return _("二重の剣撃", "Twin Slash");
-        }
-        if (desc) {
-            return _("1ターンで2度攻撃を行う。", "Attack twice in one turn.");
-        }
-
         if (cast) {
             int dir;
             if (!get_rep_dir(player_ptr, &dir)) {
@@ -913,13 +706,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 29:
-        if (name) {
-            return _("虎伏絶刀勢", "Kofuku-Zettousei");
-        }
-        if (desc) {
-            return _("強力な攻撃を行い、近くの場所にも効果が及ぶ。", "Performs a powerful attack which even affects nearby monsters.");
-        }
-
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir || (dir == 5)) {
@@ -967,14 +753,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 30:
-        if (name) {
-            return _("慶雲鬼忍剣", "Keiun-Kininken");
-        }
-        if (desc) {
-            return _("自分もダメージをくらうが、相手に非常に大きなダメージを与える。アンデッドには特に効果がある。",
-                "Attacks a monster with extremely powerful damage, but you also take some damage. Hurts an undead monster greatly.");
-        }
-
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir || (dir == 5)) {
@@ -994,13 +772,6 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         break;
 
     case 31:
-        if (name) {
-            return _("切腹", "Harakiri");
-        }
-        if (desc) {
-            return _("「武士道とは、死ぬことと見つけたり。」", "'Bushido, the way of warriors, is found in death'");
-        }
-
         if (cast) {
             int i;
             if (!input_check(_("本当に自殺しますか？", "Do you really want to commit suicide? "))) {

--- a/src/realm/realm-song.cpp
+++ b/src/realm/realm-song.cpp
@@ -23,6 +23,7 @@
 #include "status/experience.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
+#include "system/spell-info-list.h"
 #include "target/target-getter.h"
 #include "timed-effect/timed-effects.h"
 #include "util/dice.h"
@@ -71,15 +72,17 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
     DIRECTION dir;
     PLAYER_LEVEL plev = player_ptr->lev;
 
+    auto &list = SpellInfoList::get_instance().spell_list[REALM_MUSIC];
+
+    if (name) {
+        return list[spell].name;
+    }
+    if (desc) {
+        return list[spell].description;
+    }
+
     switch (spell) {
     case 0:
-        if (name) {
-            return _("遅鈍の歌", "Song of Holding");
-        }
-        if (desc) {
-            return _("視界内の全てのモンスターを減速させる。抵抗されると無効。", "Attempts to slow all monsters in sight.");
-        }
-
         /* Stop singing before start another */
         if (cast || fail) {
             stop_singing(player_ptr);
@@ -104,13 +107,6 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
         break;
 
     case 1:
-        if (name) {
-            return _("祝福の歌", "Song of Blessing");
-        }
-        if (desc) {
-            return _("命中率とACのボーナスを得る。", "Gives a bonus to hit and AC for a few turns.");
-        }
-
         /* Stop singing before start another */
         if (cast || fail) {
             stop_singing(player_ptr);
@@ -130,13 +126,6 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
         break;
 
     case 2:
-        if (name) {
-            return _("崩壊の音色", "Wrecking Note");
-        }
-        if (desc) {
-            return _("轟音のボルトを放つ。", "Fires a bolt of sound.");
-        }
-
         /* Stop singing before start another */
         if (cast || fail) {
             stop_singing(player_ptr);
@@ -160,13 +149,6 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
         break;
 
     case 3:
-        if (name) {
-            return _("朦朧の旋律", "Stun Pattern");
-        }
-        if (desc) {
-            return _("視界内の全てのモンスターを朦朧させる。抵抗されると無効。", "Attempts to stun all monsters in sight.");
-        }
-
         /* Stop singing before start another */
         if (cast || fail) {
             stop_singing(player_ptr);
@@ -192,13 +174,6 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
         break;
 
     case 4:
-        if (name) {
-            return _("生命の流れ", "Flow of Life");
-        }
-        if (desc) {
-            return _("体力を少し回復させる。", "Heals HP a little.");
-        }
-
         /* Stop singing before start another */
         if (cast || fail) {
             stop_singing(player_ptr);
@@ -224,13 +199,6 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
         break;
 
     case 5:
-        if (name) {
-            return _("太陽の歌", "Song of the Sun");
-        }
-        if (desc) {
-            return _("光源が照らしている範囲か部屋全体を永久に明るくする。", "Lights up nearby area and the inside of a room permanently.");
-        }
-
         /* Stop singing before start another */
         if (cast || fail) {
             stop_singing(player_ptr);
@@ -252,13 +220,6 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
         break;
 
     case 6:
-        if (name) {
-            return _("恐怖の歌", "Song of Fear");
-        }
-        if (desc) {
-            return _("視界内の全てのモンスターを恐怖させる。抵抗されると無効。", "Attempts to scare all monsters in sight.");
-        }
-
         /* Stop singing before start another */
         if (cast || fail) {
             stop_singing(player_ptr);
@@ -284,14 +245,6 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
         break;
 
     case 7:
-        if (name) {
-            return _("戦いの歌", "Heroic Ballad");
-        }
-
-        if (desc) {
-            return _("ヒーロー気分になる。", "Removes fear. Gives a bonus to hit for a while. Heals you for 10 HP.");
-        }
-
         if (cast || fail) {
             stop_singing(player_ptr);
         }
@@ -314,17 +267,6 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
 
         break;
     case 8:
-        if (name) {
-            return _("霊的知覚", "Clairaudience");
-        }
-        if (desc) {
-            return _("近くの罠/扉/"
-                     "階段を感知する。レベル15で全てのモンスター、20で財宝とアイテムを感知できるようになる。レベル25で周辺の地形を感知し、40でその階全体を永久"
-                     "に照らし、ダンジョン内のすべてのアイテムを感知する。この効果は歌い続けることで順に起こる。",
-                "Detects traps, doors and stairs in your vicinity. And detects all monsters at level 15, treasures and items at level 20. Maps nearby area at "
-                "level 25. Lights and know the whole level at level 40. These effects accumulate as the song continues.");
-        }
-
         /* Stop singing before start another */
         if (cast || fail) {
             stop_singing(player_ptr);
@@ -387,13 +329,6 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
         break;
 
     case 9:
-        if (name) {
-            return _("魂の歌", "Soul Shriek");
-        }
-        if (desc) {
-            return _("視界内の全てのモンスターに対して精神攻撃を行う。", "Damages all monsters in sight with PSI damages.");
-        }
-
         /* Stop singing before start another */
         if (cast || fail) {
             stop_singing(player_ptr);
@@ -419,13 +354,6 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
         break;
 
     case 10:
-        if (name) {
-            return _("知識の歌", "Song of Lore");
-        }
-        if (desc) {
-            return _("自分のいるマスと隣りのマスに落ちているアイテムを鑑定する。", "Identifies all items which are in the adjacent squares.");
-        }
-
         /* Stop singing before start another */
         if (cast || fail) {
             stop_singing(player_ptr);
@@ -455,13 +383,6 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
         break;
 
     case 11:
-        if (name) {
-            return _("隠遁の歌", "Hiding Tune");
-        }
-        if (desc) {
-            return _("隠密行動能力を上昇させる。", "Gives improved stealth.");
-        }
-
         /* Stop singing before start another */
         if (cast || fail) {
             stop_singing(player_ptr);
@@ -481,13 +402,6 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
         break;
 
     case 12:
-        if (name) {
-            return _("幻影の旋律", "Illusion Pattern");
-        }
-        if (desc) {
-            return _("視界内の全てのモンスターを混乱させる。抵抗されると無効。", "Attempts to confuse all monsters in sight.");
-        }
-
         /* Stop singing before start another */
         if (cast || fail) {
             stop_singing(player_ptr);
@@ -513,13 +427,6 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
         break;
 
     case 13:
-        if (name) {
-            return _("破滅の叫び", "Doomcall");
-        }
-        if (desc) {
-            return _("視界内の全てのモンスターに対して轟音攻撃を行う。", "Damages all monsters in sight with booming sound.");
-        }
-
         /* Stop singing before start another */
         if (cast || fail) {
             stop_singing(player_ptr);
@@ -544,35 +451,19 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
 
         break;
 
-    case 14:
-        if (name) {
-            return _("フィリエルの歌", "Firiel's Song");
-        }
-        if (desc) {
-            return _("周囲の死体や骨を生き返す。", "Resurrects nearby corpses and skeletons. And makes them your pets.");
+    case 14: {
+        /* Stop singing before start another */
+        if (cast || fail) {
+            stop_singing(player_ptr);
         }
 
-        {
-            /* Stop singing before start another */
-            if (cast || fail) {
-                stop_singing(player_ptr);
-            }
-
-            if (cast) {
-                msg_print(_("生命と復活のテーマを奏で始めた．．．", "The themes of life and revival are woven into your song..."));
-                animate_dead(player_ptr, 0, player_ptr->y, player_ptr->x);
-            }
+        if (cast) {
+            msg_print(_("生命と復活のテーマを奏で始めた．．．", "The themes of life and revival are woven into your song..."));
+            animate_dead(player_ptr, 0, player_ptr->y, player_ptr->x);
         }
-        break;
+    } break;
 
     case 15:
-        if (name) {
-            return _("旅の仲間", "Fellowship Chant");
-        }
-        if (desc) {
-            return _("視界内の全てのモンスターを魅了する。抵抗されると無効。", "Attempts to charm all monsters in sight.");
-        }
-
         /* Stop singing before start another */
         if (cast || fail) {
             stop_singing(player_ptr);
@@ -598,13 +489,6 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
         break;
 
     case 16:
-        if (name) {
-            return _("フルゥの行進曲", "Hru's March");
-        }
-        if (desc) {
-            return _("壁を掘り進む。自分の足元のアイテムは蒸発する。", "Makes you be able to burrow into walls. Objects under your feet evaporate.");
-        }
-
         /* Stop singing before start another */
         if (cast || fail) {
             stop_singing(player_ptr);
@@ -627,15 +511,6 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
         break;
 
     case 17:
-        if (name) {
-            return _("フィンロドの護り", "Finrod's Resistance");
-        }
-        if (desc) {
-            return _("酸、電撃、炎、冷気、毒に対する耐性を得る。装備による耐性に累積する。",
-                "Gives resistance to fire, cold, electricity, acid and poison. These resistances can be added to those from equipment for more powerful "
-                "resistances.");
-        }
-
         /* Stop singing before start another */
         if (cast || fail) {
             stop_singing(player_ptr);
@@ -671,13 +546,6 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
         break;
 
     case 18:
-        if (name) {
-            return _("ホビットのメロディ", "Hobbit Melodies");
-        }
-        if (desc) {
-            return _("加速する。", "Hastes you.");
-        }
-
         /* Stop singing before start another */
         if (cast || fail) {
             stop_singing(player_ptr);
@@ -696,43 +564,26 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
 
         break;
 
-    case 19:
-        if (name) {
-            return _("歪んだ世界", "World Contortion");
+    case 19: {
+        POSITION rad = plev / 15 + 1;
+        POWER power = plev * 3 + 1;
+
+        if (info) {
+            return info_radius(rad);
         }
-        if (desc) {
-            return _("近くのモンスターをテレポートさせる。抵抗されると無効。", "Teleports all nearby monsters away unless resisted.");
+
+        /* Stop singing before start another */
+        if (cast || fail) {
+            stop_singing(player_ptr);
         }
 
-        {
-            POSITION rad = plev / 15 + 1;
-            POWER power = plev * 3 + 1;
-
-            if (info) {
-                return info_radius(rad);
-            }
-
-            /* Stop singing before start another */
-            if (cast || fail) {
-                stop_singing(player_ptr);
-            }
-
-            if (cast) {
-                msg_print(_("歌が空間を歪めた．．．", "Reality whirls wildly as you sing a dizzying melody..."));
-                project(player_ptr, 0, rad, player_ptr->y, player_ptr->x, power, AttributeType::AWAY_ALL, PROJECT_KILL);
-            }
+        if (cast) {
+            msg_print(_("歌が空間を歪めた．．．", "Reality whirls wildly as you sing a dizzying melody..."));
+            project(player_ptr, 0, rad, player_ptr->y, player_ptr->x, power, AttributeType::AWAY_ALL, PROJECT_KILL);
         }
-        break;
+    } break;
 
     case 20:
-        if (name) {
-            return _("退散の歌", "Dispelling Chant");
-        }
-        if (desc) {
-            return _("視界内の全てのモンスターにダメージを与える。邪悪なモンスターに特に大きなダメージを与える。",
-                "Damages all monsters in sight. Hurts evil monsters greatly.");
-        }
-
         /* Stop singing before start another */
         if (cast || fail) {
             stop_singing(player_ptr);
@@ -759,13 +610,6 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
         break;
 
     case 21:
-        if (name) {
-            return _("サルマンの甘言", "The Voice of Saruman");
-        }
-        if (desc) {
-            return _("視界内の全てのモンスターを減速させ、眠らせようとする。抵抗されると無効。", "Attempts to slow and put to sleep all monsters in sight.");
-        }
-
         /* Stop singing before start another */
         if (cast || fail) {
             stop_singing(player_ptr);
@@ -791,73 +635,47 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
 
         break;
 
-    case 22:
-        if (name) {
-            return _("嵐の音色", "Song of the Tempest");
-        }
-        if (desc) {
-            return _("轟音のビームを放つ。", "Fires a beam of sound.");
-        }
+    case 22: {
+        const Dice dice(15 + (plev - 1) / 2, 10);
 
-        {
-            const Dice dice(15 + (plev - 1) / 2, 10);
-
-            if (info) {
-                return info_damage(dice);
-            }
-
-            /* Stop singing before start another */
-            if (cast || fail) {
-                stop_singing(player_ptr);
-            }
-
-            if (cast) {
-                if (!get_aim_dir(player_ptr, &dir)) {
-                    return std::nullopt;
-                }
-
-                fire_beam(player_ptr, AttributeType::SOUND, dir, dice.roll());
-            }
-        }
-        break;
-
-    case 23:
-        if (name) {
-            return _("もう一つの世界", "Ambarkanta");
-        }
-        if (desc) {
-            return _("現在の階を再構成する。", "Recreates current dungeon level.");
+        if (info) {
+            return info_damage(dice);
         }
 
-        {
-            int base = 15;
-            const Dice dice(1, 20);
-
-            if (info) {
-                return info_delay(base, dice);
-            }
-
-            /* Stop singing before start another */
-            if (cast || fail) {
-                stop_singing(player_ptr);
-            }
-
-            if (cast) {
-                msg_print(_("周囲が変化し始めた．．．", "You sing of the primeval shaping of Middle-earth..."));
-                reserve_alter_reality(player_ptr, dice.roll() + base);
-            }
+        /* Stop singing before start another */
+        if (cast || fail) {
+            stop_singing(player_ptr);
         }
-        break;
+
+        if (cast) {
+            if (!get_aim_dir(player_ptr, &dir)) {
+                return std::nullopt;
+            }
+
+            fire_beam(player_ptr, AttributeType::SOUND, dir, dice.roll());
+        }
+    } break;
+
+    case 23: {
+        int base = 15;
+        const Dice dice(1, 20);
+
+        if (info) {
+            return info_delay(base, dice);
+        }
+
+        /* Stop singing before start another */
+        if (cast || fail) {
+            stop_singing(player_ptr);
+        }
+
+        if (cast) {
+            msg_print(_("周囲が変化し始めた．．．", "You sing of the primeval shaping of Middle-earth..."));
+            reserve_alter_reality(player_ptr, dice.roll() + base);
+        }
+    } break;
 
     case 24:
-        if (name) {
-            return _("破壊の旋律", "Wrecking Pattern");
-        }
-        if (desc) {
-            return _(
-                "周囲のダンジョンを揺らし、壁と床をランダムに入れ変える。", "Shakes dungeon structure, and results in random swapping of floors and walls.");
-        }
-
         /* Stop singing before start another */
         if (cast || fail) {
             stop_singing(player_ptr);
@@ -883,13 +701,6 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
         break;
 
     case 25:
-        if (name) {
-            return _("停滞の歌", "Stationary Shriek");
-        }
-        if (desc) {
-            return _("視界内の全てのモンスターを麻痺させようとする。抵抗されると無効。", "Attempts to freeze all monsters in sight.");
-        }
-
         /* Stop singing before start another */
         if (cast || fail) {
             stop_singing(player_ptr);
@@ -914,36 +725,19 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
 
         break;
 
-    case 26:
-        if (name) {
-            return _("エルベレスの聖歌", "Elbereth's Chant");
-        }
-        if (desc) {
-            return _("自分のいる床の上に、モンスターが通り抜けたり召喚されたりすることができなくなるルーンを描く。",
-                "Sets a rune on the floor beneath you. If you are on a rune, monsters cannot attack you but can try to break the rune.");
+    case 26: {
+        /* Stop singing before start another */
+        if (cast || fail) {
+            stop_singing(player_ptr);
         }
 
-        {
-            /* Stop singing before start another */
-            if (cast || fail) {
-                stop_singing(player_ptr);
-            }
-
-            if (cast) {
-                msg_print(_("歌が神聖な場を作り出した．．．", "The holy power of the Music is creating sacred field..."));
-                create_rune_protection_one(player_ptr);
-            }
+        if (cast) {
+            msg_print(_("歌が神聖な場を作り出した．．．", "The holy power of the Music is creating sacred field..."));
+            create_rune_protection_one(player_ptr);
         }
-        break;
+    } break;
 
     case 27: {
-        if (name) {
-            return _("英雄の詩", "The Hero's Poem");
-        }
-
-        if (desc) {
-            return _("加速し、ヒーロー気分になり、視界内の全てのモンスターにダメージを与える。", "Hastes you. Gives heroism. Damages all monsters in sight.");
-        }
 
         if (cast || fail) {
             stop_singing(player_ptr);
@@ -980,13 +774,6 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
         break;
     }
     case 28: {
-        if (name) {
-            return _("ヤヴァンナの助け", "Relief of Yavanna");
-        }
-
-        if (desc) {
-            return _("強力な回復の歌で、負傷と朦朧状態も全快する。", "Powerful healing song. Also completely heals cuts and being stunned.");
-        }
 
         if (cast || fail) {
             stop_singing(player_ptr);
@@ -1011,68 +798,43 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
 
         break;
     }
-    case 29:
-        if (name) {
-            return _("再生の歌", "Goddess's rebirth");
-        }
-        if (desc) {
-            return _("すべてのステータスと経験値を回復する。", "Restores all stats and experience.");
+    case 29: {
+        /* Stop singing before start another */
+        if (cast || fail) {
+            stop_singing(player_ptr);
         }
 
-        {
-            /* Stop singing before start another */
-            if (cast || fail) {
-                stop_singing(player_ptr);
+        if (cast) {
+            msg_print(
+                _("暗黒の中に光と美をふりまいた。体が元の活力を取り戻した。", "You strew light and beauty in the dark as you sing. You feel refreshed."));
+            (void)restore_all_status(player_ptr);
+            (void)restore_level(player_ptr);
+        }
+    } break;
+
+    case 30: {
+        const Dice dice(50 + plev, 10);
+        POSITION rad = 0;
+
+        if (info) {
+            return info_damage(dice);
+        }
+
+        /* Stop singing before start another */
+        if (cast || fail) {
+            stop_singing(player_ptr);
+        }
+
+        if (cast) {
+            if (!get_aim_dir(player_ptr, &dir)) {
+                return std::nullopt;
             }
 
-            if (cast) {
-                msg_print(
-                    _("暗黒の中に光と美をふりまいた。体が元の活力を取り戻した。", "You strew light and beauty in the dark as you sing. You feel refreshed."));
-                (void)restore_all_status(player_ptr);
-                (void)restore_level(player_ptr);
-            }
+            fire_ball(player_ptr, AttributeType::SOUND, dir, dice.roll(), rad);
         }
-        break;
-
-    case 30:
-        if (name) {
-            return _("サウロンの魔術", "Wizardry of Sauron");
-        }
-        if (desc) {
-            return _("非常に強力でごく小さい轟音の球を放つ。", "Fires an extremely powerful tiny ball of sound.");
-        }
-
-        {
-            const Dice dice(50 + plev, 10);
-            POSITION rad = 0;
-
-            if (info) {
-                return info_damage(dice);
-            }
-
-            /* Stop singing before start another */
-            if (cast || fail) {
-                stop_singing(player_ptr);
-            }
-
-            if (cast) {
-                if (!get_aim_dir(player_ptr, &dir)) {
-                    return std::nullopt;
-                }
-
-                fire_ball(player_ptr, AttributeType::SOUND, dir, dice.roll(), rad);
-            }
-        }
-        break;
+    } break;
 
     case 31:
-        if (name) {
-            return _("フィンゴルフィンの挑戦", "Fingolfin's Challenge");
-        }
-        if (desc) {
-            return _("ダメージを受けなくなるバリアを張る。", "Generates a barrier which completely protects you from almost all damage.");
-        }
-
         /* Stop singing before start another */
         if (cast || fail) {
             stop_singing(player_ptr);

--- a/src/system/spell-info-list.cpp
+++ b/src/system/spell-info-list.cpp
@@ -5,7 +5,7 @@ SpellInfoList SpellInfoList::instance{};
 
 void SpellInfoList::initiallize()
 {
-    this->spell_list.assign(magic_realm_type::MAX_MAGIC + 1, std::vector<SpellInfo>(SPELLS_IN_REALM));
+    this->spell_list.assign(magic_realm_type::REALM_MAX, std::vector<SpellInfo>(SPELLS_IN_REALM));
 }
 
 SpellInfoList &SpellInfoList::get_instance()

--- a/src/system/spell-info-list.h
+++ b/src/system/spell-info-list.h
@@ -20,6 +20,9 @@ inline const std::unordered_map<std::string_view, int> realms_list = {
     { "CRAFT", 7 },
     { "DEMON", 8 },
     { "CRUSADE", 9 },
+    { "MUSIC", 15 },
+    { "HISSATSU", 16 },
+    { "HEX", 17 },
 };
 
 class SpellInfo {


### PR DESCRIPTION
現在魔法の10領域のみを対象としているが、対象を拡張して職業専門の3領域を追加する。