### PR TITLE
lore_type::build_speed() を定義して表記部分を軽量化した

### DIFF
--- a/src/lore/lore-util.cpp
+++ b/src/lore/lore-util.cpp
@@ -1,5 +1,6 @@
 #include "lore/lore-util.h"
 #include "game-option/birth-options.h"
+#include "locale/language-switcher.h"
 #include "monster-attack/monster-attack-table.h"
 #include "monster-race/race-sex.h"
 #include "system/monster-race-info.h"
@@ -60,6 +61,74 @@ lore_type::lore_type(MonsterRaceId r_idx, monster_lore_mode mode)
 bool lore_type::has_reinforce() const
 {
     return this->r_ptr->has_reinforce();
+}
+
+std::vector<lore_msg> lore_type::build_speed_description() const
+{
+    std::vector<lore_msg> texts;
+#ifdef JP
+#else
+    texts.emplace_back("moves");
+#endif
+    const auto random_movement_description = this->build_random_movement_description();
+    texts.insert(texts.end(), random_movement_description.begin(), random_movement_description.end());
+    if (this->speed > STANDARD_SPEED) {
+        if (this->speed > 139) {
+            texts.emplace_back(_("信じ難いほど", " incredibly"), TERM_RED);
+        } else if (this->speed > 134) {
+            texts.emplace_back(_("猛烈に", " extremely"), TERM_ORANGE);
+        } else if (this->speed > 129) {
+            texts.emplace_back(_("非常に", " very"), TERM_ORANGE);
+        } else if (this->speed > 124) {
+            texts.emplace_back(_("かなり", " fairly"), TERM_UMBER);
+        } else if (this->speed < 120) {
+            texts.emplace_back(_("やや", " somewhat"), TERM_L_UMBER);
+        }
+
+        texts.emplace_back(_("素早く", " quickly"), TERM_L_RED);
+    } else if (this->speed < STANDARD_SPEED) {
+        if (this->speed < 90) {
+            texts.emplace_back(_("信じ難いほど", " incredibly"), TERM_L_GREEN);
+        } else if (this->speed < 95) {
+            texts.emplace_back(_("非常に", " very"), TERM_BLUE);
+        } else if (this->speed < 100) {
+            texts.emplace_back(_("かなり", " fairly"), TERM_BLUE);
+        } else if (this->speed > 104) {
+            texts.emplace_back(_("やや", " somewhat"), TERM_GREEN);
+        }
+
+        texts.emplace_back(_("ゆっくりと", " slowly"), TERM_L_BLUE);
+    } else {
+        texts.emplace_back(_("普通の速さで", " at normal speed"));
+    }
+
+#ifdef JP
+    texts.emplace_back("動いている");
+#endif
+    return texts;
+}
+
+std::vector<lore_msg> lore_type::build_random_movement_description() const
+{
+    if (this->behavior_flags.has_none_of({ MonsterBehaviorType::RAND_MOVE_50, MonsterBehaviorType::RAND_MOVE_25 })) {
+        return {};
+    }
+
+    std::vector<lore_msg> texts;
+    if (this->behavior_flags.has(MonsterBehaviorType::RAND_MOVE_50) && this->behavior_flags.has(MonsterBehaviorType::RAND_MOVE_25)) {
+        texts.emplace_back(_("かなり", " extremely"));
+    } else if (this->behavior_flags.has(MonsterBehaviorType::RAND_MOVE_50)) {
+        texts.emplace_back(_("幾分", " somewhat"));
+    } else if (this->behavior_flags.has(MonsterBehaviorType::RAND_MOVE_25)) {
+        texts.emplace_back(_("少々", " a bit"));
+    }
+
+    texts.emplace_back(_("不規則に", " erratically"));
+    if (this->speed != STANDARD_SPEED) {
+        texts.emplace_back(_("、かつ", ", and"));
+    }
+
+    return texts;
 }
 
 /*!

--- a/src/lore/lore-util.h
+++ b/src/lore/lore-util.h
@@ -13,10 +13,13 @@
 #include "monster-race/race-special-flags.h"
 #include "monster-race/race-visual-flags.h"
 #include "system/angband.h"
+#include "term/term-color-types.h"
 #include "util/flag-group.h"
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 enum class MonsterRaceId : short;
 enum class MonsterSex;
@@ -30,7 +33,7 @@ enum monster_lore_mode {
 
 class MonsterRaceInfo;
 struct lore_msg {
-    lore_msg(std::string_view msg, byte color);
+    lore_msg(std::string_view msg, byte color = TERM_WHITE);
     std::string msg;
     byte color;
 };
@@ -80,6 +83,11 @@ struct lore_type {
     EnumClassFlagGroup<MonsterMiscType> misc_flags;
 
     bool has_reinforce() const;
+
+    std::vector<lore_msg> build_speed_description() const;
+
+private:
+    std::vector<lore_msg> build_random_movement_description() const;
 };
 
 using hook_c_roff_pf = void (*)(TERM_COLOR attr, std::string_view str);

--- a/src/view/display-lore.cpp
+++ b/src/view/display-lore.cpp
@@ -276,65 +276,10 @@ bool display_where_to_appear(lore_type *lore_ptr)
     return true;
 }
 
-// @todo モンスターの速度表記はmonster_typeのオブジェクトメソッドにした方がベター
 void display_monster_move(lore_type *lore_ptr)
 {
-#ifdef JP
-#else
-    hooked_roff("moves");
-#endif
-
-    display_random_move(lore_ptr);
-    if (lore_ptr->speed > STANDARD_SPEED) {
-        if (lore_ptr->speed > 139) {
-            hook_c_roff(TERM_RED, _("信じ難いほど", " incredibly"));
-        } else if (lore_ptr->speed > 134) {
-            hook_c_roff(TERM_ORANGE, _("猛烈に", " extremely"));
-        } else if (lore_ptr->speed > 129) {
-            hook_c_roff(TERM_ORANGE, _("非常に", " very"));
-        } else if (lore_ptr->speed > 124) {
-            hook_c_roff(TERM_UMBER, _("かなり", " fairly"));
-        } else if (lore_ptr->speed < 120) {
-            hook_c_roff(TERM_L_UMBER, _("やや", " somewhat"));
-        }
-        hook_c_roff(TERM_L_RED, _("素早く", " quickly"));
-    } else if (lore_ptr->speed < STANDARD_SPEED) {
-        if (lore_ptr->speed < 90) {
-            hook_c_roff(TERM_L_GREEN, _("信じ難いほど", " incredibly"));
-        } else if (lore_ptr->speed < 95) {
-            hook_c_roff(TERM_BLUE, _("非常に", " very"));
-        } else if (lore_ptr->speed < 100) {
-            hook_c_roff(TERM_BLUE, _("かなり", " fairly"));
-        } else if (lore_ptr->speed > 104) {
-            hook_c_roff(TERM_GREEN, _("やや", " somewhat"));
-        }
-        hook_c_roff(TERM_L_BLUE, _("ゆっくりと", " slowly"));
-    } else {
-        hooked_roff(_("普通の速さで", " at normal speed"));
-    }
-
-#ifdef JP
-    hooked_roff("動いている");
-#endif
-}
-
-void display_random_move(lore_type *lore_ptr)
-{
-    if (lore_ptr->behavior_flags.has_none_of({ MonsterBehaviorType::RAND_MOVE_50, MonsterBehaviorType::RAND_MOVE_25 })) {
-        return;
-    }
-
-    if (lore_ptr->behavior_flags.has(MonsterBehaviorType::RAND_MOVE_50) && lore_ptr->behavior_flags.has(MonsterBehaviorType::RAND_MOVE_25)) {
-        hooked_roff(_("かなり", " extremely"));
-    } else if (lore_ptr->behavior_flags.has(MonsterBehaviorType::RAND_MOVE_50)) {
-        hooked_roff(_("幾分", " somewhat"));
-    } else if (lore_ptr->behavior_flags.has(MonsterBehaviorType::RAND_MOVE_25)) {
-        hooked_roff(_("少々", " a bit"));
-    }
-
-    hooked_roff(_("不規則に", " erratically"));
-    if (lore_ptr->speed != STANDARD_SPEED) {
-        hooked_roff(_("、かつ", ", and"));
+    for (const auto &[text, color] : lore_ptr->build_speed_description()) {
+        hook_c_roff(color, text);
     }
 }
 

--- a/src/view/display-lore.h
+++ b/src/view/display-lore.h
@@ -11,7 +11,6 @@ void display_roff(PlayerType *player_ptr);
 void output_monster_spoiler(MonsterRaceId r_idx, hook_c_roff_pf roff_func);
 void display_kill_numbers(lore_type *lore_ptr);
 bool display_where_to_appear(lore_type *lore_ptr);
-void display_random_move(lore_type *lore_ptr);
 void display_monster_move(lore_type *lore_ptr);
 void display_monster_never_move(lore_type *lore_ptr);
 void display_monster_kind(lore_type *lore_ptr);


### PR DESCRIPTION
#4534 の内、純粋なリファクタリング部分だけを抽出したものです
チケットはありません
わざわざemplaceするために型を明記しているのがちょっと気持ち悪い (Clangがこうしないとコンパイルエラー)ので、多少実行時コストが重くてもpush\_backにすべきか少し悩んでいます
ご確認下さい