### PR TITLE
Update hengband.spec and others

### DIFF
--- a/hengband.spec
+++ b/hengband.spec
@@ -1,4 +1,4 @@
-%define version 3.0.1.24
+%define version 3.0.1.25
 %define release 1
 
 Summary: hengband %{version}
@@ -154,6 +154,9 @@ exit 0
 %license lib/help/jlicense.txt THIRD-PARTY-NOTICES.txt
 
 %changelog
+* Mon Jan 20 2025 whitehara <white@vx-xv.com>
+- hengband RPM 3.0.1.25(Beta)
+
 * Mon Jan 6 2025 whitehara <white@vx-xv.com>
 - hengband RPM 3.0.1.24(Beta)
 

--- a/hengband.spec
+++ b/hengband.spec
@@ -148,7 +148,7 @@ exit 0
 %{_datadir}/games/%{name}/lib/pref/*.prf
 %{_datadir}/games/%{name}/lib/xtra/graf/8x8.bmp
 %doc readme.md readme_angband readme-eng.md
-%license lib/help/jlicense.txt
+%license lib/help/jlicense.txt THIRD-PARTY-NOTICES.txt
 
 %changelog
 * Mon Jan 6 2025 whitehara <white@vx-xv.com>

--- a/hengband.spec
+++ b/hengband.spec
@@ -30,8 +30,9 @@ Hengband is a variant of ZAngband.
 Official page is this,
 https://hengband.github.io
 
-More infomation is /usr/share/doc/hengband/readme-eng.md
-This is a Japanese version.
+More information is in /usr/share/doc/hengband/readme-eng.md
+This package contains an executable file in Japanese.
+You also need to install hengband-data package for playing.
 
 Summary(ja): 変愚蛮怒 %{version}
 
@@ -42,7 +43,8 @@ Summary(ja): 変愚蛮怒 %{version}
 https://hengband.github.io
 
 詳しくは /usr/share/doc/hengband/readme.md を参照。
-このパッケージは日本語版です。
+このパッケージは日本語版実行ファイルです。
+他にゲーム用データファイルが必要です。
 
 %description data
 Hengband is a variant of ZAngband.
@@ -50,7 +52,7 @@ Hengband is a variant of ZAngband.
 Official page is this,
 https://hengband.github.io
 
-More infomation is /usr/share/doc/hengband/readme-eng.md
+More information is in /usr/share/doc/hengband/readme-eng.md
 This packages contains common data files.
 
 Summary(ja): 変愚蛮怒 %{version}
@@ -70,8 +72,9 @@ Hengband is a variant of ZAngband.
 Official page is this,
 https://hengband.github.io
 
-More infomation is /usr/share/doc/hengband/readme-eng.md
-This is a English version.
+More information is in /usr/share/doc/hengband/readme-eng.md
+This package contains an executable file in English.
+You also need to install hengband-data package for playing.
 
 Summary(ja): 変愚蛮怒 %{version}
 

--- a/hengband.spec
+++ b/hengband.spec
@@ -147,7 +147,7 @@ exit 0
 %{_datadir}/games/%{name}/lib/help/*.txt
 %{_datadir}/games/%{name}/lib/pref/*.prf
 %{_datadir}/games/%{name}/lib/xtra/graf/8x8.bmp
-%doc readme.md readme_angband readme-eng.md
+%doc readme.md readme_angband readme-eng.md autopick.txt autopick_eng.txt
 %license lib/help/jlicense.txt THIRD-PARTY-NOTICES.txt
 
 %changelog


### PR DESCRIPTION
- hengband.specのバージョンを3.0.1.25に更新
- 同バージョンのrpmをCoprにて配布開始 https://copr.fedorainfracloud.org/coprs/whitehara/hengband/
- rpm内のライセンス関連ファイルとしてTHIRD-PARTY-NOTICES.txtを追加
- rpm内のドキュメントファイルとしてautopick.txtおよびautopick_eng.txtを追加
- rpmの説明文に補足を追加