### PR TITLE
[Refactor] モンスターの移動先決定処理

### DIFF
--- a/src/monster-floor/monster-safety-hiding.cpp
+++ b/src/monster-floor/monster-safety-hiding.cpp
@@ -150,7 +150,7 @@ static void sweep_hiding_candidate(
  * @param m_idx モンスターの参照ID
  * @return 有効なマスがあった場合、その座標。なかったらnullopt
  */
-std::optional<Pos2DVec> find_hiding(PlayerType *player_ptr, short m_idx)
+std::optional<Pos2D> find_hiding(PlayerType *player_ptr, short m_idx)
 {
     const auto &monster = player_ptr->current_floor_ptr->m_list[m_idx];
     coordinate_candidate candidate;
@@ -164,7 +164,7 @@ std::optional<Pos2DVec> find_hiding(PlayerType *player_ptr, short m_idx)
             continue;
         }
 
-        return monster.get_position() - candidate.pos;
+        return candidate.pos;
     }
 
     return std::nullopt;

--- a/src/monster-floor/monster-safety-hiding.h
+++ b/src/monster-floor/monster-safety-hiding.h
@@ -5,4 +5,4 @@
 
 class PlayerType;
 std::optional<Pos2DVec> find_safety(PlayerType *player_ptr, short m_idx);
-std::optional<Pos2DVec> find_hiding(PlayerType *player_ptr, short m_idx);
+std::optional<Pos2D> find_hiding(PlayerType *player_ptr, short m_idx);

--- a/src/monster-floor/monster-sweep-grid.cpp
+++ b/src/monster-floor/monster-sweep-grid.cpp
@@ -23,8 +23,444 @@
 #include "system/player-type-definition.h"
 #include "target/projection-path-calculator.h"
 #include "util/bit-flags-calculator.h"
+#include <span>
 
