### PR TITLE
[Refactor] 青魔法の処理をまとめる 

### DIFF
--- a/src/blue-magic/blue-magic-ball-bolt.cpp
+++ b/src/blue-magic/blue-magic-ball-bolt.cpp
@@ -9,360 +9,97 @@
 #include "monster-race/race-ability-flags.h"
 #include "mspell/mspell-damage-calculator.h"
 #include "spell-kind/spells-launcher.h"
+#include "system/angband-exceptions.h"
 #include "system/player-type-definition.h"
 #include "target/target-getter.h"
 #include "view/display-messages.h"
+#include <fmt/format.h>
+#include <unordered_map>
 
-bool cast_blue_ball_acid(PlayerType *player_ptr, bmc_type *bmc_ptr)
+namespace {
+struct blue_magic_ball_type {
+    AttributeType attribute_type;
+    int radius;
+    std::string_view message;
+};
+
+const std::unordered_map<MonsterAbilityType, blue_magic_ball_type> BLUE_MAIGC_BALL_TABLE = {
+    { MonsterAbilityType::BA_ACID, { AttributeType::ACID, 2, _("アシッド・ボールの呪文を唱えた。", "You cast an acid ball.") } },
+    { MonsterAbilityType::BA_ELEC, { AttributeType::ELEC, 2, _("サンダー・ボールの呪文を唱えた。", "You cast a lightning ball.") } },
+    { MonsterAbilityType::BA_FIRE, { AttributeType::FIRE, 2, _("ファイア・ボールの呪文を唱えた。", "You cast a fire ball.") } },
+    { MonsterAbilityType::BA_COLD, { AttributeType::COLD, 2, _("アイス・ボールの呪文を唱えた。", "You cast a frost ball.") } },
+    { MonsterAbilityType::BA_POIS, { AttributeType::POIS, 2, _("悪臭雲の呪文を唱えた。", "You cast a stinking cloud.") } },
+    { MonsterAbilityType::BA_NUKE, { AttributeType::NUKE, 2, _("放射能球を放った。", "You cast a ball of radiation.") } },
+    { MonsterAbilityType::BA_NETH, { AttributeType::NETHER, 2, _("地獄球の呪文を唱えた。", "You cast a nether ball.") } },
+    { MonsterAbilityType::BA_CHAO, { AttributeType::CHAOS, 4, _("純ログルスを放った。", "You invoke a raw Logrus.") } },
+    { MonsterAbilityType::BA_WATE, { AttributeType::WATER, 4, _("流れるような身振りをした。", "You gesture fluidly.") } },
+    { MonsterAbilityType::BA_LITE, { AttributeType::LITE, 4, _("スターバーストの呪文を念じた。", "You invoke a starburst.") } },
+    { MonsterAbilityType::BA_DARK, { AttributeType::DARK, 4, _("暗黒の嵐の呪文を念じた。", "You invoke a darkness storm.") } },
+    { MonsterAbilityType::BA_MANA, { AttributeType::MANA, 4, _("魔力の嵐の呪文を念じた。", "You invoke a mana storm.") } },
+    { MonsterAbilityType::BA_VOID, { AttributeType::VOID_MAGIC, 4, _("虚無の嵐の呪文を念じた。", "You invoke a void storm.") } },
+    { MonsterAbilityType::BA_ABYSS, { AttributeType::ABYSS, 4, _("深淵の嵐の呪文を念じた。", "You invoke a abyss storm.") } },
+    { MonsterAbilityType::BA_METEOR, { AttributeType::METEOR, 4, _("メテオスウォームの呪文を念じた。", "You invoke a meteor swarm.") } },
+};
+
+struct blue_magic_bolt_type {
+    AttributeType attribute_type;
+    std::string_view message;
+};
+
+const std::unordered_map<MonsterAbilityType, blue_magic_bolt_type> BLUE_MAGIC_BOLT_TABLE = {
+    { MonsterAbilityType::BO_ACID, { AttributeType::ACID, _("アシッド・ボルトの呪文を唱えた。", "You cast an acid bolt.") } },
+    { MonsterAbilityType::BO_ELEC, { AttributeType::ELEC, _("サンダー・ボルトの呪文を唱えた。", "You cast a lightning bolt.") } },
+    { MonsterAbilityType::BO_FIRE, { AttributeType::FIRE, _("ファイア・ボルトの呪文を唱えた。", "You cast a fire bolt.") } },
+    { MonsterAbilityType::BO_COLD, { AttributeType::COLD, _("アイス・ボルトの呪文を唱えた。", "You cast a frost bolt.") } },
+    { MonsterAbilityType::BO_NETH, { AttributeType::NETHER, _("地獄の矢の呪文を唱えた。", "You cast a nether bolt.") } },
+    { MonsterAbilityType::BO_WATE, { AttributeType::WATER, _("ウォーター・ボルトの呪文を唱えた。", "You cast a water bolt.") } },
+    { MonsterAbilityType::BO_MANA, { AttributeType::MANA, _("魔力の矢の呪文を唱えた。", "You cast a mana bolt.") } },
+    { MonsterAbilityType::BO_PLAS, { AttributeType::PLASMA, _("プラズマ・ボルトの呪文を唱えた。", "You cast a plasma bolt.") } },
+    { MonsterAbilityType::BO_ICEE, { AttributeType::ICE, _("極寒の矢の呪文を唱えた。", "You cast a ice bolt.") } },
+    { MonsterAbilityType::MISSILE, { AttributeType::MISSILE, _("マジック・ミサイルの呪文を唱えた。", "You cast a magic missile.") } },
+    { MonsterAbilityType::BO_ABYSS, { AttributeType::ABYSS, _("アビス・ボルトの呪文を唱えた。", "You cast a abyss bolt.") } },
+    { MonsterAbilityType::BO_VOID, { AttributeType::VOID_MAGIC, _("ヴォイド・ボルトの呪文を唱えた。", "You cast a void bolt.") } },
+    { MonsterAbilityType::BO_METEOR, { AttributeType::METEOR, _("メテオストライクの呪文を唱えた。", "You cast a meteor strike.") } },
+    { MonsterAbilityType::BO_LITE, { AttributeType::LITE, _("スターライトアローの呪文を唱えた。", "You cast a starlight arrow.") } },
+};
+}
+
+bool cast_blue_magic_ball(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
+    int dir;
+    if (!get_aim_dir(player_ptr, &dir)) {
         return false;
     }
 
-    msg_print(_("アシッド・ボールの呪文を唱えた。", "You cast an acid ball."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BA_ACID, bmc_ptr->plev, DAM_ROLL);
-    fire_ball(player_ptr, AttributeType::ACID, bmc_ptr->dir, bmc_ptr->damage, 2);
-    return true;
-}
+    const auto magic = BLUE_MAIGC_BALL_TABLE.find(bmc_ptr->spell);
+    if (magic == BLUE_MAIGC_BALL_TABLE.end()) {
+        const auto message = fmt::format("Unknown blue magic ball: {}", static_cast<int>(bmc_ptr->spell));
+        THROW_EXCEPTION(std::logic_error, message);
+    }
 
-bool cast_blue_ball_elec(PlayerType *player_ptr, bmc_type *bmc_ptr)
+    const auto &[attribute_type, radius, message] = magic->second;
+    msg_print(message);
+    const auto damage = monspell_bluemage_damage(player_ptr, bmc_ptr->spell, bmc_ptr->plev, DAM_ROLL);
+    fire_ball(player_ptr, attribute_type, dir, damage, radius);
+    return true;
+};
+
+bool cast_blue_magic_bolt(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
+    int dir;
+    if (!get_aim_dir(player_ptr, &dir)) {
         return false;
     }
 
-    msg_print(_("サンダー・ボールの呪文を唱えた。", "You cast a lightning ball."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BA_ELEC, bmc_ptr->plev, DAM_ROLL);
-    fire_ball(player_ptr, AttributeType::ELEC, bmc_ptr->dir, bmc_ptr->damage, 2);
-    return true;
-}
-
-bool cast_blue_ball_fire(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
+    const auto magic = BLUE_MAGIC_BOLT_TABLE.find(bmc_ptr->spell);
+    if (magic == BLUE_MAGIC_BOLT_TABLE.end()) {
+        const auto message = fmt::format("Unknown blue magic bolt: {}", static_cast<int>(bmc_ptr->spell));
+        THROW_EXCEPTION(std::logic_error, message);
     }
 
-    msg_print(_("ファイア・ボールの呪文を唱えた。", "You cast a fire ball."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BA_FIRE, bmc_ptr->plev, DAM_ROLL);
-    fire_ball(player_ptr, AttributeType::FIRE, bmc_ptr->dir, bmc_ptr->damage, 2);
+    const auto &[attribute_type, message] = magic->second;
+    msg_print(message);
+    const auto damage = monspell_bluemage_damage(player_ptr, bmc_ptr->spell, bmc_ptr->plev, DAM_ROLL);
+    fire_bolt(player_ptr, attribute_type, dir, damage);
     return true;
-}
-
-bool cast_blue_ball_cold(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("アイス・ボールの呪文を唱えた。", "You cast a frost ball."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BA_COLD, bmc_ptr->plev, DAM_ROLL);
-    fire_ball(player_ptr, AttributeType::COLD, bmc_ptr->dir, bmc_ptr->damage, 2);
-    return true;
-}
-
-bool cast_blue_ball_pois(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("悪臭雲の呪文を唱えた。", "You cast a stinking cloud."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BA_POIS, bmc_ptr->plev, DAM_ROLL);
-    fire_ball(player_ptr, AttributeType::POIS, bmc_ptr->dir, bmc_ptr->damage, 2);
-    return true;
-}
-
-bool cast_blue_ball_nuke(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("放射能球を放った。", "You cast a ball of radiation."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BA_NUKE, bmc_ptr->plev, DAM_ROLL);
-    fire_ball(player_ptr, AttributeType::NUKE, bmc_ptr->dir, bmc_ptr->damage, 2);
-    return true;
-}
-
-bool cast_blue_ball_nether(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("地獄球の呪文を唱えた。", "You cast a nether ball."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BA_NETH, bmc_ptr->plev, DAM_ROLL);
-    fire_ball(player_ptr, AttributeType::NETHER, bmc_ptr->dir, bmc_ptr->damage, 2);
-    return true;
-}
-
-bool cast_blue_ball_chaos(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("純ログルスを放った。", "You invoke a raw Logrus."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BA_CHAO, bmc_ptr->plev, DAM_ROLL);
-    fire_ball(player_ptr, AttributeType::CHAOS, bmc_ptr->dir, bmc_ptr->damage, 4);
-    return true;
-}
-
-/*!
- * @brief ウォーター・ボールの青魔法
- * @brief 分解のブレスの青魔法
- * @param player_ptr プレイヤーへの参照ポインタ
- * @param bmc_ptr 青魔法詠唱への参照ポインタ
- * @details All my worries are blown away.
- */
-bool cast_blue_ball_water(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("流れるような身振りをした。", "You gesture fluidly."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BA_WATE, bmc_ptr->plev, DAM_ROLL);
-    fire_ball(player_ptr, AttributeType::WATER, bmc_ptr->dir, bmc_ptr->damage, 4);
-    return true;
-}
-
-bool cast_blue_ball_star_burst(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("スターバーストの呪文を念じた。", "You invoke a starburst."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BA_LITE, bmc_ptr->plev, DAM_ROLL);
-    fire_ball(player_ptr, AttributeType::LITE, bmc_ptr->dir, bmc_ptr->damage, 4);
-    return true;
-}
-
-bool cast_blue_ball_dark_storm(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("暗黒の嵐の呪文を念じた。", "You invoke a darkness storm."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BA_DARK, bmc_ptr->plev, DAM_ROLL);
-    fire_ball(player_ptr, AttributeType::DARK, bmc_ptr->dir, bmc_ptr->damage, 4);
-    return true;
-}
-
-bool cast_blue_ball_mana_storm(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("魔力の嵐の呪文を念じた。", "You invoke a mana storm."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BA_MANA, bmc_ptr->plev, DAM_ROLL);
-    fire_ball(player_ptr, AttributeType::MANA, bmc_ptr->dir, bmc_ptr->damage, 4);
-    return true;
-}
-
-bool cast_blue_ball_void(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("虚無の嵐の呪文を念じた。", "You invoke a void storm."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BA_VOID, bmc_ptr->plev, DAM_ROLL);
-    fire_ball(player_ptr, AttributeType::VOID_MAGIC, bmc_ptr->dir, bmc_ptr->damage, 4);
-    return true;
-}
-
-bool cast_blue_ball_abyss(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("深淵の嵐の呪文を念じた。", "You invoke a abyss storm."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BA_ABYSS, bmc_ptr->plev, DAM_ROLL);
-    fire_ball(player_ptr, AttributeType::ABYSS, bmc_ptr->dir, bmc_ptr->damage, 4);
-    return true;
-}
-
-bool cast_blue_ball_meteor(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("メテオスウォームの呪文を念じた。", "You invoke a meteor swarm."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BA_METEOR, bmc_ptr->plev, DAM_ROLL);
-    fire_ball(player_ptr, AttributeType::METEOR, bmc_ptr->dir, bmc_ptr->damage, 4);
-    return true;
-}
-
-bool cast_blue_bolt_acid(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("アシッド・ボルトの呪文を唱えた。", "You cast an acid bolt."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BO_ACID, bmc_ptr->plev, DAM_ROLL);
-    fire_bolt(player_ptr, AttributeType::ACID, bmc_ptr->dir, bmc_ptr->damage);
-    return true;
-}
-
-bool cast_blue_bolt_elec(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("サンダー・ボルトの呪文を唱えた。", "You cast a lightning bolt."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BO_ELEC, bmc_ptr->plev, DAM_ROLL);
-    fire_bolt(player_ptr, AttributeType::ELEC, bmc_ptr->dir, bmc_ptr->damage);
-    return true;
-}
-
-bool cast_blue_bolt_fire(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("ファイア・ボルトの呪文を唱えた。", "You cast a fire bolt."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BO_FIRE, bmc_ptr->plev, DAM_ROLL);
-    fire_bolt(player_ptr, AttributeType::FIRE, bmc_ptr->dir, bmc_ptr->damage);
-    return true;
-}
-
-bool cast_blue_bolt_cold(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("アイス・ボルトの呪文を唱えた。", "You cast a frost bolt."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BO_COLD, bmc_ptr->plev, DAM_ROLL);
-    fire_bolt(player_ptr, AttributeType::COLD, bmc_ptr->dir, bmc_ptr->damage);
-    return true;
-}
-
-bool cast_blue_bolt_nether(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("地獄の矢の呪文を唱えた。", "You cast a nether bolt."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BO_NETH, bmc_ptr->plev, DAM_ROLL);
-    fire_bolt(player_ptr, AttributeType::NETHER, bmc_ptr->dir, bmc_ptr->damage);
-    return true;
-}
-
-bool cast_blue_bolt_water(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("ウォーター・ボルトの呪文を唱えた。", "You cast a water bolt."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BO_WATE, bmc_ptr->plev, DAM_ROLL);
-    fire_bolt(player_ptr, AttributeType::WATER, bmc_ptr->dir, bmc_ptr->damage);
-    return true;
-}
-
-bool cast_blue_bolt_mana(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("魔力の矢の呪文を唱えた。", "You cast a mana bolt."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BO_MANA, bmc_ptr->plev, DAM_ROLL);
-    fire_bolt(player_ptr, AttributeType::MANA, bmc_ptr->dir, bmc_ptr->damage);
-    return true;
-}
-
-bool cast_blue_bolt_plasma(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("プラズマ・ボルトの呪文を唱えた。", "You cast a plasma bolt."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BO_PLAS, bmc_ptr->plev, DAM_ROLL);
-    fire_bolt(player_ptr, AttributeType::PLASMA, bmc_ptr->dir, bmc_ptr->damage);
-    return true;
-}
-
-bool cast_blue_bolt_icee(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("極寒の矢の呪文を唱えた。", "You cast a ice bolt."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BO_ICEE, bmc_ptr->plev, DAM_ROLL);
-    fire_bolt(player_ptr, AttributeType::ICE, bmc_ptr->dir, bmc_ptr->damage);
-    return true;
-}
-
-bool cast_blue_bolt_missile(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("マジック・ミサイルの呪文を唱えた。", "You cast a magic missile."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::MISSILE, bmc_ptr->plev, DAM_ROLL);
-    fire_bolt(player_ptr, AttributeType::MISSILE, bmc_ptr->dir, bmc_ptr->damage);
-    return true;
-}
-
-bool cast_blue_bolt_abyss(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("アビス・ボルトの呪文を唱えた。", "You cast a abyss bolt."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BO_ABYSS, bmc_ptr->plev, DAM_ROLL);
-    fire_bolt(player_ptr, AttributeType::ABYSS, bmc_ptr->dir, bmc_ptr->damage);
-    return true;
-}
-
-bool cast_blue_bolt_void(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("ヴォイド・ボルトの呪文を唱えた。", "You cast a void bolt."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BO_VOID, bmc_ptr->plev, DAM_ROLL);
-    fire_bolt(player_ptr, AttributeType::VOID_MAGIC, bmc_ptr->dir, bmc_ptr->damage);
-    return true;
-}
-
-bool cast_blue_bolt_meteor(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("メテオストライクの呪文を唱えた。", "You cast a meteor strike."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BO_METEOR, bmc_ptr->plev, DAM_ROLL);
-    fire_bolt(player_ptr, AttributeType::METEOR, bmc_ptr->dir, bmc_ptr->damage);
-    return true;
-}
-bool cast_blue_bolt_lite(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("スターライトアローの呪文を唱えた。", "You cast a starlight arrow."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BO_LITE, bmc_ptr->plev, DAM_ROLL);
-    fire_bolt(player_ptr, AttributeType::LITE, bmc_ptr->dir, bmc_ptr->damage);
-    return true;
-}
+};

--- a/src/blue-magic/blue-magic-ball-bolt.h
+++ b/src/blue-magic/blue-magic-ball-bolt.h
@@ -6,33 +6,5 @@
 
 struct bmc_type;
 class PlayerType;
-bool cast_blue_ball_acid(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_ball_elec(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_ball_fire(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_ball_cold(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_ball_pois(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_ball_nuke(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_ball_nether(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_ball_chaos(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_ball_water(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_ball_star_burst(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_ball_dark_storm(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_ball_mana_storm(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_ball_void(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_ball_abyss(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_ball_meteor(PlayerType *player_ptr, bmc_type *bmc_ptr);
-
-bool cast_blue_bolt_acid(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_bolt_elec(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_bolt_fire(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_bolt_cold(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_bolt_nether(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_bolt_water(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_bolt_mana(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_bolt_plasma(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_bolt_icee(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_bolt_void(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_bolt_abyss(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_bolt_meteor(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_bolt_lite(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_bolt_missile(PlayerType *player_ptr, bmc_type *bmc_ptr);
+bool cast_blue_magic_ball(PlayerType *player_ptr, bmc_type *bmc_ptr);
+bool cast_blue_magic_bolt(PlayerType *player_ptr, bmc_type *bmc_ptr);

--- a/src/blue-magic/blue-magic-breath.cpp
+++ b/src/blue-magic/blue-magic-breath.cpp
@@ -10,310 +10,65 @@
 #include "monster-race/race-ability-flags.h"
 #include "mspell/mspell-damage-calculator.h"
 #include "spell-kind/spells-launcher.h"
+#include "system/angband-exceptions.h"
 #include "system/player-type-definition.h"
 #include "target/target-getter.h"
 #include "view/display-messages.h"
+#include <fmt/format.h>
+#include <unordered_map>
 
-bool cast_blue_breath_acid(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
+namespace {
+struct blue_magic_breath_type {
+    AttributeType attribute_type;
+    std::string_view message;
+};
 
-    msg_print(_("酸のブレスを吐いた。", "You breathe acid."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BR_ACID, bmc_ptr->plev, DAM_ROLL);
-    fire_breath(player_ptr, AttributeType::ACID, bmc_ptr->dir, bmc_ptr->damage, (bmc_ptr->plev > 40 ? 3 : 2));
-    return true;
+const std::unordered_map<MonsterAbilityType, blue_magic_breath_type> BLUE_MAGIC_BREATH_TABLE = {
+    { MonsterAbilityType::BR_ACID, { AttributeType::ACID, _("酸のブレスを吐いた。", "You breathe acid.") } },
+    { MonsterAbilityType::BR_ELEC, { AttributeType::ELEC, _("稲妻のブレスを吐いた。", "You breathe lightning.") } },
+    { MonsterAbilityType::BR_FIRE, { AttributeType::FIRE, _("火炎のブレスを吐いた。", "You breathe fire.") } },
+    { MonsterAbilityType::BR_COLD, { AttributeType::COLD, _("冷気のブレスを吐いた。", "You breathe frost.") } },
+    { MonsterAbilityType::BR_POIS, { AttributeType::POIS, _("ガスのブレスを吐いた。", "You breathe gas.") } },
+    { MonsterAbilityType::BR_NETH, { AttributeType::NETHER, _("地獄のブレスを吐いた。", "You breathe nether.") } },
+    { MonsterAbilityType::BR_LITE, { AttributeType::LITE, _("閃光のブレスを吐いた。", "You breathe light.") } },
+    { MonsterAbilityType::BR_DARK, { AttributeType::DARK, _("暗黒のブレスを吐いた。", "You breathe darkness.") } },
+    { MonsterAbilityType::BR_CONF, { AttributeType::CONFUSION, _("混乱のブレスを吐いた。", "You breathe confusion.") } },
+    { MonsterAbilityType::BR_SOUN, { AttributeType::SOUND, _("轟音のブレスを吐いた。", "You breathe sound.") } },
+    { MonsterAbilityType::BR_CHAO, { AttributeType::CHAOS, _("カオスのブレスを吐いた。", "You breathe chaos.") } },
+    { MonsterAbilityType::BR_DISE, { AttributeType::DISENCHANT, _("劣化のブレスを吐いた。", "You breathe disenchantment.") } },
+    { MonsterAbilityType::BR_NEXU, { AttributeType::NEXUS, _("因果混乱のブレスを吐いた。", "You breathe nexus.") } },
+    { MonsterAbilityType::BR_TIME, { AttributeType::TIME, _("時間逆転のブレスを吐いた。", "You breathe time.") } },
+    { MonsterAbilityType::BR_INER, { AttributeType::INERTIAL, _("遅鈍のブレスを吐いた。", "You breathe inertia.") } },
+    { MonsterAbilityType::BR_GRAV, { AttributeType::GRAVITY, _("重力のブレスを吐いた。", "You breathe gravity.") } },
+    { MonsterAbilityType::BR_SHAR, { AttributeType::SHARDS, _("破片のブレスを吐いた。", "You breathe shards.") } },
+    { MonsterAbilityType::BR_PLAS, { AttributeType::PLASMA, _("プラズマのブレスを吐いた。", "You breathe plasma.") } },
+    { MonsterAbilityType::BR_FORC, { AttributeType::FORCE, _("フォースのブレスを吐いた。", "You breathe force.") } },
+    { MonsterAbilityType::BR_MANA, { AttributeType::MANA, _("魔力のブレスを吐いた。", "You breathe mana.") } },
+    { MonsterAbilityType::BR_NUKE, { AttributeType::NUKE, _("放射性廃棄物のブレスを吐いた。", "You breathe toxic waste.") } },
+    { MonsterAbilityType::BR_DISI, { AttributeType::DISINTEGRATE, _("分解のブレスを吐いた。", "You breathe disintegration.") } },
+    { MonsterAbilityType::BR_VOID, { AttributeType::VOID_MAGIC, _("虚無のブレスを吐いた。", "You breathe void.") } },
+    { MonsterAbilityType::BR_ABYSS, { AttributeType::ABYSS, _("深淵のブレスを吐いた。", "You breathe abyss.") } },
+
+};
 }
 
-bool cast_blue_breath_elec(PlayerType *player_ptr, bmc_type *bmc_ptr)
+bool cast_blue_magic_breath(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
+    int dir;
+    if (!get_aim_dir(player_ptr, &dir)) {
         return false;
     }
 
-    msg_print(_("稲妻のブレスを吐いた。", "You breathe lightning."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BR_ELEC, bmc_ptr->plev, DAM_ROLL);
-    fire_breath(player_ptr, AttributeType::ELEC, bmc_ptr->dir, bmc_ptr->damage, (bmc_ptr->plev > 40 ? 3 : 2));
-    return true;
-}
-
-bool cast_blue_breath_fire(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
+    const auto magic = BLUE_MAGIC_BREATH_TABLE.find(bmc_ptr->spell);
+    if (magic == BLUE_MAGIC_BREATH_TABLE.end()) {
+        const auto message = fmt::format("Unknown blue magic breath: {}", static_cast<int>(bmc_ptr->spell));
+        THROW_EXCEPTION(std::logic_error, message);
     }
 
-    msg_print(_("火炎のブレスを吐いた。", "You breathe fire."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BR_FIRE, bmc_ptr->plev, DAM_ROLL);
-    fire_breath(player_ptr, AttributeType::FIRE, bmc_ptr->dir, bmc_ptr->damage, (bmc_ptr->plev > 40 ? 3 : 2));
-    return true;
-}
-
-bool cast_blue_breath_cold(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("冷気のブレスを吐いた。", "You breathe frost."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BR_COLD, bmc_ptr->plev, DAM_ROLL);
-    fire_breath(player_ptr, AttributeType::COLD, bmc_ptr->dir, bmc_ptr->damage, (bmc_ptr->plev > 40 ? 3 : 2));
-    return true;
-}
-
-bool cast_blue_breath_pois(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("ガスのブレスを吐いた。", "You breathe gas."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BR_POIS, bmc_ptr->plev, DAM_ROLL);
-    fire_breath(player_ptr, AttributeType::POIS, bmc_ptr->dir, bmc_ptr->damage, (bmc_ptr->plev > 40 ? 3 : 2));
-    return true;
-}
-
-bool cast_blue_breath_nether(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("地獄のブレスを吐いた。", "You breathe nether."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BR_NETH, bmc_ptr->plev, DAM_ROLL);
-    fire_breath(player_ptr, AttributeType::NETHER, bmc_ptr->dir, bmc_ptr->damage, (bmc_ptr->plev > 40 ? 3 : 2));
-    return true;
-}
-
-bool cast_blue_breath_lite(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("閃光のブレスを吐いた。", "You breathe light."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BR_LITE, bmc_ptr->plev, DAM_ROLL);
-    fire_breath(player_ptr, AttributeType::LITE, bmc_ptr->dir, bmc_ptr->damage, (bmc_ptr->plev > 40 ? 3 : 2));
-    return true;
-}
-
-bool cast_blue_breath_dark(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("暗黒のブレスを吐いた。", "You breathe darkness."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BR_DARK, bmc_ptr->plev, DAM_ROLL);
-    fire_breath(player_ptr, AttributeType::DARK, bmc_ptr->dir, bmc_ptr->damage, (bmc_ptr->plev > 40 ? 3 : 2));
-    return true;
-}
-
-bool cast_blue_breath_conf(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("混乱のブレスを吐いた。", "You breathe confusion."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BR_CONF, bmc_ptr->plev, DAM_ROLL);
-    fire_breath(player_ptr, AttributeType::CONFUSION, bmc_ptr->dir, bmc_ptr->damage, (bmc_ptr->plev > 40 ? 3 : 2));
-    return true;
-}
-
-bool cast_blue_breath_sound(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("轟音のブレスを吐いた。", "You breathe sound."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BR_SOUN, bmc_ptr->plev, DAM_ROLL);
-    fire_breath(player_ptr, AttributeType::SOUND, bmc_ptr->dir, bmc_ptr->damage, (bmc_ptr->plev > 40 ? 3 : 2));
-    return true;
-}
-
-bool cast_blue_breath_chaos(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("カオスのブレスを吐いた。", "You breathe chaos."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BR_CHAO, bmc_ptr->plev, DAM_ROLL);
-    fire_breath(player_ptr, AttributeType::CHAOS, bmc_ptr->dir, bmc_ptr->damage, (bmc_ptr->plev > 40 ? 3 : 2));
-    return true;
-}
-
-bool cast_blue_breath_disenchant(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("劣化のブレスを吐いた。", "You breathe disenchantment."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BR_DISE, bmc_ptr->plev, DAM_ROLL);
-    fire_breath(player_ptr, AttributeType::DISENCHANT, bmc_ptr->dir, bmc_ptr->damage, (bmc_ptr->plev > 40 ? 3 : 2));
-    return true;
-}
-
-bool cast_blue_breath_nexus(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("因果混乱のブレスを吐いた。", "You breathe nexus."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BR_NEXU, bmc_ptr->plev, DAM_ROLL);
-    fire_breath(player_ptr, AttributeType::NEXUS, bmc_ptr->dir, bmc_ptr->damage, (bmc_ptr->plev > 40 ? 3 : 2));
-    return true;
-}
-
-bool cast_blue_breath_time(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("時間逆転のブレスを吐いた。", "You breathe time."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BR_TIME, bmc_ptr->plev, DAM_ROLL);
-    fire_breath(player_ptr, AttributeType::TIME, bmc_ptr->dir, bmc_ptr->damage, (bmc_ptr->plev > 40 ? 3 : 2));
-    return true;
-}
-
-bool cast_blue_breath_inertia(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("遅鈍のブレスを吐いた。", "You breathe inertia."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BR_INER, bmc_ptr->plev, DAM_ROLL);
-    fire_breath(player_ptr, AttributeType::INERTIAL, bmc_ptr->dir, bmc_ptr->damage, (bmc_ptr->plev > 40 ? 3 : 2));
-    return true;
-}
-
-bool cast_blue_breath_gravity(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("重力のブレスを吐いた。", "You breathe gravity."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BR_GRAV, bmc_ptr->plev, DAM_ROLL);
-    fire_breath(player_ptr, AttributeType::GRAVITY, bmc_ptr->dir, bmc_ptr->damage, (bmc_ptr->plev > 40 ? 3 : 2));
-    return true;
-}
-
-bool cast_blue_breath_shards(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("破片のブレスを吐いた。", "You breathe shards."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BR_SHAR, bmc_ptr->plev, DAM_ROLL);
-    fire_breath(player_ptr, AttributeType::SHARDS, bmc_ptr->dir, bmc_ptr->damage, (bmc_ptr->plev > 40 ? 3 : 2));
-    return true;
-}
-
-bool cast_blue_breath_plasma(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("プラズマのブレスを吐いた。", "You breathe plasma."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BR_PLAS, bmc_ptr->plev, DAM_ROLL);
-    fire_breath(player_ptr, AttributeType::PLASMA, bmc_ptr->dir, bmc_ptr->damage, (bmc_ptr->plev > 40 ? 3 : 2));
-    return true;
-}
-
-bool cast_blue_breath_force(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("フォースのブレスを吐いた。", "You breathe force."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BR_FORC, bmc_ptr->plev, DAM_ROLL);
-    fire_breath(player_ptr, AttributeType::FORCE, bmc_ptr->dir, bmc_ptr->damage, (bmc_ptr->plev > 40 ? 3 : 2));
-    return true;
-}
-
-bool cast_blue_breath_mana(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("魔力のブレスを吐いた。", "You breathe mana."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BR_MANA, bmc_ptr->plev, DAM_ROLL);
-    fire_breath(player_ptr, AttributeType::MANA, bmc_ptr->dir, bmc_ptr->damage, (bmc_ptr->plev > 40 ? 3 : 2));
-    return true;
-}
-
-bool cast_blue_breath_nuke(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("放射性廃棄物のブレスを吐いた。", "You breathe toxic waste."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BR_NUKE, bmc_ptr->plev, DAM_ROLL);
-    fire_breath(player_ptr, AttributeType::NUKE, bmc_ptr->dir, bmc_ptr->damage, (bmc_ptr->plev > 40 ? 3 : 2));
-    return true;
-}
-
-/*!
- * @brief 分解のブレスの青魔法
- * @param player_ptr プレイヤーへの参照ポインタ
- * @param bmc_ptr 青魔法詠唱への参照ポインタ
- * @details 永久の刻は過ぎ去れリ.
- */
-bool cast_blue_breath_disintegration(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("分解のブレスを吐いた。", "You breathe disintegration."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BR_DISI, bmc_ptr->plev, DAM_ROLL);
-    fire_breath(player_ptr, AttributeType::DISINTEGRATE, bmc_ptr->dir, bmc_ptr->damage, (bmc_ptr->plev > 40 ? 3 : 2));
-    return true;
-}
-
-/*!
- * @brief 虚無のブレスの青魔法
- * @param player_ptr プレイヤーへの参照ポインタ
- * @param bmc_ptr 青魔法詠唱への参照ポインタ
- */
-bool cast_blue_breath_void(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("虚無のブレスを吐いた。", "You breathe void."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BR_VOID, bmc_ptr->plev, DAM_ROLL);
-    fire_breath(player_ptr, AttributeType::VOID_MAGIC, bmc_ptr->dir, bmc_ptr->damage, (bmc_ptr->plev > 40 ? 3 : 2));
-    return true;
-}
-
-/*!
- * @brief 深淵のブレスの青魔法
- * @param player_ptr プレイヤーへの参照ポインタ
- * @param bmc_ptr 青魔法詠唱への参照ポインタ
- */
-bool cast_blue_breath_abyss(PlayerType *player_ptr, bmc_type *bmc_ptr)
-{
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
-        return false;
-    }
-
-    msg_print(_("深淵のブレスを吐いた。", "You breathe abyss."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::BR_ABYSS, bmc_ptr->plev, DAM_ROLL);
-    fire_breath(player_ptr, AttributeType::ABYSS, bmc_ptr->dir, bmc_ptr->damage, (bmc_ptr->plev > 40 ? 3 : 2));
+    const auto &[attribute_type, message] = magic->second;
+    msg_print(message);
+    const auto radius = (bmc_ptr->plev > 40 ? 3 : 2);
+    const auto damage = monspell_bluemage_damage(player_ptr, bmc_ptr->spell, bmc_ptr->plev, DAM_ROLL);
+    fire_breath(player_ptr, attribute_type, dir, damage, radius);
     return true;
 }

--- a/src/blue-magic/blue-magic-breath.h
+++ b/src/blue-magic/blue-magic-breath.h
@@ -6,27 +6,4 @@
 
 struct bmc_type;
 class PlayerType;
-bool cast_blue_breath_acid(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_breath_elec(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_breath_fire(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_breath_cold(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_breath_pois(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_breath_nether(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_breath_lite(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_breath_dark(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_breath_conf(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_breath_sound(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_breath_chaos(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_breath_disenchant(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_breath_nexus(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_breath_time(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_breath_inertia(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_breath_gravity(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_breath_shards(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_breath_plasma(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_breath_force(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_breath_mana(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_breath_nuke(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_breath_disintegration(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_breath_void(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_breath_abyss(PlayerType *player_ptr, bmc_type *bmc_ptr);
+bool cast_blue_magic_breath(PlayerType *player_ptr, bmc_type *bmc_ptr);

--- a/src/blue-magic/blue-magic-caster.cpp
+++ b/src/blue-magic/blue-magic-caster.cpp
@@ -180,9 +180,9 @@ static bool cast_blue_make_trap(PlayerType *player_ptr)
     return true;
 }
 
-static bool switch_cast_blue_magic(PlayerType *player_ptr, bmc_type *bmc_ptr, MonsterAbilityType spell)
+static bool switch_cast_blue_magic(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
-    switch (spell) {
+    switch (bmc_ptr->spell) {
     case MonsterAbilityType::SHRIEK:
         msg_print(_("かん高い金切り声をあげた。", "You make a high pitched shriek."));
         aggravate_monsters(player_ptr, 0);
@@ -199,125 +199,69 @@ static bool switch_cast_blue_magic(PlayerType *player_ptr, bmc_type *bmc_ptr, Mo
     case MonsterAbilityType::SHOOT:
         return cast_blue_shoot(player_ptr, bmc_ptr);
     case MonsterAbilityType::BR_ACID:
-        return cast_blue_breath_acid(player_ptr, bmc_ptr);
     case MonsterAbilityType::BR_ELEC:
-        return cast_blue_breath_elec(player_ptr, bmc_ptr);
     case MonsterAbilityType::BR_FIRE:
-        return cast_blue_breath_fire(player_ptr, bmc_ptr);
     case MonsterAbilityType::BR_COLD:
-        return cast_blue_breath_cold(player_ptr, bmc_ptr);
     case MonsterAbilityType::BR_POIS:
-        return cast_blue_breath_pois(player_ptr, bmc_ptr);
     case MonsterAbilityType::BR_NETH:
-        return cast_blue_breath_nether(player_ptr, bmc_ptr);
     case MonsterAbilityType::BR_LITE:
-        return cast_blue_breath_lite(player_ptr, bmc_ptr);
     case MonsterAbilityType::BR_DARK:
-        return cast_blue_breath_dark(player_ptr, bmc_ptr);
     case MonsterAbilityType::BR_CONF:
-        return cast_blue_breath_conf(player_ptr, bmc_ptr);
     case MonsterAbilityType::BR_SOUN:
-        return cast_blue_breath_sound(player_ptr, bmc_ptr);
     case MonsterAbilityType::BR_CHAO:
-        return cast_blue_breath_chaos(player_ptr, bmc_ptr);
     case MonsterAbilityType::BR_DISE:
-        return cast_blue_breath_disenchant(player_ptr, bmc_ptr);
     case MonsterAbilityType::BR_NEXU:
-        return cast_blue_breath_nexus(player_ptr, bmc_ptr);
     case MonsterAbilityType::BR_TIME:
-        return cast_blue_breath_time(player_ptr, bmc_ptr);
     case MonsterAbilityType::BR_INER:
-        return cast_blue_breath_inertia(player_ptr, bmc_ptr);
     case MonsterAbilityType::BR_GRAV:
-        return cast_blue_breath_gravity(player_ptr, bmc_ptr);
     case MonsterAbilityType::BR_SHAR:
-        return cast_blue_breath_shards(player_ptr, bmc_ptr);
     case MonsterAbilityType::BR_PLAS:
-        return cast_blue_breath_plasma(player_ptr, bmc_ptr);
     case MonsterAbilityType::BR_FORC:
-        return cast_blue_breath_force(player_ptr, bmc_ptr);
     case MonsterAbilityType::BR_MANA:
-        return cast_blue_breath_mana(player_ptr, bmc_ptr);
     case MonsterAbilityType::BR_NUKE:
-        return cast_blue_breath_nuke(player_ptr, bmc_ptr);
     case MonsterAbilityType::BR_DISI:
-        return cast_blue_breath_disintegration(player_ptr, bmc_ptr);
     case MonsterAbilityType::BR_VOID:
-        return cast_blue_breath_void(player_ptr, bmc_ptr);
     case MonsterAbilityType::BR_ABYSS:
-        return cast_blue_breath_abyss(player_ptr, bmc_ptr);
+        return cast_blue_magic_breath(player_ptr, bmc_ptr);
     case MonsterAbilityType::BA_ACID:
-        return cast_blue_ball_acid(player_ptr, bmc_ptr);
     case MonsterAbilityType::BA_ELEC:
-        return cast_blue_ball_elec(player_ptr, bmc_ptr);
     case MonsterAbilityType::BA_FIRE:
-        return cast_blue_ball_fire(player_ptr, bmc_ptr);
     case MonsterAbilityType::BA_COLD:
-        return cast_blue_ball_cold(player_ptr, bmc_ptr);
     case MonsterAbilityType::BA_POIS:
-        return cast_blue_ball_pois(player_ptr, bmc_ptr);
     case MonsterAbilityType::BA_NUKE:
-        return cast_blue_ball_nuke(player_ptr, bmc_ptr);
     case MonsterAbilityType::BA_NETH:
-        return cast_blue_ball_nether(player_ptr, bmc_ptr);
     case MonsterAbilityType::BA_CHAO:
-        return cast_blue_ball_chaos(player_ptr, bmc_ptr);
     case MonsterAbilityType::BA_WATE:
-        return cast_blue_ball_water(player_ptr, bmc_ptr);
     case MonsterAbilityType::BA_LITE:
-        return cast_blue_ball_star_burst(player_ptr, bmc_ptr);
     case MonsterAbilityType::BA_DARK:
-        return cast_blue_ball_dark_storm(player_ptr, bmc_ptr);
     case MonsterAbilityType::BA_MANA:
-        return cast_blue_ball_mana_storm(player_ptr, bmc_ptr);
     case MonsterAbilityType::BA_VOID:
-        return cast_blue_ball_void(player_ptr, bmc_ptr);
     case MonsterAbilityType::BA_ABYSS:
-        return cast_blue_ball_abyss(player_ptr, bmc_ptr);
     case MonsterAbilityType::BA_METEOR:
-        return cast_blue_ball_meteor(player_ptr, bmc_ptr);
+        return cast_blue_magic_ball(player_ptr, bmc_ptr);
     case MonsterAbilityType::DRAIN_MANA:
-        return cast_blue_drain_mana(player_ptr, bmc_ptr);
     case MonsterAbilityType::MIND_BLAST:
-        return cast_blue_mind_blast(player_ptr, bmc_ptr);
     case MonsterAbilityType::BRAIN_SMASH:
-        return cast_blue_brain_smash(player_ptr, bmc_ptr);
     case MonsterAbilityType::CAUSE_1:
-        return cast_blue_curse_1(player_ptr, bmc_ptr);
     case MonsterAbilityType::CAUSE_2:
-        return cast_blue_curse_2(player_ptr, bmc_ptr);
     case MonsterAbilityType::CAUSE_3:
-        return cast_blue_curse_3(player_ptr, bmc_ptr);
     case MonsterAbilityType::CAUSE_4:
-        return cast_blue_curse_4(player_ptr, bmc_ptr);
+        return cast_blue_magic_spirit_curse(player_ptr, bmc_ptr);
     case MonsterAbilityType::BO_ACID:
-        return cast_blue_bolt_acid(player_ptr, bmc_ptr);
     case MonsterAbilityType::BO_ELEC:
-        return cast_blue_bolt_elec(player_ptr, bmc_ptr);
     case MonsterAbilityType::BO_FIRE:
-        return cast_blue_bolt_fire(player_ptr, bmc_ptr);
     case MonsterAbilityType::BO_COLD:
-        return cast_blue_bolt_cold(player_ptr, bmc_ptr);
     case MonsterAbilityType::BO_NETH:
-        return cast_blue_bolt_nether(player_ptr, bmc_ptr);
     case MonsterAbilityType::BO_WATE:
-        return cast_blue_bolt_water(player_ptr, bmc_ptr);
     case MonsterAbilityType::BO_MANA:
-        return cast_blue_bolt_mana(player_ptr, bmc_ptr);
     case MonsterAbilityType::BO_PLAS:
-        return cast_blue_bolt_plasma(player_ptr, bmc_ptr);
     case MonsterAbilityType::BO_ICEE:
-        return cast_blue_bolt_icee(player_ptr, bmc_ptr);
     case MonsterAbilityType::BO_ABYSS:
-        return cast_blue_bolt_abyss(player_ptr, bmc_ptr);
     case MonsterAbilityType::BO_VOID:
-        return cast_blue_bolt_void(player_ptr, bmc_ptr);
     case MonsterAbilityType::BO_METEOR:
-        return cast_blue_bolt_meteor(player_ptr, bmc_ptr);
     case MonsterAbilityType::BO_LITE:
-        return cast_blue_bolt_lite(player_ptr, bmc_ptr);
     case MonsterAbilityType::MISSILE:
-        return cast_blue_bolt_missile(player_ptr, bmc_ptr);
+        return cast_blue_magic_bolt(player_ptr, bmc_ptr);
     case MonsterAbilityType::SCARE:
         return cast_blue_scare(player_ptr, bmc_ptr);
     case MonsterAbilityType::BLIND:
@@ -427,8 +371,8 @@ static bool switch_cast_blue_magic(PlayerType *player_ptr, bmc_type *bmc_ptr, Mo
 bool cast_learned_spell(PlayerType *player_ptr, MonsterAbilityType spell, const bool success)
 {
     bmc_type tmp_bm;
-    bmc_type *bmc_ptr = initialize_blue_magic_type(player_ptr, &tmp_bm, success, get_pseudo_monstetr_level);
-    if (!switch_cast_blue_magic(player_ptr, bmc_ptr, spell)) {
+    bmc_type *bmc_ptr = initialize_blue_magic_type(player_ptr, &tmp_bm, spell, success, get_pseudo_monstetr_level);
+    if (!switch_cast_blue_magic(player_ptr, bmc_ptr)) {
         return false;
     }
 

--- a/src/blue-magic/blue-magic-caster.cpp
+++ b/src/blue-magic/blue-magic-caster.cpp
@@ -59,36 +59,39 @@ static bool cast_blue_dispel(PlayerType *player_ptr)
 
 static bool cast_blue_rocket(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
+    int dir;
+    if (!get_aim_dir(player_ptr, &dir)) {
         return false;
     }
 
     msg_print(_("ロケットを発射した。", "You fire a rocket."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::ROCKET, bmc_ptr->plev, DAM_ROLL);
-    fire_rocket(player_ptr, AttributeType::ROCKET, bmc_ptr->dir, bmc_ptr->damage, 2);
+    const auto damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::ROCKET, bmc_ptr->plev, DAM_ROLL);
+    fire_rocket(player_ptr, AttributeType::ROCKET, dir, damage, 2);
     return true;
 }
 
 static bool cast_blue_shoot(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
+    int dir;
+    if (!get_aim_dir(player_ptr, &dir)) {
         return false;
     }
 
     msg_print(_("矢を放った。", "You fire an arrow."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::SHOOT, bmc_ptr->plev, DAM_ROLL);
-    fire_bolt(player_ptr, AttributeType::MONSTER_SHOOT, bmc_ptr->dir, bmc_ptr->damage);
+    const auto damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::SHOOT, bmc_ptr->plev, DAM_ROLL);
+    fire_bolt(player_ptr, AttributeType::MONSTER_SHOOT, dir, damage);
     return true;
 }
 
 static bool cast_blue_hand_doom(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
+    int dir;
+    if (!get_aim_dir(player_ptr, &dir)) {
         return false;
     }
 
     msg_print(_("<破滅の手>を放った！", "You invoke the Hand of Doom!"));
-    fire_ball_hide(player_ptr, AttributeType::HAND_DOOM, bmc_ptr->dir, bmc_ptr->plev * 3, 0);
+    fire_ball_hide(player_ptr, AttributeType::HAND_DOOM, dir, bmc_ptr->plev * 3, 0);
     return true;
 }
 
@@ -147,25 +150,27 @@ static bool cast_blue_teleport_back(PlayerType *player_ptr)
     return true;
 }
 
-static bool cast_blue_teleport_away(PlayerType *player_ptr, bmc_type *bmc_ptr)
+static bool cast_blue_teleport_away(PlayerType *player_ptr)
 {
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
+    int dir;
+    if (!get_aim_dir(player_ptr, &dir)) {
         return false;
     }
 
-    (void)fire_beam(player_ptr, AttributeType::AWAY_ALL, bmc_ptr->dir, 100);
+    (void)fire_beam(player_ptr, AttributeType::AWAY_ALL, dir, 100);
     return true;
 }
 
 static bool cast_blue_psy_spear(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
+    int dir;
+    if (!get_aim_dir(player_ptr, &dir)) {
         return false;
     }
 
     msg_print(_("光の剣を放った。", "You throw a psycho-spear."));
-    bmc_ptr->damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::PSY_SPEAR, bmc_ptr->plev, DAM_ROLL);
-    (void)fire_beam(player_ptr, AttributeType::PSY_SPEAR, bmc_ptr->dir, bmc_ptr->damage);
+    const auto damage = monspell_bluemage_damage(player_ptr, MonsterAbilityType::PSY_SPEAR, bmc_ptr->plev, DAM_ROLL);
+    (void)fire_beam(player_ptr, AttributeType::PSY_SPEAR, dir, damage);
     return true;
 }
 
@@ -303,7 +308,7 @@ static bool switch_cast_blue_magic(PlayerType *player_ptr, bmc_type *bmc_ptr)
     case MonsterAbilityType::TELE_TO:
         return cast_blue_teleport_back(player_ptr);
     case MonsterAbilityType::TELE_AWAY:
-        return cast_blue_teleport_away(player_ptr, bmc_ptr);
+        return cast_blue_teleport_away(player_ptr);
     case MonsterAbilityType::TELE_LEVEL:
         return teleport_level_other(player_ptr);
     case MonsterAbilityType::PSY_SPEAR:

--- a/src/blue-magic/blue-magic-spirit-curse.h
+++ b/src/blue-magic/blue-magic-spirit-curse.h
@@ -6,10 +6,4 @@
 
 struct bmc_type;
 class PlayerType;
-bool cast_blue_drain_mana(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_mind_blast(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_brain_smash(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_curse_1(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_curse_2(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_curse_3(PlayerType *player_ptr, bmc_type *bmc_ptr);
-bool cast_blue_curse_4(PlayerType *player_ptr, bmc_type *bmc_ptr);
+bool cast_blue_magic_spirit_curse(PlayerType *player_ptr, bmc_type *bmc_ptr);

--- a/src/blue-magic/blue-magic-status.cpp
+++ b/src/blue-magic/blue-magic-status.cpp
@@ -12,52 +12,57 @@
 
 bool cast_blue_scare(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
+    int dir;
+    if (!get_aim_dir(player_ptr, &dir)) {
         return false;
     }
 
     msg_print(_("恐ろしげな幻覚を作り出した。", "You cast a fearful illusion."));
-    fear_monster(player_ptr, bmc_ptr->dir, bmc_ptr->plev + 10);
+    fear_monster(player_ptr, dir, bmc_ptr->plev + 10);
     return true;
 }
 
 bool cast_blue_blind(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
+    int dir;
+    if (!get_aim_dir(player_ptr, &dir)) {
         return false;
     }
 
-    confuse_monster(player_ptr, bmc_ptr->dir, bmc_ptr->plev * 2);
+    confuse_monster(player_ptr, dir, bmc_ptr->plev * 2);
     return true;
 }
 
 bool cast_blue_confusion(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
+    int dir;
+    if (!get_aim_dir(player_ptr, &dir)) {
         return false;
     }
 
     msg_print(_("誘惑的な幻覚をつくり出した。", "You cast a mesmerizing illusion."));
-    confuse_monster(player_ptr, bmc_ptr->dir, bmc_ptr->plev * 2);
+    confuse_monster(player_ptr, dir, bmc_ptr->plev * 2);
     return true;
 }
 
 bool cast_blue_slow(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
+    int dir;
+    if (!get_aim_dir(player_ptr, &dir)) {
         return false;
     }
 
-    slow_monster(player_ptr, bmc_ptr->dir, bmc_ptr->plev);
+    slow_monster(player_ptr, dir, bmc_ptr->plev);
     return true;
 }
 
 bool cast_blue_sleep(PlayerType *player_ptr, bmc_type *bmc_ptr)
 {
-    if (!get_aim_dir(player_ptr, &bmc_ptr->dir)) {
+    int dir;
+    if (!get_aim_dir(player_ptr, &dir)) {
         return false;
     }
 
-    sleep_monster(player_ptr, bmc_ptr->dir, bmc_ptr->plev);
+    sleep_monster(player_ptr, dir, bmc_ptr->plev);
     return true;
 }

--- a/src/blue-magic/blue-magic-util.cpp
+++ b/src/blue-magic/blue-magic-util.cpp
@@ -8,8 +8,9 @@
 #include "system/player-type-definition.h"
 
 bmc_type *initialize_blue_magic_type(
-    PlayerType *player_ptr, bmc_type *bmc_ptr, const bool success, get_pseudo_monstetr_level_pf get_pseudo_monstetr_level)
+    PlayerType *player_ptr, bmc_type *bmc_ptr, MonsterAbilityType spell, const bool success, get_pseudo_monstetr_level_pf get_pseudo_monstetr_level)
 {
+    bmc_ptr->spell = spell;
     bmc_ptr->plev = (*get_pseudo_monstetr_level)(player_ptr);
     bmc_ptr->summon_lev = player_ptr->lev * 2 / 3 + randint1(player_ptr->lev / 2);
     bmc_ptr->damage = 0;

--- a/src/blue-magic/blue-magic-util.cpp
+++ b/src/blue-magic/blue-magic-util.cpp
@@ -13,7 +13,6 @@ bmc_type *initialize_blue_magic_type(
     bmc_ptr->spell = spell;
     bmc_ptr->plev = (*get_pseudo_monstetr_level)(player_ptr);
     bmc_ptr->summon_lev = player_ptr->lev * 2 / 3 + randint1(player_ptr->lev / 2);
-    bmc_ptr->damage = 0;
     bmc_ptr->pet = success; // read-only.
     bmc_ptr->no_trump = false;
     bmc_ptr->p_mode = bmc_ptr->pet ? PM_FORCE_PET : PM_NO_PET;

--- a/src/blue-magic/blue-magic-util.h
+++ b/src/blue-magic/blue-magic-util.h
@@ -11,10 +11,8 @@ enum class MonsterAbilityType;
 // Blue Magic Cast.
 struct bmc_type {
     MonsterAbilityType spell;
-    DIRECTION dir;
     PLAYER_LEVEL plev;
     PLAYER_LEVEL summon_lev;
-    int damage;
     bool pet;
     bool no_trump;
     BIT_FLAGS p_mode;

--- a/src/blue-magic/blue-magic-util.h
+++ b/src/blue-magic/blue-magic-util.h
@@ -6,8 +6,11 @@
 
 #include "system/angband.h"
 
+enum class MonsterAbilityType;
+
 // Blue Magic Cast.
 struct bmc_type {
+    MonsterAbilityType spell;
     DIRECTION dir;
     PLAYER_LEVEL plev;
     PLAYER_LEVEL summon_lev;
@@ -22,4 +25,4 @@ struct bmc_type {
 class PlayerType;
 typedef PLAYER_LEVEL (*get_pseudo_monstetr_level_pf)(PlayerType *player_ptr);
 bmc_type *initialize_blue_magic_type(
-    PlayerType *player_ptr, bmc_type *bmc_ptr, const bool success, get_pseudo_monstetr_level_pf get_pseudo_monstetr_level);
+    PlayerType *player_ptr, bmc_type *bmc_ptr, MonsterAbilityType spell, bool success, get_pseudo_monstetr_level_pf get_pseudo_monstetr_level);


### PR DESCRIPTION
#4962 に関連して、方向入力処理を行っている箇所を調べていたところ、青魔法のボール・ボルト・ブレス・精神攻撃の類の処理が強力発動コピペの嵐になっていたので、魔法属性をテーブルにまとめて関数を共通化しました。
これで修正しないといけない get_aim_dir が数十個減らせます（なおまだ300個近くある模様）