### PR TITLE
For descriptions, immunities and vulnerabilities override resistances

### DIFF
--- a/src/perception/identification.cpp
+++ b/src/perception/identification.cpp
@@ -420,19 +420,19 @@ bool screen_object(PlayerType *player_ptr, const ItemEntity &item, BIT_FLAGS mod
         info[i++] = _("それは恐怖への完全な耐性を授ける。", "It makes you completely fearless.");
     }
 
-    if (flags.has(TR_RES_ACID)) {
+    if (flags.has(TR_RES_ACID) && flags.has_not(TR_IM_ACID) && flags.has_not(TR_VUL_ACID)) {
         info[i++] = _("それは酸への耐性を授ける。", "It provides resistance to acid.");
     }
 
-    if (flags.has(TR_RES_ELEC)) {
+    if (flags.has(TR_RES_ELEC) && flags.has_not(TR_IM_ELEC) && flags.has_not(TR_VUL_ELEC)) {
         info[i++] = _("それは電撃への耐性を授ける。", "It provides resistance to electricity.");
     }
 
-    if (flags.has(TR_RES_FIRE)) {
+    if (flags.has(TR_RES_FIRE) && flags.has_not(TR_IM_FIRE) && flags.has_not(TR_VUL_FIRE)) {
         info[i++] = _("それは火への耐性を授ける。", "It provides resistance to fire.");
     }
 
-    if (flags.has(TR_RES_COLD)) {
+    if (flags.has(TR_RES_COLD) && flags.has_not(TR_IM_COLD) && flags.has_not(TR_VUL_COLD)) {
         info[i++] = _("それは寒さへの耐性を授ける。", "It provides resistance to cold.");
     }
 
@@ -440,11 +440,11 @@ bool screen_object(PlayerType *player_ptr, const ItemEntity &item, BIT_FLAGS mod
         info[i++] = _("それは毒への耐性を授ける。", "It provides resistance to poison.");
     }
 
-    if (flags.has(TR_RES_LITE)) {
+    if (flags.has(TR_RES_LITE) && flags.has_not(TR_VUL_LITE)) {
         info[i++] = _("それは閃光への耐性を授ける。", "It provides resistance to light.");
     }
 
-    if (flags.has(TR_RES_DARK)) {
+    if (flags.has(TR_RES_DARK) && flags.has_not(TR_IM_DARK)) {
         info[i++] = _("それは暗黒への耐性を授ける。", "It provides resistance to dark.");
     }
 
@@ -564,7 +564,7 @@ bool screen_object(PlayerType *player_ptr, const ItemEntity &item, BIT_FLAGS mod
         info[i++] = _("それは矢の呪文を反射する。", "It reflects bolt spells.");
     }
 
-    if (flags.has(TR_RES_CURSE)) {
+    if (flags.has(TR_RES_CURSE) && flags.has_not(TR_VUL_CURSE)) {
         info[i++] = _("それは呪いへの抵抗力を高める。", "It increases your resistance to curses.");
     }
 


### PR DESCRIPTION
That matches what view/display-characteristic.cpp does and resolves https://github.com/hengband/hengband/issues/4739 .

The handling for TR_RES_CURSE currently mimics what's in src/view/display-characteristic.cpp.  It was not clear to me if it also needed to test for item.curse_flags.has(CurseTraitType::VUL_CURSE) not being there as that is tested for when printing "It decreases your resistance to curses.".