### PR TITLE
モンスター性別を表すenumが重複していたので片方を消した

### DIFF
--- a/src/lore/lore-util.cpp
+++ b/src/lore/lore-util.cpp
@@ -1,6 +1,7 @@
 #include "lore/lore-util.h"
 #include "game-option/birth-options.h"
 #include "monster-attack/monster-attack-table.h"
+#include "monster-race/race-sex.h"
 #include "system/monster-race-info.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
@@ -8,18 +9,18 @@
 const who_word_definition Who::words = {
     { WHO_WORD_TYPE::WHO,
         {
-            { false, { { MSEX_NONE, _("それ", "it") }, { MSEX_MALE, _("彼", "he") }, { MSEX_FEMALE, _("彼女", "she") } } },
-            { true, { { MSEX_NONE, _("それら", "they") }, { MSEX_MALE, _("彼ら", "they") }, { MSEX_FEMALE, _("彼女ら", "they") } } },
+            { false, { { MonsterSex::NONE, _("それ", "it") }, { MonsterSex::MALE, _("彼", "he") }, { MonsterSex::FEMALE, _("彼女", "she") } } },
+            { true, { { MonsterSex::NONE, _("それら", "they") }, { MonsterSex::MALE, _("彼ら", "they") }, { MonsterSex::FEMALE, _("彼女ら", "they") } } },
         } },
     { WHO_WORD_TYPE::WHOSE,
         {
-            { false, { { MSEX_NONE, _("それの", "its") }, { MSEX_MALE, _("彼の", "his") }, { MSEX_FEMALE, _("彼女の", "her") } } },
-            { true, { { MSEX_NONE, _("それらの", "their") }, { MSEX_MALE, _("彼らの", "their") }, { MSEX_FEMALE, _("彼女らの", "their") } } },
+            { false, { { MonsterSex::NONE, _("それの", "its") }, { MonsterSex::MALE, _("彼の", "his") }, { MonsterSex::FEMALE, _("彼女の", "her") } } },
+            { true, { { MonsterSex::NONE, _("それらの", "their") }, { MonsterSex::MALE, _("彼らの", "their") }, { MonsterSex::FEMALE, _("彼女らの", "their") } } },
         } },
     { WHO_WORD_TYPE::WHOM,
         {
-            { false, { { MSEX_NONE, _("それ", "it") }, { MSEX_MALE, _("彼", "him") }, { MSEX_FEMALE, _("彼女", "her") } } },
-            { true, { { MSEX_NONE, _("それら", "them") }, { MSEX_MALE, _("彼ら", "them") }, { MSEX_FEMALE, _("彼女ら", "them") } } },
+            { false, { { MonsterSex::NONE, _("それ", "it") }, { MonsterSex::MALE, _("彼", "him") }, { MonsterSex::FEMALE, _("彼女", "her") } } },
+            { true, { { MonsterSex::NONE, _("それら", "them") }, { MonsterSex::MALE, _("彼ら", "them") }, { MonsterSex::FEMALE, _("彼女ら", "them") } } },
         } },
 };
 
@@ -37,7 +38,7 @@ lore_msg::lore_msg(std::string_view msg, byte color)
 lore_type::lore_type(MonsterRaceId r_idx, monster_lore_mode mode)
     : r_idx(r_idx)
     , mode(mode)
