### PR TITLE
Visual Editor 周辺の小修正

### DIFF
--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -218,10 +218,10 @@ void do_cmd_visuals(PlayerType *player_ptr)
                 const auto &symbol_definition = monrace.symbol_definition;
                 auto &symbol_config = monrace.symbol_config;
                 term_putstr(5, 17, -1, TERM_WHITE, format(_("モンスター = %d, 名前 = %-40.40s", "Monster = %d, Name = %-40.40s"), enum2i(monrace_id), monrace.name.data()));
-                term_putstr(10, 19, -1, TERM_WHITE, format(_("初期値  色 / 文字 = %3u / %3u", "Default attr/char = %3u / %3u"), symbol_definition.color, symbol_definition.character));
+                term_putstr(10, 19, -1, TERM_WHITE, format(_("初期値  色 / 文字 = %3u / %3u", "Default attr/char = %3u / %3u"), symbol_definition.color, static_cast<uint8_t>(symbol_definition.character)));
                 term_putstr(40, 19, -1, TERM_WHITE, empty_symbol);
                 term_queue_bigchar(43, 19, { symbol_definition, {} });
-                term_putstr(10, 20, -1, TERM_WHITE, format(_("現在値  色 / 文字 = %3u / %3u", "Current attr/char = %3u / %3u"), symbol_config.color, symbol_config.character));
+                term_putstr(10, 20, -1, TERM_WHITE, format(_("現在値  色 / 文字 = %3u / %3u", "Current attr/char = %3u / %3u"), symbol_config.color, static_cast<uint8_t>(symbol_config.character)));
                 term_putstr(40, 20, -1, TERM_WHITE, empty_symbol);
                 term_queue_bigchar(43, 20, { symbol_config, {} });
                 term_putstr(0, 22, -1, TERM_WHITE, _("コマンド (n/N/^N/a/A/^A/c/C/^C/v/V/^V): ", "Command (n/N/^N/a/A/^A/c/C/^C/v/V/^V): "));

--- a/src/knowledge/knowledge-features.cpp
+++ b/src/knowledge/knowledge-features.cpp
@@ -109,7 +109,8 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
     TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, std::nullopt);
     std::map<int, DisplaySymbol> symbols;
     const auto &[wid, hgt] = term_get_size();
-    std::vector<FEAT_IDX> feat_idx(TerrainList::get_instance().size());
+    auto &terrains = TerrainList::get_instance();
+    std::vector<FEAT_IDX> feat_idx(terrains.size());
 
     const std::string terrain_group(_("地形    ", "Terrains")); //!< @details 他と合わせるためgroupと呼ぶ.
     const auto max_length = terrain_group.length();
@@ -126,7 +127,7 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
 
         feat_cnt = 0;
     } else {
-        auto &terrain = TerrainList::get_instance().get_terrain(direct_f_idx);
+        auto &terrain = terrains.get_terrain(direct_f_idx);
         auto &symbol_config = terrain.symbol_configs.at(*lighting_level);
         feat_idx[0] = direct_f_idx;
         feat_cnt = 1;
@@ -148,7 +149,6 @@ void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f
     bool flag = false;
     bool redraw = true;
     const auto is_wizard = AngbandWorld::get_instance().wizard;
-    auto &terrains = TerrainList::get_instance();
     auto &symbols_cb = DisplaySymbolsClipboard::get_instance();
     while (!flag) {
         char ch;


### PR DESCRIPTION
符号付き/なしで異常な表示になる可能性のある場所を符号なしに統一
TerrainList を2回取得している箇所を1回に統一

上記2点実施しました
たまたま目についたものの微修正なのでチケットはありません
ご確認下さい