### PR TITLE
store_type::stock をunique_ptr<ItemEntity[]> からvector<unique_ptr<ItemEntity>> に変えた

### DIFF
--- a/src/floor/floor-town.cpp
+++ b/src/floor/floor-town.cpp
@@ -1,5 +1,3 @@
 #include "floor/floor-town.h"
-#include "system/item-entity.h"
 
-/* The towns [towns_info.size()] */
 std::vector<town_type> towns_info;

--- a/src/floor/floor-town.h
+++ b/src/floor/floor-town.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "store/store-util.h"
-#include "system/angband.h"
 #include <map>
 #include <string>
 #include <vector>
@@ -13,7 +12,7 @@
 enum class StoreSaleType : int;
 struct town_type {
     std::string name;
-    std::map<StoreSaleType, store_type> stores; /* The stores [MAX_STORES] */
+    std::map<StoreSaleType, store_type> stores;
 };
 
 constexpr short VALID_TOWNS = 6; // @details 旧海底都市クエストのマップを除外する. 有効な町に差し替え完了したら不要になるので注意.

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -541,7 +541,7 @@ static void dump_aux_home_museum(PlayerType *player_ptr, FILE *fff)
                 fprintf(fff, _("\n ( %d ページ )\n", "\n ( page %d )\n"), page++);
             }
 
-            const auto item_name = describe_flavor(player_ptr, &store_ptr->stock[i], 0);
+            const auto item_name = describe_flavor(player_ptr, store_ptr->stock[i].get(), 0);
             fprintf(fff, "%c) %s\n", I2A(i % 12), item_name.data());
         }
 
@@ -562,7 +562,7 @@ static void dump_aux_home_museum(PlayerType *player_ptr, FILE *fff)
             fprintf(fff, _("\n ( %d ページ )\n", "\n ( page %d )\n"), page++);
         }
 
-        const auto item_name = describe_flavor(player_ptr, &store_ptr->stock[i], 0);
+        const auto item_name = describe_flavor(player_ptr, store_ptr->stock[i].get(), 0);
         fprintf(fff, "%c) %s\n", I2A(i % 12), item_name.data());
     }
 

--- a/src/io-dump/random-art-info-dumper.cpp
+++ b/src/io-dump/random-art-info-dumper.cpp
@@ -83,25 +83,25 @@ void spoil_random_artifact(PlayerType *player_ptr)
     for (const auto &[tval_list, name] : group_artifact_list) {
         for (auto tval : tval_list) {
             for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-                auto *q_ptr = &player_ptr->inventory_list[i];
-                spoil_random_artifact_aux(player_ptr, q_ptr, tval, ofs);
+                auto &item = player_ptr->inventory_list[i];
+                spoil_random_artifact_aux(player_ptr, &item, tval, ofs);
             }
 
             for (int i = 0; i < INVEN_PACK; i++) {
-                auto *q_ptr = &player_ptr->inventory_list[i];
-                spoil_random_artifact_aux(player_ptr, q_ptr, tval, ofs);
+                auto &item = player_ptr->inventory_list[i];
+                spoil_random_artifact_aux(player_ptr, &item, tval, ofs);
             }
 
             const auto *store_ptr = &towns_info[1].stores[StoreSaleType::HOME];
             for (int i = 0; i < store_ptr->stock_num; i++) {
-                auto *q_ptr = &store_ptr->stock[i];
-                spoil_random_artifact_aux(player_ptr, q_ptr, tval, ofs);
+                auto &item = store_ptr->stock[i];
+                spoil_random_artifact_aux(player_ptr, item.get(), tval, ofs);
             }
 
             store_ptr = &towns_info[1].stores[StoreSaleType::MUSEUM];
             for (int i = 0; i < store_ptr->stock_num; i++) {
-                auto *q_ptr = &store_ptr->stock[i];
-                spoil_random_artifact_aux(player_ptr, q_ptr, tval, ofs);
+                auto &item = store_ptr->stock[i];
+                spoil_random_artifact_aux(player_ptr, item.get(), tval, ofs);
             }
         }
     }

--- a/src/knowledge/knowledge-inventory.cpp
+++ b/src/knowledge/knowledge-inventory.cpp
@@ -260,12 +260,12 @@ static void show_home_equipment_resistances(PlayerType *player_ptr, ItemKindType
     char where[32];
     strcpy(where, _("家", "H "));
     for (int i = 0; i < store_ptr->stock_num; i++) {
-        auto *o_ptr = &store_ptr->stock[i];
-        if (!check_item_knowledge(o_ptr, tval)) {
+        const auto &item = store_ptr->stock[i];
+        if (!check_item_knowledge(item.get(), tval)) {
             continue;
         }
 
-        do_cmd_knowledge_inventory_aux(player_ptr, fff, o_ptr, where);
+        do_cmd_knowledge_inventory_aux(player_ptr, fff, item.get(), where);
         add_res_label(label_number, fff);
     }
 }

--- a/src/knowledge/knowledge-self.cpp
+++ b/src/knowledge/knowledge-self.cpp
@@ -216,7 +216,7 @@ void do_cmd_knowledge_home(PlayerType *player_ptr)
             fprintf(fff, "\n ( %d ページ )\n", x++);
         }
 
