### PR TITLE
DungeonService クラスを作り、DungeonDefinition とDungeonRecord の両方に依存する処理を移設した

### DIFF
--- a/VisualStudio/Hengband/Hengband.vcxproj
+++ b/VisualStudio/Hengband/Hengband.vcxproj
@@ -294,6 +294,7 @@
     <ClCompile Include="..\..\src\cmd-action\cmd-tunnel.cpp" />
     <ClCompile Include="..\..\src\action\movement-execution.cpp" />
     <ClCompile Include="..\..\src\core\score-util.cpp" />
+    <ClCompile Include="..\..\src\system\services\dungeon-service.cpp" />
     <ClCompile Include="..\..\src\system\floor\floor-list.cpp" />
     <ClCompile Include="..\..\src\item-info\flavor-initializer.cpp" />
     <ClCompile Include="..\..\src\load\item\item-loader-base.cpp" />
@@ -1014,6 +1015,7 @@
     <ClInclude Include="..\..\src\action\run-execution.h" />
     <ClInclude Include="..\..\src\external-lib\include-json.h" />
     <ClInclude Include="..\..\src\external-lib\json.hpp" />
+    <ClInclude Include="..\..\src\system\services\dungeon-service.h" />
     <ClInclude Include="..\..\src\system\enums\dungeon\dungeon-id.h" />
     <ClInclude Include="..\..\src\system\floor\floor-list.h" />
     <ClInclude Include="..\..\src\item-info\flavor-initializer.h" />

--- a/VisualStudio/Hengband/Hengband.vcxproj.filters
+++ b/VisualStudio/Hengband/Hengband.vcxproj.filters
@@ -2547,6 +2547,9 @@
     <ClCompile Include="..\..\src\system\terrain\terrain-list.cpp">
       <Filter>system\terrain</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\system\services\dungeon-service.cpp">
+      <Filter>system\services</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5522,6 +5525,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\system\enums\dungeon\dungeon-id.h">
       <Filter>system\enums\dungeon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\services\dungeon-service.h">
+      <Filter>system\services</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -957,6 +957,7 @@ hengband_SOURCES = \
 	system/monrace/monrace-list.cpp system/monrace/monrace-list.h \
 	\
 	system/services/baseitem-monrace-service.cpp system/services/baseitem-monrace-service.h \
+	system/services/dungeon-service.cpp system/services/dungeon-service.h \
 	\
 	system/terrain/terrain-definition.cpp system/terrain/terrain-definition.h \
 	system/terrain/terrain-list.cpp system/terrain/terrain-list.h \

--- a/src/birth/birth-select-realm.cpp
+++ b/src/birth/birth-select-realm.cpp
@@ -29,7 +29,7 @@ struct birth_realm_type {
     int os = 0;
 };
 
