### PR TITLE
get_obj_index() をFloorType::select_baseitem_id() に繰り込み、確率テーブル処理をBaseitemAllocationTable へ移した

### DIFF
--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -121,7 +121,7 @@ bool make_object(PlayerType *player_ptr, ItemEntity *j_ptr, BIT_FLAGS mode, std:
         table.prepare_allocation();
     }
 
-    const auto bi_id = floor.get_obj_index(base, mode);
+    const auto bi_id = floor.select_baseitem_id(base, mode);
     if (get_obj_index_hook) {
         get_obj_index_hook = nullptr;
         table.prepare_allocation();

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -112,18 +112,18 @@ bool make_object(PlayerType *player_ptr, ItemEntity *j_ptr, BIT_FLAGS mode, std:
         }
     }
 
-    if (any_bits(mode, AM_GOOD) && !get_obj_index_hook) {
-        get_obj_index_hook = kind_is_good;
+    if (any_bits(mode, AM_GOOD) && !select_baseitem_id_hook) {
+        select_baseitem_id_hook = kind_is_good;
     }
 
     auto &table = BaseitemAllocationTable::get_instance();
-    if (get_obj_index_hook) {
+    if (select_baseitem_id_hook) {
         table.prepare_allocation();
     }
 
     const auto bi_id = floor.select_baseitem_id(base, mode);
-    if (get_obj_index_hook) {
-        get_obj_index_hook = nullptr;
+    if (select_baseitem_id_hook) {
+        select_baseitem_id_hook = nullptr;
         table.prepare_allocation();
     }
 

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -121,7 +121,7 @@ bool make_object(PlayerType *player_ptr, ItemEntity *j_ptr, BIT_FLAGS mode, std:
         table.prepare_allocation();
     }
 
-    const auto bi_id = get_obj_index(&floor, base, mode);
+    const auto bi_id = floor.get_obj_index(base, mode);
     if (get_obj_index_hook) {
         get_obj_index_hook = nullptr;
         table.prepare_allocation();

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -138,9 +138,9 @@ static void on_dead_raal(PlayerType *player_ptr, MonsterDeath *md_ptr)
     auto *q_ptr = &forge;
     q_ptr->wipe();
     if ((floor_ptr->dun_level > 49) && one_in_(5)) {
-        get_obj_index_hook = kind_is_good_book;
+        select_baseitem_id_hook = kind_is_good_book;
     } else {
-        get_obj_index_hook = kind_is_book;
+        select_baseitem_id_hook = kind_is_book;
     }
 
     (void)make_object(player_ptr, q_ptr, md_ptr->mo_mode);
@@ -312,22 +312,22 @@ static bool make_equipment(PlayerType *player_ptr, ItemEntity *q_ptr, const BIT_
  * @brief 死亡時ドロップとしてランダムアーティファクトのみを生成する
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param md_ptr モンスター撃破構造体への参照ポインタ
- * @param object_hook_pf アイテム種別指定、特になければnullptrで良い
+ * @param hook_pf アイテム種別指定、特になければnullptrで良い
  * @return なし
  * @details
  * 最初のアイテム生成でいきなり☆が生成された場合を除き、中途半端な☆ (例：呪われている)は生成しない.
  * このルーチンで★は生成されないので、★生成フラグのキャンセルも不要
  */
-static void on_dead_random_artifact(PlayerType *player_ptr, MonsterDeath *md_ptr, bool (*object_hook_pf)(short bi_id))
+static void on_dead_random_artifact(PlayerType *player_ptr, MonsterDeath *md_ptr, bool (*hook_pf)(short bi_id))
 {
     ItemEntity forge;
     auto *q_ptr = &forge;
-    auto is_object_hook_null = object_hook_pf == nullptr;
+    auto is_object_hook_null = hook_pf == nullptr;
     auto drop_mode = md_ptr->mo_mode | AM_NO_FIXED_ART;
     while (true) {
         // make_object() の中でアイテム種別をキャンセルしている
         // よってこのwhileループ中へ入れないと、引数で指定していない種別のアイテムが選ばれる可能性がある
-        get_obj_index_hook = object_hook_pf;
+        select_baseitem_id_hook = hook_pf;
         if (!make_equipment(player_ptr, q_ptr, drop_mode, is_object_hook_null)) {
             continue;
         }
@@ -372,7 +372,7 @@ static void drop_specific_item_on_dead(PlayerType *player_ptr, MonsterDeath *md_
     ItemEntity forge;
     auto *q_ptr = &forge;
     q_ptr->wipe();
-    get_obj_index_hook = object_hook_pf;
+    select_baseitem_id_hook = object_hook_pf;
     (void)make_object(player_ptr, q_ptr, md_ptr->mo_mode);
     (void)drop_near(player_ptr, q_ptr, -1, md_ptr->md_y, md_ptr->md_x);
 }

--- a/src/room/rooms-special.cpp
+++ b/src/room/rooms-special.cpp
@@ -137,7 +137,7 @@ bool build_type15(PlayerType *player_ptr, DungeonData *dd_ptr)
         }
 
         /* Place a potion */
-        get_obj_index_hook = kind_is_potion;
+        select_baseitem_id_hook = kind_is_potion;
         place_object(player_ptr, yval, xval, AM_NO_FIXED_ART);
         floor.get_grid({ yval, xval }).info |= CAVE_ICKY;
     } break;
@@ -208,14 +208,14 @@ bool build_type15(PlayerType *player_ptr, DungeonData *dd_ptr)
 
         /* Place two potions */
         if (one_in_(2)) {
-            get_obj_index_hook = kind_is_potion;
+            select_baseitem_id_hook = kind_is_potion;
             place_object(player_ptr, yval, xval - 1, AM_NO_FIXED_ART);
-            get_obj_index_hook = kind_is_potion;
+            select_baseitem_id_hook = kind_is_potion;
             place_object(player_ptr, yval, xval + 1, AM_NO_FIXED_ART);
         } else {
-            get_obj_index_hook = kind_is_potion;
+            select_baseitem_id_hook = kind_is_potion;
             place_object(player_ptr, yval - 1, xval, AM_NO_FIXED_ART);
-            get_obj_index_hook = kind_is_potion;
+            select_baseitem_id_hook = kind_is_potion;
             place_object(player_ptr, yval + 1, xval, AM_NO_FIXED_ART);
         }
 

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -322,7 +322,7 @@ static void store_create(PlayerType *player_ptr, short fix_k_idx, StoreSaleType 
         DEPTH level;
         if (store_num == StoreSaleType::BLACK) {
             level = 25 + randint0(25);
-            bi_id = player_ptr->current_floor_ptr->get_obj_index(level, 0x00000000);
+            bi_id = player_ptr->current_floor_ptr->select_baseitem_id(level, 0x00000000);
             if (bi_id == 0) {
                 continue;
             }

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -322,7 +322,7 @@ static void store_create(PlayerType *player_ptr, short fix_k_idx, StoreSaleType 
         DEPTH level;
         if (store_num == StoreSaleType::BLACK) {
             level = 25 + randint0(25);
-            bi_id = get_obj_index(player_ptr->current_floor_ptr, level, 0x00000000);
+            bi_id = player_ptr->current_floor_ptr->get_obj_index(level, 0x00000000);
             if (bi_id == 0) {
                 continue;
             }

--- a/src/system/alloc-entries.cpp
+++ b/src/system/alloc-entries.cpp
@@ -259,12 +259,12 @@ bool BaseitemAllocationTable::order_level(int index1, int index2) const
 
 /*!
  * @brief オブジェクト生成テーブルに生成制約を加える
- * @todo get_obj_index_hook グローバル関数ポインタは引数化して除去する
+ * @todo select_baseitem_id_hook グローバル関数ポインタは引数化して除去する
  */
 void BaseitemAllocationTable::prepare_allocation()
 {
     for (auto &entry : this->entries) {
-        if (!get_obj_index_hook || (*get_obj_index_hook)(entry.index)) {
+        if (!select_baseitem_id_hook || (*select_baseitem_id_hook)(entry.index)) {
             entry.prob2 = entry.prob1;
         } else {
             entry.prob2 = 0;

--- a/src/system/alloc-entries.h
+++ b/src/system/alloc-entries.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "util/probability-table.h"
 #include <vector>
 
 enum class MonraceId : short;
@@ -93,6 +94,7 @@ public:
     size_t size() const;
     const BaseitemAllocationEntry &get_entry(int index) const;
     BaseitemAllocationEntry &get_entry(int index);
+    short draw_lottery(int level, uint32_t mode, int count) const;
     bool order_level(int index1, int index2) const;
 
     void prepare_allocation();
@@ -101,4 +103,6 @@ private:
     static BaseitemAllocationTable instance;
     BaseitemAllocationTable() = default;
     std::vector<BaseitemAllocationEntry> entries;
+
+    ProbabilityTable<int> make_table(int level, uint32_t mode) const;
 };

--- a/src/system/floor-type-definition.cpp
+++ b/src/system/floor-type-definition.cpp
@@ -289,7 +289,7 @@ ItemEntity FloorType::make_gold(std::optional<BaseitemKey> bi_key) const
         item = ItemEntity(*bi_key);
     } else {
         const auto level = this->object_level <= 0 ? 1 : this->object_level;
-        item = ItemEntity(this->get_obj_index(level, AM_GOLD));
+        item = ItemEntity(this->select_baseitem_id(level, AM_GOLD));
     }
 
     const auto base = item.get_baseitem_cost();
@@ -318,7 +318,7 @@ std::optional<ItemEntity> FloorType::try_make_instant_artifact() const
  * @param mode 生成モード
  * @return 選ばれたベースアイテムID
  */
-short FloorType::get_obj_index(int level, uint32_t mode) const
+short FloorType::select_baseitem_id(int level, uint32_t mode) const
 {
     if (level > MAX_DEPTH - 1) {
         level = MAX_DEPTH - 1;

--- a/src/system/floor-type-definition.cpp
+++ b/src/system/floor-type-definition.cpp
@@ -359,19 +359,9 @@ short FloorType::get_obj_index(int level, uint32_t mode) const
         return 0;
     }
 
-    // 40%で1回、50%で2回、10%で3回抽選し、その中で一番レベルが高いアイテムを選択する
-    int n = 1;
-
-    const int p = randint0(100);
-    if (p < 60) {
-        n++;
-    }
-    if (p < 10) {
-        n++;
-    }
-
+    const auto count = decide_selection_count();
     std::vector<int> result;
-    ProbabilityTable<int>::lottery(std::back_inserter(result), prob_table, n);
+    ProbabilityTable<int>::lottery(std::back_inserter(result), prob_table, count);
     const auto it = std::max_element(result.begin(), result.end(), [&table](int a, int b) { return table.order_level(a, b); });
     return table.get_entry(*it).index;
 }
@@ -445,4 +435,25 @@ void FloorType::remove_mproc(short m_idx, MonsterTimedEffect mte)
     if (mproc_idx >= 0) {
         this->mproc_list[mte][*mproc_idx] = this->mproc_list[mte][--this->mproc_max[mte]];
     }
+}
+
+/*!
+ * @brief アイテムの抽選回数をランダムに決定する
+ * @return 抽選回数
+ * @details 40 % で1回、50 % で2回、10 % で3回.
+ * モンスターも同一ルーチンだが将来に亘って同一である保証はないので、アイテムはアイテムで定義する
+ */
+int FloorType::decide_selection_count()
+{
+    auto count = 1;
+    const auto p = randint0(100);
+    if (p < 60) {
+        count++;
+    }
+
+    if (p < 10) {
+        count++;
+    }
+
+    return count;
 }

--- a/src/system/floor-type-definition.cpp
+++ b/src/system/floor-type-definition.cpp
@@ -314,12 +314,13 @@ std::optional<ItemEntity> FloorType::try_make_instant_artifact() const
 
 /*!
  * @brief アイテム生成テーブルからベースアイテムIDを取得する
- * @param level 生成基準階層
+ * @param level_initial 生成基準階層 (天界や地獄の階層もそのまま渡ってくる)
  * @param mode 生成モード
  * @return 選ばれたベースアイテムID
  */
-short FloorType::select_baseitem_id(int level, uint32_t mode) const
+short FloorType::select_baseitem_id(int level_initial, uint32_t mode) const
 {
+    auto level = level_initial;
     if (level > MAX_DEPTH - 1) {
         level = MAX_DEPTH - 1;
     }

--- a/src/system/floor-type-definition.cpp
+++ b/src/system/floor-type-definition.cpp
@@ -304,7 +304,7 @@ ItemEntity FloorType::make_gold(std::optional<BaseitemKey> bi_key) const
  */
 std::optional<ItemEntity> FloorType::try_make_instant_artifact() const
 {
-    if (!this->is_in_underground() || (get_obj_index_hook != nullptr)) {
+    if (!this->is_in_underground() || (select_baseitem_id_hook != nullptr)) {
         return std::nullopt;
     }
 

--- a/src/system/floor-type-definition.h
+++ b/src/system/floor-type-definition.h
@@ -112,7 +112,7 @@ public:
 
     ItemEntity make_gold(std::optional<BaseitemKey> bi_key = std::nullopt) const;
     std::optional<ItemEntity> try_make_instant_artifact() const;
-    short get_obj_index(int level, uint32_t mode) const;
+    short select_baseitem_id(int level, uint32_t mode) const;
 
     void reset_mproc();
     void reset_mproc_max();

--- a/src/system/floor-type-definition.h
+++ b/src/system/floor-type-definition.h
@@ -112,7 +112,7 @@ public:
 
     ItemEntity make_gold(std::optional<BaseitemKey> bi_key = std::nullopt) const;
     std::optional<ItemEntity> try_make_instant_artifact() const;
-    short select_baseitem_id(int level, uint32_t mode) const;
+    short select_baseitem_id(int level_initial, uint32_t mode) const;
 
     void reset_mproc();
     void reset_mproc_max();

--- a/src/system/floor-type-definition.h
+++ b/src/system/floor-type-definition.h
@@ -112,6 +112,7 @@ public:
 
     ItemEntity make_gold(std::optional<BaseitemKey> bi_key = std::nullopt) const;
     std::optional<ItemEntity> try_make_instant_artifact() const;
+    short get_obj_index(int level, uint32_t mode) const;
 
     void reset_mproc();
     void reset_mproc_max();

--- a/src/system/floor-type-definition.h
+++ b/src/system/floor-type-definition.h
@@ -119,4 +119,7 @@ public:
     std::optional<int> get_mproc_index(short m_idx, MonsterTimedEffect mte);
     void add_mproc(short m_idx, MonsterTimedEffect mte);
     void remove_mproc(short m_idx, MonsterTimedEffect mte);
+
+private:
+    static int decide_selection_count();
 };

--- a/src/system/system-variables.cpp
+++ b/src/system/system-variables.cpp
@@ -29,4 +29,4 @@ init_flags_type init_flags; //!< @todo このグローバル変数何とかし�
 /*!
  * Function hook to restrict "get_obj_index_prep()" function
  */
-bool (*get_obj_index_hook)(short bi_id);
+bool (*select_baseitem_id_hook)(short bi_id);

--- a/src/system/system-variables.h
+++ b/src/system/system-variables.h
@@ -29,4 +29,4 @@ extern concptr ANGBAND_SYS;
 extern concptr ANGBAND_KEYBOARD;
 extern concptr ANGBAND_GRAF;
 
-extern bool (*get_obj_index_hook)(short bi_id);
+extern bool (*select_baseitem_id_hook)(short bi_id);

--- a/src/world/world-object.h
+++ b/src/world/world-object.h
@@ -4,4 +4,3 @@
 
 class FloorType;
 OBJECT_IDX o_pop(FloorType *floor_ptr);
-OBJECT_IDX get_obj_index(const FloorType *floor_ptr, DEPTH level, BIT_FLAGS mode);


### PR DESCRIPTION
掲題の通りです
一連の作業でクラスの役割分担が進展したかと思います
床落ちアイテムがdevelopと同じであることをチェック済です
ご確認下さい