### PR TITLE
[Refactor] 呪文の名称と説明文の取得処理 

### DIFF
--- a/src/cmd-action/cmd-hissatsu.cpp
+++ b/src/cmd-action/cmd-hissatsu.cpp
@@ -243,8 +243,8 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
                     }
 
                     /* Dump the spell --(-- */
-                    const auto spell_name = exe_spell(player_ptr, REALM_HISSATSU, i, SpellProcessType::NAME);
-                    psi_desc.append(format(" %-18s%2d %3d", spell_name->data(), spell.slevel, spell.smana));
+                    const auto &spell_name = PlayerRealm::get_spell_name(REALM_HISSATSU, i);
+                    psi_desc.append(format(" %-18s%2d %3d", spell_name.data(), spell.slevel, spell.smana));
                     prt(psi_desc, y + (line % 17) + (line >= 17), x + (line / 17) * 30);
                     prt("", y + (line % 17) + (line >= 17) + 1, x + (line / 17) * 30);
                 }
@@ -406,8 +406,8 @@ void do_cmd_gain_hissatsu(PlayerType *player_ptr)
 
         player_ptr->spell_learned1 |= (1UL << i);
         player_ptr->spell_worked1 |= (1UL << i);
-        const auto spell_name = exe_spell(player_ptr, REALM_HISSATSU, i, SpellProcessType::NAME);
-        msg_format(_("%sの技を覚えた。", "You have learned the special attack of %s."), spell_name->data());
+        const auto &spell_name = PlayerRealm::get_spell_name(REALM_HISSATSU, i);
+        msg_format(_("%sの技を覚えた。", "You have learned the special attack of %s."), spell_name.data());
         int j;
         for (j = 0; j < 64; j++) {
             /* Stop at the first empty space */

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -669,8 +669,8 @@ void do_cmd_browse(PlayerType *player_ptr)
         term_erase(14, 12);
         term_erase(14, 11);
 
-        const auto spell_desc = exe_spell(player_ptr, use_realm, spell, SpellProcessType::DESCRIPTION);
-        display_wrap_around(*spell_desc, 62, 11, 15);
+        const auto &spell_desc = PlayerRealm::get_spell_description(use_realm, spell);
+        display_wrap_around(spell_desc, 62, 11, 15);
     }
     screen_load();
 }
@@ -852,17 +852,17 @@ void do_cmd_study(PlayerType *player_ptr)
     if (learned) {
         auto max_exp = PlayerSkill::spell_exp_at((spell < 32) ? PlayerSkillRank::MASTER : PlayerSkillRank::EXPERT);
         const auto old_exp = player_ptr->spell_exp[spell];
-        const auto realm = increment ? player_ptr->realm2 : player_ptr->realm1;
-        const auto spell_name = exe_spell(player_ptr, realm, spell % 32, SpellProcessType::NAME);
+        const auto &realm = increment ? pr.realm2() : pr.realm1();
+        const auto &spell_name = realm.get_spell_name(spell % 32);
 
         if (old_exp >= max_exp) {
             msg_format(_("その%sは完全に使いこなせるので学ぶ必要はない。", "You don't need to study this %s anymore."), spell_category.data());
             return;
         }
 #ifdef JP
-        if (!input_check(format("%sの%sをさらに学びます。よろしいですか？", spell_name->data(), spell_category.data())))
+        if (!input_check(format("%sの%sをさらに学びます。よろしいですか？", spell_name.data(), spell_category.data())))
 #else
-        if (!input_check(format("You will study a %s of %s again. Are you sure? ", spell_category.data(), spell_name->data())))
+        if (!input_check(format("You will study a %s of %s again. Are you sure? ", spell_category.data(), spell_name.data())))
 #endif
         {
             return;
@@ -870,7 +870,7 @@ void do_cmd_study(PlayerType *player_ptr)
 
         auto new_rank = PlayerSkill(player_ptr).gain_spell_skill_exp_over_learning(spell);
         auto new_rank_str = PlayerSkill::skill_rank_str(new_rank);
-        msg_format(_("%sの熟練度が%sに上がった。", "Your proficiency of %s is now %s rank."), spell_name->data(), new_rank_str);
+        msg_format(_("%sの熟練度が%sに上がった。", "Your proficiency of %s is now %s rank."), spell_name.data(), new_rank_str);
     } else {
         /* Find the next open entry in "player_ptr->spell_order[]" */
         int i;
@@ -885,16 +885,16 @@ void do_cmd_study(PlayerType *player_ptr)
         player_ptr->spell_order[i++] = spell;
 
         /* Mention the result */
-        const auto realm = increment ? player_ptr->realm2 : player_ptr->realm1;
-        const auto spell_name = exe_spell(player_ptr, realm, spell % 32, SpellProcessType::NAME);
+        const auto &realm = increment ? pr.realm2() : pr.realm1();
+        const auto &spell_name = realm.get_spell_name(spell % 32);
 #ifdef JP
         if (mp_ptr->spell_book == ItemKindType::MUSIC_BOOK) {
-            msg_format("%sを学んだ。", spell_name->data());
+            msg_format("%sを学んだ。", spell_name.data());
         } else {
-            msg_format("%sの%sを学んだ。", spell_name->data(), spell_category.data());
+            msg_format("%sの%sを学んだ。", spell_name.data(), spell_category.data());
         }
 #else
-        msg_format("You have learned the %s of %s.", spell_category.data(), spell_name->data());
+        msg_format("You have learned the %s of %s.", spell_category.data(), spell_name.data());
 #endif
     }
 

--- a/src/knowledge/knowledge-experiences.cpp
+++ b/src/knowledge/knowledge-experiences.cpp
@@ -95,8 +95,8 @@ void do_cmd_knowledge_spell_exp(PlayerType *player_ptr)
             }
             SUB_EXP spell_exp = player_ptr->spell_exp[i];
             auto skill_rank = PlayerSkill::spell_skill_rank(spell_exp);
