### PR TITLE
AVX非対応CPUを検出したらエラーメッセージを出力する機構を追加した

### DIFF
--- a/VisualStudio/Hengband/Hengband.vcxproj
+++ b/VisualStudio/Hengband/Hengband.vcxproj
@@ -295,6 +295,7 @@
     <ClCompile Include="..\..\src\action\movement-execution.cpp" />
     <ClCompile Include="..\..\src\core\score-util.cpp" />
     <ClCompile Include="..\..\src\system\services\dungeon-monrace-service.cpp" />
+    <ClCompile Include="..\..\src\main-win\os-support-checker.cpp" />
     <ClCompile Include="..\..\src\system\services\dungeon-service.cpp" />
     <ClCompile Include="..\..\src\system\floor\floor-list.cpp" />
     <ClCompile Include="..\..\src\item-info\flavor-initializer.cpp" />
@@ -1018,6 +1019,7 @@
     <ClInclude Include="..\..\src\external-lib\include-json.h" />
     <ClInclude Include="..\..\src\external-lib\json.hpp" />
     <ClInclude Include="..\..\src\system\services\dungeon-monrace-service.h" />
+    <ClInclude Include="..\..\src\main-win\os-support-checker.h" />
     <ClInclude Include="..\..\src\system\services\dungeon-service.h" />
     <ClInclude Include="..\..\src\system\enums\dungeon\dungeon-id.h" />
     <ClInclude Include="..\..\src\system\enums\monrace\monrace-hook-types.h" />

--- a/VisualStudio/Hengband/Hengband.vcxproj.filters
+++ b/VisualStudio/Hengband/Hengband.vcxproj.filters
@@ -2556,6 +2556,9 @@
     <ClCompile Include="..\..\src\system\services\dungeon-monrace-service.cpp">
       <Filter>system\services</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\main-win\os-support-checker.cpp">
+      <Filter>main-win</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5546,6 +5549,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\system\services\dungeon-monrace-service.h">
       <Filter>system\services</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main-win\os-support-checker.h">
+      <Filter>main-win</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1088,6 +1088,7 @@ EXTRA_hengband_SOURCES = \
 	main-win/main-win-term.cpp main-win/main-win-term.h \
 	main-win/main-win-tokenizer.cpp main-win/main-win-tokenizer.h \
 	main-win/main-win-utils.cpp main-win/main-win-utils.h \
