### PR TITLE
[Fix] 骨から矢、クロスボウの矢を生成する時に骨が重ね書きされて消滅する不具合を修正。

### DIFF
--- a/src/mind/mind-archer.cpp
+++ b/src/mind/mind-archer.cpp
@@ -146,17 +146,16 @@ bool create_ammo(PlayerType *player_ptr)
         if (item_ptr == nullptr) {
             return false;
         }
-
-        item_ptr->generate({ ItemKindType::ARROW, m_bonus(1, player_ptr->lev) + 1 });
-        item_ptr->number = (byte)rand_range(5, 10);
-        object_aware(player_ptr, item_ptr);
-        item_ptr->mark_as_known();
-        ItemMagicApplier(player_ptr, item_ptr, player_ptr->lev, AM_NO_FIXED_ART).execute();
-        item_ptr->discount = 99;
-        const auto item_name = describe_flavor(player_ptr, item_ptr, 0);
+        ItemEntity ammo({ ItemKindType::ARROW, m_bonus(1, player_ptr->lev) + 1 });
+        ammo.number = (byte)rand_range(5, 10);
+        object_aware(player_ptr, &ammo);
+        ammo.mark_as_known();
+        ItemMagicApplier(player_ptr, &ammo, player_ptr->lev, AM_NO_FIXED_ART).execute();
+        ammo.discount = 99;
+        const auto item_name = describe_flavor(player_ptr, &ammo, 0);
         msg_print(_(format("%sを作った。", item_name.data()), "You make some ammo."));
         vary_item(player_ptr, i_idx, -1);
-        int16_t slot = store_item_to_inventory(player_ptr, item_ptr);
+        int16_t slot = store_item_to_inventory(player_ptr, &ammo);
         if (slot >= 0) {
             autopick_alter_item(player_ptr, slot, false);
         }
@@ -172,16 +171,16 @@ bool create_ammo(PlayerType *player_ptr)
             return false;
         }
 
-        item_ptr->generate({ ItemKindType::BOLT, m_bonus(1, player_ptr->lev) + 1 });
-        item_ptr->number = (byte)rand_range(4, 8);
-        object_aware(player_ptr, item_ptr);
-        item_ptr->mark_as_known();
-        ItemMagicApplier(player_ptr, item_ptr, player_ptr->lev, AM_NO_FIXED_ART).execute();
-        item_ptr->discount = 99;
-        const auto item_name = describe_flavor(player_ptr, item_ptr, 0);
+        ItemEntity ammo({ ItemKindType::BOLT, m_bonus(1, player_ptr->lev) + 1 });
+        ammo.number = (byte)rand_range(4, 8);
+        object_aware(player_ptr, &ammo);
+        ammo.mark_as_known();
+        ItemMagicApplier(player_ptr, &ammo, player_ptr->lev, AM_NO_FIXED_ART).execute();
+        ammo.discount = 99;
+        const auto item_name = describe_flavor(player_ptr, &ammo, 0);
         msg_print(_(format("%sを作った。", item_name.data()), "You make some ammo."));
         vary_item(player_ptr, i_idx, -1);
-        int16_t slot = store_item_to_inventory(player_ptr, item_ptr);
+        int16_t slot = store_item_to_inventory(player_ptr, &ammo);
         if (slot >= 0) {
             autopick_alter_item(player_ptr, slot, false);
         }


### PR DESCRIPTION
リファクタリング時のエンバグを即興で修正。