### PR TITLE
モンスター種族IDではなくモンスターの特定財宝ドロップフラグに基づいて生成する財宝を選択するようにした

### DIFF
--- a/VisualStudio/Hengband/Hengband.vcxproj
+++ b/VisualStudio/Hengband/Hengband.vcxproj
@@ -620,6 +620,7 @@
     <ClCompile Include="..\..\src\system\item-entity.cpp" />
     <ClCompile Include="..\..\src\system\monster-race-info.cpp" />
     <ClCompile Include="..\..\src\system\player-type-definition.cpp" />
+    <ClCompile Include="..\..\src\system\services\baseitem-monrace-service.cpp" />
     <ClCompile Include="..\..\src\system\terrain-type-definition.cpp" />
     <ClCompile Include="..\..\src\target\grid-selector.cpp" />
     <ClCompile Include="..\..\src\target\projection-path-calculator.cpp" />
@@ -1441,6 +1442,7 @@
     <ClInclude Include="..\..\src\system\floor-type-definition.h" />
     <ClInclude Include="..\..\src\system\grid-type-definition.h" />
     <ClInclude Include="..\..\src\system\player-type-definition.h" />
+    <ClInclude Include="..\..\src\system\services\baseitem-monrace-service.h" />
     <ClInclude Include="..\..\src\system\terrain-type-definition.h" />
     <ClInclude Include="..\..\src\target\grid-selector.h" />
     <ClInclude Include="..\..\src\target\projection-path-calculator.h" />

--- a/VisualStudio/Hengband/Hengband.vcxproj.filters
+++ b/VisualStudio/Hengband/Hengband.vcxproj.filters
@@ -2535,6 +2535,9 @@
     <ClCompile Include="..\..\src\system\baseitem\baseitem-list.cpp">
       <Filter>system\baseitem</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\system\services\baseitem-monrace-service.cpp">
+      <Filter>system\services</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5490,6 +5493,9 @@
     <ClInclude Include="..\..\src\system\baseitem\baseitem-list.h">
       <Filter>system\baseitem</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\system\services\baseitem-monrace-service.h">
