### PR TITLE
[Refactor] 呪文の学習・試行・忘却状態の処理

### DIFF
--- a/VisualStudio/Hengband/Hengband.vcxproj
+++ b/VisualStudio/Hengband/Hengband.vcxproj
@@ -517,6 +517,7 @@
     <ClCompile Include="..\..\src\object-use\read\read-execution.cpp" />
     <ClCompile Include="..\..\src\player\player-status-flags.cpp" />
     <ClCompile Include="..\..\src\player\player-status-table.cpp" />
+    <ClCompile Include="..\..\src\player\player-spell-status.cpp" />
     <ClCompile Include="..\..\src\player\player-view.cpp" />
     <ClCompile Include="..\..\src\racial\class-racial-switcher.cpp" />
     <ClCompile Include="..\..\src\racial\mutation-racial-selector.cpp" />
@@ -1318,6 +1319,7 @@
     <ClInclude Include="..\..\src\object-use\read\read-execution.h" />
     <ClInclude Include="..\..\src\player\player-status-flags.h" />
     <ClInclude Include="..\..\src\player\player-status-table.h" />
+    <ClInclude Include="..\..\src\player\player-spell-status.h" />
     <ClInclude Include="..\..\src\player\player-view.h" />
     <ClInclude Include="..\..\src\racial\class-racial-switcher.h" />
     <ClInclude Include="..\..\src\racial\mutation-racial-selector.h" />

--- a/VisualStudio/Hengband/Hengband.vcxproj.filters
+++ b/VisualStudio/Hengband/Hengband.vcxproj.filters
@@ -1850,6 +1850,9 @@
     <ClCompile Include="..\..\src\player\player-status-table.cpp">
       <Filter>player</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\player\player-spell-status.cpp">
+      <Filter>player</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\monster-floor\monster-lite-util.cpp">
       <Filter>monster-floor</Filter>
     </ClCompile>
@@ -4635,6 +4638,9 @@
       <Filter>racial</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\player\player-status-table.h">
+      <Filter>player</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\player\player-spell-status.h">
       <Filter>player</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\monster-floor\monster-lite-util.h">

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -689,6 +689,7 @@ hengband_SOURCES = \
 	player/player-personality.cpp player/player-personality.h \
 	player/player-realm.cpp player/player-realm.h \
 	player/player-skill.cpp player/player-skill.h \
+	player/player-spell-status.cpp player/player-spell-status.h \
 	player/player-status.cpp player/player-status.h \
 	player/player-status-flags.cpp player/player-status-flags.h \
 	player/player-status-table.cpp player/player-status-table.h \

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -13,6 +13,7 @@
 #include "player-info/race-info.h"
 #include "player-info/race-types.h"
 #include "player/digestion-processor.h"
+#include "player/player-spell-status.h"
 #include "system/artifact-type-definition.h"
 #include "system/baseitem-info.h"
 #include "system/dungeon-info.h"
@@ -82,16 +83,10 @@ void player_wipe_without_name(PlayerType *player_ptr)
     }
 
     player_ptr->food = PY_FOOD_FULL - 1;
-    if (PlayerClass(player_ptr).equals(PlayerClassType::SORCERER)) {
-        player_ptr->spell_learned1 = player_ptr->spell_learned2 = 0xffffffffL;
-        player_ptr->spell_worked1 = player_ptr->spell_worked2 = 0xffffffffL;
-    } else {
-        player_ptr->spell_learned1 = player_ptr->spell_learned2 = 0L;
-        player_ptr->spell_worked1 = player_ptr->spell_worked2 = 0L;
-    }
 
-    player_ptr->spell_forgotten1 = player_ptr->spell_forgotten2 = 0L;
-    player_ptr->spell_order_learned.clear();
+    PlayerSpellStatus pss(player_ptr);
+    pss.realm1().initialize();
+    pss.realm2().initialize();
 
     player_ptr->learned_spells = 0;
     player_ptr->add_spells = 0;

--- a/src/cmd-action/cmd-hissatsu.cpp
+++ b/src/cmd-action/cmd-hissatsu.cpp
@@ -31,6 +31,7 @@
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
 #include "player/player-realm.h"
