### PR TITLE
[Refactor] シングルトンクラスにFloorType のデータを移し、初期化はFloorType のコンストラクタで行うようにした

### DIFF
--- a/VisualStudio/Hengband/Hengband.vcxproj
+++ b/VisualStudio/Hengband/Hengband.vcxproj
@@ -272,6 +272,7 @@
     <ClCompile Include="..\..\src\cmd-action\cmd-tunnel.cpp" />
     <ClCompile Include="..\..\src\action\movement-execution.cpp" />
     <ClCompile Include="..\..\src\core\score-util.cpp" />
+    <ClCompile Include="..\..\src\floor\floor-list.cpp" />
     <ClCompile Include="..\..\src\item-info\flavor-initializer.cpp" />
     <ClCompile Include="..\..\src\load\item\item-loader-base.cpp" />
     <ClCompile Include="..\..\src\load\item\item-loader-factory.cpp" />
@@ -983,6 +984,7 @@
     <ClInclude Include="..\..\src\action\run-execution.h" />
     <ClInclude Include="..\..\src\external-lib\include-json.h" />
     <ClInclude Include="..\..\src\external-lib\json.hpp" />
+    <ClInclude Include="..\..\src\floor\floor-list.h" />
     <ClInclude Include="..\..\src\item-info\flavor-initializer.h" />
     <ClInclude Include="..\..\src\load\item\item-loader-version-types.h" />
     <ClInclude Include="..\..\src\load\item\item-loader-base.h" />

--- a/VisualStudio/Hengband/Hengband.vcxproj.filters
+++ b/VisualStudio/Hengband/Hengband.vcxproj.filters
@@ -2520,6 +2520,9 @@
     <ClCompile Include="..\..\src\market\melee-arena.cpp">
       <Filter>market</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\floor\floor-list.cpp">
+      <Filter>floor</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5403,9 +5406,9 @@
     <ClInclude Include="..\..\src\util\sha256.h">
       <Filter>util</Filter>
     </ClInclude>
-    <ClCompile Include="..\..\src\util\stack-trace.h">
+    <ClInclude Include="..\..\src\util\stack-trace.h">
       <Filter>util</Filter>
-    </ClCompile>
+    </ClInclude>
     <ClInclude Include="..\..\src\external-lib\json.hpp">
       <Filter>external-lib</Filter>
     </ClInclude>
@@ -5453,6 +5456,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\market\melee-arena.h">
       <Filter>market</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\floor\floor-list.h">
+      <Filter>floor</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -214,6 +214,7 @@ hengband_SOURCES = \
 	floor/floor-generator-util.h \
 	floor/floor-generator.cpp floor/floor-generator.h \
 	floor/floor-leaver.cpp floor/floor-leaver.h \
+	floor/floor-list.cpp floor/floor-list.h \
 	floor/floor-mode-changer.cpp floor/floor-mode-changer.h \
 	floor/floor-object.cpp floor/floor-object.h \
 	floor/floor-save.cpp floor/floor-save.h \

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -1,5 +1,6 @@
 #include "birth/game-play-initializer.h"
 #include "dungeon/quest.h"
+#include "floor/floor-list.h"
 #include "floor/floor-util.h"
 #include "game-option/birth-options.h"
 #include "game-option/cheat-options.h"
@@ -39,7 +40,7 @@ void player_wipe_without_name(PlayerType *player_ptr)
     *player_ptr = {};
 
     // TODO: キャラ作成からゲーム開始までに  current_floor_ptr を参照しなければならない処理は今後整理して外す。
