### PR TITLE
[Fix] 合体ユニークの倒した数の記録の扱いがあいまい

### DIFF
--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -142,10 +142,6 @@ bool MonsterDamageProcessor::process_dead_exp_virtue(std::string_view note, cons
     }
 
     this->death_special_flag_monster();
-    if (monrace.r_akills < MAX_SHORT) {
-        monrace.r_akills++;
-    }
-
     this->increase_kill_numbers();
     const auto m_name = monster_desc(this->player_ptr, &monster, MD_TRUE_NAME);
     this->death_amberites(m_name);
@@ -212,22 +208,21 @@ void MonsterDamageProcessor::increase_kill_numbers()
 {
     auto &monster = this->player_ptr->current_floor_ptr->m_list[this->m_idx];
     auto &monrace = monster.get_real_monrace();
-    auto is_hallucinated = this->player_ptr->effects()->hallucination().is_hallucinated();
+    monrace.increment_akills();
+
+    const auto is_hallucinated = this->player_ptr->effects()->hallucination().is_hallucinated();
     if (((monster.ml == 0) || is_hallucinated) && monrace.kind_flags.has_not(MonsterKindType::UNIQUE)) {
         return;
     }
 
-    auto &shadower = MonraceList::get_instance().get_monrace(MonraceId::KAGE);
-    if (monster.mflag2.has(MonsterConstantFlagType::KAGE) && (shadower.r_pkills < MAX_SHORT)) {
-        shadower.r_pkills++;
-    } else if (monrace.r_pkills < MAX_SHORT) {
-        monrace.r_pkills++;
-    }
-
-    if (monster.mflag2.has(MonsterConstantFlagType::KAGE) && (shadower.r_tkills < MAX_SHORT)) {
-        shadower.r_tkills++;
-    } else if (monrace.r_tkills < MAX_SHORT) {
-        monrace.r_tkills++;
+    auto &monraces = MonraceList::get_instance();
+    if (monster.mflag2.has(MonsterConstantFlagType::KAGE)) {
+        auto &shadower = monraces.get_monrace(MonraceId::KAGE);
+        shadower.increment_pkills();
+        shadower.increment_tkills();
+    } else {
+        monrace.increment_pkills();
+        monrace.increment_tkills();
     }
 
     LoreTracker::get_instance().set_trackee(monster.ap_r_idx);

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -178,11 +178,6 @@ std::optional<bool> MonraceDefinition::order_pet(const MonraceDefinition &other)
 void MonraceDefinition::kill_unique()
 {
     this->max_num = 0;
-    this->r_pkills++;
-    this->r_akills++;
-    if (this->r_tkills < MAX_SHORT) {
-        this->r_tkills++;
-    }
 }
 
 std::string MonraceDefinition::get_pronoun_of_summoned_kin() const
@@ -588,6 +583,27 @@ void MonraceDefinition::reset_max_number()
     }
 
     this->max_num = MAX_MONSTER_NUM;
+}
+
+void MonraceDefinition::increment_akills()
+{
+    if (this->r_akills < MAX_SHORT) {
+        this->r_akills++;
+    }
+}
+
+void MonraceDefinition::increment_pkills()
+{
+    if (this->r_pkills < MAX_SHORT) {
+        this->r_pkills++;
+    }
+}
+
+void MonraceDefinition::increment_tkills()
+{
+    if (this->r_tkills < MAX_SHORT) {
+        this->r_tkills++;
+    }
 }
 
 /*!

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -177,6 +177,10 @@ public:
     void decrement_current_numbers();
     void reset_max_number();
 
+    void increment_akills();
+    void increment_pkills();
+    void increment_tkills();
+
 private:
     std::vector<DropArtifact> drop_artifacts; //!< 特定アーティファクトドロップリスト
     std::vector<Reinforce> reinforces; //!< 指定護衛リスト

--- a/src/system/monrace/monrace-list.cpp
+++ b/src/system/monrace/monrace-list.cpp
@@ -214,7 +214,6 @@ void MonraceList::kill_unified_unique(const MonraceId r_idx)
 {
     const auto it_unique = unified_uniques.find(r_idx);
     if (it_unique != unified_uniques.end()) {
-        this->get_monrace(it_unique->first).kill_unique();
         for (const auto separate : it_unique->second) {
             this->get_monrace(separate).kill_unique();
         }
@@ -223,9 +222,7 @@ void MonraceList::kill_unified_unique(const MonraceId r_idx)
     }
 
     for (const auto &[unified_unique, separates] : unified_uniques) {
-        const auto it_separate = separates.find(r_idx);
-        if (it_separate != separates.end()) {
-            this->get_monrace(*it_separate).kill_unique();
+        if (separates.contains(r_idx)) {
             this->get_monrace(unified_unique).kill_unique();
             return;
         }
@@ -479,7 +476,7 @@ std::optional<std::string> MonraceList::probe_lore(MonraceId monrace_id)
  */
 void MonraceList::kill_unique_monster(MonraceId monrace_id)
 {
-    this->get_monrace(monrace_id).max_num = 0;
+    this->get_monrace(monrace_id).kill_unique();
     if (this->can_unify_separate(monrace_id)) {
         this->kill_unified_unique(monrace_id);
     }


### PR DESCRIPTION
現状合体ユニークを倒した時、合体先・分離先のモンスターも死亡済みにする処理においてあわせて倒した数の記録も増やされるようになっているが、やや不自然な挙動なので合体先・分離先のモンスターは死亡済みにする処理のみを行い、倒した数の記録を増やすのは実際に倒した対象のみとする。

Resolves #4805 
Fix #4800 