### PR TITLE
coin_type とOBJ_GOLD_LIST を廃止し、財宝ドロップ関連処理をBaseitemList でモデル化した

### DIFF
--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -171,9 +171,8 @@ static void parse_qtw_D(PlayerType *player_ptr, qtwg_type *qtwg_ptr, char *s)
         } else if (item_index) {
             ItemEntity item(item_index);
             if (item.bi_key.tval() == ItemKindType::GOLD) {
-                coin_type = item_index - OBJ_GOLD_LIST;
-                item = floor.make_gold();
-                coin_type = 0;
+                const auto offset = BaseitemList::get_instance().lookup_gold_offset(item_index);
+                item = floor.make_gold(offset);
             }
 
             ItemMagicApplier(player_ptr, &item, floor.base_level, AM_NO_FIXED_ART | AM_GOOD).execute();

--- a/src/monster-floor/monster-death-util.cpp
+++ b/src/monster-floor/monster-death-util.cpp
@@ -9,34 +9,6 @@
 #include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 
-/*!
- * @brief モンスターを倒した際の財宝svalを返す
- * @param r_idx 倒したモンスターの種族ID
- * @return 財宝のsval
- * @details
- * Hack -- Return the "automatic coin type" of a monster race
- * Used to allocate proper treasure when "Creeping coins" die
- * Note the use of actual "monster names"
- */
-static int get_coin_type(MonraceId r_idx)
-{
-    switch (r_idx) {
-    case MonraceId::COPPER_COINS:
-        return 2;
-    case MonraceId::SILVER_COINS:
-        return 5;
-    case MonraceId::GOLD_COINS:
-        return 10;
-    case MonraceId::MITHRIL_COINS:
-    case MonraceId::MITHRIL_GOLEM:
-        return 16;
-    case MonraceId::ADAMANT_COINS:
-        return 17;
-    default:
-        return 0;
-    }
-}
-
 MonsterDeath::MonsterDeath(FloorType &floor, MONSTER_IDX m_idx, bool drop_item)
     : m_idx(m_idx)
     , m_ptr(&floor.m_list[m_idx])
@@ -50,6 +22,5 @@ MonsterDeath::MonsterDeath(FloorType &floor, MONSTER_IDX m_idx, bool drop_item)
     this->do_item = this->r_ptr->drop_flags.has_not(MonsterDropType::ONLY_GOLD);
     this->do_item |= this->r_ptr->drop_flags.has_any_of({ MonsterDropType::DROP_GOOD, MonsterDropType::DROP_GREAT });
     this->cloned = this->m_ptr->mflag2.has(MonsterConstantFlagType::CLONED);
-    this->force_coin = get_coin_type(this->m_ptr->r_idx);
     this->drop_chosen_item = drop_item && !this->cloned && !floor.inside_arena && !AngbandSystem::get_instance().is_phase_out() && !this->m_ptr->is_pet();
 }

--- a/src/monster-floor/monster-death-util.h
+++ b/src/monster-floor/monster-death-util.h
@@ -15,7 +15,6 @@ public:
     bool do_gold;
     bool do_item;
     bool cloned;
