### PR TITLE
dungeons_info をDungeonList に差し替えた

### DIFF
--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -114,8 +114,8 @@ void player_wipe_without_name(PlayerType *player_ptr)
     player_ptr->pet_follow_distance = PET_FOLLOW_DIST;
     player_ptr->pet_extra_flags = (PF_TELEPORT | PF_ATTACK_SPELL | PF_SUMMON_SPELL);
 
-    for (const auto &d_ref : dungeons_info) {
-        max_dlv[d_ref.idx] = 0;
+    for (const auto &[dungeon_id, dungeon] : DungeonList::get_instance()) {
+        max_dlv[dungeon_id] = 0;
     }
 
     player_ptr->visit = 1;

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -262,7 +262,7 @@ void do_cmd_go_down(PlayerType *player_ptr)
         return;
     }
 
-    short target_dungeon = 0;
+    auto target_dungeon = 0;
     auto &fcms = FloorChangeModesStore::get_instace();
     if (!floor.is_in_underground()) {
         target_dungeon = terrain.flags.has(TerrainCharacteristics::ENTRANCE) ? grid.special : DUNGEON_ANGBAND;
@@ -273,7 +273,7 @@ void do_cmd_go_down(PlayerType *player_ptr)
 
         if (!max_dlv[target_dungeon]) {
             const auto mes = _("ここには%sの入り口(%d階相当)があります", "There is the entrance of %s (Danger level: %d)");
-            const auto &dungeon = dungeons_info[target_dungeon];
+            const auto &dungeon = DungeonList::get_instance().get_dungeon(target_dungeon);
             msg_format(mes, dungeon.name.data(), dungeon.mindepth);
             if (!input_check(_("本当にこのダンジョンに入りますか？", "Do you really get in this dungeon? "))) {
                 return;

--- a/src/dungeon/quest.h
+++ b/src/dungeon/quest.h
@@ -119,7 +119,7 @@ public:
     MONSTER_NUMBER num_mon = 0; /*!< QuestKindTypeがKILL_NUMBER時の目標撃破数 number of monsters on level */
 
     BIT_FLAGS flags = 0; /*!< クエストに関するフラグビット / quest flags */
-    DUNGEON_IDX dungeon = 0; /*!< クエスト対象のダンジョンID / quest dungeon */
+    int dungeon = 0; /*!< クエスト対象のダンジョンID / quest dungeon */
 
     PLAYER_LEVEL complev = 0; /*!< クリア時プレイヤーレベル / player level (complete) */
     REAL_TIME comptime = 0; /*!< クリア時ゲーム時間 /  quest clear time*/

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -206,7 +206,7 @@ static bool parse_qtw_QQ(QuestType *q_ptr, char **zz, int num)
     q_ptr->r_idx = i2enum<MonraceId>(atoi(zz[7]));
     const auto fa_id = i2enum<FixedArtifactId>(atoi(zz[8]));
     q_ptr->reward_fa_id = fa_id;
-    q_ptr->dungeon = (DUNGEON_IDX)atoi(zz[9]);
+    q_ptr->dungeon = std::atoi(zz[9]);
 
     if (num > 10) {
         q_ptr->flags = atoi(zz[10]);

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -301,9 +301,8 @@ static void generate_fixed_floor(PlayerType *player_ptr)
  */
 static std::optional<std::string> level_gen(PlayerType *player_ptr)
 {
-    auto *floor_ptr = player_ptr->current_floor_ptr;
-    const auto d_idx = floor_ptr->dungeon_idx;
-    const auto &dungeon = dungeons_info[d_idx];
+    auto &floor = *player_ptr->current_floor_ptr;
+    const auto &dungeon = floor.get_dungeon_definition();
     constexpr auto chance_small_floor = 3;
     auto is_small_level = always_small_levels || ironman_small_levels;
     is_small_level |= one_in_(chance_small_floor) && small_levels;
@@ -331,18 +330,18 @@ static std::optional<std::string> level_gen(PlayerType *player_ptr)
             }
         }
 
-        floor_ptr->height = level_height * SCREEN_HGT;
-        floor_ptr->width = level_width * SCREEN_WID;
-        panel_row_min = floor_ptr->height;
-        panel_col_min = floor_ptr->width;
+        floor.height = level_height * SCREEN_HGT;
+        floor.width = level_width * SCREEN_WID;
+        panel_row_min = floor.height;
+        panel_col_min = floor.width;
 
         msg_format_wizard(
-            player_ptr, CHEAT_DUNGEON, _("小さなフロア: X:%d, Y:%d", "A 'small' dungeon level: X:%d, Y:%d."), floor_ptr->width, floor_ptr->height);
+            player_ptr, CHEAT_DUNGEON, _("小さなフロア: X:%d, Y:%d", "A 'small' dungeon level: X:%d, Y:%d."), floor.width, floor.height);
     } else {
-        floor_ptr->height = MAX_HGT;
-        floor_ptr->width = MAX_WID;
-        panel_row_min = floor_ptr->height;
-        panel_col_min = floor_ptr->width;
+        floor.height = MAX_HGT;
+        floor.width = MAX_WID;
+        panel_row_min = floor.height;
+        panel_col_min = floor.width;
     }
 
     return cave_gen(player_ptr);

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -302,7 +302,7 @@ static void generate_fixed_floor(PlayerType *player_ptr)
 static std::optional<std::string> level_gen(PlayerType *player_ptr)
 {
     auto *floor_ptr = player_ptr->current_floor_ptr;
-    DUNGEON_IDX d_idx = floor_ptr->dungeon_idx;
+    const auto d_idx = floor_ptr->dungeon_idx;
     const auto &dungeon = dungeons_info[d_idx];
     constexpr auto chance_small_floor = 3;
     auto is_small_level = always_small_levels || ironman_small_levels;

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -270,7 +270,7 @@ static void preserve_info(PlayerType *player_ptr)
         }
     }
 
