### PR TITLE
[Feature] CRUSH の訳を「押し潰す」に変更し、置き換え忘れ部分を全て同様の文章に変えた

### DIFF
--- a/src/lore/combat-types-setter.cpp
+++ b/src/lore/combat-types-setter.cpp
@@ -46,7 +46,7 @@ void set_monster_blow_method(lore_type *lore_ptr, int m)
         lore_ptr->pc = TERM_L_WHITE;
         break;
     case RaceBlowMethodType::CRUSH:
-        lore_ptr->p = _("締めつける", "crush");
+        lore_ptr->p = _("押し潰す", "crush");
         lore_ptr->pc = TERM_L_WHITE;
         break;
     case RaceBlowMethodType::ENGULF:

--- a/src/melee/melee-switcher.cpp
+++ b/src/melee/melee-switcher.cpp
@@ -91,7 +91,7 @@ void describe_melee_method(PlayerType *player_ptr, mam_type *mam_ptr)
         break;
     }
     case RaceBlowMethodType::CRUSH: {
-        mam_ptr->act = _("%sに体当りした。", "crushes %s.");
+        mam_ptr->act = _("%sを押し潰した", "crushes %s.");
         mam_ptr->touched = true;
         break;
     }

--- a/src/monster-attack/monster-attack-describer.cpp
+++ b/src/monster-attack/monster-attack-describer.cpp
@@ -124,7 +124,7 @@ void describe_monster_attack_method(MonsterAttackPlayer *monap_ptr)
         break;
     }
     case RaceBlowMethodType::CRUSH: {
-        monap_ptr->act = _("体当たりされた。", "crushes you.");
+        monap_ptr->act = _("押し潰された。", "crushes you.");
         monap_ptr->do_stun = 1;
         monap_ptr->touched = true;
         sound(SOUND_CRUSH);


### PR DESCRIPTION
Close #4498 