### PR TITLE
初期配置時のset_monster_csleep()、set_monster_fast() によるステータス設定を関数呼び出しから取り出した

### DIFF
--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -375,8 +375,9 @@ std::optional<MONSTER_IDX> place_monster_one(PlayerType *player_ptr, MONSTER_IDX
 
     m_ptr->mtimed[MTIMED_CSLEEP] = 0;
     if (any_bits(mode, PM_ALLOW_SLEEP) && new_monrace.sleep && !ironman_nightmare) {
-        int val = new_monrace.sleep;
-        (void)set_monster_csleep(player_ptr, g_ptr->m_idx, (val * 2) + randint1(val * 10));
+        int val = std::clamp((new_monrace.sleep * 2) + randint1(new_monrace.sleep * 10), 0, 10000);
+        m_ptr->mtimed[MTIMED_CSLEEP] = (int16_t)val;
+        mproc_add(floor_ptr, m_idx, MTIMED_CSLEEP);
     }
 
     if (new_monrace.misc_flags.has(MonsterMiscType::FORCE_MAXHP)) {

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -403,7 +403,8 @@ std::optional<MONSTER_IDX> place_monster_one(PlayerType *player_ptr, MONSTER_IDX
     m_ptr->set_individual_speed(floor.inside_arena);
 
     if (any_bits(mode, PM_HASTE)) {
-        (void)set_monster_fast(player_ptr, g_ptr->m_idx, 100);
+        m_ptr->mtimed[MTIMED_FAST] = 100;
+        mproc_add(floor_ptr, m_idx, MTIMED_FAST);
     }
 
     if (!ironman_nightmare) {


### PR DESCRIPTION
Close #4446 
睡眠状態の変化による明かりの更新をするフラグを立てる処理を切り落としてるが、HAS_\*\*\*\* は起きていない限り効果を発揮せず、初期配置時に起きている際はplace_one_monster() 内に同フラグを立てる処理があるため切り落としても問題ないと思われる