### PR TITLE
[Feature] 悪魔領域最終攻撃魔法の差し替え

### DIFF
--- a/lib/edit/ClassMagicDefinitions.jsonc
+++ b/lib/edit/ClassMagicDefinitions.jsonc
@@ -1949,10 +1949,10 @@
               "first_cast_exp_rate": 30
             },
             {
-              "spell_tag": "Demonfire",
+              "spell_tag": "Corrupt",
               "learn_level": 33,
               "mana_cost": 30,
-              "difficulty": 85,
+              "difficulty": 70,
               "first_cast_exp_rate": 15
             },
             {
@@ -4251,10 +4251,10 @@
               "first_cast_exp_rate": 30
             },
             {
-              "spell_tag": "Demonfire",
+              "spell_tag": "Corrupt",
               "learn_level": 35,
-              "mana_cost": 33,
-              "difficulty": 85,
+              "mana_cost": 38,
+              "difficulty": 70,
               "first_cast_exp_rate": 30
             },
             {
@@ -7252,9 +7252,9 @@
               "first_cast_exp_rate": 20
             },
             {
-              "spell_tag": "Demonfire",
+              "spell_tag": "Corrupt",
               "learn_level": 44,
-              "mana_cost": 40,
+              "mana_cost": 60,
               "difficulty": 80,
               "first_cast_exp_rate": 15
             },
@@ -9795,10 +9795,10 @@
               "first_cast_exp_rate": 8
             },
             {
-              "spell_tag": "Demonfire",
+              "spell_tag": "Corrupt",
               "learn_level": 41,
-              "mana_cost": 36,
-              "difficulty": 85,
+              "mana_cost": 58,
+              "difficulty": 70,
               "first_cast_exp_rate": 15
             },
             {
@@ -10494,10 +10494,10 @@
               "first_cast_exp_rate": 8
             },
             {
-              "spell_tag": "Demonfire",
+              "spell_tag": "Corrupt",
               "learn_level": 38,
-              "mana_cost": 33,
-              "difficulty": 85,
+              "mana_cost": 38,
+              "difficulty": 70,
               "first_cast_exp_rate": 15
             },
             {
@@ -13506,7 +13506,7 @@
               "first_cast_exp_rate": 8
             },
             {
-              "spell_tag": "Demonfire",
+              "spell_tag": "Corrupt",
               "learn_level": 27,
               "mana_cost": 28,
               "difficulty": 65,
@@ -16301,10 +16301,10 @@
               "first_cast_exp_rate": 30
             },
             {
-              "spell_tag": "Demonfire",
+              "spell_tag": "Corrupt",
               "learn_level": 33,
               "mana_cost": 30,
-              "difficulty": 85,
+              "difficulty": 70,
               "first_cast_exp_rate": 15
             },
             {
@@ -18636,10 +18636,10 @@
               "first_cast_exp_rate": 30
             },
             {
-              "spell_tag": "Demonfire",
+              "spell_tag": "Corrupt",
               "learn_level": 44,
-              "mana_cost": 58,
-              "difficulty": 85,
+              "mana_cost": 75,
+              "difficulty": 80,
               "first_cast_exp_rate": 15
             },
             {

--- a/lib/edit/ClassMagicDefinitions.jsonc
+++ b/lib/edit/ClassMagicDefinitions.jsonc
@@ -2068,9 +2068,9 @@
               "first_cast_exp_rate": 200
             },
             {
-              "spell_tag": "Bloody_Curse",
+              "spell_tag": "Call_the_Abyss",
               "learn_level": 47,
-              "mana_cost": 85,
+              "mana_cost": 90,
               "difficulty": 80,
               "first_cast_exp_rate": 200
             },
@@ -4370,10 +4370,10 @@
               "first_cast_exp_rate": 150
             },
             {
-              "spell_tag": "Bloody_Curse",
+              "spell_tag": "Call_the_Abyss",
               "learn_level": 49,
               "mana_cost": 95,
-              "difficulty": 80,
+              "difficulty": 85,
               "first_cast_exp_rate": 200
             },
             {
@@ -7371,7 +7371,7 @@
               "first_cast_exp_rate": 0
             },
             {
-              "spell_tag": "Bloody_Curse",
+              "spell_tag": "Call_the_Abyss",
               "learn_level": 99,
               "mana_cost": 0,
               "difficulty": 0,
@@ -9914,10 +9914,10 @@
               "first_cast_exp_rate": 200
             },
             {
-              "spell_tag": "Bloody_Curse",
+              "spell_tag": "Call_the_Abyss",
               "learn_level": 50,
               "mana_cost": 105,
-              "difficulty": 80,
+              "difficulty": 85,
               "first_cast_exp_rate": 200
             },
             {
@@ -10613,9 +10613,9 @@
               "first_cast_exp_rate": 200
             },
             {
-              "spell_tag": "Bloody_Curse",
+              "spell_tag": "Call_the_Abyss",
               "learn_level": 48,
-              "mana_cost": 105,
+              "mana_cost": 90,
               "difficulty": 80,
               "first_cast_exp_rate": 200
             },
