### PR TITLE
[Refactor] MonraceDefinition、MonsterEntity のメソッドの一部を静的public メソッドに移した

### DIFF
--- a/src/lore/lore-calculator.cpp
+++ b/src/lore/lore-calculator.cpp
@@ -77,7 +77,7 @@ void set_flags_for_full_knowledge(lore_type *lore_ptr)
         return;
     }
 
-    lore_ptr->drop_gold = lore_ptr->drop_item = ((lore_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_4D2) ? 8 : 0) + (lore_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_3D2) ? 6 : 0) + (lore_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_2D2) ? 4 : 0) + (lore_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_1D2) ? 2 : 0) + (lore_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_90) ? 1 : 0) + (lore_ptr->r_ptr->drop_flags.has(MonsterDropType::DROP_60) ? 1 : 0));
+    lore_ptr->drop_gold = lore_ptr->drop_item = MonraceDefinition::calc_drop_num(lore_ptr->r_ptr->drop_flags);
 
     if (lore_ptr->r_ptr->drop_flags.has(MonsterDropType::ONLY_GOLD)) {
         lore_ptr->drop_item = 0;

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -673,7 +673,7 @@ int ItemEntity::get_baseitem_price() const
 
 int ItemEntity::calc_figurine_value() const
 {
-    return this->get_monrace().calc_figurine_value();
+    return this->get_monrace().get_figurine_value();
 }
 
 int ItemEntity::calc_capture_value() const

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -623,12 +623,7 @@ std::optional<std::string> MonraceDefinition::probe_lore()
     }
 
     using Mdt = MonsterDropType;
-    auto num_drops = (this->drop_flags.has(Mdt::DROP_4D2) ? 8 : 0);
-    num_drops += (this->drop_flags.has(Mdt::DROP_3D2) ? 6 : 0);
-    num_drops += (this->drop_flags.has(Mdt::DROP_2D2) ? 4 : 0);
-    num_drops += (this->drop_flags.has(Mdt::DROP_1D2) ? 2 : 0);
-    num_drops += (this->drop_flags.has(Mdt::DROP_90) ? 1 : 0);
-    num_drops += (this->drop_flags.has(Mdt::DROP_60) ? 1 : 0);
+    auto num_drops = calc_drop_num(this->drop_flags);
     if (this->drop_flags.has_not(Mdt::ONLY_GOLD)) {
         if (this->r_drop_item != num_drops) {
             n = true;
@@ -1019,4 +1014,21 @@ int MonraceDefinition::calc_power_from_moving(int power, const EnumClassFlagGrou
     }
 
     return result;
+}
+
+/*!
+ * @brief アイテムドロップフラグからドロップ数を計算する
+ * @param drop_flags アイテムドロップフラグ
+ * @return アイテムのドロップ数
+ */
+int MonraceDefinition::calc_drop_num(const EnumClassFlagGroup<MonsterDropType> &drop_flags)
+{
+    using Mdt = MonsterDropType;
+    auto num_drops = (drop_flags.has(Mdt::DROP_4D2) ? 8 : 0);
+    num_drops += (drop_flags.has(Mdt::DROP_3D2) ? 6 : 0);
+    num_drops += (drop_flags.has(Mdt::DROP_2D2) ? 4 : 0);
+    num_drops += (drop_flags.has(Mdt::DROP_1D2) ? 2 : 0);
+    num_drops += (drop_flags.has(Mdt::DROP_90) ? 1 : 0);
+    num_drops += (drop_flags.has(Mdt::DROP_60) ? 1 : 0);
+    return num_drops;
 }

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -278,26 +278,9 @@ int MonraceDefinition::calc_power() const
     return power;
 }
 
-int MonraceDefinition::calc_figurine_value() const
+int MonraceDefinition::get_figurine_value() const
 {
-    const auto figurine_level = this->level;
-    if (figurine_level < 20) {
-        return figurine_level * 50;
-    }
-
-    if (figurine_level < 30) {
-        return 1000 + (figurine_level - 20) * 150;
-    }
-
-    if (figurine_level < 40) {
-        return 2500 + (figurine_level - 30) * 350;
-    }
-
-    if (figurine_level < 50) {
-        return 6000 + (figurine_level - 40) * 800;
-    }
-
-    return 14000 + (figurine_level - 50) * 2000;
+    return MonraceDefinition::calc_figurine_value(this->level);
 }
 
 int MonraceDefinition::calc_capture_value() const
@@ -964,4 +947,30 @@ bool MonraceDefinition::check_blow_times_for_knowing_damage(const int level, con
     }
 
     return (4 + level) * (2 * hitted_time) > 80 * temp_max_damage;
