### PR TITLE
[Refactor] command_dirの型をDirectionにする

### DIFF
--- a/src/action/open-util.cpp
+++ b/src/action/open-util.cpp
@@ -38,11 +38,11 @@ short chest_check(const FloorType &floor, const Pos2D &pos, bool trapped)
 /*!
  * @brief プレイヤーの周辺9マスに箱のあるマスがいくつあるかを返す
  * @param trapped TRUEならばトラップの存在が判明している箱のみ対象にする
- * @return 該当する地形の数と、該当するマスの中から1つの座標
+ * @return 該当する地形の数と、該当するマスの中から1つの方向
  */
-std::pair<int, Pos2D> count_chests(PlayerType *player_ptr, bool trapped)
+std::pair<int, Direction> count_chests(PlayerType *player_ptr, bool trapped)
 {
-    Pos2D pos(0, 0);
+    auto dir = Direction::none();
     auto count = 0;
     for (const auto &d : Direction::directions()) {
         const auto pos_neighbor = player_ptr->get_position() + d.vec();
@@ -61,8 +61,8 @@ std::pair<int, Pos2D> count_chests(PlayerType *player_ptr, bool trapped)
         }
 
         ++count;
-        pos = pos_neighbor;
+        dir = d;
     }
 
-    return { count, pos };
+    return { count, dir };
 }

--- a/src/action/open-util.h
+++ b/src/action/open-util.h
@@ -4,10 +4,11 @@
  * @brief 開閉処理関連関数ヘッダ
  */
 
+#include "floor/geometry.h"
 #include "util/point-2d.h"
 #include <utility>
 
 class FloorType;
 class PlayerType;
 short chest_check(const FloorType &floor, const Pos2D &pos, bool trapped);
-std::pair<int, Pos2D> count_chests(PlayerType *player_ptr, bool trapped);
+std::pair<int, Direction> count_chests(PlayerType *player_ptr, bool trapped);

--- a/src/cmd-action/cmd-open-close.cpp
+++ b/src/cmd-action/cmd-open-close.cpp
@@ -106,13 +106,12 @@ void do_cmd_open(PlayerType *player_ptr)
     PlayerClass(player_ptr).break_samurai_stance({ SamuraiStanceType::MUSOU });
     auto &floor = *player_ptr->current_floor_ptr;
     if (easy_open) {
-        const auto &[num_doors, pos_door] = floor.count_doors_traps(player_ptr->get_position(), GridCountKind::CLOSED_DOOR, false);
-        const auto &[num_chests, pos_chest] = count_chests(player_ptr, false);
+        const auto &[num_doors, dir_door] = floor.count_doors_traps(player_ptr->get_position(), GridCountKind::CLOSED_DOOR, false);
+        const auto &[num_chests, dir_chest] = count_chests(player_ptr, false);
         if ((num_doors > 0) || (num_chests > 0)) {
-            const auto pos = pos_chest == Pos2D(0, 0) ? pos_door : pos_chest;
             const auto too_many = (num_doors && num_chests) || (num_doors > 1) || (num_chests > 1);
             if (!too_many) {
-                command_dir = player_ptr->point_direction(pos);
+                command_dir = num_chests == 0 ? dir_door : dir_chest;
             }
         }
     }
@@ -161,9 +160,9 @@ void do_cmd_close(PlayerType *player_ptr)
     const auto &floor = *player_ptr->current_floor_ptr;
     PlayerClass(player_ptr).break_samurai_stance({ SamuraiStanceType::MUSOU });
     if (easy_open) {
-        const auto &[num_doors, pos] = floor.count_doors_traps(player_ptr->get_position(), GridCountKind::OPEN, false);
+        const auto &[num_doors, dir] = floor.count_doors_traps(player_ptr->get_position(), GridCountKind::OPEN, false);
         if (num_doors == 1) {
-            command_dir = player_ptr->point_direction(pos);
+            command_dir = dir;
         }
     }
 
