### PR TITLE
ダンジョン突入フラグが反対になっていたのを修正した

### DIFF
--- a/src/system/services/dungeon-service.cpp
+++ b/src/system/services/dungeon-service.cpp
@@ -70,7 +70,7 @@ int DungeonService::find_max_level()
 std::optional<std::string> DungeonService::check_first_entrance(DungeonId dungeon_id)
 {
     const auto &record = DungeonRecords::get_instance().get_record(dungeon_id);
-    if (!record.has_entered()) {
+    if (record.has_entered()) {
         return std::nullopt;
     }
 


### PR DESCRIPTION
むしろ最初の1回が出ないバグです
ご確認下さい

なおローカル環境ではイーク洞の入口が0Fになるバグが別途出ていましたが、どうもコーディング中の動作確認で一時的に出たものらしくリリース時のコミットでは再現しませんでした
万が一今後bisect中にどこかのコミットで再現するかもしれませんが、その時は以下の手順で復旧できます
- 一旦イーク洞に入る (が、すぐ地上に戻される)
- 広域マップに出る
- もう一度辺境の地に入る