-        const auto item_name = describe_flavor(player_ptr, &store.stock[i], 0);
+        const auto item_name = describe_flavor(player_ptr, store.stock[i].get(), 0);
         const int item_length = item_name.length();
         if (item_length <= 80 - 3) {
             fprintf(fff, "%c%s %s\n", I2A(i % 12), close_bracket, item_name.data());
@@ -229,7 +229,7 @@ void do_cmd_knowledge_home(PlayerType *player_ptr)
         fprintf(fff, "%c%s %.*s\n", I2A(i % 12), close_bracket, n, item_name.substr(0, n).data());
         fprintf(fff, "   %.77s\n", item_name.substr(n).data());
 #else
-        const auto item_name = describe_flavor(player_ptr, &store.stock[i], 0);
+        const auto item_name = describe_flavor(player_ptr, store.stock[i].get(), 0);
         fprintf(fff, "%c%s %s\n", I2A(i % 12), close_bracket, item_name.data());
 #endif
     }

--- a/src/load/store-loader.cpp
+++ b/src/load/store-loader.cpp
@@ -30,12 +30,12 @@
 static void home_carry_load(PlayerType *player_ptr, store_type *store_ptr, ItemEntity *o_ptr)
 {
     for (auto i = 0; i < store_ptr->stock_num; i++) {
-        auto *j_ptr = &store_ptr->stock[i];
-        if (!object_similar(j_ptr, o_ptr)) {
+        auto &item = store_ptr->stock[i];
+        if (!object_similar(item.get(), o_ptr)) {
             continue;
         }
 
-        object_absorb(j_ptr, o_ptr);
+        object_absorb(item.get(), o_ptr);
         return;
     }
 
@@ -46,17 +46,17 @@ static void home_carry_load(PlayerType *player_ptr, store_type *store_ptr, ItemE
     const auto value = o_ptr->get_price();
     int slot;
     for (slot = 0; slot < store_ptr->stock_num; slot++) {
-        if (object_sort_comp(player_ptr, o_ptr, value, &store_ptr->stock[slot])) {
+        if (object_sort_comp(player_ptr, o_ptr, value, store_ptr->stock[slot].get())) {
             break;
         }
     }
 
     for (auto i = store_ptr->stock_num; i > slot; i--) {
-        store_ptr->stock[i] = store_ptr->stock[i - 1];
+        *store_ptr->stock[i] = *store_ptr->stock[i - 1];
     }
 
     store_ptr->stock_num++;
-    store_ptr->stock[slot] = *o_ptr;
+    *store_ptr->stock[slot] = *o_ptr;
     chg_virtue(player_ptr, Virtue::SACRIFICE, -1);
 }
 
@@ -113,7 +113,7 @@ static void rd_store(PlayerType *player_ptr, int town_number, StoreSaleType stor
             home_carry_load(player_ptr, store_ptr, &item);
         } else {
             int k = store_ptr->stock_num++;
-            store_ptr->stock[k].copy_from(&item);
+            *store_ptr->stock[k] = item;
         }
     }
 }

--- a/src/main/game-data-initializer.h
+++ b/src/main/game-data-initializer.h
@@ -4,8 +4,6 @@
  * @brief 変愚蛮怒のゲームデータ初期化ヘッダファイル
  */
 
-#include "system/angband.h"
-
 class PlayerType;
 void init_other(PlayerType *player_ptr);
 void init_monsters_alloc();

--- a/src/market/building-initializer.cpp
+++ b/src/market/building-initializer.cpp
@@ -14,6 +14,7 @@
 #include "util/angband-files.h"
 #include <filesystem>
 #include <set>
+#include <utility>
 #include <vector>
 
 /*!
@@ -57,7 +58,12 @@ void init_towns()
             }
 
             store_ptr->stock_size = store_get_stock_max(sst);
-            store_ptr->stock = std::make_unique<ItemEntity[]>(store_ptr->stock_size);
+            std::vector<std::unique_ptr<ItemEntity>> stock;
+            for (auto j = 0; j < store_ptr->stock_size; j++) {
+                stock.push_back(std::make_unique<ItemEntity>());
+            }
+
+            store_ptr->stock = std::move(stock);
             if ((sst == StoreSaleType::BLACK) || (sst == StoreSaleType::HOME) || (sst == StoreSaleType::MUSEUM)) {
                 continue;
             }

--- a/src/player/process-death.cpp
+++ b/src/player/process-death.cpp
@@ -256,13 +256,13 @@ static void home_aware(PlayerType *player_ptr)
     for (size_t i = 1; i < towns_info.size(); i++) {
         auto *store_ptr = &towns_info[i].stores[StoreSaleType::HOME];
         for (auto j = 0; j < store_ptr->stock_num; j++) {
-            auto *o_ptr = &store_ptr->stock[j];
-            if (!o_ptr->is_valid()) {
+            auto &item = store_ptr->stock[j];
+            if (!item->is_valid()) {
                 continue;
             }
 
-            object_aware(player_ptr, o_ptr);
-            o_ptr->mark_as_known();
+            object_aware(player_ptr, item.get());
+            item->mark_as_known();
         }
     }
 }
@@ -311,10 +311,10 @@ static void show_dead_home_items(PlayerType *player_ptr)
         for (int i = 0, k = 0; i < store_ptr->stock_num; k++) {
             term_clear();
             for (int j = 0; (j < 12) && (i < store_ptr->stock_num); j++, i++) {
-                const auto *o_ptr = &store_ptr->stock[i];
+                const auto &item = store_ptr->stock[i];
                 prt(format("%c) ", I2A(j)), j + 2, 4);
-                const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
-                c_put_str(tval_to_attr[enum2i(o_ptr->bi_key.tval())], item_name, j + 2, 7);
+                const auto item_name = describe_flavor(player_ptr, item.get(), 0);
+                c_put_str(tval_to_attr[enum2i(item->bi_key.tval())], item_name, j + 2, 7);
             }
 
             prt(format(_("我が家に置いてあったアイテム ( %d ページ): -続く-", "Your home contains (page %d): -more-"), k + 1), 0, 0);

--- a/src/save/info-writer.cpp
+++ b/src/save/info-writer.cpp
@@ -29,7 +29,7 @@ void wr_store(store_type *store_ptr)
     wr_s16b(store_ptr->bad_buy);
     wr_s32b(store_ptr->last_visit);
     for (int j = 0; j < store_ptr->stock_num; j++) {
-        wr_item(store_ptr->stock[j]);
+        wr_item(*store_ptr->stock[j]);
     }
 }
 

--- a/src/store/black-market.cpp
+++ b/src/store/black-market.cpp
@@ -42,7 +42,7 @@ bool black_market_crap(PlayerType *player_ptr, ItemEntity *o_ptr)
 
         const auto &store = towns_info[player_ptr->town_num].stores[sst];
         for (auto j = 0; j < store.stock_num; j++) {
-            if (o_ptr->bi_id == store.stock[j].bi_id) {
+            if (o_ptr->bi_id == store.stock[j]->bi_id) {
                 return true;
             }
         }

--- a/src/store/home.cpp
+++ b/src/store/home.cpp
@@ -34,10 +34,9 @@ int home_carry(PlayerType *player_ptr, ItemEntity *o_ptr, StoreSaleType store_nu
     }
 
     for (int slot = 0; slot < st_ptr->stock_num; slot++) {
-        ItemEntity *j_ptr;
-        j_ptr = &st_ptr->stock[slot];
-        if (object_similar(j_ptr, o_ptr)) {
-            object_absorb(j_ptr, o_ptr);
+        auto &item_store = st_ptr->stock[slot];
+        if (object_similar(item_store.get(), o_ptr)) {
+            object_absorb(item_store.get(), o_ptr);
             if (store_num != StoreSaleType::HOME) {
                 stack_force_notes = old_stack_force_notes;
                 stack_force_costs = old_stack_force_costs;
@@ -70,17 +69,17 @@ int home_carry(PlayerType *player_ptr, ItemEntity *o_ptr, StoreSaleType store_nu
     const auto value = o_ptr->get_price();
     int slot;
     for (slot = 0; slot < st_ptr->stock_num; slot++) {
-        if (object_sort_comp(player_ptr, o_ptr, value, &st_ptr->stock[slot])) {
+        if (object_sort_comp(player_ptr, o_ptr, value, st_ptr->stock[slot].get())) {
             break;
         }
     }
 
     for (int i = st_ptr->stock_num; i > slot; i--) {
-        st_ptr->stock[i] = st_ptr->stock[i - 1];
+        *st_ptr->stock[i] = *st_ptr->stock[i - 1];
     }
 
     st_ptr->stock_num++;
-    st_ptr->stock[slot] = *o_ptr;
+    *st_ptr->stock[slot] = *o_ptr;
     chg_virtue(player_ptr, Virtue::SACRIFICE, -1);
     (void)combine_and_reorder_home(player_ptr, store_num);
     return slot;
@@ -96,35 +95,34 @@ static bool exe_combine_store_items(ItemEntity *o_ptr, ItemEntity *j_ptr, const 
     st_ptr->stock_num--;
     int k;
     for (k = i; k < st_ptr->stock_num; k++) {
-        st_ptr->stock[k] = st_ptr->stock[k + 1];
+        *st_ptr->stock[k] = *st_ptr->stock[k + 1];
     }
 
-    (&st_ptr->stock[k])->wipe();
+    st_ptr->stock[k]->wipe();
     *combined = true;
     return true;
 }
 
 static void sweep_reorder_store_item(ItemEntity *o_ptr, const int i, bool *combined)
 {
-    for (int j = 0; j < i; j++) {
-        ItemEntity *j_ptr;
-        j_ptr = &st_ptr->stock[j];
-        if (!j_ptr->is_valid()) {
+    for (auto j = 0; j < i; j++) {
+        const auto &item = st_ptr->stock[j];
+        if (!item->is_valid()) {
             continue;
         }
 
-        int max_num = object_similar_part(j_ptr, o_ptr);
-        if (max_num == 0 || j_ptr->number >= max_num) {
+        int max_num = object_similar_part(item.get(), o_ptr);
+        if (max_num == 0 || item->number >= max_num) {
             continue;
         }
 
-        if (exe_combine_store_items(o_ptr, j_ptr, max_num, i, combined)) {
+        if (exe_combine_store_items(o_ptr, item.get(), max_num, i, combined)) {
             break;
         }
 
         ITEM_NUMBER old_num = o_ptr->number;
-        ITEM_NUMBER remain = j_ptr->number + o_ptr->number - max_num;
-        object_absorb(j_ptr, o_ptr);
+        ITEM_NUMBER remain = item->number + o_ptr->number - max_num;
+        object_absorb(item.get(), o_ptr);
         o_ptr->number = remain;
         const auto tval = o_ptr->bi_key.tval();
         if (tval == ItemKindType::ROD) {
@@ -141,17 +139,16 @@ static void sweep_reorder_store_item(ItemEntity *o_ptr, const int i, bool *combi
 
 static void exe_reorder_store_item(PlayerType *player_ptr, bool *flag)
 {
-    for (int i = 0; i < st_ptr->stock_num; i++) {
-        ItemEntity *o_ptr;
-        o_ptr = &st_ptr->stock[i];
-        if (!o_ptr->is_valid()) {
+    for (auto i = 0; i < st_ptr->stock_num; i++) {
+        auto &item = st_ptr->stock[i];
+        if (!item->is_valid()) {
             continue;
         }
 
-        const auto o_value = o_ptr->get_price();
+        const auto o_value = item->get_price();
         int j;
         for (j = 0; j < st_ptr->stock_num; j++) {
-            if (object_sort_comp(player_ptr, o_ptr, o_value, &st_ptr->stock[j])) {
+            if (object_sort_comp(player_ptr, item.get(), o_value, st_ptr->stock[j].get())) {
                 break;
             }
         }
@@ -164,12 +161,12 @@ static void exe_reorder_store_item(PlayerType *player_ptr, bool *flag)
         ItemEntity *j_ptr;
         ItemEntity forge;
         j_ptr = &forge;
-        j_ptr->copy_from(&st_ptr->stock[i]);
-        for (int k = i; k > j; k--) {
-            (&st_ptr->stock[k])->copy_from(&st_ptr->stock[k - 1]);
+        j_ptr->copy_from(st_ptr->stock[i].get());
+        for (auto k = i; k > j; k--) {
+            *st_ptr->stock[k] = *st_ptr->stock[k - 1];
         }
 
-        (&st_ptr->stock[j])->copy_from(j_ptr);
+        *st_ptr->stock[j] = *j_ptr;
     }
 }
 
@@ -181,27 +178,26 @@ static void exe_reorder_store_item(PlayerType *player_ptr, bool *flag)
  */
 bool combine_and_reorder_home(PlayerType *player_ptr, const StoreSaleType store_num)
 {
-    bool old_stack_force_notes = stack_force_notes;
-    bool old_stack_force_costs = stack_force_costs;
-    store_type *old_st_ptr = st_ptr;
+    auto old_stack_force_notes = stack_force_notes;
+    auto old_stack_force_costs = stack_force_costs;
+    auto *old_st_ptr = st_ptr;
     st_ptr = &towns_info[1].stores[store_num];
-    bool flag = false;
+    auto flag = false;
     if (store_num != StoreSaleType::HOME) {
         stack_force_notes = false;
         stack_force_costs = false;
     }
 
-    bool combined = true;
+    auto combined = true;
     while (combined) {
         combined = false;
-        for (int i = st_ptr->stock_num - 1; i > 0; i--) {
-            ItemEntity *o_ptr;
-            o_ptr = &st_ptr->stock[i];
-            if (!o_ptr->is_valid()) {
+        for (auto i = st_ptr->stock_num - 1; i > 0; i--) {
+            auto &item = st_ptr->stock[i];
+            if (!item->is_valid()) {
                 continue;
             }
 
-            sweep_reorder_store_item(o_ptr, i, &combined);
+            sweep_reorder_store_item(item.get(), i, &combined);
         }
 
         flag |= combined;

--- a/src/store/museum.cpp
+++ b/src/store/museum.cpp
@@ -32,15 +32,15 @@ void museum_remove_object(PlayerType *player_ptr)
     }
 
     const short item_num = *item_num_opt + store_top;
-    auto *o_ptr = &st_ptr->stock[item_num];
-    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    const auto &item = st_ptr->stock[item_num];
+    const auto item_name = describe_flavor(player_ptr, item.get(), 0);
     msg_print(_("展示をやめさせたアイテムは二度と見ることはできません！", "Once removed from the Museum, an item will be gone forever!"));
     if (!input_check(format(_("本当に%sの展示をやめさせますか？", "Really order to remove %s from the Museum? "), item_name.data()))) {
         return;
     }
 
     msg_format(_("%sの展示をやめさせた。", "You ordered to remove %s."), item_name.data());
-    store_item_increase(item_num, -o_ptr->number);
+    store_item_increase(item_num, -item->number);
     store_item_optimize(item_num);
     (void)combine_and_reorder_home(player_ptr, StoreSaleType::MUSEUM);
     if (st_ptr->stock_num == 0) {

--- a/src/store/pricing.cpp
+++ b/src/store/pricing.cpp
@@ -31,7 +31,7 @@
  * "greed" value is always something (?).
  * </pre>
  */
-PRICE price_item(PlayerType *player_ptr, ItemEntity *o_ptr, int greed, bool flip, StoreSaleType store_num)
+int price_item(PlayerType *player_ptr, const ItemEntity *o_ptr, int greed, bool flip, StoreSaleType store_num)
 {
     auto price = o_ptr->get_price();
     if (price <= 0) {

--- a/src/store/pricing.h
+++ b/src/store/pricing.h
@@ -1,10 +1,8 @@
 #pragma once
 
-#include "system/angband.h"
-
 #define LOW_PRICE_THRESHOLD 10L
 
 enum class StoreSaleType;
 class ItemEntity;
 class PlayerType;
-PRICE price_item(PlayerType *player_ptr, ItemEntity *o_ptr, int greed, bool flip, StoreSaleType store_num);
+int price_item(PlayerType *player_ptr, const ItemEntity *o_ptr, int greed, bool flip, StoreSaleType store_num);

--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -199,62 +199,59 @@ void store_purchase(PlayerType *player_ptr, StoreSaleType store_num)
     }
 
     const short item_num = *item_num_opt + store_top;
-    auto *o_ptr = &st_ptr->stock[item_num];
+    auto &item_store = st_ptr->stock[item_num];
 
     ITEM_NUMBER amt = 1;
-    ItemEntity forge;
-    auto *j_ptr = &forge;
-    j_ptr->copy_from(o_ptr);
+    ItemEntity item = *item_store;
 
     /*
      * If a rod or wand, allocate total maximum timeouts or charges
      * between those purchased and left on the shelf.
      */
-    reduce_charges(j_ptr, o_ptr->number - amt);
-    j_ptr->number = amt;
-    if (!check_store_item_to_inventory(player_ptr, j_ptr)) {
+    reduce_charges(&item, item_store->number - amt);
+    item.number = amt;
+    if (!check_store_item_to_inventory(player_ptr, &item)) {
         msg_print(_("そんなにアイテムを持てない。", "You cannot carry that many different items."));
         return;
     }
 
-    const auto best = price_item(player_ptr, j_ptr, ot_ptr->inflate, false, store_num);
-    if (o_ptr->number > 1) {
+    const auto best = price_item(player_ptr, &item, ot_ptr->inflate, false, store_num);
+    if (item_store->number > 1) {
         if (store_num != StoreSaleType::HOME) {
             msg_format(_("一つにつき $%dです。", "That costs %d gold per item."), best);
         }
 
-        amt = input_quantity(o_ptr->number);
+        amt = input_quantity(item_store->number);
         if (amt <= 0) {
             return;
         }
     }
 
-    j_ptr = &forge;
-    j_ptr->copy_from(o_ptr);
+    item = *item_store;
 
     /*
      * If a rod or wand, allocate total maximum timeouts or charges
      * between those purchased and left on the shelf.
      */
-    reduce_charges(j_ptr, o_ptr->number - amt);
-    j_ptr->number = amt;
-    if (!check_store_item_to_inventory(player_ptr, j_ptr)) {
+    reduce_charges(&item, item_store->number - amt);
+    item.number = amt;
+    if (!check_store_item_to_inventory(player_ptr, &item)) {
         msg_print(_("ザックにそのアイテムを入れる隙間がない。", "You cannot carry that many items."));
         return;
     }
 
     if (store_num == StoreSaleType::HOME) {
-        take_item_from_home(player_ptr, o_ptr, j_ptr, item_num);
+        take_item_from_home(player_ptr, item_store.get(), &item, item_num);
         return;
     }
 
     COMMAND_CODE item_new;
-    const auto purchased_item_name = describe_flavor(player_ptr, j_ptr, 0);
+    const auto purchased_item_name = describe_flavor(player_ptr, &item, 0);
     msg_format(_("%s(%c)を購入する。", "Buying %s (%c)."), purchased_item_name.data(), I2A(item_num));
     msg_print(nullptr);
 
     const auto &world = AngbandWorld::get_instance();
-    auto res = prompt_to_buy(player_ptr, j_ptr, store_num);
+    auto res = prompt_to_buy(player_ptr, &item, store_num);
     if (st_ptr->store_open >= world.game_turn) {
         return;
     }
@@ -273,14 +270,14 @@ void store_purchase(PlayerType *player_ptr, StoreSaleType store_num)
     if (store_num == StoreSaleType::BLACK) {
         chg_virtue(player_ptr, Virtue::JUSTICE, -1);
     }
-    if ((o_ptr->bi_key.tval() == ItemKindType::BOTTLE) && (store_num != StoreSaleType::HOME)) {
+    if ((item_store->bi_key.tval() == ItemKindType::BOTTLE) && (store_num != StoreSaleType::HOME)) {
         chg_virtue(player_ptr, Virtue::NATURE, -1);
     }
 
     sound(SOUND_BUY);
     player_ptr->au -= price;
     store_prt_gold(player_ptr);
-    object_aware(player_ptr, j_ptr);
+    object_aware(player_ptr, &item);
 
     msg_format(_("%sを $%ldで購入しました。", "You bought %s for %ld gold."), purchased_item_name.data(), (long)price);
     angband_strcpy(record_o_name, purchased_item_name, MAX_NLEN);
@@ -290,26 +287,26 @@ void store_purchase(PlayerType *player_ptr, StoreSaleType store_num)
         exe_write_diary(floor, DiaryKind::BUY, 0, purchased_item_name);
     }
 
-    const auto diary_item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
-    if (record_rand_art && o_ptr->is_random_artifact()) {
+    const auto diary_item_name = describe_flavor(player_ptr, item_store.get(), OD_NAME_ONLY);
+    if (record_rand_art && item_store->is_random_artifact()) {
         exe_write_diary(floor, DiaryKind::ART, 0, diary_item_name);
     }
 
-    j_ptr->inscription.reset();
-    j_ptr->feeling = FEEL_NONE;
-    j_ptr->ident &= ~(IDENT_STORE);
+    item.inscription.reset();
+    item.feeling = FEEL_NONE;
+    item.ident &= ~(IDENT_STORE);
 
-    const auto idx = find_autopick_list(player_ptr, j_ptr);
-    auto_inscribe_item(j_ptr, idx);
+    const auto idx = find_autopick_list(player_ptr, &item);
+    auto_inscribe_item(&item, idx);
 
-    item_new = store_item_to_inventory(player_ptr, j_ptr);
+    item_new = store_item_to_inventory(player_ptr, &item);
     handle_stuff(player_ptr);
 
     const auto got_item_name = describe_flavor(player_ptr, &player_ptr->inventory_list[item_new], 0);
     msg_format(_("%s(%c)を手に入れた。", "You have %s (%c)."), got_item_name.data(), index_to_label(item_new));
 
-    if (o_ptr->is_wand_rod()) {
-        o_ptr->pval -= j_ptr->pval;
+    if (item_store->is_wand_rod()) {
+        item_store->pval -= item.pval;
     }
 
     i = st_ptr->stock_num;

--- a/src/store/store-util.h
+++ b/src/store/store-util.h
@@ -27,7 +27,6 @@ constexpr auto STORE_SALE_TYPE_LIST = EnumRange(StoreSaleType::GENERAL, StoreSal
 /*!
  * @brief 店舗の情報構造体
  */
-class ItemEntity;
 struct store_type {
     store_type() = default;
     store_type(const store_type &) = delete;
@@ -46,8 +45,8 @@ struct store_type {
     std::vector<short> regular{}; //!< Table -- Legal regular item kinds
     std::vector<short> table{}; //!< Table -- Legal item kinds
     short stock_num{}; //!< Stock -- Number of entries
-    short stock_size{}; //!< Stock -- Total Size of Array
-    std::unique_ptr<ItemEntity[]> stock; //!< Stock -- Actual stock items
+    short stock_size{}; //!< @todo vectorのサイズを取れば良くなったので後ほど削除する.
+    std::vector<std::unique_ptr<ItemEntity>> stock{}; //!< Stock -- Actual stock items
 };
 
 extern store_type *st_ptr;

--- a/src/store/store-util.h
+++ b/src/store/store-util.h
@@ -1,10 +1,8 @@
 #pragma once
 
-#include "system/angband.h"
-
+#include "system/item-entity.h"
 #include "util/enum-converter.h"
 #include "util/enum-range.h"
-
 #include <memory>
 #include <vector>
 
@@ -24,41 +22,40 @@ enum class StoreSaleType : int {
     MAX
 };
 constexpr int MAX_STORES = enum2i(StoreSaleType::MAX); /*!< 店舗の種類最大数 / Total number of stores (see "store.c", etc) */
-
 constexpr auto STORE_SALE_TYPE_LIST = EnumRange(StoreSaleType::GENERAL, StoreSaleType::MAX);
-
-using store_k_idx = std::vector<short>;
 
 /*!
  * @brief 店舗の情報構造体
  */
 class ItemEntity;
 struct store_type {
-    byte type{}; //!< Store type
-    byte owner{}; //!< Owner index
-    byte extra{}; //!< Unused for now
-    int16_t insult_cur{}; //!< Insult counter
-    int16_t good_buy{}; //!< Number of "good" buys (3.0.0で廃止)
-    int16_t bad_buy{}; //!< Number of "bad" buys (3.0.0で廃止)
-    int32_t store_open{}; //!< Closed until this turn
-    int32_t last_visit{}; //!< Last visited on this turn
-    store_k_idx regular{}; //!< Table -- Legal regular item kinds
-    store_k_idx table{}; //!< Table -- Legal item kinds
-    int16_t stock_num{}; //!< Stock -- Number of entries
-    int16_t stock_size{}; //!< Stock -- Total Size of Array
-    std::unique_ptr<ItemEntity[]> stock; //!< Stock -- Actual stock items
-
     store_type() = default;
     store_type(const store_type &) = delete;
+    store_type(store_type &&) = delete;
     store_type &operator=(const store_type &) = delete;
+    store_type &operator=(store_type &&) = delete;
+
+    uint8_t type{}; //!< Store type
+    uint8_t owner{}; //!< Owner index
+    uint8_t extra{}; //!< Unused for now
+    short insult_cur{}; //!< Insult counter
+    short good_buy{}; //!< Number of "good" buys (3.0.0で廃止)
+    short bad_buy{}; //!< Number of "bad" buys (3.0.0で廃止)
+    int store_open{}; //!< Closed until this turn
+    int last_visit{}; //!< Last visited on this turn
+    std::vector<short> regular{}; //!< Table -- Legal regular item kinds
+    std::vector<short> table{}; //!< Table -- Legal item kinds
+    short stock_num{}; //!< Stock -- Number of entries
+    short stock_size{}; //!< Stock -- Total Size of Array
+    std::unique_ptr<ItemEntity[]> stock; //!< Stock -- Actual stock items
 };
 
 extern store_type *st_ptr;
 
 class PlayerType;
 void store_delete();
-std::vector<PARAMETER_VALUE> store_same_magic_device_pvals(ItemEntity *j_ptr);
-void store_item_increase(INVENTORY_IDX i_idx, ITEM_NUMBER num);
-void store_item_optimize(INVENTORY_IDX i_idx);
+std::vector<short> store_same_magic_device_pvals(ItemEntity *j_ptr);
+void store_item_increase(short i_idx, int item_num);
+void store_item_optimize(short i_idx);
 int store_carry(ItemEntity *o_ptr);
 bool store_object_similar(ItemEntity *o_ptr, ItemEntity *j_ptr);

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -104,7 +104,6 @@ static int check_free_space(StoreSaleType store_num)
  */
 int store_check_num(ItemEntity *o_ptr, StoreSaleType store_num)
 {
-    ItemEntity *j_ptr;
     if ((store_num == StoreSaleType::HOME) || (store_num == StoreSaleType::MUSEUM)) {
         bool old_stack_force_notes = stack_force_notes;
         bool old_stack_force_costs = stack_force_costs;
@@ -113,9 +112,9 @@ int store_check_num(ItemEntity *o_ptr, StoreSaleType store_num)
             stack_force_costs = false;
         }
 
-        for (int i = 0; i < st_ptr->stock_num; i++) {
-            j_ptr = &st_ptr->stock[i];
-            if (!object_similar(j_ptr, o_ptr)) {
+        for (auto i = 0; i < st_ptr->stock_num; i++) {
+            auto &item = st_ptr->stock[i];
+            if (!object_similar(item.get(), o_ptr)) {
                 continue;
             }
 
@@ -132,9 +131,9 @@ int store_check_num(ItemEntity *o_ptr, StoreSaleType store_num)
             stack_force_costs = old_stack_force_costs;
         }
     } else {
-        for (int i = 0; i < st_ptr->stock_num; i++) {
-            j_ptr = &st_ptr->stock[i];
-            if (store_object_similar(j_ptr, o_ptr)) {
+        for (auto i = 0; i < st_ptr->stock_num; i++) {
+            auto &item = st_ptr->stock[i];
+            if (store_object_similar(item.get(), o_ptr)) {
                 return -1;
             }
         }
@@ -228,15 +227,15 @@ void store_examine(PlayerType *player_ptr, StoreSaleType store_num)
     }
 
     const auto item_num = *item_num_opt + store_top;
-    auto *o_ptr = &st_ptr->stock[item_num];
-    if (!o_ptr->is_fully_known()) {
+    auto &item = st_ptr->stock[item_num];
+    if (!item->is_fully_known()) {
         msg_print(_("このアイテムについて特に知っていることはない。", "You have no special knowledge about that item."));
         return;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, item.get(), 0);
     msg_format(_("%sを調べている...", "Examining %s..."), item_name.data());
-    if (!screen_object(player_ptr, o_ptr, SCROBJ_FORCE_DETAIL)) {
+    if (!screen_object(player_ptr, item.get(), SCROBJ_FORCE_DETAIL)) {
         msg_print(_("特に変わったところはないようだ。", "You see nothing special."));
     }
 }
@@ -285,15 +284,14 @@ void store_shuffle(PlayerType *player_ptr, StoreSaleType store_num)
     st_ptr->store_open = 0;
     st_ptr->good_buy = 0;
     st_ptr->bad_buy = 0;
-    for (int i = 0; i < st_ptr->stock_num; i++) {
-        ItemEntity *o_ptr;
-        o_ptr = &st_ptr->stock[i];
-        if (o_ptr->is_fixed_or_random_artifact()) {
+    for (auto i = 0; i < st_ptr->stock_num; i++) {
+        auto &item = st_ptr->stock[i];
+        if (item->is_fixed_or_random_artifact()) {
             continue;
         }
 
-        o_ptr->discount = 50;
-        o_ptr->inscription.emplace(_("売出中", "on sale"));
+        item->discount = 50;
+        item->inscription.emplace(_("売出中", "on sale"));
     }
 }
 
@@ -401,9 +399,9 @@ void store_maintenance(PlayerType *player_ptr, int town_num, StoreSaleType store
     st_ptr->insult_cur = 0;
     if (store_num == StoreSaleType::BLACK) {
         for (INVENTORY_IDX j = st_ptr->stock_num - 1; j >= 0; j--) {
-            auto *o_ptr = &st_ptr->stock[j];
-            if (black_market_crap(player_ptr, o_ptr)) {
-                store_item_increase(j, 0 - o_ptr->number);
+            auto &item = st_ptr->stock[j];
+            if (black_market_crap(player_ptr, item.get())) {
+                store_item_increase(j, 0 - item->number);
                 store_item_optimize(j);
             }
         }
@@ -502,6 +500,6 @@ void store_init(int town_num, StoreSaleType store_num)
     st_ptr->stock_num = 0;
     st_ptr->last_visit = -10L * TURNS_PER_TICK * STORE_TICKS;
     for (int k = 0; k < st_ptr->stock_size; k++) {
-        (&st_ptr->stock[k])->wipe();
+        st_ptr->stock[k]->wipe();
     }
 }

--- a/src/view/display-store.cpp
+++ b/src/view/display-store.cpp
@@ -41,8 +41,7 @@ void store_prt_gold(PlayerType *player_ptr)
  */
 void display_entry(PlayerType *player_ptr, int pos, StoreSaleType store_num)
 {
-    ItemEntity *o_ptr;
-    o_ptr = &st_ptr->stock[pos];
+    const auto &item = st_ptr->stock[pos];
     int i = (pos % store_bottom);
 
     /* Label it, clear the line --(-- */
@@ -50,7 +49,7 @@ void display_entry(PlayerType *player_ptr, int pos, StoreSaleType store_num)
 
     int cur_col = 3;
     if (show_item_graph) {
-        term_queue_bigchar(cur_col, i + 6, { o_ptr->get_symbol(), {} });
+        term_queue_bigchar(cur_col, i + 6, { item->get_symbol(), {} });
         if (use_bigtile) {
             cur_col++;
         }
@@ -65,11 +64,11 @@ void display_entry(PlayerType *player_ptr, int pos, StoreSaleType store_num)
             maxwid -= 10;
         }
 
-        const auto item_name = describe_flavor(player_ptr, o_ptr, 0, maxwid);
-        c_put_str(tval_to_attr[enum2i(o_ptr->bi_key.tval())], item_name, i + 6, cur_col);
+        const auto item_name = describe_flavor(player_ptr, item.get(), 0, maxwid);
+        c_put_str(tval_to_attr[enum2i(item->bi_key.tval())], item_name, i + 6, cur_col);
 
         if (show_weights) {
-            WEIGHT wgt = o_ptr->weight;
+            const auto wgt = item->weight;
             put_str(format(_("%3d.%1d kg", "%3d.%d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10)), i + 6, _(67, 68));
         }
 
@@ -81,15 +80,15 @@ void display_entry(PlayerType *player_ptr, int pos, StoreSaleType store_num)
         maxwid -= 7;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, 0, maxwid);
-    c_put_str(tval_to_attr[enum2i(o_ptr->bi_key.tval())], item_name, i + 6, cur_col);
+    const auto item_name = describe_flavor(player_ptr, item.get(), 0, maxwid);
+    c_put_str(tval_to_attr[enum2i(item->bi_key.tval())], item_name, i + 6, cur_col);
 
     if (show_weights) {
-        int wgt = o_ptr->weight;
+        const auto wgt = item->weight;
         put_str(format("%3d.%1d", _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10)), i + 6, _(60, 61));
     }
 
-    const auto price = price_item(player_ptr, o_ptr, ot_ptr->inflate, false, store_num);
+    const auto price = price_item(player_ptr, item.get(), ot_ptr->inflate, false, store_num);
     put_str(format("%9ld  ", (long)price), i + 6, 68);
 }
 


### PR DESCRIPTION
20数ヶ所ほどstocker\[i\].get() が発生していますが、次以降のPRで調整します
買った時のストック減少 (商品がなくなる/減る)・売った時のストック増加 (商品が追加される/増える)・買い尽くしの後に補充される動作をチェック済です
ご確認下さい