### PR TITLE
[Feature] エラーレポートにコールスタック情報を含める

### DIFF
--- a/Build-Windows-Release-Package.ps1
+++ b/Build-Windows-Release-Package.ps1
@@ -25,7 +25,7 @@ function BuildPackage ($package_name, $package_unique_files, $build_conf) {
     New-Item $hengbandDir -ItemType Directory
 
     # 必要なファイルをコピーして、その中で不要になりえるものを削除
-    Copy-Item -Verbose -Path .\Hengband.exe, .\readme_angband, .\THIRD-PARTY-NOTICES.txt -Destination $hengbandDir
+    Copy-Item -Verbose -Path .\Hengband.exe, .\Hengband.pdb, .\readme_angband, .\THIRD-PARTY-NOTICES.txt -Destination $hengbandDir
     Copy-Item -Verbose -Path $package_unique_files -Destination $hengbandDir
     Copy-Item -Verbose -Recurse -Path .\lib -Destination $hengbandDir -Exclude Makefile.am, *.raw, .gitattributes
     Copy-Item -Verbose -Path .\lib\apex\h_scores.raw -Destination $hengbandDir\lib\apex

--- a/VisualStudio/Hengband/Hengband.vcxproj
+++ b/VisualStudio/Hengband/Hengband.vcxproj
@@ -95,8 +95,12 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='English-Debug|Win32'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='English-Release|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='English-Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PreprocessorDefinitions>WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32;HAVE_STDINT_H;JP;SJIS;WORLD_SCORE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -118,7 +122,7 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <TargetMachine>MachineX86</TargetMachine>
-      <AdditionalDependencies>winmm.lib;gdiplus.lib;Ws2_32.lib;Wldap32.lib;Crypt32.lib;Normaliz.lib;libcurl\lib\libcurl_a_debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>winmm.lib;gdiplus.lib;Ws2_32.lib;Wldap32.lib;Crypt32.lib;Normaliz.lib;DbgHelp.lib;libcurl\lib\libcurl_a_debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ShowProgress>LinkVerbose</ShowProgress>
       <SubSystem>Windows</SubSystem>
     </Link>
@@ -152,7 +156,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <TargetMachine>MachineX86</TargetMachine>
       <ShowProgress>LinkVerbose</ShowProgress>
-      <AdditionalDependencies>winmm.lib;gdiplus.lib;Ws2_32.lib;Wldap32.lib;Crypt32.lib;Normaliz.lib;libcurl\lib\libcurl_a_debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>winmm.lib;gdiplus.lib;Ws2_32.lib;Wldap32.lib;Crypt32.lib;Normaliz.lib;DbgHelp.lib;libcurl\lib\libcurl_a_debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>
@@ -164,7 +168,7 @@
       <DisableSpecificWarnings>4244;4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AdditionalIncludeDirectories>..\..\src;libcurl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <DebugInformationFormat>None</DebugInformationFormat>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <CompileAs>CompileAsCpp</CompileAs>
@@ -176,9 +180,9 @@
     </ClCompile>
     <Link>
       <TargetMachine>MachineX86</TargetMachine>
-      <AdditionalDependencies>winmm.lib;gdiplus.lib;Ws2_32.lib;Wldap32.lib;Crypt32.lib;Normaliz.lib;libcurl\lib\libcurl_a.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>winmm.lib;gdiplus.lib;Ws2_32.lib;Wldap32.lib;Crypt32.lib;Normaliz.lib;DbgHelp.lib;libcurl\lib\libcurl_a.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <LinkTimeCodeGeneration>UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
-      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <SubSystem>Windows</SubSystem>
@@ -210,7 +214,7 @@
       <AdditionalOptions>/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>winmm.lib;gdiplus.lib;Ws2_32.lib;Wldap32.lib;Crypt32.lib;Normaliz.lib;libcurl\lib\libcurl_a.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>winmm.lib;gdiplus.lib;Ws2_32.lib;Wldap32.lib;Crypt32.lib;Normaliz.lib;DbgHelp.lib;libcurl\lib\libcurl_a.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -328,6 +332,7 @@
     <ClCompile Include="..\..\src\main-win\graphics-win.cpp" />
     <ClCompile Include="..\..\src\main-win\main-win-term.cpp" />
     <ClCompile Include="..\..\src\main-win\wav-reader.cpp" />
+    <ClCompile Include="..\..\src\main-win\stack-trace-win.cpp" />
     <ClCompile Include="..\..\src\monster\monster-damage.cpp" />
     <ClCompile Include="..\..\src\object-enchant\others\apply-magic-amulet.cpp" />
     <ClCompile Include="..\..\src\object-enchant\protector\abstract-protector-enchanter.cpp" />
@@ -1834,6 +1839,7 @@
     <ClInclude Include="..\..\src\util\rng-xoshiro.h" />
     <ClInclude Include="..\..\src\util\dice.h" />
     <ClInclude Include="..\..\src\util\sha256.h" />
+    <ClInclude Include="..\..\src\util\stack-trace.h" />
     <ClInclude Include="..\..\src\util\string-processor.h" />
     <ClInclude Include="..\..\src\view\display-symbol.h" />
     <ClInclude Include="..\..\src\view\display-birth.h" />

--- a/VisualStudio/Hengband/Hengband.vcxproj.filters
+++ b/VisualStudio/Hengband/Hengband.vcxproj.filters
@@ -2187,6 +2187,9 @@
     <ClCompile Include="..\..\src\main-win\wav-reader.cpp">
       <Filter>main-win</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\main-win\stack-trace-win.cpp">
+      <Filter>main-win</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\monster\monster-damage.cpp">
       <Filter>monster</Filter>
     </ClCompile>
@@ -5397,6 +5400,9 @@
     <ClInclude Include="..\..\src\util\sha256.h">
       <Filter>util</Filter>
     </ClInclude>
+    <ClCompile Include="..\..\src\util\stack-trace.h">
+      <Filter>util</Filter>
+    </ClCompile>
     <ClInclude Include="..\..\src\external-lib\json.hpp">
       <Filter>external-lib</Filter>
     </ClInclude>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -400,6 +400,7 @@ hengband_SOURCES = \
 	main/sound-definitions-table.cpp main/sound-definitions-table.h \
 	main/sound-of-music.cpp main/sound-of-music.h \
 	\
+	main-unix/stack-trace-unix.cpp \
 	main-unix/unix-user-ids.cpp main-unix/unix-user-ids.h \
 	main-unix/x11-gamma-builder.cpp main-unix/x11-gamma-builder.h \
 	main-unix/x11-type-string.cpp main-unix/x11-type-string.h \
@@ -986,6 +987,7 @@ hengband_SOURCES = \
 	util/probability-table.h \
 	util/rng-xoshiro.cpp util/rng-xoshiro.h \
 	util/sha256.cpp util/sha256.h \
+	util/stack-trace.h \
 	util/string-processor.cpp util/string-processor.h \
 	\
 	view/display-birth.cpp view/display-birth.h \
@@ -1059,6 +1061,7 @@ EXTRA_hengband_SOURCES = \
 	main-win/main-win-term.cpp main-win/main-win-term.h \
 	main-win/main-win-tokenizer.cpp main-win/main-win-tokenizer.h \
 	main-win/main-win-utils.cpp main-win/main-win-utils.h \
+	main-win/stack-trace-win.cpp \
 	main-win/wav-reader.cpp main-win/wav-reader.h \
 	test/test-sha256.cpp \
 	wall.bmp \

--- a/src/main-unix/stack-trace-unix.cpp
+++ b/src/main-unix/stack-trace-unix.cpp
@@ -1,0 +1,19 @@
+#include "util/stack-trace.h"
+
+namespace util {
+
+struct StackTrace::Frame {
+};
+
+StackTrace::StackTrace()
+{
+}
+
+StackTrace::~StackTrace() = default;
+
+std::string StackTrace::dump() const
+{
+    return "Not implemented\n";
+}
+
+} // namespace util

--- a/src/main-win/main-win-exception.cpp
+++ b/src/main-win/main-win-exception.cpp
@@ -15,17 +15,20 @@ void handle_unexpected_exception(const std::exception &e)
 {
     constexpr auto caption = _(L"予期しないエラー！", L"Unexpected error!");
 
+    const std::string msg = e.what();
+    const auto first_line = msg.substr(0, msg.find('\n'));
+
 #if !defined(DISABLE_NET)
     std::wstringstream report_confirm_msg_ss;
     report_confirm_msg_ss
-        << to_wchar(e.what()).wc_str() << L"\n\n"
+        << to_wchar(first_line.data()).wc_str() << L"\n\n"
         << _(L"開発チームにエラー情報を送信してよろしいですか？\n", L"Are you sure you want to send the error information to the development team?\n")
         << _(L"※送信されるのはゲーム内の情報のみであり、個人情報が送信されることはありません。\n",
                L"Only in-game information will be sent. No personal information will be sent.\n");
 
     if (auto choice = MessageBoxW(NULL, report_confirm_msg_ss.str().data(), caption, MB_ICONEXCLAMATION | MB_YESNO | MB_ICONSTOP);
         choice == IDYES) {
-        report_error(e.what());
+        report_error(msg);
     }
 #endif
 

--- a/src/main-win/stack-trace-win.cpp
+++ b/src/main-win/stack-trace-win.cpp
@@ -1,0 +1,99 @@
+#include "util/stack-trace.h"
+
+#include "util/finalizer.h"
+#include <iomanip>
+#include <sstream>
+#include <string_view>
+#include <windows.h>
+
+// DbgHelp.h は windows.h より後にインクルードする必要がある
+#include <DbgHelp.h>
+
+namespace util {
+
+constexpr auto FRAMES_TO_CAPTURE_MAX = 100;
+constexpr auto SYMBOL_NAME_LEN_MAX = 256;
+
+namespace {
+    std::string_view cut_out_relative_path(std::string_view path)
+    {
+        const std::string_view src_dir(R"(\src\)");
+        auto pos = path.rfind(src_dir);
+        if (pos == std::string_view::npos) {
+            return path;
+        }
+        return path.substr(pos + src_dir.size());
+    }
+
+    std::pair<std::string, ULONG64> get_symbol_info(HANDLE process, ULONG64 address)
+    {
+        char symbol_info_buf[sizeof(SYMBOL_INFO) + SYMBOL_NAME_LEN_MAX]{};
+        auto *symbol = reinterpret_cast<SYMBOL_INFO *>(symbol_info_buf);
+        symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
+        symbol->MaxNameLen = SYMBOL_NAME_LEN_MAX;
+
+        DWORD64 displacement;
+        const auto has_symbol = SymFromAddr(process, address, &displacement, symbol);
+        return { has_symbol ? symbol->Name : "", symbol->Address };
+    }
+
+    std::pair<std::string, DWORD> get_line_info(HANDLE process, ULONG64 address)
+    {
+        IMAGEHLP_LINE64 line64{};
+        line64.SizeOfStruct = sizeof(IMAGEHLP_LINE64);
+        DWORD displacement;
+        const auto has_line = SymGetLineFromAddr64(process, address, &displacement, &line64);
+        const auto filename = has_line ? cut_out_relative_path(line64.FileName) : "";
+        return { has_line ? std::string(filename) : "", line64.LineNumber };
+    }
+}
+
+struct StackTrace::Frame {
+    std::string file;
+    DWORD line_num;
+    std::string symbol_name;
+    ULONG64 address;
+};
+
+StackTrace::StackTrace()
+{
+    const auto process = GetCurrentProcess();
+
+    if (!SymInitialize(process, NULL, TRUE)) {
+        return;
+    }
+    auto sym_cleanup_finalizer = util::make_finalizer([process] { SymCleanup(process); });
+
+    SymSetOptions(SYMOPT_LOAD_LINES);
+
+    void *back_trace[FRAMES_TO_CAPTURE_MAX];
+    const auto num_frames = CaptureStackBackTrace(0, FRAMES_TO_CAPTURE_MAX, back_trace, NULL);
+
+    for (auto i = 0; i < num_frames; i++) {
+        const auto frame_address = reinterpret_cast<uintptr_t>(back_trace[i]);
+
+        auto [symbol_name, symbol_address] = get_symbol_info(process, frame_address);
+        auto [file, line_num] = get_line_info(process, frame_address);
+
+        Frame frame{ std::move(file), line_num, std::move(symbol_name), symbol_address };
+        this->frames.push_back(std::move(frame));
+    }
+}
+
+StackTrace::~StackTrace() = default;
+
+std::string StackTrace::dump() const
+{
+    std::ostringstream oss;
+    for (auto frame_no = 0; const auto &frame : this->frames) {
+        oss << '#' << frame_no++ << ' '
+            << (frame.symbol_name.empty() ? "(No symbol)" : frame.symbol_name + "()");
+        if (!frame.file.empty()) {
+            oss << " at " << frame.file << ':' << frame.line_num;
+        }
+        oss << '\n';
+    }
+    return oss.str();
+}
+
+} // namespace util

--- a/src/system/angband-exceptions.h
+++ b/src/system/angband-exceptions.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "util/stack-trace.h"
 #include <concepts>
 #include <filesystem>
 #include <sstream>
@@ -17,8 +18,11 @@ namespace angband::exception::detail {
 template <std::derived_from<std::exception> T>
 [[noreturn]] void throw_exception(std::string_view msg, std::filesystem::path path, int line)
 {
+    util::StackTrace stack_trace;
     std::stringstream ss;
-    ss << path.filename().string() << ':' << line << ": " << msg;
+    ss << path.filename().string() << ':' << line << ": " << msg << '\n'
+       << "Stack trace:\n"
+       << stack_trace.dump();
     throw T(ss.str());
 }
 

--- a/src/util/stack-trace.h
+++ b/src/util/stack-trace.h
@@ -1,0 +1,31 @@
+/*!
+ * @file stack-trace.h
+ * @brief スタックトレースを取得するクラスの宣言
+ *
+ * プラットフォームに依存するため、プラットフォームごとに実装が必要
+ *
+ * 実装ファイル:
+ * - Windows: main-win/stack-trace-win.cpp
+ * - Linux/macOS(Unix系): main-unix/stack-trace-unix.cpp
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace util {
+
+class StackTrace {
+public:
+    StackTrace();
+    ~StackTrace();
+
+    std::string dump() const;
+
+private:
+    struct Frame;
+    std::vector<Frame> frames;
+};
+
+}


### PR DESCRIPTION
Resolves #4397 

StackTraceクラスを実装し、Windows版でのエラー送信機能で送信する情報にコールスタック情報を含めるようにする。