### PR TITLE
[Feature] モンスターが朦朧とする処理の修正

### DIFF
--- a/src/effect/effect-monster-resist-hurt.cpp
+++ b/src/effect/effect-monster-resist-hurt.cpp
@@ -577,6 +577,7 @@ static void effect_monster_gravity_stun(EffectMonster *em_ptr)
     em_ptr->do_stun = Dice::roll((em_ptr->caster_lev / 20) + 3, (em_ptr->dam)) + 1;
     bool has_resistance = em_ptr->r_ptr->kind_flags.has(MonsterKindType::UNIQUE);
     has_resistance |= (em_ptr->r_ptr->level > randint1(std::max(1, em_ptr->dam - 10)) + 10);
+    has_resistance |= em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::RESIST_GRAVITY);
     if (has_resistance) {
         em_ptr->do_stun = 0;
         return;
@@ -639,7 +640,10 @@ ProcessResult effect_monster_icee_bolt(PlayerType *player_ptr, EffectMonster *em
         em_ptr->obvious = true;
     }
 
-    em_ptr->do_stun = (randint1(15) + 1) / (em_ptr->r + 1);
+    if (em_ptr->r_ptr->resistance_flags.has_not(MonsterResistanceType::RESIST_SOUND)) {
+        em_ptr->do_stun = (randint1(15) + 1) / (em_ptr->r + 1);
+    }
+
     if (em_ptr->r_ptr->resistance_flags.has(MonsterResistanceType::IMMUNE_COLD)) {
         em_ptr->note = _("にはかなり耐性がある！", " resists a lot.");
         em_ptr->dam /= 9;

--- a/src/effect/effect-monster.cpp
+++ b/src/effect/effect-monster.cpp
@@ -406,7 +406,6 @@ static void effect_damage_piles_stun(PlayerType *player_ptr, EffectMonster *em_p
 {
     const auto *r_ptr = em_ptr->r_ptr;
     auto can_avoid_stun = em_ptr->do_stun == 0;
-    can_avoid_stun |= r_ptr->resistance_flags.has_any_of({ MonsterResistanceType::RESIST_SOUND, MonsterResistanceType::RESIST_FORCE });
     can_avoid_stun |= r_ptr->resistance_flags.has(MonsterResistanceType::NO_STUN);
     if (can_avoid_stun) {
         return;


### PR DESCRIPTION
これまではほぼ全ての朦朧とする処理に対して轟音耐性とフォース耐性が有効であった。
耐性と無関係の種別の攻撃まで朦朧を防ぐのは不自然かつプレイヤー側との対称性がないため、以下のように修正する。

- NO_STUNフラグがなければ朦朧とする。
- 例外は以下
-- 轟音耐性を持つとき、轟音属性攻撃由来の朦朧は防がれる
-- フォース耐性を持つとき、フォース属性攻撃由来の朦朧は防がれる
-- 重力耐性を持つとき、重力攻撃由来の朦朧は防がれる
-- 轟音耐性を持つとき、極寒属性由来の朦朧は防がれる

現在プラズマ属性、ロケット属性はモンスターに朦朧を付与しないため、プレイヤー側はこれらによる朦朧を轟音耐性で防ぐがこれは無視する。
プレイヤー側は重力攻撃による朦朧を浮遊と轟音耐性により防ぐが、モンスター側には重力耐性が定義されているためこれを使用する。