### PR TITLE
モンスター生成フィルタ用のグローバル関数解体 その1 (B案)

### DIFF
--- a/VisualStudio/Hengband/Hengband.vcxproj
+++ b/VisualStudio/Hengband/Hengband.vcxproj
@@ -294,6 +294,7 @@
     <ClCompile Include="..\..\src\cmd-action\cmd-tunnel.cpp" />
     <ClCompile Include="..\..\src\action\movement-execution.cpp" />
     <ClCompile Include="..\..\src\core\score-util.cpp" />
+    <ClCompile Include="..\..\src\system\services\dungeon-monrace-service.cpp" />
     <ClCompile Include="..\..\src\system\services\dungeon-service.cpp" />
     <ClCompile Include="..\..\src\system\floor\floor-list.cpp" />
     <ClCompile Include="..\..\src\item-info\flavor-initializer.cpp" />
@@ -1016,6 +1017,7 @@
     <ClInclude Include="..\..\src\action\run-execution.h" />
     <ClInclude Include="..\..\src\external-lib\include-json.h" />
     <ClInclude Include="..\..\src\external-lib\json.hpp" />
+    <ClInclude Include="..\..\src\system\services\dungeon-monrace-service.h" />
     <ClInclude Include="..\..\src\system\services\dungeon-service.h" />
     <ClInclude Include="..\..\src\system\enums\dungeon\dungeon-id.h" />
     <ClInclude Include="..\..\src\system\enums\monrace\monrace-hook-types.h" />

--- a/VisualStudio/Hengband/Hengband.vcxproj.filters
+++ b/VisualStudio/Hengband/Hengband.vcxproj.filters
@@ -2553,6 +2553,9 @@
     <ClCompile Include="..\..\src\wizard\monrace-filter-debug-info.cpp">
       <Filter>wizard</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\system\services\dungeon-monrace-service.cpp">
+      <Filter>system\services</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5540,6 +5543,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\wizard\monrace-filter-debug-info.h">
       <Filter>wizard</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\services\dungeon-monrace-service.h">
+      <Filter>system\services</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -959,6 +959,7 @@ hengband_SOURCES = \
 	\
 	system/services/baseitem-monrace-service.cpp system/services/baseitem-monrace-service.h \
 	system/services/dungeon-service.cpp system/services/dungeon-service.h \
+	system/services/dungeon-monrace-service.cpp system/services/dungeon-monrace-service.h \
 	\
 	system/terrain/terrain-definition.cpp system/terrain/terrain-definition.h \
 	system/terrain/terrain-list.cpp system/terrain/terrain-list.h \

--- a/src/monster-race/monster-race-hook.cpp
+++ b/src/monster-race/monster-race-hook.cpp
@@ -15,6 +15,7 @@
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
 #include "system/player-type-definition.h"
+#include "system/services/dungeon-monrace-service.h"
 #include "util/bit-flags-calculator.h"
 #include "util/string-processor.h"
 #include <set>
@@ -77,39 +78,6 @@ void vault_prep_dragon(PlayerType *player_ptr)
     }
 
     vault_aux_dragon_mask4.set(rand_choice(breath_list));
