### PR TITLE
[Feature] 財宝:黒曜石の追加、および財宝全体の生成階層、レアリティの調整

### DIFF
--- a/lib/edit/BaseitemDefinitions.jsonc
+++ b/lib/edit/BaseitemDefinitions.jsonc
@@ -22869,6 +22869,43 @@
         "ja": "安っぽい紙切れだ。グングニルの隠し場所でも書いてあるのだろうか。",
         "en": "It's a cheap piece of paper.  You should wonder if the hidden location of Gungnir is written."
       }
+    },
+    {
+      "id": 682,
+      "name": {
+        "ja": "黒曜石",
+        "en": "obsidian"
+      },
+      "symbol": {
+        "character": "$",
+        "color": "Dark Gray"
+      },
+      "itemkind": {
+        "type_value": 127,
+        "subtype_value": 19
+      },
+      "parameter_value": 0,
+      "level": 1,
+      "weight": 0,
+      "cost": 20,
+      "allocations": [
+        {
+          "depth": 1,
+          "rarity": 12
+        },
+        {
+          "depth": 5,
+          "rarity": 10
+        },
+        {
+          "depth": 10,
+          "rarity": 8
+        },
+        {
+          "depth": 12,
+          "rarity": 5
+        }
+      ]
     }
   ]
 }

