### PR TITLE
[Chore] upload-artifactのバージョンをv4に更新

### DIFF
--- a/.github/workflows/publish-spoiler-page.yml
+++ b/.github/workflows/publish-spoiler-page.yml
@@ -39,7 +39,7 @@ jobs:
         run: nkf -w --in-place ~/.angband/Hengband/*.txt
 
       - name: Upload spoilers
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: spoiler-files
           path: ~/.angband/Hengband/*.txt


### PR DESCRIPTION
upload-artifactのバージョンv2がdeprecatedとなり、自動生成スポイラーのWorkflowがエラー終了するようになったので、v4にアップデートする。