### PR TITLE
[Fix] 固定アーティファクトのデバッグ生成の名前表示

### DIFF
--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -194,8 +194,7 @@ static std::string wiz_make_named_artifact_desc(PlayerType *player_ptr, FixedArt
     const auto &artifact = ArtifactList::get_instance().get_artifact(fa_id);
     ItemEntity item(artifact.bi_key);
     item.fa_id = fa_id;
-    item.mark_as_known();
-    return describe_flavor(player_ptr, item, OD_NAME_ONLY);
+    return describe_flavor(player_ptr, item, OD_NAME_ONLY | OD_STORE);
 }
 
 /**


### PR DESCRIPTION
装飾品はItemEntity::known = trueだけだとおかしな表示になる。
describe_flavor の mode 引数に OD_STORE を設定すると店舗に並んだ時の表示となり最も適切と思われるのでそのように修正する。

Fix #4942 

装飾品のリストを表示させてみましたが問題なさそうです。
