### PR TITLE
[Fix] #4496 ガラスの床にしなければいけない箇所が壁になっていた不具合を修正した

### DIFF
--- a/src/room/rooms-special.cpp
+++ b/src/room/rooms-special.cpp
@@ -28,7 +28,7 @@ namespace {
 void place_floor_glass(PlayerType *player_ptr, Grid &grid)
 {
     place_grid(player_ptr, &grid, GB_FLOOR);
-    grid.feat = feat_glass_wall;
+    grid.feat = feat_glass_floor;
 }
 
 void place_outer_glass(PlayerType *player_ptr, Grid &grid)


### PR DESCRIPTION
1行だけの修正です
不具合発生前後のコミットを記載しておきます：

9ac6b930c3752b65ed9db3ca7416922612797ec8 (発生前)
fcb78d09f4fc033dea359d01c1b6e939e6343a1f (発生後)