-/*
+namespace {
+/*!
+ * @brief モンスターが逃走しようとするかを判定する
+ *
+ * @param m_idx モンスターの参照ID
+ * @return 逃走しようとするならtrue、そうでなければfalse
+ */
+bool mon_will_run(PlayerType *player_ptr, MONSTER_IDX m_idx)
+{
+    const auto &monster = player_ptr->current_floor_ptr->m_list[m_idx];
+    const auto &monrace = monster.get_monrace();
+    if (monster.is_pet()) {
+        return (player_ptr->pet_follow_distance < 0) && (monster.cdis <= (0 - player_ptr->pet_follow_distance));
+    }
+
+    if (monster.cdis > MAX_PLAYER_SIGHT + 5) {
+        return false;
+    }
+
+    if (monster.is_fearful()) {
+        return true;
+    }
+
+    if (monster.cdis <= 5) {
+        return false;
+    }
+
+    const auto p_lev = player_ptr->lev;
+    const auto m_lev = monrace.level + (m_idx & 0x08) + 25;
+    if (m_lev > p_lev + 4) {
+        return false;
+    }
+
+    if (m_lev + 4 <= p_lev) {
+        return true;
+    }
+
+    const auto p_chp = player_ptr->chp;
+    const auto p_mhp = player_ptr->mhp;
+    const auto m_chp = monster.hp;
+    const auto m_mhp = monster.maxhp;
+    const uint32_t p_val = (p_lev * p_mhp) + (p_chp << 2);
+    const uint32_t m_val = (m_lev * m_mhp) + (m_chp << 2);
+    return p_val * m_mhp > m_val * p_mhp;
+}
+}
+
+/*!
+ * @brief モンスターの移動先を決定するクラスの基底クラス
+ */
+class MonsterMoveGridDecider {
+public:
+    MonsterMoveGridDecider() = default;
+    virtual ~MonsterMoveGridDecider() = default;
+    virtual std::optional<Pos2D> decide_move_grid() const = 0;
+
+    /*!
+     * @brief モンスターの移動先を決定する
+     *
+     * @param deciders 移動先を決定するクラスオブジェクトのリスト
+     * @param default_pos すべてのクラスオブジェクトを実行しても移動先が決定されなかった場合の移動先
+     * @return 移動先を決定するクラスオブジェクトのリストを先頭から順に実行し、最初に移動先が決定した時点でその座標を返す。
+     * すべてのクラスオブジェクトを実行しても移動先が決定されなかった場合はdefault_posを返す。
+     */
+    static Pos2D evalute_deciders(std::span<const std::unique_ptr<const MonsterMoveGridDecider>> deciders, const Pos2D &default_pos)
+    {
+        for (const auto &decider : deciders) {
+            const auto pos = decider->decide_move_grid();
+            if (pos) {
+                return *pos;
+            }
+        }
+
+        return default_pos;
+    }
+};
+
+/*!
+ * @brief 特定のターゲットが設定されている場合の移動先を決定するクラス
+ */
+class SpecificTargetMoveGridDecider : public MonsterMoveGridDecider {
+public:
+    SpecificTargetMoveGridDecider(PlayerType *player_ptr, MONSTER_IDX m_idx)
+        : player_ptr(player_ptr)
+        , m_idx(m_idx)
+    {
+    }
+
+    std::optional<Pos2D> decide_move_grid() const override
+    {
+        const auto &floor = *this->player_ptr->current_floor_ptr;
+        const auto &monster = floor.m_list[this->m_idx];
+        const auto pos_target = monster.get_target_position();
+        const auto t_m_idx = floor.get_grid(pos_target).m_idx;
+        if (t_m_idx <= 0) {
+            return std::nullopt;
+        }
+
+        const auto is_enemies = monster.is_hostile_to_melee(floor.m_list[t_m_idx]);
+        const auto m_pos = monster.get_position();
+        const auto is_los = los(floor, m_pos, pos_target);
+        const auto is_projectable = projectable(this->player_ptr, m_pos, pos_target);
+        if (is_enemies && is_los && is_projectable) {
+            return pos_target;
+        }
+
+        return std::nullopt;
+    }
+
+private:
+    PlayerType *player_ptr;
+    MONSTER_IDX m_idx;
+};
+
+/*!
+ * @brief 隠れて待ち伏せし取り囲む事を狙うように移動先を決定するクラス
+ */
+class HidingMoveGridDecider : public MonsterMoveGridDecider {
+public:
+    HidingMoveGridDecider(PlayerType *player_ptr, MONSTER_IDX m_idx)
+        : player_ptr(player_ptr)
+        , m_idx(m_idx)
+    {
+    }
+
+    std::optional<Pos2D> decide_move_grid() const override
+    {
+        const auto &floor = *this->player_ptr->current_floor_ptr;
+        const auto &monrace = floor.m_list[this->m_idx].get_monrace();
+        const auto p_pos = this->player_ptr->get_position();
+
+        auto room = 0;
+        for (auto i = 0; i < 8; i++) {
+            const auto pos_p_neighbor = p_pos + Pos2DVec(ddy_ddd[i], ddx_ddd[i]);
+            if (!in_bounds2(&floor, pos_p_neighbor.y, pos_p_neighbor.x)) {
+                continue;
+            }
+
+            const auto &grid = floor.get_grid(pos_p_neighbor);
+            if (monster_can_cross_terrain(this->player_ptr, grid.feat, &monrace, 0)) {
+                room++;
+            }
+        }
+
+        if (floor.get_grid(p_pos).is_room()) {
+            room -= 2;
+        }
+
+        if (monrace.ability_flags.none()) {
+            room -= 2;
+        }
+
+        if (room >= (8 * (this->player_ptr->chp + this->player_ptr->csp)) / (this->player_ptr->mhp + this->player_ptr->msp)) {
+            return std::nullopt;
+        }
+
+        return find_hiding(this->player_ptr, this->m_idx);
+    }
+
+private:
+    PlayerType *player_ptr;
+    MONSTER_IDX m_idx;
+};
+
+/*!
+ * @brief プレイヤーの周囲を取り囲むように移動先を決定するクラス
+ */
+class SurroundingMoveGridDecider : public MonsterMoveGridDecider {
+public:
+    SurroundingMoveGridDecider(PlayerType *player_ptr, MONSTER_IDX m_idx)
+        : player_ptr(player_ptr)
+        , m_idx(m_idx)
+    {
+    }
+
+    std::optional<Pos2D> decide_move_grid() const override
+    {
+        const auto &floor = *this->player_ptr->current_floor_ptr;
+        const auto &monster = floor.m_list[this->m_idx];
+        const auto &monrace = monster.get_monrace();
+        const auto p_pos = this->player_ptr->get_position();
+        const auto m_pos = monster.get_position();
+
+        for (auto i = 0; i < 8; i++) {
+            const auto dir = (this->m_idx + i) & 7;
+            const auto pos_move = p_pos + Pos2DVec(ddy_ddd[dir], ddx_ddd[dir]);
+            if (m_pos == pos_move) {
+                // プレイヤーを攻撃する
+                return p_pos;
+            }
+
+            if (!in_bounds2(&floor, pos_move.y, pos_move.x) || !monster_can_enter(this->player_ptr, pos_move.y, pos_move.x, &monrace, 0)) {
+                continue;
+            }
+
+            return pos_move;
+        }
+
+        // プレイヤーの周囲に空きが無い場合はプレイヤーに向かって移動する
+        return p_pos;
+    }
+
+private:
+    PlayerType *player_ptr;
+    MONSTER_IDX m_idx;
+};
+
+/*!
+ * @brief 遠隔攻撃を行えるマスに移動するように移動先を決定するクラス
+ */
+class RangedAttackMoveGridDecider : public MonsterMoveGridDecider {
+public:
+    RangedAttackMoveGridDecider(PlayerType *player_ptr, MONSTER_IDX m_idx)
+        : player_ptr(player_ptr)
+        , m_idx(m_idx)
+    {
+    }
+
+    std::optional<Pos2D> decide_move_grid() const override
+    {
+        const auto &floor = *this->player_ptr->current_floor_ptr;
+        const auto &monster = floor.m_list[this->m_idx];
+        const auto &monrace = monster.get_monrace();
+        const auto p_pos = this->player_ptr->get_position();
+        const auto m_pos = monster.get_position();
+
+        if (projectable(this->player_ptr, m_pos, p_pos)) {
+            return std::nullopt;
+        }
+
+        const auto gf = monrace.get_grid_flow_type();
+        int now_cost = floor.get_grid(m_pos).get_cost(gf);
+        if (now_cost == 0) {
+            now_cost = 999;
+        }
+
+        const auto can_open_door = monrace.behavior_flags.has_any_of({ MonsterBehaviorType::BASH_DOOR, MonsterBehaviorType::OPEN_DOOR });
+        const auto can_pass_wall = monrace.feature_flags.has(MonsterFeatureType::PASS_WALL) && (!monster.is_riding() || has_pass_wall(player_ptr));
+        const auto can_kill_wall = monrace.feature_flags.has(MonsterFeatureType::KILL_WALL) && !monster.is_riding();
+
+        auto best = 999;
+        std::optional<Pos2D> pos_move;
+        for (auto i = 7; i >= 0; i--) {
+            const Pos2D pos_neighbor(m_pos.y + ddy_ddd[i], m_pos.x + ddx_ddd[i]);
+            if (!in_bounds2(&floor, pos_neighbor.y, pos_neighbor.x)) {
+                continue;
+            }
+
+            // プレイヤーに隣接している場合最初のprojectableで除外されるため
+            // ここで判定する必要はないはずだが、元のコードで判定しているので一応残しておく
+            if (p_pos == pos_neighbor) {
+                return std::nullopt;
+            }
+
+            const auto &grid = floor.get_grid(pos_neighbor);
+            int cost = grid.get_cost(gf);
+
+            if (!can_pass_wall && !can_kill_wall) {
+                if (cost == 0) {
+                    continue;
+                }
+
+                if (!can_open_door && floor.has_closed_door_at(pos_neighbor)) {
+                    continue;
+                }
+            }
+
+            if (cost == 0) {
+                cost = 998;
+            }
+
+            if (now_cost < cost || best < cost) {
+                continue;
+            }
+
+            if (!projectable(this->player_ptr, pos_neighbor, p_pos)) {
+                continue;
+            }
+
+            best = cost;
+            pos_move = pos_neighbor;
+        }
+
+        return pos_move;
+    }
+
+private:
+    PlayerType *player_ptr;
+    MONSTER_IDX m_idx;
+};
+
+/*!
+ * @brief grid.dists もしくは grid.costs を使用してプレイヤーの位置を追跡するように移動先を決定するクラス
+ */
+class NoiseTrackingMoveGridDecider : public MonsterMoveGridDecider {
+public:
+    NoiseTrackingMoveGridDecider(PlayerType *player_ptr, MONSTER_IDX m_idx)
+        : player_ptr(player_ptr)
+        , m_idx(m_idx)
+    {
+    }
+
+    std::optional<Pos2D> decide_move_grid() const override
+    {
+        const auto &floor = *this->player_ptr->current_floor_ptr;
+        const auto &monster = floor.m_list[this->m_idx];
+        const auto &monrace = monster.get_monrace();
+        const auto p_pos = this->player_ptr->get_position();
+        const auto m_pos = monster.get_position();
+
+        auto best = 999;
+        std::optional<Pos2D> pos_move;
+        for (auto i = 7; i >= 0; i--) {
+            const auto pos_neighbor = m_pos + Pos2DVec(ddy_ddd[i], ddx_ddd[i]);
+            if (!in_bounds2(&floor, pos_neighbor.y, pos_neighbor.x)) {
+                continue;
+            }
+
+            const auto &grid = floor.get_grid(pos_neighbor);
+            const auto gf = monrace.get_grid_flow_type();
+            const auto cost = monrace.behavior_flags.has_any_of({ MonsterBehaviorType::BASH_DOOR, MonsterBehaviorType::OPEN_DOOR }) ? grid.get_distance(gf) : grid.get_cost(gf);
+            if (cost == 0 || best < cost) {
+                continue;
+            }
+
+            best = cost;
+            pos_move = p_pos + Pos2DVec(ddy_ddd[i], ddx_ddd[i]) * 16;
+        }
+
+        return pos_move;
+    }
+
+private:
+    PlayerType *player_ptr;
+    MONSTER_IDX m_idx;
+};
+
+/*!
+ * @brief grid.when を使用してプレイヤーの位置を追跡するように移動先を決定するクラス
+ */
+class ScentTrackingMoveGridDecider : public MonsterMoveGridDecider {
+public:
+    ScentTrackingMoveGridDecider(PlayerType *player_ptr, MONSTER_IDX m_idx)
+        : player_ptr(player_ptr)
+        , m_idx(m_idx)
+    {
+    }
+
+    std::optional<Pos2D> decide_move_grid() const override
+    {
+        const auto &floor = *this->player_ptr->current_floor_ptr;
+        const auto &monster = floor.m_list[this->m_idx];
+        const auto p_pos = this->player_ptr->get_position();
+        const auto m_pos = monster.get_position();
+
+        auto best = 0;
+        std::optional<Pos2D> pos_move;
+        for (auto i = 7; i >= 0; i--) {
+            const auto pos_neighbor = m_pos + Pos2DVec(ddy_ddd[i], ddx_ddd[i]);
+            if (!in_bounds2(&floor, pos_neighbor.y, pos_neighbor.x)) {
+                continue;
+            }
+
+            const auto &grid = floor.get_grid(pos_neighbor);
+            const auto when = grid.when;
+            if (best > when) {
+                continue;
+            }
+
+            best = when;
+            pos_move = p_pos + Pos2DVec(ddy_ddd[i], ddx_ddd[i]) * 16;
+        }
+
+        return pos_move;
+    }
+
+private:
+    PlayerType *player_ptr;
+    MONSTER_IDX m_idx;
+};
+
+class MonsterMoveGridDecidersFactory {
+public:
+    static std::vector<std::unique_ptr<const MonsterMoveGridDecider>> create_deciders(PlayerType *player_ptr, MONSTER_IDX m_idx)
+    {
+        const auto &floor = *player_ptr->current_floor_ptr;
+        const auto &monster = floor.m_list[m_idx];
+        const auto &monrace = monster.get_monrace();
+        const auto will_run = mon_will_run(player_ptr, m_idx);
+        const auto p_pos = player_ptr->get_position();
+        const auto m_pos = monster.get_position();
+        const auto &m_grid = floor.get_grid(m_pos);
+        const auto gf = monrace.get_grid_flow_type();
+        const auto dist_to_player = m_grid.get_distance(gf); // 経由グリッド数換算(Grid::dists)による距離
+        const auto distance_to_player = Grid::calc_distance(m_pos, p_pos); // Grid::calc_distance()による直線距離
+        const auto no_flow = monster.mflag2.has(MonsterConstantFlagType::NOFLOW) && (m_grid.get_cost(gf) > 2);
+        const auto can_pass_wall = monrace.feature_flags.has(MonsterFeatureType::PASS_WALL) && (!monster.is_riding() || has_pass_wall(player_ptr));
+        const auto can_kill_wall = monrace.feature_flags.has(MonsterFeatureType::KILL_WALL) && !monster.is_riding();
+        const auto is_visible_from_player = m_grid.has_los() && projectable(player_ptr, p_pos, m_pos);
+        const auto can_see_player = los(floor, m_pos, p_pos) && projectable(player_ptr, m_pos, p_pos);
+
+        std::vector<std::unique_ptr<const MonsterMoveGridDecider>> deciders;
+
+        if (!will_run && monster.target_y) {
+            deciders.push_back(std::make_unique<SpecificTargetMoveGridDecider>(player_ptr, m_idx));
+        }
+
+        if (!will_run && monster.is_hostile() && monrace.misc_flags.has(MonsterMiscType::HAS_FRIENDS) &&
+            (can_see_player || (dist_to_player < MAX_PLAYER_SIGHT / 2))) {
+            if (monrace.kind_flags.has(MonsterKindType::ANIMAL) && !can_pass_wall && monrace.feature_flags.has_not(MonsterFeatureType::KILL_WALL)) {
+                deciders.push_back(std::make_unique<HidingMoveGridDecider>(player_ptr, m_idx));
+            }
+            if (dist_to_player < 3) {
+                deciders.push_back(std::make_unique<SurroundingMoveGridDecider>(player_ptr, m_idx));
+            }
+        }
+
+        if (!will_run && distance_to_player <= AngbandSystem::get_instance().get_max_range() + 1 && monrace.ability_flags.has_any_of(RF_ABILITY_ATTACK_MASK)) {
+            deciders.push_back(std::make_unique<RangedAttackMoveGridDecider>(player_ptr, m_idx));
+        }
+
+        const auto should_go_straight = no_flow || can_pass_wall || can_kill_wall;
+        const auto try_circumventing = (distance_to_player > 1) && (monrace.freq_spell == 0) && (m_grid.get_cost(gf) <= 5);
+        if (!should_go_straight && (!is_visible_from_player || try_circumventing)) {
+            if (m_grid.get_cost(gf) > 0) {
+                deciders.push_back(std::make_unique<NoiseTrackingMoveGridDecider>(player_ptr, m_idx));
+            } else if (m_grid.when > 0) {
+                deciders.push_back(std::make_unique<ScentTrackingMoveGridDecider>(player_ptr, m_idx));
+            }
+        }
+
+        return deciders;
+    }
+};
+
+/*!
  * @brief コンストラクタ
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param m_idx 移動するモンスターの参照ID
@@ -44,39 +480,19 @@ MonsterSweepGrid::MonsterSweepGrid(PlayerType *player_ptr, MONSTER_IDX m_idx, DI
  */
 bool MonsterSweepGrid::get_movable_grid()
 {
+    const auto deciders = MonsterMoveGridDecidersFactory::create_deciders(this->player_ptr, this->m_idx);
+    const auto pos_move = MonsterMoveGridDecider::evalute_deciders(std::span(deciders.begin(), deciders.size()), this->player_ptr->get_position()); // @todo clang-15以降は直接decidersを渡せる
+
     const auto &floor = *this->player_ptr->current_floor_ptr;
-    const auto &monster_from = floor.m_list[this->m_idx];
-    auto &monrace = monster_from.get_monrace();
-    Pos2DVec vec(0, 0);
-    auto pos_target = this->player_ptr->get_position();
-    this->will_run = this->mon_will_run();
-    const auto pos_monster_from = monster_from.get_position();
-    const auto no_flow = monster_from.mflag2.has(MonsterConstantFlagType::NOFLOW) && (floor.get_grid(pos_monster_from).get_cost(monrace.get_grid_flow_type()) > 2);
-    this->can_pass_wall = monrace.feature_flags.has(MonsterFeatureType::PASS_WALL) && (!monster_from.is_riding() || has_pass_wall(this->player_ptr));
-    if (!this->will_run && monster_from.target_y) {
-        const auto pos_to = monster_from.get_target_position();
-        int t_m_idx = floor.get_grid(pos_to).m_idx;
-        if (t_m_idx > 0) {
-            const auto is_enemies = monster_from.is_hostile_to_melee(floor.m_list[t_m_idx]);
-            const Pos2D pos_from = monster_from.get_position();
-            const auto is_los = los(floor, pos_from, pos_to);
-            const auto is_projectable = projectable(this->player_ptr, pos_from, pos_to);
-            if (is_enemies && is_los && is_projectable) {
-                vec = pos_from - pos_to;
-                this->done = true;
-            }
-        }
-    }
+    const auto &monster = floor.m_list[this->m_idx];
+    const auto &monrace = monster.get_monrace();
 
-    const auto &[vec_hiding, pos] = this->check_hiding_grid(vec, pos_target);
-    vec = vec_hiding;
-    pos_target = pos;
-    if (!this->done) {
-        const auto pos_movable = this->sweep_movable_grid(pos_target, no_flow);
-        vec = pos_monster_from - pos_movable;
-    }
+    const auto vec = monster.get_position() - pos_move;
 
-    const auto vec_pet = this->search_pet_runnable_grid(vec, no_flow);
+    const auto m_pos = monster.get_position();
+    const auto no_flow = monster.mflag2.has(MonsterConstantFlagType::NOFLOW) && (floor.get_grid(m_pos).get_cost(monrace.get_grid_flow_type()) > 2);
+    const auto will_run = mon_will_run(this->player_ptr, this->m_idx);
+    const auto vec_pet = this->search_pet_runnable_grid(vec, will_run, no_flow);
     if (vec_pet == Pos2DVec(0, 0)) {
         return false;
     }
@@ -85,145 +501,16 @@ bool MonsterSweepGrid::get_movable_grid()
     return true;
 }
 