-            const auto spell_name = exe_spell(player_ptr, player_ptr->realm1, i, SpellProcessType::NAME);
-            fprintf(fff, "%-25s ", spell_name->data());
+            const auto &spell_name = pr.realm1().get_spell_name(i);
+            fprintf(fff, "%-25s ", spell_name.data());
             if (pr.realm1().equals(REALM_HISSATSU)) {
                 if (show_actual_value) {
                     fprintf(fff, "----/---- ");
@@ -132,8 +132,8 @@ void do_cmd_knowledge_spell_exp(PlayerType *player_ptr)
 
             SUB_EXP spell_exp = player_ptr->spell_exp[i + 32];
             auto skill_rank = PlayerSkill::spell_skill_rank(spell_exp);
-            const auto spell_name = exe_spell(player_ptr, player_ptr->realm2, i, SpellProcessType::NAME);
-            fprintf(fff, "%-25s ", spell_name->data());
+            const auto spell_name = pr.realm2().get_spell_name(i);
+            fprintf(fff, "%-25s ", spell_name.data());
             if (show_actual_value) {
                 fprintf(fff, "%4d/%4d ", spell_exp, PlayerSkill::spell_exp_at(PlayerSkillRank::MASTER));
             }

--- a/src/player/player-realm.cpp
+++ b/src/player/player-realm.cpp
@@ -5,6 +5,7 @@
 #include "realm/realm-types.h"
 #include "system/angband-exceptions.h"
 #include "system/player-type-definition.h"
+#include "system/spell-info-list.h"
 #include "util/enum-converter.h"
 
 namespace {
@@ -110,6 +111,36 @@ const magic_type &PlayerRealm::get_spell_info(int realm, int spell_id, std::opti
     THROW_EXCEPTION(std::invalid_argument, format("Invalid realm: %d", realm));
 }
 
+const std::string &PlayerRealm::get_spell_name(int realm, int spell_id)
+{
+    if (spell_id < 0 || 32 <= spell_id) {
+        THROW_EXCEPTION(std::invalid_argument, format("Invalid spell id: %d", spell_id));
+    }
+
+    const auto realm_enum = i2enum<magic_realm_type>(realm);
+    if (!MAGIC_REALM_RANGE.contains(realm_enum) && !TECHNIC_REALM_RANGE.contains(realm_enum)) {
+        THROW_EXCEPTION(std::invalid_argument, format("Invalid realm: %d", realm));
+    }
+
+    const auto &spell_info = SpellInfoList::get_instance().spell_list[realm];
+    return spell_info[spell_id].name;
+}
+
+const std::string &PlayerRealm::get_spell_description(int realm, int spell_id)
+{
+    if (spell_id < 0 || 32 <= spell_id) {
+        THROW_EXCEPTION(std::invalid_argument, format("Invalid spell id: %d", spell_id));
+    }
+
+    const auto realm_enum = i2enum<magic_realm_type>(realm);
+    if (!MAGIC_REALM_RANGE.contains(realm_enum) && !TECHNIC_REALM_RANGE.contains(realm_enum)) {
+        THROW_EXCEPTION(std::invalid_argument, format("Invalid realm: %d", realm));
+    }
+
+    const auto &spell_info = SpellInfoList::get_instance().spell_list[realm];
+    return spell_info[spell_id].description;
+}
+
 ItemKindType PlayerRealm::get_book(int realm)
 {
     const auto it = realm_books.find(i2enum<magic_realm_type>(realm));
@@ -165,6 +196,16 @@ const LocalizedString &PlayerRealm::Realm::get_name() const
 const magic_type &PlayerRealm::Realm::get_spell_info(int spell_id) const
 {
     return PlayerRealm::get_spell_info(this->realm_, spell_id);
+}
+
+const std::string &PlayerRealm::Realm::get_spell_name(int spell_id) const
+{
+    return PlayerRealm::get_spell_name(this->realm_, spell_id);
+}
+
+const std::string &PlayerRealm::Realm::get_spell_description(int spell_id) const
+{
+    return PlayerRealm::get_spell_description(this->realm_, spell_id);
 }
 
 ItemKindType PlayerRealm::Realm::get_book() const

--- a/src/player/player-realm.cpp
+++ b/src/player/player-realm.cpp
@@ -89,22 +89,22 @@ const LocalizedString &PlayerRealm::get_name(int realm)
     return it->second;
 }
 
-const magic_type &PlayerRealm::get_spell_info(int realm, int spell_idx, std::optional<PlayerClassType> pclass)
+const magic_type &PlayerRealm::get_spell_info(int realm, int spell_id, std::optional<PlayerClassType> pclass)
 {
-    if (spell_idx < 0 || 32 <= spell_idx) {
-        THROW_EXCEPTION(std::invalid_argument, format("Invalid spell idx: %d", spell_idx));
+    if (spell_id < 0 || 32 <= spell_id) {
+        THROW_EXCEPTION(std::invalid_argument, format("Invalid spell id: %d", spell_id));
     }
 
     const auto realm_enum = i2enum<magic_realm_type>(realm);
 
     if (MAGIC_REALM_RANGE.contains(realm_enum)) {
         if (pclass) {
-            return class_magics_info.at(enum2i(*pclass)).info[realm - 1][spell_idx];
+            return class_magics_info.at(enum2i(*pclass)).info[realm - 1][spell_id];
         }
-        return mp_ptr->info[realm - 1][spell_idx];
+        return mp_ptr->info[realm - 1][spell_id];
     }
     if (TECHNIC_REALM_RANGE.contains(realm_enum)) {
-        return technic_info[realm - MIN_TECHNIC][spell_idx];
+        return technic_info[realm - MIN_TECHNIC][spell_id];
     }
 
     THROW_EXCEPTION(std::invalid_argument, format("Invalid realm: %d", realm));
@@ -162,9 +162,9 @@ const LocalizedString &PlayerRealm::Realm::get_name() const
     return PlayerRealm::get_name(this->realm_);
 }
 
-const magic_type &PlayerRealm::Realm::get_spell_info(int num) const
+const magic_type &PlayerRealm::Realm::get_spell_info(int spell_id) const
 {
-    return PlayerRealm::get_spell_info(this->realm_, num);
+    return PlayerRealm::get_spell_info(this->realm_, spell_id);
 }
 
 ItemKindType PlayerRealm::Realm::get_book() const

--- a/src/player/player-realm.h
+++ b/src/player/player-realm.h
@@ -20,6 +20,8 @@ public:
 
     static const LocalizedString &get_name(int realm);
     static const magic_type &get_spell_info(int realm, int spell_id, std::optional<PlayerClassType> pclass = std::nullopt);
+    static const std::string &get_spell_name(int realm, int spell_id);
+    static const std::string &get_spell_description(int realm, int spell_id);
     static ItemKindType get_book(int realm);
     static RealmChoices get_realm1_choices(PlayerClassType pclass);
     static RealmChoices get_realm2_choices(PlayerClassType pclass);
@@ -29,6 +31,8 @@ public:
         Realm(int realm);
         const LocalizedString &get_name() const;
         const magic_type &get_spell_info(int spell_id) const;
+        const std::string &get_spell_name(int spell_id) const;
+        const std::string &get_spell_description(int spell_id) const;
         ItemKindType get_book() const;
         bool is_available() const;
         bool is_good_attribute() const;

--- a/src/player/player-realm.h
+++ b/src/player/player-realm.h
@@ -19,7 +19,7 @@ public:
     PlayerRealm(PlayerType *player_ptr);
 
     static const LocalizedString &get_name(int realm);
-    static const magic_type &get_spell_info(int realm, int num, std::optional<PlayerClassType> pclass = std::nullopt);
+    static const magic_type &get_spell_info(int realm, int spell_id, std::optional<PlayerClassType> pclass = std::nullopt);
     static ItemKindType get_book(int realm);
     static RealmChoices get_realm1_choices(PlayerClassType pclass);
     static RealmChoices get_realm2_choices(PlayerClassType pclass);
@@ -28,7 +28,7 @@ public:
     public:
         Realm(int realm);
         const LocalizedString &get_name() const;
-        const magic_type &get_spell_info(int num) const;
+        const magic_type &get_spell_info(int spell_id) const;
         ItemKindType get_book() const;
         bool is_available() const;
         bool is_good_attribute() const;

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -567,28 +567,23 @@ static void update_num_of_spells(PlayerType *player_ptr)
             continue;
         }
 
-        int16_t which;
         if (j < 32) {
             set_bits(player_ptr->spell_forgotten1, (1UL << j));
-            which = player_ptr->realm1;
         } else {
             set_bits(player_ptr->spell_forgotten2, (1UL << (j - 32)));
-            which = player_ptr->realm2;
         }
 
         if (j < 32) {
             reset_bits(player_ptr->spell_learned1, (1UL << j));
-            which = player_ptr->realm1;
         } else {
             reset_bits(player_ptr->spell_learned2, (1UL << (j - 32)));
-            which = player_ptr->realm2;
         }
 
-        const auto spell_name = exe_spell(player_ptr, which, j % 32, SpellProcessType::NAME);
+        const auto &spell_name = realm.get_spell_name(j % 32);
 #ifdef JP
-        msg_format("%sの%sを忘れてしまった。", spell_name->data(), spell_category.data());
+        msg_format("%sの%sを忘れてしまった。", spell_name.data(), spell_category.data());
 #else
-        msg_format("You have forgotten the %s of %s.", spell_category.data(), spell_name->data());
+        msg_format("You have forgotten the %s of %s.", spell_category.data(), spell_name.data());
 #endif
         player_ptr->new_spells++;
     }
@@ -612,28 +607,24 @@ static void update_num_of_spells(PlayerType *player_ptr)
             continue;
         }
 
-        int16_t which;
         if (j < 32) {
             set_bits(player_ptr->spell_forgotten1, (1UL << j));
-            which = player_ptr->realm1;
         } else {
             set_bits(player_ptr->spell_forgotten2, (1UL << (j - 32)));
-            which = player_ptr->realm2;
         }
 
         if (j < 32) {
             reset_bits(player_ptr->spell_learned1, (1UL << j));
-            which = player_ptr->realm1;
         } else {
             reset_bits(player_ptr->spell_learned2, (1UL << (j - 32)));
-            which = player_ptr->realm2;
         }
 
-        const auto spell_name = exe_spell(player_ptr, which, j % 32, SpellProcessType::NAME);
+        const auto &realm = (j < 32) ? pr.realm1() : pr.realm2();
+        const auto &spell_name = realm.get_spell_name(j % 32);
 #ifdef JP
-        msg_format("%sの%sを忘れてしまった。", spell_name->data(), spell_category.data());
+        msg_format("%sの%sを忘れてしまった。", spell_name.data(), spell_category.data());
 #else
-        msg_format("You have forgotten the %s of %s.", spell_category.data(), spell_name->data());
+        msg_format("You have forgotten the %s of %s.", spell_category.data(), spell_name.data());
 #endif
         player_ptr->new_spells++;
     }
