### PR TITLE
[Refactor] 特殊財宝ドロップフラグの重複チェック処理

### DIFF
--- a/src/main/angband-initializer.cpp
+++ b/src/main/angband-initializer.cpp
@@ -189,7 +189,7 @@ void init_angband(PlayerType *player_ptr, bool no_term)
 
     init_note(_("[データの初期化中... (モンスター)]", "[Initializing arrays... (monsters)]"));
     init_monrace_definitions();
-    const auto error = BaseitemMonraceService::check_drop_flags();
+    const auto error = BaseitemMonraceService::check_specific_drop_gold_flags_duplication();
     if (error) {
         quit(*error);
     }

--- a/src/system/services/baseitem-monrace-service.cpp
+++ b/src/system/services/baseitem-monrace-service.cpp
@@ -29,6 +29,16 @@ const std::map<MonsterDropType, BaseitemKey> SPECIFIC_GOLD_DROPS = {
     { MonsterDropType::DROP_MITHRIL, { ItemKindType::GOLD, 17 } },
     { MonsterDropType::DROP_ADAMANTITE, { ItemKindType::GOLD, 18 } },
 };
+
+EnumClassFlagGroup<MonsterDropType> make_specific_gold_drop_flags()
+{
+    EnumClassFlagGroup<MonsterDropType> flags;
+    for (const auto &[flag, _] : SPECIFIC_GOLD_DROPS) {
+        flags.set(flag);
+    }
+
+    return flags;
+}
 }
 
 /*!
@@ -50,22 +60,18 @@ std::optional<int> BaseitemMonraceService::lookup_specific_gold_drop_offset(cons
     return std::nullopt;
 }
 
-std::optional<std::string> BaseitemMonraceService::check_drop_flags()
+std::optional<std::string> BaseitemMonraceService::check_specific_drop_gold_flags_duplication()
 {
+    const auto specific_gold_drop_flags = make_specific_gold_drop_flags();
+
     const auto &monraces = MonraceList::get_instance();
     for (const auto &[monrace_id, monrace] : monraces) {
-        std::set<MonsterDropType> flags;
-        for (const auto &[flag, _] : SPECIFIC_GOLD_DROPS) {
-            if (monrace.drop_flags.has_not(flag)) {
-                continue;
-            }
+        const auto monrace_specific_gold_drop_flags = specific_gold_drop_flags & monrace.drop_flags;
 
-            flags.insert(flag);
-            if (flags.size() > 1) {
-                constexpr auto fmt = _("財宝種別は同時に2つ以上指定できません。 ID: %d",
-                    "You cannot specify more than one treasure type at the same time. ID: %d");
-                return format(fmt, enum2i(monrace_id));
-            }
+        if (monrace_specific_gold_drop_flags.count() > 1) {
+            constexpr auto fmt = _("財宝種別は同時に2つ以上指定できません。 ID: %d",
+                "You cannot specify more than one treasure type at the same time. ID: %d");
+            return format(fmt, enum2i(monrace_id));
         }
     }
 

--- a/src/system/services/baseitem-monrace-service.h
+++ b/src/system/services/baseitem-monrace-service.h
@@ -16,5 +16,5 @@ class BaseitemMonraceService {
 public:
     BaseitemMonraceService() = delete;
     static std::optional<int> lookup_specific_gold_drop_offset(const EnumClassFlagGroup<MonsterDropType> &flags);
-    static std::optional<std::string> check_drop_flags();
+    static std::optional<std::string> check_specific_drop_gold_flags_duplication();
 };


### PR DESCRIPTION
- ロジックの修正で可読性と計算量のオーダーの改善
- 関数名をチェック内容がわかりやすいように変更

PR #4651 を見てのちょっとした改善点なので、単独Issueは無し。
※ 今思うと `std::bitset` のメソッド名に合わせたような記憶があるので、discordで言及した `EnumClassFlagGroup::count()` -> `popcount()` の変更は見送り。