### PR TITLE
[Fix] カメレオンが爆発するモンスターに変身してしまう

### DIFF
--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -225,7 +225,7 @@ static bool monster_hook_chameleon_lord(PlayerType *player_ptr, MonsterRaceId r_
         return false;
     }
 
-    if (m_ptr->is_explodable()) {
+    if (r_ptr->is_explodable()) {
         return false;
     }
 
@@ -269,7 +269,7 @@ static bool monster_hook_chameleon(PlayerType *player_ptr, MonsterRaceId r_idx, 
         return false;
     }
 
-    if (m_ptr->is_explodable()) {
+    if (r_ptr->is_explodable()) {
         return false;
     }
 


### PR DESCRIPTION
Fix #4401

25a7079 で変身元と変身先の取り違えてしまっており、変身元のモンスターに対して爆発するかどうかの判定を行うようになってしまっている。
正しく変身先のモンスターに対して判定を行うように修正する。