### PR TITLE
[Refactor] CfgReader

### DIFF
--- a/src/main-win/main-win-cfg-reader.cpp
+++ b/src/main-win/main-win-cfg-reader.cpp
@@ -10,6 +10,7 @@
 #include "main/sound-definitions-table.h"
 #include "term/z-term.h"
 #include "util/angband-files.h"
+#include <span>
 #include <windows.h>
 
 // 1つの項目に設定可能な最大ファイル数
@@ -29,46 +30,30 @@ static cfg_key make_cfg_key(int type, int val)
 }
 
 /*!
- * @brief マップのキーに対応する値を取得する
- * @param key1_type the "actions" value of "term_xtra()". see:z-term.h TERM_XTRA_xxxxx
- * @param key2_val the 2nd parameter of "term_xtra()"
- * @return キーに対応する値を返す。登録されていない場合はnullptrを返す。
- */
-static cfg_values *get_map_value(cfg_map *map, int key1_type, int key2_val)
-{
-    cfg_values *value = nullptr;
-    auto ite = map->find(make_cfg_key(key1_type, key2_val));
-    if (ite != map->end()) {
-        value = ite->second;
-    }
-    return value;
-}
-
-/*!
  * @brief 登録されている中からランダムに選択する
  * @param type the "actions" value of "term_xtra()". see:z-term.h TERM_XTRA_xxxxx
  * @param val the 2nd parameter of "term_xtra()"
- * @return キーに対応する値、複数のファイル名の中からからランダムに返す。登録されていない場合はnullptrを返す。
+ * @return キーに対応する値、複数のファイル名の中からからランダムに返す。登録されていない場合はstd::nulloptを返す。
  */
