### PR TITLE
store_type::stock へのアクセスをunique_ptr から参照に差し替えた

### DIFF
--- a/src/io-dump/random-art-info-dumper.cpp
+++ b/src/io-dump/random-art-info-dumper.cpp
@@ -92,14 +92,14 @@ void spoil_random_artifact(PlayerType *player_ptr)
 
             const auto *store_ptr = &towns_info[1].stores[StoreSaleType::HOME];
             for (int i = 0; i < store_ptr->stock_num; i++) {
-                auto &item = store_ptr->stock[i];
-                spoil_random_artifact_aux(player_ptr, *item, tval, ofs);
+                auto &item = *store_ptr->stock[i];
+                spoil_random_artifact_aux(player_ptr, item, tval, ofs);
             }
 
             store_ptr = &towns_info[1].stores[StoreSaleType::MUSEUM];
             for (int i = 0; i < store_ptr->stock_num; i++) {
-                auto &item = store_ptr->stock[i];
-                spoil_random_artifact_aux(player_ptr, *item, tval, ofs);
+                auto &item = *store_ptr->stock[i];
+                spoil_random_artifact_aux(player_ptr, item, tval, ofs);
             }
         }
     }

--- a/src/knowledge/knowledge-inventory.cpp
+++ b/src/knowledge/knowledge-inventory.cpp
@@ -260,12 +260,12 @@ static void show_home_equipment_resistances(PlayerType *player_ptr, ItemKindType
     char where[32];
     strcpy(where, _("家", "H "));
     for (int i = 0; i < store_ptr->stock_num; i++) {
-        const auto &item = store_ptr->stock[i];
-        if (!check_item_knowledge(*item, tval)) {
+        const auto &item = *store_ptr->stock[i];
+        if (!check_item_knowledge(item, tval)) {
             continue;
         }
 
-        do_cmd_knowledge_inventory_aux(player_ptr, fff, *item, where);
+        do_cmd_knowledge_inventory_aux(player_ptr, fff, item, where);
         add_res_label(label_number, fff);
     }
 }

--- a/src/load/store-loader.cpp
+++ b/src/load/store-loader.cpp
@@ -30,12 +30,12 @@
 static void home_carry_load(PlayerType *player_ptr, store_type *store_ptr, ItemEntity *o_ptr)
 {
     for (auto i = 0; i < store_ptr->stock_num; i++) {
-        auto &item = store_ptr->stock[i];
-        if (!item->is_similar(*o_ptr)) {
+        auto &item = *store_ptr->stock[i];
+        if (!item.is_similar(*o_ptr)) {
             continue;
         }
 
-        item->absorb(*o_ptr);
+        item.absorb(*o_ptr);
         return;
     }
 

--- a/src/player/process-death.cpp
+++ b/src/player/process-death.cpp
@@ -256,13 +256,13 @@ static void home_aware(PlayerType *player_ptr)
     for (size_t i = 1; i < towns_info.size(); i++) {
         auto *store_ptr = &towns_info[i].stores[StoreSaleType::HOME];
         for (auto j = 0; j < store_ptr->stock_num; j++) {
-            auto &item = store_ptr->stock[j];
-            if (!item->is_valid()) {
+            auto &item = *store_ptr->stock[j];
+            if (!item.is_valid()) {
                 continue;
             }
 
-            object_aware(player_ptr, *item);
-            item->mark_as_known();
+            object_aware(player_ptr, item);
+            item.mark_as_known();
         }
     }
 }
@@ -311,10 +311,10 @@ static void show_dead_home_items(PlayerType *player_ptr)
         for (int i = 0, k = 0; i < store_ptr->stock_num; k++) {
             term_clear();
             for (int j = 0; (j < 12) && (i < store_ptr->stock_num); j++, i++) {
-                const auto &item = store_ptr->stock[i];
+                const auto &item = *store_ptr->stock[i];
                 prt(format("%c) ", I2A(j)), j + 2, 4);
-                const auto item_name = describe_flavor(player_ptr, *item, 0);
-                c_put_str(tval_to_attr[enum2i(item->bi_key.tval())], item_name, j + 2, 7);
+                const auto item_name = describe_flavor(player_ptr, item, 0);
+                c_put_str(tval_to_attr[enum2i(item.bi_key.tval())], item_name, j + 2, 7);
             }
 
             prt(format(_("我が家に置いてあったアイテム ( %d ページ): -続く-", "Your home contains (page %d): -more-"), k + 1), 0, 0);

--- a/src/store/home.cpp
+++ b/src/store/home.cpp
@@ -35,9 +35,9 @@ int home_carry(PlayerType *player_ptr, ItemEntity *o_ptr, StoreSaleType store_nu
     }
 
     for (int slot = 0; slot < st_ptr->stock_num; slot++) {
-        auto &item_store = st_ptr->stock[slot];
-        if (item_store->is_similar(*o_ptr)) {
-            item_store->absorb(*o_ptr);
+        auto &item_store = *st_ptr->stock[slot];
+        if (item_store.is_similar(*o_ptr)) {
+            item_store.absorb(*o_ptr);
             if (store_num != StoreSaleType::HOME) {
                 stack_force_notes = old_stack_force_notes;
                 stack_force_costs = old_stack_force_costs;
@@ -100,23 +100,23 @@ static bool exe_combine_store_items(ItemEntity &item1, ItemEntity &item2, const 
 static bool sweep_reorder_store_item(ItemEntity &item, const int i)
 {
     for (auto j = 0; j < i; j++) {
-        const auto &item_store = st_ptr->stock[j];
-        if (!item_store->is_valid()) {
+        auto &item_store = *st_ptr->stock[j];
+        if (!item_store.is_valid()) {
             continue;
         }
 
-        const auto max_num = item_store->is_similar_part(item);
-        if (max_num == 0 || item_store->number >= max_num) {
+        const auto max_num = item_store.is_similar_part(item);
+        if (max_num == 0 || item_store.number >= max_num) {
             continue;
         }
 
-        if (exe_combine_store_items(item, *item_store, max_num, i)) {
+        if (exe_combine_store_items(item, item_store, max_num, i)) {
             return true;
         }
 
-        ITEM_NUMBER old_num = item.number;
-        ITEM_NUMBER remain = item_store->number + item.number - max_num;
-        item_store->absorb(item);
+        const auto old_num = item.number;
+        const auto remain = item_store.number + item.number - max_num;
+        item_store.absorb(item);
         item.number = remain;
         const auto tval = item.bi_key.tval();
         if (tval == ItemKindType::ROD) {
@@ -171,12 +171,12 @@ bool combine_and_reorder_home(PlayerType *player_ptr, const StoreSaleType store_
     while (combined) {
         combined = false;
         for (auto i = st_ptr->stock_num - 1; i > 0; i--) {
-            auto &item = st_ptr->stock[i];
-            if (!item->is_valid()) {
+            auto &item = *st_ptr->stock[i];
+            if (!item.is_valid()) {
                 continue;
             }
 
-            combined |= sweep_reorder_store_item(*item, i);
+            combined |= sweep_reorder_store_item(item, i);
         }
 
         flag |= combined;

--- a/src/store/museum.cpp
+++ b/src/store/museum.cpp
@@ -32,15 +32,15 @@ void museum_remove_object(PlayerType *player_ptr)
     }
 
     const short item_num = *item_num_opt + store_top;
-    const auto &item = st_ptr->stock[item_num];
-    const auto item_name = describe_flavor(player_ptr, *item, 0);
+    const auto &item = *st_ptr->stock[item_num];
+    const auto item_name = describe_flavor(player_ptr, item, 0);
     msg_print(_("展示をやめさせたアイテムは二度と見ることはできません！", "Once removed from the Museum, an item will be gone forever!"));
     if (!input_check(format(_("本当に%sの展示をやめさせますか？", "Really order to remove %s from the Museum? "), item_name.data()))) {
         return;
     }
 
     msg_format(_("%sの展示をやめさせた。", "You ordered to remove %s."), item_name.data());
-    store_item_increase(item_num, -item->number);
+    store_item_increase(item_num, -item.number);
     store_item_optimize(item_num);
     (void)combine_and_reorder_home(player_ptr, StoreSaleType::MUSEUM);
     if (st_ptr->stock_num == 0) {

--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -196,16 +196,15 @@ void store_purchase(PlayerType *player_ptr, StoreSaleType store_num)
     }
 
     const short item_num = *item_num_opt + store_top;
-    auto &item_store = st_ptr->stock[item_num];
-
-    ITEM_NUMBER amt = 1;
-    ItemEntity item = *item_store;
+    auto &item_store = *st_ptr->stock[item_num];
+    auto amt = 1;
+    ItemEntity item = item_store;
 
     /*
      * If a rod or wand, allocate total maximum timeouts or charges
      * between those purchased and left on the shelf.
      */
-    reduce_charges(&item, item_store->number - amt);
+    reduce_charges(&item, item_store.number - amt);
     item.number = amt;
     if (!check_store_item_to_inventory(player_ptr, &item)) {
         msg_print(_("そんなにアイテムを持てない。", "You cannot carry that many different items."));
@@ -213,24 +212,24 @@ void store_purchase(PlayerType *player_ptr, StoreSaleType store_num)
     }
 
     const auto best = price_item(player_ptr, item.calc_price(), ot_ptr->inflate, false, store_num);
-    if (item_store->number > 1) {
+    if (item_store.number > 1) {
         if (store_num != StoreSaleType::HOME) {
             msg_format(_("一つにつき $%dです。", "That costs %d gold per item."), best);
         }
 
-        amt = input_quantity(item_store->number);
+        amt = input_quantity(item_store.number);
         if (amt <= 0) {
             return;
         }
     }
 
-    item = *item_store;
+    item = item_store;
 
     /*
      * If a rod or wand, allocate total maximum timeouts or charges
      * between those purchased and left on the shelf.
      */
-    reduce_charges(&item, item_store->number - amt);
+    reduce_charges(&item, item_store.number - amt);
     item.number = amt;
     if (!check_store_item_to_inventory(player_ptr, &item)) {
         msg_print(_("ザックにそのアイテムを入れる隙間がない。", "You cannot carry that many items."));
@@ -238,7 +237,7 @@ void store_purchase(PlayerType *player_ptr, StoreSaleType store_num)
     }
 
     if (store_num == StoreSaleType::HOME) {
-        take_item_from_home(player_ptr, *item_store, item, item_num);
+        take_item_from_home(player_ptr, item_store, item, item_num);
         return;
     }
 
@@ -267,7 +266,7 @@ void store_purchase(PlayerType *player_ptr, StoreSaleType store_num)
     if (store_num == StoreSaleType::BLACK) {
         chg_virtue(player_ptr, Virtue::JUSTICE, -1);
     }
-    if ((item_store->bi_key.tval() == ItemKindType::BOTTLE) && (store_num != StoreSaleType::HOME)) {
+    if ((item_store.bi_key.tval() == ItemKindType::BOTTLE) && (store_num != StoreSaleType::HOME)) {
         chg_virtue(player_ptr, Virtue::NATURE, -1);
     }
 
@@ -284,8 +283,8 @@ void store_purchase(PlayerType *player_ptr, StoreSaleType store_num)
         exe_write_diary(floor, DiaryKind::BUY, 0, purchased_item_name);
     }
 
-    const auto diary_item_name = describe_flavor(player_ptr, *item_store, OD_NAME_ONLY);
-    if (record_rand_art && item_store->is_random_artifact()) {
+    const auto diary_item_name = describe_flavor(player_ptr, item_store, OD_NAME_ONLY);
+    if (record_rand_art && item_store.is_random_artifact()) {
         exe_write_diary(floor, DiaryKind::ART, 0, diary_item_name);
     }
 
@@ -302,8 +301,8 @@ void store_purchase(PlayerType *player_ptr, StoreSaleType store_num)
     const auto got_item_name = describe_flavor(player_ptr, player_ptr->inventory_list[item_new], 0);
     msg_format(_("%s(%c)を手に入れた。", "You have %s (%c)."), got_item_name.data(), index_to_label(item_new));
 
-    if (item_store->is_wand_rod()) {
-        item_store->pval -= item.pval;
+    if (item_store.is_wand_rod()) {
+        item_store.pval -= item.pval;
     }
 
     i = st_ptr->stock_num;

--- a/src/store/store-util.cpp
+++ b/src/store/store-util.cpp
@@ -21,16 +21,16 @@ store_type *st_ptr = nullptr;
  */
 void store_item_increase(short i_idx, int item_num)
 {
-    auto &item = st_ptr->stock[i_idx];
-    auto cnt = item->number + item_num;
+    auto &item = *st_ptr->stock[i_idx];
+    auto cnt = item.number + item_num;
     if (cnt > 255) {
         cnt = 255;
     } else if (cnt < 0) {
         cnt = 0;
     }
 
-    item_num = cnt - item->number;
-    item->number += item_num;
+    item_num = cnt - item.number;
+    item.number += item_num;
 }
 
 /*!
@@ -39,8 +39,8 @@ void store_item_increase(short i_idx, int item_num)
  */
 void store_item_optimize(short i_idx)
 {
-    const auto &item = st_ptr->stock[i_idx];
-    if (!item->is_valid() || (item->number != 0)) {
+    const auto &item = *st_ptr->stock[i_idx];
+    if (!item.is_valid() || (item.number != 0)) {
         return;
     }
 
@@ -84,12 +84,12 @@ std::vector<short> store_same_magic_device_pvals(ItemEntity *j_ptr)
 {
     auto list = std::vector<short>();
     for (INVENTORY_IDX i = 0; i < st_ptr->stock_num; i++) {
-        auto &item = st_ptr->stock[i];
-        if ((item.get() == j_ptr) || (item->bi_id != j_ptr->bi_id) || !item->is_wand_staff()) {
+        auto &item = *st_ptr->stock[i];
+        if ((&item == j_ptr) || (item.bi_id != j_ptr->bi_id) || !item.is_wand_staff()) {
             continue;
         }
 
-        list.push_back(item->pval);
+        list.push_back(item.pval);
     }
 
     return list;
@@ -166,9 +166,9 @@ int store_carry(ItemEntity *o_ptr)
     o_ptr->inscription.reset();
     o_ptr->feeling = FEEL_NONE;
     for (auto slot = 0; slot < st_ptr->stock_num; slot++) {
-        auto &item = st_ptr->stock[slot];
-        if (item->is_similar_for_store(*o_ptr)) {
-            store_object_absorb(*item, *o_ptr);
+        auto &item = *st_ptr->stock[slot];
+        if (item.is_similar_for_store(*o_ptr)) {
+            store_object_absorb(item, *o_ptr);
             return slot;
         }
     }

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -113,8 +113,8 @@ int store_check_num(const ItemEntity *o_ptr, StoreSaleType store_num)
         }
 
         for (auto i = 0; i < st_ptr->stock_num; i++) {
-            auto &item = st_ptr->stock[i];
-            if (!item->is_similar(*o_ptr)) {
+            auto &item = *st_ptr->stock[i];
+            if (!item.is_similar(*o_ptr)) {
                 continue;
             }
 
@@ -132,8 +132,8 @@ int store_check_num(const ItemEntity *o_ptr, StoreSaleType store_num)
         }
     } else {
         for (auto i = 0; i < st_ptr->stock_num; i++) {
-            auto &item = st_ptr->stock[i];
-            if (item->is_similar_for_store(*o_ptr)) {
+            auto &item = *st_ptr->stock[i];
+            if (item.is_similar_for_store(*o_ptr)) {
                 return -1;
             }
         }
@@ -227,15 +227,15 @@ void store_examine(PlayerType *player_ptr, StoreSaleType store_num)
     }
 
     const auto item_num = *item_num_opt + store_top;
-    auto &item = st_ptr->stock[item_num];
-    if (!item->is_fully_known()) {
+    auto &item = *st_ptr->stock[item_num];
+    if (!item.is_fully_known()) {
         msg_print(_("このアイテムについて特に知っていることはない。", "You have no special knowledge about that item."));
         return;
     }
 
-    const auto item_name = describe_flavor(player_ptr, *item, 0);
+    const auto item_name = describe_flavor(player_ptr, item, 0);
     msg_format(_("%sを調べている...", "Examining %s..."), item_name.data());
-    if (!screen_object(player_ptr, *item, SCROBJ_FORCE_DETAIL)) {
+    if (!screen_object(player_ptr, item, SCROBJ_FORCE_DETAIL)) {
         msg_print(_("特に変わったところはないようだ。", "You see nothing special."));
     }
 }
@@ -285,13 +285,13 @@ void store_shuffle(PlayerType *player_ptr, StoreSaleType store_num)
     st_ptr->good_buy = 0;
     st_ptr->bad_buy = 0;
     for (auto i = 0; i < st_ptr->stock_num; i++) {
-        auto &item = st_ptr->stock[i];
-        if (item->is_fixed_or_random_artifact()) {
+        auto &item = *st_ptr->stock[i];
+        if (item.is_fixed_or_random_artifact()) {
             continue;
         }
 
-        item->discount = 50;
-        item->inscription.emplace(_("売出中", "on sale"));
+        item.discount = 50;
+        item.inscription.emplace(_("売出中", "on sale"));
     }
 }
 
@@ -399,9 +399,9 @@ void store_maintenance(PlayerType *player_ptr, int town_num, StoreSaleType store
     st_ptr->insult_cur = 0;
     if (store_num == StoreSaleType::BLACK) {
         for (INVENTORY_IDX j = st_ptr->stock_num - 1; j >= 0; j--) {
-            auto &item = st_ptr->stock[j];
-            if (black_market_crap(player_ptr, *item)) {
-                store_item_increase(j, 0 - item->number);
+            auto &item = *st_ptr->stock[j];
+            if (black_market_crap(player_ptr, item)) {
+                store_item_increase(j, 0 - item.number);
                 store_item_optimize(j);
             }
         }

--- a/src/view/display-store.cpp
+++ b/src/view/display-store.cpp
@@ -41,7 +41,7 @@ void store_prt_gold(PlayerType *player_ptr)
  */
 void display_entry(PlayerType *player_ptr, int pos, StoreSaleType store_num)
 {
-    const auto &item = st_ptr->stock[pos];
+    const auto &item = *st_ptr->stock[pos];
     int i = (pos % store_bottom);
 
     /* Label it, clear the line --(-- */
@@ -49,7 +49,7 @@ void display_entry(PlayerType *player_ptr, int pos, StoreSaleType store_num)
 
     int cur_col = 3;
     if (show_item_graph) {
-        term_queue_bigchar(cur_col, i + 6, { item->get_symbol(), {} });
+        term_queue_bigchar(cur_col, i + 6, { item.get_symbol(), {} });
         if (use_bigtile) {
             cur_col++;
         }
@@ -64,11 +64,11 @@ void display_entry(PlayerType *player_ptr, int pos, StoreSaleType store_num)
             maxwid -= 10;
         }
 
-        const auto item_name = describe_flavor(player_ptr, *item, 0, maxwid);
-        c_put_str(tval_to_attr[enum2i(item->bi_key.tval())], item_name, i + 6, cur_col);
+        const auto item_name = describe_flavor(player_ptr, item, 0, maxwid);
+        c_put_str(tval_to_attr[enum2i(item.bi_key.tval())], item_name, i + 6, cur_col);
 
         if (show_weights) {
-            const auto wgt = item->weight;
+            const auto wgt = item.weight;
             put_str(format(_("%3d.%1d kg", "%3d.%d lb"), _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10)), i + 6, _(67, 68));
         }
 
@@ -80,15 +80,15 @@ void display_entry(PlayerType *player_ptr, int pos, StoreSaleType store_num)
         maxwid -= 7;
     }
 
-    const auto item_name = describe_flavor(player_ptr, *item, 0, maxwid);
-    c_put_str(tval_to_attr[enum2i(item->bi_key.tval())], item_name, i + 6, cur_col);
+    const auto item_name = describe_flavor(player_ptr, item, 0, maxwid);
+    c_put_str(tval_to_attr[enum2i(item.bi_key.tval())], item_name, i + 6, cur_col);
 
     if (show_weights) {
-        const auto wgt = item->weight;
+        const auto wgt = item.weight;
         put_str(format("%3d.%1d", _(lb_to_kg_integer(wgt), wgt / 10), _(lb_to_kg_fraction(wgt), wgt % 10)), i + 6, _(60, 61));
     }
 
-    const auto price = price_item(player_ptr, item->calc_price(), ot_ptr->inflate, false, store_num);
+    const auto price = price_item(player_ptr, item.calc_price(), ot_ptr->inflate, false, store_num);
     put_str(format("%9ld  ", (long)price), i + 6, 68);
 }
 


### PR DESCRIPTION
#4665 の続きです、先行チケットがマージされるまでドラフトにしておきます
これにてスマートポインタ対応完了です