### PR TITLE
[Refactor] AbstractVectorWrapperによるボイラープレートの削減

### DIFF
--- a/VisualStudio/Hengband/Hengband.vcxproj
+++ b/VisualStudio/Hengband/Hengband.vcxproj
@@ -1498,6 +1498,7 @@
     <ClInclude Include="..\..\src\tracking\baseitem-tracker.h" />
     <ClInclude Include="..\..\src\tracking\health-bar-tracker.h" />
     <ClInclude Include="..\..\src\tracking\lore-tracker.h" />
+    <ClInclude Include="..\..\src\util\abstract-vector-wrapper.h" />
     <ClInclude Include="..\..\src\util\bit-flags-calculator.h" />
     <ClInclude Include="..\..\src\util\buffer-shaper.h" />
     <ClInclude Include="..\..\src\util\candidate-selector.h" />

--- a/VisualStudio/Hengband/Hengband.vcxproj.filters
+++ b/VisualStudio/Hengband/Hengband.vcxproj.filters
@@ -5379,6 +5379,9 @@
     <ClInclude Include="..\..\src\net\curl-slist.h">
       <Filter>net</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\util\abstract-vector-wrapper.h">
+      <Filter>util</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\util\finalizer.h">
       <Filter>util</Filter>
     </ClInclude>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -994,6 +994,7 @@ hengband_SOURCES = \
 	tracking/health-bar-tracker.cpp tracking/health-bar-tracker.h \
 	tracking/lore-tracker.cpp tracking/lore-tracker.h \
 	\
+	util/abstract-vector-wrapper.h \
 	util/angband-files.cpp util/angband-files.h \
 	util/buffer-shaper.cpp util/buffer-shaper.h \
 	util/bit-flags-calculator.h \

--- a/src/system/baseitem/baseitem-allocation.cpp
+++ b/src/system/baseitem/baseitem-allocation.cpp
@@ -102,31 +102,6 @@ void BaseitemAllocationTable::initialize()
     }
 }
 
