### PR TITLE
[Refactor] 魔法領域のセット処理

### DIFF
--- a/src/birth/birth-select-realm.cpp
+++ b/src/birth/birth-select-realm.cpp
@@ -291,8 +291,8 @@ bool get_player_realms(PlayerType *player_ptr)
     put_str("                                   ", 5, 40);
     put_str("                                   ", 6, 40);
 
-    player_ptr->realm1 = REALM_NONE;
-    player_ptr->realm2 = REALM_NONE;
+    PlayerRealm pr(player_ptr);
+    pr.reset();
 
     if (PlayerClass(player_ptr).equals(PlayerClassType::ELEMENTALIST)) {
         player_ptr->element = select_element_realm(player_ptr);
@@ -313,7 +313,7 @@ bool get_player_realms(PlayerType *player_ptr)
     if (*realm1 == REALM_NONE) {
         return true;
     }
-    player_ptr->realm1 = *realm1;
+    pr.set(*realm1);
     print_choosed_realms(player_ptr);
 
     /* Select the second realm */
@@ -324,7 +324,7 @@ bool get_player_realms(PlayerType *player_ptr)
     if (*realm2 == REALM_NONE) {
         return true;
     }
-    player_ptr->realm2 = *realm2;
+    pr.set(*realm1, *realm2);
     print_choosed_realms(player_ptr);
 
     return true;

--- a/src/birth/quick-start.cpp
+++ b/src/birth/quick-start.cpp
@@ -7,6 +7,7 @@
 #include "player-info/class-info.h"
 #include "player-info/race-info.h"
 #include "player/player-personality.h"
+#include "player/player-realm.h"
 #include "player/player-sex.h"
 #include "player/player-status.h"
 #include "player/process-name.h"
@@ -136,13 +137,14 @@ void load_prev_data(PlayerType *player_ptr, bool swap)
     player_ptr->pclass = previous_char.pclass;
     player_ptr->ppersonality = previous_char.ppersonality;
 
+    PlayerRealm pr(player_ptr);
+    pr.reset();
     if (PlayerClass(player_ptr).equals(PlayerClassType::ELEMENTALIST)) {
         player_ptr->element = previous_char.realm1;
     } else {
-        player_ptr->realm1 = previous_char.realm1;
+        pr.set(previous_char.realm1, previous_char.realm2);
     }
 
-    player_ptr->realm2 = previous_char.realm2;
     player_ptr->age = previous_char.age;
     player_ptr->ht = previous_char.ht;
     player_ptr->wt = previous_char.wt;

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -700,11 +700,13 @@ static void change_realm2(PlayerType *player_ptr, int16_t next_realm)
     player_ptr->spell_worked2 = 0L;
     player_ptr->spell_forgotten2 = 0L;
 
+    PlayerRealm pr(player_ptr);
+
     constexpr auto fmt_realm = _("魔法の領域を%sから%sに変更した。", "changed magic realm from %s to %s.");
     const auto mes = format(fmt_realm, PlayerRealm(player_ptr).realm2().get_name().data(), PlayerRealm::get_name(next_realm).data());
     exe_write_diary(*player_ptr->current_floor_ptr, DiaryKind::DESCRIPTION, 0, mes);
     player_ptr->old_realm |= 1U << (player_ptr->realm2 - 1);
-    player_ptr->realm2 = next_realm;
+    pr.set(player_ptr->realm1, next_realm);
 
     static constexpr auto flags = {
         StatusRecalculatingFlag::REORDER,

--- a/src/load/load-zangband.cpp
+++ b/src/load/load-zangband.cpp
@@ -13,6 +13,7 @@
 #include "player/attack-defense-types.h"
 #include "player/patron.h"
 #include "player/player-personality.h"
+#include "player/player-realm.h"
 #include "player/player-skill.h"
 #include "realm/realm-types.h"
 #include "spell/spells-status.h"
@@ -84,20 +85,13 @@ void load_zangband_options(void)
 
 void set_zangband_realm(PlayerType *player_ptr)
 {
+    PlayerRealm pr(player_ptr);
     if (player_ptr->realm1 == 9) {
-        player_ptr->realm1 = REALM_MUSIC;
-    }
-
-    if (player_ptr->realm2 == 9) {
-        player_ptr->realm2 = REALM_MUSIC;
+        pr.set(REALM_MUSIC);
     }
 
     if (player_ptr->realm1 == 10) {
-        player_ptr->realm1 = REALM_HISSATSU;
-    }
-
-    if (player_ptr->realm2 == 10) {
-        player_ptr->realm2 = REALM_HISSATSU;
+        pr.set(REALM_HISSATSU);
     }
 }
 

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -18,6 +18,7 @@
 #include "player-info/mane-data-type.h"
 #include "player-info/sniper-data-type.h"
 #include "player/attack-defense-types.h"
+#include "player/player-realm.h"
 #include "player/player-skill.h"
 #include "spell-realm/spells-song.h"
 #include "system/angband-exceptions.h"
@@ -35,16 +36,21 @@
  */
 static void rd_realms(PlayerType *player_ptr)
 {
+    PlayerRealm pr(player_ptr);
+    pr.reset();
+
     if (PlayerClass(player_ptr).equals(PlayerClassType::ELEMENTALIST)) {
         player_ptr->element = rd_byte();
-    } else {
-        player_ptr->realm1 = rd_byte();
+        (void)rd_byte();
+        return;
     }
 
-    player_ptr->realm2 = rd_byte();
-    if (player_ptr->realm2 == 255) {
-        player_ptr->realm2 = 0;
+    const auto realm1 = rd_byte();
+    auto realm2 = rd_byte();
+    if (realm2 == 255) { // 何のため？
+        realm2 = 0;
     }
+    pr.set(realm1, realm2);
 }
 
 /*!

--- a/src/player/player-realm.cpp
+++ b/src/player/player-realm.cpp
@@ -77,7 +77,8 @@ const std::map<PlayerClassType, RealmChoices> realm2_choices = {
 }
 
 PlayerRealm::PlayerRealm(PlayerType *player_ptr)
-    : realm1_(player_ptr->realm1)
+    : player_ptr(player_ptr)
+    , realm1_(player_ptr->realm1)
     , realm2_(player_ptr->realm2)
 {
 }
@@ -214,6 +215,33 @@ const PlayerRealm::Realm &PlayerRealm::realm2() const
 bool PlayerRealm::is_realm_hex() const
 {
     return this->realm1_.equals(REALM_HEX);
+}
+
+void PlayerRealm::reset()
+{
+    this->set_(REALM_NONE, REALM_NONE);
+}
+
+void PlayerRealm::set(int realm1, int realm2)
+{
+    const auto realm1_enum = i2enum<magic_realm_type>(realm1);
+    if (!MAGIC_REALM_RANGE.contains(realm1_enum) && !TECHNIC_REALM_RANGE.contains(realm1_enum)) {
+        THROW_EXCEPTION(std::invalid_argument, format("Invalid realm1: %d", realm1));
+    }
+    const auto realm2_enum = i2enum<magic_realm_type>(realm2);
+    if (realm2 != REALM_NONE && !MAGIC_REALM_RANGE.contains(realm2_enum) && !TECHNIC_REALM_RANGE.contains(realm2_enum)) {
+        THROW_EXCEPTION(std::invalid_argument, format("Invalid realm2: %d", realm2));
+    }
+
+    this->set_(realm1, realm2);
+}
+
+void PlayerRealm::set_(int realm1, int realm2)
+{
+    this->player_ptr->realm1 = static_cast<int16_t>(realm1);
+    this->player_ptr->realm2 = static_cast<int16_t>(realm2);
+    this->realm1_ = Realm(realm1);
+    this->realm2_ = Realm(realm2);
 }
 
 PlayerRealm::Realm::Realm(int realm)

--- a/src/player/player-realm.h
+++ b/src/player/player-realm.h
@@ -52,8 +52,13 @@ public:
     const Realm &realm1() const;
     const Realm &realm2() const;
     bool is_realm_hex() const;
+    void reset();
+    void set(int realm1, int realm2 = REALM_NONE);
 
 private:
+    void set_(int realm1, int realm2);
+
+    PlayerType *player_ptr;
     Realm realm1_;
     Realm realm2_;
 };

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -61,6 +61,7 @@
 #include "player-status/player-energy.h"
 #include "player/digestion-processor.h"
 #include "player/patron.h"
+#include "player/player-realm.h"
 #include "player/player-skill.h"
 #include "player/player-status-table.h"
 #include "player/player-status.h"
@@ -637,6 +638,7 @@ void wiz_reset_class(PlayerType *player_ptr)
  */
 void wiz_reset_realms(PlayerType *player_ptr)
 {
+    PlayerRealm pr(player_ptr);
     const auto new_realm1 = input_numerics("1st Realm (None=0)", 0, REALM_MAX - 1, player_ptr->realm1);
     if (!new_realm1) {
         return;
@@ -647,8 +649,7 @@ void wiz_reset_realms(PlayerType *player_ptr)
         return;
     }
 
-    player_ptr->realm1 = *new_realm1;
-    player_ptr->realm2 = *new_realm2;
+    pr.set(*new_realm1, *new_realm2);
     change_birth_flags();
     handle_stuff(player_ptr);
 }


### PR DESCRIPTION
#4357 の一環

PlayerRealmに魔法領域をセットするメンバ関数 set と魔法領域なしにするメンバ関数 reset を実装し、PlayerTypeのデータメンバrealm1とrelam2に直接 値をセットしている箇所を置き換える。