+	main-win/os-support-checker.cpp main-win/os-support-checker.h \
 	main-win/stack-trace-win.cpp \
 	main-win/wav-reader.cpp main-win/wav-reader.h \
 	test/test-sha256.cpp \

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -1144,7 +1144,7 @@ static errr term_text_win(int x, int y, int n, TERM_COLOR a, concptr s)
             rc.right += 2 * td->tile_wid;
         } else if (iskanji(*(s + i))) /* 2バイト文字 */
         {
-            char tmp[] = { *(s + i), *(s + i + 1), '\0' };
+            std::string tmp = { *(s + i), *(s + i + 1), '\0' };
             to_wchar wc(tmp);
             const auto *buf = wc.wc_str();
             rc.right += td->font_wid;
@@ -1373,7 +1373,8 @@ static void init_windows(void)
     /* Font of each window */
     for (int i = 0; i < MAX_TERM_DATA; i++) {
         td = &data[i];
-        wcsncpy(td->lf.lfFaceName, to_wchar(td->font_want).wc_str(), LF_FACESIZE);
+        const std::string font(td->font_want != NULL ? td->font_want : "");
+        wcsncpy(td->lf.lfFaceName, to_wchar(font).wc_str(), LF_FACESIZE);
         td->lf.lfCharSet = _(SHIFTJIS_CHARSET, DEFAULT_CHARSET);
         td->lf.lfPitchAndFamily = FIXED_PITCH | FF_DONTCARE;
         term_force_font(td);
@@ -2582,7 +2583,7 @@ static LRESULT PASCAL AngbandListProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 static void hook_plog(std::string_view str)
 {
     if (!str.empty()) {
-        MessageBoxW(data[0].w, to_wchar(str.data()).wc_str(), _(L"警告！", L"Warning"), MB_ICONEXCLAMATION | MB_OK);
+        MessageBoxW(data[0].w, to_wchar(str).wc_str(), _(L"警告！", L"Warning"), MB_ICONEXCLAMATION | MB_OK);
     }
 }
 
@@ -2592,7 +2593,7 @@ static void hook_plog(std::string_view str)
 static void hook_quit(std::string_view str)
 {
     if (!str.empty()) {
-        MessageBoxW(data[0].w, to_wchar(str.data()).wc_str(), _(L"エラー！", L"Error"), MB_ICONEXCLAMATION | MB_OK | MB_ICONSTOP);
+        MessageBoxW(data[0].w, to_wchar(str).wc_str(), _(L"エラー！", L"Error"), MB_ICONEXCLAMATION | MB_OK | MB_ICONSTOP);
     }
 
     save_prefs();
@@ -2773,12 +2774,12 @@ static int WINAPI game_main(_In_ HINSTANCE hInst)
     // before term_data initialize
     plog_aux = [](std::string_view str) {
         if (!str.empty()) {
-            MessageBoxW(NULL, to_wchar(str.data()).wc_str(), _(L"警告！", L"Warning"), MB_ICONEXCLAMATION | MB_OK);
+            MessageBoxW(NULL, to_wchar(str).wc_str(), _(L"警告！", L"Warning"), MB_ICONEXCLAMATION | MB_OK);
         }
     };
     quit_aux = [](std::string_view str) {
         if (!str.empty()) {
-            MessageBoxW(NULL, to_wchar(str.data()).wc_str(), _(L"エラー！", L"Error"), MB_ICONEXCLAMATION | MB_OK | MB_ICONSTOP);
+            MessageBoxW(NULL, to_wchar(str).wc_str(), _(L"エラー！", L"Error"), MB_ICONEXCLAMATION | MB_OK | MB_ICONSTOP);
         }
 
         UnregisterClassW(AppName, hInstance);
@@ -2857,13 +2858,13 @@ int WINAPI WinMain(
     const auto message = OsSupportChecker::check_avx_enabled();
 #ifdef WIN_DEBUG
     if (message) {
-        MessageBoxW(NULL, to_wchar(message->data()).wc_str(), _(L"警告！", L"Warning"), MB_ICONEXCLAMATION | MB_OK);
+        MessageBoxW(NULL, to_wchar(*message).wc_str(), _(L"警告！", L"Warning"), MB_ICONEXCLAMATION | MB_OK);
     }
 
     return game_main(hInst);
 #else
     if (message) {
-        MessageBoxW(NULL, to_wchar(message->data()).wc_str(), _(L"エラー！", L"Error"), MB_ICONERROR | MB_OK);
+        MessageBoxW(NULL, to_wchar(*message).wc_str(), _(L"エラー！", L"Error"), MB_ICONERROR | MB_OK);
         quit("");
     }
 

--- a/src/main-win.cpp
+++ b/src/main-win.cpp
@@ -109,6 +109,7 @@
 #include "main-win/main-win-sound.h"
 #include "main-win/main-win-term.h"
 #include "main-win/main-win-utils.h"
+#include "main-win/os-support-checker.h"
 #include "main/angband-initializer.h"
 #include "main/sound-of-music.h"
 #include "monster-floor/monster-lite.h"
@@ -2853,9 +2854,19 @@ static int WINAPI game_main(_In_ HINSTANCE hInst)
 int WINAPI WinMain(
     _In_ HINSTANCE hInst, _In_opt_ HINSTANCE, _In_ LPSTR, _In_ int)
 {
+    const auto message = OsSupportChecker::check_avx_enabled();
 #ifdef WIN_DEBUG
+    if (message) {
+        MessageBoxW(NULL, to_wchar(message->data()).wc_str(), _(L"警告！", L"Warning"), MB_ICONEXCLAMATION | MB_OK);
+    }
+
     return game_main(hInst);
 #else
+    if (message) {
+        MessageBoxW(NULL, to_wchar(message->data()).wc_str(), _(L"エラー！", L"Error"), MB_ICONERROR | MB_OK);
+        quit("");
+    }
+
     try {
         return game_main(hInst);
     } catch (const std::exception &e) {

--- a/src/main-win/graphics-win.cpp
+++ b/src/main-win/graphics-win.cpp
@@ -53,16 +53,13 @@ static void finalize_gdi_plus()
     }
 }
 
-HBITMAP read_graphic(const char *filename)
+HBITMAP read_graphic(const std::filesystem::path &path)
 {
-    HBITMAP result = NULL;
     init_gdi_plus();
-
-    Gdiplus::Bitmap bitmap(to_wchar(filename).wc_str());
-
+    Gdiplus::Bitmap bitmap(to_wchar(path.string()).wc_str());
     COLORREF bgcolor = RGB(0x00, 0x00, 0x00);
+    HBITMAP result = NULL;
     bitmap.GetHBITMAP(bgcolor, &result);
-
     return result;
 }
 
@@ -117,8 +114,7 @@ graphics_mode change_graphics(graphics_mode arg)
     }
 
     const auto path = path_build(ANGBAND_DIR_XTRA_GRAF, name);
-    const auto filename = path.string();
-    infGraph.hBitmap = read_graphic(filename.data());
+    infGraph.hBitmap = read_graphic(path);
     if (!infGraph.hBitmap) {
         plog_fmt(_("ビットマップ '%s' を読み込めません。", "Cannot read bitmap file '%s'"), name.data());
         ANGBAND_GRAF = "ascii";
@@ -139,8 +135,7 @@ graphics_mode change_graphics(graphics_mode arg)
     }
 
     const auto path_mask = path_build(ANGBAND_DIR_XTRA_GRAF, name_mask);
-    const auto filename_mask = path_mask.string();
-    infGraph.hBitmapMask = read_graphic(filename_mask.data());
+    infGraph.hBitmapMask = read_graphic(path_mask);
     if (infGraph.hBitmapMask) {
         current_graphics_mode = arg;
         return arg;

--- a/src/main-win/graphics-win.h
+++ b/src/main-win/graphics-win.h
@@ -114,4 +114,4 @@ extern std::filesystem::path ANGBAND_DIR_XTRA_GRAF;
  * @param filename an image file name
  * @return bitmap handle
  */
-HBITMAP read_graphic(const char *filename);
+HBITMAP read_graphic(const std::filesystem::path &path);

--- a/src/main-win/main-win-bg.cpp
+++ b/src/main-win/main-win-bg.cpp
@@ -30,8 +30,7 @@ void delete_bg(void)
 bool load_bg(const std::filesystem::path &path)
 {
     delete_bg();
-    const auto &filename = path.string();
-    hBG = read_graphic(filename.data());
+    hBG = read_graphic(path);
 
     return hBG != NULL;
 }

--- a/src/main-win/main-win-exception.cpp
+++ b/src/main-win/main-win-exception.cpp
@@ -28,7 +28,7 @@ void handle_unexpected_exception(const std::exception &e)
 #if !defined(DISABLE_NET)
     std::wstringstream report_confirm_msg_ss;
     report_confirm_msg_ss
-        << to_wchar(first_line.data()).wc_str() << L"\n\n"
+        << to_wchar(first_line).wc_str() << L"\n\n"
         << _(L"開発チームにエラー情報を送信してよろしいですか？\n", L"Are you sure you want to send the error information to the development team?\n")
         << _(L"※送信されるのはゲーム内の情報のみであり、個人情報が送信されることはありません。\n",
                L"Only in-game information will be sent. No personal information will be sent.\n");

--- a/src/main-win/main-win-music.cpp
+++ b/src/main-win/main-win-music.cpp
@@ -130,9 +130,9 @@ static std::optional<std::string> monster_key_at(int index)
 void load_music_prefs()
 {
     CfgReader reader(ANGBAND_DIR_XTRA_MUSIC, { "music_debug.cfg", "music.cfg" });
-
-    char device_type[256];
-    GetPrivateProfileStringA("Device", "type", "MPEGVideo", device_type, _countof(device_type), reader.get_cfg_path().string().data());
+    constexpr auto size = 256;
+    char device_type[size];
+    GetPrivateProfileStringA("Device", "type", "MPEGVideo", device_type, size, reader.get_cfg_path().string().data());
     mci_device_type = to_wchar(device_type).wc_str();
 
     // clang-format off

--- a/src/main-win/main-win-utils.h
+++ b/src/main-win/main-win-utils.h
@@ -16,18 +16,18 @@
  */
 class to_wchar {
 public:
-    to_wchar(const char *src)
+    to_wchar(std::string_view src)
     {
-        if (!src) {
+        if (src.empty()) {
             return;
         }
 
-        int size = ::MultiByteToWideChar(932, 0, src, -1, NULL, 0);
+        const auto size = ::MultiByteToWideChar(932, 0, src.data(), src.length(), NULL, 0);
         if (size > 0) {
-            buf = std::vector<WCHAR>(size + 1);
-            if (::MultiByteToWideChar(932, 0, src, -1, (*buf).data(), (*buf).size()) == 0) {
+            this->buf = std::vector<WCHAR>(size + 1);
+            if (::MultiByteToWideChar(932, 0, src.data(), src.length(), this->buf->data(), this->buf->size()) == 0) {
                 // fail
-                buf = std::nullopt;
+                this->buf = std::nullopt;
             }
         }
     }
@@ -39,7 +39,7 @@ public:
 
     WCHAR *wc_str()
     {
-        return buf ? (*buf).data() : NULL;
+        return this->buf ? this->buf->data() : NULL;
     }
 
 protected:
@@ -53,16 +53,16 @@ class to_multibyte {
 public:
     to_multibyte(const WCHAR *src)
     {
-        if (!src) {
+        if (src == nullptr) {
             return;
         }
 
-        int size = ::WideCharToMultiByte(932, 0, src, -1, NULL, 0, NULL, NULL);
+        const auto size = ::WideCharToMultiByte(932, 0, src, -1, NULL, 0, NULL, NULL);
         if (size > 0) {
-            buf = std::vector<char>(size + 1);
-            if (::WideCharToMultiByte(932, 0, src, -1, (*buf).data(), (*buf).size(), NULL, NULL) == 0) {
+            this->buf = std::vector<char>(size + 1);
+            if (::WideCharToMultiByte(932, 0, src, -1, this->buf->data(), this->buf->size(), NULL, NULL) == 0) {
                 // fail
-                buf = std::nullopt;
+                this->buf = std::nullopt;
             }
         }
     }
@@ -74,7 +74,7 @@ public:
 
     char *c_str()
     {
-        return buf ? (*buf).data() : NULL;
+        return this->buf ? this->buf->data() : NULL;
     }
 
 protected:

--- a/src/main-win/os-support-checker.cpp
+++ b/src/main-win/os-support-checker.cpp
@@ -1,0 +1,54 @@
+/*!
+ * @brief OSやハードウェアレベルのサポート状況チェック実装
+ * @author Hourier
+ * @date 2025/01/08
+ */
+
+#include "main-win/os-support-checker.h"
+#include "locale/language-switcher.h"
+#include <intrin.h>
+#include <sstream>
+
+/*!
+ * @brief CPUの機能チェック (AVX)
+ * @return CPUとOSがAVXをサポートしており、BIOSレベルで有効化されていればnullopt。そうでないならエラーメッセージ
+ * @details 本ファイル作成現在、Windows 10 22H2、Windows 11 23H2、Windows 11 24H2 の3バージョンがサポート中である。
+ * これら全てが、AVX2対応CPUのみをサポートしている。
+ * Intel w/Win10：Haswell Refresh / Broadwell (Core i 5000番台)以降
+ * Intel w/Win11：Kaby Lake Refresh / Coffee Lake (Core i 8000番台)以降
+ * AMD w/Win10：Bulldozer (FX4000番台)以降
+ * AMD w/Win11：Raven Ridge / Pinnacle Ridge (Ryzen 2000番台)以降
+ *
+ * @todo AVX2は64ビットバイナリが推奨である。
+ * 32ビットバイナリは将来に亘ってAVXまでの有効化に留める予定。開発チームとして32ビットバイナリのサポート終了時期は未定。
+ * 64ビットバイナリを安定的に供給できる見込みが立ったら、こちらはAVX2まで有効化する。
+ */
+std::optional<std::string> OsSupportChecker::check_avx_enabled()
+{
+    int cpuInfo[4]{};
+    __cpuid(cpuInfo, 1);
+    const auto is_cpu_supporting_avx = (cpuInfo[2] & (1 << 28)) != 0;
+    const auto is_os_supporting_avx = (cpuInfo[2] & (1 << 27)) != 0;
+    if (is_cpu_supporting_avx && is_os_supporting_avx) {
+        const auto feature_mask = _xgetbv(_XCR_XFEATURE_ENABLED_MASK);
+        if ((feature_mask & 0x06) == 0x06) {
+            return std::nullopt;
+        }
+    }
+
+#ifdef WIN_DEBUG
+    return _("AVX非対応CPUはデバッグモードでのみ起動可能です。", "CPUs which don't support AVX can only be started in Debug mode.");
+#else
+    std::stringstream ss;
+#ifdef JP
+    ss << "お使いのコンピュータにはAVX非対応CPUが搭載されています。" << '\n'
+       << "マイクロソフト社は既に当該CPU群のサポートを全て打ち切っています。" << '\n'
+       << "本ソフトウェアはAVXを必要としており、起動できません。";
+#else
+    ss << "This CPU doesn't support AVX." << '\n'
+       << "Microsoft has dropped support for such CPUs." << '\n'
+       << "This software requires AVX and cannot be started.";
+#endif
+    return ss.str();
+#endif
+}

--- a/src/main-win/os-support-checker.h
+++ b/src/main-win/os-support-checker.h
@@ -1,0 +1,15 @@
+/*!
+ * @brief OSやハードウェアレベルのサポート状況チェック定義
+ * @author Hourier
+ * @date 2025/01/08
+ */
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+class OsSupportChecker {
+public:
+    static std::optional<std::string> check_avx_enabled();
+};

--- a/src/util/angband-files.cpp
+++ b/src/util/angband-files.cpp
@@ -173,7 +173,7 @@ std::filesystem::path path_build(const std::filesystem::path &path, std::string_
 #ifdef WINDOWS
     // システムロケールがUTF-8の場合、appendによるUTF-16への変換時に
     // Shift-JISをUTF-8とみなしてしまい変換に失敗するので、自前でUTF-16に変換してからappendする
-    const auto &path_ret = parsed_path.append(to_wchar(file.data()).wc_str());
+    const auto &path_ret = parsed_path.append(to_wchar(file).wc_str());
 #else
     const auto &path_ret = parsed_path.append(file);
 #endif


### PR DESCRIPTION
手持ちPCにAVX非対応CPU (Nehalem/Westmere以前)がないので正常系チェックしかできていないですが、過去のチケット報告者に見てもらうことは可能かと思います
理論上「AVX対応CPUをBIOSで無効化」という変なパターンもあるらしいですが、メーカ製PCでそんなことはあり得えないはずです (自作erは絶対何か設定弄ってるから自分で頑張れ)
ご確認下さい