### PR TITLE
MonsterSweepGrid のメソッドからポインタ引数を掃き出した

### DIFF
--- a/src/monster-floor/monster-sweep-grid.cpp
+++ b/src/monster-floor/monster-sweep-grid.cpp
@@ -82,7 +82,7 @@ bool MonsterSweepGrid::get_movable_grid()
         return false;
     }
 
-    store_moves_val(this->mm, vec_pet.y, vec_pet.x);
+    store_moves_val(this->mm, vec_pet);
     return true;
 }
 

--- a/src/monster-floor/monster-sweep-grid.cpp
+++ b/src/monster-floor/monster-sweep-grid.cpp
@@ -89,28 +89,28 @@ bool MonsterSweepGrid::get_movable_grid()
  * @brief モンスターがプレイヤーから逃走するかどうかを返す
  * @return モンスターがプレイヤーから逃走するならばTRUEを返す。
  */
-bool MonsterSweepGrid::mon_will_run()
+bool MonsterSweepGrid::mon_will_run() const
 {
-    auto *m_ptr = &this->player_ptr->current_floor_ptr->m_list[this->m_idx];
-    auto *r_ptr = &m_ptr->get_monrace();
-    if (m_ptr->is_pet()) {
-        return (this->player_ptr->pet_follow_distance < 0) && (m_ptr->cdis <= (0 - this->player_ptr->pet_follow_distance));
+    const auto &monster = this->player_ptr->current_floor_ptr->m_list[this->m_idx];
+    if (monster.is_pet()) {
+        return (this->player_ptr->pet_follow_distance < 0) && (monster.cdis <= (0 - this->player_ptr->pet_follow_distance));
     }
 
-    if (m_ptr->cdis > MAX_PLAYER_SIGHT + 5) {
+    if (monster.cdis > MAX_PLAYER_SIGHT + 5) {
         return false;
     }
 
-    if (m_ptr->is_fearful()) {
+    if (monster.is_fearful()) {
         return true;
     }
 
-    if (m_ptr->cdis <= 5) {
+    if (monster.cdis <= 5) {
         return false;
     }
 
-    auto p_lev = this->player_ptr->lev;
-    auto m_lev = r_ptr->level + (this->m_idx & 0x08) + 25;
+    const auto p_lev = this->player_ptr->lev;
+    const auto &monrace = monster.get_monrace();
+    const auto m_lev = monrace.level + (this->m_idx & 0x08) + 25;
     if (m_lev > p_lev + 4) {
         return false;
     }
@@ -121,8 +121,8 @@ bool MonsterSweepGrid::mon_will_run()
 
     auto p_chp = this->player_ptr->chp;
     auto p_mhp = this->player_ptr->mhp;
-    auto m_chp = m_ptr->hp;
-    auto m_mhp = m_ptr->maxhp;
+    auto m_chp = monster.hp;
+    auto m_mhp = monster.maxhp;
     uint32_t p_val = (p_lev * p_mhp) + (p_chp << 2);
     uint32_t m_val = (m_lev * m_mhp) + (m_chp << 2);
     return p_val * m_mhp > m_val * p_mhp;
@@ -362,7 +362,7 @@ std::optional<Pos2D> MonsterSweepGrid::sweep_ranged_attack_grid(const Pos2D &pos
     return pos;
 }
 
-bool MonsterSweepGrid::is_best_cost(const Pos2D &pos, const int now_cost)
+bool MonsterSweepGrid::is_best_cost(const Pos2D &pos, int now_cost)
 {
     const auto &floor = *this->player_ptr->current_floor_ptr;
     const auto &monster = floor.m_list[this->m_idx];
@@ -440,7 +440,7 @@ std::optional<Pos2DVec> MonsterSweepGrid::sweep_runnable_away_grid(const Pos2DVe
     return m_pos - pos_run;
 }
 
-Pos2D MonsterSweepGrid::determine_when_cost(const Pos2D &pos_initial, const Pos2D &m_pos, const bool use_scent)
+Pos2D MonsterSweepGrid::determine_when_cost(const Pos2D &pos_initial, const Pos2D &m_pos, bool use_scent)
 {
     Pos2D pos = pos_initial;
     const auto &floor = *this->player_ptr->current_floor_ptr;

--- a/src/monster-floor/monster-sweep-grid.cpp
+++ b/src/monster-floor/monster-sweep-grid.cpp
@@ -27,7 +27,7 @@
 /*
  * @brief コンストラクタ
  * @param player_ptr プレイヤーへの参照ポインタ
- * @param m_idx 逃走するモンスターの参照ID
+ * @param m_idx 移動するモンスターの参照ID
  * @param mm 移動方向を返す方向IDの参照ポインタ
  */
 MonsterSweepGrid::MonsterSweepGrid(PlayerType *player_ptr, MONSTER_IDX m_idx, DIRECTION *mm)
@@ -38,8 +38,7 @@ MonsterSweepGrid::MonsterSweepGrid(PlayerType *player_ptr, MONSTER_IDX m_idx, DI
 }
 
 /*!
- * @brief モンスターの移動方向を返す /
- * Choose "logical" directions for monster movement
+ * @brief モンスターの移動方向を返す
  * @return 有効方向があった場合TRUEを返す
  * @todo 分割したいが条件が多すぎて適切な関数名と詳細処理を追いきれない……
  */
@@ -87,8 +86,7 @@ bool MonsterSweepGrid::get_movable_grid()
 }
 
 /*!
- * @brief モンスターがプレイヤーから逃走するかどうかを返す /
- * Returns whether a given monster will try to run from the player.
+ * @brief モンスターがプレイヤーから逃走するかどうかを返す
  * @return モンスターがプレイヤーから逃走するならばTRUEを返す。
  */
 bool MonsterSweepGrid::mon_will_run()
@@ -247,6 +245,7 @@ Pos2DVec MonsterSweepGrid::search_pet_runnable_grid(const Pos2DVec &vec_initial,
  * @brief モンスターがプレイヤーに向けて接近することが可能なマスを走査する
  * @param p_pos プレイヤーの座標
  * @param no_flow モンスターにFLOWフラグが経っていない状態でTRUE
+ * @return 接近可能な座標
  */
 Pos2D MonsterSweepGrid::sweep_movable_grid(const Pos2D &p_pos, bool no_flow)
 {
@@ -290,7 +289,7 @@ std::pair<Pos2D, bool> MonsterSweepGrid::check_movable_grid(const Pos2D &pos_ini
     const auto &monster = this->player_ptr->current_floor_ptr->m_list[this->m_idx];
     const auto &monrace = monster.get_monrace();
     if (monrace.ability_flags.has_any_of(RF_ABILITY_ATTACK_MASK)) {
-        const auto &pos = sweep_ranged_attack_grid(pos_initial);
+        const auto &pos = this->sweep_ranged_attack_grid(pos_initial);
         if (pos) {
             return std::pair<Pos2D, bool>(*pos, false);
         }
@@ -399,11 +398,9 @@ bool MonsterSweepGrid::is_best_cost(const Pos2D &pos, const int now_cost)
 }
 
 /*!
- * @brief モンスターがプレイヤーから逃走することが可能なマスを走査する /
- * Provide a location to flee to, but give the player a wide berth.
- * @param yp 移動先のマスのY座標を返す参照ポインタ
- * @param xp 移動先のマスのX座標を返す参照ポインタ
- * @return 有効なマスがあった場合TRUEを返す
+ * @brief モンスターがプレイヤーから逃走することが可能なマスを走査する
+ * @param vec_initial 移動先から移動元へ向かうベクトル
+ * @return 有効なマスがあった場合はその座標、なかったらnullopt
  */
 std::optional<Pos2DVec> MonsterSweepGrid::sweep_runnable_away_grid(const Pos2DVec &vec_initial) const
 {

--- a/src/monster-floor/monster-sweep-grid.h
+++ b/src/monster-floor/monster-sweep-grid.h
@@ -24,7 +24,7 @@ private:
     int best = 999;
     bool mon_will_run();
     void sweep_movable_grid(POSITION *yp, POSITION *xp, bool no_flow);
-    bool check_movable_grid(POSITION *yp, POSITION *xp, const bool no_flow);
+    std::pair<Pos2D, bool> check_movable_grid(const Pos2D &pos_initial, bool no_flow);
     std::optional<Pos2D> sweep_ranged_attack_grid(const Pos2D &pos_initial);
     std::optional<Pos2DVec> sweep_runnable_away_grid(const Pos2DVec &vec_initial) const;
     std::pair<Pos2DVec, Pos2D> check_hiding_grid(const Pos2DVec &vec_initial, const Pos2D &p_pos);

--- a/src/monster-floor/monster-sweep-grid.h
+++ b/src/monster-floor/monster-sweep-grid.h
@@ -22,7 +22,7 @@ private:
     bool can_open_door = false;
     int cost = 0;
     int best = 999;
-    bool mon_will_run();
+    bool mon_will_run() const;
     Pos2D sweep_movable_grid(const Pos2D &p_pos, bool no_flow);
     std::pair<Pos2D, bool> check_movable_grid(const Pos2D &pos_initial, bool no_flow);
     std::optional<Pos2D> sweep_ranged_attack_grid(const Pos2D &pos_initial);
@@ -30,6 +30,6 @@ private:
     std::pair<Pos2DVec, Pos2D> check_hiding_grid(const Pos2DVec &vec_initial, const Pos2D &p_pos);
     Pos2DVec search_room_to_run(const Pos2DVec &vec_initial);
     Pos2DVec search_pet_runnable_grid(const Pos2DVec &vec_initial, bool no_flow);
-    Pos2D determine_when_cost(const Pos2D &pos_initial, const Pos2D &m_pos, const bool use_scent);
-    bool is_best_cost(const Pos2D &pos, const int now_cost);
+    Pos2D determine_when_cost(const Pos2D &pos_initial, const Pos2D &m_pos, bool use_scent);
+    bool is_best_cost(const Pos2D &pos, int now_cost);
 };

--- a/src/monster-floor/monster-sweep-grid.h
+++ b/src/monster-floor/monster-sweep-grid.h
@@ -23,7 +23,7 @@ private:
     int cost = 0;
     int best = 999;
     bool mon_will_run();
-    void sweep_movable_grid(POSITION *yp, POSITION *xp, bool no_flow);
+    Pos2D sweep_movable_grid(const Pos2D &p_pos, bool no_flow);
     std::pair<Pos2D, bool> check_movable_grid(const Pos2D &pos_initial, bool no_flow);
     std::optional<Pos2D> sweep_ranged_attack_grid(const Pos2D &pos_initial);
     std::optional<Pos2DVec> sweep_runnable_away_grid(const Pos2DVec &vec_initial) const;

--- a/src/monster-floor/monster-sweep-grid.h
+++ b/src/monster-floor/monster-sweep-grid.h
@@ -27,7 +27,7 @@ private:
     std::optional<Pos2D> sweep_ranged_attack_grid(const Pos2D &pos_initial);
     std::optional<Pos2DVec> sweep_runnable_away_grid(const Pos2DVec &vec_initial) const;
     void check_hiding_grid(POSITION *y, POSITION *x, POSITION *y2, POSITION *x2);
-    void search_room_to_run(POSITION *y, POSITION *x);
+    Pos2DVec search_room_to_run(const Pos2DVec &vec_initial);
     Pos2DVec search_pet_runnable_grid(const Pos2DVec &vec_initial, bool no_flow);
     Pos2D determine_when_cost(const Pos2D &pos_initial, const Pos2D &m_pos, const bool use_scent);
     bool is_best_cost(const Pos2D &pos, const int now_cost);

--- a/src/monster-floor/monster-sweep-grid.h
+++ b/src/monster-floor/monster-sweep-grid.h
@@ -3,6 +3,7 @@
 #include "system/angband.h"
 #include "util/point-2d.h"
 #include <optional>
+#include <utility>
 
 class PlayerType;
 class MonsterSweepGrid {
@@ -26,7 +27,7 @@ private:
     bool check_movable_grid(POSITION *yp, POSITION *xp, const bool no_flow);
     std::optional<Pos2D> sweep_ranged_attack_grid(const Pos2D &pos_initial);
     std::optional<Pos2DVec> sweep_runnable_away_grid(const Pos2DVec &vec_initial) const;
-    void check_hiding_grid(POSITION *y, POSITION *x, POSITION *y2, POSITION *x2);
+    std::pair<Pos2DVec, Pos2D> check_hiding_grid(const Pos2DVec &vec_initial, const Pos2D &p_pos);
     Pos2DVec search_room_to_run(const Pos2DVec &vec_initial);
     Pos2DVec search_pet_runnable_grid(const Pos2DVec &vec_initial, bool no_flow);
     Pos2D determine_when_cost(const Pos2D &pos_initial, const Pos2D &m_pos, const bool use_scent);

--- a/src/monster/monster-processor-util.cpp
+++ b/src/monster/monster-processor-util.cpp
@@ -87,29 +87,27 @@ void store_enemy_approch_direction(int *mm, POSITION y, POSITION x)
  * @param y 移動先Y座標
  * @param x 移動先X座標
  */
-void store_moves_val(int *mm, int y, int x)
+void store_moves_val(int *mm, const Pos2DVec &vec)
 {
-    POSITION ax = std::abs(x);
-    POSITION ay = std::abs(y);
-
-    int move_val = 0;
-    if (y < 0) {
+    const Pos2DVec vec_abs(std::abs(vec.y), std::abs(vec.x));
+    auto move_val = 0;
+    if (vec.y < 0) {
         move_val += 8;
     }
-    if (x > 0) {
+    if (vec.x > 0) {
         move_val += 4;
     }
 
-    if (ay > (ax << 1)) {
+    if (vec_abs.y > (vec_abs.x << 1)) {
         move_val += 2;
-    } else if (ax > (ay << 1)) {
+    } else if (vec_abs.x > (vec_abs.y << 1)) {
         move_val++;
     }
 
     switch (move_val) {
     case 0: {
         mm[0] = 9;
-        if (ay > ax) {
+        if (vec_abs.y > vec_abs.x) {
             mm[1] = 8;
             mm[2] = 6;
             mm[3] = 7;
@@ -126,7 +124,7 @@ void store_moves_val(int *mm, int y, int x)
     case 1:
     case 9: {
         mm[0] = 6;
-        if (y < 0) {
+        if (vec.y < 0) {
             mm[1] = 3;
             mm[2] = 9;
             mm[3] = 2;
@@ -143,7 +141,7 @@ void store_moves_val(int *mm, int y, int x)
     case 2:
     case 6: {
         mm[0] = 8;
-        if (x < 0) {
+        if (vec.x < 0) {
             mm[1] = 9;
             mm[2] = 7;
             mm[3] = 6;
@@ -159,7 +157,7 @@ void store_moves_val(int *mm, int y, int x)
     }
     case 4: {
         mm[0] = 7;
-        if (ay > ax) {
+        if (vec_abs.y > vec_abs.x) {
             mm[1] = 8;
             mm[2] = 4;
             mm[3] = 9;
@@ -176,7 +174,7 @@ void store_moves_val(int *mm, int y, int x)
     case 5:
     case 13: {
         mm[0] = 4;
-        if (y < 0) {
+        if (vec.y < 0) {
             mm[1] = 1;
             mm[2] = 7;
             mm[3] = 2;
@@ -192,7 +190,7 @@ void store_moves_val(int *mm, int y, int x)
     }
     case 8: {
         mm[0] = 3;
-        if (ay > ax) {
+        if (vec_abs.y > vec_abs.x) {
             mm[1] = 2;
             mm[2] = 6;
             mm[3] = 1;
@@ -209,7 +207,7 @@ void store_moves_val(int *mm, int y, int x)
     case 10:
     case 14: {
         mm[0] = 2;
-        if (x < 0) {
+        if (vec.x < 0) {
             mm[1] = 3;
             mm[2] = 1;
             mm[3] = 6;
@@ -225,7 +223,7 @@ void store_moves_val(int *mm, int y, int x)
     }
     case 12: {
         mm[0] = 1;
-        if (ay > ax) {
+        if (vec_abs.y > vec_abs.x) {
             mm[1] = 2;
             mm[2] = 4;
             mm[3] = 3;

--- a/src/monster/monster-processor-util.cpp
+++ b/src/monster/monster-processor-util.cpp
@@ -84,8 +84,7 @@ void store_enemy_approch_direction(int *mm, POSITION y, POSITION x)
 /*!
  * @brief get_movable_grid() における移動の方向を保存する
  * @param mm 移動方向
- * @param y 移動先Y座標
- * @param x 移動先X座標
+ * @param vec 移動方向のベクトル
  */
 void store_moves_val(int *mm, const Pos2DVec &vec)
 {

--- a/src/monster/monster-processor-util.h
+++ b/src/monster/monster-processor-util.h
@@ -69,4 +69,4 @@ struct coordinate_candidate {
 turn_flags *init_turn_flags(bool is_riding, turn_flags *turn_flags_ptr);
 
 void store_enemy_approch_direction(int *mm, POSITION y, POSITION x);
-void store_moves_val(int *mm, int y, int x);
+void store_moves_val(int *mm, const Pos2DVec &vec);


### PR DESCRIPTION
今思えばp\_pos が引数のメソッドは、中でPlayerType::get\_position() を呼べば良いだけの気もしますが、取り敢えずシグネチャを維持する方針で修正しました (意味的なリファクタリングを別途する方針もDiscord で議論している)
必要があれば引数を消す方向でコミットを積みますのでご連絡下さい