### PR TITLE
[Fix] デバッグコマンドのモンスター生成で^Iが効かないことがある

### DIFF
--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -13,6 +13,7 @@
 #include "floor/floor-util.h"
 #include "floor/pattern-walk.h"
 #include "io/gf-descriptions.h"
+#include "io/input-key-acceptor.h"
 #include "mind/mind-blue-mage.h"
 #include "monster-floor/monster-generator.h"
 #include "monster-floor/monster-summon.h"
@@ -80,18 +81,19 @@ std::optional<MonraceId> wiz_select_summon_monrace_id(MonraceId monrace_id)
         return monrace_id;
     }
 
-    constexpr auto prompt = "Enter monster symbol character(^M:Search by name, ^I:Input MonsterID): ";
-    const auto symbol = input_command(prompt);
-    if (!symbol) {
+    prt("Enter monster symbol character(^M:Search by name, ^I:Input MonsterID): ", 0, 0);
+    const auto skey = inkey_special(false);
+    prt("", 0, 0);
+    if ((skey & SKEY_MASK) || skey == ESCAPE) {
         return std::nullopt;
     }
 
     const auto &monraces = MonraceList::get_instance();
-    if (*symbol == KTRL('I')) {
+    if (skey == KTRL('I')) {
         return input_numerics("MonsterID", 1, monraces.size() - 1, MonraceId::FILTHY_URCHIN);
     }
 
-    const auto monrace_ids = wiz_collect_monster_candidates(*symbol);
+    const auto monrace_ids = wiz_collect_monster_candidates(static_cast<char>(skey));
     if (monrace_ids.empty()) {
         return std::nullopt;
     }


### PR DESCRIPTION
デバッグコマンドによるモンスター生成 (^An) で ^I を入力するとモンスターのID番号による入力を行えるが、この時 ^I（あるいはTABキー）にマクロを設定しているとマクロの内容が入力されてしまい正常に動作しない。
通常のコマンド入力関数 input_command() ではなく inkey_special() を 使用することで入力したキーそのものを取得するように修正する。

Fix #4945 