### PR TITLE
describe_flavor() の引数をポインタから参照に差し替えた

### DIFF
--- a/src/action/activation-execution.cpp
+++ b/src/action/activation-execution.cpp
@@ -156,7 +156,7 @@ static bool activate_artifact(PlayerType *player_ptr, ItemEntity *o_ptr)
         return false;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY | OD_OMIT_PREFIX | OD_BASE_NAME);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, OD_NAME_ONLY | OD_OMIT_PREFIX | OD_BASE_NAME);
     if (!switch_activation(player_ptr, &o_ptr, it_activation->index, item_name)) {
         return false;
     }

--- a/src/action/weapon-shield.cpp
+++ b/src/action/weapon-shield.cpp
@@ -30,7 +30,7 @@ void verify_equip_slot(PlayerType *player_ptr, INVENTORY_IDX i_idx)
         }
 
         o_ptr = &player_ptr->inventory_list[INVEN_SUB_HAND];
-        item_name = describe_flavor(player_ptr, o_ptr, 0);
+        item_name = describe_flavor(player_ptr, *o_ptr, 0);
 
         if (o_ptr->is_cursed()) {
             if (o_ptr->allow_two_hands_wielding() && can_two_hands_wielding(player_ptr)) {
@@ -58,7 +58,7 @@ void verify_equip_slot(PlayerType *player_ptr, INVENTORY_IDX i_idx)
 
     o_ptr = &player_ptr->inventory_list[INVEN_MAIN_HAND];
     if (o_ptr->is_valid()) {
-        item_name = describe_flavor(player_ptr, o_ptr, 0);
+        item_name = describe_flavor(player_ptr, *o_ptr, 0);
     }
 
     if (has_melee_weapon(player_ptr, INVEN_MAIN_HAND)) {

--- a/src/autopick/autopick-destroyer.cpp
+++ b/src/autopick/autopick-destroyer.cpp
@@ -150,7 +150,7 @@ void auto_destroy_item(PlayerType *player_ptr, ItemEntity *o_ptr, int autopick_i
 
     disturb(player_ptr, false, false);
     if (!can_player_destroy_object(o_ptr)) {
-        const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+        const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
         msg_format(_("%sは破壊不能だ。", "You cannot auto-destroy %s."), item_name.data());
         return;
     }

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -520,7 +520,7 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, co
         return;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NO_PLURAL | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NO_PLURAL | OD_NAME_ONLY));
 
     /*
      * If necessary, add a '^' which indicates the

--- a/src/autopick/autopick-finder.cpp
+++ b/src/autopick/autopick-finder.cpp
@@ -39,7 +39,7 @@ int find_autopick_list(PlayerType *player_ptr, const ItemEntity *o_ptr)
         return -1;
     }
 
-    auto item_name = describe_flavor(player_ptr, o_ptr, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NO_PLURAL));
+    auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NO_PLURAL));
     str_tolower(item_name.data());
     for (auto i = 0U; i < autopick_list.size(); i++) {
         const auto &entry = autopick_list[i];
@@ -66,7 +66,7 @@ bool get_object_for_search(PlayerType *player_ptr, ItemEntity **o_handle, concpt
 
     *o_handle = o_ptr;
     string_free(*search_strp);
-    const auto item_name = describe_flavor(player_ptr, *o_handle, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NO_PLURAL));
+    const auto item_name = describe_flavor(player_ptr, **o_handle, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NO_PLURAL));
     *search_strp = string_make(format("<%s>", item_name.data()).data());
     return true;
 }
@@ -82,7 +82,7 @@ bool get_destroyed_object_for_search(PlayerType *player_ptr, ItemEntity **o_hand
 
     *o_handle = &autopick_last_destroyed_object;
     string_free(*search_strp);
-    const auto item_name = describe_flavor(player_ptr, *o_handle, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NO_PLURAL));
+    const auto item_name = describe_flavor(player_ptr, **o_handle, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NO_PLURAL));
     *search_strp = string_make(format("<%s>", item_name.data()).data());
     return true;
 }
@@ -313,7 +313,7 @@ void search_for_object(PlayerType *player_ptr, text_body_type *tb, const ItemEnt
     autopick_type an_entry, *entry = &an_entry;
     int bypassed_cy = -1;
     int i = tb->cy;
-    auto item_name = describe_flavor(player_ptr, o_ptr, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NO_PLURAL));
+    auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NO_PLURAL));
     str_tolower(item_name.data());
 
     while (true) {

--- a/src/autopick/autopick-registry.cpp
+++ b/src/autopick/autopick-registry.cpp
@@ -128,7 +128,7 @@ bool autopick_autoregister(PlayerType *player_ptr, const ItemEntity *o_ptr)
     }
 
     if ((o_ptr->is_known() && o_ptr->is_fixed_or_random_artifact()) || ((o_ptr->ident & IDENT_SENSE) && (o_ptr->feeling == FEEL_TERRIBLE || o_ptr->feeling == FEEL_SPECIAL))) {
-        const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+        const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
         msg_format(_("%sは破壊不能だ。", "You cannot auto-destroy %s."), item_name.data());
         return false;
     }

--- a/src/autopick/autopick.cpp
+++ b/src/autopick/autopick.cpp
@@ -45,7 +45,7 @@ static void autopick_delayed_alter_aux(PlayerType *player_ptr, INVENTORY_IDX i_i
         return;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
     if (i_idx >= 0) {
         inven_item_increase(player_ptr, i_idx, -(o_ptr->number));
         inven_item_optimize(player_ptr, i_idx);
@@ -113,7 +113,7 @@ void autopick_pickup_items(PlayerType *player_ptr, Grid *g_ptr)
 
         disturb(player_ptr, false, false);
         if (!check_store_item_to_inventory(player_ptr, o_ptr)) {
-            const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+            const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
             msg_format(_("ザックには%sを入れる隙間がない。", "You have no room for %s."), item_name.data());
             o_ptr->marked.set(OmType::SUPRESS_MESSAGE);
             continue;
@@ -128,7 +128,7 @@ void autopick_pickup_items(PlayerType *player_ptr, Grid *g_ptr)
             continue;
         }
 
-        const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+        const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
         std::stringstream ss;
         ss << _(item_name, "Pick up ") << _("を拾いますか", item_name) << "? ";
         if (!input_check(ss.str())) {

--- a/src/cmd-item/cmd-destroy.cpp
+++ b/src/cmd-item/cmd-destroy.cpp
@@ -49,7 +49,7 @@ static bool check_destory_item(PlayerType *player_ptr, const ItemEntity &destroy
         return true;
     }
 
-    const auto item_name = describe_flavor(player_ptr, &destroying_item, OD_OMIT_PREFIX);
+    const auto item_name = describe_flavor(player_ptr, destroying_item, OD_OMIT_PREFIX);
     constexpr auto fmt = _("本当に%sを壊しますか? [y/n/Auto]", "Really destroy %s? [y/n/Auto]");
     const auto msg = format(fmt, item_name.data());
     msg_print(nullptr);
@@ -192,7 +192,7 @@ static void exe_destroy_item(PlayerType *player_ptr, ItemEntity &destroying_item
 {
     ItemEntity destroyed_item = destroying_item;
     destroyed_item.number = amount;
-    const auto item_name = describe_flavor(player_ptr, &destroyed_item, 0);
+    const auto item_name = describe_flavor(player_ptr, destroyed_item, 0);
     msg_format(_("%sを壊した。", "You destroy %s."), item_name.data());
     sound(SOUND_DESTITEM);
     reduce_charges(&destroying_item, amount);
@@ -220,13 +220,12 @@ void do_cmd_destroy(PlayerType *player_ptr)
         return;
     }
 
-    auto [o_ptr, i_idx, amt] = *selection_result;
-
+    const auto &[o_ptr, i_idx, amt] = *selection_result;
     PlayerEnergy energy(player_ptr);
     energy.set_player_turn_energy(100);
     if (!can_player_destroy_object(o_ptr)) {
         energy.reset_player_turn();
-        const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+        const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
         msg_format(_("%sは破壊不可能だ。", "You cannot destroy %s."), item_name.data());
         return;
     }

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -284,7 +284,7 @@ void exe_eat_food(PlayerType *player_ptr, INVENTORY_IDX i_idx)
     /* Balrogs change humanoid corpses to energy */
     if (food_type == PlayerRaceFoodType::CORPSE) {
         if (o_ptr->is_corpse() && o_ptr->get_monrace().symbol_char_is_any_of("pht")) {
-            const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+            const auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
             msg_format(_("%sは燃え上り灰になった。精力を吸収した気がする。", "%s^ is burnt to ashes.  You absorb its vitality!"), item_name.data());
             (void)set_food(player_ptr, PY_FOOD_MAX - 1);
 

--- a/src/cmd-item/cmd-equipment.cpp
+++ b/src/cmd-item/cmd-equipment.cpp
@@ -81,7 +81,7 @@ static void do_curse_on_equip(OBJECT_IDX slot, ItemEntity *o_ptr, PlayerType *pl
         return;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     o_ptr->curse_flags.set(CurseTraitType::HEAVY_CURSE);
     msg_format(_("悪意に満ちた黒いオーラが%sをとりまいた...", "There is a malignant black aura surrounding your %s..."), item_name.data());
     o_ptr->feeling = FEEL_NONE;
@@ -221,7 +221,7 @@ void do_cmd_wield(PlayerType *player_ptr)
     }
 
     if (player_ptr->inventory_list[slot].is_cursed()) {
-        const auto item_name = describe_flavor(player_ptr, &player_ptr->inventory_list[slot], OD_OMIT_PREFIX | OD_NAME_ONLY);
+        const auto item_name = describe_flavor(player_ptr, player_ptr->inventory_list[slot], OD_OMIT_PREFIX | OD_NAME_ONLY);
 #ifdef JP
         msg_format("%s%sは呪われているようだ。", describe_use(player_ptr, slot), item_name.data());
 #else
@@ -234,7 +234,7 @@ void do_cmd_wield(PlayerType *player_ptr)
     should_equip_cursed |= any_bits(o_ptr->ident, IDENT_SENSE) && (FEEL_BROKEN <= o_ptr->feeling) && (o_ptr->feeling <= FEEL_CURSED);
     should_equip_cursed &= confirm_wear;
     if (should_equip_cursed) {
-        const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+        const auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
         if (!input_check(format(_("本当に%s{呪われている}を使いますか？", "Really use the %s {cursed}? "), item_name.data()))) {
             return;
         }
@@ -246,7 +246,7 @@ void do_cmd_wield(PlayerType *player_ptr)
     should_change_vampire &= !pr.equals(PlayerRaceType::VAMPIRE);
     should_change_vampire &= !pr.equals(PlayerRaceType::ANDROID);
     if (should_change_vampire) {
-        const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+        const auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
         constexpr auto mes = _("%sを装備すると吸血鬼になります。よろしいですか？",
             "%s will transform you into a vampire permanently when equipped. Do you become a vampire? ");
         if (!input_check(format(mes, item_name.data()))) {
@@ -260,7 +260,7 @@ void do_cmd_wield(PlayerType *player_ptr)
         ItemEntity *switch_o_ptr = &player_ptr->inventory_list[need_switch_wielding];
         ItemEntity object_tmp;
         ItemEntity *otmp_ptr = &object_tmp;
-        const auto item_name = describe_flavor(player_ptr, switch_o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+        const auto item_name = describe_flavor(player_ptr, *switch_o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
         otmp_ptr->copy_from(switch_o_ptr);
         switch_o_ptr->copy_from(slot_o_ptr);
         slot_o_ptr->copy_from(otmp_ptr);
@@ -328,7 +328,7 @@ void do_cmd_wield(PlayerType *player_ptr)
         break;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
     msg_format(act, item_name.data(), index_to_label(slot));
     if (o_ptr->is_cursed()) {
         msg_print(_("うわ！ すさまじく冷たい！", "Oops! It feels deathly cold!"));

--- a/src/cmd-item/cmd-item.cpp
+++ b/src/cmd-item/cmd-item.cpp
@@ -161,7 +161,7 @@ void do_cmd_observe(PlayerType *player_ptr)
         return;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
     msg_format(_("%sを調べている...", "Examining %s..."), item_name.data());
     if (!screen_object(player_ptr, o_ptr, SCROBJ_FORCE_DETAIL)) {
         msg_print(_("特に変わったところはないようだ。", "You see nothing special."));
@@ -218,7 +218,7 @@ void do_cmd_inscribe(PlayerType *player_ptr)
         return;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_OMIT_INSCRIPTION);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, OD_OMIT_INSCRIPTION);
     msg_format(_("%sに銘を刻む。", "Inscribing %s."), item_name.data());
     msg_print(nullptr);
     const auto initial_inscription = o_ptr->is_inscribed() ? *o_ptr->inscription : "";

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -158,7 +158,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
                     item_name = baseitem.stripped_name();
                 } else {
                     ItemEntity dummy(baseitem.idx);
-                    item_name = describe_flavor(player_ptr, &dummy, OD_FORCE_FLAVOR);
+                    item_name = describe_flavor(player_ptr, dummy, OD_FORCE_FLAVOR);
                 }
 
                 auto_dump_printf(auto_dump_stream, "# %s\n", item_name.data());

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -483,7 +483,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX i_idx, ItemEntity *j_ptr, SP
         snipe_type = SP_NONE;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_OMIT_PREFIX);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, OD_OMIT_PREFIX);
 
     /* Use the proper number of shots */
     auto thits = player_ptr->num_fire;

--- a/src/effect/effect-item.cpp
+++ b/src/effect/effect-item.cpp
@@ -264,7 +264,7 @@ bool affect_item(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION r, POSITI
         std::string item_name("");
         if (known && o_ptr->marked.has(OmType::FOUND)) {
             is_item_affected = true;
-            item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+            item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
         }
 
         if ((is_fixed_or_random_artifact || ignore)) {

--- a/src/flavor/flavor-describer.cpp
+++ b/src/flavor/flavor-describer.cpp
@@ -577,14 +577,13 @@ static describe_option_type decide_describe_option(const ItemEntity &item, BIT_F
  * @param mode 表記に関するオプション指定
  * @return modeに応じたオブジェクトの表記
  */
-std::string describe_flavor(PlayerType *player_ptr, const ItemEntity *o_ptr, BIT_FLAGS mode, const size_t max_length)
+std::string describe_flavor(PlayerType *player_ptr, const ItemEntity &item, BIT_FLAGS mode, const size_t max_length)
 {
-    const auto &item = *o_ptr;
     const auto opt = decide_describe_option(item, mode);
     std::stringstream ss;
     ss << describe_named_item(player_ptr, item, opt);
 
-    if (any_bits(mode, OD_NAME_ONLY) || !o_ptr->is_valid()) {
+    if (any_bits(mode, OD_NAME_ONLY) || !item.is_valid()) {
         return str_substr(ss.str(), 0, max_length);
     }
 

--- a/src/flavor/flavor-describer.h
+++ b/src/flavor/flavor-describer.h
@@ -5,4 +5,4 @@
 
 class ItemEntity;
 class PlayerType;
-std::string describe_flavor(PlayerType *player_ptr, const ItemEntity *o_ptr, const BIT_FLAGS mode, const size_t max_length = std::string_view::npos);
+std::string describe_flavor(PlayerType *player_ptr, const ItemEntity &item, const BIT_FLAGS mode, const size_t max_length = std::string_view::npos);

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -74,7 +74,7 @@ static void object_mention(PlayerType *player_ptr, ItemEntity *o_ptr)
     o_ptr->mark_as_known();
 
     o_ptr->ident |= (IDENT_FULL_KNOWN);
-    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
     msg_format_wizard(player_ptr, CHEAT_OBJECT, _("%sを生成しました。", "%s was generated."), item_name.data());
 }
 
@@ -323,7 +323,7 @@ OBJECT_IDX drop_near(PlayerType *player_ptr, ItemEntity *j_ptr, PERCENTAGE chanc
     bool plural = (j_ptr->number != 1);
 #endif
     const auto &world = AngbandWorld::get_instance();
-    const auto item_name = describe_flavor(player_ptr, j_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, *j_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     if (!j_ptr->is_fixed_or_random_artifact() && evaluate_percent(chance)) {
 #ifdef JP
         msg_format("%sは消えた。", item_name.data());
@@ -588,7 +588,7 @@ void floor_item_charges(FloorType *floor_ptr, INVENTORY_IDX i_idx)
 void floor_item_describe(PlayerType *player_ptr, INVENTORY_IDX i_idx)
 {
     auto *o_ptr = &player_ptr->current_floor_ptr->o_list[i_idx];
-    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
 #ifdef JP
     if (o_ptr->number <= 0) {
         msg_format("床上には、もう%sはない。", item_name.data());

--- a/src/floor/floor-streams.cpp
+++ b/src/floor/floor-streams.cpp
@@ -357,7 +357,7 @@ void build_streamer(PlayerType *player_ptr, FEAT_IDX feat, int chance)
                     if (o_ptr->is_fixed_artifact()) {
                         o_ptr->get_fixed_artifact().is_generated = false;
                         if (cheat_peek) {
-                            const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_NAME_ONLY | OD_STORE));
+                            const auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_NAME_ONLY | OD_STORE));
                             msg_format(_("伝説のアイテム (%s) はストリーマーにより削除された。", "Artifact (%s) was deleted by streamer."), item_name.data());
                         }
                     } else if (cheat_peek && o_ptr->is_random_artifact()) {

--- a/src/floor/object-scanner.cpp
+++ b/src/floor/object-scanner.cpp
@@ -120,7 +120,7 @@ COMMAND_CODE show_floor_items(PlayerType *player_ptr, int target_item, POSITION 
     auto *floor_ptr = player_ptr->current_floor_ptr;
     for (k = 0, i = 0; i < floor_num && i < 23; i++) {
         o_ptr = &floor_ptr->o_list[floor_list[i]];
-        const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+        const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
         out_index[k] = i;
         const auto tval = o_ptr->bi_key.tval();
         out_color[k] = tval_to_attr[enum2i(tval) & 0x7F];

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -145,11 +145,11 @@ void process_player_hp_mp(PlayerType *player_ptr)
         const auto flags = o_ptr->get_flags();
 
         if ((player_ptr->inventory_list[INVEN_LITE].bi_key.tval() != ItemKindType::NONE) && flags.has_not(TR_DARK_SOURCE) && !has_resist_lite(player_ptr)) {
-            const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+            const auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
             msg_format(_("%sがあなたのアンデッドの肉体を焼き焦がした！", "The %s scorches your undead flesh!"), item_name.data());
             cave_no_regen = true;
             if (!is_invuln(player_ptr)) {
-                const auto wielding_item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
+                const auto wielding_item_name = describe_flavor(player_ptr, *o_ptr, OD_NAME_ONLY);
                 std::stringstream ss;
                 ss << _(wielding_item_name, "wielding ") << _("を装備したダメージ", wielding_item_name);
                 take_hit(player_ptr, DAMAGE_NOESCAPE, 1, ss.str());

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -219,7 +219,7 @@ static void curse_teleport(PlayerType *player_ptr)
     }
 
     o_ptr = &player_ptr->inventory_list[i_keep];
-    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     msg_format(_("%sがテレポートの能力を発動させようとしている。", "Your %s tries to teleport you."), item_name.data());
     if (input_check_strict(player_ptr, _("テレポートしますか？", "Teleport? "), UserCheck::OKAY_CANCEL)) {
         disturb(player_ptr, false, true);
@@ -279,7 +279,7 @@ static void multiply_low_curse(PlayerType *player_ptr)
         return;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     o_ptr->curse_flags.set(new_curse);
     msg_format(_("悪意に満ちた黒いオーラが%sをとりまいた...", "There is a malignant black aura surrounding your %s..."), item_name.data());
     o_ptr->feeling = FEEL_NONE;
@@ -299,7 +299,7 @@ static void multiply_high_curse(PlayerType *player_ptr)
         return;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     o_ptr->curse_flags.set(new_curse);
     msg_format(_("悪意に満ちた黒いオーラが%sをとりまいた...", "There is a malignant black aura surrounding your %s..."), item_name.data());
     o_ptr->feeling = FEEL_NONE;
@@ -318,7 +318,7 @@ static void persist_curse(PlayerType *player_ptr)
         return;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     o_ptr->curse_flags.set(CurseTraitType::HEAVY_CURSE);
     msg_format(_("悪意に満ちた黒いオーラが%sをとりまいた...", "There is a malignant black aura surrounding your %s..."), item_name.data());
     o_ptr->feeling = FEEL_NONE;
@@ -332,7 +332,7 @@ static void curse_call_monster(PlayerType *player_ptr)
     auto *floor_ptr = player_ptr->current_floor_ptr;
     if (player_ptr->cursed.has(CurseTraitType::CALL_ANIMAL) && one_in_(2500)) {
         if (summon_specific(player_ptr, player_ptr->y, player_ptr->x, floor_ptr->dun_level, SUMMON_ANIMAL, call_type)) {
-            const auto item_name = describe_flavor(player_ptr, choose_cursed_obj_name(player_ptr, CurseTraitType::CALL_ANIMAL), obj_desc_type);
+            const auto item_name = describe_flavor(player_ptr, *choose_cursed_obj_name(player_ptr, CurseTraitType::CALL_ANIMAL), obj_desc_type);
             msg_format(_("%sが動物を引き寄せた！", "Your %s has attracted an animal!"), item_name.data());
             disturb(player_ptr, false, true);
         }
@@ -340,7 +340,7 @@ static void curse_call_monster(PlayerType *player_ptr)
 
     if (player_ptr->cursed.has(CurseTraitType::CALL_DEMON) && one_in_(1111)) {
         if (summon_specific(player_ptr, player_ptr->y, player_ptr->x, floor_ptr->dun_level, SUMMON_DEMON, call_type)) {
-            const auto item_name = describe_flavor(player_ptr, choose_cursed_obj_name(player_ptr, CurseTraitType::CALL_DEMON), obj_desc_type);
+            const auto item_name = describe_flavor(player_ptr, *choose_cursed_obj_name(player_ptr, CurseTraitType::CALL_DEMON), obj_desc_type);
             msg_format(_("%sが悪魔を引き寄せた！", "Your %s has attracted a demon!"), item_name.data());
             disturb(player_ptr, false, true);
         }
@@ -348,7 +348,7 @@ static void curse_call_monster(PlayerType *player_ptr)
 
     if (player_ptr->cursed.has(CurseTraitType::CALL_DRAGON) && one_in_(800)) {
         if (summon_specific(player_ptr, player_ptr->y, player_ptr->x, floor_ptr->dun_level, SUMMON_DRAGON, call_type)) {
-            const auto item_name = describe_flavor(player_ptr, choose_cursed_obj_name(player_ptr, CurseTraitType::CALL_DRAGON), obj_desc_type);
+            const auto item_name = describe_flavor(player_ptr, *choose_cursed_obj_name(player_ptr, CurseTraitType::CALL_DRAGON), obj_desc_type);
             msg_format(_("%sがドラゴンを引き寄せた！", "Your %s has attracted a dragon!"), item_name.data());
             disturb(player_ptr, false, true);
         }
@@ -356,7 +356,7 @@ static void curse_call_monster(PlayerType *player_ptr)
 
     if (player_ptr->cursed.has(CurseTraitType::CALL_UNDEAD) && one_in_(1111)) {
         if (summon_specific(player_ptr, player_ptr->y, player_ptr->x, floor_ptr->dun_level, SUMMON_UNDEAD, call_type)) {
-            const auto item_name = describe_flavor(player_ptr, choose_cursed_obj_name(player_ptr, CurseTraitType::CALL_UNDEAD), obj_desc_type);
+            const auto item_name = describe_flavor(player_ptr, *choose_cursed_obj_name(player_ptr, CurseTraitType::CALL_UNDEAD), obj_desc_type);
             msg_format(_("%sが死霊を引き寄せた！", "Your %s has attracted an undead!"), item_name.data());
             disturb(player_ptr, false, true);
         }
@@ -423,7 +423,7 @@ static void curse_drain_hp(PlayerType *player_ptr)
     }
 
     const auto *item_ptr = choose_cursed_obj_name(player_ptr, CurseTraitType::DRAIN_HP);
-    const auto item_name = describe_flavor(player_ptr, item_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, *item_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     msg_format(_("%sはあなたの体力を吸収した！", "Your %s drains HP from you!"), item_name.data());
     take_hit(player_ptr, DAMAGE_LOSELIFE, std::min(player_ptr->lev * 2, 100), item_name);
 }
@@ -435,7 +435,7 @@ static void curse_drain_mp(PlayerType *player_ptr)
     }
 
     const auto *item_ptr = choose_cursed_obj_name(player_ptr, CurseTraitType::DRAIN_MANA);
-    const auto item_name = describe_flavor(player_ptr, item_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, *item_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     msg_format(_("%sはあなたの魔力を吸収した！", "Your %s drains mana from you!"), item_name.data());
     player_ptr->csp -= std::min<short>(player_ptr->lev, 50);
     if (player_ptr->csp < 0) {

--- a/src/inventory/inventory-damage.cpp
+++ b/src/inventory/inventory-damage.cpp
@@ -63,7 +63,7 @@ void inventory_damage(PlayerType *player_ptr, const ObjectBreaker &breaker, int 
             continue;
         }
 
-        const auto item_name = describe_flavor(player_ptr, o_ptr, OD_OMIT_PREFIX);
+        const auto item_name = describe_flavor(player_ptr, *o_ptr, OD_OMIT_PREFIX);
 
         msg_format(_("%s(%c)が%s壊れてしまった！", "%sour %s (%c) %s destroyed!"),
 #ifdef JP

--- a/src/inventory/inventory-object.cpp
+++ b/src/inventory/inventory-object.cpp
@@ -157,7 +157,7 @@ void drop_from_inventory(PlayerType *player_ptr, INVENTORY_IDX i_idx, ITEM_NUMBE
     distribute_charges(o_ptr, q_ptr, amt);
 
     q_ptr->number = amt;
-    const auto item_name = describe_flavor(player_ptr, q_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, *q_ptr, 0);
     msg_format(_("%s(%c)を落とした。", "You drop %s (%c)."), item_name.data(), index_to_label(i_idx));
     (void)drop_near(player_ptr, q_ptr, 0, player_ptr->y, player_ptr->x);
     vary_item(player_ptr, i_idx, -amt);
@@ -422,7 +422,7 @@ INVENTORY_IDX inven_takeoff(PlayerType *player_ptr, INVENTORY_IDX i_idx, ITEM_NU
     q_ptr = &forge;
     q_ptr->copy_from(o_ptr);
     q_ptr->number = amt;
-    const auto item_name = describe_flavor(player_ptr, q_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, *q_ptr, 0);
     if (((i_idx == INVEN_MAIN_HAND) || (i_idx == INVEN_SUB_HAND)) && o_ptr->is_melee_weapon()) {
         act = _("を装備からはずした", "You were wielding");
     } else if (i_idx == INVEN_BOW) {

--- a/src/inventory/inventory-util.cpp
+++ b/src/inventory/inventory-util.cpp
@@ -288,7 +288,7 @@ bool verify(PlayerType *player_ptr, concptr prompt, INVENTORY_IDX i_idx)
         o_ptr = &player_ptr->current_floor_ptr->o_list[0 - i_idx];
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
     std::stringstream ss;
     ss << prompt;
 #ifndef JP

--- a/src/inventory/pack-overflow.cpp
+++ b/src/inventory/pack-overflow.cpp
@@ -29,7 +29,7 @@ void pack_overflow(PlayerType *player_ptr)
     disturb(player_ptr, false, true);
     msg_print(_("ザックからアイテムがあふれた！", "Your pack overflows!"));
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
     msg_format(_("%s(%c)を落とした。", "You drop %s (%c)."), item_name.data(), index_to_label(INVEN_PACK));
     (void)drop_near(player_ptr, o_ptr, 0, player_ptr->y, player_ptr->x);
 

--- a/src/inventory/player-inventory.cpp
+++ b/src/inventory/player-inventory.cpp
@@ -95,7 +95,7 @@ void py_pickup_floor(PlayerType *player_ptr, bool pickup)
     for (auto it = o_idx_list.begin(); it != o_idx_list.end();) {
         const OBJECT_IDX this_o_idx = *it++;
         auto *o_ptr = &player_ptr->current_floor_ptr->o_list[this_o_idx];
-        const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+        const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
         disturb(player_ptr, false, false);
         if (o_ptr->bi_key.tval() == ItemKindType::GOLD) {
             constexpr auto mes = _(" $%ld の価値がある%sを見つけた。", "You have found %ld gold pieces worth of %s.");
@@ -126,7 +126,7 @@ void py_pickup_floor(PlayerType *player_ptr, bool pickup)
     if (!pickup) {
         if (floor_num == 1) {
             auto *o_ptr = &player_ptr->current_floor_ptr->o_list[floor_o_idx];
-            const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+            const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
             msg_format(_("%sがある。", "You see %s."), item_name.data());
         } else {
             msg_format(_("%d 個のアイテムの山がある。", "You see a pile of %d items."), floor_num);
@@ -138,7 +138,7 @@ void py_pickup_floor(PlayerType *player_ptr, bool pickup)
     if (!can_pickup) {
         if (floor_num == 1) {
             auto *o_ptr = &player_ptr->current_floor_ptr->o_list[floor_o_idx];
-            const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+            const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
             msg_format(_("ザックには%sを入れる隙間がない。", "You have no room for %s."), item_name.data());
         } else {
             msg_print(_("ザックには床にあるどのアイテムも入らない。", "You have no room for any of the objects on the floor."));
@@ -163,7 +163,7 @@ void py_pickup_floor(PlayerType *player_ptr, bool pickup)
     }
 
     auto *o_ptr = &player_ptr->current_floor_ptr->o_list[floor_o_idx];
-    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
     const auto prompt = format(_("%sを拾いますか? ", "Pick up %s? "), item_name.data());
     if (!input_check(prompt)) {
         return;
@@ -189,7 +189,7 @@ void describe_pickup_item(PlayerType *player_ptr, OBJECT_IDX o_idx)
 {
     auto *o_ptr = &player_ptr->current_floor_ptr->o_list[o_idx];
 #ifdef JP
-    const auto old_item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
+    const auto old_item_name = describe_flavor(player_ptr, *o_ptr, OD_NAME_ONLY);
     const auto picked_count_str = describe_count_with_counter_suffix(*o_ptr);
     const auto picked_count = o_ptr->number;
 #else
@@ -207,7 +207,7 @@ void describe_pickup_item(PlayerType *player_ptr, OBJECT_IDX o_idx)
         }
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
 #ifdef JP
     if (o_ptr->is_specific_artifact(FixedArtifactId::CRIMSON) && (player_ptr->ppersonality == PERSONALITY_COMBAT)) {
         msg_format("こうして、%sは『クリムゾン』を手に入れた。", player_ptr->name);
@@ -257,7 +257,7 @@ void carry(PlayerType *player_ptr, bool pickup)
     for (auto it = g_ptr->o_idx_list.begin(); it != g_ptr->o_idx_list.end();) {
         const OBJECT_IDX this_o_idx = *it++;
         auto *o_ptr = &player_ptr->current_floor_ptr->o_list[this_o_idx];
-        const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+        const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
         disturb(player_ptr, false, false);
         if (o_ptr->bi_key.tval() == ItemKindType::GOLD) {
             int value = (long)o_ptr->pval;

--- a/src/inventory/recharge-processor.cpp
+++ b/src/inventory/recharge-processor.cpp
@@ -29,7 +29,7 @@ static void recharged_notice(PlayerType *player_ptr, ItemEntity *o_ptr)
     auto s = angband_strchr(o_ptr->inscription->data(), '!');
     while (s) {
         if (s[1] == '!') {
-            const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+            const auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
 #ifdef JP
             msg_format("%sは再充填された。", item_name.data());
 #else

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -499,7 +499,7 @@ static void dump_aux_equipment_inventory(PlayerType *player_ptr, FILE *fff)
     if (player_ptr->equip_cnt) {
         fprintf(fff, _("  [キャラクタの装備]\n\n", "  [Character Equipment]\n\n"));
         for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-            auto item_name = describe_flavor(player_ptr, &player_ptr->inventory_list[i], 0);
+            auto item_name = describe_flavor(player_ptr, player_ptr->inventory_list[i], 0);
             auto is_two_handed = ((i == INVEN_MAIN_HAND) && can_attack_with_sub_hand(player_ptr));
             is_two_handed |= ((i == INVEN_SUB_HAND) && can_attack_with_main_hand(player_ptr));
             if (is_two_handed && has_two_handed_weapons(player_ptr)) {
@@ -519,7 +519,7 @@ static void dump_aux_equipment_inventory(PlayerType *player_ptr, FILE *fff)
             break;
         }
 
-        const auto item_name = describe_flavor(player_ptr, &player_ptr->inventory_list[i], 0);
+        const auto item_name = describe_flavor(player_ptr, player_ptr->inventory_list[i], 0);
         fprintf(fff, "%c) %s\n", index_to_label(i), item_name.data());
     }
 
@@ -541,7 +541,7 @@ static void dump_aux_home_museum(PlayerType *player_ptr, FILE *fff)
                 fprintf(fff, _("\n ( %d ページ )\n", "\n ( page %d )\n"), page++);
             }
 
-            const auto item_name = describe_flavor(player_ptr, store_ptr->stock[i].get(), 0);
+            const auto item_name = describe_flavor(player_ptr, *store_ptr->stock[i], 0);
             fprintf(fff, "%c) %s\n", I2A(i % 12), item_name.data());
         }
 
@@ -562,7 +562,7 @@ static void dump_aux_home_museum(PlayerType *player_ptr, FILE *fff)
             fprintf(fff, _("\n ( %d ページ )\n", "\n ( page %d )\n"), page++);
         }
 
-        const auto item_name = describe_flavor(player_ptr, store_ptr->stock[i].get(), 0);
+        const auto item_name = describe_flavor(player_ptr, *store_ptr->stock[i], 0);
         fprintf(fff, "%c) %s\n", I2A(i % 12), item_name.data());
     }
 

--- a/src/knowledge/knowledge-inventory.cpp
+++ b/src/knowledge/knowledge-inventory.cpp
@@ -153,7 +153,7 @@ static void do_cmd_knowledge_inventory_aux(PlayerType *player_ptr, FILE *fff, It
 {
     constexpr auto max_item_length = 26;
     std::stringstream ss;
-    ss << describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY, max_item_length);
+    ss << describe_flavor(player_ptr, *o_ptr, OD_NAME_ONLY, max_item_length);
     const int item_length = ss.tellp();
     constexpr auto max_display_length = 28;
     for (auto i = item_length; i < max_display_length; i++) {

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -105,7 +105,7 @@ void do_cmd_knowledge_artifacts(PlayerType *player_ptr)
         ItemEntity item(artifact.bi_key);
         item.fa_id = fa_id;
         item.ident |= IDENT_STORE;
-        const auto item_name = describe_flavor(player_ptr, &item, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+        const auto item_name = describe_flavor(player_ptr, item, (OD_OMIT_PREFIX | OD_NAME_ONLY));
         fprintf(fff, template_basename, item_name.data());
     }
 

--- a/src/knowledge/knowledge-quests.cpp
+++ b/src/knowledge/knowledge-quests.cpp
@@ -104,7 +104,7 @@ static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
                         ItemEntity item(artifact.bi_key);
                         item.fa_id = quest.reward_fa_id;
                         item.ident = IDENT_STORE;
-                        item_name = describe_flavor(player_ptr, &item, OD_NAME_ONLY);
+                        item_name = describe_flavor(player_ptr, item, OD_NAME_ONLY);
                     }
 
                     note = format(_("\n   - %sを見つけ出す。", "\n   - Find %s."), item_name.data());

--- a/src/knowledge/knowledge-self.cpp
+++ b/src/knowledge/knowledge-self.cpp
@@ -216,7 +216,7 @@ void do_cmd_knowledge_home(PlayerType *player_ptr)
             fprintf(fff, "\n ( %d ページ )\n", x++);
         }
 
-        const auto item_name = describe_flavor(player_ptr, store.stock[i].get(), 0);
+        const auto item_name = describe_flavor(player_ptr, *store.stock[i], 0);
         const int item_length = item_name.length();
         if (item_length <= 80 - 3) {
             fprintf(fff, "%c%s %s\n", I2A(i % 12), close_bracket, item_name.data());
@@ -229,7 +229,7 @@ void do_cmd_knowledge_home(PlayerType *player_ptr)
         fprintf(fff, "%c%s %.*s\n", I2A(i % 12), close_bracket, n, item_name.substr(0, n).data());
         fprintf(fff, "   %.77s\n", item_name.substr(n).data());
 #else
-        const auto item_name = describe_flavor(player_ptr, store.stock[i].get(), 0);
+        const auto item_name = describe_flavor(player_ptr, *store.stock[i], 0);
         fprintf(fff, "%c%s %s\n", I2A(i % 12), close_bracket, item_name.data());
 #endif
     }

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -56,7 +56,7 @@ bool exchange_cash(PlayerType *player_ptr)
         }
 
         change = true;
-        const auto item_name = describe_flavor(player_ptr, &item, 0);
+        const auto item_name = describe_flavor(player_ptr, item, 0);
         if (!input_check(format(fmt_convert, item_name.data()))) {
             continue;
         }
@@ -79,7 +79,7 @@ bool exchange_cash(PlayerType *player_ptr)
         }
 
         change = true;
-        const auto item_name = describe_flavor(player_ptr, &item, 0);
+        const auto item_name = describe_flavor(player_ptr, item, 0);
         if (!input_check(format(fmt_convert, item_name.data()))) {
             continue;
         }
@@ -102,7 +102,7 @@ bool exchange_cash(PlayerType *player_ptr)
         }
 
         change = true;
-        const auto item_name = describe_flavor(player_ptr, &item, 0);
+        const auto item_name = describe_flavor(player_ptr, item, 0);
         if (!input_check(format(fmt_convert, item_name.data()))) {
             continue;
         }
@@ -123,7 +123,7 @@ bool exchange_cash(PlayerType *player_ptr)
         }
 
         change = true;
-        const auto item_name = describe_flavor(player_ptr, &item, 0);
+        const auto item_name = describe_flavor(player_ptr, item, 0);
         if (!input_check(format(fmt_convert, item_name.data()))) {
             continue;
         }
@@ -143,7 +143,7 @@ bool exchange_cash(PlayerType *player_ptr)
         }
 
         change = true;
-        const auto item_name = describe_flavor(player_ptr, &item, 0);
+        const auto item_name = describe_flavor(player_ptr, item, 0);
         if (!input_check(format(fmt_convert, item_name.data()))) {
             continue;
         }
@@ -167,7 +167,7 @@ bool exchange_cash(PlayerType *player_ptr)
             }
 
             INVENTORY_IDX inventory_new;
-            const auto item_name = describe_flavor(player_ptr, &item, 0);
+            const auto item_name = describe_flavor(player_ptr, item, 0);
             if (!input_check(format(_("%sを渡しますか？", "Hand %s over? "), item_name.data()))) {
                 continue;
             }
@@ -192,7 +192,7 @@ bool exchange_cash(PlayerType *player_ptr)
              * there is at least one empty slot.
              */
             inventory_new = store_item_to_inventory(player_ptr, &prize_item);
-            const auto got_item_name = describe_flavor(player_ptr, &prize_item, 0);
+            const auto got_item_name = describe_flavor(player_ptr, prize_item, 0);
             msg_format(_("%s(%c)を貰った。", "You get %s (%c). "), got_item_name.data(), index_to_label(inventory_new));
 
             autopick_alter_item(player_ptr, inventory_new, false);

--- a/src/market/building-craft-fix.cpp
+++ b/src/market/building-craft-fix.cpp
@@ -112,13 +112,13 @@ static std::pair<short, ItemEntity *> select_repairing_broken_weapon(PlayerType 
 
 static void display_reparing_weapon(PlayerType *player_ptr, ItemEntity *o_ptr, const int row)
 {
-    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, OD_NAME_ONLY);
     prt(format(_("修復する武器　： %s", "Repairing: %s"), item_name.data()), row + 3, 2);
 }
 
 static void display_repair_success_message(PlayerType *player_ptr, ItemEntity *o_ptr, const int cost)
 {
-    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, OD_NAME_ONLY);
 #ifdef JP
     msg_format("＄%dで%sに修復しました。", cost, item_name.data());
 #else
@@ -156,7 +156,7 @@ static PRICE repair_broken_weapon_aux(PlayerType *player_ptr, PRICE bcost)
         return 0;
     }
 
-    const auto item_name = describe_flavor(player_ptr, mo_ptr, OD_NAME_ONLY);
+    const auto item_name = describe_flavor(player_ptr, *mo_ptr, OD_NAME_ONLY);
     prt(format(_("材料とする武器： %s", "Material : %s"), item_name.data()), row + 4, 2);
     const auto cost = bcost + object_value_real(o_ptr) * 2;
     if (!input_check(format(_("＄%dかかりますがよろしいですか？ ", "Costs %d gold, okay? "), cost))) {

--- a/src/market/building-craft-weapon.cpp
+++ b/src/market/building-craft-weapon.cpp
@@ -260,7 +260,7 @@ static void list_weapon(PlayerType *player_ptr, ItemEntity *o_ptr, TERM_LEN row,
     const auto eff_dd = o_ptr->damage_dice.num + player_ptr->damage_dice_bonus[0].num;
     const auto eff_ds = o_ptr->damage_dice.sides + player_ptr->damage_dice_bonus[0].sides;
     const auto hit_reliability = player_ptr->skill_thn + (player_ptr->to_h[0] + o_ptr->to_h) * BTH_PLUS_ADJ;
-    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, OD_NAME_ONLY);
     c_put_str(TERM_YELLOW, item_name, row, col);
     put_str(format(_("攻撃回数: %d", "Number of Blows: %d"), player_ptr->num_blow[0]), row + 1, col);
 

--- a/src/market/building-enchanter.cpp
+++ b/src/market/building-enchanter.cpp
@@ -40,7 +40,7 @@ bool enchant_item(PlayerType *player_ptr, PRICE cost, HIT_PROB to_hit, int to_da
 
     const PRICE total_cost = cost * o_ptr->number;
     if (player_ptr->au < total_cost) {
-        const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
+        const auto item_name = describe_flavor(player_ptr, *o_ptr, OD_NAME_ONLY);
         msg_format(_("%sを改良するだけのゴールドがありません！", "You do not have the gold to improve %s!"), item_name.data());
         return false;
     }
@@ -75,7 +75,7 @@ bool enchant_item(PlayerType *player_ptr, PRICE cost, HIT_PROB to_hit, int to_da
         return false;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_AND_ENCHANT);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, OD_NAME_AND_ENCHANT);
 #ifdef JP
     msg_format("＄%dで%sに改良しました。", total_cost, item_name.data());
 #else

--- a/src/market/building-recharger.cpp
+++ b/src/market/building-recharger.cpp
@@ -54,7 +54,7 @@ void building_recharge(PlayerType *player_ptr)
         if ((player_ptr->au >= 50) && input_check(_("＄50で鑑定しますか？ ", "Identify for 50 gold? "))) {
             player_ptr->au -= 50;
             identify_item(player_ptr, o_ptr);
-            const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+            const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
             msg_format(_("%s です。", "You have: %s."), item_name.data());
             autopick_alter_item(player_ptr, i_idx, false);
             building_prt_gold(player_ptr);
@@ -106,7 +106,7 @@ void building_recharge(PlayerType *player_ptr)
     }
 
     if (player_ptr->au < price) {
-        const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
+        const auto item_name = describe_flavor(player_ptr, *o_ptr, OD_NAME_ONLY);
 #ifdef JP
         msg_format("%sを再充填するには＄%d 必要です！", item_name.data(), price);
 #else
@@ -146,7 +146,7 @@ void building_recharge(PlayerType *player_ptr)
         o_ptr->ident &= ~(IDENT_EMPTY);
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
 #ifdef JP
     msg_format("%sを＄%d で再充填しました。", item_name.data(), price);
 #else

--- a/src/mind/mind-archer.cpp
+++ b/src/mind/mind-archer.cpp
@@ -128,7 +128,7 @@ bool create_ammo(PlayerType *player_ptr)
         ItemMagicApplier(player_ptr, &item, player_ptr->lev, AM_NO_FIXED_ART).execute();
         item.discount = 99;
         int16_t slot = store_item_to_inventory(player_ptr, &item);
-        const auto item_name = describe_flavor(player_ptr, &item, 0);
+        const auto item_name = describe_flavor(player_ptr, item, 0);
         msg_print(_(format("%sを作った。", item_name.data()), "You make some ammo."));
         if (slot >= 0) {
             autopick_alter_item(player_ptr, slot, false);
@@ -152,7 +152,7 @@ bool create_ammo(PlayerType *player_ptr)
         ammo.mark_as_known();
         ItemMagicApplier(player_ptr, &ammo, player_ptr->lev, AM_NO_FIXED_ART).execute();
         ammo.discount = 99;
-        const auto item_name = describe_flavor(player_ptr, &ammo, 0);
+        const auto item_name = describe_flavor(player_ptr, ammo, 0);
         msg_print(_(format("%sを作った。", item_name.data()), "You make some ammo."));
         vary_item(player_ptr, i_idx, -1);
         int16_t slot = store_item_to_inventory(player_ptr, &ammo);
@@ -177,7 +177,7 @@ bool create_ammo(PlayerType *player_ptr)
         ammo.mark_as_known();
         ItemMagicApplier(player_ptr, &ammo, player_ptr->lev, AM_NO_FIXED_ART).execute();
         ammo.discount = 99;
-        const auto item_name = describe_flavor(player_ptr, &ammo, 0);
+        const auto item_name = describe_flavor(player_ptr, ammo, 0);
         msg_print(_(format("%sを作った。", item_name.data()), "You make some ammo."));
         vary_item(player_ptr, i_idx, -1);
         int16_t slot = store_item_to_inventory(player_ptr, &ammo);

--- a/src/mind/mind-mage.cpp
+++ b/src/mind/mind-mage.cpp
@@ -95,7 +95,7 @@ bool eat_magic(PlayerType *player_ptr, int power)
     }
 
     if (o_ptr->is_fixed_artifact()) {
-        const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
+        const auto item_name = describe_flavor(player_ptr, *o_ptr, OD_NAME_ONLY);
         msg_format(_("魔力が逆流した！%sは完全に魔力を失った。", "The recharging backfires - %s is completely drained!"), item_name.data());
         if (tval == ItemKindType::ROD) {
             o_ptr->timeout = baseitem.pval * o_ptr->number;
@@ -106,7 +106,7 @@ bool eat_magic(PlayerType *player_ptr, int power)
         return redraw_player(player_ptr);
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
 
     /* Mages recharge objects more safely. */
     if (PlayerClass(player_ptr).is_wizard()) {

--- a/src/mind/mind-magic-eater.cpp
+++ b/src/mind/mind-magic-eater.cpp
@@ -73,7 +73,7 @@ bool import_magic_device(PlayerType *player_ptr)
         }
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
     msg_format(_("%sの魔力を取り込んだ。", "You absorb magic of %s."), item_name.data());
 
     vary_item(player_ptr, i_idx, -999);

--- a/src/mind/mind-mindcrafter.cpp
+++ b/src/mind/mind-mindcrafter.cpp
@@ -67,7 +67,7 @@ bool psychometry(PlayerType *player_ptr)
     }
 
     item_feel_type feel = pseudo_value_check_heavy(o_ptr);
-    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     if (!feel) {
         msg_format(_("%sからは特に変わった事は感じとれなかった。", "You do not perceive anything unusual about the %s."), item_name.data());
         return true;

--- a/src/mind/mind-priest.cpp
+++ b/src/mind/mind-priest.cpp
@@ -34,7 +34,7 @@ bool bless_weapon(PlayerType *player_ptr)
         return false;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
     const auto item_flags = o_ptr->get_flags();
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     if (o_ptr->is_cursed()) {

--- a/src/mind/mind-weaponsmith.cpp
+++ b/src/mind/mind-weaponsmith.cpp
@@ -133,7 +133,7 @@ static void drain_essence(PlayerType *player_ptr)
     }
 
     if (o_ptr->is_known() && !o_ptr->is_nameless()) {
-        const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+        const auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
         if (!input_check(format(_("本当に%sから抽出してよろしいですか？", "Really extract from %s? "), item_name.data()))) {
             return;
         }
@@ -453,7 +453,7 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
         return;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     const auto use_essence = Smith::get_essence_consumption(effect, o_ptr);
     if (o_ptr->number > 1) {
         msg_format(_("%d個あるのでエッセンスは%d必要です。", "For %d items, it will take %d essences."), o_ptr->number, use_essence);
@@ -530,7 +530,7 @@ static void erase_essence(PlayerType *player_ptr)
         return;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     if (!input_check(format(_("よろしいですか？ [%s]", "Are you sure? [%s]"), item_name.data()))) {
         return;
     }

--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -149,7 +149,7 @@ void process_eat_item(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
             continue;
         }
 
-        const auto item_name = describe_flavor(player_ptr, monap_ptr->o_ptr, OD_OMIT_PREFIX);
+        const auto item_name = describe_flavor(player_ptr, *monap_ptr->o_ptr, OD_OMIT_PREFIX);
 #ifdef JP
         msg_format("%s(%c)を%s盗まれた！", item_name.data(), index_to_label(i_idx), ((monap_ptr->o_ptr->number > 1) ? "一つ" : ""));
 #else
@@ -180,7 +180,7 @@ void process_eat_food(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
             continue;
         }
 
-        const auto item_name = describe_flavor(player_ptr, monap_ptr->o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+        const auto item_name = describe_flavor(player_ptr, *monap_ptr->o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
 #ifdef JP
         msg_format("%s(%c)を%s食べられてしまった！", item_name.data(), index_to_label(i_idx), ((monap_ptr->o_ptr->number > 1) ? "一つ" : ""));
 #else

--- a/src/monster-floor/monster-object.cpp
+++ b/src/monster-floor/monster-object.cpp
@@ -197,7 +197,7 @@ void update_object_by_monster_movement(PlayerType *player_ptr, turn_flags *turn_
         }
 
         const auto flags = o_ptr->get_flags();
-        const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+        const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
         const auto m_name = monster_desc(player_ptr, m_ptr, MD_INDEF_HIDDEN);
         update_object_flags(flags, flg_monster_kind, flgr);
 

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -231,7 +231,7 @@ static void warn_unique_generation(PlayerType *player_ptr, MonraceId r_idx)
 
     auto *o_ptr = choose_warning_item(player_ptr);
     if (o_ptr != nullptr) {
-        const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+        const auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
         msg_format(_("%sは%s光った。", "%s glows %s."), item_name.data(), color.data());
     } else {
         msg_format(_("%s光る物が頭に浮かんだ。", "A %s image forms in your mind."), color.data());

--- a/src/object-enchant/object-curse.cpp
+++ b/src/object-enchant/object-curse.cpp
@@ -75,7 +75,7 @@ void curse_equipment(PlayerType *player_ptr, PERCENTAGE chance, PERCENTAGE heavy
     }
 
     const auto oflags = o_ptr->get_flags();
-    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
 
     /* Extra, biased saving throw for blessed items */
     if (oflags.has(TR_BLESSED)) {

--- a/src/object-use/read/parchment-read-executor.cpp
+++ b/src/object-use/read/parchment-read-executor.cpp
@@ -34,7 +34,7 @@ bool ParchmentReadExecutor::read()
     std::stringstream ss;
     ss << "book-" << std::setfill('0') << std::right << std::setw(3) << *this->o_ptr->bi_key.sval();
     ss << "_" << _("jp", "en") << ".txt";
-    const auto item_name = describe_flavor(this->player_ptr, this->o_ptr, OD_NAME_ONLY);
+    const auto item_name = describe_flavor(this->player_ptr, *this->o_ptr, OD_NAME_ONLY);
     auto path = path_build(ANGBAND_DIR_FILE, "books");
     path.append(ss.str());
     const auto &filename = path.string();

--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -107,7 +107,7 @@ void ObjectThrowEntity::calc_throw_range()
     torch_flags(this->q_ptr, this->obj_flags);
     distribute_charges(this->o_ptr, this->q_ptr, 1);
     this->q_ptr->number = 1;
-    this->o_name = describe_flavor(this->player_ptr, this->q_ptr, OD_OMIT_PREFIX);
+    this->o_name = describe_flavor(this->player_ptr, *this->q_ptr, OD_OMIT_PREFIX);
     if (this->player_ptr->mighty_throw) {
         this->mult += 3;
     }
@@ -290,7 +290,7 @@ void ObjectThrowEntity::check_boomerang_throw()
         this->back_chance += 100;
     }
 
-    this->o2_name = describe_flavor(this->player_ptr, this->q_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
+    this->o2_name = describe_flavor(this->player_ptr, *this->q_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
     this->process_boomerang_throw();
 }
 

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -526,7 +526,7 @@ bool process_warning(PlayerType *player_ptr, POSITION xx, POSITION yy)
             auto *o_ptr = choose_warning_item(player_ptr);
             std::string item_name;
             if (o_ptr != nullptr) {
-                item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+                item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
             } else {
                 item_name = _("体", "body");
             }
@@ -550,7 +550,7 @@ bool process_warning(PlayerType *player_ptr, POSITION xx, POSITION yy)
     auto *o_ptr = choose_warning_item(player_ptr);
     std::string item_name;
     if (o_ptr != nullptr) {
-        item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+        item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     } else {
         item_name = _("体", "body");
     }

--- a/src/perception/identification.cpp
+++ b/src/perception/identification.cpp
@@ -785,9 +785,9 @@ bool screen_object(PlayerType *player_ptr, ItemEntity *o_ptr, BIT_FLAGS mode)
     const auto &[wid, hgt] = term_get_size();
     std::string item_name;
     if (!(mode & SCROBJ_FAKE_OBJECT)) {
-        item_name = describe_flavor(player_ptr, o_ptr, 0);
+        item_name = describe_flavor(player_ptr, *o_ptr, 0);
     } else {
-        item_name = describe_flavor(player_ptr, o_ptr, (OD_NAME_ONLY | OD_STORE));
+        item_name = describe_flavor(player_ptr, *o_ptr, (OD_NAME_ONLY | OD_STORE));
     }
 
     prt(item_name, 0, 0);

--- a/src/perception/object-perception.cpp
+++ b/src/perception/object-perception.cpp
@@ -42,6 +42,6 @@ void object_aware(PlayerType *player_ptr, const ItemEntity *o_ptr)
     q_ptr = &forge;
     q_ptr->copy_from(o_ptr);
     q_ptr->number = 1;
-    const auto item_name = describe_flavor(player_ptr, q_ptr, OD_NAME_ONLY);
+    const auto item_name = describe_flavor(player_ptr, *q_ptr, OD_NAME_ONLY);
     exe_write_diary(*player_ptr->current_floor_ptr, DiaryKind::FOUND, 0, item_name);
 }

--- a/src/perception/simple-perception.cpp
+++ b/src/perception/simple-perception.cpp
@@ -96,7 +96,7 @@ static void sense_inventory_aux(PlayerType *player_ptr, INVENTORY_IDX slot, bool
         disturb(player_ptr, false, false);
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     if (slot >= INVEN_MAIN_HAND) {
 #ifdef JP
         constexpr auto mes = "%s%s(%c)は%sという感じがする...";

--- a/src/player-attack/attack-chaos-effect.cpp
+++ b/src/player-attack/attack-chaos-effect.cpp
@@ -260,7 +260,7 @@ static void attack_golden_hammer(PlayerType *player_ptr, player_attack_type *pa_
     }
 
     auto *q_ptr = &floor_ptr->o_list[m_ptr->hold_o_idx_list.front()];
-    const auto item_name = describe_flavor(player_ptr, q_ptr, OD_NAME_ONLY);
+    const auto item_name = describe_flavor(player_ptr, *q_ptr, OD_NAME_ONLY);
     q_ptr->held_m_idx = 0;
     q_ptr->marked.clear().set(OmType::TOUCHED);
     m_ptr->hold_o_idx_list.pop_front();

--- a/src/player/patron.cpp
+++ b/src/player/patron.cpp
@@ -345,7 +345,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
                 }
             }
 
-            const auto item_name = describe_flavor(this->player_ptr, &this->player_ptr->inventory_list[slot], OD_NAME_ONLY);
+            const auto item_name = describe_flavor(this->player_ptr, this->player_ptr->inventory_list[slot], OD_NAME_ONLY);
             (void)curse_weapon_object(this->player_ptr, false, &this->player_ptr->inventory_list[slot]);
             reward = format(_("%sが破壊された。", "destroying %s"), item_name.data());
             break;
@@ -357,7 +357,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
 
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「汝、防具に頼ることなかれ。」", "'Thou reliest too much on thine equipment.'"));
-            const auto item_name = describe_flavor(this->player_ptr, &this->player_ptr->inventory_list[INVEN_BODY], OD_NAME_ONLY);
+            const auto item_name = describe_flavor(this->player_ptr, this->player_ptr->inventory_list[INVEN_BODY], OD_NAME_ONLY);
             (void)curse_armor(this->player_ptr);
             reward = format(_("%sが破壊された。", "destroying %s"), item_name.data());
             break;
@@ -388,7 +388,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
                         }
                     }
 
-                    const auto item_name = describe_flavor(this->player_ptr, &this->player_ptr->inventory_list[slot], OD_NAME_ONLY);
+                    const auto item_name = describe_flavor(this->player_ptr, this->player_ptr->inventory_list[slot], OD_NAME_ONLY);
                     (void)curse_weapon_object(this->player_ptr, false, &this->player_ptr->inventory_list[slot]);
                     reward = format(_("%sが破壊された。", "destroying %s"), item_name.data());
                 } else {
@@ -396,7 +396,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
                         break;
                     }
 
-                    const auto item_name = describe_flavor(this->player_ptr, &this->player_ptr->inventory_list[INVEN_BODY], OD_NAME_ONLY);
+                    const auto item_name = describe_flavor(this->player_ptr, this->player_ptr->inventory_list[INVEN_BODY], OD_NAME_ONLY);
                     (void)curse_armor(this->player_ptr);
                     reward = format(_("%sが破壊された。", "destroying %s"), item_name.data());
                 }

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -100,7 +100,7 @@ static bool acid_minus_ac(PlayerType *player_ptr)
         return false;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
     const auto item_flags = o_ptr->get_flags();
     if (o_ptr->ac + o_ptr->to_a <= 0) {
         msg_format(_("%sは既にボロボロだ！", "Your %s is already fully corroded!"), item_name.data());

--- a/src/player/process-death.cpp
+++ b/src/player/process-death.cpp
@@ -313,7 +313,7 @@ static void show_dead_home_items(PlayerType *player_ptr)
             for (int j = 0; (j < 12) && (i < store_ptr->stock_num); j++, i++) {
                 const auto &item = store_ptr->stock[i];
                 prt(format("%c) ", I2A(j)), j + 2, 4);
-                const auto item_name = describe_flavor(player_ptr, item.get(), 0);
+                const auto item_name = describe_flavor(player_ptr, *item, 0);
                 c_put_str(tval_to_attr[enum2i(item->bi_key.tval())], item_name, j + 2, 7);
             }
 

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -134,7 +134,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
                 return "";
             }
 
-            const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
+            const auto item_name = describe_flavor(player_ptr, *o_ptr, OD_NAME_ONLY);
             if (!input_check(format(_("本当に %s を呪いますか？", "Do you curse %s, really?"), item_name.data()))) {
                 return "";
             }
@@ -393,7 +393,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
             }
 
             o_ptr = &player_ptr->inventory_list[i_idx];
-            const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
+            const auto item_name = describe_flavor(player_ptr, *o_ptr, OD_NAME_ONLY);
             if (!input_check(format(_("本当に %s を呪いますか？", "Do you curse %s, really?"), item_name.data()))) {
                 return "";
             }

--- a/src/spell-kind/magic-item-recharger.cpp
+++ b/src/spell-kind/magic-item-recharger.cpp
@@ -121,7 +121,7 @@ bool recharge(PlayerType *player_ptr, int power)
     }
 
     if (o_ptr->is_fixed_artifact()) {
-        const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
+        const auto item_name = describe_flavor(player_ptr, *o_ptr, OD_NAME_ONLY);
         msg_format(_("魔力が逆流した！%sは完全に魔力を失った。", "The recharging backfires - %s is completely drained!"), item_name.data());
         if ((tval == ItemKindType::ROD) && (o_ptr->timeout < 10000)) {
             o_ptr->timeout = (o_ptr->timeout + 100) * 2;
@@ -131,7 +131,7 @@ bool recharge(PlayerType *player_ptr, int power)
         return update_player();
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     auto fail_type = 1;
     if (PlayerClass(player_ptr).is_wizard()) {
         /* 10% chance to blow up one rod, otherwise draining. */

--- a/src/spell-kind/spells-enchant.cpp
+++ b/src/spell-kind/spells-enchant.cpp
@@ -34,7 +34,7 @@ bool artifact_scroll(PlayerType *player_ptr)
         return false;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
 #ifdef JP
     msg_format("%s は眩い光を発した！", item_name.data());
 #else
@@ -96,7 +96,7 @@ bool artifact_scroll(PlayerType *player_ptr)
     }
 
     if (record_rand_art) {
-        const auto diary_item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
+        const auto diary_item_name = describe_flavor(player_ptr, *o_ptr, OD_NAME_ONLY);
         exe_write_diary(*player_ptr->current_floor_ptr, DiaryKind::ART_SCROLL, 0, diary_item_name);
     }
 

--- a/src/spell-kind/spells-equipment.cpp
+++ b/src/spell-kind/spells-equipment.cpp
@@ -47,7 +47,7 @@ bool apply_disenchant(PlayerType *player_ptr, BIT_FLAGS mode)
         return false;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     if (o_ptr->is_fixed_or_random_artifact() && evaluate_percent(71)) {
 #ifdef JP
         msg_format("%s(%c)は劣化を跳ね返した！", item_name.data(), index_to_label(t));

--- a/src/spell-kind/spells-fetcher.cpp
+++ b/src/spell-kind/spells-fetcher.cpp
@@ -109,7 +109,7 @@ void fetch_item(PlayerType *player_ptr, DIRECTION dir, WEIGHT wgt, bool require_
     o_ptr->iy = p_pos.y;
     o_ptr->ix = p_pos.x;
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, OD_NAME_ONLY);
     msg_format(_("%s^があなたの足元に飛んできた。", "%s^ flies through the air to your feet."), item_name.data());
     note_spot(player_ptr, p_pos.y, p_pos.x);
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::MAP);

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -370,7 +370,7 @@ bool destroy_area(PlayerType *player_ptr, const POSITION y1, const POSITION x1, 
                         item.get_fixed_artifact().is_generated = false;
 
                         if (in_generate && cheat_peek) {
-                            const auto item_name = describe_flavor(player_ptr, &item, (OD_NAME_ONLY | OD_STORE));
+                            const auto item_name = describe_flavor(player_ptr, item, (OD_NAME_ONLY | OD_STORE));
                             msg_format(_("伝説のアイテム (%s) は生成中に*破壊*された。", "Artifact (%s) was *destroyed* during generation."), item_name.data());
                         }
                     } else if (in_generate && cheat_peek && item.is_random_artifact()) {

--- a/src/spell-kind/spells-perception.cpp
+++ b/src/spell-kind/spells-perception.cpp
@@ -58,7 +58,7 @@ void identify_pack(PlayerType *player_ptr)
  */
 bool identify_item(PlayerType *player_ptr, ItemEntity *o_ptr)
 {
-    const auto known_item_name = describe_flavor(player_ptr, o_ptr, 0);
+    const auto known_item_name = describe_flavor(player_ptr, *o_ptr, 0);
     const auto old_known = any_bits(o_ptr->ident, IDENT_KNOWN);
     if (!o_ptr->is_fully_known()) {
         if (o_ptr->is_fixed_or_random_artifact() || one_in_(5)) {
@@ -88,7 +88,7 @@ bool identify_item(PlayerType *player_ptr, ItemEntity *o_ptr)
     angband_strcpy(record_o_name, known_item_name, MAX_NLEN);
     record_turn = AngbandWorld::get_instance().game_turn;
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_NAME_ONLY);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, OD_NAME_ONLY);
     const auto &floor = *player_ptr->current_floor_ptr;
     if (record_fix_art && !old_known && o_ptr->is_fixed_artifact()) {
         exe_write_diary(floor, DiaryKind::ART, 0, item_name);
@@ -136,7 +136,7 @@ bool ident_spell(PlayerType *player_ptr, bool only_equip)
 
     auto old_known = identify_item(player_ptr, o_ptr);
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
     if (i_idx >= INVEN_MAIN_HAND) {
         msg_format(_("%s^: %s(%c)。", "%s^: %s (%c)."), describe_use(player_ptr, i_idx), item_name.data(), index_to_label(i_idx));
     } else if (i_idx >= 0) {
@@ -189,7 +189,7 @@ bool identify_fully(PlayerType *player_ptr, bool only_equip)
 
     window_stuff(player_ptr);
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
     if (i_idx >= INVEN_MAIN_HAND) {
         msg_format(_("%s^: %s(%c)。", "%s^: %s (%c)."), describe_use(player_ptr, i_idx), item_name.data(), index_to_label(i_idx));
     } else if (i_idx >= 0) {

--- a/src/spell-realm/spells-craft.cpp
+++ b/src/spell-realm/spells-craft.cpp
@@ -298,7 +298,7 @@ bool pulish_shield(PlayerType *player_ptr)
         return false;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
     auto is_pulish_successful = o_ptr->is_valid() && !o_ptr->is_fixed_or_random_artifact() && !o_ptr->is_ego();
     is_pulish_successful &= !o_ptr->is_cursed();
     is_pulish_successful &= (o_ptr->bi_key.sval() != SV_MIRROR_SHIELD);

--- a/src/spell-realm/spells-nature.cpp
+++ b/src/spell-realm/spells-nature.cpp
@@ -28,7 +28,7 @@ bool rustproof(PlayerType *player_ptr)
         return false;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, OD_OMIT_PREFIX | OD_NAME_ONLY);
     o_ptr->art_flags.set(TR_IGNORE_ACID);
     if ((o_ptr->to_a < 0) && !o_ptr->is_cursed()) {
 #ifdef JP

--- a/src/spell-realm/spells-sorcery.cpp
+++ b/src/spell-realm/spells-sorcery.cpp
@@ -46,7 +46,7 @@ bool alchemy(PlayerType *player_ptr)
 
     const auto old_number = o_ptr->number;
     o_ptr->number = amt;
-    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
     o_ptr->number = old_number;
 
     if (!force) {

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -206,7 +206,7 @@ bool curse_armor(PlayerType *player_ptr)
         return false;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_OMIT_PREFIX);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, OD_OMIT_PREFIX);
 
     if (o_ptr->is_fixed_or_random_artifact() && one_in_(2)) {
 #ifdef JP
@@ -259,7 +259,7 @@ bool curse_weapon_object(PlayerType *player_ptr, bool force, ItemEntity *o_ptr)
         return false;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_OMIT_PREFIX);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, OD_OMIT_PREFIX);
     if (o_ptr->is_fixed_or_random_artifact() && one_in_(2) && !force) {
 #ifdef JP
         msg_format("%sが%sを包み込もうとしたが、%sはそれを跳ね返した！", "恐怖の暗黒オーラ", "武器", item_name.data());
@@ -482,7 +482,7 @@ bool enchant_spell(PlayerType *player_ptr, HIT_PROB num_hit, int num_dam, ARMOUR
         return false;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
 #ifdef JP
     msg_format("%s は明るく輝いた！", item_name.data());
 #else
@@ -550,7 +550,7 @@ void brand_weapon(PlayerType *player_ptr, int brand_type)
         return;
     }
 
-    const auto item_name = describe_flavor(player_ptr, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     concptr act = nullptr;
     switch (brand_type) {
     case 17:

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -590,7 +590,7 @@ bool cosmic_cast_off(PlayerType *player_ptr, ItemEntity **o_ptr_ptr)
     OBJECT_IDX old_o_idx = drop_near(player_ptr, &forge, 0, player_ptr->y, player_ptr->x);
     *o_ptr_ptr = &player_ptr->current_floor_ptr->o_list[old_o_idx];
 
-    const auto item_name = describe_flavor(player_ptr, &forge, OD_NAME_ONLY);
+    const auto item_name = describe_flavor(player_ptr, forge, OD_NAME_ONLY);
     msg_format(_("%sを脱ぎ捨てた。", "You cast off %s."), item_name.data());
     sound(SOUND_TAKE_OFF);
 

--- a/src/store/cmd-store.cpp
+++ b/src/store/cmd-store.cpp
@@ -177,7 +177,7 @@ void do_cmd_store(PlayerType *player_ptr)
                 msg_print(_("ザックからアイテムがあふれてしまった！", "Your pack overflows!"));
                 q_ptr = &forge;
                 q_ptr->copy_from(o_ptr);
-                const auto item_name = describe_flavor(player_ptr, q_ptr, 0);
+                const auto item_name = describe_flavor(player_ptr, *q_ptr, 0);
                 msg_format(_("%sが落ちた。(%c)", "You drop %s (%c)."), item_name.data(), index_to_label(i_idx));
                 vary_item(player_ptr, i_idx, -255);
                 handle_stuff(player_ptr);

--- a/src/store/museum.cpp
+++ b/src/store/museum.cpp
@@ -33,7 +33,7 @@ void museum_remove_object(PlayerType *player_ptr)
 
     const short item_num = *item_num_opt + store_top;
     const auto &item = st_ptr->stock[item_num];
-    const auto item_name = describe_flavor(player_ptr, item.get(), 0);
+    const auto item_name = describe_flavor(player_ptr, *item, 0);
     msg_print(_("展示をやめさせたアイテムは二度と見ることはできません！", "Once removed from the Museum, an item will be gone forever!"));
     if (!input_check(format(_("本当に%sの展示をやめさせますか？", "Really order to remove %s from the Museum? "), item_name.data()))) {
         return;

--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -100,7 +100,7 @@ static void take_item_from_home(PlayerType *player_ptr, ItemEntity *o_ptr, ItemE
     distribute_charges(o_ptr, j_ptr, amt);
 
     auto item_new = store_item_to_inventory(player_ptr, j_ptr);
-    const auto item_name = describe_flavor(player_ptr, &player_ptr->inventory_list[item_new], 0);
+    const auto item_name = describe_flavor(player_ptr, player_ptr->inventory_list[item_new], 0);
     handle_stuff(player_ptr);
     msg_format(_("%s(%c)を取った。", "You have %s (%c)."), item_name.data(), index_to_label(item_new));
 
@@ -246,7 +246,7 @@ void store_purchase(PlayerType *player_ptr, StoreSaleType store_num)
     }
 
     COMMAND_CODE item_new;
-    const auto purchased_item_name = describe_flavor(player_ptr, &item, 0);
+    const auto purchased_item_name = describe_flavor(player_ptr, item, 0);
     msg_format(_("%s(%c)を購入する。", "Buying %s (%c)."), purchased_item_name.data(), I2A(item_num));
     msg_print(nullptr);
 
@@ -287,7 +287,7 @@ void store_purchase(PlayerType *player_ptr, StoreSaleType store_num)
         exe_write_diary(floor, DiaryKind::BUY, 0, purchased_item_name);
     }
 
-    const auto diary_item_name = describe_flavor(player_ptr, item_store.get(), OD_NAME_ONLY);
+    const auto diary_item_name = describe_flavor(player_ptr, *item_store, OD_NAME_ONLY);
     if (record_rand_art && item_store->is_random_artifact()) {
         exe_write_diary(floor, DiaryKind::ART, 0, diary_item_name);
     }
@@ -302,7 +302,7 @@ void store_purchase(PlayerType *player_ptr, StoreSaleType store_num)
     item_new = store_item_to_inventory(player_ptr, &item);
     handle_stuff(player_ptr);
 
-    const auto got_item_name = describe_flavor(player_ptr, &player_ptr->inventory_list[item_new], 0);
+    const auto got_item_name = describe_flavor(player_ptr, player_ptr->inventory_list[item_new], 0);
     msg_format(_("%s(%c)を手に入れた。", "You have %s (%c)."), got_item_name.data(), index_to_label(item_new));
 
     if (item_store->is_wand_rod()) {

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -118,7 +118,7 @@ void display_rumor(PlayerType *player_ptr, bool ex)
         ItemEntity item(bi_id);
         item.fa_id = a_idx;
         item.ident = IDENT_STORE;
-        fullname = describe_flavor(player_ptr, &item, OD_NAME_ONLY);
+        fullname = describe_flavor(player_ptr, item, OD_NAME_ONLY);
     } else if (category == "MONSTER") {
         const auto &monster_name = tokens[1];
 

--- a/src/store/sell-order.cpp
+++ b/src/store/sell-order.cpp
@@ -131,7 +131,7 @@ void store_sell(PlayerType *player_ptr, StoreSaleType store_num)
 
     auto placed = false;
     if ((store_num != StoreSaleType::HOME) && (store_num != StoreSaleType::MUSEUM)) {
-        const auto item_name = describe_flavor(player_ptr, q_ptr, 0);
+        const auto item_name = describe_flavor(player_ptr, *q_ptr, 0);
         msg_format(_("%s(%c)を売却する。", "Selling %s (%c)."), item_name.data(), index_to_label(i_idx));
         msg_print(nullptr);
 
@@ -166,7 +166,7 @@ void store_sell(PlayerType *player_ptr, StoreSaleType store_num)
             }
 
             const auto value = q_ptr->get_price() * q_ptr->number;
-            const auto sold_item_name = describe_flavor(player_ptr, q_ptr, 0);
+            const auto sold_item_name = describe_flavor(player_ptr, *q_ptr, 0);
             msg_format(_("%sを $%dで売却しました。", "You sold %s for %d gold."), sold_item_name.data(), price);
 
             if (record_sell) {
@@ -193,7 +193,7 @@ void store_sell(PlayerType *player_ptr, StoreSaleType store_num)
             }
         }
     } else if (store_num == StoreSaleType::MUSEUM) {
-        const auto museum_item_name = describe_flavor(player_ptr, q_ptr, OD_NAME_ONLY);
+        const auto museum_item_name = describe_flavor(player_ptr, *q_ptr, OD_NAME_ONLY);
         if (-1 == store_check_num(q_ptr, store_num)) {
             msg_print(_("それと同じ品物は既に博物館にあるようです。", "The Museum already has one of those items."));
         } else {
@@ -220,7 +220,7 @@ void store_sell(PlayerType *player_ptr, StoreSaleType store_num)
         }
     } else {
         distribute_charges(o_ptr, q_ptr, amt);
-        const auto item_name = describe_flavor(player_ptr, q_ptr, 0);
+        const auto item_name = describe_flavor(player_ptr, *q_ptr, 0);
         msg_format(_("%sを置いた。(%c)", "You drop %s (%c)."), item_name.data(), index_to_label(i_idx));
         placed = true;
         vary_item(player_ptr, i_idx, -amt);

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -233,7 +233,7 @@ void store_examine(PlayerType *player_ptr, StoreSaleType store_num)
         return;
     }
 
-    const auto item_name = describe_flavor(player_ptr, item.get(), 0);
+    const auto item_name = describe_flavor(player_ptr, *item, 0);
     msg_format(_("%sを調べている...", "Examining %s..."), item_name.data());
     if (!screen_object(player_ptr, item.get(), SCROBJ_FORCE_DETAIL)) {
         msg_print(_("特に変わったところはないようだ。", "You see nothing special."));

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -239,7 +239,7 @@ static short describe_monster_item(PlayerType *player_ptr, GridExamination *ge_p
 {
     for (const auto this_o_idx : ge_ptr->m_ptr->hold_o_idx_list) {
         auto *o_ptr = &player_ptr->current_floor_ptr->o_list[this_o_idx];
-        const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+        const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
 #ifdef JP
         const auto out_val = format("%s%s%s%s[%s]", ge_ptr->s1, item_name.data(), ge_ptr->s2, ge_ptr->s3, ge_ptr->info);
 #else
@@ -308,7 +308,7 @@ static short describe_footing(PlayerType *player_ptr, GridExamination *ge_ptr)
     }
 
     auto *o_ptr = &player_ptr->current_floor_ptr->o_list[ge_ptr->floor_list[0]];
-    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
 #ifdef JP
     const auto out_val = format("%s%s%s%s[%s]", ge_ptr->s1, item_name.data(), ge_ptr->s2, ge_ptr->s3, ge_ptr->info);
 #else
@@ -400,7 +400,7 @@ static short describe_footing_sight(PlayerType *player_ptr, GridExamination *ge_
     }
 
     ge_ptr->boring = false;
-    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
 #ifdef JP
     const auto out_val = format("%s%s%s%s[%s]", ge_ptr->s1, item_name.data(), ge_ptr->s2, ge_ptr->s3, ge_ptr->info);
 #else

--- a/src/view/display-inventory.cpp
+++ b/src/view/display-inventory.cpp
@@ -62,7 +62,7 @@ COMMAND_CODE show_inventory(PlayerType *player_ptr, int target_item, BIT_FLAGS m
             out_color[k] = TERM_L_DARK;
         }
 
-        out_desc[k] = describe_flavor(player_ptr, o_ptr, 0);
+        out_desc[k] = describe_flavor(player_ptr, *o_ptr, 0);
         l = out_desc[k].length() + 5;
         if (show_weights) {
             l += 9;
@@ -167,7 +167,7 @@ void display_inventory(PlayerType *player_ptr, const ItemTester &item_tester)
         int cur_col = 3;
         term_erase(cur_col, i);
         term_putstr(0, i, cur_col, TERM_WHITE, label);
-        const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+        const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
         attr = tval_to_attr[enum2i(o_ptr->bi_key.tval()) % 128];
         if (o_ptr->timeout) {
             attr = TERM_L_DARK;

--- a/src/view/display-store.cpp
+++ b/src/view/display-store.cpp
@@ -64,7 +64,7 @@ void display_entry(PlayerType *player_ptr, int pos, StoreSaleType store_num)
             maxwid -= 10;
         }
 
-        const auto item_name = describe_flavor(player_ptr, item.get(), 0, maxwid);
+        const auto item_name = describe_flavor(player_ptr, *item, 0, maxwid);
         c_put_str(tval_to_attr[enum2i(item->bi_key.tval())], item_name, i + 6, cur_col);
 
         if (show_weights) {
@@ -80,7 +80,7 @@ void display_entry(PlayerType *player_ptr, int pos, StoreSaleType store_num)
         maxwid -= 7;
     }
 
-    const auto item_name = describe_flavor(player_ptr, item.get(), 0, maxwid);
+    const auto item_name = describe_flavor(player_ptr, *item, 0, maxwid);
     c_put_str(tval_to_attr[enum2i(item->bi_key.tval())], item_name, i + 6, cur_col);
 
     if (show_weights) {

--- a/src/view/object-describer.cpp
+++ b/src/view/object-describer.cpp
@@ -48,7 +48,7 @@ void inven_item_charges(const ItemEntity &item)
 void inven_item_describe(PlayerType *player_ptr, short i_idx)
 {
     auto *o_ptr = &player_ptr->inventory_list[i_idx];
-    const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
 #ifdef JP
     if (o_ptr->number <= 0) {
         msg_format("もう%sを持っていない。", item_name.data());
@@ -77,7 +77,7 @@ void display_koff(PlayerType *player_ptr)
     }
 
     const auto item = tracker.get_trackee();
-    const auto item_name = describe_flavor(player_ptr, &item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
+    const auto item_name = describe_flavor(player_ptr, item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
     term_putstr(0, 0, -1, TERM_WHITE, item_name);
     const auto sval = *item.bi_key.sval();
     const auto use_realm = PlayerRealm::get_realm_of_book(item.bi_key.tval());

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -334,7 +334,7 @@ static void display_equipment(PlayerType *player_ptr, const ItemTester &item_tes
             item_name = _("(武器を両手持ち)", "(wielding with two-hands)");
             attr = TERM_WHITE;
         } else {
-            item_name = describe_flavor(player_ptr, o_ptr, 0);
+            item_name = describe_flavor(player_ptr, *o_ptr, 0);
             attr = tval_to_attr[enum2i(o_ptr->bi_key.tval()) % 128];
         }
 
@@ -608,7 +608,7 @@ static void display_floor_item_list(PlayerType *player_ptr, const Pos2D &pos)
         if (is_hallucinated) {
             term_addstr(-1, TERM_WHITE, _("何か奇妙な物", "something strange"));
         } else {
-            const auto item_name = describe_flavor(player_ptr, &item, 0);
+            const auto item_name = describe_flavor(player_ptr, item, 0);
             TERM_COLOR attr = tval_to_attr[enum2i(tval) % 128];
             term_addstr(-1, attr, item_name);
         }
@@ -671,7 +671,7 @@ static void display_found_item_list(PlayerType *player_ptr)
 
     // 発見済みのアイテムを表示
     TERM_LEN term_y = 1;
-    for (auto item : found_item_list) {
+    for (auto item_ptr : found_item_list) {
         // 途中で行数が足りなくなったら終了。
         if (term_y >= hgt) {
             break;
@@ -680,16 +680,16 @@ static void display_found_item_list(PlayerType *player_ptr)
         term_gotoxy(0, term_y);
 
         // アイテムシンボル表示
-        const auto symbol = item->get_symbol();
+        const auto symbol = item_ptr->get_symbol();
         const auto symbol_str = format(" %c ", symbol.character);
         term_addstr(-1, symbol.color, symbol_str);
 
-        const auto item_name = describe_flavor(player_ptr, item, 0);
-        const auto color_code_for_item = tval_to_attr[enum2i(item->bi_key.tval()) % 128];
+        const auto item_name = describe_flavor(player_ptr, *item_ptr, 0);
+        const auto color_code_for_item = tval_to_attr[enum2i(item_ptr->bi_key.tval()) % 128];
         term_addstr(-1, color_code_for_item, item_name);
 
         // アイテム座標表示
-        const auto item_location = format("(X:%3d Y:%3d)", item->ix, item->iy);
+        const auto item_location = format("(X:%3d Y:%3d)", item_ptr->ix, item_ptr->iy);
         prt(item_location, term_y, wid - item_location.length() - 1);
 
         ++term_y;

--- a/src/window/main-window-equipments.cpp
+++ b/src/window/main-window-equipments.cpp
@@ -53,7 +53,7 @@ COMMAND_CODE show_equipment(PlayerType *player_ptr, int target_item, BIT_FLAGS m
             continue;
         }
 
-        const auto item_name = describe_flavor(player_ptr, o_ptr, 0);
+        const auto item_name = describe_flavor(player_ptr, *o_ptr, 0);
         if (is_two_handed) {
             out_desc[k] = _("(武器を両手持ち)", "(wielding with two-hands)");
             out_color[k] = TERM_WHITE;

--- a/src/window/main-window-util.cpp
+++ b/src/window/main-window-util.cpp
@@ -114,7 +114,7 @@ void print_map(PlayerType *player_ptr)
  */
 static void display_shortened_item_name(PlayerType *player_ptr, ItemEntity *o_ptr, int y)
 {
-    auto item_name = describe_flavor(player_ptr, o_ptr, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NAME_ONLY));
+    auto item_name = describe_flavor(player_ptr, *o_ptr, (OD_NO_FLAVOR | OD_OMIT_PREFIX | OD_NAME_ONLY));
     auto attr = tval_to_attr[enum2i(o_ptr->bi_key.tval()) % 128];
     if (player_ptr->effects()->hallucination().is_hallucinated()) {
         attr = TERM_WHITE;

--- a/src/wizard/artifact-analyzer.cpp
+++ b/src/wizard/artifact-analyzer.cpp
@@ -24,7 +24,7 @@
  */
 static std::string analyze_general(PlayerType *player_ptr, const ItemEntity *o_ptr)
 {
-    return describe_flavor(player_ptr, o_ptr, OD_NAME_AND_ENCHANT | OD_STORE | OD_DEBUG);
+    return describe_flavor(player_ptr, *o_ptr, OD_NAME_AND_ENCHANT | OD_STORE | OD_DEBUG);
 }
 
 /*!

--- a/src/wizard/items-spoiler.cpp
+++ b/src/wizard/items-spoiler.cpp
@@ -162,7 +162,7 @@ SpoilerOutputResultType spoil_obj_desc()
         for (const auto &bi_id : whats) {
             PlayerType dummy;
             const auto item = prepare_item_for_obj_desc(bi_id);
-            const auto item_name = describe_flavor(&dummy, &item, OD_NAME_ONLY | OD_STORE);
+            const auto item_name = describe_flavor(&dummy, item, OD_NAME_ONLY | OD_STORE);
             const auto &[depth, price] = get_info(item);
             const auto dam_or_ac = describe_dam_or_ac(item);
             const auto weight = describe_weight(item);

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -393,7 +393,7 @@ static void wiz_display_item(PlayerType *player_ptr, ItemEntity *o_ptr)
     }
 
     prt_alloc(o_ptr->bi_key, 1, 0);
-    const auto item_name = describe_flavor(player_ptr, o_ptr, OD_STORE);
+    const auto item_name = describe_flavor(player_ptr, *o_ptr, OD_STORE);
     prt(item_name, 2, j);
 
     auto line = 4;
@@ -811,9 +811,9 @@ static std::vector<FixedArtifactId> find_wishing_fixed_artifact(PlayerType *play
         ItemEntity item(artifact.bi_key);
         item.fa_id = fa_id;
 #ifdef JP
-        const auto item_name = describe_flavor(player_ptr, &item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
+        const auto item_name = describe_flavor(player_ptr, item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
 #else
-        auto item_name = describe_flavor(player_ptr, &item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
+        auto item_name = describe_flavor(player_ptr, item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
         str_tolower(item_name.data());
 #endif
         std::string art_description = artifact.name;
@@ -1016,9 +1016,9 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
 
             ItemEntity item(baseitem.idx);
 #ifdef JP
-            const auto item_name = describe_flavor(player_ptr, &item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
+            const auto item_name = describe_flavor(player_ptr, item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
 #else
-            auto item_name = describe_flavor(player_ptr, &item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
+            auto item_name = describe_flavor(player_ptr, item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
             str_tolower(item_name.data());
 #endif
             if (cheat_xtra) {

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -225,7 +225,7 @@ static std::string wiz_make_named_artifact_desc(PlayerType *player_ptr, FixedArt
     ItemEntity item(artifact.bi_key);
     item.fa_id = fa_id;
     item.mark_as_known();
-    return describe_flavor(player_ptr, &item, OD_NAME_ONLY);
+    return describe_flavor(player_ptr, item, OD_NAME_ONLY);
 }
 
 /**

--- a/src/wizard/wizard-spoiler.cpp
+++ b/src/wizard/wizard-spoiler.cpp
@@ -190,7 +190,7 @@ static SpoilerOutputResultType spoil_player_spell()
         std::string book_name = _("なし", "None");
         if (magic_ptr->spell_book != ItemKindType::NONE) {
             ItemEntity item({ magic_ptr->spell_book, 0 });
-            book_name = describe_flavor(&dummy_p, &item, OD_NAME_ONLY);
+            book_name = describe_flavor(&dummy_p, item, OD_NAME_ONLY);
             auto *s = angband_strchr(book_name.data(), '[');
             if (s != nullptr) {
                 book_name.erase(s - book_name.data());


### PR DESCRIPTION
1箇所を除いて単純置換です (その1箇所もコンパイル警告の除去)
ご確認下さい

単純置換ではない1箇所：
cmd-item/cmd-destroy.cpp L223 (コピーではなく参照で受けるように修正)