-    for (DUNGEON_IDX i = 1; i < floor.m_max; i++) {
+    for (short i = 1; i < floor.m_max; i++) {
         auto *m_ptr = &floor.m_list[i];
         if (!m_ptr->is_valid() || (quest_monrace_id != m_ptr->r_idx)) {
             continue;
@@ -284,7 +284,7 @@ static void preserve_info(PlayerType *player_ptr)
         delete_monster_idx(player_ptr, i);
     }
 
-    for (DUNGEON_IDX i = 0; i < INVEN_PACK; i++) {
+    for (short i = 0; i < INVEN_PACK; i++) {
         auto *o_ptr = &player_ptr->inventory_list[i];
         if (!o_ptr->is_valid()) {
             continue;
@@ -372,7 +372,7 @@ static void kill_saved_floors(PlayerType *player_ptr, saved_floor_type *sf_ptr)
 {
     const auto &fcms = FloorChangeModesStore::get_instace();
     if (fcms->has_not(FloorChangeMode::SAVE_FLOORS)) {
-        for (DUNGEON_IDX i = 0; i < MAX_SAVED_FLOORS; i++) {
+        for (auto i = 0; i < MAX_SAVED_FLOORS; i++) {
             kill_saved_floor(player_ptr, &saved_floors[i]);
         }
 

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -129,7 +129,7 @@ void set_floor_and_wall(int type)
     }
 
     cur_type = type;
-    const auto &dungeon = dungeons_info[type];
+    const auto &dungeon = DungeonList::get_instance().get_dungeon(type);
     set_floor_and_wall_aux(feat_ground_type, dungeon.floor);
     set_floor_and_wall_aux(feat_wall_type, dungeon.fill);
     feat_wall_outer = dungeon.outer_wall;
@@ -383,7 +383,7 @@ static void generate_area(PlayerType *player_ptr, const Pos2D &pos, bool is_bord
     const auto entrance = wilderness_grid.entrance;
     auto is_winner = entrance > 0;
     is_winner &= (wilderness_grid.town == 0);
-    auto is_wild_winner = dungeons_info[entrance].flags.has_not(DungeonFeatureType::WINNER);
+    auto is_wild_winner = DungeonList::get_instance().get_dungeon(entrance).flags.has_not(DungeonFeatureType::WINNER);
     is_winner &= ((AngbandWorld::get_instance().total_winner != 0) || is_wild_winner);
     if (!is_winner) {
         return;
@@ -622,6 +622,7 @@ void wilderness_gen_small(PlayerType *player_ptr)
         }
     }
 
+    const auto &dungeons = DungeonList::get_instance();
     const auto &world = AngbandWorld::get_instance();
     parse_fixed_map(player_ptr, WILDERNESS_DEFINITION, 0, 0, world.max_wild_y, world.max_wild_x);
     for (auto x = 0; x < world.max_wild_x; x++) {
@@ -643,7 +644,7 @@ void wilderness_gen_small(PlayerType *player_ptr)
             }
 
             const auto entrance = wild_grid.entrance;
-            if ((entrance > 0) && (world.total_winner || dungeons_info[entrance].flags.has_not(DungeonFeatureType::WINNER))) {
+            if ((entrance > 0) && (world.total_winner || dungeons.get_dungeon(entrance).flags.has_not(DungeonFeatureType::WINNER))) {
                 grid.feat = feat_entrance;
                 grid.special = entrance;
                 grid.info |= (CAVE_GLOW | CAVE_MARK);
@@ -795,12 +796,12 @@ parse_error_type parse_line_wilderness(PlayerType *player_ptr, char *buf, int xm
         return PARSE_ERROR_UNDEFINED_DIRECTIVE;
     }
 
-    for (const auto &dungeon : dungeons_info) {
+    for (const auto &[dungeon_id, dungeon] : DungeonList::get_instance()) {
         if (!dungeon.is_dungeon() || !dungeon.maxdepth) {
             continue;
         }
 
-        wilderness[dungeon.dy][dungeon.dx].entrance = static_cast<byte>(dungeon.idx);
+        wilderness[dungeon.dy][dungeon.dx].entrance = static_cast<uint8_t>(dungeon_id);
         if (!wilderness[dungeon.dy][dungeon.dx].town) {
             wilderness[dungeon.dy][dungeon.dx].level = dungeon.mindepth;
         }

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -121,9 +121,9 @@ static void set_floor_and_wall_aux(int16_t feat_type[100], const std::array<feat
  * / Fill the arrays of floors and walls in the good proportions
  * @param type ダンジョンID
  */
-void set_floor_and_wall(DUNGEON_IDX type)
+void set_floor_and_wall(int type)
 {
-    DUNGEON_IDX cur_type = 255;
+    auto cur_type = 255;
     if (cur_type == type) {
         return;
     }

--- a/src/floor/wild.h
+++ b/src/floor/wild.h
@@ -38,7 +38,7 @@ extern std::vector<std::vector<wilderness_type>> wilderness;
 extern bool reinit_wilderness;
 
 class PlayerType;
-void set_floor_and_wall(DUNGEON_IDX type);
+void set_floor_and_wall(int type);
 void wilderness_gen(PlayerType *player_ptr);
 void wilderness_gen_small(PlayerType *player_ptr);
 void init_wilderness_terrains();

--- a/src/info-reader/dungeon-reader.cpp
+++ b/src/info-reader/dungeon-reader.cpp
@@ -16,15 +16,14 @@
 #include <span>
 
 /*!
- * @brief テキストトークンを走査してフラグを一つ得る(ダンジョン用) /
- * Grab one flag for a dungeon type from a textual string
- * @param d_ptr 保管先のダンジョン構造体参照ポインタ
- * @param what 参照元の文字列ポインタ
+ * @brief テキストトークンを走査してフラグを一つ得る(ダンジョン用)
+ * @param dungeon ダンジョンへの参照
+ * @param what 参照元の文字列
  * @return 見つけたらtrue
  */
-static bool grab_one_dungeon_flag(DungeonDefinition *d_ptr, std::string_view what)
+static bool grab_one_dungeon_flag(DungeonDefinition &dungeon, std::string_view what)
 {
-    if (EnumClassFlagGroup<DungeonFeatureType>::grab_one_flag(d_ptr->flags, dungeon_flags, what)) {
+    if (EnumClassFlagGroup<DungeonFeatureType>::grab_one_flag(dungeon.flags, dungeon_flags, what)) {
         return true;
     }
 
@@ -33,58 +32,57 @@ static bool grab_one_dungeon_flag(DungeonDefinition *d_ptr, std::string_view wha
 }
 
 /*!
- * @brief テキストトークンを走査してフラグを一つ得る(モンスターのダンジョン出現条件用1) /
- * Grab one (basic) flag in a MonraceDefinition from a textual string
- * @param d_ptr 保管先のダンジョン構造体参照ポインタ
- * @param what 参照元の文字列ポインタ
+ * @brief テキストトークンを走査してフラグを一つ得る(モンスターのダンジョン出現条件用1)
+ * @param dungeon ダンジョンへの参照
+ * @param what 参照元の文字列
  * @return 見つけたらtrue
  */
-static bool grab_one_basic_monster_flag(DungeonDefinition *d_ptr, std::string_view what)
+static bool grab_one_basic_monster_flag(DungeonDefinition &dungeon, std::string_view what)
 {
-    if (EnumClassFlagGroup<MonsterResistanceType>::grab_one_flag(d_ptr->mon_resistance_flags, r_info_flagsr, what)) {
+    if (EnumClassFlagGroup<MonsterResistanceType>::grab_one_flag(dungeon.mon_resistance_flags, r_info_flagsr, what)) {
         return true;
     }
 
-    if (EnumClassFlagGroup<MonsterBehaviorType>::grab_one_flag(d_ptr->mon_behavior_flags, r_info_behavior_flags, what)) {
+    if (EnumClassFlagGroup<MonsterBehaviorType>::grab_one_flag(dungeon.mon_behavior_flags, r_info_behavior_flags, what)) {
         return true;
     }
 
-    if (EnumClassFlagGroup<MonsterVisualType>::grab_one_flag(d_ptr->mon_visual_flags, r_info_visual_flags, what)) {
+    if (EnumClassFlagGroup<MonsterVisualType>::grab_one_flag(dungeon.mon_visual_flags, r_info_visual_flags, what)) {
         return true;
     }
 
-    if (EnumClassFlagGroup<MonsterKindType>::grab_one_flag(d_ptr->mon_kind_flags, r_info_kind_flags, what)) {
+    if (EnumClassFlagGroup<MonsterKindType>::grab_one_flag(dungeon.mon_kind_flags, r_info_kind_flags, what)) {
         return true;
     }
 
-    if (EnumClassFlagGroup<MonsterDropType>::grab_one_flag(d_ptr->mon_drop_flags, r_info_drop_flags, what)) {
+    if (EnumClassFlagGroup<MonsterDropType>::grab_one_flag(dungeon.mon_drop_flags, r_info_drop_flags, what)) {
         return true;
     }
 
-    if (EnumClassFlagGroup<MonsterWildernessType>::grab_one_flag(d_ptr->mon_wilderness_flags, r_info_wilderness_flags, what)) {
+    if (EnumClassFlagGroup<MonsterWildernessType>::grab_one_flag(dungeon.mon_wilderness_flags, r_info_wilderness_flags, what)) {
         return true;
     }
 
-    if (EnumClassFlagGroup<MonsterFeatureType>::grab_one_flag(d_ptr->mon_feature_flags, r_info_feature_flags, what)) {
+    if (EnumClassFlagGroup<MonsterFeatureType>::grab_one_flag(dungeon.mon_feature_flags, r_info_feature_flags, what)) {
         return true;
     }
 
-    if (EnumClassFlagGroup<MonsterPopulationType>::grab_one_flag(d_ptr->mon_population_flags, r_info_population_flags, what)) {
+    if (EnumClassFlagGroup<MonsterPopulationType>::grab_one_flag(dungeon.mon_population_flags, r_info_population_flags, what)) {
         return true;
     }
 
-    if (EnumClassFlagGroup<MonsterSpeakType>::grab_one_flag(d_ptr->mon_speak_flags, r_info_speak_flags, what)) {
+    if (EnumClassFlagGroup<MonsterSpeakType>::grab_one_flag(dungeon.mon_speak_flags, r_info_speak_flags, what)) {
         return true;
     }
 
-    if (EnumClassFlagGroup<MonsterBrightnessType>::grab_one_flag(d_ptr->mon_brightness_flags, r_info_brightness_flags, what)) {
+    if (EnumClassFlagGroup<MonsterBrightnessType>::grab_one_flag(dungeon.mon_brightness_flags, r_info_brightness_flags, what)) {
         return true;
     }
 
-    if (EnumClassFlagGroup<MonsterSpecialType>::grab_one_flag(d_ptr->mon_special_flags, r_info_special_flags, what)) {
+    if (EnumClassFlagGroup<MonsterSpecialType>::grab_one_flag(dungeon.mon_special_flags, r_info_special_flags, what)) {
         return true;
     }
-    if (EnumClassFlagGroup<MonsterMiscType>::grab_one_flag(d_ptr->mon_misc_flags, r_info_misc_flags, what)) {
+    if (EnumClassFlagGroup<MonsterMiscType>::grab_one_flag(dungeon.mon_misc_flags, r_info_misc_flags, what)) {
         return true;
     }
 
@@ -93,15 +91,14 @@ static bool grab_one_basic_monster_flag(DungeonDefinition *d_ptr, std::string_vi
 }
 
 /*!
- * @brief テキストトークンを走査してフラグを一つ得る(モンスターのダンジョン出現条件用2) /
- * Grab one (spell) flag in a MonraceDefinition from a textual string
- * @param d_ptr 保管先のダンジョン構造体参照ポインタ
- * @param what 参照元の文字列ポインタ
+ * @brief テキストトークンを走査してフラグを一つ得る(モンスターのダンジョン出現条件用2)
+ * @param dungeon ダンジョンへの参照
+ * @param what 参照元の文字列
  * @return 見つけたらtrue
  */
-static bool grab_one_spell_monster_flag(DungeonDefinition *d_ptr, std::string_view what)
+static bool grab_one_spell_monster_flag(DungeonDefinition &dungeon, std::string_view what)
 {
-    if (EnumClassFlagGroup<MonsterAbilityType>::grab_one_flag(d_ptr->mon_ability_flags, r_info_ability_flags, what)) {
+    if (EnumClassFlagGroup<MonsterAbilityType>::grab_one_flag(dungeon.mon_ability_flags, r_info_ability_flags, what)) {
         return true;
     }
 
@@ -117,11 +114,11 @@ static bool grab_one_spell_monster_flag(DungeonDefinition *d_ptr, std::string_vi
  */
 errr parse_dungeons_info(std::string_view buf, angband_header *)
 {
-    static DungeonDefinition *d_ptr = nullptr;
     const auto &tokens = str_split(buf, ':', false);
     const auto &terrains = TerrainList::get_instance();
 
     // N:index:name_ja
+    auto &dungeons = DungeonList::get_instance();
     if (tokens[0] == "N") {
         if (tokens.size() < 3 || tokens[1].size() == 0) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
@@ -132,30 +129,29 @@ errr parse_dungeons_info(std::string_view buf, angband_header *)
             return PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
         }
 
-        if (i >= static_cast<int>(dungeons_info.size())) {
-            dungeons_info.resize(i + 1);
-        }
-
         error_idx = i;
-        d_ptr = &dungeons_info[i];
-        d_ptr->idx = i;
+        DungeonDefinition dungeon;
+        dungeon.idx = i;
 #ifdef JP
-        d_ptr->name = tokens[2];
+        dungeon.name = tokens[2];
 #endif
+        dungeons.emplace(i, std::move(dungeon));
         return PARSE_ERROR_NONE;
     }
 
-    if (!d_ptr) {
+    if (dungeons.empty()) {
         return PARSE_ERROR_MISSING_RECORD_HEADER;
     }
 
     // E:name_en
+    auto &[dungeon_id, dungeon] = *dungeons.rbegin();
     if (tokens[0] == "E") {
 #ifndef JP
         if (tokens.size() < 2 || tokens[1].size() == 0) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
-        d_ptr->name = tokens[1];
+
+        dungeon.name = tokens[1];
 #endif
         return PARSE_ERROR_NONE;
     }
@@ -171,7 +167,7 @@ errr parse_dungeons_info(std::string_view buf, angband_header *)
             return PARSE_ERROR_NONE;
         }
 
-        d_ptr->text.append(buf.substr(2));
+        dungeon.text.append(buf.substr(2));
 #else
         if (buf[2] != '$') {
             return PARSE_ERROR_NONE;
@@ -180,8 +176,7 @@ errr parse_dungeons_info(std::string_view buf, angband_header *)
         if (buf.length() == 3) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
-
-        append_english_text(d_ptr->text, buf.substr(3));
+        append_english_text(dungeon.text, buf.substr(3));
 #endif
         return PARSE_ERROR_NONE;
     }
@@ -197,16 +192,16 @@ errr parse_dungeons_info(std::string_view buf, angband_header *)
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
 
-        info_set_value(d_ptr->mindepth, tokens[1]);
-        info_set_value(d_ptr->maxdepth, tokens[2]);
-        info_set_value(d_ptr->min_plev, tokens[3]);
-        info_set_value(d_ptr->mode, tokens[4]);
-        info_set_value(d_ptr->min_m_alloc_level, tokens[5]);
-        info_set_value(d_ptr->max_m_alloc_chance, tokens[6]);
-        info_set_value(d_ptr->obj_good, tokens[7]);
-        info_set_value(d_ptr->obj_great, tokens[8]);
-        info_set_value(d_ptr->pit, tokens[9], 16);
-        info_set_value(d_ptr->nest, tokens[10], 16);
+        info_set_value(dungeon.mindepth, tokens[1]);
+        info_set_value(dungeon.maxdepth, tokens[2]);
+        info_set_value(dungeon.min_plev, tokens[3]);
+        info_set_value(dungeon.mode, tokens[4]);
+        info_set_value(dungeon.min_m_alloc_level, tokens[5]);
+        info_set_value(dungeon.max_m_alloc_chance, tokens[6]);
+        info_set_value(dungeon.obj_good, tokens[7]);
+        info_set_value(dungeon.obj_great, tokens[8]);
+        info_set_value(dungeon.pit, tokens[9], 16);
+        info_set_value(dungeon.nest, tokens[10], 16);
         return PARSE_ERROR_NONE;
     }
 
@@ -216,8 +211,8 @@ errr parse_dungeons_info(std::string_view buf, angband_header *)
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
 
-        info_set_value(d_ptr->dy, tokens[1]);
-        info_set_value(d_ptr->dx, tokens[2]);
+        info_set_value(dungeon.dy, tokens[1]);
+        info_set_value(dungeon.dx, tokens[2]);
         return PARSE_ERROR_NONE;
     }
 
@@ -231,16 +226,16 @@ errr parse_dungeons_info(std::string_view buf, angband_header *)
             auto feat_idx = i * 2 + 1;
             auto per_idx = feat_idx + 1;
             try {
-                d_ptr->floor[i].feat = terrains.get_terrain_id_by_tag(tokens[feat_idx]);
+                dungeon.floor[i].feat = terrains.get_terrain_id_by_tag(tokens[feat_idx]);
             } catch (const std::exception &) {
                 return PARSE_ERROR_UNDEFINED_TERRAIN_TAG;
             }
 
-            info_set_value(d_ptr->floor[i].percent, tokens[per_idx]);
+            info_set_value(dungeon.floor[i].percent, tokens[per_idx]);
         }
 
         auto tunnel_idx = DUNGEON_FEAT_PROB_NUM * 2 + 1;
-        info_set_value(d_ptr->tunnel_percent, tokens[tunnel_idx]);
+        info_set_value(dungeon.tunnel_percent, tokens[tunnel_idx]);
         return PARSE_ERROR_NONE;
     }
 
@@ -254,20 +249,20 @@ errr parse_dungeons_info(std::string_view buf, angband_header *)
             auto feat_idx = i * 2 + 1;
             auto prob_idx = feat_idx + 1;
             try {
-                d_ptr->fill[i].feat = terrains.get_terrain_id_by_tag(tokens[feat_idx]);
+                dungeon.fill[i].feat = terrains.get_terrain_id_by_tag(tokens[feat_idx]);
             } catch (const std::exception &) {
                 return PARSE_ERROR_UNDEFINED_TERRAIN_TAG;
             }
 
-            info_set_value(d_ptr->fill[i].percent, tokens[prob_idx]);
+            info_set_value(dungeon.fill[i].percent, tokens[prob_idx]);
         }
 
         try {
             const std::span tags(tokens.begin() + DUNGEON_FEAT_PROB_NUM * 2 + 1, 4);
-            d_ptr->outer_wall = terrains.get_terrain_id_by_tag(tags[0]);
-            d_ptr->inner_wall = terrains.get_terrain_id_by_tag(tags[1]);
-            d_ptr->stream1 = terrains.get_terrain_id_by_tag(tags[2]);
-            d_ptr->stream2 = terrains.get_terrain_id_by_tag(tags[3]);
+            dungeon.outer_wall = terrains.get_terrain_id_by_tag(tags[0]);
+            dungeon.inner_wall = terrains.get_terrain_id_by_tag(tags[1]);
+            dungeon.stream1 = terrains.get_terrain_id_by_tag(tags[2]);
+            dungeon.stream2 = terrains.get_terrain_id_by_tag(tags[3]);
             return PARSE_ERROR_NONE;
         } catch (const std::exception &) {
             return PARSE_ERROR_UNDEFINED_TERRAIN_TAG;
@@ -289,24 +284,24 @@ errr parse_dungeons_info(std::string_view buf, angband_header *)
             const auto &f_tokens = str_split(f, '_');
             if (f_tokens.size() == 3) {
                 if (f_tokens[0] == "FINAL" && f_tokens[1] == "ARTIFACT") {
-                    info_set_value(d_ptr->final_artifact, f_tokens[2]);
+                    info_set_value(dungeon.final_artifact, f_tokens[2]);
                     continue;
                 }
                 if (f_tokens[0] == "FINAL" && f_tokens[1] == "OBJECT") {
-                    info_set_value(d_ptr->final_object, f_tokens[2]);
+                    info_set_value(dungeon.final_object, f_tokens[2]);
                     continue;
                 }
                 if (f_tokens[0] == "FINAL" && f_tokens[1] == "GUARDIAN") {
-                    info_set_value(d_ptr->final_guardian, f_tokens[2]);
+                    info_set_value(dungeon.final_guardian, f_tokens[2]);
                     continue;
                 }
                 if (f_tokens[0] == "MONSTER" && f_tokens[1] == "DIV") {
-                    info_set_value(d_ptr->special_div, f_tokens[2]);
+                    info_set_value(dungeon.special_div, f_tokens[2]);
                     continue;
                 }
             }
 
-            if (!grab_one_dungeon_flag(d_ptr, f)) {
+            if (!grab_one_dungeon_flag(dungeon, f)) {
                 return PARSE_ERROR_INVALID_FLAG;
             }
         }
@@ -326,7 +321,7 @@ errr parse_dungeons_info(std::string_view buf, angband_header *)
                 return PARSE_ERROR_INVALID_FLAG;
             }
 
-            d_ptr->mon_sex = static_cast<MonsterSex>(sex);
+            dungeon.mon_sex = static_cast<MonsterSex>(sex);
             return 0;
         }
 
@@ -336,17 +331,17 @@ errr parse_dungeons_info(std::string_view buf, angband_header *)
 
         const auto &flags = str_split(tokens[1], '|', true);
         for (const auto &f : flags) {
-            if (f.size() == 0) {
+            if (f.empty()) {
                 continue;
             }
 
             const auto &m_tokens = str_split(f, '_');
             if (m_tokens[0] == "R" && m_tokens[1] == "CHAR") {
-                d_ptr->r_chars.insert(d_ptr->r_chars.end(), m_tokens[2].begin(), m_tokens[2].end());
+                dungeon.r_chars.insert(dungeon.r_chars.end(), m_tokens[2].begin(), m_tokens[2].end());
                 continue;
             }
 
-            if (!grab_one_basic_monster_flag(d_ptr, f)) {
+            if (!grab_one_basic_monster_flag(dungeon, f)) {
                 return PARSE_ERROR_INVALID_FLAG;
             }
         }
@@ -375,7 +370,7 @@ errr parse_dungeons_info(std::string_view buf, angband_header *)
                 continue; //!< @details MonsterRaceDefinitions.jsonc からのコピペ対策
             }
 
-            if (!grab_one_spell_monster_flag(d_ptr, f)) {
+            if (!grab_one_spell_monster_flag(dungeon, f)) {
                 return PARSE_ERROR_INVALID_FLAG;
             }
         }
@@ -391,7 +386,7 @@ errr parse_dungeons_info(std::string_view buf, angband_header *)
  */
 void retouch_dungeons_info()
 {
-    for (auto &dungeon : dungeons_info) {
+    for (auto &[_, dungeon] : DungeonList::get_instance()) {
         if (dungeon.is_dungeon() && dungeon.has_guardian()) {
             auto &monrace = dungeon.get_guardian();
             monrace.misc_flags.set(MonsterMiscType::GUARDIAN);

--- a/src/info-reader/dungeon-reader.cpp
+++ b/src/info-reader/dungeon-reader.cpp
@@ -137,7 +137,7 @@ errr parse_dungeons_info(std::string_view buf, angband_header *)
 
         error_idx = i;
         d_ptr = &dungeons_info[i];
-        d_ptr->idx = static_cast<DUNGEON_IDX>(i);
+        d_ptr->idx = i;
 #ifdef JP
         d_ptr->name = tokens[2];
 #endif

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -180,13 +180,13 @@ static void dump_aux_last_message(PlayerType *player_ptr, FILE *fff)
 static void dump_aux_recall(FILE *fff)
 {
     fprintf(fff, _("\n  [帰還場所]\n\n", "\n  [Recall Depth]\n\n"));
-    for (const auto &dungeon : dungeons_info) {
+    for (const auto &[dungeon_id, dungeon] : DungeonList::get_instance()) {
         auto is_conquered = false;
         if (!dungeon.is_dungeon() || !dungeon.maxdepth) {
             continue;
         }
 
-        if (!max_dlv[dungeon.idx]) {
+        if (!max_dlv[dungeon_id]) {
             continue;
         }
 
@@ -194,7 +194,7 @@ static void dump_aux_recall(FILE *fff)
             if (dungeon.get_guardian().max_num == 0) {
                 is_conquered = true;
             }
-        } else if (max_dlv[dungeon.idx] == dungeon.maxdepth) {
+        } else if (max_dlv[dungeon_id] == dungeon.maxdepth) {
             is_conquered = true;
         }
 

--- a/src/knowledge/knowledge-features.cpp
+++ b/src/knowledge/knowledge-features.cpp
@@ -364,13 +364,13 @@ void do_cmd_knowledge_dungeon(PlayerType *player_ptr)
         return;
     }
 
-    for (const auto &dungeon : dungeons_info) {
+    for (const auto &[dungeon_id, dungeon] : DungeonList::get_instance()) {
         auto is_conquered = false;
         if (!dungeon.is_dungeon() || !dungeon.maxdepth) {
             continue;
         }
 
-        if (!max_dlv[dungeon.idx]) {
+        if (!max_dlv[dungeon_id]) {
             continue;
         }
 
@@ -378,11 +378,11 @@ void do_cmd_knowledge_dungeon(PlayerType *player_ptr)
             if (dungeon.get_guardian().max_num == 0) {
                 is_conquered = true;
             }
-        } else if (max_dlv[dungeon.idx] == dungeon.maxdepth) {
+        } else if (max_dlv[dungeon_id] == dungeon.maxdepth) {
             is_conquered = true;
         }
 
-        fprintf(fff, _("%c%-12s :  %3d 階\n", "%c%-16s :  level %3d\n"), is_conquered ? '!' : ' ', dungeon.name.data(), (int)max_dlv[dungeon.idx]);
+        fprintf(fff, _("%c%-12s :  %3d 階\n", "%c%-16s :  level %3d\n"), is_conquered ? '!' : ' ', dungeon.name.data(), (int)max_dlv[dungeon_id]);
     }
 
     angband_fclose(fff);

--- a/src/load/world-loader.cpp
+++ b/src/load/world-loader.cpp
@@ -14,18 +14,20 @@
 #include "system/player-type-definition.h"
 #include "world/world.h"
 
-static void rd_hengband_dungeons(void)
+static void rd_hengband_dungeons()
 {
-    auto max = rd_byte();
+    const auto &dungeons = DungeonList::get_instance();
+    const auto max = rd_byte();
     for (auto i = 0U; i < max; i++) {
         auto tmp16s = rd_s16b();
-        if (i >= dungeons_info.size()) {
+        if (i >= dungeons.size()) {
             continue;
         }
 
         max_dlv[i] = tmp16s;
-        if (max_dlv[i] > dungeons_info[i].maxdepth) {
-            max_dlv[i] = dungeons_info[i].maxdepth;
+        const auto &dungeon = dungeons.get_dungeon(i);
+        if (max_dlv[i] > dungeon.maxdepth) {
+            max_dlv[i] = dungeon.maxdepth;
         }
     }
 }

--- a/src/main-win/main-win-music.cpp
+++ b/src/main-win/main-win-music.cpp
@@ -68,7 +68,7 @@ static std::optional<std::string> basic_key_at(int index)
  */
 static std::optional<std::string> dungeon_key_at(int index)
 {
-    if (index >= static_cast<int>(dungeons_info.size())) {
+    if (index >= static_cast<int>(DungeonList::get_instance().size())) {
         return std::nullopt;
     }
 

--- a/src/main/game-data-initializer.cpp
+++ b/src/main/game-data-initializer.cpp
@@ -55,7 +55,7 @@ void init_other(PlayerType *player_ptr)
     auto *floor_ptr = &floor_data.get_floor(0);
     player_ptr->current_floor_ptr = floor_ptr; // TODO:本当はこんなところで初期化したくない ← FloorTypeの方で初期化するべき？
 
-    max_dlv.assign(dungeons_info.size(), {});
+    max_dlv.assign(DungeonList::get_instance().size(), {});
     init_gf_colors();
 
     macro_patterns.assign(MACRO_MAX, {});

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -203,7 +203,8 @@ void init_class_skills_info()
 void init_dungeons_info()
 {
     init_header(&dungeons_header);
-    init_info("DungeonDefinitions.txt", dungeons_header, dungeons_info, parse_dungeons_info, retouch_dungeons_info);
+    auto &dungeons = DungeonList::get_instance();
+    init_info("DungeonDefinitions.txt", dungeons_header, dungeons, parse_dungeons_info, retouch_dungeons_info);
 }
 
 /*!

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -279,13 +279,13 @@ void determine_daily_bounty(PlayerType *player_ptr, bool conv_old)
 {
     auto max_dl = 3;
     if (!conv_old) {
-        for (const auto &dungeon : dungeons_info) {
-            if (max_dlv[dungeon.idx] < dungeon.mindepth) {
+        for (const auto &[dungeon_id, dungeon] : DungeonList::get_instance()) {
+            if (max_dlv[dungeon_id] < dungeon.mindepth) {
                 continue;
             }
 
-            if (max_dl < max_dlv[dungeon.idx]) {
-                max_dl = max_dlv[dungeon.idx];
+            if (max_dl < max_dlv[dungeon_id]) {
+                max_dl = max_dlv[dungeon_id];
             }
         }
     } else {

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -3043,10 +3043,10 @@ long calc_score(PlayerType *player_ptr)
         mult = 5;
     }
 
-    DEPTH max_dl = 0;
-    for (const auto &d_ref : dungeons_info) {
-        if (max_dl < max_dlv[d_ref.idx]) {
-            max_dl = max_dlv[d_ref.idx];
+    auto max_dl = 0;
+    for (const auto &[dungeon_id, _] : DungeonList::get_instance()) {
+        if (max_dl < max_dlv[dungeon_id]) {
+            max_dl = max_dlv[dungeon_id];
         }
     }
 

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -147,7 +147,7 @@ void wr_player(PlayerType *player_ptr)
     wr_u32b(player_ptr->csp_frac);
     wr_s16b(player_ptr->max_plv);
 
-    byte tmp8u = (byte)dungeons_info.size();
+    auto tmp8u = static_cast<uint8_t>(DungeonList::get_instance().size());
     wr_byte(tmp8u);
     for (int i = 0; i < tmp8u; i++) {
         wr_s16b((int16_t)max_dlv[i]);

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -185,7 +185,7 @@ void wr_player(PlayerType *player_ptr)
     wr_s16b(player_ptr->blessed);
     wr_s16b(player_ptr->tim_invis);
     wr_s16b(player_ptr->word_recall);
-    wr_s16b(player_ptr->recall_dungeon);
+    wr_s16b(static_cast<int16_t>(player_ptr->recall_dungeon));
     wr_s16b(player_ptr->alter_reality);
     wr_s16b(player_ptr->see_infra);
     wr_s16b(player_ptr->tim_infra);

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -362,9 +362,9 @@ void reserve_alter_reality(PlayerType *player_ptr, TIME_EFFECT turns)
  * @param x コンソールX座標
  * @return 選択されたダンジョンID
  */
-static DUNGEON_IDX choose_dungeon(concptr note, POSITION y, POSITION x)
+static int choose_dungeon(concptr note, POSITION y, POSITION x)
 {
-    DUNGEON_IDX select_dungeon;
+    int select_dungeon;
     if (lite_town || vanilla_town || ironman_downward) {
         if (max_dlv[DUNGEON_ANGBAND]) {
             return DUNGEON_ANGBAND;
@@ -375,7 +375,7 @@ static DUNGEON_IDX choose_dungeon(concptr note, POSITION y, POSITION x)
         }
     }
 
-    std::vector<DUNGEON_IDX> dun;
+    std::vector<int> dun;
 
     screen_save();
     for (const auto &dungeon : dungeons_info) {
@@ -463,11 +463,11 @@ bool recall_player(PlayerType *player_ptr, TIME_EFFECT turns)
     }
 
     if (!floor.is_in_underground()) {
-        DUNGEON_IDX select_dungeon;
-        select_dungeon = choose_dungeon(_("に帰還", "recall"), 2, 14);
-        if (!select_dungeon) {
+        const auto select_dungeon = choose_dungeon(_("に帰還", "recall"), 2, 14);
+        if (select_dungeon == 0) {
             return false;
         }
+
         player_ptr->recall_dungeon = select_dungeon;
     }
 
@@ -479,8 +479,8 @@ bool recall_player(PlayerType *player_ptr, TIME_EFFECT turns)
 
 bool free_level_recall(PlayerType *player_ptr)
 {
-    DUNGEON_IDX select_dungeon = choose_dungeon(_("にテレポート", "teleport"), 4, 0);
-    if (!select_dungeon) {
+    const auto select_dungeon = choose_dungeon(_("にテレポート", "teleport"), 4, 0);
+    if (select_dungeon == 0) {
         return false;
     }
 

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -138,7 +138,7 @@ void display_rumor(PlayerType *player_ptr, bool ex)
             monrace.r_sights++;
         }
     } else if (category == "DUNGEON") {
-        DUNGEON_IDX d_idx;
+        int d_idx;
         DungeonDefinition *d_ptr;
         const auto dungeons_size = static_cast<short>(dungeons_info.size());
         const auto &d_idx_str = tokens[1];

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -138,21 +138,22 @@ void display_rumor(PlayerType *player_ptr, bool ex)
             monrace.r_sights++;
         }
     } else if (category == "DUNGEON") {
-        int d_idx;
-        DungeonDefinition *d_ptr;
-        const auto dungeons_size = static_cast<short>(dungeons_info.size());
-        const auto &d_idx_str = tokens[1];
+        int dungeon_id;
+        const DungeonDefinition *d_ptr;
+        const auto &dungeons = DungeonList::get_instance();
+        const auto dungeons_size = static_cast<short>(dungeons.size());
+        const auto &dungeon_name = tokens[1];
         while (true) {
-            d_idx = get_rumor_num(d_idx_str, dungeons_size);
-            d_ptr = &dungeons_info[d_idx];
+            dungeon_id = get_rumor_num(dungeon_name, dungeons_size);
+            d_ptr = &dungeons.get_dungeon(dungeon_id);
             if (!d_ptr->name.empty()) {
                 break;
             }
         }
 
         full_name = d_ptr->name;
-        if (!max_dlv[d_idx]) {
-            max_dlv[d_idx] = d_ptr->mindepth;
+        if (!max_dlv[dungeon_id]) {
+            max_dlv[dungeon_id] = d_ptr->mindepth;
             rumor_format = _("%sに帰還できるようになった。", "You can recall to %s.");
         }
     } else if (category == "TOWN") {

--- a/src/system/building-type-definition.cpp
+++ b/src/system/building-type-definition.cpp
@@ -114,9 +114,9 @@ void MeleeArena::update_gladiators(PlayerType *player_ptr)
 int MeleeArena::decide_max_level() const
 {
     auto max_dl = 0;
-    for (const auto &dungeon : dungeons_info) {
-        if (max_dl < max_dlv[dungeon.idx]) {
-            max_dl = max_dlv[dungeon.idx];
+    for (const auto &[dungeon_id, dungeon] : DungeonList::get_instance()) {
+        if (max_dl < max_dlv[dungeon_id]) {
+            max_dl = max_dlv[dungeon_id];
         }
     }
 

--- a/src/system/dungeon/dungeon-definition.h
+++ b/src/system/dungeon/dungeon-definition.h
@@ -67,7 +67,7 @@ enum class TerrainCharacteristics;
 class MonraceDefinition;
 class DungeonDefinition {
 public:
-    DUNGEON_IDX idx{};
+    int idx{};
 
     std::string name; /* Name */
     std::string text; /* Description */

--- a/src/system/dungeon/dungeon-list.cpp
+++ b/src/system/dungeon/dungeon-list.cpp
@@ -7,8 +7,6 @@
 #include "system/dungeon/dungeon-list.h"
 #include "system/dungeon/dungeon-definition.h"
 
-std::vector<DungeonDefinition> dungeons_info;
-
 DungeonList DungeonList::instance{};
 
 DungeonList &DungeonList::get_instance()

--- a/src/system/dungeon/dungeon-list.cpp
+++ b/src/system/dungeon/dungeon-list.cpp
@@ -8,3 +8,75 @@
 #include "system/dungeon/dungeon-definition.h"
 
 std::vector<DungeonDefinition> dungeons_info;
+
+DungeonList DungeonList::instance{};
+
+DungeonList &DungeonList::get_instance()
+{
+    return instance;
+}
+
+DungeonDefinition &DungeonList::get_dungeon(int dungeon_id)
+{
+    return this->dungeons.at(dungeon_id);
+}
+
+const DungeonDefinition &DungeonList::get_dungeon(int dungeon_id) const
+{
+    return this->dungeons.at(dungeon_id);
+}
+
+std::map<int, DungeonDefinition>::iterator DungeonList::begin()
+{
+    return this->dungeons.begin();
+}
+
+std::map<int, DungeonDefinition>::const_iterator DungeonList::begin() const
+{
+    return this->dungeons.cbegin();
+}
+
+std::map<int, DungeonDefinition>::iterator DungeonList::end()
+{
+    return this->dungeons.end();
+}
+
+std::map<int, DungeonDefinition>::const_iterator DungeonList::end() const
+{
+    return this->dungeons.cend();
+}
+
+std::map<int, DungeonDefinition>::reverse_iterator DungeonList::rbegin()
+{
+    return this->dungeons.rbegin();
+}
+
+std::map<int, DungeonDefinition>::const_reverse_iterator DungeonList::rbegin() const
+{
+    return this->dungeons.crbegin();
+}
+
+std::map<int, DungeonDefinition>::reverse_iterator DungeonList::rend()
+{
+    return this->dungeons.rend();
+}
+
+std::map<int, DungeonDefinition>::const_reverse_iterator DungeonList::rend() const
+{
+    return this->dungeons.crend();
+}
+
+size_t DungeonList::size() const
+{
+    return this->dungeons.size();
+}
+
+bool DungeonList::empty() const
+{
+    return this->dungeons.empty();
+}
+
+void DungeonList::emplace(int dungeon_id, DungeonDefinition &&definition)
+{
+    this->dungeons.emplace(dungeon_id, definition);
+}

--- a/src/system/dungeon/dungeon-list.h
+++ b/src/system/dungeon/dungeon-list.h
@@ -6,7 +6,38 @@
 
 #pragma once
 
+#include <map>
 #include <vector>
 
 class DungeonDefinition;
 extern std::vector<DungeonDefinition> dungeons_info;
+
+class DungeonList {
+public:
+    DungeonList(DungeonList &&) = delete;
+    DungeonList(const DungeonList &) = delete;
+    DungeonList &operator=(const DungeonList &) = delete;
+    DungeonList &operator=(DungeonList &&) = delete;
+    ~DungeonList() = default;
+
+    static DungeonList &get_instance();
+    DungeonDefinition &get_dungeon(int dungeon_id);
+    const DungeonDefinition &get_dungeon(int dungeon_id) const;
+    std::map<int, DungeonDefinition>::iterator begin();
+    std::map<int, DungeonDefinition>::const_iterator begin() const;
+    std::map<int, DungeonDefinition>::iterator end();
+    std::map<int, DungeonDefinition>::const_iterator end() const;
+    std::map<int, DungeonDefinition>::reverse_iterator rbegin();
+    std::map<int, DungeonDefinition>::const_reverse_iterator rbegin() const;
+    std::map<int, DungeonDefinition>::reverse_iterator rend();
+    std::map<int, DungeonDefinition>::const_reverse_iterator rend() const;
+    size_t size() const;
+    bool empty() const;
+    void emplace(int dungeon_id, DungeonDefinition &&definition);
+
+private:
+    DungeonList() = default;
+    static DungeonList instance;
+
+    std::map<int, DungeonDefinition> dungeons;
+};

--- a/src/system/dungeon/dungeon-list.h
+++ b/src/system/dungeon/dungeon-list.h
@@ -7,11 +7,8 @@
 #pragma once
 
 #include <map>
-#include <vector>
 
 class DungeonDefinition;
-extern std::vector<DungeonDefinition> dungeons_info;
-
 class DungeonList {
 public:
     DungeonList(DungeonList &&) = delete;

--- a/src/system/floor/floor-info.cpp
+++ b/src/system/floor/floor-info.cpp
@@ -53,7 +53,7 @@ bool FloorType::is_in_quest() const
     return this->quest_number != QuestId::NONE;
 }
 
-void FloorType::set_dungeon_index(short dungeon_idx_)
+void FloorType::set_dungeon_index(int dungeon_idx_)
 {
     this->dungeon_idx = dungeon_idx_;
 }

--- a/src/system/floor/floor-info.cpp
+++ b/src/system/floor/floor-info.cpp
@@ -65,7 +65,7 @@ void FloorType::reset_dungeon_index()
 
 DungeonDefinition &FloorType::get_dungeon_definition() const
 {
-    return dungeons_info[this->dungeon_idx];
+    return DungeonList::get_instance().get_dungeon(this->dungeon_idx);
 }
 
 /*!

--- a/src/system/floor/floor-info.h
+++ b/src/system/floor/floor-info.h
@@ -47,7 +47,7 @@ class ItemEntity;
 class FloorType {
 public:
     FloorType();
-    short dungeon_idx = 0;
+    int dungeon_idx = 0;
     std::vector<std::vector<Grid>> grid_array;
     DEPTH dun_level = 0; /*!< 現在の実ダンジョン階層 base_level の参照元となる / Current dungeon level */
     DEPTH base_level = 0; /*!< 基本生成レベル、後述のobject_level, monster_levelの参照元となる / Base dungeon level */
@@ -94,7 +94,7 @@ public:
     const Grid &get_grid(const Pos2D pos) const;
     bool is_in_underground() const;
     bool is_in_quest() const;
-    void set_dungeon_index(short dungeon_idx_); /*!< @todo 後でenum class にする */
+    void set_dungeon_index(int dungeon_idx_); /*!< @todo 後でenum class にする */
     void reset_dungeon_index();
     DungeonDefinition &get_dungeon_definition() const;
     QuestId get_random_quest_id(std::optional<int> level_opt = std::nullopt) const;

--- a/src/system/h-type.h
+++ b/src/system/h-type.h
@@ -80,7 +80,6 @@ typedef int16_t FEAT_IDX; /*!< ゲーム中の地形ID型を定義 */
 typedef int16_t FLOOR_IDX; /*!< ゲーム中のフロアID型を定義 */
 
 typedef int16_t MONSTER_IDX; /*!< ゲーム中のモンスター個体ID型を定義 */
-typedef int16_t DUNGEON_IDX; /*!< ゲーム中のダンジョンID型を定義 */
 typedef int16_t EGO_IDX; /*!< アイテムエゴのID型を定義 */
 typedef int16_t QUEST_IDX; /*!< ゲーム中のクエストID型を定義 */
 

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -147,7 +147,7 @@ public:
 
     TIME_EFFECT word_recall{}; /* Word of recall counter */
     TIME_EFFECT alter_reality{}; /* Alter reality counter */
-    DUNGEON_IDX recall_dungeon{}; /* Dungeon set to be recalled */
+    int recall_dungeon{}; /* Dungeon set to be recalled */
 
     ENERGY energy_need{}; /* Energy needed for next move */
     ENERGY enchant_energy_need{}; /* Energy needed for next upkeep effect	 */

--- a/src/target/target-describer.cpp
+++ b/src/target/target-describer.cpp
@@ -480,7 +480,7 @@ static std::string decide_target_floor(PlayerType *player_ptr, GridExamination *
     }
 
     if (ge_ptr->terrain_ptr->flags.has(TerrainCharacteristics::ENTRANCE)) {
-        const auto &dungeon = dungeons_info[ge_ptr->g_ptr->special];
+        const auto &dungeon = DungeonList::get_instance().get_dungeon(ge_ptr->g_ptr->special);
         return format(_("%s(%d階相当)", "%s(level %d)"), dungeon.text.data(), dungeon.mindepth);
     }
 

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -487,7 +487,7 @@ static std::optional<int> select_debugging_dungeon(int initial_dungeon_id)
  */
 static std::optional<int> select_debugging_floor(const FloorType &floor, int dungeon_id)
 {
-    const auto &dungeon = dungeons_info[dungeon_id];
+    const auto &dungeon = DungeonList::get_instance().get_dungeon(dungeon_id);
     const auto max_depth = dungeon.maxdepth;
     const auto min_depth = dungeon.mindepth;
     const auto is_current_dungeon = floor.dungeon_idx == dungeon_id;

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -470,10 +470,10 @@ void wiz_create_feature(PlayerType *player_ptr)
  * @param player_ptr プレイヤーへの参照ポインタ
  * @details 範囲外の値が選択されたら再入力を促す
  */
-static std::optional<short> select_debugging_dungeon(short initial_dungeon_id)
+static std::optional<int> select_debugging_dungeon(int initial_dungeon_id)
 {
     if (command_arg > 0) {
-        return static_cast<short>(std::clamp(static_cast<int>(command_arg), DUNGEON_ANGBAND, DUNGEON_MAX));
+        return std::clamp(static_cast<int>(command_arg), DUNGEON_ANGBAND, DUNGEON_MAX);
     }
 
     return input_numerics("Jump which dungeon", DUNGEON_ANGBAND, DUNGEON_MAX, initial_dungeon_id);
@@ -503,7 +503,7 @@ static std::optional<int> select_debugging_floor(const FloorType &floor, int dun
  * @brief 任意のダンジョン及び階層に飛ぶ
  * Go to any level
  */
-static void wiz_jump_floor(PlayerType *player_ptr, DUNGEON_IDX dun_idx, DEPTH depth)
+static void wiz_jump_floor(PlayerType *player_ptr, int dun_idx, DEPTH depth)
 {
     auto &floor = *player_ptr->current_floor_ptr;
     floor.set_dungeon_index(dun_idx);
@@ -537,7 +537,7 @@ void wiz_jump_to_dungeon(PlayerType *player_ptr)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
     const auto is_in_dungeon = floor.is_in_underground();
-    const auto dungeon_idx = is_in_dungeon ? floor.dungeon_idx : static_cast<short>(DUNGEON_ANGBAND);
+    const auto dungeon_idx = is_in_dungeon ? floor.dungeon_idx : DUNGEON_ANGBAND;
     const auto dungeon_id = select_debugging_dungeon(dungeon_idx);
     if (!dungeon_id) {
         if (!is_in_dungeon) {


### PR DESCRIPTION
DungeonDefinition::outer\_wall などの地形特性ID とfeat\_hoge のグローバル変数廃止との整合性を取っていく上で先にやっておいた方が良さそうだと判断しました
この次のPRも含め、帰還とフロア・リセット周りの挙動が正常に動いていることをチェック済です
クラスのモデル化は別途行います
ご確認下さい