### PR TITLE
[Refactor] 騎乗判定のPlayerType 依存を全部置き換えた

### DIFF
--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -141,7 +141,7 @@ void do_cmd_pet_dismiss(PlayerType *player_ptr)
                 exe_write_diary(floor, DiaryKind::NAMED_PET, RECORD_NAMED_PET_DISMISS, m_name);
             }
 
-            if (pet_ctr == player_ptr->riding) {
+            if (monster.is_riding()) {
                 msg_format(_("%sから降りた。", "You dismount from %s. "), friend_name.data());
                 player_ptr->ride_monster(0);
                 rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);

--- a/src/core/stuff-handler.cpp
+++ b/src/core/stuff-handler.cpp
@@ -1,6 +1,8 @@
 #include "core/stuff-handler.h"
 #include "core/window-redrawer.h"
 #include "player/player-status.h"
+#include "system/floor-type-definition.h"
+#include "system/monster-entity.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "tracking/baseitem-tracker.h"
@@ -33,7 +35,9 @@ void handle_stuff(PlayerType *player_ptr)
  */
 void health_track(PlayerType *player_ptr, short m_idx)
 {
-    if (m_idx && m_idx == player_ptr->riding) {
+    const auto &floor = *player_ptr->current_floor_ptr;
+    const auto &monster = floor.m_list[m_idx];
+    if (monster.is_riding()) {
         return;
     }
 

--- a/src/effect/effect-monster-charm.cpp
+++ b/src/effect/effect-monster-charm.cpp
@@ -421,7 +421,7 @@ static void effect_monster_captured(PlayerType *player_ptr, EffectMonster *em_pt
     cap_mon_ptr->current_hp = static_cast<short>(em_ptr->m_ptr->hp);
     cap_mon_ptr->max_hp = static_cast<short>(em_ptr->m_ptr->max_maxhp);
     cap_mon_ptr->nickname = em_ptr->m_ptr->nickname;
-    if ((em_ptr->g_ptr->m_idx == player_ptr->riding) && process_fall_off_horse(player_ptr, -1, false)) {
+    if (em_ptr->m_ptr->is_riding() && process_fall_off_horse(player_ptr, -1, false)) {
         msg_print(_("地面に落とされた。", format("You have fallen from %s.", em_ptr->m_name)));
     }
 

--- a/src/effect/effect-monster-psi.cpp
+++ b/src/effect/effect-monster-psi.cpp
@@ -320,13 +320,13 @@ ProcessResult effect_monster_psi_drain(PlayerType *player_ptr, EffectMonster *em
  * @details
  * 朦朧＋ショートテレポートアウェイ
  */
-ProcessResult effect_monster_telekinesis(PlayerType *player_ptr, EffectMonster *em_ptr)
+ProcessResult effect_monster_telekinesis(EffectMonster *em_ptr)
 {
     if (em_ptr->seen) {
         em_ptr->obvious = true;
     }
     if (one_in_(4)) {
-        if (player_ptr->riding && (em_ptr->g_ptr->m_idx == player_ptr->riding)) {
+        if (em_ptr->m_ptr->is_riding()) {
             em_ptr->do_dist = 0;
         } else {
             em_ptr->do_dist = 7;

--- a/src/effect/effect-monster-psi.h
+++ b/src/effect/effect-monster-psi.h
@@ -6,4 +6,4 @@ class EffectMonster;
 class PlayerType;
 ProcessResult effect_monster_psi(PlayerType *player_ptr, EffectMonster *em_ptr);
 ProcessResult effect_monster_psi_drain(PlayerType *player_ptr, EffectMonster *em_ptr);
-ProcessResult effect_monster_telekinesis(PlayerType *player_ptr, EffectMonster *em_ptr);
+ProcessResult effect_monster_telekinesis(EffectMonster *em_ptr);

--- a/src/effect/effect-monster-resist-hurt.cpp
+++ b/src/effect/effect-monster-resist-hurt.cpp
@@ -591,7 +591,7 @@ static void effect_monster_gravity_stun(EffectMonster *em_ptr)
 ProcessResult effect_monster_gravity(PlayerType *player_ptr, EffectMonster *em_ptr)
 {
     em_ptr->do_dist = effect_monster_gravity_resist_teleport(player_ptr, em_ptr) ? 0 : 10;
-    if (player_ptr->riding && (em_ptr->g_ptr->m_idx == player_ptr->riding)) {
+    if (em_ptr->m_ptr->is_riding()) {
         em_ptr->do_dist = 0;
     }
 

--- a/src/effect/effect-monster-switcher.cpp
+++ b/src/effect/effect-monster-switcher.cpp
@@ -384,7 +384,7 @@ ProcessResult switch_effects_monster(PlayerType *player_ptr, EffectMonster *em_p
     case AttributeType::PSI_DRAIN:
         return effect_monster_psi_drain(player_ptr, em_ptr);
     case AttributeType::TELEKINESIS:
-        return effect_monster_telekinesis(player_ptr, em_ptr);
+        return effect_monster_telekinesis(em_ptr);
     case AttributeType::DOMINATION:
         return effect_monster_domination(player_ptr, em_ptr);
     case AttributeType::ICE:

--- a/src/effect/effect-player.cpp
+++ b/src/effect/effect-player.cpp
@@ -132,12 +132,12 @@ static ProcessResult check_continue_player_effect(PlayerType *player_ptr, Effect
     auto is_effective = ep_ptr->dam > 0;
     is_effective &= randint0(55) < (player_ptr->lev * 3 / 5 + 20);
     is_effective &= is_monster(ep_ptr->src_idx);
-    is_effective &= ep_ptr->src_idx != player_ptr->riding;
+    is_effective &= !ep_ptr->src_ptr || !ep_ptr->src_ptr->is_riding();
     if (is_effective && kawarimi(player_ptr, true)) {
         return ProcessResult::PROCESS_FALSE;
     }
 
-    if (is_player(ep_ptr->src_idx) || (ep_ptr->src_idx == player_ptr->riding)) {
+    if (is_player(ep_ptr->src_idx) || (ep_ptr->src_ptr && ep_ptr->src_ptr->is_riding())) {
         return ProcessResult::PROCESS_FALSE;
     }
 
@@ -225,7 +225,7 @@ bool affect_player(MONSTER_IDX src_idx, PlayerType *player_ptr, concptr src_name
     }
 
     disturb(player_ptr, true, true);
-    if (ep_ptr->dam && ep_ptr->src_idx && (ep_ptr->src_idx != player_ptr->riding)) {
+    if (ep_ptr->dam && ep_ptr->src_idx && (!ep_ptr->src_ptr || !ep_ptr->src_ptr->is_riding())) {
         (void)kawarimi(player_ptr, false);
     }
 

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -368,7 +368,7 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITIO
             if (grids <= 1) {
                 auto *m_ptr = &floor.m_list[grid.m_idx];
                 MonsterRaceInfo *ref_ptr = &m_ptr->get_monrace();
-                if ((flag & PROJECT_REFLECTABLE) && grid.m_idx && ref_ptr->misc_flags.has(MonsterMiscType::REFLECTING) && ((grid.m_idx != player_ptr->riding) || !(flag & PROJECT_PLAYER)) && (!src_idx || path_n > 1) && !one_in_(10)) {
+                if ((flag & PROJECT_REFLECTABLE) && grid.m_idx && ref_ptr->misc_flags.has(MonsterMiscType::REFLECTING) && (!m_ptr->is_riding() || !(flag & PROJECT_PLAYER)) && (!src_idx || path_n > 1) && !one_in_(10)) {
 
                     POSITION t_y, t_x;
                     int max_attempts = 10;

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -83,7 +83,7 @@ static void sweep_preserving_pet(PlayerType *player_ptr)
 
     for (MONSTER_IDX i = player_ptr->current_floor_ptr->m_max - 1, party_monster_num = 1; (i >= 1) && (party_monster_num < MAX_PARTY_MON); i--) {
         auto *m_ptr = &player_ptr->current_floor_ptr->m_list[i];
-        if (!m_ptr->is_valid() || !m_ptr->is_pet() || (i == player_ptr->riding) || check_pet_preservation_conditions(player_ptr, m_ptr)) {
+        if (!m_ptr->is_valid() || !m_ptr->is_pet() || m_ptr->is_riding() || check_pet_preservation_conditions(player_ptr, m_ptr)) {
             continue;
         }
 

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -924,7 +924,7 @@ bool change_wild_mode(PlayerType *player_ptr, bool encount)
             continue;
         }
 
-        if (m_ptr->is_pet() && i != player_ptr->riding) {
+        if (m_ptr->is_pet() && !m_ptr->is_riding()) {
             has_pet = true;
         }
 

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -878,8 +878,8 @@ bool cave_player_teleportable_bold(PlayerType *player_ptr, POSITION y, POSITION 
     if (!(mode & TELEPORT_NONMAGICAL) && grid.is_icky()) {
         return false;
     }
-
-    if (grid.has_monster() && (grid.m_idx != player_ptr->riding)) {
+    const auto &floor = *player_ptr->current_floor_ptr;
+    if (grid.has_monster() && !floor.m_list[grid.m_idx].is_riding()) {
         return false;
     }
 

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -67,7 +67,7 @@ static void dump_aux_pet(PlayerType *player_ptr, FILE *fff)
             continue;
         }
         pet_settings = true;
-        if (!m_ptr->is_named() && (player_ptr->riding != i)) {
+        if (!m_ptr->is_named() && !m_ptr->is_riding()) {
             continue;
         }
         if (!pet) {

--- a/src/melee/melee-postprocess.cpp
+++ b/src/melee/melee-postprocess.cpp
@@ -247,7 +247,7 @@ static void make_monster_fear(PlayerType *player_ptr, mam_pp_type *mam_pp_ptr)
  */
 static void fall_off_horse_by_melee(PlayerType *player_ptr, mam_pp_type *mam_pp_ptr)
 {
-    if (!player_ptr->riding || (player_ptr->riding != mam_pp_ptr->m_idx) || (mam_pp_ptr->dam <= 0)) {
+    if (!mam_pp_ptr->m_ptr->is_riding() || (mam_pp_ptr->dam <= 0)) {
         return;
     }
 
@@ -281,7 +281,7 @@ void mon_take_hit_mon(PlayerType *player_ptr, MONSTER_IDX m_idx, int dam, bool *
     prepare_redraw(mam_pp_ptr);
     (void)set_monster_csleep(player_ptr, m_idx, 0);
 
-    if (player_ptr->riding && (m_idx == player_ptr->riding)) {
+    if (m_ptr->is_riding()) {
         disturb(player_ptr, true, true);
     }
 

--- a/src/melee/melee-spell-flags-checker.cpp
+++ b/src/melee/melee-spell-flags-checker.cpp
@@ -267,9 +267,9 @@ static void check_melee_spell_special(PlayerType *player_ptr, melee_spell_type *
     ms_ptr->ability_flags.reset(MonsterAbilityType::SPECIAL);
 }
 
-static void check_riding(PlayerType *player_ptr, melee_spell_type *ms_ptr)
+static void check_riding(melee_spell_type *ms_ptr)
 {
-    if (ms_ptr->m_idx != player_ptr->riding) {
+    if (!ms_ptr->m_ptr->is_riding()) {
         return;
     }
 
@@ -295,7 +295,7 @@ static void check_pet(PlayerType *player_ptr, melee_spell_type *ms_ptr)
         ms_ptr->ability_flags.reset(RF_ABILITY_SUMMON_MASK);
     }
 
-    if (!(player_ptr->pet_extra_flags & PF_BALL_SPELL) && (ms_ptr->m_idx != player_ptr->riding)) {
+    if (!(player_ptr->pet_extra_flags & PF_BALL_SPELL) && !ms_ptr->m_ptr->is_riding()) {
         check_melee_spell_distance(player_ptr, ms_ptr);
         check_melee_spell_rocket(player_ptr, ms_ptr);
         check_melee_spell_beam(player_ptr, ms_ptr);
@@ -343,7 +343,7 @@ static void check_smart(PlayerType *player_ptr, melee_spell_type *ms_ptr)
     }
 
     const auto &floor = *player_ptr->current_floor_ptr;
-    if (ms_ptr->ability_flags.has(MonsterAbilityType::TELE_LEVEL) && floor.can_teleport_level((ms_ptr->target_idx != player_ptr->riding) ? ms_ptr->target_idx != 0 : false)) {
+    if (ms_ptr->ability_flags.has(MonsterAbilityType::TELE_LEVEL) && floor.can_teleport_level(!ms_ptr->t_ptr->is_riding() ? ms_ptr->target_idx != 0 : false)) {
         ms_ptr->ability_flags.reset(MonsterAbilityType::TELE_LEVEL);
     }
 }
@@ -391,7 +391,7 @@ bool check_melee_spell_set(PlayerType *player_ptr, melee_spell_type *ms_ptr)
         ms_ptr->ability_flags.reset(MonsterAbilityType::HEAL);
     }
 
-    check_riding(player_ptr, ms_ptr);
+    check_riding(ms_ptr);
     check_pet(player_ptr, ms_ptr);
     check_non_stupid(player_ptr, ms_ptr);
     check_smart(player_ptr, ms_ptr);

--- a/src/melee/melee-spell.cpp
+++ b/src/melee/melee-spell.cpp
@@ -113,7 +113,7 @@ bool monst_spell_monst(PlayerType *player_ptr, MONSTER_IDX m_idx)
 
     ms_ptr->m_name = monster_desc(player_ptr, ms_ptr->m_ptr, 0x00);
     ms_ptr->thrown_spell = rand_choice(ms_ptr->spells);
-    if (player_ptr->riding && (m_idx == player_ptr->riding)) {
+    if (ms_ptr->m_ptr->is_riding()) {
         disturb(player_ptr, true, true);
     }
 

--- a/src/melee/melee-switcher.cpp
+++ b/src/melee/melee-switcher.cpp
@@ -206,7 +206,7 @@ void decide_monster_attack_effect(PlayerType *player_ptr, mam_type *mam_ptr)
         break;
     case RaceBlowEffectType::EAT_ITEM:
     case RaceBlowEffectType::EAT_GOLD:
-        if ((player_ptr->riding != mam_ptr->m_idx) && one_in_(2)) {
+        if (!mam_ptr->m_ptr->is_riding() && one_in_(2)) {
             mam_ptr->blinked = true;
         }
 

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -348,7 +348,7 @@ bool monst_attack_monst(PlayerType *player_ptr, MONSTER_IDX m_idx, MONSTER_IDX t
         player_ptr->current_floor_ptr->monster_noise = true;
     }
 
-    if (player_ptr->riding && (m_idx == player_ptr->riding)) {
+    if (mam_ptr->m_ptr->is_riding()) {
         disturb(player_ptr, true, true);
     }
 

--- a/src/monster-attack/monster-attack-processor.cpp
+++ b/src/monster-attack/monster-attack-processor.cpp
@@ -131,7 +131,7 @@ bool process_monster_attack_to_monster(PlayerType *player_ptr, turn_flags *turn_
     const auto &monrace_to = monster_to.get_monrace();
     auto do_kill_body = monrace_from.behavior_flags.has(MonsterBehaviorType::KILL_BODY) && monrace_from.behavior_flags.has_not(MonsterBehaviorType::NEVER_BLOW);
     do_kill_body &= (monrace_from.mexp * monrace_from.level > monrace_to.mexp * monrace_to.level);
-    do_kill_body &= (g_ptr->m_idx != player_ptr->riding);
+    do_kill_body &= !monster_to.is_riding();
     if (do_kill_body || monster_from.is_hostile_to_melee(monster_to) || monster_from.is_confused()) {
         return exe_monster_attack_to_monster(player_ptr, m_idx, g_ptr);
     }
@@ -139,7 +139,7 @@ bool process_monster_attack_to_monster(PlayerType *player_ptr, turn_flags *turn_
     auto do_move_body = monrace_from.behavior_flags.has(MonsterBehaviorType::MOVE_BODY) && monrace_from.behavior_flags.has_not(MonsterBehaviorType::NEVER_MOVE);
     do_move_body &= (monrace_from.mexp > monrace_to.mexp);
     do_move_body &= can_cross;
-    do_move_body &= (g_ptr->m_idx != player_ptr->riding);
+    do_move_body &= !monster_to.is_riding();
     do_move_body &= monster_can_cross_terrain(player_ptr, player_ptr->current_floor_ptr->grid_array[monster_from.fy][monster_from.fx].feat, &monrace_to, 0);
     if (do_move_body) {
         turn_flags_ptr->do_move = true;

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -391,7 +391,7 @@ void monster_death(PlayerType *player_ptr, MONSTER_IDX m_idx, bool drop_item, At
 
     QuestCompletionChecker(player_ptr, md_ptr->m_ptr).complete();
     on_defeat_arena_monster(player_ptr, md_ptr);
-    if (m_idx == player_ptr->riding && process_fall_off_horse(player_ptr, -1, false)) {
+    if (md_ptr->m_ptr->is_riding() && process_fall_off_horse(player_ptr, -1, false)) {
         msg_print(_("地面に落とされた。", "You have fallen from the pet you were riding."));
     }
 

--- a/src/monster-floor/monster-direction.cpp
+++ b/src/monster-floor/monster-direction.cpp
@@ -81,8 +81,8 @@ static void decide_enemy_approch_direction(PlayerType *player_ptr, MONSTER_IDX m
             continue;
         }
 
-        const auto can_pass_wall = r_ptr->feature_flags.has(MonsterFeatureType::PASS_WALL) && ((m_idx != player_ptr->riding) || has_pass_wall(player_ptr));
-        const auto can_kill_wall = r_ptr->feature_flags.has(MonsterFeatureType::KILL_WALL) && (m_idx != player_ptr->riding);
+        const auto can_pass_wall = r_ptr->feature_flags.has(MonsterFeatureType::PASS_WALL) && (!m_ptr->is_riding() || has_pass_wall(player_ptr));
+        const auto can_kill_wall = r_ptr->feature_flags.has(MonsterFeatureType::KILL_WALL) && !m_ptr->is_riding();
         if (can_pass_wall || can_kill_wall) {
             if (!in_disintegration_range(floor_ptr, m_ptr->fy, m_ptr->fx, t_ptr->fy, t_ptr->fx)) {
                 continue;

--- a/src/monster-floor/monster-safety-hiding.cpp
+++ b/src/monster-floor/monster-safety-hiding.cpp
@@ -45,7 +45,7 @@ static coordinate_candidate sweep_safe_coordinate(PlayerType *player_ptr, MONSTE
         Grid *g_ptr;
         g_ptr = &floor_ptr->grid_array[y][x];
 
-        BIT_FLAGS16 riding_mode = (m_idx == player_ptr->riding) ? CEM_RIDING : 0;
+        BIT_FLAGS16 riding_mode = m_ptr->is_riding() ? CEM_RIDING : 0;
         if (!monster_can_cross_terrain(player_ptr, g_ptr->feat, r_ptr, riding_mode)) {
             continue;
         }

--- a/src/monster/monster-compaction.cpp
+++ b/src/monster/monster-compaction.cpp
@@ -119,7 +119,7 @@ void compact_monsters(PlayerType *player_ptr, int size)
             if (monrace.level > cur_lev) {
                 continue;
             }
-            if (i == player_ptr->riding) {
+            if (monster.is_riding()) {
                 continue;
             }
             if ((cur_dis > 0) && (monster.cdis < cur_dis)) {

--- a/src/monster/monster-describer.cpp
+++ b/src/monster/monster-describer.cpp
@@ -176,7 +176,7 @@ static std::optional<std::string> get_fake_monster_name(const PlayerType &player
         return _(replace_monster_name_undefined(name), format("%s?", name.data()));
     }
 
-    if (AngbandSystem::get_instance().is_phase_out() && !(player.riding && (&player.current_floor_ptr->m_list[player.riding] == &monster))) {
+    if (AngbandSystem::get_instance().is_phase_out() && !monster.is_riding()) {
         return format(_("%sもどき", "fake %s"), name.data());
     }
 
@@ -259,7 +259,7 @@ std::string monster_desc(PlayerType *player_ptr, const MonsterEntity *m_ptr, BIT
         ss << _("「", " called ") << m_ptr->nickname << _("」", "");
     }
 
-    if (player_ptr->riding && (&player_ptr->current_floor_ptr->m_list[player_ptr->riding] == m_ptr)) {
+    if (m_ptr->is_riding()) {
         ss << _("(乗馬中)", "(riding)");
     }
 

--- a/src/monster/monster-processor-util.cpp
+++ b/src/monster/monster-processor-util.cpp
@@ -19,9 +19,9 @@
  * @param m_idx モンスターID
  * @return 初期化済のターン経過フラグ
  */
-turn_flags *init_turn_flags(MONSTER_IDX riding_idx, MONSTER_IDX m_idx, turn_flags *turn_flags_ptr)
+turn_flags *init_turn_flags(bool is_riding, turn_flags *turn_flags_ptr)
 {
-    turn_flags_ptr->is_riding_mon = (m_idx == riding_idx);
+    turn_flags_ptr->is_riding_mon = is_riding;
     turn_flags_ptr->do_turn = false;
     turn_flags_ptr->do_move = false;
     turn_flags_ptr->do_view = false;

--- a/src/monster/monster-processor-util.h
+++ b/src/monster/monster-processor-util.h
@@ -67,8 +67,7 @@ struct coordinate_candidate {
     int gdis = 0;
 };
 
-class MonsterEntity;
-turn_flags *init_turn_flags(MONSTER_IDX riding_idx, MONSTER_IDX m_idx, turn_flags *turn_flags_ptr);
+turn_flags *init_turn_flags(bool is_riding, turn_flags *turn_flags_ptr);
 
 void store_enemy_approch_direction(int *mm, POSITION y, POSITION x);
 void store_moves_val(int *mm, int y, int x);

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -118,7 +118,7 @@ void process_monster(PlayerType *player_ptr, MONSTER_IDX m_idx)
 {
     auto *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
     turn_flags tmp_flags;
-    turn_flags *turn_flags_ptr = init_turn_flags(player_ptr->riding, m_idx, &tmp_flags);
+    turn_flags *turn_flags_ptr = init_turn_flags(m_ptr->is_riding(), &tmp_flags);
     turn_flags_ptr->see_m = is_seen(player_ptr, m_ptr);
 
     decide_drop_from_monster(player_ptr, m_idx, turn_flags_ptr->is_riding_mon);
@@ -140,7 +140,7 @@ void process_monster(PlayerType *player_ptr, MONSTER_IDX m_idx)
             RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::MONSTER_LITE);
         }
 
-        if (m_idx == player_ptr->riding) {
+        if (turn_flags_ptr->is_riding_mon) {
             msg_format(_("突然%sが変身した。", "Suddenly, %s transforms!"), old_m_name.data());
             if (new_monrace.misc_flags.has_not(MonsterMiscType::RIDING)) {
                 if (process_fall_off_horse(player_ptr, 0, true)) {

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -416,7 +416,7 @@ void monster_gain_exp(PlayerType *player_ptr, MONSTER_IDX m_idx, MonsterRaceId m
     }
 
     auto new_exp = s_ptr->mexp * s_ptr->level / (r_ptr->level + 2);
-    if (m_idx == player_ptr->riding) {
+    if (m_ptr->is_riding()) {
         new_exp = (new_exp + 1) / 2;
     }
 
@@ -431,7 +431,7 @@ void monster_gain_exp(PlayerType *player_ptr, MONSTER_IDX m_idx, MonsterRaceId m
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     if (m_ptr->exp < r_ptr->next_exp) {
-        if (m_idx == player_ptr->riding) {
+        if (m_ptr->is_riding()) {
             rfu.set_flag(StatusRecalculatingFlag::BONUS);
         }
 
@@ -514,7 +514,7 @@ void monster_gain_exp(PlayerType *player_ptr, MONSTER_IDX m_idx, MonsterRaceId m
     update_monster(player_ptr, m_idx, false);
     lite_spot(player_ptr, m_ptr->fy, m_ptr->fx);
 
-    if (m_idx == player_ptr->riding) {
+    if (m_ptr->is_riding()) {
         rfu.set_flag(StatusRecalculatingFlag::BONUS);
     }
 }

--- a/src/mspell/mspell-dispel.cpp
+++ b/src/mspell/mspell-dispel.cpp
@@ -26,6 +26,8 @@
 #include "status/shape-changer.h"
 #include "status/sight-setter.h"
 #include "status/temporary-resistance.h"
+#include "system/floor-type-definition.h"
+#include "system/monster-entity.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "view/display-messages.h"
@@ -154,9 +156,10 @@ MonsterSpellResult spell_RF4_DISPEL(MONSTER_IDX m_idx, PlayerType *player_ptr, M
 
         return res;
     }
-
+    const auto &floor = *player_ptr->current_floor_ptr;
+    const auto &target = floor.m_list[t_idx];
     if (target_type == MONSTER_TO_MONSTER) {
-        if (t_idx == player_ptr->riding) {
+        if (target.is_riding()) {
             dispel_player(player_ptr);
         }
 

--- a/src/mspell/mspell-floor.cpp
+++ b/src/mspell/mspell-floor.cpp
@@ -220,7 +220,7 @@ MonsterSpellResult spell_RF6_TELE_TO(PlayerType *player_ptr, MONSTER_IDX m_idx, 
         return res;
     }
 
-    if (t_idx == player_ptr->riding) {
+    if (t_ptr->is_riding()) {
         teleport_player_to(player_ptr, m_ptr->fy, m_ptr->fx, TELEPORT_PASSIVE);
     } else {
         teleport_monster_to(player_ptr, t_idx, m_ptr->fy, m_ptr->fx, 100, TELEPORT_PASSIVE);
@@ -300,7 +300,7 @@ MonsterSpellResult spell_RF6_TELE_AWAY(PlayerType *player_ptr, MONSTER_IDX m_idx
         return res;
     }
 
-    if (t_idx == player_ptr->riding) {
+    if (t_ptr->is_riding()) {
         teleport_player_away(m_idx, player_ptr, MAX_PLAYER_SIGHT * 2 + 5, false);
     } else {
         teleport_away(player_ptr, t_idx, MAX_PLAYER_SIGHT * 2 + 5, TELEPORT_PASSIVE);
@@ -360,7 +360,7 @@ MonsterSpellResult spell_RF6_TELE_LEVEL(PlayerType *player_ptr, MONSTER_IDX m_id
     spell_badstatus_message_to_mons(player_ptr, m_idx, t_idx, msg, resist, saving_throw);
 
     if (!resist && !saving_throw) {
-        teleport_level(player_ptr, (t_idx == player_ptr->riding) ? 0 : t_idx);
+        teleport_level(player_ptr, t_ptr->is_riding() ? 0 : t_idx);
     }
 
     return res;

--- a/src/mspell/mspell-special.cpp
+++ b/src/mspell/mspell-special.cpp
@@ -216,7 +216,7 @@ static MonsterSpellResult spell_RF6_SPECIAL_B(PlayerType *player_ptr, POSITION y
     bool fear, dead; /* dummy */
     int dam = Dice::roll(4, 8);
 
-    if (monster_to_player || t_idx == player_ptr->riding) {
+    if (monster_to_player || t_ptr->is_riding()) {
         teleport_player_to(player_ptr, m_ptr->fy, m_ptr->fx, i2enum<teleport_flags>(TELEPORT_NONMAGICAL | TELEPORT_PASSIVE));
     } else {
         teleport_monster_to(player_ptr, t_idx, m_ptr->fy, m_ptr->fx, 100, i2enum<teleport_flags>(TELEPORT_NONMAGICAL | TELEPORT_PASSIVE));

--- a/src/object-activation/activation-others.cpp
+++ b/src/object-activation/activation-others.cpp
@@ -466,7 +466,7 @@ bool activate_whistle(PlayerType *player_ptr, const ItemEntity &item)
     std::vector<short> pet_index;
     for (short pet_indice = floor.m_max - 1; pet_indice >= 1; pet_indice--) {
         const auto &monster = floor.m_list[pet_indice];
-        if (monster.is_pet() && (player_ptr->riding != pet_indice)) {
+        if (monster.is_pet() && !monster.is_riding()) {
             pet_index.push_back(pet_indice);
         }
     }

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -173,15 +173,17 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
             }
 
             auto &grid = floor.get_grid(pos);
-            if (grid.m_idx == player_ptr->riding) {
-                continue;
-            }
 
             if (!grid.has_monster()) {
                 continue;
             }
 
             auto *m_ptr = &floor.m_list[grid.m_idx];
+
+            if (m_ptr->is_riding()) {
+                continue;
+            }
+
             auto *r_ptr = &m_ptr->get_monrace();
             if (r_ptr->misc_flags.has(MonsterMiscType::QUESTOR)) {
                 map[16 + pos.y - cy][16 + pos.x - cx] = false;

--- a/src/spell-kind/spells-fetcher.cpp
+++ b/src/spell-kind/spells-fetcher.cpp
@@ -10,6 +10,7 @@
 #include "monster/monster-describer.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-update.h"
+#include "monster/monster-util.h"
 #include "system/angband-system.h"
 #include "system/floor-type-definition.h"
 #include "system/grid-type-definition.h"
@@ -123,10 +124,11 @@ bool fetch_monster(PlayerType *player_ptr)
     auto &floor = *player_ptr->current_floor_ptr;
     const Pos2D pos(target_row, target_col);
     auto m_idx = floor.get_grid(pos).m_idx;
-    if (!m_idx) {
+    if (!is_monster(m_idx)) {
         return false;
     }
-    if (m_idx == player_ptr->riding) {
+    auto &monster = floor.m_list[m_idx];
+    if (monster.is_riding()) {
         return false;
     }
     if (!floor.has_los(pos)) {
@@ -136,7 +138,6 @@ bool fetch_monster(PlayerType *player_ptr)
         return false;
     }
 
-    auto &monster = floor.m_list[m_idx];
     const auto m_name = monster_desc(player_ptr, &monster, 0);
     msg_format(_("%sを引き戻した。", "You pull back %s."), m_name.data());
     ProjectionPath path_g(player_ptr, AngbandSystem::get_instance().get_max_range(), { target_row, target_col }, player_ptr->get_position(), 0);

--- a/src/spell-kind/spells-genocide.cpp
+++ b/src/spell-kind/spells-genocide.cpp
@@ -52,7 +52,7 @@ bool genocide_aux(PlayerType *player_ptr, MONSTER_IDX m_idx, int power, bool pla
     } else if (monrace.resistance_flags.has(MonsterResistanceType::NO_INSTANTLY_DEATH)) {
         monrace.r_resistance_flags.set(MonsterResistanceType::NO_INSTANTLY_DEATH);
         resist = true;
-    } else if (m_idx == player_ptr->riding) {
+    } else if (monster.is_riding()) {
         resist = true;
     } else if (floor.is_special()) {
         resist = true;

--- a/src/target/target-preparation.cpp
+++ b/src/target/target-preparation.cpp
@@ -269,14 +269,14 @@ std::vector<MONSTER_IDX> target_pets_prepare(PlayerType *player_ptr)
         }
     }
 
-    auto comp_importance = [riding_idx = player_ptr->riding, &floor](MONSTER_IDX idx1, MONSTER_IDX idx2) {
+    auto comp_importance = [&floor](MONSTER_IDX idx1, MONSTER_IDX idx2) {
         const auto &monster1 = floor.m_list[idx1];
         const auto &monster2 = floor.m_list[idx2];
         const auto &ap_monrace1 = monster1.get_appearance_monrace();
         const auto &ap_monrace2 = monster2.get_appearance_monrace();
 
-        if ((riding_idx == idx1) != (riding_idx == idx2)) {
-            return riding_idx == idx1;
+        if (monster1.is_riding() != monster2.is_riding()) {
+            return monster1.is_riding();
         }
 
         if (monster1.is_named_pet() != monster2.is_named_pet()) {

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -792,7 +792,7 @@ void wiz_zap_floor_monsters(PlayerType *player_ptr)
     const auto &floor = *player_ptr->current_floor_ptr;
     for (MONSTER_IDX i = 1; i < floor.m_max; i++) {
         const auto &monster = floor.m_list[i];
-        if (!monster.is_valid() || (i == player_ptr->riding)) {
+        if (!monster.is_valid() || monster.is_riding()) {
             continue;
         }
 

--- a/src/world/world-turn-processor.cpp
+++ b/src/world/world-turn-processor.cpp
@@ -148,7 +148,7 @@ void WorldTurnProcessor::process_monster_arena()
     for (auto x = 0; x < floor_ptr->width; ++x) {
         for (auto y = 0; y < floor_ptr->height; y++) {
             auto *g_ptr = &floor_ptr->grid_array[y][x];
-            if (g_ptr->has_monster() && (g_ptr->m_idx != this->player_ptr->riding)) {
+            if (g_ptr->has_monster() && !floor_ptr->m_list[g_ptr->m_idx].is_riding()) {
                 number_mon++;
                 win_m_idx = g_ptr->m_idx;
             }


### PR DESCRIPTION
Close #4465 
`monster_desc()` のPlayerType 依存の解除は概ね単純置換ではあるものの変更ファイル数がかなり多かったため別PRにする