### PR TITLE
地上でLv1の財宝ドロップモンスターを倒すと異常アイテムを生成してしまう不具合を修正した

### DIFF
--- a/src/system/floor-type-definition.cpp
+++ b/src/system/floor-type-definition.cpp
@@ -277,6 +277,7 @@ bool FloorType::order_pet_dismission(short index1, short index2, short riding_in
  * @brief 特定の財宝を生成する。指定がない場合、生成階に応じたランダムな財宝を生成する。
  * @param bi_key 財宝を固定生成する場合のBaseitemKey
  * @return 財宝データで初期化したアイテム
+ * @details 生成レベルが0になったら1に補正する
  */
 ItemEntity FloorType::make_gold(std::optional<BaseitemKey> bi_key) const
 {
@@ -284,7 +285,8 @@ ItemEntity FloorType::make_gold(std::optional<BaseitemKey> bi_key) const
     if (bi_key) {
         item = ItemEntity(*bi_key);
     } else {
-        item = ItemEntity(get_obj_index(this, this->object_level, AM_GOLD));
+        const auto level = this->object_level <= 0 ? 1 : this->object_level;
+        item = ItemEntity(get_obj_index(this, level, AM_GOLD));
     }
 
     const auto base = item.get_baseitem_cost();


### PR DESCRIPTION
コードを確認したところ、地上ならば生成基準階層を1Fに固定すればなさそうだと判断しました
ご確認下さい