### PR TITLE
MSVC において、デバッグビルド以外のビルドに失敗する問題を修正した

### DIFF
--- a/VisualStudio/Hengband/Hengband.vcxproj
+++ b/VisualStudio/Hengband/Hengband.vcxproj
@@ -103,7 +103,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32;HAVE_STDINT_H;JP;SJIS;WORLD_SCORE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32;HAVE_STDINT_H;JP;SJIS;WORLD_SCORE;WIN_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>EnableAllWarnings</WarningLevel>
@@ -119,7 +119,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <AdditionalOptions>/source-charset:utf-8 /execution-charset:shift-jis %(AdditionalOptions)</AdditionalOptions>
       <StructMemberAlignment>16Bytes</StructMemberAlignment>
-      <EnableEnhancedInstructionSet>AdvancedVectorExtensions</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
       <TreatWarningAsError>true</TreatWarningAsError>
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
       <CompileAsManaged>false</CompileAsManaged>
@@ -142,13 +142,13 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='English-Debug|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32;HAVE_STDINT_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32;HAVE_STDINT_H;WIN_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>EnableAllWarnings</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <CompileAs>CompileAsCpp</CompileAs>
-      <DisableSpecificWarnings>4127;4996;4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4061;4062;4127;4244;4255;4365;4514;4668;4710;4820;4996;4774;5045;5264;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AdditionalIncludeDirectories>..\..\src;libcurl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ExceptionHandling>SyncCThrow</ExceptionHandling>
@@ -157,10 +157,11 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <AdditionalOptions>/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
       <StructMemberAlignment>16Bytes</StructMemberAlignment>
-      <EnableEnhancedInstructionSet>AdvancedVectorExtensions</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
       <TreatWarningAsError>true</TreatWarningAsError>
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
       <CompileAsManaged>false</CompileAsManaged>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -175,7 +176,7 @@
       <PreprocessorDefinitions>WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32;HAVE_STDINT_H;JP;SJIS;WORLD_SCORE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>EnableAllWarnings</WarningLevel>
-      <DisableSpecificWarnings>4244;4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4061;4062;4127;4244;4255;4365;4514;4668;4710;4711;4820;4996;4774;5045;5264;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AdditionalIncludeDirectories>..\..\src;libcurl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -192,6 +193,7 @@
       <EnableEnhancedInstructionSet>AdvancedVectorExtensions</EnableEnhancedInstructionSet>
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
       <CompileAsManaged>false</CompileAsManaged>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <TargetMachine>MachineX86</TargetMachine>
@@ -218,7 +220,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WarningLevel>EnableAllWarnings</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <DisableSpecificWarnings>4244;4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4061;4062;4127;4244;4255;4365;4514;4668;4710;4711;4820;4996;4774;5045;5264;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AdditionalIncludeDirectories>..\..\src;libcurl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ExceptionHandling>SyncCThrow</ExceptionHandling>
@@ -232,6 +234,7 @@
       <EnableEnhancedInstructionSet>AdvancedVectorExtensions</EnableEnhancedInstructionSet>
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
       <CompileAsManaged>false</CompileAsManaged>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <AdditionalDependencies>winmm.lib;gdiplus.lib;Ws2_32.lib;Wldap32.lib;Crypt32.lib;Normaliz.lib;DbgHelp.lib;libcurl\lib\libcurl_a.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/flavor/object-flavor.cpp
+++ b/src/flavor/object-flavor.cpp
@@ -34,6 +34,7 @@
 #include "sv-definition/sv-lite-types.h"
 #include "system/baseitem/baseitem-key.h"
 #include "util/bit-flags-calculator.h"
+#include <cctype>
 #include <functional>
 #include <sstream>
 #include <utility>
@@ -76,7 +77,7 @@ std::string get_table_name_aux()
     }
 
     auto name = ss.str();
-    name[0] = toupper(name[0]);
+    name[0] = static_cast<char>(std::toupper(name[0]));
     return name;
 #endif
 }

--- a/src/main-gcu.cpp
+++ b/src/main-gcu.cpp
@@ -216,9 +216,6 @@ struct term_data {
     WINDOW *win;
 };
 
-/* Max number of windows on screen */
-#define MAX_TERM_DATA 8
-
 /* Information about our windows */
 static term_data data[MAX_TERM_DATA];
 

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -144,8 +144,6 @@
  */
 LPCWSTR win_term_name[] = { L"Hengband", L"Term-1", L"Term-2", L"Term-3", L"Term-4", L"Term-5", L"Term-6", L"Term-7" };
 