@@ -207,13 +206,12 @@ void do_cmd_disarm(PlayerType *player_ptr)
     auto &floor = *player_ptr->current_floor_ptr;
     PlayerClass(player_ptr).break_samurai_stance({ SamuraiStanceType::MUSOU });
     if (easy_disarm) {
-        const auto &[num_traps, pos_trap] = floor.count_doors_traps(player_ptr->get_position(), GridCountKind::TRAP, true);
-        const auto &[num_chests, pos_chest] = count_chests(player_ptr, true);
+        const auto &[num_traps, dir_trap] = floor.count_doors_traps(player_ptr->get_position(), GridCountKind::TRAP, true);
+        const auto &[num_chests, dir_chest] = count_chests(player_ptr, true);
         if ((num_traps > 0) || (num_chests > 0)) {
-            const auto pos = pos_chest == Pos2D(0, 0) ? pos_trap : pos_chest;
             const auto too_many = (num_traps && num_chests) || (num_traps > 1) || (num_chests > 1);
             if (!too_many) {
-                command_dir = player_ptr->point_direction(pos);
+                command_dir = (num_chests == 0) ? dir_trap : dir_chest;
             }
         }
     }

--- a/src/dungeon/dungeon-processor.cpp
+++ b/src/dungeon/dungeon-processor.cpp
@@ -109,7 +109,7 @@ void process_dungeon(PlayerType *player_ptr, bool load_game)
     command_cmd = 0;
     command_rep = 0;
     command_arg = 0;
-    command_dir = 0;
+    command_dir = Direction::none();
 
     target_who = 0;
     player_ptr->pet_t_m_idx = 0;

--- a/src/io/input-key-requester.cpp
+++ b/src/io/input-key-requester.cpp
@@ -36,7 +36,7 @@ bool use_menu;
 int16_t command_cmd; /* Current "Angband Command" */
 COMMAND_ARG command_arg; /*!< 各種コマンドの汎用的な引数として扱う / Gives argument of current command */
 short command_rep; /*!< 各種コマンドの汎用的なリピート数として扱う / Gives repetition of current command */
-DIRECTION command_dir; /*!< 各種コマンドの汎用的な方向値処理として扱う/ Gives direction of current command */
+Direction command_dir = Direction::none(); /*!< 各種コマンドの汎用的な方向値処理として扱う/ Gives direction of current command */
 int16_t command_see; /* アイテム使用時等にリストを表示させるかどうか (ゲームオプションの他、様々なタイミングでONになったりOFFになったりする模様……) */
 int16_t command_wrk; /* アイテムの使用許可状況 (ex. 装備品のみ、床上もOK等) */
 TERM_LEN command_gap = 999; /* アイテムの表示に使う (詳細未調査) */
