### PR TITLE
[Refactor] SpellInfoListクラスのカプセル化を促進

### DIFF
--- a/src/info-reader/spell-reader.cpp
+++ b/src/info-reader/spell-reader.cpp
@@ -104,10 +104,10 @@ static errr set_book_data(const nlohmann::json &spell_data, std::vector<SpellInf
 /*!
  * @brief 職業魔法情報(ClassMagicDefinitions)のパース関数
  * @param buf テキスト列
- * @param head ヘッダ構造体
+ * @param spell_list パースした結果を格納する領域
  * @return エラーコード
  */
-errr parse_spell_info(nlohmann::json &spell_data, angband_header *)
+errr parse_spell_info(nlohmann::json &spell_data, std::vector<std::vector<SpellInfo>> &spell_list)
 {
     int realm_id;
     if (auto err = set_realm(spell_data, realm_id)) {
@@ -115,8 +115,7 @@ errr parse_spell_info(nlohmann::json &spell_data, angband_header *)
         return err;
     }
 
-    auto &spell_info_list = SpellInfoList::get_instance();
-    auto &realm_spell_list = spell_info_list.spell_list[realm_id];
+    auto &realm_spell_list = spell_list[realm_id];
 
     if (auto err = set_book_data(spell_data, realm_spell_list)) {
         msg_format(_("呪文詳細読込失敗。ID: '%d'。", "Failed to load spell data. ID: '%d'."), error_idx);

--- a/src/info-reader/spell-reader.h
+++ b/src/info-reader/spell-reader.h
@@ -2,7 +2,7 @@
 
 #include "external-lib/include-json.h"
 #include "system/angband.h"
-#include <string_view>
+#include <vector>
 
-struct angband_header;
-errr parse_spell_info(nlohmann::json &spell_data, angband_header *head);
+class SpellInfo;
+errr parse_spell_info(nlohmann::json &spell_data, std::vector<std::vector<SpellInfo>> &spell_list);

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -17,7 +17,6 @@
 #include "info-reader/magic-reader.h"
 #include "info-reader/race-reader.h"
 #include "info-reader/skill-reader.h"
-#include "info-reader/spell-reader.h"
 #include "info-reader/vault-reader.h"
 #include "io/files-util.h"
 #include "io/uid-checker.h"
@@ -241,8 +240,11 @@ void init_spell_info()
 {
     init_header(&spells_header);
     auto &spell_info_list = SpellInfoList::get_instance();
-    spell_info_list.initiallize();
-    init_json("SpellDefinitions.jsonc", "realms", spells_header, spell_info_list, parse_spell_info);
+    spell_info_list.initialize();
+    auto parser = [&spell_info_list](nlohmann::json &spell_data, angband_header *) {
+        return spell_info_list.parse(spell_data);
+    };
+    init_json("SpellDefinitions.jsonc", "realms", spells_header, spell_info_list, parser);
 }
 
 /*!

--- a/src/player/player-realm.cpp
+++ b/src/player/player-realm.cpp
@@ -122,8 +122,8 @@ const std::string &PlayerRealm::get_spell_name(int realm, int spell_id)
         THROW_EXCEPTION(std::invalid_argument, format("Invalid realm: %d", realm));
     }
 
-    const auto &spell_info = SpellInfoList::get_instance().spell_list[realm];
-    return spell_info[spell_id].name;
+    const auto &spell_info = SpellInfoList::get_instance().get_spell_info(realm, spell_id);
+    return spell_info.name;
 }
 
 const std::string &PlayerRealm::get_spell_description(int realm, int spell_id)
@@ -137,8 +137,8 @@ const std::string &PlayerRealm::get_spell_description(int realm, int spell_id)
         THROW_EXCEPTION(std::invalid_argument, format("Invalid realm: %d", realm));
     }
 
-    const auto &spell_info = SpellInfoList::get_instance().spell_list[realm];
-    return spell_info[spell_id].description;
+    const auto &spell_info = SpellInfoList::get_instance().get_spell_info(realm, spell_id);
+    return spell_info.description;
 }
 
 ItemKindType PlayerRealm::get_book(int realm)

--- a/src/system/spell-info-list.cpp
+++ b/src/system/spell-info-list.cpp
@@ -1,10 +1,11 @@
 #include "system/spell-info-list.h"
+#include "info-reader/spell-reader.h"
 #include "realm/realm-types.h"
 #include <algorithm>
 
 SpellInfoList SpellInfoList::instance{};
 
-void SpellInfoList::initiallize()
+void SpellInfoList::initialize()
 {
     this->spell_list.assign(magic_realm_type::REALM_MAX, std::vector<SpellInfo>(SPELLS_IN_REALM));
 }
@@ -14,7 +15,7 @@ SpellInfoList &SpellInfoList::get_instance()
     return instance;
 }
 
-std::optional<short> SpellInfoList::get_spell_id(int realm_id, std::string_view spell_tag)
+std::optional<short> SpellInfoList::get_spell_id(int realm_id, std::string_view spell_tag) const
 {
     const auto &realm = this->spell_list[realm_id];
     const auto result = std::find_if(realm.begin(), realm.end(), [spell_tag](auto &spell_info) {
@@ -25,4 +26,14 @@ std::optional<short> SpellInfoList::get_spell_id(int realm_id, std::string_view 
         return std::nullopt;
     }
     return (*result).idx;
+}
+
+const SpellInfo &SpellInfoList::get_spell_info(int realm_id, int spell_id) const
+{
+    return this->spell_list[realm_id][spell_id];
+}
+
+errr SpellInfoList::parse(nlohmann::json &spell_data)
+{
+    return parse_spell_info(spell_data, this->spell_list);
 }

--- a/src/system/spell-info-list.h
+++ b/src/system/spell-info-list.h
@@ -1,9 +1,11 @@
 #pragma once
 
-#include "realm/realm-types.h"
+#include "external-lib/include-json.h"
 #include "system/angband.h"
-#include "util/flag-group.h"
-#include <array>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
 #include <vector>
 
 constexpr int SPELLS_IN_REALM = 32;
@@ -43,15 +45,18 @@ public:
     SpellInfoList &operator=(SpellInfoList &&) = delete;
     ~SpellInfoList() = default;
 
-    void initiallize();
+    void initialize();
+    errr parse(nlohmann::json &spell_data);
 
     static SpellInfoList &get_instance();
-    std::vector<std::vector<SpellInfo>> spell_list{};
 
-    std::optional<short> get_spell_id(int realm, std::string_view spell_tag);
+    std::optional<short> get_spell_id(int realm, std::string_view spell_tag) const;
+    const SpellInfo &get_spell_info(int realm, int spell_id) const;
 
 private:
     SpellInfoList() = default;
 
     static SpellInfoList instance;
+
+    std::vector<std::vector<SpellInfo>> spell_list{};
 };


### PR DESCRIPTION
SpellInfoListのデータメンバ spell_info のアクセルレベルをprivateにし、 get_spell_info メソッド経由で情報を取得するようにして実装のカプセル化を促進する。

単体Issueはありません。
spell_listというデータメンバに直接アクセスしているのが気になったので修正しました。その他、include調整、スペルミス修正、constメンバ関数にし忘れなども合わせて修正しています。