### PR TITLE
Remember wilderness starting position; use it in initialize_position()

### DIFF
--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -22,6 +22,7 @@
 #include "system/enums/dungeon/dungeon-id.h"
 #include "system/floor/floor-info.h"
 #include "system/floor/floor-list.h"
+#include "system/floor/wilderness-grid.h"
 #include "system/inner-game-data.h"
 #include "system/item-entity.h"
 #include "system/monrace/monrace-definition.h"
@@ -117,6 +118,7 @@ void player_wipe_without_name(PlayerType *player_ptr)
     DungeonRecords::get_instance().reset_all();
     player_ptr->visit = 1;
     world.set_wild_mode(false);
+    WildernessGrids::get_instance().initialize_position();
 
     player_ptr->max_plv = player_ptr->lev = 1;
     ArenaEntryList::get_instance().reset_entry();

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -737,7 +737,8 @@ std::pair<parse_error_type, std::optional<Pos2D>> parse_line_wilderness(char *li
             return { PARSE_ERROR_TOO_FEW_ARGUMENTS, std::nullopt };
         }
 
-        wilderness.set_player_position({ std::stoi(zz[0]), std::stoi(zz[1]) });
+        wilderness.set_starting_player_position({ std::stoi(zz[0]), std::stoi(zz[1]) });
+        wilderness.initialize_position();
         if (!wilderness.is_player_in_bounds()) {
             return { PARSE_ERROR_OUT_OF_BOUNDS, std::nullopt };
         }

--- a/src/system/floor/wilderness-grid.cpp
+++ b/src/system/floor/wilderness-grid.cpp
@@ -47,8 +47,7 @@ void WildernessGrids::initialize_seeds()
 
 void WildernessGrids::initialize_position()
 {
-    constexpr Pos2D initial_position(48, 5);
-    this->current_pos = initial_position;
+    this->current_pos = this->starting_pos;
 }
 
 WildernessGrids &WildernessGrids::get_instance()
@@ -69,6 +68,11 @@ WildernessGrid &WildernessGrids::get_grid(const Pos2D &pos)
 const Pos2D &WildernessGrids::get_player_position() const
 {
     return this->current_pos;
+}
+
+void WildernessGrids::set_starting_player_position(const Pos2D &pos)
+{
+    this->starting_pos = pos;
 }
 
 void WildernessGrids::set_player_position(const Pos2D &pos)

--- a/src/system/floor/wilderness-grid.h
+++ b/src/system/floor/wilderness-grid.h
@@ -53,6 +53,7 @@ public:
     bool is_player_in_bounds() const;
     const Rect2D &get_area() const;
 
+    void set_starting_player_position(const Pos2D &pos);
     void set_player_position(const Pos2D &pos);
     void move_player_to(const Direction &dir);
 
@@ -61,6 +62,7 @@ private:
     static WildernessGrids instance;
     Rect2D area = { 0, 0, 0, 0 };
     Pos2D current_pos = { 0, 0 };
+    Pos2D starting_pos = { 0, 0 };
 };
 
 extern std::vector<std::vector<WildernessGrid>> wilderness_grids;

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -804,17 +804,11 @@ void cheat_death(PlayerType *player_ptr)
 
     floor.reset_dungeon_index();
     auto &wilderness = WildernessGrids::get_instance();
-    if (lite_town || vanilla_town) {
-        wilderness.set_player_position({ 1, 1 });
-        if (vanilla_town) {
-            player_ptr->oldpy = 10;
-            player_ptr->oldpx = 34;
-        } else {
-            player_ptr->oldpy = 33;
-            player_ptr->oldpx = 131;
-        }
+    wilderness.initialize_position();
+    if (vanilla_town) {
+        player_ptr->oldpy = 10;
+        player_ptr->oldpx = 34;
     } else {
-        wilderness.initialize_position();
         player_ptr->oldpy = 33;
         player_ptr->oldpx = 131;
     }


### PR DESCRIPTION
Use initialize_position() during player birth.  Resolves https://github.com/hengband/hengband/issues/4957 .

The interaction with old save files (see use of initialize_position() in load/world-loader.cpp's load_wilderness_info()) has not been tested:  the old code always set the current wilderness position to (48,5), the new code sets it to whatever was remembered after parsing WildernessDefinition.txt.