@@ -59,7 +59,7 @@ void InputKeyRequestor::request_command()
 {
     command_cmd = 0;
     command_arg = 0;
-    command_dir = 0;
+    command_dir = Direction::none();
     use_menu = false;
     this->process_input_command();
     if (always_repeat && (command_arg <= 0)) {

--- a/src/io/input-key-requester.h
+++ b/src/io/input-key-requester.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "floor/geometry.h"
 #include "game-option/keymap-directory-getter.h"
 #include "system/angband.h"
 #include <optional>
@@ -12,7 +13,7 @@ extern bool use_menu;
 extern COMMAND_CODE command_cmd;
 extern COMMAND_ARG command_arg;
 extern short command_rep;
-extern DIRECTION command_dir;
+extern Direction command_dir;
 extern int16_t command_see;
 extern TERM_LEN command_gap;
 extern int16_t command_wrk;

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -106,12 +106,12 @@ static int get_hack_dir(PlayerType *player_ptr)
         return 0;
     }
 
-    command_dir = dir;
+    command_dir = Direction(dir);
     if (player_ptr->effects()->confusion().is_confused()) {
         dir = rand_choice(Direction::directions_8()).dir();
     }
 
-    if (command_dir != dir) {
+    if (command_dir != Direction(dir)) {
         msg_print(_("あなたは混乱している。", "You are confused."));
     }
 

--- a/src/racial/racial-switcher.cpp
+++ b/src/racial/racial-switcher.cpp
@@ -223,7 +223,7 @@ bool switch_class_racial_execution(PlayerType *player_ptr, const int32_t command
 
         if (!player_ptr->effects()->paralysis().is_paralyzed() && !cmd_limit_cast(player_ptr)) {
             handle_stuff(player_ptr);
-            command_dir = 0;
+            command_dir = Direction::none();
             (void)do_cmd_cast(player_ptr);
         }
         return true;

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -714,7 +714,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
                 DIRECTION dir;
 
                 if (power) {
-                    command_dir = 0;
+                    command_dir = Direction::none();
 
                     do {
                         msg_print(_("復讐の時だ！", "Time for revenge!"));

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -625,7 +625,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 if (!mdeath) {
                     break;
                 }
-                command_dir = 0;
+                command_dir = Direction::none();
 
                 RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::MP);
                 handle_stuff(player_ptr);

--- a/src/system/floor/floor-info.cpp
+++ b/src/system/floor/floor-info.cpp
@@ -212,12 +212,12 @@ bool FloorType::has_trap_at(const Pos2D &pos) const
  * @param p_pos プレイヤーの現在位置
  * @param gck 判定条件
  * @param under TRUEならばプレイヤーの直下の座標も走査対象にする
- * @return 該当する地形の数と、該当する地形の中から1つの座標
+ * @return 該当する地形の数と、該当する地形の中から1つの方向
  */
-std::pair<int, Pos2D> FloorType::count_doors_traps(const Pos2D &p_pos, GridCountKind gck, bool under) const
+std::pair<int, Direction> FloorType::count_doors_traps(const Pos2D &p_pos, GridCountKind gck, bool under) const
 {
     auto count = 0;
-    Pos2D pos(0, 0);
+    auto dir = Direction::none();
     for (const auto &d : under ? Direction::directions() : Direction::directions_8()) {
         const auto pos_neighbor = p_pos + d.vec();
         if (!this->has_marked_grid_at(pos_neighbor)) {
@@ -229,10 +229,10 @@ std::pair<int, Pos2D> FloorType::count_doors_traps(const Pos2D &p_pos, GridCount
         }
 
         ++count;
-        pos = pos_neighbor;
+        dir = d;
     }
 
-    return { count, pos };
+    return { count, dir };
 }
 
 bool FloorType::check_terrain_state(const Pos2D &pos, GridCountKind gck) const

--- a/src/system/floor/floor-info.h
+++ b/src/system/floor/floor-info.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "floor/floor-base-definitions.h"
+#include "floor/geometry.h"
 #include "system/angband.h"
 #include "system/baseitem/baseitem-definition.h"
 #include "system/baseitem/baseitem-list.h"
@@ -116,7 +117,7 @@ public:
     bool has_marked_grid_at(const Pos2D &pos) const;
     bool has_closed_door_at(const Pos2D &pos, bool is_mimic = false) const;
     bool has_trap_at(const Pos2D &pos) const;
-    std::pair<int, Pos2D> count_doors_traps(const Pos2D &p_pos, GridCountKind gck, bool under) const;
+    std::pair<int, Direction> count_doors_traps(const Pos2D &p_pos, GridCountKind gck, bool under) const;
     bool check_terrain_state(const Pos2D &pos, GridCountKind gck) const;
     bool order_pet_whistle(short index1, short index2) const;
     bool order_pet_dismission(short index1, short index2, short riding_index) const;

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -180,19 +180,3 @@ bool PlayerType::try_resist_eldritch_horror() const
 {
     return evaluate_percent(this->skill_sav) || one_in_(2);
 }
-
-/*!
- * @brief プレイヤーから指定の座標がどの方角にあるかを返す
- * @param pos 確認したい座標
- * @return 方向ID
- */
-int PlayerType::point_direction(const Pos2D &pos) const
-{
-    static const std::vector<std::vector<int>> directions = { { 7, 8, 9 }, { 4, 5, 6 }, { 1, 2, 3 } };
-    const auto pos_dir = pos - this->get_position();
-    if ((std::abs(pos_dir.y) > 1) || (std::abs(pos_dir.x) > 1)) {
-        return 0;
-    }
-
-    return directions[pos_dir.y + 1][pos_dir.x + 1];
-}

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -387,7 +387,6 @@ public:
     bool in_saved_floor() const;
     int calc_life_rating() const;
     bool try_resist_eldritch_horror() const;
-    int point_direction(const Pos2D &pos) const;
 
 private:
     std::shared_ptr<TimedEffects> timed_effects;

--- a/src/target/target-getter.cpp
+++ b/src/target/target-getter.cpp
@@ -33,7 +33,7 @@
  */
 bool get_aim_dir(PlayerType *player_ptr, int *dp)
 {
-    auto dir = command_dir;
+    auto dir = command_dir ? command_dir.dir() : 0;
     if (use_old_target && target_okay(player_ptr)) {
         dir = 5;
     }
@@ -99,17 +99,17 @@ bool get_aim_dir(PlayerType *player_ptr, int *dp)
         return false;
     }
 
-    command_dir = dir;
+    command_dir = Direction(dir);
     if (player_ptr->effects()->confusion().is_confused()) {
         dir = rand_choice(Direction::directions_8()).dir();
     }
 
-    if (command_dir != dir) {
+    if (command_dir != Direction(dir)) {
         msg_print(_("あなたは混乱している。", "You are confused."));
     }
 
     *dp = dir;
-    repeat_push((COMMAND_CODE)command_dir);
+    repeat_push((COMMAND_CODE)command_dir.dir());
     return true;
 }
 
@@ -129,7 +129,7 @@ bool get_aim_dir(PlayerType *player_ptr, int *dp)
  */
 std::optional<int> get_direction(PlayerType *player_ptr)
 {
-    auto dir = command_dir;
+    auto dir = command_dir ? command_dir.dir() : 0;
     short code = 0;
     if (repeat_pull(&code) && Direction::is_valid_dir(code)) {
         dir = code;
@@ -148,16 +148,16 @@ std::optional<int> get_direction(PlayerType *player_ptr)
         }
     }
 
-    command_dir = dir;
+    command_dir = Direction(dir);
     const auto finalizer = util::make_finalizer([] {
-        repeat_push(static_cast<short>(command_dir));
+        repeat_push(static_cast<short>(command_dir.dir()));
     });
     const auto is_confused = player_ptr->effects()->confusion().is_confused();
     if (is_confused && evaluate_percent(75)) {
         dir = rand_choice(Direction::directions_8()).dir();
     }
 
-    if (command_dir == dir) {
+    if (command_dir == Direction(dir)) {
         return dir;
     }
 
@@ -193,7 +193,7 @@ std::optional<int> get_direction(PlayerType *player_ptr)
  */
 bool get_rep_dir(PlayerType *player_ptr, int *dp, bool under)
 {
-    auto dir = command_dir;
+    auto dir = command_dir ? command_dir.dir() : 0;
     short code = 0;
     if (repeat_pull(&code) && Direction::is_valid_dir(code)) {
         dir = code;
@@ -223,7 +223,7 @@ bool get_rep_dir(PlayerType *player_ptr, int *dp, bool under)
         return false;
     }
 
-    command_dir = dir;
+    command_dir = Direction(dir);
     auto is_confused = player_ptr->effects()->confusion().is_confused();
     if (is_confused) {
         if (evaluate_percent(75)) {
@@ -243,7 +243,7 @@ bool get_rep_dir(PlayerType *player_ptr, int *dp, bool under)
         }
     }
 
-    if (command_dir != dir) {
+    if (command_dir != Direction(dir)) {
         if (is_confused) {
             msg_print(_("あなたは混乱している。", "You are confused."));
         } else {
@@ -258,6 +258,6 @@ bool get_rep_dir(PlayerType *player_ptr, int *dp, bool under)
     }
 
     *dp = dir;
-    repeat_push(static_cast<short>(command_dir));
+    repeat_push(static_cast<short>(command_dir.dir()));
     return true;
 }


### PR DESCRIPTION
#4962 関連作業。

方向入力処理をDirectionに置き換える上で、command_dirを先にDirection型に 対応させておかないと色々面倒なので、`Direction`に型を変更しておく。