-concptr CfgData::get_rand(int key1_type, int key2_val)
+std::optional<std::string> CfgData::get_rand(int key1_type, int key2_val) const
 {
-    cfg_values *filenames = get_map_value(this->map, key1_type, key2_val);
-    if (!filenames) {
-        return nullptr;
+    const auto it = this->map.find(make_cfg_key(key1_type, key2_val));
+    if (it == this->map.end()) {
+        return std::nullopt;
     }
 
-    return filenames->at(Rand_external(filenames->size()));
+    const auto &filenames = it->second;
+    return filenames.at(Rand_external(filenames.size()));
 }
 
-bool CfgData::has_key(int key1_type, int key2_val)
+bool CfgData::has_key(int key1_type, int key2_val) const
 {
-    auto ite = map->find(make_cfg_key(key1_type, key2_val));
-    return ite != map->end();
+    return this->map.contains(make_cfg_key(key1_type, key2_val));
 }
 
-void CfgData::insert(int key1_type, int key2_val, cfg_values *value)
+void CfgData::insert(int key1_type, int key2_val, cfg_values &&value)
 {
-    this->map->insert(std::make_pair(make_cfg_key(key1_type, key2_val), value));
+    this->map.emplace(make_cfg_key(key1_type, key2_val), std::move(value));
 }
 
 /*!
@@ -89,51 +74,46 @@ CfgReader::CfgReader(const std::filesystem::path &dir, std::initializer_list<con
  * @param sections 読み取るデータの指定
  * @return 読み込んだデータを登録したCfgDataを返す。
  */
-CfgData *CfgReader::read_sections(std::initializer_list<cfg_section> sections)
+CfgData CfgReader::read_sections(std::initializer_list<cfg_section> sections) const
 {
-    CfgData *result = new CfgData();
+    CfgData result;
 
     if (!is_regular_file(this->cfg_path)) {
         return result;
     }
 
-    char key_buf[80];
-    char buf[MAIN_WIN_MAX_PATH];
-    char *tokens[SAMPLE_MAX];
+    const auto cfg_path_str = this->cfg_path.string();
 
     for (auto &section : sections) {
-
-        bool has_data = false;
-        int index = 0;
         concptr read_key;
-        while ((read_key = section.key_at(index, key_buf)) != nullptr) {
-            GetPrivateProfileStringA(section.section_name, read_key, "", buf, MAIN_WIN_MAX_PATH, this->cfg_path.string().data());
-            if (*buf != '\0') {
-                cfg_values *filenames = new cfg_values();
-#ifdef JP
-                // .cfg (UTF-8) to Shift-JIS
-                guess_convert_to_system_encoding(buf, MAIN_WIN_MAX_PATH);
-#endif
-                const int num = tokenize_whitespace(buf, SAMPLE_MAX, tokens);
-                for (auto j = 0; j < num; j++) {
-                    const auto path = path_build(dir, tokens[j]);
-                    if (is_regular_file(path)) {
-                        filenames->push_back(string_make(tokens[j]));
-                    }
-                }
-                if (filenames->empty()) {
-                    delete filenames;
-                } else {
-                    result->insert(section.action_type, index, filenames);
-                    has_data = true;
-                }
+        char key_buf[80]{};
+        for (auto index = 0; (read_key = section.key_at(index, key_buf)) != nullptr; ++index) {
+            char buf[MAIN_WIN_MAX_PATH]{};
+            if (GetPrivateProfileStringA(section.section_name, read_key, "", buf, MAIN_WIN_MAX_PATH, cfg_path_str.data()) == 0) {
+                continue;
             }
 
-            index++;
-        }
+#ifdef JP
+            // .cfg (UTF-8) to Shift-JIS
+            guess_convert_to_system_encoding(buf, MAIN_WIN_MAX_PATH);
+#endif
+            char *tokens[SAMPLE_MAX]{};
+            const int num = tokenize_whitespace(buf, SAMPLE_MAX, tokens);
 
-        if (section.has_data) {
-            *(section.has_data) = has_data;
+            cfg_values filenames;
+            for (const std::string_view token : std::span(tokens, num)) {
+                if (is_regular_file(path_build(this->dir, token))) {
+                    filenames.emplace_back(token);
+                }
+            }
+            if (filenames.empty()) {
+                continue;
+            }
+
+            result.insert(section.action_type, index, std::move(filenames));
+            if (section.has_data) {
+                *(section.has_data) = true;
+            }
         }
     }
 

--- a/src/main-win/main-win-cfg-reader.h
+++ b/src/main-win/main-win-cfg-reader.h
@@ -4,12 +4,13 @@
 #include <cstddef>
 #include <filesystem>
 #include <initializer_list>
+#include <optional>
 #include <unordered_map>
 #include <vector>
 
 typedef uint cfg_key;
-using cfg_values = std::vector<concptr>;
-using cfg_map = std::unordered_map<cfg_key, cfg_values *>;
+using cfg_values = std::vector<std::string>;
+using cfg_map = std::unordered_map<cfg_key, cfg_values>;
 using key_name_func = concptr (*)(int, char *);
 
 /*!
@@ -38,26 +39,20 @@ struct cfg_section {
 
 class CfgData {
 public:
-    CfgData()
-    {
-        map = new cfg_map();
-    }
-    virtual ~CfgData()
-    {
-        delete map;
-    }
-    concptr get_rand(int key1_type, int key2_val);
-    bool has_key(int key1_type, int key2_val);
-    void insert(int key1_type, int key2_val, cfg_values *value);
+    CfgData() = default;
+
+    std::optional<std::string> get_rand(int key1_type, int key2_val) const;
+    bool has_key(int key1_type, int key2_val) const;
+    void insert(int key1_type, int key2_val, cfg_values &&value);
 
 protected:
-    cfg_map *map;
+    cfg_map map{};
 };
 
 class CfgReader {
 public:
     CfgReader(const std::filesystem::path &dir, std::initializer_list<concptr> files);
-    CfgData *read_sections(std::initializer_list<cfg_section> sections);
+    CfgData read_sections(std::initializer_list<cfg_section> sections) const;
     const std::filesystem::path &get_cfg_path() const
     {
         return cfg_path;

--- a/src/main-win/main-win-music.cpp
+++ b/src/main-win/main-win-music.cpp
@@ -36,7 +36,7 @@ std::filesystem::path ANGBAND_DIR_XTRA_MUSIC;
 /*
  * "music.cfg" data
  */
-CfgData *music_cfg_data;
+std::optional<CfgData> music_cfg_data;
 
 namespace main_win_music {
 
@@ -183,12 +183,16 @@ errr play_music(int type, int val)
         return 0;
     } // now playing
 
+    if (!music_cfg_data) {
+        return 1;
+    }
+
     auto filename = music_cfg_data->get_rand(type, val);
     if (!filename) {
         return 1;
     } // no setting
 
-    auto path_music = path_build(ANGBAND_DIR_XTRA_MUSIC, filename);
+    auto path_music = path_build(ANGBAND_DIR_XTRA_MUSIC, *filename);
     if (current_music_type != TERM_XTRA_MUSIC_MUTE) {
         if (current_music_path == path_music) {
             return 0;

--- a/src/main-win/main-win-music.h
+++ b/src/main-win/main-win-music.h
@@ -5,11 +5,12 @@
 #include "system/h-type.h"
 #include <array>
 #include <filesystem>
+#include <optional>
 #include <windows.h>
 
 extern bool use_pause_music_inactive;
 extern std::filesystem::path ANGBAND_DIR_XTRA_MUSIC;
-extern CfgData *music_cfg_data;
+extern std::optional<CfgData> music_cfg_data;
 
 namespace main_win_music {
 void load_music_prefs();

--- a/src/main-win/main-win-sound.cpp
+++ b/src/main-win/main-win-sound.cpp
@@ -24,7 +24,7 @@ std::filesystem::path ANGBAND_DIR_XTRA_SOUND;
 /*
  * "sound.cfg" data
  */
-CfgData *sound_cfg_data;
+std::optional<CfgData> sound_cfg_data;
 
 /*!
  * 効果音データ
@@ -251,12 +251,16 @@ void finalize_sound(void)
  */
 int play_sound(int val, int volume)
 {
+    if (!sound_cfg_data) {
+        return 1;
+    }
+
     auto filename = sound_cfg_data->get_rand(TERM_XTRA_SOUND, val);
     if (!filename) {
         return 1;
     }
 
-    auto path = path_build(ANGBAND_DIR_XTRA_SOUND, filename);
+    auto path = path_build(ANGBAND_DIR_XTRA_SOUND, *filename);
     if (play_sound_impl(path, volume)) {
         return 0;
     }

--- a/src/main-win/main-win-sound.h
+++ b/src/main-win/main-win-sound.h
@@ -3,9 +3,10 @@
 #include "main-win/main-win-cfg-reader.h"
 #include <array>
 #include <filesystem>
+#include <optional>
 
 extern std::filesystem::path ANGBAND_DIR_XTRA_SOUND;
-extern CfgData *sound_cfg_data;
+extern std::optional<CfgData> sound_cfg_data;
 
 void load_sound_prefs();
 void finalize_sound();


### PR DESCRIPTION
Resolves #4427

生ポインタとnewを使用している古くさいコードとなっているCfgReaderをModern C++な書き方でリファクタリングを行う。