### PR TITLE
[Fix] 強力発動地震の杖の半径

### DIFF
--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -45,8 +45,8 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
         return false;
     }
 
-    if (r > 12) {
-        r = 12;
+    if (r > 15) {
+        r = 15;
     }
 
     bool map[32][32]{};


### PR DESCRIPTION
魔道具術師で地震の杖を強力発動したとき、呼び出し側は半径15を指定しているが、earthquake()側で最大半径12までに制限されているため半径12での発動となっている。
半径15でも問題はないと思われるので最大15までに修正する。
（内部で使用しているmapという二次元配列の変数も15までは対応している）
なお、半径15より大きな数値で呼ばれるのは「自然の脅威」の魔法により発生する地震で、20 + plev / 2 で最大半径45というとんでもない数値になっているがあまりにも大きすぎるし、上述の二次元配列の都合もあるのでひとまず15までとする。

FIx #4510 