### PR TITLE
川生成ルーチン周りをTerrainTag を使って改善した

### DIFF
--- a/src/floor/floor-streams.cpp
+++ b/src/floor/floor-streams.cpp
@@ -46,17 +46,14 @@
 #include "wizard/wizard-messages.h"
 
 /*!
- * @brief 再帰フラクタルアルゴリズムによりダンジョン内に川を配置する /
- * Recursive fractal algorithm to place water through the dungeon.
- * @param x1 起点x座標
- * @param y1 起点y座標
- * @param x2 終点x座標
- * @param y2 終点y座標
- * @param feat1 中央部地形ID
- * @param feat2 境界部地形ID
+ * @brief 再帰フラクタルアルゴリズムによりダンジョン内に川を配置する
+ * @param pos_start 起点座標
+ * @param pos_end 終点座標
+ * @param tag1 中央部地形ID
+ * @param tag2 境界部地形ID
  * @param width 基本幅
  */
-static void recursive_river(FloorType *floor_ptr, POSITION x1, POSITION y1, POSITION x2, POSITION y2, FEAT_IDX feat1, FEAT_IDX feat2, POSITION width)
+static void recursive_river(FloorType *floor_ptr, const Pos2D &pos_start, const Pos2D &pos_end, TerrainTag tag1, TerrainTag tag2, int width)
 {
     POSITION dx, dy, length, l, x, y;
     POSITION changex, changey;
@@ -64,15 +61,15 @@ static void recursive_river(FloorType *floor_ptr, POSITION x1, POSITION y1, POSI
     bool done;
     Grid *g_ptr;
 
-    length = distance(x1, y1, x2, y2);
+    length = distance(pos_start.x, pos_start.y, pos_end.x, pos_end.y);
 
     if (length > 4) {
         /*
          * Divide path in half and call routine twice.
          * There is a small chance of splitting the river
          */
-        dx = (x2 - x1) / 2;
-        dy = (y2 - y1) / 2;
+        dx = (pos_end.x - pos_start.x) / 2;
+        dy = (pos_end.y - pos_start.y) / 2;
 
         if (dy != 0) {
             /* perturbation perpendicular to path */
@@ -88,81 +85,83 @@ static void recursive_river(FloorType *floor_ptr, POSITION x1, POSITION y1, POSI
             changey = 0;
         }
 
-        if (!in_bounds(floor_ptr, y1 + dy + changey, x1 + dx + changex)) {
+        if (!in_bounds(floor_ptr, pos_start.y + dy + changey, pos_start.x + dx + changex)) {
             changex = 0;
             changey = 0;
         }
 
         /* construct river out of two smaller ones */
-        recursive_river(floor_ptr, x1, y1, x1 + dx + changex, y1 + dy + changey, feat1, feat2, width);
-        recursive_river(floor_ptr, x1 + dx + changex, y1 + dy + changey, x2, y2, feat1, feat2, width);
+        recursive_river(floor_ptr, pos_start, { pos_start.y + dy + changey, pos_start.x + dx + changex }, tag1, tag2, width);
+        recursive_river(floor_ptr, { pos_start.y + dy + changey, pos_start.x + dx + changex }, pos_end, tag1, tag2, width);
 
         /* Split the river some of the time - junctions look cool */
         constexpr auto chance_river_junction = 50;
         if (one_in_(chance_river_junction) && (width > 0)) {
-            recursive_river(floor_ptr, x1 + dx + changex, y1 + dy + changey, x1 + 8 * (dx + changex), y1 + 8 * (dy + changey), feat1, feat2, width - 1);
+            recursive_river(floor_ptr, { pos_start.y + dy + changey, pos_start.x + dx + changex }, { pos_start.y + 8 * (dy + changey), pos_start.x + 8 * (dx + changex) }, tag1, tag2, width - 1);
         }
-    } else {
-        /* Actually build the river */
-        const auto &terrains = TerrainList::get_instance();
-        for (l = 0; l < length; l++) {
-            x = x1 + l * (x2 - x1) / length;
-            y = y1 + l * (y2 - y1) / length;
 
-            done = false;
+        return;
+    }
 
-            while (!done) {
-                for (ty = y - width - 1; ty <= y + width + 1; ty++) {
-                    for (tx = x - width - 1; tx <= x + width + 1; tx++) {
-                        if (!in_bounds2(floor_ptr, ty, tx)) {
-                            continue;
-                        }
+    /* Actually build the river */
+    const auto &terrains = TerrainList::get_instance();
+    for (l = 0; l < length; l++) {
+        x = pos_start.x + l * (pos_end.x - pos_start.x) / length;
+        y = pos_start.y + l * (pos_end.y - pos_start.y) / length;
 
-                        g_ptr = &floor_ptr->grid_array[ty][tx];
+        done = false;
 
-                        if (g_ptr->feat == feat1) {
-                            continue;
-                        }
-                        if (g_ptr->feat == feat2) {
-                            continue;
-                        }
-
-                        if (distance(ty, tx, y, x) > rand_spread(width, 1)) {
-                            continue;
-                        }
-
-                        /* Do not convert permanent features */
-                        if (g_ptr->has(TerrainCharacteristics::PERMANENT)) {
-                            continue;
-                        }
-
-                        /*
-                         * Clear previous contents, add feature
-                         * The border mainly gets feat2, while the center gets feat1
-                         */
-                        if (distance(ty, tx, y, x) > width) {
-                            g_ptr->feat = feat2;
-                        } else {
-                            g_ptr->feat = feat1;
-                        }
-
-                        /* Clear garbage of hidden trap or door */
-                        g_ptr->mimic = 0;
-
-                        /* Lava terrain glows */
-                        if (terrains.get_terrain(feat1).flags.has(TerrainCharacteristics::LAVA)) {
-                            if (floor_ptr->get_dungeon_definition().flags.has_not(DungeonFeatureType::DARKNESS)) {
-                                g_ptr->info |= CAVE_GLOW;
-                            }
-                        }
-
-                        /* Hack -- don't teleport here */
-                        g_ptr->info |= CAVE_ICKY;
+        while (!done) {
+            for (ty = y - width - 1; ty <= y + width + 1; ty++) {
+                for (tx = x - width - 1; tx <= x + width + 1; tx++) {
+                    if (!in_bounds2(floor_ptr, ty, tx)) {
+                        continue;
                     }
-                }
 
-                done = true;
+                    g_ptr = &floor_ptr->grid_array[ty][tx];
+
+                    if (g_ptr->feat == terrains.get_terrain_id(tag1)) {
+                        continue;
+                    }
+                    if (g_ptr->feat == terrains.get_terrain_id(tag2)) {
+                        continue;
+                    }
+
+                    if (distance(ty, tx, y, x) > rand_spread(width, 1)) {
+                        continue;
+                    }
+
+                    /* Do not convert permanent features */
+                    if (g_ptr->has(TerrainCharacteristics::PERMANENT)) {
+                        continue;
+                    }
+
+                    /*
+                     * Clear previous contents, add feature
+                     * The border mainly gets tag2, while the center gets tag1
+                     */
+                    if (distance(ty, tx, y, x) > width) {
+                        g_ptr->set_terrain_id(tag2);
+                    } else {
+                        g_ptr->set_terrain_id(tag1);
+                    }
+
+                    /* Clear garbage of hidden trap or door */
+                    g_ptr->mimic = 0;
+
+                    /* Lava terrain glows */
+                    if (terrains.get_terrain(tag1).flags.has(TerrainCharacteristics::LAVA)) {
+                        if (floor_ptr->get_dungeon_definition().flags.has_not(DungeonFeatureType::DARKNESS)) {
+                            g_ptr->info |= CAVE_GLOW;
+                        }
+                    }
+
+                    /* Hack -- don't teleport here */
+                    g_ptr->info |= CAVE_ICKY;
+                }
             }
+
+            done = true;
         }
     }
 }
@@ -261,9 +260,7 @@ void add_river(FloorType *floor_ptr, DungeonData *dd_ptr)
 
     constexpr auto width_rivers = 2;
     const auto wid = randint1(width_rivers);
-    const auto terrain_id1 = terrains.get_terrain_id(tag1);
-    const auto terrain_id2 = terrains.get_terrain_id(tag2);
-    recursive_river(floor_ptr, x1, y1, x2, y2, terrain_id1, terrain_id2, wid);
+    recursive_river(floor_ptr, { y1, x1 }, { y2, x2 }, tag1, tag2, wid);
 
     /* Hack - Save the location as a "room" */
     if (dd_ptr->cent_n < dd_ptr->centers.size()) {

--- a/src/floor/floor-streams.cpp
+++ b/src/floor/floor-streams.cpp
@@ -55,7 +55,7 @@
  */
 static void recursive_river(FloorType *floor_ptr, const Pos2D &pos_start, const Pos2D &pos_end, TerrainTag tag_deep, TerrainTag tag_shallow, int width)
 {
-    const auto length = distance(pos_start.x, pos_start.y, pos_end.x, pos_end.y);
+    const auto length = distance(pos_start.y, pos_start.x, pos_end.y, pos_end.x);
     if (length > 4) {
         /*
          * Divide path in half and call routine twice.

--- a/src/system/dungeon/dungeon-definition.h
+++ b/src/system/dungeon/dungeon-definition.h
@@ -18,7 +18,9 @@
 #include "system/angband.h"
 #include "util/flag-group.h"
 #include <array>
+#include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 constexpr auto DUNGEON_FEAT_PROB_NUM = 3;
@@ -41,6 +43,7 @@ struct feat_prob {
 
 /* A structure for the != dungeon types */
 enum class TerrainCharacteristics;
+enum class TerrainTag;
 class MonraceDefinition;
 class DungeonDefinition {
 public:
@@ -105,6 +108,7 @@ public:
     std::string build_entrance_message() const;
     std::string describe_depth() const;
     int calc_cavern_terrains() const;
+    std::optional<std::pair<TerrainTag, TerrainTag>> decide_river_terrains(int threshold) const;
 
     void set_guardian_flag();
 };


### PR DESCRIPTION
単なるshort型のグローバル変数IDより大分可読性が上がったかと思います
ご確認下さい

なお、distance() の引数がXとYで逆ですが、これを変えると川生成ルーチンが全体的に変わるので一旦そのままにしてあります
関数の中身で異常な座標は生成されないような処理ですが、変更しても問題なければその旨コメント頂ければ助かります
(ゲーム内で川が生成される確率そのものは変わらず、形が変わるだけ)