@@ -13625,10 +13625,10 @@
               "first_cast_exp_rate": 200
             },
             {
-              "spell_tag": "Bloody_Curse",
+              "spell_tag": "Call_the_Abyss",
               "learn_level": 43,
-              "mana_cost": 75,
-              "difficulty": 70,
+              "mana_cost": 80,
+              "difficulty": 75,
               "first_cast_exp_rate": 200
             },
             {
@@ -16420,9 +16420,9 @@
               "first_cast_exp_rate": 200
             },
             {
-              "spell_tag": "Bloody_Curse",
+              "spell_tag": "Call_the_Abyss",
               "learn_level": 47,
-              "mana_cost": 85,
+              "mana_cost": 90,
               "difficulty": 80,
               "first_cast_exp_rate": 200
             },
@@ -18755,7 +18755,7 @@
               "first_cast_exp_rate": 0
             },
             {
-              "spell_tag": "Bloody_Curse",
+              "spell_tag": "Call_the_Abyss",
               "learn_level": 99,
               "mana_cost": 0,
               "difficulty": 0,

--- a/lib/edit/SpellDefinitions.jsonc
+++ b/lib/edit/SpellDefinitions.jsonc
@@ -3764,14 +3764,14 @@
             },
             {
               "spell_id": 30,
-              "spell_tag": "Bloody_Curse",
+              "spell_tag": "Call_the_Abyss",
               "name": {
-                "ja": "血の呪い",
-                "en": "Bloody Curse"
+                "ja": "深淵招来",
+                "en": "Call the Abyss"
               },
               "description": {
-                "ja": "自分がダメージを受けることによって対象に呪いをかけ、ダメージを与え様々な効果を引き起こす。",
-                "en": "Puts blood curse, which damages and causes various effects, on a monster. You also take damage."
+                "ja": "非常に強力な極小の深淵の球を放つ。",
+                "en": "Fires an extremely powerful tiny ball of abyss."
               }
             },
             {

--- a/lib/edit/SpellDefinitions.jsonc
+++ b/lib/edit/SpellDefinitions.jsonc
@@ -3544,14 +3544,14 @@
             },
             {
               "spell_id": 13,
-              "spell_tag": "Demonfire",
+              "spell_tag": "Corrupt",
               "name": {
-                "ja": "悪魔火",
-                "en": "Demonfire"
+                "ja": "堕落",
+                "en": "Corrupt"
               },
               "description": {
-                "ja": "強力な炎のボルトを放つ。",
-                "en": "Fires a powerful bolt of fire."
+                "ja": "強力な深淵のボルトを放つ。",
+                "en": "Fires a powerful bolt of abyss."
               }
             },
             {

--- a/src/realm/realm-demon.cpp
+++ b/src/realm/realm-demon.cpp
@@ -455,7 +455,7 @@ std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spe
     } break;
 
     case 30: {
-        int dam = 600;
+        int dam = 300 + plev * 4;
         POSITION rad = 0;
 
         if (info) {
@@ -467,8 +467,7 @@ std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spe
                 return std::nullopt;
             }
 
-            fire_ball_hide(player_ptr, AttributeType::BLOOD_CURSE, dir, dam, rad);
-            take_hit(player_ptr, DAMAGE_USELIFE, 20 + randint1(30), _("血の呪い", "Blood curse"));
+            fire_ball_hide(player_ptr, AttributeType::ABYSS, dir, dam, rad);
         }
     } break;
 

--- a/src/realm/realm-demon.cpp
+++ b/src/realm/realm-demon.cpp
@@ -224,7 +224,7 @@ std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spe
     } break;
 
     case 13: {
-        int dam = plev * 5;
+        int dam = plev * 3;
 
         if (info) {
             return info_damage(dam);
@@ -234,7 +234,7 @@ std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spe
             if (!get_aim_dir(player_ptr, &dir)) {
                 return std::nullopt;
             }
-            fire_bolt(player_ptr, AttributeType::FIRE, dir, dam);
+            fire_bolt(player_ptr, AttributeType::ABYSS, dir, dam);
         }
     } break;
 


### PR DESCRIPTION
悪魔領域「血の呪い」はデメリットが大きいが特にメリットがないという問題と、フレーバー的に非アンバーがポンポン血の呪いを放つのはおかしいという問題があった。 新規の魔法に差し替えることでこの問題を解消する。

深淵招来: 魔力の嵐と同等威力の深淵属性半径0のボール。
暗黒耐性で軽減されるが、テレポート耐性持ち、飛行抜けには威力1.25倍で減速付与までされるため非常に強力。
コスト、難度は暗黒領域「地獄の業火」に近しいものに設定した。