### PR TITLE
monraces_info へ直接アクセスしている箇所を削減した その17

### DIFF
--- a/lib/edit/MonraceDefinitions.jsonc
+++ b/lib/edit/MonraceDefinitions.jsonc
@@ -161,7 +161,7 @@
       "armor_class": 0,
       "alertness": 0,
       "level": 0,
-      "rarity": 0,
+      "rarity": 255,
       "exp": 0
     },
     //##### Town monsters #####

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -473,6 +473,10 @@ errr parse_monraces_info(nlohmann::json &mon_data, angband_header *)
         msg_format(_("モンスター希少度読込失敗。ID: '%d'。", "Failed to load monster rarity. ID: '%d'."), error_idx);
         return err;
     }
+    if (err) {
+        msg_format(_("モンスター希少度範囲外。ID: '%d'。", "Monster rarity is out of range. ID: '%d'."), error_idx);
+        return err;
+    }
     err = info_set_integer(mon_data["exp"], monrace.mexp, true, Range(0, 9999999));
     if (err) {
         msg_format(_("モンスター経験値読込失敗。ID: '%d'。", "Failed to load monster exp. ID: '%d'."), error_idx);

--- a/src/knowledge/knowledge-uniques.cpp
+++ b/src/knowledge/knowledge-uniques.cpp
@@ -48,8 +48,8 @@ static bool sweep_uniques(MonsterRaceInfo *r_ptr, bool is_alive)
         return false;
     }
 
