### PR TITLE
カメレオンの変身先選択ルーチンをdo_get_mon_num_prep() から分離した

### DIFF
--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -284,7 +284,7 @@ std::optional<MONSTER_IDX> place_monster_one(PlayerType *player_ptr, POSITION y,
     monster.mflag2.clear();
     if (monrace.misc_flags.has(MonsterMiscType::CHAMELEON)) {
         monster.r_idx = r_idx;
-        choose_chameleon_polymorph(player_ptr, grid.m_idx, grid, summoner_m_idx);
+        choose_chameleon_polymorph(player_ptr, grid.m_idx, grid.get_terrain_id(), summoner_m_idx);
         monster.mflag2.set(MonsterConstantFlagType::CHAMELEON);
     } else {
         monster.r_idx = r_idx;

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -52,7 +52,7 @@
  * @return 選択されたモンスター生成種族
  * @details nasty生成 (ゲーム内経過日数に応じて、現在フロアより深いフロアのモンスターを出現させる仕様)は
  */
-MonraceId get_mon_num(PlayerType *player_ptr, DEPTH min_level, DEPTH max_level, BIT_FLAGS mode)
+MonraceId get_mon_num(PlayerType *player_ptr, int min_level, int max_level, uint32_t mode)
 {
     /* town max_level : same delay as 10F, no nasty mons till day18 */
     auto delay = static_cast<int>(std::sqrt(max_level * 10000)) + (max_level * 5);
@@ -165,12 +165,12 @@ MonraceId get_mon_num(PlayerType *player_ptr, DEPTH min_level, DEPTH max_level, 
     return table.get_entry(*it).index;
 }
 
-static std::optional<MonraceId> polymorph_of_chameleon(PlayerType *player_ptr, MONSTER_IDX m_idx, const Grid &grid, const std::optional<MONSTER_IDX> summoner_m_idx)
+static std::optional<MonraceId> polymorph_of_chameleon(PlayerType *player_ptr, short m_idx, short terrain_id, const std::optional<short> summoner_m_idx)
 {
     auto &floor = *player_ptr->current_floor_ptr;
     auto &monster = floor.m_list[m_idx];
     const auto old_unique = monster.get_monrace().kind_flags.has(MonsterKindType::UNIQUE);
-    get_mon_num_prep_chameleon(player_ptr, m_idx, grid, summoner_m_idx, old_unique);
+    get_mon_num_prep_chameleon(player_ptr, m_idx, terrain_id, summoner_m_idx, old_unique);
 
     int level;
     if (old_unique) {
@@ -200,12 +200,11 @@ static std::optional<MonraceId> polymorph_of_chameleon(PlayerType *player_ptr, M
  * @param grid カメレオンの足元の地形
  * @param summoner_m_idx モンスターの召喚による場合、召喚者のモンスターID
  */
-void choose_chameleon_polymorph(PlayerType *player_ptr, MONSTER_IDX m_idx, const Grid &grid, std::optional<MONSTER_IDX> summoner_m_idx)
+void choose_chameleon_polymorph(PlayerType *player_ptr, short m_idx, short terrain_id, std::optional<short> summoner_m_idx)
 {
     auto &floor = *player_ptr->current_floor_ptr;
     auto &monster = floor.m_list[m_idx];
-
-    auto new_monrace_id = polymorph_of_chameleon(player_ptr, m_idx, grid, summoner_m_idx);
+    auto new_monrace_id = polymorph_of_chameleon(player_ptr, m_idx, terrain_id, summoner_m_idx);
     if (!new_monrace_id) {
         return;
     }
@@ -221,7 +220,7 @@ void choose_chameleon_polymorph(PlayerType *player_ptr, MONSTER_IDX m_idx, const
  * @param m_idx 隣接数を調べたいモンスターのID
  * @return 隣接しているモンスターの数
  */
-int get_monster_crowd_number(const FloorType *floor_ptr, MONSTER_IDX m_idx)
+int get_monster_crowd_number(const FloorType *floor_ptr, short m_idx)
 {
     auto *m_ptr = &floor_ptr->m_list[m_idx];
     POSITION my = m_ptr->fy;

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -170,7 +170,8 @@ static std::optional<MonraceId> polymorph_of_chameleon(PlayerType *player_ptr, s
     auto &floor = *player_ptr->current_floor_ptr;
     auto &monster = floor.m_list[m_idx];
     const auto old_unique = monster.get_monrace().kind_flags.has(MonsterKindType::UNIQUE);
-    get_mon_num_prep_chameleon(player_ptr, m_idx, terrain_id, summoner_m_idx, old_unique);
+    ChameleonTransformation ct(m_idx, terrain_id, old_unique, std::move(summoner_m_idx));
+    get_mon_num_prep_chameleon(player_ptr, ct);
 
     int level;
     if (old_unique) {

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -21,9 +21,7 @@
 #include "grid/grid.h"
 #include "monster-floor/monster-summon.h"
 #include "monster-floor/place-monster-types.h"
-#include "monster-race/monster-kind-mask.h"
 #include "monster/monster-describer.h"
-#include "monster/monster-info.h"
 #include "monster/monster-update.h"
 #include "monster/monster-util.h"
 #include "pet/pet-fall-off.h"
@@ -167,115 +165,12 @@ MonraceId get_mon_num(PlayerType *player_ptr, DEPTH min_level, DEPTH max_level, 
     return table.get_entry(*it).index;
 }
 
-/*!
- * @brief カメレオンの王の変身対象となるモンスターかどうか判定する
- * @param player_ptr プレイヤーへの参照ポインタ
- * @param r_idx モンスター種族ID
- * @param m_idx 変身するモンスターのモンスターID
- * @param grid カメレオンの足元の地形
- * @param summoner_m_idx モンスターの召喚による場合、召喚者のモンスターID
- * @return 対象にできるならtrueを返す
- */
-static bool monster_hook_chameleon_lord(PlayerType *player_ptr, MonraceId r_idx, MONSTER_IDX m_idx, const Grid &grid, std::optional<MONSTER_IDX> summoner_m_idx)
-{
-    const auto &monraces = MonraceList::get_instance();
-    const auto &monrace = monraces.get_monrace(r_idx);
-    if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE)) {
-        return false;
-    }
-
-    if (monrace.behavior_flags.has(MonsterBehaviorType::FRIENDLY) || monrace.misc_flags.has(MonsterMiscType::CHAMELEON)) {
-        return false;
-    }
-
-    if (std::abs(monrace.level - monraces.get_monrace(MonraceId::CHAMELEON_K).level) > 5) {
-        return false;
-    }
-
-    if (monrace.is_explodable()) {
-        return false;
-    }
-
-    if (!monster_can_cross_terrain(player_ptr, grid.feat, &monrace, 0)) {
-        return false;
-    }
-
-    const auto &floor = *player_ptr->current_floor_ptr;
-    const auto &monster = floor.m_list[m_idx];
-    const auto &old_monrace = monster.get_monrace();
-    if (old_monrace.misc_flags.has_not(MonsterMiscType::CHAMELEON)) {
-        return !monster_has_hostile_align(player_ptr, &monster, 0, 0, &monrace);
-    }
-
-    return !summoner_m_idx || !monster_has_hostile_align(player_ptr, &floor.m_list[*summoner_m_idx], 0, 0, &monrace);
-}
-
-/*!
- * @brief カメレオンの変身対象となるモンスターかどうか判定する
- * @param player_ptr プレイヤーへの参照ポインタ
- * @param r_idx モンスター種族ID
- * @param m_idx 変身するモンスターのモンスターID
- * @param grid カメレオンの足元の地形
- * @param summoner_m_idx モンスターの召喚による場合、召喚者のモンスターID
- * @return 対象にできるならtrueを返す
- * @todo グローバル変数対策の上 monster_hook.cへ移す。
- */
-static bool monster_hook_chameleon(PlayerType *player_ptr, MonraceId r_idx, MONSTER_IDX m_idx, const Grid &grid, std::optional<MONSTER_IDX> summoner_m_idx)
-{
-    const auto &monrace = MonraceList::get_instance().get_monrace(r_idx);
-    if (monrace.kind_flags.has(MonsterKindType::UNIQUE)) {
-        return false;
-    }
-
-    if (monrace.misc_flags.has(MonsterMiscType::MULTIPLY)) {
-        return false;
-    }
-
-    if (monrace.behavior_flags.has(MonsterBehaviorType::FRIENDLY) || (monrace.misc_flags.has(MonsterMiscType::CHAMELEON))) {
-        return false;
-    }
-
-    if (monrace.is_explodable()) {
-        return false;
-    }
-
-    if (!monster_can_cross_terrain(player_ptr, grid.feat, &monrace, 0)) {
-        return false;
-    }
-
-    const auto &floor = *player_ptr->current_floor_ptr;
-    const auto &monster = floor.m_list[m_idx];
-    const auto &old_monrace = monster.get_monrace();
-    if (old_monrace.misc_flags.has_not(MonsterMiscType::CHAMELEON)) {
-        if (old_monrace.kind_flags.has(MonsterKindType::GOOD) && monrace.kind_flags.has_not(MonsterKindType::GOOD)) {
-            return false;
-        }
-
-        if (old_monrace.kind_flags.has(MonsterKindType::EVIL) && monrace.kind_flags.has_not(MonsterKindType::EVIL)) {
-            return false;
-        }
-
-        if (old_monrace.kind_flags.has_none_of(alignment_mask)) {
-            return false;
-        }
-    } else if (summoner_m_idx && monster_has_hostile_align(player_ptr, &floor.m_list[*summoner_m_idx], 0, 0, &monrace)) {
-        return false;
-    }
-
-    auto hook_pf = get_monster_hook(player_ptr);
-    return hook_pf(player_ptr, r_idx);
-}
-
 static std::optional<MonraceId> polymorph_of_chameleon(PlayerType *player_ptr, MONSTER_IDX m_idx, const Grid &grid, const std::optional<MONSTER_IDX> summoner_m_idx)
 {
     auto &floor = *player_ptr->current_floor_ptr;
     auto &monster = floor.m_list[m_idx];
     const auto old_unique = monster.get_monrace().kind_flags.has(MonsterKindType::UNIQUE);
-    auto hook_fp = old_unique ? monster_hook_chameleon_lord : monster_hook_chameleon;
-    auto hook = [m_idx, grid, summoner_m_idx, hook_fp](PlayerType *player_ptr, MonraceId r_idx) {
-        return hook_fp(player_ptr, r_idx, m_idx, grid, summoner_m_idx);
-    };
-    get_mon_num_prep_chameleon(player_ptr, std::move(hook));
+    get_mon_num_prep_chameleon(player_ptr, m_idx, grid, summoner_m_idx, old_unique);
 
     int level;
     if (old_unique) {

--- a/src/monster/monster-list.h
+++ b/src/monster/monster-list.h
@@ -1,13 +1,12 @@
 #pragma once
 
-#include "system/angband.h"
+#include <cstdint>
 #include <optional>
 
 enum class MonraceId : short;
 class FloorType;
 class MonraceDefinition;
 class PlayerType;
-class Grid;
-MonraceId get_mon_num(PlayerType *player_ptr, DEPTH min_level, DEPTH max_level, BIT_FLAGS mode);
-void choose_chameleon_polymorph(PlayerType *player_ptr, MONSTER_IDX m_idx, const Grid &grid, std::optional<MONSTER_IDX> summoner_m_idx = std::nullopt);
-int get_monster_crowd_number(const FloorType *floor_ptr, MONSTER_IDX m_idx);
+MonraceId get_mon_num(PlayerType *player_ptr, int min_level, int max_level, uint32_t mode);
+void choose_chameleon_polymorph(PlayerType *player_ptr, short m_idx, short terrain_id, std::optional<short> summoner_m_idx = std::nullopt);
+int get_monster_crowd_number(const FloorType *floor_ptr, short m_idx);

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -124,16 +124,13 @@ void process_monster(PlayerType *player_ptr, MONSTER_IDX m_idx)
     decide_drop_from_monster(player_ptr, m_idx, turn_flags_ptr->is_riding_mon);
     if (m_ptr->mflag2.has(MonsterConstantFlagType::CHAMELEON) && one_in_(13) && !m_ptr->is_asleep()) {
         const auto &floor = *player_ptr->current_floor_ptr;
-
         const auto old_m_name = monster_desc(player_ptr, m_ptr, 0);
-
         const auto &monrace = m_ptr->get_monrace();
-
-        choose_chameleon_polymorph(player_ptr, m_idx, floor.get_grid(Pos2D(m_ptr->fy, m_ptr->fx)));
-
+        const auto m_pos = m_ptr->get_position();
+        const auto &grid = floor.get_grid(m_pos);
+        choose_chameleon_polymorph(player_ptr, m_idx, grid.get_terrain_id());
         update_monster(player_ptr, m_idx, false);
-        lite_spot(player_ptr, m_ptr->fy, m_ptr->fx);
-
+        lite_spot(player_ptr, m_pos.y, m_pos.x);
         const auto &new_monrace = m_ptr->get_monrace();
 
         if (new_monrace.brightness_flags.has_any_of(ld_mask) || monrace.brightness_flags.has_any_of(ld_mask)) {

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -194,6 +194,37 @@ monsterrace_hook_type get_monster_hook(PlayerType *player_ptr)
     }
 }
 
+static MonraceHook get_monster_hook(const Pos2D &pos_wilderness, bool is_underground)
+{
+    if (is_underground) {
+        return MonraceHook::DUNGEON;
+    }
+
+    switch (wilderness[pos_wilderness.y][pos_wilderness.x].terrain) {
+    case TERRAIN_TOWN:
+        return MonraceHook::TOWN;
+    case TERRAIN_DEEP_WATER:
+        return MonraceHook::OCEAN;
+    case TERRAIN_SHALLOW_WATER:
+    case TERRAIN_SWAMP:
+        return MonraceHook::SHORE;
+    case TERRAIN_DIRT:
+    case TERRAIN_DESERT:
+        return MonraceHook::WASTE;
+    case TERRAIN_GRASS:
+        return MonraceHook::GRASS;
+    case TERRAIN_TREES:
+        return MonraceHook::WOOD;
+    case TERRAIN_SHALLOW_LAVA:
+    case TERRAIN_DEEP_LAVA:
+        return MonraceHook::VOLCANO;
+    case TERRAIN_MOUNTAIN:
+        return MonraceHook::MOUNTAIN;
+    default:
+        return MonraceHook::DUNGEON;
+    }
+}
+
 /*!
  * @brief 指定された広域マップ座標の地勢を元にモンスターの生成条件関数を返す
  * @return 地勢にあったモンスターの生成条件関数
@@ -446,8 +477,31 @@ static bool monster_hook_chameleon(PlayerType *player_ptr, MonraceId r_idx, shor
         return false;
     }
 
-    const auto hook_pf = get_monster_hook(player_ptr);
-    return hook_pf(player_ptr, r_idx);
+    const Pos2D pos_wilderness(player_ptr->wilderness_y, player_ptr->wilderness_x);
+    const auto hook = get_monster_hook(pos_wilderness, floor.is_underground());
+    switch (hook) {
+    case MonraceHook::NONE:
+    case MonraceHook::DUNGEON:
+        return mon_hook_dungeon(player_ptr, r_idx);
+    case MonraceHook::TOWN:
+        return mon_hook_town(player_ptr, r_idx);
+    case MonraceHook::OCEAN:
+        return mon_hook_ocean(player_ptr, r_idx);
+    case MonraceHook::SHORE:
+        return mon_hook_shore(player_ptr, r_idx);
+    case MonraceHook::WASTE:
+        return mon_hook_waste(player_ptr, r_idx);
+    case MonraceHook::GRASS:
+        return mon_hook_grass(player_ptr, r_idx);
+    case MonraceHook::WOOD:
+        return mon_hook_wood(player_ptr, r_idx);
+    case MonraceHook::VOLCANO:
+        return mon_hook_volcano(player_ptr, r_idx);
+    case MonraceHook::MOUNTAIN:
+        return mon_hook_mountain(player_ptr, r_idx);
+    default:
+        THROW_EXCEPTION(std::logic_error, format("Invalid monrace hook type is specified! %d", enum2i(hook)));
+    }
 }
 
 /*!

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -225,6 +225,33 @@ static MonraceHook get_monster_hook(const Pos2D &pos_wilderness, bool is_undergr
     }
 }
 
+static bool do_hook(PlayerType *player_ptr, MonraceHook hook, MonraceId monrace_id)
+{
+    switch (hook) {
+    case MonraceHook::NONE:
+    case MonraceHook::DUNGEON:
+        return mon_hook_dungeon(player_ptr, monrace_id);
+    case MonraceHook::TOWN:
+        return mon_hook_town(player_ptr, monrace_id);
+    case MonraceHook::OCEAN:
+        return mon_hook_ocean(player_ptr, monrace_id);
+    case MonraceHook::SHORE:
+        return mon_hook_shore(player_ptr, monrace_id);
+    case MonraceHook::WASTE:
+        return mon_hook_waste(player_ptr, monrace_id);
+    case MonraceHook::GRASS:
+        return mon_hook_grass(player_ptr, monrace_id);
+    case MonraceHook::WOOD:
+        return mon_hook_wood(player_ptr, monrace_id);
+    case MonraceHook::VOLCANO:
+        return mon_hook_volcano(player_ptr, monrace_id);
+    case MonraceHook::MOUNTAIN:
+        return mon_hook_mountain(player_ptr, monrace_id);
+    default:
+        THROW_EXCEPTION(std::logic_error, format("Invalid monrace hook type is specified! %d", enum2i(hook)));
+    }
+}
+
 /*!
  * @brief 指定された広域マップ座標の地勢を元にモンスターの生成条件関数を返す
  * @return 地勢にあったモンスターの生成条件関数
@@ -479,29 +506,7 @@ static bool monster_hook_chameleon(PlayerType *player_ptr, MonraceId r_idx, shor
 
     const Pos2D pos_wilderness(player_ptr->wilderness_y, player_ptr->wilderness_x);
     const auto hook = get_monster_hook(pos_wilderness, floor.is_underground());
-    switch (hook) {
-    case MonraceHook::NONE:
-    case MonraceHook::DUNGEON:
-        return mon_hook_dungeon(player_ptr, r_idx);
-    case MonraceHook::TOWN:
-        return mon_hook_town(player_ptr, r_idx);
-    case MonraceHook::OCEAN:
-        return mon_hook_ocean(player_ptr, r_idx);
-    case MonraceHook::SHORE:
-        return mon_hook_shore(player_ptr, r_idx);
-    case MonraceHook::WASTE:
-        return mon_hook_waste(player_ptr, r_idx);
-    case MonraceHook::GRASS:
-        return mon_hook_grass(player_ptr, r_idx);
-    case MonraceHook::WOOD:
-        return mon_hook_wood(player_ptr, r_idx);
-    case MonraceHook::VOLCANO:
-        return mon_hook_volcano(player_ptr, r_idx);
-    case MonraceHook::MOUNTAIN:
-        return mon_hook_mountain(player_ptr, r_idx);
-    default:
-        THROW_EXCEPTION(std::logic_error, format("Invalid monrace hook type is specified! %d", enum2i(hook)));
-    }
+    return do_hook(player_ptr, hook, r_idx);
 }
 
 /*!

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -360,7 +360,7 @@ void get_mon_num_prep(PlayerType *player_ptr, const monsterrace_hook_type &hook1
  * @param summoner_m_idx モンスターの召喚による場合、召喚者のモンスターID
  * @return 対象にできるならtrueを返す
  */
-static bool monster_hook_chameleon_lord(PlayerType *player_ptr, MonraceId r_idx, short m_idx, const Grid &grid, std::optional<short> summoner_m_idx)
+static bool monster_hook_chameleon_lord(PlayerType *player_ptr, MonraceId r_idx, short m_idx, short terrain_id, std::optional<short> summoner_m_idx)
 {
     const auto &monraces = MonraceList::get_instance();
     const auto &monrace = monraces.get_monrace(r_idx);
@@ -380,7 +380,7 @@ static bool monster_hook_chameleon_lord(PlayerType *player_ptr, MonraceId r_idx,
         return false;
     }
 
-    if (!monster_can_cross_terrain(player_ptr, grid.feat, &monrace, 0)) {
+    if (!monster_can_cross_terrain(player_ptr, terrain_id, &monrace, 0)) {
         return false;
     }
 
@@ -404,7 +404,7 @@ static bool monster_hook_chameleon_lord(PlayerType *player_ptr, MonraceId r_idx,
  * @return 対象にできるならtrueを返す
  * @todo グローバル変数対策の上 monster_hook.cへ移す。
  */
-static bool monster_hook_chameleon(PlayerType *player_ptr, MonraceId r_idx, short m_idx, const Grid &grid, std::optional<short> summoner_m_idx)
+static bool monster_hook_chameleon(PlayerType *player_ptr, MonraceId r_idx, short m_idx, short terrain_id, std::optional<short> summoner_m_idx)
 {
     const auto &monrace = MonraceList::get_instance().get_monrace(r_idx);
     if (monrace.kind_flags.has(MonsterKindType::UNIQUE)) {
@@ -423,7 +423,7 @@ static bool monster_hook_chameleon(PlayerType *player_ptr, MonraceId r_idx, shor
         return false;
     }
 
-    if (!monster_can_cross_terrain(player_ptr, grid.feat, &monrace, 0)) {
+    if (!monster_can_cross_terrain(player_ptr, terrain_id, &monrace, 0)) {
         return false;
     }
 
@@ -454,12 +454,12 @@ static bool monster_hook_chameleon(PlayerType *player_ptr, MonraceId r_idx, shor
  * @brief モンスター生成テーブルの重み修正(カメレオン変身専用)
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param m_idx カメレオンのフロア内インデックス
- * @param grid カメレオンの足元グリッド
+ * @param terrain_id カメレオンの足元にある地形のID
  * @param summoner_m_idx 召喚者のモンスターインデックス
  * @param is_unique ユニークであるか否か (実質、カメレオンの王であるか否か)
  * @details get_mon_num() を呼ぶ前に get_mon_num_prep 系関数のいずれかを呼ぶこと。
  */
-void get_mon_num_prep_chameleon(PlayerType *player_ptr, short m_idx, const Grid &grid, const std::optional<short> summoner_m_idx, bool is_unique)
+void get_mon_num_prep_chameleon(PlayerType *player_ptr, short m_idx, short terrain_id, const std::optional<short> summoner_m_idx, bool is_unique)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
     const auto dungeon_level = floor.dun_level;
@@ -475,7 +475,7 @@ void get_mon_num_prep_chameleon(PlayerType *player_ptr, short m_idx, const Grid 
             continue;
         }
 
-        if (!hook_func(player_ptr, monrace_id, m_idx, grid, summoner_m_idx)) {
+        if (!hook_func(player_ptr, monrace_id, m_idx, terrain_id, summoner_m_idx)) {
             continue;
         }
 

--- a/src/monster/monster-util.h
+++ b/src/monster/monster-util.h
@@ -12,7 +12,30 @@ using monsterrace_hook_type = std::function<bool(PlayerType *, MonraceId)>;
 monsterrace_hook_type get_monster_hook(PlayerType *player_ptr);
 MonraceHookTerrain get_monster_hook2(PlayerType *player_ptr, POSITION y, POSITION x);
 void get_mon_num_prep(PlayerType *player_ptr, const monsterrace_hook_type &hook1, MonraceHookTerrain hook2 = MonraceHookTerrain::NONE, std::optional<summon_type> summon_specific_type = std::nullopt);
-void get_mon_num_prep_chameleon(PlayerType *player_ptr, short m_idx, short terrain_id, const std::optional<short> summoner_m_idx, bool is_unique);
+
+class ChameleonTransformation {
+public:
+    /*!
+     * @brief カメレオンの変身対象フィルタ
+     * @param m_idx カメレオンのフロア内インデックス
+     * @param terrain_id カメレオンの足元にある地形のID
+     * @param is_unique ユニークであるか否か (実質、カメレオンの王であるか否か)
+     * @param summoner_m_idx モンスターの召喚による場合、召喚者のモンスターID
+     */
+    ChameleonTransformation(short m_idx, short terrain_id, bool is_unique, const std::optional<short> &summoner_m_idx)
+        : m_idx(m_idx)
+        , terrain_id(terrain_id)
+        , is_unique(is_unique)
+        , summoner_m_idx(summoner_m_idx)
+    {
+    }
+
+    short m_idx;
+    short terrain_id;
+    bool is_unique;
+    std::optional<short> summoner_m_idx;
+};
+void get_mon_num_prep_chameleon(PlayerType *player_ptr, const ChameleonTransformation &ct);
 void get_mon_num_prep_bounty(PlayerType *player_ptr);
 bool is_player(MONSTER_IDX m_idx);
 bool is_monster(MONSTER_IDX m_idx);

--- a/src/monster/monster-util.h
+++ b/src/monster/monster-util.h
@@ -7,13 +7,12 @@
 
 enum summon_type : int;
 enum class MonraceId : short;
-class Grid;
 class PlayerType;
 using monsterrace_hook_type = std::function<bool(PlayerType *, MonraceId)>;
 monsterrace_hook_type get_monster_hook(PlayerType *player_ptr);
 MonraceHookTerrain get_monster_hook2(PlayerType *player_ptr, POSITION y, POSITION x);
 void get_mon_num_prep(PlayerType *player_ptr, const monsterrace_hook_type &hook1, MonraceHookTerrain hook2 = MonraceHookTerrain::NONE, std::optional<summon_type> summon_specific_type = std::nullopt);
-void get_mon_num_prep_chameleon(PlayerType *player_ptr, short m_idx, const Grid &grid, const std::optional<short> summoner_m_idx, bool is_unique);
+void get_mon_num_prep_chameleon(PlayerType *player_ptr, short m_idx, short terrain_id, const std::optional<short> summoner_m_idx, bool is_unique);
 void get_mon_num_prep_bounty(PlayerType *player_ptr);
 bool is_player(MONSTER_IDX m_idx);
 bool is_monster(MONSTER_IDX m_idx);

--- a/src/monster/monster-util.h
+++ b/src/monster/monster-util.h
@@ -7,12 +7,13 @@
 
 enum summon_type : int;
 enum class MonraceId : short;
+class Grid;
 class PlayerType;
 using monsterrace_hook_type = std::function<bool(PlayerType *, MonraceId)>;
 monsterrace_hook_type get_monster_hook(PlayerType *player_ptr);
 MonraceHookTerrain get_monster_hook2(PlayerType *player_ptr, POSITION y, POSITION x);
 void get_mon_num_prep(PlayerType *player_ptr, const monsterrace_hook_type &hook1, MonraceHookTerrain hook2 = MonraceHookTerrain::NONE, std::optional<summon_type> summon_specific_type = std::nullopt);
-void get_mon_num_prep_chameleon(PlayerType *player_ptr, const monsterrace_hook_type &hook1);
+void get_mon_num_prep_chameleon(PlayerType *player_ptr, short m_idx, const Grid &grid, const std::optional<short> summoner_m_idx, bool is_unique);
 void get_mon_num_prep_bounty(PlayerType *player_ptr);
 bool is_player(MONSTER_IDX m_idx);
 bool is_monster(MONSTER_IDX m_idx);

--- a/src/system/enums/monrace/monrace-hook-types.h
+++ b/src/system/enums/monrace/monrace-hook-types.h
@@ -6,6 +6,19 @@
 
 #pragma once
 
+enum class MonraceHook {
+    NONE,
+    DUNGEON,
+    TOWN,
+    OCEAN,
+    SHORE,
+    WASTE,
+    GRASS,
+    WOOD,
+    VOLCANO,
+    MOUNTAIN,
+};
+
 enum class MonraceHookTerrain {
     NONE,
     FLOOR,

--- a/src/system/grid-type-definition.cpp
+++ b/src/system/grid-type-definition.cpp
@@ -15,6 +15,20 @@ Grid::Grid()
     }
 }
 
+short Grid::get_terrain_id(TerrainKind tk) const
+{
+    switch (tk) {
+    case TerrainKind::NORMAL:
+        return this->feat;
+    case TerrainKind::MIMIC:
+        return this->get_feat_mimic();
+    case TerrainKind::MIMIC_RAW:
+        return this->mimic;
+    default:
+        THROW_EXCEPTION(std::logic_error, format("Invalid terrain kind is specified! %d", enum2i(tk)));
+    }
+}
+
 /*!
  * @brief 指定座標がFLOOR属性を持ったマスかどうかを返す
  * @param Y 指定Y座標

--- a/src/system/grid-type-definition.h
+++ b/src/system/grid-type-definition.h
@@ -71,6 +71,7 @@ public:
     std::map<GridFlow, uint8_t> dists; //!< Distance from player
     byte when{}; /* Hack -- when cost was computed */
 
+    short get_terrain_id(TerrainKind tk = TerrainKind::NORMAL) const;
     bool is_floor() const;
     bool is_room() const;
     bool is_extra() const;


### PR DESCRIPTION
これで関数ポインタを1つ撲滅できました
ご確認下さい