### PR TITLE
モンスター種族のレベルソートをメソッド化した

### DIFF
--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -95,7 +95,7 @@ static std::vector<MonsterRaceId> collect_monsters(short grp_cur, monster_lore_m
         }
     }
 
-    std::stable_sort(monrace_ids.begin(), monrace_ids.end(), [&monraces](auto x, auto y) { return monraces.order_level(x, y); });
+    std::stable_sort(monrace_ids.begin(), monrace_ids.end(), [&monraces](auto x, auto y) { return monraces.order_level_unique(x, y); });
     return monrace_ids;
 }
 

--- a/src/main/game-data-initializer.cpp
+++ b/src/main/game-data-initializer.cpp
@@ -100,7 +100,7 @@ void init_monsters_alloc()
 
     std::sort(elements.begin(), elements.end(),
         [](const MonsterRaceInfo *r1_ptr, const MonsterRaceInfo *r2_ptr) {
-            return r1_ptr->level < r2_ptr->level;
+            return r2_ptr->order_level_strictly(*r1_ptr);
         });
 
     alloc_race_table.clear();

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -360,7 +360,7 @@ void determine_bounty_uniques(PlayerType *player_ptr)
     // モンスターのLVで昇順に並び替える
     std::sort(bounty_monrace_ids.begin(), bounty_monrace_ids.end(),
         [&monraces](auto id1, auto id2) {
-            return monraces.get_monrace(id1).level < monraces.get_monrace(id2).level;
+            return monraces.order_level(id2, id1);
         });
 
     // 賞金首情報を設定

--- a/src/room/rooms-nest.cpp
+++ b/src/room/rooms-nest.cpp
@@ -172,12 +172,9 @@ bool NestMonsterInfo::order_nest(const NestMonsterInfo &other) const
 
     const auto &monrace1 = this->get_monrace();
     const auto &monrace2 = other.get_monrace();
