### PR TITLE
[Refactor] 呪文領域番号を1-originに統一する

### DIFF
--- a/src/info-reader/magic-reader.cpp
+++ b/src/info-reader/magic-reader.cpp
@@ -161,7 +161,7 @@ static errr set_spell_data(const nlohmann::json &spell_data, player_magic &magic
     if (!spell_id) {
         return PARSE_ERROR_INVALID_FLAG;
     }
-    auto &info = magics_info.info[enum2i(realm) - 1][*spell_id];
+    auto &info = magics_info.info[enum2i(realm)][*spell_id];
 
     if (auto err = info_set_integer(spell_data["learn_level"], info.slevel, true, Range(0, 99))) {
         msg_format(_("呪文学習レベル読込失敗。ID: '%d'。", "Failed to load spell learn_level. ID: '%d'."), error_idx);

--- a/src/player-info/class-info.h
+++ b/src/player-info/class-info.h
@@ -30,7 +30,7 @@ struct player_magic {
     int spell_first{}; /* Level of first spell */
     int spell_weight{}; /* Weight that hurts spells */
 
-    magic_type info[MAX_MAGIC][32]{}; /* The available spells */
+    magic_type info[MAX_MAGIC + 1][32]{}; /* The available spells */
 };
 
 extern std::vector<player_magic> class_magics_info;

--- a/src/player/player-realm.cpp
+++ b/src/player/player-realm.cpp
@@ -124,9 +124,9 @@ const magic_type &PlayerRealm::get_spell_info(RealmType realm, int spell_id, std
 
     if (is_magic(realm)) {
         if (pclass) {
-            return class_magics_info.at(enum2i(*pclass)).info[enum2i(realm) - 1][spell_id];
+            return class_magics_info.at(enum2i(*pclass)).info[enum2i(realm)][spell_id];
         }
-        return mp_ptr->info[enum2i(realm) - 1][spell_id];
+        return mp_ptr->info[enum2i(realm)][spell_id];
     }
     if (is_technic(realm)) {
         return technic_info[enum2i(realm) - MIN_TECHNIC][spell_id];


### PR DESCRIPTION
一部呪文領域番号を0-originで扱っている箇所を1-originに修正して一貫性を持たせる。
単発の修正のためIssueはなし。