### PR TITLE
[Reafctor] 特定の領域かどうかを調べる判定

### DIFF
--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -273,7 +273,8 @@ static bool spell_okay(PlayerType *player_ptr, int spell_id, bool learned, bool 
     }
 
     /* Spell is forgotten */
-    if ((use_realm == player_ptr->realm2) ? (player_ptr->spell_forgotten2 & (1UL << spell_id)) : (player_ptr->spell_forgotten1 & (1UL << spell_id))) {
+    PlayerRealm pr(player_ptr);
+    if (pr.realm2().equals(use_realm) ? (player_ptr->spell_forgotten2 & (1UL << spell_id)) : (player_ptr->spell_forgotten1 & (1UL << spell_id))) {
         /* Never okay */
         return false;
     }
@@ -283,7 +284,7 @@ static bool spell_okay(PlayerType *player_ptr, int spell_id, bool learned, bool 
     }
 
     /* Spell is learned */
-    if ((use_realm == player_ptr->realm2) ? (player_ptr->spell_learned2 & (1UL << spell_id)) : (player_ptr->spell_learned1 & (1UL << spell_id))) {
+    if (pr.realm2().equals(use_realm) ? (player_ptr->spell_learned2 & (1UL << spell_id)) : (player_ptr->spell_learned1 & (1UL << spell_id))) {
         /* Always true */
         return !study_pray;
     }
@@ -357,8 +358,9 @@ static int get_spell(PlayerType *player_ptr, SPELL_IDX *sn, std::string_view pro
     }
 
     PlayerClass pc(player_ptr);
+    PlayerRealm pr(player_ptr);
     auto is_every_magic = pc.is_every_magic();
-    if (((use_realm) != player_ptr->realm1) && ((use_realm) != player_ptr->realm2) && !is_every_magic) {
+    if (!pr.realm1().equals(use_realm) && !pr.realm2().equals(use_realm) && !is_every_magic) {
         return false;
     }
     if (is_every_magic && !is_magic(use_realm)) {
@@ -964,7 +966,7 @@ bool do_cmd_cast(PlayerType *player_ptr)
         return false;
     }
 
-    if (player_ptr->realm1 == REALM_HEX) {
+    if (pr.is_realm_hex()) {
         if (SpellHex(player_ptr).is_casting_full_capacity()) {
             auto flag = false;
             msg_print(_("これ以上新しい呪文を詠唱することはできない。", "Can not cast more spells."));
@@ -1172,7 +1174,7 @@ bool do_cmd_cast(PlayerType *player_ptr)
             int e = spell.sexp;
 
             /* The spell worked */
-            if (realm == player_ptr->realm1) {
+            if (pr.realm1().equals(realm)) {
                 player_ptr->spell_worked1 |= (1UL << spell_id);
             } else {
                 player_ptr->spell_worked2 |= (1UL << spell_id);

--- a/src/knowledge/knowledge-experiences.cpp
+++ b/src/knowledge/knowledge-experiences.cpp
@@ -97,7 +97,7 @@ void do_cmd_knowledge_spell_exp(PlayerType *player_ptr)
             auto skill_rank = PlayerSkill::spell_skill_rank(spell_exp);
             const auto spell_name = exe_spell(player_ptr, player_ptr->realm1, i, SpellProcessType::NAME);
             fprintf(fff, "%-25s ", spell_name->data());
-            if (player_ptr->realm1 == REALM_HISSATSU) {
+            if (pr.realm1().equals(REALM_HISSATSU)) {
                 if (show_actual_value) {
                     fprintf(fff, "----/---- ");
                 }

--- a/src/player-ability/player-constitution.cpp
+++ b/src/player-ability/player-constitution.cpp
@@ -6,6 +6,7 @@
 #include "player-info/monk-data-type.h"
 #include "player-info/samurai-data-type.h"
 #include "player/player-personality.h"
+#include "player/player-realm.h"
 #include "player/race-info-table.h"
 #include "player/special-defense-types.h"
 #include "realm/realm-hex-numbers.h"
@@ -51,7 +52,7 @@ int16_t PlayerConstitution::time_effect_bonus()
 {
     int16_t result = 0;
 
-    if (this->player_ptr->realm1 == REALM_HEX) {
+    if (PlayerRealm(this->player_ptr).is_realm_hex()) {
         if (SpellHex(this->player_ptr).is_spelling_specific(HEX_BUILDING)) {
             result += 4;
         }

--- a/src/player-ability/player-dexterity.cpp
+++ b/src/player-ability/player-dexterity.cpp
@@ -6,6 +6,7 @@
 #include "player-info/monk-data-type.h"
 #include "player-info/samurai-data-type.h"
 #include "player/player-personality.h"
+#include "player/player-realm.h"
 #include "player/race-info-table.h"
 #include "player/special-defense-types.h"
 #include "realm/realm-hex-numbers.h"
@@ -51,7 +52,7 @@ int16_t PlayerDexterity::time_effect_bonus()
 {
     int16_t result = 0;
 
-    if (this->player_ptr->realm1 == REALM_HEX) {
+    if (PlayerRealm(this->player_ptr).is_realm_hex()) {
         if (SpellHex(this->player_ptr).is_spelling_specific(HEX_BUILDING)) {
             result += 4;
         }

--- a/src/player-ability/player-strength.cpp
+++ b/src/player-ability/player-strength.cpp
@@ -5,6 +5,7 @@
 #include "player-info/monk-data-type.h"
 #include "player-info/samurai-data-type.h"
 #include "player/player-personality.h"
+#include "player/player-realm.h"
 #include "player/race-info-table.h"
 #include "player/special-defense-types.h"
 #include "realm/realm-hex-numbers.h"
@@ -53,7 +54,7 @@ int16_t PlayerStrength::time_effect_bonus()
 {
     int16_t result = 0;
 
-    if (this->player_ptr->realm1 == REALM_HEX) {
+    if (PlayerRealm(this->player_ptr).is_realm_hex()) {
         SpellHex spell_hex(this->player_ptr);
         if (spell_hex.is_spelling_specific(HEX_XTRA_MIGHT)) {
             result += 4;

--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -21,6 +21,7 @@
 #include "player-info/sniper-data-type.h"
 #include "player-info/spell-hex-data-type.h"
 #include "player/attack-defense-types.h"
+#include "player/player-realm.h"
 #include "player/player-status-flags.h"
 #include "player/special-defense-types.h"
 #include "realm/realm-types.h"
@@ -518,7 +519,7 @@ void PlayerClass::init_specific_data()
         this->player_ptr->class_specific_data = std::make_shared<ninja_data_type>();
         break;
     case PlayerClassType::HIGH_MAGE:
-        if (this->player_ptr->realm1 == REALM_HEX) {
+        if (PlayerRealm(this->player_ptr).is_realm_hex()) {
             this->player_ptr->class_specific_data = std::make_shared<spell_hex_data_type>();
         } else {
             this->player_ptr->class_specific_data = no_class_specific_data();

--- a/src/player-info/class-ability-info.cpp
+++ b/src/player-info/class-ability-info.cpp
@@ -14,7 +14,7 @@ void set_class_ability_info(PlayerType *player_ptr, self_info_type *self_ptr)
 
         break;
     case PlayerClassType::HIGH_MAGE:
-        if (player_ptr->realm1 == REALM_HEX) {
+        if (PlayerRealm(player_ptr).is_realm_hex()) {
             break;
         }
         [[fallthrough]];

--- a/src/player-status/player-speed.cpp
+++ b/src/player-status/player-speed.cpp
@@ -13,6 +13,7 @@
 #include "player-info/race-info.h"
 #include "player/attack-defense-types.h"
 #include "player/digestion-processor.h"
+#include "player/player-realm.h"
 #include "player/player-skill.h"
 #include "player/player-status-flags.h"
 #include "player/player-status.h"
@@ -195,7 +196,7 @@ int16_t PlayerSpeed::time_effect_bonus()
         bonus -= 10;
     }
 
-    if (this->player_ptr->realm1 == REALM_HEX) {
+    if (PlayerRealm(this->player_ptr).is_realm_hex()) {
         if (SpellHex(this->player_ptr).is_spelling_specific(HEX_SHOCK_CLOAK)) {
             bonus += 3;
         }

--- a/src/player-status/player-stealth.cpp
+++ b/src/player-status/player-stealth.cpp
@@ -8,6 +8,7 @@
 #include "player-info/mimic-info-table.h"
 #include "player-info/race-types.h"
 #include "player/player-personality.h"
+#include "player/player-realm.h"
 #include "player/player-skill.h"
 #include "player/player-status-flags.h"
 #include "player/player-status.h"
@@ -115,7 +116,7 @@ int16_t PlayerStealth::mutation_bonus()
 int16_t PlayerStealth::time_effect_bonus()
 {
     int16_t bonus = 0;
-    if (this->player_ptr->realm1 == REALM_HEX) {
+    if (PlayerRealm(this->player_ptr).is_realm_hex()) {
         SpellHex spell_hex(this->player_ptr);
         if (spell_hex.is_spelling_any()) {
             bonus -= spell_hex.get_casting_num() + 1;

--- a/src/player/player-realm.cpp
+++ b/src/player/player-realm.cpp
@@ -147,6 +147,11 @@ const PlayerRealm::Realm &PlayerRealm::realm2() const
     return this->realm2_;
 }
 
+bool PlayerRealm::is_realm_hex() const
+{
+    return this->realm1_.equals(REALM_HEX);
+}
+
 PlayerRealm::Realm::Realm(int realm)
     : realm(realm)
 {
@@ -175,4 +180,9 @@ bool PlayerRealm::Realm::is_available() const
 bool PlayerRealm::Realm::is_good_attribute() const
 {
     return this->realm == REALM_LIFE || this->realm == REALM_CRUSADE;
+}
+
+bool PlayerRealm::Realm::equals(int realm) const
+{
+    return this->realm == realm;
 }

--- a/src/player/player-realm.cpp
+++ b/src/player/player-realm.cpp
@@ -153,36 +153,36 @@ bool PlayerRealm::is_realm_hex() const
 }
 
 PlayerRealm::Realm::Realm(int realm)
-    : realm(realm)
+    : realm_(realm)
 {
 }
 
 const LocalizedString &PlayerRealm::Realm::get_name() const
 {
-    return PlayerRealm::get_name(this->realm);
+    return PlayerRealm::get_name(this->realm_);
 }
 
 const magic_type &PlayerRealm::Realm::get_spell_info(int num) const
 {
-    return PlayerRealm::get_spell_info(this->realm, num);
+    return PlayerRealm::get_spell_info(this->realm_, num);
 }
 
 ItemKindType PlayerRealm::Realm::get_book() const
 {
-    return PlayerRealm::get_book(this->realm);
+    return PlayerRealm::get_book(this->realm_);
 }
 
 bool PlayerRealm::Realm::is_available() const
 {
-    return this->realm != REALM_NONE;
+    return this->realm_ != REALM_NONE;
 }
 
 bool PlayerRealm::Realm::is_good_attribute() const
 {
-    return this->realm == REALM_LIFE || this->realm == REALM_CRUSADE;
+    return this->realm_ == REALM_LIFE || this->realm_ == REALM_CRUSADE;
 }
 
 bool PlayerRealm::Realm::equals(int realm) const
 {
-    return this->realm == realm;
+    return this->realm_ == realm;
 }

--- a/src/player/player-realm.h
+++ b/src/player/player-realm.h
@@ -32,6 +32,7 @@ public:
         ItemKindType get_book() const;
         bool is_available() const;
         bool is_good_attribute() const;
+        bool equals(int realm) const;
 
     private:
         int realm;
@@ -39,6 +40,7 @@ public:
 
     const Realm &realm1() const;
     const Realm &realm2() const;
+    bool is_realm_hex() const;
 
 private:
     Realm realm1_;

--- a/src/player/player-realm.h
+++ b/src/player/player-realm.h
@@ -35,7 +35,7 @@ public:
         bool equals(int realm) const;
 
     private:
-        int realm;
+        int realm_;
     };
 
     const Realm &realm1() const;

--- a/src/player/player-skill.cpp
+++ b/src/player/player-skill.cpp
@@ -352,9 +352,10 @@ void PlayerSkill::gain_riding_skill_exp_on_fall_off_check(int dam)
 
 void PlayerSkill::gain_spell_skill_exp(int realm, int spell_idx)
 {
+    PlayerRealm pr(this->player_ptr);
     auto is_valid_realm = is_magic(realm) ||
                           (realm == REALM_MUSIC) || (realm == REALM_HEX);
-    is_valid_realm &= (realm == this->player_ptr->realm1) || (realm == this->player_ptr->realm2);
+    is_valid_realm &= pr.realm1().equals(realm) || pr.realm2().equals(realm);
     const auto is_valid_spell_idx = (0 <= spell_idx) && (spell_idx < 32);
 
     if (!is_valid_realm || !is_valid_spell_idx) {
@@ -364,7 +365,7 @@ void PlayerSkill::gain_spell_skill_exp(int realm, int spell_idx)
     constexpr GainAmountList gain_amount_list_first{ { 60, 8, 2, 1 } };
     constexpr GainAmountList gain_amount_list_second{ { 60, 8, 2, 0 } };
 
-    const auto is_first_realm = (realm == this->player_ptr->realm1);
+    const auto is_first_realm = pr.realm1().equals(realm);
     const auto &spell = PlayerRealm::get_spell_info(realm, spell_idx);
 
     gain_spell_skill_exp_aux(this->player_ptr, this->player_ptr->spell_exp[spell_idx + (is_first_realm ? 0 : 32)],
@@ -421,13 +422,14 @@ PlayerSkillRank PlayerSkill::gain_spell_skill_exp_over_learning(int spell_idx)
 EXP PlayerSkill::exp_of_spell(int realm, int spell_idx) const
 {
     PlayerClass pc(this->player_ptr);
+    PlayerRealm pr(this->player_ptr);
     if (pc.equals(PlayerClassType::SORCERER)) {
         return SPELL_EXP_MASTER;
     } else if (pc.equals(PlayerClassType::RED_MAGE)) {
         return SPELL_EXP_SKILLED;
-    } else if (realm == this->player_ptr->realm1) {
+    } else if (pr.realm1().equals(realm)) {
         return this->player_ptr->spell_exp[spell_idx];
-    } else if (realm == this->player_ptr->realm2) {
+    } else if (pr.realm2().equals(realm)) {
         return this->player_ptr->spell_exp[spell_idx + 32];
     } else {
         return 0;

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -533,7 +533,7 @@ BIT_FLAGS has_xtra_might(PlayerType *player_ptr)
 BIT_FLAGS has_esp_evil(PlayerType *player_ptr)
 {
     BIT_FLAGS result = common_cause_flags(player_ptr, TR_ESP_EVIL);
-    if (player_ptr->realm1 == REALM_HEX) {
+    if (PlayerRealm(player_ptr).is_realm_hex()) {
         if (SpellHex(player_ptr).is_spelling_specific(HEX_DETECT_EVIL)) {
             result |= FLAG_CAUSE_MAGIC_TIME_EFFECT;
         }
@@ -741,14 +741,14 @@ void check_no_flowed(PlayerType *player_ptr)
     }
 
     PlayerClass pc(player_ptr);
-    if (has_sw && ((player_ptr->realm1 == REALM_NATURE) || (player_ptr->realm2 == REALM_NATURE) || pc.equals(PlayerClassType::SORCERER))) {
+    if (has_sw && (pr.realm1().equals(REALM_NATURE) || pr.realm2().equals(REALM_NATURE) || pc.equals(PlayerClassType::SORCERER))) {
         const magic_type *s_ptr = &mp_ptr->info[REALM_NATURE - 1][SPELL_SW];
         if (player_ptr->lev >= s_ptr->slevel) {
             player_ptr->no_flowed = true;
         }
     }
 
-    if (has_kabe && ((player_ptr->realm1 == REALM_CRAFT) || (player_ptr->realm2 == REALM_CRAFT) || pc.equals(PlayerClassType::SORCERER))) {
+    if (has_kabe && (pr.realm1().equals(REALM_CRAFT) || pr.realm2().equals(REALM_CRAFT) || pc.equals(PlayerClassType::SORCERER))) {
         const magic_type *s_ptr = &mp_ptr->info[REALM_CRAFT - 1][SPELL_WALL];
         if (player_ptr->lev >= s_ptr->slevel) {
             player_ptr->no_flowed = true;

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -1815,7 +1815,7 @@ static ARMOUR_CLASS calc_to_ac(PlayerType *player_ptr, bool is_real_value)
         }
     }
 
-    if (player_ptr->realm1 == REALM_HEX) {
+    if (PlayerRealm(player_ptr).is_realm_hex()) {
         if (SpellHex(player_ptr).is_spelling_specific(HEX_ICE_ARMOR)) {
             ac += 30;
         }
@@ -2118,7 +2118,7 @@ static short calc_to_damage(PlayerType *player_ptr, INVENTORY_IDX slot, bool is_
         }
     }
 
-    if ((player_ptr->realm1 == REALM_HEX) && o_ptr->is_cursed()) {
+    if (PlayerRealm(player_ptr).is_realm_hex() && o_ptr->is_cursed()) {
         if (SpellHex(player_ptr).is_spelling_specific(HEX_RUNESWORD)) {
             if (o_ptr->curse_flags.has(CurseTraitType::CURSED)) {
                 damage += 5;
@@ -2355,7 +2355,7 @@ static short calc_to_hit(PlayerType *player_ptr, INVENTORY_IDX slot, bool is_rea
         }
 
         /* Hex realm bonuses */
-        if ((player_ptr->realm1 == REALM_HEX) && o_ptr->is_cursed()) {
+        if (PlayerRealm(player_ptr).is_realm_hex() && o_ptr->is_cursed()) {
             if (o_ptr->curse_flags.has(CurseTraitType::CURSED)) {
                 hit += 5;
             }

--- a/src/racial/class-racial-switcher.cpp
+++ b/src/racial/class-racial-switcher.cpp
@@ -20,7 +20,7 @@ void switch_class_racial(PlayerType *player_ptr, rc_type *rc_ptr)
         rc_ptr->add_power(rpi, RC_IDX_CLASS_0);
         break;
     case PlayerClassType::HIGH_MAGE:
-        if (player_ptr->realm1 == REALM_HEX) {
+        if (PlayerRealm(player_ptr).is_realm_hex()) {
             rpi = rpi_type(_("詠唱をやめる", "Stop spell casting"));
             rpi.text = _("呪術の詠唱を全てやめる。", "Stops all casting hex spells.");
             rpi.min_level = 1;

--- a/src/racial/racial-switcher.cpp
+++ b/src/racial/racial-switcher.cpp
@@ -91,7 +91,7 @@ bool switch_class_racial_execution(PlayerType *player_ptr, const int32_t command
     case PlayerClassType::WARRIOR:
         return sword_dancing(player_ptr);
     case PlayerClassType::HIGH_MAGE:
-        if (player_ptr->realm1 == REALM_HEX) {
+        if (PlayerRealm(player_ptr).is_realm_hex()) {
             const auto retval = SpellHex(player_ptr).stop_spells_with_selection();
             if (retval) {
                 PlayerEnergy(player_ptr).set_player_turn_energy(10);

--- a/src/spell/spell-info.cpp
+++ b/src/spell/spell-info.cpp
@@ -141,7 +141,8 @@ PERCENTAGE spell_chance(PlayerType *player_ptr, SPELL_IDX spell_id, int16_t use_
     }
 
     PlayerClass pc(player_ptr);
-    if ((use_realm != player_ptr->realm1) && (pc.equals(PlayerClassType::MAGE) || pc.equals(PlayerClassType::PRIEST))) {
+    PlayerRealm pr(player_ptr);
+    if (!pr.realm1().equals(use_realm) && (pc.equals(PlayerClassType::MAGE) || pc.equals(PlayerClassType::PRIEST))) {
         chance += 5;
     }
 
@@ -194,7 +195,7 @@ PERCENTAGE spell_chance(PlayerType *player_ptr, SPELL_IDX spell_id, int16_t use_
         chance = 95;
     }
 
-    if ((use_realm == player_ptr->realm1) || (use_realm == player_ptr->realm2) || pc.is_every_magic()) {
+    if (pr.realm1().equals(use_realm) || pr.realm2().equals(use_realm) || pc.is_every_magic()) {
         auto exp = PlayerSkill(player_ptr).exp_of_spell(use_realm, spell_id);
         if (exp >= PlayerSkill::spell_exp_at(PlayerSkillRank::EXPERT)) {
             chance--;
@@ -238,11 +239,12 @@ void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell_id, const SPELL
 
     int increment = 64;
     PlayerClass pc(player_ptr);
+    PlayerRealm pr(player_ptr);
     if (pc.is_every_magic()) {
         increment = 0;
-    } else if (use_realm == player_ptr->realm1) {
+    } else if (pr.realm1().equals(use_realm)) {
         increment = 0;
-    } else if (use_realm == player_ptr->realm2) {
+    } else if (pr.realm2().equals(use_realm)) {
         increment = 32;
     }
 
@@ -310,16 +312,16 @@ void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell_id, const SPELL
                 comment = _("忘却", "forgotten");
                 line_attr = TERM_YELLOW;
             }
-        } else if ((use_realm != player_ptr->realm1) && (use_realm != player_ptr->realm2)) {
+        } else if (!pr.realm1().equals(use_realm) && !pr.realm2().equals(use_realm)) {
             comment = _("未知", "unknown");
             line_attr = TERM_L_BLUE;
-        } else if ((use_realm == player_ptr->realm1) ? ((player_ptr->spell_forgotten1 & (1UL << spell_id))) : ((player_ptr->spell_forgotten2 & (1UL << spell_id)))) {
+        } else if (pr.realm1().equals(use_realm) ? ((player_ptr->spell_forgotten1 & (1UL << spell_id))) : ((player_ptr->spell_forgotten2 & (1UL << spell_id)))) {
             comment = _("忘却", "forgotten");
             line_attr = TERM_YELLOW;
-        } else if (!((use_realm == player_ptr->realm1) ? (player_ptr->spell_learned1 & (1UL << spell_id)) : (player_ptr->spell_learned2 & (1UL << spell_id)))) {
+        } else if (!(pr.realm1().equals(use_realm) ? (player_ptr->spell_learned1 & (1UL << spell_id)) : (player_ptr->spell_learned2 & (1UL << spell_id)))) {
             comment = _("未知", "unknown");
             line_attr = TERM_L_BLUE;
-        } else if (!((use_realm == player_ptr->realm1) ? (player_ptr->spell_worked1 & (1UL << spell_id)) : (player_ptr->spell_worked2 & (1UL << spell_id)))) {
+        } else if (!(pr.realm1().equals(use_realm) ? (player_ptr->spell_worked1 & (1UL << spell_id)) : (player_ptr->spell_worked2 & (1UL << spell_id)))) {
             comment = _("未経験", "untried");
             line_attr = TERM_L_GREEN;
         }

--- a/src/view/object-describer.cpp
+++ b/src/view/object-describer.cpp
@@ -85,7 +85,7 @@ void display_koff(PlayerType *player_ptr)
 
     PlayerRealm pr(player_ptr);
     if (pr.realm1().is_available() || pr.realm2().is_available()) {
-        if ((use_realm != player_ptr->realm1) && (use_realm != player_ptr->realm2)) {
+        if (!pr.realm1().equals(use_realm) && !pr.realm2().equals(use_realm)) {
             return;
         }
     } else {

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -11,6 +11,7 @@
 #include "player-info/sniper-data-type.h"
 #include "player/attack-defense-types.h"
 #include "player/digestion-processor.h"
+#include "player/player-realm.h"
 #include "player/player-status-table.h"
 #include "player/player-status.h"
 #include "realm/realm-hex-numbers.h"
@@ -348,7 +349,7 @@ void print_imitation(PlayerType *player_ptr)
  */
 static void add_hex_status_flags(PlayerType *player_ptr, BIT_FLAGS *bar_flags)
 {
-    if (player_ptr->realm1 != REALM_HEX) {
+    if (!PlayerRealm(player_ptr).is_realm_hex()) {
         return;
     }
 


### PR DESCRIPTION
#4357 の一環

PlayerRealm::Realmクラスにメンバ関数equalsを実装し、現在PlayerTypeのデータメンバrealm1およびrealm2との直接比較によって特定の領域であるかを調べている箇所を置き換える。
また、呪術ハイメイジ専用処理で第1領域がREALM_HEXであるかどうかを調べている箇所は特別に多いので、PlayerRealmクラスにメンバ関数is_realm_hexを実装し、この関数によりチェックするようにする。

真偽反転がないかを特に注意していただきたく。