### PR TITLE
[Fix] 新規キャラクター作成時にクラッシュ

### DIFF
--- a/src/system/dungeon/dungeon-record.cpp
+++ b/src/system/dungeon/dungeon-record.cpp
@@ -135,7 +135,7 @@ bool DungeonRecords::empty() const
 void DungeonRecords::reset_all()
 {
     for (auto &[_, record] : this->records) {
-        record.reset();
+        record->reset();
     }
 }
 


### PR DESCRIPTION
DungeonRecord::reset() を呼ぶつもりが std::shared_ptr::reset() を呼んでしまっており、その後のアクセスがヌルポアクセスとなりクラッシュしている。
正しく DungeonRecord::reset() を呼ぶように修正する。

直近のPR #4754 でのエンバグの修正なので単体Issueなし。