### PR TITLE
[Feature] モンスター定義ファイルからのNEVER_BLOWフラグ撤廃

### DIFF
--- a/lib/edit/MonraceDefinitions.jsonc
+++ b/lib/edit/MonraceDefinitions.jsonc
@@ -68,7 +68,7 @@
       "AURA_HOLINESS", "AURA_NETHER", "AURA_DISENCHANT", "AURA_NEXUS", "AURA_TIME", "AURA_GRAVITY", "AURA_VOIDS",
       "AURA_ABYSS"
 
-      "NEVER_BLOW", "NEVER_MOVE", "OPEN_DOOR", "BASH_DOOR", "MOVE_BODY", "KILL_BODY", "TAKE_ITEM", "KILL_ITEM",
+      "NEVER_MOVE", "OPEN_DOOR", "BASH_DOOR", "MOVE_BODY", "KILL_BODY", "TAKE_ITEM", "KILL_ITEM",
       "RAND_25", "RAND_50", "STUPID", "SMART", "FRIENDLY",
       "CHAR_CLEAR", "SHAPECHANGER", "ATTR_CLEAR", "ATTR_MULTI", "ATTR_SEMIRAND", "ATTR_ANY"
       "UNIQUE", "HUMAN", "QUANTUM", "ORC", "TROLL", "GIANT", "DRAGON", "DEMON", "UNDEAD", "EVIL",