-    , msex(MSEX_NONE)
+    , msex(MonsterSex::NONE)
     , method(RaceBlowMethodType::NONE)
 {
     this->nightmare = ironman_nightmare && (mode != MONSTER_LORE_DEBUG);

--- a/src/lore/lore-util.h
+++ b/src/lore/lore-util.h
@@ -18,13 +18,8 @@
 #include <string_view>
 #include <unordered_map>
 
-enum class MonsterRaceId : int16_t;
-
-enum monster_sex {
-    MSEX_NONE = 0,
-    MSEX_MALE = 1,
-    MSEX_FEMALE = 2,
-};
+enum class MonsterRaceId : short;
+enum class MonsterSex;
 
 enum monster_lore_mode {
     MONSTER_LORE_NONE,
@@ -64,7 +59,7 @@ struct lore_type {
 
     MonsterRaceId r_idx;
     BIT_FLAGS mode;
-    monster_sex msex;
+    MonsterSex msex;
     RaceBlowMethodType method;
 
     bool nightmare;
@@ -95,7 +90,7 @@ void hooked_roff(std::string_view str);
 enum WHO_WORD_TYPE { WHO = 0,
     WHOSE = 1,
     WHOM = 2 };
-using who_word_definition = std::unordered_map<WHO_WORD_TYPE, const std::unordered_map<bool, const std::unordered_map<monster_sex, std::string>>>;
+using who_word_definition = std::unordered_map<WHO_WORD_TYPE, const std::unordered_map<bool, const std::unordered_map<MonsterSex, std::string>>>;
 
 class Who {
 public:
@@ -106,7 +101,7 @@ public:
      * @param msex モンスターの性別
      * @return 主語
      */
-    static concptr who(monster_sex msex)
+    static concptr who(MonsterSex msex)
     {
         return who(msex, false);
     }
@@ -117,7 +112,7 @@ public:
      * @param multi 複数かどうか
      * @return 主語
      */
-    static concptr who(monster_sex msex, bool multi)
+    static concptr who(MonsterSex msex, bool multi)
     {
         return words.at(WHO_WORD_TYPE::WHO).at(multi).at(msex).data();
     }
@@ -127,7 +122,7 @@ public:
      * @param msex モンスターの性別
      * @return 所有格
      */
-    static concptr whose(monster_sex msex)
+    static concptr whose(MonsterSex msex)
     {
         return whose(msex, false);
     }
@@ -138,7 +133,7 @@ public:
      * @param multi 複数かどうか
      * @return 所有格
      */
-    static concptr whose(monster_sex msex, bool multi)
+    static concptr whose(MonsterSex msex, bool multi)
     {
         return words.at(WHO_WORD_TYPE::WHOSE).at(multi).at(msex).data();
     }
@@ -148,7 +143,7 @@ public:
      * @param msex モンスターの性別
      * @return 目的語
      */
-    static concptr whom(monster_sex msex)
+    static concptr whom(MonsterSex msex)
     {
         return whom(msex, false);
     }
@@ -159,7 +154,7 @@ public:
      * @param multi 複数かどうか
      * @return 目的語
      */
-    static concptr whom(monster_sex msex, bool multi)
+    static concptr whom(MonsterSex msex, bool multi)
     {
         return words.at(WHO_WORD_TYPE::WHOM).at(multi).at(msex).data();
     }

--- a/src/lore/lore-util.h
+++ b/src/lore/lore-util.h
@@ -101,7 +101,7 @@ public:
      * @param msex モンスターの性別
      * @return 主語
      */
-    static concptr who(MonsterSex msex)
+    static std::string who(MonsterSex msex)
     {
         return who(msex, false);
     }
@@ -112,7 +112,7 @@ public:
      * @param multi 複数かどうか
      * @return 主語
      */
-    static concptr who(MonsterSex msex, bool multi)
+    static std::string who(MonsterSex msex, bool multi)
     {
         return words.at(WHO_WORD_TYPE::WHO).at(multi).at(msex).data();
     }
@@ -122,7 +122,7 @@ public:
      * @param msex モンスターの性別
      * @return 所有格
      */
-    static concptr whose(MonsterSex msex)
+    static std::string whose(MonsterSex msex)
     {
         return whose(msex, false);
     }
@@ -133,7 +133,7 @@ public:
      * @param multi 複数かどうか
      * @return 所有格
      */
-    static concptr whose(MonsterSex msex, bool multi)
+    static std::string whose(MonsterSex msex, bool multi)
     {
         return words.at(WHO_WORD_TYPE::WHOSE).at(multi).at(msex).data();
     }
@@ -143,7 +143,7 @@ public:
      * @param msex モンスターの性別
      * @return 目的語
      */
-    static concptr whom(MonsterSex msex)
+    static std::string whom(MonsterSex msex)
     {
         return whom(msex, false);
     }
@@ -154,7 +154,7 @@ public:
      * @param multi 複数かどうか
      * @return 目的語
      */
-    static concptr whom(MonsterSex msex, bool multi)
+    static std::string whom(MonsterSex msex, bool multi)
     {
         return words.at(WHO_WORD_TYPE::WHOM).at(multi).at(msex).data();
     }

--- a/src/lore/monster-lore.cpp
+++ b/src/lore/monster-lore.cpp
@@ -11,6 +11,7 @@
 #include "lore/magic-types-setter.h"
 #include "monster-race/race-indice-types.h"
 #include "monster-race/race-misc-flags.h"
+#include "monster-race/race-sex.h"
 #include "player-ability/player-ability-types.h"
 #include "system/angband.h"
 #include "system/monster-race-info.h"
@@ -24,12 +25,12 @@
 
 static void set_msex_flags(lore_type *lore_ptr)
 {
-    lore_ptr->msex = MSEX_NONE;
+    lore_ptr->msex = MonsterSex::NONE;
     if (lore_ptr->r_ptr->is_male()) {
-        lore_ptr->msex = MSEX_MALE;
+        lore_ptr->msex = MonsterSex::MALE;
     }
     if (lore_ptr->r_ptr->is_female()) {
-        lore_ptr->msex = MSEX_FEMALE;
+        lore_ptr->msex = MonsterSex::FEMALE;
     }
 }
 

--- a/src/lore/monster-lore.cpp
+++ b/src/lore/monster-lore.cpp
@@ -171,12 +171,12 @@ void process_monster_lore(PlayerType *player_ptr, MonsterRaceId r_idx, monster_l
 
     display_lore_this(player_ptr, lore_ptr);
     if (lore_ptr->special_flags.has(MonsterSpecialType::DIMINISH_MAX_DAMAGE)) {
-        hooked_roff(format(_("%s^は", "%s^ "), Who::who(lore_ptr->msex)));
+        hooked_roff(format(_("%s^は", "%s^ "), Who::who(lore_ptr->msex).data()));
         hook_c_roff(TERM_RED, _("致命的な威力の攻撃に対して大きな耐性を持っている。", "has the strong resistance for a critical damage.  "));
     }
     display_monster_aura(lore_ptr);
     if (lore_ptr->misc_flags.has(MonsterMiscType::REFLECTING)) {
-        hooked_roff(format(_("%s^は矢の呪文を跳ね返す。", "%s^ reflects bolt spells.  "), Who::who(lore_ptr->msex)));
+        hooked_roff(format(_("%s^は矢の呪文を跳ね返す。", "%s^ reflects bolt spells.  "), Who::who(lore_ptr->msex).data()));
     }
 
     display_monster_collective(lore_ptr);

--- a/src/view/display-lore-attacks.cpp
+++ b/src/view/display-lore-attacks.cpp
@@ -18,7 +18,7 @@
 static void display_monster_blow_jp(lore_type *lore_ptr, int attack_numbers, const Dice &damage_dice, int m)
 {
     if (attack_numbers == 0) {
-        hooked_roff(format("%s^は", Who::who(lore_ptr->msex)));
+        hooked_roff(format("%s^は", Who::who(lore_ptr->msex).data()));
     }
 
     if (damage_dice.is_valid() && (lore_ptr->know_everything || know_blow_damage(lore_ptr->r_idx, m))) {
@@ -66,7 +66,7 @@ static void display_monster_blow_jp(lore_type *lore_ptr, int attack_numbers, con
 static void display_monster_blow_en(lore_type *lore_ptr, int attack_numbers, const Dice &damage_dice, int m)
 {
     if (attack_numbers == 0) {
-        hooked_roff(format("%s^ can ", Who::who(lore_ptr->msex)));
+        hooked_roff(format("%s^ can ", Who::who(lore_ptr->msex).data()));
     } else if (attack_numbers < lore_ptr->count - 1) {
         hooked_roff(", ");
     } else {
@@ -134,8 +134,8 @@ void display_monster_blows(lore_type *lore_ptr)
     if (attack_numbers > 0) {
         hooked_roff(_("。", ".  "));
     } else if (lore_ptr->behavior_flags.has(MonsterBehaviorType::NEVER_BLOW)) {
-        hooked_roff(format(_("%s^は物理的な攻撃方法を持たない。", "%s^ has no physical attacks.  "), Who::who(lore_ptr->msex)));
+        hooked_roff(format(_("%s^は物理的な攻撃方法を持たない。", "%s^ has no physical attacks.  "), Who::who(lore_ptr->msex).data()));
     } else {
-        hooked_roff(format(_("%s攻撃については何も知らない。", "Nothing is known about %s attack.  "), Who::whose(lore_ptr->msex)));
+        hooked_roff(format(_("%s攻撃については何も知らない。", "Nothing is known about %s attack.  "), Who::whose(lore_ptr->msex).data()));
     }
 }

--- a/src/view/display-lore-drops.cpp
+++ b/src/view/display-lore-drops.cpp
@@ -102,7 +102,7 @@ void display_monster_drops(lore_type *lore_ptr)
         return;
     }
 
-    hooked_roff(format(_("%s^は", "%s^ may carry"), Who::who(lore_ptr->msex)));
+    hooked_roff(format(_("%s^は", "%s^ may carry"), Who::who(lore_ptr->msex).data()));
 #ifdef JP
 #else
     lore_ptr->sin = false;

--- a/src/view/display-lore-magics.cpp
+++ b/src/view/display-lore-magics.cpp
@@ -11,7 +11,7 @@ void display_monster_breath(lore_type *lore_ptr)
     }
 
     lore_ptr->breath = true;
-    hooked_roff(format(_("%s^は", "%s^"), Who::who(lore_ptr->msex)));
+    hooked_roff(format(_("%s^は", "%s^"), Who::who(lore_ptr->msex).data()));
     for (int n = 0; const auto &[msg, color] : lore_ptr->lore_msgs) {
 #ifdef JP
         if (n != 0) {
@@ -46,7 +46,7 @@ void display_monster_magic_types(lore_type *lore_ptr)
     if (lore_ptr->breath) {
         hooked_roff(_("、なおかつ", ", and is also"));
     } else {
-        hooked_roff(format(_("%s^は", "%s^ is"), Who::who(lore_ptr->msex)));
+        hooked_roff(format(_("%s^は", "%s^ is"), Who::who(lore_ptr->msex).data()));
     }
 
 #ifdef JP

--- a/src/view/display-lore-status.cpp
+++ b/src/view/display-lore-status.cpp
@@ -14,7 +14,7 @@ void display_monster_hp_ac(lore_type *lore_ptr)
         return;
     }
 
-    hooked_roff(format(_("%s^は AC%d の防御力と", "%s^ has an armor rating of %d"), Who::who(lore_ptr->msex), lore_ptr->r_ptr->ac));
+    hooked_roff(format(_("%s^は AC%d の防御力と", "%s^ has an armor rating of %d"), Who::who(lore_ptr->msex).data(), lore_ptr->r_ptr->ac));
     if (lore_ptr->misc_flags.has(MonsterMiscType::FORCE_MAXHP) || (lore_ptr->r_ptr->hit_dice.sides == 1)) {
         auto hp = lore_ptr->r_ptr->hit_dice.maxroll() * (lore_ptr->nightmare ? 2 : 1);
         hooked_roff(format(_(" %d の体力がある。", " and a life rating of %d.  "), std::min(MONSTER_MAXHP, hp)));
@@ -85,7 +85,7 @@ void display_monster_abilities(lore_type *lore_ptr)
         return;
     }
 
-    hooked_roff(format(_("%s^は", "%s^"), Who::who(lore_ptr->msex)));
+    hooked_roff(format(_("%s^は", "%s^"), Who::who(lore_ptr->msex).data()));
     for (int n = 0; const auto &[msg, color] : lore_ptr->lore_msgs) {
 #ifdef JP
         if (n != std::ssize(lore_ptr->lore_msgs) - 1) {
@@ -115,41 +115,41 @@ void display_monster_abilities(lore_type *lore_ptr)
 void display_monster_constitutions(lore_type *lore_ptr)
 {
     if (lore_ptr->r_ptr->feature_flags.has(MonsterFeatureType::AQUATIC)) {
-        hooked_roff(format(_("%s^は水中に棲んでいる。", "%s^ lives in water.  "), Who::who(lore_ptr->msex)));
+        hooked_roff(format(_("%s^は水中に棲んでいる。", "%s^ lives in water.  "), Who::who(lore_ptr->msex).data()));
     }
 
     if (lore_ptr->brightness_flags.has_any_of({ MonsterBrightnessType::SELF_LITE_1, MonsterBrightnessType::SELF_LITE_2 })) {
-        hooked_roff(format(_("%s^は光っている。", "%s^ is shining.  "), Who::who(lore_ptr->msex)));
+        hooked_roff(format(_("%s^は光っている。", "%s^ is shining.  "), Who::who(lore_ptr->msex).data()));
     }
 
     if (lore_ptr->brightness_flags.has_any_of({ MonsterBrightnessType::SELF_DARK_1, MonsterBrightnessType::SELF_DARK_2 })) {
-        hook_c_roff(TERM_L_DARK, format(_("%s^は暗黒に包まれている。", "%s^ is surrounded by darkness.  "), Who::who(lore_ptr->msex)));
+        hook_c_roff(TERM_L_DARK, format(_("%s^は暗黒に包まれている。", "%s^ is surrounded by darkness.  "), Who::who(lore_ptr->msex).data()));
     }
 
     if (lore_ptr->misc_flags.has(MonsterMiscType::INVISIBLE)) {
-        hooked_roff(format(_("%s^は透明で目に見えない。", "%s^ is invisible.  "), Who::who(lore_ptr->msex)));
+        hooked_roff(format(_("%s^は透明で目に見えない。", "%s^ is invisible.  "), Who::who(lore_ptr->msex).data()));
     }
 
     if (lore_ptr->misc_flags.has(MonsterMiscType::COLD_BLOOD)) {
-        hooked_roff(format(_("%s^は冷血動物である。", "%s^ is cold blooded.  "), Who::who(lore_ptr->msex)));
+        hooked_roff(format(_("%s^は冷血動物である。", "%s^ is cold blooded.  "), Who::who(lore_ptr->msex).data()));
     }
 
     if (lore_ptr->misc_flags.has(MonsterMiscType::EMPTY_MIND)) {
-        hooked_roff(format(_("%s^はテレパシーでは感知できない。", "%s^ is not detected by telepathy.  "), Who::who(lore_ptr->msex)));
+        hooked_roff(format(_("%s^はテレパシーでは感知できない。", "%s^ is not detected by telepathy.  "), Who::who(lore_ptr->msex).data()));
     } else if (lore_ptr->misc_flags.has(MonsterMiscType::WEIRD_MIND)) {
-        hooked_roff(format(_("%s^はまれにテレパシーで感知できる。", "%s^ is rarely detected by telepathy.  "), Who::who(lore_ptr->msex)));
+        hooked_roff(format(_("%s^はまれにテレパシーで感知できる。", "%s^ is rarely detected by telepathy.  "), Who::who(lore_ptr->msex).data()));
     }
 
     if (lore_ptr->misc_flags.has(MonsterMiscType::MULTIPLY)) {
-        hook_c_roff(TERM_L_UMBER, format(_("%s^は爆発的に増殖する。", "%s^ breeds explosively.  "), Who::who(lore_ptr->msex)));
+        hook_c_roff(TERM_L_UMBER, format(_("%s^は爆発的に増殖する。", "%s^ breeds explosively.  "), Who::who(lore_ptr->msex).data()));
     }
 
     if (lore_ptr->misc_flags.has(MonsterMiscType::REGENERATE)) {
-        hook_c_roff(TERM_L_WHITE, format(_("%s^は素早く体力を回復する。", "%s^ regenerates quickly.  "), Who::who(lore_ptr->msex)));
+        hook_c_roff(TERM_L_WHITE, format(_("%s^は素早く体力を回復する。", "%s^ regenerates quickly.  "), Who::who(lore_ptr->msex).data()));
     }
 
     if (lore_ptr->misc_flags.has(MonsterMiscType::RIDING)) {
-        hook_c_roff(TERM_SLATE, format(_("%s^に乗ることができる。", "%s^ is suitable for riding.  "), Who::who(lore_ptr->msex)));
+        hook_c_roff(TERM_SLATE, format(_("%s^に乗ることができる。", "%s^ is suitable for riding.  "), Who::who(lore_ptr->msex).data()));
     }
 }
 
@@ -178,7 +178,7 @@ void display_monster_weakness(lore_type *lore_ptr)
         return;
     }
 
-    hooked_roff(format(_("%s^には", "%s^"), Who::who(lore_ptr->msex)));
+    hooked_roff(format(_("%s^には", "%s^"), Who::who(lore_ptr->msex).data()));
     for (int n = 0; const auto &[msg, color] : lore_ptr->lore_msgs) {
 #ifdef JP
         if (n != 0) {
@@ -297,7 +297,7 @@ void display_monster_resistances(lore_type *lore_ptr)
         return;
     }
 
-    hooked_roff(format(_("%s^は", "%s^"), Who::who(lore_ptr->msex)));
+    hooked_roff(format(_("%s^は", "%s^"), Who::who(lore_ptr->msex).data()));
     for (int n = 0; const auto &[msg, color] : lore_ptr->lore_msgs) {
 #ifdef JP
         if (n != 0) {
@@ -327,11 +327,11 @@ void display_monster_evolution(lore_type *lore_ptr)
 
     const auto &monrace_next = lore_ptr->r_ptr->get_next();
     if (monrace_next.is_valid()) {
-        hooked_roff(format(_("%s^は経験を積むと、", "%s^ will evolve into "), Who::who(lore_ptr->msex)));
+        hooked_roff(format(_("%s^は経験を積むと、", "%s^ will evolve into "), Who::who(lore_ptr->msex).data()));
         hook_c_roff(TERM_YELLOW, format("%s", monrace_next.name.data()));
-        hooked_roff(_(format("に進化する。"), format(" when %s gets enough experience.  ", Who::who(lore_ptr->msex))));
+        hooked_roff(_(format("に進化する。"), format(" when %s gets enough experience.  ", Who::who(lore_ptr->msex).data())));
     } else if (lore_ptr->r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE)) {
-        hooked_roff(format(_("%sは進化しない。", "%s won't evolve.  "), Who::who(lore_ptr->msex)));
+        hooked_roff(format(_("%sは進化しない。", "%s won't evolve.  "), Who::who(lore_ptr->msex).data()));
     }
 }
 
@@ -368,7 +368,7 @@ void display_monster_immunities(lore_type *lore_ptr)
         return;
     }
 
-    hooked_roff(format(_("%s^は", "%s^"), Who::who(lore_ptr->msex)));
+    hooked_roff(format(_("%s^は", "%s^"), Who::who(lore_ptr->msex).data()));
     for (int n = 0; const auto &[msg, color] : lore_ptr->lore_msgs) {
 #ifdef JP
         if (n != 0) {
@@ -392,7 +392,7 @@ void display_monster_immunities(lore_type *lore_ptr)
 
 void display_monster_alert(lore_type *lore_ptr)
 {
-    bool alert = ((int)lore_ptr->r_ptr->r_wake * (int)lore_ptr->r_ptr->r_wake) > lore_ptr->r_ptr->sleep;
+    auto alert = ((int)lore_ptr->r_ptr->r_wake * (int)lore_ptr->r_ptr->r_wake) > lore_ptr->r_ptr->sleep;
     alert |= lore_ptr->r_ptr->r_ignore == MAX_UCHAR;
     alert |= (lore_ptr->r_ptr->sleep == 0) && (lore_ptr->r_ptr->r_tkills >= 10);
     alert |= lore_ptr->know_everything;
@@ -400,31 +400,33 @@ void display_monster_alert(lore_type *lore_ptr)
         return;
     }
 
-    concptr act;
+    std::string action;
     if (lore_ptr->r_ptr->sleep > 200) {
-        act = _("を無視しがちであるが", "prefers to ignore");
+        action = _("を無視しがちであるが", "prefers to ignore");
     } else if (lore_ptr->r_ptr->sleep > 95) {
-        act = _("に対してほとんど注意を払わないが", "pays very little attention to");
+        action = _("に対してほとんど注意を払わないが", "pays very little attention to");
     } else if (lore_ptr->r_ptr->sleep > 75) {
-        act = _("に対してあまり注意を払わないが", "pays little attention to");
+        action = _("に対してあまり注意を払わないが", "pays little attention to");
     } else if (lore_ptr->r_ptr->sleep > 45) {
-        act = _("を見過ごしがちであるが", "tends to overlook");
+        action = _("を見過ごしがちであるが", "tends to overlook");
     } else if (lore_ptr->r_ptr->sleep > 25) {
-        act = _("をほんの少しは見ており", "takes quite a while to see");
+        action = _("をほんの少しは見ており", "takes quite a while to see");
     } else if (lore_ptr->r_ptr->sleep > 10) {
-        act = _("をしばらくは見ており", "takes a while to see");
+        action = _("をしばらくは見ており", "takes a while to see");
     } else if (lore_ptr->r_ptr->sleep > 5) {
-        act = _("を幾分注意深く見ており", "is fairly observant of");
+        action = _("を幾分注意深く見ており", "is fairly observant of");
     } else if (lore_ptr->r_ptr->sleep > 3) {
-        act = _("を注意深く見ており", "is observant of");
+        action = _("を注意深く見ており", "is observant of");
     } else if (lore_ptr->r_ptr->sleep > 1) {
-        act = _("をかなり注意深く見ており", "is very observant of");
+        action = _("をかなり注意深く見ており", "is very observant of");
     } else if (lore_ptr->r_ptr->sleep > 0) {
-        act = _("を警戒しており", "is vigilant for");
+        action = _("を警戒しており", "is vigilant for");
     } else {
-        act = _("をかなり警戒しており", "is ever vigilant for");
+        action = _("をかなり警戒しており", "is ever vigilant for");
     }
 
-    hooked_roff(_(format("%s^は侵入者%s、 %d フィート先から侵入者に気付くことがある。", Who::who(lore_ptr->msex), act, 10 * lore_ptr->r_ptr->aaf),
-        format("%s^ %s intruders, which %s may notice from %d feet.  ", Who::who(lore_ptr->msex), act, Who::who(lore_ptr->msex), 10 * lore_ptr->r_ptr->aaf)));
+    constexpr auto fmt = _("%s^は侵入者%s、 %d フィート先から侵入者に気付くことがある。", "%s^ %s intruders, which %s may notice from %d feet.  ");
+    const auto who = Who::who(lore_ptr->msex);
+    hooked_roff(_(format(fmt, who.data(), action.data(), 10 * lore_ptr->r_ptr->aaf),
+        format(fmt, who.data(), action.data(), who.data(), 10 * lore_ptr->r_ptr->aaf)));
 }

--- a/src/view/display-lore.cpp
+++ b/src/view/display-lore.cpp
@@ -130,7 +130,7 @@ static bool display_kill_unique(lore_type *lore_ptr)
 
     bool dead = (lore_ptr->r_ptr->max_num == 0);
     if (lore_ptr->r_ptr->r_deaths) {
-        hooked_roff(format(_("%s^はあなたの先祖を %d 人葬っている", "%s^ has slain %d of your ancestors"), Who::who(lore_ptr->msex), lore_ptr->r_ptr->r_deaths));
+        hooked_roff(format(_("%s^はあなたの先祖を %d 人葬っている", "%s^ has slain %d of your ancestors"), Who::who(lore_ptr->msex).data(), lore_ptr->r_ptr->r_deaths));
 
         if (dead) {
             hooked_roff(
@@ -167,7 +167,7 @@ static void display_killed(lore_type *lore_ptr)
             _("が、あなたの先祖はこのモンスターを少なくとも %d 体は倒している。", "and your ancestors have exterminated at least %d of the creatures.  "),
             lore_ptr->r_ptr->r_tkills));
     } else {
-        hooked_roff(format(_("が、まだ%sを倒したことはない。", "and %s is not ever known to have been defeated.  "), Who::who(lore_ptr->msex)));
+        hooked_roff(format(_("が、まだ%sを倒したことはない。", "and %s is not ever known to have been defeated.  "), Who::who(lore_ptr->msex).data()));
     }
 }
 
@@ -199,20 +199,22 @@ static void display_number_of_nazguls(lore_type *lore_ptr)
         return;
     }
 
-    int remain = lore_ptr->r_ptr->max_num;
-    int killed = lore_ptr->r_ptr->r_akills;
+    const auto remain = lore_ptr->r_ptr->max_num;
+    const auto killed = lore_ptr->r_ptr->r_akills;
     if (remain == 0) {
+        const auto whom = Who::whom(lore_ptr->msex, (killed > 1));
 #ifdef JP
-        hooked_roff(format("%sはかつて %d 体存在した。", Who::who(lore_ptr->msex, (killed > 1)), killed));
+        hooked_roff(format("%sはかつて %d 体存在した。", whom.data(), killed));
 #else
-        hooked_roff(format("You already killed all %d of %s.  ", killed, Who::whom(lore_ptr->msex, (killed > 1))));
+        hooked_roff(format("You already killed all %d of %s.  ", killed, whom.data()));
 #endif
     } else {
+        const auto whom = Who::whom(lore_ptr->msex, (remain + killed > 1));
 #ifdef JP
-        hooked_roff(format("%sはまだ %d 体生きている。", Who::who(lore_ptr->msex, (remain + killed > 1)), remain));
+        hooked_roff(format("%sはまだ %d 体生きている。", whom.data(), remain));
 #else
-        concptr be = (remain > 1) ? "are" : "is";
-        hooked_roff(format("%d of %s %s still alive.  ", remain, Who::whom(lore_ptr->msex, (remain + killed > 1)), be));
+        std::string be((remain > 1) ? "are" : "is");
+        hooked_roff(format("%d of %s %s still alive.  ", remain, whom.data(), be.data()));
 #endif
     }
 }
@@ -247,14 +249,14 @@ bool display_where_to_appear(lore_type *lore_ptr)
 {
     lore_ptr->old = false;
     if (lore_ptr->r_ptr->level == 0) {
-        hooked_roff(format(_("%s^は町に住み", "%s^ lives in the town"), Who::who(lore_ptr->msex)));
+        hooked_roff(format(_("%s^は町に住み", "%s^ lives in the town"), Who::who(lore_ptr->msex).data()));
         lore_ptr->old = true;
     } else if (lore_ptr->r_ptr->r_tkills || lore_ptr->know_everything) {
         if (depth_in_feet) {
             hooked_roff(format(
-                _("%s^は通常地下 %d フィートで出現し", "%s^ is normally found at depths of %d feet"), Who::who(lore_ptr->msex), lore_ptr->r_ptr->level * 50));
+                _("%s^は通常地下 %d フィートで出現し", "%s^ is normally found at depths of %d feet"), Who::who(lore_ptr->msex).data(), lore_ptr->r_ptr->level * 50));
         } else {
-            hooked_roff(format(_("%s^は通常地下 %d 階で出現し", "%s^ is normally found on dungeon level %d"), Who::who(lore_ptr->msex), lore_ptr->r_ptr->level));
+            hooked_roff(format(_("%s^は通常地下 %d 階で出現し", "%s^ is normally found on dungeon level %d"), Who::who(lore_ptr->msex).data(), lore_ptr->r_ptr->level));
         }
 
         lore_ptr->old = true;
@@ -268,7 +270,7 @@ bool display_where_to_appear(lore_type *lore_ptr)
     if (lore_ptr->old) {
         hooked_roff(_("、", ", and "));
     } else {
-        hooked_roff(format(_("%s^は", "%s^ "), Who::who(lore_ptr->msex)));
+        hooked_roff(format(_("%s^は", "%s^ "), Who::who(lore_ptr->msex).data()));
         lore_ptr->old = true;
     }
 
@@ -346,7 +348,7 @@ void display_monster_never_move(lore_type *lore_ptr)
     if (lore_ptr->old) {
         hooked_roff(_("、しかし", ", but "));
     } else {
-        hooked_roff(format(_("%s^は", "%s^ "), Who::who(lore_ptr->msex)));
+        hooked_roff(format(_("%s^は", "%s^ "), Who::who(lore_ptr->msex).data()));
         lore_ptr->old = true;
     }
 
@@ -482,19 +484,19 @@ void display_monster_aura(lore_type *lore_ptr)
     auto has_cold_aura = lore_ptr->aura_flags.has(MonsterAuraType::COLD);
     if (has_fire_aura && has_elec_aura && has_cold_aura) {
         hook_c_roff(
-            TERM_VIOLET, format(_("%s^は炎と氷とスパークに包まれている。", "%s^ is surrounded by flames, ice and electricity.  "), Who::who(lore_ptr->msex)));
+            TERM_VIOLET, format(_("%s^は炎と氷とスパークに包まれている。", "%s^ is surrounded by flames, ice and electricity.  "), Who::who(lore_ptr->msex).data()));
     } else if (has_fire_aura && has_elec_aura) {
-        hook_c_roff(TERM_L_RED, format(_("%s^は炎とスパークに包まれている。", "%s^ is surrounded by flames and electricity.  "), Who::who(lore_ptr->msex)));
+        hook_c_roff(TERM_L_RED, format(_("%s^は炎とスパークに包まれている。", "%s^ is surrounded by flames and electricity.  "), Who::who(lore_ptr->msex).data()));
     } else if (has_fire_aura && has_cold_aura) {
-        hook_c_roff(TERM_BLUE, format(_("%s^は炎と氷に包まれている。", "%s^ is surrounded by flames and ice.  "), Who::who(lore_ptr->msex)));
+        hook_c_roff(TERM_BLUE, format(_("%s^は炎と氷に包まれている。", "%s^ is surrounded by flames and ice.  "), Who::who(lore_ptr->msex).data()));
     } else if (has_cold_aura && has_elec_aura) {
-        hook_c_roff(TERM_L_GREEN, format(_("%s^は氷とスパークに包まれている。", "%s^ is surrounded by ice and electricity.  "), Who::who(lore_ptr->msex)));
+        hook_c_roff(TERM_L_GREEN, format(_("%s^は氷とスパークに包まれている。", "%s^ is surrounded by ice and electricity.  "), Who::who(lore_ptr->msex).data()));
     } else if (has_fire_aura) {
-        hook_c_roff(TERM_RED, format(_("%s^は炎に包まれている。", "%s^ is surrounded by flames.  "), Who::who(lore_ptr->msex)));
+        hook_c_roff(TERM_RED, format(_("%s^は炎に包まれている。", "%s^ is surrounded by flames.  "), Who::who(lore_ptr->msex).data()));
     } else if (has_cold_aura) {
-        hook_c_roff(TERM_BLUE, format(_("%s^は氷に包まれている。", "%s^ is surrounded by ice.  "), Who::who(lore_ptr->msex)));
+        hook_c_roff(TERM_BLUE, format(_("%s^は氷に包まれている。", "%s^ is surrounded by ice.  "), Who::who(lore_ptr->msex).data()));
     } else if (has_elec_aura) {
-        hook_c_roff(TERM_L_BLUE, format(_("%s^はスパークに包まれている。", "%s^ is surrounded by electricity.  "), Who::who(lore_ptr->msex)));
+        hook_c_roff(TERM_L_BLUE, format(_("%s^はスパークに包まれている。", "%s^ is surrounded by electricity.  "), Who::who(lore_ptr->msex).data()));
     }
 }
 
@@ -570,10 +572,10 @@ static void display_monster_escort_contents(lore_type *lore_ptr)
 void display_monster_collective(lore_type *lore_ptr)
 {
     if (lore_ptr->misc_flags.has(MonsterMiscType::ESCORT) || lore_ptr->misc_flags.has(MonsterMiscType::MORE_ESCORT) || lore_ptr->has_reinforce()) {
-        hooked_roff(format(_("%s^は通常護衛を伴って現れる。", "%s^ usually appears with escorts.  "), Who::who(lore_ptr->msex)));
+        hooked_roff(format(_("%s^は通常護衛を伴って現れる。", "%s^ usually appears with escorts.  "), Who::who(lore_ptr->msex).data()));
         display_monster_escort_contents(lore_ptr);
     } else if (lore_ptr->misc_flags.has(MonsterMiscType::HAS_FRIENDS)) {
-        hooked_roff(format(_("%s^は通常集団で現れる。", "%s^ usually appears in groups.  "), Who::who(lore_ptr->msex)));
+        hooked_roff(format(_("%s^は通常集団で現れる。", "%s^ usually appears in groups.  "), Who::who(lore_ptr->msex).data()));
     }
 }
 
@@ -615,7 +617,7 @@ void display_monster_sometimes(lore_type *lore_ptr)
         return;
     }
 
-    hooked_roff(format(_("%s^は", "%s^"), Who::who(lore_ptr->msex)));
+    hooked_roff(format(_("%s^は", "%s^"), Who::who(lore_ptr->msex).data()));
     for (int n = 0; const auto &[msg, color] : lore_ptr->lore_msgs) {
 #ifdef JP
         if (n != std::ssize(lore_ptr->lore_msgs) - 1) {


### PR DESCRIPTION
これに伴いWho クラスも微調整しています
ご確認下さい
(そもそもWho に定義されたメソッドはLore のメソッドへ付け替えてもいいかもしれないが、このPRではスキップ)