### PR TITLE
[Refactor] 領域が有効か調べる判定

### DIFF
--- a/src/avatar/avatar.cpp
+++ b/src/avatar/avatar.cpp
@@ -16,6 +16,7 @@
 #include "game-option/text-display-options.h"
 #include "player-info/class-info.h"
 #include "player-info/race-types.h"
+#include "player/player-realm.h"
 #include "realm/realm-names-table.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
@@ -374,14 +375,15 @@ void initialize_virtues(PlayerType *player_ptr)
     }
 
     /* Get a virtue_names for realms */
-    if (player_ptr->realm1) {
+    PlayerRealm pr(player_ptr);
+    if (pr.realm1().is_available()) {
         tmp_vir = get_realm_virtues(player_ptr, player_ptr->realm1);
         if (tmp_vir != Virtue::NONE) {
             player_ptr->vir_types[i++] = tmp_vir;
         }
     }
 
-    if (player_ptr->realm2) {
+    if (pr.realm2().is_available()) {
         tmp_vir = get_realm_virtues(player_ptr, player_ptr->realm2);
         if (tmp_vir != Virtue::NONE) {
             player_ptr->vir_types[i++] = tmp_vir;

--- a/src/birth/character-builder.cpp
+++ b/src/birth/character-builder.cpp
@@ -67,8 +67,8 @@ static void write_birth_diary(PlayerType *player_ptr)
     const auto mes_class = format(_("%s職業に%sを選択した。", "%schose %s class."), indent, class_info.at(player_ptr->pclass).title.data());
     exe_write_diary(floor, DiaryKind::DESCRIPTION, 1, mes_class);
     PlayerRealm pr(player_ptr);
-    if (player_ptr->realm1) {
-        const auto mes_realm2 = player_ptr->realm2 ? format(_("と%s", " and %s realms"), pr.realm2().get_name().data()) : _("", " realm");
+    if (pr.realm1().is_available()) {
+        const auto mes_realm2 = pr.realm2().is_available() ? format(_("と%s", " and %s realms"), pr.realm2().get_name().data()) : _("", " realm");
         const auto mes_realm = format(_("%s魔法の領域に%s%sを選択した。", "%schose %s%s."), indent, pr.realm1().get_name().data(), mes_realm2.data());
         exe_write_diary(floor, DiaryKind::DESCRIPTION, 1, mes_realm);
     }

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -560,7 +560,7 @@ static FuncItemTester get_castable_spellbook_tester(PlayerType *player_ptr)
 
 static FuncItemTester get_learnable_spellbook_tester(PlayerType *player_ptr)
 {
-    if (player_ptr->realm2 == REALM_NONE) {
+    if (!PlayerRealm(player_ptr).realm2().is_available()) {
         return get_castable_spellbook_tester(player_ptr);
     } else {
         return FuncItemTester(item_tester_learn_spell, player_ptr);
@@ -584,7 +584,7 @@ void do_cmd_browse(PlayerType *player_ptr)
 
     /* Warriors are illiterate */
     PlayerClass pc(player_ptr);
-    if (!(player_ptr->realm1 || player_ptr->realm2) && !pc.is_every_magic()) {
+    if (!PlayerRealm(player_ptr).realm1().is_available() && !pc.is_every_magic()) {
         msg_print(_("本を読むことができない！", "You cannot read books!"));
         return;
     }
@@ -727,7 +727,8 @@ void do_cmd_study(PlayerType *player_ptr)
     /* Spells of realm2 will have an increment of +32 */
     SPELL_IDX spell = -1;
     const auto spell_category = spell_category_name(mp_ptr->spell_book);
-    if (!player_ptr->realm1) {
+    PlayerRealm pr(player_ptr);
+    if (!pr.realm1().is_available()) {
         msg_print(_("本を読むことができない！", "You cannot read books!"));
         return;
     }
@@ -769,7 +770,6 @@ void do_cmd_study(PlayerType *player_ptr)
 
     const auto tval = o_ptr->bi_key.tval();
     const auto sval = *o_ptr->bi_key.sval();
-    PlayerRealm pr(player_ptr);
     if (tval == pr.realm2().get_book()) {
         increment = 32;
     } else if (tval != pr.realm1().get_book()) {
@@ -943,7 +943,8 @@ bool do_cmd_cast(PlayerType *player_ptr)
     /* Require spell ability */
     PlayerClass pc(player_ptr);
     auto is_every_magic = pc.is_every_magic();
-    if (!player_ptr->realm1 && !is_every_magic) {
+    PlayerRealm pr(player_ptr);
+    if (!pr.realm1().is_available() && !is_every_magic) {
         msg_print(_("呪文を唱えられない！", "You cannot cast spells!"));
         return false;
     }

--- a/src/io/read-pref-file.cpp
+++ b/src/io/read-pref-file.cpp
@@ -285,11 +285,11 @@ void load_all_pref_files(PlayerType *player_ptr)
     process_pref_file(player_ptr, format(fmt, cp_ptr->title.data()));
     process_pref_file(player_ptr, format(fmt, player_ptr->base_name));
     PlayerRealm pr(player_ptr);
-    if (player_ptr->realm1 != REALM_NONE) {
+    if (pr.realm1().is_available()) {
         process_pref_file(player_ptr, format(fmt, pr.realm1().get_name().data()));
     }
 
-    if (player_ptr->realm2 != REALM_NONE) {
+    if (pr.realm2().is_available()) {
         process_pref_file(player_ptr, format(fmt, pr.realm2().get_name().data()));
     }
 

--- a/src/knowledge/knowledge-experiences.cpp
+++ b/src/knowledge/knowledge-experiences.cpp
@@ -85,7 +85,7 @@ void do_cmd_knowledge_spell_exp(PlayerType *player_ptr)
 
     PlayerRealm pr(player_ptr);
 
-    if (player_ptr->realm1 != REALM_NONE) {
+    if (pr.realm1().is_available()) {
         fprintf(fff, _("%sの魔法書\n", "%s Spellbook\n"), pr.realm1().get_name().data());
         for (SPELL_IDX i = 0; i < 32; i++) {
             const auto &spell = pr.realm1().get_spell_info(i);
@@ -121,7 +121,7 @@ void do_cmd_knowledge_spell_exp(PlayerType *player_ptr)
         }
     }
 
-    if (player_ptr->realm2 != REALM_NONE) {
+    if (pr.realm2().is_available()) {
         fprintf(fff, _("%sの魔法書\n", "\n%s Spellbook\n"), pr.realm2().get_name().data());
         for (SPELL_IDX i = 0; i < 32; i++) {
             const auto &spell = pr.realm2().get_spell_info(i);

--- a/src/knowledge/knowledge-self.cpp
+++ b/src/knowledge/knowledge-self.cpp
@@ -83,13 +83,13 @@ static void dump_yourself(PlayerType *player_ptr, FILE *fff)
 
     fprintf(fff, "\n");
     PlayerRealm pr(player_ptr);
-    if (player_ptr->realm1) {
+    if (pr.realm1().is_available()) {
         fprintf(fff, _("魔法: %s\n", "Realm: %s\n"), pr.realm1().get_name().data());
         dump_explanation(realm_explanations[technic2magic(player_ptr->realm1) - 1], fff);
     }
 
     fprintf(fff, "\n");
-    if (player_ptr->realm2) {
+    if (pr.realm2().is_available()) {
         fprintf(fff, _("魔法: %s\n", "Realm: %s\n"), pr.realm2().get_name().data());
         dump_explanation(realm_explanations[technic2magic(player_ptr->realm2) - 1], fff);
     }

--- a/src/player/player-realm.cpp
+++ b/src/player/player-realm.cpp
@@ -167,6 +167,11 @@ ItemKindType PlayerRealm::Realm::get_book() const
     return PlayerRealm::get_book(this->realm);
 }
 
+bool PlayerRealm::Realm::is_available() const
+{
+    return this->realm != REALM_NONE;
+}
+
 bool PlayerRealm::Realm::is_good_attribute() const
 {
     return this->realm == REALM_LIFE || this->realm == REALM_CRUSADE;

--- a/src/player/player-realm.h
+++ b/src/player/player-realm.h
@@ -30,6 +30,7 @@ public:
         const LocalizedString &get_name() const;
         const magic_type &get_spell_info(int num) const;
         ItemKindType get_book() const;
+        bool is_available() const;
         bool is_good_attribute() const;
 
     private:

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -25,6 +25,7 @@
 #include "player-status/player-stealth.h"
 #include "player/attack-defense-types.h"
 #include "player/digestion-processor.h"
+#include "player/player-realm.h"
 #include "player/player-skill.h"
 #include "player/player-status.h"
 #include "player/race-info-table.h"
@@ -711,7 +712,8 @@ void check_no_flowed(PlayerType *player_ptr)
         return;
     }
 
-    if (!player_ptr->realm1) {
+    PlayerRealm pr(player_ptr);
+    if (!pr.realm1().is_available()) {
         player_ptr->no_flowed = false;
         return;
     }

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -519,9 +519,10 @@ static void update_num_of_spells(PlayerType *player_ptr)
         bonus = 4;
     }
 
+    PlayerRealm pr(player_ptr);
     if (pc.equals(PlayerClassType::SAMURAI)) {
         num_allowed = 32;
-    } else if (player_ptr->realm2 == REALM_NONE) {
+    } else if (!pr.realm2().is_available()) {
         num_allowed = (num_allowed + 1) / 2;
         if (num_allowed > (32 + bonus)) {
             num_allowed = 32 + bonus;
@@ -543,7 +544,6 @@ static void update_num_of_spells(PlayerType *player_ptr)
         }
     }
 
-    PlayerRealm pr(player_ptr);
     player_ptr->new_spells = num_allowed + player_ptr->add_spells + num_boukyaku - player_ptr->learned_spells;
     for (int i = 63; i >= 0; i--) {
         if (!player_ptr->spell_learned1 && !player_ptr->spell_learned2) {
@@ -689,7 +689,7 @@ static void update_num_of_spells(PlayerType *player_ptr)
         player_ptr->new_spells--;
     }
 
-    if (player_ptr->realm2 == REALM_NONE) {
+    if (!pr.realm2().is_available()) {
         int k = 0;
         for (int j = 0; j < 32; j++) {
             const auto &spell = pr.realm1().get_spell_info(j);

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -97,7 +97,8 @@ static void display_player_basic_info(PlayerType *player_ptr)
  */
 static void display_magic_realms(PlayerType *player_ptr)
 {
-    if (player_ptr->realm1 == REALM_NONE && player_ptr->element == REALM_NONE) {
+    PlayerRealm pr(player_ptr);
+    if (!pr.realm1().is_available() && player_ptr->element == REALM_NONE) {
         return;
     }
 
@@ -106,10 +107,9 @@ static void display_magic_realms(PlayerType *player_ptr)
         return;
     }
 
-    PlayerRealm pr(player_ptr);
     std::stringstream ss;
     ss << pr.realm1().get_name();
-    if (player_ptr->realm2) {
+    if (pr.realm2().is_available()) {
         ss << ", " << pr.realm2().get_name();
     }
     display_player_one_line(ENTRY_REALM, ss.str(), TERM_L_BLUE);

--- a/src/view/object-describer.cpp
+++ b/src/view/object-describer.cpp
@@ -6,6 +6,7 @@
 #include "object/tval-types.h"
 #include "perception/object-perception.h"
 #include "player-base/player-class.h"
+#include "player/player-realm.h"
 #include "realm/realm-names-table.h"
 #include "spell/spell-info.h"
 #include "system/item-entity.h"
@@ -82,7 +83,8 @@ void display_koff(PlayerType *player_ptr)
     const auto sval = *item.bi_key.sval();
     const short use_realm = tval2realm(item.bi_key.tval());
 
-    if (player_ptr->realm1 || player_ptr->realm2) {
+    PlayerRealm pr(player_ptr);
+    if (pr.realm1().is_available() || pr.realm2().is_available()) {
         if ((use_realm != player_ptr->realm1) && (use_realm != player_ptr->realm2)) {
             return;
         }

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -815,11 +815,12 @@ static void display_spell_list(PlayerType *player_ptr)
         return;
     }
 
-    if (REALM_NONE == player_ptr->realm1) {
+    PlayerRealm pr(player_ptr);
+    if (!pr.realm1().is_available()) {
         return;
     }
 
-    for (int j = 0; j < ((player_ptr->realm2 > REALM_NONE) ? 2 : 1); j++) {
+    for (int j = 0; j < (pr.realm2().is_available() ? 2 : 1); j++) {
         m[j] = 0;
         y = (j < 3) ? 0 : (m[j - 3] + 2);
         x = 27 * (j % 3);


### PR DESCRIPTION
#4357 の一環

現在 REALM_NONE との比較によって領域が有効（魔法なしではなくなんらかの魔法領域を使用可能）であるかをチェックしている箇所を、PlayerRealm::Realmクラスのメンバ関数 is_available() によってチェックするように変更する。