### PR TITLE
自動拾い関係のconcptr をstring に変えた

### DIFF
--- a/src/autopick/autopick-drawer.cpp
+++ b/src/autopick/autopick-drawer.cpp
@@ -215,11 +215,11 @@ void draw_text_editor(PlayerType *player_ptr, text_body_type *tb)
     }
 
     if (tb->dirty_flags & DIRTY_NOT_FOUND) {
-        str1 = format(_("パターンが見つかりません: %s", "Pattern not found: %s"), tb->search_str);
+        str1 = format(_("パターンが見つかりません: %s", "Pattern not found: %s"), tb->search_str.data());
     } else if (tb->dirty_flags & DIRTY_SKIP_INACTIVE) {
-        str1 = format(_("無効状態の行をスキップしました。(%sを検索中)", "Some inactive lines are skipped. (Searching %s)"), tb->search_str);
+        str1 = format(_("無効状態の行をスキップしました。(%sを検索中)", "Some inactive lines are skipped. (Searching %s)"), tb->search_str.data());
     } else if (tb->dirty_flags & DIRTY_INACTIVE) {
-        str1 = format(_("無効状態の行だけが見付かりました。(%sを検索中)", "Found only an inactive line. (Searching %s)"), tb->search_str);
+        str1 = format(_("無効状態の行だけが見付かりました。(%sを検索中)", "Found only an inactive line. (Searching %s)"), tb->search_str.data());
     } else if (tb->dirty_flags & DIRTY_NO_SEARCH) {
         str1 = _("検索するパターンがありません(^S で検索)。", "No pattern to search. (Press ^S to search.)");
     } else if ((*tb->lines_list[tb->cy])[0] == '#') {

--- a/src/autopick/autopick-editor-command.cpp
+++ b/src/autopick/autopick-editor-command.cpp
@@ -26,6 +26,7 @@
 #include "system/player-type-definition.h"
 #include "term/term-color-types.h"
 #include "term/z-form.h"
+#include <sstream>
 #include <string>
 #include <string_view>
 
@@ -56,7 +57,6 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
             break;
         }
 
-        free_text_lines(tb->lines_list);
         tb->lines_list = read_pickpref_text_lines(player_ptr->base_name, &tb->filename_mode);
         tb->dirty_flags |= DIRTY_ALL | DIRTY_MODE | DIRTY_EXPRESSION;
         tb->cx = tb->cy = 0;