-    if (monrace1.level < monrace2.level) {
-        return true;
-    }
-
-    if (monrace1.level > monrace2.level) {
-        return false;
+    const auto order_level = monrace2.order_level(monrace1);
+    if (order_level) {
+        return *order_level;
     }
 
     if (monrace1.mexp < monrace2.mexp) {

--- a/src/system/monster-race-info.cpp
+++ b/src/system/monster-race-info.cpp
@@ -98,6 +98,19 @@ std::string MonsterRaceInfo::get_died_message() const
     return is_explodable ? _("は爆発して粉々になった。", " explodes into tiny shreds.") : _("を倒した。", " is destroyed.");
 }
 
+std::optional<bool> MonsterRaceInfo::order_level(const MonsterRaceInfo &other) const
+{
+    if (this->level > other.level) {
+        return true;
+    }
+
+    if (this->level < other.level) {
+        return false;
+    }
+
+    return std::nullopt;
+}
+
 std::optional<bool> MonsterRaceInfo::order_pet(const MonsterRaceInfo &other) const
 {
     if (this->kind_flags.has(MonsterKindType::UNIQUE) && other.kind_flags.has_not(MonsterKindType::UNIQUE)) {
@@ -108,15 +121,7 @@ std::optional<bool> MonsterRaceInfo::order_pet(const MonsterRaceInfo &other) con
         return false;
     }
 
-    if (this->level > other.level) {
-        return true;
-    }
-
-    if (this->level < other.level) {
-        return false;
-    }
-
-    return std::nullopt;
+    return this->order_level(other);
 }
 
 /*!
@@ -775,12 +780,9 @@ bool MonraceList::order_level_unique(MonsterRaceId id1, MonsterRaceId id2) const
 {
     const auto &monrace1 = this->get_monrace(id1);
     const auto &monrace2 = this->get_monrace(id2);
-    if (monrace1.level < monrace2.level) {
-        return true;
-    }
-
-    if (monrace1.level > monrace2.level) {
-        return false;
+    const auto order_level = monrace2.order_level(monrace1);
+    if (order_level) {
+        return *order_level;
     }
 
     if (monrace1.kind_flags.has_not(MonsterKindType::UNIQUE) && monrace2.kind_flags.has(MonsterKindType::UNIQUE)) {

--- a/src/system/monster-race-info.cpp
+++ b/src/system/monster-race-info.cpp
@@ -316,7 +316,7 @@ std::optional<std::string> MonsterRaceInfo::probe_lore()
 
     this->r_wake = MAX_UCHAR;
     this->r_ignore = MAX_UCHAR;
-    for (auto i = 0; i < 4; i++) {
+    for (auto i = 0; i < std::ssize(this->blows); i++) {
         const auto &blow = this->blows[i];
         if ((blow.effect != RaceBlowEffectType::NONE) || (blow.method != RaceBlowMethodType::NONE)) {
             if (this->r_blows[i] != MAX_UCHAR) {

--- a/src/system/monster-race-info.cpp
+++ b/src/system/monster-race-info.cpp
@@ -771,10 +771,10 @@ bool MonraceList::order(MonsterRaceId id1, MonsterRaceId id2, bool is_detailed) 
     return id1 < id2;
 }
 
-bool MonraceList::order_level(MonsterRaceId id1, MonsterRaceId id2) const
+bool MonraceList::order_level_unique(MonsterRaceId id1, MonsterRaceId id2) const
 {
-    const auto &monrace1 = monraces_info[id1];
-    const auto &monrace2 = monraces_info[id2];
+    const auto &monrace1 = this->get_monrace(id1);
+    const auto &monrace2 = this->get_monrace(id2);
     if (monrace1.level < monrace2.level) {
         return true;
     }

--- a/src/system/monster-race-info.cpp
+++ b/src/system/monster-race-info.cpp
@@ -781,6 +781,13 @@ bool MonraceList::order(MonsterRaceId id1, MonsterRaceId id2, bool is_detailed) 
     return id1 < id2;
 }
 
+bool MonraceList::order_level(MonsterRaceId id1, MonsterRaceId id2) const
+{
+    const auto &monrace1 = this->get_monrace(id1);
+    const auto &monrace2 = this->get_monrace(id2);
+    return monrace1.order_level_strictly(monrace2);
+}
+
 bool MonraceList::order_level_unique(MonsterRaceId id1, MonsterRaceId id2) const
 {
     const auto &monrace1 = this->get_monrace(id1);

--- a/src/system/monster-race-info.cpp
+++ b/src/system/monster-race-info.cpp
@@ -111,6 +111,11 @@ std::optional<bool> MonsterRaceInfo::order_level(const MonsterRaceInfo &other) c
     return std::nullopt;
 }
 
+bool MonsterRaceInfo::order_level_strictly(const MonsterRaceInfo &other) const
+{
+    return this->level > other.level;
+}
+
 std::optional<bool> MonsterRaceInfo::order_pet(const MonsterRaceInfo &other) const
 {
     if (this->kind_flags.has(MonsterKindType::UNIQUE) && other.kind_flags.has_not(MonsterKindType::UNIQUE)) {

--- a/src/system/monster-race-info.h
+++ b/src/system/monster-race-info.h
@@ -224,6 +224,7 @@ public:
     bool is_separated(const MonsterRaceId r_idx) const;
     bool can_select_separate(const MonsterRaceId morace_id, const int hp, const int maxhp) const;
     bool order(MonsterRaceId id1, MonsterRaceId id2, bool is_detailed = false) const;
+    bool order_level(MonsterRaceId id1, MonsterRaceId id2) const;
     bool order_level_unique(MonsterRaceId id1, MonsterRaceId id2) const;
     MonsterRaceId pick_id_at_random() const;
     const MonsterRaceInfo &pick_monrace_at_random() const;

--- a/src/system/monster-race-info.h
+++ b/src/system/monster-race-info.h
@@ -222,7 +222,7 @@ public:
     bool is_separated(const MonsterRaceId r_idx) const;
     bool can_select_separate(const MonsterRaceId morace_id, const int hp, const int maxhp) const;
     bool order(MonsterRaceId id1, MonsterRaceId id2, bool is_detailed = false) const;
-    bool order_level(MonsterRaceId id1, MonsterRaceId id2) const;
+    bool order_level_unique(MonsterRaceId id1, MonsterRaceId id2) const;
     MonsterRaceId pick_id_at_random() const;
     const MonsterRaceInfo &pick_monrace_at_random() const;
 

--- a/src/system/monster-race-info.h
+++ b/src/system/monster-race-info.h
@@ -140,6 +140,7 @@ public:
     bool symbol_char_is_any_of(std::string_view symbol_characters) const;
     std::string get_died_message() const;
     std::optional<bool> order_level(const MonsterRaceInfo &other) const;
+    bool order_level_strictly(const MonsterRaceInfo &other) const;
     std::optional<bool> order_pet(const MonsterRaceInfo &other) const;
     void kill_unique();
     std::string get_pronoun_of_summoned_kin() const;

--- a/src/system/monster-race-info.h
+++ b/src/system/monster-race-info.h
@@ -139,6 +139,7 @@ public:
     bool is_explodable() const;
     bool symbol_char_is_any_of(std::string_view symbol_characters) const;
     std::string get_died_message() const;
+    std::optional<bool> order_level(const MonsterRaceInfo &other) const;
     std::optional<bool> order_pet(const MonsterRaceInfo &other) const;
     void kill_unique();
     std::string get_pronoun_of_summoned_kin() const;

--- a/src/target/target-preparation.cpp
+++ b/src/target/target-preparation.cpp
@@ -232,7 +232,7 @@ void target_sensing_monsters_prepare(PlayerType *player_ptr, std::vector<MONSTER
 
         /* Higher level monsters first (if known) */
         if (monrace1.r_tkills && monrace2.r_tkills && monrace1.level != monrace2.level) {
-            return monrace1.level > monrace2.level;
+            return monrace1.order_level_strictly(monrace2);
         }
 
         /* Sort by index if all conditions are same */
@@ -288,7 +288,7 @@ std::vector<MONSTER_IDX> target_pets_prepare(PlayerType *player_ptr)
         }
 
         if (ap_monrace1.r_tkills && ap_monrace2.r_tkills && (ap_monrace1.level != ap_monrace2.level)) {
-            return ap_monrace1.level > ap_monrace2.level;
+            return ap_monrace1.order_level_strictly(ap_monrace2);
         }
 
         return idx1 < idx2;

