### PR TITLE
マクロ関数plural() を除去し、思い出表記のユニーク撃破状況についてlore_type へ文字列組み立てを移管した

### DIFF
--- a/src/lore/lore-util.cpp
+++ b/src/lore/lore-util.cpp
@@ -118,6 +118,21 @@ std::vector<lore_msg> lore_type::build_speed_description() const
     return texts;
 }
 
+std::string lore_type::build_revenge_description(bool has_defeated) const
+{
+#ifdef JP
+    return has_defeated ? "が、すでに仇討ちは果たしている！" : "のに、まだ仇討ちを果たしていない。";
+#else
+    if (has_defeated) {
+        return format(", but you have avenged %s!  ", Who::whom(this->msex, this->r_ptr->r_deaths == 1).data());
+    }
+
+    std::stringstream ss;
+    ss << ", who remain" << (this->r_ptr->r_deaths == 1 ? "" : "s") << "unavenged.  ";
+    return ss.str();
+#endif
+}
+
 std::vector<lore_msg> lore_type::build_random_movement_description() const
 {
     if (this->behavior_flags.has_none_of({ MonsterBehaviorType::RAND_MOVE_50, MonsterBehaviorType::RAND_MOVE_25 })) {

--- a/src/lore/lore-util.cpp
+++ b/src/lore/lore-util.cpp
@@ -118,6 +118,32 @@ std::vector<lore_msg> lore_type::build_speed_description() const
     return texts;
 }
 
+std::optional<std::vector<lore_msg>> lore_type::build_kill_unique_description() const
+{
+    if (this->kind_flags.has_not(MonsterKindType::UNIQUE)) {
+        return std::nullopt;
+    }
+
+    std::vector<lore_msg> texts;
+    const auto is_dead = (this->r_ptr->max_num == 0);
+    if (this->r_ptr->r_deaths > 0) {
+        constexpr auto fmt = _("%s^はあなたの先祖を %d 人葬っている", "%s^ has slain %d of your ancestors");
+        texts.emplace_back(format(fmt, Who::who(this->msex).data(), this->r_ptr->r_deaths));
+        texts.emplace_back(this->build_revenge_description(is_dead));
+        texts.emplace_back("\n");
+    } else {
+#ifdef JP
+        const auto mes = is_dead ? "あなたはこの仇敵をすでに葬り去っている。" : "この仇敵はまだ生きている！";
+#else
+        const auto mes = is_dead ? "You have slain this foe.  " : "This foe is still alive!  ";
+#endif
+        texts.emplace_back(mes);
+        texts.emplace_back("\n");
+    }
+
+    return texts;
+}
+
 std::string lore_type::build_revenge_description(bool has_defeated) const
 {
 #ifdef JP

--- a/src/lore/lore-util.h
+++ b/src/lore/lore-util.h
@@ -15,6 +15,7 @@
 #include "system/angband.h"
 #include "term/term-color-types.h"
 #include "util/flag-group.h"
+#include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -84,6 +85,7 @@ struct lore_type {
 
     bool has_reinforce() const;
 
+    std::optional<std::vector<lore_msg>> build_kill_unique_description() const;
     std::string build_revenge_description(bool has_defeated) const;
     std::vector<lore_msg> build_speed_description() const;
 

--- a/src/lore/lore-util.h
+++ b/src/lore/lore-util.h
@@ -84,6 +84,7 @@ struct lore_type {
 
     bool has_reinforce() const;
 
+    std::string build_revenge_description(bool has_defeated) const;
     std::vector<lore_msg> build_speed_description() const;
 
 private:


### PR DESCRIPTION
デバッグモードでは敵討ちが困難なので、その辺りのフラグを調整する機構を構想中です (ユニークに殺された思い出状況を意図的に作り出せない。未実装)
通常のセーブデータで再現実験中ですが、レビュアー側でも気付いたことがありましたらご指摘下さい