@@ -2013,7 +2013,6 @@
       "exp": 3,
       "flags": [
         "NEVER_MOVE",
-        "NEVER_BLOW",
         "STUPID",
         "EMPTY_MIND",
         "IM_POIS",
@@ -13590,7 +13589,6 @@
       "exp": 10,
       "flags": [
         "NEVER_MOVE",
-        "NEVER_BLOW",
         "FRIENDS",
         "STUPID",
         "RES_TELE",
@@ -16455,7 +16453,6 @@
       "rarity": 1,
       "exp": 70,
       "flags": [
-        "NEVER_BLOW",
         "RAND_50",
         "RAND_25",
         "CAN_FLY",
@@ -16549,7 +16546,6 @@
       "rarity": 2,
       "exp": 68,
       "flags": [
-        "NEVER_BLOW",
         "RAND_50",
         "RAND_25",
         "WEIRD_MIND",
@@ -17666,7 +17662,6 @@
       "exp": 250,
       "flags": [
         "NEVER_MOVE",
-        "NEVER_BLOW",
         "EMPTY_MIND",
         "INVISIBLE",
         "STUPID",
@@ -25931,7 +25926,6 @@
       "exp": 300,
       "flags": [
         "NEVER_MOVE",
-        "NEVER_BLOW",
         "STUPID",
         "INVISIBLE",
         "EMPTY_MIND",
@@ -30932,7 +30926,6 @@
       "exp": 1500,
       "flags": [
         "NEVER_MOVE",
-        "NEVER_BLOW",
         "NONLIVING",
         "EVIL",
         "COLD_BLOOD",
@@ -32658,8 +32651,7 @@
         "EVIL",
         "NO_SLEEP",
         "NO_CONF",
-        "CAN_FLY",
-        "NEVER_BLOW"
+        "CAN_FLY"
       ],
       "skill": {
         "probability": "1_IN_2",
@@ -33795,7 +33787,6 @@
         "ATTR_MULTI",
         "SELF_LITE_1",
         "SELF_LITE_2",
-        "NEVER_BLOW",
         "RAND_50",
         "RAND_25",
         "CAN_FLY",
@@ -36084,7 +36075,6 @@
       "flags": [
         "FORCE_MAXHP",
         "NEVER_MOVE",
-        "NEVER_BLOW",
         "INVISIBLE",
         "EMPTY_MIND",
         "ANIMAL",
@@ -42998,7 +42988,6 @@
       "flags": [
         "FORCE_MAXHP",
         "NEVER_MOVE",
-        "NEVER_BLOW",
         "INVISIBLE",
         "EMPTY_MIND",
         "ANIMAL",
@@ -44697,7 +44686,6 @@
       "flags": [
         "FORCE_MAXHP",
         "NEVER_MOVE",
-        "NEVER_BLOW",
         "RES_TELE",
         "SMART",
         "COLD_BLOOD",
@@ -44904,7 +44892,6 @@
       "flags": [
         "ATTR_MULTI",
         "ATTR_ANY",
-        "NEVER_BLOW",
         "RAND_50",
         "RAND_25",
         "CAN_FLY",
@@ -45563,7 +45550,6 @@
       "flags": [
         "FORCE_MAXHP",
         "NEVER_MOVE",
-        "NEVER_BLOW",
         "INVISIBLE",
         "EMPTY_MIND",
         "ANIMAL",
@@ -49166,7 +49152,6 @@
       "flags": [
         "FORCE_MAXHP",
         "NEVER_MOVE",
-        "NEVER_BLOW",
         "INVISIBLE",
         "EMPTY_MIND",
         "STUPID",
@@ -49215,7 +49200,6 @@
       "flags": [
         "FORCE_MAXHP",
         "NEVER_MOVE",
-        "NEVER_BLOW",
         "INVISIBLE",
         "EMPTY_MIND",
         "STUPID",
@@ -49262,7 +49246,6 @@
       "flags": [
         "FORCE_MAXHP",
         "NEVER_MOVE",
-        "NEVER_BLOW",
         "INVISIBLE",
         "EMPTY_MIND",
         "STUPID",
@@ -50921,7 +50904,6 @@
         "RES_TELE",
         "FORCE_MAXHP",
         "NEVER_MOVE",
-        "NEVER_BLOW",
         "ONLY_ITEM",
         "DROP_4D2",
         "INVISIBLE",
@@ -50971,7 +50953,6 @@
         "RES_TELE",
         "FORCE_MAXHP",
         "NEVER_MOVE",
-        "NEVER_BLOW",
         "ONLY_ITEM",
         "DROP_4D2",
         "DROP_2D2",
@@ -55100,7 +55081,6 @@
       "exp": 25,
       "odds_correction_ratio": 300,
       "flags": [
-        "NEVER_BLOW",
         "RAND_25",
         "ANIMAL",
         "WILD_WOOD"
@@ -58010,7 +57990,6 @@
       "rarity": 2,
       "exp": 50,
       "flags": [
-        "NEVER_BLOW",
         "NEVER_MOVE",
         "NO_SLEEP",
         "NO_FEAR",
@@ -58054,7 +58033,6 @@
       "rarity": 4,
       "exp": 75,
       "flags": [
-        "NEVER_BLOW",
         "ATTR_MULTI",
         "AQUATIC",
         "INVISIBLE",
@@ -58378,7 +58356,6 @@
       "rarity": 4,
       "exp": 60,
       "flags": [
-        "NEVER_BLOW",
         "ATTR_MULTI",
         "AQUATIC",
         "NO_CONF",
@@ -65331,7 +65308,6 @@
         "FORCE_MAXHP",
         "RAND_25",
         "RAND_50",
-        "NEVER_BLOW",
         "EMPTY_MIND",
         "COLD_BLOOD",
         "NONLIVING",
@@ -66170,7 +66146,6 @@
       "exp": 240,
       "sex": "MALE",
       "flags": [
-        "NEVER_BLOW",
         "HUMAN",
         "DROP_SKELETON",
         "DROP_CORPSE",
@@ -66679,7 +66654,6 @@
       "rarity": 6,
       "exp": 5000,
       "flags": [
-        "NEVER_BLOW",
         "RAND_50",
         "RAND_25",
         "CAN_FLY",
@@ -69755,8 +69729,7 @@
         "NO_CONF",
         "ONLY_ITEM",
         "DROP_90",
-        "DROP_GREAT",
-        "NEVER_BLOW"
+        "DROP_GREAT"
       ],
       "skill": {
         "probability": "1_IN_2",
@@ -70362,7 +70335,6 @@
         "HURT_COLD",
         "HURT_LITE",
         "HURT_ROCK",
-        "NEVER_BLOW",
         "ATTR_CLEAR",
         "NEVER_MOVE",
         "MULTIPLY",
@@ -73804,8 +73776,7 @@
         "NO_STUN",
         "NO_SLEEP",
         "NO_FEAR",
-        "NEVER_MOVE",
-        "NEVER_BLOW"
+        "NEVER_MOVE"
       ],
       "skill": {
         "probability": "1_IN_2",
@@ -73850,8 +73821,7 @@
         "NO_STUN",
         "NO_SLEEP",
         "NO_FEAR",
-        "NEVER_MOVE",
-        "NEVER_BLOW"
+        "NEVER_MOVE"
       ],
       "skill": {
         "probability": "1_IN_2",
@@ -80623,7 +80593,6 @@
       "flags": [
         "FORCE_MAXHP",
         "NEVER_MOVE",
-        "NEVER_BLOW",
         "INVISIBLE",
         "EMPTY_MIND",
         "ANIMAL",
@@ -80667,7 +80636,6 @@
       "flags": [
         "FORCE_MAXHP",
         "NEVER_MOVE",
-        "NEVER_BLOW",
         "INVISIBLE",
         "EMPTY_MIND",
         "STUPID",
@@ -80776,8 +80744,7 @@
         "RES_SHAR",
         "NO_CONF",
         "NO_SLEEP",
-        "NO_FEAR",
-        "NEVER_BLOW"
+        "NO_FEAR"
       ],
       "skill": {
         "probability": "1_IN_6",
@@ -85110,7 +85077,6 @@
         "FORCE_MAXHP",
         "RAND_25",
         "RAND_50",
-        "NEVER_BLOW",
         "DROP_60",
         "DROP_90",
         "DROP_GREAT",
@@ -85177,7 +85143,6 @@
         "DROP_2D2",
         "DROP_4D2",
         "DROP_GREAT",
-        "NEVER_BLOW",
         "SMART",
         "OPEN_DOOR",
         "BASH_DOOR",
@@ -86505,7 +86470,6 @@
         "DROP_CORPSE",
         "EVIL",
         "DEMON",
-        "NEVER_BLOW",
         "FORCE_MAXHP",
         "POWERFUL",
         "IM_FIRE",
@@ -86553,7 +86517,6 @@
         "DROP_CORPSE",
         "EVIL",
         "DEMON",
-        "NEVER_BLOW",
         "FORCE_MAXHP",
         "NO_FEAR",
         "RES_PLAS",
@@ -86593,7 +86556,6 @@
       "flags": [
         "ATTR_MULTI",
         "ATTR_ANY",
-        "NEVER_BLOW",
         "RAND_50",
         "RAND_25",
         "CAN_FLY",
@@ -86641,7 +86603,6 @@
       "flags": [
         "ATTR_MULTI",
         "ATTR_ANY",
-        "NEVER_BLOW",
         "RAND_50",
         "RAND_25",
         "CAN_FLY",
@@ -87028,7 +86989,6 @@
         "SMART",
         "CAN_FLY",
         "RAND_25",
-        "NEVER_BLOW",
         "HURT_FIRE",
         "IM_COLD",
         "IM_POIS",
@@ -87141,7 +87101,6 @@
         "EVIL",
         "ANIMAL",
         "DROP_CORPSE",
-        "NEVER_BLOW",
         "FORCE_MAXHP",
         "ONLY_ONE",
         "HURT_FIRE",
@@ -87183,7 +87142,6 @@
         "EVIL",
         "ANIMAL",
         "DROP_CORPSE",
-        "NEVER_BLOW",
         "FORCE_MAXHP",
         "ONLY_ONE",
         "HURT_FIRE",

--- a/schema/MonraceDefinitions.schema.json
+++ b/schema/MonraceDefinitions.schema.json
@@ -410,7 +410,6 @@
                                 "AURA_GRAVITY",
                                 "AURA_VOIDS",
                                 "AURA_ABYSS",
-                                "NEVER_BLOW",
                                 "NEVER_MOVE",
                                 "OPEN_DOOR",
                                 "BASH_DOOR",

--- a/src/info-reader/race-info-tokens-table.cpp
+++ b/src/info-reader/race-info-tokens-table.cpp
@@ -303,7 +303,6 @@ const std::unordered_map<std::string_view, MonsterAuraType> r_info_aura_flags = 
 };
 
 const std::unordered_map<std::string_view, MonsterBehaviorType> r_info_behavior_flags = {
-    { "NEVER_BLOW", MonsterBehaviorType::NEVER_BLOW },
     { "NEVER_MOVE", MonsterBehaviorType::NEVER_MOVE },
     { "OPEN_DOOR", MonsterBehaviorType::OPEN_DOOR },
     { "BASH_DOOR", MonsterBehaviorType::BASH_DOOR },

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -291,6 +291,7 @@ static errr set_mon_escorts(nlohmann::json &escort_data, MonraceDefinition &monr
 static errr set_mon_blows(nlohmann::json &blow_data, MonraceDefinition &monrace)
 {
     if (blow_data.is_null()) {
+        monrace.behavior_flags.set(MonsterBehaviorType::NEVER_BLOW);
         return PARSE_ERROR_NONE;
     }
     if (!blow_data.is_array()) {


### PR DESCRIPTION
NEVER_BLOWフラグを打撃定義のないモンスターに自動割当するよう変更した。
合わせて既存のNEVER_BLOWフラグを定義ファイルから削除した。