### PR TITLE
[Feature] 分解のブレス/ボールの軌道の表示を自然にする

### DIFF
--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -213,11 +213,13 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITIO
         auto drawn = false;
         auto pos_total = 0;
         for (auto dist_step = 0; std::cmp_less(pos_total, positions.size()); ++dist_step) {
+            auto can_see_disi = breath && any_bits(flag, PROJECT_DISI) && floor.has_los(pos_source);
+            can_see_disi |= !breath && any_bits(flag, PROJECT_DISI) && floor.has_los(pos_impact);
             for (const auto &[dist, pos] : positions) {
                 if (dist != dist_step) {
                     continue;
                 }
-                if (panel_contains(pos.y, pos.x) && floor.has_los(pos)) {
+                if (panel_contains(pos.y, pos.x) && (can_see_disi || floor.has_los(pos))) {
                     drawn = true;
                     print_bolt_pict(player_ptr, pos.y, pos.x, pos.y, pos.x, typ);
                 }


### PR DESCRIPTION
ブレスの場合: 発射した地点が見えていればいればすべての軌道が見える
ボールの場合: 着弾点が見えていればすべての軌道が見える

Resolves #4874 