### PR TITLE
function型の引数を取るget_mon_num_prep() を廃止した

### DIFF
--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -590,7 +590,7 @@ void get_mon_num_prep_summon(PlayerType *player_ptr, const SummonCondition &cond
             continue;
         }
 
-        if (!system.is_phase_out()) {
+        if (!system.is_phase_out() && (condition.type != SUMMON_GUARDIANS)) {
             if (!entry.is_permitted(dungeon_level)) {
                 continue;
             }

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -65,7 +65,7 @@ static bool is_possible_monster_or(const EnumClassFlagGroup<T> &r_flags, const E
  * @param is_chameleon_polymorph カメレオンの変身の場合、true
  * @return 召喚条件が一致するならtrue / Return TRUE is the monster is OK and FALSE otherwise
  */
-static bool restrict_monster_to_dungeon(const DungeonDefinition &dungeon, int floor_level, MonraceId monrace_id, bool has_summon_specific_type, bool is_chameleon_polymorph)
+static bool restrict_monster_to_dungeon(const DungeonDefinition &dungeon, int floor_level, MonraceId monrace_id, bool has_summon_specific_type = false, bool is_chameleon_polymorph = false)
 {
     const auto &monrace = MonraceList::get_instance().get_monrace(monrace_id);
     if (dungeon.flags.has(DungeonFeatureType::CHAMELEON)) {
@@ -387,7 +387,7 @@ void get_mon_num_prep_enum(PlayerType *player_ptr, MonraceHook hook1, MonraceHoo
         entry.prob2 = entry.prob1;
         const auto in_random_quest = floor.is_in_quest() && !QuestType::is_fixed(floor.quest_number);
         const auto cond = !system.is_phase_out() && floor.is_underground() && !in_random_quest;
-        if (cond && !restrict_monster_to_dungeon(dungeon, dungeon_level, monrace_id, false, false)) {
+        if (cond && !restrict_monster_to_dungeon(dungeon, dungeon_level, monrace_id)) {
             const int numer = entry.prob2 * dungeon.special_div;
             const int q = numer / 64;
             const int r = numer % 64;
@@ -495,7 +495,7 @@ void get_mon_num_prep_escort(PlayerType *player_ptr, MonraceId escorted_monrace_
         entry.prob2 = entry.prob1;
         const auto in_random_quest = floor.is_in_quest() && !QuestType::is_fixed(floor.quest_number);
         const auto cond = !system.is_phase_out() && floor.is_underground() && !in_random_quest;
-        if (cond && !restrict_monster_to_dungeon(dungeon, dungeon_level, monrace_id, false, false)) {
+        if (cond && !restrict_monster_to_dungeon(dungeon, dungeon_level, monrace_id)) {
             const int numer = entry.prob2 * dungeon.special_div;
             const int q = numer / 64;
             const int r = numer % 64;
@@ -603,7 +603,7 @@ void get_mon_num_prep_summon(PlayerType *player_ptr, const SummonCondition &cond
         entry.prob2 = entry.prob1;
         const auto in_random_quest = floor.is_in_quest() && !QuestType::is_fixed(floor.quest_number);
         const auto cond = !system.is_phase_out() && floor.is_underground() && !in_random_quest;
-        if (cond && !restrict_monster_to_dungeon(dungeon, dungeon_level, monrace_id, true, false)) {
+        if (cond && !restrict_monster_to_dungeon(dungeon, dungeon_level, monrace_id, true)) {
             const int numer = entry.prob2 * dungeon.special_div;
             const int q = numer / 64;
             const int r = numer % 64;
@@ -791,7 +791,7 @@ void get_mon_num_prep_bounty(PlayerType *player_ptr)
         entry.prob2 = entry.prob1;
         const auto in_random_quest = floor.is_in_quest() && !QuestType::is_fixed(floor.quest_number);
         const auto cond = !system.is_phase_out() && floor.is_underground() && !in_random_quest;
-        if (cond && !restrict_monster_to_dungeon(dungeon, dungeon_level, monrace_id, false, false)) {
+        if (cond && !restrict_monster_to_dungeon(dungeon, dungeon_level, monrace_id)) {
             const int numer = entry.prob2 * dungeon.special_div;
             const int q = numer / 64;
             const int r = numer % 64;

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -603,7 +603,7 @@ void get_mon_num_prep_summon(PlayerType *player_ptr, const SummonCondition &cond
         entry.prob2 = entry.prob1;
         const auto in_random_quest = floor.is_in_quest() && !QuestType::is_fixed(floor.quest_number);
         const auto cond = !system.is_phase_out() && floor.is_underground() && !in_random_quest;
-        if (cond && !restrict_monster_to_dungeon(dungeon, dungeon_level, monrace_id, false, false)) {
+        if (cond && !restrict_monster_to_dungeon(dungeon, dungeon_level, monrace_id, true, false)) {
             const int numer = entry.prob2 * dungeon.special_div;
             const int q = numer / 64;
             const int r = numer % 64;

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -247,6 +247,38 @@ static bool do_hook(PlayerType *player_ptr, MonraceHook hook, MonraceId monrace_
         return mon_hook_quest(player_ptr, monrace_id);
     case MonraceHook::VAULT:
         return vault_monster_okay(player_ptr, monrace_id);
+    case MonraceHook::CLONE:
+        return vault_aux_clone(player_ptr, monrace_id);
+    case MonraceHook::JELLY:
+        return vault_aux_jelly(player_ptr, monrace_id);
+    case MonraceHook::GOOD:
+        return vault_aux_symbol_g(player_ptr, monrace_id);
+    case MonraceHook::EVIL:
+        return vault_aux_symbol_e(player_ptr, monrace_id);
+    case MonraceHook::MIMIC:
+        return vault_aux_mimic(player_ptr, monrace_id);
+    case MonraceHook::LOVECRAFTIAN:
+        return vault_aux_cthulhu(player_ptr, monrace_id);
+    case MonraceHook::KENNEL:
+        return vault_aux_kennel(player_ptr, monrace_id);
+    case MonraceHook::ANIMAL:
+        return vault_aux_animal(player_ptr, monrace_id);
+    case MonraceHook::CHAPEL:
+        return vault_aux_chapel_g(player_ptr, monrace_id);
+    case MonraceHook::UNDEAD:
+        return vault_aux_undead(player_ptr, monrace_id);
+    case MonraceHook::ORC:
+        return vault_aux_orc(player_ptr, monrace_id);
+    case MonraceHook::TROLL:
+        return vault_aux_troll(player_ptr, monrace_id);
+    case MonraceHook::GIANT:
+        return vault_aux_giant(player_ptr, monrace_id);
+    case MonraceHook::DRAGON:
+        return vault_aux_dragon(player_ptr, monrace_id);
+    case MonraceHook::DEMON:
+        return vault_aux_demon(player_ptr, monrace_id);
+    case MonraceHook::DARK_ELF:
+        return vault_aux_dark_elf(player_ptr, monrace_id);
     default:
         THROW_EXCEPTION(std::logic_error, format("Invalid monrace hook type is specified! %d", enum2i(hook)));
     }
@@ -312,83 +344,14 @@ static bool filter_monrace_hook2(PlayerType *player_ptr, MonraceId monrace_id, M
 /*!
  * @brief モンスター生成テーブルの重み修正
  * @param player_ptr プレイヤーへの参照ポインタ
- * @param hook1 生成制約関数1 (nullptr の場合、制約なし)
- * @param hook2 生成制約関数2 (nullptr の場合、制約なし)
+ * @param hook1 生成制約1
+ * @param hook2 生成制約2
  * @param summon_specific_type summon_specific によるものの場合、召喚種別を指定する
  * @return 常に 0
  *
  * get_mon_num() を呼ぶ前に get_mon_num_prep() 系関数のいずれかを呼ぶこと。
  */
-void get_mon_num_prep(PlayerType *player_ptr, const monsterrace_hook_type &hook1, MonraceHookTerrain hook2, std::optional<summon_type> summon_specific_type)
-{
-    const auto &floor = *player_ptr->current_floor_ptr;
-    const auto dungeon_level = floor.dun_level;
-
-    // モンスター生成テーブルの各要素について重みを修正する。
-    const auto &system = AngbandSystem::get_instance();
-    auto &table = MonraceAllocationTable::get_instance();
-    const auto &dungeon = floor.get_dungeon_definition();
-    MonraceFilterDebugInfo mfdi;
-    for (auto &entry : table) {
-        const auto monrace_id = entry.index;
-
-        // 生成を禁止する要素は重み 0 とする。
-        entry.prob2 = 0;
-
-        // 基本重みが 0 以下なら生成禁止。
-        // テーブル内の無効エントリもこれに該当する(alloc_race_table は生成時にゼロクリアされるため)。
-        if (entry.prob1 <= 0) {
-            continue;
-        }
-
-        // 生成制約関数が偽を返したら生成禁止。
-        if (hook1 && !hook1(player_ptr, monrace_id)) {
-            continue;
-        }
-
-        if (!filter_monrace_hook2(player_ptr, monrace_id, hook2)) {
-            continue;
-        }
-
-        // 原則生成禁止するものたち(フェイズアウト状態 / カメレオンの変身先 / ダンジョンの主召喚 は例外)。
-        if (!system.is_phase_out() && summon_specific_type != SUMMON_GUARDIANS) {
-            if (!entry.is_permitted(dungeon_level)) {
-                continue;
-            }
-
-            // 殲滅系クエストの詰み防止 (クエスト内では特殊なフラグ持ちの生成を禁止する)
-            if (floor.is_in_quest() && !entry.is_defeatable(dungeon_level)) {
-                continue;
-            }
-        }
-
-        // 生成を許可するものは基本重みをそのまま引き継ぐ。
-        entry.prob2 = entry.prob1;
-
-        // ダンジョンによる制約を適用する条件:
-        //   * フェイズアウト状態でない
-        //   * 1階かそれより深いところにいる
-        //   * ランダムクエスト中でない
-        const auto in_random_quest = floor.is_in_quest() && !QuestType::is_fixed(floor.quest_number);
-        const auto cond = !system.is_phase_out() && floor.is_underground() && !in_random_quest;
-        if (cond && !restrict_monster_to_dungeon(dungeon, dungeon_level, monrace_id, summon_specific_type.has_value(), false)) {
-            // ダンジョンによる制約に掛かった場合、重みを special_div/64 倍する。
-            // 丸めは確率的に行う。
-            const int numer = entry.prob2 * dungeon.special_div;
-            const int q = numer / 64;
-            const int r = numer % 64;
-            entry.prob2 = static_cast<short>(randint0(64) < r ? q + 1 : q);
-        }
-
-        mfdi.update(entry.prob2, entry.level);
-    }
-
-    if (cheat_hear) {
-        msg_print(mfdi.to_string());
-    }
-}
-
-void get_mon_num_prep_enum(PlayerType *player_ptr, MonraceHook hook1, MonraceHookTerrain hook2, std::optional<summon_type> summon_specific_type)
+void get_mon_num_prep_enum(PlayerType *player_ptr, MonraceHook hook1, MonraceHookTerrain hook2)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
     const auto dungeon_level = floor.dun_level;
@@ -411,7 +374,7 @@ void get_mon_num_prep_enum(PlayerType *player_ptr, MonraceHook hook1, MonraceHoo
             continue;
         }
 
-        if (!system.is_phase_out() && summon_specific_type != SUMMON_GUARDIANS) {
+        if (!system.is_phase_out()) {
             if (!entry.is_permitted(dungeon_level)) {
                 continue;
             }
@@ -424,7 +387,7 @@ void get_mon_num_prep_enum(PlayerType *player_ptr, MonraceHook hook1, MonraceHoo
         entry.prob2 = entry.prob1;
         const auto in_random_quest = floor.is_in_quest() && !QuestType::is_fixed(floor.quest_number);
         const auto cond = !system.is_phase_out() && floor.is_underground() && !in_random_quest;
-        if (cond && !restrict_monster_to_dungeon(dungeon, dungeon_level, monrace_id, summon_specific_type.has_value(), false)) {
+        if (cond && !restrict_monster_to_dungeon(dungeon, dungeon_level, monrace_id, false, false)) {
             const int numer = entry.prob2 * dungeon.special_div;
             const int q = numer / 64;
             const int r = numer % 64;
@@ -445,7 +408,6 @@ void get_mon_num_prep_enum(PlayerType *player_ptr, MonraceHook hook1, MonraceHoo
  * @param escorted_monrace_id 護衛されるモンスターの種族ID
  * @param escorted_m_idx 護衛されるモンスターのフロア内インデックス
  * @return 護衛にできるならばtrue
- * @todo escorted_m_idx とescorted_monrace_id は両方グローバル変数なので、前者が指し示すモンスター種族IDが後者である保証が確認できなかった. 要調査.
  */
 static bool place_monster_can_escort(PlayerType *player_ptr, MonraceId monrace_id, MonraceId escorted_monrace_id, short escorted_m_idx)
 {
@@ -490,6 +452,13 @@ static bool place_monster_can_escort(PlayerType *player_ptr, MonraceId monrace_i
     return true;
 }
 
+/*!
+ * @brief モンスター生成テーブルの重み修正
+ * @param player_ptr プレイヤーへの参照ポインタ
+ * @param escorted_monrace_id 護衛されるモンスターの種族ID
+ * @param m_idx 護衛されるモンスターのフロア内インデックス
+ * @param hook 生成の地形条件
+ */
 void get_mon_num_prep_escort(PlayerType *player_ptr, MonraceId escorted_monrace_id, short m_idx, MonraceHookTerrain hook)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
@@ -593,6 +562,11 @@ static bool summon_specific_okay(PlayerType *player_ptr, MonraceId monrace_id, c
     return check_summon_specific(player_ptr, monster.r_idx, monrace_id, condition.type);
 }
 
+/*!
+ * @brief モンスター生成テーブルの重み修正 (召喚用)
+ * @param player_ptr プレイヤーへの参照ポインタ
+ * @param SummonCondition 生成制約
+ */
 void get_mon_num_prep_summon(PlayerType *player_ptr, const SummonCondition &condition)
 {
     const auto &floor = *player_ptr->current_floor_ptr;

--- a/src/monster/monster-util.h
+++ b/src/monster/monster-util.h
@@ -9,11 +9,9 @@
 enum summon_type : int;
 enum class MonraceId : short;
 class PlayerType;
-using monsterrace_hook_type = std::function<bool(PlayerType *, MonraceId)>;
 MonraceHook get_monster_hook(const Pos2D &pos_wilderness, bool is_underground);
 MonraceHookTerrain get_monster_hook2(PlayerType *player_ptr, POSITION y, POSITION x);
-void get_mon_num_prep(PlayerType *player_ptr, const monsterrace_hook_type &hook1, MonraceHookTerrain hook2 = MonraceHookTerrain::NONE, std::optional<summon_type> summon_specific_type = std::nullopt);
-void get_mon_num_prep_enum(PlayerType *player_ptr, MonraceHook hook1 = MonraceHook::NONE, MonraceHookTerrain hook2 = MonraceHookTerrain::NONE, std::optional<summon_type> summon_specific_type = std::nullopt);
+void get_mon_num_prep_enum(PlayerType *player_ptr, MonraceHook hook1 = MonraceHook::NONE, MonraceHookTerrain hook2 = MonraceHookTerrain::NONE);
 void get_mon_num_prep_escort(PlayerType *player_ptr, MonraceId escorted_monrace_id, short m_idx, MonraceHookTerrain hook2);
 
 class SummonCondition {

--- a/src/room/pit-nest-util.h
+++ b/src/room/pit-nest-util.h
@@ -34,11 +34,12 @@ enum class PitKind {
 };
 
 /*! pit/nest型情報の構造体定義 */
+enum class MonraceHook;
 enum class MonraceId : short;
 class PlayerType;
 struct nest_pit_type {
     std::string name; //<! 部屋名
-    std::function<bool(PlayerType *, MonraceId)> hook_func; //<! モンスターフィルタ関数
+    MonraceHook hook; //<! モンスターフィルタ関数
     std::optional<std::function<void(PlayerType *)>> prep_func; //<! 能力フィルタ関数
     int level; //<! 相当階
     int chance; //!< 生成確率

--- a/src/room/rooms-nest.cpp
+++ b/src/room/rooms-nest.cpp
@@ -33,16 +33,16 @@ constexpr auto NUM_NEST_MON_TYPE = 64; //! nestの種別数.
  * @brief 生成するNestの情報テーブル
  */
 const std::map<NestKind, nest_pit_type> nest_types = {
-    { NestKind::CLONE, { _("クローン", "clone"), vault_aux_clone, vault_prep_clone, 5, 3 } },
-    { NestKind::JELLY, { _("ゼリー", "jelly"), vault_aux_jelly, std::nullopt, 5, 6 } },
-    { NestKind::SYMBOL_GOOD, { _("シンボル(善)", "symbol good"), vault_aux_symbol_g, vault_prep_symbol, 25, 2 } },
-    { NestKind::SYMBOL_EVIL, { _("シンボル(悪)", "symbol evil"), vault_aux_symbol_e, vault_prep_symbol, 25, 2 } },
-    { NestKind::MIMIC, { _("ミミック", "mimic"), vault_aux_mimic, std::nullopt, 30, 4 } },
-    { NestKind::LOVECRAFTIAN, { _("狂気", "lovecraftian"), vault_aux_cthulhu, std::nullopt, 70, 2 } },
-    { NestKind::KENNEL, { _("犬小屋", "kennel"), vault_aux_kennel, std::nullopt, 45, 4 } },
-    { NestKind::ANIMAL, { _("動物園", "animal"), vault_aux_animal, std::nullopt, 35, 5 } },
-    { NestKind::CHAPEL, { _("教会", "chapel"), vault_aux_chapel_g, std::nullopt, 75, 4 } },
-    { NestKind::UNDEAD, { _("アンデッド", "undead"), vault_aux_undead, std::nullopt, 75, 5 } },
+    { NestKind::CLONE, { _("クローン", "clone"), MonraceHook::CLONE, vault_prep_clone, 5, 3 } },
+    { NestKind::JELLY, { _("ゼリー", "jelly"), MonraceHook::JELLY, std::nullopt, 5, 6 } },
+    { NestKind::SYMBOL_GOOD, { _("シンボル(善)", "symbol good"), MonraceHook::GOOD, vault_prep_symbol, 25, 2 } },
+    { NestKind::SYMBOL_EVIL, { _("シンボル(悪)", "symbol evil"), MonraceHook::EVIL, vault_prep_symbol, 25, 2 } },
+    { NestKind::MIMIC, { _("ミミック", "mimic"), MonraceHook::MIMIC, std::nullopt, 30, 4 } },
+    { NestKind::LOVECRAFTIAN, { _("狂気", "lovecraftian"), MonraceHook::LOVECRAFTIAN, std::nullopt, 70, 2 } },
+    { NestKind::KENNEL, { _("犬小屋", "kennel"), MonraceHook::KENNEL, std::nullopt, 45, 4 } },
+    { NestKind::ANIMAL, { _("動物園", "animal"), MonraceHook::ANIMAL, std::nullopt, 35, 5 } },
+    { NestKind::CHAPEL, { _("教会", "chapel"), MonraceHook::CHAPEL, std::nullopt, 75, 4 } },
+    { NestKind::UNDEAD, { _("アンデッド", "undead"), MonraceHook::UNDEAD, std::nullopt, 75, 5 } },
 };
 
 std::optional<std::array<NestMonsterInfo, NUM_NEST_MON_TYPE>> pick_nest_monraces(PlayerType *player_ptr, MonsterEntity &align)
@@ -212,7 +212,7 @@ bool build_type5(PlayerType *player_ptr, DungeonData *dd_ptr)
         (*nest.prep_func)(player_ptr);
     }
 
-    get_mon_num_prep(player_ptr, nest.hook_func);
+    get_mon_num_prep_enum(player_ptr, nest.hook);
     MonsterEntity align;
     align.sub_align = SUB_ALIGN_NEUTRAL;
 

--- a/src/room/rooms-pit.cpp
+++ b/src/room/rooms-pit.cpp
@@ -30,16 +30,16 @@ constexpr Pos2DVec PIT_SIZE(4, 11);
  * @brief 生成するPitの情報テーブル
  */
 const std::map<PitKind, nest_pit_type> pit_types = {
-    { PitKind::ORC, { _("オーク", "orc"), vault_aux_orc, std::nullopt, 5, 6 } },
-    { PitKind::TROLL, { _("トロル", "troll"), vault_aux_troll, std::nullopt, 20, 6 } },
-    { PitKind::GIANT, { _("巨人", "giant"), vault_aux_giant, std::nullopt, 50, 6 } },
-    { PitKind::LOVECRAFTIAN, { _("狂気", "lovecraftian"), vault_aux_cthulhu, std::nullopt, 80, 2 } },
-    { PitKind::SYMBOL_GOOD, { _("シンボル(善)", "symbol good"), vault_aux_symbol_g, vault_prep_symbol, 70, 1 } },
-    { PitKind::SYMBOL_EVIL, { _("シンボル(悪)", "symbol evil"), vault_aux_symbol_e, vault_prep_symbol, 70, 1 } },
-    { PitKind::CHAPEL, { _("教会", "chapel"), vault_aux_chapel_g, std::nullopt, 65, 2 } },
-    { PitKind::DRAGON, { _("ドラゴン", "dragon"), vault_aux_dragon, vault_prep_dragon, 70, 6 } },
-    { PitKind::DEMON, { _("デーモン", "demon"), vault_aux_demon, std::nullopt, 80, 6 } },
-    { PitKind::DARK_ELF, { _("ダークエルフ", "dark elf"), vault_aux_dark_elf, std::nullopt, 45, 4 } },
+    { PitKind::ORC, { _("オーク", "orc"), MonraceHook::ORC, std::nullopt, 5, 6 } },
+    { PitKind::TROLL, { _("トロル", "troll"), MonraceHook::TROLL, std::nullopt, 20, 6 } },
+    { PitKind::GIANT, { _("巨人", "giant"), MonraceHook::GIANT, std::nullopt, 50, 6 } },
+    { PitKind::LOVECRAFTIAN, { _("狂気", "lovecraftian"), MonraceHook::LOVECRAFTIAN, std::nullopt, 80, 2 } },
+    { PitKind::SYMBOL_GOOD, { _("シンボル(善)", "symbol good"), MonraceHook::GOOD, vault_prep_symbol, 70, 1 } },
+    { PitKind::SYMBOL_EVIL, { _("シンボル(悪)", "symbol evil"), MonraceHook::EVIL, vault_prep_symbol, 70, 1 } },
+    { PitKind::CHAPEL, { _("教会", "chapel"), MonraceHook::CHAPEL, std::nullopt, 65, 2 } },
+    { PitKind::DRAGON, { _("ドラゴン", "dragon"), MonraceHook::DRAGON, vault_prep_dragon, 70, 6 } },
+    { PitKind::DEMON, { _("デーモン", "demon"), MonraceHook::DEMON, std::nullopt, 80, 6 } },
+    { PitKind::DARK_ELF, { _("ダークエルフ", "dark elf"), MonraceHook::DARK_ELF, std::nullopt, 45, 4 } },
 };
 
 class TrappedMonster {
@@ -213,7 +213,7 @@ bool build_type6(PlayerType *player_ptr, DungeonData *dd_ptr)
         (*(pit.prep_func))(player_ptr);
     }
 
-    get_mon_num_prep(player_ptr, pit.hook_func);
+    get_mon_num_prep_enum(player_ptr, pit.hook);
     MonsterEntity align;
     align.sub_align = SUB_ALIGN_NEUTRAL;
 
@@ -359,7 +359,7 @@ bool build_type13(PlayerType *player_ptr, DungeonData *dd_ptr)
         (*(pit.prep_func))(player_ptr);
     }
 
-    get_mon_num_prep(player_ptr, pit.hook_func, MonraceHookTerrain::TRAPPED_PIT);
+    get_mon_num_prep_enum(player_ptr, pit.hook, MonraceHookTerrain::TRAPPED_PIT);
     MonsterEntity align;
     align.sub_align = SUB_ALIGN_NEUTRAL;
     auto whats = pick_pit_monraces(player_ptr, align);

--- a/src/system/enums/monrace/monrace-hook-types.h
+++ b/src/system/enums/monrace/monrace-hook-types.h
@@ -27,6 +27,22 @@ enum class MonraceHook {
     FISHING,
     QUEST,
     VAULT,
+    CLONE,
+    JELLY,
+    GOOD,
+    EVIL,
+    MIMIC,
+    LOVECRAFTIAN,
+    KENNEL,
+    ANIMAL,
+    CHAPEL,
+    UNDEAD,
+    ORC,
+    TROLL,
+    GIANT,
+    DRAGON,
+    DEMON,
+    DARK_ELF,
 };
 
 enum class MonraceHookTerrain {


### PR DESCRIPTION
これにてモンスター生成フィルタ周りの関数ポインタ絶滅が完了しました
ご確認下さい