### PR TITLE
[Fix] メイン画面の種族表示がはみ出る

### DIFF
--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -238,7 +238,7 @@ void print_frame_basic(PlayerType *player_ptr)
     const auto &title = player_ptr->mimic_form == MimicKindType::NONE
                             ? rp_ptr->title
                             : mimic_info.at(player_ptr->mimic_form).title;
-    print_field(title, ROW_RACE, COL_RACE);
+    print_field(str_substr(title, 0, 12), ROW_RACE, COL_RACE);
     print_title(player_ptr);
     print_level(player_ptr);
     print_exp(player_ptr);


### PR DESCRIPTION
マインドフレアは14桁必要だが、メイン画面の種族表示欄は12桁までしか想定されていないので表示がはみ出る。
またマップで上書きされたタイミングで「ア」が消える。
どうしようもないので12桁で切って表示するようにする。
（現在該当するのは日本語版におけるマインドフレアのみと思われる）

FIx #4780 