@@ -663,28 +654,24 @@ static void update_num_of_spells(PlayerType *player_ptr)
             continue;
         }
 
-        int16_t which;
         if (j < 32) {
             reset_bits(player_ptr->spell_forgotten1, (1UL << j));
-            which = player_ptr->realm1;
         } else {
             reset_bits(player_ptr->spell_forgotten2, (1UL << (j - 32)));
-            which = player_ptr->realm2;
         }
 
         if (j < 32) {
             set_bits(player_ptr->spell_learned1, (1UL << j));
-            which = player_ptr->realm1;
+
         } else {
             set_bits(player_ptr->spell_learned2, (1UL << (j - 32)));
-            which = player_ptr->realm2;
         }
 
-        const auto spell_name = exe_spell(player_ptr, which, j % 32, SpellProcessType::NAME);
+        const auto &spell_name = realm.get_spell_name(j % 32);
 #ifdef JP
-        msg_format("%sの%sを思い出した。", spell_name->data(), spell_category.data());
+        msg_format("%sの%sを思い出した。", spell_name.data(), spell_category.data());
 #else
-        msg_format("You have remembered the %s of %s.", spell_category.data(), spell_name->data());
+        msg_format("You have remembered the %s of %s.", spell_category.data(), spell_name.data());
 #endif
         player_ptr->new_spells--;
     }

