### PR TITLE
[Refactor] プレイ時間をElapsedTimeクラスで管理する

### DIFF
--- a/VisualStudio/Hengband/Hengband.vcxproj
+++ b/VisualStudio/Hengband/Hengband.vcxproj
@@ -672,6 +672,7 @@
     <ClCompile Include="..\..\src\tracking\health-bar-tracker.cpp" />
     <ClCompile Include="..\..\src\tracking\lore-tracker.cpp" />
     <ClCompile Include="..\..\src\util\candidate-selector.cpp" />
+    <ClCompile Include="..\..\src\util\elapsed-time.cpp" />
     <ClCompile Include="..\..\src\util\rng-xoshiro.cpp" />
     <ClCompile Include="..\..\src\util\dice.cpp" />
     <ClCompile Include="..\..\src\util\sha256.cpp" />
@@ -1510,6 +1511,7 @@
     <ClInclude Include="..\..\src\util\bit-flags-calculator.h" />
     <ClInclude Include="..\..\src\util\buffer-shaper.h" />
     <ClInclude Include="..\..\src\util\candidate-selector.h" />
+    <ClInclude Include="..\..\src\util\elapsed-time.h" />
     <ClInclude Include="..\..\src\util\enum-converter.h" />
     <ClInclude Include="..\..\src\util\enum-range.h" />
     <ClInclude Include="..\..\src\util\finalizer.h" />

--- a/VisualStudio/Hengband/Hengband.vcxproj.filters
+++ b/VisualStudio/Hengband/Hengband.vcxproj.filters
@@ -2556,6 +2556,9 @@
     <ClCompile Include="..\..\src\system\services\dungeon-monrace-service.cpp">
       <Filter>system\services</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\util\elapsed-time.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5546,6 +5549,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\system\services\dungeon-monrace-service.h">
       <Filter>system\services</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\elapsed-time.h">
+      <Filter>util</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1004,6 +1004,7 @@ hengband_SOURCES = \
 	util/buffer-shaper.cpp util/buffer-shaper.h \
 	util/bit-flags-calculator.h \
 	util/candidate-selector.cpp util/candidate-selector.h \
+	util/elapsed-time.cpp util/elapsed-time.h \
 	util/enum-converter.h \
 	util/enum-range.h \
 	util/finalizer.h \

--- a/src/birth/character-builder.cpp
+++ b/src/birth/character-builder.cpp
@@ -98,7 +98,7 @@ void player_birth(PlayerType *player_ptr)
 {
     TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, MAIN_TERM_MIN_ROWS);
 
-    AngbandWorld::get_instance().play_time = 0;
+    AngbandWorld::get_instance().play_time.reset();
     wipe_monsters_list(player_ptr);
     player_wipe_without_name(player_ptr);
     if (!ask_quick_start(player_ptr)) {

--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -79,7 +79,7 @@ void do_cmd_redraw(PlayerType *player_ptr)
         SubWindowRedrawingFlag::ITEM_KNOWLEDGE,
     };
     rfu.set_flags(flags_swrf);