--- a/src/target/target-sorter.cpp
+++ b/src/target/target-sorter.cpp
@@ -77,12 +77,9 @@ bool TargetSorter::compare_importance(const FloorType &floor, const Pos2D &pos_a
         }
 
         if (appearent_monrace1.r_tkills && appearent_monrace2.r_tkills) {
-            if (appearent_monrace1.level > appearent_monrace2.level) {
-                return true;
-            }
-
-            if (appearent_monrace1.level < appearent_monrace2.level) {
-                return false;
+            const auto order_level = appearent_monrace1.order_level(appearent_monrace2);
+            if (order_level) {
+                return *order_level;
             }
         }
 

--- a/src/util/object-sort.cpp
+++ b/src/util/object-sort.cpp
@@ -116,7 +116,7 @@ bool object_sort_comp(PlayerType *player_ptr, ItemEntity *o_ptr, int32_t o_value
     case ItemKindType::CAPTURE: {
         const auto &monrace1 = o_ptr->get_monrace();
         const auto &monrace2 = j_ptr->get_monrace();
-        if (monrace1.level < monrace2.level) {
+        if (monrace2.order_level_strictly(monrace1)) {
             return true;
         }
 

--- a/src/wizard/wizard-spoiler.cpp
+++ b/src/wizard/wizard-spoiler.cpp
@@ -61,21 +61,22 @@ static auto get_mon_evol_roots()
 {
     std::set<MonsterRaceId> evol_parents;
     std::set<MonsterRaceId> evol_children;
-    for (const auto &[monrace_id, monrace] : monraces_info) {
+    const auto &monraces = MonraceList::get_instance();
+    for (const auto &[monrace_id, monrace] : monraces) {
         if (monrace.get_next().is_valid()) {
             evol_parents.emplace(monrace_id);
             evol_children.emplace(monrace.next_r_idx);
         }
     }
 
-    auto evol_root_sort = [](MonsterRaceId i1, MonsterRaceId i2) {
-        auto &r1 = monraces_info[i1];
-        auto &r2 = monraces_info[i2];
-        if (r1.level != r2.level) {
-            return r1.level < r2.level;
+    const auto evol_root_sort = [&monraces](MonsterRaceId i1, MonsterRaceId i2) {
+        const auto &monrace1 = monraces.get_monrace(i1);
+        const auto &monrace2 = monraces.get_monrace(i2);
+        if (monrace1.level != monrace2.level) {
+            return monrace2.order_level_strictly(monrace1);
         }
-        if (r1.mexp != r2.mexp) {
-            return r1.mexp < r2.mexp;
+        if (monrace1.mexp != monrace2.mexp) {
+            return monrace1.mexp < monrace2.mexp;
         }
         return i1 <= i2;
     };


### PR DESCRIPTION
掲題の通りです
「monrace2の方が高レベルかを判定する箇所」は2箇所見つけましたが、間違っている箇所がないか重点的にご確認下さい

注：`!monrace1.order_level(monrace2)`≠`monrace2.order_level(monrace1)` です。前者はNG