### PR TITLE
[Fix] クエスト内部のトラップドア用の処理の追加

### DIFF
--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -300,13 +300,17 @@ void do_cmd_go_down(PlayerType *player_ptr)
         down_num = dungeon.mindepth;
     }
 
-    if (record_stair) {
+    if (record_stair && !floor.is_in_quest()) {
         const auto note = is_fall_trap ? _("落とし戸に落ちた", "fell through a trap door") : _("階段を下りた", "climbed down the stairs to");
         exe_write_diary(floor, DiaryKind::STAIR, down_num, note);
     }
 
     if (is_fall_trap) {
         msg_print(_("わざと落とし戸に落ちた。", "You deliberately jump through the trap door."));
+        if (floor.is_in_quest()) {
+            msg_print(_("しかし何も起こらなかった。", "But, nothing happens."));
+            return;
+        }
     } else {
         if (dungeon_id > DungeonId::WILDERNESS) {
             msg_format(_("%sへ入った。", "You entered %s."), dungeon.text.data());

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -419,6 +419,10 @@ void hit_trap(PlayerType *player_ptr, bool break_trap)
 
             take_hit(player_ptr, DAMAGE_NOESCAPE, dam, name);
 
+            if (floor.is_in_quest()) {
+                return;
+            }
+
             /* Still alive and autosave enabled */
             if (autosave_l && (player_ptr->chp >= 0)) {
                 do_cmd_save_game(player_ptr, true);


### PR DESCRIPTION
現在、クエスト内部でトラップドアを動作させた場合クエストフロアの再生成が行われる。
「罠にかかった場合ダメージのみ受ける」「自発的に降りる場合何も起きない」ように変更する。