### PR TITLE
[Refactor] 床と壁の確率による選択

### DIFF
--- a/src/system/dungeon/dungeon-definition.cpp
+++ b/src/system/dungeon/dungeon-definition.cpp
@@ -195,12 +195,12 @@ DoorKind DungeonDefinition::select_door_kind() const
 
 short DungeonDefinition::select_floor_terrain_id() const
 {
-    return rand_choice(this->floor_terrain_ids);
+    return this->prob_table_floor.pick_one_at_random();
 }
 
 short DungeonDefinition::select_wall_terrain_id() const
 {
-    return rand_choice(this->wall_terrain_ids);
+    return this->prob_table_wall.pick_one_at_random();
 }
 
 void DungeonDefinition::set_guardian_flag()
@@ -209,49 +209,6 @@ void DungeonDefinition::set_guardian_flag()
         auto &monrace = this->get_guardian();
         monrace.misc_flags.set(MonsterMiscType::GUARDIAN);
     }
-}
-
-void DungeonDefinition::set_floor_terrain_ids()
-{
-    this->floor_terrain_ids = this->make_terrain_ids(this->floor);
-}
-
-void DungeonDefinition::set_wall_terrain_ids()
-{
-    this->wall_terrain_ids = this->make_terrain_ids(this->fill);
-}
-
-/*!
- * @brief 地形生成確率の決定要素を確率テーブルから作成する
- * @param is_floor 床/地面ならtrue、壁ならfalse
- */
-std::array<short, 100> DungeonDefinition::make_terrain_ids(const std::array<TerrainProbabilityEntry, TERRAIN_PROBABILITY_NUM> &prob_table)
-{
-    std::array<int, TERRAIN_PROBABILITY_NUM> limits{};
-    limits[0] = prob_table[0].chance;
-    for (auto i = 1; i < TERRAIN_PROBABILITY_NUM; i++) {
-        limits[i] = limits[i - 1] + prob_table[i].chance;
-    }
-
-    if (limits[TERRAIN_PROBABILITY_NUM - 1] < 100) {
-        limits[TERRAIN_PROBABILITY_NUM - 1] = 100;
-    }
-
-    std::array<short, 100> ids{};
-    auto cur = 0;
-    for (auto i = 0; i < 100; i++) {
-        while (i == limits[cur]) {
-            cur++;
-        }
-
-        if (cur >= TERRAIN_PROBABILITY_NUM) {
-            THROW_EXCEPTION(std::logic_error, "Invalid probability table is generated!");
-        }
-
-        ids[i] = prob_table[cur].terrain_id;
-    }
-
-    return ids;
 }
 
 MonraceDefinition &DungeonDefinition::get_guardian()

--- a/src/system/dungeon/dungeon-definition.h
+++ b/src/system/dungeon/dungeon-definition.h
@@ -17,25 +17,17 @@
 #include "monster-race/race-wilderness-flags.h"
 #include "system/angband.h"
 #include "util/flag-group.h"
-#include <array>
+#include "util/probability-table.h"
 #include <optional>
 #include <string>
 #include <utility>
 #include <vector>
-
-constexpr auto TERRAIN_PROBABILITY_NUM = 3;
 
 enum class DungeonMode {
     AND = 1,
     NAND = 2,
     OR = 3,
     NOR = 4,
-};
-
-class TerrainProbabilityEntry {
-public:
-    short terrain_id{}; //!< 地形ID.
-    int chance{}; //!< 確率(%).
 };
 
 /* A structure for the != dungeon types */
@@ -54,8 +46,8 @@ public:
     POSITION dy{};
     POSITION dx{};
 
-    std::array<TerrainProbabilityEntry, TERRAIN_PROBABILITY_NUM> floor{}; /* Floor probability */
-    std::array<TerrainProbabilityEntry, TERRAIN_PROBABILITY_NUM> fill{}; /* Cave wall probability */
+    ProbabilityTable<short> prob_table_floor{}; /* Floor probability */
+    ProbabilityTable<short> prob_table_wall{}; /* Cave wall probability */
     short outer_wall{}; /* 外壁の地形ID */
     short inner_wall{}; /* 内壁の地形ID */
     FEAT_IDX stream1{}; /* stream tile */
@@ -115,13 +107,7 @@ public:
 
     //!< @details ここから下は、地形など全ての定義ファイルを読み込んだ後に呼び出される初期化処理.
     void set_guardian_flag();
-    void set_floor_terrain_ids();
-    void set_wall_terrain_ids();
 
 private:
-    std::array<short, 100> floor_terrain_ids{};
-    std::array<short, 100> wall_terrain_ids{};
-
-    static std::array<short, 100> make_terrain_ids(const std::array<TerrainProbabilityEntry, TERRAIN_PROBABILITY_NUM> &prob_table);
     MonraceDefinition &get_guardian();
 };

--- a/src/system/dungeon/dungeon-list.cpp
+++ b/src/system/dungeon/dungeon-list.cpp
@@ -46,7 +46,5 @@ void DungeonList::retouch()
 {
     for (auto &[_, dungeon] : this->dungeons) {
         dungeon->set_guardian_flag();
-        dungeon->set_floor_terrain_ids();
-        dungeon->set_wall_terrain_ids();
     }
 }


### PR DESCRIPTION
100個の配列に地形IDを展開する方法からProbabilityTableクラスを使用する方法に変更する。

Resolves #4884 