### PR TITLE
[Fix] 凡庸の巻物をモンスターの人形・像・骨・死体に使用するとクラッシュ

### DIFF
--- a/src/spell-kind/spells-enchant.cpp
+++ b/src/spell-kind/spells-enchant.cpp
@@ -120,10 +120,9 @@ bool artifact_scroll(PlayerType *player_ptr)
  */
 bool mundane_spell(PlayerType *player_ptr, bool only_equip)
 {
-    std::unique_ptr<ItemTester> item_tester = std::make_unique<AllMatchItemTester>();
-    if (only_equip) {
-        item_tester = std::make_unique<FuncItemTester>(&ItemEntity::is_weapon_armour_ammo);
-    }
+    std::unique_ptr<ItemTester> item_tester =
+        only_equip ? std::make_unique<FuncItemTester>(&ItemEntity::is_weapon_armour_ammo)
+                   : std::make_unique<FuncItemTester>([](const ItemEntity *o_ptr) { return !o_ptr->bi_key.is_monster(); });
 
     constexpr auto q = _("どのアイテムを凡庸化しますか？", "Mundanify which item? ");
     constexpr auto s = _("凡庸化できるアイテムがない。", "You have nothing to mundanify.");


### PR DESCRIPTION
Fix #4435 

凡庸の巻物をモンスターの人形・像・骨・死体に使用すると、pvalが0となることによりモンスター種族IDが0となるが、この状態は不正であるという扱いで例外を送出するようになっており、その結果クラッシュする。
対策として、これらのpvalをモンスター種族IDとして使用するアイテム（これらの他にモンスター・ボールも対象となる）に対して凡庸の巻物を使用できないようにする。