### PR TITLE
is_hidden_door() をGrid のオブジェクトメソッドへ繰り込み、PlayerType への依存を外した

### DIFF
--- a/src/action/tunnel-execution.cpp
+++ b/src/action/tunnel-execution.cpp
@@ -118,7 +118,7 @@ bool exe_tunnel(PlayerType *player_ptr, POSITION y, POSITION x)
         }
     }
 
-    if (is_hidden_door(player_ptr, grid) && one_in_(4)) {
+    if (grid.is_hidden_door() && one_in_(4)) {
         search(player_ptr);
     }
 

--- a/src/effect/effect-feature.cpp
+++ b/src/effect/effect-feature.cpp
@@ -171,7 +171,7 @@ bool affect_feature(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION r, POS
         break;
     }
     case AttributeType::KILL_TRAP: {
-        if (is_hidden_door(player_ptr, grid)) {
+        if (grid.is_hidden_door()) {
             disclose_grid(player_ptr, y, x);
             if (known) {
                 obvious = true;

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -146,18 +146,6 @@ bool new_player_spot(PlayerType *player_ptr)
 }
 
 /*!
- * @brief マスに隠されたドアがあるかの判定を行う。 / Return TRUE if the given grid is a hidden closed door
- * @param player_ptr プレイヤーへの参照ポインタ
- * @param grid マス構造体の参照ポインタ
- * @return 隠されたドアがあるならTRUEを返す。
- */
-bool is_hidden_door(PlayerType *player_ptr, const Grid &grid)
-{
-    (void)player_ptr; // 後でリファクタリングする.
-    return (grid.mimic || grid.cave_has_flag(TerrainCharacteristics::SECRET)) && grid.get_terrain().is_closed_door();
-}
-
-/*!
  * @brief 指定された座標のマスが現在照らされているかを返す。 / Check for "local" illumination
  * @param y y座標
  * @param x x座標

--- a/src/grid/grid.h
+++ b/src/grid/grid.h
@@ -67,7 +67,6 @@ class MonraceDefinition;
 enum class GridCountKind;
 enum class TerrainCharacteristics;
 bool new_player_spot(PlayerType *player_ptr);
-bool is_hidden_door(PlayerType *player_ptr, const Grid &grid);
 bool player_can_enter(PlayerType *player_ptr, FEAT_IDX feature, BIT_FLAGS16 mode);
 bool feat_uses_special(FEAT_IDX f_idx);
 void update_local_illumination(PlayerType *player_ptr, POSITION y, POSITION x);

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -73,7 +73,7 @@ static void discover_hidden_things(PlayerType *player_ptr, const Pos2D &pos)
         disturb(player_ptr, false, true);
     }
 
-    if (is_hidden_door(player_ptr, grid)) {
+    if (grid.is_hidden_door()) {
         msg_print(_("隠しドアを発見した。", "You have found a secret door."));
         disclose_grid(player_ptr, pos.y, pos.x);
         disturb(player_ptr, false, false);

--- a/src/system/grid-type-definition.cpp
+++ b/src/system/grid-type-definition.cpp
@@ -101,6 +101,16 @@ bool Grid::is_rune_explosion() const
     return this->is_object() && TerrainList::get_instance().get_terrain(this->mimic).flags.has(TerrainCharacteristics::RUNE_EXPLOSION);
 }
 
+/*!
+ * @brief マスに隠されたドアがあるかの判定
+ * @return 隠されたドアがあるか否か
+ */
+bool Grid::is_hidden_door() const
+{
+    const auto is_secret = (this->mimic > 0) || this->cave_has_flag(TerrainCharacteristics::SECRET);
+    return is_secret && this->get_terrain().is_closed_door();
+}
+
 bool Grid::has_monster() const
 {
     return is_monster(this->m_idx);

--- a/src/system/grid-type-definition.h
+++ b/src/system/grid-type-definition.h
@@ -79,6 +79,7 @@ public:
     bool is_mirror() const;
     bool is_rune_protection() const;
     bool is_rune_explosion() const;
+    bool is_hidden_door() const;
     bool has_monster() const;
     uint8_t get_cost(GridFlow gf) const;
     uint8_t get_distance(GridFlow gf) const;


### PR DESCRIPTION
リリース直前に出た不具合修正について、変更範囲からPlayerType がなくなったので掲題の通りリファクタリングしました
軽微なのでチケットはありません
ご確認下さい