### PR TITLE
is_similar_for_store() をItemEntity のオブジェクトメソッドへ繰り込んだ

### DIFF
--- a/src/store/store-util.cpp
+++ b/src/store/store-util.cpp
@@ -97,91 +97,6 @@ std::vector<short> store_same_magic_device_pvals(ItemEntity *j_ptr)
 }
 
 /*!
- * @brief 店舗に並べた品を同一品であるかどうか判定する /
- * Determine if a store item can "absorb" another item
- * @param o_ptr 判定するオブジェクト構造体の参照ポインタ1
- * @param j_ptr 判定するオブジェクト構造体の参照ポインタ2
- * @return 同一扱いできるならTRUEを返す
- * @details
- * <pre>
- * See "object_similar()" for the same function for the "player"
- * </pre>
- */
-bool store_object_similar(const ItemEntity *o_ptr, const ItemEntity *j_ptr)
-{
-    if (o_ptr == j_ptr) {
-        return false;
-    }
-
-    if (o_ptr->bi_id != j_ptr->bi_id) {
-        return false;
-    }
-
-    if ((o_ptr->pval != j_ptr->pval) && !o_ptr->is_wand_rod()) {
-        return false;
-    }
-
-    if (o_ptr->to_h != j_ptr->to_h) {
-        return false;
-    }
-
-    if (o_ptr->to_d != j_ptr->to_d) {
-        return false;
-    }
-
-    if (o_ptr->to_a != j_ptr->to_a) {
-        return false;
-    }
-
-    if (o_ptr->ego_idx != j_ptr->ego_idx) {
-        return false;
-    }
-
-    if (o_ptr->is_fixed_or_random_artifact() || j_ptr->is_fixed_or_random_artifact()) {
-        return false;
-    }
-
-    if (o_ptr->art_flags != j_ptr->art_flags) {
-        return false;
-    }
-
-    if (o_ptr->timeout || j_ptr->timeout) {
-        return false;
-    }
-
-    if (o_ptr->ac != j_ptr->ac) {
-        return false;
-    }
-
-    if (o_ptr->damage_dice != j_ptr->damage_dice) {
-        return false;
-    }
-
-    const auto tval = o_ptr->bi_key.tval();
-    if (tval == ItemKindType::CHEST) {
-        return false;
-    }
-
-    if (tval == ItemKindType::STATUE) {
-        return false;
-    }
-
-    if (tval == ItemKindType::CAPTURE) {
-        return false;
-    }
-
-    if ((tval == ItemKindType::LITE) && (o_ptr->fuel != j_ptr->fuel)) {
-        return false;
-    }
-
-    if (o_ptr->discount != j_ptr->discount) {
-        return false;
-    }
-
-    return true;
-}
-
-/*!
  * @brief 店舗に並べた品を重ね合わせできるかどうか判定する /
  * Allow a store item to absorb another item
  * @param o_ptr 判定するオブジェクト構造体の参照ポインタ1
@@ -259,7 +174,7 @@ int store_carry(ItemEntity *o_ptr)
     o_ptr->feeling = FEEL_NONE;
     for (auto slot = 0; slot < st_ptr->stock_num; slot++) {
         auto &item = st_ptr->stock[slot];
-        if (store_object_similar(item.get(), o_ptr)) {
+        if (item->is_similar_for_store(*o_ptr)) {
             store_object_absorb(item.get(), o_ptr);
             return slot;
         }

--- a/src/store/store-util.cpp
+++ b/src/store/store-util.cpp
@@ -97,24 +97,18 @@ std::vector<short> store_same_magic_device_pvals(ItemEntity *j_ptr)
 }
 
 /*!
- * @brief 店舗に並べた品を重ね合わせできるかどうか判定する /
- * Allow a store item to absorb another item
- * @param o_ptr 判定するオブジェクト構造体の参照ポインタ1
- * @param j_ptr 判定するオブジェクト構造体の参照ポインタ2
- * @return 重ね合わせできるならTRUEを返す
- * @details
- * <pre>
- * See "object_similar()" for the same function for the "player"
- * </pre>
+ * @brief 店舗に並べた品を重ね合わせる
+ * @param item1 重ね合わせられて残る方のアイテムへの参照
+ * @param item2 重ね合わせるて消える方のアイテムへの参照
  */
