### PR TITLE
scatter() の引数と戻り値をPos2D に差し替えた

### DIFF
--- a/src/dungeon/quest-completion-checker.cpp
+++ b/src/dungeon/quest-completion-checker.cpp
@@ -232,10 +232,7 @@ Pos2D QuestCompletionChecker::make_stairs(const bool create_stairs)
     auto &floor = *this->player_ptr->current_floor_ptr;
     auto *g_ptr = &floor.get_grid(m_pos);
     while (floor.has_terrain_characteristics(m_pos, TerrainCharacteristics::PERMANENT) || !g_ptr->o_idx_list.empty() || g_ptr->is_object()) {
-        int ny;
-        int nx;
-        scatter(this->player_ptr, &ny, &nx, m_pos.y, m_pos.x, 1, PROJECT_NONE);
-        m_pos = { ny, nx };
+        m_pos = scatter(this->player_ptr, m_pos, 1, PROJECT_NONE);
         g_ptr = &floor.get_grid(m_pos);
     }
 

--- a/src/floor/floor-util.cpp
+++ b/src/floor/floor-util.cpp
@@ -155,35 +155,31 @@ void wipe_o_list(FloorType *floor_ptr)
  *
  * Currently the "m" parameter is unused.
  */
-void scatter(PlayerType *player_ptr, POSITION *yp, POSITION *xp, POSITION y, POSITION x, POSITION d, BIT_FLAGS mode)
+Pos2D scatter(PlayerType *player_ptr, const Pos2D &pos, int d, uint32_t mode)
 {
-    const Pos2D pos(y, x);
     const auto &floor = *player_ptr->current_floor_ptr;
-    POSITION nx, ny;
     while (true) {
-        ny = rand_spread(y, d);
-        nx = rand_spread(x, d);
+        const auto ny = rand_spread(pos.y, d);
+        const auto nx = rand_spread(pos.x, d);
         const Pos2D pos_neighbor(ny, nx);
-        if (!in_bounds(&floor, ny, nx)) {
+        if (!in_bounds(&floor, pos_neighbor.y, pos_neighbor.x)) {
             continue;
         }
-        if ((d > 1) && (distance(y, x, ny, nx) > d)) {
+        if ((d > 1) && (distance(pos.y, pos.x, pos_neighbor.y, pos_neighbor.x) > d)) {
             continue;
         }
         if (mode & PROJECT_LOS) {
-            if (los(player_ptr, y, x, ny, nx)) {
-                break;
+            if (los(player_ptr, pos.y, pos.x, pos_neighbor.y, pos_neighbor.x)) {
+                return pos_neighbor;
             }
+
             continue;
         }
 
-        if (projectable(player_ptr, { y, x }, pos_neighbor)) {
-            break;
+        if (projectable(player_ptr, pos, pos_neighbor)) {
+            return pos_neighbor;
         }
     }
-
-    *yp = ny;
-    *xp = nx;
 }
 
 /*!

--- a/src/floor/floor-util.h
+++ b/src/floor/floor-util.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "system/angband.h"
+#include "util/point-2d.h"
+#include <cstdint>
 #include <string>
 
 class FloorType;
@@ -10,5 +11,5 @@ class PlayerType;
 void update_smell(FloorType *floor_ptr, PlayerType *player_ptr);
 void forget_flow(FloorType *floor_ptr);
 void wipe_o_list(FloorType *floor_ptr);
-void scatter(PlayerType *player_ptr, POSITION *yp, POSITION *xp, POSITION y, POSITION x, POSITION d, BIT_FLAGS mode);
+Pos2D scatter(PlayerType *player_ptr, const Pos2D &pos, int d, uint32_t mode);
 std::string map_name(PlayerType *player_ptr);

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -585,24 +585,25 @@ static bool cast_element_spell(PlayerType *player_ptr, SPELL_IDX spell_idx)
         return true;
     }
     case ElementSpells::BURST_1ST: {
-        auto p_pos = player_ptr->get_position();
+        const auto p_pos = player_ptr->get_position();
+        auto pos = p_pos;
         const auto num = Dice::roll(4, 3);
         const auto typ = get_element_spells_type(player_ptr, power.elem);
         for (auto k = 0; k < num; k++) {
             auto attempts = 1000;
             while (attempts--) {
-                scatter(player_ptr, &p_pos.y, &p_pos.x, player_ptr->y, player_ptr->x, 4, PROJECT_NONE);
-                if (!floor.has_terrain_characteristics(p_pos, TerrainCharacteristics::PROJECT)) {
+                pos = scatter(player_ptr, p_pos, 4, PROJECT_NONE);
+                if (!floor.has_terrain_characteristics(pos, TerrainCharacteristics::PROJECT)) {
                     continue;
                 }
 
-                if (!player_ptr->is_located_at(p_pos)) {
+                if (!player_ptr->is_located_at(pos)) {
                     break;
                 }
             }
 
             constexpr auto flag = PROJECT_BEAM | PROJECT_THRU | PROJECT_GRID | PROJECT_KILL;
-            project(player_ptr, 0, 0, p_pos.y, p_pos.x, Dice::roll(6 + plev / 8, 7), typ, flag);
+            project(player_ptr, 0, 0, pos.y, pos.x, Dice::roll(6 + plev / 8, 7), typ, flag);
         }
 
         return true;

--- a/src/monster-floor/monster-death-util.cpp
+++ b/src/monster-floor/monster-death-util.cpp
@@ -9,7 +9,7 @@
 #include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 
-MonsterDeath::MonsterDeath(FloorType &floor, MONSTER_IDX m_idx, bool drop_item)
+MonsterDeath::MonsterDeath(FloorType &floor, short m_idx, bool drop_item)
     : m_idx(m_idx)
     , m_ptr(&floor.m_list[m_idx])
 {
@@ -23,4 +23,9 @@ MonsterDeath::MonsterDeath(FloorType &floor, MONSTER_IDX m_idx, bool drop_item)
     this->do_item |= this->r_ptr->drop_flags.has_any_of({ MonsterDropType::DROP_GOOD, MonsterDropType::DROP_GREAT });
     this->cloned = this->m_ptr->mflag2.has(MonsterConstantFlagType::CLONED);
     this->drop_chosen_item = drop_item && !this->cloned && !floor.inside_arena && !AngbandSystem::get_instance().is_phase_out() && !this->m_ptr->is_pet();
+}
+
+Pos2D MonsterDeath::get_position() const
+{
+    return { this->md_y, this->md_x };
 }

--- a/src/monster-floor/monster-death-util.h
+++ b/src/monster-floor/monster-death-util.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "system/angband.h"
+#include "util/point-2d.h"
+#include <cstdint>
 
 // @todo PlayerType に依存するオブジェクトメソッドを追加予定.
 class FloorType;
@@ -8,15 +9,17 @@ class MonsterEntity;
 class MonraceDefinition;
 class MonsterDeath {
 public:
-    MonsterDeath(FloorType &floor, MONSTER_IDX m_idx, bool drop_item);
-    MONSTER_IDX m_idx;
+    MonsterDeath(FloorType &floor, short m_idx, bool drop_item);
+    short m_idx;
     MonsterEntity *m_ptr;
     MonraceDefinition *r_ptr;
     bool do_gold;
     bool do_item;
     bool cloned;
     bool drop_chosen_item;
-    POSITION md_y = 0;
-    POSITION md_x = 0;
+    int md_y = 0;
+    int md_x = 0;
     uint32_t mo_mode = 0;
+
+    Pos2D get_position() const;
 };

--- a/src/monster-floor/monster-generator.cpp
+++ b/src/monster-floor/monster-generator.cpp
@@ -187,14 +187,13 @@ static void place_monster_group(PlayerType *player_ptr, const Pos2D &pos_center,
         for (auto i = 0; (i < 8) && (positions.size() < total_size); i++) {
             //!< @details 要素数が変わると参照がダングリング状態になるので毎回取得する必要がある.
             const auto &pos_neighbor = positions.at(n);
-            int mx, my;
-            scatter(player_ptr, &my, &mx, pos_neighbor.y, pos_neighbor.x, 4, PROJECT_NONE);
-            if (!is_cave_empty_bold2(player_ptr, my, mx)) {
+            const auto pos = scatter(player_ptr, pos_neighbor, 4, PROJECT_NONE);
+            if (!is_cave_empty_bold2(player_ptr, pos.y, pos.x)) {
                 continue;
             }
 
-            if (place_monster_one(player_ptr, my, mx, monrace_id, mode, summoner_m_idx)) {
-                positions.emplace_back(my, mx);
+            if (place_monster_one(player_ptr, pos.y, pos.x, monrace_id, mode, summoner_m_idx)) {
+                positions.push_back(pos);
             }
         }
     }
@@ -214,6 +213,7 @@ static void place_monster_group(PlayerType *player_ptr, const Pos2D &pos_center,
  */
 std::optional<MONSTER_IDX> place_specific_monster(PlayerType *player_ptr, POSITION y, POSITION x, MonraceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx)
 {
+    const Pos2D pos(y, x);
     const auto &monrace = MonraceList::get_instance().get_monrace(r_idx);
     if (!(mode & PM_NO_KAGE) && one_in_(333)) {
         mode |= PM_KAGE;
@@ -235,12 +235,12 @@ std::optional<MONSTER_IDX> place_specific_monster(PlayerType *player_ptr, POSITI
 
         const auto n = reinforce.roll_dice();
         for (int j = 0; j < n; j++) {
-            POSITION nx, ny, d;
-            const POSITION scatter_min = 7;
-            const POSITION scatter_max = 40;
+            constexpr auto scatter_min = 7;
+            constexpr auto scatter_max = 40;
+            int d;
             for (d = scatter_min; d <= scatter_max; d++) {
-                scatter(player_ptr, &ny, &nx, y, x, d, PROJECT_NONE);
-                if (place_monster_one(player_ptr, ny, nx, reinforce.get_monrace_id(), mode, *m_idx)) {
+                const auto pos_neighbor = scatter(player_ptr, pos, d, PROJECT_NONE);
+                if (place_monster_one(player_ptr, pos_neighbor.y, pos_neighbor.x, reinforce.get_monrace_id(), mode, *m_idx)) {
                     break;
                 }
             }
@@ -251,29 +251,29 @@ std::optional<MONSTER_IDX> place_specific_monster(PlayerType *player_ptr, POSITI
     }
 
     if (monrace.misc_flags.has(MonsterMiscType::HAS_FRIENDS)) {
-        place_monster_group(player_ptr, { y, x }, r_idx, mode, summoner_m_idx);
+        place_monster_group(player_ptr, pos, r_idx, mode, summoner_m_idx);
     }
 
     if (monrace.misc_flags.has_not(MonsterMiscType::ESCORT)) {
         return m_idx;
     }
 
-    for (int i = 0; i < 32; i++) {
-        POSITION nx, ny, d = 3;
-        scatter(player_ptr, &ny, &nx, y, x, d, PROJECT_NONE);
-        if (!is_cave_empty_bold2(player_ptr, ny, nx)) {
+    for (auto i = 0; i < 32; i++) {
+        constexpr auto d = 3;
+        const auto pos_neighbor = scatter(player_ptr, pos, d, PROJECT_NONE);
+        if (!is_cave_empty_bold2(player_ptr, pos_neighbor.y, pos_neighbor.x)) {
             continue;
         }
 
-        get_mon_num_prep_escort(player_ptr, r_idx, *m_idx, get_monster_hook2(player_ptr, ny, nx));
+        get_mon_num_prep_escort(player_ptr, r_idx, *m_idx, get_monster_hook2(player_ptr, pos_neighbor.y, pos_neighbor.x));
         const auto monrace_id = get_mon_num(player_ptr, 0, monrace.level, 0);
         if (!MonraceList::is_valid(monrace_id)) {
             break;
         }
 
-        (void)place_monster_one(player_ptr, ny, nx, monrace_id, mode, *m_idx);
+        (void)place_monster_one(player_ptr, pos_neighbor.y, pos_neighbor.x, monrace_id, mode, *m_idx);
         if (monrace.misc_flags.has(MonsterMiscType::HAS_FRIENDS) || monrace.misc_flags.has(MonsterMiscType::MORE_ESCORT)) {
-            place_monster_group(player_ptr, { ny, nx }, monrace_id, mode, *m_idx);
+            place_monster_group(player_ptr, pos_neighbor, monrace_id, mode, *m_idx);
         }
     }
 
@@ -345,10 +345,10 @@ static std::optional<MonraceId> select_horde_leader_r_idx(PlayerType *player_ptr
  */
 bool alloc_horde(PlayerType *player_ptr, POSITION y, POSITION x, summon_specific_pf summon_specific)
 {
+    Pos2D pos(y, x);
     const auto &floor = *player_ptr->current_floor_ptr;
     const Pos2D pos_wilderness(player_ptr->wilderness_y, player_ptr->wilderness_x);
-    get_mon_num_prep_enum(player_ptr, get_monster_hook(pos_wilderness, floor.is_underground()), get_monster_hook2(player_ptr, y, x));
-
+    get_mon_num_prep_enum(player_ptr, get_monster_hook(pos_wilderness, floor.is_underground()), get_monster_hook2(player_ptr, pos.y, pos.x));
     const auto monrace_id = select_horde_leader_r_idx(player_ptr);
     if (!monrace_id) {
         return false;
@@ -364,16 +364,12 @@ bool alloc_horde(PlayerType *player_ptr, POSITION y, POSITION x, summon_specific
         }
     }
 
-    const auto m_idx = floor.get_grid({ y, x }).m_idx;
+    const auto m_idx = floor.get_grid(pos).m_idx;
     const auto &monentity = floor.m_list[m_idx];
-
-    POSITION cy = y;
-    POSITION cx = x;
     for (auto attempts = randint1(10) + 5; attempts > 0; attempts--) {
-        scatter(player_ptr, &cy, &cx, y, x, 5, PROJECT_NONE);
-        (void)(*summon_specific)(player_ptr, cy, cx, floor.dun_level + 5, SUMMON_KIN, PM_ALLOW_GROUP, m_idx);
-        y = cy;
-        x = cx;
+        const auto pos_scat = scatter(player_ptr, pos, 5, PROJECT_NONE);
+        (void)(*summon_specific)(player_ptr, pos_scat.y, pos_scat.x, floor.dun_level + 5, SUMMON_KIN, PM_ALLOW_GROUP, m_idx);
+        pos = pos_scat;
     }
 
     if (!cheat_hear) {

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -72,24 +72,23 @@ static BIT_FLAGS dead_mode(MonsterDeath *md_ptr)
  */
 static void summon_self(PlayerType *player_ptr, MonsterDeath *md_ptr, summon_type type, int probability, POSITION radius, concptr message)
 {
-    auto *floor_ptr = player_ptr->current_floor_ptr;
-    if (floor_ptr->inside_arena || AngbandSystem::get_instance().is_phase_out() || one_in_(probability)) {
+    const auto &floor = *player_ptr->current_floor_ptr;
+    if (floor.inside_arena || AngbandSystem::get_instance().is_phase_out() || one_in_(probability)) {
         return;
     }
 
-    POSITION wy = md_ptr->md_y;
-    POSITION wx = md_ptr->md_x;
-    int attempts = 100;
+    auto m_pos = md_ptr->get_position();
+    auto attempts = 100;
     do {
-        scatter(player_ptr, &wy, &wx, md_ptr->md_y, md_ptr->md_x, radius, PROJECT_NONE);
-    } while (!(in_bounds(floor_ptr, wy, wx) && is_cave_empty_bold2(player_ptr, wy, wx)) && --attempts);
+        m_pos = scatter(player_ptr, md_ptr->get_position(), radius, PROJECT_NONE);
+    } while (!(in_bounds(&floor, m_pos.y, m_pos.x) && is_cave_empty_bold2(player_ptr, m_pos.y, m_pos.x)) && --attempts);
 
     if (attempts <= 0) {
         return;
     }
 
     BIT_FLAGS mode = dead_mode(md_ptr);
-    if (summon_specific(player_ptr, wy, wx, 100, type, mode) && player_can_see_bold(player_ptr, wy, wx)) {
+    if (summon_specific(player_ptr, m_pos.y, m_pos.x, 100, type, mode) && player_can_see_bold(player_ptr, m_pos.y, m_pos.x)) {
         msg_print(message);
     }
 }

--- a/src/mspell/specified-summon.cpp
+++ b/src/mspell/specified-summon.cpp
@@ -182,8 +182,9 @@ MONSTER_NUMBER summon_DEMON_SLAYER(PlayerType *player_ptr, POSITION y, POSITION 
 MONSTER_NUMBER summon_NAZGUL(PlayerType *player_ptr, POSITION y, POSITION x, MONSTER_IDX m_idx)
 {
     BIT_FLAGS mode = 0L;
-    POSITION cy = y;
-    POSITION cx = x;
+    Pos2D pos_initial(y, x);
+    auto pos = pos_initial;
+    auto pos_scat = pos_initial;
     const auto m_name = monster_name(player_ptr, m_idx);
 
     if (player_ptr->effects()->blindness().is_blind()) {
@@ -194,32 +195,31 @@ MONSTER_NUMBER summon_NAZGUL(PlayerType *player_ptr, POSITION y, POSITION x, MON
 
     msg_print(nullptr);
 
-    int count = 0;
-    for (int k = 0; k < 30; k++) {
-        if (!summon_possible(player_ptr, cy, cx) || !is_cave_empty_bold(player_ptr, cy, cx)) {
+    auto count = 0;
+    for (auto k = 0; k < 30; k++) {
+        if (!summon_possible(player_ptr, pos_scat.y, pos_scat.x) || !is_cave_empty_bold(player_ptr, pos_scat.y, pos_scat.x)) {
             int j;
             for (j = 100; j > 0; j--) {
-                scatter(player_ptr, &cy, &cx, y, x, 2, PROJECT_NONE);
-                if (is_cave_empty_bold(player_ptr, cy, cx)) {
+                pos_scat = scatter(player_ptr, pos, 2, PROJECT_NONE);
+                if (is_cave_empty_bold(player_ptr, pos_scat.y, pos_scat.x)) {
                     break;
                 }
             }
 
-            if (!j) {
+            if (j == 0) {
                 break;
             }
         }
 
-        if (!is_cave_empty_bold(player_ptr, cy, cx)) {
+        if (!is_cave_empty_bold(player_ptr, pos_scat.y, pos_scat.x)) {
             continue;
         }
 
-        if (!summon_named_creature(player_ptr, m_idx, cy, cx, MonraceId::NAZGUL, mode)) {
+        if (!summon_named_creature(player_ptr, m_idx, pos_scat.y, pos_scat.x, MonraceId::NAZGUL, mode)) {
             continue;
         }
 
-        y = cy;
-        x = cx;
+        pos = pos_scat;
         count++;
         if (count == 1) {
             msg_format(_("「幽鬼戦隊%d号、ナズグル・ブラック！」", "A Nazgul says 'Nazgul-Rangers Number %d, Nazgul-Black!'"), count);

--- a/src/object-activation/activation-bolt-ball.cpp
+++ b/src/object-activation/activation-bolt-ball.cpp
@@ -337,21 +337,24 @@ bool activate_ball_lite(PlayerType *player_ptr, std::string_view name)
 {
     const auto num = Dice::roll(5, 3);
     msg_format(_("%sが稲妻で覆われた...", "The %s is surrounded by lightning..."), name.data());
+    const auto p_pos = player_ptr->get_position();
+    const auto &floor = *player_ptr->current_floor_ptr;
     for (auto k = 0; k < num; k++) {
         auto attempts = 1000;
         Pos2D pos(0, 0);
         while (attempts--) {
-            scatter(player_ptr, &pos.y, &pos.x, player_ptr->y, player_ptr->x, 4, PROJECT_NONE);
-            if (!player_ptr->current_floor_ptr->has_terrain_characteristics(pos, TerrainCharacteristics::PROJECT)) {
+            pos = scatter(player_ptr, p_pos, 4, PROJECT_NONE);
+            if (!floor.has_terrain_characteristics(pos, TerrainCharacteristics::PROJECT)) {
                 continue;
             }
 
-            if (!player_ptr->is_located_at(pos)) {
+            if (pos != p_pos) {
                 break;
             }
         }
 
-        project(player_ptr, 0, 3, pos.y, pos.x, 150, AttributeType::ELEC, PROJECT_THRU | PROJECT_STOP | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL);
+        constexpr uint32_t flags = PROJECT_THRU | PROJECT_STOP | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL;
+        project(player_ptr, 0, 3, pos.y, pos.x, 150, AttributeType::ELEC, flags);
     }
 
     return true;

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -2736,32 +2736,28 @@ bool player_place(PlayerType *player_ptr, POSITION y, POSITION x)
  */
 void wreck_the_pattern(PlayerType *player_ptr)
 {
-    auto *floor_ptr = player_ptr->current_floor_ptr;
+    const auto &floor = *player_ptr->current_floor_ptr;
     const auto p_pos = player_ptr->get_position();
-    const auto &terrain = floor_ptr->get_grid(p_pos).get_terrain();
+    const auto &terrain = floor.get_grid(p_pos).get_terrain();
     if (terrain.subtype == PATTERN_TILE_WRECKED) {
         return;
     }
 
     msg_print(_("パターンを血で汚してしまった！", "You bleed on the Pattern!"));
     msg_print(_("何か恐ろしい事が起こった！", "Something terrible happens!"));
-
     if (!is_invuln(player_ptr)) {
         take_hit(player_ptr, DAMAGE_NOESCAPE, Dice::roll(10, 8), _("パターン損壊", "corrupting the Pattern"));
     }
 
     auto to_ruin = randint1(45) + 35;
     while (to_ruin--) {
-        int y;
-        int x;
-        scatter(player_ptr, &y, &x, player_ptr->y, player_ptr->x, 4, PROJECT_NONE);
-        const Pos2D pos(y, x);
-        if (pattern_tile(floor_ptr, pos.y, pos.x) && (floor_ptr->get_grid(pos).get_terrain().subtype != PATTERN_TILE_WRECKED)) {
+        const auto pos = scatter(player_ptr, p_pos, 4, PROJECT_NONE);
+        if (pattern_tile(&floor, pos.y, pos.x) && (floor.get_grid(pos).get_terrain().subtype != PATTERN_TILE_WRECKED)) {
             cave_set_feat(player_ptr, pos.y, pos.x, feat_pattern_corrupted);
         }
     }
 
-    cave_set_feat(player_ptr, player_ptr->y, player_ptr->x, feat_pattern_corrupted);
+    cave_set_feat(player_ptr, p_pos.y, p_pos.x, feat_pattern_corrupted);
 }
 
 /*!

--- a/src/realm/realm-crusade.cpp
+++ b/src/realm/realm-crusade.cpp
@@ -457,12 +457,13 @@ std::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX sp
             auto sp_sides = 20 + plev;
             auto sp_base = plev;
             crusade(player_ptr);
+            const auto p_pos = player_ptr->get_position();
             for (auto i = 0; i < 12; i++) {
                 auto attempt = 10;
-                POSITION my = 0, mx = 0;
+                Pos2D pos(0, 0);
                 while (attempt--) {
-                    scatter(player_ptr, &my, &mx, player_ptr->y, player_ptr->x, 4, PROJECT_NONE);
-                    if (is_cave_empty_bold2(player_ptr, my, mx)) {
+                    pos = scatter(player_ptr, p_pos, 4, PROJECT_NONE);
+                    if (is_cave_empty_bold2(player_ptr, pos.y, pos.x)) {
                         break;
                     }
                 }
@@ -471,7 +472,7 @@ std::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX sp
                     continue;
                 }
 
-                summon_specific(player_ptr, my, mx, plev, SUMMON_KNIGHTS, PM_ALLOW_GROUP | PM_FORCE_PET | PM_HASTE);
+                summon_specific(player_ptr, pos.y, pos.x, plev, SUMMON_KNIGHTS, PM_ALLOW_GROUP | PM_FORCE_PET | PM_HASTE);
             }
 
             set_hero(player_ptr, randint1(base) + base, false);

--- a/src/room/vault-builder.cpp
+++ b/src/room/vault-builder.cpp
@@ -43,21 +43,19 @@ static bool is_cave_empty_grid(PlayerType *player_ptr, Grid *g_ptr)
  */
 void vault_monsters(PlayerType *player_ptr, POSITION y1, POSITION x1, int num)
 {
-    auto *floor_ptr = player_ptr->current_floor_ptr;
-    for (int k = 0; k < num; k++) {
-        for (int i = 0; i < 9; i++) {
-            int d = 1;
-            POSITION y, x;
-            scatter(player_ptr, &y, &x, y1, x1, d, 0);
-            Grid *g_ptr;
-            g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
-            if (!is_cave_empty_grid(player_ptr, g_ptr)) {
+    auto &floor = *player_ptr->current_floor_ptr;
+    for (auto k = 0; k < num; k++) {
+        for (auto i = 0; i < 9; i++) {
+            const auto d = 1;
+            const auto pos = scatter(player_ptr, { y1, x1 }, d, 0);
+            auto &grid = floor.get_grid(pos);
+            if (!is_cave_empty_grid(player_ptr, &grid)) {
                 continue;
             }
 
-            floor_ptr->monster_level = floor_ptr->base_level + 2;
-            (void)place_random_monster(player_ptr, y, x, PM_ALLOW_SLEEP | PM_ALLOW_GROUP);
-            floor_ptr->monster_level = floor_ptr->base_level;
+            floor.monster_level = floor.base_level + 2;
+            (void)place_random_monster(player_ptr, pos.y, pos.x, PM_ALLOW_SLEEP | PM_ALLOW_GROUP);
+            floor.monster_level = floor.base_level;
         }
     }
 }

--- a/src/spell-kind/spells-lite.cpp
+++ b/src/spell-kind/spells-lite.cpp
@@ -377,14 +377,13 @@ bool starlight(PlayerType *player_ptr, bool magic)
         msg_print(_("杖の先が明るく輝いた...", "The end of the staff glows brightly..."));
     }
 
-    int num = Dice::roll(5, 3);
-    auto y = 0;
-    auto x = 0;
-    for (int k = 0; k < num; k++) {
+    const auto p_pos = player_ptr->get_position();
+    const auto num = Dice::roll(5, 3);
+    for (auto k = 0; k < num; k++) {
+        Pos2D pos(0, 0);
         auto attempts = 1000;
         while (attempts--) {
-            scatter(player_ptr, &y, &x, player_ptr->y, player_ptr->x, 4, PROJECT_LOS);
-            const Pos2D pos(y, x);
+            pos = scatter(player_ptr, p_pos, 4, PROJECT_LOS);
             if (!player_ptr->current_floor_ptr->has_terrain_characteristics(pos, TerrainCharacteristics::PROJECT)) {
                 continue;
             }
@@ -395,7 +394,7 @@ bool starlight(PlayerType *player_ptr, bool magic)
         }
 
         constexpr uint flags = PROJECT_BEAM | PROJECT_THRU | PROJECT_GRID | PROJECT_KILL | PROJECT_LOS;
-        project(player_ptr, 0, 0, y, x, Dice::roll(6 + player_ptr->lev / 8, 10), AttributeType::LITE_WEAK, flags);
+        project(player_ptr, 0, 0, pos.y, pos.x, Dice::roll(6 + player_ptr->lev / 8, 10), AttributeType::LITE_WEAK, flags);
     }
 
     return true;

--- a/src/spell-kind/spells-neighbor.cpp
+++ b/src/spell-kind/spells-neighbor.cpp
@@ -126,13 +126,12 @@ bool animate_dead(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION y, POSIT
  */
 void wall_breaker(PlayerType *player_ptr)
 {
-    auto y = 0;
-    auto x = 0;
+    const auto p_pos = player_ptr->get_position();
     auto attempts = 1000;
     if (randint1(80 + player_ptr->lev) < 70) {
+        Pos2D pos(0, 0);
         while (attempts--) {
-            scatter(player_ptr, &y, &x, player_ptr->y, player_ptr->x, 4, PROJECT_NONE);
-            const Pos2D pos(y, x);
+            pos = scatter(player_ptr, p_pos, 4, PROJECT_NONE);
             if (!player_ptr->current_floor_ptr->has_terrain_characteristics(pos, TerrainCharacteristics::PROJECT)) {
                 continue;
             }
@@ -143,7 +142,7 @@ void wall_breaker(PlayerType *player_ptr)
         }
 
         constexpr auto flags = PROJECT_BEAM | PROJECT_THRU | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL;
-        project(player_ptr, 0, 0, y, x, 20 + randint1(30), AttributeType::KILL_WALL, flags);
+        project(player_ptr, 0, 0, pos.y, pos.x, 20 + randint1(30), AttributeType::KILL_WALL, flags);
         return;
     }
 
@@ -152,17 +151,17 @@ void wall_breaker(PlayerType *player_ptr)
         return;
     }
 
-    int num = Dice::roll(5, 3);
-    for (int i = 0; i < num; i++) {
+    const auto num = Dice::roll(5, 3);
+    for (auto i = 0; i < num; i++) {
+        Pos2D pos(0, 0);
         while (true) {
-            scatter(player_ptr, &y, &x, player_ptr->y, player_ptr->x, 10, PROJECT_NONE);
-            const Pos2D pos(y, x);
+            pos = scatter(player_ptr, p_pos, 10, PROJECT_NONE);
             if (!player_ptr->is_located_at(pos)) {
                 break;
             }
         }
 
         constexpr auto flags = PROJECT_BEAM | PROJECT_THRU | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL;
-        project(player_ptr, 0, 0, y, x, 20 + randint1(30), AttributeType::KILL_WALL, flags);
+        project(player_ptr, 0, 0, pos.y, pos.x, 20 + randint1(30), AttributeType::KILL_WALL, flags);
     }
 }

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -170,17 +170,17 @@ void wiz_dimension_door(PlayerType *player_ptr)
  */
 void wiz_summon_horde(PlayerType *player_ptr)
 {
-    POSITION wy = player_ptr->y, wx = player_ptr->x;
-    int attempts = 1000;
-
+    const auto p_pos = player_ptr->get_position();
+    auto pos = p_pos;
+    auto attempts = 1000;
     while (--attempts) {
-        scatter(player_ptr, &wy, &wx, player_ptr->y, player_ptr->x, 3, PROJECT_NONE);
-        if (is_cave_empty_bold(player_ptr, wy, wx)) {
+        pos = scatter(player_ptr, p_pos, 3, PROJECT_NONE);
+        if (is_cave_empty_bold(player_ptr, pos.y, pos.x)) {
             break;
         }
     }
 
-    (void)alloc_horde(player_ptr, wy, wx, summon_specific);
+    (void)alloc_horde(player_ptr, pos.y, pos.x, summon_specific);
 }
 
 /*!


### PR DESCRIPTION
(#4813 の件はありますが、これとこの次のPRはしばらく前に作って順繰りにレビューしてもらっていたものなので取り敢えず出すだけ出しておきます)

ざっくり検証ですが、ダンジョンをdevelopとこのブランチでデバッグ生成したところ、同じモンスター配置になりました
ご確認下さい
たった1コミットでえらいことになっていますが分割は難しいです (floor\_ptr → floor はコミットを分ける余地もあったか……)