-    int force_coin;
     bool drop_chosen_item;
     POSITION md_y = 0;
     POSITION md_x = 0;

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -282,10 +282,12 @@ static void drop_items_golds(PlayerType *player_ptr, MonsterDeath *md_ptr, int d
     auto dump_item = 0;
     auto dump_gold = 0;
     auto &floor = *player_ptr->current_floor_ptr;
+    const auto &baseitems = BaseitemList::get_instance();
     for (auto i = 0; i < drop_numbers; i++) {
         ItemEntity item;
         if (md_ptr->do_gold && (!md_ptr->do_item || one_in_(2))) {
-            item = floor.make_gold();
+            const auto offset = baseitems.lookup_creeping_coin_drop_offset(md_ptr->m_ptr->r_idx);
+            item = floor.make_gold(offset);
             dump_gold++;
         } else {
             if (!make_object(player_ptr, &item, md_ptr->mo_mode)) {
@@ -299,7 +301,6 @@ static void drop_items_golds(PlayerType *player_ptr, MonsterDeath *md_ptr, int d
     }
 
     floor.object_level = floor.base_level;
-    coin_type = 0;
     auto visible = md_ptr->m_ptr->ml && !player_ptr->effects()->hallucination().is_hallucinated();
     visible |= (md_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE));
     if (visible && (dump_item || dump_gold)) {
@@ -396,8 +397,7 @@ void monster_death(PlayerType *player_ptr, MONSTER_IDX m_idx, bool drop_item, At
     decide_drop_quality(md_ptr);
     switch_special_death(player_ptr, md_ptr, attribute_flags);
     drop_artifacts(player_ptr, md_ptr);
-    int drop_numbers = decide_drop_numbers(md_ptr, drop_item, floor.inside_arena);
-    coin_type = md_ptr->force_coin;
+    const auto drop_numbers = decide_drop_numbers(md_ptr, drop_item, floor.inside_arena);
     floor.object_level = (floor.dun_level + md_ptr->r_ptr->level) / 2;
     drop_items_golds(player_ptr, md_ptr, drop_numbers);
     if ((md_ptr->r_ptr->misc_flags.has_not(MonsterMiscType::QUESTOR)) || AngbandSystem::get_instance().is_phase_out() || (md_ptr->m_ptr->r_idx != MonraceId::SERPENT) || md_ptr->cloned) {

--- a/src/system/baseitem-info.cpp
+++ b/src/system/baseitem-info.cpp
@@ -20,8 +20,11 @@
 #include "sv-definition/sv-staff-types.h"
 #include "sv-definition/sv-weapon-types.h"
 #include "system/angband-exceptions.h"
+#include "system/enums/monrace/monrace-id.h"
 #include "util/enum-converter.h"
 #include "util/string-processor.h"
+#include <algorithm>
+#include <numeric>
 #include <set>
 #include <unordered_map>
 
@@ -30,6 +33,28 @@ constexpr auto ITEM_NOT_BOW = "This item is not a bow!";
 constexpr auto ITEM_NOT_ROD = "This item is not a rod!";
 constexpr auto ITEM_NOT_LITE = "This item is not a lite!";
 constexpr auto INVALID_BI_ID_FORMAT = "Invalid Baseitem ID is specified! %d";
+constexpr auto INVALID_BASEITEM_KEY = "Invalid Baseitem Key is specified! Type: %d, Subtype: %d";
+const std::map<MoneyKind, std::string> GOLD_KINDS = {
+    { MoneyKind::COPPER, _("銅塊", "copper") },
+    { MoneyKind::SILVER, _("銀塊", "silver") },
+    { MoneyKind::GARNET, _("ガーネット", "garnets") },
+    { MoneyKind::GOLD, _("金塊", "gold") },
+    { MoneyKind::OPAL, _("オパール", "opals") },
+    { MoneyKind::SAPPHIRE, _("サファイア", "sapphires") },
+    { MoneyKind::RUBY, _("ルビー", "rubies") },
+    { MoneyKind::DIAMOND, _("ダイヤモンド", "diamonds") },
+    { MoneyKind::EMERALD, _("エメラルド", "emeralds") },
+    { MoneyKind::MITHRIL, _("ミスリル", "mithril") },
+    { MoneyKind::ADAMANTITE, _("アダマンタイト", "adamantite") },
+};
+const std::map<MonraceId, BaseitemKey> CREEPING_COIN_DROPS = {
+    { MonraceId::COPPER_COINS, { ItemKindType::GOLD, 3 } },
+    { MonraceId::SILVER_COINS, { ItemKindType::GOLD, 6 } },
+    { MonraceId::GOLD_COINS, { ItemKindType::GOLD, 11 } },
+    { MonraceId::MITHRIL_COINS, { ItemKindType::GOLD, 17 } },
+    { MonraceId::MITHRIL_GOLEM, { ItemKindType::GOLD, 17 } },
+    { MonraceId::ADAMANT_COINS, { ItemKindType::GOLD, 18 } },
+};
 }
 
 bool BaseitemKey::operator==(const BaseitemKey &other) const
@@ -663,6 +688,11 @@ std::string BaseitemInfo::stripped_name() const
     return ss.str();
 }
 
+bool BaseitemInfo::order_cost(const BaseitemInfo &other) const
+{
+    return this->cost < other.cost;
+}
+
 /*!
  * @brief 最初から簡易な名称が明らかなベースアイテムにその旨のフラグを立てる
  */
@@ -800,6 +830,81 @@ void BaseitemList::shrink_to_fit()
     this->baseitems.shrink_to_fit();
 }
 
+/*!
+ * @brief モンスター種族IDから財宝アイテムの価値を引く
+ * @param monrace_id モンスター種族ID
+ * @return 特定の財宝を落とすならそのアイテムの価値オフセット、一般的な財宝ドロップならばnullopt
+ */
+std::optional<int> BaseitemList::lookup_creeping_coin_drop_offset(MonraceId monrace_id) const
+{
+    const auto it = CREEPING_COIN_DROPS.find(monrace_id);
+    if (it == CREEPING_COIN_DROPS.end()) {
+        return std::nullopt;
+    }
+
+    return this->lookup_gold_offset(it->second);
+}
+
+/*!
+ * @brief ベースアイテム定義群から財宝アイテムの数を計算する
+ * @return 財宝を示すベースアイテム数
+ */
+int BaseitemList::calc_num_gold_subtypes() const
+{
+    static const auto &golds = this->create_sorted_golds();
+    static const auto sum = std::accumulate(golds.begin(), golds.end(), 0,
+        [](int count, const auto &pair) {
+            return count + pair.second.size();
+        });
+    return sum;
+}
+
+/*!
+ * @brief 財宝アイテムの価値からベースアイテムを引く
+ * @param target_offset 財宝アイテムの価値
+ * @return ベースアイテムID
+ * @details 同一の財宝カテゴリ内ならば常に大きいほど価値が高い.
+ * カテゴリが異なるならば価値の大小は保証しない. 即ち「最も高い銅貨>最も安い銀貨」はあり得る.
+ */
+const BaseitemInfo &BaseitemList::lookup_gold(int target_offset) const
+{
+    auto offset = 0;
+    for (const auto &pair : this->create_sorted_golds()) {
+        for (const auto &bi_key : pair.second) {
+            if (offset == target_offset) {
+                return this->get_baseitem(this->exe_lookup(bi_key));
+            }
+
+            offset++;
+        }
+    }
+
+    THROW_EXCEPTION(std::runtime_error, format("Invalid gold offset is specified! %d", target_offset));
+}
+
+/*!
+ * @brief ベースアイテムIDから財宝アイテムの価値を引く
+ * @param bi_id ベースアイテムID
+ * @return 財宝アイテムの価値オフセット
+ * @details 同一の財宝カテゴリ内ならば常に大きいほど価値が高い.
+ * カテゴリが異なるならば価値の大小は保証しない. 即ち「最も高い銅貨>最も安い銀貨」はあり得る.
+ */
+int BaseitemList::lookup_gold_offset(short bi_id) const
+{
+    auto offset = 0;
+    for (const auto &pair : this->create_sorted_golds()) {
+        for (const auto &bi_key : pair.second) {
+            if (bi_id == this->exe_lookup(bi_key)) {
+                return offset;
+            }
+
+            offset++;
+        }
+    }
+
+    THROW_EXCEPTION(std::runtime_error, format(INVALID_BI_ID_FORMAT, bi_id));
+}
+
 void BaseitemList::reset_all_visuals()
 {
     for (auto &baseitem : this->baseitems) {
@@ -892,8 +997,7 @@ short BaseitemList::exe_lookup(const BaseitemKey &bi_key) const
     static const auto &cache = create_baseitem_index_chache();
     const auto itr = cache.find(bi_key);
     if (itr == cache.end()) {
-        constexpr auto fmt = "Invalid Baseitem Key is specified! %d, %d";
-        THROW_EXCEPTION(std::runtime_error, format(fmt, enum2i(bi_key.tval()), *bi_key.sval()));
+        THROW_EXCEPTION(std::runtime_error, format(INVALID_BASEITEM_KEY, enum2i(bi_key.tval()), *bi_key.sval()));
     }
 
     return itr->second;
@@ -936,6 +1040,78 @@ const std::map<ItemKindType, std::vector<int>> &BaseitemList::create_baseitems_c
     }
 
     return cache;
+}
+
+/*!
+ * @brief ベースアイテムキーから財宝アイテムの価値を引く
+ * @param finding_bi_key 探索対象のベースアイテムキー
+ * @return 財宝アイテムの価値番号 (大きいほど価値が高い)
+ * @details 同一の財宝カテゴリ内ならば常に番号が大きいほど価値も高い.
+ * カテゴリが異なるならば価値の大小は保証しない. 即ち「最も高い銅貨>最も安い銀貨」はあり得る.
+ */
+int BaseitemList::lookup_gold_offset(const BaseitemKey &finding_bi_key) const
+{
+    auto offset = 0;
+    for (const auto &pair : this->create_sorted_golds()) {
+        for (const auto &bi_key : pair.second) {
+            if (finding_bi_key == bi_key) {
+                return offset;
+            }
+
+            offset++;
+        }
+    }
+
+    THROW_EXCEPTION(std::runtime_error, format(INVALID_BASEITEM_KEY, enum2i(finding_bi_key.tval()), *finding_bi_key.sval()));
+}
+
+/*!
+ * @brief ベースアイテム定義リストから財宝の辞書を作る (価値順)
+ * @return 財宝種別をキー、それに対応するベースアイテムキーの配列 (安い順にソート済)を値とした辞書
+ */
+const std::map<MoneyKind, std::vector<BaseitemKey>> &BaseitemList::create_sorted_golds() const
+{
+    static std::map<MoneyKind, std::vector<BaseitemKey>> list;
+    if (!list.empty()) {
+        return list;
+    }
+
+    list = this->create_unsorted_golds();
+    for (auto &[money_kind, bi_keys] : list) {
+        std::stable_sort(bi_keys.begin(), bi_keys.end(),
+            [this](const auto &bi_key1, const auto &bi_key2) {
+                const auto &baseitem1 = this->lookup_baseitem(bi_key1);
+                const auto &baseitem2 = this->lookup_baseitem(bi_key2);
+                return baseitem1.order_cost(baseitem2);
+            });
+    }
+
+    return list;
+}
+
+/*!
+ * @brief ベースアイテム定義リストから財宝の辞書を作る (ベースアイテムID順)
+ * @return 財宝種別をキー、それに対応するベースアイテムキーの配列を値とした辞書
+ */
+std::map<MoneyKind, std::vector<BaseitemKey>> BaseitemList::create_unsorted_golds() const
+{
+    std::map<MoneyKind, std::vector<BaseitemKey>> list;
+    for (const auto &baseitem : this->baseitems) {
+        const auto &bi_key = baseitem.bi_key;
+        if (bi_key.tval() != ItemKindType::GOLD) {
+            continue;
+        }
+
+        for (const auto money_kind : MONEY_KIND_RANGE) {
+            if (baseitem.name != GOLD_KINDS.at(money_kind)) {
+                continue;
+            }
+
+            list[money_kind].push_back(bi_key);
+        }
+    }
+
+    return list;
 }
 
 /*!

--- a/src/system/baseitem-info.h
+++ b/src/system/baseitem-info.h
@@ -196,6 +196,8 @@ public:
     void shrink_to_fit();
 
     std::optional<int> lookup_creeping_coin_drop_offset(MonraceId monrace_id) const;
+    short lookup_baseitem_id(const BaseitemKey &bi_key) const;
+    const BaseitemInfo &lookup_baseitem(const BaseitemKey &bi_key) const;
     int calc_num_gold_subtypes() const;
     const BaseitemInfo &lookup_gold(int target_offset) const;
     int lookup_gold_offset(short bi_id) const;
@@ -203,8 +205,6 @@ public:
     void reset_all_visuals();
     void reset_identification_flags();
     void mark_common_items_as_aware();
-    short lookup_baseitem_id(const BaseitemKey &bi_key) const;
-    const BaseitemInfo &lookup_baseitem(const BaseitemKey &bi_key) const;
     void shuffle_flavors();
 
 private:
@@ -213,13 +213,13 @@ private:
     static BaseitemList instance;
     std::vector<BaseitemInfo> baseitems{};
 
-    BaseitemInfo &lookup_baseitem(const BaseitemKey &bi_key);
     short exe_lookup(const BaseitemKey &bi_key) const;
     const std::map<BaseitemKey, short> &create_baseitem_index_chache() const;
     const std::map<ItemKindType, std::vector<int>> &create_baseitems_cache() const;
     int lookup_gold_offset(const BaseitemKey &finding_bi_key) const;
     const std::map<MoneyKind, std::vector<BaseitemKey>> &create_sorted_golds() const;
     std::map<MoneyKind, std::vector<BaseitemKey>> create_unsorted_golds() const;
-    
+
+    BaseitemInfo &lookup_baseitem(const BaseitemKey &bi_key);
     void shuffle_flavors(ItemKindType tval);
 };

--- a/src/system/baseitem-info.h
+++ b/src/system/baseitem-info.h
@@ -5,12 +5,31 @@
 #include "object/tval-types.h"
 #include "system/angband.h"
 #include "util/dice.h"
+#include "util/enum-range.h"
 #include "util/flag-group.h"
 #include "view/display-symbol.h"
 #include <array>
+#include <map>
 #include <optional>
 #include <string>
 #include <vector>
+
+enum class MoneyKind {
+    COPPER,
+    SILVER,
+    GARNET,
+    GOLD,
+    OPAL,
+    SAPPHIRE,
+    RUBY,
+    DIAMOND,
+    EMERALD,
+    MITHRIL,
+    ADAMANTITE,
+    MAX,
+};
+
+constexpr EnumRange<MoneyKind> MONEY_KIND_RANGE(MoneyKind::COPPER, MoneyKind::MAX);
 
 class BaseitemKey {
 public:
@@ -135,6 +154,7 @@ public:
 
     bool is_valid() const;
     std::string stripped_name() const;
+    bool order_cost(const BaseitemInfo &other) const;
     void decide_easy_know();
 
     /* @todo ここから下はBaseitemDefinitions.txt に依存しないミュータブルなフィールド群なので、将来的に分離予定 */
@@ -149,6 +169,7 @@ public:
     void mark_as_aware();
 };
 
+enum class MonraceId : short;
 class BaseitemList {
 public:
     BaseitemList(BaseitemList &&) = delete;
@@ -174,6 +195,11 @@ public:
     void resize(size_t new_size);
     void shrink_to_fit();
 
+    std::optional<int> lookup_creeping_coin_drop_offset(MonraceId monrace_id) const;
+    int calc_num_gold_subtypes() const;
+    const BaseitemInfo &lookup_gold(int target_offset) const;
+    int lookup_gold_offset(short bi_id) const;
+
     void reset_all_visuals();
     void reset_identification_flags();
     void mark_common_items_as_aware();
@@ -191,5 +217,9 @@ private:
     short exe_lookup(const BaseitemKey &bi_key) const;
     const std::map<BaseitemKey, short> &create_baseitem_index_chache() const;
     const std::map<ItemKindType, std::vector<int>> &create_baseitems_cache() const;
+    int lookup_gold_offset(const BaseitemKey &finding_bi_key) const;
+    const std::map<MoneyKind, std::vector<BaseitemKey>> &create_sorted_golds() const;
+    std::map<MoneyKind, std::vector<BaseitemKey>> create_unsorted_golds() const;
+    
     void shuffle_flavors(ItemKindType tval);
 };

--- a/src/system/floor-type-definition.cpp
+++ b/src/system/floor-type-definition.cpp
@@ -199,30 +199,30 @@ bool FloorType::order_pet_dismission(short index1, short index2, short riding_in
 
 /*!
  * @brief 生成階に応じた財宝を生成する.
+ * @param initial_offset 財宝を価値の低い順に並べた時の番号 (0スタート、nulloptならば乱数で決定)
  * @return 財宝データで初期化したアイテム
- * @todo クリーピングコインのドロップ判定はグローバル変数で判定しており、後で何とかする.
  */
-ItemEntity FloorType::make_gold() const
+ItemEntity FloorType::make_gold(std::optional<int> initial_offset) const
 {
-    int num_gold;
-    if (coin_type > 0) {
-        num_gold = coin_type;
+    int offset;
+    if (initial_offset) {
+        offset = *initial_offset;
     } else {
-        num_gold = ((randint1(this->object_level + 2) + 2) / 2) - 1;
+        offset = ((randint1(this->object_level + 2) + 2) / 2) - 1;
         if (one_in_(CHANCE_BASEITEM_LEVEL_BOOST)) {
-            num_gold += randint1(this->object_level + 1);
+            offset += randint1(this->object_level + 1);
         }
     }
 
-    //!< @todo 後でベースアイテムリストから動的に引けるようにする.
-    constexpr auto num_gold_subtypes = 18;
-    if (num_gold >= num_gold_subtypes) {
-        num_gold = num_gold_subtypes - 1;
+    const auto &baseitems = BaseitemList::get_instance();
+    const auto num_gold_subtypes = baseitems.calc_num_gold_subtypes();
+    if (offset >= num_gold_subtypes) {
+        offset = num_gold_subtypes - 1;
     }
 
-    ItemEntity item(OBJ_GOLD_LIST + num_gold);
-    const auto &baseitems = BaseitemList::get_instance();
-    const auto base = baseitems.get_baseitem(OBJ_GOLD_LIST + num_gold).cost;
+    const auto &baseitem = baseitems.lookup_gold(offset);
+    const auto base = baseitem.cost;
+    ItemEntity item(baseitem.bi_key);
     item.pval = base + (8 * randint1(base)) + randint1(8);
     return item;
 }

--- a/src/system/floor-type-definition.h
+++ b/src/system/floor-type-definition.h
@@ -9,12 +9,6 @@
 #include <vector>
 
 /*!
- * @brief ベースアイテムリストの内、財宝を示す最初のID
- * @todo 後でベースアイテムリストから動的に引けるようにする.
- */
-constexpr short OBJ_GOLD_LIST = 480;
-
-/*!
  * @brief プレイヤー用光源処理配列サイズ / Max array size of player's lite
  * @details 光源の最大半径は14,実グリッド数では581である.
  */
@@ -108,7 +102,7 @@ public:
     bool order_pet_whistle(short index1, short index2) const;
     bool order_pet_dismission(short index1, short index2, short riding_index) const;
 
-    ItemEntity make_gold() const;
+    ItemEntity make_gold(std::optional<int> initial_offset = std::nullopt) const;
     std::optional<ItemEntity> try_make_instant_artifact() const;
 
     void reset_mproc();

--- a/src/system/system-variables.cpp
+++ b/src/system/system-variables.cpp
@@ -30,5 +30,3 @@ init_flags_type init_flags; //!< @todo このグローバル変数何とかし�
  * Function hook to restrict "get_obj_index_prep()" function
  */
 bool (*get_obj_index_hook)(short bi_id);
-
-int coin_type;

--- a/src/system/system-variables.h
+++ b/src/system/system-variables.h
@@ -29,5 +29,4 @@ extern concptr ANGBAND_SYS;
 extern concptr ANGBAND_KEYBOARD;
 extern concptr ANGBAND_GRAF;
 
-extern int coin_type;
 extern bool (*get_obj_index_hook)(short bi_id);


### PR DESCRIPTION
Discord での議論により、レビュアーは @dis- 氏にお願いします
(#4608 との整合性は、CREEPING\_COIN\_DROPS においてキーをMonraceId から特定財宝ドロップフラグに変えることで実現できると思われます)

財宝に関して、以下を実現しました：
- 価値の低い順で並んでいる必要はない
- sval 順で並んでいる必要はない
- ベースアイテムIDが連続している必要はない
- バリアントなどで「最初の財宝」を示すベースアイテムIDが変わってもOK (現在はID 480)
- クリーピングコインの追加が(以前に比べて)簡単になった

手元で、ベースアイテム定義はas-is の条件で、developと同じ動作を確認しました：
- フロアのランダム床落ちが同じ
- クエストの固定床落ちが同じ
- クリーピングコインのドロップが個数・金額も含めて同じ
- 一般的な財宝ドロップモンスターのドロップが個数・種類も含めて同じ (金額までは上記で担保できていると考え省略)

テストとしては以下の項目が考えられます
追加財宝例は「スピネル」とか「途方も価値のない錆びた偽物の金塊」があります
もしヌケモレありましたら適宜追加実施お願いします
- ベースアイテムID 440～479 に財宝を追加しても正常動作する
  -  銅貨1 (ID 480)より価値の低いもの
  - アダマンタイトより価値の高いもの
  - 中間くらいの価値のもの
- ベースアイテムIDが指し示す中身を入れ替えても正常動作する (IDそのものを入れ替えると初期化処理でアウト)
  - 銅貨1と銀貨1
  - 銅貨3とアダマンタイト
  - その他
- アイテムの価値 (cost値)を入れ替えても正常動作する
  - ガーネットとエメラルド
  - ダイヤモンドとアダマンタイト
  - その他 (あくまでテストなので銅貨と銀貨なども？)
- IDの末尾に財宝を追加しても正常動作する (本PR提出時点での新規IDは682)
  - アダマンタイトより高い価値を持つものとする
  - サファイアと同じくらいの価値を持つものとする
  - 銅貨より安い価値を持つものとする