### PR TITLE
[Refactor] コピーされるべきでないクラスのコピーコンストラクタ/コピー代入演算子の削除

### DIFF
--- a/src/info-reader/artifact-reader.cpp
+++ b/src/info-reader/artifact-reader.cpp
@@ -192,6 +192,6 @@ errr parse_artifacts_info(nlohmann::json &art_data, angband_header *)
         return err;
     }
 
-    ArtifactList::get_instance().emplace(artifact_id, artifact);
+    ArtifactList::get_instance().emplace(artifact_id, std::move(artifact));
     return PARSE_ERROR_NONE;
 }

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -132,7 +132,7 @@ static bool restrict_monster_to_dungeon(const DungeonDefinition &dungeon, int fl
         };
 
         auto result = std::all_of(is_possible.begin(), is_possible.end(), [](const auto &v) { return v; });
-        result &= std::all_of(dungeon.r_chars.begin(), dungeon.r_chars.end(), [monrace](const auto &v) { return v == monrace.symbol_definition.character; });
+        result &= std::all_of(dungeon.r_chars.begin(), dungeon.r_chars.end(), [&monrace](const auto &v) { return v == monrace.symbol_definition.character; });
         return dungeon.mode == DungeonMode::AND ? result : !result;
     }
     case DungeonMode::OR:
@@ -152,7 +152,7 @@ static bool restrict_monster_to_dungeon(const DungeonDefinition &dungeon, int fl
         };
 
         auto result = std::any_of(is_possible.begin(), is_possible.end(), [](const auto &v) { return v; });
-        result |= std::any_of(dungeon.r_chars.begin(), dungeon.r_chars.end(), [monrace](const auto &v) { return v == monrace.symbol_definition.character; });
+        result |= std::any_of(dungeon.r_chars.begin(), dungeon.r_chars.end(), [&monrace](const auto &v) { return v == monrace.symbol_definition.character; });
         return dungeon.mode == DungeonMode::OR ? result : !result;
     }
     }

--- a/src/object-enchant/object-ego.h
+++ b/src/object-enchant/object-ego.h
@@ -242,6 +242,11 @@ enum class RandomArtActType : short;
 class EgoItemDefinition {
 public:
     EgoItemDefinition() = default;
+    EgoItemDefinition(EgoItemDefinition &) = delete;
+    EgoItemDefinition &operator=(EgoItemDefinition &) = delete;
+    EgoItemDefinition(EgoItemDefinition &&) = default;
+    EgoItemDefinition &operator=(EgoItemDefinition &&) = delete;
+
     EgoType idx{};
 
     std::string name; //!< エゴの名前

--- a/src/system/artifact-type-definition.cpp
+++ b/src/system/artifact-type-definition.cpp
@@ -161,9 +161,9 @@ bool ArtifactList::order(const FixedArtifactId id1, const FixedArtifactId id2) c
     return id1 < id2;
 }
 
-void ArtifactList::emplace(const FixedArtifactId fa_id, const ArtifactType &artifact)
+void ArtifactList::emplace(const FixedArtifactId fa_id, ArtifactType &&artifact)
 {
-    this->artifacts.emplace(fa_id, artifact);
+    this->artifacts.emplace(fa_id, std::move(artifact));
 }
 
 void ArtifactList::reset_generated_flags()

--- a/src/system/artifact-type-definition.h
+++ b/src/system/artifact-type-definition.h
@@ -20,6 +20,10 @@ enum class RandomArtActType : short;
 class ArtifactType {
 public:
     ArtifactType();
+    ArtifactType(const ArtifactType &) = delete;
+    ArtifactType &operator=(const ArtifactType &) = delete;
+    ArtifactType(ArtifactType &&) = default;
+    ArtifactType &operator=(ArtifactType &&) = delete;
 
     std::string name; /*!< アーティファクト名 / Name */
     std::string text; /*!< アーティファクト解説 / Text */
@@ -64,7 +68,7 @@ public:
     ArtifactType &get_artifact(const FixedArtifactId fa_id);
 
     bool order(const FixedArtifactId id1, const FixedArtifactId id2) const;
-    void emplace(const FixedArtifactId fa_id, const ArtifactType &artifact);
+    void emplace(const FixedArtifactId fa_id, ArtifactType &&artifact);
     void reset_generated_flags();
     std::optional<ItemEntity> try_make_instant_artifact(int making_level) const;
 

--- a/src/system/baseitem/baseitem-definition.h
+++ b/src/system/baseitem/baseitem-definition.h
@@ -20,6 +20,11 @@ enum class RandomArtActType : short;
 class BaseitemDefinition {
 public:
     BaseitemDefinition();
+    BaseitemDefinition(BaseitemDefinition &) = delete;
+    BaseitemDefinition &operator=(BaseitemDefinition &) = delete;
+    BaseitemDefinition(BaseitemDefinition &&) = default;
+    BaseitemDefinition &operator=(BaseitemDefinition &&) = delete;
+
     short idx{};
 
     std::string name; /*!< ベースアイテム名 */

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -74,6 +74,10 @@ enum class GridFlow : int;
 class MonraceDefinition {
 public:
     MonraceDefinition();
+    MonraceDefinition(const MonraceDefinition &) = delete;
+    MonraceDefinition &operator=(const MonraceDefinition &) = delete;
+    MonraceDefinition(MonraceDefinition &&) = default;
+    MonraceDefinition &operator=(MonraceDefinition &&) = delete;
 
     MonraceId idx{};
     LocalizedString name{}; //!< モンスターの名称


### PR DESCRIPTION
Resolves #4686 

ムーブコンストラクタだけは初期化の都合上必要なので残しています。（std::mapで持っている場合ムーブコンストラクタも削除できなくはないが、初期化のコードをかなりいじらないといけないので面倒）