### PR TITLE
check_magic_eater_spell_repeat() をmagic_eater_data_type のメソッドへ繰り込んだ

### DIFF
--- a/src/cmd-building/cmd-inn.cpp
+++ b/src/cmd-building/cmd-inn.cpp
@@ -5,6 +5,7 @@
 #include "io/write-diary.h"
 #include "market/bounty.h"
 #include "market/building-actions-table.h"
+#include "object/tval-types.h"
 #include "player-base/player-class.h"
 #include "player-base/player-race.h"
 #include "player-info/magic-eater-data-type.h"

--- a/src/cmd-building/cmd-inn.cpp
+++ b/src/cmd-building/cmd-inn.cpp
@@ -124,7 +124,7 @@ static void back_to_health(PlayerType *player_ptr)
  */
 static void charge_magic_eating_energy(PlayerType *player_ptr)
 {
-    auto magic_eater_data = PlayerClass(player_ptr).get_specific_data<magic_eater_data_type>();
+    auto magic_eater_data = PlayerClass(player_ptr).get_specific_data<MagicEaterDataList>();
     if (!magic_eater_data) {
         return;
     }

--- a/src/cmd-item/cmd-magiceat.cpp
+++ b/src/cmd-item/cmd-magiceat.cpp
@@ -84,52 +84,6 @@
 #include <algorithm>
 #include <optional>
 
-static std::optional<BaseitemKey> check_magic_eater_spell_repeat(magic_eater_data_type *magic_eater_data)
-{
-    COMMAND_CODE sn;
-    if (!repeat_pull(&sn)) {
-        return std::nullopt;
-    }
-
-    auto tval = ItemKindType::NONE;
-    if (EATER_STAFF_BASE <= sn && sn < EATER_STAFF_BASE + EATER_ITEM_GROUP_SIZE) {
-        tval = ItemKindType::STAFF;
-    } else if (EATER_WAND_BASE <= sn && sn < EATER_WAND_BASE + EATER_ITEM_GROUP_SIZE) {
-        tval = ItemKindType::WAND;
-    } else if (EATER_ROD_BASE <= sn && sn < EATER_ROD_BASE + EATER_ITEM_GROUP_SIZE) {
-        tval = ItemKindType::ROD;
-    }
-
-    const auto &item_group = magic_eater_data->get_item_group(tval);
-    auto sval = sn % EATER_ITEM_GROUP_SIZE;
-    if (sval >= static_cast<int>(item_group.size())) {
-        return std::nullopt;
-    }
-
-    auto &item = item_group[sval];
-    /* Verify the spell */
-    switch (tval) {
-    case ItemKindType::ROD: {
-        const auto &baseitems = BaseitemList::get_instance();
-        const auto &baseitem = baseitems.lookup_baseitem({ ItemKindType::ROD, sval });
-        if (item.charge <= baseitem.pval * (item.count - 1) * EATER_ROD_CHARGE) {
-            return BaseitemKey(tval, sval);
-        }
-
-        return std::nullopt;
-    }
-    case ItemKindType::STAFF:
-    case ItemKindType::WAND:
-        if (item.charge >= EATER_CHARGE) {
-            return BaseitemKey(tval, sval);
-        }
-
-        return std::nullopt;
-    default:
-        return std::nullopt;
-    }
-}
-
 /*!
  * @brief 魔道具術師の取り込んだ魔力一覧から選択/閲覧する /
  * @param only_browse 閲覧するだけならばTRUE
@@ -141,9 +95,8 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
     auto tval = ItemKindType::NONE;
     int menu_line = (use_menu ? 1 : 0);
 
-    auto magic_eater_data = PlayerClass(player_ptr).get_specific_data<magic_eater_data_type>();
-
-    if (auto result = check_magic_eater_spell_repeat(magic_eater_data.get());
+    const auto magic_eater_data = PlayerClass(player_ptr).get_specific_data<magic_eater_data_type>();
+    if (const auto result = magic_eater_data->check_magic_eater_spell_repeat();
         result) {
         return result;
     }

--- a/src/cmd-item/cmd-magiceat.cpp
+++ b/src/cmd-item/cmd-magiceat.cpp
@@ -95,7 +95,7 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
     auto tval = ItemKindType::NONE;
     int menu_line = (use_menu ? 1 : 0);
 
-    const auto magic_eater_data = PlayerClass(player_ptr).get_specific_data<magic_eater_data_type>();
+    const auto magic_eater_data = PlayerClass(player_ptr).get_specific_data<MagicEaterDataList>();
     if (const auto result = magic_eater_data->check_magic_eater_spell_repeat();
         result) {
         return result;
@@ -584,7 +584,7 @@ bool do_cmd_magic_eater(PlayerType *player_ptr, bool only_browse, bool powerful)
         }
     }
 
-    auto magic_eater_data = PlayerClass(player_ptr).get_specific_data<magic_eater_data_type>();
+    auto magic_eater_data = PlayerClass(player_ptr).get_specific_data<MagicEaterDataList>();
     const auto sval = bi_key->sval();
     if (!sval) {
         return false;

--- a/src/hpmp/hp-mp-regenerator.cpp
+++ b/src/hpmp/hp-mp-regenerator.cpp
@@ -124,7 +124,7 @@ void regenmana(PlayerType *player_ptr, MANA_POINT upkeep_factor, MANA_POINT rege
  */
 void regenmagic(PlayerType *player_ptr, int regen_amount)
 {
-    auto magic_eater_data = PlayerClass(player_ptr).get_specific_data<magic_eater_data_type>();
+    auto magic_eater_data = PlayerClass(player_ptr).get_specific_data<MagicEaterDataList>();
     if (!magic_eater_data) {
         return;
     }

--- a/src/io-dump/special-class-dump.cpp
+++ b/src/io-dump/special-class-dump.cpp
@@ -34,7 +34,7 @@ struct learnt_spell_table {
  */
 static void dump_magic_eater(PlayerType *player_ptr, FILE *fff)
 {
-    auto magic_eater_data = PlayerClass(player_ptr).get_specific_data<magic_eater_data_type>();
+    auto magic_eater_data = PlayerClass(player_ptr).get_specific_data<MagicEaterDataList>();
     if (!magic_eater_data) {
         return;
     }

--- a/src/load/player-class-specific-data-loader.cpp
+++ b/src/load/player-class-specific-data-loader.cpp
@@ -91,7 +91,7 @@ void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<bluemage_data_typ
     }
 }
 
-void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<magic_eater_data_type> &magic_eater_data) const
+void PlayerClassSpecificDataLoader::operator()(std::shared_ptr<MagicEaterDataList> &magic_eater_data) const
 {
     if (loading_savefile_version_is_older_than(9)) {
         auto [magic_num1, magic_num2] = load_old_savfile_magic_num();

--- a/src/load/player-class-specific-data-loader.h
+++ b/src/load/player-class-specific-data-loader.h
@@ -7,7 +7,7 @@ struct no_class_specific_data;
 struct smith_data_type;
 struct force_trainer_data_type;
 struct bluemage_data_type;
-struct magic_eater_data_type;
+class MagicEaterDataList;
 struct bard_data_type;
 struct mane_data_type;
 class SniperData;
@@ -23,7 +23,7 @@ public:
     void operator()(std::shared_ptr<smith_data_type> &smith_data) const;
     void operator()(std::shared_ptr<force_trainer_data_type> &force_trainer_data) const;
     void operator()(std::shared_ptr<bluemage_data_type> &bluemage_data) const;
-    void operator()(std::shared_ptr<magic_eater_data_type> &magic_eater_data) const;
+    void operator()(std::shared_ptr<MagicEaterDataList> &magic_eater_data) const;
     void operator()(std::shared_ptr<bard_data_type> &bird_data) const;
     void operator()(std::shared_ptr<mane_data_type> &mane_data) const;
     void operator()(std::shared_ptr<SniperData> &sniper_data) const;

--- a/src/mind/mind-magic-eater.cpp
+++ b/src/mind/mind-magic-eater.cpp
@@ -45,7 +45,7 @@ bool import_magic_device(PlayerType *player_ptr)
         return false;
     }
 
-    auto magic_eater_data = PlayerClass(player_ptr).get_specific_data<magic_eater_data_type>();
+    auto magic_eater_data = PlayerClass(player_ptr).get_specific_data<MagicEaterDataList>();
     const auto tval = bi_key.tval();
     auto &target_item = magic_eater_data->get_item_group(tval)[*bi_key.sval()];
     auto pval = o_ptr->pval;

--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -498,7 +498,7 @@ void PlayerClass::init_specific_data()
         this->player_ptr->class_specific_data = std::make_shared<bluemage_data_type>();
         break;
     case PlayerClassType::MAGIC_EATER:
-        this->player_ptr->class_specific_data = std::make_shared<magic_eater_data_type>();
+        this->player_ptr->class_specific_data = std::make_shared<MagicEaterDataList>();
         break;
     case PlayerClassType::BARD:
         this->player_ptr->class_specific_data = std::make_shared<bard_data_type>();

--- a/src/player-info/class-specific-data.h
+++ b/src/player-info/class-specific-data.h
@@ -8,7 +8,7 @@ struct no_class_specific_data {
 struct smith_data_type;
 struct force_trainer_data_type;
 struct bluemage_data_type;
-struct magic_eater_data_type;
+class MagicEaterDataList;
 struct bard_data_type;
 struct mane_data_type;
 class SniperData;
@@ -23,7 +23,7 @@ using ClassSpecificData = std::variant<
     std::shared_ptr<smith_data_type>,
     std::shared_ptr<force_trainer_data_type>,
     std::shared_ptr<bluemage_data_type>,
-    std::shared_ptr<magic_eater_data_type>,
+    std::shared_ptr<MagicEaterDataList>,
     std::shared_ptr<bard_data_type>,
     std::shared_ptr<mane_data_type>,
     std::shared_ptr<SniperData>,

--- a/src/player-info/magic-eater-data-type.cpp
+++ b/src/player-info/magic-eater-data-type.cpp
@@ -1,7 +1,9 @@
 #include "player-info/magic-eater-data-type.h"
+#include "io/command-repeater.h"
 #include "sv-definition/sv-rod-types.h"
 #include "sv-definition/sv-staff-types.h"
 #include "sv-definition/sv-wand-types.h"
+#include "system/baseitem-info.h"
 
 magic_eater_data_type::magic_eater_data_type()
     : staves(SV_STAFF_MAX)
@@ -17,6 +19,67 @@ magic_eater_data_type::magic_eater_data_type()
  * @return tvalで指定した種類の取り込んだ魔道具のデータ配列の参照
  */
 std::vector<magic_eater_data_type::magic_type> &magic_eater_data_type::get_item_group(ItemKindType tval)
+{
+    switch (tval) {
+    case ItemKindType::STAFF:
+        return this->staves;
+    case ItemKindType::WAND:
+        return this->wands;
+    case ItemKindType::ROD:
+        return this->rods;
+    default:
+        // ダミーデータ。通常使用されることはない。
+        return magic_eater_data_type::none;
+    }
+}
+
+std::optional<BaseitemKey> magic_eater_data_type::check_magic_eater_spell_repeat() const
+{
+    short sn;
+    if (!repeat_pull(&sn)) {
+        return std::nullopt;
+    }
+
+    auto tval = ItemKindType::NONE;
+    if (EATER_STAFF_BASE <= sn && sn < EATER_STAFF_BASE + EATER_ITEM_GROUP_SIZE) {
+        tval = ItemKindType::STAFF;
+    } else if (EATER_WAND_BASE <= sn && sn < EATER_WAND_BASE + EATER_ITEM_GROUP_SIZE) {
+        tval = ItemKindType::WAND;
+    } else if (EATER_ROD_BASE <= sn && sn < EATER_ROD_BASE + EATER_ITEM_GROUP_SIZE) {
+        tval = ItemKindType::ROD;
+    }
+
+    const auto &item_group = this->get_item_group(tval);
+    auto sval = sn % EATER_ITEM_GROUP_SIZE;
+    if (sval >= static_cast<int>(item_group.size())) {
+        return std::nullopt;
+    }
+
+    auto &item = item_group[sval];
+    /* Verify the spell */
+    switch (tval) {
+    case ItemKindType::ROD: {
+        const auto &baseitems = BaseitemList::get_instance();
+        const auto &baseitem = baseitems.lookup_baseitem({ ItemKindType::ROD, sval });
+        if (item.charge <= baseitem.pval * (item.count - 1) * EATER_ROD_CHARGE) {
+            return BaseitemKey(tval, sval);
+        }
+
+        return std::nullopt;
+    }
+    case ItemKindType::STAFF:
+    case ItemKindType::WAND:
+        if (item.charge >= EATER_CHARGE) {
+            return BaseitemKey(tval, sval);
+        }
+
+        return std::nullopt;
+    default:
+        return std::nullopt;
+    }
+}
+
+const std::vector<magic_eater_data_type::magic_type> &magic_eater_data_type::get_item_group(ItemKindType tval) const
 {
     switch (tval) {
     case ItemKindType::STAFF:

--- a/src/player-info/magic-eater-data-type.cpp
+++ b/src/player-info/magic-eater-data-type.cpp
@@ -5,7 +5,7 @@
 #include "sv-definition/sv-wand-types.h"
 #include "system/baseitem-info.h"
 
-magic_eater_data_type::magic_eater_data_type()
+MagicEaterDataList::MagicEaterDataList()
     : staves(SV_STAFF_MAX)
     , wands(SV_WAND_MAX)
     , rods(SV_ROD_MAX)
@@ -18,7 +18,7 @@ magic_eater_data_type::magic_eater_data_type()
  * @param tval 魔道具の種類(TV_STAFF/TV_WAND/TV_ROD)を指定する
  * @return tvalで指定した種類の取り込んだ魔道具のデータ配列の参照
  */
-std::vector<magic_eater_data_type::magic_type> &magic_eater_data_type::get_item_group(ItemKindType tval)
+std::vector<MagicEaterDataList::MagicEaterDatum> &MagicEaterDataList::get_item_group(ItemKindType tval)
 {
     switch (tval) {
     case ItemKindType::STAFF:
@@ -29,11 +29,11 @@ std::vector<magic_eater_data_type::magic_type> &magic_eater_data_type::get_item_
         return this->rods;
     default:
         // ダミーデータ。通常使用されることはない。
-        return magic_eater_data_type::none;
+        return MagicEaterDataList::none;
     }
 }
 
-std::optional<BaseitemKey> magic_eater_data_type::check_magic_eater_spell_repeat() const
+std::optional<BaseitemKey> MagicEaterDataList::check_magic_eater_spell_repeat() const
 {
     short sn;
     if (!repeat_pull(&sn)) {
@@ -79,7 +79,7 @@ std::optional<BaseitemKey> magic_eater_data_type::check_magic_eater_spell_repeat
     }
 }
 
-const std::vector<magic_eater_data_type::magic_type> &magic_eater_data_type::get_item_group(ItemKindType tval) const
+const std::vector<MagicEaterDataList::MagicEaterDatum> &MagicEaterDataList::get_item_group(ItemKindType tval) const
 {
     switch (tval) {
     case ItemKindType::STAFF:
@@ -90,6 +90,6 @@ const std::vector<magic_eater_data_type::magic_type> &magic_eater_data_type::get
         return this->rods;
     default:
         // ダミーデータ。通常使用されることはない。
-        return magic_eater_data_type::none;
+        return MagicEaterDataList::none;
     }
 }

--- a/src/player-info/magic-eater-data-type.h
+++ b/src/player-info/magic-eater-data-type.h
@@ -1,20 +1,22 @@
 #pragma once
 
-#include "system/angband.h"
-
-#include "object/tval-types.h"
+#include <cstdint>
+#include <optional>
+#include <vector>
 
 inline constexpr int EATER_ITEM_GROUP_SIZE = 256; //!< 魔道具1種あたりの最大数
 inline constexpr int EATER_STAFF_BASE = 0; //!< 杖の開始番号(繰り返しコマンド用)
 inline constexpr int EATER_WAND_BASE = EATER_STAFF_BASE + EATER_ITEM_GROUP_SIZE; //!< 魔法棒の開始番号(繰り返しコマンド用)
 inline constexpr int EATER_ROD_BASE = EATER_WAND_BASE + EATER_ITEM_GROUP_SIZE; //!< ロッドの開始番号(繰り返しコマンド用)
-inline constexpr int32_t EATER_CHARGE = 0x10000L;
-inline constexpr int32_t EATER_ROD_CHARGE = 0x10L;
+inline constexpr int EATER_CHARGE = 0x10000L;
+inline constexpr int EATER_ROD_CHARGE = 0x10L;
 
+enum class ItemKindType : short;
+class BaseitemKey;
 struct magic_eater_data_type {
     struct magic_type {
-        int32_t charge{}; //!< 充填量 (杖/魔法棒とロッドで仕様が異なる)
-        byte count{}; //!< 取り込んだ回数(杖/魔法棒)もしくは本数(ロッド)
+        int charge{}; //!< 充填量 (杖/魔法棒とロッドで仕様が異なる)
+        uint8_t count{}; //!< 取り込んだ回数(杖/魔法棒)もしくは本数(ロッド)
     };
 
     magic_eater_data_type();
@@ -22,7 +24,11 @@ struct magic_eater_data_type {
     std::vector<magic_type> staves{}; //!< 杖のデータ
     std::vector<magic_type> wands{}; //!< 魔法棒のデータ
     std::vector<magic_type> rods{}; //!< ロッドのデータ
-    inline static std::vector<magic_type> none{}; //!< いずれの魔道具でもないダミー
+    inline static std::vector<magic_eater_data_type::magic_type> none{}; //!< いずれの魔道具でもないダミー
 
+    std::optional<BaseitemKey> check_magic_eater_spell_repeat() const;
     std::vector<magic_type> &get_item_group(ItemKindType tval);
+
+private:
+    const std::vector<magic_type> &get_item_group(ItemKindType tval) const;
 };

--- a/src/player-info/magic-eater-data-type.h
+++ b/src/player-info/magic-eater-data-type.h
@@ -13,22 +13,25 @@ inline constexpr int EATER_ROD_CHARGE = 0x10L;
 
 enum class ItemKindType : short;
 class BaseitemKey;
-struct magic_eater_data_type {
-    struct magic_type {
+class MagicEaterDataList {
+public:
+    class MagicEaterDatum {
+    public:
+        MagicEaterDatum() = default;
         int charge{}; //!< 充填量 (杖/魔法棒とロッドで仕様が異なる)
         uint8_t count{}; //!< 取り込んだ回数(杖/魔法棒)もしくは本数(ロッド)
     };
 
-    magic_eater_data_type();
+    MagicEaterDataList();
 
-    std::vector<magic_type> staves{}; //!< 杖のデータ
-    std::vector<magic_type> wands{}; //!< 魔法棒のデータ
-    std::vector<magic_type> rods{}; //!< ロッドのデータ
-    inline static std::vector<magic_eater_data_type::magic_type> none{}; //!< いずれの魔道具でもないダミー
+    std::vector<MagicEaterDatum> staves{}; //!< 杖のデータ
+    std::vector<MagicEaterDatum> wands{}; //!< 魔法棒のデータ
+    std::vector<MagicEaterDatum> rods{}; //!< ロッドのデータ
+    inline static std::vector<MagicEaterDataList::MagicEaterDatum> none{}; //!< いずれの魔道具でもないダミー
 
     std::optional<BaseitemKey> check_magic_eater_spell_repeat() const;
-    std::vector<magic_type> &get_item_group(ItemKindType tval);
+    std::vector<MagicEaterDatum> &get_item_group(ItemKindType tval);
 
 private:
-    const std::vector<magic_type> &get_item_group(ItemKindType tval) const;
+    const std::vector<MagicEaterDatum> &get_item_group(ItemKindType tval) const;
 };

--- a/src/save/player-class-specific-data-writer.cpp
+++ b/src/save/player-class-specific-data-writer.cpp
@@ -35,7 +35,7 @@ void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<bluemage_da
     wr_FlagGroup(bluemage_data->learnt_blue_magics, wr_byte);
 }
 
-void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<magic_eater_data_type> &magic_eater_data) const
+void PlayerClassSpecificDataWriter::operator()(const std::shared_ptr<MagicEaterDataList> &magic_eater_data) const
 {
     auto write_item_group = [](const auto &item_group) {
         wr_u16b(static_cast<uint16_t>(item_group.size()));

--- a/src/save/player-class-specific-data-writer.h
+++ b/src/save/player-class-specific-data-writer.h
@@ -7,7 +7,7 @@ struct spell_hex_data_type;
 struct smith_data_type;
 struct force_trainer_data_type;
 struct bluemage_data_type;
-struct magic_eater_data_type;
+class MagicEaterDataList;
 struct bard_data_type;
 struct mane_data_type;
 class SniperData;
@@ -22,7 +22,7 @@ public:
     void operator()(const std::shared_ptr<smith_data_type> &smith_data) const;
     void operator()(const std::shared_ptr<force_trainer_data_type> &force_trainer_data) const;
     void operator()(const std::shared_ptr<bluemage_data_type> &bluemage_data) const;
-    void operator()(const std::shared_ptr<magic_eater_data_type> &magic_eater_data) const;
+    void operator()(const std::shared_ptr<MagicEaterDataList> &magic_eater_data) const;
     void operator()(const std::shared_ptr<bard_data_type> &bird_data) const;
     void operator()(const std::shared_ptr<mane_data_type> &mane_data) const;
     void operator()(const std::shared_ptr<SniperData> &sniper_data) const;

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -468,7 +468,7 @@ bool restore_mana(PlayerType *player_ptr, bool magic_eater)
         // 魔力復活による、魔道具術師の取り込んだ魔法の回復量
         // 取り込み数が10回未満: 3 回分回復
         // 取り込み数が10回以上: 取り込み回数/3 回分回復
-        auto magic_eater_data = PlayerClass(player_ptr).get_specific_data<magic_eater_data_type>();
+        auto magic_eater_data = PlayerClass(player_ptr).get_specific_data<MagicEaterDataList>();
         for (auto tval : { ItemKindType::STAFF, ItemKindType::WAND }) {
             for (auto &item : magic_eater_data->get_item_group(tval)) {
                 item.charge += (item.count < 10) ? EATER_CHARGE * 3 : item.count * EATER_CHARGE / 3;


### PR DESCRIPTION
#4580 の後続チケットです
マージされるまではドラフトにしておきます
繰り込み後のメソッド名は特に思いつかなかった (職種依存のdata\_type はvariant で管理されているのでメソッド名でも区別できた方がベターと判断)ので一旦そのままにしてあります
ご確認下さい