### PR TITLE
[Feature] 自動拾いエディタのカーソル上下の挙動を自然にする

### DIFF
--- a/src/autopick/autopick-util.h
+++ b/src/autopick/autopick-util.h
@@ -42,8 +42,13 @@ struct autopick_type {
 class ItemEntity;
 struct text_body_type {
     text_body_type(int cx, int cy); //!< @details 画面表示はX→Yの順番であることが多いので一応揃える.
+
+    void adjust_cursor_column();
+    void update_cursor_column_record(int com_id);
+
     int cx;
     int cy;
+    int rec_cx = 0;
     int wid = 0;
     int hgt = 0;
     int upper = 0;


### PR DESCRIPTION
自動エディタのカーソルを上下方向に動かした時（スクロールアップ/ダウンやエディタの先頭行・最終行への移動を含む）に、移動前の行より短い行に移動した場合にカーソルの位置も短い行にあわせて移動させる。
またその行から長い行に行った場合に元のカーソルの位置に戻そうとする。

Resolves #4836 