### PR TITLE
ターゲッティングが正しく実行できない不具合を修正した

### DIFF
--- a/src/target/projection-path-calculator.cpp
+++ b/src/target/projection-path-calculator.cpp
@@ -9,6 +9,7 @@
 #include "system/grid-type-definition.h"
 #include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
+#include "util/finalizer.h"
 
 class ProjectionPathHelper {
 public:
@@ -235,6 +236,7 @@ ProjectionPath::ProjectionPath(PlayerType *player_ptr, int range, const Pos2D &p
     }
 
     ProjectionPathHelper pph(range, flag, pos_src, pos_dst);
+    const auto finalizer = util::make_finalizer([this, &pph] { this->positions = std::move(pph.positions); });
     if (calc_vertical_projection(floor, p_pos, &pph)) {
         return;
     }
@@ -244,7 +246,6 @@ ProjectionPath::ProjectionPath(PlayerType *player_ptr, int range, const Pos2D &p
     }
 
     calc_diagonal_projection(floor, p_pos, &pph);
-    this->positions = std::move(pph.positions);
 }
 
 /*


### PR DESCRIPTION
ProjectionPathHelper の実行結果とは無関係にpositions をムーブすべきところでできていなかったのが原因です
ご確認下さい