### PR TITLE
[Refactor] 死亡済みのユニークモンスターかどうかの判定

### DIFF
--- a/src/dungeon/dungeon-processor.cpp
+++ b/src/dungeon/dungeon-processor.cpp
@@ -191,7 +191,7 @@ void process_dungeon(PlayerType *player_ptr, bool load_game)
     const auto &dungeon = floor.get_dungeon_definition();
     if (floor.dun_level == dungeon.maxdepth) {
         const auto &monrace = dungeon.get_guardian();
-        if (monrace.max_num > 0) {
+        if (!monrace.is_dead_unique()) {
 #ifdef JP
             msg_format("この階には%sの主である%sが棲んでいる。", dungeon.name.data(), monrace.name.data());
 #else

--- a/src/dungeon/quest.cpp
+++ b/src/dungeon/quest.cpp
@@ -266,9 +266,7 @@ void quest_discovery(QuestId quest_id)
         return;
     }
 
-    auto is_random_quest_skipped = monrace.kind_flags.has(MonsterKindType::UNIQUE);
-    is_random_quest_skipped &= monrace.max_num == 0;
-    if (!is_random_quest_skipped) {
+    if (!monrace.is_dead_unique()) {
         msg_format(_("注意せよ！この階は%sによって守られている！", "Beware, this level is protected by %s!"), name.data());
         return;
     }

--- a/src/floor/object-allocator.cpp
+++ b/src/floor/object-allocator.cpp
@@ -95,7 +95,7 @@ bool alloc_stairs(PlayerType *player_ptr, FEAT_IDX feat, int num, int walls)
         const auto &quests = QuestList::get_instance();
         if (floor.dun_level > 1 && inside_quest(quest_id)) {
             const auto &monrace = quests.get_quest(quest_id).get_bounty();
-            if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) || (monrace.max_num > 0)) {
+            if (!monrace.is_dead_unique()) {
                 return true;
             }
         }

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -307,8 +307,7 @@ static void dump_aux_monsters(FILE *fff)
         }
 
         if (monrace.kind_flags.has(MonsterKindType::UNIQUE)) {
-            auto dead = (monrace.max_num == 0);
-            if (dead) {
+            if (monrace.is_dead_unique()) {
                 norm_total++;
 
                 /* Add a unique monster to the list */

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -172,7 +172,7 @@ void do_cmd_knowledge_kill_count(PlayerType *player_ptr)
     for (const auto monrace_id : monrace_ids) {
         const auto &monrace = monraces.get_monrace(monrace_id);
         if (monrace.kind_flags.has(MonsterKindType::UNIQUE)) {
-            if (monrace.max_num == 0) {
+            if (monrace.is_dead_unique()) {
                 std::string details;
                 if (monrace.defeat_level && monrace.defeat_time) {
                     details = format(_(" - レベル%2d - %d:%02d:%02d", " - level %2d - %d:%02d:%02d"), monrace.defeat_level, monrace.defeat_time / (60 * 60),
@@ -247,7 +247,8 @@ static void display_monster_list(int col, int row, int per_page, const std::vect
             if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE)) {
                 put_str(format("%5d", monrace.r_pkills), row + i, 73);
             } else {
-                c_put_str((monrace.max_num == 0 ? TERM_L_DARK : TERM_WHITE), (monrace.max_num == 0 ? _("死亡", " dead") : _("生存", "alive")), row + i, 74);
+                const auto is_dead = monrace.is_dead_unique();
+                c_put_str((is_dead ? TERM_L_DARK : TERM_WHITE), (is_dead ? _("死亡", " dead") : _("生存", "alive")), row + i, 74);
             }
         }
     }

--- a/src/load/load-zangband.cpp
+++ b/src/load/load-zangband.cpp
@@ -122,7 +122,7 @@ void set_zangband_bounty_uniques(PlayerType *player_ptr)
     const auto &monraces = MonraceList::get_instance();
     for (auto &[monrace_id, is_achieved] : AngbandWorld::get_instance().bounties) {
         /* Is this bounty unique already dead? */
-        if (monraces.get_monrace(monrace_id).max_num == 0) {
+        if (monraces.get_monrace(monrace_id).is_dead_unique()) {
             is_achieved = true;
         }
     }

--- a/src/lore/lore-util.cpp
+++ b/src/lore/lore-util.cpp
@@ -136,7 +136,7 @@ std::optional<std::vector<lore_msg>> lore_type::build_kill_unique_description() 
     }
 
     std::vector<lore_msg> texts;
-    const auto is_dead = (this->r_ptr->max_num == 0);
+    const auto is_dead = this->r_ptr->is_dead_unique();
     if (this->r_ptr->r_deaths > 0) {
         constexpr auto fmt = _("%s^はあなたの先祖を %d 人葬っている", "%s^ has slain %d of your ancestors");
         texts.emplace_back(format(fmt, Who::who(this->msex).data(), this->r_ptr->r_deaths));

--- a/src/mspell/summon-checker.cpp
+++ b/src/mspell/summon-checker.cpp
@@ -153,7 +153,7 @@ bool check_summon_specific(PlayerType *player_ptr, MonraceId summoner_id, Monrac
         return is_match;
     }
     case SUMMON_DEAD_UNIQUE: {
-        return monrace.kind_flags.has(MonsterKindType::UNIQUE) && monrace.max_num == 0;
+        return monrace.is_dead_unique();
     }
     default:
         return false;

--- a/src/system/dungeon/dungeon-definition.cpp
+++ b/src/system/dungeon/dungeon-definition.cpp
@@ -109,7 +109,7 @@ bool DungeonDefinition::is_conquered() const
         return false;
     }
 
-    return this->get_guardian().max_num == 0;
+    return this->get_guardian().is_dead_unique();
 }
 
 std::string DungeonDefinition::build_entrance_message() const

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -171,15 +171,6 @@ std::optional<bool> MonraceDefinition::order_pet(const MonraceDefinition &other)
     return this->order_level(other);
 }
 
-/*!
- * @brief ユニークモンスターの撃破状態を更新する
- * @todo 状態変更はモンスター「定義」ではないので将来的に別クラスへ分離する
- */
-void MonraceDefinition::kill_unique()
-{
-    this->max_num = 0;
-}
-
 std::string MonraceDefinition::get_pronoun_of_summoned_kin() const
 {
     if (this->kind_flags.has(MonsterKindType::UNIQUE)) {
@@ -565,6 +556,15 @@ bool MonraceDefinition::is_blow_damage_known(int num_blow) const
     }
 
     return (4 + this->level) * (2 * r_blow) > 80 * max_damage;
+}
+
+/*!
+ * @brief ユニークモンスターの撃破状態を更新する
+ * @todo 状態変更はモンスター「定義」ではないので将来的に別クラスへ分離する
+ */
+void MonraceDefinition::kill_unique()
+{
+    this->max_num = 0;
 }
 
 void MonraceDefinition::reset_current_numbers()

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -567,6 +567,11 @@ void MonraceDefinition::kill_unique()
     this->max_num = 0;
 }
 
+bool MonraceDefinition::is_dead_unique() const
+{
+    return this->kind_flags.has(MonsterKindType::UNIQUE) && this->max_num == 0;
+}
+
 void MonraceDefinition::reset_current_numbers()
 {
     this->cur_num = 0;

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -173,6 +173,7 @@ public:
     bool is_details_known() const;
     bool is_blow_damage_known(int num_blow) const;
     void kill_unique();
+    bool is_dead_unique() const;
 
     void reset_current_numbers();
     void increment_current_numbers();

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -147,7 +147,6 @@ public:
     std::optional<bool> order_level(const MonraceDefinition &other) const;
     bool order_level_strictly(const MonraceDefinition &other) const;
     std::optional<bool> order_pet(const MonraceDefinition &other) const;
-    void kill_unique();
     std::string get_pronoun_of_summoned_kin() const;
     const MonraceDefinition &get_next() const;
     bool is_bounty(bool unachieved_only) const;
@@ -173,6 +172,7 @@ public:
     bool should_display(bool is_alive) const;
     bool is_details_known() const;
     bool is_blow_damage_known(int num_blow) const;
+    void kill_unique();
 
     void reset_current_numbers();
     void increment_current_numbers();

--- a/src/system/monrace/monrace-list.cpp
+++ b/src/system/monrace/monrace-list.cpp
@@ -253,13 +253,13 @@ bool MonraceList::is_selectable(const MonraceId r_idx) const
 void MonraceList::defeat_separated_uniques()
 {
     for (const auto &[unified_unique, separates] : unified_uniques) {
-        if (this->get_monrace(unified_unique).max_num > 0) {
+        if (!this->get_monrace(unified_unique).is_dead_unique()) {
             continue;
         }
 
         for (const auto separate : separates) {
             auto &monrace = this->get_monrace(separate);
-            if (monrace.max_num == 0) {
+            if (monrace.is_dead_unique()) {
                 continue;
             }
 
@@ -320,7 +320,7 @@ bool MonraceList::can_select_separate(const MonraceId monrace_id, const int hp, 
         return false;
     }
 
-    return std::all_of(found_separates.begin(), found_separates.end(), [this](const auto x) { return this->get_monrace(x).max_num > 0; });
+    return std::all_of(found_separates.begin(), found_separates.end(), [this](const auto x) { return !this->get_monrace(x).is_dead_unique(); });
 }
 
 bool MonraceList::order(MonraceId id1, MonraceId id2, bool is_detailed) const
@@ -428,7 +428,7 @@ int MonraceList::calc_defeat_count() const
     auto total = 0;
     for (const auto &[_, monrace] : monraces_info) {
         if (monrace.kind_flags.has(MonsterKindType::UNIQUE)) {
-            if (monrace.max_num == 0) {
+            if (monrace.is_dead_unique()) {
                 total++;
             }
 


### PR DESCRIPTION
死亡済みのユニークモンスターかどうかの判定を MonraceDefinition::max_num を直接調べている箇所が多数あるので、MonraceDefinition::is_dead_unique() にカプセル化する。

#4811 の作業に先立ってコードを確認していて気になったので、一旦これだけ単体PRとして提出します。