### PR TITLE
モンスターの固定ドロップをクラス化した

### DIFF
--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -240,12 +240,12 @@ static errr set_mon_artifacts(nlohmann::json &artifact_data, MonsterRaceInfo &mo
         if (auto err = info_set_integer(artifact.value()["drop_artifact_id"], fa_id, true, Range(0, 1024))) {
             return err;
         }
-        int prob;
-        if (auto err = info_set_integer(artifact.value()["drop_probability"], prob, true, Range(1, 100))) {
+        int chance;
+        if (auto err = info_set_integer(artifact.value()["drop_probability"], chance, true, Range(1, 100))) {
             return err;
         }
 
-        monrace.drop_artifacts.emplace_back(fa_id, prob);
+        monrace.emplace_drop_artifact(fa_id, chance);
     }
     return PARSE_ERROR_NONE;
 }

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -148,12 +148,12 @@ static void drop_corpse(PlayerType *player_ptr, MonsterDeath *md_ptr)
 static void drop_artifact_from_unique(PlayerType *player_ptr, MonsterDeath *md_ptr)
 {
     const auto is_wizard = AngbandWorld::get_instance().wizard;
-    for (const auto &[a_idx, chance] : md_ptr->r_ptr->drop_artifacts) {
+    for (const auto &[fa_id, chance] : md_ptr->r_ptr->get_drop_artifacts()) {
         if (!is_wizard && !evaluate_percent(chance)) {
             continue;
         }
 
-        if (drop_single_artifact(player_ptr, md_ptr, a_idx)) {
+        if (drop_single_artifact(player_ptr, md_ptr, fa_id)) {
             return;
         }
     }

--- a/src/system/monster-race-info.cpp
+++ b/src/system/monster-race-info.cpp
@@ -264,6 +264,11 @@ bool MonsterRaceInfo::has_reinforce() const
     return it != end;
 }
 
+const std::vector<DropArtifact> &MonsterRaceInfo::get_drop_artifacts() const
+{
+    return this->drop_artifacts;
+}
+
 const std::vector<Reinforce> &MonsterRaceInfo::get_reinforces() const
 {
     return this->reinforces;
@@ -372,6 +377,11 @@ void MonsterRaceInfo::make_lore_treasure(int num_item, int num_gold)
     }
 }
 
+void MonsterRaceInfo::emplace_drop_artifact(FixedArtifactId fa_id, int chance)
+{
+    this->drop_artifacts.emplace_back(fa_id, chance);
+}
+
 void MonsterRaceInfo::emplace_reinforce(MonsterRaceId monrace_id, const Dice &dice)
 {
     this->reinforces.emplace_back(monrace_id, dice);
@@ -394,6 +404,12 @@ const std::string &MonsterRaceInfo::decide_horror_message() const
     }
 
     return horror_desc_neutral[horror_num - horror_desc_common_size];
+}
+
+DropArtifact::DropArtifact(FixedArtifactId fa_id, int chance)
+    : fa_id(fa_id)
+    , chance(chance)
+{
 }
 
 Reinforce::Reinforce(MonsterRaceId monrace_id, Dice dice)

--- a/src/system/monster-race-info.h
+++ b/src/system/monster-race-info.h
@@ -63,6 +63,7 @@ public:
  * monster recall (no knowledge of spells, etc).  All of the "recall"
  * fields have a special prefix to aid in searching for them.
  */
+class DropArtifact;
 class Reinforce;
 class MonsterRaceInfo {
 public:
@@ -95,9 +96,6 @@ public:
     EnumClassFlagGroup<MonsterMiscType> misc_flags; //!< 能力フラグ（その他） / Speaking Other
     MonsterBlow blows[MAX_NUM_BLOWS]{}; //!< 打撃能力定義 / Up to four blows per round
     Dice shoot_damage_dice; //!< 射撃ダメージダイス / shoot damage dice
-
-    //! 特定アーティファクトドロップリスト <アーティファクトID,ドロップ率>
-    std::vector<std::tuple<FixedArtifactId, PERCENTAGE>> drop_artifacts;
 
     PERCENTAGE arena_ratio{}; //!< モンスター闘技場の掛け金倍率修正値(%基準 / 0=100%) / The adjustment ratio for gambling monster
     MonsterRaceId next_r_idx{}; //!< 進化先モンスター種族ID
@@ -149,16 +147,26 @@ public:
     int calc_capture_value() const;
     std::string build_eldritch_horror_message(std::string_view description) const;
     bool has_reinforce() const;
+    const std::vector<DropArtifact> &get_drop_artifacts() const;
     const std::vector<Reinforce> &get_reinforces() const;
 
     std::optional<std::string> probe_lore();
     void make_lore_treasure(int num_item, int num_drop);
+    void emplace_drop_artifact(FixedArtifactId fa_id, int percentage);
     void emplace_reinforce(MonsterRaceId monrace_id, const Dice &dice);
 
 private:
+    std::vector<DropArtifact> drop_artifacts; //!< 特定アーティファクトドロップリスト
     std::vector<Reinforce> reinforces; //!< 指定護衛リスト
 
     const std::string &decide_horror_message() const;
+};
+
+class DropArtifact {
+public:
+    DropArtifact(FixedArtifactId fa_id, int chance);
+    FixedArtifactId fa_id;
+    int chance; //!< ドロップ確率 (%)
 };
 
 class Reinforce {


### PR DESCRIPTION
タプルよりはマシになったかと思います
ドロップ処理 (の一部？)を上手いことメソッドに繰り込めれば使い勝手も上がるかと思いますが現時点では見送りました
ご確認下さい