-#define MAX_TERM_DATA 8 //!< Maximum number of windows
-
 static term_data data[MAX_TERM_DATA]; //!< An array of term_data's
 static bool is_main_term(term_data *td)
 {
@@ -191,7 +189,7 @@ static HICON hIcon;
 
 /* bg */
 bg_mode current_bg_mode = bg_mode::BG_NONE;
-#define DEFAULT_BG_FILENAME "bg.bmp"
+constexpr auto DEFAULT_BG_FILENAME = "bg.bmp";
 std::filesystem::path wallpaper_path = ""; //!< 壁紙ファイル名。
 
 /*
@@ -446,7 +444,7 @@ static void save_prefs(void)
 /*!
  * @brief callback for EnumDisplayMonitors API
  */
-BOOL CALLBACK monitor_enum_procedure([[maybe_unused]] HMONITOR hMon, [[maybe_unused]] HDC hdcMon, [[maybe_unused]] LPRECT lpMon, LPARAM dwDate)
+static BOOL CALLBACK monitor_enum_procedure([[maybe_unused]] HMONITOR hMon, [[maybe_unused]] HDC hdcMon, [[maybe_unused]] LPRECT lpMon, LPARAM dwDate)
 {
     bool *result = (bool *)dwDate;
     *result = true;
@@ -737,7 +735,7 @@ static void term_data_redraw(term_data *td)
 /*!
  * @brief termの反転色表示
  */
-void term_inversed_area(HWND hWnd, int x, int y, int w, int h)
+static void term_inversed_area(HWND hWnd, int x, int y, int w, int h)
 {
     term_data *td = (term_data *)GetWindowLong(hWnd, 0);
     int tx = td->size_ow1 + x * td->tile_wid;
@@ -2243,7 +2241,7 @@ static bool handle_window_resize(term_data *td, UINT uMsg, WPARAM wParam, LPARAM
 /*!
  * @brief メインウインドウ用ウインドウプロシージャ
  */
-LRESULT PASCAL angband_window_procedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+static LRESULT PASCAL angband_window_procedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     term_data *td = (term_data *)GetWindowLong(hWnd, 0);
 
@@ -2512,7 +2510,7 @@ LRESULT PASCAL angband_window_procedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
 /*!
  * @brief サブウインドウ用ウインドウプロシージャ
  */
-LRESULT PASCAL AngbandListProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+static LRESULT PASCAL AngbandListProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     term_data *td = (term_data *)GetWindowLong(hWnd, 0);
     if (handle_window_resize(td, uMsg, wParam, lParam)) {
@@ -2761,7 +2759,7 @@ static void register_wndclass(void)
 /*!
  * @brief ゲームのメインルーチン
  */
-int WINAPI game_main(_In_ HINSTANCE hInst)
+static int WINAPI game_main(_In_ HINSTANCE hInst)
 {
     setlocale(LC_ALL, "ja_JP");
     hInstance = hInst;
@@ -2848,7 +2846,9 @@ int WINAPI game_main(_In_ HINSTANCE hInst)
     }
 
     quit("");
+#ifdef WIN_DEBUG
     return 0;
+#endif
 }
 
 /*!

--- a/src/main-x11.cpp
+++ b/src/main-x11.cpp
@@ -1022,11 +1022,6 @@ struct term_data {
 }
 
 /*
- * The number of term data structures
- */
-#define MAX_TERM_DATA 8
-
-/*
  * The array of term data structures
  */
 static term_data data[MAX_TERM_DATA];

--- a/src/term/gameterm.h
+++ b/src/term/gameterm.h
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <utility>
 
+constexpr auto MAX_TERM_DATA = 8; //!< Maximum number of terminals
 constexpr auto TERM_DEFAULT_COLS = 80;
 constexpr auto TERM_DEFAULT_ROWS = 24;
 constexpr auto MAIN_TERM_MIN_COLS = TERM_DEFAULT_COLS;


### PR DESCRIPTION
詳細は以下の通りです
リリース作業に支障がある可能性が高いのでお早めにチェック頂けると助かります
- リリースビルドにおける単なる情報表示 (C4711、インライン関数展開)が警告扱いになってコンパイルエラーを起こしているので、デバッグビルドのみWIN_DEBUG のプリプロを定義した
  - 4061 など新たに追加されているが、これらはVS2022 のデフォルト抑制
- 戻り値がvoid でない関数においてquit() が呼ばれる時、デバッグビルドではダミー戻り値を返すコードを書いていたが、リリースビルドでは警告からのコンパイルエラーになるので、リリースビルドのみ抑制した
- デバッグビルドでは、AVX 命令が有効でもほぼ性能向上は見込めず、それどころかステップ実行に悪影響が出る可能性があるらしいので、デバッグビルドにおいては拡張命令全般を無効化した
- MSVC 専用拡張記法を無効化した (GNU 拡張は以前に無効化済)
- その他main-win.cpp におけるサジェスト対応 (define 定数、static 関数、ナローキャスト)