### PR TITLE
[Feature] デバッグコマンドでモンスターを選択しやすくする 

### DIFF
--- a/src/system/monrace/monrace-list.cpp
+++ b/src/system/monrace/monrace-list.cpp
@@ -140,7 +140,7 @@ std::vector<MonraceId> MonraceList::search_by_name(std::string_view name, bool i
     const auto lowered_search_name = str_tolower(name);
 
     auto filter = [&](const MonraceDefinition &monrace) {
-        const auto lowered_en_name = monrace.name.en_string();
+        const auto lowered_en_name = str_tolower(monrace.name.en_string());
 
 #ifdef JP
         return str_find(lowered_en_name, lowered_search_name) || str_find(monrace.name.string(), lowered_search_name);


### PR DESCRIPTION
デバッグコマンドでモンスターを召喚する時以下の選択方法を可能にする

- モンスターのシンボル文字を入力し、該当モンスター一覧から選択
- 入力した文字列がモンスター名称に部分一致するモンスター一覧から選択
- 既存のモンスター種族IDを入力する方法

また、英名で検索する時に正しくcase-insensitiveになっていない不具合があったので合わせて修正しました。

選択候補の表示ではとりあえずモンスターの名称のみを表示していますが、MonsterIDやその他の情報で合わせて表示されていると便利そうなものがあれば対応できそうです。

Resolves #4775