+      <Filter>system\services</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\src\wall.bmp" />
@@ -5765,6 +5771,9 @@
     </Filter>
     <Filter Include="system\baseitem">
       <UniqueIdentifier>{b1f45c00-0add-4e05-8c05-bac1f29550c6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="system\services">
+      <UniqueIdentifier>{0f6862b2-2ab3-4d92-abc2-09a28f3a17b4}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -949,6 +949,8 @@ hengband_SOURCES = \
 	system/enums/monrace/monrace-id.h \
 	system/enums/grid-count-kind.h \
 	\
+	system/services/baseitem-monrace-service.cpp system/services/baseitem-monrace-service.h \
+	\
 	target/grid-selector.cpp target/grid-selector.h \
 	target/projection-path-calculator.cpp target/projection-path-calculator.h \
 	target/target-checker.cpp target/target-checker.h \

--- a/src/main/angband-initializer.cpp
+++ b/src/main/angband-initializer.cpp
@@ -25,6 +25,7 @@
 #include "system/angband-system.h"
 #include "system/dungeon-info.h"
 #include "system/monster-race-info.h"
+#include "system/services/baseitem-monrace-service.h"
 #include "system/system-variables.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
@@ -188,6 +189,10 @@ void init_angband(PlayerType *player_ptr, bool no_term)
 
     init_note(_("[データの初期化中... (モンスター)]", "[Initializing arrays... (monsters)]"));
     init_monrace_definitions();
+    const auto error = BaseitemMonraceService::check_drop_flags();
+    if (error) {
+        quit(*error);
+    }
 
     init_note(_("[データの初期化中... (ダンジョン)]", "[Initializing arrays... (dungeon)]"));
     init_dungeons_info();

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -41,6 +41,7 @@
 #include "system/monster-race-info.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
+#include "system/services/baseitem-monrace-service.h"
 #include "system/system-variables.h"
 #include "timed-effect/timed-effects.h"
 #include "util/bit-flags-calculator.h"
@@ -284,13 +285,12 @@ static void drop_items_golds(PlayerType *player_ptr, MonsterDeath *md_ptr, int d
     auto dump_item = 0;
     auto dump_gold = 0;
     auto &floor = *player_ptr->current_floor_ptr;
-    const auto &baseitems = BaseitemList::get_instance();
     const auto &monraces = MonraceList::get_instance();
     for (auto i = 0; i < drop_numbers; i++) {
         ItemEntity item;
         if (md_ptr->do_gold && (!md_ptr->do_item || one_in_(2))) {
             const auto &monrace = monraces.get_monrace(md_ptr->m_ptr->r_idx);
-            const auto offset = baseitems.lookup_creeping_coin_drop_offset(monrace.drop_flags);
+            const auto offset = BaseitemMonraceService::lookup_specific_gold_drop_offset(monrace.drop_flags);
             item = floor.make_gold(offset);
             dump_gold++;
         } else {

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -285,10 +285,12 @@ static void drop_items_golds(PlayerType *player_ptr, MonsterDeath *md_ptr, int d
     auto dump_gold = 0;
     auto &floor = *player_ptr->current_floor_ptr;
     const auto &baseitems = BaseitemList::get_instance();
+    const auto &monraces = MonraceList::get_instance();
     for (auto i = 0; i < drop_numbers; i++) {
         ItemEntity item;
         if (md_ptr->do_gold && (!md_ptr->do_item || one_in_(2))) {
-            const auto offset = baseitems.lookup_creeping_coin_drop_offset(md_ptr->m_ptr->r_idx);
+            const auto &monrace = monraces.get_monrace(md_ptr->m_ptr->r_idx);
+            const auto offset = baseitems.lookup_creeping_coin_drop_offset(monrace.drop_flags);
             item = floor.make_gold(offset);
             dump_gold++;
         } else {

--- a/src/system/baseitem/baseitem-list.cpp
+++ b/src/system/baseitem/baseitem-list.cpp
@@ -11,7 +11,6 @@
 #include "system/angband-exceptions.h"
 #include "system/baseitem/baseitem-definition.h"
 #include "system/baseitem/baseitem-key.h"
-#include "system/enums/monrace/monrace-id.h"
 #include "util/enum-converter.h"
 #include "util/enum-range.h"
 #include "util/string-processor.h"
@@ -36,13 +35,18 @@ const std::map<MoneyKind, std::string> GOLD_KINDS = {
     { MoneyKind::MITHRIL, _("ミスリル", "mithril") },
     { MoneyKind::ADAMANTITE, _("アダマンタイト", "adamantite") },
 };
-const std::map<MonraceId, BaseitemKey> CREEPING_COIN_DROPS = {
-    { MonraceId::COPPER_COINS, { ItemKindType::GOLD, 3 } },
-    { MonraceId::SILVER_COINS, { ItemKindType::GOLD, 6 } },
-    { MonraceId::GOLD_COINS, { ItemKindType::GOLD, 11 } },
-    { MonraceId::MITHRIL_COINS, { ItemKindType::GOLD, 17 } },
-    { MonraceId::MITHRIL_GOLEM, { ItemKindType::GOLD, 17 } },
-    { MonraceId::ADAMANT_COINS, { ItemKindType::GOLD, 18 } },
+const std::map<MonsterDropType, BaseitemKey> CREEPING_COIN_DROPS = {
+    { MonsterDropType::DROP_COPPER, { ItemKindType::GOLD, 3 } },
+    { MonsterDropType::DROP_SILVER, { ItemKindType::GOLD, 6 } },
+    { MonsterDropType::DROP_GARNET, { ItemKindType::GOLD, 8 } },
+    { MonsterDropType::DROP_GOLD, { ItemKindType::GOLD, 11 } },
+    { MonsterDropType::DROP_OPAL, { ItemKindType::GOLD, 12 } },
+    { MonsterDropType::DROP_SAPPHIRE, { ItemKindType::GOLD, 13 } },
+    { MonsterDropType::DROP_RUBY, { ItemKindType::GOLD, 14 } },
+    { MonsterDropType::DROP_DIAMOND, { ItemKindType::GOLD, 15 } },
+    { MonsterDropType::DROP_EMERALD, { ItemKindType::GOLD, 16 } },
+    { MonsterDropType::DROP_MITHRIL, { ItemKindType::GOLD, 17 } },
+    { MonsterDropType::DROP_ADAMANTITE, { ItemKindType::GOLD, 18 } },
 };
 }
 
@@ -166,14 +170,17 @@ const BaseitemDefinition &BaseitemList::lookup_baseitem(const BaseitemKey &bi_ke
  * @param monrace_id モンスター種族ID
  * @return 特定の財宝を落とすならそのアイテムの価値オフセット、一般的な財宝ドロップならばnullopt
  */
-std::optional<int> BaseitemList::lookup_creeping_coin_drop_offset(MonraceId monrace_id) const
+std::optional<int> BaseitemList::lookup_creeping_coin_drop_offset(const EnumClassFlagGroup<MonsterDropType> &flags) const
 {
-    const auto it = CREEPING_COIN_DROPS.find(monrace_id);
-    if (it == CREEPING_COIN_DROPS.end()) {
-        return std::nullopt;
+    for (const auto &pair : CREEPING_COIN_DROPS) {
+        if (flags.has_not(pair.first)) {
+            continue;
+        }
+
+        return this->lookup_gold_offset(pair.second);
     }
 
-    return this->lookup_gold_offset(it->second);
+    return std::nullopt;
 }
 
 /*!

--- a/src/system/baseitem/baseitem-list.h
+++ b/src/system/baseitem/baseitem-list.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include "monster-race/race-drop-flags.h"
+#include "util/flag-group.h"
 #include <map>
 #include <optional>
 #include <vector>
@@ -54,7 +56,7 @@ public:
     void resize(size_t new_size);
     void shrink_to_fit();
 
-    std::optional<int> lookup_creeping_coin_drop_offset(MonraceId monrace_id) const;
+    std::optional<int> lookup_creeping_coin_drop_offset(const EnumClassFlagGroup<MonsterDropType> &flags) const;
     short lookup_baseitem_id(const BaseitemKey &bi_key) const;
     const BaseitemDefinition &lookup_baseitem(const BaseitemKey &bi_key) const;
     int calc_num_gold_subtypes() const;

--- a/src/system/baseitem/baseitem-list.h
+++ b/src/system/baseitem/baseitem-list.h
@@ -6,8 +6,6 @@
 
 #pragma once
 
-#include "monster-race/race-drop-flags.h"
-#include "util/flag-group.h"
 #include <map>
 #include <optional>
 #include <vector>
@@ -56,12 +54,12 @@ public:
     void resize(size_t new_size);
     void shrink_to_fit();
 
-    std::optional<int> lookup_creeping_coin_drop_offset(const EnumClassFlagGroup<MonsterDropType> &flags) const;
     short lookup_baseitem_id(const BaseitemKey &bi_key) const;
     const BaseitemDefinition &lookup_baseitem(const BaseitemKey &bi_key) const;
     int calc_num_gold_subtypes() const;
     const BaseitemDefinition &lookup_gold(int target_offset) const;
     int lookup_gold_offset(short bi_id) const;
+    int lookup_gold_offset(const BaseitemKey &finding_bi_key) const;
 
     void reset_all_visuals();
     void reset_identification_flags();
@@ -77,7 +75,6 @@ private:
     short exe_lookup(const BaseitemKey &bi_key) const;
     const std::map<BaseitemKey, short> &create_baseitem_keys_cache() const;
     const std::map<ItemKindType, std::vector<int>> &create_baseitem_subtypes_cache() const;
-    int lookup_gold_offset(const BaseitemKey &finding_bi_key) const;
     const std::map<MoneyKind, std::vector<BaseitemKey>> &create_sorted_golds() const;
     std::map<MoneyKind, std::vector<BaseitemKey>> create_unsorted_golds() const;
 

--- a/src/system/services/baseitem-monrace-service.cpp
+++ b/src/system/services/baseitem-monrace-service.cpp
@@ -1,0 +1,51 @@
+/*!
+ * @brief ベースアイテムとモンスター種族を接続するサービスクラス実装
+ * @author Hourier
+ * @date 2024/11/26
+ */
+
+#include "system/services/baseitem-monrace-service.h"
+#include "locale/language-switcher.h"
+#include "system/baseitem/baseitem-definition.h"
+#include "system/baseitem/baseitem-key.h"
+#include "system/baseitem/baseitem-list.h"
+#include "system/monster-race-info.h"
+#include "term/z-form.h"
+#include "util/enum-converter.h"
+#include <map>
+#include <set>
+
+namespace {
+const std::map<MonsterDropType, BaseitemKey> SPECIFIC_GOLD_DROPS = {
+    { MonsterDropType::DROP_COPPER, { ItemKindType::GOLD, 3 } },
+    { MonsterDropType::DROP_SILVER, { ItemKindType::GOLD, 6 } },
+    { MonsterDropType::DROP_GARNET, { ItemKindType::GOLD, 8 } },
+    { MonsterDropType::DROP_GOLD, { ItemKindType::GOLD, 11 } },
+    { MonsterDropType::DROP_OPAL, { ItemKindType::GOLD, 12 } },
+    { MonsterDropType::DROP_SAPPHIRE, { ItemKindType::GOLD, 13 } },
+    { MonsterDropType::DROP_RUBY, { ItemKindType::GOLD, 14 } },
+    { MonsterDropType::DROP_DIAMOND, { ItemKindType::GOLD, 15 } },
+    { MonsterDropType::DROP_EMERALD, { ItemKindType::GOLD, 16 } },
+    { MonsterDropType::DROP_MITHRIL, { ItemKindType::GOLD, 17 } },
+    { MonsterDropType::DROP_ADAMANTITE, { ItemKindType::GOLD, 18 } },
+};
+}
+
+/*!
+ * @brief モンスター種族IDから財宝アイテムの価値を引く
+ * @param monrace_id モンスター種族ID
+ * @return 特定の財宝を落とすならそのアイテムの価値オフセット、一般的な財宝ドロップならばnullopt
+ */
+std::optional<int> BaseitemMonraceService::lookup_specific_gold_drop_offset(const EnumClassFlagGroup<MonsterDropType> &flags)
+{
+    const auto &baseitems = BaseitemList::get_instance();
+    for (const auto &pair : SPECIFIC_GOLD_DROPS) {
+        if (flags.has_not(pair.first)) {
+            continue;
+        }
+
+        return baseitems.lookup_gold_offset(pair.second);
+    }
+
+    return std::nullopt;
+}

--- a/src/system/services/baseitem-monrace-service.cpp
+++ b/src/system/services/baseitem-monrace-service.cpp
@@ -49,3 +49,25 @@ std::optional<int> BaseitemMonraceService::lookup_specific_gold_drop_offset(cons
 
     return std::nullopt;
 }
+
+std::optional<std::string> BaseitemMonraceService::check_drop_flags()
+{
+    const auto &monraces = MonraceList::get_instance();
+    for (const auto &[monrace_id, monrace] : monraces) {
+        std::set<MonsterDropType> flags;
+        for (const auto &[flag, _] : SPECIFIC_GOLD_DROPS) {
+            if (monrace.drop_flags.has_not(flag)) {
+                continue;
+            }
+
+            flags.insert(flag);
+            if (flags.size() > 1) {
+                constexpr auto fmt = _("財宝種別は同時に2つ以上指定できません。 ID: %d",
+                    "You cannot specify more than one treasure type at the same time. ID: %d");
+                return format(fmt, enum2i(monrace_id));
+            }
+        }
+    }
+
+    return std::nullopt;
+}

--- a/src/system/services/baseitem-monrace-service.h
+++ b/src/system/services/baseitem-monrace-service.h
@@ -1,0 +1,19 @@
+/*!
+ * @brief ベースアイテムとモンスター種族を接続するサービスクラス定義
+ * @author Hourier
+ * @date 2024/11/26
+ * @details サービスクラスはステートレスであるべきなのでメソッドは全てstatic である
+ */
+
+#pragma once
+
+#include "monster-race/race-drop-flags.h"
+#include "util/flag-group.h"
+#include <optional>
+#include <string>
+
+class BaseitemMonraceService {
+public:
+    BaseitemMonraceService() = delete;
+    static std::optional<int> lookup_specific_gold_drop_offset(const EnumClassFlagGroup<MonsterDropType> &flags);
+};

--- a/src/system/services/baseitem-monrace-service.h
+++ b/src/system/services/baseitem-monrace-service.h
@@ -16,4 +16,5 @@ class BaseitemMonraceService {
 public:
     BaseitemMonraceService() = delete;
     static std::optional<int> lookup_specific_gold_drop_offset(const EnumClassFlagGroup<MonsterDropType> &flags);
+    static std::optional<std::string> check_drop_flags();
 };


### PR DESCRIPTION
※ これは摺り合わせのための暫定ドラフトです

#4608 で導入されたフラグを組み込みました
設計上の課題2点についてはスルー中です：
- ベースアイテムとモンスター種族 (のフラグ)が密結合のままである。後でサービスクラス化して差し替えることを検討
- 同一モンスター種族に2つ以上の特定財宝ドロップ (例：DROP\_SILVER かつDROP\_EMERALD)があってもスルーしてしまう。チェックルーチンを検討中