@@ -85,18 +85,14 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
     }
     case EC_LEFT: {
         if (0 < tb->cx) {
-            int len;
-#ifdef JP
-            int i;
-#endif
             tb->cx--;
-            len = strlen(tb->lines_list[tb->cy]);
+            const int len = tb->lines_list[tb->cy]->length();
             if (len < tb->cx) {
                 tb->cx = len;
             }
 #ifdef JP
-            for (i = 0; tb->lines_list[tb->cy][i]; i++) {
-                if (iskanji(tb->lines_list[tb->cy][i])) {
+            for (auto i = 0; (*tb->lines_list[tb->cy])[i] != '\0'; i++) {
+                if (iskanji((*tb->lines_list[tb->cy])[i])) {
                     i++;
                     if (i == tb->cx) {
                         tb->cx--;
@@ -107,7 +103,7 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
 #endif
         } else if (tb->cy > 0) {
             tb->cy--;
-            tb->cx = strlen(tb->lines_list[tb->cy]);
+            tb->cx = tb->lines_list[tb->cy]->length();
         }
 
         break;
@@ -128,9 +124,9 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
         }
         break;
     case EC_RIGHT: {
-        const int len = strlen(tb->lines_list[tb->cy]);
+        const int len = tb->lines_list[tb->cy]->length();
 #ifdef JP
-        if ((tb->cx + 1 < len) && iskanji(tb->lines_list[tb->cy][tb->cx])) {
+        if ((tb->cx + 1 < len) && iskanji((*tb->lines_list[tb->cy])[tb->cx])) {
             tb->cx++;
         }
 #endif
@@ -154,7 +150,7 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
         tb->cx = 0;
         break;
     case EC_EOL:
-        tb->cx = strlen(tb->lines_list[tb->cy]);
+        tb->cx = tb->lines_list[tb->cy]->length();
         break;
     case EC_PGUP:
         while (0 < tb->cy && tb->upper <= tb->cy) {
@@ -198,9 +194,9 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
     case EC_CUT: {
         copy_text_to_yank(tb);
         if (tb->my == tb->cy) {
-            int bx1 = std::min(tb->mx, tb->cx);
-            int bx2 = std::max(tb->mx, tb->cx);
-            int len = strlen(tb->lines_list[tb->cy]);
+            const auto bx1 = std::min(tb->mx, tb->cx);
+            auto bx2 = std::max(tb->mx, tb->cx);
+            const int len = tb->lines_list[tb->cy]->length();
             if (bx2 > len) {
                 bx2 = len;
             }
@@ -208,12 +204,10 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
             kill_line_segment(tb, tb->cy, bx1, bx2, true);
             tb->cx = bx1;
         } else {
-            int by1 = std::min(tb->my, tb->cy);
-            int by2 = std::max(tb->my, tb->cy);
-
-            for (int y = by2; y >= by1; y--) {
-                int len = strlen(tb->lines_list[y]);
-
+            const auto by1 = std::min(tb->my, tb->cy);
+            const auto by2 = std::max(tb->my, tb->cy);
+            for (auto y = by2; y >= by1; y--) {
+                const int len = tb->lines_list[y]->length();
                 kill_line_segment(tb, y, 0, len, true);
             }
 
@@ -247,7 +241,7 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
         }
 
         tb->cx = std::max(tb->cx, tb->mx);
-        if (!tb->lines_list[tb->cy][tb->cx]) {
+        if ((*tb->lines_list[tb->cy])[tb->cx] == '\0') {
             if (!tb->lines_list[tb->cy + 1]) {
                 if (!add_empty_line(tb)) {
                     break;
@@ -261,7 +255,7 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
         break;
     }
     case EC_PASTE: {
-        int len = strlen(tb->lines_list[tb->cy]);
+        const int len = tb->lines_list[tb->cy]->length();
         if (tb->yank.empty()) {
             break;
         }
@@ -275,7 +269,7 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
         }
 
         for (auto i = 0U; i < tb->yank.size(); ++i) {
-            const std::string_view line(tb->lines_list[tb->cy]);
+            const std::string_view line(*tb->lines_list[tb->cy]);
             std::string buf(line.substr(0, tb->cx));
             buf.append(tb->yank[i], 0, MAX_LINELEN - buf.length() - 1);
 
@@ -284,11 +278,10 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
                 if (!insert_return_code(tb)) {
                     break;
                 }
-                string_free(tb->lines_list[tb->cy]);
-                tb->lines_list[tb->cy] = string_make(buf.data());
+
+                tb->lines_list[tb->cy] = std::make_unique<std::string>(std::move(buf));
                 tb->cx = 0;
                 tb->cy++;
-
                 continue;
             }
 
@@ -296,8 +289,7 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
             tb->cx = buf.length();
             buf.append(rest, 0, MAX_LINELEN - buf.length() - 1);
 
-            string_free(tb->lines_list[tb->cy]);
-            tb->lines_list[tb->cy] = string_make(buf.data());
+            tb->lines_list[tb->cy] = std::make_unique<std::string>(std::move(buf));
             break;
         }
 
@@ -325,7 +317,7 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
             break;
         }
 
-        int len = strlen(tb->lines_list[tb->cy]);
+        const int len = tb->lines_list[tb->cy]->length();
 
         tb->my = tb->cy;
         tb->mx = tb->cx;
@@ -335,7 +327,7 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
         break;
     }
     case EC_KILL_LINE: {
-        int len = strlen(tb->lines_list[tb->cy]);
+        const int len = tb->lines_list[tb->cy]->length();
         if (tb->cx > len) {
             tb->cx = len;
         }
@@ -350,7 +342,7 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
         }
 
         if (tb->cx < len) {
-            add_str_to_yank(tb, &(tb->lines_list[tb->cy][tb->cx]));
+            add_str_to_yank(tb, &((*tb->lines_list[tb->cy])[tb->cx]));
             kill_line_segment(tb, tb->cy, tb->cx, len, false);
             tb->dirty_line = tb->cy;
             break;
@@ -371,12 +363,12 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
         }
 
 #ifdef JP
-        if (iskanji(tb->lines_list[tb->cy][tb->cx])) {
+        if (iskanji((*tb->lines_list[tb->cy])[tb->cx])) {
             tb->cx++;
         }
 #endif
         tb->cx++;
-        int len = strlen(tb->lines_list[tb->cy]);
+        const int len = tb->lines_list[tb->cy]->length();
         if (len >= tb->cx) {
             do_editor_command(player_ptr, tb, EC_BACKSPACE);
             break;
@@ -394,14 +386,12 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
         break;
     }
     case EC_BACKSPACE: {
-        int len, i, j, k;
-        char buf[MAX_LINELEN];
         if (tb->mark) {
             tb->mark = 0;
             tb->dirty_flags |= DIRTY_ALL;
         }
 
-        len = strlen(tb->lines_list[tb->cy]);
+        const int len = tb->lines_list[tb->cy]->length();
         if (len < tb->cx) {
             tb->cx = len;
         }
@@ -410,18 +400,17 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
             if (tb->cy == 0) {
                 break;
             }
-            tb->cx = strlen(tb->lines_list[tb->cy - 1]);
-            strcpy(buf, tb->lines_list[tb->cy - 1]);
-            strcat(buf, tb->lines_list[tb->cy]);
-            string_free(tb->lines_list[tb->cy - 1]);
-            string_free(tb->lines_list[tb->cy]);
-            tb->lines_list[tb->cy - 1] = string_make(buf);
+            tb->cx = tb->lines_list[tb->cy - 1]->length();
+            std::stringstream ss;
+            ss << *tb->lines_list[tb->cy - 1] << *tb->lines_list[tb->cy];
+            tb->lines_list[tb->cy - 1] = std::make_unique<std::string>(ss.str());
 
+            int i;
             for (i = tb->cy; tb->lines_list[i + 1]; i++) {
-                tb->lines_list[i] = tb->lines_list[i + 1];
+                std::swap(tb->lines_list[i], tb->lines_list[i + 1]);
             }
 
-            tb->lines_list[i] = nullptr;
+            tb->lines_list[i].reset();
             tb->cy--;
             tb->dirty_flags |= DIRTY_ALL;
             tb->dirty_flags |= DIRTY_EXPRESSION;
@@ -429,28 +418,18 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
             break;
         }
 
-        for (i = j = k = 0; tb->lines_list[tb->cy][i] && i < tb->cx; i++) {
-            k = j;
+        auto first_half = 0;
+        for (auto i = 0; (*tb->lines_list[tb->cy])[i] != '\0' && i < tb->cx; i++) {
+            first_half = i;
 #ifdef JP
-            if (iskanji(tb->lines_list[tb->cy][i])) {
-                buf[j++] = tb->lines_list[tb->cy][i++];
+            if (iskanji((*tb->lines_list[tb->cy])[i])) {
+                i++;
             }
 #endif
-            buf[j++] = tb->lines_list[tb->cy][i];
         }
 
-        while (j > k) {
-            tb->cx--;
-            j--;
-        }
-
-        for (; tb->lines_list[tb->cy][i]; i++) {
-            buf[j++] = tb->lines_list[tb->cy][i];
-        }
-
-        buf[j] = '\0';
-        string_free(tb->lines_list[tb->cy]);
-        tb->lines_list[tb->cy] = string_make(buf);
+        tb->lines_list[tb->cy]->erase(first_half, tb->cx - first_half);
+        tb->cx = first_half;
         tb->dirty_line = tb->cy;
         check_expression_line(tb, tb->cy);
         tb->changed = true;
@@ -531,8 +510,8 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
         if (!insert_return_code(tb)) {
             break;
         }
-        string_free(tb->lines_list[tb->cy]);
-        tb->lines_list[tb->cy] = autopick_line_from_entry(*entry);
+
+        tb->lines_list[tb->cy] = std::make_unique<std::string>(autopick_line_from_entry(*entry));
         tb->dirty_flags |= DIRTY_SCREEN;
         break;
     }
@@ -545,8 +524,8 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
         if (!insert_return_code(tb)) {
             break;
         }
-        string_free(tb->lines_list[tb->cy]);
-        tb->lines_list[tb->cy] = string_make(tb->last_destroyed);
+
+        tb->lines_list[tb->cy] = std::make_unique<std::string>(tb->last_destroyed);
         tb->dirty_flags |= DIRTY_ALL;
         tb->changed = true;
         break;
@@ -560,12 +539,10 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
             player_ptr->lev);
         tb->cx = 0;
         insert_return_code(tb);
-        string_free(tb->lines_list[tb->cy]);
-        tb->lines_list[tb->cy] = string_make(expression.data());
+        tb->lines_list[tb->cy] = std::make_unique<std::string>(expression);
         tb->cy++;
         insert_return_code(tb);
-        string_free(tb->lines_list[tb->cy]);
-        tb->lines_list[tb->cy] = string_make("?:1");
+        tb->lines_list[tb->cy] = std::make_unique<std::string>("?:1");
         tb->dirty_flags |= DIRTY_ALL;
         tb->changed = true;
         break;

--- a/src/autopick/autopick-editor-command.cpp
+++ b/src/autopick/autopick-editor-command.cpp
@@ -516,7 +516,7 @@ ape_quittance do_editor_command(PlayerType *player_ptr, text_body_type *tb, int 
         break;
     }
     case EC_INSERT_DESTROYED: {
-        if (!tb->last_destroyed) {
+        if (tb->last_destroyed.empty()) {
             break;
         }
 

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -32,16 +32,18 @@ static char kanji_colon[] = "：";
 /*!
  * @brief A function to create new entry
  */
-bool autopick_new_entry(autopick_type *entry, concptr str, bool allow_default)
+bool autopick_new_entry(autopick_type *entry, std::string_view str_view, bool allow_default)
 {
-    if (str[0] && str[1] == ':') {
-        switch (str[0]) {
+    if ((str_view.length() > 1) && (str_view[1] == ':')) {
+        switch (str_view[0]) {
         case '?':
         case '%':
         case 'A':
         case 'P':
         case 'C':
             return false;
+        default:
+            break;
         }
     }
 
@@ -50,6 +52,7 @@ bool autopick_new_entry(autopick_type *entry, concptr str, bool allow_default)
     entry->bonus = 0;
 
     byte act = DO_AUTOPICK | DO_DISPLAY;
+    auto str = str_view.data();
     while (true) {
         if ((act & DO_AUTOPICK) && *str == '!') {
             act &= ~DO_AUTOPICK;

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -531,7 +531,7 @@ void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, co
     entry->name = str_tolower(std::string(is_hat_added ? "^" : "").append(item_name));
 }
 
-std::string shape_autopick_key(const std::string &key)
+static std::string shape_autopick_key(const std::string &key)
 {
 #ifdef JP
     return key;
@@ -545,7 +545,7 @@ std::string shape_autopick_key(const std::string &key)
 /*!
  * @brief Reconstruct preference line from entry
  */
-concptr autopick_line_from_entry(const autopick_type &entry)
+std::string autopick_line_from_entry(const autopick_type &entry)
 {
     std::stringstream ss;
     if (!(entry.action & DO_DISPLAY)) {
@@ -724,13 +724,11 @@ concptr autopick_line_from_entry(const autopick_type &entry)
     }
 
     if (entry.insc.empty()) {
-        auto str = ss.str();
-        return string_make(str.data());
+        return ss.str();
     }
 
     ss << '#' << entry.insc;
-    auto str = ss.str();
-    return string_make(str.data());
+    return ss.str();
 }
 
 /*!

--- a/src/autopick/autopick-entry.h
+++ b/src/autopick/autopick-entry.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "system/angband.h"
 #include <string_view>
 
 struct autopick_type;
@@ -8,5 +7,5 @@ class ItemEntity;
 class PlayerType;
 bool autopick_new_entry(autopick_type *entry, std::string_view str, bool allow_default);
 void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, const ItemEntity *o_ptr);
-concptr autopick_line_from_entry(const autopick_type &entry);
+std::string autopick_line_from_entry(const autopick_type &entry);
 bool entry_from_choosed_object(PlayerType *player_ptr, autopick_type *entry);

--- a/src/autopick/autopick-entry.h
+++ b/src/autopick/autopick-entry.h
@@ -1,11 +1,12 @@
 #pragma once
 
 #include "system/angband.h"
+#include <string_view>
 
 struct autopick_type;
 class ItemEntity;
 class PlayerType;
-bool autopick_new_entry(autopick_type *entry, concptr str, bool allow_default);
+bool autopick_new_entry(autopick_type *entry, std::string_view str, bool allow_default);
 void autopick_entry_from_object(PlayerType *player_ptr, autopick_type *entry, const ItemEntity *o_ptr);
 concptr autopick_line_from_entry(const autopick_type &entry);
 bool entry_from_choosed_object(PlayerType *player_ptr, autopick_type *entry);

--- a/src/autopick/autopick-finder.cpp
+++ b/src/autopick/autopick-finder.cpp
@@ -325,7 +325,7 @@ void search_for_object(PlayerType *player_ptr, text_body_type *tb, const ItemEnt
             }
         }
 
-        if (!autopick_new_entry(entry, tb->lines_list[i], false)) {
+        if (!autopick_new_entry(entry, *tb->lines_list[i], false)) {
             continue;
         }
 
@@ -370,7 +370,6 @@ void search_for_string(text_body_type *tb, concptr search_str, bool forward)
 
     int i = tb->cy;
     while (true) {
-        concptr pos;
         if (forward) {
             if (!tb->lines_list[++i]) {
                 break;
@@ -381,7 +380,8 @@ void search_for_string(text_body_type *tb, concptr search_str, bool forward)
             }
         }
 
-        pos = angband_strstr(tb->lines_list[i], search_str);
+        const auto line_data = tb->lines_list[i]->data();
+        const auto *pos = angband_strstr(line_data, search_str);
         if (!pos) {
             continue;
         }
@@ -389,13 +389,13 @@ void search_for_string(text_body_type *tb, concptr search_str, bool forward)
         if ((tb->states[i] & LSTAT_BYPASS) && !(tb->states[i] & LSTAT_EXPRESSION)) {
             if (bypassed_cy == -1) {
                 bypassed_cy = i;
-                bypassed_cx = (int)(pos - tb->lines_list[i]);
+                bypassed_cx = (int)(pos - line_data);
             }
 
             continue;
         }
 
-        tb->cx = (int)(pos - tb->lines_list[i]);
+        tb->cx = (int)(pos - line_data);
         tb->cy = i;
 
         if (bypassed_cy != -1) {

--- a/src/autopick/autopick-finder.h
+++ b/src/autopick/autopick-finder.h
@@ -1,13 +1,34 @@
 #pragma once
 
-#include "system/angband.h"
+#include <string>
+#include <string_view>
 
 class ItemEntity;
 class PlayerType;
 struct text_body_type;
 int find_autopick_list(PlayerType *player_ptr, const ItemEntity *o_ptr);
-bool get_object_for_search(PlayerType *player_ptr, ItemEntity **o_handle, concptr *search_strp);
-bool get_destroyed_object_for_search(PlayerType *player_ptr, ItemEntity **o_handle, concptr *search_strp);
-byte get_string_for_search(PlayerType *player_ptr, ItemEntity **o_handle, concptr *search_strp);
 void search_for_object(PlayerType *player_ptr, text_body_type *tb, const ItemEntity *o_ptr, bool forward);
-void search_for_string(text_body_type *tb, concptr search_str, bool forward);
+void search_for_string(text_body_type *tb, std::string_view search_str, bool forward);
+
+enum class AutopickSearchResult {
+    BACK = -1,
+    CANCEL = 0,
+    FORWARD = 1,
+};
+
+class AutopickSearch {
+public:
+    AutopickSearch(ItemEntity *item_ptr, std::string_view search_str)
+        : item_ptr(item_ptr)
+        , search_str(search_str)
+    {
+    }
+
+    ItemEntity *item_ptr;
+    std::string search_str;
+    AutopickSearchResult result = AutopickSearchResult::CANCEL;
+};
+
+AutopickSearch get_string_for_search(PlayerType *player_ptr, const AutopickSearch &as_initial);
+bool get_object_for_search(PlayerType *player_ptr, AutopickSearch &as);
+bool get_destroyed_object_for_search(PlayerType *player_ptr, AutopickSearch &as);

--- a/src/autopick/autopick-reader-writer.cpp
+++ b/src/autopick/autopick-reader-writer.cpp
@@ -188,8 +188,8 @@ std::vector<std::unique_ptr<std::string>> read_pickpref_text_lines(std::string_v
 bool write_text_lines(std::string_view filename, const std::vector<std::unique_ptr<std::string>> &lines)
 {
     const auto path = path_build(ANGBAND_DIR_USER, filename);
-    auto *fff = angband_fopen(path, FileOpenMode::WRITE);
-    if (!fff) {
+    auto ofs = std::ofstream(path);
+    if (!ofs) {
         return false;
     }
 
@@ -198,9 +198,8 @@ bool write_text_lines(std::string_view filename, const std::vector<std::unique_p
             break;
         }
 
-        fprintf(fff, "%s\n", line->data());
+        ofs << *line << '\n';
     }
 
-    angband_fclose(fff);
     return true;
 }

--- a/src/autopick/autopick-reader-writer.h
+++ b/src/autopick/autopick-reader-writer.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "system/angband.h"
 #include <filesystem>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -9,6 +9,6 @@
 class PlayerType;
 void autopick_load_pref(PlayerType *player_ptr, bool disp_mes);
 std::filesystem::path search_pickpref_path(std::string_view player_base_name);
-std::vector<concptr> read_pickpref_text_lines(std::string_view player_base_name, int *filename_mode_p);
-bool write_text_lines(std::string_view filename, const std::vector<concptr> &lines);
+std::vector<std::unique_ptr<std::string>> read_pickpref_text_lines(std::string_view player_base_name, int *filename_mode_p);
+bool write_text_lines(std::string_view filename, const std::vector<std::unique_ptr<std::string>> &lines);
 std::string pickpref_filename(std::string_view player_base_name, int filename_mode);

--- a/src/autopick/autopick-registry.cpp
+++ b/src/autopick/autopick-registry.cpp
@@ -187,9 +187,8 @@ bool autopick_autoregister(PlayerType *player_ptr, const ItemEntity *o_ptr)
     entry->action = DO_AUTODESTROY;
     autopick_list.push_back(*entry);
 
-    concptr tmp = autopick_line_from_entry(*entry);
-    fprintf(pref_fff, "%s\n", tmp);
-    string_free(tmp);
+    const auto line = autopick_line_from_entry(*entry);
+    fprintf(pref_fff, "%s\n", line.data());
     fclose(pref_fff);
     return true;
 }

--- a/src/autopick/autopick-util.cpp
+++ b/src/autopick/autopick-util.cpp
@@ -39,18 +39,6 @@ void autopick_type::remove(int flag)
 }
 
 /*!
- * @brief Free memory of lines_list.
- */
-void free_text_lines(std::vector<concptr> &lines_list)
-{
-    for (int lines = 0; lines_list[lines]; lines++) {
-        string_free(lines_list[lines]);
-    }
-
-    lines_list.clear();
-}
-
-/*!
  * @brief Find a command by 'key'.
  */
 int get_com_id(char key)

--- a/src/autopick/autopick-util.cpp
+++ b/src/autopick/autopick-util.cpp
@@ -97,10 +97,9 @@ void auto_inscribe_item(ItemEntity *o_ptr, int idx)
  */
 int count_line(text_body_type *tb)
 {
-    int num_lines;
-    for (num_lines = 0; tb->lines_list[num_lines]; num_lines++) {
-        ;
-    }
-
-    return num_lines;
+    const auto begin = tb->lines_list.begin();
+    const auto it = std::find_if(begin, tb->lines_list.end(), [](const auto &line) {
+        return !line;
+    });
+    return std::distance(begin, it);
 }

--- a/src/autopick/autopick-util.h
+++ b/src/autopick/autopick-util.h
@@ -80,7 +80,6 @@ struct text_body_type {
 extern std::vector<autopick_type> autopick_list;
 extern ItemEntity autopick_last_destroyed_object;
 
-void free_text_lines(std::vector<concptr> &lines_list);
 int get_com_id(char key);
 void auto_inscribe_item(ItemEntity *o_ptr, int idx);
 int count_line(text_body_type *tb);

--- a/src/autopick/autopick-util.h
+++ b/src/autopick/autopick-util.h
@@ -58,7 +58,7 @@ struct text_body_type {
 
     ItemEntity *search_o_ptr = nullptr;
     concptr search_str = "";
-    concptr last_destroyed = "";
+    std::string last_destroyed = "";
 
     std::vector<std::string> yank{};
     bool yank_eol = false;

--- a/src/autopick/autopick-util.h
+++ b/src/autopick/autopick-util.h
@@ -41,17 +41,18 @@ struct autopick_type {
  */
 class ItemEntity;
 struct text_body_type {
+    text_body_type(int cx, int cy); //!< @details 画面表示はX→Yの順番であることが多いので一応揃える.
+    int cx;
+    int cy;
     int wid = 0;
     int hgt = 0;
-    int cx = 0;
-    int cy = 0;
     int upper = 0;
     int left = 0;
-    int old_wid = 0;
-    int old_hgt = 0;
-    int old_cy = 0;
-    int old_upper = 0;
-    int old_left = 0;
+    int old_wid = -1;
+    int old_hgt = -1;
+    int old_cy = -1;
+    int old_upper = -1;
+    int old_left = -1;
     int mx = 0;
     int my = 0;
     byte mark = 0;
@@ -67,7 +68,7 @@ struct text_body_type {
     byte states[MAX_LINES]{};
 
     uint16_t dirty_flags = 0;
-    int dirty_line = 0;
+    int dirty_line = -1;
     int filename_mode = 0;
     int old_com_id = 0;
 

--- a/src/autopick/autopick-util.h
+++ b/src/autopick/autopick-util.h
@@ -57,7 +57,7 @@ struct text_body_type {
     byte mark = 0;
 
     ItemEntity *search_o_ptr = nullptr;
-    concptr search_str = "";
+    std::string search_str = "";
     std::string last_destroyed = "";
 
     std::vector<std::string> yank{};

--- a/src/autopick/autopick-util.h
+++ b/src/autopick/autopick-util.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "system/angband.h"
-
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -63,7 +63,7 @@ struct text_body_type {
     std::vector<std::string> yank{};
     bool yank_eol = false;
 
-    std::vector<concptr> lines_list{};
+    std::vector<std::unique_ptr<std::string>> lines_list;
     byte states[MAX_LINES]{};
 
     uint16_t dirty_flags = 0;

--- a/src/cmd-io/cmd-autopick.cpp
+++ b/src/cmd-io/cmd-autopick.cpp
@@ -78,7 +78,7 @@ static int analyze_move_key(text_body_type *tb, uint32_t skey)
         return com_id;
     }
 
-    int len = strlen(tb->lines_list[tb->cy]);
+    const int len = tb->lines_list[tb->cy]->length();
     tb->mark = MARK_MARK | MARK_BY_SHIFT;
     tb->my = tb->cy;
     tb->mx = tb->cx;
@@ -211,7 +211,6 @@ void do_cmd_edit_autopick(PlayerType *player_ptr)
         write_text_lines(filename, tb->lines_list);
     }
 
-    free_text_lines(tb->lines_list);
     string_free(tb->search_str);
     string_free(tb->last_destroyed);
     kill_yank_chain(tb);

--- a/src/cmd-io/cmd-autopick.cpp
+++ b/src/cmd-io/cmd-autopick.cpp
@@ -123,7 +123,6 @@ void do_cmd_edit_autopick(PlayerType *player_ptr)
 
     tb->yank.clear();
     tb->search_o_ptr = nullptr;
-    tb->search_str = nullptr;
     tb->dirty_flags = DIRTY_ALL | DIRTY_MODE | DIRTY_EXPRESSION;
     tb->dirty_line = -1;
     tb->filename_mode = PT_DEFAULT;
@@ -209,9 +208,6 @@ void do_cmd_edit_autopick(PlayerType *player_ptr)
     if (quit == APE_QUIT_AND_SAVE) {
         write_text_lines(filename, tb->lines_list);
     }
-
-    string_free(tb->search_str);
-    kill_yank_chain(tb);
 
     process_autopick_file(player_ptr, filename);
     cx_save = tb->cx;

--- a/src/cmd-io/cmd-autopick.cpp
+++ b/src/cmd-io/cmd-autopick.cpp
@@ -22,6 +22,12 @@
 #include "util/int-char-converter.h"
 #include "world/world.h"
 
+text_body_type::text_body_type(int cx, int cy)
+    : cx(cx)
+    , cy(cy)
+{
+}
+
 /*
  * Check special key code and get a movement command id
  */
@@ -109,22 +115,9 @@ void do_cmd_edit_autopick(PlayerType *player_ptr)
     static int32_t old_autosave_turn = 0L;
     ape_quittance quit = APE_QUIT;
 
-    text_body_type text_body;
+    text_body_type text_body(cx_save, cy_save);
     text_body_type *tb = &text_body;
-    tb->changed = false;
-    tb->cx = cx_save;
-    tb->cy = cy_save;
-    tb->upper = tb->left = 0;
-    tb->mark = 0;
-    tb->mx = tb->my = 0;
-    tb->old_cy = tb->old_upper = tb->old_left = -1;
-    tb->old_wid = tb->old_hgt = -1;
-    tb->old_com_id = 0;
-
-    tb->yank.clear();
-    tb->search_o_ptr = nullptr;
     tb->dirty_flags = DIRTY_ALL | DIRTY_MODE | DIRTY_EXPRESSION;
-    tb->dirty_line = -1;
     tb->filename_mode = PT_DEFAULT;
     auto &world = AngbandWorld::get_instance();
     world.play_time.pause();

--- a/src/cmd-io/cmd-autopick.cpp
+++ b/src/cmd-io/cmd-autopick.cpp
@@ -124,7 +124,6 @@ void do_cmd_edit_autopick(PlayerType *player_ptr)
     tb->yank.clear();
     tb->search_o_ptr = nullptr;
     tb->search_str = nullptr;
-    tb->last_destroyed = nullptr;
     tb->dirty_flags = DIRTY_ALL | DIRTY_MODE | DIRTY_EXPRESSION;
     tb->dirty_line = -1;
     tb->filename_mode = PT_DEFAULT;
@@ -212,7 +211,6 @@ void do_cmd_edit_autopick(PlayerType *player_ptr)
     }
 
     string_free(tb->search_str);
-    string_free(tb->last_destroyed);
     kill_yank_chain(tb);
 
     process_autopick_file(player_ptr, filename);

--- a/src/knowledge/knowledge-autopick.cpp
+++ b/src/knowledge/knowledge-autopick.cpp
@@ -47,27 +47,22 @@ void do_cmd_knowledge_autopick(PlayerType *player_ptr)
     }
 
     for (const auto &entry : autopick_list) {
-        concptr tmp;
-        byte act = entry.action;
-        if (act & DONT_AUTOPICK) {
-            tmp = _("放置", "Leave");
+        std::string command;
+        const auto act = entry.action;
+        if (any_bits(act, DONT_AUTOPICK)) {
+            command = _("放置", "Leave");
         } else if (act & DO_AUTODESTROY) {
-            tmp = _("破壊", "Destroy");
+            command = _("破壊", "Destroy");
         } else if (act & DO_AUTOPICK) {
-            tmp = _("拾う", "Pickup");
+            command = _("拾う", "Pickup");
         } else {
-            tmp = _("確認", "Query");
+            command = _("確認", "Query");
         }
 
-        if (act & DO_DISPLAY) {
-            fprintf(fff, "%11s", format("[%s]", tmp).data());
-        } else {
-            fprintf(fff, "%11s", format("(%s)", tmp).data());
-        }
-
-        tmp = autopick_line_from_entry(entry);
-        fprintf(fff, " %s", tmp);
-        string_free(tmp);
+        const auto fmt = any_bits(act, DO_DISPLAY) ? "[%s]" : "(%s)";
+        fprintf(fff, "%11s", format(fmt, command.data()).data());
+        const auto line = autopick_line_from_entry(entry);
+        fprintf(fff, " %s", line.data());
         fprintf(fff, "\n");
     }
 


### PR DESCRIPTION
※ ドラフトにしておきます。他のPRレビューを優先して下さい

最初のコミットで既にバグっています
具体的には自動拾いエディタを開いてもサンプル設定以降が表示されません
他にも複数箇所怪しい動きをしている箇所があるかもしれません
ステップ実行したところ、以下のコード (cmd-autopick.cpp)までは正常に読み込めているようです
お手すきのタイミングで確認頂けると助かります

```cpp
tb->lines_list = read_pickpref_text_lines(player_ptr->base_name, &tb->filename_mode);
```