### PR TITLE
sweep_ranged_attack_grid() の引数をPos2D に変え、戻り値をoptional<Pos2D> に変えた

### DIFF
--- a/src/monster-floor/monster-sweep-grid.h
+++ b/src/monster-floor/monster-sweep-grid.h
@@ -24,7 +24,7 @@ private:
     bool mon_will_run();
     void sweep_movable_grid(POSITION *yp, POSITION *xp, bool no_flow);
     bool check_movable_grid(POSITION *yp, POSITION *xp, const bool no_flow);
-    bool sweep_ranged_attack_grid(POSITION *yp, POSITION *xp);
+    std::optional<Pos2D> sweep_ranged_attack_grid(const Pos2D &pos_initial);
     std::optional<Pos2DVec> sweep_runnable_away_grid(const Pos2DVec &vec_initial) const;
     void check_hiding_grid(POSITION *y, POSITION *x, POSITION *y2, POSITION *x2);
     void search_room_to_run(POSITION *y, POSITION *x);


### PR DESCRIPTION
元のコード (というべきか設計というべきか第1次リファクタリングのミスというべきか)がぐちゃぐちゃなのであまり自信がありませんが論理的には合っているように思います
引数/戻り値をPos2D に変えてポインタ引数がなくなったらもう設計を見直すのが良いかと思います
ご確認下さい