### PR TITLE
[Refactor] 魔法領域の取得処理 

### DIFF
--- a/src/avatar/avatar.cpp
+++ b/src/avatar/avatar.cpp
@@ -377,14 +377,14 @@ void initialize_virtues(PlayerType *player_ptr)
     /* Get a virtue_names for realms */
     PlayerRealm pr(player_ptr);
     if (pr.realm1().is_available()) {
-        tmp_vir = get_realm_virtues(player_ptr, player_ptr->realm1);
+        tmp_vir = get_realm_virtues(player_ptr, pr.realm1().to_enum());
         if (tmp_vir != Virtue::NONE) {
             player_ptr->vir_types[i++] = tmp_vir;
         }
     }
 
     if (pr.realm2().is_available()) {
-        tmp_vir = get_realm_virtues(player_ptr, player_ptr->realm2);
+        tmp_vir = get_realm_virtues(player_ptr, pr.realm2().to_enum());
         if (tmp_vir != Virtue::NONE) {
             player_ptr->vir_types[i++] = tmp_vir;
         }

--- a/src/birth/inventory-initializer.cpp
+++ b/src/birth/inventory-initializer.cpp
@@ -264,7 +264,7 @@ void player_outfit(PlayerType *player_ptr)
 
         /* Only assassins get a poisoned weapon */
         ItemEntity item({ tval, sval });
-        if (((tval == ItemKindType::SWORD) || (tval == ItemKindType::HAFTED)) && (pc.equals(PlayerClassType::ROGUE) && (player_ptr->realm1 == REALM_DEATH))) {
+        if (((tval == ItemKindType::SWORD) || (tval == ItemKindType::HAFTED)) && (pc.equals(PlayerClassType::ROGUE) && prealm.realm1().equals(REALM_DEATH))) {
             item.ego_idx = EgoType::BRAND_POIS;
         }
 

--- a/src/birth/quick-start.cpp
+++ b/src/birth/quick-start.cpp
@@ -90,11 +90,13 @@ void save_prev_data(PlayerType *player_ptr, birther *birther_ptr)
 
     if (PlayerClass(player_ptr).equals(PlayerClassType::ELEMENTALIST)) {
         birther_ptr->realm1 = player_ptr->element;
+        birther_ptr->realm2 = 0;
     } else {
-        birther_ptr->realm1 = player_ptr->realm1;
+        PlayerRealm pr(player_ptr);
+        birther_ptr->realm1 = pr.realm1().to_enum();
+        birther_ptr->realm2 = pr.realm2().to_enum();
     }
 
-    birther_ptr->realm2 = player_ptr->realm2;
     birther_ptr->age = player_ptr->age;
     birther_ptr->ht = player_ptr->ht;
     birther_ptr->wt = player_ptr->wt;

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -705,8 +705,8 @@ static void change_realm2(PlayerType *player_ptr, int16_t next_realm)
     constexpr auto fmt_realm = _("魔法の領域を%sから%sに変更した。", "changed magic realm from %s to %s.");
     const auto mes = format(fmt_realm, PlayerRealm(player_ptr).realm2().get_name().data(), PlayerRealm::get_name(next_realm).data());
     exe_write_diary(*player_ptr->current_floor_ptr, DiaryKind::DESCRIPTION, 0, mes);
-    player_ptr->old_realm |= 1U << (player_ptr->realm2 - 1);
-    pr.set(player_ptr->realm1, next_realm);
+    player_ptr->old_realm |= 1U << (enum2i(pr.realm2().to_enum()) - 1);
+    pr.set(pr.realm1().to_enum(), next_realm);
 
     static constexpr auto flags = {
         StatusRecalculatingFlag::REORDER,
@@ -807,7 +807,8 @@ void do_cmd_study(PlayerType *player_ptr)
             /* Check spells in the book */
             if ((fake_spell_flags[sval] & (1UL << spell))) {
                 /* Skip non "okay" prayers */
-                if (!spell_okay(player_ptr, spell, false, true, (increment ? player_ptr->realm2 : player_ptr->realm1))) {
+                const auto &realm = increment ? pr.realm2() : pr.realm1();
+                if (!spell_okay(player_ptr, spell, false, true, realm.to_enum())) {
                     continue;
                 }
 

--- a/src/load/load-zangband.cpp
+++ b/src/load/load-zangband.cpp
@@ -86,11 +86,12 @@ void load_zangband_options(void)
 void set_zangband_realm(PlayerType *player_ptr)
 {
     PlayerRealm pr(player_ptr);
-    if (player_ptr->realm1 == 9) {
+    const auto realm1 = enum2i(pr.realm1().to_enum());
+    if (realm1 == 9) {
         pr.set(REALM_MUSIC);
     }
 
-    if (player_ptr->realm1 == 10) {
+    if (realm1 == 10) {
         pr.set(REALM_HISSATSU);
     }
 }

--- a/src/market/building-service.cpp
+++ b/src/market/building-service.cpp
@@ -1,5 +1,6 @@
 #include "market/building-service.h"
 #include "player-base/player-class.h"
+#include "player/player-realm.h"
 #include "realm/realm-names-table.h"
 #include "system/building-type-definition.h"
 #include "system/player-type-definition.h"
@@ -27,8 +28,9 @@ bool is_owner(PlayerType *player_ptr, building_type *bldg)
         return true;
     }
 
-    int16_t realm1 = player_ptr->realm1;
-    int16_t realm2 = player_ptr->realm2;
+    PlayerRealm pr(player_ptr);
+    const auto realm1 = pr.realm1().to_enum();
+    const auto realm2 = pr.realm2().to_enum();
     if ((is_magic(realm1) && (bldg->member_realm[realm1] == building_owner)) || (is_magic(realm2) && (bldg->member_realm[realm2] == building_owner))) {
         return true;
     }
@@ -56,8 +58,9 @@ bool is_member(PlayerType *player_ptr, building_type *bldg)
         return true;
     }
 
-    int16_t realm1 = player_ptr->realm1;
-    int16_t realm2 = player_ptr->realm2;
+    PlayerRealm pr(player_ptr);
+    const auto realm1 = pr.realm1().to_enum();
+    const auto realm2 = pr.realm2().to_enum();
     if ((is_magic(realm1) && bldg->member_realm[realm1]) || (is_magic(realm2) && bldg->member_realm[realm2])) {
         return true;
     }

--- a/src/player/player-realm.cpp
+++ b/src/player/player-realm.cpp
@@ -298,3 +298,8 @@ bool PlayerRealm::Realm::equals(int realm) const
 {
     return this->realm_ == realm;
 }
+
+magic_realm_type PlayerRealm::Realm::to_enum() const
+{
+    return i2enum<magic_realm_type>(this->realm_);
+}

--- a/src/player/player-realm.h
+++ b/src/player/player-realm.h
@@ -44,6 +44,7 @@ public:
         bool is_available() const;
         bool is_good_attribute() const;
         bool equals(int realm) const;
+        magic_realm_type to_enum() const;
 
     private:
         int realm_;

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -3,6 +3,7 @@
 #include "market/arena-entry.h"
 #include "object/tval-types.h"
 #include "player-base/player-class.h"
+#include "player/player-realm.h"
 #include "player/player-skill.h"
 #include "save/info-writer.h"
 #include "save/player-class-specific-data-writer.h"
@@ -23,12 +24,13 @@
  */
 static void wr_relams(PlayerType *player_ptr)
 {
+    PlayerRealm pr(player_ptr);
     if (PlayerClass(player_ptr).equals(PlayerClassType::ELEMENTALIST)) {
         wr_byte((byte)player_ptr->element);
     } else {
-        wr_byte((byte)player_ptr->realm1);
+        wr_byte((byte)pr.realm1().to_enum());
     }
-    wr_byte((byte)player_ptr->realm2);
+    wr_byte((byte)pr.realm2().to_enum());
 }
 
 /*!

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -639,12 +639,12 @@ void wiz_reset_class(PlayerType *player_ptr)
 void wiz_reset_realms(PlayerType *player_ptr)
 {
     PlayerRealm pr(player_ptr);
-    const auto new_realm1 = input_numerics("1st Realm (None=0)", 0, REALM_MAX - 1, player_ptr->realm1);
+    const auto new_realm1 = input_numerics("1st Realm (None=0)", 0, REALM_MAX - 1, pr.realm1().to_enum());
     if (!new_realm1) {
         return;
     }
 
-    const auto new_realm2 = input_numerics("2nd Realm (None=0)", 0, REALM_MAX - 1, player_ptr->realm2);
+    const auto new_realm2 = input_numerics("2nd Realm (None=0)", 0, REALM_MAX - 1, pr.realm2().to_enum());
     if (!new_realm2) {
         return;
     }


### PR DESCRIPTION
#4357 の一環

PlayerRealm::Realmクラスにメンバ関数 to_enum() を実装し、魔法領域番号を取得するために直接PlayerRealmクラスのデータメンバrealm1とrealm2にアクセスしている箇所を置き換える。

これで player_ptr->realm1 と realm2 にアクセスするのは PlayerRealm クラスのみになります。