-    bool is_except_arena = is_alive ? (r_ptr->rarity > 100) && (r_ptr->misc_flags.has_not(MonsterMiscType::QUESTOR)) : false;
-    if (!r_ptr->rarity || is_except_arena) {
+    const auto is_except_arena = is_alive ? (r_ptr->rarity > 100) && (r_ptr->misc_flags.has_not(MonsterMiscType::QUESTOR)) : false;
+    if (is_except_arena) {
         return false;
     }
 

--- a/src/main/game-data-initializer.cpp
+++ b/src/main/game-data-initializer.cpp
@@ -91,29 +91,8 @@ void init_other(PlayerType *player_ptr)
  */
 void init_monsters_alloc()
 {
-    std::vector<const MonsterRaceInfo *> elements;
-    for (const auto &[monrace_id, monrace] : monraces_info) {
-        if (monrace.is_valid()) {
-            elements.push_back(&monrace);
-        }
-    }
-
-    std::sort(elements.begin(), elements.end(),
-        [](const MonsterRaceInfo *r1_ptr, const MonsterRaceInfo *r2_ptr) {
-            return r2_ptr->order_level_strictly(*r1_ptr);
-        });
-
-    alloc_race_table.clear();
-    for (const auto r_ptr : elements) {
-        if (r_ptr->rarity == 0) {
-            continue;
-        }
-
-        const auto index = static_cast<short>(r_ptr->idx);
-        const auto level = r_ptr->level;
-        const auto prob = static_cast<PROB>(100 / r_ptr->rarity);
-        alloc_race_table.push_back({ index, level, prob, prob });
-    }
+    auto &table = MonraceAllocationTable::get_instance();
+    table.initialize();
 }
 
 /*!

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -150,7 +150,7 @@ MonsterRaceId get_mon_num(PlayerType *player_ptr, DEPTH min_level, DEPTH max_lev
         if (max_level < entry.level) {
             break;
         } // sorted by depth array,
-        auto monrace_id = i2enum<MonsterRaceId>(entry.index);
+        const auto monrace_id = entry.index;
         auto &monrace = monraces.get_monrace(monrace_id);
         if (none_bits(mode, PM_ARENA | PM_CHAMELEON)) {
             if (monrace.can_generate() && none_bits(mode, PM_CLONE)) {
@@ -197,7 +197,7 @@ MonsterRaceId get_mon_num(PlayerType *player_ptr, DEPTH min_level, DEPTH max_lev
     ProbabilityTable<int>::lottery(std::back_inserter(result), prob_table, n);
     const auto it = std::max_element(result.begin(), result.end(),
         [&table](int a, int b) { return table.get_entry(a).level < table.get_entry(b).level; });
-    return i2enum<MonsterRaceId>(table.get_entry(*it).index);
+    return table.get_entry(*it).index;
 }
 
 /*!

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -45,9 +45,6 @@
 #include <cmath>
 #include <iterator>
 
-#define HORDE_NOGOOD 0x01 /*!< (未実装フラグ)HORDE生成でGOODなモンスターの生成を禁止する？ */
-#define HORDE_NOEVIL 0x02 /*!< (未実装フラグ)HORDE生成でEVILなモンスターの生成を禁止する？ */
-
 /*!
  * @brief モンスター配列の空きを探す / Acquires and returns the index of a "free" monster.
  * @return 利用可能なモンスター配列の添字

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -144,8 +144,9 @@ MonsterRaceId get_mon_num(PlayerType *player_ptr, DEPTH min_level, DEPTH max_lev
 
     /* Process probabilities */
     const auto &monraces = MonraceList::get_instance();
-    for (auto i = 0U; i < alloc_race_table.size(); i++) {
-        const auto &entry = alloc_race_table[i];
+    const auto &table = MonraceAllocationTable::get_instance();
+    for (auto i = 0U; i < table.size(); i++) {
+        const auto &entry = table.get_entry(i);
         if (entry.level < min_level) {
             continue;
         }
@@ -197,10 +198,9 @@ MonsterRaceId get_mon_num(PlayerType *player_ptr, DEPTH min_level, DEPTH max_lev
 
     std::vector<int> result;
     ProbabilityTable<int>::lottery(std::back_inserter(result), prob_table, n);
-
-    auto it = std::max_element(result.begin(), result.end(), [](int a, int b) { return alloc_race_table[a].level < alloc_race_table[b].level; });
-
-    return i2enum<MonsterRaceId>(alloc_race_table[*it].index);
+    const auto it = std::max_element(result.begin(), result.end(),
+        [&table](int a, int b) { return table.get_entry(a).level < table.get_entry(b).level; });
+    return i2enum<MonsterRaceId>(table.get_entry(*it).index);
 }
 
 /*!

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -231,11 +231,10 @@ static errr do_get_mon_num_prep(PlayerType *player_ptr, const monsterrace_hook_t
 
     // モンスター生成テーブルの各要素について重みを修正する。
     const auto &system = AngbandSystem::get_instance();
-    const auto &monraces = MonraceList::get_instance();
     auto &table = MonraceAllocationTable::get_instance();
     for (auto &entry : table) {
-        const auto monrace_id = i2enum<MonsterRaceId>(entry.index);
-        const auto &monrace = monraces.get_monrace(monrace_id);
+        const auto monrace_id = entry.index;
+        const auto &monrace = entry.get_monrace();
 
         // 生成を禁止する要素は重み 0 とする。
         entry.prob2 = 0;

--- a/src/object-enchant/others/apply-magic-others.cpp
+++ b/src/object-enchant/others/apply-magic-others.cpp
@@ -116,7 +116,7 @@ void OtherItemsEnchanter::generate_figurine()
 
         const auto &monrace = monraces.get_monrace(monrace_id);
         auto check = (floor.dun_level < monrace.level) ? (monrace.level - floor.dun_level) : 0;
-        if ((monrace.rarity == 0) || (monrace.rarity > 100) || (randint0(check) > 0)) {
+        if ((monrace.rarity > 100) || (randint0(check) > 0)) {
             continue;
         }
 
@@ -157,7 +157,7 @@ void OtherItemsEnchanter::generate_corpse()
             continue;
         }
 
-        if ((monrace.rarity == 0) || (match.find(*sval) != match.end() && monrace.drop_flags.has_not(match.at(*sval))) || (randint0(check) > 0)) {
+        if ((match.find(*sval) != match.end() && monrace.drop_flags.has_not(match.at(*sval))) || (randint0(check) > 0)) {
             continue;
         }
 
@@ -171,7 +171,6 @@ void OtherItemsEnchanter::generate_corpse()
 
 /*
  * @brief ランダムに選択したモンスター種族IDからその像を作る
- * @details レアリティが1以上のものだけ生成対象になる
  */
 void OtherItemsEnchanter::generate_statue()
 {
@@ -179,9 +178,7 @@ void OtherItemsEnchanter::generate_statue()
     const auto pick_monrace_id_for_statue = [&monraces] {
         while (true) {
             auto &monrace = monraces.pick_monrace_at_random();
-            if (monrace.rarity > 0) {
-                return monrace.idx;
-            }
+            return monrace.idx;
         }
     };
     const auto monrace_id = pick_monrace_id_for_statue();

--- a/src/system/alloc-entries.cpp
+++ b/src/system/alloc-entries.cpp
@@ -2,9 +2,6 @@
 #include "system/baseitem-info.h"
 #include "system/monster-race-info.h"
 
-/* The entries in the "race allocator table" */
-std::vector<alloc_entry> alloc_race_table;
-
 MonraceAllocationTable MonraceAllocationTable::instance{};
 
 MonraceAllocationTable &MonraceAllocationTable::get_instance()
@@ -21,7 +18,7 @@ void MonraceAllocationTable::initialize()
 {
     const auto &monraces = MonraceList::get_instance();
     std::vector<const MonsterRaceInfo *> elements;
-    for (const auto &[monrace_id, monrace] : monraces_info) {
+    for (const auto &[monrace_id, monrace] : monraces) {
         if (monrace.is_valid()) {
             elements.push_back(&monrace);
         }
@@ -41,6 +38,26 @@ void MonraceAllocationTable::initialize()
         const auto prob = static_cast<short>(100 / r_ptr->rarity);
         this->entries.emplace_back(index, level, prob, prob);
     }
+}
+
+std::vector<alloc_entry>::iterator MonraceAllocationTable::begin()
+{
+    return this->entries.begin();
+}
+
+std::vector<alloc_entry>::const_iterator MonraceAllocationTable::begin() const
+{
+    return this->entries.begin();
+}
+
+std::vector<alloc_entry>::iterator MonraceAllocationTable::end()
+{
+    return this->entries.end();
+}
+
+std::vector<alloc_entry>::const_iterator MonraceAllocationTable::end() const
+{
+    return this->entries.end();
 }
 
 const alloc_entry &MonraceAllocationTable::get_entry(int index) const

--- a/src/system/alloc-entries.cpp
+++ b/src/system/alloc-entries.cpp
@@ -29,27 +29,16 @@ size_t MonraceAllocationTable::size() const
 
 void MonraceAllocationTable::initialize()
 {
-    const auto &monraces = MonraceList::get_instance();
-    std::vector<const MonsterRaceInfo *> elements;
-    for (const auto &[monrace_id, monrace] : monraces) {
-        if (monrace.is_valid()) {
-            elements.push_back(&monrace);
-        }
-    }
-
-    std::stable_sort(elements.begin(), elements.end(), [](const auto *r_ptr1, const auto *r_ptr2) {
-        return r_ptr2->order_level_strictly(*r_ptr1);
-    });
-    this->entries.reserve(monraces.size());
-    for (const auto *r_ptr : elements) {
+    auto &monraces = MonraceList::get_instance();
+    const auto &elements = monraces.get_sorted_monraces();
+    this->entries.reserve(elements.size());
+    for (const auto &[monrace_id, r_ptr] : elements) {
         if (r_ptr->rarity == 0) { //!< ここ要検討、jsoncロード時に弾くべき.
             continue;
         }
 
-        const auto index = r_ptr->idx;
-        const auto level = r_ptr->level;
         const auto prob = static_cast<short>(100 / r_ptr->rarity);
-        this->entries.emplace_back(index, level, prob, prob);
+        this->entries.emplace_back(monrace_id, r_ptr->level, prob, prob);
     }
 }
 

--- a/src/system/alloc-entries.cpp
+++ b/src/system/alloc-entries.cpp
@@ -1,8 +1,57 @@
 #include "system/alloc-entries.h"
 #include "system/baseitem-info.h"
+#include "system/monster-race-info.h"
 
 /* The entries in the "race allocator table" */
 std::vector<alloc_entry> alloc_race_table;
+
+MonraceAllocationTable MonraceAllocationTable::instance{};
+
+MonraceAllocationTable &MonraceAllocationTable::get_instance()
+{
+    return instance;
+}
+
+size_t MonraceAllocationTable::size() const
+{
+    return this->entries.size();
+}
+
+void MonraceAllocationTable::initialize()
+{
+    const auto &monraces = MonraceList::get_instance();
+    std::vector<const MonsterRaceInfo *> elements;
+    for (const auto &[monrace_id, monrace] : monraces_info) {
+        if (monrace.is_valid()) {
+            elements.push_back(&monrace);
+        }
+    }
+
+    std::stable_sort(elements.begin(), elements.end(), [](const auto *r_ptr1, const auto *r_ptr2) {
+        return r_ptr2->order_level_strictly(*r_ptr1);
+    });
+    this->entries.reserve(monraces.size());
+    for (const auto *r_ptr : elements) {
+        if (r_ptr->rarity == 0) { //!< ここ要検討、jsoncロード時に弾くべき.
+            continue;
+        }
+
+        const auto index = static_cast<short>(r_ptr->idx);
+        const auto level = r_ptr->level;
+        const auto prob = static_cast<short>(100 / r_ptr->rarity);
+        this->entries.emplace_back(index, level, prob, prob);
+    }
+}
+
+const alloc_entry &MonraceAllocationTable::get_entry(int index) const
+{
+    return this->entries.at(index);
+}
+
+alloc_entry &MonraceAllocationTable::get_entry(int index)
+{
+    return this->entries.at(index);
+}
 
 /* The entries in the "kind allocator table" */
 std::vector<alloc_entry> alloc_kind_table;

--- a/src/system/alloc-entries.cpp
+++ b/src/system/alloc-entries.cpp
@@ -33,10 +33,6 @@ void MonraceAllocationTable::initialize()
     const auto &elements = monraces.get_sorted_monraces();
     this->entries.reserve(elements.size());
     for (const auto &[monrace_id, r_ptr] : elements) {
-        if (r_ptr->rarity == 0) { //!< ここ要検討、jsoncロード時に弾くべき.
-            continue;
-        }
-
         const auto prob = static_cast<short>(100 / r_ptr->rarity);
         this->entries.emplace_back(monrace_id, r_ptr->level, prob, prob);
     }

--- a/src/system/alloc-entries.cpp
+++ b/src/system/alloc-entries.cpp
@@ -2,6 +2,19 @@
 #include "system/baseitem-info.h"
 #include "system/monster-race-info.h"
 
+MonraceAllocationEntry::MonraceAllocationEntry(MonsterRaceId index, int level, short prob1, short prob2)
+    : index(index)
+    , level(level)
+    , prob1(prob1)
+    , prob2(prob2)
+{
+}
+
+const MonsterRaceInfo &MonraceAllocationEntry::get_monrace() const
+{
+    return MonraceList::get_instance().get_monrace(index);
+}
+
 MonraceAllocationTable MonraceAllocationTable::instance{};
 
 MonraceAllocationTable &MonraceAllocationTable::get_instance()
@@ -33,39 +46,39 @@ void MonraceAllocationTable::initialize()
             continue;
         }
 
-        const auto index = static_cast<short>(r_ptr->idx);
+        const auto index = r_ptr->idx;
         const auto level = r_ptr->level;
         const auto prob = static_cast<short>(100 / r_ptr->rarity);
         this->entries.emplace_back(index, level, prob, prob);
     }
 }
 
-std::vector<alloc_entry>::iterator MonraceAllocationTable::begin()
+std::vector<MonraceAllocationEntry>::iterator MonraceAllocationTable::begin()
 {
     return this->entries.begin();
 }
 
-std::vector<alloc_entry>::const_iterator MonraceAllocationTable::begin() const
+std::vector<MonraceAllocationEntry>::const_iterator MonraceAllocationTable::begin() const
 {
     return this->entries.begin();
 }
 
-std::vector<alloc_entry>::iterator MonraceAllocationTable::end()
+std::vector<MonraceAllocationEntry>::iterator MonraceAllocationTable::end()
 {
     return this->entries.end();
 }
 
-std::vector<alloc_entry>::const_iterator MonraceAllocationTable::end() const
+std::vector<MonraceAllocationEntry>::const_iterator MonraceAllocationTable::end() const
 {
     return this->entries.end();
 }
 
-const alloc_entry &MonraceAllocationTable::get_entry(int index) const
+const MonraceAllocationEntry &MonraceAllocationTable::get_entry(int index) const
 {
     return this->entries.at(index);
 }
 
-alloc_entry &MonraceAllocationTable::get_entry(int index)
+MonraceAllocationEntry &MonraceAllocationTable::get_entry(int index)
 {
     return this->entries.at(index);
 }

--- a/src/system/alloc-entries.cpp
+++ b/src/system/alloc-entries.cpp
@@ -10,6 +10,45 @@ MonraceAllocationEntry::MonraceAllocationEntry(MonsterRaceId index, int level, s
 {
 }
 
+/*!
+ * @brief 一般的なモンスター生成ルーチンで生成しても良いモンスターか否かのフィルタ処理
+ * @param level 生成基準階
+ * @return 生成許可ならばtrue、禁止ならばfalse
+ * @details クエストモンスター、ダンジョンの主、指定階未満でのFORCE_DEPTH フラグ持ちは生成禁止
+ */
+bool MonraceAllocationEntry::is_permitted(int threshold_level) const
+{
+    const auto &monrace = this->get_monrace();
+    if (monrace.misc_flags.has(MonsterMiscType::QUESTOR)) {
+        return false;
+    }
+
+    if (monrace.misc_flags.has(MonsterMiscType::GUARDIAN)) {
+        return false;
+    }
+
+    if (monrace.misc_flags.has(MonsterMiscType::FORCE_DEPTH) && (monrace.level > threshold_level)) {
+        return false;
+    }
+
+    return true;
+}
+
+/*!
+ * @brief クエスト内で生成しても良いモンスターか否かのフィルタ処理
+ * @param level 生成基準階
+ * @return 生成許可ならばtrue、禁止ならばfalse
+ * @details RES_ALL、または生成標準階未満でのダメージ低減フラグ持ちは生成禁止
+ */
+bool MonraceAllocationEntry::is_defeatable(int threshold_level) const
+{
+    const auto &monrace = this->get_monrace();
+    const auto has_resist_all = monrace.resistance_flags.has(MonsterResistanceType::RESIST_ALL);
+    const auto can_diminish = monrace.special_flags.has(MonsterSpecialType::DIMINISH_MAX_DAMAGE);
+    const auto is_shallow = monrace.level > threshold_level;
+    return !has_resist_all && !(can_diminish && is_shallow);
+}
+
 const MonsterRaceInfo &MonraceAllocationEntry::get_monrace() const
 {
     return MonraceList::get_instance().get_monrace(index);

--- a/src/system/alloc-entries.h
+++ b/src/system/alloc-entries.h
@@ -20,6 +20,10 @@ public:
     int level; /* Base dungeon level */
     short prob1; /* Probability, pass 1 */
     short prob2; /* Probability, pass 2 */
+    bool is_permitted(int threshold_level) const;
+    bool is_defeatable(int threshold_level) const;
+
+private:
     const MonsterRaceInfo &get_monrace() const;
 };
 

--- a/src/system/alloc-entries.h
+++ b/src/system/alloc-entries.h
@@ -34,6 +34,10 @@ public:
     static MonraceAllocationTable &get_instance();
 
     void initialize();
+    std::vector<alloc_entry>::iterator begin();
+    std::vector<alloc_entry>::const_iterator begin() const;
+    std::vector<alloc_entry>::iterator end();
+    std::vector<alloc_entry>::const_iterator end() const;
     size_t size() const;
     const alloc_entry &get_entry(int index) const;
     alloc_entry &get_entry(int index);
@@ -43,7 +47,5 @@ private:
     MonraceAllocationTable() = default;
     std::vector<alloc_entry> entries{};
 };
-
-extern std::vector<alloc_entry> alloc_race_table;
 
 extern std::vector<alloc_entry> alloc_kind_table;

--- a/src/system/alloc-entries.h
+++ b/src/system/alloc-entries.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "system/angband.h"
 #include <vector>
 
 /*
@@ -20,12 +19,29 @@
 class BaseitemInfo;
 struct alloc_entry {
     short index; /* The actual index */
-
-    DEPTH level; /* Base dungeon level */
-    PROB prob1; /* Probability, pass 1 */
-    PROB prob2; /* Probability, pass 2 */
-
+    int level; /* Base dungeon level */
+    short prob1; /* Probability, pass 1 */
+    short prob2; /* Probability, pass 2 */
     BaseitemInfo &get_baseitem() const;
+};
+
+class MonraceAllocationTable {
+public:
+    MonraceAllocationTable(const MonraceAllocationTable &) = delete;
+    MonraceAllocationTable(MonraceAllocationTable &&) = delete;
+    MonraceAllocationTable operator=(const MonraceAllocationTable &) = delete;
+    MonraceAllocationTable operator=(MonraceAllocationTable &&) = delete;
+    static MonraceAllocationTable &get_instance();
+
+    void initialize();
+    size_t size() const;
+    const alloc_entry &get_entry(int index) const;
+    alloc_entry &get_entry(int index);
+
+private:
+    static MonraceAllocationTable instance;
+    MonraceAllocationTable() = default;
+    std::vector<alloc_entry> entries{};
 };
 
 extern std::vector<alloc_entry> alloc_race_table;

--- a/src/system/alloc-entries.h
+++ b/src/system/alloc-entries.h
@@ -10,6 +10,19 @@
 
 #include <vector>
 
+enum class MonsterRaceId : short;
+class MonsterRaceInfo;
+class MonraceAllocationEntry {
+public:
+    MonraceAllocationEntry() = default;
+    MonraceAllocationEntry(MonsterRaceId index, int level, short prob1, short prob2);
+    MonsterRaceId index{}; /* The actual index */
+    int level; /* Base dungeon level */
+    short prob1; /* Probability, pass 1 */
+    short prob2; /* Probability, pass 2 */
+    const MonsterRaceInfo &get_monrace() const;
+};
+
 /*
  * An entry for the object/monster allocation functions
  *
@@ -34,18 +47,18 @@ public:
     static MonraceAllocationTable &get_instance();
 
     void initialize();
-    std::vector<alloc_entry>::iterator begin();
-    std::vector<alloc_entry>::const_iterator begin() const;
-    std::vector<alloc_entry>::iterator end();
-    std::vector<alloc_entry>::const_iterator end() const;
+    std::vector<MonraceAllocationEntry>::iterator begin();
+    std::vector<MonraceAllocationEntry>::const_iterator begin() const;
+    std::vector<MonraceAllocationEntry>::iterator end();
+    std::vector<MonraceAllocationEntry>::const_iterator end() const;
     size_t size() const;
-    const alloc_entry &get_entry(int index) const;
-    alloc_entry &get_entry(int index);
+    const MonraceAllocationEntry &get_entry(int index) const;
+    MonraceAllocationEntry &get_entry(int index);
 
 private:
     static MonraceAllocationTable instance;
     MonraceAllocationTable() = default;
-    std::vector<alloc_entry> entries{};
+    std::vector<MonraceAllocationEntry> entries{};
 };
 
 extern std::vector<alloc_entry> alloc_kind_table;

--- a/src/system/monster-race-info.cpp
+++ b/src/system/monster-race-info.cpp
@@ -625,6 +625,26 @@ const std::vector<MonsterRaceId> &MonraceList::get_valid_monrace_ids() const
     return valid_monraces;
 }
 
+//!< @todo ややトリッキーだが、元のmapでMonsterRaceInfo をshared_ptr で持つようにすればかなりスッキリ書けるはず.
+const std::vector<std::pair<MonsterRaceId, const MonsterRaceInfo *>> &MonraceList::get_sorted_monraces() const
+{
+    static std::vector<std::pair<MonsterRaceId, const MonsterRaceInfo *>> sorted_monraces;
+    if (!sorted_monraces.empty()) {
+        return sorted_monraces;
+    }
+
+    for (const auto &pair : monraces_info) {
+        if (pair.second.is_valid()) {
+            sorted_monraces.emplace_back(pair.first, &pair.second);
+        }
+    }
+
+    std::stable_sort(sorted_monraces.begin(), sorted_monraces.end(), [](const auto &pair1, const auto &pair2) {
+        return pair2.second->order_level_strictly(*pair1.second);
+    });
+    return sorted_monraces;
+}
+
 /*!
  * @brief 合体/分離ユニーク判定
  * @param r_idx 調査対象のモンスター種族ID

--- a/src/system/monster-race-info.h
+++ b/src/system/monster-race-info.h
@@ -223,6 +223,7 @@ public:
     MonsterRaceInfo &get_monrace(MonsterRaceId monrace_id);
     const MonsterRaceInfo &get_monrace(MonsterRaceId monrace_id) const;
     const std::vector<MonsterRaceId> &get_valid_monrace_ids() const;
+    const std::vector<std::pair<MonsterRaceId, const MonsterRaceInfo *>> &get_sorted_monraces() const;
     bool can_unify_separate(const MonsterRaceId r_idx) const;
     void kill_unified_unique(const MonsterRaceId r_idx);
     bool is_selectable(const MonsterRaceId r_idx) const;


### PR DESCRIPTION
掲題の通りです
#4551 の後続チケットなので、マージされるまではドラフトにしておきます

なおdevelopブランチとフロアリセット時に生成されるモンスターが異なりますが、これはソートアルゴリズムの変更によるものです (std::sort → std::stable\_sort、同レベルモンスターが配列に格納される順番が異なるが、相異なるレベルでのソートは正常)
鉄獄50Fで何度かリセットしてみましたが、50Fらしい分布になっており異常はありませんでした
ご確認下さい

備考：
上記ソートアルゴリズムを元に戻し、^A → j → Enter2回 でdevelopとこのブランチが同じモンスター分布になることを確認可能