### PR TITLE
DungeonData のコンストラクタを改善し、外から初期化する項目を減らした

### DIFF
--- a/src/floor/cave-generator.cpp
+++ b/src/floor/cave-generator.cpp
@@ -403,16 +403,7 @@ std::optional<std::string> cave_gen(PlayerType *player_ptr)
     set_floor_and_wall(floor.dungeon_id);
     get_mon_num_prep(player_ptr, get_monster_hook(player_ptr), nullptr);
 
-    DungeonData dd;
-    dd.row_rooms = floor.height / BLOCK_HGT;
-    dd.col_rooms = floor.width / BLOCK_WID;
-    for (POSITION y = 0; y < dd.row_rooms; y++) {
-        for (POSITION x = 0; x < dd.col_rooms; x++) {
-            dd.room_map[y][x] = false;
-        }
-    }
-
-    dd.cent_n = 0;
+    DungeonData dd({ floor.height, floor.width });
     auto &dungeon = floor.get_dungeon_definition();
     constexpr auto chance_empty_floor = 24;
     if (ironman_empty_levels || (dungeon.flags.has(DungeonFeatureType::ARENA) && (empty_levels && one_in_(chance_empty_floor)))) {

--- a/src/system/dungeon/dungeon-data-definition.cpp
+++ b/src/system/dungeon/dungeon-data-definition.cpp
@@ -1,8 +1,10 @@
 #include "system/dungeon/dungeon-data-definition.h"
 #include "floor/floor-base-definitions.h"
 
-DungeonData::DungeonData()
-    : tunnel_pos(0, 0)
+DungeonData::DungeonData(const Pos2DVec &dungeon_size)
+    : row_rooms(dungeon_size.y / BLOCK_HGT)
+    , col_rooms(dungeon_size.x / BLOCK_WID)
+    , tunnel_pos(0, 0)
 {
     constexpr auto max_centers = 100;
     for (auto i = 0; i < max_centers; i++) {

--- a/src/system/dungeon/dungeon-data-definition.h
+++ b/src/system/dungeon/dungeon-data-definition.h
@@ -10,7 +10,7 @@
  */
 class DungeonData {
 public:
-    DungeonData();
+    DungeonData(const Pos2DVec &dungeon_size);
 
     size_t cent_n = 0;
     std::vector<Pos2D> centers;
@@ -25,8 +25,8 @@ public:
     std::vector<Pos2D> tunnels;
 
     /* Number of blocks along each axis */
-    int row_rooms = 0;
-    int col_rooms = 0;
+    int row_rooms;
+    int col_rooms;
 
     /* Array of which blocks are used */
     std::vector<std::vector<bool>> room_map;


### PR DESCRIPTION
他作業でちょっと気になったので修正です
小規模なのでチケットはありません
ご確認下さい
- vector\<bool\> の中身は元からfalse で初期化されるので削除
- cent\_n も0初期化されているので削除
- 部屋数はコンストラクタ引数に変更