-}
-
-/*!
- * @brief モンスターがダンジョンに出現するかどうかを返す
- * @param r_idx 判定するモンスターの種族ID
- * @return ダンジョンに出現するならばTRUEを返す
- * @details
- * <pre>
- * 地上は常にTRUE(荒野の出現は別hookで絞るため)。
- * 荒野限定(WILD_ONLY)の場合、荒野の山に出るモンスターにのみダンジョンの山に出現を許可する。
- * その他の場合、山及び火山以外のダンジョンでは全てのモンスターに出現を許可する。
- * ダンジョンが山の場合は、荒野の山(WILD_MOUNTAIN)に出ない水棲動物(AQUATIC)は許可しない。
- * ダンジョンが火山の場合は、荒野の火山(WILD_VOLCANO)に出ない水棲動物(AQUATIC)は許可しない。
- * </pre>
- */
-bool mon_hook_dungeon(PlayerType *player_ptr, MonraceId r_idx)
-{
-    const auto &floor = *player_ptr->current_floor_ptr;
-    if (!floor.is_underground() && !floor.is_in_quest()) {
-        return true;
-    }
-
-    auto *r_ptr = &monraces_info[r_idx];
-    DungeonDefinition *d_ptr = &floor.get_dungeon_definition();
-    if (r_ptr->wilderness_flags.has(MonsterWildernessType::WILD_ONLY)) {
-        return d_ptr->mon_wilderness_flags.has(MonsterWildernessType::WILD_MOUNTAIN) && r_ptr->wilderness_flags.has(MonsterWildernessType::WILD_MOUNTAIN);
-    }
-
-    auto land = r_ptr->feature_flags.has_not(MonsterFeatureType::AQUATIC);
-    auto is_mountain_monster = d_ptr->mon_wilderness_flags.has_none_of({ MonsterWildernessType::WILD_MOUNTAIN, MonsterWildernessType::WILD_VOLCANO });
-    is_mountain_monster |= d_ptr->mon_wilderness_flags.has(MonsterWildernessType::WILD_MOUNTAIN) && (land || r_ptr->wilderness_flags.has(MonsterWildernessType::WILD_MOUNTAIN));
-    is_mountain_monster |= d_ptr->mon_wilderness_flags.has(MonsterWildernessType::WILD_VOLCANO) && (land || r_ptr->wilderness_flags.has(MonsterWildernessType::WILD_VOLCANO));
-    return is_mountain_monster;
 }
 
 /*!
@@ -231,12 +199,13 @@ bool mon_hook_grass(PlayerType *player_ptr, MonraceId r_idx)
  */
 bool mon_hook_deep_water(PlayerType *player_ptr, MonraceId r_idx)
 {
-    auto *r_ptr = &monraces_info[r_idx];
-    if (!mon_hook_dungeon(player_ptr, r_idx)) {
+    const auto &monrace = monraces_info[r_idx];
+    const auto &floor = *player_ptr->current_floor_ptr;
+    if (floor.is_underground() && !DungeonMonraceService::is_suitable_for_dungeon(floor.dungeon_id, r_idx)) {
         return false;
     }
 
-    return r_ptr->feature_flags.has(MonsterFeatureType::AQUATIC);
+    return monrace.feature_flags.has(MonsterFeatureType::AQUATIC);
 }
 
 /*!
@@ -246,12 +215,13 @@ bool mon_hook_deep_water(PlayerType *player_ptr, MonraceId r_idx)
  */
 bool mon_hook_shallow_water(PlayerType *player_ptr, MonraceId r_idx)
 {
-    auto *r_ptr = &monraces_info[r_idx];
-    if (!mon_hook_dungeon(player_ptr, r_idx)) {
+    const auto &monrace = monraces_info[r_idx];
+    const auto &floor = *player_ptr->current_floor_ptr;
+    if (floor.is_underground() && !DungeonMonraceService::is_suitable_for_dungeon(floor.dungeon_id, r_idx)) {
         return false;
     }
 
-    return r_ptr->aura_flags.has_not(MonsterAuraType::FIRE);
+    return monrace.aura_flags.has_not(MonsterAuraType::FIRE);
 }
 
 /*!
@@ -261,12 +231,13 @@ bool mon_hook_shallow_water(PlayerType *player_ptr, MonraceId r_idx)
  */
 bool mon_hook_lava(PlayerType *player_ptr, MonraceId r_idx)
 {
-    auto *r_ptr = &monraces_info[r_idx];
-    if (!mon_hook_dungeon(player_ptr, r_idx)) {
+    const auto &monrace = monraces_info[r_idx];
+    const auto &floor = *player_ptr->current_floor_ptr;
+    if (floor.is_underground() && !DungeonMonraceService::is_suitable_for_dungeon(floor.dungeon_id, r_idx)) {
         return false;
     }
 
-    return (r_ptr->resistance_flags.has_any_of(RFR_EFF_IM_FIRE_MASK) || r_ptr->feature_flags.has(MonsterFeatureType::CAN_FLY)) && r_ptr->aura_flags.has_not(MonsterAuraType::COLD);
+    return (monrace.resistance_flags.has_any_of(RFR_EFF_IM_FIRE_MASK) || monrace.feature_flags.has(MonsterFeatureType::CAN_FLY)) && monrace.aura_flags.has_not(MonsterAuraType::COLD);
 }
 
 /*!
@@ -867,7 +838,8 @@ bool item_monster_okay(PlayerType *player_ptr, MonraceId r_idx)
 bool vault_monster_okay(PlayerType *player_ptr, MonraceId r_idx)
 {
     const auto &monrace = monraces_info[r_idx];
-    auto is_valid = mon_hook_dungeon(player_ptr, r_idx);
+    const auto &floor = *player_ptr->current_floor_ptr;
+    auto is_valid = !floor.is_underground() || DungeonMonraceService::is_suitable_for_dungeon(floor.dungeon_id, r_idx);
     is_valid &= monrace.kind_flags.has_not(MonsterKindType::UNIQUE);
     is_valid &= monrace.population_flags.has_not(MonsterPopulationType::ONLY_ONE);
     is_valid &= monrace.resistance_flags.has_not(MonsterResistanceType::RESIST_ALL);

--- a/src/monster-race/monster-race-hook.cpp
+++ b/src/monster-race/monster-race-hook.cpp
@@ -80,53 +80,6 @@ void vault_prep_dragon(PlayerType *player_ptr)
 }
 
 /*!
- * @brief モンスター種族がランダムクエストの討伐対象に成り得るかを返す
- * @param r_idx モンスター種族ID
- * @return 討伐対象にできるならTRUEを返す。
- */
-bool mon_hook_quest(PlayerType *player_ptr, MonraceId r_idx)
-{
-    /* Unused */
-    (void)player_ptr;
-
-    const auto &monraces = MonraceList::get_instance();
-    const auto &monrace = monraces.get_monrace(r_idx);
-    if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE)) {
-        return false;
-    }
-
-    if (monrace.misc_flags.has(MonsterMiscType::NO_QUEST)) {
-        return false;
-    }
-
-    if (monrace.misc_flags.has(MonsterMiscType::QUESTOR)) {
-        return false;
-    }
-
-    if (monrace.rarity > 100) {
-        return false;
-    }
-
-    if (monrace.wilderness_flags.has(MonsterWildernessType::WILD_ONLY)) {
-        return false;
-    }
-
-    if (monrace.feature_flags.has(MonsterFeatureType::AQUATIC)) {
-        return false;
-    }
-
-    if (monrace.misc_flags.has(MonsterMiscType::MULTIPLY)) {
-        return false;
-    }
-
-    if (monrace.behavior_flags.has(MonsterBehaviorType::FRIENDLY)) {
-        return false;
-    }
-
-    return true;
-}
-
-/*!
  * @brief モンスターがダンジョンに出現するかどうかを返す
  * @param r_idx 判定するモンスターの種族ID
  * @return ダンジョンに出現するならばTRUEを返す

--- a/src/monster-race/monster-race-hook.h
+++ b/src/monster-race/monster-race-hook.h
@@ -10,7 +10,6 @@ extern char vault_aux_char;
 extern EnumClassFlagGroup<MonsterAbilityType> vault_aux_dragon_mask4;
 
 class PlayerType;
-bool mon_hook_quest(PlayerType *player_ptr, MonraceId r_idx);
 bool mon_hook_dungeon(PlayerType *player_ptr, MonraceId r_idx);
 bool mon_hook_ocean(PlayerType *player_ptr, MonraceId r_idx);
 bool mon_hook_shore(PlayerType *player_ptr, MonraceId r_idx);

--- a/src/monster-race/monster-race-hook.h
+++ b/src/monster-race/monster-race-hook.h
@@ -10,7 +10,6 @@ extern char vault_aux_char;
 extern EnumClassFlagGroup<MonsterAbilityType> vault_aux_dragon_mask4;
 
 class PlayerType;
-bool mon_hook_dungeon(PlayerType *player_ptr, MonraceId r_idx);
 bool mon_hook_ocean(PlayerType *player_ptr, MonraceId r_idx);
 bool mon_hook_shore(PlayerType *player_ptr, MonraceId r_idx);
 bool mon_hook_waste(PlayerType *player_ptr, MonraceId r_idx);

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -192,6 +192,7 @@ MonraceHook get_monster_hook(const Pos2D &pos_wilderness, bool is_underground)
 
 static bool do_hook(PlayerType *player_ptr, MonraceHook hook, MonraceId monrace_id)
 {
+    const auto &monrace = MonraceList::get_instance().get_monrace(monrace_id);
     switch (hook) {
     case MonraceHook::NONE:
     case MonraceHook::DUNGEON:
@@ -225,7 +226,6 @@ static bool do_hook(PlayerType *player_ptr, MonraceHook hook, MonraceId monrace_
     case MonraceHook::SHARDS:
         return vault_aux_shards(player_ptr, monrace_id);
     case MonraceHook::TANUKI: {
-        const auto &monrace = MonraceList::get_instance().get_monrace(monrace_id);
         auto unselectable = monrace.kind_flags.has(MonsterKindType::UNIQUE);
         unselectable |= monrace.misc_flags.has(MonsterMiscType::MULTIPLY);
         unselectable |= monrace.behavior_flags.has(MonsterBehaviorType::FRIENDLY);
@@ -244,7 +244,7 @@ static bool do_hook(PlayerType *player_ptr, MonraceHook hook, MonraceId monrace_
     case MonraceHook::FISHING:
         return monster_is_fishing_target(player_ptr, monrace_id);
     case MonraceHook::QUEST:
-        return mon_hook_quest(player_ptr, monrace_id);
+        return monrace.is_suitable_for_random_quest();
     case MonraceHook::VAULT:
         return vault_monster_okay(player_ptr, monrace_id);
     case MonraceHook::CLONE:

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -388,10 +388,7 @@ void get_mon_num_prep_enum(PlayerType *player_ptr, MonraceHook hook1, MonraceHoo
         const auto in_random_quest = floor.is_in_quest() && !QuestType::is_fixed(floor.quest_number);
         const auto cond = !system.is_phase_out() && floor.is_underground() && !in_random_quest;
         if (cond && !restrict_monster_to_dungeon(dungeon, dungeon_level, monrace_id)) {
-            const int numer = entry.prob2 * dungeon.special_div;
-            const int q = numer / 64;
-            const int r = numer % 64;
-            entry.prob2 = static_cast<short>(randint0(64) < r ? q + 1 : q);
+            entry.update_prob2(dungeon.special_div);
         }
 
         mfdi.update(entry.prob2, entry.level);
@@ -496,10 +493,7 @@ void get_mon_num_prep_escort(PlayerType *player_ptr, MonraceId escorted_monrace_
         const auto in_random_quest = floor.is_in_quest() && !QuestType::is_fixed(floor.quest_number);
         const auto cond = !system.is_phase_out() && floor.is_underground() && !in_random_quest;
         if (cond && !restrict_monster_to_dungeon(dungeon, dungeon_level, monrace_id)) {
-            const int numer = entry.prob2 * dungeon.special_div;
-            const int q = numer / 64;
-            const int r = numer % 64;
-            entry.prob2 = static_cast<short>(randint0(64) < r ? q + 1 : q);
+            entry.update_prob2(dungeon.special_div);
         }
 
         mfdi.update(entry.prob2, entry.level);
@@ -604,10 +598,7 @@ void get_mon_num_prep_summon(PlayerType *player_ptr, const SummonCondition &cond
         const auto in_random_quest = floor.is_in_quest() && !QuestType::is_fixed(floor.quest_number);
         const auto cond = !system.is_phase_out() && floor.is_underground() && !in_random_quest;
         if (cond && !restrict_monster_to_dungeon(dungeon, dungeon_level, monrace_id, true)) {
-            const int numer = entry.prob2 * dungeon.special_div;
-            const int q = numer / 64;
-            const int r = numer % 64;
-            entry.prob2 = static_cast<short>(randint0(64) < r ? q + 1 : q);
+            entry.update_prob2(dungeon.special_div);
         }
 
         mfdi.update(entry.prob2, entry.level);
@@ -744,10 +735,7 @@ void get_mon_num_prep_chameleon(PlayerType *player_ptr, const ChameleonTransform
         const auto in_random_quest = floor.is_in_quest() && !QuestType::is_fixed(floor.quest_number);
         const auto cond = !system.is_phase_out() && floor.is_underground() && !in_random_quest;
         if (cond && !restrict_monster_to_dungeon(dungeon, dungeon_level, monrace_id, false, true)) {
-            const int numer = entry.prob2 * dungeon.special_div;
-            const int q = numer / 64;
-            const int r = numer % 64;
-            entry.prob2 = static_cast<short>(randint0(64) < r ? q + 1 : q);
+            entry.update_prob2(dungeon.special_div);
         }
 
         mfdi.update(entry.prob2, entry.level);
@@ -792,10 +780,7 @@ void get_mon_num_prep_bounty(PlayerType *player_ptr)
         const auto in_random_quest = floor.is_in_quest() && !QuestType::is_fixed(floor.quest_number);
         const auto cond = !system.is_phase_out() && floor.is_underground() && !in_random_quest;
         if (cond && !restrict_monster_to_dungeon(dungeon, dungeon_level, monrace_id)) {
-            const int numer = entry.prob2 * dungeon.special_div;
-            const int q = numer / 64;
-            const int r = numer % 64;
-            entry.prob2 = static_cast<short>(randint0(64) < r ? q + 1 : q);
+            entry.update_prob2(dungeon.special_div);
         }
 
         mfdi.update(entry.prob2, entry.level);

--- a/src/system/floor/floor-info.cpp
+++ b/src/system/floor/floor-info.cpp
@@ -17,6 +17,8 @@
 #include "system/gamevalue.h"
 #include "system/grid-type-definition.h"
 #include "system/item-entity.h"
+#include "system/monrace/monrace-definition.h"
+#include "system/monrace/monrace-list.h"
 #include "system/monster-entity.h"
 #include "system/terrain/terrain-definition.h"
 #include "util/bit-flags-calculator.h"

--- a/src/system/floor/floor-info.h
+++ b/src/system/floor/floor-info.h
@@ -40,6 +40,7 @@ constexpr auto REDRAW_MAX = 2298;
 enum class DungeonId;
 enum class GridCountKind;
 enum class MonsterTimedEffect : int;
+enum class MonraceId : short;
 enum class QuestId : short;
 enum class TerrainCharacteristics;
 enum class TerrainTag;

--- a/src/system/monrace/monrace-allocation.cpp
+++ b/src/system/monrace/monrace-allocation.cpp
@@ -55,6 +55,14 @@ bool MonraceAllocationEntry::is_defeatable(int threshold_level) const
     return !has_resist_all && !(can_diminish && is_shallow);
 }
 
+void MonraceAllocationEntry::update_prob2(int division)
+{
+    const auto numer = this->prob2 * division;
+    const auto q = numer / 64;
+    const auto r = numer % 64;
+    this->prob2 = static_cast<short>(randint0(64) < r ? q + 1 : q);
+}
+
 const MonraceDefinition &MonraceAllocationEntry::get_monrace() const
 {
     return MonraceList::get_instance().get_monrace(index);

--- a/src/system/monrace/monrace-allocation.h
+++ b/src/system/monrace/monrace-allocation.h
@@ -22,6 +22,8 @@ public:
     bool is_permitted(int threshold_level) const;
     bool is_defeatable(int threshold_level) const;
 
+    void update_prob2(int division);
+
 private:
     const MonraceDefinition &get_monrace() const;
 };

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -352,6 +352,23 @@ GridFlow MonraceDefinition::get_grid_flow_type() const
     return this->feature_flags.has(MonsterFeatureType::CAN_FLY) ? GridFlow::CAN_FLY : GridFlow::NORMAL;
 }
 
+/*!
+ * @brief モンスター種族がランダムクエストの討伐対象に成り得るかをチェックする
+ * @return 討伐対象にできるか否か
+ */
+bool MonraceDefinition::is_suitable_for_random_quest() const
+{
+    auto is_suitable = this->kind_flags.has(MonsterKindType::UNIQUE);
+    is_suitable &= this->misc_flags.has_not(MonsterMiscType::NO_QUEST);
+    is_suitable &= this->misc_flags.has_not(MonsterMiscType::QUESTOR);
+    is_suitable &= this->rarity <= 100;
+    is_suitable &= this->wilderness_flags.has_not(MonsterWildernessType::WILD_ONLY);
+    is_suitable &= this->feature_flags.has_not(MonsterFeatureType::AQUATIC);
+    is_suitable &= this->misc_flags.has_not(MonsterMiscType::MULTIPLY);
+    is_suitable &= this->behavior_flags.has_not(MonsterBehaviorType::FRIENDLY);
+    return is_suitable;
+}
+
 void MonraceDefinition::init_sex(uint32_t value)
 {
     const auto sex_tmp = i2enum<MonsterSex>(value);

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -159,6 +159,7 @@ public:
     const std::vector<Reinforce> &get_reinforces() const;
     bool can_generate() const;
     GridFlow get_grid_flow_type() const;
+    bool is_suitable_for_random_quest() const;
 
     void init_sex(uint32_t value);
     std::optional<std::string> probe_lore();

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -69,6 +69,7 @@ private:
  * MonraceMemory (r_hoge の思い出関係フラグ類)
  * MonraceInfo (max_num/cur_num/floor_id/defeat_level/defeat_time 他、思い出以外でゲームデータ依存の数値類)
  */
+enum class DungeonId;
 enum class GridFlow : int;
 class MonraceDefinition {
 public:

--- a/src/system/services/dungeon-monrace-service.cpp
+++ b/src/system/services/dungeon-monrace-service.cpp
@@ -1,0 +1,39 @@
+/*!
+ * @brief ダンジョンとモンスター種族定義の両方に依存するサービス実装
+ * @author Hourier
+ * @date 2025/01/11
+ */
+
+#include "system/services/dungeon-monrace-service.h"
+#include "system/dungeon/dungeon-definition.h"
+#include "system/dungeon/dungeon-list.h"
+#include "system/enums/dungeon/dungeon-id.h"
+#include "system/enums/monrace/monrace-id.h"
+#include "system/monrace/monrace-definition.h"
+#include "system/monrace/monrace-list.h"
+
+/*!
+ * @brief モンスターがダンジョンに出現するかどうかを返す
+ * @param dungeon_id 出現させようとするダンジョンID
+ * @param monrace_id モンスター種族ID
+ * @return ダンジョンに出現するならばTRUEを返す
+ * @details
+ * 荒野限定(WILD_ONLY)の場合、荒野の山(WILD_MOUNTAIN)に出るモンスターにのみ、ダンジョンの山にも出現を許可する。
+ * その他の場合、山と火山以外のダンジョンでは全てのモンスターに出現を許可する。
+ * ダンジョンが山の場合は、荒野の山(WILD_MOUNTAIN)に出ない水棲動物(AQUATIC)は許可しない。
+ * ダンジョンが火山の場合は、荒野の火山(WILD_VOLCANO)に出ない水棲動物(AQUATIC)は許可しない。
+ */
+bool DungeonMonraceService::is_suitable_for_dungeon(DungeonId dungeon_id, MonraceId monrace_id)
+{
+    const auto &dungeon = DungeonList::get_instance().get_dungeon(dungeon_id);
+    const auto &monrace = MonraceList::get_instance().get_monrace(monrace_id);
+    if (monrace.wilderness_flags.has(MonsterWildernessType::WILD_ONLY)) {
+        return dungeon.mon_wilderness_flags.has(MonsterWildernessType::WILD_MOUNTAIN) && monrace.wilderness_flags.has(MonsterWildernessType::WILD_MOUNTAIN);
+    }
+
+    const auto land = monrace.feature_flags.has_not(MonsterFeatureType::AQUATIC);
+    auto is_mountain_monster = dungeon.mon_wilderness_flags.has_none_of({ MonsterWildernessType::WILD_MOUNTAIN, MonsterWildernessType::WILD_VOLCANO });
+    is_mountain_monster |= dungeon.mon_wilderness_flags.has(MonsterWildernessType::WILD_MOUNTAIN) && (land || monrace.wilderness_flags.has(MonsterWildernessType::WILD_MOUNTAIN));
+    is_mountain_monster |= dungeon.mon_wilderness_flags.has(MonsterWildernessType::WILD_VOLCANO) && (land || monrace.wilderness_flags.has(MonsterWildernessType::WILD_VOLCANO));
+    return is_mountain_monster;
+}

--- a/src/system/services/dungeon-monrace-service.h
+++ b/src/system/services/dungeon-monrace-service.h
@@ -1,0 +1,15 @@
+/*!
+ * @brief ダンジョンとモンスター種族定義の両方に依存するサービス定義
+ * @author Hourier
+ * @date 2025/01/11
+ */
+
+#pragma once
+
+enum class DungeonId;
+enum class MonraceId : short;
+class DungeonMonraceService {
+public:
+    DungeonMonraceService() = delete;
+    static bool is_suitable_for_dungeon(DungeonId dungeon_id, MonraceId monrace_id);
+};


### PR DESCRIPTION
#4795 のサービスクラスバージョンです
個人的にはこっちの方が対称性が高くて扱いやすい印象です
(フラグ有無を確認しているところは相変わらず露出したままだが、本質的ではないので省略)