### PR TITLE
[Refactor] PlayerType::get_neighbor()にDirection型を取るオーバーロードを追加

### DIFF
--- a/src/action/open-util.cpp
+++ b/src/action/open-util.cpp
@@ -45,7 +45,7 @@ std::pair<int, Pos2D> count_chests(PlayerType *player_ptr, bool trapped)
     Pos2D pos(0, 0);
     auto count = 0;
     for (const auto &d : Direction::directions()) {
-        const auto pos_neighbor = player_ptr->get_position() + d.vec();
+        const auto pos_neighbor = player_ptr->get_neighbor(d);
         const auto o_idx = chest_check(*player_ptr->current_floor_ptr, pos_neighbor, false);
         if (o_idx == 0) {
             continue;

--- a/src/action/run-execution.cpp
+++ b/src/action/run-execution.cpp
@@ -110,7 +110,7 @@ static void run_init(PlayerType *player_ptr, const Direction &dir)
     const auto pos = player_ptr->get_position();
     player_ptr->run_py = pos.y;
     player_ptr->run_px = pos.x;
-    const auto pos_neighbor = player_ptr->get_position() + dir.vec();
+    const auto pos_neighbor = player_ptr->get_neighbor(dir);
     ignore_avoid_run = player_ptr->current_floor_ptr->has_terrain_characteristics(pos_neighbor, TerrainCharacteristics::AVOID_RUN);
     const auto dir_left45 = dir.rotated_45degree(1);
     const auto dir_right45 = dir.rotated_45degree(-1);
@@ -221,7 +221,7 @@ static bool run_test(PlayerType *player_ptr)
     const auto max = prev_dir.is_diagonal() ? 2 : 1;
     for (auto i = -max; i <= max; i++) {
         const auto new_dir = prev_dir.rotated_45degree(i);
-        const auto pos = player_ptr->get_position() + new_dir.vec();
+        const auto pos = player_ptr->get_neighbor(new_dir);
         const auto &grid = floor.get_grid(pos);
         if (grid.has_monster()) {
             const auto &monster = floor.m_list[grid.m_idx];
@@ -342,7 +342,7 @@ static bool run_test(PlayerType *player_ptr)
         return see_wall(player_ptr, find_current, p_pos);
     }
 
-    const auto pos = player_ptr->get_position() + option.vec();
+    const auto pos = player_ptr->get_neighbor(option);
     if (!see_wall(player_ptr, option, pos) || !see_wall(player_ptr, check_dir, pos)) {
         if (see_nothing(player_ptr, option, pos) && see_nothing(player_ptr, option2, pos)) {
             find_current = option;

--- a/src/action/travel-execution.cpp
+++ b/src/action/travel-execution.cpp
@@ -68,7 +68,7 @@ static DIRECTION travel_test(PlayerType *player_ptr, DIRECTION prev_dir)
     int cost = travel.cost[player_ptr->y][player_ptr->x];
     DIRECTION new_dir = 0;
     for (const auto &d : Direction::directions_8()) {
-        const auto pos_neighbor = player_ptr->get_position() + d.vec();
+        const auto pos_neighbor = player_ptr->get_neighbor(d);
         int dir_cost = travel.cost[pos_neighbor.y][pos_neighbor.x];
         if (dir_cost < cost) {
             new_dir = d.dir();

--- a/src/mind/mind-warrior.cpp
+++ b/src/mind/mind-warrior.cpp
@@ -45,7 +45,7 @@ bool sword_dancing(PlayerType *player_ptr)
 {
     for (auto i = 0; i < 6; i++) {
         const auto d = rand_choice(Direction::directions_8());
-        const auto pos = player_ptr->get_position() + d.vec();
+        const auto pos = player_ptr->get_neighbor(d);
         const auto &grid = player_ptr->current_floor_ptr->get_grid(pos);
         if (grid.has_monster()) {
             do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_NONE);

--- a/src/pet/pet-fall-off.cpp
+++ b/src/pet/pet-fall-off.cpp
@@ -105,7 +105,7 @@ bool process_fall_off_horse(PlayerType *player_ptr, int dam, bool force)
 
         /* Check around the player */
         for (const auto &d : Direction::directions_8()) {
-            const auto pos = player_ptr->get_position() + d.vec();
+            const auto pos = player_ptr->get_neighbor(d);
 
             const auto &grid = player_ptr->current_floor_ptr->get_grid(pos);
 

--- a/src/player-attack/player-attack.cpp
+++ b/src/player-attack/player-attack.cpp
@@ -593,7 +593,7 @@ void massacre(PlayerType *player_ptr)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
     for (const auto &d : Direction::directions_8()) {
-        const auto pos = player_ptr->get_position() + d.vec();
+        const auto pos = player_ptr->get_neighbor(d);
         const auto &grid = floor.get_grid(pos);
         const auto &monster = floor.m_list[grid.m_idx];
         if (grid.has_monster() && (monster.ml || floor.has_terrain_characteristics(pos, TerrainCharacteristics::PROJECT))) {

--- a/src/player/player-move.cpp
+++ b/src/player/player-move.cpp
@@ -115,7 +115,7 @@ void search(PlayerType *player_ptr)
 
     for (const auto &d : Direction::directions()) {
         if (evaluate_percent(chance)) {
-            discover_hidden_things(player_ptr, player_ptr->get_position() + d.vec());
+            discover_hidden_things(player_ptr, player_ptr->get_neighbor(d));
         }
     }
 }

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -81,7 +81,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             }
 
             const auto attack_to = [player_ptr](const Direction &dir) {
-                const auto pos = player_ptr->get_position() + dir.vec();
+                const auto pos = player_ptr->get_neighbor(dir);
                 const auto &grid = player_ptr->current_floor_ptr->get_grid(pos);
 
                 if (grid.has_monster()) {

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -92,7 +92,7 @@ bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MO
     Pos2D p_pos_new(0, 0); // 落石を避けた後のプレイヤー座標
     if (hurt && !has_pass_wall(player_ptr) && !has_kill_wall(player_ptr)) {
         for (const auto &d : Direction::directions_8()) {
-            const auto pos = player_ptr->get_position() + d.vec();
+            const auto pos = player_ptr->get_neighbor(d);
             if (!is_cave_empty_bold(player_ptr, pos.y, pos.x)) {
                 continue;
             }

--- a/src/spell-realm/spells-chaos.cpp
+++ b/src/spell-realm/spells-chaos.cpp
@@ -36,7 +36,7 @@ void call_the_void(PlayerType *player_ptr)
     auto do_call = true;
     const auto &floor = *player_ptr->current_floor_ptr;
     for (const auto &d : Direction::directions()) {
-        const auto p_pos_neighbor = player_ptr->get_position() + d.vec();
+        const auto p_pos_neighbor = player_ptr->get_neighbor(d);
         const auto &grid = floor.get_grid(p_pos_neighbor);
         if (!grid.has(TerrainCharacteristics::PROJECT)) {
             if (!grid.mimic || grid.get_terrain(TerrainKind::MIMIC_RAW).flags.has_not(TerrainCharacteristics::PROJECT) || !grid.get_terrain().is_permanent_wall()) {

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -136,6 +136,16 @@ Pos2D PlayerType::get_neighbor(int dir) const
     return this->get_position() + Direction(dir).vec();
 }
 
+/*!
+ * @brief 現在地の隣 (瞬時値)または現在地を返す
+ * @param dir 隣を表す方向
+ * @attention プレイヤーが移動する前後の文脈で使用すると不整合を起こすので注意
+ */
+Pos2D PlayerType::get_neighbor(const Direction &dir) const
+{
+    return this->get_position() + dir.vec();
+}
+
 bool PlayerType::is_located_at_running_destination() const
 {
     return (this->y == this->run_py) && (this->x == this->run_px);

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -25,6 +25,7 @@ enum class MonsterAbilityType;
 enum class PlayerSkillKindType;
 enum class RealmType;
 enum class Virtue : short;
+class Direction;
 class FloorType;
 class ItemEntity;
 class TimedEffects;
@@ -381,6 +382,7 @@ public:
     std::string decrease_ability_all();
     Pos2D get_position() const;
     Pos2D get_neighbor(int dir) const;
+    Pos2D get_neighbor(const Direction &dir) const;
     bool is_located_at_running_destination() const;
     bool is_located_at(const Pos2D &pos) const;
     void set_position(const Pos2D &pos);


### PR DESCRIPTION
PlayerType::get_neighbor()に、Direction型を取るオーバーロードを追加し、 player_type->get_position() + dir.vec(); のパターンをこのオーバーロードで置換する。

すでに（dir が int型(a.k.a DIRECTION)の） `player_type->get_neighbor(dir);` というコードが多量にあるので、Direction型に置き換えた時にいちいち書き換えなくてすむようにするため。