-    AngbandWorld::get_instance().update_playtime();
+    AngbandWorld::get_instance().play_time.update();
     handle_stuff(player_ptr);
     if (PlayerRace(player_ptr).equals(PlayerRaceType::ANDROID)) {
         calc_android_exp(player_ptr);
@@ -115,7 +115,7 @@ static std::optional<int> input_status_command(PlayerType *player_ptr, int page)
 
         const auto &filename = str_ltrim(*input_filename);
         if (!filename.empty()) {
-            AngbandWorld::get_instance().update_playtime();
+            AngbandWorld::get_instance().play_time.update();
             file_character(player_ptr, filename);
         }
 
@@ -143,7 +143,7 @@ void do_cmd_player_status(PlayerType *player_ptr)
     while (true) {
         TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, MAIN_TERM_MIN_ROWS);
 
-        world.update_playtime();
+        world.play_time.update();
         (void)display_player(player_ptr, page);
         if (page == 5) {
             page = 0;

--- a/src/core/game-closer.cpp
+++ b/src/core/game-closer.cpp
@@ -170,8 +170,8 @@ void close_game(PlayerType *player_ptr)
 
     auto do_send = true;
     if (!cheat_save || input_check(_("死んだデータをセーブしますか？ ", "Save death? "))) {
-        world.update_playtime();
-        world.sf_play_time += world.play_time;
+        world.play_time.update();
+        world.sf_play_time += world.play_time.elapsed_sec();
 
         if (!save_player(player_ptr, SaveType::CLOSE_GAME)) {
             msg_print(_("セーブ失敗！", "death save failed!"));

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -132,7 +132,7 @@ static void send_waiting_record(PlayerType *player_ptr)
     update_creature(player_ptr);
     player_ptr->is_dead = true;
     auto &world = AngbandWorld::get_instance();
-    world.start_time = (uint32_t)time(nullptr);
+    world.play_time.pause();
     signals_ignore_tstp();
     world.character_icky_depth = 1;
     const auto path = path_build(ANGBAND_DIR_APEX, "scores.raw");
@@ -238,7 +238,6 @@ static void reset_world_info(PlayerType *player_ptr)
     world.timewalk_m_idx = 0;
     player_ptr->now_damaged = false;
     now_message = 0;
-    world.start_time = time(nullptr) - 1;
     record_o_name[0] = '\0';
 }
 
@@ -369,6 +368,7 @@ static void process_game_turn(PlayerType *player_ptr)
     auto load_game = true;
     auto &floor = *player_ptr->current_floor_ptr;
     auto &world = AngbandWorld::get_instance();
+    world.play_time.unpause();
     while (true) {
         process_dungeon(player_ptr, load_game);
         world.character_xtra = true;

--- a/src/dungeon/quest.cpp
+++ b/src/dungeon/quest.cpp
@@ -183,8 +183,8 @@ void record_quest_final_status(QuestType *q_ptr, PLAYER_LEVEL lev, QuestStatusTy
     q_ptr->status = stat;
     q_ptr->complev = lev;
     auto &world = AngbandWorld::get_instance();
-    world.update_playtime();
-    q_ptr->comptime = world.play_time;
+    world.play_time.update();
+    q_ptr->comptime = world.play_time.elapsed_sec();
 }
 
 /*!
@@ -346,8 +346,8 @@ void leave_tower_check(PlayerType *player_ptr)
     tower1.status = QuestStatusType::FAILED;
     tower1.complev = player_ptr->lev;
     auto &world = AngbandWorld::get_instance();
-    world.update_playtime();
-    tower1.comptime = world.play_time;
+    world.play_time.update();
+    tower1.comptime = world.play_time.elapsed_sec();
 }
 
 /*!

--- a/src/knowledge/knowledge-self.cpp
+++ b/src/knowledge/knowledge-self.cpp
@@ -152,8 +152,8 @@ void do_cmd_knowledge_stat(PlayerType *player_ptr)
     }
 
     auto &world = AngbandWorld::get_instance();
-    world.update_playtime();
-    const auto play_time = world.play_time;
+    world.play_time.update();
+    const auto play_time = world.play_time.elapsed_sec();
     const auto all_time = world.sf_play_time + play_time;
     fprintf(fff, _("現在のプレイ時間 : %d:%02d:%02d\n", "Current Play Time is %d:%02d:%02d\n"), play_time / (60 * 60), (play_time / 60) % 60, play_time % 60);
     fprintf(fff, _("合計のプレイ時間 : %d:%02d:%02d\n", "  Total play Time is %d:%02d:%02d\n"), all_time / (60 * 60), (all_time / 60) % 60, all_time % 60);

--- a/src/load/extra-loader.cpp
+++ b/src/load/extra-loader.cpp
@@ -34,9 +34,9 @@ void rd_extra(PlayerType *player_ptr)
     rd_dummy_monsters(player_ptr);
     auto &world = AngbandWorld::get_instance();
     if (h_older_than(0, 1, 2)) {
-        world.play_time = 0;
+        world.play_time = ElapsedTime();
     } else {
-        world.play_time = rd_u32b();
+        world.play_time = ElapsedTime(rd_u32b());
     }
 
     rd_visited_towns(player_ptr);

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -471,7 +471,7 @@ bool load_savedata(PlayerType *player_ptr, bool *new_game)
         player_ptr->count = tmp;
     }
 
-    const auto play_time = world.play_time;
+    const auto play_time = world.play_time.elapsed_sec();
     if (counts_read(player_ptr, 0) > play_time || counts_read(player_ptr, 1) == play_time) {
         counts_write(player_ptr, 2, ++player_ptr->count);
     }

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -375,8 +375,8 @@ void monster_death(PlayerType *player_ptr, MONSTER_IDX m_idx, bool drop_item, At
 
     // プレイヤーしかユニークを倒せないのでここで時間を記録
     if (md_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE) && md_ptr->m_ptr->mflag2.has_not(MonsterConstantFlagType::CLONED)) {
-        world.update_playtime();
-        md_ptr->r_ptr->defeat_time = world.play_time;
+        world.play_time.update();
+        md_ptr->r_ptr->defeat_time = world.play_time.elapsed_sec();
         md_ptr->r_ptr->defeat_level = player_ptr->lev;
     }
 

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -271,7 +271,7 @@ void wr_player(PlayerType *player_ptr)
 
     /* Save temporary preserved pets (obsolated) */
     wr_s16b(0);
-    wr_u32b(world.play_time);
+    wr_u32b(world.play_time.elapsed_sec());
     wr_s32b(player_ptr->visit);
     wr_u32b(player_ptr->count);
 }

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -287,7 +287,7 @@ static bool save_player_aux(PlayerType *player_ptr, const std::filesystem::path 
     }
 
     auto &world = AngbandWorld::get_instance();
-    counts_write(player_ptr, 0, world.play_time);
+    counts_write(player_ptr, 0, world.play_time.elapsed_sec());
     world.character_saved = true;
     return true;
 }
@@ -312,7 +312,7 @@ bool save_player(PlayerType *player_ptr, SaveType type)
 
     safe_setuid_drop();
     auto &world = AngbandWorld::get_instance();
-    world.update_playtime();
+    world.play_time.update();
     auto result = false;
     if (save_player_aux(player_ptr, savefile_new.data())) {
         std::stringstream ss_old;

--- a/src/util/elapsed-time.cpp
+++ b/src/util/elapsed-time.cpp
@@ -1,0 +1,49 @@
+#include "util/elapsed-time.h"
+
+using namespace std::chrono;
+
+ElapsedTime::ElapsedTime()
+    : ElapsedTime(0)
+{
+}
+
+ElapsedTime::ElapsedTime(uint32_t current_sec)
+    : elapsed_time(duration_cast<milliseconds>(seconds(current_sec)))
+    , last_update_time(steady_clock::now())
+{
+}
+
+uint32_t ElapsedTime::elapsed_sec() const
+{
+    const auto elapsed_sec = duration_cast<seconds>(this->elapsed_time).count();
+    return static_cast<uint32_t>(elapsed_sec);
+}
+
+void ElapsedTime::update()
+{
+    if (this->is_paused) {
+        return;
+    }
+
+    const auto now = steady_clock::now();
+    const auto duration = now - this->last_update_time;
+
+    this->elapsed_time += duration_cast<milliseconds>(duration);
+    this->last_update_time = now;
+}
+
+void ElapsedTime::reset()
+{
+    *this = {};
+}
+
+void ElapsedTime::pause()
+{
+    this->is_paused = true;
+}
+
+void ElapsedTime::unpause()
+{
+    this->is_paused = false;
+    this->last_update_time = steady_clock::now();
+}

--- a/src/util/elapsed-time.h
+++ b/src/util/elapsed-time.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+
+class ElapsedTime {
+public:
+    ElapsedTime();
+    explicit ElapsedTime(uint32_t current_sec);
+
+    uint32_t elapsed_sec() const;
+    void update();
+    void reset();
+    void pause();
+    void unpause();
+
+private:
+    std::chrono::milliseconds elapsed_time;
+    std::chrono::steady_clock::time_point last_update_time;
+    bool is_paused = true;
+};

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -391,7 +391,7 @@ void fix_equip(PlayerType *player_ptr)
  */
 void fix_player(PlayerType *player_ptr)
 {
-    AngbandWorld::get_instance().update_playtime();
+    AngbandWorld::get_instance().play_time.update();
     display_sub_windows(SubWindowRedrawingFlag::PLAYER,
         [player_ptr] {
             display_player(player_ptr, 0);

--- a/src/world/world-movement-processor.cpp
+++ b/src/world/world-movement-processor.cpp
@@ -45,8 +45,8 @@ void check_random_quest_auto_failure(PlayerType *player_ptr)
 
         quest.status = QuestStatusType::FAILED;
         quest.complev = (byte)player_ptr->lev;
-        world.update_playtime();
-        quest.comptime = world.play_time;
+        world.play_time.update();
+        quest.comptime = world.play_time.elapsed_sec();
         quest.get_bounty().misc_flags.reset(MonsterMiscType::QUESTOR);
     }
 }

--- a/src/world/world.cpp
+++ b/src/world/world.cpp
@@ -80,20 +80,6 @@ std::tuple<int, int, int> AngbandWorld::extract_date_time(PlayerRaceType start_r
 }
 
 /*!
- * @brief 実ゲームプレイ時間を更新する
- */
-void AngbandWorld::update_playtime()
-{
-    if (this->start_time == 0) {
-        return;
-    }
-
-    const auto current_time = static_cast<uint32_t>(time(nullptr));
-    this->play_time += (current_time - this->start_time);
-    this->start_time = current_time;
-}
-
-/*!
  * @brief 勝利したクラスを追加する
  */
 void AngbandWorld::add_winner_class(PlayerClassType c)
@@ -189,9 +175,10 @@ void AngbandWorld::pass_game_turn_by_stay()
  */
 std::string AngbandWorld::format_real_playtime() const
 {
-    const auto hour = this->play_time / (60 * 60);
-    const auto min = (this->play_time / 60) % 60;
-    const auto sec = this->play_time % 60;
+    const auto playtime = this->play_time.elapsed_sec();
+    const auto hour = playtime / (60 * 60);
+    const auto min = (playtime / 60) % 60;
+    const auto sec = playtime % 60;
     return format("%.2u:%.2u:%.2u", hour, min, sec);
 }
 

--- a/src/world/world.h
+++ b/src/world/world.h
@@ -3,6 +3,7 @@
 #include "market/bounty-type-definition.h"
 #include "player-info/class-types.h"
 #include "system/angband.h"
+#include "util/elapsed-time.h"
 #include "util/flag-group.h"
 #include <tuple>
 
@@ -29,7 +30,6 @@ public:
     GAME_TURN dungeon_turn{}; /*!< NASTY生成の計算に関わる内部ターン値 / Game turn in dungeon */
     GAME_TURN dungeon_turn_limit{}; /*!< dungeon_turnの最大値 / Limit of game_turn in dungeon */
     GAME_TURN arena_start_turn{}; /*!< 闘技場賭博の開始ターン値 */
-    uint32_t start_time{};
     uint16_t noscore{}; /* Cheating flags */
     uint16_t total_winner{}; /* Total winner */
 
@@ -39,7 +39,7 @@ public:
     bool knows_daily_bounty{}; //!< 日替わり賞金首を知っているか否か
     MonraceId today_mon{}; //!< 実際の日替わり賞金首
 
-    uint32_t play_time{}; /*!< 実プレイ時間 */
+    ElapsedTime play_time{}; /*!< 実プレイ時間 */
 
     bool is_loading_now{}; /*!< ロード処理中フラグ...ロード直後にcalc_bonus()時の徳変化、及びsanity_blast()による異常を抑止する */
 
@@ -69,7 +69,6 @@ public:
     bool get_arena() const;
     std::tuple<int, int, int> extract_date_time(PlayerRaceType start_race) const;
     bool is_daytime() const;
-    void update_playtime();
     void add_winner_class(PlayerClassType c);
     void add_retired_class(PlayerClassType c);
     term_color_type get_birth_class_color(PlayerClassType c) const;


### PR DESCRIPTION
現在プレイ時間を生の整数型で管理しているが、新たにElapsedTimeクラスを作成してこれを使用して管理するようにする。

Resolves #4860 

## Fix #4858 

std::chrono::steady_clock を使用しているので、少なくとも「◯◯年問題」系にはひっかからなくなったはず。セーブファイル上に保存するプレイ時間が符号なし32bit整数なので、合計68年間変愚蛮怒を遊ぶとオーバーフローする問題は依然としてある。

## Fix #3606 

自動拾いエディタを起動中はプレイ時間が進まなくなるのは仕様であるが、#3606 の不具合はサブウィンドウ描画のためにプレイ時間更新処理が行われることが原因と思われる。
ElapsedTimeクラスに pause() / unpause() を実装して自動拾いエディタ起動中は確実にプレイ時間の進行をストップするようにしたので、この不具合も修正されたはず。