+#include "player/player-spell-status.h"
 #include "player/special-defense-types.h"
 #include "spell/spells-execution.h"
 #include "spell/technic-info-table.h"
@@ -105,6 +106,7 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
     }
     choice = always_show_list ? ESCAPE : 1;
 
+    const auto realm_status = PlayerSpellStatus(player_ptr).realm1();
     while (!flag) {
         if (choice == ESCAPE) {
             choice = ' ';
@@ -133,7 +135,7 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
                     if (menu_line > 32) {
                         menu_line -= 32;
                     }
-                } while (!(player_ptr->spell_learned1 & (1UL << (menu_line - 1))));
+                } while (!realm_status.is_learned(menu_line - 1));
                 break;
             }
 
@@ -145,7 +147,7 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
                     if (menu_line > 32) {
                         menu_line -= 32;
                     }
-                } while (!(player_ptr->spell_learned1 & (1UL << (menu_line - 1))));
+                } while (!realm_status.is_learned(menu_line - 1));
                 break;
             }
 
@@ -165,7 +167,7 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
                 } else {
                     menu_line += 16;
                 }
-                while (!(player_ptr->spell_learned1 & (1UL << (menu_line - 1)))) {
+                while (!realm_status.is_learned(menu_line - 1)) {
                     if (reverse) {
                         menu_line--;
                         if (menu_line < 2) {
@@ -213,15 +215,12 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
                         continue;
                     }
                     line++;
-                    if (!(player_ptr->spell_learned1 >> i)) {
-                        break;
-                    }
 
                     /* Access the spell */
                     if (spell.slevel > plev) {
                         continue;
                     }
-                    if (!(player_ptr->spell_learned1 & (1UL << i))) {
+                    if (!realm_status.is_learned(i)) {
                         continue;
                     }
                     std::string psi_desc;
@@ -270,7 +269,7 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
         }
 
         /* Totally Illegal */
-        if ((i < 0) || (i >= 32) || !(player_ptr->spell_learned1 & (1U << selections[i]))) {
+        if ((i < 0) || (i >= 32) || !realm_status.is_learned(selections[i])) {
             bell();
             continue;
         }
@@ -318,7 +317,7 @@ void do_cmd_hissatsu(PlayerType *player_ptr)
         msg_print(_("武器を持たないと必殺技は使えない！", "You need to wield a weapon!"));
         return;
     }
-    if (!player_ptr->spell_learned1) {
+    if (PlayerSpellStatus(player_ptr).realm1().is_nothing_learned()) {
         msg_print(_("何も技を知らない。", "You don't know any special attacks."));
         return;
     }
@@ -395,8 +394,9 @@ void do_cmd_gain_hissatsu(PlayerType *player_ptr)
 
     const auto sval = *o_ptr->bi_key.sval();
     auto gain = false;
+    auto realm_status = PlayerSpellStatus(player_ptr).realm1();
     for (auto i = sval * 8; i < sval * 8 + 8; i++) {
-        if (player_ptr->spell_learned1 & (1UL << i)) {
+        if (realm_status.is_learned(i)) {
             continue;
         }
 
@@ -404,8 +404,8 @@ void do_cmd_gain_hissatsu(PlayerType *player_ptr)
             continue;
         }
 
-        player_ptr->spell_learned1 |= (1UL << i);
-        player_ptr->spell_worked1 |= (1UL << i);
+        realm_status.set_learned(i);
+        realm_status.set_worked(i);
         const auto &spell_name = PlayerRealm::get_spell_name(RealmType::HISSATSU, i);
         msg_format(_("%sの技を覚えた。", "You have learned the special attack of %s."), spell_name.data());
         player_ptr->spell_order_learned.push_back(i);

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -41,6 +41,7 @@
 #include "player/player-damage.h"
 #include "player/player-realm.h"
 #include "player/player-skill.h"
+#include "player/player-spell-status.h"
 #include "player/player-status.h"
 #include "player/special-defense-types.h"
 #include "spell-kind/spells-random.h"
@@ -274,7 +275,9 @@ static bool spell_okay(PlayerType *player_ptr, int spell_id, bool learned, bool 
 
     /* Spell is forgotten */
     PlayerRealm pr(player_ptr);
-    if (pr.realm2().equals(use_realm) ? (player_ptr->spell_forgotten2 & (1UL << spell_id)) : (player_ptr->spell_forgotten1 & (1UL << spell_id))) {
+    PlayerSpellStatus pss(player_ptr);
+    const auto realm_status = pr.realm2().equals(use_realm) ? pss.realm2() : pss.realm1();
+    if (realm_status.is_forgotten(spell_id)) {
         /* Never okay */
         return false;
     }
@@ -284,7 +287,7 @@ static bool spell_okay(PlayerType *player_ptr, int spell_id, bool learned, bool 
     }
 
     /* Spell is learned */
-    if (pr.realm2().equals(use_realm) ? (player_ptr->spell_learned2 & (1UL << spell_id)) : (player_ptr->spell_learned1 & (1UL << spell_id))) {
+    if (realm_status.is_learned(spell_id)) {
         /* Always true */
         return !study_pray;
     }
@@ -683,15 +686,11 @@ void do_cmd_browse(PlayerType *player_ptr)
  */
 static void change_realm2(PlayerType *player_ptr, PlayerRealm &pr, RealmType next_realm)
 {
-    auto is_realm2_spell = [](auto spell_id) { return spell_id >= 32; };
-    std::erase_if(player_ptr->spell_order_learned, is_realm2_spell);
+    PlayerSpellStatus(player_ptr).realm2().initialize();
 
     for (auto i = 32; i < 64; i++) {
         player_ptr->spell_exp[i] = PlayerSkill::spell_exp_at(PlayerSkillRank::UNSKILLED);
     }
-    player_ptr->spell_learned2 = 0L;
-    player_ptr->spell_worked2 = 0L;
-    player_ptr->spell_forgotten2 = 0L;
 
     constexpr auto fmt_realm = _("魔法の領域を%sから%sに変更した。", "changed magic realm from %s to %s.");
     const auto mes = format(fmt_realm, pr.realm2().get_name().data(), PlayerRealm::get_name(next_realm).data());
@@ -717,7 +716,6 @@ static void change_realm2(PlayerType *player_ptr, PlayerRealm &pr, RealmType nex
 void do_cmd_study(PlayerType *player_ptr)
 {
     auto increment = 0;
-    auto learned = false;
 
     /* Spells of realm2 will have an increment of +32 */
     SPELL_IDX spell = -1;
@@ -830,21 +828,10 @@ void do_cmd_study(PlayerType *player_ptr)
     }
 
     /* Learn the spell */
-    if (spell < 32) {
-        if (player_ptr->spell_learned1 & (1UL << spell)) {
-            learned = true;
-        } else {
-            player_ptr->spell_learned1 |= (1UL << spell);
-        }
-    } else {
-        if (player_ptr->spell_learned2 & (1UL << (spell - 32))) {
-            learned = true;
-        } else {
-            player_ptr->spell_learned2 |= (1UL << (spell - 32));
-        }
-    }
+    PlayerSpellStatus pss(player_ptr);
+    auto realm_status = increment ? pss.realm2() : pss.realm1();
 
-    if (learned) {
+    if (realm_status.is_learned(spell % 32)) {
         auto max_exp = PlayerSkill::spell_exp_at((spell < 32) ? PlayerSkillRank::MASTER : PlayerSkillRank::EXPERT);
         const auto old_exp = player_ptr->spell_exp[spell];
         const auto &realm = increment ? pr.realm2() : pr.realm1();
@@ -867,6 +854,8 @@ void do_cmd_study(PlayerType *player_ptr)
         auto new_rank_str = PlayerSkill::skill_rank_str(new_rank);
         msg_format(_("%sの熟練度が%sに上がった。", "Your proficiency of %s is now %s rank."), spell_name.data(), new_rank_str);
     } else {
+        realm_status.set_learned(spell % 32);
+
         /* Add the spell to the known list */
         player_ptr->spell_order_learned.push_back(spell);
 
@@ -1146,15 +1135,13 @@ bool do_cmd_cast(PlayerType *player_ptr)
         }
 
         /* A spell was cast */
-        if (!(increment ? (player_ptr->spell_worked2 & (1UL << spell_id)) : (player_ptr->spell_worked1 & (1UL << spell_id))) && !is_every_magic) {
+        PlayerSpellStatus pss(player_ptr);
+        auto realm_status = increment ? pss.realm2() : pss.realm1();
+        if (!realm_status.is_worked(spell_id) && !is_every_magic) {
             int e = spell.sexp;
 
             /* The spell worked */
-            if (pr.realm1().equals(use_realm)) {
-                player_ptr->spell_worked1 |= (1UL << spell_id);
-            } else {
-                player_ptr->spell_worked2 |= (1UL << spell_id);
-            }
+            realm_status.set_worked(spell_id);
 
             gain_exp(player_ptr, e * spell.slevel);
             RedrawingFlagsUpdater::get_instance().set_flag(SubWindowRedrawingFlag::ITEM_KNOWLEDGE);

--- a/src/load/load-zangband.cpp
+++ b/src/load/load-zangband.cpp
@@ -15,6 +15,7 @@
 #include "player/player-personality.h"
 #include "player/player-realm.h"
 #include "player/player-skill.h"
+#include "player/player-spell-status.h"
 #include "realm/realm-types.h"
 #include "spell/spells-status.h"
 #include "system/building-type-definition.h"
@@ -233,9 +234,12 @@ void set_zangband_class(PlayerType *player_ptr)
 void set_zangband_learnt_spells(PlayerType *player_ptr)
 {
     player_ptr->learned_spells = 0;
-    for (int i = 0; i < 64; i++) {
-        if ((i < 32) ? (player_ptr->spell_learned1 & (1UL << i)) : (player_ptr->spell_learned2 & (1UL << (i - 32)))) {
-            player_ptr->learned_spells++;
+    PlayerSpellStatus pss(player_ptr);
+    for (const auto &realm_status : { pss.realm1(), pss.realm2() }) {
+        for (auto i = 0; i < 32; i++) {
+            if (realm_status.is_learned(i)) {
+                player_ptr->learned_spells++;
+            }
         }
     }
 }

--- a/src/player/player-spell-status.cpp
+++ b/src/player/player-spell-status.cpp
@@ -1,0 +1,94 @@
+#include "player/player-spell-status.h"
+#include "player-base/player-class.h"
+#include "system/player-type-definition.h"
+#include "util/bit-flags-calculator.h"
+
+namespace {
+
+void set_flag_bit(BIT_FLAGS &flags, int bit_pos, bool value)
+{
+    if (value) {
+        set_bits(flags, 1U << bit_pos);
+    } else {
+        reset_bits(flags, 1U << bit_pos);
+    }
+}
+
+}
+
+PlayerSpellStatus::PlayerSpellStatus(PlayerType *player_ptr)
+    : player_ptr(player_ptr)
+{
+}
+
+PlayerSpellStatus::Realm PlayerSpellStatus::realm1() const
+{
+    return Realm(this->player_ptr, true);
+}
+
+PlayerSpellStatus::Realm PlayerSpellStatus::realm2() const
+{
+    return Realm(this->player_ptr, false);
+}
+
+PlayerSpellStatus::Realm::Realm(PlayerType *player_ptr, bool is_realm1)
+    : player_ptr(player_ptr)
+    , is_realm1(is_realm1)
+{
+}
+
+void PlayerSpellStatus::Realm::initialize()
+{
+    auto &learned = this->is_realm1 ? this->player_ptr->spell_learned1 : this->player_ptr->spell_learned2;
+    auto &worked = this->is_realm1 ? this->player_ptr->spell_worked1 : this->player_ptr->spell_worked2;
+    auto &forgotten = this->is_realm1 ? this->player_ptr->spell_forgotten1 : this->player_ptr->spell_forgotten2;
+
+    const auto is_sorcerer = PlayerClass(player_ptr).equals(PlayerClassType::SORCERER);
+    learned = worked = is_sorcerer ? 0xffffffffU : 0;
+    forgotten = 0;
+
+    auto is_erase_spell_id = this->is_realm1 ? [](int spell_id) { return spell_id >= 32; } : [](int spell_id) { return spell_id < 32; };
+    std::erase_if(this->player_ptr->spell_order_learned, is_erase_spell_id);
+}
+
+bool PlayerSpellStatus::Realm::is_nothing_learned() const
+{
+    const auto learned = this->is_realm1 ? this->player_ptr->spell_learned1 : this->player_ptr->spell_learned2;
+    return learned == 0;
+}
+
+bool PlayerSpellStatus::Realm::is_learned(int spell_id) const
+{
+    const auto learned = this->is_realm1 ? this->player_ptr->spell_learned1 : this->player_ptr->spell_learned2;
+    return any_bits(learned, 1U << spell_id);
+}
+
+bool PlayerSpellStatus::Realm::is_worked(int spell_id) const
+{
+    const auto worked = this->is_realm1 ? this->player_ptr->spell_worked1 : this->player_ptr->spell_worked2;
+    return any_bits(worked, 1U << spell_id);
+}
+
+bool PlayerSpellStatus::Realm::is_forgotten(int spell_id) const
+{
+    const auto forgotten = this->is_realm1 ? this->player_ptr->spell_forgotten1 : this->player_ptr->spell_forgotten2;
+    return any_bits(forgotten, 1U << spell_id);
+}
+
+void PlayerSpellStatus::Realm::set_learned(int spell_id, bool value)
+{
+    auto &learned = this->is_realm1 ? this->player_ptr->spell_learned1 : this->player_ptr->spell_learned2;
+    set_flag_bit(learned, spell_id, value);
+}
+
+void PlayerSpellStatus::Realm::set_worked(int spell_id, bool value)
+{
+    auto &worked = this->is_realm1 ? this->player_ptr->spell_worked1 : this->player_ptr->spell_worked2;
+    set_flag_bit(worked, spell_id, value);
+}
+
+void PlayerSpellStatus::Realm::set_forgotten(int spell_id, bool value)
+{
+    auto &forgotten = this->is_realm1 ? this->player_ptr->spell_forgotten1 : this->player_ptr->spell_forgotten2;
+    set_flag_bit(forgotten, spell_id, value);
+}

--- a/src/player/player-spell-status.h
+++ b/src/player/player-spell-status.h
@@ -1,0 +1,32 @@
+#pragma once
+
+class PlayerType;
+
+class PlayerSpellStatus {
+public:
+    PlayerSpellStatus(PlayerType *player_ptr);
+
+    class Realm {
+    public:
+        Realm(PlayerType *player_ptr, bool is_realm1);
+
+        void initialize();
+        bool is_nothing_learned() const;
+        bool is_learned(int spell_id) const;
+        bool is_worked(int spell_id) const;
+        bool is_forgotten(int spell_id) const;
+        void set_learned(int spell_id, bool value = true);
+        void set_worked(int spell_id, bool value = true);
+        void set_forgotten(int spell_id, bool value = true);
+
+    private:
+        PlayerType *player_ptr;
+        bool is_realm1;
+    };
+
+    Realm realm1() const;
+    Realm realm2() const;
+
+private:
+    PlayerType *player_ptr;
+};

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -75,6 +75,7 @@
 #include "player/player-personality.h"
 #include "player/player-realm.h"
 #include "player/player-skill.h"
+#include "player/player-spell-status.h"
 #include "player/player-status-flags.h"
 #include "player/player-status-table.h"
 #include "player/player-view.h"
@@ -536,46 +537,38 @@ static void update_num_of_spells(PlayerType *player_ptr)
         }
     }
 
-    int num_boukyaku = 0;
-    for (int j = 0; j < 64; j++) {
-        if ((j < 32) ? any_bits(player_ptr->spell_forgotten1, (1UL << j)) : any_bits(player_ptr->spell_forgotten2, (1UL << (j - 32)))) {
-            num_boukyaku++;
+    PlayerSpellStatus pss(player_ptr);
+
+    auto num_forgotten = 0;
+    for (const auto &realm_status : { pss.realm1(), pss.realm2() }) {
+        for (auto spell_id = 0; spell_id < 32; spell_id++) {
+            if (realm_status.is_forgotten(spell_id)) {
+                num_forgotten++;
+            }
         }
     }
 
-    player_ptr->new_spells = num_allowed + player_ptr->add_spells + num_boukyaku - player_ptr->learned_spells;
+    player_ptr->new_spells = num_allowed + player_ptr->add_spells + num_forgotten - player_ptr->learned_spells;
+
     for (auto it = player_ptr->spell_order_learned.crbegin(); it != player_ptr->spell_order_learned.crend(); ++it) {
-        if (!player_ptr->spell_learned1 && !player_ptr->spell_learned2) {
-            break;
-        }
-
-        const auto j = *it;
-
-        const auto &realm = (j < 32) ? pr.realm1() : pr.realm2();
-        const auto &spell = realm.get_spell_info(j % 32);
+        const auto is_realm1 = *it < 32;
+        const auto spell_id = *it % 32;
+        const auto &realm = is_realm1 ? pr.realm1() : pr.realm2();
+        const auto &spell = realm.get_spell_info(spell_id);
 
         if (spell.slevel <= player_ptr->lev) {
             continue;
         }
 
-        bool is_spell_learned = (j < 32) ? any_bits(player_ptr->spell_learned1, (1UL << j)) : any_bits(player_ptr->spell_learned2, (1UL << (j - 32)));
-        if (!is_spell_learned) {
+        auto realm_status = is_realm1 ? pss.realm1() : pss.realm2();
+        if (!realm_status.is_learned(spell_id)) {
             continue;
         }
 
-        if (j < 32) {
-            set_bits(player_ptr->spell_forgotten1, (1UL << j));
-        } else {
-            set_bits(player_ptr->spell_forgotten2, (1UL << (j - 32)));
-        }
+        realm_status.set_forgotten(spell_id);
+        realm_status.set_learned(spell_id, false);
 
-        if (j < 32) {
-            reset_bits(player_ptr->spell_learned1, (1UL << j));
-        } else {
-            reset_bits(player_ptr->spell_learned2, (1UL << (j - 32)));
-        }
-
-        const auto &spell_name = realm.get_spell_name(j % 32);
+        const auto &spell_name = realm.get_spell_name(spell_id);
 #ifdef JP
         msg_format("%sの%sを忘れてしまった。", spell_name.data(), spell_category.data());
 #else
@@ -589,31 +582,20 @@ static void update_num_of_spells(PlayerType *player_ptr)
         if (player_ptr->new_spells >= 0) {
             break;
         }
-        if (!player_ptr->spell_learned1 && !player_ptr->spell_learned2) {
-            break;
-        }
 
-        const auto j = *it;
+        const auto is_realm1 = *it < 32;
+        const auto spell_id = *it % 32;
 
-        bool is_spell_learned = (j < 32) ? any_bits(player_ptr->spell_learned1, (1UL << j)) : any_bits(player_ptr->spell_learned2, (1UL << (j - 32)));
-        if (!is_spell_learned) {
+        auto realm_status = is_realm1 ? pss.realm1() : pss.realm2();
+        if (!realm_status.is_learned(spell_id)) {
             continue;
         }
 
-        if (j < 32) {
-            set_bits(player_ptr->spell_forgotten1, (1UL << j));
-        } else {
-            set_bits(player_ptr->spell_forgotten2, (1UL << (j - 32)));
-        }
+        realm_status.set_forgotten(spell_id);
+        realm_status.set_learned(spell_id, false);
 
-        if (j < 32) {
-            reset_bits(player_ptr->spell_learned1, (1UL << j));
-        } else {
-            reset_bits(player_ptr->spell_learned2, (1UL << (j - 32)));
-        }
-
-        const auto &realm = (j < 32) ? pr.realm1() : pr.realm2();
-        const auto &spell_name = realm.get_spell_name(j % 32);
+        const auto &realm = is_realm1 ? pr.realm1() : pr.realm2();
+        const auto &spell_name = realm.get_spell_name(spell_id);
 #ifdef JP
         msg_format("%sの%sを忘れてしまった。", spell_name.data(), spell_category.data());
 #else
@@ -627,36 +609,26 @@ static void update_num_of_spells(PlayerType *player_ptr)
         if (player_ptr->new_spells <= 0) {
             break;
         }
-        if (!player_ptr->spell_forgotten1 && !player_ptr->spell_forgotten2) {
-            break;
-        }
 
-        const auto &realm = (j < 32) ? pr.realm1() : pr.realm2();
-        const auto &spell = realm.get_spell_info(j % 32);
+        const auto is_realm1 = j < 32;
+        const auto spell_id = j % 32;
+
+        const auto &realm = is_realm1 ? pr.realm1() : pr.realm2();
+        const auto &spell = realm.get_spell_info(spell_id);
 
         if (spell.slevel > player_ptr->lev) {
             continue;
         }
 
-        bool is_spell_learned = (j < 32) ? any_bits(player_ptr->spell_forgotten1, (1UL << j)) : any_bits(player_ptr->spell_forgotten2, (1UL << (j - 32)));
-        if (!is_spell_learned) {
+        auto realm_status = is_realm1 ? pss.realm1() : pss.realm2();
+        if (!realm_status.is_forgotten(spell_id)) {
             continue;
         }
 
-        if (j < 32) {
-            reset_bits(player_ptr->spell_forgotten1, (1UL << j));
-        } else {
-            reset_bits(player_ptr->spell_forgotten2, (1UL << (j - 32)));
-        }
+        realm_status.set_forgotten(spell_id, false);
+        realm_status.set_learned(spell_id);
 
-        if (j < 32) {
-            set_bits(player_ptr->spell_learned1, (1UL << j));
-
-        } else {
-            set_bits(player_ptr->spell_learned2, (1UL << (j - 32)));
-        }
-
-        const auto &spell_name = realm.get_spell_name(j % 32);
+        const auto &spell_name = realm.get_spell_name(spell_id);
 #ifdef JP
         msg_format("%sの%sを思い出した。", spell_name.data(), spell_category.data());
 #else
@@ -674,7 +646,7 @@ static void update_num_of_spells(PlayerType *player_ptr)
                 continue;
             }
 
-            if (any_bits(player_ptr->spell_learned1, (1UL << j))) {
+            if (pss.realm1().is_learned(j)) {
                 continue;
             }
 

--- a/src/spell/spell-info.cpp
+++ b/src/spell/spell-info.cpp
@@ -4,6 +4,7 @@
 #include "player-info/class-info.h"
 #include "player/player-realm.h"
 #include "player/player-skill.h"
+#include "player/player-spell-status.h"
 #include "player/player-status-table.h"
 #include "player/player-status.h"
 #include "realm/realm-types.h"
@@ -303,6 +304,8 @@ void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell_id, const SPELL
         const auto info = exe_spell(player_ptr, use_realm, spell_id, SpellProcessType::INFO);
         concptr comment = info->data();
         byte line_attr = TERM_WHITE;
+        PlayerSpellStatus pss(player_ptr);
+        const auto realm_status = pr.realm1().equals(use_realm) ? pss.realm1() : pss.realm2();
         if (pc.is_every_magic()) {
             if (spell.slevel > player_ptr->max_plv) {
                 comment = _("未知", "unknown");
@@ -314,13 +317,13 @@ void print_spells(PlayerType *player_ptr, SPELL_IDX target_spell_id, const SPELL
         } else if (!pr.realm1().equals(use_realm) && !pr.realm2().equals(use_realm)) {
             comment = _("未知", "unknown");
             line_attr = TERM_L_BLUE;
-        } else if (pr.realm1().equals(use_realm) ? ((player_ptr->spell_forgotten1 & (1UL << spell_id))) : ((player_ptr->spell_forgotten2 & (1UL << spell_id)))) {
+        } else if (realm_status.is_forgotten(spell_id)) {
             comment = _("忘却", "forgotten");
             line_attr = TERM_YELLOW;
-        } else if (!(pr.realm1().equals(use_realm) ? (player_ptr->spell_learned1 & (1UL << spell_id)) : (player_ptr->spell_learned2 & (1UL << spell_id)))) {
+        } else if (!realm_status.is_learned(spell_id)) {
             comment = _("未知", "unknown");
             line_attr = TERM_L_BLUE;
-        } else if (!(pr.realm1().equals(use_realm) ? (player_ptr->spell_worked1 & (1UL << spell_id)) : (player_ptr->spell_worked2 & (1UL << spell_id)))) {
+        } else if (!realm_status.is_worked(spell_id)) {
             comment = _("未経験", "untried");
             line_attr = TERM_L_GREEN;
         }

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -22,6 +22,7 @@
 #include "player-base/player-class.h"
 #include "player-info/class-info.h"
 #include "player/player-realm.h"
+#include "player/player-spell-status.h"
 #include "player/player-status-flags.h"
 #include "player/player-status-table.h"
 #include "player/player-status.h"
@@ -824,22 +825,26 @@ static void display_spell_list(PlayerType *player_ptr)
         y = (j < 3) ? 0 : (m[j - 3] + 2);
         x = 27 * (j % 3);
         int n = 0;
-        for (int i = 0; i < 32; i++) {
+
+        PlayerSpellStatus pss(player_ptr);
+        const auto realm_status = (j < 1) ? pss.realm1() : pss.realm2();
+
+        for (auto spell_id = 0; spell_id < 32; spell_id++) {
             byte a = TERM_WHITE;
 
             const auto &realm = (j < 1) ? pr.realm1() : pr.realm2();
-            const auto &spell = realm.get_spell_info(i);
-            const auto &spell_name = realm.get_spell_name(i % 32);
+            const auto &spell = realm.get_spell_info(spell_id);
+            const auto &spell_name = realm.get_spell_name(spell_id);
             auto name = spell_name.data();
 
             if (spell.slevel >= 99) {
                 name = _("(判読不能)", "(illegible)");
                 a = TERM_L_DARK;
-            } else if ((j < 1) ? ((player_ptr->spell_forgotten1 & (1UL << i))) : ((player_ptr->spell_forgotten2 & (1UL << (i % 32))))) {
+            } else if (realm_status.is_forgotten(spell_id)) {
                 a = TERM_ORANGE;
-            } else if (!((j < 1) ? (player_ptr->spell_learned1 & (1UL << i)) : (player_ptr->spell_learned2 & (1UL << (i % 32))))) {
+            } else if (!realm_status.is_learned(spell_id)) {
                 a = TERM_RED;
-            } else if (!((j < 1) ? (player_ptr->spell_worked1 & (1UL << i)) : (player_ptr->spell_worked2 & (1UL << (i % 32))))) {
+            } else if (!realm_status.is_worked(spell_id)) {
                 a = TERM_YELLOW;
             }
 

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -63,6 +63,7 @@
 #include "player/patron.h"
 #include "player/player-realm.h"
 #include "player/player-skill.h"
+#include "player/player-spell-status.h"
 #include "player/player-status-table.h"
 #include "player/player-status.h"
 #include "player/race-info-table.h"
@@ -684,6 +685,10 @@ void wiz_reset_class(PlayerType *player_ptr)
     if (chosen_realms->first != RealmType::NONE) {
         pr.set(chosen_realms->first, chosen_realms->second);
     }
+    PlayerSpellStatus pss(player_ptr);
+    pss.realm1().initialize();
+    pss.realm2().initialize();
+    player_ptr->learned_spells = 0;
     change_birth_flags();
     handle_stuff(player_ptr);
 }
@@ -704,6 +709,10 @@ void wiz_reset_realms(PlayerType *player_ptr)
     if (chosen_realms->first != RealmType::NONE) {
         pr.set(chosen_realms->first, chosen_realms->second);
     }
+    PlayerSpellStatus pss(player_ptr);
+    pss.realm1().initialize();
+    pss.realm2().initialize();
+    player_ptr->learned_spells = 0;
     change_birth_flags();
     handle_stuff(player_ptr);
 }


### PR DESCRIPTION
呪文の学習・試行・忘却状態の処理を行うPlayerSpellStatusクラスを実装し、
現状直接 spell?_learned, spell?_worked, spell?_forgotten にアクセス
している箇所をPlayerSpellStatusクラスによる処理で置き換える。

また、 #4421 の対策として、職業や領域の変更時にPlayerSpellStatusクラスを用いて、学習状況の初期化を行うようにする。