-birth_realm_type ::birth_realm_type()
+birth_realm_type::birth_realm_type()
 {
     for (auto i = 0; i < TOTAL_REALM_NUM; i++) {
         this->sym[i] = '\0';

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -33,13 +33,12 @@
 #include "spell-realm/spells-song.h"
 #include "status/action-setter.h"
 #include "system/dungeon/dungeon-definition.h"
-#include "system/dungeon/dungeon-list.h"
-#include "system/dungeon/dungeon-record.h"
 #include "system/enums/dungeon/dungeon-id.h"
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
+#include "system/services/dungeon-service.h"
 #include "system/terrain/terrain-definition.h"
 #include "target/target-getter.h"
 #include "timed-effect/timed-effects.h"
@@ -267,10 +266,9 @@ void do_cmd_go_down(PlayerType *player_ptr)
             return;
         }
 
-        const auto &[dungeon_record, dungeon] = DungeonRecords::get_instance().get_dungeon_pair(dungeon_id);
-        if (!dungeon_record->has_entered()) {
-            const auto mes = dungeon->build_entrance_message();
-            msg_print(mes);
+        const auto mes_entrance = DungeonService::check_first_entrance(dungeon_id);
+        if (mes_entrance) {
+            msg_print(*mes_entrance);
             if (!input_check(_("本当にこのダンジョンに入りますか？", "Do you really get in this dungeon? "))) {
                 return;
             }

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -29,7 +29,6 @@
 #include "store/store.h"
 #include "system/angband-system.h"
 #include "system/building-type-definition.h"
-#include "system/dungeon/dungeon-record.h"
 #include "system/floor/floor-info.h"
 #include "system/floor/town-info.h"
 #include "system/floor/town-list.h"
@@ -39,6 +38,7 @@
 #include "system/monrace/monrace-list.h"
 #include "system/monster-entity.h"
 #include "system/player-type-definition.h"
+#include "system/services/dungeon-service.h"
 #include "term/gameterm.h"
 #include "term/z-form.h"
 #include "util/buffer-shaper.h"
@@ -178,8 +178,7 @@ static void dump_aux_last_message(PlayerType *player_ptr, FILE *fff)
 static void dump_aux_recall(FILE *fff)
 {
     fprintf(fff, _("\n  [帰還場所]\n\n", "\n  [Recall Depth]\n\n"));
-    const auto &dungeon_records = DungeonRecords::get_instance();
-    for (const auto &known_dungeon : dungeon_records.build_known_dungeons(DungeonMessageFormat::DUMP)) {
+    for (const auto &known_dungeon : DungeonService::build_known_dungeons(DungeonMessageFormat::DUMP)) {
         fprintf(fff, "%s", known_dungeon.data());
     }
 }

--- a/src/knowledge/knowledge-features.cpp
+++ b/src/knowledge/knowledge-features.cpp
@@ -11,9 +11,9 @@
 #include "io-dump/dump-util.h"
 #include "io/input-key-acceptor.h"
 #include "knowledge/lighting-level-table.h"
-#include "system/dungeon/dungeon-record.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/player-type-definition.h"
+#include "system/services/dungeon-service.h"
 #include "system/terrain/terrain-definition.h"
 #include "system/terrain/terrain-list.h"
 #include "term/gameterm.h"
@@ -362,7 +362,7 @@ void do_cmd_knowledge_dungeon(PlayerType *player_ptr)
         return;
     }
 
-    const auto known_dungeons = DungeonRecords::get_instance().build_known_dungeons(DungeonMessageFormat::KNOWLEDGE);
+    const auto known_dungeons = DungeonService::build_known_dungeons(DungeonMessageFormat::KNOWLEDGE);
     for (const auto &known_dungeon : known_dungeons) {
         fprintf(fff, "%s", known_dungeon.data());
     }

--- a/src/load/world-loader.cpp
+++ b/src/load/world-loader.cpp
@@ -18,7 +18,8 @@
 static void rd_hengband_dungeons()
 {
     const int dungeons_size = DungeonList::get_instance().size();
-    const auto &dungeon_records = DungeonRecords::get_instance();
+    const auto &dungeons = DungeonList::get_instance();
+    auto &records = DungeonRecords::get_instance();
     const int max = rd_byte();
     for (auto i = 0; i < max; i++) {
         int tmp16s = rd_s16b();
@@ -27,13 +28,14 @@ static void rd_hengband_dungeons()
         }
 
         const auto dungeon_id = i2enum<DungeonId>(i);
-        const auto &[dungeon_record, dungeon] = dungeon_records.get_dungeon_pair(dungeon_id);
+        const auto &dungeon = dungeons.get_dungeon(dungeon_id);
+        auto &record = records.get_record(dungeon_id);
         if (tmp16s > 0) {
-            dungeon_record->set_max_level(tmp16s);
+            record.set_max_level(tmp16s);
         }
 
-        if (dungeon_record->get_max_level() > dungeon->maxdepth) {
-            dungeon_record->set_max_level(dungeon->maxdepth);
+        if (record.get_max_level() > dungeon.maxdepth) {
+            record.set_max_level(dungeon.maxdepth);
         }
     }
 }

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -19,7 +19,6 @@
 #include "object/object-info.h"
 #include "perception/object-perception.h"
 #include "sv-definition/sv-other-types.h"
-#include "system/dungeon/dungeon-record.h"
 #include "system/enums/dungeon/dungeon-id.h"
 #include "system/enums/monrace/monrace-id.h"
 #include "system/floor/floor-info.h"
@@ -28,6 +27,7 @@
 #include "system/monrace/monrace-list.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
+#include "system/services/dungeon-service.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 #include "term/z-form.h"
@@ -275,8 +275,7 @@ void show_bounty(void)
  */
 void determine_daily_bounty(PlayerType *player_ptr)
 {
-    const auto &dungeon_records = DungeonRecords::get_instance();
-    const auto max_dungeon_level = std::max(dungeon_records.find_max_level(), 3);
+    const auto max_dungeon_level = std::max(DungeonService::find_max_level(), 3);
     get_mon_num_prep_bounty(player_ptr);
     auto &world = AngbandWorld::get_instance();
     while (true) {

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -95,9 +95,6 @@
 #include "status/base-status.h"
 #include "sv-definition/sv-lite-types.h"
 #include "sv-definition/sv-weapon-types.h"
-#include "system/dungeon/dungeon-definition.h"
-#include "system/dungeon/dungeon-list.h"
-#include "system/dungeon/dungeon-record.h"
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
@@ -105,6 +102,7 @@
 #include "system/monster-entity.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
+#include "system/services/dungeon-service.h"
 #include "system/terrain/terrain-definition.h"
 #include "term/screen-processor.h"
 #include "timed-effect/timed-effects.h"
@@ -3043,7 +3041,7 @@ long calc_score(PlayerType *player_ptr)
         mult = 5;
     }
 
-    const auto max_dungeon_level = DungeonRecords::get_instance().find_max_level();
+    const auto max_dungeon_level = DungeonService::find_max_level();
     uint32_t point_l = (player_ptr->max_max_exp + (100 * max_dungeon_level));
     uint32_t point_h = point_l / 0x10000L;
     point_l = point_l % 0x10000L;

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -35,6 +35,7 @@
 #include "system/monster-entity.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
+#include "system/services/dungeon-service.h"
 #include "target/projection-path-calculator.h"
 #include "target/target-checker.h"
 #include "target/target-setter.h"
@@ -379,7 +380,7 @@ static std::optional<DungeonId> choose_dungeon(std::string_view note, int row, i
     }
 
     screen_save();
-    const auto dungeon_messages = dungeon_records.build_known_dungeons(DungeonMessageFormat::RECALL);
+    const auto dungeon_messages = DungeonService::build_known_dungeons(DungeonMessageFormat::RECALL);
     const int num_messages = dungeon_messages.size();
     for (auto i = 0; i < num_messages; i++) {
         prt(dungeon_messages.at(i), row + i, col);

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -517,23 +517,24 @@ bool reset_recall(PlayerType *player_ptr)
     }
 
     constexpr auto prompt = _("何階にセットしますか？", "Reset to which level?");
-    const auto &[dungeon_record, dungeon] = DungeonRecords::get_instance().get_dungeon_pair(*select_dungeon);
-    const auto min_level = dungeon->mindepth;
-    const auto max_level = dungeon_record->get_max_level();
+    const auto &dungeon = DungeonList::get_instance().get_dungeon(*select_dungeon);
+    const auto min_level = dungeon.mindepth;
+    auto &dungeon_record = DungeonRecords::get_instance().get_record(*select_dungeon);
+    const auto max_level = dungeon_record.get_max_level();
     const auto reset_level = input_numerics(prompt, min_level, max_level, max_level);
     if (!reset_level) {
         return false;
     }
 
-    dungeon_record->set_max_level(*reset_level);
+    dungeon_record.set_max_level(*reset_level);
     if (record_maxdepth) {
         constexpr auto note = _("フロア・リセットで", "using a scroll of reset recall");
         exe_write_diary(*player_ptr->current_floor_ptr, DiaryKind::TRUMP, enum2i(*select_dungeon), note);
     }
 #ifdef JP
-    msg_format("%sの帰還レベルを %d 階にセット。", dungeon->name.data(), *reset_level);
+    msg_format("%sの帰還レベルを %d 階にセット。", dungeon.name.data(), *reset_level);
 #else
-    msg_format("Recall depth of %s set to level %d (%d').", dungeon->name.data(), *reset_level, *reset_level * 50);
+    msg_format("Recall depth of %s set to level %d (%d').", dungeon.name.data(), *reset_level, *reset_level * 50);
 #endif
     return true;
 }

--- a/src/system/building-type-definition.cpp
+++ b/src/system/building-type-definition.cpp
@@ -3,10 +3,10 @@
 #include "monster-race/monster-race-hook.h"
 #include "monster/monster-list.h"
 #include "monster/monster-util.h"
-#include "system/dungeon/dungeon-record.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
 #include "system/player-type-definition.h"
+#include "system/services/dungeon-service.h"
 #include <numeric>
 
 std::array<building_type, MAX_BUILDINGS> buildings;
@@ -98,7 +98,7 @@ std::vector<std::string> MeleeArena::build_gladiators_names() const
  */
 void MeleeArena::update_gladiators(PlayerType *player_ptr)
 {
-    const auto mon_level = DungeonRecords::get_instance().decide_gradiator_level();
+    const auto mon_level = DungeonService::decide_gradiator_level();
     while (true) {
         auto [total, is_applicable] = this->set_gladiators(player_ptr, mon_level);
         const auto &[count, new_total] = this->set_odds(total, is_applicable);

--- a/src/system/dungeon/dungeon-list.cpp
+++ b/src/system/dungeon/dungeon-list.cpp
@@ -24,7 +24,12 @@ const DungeonDefinition &DungeonList::get_dungeon(DungeonId dungeon_id) const
     return *this->dungeons.at(dungeon_id);
 }
 
-std::shared_ptr<DungeonDefinition> DungeonList::get_dungeon_shared(DungeonId dungeon_id) const
+std::shared_ptr<DungeonDefinition> DungeonList::get_dungeon_shared(DungeonId dungeon_id)
+{
+    return this->dungeons.at(dungeon_id);
+}
+
+std::shared_ptr<const DungeonDefinition> DungeonList::get_dungeon_shared(DungeonId dungeon_id) const
 {
     return this->dungeons.at(dungeon_id);
 }

--- a/src/system/dungeon/dungeon-list.h
+++ b/src/system/dungeon/dungeon-list.h
@@ -22,7 +22,8 @@ public:
     static DungeonList &get_instance();
     DungeonDefinition &get_dungeon(DungeonId dungeon_id);
     const DungeonDefinition &get_dungeon(DungeonId dungeon_id) const;
-    std::shared_ptr<DungeonDefinition> get_dungeon_shared(DungeonId dungeon_id) const;
+    std::shared_ptr<DungeonDefinition> get_dungeon_shared(DungeonId dungeon_id);
+    std::shared_ptr<const DungeonDefinition> get_dungeon_shared(DungeonId dungeon_id) const;
     std::map<DungeonId, std::shared_ptr<DungeonDefinition>>::iterator begin();
     std::map<DungeonId, std::shared_ptr<DungeonDefinition>>::const_iterator begin() const;
     std::map<DungeonId, std::shared_ptr<DungeonDefinition>>::iterator end();

--- a/src/system/dungeon/dungeon-record.cpp
+++ b/src/system/dungeon/dungeon-record.cpp
@@ -8,6 +8,7 @@
 #include "locale/language-switcher.h"
 #include "system/angband-exceptions.h"
 #include "system/enums/dungeon/dungeon-id.h"
+#include "term/z-form.h"
 #include "term/z-rand.h"
 #include "util/enum-converter.h"
 #include "util/enum-range.h"
@@ -29,11 +30,14 @@ int DungeonRecord::get_max_max_level() const
 
 void DungeonRecord::set_max_level(int level)
 {
-    if (!this->max_max_level || (level > this->max_max_level)) {
-        this->max_max_level = level;
+    if (level <= 0) {
+        THROW_EXCEPTION(std::logic_error, format("Invalid dungeon level: %d", level));
     }
 
     this->max_level = level;
+    if (!this->max_max_level || (level > this->max_max_level)) {
+        this->max_max_level = level;
+    }
 }
 
 void DungeonRecord::reset()
@@ -135,12 +139,12 @@ void DungeonRecords::reset_all()
 
 std::vector<DungeonId> DungeonRecords::collect_entered_dungeon_ids() const
 {
-    std::vector<DungeonId> entered_dungeons;
+    std::vector<DungeonId> ids;
     for (const auto &[dungeon_id, record] : this->records) {
         if (record->has_entered()) {
-            entered_dungeons.push_back(dungeon_id);
+            ids.push_back(dungeon_id);
         }
     }
 
-    return entered_dungeons;
+    return ids;
 }

--- a/src/system/dungeon/dungeon-record.cpp
+++ b/src/system/dungeon/dungeon-record.cpp
@@ -15,8 +15,6 @@
 #include "util/enum-range.h"
 
 namespace {
-constexpr EnumRange<DungeonId> DUNGEON_IDS(DungeonId::WILDERNESS, DungeonId::MAX);
-
 std::string get_dungeon_format(DungeonMessageFormat dmf)
 {
     switch (dmf) {
@@ -86,6 +84,16 @@ const DungeonRecord &DungeonRecords::get_record(DungeonId dungeon_id) const
     return *this->records.at(dungeon_id);
 }
 
+std::shared_ptr<DungeonRecord> DungeonRecords::get_record_shared(DungeonId dungeon_id)
+{
+    return this->records.at(dungeon_id);
+}
+
+std::shared_ptr<const DungeonRecord> DungeonRecords::get_record_shared(DungeonId dungeon_id) const
+{
+    return this->records.at(dungeon_id);
+}
+
 std::map<DungeonId, std::shared_ptr<DungeonRecord>>::iterator DungeonRecords::begin()
 {
     return this->records.begin();
@@ -141,41 +149,6 @@ void DungeonRecords::reset_all()
     for (auto &[_, record] : this->records) {
         record->reset();
     }
-}
-
-int DungeonRecords::find_max_level() const
-{
-    auto max_level = 0;
-    for (auto dungeon_id : DUNGEON_IDS) {
-        const auto &[record, dungeon] = this->get_dungeon_pair(dungeon_id);
-        const auto max_level_each = record->get_max_level();
-        if (max_level_each < dungeon->mindepth) {
-            continue;
-        }
-
-        if (max_level < max_level_each) {
-            max_level = max_level_each;
-        }
-    }
-
-    return max_level;
-}
-
-int DungeonRecords::decide_gradiator_level() const
-{
-    const auto max_dungeon_level = this->find_max_level();
-    auto gradiator_level = randint1(std::min(max_dungeon_level, 122)) + 5;
-    if (evaluate_percent(60)) {
-        const auto random_level = randint1(std::min(max_dungeon_level, 122)) + 5;
-        gradiator_level = std::max(random_level, gradiator_level);
-    }
-
-    if (evaluate_percent(30)) {
-        const auto random_level = randint1(std::min(max_dungeon_level, 122)) + 5;
-        gradiator_level = std::max(random_level, gradiator_level);
-    }
-
-    return gradiator_level;
 }
 
 std::vector<std::string> DungeonRecords::build_known_dungeons(DungeonMessageFormat dmf) const

--- a/src/system/dungeon/dungeon-record.cpp
+++ b/src/system/dungeon/dungeon-record.cpp
@@ -197,8 +197,3 @@ std::vector<DungeonId> DungeonRecords::collect_entered_dungeon_ids() const
 
     return entered_dungeons;
 }
-
-std::pair<std::shared_ptr<DungeonRecord>, std::shared_ptr<DungeonDefinition>> DungeonRecords::get_dungeon_pair(DungeonId dungeon_id) const
-{
-    return { this->records.at(dungeon_id), DungeonList::get_instance().get_dungeon_shared(dungeon_id) };
-}

--- a/src/system/dungeon/dungeon-record.cpp
+++ b/src/system/dungeon/dungeon-record.cpp
@@ -7,28 +7,10 @@
 #include "system/dungeon/dungeon-record.h"
 #include "locale/language-switcher.h"
 #include "system/angband-exceptions.h"
-#include "system/dungeon/dungeon-definition.h"
-#include "system/dungeon/dungeon-list.h"
 #include "system/enums/dungeon/dungeon-id.h"
 #include "term/z-rand.h"
 #include "util/enum-converter.h"
 #include "util/enum-range.h"
-
-namespace {
-std::string get_dungeon_format(DungeonMessageFormat dmf)
-{
-    switch (dmf) {
-    case DungeonMessageFormat::DUMP:
-        return _("   %c%-12s: %3d 階\n", "   %c%-16s: level %3d\n");
-    case DungeonMessageFormat::KNOWLEDGE:
-        return _("%c%-12s :  %3d 階\n", "%c%-16s :  level %3d\n");
-    case DungeonMessageFormat::RECALL:
-        return _("      %c) %c%-12s : 最大 %d 階", "      %c) %c%-16s : Max level %d");
-    default:
-        THROW_EXCEPTION(std::logic_error, format("Invalid dungeon message format is specified! %d", enum2i(dmf)));
-    }
-}
-}
 
 bool DungeonRecord::has_entered() const
 {
@@ -149,41 +131,6 @@ void DungeonRecords::reset_all()
     for (auto &[_, record] : this->records) {
         record->reset();
     }
-}
-
-std::vector<std::string> DungeonRecords::build_known_dungeons(DungeonMessageFormat dmf) const
-{
-    const auto fmt = get_dungeon_format(dmf);
-    const auto &dungeons = DungeonList::get_instance();
-    std::vector<std::string> recall_dungeons;
-    auto num_entered = 0;
-    for (const auto &[dungeon_id, record] : this->records) {
-        if (!record->has_entered()) {
-            continue;
-        }
-
-        const auto max_level = record->get_max_level();
-        const auto &dungeon = dungeons.get_dungeon(dungeon_id);
-        const auto is_dungeon_conquered = dungeon.is_conquered();
-        const auto is_conquered = is_dungeon_conquered || (max_level == dungeon.maxdepth);
-        std::string message;
-        switch (dmf) {
-        case DungeonMessageFormat::DUMP:
-        case DungeonMessageFormat::KNOWLEDGE:
-            message = format(fmt.data(), is_conquered ? '!' : ' ', dungeon.name.data(), max_level);
-            break;
-        case DungeonMessageFormat::RECALL:
-            message = format(fmt.data(), static_cast<char>('a' + num_entered), is_conquered ? '!' : ' ', dungeon.name.data(), max_level);
-            num_entered++;
-            break;
-        default:
-            THROW_EXCEPTION(std::logic_error, format("Invalid dungeon message format is specified! %d", enum2i(dmf)));
-        }
-
-        recall_dungeons.push_back(message);
-    }
-
-    return recall_dungeons;
 }
 
 std::vector<DungeonId> DungeonRecords::collect_entered_dungeon_ids() const

--- a/src/system/dungeon/dungeon-record.h
+++ b/src/system/dungeon/dungeon-record.h
@@ -10,7 +10,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <utility>
 #include <vector>
 
 enum class DungeonMessageFormat {
@@ -62,7 +61,6 @@ public:
 
     std::vector<std::string> build_known_dungeons(DungeonMessageFormat dmf) const;
     std::vector<DungeonId> collect_entered_dungeon_ids() const;
-    std::pair<std::shared_ptr<DungeonRecord>, std::shared_ptr<DungeonDefinition>> get_dungeon_pair(DungeonId dungeon_id) const;
 
 private:
     DungeonRecords();

--- a/src/system/dungeon/dungeon-record.h
+++ b/src/system/dungeon/dungeon-record.h
@@ -46,6 +46,8 @@ public:
     static DungeonRecords &get_instance();
     DungeonRecord &get_record(DungeonId dungeon_id);
     const DungeonRecord &get_record(DungeonId dungeon_id) const;
+    std::shared_ptr<DungeonRecord> get_record_shared(DungeonId dungeon_id);
+    std::shared_ptr<const DungeonRecord> get_record_shared(DungeonId dungeon_id) const;
     std::map<DungeonId, std::shared_ptr<DungeonRecord>>::iterator begin();
     std::map<DungeonId, std::shared_ptr<DungeonRecord>>::const_iterator begin() const;
     std::map<DungeonId, std::shared_ptr<DungeonRecord>>::iterator end();
@@ -58,8 +60,6 @@ public:
     bool empty() const;
     void reset_all();
 
-    int find_max_level() const;
-    int decide_gradiator_level() const;
     std::vector<std::string> build_known_dungeons(DungeonMessageFormat dmf) const;
     std::vector<DungeonId> collect_entered_dungeon_ids() const;
     std::pair<std::shared_ptr<DungeonRecord>, std::shared_ptr<DungeonDefinition>> get_dungeon_pair(DungeonId dungeon_id) const;

--- a/src/system/dungeon/dungeon-record.h
+++ b/src/system/dungeon/dungeon-record.h
@@ -12,12 +12,6 @@
 #include <string>
 #include <vector>
 
-enum class DungeonMessageFormat {
-    DUMP,
-    KNOWLEDGE,
-    RECALL,
-};
-
 class DungeonRecord {
 public:
     DungeonRecord() = default;
@@ -59,7 +53,6 @@ public:
     bool empty() const;
     void reset_all();
 
-    std::vector<std::string> build_known_dungeons(DungeonMessageFormat dmf) const;
     std::vector<DungeonId> collect_entered_dungeon_ids() const;
 
 private:

--- a/src/system/enums/dungeon/dungeon-id.h
+++ b/src/system/enums/dungeon/dungeon-id.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include "util/enum-range.h"
+
 enum class DungeonId {
     WILDERNESS = 0,
     ANGBAND = 1,
@@ -30,3 +32,5 @@ enum class DungeonId {
     GLASS = 20,
     MAX,
 };
+
+constexpr EnumRange<DungeonId> DUNGEON_IDS(DungeonId::WILDERNESS, DungeonId::MAX);

--- a/src/system/services/dungeon-service.cpp
+++ b/src/system/services/dungeon-service.cpp
@@ -48,3 +48,13 @@ int DungeonService::find_max_level()
 
     return max_level;
 }
+
+std::optional<std::string> DungeonService::check_first_entrance(DungeonId dungeon_id)
+{
+    const auto &record = DungeonRecords::get_instance().get_record(dungeon_id);
+    if (!record.has_entered()) {
+        return std::nullopt;
+    }
+
+    return DungeonList::get_instance().get_dungeon(dungeon_id).build_entrance_message();
+}

--- a/src/system/services/dungeon-service.cpp
+++ b/src/system/services/dungeon-service.cpp
@@ -1,0 +1,50 @@
+/*!
+ * @brief ダンジョンの定義と記録に関するサービス処理実装
+ * @author Hourier
+ * @date 2024/12/28
+ */
+
+#include "system/services/dungeon-service.h"
+#include "system/dungeon/dungeon-definition.h"
+#include "system/dungeon/dungeon-list.h"
+#include "system/dungeon/dungeon-record.h"
+#include "system/enums/dungeon/dungeon-id.h"
+#include "term/z-rand.h"
+
+int DungeonService::decide_gradiator_level()
+{
+    const auto max_dungeon_level = find_max_level();
+    auto gradiator_level = randint1(std::min(max_dungeon_level, 122)) + 5;
+    if (evaluate_percent(60)) {
+        const auto random_level = randint1(std::min(max_dungeon_level, 122)) + 5;
+        gradiator_level = std::max(random_level, gradiator_level);
+    }
+
+    if (evaluate_percent(30)) {
+        const auto random_level = randint1(std::min(max_dungeon_level, 122)) + 5;
+        gradiator_level = std::max(random_level, gradiator_level);
+    }
+
+    return gradiator_level;
+}
+
+int DungeonService::find_max_level()
+{
+    const auto &records = DungeonRecords::get_instance();
+    const auto &dungeons = DungeonList::get_instance();
+    auto max_level = 0;
+    for (auto dungeon_id : DUNGEON_IDS) {
+        const auto &record = records.get_record(dungeon_id);
+        const auto &dungeon = dungeons.get_dungeon(dungeon_id);
+        const auto max_level_each = record.get_max_level();
+        if (max_level_each < dungeon.mindepth) {
+            continue;
+        }
+
+        if (max_level < max_level_each) {
+            max_level = max_level_each;
+        }
+    }
+
+    return max_level;
+}

--- a/src/system/services/dungeon-service.cpp
+++ b/src/system/services/dungeon-service.cpp
@@ -5,11 +5,29 @@
  */
 
 #include "system/services/dungeon-service.h"
+#include "system/angband-exceptions.h"
 #include "system/dungeon/dungeon-definition.h"
 #include "system/dungeon/dungeon-list.h"
 #include "system/dungeon/dungeon-record.h"
 #include "system/enums/dungeon/dungeon-id.h"
 #include "term/z-rand.h"
+#include "util/enum-converter.h"
+
+namespace {
+std::string get_dungeon_format(DungeonMessageFormat dmf)
+{
+    switch (dmf) {
+    case DungeonMessageFormat::DUMP:
+        return _("   %c%-12s: %3d 階\n", "   %c%-16s: level %3d\n");
+    case DungeonMessageFormat::KNOWLEDGE:
+        return _("%c%-12s :  %3d 階\n", "%c%-16s :  level %3d\n");
+    case DungeonMessageFormat::RECALL:
+        return _("      %c) %c%-12s : 最大 %d 階", "      %c) %c%-16s : Max level %d");
+    default:
+        THROW_EXCEPTION(std::logic_error, format("Invalid dungeon message format is specified! %d", enum2i(dmf)));
+    }
+}
+}
 
 int DungeonService::decide_gradiator_level()
 {
@@ -57,4 +75,39 @@ std::optional<std::string> DungeonService::check_first_entrance(DungeonId dungeo
     }
 
     return DungeonList::get_instance().get_dungeon(dungeon_id).build_entrance_message();
+}
+
+std::vector<std::string> DungeonService::build_known_dungeons(DungeonMessageFormat dmf)
+{
+    const auto fmt = get_dungeon_format(dmf);
+    const auto &dungeons = DungeonList::get_instance();
+    std::vector<std::string> known_dungeons;
+    auto num_entered = 0;
+    for (const auto &[dungeon_id, record] : DungeonRecords::get_instance()) {
+        if (!record->has_entered()) {
+            continue;
+        }
+
+        const auto max_level = record->get_max_level();
+        const auto &dungeon = dungeons.get_dungeon(dungeon_id);
+        const auto is_dungeon_conquered = dungeon.is_conquered();
+        const auto is_conquered = is_dungeon_conquered || (max_level == dungeon.maxdepth);
+        std::string known_dungeon;
+        switch (dmf) {
+        case DungeonMessageFormat::DUMP:
+        case DungeonMessageFormat::KNOWLEDGE:
+            known_dungeon = format(fmt.data(), is_conquered ? '!' : ' ', dungeon.name.data(), max_level);
+            break;
+        case DungeonMessageFormat::RECALL:
+            known_dungeon = format(fmt.data(), static_cast<char>('a' + num_entered), is_conquered ? '!' : ' ', dungeon.name.data(), max_level);
+            num_entered++;
+            break;
+        default:
+            THROW_EXCEPTION(std::logic_error, format("Invalid dungeon message format is specified! %d", enum2i(dmf)));
+        }
+
+        known_dungeons.push_back(known_dungeon);
+    }
+
+    return known_dungeons;
 }

--- a/src/system/services/dungeon-service.h
+++ b/src/system/services/dungeon-service.h
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <memory>
+#include <optional>
+#include <string>
 
 enum class DungeonId;
 class DungeonDefinition;
@@ -17,4 +19,5 @@ public:
     DungeonService() = delete;
     static int decide_gradiator_level();
     static int find_max_level();
+    static std::optional<std::string> check_first_entrance(DungeonId dungeon_id);
 };

--- a/src/system/services/dungeon-service.h
+++ b/src/system/services/dungeon-service.h
@@ -1,0 +1,20 @@
+/*!
+ * @brief ダンジョンの定義と記録に関するサービス処理定義
+ * @author Hourier
+ * @date 2024/12/28
+ * @details サービスクラスはステートレスであるべきなのでメソッドは全てstatic である
+ */
+
+#pragma once
+
+#include <memory>
+
+enum class DungeonId;
+class DungeonDefinition;
+class DungeonRecord;
+class DungeonService {
+public:
+    DungeonService() = delete;
+    static int decide_gradiator_level();
+    static int find_max_level();
+};

--- a/src/system/services/dungeon-service.h
+++ b/src/system/services/dungeon-service.h
@@ -10,6 +10,13 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
+
+enum class DungeonMessageFormat {
+    DUMP,
+    KNOWLEDGE,
+    RECALL,
+};
 
 enum class DungeonId;
 class DungeonDefinition;
@@ -20,4 +27,5 @@ public:
     static int decide_gradiator_level();
     static int find_max_level();
     static std::optional<std::string> check_first_entrance(DungeonId dungeon_id);
+    static std::vector<std::string> build_known_dungeons(DungeonMessageFormat dmf);
 };


### PR DESCRIPTION
shared\_ptr を直接取得するメソッドが残っていますが、これは後でFloorType::dungeon\_id をshared\_ptr に差し替える計画です (その他将来の拡張)
ご確認下さい