### PR TITLE
[Refactor] 幻覚時のランダム表示されるモンスター名の処理

### DIFF
--- a/src/monster/monster-describer.cpp
+++ b/src/monster/monster-describer.cpp
@@ -137,12 +137,9 @@ static std::string get_describing_monster_name(const MonsterEntity &monster, con
         }
     }
 
-    const MonraceDefinition *hallu_race = nullptr;
     const auto &monraces = MonraceList::get_instance();
-    do {
-        hallu_race = &monraces.pick_monrace_at_random();
-    } while (hallu_race->kind_flags.has(MonsterKindType::UNIQUE));
-    return hallu_race->name.string();
+    const auto ids = monraces.search([](const auto &monrace) { return monrace.kind_flags.has_not(MonsterKindType::UNIQUE); });
+    return monraces.get_monrace(rand_choice(ids)).name.string();
 }
 
 #ifdef JP

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -423,14 +423,12 @@ void monster_gain_exp(PlayerType *player_ptr, MONSTER_IDX m_idx, MonraceId monra
         const auto is_hallucinated = player_ptr->effects()->hallucination().is_hallucinated();
         if (!ignore_unview || player_can_see_bold(player_ptr, monster.fy, monster.fx)) {
             if (is_hallucinated) {
-                const MonraceDefinition *hallucinated_race = nullptr;
-                do {
-                    hallucinated_race = &monraces.pick_monrace_at_random();
-                } while (hallucinated_race->kind_flags.has(MonsterKindType::UNIQUE));
+                const auto ids = monraces.search([](const auto &monrace) { return monrace.kind_flags.has_not(MonsterKindType::UNIQUE); });
+                const auto &monrace_hallucinated = monraces.get_monrace(rand_choice(ids));
                 auto mes_evolution = _("%sは%sに進化した。", "%s^ evolved into %s.");
                 auto mes_degeneration = _("%sは%sに退化した。", "%s^ degenerated into %s.");
                 auto mes = randint0(2) == 0 ? mes_evolution : mes_degeneration;
-                msg_format(mes, m_name.data(), hallucinated_race->name.data());
+                msg_format(mes, m_name.data(), monrace_hallucinated.name.data());
             } else {
                 msg_format(_("%sは%sに進化した。", "%s^ evolved into %s."), m_name.data(), new_monrace.name.data());
             }


### PR DESCRIPTION
幻覚時にランダム表示されるモンスター名の候補決定処理を MonraceList::search() により行うようにする。
これにより、コード内でnullptrを使用することを避けることができる。

r_ptr を monrace に置き換える作業をどうやろうかと r_ptr を眺めている時に nullptr の使用箇所があったので先に対処しておく。