### PR TITLE
[Refactor] fill_treasureの引数をRect2D型にする

### DIFF
--- a/src/room/rooms-maze-vault.cpp
+++ b/src/room/rooms-maze-vault.cpp
@@ -135,6 +135,6 @@ void build_maze_vault(PlayerType *player_ptr, const Pos2D &center, const Pos2DVe
     std::vector<int> visited(num_vertices);
     r_visit(player_ptr, y1, x1, y2, x2, randint0(num_vertices), 0, visited.data());
     if (is_vault) {
-        fill_treasure(player_ptr, { y1, x1 }, { y2, x2 }, randint1(5));
+        fill_treasure(player_ptr, { y1, x1, y2, x2 }, randint1(5));
     }
 }

--- a/src/room/treasure-deployment.cpp
+++ b/src/room/treasure-deployment.cpp
@@ -125,15 +125,13 @@ void deploy_treasure(PlayerType *player_ptr, FloorType &floor, const Pos2D &cent
 /*
  * Routine that fills the empty areas of a room with treasure and monsters.
  */
-void fill_treasure(PlayerType *player_ptr, const Pos2D &top_left, const Pos2D &bottom_right, int difficulty)
+void fill_treasure(PlayerType *player_ptr, const Rect2D &area, int difficulty)
 {
-    const auto center = Pos2D::midpoint(top_left, bottom_right);
-    const auto size = std::abs(bottom_right.x - top_left.x) + std::abs(bottom_right.y - top_left.y);
+    const auto center = area.center();
+    const auto size = area.width() - 1 + area.height() - 1;
     auto &floor = *player_ptr->current_floor_ptr;
 
-    for (auto x = top_left.x; x <= bottom_right.x; x++) {
-        for (auto y = top_left.y; y <= bottom_right.y; y++) {
-            deploy_treasure(player_ptr, floor, center, { y, x }, size, difficulty);
-        }
-    }
+    area.each_area([&](const Pos2D &pos) {
+        deploy_treasure(player_ptr, floor, center, pos, size, difficulty);
+    });
 }

--- a/src/room/treasure-deployment.h
+++ b/src/room/treasure-deployment.h
@@ -3,4 +3,4 @@
 #include "util/point-2d.h"
 
 class PlayerType;
-void fill_treasure(PlayerType *player_ptr, const Pos2D &top_left, const Pos2D &bottom_right, int difficulty);
+void fill_treasure(PlayerType *player_ptr, const Rect2D &area, int difficulty);

--- a/src/util/point-2d.h
+++ b/src/util/point-2d.h
@@ -157,6 +157,21 @@ struct Rectangle2D {
     {
     }
 
+    constexpr T width() const
+    {
+        return this->bottom_right.x - this->top_left.x + 1;
+    }
+
+    constexpr T height() const
+    {
+        return this->bottom_right.y - this->top_left.y + 1;
+    }
+
+    constexpr Point2D<T> center() const
+    {
+        return Point2D<T>::midpoint(this->top_left, this->bottom_right);
+    }
+
     constexpr Rectangle2D resized(T margin) const
     {
         const Vector2D<T> vec(margin, margin);

--- a/src/util/point-2d.h
+++ b/src/util/point-2d.h
@@ -141,9 +141,14 @@ template <std::integral T>
 struct Rectangle2D {
     Point2D<T> top_left;
     Point2D<T> bottom_right;
+    constexpr Rectangle2D(T y1, T x1, T y2, T x2)
+        : top_left(std::min<T>(y1, y2), std::min<T>(x1, x2))
+        , bottom_right(std::max<T>(y1, y2), std::max<T>(x1, x2))
+    {
+    }
+
     constexpr Rectangle2D(const Point2D<T> &pos1, const Point2D<T> &pos2)
-        : top_left(std::min<T>(pos1.y, pos2.y), std::min<T>(pos1.x, pos2.x))
-        , bottom_right(std::max<T>(pos1.y, pos2.y), std::max<T>(pos1.x, pos2.x))
+        : Rectangle2D(pos1.y, pos1.x, pos2.y, pos2.x)
     {
     }
 


### PR DESCRIPTION
https://github.com/hengband/hengband/pull/4819#pullrequestreview-2546018618 のRect2D化です。

厳密にはxとyのイテレーションの優先順位が入れ替わっています（元は for x for y、each_areaの実装は for y for x）が、本質的に問題は無いと思います。

なお、room_info_nomral テーブルをいじって build_type10 が呼ばれまくるようにした状態にしたうえで、一時的に元と同じ順序の優先順位でのイテレーションをする each_area2 を実装してfill_treasureからそちらを呼ぶようにしたものと、変更前のコードで同じセーブファイルから複数回ダンジョンを生成し、毎回同じマップが生成されるのを確認しています。