### PR TITLE
Nest 関係のモンスター生成フィルタをMonraceDefinition のオブジェクトメソッドに繰り込んだ

### DIFF
--- a/src/monster-race/monster-race-hook.cpp
+++ b/src/monster-race/monster-race-hook.cpp
@@ -81,29 +81,6 @@ void vault_prep_dragon(PlayerType *player_ptr)
 }
 
 /*!
- * @brief モンスターがアンデッドnestの生成必要条件を満たしているかを返す /
- * Helper function for "monster nest (undead)"
- * @param r_idx 確認したいモンスター種族ID
- * @return 生成必要条件を満たしているならTRUEを返す。
- */
-bool vault_aux_undead(PlayerType *player_ptr, MonraceId r_idx)
-{
-    const auto &monrace = MonraceList::get_instance().get_monrace(r_idx);
-    const auto &floor = *player_ptr->current_floor_ptr;
-    auto is_valid = !floor.is_underground() || DungeonMonraceService::is_suitable_for_dungeon(floor.dungeon_id, r_idx);
-    is_valid &= monrace.is_suitable_for_special_room();
-    if (!is_valid) {
-        return false;
-    }
-
-    if (monrace.kind_flags.has_not(MonsterKindType::UNDEAD)) {
-        return false;
-    }
-
-    return true;
-}
-
-/*!
  * @brief モンスターが単一クローンnestの生成必要条件を満たしているかを返す /
  * Helper function for "monster nest (clone)"
  * @param r_idx 確認したいモンスター種族ID

--- a/src/monster-race/monster-race-hook.cpp
+++ b/src/monster-race/monster-race-hook.cpp
@@ -154,53 +154,6 @@ bool vault_aux_undead(PlayerType *player_ptr, MonraceId r_idx)
 }
 
 /*!
- * @brief モンスターが聖堂nestの生成必要条件を満たしているかを返す /
- * Helper function for "monster nest (chapel)"
- * @param r_idx 確認したいモンスター種族ID
- * @return 生成必要条件を満たしているならTRUEを返す。
- */
-bool vault_aux_chapel_g(PlayerType *player_ptr, MonraceId r_idx)
-{
-    static const std::set<MonraceId> chapel_list = {
-        MonraceId::NOV_PRIEST,
-        MonraceId::NOV_PALADIN,
-        MonraceId::NOV_PRIEST_G,
-        MonraceId::NOV_PALADIN_G,
-        MonraceId::PRIEST,
-        MonraceId::JADE_MONK,
-        MonraceId::IVORY_MONK,
-        MonraceId::ULTRA_PALADIN,
-        MonraceId::EBONY_MONK,
-        MonraceId::W_KNIGHT,
-        MonraceId::KNI_TEMPLAR,
-        MonraceId::PALADIN,
-        MonraceId::TOPAZ_MONK,
-    };
-
-    const auto &monrace = MonraceList::get_instance().get_monrace(r_idx);
-    const auto &floor = *player_ptr->current_floor_ptr;
-    auto is_valid = !floor.is_underground() || DungeonMonraceService::is_suitable_for_dungeon(floor.dungeon_id, r_idx);
-    is_valid &= monrace.is_suitable_for_special_room();
-    if (!is_valid) {
-        return false;
-    }
-
-    if (monrace.kind_flags.has(MonsterKindType::EVIL)) {
-        return false;
-    }
-
-    if ((r_idx == MonraceId::A_GOLD) || (r_idx == MonraceId::A_SILVER)) {
-        return false;
-    }
-
-    if (monrace.symbol_char_is_any_of("A")) {
-        return true;
-    }
-
-    return chapel_list.find(r_idx) != chapel_list.end();
-}
-
-/*!
  * @brief モンスターが単一クローンnestの生成必要条件を満たしているかを返す /
  * Helper function for "monster nest (clone)"
  * @param r_idx 確認したいモンスター種族ID

--- a/src/monster-race/monster-race-hook.cpp
+++ b/src/monster-race/monster-race-hook.cpp
@@ -81,29 +81,6 @@ void vault_prep_dragon(PlayerType *player_ptr)
 }
 
 /*!
- * @brief モンスターが動物nestの生成必要条件を満たしているかを返す /
- * Helper function for "monster nest (animal)"
- * @param r_idx 確認したいモンスター種族ID
- * @return 生成必要条件を満たしているならTRUEを返す。
- */
-bool vault_aux_animal(PlayerType *player_ptr, MonraceId r_idx)
-{
-    const auto &monrace = MonraceList::get_instance().get_monrace(r_idx);
-    const auto &floor = *player_ptr->current_floor_ptr;
-    auto is_valid = !floor.is_underground() || DungeonMonraceService::is_suitable_for_dungeon(floor.dungeon_id, r_idx);
-    is_valid &= monrace.is_suitable_for_special_room();
-    if (!is_valid) {
-        return false;
-    }
-
-    if (monrace.kind_flags.has_not(MonsterKindType::ANIMAL)) {
-        return false;
-    }
-
-    return true;
-}
-
-/*!
  * @brief モンスターがアンデッドnestの生成必要条件を満たしているかを返す /
  * Helper function for "monster nest (undead)"
  * @param r_idx 確認したいモンスター種族ID

--- a/src/monster-race/monster-race-hook.cpp
+++ b/src/monster-race/monster-race-hook.cpp
@@ -201,25 +201,6 @@ bool vault_aux_chapel_g(PlayerType *player_ptr, MonraceId r_idx)
 }
 
 /*!
- * @brief モンスターが犬小屋nestの生成必要条件を満たしているかを返す /
- * Helper function for "monster nest (kennel)"
- * @param r_idx 確認したいモンスター種族ID
- * @return 生成必要条件を満たしているならTRUEを返す。
- */
-bool vault_aux_kennel(PlayerType *player_ptr, MonraceId r_idx)
-{
-    const auto &monrace = MonraceList::get_instance().get_monrace(r_idx);
-    const auto &floor = *player_ptr->current_floor_ptr;
-    auto is_valid = !floor.is_underground() || DungeonMonraceService::is_suitable_for_dungeon(floor.dungeon_id, r_idx);
-    is_valid &= monrace.is_suitable_for_special_room();
-    if (!is_valid) {
-        return false;
-    }
-
-    return monrace.symbol_char_is_any_of("CZ");
-}
-
-/*!
  * @brief モンスターが単一クローンnestの生成必要条件を満たしているかを返す /
  * Helper function for "monster nest (clone)"
  * @param r_idx 確認したいモンスター種族ID

--- a/src/monster-race/monster-race-hook.cpp
+++ b/src/monster-race/monster-race-hook.cpp
@@ -220,25 +220,6 @@ bool vault_aux_kennel(PlayerType *player_ptr, MonraceId r_idx)
 }
 
 /*!
- * @brief モンスターがミミックnestの生成必要条件を満たしているかを返す /
- * Helper function for "monster nest (mimic)"
- * @param r_idx 確認したいモンスター種族ID
- * @return 生成必要条件を満たしているならTRUEを返す。
- */
-bool vault_aux_mimic(PlayerType *player_ptr, MonraceId r_idx)
-{
-    const auto &monrace = MonraceList::get_instance().get_monrace(r_idx);
-    const auto &floor = *player_ptr->current_floor_ptr;
-    auto is_valid = !floor.is_underground() || DungeonMonraceService::is_suitable_for_dungeon(floor.dungeon_id, r_idx);
-    is_valid &= monrace.is_suitable_for_special_room();
-    if (!is_valid) {
-        return false;
-    }
-
-    return monrace.symbol_char_is_any_of("!$&(/=?[\\|][`~>+");
-}
-
-/*!
  * @brief モンスターが単一クローンnestの生成必要条件を満たしているかを返す /
  * Helper function for "monster nest (clone)"
  * @param r_idx 確認したいモンスター種族ID

--- a/src/monster-race/monster-race-hook.cpp
+++ b/src/monster-race/monster-race-hook.cpp
@@ -81,33 +81,6 @@ void vault_prep_dragon(PlayerType *player_ptr)
 }
 
 /*!
- * @brief モンスターがゼリーnestの生成必要条件を満たしているかを返す /
- * Helper function for "monster nest (jelly)"
- * @param r_idx 確認したいモンスター種族ID
- * @return 生成必要条件を満たしているならTRUEを返す。
- */
-bool vault_aux_jelly(PlayerType *player_ptr, MonraceId r_idx)
-{
-    const auto &monrace = MonraceList::get_instance().get_monrace(r_idx);
-    const auto &floor = *player_ptr->current_floor_ptr;
-    auto is_valid = !floor.is_underground() || DungeonMonraceService::is_suitable_for_dungeon(floor.dungeon_id, r_idx);
-    is_valid &= monrace.is_suitable_for_special_room();
-    if (!is_valid) {
-        return false;
-    }
-
-    if (monrace.behavior_flags.has(MonsterBehaviorType::KILL_BODY) && monrace.behavior_flags.has_not(MonsterBehaviorType::NEVER_BLOW)) {
-        return false;
-    }
-
-    if (monrace.kind_flags.has(MonsterKindType::EVIL)) {
-        return false;
-    }
-
-    return monrace.symbol_char_is_any_of("ijm,");
-}
-
-/*!
  * @brief モンスターが動物nestの生成必要条件を満たしているかを返す /
  * Helper function for "monster nest (animal)"
  * @param r_idx 確認したいモンスター種族ID

--- a/src/monster-race/monster-race-hook.h
+++ b/src/monster-race/monster-race-hook.h
@@ -19,7 +19,6 @@ bool vault_aux_animal(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_undead(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_chapel_g(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_kennel(PlayerType *player_ptr, MonraceId r_idx);
-bool vault_aux_mimic(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_clone(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_symbol_e(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_symbol_g(PlayerType *player_ptr, MonraceId r_idx);

--- a/src/monster-race/monster-race-hook.h
+++ b/src/monster-race/monster-race-hook.h
@@ -14,7 +14,6 @@ void vault_prep_clone(PlayerType *player_ptr);
 void vault_prep_dragon(PlayerType *player_ptr);
 void vault_prep_symbol(PlayerType *player_ptr);
 
-bool vault_aux_jelly(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_animal(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_undead(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_clone(PlayerType *player_ptr, MonraceId r_idx);

--- a/src/monster-race/monster-race-hook.h
+++ b/src/monster-race/monster-race-hook.h
@@ -18,7 +18,6 @@ bool vault_aux_jelly(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_animal(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_undead(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_chapel_g(PlayerType *player_ptr, MonraceId r_idx);
-bool vault_aux_kennel(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_clone(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_symbol_e(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_symbol_g(PlayerType *player_ptr, MonraceId r_idx);

--- a/src/monster-race/monster-race-hook.h
+++ b/src/monster-race/monster-race-hook.h
@@ -17,7 +17,6 @@ void vault_prep_symbol(PlayerType *player_ptr);
 bool vault_aux_jelly(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_animal(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_undead(PlayerType *player_ptr, MonraceId r_idx);
-bool vault_aux_chapel_g(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_clone(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_symbol_e(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_symbol_g(PlayerType *player_ptr, MonraceId r_idx);

--- a/src/monster-race/monster-race-hook.h
+++ b/src/monster-race/monster-race-hook.h
@@ -14,7 +14,6 @@ void vault_prep_clone(PlayerType *player_ptr);
 void vault_prep_dragon(PlayerType *player_ptr);
 void vault_prep_symbol(PlayerType *player_ptr);
 
-bool vault_aux_undead(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_clone(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_symbol_e(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_symbol_g(PlayerType *player_ptr, MonraceId r_idx);

--- a/src/monster-race/monster-race-hook.h
+++ b/src/monster-race/monster-race-hook.h
@@ -14,7 +14,6 @@ void vault_prep_clone(PlayerType *player_ptr);
 void vault_prep_dragon(PlayerType *player_ptr);
 void vault_prep_symbol(PlayerType *player_ptr);
 
-bool vault_aux_animal(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_undead(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_clone(PlayerType *player_ptr, MonraceId r_idx);
 bool vault_aux_symbol_e(PlayerType *player_ptr, MonraceId r_idx);

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -275,7 +275,7 @@ static bool do_hook(PlayerType *player_ptr, MonraceHook hook, MonraceId monrace_
     case MonraceHook::DEMON:
         return is_suitable_for_dungeon && monrace.is_suitable_for_demon_pit();
     case MonraceHook::DARK_ELF:
-        return is_suitable_for_dungeon && monrace.is_suitable_for_special_room() && MonraceList::is_dark_elf(monrace_id);
+        return is_suitable_for_dungeon && MonraceList::is_dark_elf(monrace_id) && monrace.is_suitable_for_special_room();
     default:
         THROW_EXCEPTION(std::logic_error, format("Invalid monrace hook type is specified! %d", enum2i(hook)));
     }

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -247,7 +247,7 @@ static bool do_hook(PlayerType *player_ptr, MonraceHook hook, MonraceId monrace_
     case MonraceHook::CLONE:
         return vault_aux_clone(player_ptr, monrace_id);
     case MonraceHook::JELLY:
-        return vault_aux_jelly(player_ptr, monrace_id);
+        return is_suitable_for_dungeon && monrace.is_suitable_for_jelly_nest();
     case MonraceHook::GOOD:
         return vault_aux_symbol_g(player_ptr, monrace_id);
     case MonraceHook::EVIL:

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -252,7 +252,7 @@ static bool do_hook(PlayerType *player_ptr, MonraceHook hook, MonraceId monrace_
     case MonraceHook::EVIL:
         return vault_aux_symbol_e(player_ptr, monrace_id);
     case MonraceHook::MIMIC:
-        return vault_aux_mimic(player_ptr, monrace_id);
+        return is_suitable_for_dungeon && monrace.is_suitable_for_mimic_nest();
     case MonraceHook::HORROR:
         return is_suitable_for_dungeon && monrace.is_suitable_for_horror_pit();
     case MonraceHook::KENNEL:

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -259,7 +259,7 @@ static bool do_hook(PlayerType *player_ptr, MonraceHook hook, MonraceId monrace_
     case MonraceHook::KENNEL:
         return is_suitable_for_dungeon && monrace.is_suitable_for_dog_nest();
     case MonraceHook::ANIMAL:
-        return vault_aux_animal(player_ptr, monrace_id);
+        return is_suitable_for_dungeon && monrace.is_suitable_for_animal_nest();
     case MonraceHook::CHAPEL:
         return is_suitable_for_dungeon && (monraces.is_angel(monrace_id) || MonraceList::is_chapel(monrace_id)) && monrace.is_suitable_for_chapel_nest();
     case MonraceHook::UNDEAD:

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -193,7 +193,8 @@ MonraceHook get_monster_hook(const Pos2D &pos_wilderness, bool is_underground)
 
 static bool do_hook(PlayerType *player_ptr, MonraceHook hook, MonraceId monrace_id)
 {
-    const auto &monrace = MonraceList::get_instance().get_monrace(monrace_id);
+    const auto &monraces = MonraceList::get_instance();
+    const auto &monrace = monraces.get_monrace(monrace_id);
     const auto &floor = *player_ptr->current_floor_ptr;
     const auto is_suitable_for_dungeon = !floor.is_underground() || DungeonMonraceService::is_suitable_for_dungeon(floor.dungeon_id, monrace_id);
     switch (hook) {
@@ -260,7 +261,7 @@ static bool do_hook(PlayerType *player_ptr, MonraceHook hook, MonraceId monrace_
     case MonraceHook::ANIMAL:
         return vault_aux_animal(player_ptr, monrace_id);
     case MonraceHook::CHAPEL:
-        return vault_aux_chapel_g(player_ptr, monrace_id);
+        return is_suitable_for_dungeon && (monraces.is_angel(monrace_id) || MonraceList::is_chapel(monrace_id)) && monrace.is_suitable_for_chapel_nest();
     case MonraceHook::UNDEAD:
         return vault_aux_undead(player_ptr, monrace_id);
     case MonraceHook::ORC:

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -256,7 +256,7 @@ static bool do_hook(PlayerType *player_ptr, MonraceHook hook, MonraceId monrace_
     case MonraceHook::HORROR:
         return is_suitable_for_dungeon && monrace.is_suitable_for_horror_pit();
     case MonraceHook::KENNEL:
-        return vault_aux_kennel(player_ptr, monrace_id);
+        return is_suitable_for_dungeon && monrace.is_suitable_for_dog_nest();
     case MonraceHook::ANIMAL:
         return vault_aux_animal(player_ptr, monrace_id);
     case MonraceHook::CHAPEL:

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -263,7 +263,7 @@ static bool do_hook(PlayerType *player_ptr, MonraceHook hook, MonraceId monrace_
     case MonraceHook::CHAPEL:
         return is_suitable_for_dungeon && (monraces.is_angel(monrace_id) || MonraceList::is_chapel(monrace_id)) && monrace.is_suitable_for_chapel_nest();
     case MonraceHook::UNDEAD:
-        return vault_aux_undead(player_ptr, monrace_id);
+        return is_suitable_for_dungeon && monrace.is_suitable_for_undead_nest();
     case MonraceHook::ORC:
         return is_suitable_for_dungeon && monrace.is_suitable_for_orc_pit();
     case MonraceHook::TROLL:

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -575,6 +575,13 @@ bool MonraceDefinition::is_suitable_for_horror_pit() const
     return is_suitable;
 }
 
+bool MonraceDefinition::is_suitable_for_mimic_nest() const
+{
+    auto is_suitable = this->is_suitable_for_special_room();
+    is_suitable &= this->symbol_char_is_any_of("!$&(/=?[\\|][`~>+");
+    return is_suitable;
+}
+
 void MonraceDefinition::init_sex(uint32_t value)
 {
     const auto sex_tmp = i2enum<MonsterSex>(value);

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -582,6 +582,13 @@ bool MonraceDefinition::is_suitable_for_mimic_nest() const
     return is_suitable;
 }
 
+bool MonraceDefinition::is_suitable_for_dog_nest() const
+{
+    auto is_suitable = this->is_suitable_for_special_room();
+    is_suitable &= this->symbol_char_is_any_of("CZ");
+    return is_suitable;
+}
+
 void MonraceDefinition::init_sex(uint32_t value)
 {
     const auto sex_tmp = i2enum<MonsterSex>(value);

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -608,6 +608,15 @@ bool MonraceDefinition::is_suitable_for_chapel_nest() const
     return is_suitable;
 }
 
+bool MonraceDefinition::is_suitable_for_jelly_nest() const
+{
+    auto is_suitable = this->is_suitable_for_special_room();
+    is_suitable &= this->behavior_flags.has_not(MonsterBehaviorType::KILL_BODY) && this->behavior_flags.has(MonsterBehaviorType::NEVER_BLOW);
+    is_suitable &= this->kind_flags.has_not(MonsterKindType::EVIL);
+    is_suitable &= this->symbol_char_is_any_of("ijm,");
+    return is_suitable;
+}
+
 void MonraceDefinition::init_sex(uint32_t value)
 {
     const auto sex_tmp = i2enum<MonsterSex>(value);

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -624,6 +624,13 @@ bool MonraceDefinition::is_suitable_for_animal_nest() const
     return is_suitable;
 }
 
+bool MonraceDefinition::is_suitable_for_undead_nest() const
+{
+    auto is_suitable = this->is_suitable_for_special_room();
+    is_suitable &= this->kind_flags.has(MonsterKindType::UNDEAD);
+    return is_suitable;
+}
+
 void MonraceDefinition::init_sex(uint32_t value)
 {
     const auto sex_tmp = i2enum<MonsterSex>(value);

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -118,6 +118,18 @@ bool MonraceDefinition::is_explodable() const
 }
 
 /*!
+ * @brief モンスターが表面的に天使かどうかを返す
+ * @return 天使か否か
+ * @details 「Aシンボルだが天使ではないモンスター」もいる。例外リストはMonraceList 側に定義されている
+ */
+bool MonraceDefinition::is_angel_superficially() const
+{
+    auto is_angel = this->symbol_char_is_any_of("A");
+    is_angel |= this->kind_flags.has(MonsterKindType::ANGEL);
+    return is_angel;
+}
+
+/*!
  * @brief モンスターのシンボル文字が指定された文字列に含まれるかどうかを返す
  * @param candidate_chars シンボル文字の集合の文字列。"pht" のように複数の文字を指定可能。
  * @return モンスターのシンボル文字が candidate_chars に含まれるならばtrue
@@ -586,6 +598,13 @@ bool MonraceDefinition::is_suitable_for_dog_nest() const
 {
     auto is_suitable = this->is_suitable_for_special_room();
     is_suitable &= this->symbol_char_is_any_of("CZ");
+    return is_suitable;
+}
+
+bool MonraceDefinition::is_suitable_for_chapel_nest() const
+{
+    auto is_suitable = this->is_suitable_for_special_room();
+    is_suitable &= this->kind_flags.has_not(MonsterKindType::EVIL);
     return is_suitable;
 }
 

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -511,9 +511,9 @@ bool MonraceDefinition::can_entry_arena() const
     return can_entry;
 }
 
-bool MonraceDefinition::is_suitable_for_nightmare(int max_level) const
+bool MonraceDefinition::is_suitable_for_nightmare(int min_level) const
 {
-    return this->misc_flags.has(MonsterMiscType::ELDRITCH_HORROR) && (this->level > max_level);
+    return this->misc_flags.has(MonsterMiscType::ELDRITCH_HORROR) && (this->level > min_level);
 }
 
 bool MonraceDefinition::is_human() const

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -617,6 +617,13 @@ bool MonraceDefinition::is_suitable_for_jelly_nest() const
     return is_suitable;
 }
 
+bool MonraceDefinition::is_suitable_for_animal_nest() const
+{
+    auto is_suitable = this->is_suitable_for_special_room();
+    is_suitable &= this->kind_flags.has(MonsterKindType::ANIMAL);
+    return is_suitable;
+}
+
 void MonraceDefinition::init_sex(uint32_t value)
 {
     const auto sex_tmp = i2enum<MonsterSex>(value);

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -193,6 +193,7 @@ public:
     bool is_suitable_for_dog_nest() const;
     bool is_suitable_for_chapel_nest() const;
     bool is_suitable_for_jelly_nest() const;
+    bool is_suitable_for_animal_nest() const;
 
     void init_sex(uint32_t value);
     std::optional<std::string> probe_lore();

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -189,6 +189,7 @@ public:
     bool is_suitable_for_demon_pit() const;
     bool is_suitable_for_horror_pit() const;
     bool is_suitable_for_mimic_nest() const;
+    bool is_suitable_for_dog_nest() const;
 
     void init_sex(uint32_t value);
     std::optional<std::string> probe_lore();

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -179,7 +179,7 @@ public:
     bool is_suitable_for_tanuki() const;
     bool is_suitable_for_figurine() const;
     bool can_entry_arena() const;
-    bool is_suitable_for_nightmare(int max_level) const;
+    bool is_suitable_for_nightmare(int min_level) const;
     bool is_human() const;
     bool is_eatable_human() const;
     bool is_catchable_for_fishing() const;

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -194,6 +194,7 @@ public:
     bool is_suitable_for_chapel_nest() const;
     bool is_suitable_for_jelly_nest() const;
     bool is_suitable_for_animal_nest() const;
+    bool is_suitable_for_undead_nest() const;
 
     void init_sex(uint32_t value);
     std::optional<std::string> probe_lore();

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -188,6 +188,7 @@ public:
     bool is_suitable_for_giant_pit() const;
     bool is_suitable_for_demon_pit() const;
     bool is_suitable_for_horror_pit() const;
+    bool is_suitable_for_mimic_nest() const;
 
     void init_sex(uint32_t value);
     std::optional<std::string> probe_lore();

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -192,6 +192,7 @@ public:
     bool is_suitable_for_mimic_nest() const;
     bool is_suitable_for_dog_nest() const;
     bool is_suitable_for_chapel_nest() const;
+    bool is_suitable_for_jelly_nest() const;
 
     void init_sex(uint32_t value);
     std::optional<std::string> probe_lore();

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -142,6 +142,7 @@ public:
     bool is_female() const;
     bool has_living_flag() const;
     bool is_explodable() const;
+    bool is_angel_superficially() const;
     bool symbol_char_is_any_of(std::string_view symbol_characters) const;
     std::string get_died_message() const;
     std::optional<bool> order_level(const MonraceDefinition &other) const;
@@ -190,6 +191,7 @@ public:
     bool is_suitable_for_horror_pit() const;
     bool is_suitable_for_mimic_nest() const;
     bool is_suitable_for_dog_nest() const;
+    bool is_suitable_for_chapel_nest() const;
 
     void init_sex(uint32_t value);
     std::optional<std::string> probe_lore();

--- a/src/system/monrace/monrace-list.cpp
+++ b/src/system/monrace/monrace-list.cpp
@@ -26,6 +26,28 @@ const std::set<MonraceId> DARK_ELF_RACES = {
     MonraceId::D_ELF_SORC,
     MonraceId::D_ELF_SHADE,
 };
+
+const std::set<MonraceId> CHAPEL_RACES = {
+    MonraceId::NOV_PRIEST,
+    MonraceId::NOV_PALADIN,
+    MonraceId::NOV_PRIEST_G,
+    MonraceId::NOV_PALADIN_G,
+    MonraceId::PRIEST,
+    MonraceId::JADE_MONK,
+    MonraceId::IVORY_MONK,
+    MonraceId::ULTRA_PALADIN,
+    MonraceId::EBONY_MONK,
+    MonraceId::W_KNIGHT,
+    MonraceId::KNI_TEMPLAR,
+    MonraceId::PALADIN,
+    MonraceId::TOPAZ_MONK,
+};
+
+//!< @details 「Aシンボルだが天使ではない」モンスターのリスト.
+const std::set<MonraceId> NON_ANGEL_RACES = {
+    MonraceId::A_GOLD,
+    MonraceId::A_SILVER,
+};
 }
 
 std::map<MonraceId, MonraceDefinition> monraces_info;
@@ -72,6 +94,11 @@ bool MonraceList::is_tsuchinoko(MonraceId monrace_id)
 bool MonraceList::is_dark_elf(MonraceId monrace_id)
 {
     return DARK_ELF_RACES.contains(monrace_id);
+}
+
+bool MonraceList::is_chapel(MonraceId monrace_id)
+{
+    return CHAPEL_RACES.contains(monrace_id);
 }
 
 MonraceDefinition &MonraceList::emplace(MonraceId monrace_id)
@@ -186,6 +213,14 @@ std::vector<MonraceId> MonraceList::search_by_symbol(char symbol, bool is_known_
     };
 
     return this->search(std::move(filter), is_known_only);
+}
+
+bool MonraceList::is_angel(MonraceId monrace_id) const
+{
+    const auto &monrace = this->get_monrace(monrace_id);
+    auto is_angel = monrace.is_angel_superficially();
+    is_angel &= !NON_ANGEL_RACES.contains(monrace_id);
+    return is_angel;
 }
 
 //!< @todo ややトリッキーだが、元のmapでMonsterRaceInfo をshared_ptr で持つようにすればかなりスッキリ書けるはず.

--- a/src/system/monrace/monrace-list.h
+++ b/src/system/monrace/monrace-list.h
@@ -32,6 +32,7 @@ public:
     static MonraceId empty_id();
     static bool is_tsuchinoko(MonraceId monrace_id);
     static bool is_dark_elf(MonraceId monrace_id);
+    static bool is_chapel(MonraceId monrace_id);
     MonraceDefinition &emplace(MonraceId monrace_id);
     std::map<MonraceId, MonraceDefinition> &get_raw_map();
     MonraceDefinition &get_monrace(MonraceId monrace_id);
@@ -41,6 +42,7 @@ public:
     std::vector<MonraceId> search_by_name(std::string_view name, bool is_known_only = false) const;
     std::vector<MonraceId> search_by_symbol(char symbol, bool is_known_only) const;
     const std::vector<std::pair<MonraceId, const MonraceDefinition *>> &get_sorted_monraces() const;
+    bool is_angel(MonraceId monrace_id) const;
     bool can_unify_separate(MonraceId monrace_id) const;
     void kill_unified_unique(MonraceId monrace_id);
     bool is_selectable(MonraceId monrace_id) const;


### PR DESCRIPTION
この次はグローバル変数の読み書きが発生する極悪ゾーンです
それ以外は全て繰り込み完了しました
ご確認下さい
(次かその次でようやくmonraces\_info の完全な撲滅が達成できる予定)