-std::vector<BaseitemAllocationEntry>::iterator BaseitemAllocationTable::begin()
-{
-    return this->entries.begin();
-}
-
-std::vector<BaseitemAllocationEntry>::const_iterator BaseitemAllocationTable::begin() const
-{
-    return this->entries.cbegin();
-}
-
-std::vector<BaseitemAllocationEntry>::iterator BaseitemAllocationTable::end()
-{
-    return this->entries.end();
-}
-
-std::vector<BaseitemAllocationEntry>::const_iterator BaseitemAllocationTable::end() const
-{
-    return this->entries.cend();
-}
-
-size_t BaseitemAllocationTable::size() const
-{
-    return this->entries.size();
-}
-
 const BaseitemAllocationEntry &BaseitemAllocationTable::get_entry(int index) const
 {
     return this->entries.at(index);

--- a/src/system/baseitem/baseitem-allocation.h
+++ b/src/system/baseitem/baseitem-allocation.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "util/abstract-vector-wrapper.h"
 #include "util/probability-table.h"
 
 /*
@@ -35,7 +36,7 @@ private:
     const BaseitemKey &get_bi_key() const;
 };
 
-class BaseitemAllocationTable {
+class BaseitemAllocationTable : public util::AbstractVectorWrapper<BaseitemAllocationEntry> {
 public:
     BaseitemAllocationTable(const BaseitemAllocationTable &) = delete;
     BaseitemAllocationTable(BaseitemAllocationTable &&) = delete;
@@ -44,11 +45,6 @@ public:
     static BaseitemAllocationTable &get_instance();
 
     void initialize();
-    std::vector<BaseitemAllocationEntry>::iterator begin();
-    std::vector<BaseitemAllocationEntry>::const_iterator begin() const;
-    std::vector<BaseitemAllocationEntry>::iterator end();
-    std::vector<BaseitemAllocationEntry>::const_iterator end() const;
-    size_t size() const;
     const BaseitemAllocationEntry &get_entry(int index) const;
     BaseitemAllocationEntry &get_entry(int index);
     short draw_lottery(int level, uint32_t mode, int count) const;
@@ -60,6 +56,11 @@ private:
     static BaseitemAllocationTable instance;
     BaseitemAllocationTable() = default;
     std::vector<BaseitemAllocationEntry> entries;
+
+    std::vector<BaseitemAllocationEntry> &get_inner_container() override
+    {
+        return this->entries;
+    }
 
     ProbabilityTable<int> make_table(int level, uint32_t mode) const;
 };

--- a/src/system/baseitem/baseitem-list.cpp
+++ b/src/system/baseitem/baseitem-list.cpp
@@ -48,66 +48,6 @@ const BaseitemDefinition &BaseitemList::get_baseitem(const short bi_id) const
     return this->baseitems[bi_id];
 }
 
-std::vector<BaseitemDefinition>::iterator BaseitemList::begin()
-{
-    return this->baseitems.begin();
-}
-
-std::vector<BaseitemDefinition>::const_iterator BaseitemList::begin() const
-{
-    return this->baseitems.begin();
-}
-
-std::vector<BaseitemDefinition>::iterator BaseitemList::end()
-{
-    return this->baseitems.end();
-}
-
-std::vector<BaseitemDefinition>::const_iterator BaseitemList::end() const
-{
-    return this->baseitems.end();
-}
-
-std::vector<BaseitemDefinition>::reverse_iterator BaseitemList::rbegin()
-{
-    return this->baseitems.rbegin();
-}
-
-std::vector<BaseitemDefinition>::const_reverse_iterator BaseitemList::rbegin() const
-{
-    return this->baseitems.rbegin();
-}
-
-std::vector<BaseitemDefinition>::reverse_iterator BaseitemList::rend()
-{
-    return this->baseitems.rend();
-}
-
-std::vector<BaseitemDefinition>::const_reverse_iterator BaseitemList::rend() const
-{
-    return this->baseitems.rend();
-}
-
-size_t BaseitemList::size() const
-{
-    return this->baseitems.size();
-}
-
-bool BaseitemList::empty() const
-{
-    return this->baseitems.empty();
-}
-
-void BaseitemList::resize(size_t new_size)
-{
-    this->baseitems.resize(new_size);
-}
-
-void BaseitemList::shrink_to_fit()
-{
-    this->baseitems.shrink_to_fit();
-}
-
 /*!
  * @brief ベースアイテムキーからIDを引いて返す
  * @param key ベースアイテムキー、但しsvalはランダム(nullopt) の可能性がある

--- a/src/system/baseitem/baseitem-list.h
+++ b/src/system/baseitem/baseitem-list.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "util/abstract-vector-wrapper.h"
 #include <map>
 #include <optional>
 #include <vector>
@@ -14,7 +15,7 @@ enum class ItemKindType : short;
 enum class MonraceId : short;
 class BaseitemDefinition;
 class BaseitemKey;
-class BaseitemList {
+class BaseitemList : public util::AbstractVectorWrapper<BaseitemDefinition> {
 public:
     BaseitemList(BaseitemList &&) = delete;
     BaseitemList(const BaseitemList &) = delete;
@@ -25,19 +26,6 @@ public:
     static BaseitemList &get_instance();
     BaseitemDefinition &get_baseitem(const short bi_id);
     const BaseitemDefinition &get_baseitem(const short bi_id) const;
-
-    std::vector<BaseitemDefinition>::iterator begin();
-    std::vector<BaseitemDefinition>::const_iterator begin() const;
-    std::vector<BaseitemDefinition>::iterator end();
-    std::vector<BaseitemDefinition>::const_iterator end() const;
-    std::vector<BaseitemDefinition>::reverse_iterator rbegin();
-    std::vector<BaseitemDefinition>::const_reverse_iterator rbegin() const;
-    std::vector<BaseitemDefinition>::reverse_iterator rend();
-    std::vector<BaseitemDefinition>::const_reverse_iterator rend() const;
-    size_t size() const;
-    bool empty() const;
-    void resize(size_t new_size);
-    void shrink_to_fit();
 
     short lookup_baseitem_id(const BaseitemKey &bi_key) const;
     const BaseitemDefinition &lookup_baseitem(const BaseitemKey &bi_key) const;
@@ -52,6 +40,11 @@ private:
 
     static BaseitemList instance;
     std::vector<BaseitemDefinition> baseitems{};
+
+    std::vector<BaseitemDefinition> &get_inner_container() override
+    {
+        return this->baseitems;
+    }
 
     short exe_lookup(const BaseitemKey &bi_key) const;
     const std::map<BaseitemKey, short> &create_baseitem_keys_cache() const;

--- a/src/system/monrace/monrace-allocation.cpp
+++ b/src/system/monrace/monrace-allocation.cpp
@@ -67,11 +67,6 @@ MonraceAllocationTable &MonraceAllocationTable::get_instance()
     return instance;
 }
 
-size_t MonraceAllocationTable::size() const
-{
-    return this->entries.size();
-}
-
 void MonraceAllocationTable::initialize()
 {
     auto &monraces = MonraceList::get_instance();
@@ -81,26 +76,6 @@ void MonraceAllocationTable::initialize()
         const auto prob = static_cast<short>(100 / r_ptr->rarity);
         this->entries.emplace_back(monrace_id, r_ptr->level, prob, prob);
     }
-}
-
-std::vector<MonraceAllocationEntry>::iterator MonraceAllocationTable::begin()
-{
-    return this->entries.begin();
-}
-
-std::vector<MonraceAllocationEntry>::const_iterator MonraceAllocationTable::begin() const
-{
-    return this->entries.begin();
-}
-
-std::vector<MonraceAllocationEntry>::iterator MonraceAllocationTable::end()
-{
-    return this->entries.end();
-}
-
-std::vector<MonraceAllocationEntry>::const_iterator MonraceAllocationTable::end() const
-{
-    return this->entries.end();
 }
 
 const MonraceAllocationEntry &MonraceAllocationTable::get_entry(int index) const

--- a/src/system/monrace/monrace-allocation.h
+++ b/src/system/monrace/monrace-allocation.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "util/abstract-vector-wrapper.h"
 #include <vector>
 
 enum class MonraceId : short;
@@ -25,7 +26,7 @@ private:
     const MonraceDefinition &get_monrace() const;
 };
 
-class MonraceAllocationTable {
+class MonraceAllocationTable : public util::AbstractVectorWrapper<MonraceAllocationEntry> {
 public:
     MonraceAllocationTable(const MonraceAllocationTable &) = delete;
     MonraceAllocationTable(MonraceAllocationTable &&) = delete;
@@ -34,11 +35,6 @@ public:
     static MonraceAllocationTable &get_instance();
 
     void initialize();
-    std::vector<MonraceAllocationEntry>::iterator begin();
-    std::vector<MonraceAllocationEntry>::const_iterator begin() const;
-    std::vector<MonraceAllocationEntry>::iterator end();
-    std::vector<MonraceAllocationEntry>::const_iterator end() const;
-    size_t size() const;
     const MonraceAllocationEntry &get_entry(int index) const;
     MonraceAllocationEntry &get_entry(int index);
 
@@ -46,4 +42,9 @@ private:
     static MonraceAllocationTable instance;
     MonraceAllocationTable() = default;
     std::vector<MonraceAllocationEntry> entries{};
+
+    std::vector<MonraceAllocationEntry> &get_inner_container() override
+    {
+        return this->entries;
+    }
 };

--- a/src/system/terrain/terrain-list.cpp
+++ b/src/system/terrain/terrain-list.cpp
@@ -60,66 +60,6 @@ short TerrainList::get_terrain_id_by_tag(std::string_view tag) const
     return static_cast<short>(std::distance(this->terrains.begin(), it));
 }
 
-std::vector<TerrainType>::iterator TerrainList::begin()
-{
-    return this->terrains.begin();
-}
-
-std::vector<TerrainType>::const_iterator TerrainList::begin() const
-{
-    return this->terrains.cbegin();
-}
-
-std::vector<TerrainType>::reverse_iterator TerrainList::rbegin()
-{
-    return this->terrains.rbegin();
-}
-
-std::vector<TerrainType>::const_reverse_iterator TerrainList::rbegin() const
-{
-    return this->terrains.crbegin();
-}
-
-std::vector<TerrainType>::iterator TerrainList::end()
-{
-    return this->terrains.end();
-}
-
-std::vector<TerrainType>::const_iterator TerrainList::end() const
-{
-    return this->terrains.cend();
-}
-
-std::vector<TerrainType>::reverse_iterator TerrainList::rend()
-{
-    return this->terrains.rend();
-}
-
-std::vector<TerrainType>::const_reverse_iterator TerrainList::rend() const
-{
-    return this->terrains.crend();
-}
-
-size_t TerrainList::size() const
-{
-    return this->terrains.size();
-}
-
-bool TerrainList::empty() const
-{
-    return this->terrains.empty();
-}
-
-void TerrainList::resize(size_t new_size)
-{
-    this->terrains.resize(new_size);
-}
-
-void TerrainList::shrink_to_fit()
-{
-    this->terrains.shrink_to_fit();
-}
-
 /*!
  * @brief 地形情報の各種タグからIDへ変換して結果を収める
  */

--- a/src/system/terrain/terrain-list.h
+++ b/src/system/terrain/terrain-list.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "util/abstract-vector-wrapper.h"
 #include <map>
 #include <optional>
 #include <string_view>
@@ -13,7 +14,7 @@
 
 enum class TerrainTag;
 class TerrainType;
-class TerrainList {
+class TerrainList : public util::AbstractVectorWrapper<TerrainType> {
 public:
     TerrainList(const TerrainList &) = delete;
     TerrainList(TerrainList &&) = delete;
@@ -27,18 +28,6 @@ public:
     const TerrainType &get_terrain(TerrainTag tag) const;
     short get_terrain_id(TerrainTag tag) const;
     short get_terrain_id_by_tag(std::string_view tag) const;
-    std::vector<TerrainType>::iterator begin();
-    std::vector<TerrainType>::const_iterator begin() const;
-    std::vector<TerrainType>::reverse_iterator rbegin();
-    std::vector<TerrainType>::const_reverse_iterator rbegin() const;
-    std::vector<TerrainType>::iterator end();
-    std::vector<TerrainType>::const_iterator end() const;
-    std::vector<TerrainType>::reverse_iterator rend();
-    std::vector<TerrainType>::const_reverse_iterator rend() const;
-    size_t size() const;
-    bool empty() const;
-    void resize(size_t new_size);
-    void shrink_to_fit();
 
     void retouch();
     void emplace_tag(std::string_view tag);
@@ -49,6 +38,11 @@ private:
     static TerrainList instance;
     std::vector<TerrainType> terrains{};
     std::map<TerrainTag, short> tags; //!< @details 全てのTerrainTag を繰り込んだら、terrains からlookupが可能になる. そうなったら削除する.
+
+    std::vector<TerrainType> &get_inner_container() override
+    {
+        return this->terrains;
+    }
 
     std::optional<short> search_real_terrain(std::string_view tag) const;
 };

--- a/src/util/abstract-vector-wrapper.h
+++ b/src/util/abstract-vector-wrapper.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <vector>
+
+namespace util {
+
+/*!
+ * @brief std::vector をラップする抽象クラス
+ *
+ * @tparam T ラップする std::vector の要素の型
+ */
+template <typename T>
+class AbstractVectorWrapper {
+public:
+    using Container = std::vector<T>;
+    using Iterator = typename Container::iterator;
+    using ConstIterator = typename Container::const_iterator;
+    using ReverseIterator = typename Container::reverse_iterator;
+    using ConstReverseIterator = typename Container::const_reverse_iterator;
+
+    virtual ~AbstractVectorWrapper() = default;
+
+    Iterator begin() noexcept
+    {
+        return this->get_inner_container().begin();
+    }
+    ConstIterator begin() const noexcept
+    {
+        return this->get_inner_container().begin();
+    }
+    Iterator end() noexcept
+    {
+        return this->get_inner_container().end();
+    }
+    ConstIterator end() const noexcept
+    {
+        return this->get_inner_container().end();
+    }
+    ConstIterator cbegin() const noexcept
+    {
+        return this->get_inner_container().cbegin();
+    }
+    ConstIterator cend() const noexcept
+    {
+        return this->get_inner_container().cend();
+    }
+    ReverseIterator rbegin() noexcept
+    {
+        return this->get_inner_container().rbegin();
+    }
+    ConstReverseIterator rbegin() const noexcept
+    {
+        return this->get_inner_container().rbegin();
+    }
+    ReverseIterator rend() noexcept
+    {
+        return this->get_inner_container().rend();
+    }
+    ConstReverseIterator rend() const noexcept
+    {
+        return this->get_inner_container().rend();
+    }
+    ConstReverseIterator crbegin() const noexcept
+    {
+        return this->get_inner_container().crbegin();
+    }
+    ConstReverseIterator crend() const noexcept
+    {
+        return this->get_inner_container().crend();
+    }
+
+    bool empty() const noexcept
+    {
+        return this->get_inner_container().empty();
+    }
+    size_t size() const noexcept
+    {
+        return this->get_inner_container().size();
+    }
+    void resize(size_t new_size)
+    {
+        this->get_inner_container().resize(new_size);
+    }
+    void shrink_to_fit()
+    {
+        this->get_inner_container().shrink_to_fit();
+    }
+
+private:
+    virtual Container &get_inner_container() = 0;
+
+    const Container &get_inner_container() const
+    {
+        return static_cast<const Container &>(const_cast<AbstractVectorWrapper *>(this)->get_inner_container());
+    }
+};
+
+}


### PR DESCRIPTION
std::vectorをラップする抽象クラスAbstractVectorWrapperを導入し、std::vectorをラップしているクラスをAbstractVectorWrapperを継承する形に変更することで、内部のコンテナに移譲するだけのボイラープレートを削減する。

#4719 の作業の一環。まずは std::vector をラップするクラスについて抽象クラスを作成してみました。