### PR TITLE
get_monster_hook() を廃止した

### DIFF
--- a/src/birth/inventory-initializer.cpp
+++ b/src/birth/inventory-initializer.cpp
@@ -101,7 +101,7 @@ static void decide_initial_items(PlayerType *player_ptr)
         return;
     case PlayerRaceType::BALROG:
         /* Demon can drain vitality from humanoid corpse */
-        get_mon_num_prep(player_ptr, monster_hook_human);
+        get_mon_num_prep_enum(player_ptr, MonraceHook::HUMAN);
         for (int i = rand_range(3, 4); i > 0; i--) {
             ItemEntity item({ ItemKindType::MONSTER_REMAINS, SV_CORPSE });
             item.pval = enum2i(get_mon_num(player_ptr, 0, 2, PM_NONE));

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -70,7 +70,7 @@ static void process_fishing(PlayerType *player_ptr)
     term_xtra(TERM_XTRA_DELAY, 10);
     if (one_in_(1000)) {
         bool success = false;
-        get_mon_num_prep(player_ptr, monster_is_fishing_target);
+        get_mon_num_prep_enum(player_ptr, MonraceHook::FISHING);
         auto *floor_ptr = player_ptr->current_floor_ptr;
         const auto wild_level = wilderness[player_ptr->wilderness_y][player_ptr->wilderness_x].level;
         const auto level = floor_ptr->is_underground() ? floor_ptr->dun_level : wild_level;

--- a/src/dungeon/quest.cpp
+++ b/src/dungeon/quest.cpp
@@ -154,7 +154,7 @@ bool QuestList::order_completed(QuestId id1, QuestId id2) const
  */
 void determine_random_questor(PlayerType *player_ptr, QuestType &quest)
 {
-    get_mon_num_prep(player_ptr, mon_hook_quest);
+    get_mon_num_prep_enum(player_ptr, MonraceHook::QUEST);
     const auto &monraces = MonraceList::get_instance();
     MonraceId r_idx;
     while (true) {

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -47,29 +47,6 @@
 #include "world/world.h"
 
 /*!
- * @brief たぬきの変身対象となるモンスターかどうか判定する / Hook for Tanuki
- * @param monrace_id モンスター種族ID
- * @return 対象にできるならtrueを返す
- * @todo グローバル変数対策の上 monster_hook.cへ移す。
- */
-static bool monster_hook_tanuki(PlayerType *player_ptr, MonraceId monrace_id)
-{
-    const auto &monrace = MonraceList::get_instance().get_monrace(monrace_id);
-    bool unselectable = monrace.kind_flags.has(MonsterKindType::UNIQUE);
-    unselectable |= monrace.misc_flags.has(MonsterMiscType::MULTIPLY);
-    unselectable |= monrace.behavior_flags.has(MonsterBehaviorType::FRIENDLY);
-    unselectable |= monrace.feature_flags.has(MonsterFeatureType::AQUATIC);
-    unselectable |= monrace.misc_flags.has(MonsterMiscType::CHAMELEON);
-    unselectable |= monrace.is_explodable();
-    if (unselectable) {
-        return false;
-    }
-
-    auto hook_pf = get_monster_hook(player_ptr);
-    return hook_pf(player_ptr, monrace_id);
-}
-
-/*!
  * @param player_ptr プレイヤーへの参照ポインタ
  * @brief モンスターの表層IDを設定する / Set initial racial appearance of a monster
  * @param monrace_id モンスター種族ID
@@ -86,7 +63,7 @@ static MonraceId initial_monrace_appearance(PlayerType *player_ptr, MonraceId mo
         return monrace_id;
     }
 
-    get_mon_num_prep(player_ptr, monster_hook_tanuki);
+    get_mon_num_prep_enum(player_ptr, MonraceHook::TANUKI);
     auto attempts = 1000;
     const auto &floor = *player_ptr->current_floor_ptr;
     auto min = std::min(floor.base_level - 5, 50);

--- a/src/monster-race/monster-race-hook.cpp
+++ b/src/monster-race/monster-race-hook.cpp
@@ -34,7 +34,7 @@ EnumClassFlagGroup<MonsterAbilityType> vault_aux_dragon_mask4;
  */
 void vault_prep_clone(PlayerType *player_ptr)
 {
-    get_mon_num_prep(player_ptr, vault_monster_okay);
+    get_mon_num_prep_enum(player_ptr, MonraceHook::VAULT);
     vault_aux_race = get_mon_num(player_ptr, 0, player_ptr->current_floor_ptr->dun_level + 10, PM_NONE);
     get_mon_num_prep_enum(player_ptr);
 }
@@ -45,7 +45,7 @@ void vault_prep_clone(PlayerType *player_ptr)
  */
 void vault_prep_symbol(PlayerType *player_ptr)
 {
-    get_mon_num_prep(player_ptr, vault_monster_okay);
+    get_mon_num_prep_enum(player_ptr, MonraceHook::VAULT);
     MonraceId r_idx = get_mon_num(player_ptr, 0, player_ptr->current_floor_ptr->dun_level + 10, PM_NONE);
     get_mon_num_prep_enum(player_ptr);
     vault_aux_char = monraces_info[r_idx].symbol_definition.character;

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -241,6 +241,12 @@ static bool do_hook(PlayerType *player_ptr, MonraceHook hook, MonraceId monrace_
         const auto hook_tanuki = get_monster_hook(pos_wilderness, floor.is_underground());
         return do_hook(player_ptr, hook_tanuki, monrace_id);
     }
+    case MonraceHook::FISHING:
+        return monster_is_fishing_target(player_ptr, monrace_id);
+    case MonraceHook::QUEST:
+        return mon_hook_quest(player_ptr, monrace_id);
+    case MonraceHook::VAULT:
+        return vault_monster_okay(player_ptr, monrace_id);
     default:
         THROW_EXCEPTION(std::logic_error, format("Invalid monrace hook type is specified! %d", enum2i(hook)));
     }

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -261,9 +261,34 @@ static bool do_hook(PlayerType *player_ptr, MonraceHook hook, MonraceId monrace_
         return vault_aux_lite(player_ptr, monrace_id);
     case MonraceHook::SHARDS:
         return vault_aux_shards(player_ptr, monrace_id);
+    case MonraceHook::TANUKI:
+        return monster_hook_tanuki(player_ptr, monrace_id);
     default:
         THROW_EXCEPTION(std::logic_error, format("Invalid monrace hook type is specified! %d", enum2i(hook)));
     }
+}
+
+/*!
+ * @brief たぬきの変身対象となるモンスターかどうか判定する / Hook for Tanuki
+ * @param monrace_id モンスター種族ID
+ * @return 対象にできるならtrueを返す
+ * @todo グローバル変数対策の上 monster_hook.cへ移す。
+ */
+static bool monster_hook_tanuki(PlayerType *player_ptr, MonraceId monrace_id)
+{
+    const auto &monrace = MonraceList::get_instance().get_monrace(monrace_id);
+    auto unselectable = monrace.kind_flags.has(MonsterKindType::UNIQUE);
+    unselectable |= monrace.misc_flags.has(MonsterMiscType::MULTIPLY);
+    unselectable |= monrace.behavior_flags.has(MonsterBehaviorType::FRIENDLY);
+    unselectable |= monrace.feature_flags.has(MonsterFeatureType::AQUATIC);
+    unselectable |= monrace.misc_flags.has(MonsterMiscType::CHAMELEON);
+    unselectable |= monrace.is_explodable();
+    if (unselectable) {
+        return false;
+    }
+
+    auto hook_pf = get_monster_hook(player_ptr);
+    return hook_pf(player_ptr, monrace_id);
 }
 
 /*!

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -249,6 +249,18 @@ static bool do_hook(PlayerType *player_ptr, MonraceHook hook, MonraceId monrace_
         return mon_hook_volcano(player_ptr, monrace_id);
     case MonraceHook::MOUNTAIN:
         return mon_hook_mountain(player_ptr, monrace_id);
+    case MonraceHook::FIGURINE:
+        return item_monster_okay(player_ptr, monrace_id);
+    case MonraceHook::ARENA:
+        return monster_can_entry_arena(player_ptr, monrace_id);
+    case MonraceHook::NIGHTMARE:
+        return get_nightmare(player_ptr, monrace_id);
+    case MonraceHook::HUMAN:
+        return monster_hook_human(player_ptr, monrace_id);
+    case MonraceHook::GLASS:
+        return vault_aux_lite(player_ptr, monrace_id);
+    case MonraceHook::SHARDS:
+        return vault_aux_shards(player_ptr, monrace_id);
     default:
         THROW_EXCEPTION(std::logic_error, format("Invalid monrace hook type is specified! %d", enum2i(hook)));
     }

--- a/src/monster/monster-util.h
+++ b/src/monster/monster-util.h
@@ -10,7 +10,6 @@ enum summon_type : int;
 enum class MonraceId : short;
 class PlayerType;
 using monsterrace_hook_type = std::function<bool(PlayerType *, MonraceId)>;
-monsterrace_hook_type get_monster_hook(PlayerType *player_ptr);
 MonraceHook get_monster_hook(const Pos2D &pos_wilderness, bool is_underground);
 MonraceHookTerrain get_monster_hook2(PlayerType *player_ptr, POSITION y, POSITION x);
 void get_mon_num_prep(PlayerType *player_ptr, const monsterrace_hook_type &hook1, MonraceHookTerrain hook2 = MonraceHookTerrain::NONE, std::optional<summon_type> summon_specific_type = std::nullopt);

--- a/src/object-enchant/others/apply-magic-others.cpp
+++ b/src/object-enchant/others/apply-magic-others.cpp
@@ -144,7 +144,7 @@ void OtherItemsEnchanter::generate_corpse()
         { SV_CORPSE, MonsterDropType::DROP_CORPSE },
     };
 
-    get_mon_num_prep(this->player_ptr, item_monster_okay);
+    get_mon_num_prep_enum(this->player_ptr, MonraceHook::FIGURINE);
     const auto &floor = *this->player_ptr->current_floor_ptr;
     const auto &monraces = MonraceList::get_instance();
     MonraceId monrace_id;

--- a/src/player/eldritch-horror.cpp
+++ b/src/player/eldritch-horror.cpp
@@ -118,7 +118,7 @@ void sanity_blast(PlayerType *player_ptr, MonsterEntity *m_ptr, bool necro)
             break;
         }
     } else if (!necro) {
-        get_mon_num_prep(player_ptr, get_nightmare);
+        get_mon_num_prep_enum(player_ptr, MonraceHook::NIGHTMARE);
         const auto monrace_id = get_mon_num(player_ptr, 0, MAX_DEPTH, PM_NONE);
         auto &monrace = monraces.get_monrace(monrace_id);
         power = monrace.level + 10;

--- a/src/room/rooms-special.cpp
+++ b/src/room/rooms-special.cpp
@@ -101,7 +101,7 @@ bool build_type15(PlayerType *player_ptr, DungeonData *dd_ptr)
     switch (randint1(3)) {
     case 1: /* 4 lite breathers + potion */
     {
-        get_mon_num_prep(player_ptr, vault_aux_lite);
+        get_mon_num_prep_enum(player_ptr, MonraceHook::GLASS);
 
         /* Place fixed lite berathers */
         for (auto dir1 = 4; dir1 < 8; dir1++) {
@@ -147,7 +147,7 @@ bool build_type15(PlayerType *player_ptr, DungeonData *dd_ptr)
         place_inner_glass(player_ptr, floor.get_grid({ top + 1, right - 1 }));
         place_inner_glass(player_ptr, floor.get_grid({ bottom - 1, left + 1 }));
         place_inner_glass(player_ptr, floor.get_grid({ bottom - 1, right - 1 }));
-        get_mon_num_prep(player_ptr, vault_aux_lite);
+        get_mon_num_prep_enum(player_ptr, MonraceHook::GLASS);
 
         const auto monrace_id = get_mon_num(player_ptr, 0, floor.dun_level, 0);
         if (MonraceList::is_valid(monrace_id)) {
@@ -192,7 +192,7 @@ bool build_type15(PlayerType *player_ptr, DungeonData *dd_ptr)
             place_inner_glass(player_ptr, floor.get_grid({ center->y + 2 * ddy_ddd[dir1], center->x + 2 * ddx_ddd[dir1] }));
         }
 
-        get_mon_num_prep(player_ptr, vault_aux_shards);
+        get_mon_num_prep_enum(player_ptr, MonraceHook::SHARDS);
 
         /* Place shard berathers */
         for (auto dir1 = 4; dir1 < 8; dir1++) {

--- a/src/system/building-type-definition.cpp
+++ b/src/system/building-type-definition.cpp
@@ -168,7 +168,7 @@ MonraceId MeleeArena::search_gladiator(PlayerType *player_ptr, int mon_level, in
     const auto &monraces = MonraceList::get_instance();
     MonraceId monrace_id;
     while (true) {
-        get_mon_num_prep(player_ptr, monster_can_entry_arena);
+        get_mon_num_prep_enum(player_ptr, MonraceHook::ARENA);
         monrace_id = get_mon_num(player_ptr, 0, mon_level, PM_ARENA);
         if (!MonraceList::is_valid(monrace_id)) {
             continue;

--- a/src/system/enums/monrace/monrace-hook-types.h
+++ b/src/system/enums/monrace/monrace-hook-types.h
@@ -23,6 +23,7 @@ enum class MonraceHook {
     HUMAN,
     GLASS, // ガラス (取り違え注意)
     SHARDS,
+    TANUKI,
 };
 
 enum class MonraceHookTerrain {

--- a/src/system/enums/monrace/monrace-hook-types.h
+++ b/src/system/enums/monrace/monrace-hook-types.h
@@ -13,10 +13,16 @@ enum class MonraceHook {
     OCEAN,
     SHORE,
     WASTE,
-    GRASS,
+    GRASS, // 草原 (取り違え注意)
     WOOD,
     VOLCANO,
     MOUNTAIN,
+    FIGURINE,
+    ARENA,
+    NIGHTMARE,
+    HUMAN,
+    GLASS, // ガラス (取り違え注意)
+    SHARDS,
 };
 
 enum class MonraceHookTerrain {

--- a/src/system/enums/monrace/monrace-hook-types.h
+++ b/src/system/enums/monrace/monrace-hook-types.h
@@ -24,6 +24,9 @@ enum class MonraceHook {
     GLASS, // ガラス (取り違え注意)
     SHARDS,
     TANUKI,
+    FISHING,
+    QUEST,
+    VAULT,
 };
 
 enum class MonraceHookTerrain {


### PR DESCRIPTION
「無理やりシグネチャを統一した関数ポインタを返す関数」とかいう闇の深い設計を廃止して見通しが良くなりました
ご確認下さい