### PR TITLE
[Feature] カオス耐性による混乱防御の仕様変更

### DIFF
--- a/src/effect/effect-monster.cpp
+++ b/src/effect/effect-monster.cpp
@@ -437,7 +437,7 @@ static void effect_damage_piles_stun(PlayerType *player_ptr, EffectMonster *em_p
  */
 static void effect_damage_piles_confusion(PlayerType *player_ptr, EffectMonster *em_ptr)
 {
-    if ((em_ptr->do_conf == 0) || (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_CONF)) || em_ptr->r_ptr->resistance_flags.has_any_of(RFR_EFF_RESIST_CHAOS_MASK)) {
+    if ((em_ptr->do_conf == 0) || (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::NO_CONF))) {
         return;
     }
 

--- a/src/effect/effect-player-resist-hurt.cpp
+++ b/src/effect/effect-player-resist-hurt.cpp
@@ -246,7 +246,7 @@ void effect_player_chaos(PlayerType *player_ptr, EffectPlayerType *ep_ptr)
     }
 
     BadStatusSetter bss(player_ptr);
-    if (!has_resist_conf(player_ptr)) {
+    if (!has_resist_conf(player_ptr) && !has_resist_chaos(player_ptr)) {
         (void)bss.mod_confusion(randint0(20) + 10);
     }
 


### PR DESCRIPTION
カオス耐性を持ち、混乱耐性を持たない場合の挙動がプレイヤーモンスター間で統一されておらず、非常に分かりにくいので一貫性のある仕様を改めて定義する。

カオス属性攻撃を受けた場合：混乱しない
それ以外の要素で混乱させられる場合：混乱する

関連#4929