### PR TITLE
[Refactor] PlayerType::spell_order

### DIFF
--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -91,9 +91,7 @@ void player_wipe_without_name(PlayerType *player_ptr)
     }
 
     player_ptr->spell_forgotten1 = player_ptr->spell_forgotten2 = 0L;
-    for (int i = 0; i < 64; i++) {
-        player_ptr->spell_order[i] = 99;
-    }
+    player_ptr->spell_order_learned.clear();
 
     player_ptr->learned_spells = 0;
     player_ptr->add_spells = 0;

--- a/src/cmd-action/cmd-hissatsu.cpp
+++ b/src/cmd-action/cmd-hissatsu.cpp
@@ -408,15 +408,7 @@ void do_cmd_gain_hissatsu(PlayerType *player_ptr)
         player_ptr->spell_worked1 |= (1UL << i);
         const auto &spell_name = PlayerRealm::get_spell_name(RealmType::HISSATSU, i);
         msg_format(_("%sの技を覚えた。", "You have learned the special attack of %s."), spell_name.data());
-        int j;
-        for (j = 0; j < 64; j++) {
-            /* Stop at the first empty space */
-            if (player_ptr->spell_order[j] == 99) {
-                break;
-            }
-        }
-
-        player_ptr->spell_order[j] = i;
+        player_ptr->spell_order_learned.push_back(i);
         gain = true;
     }
 

--- a/src/load/inventory-loader.cpp
+++ b/src/load/inventory-loader.cpp
@@ -65,8 +65,10 @@ static errr rd_inventory(PlayerType *player_ptr)
 
 errr load_inventory(PlayerType *player_ptr)
 {
-    for (int i = 0; i < 64; i++) {
-        player_ptr->spell_order[i] = rd_byte();
+    for (auto i = 0; i < 64; i++) {
+        if (const auto spell_id = rd_byte(); spell_id < 64) {
+            player_ptr->spell_order_learned.push_back(spell_id);
+        }
     }
 
     if (!rd_inventory(player_ptr)) {

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -544,15 +544,12 @@ static void update_num_of_spells(PlayerType *player_ptr)
     }
 
     player_ptr->new_spells = num_allowed + player_ptr->add_spells + num_boukyaku - player_ptr->learned_spells;
-    for (int i = 63; i >= 0; i--) {
+    for (auto it = player_ptr->spell_order_learned.crbegin(); it != player_ptr->spell_order_learned.crend(); ++it) {
         if (!player_ptr->spell_learned1 && !player_ptr->spell_learned2) {
             break;
         }
 
-        int j = player_ptr->spell_order[i];
-        if (j >= 99) {
-            continue;
-        }
+        const auto j = *it;
 
         const auto &realm = (j < 32) ? pr.realm1() : pr.realm2();
         const auto &spell = realm.get_spell_info(j % 32);
@@ -588,7 +585,7 @@ static void update_num_of_spells(PlayerType *player_ptr)
     }
 
     /* Forget spells if we know too many spells */
-    for (int i = 63; i >= 0; i--) {
+    for (auto it = player_ptr->spell_order_learned.crbegin(); it != player_ptr->spell_order_learned.crend(); ++it) {
         if (player_ptr->new_spells >= 0) {
             break;
         }
@@ -596,10 +593,7 @@ static void update_num_of_spells(PlayerType *player_ptr)
             break;
         }
 
-        int j = player_ptr->spell_order[i];
-        if (j >= 99) {
-            continue;
-        }
+        const auto j = *it;
 
         bool is_spell_learned = (j < 32) ? any_bits(player_ptr->spell_learned1, (1UL << j)) : any_bits(player_ptr->spell_learned2, (1UL << (j - 32)));
         if (!is_spell_learned) {
@@ -629,15 +623,11 @@ static void update_num_of_spells(PlayerType *player_ptr)
     }
 
     /* Check for spells to remember */
-    for (int i = 0; i < 64; i++) {
+    for (const auto j : player_ptr->spell_order_learned) {
         if (player_ptr->new_spells <= 0) {
             break;
         }
         if (!player_ptr->spell_forgotten1 && !player_ptr->spell_forgotten2) {
-            break;
-        }
-        int j = player_ptr->spell_order[i];
-        if (j >= 99) {
             break;
         }
 

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -193,8 +193,9 @@ static bool wr_savefile_new(PlayerType *player_ptr)
     wr_u32b(player_ptr->spell_forgotten2);
     wr_s16b(player_ptr->learned_spells);
     wr_s16b(player_ptr->add_spells);
-    for (int i = 0; i < 64; i++) {
-        wr_byte((byte)player_ptr->spell_order[i]);
+    for (auto i = 0; i < 64; i++) {
+        const auto spell_id = (i < std::ssize(player_ptr->spell_order_learned)) ? player_ptr->spell_order_learned[i] : 255;
+        wr_byte(static_cast<byte>(spell_id));
     }
 
     for (int i = 0; i < INVEN_TOTAL; i++) {

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -173,7 +173,7 @@ public:
     BIT_FLAGS spell_worked2{}; /* bit mask of spells tried and worked */
     BIT_FLAGS spell_forgotten1{}; /* bit mask of spells learned but forgotten */
     BIT_FLAGS spell_forgotten2{}; /* bit mask of spells learned but forgotten */
-    SPELL_IDX spell_order[64]{}; /* order spells learned/remembered/forgotten */
+    std::vector<int> spell_order_learned{}; /* order spells learned */
 
     SUB_EXP spell_exp[64]{}; /* Proficiency of spells */
     std::map<ItemKindType, std::array<SUB_EXP, 64>> weapon_exp{}; /* Proficiency of weapons */


### PR DESCRIPTION
魔法を学習した順序を記録する PlayerType::spell_order を固定長配列から std::vector に変更して扱いやすくする。

#4357 に関連したリファクタリングです。