-    player_ptr->current_floor_ptr = &floor_info;
+    player_ptr->current_floor_ptr = &FloorList::get_instance().get_floor(0);
     //! @todo std::make_shared の配列対応版は C++20 から
     player_ptr->inventory_list = std::shared_ptr<ItemEntity[]>{ new ItemEntity[INVEN_TOTAL] };
     for (int i = 0; i < 4; i++) {

--- a/src/floor/floor-list.cpp
+++ b/src/floor/floor-list.cpp
@@ -1,0 +1,24 @@
+#include "floor/floor-list.h"
+#include "system/grid-type-definition.h"
+#include "system/item-entity.h"
+#include "system/monster-entity.h"
+
+FloorList FloorList::instance{};
+
+FloorList &FloorList::get_instance()
+{
+    return instance;
+}
+
+/*!
+ * @brief 指定IDからフロアの参照を取得する
+ * @param num 番号（現状は今後配列化する際の仮定義）
+ * @return フロアの参照
+ * @details 現状num はどの数値を指定しても一緒だが、置換しやすいように0を使うこと
+ */
+FloorType &FloorList::get_floor(int num)
+{
+    (void)num;
+
+    return this->floor;
+}

--- a/src/floor/floor-list.h
+++ b/src/floor/floor-list.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "system/floor-type-definition.h"
+
+class FloorList final {
+public:
+    FloorList(const FloorList &) = delete;
+    FloorList(FloorList &&) = delete;
+    FloorList &operator=(const FloorList &) = delete;
+    FloorList &operator=(FloorList &&) = delete;
+    static FloorList &get_instance();
+
+    FloorType &get_floor(int num);
+
+private:
+    static FloorList instance;
+    FloorType floor{};
+    FloorList() = default;
+};

--- a/src/main/game-data-initializer.cpp
+++ b/src/main/game-data-initializer.cpp
@@ -6,6 +6,7 @@
 #include "main/game-data-initializer.h"
 #include "cmd-io/macro-util.h"
 #include "dungeon/quest.h"
+#include "floor/floor-list.h"
 #include "floor/floor-util.h"
 #include "game-option/option-flags.h"
 #include "game-option/option-types-table.h"
@@ -45,16 +46,11 @@ static void init_gf_colors()
  */
 void init_other(PlayerType *player_ptr)
 {
-    player_ptr->current_floor_ptr = &floor_info; // TODO:本当はこんなところで初期化したくない
-    auto *floor_ptr = player_ptr->current_floor_ptr;
-    floor_ptr->o_list.assign(MAX_FLOOR_ITEMS, {});
-    floor_ptr->m_list.assign(MAX_FLOOR_MONSTERS, {});
-    for (auto &list : floor_ptr->mproc_list) {
-        list.assign(MAX_FLOOR_MONSTERS, {});
-    }
+    auto &floor_data = FloorList::get_instance();
+    auto *floor_ptr = &floor_data.get_floor(0);
+    player_ptr->current_floor_ptr = floor_ptr; // TODO:本当はこんなところで初期化したくない ← FloorTypeの方で初期化するべき？
 
     max_dlv.assign(dungeons_info.size(), {});
-    floor_ptr->grid_array.assign(MAX_HGT, std::vector<Grid>(MAX_WID));
     init_gf_colors();
 
     macro_patterns.assign(MACRO_MAX, {});

--- a/src/system/floor-type-definition.cpp
+++ b/src/system/floor-type-definition.cpp
@@ -1,9 +1,11 @@
 #include "system/floor-type-definition.h"
 #include "dungeon/quest.h"
 #include "game-option/birth-options.h"
+#include "monster/monster-timed-effect-types.h"
 #include "system/angband-system.h"
 #include "system/artifact-type-definition.h"
 #include "system/dungeon-info.h"
+#include "system/gamevalue.h"
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
 #include "system/monster-entity.h"
@@ -11,7 +13,11 @@
 #include "util/enum-range.h"
 
 FloorType::FloorType()
-    : quest_number(QuestId::NONE)
+    : grid_array(MAX_HGT, std::vector<Grid>(MAX_WID))
+    , o_list(MAX_FLOOR_ITEMS)
+    , m_list(MAX_FLOOR_MONSTERS)
+    , mproc_list(MAX_MTIMED, std::vector<int16_t>(MAX_FLOOR_MONSTERS, {}))
+    , quest_number(QuestId::NONE)
 {
 }
 

--- a/src/system/floor-type-definition.h
+++ b/src/system/floor-type-definition.h
@@ -62,7 +62,7 @@ public:
     MONSTER_IDX m_max = 0; /* Number of allocated monsters */
     MONSTER_IDX m_cnt = 0; /* Number of live monsters */
 
-    std::vector<int16_t> mproc_list[MAX_MTIMED]{}; /*!< The array to process dungeon monsters[max_m_idx] */
+    std::vector<std::vector<int16_t>> mproc_list; /*!< The array to process dungeon monsters[max_m_idx] */
     int16_t mproc_max[MAX_MTIMED]{}; /*!< Number of monsters to be processed */
 
     POSITION_IDX lite_n = 0; //!< Array of grids lit by player lite


### PR DESCRIPTION
Close #4468 
`init_other()`で初期化している箇所はコメントアウトされているTODO についてFloorType のコンストラクタに移植するべきと判断し移植しているため、該当部分に関してもレビュー求む