+}
+
+/*!
+ * @brief 人形の価格を計算する
+ * @param level モンスターのレベル
+ * @return 計算した価格
+ */
+int MonraceDefinition::calc_figurine_value(int level)
+{
+    if (level < 20) {
+        return level * 50;
+    }
+
+    if (level < 30) {
+        return 1000 + (level - 20) * 150;
+    }
+
+    if (level < 40) {
+        return 2500 + (level - 30) * 350;
+    }
+
+    if (level < 50) {
+        return 6000 + (level - 40) * 800;
+    }
+
+    return 14000 + (level - 50) * 2000;
 }

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -317,7 +317,7 @@ int MonraceDefinition::calc_capture_value() const
  */
 std::string MonraceDefinition::build_eldritch_horror_message(std::string_view description) const
 {
-    const auto &horror_message = this->decide_horror_message();
+    const auto &horror_message = MonraceDefinition::decide_horror_message(this->kind_flags);
     constexpr auto fmt = _("%s%sの顔を見てしまった！", "You behold the %s visage of %s!");
     return format(fmt, horror_message.data(), description.data());
 }
@@ -933,9 +933,10 @@ bool MonraceDefinition::has_blow_with_damage() const
 
 /*!
  * @brief エルドリッチホラーの形容詞種別を決める
+ * @param モンスターの種族フラグ
  * @return エルドリッチホラーの形容詞
  */
-const std::string &MonraceDefinition::decide_horror_message() const
+const std::string &MonraceDefinition::decide_horror_message(const EnumClassFlagGroup<MonsterKindType> &kind_flags)
 {
     const int horror_desc_common_size = horror_desc_common.size();
     auto horror_num = randint0(horror_desc_common_size + horror_desc_evil.size());
@@ -943,7 +944,7 @@ const std::string &MonraceDefinition::decide_horror_message() const
         return horror_desc_common[horror_num];
     }
 
-    if (this->kind_flags.has(MonsterKindType::EVIL)) {
+    if (kind_flags.has(MonsterKindType::EVIL)) {
         return horror_desc_evil[horror_num - horror_desc_common_size];
     }
 

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -209,6 +209,7 @@ public:
     static int calc_power_from_speed(int power, decltype(MonraceDefinition::speed) speed);
     static int calc_power_from_defensiveness(int power, int num_resistances, const EnumClassFlagGroup<MonsterAbilityType> &ability_flags);
     static int calc_power_from_moving(int power, const EnumClassFlagGroup<MonsterBehaviorType> &behavior_flags);
+    static int calc_drop_num(const EnumClassFlagGroup<MonsterDropType> &drop_flags);
 
     //!< @todo ここから先はミュータブルなフィールドなので分離すべき.
     bool has_entity() const;

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -201,8 +201,9 @@ public:
     void make_lore_treasure(int num_item, int num_drop);
     void emplace_drop_artifact(FixedArtifactId fa_id, int percentage);
     void emplace_reinforce(MonraceId monrace_id, const Dice &dice);
-    
-    static const std::string &decide_horror_message(EnumClassFlagGroup<MonsterKindType> &kind_flags);
+
+    static const std::string &decide_horror_message(const EnumClassFlagGroup<MonsterKindType> &kind_flags);
+    static bool check_blow_times_for_knowing_damage(const int level, const int max_roll, const int hitted_time, const EnumClassFlagGroup<MonsterKindType> &kind_flags);
 
     //!< @todo ここから先はミュータブルなフィールドなので分離すべき.
     bool has_entity() const;

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -201,6 +201,8 @@ public:
     void make_lore_treasure(int num_item, int num_drop);
     void emplace_drop_artifact(FixedArtifactId fa_id, int percentage);
     void emplace_reinforce(MonraceId monrace_id, const Dice &dice);
+    
+    static const std::string &decide_horror_message(EnumClassFlagGroup<MonsterKindType> &kind_flags);
 
     //!< @todo ここから先はミュータブルなフィールドなので分離すべき.
     bool has_entity() const;
@@ -226,5 +228,4 @@ private:
 
     bool is_suitable_for_arena() const;
     bool has_blow_with_damage() const;
-    const std::string &decide_horror_message() const;
 };

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -152,7 +152,7 @@ public:
     const MonraceDefinition &get_next() const;
     bool is_bounty(bool unachieved_only) const;
     int calc_power() const;
-    int calc_figurine_value() const;
+    int get_figurine_value() const;
     int calc_capture_value() const;
     std::string build_eldritch_horror_message(std::string_view description) const;
     bool has_reinforce() const;
@@ -204,6 +204,7 @@ public:
 
     static const std::string &decide_horror_message(const EnumClassFlagGroup<MonsterKindType> &kind_flags);
     static bool check_blow_times_for_knowing_damage(const int level, const int max_roll, const int hitted_time, const EnumClassFlagGroup<MonsterKindType> &kind_flags);
+    static int calc_figurine_value(int level);
 
     //!< @todo ここから先はミュータブルなフィールドなので分離すべき.
     bool has_entity() const;

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -205,6 +205,10 @@ public:
     static const std::string &decide_horror_message(const EnumClassFlagGroup<MonsterKindType> &kind_flags);
     static bool check_blow_times_for_knowing_damage(const int level, const int max_roll, const int hitted_time, const EnumClassFlagGroup<MonsterKindType> &kind_flags);
     static int calc_figurine_value(int level);
