### PR TITLE
[Refactor] MonraceAllocationTable::initialize()

### DIFF
--- a/src/system/monrace/monrace-list.cpp
+++ b/src/system/monrace/monrace-list.cpp
@@ -216,26 +216,6 @@ bool MonraceList::is_angel(MonraceId monrace_id) const
     return is_angel;
 }
 
-//!< @todo ややトリッキーだが、元のmapでMonsterRaceInfo をshared_ptr で持つようにすればかなりスッキリ書けるはず.
-const std::vector<std::pair<MonraceId, const MonraceDefinition *>> &MonraceList::get_sorted_monraces() const
-{
-    static std::vector<std::pair<MonraceId, const MonraceDefinition *>> sorted_monraces;
-    if (!sorted_monraces.empty()) {
-        return sorted_monraces;
-    }
-
-    for (const auto &pair : this->monraces) {
-        if (pair.second.is_valid()) {
-            sorted_monraces.emplace_back(pair.first, &pair.second);
-        }
-    }
-
-    std::stable_sort(sorted_monraces.begin(), sorted_monraces.end(), [](const auto &pair1, const auto &pair2) {
-        return pair2.second->order_level_strictly(*pair1.second);
-    });
-    return sorted_monraces;
-}
-
 /*!
  * @brief 合体/分離ユニーク判定
  * @param monrace_id 調査対象のモンスター種族ID

--- a/src/system/monrace/monrace-list.h
+++ b/src/system/monrace/monrace-list.h
@@ -38,7 +38,6 @@ public:
     std::vector<MonraceId> search(std::function<bool(const MonraceDefinition &)> filter, bool is_known_only = false) const;
     std::vector<MonraceId> search_by_name(std::string_view name, bool is_known_only = false) const;
     std::vector<MonraceId> search_by_symbol(char symbol, bool is_known_only) const;
-    const std::vector<std::pair<MonraceId, const MonraceDefinition *>> &get_sorted_monraces() const;
     bool is_angel(MonraceId monrace_id) const;
     bool can_unify_separate(MonraceId monrace_id) const;
     void kill_unified_unique(MonraceId monrace_id);


### PR DESCRIPTION
テーブルのソートはMonraceAllocationTable自身が行うべきものなので、MonraceList::get_sorted_monraces() に頼らず自前で処理するようにする。
MonraceList::get_sorted_monnaces() は当該の処理のみでしか使用されて いないため削除する。

これも `MonraceDefinition *r_ptr` を参照に変えるうえで邪魔になってくるところの事前修正。