### PR TITLE
English: in revenge part of lore, add missing space and match verb to subject

### DIFF
--- a/src/lore/lore-util.cpp
+++ b/src/lore/lore-util.cpp
@@ -165,7 +165,7 @@ std::string lore_type::build_revenge_description(bool has_defeated) const
     }
 
     std::stringstream ss;
-    ss << ", who remain" << (this->r_ptr->r_deaths == 1 ? "" : "s") << "unavenged.  ";
+    ss << ", who remain" << (this->r_ptr->r_deaths != 1 ? "" : "s") << " unavenged.  ";
     return ss.str();
 #endif
 }


### PR DESCRIPTION
Resolves https://github.com/hengband/hengband/issues/4745 .