### PR TITLE
[Fix] 神の怒りを画面端に打つとクラッシュする

### DIFF
--- a/src/spell-realm/spells-crusade.cpp
+++ b/src/spell-realm/spells-crusade.cpp
@@ -90,8 +90,7 @@ bool cast_wrath_of_the_god(PlayerType *player_ptr, int dam, POSITION rad)
             continue;
         }
 
-        auto should_cast = in_bounds(&floor, pos_explode.y, pos_explode.x);
-        should_cast &= !cave_stop_disintegration(&floor, pos_explode.y, pos_explode.x);
+        auto should_cast = in_bounds(&floor, pos_explode.y, pos_explode.x) && !cave_stop_disintegration(&floor, pos_explode.y, pos_explode.x);
         should_cast &= in_disintegration_range(&floor, pos_target.y, pos_target.x, pos_explode.y, pos_explode.x);
         if (!should_cast) {
             continue;


### PR DESCRIPTION
Fix #4403 

2a53154 の修正で短絡評価でなくなってしまったため、is_boundが偽であり x,y が配列範囲外の時にも cave_stop_disintegration が呼ばれるのが原因。 短絡評価に戻し、is_boundが偽の時は cave_stop_disintegration が呼ばれない ように修正する。