### PR TITLE
自動拾い関係の引数からPlayerType を掃き出した

### DIFF
--- a/src/autopick/autopick-editor-command.cpp
+++ b/src/autopick/autopick-editor-command.cpp
@@ -57,7 +57,7 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
         }
 
         free_text_lines(tb->lines_list);
-        tb->lines_list = read_pickpref_text_lines(player_ptr, &tb->filename_mode);
+        tb->lines_list = read_pickpref_text_lines(player_ptr->base_name, &tb->filename_mode);
         tb->dirty_flags |= DIRTY_ALL | DIRTY_MODE | DIRTY_EXPRESSION;
         tb->cx = tb->cy = 0;
         tb->mark = 0;

--- a/src/autopick/autopick-reader-writer.cpp
+++ b/src/autopick/autopick-reader-writer.cpp
@@ -160,21 +160,21 @@ static void prepare_default_pickpref(std::string_view player_base_name)
  * @brief Read an autopick prefence file to memory
  * Prepare default if no user file is found
  */
-std::vector<concptr> read_pickpref_text_lines(PlayerType *player_ptr, int *filename_mode_p)
+std::vector<concptr> read_pickpref_text_lines(std::string_view player_base_name, int *filename_mode_p)
 {
     /* Try a filename with player name */
     *filename_mode_p = PT_WITH_PNAME;
-    auto filename = pickpref_filename(player_ptr->base_name, *filename_mode_p);
+    auto filename = pickpref_filename(player_base_name, *filename_mode_p);
     std::vector<concptr> lines_list = read_text_lines(filename);
 
     if (lines_list.empty()) {
         *filename_mode_p = PT_DEFAULT;
-        filename = pickpref_filename(player_ptr->base_name, *filename_mode_p);
+        filename = pickpref_filename(player_base_name, *filename_mode_p);
         lines_list = read_text_lines(filename);
     }
 
     if (lines_list.empty()) {
-        prepare_default_pickpref(player_ptr->base_name);
+        prepare_default_pickpref(player_base_name);
         lines_list = read_text_lines(filename);
     }
 

--- a/src/autopick/autopick-reader-writer.cpp
+++ b/src/autopick/autopick-reader-writer.cpp
@@ -20,7 +20,7 @@ void autopick_load_pref(PlayerType *player_ptr, bool disp_mes)
 {
     init_autopick();
 
-    const auto path = search_pickpref_path(player_ptr);
+    const auto path = search_pickpref_path(player_ptr->base_name);
     if (!path.empty()) {
         const auto pickpref_filename = path.filename().string();
         if (process_autopick_file(player_ptr, pickpref_filename) == 0) {
@@ -44,10 +44,10 @@ void autopick_load_pref(PlayerType *player_ptr, bool disp_mes)
  *
  * @return 見つかった自動拾い設定ファイルのパス。見つからなかった場合は空のパス。
  */
-std::filesystem::path search_pickpref_path(PlayerType *player_ptr)
+std::filesystem::path search_pickpref_path(std::string_view player_base_name)
 {
     for (const auto filename_mode : { PT_WITH_PNAME, PT_DEFAULT }) {
-        const auto filename = pickpref_filename(player_ptr->base_name, filename_mode);
+        const auto filename = pickpref_filename(player_base_name, filename_mode);
         const auto path = path_build(ANGBAND_DIR_USER, filename);
         if (std::filesystem::exists(path)) {
             return path;
@@ -113,13 +113,13 @@ static std::vector<concptr> read_text_lines(std::string_view filename)
 /*!
  * @brief Copy the default autopick file to the user directory
  */
-static void prepare_default_pickpref(PlayerType *player_ptr)
+static void prepare_default_pickpref(std::string_view player_base_name)
 {
     const std::vector<std::string> messages = { _("あなたは「自動拾いエディタ」を初めて起動しました。", "You have activated the Auto-Picker Editor for the first time."),
         _("自動拾いのユーザー設定ファイルがまだ書かれていないので、", "Since user pref file for autopick is not yet created,"),
         _("基本的な自動拾い設定ファイルをlib/pref/picktype.prfからコピーします。", "the default setting is loaded from lib/pref/pickpref.prf .") };
 
-    const auto filename = pickpref_filename(player_ptr->base_name, PT_DEFAULT);
+    const auto filename = pickpref_filename(player_base_name, PT_DEFAULT);
     for (const auto &message : messages) {
         msg_print(message);
     }
@@ -174,7 +174,7 @@ std::vector<concptr> read_pickpref_text_lines(PlayerType *player_ptr, int *filen
     }
 
     if (lines_list.empty()) {
-        prepare_default_pickpref(player_ptr);
+        prepare_default_pickpref(player_ptr->base_name);
         lines_list = read_text_lines(filename);
     }
 

--- a/src/autopick/autopick-reader-writer.cpp
+++ b/src/autopick/autopick-reader-writer.cpp
@@ -47,7 +47,7 @@ void autopick_load_pref(PlayerType *player_ptr, bool disp_mes)
 std::filesystem::path search_pickpref_path(PlayerType *player_ptr)
 {
     for (const auto filename_mode : { PT_WITH_PNAME, PT_DEFAULT }) {
-        const auto filename = pickpref_filename(player_ptr, filename_mode);
+        const auto filename = pickpref_filename(player_ptr->base_name, filename_mode);
         const auto path = path_build(ANGBAND_DIR_USER, filename);
         if (std::filesystem::exists(path)) {
             return path;
@@ -60,7 +60,7 @@ std::filesystem::path search_pickpref_path(PlayerType *player_ptr)
 /*!
  * @brief Get file name for autopick preference
  */
-std::string pickpref_filename(PlayerType *player_ptr, int filename_mode)
+std::string pickpref_filename(std::string_view player_base_name, int filename_mode)
 {
     static const char namebase[] = _("picktype", "pickpref");
 
@@ -69,7 +69,7 @@ std::string pickpref_filename(PlayerType *player_ptr, int filename_mode)
         return format("%s.prf", namebase);
 
     case PT_WITH_PNAME:
-        return format("%s-%s.prf", namebase, player_ptr->base_name);
+        return format("%s-%s.prf", namebase, player_base_name.data());
 
     default: {
         const auto msg = format("The value of argument 'filename_mode' is invalid: %d", filename_mode);
@@ -119,7 +119,7 @@ static void prepare_default_pickpref(PlayerType *player_ptr)
         _("自動拾いのユーザー設定ファイルがまだ書かれていないので、", "Since user pref file for autopick is not yet created,"),
         _("基本的な自動拾い設定ファイルをlib/pref/picktype.prfからコピーします。", "the default setting is loaded from lib/pref/pickpref.prf .") };
 
-    const auto filename = pickpref_filename(player_ptr, PT_DEFAULT);
+    const auto filename = pickpref_filename(player_ptr->base_name, PT_DEFAULT);
     for (const auto &message : messages) {
         msg_print(message);
     }
@@ -164,12 +164,12 @@ std::vector<concptr> read_pickpref_text_lines(PlayerType *player_ptr, int *filen
 {
     /* Try a filename with player name */
     *filename_mode_p = PT_WITH_PNAME;
-    auto filename = pickpref_filename(player_ptr, *filename_mode_p);
+    auto filename = pickpref_filename(player_ptr->base_name, *filename_mode_p);
     std::vector<concptr> lines_list = read_text_lines(filename);
 
     if (lines_list.empty()) {
         *filename_mode_p = PT_DEFAULT;
-        filename = pickpref_filename(player_ptr, *filename_mode_p);
+        filename = pickpref_filename(player_ptr->base_name, *filename_mode_p);
         lines_list = read_text_lines(filename);
     }
 

--- a/src/autopick/autopick-reader-writer.cpp
+++ b/src/autopick/autopick-reader-writer.cpp
@@ -202,7 +202,7 @@ bool write_text_lines(std::string_view filename, const std::vector<concptr> &lin
             break;
         }
 
-        angband_fputs(fff, line, 1024);
+        fprintf(fff, "%s\n", line);
     }
 
     angband_fclose(fff);

--- a/src/autopick/autopick-reader-writer.h
+++ b/src/autopick/autopick-reader-writer.h
@@ -9,6 +9,6 @@
 class PlayerType;
 void autopick_load_pref(PlayerType *player_ptr, bool disp_mes);
 std::filesystem::path search_pickpref_path(std::string_view player_base_name);
-std::vector<concptr> read_pickpref_text_lines(PlayerType *player_ptr, int *filename_mode_p);
+std::vector<concptr> read_pickpref_text_lines(std::string_view player_base_name, int *filename_mode_p);
 bool write_text_lines(std::string_view filename, const std::vector<concptr> &lines);
 std::string pickpref_filename(std::string_view player_base_name, int filename_mode);

--- a/src/autopick/autopick-reader-writer.h
+++ b/src/autopick/autopick-reader-writer.h
@@ -8,7 +8,7 @@
 
 class PlayerType;
 void autopick_load_pref(PlayerType *player_ptr, bool disp_mes);
-std::filesystem::path search_pickpref_path(PlayerType *player_ptr);
+std::filesystem::path search_pickpref_path(std::string_view player_base_name);
 std::vector<concptr> read_pickpref_text_lines(PlayerType *player_ptr, int *filename_mode_p);
 bool write_text_lines(std::string_view filename, const std::vector<concptr> &lines);
 std::string pickpref_filename(std::string_view player_base_name, int filename_mode);

--- a/src/autopick/autopick-reader-writer.h
+++ b/src/autopick/autopick-reader-writer.h
@@ -11,4 +11,4 @@ void autopick_load_pref(PlayerType *player_ptr, bool disp_mes);
 std::filesystem::path search_pickpref_path(PlayerType *player_ptr);
 std::vector<concptr> read_pickpref_text_lines(PlayerType *player_ptr, int *filename_mode_p);
 bool write_text_lines(std::string_view filename, const std::vector<concptr> &lines);
-std::string pickpref_filename(PlayerType *player_ptr, int filename_mode);
+std::string pickpref_filename(std::string_view player_base_name, int filename_mode);

--- a/src/autopick/autopick-registry.cpp
+++ b/src/autopick/autopick-registry.cpp
@@ -28,7 +28,7 @@ static const char autoregister_header[] = "?:$AUTOREGISTER";
  */
 static bool clear_auto_register(PlayerType *player_ptr)
 {
-    const auto path_pref = search_pickpref_path(player_ptr);
+    const auto path_pref = search_pickpref_path(player_ptr->base_name);
     if (path_pref.empty()) {
         return true;
     }
@@ -139,7 +139,7 @@ bool autopick_autoregister(PlayerType *player_ptr, const ItemEntity *o_ptr)
         }
     }
 
-    const auto path_pref = search_pickpref_path(player_ptr);
+    const auto path_pref = search_pickpref_path(player_ptr->base_name);
     auto *pref_fff = !path_pref.empty() ? angband_fopen(path_pref, FileOpenMode::READ) : nullptr;
 
     if (pref_fff) {

--- a/src/autopick/autopick-registry.cpp
+++ b/src/autopick/autopick-registry.cpp
@@ -26,9 +26,9 @@ static const char autoregister_header[] = "?:$AUTOREGISTER";
 /*!
  * @brief Clear auto registered lines in the picktype.prf .
  */
-static bool clear_auto_register(PlayerType *player_ptr)
+static bool clear_auto_register(std::string_view player_base_name)
 {
-    const auto path_pref = search_pickpref_path(player_ptr->base_name);
+    const auto path_pref = search_pickpref_path(player_base_name);
     if (path_pref.empty()) {
         return true;
     }
@@ -134,7 +134,7 @@ bool autopick_autoregister(PlayerType *player_ptr, const ItemEntity *o_ptr)
     }
 
     if (!player_ptr->autopick_autoregister) {
-        if (!clear_auto_register(player_ptr)) {
+        if (!clear_auto_register(player_ptr->base_name)) {
             return false;
         }
     }

--- a/src/cmd-io/cmd-autopick.cpp
+++ b/src/cmd-io/cmd-autopick.cpp
@@ -145,7 +145,7 @@ void do_cmd_edit_autopick(PlayerType *player_ptr)
         tb->last_destroyed = autopick_line_from_entry(*entry);
     }
 
-    tb->lines_list = read_pickpref_text_lines(player_ptr, &tb->filename_mode);
+    tb->lines_list = read_pickpref_text_lines(player_ptr->base_name, &tb->filename_mode);
     for (i = 0; i < tb->cy; i++) {
         if (!tb->lines_list[i]) {
             tb->cy = tb->cx = 0;

--- a/src/cmd-io/cmd-autopick.cpp
+++ b/src/cmd-io/cmd-autopick.cpp
@@ -15,6 +15,7 @@
 #include "io/input-key-acceptor.h"
 #include "io/read-pref-file.h"
 #include "system/item-entity.h"
+#include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "util/int-char-converter.h"
 #include "world/world.h"
@@ -201,7 +202,7 @@ void do_cmd_edit_autopick(PlayerType *player_ptr)
     }
 
     screen_load();
-    const auto filename = pickpref_filename(player_ptr, tb->filename_mode);
+    const auto filename = pickpref_filename(player_ptr->base_name, tb->filename_mode);
 
     if (quit == APE_QUIT_AND_SAVE) {
         write_text_lines(filename, tb->lines_list);

--- a/src/core/show-file.cpp
+++ b/src/core/show-file.cpp
@@ -496,7 +496,8 @@ void FileDisplayer::display(bool show_version, std::string_view name_with_tag, i
                 if (!line_str) {
                     break;
                 }
-                angband_fputs(ffp, line_str->data(), line_str->size());
+
+                fprintf(ffp, "%s\n", line_str->data());
             }
             angband_fclose(fff);
             angband_fclose(ffp);

--- a/src/util/angband-files.cpp
+++ b/src/util/angband-files.cpp
@@ -364,18 +364,6 @@ std::optional<std::string> angband_fgets(FILE *fp, size_t n)
 }
 
 /*
- * Hack -- replacement for "fputs()"
- * Dump a string, plus a newline, to a file
- * Process internal weirdness?
- */
-errr angband_fputs(FILE *fff, concptr buf, ulong n)
-{
-    n = n ? n : 0;
-    (void)fprintf(fff, "%s\n", buf);
-    return 0;
-}
-
-/*
  * Several systems have no "O_BINARY" flag
  */
 #ifndef O_BINARY

--- a/src/util/angband-files.h
+++ b/src/util/angband-files.h
@@ -48,7 +48,6 @@ std::filesystem::path path_build(const std::filesystem::path &path, std::string_
 FILE *angband_fopen(const std::filesystem::path &path, const FileOpenMode mode, const bool is_binary = false);
 FILE *angband_fopen_temp(char *buf, int max);
 std::optional<std::string> angband_fgets(FILE *fp, size_t n = std::string::npos);
-errr angband_fputs(FILE *fff, concptr buf, ulong n);
 errr angband_fclose(FILE *fff);
 void fd_kill(const std::filesystem::path &path);
 void fd_move(const std::filesystem::path &path_from, const std::filesystem::path &path_to);


### PR DESCRIPTION
掲題の通りです
angband\_fputs() はこれといってバッファオーバーフロー対策を何もやっていない無意味なラッパー関数感があるので、この際消してしまっても良いように思います
ご意見あればお願いします