### PR TITLE
[Refactor] 方向ベクトルとそれを使用する処理

### DIFF
--- a/src/action/open-util.cpp
+++ b/src/action/open-util.cpp
@@ -44,8 +44,8 @@ std::pair<int, Pos2D> count_chests(PlayerType *player_ptr, bool trapped)
 {
     Pos2D pos(0, 0);
     auto count = 0;
-    for (auto d = 0; d < 9; d++) {
-        const Pos2D pos_neighbor(player_ptr->y + ddy_ddd[d], player_ptr->x + ddx_ddd[d]);
+    for (const auto &d : Direction::directions()) {
+        const auto pos_neighbor = player_ptr->get_position() + d.vec();
         const auto o_idx = chest_check(player_ptr->current_floor_ptr, pos_neighbor, false);
         if (o_idx == 0) {
             continue;

--- a/src/action/travel-execution.cpp
+++ b/src/action/travel-execution.cpp
@@ -67,10 +67,11 @@ static DIRECTION travel_test(PlayerType *player_ptr, DIRECTION prev_dir)
 
     int cost = travel.cost[player_ptr->y][player_ptr->x];
     DIRECTION new_dir = 0;
-    for (int i = 0; i < 8; ++i) {
-        int dir_cost = travel.cost[player_ptr->y + ddy_ddd[i]][player_ptr->x + ddx_ddd[i]];
+    for (const auto &d : Direction::directions_8()) {
+        const auto pos_neighbor = player_ptr->get_position() + d.vec();
+        int dir_cost = travel.cost[pos_neighbor.y][pos_neighbor.x];
         if (dir_cost < cost) {
-            new_dir = ddd[i];
+            new_dir = d.dir();
             cost = dir_cost;
         }
     }

--- a/src/cmd-action/cmd-travel.cpp
+++ b/src/cmd-action/cmd-travel.cpp
@@ -144,8 +144,8 @@ static void travel_flow(PlayerType *player_ptr, const Pos2D pos)
             flow_tail = 0;
         }
 
-        for (auto d = 0; d < 8; d++) {
-            const Pos2D pos_neighbor(pos_flow.y + ddy_ddd[d], pos_flow.x + ddx_ddd[d]);
+        for (const auto &d : Direction::directions_8()) {
+            const auto pos_neighbor = pos_flow + d.vec();
             travel_flow_aux(player_ptr, pos_neighbor, travel.cost[pos_flow.y][pos_flow.x], wall);
         }
     }

--- a/src/effect/effect-feature.cpp
+++ b/src/effect/effect-feature.cpp
@@ -367,8 +367,8 @@ bool affect_feature(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION r, POS
         }
 
         if (floor.is_underground() || !AngbandWorld::get_instance().is_daytime()) {
-            for (int j = 0; j < 9; j++) {
-                const Pos2D pos_neighbor(y + ddy_ddd[j], x + ddx_ddd[j]);
+            for (const auto &d : Direction::directions()) {
+                const auto pos_neighbor = Pos2D(y, x) + d.vec();
                 if (!in_bounds2(&floor, pos_neighbor.y, pos_neighbor.x)) {
                     continue;
                 }

--- a/src/floor/floor-events.cpp
+++ b/src/floor/floor-events.cpp
@@ -337,8 +337,8 @@ void glow_deep_lava_and_bldg(PlayerType *player_ptr)
                 continue;
             }
 
-            for (auto i = 0; i < 9; i++) {
-                const Pos2D pos(y + ddy_ddd[i], x + ddx_ddd[i]);
+            for (const auto &d : Direction::directions()) {
+                const auto pos = Pos2D(y, x) + d.vec();
                 if (!in_bounds2(&floor, pos.y, pos.x)) {
                     continue;
                 }

--- a/src/floor/geometry.h
+++ b/src/floor/geometry.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include "system/angband-exceptions.h"
 #include "system/angband.h"
 #include "util/point-2d.h"
 #include <array>
+#include <span>
+#include <utility>
 
 /*!
  * @brief 視界及び光源の過渡処理配列サイズ / Maximum size of the "temp" array
@@ -14,11 +17,143 @@
  */
 #define TEMP_MAX 2298
 
-constexpr std::array<int, 9> ddd = { { 2, 8, 6, 4, 3, 1, 9, 7, 5 } }; //!< キーパッドの方向 (南から反時計回り順).
+class Direction {
+public:
+    /*!
+     * @brief 方向クラスのコンストラクタ
+     *
+     * 方向ID dir で指定した方向を示すクラスを生成する。
+     *
+     * 方向IDは5を中央とし以下のように定義される。
+     *
+     * 7 8 9
+     *  \|/
+     * 4-5-6
+     *  /|\
+     * 1 2 3
+     *
+     * 0: 5と同じ
+     *
+     * @param dir 方向ID
+     */
+    constexpr explicit Direction(int dir)
+        : dir_(dir)
+    {
+        if ((dir < 0) || std::cmp_greater_equal(dir, DIR_TO_VEC.size())) {
+            THROW_EXCEPTION(std::logic_error, "Invalid direction is specified!");
+        }
+    }
+
+    constexpr Direction()
+        : dir_(0)
+    {
+    }
+
+    static constexpr std::span<const Direction> directions();
+    static constexpr std::span<const Direction> directions_8();
+    static constexpr std::span<const Direction> directions_4();
+    static constexpr std::span<const Direction> directions_diag4();
+    static constexpr std::span<const Direction> directions_reverse();
+    static constexpr std::span<const Direction> directions_8_reverse();
+
+    /*!
+     * @brief 方向を示すベクトルを取得する
+     *
+     * ベクトルのy, xの値はその方向を示すY成分/X成分があれば1もしくは-1、なければ0を返す。
+     *
+     * @return 方向を示すベクトル
+     */
+    constexpr Pos2DVec vec() const
+    {
+        return DIR_TO_VEC[this->dir_];
+    }
+
+    /*!
+     * @brief 方向IDを取得する
+     * @return 方向ID
+     */
+    constexpr int dir() const noexcept
+    {
+        return this->dir_;
+    }
+
+private:
+    /// 方向IDに対応するベクトルの定義
+    static constexpr std::array<Pos2DVec, 10> DIR_TO_VEC = {
+        { { 0, 0 }, { 1, -1 }, { 1, 0 }, { 1, 1 }, { 0, -1 }, { 0, 0 }, { 0, 1 }, { -1, -1 }, { -1, 0 }, { -1, 1 } }
+    };
+
+    int dir_; //<! 方向ID
+};
+
+/* 以降の定義は直接使用しないようdetail名前空間に入れておく*/
+namespace detail {
+/// 下・上・右・左・右下・左下・右上・左上・中央の順にDirectionクラスのインスタンスを保持する配列
+constexpr std::array<Direction, 9> DIRECTIONS = {
+    { Direction(2), Direction(8), Direction(6), Direction(4), Direction(3), Direction(1), Direction(9), Direction(7), Direction(5) }
+};
+
+constexpr std::array<Direction, 9> reverse_array(const std::array<Direction, 9> &arr)
+{
+    std::array<Direction, 9> res{};
+    for (std::size_t i = 0; i < 9; ++i) {
+        res[i] = arr[9 - 1 - i];
+    }
+    return res;
+}
+
+/// DIRECTIONSの要素を逆順にした配列
+constexpr auto REVERSE_DIRECTIONS = reverse_array(DIRECTIONS);
+}
+
+/*!
+ * @brief 下・上・右・左・右下・左下・右上・左上・中央 の順にDirectionクラスのオブジェクトを参照する配列を返す
+ */
+constexpr std::span<const Direction> Direction::directions()
+{
+    return detail::DIRECTIONS;
+}
+/*!
+ * @brief 下・上・右・左・右下・左下・右上・左上 の順にDirectionクラスのオブジェクトを参照する配列を返す
+ */
+constexpr std::span<const Direction> Direction::directions_8()
+{
+    return Direction::directions().first(8);
+}
+/*!
+ * @brief 下・上・右・左 の順にDirectionクラスのオブジェクトを参照する配列を返す
+ */
+constexpr std::span<const Direction> Direction::directions_4()
+{
+    return Direction::directions().first(4);
+}
+/*!
+ * @brief 右下・左下・右上・左上 の順にDirectionクラスのオブジェクトを参照する配列を返す
+ */
+constexpr std::span<const Direction> Direction::directions_diag4()
+{
+    return Direction::directions().subspan(4, 4);
+}
+
+/*!
+ * @brief Directions::directions() の逆順の配列を返す
+ */
+constexpr std::span<const Direction> Direction::directions_reverse()
+{
+    return detail::REVERSE_DIRECTIONS;
+}
+
+/*!
+ * @brief Directions::directions_8() の逆順の配列を返す
+ * @note 斜め方向を先に処理したい時に使用する
+ */
+constexpr std::span<const Direction> Direction::directions_8_reverse()
+{
+    return Direction::directions_reverse().subspan(1, 8);
+}
+
 constexpr std::array<int, 10> ddx = { { 0, -1, 0, 1, -1, 0, 1, -1, 0, 1 } }; //!< dddで定義した順にベクトルのX軸成分.
 constexpr std::array<int, 10> ddy = { { 0, 1, 1, 1, 0, 0, 0, -1, -1, -1 } }; //!< dddで定義した順にベクトルのY軸成分.
-constexpr std::array<int, 9> ddx_ddd = { { 0, 0, 1, -1, 1, -1, 1, -1, 0 } }; //!< ddd越しにベクトルのX軸成分.
-constexpr std::array<int, 9> ddy_ddd = { { 1, -1, 0, 0, 1, 1, -1, -1, 0 } }; //!< ddd越しにベクトルのY軸成分.
 
 //! 下方向から反時計回りに8方向への方向ベクトル配列
 constexpr std::array<Pos2DVec, 8> CCW_DD = {

--- a/src/floor/geometry.h
+++ b/src/floor/geometry.h
@@ -14,13 +14,6 @@
  */
 #define TEMP_MAX 2298
 
-//!< 対象グリッドの一覧をまとめる構造体
-struct pos_list {
-    POSITION_IDX n; //!< Array of grids for use by various functions (see grid.c")
-    POSITION y[TEMP_MAX];
-    POSITION x[TEMP_MAX];
-};
-
 constexpr std::array<int, 9> ddd = { { 2, 8, 6, 4, 3, 1, 9, 7, 5 } }; //!< キーパッドの方向 (南から反時計回り順).
 constexpr std::array<int, 10> ddx = { { 0, -1, 0, 1, -1, 0, 1, -1, 0, 1 } }; //!< dddで定義した順にベクトルのX軸成分.
 constexpr std::array<int, 10> ddy = { { 0, 1, 1, 1, 0, 0, 0, -1, -1, -1 } }; //!< dddで定義した順にベクトルのY軸成分.

--- a/src/floor/tunnel-generator.cpp
+++ b/src/floor/tunnel-generator.cpp
@@ -14,8 +14,8 @@
  */
 static Pos2DVec rand_dir()
 {
-    const auto dir = randint0(4);
-    return { ddy_ddd[dir], ddx_ddd[dir] };
+    const auto d = rand_choice(Direction::directions_4());
+    return d.vec();
 }
 
 /*!

--- a/src/grid/feature-generator.cpp
+++ b/src/grid/feature-generator.cpp
@@ -120,11 +120,10 @@ void gen_caverns_and_lakes(PlayerType *player_ptr, const DungeonDefinition &dung
 static int next_to_corr(FloorType *floor_ptr, POSITION y1, POSITION x1)
 {
     int k = 0;
-    for (int i = 0; i < 4; i++) {
-        POSITION y = y1 + ddy_ddd[i];
-        POSITION x = x1 + ddx_ddd[i];
+    for (const auto &d : Direction::directions_4()) {
+        const auto pos = Pos2D(y1, x1) + d.vec();
         Grid *g_ptr;
-        g_ptr = &floor_ptr->grid_array[y][x];
+        g_ptr = &floor_ptr->get_grid(pos);
         if (g_ptr->has(TerrainCharacteristics::WALL) || !g_ptr->is_floor() || g_ptr->is_room()) {
             continue;
         }

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -74,8 +74,8 @@ void set_terrain_id_to_grid(PlayerType *player_ptr, const Pos2D &pos, short terr
         grid.set_terrain_id(terrain_id);
         grid.set_terrain_id(TerrainTag::NONE, TerrainKind::MIMIC);
         if (terrain.flags.has(TerrainCharacteristics::GLOW) && dungeon.flags.has_not(DungeonFeatureType::DARKNESS)) {
-            for (auto i = 0; i < 9; i++) {
-                const auto pos_neighbor = pos + Pos2DVec(ddy_ddd[i], ddx_ddd[i]);
+            for (const auto &d : Direction::directions()) {
+                const auto pos_neighbor = pos + d.vec();
                 if (!in_bounds2(&floor, pos_neighbor.y, pos_neighbor.x)) {
                     continue;
                 }
@@ -125,8 +125,8 @@ void set_terrain_id_to_grid(PlayerType *player_ptr, const Pos2D &pos, short terr
         return;
     }
 
-    for (auto i = 0; i < 9; i++) {
-        const auto pos_neighbor = pos + Pos2DVec(ddy_ddd[i], ddx_ddd[i]);
+    for (const auto &d : Direction::directions()) {
+        const auto pos_neighbor = pos + d.vec();
         if (!in_bounds2(&floor, pos_neighbor.y, pos_neighbor.x)) {
             continue;
         }
@@ -743,10 +743,10 @@ void update_flow(PlayerType *player_ptr)
             const auto &grid = floor.get_grid(pos);
 
             /* Add the "children" */
-            for (auto d = 0; d < 8; d++) {
+            for (const auto &d : Direction::directions_8()) {
                 uint8_t m = grid.costs.at(gf) + 1;
                 const uint8_t n = grid.dists.at(gf) + 1;
-                const Pos2D pos_neighbor(pos.y + ddy_ddd[d], pos.x + ddx_ddd[d]);
+                const auto pos_neighbor = pos + d.vec();
 
                 /* Ignore player's grid */
                 if (player_ptr->is_located_at(pos_neighbor)) {

--- a/src/mind/mind-warrior.cpp
+++ b/src/mind/mind-warrior.cpp
@@ -44,8 +44,8 @@ bool hit_and_away(PlayerType *player_ptr)
 bool sword_dancing(PlayerType *player_ptr)
 {
     for (auto i = 0; i < 6; i++) {
-        const auto dir = randint0(8);
-        const Pos2D pos(player_ptr->y + ddy_ddd[dir], player_ptr->x + ddx_ddd[dir]);
+        const auto d = rand_choice(Direction::directions_8());
+        const auto pos = player_ptr->get_position() + d.vec();
         const auto &grid = player_ptr->current_floor_ptr->get_grid(pos);
         if (grid.has_monster()) {
             do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_NONE);

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -392,7 +392,7 @@ bool process_monster_movement(PlayerType *player_ptr, turn_flags *turn_flags_ptr
     for (int i = 0; mm[i]; i++) {
         int d = mm[i];
         if (d == 5) {
-            d = ddd[randint0(8)];
+            d = rand_choice(Direction::directions_8()).dir();
         }
 
         const Pos2D pos_neighbor(pos.y + ddy[d], pos.x + ddx[d]);

--- a/src/monster-floor/monster-sweep-grid.cpp
+++ b/src/monster-floor/monster-sweep-grid.cpp
@@ -157,8 +157,8 @@ public:
         const auto p_pos = this->player_ptr->get_position();
 
         auto room = 0;
-        for (auto i = 0; i < 8; i++) {
-            const auto pos_p_neighbor = p_pos + Pos2DVec(ddy_ddd[i], ddx_ddd[i]);
+        for (const auto &d : Direction::directions_8()) {
+            const auto pos_p_neighbor = p_pos + d.vec();
             if (!in_bounds2(&floor, pos_p_neighbor.y, pos_p_neighbor.x)) {
                 continue;
             }
@@ -208,9 +208,11 @@ public:
         const auto p_pos = this->player_ptr->get_position();
         const auto m_pos = monster.get_position();
 
+        /// @todo std::views::enumerate
+        constexpr auto directions = Direction::directions_8();
         for (auto i = 0; i < 8; i++) {
-            const auto dir = (this->m_idx + i) & 7;
-            const auto pos_move = p_pos + Pos2DVec(ddy_ddd[dir], ddx_ddd[dir]);
+            const auto d = (this->m_idx + i) & 7;
+            const auto pos_move = p_pos + directions[d].vec();
             if (m_pos == pos_move) {
                 // プレイヤーを攻撃する
                 return p_pos;
@@ -267,8 +269,8 @@ public:
 
         auto best = 999;
         std::optional<Pos2D> pos_move;
-        for (auto i = 7; i >= 0; i--) {
-            const Pos2D pos_neighbor(m_pos.y + ddy_ddd[i], m_pos.x + ddx_ddd[i]);
+        for (const auto &d : Direction::directions_8_reverse()) {
+            const auto pos_neighbor = m_pos + d.vec();
             if (!in_bounds2(&floor, pos_neighbor.y, pos_neighbor.x)) {
                 continue;
             }
@@ -337,8 +339,8 @@ public:
 
         auto best = 999;
         std::optional<Pos2D> pos_move;
-        for (auto i = 7; i >= 0; i--) {
-            const auto pos_neighbor = m_pos + Pos2DVec(ddy_ddd[i], ddx_ddd[i]);
+        for (const auto &d : Direction::directions_8_reverse()) {
+            const auto pos_neighbor = m_pos + d.vec();
             if (!in_bounds2(&floor, pos_neighbor.y, pos_neighbor.x)) {
                 continue;
             }
@@ -351,7 +353,7 @@ public:
             }
 
             best = cost;
-            pos_move = p_pos + Pos2DVec(ddy_ddd[i], ddx_ddd[i]) * 16;
+            pos_move = p_pos + d.vec() * 16;
         }
 
         return pos_move;
@@ -382,8 +384,8 @@ public:
 
         auto best = 0;
         std::optional<Pos2D> pos_move;
-        for (auto i = 7; i >= 0; i--) {
-            const auto pos_neighbor = m_pos + Pos2DVec(ddy_ddd[i], ddx_ddd[i]);
+        for (const auto &d : Direction::directions_8_reverse()) {
+            const auto pos_neighbor = m_pos + d.vec();
             if (!in_bounds2(&floor, pos_neighbor.y, pos_neighbor.x)) {
                 continue;
             }
@@ -395,7 +397,7 @@ public:
             }
 
             best = when;
-            pos_move = p_pos + Pos2DVec(ddy_ddd[i], ddx_ddd[i]) * 16;
+            pos_move = p_pos + d.vec() * 16;
         }
 
         return pos_move;
@@ -541,14 +543,12 @@ std::optional<Pos2DVec> MonsterSweepGrid::sweep_runnable_away_grid(const Pos2DVe
     const auto m_pos = monster.get_position();
     auto pos1 = m_pos + vec_initial.inverted();
     auto score = -1;
-    for (auto i = 7; i >= 0; i--) {
-        auto y = m_pos.y + ddy_ddd[i];
-        auto x = m_pos.x + ddx_ddd[i];
-        if (!in_bounds2(&floor, y, x)) {
+    for (const auto &d : Direction::directions_8_reverse()) {
+        const auto pos = m_pos + d.vec();
+        if (!in_bounds2(&floor, pos.y, pos.x)) {
             continue;
         }
 
-        const Pos2D pos(y, x);
         const auto dis = Grid::calc_distance(pos, pos1);
         auto s = 5000 / (dis + 3) - 500 / (floor.get_grid(pos).get_distance(monrace.get_grid_flow_type()) + 1);
         if (s < 0) {

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -231,8 +231,8 @@ int get_monster_crowd_number(const FloorType *floor_ptr, short m_idx)
     const auto &monster = floor_ptr->m_list[m_idx];
     const auto m_pos = monster.get_position();
     auto count = 0;
-    for (auto i = 0; i < 7; i++) {
-        const auto pos = m_pos + Pos2DVec(ddy_ddd[i], ddx_ddd[i]);
+    for (const auto &d : Direction::directions_8()) {
+        const auto pos = m_pos + d.vec();
         if (!in_bounds(floor_ptr, pos.y, pos.x)) {
             continue;
         }

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -108,7 +108,7 @@ static int get_hack_dir(PlayerType *player_ptr)
 
     command_dir = dir;
     if (player_ptr->effects()->confusion().is_confused()) {
-        dir = ddd[randint0(8)];
+        dir = rand_choice(Direction::directions_8()).dir();
     }
 
     if (command_dir != dir) {

--- a/src/pet/pet-fall-off.cpp
+++ b/src/pet/pet-fall-off.cpp
@@ -104,12 +104,11 @@ bool process_fall_off_horse(PlayerType *player_ptr, int dam, bool force)
         }
 
         /* Check around the player */
-        for (DIRECTION i = 0; i < 8; i++) {
-            POSITION y = player_ptr->y + ddy_ddd[i];
-            POSITION x = player_ptr->x + ddx_ddd[i];
+        for (const auto &d : Direction::directions_8()) {
+            const auto pos = player_ptr->get_position() + d.vec();
 
             Grid *g_ptr;
-            g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
+            g_ptr = &player_ptr->current_floor_ptr->get_grid(pos);
 
             if (g_ptr->has_monster()) {
                 continue;
@@ -135,8 +134,8 @@ bool process_fall_off_horse(PlayerType *player_ptr, int dam, bool force)
             }
 
             /* Save the safe location */
-            sy = y;
-            sx = x;
+            sy = pos.y;
+            sx = pos.x;
         }
 
         if (!sn) {

--- a/src/player-attack/player-attack.cpp
+++ b/src/player-attack/player-attack.cpp
@@ -592,8 +592,8 @@ void exe_player_attack_to_monster(PlayerType *player_ptr, POSITION y, POSITION x
 void massacre(PlayerType *player_ptr)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
-    for (auto dir = 0; dir < 8; dir++) {
-        const auto pos = player_ptr->get_position() + Pos2DVec(ddy_ddd[dir], ddx_ddd[dir]);
+    for (const auto &d : Direction::directions_8()) {
+        const auto pos = player_ptr->get_position() + d.vec();
         const auto &grid = floor.get_grid(pos);
         const auto &monster = floor.m_list[grid.m_idx];
         if (grid.has_monster() && (monster.ml || floor.has_terrain_characteristics(pos, TerrainCharacteristics::PROJECT))) {

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -113,9 +113,9 @@ void search(PlayerType *player_ptr)
         chance = chance / 10;
     }
 
-    for (DIRECTION i = 0; i < 9; ++i) {
+    for (const auto &d : Direction::directions()) {
         if (evaluate_percent(chance)) {
-            discover_hidden_things(player_ptr, { player_ptr->y + ddy_ddd[i], player_ptr->x + ddx_ddd[i] });
+            discover_hidden_things(player_ptr, player_ptr->get_position() + d.vec());
         }
     }
 }

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -649,10 +649,9 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
                 flag = false;
 
                 const auto *floor_ptr = player_ptr->current_floor_ptr;
-                for (auto d = 0; d < 8; d++) {
-                    const auto dy = y + ddy_ddd[d];
-                    const auto dx = x + ddx_ddd[d];
-                    if (floor_ptr->grid_array[dy][dx].has_monster()) {
+                for (const auto &d : Direction::directions_8()) {
+                    const auto pos_neighbor = Pos2D(y, x) + d.vec();
+                    if (floor_ptr->get_grid(pos_neighbor).has_monster()) {
                         flag = true;
                     }
                 }

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -422,9 +422,9 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             short new_cut = current_cut < 300 ? current_cut + 300 : current_cut * 2;
             (void)BadStatusSetter(player_ptr).set_cut(new_cut);
             const auto &floor = *player_ptr->current_floor_ptr;
-            for (auto dir = 0; dir < 8; dir++) {
+            for (const auto &d : Direction::directions_8()) {
                 const auto pos = player_ptr->get_position();
-                const Pos2D pos_ddd(pos.y + ddy_ddd[dir], pos.x + ddx_ddd[dir]);
+                const auto pos_ddd = pos + d.vec();
                 const auto &grid = floor.get_grid(pos_ddd);
                 const auto &monster = floor.m_list[grid.m_idx];
                 if (!grid.has_monster() || (!monster.ml && !floor.has_terrain_characteristics(pos_ddd, TerrainCharacteristics::PROJECT))) {

--- a/src/room/cave-filler.cpp
+++ b/src/room/cave-filler.cpp
@@ -244,8 +244,8 @@ static void cave_fill(PlayerType *player_ptr, const Pos2D &initial_pos)
         // 参照で受けるとダングリング状態になるのでコピーする.
         const Pos2D pos = que.front();
         que.pop();
-        for (int d = 0; d < 8; d++) {
-            const Pos2D pos_to(pos.y + ddy_ddd[d], pos.x + ddx_ddd[d]);
+        for (const auto &d : Direction::directions_8()) {
+            const auto pos_to = pos + d.vec();
             auto &grid = floor.get_grid(pos_to);
             if (!in_bounds(&floor, pos_to.y, pos_to.x)) {
                 grid.info |= CAVE_ICKY;

--- a/src/room/rooms-builder.cpp
+++ b/src/room/rooms-builder.cpp
@@ -77,9 +77,8 @@ void build_small_room(PlayerType *player_ptr, POSITION x0, POSITION y0)
         place_bold(player_ptr, pos.y + 1, x, GB_INNER);
     }
 
-    const auto n = randint0(4);
-    const Pos2DVec vec(ddy_ddd[n], ddx_ddd[n]);
-    place_secret_door(player_ptr, pos + vec);
+    const auto d = rand_choice(Direction::directions_4());
+    place_secret_door(player_ptr, pos + d.vec());
 
     player_ptr->current_floor_ptr->set_terrain_id_at(pos, TerrainTag::NONE, TerrainKind::MIMIC);
     place_bold(player_ptr, pos.y, pos.x, GB_FLOOR);

--- a/src/room/rooms-special.cpp
+++ b/src/room/rooms-special.cpp
@@ -100,31 +100,28 @@ bool build_type15(PlayerType *player_ptr, DungeonData *dd_ptr)
         get_mon_num_prep_enum(player_ptr, MonraceHook::GLASS);
 
         /* Place fixed lite berathers */
-        for (auto dir1 = 4; dir1 < 8; dir1++) {
+        for (const auto &d_diag : Direction::directions_diag4()) {
             const auto monrace_id = get_mon_num(player_ptr, 0, floor.dun_level, 0);
-            const auto y = center->y + 2 * ddy_ddd[dir1];
-            const auto x = center->x + 2 * ddx_ddd[dir1];
+            const auto pos = *center + d_diag.vec() * 2;
             if (MonraceList::is_valid(monrace_id)) {
-                place_specific_monster(player_ptr, y, x, monrace_id, PM_ALLOW_SLEEP);
+                place_specific_monster(player_ptr, pos.y, pos.x, monrace_id, PM_ALLOW_SLEEP);
             }
 
             /* Walls around the breather */
-            for (auto dir2 = 0; dir2 < 8; dir2++) {
-                place_inner_glass(player_ptr, floor.get_grid({ y + ddy_ddd[dir2], x + ddx_ddd[dir2] }));
+            for (const auto &d : Direction::directions_8()) {
+                place_inner_glass(player_ptr, floor.get_grid(pos + d.vec()));
             }
         }
 
         /* Walls around the potion */
-        for (auto dir1 = 0; dir1 < 4; dir1++) {
-            place_inner_perm_glass(player_ptr, floor.get_grid({ center->y + 2 * ddy_ddd[dir1], center->x + 2 * ddx_ddd[dir1] }));
-            floor.get_grid({ center->y + ddy_ddd[dir1], center->x + ddx_ddd[dir1] }).info |= CAVE_ICKY;
+        for (const auto &d : Direction::directions_4()) {
+            place_inner_perm_glass(player_ptr, floor.get_grid(*center + d.vec() * 2));
+            floor.get_grid(*center + d.vec()).info |= CAVE_ICKY;
         }
 
         /* Glass door */
-        const auto dir1 = randint0(4);
-        const auto y = center->y + 2 * ddy_ddd[dir1];
-        const auto x = center->x + 2 * ddx_ddd[dir1];
-        const Pos2D pos(y, x);
+        const auto d = rand_choice(Direction::directions_4());
+        const auto pos = *center + d.vec() * 2;
         place_secret_door(player_ptr, pos, DoorKind::GLASS_DOOR);
         if (floor.has_closed_door_at(pos)) {
             floor.get_grid(pos).set_terrain_id(TerrainTag::GLASS_WALL, TerrainKind::MIMIC);
@@ -151,8 +148,8 @@ bool build_type15(PlayerType *player_ptr, DungeonData *dd_ptr)
         }
 
         /* Walls around the breather */
-        for (auto dir1 = 0; dir1 < 8; dir1++) {
-            place_inner_glass(player_ptr, floor.get_grid({ center->y + ddy_ddd[dir1], center->x + ddx_ddd[dir1] }));
+        for (const auto &d : Direction::directions_8()) {
+            place_inner_glass(player_ptr, floor.get_grid(*center + d.vec()));
         }
 
         /* Curtains around the breather */
@@ -184,19 +181,18 @@ bool build_type15(PlayerType *player_ptr, DungeonData *dd_ptr)
             place_inner_glass(player_ptr, floor.get_grid({ center->y + 3, x }));
         }
 
-        for (auto dir1 = 4; dir1 < 8; dir1++) {
-            place_inner_glass(player_ptr, floor.get_grid({ center->y + 2 * ddy_ddd[dir1], center->x + 2 * ddx_ddd[dir1] }));
+        for (const auto &d_diag : Direction::directions_diag4()) {
+            place_inner_glass(player_ptr, floor.get_grid(*center + d_diag.vec() * 2));
         }
 
         get_mon_num_prep_enum(player_ptr, MonraceHook::SHARDS);
 
         /* Place shard berathers */
-        for (auto dir1 = 4; dir1 < 8; dir1++) {
+        for (const auto &d_diag : Direction::directions_diag4()) {
             const auto monrace_id = get_mon_num(player_ptr, 0, floor.dun_level, 0);
-            const auto y = center->y + ddy_ddd[dir1];
-            const auto x = center->x + ddx_ddd[dir1];
+            const auto pos = *center + d_diag.vec();
             if (MonraceList::is_valid(monrace_id)) {
-                place_specific_monster(player_ptr, y, x, monrace_id, 0L);
+                place_specific_monster(player_ptr, pos.y, pos.x, monrace_id, 0L);
             }
         }
 

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -91,18 +91,17 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
     auto sn = 0;
     Pos2D p_pos_new(0, 0); // 落石を避けた後のプレイヤー座標
     if (hurt && !has_pass_wall(player_ptr) && !has_kill_wall(player_ptr)) {
-        for (auto i = 0; i < 8; i++) {
-            auto y = player_ptr->y + ddy_ddd[i];
-            auto x = player_ptr->x + ddx_ddd[i];
-            if (!is_cave_empty_bold(player_ptr, y, x)) {
+        for (const auto &d : Direction::directions_8()) {
+            const auto pos = player_ptr->get_position() + d.vec();
+            if (!is_cave_empty_bold(player_ptr, pos.y, pos.x)) {
                 continue;
             }
 
-            if (map[16 + y - cy][16 + x - cx]) {
+            if (map[16 + pos.y - cy][16 + pos.x - cx]) {
                 continue;
             }
 
-            if (floor.grid_array[y][x].has_monster()) {
+            if (floor.get_grid(pos).has_monster()) {
                 continue;
             }
 
@@ -111,7 +110,7 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
                 continue;
             }
 
-            p_pos_new = { y, x };
+            p_pos_new = pos;
         }
 
         constexpr static auto msgs = {
@@ -185,8 +184,8 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
 
             sn = 0;
             if (monrace.behavior_flags.has_not(MonsterBehaviorType::NEVER_MOVE)) {
-                for (auto i = 0; i < 8; i++) {
-                    const Pos2D pos_neighbor(pos.y + ddy_ddd[i], pos.x + ddx_ddd[i]);
+                for (const auto &d : Direction::directions_8()) {
+                    const auto pos_neighbor = pos + d.vec();
                     if (!is_cave_empty_bold(player_ptr, pos_neighbor.y, pos_neighbor.x)) {
                         continue;
                     }
@@ -320,8 +319,8 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
                 continue;
             }
 
-            for (auto j = 0; j < 9; j++) {
-                const Pos2D pos_neighbor(pos.y + ddy_ddd[j], pos.x + ddx_ddd[j]);
+            for (const auto &d : Direction::directions()) {
+                const auto pos_neighbor = pos + d.vec();
                 if (!in_bounds2(&floor, pos_neighbor.y, pos_neighbor.x)) {
                     continue;
                 }

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -73,8 +73,8 @@ void wiz_lite(PlayerType *player_ptr, bool ninja)
             grid.info |= (CAVE_KNOWN);
 
             /* Scan all neighbors */
-            for (OBJECT_IDX i = 0; i < 9; i++) {
-                const auto pos_neighbor = pos + Pos2DVec(ddy_ddd[i], ddx_ddd[i]);
+            for (const auto &d : Direction::directions()) {
+                const auto pos_neighbor = pos + d.vec();
                 auto &grid_neighbor = floor.get_grid(pos_neighbor);
 
                 /* Feature code (applying "mimic" field) */
@@ -218,8 +218,8 @@ void map_area(PlayerType *player_ptr, POSITION range)
             }
 
             /* Memorize known walls */
-            for (int i = 0; i < 8; i++) {
-                auto &grid_neighbor = floor.get_grid(pos + Pos2DVec(ddy_ddd[i], ddx_ddd[i]));
+            for (const auto &d : Direction::directions_8()) {
+                auto &grid_neighbor = floor.get_grid(pos + d.vec());
 
                 /* Feature code (applying "mimic" field) */
                 const auto terrain_id = grid_neighbor.get_terrain_id(TerrainKind::MIMIC);
@@ -441,8 +441,8 @@ bool destroy_area(PlayerType *player_ptr, const POSITION y1, const POSITION x1, 
                 continue;
             }
 
-            for (auto i = 0; i < 9; i++) {
-                const Pos2D pos_neighbor(pos.y + ddy_ddd[i], pos.x + ddx_ddd[i]);
+            for (const auto &d : Direction::directions()) {
+                const auto pos_neighbor = pos + d.vec();
                 if (!in_bounds2(&floor, pos_neighbor.y, pos_neighbor.x)) {
                     continue;
                 }

--- a/src/spell-kind/spells-lite.cpp
+++ b/src/spell-kind/spells-lite.cpp
@@ -102,8 +102,8 @@ static void cave_temp_room_unlite(PlayerType *player_ptr, const std::vector<Pos2
         }
 
         if (floor.is_underground() || !world.is_daytime()) {
-            for (auto j = 0; j < 9; j++) {
-                const Pos2D pos_neighbor(pos.y + ddy_ddd[j], pos.x + ddx_ddd[j]);
+            for (const auto &d : Direction::directions()) {
+                const Pos2D pos_neighbor = pos + d.vec();
                 if (!in_bounds2(&floor, pos_neighbor.y, pos_neighbor.x)) {
                     continue;
                 }
@@ -176,13 +176,11 @@ static int next_to_open(FloorType *floor_ptr, const POSITION cy, const POSITION 
  */
 static int next_to_walls_adj(FloorType *floor_ptr, const POSITION cy, const POSITION cx, const PassBoldFunc pass_bold)
 {
-    POSITION y, x;
-    int c = 0;
-    for (DIRECTION i = 0; i < 8; i++) {
-        y = cy + ddy_ddd[i];
-        x = cx + ddx_ddd[i];
+    auto c = 0;
+    for (const auto &d : Direction::directions_8()) {
+        const auto pos = Pos2D(cy, cx) + d.vec();
 
-        if (!pass_bold(floor_ptr, y, x)) {
+        if (!pass_bold(floor_ptr, pos.y, pos.x)) {
             c++;
         }
     }

--- a/src/spell-realm/spells-chaos.cpp
+++ b/src/spell-realm/spells-chaos.cpp
@@ -35,8 +35,8 @@ void call_the_void(PlayerType *player_ptr)
 {
     auto do_call = true;
     const auto &floor = *player_ptr->current_floor_ptr;
-    for (int i = 0; i < 9; i++) {
-        const Pos2D p_pos_neighbor(player_ptr->y + ddy_ddd[i], player_ptr->x + ddx_ddd[i]);
+    for (const auto &d : Direction::directions()) {
+        const auto p_pos_neighbor = player_ptr->get_position() + d.vec();
         const auto &grid = floor.get_grid(p_pos_neighbor);
         if (!grid.has(TerrainCharacteristics::PROJECT)) {
             if (!grid.mimic || grid.get_terrain(TerrainKind::MIMIC_RAW).flags.has_not(TerrainCharacteristics::PROJECT) || !grid.get_terrain().is_permanent_wall()) {

--- a/src/system/floor/floor-info.cpp
+++ b/src/system/floor/floor-info.cpp
@@ -211,12 +211,8 @@ std::pair<int, Pos2D> FloorType::count_doors_traps(const Pos2D &p_pos, GridCount
 {
     auto count = 0;
     Pos2D pos(0, 0);
-    for (auto d = 0; d < 9; d++) {
-        if ((d == 8) && !under) {
-            continue;
-        }
-
-        Pos2D pos_neighbor = p_pos + Pos2DVec(ddy_ddd[d], ddx_ddd[d]);
+    for (const auto &d : under ? Direction::directions() : Direction::directions_8()) {
+        const auto pos_neighbor = p_pos + d.vec();
         if (!this->has_marked_grid_at(pos_neighbor)) {
             continue;
         }

--- a/src/target/target-getter.cpp
+++ b/src/target/target-getter.cpp
@@ -108,7 +108,7 @@ bool get_aim_dir(PlayerType *player_ptr, int *dp)
 
     command_dir = dir;
     if (player_ptr->effects()->confusion().is_confused()) {
-        dir = ddd[randint0(8)];
+        dir = rand_choice(Direction::directions_8()).dir();
     }
 
     if (command_dir != dir) {
@@ -161,7 +161,7 @@ std::optional<int> get_direction(PlayerType *player_ptr)
     });
     const auto is_confused = player_ptr->effects()->confusion().is_confused();
     if (is_confused && evaluate_percent(75)) {
-        dir = ddd[randint0(8)];
+        dir = rand_choice(Direction::directions_8()).dir();
     }
 
     if (command_dir == dir) {
@@ -260,19 +260,19 @@ bool get_rep_dir(PlayerType *player_ptr, int *dp, bool under)
     auto is_confused = player_ptr->effects()->confusion().is_confused();
     if (is_confused) {
         if (evaluate_percent(75)) {
-            dir = ddd[randint0(8)];
+            dir = rand_choice(Direction::directions_8()).dir();
         }
     } else if (player_ptr->riding) {
         auto *m_ptr = &player_ptr->current_floor_ptr->m_list[player_ptr->riding];
         auto *r_ptr = &m_ptr->get_monrace();
         if (m_ptr->is_confused()) {
             if (evaluate_percent(75)) {
-                dir = ddd[randint0(8)];
+                dir = rand_choice(Direction::directions_8()).dir();
             }
         } else if (r_ptr->behavior_flags.has_all_of({ MonsterBehaviorType::RAND_MOVE_50, MonsterBehaviorType::RAND_MOVE_25 }) && one_in_(2)) {
-            dir = ddd[randint0(8)];
+            dir = rand_choice(Direction::directions_8()).dir();
         } else if (r_ptr->behavior_flags.has(MonsterBehaviorType::RAND_MOVE_50) && one_in_(4)) {
-            dir = ddd[randint0(8)];
+            dir = rand_choice(Direction::directions_8()).dir();
         }
     }
 


### PR DESCRIPTION
#4905 の一環

後で ddx / ddy と CCW_DD を使用した処理も組み込む予定ですが、今回の範囲は一旦 ddd / ddx_ddd / ddy_ddd の箇所のみを変更しています。

## 気をつけてチェックしてほしい点

- 元のループ範囲と、仕様する範囲の対応が合っているか
  - [0, 9) → Direction::directions()
  - [0, 8) → Direction::directions_8()
  - [0, 4) → Direction::directions_4()
  - [4, 8) → Direction::directions_diag4()
  - [7, 0] → Direction::directions_8_reverse()
- 元のコードで差分に掛け算をしている場合に変更先でベクトルに掛け算するのを忘れていないか

なお、get_monster_crowd_number() は [0, 7) になっていますが明らかに間違いと思われるので [0, 8) としています。