-static void store_object_absorb(ItemEntity *o_ptr, ItemEntity *j_ptr)
+static void store_object_absorb(ItemEntity &item1, const ItemEntity &item2)
 {
-    int max_num = (o_ptr->bi_key.tval() == ItemKindType::ROD) ? std::min(99, MAX_SHORT / o_ptr->get_baseitem().pval) : 99;
-    int total = o_ptr->number + j_ptr->number;
-    int diff = (total > max_num) ? total - max_num : 0;
-    o_ptr->number = (total > max_num) ? max_num : total;
-    if (o_ptr->is_wand_rod()) {
-        o_ptr->pval += j_ptr->pval * (j_ptr->number - diff) / j_ptr->number;
+    const auto max_num = (item1.bi_key.tval() == ItemKindType::ROD) ? std::min(99, MAX_SHORT / item1.get_baseitem().pval) : 99;
+    const auto total = item1.number + item2.number;
+    const auto diff = (total > max_num) ? total - max_num : 0;
+    item1.number = (total > max_num) ? max_num : total;
+    if (item1.is_wand_rod()) {
+        item1.pval += item2.pval * (item2.number - diff) / item2.number;
     }
 }
 
@@ -175,7 +169,7 @@ int store_carry(ItemEntity *o_ptr)
     for (auto slot = 0; slot < st_ptr->stock_num; slot++) {
         auto &item = st_ptr->stock[slot];
         if (item->is_similar_for_store(*o_ptr)) {
-            store_object_absorb(item.get(), o_ptr);
+            store_object_absorb(*item, *o_ptr);
             return slot;
         }
     }

--- a/src/store/store-util.h
+++ b/src/store/store-util.h
@@ -57,4 +57,3 @@ std::vector<short> store_same_magic_device_pvals(ItemEntity *j_ptr);
 void store_item_increase(short i_idx, int item_num);
 void store_item_optimize(short i_idx);
 int store_carry(ItemEntity *o_ptr);
-bool store_object_similar(const ItemEntity *o_ptr, const ItemEntity *j_ptr);

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -133,7 +133,7 @@ int store_check_num(const ItemEntity *o_ptr, StoreSaleType store_num)
     } else {
         for (auto i = 0; i < st_ptr->stock_num; i++) {
             auto &item = st_ptr->stock[i];
-            if (store_object_similar(item.get(), o_ptr)) {
+            if (item->is_similar_for_store(*o_ptr)) {
                 return -1;
             }
         }

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -957,6 +957,85 @@ void ItemEntity::track_baseitem() const
     BaseitemTracker::get_instance().set_trackee(this->bi_id);
 }
 
+/*!
+ * @brief 店舗に並べた品を同一品であるかどうか判定する
+ * @param other 比較対象アイテムへの参照
+ * @return 同一扱いできるならTRUEを返す
+ */
+bool ItemEntity::is_similar_for_store(const ItemEntity &other) const
+{
+    if (this == &other) {
+        return false;
+    }
+
+    if (this->bi_id != other.bi_id) {
+        return false;
+    }
+
+    if ((this->pval != other.pval) && !this->is_wand_rod()) {
+        return false;
+    }
+
+    if (this->to_h != other.to_h) {
+        return false;
+    }
+
+    if (this->to_d != other.to_d) {
+        return false;
+    }
+
+    if (this->to_a != other.to_a) {
+        return false;
+    }
+
+    if (this->ego_idx != other.ego_idx) {
+        return false;
+    }
+
+    if (this->is_fixed_or_random_artifact() || other.is_fixed_or_random_artifact()) {
+        return false;
+    }
+
+    if (this->art_flags != other.art_flags) {
+        return false;
+    }
+
+    if (this->timeout || other.timeout) {
+        return false;
+    }
+
+    if (this->ac != other.ac) {
+        return false;
+    }
+
+    if (this->damage_dice != other.damage_dice) {
+        return false;
+    }
+
+    const auto tval = this->bi_key.tval();
+    if (tval == ItemKindType::CHEST) {
+        return false;
+    }
+
+    if (tval == ItemKindType::STATUE) {
+        return false;
+    }
+
+    if (tval == ItemKindType::CAPTURE) {
+        return false;
+    }
+
+    if ((tval == ItemKindType::LITE) && (this->fuel != other.fuel)) {
+        return false;
+    }
+
+    if (this->discount != other.discount) {
+        return false;
+    }
+
+    return true;
+}
+
 std::string ItemEntity::build_timeout_description(const ActivationType &act) const
 {
     const auto description = act.build_timeout_description();

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -160,6 +160,7 @@ public:
     bool has_monrace() const;
     const MonraceDefinition &get_monrace() const;
     void track_baseitem() const;
+    bool is_similar_for_store(const ItemEntity &other) const;
 
     void mark_as_known();
     void mark_as_tried() const;


### PR DESCRIPTION
unique\_ptr::get() を削減しました
https://github.com/hengband/hengband/pull/4616 がマージされるまでドラフトにしておきます