### PR TITLE
[Refactor] Grid *g_ptr を Grid &grid にする 

### DIFF
--- a/src/action/open-util.cpp
+++ b/src/action/open-util.cpp
@@ -22,8 +22,8 @@
  */
 short chest_check(const FloorType &floor, const Pos2D &pos, bool trapped)
 {
-    auto *g_ptr = &floor.get_grid(pos);
-    for (const auto this_o_idx : g_ptr->o_idx_list) {
+    const auto &grid = floor.get_grid(pos);
+    for (const auto this_o_idx : grid.o_idx_list) {
         const auto &item = floor.o_list[this_o_idx];
         const auto is_empty = trapped || (item.pval == 0);
         const auto trapped_only = trapped && (item.pval > 0);

--- a/src/autopick/autopick.cpp
+++ b/src/autopick/autopick.cpp
@@ -99,9 +99,9 @@ void autopick_alter_item(PlayerType *player_ptr, INVENTORY_IDX i_idx, bool destr
 /*!
  * @brief Automatically pickup/destroy items in this grid.
  */
-void autopick_pickup_items(PlayerType *player_ptr, Grid *g_ptr)
+void autopick_pickup_items(PlayerType *player_ptr, const Grid &grid)
 {
-    for (auto it = g_ptr->o_idx_list.begin(); it != g_ptr->o_idx_list.end();) {
+    for (auto it = grid.o_idx_list.begin(); it != grid.o_idx_list.end();) {
         OBJECT_IDX this_o_idx = *it++;
         auto &item = player_ptr->current_floor_ptr->o_list[this_o_idx];
         int idx = find_autopick_list(player_ptr, &item);

--- a/src/autopick/autopick.h
+++ b/src/autopick/autopick.h
@@ -6,4 +6,4 @@ class Grid;
 class PlayerType;
 void autopick_alter_item(PlayerType *player_ptr, INVENTORY_IDX i_idx, bool destroy);
 void autopick_delayed_alter(PlayerType *player_ptr);
-void autopick_pickup_items(PlayerType *player_ptr, Grid *g_ptr);
+void autopick_pickup_items(PlayerType *player_ptr, const Grid &grid);

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -195,7 +195,7 @@ bool do_cmd_riding(PlayerType *player_ptr, bool force)
 
     if (player_ptr->riding) {
         /* Skip non-empty grids */
-        if (!can_player_ride_pet(player_ptr, &grid, false)) {
+        if (!can_player_ride_pet(player_ptr, grid, false)) {
             msg_print(_("そちらには降りられません。", "You cannot go that direction."));
             return false;
         }
@@ -240,7 +240,7 @@ bool do_cmd_riding(PlayerType *player_ptr, bool force)
             return false;
         }
 
-        if (!can_player_ride_pet(player_ptr, &grid, true)) {
+        if (!can_player_ride_pet(player_ptr, grid, true)) {
             /* Feature code (applying "mimic" field) */
             const auto &terrain = grid.get_terrain(TerrainKind::MIMIC);
             using Tc = TerrainCharacteristics;
@@ -686,8 +686,8 @@ void do_cmd_pet(PlayerType *player_ptr)
         if (!target_set(player_ptr, TARGET_KILL)) {
             player_ptr->pet_t_m_idx = 0;
         } else {
-            auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[target_row][target_col];
-            if (g_ptr->has_monster() && (player_ptr->current_floor_ptr->m_list[g_ptr->m_idx].ml)) {
+            const auto &grid = player_ptr->current_floor_ptr->grid_array[target_row][target_col];
+            if (grid.has_monster() && (player_ptr->current_floor_ptr->m_list[grid.m_idx].ml)) {
                 player_ptr->pet_t_m_idx = player_ptr->current_floor_ptr->grid_array[target_row][target_col].m_idx;
                 player_ptr->pet_follow_distance = PET_DESTROY_DIST;
             } else {

--- a/src/dungeon/quest-completion-checker.cpp
+++ b/src/dungeon/quest-completion-checker.cpp
@@ -222,10 +222,10 @@ Pos2D QuestCompletionChecker::make_stairs(const bool create_stairs)
     }
 
     auto &floor = *this->player_ptr->current_floor_ptr;
-    auto *g_ptr = &floor.get_grid(m_pos);
-    while (floor.has_terrain_characteristics(m_pos, TerrainCharacteristics::PERMANENT) || !g_ptr->o_idx_list.empty() || g_ptr->is_object()) {
+    const auto *grid_ptr = &floor.get_grid(m_pos);
+    while (floor.has_terrain_characteristics(m_pos, TerrainCharacteristics::PERMANENT) || !grid_ptr->o_idx_list.empty() || grid_ptr->is_object()) {
         m_pos = scatter(this->player_ptr, m_pos, 1, PROJECT_NONE);
-        g_ptr = &floor.get_grid(m_pos);
+        grid_ptr = &floor.get_grid(m_pos);
     }
 
     msg_print(_("魔法の階段が現れた...", "A magical staircase appears..."));

--- a/src/floor/cave-generator.cpp
+++ b/src/floor/cave-generator.cpp
@@ -263,7 +263,7 @@ static void make_aqua_streams(PlayerType *player_ptr, DungeonData *dd_ptr, const
 
 /*!
  * @brief マスにフロア端用の永久壁を配置する / Set boundary mimic and add "solid" perma-wall
- * @param g_ptr 永久壁を配置したいマス構造体の参照ポインタ
+ * @param grid 永久壁を配置したいグリッドへの参照
  */
 static void place_bound_perm_wall(PlayerType *player_ptr, Grid &grid)
 {

--- a/src/floor/cave-generator.cpp
+++ b/src/floor/cave-generator.cpp
@@ -129,9 +129,8 @@ static void make_tunnels(PlayerType *player_ptr, DungeonData *dd_ptr)
 static void make_walls(PlayerType *player_ptr, DungeonData *dd_ptr, const DungeonDefinition &dungeon, dt_type *dt_ptr)
 {
     for (size_t j = 0; j < dd_ptr->wall_n; j++) {
-        Grid *g_ptr;
         dd_ptr->tunnel_pos = dd_ptr->walls[j];
-        g_ptr = &player_ptr->current_floor_ptr->get_grid(dd_ptr->tunnel_pos);
+        auto *g_ptr = &player_ptr->current_floor_ptr->get_grid(dd_ptr->tunnel_pos);
         g_ptr->mimic = 0;
         place_grid(player_ptr, g_ptr, GB_FLOOR);
         if (evaluate_percent(dt_ptr->dun_tun_pen) && dungeon.flags.has_not(DungeonFeatureType::NO_DOORS)) {

--- a/src/floor/cave-generator.cpp
+++ b/src/floor/cave-generator.cpp
@@ -121,7 +121,7 @@ static void make_tunnels(PlayerType *player_ptr, DungeonData *dd_ptr)
         const auto &terrain = grid.get_terrain();
         if (terrain.flags.has_not(TerrainCharacteristics::MOVE) || terrain.flags.has_none_of({ TerrainCharacteristics::WATER, TerrainCharacteristics::LAVA })) {
             grid.mimic = 0;
-            place_grid(player_ptr, &grid, GB_FLOOR);
+            place_grid(player_ptr, grid, GB_FLOOR);
         }
     }
 }
@@ -130,9 +130,9 @@ static void make_walls(PlayerType *player_ptr, DungeonData *dd_ptr, const Dungeo
 {
     for (size_t j = 0; j < dd_ptr->wall_n; j++) {
         dd_ptr->tunnel_pos = dd_ptr->walls[j];
-        auto *g_ptr = &player_ptr->current_floor_ptr->get_grid(dd_ptr->tunnel_pos);
-        g_ptr->mimic = 0;
-        place_grid(player_ptr, g_ptr, GB_FLOOR);
+        auto &grid = player_ptr->current_floor_ptr->get_grid(dd_ptr->tunnel_pos);
+        grid.mimic = 0;
+        place_grid(player_ptr, grid, GB_FLOOR);
         if (evaluate_percent(dt_ptr->dun_tun_pen) && dungeon.flags.has_not(DungeonFeatureType::NO_DOORS)) {
             place_random_door(player_ptr, dd_ptr->tunnel_pos, true);
         }
@@ -269,7 +269,7 @@ static void place_bound_perm_wall(PlayerType *player_ptr, Grid &grid)
 {
     if (bound_walls_perm) {
         grid.mimic = 0;
-        place_grid(player_ptr, &grid, GB_SOLID_PERM);
+        place_grid(player_ptr, grid, GB_SOLID_PERM);
         return;
     }
 
@@ -279,7 +279,7 @@ static void place_bound_perm_wall(PlayerType *player_ptr, Grid &grid)
     }
 
     grid.mimic = grid.feat;
-    place_grid(player_ptr, &grid, GB_SOLID_PERM);
+    place_grid(player_ptr, grid, GB_SOLID_PERM);
 }
 
 static void make_perm_walls(PlayerType *player_ptr)

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -62,8 +62,8 @@ static void drop_here(FloorType &floor, ItemEntity &&item, POSITION y, POSITION 
     dropped_item.iy = y;
     dropped_item.ix = x;
     dropped_item.held_m_idx = 0;
-    auto *g_ptr = &floor.grid_array[y][x];
-    g_ptr->o_idx_list.add(floor, item_idx);
+    auto &grid = floor.grid_array[y][x];
+    grid.o_idx_list.add(floor, item_idx);
 }
 
 static void generate_artifact(PlayerType *player_ptr, qtwg_type *qtwg_ptr, const FixedArtifactId a_idx)

--- a/src/floor/floor-events.cpp
+++ b/src/floor/floor-events.cpp
@@ -388,8 +388,8 @@ void forget_view(FloorType &floor)
     for (int i = 0; i < floor.view_n; i++) {
         POSITION y = floor.view_y[i];
         POSITION x = floor.view_x[i];
-        auto *g_ptr = &floor.grid_array[y][x];
-        g_ptr->info &= ~(CAVE_VIEW);
+        auto &grid = floor.grid_array[y][x];
+        grid.info &= ~(CAVE_VIEW);
     }
 
     floor.view_n = 0;

--- a/src/floor/floor-events.cpp
+++ b/src/floor/floor-events.cpp
@@ -388,8 +388,7 @@ void forget_view(FloorType &floor)
     for (int i = 0; i < floor.view_n; i++) {
         POSITION y = floor.view_y[i];
         POSITION x = floor.view_x[i];
-        Grid *g_ptr;
-        g_ptr = &floor.grid_array[y][x];
+        auto *g_ptr = &floor.grid_array[y][x];
         g_ptr->info &= ~(CAVE_VIEW);
     }
 

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -393,16 +393,16 @@ void clear_cave(PlayerType *player_ptr)
     precalc_cur_num_of_pet();
     for (POSITION y = 0; y < MAX_HGT; y++) {
         for (POSITION x = 0; x < MAX_WID; x++) {
-            auto *g_ptr = &floor.grid_array[y][x];
-            g_ptr->info = 0;
-            g_ptr->feat = 0;
-            g_ptr->o_idx_list.clear();
-            g_ptr->m_idx = 0;
-            g_ptr->special = 0;
-            g_ptr->mimic = 0;
-            g_ptr->reset_costs();
-            g_ptr->reset_dists();
-            g_ptr->when = 0;
+            auto &grid = floor.grid_array[y][x];
+            grid.info = 0;
+            grid.feat = 0;
+            grid.o_idx_list.clear();
+            grid.m_idx = 0;
+            grid.special = 0;
+            grid.mimic = 0;
+            grid.reset_costs();
+            grid.reset_dists();
+            grid.when = 0;
         }
     }
 

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -386,15 +386,15 @@ static void kill_saved_floors(PlayerType *player_ptr, saved_floor_type *sf_ptr)
     }
 }
 
-static void refresh_new_floor_id(PlayerType *player_ptr, Grid *g_ptr)
+static void refresh_new_floor_id(PlayerType *player_ptr, Grid *grid_ptr)
 {
     if (new_floor_id != 0) {
         return;
     }
 
     new_floor_id = get_unused_floor_id(player_ptr);
-    if ((g_ptr != nullptr) && !g_ptr->has_special_terrain()) {
-        g_ptr->special = new_floor_id;
+    if ((grid_ptr != nullptr) && !grid_ptr->has_special_terrain()) {
+        grid_ptr->special = new_floor_id;
     }
 }
 
@@ -414,7 +414,7 @@ static void update_upper_lower_or_floor_id(saved_floor_type *sf_ptr)
 
 static void exe_leave_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr)
 {
-    auto g_ptr = set_grid_by_leaving_floor(*player_ptr->current_floor_ptr, player_ptr->get_position());
+    auto *grid_ptr = set_grid_by_leaving_floor(*player_ptr->current_floor_ptr, player_ptr->get_position());
     jump_floors(*player_ptr->current_floor_ptr);
     exit_to_wilderness(player_ptr);
     kill_saved_floors(player_ptr, sf_ptr);
@@ -422,7 +422,7 @@ static void exe_leave_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr)
         return;
     }
 
-    refresh_new_floor_id(player_ptr, g_ptr);
+    refresh_new_floor_id(player_ptr, grid_ptr);
     update_upper_lower_or_floor_id(sf_ptr);
     auto &fcms = FloorChangeModesStore::get_instace();
     if (fcms->has_not(FloorChangeMode::SAVE_FLOORS) || fcms->has(FloorChangeMode::NO_RETURN)) {

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -304,17 +304,17 @@ static Grid *set_grid_by_leaving_floor(FloorType &floor, const Pos2D &p_pos)
         return nullptr;
     }
 
-    auto *g_ptr = &floor.get_grid(p_pos);
-    const auto &terrain = g_ptr->get_terrain();
-    if (g_ptr->special && terrain.flags.has_not(TerrainCharacteristics::SPECIAL) && get_sf_ptr(g_ptr->special)) {
-        new_floor_id = g_ptr->special;
+    auto &grid = floor.get_grid(p_pos);
+    const auto &terrain = grid.get_terrain();
+    if (grid.special && terrain.flags.has_not(TerrainCharacteristics::SPECIAL) && get_sf_ptr(grid.special)) {
+        new_floor_id = grid.special;
     }
 
     if (terrain.flags.has_all_of({ TerrainCharacteristics::STAIRS, TerrainCharacteristics::SHAFT })) {
         FloorChangeModesStore::get_instace()->set(FloorChangeMode::SHAFT);
     }
 
-    return g_ptr;
+    return &grid;
 }
 
 static void jump_floors(FloorType &floor)

--- a/src/floor/floor-util.cpp
+++ b/src/floor/floor-util.cpp
@@ -115,7 +115,7 @@ void forget_flow(FloorType &floor)
  * Delete all the items when player leaves the level
  * @note we do NOT visually reflect these (irrelevant) changes
  * @details
- * Hack -- we clear the "g_ptr->o_idx" field for every grid,
+ * Hack -- we clear the "grid.o_idx" field for every grid,
  * and the "m_ptr->next_o_idx" field for every monster, since
  * we know we are clearing every object.  Technically, we only
  * clear those fields for grids/monsters containing objects,

--- a/src/floor/object-allocator.cpp
+++ b/src/floor/object-allocator.cpp
@@ -113,7 +113,6 @@ bool alloc_stairs(PlayerType *player_ptr, FEAT_IDX feat, int num, int walls)
 
     for (int i = 0; i < num; i++) {
         while (true) {
-            Grid *g_ptr;
             int candidates = 0;
             const POSITION max_x = floor.width - 1;
             for (POSITION y = 1; y < floor.height - 1; y++) {
@@ -151,7 +150,7 @@ bool alloc_stairs(PlayerType *player_ptr, FEAT_IDX feat, int num, int walls)
                 }
             }
 
-            g_ptr = &floor.grid_array[y][x];
+            auto *g_ptr = &floor.grid_array[y][x];
             g_ptr->mimic = 0;
             g_ptr->feat = (i < shaft_num) ? dungeon.convert_terrain_id(feat, TerrainCharacteristics::SHAFT) : feat;
             g_ptr->info &= ~(CAVE_FLOOR);

--- a/src/floor/object-allocator.cpp
+++ b/src/floor/object-allocator.cpp
@@ -60,8 +60,8 @@ static int next_to_walls(const FloorType &floor, POSITION y, POSITION x)
 static bool alloc_stairs_aux(PlayerType *player_ptr, POSITION y, POSITION x, int walls)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
-    auto *g_ptr = &floor.grid_array[y][x];
-    if (!g_ptr->is_floor() || pattern_tile(floor, y, x) || !g_ptr->o_idx_list.empty() || g_ptr->has_monster() || next_to_walls(floor, y, x) < walls) {
+    const auto &grid = floor.grid_array[y][x];
+    if (!grid.is_floor() || pattern_tile(floor, y, x) || !grid.o_idx_list.empty() || grid.has_monster() || next_to_walls(floor, y, x) < walls) {
         return false;
     }
 
@@ -150,10 +150,10 @@ bool alloc_stairs(PlayerType *player_ptr, FEAT_IDX feat, int num, int walls)
                 }
             }
 
-            auto *g_ptr = &floor.grid_array[y][x];
-            g_ptr->mimic = 0;
-            g_ptr->feat = (i < shaft_num) ? dungeon.convert_terrain_id(feat, TerrainCharacteristics::SHAFT) : feat;
-            g_ptr->info &= ~(CAVE_FLOOR);
+            auto &grid = floor.grid_array[y][x];
+            grid.mimic = 0;
+            grid.feat = (i < shaft_num) ? dungeon.convert_terrain_id(feat, TerrainCharacteristics::SHAFT) : feat;
+            grid.info &= ~(CAVE_FLOOR);
             break;
         }
     }

--- a/src/floor/tunnel-generator.cpp
+++ b/src/floor/tunnel-generator.cpp
@@ -372,8 +372,8 @@ bool build_tunnel2(PlayerType *player_ptr, DungeonData *dd_ptr, const Pos2D &pos
         pos.y = (pos_start.y + pos_end.y) / 2;
     }
 
-    const auto *g_ptr = &floor.get_grid(pos);
-    if (g_ptr->is_solid()) {
+    const auto *grid_ptr = &floor.get_grid(pos);
+    if (grid_ptr->is_solid()) {
         auto i = 50;
         vec = { 0, 0 };
         while ((i > 0) && floor.get_grid(pos + vec).is_solid()) {
@@ -394,12 +394,12 @@ bool build_tunnel2(PlayerType *player_ptr, DungeonData *dd_ptr, const Pos2D &pos
         }
 
         pos += vec;
-        g_ptr = &floor.get_grid(pos);
+        grid_ptr = &floor.get_grid(pos);
     }
 
     bool is_tunnel_built;
     bool is_successful;
-    if (g_ptr->is_floor()) {
+    if (grid_ptr->is_floor()) {
         if (build_tunnel2(player_ptr, dd_ptr, pos_start, pos, type, cutoff)) {
             if (floor.get_grid(pos).is_room() || (randint1(100) > 95)) {
                 is_tunnel_built = build_tunnel2(player_ptr, dd_ptr, pos, pos_end, type, cutoff);

--- a/src/floor/tunnel-generator.cpp
+++ b/src/floor/tunnel-generator.cpp
@@ -216,7 +216,7 @@ static bool set_tunnel(PlayerType *player_ptr, DungeonData *dd_ptr, POSITION *y,
         }
 
         if (i == 0) {
-            place_grid(player_ptr, &grid, GB_OUTER);
+            place_grid(player_ptr, grid, GB_OUTER);
             vec = { 0, 0 };
         }
 

--- a/src/grid/feature-generator.cpp
+++ b/src/grid/feature-generator.cpp
@@ -122,8 +122,8 @@ static int next_to_corr(const FloorType &floor, POSITION y1, POSITION x1)
     int k = 0;
     for (const auto &d : Direction::directions_4()) {
         const auto pos = Pos2D(y1, x1) + d.vec();
-        const auto *g_ptr = &floor.get_grid(pos);
-        if (g_ptr->has(TerrainCharacteristics::WALL) || !g_ptr->is_floor() || g_ptr->is_room()) {
+        const auto &grid = floor.get_grid(pos);
+        if (grid.has(TerrainCharacteristics::WALL) || !grid.is_floor() || grid.is_room()) {
             continue;
         }
 

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -1082,7 +1082,7 @@ void place_grid(PlayerType *player_ptr, Grid *g_ptr, grid_bold_type gb_type)
 
 void place_bold(PlayerType *player_ptr, POSITION y, POSITION x, grid_bold_type gb_type)
 {
-    Grid *const g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
+    auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
     place_grid(player_ptr, g_ptr, gb_type);
 }
 

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -993,81 +993,81 @@ bool player_can_enter(PlayerType *player_ptr, FEAT_IDX feature, BIT_FLAGS16 mode
     return true;
 }
 
-void place_grid(PlayerType *player_ptr, Grid *g_ptr, grid_bold_type gb_type)
+void place_grid(PlayerType *player_ptr, Grid &grid, grid_bold_type gb_type)
 {
     const auto &dungeon = player_ptr->current_floor_ptr->get_dungeon_definition();
     switch (gb_type) {
     case GB_FLOOR: {
-        g_ptr->set_terrain_id(dungeon.select_floor_terrain_id());
-        g_ptr->info &= ~(CAVE_MASK);
-        g_ptr->info |= CAVE_FLOOR;
+        grid.set_terrain_id(dungeon.select_floor_terrain_id());
+        grid.info &= ~(CAVE_MASK);
+        grid.info |= CAVE_FLOOR;
         break;
     }
     case GB_EXTRA: {
-        g_ptr->set_terrain_id(dungeon.select_wall_terrain_id());
-        g_ptr->info &= ~(CAVE_MASK);
-        g_ptr->info |= CAVE_EXTRA;
+        grid.set_terrain_id(dungeon.select_wall_terrain_id());
+        grid.info &= ~(CAVE_MASK);
+        grid.info |= CAVE_EXTRA;
         break;
     }
     case GB_EXTRA_PERM: {
-        g_ptr->set_terrain_id(TerrainTag::PERMANENT_WALL);
-        g_ptr->info &= ~(CAVE_MASK);
-        g_ptr->info |= CAVE_EXTRA;
+        grid.set_terrain_id(TerrainTag::PERMANENT_WALL);
+        grid.info &= ~(CAVE_MASK);
+        grid.info |= CAVE_EXTRA;
         break;
     }
     case GB_INNER: {
-        g_ptr->set_terrain_id(dungeon.inner_wall);
-        g_ptr->info &= ~(CAVE_MASK);
-        g_ptr->info |= CAVE_INNER;
+        grid.set_terrain_id(dungeon.inner_wall);
+        grid.info &= ~(CAVE_MASK);
+        grid.info |= CAVE_INNER;
         break;
     }
     case GB_INNER_PERM: {
-        g_ptr->set_terrain_id(TerrainTag::PERMANENT_WALL);
-        g_ptr->info &= ~(CAVE_MASK);
-        g_ptr->info |= CAVE_INNER;
+        grid.set_terrain_id(TerrainTag::PERMANENT_WALL);
+        grid.info &= ~(CAVE_MASK);
+        grid.info |= CAVE_INNER;
         break;
     }
     case GB_OUTER: {
-        g_ptr->set_terrain_id(dungeon.outer_wall);
-        g_ptr->info &= ~(CAVE_MASK);
-        g_ptr->info |= CAVE_OUTER;
+        grid.set_terrain_id(dungeon.outer_wall);
+        grid.info &= ~(CAVE_MASK);
+        grid.info |= CAVE_OUTER;
         break;
     }
     case GB_OUTER_NOPERM: {
         const auto &terrain = TerrainList::get_instance().get_terrain(dungeon.outer_wall);
         if (terrain.is_permanent_wall()) {
             const auto terrain_id = dungeon.convert_terrain_id(dungeon.outer_wall, TerrainCharacteristics::UNPERM);
-            g_ptr->set_terrain_id(terrain_id);
+            grid.set_terrain_id(terrain_id);
         } else {
-            g_ptr->set_terrain_id(dungeon.outer_wall);
+            grid.set_terrain_id(dungeon.outer_wall);
         }
 
-        g_ptr->info &= ~(CAVE_MASK);
-        g_ptr->info |= (CAVE_OUTER | CAVE_VAULT);
+        grid.info &= ~(CAVE_MASK);
+        grid.info |= (CAVE_OUTER | CAVE_VAULT);
         break;
     }
     case GB_SOLID: {
-        g_ptr->set_terrain_id(dungeon.outer_wall);
-        g_ptr->info &= ~(CAVE_MASK);
-        g_ptr->info |= CAVE_SOLID;
+        grid.set_terrain_id(dungeon.outer_wall);
+        grid.info &= ~(CAVE_MASK);
+        grid.info |= CAVE_SOLID;
         break;
     }
     case GB_SOLID_PERM: {
-        g_ptr->set_terrain_id(TerrainTag::PERMANENT_WALL);
-        g_ptr->info &= ~(CAVE_MASK);
-        g_ptr->info |= CAVE_SOLID;
+        grid.set_terrain_id(TerrainTag::PERMANENT_WALL);
+        grid.info &= ~(CAVE_MASK);
+        grid.info |= CAVE_SOLID;
         break;
     }
     case GB_SOLID_NOPERM: {
         const auto &terrain = TerrainList::get_instance().get_terrain(dungeon.outer_wall);
-        if ((g_ptr->info & CAVE_VAULT) && terrain.is_permanent_wall()) {
+        if ((grid.info & CAVE_VAULT) && terrain.is_permanent_wall()) {
             const auto terrain_id = dungeon.convert_terrain_id(dungeon.outer_wall, TerrainCharacteristics::UNPERM);
-            g_ptr->set_terrain_id(terrain_id);
+            grid.set_terrain_id(terrain_id);
         } else {
-            g_ptr->set_terrain_id(dungeon.outer_wall);
+            grid.set_terrain_id(dungeon.outer_wall);
         }
-        g_ptr->info &= ~(CAVE_MASK);
-        g_ptr->info |= CAVE_SOLID;
+        grid.info &= ~(CAVE_MASK);
+        grid.info |= CAVE_SOLID;
         break;
     }
     default:
@@ -1075,15 +1075,15 @@ void place_grid(PlayerType *player_ptr, Grid *g_ptr, grid_bold_type gb_type)
         return;
     }
 
-    if (g_ptr->has_monster()) {
-        delete_monster_idx(player_ptr, g_ptr->m_idx);
+    if (grid.has_monster()) {
+        delete_monster_idx(player_ptr, grid.m_idx);
     }
 }
 
 void place_bold(PlayerType *player_ptr, POSITION y, POSITION x, grid_bold_type gb_type)
 {
-    auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
-    place_grid(player_ptr, g_ptr, gb_type);
+    auto &grid = player_ptr->current_floor_ptr->grid_array[y][x];
+    place_grid(player_ptr, grid, gb_type);
 }
 
 /*
@@ -1094,12 +1094,12 @@ void place_bold(PlayerType *player_ptr, POSITION y, POSITION x, grid_bold_type g
  */
 void cave_lite_hack(FloorType &floor, POSITION y, POSITION x)
 {
-    auto *g_ptr = &floor.grid_array[y][x];
-    if (g_ptr->is_lite()) {
+    auto &grid = floor.grid_array[y][x];
+    if (grid.is_lite()) {
         return;
     }
 
-    g_ptr->info |= CAVE_LITE;
+    grid.info |= CAVE_LITE;
     floor.lite_y[floor.lite_n] = y;
     floor.lite_x[floor.lite_n++] = x;
 }
@@ -1109,12 +1109,12 @@ void cave_lite_hack(FloorType &floor, POSITION y, POSITION x)
  */
 void cave_redraw_later(FloorType &floor, POSITION y, POSITION x)
 {
-    auto *g_ptr = &floor.grid_array[y][x];
-    if (g_ptr->is_redraw()) {
+    auto &grid = floor.grid_array[y][x];
+    if (grid.is_redraw()) {
         return;
     }
 
-    g_ptr->info |= CAVE_REDRAW;
+    grid.info |= CAVE_REDRAW;
     floor.redraw_y[floor.redraw_n] = y;
     floor.redraw_x[floor.redraw_n++] = x;
 }
@@ -1130,12 +1130,12 @@ void cave_note_and_redraw_later(FloorType &floor, POSITION y, POSITION x)
 
 void cave_view_hack(FloorType &floor, POSITION y, POSITION x)
 {
-    auto *g_ptr = &floor.grid_array[y][x];
-    if (g_ptr->is_view()) {
+    auto &grid = floor.grid_array[y][x];
+    if (grid.is_view()) {
         return;
     }
 
-    g_ptr->info |= CAVE_VIEW;
+    grid.info |= CAVE_VIEW;
     floor.view_y[floor.view_n] = y;
     floor.view_x[floor.view_n] = x;
     floor.view_n++;

--- a/src/grid/grid.h
+++ b/src/grid/grid.h
@@ -76,7 +76,7 @@ void cave_alter_feat(PlayerType *player_ptr, POSITION y, POSITION x, TerrainChar
 bool check_local_illumination(PlayerType *player_ptr, POSITION y, POSITION x);
 bool cave_monster_teleportable_bold(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION y, POSITION x, teleport_flags mode);
 bool cave_player_teleportable_bold(PlayerType *player_ptr, POSITION y, POSITION x, teleport_flags mode);
-void place_grid(PlayerType *player_ptr, Grid *g_ptr, grid_bold_type pg_type);
+void place_grid(PlayerType *player_ptr, Grid &grid, grid_bold_type pg_type);
 void place_bold(PlayerType *player_ptr, POSITION y, POSITION x, grid_bold_type gh_type);
 void cave_lite_hack(FloorType &floor, POSITION y, POSITION x);
 void cave_redraw_later(FloorType &floor, POSITION y, POSITION x);

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -131,14 +131,14 @@ const std::vector<EnumClassFlagGroup<ChestTrapType>> chest_traps = {
  */
 void disclose_grid(PlayerType *player_ptr, POSITION y, POSITION x)
 {
-    auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
+    auto &grid = player_ptr->current_floor_ptr->grid_array[y][x];
 
-    if (g_ptr->has(TerrainCharacteristics::SECRET)) {
+    if (grid.has(TerrainCharacteristics::SECRET)) {
         /* No longer hidden */
         cave_alter_feat(player_ptr, y, x, TerrainCharacteristics::SECRET);
-    } else if (g_ptr->mimic) {
+    } else if (grid.mimic) {
         /* No longer hidden */
-        g_ptr->mimic = 0;
+        grid.mimic = 0;
 
         note_spot(player_ptr, y, x);
         lite_spot(player_ptr, y, x);

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -653,18 +653,18 @@ bool get_item_floor(PlayerType *player_ptr, COMMAND_CODE *cp, concptr pmt, concp
         case '\n':
         case '\r':
         case '+': {
-            auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x];
+            auto &grid = player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x];
             if (command_wrk != (USE_FLOOR)) {
                 break;
             }
 
-            if (g_ptr->o_idx_list.size() < 2) {
+            if (grid.o_idx_list.size() < 2) {
                 break;
             }
 
             const auto next_o_idx = fis_ptr->floor_list[1];
-            while (g_ptr->o_idx_list.front() != next_o_idx) {
-                g_ptr->o_idx_list.rotate(*player_ptr->current_floor_ptr);
+            while (grid.o_idx_list.front() != next_o_idx) {
+                grid.o_idx_list.rotate(*player_ptr->current_floor_ptr);
             }
 
             rfu.set_flag(SubWindowRedrawingFlag::FLOOR_ITEMS);

--- a/src/inventory/player-inventory.cpp
+++ b/src/inventory/player-inventory.cpp
@@ -247,14 +247,14 @@ void carry(PlayerType *player_ptr, bool pickup)
     rfu.set_flag(MainWindowRedrawingFlag::MAP);
     rfu.set_flag(SubWindowRedrawingFlag::OVERHEAD);
     handle_stuff(player_ptr);
-    auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x];
-    autopick_pickup_items(player_ptr, g_ptr);
+    const auto &grid = player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x];
+    autopick_pickup_items(player_ptr, grid);
     if (easy_floor) {
         py_pickup_floor(player_ptr, pickup);
         return;
     }
 
-    for (auto it = g_ptr->o_idx_list.begin(); it != g_ptr->o_idx_list.end();) {
+    for (auto it = grid.o_idx_list.begin(); it != grid.o_idx_list.end();) {
         const OBJECT_IDX this_o_idx = *it++;
         auto &item = player_ptr->current_floor_ptr->o_list[this_o_idx];
         const auto item_name = describe_flavor(player_ptr, item, 0);

--- a/src/io/cursor.cpp
+++ b/src/io/cursor.cpp
@@ -48,10 +48,10 @@ void print_path(PlayerType *player_ptr, POSITION y, POSITION x)
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::MAP);
     handle_stuff(player_ptr);
     for (const auto &pos_path : path_g) {
-        auto *g_ptr = &floor.get_grid(pos_path);
+        const auto &grid = floor.get_grid(pos_path);
         if (panel_contains(pos_path.y, pos_path.x)) {
             DisplaySymbolPair symbol_pair({ default_color, '\0' }, { default_color, '*' });
-            if (g_ptr->has_monster() && floor.m_list[g_ptr->m_idx].ml) {
+            if (grid.has_monster() && floor.m_list[grid.m_idx].ml) {
                 symbol_pair = map_info(player_ptr, pos_path);
                 auto &symbol_foreground = symbol_pair.symbol_foreground;
                 if (!symbol_foreground.is_ascii_graphics()) {
@@ -68,7 +68,7 @@ void print_path(PlayerType *player_ptr, POSITION y, POSITION x)
             term_queue_bigchar(panel_col_of(pos_path.x), pos_path.y - panel_row_prt, symbol_pair);
         }
 
-        if (g_ptr->is_mark() && !g_ptr->has(TerrainCharacteristics::PROJECT)) {
+        if (grid.is_mark() && !grid.has(TerrainCharacteristics::PROJECT)) {
             break;
         }
 

--- a/src/load/floor-loader.cpp
+++ b/src/load/floor-loader.cpp
@@ -126,11 +126,11 @@ errr rd_saved_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr)
         } while (tmp8u == MAX_UCHAR);
 
         for (int i = count; i > 0; i--) {
-            auto *g_ptr = &floor.grid_array[y][x];
-            g_ptr->info = templates[id].info;
-            g_ptr->feat = templates[id].feat;
-            g_ptr->mimic = templates[id].mimic;
-            g_ptr->special = templates[id].special;
+            auto &grid = floor.grid_array[y][x];
+            grid.info = templates[id].info;
+            grid.feat = templates[id].feat;
+            grid.mimic = templates[id].mimic;
+            grid.special = templates[id].special;
 
             if (++x >= xmax) {
                 x = 0;

--- a/src/mind/mind-mirror-master.cpp
+++ b/src/mind/mind-mirror-master.cpp
@@ -371,10 +371,10 @@ bool cast_mirror_spell(PlayerType *player_ptr, MindMirrorMasterType spell)
     int tmp;
     TIME_EFFECT t;
     POSITION x, y;
-    auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x];
+    const auto &grid = player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x];
     switch (spell) {
     case MindMirrorMasterType::MIRROR_SEEING:
-        tmp = g_ptr->is_mirror() ? 4 : 0;
+        tmp = grid.is_mirror() ? 4 : 0;
         if (plev + tmp > 4) {
             detect_monsters_normal(player_ptr, DETECT_RAD_DEFAULT);
         }
@@ -407,7 +407,7 @@ bool cast_mirror_spell(PlayerType *player_ptr, MindMirrorMasterType spell)
             return false;
         }
 
-        if (plev > 9 && g_ptr->is_mirror()) {
+        if (plev > 9 && grid.is_mirror()) {
             fire_beam(player_ptr, AttributeType::LITE, dir, Dice::roll(3 + ((plev - 1) / 5), 4));
         } else {
             fire_bolt(player_ptr, AttributeType::LITE, dir, Dice::roll(3 + ((plev - 1) / 5), 4));
@@ -481,7 +481,7 @@ bool cast_mirror_spell(PlayerType *player_ptr, MindMirrorMasterType spell)
         SpellsMirrorMaster(player_ptr).super_ray(dir, 150 + randint1(2 * plev));
         break;
     case MindMirrorMasterType::ILLUSION_LIGHT:
-        tmp = g_ptr->is_mirror() ? 4 : 3;
+        tmp = grid.is_mirror() ? 4 : 3;
         slow_monsters(player_ptr, plev);
         stun_monsters(player_ptr, plev * tmp * 2);
         confuse_monsters(player_ptr, plev * tmp);
@@ -489,7 +489,7 @@ bool cast_mirror_spell(PlayerType *player_ptr, MindMirrorMasterType spell)
         stasis_monsters(player_ptr, plev * tmp);
         break;
     case MindMirrorMasterType::MIRROR_SHIFT:
-        if (!g_ptr->is_mirror()) {
+        if (!grid.is_mirror()) {
             msg_print(_("鏡の国の場所がわからない！", "You cannot find out where the mirror is!"));
             break;
         }

--- a/src/mind/monk-attack.cpp
+++ b/src/mind/monk-attack.cpp
@@ -219,7 +219,7 @@ static void process_attack_vital_spot(PlayerType *player_ptr, player_attack_type
  * @brief 朦朧効果を受けたモンスターのステータス表示
  * @param player_ptr プレイヤーの参照ポインタ
  * @param pa_ptr 直接攻撃構造体への参照ポインタ
- * @param g_ptr グリッドへの参照ポインタ
+ * @param grid グリッドへの参照
  * @param stun_effect 朦朧の残りターン
  * @param resist_stun 朦朧への抵抗値
  */
@@ -241,7 +241,7 @@ static void print_stun_effect(PlayerType *player_ptr, player_attack_type *pa_ptr
  * @brief 強力な素手攻撃ができる職業 (修行僧、狂戦士、練気術師)の素手攻撃処理メインルーチン
  * @param player_ptr プレイヤーの参照ポインタ
  * @param pa_ptr 直接攻撃構造体への参照ポインタ
- * @param g_ptr グリッドへの参照ポインタ
+ * @param grid グリッドへの参照
  */
 void process_monk_attack(PlayerType *player_ptr, player_attack_type *pa_ptr)
 {

--- a/src/monster-attack/monster-attack-processor.cpp
+++ b/src/monster-attack/monster-attack-processor.cpp
@@ -72,12 +72,12 @@ void exe_monster_attack_to_player(PlayerType *player_ptr, turn_flags *turn_flags
  * @param m_idx モンスターID
  * @param g_ptr グリッドへの参照ポインタ
  */
-static bool exe_monster_attack_to_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, Grid *g_ptr)
+static bool exe_monster_attack_to_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, const Grid &grid)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
     const auto &monster = floor.m_list[m_idx];
     auto &monrace = monster.get_monrace();
-    const auto &monster_target = player_ptr->current_floor_ptr->m_list[g_ptr->m_idx];
+    const auto &monster_target = player_ptr->current_floor_ptr->m_list[grid.m_idx];
     if (monrace.behavior_flags.has(MonsterBehaviorType::NEVER_BLOW)) {
         return false;
     }
@@ -89,7 +89,7 @@ static bool exe_monster_attack_to_monster(PlayerType *player_ptr, MONSTER_IDX m_
     if (!monster_target.is_valid() || (monster_target.hp < 0)) {
         return false;
     }
-    if (monst_attack_monst(player_ptr, m_idx, g_ptr->m_idx)) {
+    if (monst_attack_monst(player_ptr, m_idx, grid.m_idx)) {
         return true;
     }
     if (floor.get_dungeon_definition().flags.has_not(DungeonFeatureType::NO_MELEE)) {
@@ -118,22 +118,22 @@ static bool exe_monster_attack_to_monster(PlayerType *player_ptr, MONSTER_IDX m_
  * @param can_cross モンスターが地形を踏破できるならばTRUE
  * @return ターン消費が発生したらTRUE
  */
-bool process_monster_attack_to_monster(PlayerType *player_ptr, turn_flags *turn_flags_ptr, MONSTER_IDX m_idx, Grid *g_ptr, bool can_cross)
+bool process_monster_attack_to_monster(PlayerType *player_ptr, turn_flags *turn_flags_ptr, MONSTER_IDX m_idx, const Grid &grid, bool can_cross)
 {
-    if (!turn_flags_ptr->do_move || !g_ptr->has_monster()) {
+    if (!turn_flags_ptr->do_move || !grid.has_monster()) {
         return false;
     }
 
     turn_flags_ptr->do_move = false;
     const auto &monster_from = player_ptr->current_floor_ptr->m_list[m_idx];
     const auto &monrace_from = monster_from.get_monrace();
-    const auto &monster_to = player_ptr->current_floor_ptr->m_list[g_ptr->m_idx];
+    const auto &monster_to = player_ptr->current_floor_ptr->m_list[grid.m_idx];
     const auto &monrace_to = monster_to.get_monrace();
     auto do_kill_body = monrace_from.behavior_flags.has(MonsterBehaviorType::KILL_BODY) && monrace_from.behavior_flags.has_not(MonsterBehaviorType::NEVER_BLOW);
     do_kill_body &= (monrace_from.mexp * monrace_from.level > monrace_to.mexp * monrace_to.level);
     do_kill_body &= !monster_to.is_riding();
     if (do_kill_body || monster_from.is_hostile_to_melee(monster_to) || monster_from.is_confused()) {
-        return exe_monster_attack_to_monster(player_ptr, m_idx, g_ptr);
+        return exe_monster_attack_to_monster(player_ptr, m_idx, grid);
     }
 
     auto do_move_body = monrace_from.behavior_flags.has(MonsterBehaviorType::MOVE_BODY) && monrace_from.behavior_flags.has_not(MonsterBehaviorType::NEVER_MOVE);
@@ -144,7 +144,7 @@ bool process_monster_attack_to_monster(PlayerType *player_ptr, turn_flags *turn_
     if (do_move_body) {
         turn_flags_ptr->do_move = true;
         turn_flags_ptr->did_move_body = true;
-        (void)set_monster_csleep(player_ptr, g_ptr->m_idx, 0);
+        (void)set_monster_csleep(player_ptr, grid.m_idx, 0);
     }
 
     return false;

--- a/src/monster-attack/monster-attack-processor.cpp
+++ b/src/monster-attack/monster-attack-processor.cpp
@@ -70,7 +70,7 @@ void exe_monster_attack_to_player(PlayerType *player_ptr, turn_flags *turn_flags
  * @brief モンスターからモンスターへの直接攻撃を実行する
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param m_idx モンスターID
- * @param g_ptr グリッドへの参照ポインタ
+ * @param grid グリッドへの参照
  */
 static bool exe_monster_attack_to_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, const Grid &grid)
 {
@@ -114,7 +114,7 @@ static bool exe_monster_attack_to_monster(PlayerType *player_ptr, MONSTER_IDX m_
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param turn_flags_ptr ターン経過処理フラグへの参照ポインタ
  * @param m_idx モンスターID
- * @param g_ptr グリッドへの参照ポインタ
+ * @param grid グリッドへの参照
  * @param can_cross モンスターが地形を踏破できるならばTRUE
  * @return ターン消費が発生したらTRUE
  */

--- a/src/monster-attack/monster-attack-processor.h
+++ b/src/monster-attack/monster-attack-processor.h
@@ -7,4 +7,4 @@ class Grid;
 class PlayerType;
 struct turn_flags;
 void exe_monster_attack_to_player(PlayerType *player_ptr, turn_flags *turn_flags_ptr, MONSTER_IDX m_idx, const Pos2D &pos);
-bool process_monster_attack_to_monster(PlayerType *player_ptr, turn_flags *turn_flags_ptr, MONSTER_IDX m_idx, Grid *g_ptr, bool can_cross);
+bool process_monster_attack_to_monster(PlayerType *player_ptr, turn_flags *turn_flags_ptr, MONSTER_IDX m_idx, const Grid &grid, bool can_cross);

--- a/src/monster-floor/monster-lite.cpp
+++ b/src/monster-floor/monster-lite.cpp
@@ -367,8 +367,7 @@ void update_mon_lite(PlayerType *player_ptr)
 void clear_mon_lite(FloorType &floor)
 {
     for (int i = 0; i < floor.mon_lite_n; i++) {
-        Grid *g_ptr;
-        g_ptr = &floor.grid_array[floor.mon_lite_y[i]][floor.mon_lite_x[i]];
+        auto *g_ptr = &floor.grid_array[floor.mon_lite_y[i]][floor.mon_lite_x[i]];
         g_ptr->info &= ~(CAVE_MNLT | CAVE_MNDK);
     }
 

--- a/src/monster-floor/monster-lite.cpp
+++ b/src/monster-floor/monster-lite.cpp
@@ -367,8 +367,8 @@ void update_mon_lite(PlayerType *player_ptr)
 void clear_mon_lite(FloorType &floor)
 {
     for (int i = 0; i < floor.mon_lite_n; i++) {
-        auto *g_ptr = &floor.grid_array[floor.mon_lite_y[i]][floor.mon_lite_x[i]];
-        g_ptr->info &= ~(CAVE_MNLT | CAVE_MNDK);
+        auto &grid = floor.grid_array[floor.mon_lite_y[i]][floor.mon_lite_x[i]];
+        grid.info &= ~(CAVE_MNLT | CAVE_MNDK);
     }
 
     floor.mon_lite_n = 0;

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -418,7 +418,7 @@ bool process_monster_movement(PlayerType *player_ptr, turn_flags *turn_flags_ptr
         }
 
         exe_monster_attack_to_player(player_ptr, turn_flags_ptr, m_idx, pos_neighbor);
-        if (process_monster_attack_to_monster(player_ptr, turn_flags_ptr, m_idx, &grid, can_cross)) {
+        if (process_monster_attack_to_monster(player_ptr, turn_flags_ptr, m_idx, grid, can_cross)) {
             return false;
         }
 

--- a/src/monster-floor/monster-object.cpp
+++ b/src/monster-floor/monster-object.cpp
@@ -181,9 +181,9 @@ void update_object_by_monster_movement(PlayerType *player_ptr, turn_flags *turn_
 {
     auto *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
     auto *r_ptr = &m_ptr->get_monrace();
-    auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[ny][nx];
+    const auto &grid = player_ptr->current_floor_ptr->grid_array[ny][nx];
     turn_flags_ptr->do_take = r_ptr->behavior_flags.has(MonsterBehaviorType::TAKE_ITEM);
-    for (auto it = g_ptr->o_idx_list.begin(); it != g_ptr->o_idx_list.end();) {
+    for (auto it = grid.o_idx_list.begin(); it != grid.o_idx_list.end();) {
         EnumClassFlagGroup<MonsterKindType> flg_monster_kind;
         EnumClassFlagGroup<MonsterResistanceType> flgr;
         OBJECT_IDX this_o_idx = *it++;

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -69,20 +69,20 @@ struct um_type {
 bool update_riding_monster(PlayerType *player_ptr, turn_flags *turn_flags_ptr, MONSTER_IDX m_idx, POSITION oy, POSITION ox, POSITION ny, POSITION nx)
 {
     auto *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
-    auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[ny][nx];
-    MonsterEntity *y_ptr = &player_ptr->current_floor_ptr->m_list[g_ptr->m_idx];
+    auto &grid = player_ptr->current_floor_ptr->grid_array[ny][nx];
+    MonsterEntity *y_ptr = &player_ptr->current_floor_ptr->m_list[grid.m_idx];
     if (turn_flags_ptr->is_riding_mon) {
         return move_player_effect(player_ptr, ny, nx, MPE_DONT_PICKUP);
     }
 
-    player_ptr->current_floor_ptr->grid_array[oy][ox].m_idx = g_ptr->m_idx;
-    if (g_ptr->has_monster()) {
+    player_ptr->current_floor_ptr->grid_array[oy][ox].m_idx = grid.m_idx;
+    if (grid.has_monster()) {
         y_ptr->fy = oy;
         y_ptr->fx = ox;
-        update_monster(player_ptr, g_ptr->m_idx, true);
+        update_monster(player_ptr, grid.m_idx, true);
     }
 
-    g_ptr->m_idx = m_idx;
+    grid.m_idx = m_idx;
     m_ptr->fy = ny;
     m_ptr->fx = nx;
     update_monster(player_ptr, m_idx, true);

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -361,13 +361,13 @@ bool process_warning(PlayerType *player_ptr, POSITION xx, POSITION yy)
                 continue;
             }
 
-            const auto *g_ptr = &floor.grid_array[my][mx];
+            const auto &grid = floor.grid_array[my][mx];
 
-            if (!g_ptr->has_monster()) {
+            if (!grid.has_monster()) {
                 continue;
             }
 
-            auto *m_ptr = &floor.m_list[g_ptr->m_idx];
+            auto *m_ptr = &floor.m_list[grid.m_idx];
 
             if (m_ptr->is_asleep()) {
                 continue;
@@ -384,105 +384,105 @@ bool process_warning(PlayerType *player_ptr, POSITION xx, POSITION yy)
 
                 if (dungeon.flags.has_not(DungeonFeatureType::NO_MAGIC)) {
                     if (flags.has(MonsterAbilityType::BA_CHAO)) {
-                        spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BA_CHAO, AttributeType::CHAOS, g_ptr->m_idx, &dam_max0);
+                        spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BA_CHAO, AttributeType::CHAOS, grid.m_idx, &dam_max0);
                     }
                     if (flags.has(MonsterAbilityType::BA_MANA)) {
-                        spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BA_MANA, AttributeType::MANA, g_ptr->m_idx, &dam_max0);
+                        spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BA_MANA, AttributeType::MANA, grid.m_idx, &dam_max0);
                     }
                     if (flags.has(MonsterAbilityType::BA_DARK)) {
-                        spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BA_DARK, AttributeType::DARK, g_ptr->m_idx, &dam_max0);
+                        spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BA_DARK, AttributeType::DARK, grid.m_idx, &dam_max0);
                     }
                     if (flags.has(MonsterAbilityType::BA_LITE)) {
-                        spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BA_LITE, AttributeType::LITE, g_ptr->m_idx, &dam_max0);
+                        spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BA_LITE, AttributeType::LITE, grid.m_idx, &dam_max0);
                     }
                     if (flags.has(MonsterAbilityType::HAND_DOOM)) {
-                        spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::HAND_DOOM, AttributeType::HAND_DOOM, g_ptr->m_idx, &dam_max0);
+                        spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::HAND_DOOM, AttributeType::HAND_DOOM, grid.m_idx, &dam_max0);
                     }
                     if (flags.has(MonsterAbilityType::PSY_SPEAR)) {
-                        spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::PSY_SPEAR, AttributeType::PSY_SPEAR, g_ptr->m_idx, &dam_max0);
+                        spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::PSY_SPEAR, AttributeType::PSY_SPEAR, grid.m_idx, &dam_max0);
                     }
                     if (flags.has(MonsterAbilityType::BA_VOID)) {
-                        spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BA_VOID, AttributeType::VOID_MAGIC, g_ptr->m_idx, &dam_max0);
+                        spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BA_VOID, AttributeType::VOID_MAGIC, grid.m_idx, &dam_max0);
                     }
                     if (flags.has(MonsterAbilityType::BA_ABYSS)) {
-                        spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BA_ABYSS, AttributeType::ABYSS, g_ptr->m_idx, &dam_max0);
+                        spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BA_ABYSS, AttributeType::ABYSS, grid.m_idx, &dam_max0);
                     }
                 }
 
                 if (flags.has(MonsterAbilityType::ROCKET)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::ROCKET, AttributeType::ROCKET, g_ptr->m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::ROCKET, AttributeType::ROCKET, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_ACID)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_ACID, AttributeType::ACID, g_ptr->m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_ACID, AttributeType::ACID, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_ELEC)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_ELEC, AttributeType::ELEC, g_ptr->m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_ELEC, AttributeType::ELEC, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_FIRE)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_FIRE, AttributeType::FIRE, g_ptr->m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_FIRE, AttributeType::FIRE, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_COLD)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_COLD, AttributeType::COLD, g_ptr->m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_COLD, AttributeType::COLD, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_POIS)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_POIS, AttributeType::POIS, g_ptr->m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_POIS, AttributeType::POIS, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_NETH)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_NETH, AttributeType::NETHER, g_ptr->m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_NETH, AttributeType::NETHER, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_LITE)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_LITE, AttributeType::LITE, g_ptr->m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_LITE, AttributeType::LITE, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_DARK)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_DARK, AttributeType::DARK, g_ptr->m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_DARK, AttributeType::DARK, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_CONF)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_CONF, AttributeType::CONFUSION, g_ptr->m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_CONF, AttributeType::CONFUSION, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_SOUN)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_SOUN, AttributeType::SOUND, g_ptr->m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_SOUN, AttributeType::SOUND, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_CHAO)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_CHAO, AttributeType::CHAOS, g_ptr->m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_CHAO, AttributeType::CHAOS, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_DISE)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_DISE, AttributeType::DISENCHANT, g_ptr->m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_DISE, AttributeType::DISENCHANT, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_NEXU)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_NEXU, AttributeType::NEXUS, g_ptr->m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_NEXU, AttributeType::NEXUS, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_TIME)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_TIME, AttributeType::TIME, g_ptr->m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_TIME, AttributeType::TIME, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_INER)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_INER, AttributeType::INERTIAL, g_ptr->m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_INER, AttributeType::INERTIAL, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_GRAV)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_GRAV, AttributeType::GRAVITY, g_ptr->m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_GRAV, AttributeType::GRAVITY, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_SHAR)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_SHAR, AttributeType::SHARDS, g_ptr->m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_SHAR, AttributeType::SHARDS, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_PLAS)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_PLAS, AttributeType::PLASMA, g_ptr->m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_PLAS, AttributeType::PLASMA, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_FORC)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_FORC, AttributeType::FORCE, g_ptr->m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_FORC, AttributeType::FORCE, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_MANA)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_MANA, AttributeType::MANA, g_ptr->m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_MANA, AttributeType::MANA, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_NUKE)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_NUKE, AttributeType::NUKE, g_ptr->m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_NUKE, AttributeType::NUKE, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_DISI)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_DISI, AttributeType::DISINTEGRATE, g_ptr->m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_DISI, AttributeType::DISINTEGRATE, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_VOID)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_VOID, AttributeType::VOID_MAGIC, g_ptr->m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_VOID, AttributeType::VOID_MAGIC, grid.m_idx, &dam_max0);
                 }
                 if (flags.has(MonsterAbilityType::BR_ABYSS)) {
-                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_ABYSS, AttributeType::ABYSS, g_ptr->m_idx, &dam_max0);
+                    spell_damcalc_by_spellnum(player_ptr, MonsterAbilityType::BR_ABYSS, AttributeType::ABYSS, grid.m_idx, &dam_max0);
                 }
             }
             /* Monster melee attacks */

--- a/src/pet/pet-fall-off.cpp
+++ b/src/pet/pet-fall-off.cpp
@@ -107,20 +107,20 @@ bool process_fall_off_horse(PlayerType *player_ptr, int dam, bool force)
         for (const auto &d : Direction::directions_8()) {
             const auto pos = player_ptr->get_position() + d.vec();
 
-            auto *g_ptr = &player_ptr->current_floor_ptr->get_grid(pos);
+            const auto &grid = player_ptr->current_floor_ptr->get_grid(pos);
 
-            if (g_ptr->has_monster()) {
+            if (grid.has_monster()) {
                 continue;
             }
 
             /* Skip non-empty grids */
-            if (!g_ptr->has(TerrainCharacteristics::MOVE) && !g_ptr->has(TerrainCharacteristics::CAN_FLY)) {
-                if (!can_player_ride_pet(player_ptr, g_ptr, false)) {
+            if (!grid.has(TerrainCharacteristics::MOVE) && !grid.has(TerrainCharacteristics::CAN_FLY)) {
+                if (!can_player_ride_pet(player_ptr, grid, false)) {
                     continue;
                 }
             }
 
-            if (g_ptr->has(TerrainCharacteristics::PATTERN)) {
+            if (grid.has(TerrainCharacteristics::PATTERN)) {
                 continue;
             }
 

--- a/src/pet/pet-fall-off.cpp
+++ b/src/pet/pet-fall-off.cpp
@@ -107,8 +107,7 @@ bool process_fall_off_horse(PlayerType *player_ptr, int dam, bool force)
         for (const auto &d : Direction::directions_8()) {
             const auto pos = player_ptr->get_position() + d.vec();
 
-            Grid *g_ptr;
-            g_ptr = &player_ptr->current_floor_ptr->get_grid(pos);
+            auto *g_ptr = &player_ptr->current_floor_ptr->get_grid(pos);
 
             if (g_ptr->has_monster()) {
                 continue;

--- a/src/pet/pet-util.cpp
+++ b/src/pet/pet-util.cpp
@@ -17,7 +17,7 @@ int total_friends = 0;
 
 /*!
  * @brief プレイヤーの騎乗/下馬処理判定
- * @param g_ptr プレイヤーの移動先マスの構造体参照ポインタ
+ * @param grid プレイヤーの移動先グリッドへの参照
  * @param now_riding trueなら下馬処理、falseならば騎乗処理
  * @return 可能ならばtrueを返す
  */

--- a/src/pet/pet-util.cpp
+++ b/src/pet/pet-util.cpp
@@ -21,7 +21,7 @@ int total_friends = 0;
  * @param now_riding trueなら下馬処理、falseならば騎乗処理
  * @return 可能ならばtrueを返す
  */
-bool can_player_ride_pet(PlayerType *player_ptr, const Grid *g_ptr, bool now_riding)
+bool can_player_ride_pet(PlayerType *player_ptr, const Grid &grid, bool now_riding)
 {
     auto &world = AngbandWorld::get_instance();
     const auto old_character_xtra = world.character_xtra;
@@ -32,7 +32,7 @@ bool can_player_ride_pet(PlayerType *player_ptr, const Grid *g_ptr, bool now_rid
     world.character_xtra = true;
 
     if (now_riding) {
-        player_ptr->ride_monster(g_ptr->m_idx);
+        player_ptr->ride_monster(grid.m_idx);
     } else {
         player_ptr->ride_monster(0);
         player_ptr->pet_extra_flags &= ~(PF_TWO_HANDS);
@@ -43,7 +43,7 @@ bool can_player_ride_pet(PlayerType *player_ptr, const Grid *g_ptr, bool now_rid
     rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
 
-    bool p_can_enter = player_can_enter(player_ptr, g_ptr->feat, CEM_P_CAN_ENTER_PATTERN);
+    bool p_can_enter = player_can_enter(player_ptr, grid.feat, CEM_P_CAN_ENTER_PATTERN);
     player_ptr->ride_monster(old_riding);
     if (old_pf_two_hands) {
         player_ptr->pet_extra_flags |= (PF_TWO_HANDS);

--- a/src/pet/pet-util.h
+++ b/src/pet/pet-util.h
@@ -44,5 +44,5 @@ extern int total_friends;
 
 class Grid;
 class PlayerType;
-bool can_player_ride_pet(PlayerType *player_ptr, const Grid *g_ptr, bool now_riding);
+bool can_player_ride_pet(PlayerType *player_ptr, const Grid &grid, bool now_riding);
 PERCENTAGE calculate_upkeep(PlayerType *player_ptr);

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -157,21 +157,21 @@ static void delayed_visual_update(PlayerType *player_ptr)
     for (int i = 0; i < floor.redraw_n; i++) {
         POSITION y = floor.redraw_y[i];
         POSITION x = floor.redraw_x[i];
-        auto *g_ptr = &floor.grid_array[y][x];
-        if (none_bits(g_ptr->info, CAVE_REDRAW)) {
+        auto &grid = floor.grid_array[y][x];
+        if (none_bits(grid.info, CAVE_REDRAW)) {
             continue;
         }
 
-        if (any_bits(g_ptr->info, CAVE_NOTE)) {
+        if (any_bits(grid.info, CAVE_NOTE)) {
             note_spot(player_ptr, y, x);
         }
 
         lite_spot(player_ptr, y, x);
-        if (g_ptr->has_monster()) {
-            update_monster(player_ptr, g_ptr->m_idx, false);
+        if (grid.has_monster()) {
+            update_monster(player_ptr, grid.m_idx, false);
         }
 
-        reset_bits(g_ptr->info, (CAVE_NOTE | CAVE_REDRAW));
+        reset_bits(grid.info, (CAVE_NOTE | CAVE_REDRAW));
     }
 
     floor.redraw_n = 0;

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -157,8 +157,7 @@ static void delayed_visual_update(PlayerType *player_ptr)
     for (int i = 0; i < floor.redraw_n; i++) {
         POSITION y = floor.redraw_y[i];
         POSITION x = floor.redraw_x[i];
-        Grid *g_ptr;
-        g_ptr = &floor.grid_array[y][x];
+        auto *g_ptr = &floor.grid_array[y][x];
         if (none_bits(g_ptr->info, CAVE_REDRAW)) {
             continue;
         }

--- a/src/player/player-view.cpp
+++ b/src/player/player-view.cpp
@@ -45,12 +45,12 @@ static bool update_view_aux(PlayerType *player_ptr, POSITION y, POSITION x, POSI
         return true;
     }
 
-    auto *g_ptr = &floor.grid_array[y][x];
-    bool wall = !g_ptr->has_los_terrain();
+    auto &grid = floor.grid_array[y][x];
+    bool wall = !grid.has_los_terrain();
     bool z1 = (v1 && (g1_c_ptr->info & CAVE_XTRA));
     bool z2 = (v2 && (g2_c_ptr->info & CAVE_XTRA));
     if (z1 && z2) {
-        g_ptr->info |= CAVE_XTRA;
+        grid.info |= CAVE_XTRA;
         cave_view_hack(floor, y, x);
         return wall;
     }
@@ -123,9 +123,9 @@ void update_view(PlayerType *player_ptr)
     for (n = 0; n < floor.view_n; n++) {
         y = floor.view_y[n];
         x = floor.view_x[n];
-        auto *g_ptr = &floor.grid_array[y][x];
-        g_ptr->info &= ~(CAVE_VIEW);
-        g_ptr->info |= CAVE_TEMP;
+        auto &grid = floor.grid_array[y][x];
+        grid.info &= ~(CAVE_VIEW);
+        grid.info |= CAVE_TEMP;
 
         points.emplace_back(y, x);
     }
@@ -134,83 +134,83 @@ void update_view(PlayerType *player_ptr)
         floor.view_n = 0;
         y = player_ptr->y;
         x = player_ptr->x;
-        auto *g_ptr = &floor.grid_array[y][x];
-        g_ptr->info |= CAVE_XTRA;
+        auto &grid = floor.grid_array[y][x];
+        grid.info |= CAVE_XTRA;
         cave_view_hack(floor, y, x);
     }
 
     z = full * 2 / 3;
     for (d = 1; d <= z; d++) {
-        auto *g_ptr = &floor.grid_array[y + d][x + d];
-        g_ptr->info |= CAVE_XTRA;
+        auto &grid = floor.grid_array[y + d][x + d];
+        grid.info |= CAVE_XTRA;
         cave_view_hack(floor, y + d, x + d);
-        if (!g_ptr->has_los_terrain()) {
+        if (!grid.has_los_terrain()) {
             break;
         }
     }
 
     for (d = 1; d <= z; d++) {
-        auto *g_ptr = &floor.grid_array[y + d][x - d];
-        g_ptr->info |= CAVE_XTRA;
+        auto &grid = floor.grid_array[y + d][x - d];
+        grid.info |= CAVE_XTRA;
         cave_view_hack(floor, y + d, x - d);
-        if (!g_ptr->has_los_terrain()) {
+        if (!grid.has_los_terrain()) {
             break;
         }
     }
 
     for (d = 1; d <= z; d++) {
-        auto *g_ptr = &floor.grid_array[y - d][x + d];
-        g_ptr->info |= CAVE_XTRA;
+        auto &grid = floor.grid_array[y - d][x + d];
+        grid.info |= CAVE_XTRA;
         cave_view_hack(floor, y - d, x + d);
-        if (!g_ptr->has_los_terrain()) {
+        if (!grid.has_los_terrain()) {
             break;
         }
     }
 
     for (d = 1; d <= z; d++) {
-        auto *g_ptr = &floor.grid_array[y - d][x - d];
-        g_ptr->info |= CAVE_XTRA;
+        auto &grid = floor.grid_array[y - d][x - d];
+        grid.info |= CAVE_XTRA;
         cave_view_hack(floor, y - d, x - d);
-        if (!g_ptr->has_los_terrain()) {
+        if (!grid.has_los_terrain()) {
             break;
         }
     }
 
     for (d = 1; d <= full; d++) {
-        auto *g_ptr = &floor.grid_array[y + d][x];
-        g_ptr->info |= CAVE_XTRA;
+        auto &grid = floor.grid_array[y + d][x];
+        grid.info |= CAVE_XTRA;
         cave_view_hack(floor, y + d, x);
-        if (!g_ptr->has_los_terrain()) {
+        if (!grid.has_los_terrain()) {
             break;
         }
     }
 
     se = sw = d;
     for (d = 1; d <= full; d++) {
-        auto *g_ptr = &floor.grid_array[y - d][x];
-        g_ptr->info |= CAVE_XTRA;
+        auto &grid = floor.grid_array[y - d][x];
+        grid.info |= CAVE_XTRA;
         cave_view_hack(floor, y - d, x);
-        if (!g_ptr->has_los_terrain()) {
+        if (!grid.has_los_terrain()) {
             break;
         }
     }
 
     ne = nw = d;
     for (d = 1; d <= full; d++) {
-        auto *g_ptr = &floor.grid_array[y][x + d];
-        g_ptr->info |= CAVE_XTRA;
+        auto &grid = floor.grid_array[y][x + d];
+        grid.info |= CAVE_XTRA;
         cave_view_hack(floor, y, x + d);
-        if (!g_ptr->has_los_terrain()) {
+        if (!grid.has_los_terrain()) {
             break;
         }
     }
 
     es = en = d;
     for (d = 1; d <= full; d++) {
-        auto *g_ptr = &floor.grid_array[y][x - d];
-        g_ptr->info |= CAVE_XTRA;
+        auto &grid = floor.grid_array[y][x - d];
+        grid.info |= CAVE_XTRA;
         cave_view_hack(floor, y, x - d);
-        if (!g_ptr->has_los_terrain()) {
+        if (!grid.has_los_terrain()) {
             break;
         }
     }
@@ -359,9 +359,9 @@ void update_view(PlayerType *player_ptr)
     for (n = 0; n < floor.view_n; n++) {
         y = floor.view_y[n];
         x = floor.view_x[n];
-        auto *g_ptr = &floor.grid_array[y][x];
-        g_ptr->info &= ~(CAVE_XTRA);
-        if (g_ptr->info & CAVE_TEMP) {
+        auto &grid = floor.grid_array[y][x];
+        grid.info &= ~(CAVE_XTRA);
+        if (grid.info & CAVE_TEMP) {
             continue;
         }
 
@@ -369,9 +369,9 @@ void update_view(PlayerType *player_ptr)
     }
 
     for (const auto &[py, px] : points) {
-        auto *g_ptr = &floor.grid_array[py][px];
-        g_ptr->info &= ~(CAVE_TEMP);
-        if (g_ptr->info & CAVE_VIEW) {
+        auto &grid = floor.grid_array[py][px];
+        grid.info &= ~(CAVE_TEMP);
+        if (grid.info & CAVE_VIEW) {
             continue;
         }
 

--- a/src/player/player-view.cpp
+++ b/src/player/player-view.cpp
@@ -45,8 +45,7 @@ static bool update_view_aux(PlayerType *player_ptr, POSITION y, POSITION x, POSI
         return true;
     }
 
-    Grid *g_ptr;
-    g_ptr = &floor.grid_array[y][x];
+    auto *g_ptr = &floor.grid_array[y][x];
     bool wall = !g_ptr->has_los_terrain();
     bool z1 = (v1 && (g1_c_ptr->info & CAVE_XTRA));
     bool z2 = (v2 && (g2_c_ptr->info & CAVE_XTRA));
@@ -113,7 +112,6 @@ void update_view(PlayerType *player_ptr)
     POSITION y_max = floor.height - 1;
     POSITION x_max = floor.width - 1;
 
-    Grid *g_ptr;
     if (view_reduce_view && !floor.is_underground()) {
         full = MAX_PLAYER_SIGHT / 2;
         over = MAX_PLAYER_SIGHT * 3 / 4;
@@ -125,23 +123,25 @@ void update_view(PlayerType *player_ptr)
     for (n = 0; n < floor.view_n; n++) {
         y = floor.view_y[n];
         x = floor.view_x[n];
-        g_ptr = &floor.grid_array[y][x];
+        auto *g_ptr = &floor.grid_array[y][x];
         g_ptr->info &= ~(CAVE_VIEW);
         g_ptr->info |= CAVE_TEMP;
 
         points.emplace_back(y, x);
     }
 
-    floor.view_n = 0;
-    y = player_ptr->y;
-    x = player_ptr->x;
-    g_ptr = &floor.grid_array[y][x];
-    g_ptr->info |= CAVE_XTRA;
-    cave_view_hack(floor, y, x);
+    {
+        floor.view_n = 0;
+        y = player_ptr->y;
+        x = player_ptr->x;
+        auto *g_ptr = &floor.grid_array[y][x];
+        g_ptr->info |= CAVE_XTRA;
+        cave_view_hack(floor, y, x);
+    }
 
     z = full * 2 / 3;
     for (d = 1; d <= z; d++) {
-        g_ptr = &floor.grid_array[y + d][x + d];
+        auto *g_ptr = &floor.grid_array[y + d][x + d];
         g_ptr->info |= CAVE_XTRA;
         cave_view_hack(floor, y + d, x + d);
         if (!g_ptr->has_los_terrain()) {
@@ -150,7 +150,7 @@ void update_view(PlayerType *player_ptr)
     }
 
     for (d = 1; d <= z; d++) {
-        g_ptr = &floor.grid_array[y + d][x - d];
+        auto *g_ptr = &floor.grid_array[y + d][x - d];
         g_ptr->info |= CAVE_XTRA;
         cave_view_hack(floor, y + d, x - d);
         if (!g_ptr->has_los_terrain()) {
@@ -159,7 +159,7 @@ void update_view(PlayerType *player_ptr)
     }
 
     for (d = 1; d <= z; d++) {
-        g_ptr = &floor.grid_array[y - d][x + d];
+        auto *g_ptr = &floor.grid_array[y - d][x + d];
         g_ptr->info |= CAVE_XTRA;
         cave_view_hack(floor, y - d, x + d);
         if (!g_ptr->has_los_terrain()) {
@@ -168,7 +168,7 @@ void update_view(PlayerType *player_ptr)
     }
 
     for (d = 1; d <= z; d++) {
-        g_ptr = &floor.grid_array[y - d][x - d];
+        auto *g_ptr = &floor.grid_array[y - d][x - d];
         g_ptr->info |= CAVE_XTRA;
         cave_view_hack(floor, y - d, x - d);
         if (!g_ptr->has_los_terrain()) {
@@ -177,7 +177,7 @@ void update_view(PlayerType *player_ptr)
     }
 
     for (d = 1; d <= full; d++) {
-        g_ptr = &floor.grid_array[y + d][x];
+        auto *g_ptr = &floor.grid_array[y + d][x];
         g_ptr->info |= CAVE_XTRA;
         cave_view_hack(floor, y + d, x);
         if (!g_ptr->has_los_terrain()) {
@@ -187,7 +187,7 @@ void update_view(PlayerType *player_ptr)
 
     se = sw = d;
     for (d = 1; d <= full; d++) {
-        g_ptr = &floor.grid_array[y - d][x];
+        auto *g_ptr = &floor.grid_array[y - d][x];
         g_ptr->info |= CAVE_XTRA;
         cave_view_hack(floor, y - d, x);
         if (!g_ptr->has_los_terrain()) {
@@ -197,7 +197,7 @@ void update_view(PlayerType *player_ptr)
 
     ne = nw = d;
     for (d = 1; d <= full; d++) {
-        g_ptr = &floor.grid_array[y][x + d];
+        auto *g_ptr = &floor.grid_array[y][x + d];
         g_ptr->info |= CAVE_XTRA;
         cave_view_hack(floor, y, x + d);
         if (!g_ptr->has_los_terrain()) {
@@ -207,7 +207,7 @@ void update_view(PlayerType *player_ptr)
 
     es = en = d;
     for (d = 1; d <= full; d++) {
-        g_ptr = &floor.grid_array[y][x - d];
+        auto *g_ptr = &floor.grid_array[y][x - d];
         g_ptr->info |= CAVE_XTRA;
         cave_view_hack(floor, y, x - d);
         if (!g_ptr->has_los_terrain()) {
@@ -359,7 +359,7 @@ void update_view(PlayerType *player_ptr)
     for (n = 0; n < floor.view_n; n++) {
         y = floor.view_y[n];
         x = floor.view_x[n];
-        g_ptr = &floor.grid_array[y][x];
+        auto *g_ptr = &floor.grid_array[y][x];
         g_ptr->info &= ~(CAVE_XTRA);
         if (g_ptr->info & CAVE_TEMP) {
             continue;
@@ -369,7 +369,7 @@ void update_view(PlayerType *player_ptr)
     }
 
     for (const auto &[py, px] : points) {
-        g_ptr = &floor.grid_array[py][px];
+        auto *g_ptr = &floor.grid_array[py][px];
         g_ptr->info &= ~(CAVE_TEMP);
         if (g_ptr->info & CAVE_VIEW) {
             continue;

--- a/src/room/cave-filler.cpp
+++ b/src/room/cave-filler.cpp
@@ -297,102 +297,102 @@ bool generate_fracave(PlayerType *player_ptr, POSITION y0, POSITION x0, POSITION
     }
 
     for (int i = 0; i <= xsize; ++i) {
-        auto *g_ptr1 = &floor.grid_array[y0 - yhsize][i + x0 - xhsize];
-        if (g_ptr1->is_icky() && (room)) {
+        auto &grid1 = floor.grid_array[y0 - yhsize][i + x0 - xhsize];
+        if (grid1.is_icky() && (room)) {
             place_bold(player_ptr, y0 - yhsize, x0 + i - xhsize, GB_OUTER);
             if (light) {
                 floor.grid_array[y0 - yhsize][x0 + i - xhsize].info |= (CAVE_GLOW);
             }
 
-            g_ptr1->info |= (CAVE_ROOM);
+            grid1.info |= (CAVE_ROOM);
             place_bold(player_ptr, y0 - yhsize, x0 + i - xhsize, GB_OUTER);
         } else {
             place_bold(player_ptr, y0 - yhsize, x0 + i - xhsize, GB_EXTRA);
         }
 
-        auto *g_ptr2 = &floor.grid_array[ysize + y0 - yhsize][i + x0 - xhsize];
-        if (g_ptr2->is_icky() && (room)) {
+        auto &grid2 = floor.grid_array[ysize + y0 - yhsize][i + x0 - xhsize];
+        if (grid2.is_icky() && (room)) {
             place_bold(player_ptr, y0 + ysize - yhsize, x0 + i - xhsize, GB_OUTER);
             if (light) {
-                g_ptr2->info |= (CAVE_GLOW);
+                grid2.info |= (CAVE_GLOW);
             }
 
-            g_ptr2->info |= (CAVE_ROOM);
+            grid2.info |= (CAVE_ROOM);
             place_bold(player_ptr, y0 + ysize - yhsize, x0 + i - xhsize, GB_OUTER);
         } else {
             place_bold(player_ptr, y0 + ysize - yhsize, x0 + i - xhsize, GB_EXTRA);
         }
 
-        g_ptr1->info &= ~(CAVE_ICKY);
-        g_ptr2->info &= ~(CAVE_ICKY);
+        grid1.info &= ~(CAVE_ICKY);
+        grid2.info &= ~(CAVE_ICKY);
     }
 
     for (int i = 1; i < ysize; ++i) {
-        auto *g_ptr1 = &floor.grid_array[i + y0 - yhsize][x0 - xhsize];
-        if (g_ptr1->is_icky() && room) {
+        auto &grid1 = floor.grid_array[i + y0 - yhsize][x0 - xhsize];
+        if (grid1.is_icky() && room) {
             place_bold(player_ptr, y0 + i - yhsize, x0 - xhsize, GB_OUTER);
             if (light) {
-                g_ptr1->info |= (CAVE_GLOW);
+                grid1.info |= (CAVE_GLOW);
             }
 
-            g_ptr1->info |= (CAVE_ROOM);
+            grid1.info |= (CAVE_ROOM);
             place_bold(player_ptr, y0 + i - yhsize, x0 - xhsize, GB_OUTER);
         } else {
             place_bold(player_ptr, y0 + i - yhsize, x0 - xhsize, GB_EXTRA);
         }
 
-        auto *g_ptr2 = &floor.grid_array[i + y0 - yhsize][xsize + x0 - xhsize];
-        if (g_ptr2->is_icky() && room) {
+        auto &grid2 = floor.grid_array[i + y0 - yhsize][xsize + x0 - xhsize];
+        if (grid2.is_icky() && room) {
             place_bold(player_ptr, y0 + i - yhsize, x0 + xsize - xhsize, GB_OUTER);
             if (light) {
-                g_ptr2->info |= (CAVE_GLOW);
+                grid2.info |= (CAVE_GLOW);
             }
 
-            g_ptr2->info |= (CAVE_ROOM);
+            grid2.info |= (CAVE_ROOM);
             place_bold(player_ptr, y0 + i - yhsize, x0 + xsize - xhsize, GB_OUTER);
         } else {
             place_bold(player_ptr, y0 + i - yhsize, x0 + xsize - xhsize, GB_EXTRA);
         }
 
-        g_ptr1->info &= ~(CAVE_ICKY);
-        g_ptr2->info &= ~(CAVE_ICKY);
+        grid1.info &= ~(CAVE_ICKY);
+        grid2.info &= ~(CAVE_ICKY);
     }
 
     for (POSITION x = 1; x < xsize; ++x) {
         for (POSITION y = 1; y < ysize; ++y) {
-            auto *g_ptr1 = &floor.grid_array[y0 + y - yhsize][x0 + x - xhsize];
-            if (g_ptr1->is_floor() && g_ptr1->is_icky()) {
-                g_ptr1->info &= ~CAVE_ICKY;
+            auto &grid1 = floor.grid_array[y0 + y - yhsize][x0 + x - xhsize];
+            if (grid1.is_floor() && grid1.is_icky()) {
+                grid1.info &= ~CAVE_ICKY;
                 if (light) {
-                    g_ptr1->info |= (CAVE_GLOW);
+                    grid1.info |= (CAVE_GLOW);
                 }
 
                 if (room) {
-                    g_ptr1->info |= (CAVE_ROOM);
+                    grid1.info |= (CAVE_ROOM);
                 }
 
                 continue;
             }
 
-            auto *g_ptr2 = &floor.grid_array[y0 + y - yhsize][x0 + x - xhsize];
-            if (g_ptr2->is_outer() && g_ptr2->is_icky()) {
-                g_ptr2->info &= ~(CAVE_ICKY);
+            auto &grid2 = floor.grid_array[y0 + y - yhsize][x0 + x - xhsize];
+            if (grid2.is_outer() && grid2.is_icky()) {
+                grid2.info &= ~(CAVE_ICKY);
                 if (light) {
-                    g_ptr2->info |= (CAVE_GLOW);
+                    grid2.info |= (CAVE_GLOW);
                 }
 
                 if (room) {
-                    g_ptr2->info |= (CAVE_ROOM);
+                    grid2.info |= (CAVE_ROOM);
                 } else {
                     place_bold(player_ptr, y0 + y - yhsize, x0 + x - xhsize, GB_EXTRA);
-                    g_ptr2->info &= ~(CAVE_ROOM);
+                    grid2.info &= ~(CAVE_ROOM);
                 }
 
                 continue;
             }
 
             place_bold(player_ptr, y0 + y - yhsize, x0 + x - xhsize, GB_EXTRA);
-            g_ptr2->info &= ~(CAVE_ICKY | CAVE_ROOM);
+            grid2.info &= ~(CAVE_ICKY | CAVE_ROOM);
         }
     }
 

--- a/src/room/rooms-builder.cpp
+++ b/src/room/rooms-builder.cpp
@@ -185,12 +185,12 @@ void build_room(PlayerType *player_ptr, POSITION x1, POSITION x2, POSITION y1, P
 
     for (POSITION x = 1; x < xsize; x++) {
         for (POSITION y = 1; y < ysize; y++) {
-            auto *g_ptr = &floor.grid_array[y1 + y][x1 + x];
-            if (g_ptr->is_extra()) {
+            auto &grid = floor.grid_array[y1 + y][x1 + x];
+            if (grid.is_extra()) {
                 place_bold(player_ptr, y1 + y, x1 + x, GB_FLOOR);
-                g_ptr->info |= (CAVE_ROOM | CAVE_ICKY);
+                grid.info |= (CAVE_ROOM | CAVE_ICKY);
             } else {
-                g_ptr->info |= (CAVE_ROOM | CAVE_ICKY);
+                grid.info |= (CAVE_ROOM | CAVE_ICKY);
             }
         }
     }

--- a/src/room/rooms-city.cpp
+++ b/src/room/rooms-city.cpp
@@ -70,7 +70,7 @@ void generate_room_floor(PlayerType *player_ptr, const Rect2D &rectangle, int li
 
     rectangle.each_area([player_ptr, info](const Pos2D &pos) {
         auto &grid = player_ptr->current_floor_ptr->get_grid(pos);
-        place_grid(player_ptr, &grid, GB_FLOOR);
+        place_grid(player_ptr, grid, GB_FLOOR);
         grid.add_info(info);
     });
 }

--- a/src/room/rooms-maze-vault.cpp
+++ b/src/room/rooms-maze-vault.cpp
@@ -116,11 +116,11 @@ void build_maze_vault(PlayerType *player_ptr, const Pos2D &center, const Pos2DVe
                 grid.info |= CAVE_ICKY;
             }
             if ((x == x1 - 1) || (x == x2 + 1) || (y == y1 - 1) || (y == y2 + 1)) {
-                place_grid(player_ptr, &grid, GB_OUTER);
+                place_grid(player_ptr, grid, GB_OUTER);
             } else if (!is_vault) {
-                place_grid(player_ptr, &grid, GB_EXTRA);
+                place_grid(player_ptr, grid, GB_EXTRA);
             } else {
-                place_grid(player_ptr, &grid, GB_INNER);
+                place_grid(player_ptr, grid, GB_INNER);
             }
 
             if (light) {

--- a/src/room/rooms-nest.cpp
+++ b/src/room/rooms-nest.cpp
@@ -70,12 +70,12 @@ Rect2D generate_large_room(PlayerType *player_ptr, const Pos2D &center)
     const Rect2D rectangle(center, vec);
     rectangle.resized(1).each_area([player_ptr, &floor](const Pos2D &pos) {
         auto &grid = floor.get_grid(pos);
-        place_grid(player_ptr, &grid, GB_FLOOR);
+        place_grid(player_ptr, grid, GB_FLOOR);
         grid.add_info(CAVE_ROOM);
     });
 
     rectangle.resized(1).each_edge([player_ptr, &floor](const Pos2D &pos) {
-        place_grid(player_ptr, &floor.get_grid(pos), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid(pos), GB_OUTER);
     });
 
     return rectangle;
@@ -87,7 +87,7 @@ void generate_inner_room(PlayerType *player_ptr, const Pos2D &center, Rect2D &re
     const auto inner_rectangle = rectangle.resized(-2);
 
     inner_rectangle.resized(1).each_edge([player_ptr, &floor](const Pos2D &pos) {
-        place_grid(player_ptr, &floor.get_grid(pos), GB_INNER);
+        place_grid(player_ptr, floor.get_grid(pos), GB_INNER);
     });
 
     inner_rectangle.each_area([&floor](const Pos2D &pos) {

--- a/src/room/rooms-normal.cpp
+++ b/src/room/rooms-normal.cpp
@@ -54,7 +54,7 @@ bool build_type1(PlayerType *player_ptr, DungeonData *dd_ptr)
     for (auto y = top - 1; y <= bottom + 1; y++) {
         for (auto x = left - 1; x <= right + 1; x++) {
             auto &grid = floor.get_grid({ y, x });
-            place_grid(player_ptr, &grid, GB_FLOOR);
+            place_grid(player_ptr, grid, GB_FLOOR);
             grid.info |= (CAVE_ROOM);
             if (should_brighten) {
                 grid.info |= (CAVE_GLOW);
@@ -64,13 +64,13 @@ bool build_type1(PlayerType *player_ptr, DungeonData *dd_ptr)
 
     /* Walls around the room */
     for (auto y = top - 1; y <= bottom + 1; y++) {
-        place_grid(player_ptr, &floor.get_grid({ y, left - 1 }), GB_OUTER);
-        place_grid(player_ptr, &floor.get_grid({ y, right + 1 }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y, left - 1 }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y, right + 1 }), GB_OUTER);
     }
 
     for (auto x = left - 1; x <= right + 1; x++) {
-        place_grid(player_ptr, &floor.get_grid({ top - 1, x }), GB_OUTER);
-        place_grid(player_ptr, &floor.get_grid({ bottom + 1, x }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ top - 1, x }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ bottom + 1, x }), GB_OUTER);
     }
 
     /* Hack -- Occasional curtained room */
@@ -91,7 +91,7 @@ bool build_type1(PlayerType *player_ptr, DungeonData *dd_ptr)
         for (auto y = top; y <= bottom; y += 2) {
             for (auto x = left; x <= right; x += 2) {
                 auto &grid = floor.get_grid({ y, x });
-                place_grid(player_ptr, &grid, GB_INNER);
+                place_grid(player_ptr, grid, GB_INNER);
             }
         }
 
@@ -101,10 +101,10 @@ bool build_type1(PlayerType *player_ptr, DungeonData *dd_ptr)
     /* Hack -- Occasional room with four pillars */
     if (one_in_(20)) {
         if ((top + 4 < bottom) && (left + 4 < right)) {
-            place_grid(player_ptr, &floor.get_grid({ top + 1, left + 1 }), GB_INNER);
-            place_grid(player_ptr, &floor.get_grid({ top + 1, right - 1 }), GB_INNER);
-            place_grid(player_ptr, &floor.get_grid({ bottom - 1, left + 1 }), GB_INNER);
-            place_grid(player_ptr, &floor.get_grid({ bottom - 1, right - 1 }), GB_INNER);
+            place_grid(player_ptr, floor.get_grid({ top + 1, left + 1 }), GB_INNER);
+            place_grid(player_ptr, floor.get_grid({ top + 1, right - 1 }), GB_INNER);
+            place_grid(player_ptr, floor.get_grid({ bottom - 1, left + 1 }), GB_INNER);
+            place_grid(player_ptr, floor.get_grid({ bottom - 1, right - 1 }), GB_INNER);
         }
 
         return true;
@@ -113,13 +113,13 @@ bool build_type1(PlayerType *player_ptr, DungeonData *dd_ptr)
     /* Hack -- Occasional ragged-edge room */
     if (one_in_(50)) {
         for (auto y = top + 2; y <= bottom - 2; y += 2) {
-            place_grid(player_ptr, &floor.get_grid({ y, left }), GB_INNER);
-            place_grid(player_ptr, &floor.get_grid({ y, right }), GB_INNER);
+            place_grid(player_ptr, floor.get_grid({ y, left }), GB_INNER);
+            place_grid(player_ptr, floor.get_grid({ y, right }), GB_INNER);
         }
 
         for (auto x = left + 2; x <= right - 2; x += 2) {
-            place_grid(player_ptr, &floor.get_grid({ top, x }), GB_INNER);
-            place_grid(player_ptr, &floor.get_grid({ bottom, x }), GB_INNER);
+            place_grid(player_ptr, floor.get_grid({ top, x }), GB_INNER);
+            place_grid(player_ptr, floor.get_grid({ bottom, x }), GB_INNER);
         }
 
         return true;
@@ -197,7 +197,7 @@ bool build_type2(PlayerType *player_ptr, DungeonData *dd_ptr)
     for (auto y = y1a - 1; y <= y2a + 1; y++) {
         for (auto x = x1a - 1; x <= x2a + 1; x++) {
             auto &grid = floor.get_grid({ y, x });
-            place_grid(player_ptr, &grid, GB_FLOOR);
+            place_grid(player_ptr, grid, GB_FLOOR);
             grid.info |= (CAVE_ROOM);
             if (should_brighten) {
                 grid.info |= (CAVE_GLOW);
@@ -209,7 +209,7 @@ bool build_type2(PlayerType *player_ptr, DungeonData *dd_ptr)
     for (auto y = y1b - 1; y <= y2b + 1; y++) {
         for (auto x = x1b - 1; x <= x2b + 1; x++) {
             auto &grid = floor.get_grid({ y, x });
-            place_grid(player_ptr, &grid, GB_FLOOR);
+            place_grid(player_ptr, grid, GB_FLOOR);
             grid.info |= (CAVE_ROOM);
             if (should_brighten) {
                 grid.info |= (CAVE_GLOW);
@@ -219,35 +219,35 @@ bool build_type2(PlayerType *player_ptr, DungeonData *dd_ptr)
 
     /* Place the walls around room "a" */
     for (auto y = y1a - 1; y <= y2a + 1; y++) {
-        place_grid(player_ptr, &floor.get_grid({ y, x1a - 1 }), GB_OUTER);
-        place_grid(player_ptr, &floor.get_grid({ y, x2a + 1 }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y, x1a - 1 }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y, x2a + 1 }), GB_OUTER);
     }
     for (auto x = x1a - 1; x <= x2a + 1; x++) {
-        place_grid(player_ptr, &floor.get_grid({ y1a - 1, x }), GB_OUTER);
-        place_grid(player_ptr, &floor.get_grid({ y2a + 1, x }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y1a - 1, x }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y2a + 1, x }), GB_OUTER);
     }
 
     /* Place the walls around room "b" */
     for (auto y = y1b - 1; y <= y2b + 1; y++) {
-        place_grid(player_ptr, &floor.get_grid({ y, x1b - 1 }), GB_OUTER);
-        place_grid(player_ptr, &floor.get_grid({ y, x2b + 1 }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y, x1b - 1 }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y, x2b + 1 }), GB_OUTER);
     }
     for (auto x = x1b - 1; x <= x2b + 1; x++) {
-        place_grid(player_ptr, &floor.get_grid({ y1b - 1, x }), GB_OUTER);
-        place_grid(player_ptr, &floor.get_grid({ y2b + 1, x }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y1b - 1, x }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y2b + 1, x }), GB_OUTER);
     }
 
     /* Replace the floor for room "a" */
     for (auto y = y1a; y <= y2a; y++) {
         for (auto x = x1a; x <= x2a; x++) {
-            place_grid(player_ptr, &floor.get_grid({ y, x }), GB_FLOOR);
+            place_grid(player_ptr, floor.get_grid({ y, x }), GB_FLOOR);
         }
     }
 
     /* Replace the floor for room "b" */
     for (auto y = y1b; y <= y2b; y++) {
         for (auto x = x1b; x <= x2b; x++) {
-            place_grid(player_ptr, &floor.get_grid({ y, x }), GB_FLOOR);
+            place_grid(player_ptr, floor.get_grid({ y, x }), GB_FLOOR);
         }
     }
 
@@ -305,7 +305,7 @@ bool build_type3(PlayerType *player_ptr, DungeonData *dd_ptr)
     for (auto y = y1a - 1; y <= y2a + 1; y++) {
         for (auto x = x1a - 1; x <= x2a + 1; x++) {
             auto &grid = floor.get_grid({ y, x });
-            place_grid(player_ptr, &grid, GB_FLOOR);
+            place_grid(player_ptr, grid, GB_FLOOR);
             grid.info |= (CAVE_ROOM);
             if (should_brighten) {
                 grid.info |= (CAVE_GLOW);
@@ -317,7 +317,7 @@ bool build_type3(PlayerType *player_ptr, DungeonData *dd_ptr)
     for (auto y = y1b - 1; y <= y2b + 1; y++) {
         for (auto x = x1b - 1; x <= x2b + 1; x++) {
             auto &grid = floor.get_grid({ y, x });
-            place_grid(player_ptr, &grid, GB_FLOOR);
+            place_grid(player_ptr, grid, GB_FLOOR);
             grid.info |= (CAVE_ROOM);
             if (should_brighten) {
                 grid.info |= (CAVE_GLOW);
@@ -327,35 +327,35 @@ bool build_type3(PlayerType *player_ptr, DungeonData *dd_ptr)
 
     /* Place the walls around room "a" */
     for (auto y = y1a - 1; y <= y2a + 1; y++) {
-        place_grid(player_ptr, &floor.get_grid({ y, x1a - 1 }), GB_OUTER);
-        place_grid(player_ptr, &floor.get_grid({ y, x2a + 1 }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y, x1a - 1 }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y, x2a + 1 }), GB_OUTER);
     }
     for (auto x = x1a - 1; x <= x2a + 1; x++) {
-        place_grid(player_ptr, &floor.get_grid({ y1a - 1, x }), GB_OUTER);
-        place_grid(player_ptr, &floor.get_grid({ y2a + 1, x }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y1a - 1, x }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y2a + 1, x }), GB_OUTER);
     }
 
     /* Place the walls around room "b" */
     for (auto y = y1b - 1; y <= y2b + 1; y++) {
-        place_grid(player_ptr, &floor.get_grid({ y, x1b - 1 }), GB_OUTER);
-        place_grid(player_ptr, &floor.get_grid({ y, x2b + 1 }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y, x1b - 1 }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y, x2b + 1 }), GB_OUTER);
     }
     for (auto x = x1b - 1; x <= x2b + 1; x++) {
-        place_grid(player_ptr, &floor.get_grid({ y1b - 1, x }), GB_OUTER);
-        place_grid(player_ptr, &floor.get_grid({ y2b + 1, x }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y1b - 1, x }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y2b + 1, x }), GB_OUTER);
     }
 
     /* Replace the floor for room "a" */
     for (auto y = y1a; y <= y2a; y++) {
         for (auto x = x1a; x <= x2a; x++) {
-            place_grid(player_ptr, &floor.get_grid({ y, x }), GB_FLOOR);
+            place_grid(player_ptr, floor.get_grid({ y, x }), GB_FLOOR);
         }
     }
 
     /* Replace the floor for room "b" */
     for (auto y = y1b; y <= y2b; y++) {
         for (auto x = x1b; x <= x2b; x++) {
-            place_grid(player_ptr, &floor.get_grid({ y, x }), GB_FLOOR);
+            place_grid(player_ptr, floor.get_grid({ y, x }), GB_FLOOR);
         }
     }
 
@@ -365,7 +365,7 @@ bool build_type3(PlayerType *player_ptr, DungeonData *dd_ptr)
         /* Large solid middle pillar */
     case 1: {
         rect_inner.each_area([&](const auto &pos) {
-            place_grid(player_ptr, &floor.get_grid(pos), GB_INNER);
+            place_grid(player_ptr, floor.get_grid(pos), GB_INNER);
         });
         break;
     }
@@ -374,7 +374,7 @@ bool build_type3(PlayerType *player_ptr, DungeonData *dd_ptr)
     case 2: {
         /* Build the vault */
         rect_inner.each_edge([&](const auto &pos) {
-            place_grid(player_ptr, &floor.get_grid(pos), GB_INNER);
+            place_grid(player_ptr, floor.get_grid(pos), GB_INNER);
         });
 
         /* Place a secret door on the inner room */
@@ -415,8 +415,8 @@ bool build_type3(PlayerType *player_ptr, DungeonData *dd_ptr)
                     continue;
                 }
 
-                place_grid(player_ptr, &floor.get_grid({ y, x1a - 1 }), GB_INNER);
-                place_grid(player_ptr, &floor.get_grid({ y, x2a + 1 }), GB_INNER);
+                place_grid(player_ptr, floor.get_grid({ y, x1a - 1 }), GB_INNER);
+                place_grid(player_ptr, floor.get_grid({ y, x2a + 1 }), GB_INNER);
             }
 
             /* Pinch the north/south sides */
@@ -425,8 +425,8 @@ bool build_type3(PlayerType *player_ptr, DungeonData *dd_ptr)
                     continue;
                 }
 
-                place_grid(player_ptr, &floor.grid_array[y1b - 1][x], GB_INNER);
-                place_grid(player_ptr, &floor.grid_array[y2b + 1][x], GB_INNER);
+                place_grid(player_ptr, floor.grid_array[y1b - 1][x], GB_INNER);
+                place_grid(player_ptr, floor.grid_array[y2b + 1][x], GB_INNER);
             }
 
             /* Sometimes shut using secret doors */
@@ -444,16 +444,16 @@ bool build_type3(PlayerType *player_ptr, DungeonData *dd_ptr)
 
         /* Occasionally put a "plus" in the center */
         else if (one_in_(3)) {
-            place_grid(player_ptr, &floor.get_grid(*center), GB_INNER);
-            place_grid(player_ptr, &floor.get_grid({ y1b, center->x }), GB_INNER);
-            place_grid(player_ptr, &floor.get_grid({ y2b, center->x }), GB_INNER);
-            place_grid(player_ptr, &floor.get_grid({ center->y, x1a }), GB_INNER);
-            place_grid(player_ptr, &floor.get_grid({ center->y, x2a }), GB_INNER);
+            place_grid(player_ptr, floor.get_grid(*center), GB_INNER);
+            place_grid(player_ptr, floor.get_grid({ y1b, center->x }), GB_INNER);
+            place_grid(player_ptr, floor.get_grid({ y2b, center->x }), GB_INNER);
+            place_grid(player_ptr, floor.get_grid({ center->y, x1a }), GB_INNER);
+            place_grid(player_ptr, floor.get_grid({ center->y, x2a }), GB_INNER);
         }
 
         /* Occasionally put a pillar in the center */
         else if (one_in_(3)) {
-            place_grid(player_ptr, &floor.get_grid(*center), GB_INNER);
+            place_grid(player_ptr, floor.get_grid(*center), GB_INNER);
         }
 
         break;
@@ -497,7 +497,7 @@ bool build_type4(PlayerType *player_ptr, DungeonData *dd_ptr)
     for (auto y = y1_outer - 1; y <= y2_outer + 1; y++) {
         for (auto x = x1_outer - 1; x <= x2_outer + 1; x++) {
             auto &grid = floor.get_grid({ y, x });
-            place_grid(player_ptr, &grid, GB_FLOOR);
+            place_grid(player_ptr, grid, GB_FLOOR);
             grid.info |= (CAVE_ROOM);
             if (should_brighten) {
                 grid.info |= (CAVE_GLOW);
@@ -507,12 +507,12 @@ bool build_type4(PlayerType *player_ptr, DungeonData *dd_ptr)
 
     /* Outer Walls */
     for (auto y = y1_outer - 1; y <= y2_outer + 1; y++) {
-        place_grid(player_ptr, &floor.get_grid({ y, x1_outer - 1 }), GB_OUTER);
-        place_grid(player_ptr, &floor.get_grid({ y, x2_outer + 1 }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y, x1_outer - 1 }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y, x2_outer + 1 }), GB_OUTER);
     }
     for (auto x = x1_outer - 1; x <= x2_outer + 1; x++) {
-        place_grid(player_ptr, &floor.get_grid({ y1_outer - 1, x }), GB_OUTER);
-        place_grid(player_ptr, &floor.get_grid({ y2_outer + 1, x }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y1_outer - 1, x }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y2_outer + 1, x }), GB_OUTER);
     }
 
     const auto y1_inner = y1_outer + 2;
@@ -522,12 +522,12 @@ bool build_type4(PlayerType *player_ptr, DungeonData *dd_ptr)
 
     /* The inner walls */
     for (auto y = y1_inner - 1; y <= y2_inner + 1; y++) {
-        place_grid(player_ptr, &floor.get_grid({ y, x1_inner - 1 }), GB_INNER);
-        place_grid(player_ptr, &floor.get_grid({ y, x2_inner + 1 }), GB_INNER);
+        place_grid(player_ptr, floor.get_grid({ y, x1_inner - 1 }), GB_INNER);
+        place_grid(player_ptr, floor.get_grid({ y, x2_inner + 1 }), GB_INNER);
     }
     for (auto x = x1_inner - 1; x <= x2_inner + 1; x++) {
-        place_grid(player_ptr, &floor.get_grid({ y1_inner - 1, x }), GB_INNER);
-        place_grid(player_ptr, &floor.get_grid({ y2_inner + 1, x }), GB_INNER);
+        place_grid(player_ptr, floor.get_grid({ y1_inner - 1, x }), GB_INNER);
+        place_grid(player_ptr, floor.get_grid({ y2_inner + 1, x }), GB_INNER);
     }
 
     /* Inner room variations */
@@ -581,7 +581,7 @@ bool build_type4(PlayerType *player_ptr, DungeonData *dd_ptr)
                     continue;
                 }
 
-                place_grid(player_ptr, &floor.get_grid({ y, x }), GB_INNER);
+                place_grid(player_ptr, floor.get_grid({ y, x }), GB_INNER);
             }
         }
 
@@ -637,7 +637,7 @@ bool build_type4(PlayerType *player_ptr, DungeonData *dd_ptr)
         /* Large Inner Pillar */
         for (auto y = center->y - 1; y <= center->y + 1; y++) {
             for (auto x = center->x - 1; x <= center->x + 1; x++) {
-                place_grid(player_ptr, &floor.get_grid({ y, x }), GB_INNER);
+                place_grid(player_ptr, floor.get_grid({ y, x }), GB_INNER);
             }
         }
 
@@ -646,11 +646,11 @@ bool build_type4(PlayerType *player_ptr, DungeonData *dd_ptr)
             const auto tmp = randint1(2);
             for (auto y = center->y - 1; y <= center->y + 1; y++) {
                 for (auto x = center->x - 5 - tmp; x <= center->x - 3 - tmp; x++) {
-                    place_grid(player_ptr, &floor.get_grid({ y, x }), GB_INNER);
+                    place_grid(player_ptr, floor.get_grid({ y, x }), GB_INNER);
                 }
 
                 for (auto x = center->x + 3 + tmp; x <= center->x + 5 + tmp; x++) {
-                    place_grid(player_ptr, &floor.get_grid({ y, x }), GB_INNER);
+                    place_grid(player_ptr, floor.get_grid({ y, x }), GB_INNER);
                 }
             }
         }
@@ -663,13 +663,13 @@ bool build_type4(PlayerType *player_ptr, DungeonData *dd_ptr)
 
             /* Long horizontal walls */
             for (auto x = center->x - 5; x <= center->x + 5; x++) {
-                place_grid(player_ptr, &floor.get_grid({ center->y - 1, x }), GB_INNER);
-                place_grid(player_ptr, &floor.get_grid({ center->y + 1, x }), GB_INNER);
+                place_grid(player_ptr, floor.get_grid({ center->y - 1, x }), GB_INNER);
+                place_grid(player_ptr, floor.get_grid({ center->y + 1, x }), GB_INNER);
             }
 
             /* Close off the left/right edges */
-            place_grid(player_ptr, &floor.get_grid({ center->y, center->x - 5 }), GB_INNER);
-            place_grid(player_ptr, &floor.get_grid({ center->y, center->x + 5 }), GB_INNER);
+            place_grid(player_ptr, floor.get_grid({ center->y, center->x - 5 }), GB_INNER);
+            place_grid(player_ptr, floor.get_grid({ center->y, center->x + 5 }), GB_INNER);
 
             /* Secret doors (random top/bottom) */
             place_secret_door(player_ptr, { center->y - 3 + (randint1(2) * 2), center->x - 3 }, door_type);
@@ -713,7 +713,7 @@ bool build_type4(PlayerType *player_ptr, DungeonData *dd_ptr)
         for (auto y = y1_inner; y <= y2_inner; y++) {
             for (auto x = x1_inner; x <= x2_inner; x++) {
                 if (0x1 & (x + y)) {
-                    place_grid(player_ptr, &floor.get_grid({ y, x }), GB_INNER);
+                    place_grid(player_ptr, floor.get_grid({ y, x }), GB_INNER);
                 }
             }
         }
@@ -740,11 +740,11 @@ bool build_type4(PlayerType *player_ptr, DungeonData *dd_ptr)
 
         /* Inner "cross" */
         for (auto y = y1_inner; y <= y2_inner; y++) {
-            place_grid(player_ptr, &floor.get_grid({ y, center->x }), GB_INNER);
+            place_grid(player_ptr, floor.get_grid({ y, center->x }), GB_INNER);
         }
 
         for (auto x = x1_inner; x <= x2_inner; x++) {
-            place_grid(player_ptr, &floor.get_grid({ center->y, x }), GB_INNER);
+            place_grid(player_ptr, floor.get_grid({ center->y, x }), GB_INNER);
         }
 
         /* Doors into the rooms */

--- a/src/room/rooms-pit.cpp
+++ b/src/room/rooms-pit.cpp
@@ -107,19 +107,19 @@ void place_pit_outer(PlayerType *player_ptr, const Pos2D &center)
     for (auto y = rectangle.top_left.y - 1; y <= rectangle.bottom_right.y + 1; y++) {
         for (auto x = rectangle.top_left.x - 1; x <= rectangle.bottom_right.x + 1; x++) {
             auto &grid = floor.get_grid({ y, x });
-            place_grid(player_ptr, &grid, GB_FLOOR);
+            place_grid(player_ptr, grid, GB_FLOOR);
             grid.add_info(CAVE_ROOM);
         }
     }
 
     for (auto y = rectangle.top_left.y - 1; y <= rectangle.bottom_right.y + 1; y++) {
-        place_grid(player_ptr, &floor.get_grid({ y, rectangle.top_left.x - 1 }), GB_OUTER);
-        place_grid(player_ptr, &floor.get_grid({ y, rectangle.bottom_right.x + 1 }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y, rectangle.top_left.x - 1 }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y, rectangle.bottom_right.x + 1 }), GB_OUTER);
     }
 
     for (auto x = rectangle.top_left.x - 1; x <= rectangle.bottom_right.x + 1; x++) {
-        place_grid(player_ptr, &floor.get_grid({ rectangle.top_left.y - 1, x }), GB_OUTER);
-        place_grid(player_ptr, &floor.get_grid({ rectangle.bottom_right.y + 1, x }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ rectangle.top_left.y - 1, x }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ rectangle.bottom_right.y + 1, x }), GB_OUTER);
     }
 }
 
@@ -128,13 +128,13 @@ void place_pit_inner(PlayerType *player_ptr, const Pos2D &center)
     auto &floor = *player_ptr->current_floor_ptr;
     const auto rectangle = Rect2D(center, PIT_SIZE).resized(-2);
     for (auto y = rectangle.top_left.y - 1; y <= rectangle.bottom_right.y + 1; y++) {
-        place_grid(player_ptr, &floor.get_grid({ y, rectangle.top_left.x - 1 }), GB_INNER);
-        place_grid(player_ptr, &floor.get_grid({ y, rectangle.bottom_right.x + 1 }), GB_INNER);
+        place_grid(player_ptr, floor.get_grid({ y, rectangle.top_left.x - 1 }), GB_INNER);
+        place_grid(player_ptr, floor.get_grid({ y, rectangle.bottom_right.x + 1 }), GB_INNER);
     }
 
     for (auto x = rectangle.top_left.x - 1; x <= rectangle.bottom_right.x + 1; x++) {
-        place_grid(player_ptr, &floor.get_grid({ rectangle.top_left.y - 1, x }), GB_INNER);
-        place_grid(player_ptr, &floor.get_grid({ rectangle.bottom_right.y + 1, x }), GB_INNER);
+        place_grid(player_ptr, floor.get_grid({ rectangle.top_left.y - 1, x }), GB_INNER);
+        place_grid(player_ptr, floor.get_grid({ rectangle.bottom_right.y + 1, x }), GB_INNER);
     }
 
     for (auto y = rectangle.top_left.y; y <= rectangle.bottom_right.y; y++) {
@@ -367,7 +367,7 @@ bool build_type13(PlayerType *player_ptr, DungeonData *dd_ptr)
     for (auto y = rectangle.top_left.y - 1; y <= rectangle.bottom_right.y + 1; y++) {
         for (auto x = rectangle.top_left.x - 1; x <= rectangle.bottom_right.x + 1; x++) {
             auto &grid = floor.get_grid({ y, x });
-            place_grid(player_ptr, &grid, GB_INNER);
+            place_grid(player_ptr, grid, GB_INNER);
             grid.add_info(CAVE_ROOM);
         }
     }
@@ -375,41 +375,41 @@ bool build_type13(PlayerType *player_ptr, DungeonData *dd_ptr)
     /* Place the floor area 1 */
     for (auto x = rectangle.top_left.x + 3; x <= rectangle.bottom_right.x - 3; x++) {
         auto &grid_top = floor.get_grid({ center->y - 2, x });
-        place_grid(player_ptr, &grid_top, GB_FLOOR);
+        place_grid(player_ptr, grid_top, GB_FLOOR);
         grid_top.add_info(CAVE_ICKY);
 
         auto &grid_bottom = floor.get_grid({ center->y + 2, x });
-        place_grid(player_ptr, &grid_bottom, GB_FLOOR);
+        place_grid(player_ptr, grid_bottom, GB_FLOOR);
         grid_bottom.add_info(CAVE_ICKY);
     }
 
     /* Place the floor area 2 */
     for (auto x = rectangle.top_left.x + 5; x <= rectangle.bottom_right.x - 5; x++) {
         auto &grid_left = floor.get_grid({ center->y - 3, x });
-        place_grid(player_ptr, &grid_left, GB_FLOOR);
+        place_grid(player_ptr, grid_left, GB_FLOOR);
         grid_left.add_info(CAVE_ICKY);
 
         auto &grid_right = floor.get_grid({ center->y + 3, x });
-        place_grid(player_ptr, &grid_right, GB_FLOOR);
+        place_grid(player_ptr, grid_right, GB_FLOOR);
         grid_right.add_info(CAVE_ICKY);
     }
 
     /* Corridor */
     for (auto x = rectangle.top_left.x; x <= rectangle.bottom_right.x; x++) {
-        place_grid(player_ptr, &floor.get_grid({ center->y, x }), GB_FLOOR);
-        place_grid(player_ptr, &floor.get_grid({ rectangle.top_left.y, x }), GB_FLOOR);
-        place_grid(player_ptr, &floor.get_grid({ rectangle.bottom_right.y, x }), GB_FLOOR);
+        place_grid(player_ptr, floor.get_grid({ center->y, x }), GB_FLOOR);
+        place_grid(player_ptr, floor.get_grid({ rectangle.top_left.y, x }), GB_FLOOR);
+        place_grid(player_ptr, floor.get_grid({ rectangle.bottom_right.y, x }), GB_FLOOR);
     }
 
     /* Place the outer walls */
     for (auto y = rectangle.top_left.y - 1; y <= rectangle.bottom_right.y + 1; y++) {
-        place_grid(player_ptr, &floor.get_grid({ y, rectangle.top_left.x - 1 }), GB_OUTER);
-        place_grid(player_ptr, &floor.get_grid({ y, rectangle.bottom_right.x + 1 }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y, rectangle.top_left.x - 1 }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y, rectangle.bottom_right.x + 1 }), GB_OUTER);
     }
 
     for (auto x = rectangle.top_left.x - 1; x <= rectangle.bottom_right.x + 1; x++) {
-        place_grid(player_ptr, &floor.get_grid({ rectangle.top_left.y - 1, x }), GB_OUTER);
-        place_grid(player_ptr, &floor.get_grid({ rectangle.bottom_right.y + 1, x }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ rectangle.top_left.y - 1, x }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ rectangle.bottom_right.y + 1, x }), GB_OUTER);
     }
 
     /* Random corridor */

--- a/src/room/rooms-special.cpp
+++ b/src/room/rooms-special.cpp
@@ -23,25 +23,25 @@
 namespace {
 void place_floor_glass(PlayerType *player_ptr, Grid &grid)
 {
-    place_grid(player_ptr, &grid, GB_FLOOR);
+    place_grid(player_ptr, grid, GB_FLOOR);
     grid.set_terrain_id(TerrainTag::GLASS_FLOOR);
 }
 
 void place_outer_glass(PlayerType *player_ptr, Grid &grid)
 {
-    place_grid(player_ptr, &grid, GB_OUTER);
+    place_grid(player_ptr, grid, GB_OUTER);
     grid.set_terrain_id(TerrainTag::GLASS_WALL);
 }
 
 void place_inner_glass(PlayerType *player_ptr, Grid &grid)
 {
-    place_grid(player_ptr, &grid, GB_INNER);
+    place_grid(player_ptr, grid, GB_INNER);
     grid.set_terrain_id(TerrainTag::GLASS_WALL);
 }
 
 void place_inner_perm_glass(PlayerType *player_ptr, Grid &grid)
 {
-    place_grid(player_ptr, &grid, GB_INNER_PERM);
+    place_grid(player_ptr, grid, GB_INNER_PERM);
     grid.set_terrain_id(TerrainTag::PERMANENT_GLASS_WALL);
 }
 }

--- a/src/room/rooms-trap.cpp
+++ b/src/room/rooms-trap.cpp
@@ -50,7 +50,7 @@ bool build_type14(PlayerType *player_ptr, DungeonData *dd_ptr)
     for (auto y = y1 - 1; y <= y2 + 1; y++) {
         for (auto x = x1 - 1; x <= x2 + 1; x++) {
             auto &grid = floor.get_grid({ y, x });
-            place_grid(player_ptr, &grid, GB_FLOOR);
+            place_grid(player_ptr, grid, GB_FLOOR);
             grid.info |= (CAVE_ROOM);
             if (light) {
                 grid.info |= (CAVE_GLOW);
@@ -60,13 +60,13 @@ bool build_type14(PlayerType *player_ptr, DungeonData *dd_ptr)
 
     /* Walls around the room */
     for (auto y = y1 - 1; y <= y2 + 1; y++) {
-        place_grid(player_ptr, &floor.get_grid({ y, x1 - 1 }), GB_OUTER);
-        place_grid(player_ptr, &floor.get_grid({ y, x2 + 1 }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y, x1 - 1 }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y, x2 + 1 }), GB_OUTER);
     }
 
     for (auto x = x1 - 1; x <= x2 + 1; x++) {
-        place_grid(player_ptr, &floor.get_grid({ y1 - 1, x }), GB_OUTER);
-        place_grid(player_ptr, &floor.get_grid({ y2 + 1, x }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y1 - 1, x }), GB_OUTER);
+        place_grid(player_ptr, floor.get_grid({ y2 + 1, x }), GB_OUTER);
     }
 
     const auto trap = floor.dun_level < 30 + randint1(30) ? TerrainTag::TRAP_PIRANHA : TerrainTag::TRAP_ARMAGEDDON;

--- a/src/room/rooms-vault.cpp
+++ b/src/room/rooms-vault.cpp
@@ -340,7 +340,7 @@ static void build_vault(
             auto &grid = floor.get_grid(pos);
 
             /* Lay down a floor */
-            place_grid(player_ptr, &grid, GB_FLOOR);
+            place_grid(player_ptr, grid, GB_FLOOR);
             grid.mimic = 0;
 
             /* Part of a vault */
@@ -349,20 +349,20 @@ static void build_vault(
             /* Analyze the grid */
             switch (*t) {
             case '%':
-                place_grid(player_ptr, &grid, GB_OUTER_NOPERM);
+                place_grid(player_ptr, grid, GB_OUTER_NOPERM);
                 break;
             case '#':
-                place_grid(player_ptr, &grid, GB_INNER);
+                place_grid(player_ptr, grid, GB_INNER);
                 break;
             case '$':
-                place_grid(player_ptr, &grid, GB_INNER);
+                place_grid(player_ptr, grid, GB_INNER);
                 grid.set_terrain_id(TerrainTag::GLASS_WALL);
                 break;
             case 'X':
-                place_grid(player_ptr, &grid, GB_INNER_PERM);
+                place_grid(player_ptr, grid, GB_INNER_PERM);
                 break;
             case 'Y':
-                place_grid(player_ptr, &grid, GB_INNER_PERM);
+                place_grid(player_ptr, grid, GB_INNER_PERM);
                 grid.set_terrain_id(TerrainTag::PERMANENT_GLASS_WALL);
                 break;
             case '*':
@@ -785,7 +785,7 @@ static void build_mini_c_vault(PlayerType *player_ptr, const Pos2D &center, cons
             grid.info |= (CAVE_ROOM | CAVE_ICKY);
 
             /* Permanent walls */
-            place_grid(player_ptr, &grid, GB_INNER_PERM);
+            place_grid(player_ptr, grid, GB_INNER_PERM);
         }
     }
 

--- a/src/room/vault-builder.cpp
+++ b/src/room/vault-builder.cpp
@@ -119,7 +119,6 @@ void vault_objects(PlayerType *player_ptr, POSITION y, POSITION x, int num)
  */
 static void vault_trap_aux(FloorType &floor, POSITION y, POSITION x, POSITION yd, POSITION xd)
 {
-    Grid *g_ptr;
     int y1 = y, x1 = x;
     int dummy = 0;
     for (int count = 0; count <= 5; count++) {
@@ -137,7 +136,7 @@ static void vault_trap_aux(FloorType &floor, POSITION y, POSITION x, POSITION yd
             msg_print(_("警告！地下室のトラップを配置できません！", "Warning! Could not place vault trap!"));
         }
 
-        g_ptr = &floor.grid_array[y1][x1];
+        auto *g_ptr = &floor.grid_array[y1][x1];
         if (!g_ptr->is_floor() || !g_ptr->o_idx_list.empty() || g_ptr->has_monster()) {
             continue;
         }

--- a/src/room/vault-builder.cpp
+++ b/src/room/vault-builder.cpp
@@ -16,19 +16,19 @@
 /*
  * Grid based version of "creature_bold()"
  */
-static bool player_grid(PlayerType *player_ptr, Grid *g_ptr)
+static bool player_grid(PlayerType *player_ptr, const Grid &grid)
 {
-    return g_ptr == &player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x];
+    return &grid == &player_ptr->current_floor_ptr->grid_array[player_ptr->y][player_ptr->x];
 }
 
 /*
  * Grid based version of "cave_empty_bold()"
  */
-static bool is_cave_empty_grid(PlayerType *player_ptr, Grid *g_ptr)
+static bool is_cave_empty_grid(PlayerType *player_ptr, const Grid &grid)
 {
-    bool is_empty_grid = g_ptr->has(TerrainCharacteristics::PLACE);
-    is_empty_grid &= !g_ptr->has_monster();
-    is_empty_grid &= !player_grid(player_ptr, g_ptr);
+    bool is_empty_grid = grid.has(TerrainCharacteristics::PLACE);
+    is_empty_grid &= !grid.has_monster();
+    is_empty_grid &= !player_grid(player_ptr, grid);
     return is_empty_grid;
 }
 
@@ -49,7 +49,7 @@ void vault_monsters(PlayerType *player_ptr, POSITION y1, POSITION x1, int num)
             const auto d = 1;
             const auto pos = scatter(player_ptr, { y1, x1 }, d, 0);
             auto &grid = floor.get_grid(pos);
-            if (!is_cave_empty_grid(player_ptr, &grid)) {
+            if (!is_cave_empty_grid(player_ptr, grid)) {
                 continue;
             }
 
@@ -136,8 +136,8 @@ static void vault_trap_aux(FloorType &floor, POSITION y, POSITION x, POSITION yd
             msg_print(_("警告！地下室のトラップを配置できません！", "Warning! Could not place vault trap!"));
         }
 
-        auto *g_ptr = &floor.grid_array[y1][x1];
-        if (!g_ptr->is_floor() || !g_ptr->o_idx_list.empty() || g_ptr->has_monster()) {
+        const auto &grid = floor.grid_array[y1][x1];
+        if (!grid.is_floor() || !grid.o_idx_list.empty() || grid.has_monster()) {
             continue;
         }
 

--- a/src/specific-object/torch.cpp
+++ b/src/specific-object/torch.cpp
@@ -268,8 +268,8 @@ void update_lite(PlayerType *player_ptr)
     for (int i = 0; i < floor.lite_n; i++) {
         POSITION y = floor.lite_y[i];
         POSITION x = floor.lite_x[i];
-        auto *g_ptr = &floor.grid_array[y][x];
-        if (g_ptr->info & CAVE_TEMP) {
+        const auto &grid = floor.grid_array[y][x];
+        if (grid.info & CAVE_TEMP) {
             continue;
         }
 
@@ -278,9 +278,9 @@ void update_lite(PlayerType *player_ptr)
 
     // 前回照らされていた座標たちのうち、状態が変わったものについて再描画フラグを立てる。
     for (const auto &[y, x] : points) {
-        auto *g_ptr = &floor.grid_array[y][x];
-        g_ptr->info &= ~(CAVE_TEMP);
-        if (g_ptr->info & CAVE_LITE) {
+        auto &grid = floor.grid_array[y][x];
+        grid.info &= ~(CAVE_TEMP);
+        if (grid.info & CAVE_LITE) {
             continue;
         }
 

--- a/src/spell-class/spells-mirror-master.cpp
+++ b/src/spell-class/spells-mirror-master.cpp
@@ -405,14 +405,14 @@ static bool activate_super_ray_effect(PlayerType *player_ptr, int y, int x, int 
     (void)affect_monster(player_ptr, 0, 0, y, x, dam, typ, flag, true);
 
     const auto &floor = *player_ptr->current_floor_ptr;
-    const auto *g_ptr = &floor.grid_array[project_m_y][project_m_x];
-    const auto *m_ptr = &floor.m_list[g_ptr->m_idx];
-    if (project_m_n == 1 && g_ptr->has_monster() && m_ptr->ml) {
+    const auto &grid = floor.grid_array[project_m_y][project_m_x];
+    const auto *m_ptr = &floor.m_list[grid.m_idx];
+    if (project_m_n == 1 && grid.has_monster() && m_ptr->ml) {
         if (!player_ptr->effects()->hallucination().is_hallucinated()) {
             LoreTracker::get_instance().set_trackee(m_ptr->ap_r_idx);
         }
 
-        health_track(player_ptr, g_ptr->m_idx);
+        health_track(player_ptr, grid.m_idx);
     }
 
     return notice;

--- a/src/spell-kind/blood-curse.cpp
+++ b/src/spell-kind/blood-curse.cpp
@@ -20,7 +20,7 @@
 void blood_curse_to_enemy(PlayerType *player_ptr, MONSTER_IDX m_idx)
 {
     auto *m_ptr = &player_ptr->current_floor_ptr->m_list[m_idx];
-    auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[m_ptr->fy][m_ptr->fx];
+    const auto &grid = player_ptr->current_floor_ptr->grid_array[m_ptr->fy][m_ptr->fx];
     BIT_FLAGS curse_flg = (PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_JUMP);
     int count = 0;
     bool is_first_loop = true;
@@ -55,7 +55,7 @@ void blood_curse_to_enemy(PlayerType *player_ptr, MONSTER_IDX m_idx)
             if (!count) {
                 msg_print(_("空間が歪んだ！", "Space warps about you!"));
                 if (m_ptr->is_valid()) {
-                    teleport_away(player_ptr, g_ptr->m_idx, Dice::roll(10, 10), TELEPORT_PASSIVE);
+                    teleport_away(player_ptr, grid.m_idx, Dice::roll(10, 10), TELEPORT_PASSIVE);
                 }
                 if (one_in_(13)) {
                     count += activate_hi_summon(player_ptr, m_ptr->fy, m_ptr->fx, true);

--- a/src/spell-kind/spells-detection.cpp
+++ b/src/spell-kind/spells-detection.cpp
@@ -41,23 +41,23 @@ static bool detect_feat_flag(PlayerType *player_ptr, POSITION range, TerrainChar
                 continue;
             }
 
-            auto *g_ptr = &floor.grid_array[y][x];
+            auto &grid = floor.grid_array[y][x];
             if (flag == TerrainCharacteristics::TRAP) {
                 /* Mark as detected */
                 if (dist <= range && known) {
                     if (dist <= range - 1) {
-                        g_ptr->info |= (CAVE_IN_DETECT);
+                        grid.info |= (CAVE_IN_DETECT);
                     }
 
-                    g_ptr->info &= ~(CAVE_UNSAFE);
+                    grid.info &= ~(CAVE_UNSAFE);
 
                     lite_spot(player_ptr, y, x);
                 }
             }
 
-            if (g_ptr->has(flag)) {
+            if (grid.has(flag)) {
                 disclose_grid(player_ptr, y, x);
-                g_ptr->info |= (CAVE_MARK);
+                grid.info |= (CAVE_MARK);
                 lite_spot(player_ptr, y, x);
                 detect = true;
             }

--- a/src/spell-kind/spells-fetcher.cpp
+++ b/src/spell-kind/spells-fetcher.cpp
@@ -45,7 +45,7 @@ void fetch_item(PlayerType *player_ptr, DIRECTION dir, WEIGHT wgt, bool require_
         return;
     }
 
-    Grid *g_ptr;
+    Grid *grid_ptr;
     const auto &system = AngbandSystem::get_instance();
     if (dir == 5 && target_okay(player_ptr)) {
         const Pos2D pos(target_col, target_row);
@@ -54,13 +54,13 @@ void fetch_item(PlayerType *player_ptr, DIRECTION dir, WEIGHT wgt, bool require_
             return;
         }
 
-        g_ptr = &floor.get_grid(pos);
-        if (g_ptr->o_idx_list.empty()) {
+        grid_ptr = &floor.get_grid(pos);
+        if (grid_ptr->o_idx_list.empty()) {
             msg_print(_("そこには何もありません。", "There is no object there."));
             return;
         }
 
-        if (g_ptr->is_icky()) {
+        if (grid_ptr->is_icky()) {
             msg_print(_("アイテムがコントロールを外れて落ちた。", "The item slips from your control."));
             return;
         }
@@ -77,11 +77,11 @@ void fetch_item(PlayerType *player_ptr, DIRECTION dir, WEIGHT wgt, bool require_
     } else {
         auto pos = p_pos;
         auto is_first_loop = true;
-        g_ptr = &floor.get_grid(pos);
-        while (is_first_loop || g_ptr->o_idx_list.empty()) {
+        grid_ptr = &floor.get_grid(pos);
+        while (is_first_loop || grid_ptr->o_idx_list.empty()) {
             is_first_loop = false;
             pos += Pos2DVec(ddy[dir], ddx[dir]);
-            g_ptr = &floor.get_grid(pos);
+            grid_ptr = &floor.get_grid(pos);
             if ((Grid::calc_distance(p_pos, pos) > system.get_max_range())) {
                 return;
             }
@@ -92,14 +92,14 @@ void fetch_item(PlayerType *player_ptr, DIRECTION dir, WEIGHT wgt, bool require_
         }
     }
 
-    auto &item = floor.o_list[g_ptr->o_idx_list.front()];
+    auto &item = floor.o_list[grid_ptr->o_idx_list.front()];
     if (item.weight > wgt) {
         msg_print(_("そのアイテムは重過ぎます。", "The object is too heavy."));
         return;
     }
 
-    const auto item_idx = g_ptr->o_idx_list.front();
-    g_ptr->o_idx_list.pop_front();
+    const auto item_idx = grid_ptr->o_idx_list.front();
+    grid_ptr->o_idx_list.pop_front();
     floor.get_grid(p_pos).o_idx_list.add(floor, item_idx); /* 'move' it */
     item.set_position(p_pos);
 

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -125,11 +125,11 @@ void wiz_dark(PlayerType *player_ptr)
     /* Forget every grid */
     for (POSITION y = 1; y < player_ptr->current_floor_ptr->height - 1; y++) {
         for (POSITION x = 1; x < player_ptr->current_floor_ptr->width - 1; x++) {
-            auto *g_ptr = &player_ptr->current_floor_ptr->grid_array[y][x];
+            auto &grid = player_ptr->current_floor_ptr->grid_array[y][x];
 
             /* Process the grid */
-            g_ptr->info &= ~(CAVE_MARK | CAVE_IN_DETECT | CAVE_KNOWN);
-            g_ptr->info |= (CAVE_UNSAFE);
+            grid.info &= ~(CAVE_MARK | CAVE_IN_DETECT | CAVE_KNOWN);
+            grid.info |= (CAVE_UNSAFE);
         }
     }
 
@@ -396,7 +396,7 @@ bool destroy_area(PlayerType *player_ptr, const POSITION y1, const POSITION x1, 
 
             if (t < 20) {
                 /* Create granite wall */
-                place_grid(player_ptr, &grid, GB_EXTRA);
+                place_grid(player_ptr, grid, GB_EXTRA);
             } else if (t < 70) {
                 /* Create quartz vein */
                 grid.set_terrain_id(TerrainTag::QUARTZ_VEIN);
@@ -405,7 +405,7 @@ bool destroy_area(PlayerType *player_ptr, const POSITION y1, const POSITION x1, 
                 grid.set_terrain_id(TerrainTag::MAGMA_VEIN);
             } else {
                 /* Create floor */
-                place_grid(player_ptr, &grid, GB_FLOOR);
+                place_grid(player_ptr, grid, GB_FLOOR);
             }
 
             /* Clear garbage of hidden trap or door */

--- a/src/spell-kind/spells-polymorph.cpp
+++ b/src/spell-kind/spells-polymorph.cpp
@@ -68,12 +68,12 @@ static MonraceId select_polymorph_monrace_id(PlayerType *player_ptr, MonraceId m
 bool polymorph_monster(PlayerType *player_ptr, POSITION y, POSITION x)
 {
     auto &floor = *player_ptr->current_floor_ptr;
-    auto *g_ptr = &floor.grid_array[y][x];
-    auto *m_ptr = &floor.m_list[g_ptr->m_idx];
+    const auto &grid = floor.grid_array[y][x];
+    auto *m_ptr = &floor.m_list[grid.m_idx];
     MonraceId new_r_idx;
     MonraceId old_r_idx = m_ptr->r_idx;
-    bool targeted = target_who == g_ptr->m_idx;
-    auto health_tracked = HealthBarTracker::get_instance().is_tracking(g_ptr->m_idx);
+    bool targeted = target_who == grid.m_idx;
+    auto health_tracked = HealthBarTracker::get_instance().is_tracking(grid.m_idx);
 
     if (floor.inside_arena || AngbandSystem::get_instance().is_phase_out()) {
         return false;
@@ -102,7 +102,7 @@ bool polymorph_monster(PlayerType *player_ptr, POSITION y, POSITION x)
     }
 
     m_ptr->hold_o_idx_list.clear();
-    delete_monster_idx(player_ptr, g_ptr->m_idx);
+    delete_monster_idx(player_ptr, grid.m_idx);
     bool polymorphed = false;
     auto m_idx = place_specific_monster(player_ptr, y, x, new_r_idx, mode);
     if (m_idx) {

--- a/src/target/grid-selector.cpp
+++ b/src/target/grid-selector.cpp
@@ -74,20 +74,20 @@ static std::vector<Pos2D> tgt_pt_prepare(PlayerType *player_ptr)
 /*!
  * @brief 指定したシンボルのマスかどうかを判定するための条件式コールバック
  */
-std::unordered_map<int, std::function<bool(Grid *)>> tgt_pt_symbol_call_back = {
-    { '<', [](Grid *g_ptr) { return g_ptr->has(TerrainCharacteristics::STAIRS) && g_ptr->has(TerrainCharacteristics::LESS); } },
-    { '>', [](Grid *g_ptr) { return g_ptr->has(TerrainCharacteristics::STAIRS) && g_ptr->has(TerrainCharacteristics::MORE); } },
-    { '+', [](Grid *g_ptr) { return g_ptr->has(TerrainCharacteristics::BLDG); } },
-    { '0', [](Grid *g_ptr) { return g_ptr->has(TerrainCharacteristics::STORE) && g_ptr->is_symbol('0'); } },
-    { '!', [](Grid *g_ptr) { return g_ptr->has(TerrainCharacteristics::STORE) && g_ptr->is_symbol('1'); } },
-    { '"', [](Grid *g_ptr) { return g_ptr->has(TerrainCharacteristics::STORE) && g_ptr->is_symbol('2'); } },
-    { '#', [](Grid *g_ptr) { return g_ptr->has(TerrainCharacteristics::STORE) && g_ptr->is_symbol('3'); } },
-    { '$', [](Grid *g_ptr) { return g_ptr->has(TerrainCharacteristics::STORE) && g_ptr->is_symbol('4'); } },
-    { '%', [](Grid *g_ptr) { return g_ptr->has(TerrainCharacteristics::STORE) && g_ptr->is_symbol('5'); } },
-    { '&', [](Grid *g_ptr) { return g_ptr->has(TerrainCharacteristics::STORE) && g_ptr->is_symbol('6'); } },
-    { '\'', [](Grid *g_ptr) { return g_ptr->has(TerrainCharacteristics::STORE) && g_ptr->is_symbol('7'); } },
-    { '(', [](Grid *g_ptr) { return g_ptr->has(TerrainCharacteristics::STORE) && g_ptr->is_symbol('8'); } },
-    { ')', [](Grid *g_ptr) { return g_ptr->has(TerrainCharacteristics::STORE) && g_ptr->is_symbol('9'); } },
+std::unordered_map<int, std::function<bool(const Grid &)>> tgt_pt_symbol_call_back = {
+    { '<', [](const Grid &grid) { return grid.has(TerrainCharacteristics::STAIRS) && grid.has(TerrainCharacteristics::LESS); } },
+    { '>', [](const Grid &grid) { return grid.has(TerrainCharacteristics::STAIRS) && grid.has(TerrainCharacteristics::MORE); } },
+    { '+', [](const Grid &grid) { return grid.has(TerrainCharacteristics::BLDG); } },
+    { '0', [](const Grid &grid) { return grid.has(TerrainCharacteristics::STORE) && grid.is_symbol('0'); } },
+    { '!', [](const Grid &grid) { return grid.has(TerrainCharacteristics::STORE) && grid.is_symbol('1'); } },
+    { '"', [](const Grid &grid) { return grid.has(TerrainCharacteristics::STORE) && grid.is_symbol('2'); } },
+    { '#', [](const Grid &grid) { return grid.has(TerrainCharacteristics::STORE) && grid.is_symbol('3'); } },
+    { '$', [](const Grid &grid) { return grid.has(TerrainCharacteristics::STORE) && grid.is_symbol('4'); } },
+    { '%', [](const Grid &grid) { return grid.has(TerrainCharacteristics::STORE) && grid.is_symbol('5'); } },
+    { '&', [](const Grid &grid) { return grid.has(TerrainCharacteristics::STORE) && grid.is_symbol('6'); } },
+    { '\'', [](const Grid &grid) { return grid.has(TerrainCharacteristics::STORE) && grid.is_symbol('7'); } },
+    { '(', [](const Grid &grid) { return grid.has(TerrainCharacteristics::STORE) && grid.is_symbol('8'); } },
+    { ')', [](const Grid &grid) { return grid.has(TerrainCharacteristics::STORE) && grid.is_symbol('9'); } },
 };
 
 /*!
@@ -106,7 +106,7 @@ struct tgt_pt_info {
     size_t n = 0; //<! シンボル配列の何番目か
     char ch = '\0'; //<! 入力キー
     char prev_ch = '\0'; //<! 前回入力キー
-    std::function<bool(Grid *)> callback{}; //<! 条件判定コールバック
+    std::function<bool(const Grid &)> callback{}; //<! 条件判定コールバック
 
     void move_to_symbol(PlayerType *player_ptr);
 };
@@ -134,8 +134,8 @@ void tgt_pt_info::move_to_symbol(PlayerType *player_ptr)
     const auto size = this->positions.size();
     for (; this->n < size; ++this->n) {
         const auto &pos_cur = this->positions.at(this->n);
-        auto *g_ptr = &player_ptr->current_floor_ptr->get_grid(pos_cur);
-        if (this->callback(g_ptr)) {
+        const auto &grid = player_ptr->current_floor_ptr->get_grid(pos_cur);
+        if (this->callback(grid)) {
             break;
         }
     }

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -528,13 +528,13 @@ void fix_object(PlayerType *player_ptr)
  * @details
  * Lookコマンドでカーソルを合わせた場合に合わせてミミックは考慮しない。
  */
-static const MonsterEntity *monster_on_floor_items(const FloorType &floor, const Grid *g_ptr)
+static const MonsterEntity *monster_on_floor_items(const FloorType &floor, const Grid &grid)
 {
-    if (!g_ptr->has_monster()) {
+    if (!grid.has_monster()) {
         return nullptr;
     }
 
-    auto m_ptr = &floor.m_list[g_ptr->m_idx];
+    auto m_ptr = &floor.m_list[grid.m_idx];
     if (!m_ptr->is_valid() || !m_ptr->ml) {
         return nullptr;
     }
@@ -566,7 +566,7 @@ static void display_floor_item_list(PlayerType *player_ptr, const Pos2D &pos)
     const auto is_hallucinated = player_ptr->effects()->hallucination().is_hallucinated();
     if (player_ptr->is_located_at(pos)) {
         line = format(_("(X:%03d Y:%03d) あなたの足元のアイテム一覧", "Items at (%03d,%03d) under you"), pos.x, pos.y);
-    } else if (const auto *m_ptr = monster_on_floor_items(floor, &grid); m_ptr != nullptr) {
+    } else if (const auto *m_ptr = monster_on_floor_items(floor, grid); m_ptr != nullptr) {
         if (is_hallucinated) {
             line = format(_("(X:%03d Y:%03d) 何か奇妙な物の足元の発見済みアイテム一覧", "Found items at (%03d,%03d) under something strange"), pos.x, pos.y);
         } else {

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -523,7 +523,7 @@ void fix_object(PlayerType *player_ptr)
 /*!
  * @brief 床上のモンスター情報を返す
  * @param floor フロアへの参照
- * @param grid_prt 座標グリッドの情報への参照ポインタ
+ * @param grid グリッドへの参照
  * @return モンスターが見える場合にはモンスター情報への参照ポインタ、それ以外はnullptr
  * @details
  * Lookコマンドでカーソルを合わせた場合に合わせてミミックは考慮しない。


### PR DESCRIPTION
Resolves #4931 

<details>

<summary>変換スクリプト</summary>

```python
import re
import sys


def process_file(filepath):
    with open(filepath, "r", encoding="utf-8") as f:
        text = f.read()

    text = re.sub(
        r"(const\s+)?Grid \*g_ptr([,)])",
        lambda m: (m.group(1) if m.group(1) else "const ") + "Grid &grid" + m.group(2),
        text,
    )
    text = re.sub(
        r"(const\s+)?auto \*g_ptr(\d)? = &",
        lambda m: (m.group(1) if m.group(1) else "const ")
        + "auto &grid"
        + (m.group(2) if m.group(2) else "")
        + " = ",
        text,
    )
    text = re.sub(
        r"(const\s+)?auto \*g_ptr(\d)? = ([^&])",
        lambda m: (m.group(1) if m.group(1) else "const ")
        + "auto &grid"
        + (m.group(2) if m.group(2) else "")
        + " = *"
        + m.group(3),
        text,
    )

    text = re.sub(r"([^>\w])g_ptr(\d)?->", "\\1grid\\2.", text)

    text = re.sub(r"(, |\()&grid([_a-z]+)?([,)])", "\\1grid\\2\\3", text)
    text = re.sub(r"(, |\()g_ptr([,)])", "\\1grid\\2", text)

    text = text.replace(
        "place_grid(player_ptr, &floor.get_grid",
        "place_grid(player_ptr, floor.get_grid",
    )
    text = text.replace(
        "place_grid(player_ptr, &floor.grid_array",
        "place_grid(player_ptr, floor.grid_array",
    )

    text = text.replace(
        "std::function<bool(Grid *)>", "std::function<bool(const Grid &)>"
    )

    text = text.replace("g_ptr ==", "&grid ==")

    text = text.replace("return g_ptr;", "return &grid;")

    with open(filepath, "w", encoding="utf-8") as f:
        f.write(text)


def main():
    for filepath in sys.argv[1:]:
        process_file(filepath)


if __name__ == "__main__":
    main()
```

</details>