### PR TITLE
隠しドアが見つからない不具合を修正した

### DIFF
--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -153,7 +153,8 @@ bool new_player_spot(PlayerType *player_ptr)
  */
 bool is_hidden_door(PlayerType *player_ptr, const Grid &grid)
 {
-    return (grid.mimic || grid.cave_has_flag(TerrainCharacteristics::SECRET)) && player_ptr->current_floor_ptr->is_closed_door(player_ptr->get_position());
+    (void)player_ptr; // 後でリファクタリングする.
+    return (grid.mimic || grid.cave_has_flag(TerrainCharacteristics::SECRET)) && grid.get_terrain().is_closed_door();
 }
 
 /*!


### PR DESCRIPTION
上から降ってきたGrid に対して判定が必要なところ、プレイヤー自身の座標にあるGrid で判定してしまっていました
ご確認下さい