+    static int calc_power_from_maxhp(decltype(MonraceDefinition::hit_dice) hit_dice, bool force_maxhp);
+    static int calc_power_from_speed(int power, decltype(MonraceDefinition::speed) speed);
+    static int calc_power_from_defensiveness(int power, int num_resistances, const EnumClassFlagGroup<MonsterAbilityType> &ability_flags);
+    static int calc_power_from_moving(int power, const EnumClassFlagGroup<MonsterBehaviorType> &behavior_flags);
 
     //!< @todo ここから先はミュータブルなフィールドなので分離すべき.
     bool has_entity() const;

--- a/src/system/monster-entity.cpp
+++ b/src/system/monster-entity.cpp
@@ -263,25 +263,12 @@ bool MonsterEntity::is_invulnerable() const
     return this->get_remaining_invulnerability() > 0;
 }
 
-/*
+/*!
  * @brief 悪夢モード、一時加速、一時減速に基づくモンスターの現在速度を返す
  */
 byte MonsterEntity::get_temporary_speed() const
 {
-    auto speed = this->mspeed;
-    if (ironman_nightmare) {
-        speed += 5;
-    }
-
-    if (this->is_accelerated()) {
-        speed += 10;
-    }
-
-    if (this->is_decelerated()) {
-        speed -= 10;
-    }
-
-    return speed;
+    return MonsterEntity::calc_temporary_speed(this->mspeed, this->is_accelerated(), this->is_decelerated());
 }
 
 /*!
@@ -552,4 +539,29 @@ bool MonsterEntity::can_ring_boss_call_nazgul() const
     const auto &nazgul = MonraceList::get_instance().get_monrace(MonraceId::NAZGUL);
     const auto is_nazgul_alive = (nazgul.cur_num + 2) < nazgul.max_num;
     return is_boss && is_nazgul_alive;
+}
+
+/*!
+ * @brief 悪夢モード、一時加速、一時減速に基づくモンスターの現在速度を計算する
+ * @param speed モンスターのスピード
+ * @param accelerated 一時加速の有無
+ * @param decelerated 一時減速の有無
+ * @return 現在速度の計算結果
+ */
+byte MonsterEntity::calc_temporary_speed(decltype(MonsterEntity::mspeed) speed, bool accelerated, bool decelerated)
+{
+    auto result_speed = speed;
+    if (ironman_nightmare) {
+        result_speed += 5;
+    }
+
+    if (accelerated) {
+        result_speed += 10;
+    }
+
+    if (decelerated) {
+        result_speed -= 10;
+    }
+
+    return result_speed;
 }

--- a/src/system/monster-entity.h
+++ b/src/system/monster-entity.h
@@ -119,6 +119,8 @@ public:
     void set_target(POSITION y, POSITION x);
     void reset_target();
     void set_friendly();
+    
+    static byte calc_temporary_speed(decltype(MonsterEntity::mspeed) speed, bool accelerated, bool decelerated);
 
 private:
     MonsterEntity(const MonsterEntity &) = default;

--- a/src/system/monster-entity.h
+++ b/src/system/monster-entity.h
@@ -119,8 +119,9 @@ public:
     void set_target(POSITION y, POSITION x);
     void reset_target();
     void set_friendly();
-    
+
     static byte calc_temporary_speed(decltype(MonsterEntity::mspeed) speed, bool accelerated, bool decelerated);
+    static decltype(MonsterEntity::mspeed) calc_individual_speed(decltype(MonsterEntity::mspeed) speed, bool fixed_speed);
 
 private:
     MonsterEntity(const MonsterEntity &) = default;


### PR DESCRIPTION
close #4845 

かなり試金石的なリファクタリング
このリファクタリングによって、ドロップ数の計算を例に挙げると下記のようなユニットテストができるようになる

```
...

TEST_METHOD(DropItemCalcTest)
{
    EnumClassFlagGroup<MonsterDropType> drop_flags = {};
    Assert::IsTrue(MonraceDefinition::calc_drop_num(drop_flags) == 0);

    drop_flags.set(MonsterDropType::DROP_60);
    Assert::IsTrue(MonraceDefinition::calc_drop_num(drop_flags) == 1);

    drop_flags.set(MonsterDropType::DROP_90);
    Assert::IsTrue(MonraceDefinition::calc_drop_num(drop_flags) == 2);

    drop_flags.set(MonsterDropType::DROP_1D2);
    Assert::IsTrue(MonraceDefinition::calc_drop_num(drop_flags) == 4);

    drop_flags.set(MonsterDropType::DROP_2D2);
    Assert::IsTrue(MonraceDefinition::calc_drop_num(drop_flags) == 8);

    drop_flags.set(MonsterDropType::DROP_3D2);
    Assert::IsTrue(MonraceDefinition::calc_drop_num(drop_flags) == 14);

    drop_flags.set(MonsterDropType::DROP_4D2);
    Assert::IsTrue(MonraceDefinition::calc_drop_num(drop_flags) == 22);
}
```