--- a/src/realm/realm-arcane.cpp
+++ b/src/realm/realm-arcane.cpp
@@ -23,7 +23,6 @@
 #include "status/element-resistance.h"
 #include "status/sight-setter.h"
 #include "system/player-type-definition.h"
-#include "system/spell-info-list.h"
 #include "target/target-getter.h"
 #include "util/dice.h"
 #include "view/display-messages.h"
@@ -37,22 +36,11 @@
  */
 std::optional<std::string> do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
-    bool name = mode == SpellProcessType::NAME;
-    bool desc = mode == SpellProcessType::DESCRIPTION;
     bool info = mode == SpellProcessType::INFO;
     bool cast = mode == SpellProcessType::CAST;
 
     DIRECTION dir;
     PLAYER_LEVEL plev = player_ptr->lev;
-
-    auto &list = SpellInfoList::get_instance().spell_list[REALM_ARCANE];
-
-    if (name) {
-        return list[spell].name;
-    }
-    if (desc) {
-        return list[spell].description;
-    }
 
     switch (spell) {
     case 0: {

--- a/src/realm/realm-chaos.cpp
+++ b/src/realm/realm-chaos.cpp
@@ -23,7 +23,6 @@
 #include "status/shape-changer.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
-#include "system/spell-info-list.h"
 #include "target/target-getter.h"
 #include "util/dice.h"
 #include "view/display-messages.h"
@@ -37,22 +36,11 @@
  */
 std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
-    bool name = mode == SpellProcessType::NAME;
-    bool desc = mode == SpellProcessType::DESCRIPTION;
     bool info = mode == SpellProcessType::INFO;
     bool cast = mode == SpellProcessType::CAST;
 
     DIRECTION dir;
     PLAYER_LEVEL plev = player_ptr->lev;
-
-    auto &list = SpellInfoList::get_instance().spell_list[REALM_CHAOS];
-
-    if (name) {
-        return list[spell].name;
-    }
-    if (desc) {
-        return list[spell].description;
-    }
 
     switch (spell) {
     case 0: {

--- a/src/realm/realm-craft.cpp
+++ b/src/realm/realm-craft.cpp
@@ -19,7 +19,6 @@
 #include "status/element-resistance.h"
 #include "status/sight-setter.h"
 #include "system/player-type-definition.h"
-#include "system/spell-info-list.h"
 #include "view/display-messages.h"
 
 /*!
@@ -30,21 +29,10 @@
  */
 std::optional<std::string> do_craft_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
-    bool name = mode == SpellProcessType::NAME;
-    bool desc = mode == SpellProcessType::DESCRIPTION;
     bool info = mode == SpellProcessType::INFO;
     bool cast = mode == SpellProcessType::CAST;
 
     PLAYER_LEVEL plev = player_ptr->lev;
-
-    auto &list = SpellInfoList::get_instance().spell_list[REALM_CRAFT];
-
-    if (name) {
-        return list[spell].name;
-    }
-    if (desc) {
-        return list[spell].description;
-    }
 
     switch (spell) {
     case 0: {

--- a/src/realm/realm-crusade.cpp
+++ b/src/realm/realm-crusade.cpp
@@ -28,7 +28,6 @@
 #include "status/buff-setter.h"
 #include "status/sight-setter.h"
 #include "system/player-type-definition.h"
-#include "system/spell-info-list.h"
 #include "target/target-getter.h"
 #include "util/dice.h"
 #include "view/display-messages.h"
@@ -43,22 +42,11 @@
  */
 std::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
-    bool name = mode == SpellProcessType::NAME;
-    bool desc = mode == SpellProcessType::DESCRIPTION;
     bool info = mode == SpellProcessType::INFO;
     bool cast = mode == SpellProcessType::CAST;
 
     DIRECTION dir;
     PLAYER_LEVEL plev = player_ptr->lev;
-
-    auto &list = SpellInfoList::get_instance().spell_list[REALM_CRUSADE];
-
-    if (name) {
-        return list[spell].name;
-    }
-    if (desc) {
-        return list[spell].description;
-    }
 
     switch (spell) {
     case 0: {

--- a/src/realm/realm-death.cpp
+++ b/src/realm/realm-death.cpp
@@ -26,7 +26,6 @@
 #include "status/experience.h"
 #include "status/shape-changer.h"
 #include "system/player-type-definition.h"
-#include "system/spell-info-list.h"
 #include "target/target-getter.h"
 #include "util/dice.h"
 
@@ -39,22 +38,11 @@
  */
 std::optional<std::string> do_death_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
-    bool name = mode == SpellProcessType::NAME;
-    bool desc = mode == SpellProcessType::DESCRIPTION;
     bool info = mode == SpellProcessType::INFO;
     bool cast = mode == SpellProcessType::CAST;
 
     DIRECTION dir;
     PLAYER_LEVEL plev = player_ptr->lev;
-
-    auto &list = SpellInfoList::get_instance().spell_list[REALM_DEATH];
-
-    if (name) {
-        return list[spell].name;
-    }
-    if (desc) {
-        return list[spell].description;
-    }
 
     switch (spell) {
     case 0: {

--- a/src/realm/realm-demon.cpp
+++ b/src/realm/realm-demon.cpp
@@ -26,7 +26,6 @@
 #include "status/sight-setter.h"
 #include "status/temporary-resistance.h"
 #include "system/player-type-definition.h"
-#include "system/spell-info-list.h"
 #include "target/target-getter.h"
 #include "util/dice.h"
 #include "view/display-messages.h"
@@ -40,22 +39,11 @@
  */
 std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
-    bool name = mode == SpellProcessType::NAME;
-    bool desc = mode == SpellProcessType::DESCRIPTION;
     bool info = mode == SpellProcessType::INFO;
     bool cast = mode == SpellProcessType::CAST;
 
     DIRECTION dir;
     PLAYER_LEVEL plev = player_ptr->lev;
-
-    auto &list = SpellInfoList::get_instance().spell_list[REALM_DAEMON];
-
-    if (name) {
-        return list[spell].name;
-    }
-    if (desc) {
-        return list[spell].description;
-    }
 
     switch (spell) {
     case 0: {

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -26,6 +26,7 @@
 #include "object/item-tester-hooker.h"
 #include "object/item-use-flags.h"
 #include "player/attack-defense-types.h"
+#include "player/player-realm.h"
 #include "player/player-skill.h"
 #include "player/player-status.h"
 #include "spell-kind/magic-item-recharger.h"
@@ -43,7 +44,6 @@
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
-#include "system/spell-info-list.h"
 #include "target/grid-selector.h"
 #include "target/target-getter.h"
 #include "term/screen-processor.h"
@@ -64,23 +64,12 @@
  */
 std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type spell, SpellProcessType mode)
 {
-    auto name = mode == SpellProcessType::NAME;
-    auto description = mode == SpellProcessType::DESCRIPTION;
     auto info = mode == SpellProcessType::INFO;
     auto cast = mode == SpellProcessType::CAST;
     auto continuation = mode == SpellProcessType::CONTNUATION;
     auto stop = mode == SpellProcessType::STOP;
     auto should_continue = true;
     int power;
-
-    auto &list = SpellInfoList::get_instance().spell_list[REALM_HEX];
-
-    if (name) {
-        return list[spell].name;
-    }
-    if (description) {
-        return list[spell].description;
-    }
 
     switch (spell) {
         /*** 1st book (0-7) ***/
@@ -561,8 +550,8 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
             }
 
             if (!flag) {
-                const auto spell_name = exe_spell(player_ptr, REALM_HEX, HEX_RESTORE, SpellProcessType::NAME);
-                msg_format(_("%sの呪文の詠唱をやめた。", "Finish casting '%s^'."), spell_name->data());
+                const auto &spell_name = PlayerRealm::get_spell_name(REALM_HEX, HEX_RESTORE);
+                msg_format(_("%sの呪文の詠唱をやめた。", "Finish casting '%s^'."), spell_name.data());
                 SpellHex spell_hex(player_ptr);
                 spell_hex.reset_casting_flag(HEX_RESTORE);
                 if (!spell_hex.is_spelling_any()) {

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -46,7 +46,6 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
-#include "system/spell-info-list.h"
 #include "target/grid-selector.h"
 #include "target/projection-path-calculator.h"
 #include "target/target-getter.h"
@@ -65,20 +64,9 @@
  */
 std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell_id, SpellProcessType mode)
 {
-    bool name = mode == SpellProcessType::NAME;
-    bool desc = mode == SpellProcessType::DESCRIPTION;
     bool cast = mode == SpellProcessType::CAST;
 
     PLAYER_LEVEL plev = player_ptr->lev;
-
-    auto &list = SpellInfoList::get_instance().spell_list[REALM_HISSATSU];
-
-    if (name) {
-        return list[spell_id].name;
-    }
-    if (desc) {
-        return list[spell_id].description;
-    }
 
     switch (spell_id) {
     case 0:

--- a/src/realm/realm-life.cpp
+++ b/src/realm/realm-life.cpp
@@ -22,7 +22,6 @@
 #include "status/temporary-resistance.h"
 #include "system/floor-type-definition.h"
 #include "system/player-type-definition.h"
-#include "system/spell-info-list.h"
 #include "target/target-getter.h"
 #include "util/dice.h"
 
@@ -35,22 +34,11 @@
  */
 std::optional<std::string> do_life_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
-    bool name = mode == SpellProcessType::NAME;
-    bool desc = mode == SpellProcessType::DESCRIPTION;
     bool info = mode == SpellProcessType::INFO;
     bool cast = mode == SpellProcessType::CAST;
 
     DIRECTION dir;
     PLAYER_LEVEL plev = player_ptr->lev;
-
-    auto &list = SpellInfoList::get_instance().spell_list[REALM_LIFE];
-
-    if (name) {
-        return list[spell].name;
-    }
-    if (desc) {
-        return list[spell].description;
-    }
 
     switch (spell) {
     case 0: {

--- a/src/realm/realm-nature.cpp
+++ b/src/realm/realm-nature.cpp
@@ -38,7 +38,6 @@
 #include "sv-definition/sv-food-types.h"
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
-#include "system/spell-info-list.h"
 #include "target/target-getter.h"
 #include "util/dice.h"
 #include "view/display-messages.h"
@@ -52,22 +51,11 @@
  */
 std::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
-    bool name = mode == SpellProcessType::NAME;
-    bool desc = mode == SpellProcessType::DESCRIPTION;
     bool info = mode == SpellProcessType::INFO;
     bool cast = mode == SpellProcessType::CAST;
 
     DIRECTION dir;
     PLAYER_LEVEL plev = player_ptr->lev;
-
-    auto &list = SpellInfoList::get_instance().spell_list[REALM_NATURE];
-
-    if (name) {
-        return list[spell].name;
-    }
-    if (desc) {
-        return list[spell].description;
-    }
 
     switch (spell) {
     case 0: {

--- a/src/realm/realm-song.cpp
+++ b/src/realm/realm-song.cpp
@@ -23,7 +23,6 @@
 #include "status/experience.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
-#include "system/spell-info-list.h"
 #include "target/target-getter.h"
 #include "timed-effect/timed-effects.h"
 #include "util/dice.h"
@@ -61,8 +60,6 @@ static void start_singing(PlayerType *player_ptr, SPELL_IDX spell, int32_t song)
  */
 std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
-    bool name = mode == SpellProcessType::NAME;
-    bool desc = mode == SpellProcessType::DESCRIPTION;
     bool info = mode == SpellProcessType::INFO;
     bool cast = mode == SpellProcessType::CAST;
     bool fail = mode == SpellProcessType::FAIL;
@@ -71,15 +68,6 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
 
     DIRECTION dir;
     PLAYER_LEVEL plev = player_ptr->lev;
-
-    auto &list = SpellInfoList::get_instance().spell_list[REALM_MUSIC];
-
-    if (name) {
-        return list[spell].name;
-    }
-    if (desc) {
-        return list[spell].description;
-    }
 
     switch (spell) {
     case 0:

--- a/src/realm/realm-sorcery.cpp
+++ b/src/realm/realm-sorcery.cpp
@@ -23,7 +23,6 @@
 #include "status/buff-setter.h"
 #include "status/sight-setter.h"
 #include "system/player-type-definition.h"
-#include "system/spell-info-list.h"
 #include "target/target-getter.h"
 #include "util/dice.h"
 #include "view/display-messages.h"
@@ -37,22 +36,11 @@
  */
 std::optional<std::string> do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
-    bool name = mode == SpellProcessType::NAME;
-    bool desc = mode == SpellProcessType::DESCRIPTION;
     bool info = mode == SpellProcessType::INFO;
     bool cast = mode == SpellProcessType::CAST;
 
     DIRECTION dir;
     PLAYER_LEVEL plev = player_ptr->lev;
-
-    auto &list = SpellInfoList::get_instance().spell_list[REALM_SORCERY];
-
-    if (name) {
-        return list[spell].name;
-    }
-    if (desc) {
-        return list[spell].description;
-    }
 
     switch (spell) {
     case 0: {

--- a/src/realm/realm-trump.cpp
+++ b/src/realm/realm-trump.cpp
@@ -23,7 +23,6 @@
 #include "spell/summon-types.h"
 #include "status/sight-setter.h"
 #include "system/player-type-definition.h"
-#include "system/spell-info-list.h"
 #include "target/target-checker.h"
 #include "target/target-getter.h"
 #include "target/target-setter.h"
@@ -39,23 +38,12 @@
  */
 std::optional<std::string> do_trump_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
-    bool name = mode == SpellProcessType::NAME;
-    bool desc = mode == SpellProcessType::DESCRIPTION;
     bool info = mode == SpellProcessType::INFO;
     bool cast = mode == SpellProcessType::CAST;
     bool fail = mode == SpellProcessType::FAIL;
 
     DIRECTION dir;
     PLAYER_LEVEL plev = player_ptr->lev;
-
-    auto &list = SpellInfoList::get_instance().spell_list[REALM_TRUMP];
-
-    if (name) {
-        return list[spell].name;
-    }
-    if (desc) {
-        return list[spell].description;
-    }
 
     switch (spell) {
     case 0: {

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -170,8 +170,8 @@ void SpellHex::display_casting_spells_list()
     prt(_("     名前", "     Name"), y, x + 5);
     for (auto spell : this->casting_spells) {
         term_erase(x, y + n + 1);
-        const auto spell_name = exe_spell(this->player_ptr, REALM_HEX, spell, SpellProcessType::NAME);
-        put_str(format("%c)  %s", I2A(n), spell_name->data()), y + n + 1, x + 2);
+        const auto &spell_name = PlayerRealm::get_spell_name(REALM_HEX, spell);
+        put_str(format("%c)  %s", I2A(n), spell_name.data()), y + n + 1, x + 2);
         n++;
     }
 }

--- a/src/spell/spell-info.cpp
+++ b/src/spell/spell-info.cpp
@@ -326,11 +326,11 @@ void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell_id, const SPELL
             line_attr = TERM_L_GREEN;
         }
 
-        const auto spell_name = exe_spell(player_ptr, use_realm, spell_id, SpellProcessType::NAME);
+        const auto &spell_name = PlayerRealm::get_spell_name(use_realm, spell_id);
         if (use_realm == REALM_HISSATSU) {
-            out_val.append(format("%-25s %2d %4d", spell_name->data(), spell.slevel, need_mana));
+            out_val.append(format("%-25s %2d %4d", spell_name.data(), spell.slevel, need_mana));
         } else {
-            out_val.append(format("%-25s%c%-4s %2d %4d %3d%% %s", spell_name->data(), (max ? '!' : ' '), ryakuji, spell.slevel,
+            out_val.append(format("%-25s%c%-4s %2d %4d %3d%% %s", spell_name.data(), (max ? '!' : ' '), ryakuji, spell.slevel,
                 need_mana, spell_chance(player_ptr, spell_id, use_realm), comment));
         }
 

--- a/src/spell/spells-util.h
+++ b/src/spell/spells-util.h
@@ -5,13 +5,11 @@
 #define DETECT_RAD_ALL 255
 
 enum class SpellProcessType {
-    NAME = 0,
-    DESCRIPTION = 1,
-    INFO = 2,
-    CAST = 3,
-    FAIL = 4,
-    STOP = 5,
-    CONTNUATION = 6
+    INFO,
+    CAST,
+    FAIL,
+    STOP,
+    CONTNUATION,
 };
 
 enum spell_operation {

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -828,10 +828,10 @@ static void display_spell_list(PlayerType *player_ptr)
         for (int i = 0; i < 32; i++) {
             byte a = TERM_WHITE;
 
-            const auto realm = (j < 1) ? player_ptr->realm1 : player_ptr->realm2;
-            const auto &spell = PlayerRealm::get_spell_info(realm, i % 32);
-            const auto spell_name = exe_spell(player_ptr, realm, i % 32, SpellProcessType::NAME);
-            auto name = spell_name->data();
+            const auto &realm = (j < 1) ? pr.realm1() : pr.realm2();
+            const auto &spell = realm.get_spell_info(i);
+            const auto &spell_name = realm.get_spell_name(i % 32);
+            auto name = spell_name.data();
 
             if (spell.slevel >= 99) {
                 name = _("(判読不能)", "(illegible)");

--- a/src/wizard/wizard-spoiler.cpp
+++ b/src/wizard/wizard-spoiler.cpp
@@ -219,8 +219,8 @@ static SpoilerOutputResultType spoil_player_spell()
             spoil_out("Name                     Lv Cst Dif Exp\n");
             for (SPELL_IDX i = 0; i < 32; i++) {
                 const auto &spell = PlayerRealm::get_spell_info(realm, i, pclass);
-                const auto spell_name = exe_spell(&dummy_p, realm, i, SpellProcessType::NAME);
-                spoil_out(format("%-24s %2d %3d %3d %3d\n", spell_name->data(), spell.slevel, spell.smana, spell.sfail, spell.sexp));
+                const auto &spell_name = PlayerRealm::get_spell_name(realm, i);
+                spoil_out(format("%-24s %2d %3d %3d %3d\n", spell_name.data(), spell.slevel, spell.smana, spell.sfail, spell.sexp));
             }
             spoil_out("\n");
         }


### PR DESCRIPTION
#4357 の一環

呪文の名称と説明が realm-*.cpp から分離されたことにより、いろいろやらせすぎな exe_spell から呪文の名称と説明の取得処理を分離することが可能となったので対応しました。