### PR TITLE
[Feature] 特定財宝ドロップを指定するフラグを有効にする

### DIFF
--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -286,7 +286,7 @@ static void drop_items_golds(PlayerType *player_ptr, MonsterDeath *md_ptr, int d
     for (auto i = 0; i < drop_numbers; i++) {
         ItemEntity item;
         if (md_ptr->do_gold && (!md_ptr->do_item || one_in_(2))) {
-            const auto offset = baseitems.lookup_creeping_coin_drop_offset(md_ptr->m_ptr->r_idx);
+            const auto offset = baseitems.lookup_specific_coin_drop_offset(md_ptr->r_ptr->drop_flags);
             item = floor.make_gold(offset);
             dump_gold++;
         } else {

--- a/src/system/baseitem-info.cpp
+++ b/src/system/baseitem-info.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "system/baseitem-info.h"
+#include "monster-race/race-drop-flags.h"
 #include "object/tval-types.h"
 #include "sv-definition/sv-armor-types.h"
 #include "sv-definition/sv-bow-types.h"
@@ -46,14 +47,6 @@ const std::map<MoneyKind, std::string> GOLD_KINDS = {
     { MoneyKind::EMERALD, _("エメラルド", "emeralds") },
     { MoneyKind::MITHRIL, _("ミスリル", "mithril") },
     { MoneyKind::ADAMANTITE, _("アダマンタイト", "adamantite") },
-};
-const std::map<MonraceId, BaseitemKey> CREEPING_COIN_DROPS = {
-    { MonraceId::COPPER_COINS, { ItemKindType::GOLD, 3 } },
-    { MonraceId::SILVER_COINS, { ItemKindType::GOLD, 6 } },
-    { MonraceId::GOLD_COINS, { ItemKindType::GOLD, 11 } },
-    { MonraceId::MITHRIL_COINS, { ItemKindType::GOLD, 17 } },
-    { MonraceId::MITHRIL_GOLEM, { ItemKindType::GOLD, 17 } },
-    { MonraceId::ADAMANT_COINS, { ItemKindType::GOLD, 18 } },
 };
 }
 
@@ -861,18 +854,47 @@ const BaseitemInfo &BaseitemList::lookup_baseitem(const BaseitemKey &bi_key) con
 }
 
 /*!
- * @brief モンスター種族IDから財宝アイテムの価値を引く
- * @param monrace_id モンスター種族ID
+ * @brief ドロップフラグから財宝アイテムの価値を引く
+ * @param drop_flags 該当モンスターのドロップ関連フラググループ
  * @return 特定の財宝を落とすならそのアイテムの価値オフセット、一般的な財宝ドロップならばnullopt
  */
-std::optional<int> BaseitemList::lookup_creeping_coin_drop_offset(MonraceId monrace_id) const
+std::optional<int> BaseitemList::lookup_specific_coin_drop_offset(EnumClassFlagGroup<MonsterDropType> &drop_flags) const
 {
-    const auto it = CREEPING_COIN_DROPS.find(monrace_id);
-    if (it == CREEPING_COIN_DROPS.end()) {
-        return std::nullopt;
+    if (drop_flags.has(MonsterDropType::DROP_COPPER)) {
+        return 2;
+    }
+    if (drop_flags.has(MonsterDropType::DROP_SILVER)) {
+        return 5;
+    }
+    if (drop_flags.has(MonsterDropType::DROP_GARNET)) {
+        return 7;
+    }
+    if (drop_flags.has(MonsterDropType::DROP_GOLD)) {
+        return 10;
+    }
+    if (drop_flags.has(MonsterDropType::DROP_OPAL)) {
+        return 11;
+    }
+    if (drop_flags.has(MonsterDropType::DROP_SAPPHIRE)) {
+        return 12;
+    }
+    if (drop_flags.has(MonsterDropType::DROP_RUBY)) {
+        return 13;
+    }
+    if (drop_flags.has(MonsterDropType::DROP_DIAMOND)) {
+        return 14;
+    }
+    if (drop_flags.has(MonsterDropType::DROP_EMERALD)) {
+        return 15;
+    }
+    if (drop_flags.has(MonsterDropType::DROP_MITHRIL)) {
+        return 16;
+    }
+    if (drop_flags.has(MonsterDropType::DROP_ADAMANTITE)) {
+        return 17;
     }
 
-    return this->lookup_gold_offset(it->second);
+    return std::nullopt;
 }
 
 /*!

--- a/src/system/baseitem-info.h
+++ b/src/system/baseitem-info.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "monster-race/race-drop-flags.h"
 #include "object-enchant/tr-flags.h"
 #include "object-enchant/trg-types.h"
 #include "object/tval-types.h"
@@ -195,7 +196,7 @@ public:
     void resize(size_t new_size);
     void shrink_to_fit();
 
-    std::optional<int> lookup_creeping_coin_drop_offset(MonraceId monrace_id) const;
+    std::optional<int> lookup_specific_coin_drop_offset(EnumClassFlagGroup<MonsterDropType> &drop_flags) const;
     short lookup_baseitem_id(const BaseitemKey &bi_key) const;
     const BaseitemInfo &lookup_baseitem(const BaseitemKey &bi_key) const;
     int calc_num_gold_subtypes() const;


### PR DESCRIPTION
関連Issue #4610
モンスター定義に特定の財宝を指定してドロップさせるフラグが #4608 で追加された。
これを有効にする。