### PR TITLE
[Fix] X11版: 基本ウェイト量が0でもスリープしてしまう

### DIFF
--- a/src/main-x11.cpp
+++ b/src/main-x11.cpp
@@ -1970,7 +1970,9 @@ static errr game_term_xtra_x11(int n, int v)
         s_ptr->drawn = false;
         return 0;
     case TERM_XTRA_DELAY:
-        usleep(1000 * v);
+        if (v > 0) {
+            usleep(1000 * v);
+        }
         return 0;
     case TERM_XTRA_REACT:
         return game_term_xtra_x11_react();


### PR DESCRIPTION
基本ウェイト量の設定が0の時、X11版ではusleep(0)が呼ばれるが、引数が0でもプロセスは一旦スリープ状態に入るので次にタスクスイッチでプロセスが起動されるのを待つことになり、結果的に最小の時分割単位でディレイが発生してしまう。
この問題を回避するため、ウェイト量が0の場合はusleep()自体を呼ばないようにする。

軽微な修正なのでIssueなし。