### PR TITLE
財宝価値決定式の変更、および生成階層とレアリティの調整

### DIFF
--- a/lib/edit/BaseitemDefinitions.jsonc
+++ b/lib/edit/BaseitemDefinitions.jsonc
@@ -16506,15 +16506,15 @@
       "allocations": [
         {
           "depth": 1,
-          "rarity": 10
+          "rarity": 15
         },
         {
           "depth": 10,
-          "rarity": 5
+          "rarity": 10
         },
         {
           "depth": 12,
-          "rarity": 2
+          "rarity": 4
         }
       ]
     },
@@ -16539,15 +16539,15 @@
       "allocations": [
         {
           "depth": 1,
-          "rarity": 10
+          "rarity": 15
         },
         {
           "depth": 10,
-          "rarity": 5
+          "rarity": 10
         },
         {
           "depth": 14,
-          "rarity": 2
+          "rarity": 4
         }
       ]
     },
@@ -16671,19 +16671,19 @@
       "allocations": [
         {
           "depth": 1,
-          "rarity": 10
+          "rarity": 15
         },
         {
           "depth": 10,
-          "rarity": 5
+          "rarity": 10
         },
         {
           "depth": 20,
-          "rarity": 3
+          "rarity": 6
         },
         {
           "depth": 22,
-          "rarity": 2
+          "rarity": 4
         }
       ]
     },
@@ -16708,19 +16708,19 @@
       "allocations": [
         {
           "depth": 1,
-          "rarity": 10
+          "rarity": 15
         },
         {
           "depth": 10,
-          "rarity": 5
+          "rarity": 10
         },
         {
           "depth": 20,
-          "rarity": 3
+          "rarity": 6
         },
         {
           "depth": 24,
-          "rarity": 2
+          "rarity": 4
         }
       ]
     },
@@ -16745,19 +16745,19 @@
       "allocations": [
         {
           "depth": 1,
-          "rarity": 10
+          "rarity": 15
         },
         {
           "depth": 10,
-          "rarity": 5
+          "rarity": 12
         },
         {
           "depth": 20,
-          "rarity": 3
+          "rarity": 8
         },
         {
           "depth": 26,
-          "rarity": 2
+          "rarity": 6
         }
       ]
     },
@@ -16782,19 +16782,19 @@
       "allocations": [
         {
           "depth": 1,
-          "rarity": 10
+          "rarity": 15
         },
         {
           "depth": 10,
-          "rarity": 5
+          "rarity": 12
         },
         {
           "depth": 20,
-          "rarity": 3
+          "rarity": 8
         },
         {
           "depth": 28,
-          "rarity": 2
+          "rarity": 6
         }
       ]
     },
@@ -16819,19 +16819,19 @@
       "allocations": [
         {
           "depth": 1,
-          "rarity": 10
+          "rarity": 15
         },
         {
           "depth": 10,
-          "rarity": 5
+          "rarity": 12
         },
         {
           "depth": 20,
-          "rarity": 3
+          "rarity": 8
         },
         {
           "depth": 30,
-          "rarity": 2
+          "rarity": 6
         }
       ]
     },
@@ -16856,19 +16856,19 @@
       "allocations": [
         {
           "depth": 1,
-          "rarity": 12
+          "rarity": 20
         },
         {
           "depth": 10,
-          "rarity": 6
+          "rarity": 16
         },
         {
-          "depth": 20,
-          "rarity": 4
+          "depth": 25,
+          "rarity": 12
         },
         {
           "depth": 40,
-          "rarity": 3
+          "rarity": 8
         }
       ]
     },
@@ -16893,19 +16893,19 @@
       "allocations": [
         {
           "depth": 1,
-          "rarity": 12
+          "rarity": 20
         },
         {
           "depth": 10,
-          "rarity": 6
+          "rarity": 16
         },
         {
-          "depth": 20,
-          "rarity": 4
+          "depth": 25,
+          "rarity": 12
         },
         {
           "depth": 50,
-          "rarity": 3
+          "rarity": 8
         }
       ]
     },

--- a/src/system/floor-type-definition.cpp
+++ b/src/system/floor-type-definition.cpp
@@ -288,7 +288,7 @@ ItemEntity FloorType::make_gold(std::optional<BaseitemKey> bi_key) const
     }
 
     const auto base = item.get_baseitem_cost();
-    item.pval = base + (8 * randint1(base)) + randint1(8);
+    item.pval = 3 * base + randint1(6 * base);
     return item;
 }
 


### PR DESCRIPTION
従来の財宝価値決定式は下限が低かったため、「当たり」財宝を引いてもがっかりするケースがそれなりにあった。
価値決定式を 3 * cost + 1d(6 * cost) として最低値を担保しつつある程度のバラツキを維持する。

合わせて財宝の生成階層とレアリティの見直しを行った。
高すぎた宝石類の生成確率を少し絞り、財宝生成ルーチン変更前のバランスに近づけた。
具体的には生成パワー1, 10, 20それぞれで財宝生成ルーチン変更前の1.5-2.0倍程度の収入になるように調整した。