### PR TITLE
[Fix] 8bitサンプリングの効果音にノイズが乗る

### DIFF
--- a/src/main-win/main-win-sound.cpp
+++ b/src/main-win/main-win-sound.cpp
@@ -91,18 +91,19 @@ std::queue<sound_res *> sound_queue;
  */
 static void modulate_amplitude(int bits_per_sample, BYTE *pcm_buf, size_t bufsize, int mult, int div)
 {
-    auto modulate = [mult, div](auto sample) {
+    auto modulate = [mult, div](auto sample, int standard = 0) {
         using sample_t = decltype(sample);
         constexpr auto min = std::numeric_limits<sample_t>::min();
         constexpr auto max = std::numeric_limits<sample_t>::max();
-        const auto modulated_sample = std::clamp<int>(sample * mult / div, min, max);
+        const auto diff = sample - standard;
+        const auto modulated_sample = std::clamp<int>(standard + diff * mult / div, min, max);
         return static_cast<sample_t>(modulated_sample);
     };
 
     switch (bits_per_sample) {
     case 8:
         for (auto i = 0U; i < bufsize; ++i) {
-            pcm_buf[i] = modulate(pcm_buf[i]);
+            pcm_buf[i] = modulate(pcm_buf[i], 128);
         }
         break;
 


### PR DESCRIPTION
Fix #4432

8bitサンプリングのPCM音源の波形データはサンプルごとの値は0～255で基準値(無音)を128とするが、0を基準として振幅変調を行っているため想定通りの振幅変調が行えておらず、効果音再生時にノイズが乗ってしまう。
8bitサンプリングのPCMの場合は128を基準値として振幅変調を行うように修正する。