-/*!
- * @brief モンスターがプレイヤーから逃走するかどうかを返す
- * @return モンスターがプレイヤーから逃走するならばTRUEを返す。
- */
-bool MonsterSweepGrid::mon_will_run() const
-{
-    const auto &monster = this->player_ptr->current_floor_ptr->m_list[this->m_idx];
-    if (monster.is_pet()) {
-        return (this->player_ptr->pet_follow_distance < 0) && (monster.cdis <= (0 - this->player_ptr->pet_follow_distance));
-    }
-
-    if (monster.cdis > MAX_PLAYER_SIGHT + 5) {
-        return false;
-    }
-
-    if (monster.is_fearful()) {
-        return true;
-    }
-
-    if (monster.cdis <= 5) {
-        return false;
-    }
-
-    const auto p_lev = this->player_ptr->lev;
-    const auto &monrace = monster.get_monrace();
-    const auto m_lev = monrace.level + (this->m_idx & 0x08) + 25;
-    if (m_lev > p_lev + 4) {
-        return false;
-    }
-
-    if (m_lev + 4 <= p_lev) {
-        return true;
-    }
-
-    auto p_chp = this->player_ptr->chp;
-    auto p_mhp = this->player_ptr->mhp;
-    auto m_chp = monster.hp;
-    auto m_mhp = monster.maxhp;
-    uint32_t p_val = (p_lev * p_mhp) + (p_chp << 2);
-    uint32_t m_val = (m_lev * m_mhp) + (m_chp << 2);
-    return p_val * m_mhp > m_val * p_mhp;
-}
-
-std::pair<Pos2DVec, Pos2D> MonsterSweepGrid::check_hiding_grid(const Pos2DVec &vec_initial, const Pos2D &p_pos)
-{
-    const auto &floor = *this->player_ptr->current_floor_ptr;
-    const auto &monster = floor.m_list[this->m_idx];
-    const auto &monrace = monster.get_monrace();
-    if (this->done || this->will_run || !monster.is_hostile() || monrace.misc_flags.has_not(MonsterMiscType::HAS_FRIENDS)) {
-        return std::pair<Pos2DVec, Pos2D>(vec_initial, p_pos);
-    }
-
-    const auto m_pos = monster.get_position();
-    const auto gf = monrace.get_grid_flow_type();
-    const auto distance = floor.get_grid(m_pos).get_distance(gf);
-    if (!los(floor, m_pos, p_pos) || !projectable(this->player_ptr, m_pos, p_pos)) {
-        if (distance >= MAX_PLAYER_SIGHT / 2) {
-            return std::pair<Pos2DVec, Pos2D>(vec_initial, p_pos);
-        }
-    }
-
-    const auto vec = this->search_room_to_run(vec_initial);
-    if (this->done || (distance >= 3)) {
-        return std::pair<Pos2DVec, Pos2D>(vec, p_pos);
-    }
-
-    Pos2D pos = p_pos;
-    for (auto i = 0; i < 8; i++) {
-        const auto dir = (this->m_idx + i) & 7;
-        pos = p_pos + Pos2DVec(ddy_ddd[dir], ddx_ddd[dir]);
-        if (m_pos == pos) {
-            pos = p_pos;
-            break;
-        }
-
-        if (!in_bounds2(&floor, pos.y, pos.x) || !monster_can_enter(this->player_ptr, pos.y, pos.x, &monrace, 0)) {
-            continue;
-        }
-
-        break;
-    }
-
-    this->done = true;
-    return std::pair<Pos2DVec, Pos2D>(m_pos - pos, pos);
-}
-
-Pos2DVec MonsterSweepGrid::search_room_to_run(const Pos2DVec &vec_initial)
-{
-    const auto &floor = *this->player_ptr->current_floor_ptr;
-    const auto &monrace = floor.m_list[this->m_idx].get_monrace();
-    if (monrace.kind_flags.has_not(MonsterKindType::ANIMAL) || this->can_pass_wall || monrace.feature_flags.has(MonsterFeatureType::KILL_WALL)) {
-        return vec_initial;
-    }
-
-    auto room = 0;
-    for (auto i = 0; i < 8; i++) {
-        auto xx = this->player_ptr->x + ddx_ddd[i];
-        auto yy = this->player_ptr->y + ddy_ddd[i];
-        if (!in_bounds2(&floor, yy, xx)) {
-            continue;
-        }
-
-        auto *g_ptr = &floor.grid_array[yy][xx];
-        if (monster_can_cross_terrain(this->player_ptr, g_ptr->feat, &monrace, 0)) {
-            room++;
-        }
-    }
-
-    if (floor.grid_array[this->player_ptr->y][this->player_ptr->x].is_room()) {
-        room -= 2;
-    }
-
-    if (monrace.ability_flags.none()) {
-        room -= 2;
-    }
-
-    if (room >= (8 * (this->player_ptr->chp + this->player_ptr->csp)) / (this->player_ptr->mhp + this->player_ptr->msp)) {
-        return vec_initial;
-    }
-
-    const auto vec = find_hiding(this->player_ptr, this->m_idx);
-    if (!vec) {
-        return vec_initial;
-    }
-
-    this->done = true;
-    return *vec;
-}
-
-Pos2DVec MonsterSweepGrid::search_pet_runnable_grid(const Pos2DVec &vec_initial, bool no_flow)
+Pos2DVec MonsterSweepGrid::search_pet_runnable_grid(const Pos2DVec &vec_initial, bool will_run, bool no_flow)
 {
     const auto &floor = *this->player_ptr->current_floor_ptr;
     const auto &monster = floor.m_list[this->m_idx];
     const auto vec_inverted = vec_initial.inverted();
-    if (monster.is_pet() && this->will_run) {
+    if (monster.is_pet() && will_run) {
         return vec_inverted;
     }
 
-    if (this->done || !this->will_run) {
+    if (!will_run) {
         return vec_initial;
     }
 
@@ -237,164 +524,7 @@ Pos2DVec MonsterSweepGrid::search_pet_runnable_grid(const Pos2DVec &vec_initial,
         return vec_inverted;
     }
 
-    this->done = true;
     return *vec_runaway;
-}
-
-/*!
- * @brief モンスターがプレイヤーに向けて接近することが可能なマスを走査する
- * @param p_pos プレイヤーの座標
- * @param no_flow モンスターにFLOWフラグが経っていない状態でTRUE
- * @return 接近可能な座標
- */
-Pos2D MonsterSweepGrid::sweep_movable_grid(const Pos2D &p_pos, bool no_flow)
-{
-    const auto &floor = *this->player_ptr->current_floor_ptr;
-    const auto &monster = floor.m_list[this->m_idx];
-    const auto &monrace = monster.get_monrace();
-    const auto &[pos_movable, check] = this->check_movable_grid(p_pos, no_flow);
-    if (!check) {
-        return pos_movable;
-    }
-
-    const auto m_pos = monster.get_position();
-    const auto &grid = floor.get_grid(m_pos);
-    const auto gf = monrace.get_grid_flow_type();
-    if (grid.has_los() && projectable(this->player_ptr, p_pos, m_pos)) {
-        if ((Grid::calc_distance(m_pos, p_pos) == 1) || (monrace.freq_spell > 0) || (grid.get_cost(gf) > 5)) {
-            return pos_movable;
-        }
-    }
-
-    auto use_scent = false;
-    if (grid.get_cost(gf)) {
-        this->best = 999;
-    } else if (grid.when) {
-        if (floor.get_grid(p_pos).when - grid.when > 127) {
-            return pos_movable;
-        }
-
-        use_scent = true;
-        this->best = 0;
-    } else {
-        return pos_movable;
-    }
-
-    const auto pos = this->determine_when_cost(pos_movable, m_pos, use_scent);
-    return pos;
-}
-
-std::pair<Pos2D, bool> MonsterSweepGrid::check_movable_grid(const Pos2D &pos_initial, bool no_flow)
-{
-    const auto &monster = this->player_ptr->current_floor_ptr->m_list[this->m_idx];
-    const auto &monrace = monster.get_monrace();
-    if (monrace.ability_flags.has_any_of(RF_ABILITY_ATTACK_MASK)) {
-        const auto &pos = this->sweep_ranged_attack_grid(pos_initial);
-        if (pos) {
-            return std::pair<Pos2D, bool>(*pos, false);
-        }
-    }
-
-    if (no_flow) {
-        return std::pair<Pos2D, bool>(pos_initial, false);
-    }
-
-    if (monrace.feature_flags.has(MonsterFeatureType::PASS_WALL) && (!monster.is_riding() || has_pass_wall(this->player_ptr))) {
-        return std::pair<Pos2D, bool>(pos_initial, false);
-    }
-
-    if (monrace.feature_flags.has(MonsterFeatureType::KILL_WALL) && !monster.is_riding()) {
-        return std::pair<Pos2D, bool>(pos_initial, false);
-    }
-
-    return std::pair<Pos2D, bool>(pos_initial, true);
-}
-
-/*!
- * @brief モンスターがプレイヤーに向けて遠距離攻撃を行うことが可能なマスを走査する
- * @return 有効なグリッドがあった場合その座標、なかったらnullopt
- */
-std::optional<Pos2D> MonsterSweepGrid::sweep_ranged_attack_grid(const Pos2D &pos_initial)
-{
-    const auto &floor = *this->player_ptr->current_floor_ptr;
-    const auto &monster = floor.m_list[this->m_idx];
-    const auto &monrace = monster.get_monrace();
-    const auto m_pos = monster.get_position();
-    if (projectable(this->player_ptr, m_pos, this->player_ptr->get_position())) {
-        return std::nullopt;
-    }
-
-    const auto gf = monrace.get_grid_flow_type();
-    int now_cost = floor.grid_array[m_pos.y][m_pos.x].get_cost(gf);
-    if (now_cost == 0) {
-        now_cost = 999;
-    }
-
-    if (monrace.behavior_flags.has_any_of({ MonsterBehaviorType::BASH_DOOR, MonsterBehaviorType::OPEN_DOOR })) {
-        this->can_open_door = true;
-    }
-
-    Pos2D pos = pos_initial;
-    for (auto i = 7; i >= 0; i--) {
-        const Pos2D pos_neighbor(m_pos.y + ddy_ddd[i], m_pos.x + ddx_ddd[i]);
-        if (!in_bounds2(&floor, pos_neighbor.y, pos_neighbor.x)) {
-            continue;
-        }
-
-        if (this->player_ptr->is_located_at(pos_neighbor)) {
-            return std::nullopt;
-        }
-
-        const auto &grid = floor.get_grid(pos_neighbor);
-        this->cost = grid.get_cost(gf);
-        if (!this->is_best_cost(pos_neighbor, now_cost)) {
-            continue;
-        }
-
-        this->best = this->cost;
-        pos = m_pos + Pos2DVec(ddy_ddd[i], ddx_ddd[i]);
-    }
-
-    if (this->best >= 999) {
-        return std::nullopt;
-    }
-
-    return pos;
-}
-
-bool MonsterSweepGrid::is_best_cost(const Pos2D &pos, int now_cost)
-{
-    const auto &floor = *this->player_ptr->current_floor_ptr;
-    const auto &monster = floor.m_list[this->m_idx];
-    const auto &monrace = monster.get_monrace();
-    auto is_riding = monster.is_riding();
-    if ((monrace.feature_flags.has_not(MonsterFeatureType::PASS_WALL) || (is_riding && !has_pass_wall(this->player_ptr))) && (monrace.feature_flags.has_not(MonsterFeatureType::KILL_WALL) || is_riding)) {
-        if (this->cost == 0) {
-            return false;
-        }
-
-        if (!this->can_open_door && floor.has_closed_door_at(pos)) {
-            return false;
-        }
-    }
-
-    if (this->cost == 0) {
-        this->cost = 998;
-    }
-
-    if (now_cost < this->cost) {
-        return false;
-    }
-
-    if (!projectable(this->player_ptr, pos, this->player_ptr->get_position())) {
-        return false;
-    }
-
-    if (this->best < this->cost) {
-        return false;
-    }
-
-    return true;
 }
 
 /*!
@@ -438,40 +568,4 @@ std::optional<Pos2DVec> MonsterSweepGrid::sweep_runnable_away_grid(const Pos2DVe
     }
 
     return m_pos - pos_run;
-}
-
-Pos2D MonsterSweepGrid::determine_when_cost(const Pos2D &pos_initial, const Pos2D &m_pos, bool use_scent)
-{
-    Pos2D pos = pos_initial;
-    const auto &floor = *this->player_ptr->current_floor_ptr;
-    for (auto i = 7; i >= 0; i--) {
-        auto y = m_pos.y + ddy_ddd[i];
-        auto x = m_pos.x + ddx_ddd[i];
-        if (!in_bounds2(&floor, y, x)) {
-            continue;
-        }
-
-        const auto &grid = floor.grid_array[y][x];
-        if (use_scent) {
-            int when = grid.when;
-            if (this->best > when) {
-                continue;
-            }
-
-            this->best = when;
-        } else {
-            const auto &monrace = floor.m_list[this->m_idx].get_monrace();
-            const auto gf = monrace.get_grid_flow_type();
-            this->cost = monrace.behavior_flags.has_any_of({ MonsterBehaviorType::BASH_DOOR, MonsterBehaviorType::OPEN_DOOR }) ? grid.get_distance(gf) : grid.get_cost(gf);
-            if ((this->cost == 0) || (this->best < this->cost)) {
-                continue;
-            }
-
-            this->best = this->cost;
-        }
-
-        pos = this->player_ptr->get_position() + Pos2DVec(ddy_ddd[i], ddx_ddd[i]) * 16;
-    }
-
-    return pos;
 }

--- a/src/monster-floor/monster-sweep-grid.h
+++ b/src/monster-floor/monster-sweep-grid.h
@@ -16,20 +16,6 @@ public:
     bool get_movable_grid();
 
 private:
-    bool done = false;
-    bool will_run = false;
-    bool can_pass_wall = false;
-    bool can_open_door = false;
-    int cost = 0;
-    int best = 999;
-    bool mon_will_run() const;
-    Pos2D sweep_movable_grid(const Pos2D &p_pos, bool no_flow);
-    std::pair<Pos2D, bool> check_movable_grid(const Pos2D &pos_initial, bool no_flow);
-    std::optional<Pos2D> sweep_ranged_attack_grid(const Pos2D &pos_initial);
     std::optional<Pos2DVec> sweep_runnable_away_grid(const Pos2DVec &vec_initial) const;
-    std::pair<Pos2DVec, Pos2D> check_hiding_grid(const Pos2DVec &vec_initial, const Pos2D &p_pos);
-    Pos2DVec search_room_to_run(const Pos2DVec &vec_initial);
-    Pos2DVec search_pet_runnable_grid(const Pos2DVec &vec_initial, bool no_flow);
-    Pos2D determine_when_cost(const Pos2D &pos_initial, const Pos2D &m_pos, bool use_scent);
-    bool is_best_cost(const Pos2D &pos, int now_cost);
+    Pos2DVec search_pet_runnable_grid(const Pos2DVec &vec_initial, bool will_run, bool no_flow);
 };


### PR DESCRIPTION
モンスターの移動先決定処理のコードが複雑で処理が追いにくくなっているため、処理の構造を大幅にリファクタリングして理解しやすくする。

#4901 の一環。
逃走処理は移動先を一旦決定した後に行うため、まず移動先を決定する処理をリファクタリングしました。

全体の構成としては、
モンスターの移動先決定処理をそれぞれ `MonsterMoveGridDecider` のサブクラスとして定義し、MonsterMoveGridDecidersFactory::create_deciders() によりどの移動先決定処理を採用するかを決め、順に実行して最初に決定したものを採用する、
といった流れになります。

一通りの移動先決定パターンを試した限りではリファクタリング前と同様の挙動をしているように見えます。