### PR TITLE
[Refactor] MonsterEntityのコピーコンストラクタとコピー代入演算子を隠蔽

### DIFF
--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -112,7 +112,7 @@ static MonraceDefinition &set_pet_params(PlayerType *player_ptr, const int curre
     auto *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
     player_ptr->current_floor_ptr->grid_array[cy][cx].m_idx = m_idx;
     m_ptr->r_idx = party_mon[current_monster].r_idx;
-    *m_ptr = party_mon[current_monster];
+    *m_ptr = party_mon[current_monster].clone();
     m_ptr->fy = cy;
     m_ptr->fx = cx;
     m_ptr->current_floor_ptr = player_ptr->current_floor_ptr;
@@ -165,7 +165,9 @@ static void place_pet(PlayerType *player_ptr)
         }
     }
 
-    std::fill(std::begin(party_mon), std::end(party_mon), MonsterEntity{});
+    for (auto &monster : party_mon) {
+        monster.wipe();
+    }
 }
 
 /*!

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -378,7 +378,9 @@ void clear_cave(PlayerType *player_ptr)
     floor_ptr->o_cnt = 0;
 
     MonraceList::get_instance().reset_current_numbers();
-    std::fill_n(floor_ptr->m_list.begin(), floor_ptr->m_max, MonsterEntity{});
+    for (auto &monster : floor_ptr->m_list) {
+        monster.wipe();
+    }
     floor_ptr->m_max = 1;
     floor_ptr->m_cnt = 0;
     for (const auto mte : MONSTER_TIMED_EFFECT_RANGE) {

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -48,7 +48,7 @@ static void check_riding_preservation(PlayerType *player_ptr)
         player_ptr->pet_extra_flags &= ~(PF_TWO_HANDS);
         player_ptr->riding_ryoute = player_ptr->old_riding_ryoute = false;
     } else {
-        party_mon[0] = *m_ptr;
+        party_mon[0] = m_ptr->clone();
         delete_monster_idx(player_ptr, player_ptr->riding);
     }
 }
@@ -90,7 +90,7 @@ static void sweep_preserving_pet(PlayerType *player_ptr)
             continue;
         }
 
-        party_mon[party_monster_num] = player_ptr->current_floor_ptr->m_list[i];
+        party_mon[party_monster_num] = player_ptr->current_floor_ptr->m_list[i].clone();
         party_monster_num++;
         delete_monster_idx(player_ptr, i);
     }

--- a/src/monster/monster-compaction.cpp
+++ b/src/monster/monster-compaction.cpp
@@ -15,6 +15,7 @@
 #include "target/target-checker.h"
 #include "tracking/health-bar-tracker.h"
 #include "view/display-messages.h"
+#include <utility>
 
 /*!
  * @brief モンスター情報を配列内移動する / Move an object from index i1 to index i2 in the object list
@@ -71,8 +72,7 @@ static void compact_monsters_aux(PlayerType *player_ptr, MONSTER_IDX i1, MONSTER
         }
     }
 
-    floor.m_list[i2] = floor.m_list[i1];
-    floor.m_list[i1] = {};
+    floor.m_list[i2] = std::exchange(floor.m_list[i1], {});
 
     for (const auto mte : MONSTER_TIMED_EFFECT_RANGE) {
         const auto index = floor.get_mproc_index(i1, mte);

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -94,7 +94,7 @@ MonsterDamageProcessor::MonsterDamageProcessor(PlayerType *player_ptr, MONSTER_I
 bool MonsterDamageProcessor::mon_take_hit(std::string_view note)
 {
     auto &monster = this->player_ptr->current_floor_ptr->m_list[this->m_idx];
-    const MonsterEntity exp_mon = monster;
+    const auto exp_mon = monster.clone();
     auto exp_dam = (monster.hp > this->dam) ? this->dam : monster.hp;
     this->get_exp_from_mon(exp_mon, exp_dam);
     if (this->genocide_chaos_patron()) {

--- a/src/spell-kind/spells-polymorph.cpp
+++ b/src/spell-kind/spells-polymorph.cpp
@@ -82,7 +82,7 @@ bool polymorph_monster(PlayerType *player_ptr, POSITION y, POSITION x)
         return false;
     }
 
-    MonsterEntity back_m = *m_ptr;
+    const auto back_m = m_ptr->clone();
     new_r_idx = select_polymorph_monrace_id(player_ptr, old_r_idx);
     if (new_r_idx == old_r_idx) {
         return false;
@@ -114,7 +114,7 @@ bool polymorph_monster(PlayerType *player_ptr, POSITION y, POSITION x)
     } else {
         m_idx = place_specific_monster(player_ptr, y, x, old_r_idx, (mode | PM_NO_KAGE | PM_IGNORE_TERRAIN));
         if (m_idx) {
-            floor_ptr->m_list[*m_idx] = back_m;
+            floor_ptr->m_list[*m_idx] = back_m.clone();
             floor_ptr->reset_mproc();
         } else {
             preserve_hold_objects = false;

--- a/src/system/monster-entity.cpp
+++ b/src/system/monster-entity.cpp
@@ -45,6 +45,16 @@ bool MonsterEntity::check_sub_alignments(const byte sub_align1, const byte sub_a
     return this_good;
 }
 
+void MonsterEntity::wipe()
+{
+    *this = {};
+}
+
+MonsterEntity MonsterEntity::clone() const
+{
+    return *this;
+}
+
 bool MonsterEntity::is_friendly() const
 {
     return this->mflag2.has(MonsterConstantFlagType::FRIENDLY);

--- a/src/system/monster-entity.h
+++ b/src/system/monster-entity.h
@@ -27,6 +27,9 @@ class MonsterEntity {
 public:
     friend class MonsterEntityWriter;
     MonsterEntity();
+    MonsterEntity(MonsterEntity &&) = default;
+    MonsterEntity &operator=(MonsterEntity &&) = default;
+
     MonraceId r_idx{}; /*!< モンスターの実種族ID (これが0の時は死亡扱いになる) / Monster race index 0 = dead. */
     MonraceId ap_r_idx{}; /*!< モンスターの外見種族ID（あやしい影、たぬき、ジュラル星人誤認などにより変化する）Monster race appearance index */
     FloorType *current_floor_ptr{}; /*!< 所在フロアID（現状はFloorType構造体によるオブジェクトは1つしかないためソースコード設計上の意義以外はない）*/
@@ -62,6 +65,8 @@ public:
 
     static bool check_sub_alignments(const byte sub_align1, const byte sub_align2);
 
+    void wipe();
+    MonsterEntity clone() const;
     bool is_friendly() const;
     bool is_pet() const;
     bool is_hostile() const;
@@ -116,6 +121,9 @@ public:
     void set_friendly();
 
 private:
+    MonsterEntity(const MonsterEntity &) = default;
+    MonsterEntity &operator=(const MonsterEntity &) = default;
+
     std::optional<bool> order_pet_named(const MonsterEntity &other) const;
     std::optional<bool> order_pet_hp(const MonsterEntity &other) const;
 };


### PR DESCRIPTION
MonsterEntityクラスのコピーコンストラクタとコピー代入演算子を隠蔽し、オブジェクトのコピーが必要なところでは明示的に ItemEntity::clone() を呼ぶようにする。
また、ItemEntityとの対称性を考慮し、MonsterEntity::wipe()も実装する。

#4686 の一環。