--- a/lib/edit/BaseitemDefinitions.jsonc
+++ b/lib/edit/BaseitemDefinitions.jsonc
@@ -16332,7 +16332,7 @@
       "allocations": [
         {
           "depth": 1,
-          "rarity": 10
+          "rarity": 1
         },
         {
           "depth": 1,
@@ -16361,10 +16361,10 @@
       "allocations": [
         {
           "depth": 1,
-          "rarity": 10
+          "rarity": 1
         },
         {
-          "depth": 2,
+          "depth": 1,
           "rarity": 1
         }
       ]
@@ -16390,10 +16390,10 @@
       "allocations": [
         {
           "depth": 1,
-          "rarity": 10
+          "rarity": 1
         },
         {
-          "depth": 4,
+          "depth": 1,
           "rarity": 1
         }
       ]
@@ -16415,11 +16415,15 @@
       "parameter_value": 0,
       "level": 1,
       "weight": 0,
-      "cost": 8,
+      "cost": 9,
       "allocations": [
         {
           "depth": 1,
-          "rarity": 8
+          "rarity": 3
+        },
+        {
+          "depth": 5,
+          "rarity": 2
         },
         {
           "depth": 6,
@@ -16444,11 +16448,15 @@
       "parameter_value": 0,
       "level": 1,
       "weight": 0,
-      "cost": 9,
+      "cost": 10,
       "allocations": [
         {
           "depth": 1,
-          "rarity": 8
+          "rarity": 3
+        },
+        {
+          "depth": 5,
+          "rarity": 2
         },
         {
           "depth": 8,
@@ -16473,11 +16481,15 @@
       "parameter_value": 0,
       "level": 1,
       "weight": 0,
-      "cost": 10,
+      "cost": 11,
       "allocations": [
         {
           "depth": 1,
-          "rarity": 8
+          "rarity": 3
+        },
+        {
+          "depth": 5,
+          "rarity": 2
         },
         {
           "depth": 10,
@@ -16506,15 +16518,19 @@
       "allocations": [
         {
           "depth": 1,
-          "rarity": 15
+          "rarity": 12
         },
         {
-          "depth": 10,
+          "depth": 5,
           "rarity": 10
         },
         {
+          "depth": 10,
+          "rarity": 8
+        },
+        {
           "depth": 12,
-          "rarity": 4
+          "rarity": 5
         }
       ]
     },
@@ -16539,15 +16555,19 @@
       "allocations": [
         {
           "depth": 1,
-          "rarity": 15
+          "rarity": 12
         },
         {
-          "depth": 10,
+          "depth": 5,
           "rarity": 10
         },
         {
+          "depth": 10,
+          "rarity": 8
+        },
+        {
           "depth": 14,
-          "rarity": 4
+          "rarity": 5
         }
       ]
     },
@@ -16568,15 +16588,19 @@
       "parameter_value": 0,
       "level": 1,
       "weight": 0,
-      "cost": 16,
+      "cost": 15,
       "allocations": [
         {
           "depth": 1,
           "rarity": 10
         },
         {
+          "depth": 5,
+          "rarity": 3
+        },
+        {
           "depth": 10,
-          "rarity": 5
+          "rarity": 2
         },
         {
           "depth": 16,
@@ -16601,15 +16625,19 @@
       "parameter_value": 0,
       "level": 1,
       "weight": 0,
-      "cost": 17,
+      "cost": 16,
       "allocations": [
         {
           "depth": 1,
           "rarity": 10
         },
         {
+          "depth": 5,
+          "rarity": 3
+        },
+        {
           "depth": 10,
-          "rarity": 5
+          "rarity": 2
         },
         {
           "depth": 18,
@@ -16634,15 +16662,19 @@
       "parameter_value": 0,
       "level": 1,
       "weight": 0,
-      "cost": 18,
+      "cost": 17,
       "allocations": [
         {
           "depth": 1,
           "rarity": 10
         },
         {
+          "depth": 5,
+          "rarity": 3
+        },
+        {
           "depth": 10,
-          "rarity": 5
+          "rarity": 2
         },
         {
           "depth": 20,
@@ -16683,7 +16715,7 @@
         },
         {
           "depth": 22,
-          "rarity": 4
+          "rarity": 5
         }
       ]
     },
@@ -16720,7 +16752,7 @@
         },
         {
           "depth": 24,
-          "rarity": 4
+          "rarity": 5
         }
       ]
     },
@@ -16856,7 +16888,7 @@
       "allocations": [
         {
           "depth": 1,
-          "rarity": 20
+          "rarity": 25
         },
         {
           "depth": 10,
@@ -16893,7 +16925,7 @@
       "allocations": [
         {
           "depth": 1,
-          "rarity": 20
+          "rarity": 25
         },
         {
           "depth": 10,

--- a/schema/MonraceDefinitions.schema.json
+++ b/schema/MonraceDefinitions.schema.json
@@ -467,6 +467,7 @@
                                 "DROP_EMERALD",
                                 "DROP_MITHRIL",
                                 "DROP_ADAMANTITE",
+                                "DROP_OBSIDIAN",
                                 "WILD_ONLY",
                                 "WILD_TOWN",
                                 "WILD_SHORE",

--- a/src/info-reader/race-info-tokens-table.cpp
+++ b/src/info-reader/race-info-tokens-table.cpp
@@ -369,6 +369,7 @@ const std::unordered_map<std::string_view, MonsterDropType> r_info_drop_flags = 
     { "DROP_EMERALD", MonsterDropType::DROP_EMERALD },
     { "DROP_MITHRIL", MonsterDropType::DROP_MITHRIL },
     { "DROP_ADAMANTITE", MonsterDropType::DROP_ADAMANTITE },
+    { "DROP_OBSIDIAN", MonsterDropType::DROP_OBSIDIAN },
 };
 
 const std::unordered_map<std::string_view, MonsterWildernessType> r_info_wilderness_flags = {

--- a/src/monster-race/race-drop-flags.h
+++ b/src/monster-race/race-drop-flags.h
@@ -24,5 +24,6 @@ enum class MonsterDropType {
     DROP_EMERALD = 20,
     DROP_MITHRIL = 21,
     DROP_ADAMANTITE = 22,
+    DROP_OBSIDIAN = 23,
     MAX,
 };

--- a/src/system/services/baseitem-monrace-service.cpp
+++ b/src/system/services/baseitem-monrace-service.cpp
@@ -27,6 +27,7 @@ const std::map<MonsterDropType, BaseitemKey> FIXED_GOLD_DROPS = {
     { MonsterDropType::DROP_EMERALD, { ItemKindType::GOLD, 16 } },
     { MonsterDropType::DROP_MITHRIL, { ItemKindType::GOLD, 17 } },
     { MonsterDropType::DROP_ADAMANTITE, { ItemKindType::GOLD, 18 } },
+    { MonsterDropType::DROP_OBSIDIAN, { ItemKindType::GOLD, 19 } },
 };
 
 EnumClassFlagGroup<MonsterDropType> make_fixed_gold_drop_flags()


### PR DESCRIPTION
財宝生成調整の一環として低層に宝石類を追加で配置した。
12Fで出現率が最大になる。cost=20なので価格は60+1d120となる。

合わせて財宝類全体の生成階層とレアリティの見直しを行った。
前回の調整から以下を修正。
・生成パワー1,10,20,40の価格期待値を正確に出し、単調に増加するよう調整
・調整が甘く期待値が高すぎたため生成確率を従来の1.5-2.0倍を目安に再度修正

価値20以上の宝石類、価値50以上の上位宝石類の生成分布を以下のように調整した。

poewr1/宝石類7.8%/上位宝石類4.0%/財宝期待値$63
power10/宝石類11.4%/上位宝石類4.8%/財宝期待値$83
power20/宝石類15.3%/上位宝石類6.4%/財宝期待値$94
power40/宝石類19.9%/上位宝石類10.5%/財宝期待値$112